### PR TITLE
Str Function Annotations

### DIFF
--- a/compiler/load/src/docs.rs
+++ b/compiler/load/src/docs.rs
@@ -165,13 +165,14 @@ fn generate_entry_doc<'a>(
             (new_acc, Some(comments_or_new_lines))
         }
 
-        Def::Annotation(loc_pattern, _loc_ann) => match loc_pattern.value {
+        Def::Annotation(loc_pattern, loc_ann) => match loc_pattern.value {
             Pattern::Identifier(identifier) => {
                 // Check if the definition is exposed
                 if ident_ids.get_id(&identifier.into()).is_some() {
+                    let name = identifier.to_string();
                     let doc_def = DocDef {
-                        name: identifier.to_string(),
-                        type_annotation: NoTypeAnn,
+                        name,
+                        type_annotation: type_to_docs(false, loc_ann.value),
                         type_vars: Vec::new(),
                         docs: before_comments_or_new_lines.and_then(comments_or_new_lines_to_docs),
                     };

--- a/docs/src/lib.rs
+++ b/docs/src/lib.rs
@@ -624,7 +624,7 @@ fn should_be_multiline(type_ann: &TypeAnnotation) -> bool {
             is_multiline
         }
         TypeAnnotation::Function { args, output } => {
-            let mut is_multiline = should_be_multiline(output) || args.len() > 1;
+            let mut is_multiline = should_be_multiline(output) || args.len() > 2;
 
             for arg in args {
                 if is_multiline {


### PR DESCRIPTION
I dont know why things work this way, but all the functions in `Str.roc` lead to `Def::Annotation`, which for some reason always goes to `NoTypeAnn`. The functions in my test roc module go to `Def::AnnotatedBody` which does not.

**SOLUTION**
Compute the annotation from `loc_ann` instead of doing `NoTypeAnn`