### PR TITLE
Render Expr2 Better Number Matches

### DIFF
--- a/editor/src/lib.rs
+++ b/editor/src/lib.rs
@@ -304,7 +304,13 @@ fn run_event_loop(file_path_opt: Option<&Path>) -> Result<(), Box<dyn Error>> {
                     )
                     .unwrap();
 
-                    render::render_expr2(&size, &expr2, CODE_TXT_XY.into(), &mut glyph_brush);
+                    render::render_expr2(
+                        &arena,
+                        &size,
+                        &expr2,
+                        CODE_TXT_XY.into(),
+                        &mut glyph_brush,
+                    );
                 }
 
                 match draw_all_rects(

--- a/editor/src/render.rs
+++ b/editor/src/render.rs
@@ -1,3 +1,4 @@
+use bumpalo::Bump;
 use cgmath::Vector2;
 use wgpu_glyph::GlyphBrush;
 use winit::dpi::PhysicalSize;
@@ -8,53 +9,68 @@ use crate::{
         primitives::text::{queue_code_text_draw, Text},
         style::CODE_FONT_SIZE,
     },
-    lang::ast::Expr2,
+    lang::ast::{Expr2, FloatVal, IntVal},
 };
 
-pub fn render_expr2(
+pub fn render_expr2<'a>(
+    _arena: &'a Bump,
     size: &PhysicalSize<u32>,
     expr2: &Expr2,
     position: Vector2<f32>,
     glyph_brush: &mut GlyphBrush<()>,
 ) {
-    use Expr2::*;
-
     let area_bounds = (size.width as f32, size.height as f32).into();
 
     match expr2 {
-        SmallInt {
+        Expr2::SmallInt {
             number,
             ..
             // text,
             // style, pretending always decimal for now
             // var,
         } => {
+            let text = match number {
+                IntVal::I64(val) => format!("{}", val),
+                IntVal::I32(val) => format!("{}", val),
+                IntVal::I16(val) => format!("{}", val),
+                IntVal::I8(val) => format!("{}", val),
+                IntVal::U64(val) => format!("{}", val),
+                IntVal::U32(val ) => format!("{}", val),
+                IntVal::U16(val) => format!("{}", val),
+                IntVal::U8(val) => format!("{}", val),
+            };
+
             let code_text = Text {
                 position,
                 area_bounds,
                 color: CODE_COLOR.into(),
-                text: format!("{:?}", number),
+                text,
                 size: CODE_FONT_SIZE,
                 ..Default::default()
             };
 
             queue_code_text_draw(&code_text, glyph_brush);
         }
-        Float {
+        Expr2::Float {
             number,
             ..
         } => {
+            let text = match number {
+                FloatVal::F64(val) => format!("{}", val),
+                FloatVal::F32(val) => format!("{}", val),
+            };
+
             let code_text = Text {
                 position,
                 area_bounds,
                 color: CODE_COLOR.into(),
-                text: format!("{:?}", number),
+                text,
                 size: CODE_FONT_SIZE,
                 ..Default::default()
             };
 
             queue_code_text_draw(&code_text, glyph_brush);
         }
-        rest => panic!("implement {:?} render", rest)
+        rest => todo!("implement {:?} render", rest)
     };
 }


### PR DESCRIPTION
* match on all cases of IntVal and FloatVal

I still need to avoid using `format!`