### PR TITLE
Make nightly distibution compatible with most CPUs

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -117,7 +117,7 @@ build-nightly-release:
     RUN git log --pretty=format:'%h' -n 1 >> version.txt
     RUN printf " on: " >> version.txt
     RUN date >> version.txt
-    RUN cargo build --features with_sound --release
+    RUN RUSTFLAGS="-C target-cpu=x86-64-v2" cargo build --features with_sound --release
     RUN cd ./target/release && tar -czvf roc_linux_x86_64.tar.gz ./roc ../../LICENSE ../../LEGAL_DETAILS ../../examples/hello-world ../../examples/hello-rust ../../examples/hello-zig ../../compiler/builtins/bitcode/src/ ../../roc_std
     SAVE ARTIFACT ./target/release/roc_linux_x86_64.tar.gz AS LOCAL roc_linux_x86_64.tar.gz
 


### PR DESCRIPTION
Some CPUs will encounter `Illegal instruction (core dumped)` with the current nightly release target-cpu.
Setting the target-cpu to x86-64-v2 will prevent this issue for most CPUs. x86-64-v2 was decided based on #2119 .
Some specialized instructions will not be used, resulting in a likely mild slowdown in execution of the roc binary.
The execution speed of roc programs and platforms should not be affected.