### PR TITLE
Switched order of checking layout and list length for list reverse

### DIFF
--- a/compiler/gen/src/llvm/build.rs
+++ b/compiler/gen/src/llvm/build.rs
@@ -1649,27 +1649,27 @@ fn run_low_level<'a, 'ctx, 'env>(
 
             let (list, list_layout) = &args[0];
 
-            let wrapper_struct =
-                build_expr(env, layout_ids, scope, parent, list).into_struct_value();
+            match list_layout {
+                Layout::Builtin(Builtin::List(elem_layout)) => {
+                    let wrapper_struct =
+                        build_expr(env, layout_ids, scope, parent, list).into_struct_value();
 
-            let builder = env.builder;
-            let ctx = env.context;
+                    let builder = env.builder;
+                    let ctx = env.context;
 
-            let list_len = load_list_len(builder, wrapper_struct);
+                    let list_len = load_list_len(builder, wrapper_struct);
 
-            // list_len > 0
-            // We do this check to avoid allocating memory. If the input
-            // list is empty, then we can just return an empty list.
-            let comparison = builder.build_int_compare(
-                IntPredicate::UGT,
-                list_len,
-                ctx.i64_type().const_int(0, false),
-                "greaterthanzero",
-            );
+                    // list_len > 0
+                    // We do this check to avoid allocating memory. If the input
+                    // list is empty, then we can just return an empty list.
+                    let comparison = builder.build_int_compare(
+                        IntPredicate::UGT,
+                        list_len,
+                        ctx.i64_type().const_int(0, false),
+                        "greaterthanzero",
+                    );
 
-            let build_then = || {
-                match list_layout {
-                    Layout::Builtin(Builtin::List(elem_layout)) => {
+                    let build_then = || {
                         // Allocate space for the new array that we'll copy into.
                         let elem_type =
                             basic_type_from_layout(env.arena, ctx, elem_layout, env.ptr_bytes);
@@ -1785,26 +1785,26 @@ fn run_low_level<'a, 'ctx, 'env>(
                             collection(ctx, ptr_bytes),
                             "cast_collection",
                         )
-                    }
-                    Layout::Builtin(Builtin::EmptyList) => empty_list(env),
-                    _ => {
-                        unreachable!("Invalid List layout for List.get: {:?}", list_layout);
-                    }
+                    };
+
+                    let build_else = || empty_list(env);
+
+                    let struct_type = collection(ctx, env.ptr_bytes);
+
+                    build_basic_phi2(
+                        env,
+                        parent,
+                        comparison,
+                        build_then,
+                        build_else,
+                        BasicTypeEnum::StructType(struct_type),
+                    )
                 }
-            };
-
-            let build_else = || empty_list(env);
-
-            let struct_type = collection(ctx, env.ptr_bytes);
-
-            build_basic_phi2(
-                env,
-                parent,
-                comparison,
-                build_then,
-                build_else,
-                BasicTypeEnum::StructType(struct_type),
-            )
+                Layout::Builtin(Builtin::EmptyList) => empty_list(env),
+                _ => {
+                    unreachable!("Invalid List layout for List.reverse {:?}", list_layout);
+                }
+            }
         }
         ListPush => {
             // List.push List elem, elem -> List elem


### PR DESCRIPTION
**BEFORE**
The steps for `List.reverse` code gen were:
```
    comparison (list_len > 0)
    phi then case ->
        List() ->
        EmptyList ->

    phi else case ->
    
    build phi node
```

But this order is impossible. It checks if its `length > 0` and _then_ checks if its an `EmptyList`. But it cant be `EmptyList` if it has a length greater than 0, so it is having to build and run a comparison for cases where the compiler knows in advance the length is 0.

**NOW**
Now the steps are:
```
    List() ->
        comparison (list_len > 0)
        phi then case->
        phi else case ->
        build phi node

    EmptyList ->
```

Writing and testing this change is a little bit of a sanity check for myself, but, I think it improves the code gen slightly since now the compiler doesnt build a phi node or a `comparison` in the case that the list layout is an `EmptyList`. 