### PR TITLE
Drop unused variant parse::ast::TypedBody

### DIFF
--- a/compiler/can/src/def.rs
+++ b/compiler/can/src/def.rs
@@ -1326,15 +1326,6 @@ fn to_pending_def<'a>(
                 PendingDef::Body(loc_pattern, loc_can_pattern, loc_expr),
             )
         }
-        TypedBody(loc_pattern, loc_ann, loc_expr) => pending_typed_body(
-            env,
-            loc_pattern,
-            loc_ann,
-            loc_expr,
-            var_store,
-            scope,
-            pattern_type,
-        ),
 
         Alias { name, vars, ann } => {
             let region = Region::span_across(&name.region, &ann.region);

--- a/compiler/can/src/operator.rs
+++ b/compiler/can/src/operator.rs
@@ -38,12 +38,6 @@ pub fn desugar_def<'a>(arena: &'a Bump, def: &'a Def<'a>) -> Def<'a> {
         Body(loc_pattern, loc_expr) | Nested(Body(loc_pattern, loc_expr)) => {
             Body(loc_pattern, desugar_expr(arena, loc_expr))
         }
-        TypedBody(loc_pattern, loc_annotation, loc_expr)
-        | Nested(TypedBody(loc_pattern, loc_annotation, loc_expr)) => TypedBody(
-            loc_pattern,
-            loc_annotation.clone(),
-            desugar_expr(arena, loc_expr),
-        ),
         SpaceBefore(def, _)
         | SpaceAfter(def, _)
         | Nested(SpaceBefore(def, _))

--- a/compiler/fmt/src/def.rs
+++ b/compiler/fmt/src/def.rs
@@ -16,10 +16,6 @@ impl<'a> Formattable<'a> for Def<'a> {
             }
             Body(loc_pattern, loc_expr) => loc_pattern.is_multiline() || loc_expr.is_multiline(),
 
-            TypedBody(_loc_pattern, _loc_annotation, _loc_expr) => {
-                unreachable!("annotations and bodies have not yet been merged into TypedBody");
-            }
-
             SpaceBefore(sub_def, spaces) | SpaceAfter(sub_def, spaces) => {
                 spaces.iter().any(|s| is_comment(s)) || sub_def.is_multiline()
             }
@@ -60,9 +56,6 @@ impl<'a> Formattable<'a> for Def<'a> {
             }
             Body(loc_pattern, loc_expr) => {
                 fmt_body(buf, &loc_pattern.value, &loc_expr.value, indent);
-            }
-            TypedBody(_loc_pattern, _loc_annotation, _loc_expr) => {
-                unreachable!("annotations and bodies have not yet been merged into TypedBody");
             }
             SpaceBefore(sub_def, spaces) => {
                 fmt_spaces(buf, spaces.iter(), indent);

--- a/compiler/parse/src/ast.rs
+++ b/compiler/parse/src/ast.rs
@@ -233,12 +233,6 @@ pub enum Def<'a> {
     // No need to track that relationship in any data structure.
     Body(&'a Loc<Pattern<'a>>, &'a Loc<Expr<'a>>),
 
-    TypedBody(
-        &'a Loc<Pattern<'a>>,
-        Loc<TypeAnnotation<'a>>,
-        &'a Loc<Expr<'a>>,
-    ),
-
     // Blank Space (e.g. comments, spaces, newlines) before or after a def.
     // We preserve this for the formatter; canonicalization ignores it.
     SpaceBefore(&'a Def<'a>, &'a [CommentOrNewline<'a>]),


### PR DESCRIPTION
Turns out we aren't using this anymore!