### PR TITLE
Constrain Expr2: SmallStr(_) & Blank

### DIFF
--- a/editor/src/lang/constrain.rs
+++ b/editor/src/lang/constrain.rs
@@ -49,6 +49,8 @@ pub fn constrain_expr<'a>(
 
     match expr {
         Expr2::Str(_) => Eq(str_type(env.pool), expected, Category::Str, region),
+        Expr2::SmallStr(_) => Eq(str_type(env.pool), expected, Category::Str, region),
+        Expr2::Blank => True,
         Expr2::EmptyRecord => constrain_empty_record(expected, region),
         Expr2::SmallInt { var, .. } => {
             let mut flex_vars = BumpVec::with_capacity_in(1, arena);


### PR DESCRIPTION
* adds match case for `Expr2::SmallStr(_)`
* adds match case for `Expr2::Blank`

### Questions

1. Is `Blank` correct?
2. How do I write a test case for each of these?