### PR TITLE
Render Expr2::{List, Record}

### DIFF
--- a/editor/src/lib.rs
+++ b/editor/src/lib.rs
@@ -303,7 +303,7 @@ fn run_event_loop(file_path_opt: Option<&Path>) -> Result<(), Box<dyn Error>> {
 
                     let (expr2, _) = crate::lang::expr::str_to_expr2(
                         &arena,
-                        "[ 1, 2, 3 ]",
+                        "{ x: 2, y: 5 }",
                         &mut env,
                         &mut scope,
                         region,

--- a/editor/src/render.rs
+++ b/editor/src/render.rs
@@ -168,6 +168,92 @@ pub fn render_expr2<'a>(
 
             queue_code_text_draw(&code_text, glyph_brush);
         }
+        Expr2::Record { fields, .. } => {
+            let code_text = Text {
+                position,
+                area_bounds,
+                color: CODE_COLOR.into(),
+                text: "{",
+                size: CODE_FONT_SIZE,
+                ..Default::default()
+            };
+
+            queue_code_text_draw(&code_text, glyph_brush);
+
+            let mut x_pos = position.x;
+
+            for (idx, node_id) in fields.iter_node_ids().enumerate() {
+                let (pool_field_name, _, sub_expr2_node_id) = env.pool.get(node_id);
+
+                let field_name = env.pool.get_str(pool_field_name);
+
+                x_pos += 20.0;
+
+                let code_text = Text {
+                    position: Vector2::new(x_pos, position.y),
+                    area_bounds,
+                    color: CODE_COLOR.into(),
+                    text: field_name,
+                    size: CODE_FONT_SIZE,
+                    ..Default::default()
+                };
+
+                queue_code_text_draw(&code_text, glyph_brush);
+
+                x_pos += 10.0;
+
+                let code_text = Text {
+                    position: Vector2::new(x_pos, position.y),
+                    area_bounds,
+                    color: CODE_COLOR.into(),
+                    text: ":",
+                    size: CODE_FONT_SIZE,
+                    ..Default::default()
+                };
+
+                queue_code_text_draw(&code_text, glyph_brush);
+
+                let sub_expr2 = env.pool.get(*sub_expr2_node_id);
+
+                x_pos += 20.0;
+
+                render_expr2(
+                    env,
+                    sub_expr2,
+                    size,
+                    Vector2::new(x_pos, position.y),
+                    glyph_brush,
+                );
+
+                if idx + 1 < fields.len() {
+                    x_pos += 10.0;
+
+                    let code_text = Text {
+                        position: Vector2::new(x_pos, position.y),
+                        area_bounds,
+                        color: CODE_COLOR.into(),
+                        text: ",",
+                        size: CODE_FONT_SIZE,
+                        ..Default::default()
+                    };
+
+                    queue_code_text_draw(&code_text, glyph_brush);
+                }
+            }
+
+            x_pos += 20.0;
+
+            let code_text = Text {
+                position: Vector2::new(x_pos, position.y),
+                area_bounds,
+                color: CODE_COLOR.into(),
+                text: "}",
+                size: CODE_FONT_SIZE,
+                ..Default::default()
+            };
+
+            queue_code_text_draw(&code_text, glyph_brush);
+        }
         rest => todo!("implement {:?} render", rest),
     };
 }


### PR DESCRIPTION
* renders lists
* renders records
* nesting seems to work but prints out with bad positioning

> some hacky spacing for list and record elems so that they don't stack. we can probably sort out how to render all this in a prettier way later