### PR TITLE
Clean up some PoolVec inits

### DIFF
--- a/editor/src/lang/constrain.rs
+++ b/editor/src/lang/constrain.rs
@@ -249,7 +249,7 @@ pub fn constrain_expr<'a>(
 
             let union_con = Eq(
                 Type2::TagUnion(
-                    PoolVec::new(vec![(*name, types)].into_iter(), env.pool),
+                    PoolVec::new(std::iter::once((*name, types)), env.pool),
                     env.pool.add(Type2::Variable(*ext_var)),
                 ),
                 expected.shallow_clone(),


### PR DESCRIPTION
* makes use of PoolVec::new in 2 places
* I forget to use `into_iter` last time and was confused about why `iter` was giving me problems
* This looks better than using the zip function and a raw for loop.