### PR TITLE
Remove cargo update from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
       - name: Install LLVM
         run: sudo ./ci/install-llvm.sh 8
       - uses: actions-rs/toolchain@v1
+        name: Install Rust Toolchain
         with:
           profile: minimal
           toolchain: stable
@@ -27,6 +28,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
+        name: Install Rust Toolchain
         with:
           profile: minimal
           toolchain: stable


### PR DESCRIPTION
According to [this 2014 comment from a Rust dev](https://github.com/rust-lang/cargo/issues/1103#issuecomment-68375115), `cargo update` is only for updating the lockfile.

I notice CI reports running the same step (and failing at the same point) even if we don't have `cargo update`:

```
 Updating crates.io index
    Updating git repository `https://github.com/TheDan64/inkwell`
```

This does, however, mean I have no idea what the problem is on CI.