### PR TITLE
make empty tag union compile

### DIFF
--- a/compiler/gen/tests/gen_tags.rs
+++ b/compiler/gen/tests/gen_tags.rs
@@ -920,4 +920,25 @@ mod gen_tags {
             (i64, i64)
         );
     }
+
+    #[test]
+    fn result_never() {
+        assert_evals_to!(
+            indoc!(
+                r"#
+                res : Result I64 []
+                res = Ok 4
+
+                # we should provide this in the stdlib
+                never : [] -> a
+
+                when res is
+                    Ok v -> v
+                    Err empty -> never empty
+                #"
+            ),
+            4,
+            i64
+        );
+    }
 }

--- a/examples/effect/Main.roc
+++ b/examples/effect/Main.roc
@@ -3,6 +3,6 @@ app "effect-example"
     imports [base.Task]
     provides [ main ] to base
 
-main : Task.Task {} F64
+main : Task.Task {} []
 main =
     Task.after Task.getLine \lineThisThing -> Task.putLine lineThisThing

--- a/examples/effect/thing/platform-dir/Pkg-Config.roc
+++ b/examples/effect/thing/platform-dir/Pkg-Config.roc
@@ -12,5 +12,5 @@ platform folkertdev/foo
         }
 
 
-mainForHost : Task.Task {} F64 as Fx
+mainForHost : Task.Task {} [] as Fx
 mainForHost = main


### PR DESCRIPTION
make it possible to use the empty tag union in type signatures (and have the code compile)