### PR TITLE
Enable nix shell on aarch64

### DIFF
--- a/nix/zig.nix
+++ b/nix/zig.nix
@@ -1,4 +1,4 @@
-{ pkgs, isMacOS }:
+{ pkgs, isMacOS, isAarch64 }:
 
 # We require at least specific commit of Zig after the latest tagged
 # release (0.6.0), so we just download the binaries for that commit
@@ -9,10 +9,16 @@ let
     if isMacOS
       then "macos"
       else "linux";
-  archiveName = "zig-${osName}-x86_64-${version}";
+  archName =
+    if isAarch64
+      then "aarch64"
+      else "x86_64";
+  archiveName = "zig-${osName}-${archName}-${version}";
   sha256 = 
     if isMacOS
       then "665c1a7f472cfc5e0715f0ddf6ff8409fb749ac91cbbae68c443b4a37ebd058e"
+    else if isAarch64
+      then "116ms44vx4xz57m9z9lsgrxd1g22qp00m5qbmklky8xdd2jmj24w"
       else "bab70ae3bd0af538022bc3ef50d8f34fa8dceac39ba7d9e5d528eee7e6d5a1cf";
 in
 pkgs.stdenv.mkDerivation {

--- a/shell.nix
+++ b/shell.nix
@@ -1,6 +1,10 @@
 { }:
 
-with {
+let
+  splitSystem = builtins.split "-" builtins.currentSystem;
+  currentArch = builtins.elemAt splitSystem 0;
+  currentOS = builtins.elemAt splitSystem 2;
+in with {
   # Look here for information about how pin version of nixpkgs
   #  → https://nixos.wiki/wiki/FAQ/Pinning_Nixpkgs
   pkgs = import (builtins.fetchGit {
@@ -10,7 +14,8 @@ with {
     rev = "502845c3e31ef3de0e424f3fcb09217df2ce6df6";
   }) { };
 
-  isMacOS = builtins.currentSystem == "x86_64-darwin";
+  isMacOS = currentOS == "darwin";
+  isAarch64 = currentArch == "aarch64";
 };
 
 with (pkgs);
@@ -42,7 +47,7 @@ let
     [ ];
 
   llvmPkgs = pkgs.llvmPackages_10;
-  zig = import ./nix/zig.nix { inherit pkgs isMacOS; };
+  zig = import ./nix/zig.nix { inherit pkgs isMacOS isAarch64; };
   inputs = [
     # build libraries
     rustc


### PR DESCRIPTION
Just fixes the zig dependency by checking if on aarch64.

Would be good if someone on mac tests this to make sure I got my changes to isMacos correct right.