### PR TITLE
Fix bug in Num.sqrt

### DIFF
--- a/compiler/test_gen/src/gen_num.rs
+++ b/compiler/test_gen/src/gen_num.rs
@@ -376,6 +376,36 @@ mod gen_num {
     }
 
     #[test]
+    fn f64_sqrt_zero() {
+        assert_evals_to!(
+            indoc!(
+                r#"
+                    when Num.sqrt 0 is
+                        Ok val -> val
+                        Err _ -> -1
+                "#
+            ),
+            0.0,
+            f64
+        );
+    }
+
+    #[test]
+    fn f64_sqrt_negative() {
+        assert_evals_to!(
+            indoc!(
+                r#"
+                    when Num.sqrt -1 is
+                        Err _ -> 42
+                        Ok val -> val
+                "#
+            ),
+            42.0,
+            f64
+        );
+    }
+
+    #[test]
     fn f64_round_old() {
         assert_evals_to!("Num.round 3.6", 4, i64);
     }


### PR DESCRIPTION
Bumped into this while pairing with @folkertdev, current implementation of sqrt checks for zero while it should be checking for non-negative numbers.