### PR TITLE
Tags soa phase 2

### DIFF
--- a/cli/src/repl/eval.rs
+++ b/cli/src/repl/eval.rs
@@ -486,7 +486,8 @@ fn list_to_ast<'a>(
         Content::Structure(FlatType::Apply(Symbol::LIST_LIST, vars)) => {
             debug_assert_eq!(vars.len(), 1);
 
-            let elem_var = *vars.first().unwrap();
+            let elem_var_index = vars.into_iter().next().unwrap();
+            let elem_var = env.subs[elem_var_index];
 
             env.subs.get_content_without_compacting(elem_var)
         }

--- a/compiler/mono/src/layout.rs
+++ b/compiler/mono/src/layout.rs
@@ -1121,6 +1121,8 @@ fn layout_from_flat_type<'a>(
 
     match flat_type {
         Apply(symbol, args) => {
+            let args = Vec::from_iter_in(args.into_iter().map(|index| subs[index]), arena);
+
             match symbol {
                 // Ints
                 Symbol::NUM_NAT => {
@@ -1188,8 +1190,8 @@ fn layout_from_flat_type<'a>(
                     // Num.Num should only ever have 1 argument, e.g. Num.Num Int.Integer
                     debug_assert_eq!(args.len(), 1);
 
-                    let var = args.first().unwrap();
-                    let content = subs.get_content_without_compacting(*var);
+                    let var = args[0];
+                    let content = subs.get_content_without_compacting(var);
 
                     layout_from_num_content(content)
                 }
@@ -1199,7 +1201,10 @@ fn layout_from_flat_type<'a>(
                 Symbol::DICT_DICT => dict_layout_from_key_value(env, args[0], args[1]),
                 Symbol::SET_SET => dict_layout_from_key_value(env, args[0], Variable::EMPTY_RECORD),
                 _ => {
-                    panic!("TODO layout_from_flat_type for {:?}", Apply(symbol, args));
+                    panic!(
+                        "TODO layout_from_flat_type for Apply({:?}, {:?})",
+                        symbol, args
+                    );
                 }
             }
         }

--- a/compiler/solve/src/solve.rs
+++ b/compiler/solve/src/solve.rs
@@ -644,12 +644,14 @@ fn type_to_variable(
     match typ {
         Variable(var) => *var,
         Apply(symbol, args) => {
-            let mut arg_vars = Vec::with_capacity(args.len());
+            let mut new_arg_vars = Vec::with_capacity(args.len());
 
             for arg in args {
-                arg_vars.push(type_to_variable(subs, rank, pools, cached, arg))
+                let var = type_to_variable(subs, rank, pools, cached, arg);
+                new_arg_vars.push(var);
             }
 
+            let arg_vars = VariableSubsSlice::insert_into_subs(subs, new_arg_vars);
             let flat_type = FlatType::Apply(*symbol, arg_vars);
             let content = Content::Structure(flat_type);
 
@@ -1055,9 +1057,9 @@ fn adjust_rank_content(
                 Apply(_, args) => {
                     let mut rank = Rank::toplevel();
 
-                    for var in args {
-                        rank =
-                            rank.max(adjust_rank(subs, young_mark, visit_mark, group_rank, *var));
+                    for var_index in args.into_iter() {
+                        let var = subs[var_index];
+                        rank = rank.max(adjust_rank(subs, young_mark, visit_mark, group_rank, var));
                     }
 
                     rank
@@ -1239,7 +1241,8 @@ fn instantiate_rigids_help(
         Structure(flat_type) => {
             match flat_type {
                 Apply(_, args) => {
-                    for var in args.into_iter() {
+                    for var_index in args.into_iter() {
+                        let var = subs[var_index];
                         instantiate_rigids_help(subs, max_rank, pools, var);
                     }
                 }
@@ -1378,12 +1381,17 @@ fn deep_copy_var_help(
         Structure(flat_type) => {
             let new_flat_type = match flat_type {
                 Apply(symbol, args) => {
-                    let args = args
-                        .into_iter()
-                        .map(|var| deep_copy_var_help(subs, max_rank, pools, var))
-                        .collect();
+                    let mut new_arg_vars = Vec::with_capacity(args.len());
 
-                    Apply(symbol, args)
+                    for index in args.into_iter() {
+                        let var = subs[index];
+                        let copy_var = deep_copy_var_help(subs, max_rank, pools, var);
+                        new_arg_vars.push(copy_var);
+                    }
+
+                    let arg_vars = VariableSubsSlice::insert_into_subs(subs, new_arg_vars);
+
+                    Apply(symbol, arg_vars)
                 }
 
                 Func(arg_vars, closure_var, ret_var) => {

--- a/compiler/types/src/solved_types.rs
+++ b/compiler/types/src/solved_types.rs
@@ -378,8 +378,8 @@ impl SolvedType {
             Apply(symbol, args) => {
                 let mut new_args = Vec::with_capacity(args.len());
 
-                for var in args.iter().copied() {
-                    new_args.push(Self::from_var_help(subs, recursion_vars, var));
+                for var in subs.get_subs_slice(*args.as_subs_slice()) {
+                    new_args.push(Self::from_var_help(subs, recursion_vars, *var));
                 }
 
                 SolvedType::Apply(*symbol, new_args)

--- a/compiler/types/src/subs.rs
+++ b/compiler/types/src/subs.rs
@@ -9,9 +9,9 @@ use ven_ena::unify::{InPlace, Snapshot, UnificationTable, UnifyKey};
 // if your changes cause this number to go down, great!
 // please change it to the lower number.
 // if it went up, maybe check that the change is really required
-static_assertions::assert_eq_size!([u8; 64], Descriptor);
-static_assertions::assert_eq_size!([u8; 48], Content);
-static_assertions::assert_eq_size!([u8; 40], FlatType);
+static_assertions::assert_eq_size!([u8; 56], Descriptor);
+static_assertions::assert_eq_size!([u8; 40], Content);
+static_assertions::assert_eq_size!([u8; 24], FlatType);
 static_assertions::assert_eq_size!([u8; 48], Problem);
 
 #[derive(Clone, Copy, Hash, PartialEq, Eq)]
@@ -230,15 +230,15 @@ impl<T> SubsSlice<T> {
         &mut slice[self.start as usize..][..self.length as usize]
     }
 
-    pub fn len(&self) -> usize {
+    pub const fn len(&self) -> usize {
         self.length as usize
     }
 
-    pub fn is_empty(&self) -> bool {
+    pub const fn is_empty(&self) -> bool {
         self.len() == 0
     }
 
-    pub fn new(start: u32, length: u16) -> Self {
+    pub const fn new(start: u32, length: u16) -> Self {
         Self {
             start,
             length,
@@ -879,7 +879,7 @@ impl Content {
 
 #[derive(Clone, Debug)]
 pub enum FlatType {
-    Apply(Symbol, Vec<Variable>),
+    Apply(Symbol, VariableSubsSlice),
     Func(VariableSubsSlice, Variable, Variable),
     Record(RecordFields, Variable),
     TagUnion(UnionTags, Variable),
@@ -948,19 +948,39 @@ impl IntoIterator for VariableSubsSlice {
 
 #[derive(Clone, Copy, Debug, Default)]
 pub struct UnionTags {
-    pub tag_names: SubsSlice<TagName>,
-    pub variables: SubsSlice<VariableSubsSlice>,
+    length: u16,
+    tag_names_start: u32,
+    variables_start: u32,
 }
 
 impl UnionTags {
     pub fn from_tag_name_index(index: SubsIndex<TagName>) -> Self {
+        Self::from_slices(
+            SubsSlice::new(index.start, 1),
+            SubsSlice::new(0, 1), // the first variablesubsslice is the empty slice
+        )
+    }
+
+    fn from_slices(tag_names: SubsSlice<TagName>, variables: SubsSlice<VariableSubsSlice>) -> Self {
+        debug_assert_eq!(tag_names.len(), variables.len());
+
         Self {
-            tag_names: SubsSlice::new(index.start, 1),
-            variables: SubsSlice::new(0, 1), // the first variablesubsslice is the empty slice
+            length: tag_names.len() as u16,
+            tag_names_start: tag_names.start,
+            variables_start: variables.start,
         }
     }
-    pub fn len(&self) -> usize {
-        self.tag_names.len()
+
+    const fn tag_names(&self) -> SubsSlice<TagName> {
+        SubsSlice::new(self.tag_names_start, self.length)
+    }
+
+    pub const fn variables(&self) -> SubsSlice<VariableSubsSlice> {
+        SubsSlice::new(self.variables_start, self.length)
+    }
+
+    pub const fn len(&self) -> usize {
+        self.length as usize
     }
 
     pub fn is_empty(&self) -> bool {
@@ -994,10 +1014,10 @@ impl UnionTags {
             length += 1;
         }
 
-        UnionTags {
-            variables: SubsSlice::new(variables_start, length),
-            tag_names: SubsSlice::new(tag_names_start, length),
-        }
+        Self::from_slices(
+            SubsSlice::new(tag_names_start, length),
+            SubsSlice::new(variables_start, length),
+        )
     }
 
     pub fn insert_slices_into_subs<I>(subs: &mut Subs, input: I) -> Self
@@ -1021,16 +1041,19 @@ impl UnionTags {
             length += 1;
         }
 
-        UnionTags {
-            variables: SubsSlice::new(variables_start, length),
-            tag_names: SubsSlice::new(tag_names_start, length),
+        Self {
+            length,
+            tag_names_start,
+            variables_start,
         }
     }
 
     pub fn iter_all(
         &self,
     ) -> impl Iterator<Item = (SubsIndex<TagName>, SubsIndex<VariableSubsSlice>)> {
-        self.tag_names.into_iter().zip(self.variables.into_iter())
+        self.tag_names()
+            .into_iter()
+            .zip(self.variables().into_iter())
     }
 
     #[inline(always)]
@@ -1162,7 +1185,7 @@ fn first<K: Ord, V>(x: &(K, V), y: &(K, V)) -> std::cmp::Ordering {
 pub type SortedIterator<'a> = Box<dyn Iterator<Item = (Lowercase, RecordField<Variable>)> + 'a>;
 
 impl RecordFields {
-    pub fn len(&self) -> usize {
+    pub const fn len(&self) -> usize {
         self.length as usize
     }
 
@@ -1352,7 +1375,12 @@ fn occurs(
                 new_seen.insert(root_var);
 
                 match flat_type {
-                    Apply(_, args) => short_circuit(subs, root_var, &new_seen, args.iter()),
+                    Apply(_, args) => short_circuit(
+                        subs,
+                        root_var,
+                        &new_seen,
+                        subs.get_subs_slice(*args.as_subs_slice()).iter(),
+                    ),
                     Func(arg_vars, closure_var, ret_var) => {
                         let it = once(ret_var)
                             .chain(once(closure_var))
@@ -1366,7 +1394,7 @@ fn occurs(
                         short_circuit(subs, root_var, &new_seen, it)
                     }
                     TagUnion(tags, ext_var) => {
-                        for slice_index in tags.variables {
+                        for slice_index in tags.variables() {
                             let slice = subs[slice_index];
                             for var_index in slice {
                                 let var = subs[var_index];
@@ -1382,7 +1410,7 @@ fn occurs(
                     }
                     RecursiveTagUnion(_rec_var, tags, ext_var) => {
                         // TODO rec_var is excluded here, verify that this is correct
-                        for slice_index in tags.variables {
+                        for slice_index in tags.variables() {
                             let slice = subs[slice_index];
                             for var_index in slice {
                                 let var = subs[var_index];
@@ -1459,12 +1487,13 @@ fn explicit_substitute(
                 Structure(flat_type) => {
                     match flat_type {
                         Apply(symbol, args) => {
-                            let new_args = args
-                                .iter()
-                                .map(|var| explicit_substitute(subs, from, to, *var, seen))
-                                .collect();
+                            for var_index in args.into_iter() {
+                                let var = subs[var_index];
+                                let answer = explicit_substitute(subs, from, to, var, seen);
+                                subs[var_index] = answer;
+                            }
 
-                            subs.set_content(in_var, Structure(Apply(symbol, new_args)));
+                            subs.set_content(in_var, Structure(Apply(symbol, args)));
                         }
                         Func(arg_vars, closure_var, ret_var) => {
                             for var_index in arg_vars.into_iter() {
@@ -1486,7 +1515,7 @@ fn explicit_substitute(
                             let new_ext_var = explicit_substitute(subs, from, to, ext_var, seen);
 
                             let mut new_slices = Vec::new();
-                            for slice_index in tags.variables {
+                            for slice_index in tags.variables() {
                                 let slice = subs[slice_index];
 
                                 let mut new_variables = Vec::new();
@@ -1505,12 +1534,13 @@ fn explicit_substitute(
                             }
 
                             let start = subs.variable_slices.len() as u32;
-                            let length = new_slices.len() as u16;
+                            let length = new_slices.len();
 
                             subs.variable_slices.extend(new_slices);
 
                             let mut union_tags = tags;
-                            union_tags.variables = SubsSlice::new(start, length);
+                            debug_assert_eq!(length, union_tags.len());
+                            union_tags.variables_start = start;
 
                             subs.set_content(in_var, Structure(TagUnion(union_tags, new_ext_var)));
                         }
@@ -1526,7 +1556,7 @@ fn explicit_substitute(
                             let new_ext_var = explicit_substitute(subs, from, to, ext_var, seen);
 
                             let mut new_slices = Vec::new();
-                            for slice_index in tags.variables {
+                            for slice_index in tags.variables() {
                                 let slice = subs[slice_index];
 
                                 let mut new_variables = Vec::new();
@@ -1545,12 +1575,13 @@ fn explicit_substitute(
                             }
 
                             let start = subs.variable_slices.len() as u32;
-                            let length = new_slices.len() as u16;
+                            let length = new_slices.len();
 
                             subs.variable_slices.extend(new_slices);
 
                             let mut union_tags = tags;
-                            union_tags.variables = SubsSlice::new(start, length);
+                            debug_assert_eq!(length, union_tags.len());
+                            union_tags.variables_start = start;
 
                             subs.set_content(
                                 in_var,
@@ -1636,7 +1667,7 @@ fn get_var_names(
             Structure(flat_type) => match flat_type {
                 FlatType::Apply(_, args) => {
                     args.into_iter().fold(taken_names, |answer, arg_var| {
-                        get_var_names(subs, arg_var, answer)
+                        get_var_names(subs, subs[arg_var], answer)
                     })
                 }
 
@@ -1673,7 +1704,7 @@ fn get_var_names(
                 FlatType::TagUnion(tags, ext_var) => {
                     let mut taken_names = get_var_names(subs, ext_var, taken_names);
 
-                    for slice_index in tags.variables {
+                    for slice_index in tags.variables() {
                         let slice = subs[slice_index];
                         for var_index in slice {
                             let var = subs[var_index];
@@ -1692,7 +1723,7 @@ fn get_var_names(
                     let taken_names = get_var_names(subs, ext_var, taken_names);
                     let mut taken_names = get_var_names(subs, rec_var, taken_names);
 
-                    for slice_index in tags.variables {
+                    for slice_index in tags.variables() {
                         let slice = subs[slice_index];
                         for var_index in slice {
                             let arg_var = subs[var_index];
@@ -1854,7 +1885,10 @@ fn flat_type_to_err_type(
         Apply(symbol, args) => {
             let arg_types = args
                 .into_iter()
-                .map(|var| var_to_err_type(subs, state, var))
+                .map(|index| {
+                    let arg_var = subs[index];
+                    var_to_err_type(subs, state, arg_var)
+                })
                 .collect();
 
             ErrorType::Type(symbol, arg_types)
@@ -2047,7 +2081,8 @@ fn restore_content(subs: &mut Subs, content: &Content) {
 
         Structure(flat_type) => match flat_type {
             Apply(_, args) => {
-                for &var in args {
+                for index in args.into_iter() {
+                    let var = subs[index];
                     subs.restore(var);
                 }
             }
@@ -2074,7 +2109,7 @@ fn restore_content(subs: &mut Subs, content: &Content) {
                 subs.restore(*ext_var);
             }
             TagUnion(tags, ext_var) => {
-                for slice_index in tags.variables {
+                for slice_index in tags.variables() {
                     let slice = subs[slice_index];
                     for var_index in slice {
                         let var = subs[var_index];
@@ -2089,7 +2124,7 @@ fn restore_content(subs: &mut Subs, content: &Content) {
             }
 
             RecursiveTagUnion(rec_var, tags, ext_var) => {
-                for slice_index in tags.variables {
+                for slice_index in tags.variables() {
                     let slice = subs[slice_index];
                     for var_index in slice {
                         let var = subs[var_index];

--- a/compiler/unify/src/unify.rs
+++ b/compiler/unify/src/unify.rs
@@ -961,10 +961,11 @@ fn unify_flat_type(
         }
 
         (Apply(l_symbol, l_args), Apply(r_symbol, r_args)) if l_symbol == r_symbol => {
-            let problems = unify_zip(subs, pool, l_args.iter(), r_args.iter());
+            let problems =
+                unify_zip_slices(subs, pool, *l_args.as_subs_slice(), *r_args.as_subs_slice());
 
             if problems.is_empty() {
-                merge(subs, ctx, Structure(Apply(*r_symbol, (*r_args).clone())))
+                merge(subs, ctx, Structure(Apply(*r_symbol, *r_args)))
             } else {
                 problems
             }
@@ -1088,21 +1089,6 @@ fn unify_zip_slices(
         let l_var = subs[l_index];
         let r_var = subs[r_index];
 
-        problems.extend(unify_pool(subs, pool, l_var, r_var));
-    }
-
-    problems
-}
-
-fn unify_zip<'a, I>(subs: &mut Subs, pool: &mut Pool, left_iter: I, right_iter: I) -> Outcome
-where
-    I: Iterator<Item = &'a Variable>,
-{
-    let mut problems = Vec::new();
-
-    let it = left_iter.zip(right_iter);
-
-    for (&l_var, &r_var) in it {
         problems.extend(unify_pool(subs, pool, l_var, r_var));
     }
 


### PR DESCRIPTION
it is done, and even a net negative LOC change!

This PR shrinks the size of a FlatType to 40 bytes, and uses the new memory representation for recursive tag unions.