### PR TITLE
Rename Str.toBytes to Str.toUtf8

### DIFF
--- a/compiler/builtins/bitcode/src/main.zig
+++ b/compiler/builtins/bitcode/src/main.zig
@@ -96,7 +96,7 @@ comptime {
     exportStrFn(str.strFromIntC, "from_int");
     exportStrFn(str.strFromFloatC, "from_float");
     exportStrFn(str.strEqual, "equal");
-    exportStrFn(str.strToBytesC, "to_bytes");
+    exportStrFn(str.strToUtf8C, "to_utf8");
     exportStrFn(str.fromUtf8C, "from_utf8");
 }
 

--- a/compiler/builtins/bitcode/src/str.zig
+++ b/compiler/builtins/bitcode/src/str.zig
@@ -1129,8 +1129,8 @@ test "RocStr.joinWith: result is big" {
     try expect(roc_result.eq(result));
 }
 
-// Str.toBytes
-pub fn strToBytesC(arg: RocStr) callconv(.C) RocList {
+// Str.toUtf8
+pub fn strToUtf8C(arg: RocStr) callconv(.C) RocList {
     return @call(.{ .modifier = always_inline }, strToBytes, .{arg});
 }
 

--- a/compiler/builtins/docs/Str.roc
+++ b/compiler/builtins/docs/Str.roc
@@ -15,7 +15,7 @@ interface Str
             fromUtf8,
             Utf8Problem,
             Utf8ByteProblem,
-            toBytes,
+            toUtf8,
             startsWithCodePt
         ]
     imports []

--- a/compiler/builtins/src/bitcode.rs
+++ b/compiler/builtins/src/bitcode.rs
@@ -22,7 +22,7 @@ pub const STR_NUMBER_OF_BYTES: &str = "roc_builtins.str.number_of_bytes";
 pub const STR_FROM_INT: &str = "roc_builtins.str.from_int";
 pub const STR_FROM_FLOAT: &str = "roc_builtins.str.from_float";
 pub const STR_EQUAL: &str = "roc_builtins.str.equal";
-pub const STR_TO_BYTES: &str = "roc_builtins.str.to_bytes";
+pub const STR_TO_UTF8: &str = "roc_builtins.str.to_utf8";
 pub const STR_FROM_UTF8: &str = "roc_builtins.str.from_utf8";
 
 pub const DICT_HASH: &str = "roc_builtins.dict.hash";

--- a/compiler/builtins/src/std.rs
+++ b/compiler/builtins/src/std.rs
@@ -607,9 +607,9 @@ pub fn types() -> MutMap<Symbol, (SolvedType, Region)> {
         Box::new(result_type(str_type(), bad_utf8)),
     );
 
-    // toBytes : Str -> List U8
+    // toUtf8 : Str -> List U8
     add_top_level_function_type!(
-        Symbol::STR_TO_BYTES,
+        Symbol::STR_TO_UTF8,
         vec![str_type()],
         Box::new(list_type(u8_type()))
     );

--- a/compiler/can/src/builtins.rs
+++ b/compiler/can/src/builtins.rs
@@ -63,7 +63,7 @@ pub fn builtin_defs_map(symbol: Symbol, var_store: &mut VarStore) -> Option<Def>
         STR_COUNT_GRAPHEMES => str_count_graphemes,
         STR_FROM_INT => str_from_int,
         STR_FROM_UTF8 => str_from_utf8,
-        STR_TO_BYTES => str_to_bytes,
+        STR_TO_UTF8 => str_to_utf8,
         STR_FROM_FLOAT=> str_from_float,
         LIST_LEN => list_len,
         LIST_GET => list_get,
@@ -1456,9 +1456,9 @@ fn str_from_utf8(symbol: Symbol, var_store: &mut VarStore) -> Def {
     )
 }
 
-/// Str.toBytes : Str -> List U8
-fn str_to_bytes(symbol: Symbol, var_store: &mut VarStore) -> Def {
-    lowlevel_1(symbol, LowLevel::StrToBytes, var_store)
+/// Str.toUtf8 : Str -> List U8
+fn str_to_utf8(symbol: Symbol, var_store: &mut VarStore) -> Def {
+    lowlevel_1(symbol, LowLevel::StrToUtf8, var_store)
 }
 
 /// Str.fromFloat : Float * -> Str

--- a/compiler/gen_llvm/src/llvm/build.rs
+++ b/compiler/gen_llvm/src/llvm/build.rs
@@ -15,7 +15,7 @@ use crate::llvm::build_list::{
 use crate::llvm::build_str::{
     empty_str, str_concat, str_count_graphemes, str_ends_with, str_from_float, str_from_int,
     str_from_utf8, str_join_with, str_number_of_bytes, str_split, str_starts_with,
-    str_starts_with_code_point, str_to_bytes,
+    str_starts_with_code_point, str_to_utf8,
 };
 use crate::llvm::compare::{generic_eq, generic_neq};
 use crate::llvm::convert::{
@@ -4444,7 +4444,7 @@ fn run_low_level<'a, 'ctx, 'env>(
 
             str_from_utf8(env, parent, original_wrapper)
         }
-        StrToBytes => {
+        StrToUtf8 => {
             // Str.fromInt : Str -> List U8
             debug_assert_eq!(args.len(), 1);
 
@@ -4452,7 +4452,7 @@ fn run_low_level<'a, 'ctx, 'env>(
             // we just implement it here to subvert the type system
             let string = load_symbol(scope, &args[0]);
 
-            str_to_bytes(env, string.into_struct_value())
+            str_to_utf8(env, string.into_struct_value())
         }
         StrSplit => {
             // Str.split : Str, Str -> List Str

--- a/compiler/gen_llvm/src/llvm/build_str.rs
+++ b/compiler/gen_llvm/src/llvm/build_str.rs
@@ -235,8 +235,8 @@ pub fn str_from_int<'a, 'ctx, 'env>(
     call_bitcode_fn(env, &[int], bitcode::STR_FROM_INT)
 }
 
-/// Str.toBytes : Str -> List U8
-pub fn str_to_bytes<'a, 'ctx, 'env>(
+/// Str.toUtf8 : Str -> List U8
+pub fn str_to_utf8<'a, 'ctx, 'env>(
     env: &Env<'a, 'ctx, 'env>,
     original_wrapper: StructValue<'ctx>,
 ) -> BasicValueEnum<'ctx> {
@@ -244,10 +244,10 @@ pub fn str_to_bytes<'a, 'ctx, 'env>(
         env.builder,
         original_wrapper.into(),
         env.context.i128_type().into(),
-        "to_bytes",
+        "to_utf8",
     );
 
-    call_bitcode_fn_returns_list(env, &[string], bitcode::STR_TO_BYTES)
+    call_bitcode_fn_returns_list(env, &[string], bitcode::STR_TO_UTF8)
 }
 
 /// Str.fromUtf8 : List U8 -> { a : Bool, b : Str, c : Nat, d : I8 }

--- a/compiler/module/src/low_level.rs
+++ b/compiler/module/src/low_level.rs
@@ -13,7 +13,7 @@ pub enum LowLevel {
     StrCountGraphemes,
     StrFromInt,
     StrFromUtf8,
-    StrToBytes,
+    StrToUtf8,
     StrFromFloat,
     ListLen,
     ListGetUnsafe,
@@ -110,11 +110,11 @@ impl LowLevel {
 
         match self {
             StrConcat | StrJoinWith | StrIsEmpty | StrStartsWith | StrStartsWithCodePt
-            | StrEndsWith | StrSplit | StrCountGraphemes | StrFromInt | StrFromUtf8
-            | StrToBytes | StrFromFloat | ListLen | ListGetUnsafe | ListSet | ListDrop
-            | ListSingle | ListRepeat | ListReverse | ListConcat | ListContains | ListAppend
-            | ListPrepend | ListJoin | ListRange | ListSwap | DictSize | DictEmpty | DictInsert
-            | DictRemove | DictContains | DictGetUnsafe | DictKeys | DictValues | DictUnion
+            | StrEndsWith | StrSplit | StrCountGraphemes | StrFromInt | StrFromUtf8 | StrToUtf8
+            | StrFromFloat | ListLen | ListGetUnsafe | ListSet | ListDrop | ListSingle
+            | ListRepeat | ListReverse | ListConcat | ListContains | ListAppend | ListPrepend
+            | ListJoin | ListRange | ListSwap | DictSize | DictEmpty | DictInsert | DictRemove
+            | DictContains | DictGetUnsafe | DictKeys | DictValues | DictUnion
             | DictIntersection | DictDifference | SetFromList | NumAdd | NumAddWrap
             | NumAddChecked | NumSub | NumSubWrap | NumSubChecked | NumMul | NumMulWrap
             | NumMulChecked | NumGt | NumGte | NumLt | NumLte | NumCompare | NumDivUnchecked

--- a/compiler/module/src/symbol.rs
+++ b/compiler/module/src/symbol.rs
@@ -918,7 +918,7 @@ define_builtins! {
         12 STR_FROM_UTF8: "fromUtf8"
         13 STR_UT8_PROBLEM: "Utf8Problem" // the Utf8Problem type alias
         14 STR_UT8_BYTE_PROBLEM: "Utf8ByteProblem" // the Utf8ByteProblem type alias
-        15 STR_TO_BYTES: "toBytes"
+        15 STR_TO_UTF8: "toUtf8"
         16 STR_STARTS_WITH_CODE_PT: "startsWithCodePt"
         17 STR_ALIAS_ANALYSIS_STATIC: "#aliasAnalysisStatic" // string with the static lifetime
     }

--- a/compiler/mono/src/borrow.rs
+++ b/compiler/mono/src/borrow.rs
@@ -1015,7 +1015,7 @@ pub fn lowlevel_borrow_signature(arena: &Bump, op: LowLevel) -> &[bool] {
         StrStartsWith | StrEndsWith => arena.alloc_slice_copy(&[owned, borrowed]),
         StrStartsWithCodePt => arena.alloc_slice_copy(&[borrowed, irrelevant]),
         StrFromUtf8 => arena.alloc_slice_copy(&[owned]),
-        StrToBytes => arena.alloc_slice_copy(&[owned]),
+        StrToUtf8 => arena.alloc_slice_copy(&[owned]),
         StrFromInt | StrFromFloat => arena.alloc_slice_copy(&[irrelevant]),
         Hash => arena.alloc_slice_copy(&[borrowed, irrelevant]),
         DictSize => arena.alloc_slice_copy(&[borrowed]),

--- a/compiler/test_gen/src/gen_str.rs
+++ b/compiler/test_gen/src/gen_str.rs
@@ -819,10 +819,10 @@ fn str_from_float() {
 }
 
 #[test]
-fn str_to_bytes() {
-    assert_evals_to!(r#"Str.toBytes "hello""#, &[104, 101, 108, 108, 111], &[u8]);
+fn str_to_utf8() {
+    assert_evals_to!(r#"Str.toUtf8 "hello""#, &[104, 101, 108, 108, 111], &[u8]);
     assert_evals_to!(
-        r#"Str.toBytes "this is a long string""#,
+        r#"Str.toUtf8 "this is a long string""#,
         &[
             116, 104, 105, 115, 32, 105, 115, 32, 97, 32, 108, 111, 110, 103, 32, 115, 116, 114,
             105, 110, 103

--- a/compiler/test_gen/src/gen_tags.rs
+++ b/compiler/test_gen/src/gen_tags.rs
@@ -477,7 +477,7 @@ fn if_guard_vanilla() {
             r#"
                 when "fooz" is
                     s if s == "foo" -> 0
-                    s -> List.len (Str.toBytes s)
+                    s -> List.len (Str.toUtf8 s)
                 "#
         ),
         4,

--- a/examples/benchmarks/Base64.roc
+++ b/examples/benchmarks/Base64.roc
@@ -10,7 +10,7 @@ fromBytes = \bytes ->
 # base 64 encoding from a string 
 fromStr : Str -> Result Str [ InvalidInput ]*
 fromStr = \str ->
-    fromBytes (Str.toBytes str)
+    fromBytes (Str.toUtf8 str)
 
 # base64-encode bytes to the original 
 toBytes : Str -> Result (List U8) [ InvalidInput ]*

--- a/examples/benchmarks/Base64/Encode.roc
+++ b/examples/benchmarks/Base64/Encode.roc
@@ -9,7 +9,7 @@ InvalidChar : U8
 toBytes : Str -> List U8
 toBytes = \str ->
     str
-        |> Str.toBytes
+        |> Str.toUtf8
         |> encodeChunks
         |> Bytes.Encode.sequence
         |> Bytes.Encode.encode

--- a/examples/benchmarks/TestBase64.roc
+++ b/examples/benchmarks/TestBase64.roc
@@ -7,7 +7,7 @@ IO a : Task.Task a []
 
 main : IO {}
 main =
-    when Base64.fromBytes (Str.toBytes "Hello World") is
+    when Base64.fromBytes (Str.toUtf8 "Hello World") is
         Err _ ->
             Task.putLine "sadness"
 


### PR DESCRIPTION
cc @jxxcarlson - once this is merged, `Str.toUtf8` will be available!