### PR TITLE
update nix macos instructions

### DIFF
--- a/BUILDING_FROM_SOURCE.md
+++ b/BUILDING_FROM_SOURCE.md
@@ -94,7 +94,7 @@ Install nix:
 
 `curl -L https://nixos.org/nix/install | sh`
 
-You will need to use a new terminal to use nix.
+You will need to start a fresh terminal session to use nix.
 
 ### Usage
 


### PR DESCRIPTION
The extra flag is no longer necessary to install nix.