### PR TITLE
fixed high mem+CPU usage for gui-example and editor

### DIFF
--- a/editor/src/editor/main.rs
+++ b/editor/src/editor/main.rs
@@ -266,7 +266,6 @@ fn run_event_loop(project_dir_path_opt: Option<&Path>) -> Result<(), Box<dyn Err
             } => {
                 keyboard_modifiers = modifiers;
             }
-            Event::MainEventsCleared => window.request_redraw(),
             Event::RedrawRequested { .. } => {
                 // Get a command encoder for the current frame
                 let mut encoder =

--- a/examples/gui/platform/src/gui.rs
+++ b/examples/gui/platform/src/gui.rs
@@ -187,7 +187,6 @@ fn run_event_loop(title: &str, root: RocElem) -> Result<(), Box<dyn Error>> {
             } => {
                 keyboard_modifiers = modifiers;
             }
-            Event::MainEventsCleared => window.request_redraw(),
             Event::RedrawRequested { .. } => {
                 // Get a command cmd_encoder for the current frame
                 let mut cmd_encoder =


### PR DESCRIPTION
This fixes the high memory usage on MacOS (now ~58 MB) and reduces the CPU usage to 0.0 :drops_mic:
I couldn't test this for the editor because I'm having some trouble running it on my laptop but everything works fine for the gui-example.