### PR TITLE
Make `debuggir` and `llc` more discoverable from the Roc CLI 

### DIFF
--- a/compiler/build/src/program.rs
+++ b/compiler/build/src/program.rs
@@ -17,7 +17,7 @@ pub struct CodeGenTiming {
 }
 
 // TODO: If modules besides this one start needing to know which version of
-// llvm we're using, consider moving me somwhere else.
+// llvm we're using, consider moving me somewhere else.
 const LLVM_VERSION: &str = "12";
 
 // TODO how should imported modules factor into this? What if those use builtins too?


### PR DESCRIPTION
When using the `--debug` flag with the roc CLI, we try to invoke several helpful external programs to aid in debugging. However, on some systems (mine and @Anton-4), the CLI couldn't find them because it cleared out `$PATH` and wasn't aware that `llc` sometimes doesn't have the `-12` on some computers (e.g., mine). This patch addresses those issues.

(Incidentally, I'm working on adding `Num.bytesToU16` and `Num.bytesToU32` to the language, but my code is completely broken right now in lots of fun ways. I'm learning a lot by trying to debug it! 🐥 Once it's closer to working, I can make a PR; for now, I've put it on the `Num.bytesTo` branch.)