### PR TITLE
Adds nix expression for debugir

### DIFF
--- a/nix/debugir.nix
+++ b/nix/debugir.nix
@@ -1,0 +1,27 @@
+{ pkgs ? import <nixpkgs> {}}:
+
+pkgs.stdenv.mkDerivation {
+  name = "debugir";
+  src = pkgs.fetchFromGitHub {
+    owner = "vaivaswatha";
+    repo = "debugir";
+    rev = "ed454ba264f30d2a70264357a31d94db3dd676eb";
+    sha256 = "08hrn66zn5pa8jk45msl9ipa8d1p7r9gmpknh41fyjr6c7qpmfrk";
+  };
+  buildInputs = with pkgs; [
+    cmake
+    libxml2
+    llvmPackages_12.llvm.dev
+  ];
+  buildPhase = ''
+    mkdir build
+    cd build
+    cmake -DLLVM_DIR=${pkgs.llvmPackages_12.llvm.dev} -DCMAKE_BUILD_TYPE=Release ../
+    cmake --build ../
+    cp ../debugir .
+  '';
+  installPhase = ''
+    mkdir -p $out/bin
+    cp debugir $out/bin
+  '';
+}

--- a/shell.nix
+++ b/shell.nix
@@ -32,6 +32,7 @@ let
   llvmPkgs = pkgs.llvmPackages_12;
 
   zig = import ./nix/zig.nix { inherit pkgs; };
+  debugir = import ./nix/debugir.nix { inherit pkgs; };
 
   inputs = with pkgs; [
     # build libraries
@@ -60,6 +61,7 @@ let
 
     # faster builds - see https://github.com/rtfeldman/roc/blob/trunk/BUILDING_FROM_SOURCE.md#use-lld-for-the-linker
     llvmPkgs.lld
+    debugir
 
     # meta-tools
     # note: niv manages its own nixpkgs so it doesn't need pkgs.callPackage. Do


### PR DESCRIPTION
This patch adds a nix expression for [DebugIR](https://github.com/vaivaswatha/debugir) for developers who don't want to install it manually with CMake.