### PR TITLE
Remove trailing whitespace from the output of the formatter

### DIFF
--- a/compiler/fmt/src/annotation.rs
+++ b/compiler/fmt/src/annotation.rs
@@ -176,11 +176,13 @@ impl<'a> Formattable for TypeAnnotation<'a> {
                     );
 
                     if it.peek().is_some() {
-                        buf.push_str(", ");
+                        buf.push_str(",");
+                        buf.spaces(1);
                     }
                 }
 
-                buf.push_str(" -> ");
+                buf.push_str(" ->");
+                buf.spaces(1);
 
                 (&result.value).format_with_options(
                     buf,
@@ -210,7 +212,7 @@ impl<'a> Formattable for TypeAnnotation<'a> {
                 buf.push_str(name);
 
                 for argument in *arguments {
-                    buf.push(' ');
+                    buf.spaces(1);
                     (&argument.value).format_with_options(
                         buf,
                         Parens::InApply,
@@ -246,7 +248,8 @@ impl<'a> Formattable for TypeAnnotation<'a> {
             As(lhs, _spaces, rhs) => {
                 // TODO use spaces?
                 lhs.value.format(buf, indent);
-                buf.push_str(" as ");
+                buf.push_str(" as");
+                buf.spaces(1);
                 rhs.value.format(buf, indent);
             }
 
@@ -288,7 +291,7 @@ impl<'a> Formattable for AssignedField<'a, TypeAnnotation<'a>> {
         indent: u16,
     ) {
         // we abuse the `Newlines` type to decide between multiline or single-line layout
-        format_assigned_field_help(self, buf, parens, indent, " ", newlines == Newlines::Yes);
+        format_assigned_field_help(self, buf, parens, indent, 1, newlines == Newlines::Yes);
     }
 }
 
@@ -305,7 +308,7 @@ impl<'a> Formattable for AssignedField<'a, Expr<'a>> {
         indent: u16,
     ) {
         // we abuse the `Newlines` type to decide between multiline or single-line layout
-        format_assigned_field_help(self, buf, parens, indent, "", newlines == Newlines::Yes);
+        format_assigned_field_help(self, buf, parens, indent, 0, newlines == Newlines::Yes);
     }
 }
 
@@ -327,7 +330,7 @@ fn format_assigned_field_help<'a, 'buf, T>(
     buf: &mut Buf<'buf>,
     parens: Parens,
     indent: u16,
-    separator_prefix: &str,
+    separator_spaces: usize,
     is_multiline: bool,
 ) where
     T: Formattable,
@@ -347,8 +350,9 @@ fn format_assigned_field_help<'a, 'buf, T>(
                 fmt_spaces(buf, spaces.iter(), indent);
             }
 
-            buf.push_str(separator_prefix);
-            buf.push_str(": ");
+            buf.spaces(separator_spaces);
+            buf.push_str(":");
+            buf.spaces(1);
             ann.value.format(buf, indent);
         }
         OptionalValue(name, spaces, ann) => {
@@ -363,7 +367,7 @@ fn format_assigned_field_help<'a, 'buf, T>(
                 fmt_spaces(buf, spaces.iter(), indent);
             }
 
-            buf.push_str(separator_prefix);
+            buf.spaces(separator_spaces);
             buf.push('?');
             ann.value.format(buf, indent);
         }
@@ -382,7 +386,7 @@ fn format_assigned_field_help<'a, 'buf, T>(
                 buf,
                 parens,
                 indent,
-                separator_prefix,
+                separator_spaces,
                 is_multiline,
             );
         }
@@ -392,7 +396,7 @@ fn format_assigned_field_help<'a, 'buf, T>(
                 buf,
                 parens,
                 indent,
-                separator_prefix,
+                separator_spaces,
                 is_multiline,
             );
             fmt_comments_only(buf, spaces.iter(), NewlineAt::Bottom, indent);
@@ -438,7 +442,7 @@ impl<'a> Formattable for Tag<'a> {
                     }
                 } else {
                     for arg in *args {
-                        buf.push(' ');
+                        buf.spaces(1);
                         arg.format_with_options(buf, Parens::InApply, Newlines::No, indent);
                     }
                 }
@@ -456,7 +460,7 @@ impl<'a> Formattable for Tag<'a> {
                     }
                 } else {
                     for arg in *args {
-                        buf.push(' ');
+                        buf.spaces(1);
                         arg.format_with_options(buf, Parens::InApply, Newlines::No, indent);
                     }
                 }

--- a/compiler/fmt/src/collection.rs
+++ b/compiler/fmt/src/collection.rs
@@ -52,14 +52,13 @@ pub fn fmt_collection<'a, 'buf, T: ExtractSpaces<'a> + Formattable>(
             item_indent,
         );
         buf.newline();
-        buf.indent(braces_indent);
     } else {
         // is_multiline == false
         // there is no comment to add
         buf.push(start);
         let mut iter = items.iter().peekable();
         while let Some(item) = iter.next() {
-            buf.push(' ');
+            buf.spaces(1);
             item.format(buf, indent);
             if iter.peek().is_some() {
                 buf.push(',');
@@ -67,8 +66,9 @@ pub fn fmt_collection<'a, 'buf, T: ExtractSpaces<'a> + Formattable>(
         }
 
         if !items.is_empty() {
-            buf.push(' ');
+            buf.spaces(1);
         }
     }
+    buf.indent(indent);
     buf.push(end);
 }

--- a/compiler/fmt/src/def.rs
+++ b/compiler/fmt/src/def.rs
@@ -60,15 +60,16 @@ impl<'a> Formattable for Def<'a> {
                 buf.push_str(name.value);
 
                 if vars.is_empty() {
-                    buf.push(' ');
+                    buf.spaces(1);
                 } else {
                     for var in *vars {
-                        buf.push(' ');
+                        buf.spaces(1);
                         fmt_pattern(buf, &var.value, indent, Parens::NotNeeded);
                     }
                 }
 
-                buf.push_str(" : ");
+                buf.push_str(" :");
+                buf.spaces(1);
 
                 ann.format(buf, indent + INDENT)
             }
@@ -84,10 +85,12 @@ impl<'a> Formattable for Def<'a> {
                 body_expr,
             } => {
                 ann_pattern.format(buf, indent);
-                buf.push_str(" : ");
+                buf.push_str(" :");
+                buf.spaces(1);
                 ann_type.format(buf, indent);
                 if let Some(comment_str) = comment {
-                    buf.push_str(" # ");
+                    buf.push_str(" #");
+                    buf.spaces(1);
                     buf.push_str(comment_str.trim());
                 }
                 buf.newline();
@@ -145,12 +148,12 @@ pub fn fmt_body<'a, 'buf>(
                 body.format_with_options(buf, Parens::NotNeeded, Newlines::Yes, indent + INDENT);
             }
             _ => {
-                buf.push(' ');
+                buf.spaces(1);
                 body.format_with_options(buf, Parens::NotNeeded, Newlines::Yes, indent);
             }
         }
     } else {
-        buf.push(' ');
+        buf.spaces(1);
         body.format_with_options(buf, Parens::NotNeeded, Newlines::Yes, indent);
     }
 }

--- a/compiler/fmt/src/expr.rs
+++ b/compiler/fmt/src/expr.rs
@@ -187,7 +187,7 @@ impl<'a> Formattable for Expr<'a> {
                     }
                 } else {
                     for loc_arg in loc_args.iter() {
-                        buf.push(' ');
+                        buf.spaces(1);
                         loc_arg.format_with_options(buf, Parens::InApply, Newlines::Yes, indent);
                     }
                 }
@@ -294,7 +294,7 @@ fn format_str_segment<'a, 'buf>(seg: &StrSegment<'a>, buf: &mut Buf<'buf>, inden
 
     match seg {
         Plaintext(string) => {
-            buf.push_str(string);
+            buf.push_str_allow_spaces(string);
         }
         Unicode(loc_str) => {
             buf.push_str("\\u(");
@@ -351,7 +351,7 @@ pub fn fmt_str_literal<'buf>(buf: &mut Buf<'buf>, literal: StrLiteral, indent: u
     buf.push('"');
     match literal {
         PlainLine(string) => {
-            buf.push_str(string);
+            buf.push_str_allow_spaces(string);
         }
         Line(segments) => {
             for seg in segments.iter() {
@@ -416,12 +416,12 @@ fn fmt_bin_ops<'a, 'buf>(
             buf.newline();
             buf.indent(indent + INDENT);
         } else {
-            buf.push(' ');
+            buf.spaces(1);
         }
 
         push_op(buf, bin_op);
 
-        buf.push(' ');
+        buf.spaces(1);
     }
 
     loc_right_side.format_with_options(buf, apply_needs_parens, Newlines::Yes, indent);
@@ -502,9 +502,9 @@ fn fmt_when<'a, 'buf>(
         }
         buf.indent(indent);
     } else {
-        buf.push(' ');
+        buf.spaces(1);
         loc_condition.format(buf, indent);
-        buf.push(' ');
+        buf.spaces(1);
     }
     buf.push_str("is");
     buf.newline();
@@ -530,12 +530,14 @@ fn fmt_when<'a, 'buf>(
                 buf.newline();
                 buf.indent(indent + INDENT);
             }
-            buf.push_str(" | ");
+            buf.push_str(" |");
+            buf.spaces(1);
             fmt_pattern(buf, &when_pattern.value, indent + INDENT, Parens::NotNeeded);
         }
 
         if let Some(guard_expr) = &branch.guard {
-            buf.push_str(" if ");
+            buf.push_str(" if");
+            buf.spaces(1);
             guard_expr.format_with_options(buf, Parens::NotNeeded, Newlines::Yes, indent + INDENT);
         }
 
@@ -612,7 +614,8 @@ fn fmt_if<'a, 'buf>(
         buf.indent(indent);
 
         if i > 0 {
-            buf.push_str("else ");
+            buf.push_str("else");
+            buf.spaces(1);
         }
 
         buf.push_str("if");
@@ -656,9 +659,9 @@ fn fmt_if<'a, 'buf>(
             }
             buf.indent(indent);
         } else {
-            buf.push(' ');
+            buf.spaces(1);
             loc_condition.format_with_options(buf, Parens::NotNeeded, Newlines::Yes, indent);
-            buf.push(' ');
+            buf.spaces(1);
         }
 
         buf.push_str("then");
@@ -693,7 +696,8 @@ fn fmt_if<'a, 'buf>(
                 }
             }
         } else {
-            buf.push_str(" ");
+            buf.push_str("");
+            buf.spaces(1);
             loc_then.format(buf, return_indent);
         }
     }
@@ -703,7 +707,8 @@ fn fmt_if<'a, 'buf>(
         buf.push_str("else");
         buf.newline();
     } else {
-        buf.push_str(" else ");
+        buf.push_str(" else");
+        buf.spaces(1);
     }
 
     final_else.format(buf, return_indent);
@@ -742,7 +747,8 @@ fn fmt_closure<'a, 'buf>(
                 buf.push(',');
                 buf.newline();
             } else {
-                buf.push_str(", ");
+                buf.push_str(",");
+                buf.spaces(1);
             }
         }
     }
@@ -751,7 +757,7 @@ fn fmt_closure<'a, 'buf>(
         buf.newline();
         buf.indent(indent);
     } else {
-        buf.push(' ');
+        buf.spaces(1);
     }
 
     buf.push_str("->");
@@ -775,7 +781,7 @@ fn fmt_closure<'a, 'buf>(
         }
         _ => {
             // add a space after the `->`
-            buf.push(' ');
+            buf.spaces(1);
         }
     };
 
@@ -821,7 +827,8 @@ fn fmt_backpassing<'a, 'buf>(
                 buf.push(',');
                 buf.newline();
             } else {
-                buf.push_str(", ");
+                buf.push_str(",");
+                buf.spaces(1);
             }
         }
     }
@@ -834,7 +841,7 @@ fn fmt_backpassing<'a, 'buf>(
         buf.newline();
         buf.indent(indent);
     } else {
-        buf.push(' ');
+        buf.spaces(1);
     }
 
     buf.push_str("<-");
@@ -858,7 +865,7 @@ fn fmt_backpassing<'a, 'buf>(
         }
         _ => {
             // add a space after the `<-`
-            buf.push(' ');
+            buf.spaces(1);
         }
     };
 
@@ -897,7 +904,7 @@ fn fmt_record<'a, 'buf>(
             // it this far. For example "{ 4 & hello = 9 }"
             // doesnt make sense.
             Some(record_var) => {
-                buf.push(' ');
+                buf.spaces(1);
                 record_var.format(buf, indent);
                 buf.push_str(" &");
             }
@@ -923,17 +930,18 @@ fn fmt_record<'a, 'buf>(
             buf.newline();
         } else {
             // is_multiline == false
-            buf.push(' ');
+            buf.spaces(1);
             let field_indent = indent;
             let mut iter = loc_fields.iter().peekable();
             while let Some(field) = iter.next() {
                 field.format_with_options(buf, Parens::NotNeeded, Newlines::No, field_indent);
 
                 if iter.peek().is_some() {
-                    buf.push_str(", ");
+                    buf.push_str(",");
+                    buf.spaces(1);
                 }
             }
-            buf.push(' ');
+            buf.spaces(1);
             // if we are here, that means that `final_comments` is empty, thus we don't have
             // to add a comment. Anyway, it is not possible to have a single line record with
             // a comment in it.
@@ -965,7 +973,8 @@ fn format_field_multiline<'a, 'buf, T>(
             }
 
             buf.push_str(separator_prefix);
-            buf.push_str(": ");
+            buf.push_str(":");
+            buf.spaces(1);
             ann.value.format(buf, indent);
             buf.push(',');
         }
@@ -979,7 +988,8 @@ fn format_field_multiline<'a, 'buf, T>(
             }
 
             buf.push_str(separator_prefix);
-            buf.push_str("? ");
+            buf.push_str("?");
+            buf.spaces(1);
             ann.value.format(buf, indent);
             buf.push(',');
         }

--- a/compiler/fmt/src/module.rs
+++ b/compiler/fmt/src/module.rs
@@ -31,21 +31,21 @@ pub fn fmt_interface_header<'a, 'buf>(buf: &mut Buf<'buf>, header: &'a Interface
     buf.push_str("interface");
 
     // module name
-    fmt_default_spaces(buf, header.after_interface_keyword, " ", indent);
+    fmt_default_spaces(buf, header.after_interface_keyword, indent);
     buf.push_str(header.name.value.as_str());
 
     // exposes
-    fmt_default_spaces(buf, header.before_exposes, " ", indent);
+    fmt_default_spaces(buf, header.before_exposes, indent);
     buf.indent(indent);
     buf.push_str("exposes");
-    fmt_default_spaces(buf, header.after_exposes, " ", indent);
+    fmt_default_spaces(buf, header.after_exposes, indent);
     fmt_exposes(buf, header.exposes, indent);
 
     // imports
-    fmt_default_spaces(buf, header.before_imports, " ", indent);
+    fmt_default_spaces(buf, header.before_imports, indent);
     buf.indent(indent);
     buf.push_str("imports");
-    fmt_default_spaces(buf, header.after_imports, " ", indent);
+    fmt_default_spaces(buf, header.after_imports, indent);
     fmt_imports(buf, header.imports, indent);
 }
 
@@ -54,33 +54,33 @@ pub fn fmt_app_header<'a, 'buf>(buf: &mut Buf<'buf>, header: &'a AppHeader<'a>) 
     buf.indent(0);
     buf.push_str("app");
 
-    fmt_default_spaces(buf, header.after_app_keyword, " ", indent);
+    fmt_default_spaces(buf, header.after_app_keyword, indent);
     fmt_str_literal(buf, header.name.value, indent);
 
     // packages
-    fmt_default_spaces(buf, header.before_packages, " ", indent);
+    fmt_default_spaces(buf, header.before_packages, indent);
     buf.indent(indent);
     buf.push_str("packages");
-    fmt_default_spaces(buf, header.after_packages, " ", indent);
+    fmt_default_spaces(buf, header.after_packages, indent);
     fmt_packages(buf, header.packages, indent);
 
     // imports
-    fmt_default_spaces(buf, header.before_imports, " ", indent);
+    fmt_default_spaces(buf, header.before_imports, indent);
     buf.indent(indent);
     buf.push_str("imports");
-    fmt_default_spaces(buf, header.after_imports, " ", indent);
+    fmt_default_spaces(buf, header.after_imports, indent);
     fmt_imports(buf, header.imports, indent);
 
     // provides
-    fmt_default_spaces(buf, header.before_provides, " ", indent);
+    fmt_default_spaces(buf, header.before_provides, indent);
     buf.indent(indent);
     buf.push_str("provides");
-    fmt_default_spaces(buf, header.after_provides, " ", indent);
+    fmt_default_spaces(buf, header.after_provides, indent);
     fmt_provides(buf, header.provides, indent);
-    fmt_default_spaces(buf, header.before_to, " ", indent);
+    fmt_default_spaces(buf, header.before_to, indent);
     buf.indent(indent);
     buf.push_str("to");
-    fmt_default_spaces(buf, header.after_to, " ", indent);
+    fmt_default_spaces(buf, header.after_to, indent);
     fmt_to(buf, header.to.value, indent);
 }
 
@@ -90,42 +90,42 @@ pub fn fmt_platform_header<'a, 'buf>(buf: &mut Buf<'buf>, header: &'a PlatformHe
     buf.indent(0);
     buf.push_str("platform");
 
-    fmt_default_spaces(buf, header.after_platform_keyword, " ", indent);
+    fmt_default_spaces(buf, header.after_platform_keyword, indent);
     fmt_package_name(buf, header.name.value);
 
     // requires
-    fmt_default_spaces(buf, header.before_requires, " ", indent);
+    fmt_default_spaces(buf, header.before_requires, indent);
     buf.indent(indent);
     buf.push_str("requires");
-    fmt_default_spaces(buf, header.after_requires, " ", indent);
+    fmt_default_spaces(buf, header.after_requires, indent);
     fmt_requires(buf, &header.requires, indent);
 
     // exposes
-    fmt_default_spaces(buf, header.before_exposes, " ", indent);
+    fmt_default_spaces(buf, header.before_exposes, indent);
     buf.indent(indent);
     buf.push_str("exposes");
-    fmt_default_spaces(buf, header.after_exposes, " ", indent);
+    fmt_default_spaces(buf, header.after_exposes, indent);
     fmt_exposes(buf, header.exposes, indent);
 
     // packages
-    fmt_default_spaces(buf, header.before_packages, " ", indent);
+    fmt_default_spaces(buf, header.before_packages, indent);
     buf.indent(indent);
     buf.push_str("packages");
-    fmt_default_spaces(buf, header.after_packages, " ", indent);
+    fmt_default_spaces(buf, header.after_packages, indent);
     fmt_packages(buf, header.packages, indent);
 
     // imports
-    fmt_default_spaces(buf, header.before_imports, " ", indent);
+    fmt_default_spaces(buf, header.before_imports, indent);
     buf.indent(indent);
     buf.push_str("imports");
-    fmt_default_spaces(buf, header.after_imports, " ", indent);
+    fmt_default_spaces(buf, header.after_imports, indent);
     fmt_imports(buf, header.imports, indent);
 
     // provides
-    fmt_default_spaces(buf, header.before_provides, " ", indent);
+    fmt_default_spaces(buf, header.before_provides, indent);
     buf.indent(indent);
     buf.push_str("provides");
-    fmt_default_spaces(buf, header.after_provides, " ", indent);
+    fmt_default_spaces(buf, header.after_provides, indent);
     fmt_provides(buf, header.provides, indent);
 
     fmt_effects(buf, &header.effects, indent);
@@ -134,23 +134,24 @@ pub fn fmt_platform_header<'a, 'buf>(buf: &mut Buf<'buf>, header: &'a PlatformHe
 fn fmt_requires<'a, 'buf>(buf: &mut Buf<'buf>, requires: &PlatformRequires<'a>, indent: u16) {
     fmt_collection(buf, indent, '{', '}', requires.rigids, Newlines::No);
 
-    buf.push_str(" { ");
+    buf.push_str(" {");
+    buf.spaces(1);
     requires.signature.value.format(buf, indent);
     buf.push_str(" }");
 }
 
 fn fmt_effects<'a, 'buf>(buf: &mut Buf<'buf>, effects: &Effects<'a>, indent: u16) {
-    fmt_default_spaces(buf, effects.spaces_before_effects_keyword, " ", indent);
+    fmt_default_spaces(buf, effects.spaces_before_effects_keyword, indent);
     buf.indent(indent);
     buf.push_str("effects");
-    fmt_default_spaces(buf, effects.spaces_after_effects_keyword, " ", indent);
+    fmt_default_spaces(buf, effects.spaces_after_effects_keyword, indent);
 
     buf.indent(indent);
     buf.push_str(effects.effect_shortname);
     buf.push('.');
     buf.push_str(effects.effect_type_name);
 
-    fmt_default_spaces(buf, effects.spaces_after_type_name, " ", indent);
+    fmt_default_spaces(buf, effects.spaces_after_type_name, indent);
 
     fmt_collection(buf, indent, '{', '}', effects.entries, Newlines::No)
 }
@@ -163,8 +164,9 @@ impl<'a> Formattable for TypedIdent<'a> {
     fn format<'buf>(&self, buf: &mut Buf<'buf>, indent: u16) {
         buf.indent(indent);
         buf.push_str(self.ident.value);
-        fmt_default_spaces(buf, self.spaces_before_colon, " ", indent);
-        buf.push_str(": ");
+        fmt_default_spaces(buf, self.spaces_before_colon, indent);
+        buf.push_str(":");
+        buf.spaces(1);
         self.ann.value.format(buf, indent);
     }
 }
@@ -321,7 +323,7 @@ impl<'a> Formattable for ImportsEntry<'a> {
 fn fmt_packages_entry<'a, 'buf>(buf: &mut Buf<'buf>, entry: &PackageEntry<'a>, indent: u16) {
     buf.push_str(entry.shorthand);
     buf.push(':');
-    fmt_default_spaces(buf, entry.spaces_after_shorthand, " ", indent);
+    fmt_default_spaces(buf, entry.spaces_after_shorthand, indent);
     fmt_package_or_path(buf, &entry.package_or_path.value, indent);
 }
 

--- a/compiler/fmt/src/pattern.rs
+++ b/compiler/fmt/src/pattern.rs
@@ -73,7 +73,7 @@ impl<'a> Formattable for Pattern<'a> {
                 loc_pattern.format_with_options(buf, Parens::InApply, Newlines::No, indent);
 
                 for loc_arg in loc_arg_patterns.iter() {
-                    buf.push(' ');
+                    buf.spaces(1);
                     loc_arg.format_with_options(buf, Parens::InApply, Newlines::No, indent);
                 }
 
@@ -83,7 +83,8 @@ impl<'a> Formattable for Pattern<'a> {
             }
             RecordDestructure(loc_patterns) => {
                 buf.indent(indent);
-                buf.push_str("{ ");
+                buf.push_str("{");
+                buf.spaces(1);
 
                 let mut it = loc_patterns.iter().peekable();
 
@@ -91,7 +92,8 @@ impl<'a> Formattable for Pattern<'a> {
                     loc_pattern.format(buf, indent);
 
                     if it.peek().is_some() {
-                        buf.push_str(", ");
+                        buf.push_str(",");
+                        buf.spaces(1);
                     }
                 }
 
@@ -101,14 +103,16 @@ impl<'a> Formattable for Pattern<'a> {
             RequiredField(name, loc_pattern) => {
                 buf.indent(indent);
                 buf.push_str(name);
-                buf.push_str(": ");
+                buf.push_str(":");
+                buf.spaces(1);
                 loc_pattern.format(buf, indent);
             }
 
             OptionalField(name, loc_pattern) => {
                 buf.indent(indent);
                 buf.push_str(name);
-                buf.push_str(" ? ");
+                buf.push_str(" ?");
+                buf.spaces(1);
                 loc_pattern.format(buf, indent);
             }
 

--- a/compiler/fmt/src/spaces.rs
+++ b/compiler/fmt/src/spaces.rs
@@ -1,4 +1,3 @@
-use bumpalo::collections::String;
 use roc_parse::ast::CommentOrNewline;
 
 use crate::Buf;
@@ -6,26 +5,13 @@ use crate::Buf;
 /// The number of spaces to indent.
 pub const INDENT: u16 = 4;
 
-pub fn newline(buf: &mut String<'_>, indent: u16) {
-    buf.push('\n');
-
-    add_spaces(buf, indent);
-}
-
-pub fn add_spaces(buf: &mut String<'_>, spaces: u16) {
-    for _ in 0..spaces {
-        buf.push(' ');
-    }
-}
-
 pub fn fmt_default_spaces<'a, 'buf>(
     buf: &mut Buf<'buf>,
     spaces: &[CommentOrNewline<'a>],
-    default: &str,
     indent: u16,
 ) {
     if spaces.is_empty() {
-        buf.push_str(default);
+        buf.spaces(1);
     } else {
         fmt_spaces(buf, spaces.iter(), indent);
     }
@@ -126,15 +112,15 @@ pub fn fmt_comments_only<'a, 'buf, I>(
 fn fmt_comment<'buf>(buf: &mut Buf<'buf>, comment: &str) {
     buf.push('#');
     if !comment.starts_with(' ') {
-        buf.push(' ');
+        buf.spaces(1);
     }
-    buf.push_str(comment);
+    buf.push_str(comment.trim_end());
 }
 
 fn fmt_docs<'buf>(buf: &mut Buf<'buf>, docs: &str) {
     buf.push_str("##");
     if !docs.starts_with(' ') {
-        buf.push(' ');
+        buf.spaces(1);
     }
     buf.push_str(docs);
 }


### PR DESCRIPTION
This makes it more or less impossible to accidentally introduce trailing spaces in the formatter, by:
1. Making sure all spacing that _might_ be at the end of a line is done thru `buf.spaces(<n>)`. There's one tiny escape hatch here, necessary for formatting string literals.
2. Accumulating those spaces in a new field in `Buf`, and only flushing them if the next thing printed is _not_ a newline
