### PR TITLE
use ManuallyDrop instead of forget for rust host fx functions

### DIFF
--- a/examples/cli/platform/src/lib.rs
+++ b/examples/cli/platform/src/lib.rs
@@ -2,7 +2,7 @@
 
 use core::alloc::Layout;
 use core::ffi::c_void;
-use core::mem::MaybeUninit;
+use core::mem::{ManuallyDrop, MaybeUninit};
 use libc;
 use roc_std::RocStr;
 use std::ffi::CStr;
@@ -119,13 +119,8 @@ pub extern "C" fn roc_fx_getLine() -> RocStr {
 }
 
 #[no_mangle]
-pub extern "C" fn roc_fx_putLine(line: RocStr) -> () {
+pub extern "C" fn roc_fx_putLine(line: ManuallyDrop<RocStr>) {
     let bytes = line.as_slice();
     let string = unsafe { std::str::from_utf8_unchecked(bytes) };
     println!("{}", string);
-
-    // don't mess with the refcount!
-    core::mem::forget(line);
-
-    ()
 }


### PR DESCRIPTION
Just an update from using forget to using ManuallyDrop as mentioned on zulip.