### PR TITLE
Remove unnecessary unwraps in CLIs by using subcommand()

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -21,7 +21,7 @@ use roc_cli::build;
 fn main() -> io::Result<()> {
     let matches = build_app().get_matches();
 
-    let exit_code = match matches.subcommand_name() {
+    let exit_code = match matches.subcommand() {
         None => {
             match matches.index_of(ROC_FILE) {
                 Some(arg_index) => {
@@ -37,14 +37,10 @@ fn main() -> io::Result<()> {
                 }
             }
         }
-        Some(CMD_BUILD) => Ok(build(
-            matches.subcommand_matches(CMD_BUILD).unwrap(),
-            BuildConfig::BuildOnly,
-        )?),
-        Some(CMD_CHECK) => {
+        Some((CMD_BUILD, matches)) => Ok(build(matches, BuildConfig::BuildOnly)?),
+        Some((CMD_CHECK, matches)) => {
             let arena = bumpalo::Bump::new();
 
-            let matches = matches.subcommand_matches(CMD_CHECK).unwrap();
             let emit_timings = matches.is_present(FLAG_TIME);
             let filename = matches.value_of(ROC_FILE).unwrap();
             let roc_file_path = PathBuf::from(filename);
@@ -66,16 +62,14 @@ fn main() -> io::Result<()> {
                 }
             }
         }
-        Some(CMD_REPL) => {
+        Some((CMD_REPL, _)) => {
             repl::main()?;
 
             // Exit 0 if the repl exited normally
             Ok(0)
         }
-        Some(CMD_EDIT) => {
+        Some((CMD_EDIT, matches)) => {
             match matches
-                .subcommand_matches(CMD_EDIT)
-                .unwrap()
                 .values_of_os(DIRECTORY_OR_FILES)
                 .map(|mut values| values.next())
             {
@@ -90,11 +84,8 @@ fn main() -> io::Result<()> {
             // Exit 0 if the editor exited normally
             Ok(0)
         }
-        Some(CMD_DOCS) => {
-            let maybe_values = matches
-                .subcommand_matches(CMD_DOCS)
-                .unwrap()
-                .values_of_os(DIRECTORY_OR_FILES);
+        Some((CMD_DOCS, matches)) => {
+            let maybe_values = matches.values_of_os(DIRECTORY_OR_FILES);
 
             let mut values: Vec<OsString> = Vec::new();
 
@@ -128,11 +119,8 @@ fn main() -> io::Result<()> {
 
             Ok(0)
         }
-        Some(CMD_FORMAT) => {
-            let maybe_values = matches
-                .subcommand_matches(CMD_FORMAT)
-                .unwrap()
-                .values_of_os(DIRECTORY_OR_FILES);
+        Some((CMD_FORMAT, matches)) => {
+            let maybe_values = matches.values_of_os(DIRECTORY_OR_FILES);
 
             let mut values: Vec<OsString> = Vec::new();
 
@@ -166,7 +154,7 @@ fn main() -> io::Result<()> {
 
             Ok(0)
         }
-        Some(CMD_VERSION) => {
+        Some((CMD_VERSION, _)) => {
             println!("roc {}", concatcp!(include_str!("../../version.txt"), "\n"));
 
             Ok(0)

--- a/linker/src/main.rs
+++ b/linker/src/main.rs
@@ -4,16 +4,10 @@ use std::io;
 fn main() -> io::Result<()> {
     let matches = build_app().get_matches();
 
-    let exit_code = match matches.subcommand_name() {
+    let exit_code = match matches.subcommand() {
         None => Ok::<i32, io::Error>(-1),
-        Some(CMD_PREPROCESS) => {
-            let sub_matches = matches.subcommand_matches(CMD_PREPROCESS).unwrap();
-            preprocess(sub_matches)
-        }
-        Some(CMD_SURGERY) => {
-            let sub_matches = matches.subcommand_matches(CMD_SURGERY).unwrap();
-            surgery(sub_matches)
-        }
+        Some((CMD_PREPROCESS, sub_matches)) => preprocess(sub_matches),
+        Some((CMD_SURGERY, sub_matches)) => surgery(sub_matches),
         _ => unreachable!(),
     }?;
     std::process::exit(exit_code);


### PR DESCRIPTION
Part of #2046.

Replace `subcommand_name() and subcommand_matches()` with a single `subcommand()` to avoid redundant `Option` unwraping.

We may want to wait for the 3.0.0 release of clap since the return value of `subcommand()` changed between 3.0.0-beta-1 and 3.0.0-beta-2, I'm not sure how stable the api is.