### PR TITLE
Add missing section headers to `Set` docs

### DIFF
--- a/compiler/builtins/docs/Set.roc
+++ b/compiler/builtins/docs/Set.roc
@@ -29,6 +29,8 @@ isEmpty : Set * -> Bool
 
 len : Set * -> Nat
 
+## Modify
+
 # TODO: removed `'` from signature because parser does not support it yet
 # Original signature: `add : Set 'elem, 'elem -> Set 'elem`
 ## Make sure never to add a *NaN* to a [Set]! Because *NaN* is defined to be
@@ -40,6 +42,8 @@ add : Set elem, elem -> Set elem
 # TODO: removed `'` from signature because parser does not support it yet
 # Original signature: `drop : Set 'elem, 'elem -> Set 'elem`
 drop : Set elem, elem -> Set elem
+
+## Transform
 
 ## Convert each element in the set to something new, by calling a conversion
 ## function on each of them. Then return a new set of the converted values.


### PR DESCRIPTION
This emulates [the section headers in `List` docs](https://github.com/rtfeldman/roc/blob/09c1222b280d986bf66946cea0feb7da4de69a5f/compiler/builtins/docs/List.roc#L216).