### PR TITLE
Verify ast matches before/after formatting

### DIFF
--- a/cli/src/format.rs
+++ b/cli/src/format.rs
@@ -83,6 +83,16 @@ fn fmt_all<'a>(arena: &'a Bump, buf: &mut String<'a>, ast: &'a Ast) {
     }
 }
 
+/// RemoveSpaces normalizes the ast to something that we _expect_ to be invariant under formatting.
+///
+/// Currently this consists of:
+/// * Removing newlines
+/// * Removing comments
+/// * Removing parens in Exprs
+///
+/// Long term, we actuall want this transform to preserve comments (so we can assert they're maintained by formatting)
+/// - but there are currently several bugs where they're _not_ preserved.
+/// TODO: ensure formatting retains comments
 trait RemoveSpaces<'a> {
     fn remove_spaces(&self, arena: &'a Bump) -> Self;
 }


### PR DESCRIPTION
This makes sure that we don't have subtle bugs in the formatting logic that actually changes the meaning (or parsability) of the code. This assert found #2078, #2079, #2080, and #2081, as well as a few others that I don't yet have a fix for.