### PR TITLE
Refactor out a .clone()

### DIFF
--- a/src/can/def.rs
+++ b/src/can/def.rs
@@ -21,6 +21,7 @@ use crate::parse::ast;
 use crate::region::{Located, Region};
 use crate::subs::{VarStore, Variable};
 use crate::types::Type;
+use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::fmt::Debug;
 
@@ -131,19 +132,6 @@ pub fn canonicalize_defs<'a>(
     let mut refs_by_symbol = MutMap::default();
     let mut can_defs_by_symbol = HashMap::with_capacity_and_hasher(num_defs, default_hasher());
     let mut pending = Vec::with_capacity(num_defs); // TODO bump allocate this!
-
-    use std::cmp::Ordering;
-
-    let aliases_first = |x: &&Located<ast::Def<'a>>, _: &&Located<ast::Def<'a>>| -> Ordering {
-        match x.value {
-            ast::Def::Alias { .. } | ast::Def::Nested(ast::Def::Alias { .. }) => Ordering::Less,
-            _ => Ordering::Greater,
-        }
-    };
-
-    let mut loc_defs = loc_defs.clone();
-    loc_defs.sort_by(aliases_first);
-
     let mut iter = loc_defs.iter().peekable();
 
     // Canonicalize all the patterns, record shadowing problems, and store
@@ -192,6 +180,13 @@ pub fn canonicalize_defs<'a>(
     if cfg!(debug_assertions) {
         env.home.register_debug_idents(&env.ident_ids);
     }
+
+    let aliases_first = |x: &PendingDef<'_>, _: &PendingDef<'_>| match x {
+        PendingDef::Alias { .. } => Ordering::Less,
+        _ => Ordering::Greater,
+    };
+
+    pending.sort_by(aliases_first);
 
     // Now that we have the scope completely assembled, and shadowing resolved,
     // we're ready to canonicalize any body exprs.


### PR DESCRIPTION
Now that we have an owned copy of `PendingDefs`, we can sort that for aliases instead of having to clone our previous refs to `ast::Def` instances.