### PR TITLE
make zig fmt fail louder

### DIFF
--- a/compiler/builtins/bitcode/run-tests.sh
+++ b/compiler/builtins/bitcode/run-tests.sh
@@ -6,4 +6,4 @@ set -euxo pipefail
 zig build test
 
 # fmt every zig
-find src/*.zig -type f -print0 | xargs -n 1 -0 zig fmt --check
+find src/*.zig -type f -print0 | xargs -n 1 -0 zig fmt --check || (echo "zig fmt --check FAILED! Check the previuous lines to see which files were improperly formatted." && exit 1)


### PR DESCRIPTION
If a zig file used to be improperly formatted the output was:
```
src/dict.zig
```
Now it is:
```
src/dict.zig
zig fmt --check FAILED! Check the previuous lines to see which files were improperly formatted.
```