### PR TITLE
Unify all collection formatting with fmt_collection

### DIFF
--- a/compiler/fmt/src/collection.rs
+++ b/compiler/fmt/src/collection.rs
@@ -1,52 +1,74 @@
-use roc_parse::ast::Collection;
+use roc_parse::ast::{Collection, ExtractSpaces};
 
 use crate::{
-    annotation::{Formattable, Newlines, Parens},
+    annotation::{Formattable, Newlines},
     spaces::{fmt_comments_only, NewlineAt, INDENT},
     Buf,
 };
 
-pub struct CollectionConfig {
-    pub begin: char,
-    pub end: char,
-    pub delimiter: char,
-}
-
-pub fn fmt_collection<'a, F: Formattable<'a>>(
-    buf: &mut Buf<'a>,
-    items: Collection<'_, F>,
+pub fn fmt_collection<'a, 'b, T: ExtractSpaces<'a> + Formattable<'b>>(
+    buf: &mut Buf<'b>,
     indent: u16,
-    config: CollectionConfig,
-) {
-    let loc_items = items.items;
-    let final_comments = items.final_comments();
+    start: char,
+    end: char,
+    items: Collection<'a, T>,
+    newline: Newlines,
+) where
+    <T as ExtractSpaces<'a>>::Item: Formattable<'b>,
+{
     buf.indent(indent);
-    buf.push(config.begin);
-    if !loc_items.is_empty() || !final_comments.iter().all(|c| c.is_newline()) {
-        let is_multiline = loc_items.iter().any(|item| item.is_multiline());
-        if is_multiline {
-            let item_indent = indent + INDENT;
-            for item in loc_items.iter() {
-                buf.newline();
-                item.format_with_options(buf, Parens::NotNeeded, Newlines::Yes, item_indent);
-                buf.push(config.delimiter);
-            }
-            fmt_comments_only(buf, final_comments.iter(), NewlineAt::Top, item_indent);
+    let is_multiline =
+        items.iter().any(|item| item.is_multiline()) || !items.final_comments().is_empty();
+
+    if is_multiline {
+        let braces_indent = indent;
+        let item_indent = braces_indent + INDENT;
+        if newline == Newlines::Yes {
             buf.newline();
-        } else {
-            // is_multiline == false
-            let mut iter = loc_items.iter().peekable();
-            while let Some(item) = iter.next() {
-                buf.push(' ');
-                item.format_with_options(buf, Parens::NotNeeded, Newlines::Yes, indent);
-                if iter.peek().is_some() {
-                    buf.push(config.delimiter);
-                }
+        }
+        buf.indent(braces_indent);
+        buf.push(start);
+
+        for item in items.iter() {
+            let item = item.extract_spaces();
+
+            buf.newline();
+            if !item.before.is_empty() {
+                fmt_comments_only(buf, item.before.iter(), NewlineAt::Bottom, item_indent);
             }
-            buf.indent(indent);
+
+            item.item.format(buf, item_indent);
+
+            buf.push(',');
+
+            if !item.after.is_empty() {
+                fmt_comments_only(buf, item.after.iter(), NewlineAt::Top, item_indent);
+            }
+        }
+        fmt_comments_only(
+            buf,
+            items.final_comments().iter(),
+            NewlineAt::Top,
+            item_indent,
+        );
+        buf.newline();
+        buf.indent(braces_indent);
+    } else {
+        // is_multiline == false
+        // there is no comment to add
+        buf.push(start);
+        let mut iter = items.iter().peekable();
+        while let Some(item) = iter.next() {
+            buf.push(' ');
+            item.format(buf, indent);
+            if iter.peek().is_some() {
+                buf.push(',');
+            }
+        }
+
+        if !items.is_empty() {
             buf.push(' ');
         }
     }
-    buf.indent(indent);
-    buf.push(config.end);
+    buf.push(end);
 }

--- a/compiler/fmt/src/module.rs
+++ b/compiler/fmt/src/module.rs
@@ -1,5 +1,5 @@
-use crate::annotation::Formattable;
-use crate::collection::{fmt_collection, CollectionConfig};
+use crate::annotation::{Formattable, Newlines};
+use crate::collection::fmt_collection;
 use crate::expr::fmt_str_literal;
 use crate::spaces::{fmt_default_spaces, fmt_spaces, INDENT};
 use crate::Buf;
@@ -132,16 +132,7 @@ pub fn fmt_platform_header<'a>(buf: &mut Buf<'a>, header: &'a PlatformHeader<'a>
 }
 
 fn fmt_requires<'a>(buf: &mut Buf<'a>, requires: &PlatformRequires<'a>, indent: u16) {
-    fmt_collection(
-        buf,
-        requires.rigids,
-        indent,
-        CollectionConfig {
-            begin: '{',
-            end: '}',
-            delimiter: ',',
-        },
-    );
+    fmt_collection(buf, indent, '{', '}', requires.rigids, Newlines::No);
 
     buf.push_str(" { ");
     fmt_typed_ident(buf, &requires.signature.value, indent);
@@ -161,16 +152,7 @@ fn fmt_effects<'a>(buf: &mut Buf<'a>, effects: &Effects<'a>, indent: u16) {
 
     fmt_default_spaces(buf, effects.spaces_after_type_name, " ", indent);
 
-    fmt_collection(
-        buf,
-        effects.entries,
-        indent,
-        CollectionConfig {
-            begin: '{',
-            end: '}',
-            delimiter: ',',
-        },
-    );
+    fmt_collection(buf, indent, '{', '}', effects.entries, Newlines::No)
 }
 
 fn fmt_typed_ident<'a>(buf: &mut Buf<'a>, entry: &TypedIdent<'a>, indent: u16) {
@@ -250,16 +232,7 @@ fn fmt_imports<'a>(
     loc_entries: Collection<'a, Located<ImportsEntry<'a>>>,
     indent: u16,
 ) {
-    fmt_collection(
-        buf,
-        loc_entries,
-        indent,
-        CollectionConfig {
-            begin: '[',
-            end: ']',
-            delimiter: ',',
-        },
-    );
+    fmt_collection(buf, indent, '[', ']', loc_entries, Newlines::No)
 }
 
 fn fmt_provides<'a>(
@@ -267,16 +240,7 @@ fn fmt_provides<'a>(
     loc_entries: Collection<'a, Located<ExposesEntry<'a, &'a str>>>,
     indent: u16,
 ) {
-    fmt_collection(
-        buf,
-        loc_entries,
-        indent,
-        CollectionConfig {
-            begin: '[',
-            end: ']',
-            delimiter: ',',
-        },
-    );
+    fmt_collection(buf, indent, '[', ']', loc_entries, Newlines::No)
 }
 
 fn fmt_to<'a>(buf: &mut Buf<'a>, to: To<'a>, indent: u16) {
@@ -288,21 +252,12 @@ fn fmt_to<'a>(buf: &mut Buf<'a>, to: To<'a>, indent: u16) {
     }
 }
 
-fn fmt_exposes<'a, N: FormatName + 'a>(
+fn fmt_exposes<'a, N: FormatName + Copy + 'a>(
     buf: &mut Buf<'a>,
     loc_entries: Collection<'_, Located<ExposesEntry<'_, N>>>,
     indent: u16,
 ) {
-    fmt_collection(
-        buf,
-        loc_entries,
-        indent,
-        CollectionConfig {
-            begin: '[',
-            end: ']',
-            delimiter: ',',
-        },
-    );
+    fmt_collection(buf, indent, '[', ']', loc_entries, Newlines::No)
 }
 
 impl<'a, 'b, N: FormatName> Formattable<'a> for ExposesEntry<'b, N> {
@@ -357,16 +312,7 @@ fn fmt_packages<'a>(
     loc_entries: Collection<'a, Located<PackageEntry<'a>>>,
     indent: u16,
 ) {
-    fmt_collection(
-        buf,
-        loc_entries,
-        indent,
-        CollectionConfig {
-            begin: '{',
-            end: '}',
-            delimiter: ',',
-        },
-    );
+    fmt_collection(buf, indent, '{', '}', loc_entries, Newlines::No)
 }
 
 impl<'a> Formattable<'a> for PackageEntry<'a> {
@@ -431,16 +377,7 @@ fn fmt_imports_entry<'a>(buf: &mut Buf<'a>, entry: &ImportsEntry<'a>, indent: u1
             if !loc_exposes_entries.is_empty() {
                 buf.push('.');
 
-                fmt_collection(
-                    buf,
-                    *loc_exposes_entries,
-                    indent,
-                    CollectionConfig {
-                        begin: '{',
-                        end: '}',
-                        delimiter: ',',
-                    },
-                );
+                fmt_collection(buf, indent, '{', '}', *loc_exposes_entries, Newlines::No)
             }
         }
 
@@ -452,16 +389,7 @@ fn fmt_imports_entry<'a>(buf: &mut Buf<'a>, entry: &ImportsEntry<'a>, indent: u1
             if !entries.is_empty() {
                 buf.push('.');
 
-                fmt_collection(
-                    buf,
-                    *entries,
-                    indent,
-                    CollectionConfig {
-                        begin: '{',
-                        end: '}',
-                        delimiter: ',',
-                    },
-                );
+                fmt_collection(buf, indent, '{', '}', *entries, Newlines::No)
             }
         }
 


### PR DESCRIPTION
This replaces `fmt_list` and `format_sequence!` with code that's functionally identical to `format_sequence!`, but that doesn't need to be a macro to work. Now all collections should be formatted uniformly (yay!).

This also introduces a `Spaces` struct and a corresponding `ExtractSpaces` trait, which serve to make the before/after spacing information available generically, regardless of the underlying enum type.

Fixes #546