### PR TITLE
Fix formatting of applies in backpassing

### DIFF
--- a/compiler/fmt/tests/test_fmt.rs
+++ b/compiler/fmt/tests/test_fmt.rs
@@ -2714,6 +2714,46 @@ mod test_fmt {
         ));
     }
 
+    #[test]
+    fn backpassing_simple() {
+        expr_formats_same(indoc!(
+            r#"
+                getChar = \ctx ->
+                    x <- Task.await (getCharScope scope)
+                    42
+
+                42
+            "#
+        ));
+    }
+
+    #[test]
+    fn backpassing_apply_tag() {
+        expr_formats_same(indoc!(
+            r#"
+                getChar = \ctx ->
+                    (T val newScope) <- Task.await (getCharScope scope)
+                    42
+
+                42
+            "#
+        ));
+    }
+
+    #[test]
+    fn backpassing_body_on_newline() {
+        expr_formats_same(indoc!(
+            r#"
+                getChar = \ctx ->
+                    x <-
+                        Task.await (getCharScope scope)
+                    42
+
+                42
+            "#
+        ));
+    }
+
     // this is a parse error atm
     //    #[test]
     //    fn multiline_apply() {


### PR DESCRIPTION
Most of this is making sure parens are applied when matching an apply pattern in backpassing - because without the parens this becomes a parse error.

I also fixed a small bug around deciding whether to put a ' ' between the '->' and what comes next.