### PR TITLE
add target triple for zig on macos

### DIFF
--- a/compiler/build/src/target.rs
+++ b/compiler/build/src/target.rs
@@ -76,12 +76,12 @@ pub fn target_zig_str(target: &Triple) -> &'static str {
             architecture: Architecture::X86_64,
             operating_system: OperatingSystem::Darwin,
             ..
-        } => "x86_64-apple-darwinn",
+        } => "x86_64-apple-darwin",
         Triple {
             architecture: Architecture::Aarch64(_),
             operating_system: OperatingSystem::Darwin,
             ..
-        } => "aarch64-apple-darwinn",
+        } => "aarch64-apple-darwin",
         _ => panic!("TODO gracefully handle unsupported target: {:?}", target),
     }
 }


### PR DESCRIPTION
Add target triple for zig on macos to fix building examples.