### PR TITLE
Super minor PR for readability in a refcount function. Just uses const variable instead of magic constant.

### DIFF
--- a/compiler/builtins/bitcode/src/utils.zig
+++ b/compiler/builtins/bitcode/src/utils.zig
@@ -174,7 +174,7 @@ inline fn decref_ptr_to_refcount(
 
     if (refcount == REFCOUNT_ONE_ISIZE) {
         dealloc(@ptrCast([*]u8, refcount_ptr) - (extra_bytes - @sizeOf(usize)), alignment);
-    } else if (refcount < 0) {
+    } else if (refcount < REFCOUNT_MAX_ISIZE) {
         refcount_ptr[0] = refcount - 1;
     }
 }


### PR DESCRIPTION
switch from constant to variable for readability