### PR TITLE
Add RocDec.toString

### DIFF
--- a/compiler/builtins/bitcode/src/dec.zig
+++ b/compiler/builtins/bitcode/src/dec.zig
@@ -183,7 +183,7 @@ pub const RocDec = struct {
         var str_bytes: [max_digits + 2]u8 = undefined;
 
         // Join the whole number slice & the decimal slice together
-        // The format template arg in bufPrint is `comptime`, so we have to repeate the whole statment in each branch
+        // The format template arg in bufPrint is `comptime`, so we have to repeate the whole statement in each branch
         if (is_negative) {
             _ = std.fmt.bufPrint(str_bytes[0 .. str_len + 1], "-{s}.{s}", .{ before_digits_slice, after_digits_slice }) catch {
                 std.debug.panic("TODO runtime exception failing to print slices", .{});


### PR DESCRIPTION
This needs https://github.com/rtfeldman/roc/pull/1381 before it can be merged. It wasn't really necessary for the feature, but it was kind of annoying to have to keep switching Zig versions, etc.

I changed the base to `update_zig` so the diff is easier to see, but once `update_zig` is merged I can switch back to `trunk`. Either way, it should be reviewable!