### PR TITLE
Wasm test speedup

### DIFF
--- a/compiler/test_gen/src/helpers/wasm.rs
+++ b/compiler/test_gen/src/helpers/wasm.rs
@@ -201,8 +201,8 @@ fn run_linker(
         "#UserApp_main_1",
     ];
 
-    // For some reason, this makes linking ~3x slower
     if matches!(test_type, TestType::Refcount) {
+        // If we always export this, tests run ~2.5x slower! Not sure why.
         args.extend_from_slice(&["--export", "init_refcount_test"]);
     }
 


### PR DESCRIPTION
My recent PR to add tests for refcounting somehow slowed down all the other tests!
`cargo test-gen-wasm` went from 49s to around 2m10s on my machine.

The difference all seems to come from the linker option `--export init_refcount_test`, which exports the new function from the C platform file. This is quite strange! That C file is included for any test that uses `roc_alloc`, so I don't know why exporting one more function matters. 🤷 But it still needs to be fixed.

This PR makes the following changes
- Only use `--export init_refcount_test` for the refcounting tests
- Refactor the test helper code by splitting it into smaller functions for each step of the process
- Skip the linking step when the test app has no imports. (In fact, skip writing to the filesystem at all)
- Get rid of some debug logging that has been replaced by something better now anyway

Test time is now around 44s.