### PR TITLE
Fix invalid memory access in IdentStr Drop impl

### DIFF
--- a/compiler/ident/src/lib.rs
+++ b/compiler/ident/src/lib.rs
@@ -311,7 +311,7 @@ impl Clone for IdentStr {
 
 impl Drop for IdentStr {
     fn drop(&mut self) {
-        if !self.is_small_str() {
+        if !self.is_empty() && !self.is_small_str() {
             unsafe {
                 let align = mem::align_of::<u8>();
                 let layout = Layout::from_size_align_unchecked(self.length, align);


### PR DESCRIPTION
once again we missed the empty case ...