### PR TITLE
Fix a macOS linking problem

### DIFF
--- a/compiler/build/src/link.rs
+++ b/compiler/build/src/link.rs
@@ -463,8 +463,9 @@ fn link_macos(
                 // "-lrt", // TODO shouldn't we need this?
                 // "-lc_nonshared", // TODO shouldn't we need this?
                 // "-lgcc", // TODO will eventually need compiler_rt from gcc or something - see https://github.com/rtfeldman/roc/pull/554#discussion_r496370840
+                "-lc++",
+                // "-lc++abi",
                 // "-lunwind", // TODO will eventually need this, see https://github.com/rtfeldman/roc/pull/554#discussion_r496370840
-                "-lc++", // TODO shouldn't we need this?
                 // Output
                 "-o",
                 output_path.to_str().unwrap(), // app


### PR DESCRIPTION
Without this,`cargo run run examples/cli/Echo.roc` would fail to link.

Now, it's much better: it crashes on a `malloc` error at runtime!

```
What's your first name?
echo(35266,0x109806dc0) malloc: *** error for object 0x7ff311c05a20: pointer being freed was not allocated
echo(35266,0x109806dc0) malloc: *** set a breakpoint in malloc_error_break to debug
```