### PR TITLE
correctly print repeatedly-used rigids

### DIFF
--- a/src/can/def.rs
+++ b/src/can/def.rs
@@ -719,6 +719,10 @@ fn canonicalize_pending_def<'a>(
                 output.rigids.insert(k, v);
             }
 
+            for (k, v) in ann.ftv {
+                output.ftv.insert(k, v);
+            }
+
             pattern_to_vars_by_symbol(&mut vars_by_symbol, &loc_can_pattern.value, expr_var);
 
             let typ = ann.typ;
@@ -842,6 +846,10 @@ fn canonicalize_pending_def<'a>(
             for (k, v) in can_ann.rigids {
                 output.rigids.insert(k, v);
             }
+
+            for (k, v) in can_ann.ftv {
+                output.ftv.insert(k, v);
+            }
         }
         TypedBody(loc_pattern, loc_can_pattern, loc_ann, loc_expr) => {
             let ann =
@@ -863,6 +871,10 @@ fn canonicalize_pending_def<'a>(
             // union seen rigids with already found ones
             for (k, v) in ann.rigids {
                 output.rigids.insert(k, v);
+            }
+
+            for (k, v) in ann.ftv {
+                output.ftv.insert(k, v);
             }
 
             // bookkeeping for tail-call detection. If we're assigning to an
@@ -1147,6 +1159,7 @@ pub fn can_defs_with_return<'a>(
         canonicalize_expr(env, var_store, &mut scope, loc_ret.region, &loc_ret.value);
 
     output.rigids = output.rigids.union(defs_output.rigids);
+    output.ftv = output.ftv.union(defs_output.ftv);
     output.references = output.references.union(defs_output.references);
 
     // Now that we've collected all the references, check to see if any of the new idents

--- a/src/can/expr.rs
+++ b/src/can/expr.rs
@@ -26,6 +26,7 @@ pub struct Output {
     pub references: References,
     pub tail_call: Option<Symbol>,
     pub rigids: SendMap<Lowercase, Variable>,
+    pub ftv: SendMap<Variable, Lowercase>,
     pub aliases: SendMap<Symbol, Alias>,
 }
 

--- a/tests/test_infer.rs
+++ b/tests/test_infer.rs
@@ -38,7 +38,7 @@ mod test_infer {
 
         assert_correct_variable_usage(&constraint);
 
-        for (name, var) in output.rigids {
+        for (var, name) in output.ftv {
             subs.rigid_var(var, name);
         }
 
@@ -2292,6 +2292,24 @@ mod test_infer {
                 "#
             ),
             "Result Int [ IndexOutOfBounds ]*",
+        );
+    }
+
+    #[test]
+    fn use_rigid_twice() {
+        infer_eq_without_problem(
+            indoc!(
+                r#"
+                id1 : q -> q
+                id1 = \x -> x
+
+                id2 : q -> q
+                id2 = \x -> x
+
+                { id1, id2 }
+                "#
+            ),
+            "{ id1 : q -> q, id2 : q -> q }",
         );
     }
 }

--- a/tests/test_uniqueness_infer.rs
+++ b/tests/test_uniqueness_infer.rs
@@ -21,7 +21,7 @@ mod test_infer_uniq {
 
         assert_correct_variable_usage(&constraint);
 
-        for (name, var) in output.rigids {
+        for (var, name) in output.ftv {
             subs.rigid_var(var, name);
         }
 


### PR DESCRIPTION
They were not stored correctly