### PR TITLE
CI try fixing issue #1265 failed to mount 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ env:
 jobs:
   prep-dependency-container:
     name: fmt, clippy, test --release
-    runs-on: [self-hosted, i7-6700K]
+    runs-on: [self-hosted]
     timeout-minutes: 60
     env:
       FORCE_COLOR: 1


### PR DESCRIPTION
The git repo dir used to be kept between CI runs for caching, this is no longer necessary.
I'm not certain but this could fix #1265.