### PR TITLE
run all CI steps for markdown files

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,7 +1,4 @@
-on:
-  pull_request:
-    paths-ignore:
-          - '**.md'
+on: [pull_request]
 
 name: Benchmarks
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,4 @@
-on:
-  pull_request:
-    paths-ignore:
-          - '**.md'
+on: [pull_request]
 
 name: CI
 


### PR DESCRIPTION
In order to avoid branch protection issues with ignored .md files, just run all CI steps.
Ideally, we'd like to mark a check as passed when only markdown files to achieve #2197.
However, there is no elegant way to achieve this, only a tedious way.
So for now we can just run all CI steps.

I've requested an elegant solution [here](https://github.com/github/feedback/discussions/8832).