### PR TITLE
Make builtin build.rs script more resilient

### DIFF
--- a/compiler/builtins/build.rs
+++ b/compiler/builtins/build.rs
@@ -1,41 +1,36 @@
 use std::convert::AsRef;
 use std::env;
 use std::ffi::OsStr;
-use std::fs::{self};
+use std::fs;
 use std::io;
 use std::path::Path;
 use std::process::Command;
 use std::str;
 
-// TODO: Use zig build system command instead
-
 fn main() {
     let out_dir = env::var_os("OUT_DIR").unwrap();
 
     // "." is relative to where "build.rs" is
-    let build_script_dir_path = Path::new(".");
-
+    let build_script_dir_path = fs::canonicalize(Path::new(".")).unwrap();
     let bitcode_path = build_script_dir_path.join("bitcode");
 
     let src_path = bitcode_path.join("src");
 
-    let build_zig_path = bitcode_path.join("build.zig");
-    let build_zig = build_zig_path.to_str().expect("Invalid build path");
-
-    let dest_ir_path = build_script_dir_path.join("builtins.ll");
+    let dest_ir_path = bitcode_path.join("builtins.ll");
     let dest_ir = dest_ir_path.to_str().expect("Invalid dest ir path");
     println!("Compiling ir to: {}", dest_ir);
 
-    run_command(
-        "zig",
-        &["build", "ir", "-Drelease=true", "--build-file", build_zig],
-    );
+    run_command(bitcode_path, "zig", &["build", "ir", "-Drelease=true"]);
 
     let dest_bc_path = Path::new(&out_dir).join("builtins.bc");
     let dest_bc = dest_bc_path.to_str().expect("Invalid dest bc path");
     println!("Compiling bitcode to: {}", dest_bc);
 
-    run_command("llvm-as-10", &[dest_ir, "-o", dest_bc]);
+    run_command(
+        build_script_dir_path,
+        "llvm-as-10",
+        &[dest_ir, "-o", dest_bc],
+    );
 
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rustc-env=BUILTINS_BC={}", dest_bc);
@@ -49,12 +44,15 @@ fn main() {
     .unwrap();
 }
 
-fn run_command<S, I>(command_str: &str, args: I)
+fn run_command<S, I, P: AsRef<Path>>(path: P, command_str: &str, args: I)
 where
     I: IntoIterator<Item = S>,
     S: AsRef<OsStr>,
 {
-    let output_result = Command::new(OsStr::new(&command_str)).args(args).output();
+    let output_result = Command::new(OsStr::new(&command_str))
+        .current_dir(path)
+        .args(args)
+        .output();
     match output_result {
         Ok(output) => match output.status.success() {
             true => (),


### PR DESCRIPTION
Before this change, re-running it from the root of the project
failed for me on `trunk` after I had deleted `builtins.ll`