### PR TITLE
Add .reuse/dep5

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -1,0 +1,8 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: Roc
+Upstream-Contact: Richard Feldman <oss@rtfeldman.com>
+Source: https://github.com/rtfeldman/roc
+
+Files: *
+Copyright: © The Roc Contributors
+License: UPL-1.0


### PR DESCRIPTION
This makes the repo compatible with https://reuse.software/

Closes https://github.com/rtfeldman/roc/issues/1032

I decided against the Developer Certificate of Origin because GitHub already has a sensible default one if you don't specify one, and I think it's actually riskier to override that default.