### PR TITLE
Use assert_eq over assert

### DIFF
--- a/compiler/mono/tests/test_mono.rs
+++ b/compiler/mono/tests/test_mono.rs
@@ -78,8 +78,8 @@ mod test_mono {
             println!("Ignoring {} canonicalization problems", can_problems.len());
         }
 
-        assert!(type_problems.is_empty());
-        assert!(mono_problems.is_empty());
+        assert_eq!(type_problems, Vec::new());
+        assert_eq!(mono_problems, Vec::new());
 
         debug_assert_eq!(exposed_to_host.len(), 1);
 


### PR DESCRIPTION
This makes error messages in `test_mono` a bit more helpful, and will hopefully also get rid of the last CI warning about the `#[macro_use]` for `extern crate pretty_assertions` being unused in `cargo test --release`!