### PR TITLE
build-essential typo

### DIFF
--- a/getting_started/linux_x86.md
+++ b/getting_started/linux_x86.md
@@ -17,7 +17,7 @@
     ```
     - for the C example:
     ```
-    sudo apt install build-essentials clang
+    sudo apt install build-essential clang
     ```
 0. Run examples with:
     ```


### PR DESCRIPTION
Linux x86 Getting Started Guide has a typo.