### PR TITLE
Ensure we pass stdout (the String contents) instead of the Out struct

### DIFF
--- a/cli/tests/cli_run.rs
+++ b/cli/tests/cli_run.rs
@@ -129,7 +129,7 @@ mod cli_run {
         if !&out.stdout.ends_with(expected_ending) {
             panic!(
                 "expected output to end with {:?} but instead got {:#?}",
-                expected_ending, out
+                expected_ending, out.stdout
             );
         }
         assert!(out.status.success());


### PR DESCRIPTION
When running `cargo test` on macOS using LLVM 12.0.1, Zig 0.8.1 and Rust 1.56.0, I got one test failure. While this pull request doesn't address the test failure itself, it ensures we pass `out.stdout` instead of `out` as the actual result.
 
```console
---- cli_run::false_interpreter stdout ----
thread 'cli_run::false_interpreter' panicked at 'expected output to end with "Hello, World!\n" but instead got Out {
    stdout: "",
    stderr: "",
    status: ExitStatus(
        ExitStatus(
            6,
        ),
    ),
}', cli/tests/cli_run.rs:130:13
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    cli_run::false_interpreter

test result: FAILED. 21 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 35.62s
```

becomes

```console
---- cli_run::false_interpreter stdout ----
thread 'cli_run::false_interpreter' panicked at 'expected output to end with "Hello, World!\n" but instead got ""', cli/tests/cli_run.rs:130:13
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    cli_run::false_interpreter

test result: FAILED. 21 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 38.08s
```