### PR TITLE
fix usize vs. u32/u64 conflict

### DIFF
--- a/compiler/can/src/builtins.rs
+++ b/compiler/can/src/builtins.rs
@@ -2792,9 +2792,9 @@ fn num_div_int(symbol: Symbol, var_store: &mut VarStore) -> Def {
 fn list_first(symbol: Symbol, var_store: &mut VarStore) -> Def {
     let bool_var = var_store.fresh();
     let list_var = var_store.fresh();
-    let len_var = var_store.fresh();
-    let zero_var = var_store.fresh();
-    let zero_precision_var = var_store.fresh();
+    let len_var = Variable::NAT;
+    let zero_var = len_var;
+    let zero_precision_var = Variable::NATURAL;
     let list_elem_var = var_store.fresh();
     let ret_var = var_store.fresh();
 

--- a/compiler/mono/src/ir.rs
+++ b/compiler/mono/src/ir.rs
@@ -7494,7 +7494,9 @@ fn from_can_record_destruct<'a>(
     })
 }
 
+#[derive(Debug)]
 pub enum IntPrecision {
+    Usize,
     I128,
     I64,
     I32,
@@ -7530,6 +7532,7 @@ fn int_precision_to_builtin(precision: IntPrecision) -> Builtin<'static> {
         I32 => Builtin::Int32,
         I16 => Builtin::Int16,
         I8 => Builtin::Int8,
+        Usize => Builtin::Usize,
     }
 }
 
@@ -7628,16 +7631,8 @@ pub fn num_argument_to_int_or_float(
         Content::Alias(Symbol::NUM_NAT, _, _)
         | Content::Alias(Symbol::NUM_NATURAL, _, _)
         | Content::Alias(Symbol::NUM_AT_NATURAL, _, _) => {
-            match ptr_bytes {
-                1 => IntOrFloat::UnsignedIntType(IntPrecision::I8),
-                2 => IntOrFloat::UnsignedIntType(IntPrecision::I16),
-                4 => IntOrFloat::UnsignedIntType(IntPrecision::I32),
-                8 => IntOrFloat::UnsignedIntType(IntPrecision::I64),
-                _ => panic!(
-                    "Invalid target for Num type argument: Roc does't support compiling to {}-bit systems.",
-                    ptr_bytes * 8
-                ),
-            }
+            IntOrFloat::UnsignedIntType(IntPrecision::Usize)
+
         }
         other => {
             panic!(

--- a/compiler/types/src/subs.rs
+++ b/compiler/types/src/subs.rs
@@ -961,19 +961,19 @@ fn define_integer_types(subs: &mut Subs) {
         Variable::U8,
     );
 
-    //    integer_type(
-    //        subs,
-    //        Symbol::NUM_AT_NATURAL,
-    //        Symbol::NUM_NATURAL,
-    //        Symbol::NUM_NAT,
-    //        Variable::AT_NATURAL,
-    //        Variable::NATURAL,
-    //        Variable::AT_INTEGER_NATURAL,
-    //        Variable::INTEGER_NATURAL,
-    //        Variable::AT_NUM_INTEGER_NATURAL,
-    //        Variable::NUM_INTEGER_NATURAL,
-    //        Variable::NAT,
-    //    );
+    integer_type(
+        subs,
+        Symbol::NUM_AT_NATURAL,
+        Symbol::NUM_NATURAL,
+        Symbol::NUM_NAT,
+        Variable::AT_NATURAL,
+        Variable::NATURAL,
+        Variable::AT_INTEGER_NATURAL,
+        Variable::INTEGER_NATURAL,
+        Variable::AT_NUM_INTEGER_NATURAL,
+        Variable::NUM_INTEGER_NATURAL,
+        Variable::NAT,
+    );
 }
 
 impl Subs {


### PR DESCRIPTION
taken from #1625 for easier reviewing

In some cases, we turned Usize into I32/I64, in others we did not. Decided to maintain the usize information, and so add an extra case for this scenario. 