### PR TITLE
Add --no-link flag for more complex linking cases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3370,6 +3370,7 @@ dependencies = [
  "roc_can",
  "roc_collections",
  "roc_constrain",
+ "roc_error_macros",
  "roc_gen_dev",
  "roc_gen_llvm",
  "roc_gen_wasm",

--- a/cli/src/build.rs
+++ b/cli/src/build.rs
@@ -246,6 +246,11 @@ pub fn build_file<'a>(
                 todo!("gracefully handle failing to surgically link");
             })?;
         BuildOutcome::NoProblems
+    } else if matches!(link_type, LinkType::None) {
+        // Just copy the object file to the output folder.
+        binary_path.set_extension(app_extension);
+        std::fs::copy(app_o_file, &binary_path).unwrap();
+        BuildOutcome::NoProblems
     } else {
         let mut inputs = vec![
             host_input_path.as_path().to_str().unwrap(),

--- a/compiler/build/Cargo.toml
+++ b/compiler/build/Cargo.toml
@@ -24,6 +24,7 @@ roc_gen_llvm = { path = "../gen_llvm", optional = true }
 roc_gen_wasm = { path = "../gen_wasm", optional = true }
 roc_gen_dev = { path = "../gen_dev", default-features = false }
 roc_reporting = { path = "../../reporting" }
+roc_error_macros = { path = "../../error_macros" }
 roc_std = { path = "../../roc_std", default-features = false }
 bumpalo = { version = "3.8.0", features = ["collections"] }
 libloading = "0.7.1"

--- a/compiler/build/src/link.rs
+++ b/compiler/build/src/link.rs
@@ -2,6 +2,7 @@ use crate::target::{arch_str, target_zig_str};
 #[cfg(feature = "llvm")]
 use libloading::{Error, Library};
 use roc_builtins::bitcode;
+use roc_error_macros::internal_error;
 // #[cfg(feature = "llvm")]
 use roc_mono::ir::OptLevel;
 use std::collections::HashMap;
@@ -20,10 +21,10 @@ fn zig_executable() -> String {
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum LinkType {
-    // These numbers correspond to the --lib flag; if it's present
-    // (e.g. is_present returns `1 as bool`), this will be 1 as well.
+    // These numbers correspond to the --lib and --no-link flags
     Executable = 0,
     Dylib = 1,
+    None = 2,
 }
 
 /// input_paths can include the host as well as the app. e.g. &["host.o", "roc_app.o"]
@@ -835,6 +836,7 @@ fn link_linux(
                 output_path,
             )
         }
+        LinkType::None => internal_error!("link_linux should not be called with link type of none"),
     };
 
     let env_path = env::var("PATH").unwrap_or_else(|_| "".to_string());
@@ -904,6 +906,7 @@ fn link_macos(
 
             ("-dylib", output_path)
         }
+        LinkType::None => internal_error!("link_macos should not be called with link type of none"),
     };
 
     let arch = match target.architecture {


### PR DESCRIPTION
This adds a `--no-link` flag. The flag is mostly for convenience currently since platforms are not able to specify their own build instructions and linking information. That being said, it is also needed for supporting embedded where the surgical linker will never be able to do the linking.