### PR TITLE
Implement platform header formatting

### DIFF
--- a/compiler/fmt/src/collection.rs
+++ b/compiler/fmt/src/collection.rs
@@ -14,7 +14,7 @@ pub struct CollectionConfig {
 
 pub fn fmt_collection<'a, F: Formattable<'a>>(
     buf: &mut String<'a>,
-    items: Collection<'a, F>,
+    items: Collection<'_, F>,
     indent: u16,
     config: CollectionConfig,
 ) {

--- a/compiler/fmt/src/spaces.rs
+++ b/compiler/fmt/src/spaces.rs
@@ -29,9 +29,9 @@ pub fn fmt_default_spaces<'a>(
     }
 }
 
-pub fn fmt_spaces<'b, 'a: 'b, I>(buf: &mut String<'a>, spaces: I, indent: u16)
+pub fn fmt_spaces<'a, 'b, I>(buf: &mut String<'a>, spaces: I, indent: u16)
 where
-    I: Iterator<Item = &'b CommentOrNewline<'a>>,
+    I: Iterator<Item = &'b CommentOrNewline<'b>>,
 {
     use self::CommentOrNewline::*;
 
@@ -85,13 +85,13 @@ pub enum NewlineAt {
 /// The `new_line_at` argument describes how new lines should be inserted
 /// at the beginning or at the end of the block
 /// in the case of there is some comment in the `spaces` argument.
-pub fn fmt_comments_only<'a, I>(
+pub fn fmt_comments_only<'a, 'b, I>(
     buf: &mut String<'a>,
     spaces: I,
     new_line_at: NewlineAt,
     indent: u16,
 ) where
-    I: Iterator<Item = &'a CommentOrNewline<'a>>,
+    I: Iterator<Item = &'b CommentOrNewline<'b>>,
 {
     use self::CommentOrNewline::*;
     use NewlineAt::*;
@@ -122,7 +122,7 @@ pub fn fmt_comments_only<'a, I>(
     }
 }
 
-fn fmt_comment<'a>(buf: &mut String<'a>, comment: &'a str) {
+fn fmt_comment<'a>(buf: &mut String<'a>, comment: &str) {
     buf.push('#');
     if !comment.starts_with(' ') {
         buf.push(' ');
@@ -130,7 +130,7 @@ fn fmt_comment<'a>(buf: &mut String<'a>, comment: &'a str) {
     buf.push_str(comment);
 }
 
-fn fmt_docs<'a>(buf: &mut String<'a>, docs: &'a str) {
+fn fmt_docs<'a>(buf: &mut String<'a>, docs: &str) {
     buf.push_str("##");
     if !docs.starts_with(' ') {
         buf.push(' ');

--- a/compiler/fmt/tests/test_fmt.rs
+++ b/compiler/fmt/tests/test_fmt.rs
@@ -2489,6 +2489,30 @@ mod test_fmt {
         ));
     }
 
+    #[test]
+    fn single_line_platform() {
+        // There are many places that there should probably be spaces, e.g.:
+        // requires { model=>Model, msg=>Msg } { main : Effect {} }
+        //                                             ^
+        // putLine : Str -> Effect {},
+        //          ^
+        // TODO: improve spacing
+        module_formats_same(
+            "platform folkertdev/foo \
+            requires { model=>Model, msg=>Msg } { main :Effect {} } \
+            exposes [] \
+            packages {} \
+            imports [ Task.{ Task } ] \
+            provides [ mainForHost ] \
+            effects fx.Effect \
+            { \
+                putLine :Str -> Effect {}, \
+                putInt :I64 -> Effect {}, \
+                getInt :Effect { value : I64, errorCode : [ A, B ], isError : Bool } \
+            } ",
+        );
+    }
+
     /// Annotations and aliases
 
     #[test]

--- a/compiler/load/src/file.rs
+++ b/compiler/load/src/file.rs
@@ -3437,7 +3437,7 @@ fn fabricate_effects_module<'a>(
 
     let module_id: ModuleId;
 
-    let effect_entries = unpack_exposes_entries(arena, effects.entries);
+    let effect_entries = unpack_exposes_entries(arena, effects.entries.items);
     let name = effects.effect_type_name;
     let declared_name: ModuleName = name.into();
 

--- a/compiler/parse/src/header.rs
+++ b/compiler/parse/src/header.rs
@@ -174,7 +174,7 @@ pub struct Effects<'a> {
     pub spaces_after_type_name: &'a [CommentOrNewline<'a>],
     pub effect_shortname: &'a str,
     pub effect_type_name: &'a str,
-    pub entries: &'a [Loc<TypedIdent<'a>>],
+    pub entries: Collection<'a, Loc<TypedIdent<'a>>>,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq)]

--- a/compiler/parse/src/module.rs
+++ b/compiler/parse/src/module.rs
@@ -718,7 +718,7 @@ fn effects<'a>() -> impl Parser<'a, Effects<'a>, EEffects<'a>> {
                 spaces_after_type_name,
                 effect_shortname: type_shortname,
                 effect_type_name: type_name,
-                entries: entries.items,
+                entries,
             },
             state,
         ))


### PR DESCRIPTION
... and also implement the majority of `todo!`s in formatting headers.

With this change, I can successfully run `for x in examples/**/*.roc; echo $x; cargo run -- format $x || break; end`, without running into any `unimplemented!` / `todo!` panics.

There are some ast-breaking format problems when trying to format examples/**/*.roc (e.g. missing indents, etc). I'll try to fix those up next, and add a check to the `roc format` command, where we re-parse the formatted output and assert the ast is the same, prior to writing it out.