### PR TITLE
Improve isMultipleOf perf cost.

### DIFF
--- a/compiler/gen/src/llvm/build.rs
+++ b/compiler/gen/src/llvm/build.rs
@@ -4795,7 +4795,7 @@ fn build_int_binop<'a, 'ctx, 'env>(
 
             let current_block = bd.get_insert_block().unwrap(); //block that we are in right now;
             let then_block = env.context.append_basic_block(parent, "then");
-            let cont_block = env.context.append_basic_block(parent, "branchcont"); //
+            let cont_block = env.context.append_basic_block(parent, "branchcont");
 
             bd.build_conditional_branch(condition_rhs, then_block, cont_block);
 


### PR DESCRIPTION
To better facilitate the CPU's branch prediction, make the `then` branch of the `if` statement the one that will happen most often when using `isMultipleOf`. The more likely case is when the right hand operand is not zero.

Thank for the guidance @rtfeldman!