### PR TITLE
Record references in can/expr before evaluating to runtime error

### DIFF
--- a/compiler/can/src/expr.rs
+++ b/compiler/can/src/expr.rs
@@ -349,6 +349,10 @@ pub fn canonicalize_expr<'a>(
             // Default: We're not tail-calling a symbol (by name), we're tail-calling a function value.
             output.tail_call = None;
 
+            for arg_out in outputs {
+                output.references = output.references.union(arg_out.references);
+            }
+
             let expr = match fn_expr.value {
                 Var(symbol) => {
                     output.references.calls.insert(symbol);
@@ -399,10 +403,6 @@ pub fn canonicalize_expr<'a>(
                     )
                 }
             };
-
-            for arg_out in outputs {
-                output.references = output.references.union(arg_out.references);
-            }
 
             (expr, output)
         }

--- a/compiler/reporting/tests/test_reporting.rs
+++ b/compiler/reporting/tests/test_reporting.rs
@@ -418,6 +418,44 @@ mod test_reporting {
     }
 
     #[test]
+    fn unused_undefined_argument() {
+        report_problem_as(
+            indoc!(
+                r#"
+                foo = { x: 1 == 1, y: 0x4 }
+
+                baz = 3
+
+                main : Str
+                main =
+                    when foo.y is
+                        4 -> bar baz "yay"
+                        _ -> "nay"
+
+                main
+                "#
+            ),
+            indoc!(
+                r#"
+                ── SYNTAX PROBLEM ──────────────────────────────────────────────────────────────
+               
+                I cannot find a `bar` value
+               
+                8│          4 -> bar baz "yay"
+                                 ^^^
+
+                these names seem close though:
+
+                    baz
+                    Map
+                    Str
+                    main
+                "#
+            ),
+        )
+    }
+
+    #[test]
     fn report_precedence_problem_multiline() {
         report_problem_as(
             indoc!(


### PR DESCRIPTION
**PROBLEM**
If a variable that _did_ exist (`bar`) was applied to a function that _did not_ exist (`foo` in `foo bar`), the errors included that `bar` was not used.

**SOLUTION**
Record the references in can/expr before it is evaluated to a `RunTimeError`