### PR TITLE
Use Internal linkage to keep roc function symbols in the final binary

### DIFF
--- a/compiler/gen_llvm/src/llvm/build.rs
+++ b/compiler/gen_llvm/src/llvm/build.rs
@@ -4136,7 +4136,7 @@ fn build_proc_header<'a, 'ctx, 'env>(
         env.module,
         fn_name.as_str(),
         fn_type,
-        Linkage::Private,
+        Linkage::Internal,
         FAST_CALL_CONV,
     );
 
@@ -6213,7 +6213,7 @@ fn build_foreign_symbol<'a, 'ctx, 'env>(
                 env.module,
                 &fastcc_function_name,
                 fastcc_type,
-                Linkage::Private,
+                Linkage::Internal,
                 FAST_CALL_CONV,
             );
 

--- a/compiler/gen_llvm/src/llvm/refcounting.rs
+++ b/compiler/gen_llvm/src/llvm/refcounting.rs
@@ -183,7 +183,7 @@ impl<'ctx> PointerToRefcount<'ctx> {
                     env.module,
                     fn_name,
                     fn_type,
-                    Linkage::Private,
+                    Linkage::Internal,
                     FAST_CALL_CONV, // Because it's an internal-only function, it should use the fast calling convention.
                 );
 


### PR DESCRIPTION
According to the LLVM manual, the difference between Private and Internal is that `Private` isn't included in the local symbol table, whereas `Internal` is. `Internal` is documented as "This corresponds to the notion of the ‘static’ keyword in C", which sounds like what we want.

Fixes #2011