### PR TITLE
Fix formatting of if/else chains

### DIFF
--- a/compiler/fmt/src/expr.rs
+++ b/compiler/fmt/src/expr.rs
@@ -672,8 +672,12 @@ fn fmt_if<'a>(
         indent
     };
 
-    for (loc_condition, loc_then) in branches.iter() {
+    for (i, (loc_condition, loc_then)) in branches.iter().enumerate() {
         let is_multiline_condition = loc_condition.is_multiline();
+
+        if i > 0 {
+            buf.push_str("else ");
+        }
 
         buf.push_str("if");
 


### PR DESCRIPTION
I found this issue while trying to format everything under examples/, where the formatter was simply leaving off the 'else' bit of the if/else chain.