### PR TITLE
make vars-by-symbol a vector

### DIFF
--- a/compiler/load/src/file.rs
+++ b/compiler/load/src/file.rs
@@ -502,7 +502,7 @@ enum Msg<'a> {
     },
     FinishedAllTypeChecking {
         solved_subs: Solved<Subs>,
-        exposed_vars_by_symbol: MutMap<Symbol, Variable>,
+        exposed_vars_by_symbol: Vec<(Symbol, Variable)>,
         exposed_aliases_by_symbol: MutMap<Symbol, Alias>,
         exposed_values: Vec<Symbol>,
         dep_idents: MutMap<ModuleId, IdentIds>,
@@ -2131,7 +2131,7 @@ fn finish(
     solved: Solved<Subs>,
     exposed_values: Vec<Symbol>,
     exposed_aliases_by_symbol: MutMap<Symbol, Alias>,
-    exposed_vars_by_symbol: MutMap<Symbol, Variable>,
+    exposed_vars_by_symbol: Vec<(Symbol, Variable)>,
     dep_idents: MutMap<ModuleId, IdentIds>,
     documentation: MutMap<ModuleId, ModuleDocumentation>,
 ) -> LoadedModule {
@@ -3104,8 +3104,10 @@ fn run_solve<'a>(
     let (solved_subs, solved_env, problems) =
         roc_solve::module::run_solve(rigid_variables, constraint, var_store);
 
-    let mut exposed_vars_by_symbol: MutMap<Symbol, Variable> = solved_env.vars_by_symbol();
-    exposed_vars_by_symbol.retain(|k, _| exposed_symbols.contains(k));
+    let exposed_vars_by_symbol: Vec<_> = solved_env
+        .vars_by_symbol()
+        .filter(|(k, _)| exposed_symbols.contains(k))
+        .collect();
 
     let solved_types = roc_solve::module::make_solved_types(&solved_subs, &exposed_vars_by_symbol);
 

--- a/compiler/solve/src/module.rs
+++ b/compiler/solve/src/module.rs
@@ -12,7 +12,7 @@ pub struct SolvedModule {
     pub solved_types: MutMap<Symbol, SolvedType>,
     pub aliases: MutMap<Symbol, Alias>,
     pub exposed_symbols: Vec<Symbol>,
-    pub exposed_vars_by_symbol: MutMap<Symbol, Variable>,
+    pub exposed_vars_by_symbol: Vec<(Symbol, Variable)>,
     pub problems: Vec<solve::TypeError>,
 }
 
@@ -41,7 +41,7 @@ pub fn run_solve(
 
 pub fn make_solved_types(
     solved_subs: &Solved<Subs>,
-    exposed_vars_by_symbol: &MutMap<Symbol, Variable>,
+    exposed_vars_by_symbol: &[(Symbol, Variable)],
 ) -> MutMap<Symbol, SolvedType> {
     let mut solved_types = MutMap::default();
 

--- a/compiler/solve/src/solve.rs
+++ b/compiler/solve/src/solve.rs
@@ -84,11 +84,11 @@ pub struct Env {
 }
 
 impl Env {
-    pub fn vars_by_symbol(&self) -> MutMap<Symbol, Variable> {
+    pub fn vars_by_symbol(&self) -> impl Iterator<Item = (Symbol, Variable)> + '_ {
         let it1 = self.symbols.iter().copied();
         let it2 = self.variables.iter().copied();
 
-        it1.zip(it2).collect()
+        it1.zip(it2)
     }
 
     fn get_var_by_symbol(&self, symbol: &Symbol) -> Option<Variable> {


### PR DESCRIPTION
little follow-up. Apparently the MutMap creation was still expensive. `Vec` to the rescue