### PR TITLE
On `Ctrl+R` do `cargo run check` before `cargo run`

### DIFF
--- a/editor/src/editor/ed_error.rs
+++ b/editor/src/editor/ed_error.rs
@@ -42,16 +42,22 @@ pub enum EdError {
     },
 
     #[snafu(display("ClipboardReadFailed: could not get clipboard contents: {}", err_msg))]
-    ClipboardReadFailed { err_msg: String },
+    ClipboardReadFailed {
+        err_msg: String,
+    },
 
     #[snafu(display("ClipboardWriteFailed: could not set clipboard contents: {}", err_msg))]
-    ClipboardWriteFailed { err_msg: String },
+    ClipboardWriteFailed {
+        err_msg: String,
+    },
 
     #[snafu(display(
         "ClipboardInitFailed: could not initialize ClipboardContext: {}.",
         err_msg
     ))]
-    ClipboardInitFailed { err_msg: String },
+    ClipboardInitFailed {
+        err_msg: String,
+    },
 
     #[snafu(display(
         "ExpectedTextNode: the function {} expected a Text node, got {} instead.",
@@ -67,7 +73,9 @@ pub enum EdError {
     #[snafu(display(
         "EmptyCodeString: I need to have a code string (code_str) that contains either an app, interface or Package-Config header. The code string was empty.",
     ))]
-    EmptyCodeString { backtrace: Backtrace },
+    EmptyCodeString {
+        backtrace: Backtrace,
+    },
 
     #[snafu(display("FailedToUpdateIdentIdName: {}", err_str))]
     FailedToUpdateIdentIdName {
@@ -76,7 +84,9 @@ pub enum EdError {
     },
 
     #[snafu(display("GetContentOnNestedNode: tried to get string content from Nested MarkupNode. Can only get content from Text or Blank nodes."))]
-    GetContentOnNestedNode { backtrace: Backtrace },
+    GetContentOnNestedNode {
+        backtrace: Backtrace,
+    },
 
     #[snafu(display(
         "IndexOfFailed: Element {} was not found in collection {}.",
@@ -107,7 +117,9 @@ pub enum EdError {
     #[snafu(display(
         "MissingSelection: ed_model.selected_expr2_id was Some(ExprId) but ed_model.caret_w_sel_vec did not contain any Some(Selection)."
     ))]
-    MissingSelection { backtrace: Backtrace },
+    MissingSelection {
+        backtrace: Backtrace,
+    },
 
     #[snafu(display("NestedNodeMissingChild: expected to find child with id {} in Nested MarkupNode, but it was missing. Id's of the children are {:?}.", node_id, children_ids))]
     NestedNodeMissingChild {
@@ -138,7 +150,9 @@ pub enum EdError {
     },
 
     #[snafu(display("NodeWithoutAttributes: expected to have a node with attributes. This is a Nested MarkupNode, only Text and Blank nodes have attributes."))]
-    NodeWithoutAttributes { backtrace: Backtrace },
+    NodeWithoutAttributes {
+        backtrace: Backtrace,
+    },
 
     #[snafu(display(
         "NodeIdNotInGridNodeMap: MarkNodeId {} was not found in ed_model.grid_node_map.",
@@ -159,6 +173,41 @@ pub enum EdError {
     },
 
     #[snafu(display(
+        "OutOfBounds: index {} was out of bounds for {} with length {}.",
+        index,
+        collection_name,
+        len
+    ))]
+    OutOfBounds {
+        index: usize,
+        collection_name: String,
+        len: usize,
+        backtrace: Backtrace,
+    },
+
+    #[snafu(display("RecordWithoutFields: expected record to have at least one field because it is not an EmptyRecord."))]
+    RecordWithoutFields {
+        backtrace: Backtrace,
+    },
+
+    #[snafu(display(
+        "RocCheckFailed: `cargo run check`/`roc check` detected errors(see terminal)."
+    ))]
+    RocCheckFailed,
+
+    #[snafu(display("ParseError: Failed to parse AST: SyntaxError: {}.", syntax_err))]
+    SrcParseError {
+        syntax_err: String,
+        backtrace: Backtrace,
+    },
+
+    #[snafu(display("StringParseError: {}", msg))]
+    StringParseError {
+        msg: String,
+        backtrace: Backtrace,
+    },
+
+    #[snafu(display(
         "UnexpectedASTNode: required a {} at this position, node was a {}.",
         required_node_type,
         encountered_node_type
@@ -166,6 +215,15 @@ pub enum EdError {
     UnexpectedASTNode {
         required_node_type: String,
         encountered_node_type: String,
+        backtrace: Backtrace,
+    },
+
+    #[snafu(display(
+        "UnexpectedEmptyPoolVec: expected PoolVec {} to have at least one element.",
+        descriptive_vec_name
+    ))]
+    UnexpectedEmptyPoolVec {
+        descriptive_vec_name: String,
         backtrace: Backtrace,
     },
 
@@ -180,46 +238,25 @@ pub enum EdError {
         backtrace: Backtrace,
     },
 
-    #[snafu(display(
-        "UnexpectedEmptyPoolVec: expected PoolVec {} to have at least one element.",
-        descriptive_vec_name
-    ))]
-    UnexpectedEmptyPoolVec {
-        descriptive_vec_name: String,
-        backtrace: Backtrace,
-    },
-
-    #[snafu(display(
-        "OutOfBounds: index {} was out of bounds for {} with length {}.",
-        index,
-        collection_name,
-        len
-    ))]
-    OutOfBounds {
-        index: usize,
-        collection_name: String,
-        len: usize,
-        backtrace: Backtrace,
-    },
-
-    #[snafu(display("ParseError: Failed to parse AST: SyntaxError: {}.", syntax_err))]
-    SrcParseError {
-        syntax_err: String,
-        backtrace: Backtrace,
-    },
-
-    #[snafu(display("RecordWithoutFields: expected record to have at least one field because it is not an EmptyRecord."))]
-    RecordWithoutFields { backtrace: Backtrace },
-
-    #[snafu(display("StringParseError: {}", msg))]
-    StringParseError { msg: String, backtrace: Backtrace },
-
     #[snafu(display("ASTError: {}", msg))]
-    ASTErrorBacktrace { msg: String, backtrace: Backtrace },
+    ASTErrorBacktrace {
+        msg: String,
+        backtrace: Backtrace,
+    },
     #[snafu(display("UIError: {}", msg))]
-    UIErrorBacktrace { msg: String, backtrace: Backtrace },
+    UIErrorBacktrace {
+        msg: String,
+        backtrace: Backtrace,
+    },
     #[snafu(display("MarkError: {}", msg))]
-    MarkErrorBacktrace { msg: String, backtrace: Backtrace },
+    MarkErrorBacktrace {
+        msg: String,
+        backtrace: Backtrace,
+    },
+
+    WrapIoError {
+        source: std::io::Error,
+    },
 }
 
 pub type EdResult<T, E = EdError> = std::result::Result<T, E>;
@@ -308,5 +345,11 @@ impl From<ASTError> for EdError {
         // hack to handle EdError derive
         let dummy_res: Result<(), NoneError> = Err(NoneError {});
         dummy_res.context(ASTErrorBacktrace { msg }).unwrap_err()
+    }
+}
+
+impl From<std::io::Error> for EdError {
+    fn from(io_err: std::io::Error) -> Self {
+        Self::WrapIoError { source: io_err }
     }
 }

--- a/editor/src/editor/mvc/ed_update.rs
+++ b/editor/src/editor/mvc/ed_update.rs
@@ -5,7 +5,7 @@ use std::process::Stdio;
 
 use crate::editor::code_lines::CodeLines;
 use crate::editor::ed_error::EdResult;
-use crate::editor::ed_error::MissingSelection;
+use crate::editor::ed_error::{MissingSelection, RocCheckFailed};
 use crate::editor::grid_node_map::GridNodeMap;
 use crate::editor::mvc::app_update::InputOutcome;
 use crate::editor::mvc::ed_model::EdModel;
@@ -549,6 +549,7 @@ impl<'a> EdModel<'a> {
             }
             R => {
                 if modifiers.cmd_or_ctrl() {
+                    self.check_file()?;
                     self.run_file()?
                 }
             }
@@ -634,8 +635,27 @@ impl<'a> EdModel<'a> {
         Ok(())
     }
 
-    fn run_file(&mut self) -> UIResult<()> {
-        println!("Executing file...");
+    fn check_file(&mut self) -> EdResult<()> {
+        println!("Checking file (cargo run check <file>)...");
+
+        let roc_file_str = path_to_string(self.file_path);
+
+        let cmd_out = Command::new("cargo")
+            .arg("run")
+            .arg("check")
+            .arg(roc_file_str)
+            .stdout(Stdio::inherit())
+            .output()?;
+
+        if !cmd_out.status.success() {
+            RocCheckFailed.fail()?
+        }
+
+        Ok(())
+    }
+
+    fn run_file(&mut self) -> EdResult<()> {
+        println!("Executing file (cargo run <file>)...");
 
         let roc_file_str = path_to_string(self.file_path);
 
@@ -644,8 +664,7 @@ impl<'a> EdModel<'a> {
             .arg(roc_file_str)
             .stdout(Stdio::inherit())
             .stderr(Stdio::inherit())
-            .output()
-            .expect("Failed to run file");
+            .output()?;
 
         Ok(())
     }


### PR DESCRIPTION
- `Ctrl+R` only runs the code if `roc check` succeeded.
- Sorted `EdError` variants alphabetically.