### PR TITLE
fixes test_big_sel_text failures

### DIFF
--- a/editor/src/graphics/lowlevel/vertex.rs
+++ b/editor/src/graphics/lowlevel/vertex.rs
@@ -4,7 +4,6 @@ use cgmath::Vector2;
 
 #[derive(Copy, Clone)]
 pub struct Vertex {
-    #[allow(dead_code)]
     pub position: Vector2<f32>,
     pub color: [f32; 4],
 }


### PR DESCRIPTION
Tests sometimes showed the following errors:
```
---- ui::text::big_selectable_text::test_big_sel_text::move_down stdout ----
thread 'ui::text::big_selectable_text::test_big_sel_text::move_down' panicked at 'called `Result::unwrap()` on an `Err` value: Os { code: 2, kind: NotFound, message: "No such file or directory" }', editor/src/ui/text/big_selectable_text.rs:800:31
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

---- ui::text::big_selectable_text::test_big_sel_text::end_selection_left stdout ----
thread 'ui::text::big_selectable_text::test_big_sel_text::end_selection_left' panicked at 'called `Result::unwrap()` on an `Err` value: Os { code: 2, kind: NotFound, message: "No such file or directory" }', editor/src/ui/text/big_selectable_text.rs:800:31

---- ui::text::big_selectable_text::test_big_sel_text::extend_selection_left stdout ----
thread 'ui::text::big_selectable_text::test_big_sel_text::extend_selection_left' panicked at 'assertion failed: `(left == right)`
  left: `["|[a]bc"]`,
 right: `["|[a]bcc"]`', editor/src/ui/text/big_selectable_text.rs:1130:17

---- ui::text::big_selectable_text::test_big_sel_text::end_selection_right stdout ----
thread 'ui::text::big_selectable_text::test_big_sel_text::end_selection_right' panicked at 'called `Result::unwrap()` on an `Err` value: Os { code: 2, kind: NotFound, message: "No such file or directory" }', editor/src/ui/text/big_selectable_text.rs:800:31
```
This was due to `BigSelectableText` being created from real files, I think this caused some async io problems.