### PR TITLE
Fix compiler builds on macOS

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -33,8 +33,6 @@ install-zig-llvm-valgrind-clippy-rustfmt:
     RUN rustup component add clippy
     # rustfmt
     RUN rustup component add rustfmt
-    # macOS target for checking Mac-specific compilations
-    RUN rustup target add x86_64-apple-darwin
     # criterion
     RUN cargo install cargo-criterion
     # editor
@@ -55,10 +53,6 @@ test-zig:
     FROM +install-zig-llvm-valgrind-clippy-rustfmt
     COPY --dir compiler/builtins/bitcode ./
     RUN cd bitcode && ./run-tests.sh
-
-check-macos:
-    FROM +copy-dirs
-    RUN cargo check --target x86_64-apple-darwin
 
 check-clippy:
     FROM +copy-dirs
@@ -110,7 +104,6 @@ verify-no-git-changes:
 
 test-all:
     BUILD +test-zig
-    BUILD +check-macos
     BUILD +check-rustfmt
     BUILD +check-clippy
     BUILD +test-rust


### PR DESCRIPTION
`cargo build` is currently failing on trunk. #1986 added an extra
parameter to the definition of `build_zig_host_native` active for
non-macOS targets, but did not reflect that parameter in the
macOS-specific definition.

I don't think there is a good way to test against these kinds of things
without a dedicated macOS machine on the CI runner (`cargo check
--target x86_64-apple-darwin` won't work since some dependencies need
arch-specific things to be present during build time). Any suggestions
are appreciated!