### PR TITLE
Fix urls and paths for docs

### DIFF
--- a/docs/src/lib.rs
+++ b/docs/src/lib.rs
@@ -63,9 +63,9 @@ pub fn generate(filenames: Vec<PathBuf>, std_lib: StdLib, build_dir: &Path) {
     // Write each package's module docs html file
     for (docs_by_id, interns) in package.modules.iter_mut() {
         for module in docs_by_id.values_mut() {
-            let module_dir = build_dir.join(module.name.as_str());
+            let module_dir = build_dir.join(module.name.replace(".", "/").as_str());
 
-            fs::create_dir(&module_dir)
+            fs::create_dir_all(&module_dir)
                 .expect("TODO gracefully handle not being able to create the module dir");
 
             let rendered_module = template_html

--- a/docs/src/static/index.html
+++ b/docs/src/static/index.html
@@ -6,9 +6,9 @@
     <!-- <title>TODO populate this based on the module's name, e.g. "Parser - roc/parser"</title> -->
     <!-- <meta name="description" content="TODO populate this based on the module's description"> -->
     <meta name="viewport" content="width=device-width">
-    <link rel="icon" href="favicon.svg">
-    <script type="text/javascript" src="search.js" defer></script>
-    <link rel="stylesheet" href="styles.css">
+    <link rel="icon" href="/favicon.svg">
+    <script type="text/javascript" src="/search.js" defer></script>
+    <link rel="stylesheet" href="/styles.css">
 </head>
 
 <body>


### PR DESCRIPTION
- I switched the assets from `style.css` to `/style.css`
- Modules like `Json.Decode` with a dot in them will show up at `/Json/Decode/index.html`