### PR TITLE
Add local+global persistent command history and session history to REPL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1701,6 +1701,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 
 [[package]]
+name = "home"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2456aef2e6b6a9784192ae780c0f15bc57df0e918585282325e8c8ac27737654"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "hound"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3778,6 +3787,7 @@ version = "0.1.0"
 dependencies = [
  "bumpalo",
  "const_format",
+ "home",
  "inkwell 0.1.0",
  "libloading 0.7.1",
  "roc_build",

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -40,6 +40,7 @@ pub const FLAG_LINK: &str = "roc-linker";
 pub const FLAG_PRECOMPILED: &str = "precompiled-host";
 pub const FLAG_VALGRIND: &str = "valgrind";
 pub const FLAG_CHECK: &str = "check";
+pub const FLAG_NO_HISTORY: &str = "no-history";
 pub const ROC_FILE: &str = "ROC_FILE";
 pub const ROC_DIR: &str = "ROC_DIR";
 pub const DIRECTORY_OR_FILES: &str = "DIRECTORY_OR_FILES";
@@ -121,6 +122,12 @@ pub fn build_app<'a>() -> App<'a> {
         )
         .subcommand(App::new(CMD_REPL)
             .about("Launch the interactive Read Eval Print Loop (REPL)")
+            .arg(
+                Arg::new(FLAG_NO_HISTORY)
+                    .long(FLAG_NO_HISTORY)
+                    .about("Start the repl without loading or saving to persistent history files")
+                    .required(false)
+            )
         )
         .subcommand(App::new(CMD_FORMAT)
             .about("Format Roc code")

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,7 +1,8 @@
 use roc_cli::build::check_file;
 use roc_cli::{
     build_app, docs, format, BuildConfig, FormatMode, CMD_BUILD, CMD_CHECK, CMD_DOCS, CMD_EDIT,
-    CMD_FORMAT, CMD_REPL, CMD_VERSION, DIRECTORY_OR_FILES, FLAG_CHECK, FLAG_TIME, ROC_FILE,
+    CMD_FORMAT, CMD_REPL, CMD_VERSION, DIRECTORY_OR_FILES, FLAG_CHECK, FLAG_NO_HISTORY, FLAG_TIME,
+    ROC_FILE,
 };
 use roc_load::file::LoadingProblem;
 use std::fs::{self, FileType};
@@ -62,10 +63,12 @@ fn main() -> io::Result<()> {
                 }
             }
         }
-        Some((CMD_REPL, _)) => {
+        Some((CMD_REPL, matches)) => {
             #[cfg(feature = "llvm")]
             {
-                roc_repl_cli::main()?;
+                let persist_history = !matches.is_present(FLAG_NO_HISTORY);
+
+                roc_repl_cli::main(persist_history)?;
 
                 // Exit 0 if the repl exited normally
                 Ok(0)

--- a/repl_cli/Cargo.toml
+++ b/repl_cli/Cargo.toml
@@ -21,6 +21,7 @@ libloading = "0.7.1"
 rustyline = {git = "https://github.com/rtfeldman/rustyline", rev = "e74333c"}
 rustyline-derive = {git = "https://github.com/rtfeldman/rustyline", rev = "e74333c"}
 target-lexicon = "0.12.2"
+home = "0.5.3"
 
 # TODO: make llvm optional
 roc_build = {path = "../compiler/build", features = ["llvm"]}

--- a/repl_cli/src/lib.rs
+++ b/repl_cli/src/lib.rs
@@ -430,7 +430,7 @@ pub fn main(with_history: bool) -> io::Result<()> {
                 |path| match touch(path.clone()).map(|path| editor.load_history(&path)) {
                     Ok(_) => Some(path),
                     Err(_) => {
-                        println!("Failed to load or initialize global history");
+                        eprintln!("Failed to load or initialize global history");
                         None
                     }
                 },
@@ -444,7 +444,7 @@ pub fn main(with_history: bool) -> io::Result<()> {
         match touch(local_history_path()).map(|path| editor.load_history(&path)) {
             Ok(_) => Some(local_history_path()),
             Err(_) => {
-                println!("Failed to load or initialize local history");
+                eprintln!("Failed to load or initialize local history");
                 None
             }
         }

--- a/repl_test/src/cli.rs
+++ b/repl_test/src/cli.rs
@@ -42,7 +42,7 @@ fn path_to_roc_binary() -> PathBuf {
 fn repl_eval(input: &str) -> Out {
     let mut cmd = Command::new(path_to_roc_binary());
 
-    cmd.arg("repl").arg("--no-history");
+    cmd.arg("repl").current_dir("tmp");
 
     let mut child = cmd
         .stdin(Stdio::piped())

--- a/repl_test/src/cli.rs
+++ b/repl_test/src/cli.rs
@@ -42,6 +42,9 @@ fn path_to_roc_binary() -> PathBuf {
 fn repl_eval(input: &str) -> Out {
     let mut cmd = Command::new(path_to_roc_binary());
 
+    env::set_var("ROC_REPL_LOCAL_HISTORY_PATH", "local_history.dat");
+    env::set_var("ROC_REPL_GLOBAL_HISTORY_PATH", "global_history.dat");
+
     cmd.arg("repl").current_dir("tmp");
 
     let mut child = cmd

--- a/repl_test/src/cli.rs
+++ b/repl_test/src/cli.rs
@@ -42,7 +42,7 @@ fn path_to_roc_binary() -> PathBuf {
 fn repl_eval(input: &str) -> Out {
     let mut cmd = Command::new(path_to_roc_binary());
 
-    cmd.arg("repl");
+    cmd.arg("repl").arg("--no-history");
 
     let mut child = cmd
         .stdin(Stdio::piped())


### PR DESCRIPTION
This change adds a project-specific, session-specific, and global command history to the repl. The project-specific command history is saved to `./.roc_cache/repl_history.dat` and the global command history is saved to `.roc_cache/repl_history.dat` in the user's home directory (os-dependent.)

This change also adds a :save command to the repl which uses rustyline's built-in history to save your current session's command history to a file. By default, your session's command history is discarded when the repl is terminated.

:save newfile should create a the file and save to it
:save existingfile saves the history to that file if it's writable, overwriting its contents. (Maybe this is less than desirable.)
:save unwritablefile surfaces the IO error to the user if it can't be saved.

This change also adds a `no-history` flag which tells the repl not to load or save to the project-specific or global history files during the session. This makes for a cleaner interface with the current repl tests, which would otherwise potentially fail on disk issues or fill up the global command history file with test commands and make a big mess.

current flaws; File errors are surfaced on open, not on write, so if you open the file and then set it unwritable while the repl is running it will not surface an error. Might fail silently with a full disk. Might have trouble with multiple repl's open simultaneously trying to lock the global command history. (it seems okay with two)

