### PR TITLE
Explicitly return from `main` in Swift host

### DIFF
--- a/examples/hello-swift/platform/host.swift
+++ b/examples/hello-swift/platform/host.swift
@@ -52,6 +52,7 @@ extension RocStr {
 }
 
 @_cdecl("main")
-func main() {
+func main() -> UInt8 {
     print(roc__mainForHost_1_exposed().string)
+    return 0
 }


### PR DESCRIPTION
If I'm not mistaken we expect `main` to return `0` upon success. The `hello_swift` test was failing macOS due to an unexpected exit status.