### PR TITLE
Fix a failing test

### DIFF
--- a/compiler/parse/tests/snapshots/pass/comment_after_def.module.result-ast
+++ b/compiler/parse/tests/snapshots/pass/comment_after_def.module.result-ast
@@ -1,11 +1,11 @@
 [
-    |L 0-0, C 0-7| SpaceAfter(
+    @0-7 SpaceAfter(
         SpaceBefore(
             Body(
-                |L 0-0, C 0-3| Identifier(
+                @0-3 Identifier(
                     "foo",
                 ),
-                |L 0-0, C 6-7| Num(
+                @6-7 Num(
                     "1",
                 ),
             ),


### PR DESCRIPTION
How did this pass CI testing?

Output from `cargo test --release`:
```
failures:

---- test_parse::comment_after_def stdout ----
The source code for this test did not successfully parse!

thread 'test_parse::comment_after_def' panicked at 'assertion failed: `(left == right)`

Diff < left / right > :
 [
<    |L 0-0, C 0-7| SpaceAfter(
>    @0-7 SpaceAfter(
         SpaceBefore(
             Body(
<                |L 0-0, C 0-3| Identifier(
>                @0-3 Identifier(
                     "foo",
                 ),
<                |L 0-0, C 6-7| Num(
>                @6-7 Num(
                     "1",
                 ),
             ),
             [],
         ),
         [
             LineComment(
                 " comment after",
             ),
         ],
     ),
 ]

', compiler/parse/tests/test_parse.rs:291:13
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

failures:
    test_parse::comment_after_def

test result: FAILED. 164 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s

error: test failed, to rerun pass '-p roc_parse --test test_parse'
```