### PR TITLE
Add Scope to mono::expr::Env

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -392,6 +392,7 @@ fn gen(
         ident_ids: &mut ident_ids,
         pointer_size: ptr_bytes,
         jump_counter: arena.alloc(0),
+        scope: roc_mono::expr::Scope::default()
     };
 
     // Add modules' decls to Procs

--- a/cli/src/repl.rs
+++ b/cli/src/repl.rs
@@ -256,6 +256,7 @@ pub fn gen(src: &str, target: Triple, opt_level: OptLevel) -> Result<(String, St
         ident_ids: &mut ident_ids,
         pointer_size: ptr_bytes,
         jump_counter: arena.alloc(0),
+        scope: roc_mono::expr::Scope::default(),
     };
     let main_body = roc_mono::expr::Expr::new(&mut mono_env, loc_expr.value, &mut procs);
 

--- a/compiler/gen/tests/helpers/eval.rs
+++ b/compiler/gen/tests/helpers/eval.rs
@@ -72,6 +72,7 @@ macro_rules! assert_llvm_evals_to {
             ident_ids: &mut ident_ids,
             pointer_size: ptr_bytes,
             jump_counter: arena.alloc(0),
+            scope: roc_mono::expr::Scope::default()
         };
         let main_body = Expr::new(&mut mono_env, loc_expr.value, &mut procs);
 
@@ -237,6 +238,7 @@ macro_rules! assert_opt_evals_to {
             ident_ids: &mut ident_ids,
             pointer_size: ptr_bytes,
             jump_counter: arena.alloc(0),
+            scope: roc_mono::expr::Scope::default()
         };
         let main_body = Expr::new(&mut mono_env, loc_expr.value, &mut procs);
 

--- a/compiler/mono/tests/test_mono.rs
+++ b/compiler/mono/tests/test_mono.rs
@@ -61,6 +61,7 @@ mod test_mono {
             ident_ids: &mut ident_ids,
             pointer_size,
             jump_counter: arena.alloc(0),
+            scope: roc_mono::expr::Scope::default(),
         };
         let mono_expr = Expr::new(&mut mono_env, loc_expr.value, &mut procs);
 
@@ -608,10 +609,10 @@ mod test_mono {
                             )]),
                             arena.alloc(Dec {
                                 ret: arena.alloc(Inc(arena.alloc(Load(var_other_name)))),
-                                others: arena.alloc([var_other_name])
+                                others: arena.alloc([var_other_name]),
                             }),
                         )),
-                        others: arena.alloc([var_name])
+                        others: arena.alloc([var_name]),
                     }),
                 )
 

--- a/compiler/mono/tests/test_opt.rs
+++ b/compiler/mono/tests/test_opt.rs
@@ -50,6 +50,7 @@ mod test_opt {
             ident_ids: &mut ident_ids,
             pointer_size,
             jump_counter: arena.alloc(0),
+            scope: roc_mono::expr::Scope::default(),
         };
         let mono_expr = Expr::new(&mut mono_env, loc_expr.value, &mut procs);
 
@@ -220,6 +221,7 @@ mod test_opt {
             ident_ids: &mut ident_ids,
             pointer_size,
             jump_counter: arena.alloc(0),
+            scope: roc_mono::expr::Scope::default(),
         };
         let mono_expr = Expr::new(&mut mono_env, loc_expr.value, &mut procs);
 

--- a/compiler/reporting/tests/test_reporting.rs
+++ b/compiler/reporting/tests/test_reporting.rs
@@ -98,6 +98,7 @@ mod test_reporting {
                 ident_ids: &mut ident_ids,
                 pointer_size,
                 jump_counter: arena.alloc(0),
+                scope: roc_mono::expr::Scope::default(),
             };
             let _mono_expr = Expr::new(&mut mono_env, loc_expr.value, &mut procs);
         }


### PR DESCRIPTION
This changes `mono::expr` to introduce a `Scope` that gets passed around through `Env`. It records a mapping from `Symbol` to `Layout` each time a new Let is introduced, which lets the logic for when to add an `Inc` take the layout into account.

That will be especially important for nested types like records and unions, but for now its only use is to prevent generating an `Inc` for functions - since that both doesn't make sense and also was causing a ton of test failures. (There are still 4 test failures left in `test_mono`, but they're just a couple of missing `Inc` and `Dec` wrappers, which was always to be expected on this branch.)

@pzp1997 if this looks good to you, feel free to merge! (This PR is targeting your `ref_count` branch, not `trunk`.)