### PR TITLE
Move alias analysis to its own crate instead of roc_mono

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3264,6 +3264,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "roc_alias_analysis"
+version = "0.1.0"
+dependencies = [
+ "morphic_lib",
+ "roc_collections",
+ "roc_module",
+ "roc_mono",
+]
+
+[[package]]
 name = "roc_ast"
 version = "0.1.0"
 dependencies = [
@@ -3559,6 +3569,7 @@ dependencies = [
  "bumpalo",
  "inkwell 0.1.0",
  "morphic_lib",
+ "roc_alias_analysis",
  "roc_builtins",
  "roc_collections",
  "roc_error_macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
     "compiler/solve",
     "compiler/fmt",
     "compiler/mono",
+    "compiler/alias_analysis",
     "compiler/test_mono",
     "compiler/load",
     "compiler/gen_llvm",

--- a/compiler/alias_analysis/Cargo.toml
+++ b/compiler/alias_analysis/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+authors = ["The Roc Contributors"]
+edition = "2018"
+license = "UPL-1.0"
+name = "roc_alias_analysis"
+version = "0.1.0"
+
+[dependencies]
+morphic_lib = {path = "../../vendor/morphic_lib"}
+roc_collections = {path = "../collections"}
+roc_module = {path = "../module"}
+roc_mono = {path = "../mono"}
+

--- a/compiler/alias_analysis/src/lib.rs
+++ b/compiler/alias_analysis/src/lib.rs
@@ -8,11 +8,11 @@ use roc_collections::all::{MutMap, MutSet};
 use roc_module::low_level::LowLevel;
 use roc_module::symbol::Symbol;
 
-use crate::ir::{
+use roc_mono::ir::{
     Call, CallType, Expr, HigherOrderLowLevel, HostExposedLayouts, ListLiteralElement, Literal,
     ModifyRc, OptLevel, Proc, Stmt,
 };
-use crate::layout::{Builtin, Layout, RawFunctionLayout, UnionLayout};
+use roc_mono::layout::{Builtin, Layout, RawFunctionLayout, UnionLayout};
 
 // just using one module for now
 pub const MOD_APP: ModName = ModName(b"UserApp");
@@ -110,7 +110,7 @@ fn bytes_as_ascii(bytes: &[u8]) -> String {
 
 pub fn spec_program<'a, I>(
     opt_level: OptLevel,
-    entry_point: crate::ir::EntryPoint<'a>,
+    entry_point: roc_mono::ir::EntryPoint<'a>,
     procs: I,
 ) -> Result<morphic_lib::Solutions>
 where
@@ -266,7 +266,7 @@ fn terrible_hack(builder: &mut FuncDefBuilder, block: BlockId, type_id: TypeId) 
 }
 
 fn build_entry_point(
-    layout: crate::ir::ProcLayout,
+    layout: roc_mono::ir::ProcLayout,
     func_name: FuncName,
     host_exposed_functions: &[([u8; SIZE], &[Layout])],
 ) -> Result<FuncDef> {
@@ -363,7 +363,7 @@ fn proc_spec<'a>(proc: &Proc<'a>) -> Result<(FuncDef, MutSet<UnionLayout<'a>>)> 
 #[derive(Default)]
 struct Env<'a> {
     symbols: MutMap<Symbol, ValueId>,
-    join_points: MutMap<crate::ir::JoinPointId, morphic_lib::ContinuationId>,
+    join_points: MutMap<roc_mono::ir::JoinPointId, morphic_lib::ContinuationId>,
     type_names: MutSet<UnionLayout<'a>>,
 }
 
@@ -711,7 +711,7 @@ fn call_spec(
             passed_function,
             ..
         }) => {
-            use crate::low_level::HigherOrder::*;
+            use roc_mono::low_level::HigherOrder::*;
 
             let array = passed_function.specialization_id.to_bytes();
             let spec_var = CalleeSpecVar(&array);
@@ -1196,7 +1196,7 @@ fn lowlevel_spec(
     block: BlockId,
     layout: &Layout,
     op: &LowLevel,
-    update_mode: crate::ir::UpdateModeId,
+    update_mode: roc_mono::ir::UpdateModeId,
     arguments: &[Symbol],
 ) -> Result<ValueId> {
     use LowLevel::*;

--- a/compiler/gen_llvm/Cargo.toml
+++ b/compiler/gen_llvm/Cargo.toml
@@ -7,6 +7,7 @@ license = "UPL-1.0"
 edition = "2018"
 
 [dependencies]
+roc_alias_analysis = { path = "../alias_analysis" }
 roc_collections = { path = "../collections" }
 roc_module = { path = "../module" }
 roc_builtins = { path = "../builtins" }

--- a/compiler/gen_llvm/src/llvm/build.rs
+++ b/compiler/gen_llvm/src/llvm/build.rs
@@ -710,7 +710,7 @@ fn promote_to_main_function<'a, 'ctx, 'env>(
     top_level: ProcLayout<'a>,
 ) -> (&'static str, FunctionValue<'ctx>) {
     let it = top_level.arguments.iter().copied();
-    let bytes = roc_mono::alias_analysis::func_name_bytes_help(symbol, it, &top_level.result);
+    let bytes = roc_alias_analysis::func_name_bytes_help(symbol, it, &top_level.result);
     let func_name = FuncName(&bytes);
     let func_solutions = mod_solutions.func_solutions(func_name).unwrap();
 
@@ -4045,7 +4045,7 @@ pub fn build_proc_headers<'a, 'ctx, 'env>(
     // Populate Procs further and get the low-level Expr from the canonical Expr
     let mut headers = Vec::with_capacity_in(procedures.len(), env.arena);
     for ((symbol, layout), proc) in procedures {
-        let name_bytes = roc_mono::alias_analysis::func_name_bytes(&proc);
+        let name_bytes = roc_alias_analysis::func_name_bytes(&proc);
         let func_name = FuncName(&name_bytes);
 
         let func_solutions = mod_solutions.func_solutions(func_name).unwrap();
@@ -4110,7 +4110,7 @@ fn build_procedures_help<'a, 'ctx, 'env>(
 
     let it = procedures.iter().map(|x| x.1);
 
-    let solutions = match roc_mono::alias_analysis::spec_program(opt_level, entry_point, it) {
+    let solutions = match roc_alias_analysis::spec_program(opt_level, entry_point, it) {
         Err(e) => panic!("Error in alias analysis: {}", e),
         Ok(solutions) => solutions,
     };
@@ -4118,7 +4118,7 @@ fn build_procedures_help<'a, 'ctx, 'env>(
     let solutions = env.arena.alloc(solutions);
 
     let mod_solutions = solutions
-        .mod_solutions(roc_mono::alias_analysis::MOD_APP)
+        .mod_solutions(roc_alias_analysis::MOD_APP)
         .unwrap();
 
     // Add all the Proc headers to the module.
@@ -4470,11 +4470,8 @@ pub fn build_proc<'a, 'ctx, 'env>(
                         // * roc__mainForHost_1_Update_result_size() -> i64
 
                         let it = top_level.arguments.iter().copied();
-                        let bytes = roc_mono::alias_analysis::func_name_bytes_help(
-                            symbol,
-                            it,
-                            &top_level.result,
-                        );
+                        let bytes =
+                            roc_alias_analysis::func_name_bytes_help(symbol, it, &top_level.result);
                         let func_name = FuncName(&bytes);
                         let func_solutions = mod_solutions.func_solutions(func_name).unwrap();
 

--- a/compiler/mono/src/lib.rs
+++ b/compiler/mono/src/lib.rs
@@ -2,7 +2,6 @@
 // See github.com/rtfeldman/roc/issues/800 for discussion of the large_enum_variant check.
 #![allow(clippy::large_enum_variant, clippy::upper_case_acronyms)]
 
-pub mod alias_analysis;
 pub mod borrow;
 pub mod code_gen_help;
 pub mod inc_dec;


### PR DESCRIPTION
Shrinks `roc_repl_wasm` from 5.7MB to 5.3MB (~8%), resolving #2638

This seems to be related to the fact that `morphic_lib` has lots of `extern` symbols. These are preserved all the way through to the .wasm file, eventually becoming exports to JS.
