### PR TITLE
List.contains use borrowed

### DIFF
--- a/compiler/mono/src/borrow.rs
+++ b/compiler/mono/src/borrow.rs
@@ -534,7 +534,7 @@ pub fn lowlevel_borrow_signature(arena: &Bump, op: LowLevel) -> &[bool] {
         ListJoin => arena.alloc_slice_copy(&[irrelevant]),
         ListMap => arena.alloc_slice_copy(&[owned, irrelevant]),
         ListKeepIf => arena.alloc_slice_copy(&[owned, irrelevant]),
-        ListContains => arena.alloc_slice_copy(&[owned, irrelevant]),
+        ListContains => arena.alloc_slice_copy(&[borrowed, irrelevant]),
         ListWalkRight => arena.alloc_slice_copy(&[borrowed, irrelevant, owned]),
 
         Eq | NotEq | And | Or | NumAdd | NumAddWrap | NumAddChecked | NumSub | NumMul | NumGt


### PR DESCRIPTION
The list passed to `List.contains` does not need to be owned because contains will never mutate the list