### PR TITLE
replaced deprecated `std::u16::MAX` with `u16::MAX`

### DIFF
--- a/compiler/can/src/string.rs
+++ b/compiler/can/src/string.rs
@@ -52,9 +52,9 @@ pub fn canonical_string_literal<'a>(_arena: &Bump, _raw: &'a str, _region: Regio
 //                     // line length, that would have already happened back
 //                     // in the parsing step, and we never would have reached
 //                     // this code. Still, debug_assert that they won't!
-//                     debug_assert!(buf_col_offset <= std::u16::MAX as usize);
-//                     debug_assert!(ident.len() <= std::u16::MAX as usize);
-//                     debug_assert!((parsed_length - ident.len() - 1) <= std::u16::MAX as usize);
+//                     debug_assert!(buf_col_offset <= u16::MAX as usize);
+//                     debug_assert!(ident.len() <= u16::MAX as usize);
+//                     debug_assert!((parsed_length - ident.len() - 1) <= u16::MAX as usize);
 
 //                     let start_line = state.line;
 

--- a/compiler/parse/tests/test_parse.rs
+++ b/compiler/parse/tests/test_parse.rs
@@ -296,7 +296,7 @@ mod test_parse {
 
     #[test]
     fn first_line_too_long() {
-        let max_line_length = std::u16::MAX as usize;
+        let max_line_length = u16::MAX as usize;
 
         // the string literal "ZZZZZZZZZ" but with way more Zs
         let too_long_str_body: String = (1..max_line_length)

--- a/editor/src/ast.rs
+++ b/editor/src/ast.rs
@@ -17,7 +17,7 @@ pub type Res<T> = Result<T, Problem>;
 pub struct NodeId(u32);
 
 impl NodeId {
-    pub const NONE: NodeId = NodeId(std::u32::MAX);
+    pub const NONE: NodeId = NodeId(u32::MAX);
 
     pub fn as_index(self) -> usize {
         self.0 as usize
@@ -154,7 +154,7 @@ impl Nodes {
 
         self.nodes.push(node);
 
-        if index < std::u32::MAX as usize {
+        if index < u32::MAX as usize {
             Ok(NodeId(index as u32))
         } else {
             // u32::MAX is reserved for NodeId::NONE, so if we hit that on a


### PR DESCRIPTION
see [docs](https://doc.rust-lang.org/std/u16/constant.MAX.html)