### PR TITLE
Feature name correction

### DIFF
--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -100,7 +100,7 @@ pub fn build_app<'a>() -> App<'a> {
                 )
         );
 
-    if cfg!(feature = "edit") {
+    if cfg!(feature = "editor") {
         app.subcommand(
             App::new(CMD_EDIT).about("Launch the Roc editor").arg(
                 Arg::with_name(DIRECTORY_OR_FILES)


### PR DESCRIPTION
In `cli/src/lib.rs` `if cfg!(feature = "edit") {` should be `if cfg!(feature = "editor") {` to be able to run the editor.