### PR TITLE
Apple M1 Build Support

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -8,7 +8,7 @@ in with {
   # Look here for information about how pin version of nixpkgs
   #  → https://nixos.wiki/wiki/FAQ/Pinning_Nixpkgs
   pkgs = import (builtins.fetchGit {
-    name = "nixpkgs-2021-04-23";
+    name = "nixpkgs-unstable-2021-04-23";
     url = "https://github.com/nixos/nixpkgs/";
     ref = "refs/heads/nixpkgs-unstable";
     rev = "8d0340aee5caac3807c58ad7fa4ebdbbdd9134d6";
@@ -113,4 +113,3 @@ in mkShell (nixos-env // {
     export PATH="$PATH:$PWD/nix/bin"
   '';
 })
-


### PR DESCRIPTION
I've been trying to build Roc from source using nix on a new macOS M1 chipset macbook pro.

NB: I'm a nix newbie so perhaps some of my steps are misguided – feedback welcome!

Notes in order of commits:

### 1. Bumping nixpkgs pinning

The `.envrc` initiated `use_nix -s shell.nix` kicked in by default when moving into roc root, so I let that pan out.

After almost 2 days of continuous compilation (!!!) it [failed on python](https://gist.github.com/supermario/8ef88a6a2db10fd599849643763d38b1).

This whole endeavour appears to be irrelevant however: we're pinned to `nixpkgs-unstable` from January.

I tried updating to the latest unstable branch SHA, and nix setup succeeded within a few minutes (sigh) – assuming this is because nix actually has package caches for M1 macs now, and didn't for the pinned versions back in Jan.

### 2. Adding libiconv

Now we're here:

```
$ nix-shell
[nix-shell:~/dev/projects/roc]$ RUST_BACKTRACE=1 cargo run repl
   Compiling roc_builtins v0.1.0 (/Users/mario/dev/projects/roc/compiler/builtins)
<snip>
error: failed to run custom build command for `roc_builtins v0.1.0 (/Users/mario/dev/projects/roc/compiler/builtins)`

Caused by:
  process didn't exit successfully: `/Users/mario/dev/projects/roc/target/debug/build/roc_builtins-3837a3e18cec61df/build-script-build` (exit code: 101)
  --- stdout
  Compiling zig object to: /Users/mario/dev/projects/roc/compiler/builtins/bitcode/builtins.o

  --- stderr
  thread 'main' panicked at 'zig failed: ', compiler/builtins/build.rs:75:17
  stack backtrace:
  note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
warning: build failed, waiting for other jobs to finish...
error: linking with `cc` failed: exit code: 1
  |
<snip>
  = note: ld: library not found for -liconv
          clang-7: error: linker command failed with exit code 1 (use -v to see invocation)
```

Sounds like the iconv lib isn't found – seems like in nix that's `libiconv` which I added to `# lib deps` in `shell.nix`.

### 3. Zig failure

Now we're here:

```
[nix-shell:~/dev/projects/roc]$ RUST_BACKTRACE=full cargo run repl
   Compiling roc_builtins v0.1.0 (/Users/mario/dev/projects/roc/compiler/builtins)
   Compiling rustyline v7.1.0
   Compiling const_format v0.2.14
   Compiling crossbeam-deque v0.8.0
   Compiling crossbeam-deque v0.7.3
   Compiling glyph_brush_layout v0.2.1
   Compiling cgmath v0.18.0
   Compiling im v14.3.0
error: failed to run custom build command for `roc_builtins v0.1.0 (/Users/mario/dev/projects/roc/compiler/builtins)`

Caused by:
  process didn't exit successfully: `/Users/mario/dev/projects/roc/target/debug/build/roc_builtins-3837a3e18cec61df/build-script-build` (exit code: 101)
  --- stdout
  Compiling zig object to: /Users/mario/dev/projects/roc/compiler/builtins/bitcode/builtins.o

  --- stderr
  thread 'main' panicked at 'zig failed: ', compiler/builtins/build.rs:75:17
  stack backtrace:
     0:        0x100a5500e - <unknown>
     1:        0x100a71fbe - <unknown>
     2:        0x100a5496a - <unknown>
     3:        0x100a3f209 - <unknown>
     4:        0x100a3ed7b - <unknown>
     5:        0x100a3f79a - <unknown>
     6:        0x100a55785 - <unknown>
     7:        0x100a55188 - <unknown>
     8:        0x100a3f313 - <unknown>
     9:        0x100a7633b - <unknown>
    10:        0x100a31e6b - <unknown>
    11:        0x100a35767 - <unknown>
    12:        0x100a2f59e - <unknown>
    13:        0x100a32991 - <unknown>
    14:        0x100a2bbe4 - <unknown>
    15:        0x100a45ee0 - <unknown>
    16:        0x100a2bbc1 - <unknown>
    17:        0x100a36752 - <unknown>
warning: build failed, waiting for other jobs to finish...
error: build failed
```

I'm unsure how to debug this in more detail, `RUST_BACKTRACE=full` was already the suggestion on a less-verbose run.

