### PR TITLE
Mono tests improved

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3911,29 +3911,46 @@ dependencies = [
 ]
 
 [[package]]
-name = "test_mono_macros"
+name = "test_mono"
 version = "0.1.0"
 dependencies = [
- "darling",
+ "bumpalo",
+ "either",
+ "im 14.3.0",
+ "im-rc 14.3.0",
  "indoc 0.3.6",
- "maplit",
+ "inlinable_string",
+ "libc",
+ "libloading 0.6.7",
  "pretty_assertions 0.5.1",
- "proc-macro2 1.0.27",
  "quickcheck 0.8.5",
  "quickcheck_macros 0.8.0",
- "quote 1.0.9",
+ "roc_build",
  "roc_builtins",
  "roc_can",
  "roc_collections",
+ "roc_constrain",
  "roc_load",
  "roc_module",
  "roc_mono",
  "roc_parse",
  "roc_problem",
  "roc_region",
+ "roc_reporting",
  "roc_solve",
  "roc_types",
  "roc_unify",
+ "target-lexicon",
+ "test_mono_macros",
+]
+
+[[package]]
+name = "test_mono_macros"
+version = "0.1.0"
+dependencies = [
+ "darling",
+ "proc-macro2 1.0.27",
+ "quote 1.0.9",
  "syn 1.0.72",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
     "compiler/fmt",
     "compiler/mono",
     "compiler/test_mono_macros",
+    "compiler/test_mono",
     "compiler/load",
     "compiler/gen",
     "compiler/gen_dev",

--- a/compiler/test_mono/Cargo.toml
+++ b/compiler/test_mono/Cargo.toml
@@ -1,0 +1,40 @@
+[package]
+name = "test_mono"
+version = "0.1.0"
+authors = ["The Roc Contributors"]
+license = "UPL-1.0"
+edition = "2018"
+
+[dependencies]
+roc_collections = { path = "../collections" }
+roc_region = { path = "../region" }
+roc_module = { path = "../module" }
+roc_problem = { path = "../problem" }
+roc_types = { path = "../types" }
+roc_builtins = { path = "../builtins" }
+roc_constrain = { path = "../constrain" }
+roc_unify = { path = "../unify" }
+roc_solve = { path = "../solve" }
+roc_reporting = { path = "../reporting" }
+roc_load = { path = "../load" }
+roc_can = { path = "../can" }
+roc_parse = { path = "../parse" }
+roc_build = { path = "../build" }
+roc_mono = { path = "../mono" }
+test_mono_macros = { path = "../test_mono_macros" }
+im    = "14" # im and im-rc should always have the same version!
+im-rc = "14" # im and im-rc should always have the same version!
+bumpalo = { version = "3.6.1", features = ["collections"] }
+inlinable_string = "0.1"
+either = "1.6.1"
+indoc = "0.3.3"
+libc = "0.2"
+target-lexicon = "0.10"
+libloading = "0.6"
+
+[dev-dependencies]
+pretty_assertions = "0.5.1"
+indoc = "0.3.3"
+quickcheck = "0.8"
+quickcheck_macros = "0.8"
+bumpalo = { version = "3.6.1", features = ["collections"] }

--- a/compiler/test_mono/generated/ir_int_add.txt
+++ b/compiler/test_mono/generated/ir_int_add.txt
@@ -1,0 +1,25 @@
+procedure List.7 (#Attr.2):
+    let Test.6 = lowlevel ListLen #Attr.2;
+    ret Test.6;
+
+procedure Num.24 (#Attr.2, #Attr.3):
+    let Test.5 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Test.5;
+
+procedure Test.0 ():
+    let Test.11 = 1i64;
+    let Test.12 = 2i64;
+    let Test.1 = Array [Test.11, Test.12];
+    let Test.9 = 5i64;
+    let Test.10 = 4i64;
+    invoke Test.7 = CallByName Num.24 Test.9 Test.10 catch
+        dec Test.1;
+        unreachable;
+    let Test.8 = 3i64;
+    invoke Test.3 = CallByName Num.24 Test.7 Test.8 catch
+        dec Test.1;
+        unreachable;
+    let Test.4 = CallByName List.7 Test.1;
+    dec Test.1;
+    let Test.2 = CallByName Num.24 Test.3 Test.4;
+    ret Test.2;

--- a/compiler/test_mono/generated/ir_int_literal.txt
+++ b/compiler/test_mono/generated/ir_int_literal.txt
@@ -1,0 +1,3 @@
+procedure Test.0 ():
+    let Test.1 = 5i64;
+    ret Test.1;

--- a/compiler/test_mono/src/lib.rs
+++ b/compiler/test_mono/src/lib.rs
@@ -1,0 +1,184 @@
+#![cfg(test)]
+#![warn(clippy::dbg_macro)]
+// See github.com/rtfeldman/roc/issues/800 for discussion of the large_enum_variant check.
+#![allow(clippy::large_enum_variant)]
+// we actually want to compare against the literal float bits
+#![allow(clippy::clippy::float_cmp)]
+
+#[macro_use]
+extern crate pretty_assertions;
+
+use test_mono_macros::*;
+
+use roc_can::builtins::builtin_defs_map;
+use roc_collections::all::MutMap;
+use roc_module::symbol::Symbol;
+use roc_mono::ir::Proc;
+
+use roc_mono::ir::TopLevelFunctionLayout;
+
+fn promote_expr_to_module(src: &str) -> String {
+    let mut buffer = String::from("app \"test\" provides [ main ] to \"./platform\"\n\nmain =\n");
+
+    for line in src.lines() {
+        // indent the body!
+        buffer.push_str("    ");
+        buffer.push_str(line);
+        buffer.push('\n');
+    }
+
+    buffer
+}
+
+fn compiles_to_ir(test_name: &str, src: &str) {
+    use bumpalo::Bump;
+    use std::path::{Path, PathBuf};
+
+    let arena = &Bump::new();
+
+    // let stdlib = roc_builtins::unique::uniq_stdlib();
+    let stdlib = roc_builtins::std::standard_stdlib();
+    let filename = PathBuf::from("Test.roc");
+    let src_dir = Path::new("fake/test/path");
+
+    let module_src;
+    let temp;
+    if src.starts_with("app") {
+        // this is already a module
+        module_src = src;
+    } else {
+        // this is an expression, promote it to a module
+        temp = promote_expr_to_module(src);
+        module_src = &temp;
+    }
+
+    let exposed_types = MutMap::default();
+
+    let loaded = roc_load::file::load_and_monomorphize_from_str(
+        arena,
+        filename,
+        &module_src,
+        &stdlib,
+        src_dir,
+        exposed_types,
+        8,
+        builtin_defs_map,
+    );
+
+    let mut loaded = match loaded {
+        Ok(x) => x,
+        Err(roc_load::file::LoadingProblem::FormattedReport(report)) => {
+            println!("{}", report);
+            panic!();
+        }
+        Err(e) => panic!("{:?}", e),
+    };
+
+    use roc_load::file::MonomorphizedModule;
+    let MonomorphizedModule {
+        module_id: home,
+        procedures,
+        exposed_to_host,
+        ..
+    } = loaded;
+
+    let can_problems = loaded.can_problems.remove(&home).unwrap_or_default();
+    let type_problems = loaded.type_problems.remove(&home).unwrap_or_default();
+    let mono_problems = loaded.mono_problems.remove(&home).unwrap_or_default();
+
+    if !can_problems.is_empty() {
+        println!("Ignoring {} canonicalization problems", can_problems.len());
+    }
+
+    assert_eq!(type_problems, Vec::new());
+    assert_eq!(mono_problems, Vec::new());
+
+    debug_assert_eq!(exposed_to_host.len(), 1);
+
+    let main_fn_symbol = exposed_to_host.keys().copied().next().unwrap();
+
+    verify_procedures(test_name, procedures, main_fn_symbol);
+}
+
+#[cfg(debug_assertions)]
+fn verify_procedures(
+    test_name: &str,
+    procedures: MutMap<(Symbol, TopLevelFunctionLayout<'_>), Proc<'_>>,
+    main_fn_symbol: Symbol,
+) {
+    let index = procedures
+        .keys()
+        .position(|(s, _)| *s == main_fn_symbol)
+        .unwrap();
+
+    let mut procs_string = procedures
+        .values()
+        .map(|proc| proc.to_pretty(200))
+        .collect::<Vec<_>>();
+
+    let main_fn = procs_string.swap_remove(index);
+
+    procs_string.sort();
+    procs_string.push(main_fn);
+
+    let result = procs_string.join("\n");
+
+    let path = format!("generated/{}.txt", test_name);
+    std::fs::create_dir_all("generated").unwrap();
+    std::fs::write(&path, result).unwrap();
+
+    use std::process::Command;
+    let is_tracked = Command::new("git")
+        .args(&["ls-files", "--error-unmatch", &path])
+        .output()
+        .unwrap();
+
+    if !is_tracked.status.success() {
+        panic!(
+            "The file {:?} is not tracked by git. Try using `git add` on it",
+            &path
+        );
+    }
+
+    let has_changes = Command::new("git")
+        .args(&["diff", "--color=always", &path])
+        .output()
+        .unwrap();
+
+    if !has_changes.status.success() {
+        eprintln!("`git diff {:?}` failed", &path);
+        unreachable!();
+    }
+
+    if !has_changes.stdout.is_empty() {
+        println!("{}", std::str::from_utf8(&has_changes.stdout).unwrap());
+        panic!("Output changed: resolve conflicts and `git add` the file.");
+    }
+}
+
+// NOTE because the Show instance of module names is different in --release mode,
+// these tests would all fail. In the future, when we do interesting optimizations,
+// we'll likely want some tests for --release too.
+#[cfg(not(debug_assertions))]
+fn verify_procedures(
+    _expected: &str,
+    _procedures: MutMap<(Symbol, TopLevelFunctionLayout<'_>), Proc<'_>>,
+    _main_fn_symbol: Symbol,
+) {
+    // Do nothing
+}
+
+#[mono_test]
+fn ir_int_literal() {
+    r#"
+    5
+    "#
+}
+
+#[mono_test]
+fn ir_int_add() {
+    r#"
+    x = [ 1,2 ]
+    5 + 4 + 3 + List.len x
+    "#
+}

--- a/compiler/test_mono_macros/Cargo.toml
+++ b/compiler/test_mono_macros/Cargo.toml
@@ -9,28 +9,7 @@ edition = "2018"
 proc-macro = true
 
 [dependencies]
-roc_collections = { path = "../collections" }
-roc_region = { path = "../region" }
-roc_module = { path = "../module" }
-roc_types = { path = "../types" }
-roc_can = { path = "../can" }
-roc_unify = { path = "../unify" }
-roc_solve = { path = "../solve" }
-roc_problem = { path = "../problem" }
-roc_mono = { path = "../mono" }
-
 syn = { version = "1.0.39", features = ["full", "extra-traits"] }
 quote = "1.0.7"
 darling = "0.10.2"
 proc-macro2 = "1.0.24"
-
-[dev-dependencies]
-roc_load= { path = "../load" }
-roc_builtins = { path = "../builtins" }
-roc_parse = { path = "../parse" }
-roc_solve = { path = "../solve" }
-pretty_assertions = "0.5.1"
-maplit = "1.0.1"
-indoc = "0.3.3"
-quickcheck = "0.8"
-quickcheck_macros = "0.8"

--- a/compiler/test_mono_macros/src/lib.rs
+++ b/compiler/test_mono_macros/src/lib.rs
@@ -1,45 +1,25 @@
-#![warn(clippy::dbg_macro)]
-// See github.com/rtfeldman/roc/issues/800 for discussion of the large_enum_variant check.
-#![allow(clippy::large_enum_variant)]
-// we actually want to compare against the literal float bits
-#![allow(clippy::clippy::float_cmp)]
-
 extern crate proc_macro;
 
-use proc_macro::{Span, TokenStream};
-use quote::{format_ident, quote};
-use syn::spanned::Spanned;
-
-// pub mod gen_compare;
-// pub mod gen_dict;
-// pub mod gen_hash;
-// pub mod gen_list;
-// pub mod gen_num;
-// pub mod gen_primitives;
-// pub mod gen_records;
-// pub mod gen_result;
-// pub mod gen_set;
-// pub mod gen_str;
-// pub mod gen_tags;
-// mod helpers;
+use proc_macro::TokenStream;
+use quote::quote;
 
 #[proc_macro_attribute]
-pub fn mono_test(args: TokenStream, item: TokenStream) -> TokenStream {
-    let macro_args = syn::parse_macro_input!(args as syn::AttributeArgs);
+pub fn mono_test(_args: TokenStream, item: TokenStream) -> TokenStream {
     let task_fn = syn::parse_macro_input!(item as syn::ItemFn);
 
-    let mut arg_names: syn::punctuated::Punctuated<syn::Ident, syn::Token![,]> =
-        syn::punctuated::Punctuated::new();
-    let mut args = task_fn.sig.inputs.clone();
+    let args = task_fn.sig.inputs.clone();
 
     let name = task_fn.sig.ident.clone();
+    let name_str = name.to_string();
     let body = task_fn.block.clone();
 
     let visibility = &task_fn.vis;
 
     let result = quote! {
-        #visibility fn #name(#args) {
-            println!( #body);
+        #[test]
+        #visibility fn #name(#args) -> () {
+            compiles_to_ir(#name_str, #body);
+
         }
     };
     result.into()


### PR DESCRIPTION
use a procedural macro to write test results to a file, and on subsequent runs diff the new result against the file. Has the benefit that it is much easier to update the desired test output when our codegen changes the output (e.g. variable names get generated  differently). 