### PR TITLE
Ignore macOS desktop service store files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ earthly_log.txt
 
 # created to test release
 roc_linux_x86_64.tar.gz
+
+# macOS .DS_Store files
+.DS_Store


### PR DESCRIPTION
macOS generates [.DS_Store](https://en.wikipedia.org/wiki/.DS_Store) files that we do not want to track.