### PR TITLE
Fix RocList memory leak

### DIFF
--- a/examples/quicksort/platform/src/lib.rs
+++ b/examples/quicksort/platform/src/lib.rs
@@ -6,7 +6,7 @@ extern "C" {
     fn quicksort(list: RocList<i64>) -> RocList<i64>;
 }
 
-const NUM_NUMS: usize = 1_000_000;
+const NUM_NUMS: usize = 10_000;
 
 #[no_mangle]
 pub fn rust_main() -> isize {
@@ -14,7 +14,7 @@ pub fn rust_main() -> isize {
         let mut nums = Vec::with_capacity(NUM_NUMS);
 
         for index in 0..nums.capacity() {
-            let num = index as i64 % 12345;
+            let num = index as i64 % 123;
 
             nums.push(num);
         }

--- a/roc_std/src/lib.rs
+++ b/roc_std/src/lib.rs
@@ -71,7 +71,7 @@ impl<T> RocList<T> {
             let value = *self.get_storage_ptr();
 
             // NOTE doesn't work with elements of 16 or more bytes
-            match usize::cmp(&0, &value) {
+            match isize::cmp(&(value as isize), &0) {
                 Equal => Some(Storage::ReadOnly),
                 Less => Some(Storage::Refcounted(value)),
                 Greater => Some(Storage::Capacity(value)),


### PR DESCRIPTION
Also, reduces the number of elements in the quicksort example to make it
run better with valgrind.

This doesn't deal with the other part of the memory leak we talked about in chat based on whether or not the same list is return from Roc.