### PR TITLE
use small-ci for tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ env:
 jobs:
   build-fmt-clippy-test:
     name: fmt, clippy, test --release
-    runs-on: [self-hosted, anton-vm-small]
+    runs-on: [self-hosted, i5-4690K]
     timeout-minutes: 90
     env:
       FORCE_COLOR: 1


### PR DESCRIPTION
To prevent the 32 bit valgrind tests from failing on the big-CI server.