### PR TITLE
Add shaderc to nix shell

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -55,6 +55,8 @@ let
       pkgs.rust-analyzer
       # (import ./nix/zls.nix { inherit pkgs zig; })
       pkgs.ccls
+      # shaderc for compiling GLSL shaders to SPIR-V
+      pkgs.shaderc
     ];
 in pkgs.mkShell {
   buildInputs = inputs ++ darwin-frameworks;


### PR DESCRIPTION
This is causing a seg fault when I try to run `nix-shell`. It might just be something wrong with my system, however, so I'm curious if it causes any problems for you.