### PR TITLE
Repro of non-unification in definition of joinMap

### DIFF
--- a/compiler/builtins/src/std.rs
+++ b/compiler/builtins/src/std.rs
@@ -877,6 +877,19 @@ pub fn types() -> MutMap<Symbol, (SolvedType, Region)> {
         Box::new(list_type(int_type(flex(TVAR1)))),
     );
 
+    // joinMap : List before, (before -> List after) -> List after
+    {
+        let_tvars! { cvar, before, after }
+        add_top_level_function_type!(
+            Symbol::LIST_JOIN_MAP,
+            vec![
+                list_type(flex(before)),
+                closure(vec![flex(before)], cvar, Box::new(list_type(flex(after)))),
+            ],
+            Box::new(list_type(flex(after))),
+        );
+    }
+
     // map : List before, (before -> after) -> List after
     add_top_level_function_type!(
         Symbol::LIST_MAP,

--- a/compiler/module/src/symbol.rs
+++ b/compiler/module/src/symbol.rs
@@ -1061,6 +1061,8 @@ define_builtins! {
         38 LIST_MAX: "max"
         39 LIST_MAX_GT: "#maxGt"
         40 LIST_MAP4: "map4"
+        41 LIST_JOIN_MAP: "joinMap"
+        42 LIST_JOIN_MAP_CONCAT: "#joinMapConcat"
     }
     5 RESULT: "Result" => {
         0 RESULT_RESULT: "Result" imported // the Result.Result type alias

--- a/compiler/mono/src/ir.rs
+++ b/compiler/mono/src/ir.rs
@@ -35,9 +35,10 @@ macro_rules! return_on_layout_error {
 macro_rules! return_on_layout_error_help {
     ($env:expr, $error:expr) => {
         match $error {
-            LayoutProblem::UnresolvedTypeVar(_) => {
+            LayoutProblem::UnresolvedTypeVar(v) => {
                 return Stmt::RuntimeError($env.arena.alloc(format!(
-                    "UnresolvedTypeVar {} line {}",
+                    "UnresolvedTypeVar: {} at {} line {}",
+                    v.index(),
                     file!(),
                     line!()
                 )));

--- a/compiler/test_gen/src/gen_list.rs
+++ b/compiler/test_gen/src/gen_list.rs
@@ -2210,3 +2210,21 @@ fn empty_list_of_function_type() {
         RocStr
     );
 }
+
+#[test]
+fn list_join_map() {
+    assert_evals_to!(
+        indoc!(
+            r#"
+            List.joinMap ["guava,apple", "bailey,cyrus"] (\s -> Str.split s ",")
+            "#
+        ),
+        RocList::from_slice(&[
+            RocStr::from_slice("guava".as_bytes()),
+            RocStr::from_slice("apple".as_bytes()),
+            RocStr::from_slice("bailey".as_bytes()),
+            RocStr::from_slice("cyrus".as_bytes()),
+        ]),
+        RocList<RocStr>
+    );
+}


### PR DESCRIPTION
Still a WIP, opening as draft to showcase an issue I described on Zulip.

```
> cargo test -p test_gen gen_list::list_join_map -- --nocapture
...
running 1 test
[compiler/can/src/builtins.rs:2186] "list_list_b: {}" = "list_list_b: {}"
[compiler/can/src/builtins.rs:2186] list_list_b.index() = 127
thread 'gen_list::list_join_map' panicked at 'Roc failed with message: "UnresolvedTypeVar: 127 at compiler/mono/src/ir.rs line 3987"', compiler/test_gen/src/gen_list.rs:2216:5
test gen_list::list_join_map ... FAILED
```

We can see from the error message that `list_list_b` is not resolved,
even though once we have the concrete typings for the arguments to
`joinMap` as

```
ARG_1: List TA
ARG_2: TA -> List TB
```

we should, in principle, have generated the constraints

```
// from List.map : List before, (before -> after) -> List after

List before = List TA
before -> after = TA -> List TB
List after = list_list_b
```

which should solve to

```
before = TA
after = List TB
list_list_b = List (List TB)
```

So it seems like the type of `ListMap` in `RunLowLevel` is not being
considered during typechecking?
