### PR TITLE
Read ROC_LINK_FLAGS env var to inject more link flags

### DIFF
--- a/compiler/build/src/link.rs
+++ b/compiler/build/src/link.rs
@@ -859,7 +859,7 @@ fn link_macos(
         Err(_) => "".to_string(),
     };
     for roc_link_flag in roc_link_flags.split_whitespace() {
-        ld_command.arg(format!("{}", roc_link_flag));
+        ld_command.arg(roc_link_flag.to_string());
     }
 
     ld_command.args(&[


### PR DESCRIPTION
This makes it possible to add additional libs when building roc programs. This can a temporary workaround until surgical linking lands.

Usage:

```console
$ ROC_LINK_FLAGS="-L/path/to/my/libs -lfoo -lbar" cargo run path/to/file.roc

# or

$ export ROC_LINK_FLAGS="-L/path/to/my/libs -lfoo -lbar" 
$ cargo run path/to/file.roc
```

Note: Flags should not contain whitespaces since the value is split on them

Disclaimer: I know no rust 🙈 