### PR TITLE
preallocate variables to prevent extra vector allocations

### DIFF
--- a/compiler/types/src/subs.rs
+++ b/compiler/types/src/subs.rs
@@ -1548,6 +1548,15 @@ impl VariableSubsSlice {
         }
     }
 
+    pub fn reserve_into_subs(subs: &mut Subs, length: usize) -> Self {
+        let start = subs.variables.len() as u32;
+
+        subs.variables
+            .extend(std::iter::repeat(Variable::NULL).take(length));
+
+        Self::new(start, length as u16)
+    }
+
     pub fn insert_into_subs<I>(subs: &mut Subs, input: I) -> Self
     where
         I: IntoIterator<Item = Variable>,


### PR DESCRIPTION
We can't just push these because the recursive call to `type_to_var` might also add variables. So we need to reserve space to put them. But, the big `subs.variables` array probably already has space (in practice it always doubles its capacity), so filling it with `0`s should be fast. I think with some further refactoring we can eventually turn this into a loop (i.e. it's not recursive any more)