### PR TITLE
Fix test warnings

### DIFF
--- a/compiler/mono/tests/test_mono.rs
+++ b/compiler/mono/tests/test_mono.rs
@@ -171,7 +171,6 @@ mod test_mono {
     }
 
     #[test]
-    #[test]
     fn ir_when_maybe() {
         compiles_to_ir(
             r#"


### PR DESCRIPTION
We get a bunch of unused code warnings that show up in file diffs on GitHub because we can't run all the checks we want to in `test_mono` in `--release` because it relies on capturing debug info that doesn't get printed in release builds.

This makes it so that we run more checks than before, but still not all. (Specifically, we don't run the very last checks, which are the ones that would fail.) This not only gives us a bit more test coverage, it should also fix the warnings!