### PR TITLE
Just enough changes to compile on M1

### DIFF
--- a/compiler/build/Cargo.toml
+++ b/compiler/build/Cargo.toml
@@ -42,7 +42,7 @@ quickcheck = "0.8"
 quickcheck_macros = "0.8"
 
 [features]
-default = ["llvm", "target-webassembly"]
+default = ["llvm", "target-webassembly", "target-aarch64"]
 target-arm = []
 target-aarch64 = []
 target-webassembly = []

--- a/compiler/build/src/target.rs
+++ b/compiler/build/src/target.rs
@@ -32,6 +32,11 @@ pub fn target_triple_str(target: &Triple) -> &'static str {
             ..
         } => "aarch64-unknown-linux-gnu",
         Triple {
+            architecture: Architecture::Aarch64(_),
+            operating_system: OperatingSystem::Darwin,
+            ..
+        } => "aarch64-apple-darwin",
+        Triple {
             architecture: Architecture::X86_64,
             operating_system: OperatingSystem::Darwin,
             ..


### PR DESCRIPTION
Related to #1204

Apple requires libraries and executables to be codesigned before they can be run on M1 Macs. Otherwise they fail like this:
```
> Enter an expression, or :help, or :exit/:q.

» 1
'-use-aa' is not a recognized feature for this target (ignoring feature)
'+zcz-fp' is not a recognized feature for this target (ignoring feature)
'-use-aa' is not a recognized feature for this target (ignoring feature)
'+zcz-fp' is not a recognized feature for this target (ignoring feature)
thread 'main' panicked at 'Error loading compiled dylib for test: DlOpen { desc: "dlopen(/var/folders/gg/1zw0wwxx4fl6x74n0jz_r6h00000gn/T/.tmpZQTdrR/app.dylib, 0x0002): tried: \'/var/folders/gg/1zw0wwxx4fl6x74n0jz_r6h00000gn/T/.tmpZQTdrR/app.dylib\' (code signature in <E7A1A8E3-B46D-391C-8915-B0CCF2AFC1A3> \'/private/var/folders/gg/1zw0wwxx4fl6x74n0jz_r6h00000gn/T/.tmpZQTdrR/app.dylib\' not valid for use in process: Trying to load an unsigned library), \'/usr/local/lib/app.dylib\' (no such file), \'/usr/lib/app.dylib\' (no such file), \'/private/var/folders/gg/1zw0wwxx4fl6x74n0jz_r6h00000gn/T/.tmpZQTdrR/app.dylib\' (code signature in <E7A1A8E3-B46D-391C-8915-B0CCF2AFC1A3> \'/private/var/folders/gg/1zw0wwxx4fl6x74n0jz_r6h00000gn/T/.tmpZQTdrR/app.dylib\' not valid for use in process: Trying to load an unsigned library), \'/usr/local/lib/app.dylib\' (no such file), \'/usr/lib/app.dylib\' (no such file)" }', cli/src/repl/gen.rs:227:14
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Rust, Zig and Go all had to go through this transition. The simplest solution is to do an ad-hoc codesigning using `codesign -s - PATH_TO_FILE` command. 

This PR adds a target triple and arch string and executes the codesign command after ld. The existing `link` function expects to return one child back but the child is waited and unwrapped right away. So instead, I wait for the `ld` spawn in the linking step and instead return the `codesign` spawn. 

I couldn't figure out a way to selectively enable `target-aarch64` feature on those platforms and therefore I've added them to the default. Similarly the `(ignoring feature)` messages are still there.

Suggestions highly welcome!