### PR TITLE
Support multiline repl input

### DIFF
--- a/cli/src/repl.rs
+++ b/cli/src/repl.rs
@@ -374,6 +374,8 @@ pub fn can_expr(expr_str: &str) -> Result<CanExprOut, Fail> {
     can_expr_with(&Bump::new(), repl_home(), expr_str)
 }
 
+// TODO make this return a named struct instead of a big tuple
+#[allow(clippy::type_complexity)]
 pub fn uniq_expr(
     expr_str: &str,
 ) -> Result<
@@ -394,6 +396,8 @@ pub fn uniq_expr(
     uniq_expr_with(&Bump::new(), expr_str, declared_idents)
 }
 
+// TODO make this return a named struct instead of a big tuple
+#[allow(clippy::type_complexity)]
 pub fn uniq_expr_with(
     arena: &Bump,
     expr_str: &str,


### PR DESCRIPTION
Now you can input more than one line in the repl.

This works by checking for "unexpected EOF" parse errors, and when it encounters them, assuming you're not done and letting you keep adding lines.

This works fine with basic defs, but isn't totally smooth yet.

* It's a bit funny with `when` because as soon as you add a single branch, it parses successfully and proceeds even if you weren't done adding cases yet. So `when` will need special handling in the future.
* Separately, there seems to be a parser bug where `if True then` does not report an unexpected EOF parse error, even though it should, so that scenario also doesn't work at the moment. Same for entering `1 +` with no other operand; this successfully parses as the expression `1`.
*  Nested multiline things don't work yet, possibly because of indentation - e.g. `x = 5` works, but `x = when True is` gives a parse error about indentation. (Maybe the answer there is to special-case indentation complaints like we do EOF, and automatically add the appropriate indentation?)
* There may be other bugs with it!