### PR TITLE
Docs : Inlined style, javascript, and fav icon

### DIFF
--- a/docs/src/lib.rs
+++ b/docs/src/lib.rs
@@ -30,7 +30,6 @@ pub fn generate(filenames: Vec<PathBuf>, std_lib: StdLib, build_dir: &Path) {
         fs::create_dir_all(build_dir).expect("TODO gracefully handle unable to create build dir");
     }
 
-    // Copy over the assets
     let template_html = include_str!("./static/index.html").replace(
         "<!-- Module links -->",
         render_sidebar(

--- a/docs/src/static/index.html
+++ b/docs/src/static/index.html
@@ -6,7 +6,6 @@
     <!-- <title>TODO populate this based on the module's name, e.g. "Parser - roc/parser"</title> -->
     <!-- <meta name="description" content="TODO populate this based on the module's description"> -->
     <meta name="viewport" content="width=device-width">
-<!--    <link rel="icon" href="data:image/svg+xml,%3Csvg+viewBox%3D%220+0+52+53%22+xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%0D%0A++%3Cstyle%3Epolygon+%7Bfill%3A+%235c0bff%3B%7D%40media+%28prefers-color-scheme%3A+dark%29+%7Bpolygon+%7Bfill%3A+%237733ff%3B%7D%7D+%3C%2Fstyle%3E%0D%0A++%3Cpolygon+points%3D%220%2C0+23.8834%2C3.21052+37.2438%2C19.0101+45.9665%2C16.6324+50.5%2C22+45%2C22+44.0315%2C26.3689+26.4673%2C39.3424+27.4527%2C45.2132+17.655%2C53+23.6751%2C22.7086%22%2F%3E%0D%0A%3C%2Fsvg%3E%0D%0A">-->
     <style>
         <!-- Styles -->
     </style>


### PR DESCRIPTION
@rtfeldman you changed the docs to get generated as `X/index.html` where as before it was `X.html`.

I think that broke the relative paths to the assets from the `index.html`.

To fix that (and avoid any relative path issues in the future) I inlined the styles, javascript, and the fav icon.

Is that alright?