### PR TITLE
Use cfg to check if we're compiling for windows (in reporting)

### DIFF
--- a/reporting/src/report.rs
+++ b/reporting/src/report.rs
@@ -16,7 +16,6 @@ const CYCLE_ELEMENTS: [&str; 4] = ["+-----+", "|     ", "|     |", "+-<---+"];
 #[cfg(not(windows))]
 const CYCLE_ELEMENTS: [&str; 4] = ["┌─────┐", "│     ", "│     ↓", "└─────┘"];
 
-// trick to branch in a const. Can be replaced by an if when that is merged into rustc
 const CYCLE_TOP: &str = CYCLE_ELEMENTS[0];
 const CYCLE_LN: &str = CYCLE_ELEMENTS[1];
 const CYCLE_MID: &str = CYCLE_ELEMENTS[2];


### PR DESCRIPTION
actually check if we're compiling (the compiler) for windows