### PR TITLE
Fix a bug in LLVM backend refcounting

### DIFF
--- a/compiler/gen_llvm/src/llvm/refcounting.rs
+++ b/compiler/gen_llvm/src/llvm/refcounting.rs
@@ -442,8 +442,8 @@ fn modify_refcount_builtin<'a, 'ctx, 'env>(
             Some(function)
         }
         Set(element_layout) => {
-            let key_layout = &Layout::Struct(&[]);
-            let value_layout = element_layout;
+            let key_layout = element_layout;
+            let value_layout = &Layout::Struct(&[]);
 
             let function = modify_refcount_dict(
                 env,


### PR DESCRIPTION
Spotted what looks like a bug in refcounting for LLVM backend while implementing similar code for the other backends.
A Set is a Dict with no _values_, not a Dict with no keys.
Let's see if the change breaks any tests!