### PR TITLE
Fix use of undeclared symbol

### DIFF
--- a/compiler/mono/src/ir.rs
+++ b/compiler/mono/src/ir.rs
@@ -4318,7 +4318,7 @@ pub fn with_hole<'a>(
                         procs,
                         layout_cache,
                         args[1].0, // the closure
-                        Located::at_zero(args[1].1.clone()),
+                        Loc::at_zero(args[1].1.clone()),
                         arg_symbols[1],
                         stmt,
                     )


### PR DESCRIPTION
090a8923c5d32716e0586feda3d3071c0ec1de09 changed `Located -> Loc`, but
5d7aff373ca6e51cdbdf3fcf35e64ee7108cd109 introduced another instance of
`Located` and didn't have the commit history of 090a8923c5d32716e0586feda3d3071c0ec1de09
