### PR TITLE
Parse _ in type annotations as an 'Inferred' type

### DIFF
--- a/ast/src/lang/core/types.rs
+++ b/ast/src/lang/core/types.rs
@@ -389,6 +389,9 @@ pub fn to_type2<'a>(
                 }
             }
         }
+        Inferred => {
+            unimplemented!();
+        }
         Wildcard | Malformed(_) => {
             let var = env.var_store.fresh();
 

--- a/compiler/can/src/annotation.rs
+++ b/compiler/can/src/annotation.rs
@@ -459,6 +459,9 @@ fn can_annotation_help(
 
             Type::Variable(var)
         }
+        Inferred => {
+            unimplemented!();
+        }
         Malformed(string) => {
             malformed(env, region, string);
 

--- a/compiler/fmt/src/annotation.rs
+++ b/compiler/fmt/src/annotation.rs
@@ -180,7 +180,7 @@ impl<'a> Formattable<'a> for TypeAnnotation<'a> {
                 true
             }
 
-            Wildcard | BoundVariable(_) | Malformed(_) => false,
+            Wildcard | Inferred | BoundVariable(_) | Malformed(_) => false,
             Function(args, result) => {
                 (&result.value).is_multiline()
                     || args.iter().any(|loc_arg| (&loc_arg.value).is_multiline())
@@ -279,6 +279,7 @@ impl<'a> Formattable<'a> for TypeAnnotation<'a> {
             }
             BoundVariable(v) => buf.push_str(v),
             Wildcard => buf.push('*'),
+            Inferred => buf.push('_'),
 
             TagUnion { tags, ext } => {
                 format_sequence!(buf, indent, '[', ']', tags, newlines, Tag);

--- a/compiler/parse/src/ast.rs
+++ b/compiler/parse/src/ast.rs
@@ -240,6 +240,9 @@ pub enum TypeAnnotation<'a> {
         tags: Collection<'a, Loc<Tag<'a>>>,
     },
 
+    /// '_', indicating the compiler should infer the type
+    Inferred,
+
     /// The `*` type variable, e.g. in (List *)
     Wildcard,
 

--- a/compiler/parse/src/parser.rs
+++ b/compiler/parse/src/parser.rs
@@ -626,6 +626,7 @@ pub enum EType<'a> {
     TApply(ETypeApply, Row, Col),
     TBadTypeVariable(Row, Col),
     TWildcard(Row, Col),
+    TInferred(Row, Col),
     ///
     TStart(Row, Col),
     TEnd(Row, Col),

--- a/compiler/parse/src/type_annotation.rs
+++ b/compiler/parse/src/type_annotation.rs
@@ -55,6 +55,7 @@ fn term<'a>(min_indent: u16) -> impl Parser<'a, Located<TypeAnnotation<'a>>, ETy
         and!(
             one_of!(
                 loc_wildcard(),
+                loc_inferred(),
                 specialize(EType::TInParens, loc_type_in_parens(min_indent)),
                 loc!(specialize(EType::TRecord, record_type(min_indent))),
                 loc!(specialize(EType::TTagUnion, tag_union_type(min_indent))),
@@ -111,6 +112,15 @@ fn loc_wildcard<'a>() -> impl Parser<'a, Located<TypeAnnotation<'a>>, EType<'a>>
     })
 }
 
+/// The `_` indicating an inferred type, e.g. in (List _)
+fn loc_inferred<'a>() -> impl Parser<'a, Located<TypeAnnotation<'a>>, EType<'a>> {
+    map!(loc!(word1(b'_', EType::TInferred)), |loc_val: Located<
+        (),
+    >| {
+        loc_val.map(|_| TypeAnnotation::Inferred)
+    })
+}
+
 fn loc_applied_arg<'a>(min_indent: u16) -> impl Parser<'a, Located<TypeAnnotation<'a>>, EType<'a>> {
     use crate::ast::Spaceable;
 
@@ -119,6 +129,7 @@ fn loc_applied_arg<'a>(min_indent: u16) -> impl Parser<'a, Located<TypeAnnotatio
             backtrackable(space0_e(min_indent, EType::TSpace, EType::TIndentStart)),
             one_of!(
                 loc_wildcard(),
+                loc_inferred(),
                 specialize(EType::TInParens, loc_type_in_parens(min_indent)),
                 loc!(specialize(EType::TRecord, record_type(min_indent))),
                 loc!(specialize(EType::TTagUnion, tag_union_type(min_indent))),

--- a/compiler/parse/tests/snapshots/pass/type_decl_with_underscore.expr.result-ast
+++ b/compiler/parse/tests/snapshots/pass/type_decl_with_underscore.expr.result-ast
@@ -1,0 +1,38 @@
+Defs(
+    [
+        |L 0-0, C 0-30| Annotation(
+            |L 0-0, C 0-7| Identifier(
+                "doStuff",
+            ),
+            |L 0-0, C 20-30| Function(
+                [
+                    |L 0-0, C 10-16| Apply(
+                        "",
+                        "UserId",
+                        [],
+                    ),
+                ],
+                |L 0-0, C 20-30| Apply(
+                    "",
+                    "Task",
+                    [
+                        |L 0-0, C 25-28| Apply(
+                            "",
+                            "Str",
+                            [],
+                        ),
+                        |L 0-0, C 29-30| Inferred,
+                    ],
+                ),
+            ),
+        ),
+    ],
+    |L 1-1, C 0-2| SpaceBefore(
+        Num(
+            "42",
+        ),
+        [
+            Newline,
+        ],
+    ),
+)

--- a/compiler/parse/tests/snapshots/pass/type_decl_with_underscore.expr.roc
+++ b/compiler/parse/tests/snapshots/pass/type_decl_with_underscore.expr.roc
@@ -1,0 +1,2 @@
+doStuff : UserId -> Task Str _
+42

--- a/compiler/parse/tests/test_parse.rs
+++ b/compiler/parse/tests/test_parse.rs
@@ -196,6 +196,7 @@ mod test_parse {
             two_backpassing,
             two_branch_when,
             two_spaced_def,
+            type_decl_with_underscore,
             unary_negation,
             unary_negation_access, // Regression test for https://github.com/rtfeldman/roc/issues/509
             unary_negation_arg,


### PR DESCRIPTION
This allows parsing of '_' as a type alias - but nothing else; the compiler will currently crash with `unimplemented!()` if this is encountered.

(Part of #1804)