### PR TITLE
Add error message when `imports` are missing

### DIFF
--- a/reporting/src/error/parse.rs
+++ b/reporting/src/error/parse.rs
@@ -3400,7 +3400,7 @@ fn to_imports_report<'a>(
             }
         }
 
-        EImports::Imports(pos) => {
+        EImports::Imports(pos) | EImports::IndentImports(pos) => {
             let surroundings = Region::new(start, pos);
             let region = LineColumnRegion::from_pos(lines.convert_pos(pos));
 

--- a/reporting/tests/test_reporting.rs
+++ b/reporting/tests/test_reporting.rs
@@ -6139,6 +6139,32 @@ I need all branches in an `if` to have the same type!
     }
 
     #[test]
+    fn missing_imports() {
+        report_header_problem_as(
+            indoc!(
+                r#"
+                interface Foobar
+                    exposes [ main, Foo ]
+                "#
+            ),
+            indoc!(
+                r#"
+                ── WEIRD IMPORTS ───────────────────────────────────────────────────────────────
+
+                I am partway through parsing a header, but I got stuck here:
+
+                2│      exposes [ main, Foo ]
+                                             ^
+
+                I am expecting the `imports` keyword next, like 
+
+                    imports [ Animal, default, tame ]
+                "#
+            ),
+        )
+    }
+
+    #[test]
     fn exposes_identifier() {
         report_header_problem_as(
             indoc!(


### PR DESCRIPTION
I ran into this error when I forgot to add `imports` in the module header.
I found that currently, the parser produces two kinds of error here: `EImports::Imports` and `EImports::IndentImports`.
The parser will produce the former error if it found a lexeme after `exposes`, and it will produce the latter if a header ends without any `imports`.