### PR TITLE
limit linux-only workflows to linux machines

### DIFF
--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -8,7 +8,7 @@ env:
 jobs:
   spell-check:
     name: spell check
-    runs-on: [self-hosted]
+    runs-on: [self-hosted, linux]
     timeout-minutes: 10
     env:
       FORCE_COLOR: 1

--- a/.github/workflows/www.yml
+++ b/.github/workflows/www.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   deploy:
     name: 'Deploy to Netlify'
-    runs-on: [self-hosted]
+    runs-on: [self-hosted, linux]
     steps:
       - uses: jsmrcaga/action-netlify-deploy@v1.6.0
         with:


### PR DESCRIPTION
This prevents spellcheck and www workflows from trying to run on macOS, which would fail.