### PR TITLE
Fix formatting of if as an left-hand-side of an operator

### DIFF
--- a/compiler/fmt/src/expr.rs
+++ b/compiler/fmt/src/expr.rs
@@ -1098,6 +1098,7 @@ fn sub_expr_requests_parens(expr: &Expr<'_>) -> bool {
                     BinOp::Pizza | BinOp::Assignment | BinOp::HasType | BinOp::Backpassing => false,
                 })
         }
+        Expr::If(_, _) => true,
         _ => false,
     }
 }

--- a/compiler/fmt/tests/test_fmt.rs
+++ b/compiler/fmt/tests/test_fmt.rs
@@ -2311,6 +2311,15 @@ mod test_fmt {
         ));
     }
 
+    #[test]
+    fn binop_if() {
+        expr_formats_same(indoc!(
+            r#"
+            5 * (if x > 0 then 1 else 2)
+            "#
+        ));
+    }
+
     // UNARY OP
 
     #[test]


### PR DESCRIPTION
This gets us one step closer to being able to correctly format everything under examples/.