### PR TITLE
More useful stack traces for gen_wasm bugs

### DIFF
--- a/compiler/gen_wasm/src/lib.rs
+++ b/compiler/gen_wasm/src/lib.rs
@@ -128,7 +128,7 @@ fn copy_memory(
     size: u32,
     alignment_bytes: u32,
     offset: u32,
-) -> Result<(), String> {
+) {
     let alignment_flag = encode_alignment(alignment_bytes);
     let mut current_offset = offset;
     while size - current_offset >= 8 {
@@ -152,7 +152,6 @@ fn copy_memory(
         instructions.push(I32Store8(alignment_flag, current_offset));
         current_offset += 1;
     }
-    Ok(())
 }
 
 /// Round up to alignment_bytes (assumed to be a power of 2)

--- a/compiler/gen_wasm/src/storage.rs
+++ b/compiler/gen_wasm/src/storage.rs
@@ -82,7 +82,7 @@ impl SymbolStorage {
         instructions: &mut Vec<Instruction>,
         to_pointer: LocalId,
         to_offset: u32,
-    ) -> Result<u32, String> {
+    ) -> u32 {
         match self {
             Self::ParamPrimitive {
                 local_id,
@@ -104,16 +104,13 @@ impl SymbolStorage {
                     (ValueType::F32, 4) => F32Store(ALIGN_4, to_offset),
                     (ValueType::F64, 8) => F64Store(ALIGN_8, to_offset),
                     _ => {
-                        return Err(format!(
-                            "Cannot store {:?} with alignment of {:?}",
-                            value_type, size
-                        ));
+                        panic!("Cannot store {:?} with alignment of {:?}", value_type, size);
                     }
                 };
                 instructions.push(GetLocal(to_pointer.0));
                 instructions.push(GetLocal(local_id.0));
                 instructions.push(store_instruction);
-                Ok(*size)
+                *size
             }
 
             Self::ParamStackMemory {
@@ -134,15 +131,15 @@ impl SymbolStorage {
                     *size,
                     *alignment_bytes,
                     to_offset,
-                )?;
-                Ok(*size)
+                );
+                *size
             }
 
             Self::VarHeapMemory { local_id, .. } => {
                 instructions.push(GetLocal(to_pointer.0));
                 instructions.push(GetLocal(local_id.0));
                 instructions.push(I32Store(ALIGN_4, to_offset));
-                Ok(4)
+                4
             }
         }
     }


### PR DESCRIPTION
`Result` makes sense where I have something meaningful to say to the user like "X is not implemented yet".
And also for public functions that may interface with other parts of the project like `Backend`. (I haven't changed any signatures that match `Backend`)

But for private functions internal to `gen_wasm`, it's just unhelpful to get a stack trace to where the `Result` is unwrapped! I want a stack trace to the root cause. I always end up temporarily rewriting `Err("oops")` to `panic!("oops")` and then waiting for it to recompile.

This feels like a more balanced approach, using each technique where it makes sense.