### PR TITLE
use ROC_ZIG environment variable to configure which zig is used

### DIFF
--- a/compiler/builtins/build.rs
+++ b/compiler/builtins/build.rs
@@ -7,6 +7,13 @@ use std::path::Path;
 use std::process::Command;
 use std::str;
 
+fn zig_executable() -> String {
+    match std::env::var("ROC_ZIG") {
+        Ok(path) => path,
+        Err(_) => "zig".into(),
+    }
+}
+
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
 
@@ -89,7 +96,7 @@ fn generate_object_file(
 
     run_command(
         &bitcode_path,
-        "zig",
+        &zig_executable(),
         &["build", zig_object, "-Drelease=true"],
     );
 
@@ -113,7 +120,7 @@ fn generate_bc_file(
 
     run_command(
         &bitcode_path,
-        "zig",
+        &zig_executable(),
         &["build", zig_object, "-Drelease=true"],
     );
 
@@ -177,26 +184,3 @@ fn get_zig_files(dir: &Path, cb: &dyn Fn(&Path)) -> io::Result<()> {
     }
     Ok(())
 }
-
-// fn get_zig_files(dir: &Path) -> io::Result<Vec<&Path>> {
-// let mut vec = Vec::new();
-// if dir.is_dir() {
-// for entry in fs::read_dir(dir)? {
-// let entry = entry?;
-// let path_buf = entry.path();
-// if path_buf.is_dir() {
-// match get_zig_files(&path_buf) {
-// Ok(sub_files) => vec = [vec, sub_files].concat(),
-// Err(_) => (),
-// };
-// } else {
-// let path = path_buf.as_path();
-// let path_ext = path.extension().unwrap();
-// if path_ext == "zig" {
-// vec.push(path.clone());
-// }
-// }
-// }
-// }
-// Ok(vec)
-// }

--- a/compiler/test_gen/build.rs
+++ b/compiler/test_gen/build.rs
@@ -24,12 +24,19 @@ fn build_wasm() {
     build_wasm_libc(&out_dir);
 }
 
+fn zig_executable() -> String {
+    match std::env::var("ROC_ZIG") {
+        Ok(path) => path,
+        Err(_) => "zig".into(),
+    }
+}
+
 fn build_wasm_test_platform(out_dir: &str) {
     println!("cargo:rerun-if-changed=src/helpers/{}.c", PLATFORM_FILENAME);
 
     run_command(
         Path::new("."),
-        "zig",
+        &zig_executable(),
         [
             "build-obj",
             "-target",
@@ -49,7 +56,7 @@ fn build_wasm_libc(out_dir: &str) {
 
     run_command(
         cwd,
-        "zig",
+        &zig_executable(),
         [
             "build-exe", // must be an executable or it won't compile libc
             "-target",

--- a/compiler/test_gen/src/helpers/llvm.rs
+++ b/compiler/test_gen/src/helpers/llvm.rs
@@ -369,7 +369,7 @@ pub fn helper_wasm<'a>(
 
     use std::process::Command;
 
-    Command::new("zig")
+    Command::new(&crate::helpers::zig_executable())
         .current_dir(dir_path)
         .args(&[
             "wasm-ld",

--- a/compiler/test_gen/src/helpers/mod.rs
+++ b/compiler/test_gen/src/helpers/mod.rs
@@ -10,6 +10,13 @@ pub mod wasm;
 #[cfg(feature = "gen-wasm")]
 pub mod wasm32_test_result;
 
+pub fn zig_executable() -> String {
+    match std::env::var("ROC_ZIG") {
+        Ok(path) => path,
+        Err(_) => "zig".into(),
+    }
+}
+
 /// Used in the with_larger_debug_stack() function, for tests that otherwise
 /// run out of stack space in debug builds (but don't in --release builds)
 #[allow(dead_code)]

--- a/compiler/test_gen/src/helpers/wasm.rs
+++ b/compiler/test_gen/src/helpers/wasm.rs
@@ -188,7 +188,7 @@ pub fn helper_wasm<'a, T: Wasm32TestResult>(
             "#UserApp_main_1",
         ];
 
-        let linker_output = std::process::Command::new("zig")
+        let linker_output = std::process::Command::new(&crate::helpers::zig_executable())
             .args(args)
             .output()
             .unwrap();


### PR DESCRIPTION
fixes #2189

we have to redefine this in a couple different places, notable some `build.rs` files that can't use code from our crates.