### PR TITLE
Syntax highlighting for keywords in reports

### DIFF
--- a/compiler/reporting/src/report.rs
+++ b/compiler/reporting/src/report.rs
@@ -128,6 +128,7 @@ impl<'b> Report<'b> {
 pub struct Palette<'a> {
     pub primary: &'a str,
     pub code_block: &'a str,
+    pub keyword: &'a str,
     pub variable: &'a str,
     pub type_variable: &'a str,
     pub structure: &'a str,
@@ -146,6 +147,7 @@ pub struct Palette<'a> {
 pub const DEFAULT_PALETTE: Palette = Palette {
     primary: WHITE_CODE,
     code_block: WHITE_CODE,
+    keyword: GREEN_CODE,
     variable: BLUE_CODE,
     type_variable: YELLOW_CODE,
     structure: GREEN_CODE,
@@ -810,6 +812,9 @@ where
             Symbol => {
                 self.write_str(self.palette.variable)?;
             }
+            Keyword => {
+                self.write_str(self.palette.keyword)?;
+            }
             GutterBar => {
                 self.write_str(self.palette.gutter_bar)?;
             }
@@ -837,7 +842,7 @@ where
             ParserSuggestion => {
                 self.write_str(self.palette.parser_suggestion)?;
             }
-            TypeBlock | GlobalTag | PrivateTag | RecordField | Keyword => { /* nothing yet */ }
+            TypeBlock | GlobalTag | PrivateTag | RecordField => { /* nothing yet */ }
         }
         self.style_stack.push(*annotation);
         Ok(())
@@ -851,11 +856,11 @@ where
             Some(annotation) => match annotation {
                 Emphasized | Url | TypeVariable | Alias | Symbol | BinOp | Error | GutterBar
                 | Typo | TypoSuggestion | ParserSuggestion | Structure | CodeBlock | PlainText
-                | LineNumber | Tip | Module | Header => {
+                | LineNumber | Tip | Module | Header | Keyword => {
                     self.write_str(RESET_CODE)?;
                 }
 
-                TypeBlock | GlobalTag | PrivateTag | RecordField | Keyword => { /* nothing yet */ }
+                TypeBlock | GlobalTag | PrivateTag | RecordField => { /* nothing yet */ }
             },
         }
         Ok(())


### PR DESCRIPTION
Now they're highlighted as green:

<img width="820" alt="Screen Shot 2021-09-18 at 2 56 44 AM" src="https://user-images.githubusercontent.com/1094080/133879519-711aee85-cfa0-43d8-8b94-fcc1851ca647.png">
