### PR TITLE
move List.prepend to zig

### DIFF
--- a/compiler/builtins/bitcode/src/list.zig
+++ b/compiler/builtins/bitcode/src/list.zig
@@ -733,6 +733,30 @@ pub fn listAppend(list: RocList, alignment: u32, element: Opaque, element_width:
     return output;
 }
 
+pub fn listPrepend(list: RocList, alignment: u32, element: Opaque, element_width: usize) callconv(.C) RocList {
+    const old_length = list.len();
+    var output = list.reallocate(alignment, old_length + 1, element_width);
+
+    // can't use one memcpy here because source and target overlap
+    if (output.bytes) |target| {
+        var i: usize = old_length;
+
+        while (i > 0) {
+            i -= 1;
+
+            // move the ith element to the (i + 1)th position
+            @memcpy(target + (i + 1) * element_width, target + i * element_width, element_width);
+        }
+
+        // finally copy in the new first element
+        if (element) |source| {
+            @memcpy(target, source, element_width);
+        }
+    }
+
+    return output;
+}
+
 pub fn listSwap(
     list: RocList,
     alignment: u32,

--- a/compiler/builtins/bitcode/src/main.zig
+++ b/compiler/builtins/bitcode/src/main.zig
@@ -33,6 +33,7 @@ comptime {
     exportListFn(list.listContains, "contains");
     exportListFn(list.listRepeat, "repeat");
     exportListFn(list.listAppend, "append");
+    exportListFn(list.listPrepend, "prepend");
     exportListFn(list.listSingle, "single");
     exportListFn(list.listJoin, "join");
     exportListFn(list.listRange, "range");

--- a/compiler/builtins/src/bitcode.rs
+++ b/compiler/builtins/src/bitcode.rs
@@ -57,6 +57,7 @@ pub const LIST_WALK_BACKWARDS: &str = "roc_builtins.list.walk_backwards";
 pub const LIST_CONTAINS: &str = "roc_builtins.list.contains";
 pub const LIST_REPEAT: &str = "roc_builtins.list.repeat";
 pub const LIST_APPEND: &str = "roc_builtins.list.append";
+pub const LIST_PREPEND: &str = "roc_builtins.list.prepend";
 pub const LIST_DROP: &str = "roc_builtins.list.drop";
 pub const LIST_SWAP: &str = "roc_builtins.list.swap";
 pub const LIST_SINGLE: &str = "roc_builtins.list.single";

--- a/compiler/test_gen/src/gen_list.rs
+++ b/compiler/test_gen/src/gen_list.rs
@@ -276,6 +276,20 @@ fn list_prepend() {
         RocList::from_slice(&[6, 4]),
         RocList<i64>
     );
+
+    assert_evals_to!(
+        indoc!(
+            r#"
+                init : List Str
+                init =
+                    ["foo"]
+
+                List.prepend init "bar"
+            "#
+        ),
+        RocList::from_slice(&[RocStr::from_slice(b"bar"), RocStr::from_slice(b"foo"),]),
+        RocList<RocStr>
+    );
 }
 
 #[test]


### PR DESCRIPTION
fixes #1581 

moves the code for List.prepend to zig so it works for all input types.