### PR TITLE
fix `IdentStr::clone`

### DIFF
--- a/compiler/ident/src/lib.rs
+++ b/compiler/ident/src/lib.rs
@@ -285,8 +285,7 @@ impl Clone for IdentStr {
                 length: self.length,
             }
         } else {
-            let capacity_size = core::mem::size_of::<usize>();
-            let copy_length = self.length + capacity_size;
+            let copy_length = self.length;
             let elements = unsafe {
                 let align = mem::align_of::<u8>();
                 let layout = Layout::from_size_align_unchecked(copy_length, align);


### PR DESCRIPTION
`IdentStr` no longer has a capacity, so `copy_length` was incorrect leading to reading data out of bounds and later deallocating memory with a wrong size.