### PR TITLE
Make assert output for fmt+parse tests more understandable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3383,6 +3383,7 @@ dependencies = [
  "roc_module",
  "roc_parse",
  "roc_region",
+ "roc_test_utils",
 ]
 
 [[package]]
@@ -3525,9 +3526,7 @@ dependencies = [
 name = "roc_parse"
 version = "0.1.0"
 dependencies = [
- "ansi_term",
  "bumpalo",
- "diff",
  "encode_unicode",
  "indoc",
  "pretty_assertions",
@@ -3536,6 +3535,7 @@ dependencies = [
  "roc_collections",
  "roc_module",
  "roc_region",
+ "roc_test_utils",
 ]
 
 [[package]]
@@ -3598,6 +3598,10 @@ dependencies = [
 
 [[package]]
 name = "roc_std"
+version = "0.1.0"
+
+[[package]]
+name = "roc_test_utils"
 version = "0.1.0"
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ members = [
     "code_markup",
     "reporting",
     "roc_std",
+    "test_utils",
     "utils",
     "docs",
     "linker",

--- a/Earthfile
+++ b/Earthfile
@@ -47,7 +47,7 @@ install-zig-llvm-valgrind-clippy-rustfmt:
 
 copy-dirs:
     FROM +install-zig-llvm-valgrind-clippy-rustfmt
-    COPY --dir cli cli_utils compiler docs editor ast code_markup utils reporting roc_std vendor examples linker Cargo.toml Cargo.lock version.txt ./
+    COPY --dir cli cli_utils compiler docs editor ast code_markup utils test_utils reporting roc_std vendor examples linker Cargo.toml Cargo.lock version.txt ./
 
 test-zig:
     FROM +install-zig-llvm-valgrind-clippy-rustfmt

--- a/compiler/fmt/Cargo.toml
+++ b/compiler/fmt/Cargo.toml
@@ -15,3 +15,4 @@ bumpalo = { version = "3.8.0", features = ["collections"] }
 [dev-dependencies]
 pretty_assertions = "1.0.0"
 indoc = "1.0.3"
+roc_test_utils = { path = "../../test_utils" }

--- a/compiler/fmt/tests/test_fmt.rs
+++ b/compiler/fmt/tests/test_fmt.rs
@@ -1,6 +1,4 @@
 #[macro_use]
-extern crate pretty_assertions;
-#[macro_use]
 extern crate indoc;
 extern crate bumpalo;
 extern crate roc_fmt;
@@ -14,6 +12,7 @@ mod test_fmt {
     use roc_fmt::module::fmt_module;
     use roc_parse::module::{self, module_defs};
     use roc_parse::parser::{Parser, State};
+    use roc_test_utils::assert_multiline_str_eq;
 
     fn expr_formats_to(input: &str, expected: &str) {
         let arena = Bump::new();
@@ -26,7 +25,7 @@ mod test_fmt {
 
                 actual.format_with_options(&mut buf, Parens::NotNeeded, Newlines::Yes, 0);
 
-                assert_eq!(buf, expected)
+                assert_multiline_str_eq!(expected, buf.as_str())
             }
             Err(error) => panic!("Unexpected parse failure when parsing this for formatting:\n\n{}\n\nParse error was:\n\n{:?}\n\n", input, error)
         };
@@ -56,7 +55,7 @@ mod test_fmt {
                     Err(error) => panic!("Unexpected parse failure when parsing this for defs formatting:\n\n{:?}\n\nParse error was:\n\n{:?}\n\n", src, error)
                 }
 
-                assert_eq!(buf, expected)
+                assert_multiline_str_eq!(expected, buf.as_str())
             }
             Err(error) => panic!("Unexpected parse failure when parsing this for module header formatting:\n\n{:?}\n\nParse error was:\n\n{:?}\n\n", src, error)
         };

--- a/compiler/parse/Cargo.toml
+++ b/compiler/parse/Cargo.toml
@@ -17,5 +17,4 @@ pretty_assertions = "1.0.0"
 indoc = "1.0.3"
 quickcheck = "1.0.3"
 quickcheck_macros = "1.0.0"
-diff = "0.1.12"
-ansi_term = "0.12.1"
+roc_test_utils = { path = "../../test_utils" }

--- a/compiler/parse/tests/test_parse.rs
+++ b/compiler/parse/tests/test_parse.rs
@@ -23,6 +23,7 @@ mod test_parse {
     use roc_parse::parser::{Parser, State, SyntaxError};
     use roc_parse::test_helpers::parse_expr_with;
     use roc_region::all::{Located, Region};
+    use roc_test_utils::assert_multiline_str_eq;
     use std::{f64, i64};
 
     macro_rules! snapshot_tests {
@@ -254,10 +255,7 @@ mod test_parse {
         } else {
             let expected_result = std::fs::read_to_string(&result_path).unwrap();
 
-            // TODO: do a diff over the "real" content of these strings, rather than
-            // the debug-formatted content. As is, we get an ugly single-line diff
-            // from pretty_assertions
-            assert_eq!(expected_result, actual_result);
+            assert_multiline_str_eq!(expected_result, actual_result);
         }
     }
 

--- a/test_utils/Cargo.toml
+++ b/test_utils/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "roc_test_utils"
+version = "0.1.0"
+authors = ["The Roc Contributors"]
+license = "UPL-1.0"
+edition = "2018"
+description = "Utility functions used all over the code base."
+
+[dependencies]
+
+[dev-dependencies]

--- a/test_utils/src/lib.rs
+++ b/test_utils/src/lib.rs
@@ -1,0 +1,15 @@
+#[derive(PartialEq)]
+pub struct DebugAsDisplay<T>(pub T);
+
+impl<T: std::fmt::Display> std::fmt::Debug for DebugAsDisplay<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+#[macro_export]
+macro_rules! assert_multiline_str_eq {
+    ($a:expr, $b:expr) => {
+        assert_eq!($crate::DebugAsDisplay($a), $crate::DebugAsDisplay($b))
+    };
+}


### PR DESCRIPTION
Before:
```
Diff < left / right > :
<"when b is\n    1 | 2 ->\n        when c is\n            6 | 7 ->\n                8\n\n    3 | 4 ->\n        5"
>"when b is\n    1 | 2 ->\n        when     c is\n            6 | 7 ->\n                8\n\n    3 | 4 ->\n        5"
```

After:
```
Diff < left / right > :
 when b is
     1 | 2 ->
<        when     c is
>        when c is
             6 | 7 ->
                 8

     3 | 4 ->
         5
```

(coloring on the terminal makes this look even friendlier of course)