### PR TITLE
Fix bug that caused extraneous assignment in IR generation

### DIFF
--- a/compiler/mono/src/ir.rs
+++ b/compiler/mono/src/ir.rs
@@ -1806,33 +1806,9 @@ fn patterns_to_when<'a>(
     for (pattern_var, pattern) in patterns.into_iter() {
         let context = crate::exhaustive::Context::BadArg;
         let mono_pattern = match from_can_pattern(env, layout_cache, &pattern.value) {
-            Ok((pat, assignments)) => {
-                for (symbol, variable, expr) in assignments.into_iter().rev() {
-                    if let Ok(old_body) = body {
-                        let def = roc_can::def::Def {
-                            annotation: None,
-                            expr_var: variable,
-                            loc_expr: Loc::at(pattern.region, expr),
-                            loc_pattern: Loc::at(
-                                pattern.region,
-                                roc_can::pattern::Pattern::Identifier(symbol),
-                            ),
-                            pattern_vars: std::iter::once((symbol, variable)).collect(),
-                        };
-                        let new_expr = roc_can::expr::Expr::LetNonRec(
-                            Box::new(def),
-                            Box::new(old_body),
-                            variable,
-                        );
-                        let new_body = Loc {
-                            region: pattern.region,
-                            value: new_expr,
-                        };
-
-                        body = Ok(new_body);
-                    }
-                }
-
+            Ok((pat, _assignments)) => {
+                // Don't apply any assignments (e.g. to initialize optional variables) yet.
+                // We'll take care of that later when expanding the new "when" branch.
                 pat
             }
             Err(runtime_error) => {

--- a/compiler/test_gen/src/gen_records.rs
+++ b/compiler/test_gen/src/gen_records.rs
@@ -587,9 +587,7 @@ fn optional_field_function_use_default() {
 
 #[test]
 #[cfg(any(feature = "gen-llvm"))]
-#[ignore]
 fn optional_field_function_no_use_default() {
-    // blocked on https://github.com/rtfeldman/roc/issues/786
     assert_evals_to!(
         indoc!(
             r#"
@@ -608,9 +606,7 @@ fn optional_field_function_no_use_default() {
 
 #[test]
 #[cfg(any(feature = "gen-llvm"))]
-#[ignore]
 fn optional_field_function_no_use_default_nested() {
-    // blocked on https://github.com/rtfeldman/roc/issues/786
     assert_evals_to!(
         indoc!(
             r#"

--- a/compiler/test_mono/generated/record_optional_field_function_no_use_default.txt
+++ b/compiler/test_mono/generated/record_optional_field_function_no_use_default.txt
@@ -5,7 +5,6 @@ procedure Num.24 (#Attr.2, #Attr.3):
 procedure Test.1 (Test.4):
     let Test.2 = StructAtIndex 0 Test.4;
     let Test.3 = StructAtIndex 1 Test.4;
-    let Test.2 = 10i64;
     let Test.7 = CallByName Num.24 Test.2 Test.3;
     ret Test.7;
 

--- a/compiler/test_mono/generated/record_optional_field_function_use_default.txt
+++ b/compiler/test_mono/generated/record_optional_field_function_use_default.txt
@@ -4,7 +4,6 @@ procedure Num.24 (#Attr.2, #Attr.3):
 
 procedure Test.1 (Test.4):
     let Test.2 = 10i64;
-    let Test.2 = 10i64;
     let Test.7 = CallByName Num.24 Test.2 Test.4;
     ret Test.7;
 


### PR DESCRIPTION
Previously we would expand optional record fields to assignments when
converting record patterns to "when" expressions. This resulted in
incorrect code being generated.
