### PR TITLE
strip the layout cache so it does no extra work

### DIFF
--- a/compiler/mono/src/layout.rs
+++ b/compiler/mono/src/layout.rs
@@ -885,9 +885,7 @@ impl<'a> LayoutCache<'a> {
     pub fn rollback_to(&mut self, _snapshot: SnapshotKeyPlaceholder) {}
 }
 
-/// placeholder for the type
-///
-///      ven_ena::unify::Snapshot<ven_ena::unify::InPlace<CachedVariable<'a>>>
+// placeholder for the type ven_ena::unify::Snapshot<ven_ena::unify::InPlace<CachedVariable<'a>>>
 pub struct SnapshotKeyPlaceholder;
 
 impl<'a> Builtin<'a> {


### PR DESCRIPTION
it was still doing work, allocating space for many variables.

We concluded that because we use ena's snapshots during specialization, caching of layouts is really not possible in the general sense. We have to revisit if there is something we can do. In the meantime, the cache should not introduce overhead.