### PR TITLE
update inkwell to ease the llvm13 transition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1670,13 +1670,13 @@ dependencies = [
 name = "inkwell"
 version = "0.1.0"
 dependencies = [
- "inkwell 0.1.0 (git+https://github.com/rtfeldman/inkwell?tag=llvm12-0.release8)",
+ "inkwell 0.1.0 (git+https://github.com/rtfeldman/inkwell?tag=llvm13-0.release1)",
 ]
 
 [[package]]
 name = "inkwell"
 version = "0.1.0"
-source = "git+https://github.com/rtfeldman/inkwell?tag=llvm12-0.release8#14b78d96d2dbc95694e181be66e4cd53df3fc02f"
+source = "git+https://github.com/rtfeldman/inkwell?tag=llvm13-0.release1#e15d665227b2acad4ca949820d80048e09f3f4e5"
 dependencies = [
  "either",
  "inkwell_internals",
@@ -1684,13 +1684,12 @@ dependencies = [
  "llvm-sys",
  "once_cell",
  "parking_lot",
- "regex",
 ]
 
 [[package]]
 name = "inkwell_internals"
-version = "0.3.0"
-source = "git+https://github.com/rtfeldman/inkwell?tag=llvm12-0.release8#14b78d96d2dbc95694e181be66e4cd53df3fc02f"
+version = "0.5.0"
+source = "git+https://github.com/rtfeldman/inkwell?tag=llvm13-0.release1#e15d665227b2acad4ca949820d80048e09f3f4e5"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/compiler/gen_llvm/src/llvm/build.rs
+++ b/compiler/gen_llvm/src/llvm/build.rs
@@ -39,11 +39,13 @@ use inkwell::debug_info::{
 use inkwell::memory_buffer::MemoryBuffer;
 use inkwell::module::{Linkage, Module};
 use inkwell::passes::{PassManager, PassManagerBuilder};
-use inkwell::types::{BasicType, BasicTypeEnum, FunctionType, IntType, StructType};
+use inkwell::types::{
+    BasicMetadataTypeEnum, BasicType, BasicTypeEnum, FunctionType, IntType, StructType,
+};
 use inkwell::values::BasicValueEnum::{self, *};
 use inkwell::values::{
-    BasicValue, CallSiteValue, CallableValue, FloatValue, FunctionValue, InstructionOpcode,
-    InstructionValue, IntValue, PointerValue, StructValue,
+    BasicMetadataValueEnum, BasicValue, CallSiteValue, CallableValue, FloatValue, FunctionValue,
+    InstructionOpcode, InstructionValue, IntValue, PointerValue, StructValue,
 };
 use inkwell::OptimizationLevel;
 use inkwell::{AddressSpace, IntPredicate};
@@ -226,10 +228,11 @@ impl<'a, 'ctx, 'env> Env<'a, 'ctx, 'env> {
             .get_function(intrinsic_name)
             .unwrap_or_else(|| panic!("Unrecognized intrinsic function: {}", intrinsic_name));
 
-        let mut arg_vals: Vec<BasicValueEnum> = Vec::with_capacity_in(args.len(), self.arena);
+        let mut arg_vals: Vec<BasicMetadataValueEnum> =
+            Vec::with_capacity_in(args.len(), self.arena);
 
         for arg in args.iter() {
-            arg_vals.push(*arg);
+            arg_vals.push((*arg).into());
         }
 
         let call = self
@@ -3287,7 +3290,9 @@ fn expose_function_to_host_help_c_abi_generic<'a, 'ctx, 'env>(
             let output_type = return_type.ptr_type(AddressSpace::Generic);
             argument_types.push(output_type.into());
 
-            env.context.void_type().fn_type(&argument_types, false)
+            env.context
+                .void_type()
+                .fn_type(&function_arguments(env, &argument_types), false)
         }
     };
 
@@ -3392,7 +3397,9 @@ fn expose_function_to_host_help_c_abi_gen_test<'a, 'ctx, 'env>(
     let c_function_type = {
         let output_type = return_type.ptr_type(AddressSpace::Generic);
         argument_types.push(output_type.into());
-        env.context.void_type().fn_type(&argument_types, false)
+        env.context
+            .void_type()
+            .fn_type(&function_arguments(env, &argument_types), false)
     };
 
     let c_function = add_func(
@@ -3536,12 +3543,17 @@ fn expose_function_to_host_help_c_abi<'a, 'ctx, 'env>(
     let cc_return = to_cc_return(env, &return_layout);
 
     let c_function_type = match cc_return {
-        CCReturn::Void => env.context.void_type().fn_type(&argument_types, false),
-        CCReturn::Return => return_type.fn_type(&argument_types, false),
+        CCReturn::Void => env
+            .context
+            .void_type()
+            .fn_type(&function_arguments(env, &argument_types), false),
+        CCReturn::Return => return_type.fn_type(&function_arguments(env, &argument_types), false),
         CCReturn::ByPointer => {
             let output_type = return_type.ptr_type(AddressSpace::Generic);
             argument_types.push(output_type.into());
-            env.context.void_type().fn_type(&argument_types, false)
+            env.context
+                .void_type()
+                .fn_type(&function_arguments(env, &argument_types), false)
         }
     };
 
@@ -3902,7 +3914,8 @@ fn make_exception_catching_wrapper<'a, 'ctx, 'env>(
     // argument_types.push(wrapper_return_type.ptr_type(AddressSpace::Generic).into());
 
     // let wrapper_function_type = env.context.void_type().fn_type(&argument_types, false);
-    let wrapper_function_type = wrapper_return_type.fn_type(&argument_types, false);
+    let wrapper_function_type =
+        wrapper_return_type.fn_type(&function_arguments(env, &argument_types), false);
 
     // Add main to the module.
     let wrapper_function = add_func(
@@ -4134,11 +4147,13 @@ fn build_proc_header<'a, 'ctx, 'env>(
     }
 
     let fn_type = match RocReturn::from_layout(env, &proc.ret_layout) {
-        RocReturn::Return => ret_type.fn_type(&arg_basic_types, false),
+        RocReturn::Return => ret_type.fn_type(&function_arguments(env, &arg_basic_types), false),
         RocReturn::ByPointer => {
             // println!( "{:?}  will return void instead of {:?}", symbol, proc.ret_layout);
             arg_basic_types.push(ret_type.ptr_type(AddressSpace::Generic).into());
-            env.context.void_type().fn_type(&arg_basic_types, false)
+            env.context
+                .void_type()
+                .fn_type(&function_arguments(env, &arg_basic_types), false)
         }
     };
 
@@ -4542,7 +4557,8 @@ pub fn call_roc_function<'a, 'ctx, 'env>(
     match RocReturn::from_layout(env, result_layout) {
         RocReturn::ByPointer if !pass_by_pointer => {
             // WARNING this is a hack!!
-            let mut arguments = Vec::from_iter_in(arguments.iter().copied(), env.arena);
+            let it = arguments.iter().map(|x| (*x).into());
+            let mut arguments = Vec::from_iter_in(it, env.arena);
             arguments.pop();
 
             let result_type = basic_type_from_layout(env, result_layout);
@@ -4563,7 +4579,8 @@ pub fn call_roc_function<'a, 'ctx, 'env>(
             env.builder.build_load(result_alloca, "load_result")
         }
         RocReturn::ByPointer => {
-            let mut arguments = Vec::from_iter_in(arguments.iter().copied(), env.arena);
+            let it = arguments.iter().map(|x| (*x).into());
+            let mut arguments = Vec::from_iter_in(it, env.arena);
 
             let result_type = basic_type_from_layout(env, result_layout);
             let result_alloca = tag_alloca(env, result_type, "result_value");
@@ -4592,7 +4609,10 @@ pub fn call_roc_function<'a, 'ctx, 'env>(
                 roc_function.get_type().get_param_types().len(),
                 arguments.len()
             );
-            let call = env.builder.build_call(roc_function, arguments, "call");
+            let it = arguments.iter().map(|x| (*x).into());
+            let arguments = Vec::from_iter_in(it, env.arena);
+
+            let call = env.builder.build_call(roc_function, &arguments, "call");
 
             // roc functions should have the fast calling convention
             debug_assert_eq!(roc_function.get_call_conventions(), FAST_CALL_CONV);
@@ -6135,6 +6155,14 @@ fn to_cc_return<'a, 'ctx, 'env>(env: &Env<'a, 'ctx, 'env>, layout: &Layout<'a>) 
     }
 }
 
+fn function_arguments<'a, 'ctx, 'env>(
+    env: &Env<'a, 'ctx, 'env>,
+    arguments: &[BasicTypeEnum<'ctx>],
+) -> Vec<'a, BasicMetadataTypeEnum<'ctx>> {
+    let it = arguments.iter().map(|x| (*x).into());
+    Vec::from_iter_in(it, env.arena)
+}
+
 fn build_foreign_symbol<'a, 'ctx, 'env>(
     env: &Env<'a, 'ctx, 'env>,
     scope: &mut Scope<'a, 'ctx>,
@@ -6189,17 +6217,25 @@ fn build_foreign_symbol<'a, 'ctx, 'env>(
             }
 
             let cc_type = match cc_return {
-                CCReturn::Void => env.context.void_type().fn_type(&cc_argument_types, false),
+                CCReturn::Void => env
+                    .context
+                    .void_type()
+                    .fn_type(&function_arguments(env, &cc_argument_types), false),
                 CCReturn::ByPointer => {
                     cc_argument_types.push(return_type.ptr_type(AddressSpace::Generic).into());
-                    env.context.void_type().fn_type(&cc_argument_types, false)
+                    env.context
+                        .void_type()
+                        .fn_type(&function_arguments(env, &cc_argument_types), false)
                 }
-                CCReturn::Return => return_type.fn_type(&cc_argument_types, false),
+                CCReturn::Return => {
+                    return_type.fn_type(&function_arguments(env, &cc_argument_types), false)
+                }
             };
 
             let cc_function = get_foreign_symbol(env, foreign.clone(), cc_type);
 
-            let fastcc_type = return_type.fn_type(&fastcc_argument_types, false);
+            let fastcc_type =
+                return_type.fn_type(&function_arguments(env, &fastcc_argument_types), false);
 
             let fastcc_function = add_func(
                 env.module,
@@ -6220,14 +6256,14 @@ fn build_foreign_symbol<'a, 'ctx, 'env>(
                 let mut cc_arguments =
                     Vec::with_capacity_in(fastcc_parameters.len() + 1, env.arena);
 
-                for (param, cc_type) in fastcc_parameters.into_iter().zip(cc_argument_types.iter())
-                {
+                let it = fastcc_parameters.into_iter().zip(cc_argument_types.iter());
+                for (param, cc_type) in it {
                     if param.get_type() == *cc_type {
-                        cc_arguments.push(param);
+                        cc_arguments.push(param.into());
                     } else {
                         let as_cc_type =
                             complex_bitcast(env.builder, param, *cc_type, "to_cc_type");
-                        cc_arguments.push(as_cc_type);
+                        cc_arguments.push(as_cc_type.into());
                     }
                 }
 

--- a/compiler/gen_llvm/src/llvm/build_hash.rs
+++ b/compiler/gen_llvm/src/llvm/build_hash.rs
@@ -346,7 +346,7 @@ fn build_hash_tag<'a, 'ctx, 'env>(
         .set_current_debug_location(env.context, di_location);
     let call = env
         .builder
-        .build_call(function, &[seed.into(), value], "struct_hash");
+        .build_call(function, &[seed.into(), value.into()], "struct_hash");
 
     call.set_call_convention(FAST_CALL_CONV);
 

--- a/compiler/gen_llvm/src/llvm/compare.rs
+++ b/compiler/gen_llvm/src/llvm/compare.rs
@@ -804,7 +804,9 @@ fn build_tag_eq<'a, 'ctx, 'env>(
     env.builder.position_at_end(block);
     env.builder
         .set_current_debug_location(env.context, di_location);
-    let call = env.builder.build_call(function, &[tag1, tag2], "tag_eq");
+    let call = env
+        .builder
+        .build_call(function, &[tag1.into(), tag2.into()], "tag_eq");
 
     call.set_call_convention(FAST_CALL_CONV);
 

--- a/compiler/gen_llvm/src/llvm/externs.rs
+++ b/compiler/gen_llvm/src/llvm/externs.rs
@@ -96,7 +96,7 @@ pub fn add_default_roc_externs(env: &Env<'_, '_, '_>) {
         // Call libc realloc()
         let call = builder.build_call(
             libc_realloc_val,
-            &[ptr_arg, new_size_arg],
+            &[ptr_arg.into(), new_size_arg.into()],
             "call_libc_realloc",
         );
 

--- a/compiler/gen_llvm/src/llvm/refcounting.rs
+++ b/compiler/gen_llvm/src/llvm/refcounting.rs
@@ -10,7 +10,7 @@ use bumpalo::collections::Vec;
 use inkwell::basic_block::BasicBlock;
 use inkwell::context::Context;
 use inkwell::module::Linkage;
-use inkwell::types::{AnyTypeEnum, BasicType, BasicTypeEnum};
+use inkwell::types::{AnyTypeEnum, BasicMetadataTypeEnum, BasicType, BasicTypeEnum};
 use inkwell::values::{
     BasicValue, BasicValueEnum, FunctionValue, IntValue, PointerValue, StructValue,
 };
@@ -567,9 +567,11 @@ fn call_help<'a, 'ctx, 'env>(
     let call = match call_mode {
         CallMode::Inc(inc_amount) => {
             env.builder
-                .build_call(function, &[value, inc_amount.into()], "increment")
+                .build_call(function, &[value.into(), inc_amount.into()], "increment")
         }
-        CallMode::Dec => env.builder.build_call(function, &[value], "decrement"),
+        CallMode::Dec => env
+            .builder
+            .build_call(function, &[value.into()], "decrement"),
     };
 
     call.set_call_convention(FAST_CALL_CONV);
@@ -1053,6 +1055,11 @@ pub fn build_header_help<'a, 'ctx, 'env>(
     arguments: &[BasicTypeEnum<'ctx>],
 ) -> FunctionValue<'ctx> {
     use inkwell::types::AnyTypeEnum::*;
+
+    let it = arguments.iter().map(|x| BasicMetadataTypeEnum::from(*x));
+    let vec = Vec::from_iter_in(it, env.arena);
+    let arguments = vec.as_slice();
+
     let fn_type = match return_type {
         ArrayType(t) => t.fn_type(arguments, false),
         FloatType(t) => t.fn_type(arguments, false),

--- a/vendor/inkwell/Cargo.toml
+++ b/vendor/inkwell/Cargo.toml
@@ -23,7 +23,7 @@ edition = "2018"
 # commit of TheDan64/inkwell, push a new tag which points to the latest commit,
 # change the tag value in this Cargo.toml to point to that tag, and `cargo update`.
 # This way, GitHub Actions works and nobody's builds get broken.
-inkwell = { git = "https://github.com/rtfeldman/inkwell", tag = "llvm12-0.release8", features = [ "llvm12-0" ] }
+inkwell = { git = "https://github.com/rtfeldman/inkwell", tag = "llvm13-0.release1", features = [ "llvm12-0" ] }
 
 [features]
 target-arm = []


### PR DESCRIPTION
Moves us to a version of inkwell that has llvm13 support, but we're still using llvm12 for the moment, until the new zig version is released