### PR TITLE
Remove typo from Elm guide

### DIFF
--- a/roc-for-elm-programmers.md
+++ b/roc-for-elm-programmers.md
@@ -209,7 +209,7 @@ In Elm:
 In Roc:
 
 ```
-{ x : name : Str, email : Str }* -> Str
+{ name : Str, email : Str }* -> Str
 ```
 
 Here, the open record's type variable appears immediately after the `}`.


### PR DESCRIPTION
This part confused me when reading through the guide, but now it makes senes.

Not sure if the flow of the text makes sense now though, as this same example is repeated twice in a row:

```elm
{ name : Str, email : Str }* -> Str
```