### PR TITLE
Position correct basic block before calling error catcher

### DIFF
--- a/cli/tests/repl_eval.rs
+++ b/cli/tests/repl_eval.rs
@@ -805,6 +805,14 @@ mod repl_eval {
         )
     }
 
+    #[test]
+    fn issue_2300() {
+        expect_success(
+            r#"\Email str -> str == """#,
+            r#"<function> : [ Email Str ] -> Bool"#,
+        )
+    }
+
     //    #[test]
     //    fn parse_problem() {
     //        // can't find something that won't parse currently

--- a/compiler/gen_llvm/src/llvm/build.rs
+++ b/compiler/gen_llvm/src/llvm/build.rs
@@ -3468,9 +3468,11 @@ fn expose_function_to_host_help_c_abi_gen_test<'a, 'ctx, 'env>(
     let arguments_for_call = &arguments_for_call.into_bump_slice();
 
     let call_result = {
+        let last_block = builder.get_insert_block().unwrap();
+
         let roc_wrapper_function = make_exception_catcher(env, roc_function, return_layout);
 
-        builder.position_at_end(entry);
+        builder.position_at_end(last_block);
 
         call_roc_function(
             env,


### PR DESCRIPTION
While building the main function for tests, we may need to generate
additional blocks while marshalling arugments to the error catcher into
the expected calling convention. This pushes the last block in the main
function down, so that the "entry" block may not be last BB in the
function. Instead, look up the last insertion block before generating
the catcher, and then add a call to the catcher at the end of this last
block.

Closes #2300
