### PR TITLE
repl_www: use up and down arrows to navigate input history

### DIFF
--- a/repl_www/public/repl.js
+++ b/repl_www/public/repl.js
@@ -15,6 +15,8 @@ const repl = {
 
   inputQueue: [],
   inputHistory: [],
+  inputHistoryIndex: 0,
+  inputStash: "", // stash the user input while we're toggling through history with up/down arrows
 
   textDecoder: new TextDecoder(),
   textEncoder: new TextEncoder(),
@@ -28,6 +30,7 @@ const repl = {
 
 // Initialise
 repl.elemSourceInput.addEventListener("change", onInputChange);
+repl.elemSourceInput.addEventListener("keyup", onInputKeyup);
 roc_repl_wasm.default().then((instance) => {
   repl.compiler = instance;
 });
@@ -38,6 +41,8 @@ roc_repl_wasm.default().then((instance) => {
 
 function onInputChange(event) {
   const inputText = event.target.value;
+  if (!inputText) return;
+
   event.target.value = "";
 
   repl.inputQueue.push(inputText);
@@ -46,13 +51,60 @@ function onInputChange(event) {
   }
 }
 
+function onInputKeyup(event) {
+  const UP = 38;
+  const DOWN = 40;
+  const ENTER = 13;
+
+  const { keyCode } = event;
+
+  const el = repl.elemSourceInput;
+
+  switch (keyCode) {
+    case UP:
+      if (repl.inputHistoryIndex == repl.inputHistory.length - 1) {
+        repl.inputStash = el.value;
+      }
+      setInput(repl.inputHistory[repl.inputHistoryIndex]);
+
+      if (repl.inputHistoryIndex > 0) {
+        repl.inputHistoryIndex--;
+      }
+      break;
+
+    case DOWN:
+      if (repl.inputHistoryIndex === repl.inputHistory.length - 1) {
+        setInput(repl.inputStash);
+      } else {
+        repl.inputHistoryIndex++;
+        setInput(repl.inputHistory[repl.inputHistoryIndex]);
+      }
+      break;
+
+    case ENTER:
+      onInputChange({ target: repl.elemSourceInput });
+      break;
+
+    default:
+      break;
+  }
+}
+
+function setInput(value) {
+  const el = repl.elemSourceInput;
+  el.value = value;
+  el.selectionStart = value.length;
+  el.selectionEnd = value.length;
+}
+
 // Use a queue just in case we somehow get inputs very fast
 // We want the REPL to only process one at a time, since we're using some global state.
 // In normal usage we shouldn't see this edge case anyway. Maybe with copy/paste?
 async function processInputQueue() {
   while (repl.inputQueue.length) {
     const inputText = repl.inputQueue[0];
-    const historyIndex = createHistoryEntry(inputText);
+    repl.inputHistoryIndex = createHistoryEntry(inputText);
+    repl.inputStash = "";
 
     let outputText;
     let ok = true;
@@ -63,7 +115,7 @@ async function processInputQueue() {
       ok = false;
     }
 
-    updateHistoryEntry(historyIndex, ok, outputText);
+    updateHistoryEntry(repl.inputHistoryIndex, ok, outputText);
     repl.inputQueue.shift();
   }
 }


### PR DESCRIPTION
When I was testing the web REPL, I kept absent-mindedly pressing the "up arrow" key to get previous inputs.
But it doesn't have that feature yet! And I should know better because I wrote it 😆
Let's get it in there before it just irritates everyone!
