### PR TITLE
Run cargo test (without --release) on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,24 @@ jobs:
         name: cargo test
         with:
           command: test
+
+  test-release:
+    name: cargo test --release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Install LLVM
+        run: sudo ./ci/install-llvm.sh 8
+      - uses: actions-rs/toolchain@v1
+        name: Install Rust Toolchain
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: actions-rs/cargo@v1
+        name: cargo test
+        with:
+          command: test
           args: --release
 
   fmt:


### PR DESCRIPTION
Since we're getting stack overflows on dev builds, but not with `--release`, this makes CI run both to make sure we aren't accidentally merging anything that would break local dev builds.