### PR TITLE
emit an error message when a symbol is not defined

### DIFF
--- a/compiler/mono/src/ir.rs
+++ b/compiler/mono/src/ir.rs
@@ -7927,13 +7927,15 @@ fn union_lambda_set_to_switch<'a>(
     assigned: Symbol,
     hole: &'a Stmt<'a>,
 ) -> Stmt<'a> {
-    // NOTE this can happen if there is a type error somewhere. Since the lambda set is empty,
-    // there is really nothing we can do here, so we just proceed with the hole itself and
-    // hope that the type error is communicated in a clear way elsewhere.
     if lambda_set.is_empty() {
-        return hole.clone();
+        // NOTE this can happen if there is a type error somewhere. Since the lambda set is empty,
+        // there is really nothing we can do here. We generate a runtime error here which allows
+        // code gen to proceed. We then assume that we hit another (more descriptive) error before
+        // hitting this one
+
+        let msg = "a Lambda Set isempty. Most likely there is a type error in your program.";
+        return Stmt::RuntimeError(msg);
     }
-    debug_assert!(!lambda_set.is_empty());
 
     let join_point_id = JoinPointId(env.unique_symbol());
 

--- a/compiler/test_gen/src/gen_primitives.rs
+++ b/compiler/test_gen/src/gen_primitives.rs
@@ -2760,3 +2760,21 @@ fn unresolved_tvar_when_capture_is_unused() {
         i64
     );
 }
+
+#[test]
+#[should_panic(expected = "Roc failed with message: ")]
+fn value_not_exposed_hits_panic() {
+    assert_evals_to!(
+        indoc!(
+            r#"
+                app "test" provides [ main ] to "./platform"
+
+                main : I64
+                main =
+                    Str.toInt 32
+            "#
+        ),
+        32,
+        i64
+    );
+}


### PR DESCRIPTION
fix #1613, #1611 

i.e. don't panic in this case