### PR TITLE
Remove i64_to_f64 from builtin bitcode

### DIFF
--- a/compiler/builtins/bitcode/src/lib.rs
+++ b/compiler/builtins/bitcode/src/lib.rs
@@ -6,8 +6,8 @@
 
 mod libm;
 
-/// TODO replace this with a normal Inkwell build_cast call - this was just
-/// used as a proof of concept for getting bitcode importing working!
+/// TODO this is no longer used. Feel free to delete it the next time
+/// we need to rebuild builtins.bc!
 #[no_mangle]
 pub fn i64_to_f64_(num: i64) -> f64 {
     num as f64

--- a/compiler/gen/src/llvm/build.rs
+++ b/compiler/gen/src/llvm/build.rs
@@ -2619,8 +2619,13 @@ fn build_int_unary_op<'a, 'ctx, 'env>(
             ))
         }
         NumToFloat => {
-            // TODO specialize this to be not just for i64!
-            call_bitcode_fn(NumToFloat, env, &[arg.into()], "i64_to_f64_")
+            // This is an Int, so we need to convert it.
+            bd.build_cast(
+                InstructionOpcode::SIToFP,
+                arg,
+                env.context.f64_type(),
+                "i64_to_f64",
+            )
         }
         _ => {
             unreachable!("Unrecognized int unary operation: {:?}", op);


### PR DESCRIPTION
This was originally a proof-of-concept for the bitcode strategy. Inkwell provides a primitive for this!