### PR TITLE
Fix indent formatting in Def::AnnotatedBody

### DIFF
--- a/compiler/fmt/src/def.rs
+++ b/compiler/fmt/src/def.rs
@@ -89,7 +89,7 @@ impl<'a> Formattable<'a> for Def<'a> {
                     buf.push_str(" # ");
                     buf.push_str(comment_str.trim());
                 }
-                buf.push_str("\n");
+                newline(buf, indent);
                 fmt_body(buf, &body_pattern.value, &body_expr.value, indent);
             }
 


### PR DESCRIPTION
This fixes a bug where the body ends up not indented properly for any Def that's not at global scope.