### PR TITLE
[Enhancement] Improve library lookup in native linker

### DIFF
--- a/compiler/build/src/link.rs
+++ b/compiler/build/src/link.rs
@@ -699,10 +699,11 @@ fn link_linux(
 
     // Some things we'll need to build a list of dirs to check for libraries
     let maybe_nix_path = nix_path_opt();
-    let architecture_path = ["/usr", "lib", &architecture];
+    let usr_lib_arch = ["/usr", "lib", &architecture];
+    let lib_arch = ["/lib", &architecture];
     let nix_path_segments;
-    let lib_dirs_if_nix: [&[&str]; 4];
-    let lib_dirs_if_nonix: [&[&str]; 3];
+    let lib_dirs_if_nix: [&[&str]; 5];
+    let lib_dirs_if_nonix: [&[&str]; 4];
 
     // Build the aformentioned list
     let lib_dirs: &[&[&str]] =
@@ -711,14 +712,16 @@ fn link_linux(
             nix_path_segments = [nix_path.as_str()];
             lib_dirs_if_nix = [
                 &nix_path_segments,
-                &architecture_path,
+                &usr_lib_arch,
+                &lib_arch,
                 &["/usr", "lib"],
                 &["/usr", "lib64"],
             ];
             &lib_dirs_if_nix
         } else {
             lib_dirs_if_nonix = [
-                &architecture_path,
+                &usr_lib_arch,
+                &lib_arch,
                 &["/usr", "lib"],
                 &["/usr", "lib64"],
             ];


### PR DESCRIPTION
**!  This PR supersedes #2546  !**

As discussed in the [Zulip chat (`request to open pr: linker library searching`)](https://roc.zulipchat.com/#narrow/stream/231634-beginners/topic/request.20to.20open.20pr.3A.20.20linker.20library.20searching).

This is a small rework of how the native linker looks for libraries on linux.  Specifically a few instances of manually looking up a library have been replaced with a function call to the new function, `look_for_library`, which abstracts this code and improves its resilience in a few cases.

This also allows us to group several of the library lookups, and also more explicitly handle their errors.  In particular, current behavior in the event of a missing library is either to misreport it, causing `ld` to print an error when invoked, or simply to panic.  The new behavior prints out an error message indicating what file is missing, where we looked for it, and what package might need to be installed to fix the problem.

Finally, this also adds `/usr/lib64` as a possible search path, for which the first change was a prerequisite.  On my machine (Fedora 35), the glibc libraries are stored in this directory, so by adding it to the library search directories, support for distros like this one is fixed.

🐛 Fix bug where /usr/lib isn't checked if /usr/lib/{arch} exists
✨ Better error messages on missing libraries
✨ Check /usr/lib64 for libraries