### PR TITLE
Fix List.set tests

### DIFF
--- a/compiler/gen/src/crane/convert.rs
+++ b/compiler/gen/src/crane/convert.rs
@@ -27,10 +27,7 @@ pub fn type_from_layout(cfg: TargetFrontendConfig, layout: &Layout<'_>) -> Type 
         Builtin(builtin) => match builtin {
             Int64 => types::I64,
             Float64 => types::F64,
-            Str => cfg.pointer_type(),
-            Map(_, _) => panic!("TODO layout_to_crane_type for Builtin::Map"),
-            Set(_) => panic!("TODO layout_to_crane_type for Builtin::Set"),
-            List(_) => panic!("TODO layout_to_crane_type for Builtin::List"),
+            Str | Map(_, _) | Set(_) | List(_) => cfg.pointer_type(),
         },
     }
 }

--- a/compiler/gen/src/llvm/build.rs
+++ b/compiler/gen/src/llvm/build.rs
@@ -593,12 +593,7 @@ fn call_with_args<'a, 'ctx, 'env>(
 
             builder.build_load(elem_ptr, "List.get")
         }
-        Symbol::LIST_SET => {
-            debug_assert!(args.len() == 3);
-
-            panic!("TODO List.set with clone");
-        }
-        Symbol::LIST_SET_IN_PLACE => {
+        Symbol::LIST_SET /* TODO clone first for LIST_SET! */ | Symbol::LIST_SET_IN_PLACE => {
             debug_assert!(args.len() == 3);
 
             let list_ptr = args[0].into_pointer_value();

--- a/compiler/gen/src/llvm/convert.rs
+++ b/compiler/gen/src/llvm/convert.rs
@@ -56,7 +56,9 @@ pub fn basic_type_from_layout<'ctx>(
                 .as_basic_type_enum(),
             Map(_, _) => panic!("TODO layout_to_basic_type for Builtin::Map"),
             Set(_) => panic!("TODO layout_to_basic_type for Builtin::Set"),
-            List(_) => panic!("TODO layout_to_basic_type for Builtin::List"),
+            List(elem_layout) => basic_type_from_layout(context, elem_layout)
+                .ptr_type(AddressSpace::Generic)
+                .as_basic_type_enum(),
         },
     }
 }

--- a/compiler/gen/tests/test_gen.rs
+++ b/compiler/gen/tests/test_gen.rs
@@ -444,7 +444,6 @@ mod test_gen {
             {
                 assert_llvm_evals_to!($src, $expected, $ty, (|val| val));
             }
-
             {
                 assert_opt_evals_to!($src, $expected, $ty, (|val| val));
             }
@@ -488,25 +487,25 @@ mod test_gen {
         assert_evals_to!("List.getUnsafe [ 12, 9, 6, 3 ] 1", 9, i64);
     }
 
-    // #[test]
-    // fn set_unique_int_list() {
-    //     assert_evals_to!("List.getUnsafe (List.set [ 12, 9, 7, 3 ] 1 42) 1", 42, i64);
-    // }
+    #[test]
+    fn set_unique_int_list() {
+        assert_evals_to!("List.getUnsafe (List.set [ 12, 9, 7, 3 ] 1 42) 1", 42, i64);
+    }
 
-    // #[test]
-    // fn set_shared_int_list() {
-    //     assert_evals_to!(
-    //         indoc!(
-    //             r#"
-    //                 shared = [ 2, 4 ]
+    #[test]
+    fn set_shared_int_list() {
+        assert_evals_to!(
+            indoc!(
+                r#"
+                    shared = [ 2, 4 ]
 
-    //                 List.getUnsafe shared 1
-    //             "#
-    //         ),
-    //         4,
-    //         i64
-    //     );
-    // }
+                    List.getUnsafe shared 1
+                "#
+            ),
+            4,
+            i64
+        );
+    }
 
     #[test]
     fn branch_first_float() {


### PR DESCRIPTION
Restores the `List.set` tests and implements just enough to get them passing.