### PR TITLE
Use template-style copyright section in LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2019 Richard Feldman
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
Per https://github.com/rtfeldman/roc/issues/1032, it's apparently supposed to say `Copyright [yyyy] [name of copyright owner]` with the brackets and everything!