### PR TITLE
Remove f16. It is not really supported by modern CPU hardware.

### DIFF
--- a/compiler/gen_llvm/src/llvm/build.rs
+++ b/compiler/gen_llvm/src/llvm/build.rs
@@ -4863,7 +4863,7 @@ fn run_low_level<'a, 'ctx, 'env>(
                         Usize | Int128 | Int64 | Int32 | Int16 | Int8 => {
                             build_int_unary_op(env, arg.into_int_value(), arg_builtin, op)
                         }
-                        Float128 | Float64 | Float32 | Float16 => {
+                        Float128 | Float64 | Float32 => {
                             build_float_unary_op(env, arg.into_float_value(), op)
                         }
                         _ => {
@@ -4959,7 +4959,7 @@ fn run_low_level<'a, 'ctx, 'env>(
                                 "lt_or_gt",
                             )
                         }
-                        Float128 | Float64 | Float32 | Float16 => {
+                        Float128 | Float64 | Float32 => {
                             let are_equal = env.builder.build_float_compare(
                                 FloatPredicate::OEQ,
                                 lhs_arg.into_float_value(),
@@ -5405,8 +5405,7 @@ fn to_cc_type_builtin<'a, 'ctx, 'env>(
         | Builtin::Decimal
         | Builtin::Float128
         | Builtin::Float64
-        | Builtin::Float32
-        | Builtin::Float16 => basic_type_from_builtin(env, builtin),
+        | Builtin::Float32 => basic_type_from_builtin(env, builtin),
         Builtin::Str | Builtin::EmptyStr | Builtin::List(_) | Builtin::EmptyList => {
             env.str_list_c_abi().into()
         }
@@ -5769,7 +5768,7 @@ pub fn build_num_binop<'a, 'ctx, 'env>(
                     rhs_layout,
                     op,
                 ),
-                Float128 | Float64 | Float32 | Float16 => build_float_binop(
+                Float128 | Float64 | Float32 => build_float_binop(
                     env,
                     parent,
                     lhs_arg.into_float_value(),

--- a/compiler/gen_llvm/src/llvm/build_hash.rs
+++ b/compiler/gen_llvm/src/llvm/build_hash.rs
@@ -132,7 +132,6 @@ fn hash_builtin<'a, 'ctx, 'env>(
         | Builtin::Float64
         | Builtin::Float32
         | Builtin::Float128
-        | Builtin::Float16
         | Builtin::Decimal
         | Builtin::Usize => {
             let hash_bytes = store_and_use_as_u8_ptr(env, val, layout);

--- a/compiler/gen_llvm/src/llvm/compare.rs
+++ b/compiler/gen_llvm/src/llvm/compare.rs
@@ -103,7 +103,6 @@ fn build_eq_builtin<'a, 'ctx, 'env>(
         Builtin::Float128 => float_cmp(FloatPredicate::OEQ, "eq_f128"),
         Builtin::Float64 => float_cmp(FloatPredicate::OEQ, "eq_f64"),
         Builtin::Float32 => float_cmp(FloatPredicate::OEQ, "eq_f32"),
-        Builtin::Float16 => float_cmp(FloatPredicate::OEQ, "eq_f16"),
 
         Builtin::Str => str_equal(env, lhs_val, rhs_val),
         Builtin::List(elem) => build_list_eq(
@@ -247,7 +246,6 @@ fn build_neq_builtin<'a, 'ctx, 'env>(
         Builtin::Float128 => float_cmp(FloatPredicate::ONE, "neq_f128"),
         Builtin::Float64 => float_cmp(FloatPredicate::ONE, "neq_f64"),
         Builtin::Float32 => float_cmp(FloatPredicate::ONE, "neq_f32"),
-        Builtin::Float16 => float_cmp(FloatPredicate::ONE, "neq_f16"),
 
         Builtin::Str => {
             let is_equal = str_equal(env, lhs_val, rhs_val).into_int_value();

--- a/compiler/gen_llvm/src/llvm/convert.rs
+++ b/compiler/gen_llvm/src/llvm/convert.rs
@@ -97,7 +97,6 @@ pub fn basic_type_from_builtin<'a, 'ctx, 'env>(
         Float128 => context.f128_type().as_basic_type_enum(),
         Float64 => context.f64_type().as_basic_type_enum(),
         Float32 => context.f32_type().as_basic_type_enum(),
-        Float16 => context.f16_type().as_basic_type_enum(),
         Dict(_, _) | EmptyDict => zig_dict_type(env).into(),
         Set(_) | EmptySet => zig_dict_type(env).into(),
         List(_) | EmptyList => zig_list_type(env).into(),

--- a/compiler/gen_wasm/src/backend.rs
+++ b/compiler/gen_wasm/src/backend.rs
@@ -55,7 +55,6 @@ impl WasmLayout {
             Layout::Builtin(Builtin::Float128) => Self::StackMemory(size),
             Layout::Builtin(Builtin::Float64) => Self::LocalOnly(F64, size),
             Layout::Builtin(Builtin::Float32) => Self::LocalOnly(F32, size),
-            Layout::Builtin(Builtin::Float16) => Self::LocalOnly(F32, size),
             Layout::Builtin(Builtin::Str) => Self::StackMemory(size),
             Layout::Builtin(Builtin::Dict(_, _)) => Self::StackMemory(size),
             Layout::Builtin(Builtin::Set(_)) => Self::StackMemory(size),

--- a/compiler/mono/src/alias_analysis.rs
+++ b/compiler/mono/src/alias_analysis.rs
@@ -1241,7 +1241,7 @@ fn builtin_spec(
 
     match builtin {
         Int128 | Int64 | Int32 | Int16 | Int8 | Int1 | Usize => builder.add_tuple_type(&[]),
-        Decimal | Float128 | Float64 | Float32 | Float16 => builder.add_tuple_type(&[]),
+        Decimal | Float128 | Float64 | Float32 => builder.add_tuple_type(&[]),
         Str | EmptyStr => str_type(builder),
         Dict(key_layout, value_layout) => {
             let value_type = layout_spec_help(builder, value_layout, when_recursive)?;

--- a/compiler/mono/src/layout.rs
+++ b/compiler/mono/src/layout.rs
@@ -681,7 +681,6 @@ pub enum Builtin<'a> {
     Float128,
     Float64,
     Float32,
-    Float16,
     Str,
     Dict(&'a Layout<'a>, &'a Layout<'a>),
     Set(&'a Layout<'a>),
@@ -1119,7 +1118,6 @@ impl<'a> Builtin<'a> {
     const F128_SIZE: u32 = 16;
     const F64_SIZE: u32 = std::mem::size_of::<f64>() as u32;
     const F32_SIZE: u32 = std::mem::size_of::<f32>() as u32;
-    const F16_SIZE: u32 = 2;
 
     /// Number of machine words in an empty one of these
     pub const STR_WORDS: u32 = 2;
@@ -1149,7 +1147,6 @@ impl<'a> Builtin<'a> {
             Float128 => Builtin::F128_SIZE,
             Float64 => Builtin::F64_SIZE,
             Float32 => Builtin::F32_SIZE,
-            Float16 => Builtin::F16_SIZE,
             Str | EmptyStr => Builtin::STR_WORDS * pointer_size,
             Dict(_, _) | EmptyDict => Builtin::DICT_WORDS * pointer_size,
             Set(_) | EmptySet => Builtin::SET_WORDS * pointer_size,
@@ -1176,7 +1173,6 @@ impl<'a> Builtin<'a> {
             Float128 => align_of::<i128>() as u32,
             Float64 => align_of::<f64>() as u32,
             Float32 => align_of::<f32>() as u32,
-            Float16 => align_of::<i16>() as u32,
             Dict(_, _) | EmptyDict => pointer_size,
             Set(_) | EmptySet => pointer_size,
             // we often treat these as i128 (64-bit systems)
@@ -1194,7 +1190,7 @@ impl<'a> Builtin<'a> {
 
         match self {
             Int128 | Int64 | Int32 | Int16 | Int8 | Int1 | Usize | Decimal | Float128 | Float64
-            | Float32 | Float16 | EmptyStr | EmptyDict | EmptyList | EmptySet => true,
+            | Float32 | EmptyStr | EmptyDict | EmptyList | EmptySet => true,
             Str | Dict(_, _) | Set(_) | List(_) => false,
         }
     }
@@ -1205,7 +1201,7 @@ impl<'a> Builtin<'a> {
 
         match self {
             Int128 | Int64 | Int32 | Int16 | Int8 | Int1 | Usize | Decimal | Float128 | Float64
-            | Float32 | Float16 | EmptyStr | EmptyDict | EmptyList | EmptySet => false,
+            | Float32 | EmptyStr | EmptyDict | EmptyList | EmptySet => false,
             List(_) => true,
 
             Str | Dict(_, _) | Set(_) => true,
@@ -1232,7 +1228,6 @@ impl<'a> Builtin<'a> {
             Float128 => alloc.text("Float128"),
             Float64 => alloc.text("Float64"),
             Float32 => alloc.text("Float32"),
-            Float16 => alloc.text("Float16"),
 
             EmptyStr => alloc.text("EmptyStr"),
             EmptyList => alloc.text("EmptyList"),
@@ -1266,8 +1261,7 @@ impl<'a> Builtin<'a> {
             | Builtin::Decimal
             | Builtin::Float128
             | Builtin::Float64
-            | Builtin::Float32
-            | Builtin::Float16 => unreachable!("not heap-allocated"),
+            | Builtin::Float32 => unreachable!("not heap-allocated"),
             Builtin::Str => pointer_size,
             Builtin::Dict(k, v) => k
                 .alignment_bytes(pointer_size)

--- a/compiler/test_mono/generated/quicksort_help.txt
+++ b/compiler/test_mono/generated/quicksort_help.txt
@@ -10,7 +10,7 @@ procedure Num.27 (#Attr.2, #Attr.3):
     let Test.26 = lowlevel NumLt #Attr.2 #Attr.3;
     ret Test.26;
 
-procedure Test.1 (Test.29, Test.30, Test.31):
+procedure Test.1 (Test.27, Test.28, Test.29):
     joinpoint Test.12 Test.2 Test.3 Test.4:
         let Test.14 = CallByName Num.27 Test.3 Test.4;
         if Test.14 then
@@ -29,7 +29,7 @@ procedure Test.1 (Test.29, Test.30, Test.31):
         else
             ret Test.2;
     in
-    jump Test.12 Test.29 Test.30 Test.31;
+    jump Test.12 Test.27 Test.28 Test.29;
 
 procedure Test.0 ():
     let Test.9 = Array [];


### PR DESCRIPTION
The pull request is pretty straight forward. It remove `Builtin::Float16`. I was discussing with Richard, and it does not make sense to support. It is really only support by accelerators like GPUs and TPUs.

That being said, it made me change `compiler/test_mono/generated/quicksort_help.txt`, not really sure why.