### PR TITLE
Add empty-delimiter handling for `Str.split`

### DIFF
--- a/compiler/builtins/bitcode/src/str.zig
+++ b/compiler/builtins/bitcode/src/str.zig
@@ -527,7 +527,7 @@ fn strSplitInPlace(array: [*]RocStr, string: RocStr, delimiter: RocStr) void {
     const delimiter_bytes_ptrs = delimiter.asU8ptr();
     const delimiter_len = delimiter.len();
 
-    if (str_len > delimiter_len) {
+    if (str_len > delimiter_len and delimiter_len > 0) {
         const end_index: usize = str_len - delimiter_len + 1;
         while (str_index <= end_index) {
             var delimiter_index: usize = 0;
@@ -559,6 +559,40 @@ fn strSplitInPlace(array: [*]RocStr, string: RocStr, delimiter: RocStr) void {
     }
 
     array[ret_array_index] = RocStr.init(str_bytes + slice_start_index, str_len - slice_start_index);
+}
+
+test "strSplitInPlace: empty delimiter" {
+    // Str.split "abc" "" == [ "abc" ]
+    const str_arr = "abc";
+    const str = RocStr.init(str_arr, str_arr.len);
+
+    const delimiter_arr = "";
+    const delimiter = RocStr.init(delimiter_arr, delimiter_arr.len);
+
+    var array: [1]RocStr = undefined;
+    const array_ptr: [*]RocStr = &array;
+
+    strSplitInPlace(array_ptr, str, delimiter);
+
+    var expected = [1]RocStr{
+        str,
+    };
+
+    defer {
+        for (array) |roc_str| {
+            roc_str.deinit();
+        }
+
+        for (expected) |roc_str| {
+            roc_str.deinit();
+        }
+
+        str.deinit();
+        delimiter.deinit();
+    }
+
+    try expectEqual(array.len, expected.len);
+    try expect(array[0].eq(expected[0]));
 }
 
 test "strSplitInPlace: no delimiter" {
@@ -734,7 +768,7 @@ pub fn countSegments(string: RocStr, delimiter: RocStr) callconv(.C) usize {
 
     var count: usize = 1;
 
-    if (str_len > delimiter_len) {
+    if (str_len > delimiter_len and delimiter_len > 0) {
         var str_index: usize = 0;
         const end_cond: usize = str_len - delimiter_len + 1;
 

--- a/compiler/test_gen/src/gen_str.rs
+++ b/compiler/test_gen/src/gen_str.rs
@@ -17,6 +17,36 @@ use roc_std::{RocList, RocStr};
 
 #[test]
 #[cfg(any(feature = "gen-llvm"))]
+fn str_split_empty_delimiter() {
+    assert_evals_to!(
+        indoc!(
+            r#"
+                    List.len (Str.split "hello" "")
+                "#
+        ),
+        1,
+        i64
+    );
+
+    assert_evals_to!(
+        indoc!(
+            r#"
+                    when List.first (Str.split "JJJ" "") is
+                        Ok str ->
+                            Str.countGraphemes str
+
+                        _ ->
+                            -1
+
+                "#
+        ),
+        3,
+        i64
+    );
+}
+
+#[test]
+#[cfg(any(feature = "gen-llvm"))]
 fn str_split_bigger_delimiter_small_str() {
     assert_evals_to!(
         indoc!(

--- a/compiler/test_gen/src/wasm_str.rs
+++ b/compiler/test_gen/src/wasm_str.rs
@@ -15,6 +15,35 @@ use indoc::indoc;
 use roc_std::RocStr;
 
 // #[test]
+// fn str_split_empty_delimiter() {
+//     assert_evals_to!(
+//         indoc!(
+//             r#"
+//                     List.len (Str.split "hello" "")
+//                 "#
+//         ),
+//         1,
+//         i64
+//     );
+
+//     assert_evals_to!(
+//         indoc!(
+//             r#"
+//                     when List.first (Str.split "JJJ" "") is
+//                         Ok str ->
+//                             Str.countGraphemes str
+
+//                         _ ->
+//                             -1
+
+//                 "#
+//         ),
+//         3,
+//         i64
+//     );
+// }
+
+// #[test]
 // fn str_split_bigger_delimiter_small_str() {
 //     assert_evals_to!(
 //         indoc!(


### PR DESCRIPTION
@rtfeldman requested this in #2188.

This should make [this claim in the builtins docs](https://github.com/rtfeldman/roc/blob/12818f9b9df10b48fd9cddba60399e91d4b369bc/compiler/builtins/docs/Str.roc#L136) accurate.

Warning: I've never learned/written Zig or Rust, so I'm just copying+pasting+modifying adjacent code.

Before:
```
jan@Jans-MacBook-Pro roc % ./target/release/roc repl

  The rockin’ roc repl
────────────────────────

Enter an expression, or :help, or :exit/:q.

» Str.split "abc" ""
zsh: segmentation fault  ./target/release/roc repl
jan@Jans-MacBook-Pro roc % 
```

After:
```
jan@Jans-MacBook-Pro roc % ./target/release/roc repl

  The rockin’ roc repl
────────────────────────

Enter an expression, or :help, or :exit/:q.

» Str.split "abc" ""

[ "abc" ] : List Str

» 
```