### PR TITLE
Use is_zero_sized

### DIFF
--- a/cli/src/repl.rs
+++ b/cli/src/repl.rs
@@ -223,7 +223,7 @@ pub fn gen(src: &[u8], target: Triple, opt_level: OptLevel) -> Result<(String, S
     let expr_type_str = content_to_string(content.clone(), &subs, home, &interns);
 
     // Compute main_fn_type before moving subs to Env
-    let layout = Layout::new(&arena, content, &subs, ptr_bytes).unwrap_or_else(|err| {
+    let layout = Layout::new(&arena, content, &subs).unwrap_or_else(|err| {
         panic!(
             "Code gen error in test: could not convert to layout. Err was {:?}",
             err
@@ -258,7 +258,6 @@ pub fn gen(src: &[u8], target: Triple, opt_level: OptLevel) -> Result<(String, S
         problems: &mut mono_problems,
         home,
         ident_ids: &mut ident_ids,
-        pointer_size: ptr_bytes,
         jump_counter: arena.alloc(0),
     };
 

--- a/compiler/build/src/program.rs
+++ b/compiler/build/src/program.rs
@@ -137,14 +137,14 @@ pub fn gen(
     fpm.initialize();
 
     // Compute main_fn_type before moving subs to Env
-    let ptr_bytes = target.pointer_width().unwrap().bytes() as u32;
-    let layout = Layout::new(&arena, content, &subs, ptr_bytes).unwrap_or_else(|err| {
+    let layout = Layout::new(&arena, content, &subs).unwrap_or_else(|err| {
         panic!(
             "Code gen error in Program: could not convert to layout. Err was {:?}",
             err
         )
     });
 
+    let ptr_bytes = target.pointer_width().unwrap().bytes() as u32;
     let main_fn_type =
         basic_type_from_layout(&arena, &context, &layout, ptr_bytes).fn_type(&[], false);
     let main_fn_name = "$main";
@@ -169,7 +169,6 @@ pub fn gen(
         problems: &mut mono_problems,
         home,
         ident_ids: &mut ident_ids,
-        pointer_size: ptr_bytes,
         jump_counter: arena.alloc(0),
     };
 

--- a/compiler/gen/tests/helpers/eval.rs
+++ b/compiler/gen/tests/helpers/eval.rs
@@ -38,7 +38,7 @@ macro_rules! assert_llvm_evals_to {
         fpm.initialize();
 
         // Compute main_fn_type before moving subs to Env
-        let layout = Layout::new(&arena, content, &subs, ptr_bytes)
+        let layout = Layout::new(&arena, content, &subs)
     .unwrap_or_else(|err| panic!("Code gen error in NON-OPTIMIZED test: could not convert to layout. Err was {:?}", err));
         let execution_engine =
             module
@@ -70,7 +70,6 @@ macro_rules! assert_llvm_evals_to {
             problems: &mut mono_problems,
             home,
             ident_ids: &mut ident_ids,
-            pointer_size: ptr_bytes,
             jump_counter: arena.alloc(0),
         };
 
@@ -223,7 +222,7 @@ macro_rules! assert_opt_evals_to {
         fpm.initialize();
 
         // Compute main_fn_type before moving subs to Env
-        let layout = Layout::new(&arena, content, &subs, ptr_bytes)
+        let layout = Layout::new(&arena, content, &subs)
     .unwrap_or_else(|err| panic!("Code gen error in OPTIMIZED test: could not convert to layout. Err was {:?}", err));
 
         let execution_engine =
@@ -256,7 +255,6 @@ macro_rules! assert_opt_evals_to {
             problems: &mut mono_problems,
             home,
             ident_ids: &mut ident_ids,
-            pointer_size: ptr_bytes,
             jump_counter: arena.alloc(0),
         };
         let main_body = Expr::new(&mut mono_env, loc_expr.value, &mut procs);

--- a/compiler/mono/src/layout.rs
+++ b/compiler/mono/src/layout.rs
@@ -50,17 +50,12 @@ pub enum Builtin<'a> {
 }
 
 impl<'a> Layout<'a> {
-    pub fn new(
-        arena: &'a Bump,
-        content: Content,
-        subs: &Subs,
-        pointer_size: u32,
-    ) -> Result<Self, LayoutProblem> {
+    pub fn new(arena: &'a Bump, content: Content, subs: &Subs) -> Result<Self, LayoutProblem> {
         use roc_types::subs::Content::*;
 
         match content {
             FlexVar(_) | RigidVar(_) => Err(LayoutProblem::UnresolvedTypeVar),
-            Structure(flat_type) => layout_from_flat_type(arena, flat_type, subs, pointer_size),
+            Structure(flat_type) => layout_from_flat_type(arena, flat_type, subs),
 
             Alias(Symbol::NUM_INT, args, _) => {
                 debug_assert!(args.is_empty());
@@ -70,12 +65,7 @@ impl<'a> Layout<'a> {
                 debug_assert!(args.is_empty());
                 Ok(Layout::Builtin(Builtin::Float64))
             }
-            Alias(_, _, var) => Self::new(
-                arena,
-                subs.get_without_compacting(var).content,
-                subs,
-                pointer_size,
-            ),
+            Alias(_, _, var) => Self::new(arena, subs.get_without_compacting(var).content, subs),
             Error => Err(LayoutProblem::Erroneous),
         }
     }
@@ -83,15 +73,10 @@ impl<'a> Layout<'a> {
     /// Returns Err(()) if given an error, or Ok(Layout) if given a non-erroneous Structure.
     /// Panics if given a FlexVar or RigidVar, since those should have been
     /// monomorphized away already!
-    fn from_var(
-        arena: &'a Bump,
-        var: Variable,
-        subs: &Subs,
-        pointer_size: u32,
-    ) -> Result<Self, LayoutProblem> {
+    fn from_var(arena: &'a Bump, var: Variable, subs: &Subs) -> Result<Self, LayoutProblem> {
         let content = subs.get_without_compacting(var).content;
 
-        Self::new(arena, content, subs, pointer_size)
+        Self::new(arena, content, subs)
     }
 
     pub fn safe_to_memcpy(&self) -> bool {
@@ -114,6 +99,13 @@ impl<'a> Layout<'a> {
                 false
             }
         }
+    }
+
+    pub fn is_zero_sized(&self) -> bool {
+        // For this calculation, we don't need an accurate
+        // stack size, we just need to know whether it's zero,
+        // so it's fine to use a pointer size of 1.
+        self.stack_size(1) == 0
     }
 
     pub fn stack_size(&self, pointer_size: u32) -> u32 {
@@ -161,7 +153,6 @@ impl<'a> LayoutCache<'a> {
         arena: &'a Bump,
         var: Variable,
         subs: &Subs,
-        pointer_size: u32,
     ) -> Result<Layout<'a>, LayoutProblem> {
         // Store things according to the root Variable, to avoid duplicate work.
         let var = subs.get_root_key_without_compacting(var);
@@ -171,7 +162,7 @@ impl<'a> LayoutCache<'a> {
             .or_insert_with(|| {
                 let content = subs.get_without_compacting(var).content;
 
-                Layout::new(arena, content, subs, pointer_size)
+                Layout::new(arena, content, subs)
             })
             .clone()
     }
@@ -238,7 +229,6 @@ fn layout_from_flat_type<'a>(
     arena: &'a Bump,
     flat_type: FlatType,
     subs: &Subs,
-    pointer_size: u32,
 ) -> Result<Layout<'a>, LayoutProblem> {
     use roc_types::subs::FlatType::*;
 
@@ -263,7 +253,7 @@ fn layout_from_flat_type<'a>(
                     layout_from_num_content(content)
                 }
                 Symbol::STR_STR => Ok(Layout::Builtin(Builtin::Str)),
-                Symbol::LIST_LIST => list_layout_from_elem(arena, subs, args[0], pointer_size),
+                Symbol::LIST_LIST => list_layout_from_elem(arena, subs, args[0]),
                 Symbol::ATTR_ATTR => {
                     debug_assert_eq!(args.len(), 2);
 
@@ -274,7 +264,7 @@ fn layout_from_flat_type<'a>(
                     // For now, layout is unaffected by uniqueness.
                     // (Incorporating refcounting may change this.)
                     // Unwrap and continue
-                    Layout::from_var(arena, wrapped_var, subs, pointer_size)
+                    Layout::from_var(arena, wrapped_var, subs)
                 }
                 _ => {
                     panic!("TODO layout_from_flat_type for {:?}", Apply(symbol, args));
@@ -287,11 +277,11 @@ fn layout_from_flat_type<'a>(
             for arg_var in args {
                 let arg_content = subs.get_without_compacting(arg_var).content;
 
-                fn_args.push(Layout::new(arena, arg_content, subs, pointer_size)?);
+                fn_args.push(Layout::new(arena, arg_content, subs)?);
             }
 
             let ret_content = subs.get_without_compacting(ret_var).content;
-            let ret = Layout::new(arena, ret_content, subs, pointer_size)?;
+            let ret = Layout::new(arena, ret_content, subs)?;
 
             Ok(Layout::FunctionPointer(
                 fn_args.into_bump_slice(),
@@ -319,10 +309,10 @@ fn layout_from_flat_type<'a>(
                 let field_var = field.into_inner();
                 let field_content = subs.get_without_compacting(field_var).content;
 
-                match Layout::new(arena, field_content, subs, pointer_size) {
+                match Layout::new(arena, field_content, subs) {
                     Ok(layout) => {
-                        // Drop any zero-sized fields like {}
-                        if layout.stack_size(pointer_size) != 0 {
+                        // Drop any zero-sized fields like {}.
+                        if !layout.is_zero_sized() {
                             layouts.push(layout);
                         }
                     }
@@ -344,7 +334,7 @@ fn layout_from_flat_type<'a>(
         TagUnion(tags, ext_var) => {
             debug_assert!(ext_var_is_empty_tag_union(subs, ext_var));
 
-            Ok(layout_from_tag_union(arena, tags, subs, pointer_size))
+            Ok(layout_from_tag_union(arena, tags, subs))
         }
         RecursiveTagUnion(_, _, _) => {
             panic!("TODO make Layout for non-empty Tag Union");
@@ -364,7 +354,6 @@ pub fn sort_record_fields<'a>(
     arena: &'a Bump,
     var: Variable,
     subs: &Subs,
-    pointer_size: u32,
 ) -> Vec<'a, (Lowercase, Layout<'a>)> {
     let mut fields_map = MutMap::default();
 
@@ -375,11 +364,10 @@ pub fn sort_record_fields<'a>(
 
             for (label, field) in fields_map {
                 let var = field.into_inner();
-                let layout = Layout::from_var(arena, var, subs, pointer_size)
-                    .expect("invalid layout from var");
+                let layout = Layout::from_var(arena, var, subs).expect("invalid layout from var");
 
                 // Drop any zero-sized fields like {}
-                if layout.stack_size(pointer_size) != 0 {
+                if !layout.is_zero_sized() {
                     sorted_fields.push((label, layout));
                 }
             }
@@ -402,17 +390,10 @@ pub enum UnionVariant<'a> {
     Wrapped(Vec<'a, (TagName, &'a [Layout<'a>])>),
 }
 
-pub fn union_sorted_tags<'a>(
-    arena: &'a Bump,
-    var: Variable,
-    subs: &Subs,
-    pointer_size: u32,
-) -> UnionVariant<'a> {
+pub fn union_sorted_tags<'a>(arena: &'a Bump, var: Variable, subs: &Subs) -> UnionVariant<'a> {
     let mut tags_vec = std::vec::Vec::new();
     match roc_types::pretty_print::chase_ext_tag_union(subs, var, &mut tags_vec) {
-        Ok(()) | Err((_, Content::FlexVar(_))) => {
-            union_sorted_tags_help(arena, tags_vec, subs, pointer_size)
-        }
+        Ok(()) | Err((_, Content::FlexVar(_))) => union_sorted_tags_help(arena, tags_vec, subs),
         Err(other) => panic!("invalid content in tag union variable: {:?}", other),
     }
 }
@@ -421,7 +402,6 @@ fn union_sorted_tags_help<'a>(
     arena: &'a Bump,
     mut tags_vec: std::vec::Vec<(TagName, std::vec::Vec<Variable>)>,
     subs: &Subs,
-    pointer_size: u32,
 ) -> UnionVariant<'a> {
     // sort up front; make sure the ordering stays intact!
     tags_vec.sort();
@@ -444,10 +424,10 @@ fn union_sorted_tags_help<'a>(
                 }
                 _ => {
                     for var in arguments {
-                        match Layout::from_var(arena, var, subs, pointer_size) {
+                        match Layout::from_var(arena, var, subs) {
                             Ok(layout) => {
                                 // Drop any zero-sized arguments like {}
-                                if layout.stack_size(pointer_size) != 0 {
+                                if !layout.is_zero_sized() {
                                     layouts.push(layout);
                                 }
                             }
@@ -483,10 +463,10 @@ fn union_sorted_tags_help<'a>(
                 arg_layouts.push(Layout::Builtin(Builtin::Int64));
 
                 for var in arguments {
-                    match Layout::from_var(arena, var, subs, pointer_size) {
+                    match Layout::from_var(arena, var, subs) {
                         Ok(layout) => {
                             // Drop any zero-sized arguments like {}
-                            if layout.stack_size(pointer_size) != 0 {
+                            if !layout.is_zero_sized() {
                                 has_any_arguments = true;
 
                                 arg_layouts.push(layout);
@@ -537,14 +517,13 @@ pub fn layout_from_tag_union<'a>(
     arena: &'a Bump,
     tags: MutMap<TagName, std::vec::Vec<Variable>>,
     subs: &Subs,
-    pointer_size: u32,
 ) -> Layout<'a> {
     use UnionVariant::*;
 
     let tags_vec: std::vec::Vec<_> = tags.into_iter().collect();
 
     if tags_vec[0].0 != TagName::Private(Symbol::NUM_AT_NUM) {
-        let variant = union_sorted_tags_help(arena, tags_vec, subs, pointer_size);
+        let variant = union_sorted_tags_help(arena, tags_vec, subs);
 
         match variant {
             Never => panic!("TODO gracefully handle trying to instantiate Never"),
@@ -678,7 +657,6 @@ pub fn list_layout_from_elem<'a>(
     arena: &'a Bump,
     subs: &Subs,
     var: Variable,
-    pointer_size: u32,
 ) -> Result<Layout<'a>, LayoutProblem> {
     match subs.get_without_compacting(var).content {
         Content::Structure(FlatType::Apply(Symbol::ATTR_ATTR, args)) => {
@@ -686,14 +664,14 @@ pub fn list_layout_from_elem<'a>(
 
             let arg_var = args.get(1).unwrap();
 
-            list_layout_from_elem(arena, subs, *arg_var, pointer_size)
+            list_layout_from_elem(arena, subs, *arg_var)
         }
         Content::FlexVar(_) | Content::RigidVar(_) => {
             // If this was still a (List *) then it must have been an empty list
             Ok(Layout::Builtin(Builtin::EmptyList))
         }
         content => {
-            let elem_layout = Layout::new(arena, content, subs, pointer_size)?;
+            let elem_layout = Layout::new(arena, content, subs)?;
 
             // This is a normal list.
             Ok(Layout::Builtin(Builtin::List(arena.alloc(elem_layout))))

--- a/compiler/mono/tests/test_mono.rs
+++ b/compiler/mono/tests/test_mono.rs
@@ -50,9 +50,6 @@ mod test_mono {
         let mut procs = Procs::default();
         let mut ident_ids = interns.all_ident_ids.remove(&home).unwrap();
 
-        // assume 64-bit pointers
-        let pointer_size = std::mem::size_of::<u64>() as u32;
-
         // Populate Procs and Subs, and get the low-level Expr from the canonical Expr
         let mut mono_problems = Vec::new();
         let mut mono_env = roc_mono::expr::Env {
@@ -61,7 +58,6 @@ mod test_mono {
             problems: &mut mono_problems,
             home,
             ident_ids: &mut ident_ids,
-            pointer_size,
             jump_counter: arena.alloc(0),
         };
         let mono_expr = Expr::new(&mut mono_env, loc_expr.value, &mut procs);

--- a/compiler/reporting/tests/test_reporting.rs
+++ b/compiler/reporting/tests/test_reporting.rs
@@ -86,9 +86,6 @@ mod test_reporting {
             let mut procs = Procs::default();
             let mut ident_ids = interns.all_ident_ids.remove(&home).unwrap();
 
-            // assume 64-bit pointers
-            let pointer_size = std::mem::size_of::<u64>() as u32;
-
             // Populate Procs and Subs, and get the low-level Expr from the canonical Expr
             let mut mono_env = roc_mono::expr::Env {
                 arena: &arena,
@@ -96,7 +93,6 @@ mod test_reporting {
                 problems: &mut mono_problems,
                 home,
                 ident_ids: &mut ident_ids,
-                pointer_size,
                 jump_counter: arena.alloc(0),
             };
             let _mono_expr = Expr::new(&mut mono_env, loc_expr.value, &mut procs);


### PR DESCRIPTION
I realized that the only reason monomorphization required a `ptr_bytes` value when constructing a `Layout` is that it needed to check whether layouts were zero-sized. That doesn't require an *accurate* size calculation, it just needs to know whether the size is zero - so I made it assume a pointer size of 1 byte rather than requiring an argument for it, since 1 gives the same answer to the question "is this zero after summing everything up?" as any other positive integer would.

This in turn removed the necessity of having access to the number of pointer bytes from lots of places, including `load::file` (which I'm working on, and which doesn't currently have access to that value - but shouldn't need to, as it turns out!)