### PR TITLE
Comment in repeated Str.concat test

### DIFF
--- a/compiler/gen/tests/gen_str.rs
+++ b/compiler/gen/tests/gen_str.rs
@@ -71,26 +71,29 @@ mod gen_str {
             3,
             i64
         );
+    }
 
-        // assert_evals_to!(
-        //     indoc!(
-        //         r#"
-        //             when List.first (Str.split "JJJJJ" "JJJJ there") is
-        //                 Ok str ->
-        //                     str
-        //                         |> Str.concat str
-        //                         |> Str.concat str
-        //                         |> Str.concat str
-        //                         |> Str.concat str
-        //
-        //                 _ ->
-        //                     "Not Str!"
-        //
-        //         "#
-        //     ),
-        //     "JJJJJJJJJJJJJJJJJJJJJJJJJ",
-        //     &'static str
-        // );
+    #[test]
+    fn str_split_str_concat_repeated() {
+        assert_evals_to!(
+            indoc!(
+                r#"
+                    when List.first (Str.split "JJJJJ" "JJJJ there") is
+                        Ok str ->
+                            str
+                                |> Str.concat str
+                                |> Str.concat str
+                                |> Str.concat str
+                                |> Str.concat str
+        
+                        _ ->
+                            "Not Str!"
+        
+                "#
+            ),
+            "JJJJJJJJJJJJJJJJJJJJJJJJJ",
+            &'static str
+        );
     }
 
     #[test]


### PR DESCRIPTION
This test was failing, so I had it commented out, and Folkert and I just commented it back in to fix it, but it works now! I think the completion of the small string implementation in Zig fixed this.