### PR TITLE
Rename `base` package to `pf` everywhere, to match tutorial

### DIFF
--- a/cli/tests/fixtures/multi-dep-str/Main.roc
+++ b/cli/tests/fixtures/multi-dep-str/Main.roc
@@ -1,7 +1,7 @@
 app "multi-dep-str"
-    packages { base: "platform" }
+    packages { pf: "platform" }
     imports [ Dep1 ]
-    provides [ main ] to base
+    provides [ main ] to pf
 
 main : Str
 main = Dep1.str1

--- a/cli/tests/fixtures/multi-dep-thunk/Main.roc
+++ b/cli/tests/fixtures/multi-dep-thunk/Main.roc
@@ -1,7 +1,7 @@
 app "multi-dep-thunk"
-    packages { base: "platform" }
+    packages { pf: "platform" }
     imports [ Dep1 ]
-    provides [ main ] to base
+    provides [ main ] to pf
 
 main : Str
 main = Dep1.value1 {}

--- a/compiler/builtins/docs/Num.roc
+++ b/compiler/builtins/docs/Num.roc
@@ -621,13 +621,13 @@ toStr : Num * -> Str
 ## Examples:
 ##
 ## In some countries (e.g. USA and UK), a comma is used to separate thousands:
-## >>> Num.format 1_000_000 { base: Decimal, wholeSep: { mark: ",", places: 3 } }
+## >>> Num.format 1_000_000 { pf: Decimal, wholeSep: { mark: ",", places: 3 } }
 ##
 ## Sometimes when rendering bits, it's nice to group them into groups of 4:
-## >>> Num.format 1_000_000 { base: Binary, wholeSep: { mark: " ", places: 4 } }
+## >>> Num.format 1_000_000 { pf: Binary, wholeSep: { mark: " ", places: 4 } }
 ##
 ## It's also common to render hexadecimal in groups of 2:
-## >>> Num.format 1_000_000 { base: Hexadecimal, wholeSep: { mark: " ", places: 2 } }
+## >>> Num.format 1_000_000 { pf: Hexadecimal, wholeSep: { mark: " ", places: 2 } }
 format :
     Num *,
     {

--- a/compiler/fmt/tests/test_fmt.rs
+++ b/compiler/fmt/tests/test_fmt.rs
@@ -2625,7 +2625,7 @@ mod test_fmt {
     fn single_line_app() {
         module_formats_same(indoc!(
             r#"
-                app "Foo" packages { base: "platform" } imports [] provides [ main ] to base"#
+                app "Foo" packages { pf: "platform" } imports [] provides [ main ] to pf"#
         ));
     }
 

--- a/compiler/load/src/file.rs
+++ b/compiler/load/src/file.rs
@@ -684,7 +684,7 @@ enum HeaderFor<'a> {
         to_platform: To<'a>,
     },
     PkgConfig {
-        /// usually `base`
+        /// usually `pf`
         config_shorthand: &'a str,
         /// the type scheme of the main function (required by the platform)
         /// (currently unused)
@@ -2845,7 +2845,7 @@ fn send_header<'a>(
 
         // For each of our imports, add an entry to deps_by_name
         //
-        // e.g. for `imports [ base.Foo.{ bar } ]`, add `Foo` to deps_by_name
+        // e.g. for `imports [ pf.Foo.{ bar } ]`, add `Foo` to deps_by_name
         //
         // Also build a list of imported_values_to_expose (like `bar` above.)
         for (qualified_module_name, exposed_idents, region) in imported.into_iter() {
@@ -3066,7 +3066,7 @@ fn send_header_two<'a>(
 
         // For each of our imports, add an entry to deps_by_name
         //
-        // e.g. for `imports [ base.Foo.{ bar } ]`, add `Foo` to deps_by_name
+        // e.g. for `imports [ pf.Foo.{ bar } ]`, add `Foo` to deps_by_name
         //
         // Also build a list of imported_values_to_expose (like `bar` above.)
         for (qualified_module_name, exposed_idents, region) in imported.into_iter() {
@@ -4428,7 +4428,7 @@ fn to_missing_platform_report(module_id: ModuleId, other: PlatformPath) -> Strin
                     alloc.reflow("I could not find a platform based on your input file."),
                     alloc.reflow(r"Does the module header contain an entry that looks like this:"),
                     alloc
-                        .parser_suggestion(" packages { base: \"platform\" }")
+                        .parser_suggestion(" packages { pf: \"platform\" }")
                         .indent(4),
                     alloc.reflow("See also TODO."),
                 ]);

--- a/compiler/module/src/symbol.rs
+++ b/compiler/module/src/symbol.rs
@@ -359,7 +359,7 @@ impl fmt::Debug for ModuleId {
     }
 }
 
-/// base.Task
+/// pf.Task
 /// 1. build mapping from short name to package
 /// 2. when adding new modules from package we need to register them in some other map (this module id goes with short name) (shortname, module-name) -> moduleId
 /// 3. pass this around to other modules getting headers parsed. when parsing interfaces we need to use this map to reference shortnames

--- a/compiler/parse/src/header.rs
+++ b/compiler/parse/src/header.rs
@@ -204,7 +204,7 @@ pub enum ImportsEntry<'a> {
         Collection<'a, Loc<ExposesEntry<'a, &'a str>>>,
     ),
 
-    /// e.g. `base.Task` or `base.Task.{ after }` or `base.{ Task.{ Task, after } }`
+    /// e.g. `pf.Task` or `pf.Task.{ after }` or `pf.{ Task.{ Task, after } }`
     Package(
         &'a str,
         ModuleName<'a>,

--- a/compiler/parse/src/module.rs
+++ b/compiler/parse/src/module.rs
@@ -786,7 +786,7 @@ fn imports_entry<'a>() -> impl Parser<'a, ImportsEntry<'a>, EImports> {
     map_with_arena!(
         and!(
             and!(
-                // e.g. `base.`
+                // e.g. `pf.`
                 maybe!(skip_second!(
                     shortname(),
                     word1(b'.', EImports::ShorthandDot)

--- a/compiler/parse/tests/snapshots/pass/full_app_header.header.roc
+++ b/compiler/parse/tests/snapshots/pass/full_app_header.header.roc
@@ -1,4 +1,4 @@
 app "quicksort"
-    packages { base: "./platform" }
+    packages { pf: "./platform" }
     imports [ foo.Bar.Baz ]
-    provides [ quicksort ] to base
+    provides [ quicksort ] to pf

--- a/compiler/parse/tests/snapshots/pass/full_app_header_trailing_commas.header.roc
+++ b/compiler/parse/tests/snapshots/pass/full_app_header_trailing_commas.header.roc
@@ -1,8 +1,8 @@
 app "quicksort"
-    packages { base: "./platform", }
+    packages { pf: "./platform", }
     imports [ foo.Bar.{
         Baz,
         FortyTwo,
         # I'm a happy comment
     } ]
-    provides [ quicksort, ] to base
+    provides [ quicksort, ] to pf

--- a/docs/tests/insert_syntax_highlighting.rs
+++ b/docs/tests/insert_syntax_highlighting.rs
@@ -58,9 +58,9 @@ mod insert_doc_syntax_highlighting {
 
     pub const HELLO_WORLD: &str = r#"
 app "test-app"
-    packages { base: "platform" }
+    packages { pf: "platform" }
     imports []
-    provides [ main ] to base
+    provides [ main ] to pf
 
 main = "Hello, world!"
 

--- a/editor/src/editor/resources/strings.rs
+++ b/editor/src/editor/resources/strings.rs
@@ -17,9 +17,9 @@ For convenience and consistency, there is only one way to format roc.
 
 pub const HELLO_WORLD: &str = r#"
 app "test-app"
-    packages { base: "platform" }
+    packages { pf: "platform" }
     imports []
-    provides [ main ] to base
+    provides [ main ] to pf
 
 main = "Hello, world!"
 

--- a/examples/benchmarks/CFold.roc
+++ b/examples/benchmarks/CFold.roc
@@ -1,7 +1,7 @@
 app "cfold"
-    packages { base: "platform" }
-    imports [base.Task]
-    provides [ main ] to base
+    packages { pf: "platform" }
+    imports [pf.Task]
+    provides [ main ] to pf
 
 # adapted from https://github.com/koka-lang/koka/blob/master/test/bench/haskell/cfold.hs
 

--- a/examples/benchmarks/Closure.roc
+++ b/examples/benchmarks/Closure.roc
@@ -1,7 +1,7 @@
 app "closure"
-    packages { base: "platform" }
-    imports [base.Task]
-    provides [ main ] to base
+    packages { pf: "platform" }
+    imports [pf.Task]
+    provides [ main ] to pf
 
 # see https://github.com/rtfeldman/roc/issues/985
 

--- a/examples/benchmarks/Deriv.roc
+++ b/examples/benchmarks/Deriv.roc
@@ -1,7 +1,7 @@
 app "deriv"
-    packages { base: "platform" }
-    imports [base.Task]
-    provides [ main ] to base
+    packages { pf: "platform" }
+    imports [pf.Task]
+    provides [ main ] to pf
 
 # based on: https://github.com/koka-lang/koka/blob/master/test/bench/haskell/deriv.hs
 

--- a/examples/benchmarks/NQueens.roc
+++ b/examples/benchmarks/NQueens.roc
@@ -1,7 +1,7 @@
 app "nqueens"
-    packages { base: "platform" }
-    imports [base.Task]
-    provides [ main ] to base
+    packages { pf: "platform" }
+    imports [pf.Task]
+    provides [ main ] to pf
 
 main : Task.Task {} []
 main =

--- a/examples/benchmarks/QuicksortApp.roc
+++ b/examples/benchmarks/QuicksortApp.roc
@@ -1,7 +1,7 @@
 app "quicksortapp"
-    packages { base: "platform" }
-    imports [base.Task, Quicksort]
-    provides [ main ] to base
+    packages { pf: "platform" }
+    imports [pf.Task, Quicksort]
+    provides [ main ] to pf
 
 main : Task.Task {} []
 main =

--- a/examples/benchmarks/RBTreeCk.roc
+++ b/examples/benchmarks/RBTreeCk.roc
@@ -1,7 +1,7 @@
 app "rbtree-ck"
-    packages { base: "platform" }
-    imports [base.Task]
-    provides [ main ] to base
+    packages { pf: "platform" }
+    imports [pf.Task]
+    provides [ main ] to pf
 
 
 Color : [ Red, Black ]

--- a/examples/benchmarks/RBTreeDel.roc
+++ b/examples/benchmarks/RBTreeDel.roc
@@ -1,7 +1,7 @@
 app "rbtree-del"
-    packages { base: "platform" }
-    imports [base.Task]
-    provides [ main ] to base
+    packages { pf: "platform" }
+    imports [pf.Task]
+    provides [ main ] to pf
 
 
 Color : [ Red, Black ]

--- a/examples/benchmarks/RBTreeInsert.roc
+++ b/examples/benchmarks/RBTreeInsert.roc
@@ -1,7 +1,7 @@
 app "rbtree-insert"
-    packages { base: "platform" }
-    imports [base.Task]
-    provides [ main ] to base
+    packages { pf: "platform" }
+    imports [pf.Task]
+    provides [ main ] to pf
 
 main : Task.Task {} []
 main =

--- a/examples/benchmarks/TestAStar.roc
+++ b/examples/benchmarks/TestAStar.roc
@@ -1,7 +1,7 @@
 app "test-astar"
-    packages { base: "platform" }
-    imports [base.Task, AStar]
-    provides [ main ] to base
+    packages { pf: "platform" }
+    imports [pf.Task, AStar]
+    provides [ main ] to pf
 
 main : Task.Task {} []
 main =

--- a/examples/benchmarks/TestBase64.roc
+++ b/examples/benchmarks/TestBase64.roc
@@ -1,7 +1,7 @@
 app "test-base64"
-    packages { base: "platform" }
-    imports [base.Task, Base64 ]
-    provides [ main ] to base
+    packages { pf: "platform" }
+    imports [pf.Task, Base64 ]
+    provides [ main ] to pf
 
 IO a : Task.Task a []
 

--- a/examples/cli/Echo.roc
+++ b/examples/cli/Echo.roc
@@ -1,9 +1,9 @@
 #!/usr/bin/env roc
 
 app "echo"
-    packages { base: "platform" }
-    imports [ base.Task.{ Task, await }, base.Stdout, base.Stdin ]
-    provides [ main ] to base
+    packages { pf: "platform" }
+    imports [ pf.Task.{ Task, await }, pf.Stdout, pf.Stdin ]
+    provides [ main ] to pf
 
 main : Task {} *
 main =

--- a/examples/effect/Main.roc
+++ b/examples/effect/Main.roc
@@ -1,7 +1,7 @@
 app "effect-example"
-    packages { base: "thing/platform-dir" }
+    packages { pf: "thing/platform-dir" }
     imports [fx.Effect]
-    provides [ main ] to base
+    provides [ main ] to pf
 
 main : Effect.Effect {}
 main =

--- a/examples/false-interpreter/Context.roc
+++ b/examples/false-interpreter/Context.roc
@@ -1,6 +1,6 @@
 interface Context
     exposes [ Context, Data, with, getChar, Option, pushStack, popStack, toStr, inWhileScope ]
-    imports [ base.File, base.Task.{ Task }, Variable.{ Variable } ]
+    imports [ pf.File, pf.Task.{ Task }, Variable.{ Variable } ]
 
 Option a : [ Some a, None ]
 

--- a/examples/false-interpreter/False.roc
+++ b/examples/false-interpreter/False.roc
@@ -1,8 +1,8 @@
 #!/usr/bin/env roc
 app "false"
-    packages { base: "platform" }
-    imports [ base.Task.{ Task }, base.Stdout, base.Stdin, Context.{ Context }, Variable.{ Variable } ]
-    provides [ main ] to base
+    packages { pf: "platform" }
+    imports [ pf.Task.{ Task }, pf.Stdout, pf.Stdin, Context.{ Context }, Variable.{ Variable } ]
+    provides [ main ] to pf
 
 # An interpreter for the False programming language: https://strlen.com/false-language/
 # This is just a silly example to test this variety of program.

--- a/examples/fib/Fib.roc
+++ b/examples/fib/Fib.roc
@@ -1,7 +1,7 @@
 app "fib"
-    packages { base: "platform" }
+    packages { pf: "platform" }
     imports []
-    provides [ main ] to base
+    provides [ main ] to pf
 
 main = \n -> fib n 0 1
 

--- a/examples/hello-rust/Hello.roc
+++ b/examples/hello-rust/Hello.roc
@@ -1,7 +1,7 @@
 app "hello-rust"
-    packages { base: "platform" }
+    packages { pf: "platform" }
     imports []
-    provides [ main ] to base
+    provides [ main ] to pf
 
 greeting =
     hi = "Hello"

--- a/examples/hello-swift/Hello.roc
+++ b/examples/hello-swift/Hello.roc
@@ -1,7 +1,7 @@
 app "hello-swift"
-    packages { base: "platform" }
+    packages { pf: "platform" }
     imports []
-    provides [ main ] to base
+    provides [ main ] to pf
 
 main =
     host = "Swift"

--- a/examples/hello-web/Hello.roc
+++ b/examples/hello-web/Hello.roc
@@ -1,7 +1,7 @@
 app "hello-web"
-    packages { base: "platform" }
+    packages { pf: "platform" }
     imports []
-    provides [ main ] to base
+    provides [ main ] to pf
 
 greeting =
     hi = "Hello"

--- a/examples/hello-world/Hello.roc
+++ b/examples/hello-world/Hello.roc
@@ -1,6 +1,6 @@
 app "hello-world"
-    packages { base: "platform" }
+    packages { pf: "platform" }
     imports []
-    provides [ main ] to base
+    provides [ main ] to pf
 
 main = "Hello, World!\n"

--- a/examples/hello-zig/Hello.roc
+++ b/examples/hello-zig/Hello.roc
@@ -1,7 +1,7 @@
 app "hello-world"
-    packages { base: "platform" }
+    packages { pf: "platform" }
     imports []
-    provides [ main ] to base
+    provides [ main ] to pf
 
 greeting =
     hi = "Hello"

--- a/examples/quicksort/Quicksort.roc
+++ b/examples/quicksort/Quicksort.roc
@@ -1,7 +1,7 @@
 app "quicksort"
-    packages { base: "platform" }
+    packages { pf: "platform" }
     imports []
-    provides [ quicksort ] to base
+    provides [ quicksort ] to pf
 
 quicksort = \originalList ->
     n = List.len originalList

--- a/reporting/tests/test_reporting.rs
+++ b/reporting/tests/test_reporting.rs
@@ -6048,9 +6048,9 @@ I need all branches in an `if` to have the same type!
             indoc!(
                 r#"
                 app "test-base64"
-                    packages { base: "platform" }
-                    imports [base.Task, Base64 ]
-                    provides [ main, @Foo ] to base
+                    packages { pf: "platform" }
+                    imports [pf.Task, Base64 ]
+                    provides [ main, @Foo ] to pf
                 "#
             ),
             indoc!(
@@ -6059,8 +6059,8 @@ I need all branches in an `if` to have the same type!
 
                 I am partway through parsing a provides list, but I got stuck here:
 
-                3│      imports [base.Task, Base64 ]
-                4│      provides [ main, @Foo ] to base
+                3│      imports [pf.Task, Base64 ]
+                4│      provides [ main, @Foo ] to pf
                                          ^
 
                 I was expecting a type name, value name or function name next, like
@@ -6116,7 +6116,7 @@ I need all branches in an `if` to have the same type!
                 r#"
                 interface Foobar
                     exposes [ main, @Foo ]
-                    imports [base.Task, Base64 ]
+                    imports [pf.Task, Base64 ]
                 "#
             ),
             indoc!(
@@ -6144,7 +6144,7 @@ I need all branches in an `if` to have the same type!
                 r#"
                 interface foobar
                     exposes [ main, @Foo ]
-                    imports [base.Task, Base64 ]
+                    imports [pf.Task, Base64 ]
                 "#
             ),
             indoc!(
@@ -6170,7 +6170,7 @@ I need all branches in an `if` to have the same type!
                 r#"
                 app foobar
                     exposes [ main, @Foo ]
-                    imports [base.Task, Base64 ]
+                    imports [pf.Task, Base64 ]
                 "#
             ),
             indoc!(


### PR DESCRIPTION
Although `base` vs. `pf` is a subjective choice, a consistent convention makes examples more readable to newcomers.