### PR TITLE
Print rebuild logs when rebuilding the host

### DIFF
--- a/cli/src/build.rs
+++ b/cli/src/build.rs
@@ -291,6 +291,8 @@ fn spawn_rebuild_thread(
 ) -> std::thread::JoinHandle<u128> {
     let thread_local_target = target.clone();
     std::thread::spawn(move || {
+        print!("🔨 Rebuilding host... ");
+
         let rebuild_host_start = SystemTime::now();
         if !precompiled {
             if surgically_link {
@@ -316,6 +318,9 @@ fn spawn_rebuild_thread(
             std::fs::copy(prehost, binary_path.as_path()).unwrap();
         }
         let rebuild_host_end = rebuild_host_start.elapsed().unwrap();
+
+        println!("Done!");
+
         rebuild_host_end.as_millis()
     })
 }


### PR DESCRIPTION
Closing #1814 

This is a very naive implementation to try to get my feet wet.

I am unsure about a few things
1. "Done!" is logged even on link errors
2. [`preprocess_impl`](https://github.com/rtfeldman/roc/blob/b03ed18553569314a420d5bf1fb0ead4b6b5ecda/linker/src/lib.rs#L278) can `println!` on `parse` error, messing up the log. Unfortunately, I couldn't reproduce this
3. most importantly: whether to include an emoji or not