### PR TITLE
Fix usage of `Result.withDefault`

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -792,7 +792,7 @@ style using the `|>` operator. Here are three examples of writing the same expre
 compile to exactly the same thing, but two of them use the `|>` operator to change how the calls look.
 
 ```coffee
-Result.withDefault "" (List.get [ "a", "b", "c" ] 1)
+Result.withDefault (List.get [ "a", "b", "c" ] 1) ""
 ```
 
 ```coffee


### PR DESCRIPTION
```
Result.withDefault "" (List.get [ "a", "b", "c" ] 100)
Mismatch in compiler/unify/src/unify.rs Line 1078 Column 13
Trying to unify two flat types that are incompatible: Apply(`Str.Str`, []) ~ [ Global('Err') [178], Global('Ok') [174], ]<180>


── TYPE MISMATCH ───────────────────────────────────────────────────────────────

The 1st argument to withDefault is not what I expect:

4│      Result.withDefault "" (List.get [ "a", "b", "c" ] 100)
                           ^^

This argument is a string of type:

    Str

But withDefault needs the 1st argument to be:

    Result b a


» Result.withDefault (List.get [ "a", "b", "c" ] 100) ""

"" : Str
```
