### PR TITLE
Drop unnecessary arg_basic_types

### DIFF
--- a/cli/src/repl.rs
+++ b/cli/src/repl.rs
@@ -294,21 +294,20 @@ pub fn gen(src: &[u8], target: Triple, opt_level: OptLevel) -> Result<(String, S
                 panic!("A specialization was still marked InProgress after monomorphization had completed: {:?} with layout {:?}", symbol, layout);
             }
             Done(proc) => {
-                let (fn_val, arg_basic_types) =
-                    build_proc_header(&env, &mut layout_ids, symbol, &layout, &proc);
+                let fn_val = build_proc_header(&env, &mut layout_ids, symbol, &layout, &proc);
 
-                headers.push((proc, fn_val, arg_basic_types));
+                headers.push((proc, fn_val));
             }
         }
     }
 
     // Build each proc using its header info.
-    for (proc, fn_val, arg_basic_types) in headers {
+    for (proc, fn_val) in headers {
         // NOTE: This is here to be uncommented in case verification fails.
         // (This approach means we don't have to defensively clone name here.)
         //
         // println!("\n\nBuilding and then verifying function {}\n\n", name);
-        build_proc(&env, &mut layout_ids, proc, fn_val, arg_basic_types);
+        build_proc(&env, &mut layout_ids, proc, fn_val);
 
         if fn_val.verify(true) {
             fpm.run_on(&fn_val);

--- a/compiler/build/src/program.rs
+++ b/compiler/build/src/program.rs
@@ -250,19 +250,18 @@ pub fn gen(
     // We have to do this in a separate pass first,
     // because their bodies may reference each other.
     for ((symbol, layout), proc) in procs.get_specialized_procs(arena) {
-        let (fn_val, arg_basic_types) =
-            build_proc_header(&env, &mut layout_ids, symbol, &layout, &proc);
+        let fn_val = build_proc_header(&env, &mut layout_ids, symbol, &layout, &proc);
 
-        headers.push((proc, fn_val, arg_basic_types));
+        headers.push((proc, fn_val));
     }
 
     // Build each proc using its header info.
-    for (proc, fn_val, arg_basic_types) in headers {
+    for (proc, fn_val) in headers {
         // NOTE: This is here to be uncommented in case verification fails.
         // (This approach means we don't have to defensively clone name here.)
         //
         // println!("\n\nBuilding and then verifying function {:?}\n\n", proc);
-        build_proc(&env, &mut layout_ids, proc, fn_val, arg_basic_types);
+        build_proc(&env, &mut layout_ids, proc, fn_val);
 
         if fn_val.verify(true) {
             fpm.run_on(&fn_val);

--- a/compiler/gen/tests/helpers/eval.rs
+++ b/compiler/gen/tests/helpers/eval.rs
@@ -135,15 +135,14 @@ pub fn helper_without_uniqueness<'a>(
     // because their bodies may reference each other.
 
     for ((symbol, layout), proc) in procs.get_specialized_procs(env.arena).drain() {
-        let (fn_val, arg_basic_types) =
-            build_proc_header(&env, &mut layout_ids, symbol, &layout, &proc);
+        let fn_val = build_proc_header(&env, &mut layout_ids, symbol, &layout, &proc);
 
-        headers.push((proc, fn_val, arg_basic_types));
+        headers.push((proc, fn_val));
     }
 
     // Build each proc using its header info.
-    for (proc, fn_val, arg_basic_types) in headers {
-        build_proc(&env, &mut layout_ids, proc, fn_val, arg_basic_types);
+    for (proc, fn_val) in headers {
+        build_proc(&env, &mut layout_ids, proc, fn_val);
 
         if fn_val.verify(true) {
             function_pass.run_on(&fn_val);
@@ -324,15 +323,14 @@ pub fn helper_with_uniqueness<'a>(
     // We have to do this in a separate pass first,
     // because their bodies may reference each other.
     for ((symbol, layout), proc) in procs.get_specialized_procs(env.arena).drain() {
-        let (fn_val, arg_basic_types) =
-            build_proc_header(&env, &mut layout_ids, symbol, &layout, &proc);
+        let fn_val = build_proc_header(&env, &mut layout_ids, symbol, &layout, &proc);
 
-        headers.push((proc, fn_val, arg_basic_types));
+        headers.push((proc, fn_val));
     }
 
     // Build each proc using its header info.
-    for (proc, fn_val, arg_basic_types) in headers {
-        build_proc(&env, &mut layout_ids, proc, fn_val, arg_basic_types);
+    for (proc, fn_val) in headers {
+        build_proc(&env, &mut layout_ids, proc, fn_val);
 
         if fn_val.verify(true) {
             fpm.run_on(&fn_val);


### PR DESCRIPTION
Turns out we don't need to track this separately, because Inkwell lets us read it back out. This gives us a single source of truth in a place where previously we had two competing sources of truth!