### PR TITLE
Web REPL: Download a pre-built Wasm binary to Netlify

### DIFF
--- a/www/build.sh
+++ b/www/build.sh
@@ -11,15 +11,17 @@ cd $SCRIPT_RELATIVE_DIR
 rm -rf build/
 cp -r public/ build/
 
-# Build the repl page
-mkdir -p build/repl
-pushd ..
-repl_www/build.sh www/build/repl
-popd
-
-# grab the source code and copy it to Netlify's server; if it's not there, fail the build.
 pushd build
+# grab the source code and copy it to Netlify's server; if it's not there, fail the build.
 wget https://github.com/rtfeldman/elm-css/files/8037422/roc-source-code.zip
+
+# grab the pre-compiled REPL and copy it to Netlify's server; if it's not there, fail the build.
+mkdir -p repl
+cd repl
+wget https://github.com/brian-carroll/mock-repl/files/8167902/roc_repl_wasm.tar.gz
+tar xzvf roc_repl_wasm.tar.gz
+rm roc_repl_wasm.tar.gz
+cp ../../../repl_www/public/* .
 popd
 
 # pushd ..


### PR DESCRIPTION
It's a lot of hassle to build the REPL on Netlify. We need Zig builtins, there are issues with `llvm-as`, etc. etc.
Instead, at least for now, let's use a pre-compiled .wasm binary.

Here I'm loading it from GitHub. (The repo where I made the prototype for this REPL!) The only traffic will be from the Netlify build. After that, it will be served directly from Netlify. This is also what we're doing for the source code bundle.

We are downloading a 1.6MB tarfile containing two generated files: `roc_repl_wasm_bg.wasm` and `roc_repl_wasm.js`. This expands out to about 5.6MB.

The tarfile is only for generated files. The handwritten HTML and JS files just come from the Netlify copy of the repo. This means most edits to tweak the UI won't require messing with the tarfile.

Here's what the folder will look like when deployed
```
build
├── favicon.svg
├── index.html
├── license
│   └── index.html
├── logo.svg
├── repl
│   ├── index.html
│   ├── repl.js
│   ├── roc_repl_wasm.js
│   ├── roc_repl_wasm_bg.wasm
│   └── wasi.js
├── roc-source-code.zip
└── styles.css
```