### PR TITLE
Remove Results from gen_wasm and use appropriate error macros

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3425,6 +3425,7 @@ dependencies = [
  "roc_collections",
  "roc_module",
  "roc_mono",
+ "roc_reporting",
  "roc_std",
 ]
 

--- a/compiler/gen_wasm/Cargo.toml
+++ b/compiler/gen_wasm/Cargo.toml
@@ -12,3 +12,4 @@ roc_collections = { path = "../collections" }
 roc_module = { path = "../module" }
 roc_mono = { path = "../mono" }
 roc_std = { path = "../../roc_std" }
+roc_reporting = { path = "../../reporting" }

--- a/compiler/gen_wasm/src/lib.rs
+++ b/compiler/gen_wasm/src/lib.rs
@@ -13,6 +13,7 @@ use roc_module::symbol::{Interns, ModuleId, Symbol};
 use roc_mono::gen_refcount::RefcountProcGenerator;
 use roc_mono::ir::{Proc, ProcLayout};
 use roc_mono::layout::LayoutIds;
+use roc_reporting::internal_error;
 
 use crate::backend::WasmBackend;
 use crate::wasm_module::{
@@ -106,7 +107,7 @@ pub fn build_module_help<'a>(
 
     // Generate procs from user code
     for proc in procs.iter() {
-        backend.build_proc(proc)?;
+        backend.build_proc(proc);
     }
 
     // Generate IR for refcounting procs
@@ -124,7 +125,7 @@ pub fn build_module_help<'a>(
 
     // Generate Wasm for refcounting procs
     for proc in refcount_procs.iter() {
-        backend.build_proc(proc)?;
+        backend.build_proc(proc);
     }
 
     let module = backend.finalize_module();
@@ -180,7 +181,7 @@ pub fn round_up_to_alignment(unaligned: i32, alignment_bytes: i32) -> i32 {
         return unaligned;
     }
     if alignment_bytes.count_ones() != 1 {
-        panic!(
+        internal_error!(
             "Cannot align to {} bytes. Not a power of 2.",
             alignment_bytes
         );
@@ -192,5 +193,5 @@ pub fn round_up_to_alignment(unaligned: i32, alignment_bytes: i32) -> i32 {
 }
 
 pub fn debug_panic<E: std::fmt::Debug>(error: E) {
-    panic!("{:?}", error);
+    internal_error!("{:?}", error);
 }

--- a/compiler/gen_wasm/src/low_level.rs
+++ b/compiler/gen_wasm/src/low_level.rs
@@ -1,6 +1,7 @@
 use roc_builtins::bitcode::{self, FloatWidth};
 use roc_module::low_level::{LowLevel, LowLevel::*};
 use roc_module::symbol::Symbol;
+use roc_reporting::internal_error;
 
 use crate::layout::{StackMemoryFormat::*, WasmLayout};
 use crate::storage::{Storage, StoredValue};
@@ -21,7 +22,8 @@ pub fn decode_low_level<'a>(
 ) -> LowlevelBuildResult {
     use LowlevelBuildResult::*;
 
-    let panic_ret_type = || panic!("Invalid return layout for {:?}: {:?}", lowlevel, ret_layout);
+    let panic_ret_type =
+        || internal_error!("Invalid return layout for {:?}: {:?}", lowlevel, ret_layout);
 
     match lowlevel {
         StrConcat => return BuiltinCall(bitcode::STR_CONCAT),
@@ -525,6 +527,6 @@ fn float_width_from_layout(wasm_layout: &WasmLayout) -> FloatWidth {
     match wasm_layout {
         WasmLayout::Primitive(F32, _) => FloatWidth::F32,
         WasmLayout::Primitive(F64, _) => FloatWidth::F64,
-        _ => panic!("{:?} does not have a FloatWidth", wasm_layout),
+        _ => internal_error!("{:?} does not have a FloatWidth", wasm_layout),
     }
 }

--- a/compiler/gen_wasm/src/storage.rs
+++ b/compiler/gen_wasm/src/storage.rs
@@ -3,6 +3,7 @@ use bumpalo::Bump;
 
 use roc_collections::all::MutMap;
 use roc_module::symbol::Symbol;
+use roc_reporting::internal_error;
 
 use crate::layout::{
     CallConv, ReturnMethod, StackMemoryFormat, WasmLayout, ZigVersion, BUILTINS_ZIG_VERSION,
@@ -198,9 +199,10 @@ impl<'a> Storage<'a> {
     /// Get storage info for a given symbol
     pub fn get(&self, sym: &Symbol) -> &StoredValue {
         self.symbol_storage_map.get(sym).unwrap_or_else(|| {
-            panic!(
+            internal_error!(
                 "Symbol {:?} not found in function scope:\n{:?}",
-                sym, self.symbol_storage_map
+                sym,
+                self.symbol_storage_map
             )
         })
     }
@@ -335,7 +337,7 @@ impl<'a> Storage<'a> {
         let storage = self.get(&sym).to_owned();
         match storage {
             StoredValue::VirtualMachineStack { .. } | StoredValue::Local { .. } => {
-                unreachable!("these storage types are not returned by writing to a pointer")
+                internal_error!("these storage types are not returned by writing to a pointer")
             }
             StoredValue::StackMemory { location, size, .. } => {
                 if size == 0 {
@@ -400,7 +402,7 @@ impl<'a> Storage<'a> {
                 0 => {}
                 1 => wasm_args.push(*arg),
                 2 => wasm_args.extend_from_slice(&[*arg, *arg]),
-                n => unreachable!("Cannot have {} Wasm arguments for 1 Roc argument", n),
+                n => internal_error!("Cannot have {} Wasm arguments for 1 Roc argument", n),
             }
         }
 
@@ -471,7 +473,11 @@ impl<'a> Storage<'a> {
                     (ValueType::F32, 4) => code_builder.f32_store(Bytes4, to_offset),
                     (ValueType::F64, 8) => code_builder.f64_store(Bytes8, to_offset),
                     _ => {
-                        panic!("Cannot store {:?} with alignment of {:?}", value_type, size);
+                        internal_error!(
+                            "Cannot store {:?} with alignment of {:?}",
+                            value_type,
+                            size
+                        );
                     }
                 };
                 size
@@ -528,7 +534,11 @@ impl<'a> Storage<'a> {
                     (ValueType::F32, 4) => code_builder.f32_load(Bytes4, from_offset),
                     (ValueType::F64, 8) => code_builder.f64_load(Bytes8, from_offset),
                     _ => {
-                        panic!("Cannot store {:?} with alignment of {:?}", value_type, size);
+                        internal_error!(
+                            "Cannot store {:?} with alignment of {:?}",
+                            value_type,
+                            size
+                        );
                     }
                 };
 
@@ -623,7 +633,7 @@ impl<'a> Storage<'a> {
             }
 
             _ => {
-                panic!("Cannot copy storage from {:?} to {:?}", from, to);
+                internal_error!("Cannot copy storage from {:?} to {:?}", from, to);
             }
         }
     }

--- a/compiler/gen_wasm/src/wasm_module/code_builder.rs
+++ b/compiler/gen_wasm/src/wasm_module/code_builder.rs
@@ -1,6 +1,7 @@
 use bumpalo::collections::vec::Vec;
 use bumpalo::Bump;
 use core::panic;
+use roc_reporting::internal_error;
 
 use roc_module::symbol::Symbol;
 
@@ -108,7 +109,7 @@ impl From<u32> for Align {
             16 => Align::Bytes16,
             32 => Align::Bytes32,
             64 => Align::Bytes64,
-            _ => panic!("{:?}-byte alignment not supported", x),
+            _ => internal_error!("{:?}-byte alignment not supported", x),
         }
     }
 }
@@ -236,7 +237,7 @@ impl<'a> CodeBuilder<'a> {
         let pushed_at = self.code.len();
         let top_symbol: &mut Symbol = current_stack
             .last_mut()
-            .unwrap_or_else(|| unreachable!("Empty stack when trying to set Symbol {:?}", sym));
+            .unwrap_or_else(|| internal_error!("Empty stack when trying to set Symbol {:?}", sym));
         *top_symbol = sym;
 
         VmSymbolState::Pushed { pushed_at }
@@ -296,7 +297,9 @@ impl<'a> CodeBuilder<'a> {
         use VmSymbolState::*;
 
         match vm_state {
-            NotYetPushed => unreachable!("Symbol {:?} has no value yet. Nothing to load.", symbol),
+            NotYetPushed => {
+                internal_error!("Symbol {:?} has no value yet. Nothing to load.", symbol)
+            }
 
             Pushed { pushed_at } => {
                 match self.current_stack().last() {
@@ -648,7 +651,7 @@ impl<'a> CodeBuilder<'a> {
     }
     #[allow(dead_code)]
     fn br_table() {
-        panic!("TODO");
+        todo!("br instruction");
     }
 
     instruction_no_args!(return_, RETURN, 0, false);
@@ -684,7 +687,9 @@ impl<'a> CodeBuilder<'a> {
 
     #[allow(dead_code)]
     fn call_indirect() {
-        panic!("Not implemented. Roc doesn't use function pointers");
+        unimplemented!(
+            "There is no plan to implement call_indirect. Roc doesn't use function pointers"
+        );
     }
 
     instruction_no_args!(drop_, DROP, 1, false);

--- a/compiler/gen_wasm/src/wasm_module/linking.rs
+++ b/compiler/gen_wasm/src/wasm_module/linking.rs
@@ -1,5 +1,6 @@
 use bumpalo::collections::vec::Vec;
 use bumpalo::Bump;
+use roc_reporting::internal_error;
 
 use super::sections::{update_section_size, write_custom_section_header};
 use super::serialize::{SerialBuffer, Serialize};
@@ -477,7 +478,7 @@ impl<'a> LinkingSection<'a> {
                 return syminfos;
             }
         }
-        panic!("Symbol table not found");
+        internal_error!("Symbol table not found");
     }
 }
 


### PR DESCRIPTION
## Update gen_wasm's error handling

Remove the `Result` error messages and adopt a consistent pattern of macro usage.

### Background for anyone who missed it

The errors we get in the backends are *never* caused by the user program and are *always* compiler bugs. They are all to do with low level details of instruction sets and object files and things. We don't have useful feedback to give app developers so there's not much point in using `Result`. And for compiler developers, the Result is still unwrapped which panics, but the panic happens far away from the problem.

### Macros used

`roc_reporting::internal_error!` for "impossible" conditions that can only be reached if there is a bug. This uses a standard formatting that tells app developers it's a compiler bug and not an app bug. (See #2040 and #2094)

`std::todo!` for parts of the IR that are just not implemented in Wasm yet. In a way, this is the most useful of the error messages in the sense that you _might_ be able to refactor your Roc app to avoid the issue!

`std::unimplemented!` for parts of the Wasm spec that Roc doesn't use but where I want to note that it exists in case some day we want it.
