### PR TITLE
Increase benchmarks time-out

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -12,7 +12,7 @@ jobs:
   prep-dependency-container:
     name: benchmark roc programs
     runs-on: [self-hosted, i7-6700K]
-    timeout-minutes: 60
+    timeout-minutes: 90
     env:
       FORCE_COLOR: 1
     steps:


### PR DESCRIPTION
Based on [this run](https://github.com/rtfeldman/roc/pull/1706/checks?check_run_id=3636559577) it can occasionally take this long to run compilation+benchmarks.