### PR TITLE
Alphabetize compiler/builtins/docs definitions, within their sections

### DIFF
--- a/compiler/builtins/docs/Bool.roc
+++ b/compiler/builtins/docs/Bool.roc
@@ -2,9 +2,6 @@ interface Bool
     exposes [ and, isEq, isNotEq, not, or, xor ]
     imports []
 
-## Returns `False` when given `True`, and vice versa.
-not : [True, False] -> [True, False]
-
 ## Returns `True` when given `True` and `True`, and `False` when either argument is `False`.
 ##
 ## `a && b` is shorthand for `Bool.and a b`
@@ -38,29 +35,6 @@ not : [True, False] -> [True, False]
 ## one explicitly!)
 and : Bool, Bool -> Bool
 
-
-## Returns `True` when given `True` for either argument, and `False` only when given `False` and `False`.
-##
-## `a || b` is shorthand for `Bool.or a b`.
-##
-## >>> True || True
-#
-## >>> True || False
-#
-## >>> False || True
-##
-## >>> False || False
-##
-## ## Performance Notes
-##
-## In some languages, `&&` and `||` are special-cased in the compiler to skip
-## evaluating the expression after the operator under certain circumstances.
-## In Roc, this is not the case. See the performance notes for [Bool.and] for details.
-or : Bool, Bool -> Bool
-
-## Exclusive or
-xor : Bool, Bool -> Bool
-
 # TODO: removed `'` from signature because parser does not support it yet
 # Original signature: `isEq : 'val, 'val -> Bool`
 ## Returns `True` if the two values are *structurally equal*, and `False` otherwise.
@@ -88,3 +62,28 @@ isEq : val, val -> Bool
 ## Note that `isNotEq` takes `'val` instead of `val`, which means `isNotEq` does not
 ## accept arguments whose types contain functions.
 isNotEq : val, val -> Bool
+
+## Returns `False` when given `True`, and vice versa.
+not : [True, False] -> [True, False]
+
+## Returns `True` when given `True` for either argument, and `False` only when given `False` and `False`.
+##
+## `a || b` is shorthand for `Bool.or a b`.
+##
+## >>> True || True
+#
+## >>> True || False
+#
+## >>> False || True
+##
+## >>> False || False
+##
+## ## Performance Notes
+##
+## In some languages, `&&` and `||` are special-cased in the compiler to skip
+## evaluating the expression after the operator under certain circumstances.
+## In Roc, this is not the case. See the performance notes for [Bool.and] for details.
+or : Bool, Bool -> Bool
+
+## Exclusive or
+xor : Bool, Bool -> Bool

--- a/compiler/builtins/docs/Dict.roc
+++ b/compiler/builtins/docs/Dict.roc
@@ -18,7 +18,17 @@ interface Dict
         ]
     imports []
 
-size : Dict * * -> Nat
+# DESIGN NOTES: The reason for panicking when given NaN is that:
+# * If we allowed NaN in, Dict.insert would no longer be idempotent.
+# * If we allowed NaN but overrode its semantics to make it feel like "NaN == NaN" we'd need isNaN checks in all hashing operations as well as all equality checks (during collision detection), not just insert. This would be much worse for performance than panicking on insert, which only requires one extra conditional on insert.
+# * It's obviously invalid; the whole point of NaN is that an error occurred. Giving a runtime error notifies you when this problem happens. Giving it only on insert is the best for performance, because it means you aren't paying for isNaN checks on lookups as well.
+
+# TODO: removed `'` from signature because parser does not support it yet
+# Original signature: insert : Dict 'key val, 'key, val -> Dict 'key val
+## Make sure never to insert a key of *NaN* into a [Dict]! Because *NaN* is
+## defined to be unequal to *NaN*, inserting a *NaN* key results in an entry
+## that can never be retrieved or removed from the [Dict].
+insert : Dict key val, key, val -> Dict key val
 
 isEmpty : Dict * * -> Bool
 
@@ -36,14 +46,4 @@ map :
     ({ key: beforeKey, value: beforeValue } -> { key: afterKey, value: afterValue })
     -> Dict afterKey afterValue
 
-# DESIGN NOTES: The reason for panicking when given NaN is that:
-# * If we allowed NaN in, Dict.insert would no longer be idempotent.
-# * If we allowed NaN but overrode its semantics to make it feel like "NaN == NaN" we'd need isNaN checks in all hashing operations as well as all equality checks (during collision detection), not just insert. This would be much worse for performance than panicking on insert, which only requires one extra conditional on insert.
-# * It's obviously invalid; the whole point of NaN is that an error occurred. Giving a runtime error notifies you when this problem happens. Giving it only on insert is the best for performance, because it means you aren't paying for isNaN checks on lookups as well.
-
-# TODO: removed `'` from signature because parser does not support it yet
-# Original signature: insert : Dict 'key val, 'key, val -> Dict 'key val
-## Make sure never to insert a key of *NaN* into a [Dict]! Because *NaN* is
-## defined to be unequal to *NaN*, inserting a *NaN* key results in an entry
-## that can never be retrieved or removed from the [Dict].
-insert : Dict key val, key, val -> Dict key val
+size : Dict * * -> Nat

--- a/compiler/builtins/docs/Num.roc
+++ b/compiler/builtins/docs/Num.roc
@@ -307,30 +307,6 @@ Float a : Num [ @Fraction a ]
 ## * Finally, if a particular numeric calculation is running too slowly, you can try experimenting with other number sizes. This rarely makes a meaningful difference, but some processors can operate on different number sizes at different speeds.
 Int size : Num [ @Integer size ]
 
-## A signed 8-bit integer, ranging from -128 to 127
-I8 : Int [ @Signed8 ]
-U8 : Int [ @Unsigned8 ]
-I16 : Int [ @Signed16 ]
-U16 : Int [ @Unsigned16 ]
-I32 : Int [ @Signed32 ]
-U32 : Int [ @Unsigned32 ]
-I64 : Int [ @Signed64 ]
-U64 : Int [ @Unsigned64 ]
-I128 : Int [ @Signed128 ]
-U128 : Int [ @Unsigned128 ]
-
-## A [natural number](https://en.wikipedia.org/wiki/Natural_number) represented
-## as a 64-bit unsigned integer on 64-bit systems, a 32-bit unsigned integer
-## on 32-bit systems, and so on.
-##
-## This system-specific size makes it useful for certain data structure
-## functions like [List.len], because the number of elements many data strucures
-## can hold is also system-specific. For example, the maximum number of elements
-## a [List] can hold on a 64-bit system fits in a 64-bit unsigned integer, and
-## on a 32-bit system it fits in 32-bit unsigned integer. This makes [Nat] a
-## good fit for [List.len] regardless of system.
-Nat : Int [ @Natural ]
-
 ## A 64-bit signed integer. All number literals without decimal points are compatible with #Int values.
 ##
 ## >>> 1
@@ -407,28 +383,32 @@ Nat : Int [ @Natural ]
 ## If you need to do math outside these bounds, consider using a larger numeric size.
 Int size : Num [ @Int size ]
 
-## Convert
+## A signed 8-bit integer, ranging from -128 to 127
+I8 : Int [ @Signed8 ]
+I16 : Int [ @Signed16 ]
+I32 : Int [ @Signed32 ]
+I64 : Int [ @Signed64 ]
+I128 : Int [ @Signed128 ]
 
-## Return a negative number when given a positive one, and vice versa.
+## A [natural number](https://en.wikipedia.org/wiki/Natural_number) represented
+## as a 64-bit unsigned integer on 64-bit systems, a 32-bit unsigned integer
+## on 32-bit systems, and so on.
 ##
-## >>> Num.neg 5
-##
-## >>> Num.neg -2.5
-##
-## >>> Num.neg 0
-##
-## >>> Num.neg 0.0
-##
-## This is safe to use with any [Float], but it can cause overflow when used with certain #Int values.
-##
-## For example, calling #Num.neg on the lowest value of a signed integer (such as #Int.lowestI64 or #Int.lowestI32) will cause overflow.
-## This is because, for any given size of signed integer (32-bit, 64-bit, etc.) its negated lowest value turns out to be 1 higher than
-## the highest value it can represent. (For this reason, calling #Num.abs on the lowest signed value will also cause overflow.)
-##
-## Additionally, calling #Num.neg on any unsigned integer (such as any #U64 or #U32 value) other than zero will cause overflow.
-##
-## (It will never crash when given a [Float], however, because of how floating point numbers represent positive and negative numbers.)
-neg : Num a -> Num a
+## This system-specific size makes it useful for certain data structure
+## functions like [List.len], because the number of elements many data strucures
+## can hold is also system-specific. For example, the maximum number of elements
+## a [List] can hold on a 64-bit system fits in a 64-bit unsigned integer, and
+## on a 32-bit system it fits in 32-bit unsigned integer. This makes [Nat] a
+## good fit for [List.len] regardless of system.
+Nat : Int [ @Natural ]
+
+U8 : Int [ @Unsigned8 ]
+U16 : Int [ @Unsigned16 ]
+U32 : Int [ @Unsigned32 ]
+U64 : Int [ @Unsigned64 ]
+U128 : Int [ @Unsigned128 ]
+
+## Convert
 
 ## Return the absolute value of the number.
 ##
@@ -453,26 +433,47 @@ neg : Num a -> Num a
 ## Calling this on an unsigned integer (like #U32 or #U64) never does anything.
 abs : Num a -> Num a
 
+## Return a negative number when given a positive one, and vice versa.
+##
+## >>> Num.neg 5
+##
+## >>> Num.neg -2.5
+##
+## >>> Num.neg 0
+##
+## >>> Num.neg 0.0
+##
+## This is safe to use with any [Float], but it can cause overflow when used with certain #Int values.
+##
+## For example, calling #Num.neg on the lowest value of a signed integer (such as #Int.lowestI64 or #Int.lowestI32) will cause overflow.
+## This is because, for any given size of signed integer (32-bit, 64-bit, etc.) its negated lowest value turns out to be 1 higher than
+## the highest value it can represent. (For this reason, calling #Num.abs on the lowest signed value will also cause overflow.)
+##
+## Additionally, calling #Num.neg on any unsigned integer (such as any #U64 or #U32 value) other than zero will cause overflow.
+##
+## (It will never crash when given a [Float], however, because of how floating point numbers represent positive and negative numbers.)
+neg : Num a -> Num a
+
 ## Check
-
-## The same as using `== 0` on the number.
-isZero : Num * -> Bool
-
-## Positive numbers are greater than 0.
-isPositive : Num * -> Bool
-
-## Negative numbers are less than 0.
-isNegative : Num * -> Bool
 
 ## A number is even if dividing it by 2 gives a remainder of 0.
 ##
 ## Examples of even numbers: 0, 2, 4, 6, 8, -2, -4, -6, -8
 isEven : Num * -> Bool
 
+## Negative numbers are less than 0.
+isNegative : Num * -> Bool
+
 ## A number is odd if dividing it by 2 gives a remainder of 1.
 ##
 ## Examples of odd numbers: 1, 3, 5, 7, -1, -3, -5, -7
 isOdd : Num * -> Bool
+
+## Positive numbers are greater than 0.
+isPositive : Num * -> Bool
+
+## The same as using `== 0` on the number.
+isZero : Num * -> Bool
 
 ## Arithmetic
 
@@ -503,33 +504,6 @@ add : Num a, Num a -> Num a
 ## panicking or returning ∞ or -∞, it will return `Err Overflow`.
 addCheckOverflow : Num a, Num a -> Result (Num a) [ Overflow ]*
 
-## Subtract two numbers of the same type.
-##
-## (To subtract an #Int and a [Float], first convert one so that they both have the same type. There are functions in the [`Frac`](/Frac) module that can convert both #Int to [Float] and the other way around.)
-##
-## `a - b` is shorthand for `Num.sub a b`.
-##
-## >>> 7 - 5
-##
-## >>> Num.sub 7 5
-##
-## `Num.sub` can be convenient in pipelines.
-##
-## >>> Frac.pi
-## >>>     |> Num.sub 2.0
-##
-## If the answer to this operation can't fit in the return value (e.g. an
-## [I8] answer that's higher than 127 or lower than -128), the result is an
-## *overflow*. For [F64] and [F32], overflow results in an answer of either
-## ∞ or -∞. For all other number types, overflow results in a panic.
-sub : Num a, Num a -> Num a
-
-## Subtract two numbers and check for overflow.
-##
-## This is the same as [Num.sub] except if the operation overflows, instead of
-## panicking or returning ∞ or -∞, it will return `Err Overflow`.
-subCheckOverflow : Num a, Num a -> Result (Num a) [ Overflow ]*
-
 ## Multiply two numbers of the same type.
 ##
 ## (To multiply an #Int and a [Float], first convert one so that they both have the same type. There are functions in the [`Frac`](/Frac) module that can convert both #Int to [Float] and the other way around.)
@@ -557,26 +531,61 @@ mul : Num a, Num a -> Num a
 ## panicking or returning ∞ or -∞, it will return `Err Overflow`.
 mulCheckOverflow : Num a, Num a -> Result (Num a) [ Overflow ]*
 
+## Subtract two numbers of the same type.
+##
+## (To subtract an #Int and a [Float], first convert one so that they both have the same type. There are functions in the [`Frac`](/Frac) module that can convert both #Int to [Float] and the other way around.)
+##
+## `a - b` is shorthand for `Num.sub a b`.
+##
+## >>> 7 - 5
+##
+## >>> Num.sub 7 5
+##
+## `Num.sub` can be convenient in pipelines.
+##
+## >>> Frac.pi
+## >>>     |> Num.sub 2.0
+##
+## If the answer to this operation can't fit in the return value (e.g. an
+## [I8] answer that's higher than 127 or lower than -128), the result is an
+## *overflow*. For [F64] and [F32], overflow results in an answer of either
+## ∞ or -∞. For all other number types, overflow results in a panic.
+sub : Num a, Num a -> Num a
+
+## Subtract two numbers and check for overflow.
+##
+## This is the same as [Num.sub] except if the operation overflows, instead of
+## panicking or returning ∞ or -∞, it will return `Err Overflow`.
+subCheckOverflow : Num a, Num a -> Result (Num a) [ Overflow ]*
+
 ## Convert
 
-## Convert a number to a [Str].
+ceil : Float * -> Int *
+
+## Divide two integers and #Num.round  the resulut.
 ##
-## This is the same as calling `Num.format {}` - so for more details on
-## exact formatting, see [Num.format].
+## Division by zero is undefined in mathematics. As such, you should make
+## sure never to pass zero as the denomaintor to this function!
 ##
-## >>> Num.toStr 42
+## If zero does get passed as the denominator...
 ##
-## Only [Float] values will include a decimal point, and they will always include one.
+## * In a development build, you'll get an assertion failure.
+## * In an optimized build, the function will return 0.
 ##
-## >>> Num.toStr 4.2
+## `a // b` is shorthand for `Num.divRound a b`.
 ##
-## >>> Num.toStr 4.0
+## >>> 5 // 7
 ##
-## When this function is given a non-[finite](Num.isFinite)
-## [F64] or [F32] value, the returned string will be `"NaN"`, `"∞"`, or `"-∞"`.
+## >>> Num.divRound 5 7
 ##
-## To get strings in hexadecimal, octal, or binary format, use [Num.format].
-toStr : Num * -> Str
+## >>> 8 // -3
+##
+## >>> Num.divRound 8 -3
+##
+## This is the same as the #// operator.
+divRound : Int a, Int a -> Int a
+
+floor : Float * -> Int *
 
 ## Convert a number into a [Str], formatted with the given options.
 ##
@@ -640,82 +649,6 @@ format :
     }
     -> Str
 
-## Round off the given float to the nearest integer.
-round : Float * -> Int *
-ceil : Float * -> Int *
-floor : Float * -> Int *
-trunc : Float * -> Int *
-
-## Convert an #Int to a #Nat. If the given number doesn't fit in #Nat, it will be truncated.
-## Since #Nat has a different maximum number depending on the system you're building
-## for, this may give a different answer on different systems.
-##
-## For example, on a 32-bit system, [Num.maxNat] will return the same answer as
-## #Num.maxU32. This means that calling `Num.toNat 9_000_000_000` on a 32-bit
-## system will return #Num.maxU32 instead of 9 billion, because 9 billion is
-## higher than #Num.maxU32 and will not fit in a #Nat on a 32-bit system.
-##
-## However, calling `Num.toNat 9_000_000_000` on a 64-bit system will return
-## the #Nat value of 9_000_000_000. This is because on a 64-bit system, #Nat can
-## hold up to #Num.maxU64, and 9_000_000_000 is lower than #Num.maxU64.
-##
-## To convert a [Float] to a #Nat, first call either #Num.round, #Num.ceil, or #Num.floor
-## on it, then call this on the resulting #Int.
-toNat : Int * -> Nat
-
-## Convert an #Int to an #I8. If the given number doesn't fit in #I8, it will be truncated.
-##
-## To convert a [Float] to an #I8, first call either #Num.round, #Num.ceil, or #Num.floor
-## on it, then call this on the resulting #Int.
-toI8 : Int * -> I8
-toI16 : Int * -> I16
-toI32 : Int * -> I32
-toI64 : Int * -> I64
-toI128 : Int * -> I128
-
-## Convert an #Int to an #U8. If the given number doesn't fit in #U8, it will be truncated.
-## Crashes if the given number is negative.
-toU8 : Int * -> U8
-toU16 : Int * -> U16
-toU32 : Int * -> U32
-toU64 : Int * -> U64
-toU128 : Int * -> U128
-
-## Convert a #Num to a #F32. If the given number can't be precisely represented in a #F32,
-## there will be a loss of precision.
-toF32 : Num * -> F32
-
-## Convert a #Num to a #F64. If the given number can't be precisely represented in a #F64,
-## there will be a loss of precision.
-toF64 : Num * -> F64
-
-## Convert a #Num to a #Dec. If the given number can't be precisely represented in a #Dec,
-## there will be a loss of precision.
-toDec : Num * -> Dec
-
-## Divide two integers and #Num.round  the resulut.
-##
-## Division by zero is undefined in mathematics. As such, you should make
-## sure never to pass zero as the denomaintor to this function!
-##
-## If zero does get passed as the denominator...
-##
-## * In a development build, you'll get an assertion failure.
-## * In an optimized build, the function will return 0.
-##
-## `a // b` is shorthand for `Num.divRound a b`.
-##
-## >>> 5 // 7
-##
-## >>> Num.divRound 5 7
-##
-## >>> 8 // -3
-##
-## >>> Num.divRound 8 -3
-##
-## This is the same as the #// operator.
-divRound : Int a, Int a -> Int a
-
 ## Perform flooring modulo on two integers.
 ##
 ## Modulo is the same as remainder when working with positive numbers,
@@ -738,16 +671,108 @@ divRound : Int a, Int a -> Int a
 ## >>> Int.modFloor -8 -3
 #modFloor : Int a, Int a -> Result (Int a) [ DivByZero ]*
 
+## Round off the given float to the nearest integer.
+round : Float * -> Int *
+
+## Convert a #Num to a #Dec. If the given number can't be precisely represented in a #Dec,
+## there will be a loss of precision.
+toDec : Num * -> Dec
+
+## Convert a #Num to a #F32. If the given number can't be precisely represented in a #F32,
+## there will be a loss of precision.
+toF32 : Num * -> F32
+
+## Convert a #Num to a #F64. If the given number can't be precisely represented in a #F64,
+## there will be a loss of precision.
+toF64 : Num * -> F64
+
+## Convert an #Int to an #I8. If the given number doesn't fit in #I8, it will be truncated.
+##
+## To convert a [Float] to an #I8, first call either #Num.round, #Num.ceil, or #Num.floor
+## on it, then call this on the resulting #Int.
+toI8 : Int * -> I8
+toI16 : Int * -> I16
+toI32 : Int * -> I32
+toI64 : Int * -> I64
+toI128 : Int * -> I128
+
+## Convert an #Int to a #Nat. If the given number doesn't fit in #Nat, it will be truncated.
+## Since #Nat has a different maximum number depending on the system you're building
+## for, this may give a different answer on different systems.
+##
+## For example, on a 32-bit system, [Num.maxNat] will return the same answer as
+## #Num.maxU32. This means that calling `Num.toNat 9_000_000_000` on a 32-bit
+## system will return #Num.maxU32 instead of 9 billion, because 9 billion is
+## higher than #Num.maxU32 and will not fit in a #Nat on a 32-bit system.
+##
+## However, calling `Num.toNat 9_000_000_000` on a 64-bit system will return
+## the #Nat value of 9_000_000_000. This is because on a 64-bit system, #Nat can
+## hold up to #Num.maxU64, and 9_000_000_000 is lower than #Num.maxU64.
+##
+## To convert a [Float] to a #Nat, first call either #Num.round, #Num.ceil, or #Num.floor
+## on it, then call this on the resulting #Int.
+toNat : Int * -> Nat
+
+## Convert a number to a [Str].
+##
+## This is the same as calling `Num.format {}` - so for more details on
+## exact formatting, see [Num.format].
+##
+## >>> Num.toStr 42
+##
+## Only [Float] values will include a decimal point, and they will always include one.
+##
+## >>> Num.toStr 4.2
+##
+## >>> Num.toStr 4.0
+##
+## When this function is given a non-[finite](Num.isFinite)
+## [F64] or [F32] value, the returned string will be `"NaN"`, `"∞"`, or `"-∞"`.
+##
+## To get strings in hexadecimal, octal, or binary format, use [Num.format].
+toStr : Num * -> Str
+
+## Convert an #Int to an #U8. If the given number doesn't fit in #U8, it will be truncated.
+## Crashes if the given number is negative.
+toU8 : Int * -> U8
+toU16 : Int * -> U16
+toU32 : Int * -> U32
+toU64 : Int * -> U64
+toU128 : Int * -> U128
+
+trunc : Float * -> Int *
 
 ## Bitwise
-
-xor : Int a, Int a -> Int a
 
 and : Int a, Int a -> Int a
 
 not : Int a -> Int a
 
+xor : Int a, Int a -> Int a
+
 ## Limits
+
+## The highest supported #Dec value you can have, which is precisely 170_141_183_460_469_231_731.687303715884105727.
+##
+## If you go higher than this, your running Roc code will crash - so be careful not to!
+maxDec : Dec
+
+## The highest supported #F32 value you can have, which is approximately 1.8 × 10^308.
+##
+## If you go higher than this, your running Roc code will crash - so be careful not to!
+maxF32 : F32
+
+## The highest supported #F64 value you can have, which is approximately 1.8 × 10^308.
+##
+## If you go higher than this, your running Roc code will crash - so be careful not to!
+maxF64 : F64
+
+## The highest number that can be stored in an #I32 without overflowing its
+## available memory and crashing.
+##
+## Note that this is smaller than the positive version of #Int.minI32
+## which means if you call #Num.abs on #Int.minI32, it will overflow and crash!
+maxI32 : I32
 
 ## The highest number that can be stored in a #Nat without overflowing its
 ## available memory and crashing.
@@ -757,19 +782,32 @@ not : Int a -> Int a
 ## 32-bit system, this will be equal to #Num.maxU32.
 maxNat : Nat
 
-## The number zero.
-##
-## #Num.minNat is the lowest number that can be stored in a #Nat, which is zero
-## because #Nat is [unsigned](https://en.wikipedia.org/wiki/Signed_number_representations),
-## and zero is the lowest unsigned number. Unsigned numbers cannot be negative.
-minNat : Nat
-
-## The highest number that can be stored in an #I32 without overflowing its
+## The highest number that can be stored in a #U32 without overflowing its
 ## available memory and crashing.
 ##
-## Note that this is smaller than the positive version of #Int.minI32
-## which means if you call #Num.abs on #Int.minI32, it will overflow and crash!
-maxI32 : I32
+## For reference, that number is `4_294_967_295`, which is over 4 million.
+maxU32 : U32
+
+## The highest number that can be stored in a #U64 without overflowing its
+## available memory and crashing.
+##
+## For reference, that number is `18_446_744_073_709_551_615`, which is over 18 quintillion.
+maxU64 : U64
+
+## The lowest supported #Dec value you can have, which is precisely -170_141_183_460_469_231_731.687303715884105728.
+##
+## If you go lower than this, your running Roc code will crash - so be careful not to!
+minDec : Dec
+
+## The lowest supported #F32 value you can have, which is approximately -1.8 × 10^308.
+##
+## If you go lower than this, your running Roc code will crash - so be careful not to!
+minF32 : F32
+
+## The lowest supported #F64 value you can have, which is approximately -1.8 × 10^308.
+##
+## If you go lower than this, your running Roc code will crash - so be careful not to!
+minF64 : F64
 
 ## The min number that can be stored in an #I32 without overflowing its
 ## available memory and crashing.
@@ -778,24 +816,12 @@ maxI32 : I32
 ## #Int.maxI32, which means if you call #Num.abs on #Int.minI32, it will overflow and crash!
 minI32 : I32
 
-## The highest number that can be stored in a #U64 without overflowing its
-## available memory and crashing.
-##
-## For reference, that number is `18_446_744_073_709_551_615`, which is over 18 quintillion.
-maxU64 : U64
-
 ## The number zero.
 ##
-## #Num.minU64 is the lowest number that can be stored in a #U64, which is zero
-## because #U64 is [unsigned](https://en.wikipedia.org/wiki/Signed_number_representations),
+## #Num.minNat is the lowest number that can be stored in a #Nat, which is zero
+## because #Nat is [unsigned](https://en.wikipedia.org/wiki/Signed_number_representations),
 ## and zero is the lowest unsigned number. Unsigned numbers cannot be negative.
-minU64 : U64
-
-## The highest number that can be stored in a #U32 without overflowing its
-## available memory and crashing.
-##
-## For reference, that number is `4_294_967_295`, which is over 4 million.
-maxU32 : U32
+minNat : Nat
 
 ## The number zero.
 ##
@@ -804,35 +830,12 @@ maxU32 : U32
 ## and zero is the lowest unsigned number. Unsigned numbers cannot be negative.
 minU32 : U32
 
-## The highest supported #F64 value you can have, which is approximately 1.8 × 10^308.
+## The number zero.
 ##
-## If you go higher than this, your running Roc code will crash - so be careful not to!
-maxF64 : F64
-
-## The lowest supported #F64 value you can have, which is approximately -1.8 × 10^308.
-##
-## If you go lower than this, your running Roc code will crash - so be careful not to!
-minF64 : F64
-
-## The highest supported #F32 value you can have, which is approximately 1.8 × 10^308.
-##
-## If you go higher than this, your running Roc code will crash - so be careful not to!
-maxF32 : F32
-
-## The lowest supported #F32 value you can have, which is approximately -1.8 × 10^308.
-##
-## If you go lower than this, your running Roc code will crash - so be careful not to!
-minF32 : F32
-
-## The highest supported #Dec value you can have, which is precisely 170_141_183_460_469_231_731.687303715884105727.
-##
-## If you go higher than this, your running Roc code will crash - so be careful not to!
-maxDec : Dec
-
-## The lowest supported #Dec value you can have, which is precisely -170_141_183_460_469_231_731.687303715884105728.
-##
-## If you go lower than this, your running Roc code will crash - so be careful not to!
-minDec : Dec
+## #Num.minU64 is the lowest number that can be stored in a #U64, which is zero
+## because #U64 is [unsigned](https://en.wikipedia.org/wiki/Signed_number_representations),
+## and zero is the lowest unsigned number. Unsigned numbers cannot be negative.
+minU64 : U64
 
 ## Constants
 
@@ -844,17 +847,17 @@ pi : Float *
 
 ## Trigonometry
 
-cos : Float a -> Float a
-
 acos : Float a -> Float a
-
-sin : Float a -> Float a
 
 asin : Float a -> Float a
 
-tan : Float a -> Float a
-
 atan : Float a -> Float a
+
+cos : Float a -> Float a
+
+sin : Float a -> Float a
+
+tan : Float a -> Float a
 
 ## Other Calculations (arithmetic?)
 
@@ -890,6 +893,28 @@ atan : Float a -> Float a
 ## >>>     |> Num.div 2.0
 div : Float a, Float a -> Float a
 
+## Raises an integer to the power of another, by multiplying the integer by
+## itself the given number of times.
+##
+## This process is known as [exponentiation by squaring](https://en.wikipedia.org/wiki/Exponentiation_by_squaring).
+##
+## For a [Float] alternative to this function, which supports negative exponents,
+## see #Num.exp.
+##
+## >>> Num.exp 5 0
+##
+## >>> Num.exp 5 1
+##
+## >>> Num.exp 5 2
+##
+## >>> Num.exp 5 6
+##
+## ## Performance Notes
+##
+## Be careful! Even though this function takes only a #U8, it is very easy to
+## overflow
+expBySquaring : Int a, U8 -> Int a
+
 ## Perform modulo on two [Float]s.
 ##
 ## Modulo is the same as remainder when working with positive numbers,
@@ -921,28 +946,6 @@ mod : Float a, Float a -> Float a
 ## For an #Int alternative to this function, see #Num.raise.
 pow : Float a, Float a -> Float a
 
-## Raises an integer to the power of another, by multiplying the integer by
-## itself the given number of times.
-##
-## This process is known as [exponentiation by squaring](https://en.wikipedia.org/wiki/Exponentiation_by_squaring).
-##
-## For a [Float] alternative to this function, which supports negative exponents,
-## see #Num.exp.
-##
-## >>> Num.exp 5 0
-##
-## >>> Num.exp 5 1
-##
-## >>> Num.exp 5 2
-##
-## >>> Num.exp 5 6
-##
-## ## Performance Notes
-##
-## Be careful! Even though this function takes only a #U8, it is very easy to
-## overflow
-expBySquaring : Int a, U8 -> Int a
-
 ## Returns an approximation of the absolute value of a [Float]'s square root.
 ##
 ## The square root of a negative number is an irrational number, and [Float] only
@@ -973,6 +976,19 @@ sqrt : Float a -> Float a
 
 ## Bit shifts
 
+## [Endianness](https://en.wikipedia.org/wiki/Endianness)
+# Endi : [ Big, Little, Native ]
+
+## when Num.fromBytes bytes Big is
+##     Ok f64 -> ...
+##     Err (ExpectedNum (Float Binary64)) -> ...
+# fromBytes : List U8, Endi -> Result (Num a) [ ExpectedNum a ]*
+
+## when Num.parseBytes bytes Big is
+##     Ok { val: f64, rest } -> ...
+##     Err (ExpectedNum (Float Binary64)) -> ...
+# parseBytes : List U8, Endi -> Result { val : Num a, rest : List U8 } [ ExpectedNum a ]*
+
 ## [Logical bit shift](https://en.wikipedia.org/wiki/Bitwise_operation#Logical_shift) left.
 ##
 ## `a << b` is shorthand for `Num.shl a b`.
@@ -997,43 +1013,34 @@ shr : Int a, Int a -> Int a
 ## the beginning. (In contrast, [shr] replaces discarded bits with zeroes.)
 shrWrap : Int a, Int a -> Int a
 
-## [Endianness](https://en.wikipedia.org/wiki/Endianness)
-# Endi : [ Big, Little, Native ]
-
 ## The `Endi` argument does not matter for [U8] and [I8], since they have
 ## only one byte.
 # toBytes : Num *, Endi -> List U8
 
-## when Num.parseBytes bytes Big is
-##     Ok { val: f64, rest } -> ...
-##     Err (ExpectedNum (Float Binary64)) -> ...
-# parseBytes : List U8, Endi -> Result { val : Num a, rest : List U8 } [ ExpectedNum a ]*
-
-## when Num.fromBytes bytes Big is
-##     Ok f64 -> ...
-##     Err (ExpectedNum (Float Binary64)) -> ...
-# fromBytes : List U8, Endi -> Result (Num a) [ ExpectedNum a ]*
-
 ## Comparison
 
-## Returns `True` if the first number is less than the second.
-##
-## `a < b` is shorthand for `Num.isLt a b`.
-##
-## If either argument is [*NaN*](Num.isNaN), returns `False` no matter what. (*NaN*
-## is [defined to be unordered](https://en.wikipedia.org/wiki/NaN#Comparison_with_NaN).)
-##
-## >>> 5
-## >>>     |> Num.isLt 6
-isLt : Num a, Num a -> Bool
+# Branchless implementation that works for all numeric types:
+#
+# let is_lt = arg1 < arg2;
+# let is_eq = arg1 == arg2;
+# return (is_lt as i8 - is_eq as i8) + 1;
+#
+# 1, 1 -> (0 - 1) + 1 == 0 # Eq
+# 5, 1 -> (0 - 0) + 1 == 1 # Gt
+# 1, 5 -> (1 - 0) + 1 == 2 # Lt
 
-## Returns `True` if the first number is less than or equal to the second.
+## Returns `Lt` if the first number is less than the second, `Gt` if
+## the first is greater than the second, and `Eq` if they're equal.
 ##
-## `a <= b` is shorthand for `Num.isLte a b`.
+## Although this can be passed to `List.sort`, you'll get better performance
+## by using `List.sortAsc` or `List.sortDesc` instead.
+compare : Num a, Num a -> [ Lt, Eq, Gt ]
+
+## Returns the higher of two numbers.
 ##
 ## If either argument is [*NaN*](Num.isNaN), returns `False` no matter what. (*NaN*
 ## is [defined to be unordered](https://en.wikipedia.org/wiki/NaN#Comparison_with_NaN).)
-isLte : Num a, Num a -> Bool
+higher : Num a, Num a -> Num a
 
 ## Returns `True` if the first number is greater than the second.
 ##
@@ -1054,34 +1061,30 @@ isGt : Num a, Num a -> Bool
 ## is [defined to be unordered](https://en.wikipedia.org/wiki/NaN#Comparison_with_NaN).)
 isGte : Num a, Num a -> Bool
 
-## Returns the higher of two numbers.
+## Returns `True` if the first number is less than the second.
+##
+## `a < b` is shorthand for `Num.isLt a b`.
 ##
 ## If either argument is [*NaN*](Num.isNaN), returns `False` no matter what. (*NaN*
 ## is [defined to be unordered](https://en.wikipedia.org/wiki/NaN#Comparison_with_NaN).)
-higher : Num a, Num a -> Num a
+##
+## >>> 5
+## >>>     |> Num.isLt 6
+isLt : Num a, Num a -> Bool
+
+## Returns `True` if the first number is less than or equal to the second.
+##
+## `a <= b` is shorthand for `Num.isLte a b`.
+##
+## If either argument is [*NaN*](Num.isNaN), returns `False` no matter what. (*NaN*
+## is [defined to be unordered](https://en.wikipedia.org/wiki/NaN#Comparison_with_NaN).)
+isLte : Num a, Num a -> Bool
 
 ## Returns the lower of two numbers.
 ##
 ## If either argument is [*NaN*](Num.isNaN), returns `False` no matter what. (*NaN*
 ## is [defined to be unordered](https://en.wikipedia.org/wiki/NaN#Comparison_with_NaN).)
 lower : Num a, Num a -> Num a
-
-# Branchless implementation that works for all numeric types:
-#
-# let is_lt = arg1 < arg2;
-# let is_eq = arg1 == arg2;
-# return (is_lt as i8 - is_eq as i8) + 1;
-#
-# 1, 1 -> (0 - 1) + 1 == 0 # Eq
-# 5, 1 -> (0 - 0) + 1 == 1 # Gt
-# 1, 5 -> (1 - 0) + 1 == 2 # Lt
-
-## Returns `Lt` if the first number is less than the second, `Gt` if
-## the first is greater than the second, and `Eq` if they're equal.
-##
-## Although this can be passed to `List.sort`, you'll get better performance
-## by using `List.sortAsc` or `List.sortDesc` instead.
-compare : Num a, Num a -> [ Lt, Eq, Gt ]
 
 ## Special Floating-Point Values
 

--- a/compiler/builtins/docs/Result.roc
+++ b/compiler/builtins/docs/Result.roc
@@ -15,24 +15,6 @@ interface Result
 ## okay, or else there was an error of some sort.
 Result ok err : [ @Result ok err ]
 
-## Return True if the result indicates a success, else return False
-##
-## >>> Result.isOk (Ok 5)
-isOk : Result * * -> bool
-
-## Return True if the result indicates a failure, else return False
-##
-## >>> Result.isErr (Err "uh oh")
-isErr : Result * * -> bool
-
-## If the result is `Ok`, return the value it holds. Otherwise, return
-## the given default value.
-##
-## >>> Result.withDefault (Ok 7) 42
-##
-## >>> Result.withDefault (Err "uh oh") 42
-withDefault : Result ok err, ok -> ok
-
 ## If the result is `Ok`, transform the entire result by running a conversion
 ## function on the value the `Ok` holds. Then return that new result.
 ##
@@ -42,6 +24,16 @@ withDefault : Result ok err, ok -> ok
 ##
 ## >>> Result.after (Err "yipes!") \num -> if num < 0 then Err "negative!" else Ok -num
 after : Result before err, (before -> Result after err) -> Result after err
+
+## Return True if the result indicates a success, else return False
+##
+## >>> Result.isOk (Ok 5)
+isOk : Result * * -> bool
+
+## Return True if the result indicates a failure, else return False
+##
+## >>> Result.isErr (Err "uh oh")
+isErr : Result * * -> bool
 
 ## If the result is `Ok`, transform the value it holds by running a conversion
 ## function on it. Then return a new `Ok` holding the transformed value.
@@ -65,3 +57,11 @@ map : Result before err, (before -> after) -> Result after err
 ##
 ## >>> Result.mapErr (Ok 12) Str.isEmpty
 mapErr : Result ok before, (before -> after) -> Result ok after
+
+## If the result is `Ok`, return the value it holds. Otherwise, return
+## the given default value.
+##
+## >>> Result.withDefault (Ok 7) 42
+##
+## >>> Result.withDefault (Err "uh oh") 42
+withDefault : Result ok err, ok -> ok

--- a/compiler/builtins/docs/Str.roc
+++ b/compiler/builtins/docs/Str.roc
@@ -125,22 +125,6 @@ Str : [ @Str ]
 ## If you want to keep all the digits, use [Str.num] instead.
 decimal : Float *, Nat -> Str
 
-
-## Convert a [Num] to a string.
-num : Float *, Nat -> Str
-
-## Split a string around a separator.
-##
-## >>> Str.split "1,2,3" ","
-##
-## Passing `""` for the separator is not useful; it returns the original string
-## wrapped in a list.
-##
-## >>> Str.split "1,2,3" ""
-##
-## To split a string into its individual graphemes, use `Str.graphemes`
-split : Str, Str -> List Str
-
 ## Split a string around newlines.
 ##
 ## On strings that use `"\n"` for their line endings, this gives the same answer
@@ -156,7 +140,30 @@ split : Str, Str -> List Str
 ## string splitting, use a #Parser.
 lines : Str, Str -> List Str
 
+## Split a string around a separator.
+##
+## >>> Str.split "1,2,3" ","
+##
+## Passing `""` for the separator is not useful; it returns the original string
+## wrapped in a list.
+##
+## >>> Str.split "1,2,3" ""
+##
+## To split a string into its individual graphemes, use `Str.graphemes`
+split : Str, Str -> List Str
+
+## Convert a [Num] to a string.
+num : Float *, Nat -> Str
+
 ## Check
+
+allGraphemes : Str, (Str -> Bool) -> Bool
+
+anyGraphemes : Str, (Str -> Bool) -> Bool
+
+contains : Str, Str -> Bool
+
+endsWith : Str, Str -> Bool
 
 ## Returns `True` if the string is empty, and `False` otherwise.
 ##
@@ -183,14 +190,6 @@ startsWith : Str, Str -> Bool
 ## single [U32]. You'd need to use `Str.startsWithCodePt "🕊"` instead.
 startsWithCodePt : Str, U32 -> Bool
 
-endsWith : Str, Str -> Bool
-
-contains : Str, Str -> Bool
-
-anyGraphemes : Str, (Str -> Bool) -> Bool
-
-allGraphemes : Str, (Str -> Bool) -> Bool
-
 ## Combine
 
 ## Combine a list of strings into a single string.
@@ -204,18 +203,6 @@ join : List Str -> Str
 ## >>> Str.joinWith [ "one", "two", "three" ] ", "
 joinWith : List Str, Str -> Str
 
-## Add to the start of a string until it has at least the given number of
-## graphemes.
-##
-## >>> Str.padGraphemesStart "0" 5 "36"
-##
-## >>> Str.padGraphemesStart "0" 1 "36"
-##
-## >>> Str.padGraphemesStart "0" 5 "12345"
-##
-## >>> Str.padGraphemesStart "✈️"" 5 "👩‍👩‍👦‍👦👩‍👩‍👦‍👦👩‍👩‍👦‍👦"
-padGraphemesStart : Str, Nat, Str -> Str
-
 ## Add to the end of a string until it has at least the given number of
 ## graphemes.
 ##
@@ -228,15 +215,19 @@ padGraphemesStart : Str, Nat, Str -> Str
 ## >>> Str.padGraphemesStart "✈️"" 5 "👩‍👩‍👦‍👦👩‍👩‍👦‍👦👩‍👩‍👦‍👦"
 padGraphemesEnd : Str, Nat, Str -> Str
 
-## Graphemes
+## Add to the start of a string until it has at least the given number of
+## graphemes.
+##
+## >>> Str.padGraphemesStart "0" 5 "36"
+##
+## >>> Str.padGraphemesStart "0" 1 "36"
+##
+## >>> Str.padGraphemesStart "0" 5 "12345"
+##
+## >>> Str.padGraphemesStart "✈️"" 5 "👩‍👩‍👦‍👦👩‍👩‍👦‍👦👩‍👩‍👦‍👦"
+padGraphemesStart : Str, Nat, Str -> Str
 
-## Split a string into its individual graphemes.
-##
-## >>> Str.graphemes "1,2,3"
-##
-## >>> Str.graphemes  "👍👍👍"
-##
-graphemes : Str -> List Str
+## Graphemes
 
 ## Count the number of [extended grapheme clusters](http://www.unicode.org/glossary/#extended_grapheme_cluster)
 ## in the string.
@@ -246,26 +237,47 @@ graphemes : Str -> List Str
 ##     Str.countGraphemes "🕊"     # 1
 countGraphemes : Str -> Nat
 
-## Reverse the order of the string's individual graphemes.
+## Returns `True` if the string consists entirely of lowercase letters.
 ##
-## >>> Str.reverseGraphemes "1-2-3"
+## >>> Str.isAllLowercase "hi"
 ##
-## >>> Str.reverseGraphemes  "🐦✈️"👩‍👩‍👦‍👦"
+## >>> Str.isAllLowercase "Hi"
 ##
-## >>> Str.reversegraphemes "Crème Brûlée"
-reverseGraphemes : Str -> Str
+## >>> Str.isAllLowercase "HI"
+##
+## >>> Str.isAllLowercase " Hi"
+##
+## >>> Str.isAllLowercase "Česká"
+##
+## >>> Str.isAllLowercase "Э"
+##
+## >>> Str.isAllLowercase "東京"
+##
+## >>> Str.isAllLowercase "🐦"
+##
+## >>> Str.isAllLowercase ""
+isAllLowercase : Str -> Bool
 
-## Returns `True` if the two strings are equal when ignoring case.
+## Returns `True` if the string consists entirely of uppercase letters.
 ##
-## >>> Str.caseInsensitiveEq "hi" "Hi"
-isCaseInsensitiveEq : Str, Str -> Bool
-
-isCaseInsensitiveNeq : Str, Str -> Bool
-
-walkGraphemes : Str, { start: state, step: (state, Str -> state) } -> state
-walkGraphemesUntil : Str, { start: state, step: (state, Str -> [ Continue state, Done state ]) } -> state
-walkGraphemesBackwards : Str, { start: state, step: (state, Str -> state) } -> state
-walkGraphemesBackwardsUntil : Str, { start: state, step: (state, Str -> [ Continue state, Done state ]) } -> state
+## >>> Str.isAllUppercase "hi"
+##
+## >>> Str.isAllUppercase "Hi"
+##
+## >>> Str.isAllUppercase "HI"
+##
+## >>> Str.isAllUppercase " Hi"
+##
+## >>> Str.isAllUppercase "Česká"
+##
+## >>> Str.isAllUppercase "Э"
+##
+## >>> Str.isAllUppercase "東京"
+##
+## >>> Str.isAllUppercase "🐦"
+##
+## >>> Str.isAllUppercase ""
+isAllUppercase : Str -> Bool
 
 ## Returns `True` if the string begins with an uppercase letter.
 ##
@@ -292,60 +304,18 @@ walkGraphemesBackwardsUntil : Str, { start: state, step: (state, Str -> [ Contin
 ## package for functions which capitalize strings.
 isCapitalized : Str -> Bool
 
-## Returns `True` if the string consists entirely of uppercase letters.
+## Returns `True` if the two strings are equal when ignoring case.
 ##
-## >>> Str.isAllUppercase "hi"
-##
-## >>> Str.isAllUppercase "Hi"
-##
-## >>> Str.isAllUppercase "HI"
-##
-## >>> Str.isAllUppercase " Hi"
-##
-## >>> Str.isAllUppercase "Česká"
-##
-## >>> Str.isAllUppercase "Э"
-##
-## >>> Str.isAllUppercase "東京"
-##
-## >>> Str.isAllUppercase "🐦"
-##
-## >>> Str.isAllUppercase ""
-isAllUppercase : Str -> Bool
+## >>> Str.caseInsensitiveEq "hi" "Hi"
+isCaseInsensitiveEq : Str, Str -> Bool
 
-## Returns `True` if the string consists entirely of lowercase letters.
-##
-## >>> Str.isAllLowercase "hi"
-##
-## >>> Str.isAllLowercase "Hi"
-##
-## >>> Str.isAllLowercase "HI"
-##
-## >>> Str.isAllLowercase " Hi"
-##
-## >>> Str.isAllLowercase "Česká"
-##
-## >>> Str.isAllLowercase "Э"
-##
-## >>> Str.isAllLowercase "東京"
-##
-## >>> Str.isAllLowercase "🐦"
-##
-## >>> Str.isAllLowercase ""
-isAllLowercase : Str -> Bool
-
-## Return the string with any blank spaces removed from both the beginning
-## as well as the end.
-trim : Str -> Str
+isCaseInsensitiveNeq : Str, Str -> Bool
 
 ## If the given [U32] is a valid [Unicode Scalar Value](http://www.unicode.org/glossary/#unicode_scalar_value),
 ## return a [Str] containing only that scalar.
-fromScalar : U32 -> Result Str [ BadScalar ]*
 fromCodePts : List U32 -> Result Str [ BadCodePt U32 ]*
+fromScalar : U32 -> Result Str [ BadScalar ]*
 fromUtf8 : List U8 -> Result Str [ BadUtf8 ]*
-
-## Create a [Str] from bytes encoded as [UTF-16LE](https://en.wikipedia.org/wiki/UTF-16#Byte-order_encoding_schemes).
-# fromUtf16Le : List U8 -> Result Str [ BadUtf16Le Endi ]*
 
 # ## Create a [Str] from bytes encoded as [UTF-16BE](https://en.wikipedia.org/wiki/UTF-16#Byte-order_encoding_schemes).
 # fromUtf16Be : List U8 -> Result Str [ BadUtf16Be Endi ]*
@@ -353,8 +323,8 @@ fromUtf8 : List U8 -> Result Str [ BadUtf8 ]*
 # ## Create a [Str] from bytes encoded as UTF-16 with a [Byte Order Mark](https://en.wikipedia.org/wiki/Byte_order_mark).
 # fromUtf16Bom : List U8 -> Result Str [ BadUtf16 Endi, NoBom ]*
 
-# ## Create a [Str] from bytes encoded as [UTF-32LE](https://web.archive.org/web/20120322145307/http://mail.apps.ietf.org/ietf/charsets/msg01095.html)
-# fromUtf32Le : List U8 -> Result Str [ BadUtf32Le Endi ]*
+## Create a [Str] from bytes encoded as [UTF-16LE](https://en.wikipedia.org/wiki/UTF-16#Byte-order_encoding_schemes).
+# fromUtf16Le : List U8 -> Result Str [ BadUtf16Le Endi ]*
 
 # ## Create a [Str] from bytes encoded as [UTF-32BE](https://web.archive.org/web/20120322145307/http://mail.apps.ietf.org/ietf/charsets/msg01095.html)
 # fromUtf32Be : List U8 -> Result Str [ BadUtf32Be Endi ]*
@@ -362,11 +332,31 @@ fromUtf8 : List U8 -> Result Str [ BadUtf8 ]*
 # ## Create a [Str] from bytes encoded as UTF-32 with a [Byte Order Mark](https://en.wikipedia.org/wiki/Byte_order_mark).
 # fromUtf32Bom : List U8 -> Result Str [ BadUtf32 Endi, NoBom ]*
 
+# ## Create a [Str] from bytes encoded as [UTF-32LE](https://web.archive.org/web/20120322145307/http://mail.apps.ietf.org/ietf/charsets/msg01095.html)
+# fromUtf32Le : List U8 -> Result Str [ BadUtf32Le Endi ]*
+
 # ## Convert from UTF-8, substituting the replacement character ("�") for any
 # ## invalid sequences encountered.
 # fromUtf8Sub : List U8 -> Str
-# fromUtf16Sub : List U8, Endi -> Str
 # fromUtf16BomSub : List U8 -> Result Str [ NoBom ]*
+# fromUtf16Sub : List U8, Endi -> Str
+
+## Split a string into its individual graphemes.
+##
+## >>> Str.graphemes "1,2,3"
+##
+## >>> Str.graphemes  "👍👍👍"
+##
+graphemes : Str -> List Str
+
+## Reverse the order of the string's individual graphemes.
+##
+## >>> Str.reverseGraphemes "1-2-3"
+##
+## >>> Str.reverseGraphemes  "🐦✈️"👩‍👩‍👦‍👦"
+##
+## >>> Str.reversegraphemes "Crème Brûlée"
+reverseGraphemes : Str -> Str
 
 ## Return a [List] of the string's [U8] UTF-8 [code units](https://unicode.org/glossary/#code_unit).
 ## (To split the string into a [List] of smaller [Str] values instead of [U8] values,
@@ -384,27 +374,22 @@ fromUtf8 : List U8 -> Result Str [ BadUtf8 ]*
 ## without creating a [List], see `Str.walkUtf8` and `Str.walkRevUtf8`.
 toUtf8 : Str -> List U8
 toUtf16Be : Str -> List U8
-toUtf16Le : Str -> List U8
 # toUtf16Bom : Str, Endi -> List U8
+toUtf16Le : Str -> List U8
 toUtf32Be : Str -> List U8
-toUtf32Le : Str -> List U8
 # toUtf32Bom : Str, Endi -> List U8
+toUtf32Le : Str -> List U8
+
+## Return the string with any blank spaces removed from both the beginning
+## as well as the end.
+trim : Str -> Str
+
+walkGraphemes : Str, { start: state, step: (state, Str -> state) } -> state
+walkGraphemesBackwards : Str, { start: state, step: (state, Str -> state) } -> state
+walkGraphemesBackwardsUntil : Str, { start: state, step: (state, Str -> [ Continue state, Done state ]) } -> state
+walkGraphemesUntil : Str, { start: state, step: (state, Str -> [ Continue state, Done state ]) } -> state
 
 # Parsing
-
-## If the string begins with a valid [extended grapheme cluster](http://www.unicode.org/glossary/#extended_grapheme_cluster),
-## return it along with the rest of the string after that grapheme.
-##
-## If the string does not begin with a full grapheme, for example because it was
-## empty, return `Err`.
-parseGrapheme : Str -> Result { val : Str, rest : Str } [ Expected [ Grapheme ]* Str ]*
-
-## If the string begins with a valid [Unicode code point](http://www.unicode.org/glossary/#code_point),
-## return it along with the rest of the string after that code point.
-##
-## If the string does not begin with a valid code point, for example because it was
-## empty, return `Err`.
-parseCodePt : Str -> Result { val : U32, rest : Str } [ Expected [ CodePt ]* Str ]*
 
 ## If the first string begins with the second, return whatever comes
 ## after the second.
@@ -414,38 +399,19 @@ chomp : Str, Str -> Result Str [ Expected [ ExactStr Str ]* Str ]*
 ## equal to the given [U32], return whatever comes after that code point.
 chompCodePt : Str, U32 -> Result Str [ Expected [ ExactCodePt U32 ]* Str ]*
 
-## If the string represents a valid [U8] number, return that number.
+## If the string begins with a valid [Unicode code point](http://www.unicode.org/glossary/#code_point),
+## return it along with the rest of the string after that code point.
 ##
-## For more advanced options, see [parseU8].
-toU8 : Str -> Result U8 [ InvalidU8 ]*
-toI8 : Str -> Result I8 [ InvalidI8 ]*
-toU16 : Str -> Result U16 [ InvalidU16 ]*
-toI16 : Str -> Result I16 [ InvalidI16 ]*
-toU32 : Str -> Result U32 [ InvalidU32 ]*
-toI32 : Str -> Result I32 [ InvalidI32 ]*
-toU64 : Str -> Result U64 [ InvalidU64 ]*
-toI64 : Str -> Result I64 [ InvalidI64 ]*
-toU128 : Str -> Result U128 [ InvalidU128 ]*
-toI128 : Str -> Result I128 [ InvalidI128 ]*
-toF64 : Str -> Result U128 [ InvalidF64 ]*
-toF32 : Str -> Result I128 [ InvalidF32 ]*
-toDec : Str -> Result Dec [ InvalidDec ]*
+## If the string does not begin with a valid code point, for example because it was
+## empty, return `Err`.
+parseCodePt : Str -> Result { val : U32, rest : Str } [ Expected [ CodePt ]* Str ]*
 
-## If the string represents a valid number, return that number.
+## If the string begins with a valid [extended grapheme cluster](http://www.unicode.org/glossary/#extended_grapheme_cluster),
+## return it along with the rest of the string after that grapheme.
 ##
-## The exact number type to look for will be inferred from usage.
-## In the example below, the usage of I64 in the type signature will require that type instead of (Num *).
-##
-## >>> strToI64 : Str -> Result I64 [ InvalidNumStr ]*
-## >>> strToI64 = \inputStr ->
-## >>>     Str.toNum inputStr
-##
-## If the string is exactly `"NaN"`, `"∞"`, or `"-∞"`, they will be accepted
-## only when converting to [F64] or [F32] numbers, and will be translated accordingly.
-##
-## This never accepts numbers with underscores or commas in them. For more
-## advanced options, see [parseNum].
-toNum : Str -> Result (Num *) [ InvalidNumStr ]*
+## If the string does not begin with a full grapheme, for example because it was
+## empty, return `Err`.
+parseGrapheme : Str -> Result { val : Str, rest : Str } [ Expected [ Grapheme ]* Str ]*
 
 ## If the string begins with an [Int] or a [finite](Num.isFinite) [Frac], return
 ## that number along with the rest of the string after it.
@@ -476,3 +442,39 @@ toNum : Str -> Result (Num *) [ InvalidNumStr ]*
 #         trailingZeroes ? [ Allowed, Disallowed ],
 #         wholeSep ? { mark : Str, policy : [ Allowed, Required U64 ] }
 #     }
+
+toDec : Str -> Result Dec [ InvalidDec ]*
+
+toF32 : Str -> Result I128 [ InvalidF32 ]*
+toF64 : Str -> Result U128 [ InvalidF64 ]*
+
+toI8 : Str -> Result I8 [ InvalidI8 ]*
+toI16 : Str -> Result I16 [ InvalidI16 ]*
+toI32 : Str -> Result I32 [ InvalidI32 ]*
+toI64 : Str -> Result I64 [ InvalidI64 ]*
+toI128 : Str -> Result I128 [ InvalidI128 ]*
+
+## If the string represents a valid number, return that number.
+##
+## The exact number type to look for will be inferred from usage.
+## In the example below, the usage of I64 in the type signature will require that type instead of (Num *).
+##
+## >>> strToI64 : Str -> Result I64 [ InvalidNumStr ]*
+## >>> strToI64 = \inputStr ->
+## >>>     Str.toNum inputStr
+##
+## If the string is exactly `"NaN"`, `"∞"`, or `"-∞"`, they will be accepted
+## only when converting to [F64] or [F32] numbers, and will be translated accordingly.
+##
+## This never accepts numbers with underscores or commas in them. For more
+## advanced options, see [parseNum].
+toNum : Str -> Result (Num *) [ InvalidNumStr ]*
+
+## If the string represents a valid [U8] number, return that number.
+##
+## For more advanced options, see [parseU8].
+toU8 : Str -> Result U8 [ InvalidU8 ]*
+toU16 : Str -> Result U16 [ InvalidU16 ]*
+toU32 : Str -> Result U32 [ InvalidU32 ]*
+toU64 : Str -> Result U64 [ InvalidU64 ]*
+toU128 : Str -> Result U128 [ InvalidU128 ]*


### PR DESCRIPTION
I think this is probably a good idea, but I'm not sure.

Currently, within their sections, docs definitions are sorted loosely by logical associations (and recency of implementation?).
This PR maintains the sections as-is but changes the sub-section sorting algorithm from logical(/chronological?) to alphabetical.

If there are any missing-but-implied section headers, then this will accidentally merge those sections.

Merging this PR should wait until after #2235 is merged.