### PR TITLE
Set zig target cpu model for compatibility

### DIFF
--- a/compiler/builtins/bitcode/build.zig
+++ b/compiler/builtins/bitcode/build.zig
@@ -24,8 +24,7 @@ pub fn build(b: *Builder) void {
     // Targets
     const host_target = b.standardTargetOptions(.{
         .default_target = CrossTarget{
-            .cpu_arch = Arch.x86_64,
-            .cpu_model = .{ .explicit = &std.Target.x86.cpu.x86_64_v2 }, // x86_64_v2 is in sync with Earthfile > RUSTFLAGS="-C target-cpu=x86-64-v2"
+            .cpu_model = .baseline,
             // TODO allow for native target for maximum speed
         }
     });


### PR DESCRIPTION
Until we settle on how to arrange native compilation, I propose we set things up for maximal compatibility.