### PR TITLE
add record accessor functions

### DIFF
--- a/tests/test_infer.rs
+++ b/tests/test_infer.rs
@@ -869,4 +869,9 @@ mod test_infer {
             "custom -> custom",
         );
     }
+
+    #[test]
+    fn accessor_function() {
+        infer_eq(".foo", "{ foo : a }* -> a");
+    }
 }


### PR DESCRIPTION
e.g.  `List.map .foo someList`

This means only three variants are now not canonicalized: 
```
        ast::Expr::If(_)
        | ast::Expr::GlobalTag(_)
        | ast::Expr::PrivateTag(_)
```
All related to Roc variant types.