### PR TITLE
nix update

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -1,4 +1,4 @@
-FROM rust:1.57.0-slim-bullseye
+FROM rust:1.57.0-slim-bullseye # make sure to update nixpkgs-unstable in sources.json too so that it uses the same rust version > search for cargo on unstable here: https://search.nixos.org/packages
 WORKDIR /earthbuild
 
 prep-debian:

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -12,15 +12,27 @@
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {
+        "branch": "release-21.11",
+        "description": "Nix Packages collection",
+        "homepage": "",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "fe6f208d68ac254873b659db9676d44dea9b0555",
+        "sha256": "0ybvy1zx97k811bz73xmgsb41d33i2kr2dfqcxzq9m9h958178nq",
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/fe6f208d68ac254873b659db9676d44dea9b0555.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
+    "nixpkgs-unstable": {
         "branch": "nixpkgs-unstable",
         "description": "Nix Packages collection",
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "47b35f569e84eb6dbbcf0a9fc75d8729ab8837fd",
-        "sha256": "0c5ny3yxlxixrd6z99g1wg8i6ysqpja763cxn9bh1g1c0byq8bdj",
+        "rev": "ea171bc81fcb3c6f21deeb46dbc10000087777ef",
+        "sha256": "15hh28c98kb6pf7wgydc07bx2ivq04a2cay5mhwnqk5cpa8dbiap",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/47b35f569e84eb6dbbcf0a9fc75d8729ab8837fd.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/ea171bc81fcb3c6f21deeb46dbc10000087777ef.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/nix/zig.nix
+++ b/nix/zig.nix
@@ -1,7 +1,7 @@
 { pkgs }:
 
 let
-  version = "0.8.0";
+  version = "0.8.1";
 
   osName = if pkgs.stdenv.isDarwin then "macos" else "linux";
 
@@ -14,13 +14,13 @@ let
   # If your system is not aarch64, we assume it's x86_64
   sha256 = if pkgs.stdenv.isDarwin then
     if isAarch64 then
-      "b32d13f66d0e1ff740b3326d66a469ee6baddbd7211fa111c066d3bd57683111"
+      "5351297e3b8408213514b29c0a938002c5cf9f97eee28c2f32920e1227fd8423" # macos-aarch64
     else
-      "279f9360b5cb23103f0395dc4d3d0d30626e699b1b4be55e98fd985b62bc6fbe"
+      "16b0e1defe4c1807f2e128f72863124bffdd906cefb21043c34b673bf85cd57f" # macos-x86_64
   else if isAarch64 then
-    "ee204ca2c2037952cf3f8b10c609373a08a291efa4af7b3c73be0f2b27720470"
+    "2166dc9f2d8df387e8b4122883bb979d739281e1ff3f3d5483fec3a23b957510" # linux-aarch64
   else
-    "502625d3da3ae595c5f44a809a87714320b7a40e6dff4a895b5fa7df3391d01e";
+    "6c032fc61b5d77a3f3cf781730fa549f8f059ffdb3b3f6ad1c2994d2b2d87983"; # linux-x86_64
 in pkgs.stdenv.mkDerivation {
   pname = "zig";
   version = version;

--- a/shell.nix
+++ b/shell.nix
@@ -3,6 +3,7 @@
 let
   sources = import nix/sources.nix { };
   pkgs = import sources.nixpkgs { };
+  unstable-pkgs = import sources.nixpkgs-unstable { };
 
   darwinInputs = with pkgs;
     lib.optionals stdenv.isDarwin (with pkgs.darwin.apple_sdk.frameworks; [
@@ -35,12 +36,8 @@ let
   zig = import ./nix/zig.nix { inherit pkgs; };
   debugir = import ./nix/debugir.nix { inherit pkgs; };
 
-  inputs = with pkgs; [
+  inputs = (with pkgs; [
     # build libraries
-    rustc
-    cargo
-    clippy
-    rustfmt
     cmake
     git
     python3
@@ -68,7 +65,13 @@ let
 
     # tools for development environment
     less
-  ];
+  ]) ++ (with unstable-pkgs; [
+    rustc
+    cargo
+    clippy
+    rustfmt
+  ]);
+
 in pkgs.mkShell {
   buildInputs = inputs ++ darwinInputs ++ linuxInputs;
 


### PR DESCRIPTION
- fixes cargo build not working inside nix due to use of rust feature that was unstable on 1.56
- now using rust 1.57.0
- packages now use the nix 21.11 branch with the exception of rust packages
- updated nix zig package 0.8.0 -> 0.8.1

Tested on linux x86_64 and macos aarch64.