### PR TITLE
Have clippy warn on dbg macro use

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![warn(clippy::all, clippy::dbg_macro)]
+
 pub mod can;
 pub mod collections;
 pub mod graph;


### PR DESCRIPTION
This way if we leave in any stray `dbg` macros, clippy will point it out!