### PR TITLE
cache aliases in type_to_var

### DIFF
--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -227,6 +227,13 @@ impl Type {
             0
         }
     }
+    pub fn is_recursive(&self) -> bool {
+        match self {
+            Type::RecursiveTagUnion(_, _, _) => true,
+            Type::Alias(Symbol::ATTR_ATTR, _, actual) => actual.is_recursive(),
+            _ => false,
+        }
+    }
 
     pub fn variables(&self) -> ImSet<Variable> {
         let mut result = ImSet::default();


### PR DESCRIPTION
I observed that we generate a new variable for every alias occurence in a signature. So `(//) : Int -> Int -> Int` would create three variables with the `Int` alias as their content, really blowing up the number of variables used. With some simple caching, we can use just one variable for `Int` that gets re-used.

This only works for aliases without type arguments, and for uniqueness types it only works for non-recursive types. But realistically recursive types will have type variables in practice (or you must be really into Peano arithmetic) so I don't think that additional constraint is too bad.