### PR TITLE
Handle builtin defs in canonicalize_module_defs

### DIFF
--- a/compiler/can/src/module.rs
+++ b/compiler/can/src/module.rs
@@ -1,3 +1,4 @@
+use crate::builtins;
 use crate::def::{canonicalize_defs, sort_can_defs, Declaration};
 use crate::env::Env;
 use crate::expr::Output;
@@ -256,6 +257,15 @@ pub fn canonicalize_module_defs<'a>(
                         fix_values_captured_in_closure_defs(defs, &mut MutSet::default())
                     }
                     InvalidCycle(_, _) | Builtin(_) => {}
+                }
+            }
+
+            // Add builtin defs (e.g. List.get) to the module's defs
+            let builtin_defs = builtins::builtin_defs(var_store);
+
+            for (symbol, def) in builtin_defs {
+                if references.contains(&symbol) {
+                    declarations.push(Declaration::Builtin(def));
                 }
             }
 

--- a/compiler/load/src/file.rs
+++ b/compiler/load/src/file.rs
@@ -2042,17 +2042,7 @@ fn parse_and_constrain<'a>(
     );
     let canonicalize_end = SystemTime::now();
     let (module, declarations, ident_ids, constraint, problems) = match canonicalized {
-        Ok(mut module_output) => {
-            // Add builtin defs (e.g. List.get) to the module's defs
-            let builtin_defs = roc_can::builtins::builtin_defs(&mut var_store);
-            let references = &module_output.references;
-
-            for (symbol, def) in builtin_defs {
-                if references.contains(&symbol) {
-                    module_output.declarations.push(Declaration::Builtin(def));
-                }
-            }
-
+        Ok(module_output) => {
             let constraint = constrain_module(&module_output, module_id, mode, &mut var_store);
 
             // Now that we're done with parsing, canonicalization, and constraint gen,


### PR DESCRIPTION
This moves some logic to `canonicalize_module_defs` which should always get run. There's no situation where we're canonicalizing module defs and don't want this to happen!