### PR TITLE
merge `ext` fields into the record when printing

### DIFF
--- a/src/pretty_print_types.rs
+++ b/src/pretty_print_types.rs
@@ -208,6 +208,13 @@ fn write_flat_type(flat_type: FlatType, subs: &mut Subs, buf: &mut String, paren
         EmptyTagUnion => buf.push_str(EMPTY_TAG_UNION),
         Func(args, ret) => write_fn(args, ret, subs, buf, parens),
         Record(fields, ext_var) => {
+            use crate::unify::gather_fields;
+            use crate::unify::RecordStructure;
+
+            // If the `ext` has concrete fields (e.g. { foo : Int}{ bar : Bool }), merge them
+            let RecordStructure { fields, ext } = gather_fields(subs, fields, ext_var);
+            let ext_var = ext;
+
             if fields.is_empty() {
                 buf.push_str(EMPTY_RECORD)
             } else {

--- a/src/unify.rs
+++ b/src/unify.rs
@@ -16,9 +16,9 @@ struct Context {
     second_desc: Descriptor,
 }
 
-struct RecordStructure {
-    fields: ImMap<RecordFieldLabel, Variable>,
-    ext: Variable,
+pub struct RecordStructure {
+    pub fields: ImMap<RecordFieldLabel, Variable>,
+    pub ext: Variable,
 }
 
 struct TagUnionStructure {
@@ -519,7 +519,7 @@ fn unify_flex(
     }
 }
 
-fn gather_fields(
+pub fn gather_fields(
     subs: &mut Subs,
     fields: ImMap<RecordFieldLabel, Variable>,
     var: Variable,

--- a/tests/test_infer.rs
+++ b/tests/test_infer.rs
@@ -1006,7 +1006,7 @@ mod test_infer {
                 { user & year: "foo" }
                 "#
             ),
-            "{ year : Str }{ name : Str }",
+            "{ name : Str, year : Str }",
         );
     }
 

--- a/tests/test_uniqueness_infer.rs
+++ b/tests/test_uniqueness_infer.rs
@@ -917,7 +917,7 @@ mod test_infer_uniq {
                 { user & year: "foo" }
                 "#
             ),
-            "Attr.Attr * { year : (Attr.Attr * Str) }{ name : (Attr.Attr * Str) }",
+            "Attr.Attr * { name : (Attr.Attr * Str), year : (Attr.Attr * Str) }",
         );
     }
 


### PR DESCRIPTION
when the `ext` variable of a record has concrete fields (rather than being a type variable), merge them into one record when pretty printing. This means that 

`{ year : Str }{ name : Str }` is now printed as `{ name : Str, year : Str }`