### PR TITLE
fixed config location in BUILDING_FROM_SOURCE

### DIFF
--- a/BUILDING_FROM_SOURCE.md
+++ b/BUILDING_FROM_SOURCE.md
@@ -150,7 +150,7 @@ Once all that was done, `cargo` ran successfully for Roc!
 Using [`lld` for Rust's linker](https://github.com/rust-lang/rust/issues/39915#issuecomment-538049306)
 makes build times a lot faster, and I highly recommend it.
 
-Create `~/.config/cargo` and add this to it:
+Create `~/.cargo/config.toml` if it does not exist and add this to it:
 
 ```
 [build]


### PR DESCRIPTION
Based on the [cargo book](https://doc.rust-lang.org/cargo/reference/config.html#hierarchical-structure) I don't think `.config/cargo` is picked up by cargo. So I have changed it to `~/.cargo/config.toml` and have verified this does indeed speed up building.