### PR TITLE
Wasmer: use cranelift for non-x86_64 since singlepass is not supported

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,7 +24,7 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b"
 dependencies = [
- "gimli",
+ "gimli 0.26.1",
 ]
 
 [[package]]
@@ -740,6 +740,66 @@ dependencies = [
 ]
 
 [[package]]
+name = "cranelift-bforest"
+version = "0.74.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ca3560686e7c9c7ed7e0fe77469f2410ba5d7781b1acaa9adc8d8deea28e3e"
+dependencies = [
+ "cranelift-entity",
+]
+
+[[package]]
+name = "cranelift-codegen"
+version = "0.74.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf9bf1ffffb6ce3d2e5ebc83549bd2436426c99b31cc550d521364cbe35d276"
+dependencies = [
+ "cranelift-bforest",
+ "cranelift-codegen-meta",
+ "cranelift-codegen-shared",
+ "cranelift-entity",
+ "gimli 0.24.0",
+ "log",
+ "regalloc",
+ "smallvec",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-codegen-meta"
+version = "0.74.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cc21936a5a6d07e23849ffe83e5c1f6f50305c074f4b2970ca50c13bf55b821"
+dependencies = [
+ "cranelift-codegen-shared",
+ "cranelift-entity",
+]
+
+[[package]]
+name = "cranelift-codegen-shared"
+version = "0.74.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca5b6ffaa87560bebe69a5446449da18090b126037920b0c1c6d5945f72faf6b"
+
+[[package]]
+name = "cranelift-entity"
+version = "0.74.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d6b4a8bef04f82e4296782646f733c641d09497df2fabf791323fefaa44c64c"
+
+[[package]]
+name = "cranelift-frontend"
+version = "0.74.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b783b351f966fce33e3c03498cb116d16d97a8f9978164a60920bd0d3a99c"
+dependencies = [
+ "cranelift-codegen",
+ "log",
+ "smallvec",
+ "target-lexicon",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1253,6 +1313,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 
 [[package]]
+name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+
+[[package]]
 name = "fd-lock"
 version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1469,6 +1535,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "gimli"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e4075386626662786ddb0ec9081e7c7eeb1ba31951f447ca780ef9f5d568189"
+dependencies = [
+ "fallible-iterator",
+ "indexmap",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -3080,6 +3157,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "regalloc"
+version = "0.0.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "571f7f397d61c4755285cd37853fe8e03271c243424a907415909379659381c5"
+dependencies = [
+ "log",
+ "rustc-hash",
+ "smallvec",
+]
+
+[[package]]
 name = "regex"
 version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4166,6 +4254,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4692,6 +4786,7 @@ dependencies = [
  "target-lexicon",
  "thiserror",
  "wasmer-compiler",
+ "wasmer-compiler-cranelift",
  "wasmer-compiler-singlepass",
  "wasmer-derive",
  "wasmer-engine",
@@ -4719,6 +4814,26 @@ dependencies = [
  "wasmer-types",
  "wasmer-vm",
  "wasmparser",
+]
+
+[[package]]
+name = "wasmer-compiler-cranelift"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a570746cbec434179e2d53357973a34dfdb208043104e8fac3b7b0023015cf6"
+dependencies = [
+ "cranelift-codegen",
+ "cranelift-entity",
+ "cranelift-frontend",
+ "gimli 0.24.0",
+ "loupe",
+ "more-asserts",
+ "rayon",
+ "smallvec",
+ "tracing",
+ "wasmer-compiler",
+ "wasmer-types",
+ "wasmer-vm",
 ]
 
 [[package]]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -65,12 +65,16 @@ mimalloc = { version = "0.1.26", default-features = false }
 
 target-lexicon = "0.12.2"
 tempfile = "3.2.0"
-
-wasmer = { version = "2.0.0", optional = true, default-features = false, features = ["default-singlepass", "default-universal"] }
 wasmer-wasi = { version = "2.0.0", optional = true }
 
+# Wasmer singlepass compiler only works on x86_64.
+[target.'cfg(target_arch = "x86_64")'.dependencies]
+wasmer = { version = "2.0.0", optional = true, default-features = false, features = ["default-singlepass", "default-universal"] }
+
+[target.'cfg(not(target_arch = "x86_64"))'.dependencies]
+wasmer = { version = "2.0.0", optional = true, default-features = false, features = ["default-cranelift", "default-universal"] }
+
 [dev-dependencies]
-wasmer = { version = "2.0.0", default-features = false, features = ["default-singlepass", "default-universal"] }
 wasmer-wasi = "2.0.0"
 pretty_assertions = "1.0.0"
 roc_test_utils = { path = "../test_utils" }
@@ -78,6 +82,13 @@ indoc = "1.0.3"
 serial_test = "0.5.1"
 criterion = { git = "https://github.com/Anton-4/criterion.rs"}
 cli_utils = { path = "../cli_utils" }
+
+# Wasmer singlepass compiler only works on x86_64.
+[target.'cfg(target_arch = "x86_64")'.dev-dependencies]
+wasmer = { version = "2.0.0", default-features = false, features = ["default-singlepass", "default-universal"] }
+
+[target.'cfg(not(target_arch = "x86_64"))'.dev-dependencies]
+wasmer = { version = "2.0.0", default-features = false, features = ["default-cranelift", "default-universal"] }
 
 [[bench]]
 name = "time_bench"

--- a/compiler/test_gen/Cargo.toml
+++ b/compiler/test_gen/Cargo.toml
@@ -39,10 +39,16 @@ libc = "0.2.106"
 inkwell = { path = "../../vendor/inkwell" }
 target-lexicon = "0.12.2"
 libloading = "0.7.1"
-wasmer = { version = "2.0.0", default-features = false, features = ["default-singlepass", "default-universal"] }
 wasmer-wasi = "2.0.0"
 tempfile = "3.2.0"
 indoc = "1.0.3"
+
+# Wasmer singlepass compiler only works on x86_64.
+[target.'cfg(target_arch = "x86_64")'.dev-dependencies]
+wasmer = { version = "2.0.0", default-features = false, features = ["default-singlepass", "default-universal"] }
+
+[target.'cfg(not(target_arch = "x86_64"))'.dev-dependencies]
+wasmer = { version = "2.0.0", default-features = false, features = ["default-cranelift", "default-universal"] }
 
 [features]
 default = ["gen-llvm"]

--- a/repl_test/Cargo.toml
+++ b/repl_test/Cargo.toml
@@ -13,11 +13,17 @@ roc_cli = {path = "../cli"}
 [dev-dependencies]
 indoc = "1.0.3"
 strip-ansi-escapes = "0.1.1"
-wasmer = {version = "2.0.0", default-features = false, features = ["default-singlepass", "default-universal"]}
 wasmer-wasi = "2.0.0"
 
 roc_repl_cli = {path = "../repl_cli"}
 roc_test_utils = {path = "../test_utils"}
+
+# Wasmer singlepass compiler only works on x86_64.
+[target.'cfg(target_arch = "x86_64")'.dev-dependencies]
+wasmer = { version = "2.0.0", default-features = false, features = ["default-singlepass", "default-universal"] }
+
+[target.'cfg(not(target_arch = "x86_64"))'.dev-dependencies]
+wasmer = { version = "2.0.0", default-features = false, features = ["default-cranelift", "default-universal"] }
 
 [features]
 wasm = []


### PR DESCRIPTION
Just trying to fix the build on M1 macs