### PR TITLE
set cpu-target for maximal compatibility

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -117,7 +117,7 @@ build-nightly-release:
     RUN git log --pretty=format:'%h' -n 1 >> version.txt
     RUN printf " on: " >> version.txt
     RUN date >> version.txt
-    RUN RUSTFLAGS="-C target-cpu=x86-64-v2" cargo build --features with_sound --release
+    RUN RUSTFLAGS="-C target-cpu=x86-64" cargo build --features with_sound --release
     RUN cd ./target/release && tar -czvf roc_linux_x86_64.tar.gz ./roc ../../LICENSE ../../LEGAL_DETAILS ../../examples/hello-world ../../examples/hello-rust ../../examples/hello-zig ../../compiler/builtins/bitcode/src/ ../../roc_std
     SAVE ARTIFACT ./target/release/roc_linux_x86_64.tar.gz AS LOCAL roc_linux_x86_64.tar.gz
 


### PR DESCRIPTION
Issues with virtual machines inside windows require us to use the most basic CPU instructions.

Not doing this will lead to `Illegal instruction (core dumped)` when executing for example `Num.toStr 5` inside the repl.