### PR TITLE
Make sure unary operators around function calls get parens

### DIFF
--- a/compiler/fmt/src/expr.rs
+++ b/compiler/fmt/src/expr.rs
@@ -258,7 +258,7 @@ impl<'a> Formattable<'a> for Expr<'a> {
                     }
                 }
 
-                sub_expr.format_with_options(buf, parens, newlines, indent);
+                sub_expr.format_with_options(buf, Parens::InApply, newlines, indent);
             }
             AccessorFunction(key) => {
                 buf.push('.');

--- a/compiler/fmt/tests/test_fmt.rs
+++ b/compiler/fmt/tests/test_fmt.rs
@@ -2324,6 +2324,25 @@ mod test_fmt {
         ));
     }
 
+    #[test]
+    fn unary_call_parens() {
+        expr_formats_same(indoc!(
+            r#"
+                !(f 1)
+            "#
+        ));
+    }
+
+    #[test]
+    fn unary_call_no_parens() {
+        // TIL: Negating a function "does what you might expect"... which is cool!
+        expr_formats_same(indoc!(
+            r#"
+                !f 1
+            "#
+        ));
+    }
+
     // BINARY OP
 
     #[test]


### PR DESCRIPTION
Yet-another bug found by trying to run the formatter on stuff in examples/ (yay!)