### PR TITLE
Fix total_problems calculation

### DIFF
--- a/compiler/load/src/file.rs
+++ b/compiler/load/src/file.rs
@@ -723,7 +723,21 @@ pub struct MonomorphizedModule<'a> {
 
 impl<'a> MonomorphizedModule<'a> {
     pub fn total_problems(&self) -> usize {
-        self.can_problems.len() + self.type_problems.len() + self.mono_problems.len()
+        let mut total = 0;
+
+        for problems in self.can_problems.values() {
+            total += problems.len();
+        }
+
+        for problems in self.type_problems.values() {
+            total += problems.len();
+        }
+
+        for problems in self.mono_problems.values() {
+            total += problems.len();
+        }
+
+        total
     }
 }
 


### PR DESCRIPTION
This was counting the keys in the hashmap, not just the values, resulting in printing the horizontal rule from https://github.com/rtfeldman/roc/pull/1656 even when nothing had been reported!