### PR TITLE
Fix args order in some docs

### DIFF
--- a/compiler/builtins/docs/List.roc
+++ b/compiler/builtins/docs/List.roc
@@ -205,7 +205,7 @@ empty : List *
 ## Returns a list with the given length, where every element is the given value.
 ##
 ##
-repeat : elem, Nat -> List elem
+repeat : Nat, elem -> List elem
 
 ## Returns a list of all the integers between one and another,
 ## including both of the given numbers.
@@ -277,7 +277,7 @@ map4 : List a, List b, List c, List d, (a, b, c, d -> e) -> List e
 
 ## This works like [List.map], except it also passes the index
 ## of the element to the conversion function.
-mapWithIndex : List before, (before, Nat -> after) -> List after
+mapWithIndex : List before, (Nat, before -> after) -> List after
 
 ## This works like [List.map], except at any time you can return `Err` to
 ## cancel the entire operation immediately, and return that #Err.


### PR DESCRIPTION
These changes reflect the builtins as they're currently implemented, but I wish that instead they worked as (previously) described. Should this PR be abandoned in favor of an actual argument swap?