### PR TITLE
Fix gen_list

### DIFF
--- a/compiler/gen/tests/gen_list.rs
+++ b/compiler/gen/tests/gen_list.rs
@@ -1273,7 +1273,7 @@ mod gen_list {
                 app "quicksort" provides [ main ] to "./platform"
 
 
-                swap : Int *, Int *, List a -> List a
+                swap : Nat, Nat, List a -> List a
                 swap = \i, j, list ->
                     when Pair (List.get list i) (List.get list j) is
                         Pair (Ok atI) (Ok atJ) ->
@@ -1396,7 +1396,7 @@ mod gen_list {
                         quicksortHelp list 0 (n - 1)
 
 
-                    quicksortHelp : List (Num a), Int *, Int * -> List (Num a)
+                    quicksortHelp : List (Num a), Nat, Nat -> List (Num a)
                     quicksortHelp = \list, low, high ->
                         if low < high then
                             when partition low high list is
@@ -1408,7 +1408,7 @@ mod gen_list {
                             list
 
 
-                    swap : Int *, Int *, List a -> List a
+                    swap : Nat, Nat, List a -> List a
                     swap = \i, j, list ->
                         when Pair (List.get list i) (List.get list j) is
                             Pair (Ok atI) (Ok atJ) ->
@@ -1419,7 +1419,7 @@ mod gen_list {
                             _ ->
                                 []
 
-                    partition : Int *, Int *, List (Num a) -> [ Pair (Int *) (List (Num a)) ]
+                    partition : Nat, Nat, List (Num a) -> [ Pair Nat (List (Num a)) ]
                     partition = \low, high, initialList ->
                         when List.get initialList high is
                             Ok pivot ->
@@ -1431,7 +1431,7 @@ mod gen_list {
                                 Pair (low - 1) initialList
 
 
-                    partitionHelp : Int *, Int *, List (Num a), Int *, (Num a) -> [ Pair (Int *) (List (Num a)) ]
+                    partitionHelp : Nat, Nat, List (Num a), Nat, (Num a) -> [ Pair Nat (List (Num a)) ]
                     partitionHelp = \i, j, list, high, pivot ->
                         if j < high then
                             when List.get list j is
@@ -1466,7 +1466,7 @@ mod gen_list {
                            quicksortHelp list 0 (List.len list - 1)
 
 
-                       quicksortHelp : List (Num a), Int *, Int * -> List (Num a)
+                       quicksortHelp : List (Num a), Nat, Nat -> List (Num a)
                        quicksortHelp = \list, low, high ->
                            if low < high then
                                when partition low high list is
@@ -1478,7 +1478,7 @@ mod gen_list {
                                list
 
 
-                       swap : Int *, Int *, List a -> List a
+                       swap : Nat, Nat, List a -> List a
                        swap = \i, j, list ->
                            when Pair (List.get list i) (List.get list j) is
                                Pair (Ok atI) (Ok atJ) ->
@@ -1489,7 +1489,7 @@ mod gen_list {
                                _ ->
                                    []
 
-                       partition : Int *, Int *, List (Num a) -> [ Pair (Int *) (List (Num a)) ]
+                       partition : Nat, Nat, List (Num a) -> [ Pair Nat (List (Num a)) ]
                        partition = \low, high, initialList ->
                            when List.get initialList high is
                                Ok pivot ->
@@ -1501,7 +1501,7 @@ mod gen_list {
                                    Pair (low - 1) initialList
 
 
-                       partitionHelp : Int *, Int *, List (Num a), Int *, Num a -> [ Pair (Int *) (List (Num a)) ]
+                       partitionHelp : Nat, Nat, List (Num a), Nat, Num a -> [ Pair Nat (List (Num a)) ]
                        partitionHelp = \i, j, list, high, pivot ->
                            # if j < high then
                            if False then
@@ -1539,7 +1539,7 @@ mod gen_list {
                            quicksortHelp list 0 (List.len list - 1)
 
 
-                       quicksortHelp : List (Num a), Int *, Int * -> List (Num a)
+                       quicksortHelp : List (Num a), Nat, Nat -> List (Num a)
                        quicksortHelp = \list, low, high ->
                            if low < high then
                                when partition low high list is
@@ -1551,7 +1551,7 @@ mod gen_list {
                                list
 
 
-                       swap : Int *, Int *, List a -> List a
+                       swap : Nat, Nat, List a -> List a
                        swap = \i, j, list ->
                            when Pair (List.get list i) (List.get list j) is
                                Pair (Ok atI) (Ok atJ) ->
@@ -1562,7 +1562,7 @@ mod gen_list {
                                _ ->
                                    []
 
-                       partition : Int *, Int *, List (Num a) -> [ Pair (Int *) (List (Num a)) ]
+                       partition : Nat, Nat, List (Num a) -> [ Pair Nat (List (Num a)) ]
                        partition = \low, high, initialList ->
                            when List.get initialList high is
                                Ok pivot ->
@@ -1574,7 +1574,7 @@ mod gen_list {
                                    Pair (low - 1) initialList
 
 
-                       partitionHelp : Int *, Int *, List (Num a), Int *, Num a -> [ Pair (Int *) (List (Num a)) ]
+                       partitionHelp : Nat, Nat, List (Num a), Nat, Num a -> [ Pair Nat (List (Num a)) ]
                        partitionHelp = \i, j, list, high, pivot ->
                            if j < high then
                                when List.get list j is


### PR DESCRIPTION
I overlooked making these tests use `Nat` instead of `Int *`

Somehow `--release` let them through and I never saw them fail locally, not sure what happened sorry about that, but thanks to @Anton-4 we are good now.