### PR TITLE
Make pattern_symbols be a slice

### DIFF
--- a/compiler/build/src/program.rs
+++ b/compiler/build/src/program.rs
@@ -202,7 +202,7 @@ pub fn gen(
                                 let proc = PartialProc {
                                     annotation: def.expr_var,
                                     // This is a 0-arity thunk, so it has no arguments.
-                                    pattern_symbols: bumpalo::collections::Vec::new_in(arena),
+                                    pattern_symbols: &[],
                                     body,
                                 };
 

--- a/compiler/mono/src/expr.rs
+++ b/compiler/mono/src/expr.rs
@@ -15,7 +15,7 @@ use std::collections::HashMap;
 #[derive(Clone, Debug, PartialEq)]
 pub struct PartialProc<'a> {
     pub annotation: Variable,
-    pub pattern_symbols: Vec<'a, Symbol>,
+    pub pattern_symbols: &'a [Symbol],
     pub body: roc_can::expr::Expr,
 }
 
@@ -426,7 +426,7 @@ fn patterns_to_when<'a>(
 ) -> Result<
     (
         Vec<'a, Variable>,
-        Vec<'a, Symbol>,
+        &'a [Symbol],
         Located<roc_can::expr::Expr>,
     ),
     Located<RuntimeError>,
@@ -483,7 +483,7 @@ fn patterns_to_when<'a>(
     }
 
     match body {
-        Ok(body) => Ok((arg_vars, symbols, body)),
+        Ok(body) => Ok((arg_vars, symbols.into_bump_slice(), body)),
         Err(loc_error) => Err(loc_error),
     }
 }


### PR DESCRIPTION
This is necessary so that partial procs can be sent across threads!