### PR TITLE
Suppress warnings when generating www.roc-lang.org

### DIFF
--- a/www/build.sh
+++ b/www/build.sh
@@ -13,8 +13,13 @@ cp -r public/ build/
 
 pushd ..
 echo 'Generating docs...'
-# We run the CLI with --no-default-features because that way we don't have a LLVM
-# dependency. (Netlify's build servers have Rust installed, but not LLVM.)
-cargo run -p roc_cli --no-default-features docs compiler/builtins/docs/Bool.roc
+# We run the CLI with --no-default-features because that way we don't have the
+# "llvm" feature and therefore don't depend on LLVM being installed on the
+# system. (Netlify's build servers have Rust installed, but not LLVM.)
+#
+# We set RUSTFLAGS to -Awarnings to ignore warnings during this build,
+# because when building without "the" llvm feature (which is only ever done
+# for this exact use case), the result is lots of "unused" warnings!
+RUSTFLAGS=-Awarnings cargo run -p roc_cli --no-default-features docs compiler/builtins/docs/Bool.roc
 mv generated-docs/ www/build/builtins
 popd


### PR DESCRIPTION
Currently it displays of unhelpful "unused" warnings due to building without LLVM. We can safely ignore them in this use case!