### PR TITLE
Wasm reference counting `decref` operator

### DIFF
--- a/compiler/mono/src/code_gen_help/mod.rs
+++ b/compiler/mono/src/code_gen_help/mod.rs
@@ -123,7 +123,8 @@ impl<'a> CodeGenHelp<'a> {
             ModifyRc::Inc(..) => HelperOp::Inc,
             ModifyRc::Dec(_) => HelperOp::Dec,
             ModifyRc::DecRef(_) => {
-                HelperOp::DecRef(JoinPointId(self.create_symbol(ident_ids, "jp_decref")))
+                let jp_decref = JoinPointId(self.create_symbol(ident_ids, "jp_decref"));
+                HelperOp::DecRef(jp_decref)
             }
         };
 
@@ -134,7 +135,7 @@ impl<'a> CodeGenHelp<'a> {
         };
 
         let rc_stmt = refcount::refcount_stmt(self, ident_ids, &mut ctx, layout, modify, following);
-        (self.arena.alloc(rc_stmt), ctx.new_linker_data)
+        (rc_stmt, ctx.new_linker_data)
     }
 
     /// Replace a generic `Lowlevel::Eq` call with a specialized helper proc.


### PR DESCRIPTION
`DecRef` decrements the reference count of a container but not the contents.

This means we can skip a lot of the generated IR. But some layouts still have checks for things like empty strings or lists, as well as the call to the Zig `decref` function.

Since there is no complex traversal of data structures, it seems like it's not really worth making functions for this, so I've just inlined the statements instead. The early returns are transformed to `Jump`s, so the refcounting code is all inside a `Join`.

We have no tests that exercise this code at the moment because the backend doesn't yet support `List.map` or `LambdaSet`s properly. We'll have to come back and add some `DecRef` tests later. The aim for now is just to get the refcount generation code into the right structure.