### PR TITLE
Fix formatting of private tags

### DIFF
--- a/compiler/fmt/src/annotation.rs
+++ b/compiler/fmt/src/annotation.rs
@@ -518,7 +518,7 @@ impl<'a> Formattable<'a> for Tag<'a> {
                 }
             }
             Tag::Private { name, args } => {
-                buf.push('@');
+                debug_assert!(name.value.starts_with('@'));
                 buf.push_str(name.value);
                 if is_multiline {
                     let arg_indent = indent + INDENT;


### PR DESCRIPTION
I found this issue while trying to format everything under examples/, where the formatter turned `@Decoder` into `@@Decoder`, which doesn't parse.