### PR TITLE
Change Zulip link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ Earthly may temporarily use a lot of disk space, up to 90 GB. This disk space is
 
 ## Contribution Tips
 
-- Before making your first pull request, definitely talk to an existing contributor on [Roc Zulip](https://roc.zulipchat.com/join/rz7n4d42v7tfilp3njzbm5eg/) first about what you plan to do! This can not only avoid duplicated effort, it can also avoid making a whole PR only to discover it won't be accepted because the change doesn't fit with the goals of the language's design or implementation.
+- Before making your first pull request, definitely talk to an existing contributor on [Roc Zulip](https://roc.zulipchat.com) first about what you plan to do! This can not only avoid duplicated effort, it can also avoid making a whole PR only to discover it won't be accepted because the change doesn't fit with the goals of the language's design or implementation.
 - It's a good idea to open a work-in-progress pull request as you begin working on something. This way, others can see that you're working on it, which avoids duplicate effort, and others can give feedback sooner rather than later if they notice a problem in the direction things are going. Be sure to include "WIP" in the title of the PR as long as it's not ready for review!
 - Make sure to create a branch on the roc repository for your changes. We do not allow CI to be run on forks for security.
 


### PR DESCRIPTION
I set Zulip to no longer require invitations to join, so hopefully now a normal link to it should work!

Fixes #1539 