### PR TITLE
Fixed some typos in roc for elm

### DIFF
--- a/roc-for-elm-programmers.md
+++ b/roc-for-elm-programmers.md
@@ -509,7 +509,7 @@ Elm's custom types) instead of product types (such as records).
 > algebraic data types, and they have the usual support for pattern matching,
 > exhaustiveness checking, and so on.
 
-You don't need to declare tag unions them before using them. Instead, you can
+You don't need to declare tag unions before using them. Instead, you can
 just write a *tag* (essentially a variant) anywhere you like, and Roc will infer
 the type of the union it goes in.
 
@@ -847,7 +847,7 @@ error. However, the `/` operator in Roc is infix syntax sugar for `Num.div`,
 which is a normal function you can pass to anything you like.
 
 Elm has one unary operator, namely `-`. (In Elm, `-x` means
-"apply unary `negate` to `x`.") Roc has that one, and also unary `!`.
+"apply unary `negate` to `x`.") Roc has that one too, and also unary `!`.
 The expression `!foo` desugars to `Bool.not foo`, and `!foo bar` desugars
 to `Bool.not (foo bar)`.
 


### PR DESCRIPTION
Great intro, thanks a lot! 

In a let ... in block, accessing assignments are order independent, right? In the case of backpassing, does the assignment get scoped to the closure? Is this something that you've though about how it might confuse people? 

```coffeescript
task =
    defaultName = firstname
    user <- Task.await fetchUser
    firstname = "Viktor"
    Task.succeed { user, defaultName }
```

```coffeescript
task =
    defaultName = firstname
    firstname = "Viktor"
    Task.succeed defaultName
```

The more I think about it, in practice this probably isn't going to be a problem. I'll leave it here, just because I'm curious 😊