### PR TITLE
Wasm list equality

### DIFF
--- a/compiler/mono/src/code_gen_help.rs
+++ b/compiler/mono/src/code_gen_help.rs
@@ -325,7 +325,7 @@ impl<'a> CodeGenHelp<'a> {
             (*existing_symbol, None)
         } else {
             let layout_name = layout_debug_name(layout);
-            let debug_name = format!("#help{:?}_{}", op, layout_name);
+            let debug_name = format!("#help{:?}_{}_{}", op, layout_name, self.specs.len());
             let new_symbol: Symbol = self.create_symbol(ident_ids, &debug_name);
             self.specs.push((*layout, op, new_symbol));
 

--- a/compiler/test_gen/src/gen_compare.rs
+++ b/compiler/test_gen/src/gen_compare.rs
@@ -481,7 +481,7 @@ fn list_eq_compare_pointwise() {
 }
 
 #[test]
-#[cfg(any(feature = "gen-llvm"))]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
 fn list_eq_nested() {
     assert_evals_to!("[[1]] == [[1]]", true, bool);
     assert_evals_to!("[[2]] == [[1]]", false, bool);
@@ -495,7 +495,7 @@ fn list_neq_compare_pointwise() {
 }
 
 #[test]
-#[cfg(any(feature = "gen-llvm"))]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
 fn list_neq_nested() {
     assert_evals_to!("[[1]] != [[1]]", false, bool);
     assert_evals_to!("[[2]] != [[1]]", true, bool);


### PR DESCRIPTION
Changes:
- Generate IR for `==` on `List`, using a loop that advances two pointers along each list.
- ~~Added support for more complex layouts like Rose tree.~~ (will leave this till next PR)
- Small tidy-ups
   - Creating local constants for  `ARG_1` and  `ARG_2`
   - Hardcode some variables that never actually varied (mainly `&[ARG_1, ARG2]`)

Here's the generated IR for `==` on `List I64`:
```
procedure : `#UserApp.#helpEq_list` Int1
        procedure = `#UserApp.#helpEq_list` (`#Attr.#arg1`, `#Attr.#arg2`):
        let `Bool.True` = 1i64;
        let `Bool.False` = 0i64;
        let `#UserApp.addr1` = lowlevel PtrCast `#Attr.#arg1`;
        let `#UserApp.addr2` = lowlevel PtrCast `#Attr.#arg2`;
        let `#UserApp.eq_addr` = lowlevel Eq `#UserApp.addr1` `#UserApp.addr2`;
        if `#UserApp.eq_addr` then
            ret `Bool.True`;
        else
            let `#UserApp.len_1` = lowlevel ListLen `#Attr.#arg1`;
            let `#UserApp.len_2` = lowlevel ListLen `#Attr.#arg2`;
            let `#UserApp.eq_len` = lowlevel Eq `#UserApp.len_1` `#UserApp.len_2`;
            switch `#UserApp.eq_len`:
                case 0:
                    ret `Bool.False`;
                default:
                    let `#UserApp.elements_1` = StructAtIndex 0 `#Attr.#arg1`;
                    let `#UserApp.elements_2` = StructAtIndex 0 `#Attr.#arg2`;
                    let `#UserApp.start_addr_1` = lowlevel PtrCast `#UserApp.elements_1`;
                    let `#UserApp.start_addr_2` = lowlevel PtrCast `#UserApp.elements_2`;
                    let `#UserApp.elem_size` = 8i64;
                    let `#UserApp.list_size` = lowlevel NumMul `#UserApp.len_1` `#UserApp.elem_size`;
                    let `#UserApp.end_addr_1` = lowlevel NumAdd `#UserApp.start_addr_1` `#UserApp.list_size`;
                    joinpoint `#UserApp.elems_loop` `#UserApp.addr1` `#UserApp.addr2`:
                        let `#UserApp.is_end` = lowlevel NumGte `#UserApp.addr1` `#UserApp.end_addr_1`;
                        if `#UserApp.is_end` then
                            ret `Bool.True`;
                        else
                            let `#UserApp.box1` = lowlevel PtrCast `#UserApp.addr1`;
                            let `#UserApp.box2` = lowlevel PtrCast `#UserApp.addr2`;
                            let `#UserApp.elem1` = UnionAtIndex (Id 0) (Index 0) `#UserApp.box1`;
                            let `#UserApp.elem2` = UnionAtIndex (Id 0) (Index 0) `#UserApp.box2`;
                            let `#UserApp.eq_elems` = lowlevel Eq `#UserApp.elem1` `#UserApp.elem2`;
                            switch `#UserApp.eq_elems`:
                                case 0:
                                    ret `Bool.False`;
                                default:
                                    let `#UserApp.next_addr_1` = lowlevel NumAdd `#UserApp.addr1` `#UserApp.elem_size`;
                                    let `#UserApp.next_addr_2` = lowlevel NumAdd `#UserApp.addr2` `#UserApp.elem_size`;
                                    jump `#UserApp.elems_loop` `#UserApp.next_addr_1` `#UserApp.next_addr_2`;
                    in
                    jump `#UserApp.elems_loop` `#UserApp.start_addr_1` `#UserApp.start_addr_2`;
```