### PR TITLE
[WIP][DO NOT MERGE] RFC: Debug Buffer recorder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,6 +179,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base32"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23ce669cd6c8588f79e15cf450314f9638f967fc5770ff1c7c1deb0925ea7cfa"
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -249,6 +255,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake2"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a58bdf5134c5beae6fc382002c4d88950bad1feea20f8f7165494b6b43b049de"
+dependencies = [
+ "digest 0.10.0",
+]
+
+[[package]]
 name = "block"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -271,6 +286,15 @@ name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "generic-array 0.14.4",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1d36a02058e76b040de25a4464ba1c80935655595b661505c8b39b664828b95"
 dependencies = [
  "generic-array 0.14.4",
 ]
@@ -900,6 +924,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567569e659735adb39ff2d4c20600f7cd78be5471f8c58ab162bce3c03fdbc5f"
+dependencies = [
+ "generic-array 0.14.4",
+]
+
+[[package]]
 name = "csv"
 version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1045,6 +1078,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
  "generic-array 0.14.4",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8549e6bfdecd113b7e221fe60b433087f6957387a20f8118ebca9b12af19143d"
+dependencies = [
+ "block-buffer 0.10.0",
+ "crypto-common",
+ "generic-array 0.14.4",
+ "subtle",
 ]
 
 [[package]]
@@ -3293,6 +3338,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "roc_debug_buf"
+version = "0.1.0"
+dependencies = [
+ "backtrace",
+ "base32",
+ "blake2",
+ "indoc",
+ "pretty_assertions",
+ "roc_test_utils",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "roc_docs"
 version = "0.1.0"
 dependencies = [
@@ -3342,6 +3401,7 @@ dependencies = [
  "roc_can",
  "roc_code_markup",
  "roc_collections",
+ "roc_debug_buf",
  "roc_load",
  "roc_module",
  "roc_parse",
@@ -3371,6 +3431,7 @@ dependencies = [
  "indoc",
  "pretty_assertions",
  "roc_collections",
+ "roc_debug_buf",
  "roc_module",
  "roc_parse",
  "roc_region",
@@ -3815,9 +3876,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.69"
+version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e466864e431129c7e0d3476b92f20458e5879919a0596c6472738d9fa2d342f8"
+checksum = "d0ffa0837f2dfa6fb90868c2b5468cad482e175f7dad97e7421951e663f2b527"
 dependencies = [
  "itoa",
  "ryu",
@@ -4054,6 +4115,12 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "subtle"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"

--- a/compiler/debug_buf/Cargo.toml
+++ b/compiler/debug_buf/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "roc_debug_buf"
+version = "0.1.0"
+authors = ["The Roc Contributors"]
+license = "UPL-1.0"
+edition = "2018"
+
+[dependencies]
+backtrace = "0.3.63"
+serde = "1.0.130"
+serde_json = "1.0.72"
+blake2 = "0.10.0"
+base32 = "0.4.0"
+
+[dev-dependencies]
+pretty_assertions = "1.0.0"
+indoc = "1.0.3"
+roc_test_utils = { path = "../../test_utils" }

--- a/compiler/debug_buf/src/lib.rs
+++ b/compiler/debug_buf/src/lib.rs
@@ -1,0 +1,134 @@
+use std::{collections::{HashMap, HashSet}, ffi::c_void, path::PathBuf};
+
+#[derive(Copy, Clone, Eq, PartialEq, Hash)]
+struct Address(u64);
+
+#[derive(Copy, Clone, Eq, PartialEq, Hash)]
+struct FrameIndex(u32);
+
+pub struct FlightRecorder {
+    tmp_frame_buf: Vec<Address>,
+    frames: Vec<(Address, FrameIndex)>,
+    unique_frames: HashMap<(Address, FrameIndex), FrameIndex>,
+    ranges: Vec<(FrameIndex, usize, usize)>,
+    text: std::string::String,
+}
+
+impl FlightRecorder {
+    pub fn new() -> Self {
+        FlightRecorder {
+            tmp_frame_buf: Vec::new(),
+            frames: Vec::new(),
+            unique_frames: HashMap::new(),
+            ranges: Vec::new(),
+            text: std::string::String::new(),
+        }
+    }
+
+    pub fn push(&mut self, ch: char) {
+        self.text.push(ch);
+    }
+
+    pub fn push_str(&mut self, s: &str) {
+        self.text.push_str(s);
+    }
+
+    pub fn len(&self) -> usize {
+        self.text.len()
+    }
+
+    pub fn take_sample(&mut self, offset: usize, len: usize) {
+        assert!(offset <= self.text.len());
+        assert!(offset + len <= self.text.len());
+        let top = self.capture_backtrace();
+        self.ranges.push((top, offset, len));
+    }
+
+    fn capture_backtrace(&mut self) -> FrameIndex {
+        self.tmp_frame_buf.clear();
+        backtrace::trace(|frame| {
+            let ip = Address(frame.ip() as u64);
+            self.tmp_frame_buf.push(ip);
+            true // keep going to the next frame
+        });
+
+        let mut last_frame = FrameIndex(u32::MAX);
+        for ip in self.tmp_frame_buf.drain(..).rev() {
+            let frames = &mut self.frames;
+            
+            last_frame = *self.unique_frames.entry((ip, last_frame)).or_insert_with(|| {
+                let next_frame_id = FrameIndex(frames.len() as u32);
+                frames.push((ip, last_frame));
+                next_frame_id
+            });
+        }
+
+        last_frame
+    }
+
+    pub fn serialize(&self) -> Vec<u8> {
+        let addresses = self.frames.iter().map(|(addr, _)| *addr).collect::<HashSet<_>>();
+        #[derive(serde::Serialize)]
+        struct Frame {
+            addr: Option<u64>,
+            name: Option<std::string::String>,
+            filename: Option<std::path::PathBuf>,
+            lineno: Option<u32>,
+            colno: Option<u32>,
+        }
+        let addrs = addresses.into_iter().map(|addr| {
+            let mut res = Vec::new();
+            backtrace::resolve(addr.0 as *mut c_void, |symbol| {
+                res.push(Frame {
+                    addr: symbol.addr().map(|a| a as u64),
+                    name: symbol.name().map(|n| n.to_string()),
+                    filename: symbol.filename().map(|n| n.to_owned()),
+                    lineno: symbol.lineno(),
+                    colno: symbol.colno()
+                });
+            });
+            (addr.0, res)
+        }).collect::<HashMap<_, _>>();
+
+        #[derive(serde::Serialize)]
+        struct Encoded {
+            addrs: HashMap<u64, Vec<Frame>>,
+            frames: Vec<(u64, u32)>,
+            ranges: Vec<(u32, usize, usize)>,
+            text: std::string::String,
+        }
+
+        let encoded = Encoded {
+            addrs,
+            frames: self.frames.iter().map(|(a, f)| (a.0, f.0)).collect(),
+            ranges: self.ranges.iter().map(|(f, offset, len)| (f.0, *offset, *len)).collect(),
+            text: self.text.clone(),
+        };
+
+        serde_json::to_string(&encoded).unwrap().into_bytes()
+    }
+}
+
+impl Drop for FlightRecorder {
+    fn drop(&mut self) {
+        // Write to a file if possible
+        if let Ok(dir) = std::env::var("ROC_DEBUG_FMT_DIR") {
+            use blake2::Blake2bVar;
+            use blake2::digest::{Update, VariableOutput};
+
+            let mut hasher = Blake2bVar::new(16).unwrap();
+            hasher.update(self.text.as_bytes());
+            // TODO: figure out a better naming scheme
+            hasher.update(&std::time::SystemTime::now().duration_since(std::time::SystemTime::UNIX_EPOCH).unwrap().as_micros().to_le_bytes());
+            let mut buf = [0u8; 16];
+            hasher.finalize_variable(&mut buf).unwrap();
+            
+            let mut filename = base32::encode(base32::Alphabet::RFC4648 { padding: false }, &buf);
+            filename.push_str(".rocfmtdbg");
+            let path = PathBuf::from(dir).join(filename);
+
+            std::fs::write(&path, self.serialize()).unwrap();
+            println!("Wrote recording to {}", std::fs::canonicalize(path).unwrap().display());
+        }
+    }
+}

--- a/compiler/fmt/Cargo.toml
+++ b/compiler/fmt/Cargo.toml
@@ -10,6 +10,7 @@ roc_collections = { path = "../collections" }
 roc_region = { path = "../region" }
 roc_module = { path = "../module" }
 roc_parse = { path = "../parse" }
+roc_debug_buf = { path = "../debug_buf" }
 bumpalo = { version = "3.8.0", features = ["collections"] }
 
 [dev-dependencies]

--- a/editor/Cargo.toml
+++ b/editor/Cargo.toml
@@ -31,6 +31,7 @@ roc_types = { path = "../compiler/types" }
 roc_unify = { path = "../compiler/unify" }
 roc_reporting = { path = "../reporting" }
 roc_solve = { path = "../compiler/solve" }
+roc_debug_buf = { path = "../compiler/debug_buf" }
 ven_graph = { path = "../vendor/pathfinding" }
 bumpalo = { version = "3.8.0", features = ["collections"] }
 arrayvec = "0.7.2"


### PR DESCRIPTION
This is not in a mergeable state, but I'm getting tired of maintaining this locally as a series of patches 😬. I want to start a discussion on what changes need to be made before this (or something like it) is mergeable.

I've been using this a fair amount locally to understand the parser/formatter better.

The idea here is to record operations happening to a buffer as backtraces that relate to a range of bytes in the buffer. This is a _very_ general concept, and here I'm demoing what it looks like to integrate "debug buf recording" functionality into the roc formatter.

The intended workflow is that a developer wishing to debug the formatter (or understand better how it works), would build roc with a new feature, e.g. `cargo build --features=debug_buf`. They'd then run their test (with the appropriate feature), or run `./target/debug/roc format MyBuggyFile.roc`, and a new `<something>.rocdbgbuf` file would be created. The developer can then load this file into a viewer - which I've prototyped here: https://github.com/joshuawarner32/debug_buf_viewer - and see which stack trace(s) interacted with which ranges of bytes in the file, by simply navigating around with arrow keys. It wouldn't be hard to add integrations to then jump over to a particular stack frame in the compiler, in the user's editor of choice.

A picture is worth a thousand words:
<img width="962" alt="Debug Buffer Viewer Prototype" src="https://user-images.githubusercontent.com/182686/146119254-01c624c2-1e9f-4fa1-b8d8-800c3864cf61.png">

Here you can see my (terminal) cursor is over "Task" (on the left pane), and on the right pane you can see the stack trace where "Task" was appended to the buffer. Currently things are color coded based on the depth of the stack, but you could imagine all sorts of interesting visualizations.

This is all information that could be extracted from a debugger, source diving, clever insertions of `dbg!` statements, etc - but the point here is to make the connection much more immediate, à la Bret Victor / Inventing on Principle.

I have another series of patches locally that add integrations in the parser to do exactly the same thing - just a little trickier, since the parser is based around a immutable, copied-everywhere `State` struct, rather than a single mutable `Buf`.

Some questions that need answering prior to merging:
* (design question) What's the right way to name the output file? I was originally naming them based on the hash of the final buffer, and then I transitioned to a randomly-generated name (the vestiges of this are still in the code and need to be cleaned up!). One could also imagine specifying the name via an env var - but what if there are multiple recording bufs generated during the course of a test (as is common now, because we assert formatting is stable)?
* (design question) What's the right way to enable this recording? My initial thought was to enable it for debug builds, and otherwise enable it via env var. This adds a small overhead to debug builds, for the benefit of making it easier to play with. We can get rid of the tiny bit of overhead by only compiling in support under a separate cargo feature, but that makes it a little harder to use and introduces the possibility that it'll accidentally get broken by someone changes (because presumably we wouldn't be compiling with that feature in CI).
* What state should be viewer be in prior to merging this? Does it need to be merged into the same repo? Because it's based on someone else's code, the prototype viewer must be licensed as BSD 2, which I don't think is compatible with the rest of the roc repo. I've been toying with rewriting the prototype viewer in Roc; but that's been slow going ;)