### PR TITLE
Bump rustc in shell.nix

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -8,10 +8,10 @@ in with {
   # Look here for information about how pin version of nixpkgs
   #  → https://nixos.wiki/wiki/FAQ/Pinning_Nixpkgs
   pkgs = import (builtins.fetchGit {
-    name = "nixpkgs-2021-01-07";
+    name = "nixpkgs-2021-04-23";
     url = "https://github.com/nixos/nixpkgs/";
     ref = "refs/heads/nixpkgs-unstable";
-    rev = "4a580eb51bce94cae356e841f3f5303d31afbaf1";
+    rev = "8d0340aee5caac3807c58ad7fa4ebdbbdd9134d6";
   }) { };
 
   isMacOS = currentOS == "darwin";
@@ -83,6 +83,7 @@ let
     libxml2
     ncurses
     zlib
+    libiconv
     # faster builds - see https://github.com/rtfeldman/roc/blob/trunk/BUILDING_FROM_SOURCE.md#use-lld-for-the-linker
     llvmPkgs.lld
     # dev tools


### PR DESCRIPTION
- Bumps nixpkgs-unstable to get an up to date rustc (from 1.49 to 1.51)
- Adds libiconv

So, this is basically the same as #1204 by @supermario without the expectation of M1 support. Yet this changes seems needed to be able to build roc using nix as a self contained development environment. 

Without these changes building roc with the current rustc in shell.nix (1.49) leads to

```
error[E0658]: use of unstable library feature 'split_inclusive'
  --> editor/src/editor/code_lines.rs:20:18
   |
20 |                 .split_inclusive('\n')
   |                  ^^^^^^^^^^^^^^^
   |
   = note: see issue #72360 <https://github.com/rust-lang/rust/issues/72360> for more information

error: aborting due to previous error

For more information about this error, try `rustc --explain E0658`.
error: could not compile `roc_editor`
```