### PR TITLE
Revise wording on naming suggestions

### DIFF
--- a/compiler/reporting/src/error/canonicalize.rs
+++ b/compiler/reporting/src/error/canonicalize.rs
@@ -1192,7 +1192,7 @@ fn not_found<'b>(
         alloc.reflow(" missing up-top"),
     ]);
 
-    let default_yes = alloc.reflow("these names seem close though:");
+    let default_yes = alloc.reflow("Did you mean one of these?");
 
     let to_details = |no_suggestion_details, yes_suggestion_details| {
         if suggestions.is_empty() {
@@ -1240,7 +1240,7 @@ fn module_not_found<'b>(
     ]);
 
     let default_yes = alloc
-        .reflow("Is there an import missing? Perhaps there is a typo, these names seem close:");
+        .reflow("Is there an import missing? Perhaps there is a typo. Did you mean one of these?");
 
     let to_details = |no_suggestion_details, yes_suggestion_details| {
         if suggestions.is_empty() {

--- a/compiler/reporting/tests/test_reporting.rs
+++ b/compiler/reporting/tests/test_reporting.rs
@@ -541,7 +541,7 @@ mod test_reporting {
                 8│          4 -> bar baz "yay"
                                  ^^^
 
-                these names seem close though:
+                Did you mean one of these?
 
                     baz
                     Nat
@@ -739,7 +739,7 @@ mod test_reporting {
                 <cyan>3<reset><cyan>│<reset>  <white>theAdmin<reset>
                     <red>^^^^^^^^<reset>
 
-                these names seem close though:
+                Did you mean one of these?
 
                     Decimal
                     Dec
@@ -1491,7 +1491,7 @@ mod test_reporting {
                 2│      { foo: 2 } -> foo
                                       ^^^
 
-                these names seem close though:
+                Did you mean one of these?
 
                     Bool
                     U8
@@ -1947,7 +1947,7 @@ mod test_reporting {
                 2│  f = \_ -> ok 4
                               ^^
 
-                these names seem close though:
+                Did you mean one of these?
 
                     U8
                     f
@@ -3634,8 +3634,8 @@ mod test_reporting {
                 1│  Foo.test
                     ^^^^^^^^
 
-                Is there an import missing? Perhaps there is a typo, these names seem
-                close:
+                Is there an import missing? Perhaps there is a typo. Did you mean one
+                of these?
 
                     Bool
                     Num
@@ -5797,7 +5797,7 @@ mod test_reporting {
                 1│  [ "foo", bar("") ]
                              ^^^
 
-                these names seem close though:
+                Did you mean one of these?
 
                     Nat
                     Str


### PR DESCRIPTION
## Before

<img width="811" alt="Screen Shot 2021-09-18 at 2 06 00 AM" src="https://user-images.githubusercontent.com/1094080/133878240-158f06fa-b2df-49fa-afdd-17d010575f58.png">

## After

<img width="809" alt="Screen Shot 2021-09-18 at 3 03 06 AM" src="https://user-images.githubusercontent.com/1094080/133879668-a599b038-e8e1-445a-818e-ecdca308b719.png">

Now we no longer claim the suggestions look close, since they might not actually be close. 😄 