### PR TITLE
Use expanded stack on load tests

### DIFF
--- a/compiler/load/tests/helpers/mod.rs
+++ b/compiler/load/tests/helpers/mod.rs
@@ -28,6 +28,29 @@ pub fn test_home() -> ModuleId {
     ModuleIds::default().get_or_insert(&"Test".into())
 }
 
+/// Without a larger-than-default stack size, some tests
+/// run out of stack space in debug builds (but don't in --release builds)
+#[allow(dead_code)]
+const THREAD_STACK_SIZE: usize = 4 * 1024 * 1024;
+
+pub fn test_async<F: std::future::Future>(future: F) -> F::Output {
+    use tokio::runtime::Builder;
+
+    // Create the runtime
+    let mut rt = Builder::new()
+        .thread_name("tokio-thread-for-tests")
+        .thread_stack_size(THREAD_STACK_SIZE)
+        // DEBUG: Replace this with .basic_scheduler() to make tests run single-threaded on the main thread.
+        // Doing this makes assertion failures easier to read, but means
+        // the tests can't reveal concurrency bugs, so leave this off by default!
+        .threaded_scheduler()
+        .build()
+        .expect("Error initializing Tokio runtime.");
+
+    // Spawn the root task
+    rt.block_on(future)
+}
+
 #[allow(dead_code)]
 pub fn infer_expr(
     subs: Subs,

--- a/compiler/load/tests/test_load.rs
+++ b/compiler/load/tests/test_load.rs
@@ -13,7 +13,7 @@ mod helpers;
 
 #[cfg(test)]
 mod test_load {
-    use crate::helpers::fixtures_dir;
+    use crate::helpers::{fixtures_dir, test_async};
     use inlinable_string::InlinableString;
     use roc_can::def::Declaration::*;
     use roc_can::def::Def;
@@ -26,16 +26,6 @@ mod test_load {
     use std::collections::HashMap;
 
     // HELPERS
-
-    fn test_async<F: std::future::Future>(future: F) -> F::Output {
-        use tokio::runtime::Runtime;
-
-        // Create the runtime
-        let mut rt = Runtime::new().expect("Error initializing Tokio runtime.");
-
-        // Spawn the root task
-        rt.block_on(future)
-    }
 
     async fn load_fixture(
         dir_name: &str,

--- a/compiler/load/tests/test_uniq_load.rs
+++ b/compiler/load/tests/test_uniq_load.rs
@@ -13,7 +13,7 @@ mod helpers;
 
 #[cfg(test)]
 mod test_uniq_load {
-    use crate::helpers::fixtures_dir;
+    use crate::helpers::{fixtures_dir, test_async};
     use inlinable_string::InlinableString;
     use roc_builtins::unique;
     use roc_can::def::Declaration::*;
@@ -27,16 +27,6 @@ mod test_uniq_load {
     use std::collections::HashMap;
 
     // HELPERS
-
-    fn test_async<F: std::future::Future>(future: F) -> F::Output {
-        use tokio::runtime::Runtime;
-
-        // Create the runtime
-        let mut rt = Runtime::new().expect("Error initializing Tokio runtime.");
-
-        // Spawn the root task
-        rt.block_on(future)
-    }
 
     async fn load_fixture(
         dir_name: &str,


### PR DESCRIPTION
This fixes some stack overflows I was seeing locally in debug tests only.