### PR TITLE
Remove awkward split between header_sources and defs sources

### DIFF
--- a/compiler/build/src/program.rs
+++ b/compiler/build/src/program.rs
@@ -31,7 +31,6 @@ const LLVM_VERSION: &str = "12";
 pub fn report_problems_monomorphized(loaded: &mut MonomorphizedModule) -> usize {
     report_problems_help(
         loaded.total_problems(),
-        &loaded.header_sources,
         &loaded.sources,
         &loaded.interns,
         &mut loaded.can_problems,
@@ -43,7 +42,6 @@ pub fn report_problems_monomorphized(loaded: &mut MonomorphizedModule) -> usize 
 pub fn report_problems_typechecked(loaded: &mut LoadedModule) -> usize {
     report_problems_help(
         loaded.total_problems(),
-        &loaded.header_sources,
         &loaded.sources,
         &loaded.interns,
         &mut loaded.can_problems,
@@ -54,7 +52,6 @@ pub fn report_problems_typechecked(loaded: &mut LoadedModule) -> usize {
 
 fn report_problems_help(
     total_problems: usize,
-    header_sources: &MutMap<ModuleId, (PathBuf, Box<str>)>,
     sources: &MutMap<ModuleId, (PathBuf, Box<str>)>,
     interns: &Interns,
     can_problems: &mut MutMap<ModuleId, Vec<roc_problem::can::Problem>>,
@@ -75,12 +72,7 @@ fn report_problems_help(
     for (home, (module_path, src)) in sources.iter() {
         let mut src_lines: Vec<&str> = Vec::new();
 
-        if let Some((_, header_src)) = header_sources.get(home) {
-            src_lines.extend(header_src.split('\n'));
-            src_lines.extend(src.split('\n').skip(1));
-        } else {
-            src_lines.extend(src.split('\n'));
-        }
+        src_lines.extend(src.split('\n'));
 
         let lines = LineInfo::new(&src_lines.join("\n"));
 

--- a/compiler/load/src/file.rs
+++ b/compiler/load/src/file.rs
@@ -366,7 +366,6 @@ struct ModuleCache<'a> {
     mono_problems: MutMap<ModuleId, Vec<roc_mono::ir::MonoProblem>>,
 
     sources: MutMap<ModuleId, (PathBuf, &'a str)>,
-    header_sources: MutMap<ModuleId, (PathBuf, &'a str)>,
 }
 
 fn start_phase<'a>(
@@ -625,7 +624,6 @@ pub struct LoadedModule {
     pub dep_idents: MutMap<ModuleId, IdentIds>,
     pub exposed_aliases: MutMap<Symbol, Alias>,
     pub exposed_values: Vec<Symbol>,
-    pub header_sources: MutMap<ModuleId, (PathBuf, Box<str>)>,
     pub sources: MutMap<ModuleId, (PathBuf, Box<str>)>,
     pub timings: MutMap<ModuleId, ModuleTiming>,
     pub documentation: MutMap<ModuleId, ModuleDocumentation>,
@@ -672,7 +670,6 @@ struct ModuleHeader<'a> {
     package_qualified_imported_modules: MutSet<PackageQualified<'a, ModuleId>>,
     exposes: Vec<Symbol>,
     exposed_imports: MutMap<Ident, (Symbol, Region)>,
-    header_src: &'a str,
     parse_state: roc_parse::state::State<'a>,
     module_timing: ModuleTiming,
 }
@@ -740,7 +737,6 @@ pub struct MonomorphizedModule<'a> {
     pub procedures: MutMap<(Symbol, ProcLayout<'a>), Proc<'a>>,
     pub entry_point: EntryPoint<'a>,
     pub exposed_to_host: MutMap<Symbol, Variable>,
-    pub header_sources: MutMap<ModuleId, (PathBuf, Box<str>)>,
     pub sources: MutMap<ModuleId, (PathBuf, Box<str>)>,
     pub timings: MutMap<ModuleId, ModuleTiming>,
 }
@@ -1741,11 +1737,6 @@ fn update<'a>(
 
             state
                 .module_cache
-                .header_sources
-                .insert(home, (header.module_path.clone(), header.header_src));
-
-            state
-                .module_cache
                 .imports
                 .entry(header.module_id)
                 .or_default()
@@ -2198,16 +2189,10 @@ fn finish_specialization(
         type_problems,
         can_problems,
         sources,
-        header_sources,
         ..
     } = module_cache;
 
     let sources: MutMap<ModuleId, (PathBuf, Box<str>)> = sources
-        .into_iter()
-        .map(|(id, (path, src))| (id, (path, src.into())))
-        .collect();
-
-    let header_sources: MutMap<ModuleId, (PathBuf, Box<str>)> = header_sources
         .into_iter()
         .map(|(id, (path, src))| (id, (path, src.into())))
         .collect();
@@ -2274,7 +2259,6 @@ fn finish_specialization(
         procedures,
         entry_point,
         sources,
-        header_sources,
         timings: state.timings,
     })
 }
@@ -2305,13 +2289,6 @@ fn finish(
         .map(|(id, (path, src))| (id, (path, src.into())))
         .collect();
 
-    let header_sources = state
-        .module_cache
-        .header_sources
-        .into_iter()
-        .map(|(id, (path, src))| (id, (path, src.into())))
-        .collect();
-
     LoadedModule {
         module_id: state.root_id,
         interns,
@@ -2323,7 +2300,6 @@ fn finish(
         exposed_aliases: exposed_aliases_by_symbol,
         exposed_values,
         exposed_to_host: exposed_vars_by_symbol.into_iter().collect(),
-        header_sources,
         sources,
         timings: state.timings,
         documentation,
@@ -2379,10 +2355,6 @@ fn load_pkg_config<'a>(
                     )))
                 }
                 Ok((ast::Module::Platform { header }, parser_state)) => {
-                    let delta = bytes.len() - parser_state.bytes().len();
-                    let chomped = &bytes[..delta];
-                    let header_src = unsafe { std::str::from_utf8_unchecked(chomped) };
-
                     // make a Package-Config module that ultimately exposes `main` to the host
                     let pkg_config_module_msg = fabricate_pkg_config_module(
                         arena,
@@ -2393,7 +2365,6 @@ fn load_pkg_config<'a>(
                         module_ids.clone(),
                         ident_ids_by_module.clone(),
                         &header,
-                        header_src,
                         pkg_module_timing,
                     )
                     .1;
@@ -2530,11 +2501,6 @@ fn parse_header<'a>(
 
     match parsed {
         Ok((ast::Module::Interface { header }, parse_state)) => {
-            let header_src = unsafe {
-                let chomped = src_bytes.len() - parse_state.bytes().len();
-                std::str::from_utf8_unchecked(&src_bytes[..chomped])
-            };
-
             let info = HeaderInfo {
                 loc_name: Loc {
                     region: header.name.region,
@@ -2543,7 +2509,6 @@ fn parse_header<'a>(
                 filename,
                 is_root_module,
                 opt_shorthand,
-                header_src,
                 packages: &[],
                 exposes: unspace(arena, header.exposes.items),
                 imports: unspace(arena, header.imports.items),
@@ -2562,11 +2527,6 @@ fn parse_header<'a>(
             let mut pkg_config_dir = filename.clone();
             pkg_config_dir.pop();
 
-            let header_src = unsafe {
-                let chomped = src_bytes.len() - parse_state.bytes().len();
-                std::str::from_utf8_unchecked(&src_bytes[..chomped])
-            };
-
             let packages = unspace(arena, header.packages.items);
 
             let info = HeaderInfo {
@@ -2577,7 +2537,6 @@ fn parse_header<'a>(
                 filename,
                 is_root_module,
                 opt_shorthand,
-                header_src,
                 packages,
                 exposes: unspace(arena, header.provides.items),
                 imports: unspace(arena, header.imports.items),
@@ -2736,7 +2695,6 @@ struct HeaderInfo<'a> {
     filename: PathBuf,
     is_root_module: bool,
     opt_shorthand: Option<&'a str>,
-    header_src: &'a str,
     packages: &'a [Loc<PackageEntry<'a>>],
     exposes: &'a [Loc<ExposedName<'a>>],
     imports: &'a [Loc<ImportsEntry<'a>>],
@@ -2762,7 +2720,6 @@ fn send_header<'a>(
         exposes,
         imports,
         to_platform,
-        header_src,
     } = info;
 
     let declared_name: ModuleName = match &loc_name.value {
@@ -2932,7 +2889,6 @@ fn send_header<'a>(
                 package_qualified_imported_modules,
                 deps_by_name,
                 exposes: exposed,
-                header_src,
                 parse_state,
                 exposed_imports: scope,
                 module_timing,
@@ -2947,7 +2903,6 @@ struct PlatformHeaderInfo<'a> {
     filename: PathBuf,
     is_root_module: bool,
     shorthand: &'a str,
-    header_src: &'a str,
     app_module_id: ModuleId,
     packages: &'a [Loc<PackageEntry<'a>>],
     provides: &'a [Loc<ExposedName<'a>>],
@@ -2968,7 +2923,6 @@ fn send_header_two<'a>(
         filename,
         shorthand,
         is_root_module,
-        header_src,
         app_module_id,
         packages,
         provides,
@@ -3162,7 +3116,6 @@ fn send_header_two<'a>(
                 package_qualified_imported_modules,
                 deps_by_name,
                 exposes: exposed,
-                header_src,
                 parse_state,
                 exposed_imports: scope,
                 module_timing,
@@ -3310,14 +3263,12 @@ fn fabricate_pkg_config_module<'a>(
     module_ids: Arc<Mutex<PackageModuleIds<'a>>>,
     ident_ids_by_module: Arc<Mutex<MutMap<ModuleId, IdentIds>>>,
     header: &PlatformHeader<'a>,
-    header_src: &'a str,
     module_timing: ModuleTiming,
 ) -> (ModuleId, Msg<'a>) {
     let info = PlatformHeaderInfo {
         filename,
         is_root_module: false,
         shorthand,
-        header_src,
         app_module_id,
         packages: &[],
         provides: unspace(arena, header.provides.items),
@@ -3703,7 +3654,7 @@ where
 fn parse<'a>(arena: &'a Bump, header: ModuleHeader<'a>) -> Result<Msg<'a>, LoadingProblem<'a>> {
     let mut module_timing = header.module_timing;
     let parse_start = SystemTime::now();
-    let source = header.parse_state.bytes();
+    let source = header.parse_state.original_bytes();
     let parse_state = header.parse_state;
     let parsed_defs = match module_defs().parse(arena, parse_state) {
         Ok((_, success, _state)) => success,

--- a/compiler/parse/src/state.rs
+++ b/compiler/parse/src/state.rs
@@ -34,7 +34,7 @@ impl<'a> State<'a> {
         self.original_bytes
     }
 
-    pub fn bytes(&self) -> &'a [u8] {
+    pub(crate) fn bytes(&self) -> &'a [u8] {
         &self.original_bytes[self.offset..]
     }
 
@@ -43,7 +43,7 @@ impl<'a> State<'a> {
     }
 
     #[must_use]
-    pub fn advance(&self, offset: usize) -> State<'a> {
+    pub(crate) fn advance(&self, offset: usize) -> State<'a> {
         let mut state = self.clone();
         debug_assert!(!state.bytes()[..offset].iter().any(|b| *b == b'\n'));
         state.offset += offset;
@@ -51,7 +51,7 @@ impl<'a> State<'a> {
     }
 
     #[must_use]
-    pub fn advance_newline(&self) -> State<'a> {
+    pub(crate) fn advance_newline(&self) -> State<'a> {
         let mut state = self.clone();
         state.offset += 1;
         state.line_start = state.pos();


### PR DESCRIPTION
Previously a source file was artificially split into two chunks: the header source and the 'defs' source (i.e. the rest). This lead to confusion and problems like #2329.

There's only one place that header_sources were actually used, and at that spot they were simply concatenated with the defs sources.

After this refactoring, the source for a file is stored together in one string.