### PR TITLE
Combine CI steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,75 +4,43 @@ name: CI
 
 jobs:
   test:
-    name: cargo test
+    name: fmt, clippy, test, test --release
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
       - name: Install LLVM
         run: sudo ./ci/install-llvm.sh 8
-      - uses: actions-rs/toolchain@v1
-        name: Install Rust Toolchain
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - uses: actions-rs/cargo@v1
-        name: cargo test
-        with:
-          command: test
 
-  test-release:
-    name: cargo test --release
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v1
-      - name: Install LLVM
-        run: sudo ./ci/install-llvm.sh 8
       - uses: actions-rs/toolchain@v1
         name: Install Rust Toolchain
         with:
           profile: minimal
           toolchain: stable
           override: true
-      - uses: actions-rs/cargo@v1
-        name: cargo test
-        with:
-          command: test
-          args: --release
 
-  fmt:
-    name: cargo fmt
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v1
-      - uses: actions-rs/toolchain@v1
-        name: Install Rust Toolchain
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
       - run: rustup component add rustfmt
+
       - uses: actions-rs/cargo@v1
         name: cargo fmt --check
         with:
           command: fmt
           args: --all -- --check
 
-  clippy:
-    name: cargo clippy
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v1
-      - name: Install LLVM
-        run: sudo ./ci/install-llvm.sh 8
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
       - run: rustup component add clippy
+
       - uses: actions-rs/cargo@v1
         name: cargo clippy
         with:
           command: clippy
           args: -- -D warnings
+
+      - uses: actions-rs/cargo@v1
+        name: cargo test
+        with:
+          command: test
+
+      - uses: actions-rs/cargo@v1
+        name: cargo test --release
+        with:
+          command: test
+          args: --release


### PR DESCRIPTION
I got a notification about having used 70% of the GH Actions minutes for the month. And that's with only 3 people making PRs!

This may be an indication that GH Actions won't be a scalable CI solution in the long run, but for now, we can cut down on minutes used per build by removing the parallel build steps. That way it's only using minutes to install Rust and LLVM once instead of 4 times, etc.