### PR TITLE
windows zig path validation workaround

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1134,6 +1134,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56899898ce76aaf4a0f24d914c97ea6ed976d42fec6ad33fcbb0a1103e07b2b0"
 
 [[package]]
+name = "dunce"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "453440c271cf5577fd2a40e4942540cb7d0d2f85e27c8d07dd0023c925a67541"
+
+[[package]]
 name = "dynasm"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3228,6 +3234,7 @@ dependencies = [
 name = "roc_builtins"
 version = "0.1.0"
 dependencies = [
+ "dunce",
  "roc_collections",
  "roc_module",
  "roc_region",

--- a/compiler/builtins/Cargo.toml
+++ b/compiler/builtins/Cargo.toml
@@ -11,3 +11,7 @@ roc_region = { path = "../region" }
 roc_module = { path = "../module" }
 roc_types = { path = "../types" }
 roc_target = { path = "../roc_target" }
+
+[build-dependencies]
+# dunce can be removed once ziglang/zig#5109 is fixed
+dunce = "1.0.2"

--- a/compiler/builtins/build.rs
+++ b/compiler/builtins/build.rs
@@ -27,7 +27,8 @@ fn main() {
     }
 
     // "." is relative to where "build.rs" is
-    let build_script_dir_path = fs::canonicalize(Path::new(".")).unwrap();
+    // dunce can be removed once ziglang/zig#5109 is fixed
+    let build_script_dir_path = dunce::canonicalize(Path::new(".")).unwrap();
     let bitcode_path = build_script_dir_path.join("bitcode");
 
     // LLVM .bc FILES


### PR DESCRIPTION
Trying to run `cargo build` on windows used to error with something like zig failed `BadPathName`. These changes fix that.

`std::fs::canonicalize` adds a special windows prefix `?`, zig erroneously (ziglang/zig#5109) does not allow `?` in windows paths, dunce correctly removes this `?` prefix.