### PR TITLE
Switch to thin lto for faster compilation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,8 +31,10 @@ members = [
 
 # Optimizations based on https://deterministic.space/high-performance-rust.html
 [profile.release]
-lto = "fat"
+lto = "thin"
 codegen-units = 1
 # debug = true # enable when profiling
 
-
+[profile.bench]
+lto = "thin"
+codegen-units = 1


### PR DESCRIPTION
Also, makes the bench and release profile match each other so that
tests built in release mode don't need to recompile everything compared
to regular release builds.