### PR TITLE
Keep indent state in new fmt::Buf struct

### DIFF
--- a/cli/src/format.rs
+++ b/cli/src/format.rs
@@ -1,9 +1,10 @@
 use std::path::PathBuf;
 
-use bumpalo::collections::{String, Vec};
+use bumpalo::collections::Vec;
 use bumpalo::Bump;
 use roc_fmt::def::fmt_def;
 use roc_fmt::module::fmt_module;
+use roc_fmt::Buf;
 use roc_module::called_via::{BinOp, UnaryOp};
 use roc_parse::ast::{
     AssignedField, Collection, Expr, Pattern, StrLiteral, StrSegment, Tag, TypeAnnotation,
@@ -30,13 +31,13 @@ pub fn format(files: std::vec::Vec<PathBuf>) {
         let ast = arena.alloc(parse_all(&arena, &src).unwrap_or_else(|e| {
             user_error!("Unexpected parse failure when parsing this formatting:\n\n{:?}\n\nParse error was:\n\n{:?}\n\n", src, e)
         }));
-        let mut buf = String::new_in(&arena);
+        let mut buf = Buf::new_in(&arena);
         fmt_all(&arena, &mut buf, ast);
 
-        let reparsed_ast = arena.alloc(parse_all(&arena, &buf).unwrap_or_else(|e| {
+        let reparsed_ast = arena.alloc(parse_all(&arena, buf.as_str()).unwrap_or_else(|e| {
             let mut fail_file = file.clone();
             fail_file.set_extension("roc-format-failed");
-            std::fs::write(&fail_file, &buf).unwrap();
+            std::fs::write(&fail_file, buf.as_str()).unwrap();
             internal_error!(
                 "Formatting bug; formatted code isn't valid\n\n\
                 I wrote the incorrect result to this file for debugging purposes:\n{}\n\n\
@@ -57,7 +58,7 @@ pub fn format(files: std::vec::Vec<PathBuf>) {
         if format!("{:?}", ast_normalized) != format!("{:?}", reparsed_ast_normalized) {
             let mut fail_file = file.clone();
             fail_file.set_extension("roc-format-failed");
-            std::fs::write(&fail_file, &buf).unwrap();
+            std::fs::write(&fail_file, buf.as_str()).unwrap();
 
             let mut before_file = file.clone();
             before_file.set_extension("roc-format-failed-ast-before");
@@ -77,16 +78,16 @@ pub fn format(files: std::vec::Vec<PathBuf>) {
         }
 
         // Now verify that the resultant formatting is _stable_ - i.e. that it doesn't change again if re-formatted
-        let mut reformatted_buf = String::new_in(&arena);
+        let mut reformatted_buf = Buf::new_in(&arena);
         fmt_all(&arena, &mut reformatted_buf, reparsed_ast);
         if buf.as_str() != reformatted_buf.as_str() {
             let mut unstable_1_file = file.clone();
             unstable_1_file.set_extension("roc-format-unstable-1");
-            std::fs::write(&unstable_1_file, &buf).unwrap();
+            std::fs::write(&unstable_1_file, buf.as_str()).unwrap();
 
             let mut unstable_2_file = file.clone();
             unstable_2_file.set_extension("roc-format-unstable-2");
-            std::fs::write(&unstable_2_file, &reformatted_buf).unwrap();
+            std::fs::write(&unstable_2_file, reformatted_buf.as_str()).unwrap();
 
             internal_error!(
                 "Formatting bug; formatting is not stable. Reformatting the formatted file changed it again.\n\n\
@@ -97,7 +98,7 @@ pub fn format(files: std::vec::Vec<PathBuf>) {
         }
 
         // If all the checks above passed, actually write out the new file.
-        std::fs::write(&file, &buf).unwrap();
+        std::fs::write(&file, buf.as_str()).unwrap();
     }
 }
 
@@ -116,7 +117,7 @@ fn parse_all<'a>(arena: &'a Bump, src: &'a str) -> Result<Ast<'a>, SyntaxError<'
     Ok(Ast { module, defs })
 }
 
-fn fmt_all<'a>(arena: &'a Bump, buf: &mut String<'a>, ast: &'a Ast) {
+fn fmt_all<'a>(arena: &'a Bump, buf: &mut Buf<'a>, ast: &'a Ast) {
     fmt_module(buf, &ast.module);
     for def in &ast.defs {
         fmt_def(buf, arena.alloc(def.value), 0);

--- a/cli/src/repl/gen.rs
+++ b/cli/src/repl/gen.rs
@@ -238,7 +238,7 @@ pub fn gen_and_eval<'a>(
                 ptr_bytes,
             )
         };
-        let mut expr = bumpalo::collections::String::new_in(&arena);
+        let mut expr = roc_fmt::Buf::new_in(&arena);
 
         use eval::ToAstProblem::*;
         match res_answer {

--- a/compiler/fmt/src/collection.rs
+++ b/compiler/fmt/src/collection.rs
@@ -1,9 +1,9 @@
-use bumpalo::collections::String;
 use roc_parse::ast::Collection;
 
 use crate::{
     annotation::{Formattable, Newlines, Parens},
-    spaces::{fmt_comments_only, newline, NewlineAt, INDENT},
+    spaces::{fmt_comments_only, NewlineAt, INDENT},
+    Buf,
 };
 
 pub struct CollectionConfig {
@@ -13,25 +13,26 @@ pub struct CollectionConfig {
 }
 
 pub fn fmt_collection<'a, F: Formattable<'a>>(
-    buf: &mut String<'a>,
+    buf: &mut Buf<'a>,
     items: Collection<'_, F>,
     indent: u16,
     config: CollectionConfig,
 ) {
     let loc_items = items.items;
     let final_comments = items.final_comments();
+    buf.indent(indent);
     buf.push(config.begin);
     if !loc_items.is_empty() || !final_comments.iter().all(|c| c.is_newline()) {
         let is_multiline = loc_items.iter().any(|item| item.is_multiline());
         if is_multiline {
             let item_indent = indent + INDENT;
             for item in loc_items.iter() {
-                newline(buf, item_indent);
+                buf.newline();
                 item.format_with_options(buf, Parens::NotNeeded, Newlines::Yes, item_indent);
                 buf.push(config.delimiter);
             }
             fmt_comments_only(buf, final_comments.iter(), NewlineAt::Top, item_indent);
-            newline(buf, indent);
+            buf.newline();
         } else {
             // is_multiline == false
             let mut iter = loc_items.iter().peekable();
@@ -42,8 +43,10 @@ pub fn fmt_collection<'a, F: Formattable<'a>>(
                     buf.push(config.delimiter);
                 }
             }
+            buf.indent(indent);
             buf.push(' ');
         }
     }
+    buf.indent(indent);
     buf.push(config.end);
 }

--- a/compiler/fmt/src/lib.rs
+++ b/compiler/fmt/src/lib.rs
@@ -8,3 +8,53 @@ pub mod expr;
 pub mod module;
 pub mod pattern;
 pub mod spaces;
+
+use bumpalo::{collections::String, Bump};
+
+pub struct Buf<'a> {
+    text: String<'a>,
+    beginning_of_line: bool,
+}
+
+impl<'a> Buf<'a> {
+    pub fn new_in(arena: &'a Bump) -> Buf<'a> {
+        Buf {
+            text: String::new_in(arena),
+            beginning_of_line: true,
+        }
+    }
+
+    pub fn as_str(&'a self) -> &'a str {
+        self.text.as_str()
+    }
+
+    pub fn into_bump_str(self) -> &'a str {
+        self.text.into_bump_str()
+    }
+
+    pub fn indent(&mut self, indent: u16) {
+        if self.beginning_of_line {
+            for _ in 0..indent {
+                self.text.push(' ');
+            }
+        }
+        self.beginning_of_line = false;
+    }
+
+    pub fn push(&mut self, ch: char) {
+        debug_assert!(!self.beginning_of_line);
+        debug_assert!(ch != '\n');
+        self.text.push(ch);
+    }
+
+    pub fn push_str(&mut self, s: &str) {
+        debug_assert!(!self.beginning_of_line);
+        debug_assert!(!s.contains('\n'));
+        self.text.push_str(s);
+    }
+
+    pub fn newline(&mut self) {
+        self.text.push('\n');
+        self.beginning_of_line = true;
+    }
+}

--- a/compiler/fmt/src/module.rs
+++ b/compiler/fmt/src/module.rs
@@ -2,7 +2,7 @@ use crate::annotation::Formattable;
 use crate::collection::{fmt_collection, CollectionConfig};
 use crate::expr::fmt_str_literal;
 use crate::spaces::{fmt_default_spaces, fmt_spaces, INDENT};
-use bumpalo::collections::String;
+use crate::Buf;
 use roc_parse::ast::{Collection, Module};
 use roc_parse::header::{
     AppHeader, Effects, ExposesEntry, ImportsEntry, InterfaceHeader, ModuleName, PackageEntry,
@@ -10,7 +10,7 @@ use roc_parse::header::{
 };
 use roc_region::all::Located;
 
-pub fn fmt_module<'a>(buf: &mut String<'a>, module: &'a Module<'a>) {
+pub fn fmt_module<'a>(buf: &mut Buf<'a>, module: &'a Module<'a>) {
     match module {
         Module::Interface { header } => {
             fmt_interface_header(buf, header);
@@ -24,9 +24,10 @@ pub fn fmt_module<'a>(buf: &mut String<'a>, module: &'a Module<'a>) {
     }
 }
 
-pub fn fmt_interface_header<'a>(buf: &mut String<'a>, header: &'a InterfaceHeader<'a>) {
+pub fn fmt_interface_header<'a>(buf: &mut Buf<'a>, header: &'a InterfaceHeader<'a>) {
     let indent = INDENT;
 
+    buf.indent(0);
     buf.push_str("interface");
 
     // module name
@@ -35,20 +36,22 @@ pub fn fmt_interface_header<'a>(buf: &mut String<'a>, header: &'a InterfaceHeade
 
     // exposes
     fmt_default_spaces(buf, header.before_exposes, " ", indent);
+    buf.indent(indent);
     buf.push_str("exposes");
     fmt_default_spaces(buf, header.after_exposes, " ", indent);
     fmt_exposes(buf, header.exposes, indent);
 
     // imports
     fmt_default_spaces(buf, header.before_imports, " ", indent);
+    buf.indent(indent);
     buf.push_str("imports");
     fmt_default_spaces(buf, header.after_imports, " ", indent);
     fmt_imports(buf, header.imports, indent);
 }
 
-pub fn fmt_app_header<'a>(buf: &mut String<'a>, header: &'a AppHeader<'a>) {
+pub fn fmt_app_header<'a>(buf: &mut Buf<'a>, header: &'a AppHeader<'a>) {
     let indent = INDENT;
-
+    buf.indent(0);
     buf.push_str("app");
 
     fmt_default_spaces(buf, header.after_app_keyword, " ", indent);
@@ -56,30 +59,35 @@ pub fn fmt_app_header<'a>(buf: &mut String<'a>, header: &'a AppHeader<'a>) {
 
     // packages
     fmt_default_spaces(buf, header.before_packages, " ", indent);
+    buf.indent(indent);
     buf.push_str("packages");
     fmt_default_spaces(buf, header.after_packages, " ", indent);
     fmt_packages(buf, header.packages, indent);
 
     // imports
     fmt_default_spaces(buf, header.before_imports, " ", indent);
+    buf.indent(indent);
     buf.push_str("imports");
     fmt_default_spaces(buf, header.after_imports, " ", indent);
     fmt_imports(buf, header.imports, indent);
 
     // provides
     fmt_default_spaces(buf, header.before_provides, " ", indent);
+    buf.indent(indent);
     buf.push_str("provides");
     fmt_default_spaces(buf, header.after_provides, " ", indent);
     fmt_provides(buf, header.provides, indent);
     fmt_default_spaces(buf, header.before_to, " ", indent);
+    buf.indent(indent);
     buf.push_str("to");
     fmt_default_spaces(buf, header.after_to, " ", indent);
     fmt_to(buf, header.to.value, indent);
 }
 
-pub fn fmt_platform_header<'a>(buf: &mut String<'a>, header: &'a PlatformHeader<'a>) {
+pub fn fmt_platform_header<'a>(buf: &mut Buf<'a>, header: &'a PlatformHeader<'a>) {
     let indent = INDENT;
 
+    buf.indent(0);
     buf.push_str("platform");
 
     fmt_default_spaces(buf, header.after_platform_keyword, " ", indent);
@@ -87,30 +95,35 @@ pub fn fmt_platform_header<'a>(buf: &mut String<'a>, header: &'a PlatformHeader<
 
     // requires
     fmt_default_spaces(buf, header.before_requires, " ", indent);
+    buf.indent(indent);
     buf.push_str("requires");
     fmt_default_spaces(buf, header.after_requires, " ", indent);
     fmt_requires(buf, &header.requires, indent);
 
     // exposes
     fmt_default_spaces(buf, header.before_exposes, " ", indent);
+    buf.indent(indent);
     buf.push_str("exposes");
     fmt_default_spaces(buf, header.after_exposes, " ", indent);
     fmt_exposes(buf, header.exposes, indent);
 
     // packages
     fmt_default_spaces(buf, header.before_packages, " ", indent);
+    buf.indent(indent);
     buf.push_str("packages");
     fmt_default_spaces(buf, header.after_packages, " ", indent);
     fmt_packages(buf, header.packages, indent);
 
     // imports
     fmt_default_spaces(buf, header.before_imports, " ", indent);
+    buf.indent(indent);
     buf.push_str("imports");
     fmt_default_spaces(buf, header.after_imports, " ", indent);
     fmt_imports(buf, header.imports, indent);
 
     // provides
     fmt_default_spaces(buf, header.before_provides, " ", indent);
+    buf.indent(indent);
     buf.push_str("provides");
     fmt_default_spaces(buf, header.after_provides, " ", indent);
     fmt_provides(buf, header.provides, indent);
@@ -118,7 +131,7 @@ pub fn fmt_platform_header<'a>(buf: &mut String<'a>, header: &'a PlatformHeader<
     fmt_effects(buf, &header.effects, indent);
 }
 
-fn fmt_requires<'a>(buf: &mut String<'a>, requires: &PlatformRequires<'a>, indent: u16) {
+fn fmt_requires<'a>(buf: &mut Buf<'a>, requires: &PlatformRequires<'a>, indent: u16) {
     fmt_collection(
         buf,
         requires.rigids,
@@ -135,11 +148,13 @@ fn fmt_requires<'a>(buf: &mut String<'a>, requires: &PlatformRequires<'a>, inden
     buf.push_str(" }");
 }
 
-fn fmt_effects<'a>(buf: &mut String<'a>, effects: &Effects<'a>, indent: u16) {
+fn fmt_effects<'a>(buf: &mut Buf<'a>, effects: &Effects<'a>, indent: u16) {
     fmt_default_spaces(buf, effects.spaces_before_effects_keyword, " ", indent);
+    buf.indent(indent);
     buf.push_str("effects");
     fmt_default_spaces(buf, effects.spaces_after_effects_keyword, " ", indent);
 
+    buf.indent(indent);
     buf.push_str(effects.effect_shortname);
     buf.push('.');
     buf.push_str(effects.effect_type_name);
@@ -158,7 +173,7 @@ fn fmt_effects<'a>(buf: &mut String<'a>, effects: &Effects<'a>, indent: u16) {
     );
 }
 
-fn fmt_typed_ident<'a>(buf: &mut String<'a>, entry: &TypedIdent<'a>, indent: u16) {
+fn fmt_typed_ident<'a>(buf: &mut Buf<'a>, entry: &TypedIdent<'a>, indent: u16) {
     use TypedIdent::*;
     match entry {
         Entry {
@@ -166,6 +181,7 @@ fn fmt_typed_ident<'a>(buf: &mut String<'a>, entry: &TypedIdent<'a>, indent: u16
             spaces_before_colon,
             ann,
         } => {
+            buf.indent(indent);
             buf.push_str(ident.value);
             fmt_default_spaces(buf, spaces_before_colon, " ", indent);
             buf.push(':');
@@ -187,7 +203,7 @@ impl<'a> Formattable<'a> for TypedIdent<'a> {
         false
     }
 
-    fn format(&self, buf: &mut String<'a>, indent: u16) {
+    fn format(&self, buf: &mut Buf<'a>, indent: u16) {
         fmt_typed_ident(buf, self, indent);
     }
 }
@@ -197,18 +213,18 @@ impl<'a> Formattable<'a> for PlatformRigid<'a> {
         false
     }
 
-    fn format(&self, buf: &mut String<'a>, indent: u16) {
+    fn format(&self, buf: &mut Buf<'a>, indent: u16) {
         fmt_platform_rigid(buf, self, indent);
     }
 }
 
-fn fmt_package_name<'a>(buf: &mut String<'a>, name: PackageName) {
+fn fmt_package_name<'a>(buf: &mut Buf<'a>, name: PackageName) {
     buf.push_str(name.account);
     buf.push('/');
     buf.push_str(name.pkg);
 }
 
-fn fmt_platform_rigid<'a>(buf: &mut String<'a>, entry: &PlatformRigid<'a>, indent: u16) {
+fn fmt_platform_rigid<'a>(buf: &mut Buf<'a>, entry: &PlatformRigid<'a>, indent: u16) {
     use roc_parse::header::PlatformRigid::*;
 
     match entry {
@@ -230,7 +246,7 @@ fn fmt_platform_rigid<'a>(buf: &mut String<'a>, entry: &PlatformRigid<'a>, inden
 }
 
 fn fmt_imports<'a>(
-    buf: &mut String<'a>,
+    buf: &mut Buf<'a>,
     loc_entries: Collection<'a, Located<ImportsEntry<'a>>>,
     indent: u16,
 ) {
@@ -247,7 +263,7 @@ fn fmt_imports<'a>(
 }
 
 fn fmt_provides<'a>(
-    buf: &mut String<'a>,
+    buf: &mut Buf<'a>,
     loc_entries: Collection<'a, Located<ExposesEntry<'a, &'a str>>>,
     indent: u16,
 ) {
@@ -263,7 +279,7 @@ fn fmt_provides<'a>(
     );
 }
 
-fn fmt_to<'a>(buf: &mut String<'a>, to: To<'a>, indent: u16) {
+fn fmt_to<'a>(buf: &mut Buf<'a>, to: To<'a>, indent: u16) {
     match to {
         To::ExistingPackage(name) => {
             buf.push_str(name);
@@ -273,7 +289,7 @@ fn fmt_to<'a>(buf: &mut String<'a>, to: To<'a>, indent: u16) {
 }
 
 fn fmt_exposes<'a, N: FormatName + 'a>(
-    buf: &mut String<'a>,
+    buf: &mut Buf<'a>,
     loc_entries: Collection<'_, Located<ExposesEntry<'_, N>>>,
     indent: u16,
 ) {
@@ -294,29 +310,29 @@ impl<'a, 'b, N: FormatName> Formattable<'a> for ExposesEntry<'b, N> {
         false
     }
 
-    fn format(&self, buf: &mut String<'a>, indent: u16) {
+    fn format(&self, buf: &mut Buf<'a>, indent: u16) {
         fmt_exposes_entry(buf, self, indent);
     }
 }
 
 pub trait FormatName {
-    fn format<'a>(&self, buf: &mut String<'a>);
+    fn format<'a>(&self, buf: &mut Buf<'a>);
 }
 
 impl<'a> FormatName for &'a str {
-    fn format<'b>(&self, buf: &mut String<'b>) {
+    fn format<'b>(&self, buf: &mut Buf<'b>) {
         buf.push_str(self)
     }
 }
 
 impl<'a> FormatName for ModuleName<'a> {
-    fn format<'b>(&self, buf: &mut String<'b>) {
+    fn format<'b>(&self, buf: &mut Buf<'b>) {
         buf.push_str(self.as_str());
     }
 }
 
 fn fmt_exposes_entry<'a, 'b, N: FormatName>(
-    buf: &mut String<'a>,
+    buf: &mut Buf<'a>,
     entry: &ExposesEntry<'b, N>,
     indent: u16,
 ) {
@@ -337,7 +353,7 @@ fn fmt_exposes_entry<'a, 'b, N: FormatName>(
 }
 
 fn fmt_packages<'a>(
-    buf: &mut String<'a>,
+    buf: &mut Buf<'a>,
     loc_entries: Collection<'a, Located<PackageEntry<'a>>>,
     indent: u16,
 ) {
@@ -358,7 +374,7 @@ impl<'a> Formattable<'a> for PackageEntry<'a> {
         false
     }
 
-    fn format(&self, buf: &mut String<'a>, indent: u16) {
+    fn format(&self, buf: &mut Buf<'a>, indent: u16) {
         fmt_packages_entry(buf, self, indent);
     }
 }
@@ -368,11 +384,11 @@ impl<'a> Formattable<'a> for ImportsEntry<'a> {
         false
     }
 
-    fn format(&self, buf: &mut String<'a>, indent: u16) {
+    fn format(&self, buf: &mut Buf<'a>, indent: u16) {
         fmt_imports_entry(buf, self, indent);
     }
 }
-fn fmt_packages_entry<'a>(buf: &mut String<'a>, entry: &PackageEntry<'a>, indent: u16) {
+fn fmt_packages_entry<'a>(buf: &mut Buf<'a>, entry: &PackageEntry<'a>, indent: u16) {
     use PackageEntry::*;
     match entry {
         Entry {
@@ -396,7 +412,7 @@ fn fmt_packages_entry<'a>(buf: &mut String<'a>, entry: &PackageEntry<'a>, indent
     }
 }
 
-fn fmt_package_or_path<'a>(buf: &mut String<'a>, package_or_path: &PackageOrPath<'a>, indent: u16) {
+fn fmt_package_or_path<'a>(buf: &mut Buf<'a>, package_or_path: &PackageOrPath<'a>, indent: u16) {
     match package_or_path {
         PackageOrPath::Package(_name, _version) => {
             todo!("format package");
@@ -405,7 +421,7 @@ fn fmt_package_or_path<'a>(buf: &mut String<'a>, package_or_path: &PackageOrPath
     }
 }
 
-fn fmt_imports_entry<'a>(buf: &mut String<'a>, entry: &ImportsEntry<'a>, indent: u16) {
+fn fmt_imports_entry<'a>(buf: &mut Buf<'a>, entry: &ImportsEntry<'a>, indent: u16) {
     use roc_parse::header::ImportsEntry::*;
 
     match entry {

--- a/compiler/fmt/tests/test_fmt.rs
+++ b/compiler/fmt/tests/test_fmt.rs
@@ -10,6 +10,7 @@ mod test_fmt {
     use roc_fmt::annotation::{Formattable, Newlines, Parens};
     use roc_fmt::def::fmt_def;
     use roc_fmt::module::fmt_module;
+    use roc_fmt::Buf;
     use roc_parse::module::{self, module_defs};
     use roc_parse::parser::{Parser, State};
     use roc_test_utils::assert_multiline_str_eq;
@@ -19,7 +20,7 @@ mod test_fmt {
         let arena = Bump::new();
         match roc_parse::test_helpers::parse_expr_with(&arena, input.trim()) {
             Ok(actual) => {
-                let mut buf = String::new_in(&arena);
+                let mut buf = Buf::new_in(&arena);
 
                 actual.format_with_options(&mut buf, Parens::NotNeeded, Newlines::Yes, 0);
 
@@ -52,7 +53,7 @@ mod test_fmt {
 
         match module::parse_header(&arena, State::new(src.as_bytes())) {
             Ok((actual, state)) => {
-                let mut buf = String::new_in(&arena);
+                let mut buf = Buf::new_in(&arena);
 
                 fmt_module(&mut buf, &actual);
 
@@ -2697,6 +2698,21 @@ mod test_fmt {
     }
 
     #[test]
+    fn multiline_tag_union_annotation_beginning_on_same_line() {
+        expr_formats_same(indoc!(
+            r#"
+            Expr  : [
+                    Add Expr Expr,
+                    Mul Expr Expr,
+                    Val I64,
+                    Var I64,
+                ]
+
+            Expr"#
+        ));
+    }
+
+    #[test]
     fn multiline_tag_union_annotation_with_final_comment() {
         expr_formats_to(
             indoc!(
@@ -2873,12 +2889,13 @@ mod test_fmt {
         expr_formats_same(indoc!(
             r#"
             Task.fromResult
-                (a, b <- binaryOp ctx
+                (
+                    a, b <- binaryOp ctx
                     if a == b then
                         -1
                     else
                         0
-                    )
+                )
             "#
         ));
     }


### PR DESCRIPTION
As described in this comment: https://github.com/rtfeldman/roc/pull/2114#discussion_r760666300, this should give better control over how things are indented - since the _code on the line in question_ can decide its own indentation, rather than letting that be decided when the previous newline was added to the buffer, which might have been a long ways away in the code.

Having `Buf` store a little extra state is perhaps not in keeping fully with the _mostly_ functional nature of the existing fmt code, but I think this strategy is preferable over essentially using an explicit "state monad" (i.e. threading this thru args and return values). Because of the enforced no-shared-mutable guarantee in Rust, we get the same benefits as the functional version would, from an understandably perspective, while also eliminating the possibility that some function might return a stale or otherwise incorrect state (a bug that could be very subtle & hard to detect+debug).

Note that this is not a full fix for #2123. This allows us to indent the delimiters as described in that issue, but still relies on SpaceBefore / SpaceAfter being present to provide the newlines.