### PR TITLE
Fix MacOS

### DIFF
--- a/compiler/builtins/bitcode/build.sh
+++ b/compiler/builtins/bitcode/build.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-set -euxo pipefail
-
-zig build-obj src/main.zig -O ReleaseFast -femit-llvm-ir=builtins.ll -femit-bin=builtins.o --strip


### PR DESCRIPTION
I think macOS builds were broken because of some of the wasm changes. The build.sh script that was used on Mac instead of `zig build` commands was not using the correct names for the generated files `.o` and `.ll`.

I also tried out just using the `zig build`commands on Big Sur and they seem to work. So I removed the `build.sh` and the conditional for detecting if we are on Big Sur.