### PR TITLE
Add a 60-minute timeout to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ jobs:
   test:
     name: fmt, clippy, test, test --release
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v1
 


### PR DESCRIPTION
This way if CI hangs due to a deadlock or something, it won't eat up a ton of CI minutes.