### PR TITLE
use macros in preparation for lambda set inference

### DIFF
--- a/compiler/builtins/src/std.rs
+++ b/compiler/builtins/src/std.rs
@@ -1168,15 +1168,6 @@ fn flex(tvar: VarId) -> SolvedType {
 }
 
 #[inline(always)]
-fn top_level_function(arguments: Vec<SolvedType>, ret: Box<SolvedType>) -> SolvedType {
-    SolvedType::Func(
-        arguments,
-        Box::new(SolvedType::Flex(TOP_LEVEL_CLOSURE_VAR)),
-        ret,
-    )
-}
-
-#[inline(always)]
 fn closure(arguments: Vec<SolvedType>, closure_var: VarId, ret: Box<SolvedType>) -> SolvedType {
     SolvedType::Func(arguments, Box::new(SolvedType::Flex(closure_var)), ret)
 }


### PR DESCRIPTION
no functional changes yet, but this is required for my polyvariant defunctionalization work. Every function is in its own lambda set.