### PR TITLE
Rename CLI --backend to --target since that's what it has always meant

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -93,7 +93,7 @@ test-rust:
     RUN --mount=type=cache,target=$SCCACHE_DIR \
         repl_test/test_wasm.sh && sccache --show-stats
     # run i386 (32-bit linux) cli tests
-    RUN echo "4" | cargo run --locked --release --features="target-x86" -- --backend=x86_32 examples/benchmarks/NQueens.roc
+    RUN echo "4" | cargo run --locked --release --features="target-x86" -- --target=x86_32 examples/benchmarks/NQueens.roc
     RUN --mount=type=cache,target=$SCCACHE_DIR \
         cargo test --locked --release --features with_sound --test cli_run i386 --features="i386-cli-run" && sccache --show-stats
 

--- a/cli/tests/cli_run.rs
+++ b/cli/tests/cli_run.rs
@@ -194,7 +194,7 @@ mod cli_run {
     ) {
         assert_eq!(input_file, None, "Wasm does not support input files");
         let mut flags = flags.to_vec();
-        flags.push("--backend=wasm32");
+        flags.push("--target=wasm32");
 
         let compile_out = run_roc(&[&["build", file.to_str().unwrap()], flags.as_slice()].concat());
         if !compile_out.stderr.is_empty() {
@@ -565,7 +565,7 @@ mod cli_run {
                         &file_name,
                         benchmark.stdin,
                         benchmark.executable_filename,
-                        &["--backend=x86_32"],
+                        &["--target=x86_32"],
                         benchmark.input_file.and_then(|file| Some(examples_dir("benchmarks").join(file))),
                         benchmark.expected_ending,
                         benchmark.use_valgrind,
@@ -575,7 +575,7 @@ mod cli_run {
                         &file_name,
                         benchmark.stdin,
                         benchmark.executable_filename,
-                        &["--backend=x86_32", "--optimize"],
+                        &["--target=x86_32", "--optimize"],
                         benchmark.input_file.and_then(|file| Some(examples_dir("benchmarks").join(file))),
                         benchmark.expected_ending,
                         benchmark.use_valgrind,

--- a/examples/hello-web/README.md
+++ b/examples/hello-web/README.md
@@ -3,7 +3,7 @@
 To run, go to the project home directory and run:
 
 ```bash
-$ cargo run -- build --backend=wasm32 examples/hello-web/Hello.roc
+$ cargo run -- build --target=wasm32 examples/hello-web/Hello.roc
 ```
 
 Then `cd` into the example directory and run any web server that can handle WebAssembly.


### PR DESCRIPTION
Currently on `trunk`, the `--backend` option is describing targets, not backends. It's simply using the wrong name for the concept that it represents.

It has help text like this:
```
        --backend <target>     Choose a different backend [default: host] [possible values: host,
                              x86_32, x86_64, wasm32]
```

But these are not backends! They are targets!

Similarly in the code it is defined by the following enum in `roc_cli`
```rs
enum Backend {
    Host,
    X86_32,
    X86_64,
    Wasm32,
}
```

This PR just renames it to `--target` and `Target` everywhere, *without changing what it does in any way*. If we decide to change what it does, that will be another PR.
