### PR TITLE
Docs complex type signatures

### DIFF
--- a/docs/src/lib.rs
+++ b/docs/src/lib.rs
@@ -515,7 +515,7 @@ fn type_annotation_to_html(indent_level: usize, buf: &mut String, type_ann: &Typ
             let mut next_indent_level = indent_level;
 
             if should_be_multiline(output) {
-                next_indent_level = next_indent_level + 1;
+                next_indent_level += 1;
             }
 
             type_annotation_to_html(next_indent_level, buf, output);


### PR DESCRIPTION
Functions, records, and tag unions should render in multiline mode if any of their sub-components are multiline, and checking for this was not implemented.

Now it is!

![Screen Shot 2021-07-11 at 14 58 13](https://user-images.githubusercontent.com/2939686/125207187-e613f880-e258-11eb-8941-2a2bd3e2b0d4.png)
![Screen Shot 2021-07-11 at 14 58 18](https://user-images.githubusercontent.com/2939686/125207188-e613f880-e258-11eb-812a-7f6f02e4a373.png)

