### PR TITLE
Specialize zero-argument thunks with the correct variable

### DIFF
--- a/compiler/mono/src/ir.rs
+++ b/compiler/mono/src/ir.rs
@@ -2941,8 +2941,7 @@ fn specialize_naked_symbol<'a>(
     symbol: Symbol,
 ) -> Stmt<'a> {
     if procs.is_module_thunk(symbol) {
-        let partial_proc = procs.get_partial_proc(symbol).unwrap();
-        let fn_var = partial_proc.annotation;
+        let fn_var = variable;
 
         // This is a top-level declaration, which will code gen to a 0-arity thunk.
         let result = call_by_name(

--- a/compiler/test_gen/src/gen_tags.rs
+++ b/compiler/test_gen/src/gen_tags.rs
@@ -1449,3 +1449,28 @@ fn issue_2365_monomorphize_tag_with_non_empty_ext_var_wrapped_nested() {
         u8
     )
 }
+
+#[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
+fn issue_2445() {
+    assert_evals_to!(
+        indoc!(
+            r#"
+            app "test" provides [ main ] to "./platform"
+
+            none : [ None, Update a ]
+            none = None
+
+            press : [ None, Update U8 ]
+            press = none
+
+            main =
+                when press is
+                    None -> 15
+                    Update _ -> 25
+            "#
+        ),
+        15,
+        i64
+    );
+}


### PR DESCRIPTION
Previously we would pass the annotation down as the
type-to-be-monomorphized for, but that would just mean the annotation
would unify with itself. We instead want to use the variable the thunk
is being used as to be the one unified with the thunk's annotation.

Closes #2445
Closes #2446