### PR TITLE
Fix nix build issues on MacOS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,7 +217,7 @@ dependencies = [
 [[package]]
 name = "clap"
 version = "3.0.0-beta.1"
-source = "git+https://github.com/rtfeldman/clap#e1d83a78804a271b053d4d21f69b67f7eb01ad01"
+source = "git+https://github.com/rtfeldman/clap?branch=master#e1d83a78804a271b053d4d21f69b67f7eb01ad01"
 dependencies = [
  "atty",
  "bitflags",
@@ -234,7 +234,7 @@ dependencies = [
 [[package]]
 name = "clap_derive"
 version = "3.0.0-beta.1"
-source = "git+https://github.com/rtfeldman/clap#e1d83a78804a271b053d4d21f69b67f7eb01ad01"
+source = "git+https://github.com/rtfeldman/clap?branch=master#e1d83a78804a271b053d4d21f69b67f7eb01ad01"
 dependencies = [
  "heck",
  "proc-macro-error",

--- a/nix/inputs.nix
+++ b/nix/inputs.nix
@@ -1,9 +1,0 @@
-{ pkgs }: [
-  pkgs.rustup
-  pkgs.cargo
-  pkgs.llvm_10
-  # libraries for llvm
-  pkgs.libffi
-  pkgs.libxml2
-  pkgs.zlib
-]

--- a/nix/nixpkgs-version.json
+++ b/nix/nixpkgs-version.json
@@ -1,7 +1,0 @@
-{
-  "url": "https://github.com/NixOS/nixpkgs-channels.git",
-  "rev": "9beb0d1ac2ebd6063efbdc4d3631f8ce137bbf90",
-  "date": "2020-01-06T05:49:56-05:00",
-  "sha256": "1v95779di35qhrz70p2v27kmwm09h8pgh74i1wc72v0zp3bdrf50",
-  "fetchSubmodules": false
-}

--- a/shell.nix
+++ b/shell.nix
@@ -1,12 +1,10 @@
 let
-  # Look here for information about how to generate `nixpkgs-version.json`.
+  # Look here for information about how pin version of nixpkgs
   #  → https://nixos.wiki/wiki/FAQ/Pinning_Nixpkgs
-  pinnedVersion =
-    builtins.fromJSON (builtins.readFile ./nix/nixpkgs-version.json);
   pinnedPkgs = import (builtins.fetchGit {
-    inherit (pinnedVersion) url rev;
-
-    ref = "nixos-unstable";
+    name = "nixpkgs-20.03";
+    url = "https://github.com/nixos/nixpkgs/";
+    ref = "refs/heads/release-20.03";
   }) { };
 
   # This allows overriding pkgs by passing `--arg pkgs ...`
@@ -17,11 +15,29 @@ let
   isOsX = builtins.currentSystem == "x86_64-darwin";
   darwin-frameworks = if isOsX then
     with pkgs.darwin.apple_sdk.frameworks; [
-      Security
+      AppKit
       CoreFoundation
       CoreServices
+      CoreVideo
+      Foundation
+      Metal
+      Security
     ]
   else
     [ ];
-  inputs = pkgs.callPackage ./nix/inputs.nix { };
-in pkgs.mkShell { buildInputs = inputs ++ darwin-frameworks; }
+  llvm = pkgs.llvm_10;
+  inputs =
+    [
+      pkgs.rustup
+      pkgs.cargo
+      pkgs.llvm_10
+      # libraries for llvm
+      pkgs.libffi
+      pkgs.libxml2
+      pkgs.zlib
+    ];
+in pkgs.mkShell {
+  buildInputs = inputs ++ darwin-frameworks;
+  LLVM_SYS_100_PREFIX = "${llvm}";
+}
+


### PR DESCRIPTION
Fixes https://github.com/rtfeldman/roc/issues/484

Two other things:
1. I'm not sure why `Cargo.lock` changed, I only ran `cargo run repl` and it auto-updated
2. I move the stuff in `nix/` into `shell.nix` and updated how the nixpkgs is pinned for nix versions > 2.0 as recommended [in the nix docs](https://nixos.wiki/wiki/FAQ/Pinning_Nixpkgs)

Assgiend @stoeffel as the reviewer since Richard said he was the one that originally setup the nix stuff