### PR TITLE
Add `Num.minI128` builtin

### DIFF
--- a/compiler/builtins/docs/Num.roc
+++ b/compiler/builtins/docs/Num.roc
@@ -65,6 +65,7 @@ interface Num
             maxI128,
             maxInt,
             minFloat,
+            minI128,
             minInt,
             modInt,
             modFloat,
@@ -831,6 +832,15 @@ minU32 : U32
 ## Note that this is smaller than the positive version of #Int.minI128,
 ## which means if you call #Num.abs on #Int.minI128, it will overflow and crash!
 maxI128 : I128
+
+## The min number that can be stored in an #I128 without underflowing its
+## available memory and crashing.
+##
+## For reference, this number is `-170_141_183_460_469_231_731_687_303_715_884_105_728`.
+##
+## Note that the positive version of this number is larger than #Int.maxI128,
+## which means if you call #Num.abs on #Int.minI128, it will overflow and crash!
+minI128 : I128
 
 ## The highest supported #F64 value you can have, which is approximately 1.8 × 10^308.
 ##

--- a/compiler/builtins/src/std.rs
+++ b/compiler/builtins/src/std.rs
@@ -397,6 +397,9 @@ pub fn types() -> MutMap<Symbol, (SolvedType, Region)> {
         Box::new(bool_type()),
     );
 
+    // minI128 : I128
+    add_type!(Symbol::NUM_MIN_I128, i128_type());
+
     // maxI128 : I128
     add_type!(Symbol::NUM_MAX_I128, i128_type());
 

--- a/compiler/module/src/symbol.rs
+++ b/compiler/module/src/symbol.rs
@@ -995,6 +995,7 @@ define_builtins! {
         107 NUM_CAST_TO_NAT: "#castToNat"
         108 NUM_DIV_CEIL: "divCeil"
         109 NUM_TO_STR: "toStr"
+        110 NUM_MIN_I128: "minI128"
     }
     2 BOOL: "Bool" => {
         0 BOOL_BOOL: "Bool" imported // the Bool.Bool type alias

--- a/compiler/solve/tests/solve_expr.rs
+++ b/compiler/solve/tests/solve_expr.rs
@@ -3342,6 +3342,18 @@ mod solve_expr {
     }
 
     #[test]
+    fn min_i128() {
+        infer_eq_without_problem(
+            indoc!(
+                r#"
+                Num.minI128
+                "#
+            ),
+            "I128",
+        );
+    }
+
+    #[test]
     fn max_i128() {
         infer_eq_without_problem(
             indoc!(

--- a/compiler/test_gen/src/gen_num.rs
+++ b/compiler/test_gen/src/gen_num.rs
@@ -1831,6 +1831,20 @@ fn shift_right_zf_by() {
 
 #[test]
 #[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
+fn min_i128() {
+    assert_evals_to!(
+        indoc!(
+            r#"
+                Num.minI128
+                "#
+        ),
+        i128::MIN,
+        i128
+    );
+}
+
+#[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
 fn max_i128() {
     assert_evals_to!(
         indoc!(


### PR DESCRIPTION
This copies all existing `Num.maxI128` implementation pieces into corresponding new `Num.minI128` implementation pieces.

Closes #2353 