### PR TITLE
Add hello-fast example

### DIFF
--- a/examples/hello-fast/.gitignore
+++ b/examples/hello-fast/.gitignore
@@ -1,0 +1,1 @@
+hello-world

--- a/examples/hello-fast/Hello.roc
+++ b/examples/hello-fast/Hello.roc
@@ -1,0 +1,6 @@
+app "hello-world"
+    packages { base: "platform" }
+    imports []
+    provides [ main ] to base
+
+main = "Hello, World!\n"

--- a/examples/hello-fast/README.md
+++ b/examples/hello-fast/README.md
@@ -1,0 +1,48 @@
+# Hello, World!
+
+To run, `cd` into this directory and run:
+
+```bash
+$ cargo run run Hello.roc
+```
+
+To run in release mode instead, do:
+
+```bash
+$ cargo run --release run Hello.roc
+```
+
+## Troubleshooting
+
+If you encounter `cannot find -lc++`, run the following for ubuntu `sudo apt install libc++-dev`.
+
+## Design Notes
+
+This demonstrates the basic design of hosts: Roc code gets compiled into a pure 
+function (in this case, a thunk that always returns `"Hello, World!"`) and
+then the host calls that function. Fundamentally, that's the whole idea! The host
+might not even have a `main` - it could be a library, a plugin, anything.
+Everything else is built on this basic "hosts calling linked pure functions" design.
+
+For example, things get more interesting when the compiled Roc function returns
+a `Task` - that is, a tagged union data structure containing function pointers 
+to callback closures. This lets the Roc pure function describe arbitrary 
+chainable effects, which the host can interpret to perform I/O as requested by 
+the Roc program.  (The tagged union `Task` would have a variant for each supported 
+I/O operation.)
+
+In this trivial example, it's very easy to line up the API between the host and
+the Roc program. In a more involved host, this would be much trickier - especially
+if the API were changing frequently during development.
+
+The idea there is to have a first-class concept of "glue code" which host authors
+can write (it would be plain Roc code, but with some extra keywords that aren't
+available in normal modules - kinda like `port module` in Elm), and which
+describe both the Roc-host/C boundary as well as the Roc-host/Roc-app boundary.
+Roc application authors only care about the Roc-host/Roc-app portion, and the
+host author only cares about the Roc-host/C bounary when implementing the host.
+
+Using this glue code, the Roc compiler can generate C header files describing the
+boundary. This not only gets us host compatibility with C compilers, but also 
+Rust FFI for free, because [`rust-bindgen`](https://github.com/rust-lang/rust-bindgen) 
+generates correct Rust FFI bindings from C headers.

--- a/examples/hello-fast/platform/Package-Config.roc
+++ b/examples/hello-fast/platform/Package-Config.roc
@@ -1,0 +1,10 @@
+platform examples/hello-world
+    requires {}{ main : Str }
+    exposes []
+    packages {}
+    imports []
+    provides [ mainForHost ]
+    effects fx.Effect {}
+
+mainForHost : Str
+mainForHost = main

--- a/examples/hello-fast/platform/host.c
+++ b/examples/hello-fast/platform/host.c
@@ -1,0 +1,44 @@
+#include <stdlib.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <errno.h>
+#include <string.h>
+
+void* roc_alloc(size_t size, unsigned int alignment) {
+    return malloc(size);
+}
+
+void* roc_realloc(void* ptr, size_t old_size, size_t new_size, unsigned int alignment) {
+    return realloc(ptr, new_size);
+}
+
+void roc_dealloc(void* ptr, unsigned int alignment) {
+    free(ptr);
+}
+
+struct RocStr {
+    char* bytes;
+    size_t len;
+};
+
+struct RocCallResult {
+    size_t flag;
+    struct RocStr content;
+};
+
+extern void roc__mainForHost_1_exposed(struct RocCallResult *re);
+
+int main() {
+    // Make space for the result
+    struct RocCallResult callresult;
+
+    // Call roc to populate the callresult
+    roc__mainForHost_1_exposed(&callresult);
+
+    struct RocStr str = callresult.content;
+
+    // Write to stdout
+    write(1, &str.bytes, 14);
+
+    return 0;
+}


### PR DESCRIPTION
This is like the Hello World example, but with a much simpler (and faster!) host because instead of doing all the work to convert `RocStr` to null-terminated C str, it writes the `RocStr`'s bytes directly to the `stdout` file descriptor, which doesn't require null-termination!