### PR TITLE
Fix: Add missing import alsa-lib

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -28,6 +28,7 @@ let
       xorg.libXrandr
       xorg.libXi
       xorg.libxcb
+      alsa-lib
     ];
 
   llvmPkgs = pkgs.llvmPackages_12;


### PR DESCRIPTION
With this I was able to build the `roc` binary on nixos with `nix-shell --run "cargo build"`.