### PR TITLE
Stop printing host rebuilding message with --precompiled-host

### DIFF
--- a/cli/src/build.rs
+++ b/cli/src/build.rs
@@ -309,10 +309,12 @@ fn spawn_rebuild_thread(
 ) -> std::thread::JoinHandle<u128> {
     let thread_local_target = target.clone();
     std::thread::spawn(move || {
-        let rebuild_host_start = SystemTime::now();
         if !precompiled {
             print!("🔨 Rebuilding host... ");
+        }
 
+        let rebuild_host_start = SystemTime::now();
+        if !precompiled {
             if surgically_link {
                 roc_linker::build_and_preprocess_host(
                     opt_level,


### PR DESCRIPTION
Super tiny PR. The message just annoyed me. Now it only prints when actually trying to rebuild the host.