### PR TITLE
Make sure float suffixes are parsed out after can

### DIFF
--- a/ast/src/lang/core/expr/expr_to_expr2.rs
+++ b/ast/src/lang/core/expr/expr_to_expr2.rs
@@ -55,11 +55,11 @@ pub fn expr_to_expr2<'a>(
     match parse_expr {
         Float(string) => {
             match finish_parsing_float(string) {
-                Ok((float, _bound)) => {
+                Ok((string_without_suffix, float, _bound)) => {
                     let expr = Expr2::Float {
                         number: FloatVal::F64(float),
                         var: env.var_store.fresh(),
-                        text: PoolStr::new(string, env.pool),
+                        text: PoolStr::new(string_without_suffix, env.pool),
                     };
 
                     (expr, Output::default())

--- a/ast/src/lang/core/pattern.rs
+++ b/ast/src/lang/core/pattern.rs
@@ -187,7 +187,7 @@ pub fn to_pattern2<'a>(
                     let problem = MalformedPatternProblem::MalformedFloat;
                     malformed_pattern(env, problem, region)
                 }
-                Ok((float, _bound)) => Pattern2::FloatLiteral(FloatVal::F64(float)),
+                Ok((_, float, _bound)) => Pattern2::FloatLiteral(FloatVal::F64(float)),
             },
             ptype => unsupported_pattern(env, ptype, region),
         },

--- a/compiler/can/src/expr.rs
+++ b/compiler/can/src/expr.rs
@@ -315,12 +315,7 @@ pub fn canonicalize_expr<'a>(
             (answer, Output::default())
         }
         &ast::Expr::Float(str) => {
-            let answer = float_expr_from_result(
-                var_store,
-                finish_parsing_float(str).map(|(f, bound)| (str, f, bound)),
-                region,
-                env,
-            );
+            let answer = float_expr_from_result(var_store, finish_parsing_float(str), region, env);
 
             (answer, Output::default())
         }

--- a/compiler/can/src/num.rs
+++ b/compiler/can/src/num.rs
@@ -144,7 +144,7 @@ pub fn finish_parsing_base(
 }
 
 #[inline(always)]
-pub fn finish_parsing_float(raw: &str) -> Result<(f64, FloatBound), (&str, FloatErrorKind)> {
+pub fn finish_parsing_float(raw: &str) -> Result<(&str, f64, FloatBound), (&str, FloatErrorKind)> {
     let (opt_bound, raw_without_suffix) = parse_literal_suffix(raw);
 
     let bound = match opt_bound {
@@ -155,7 +155,7 @@ pub fn finish_parsing_float(raw: &str) -> Result<(f64, FloatBound), (&str, Float
 
     // Ignore underscores.
     match raw_without_suffix.replace('_', "").parse::<f64>() {
-        Ok(float) if float.is_finite() => Ok((float, bound)),
+        Ok(float) if float.is_finite() => Ok((raw_without_suffix, float, bound)),
         Ok(float) => {
             if float.is_sign_positive() {
                 Err((raw, FloatErrorKind::PositiveInfinity))

--- a/compiler/can/src/pattern.rs
+++ b/compiler/can/src/pattern.rs
@@ -282,10 +282,10 @@ pub fn canonicalize_pattern<'a>(
                     let problem = MalformedPatternProblem::MalformedFloat;
                     malformed_pattern(env, problem, region)
                 }
-                Ok((float, bound)) => Pattern::FloatLiteral(
+                Ok((str_without_suffix, float, bound)) => Pattern::FloatLiteral(
                     var_store.fresh(),
                     var_store.fresh(),
-                    (str).into(),
+                    str_without_suffix.into(),
                     float,
                     bound,
                 ),

--- a/compiler/test_gen/src/gen_num.rs
+++ b/compiler/test_gen/src/gen_num.rs
@@ -2906,3 +2906,17 @@ fn div_of_unsigned() {
         u8
     )
 }
+
+#[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
+fn dec_float_suffix() {
+    assert_evals_to!(
+        indoc!(
+            r#"
+            123.0dec
+            "#
+        ),
+        RocDec::from_str_to_i128_unsafe("123.0"),
+        i128
+    );
+}


### PR DESCRIPTION
Before we hit mono, we need to make sure the suffixes of numeric
literals are parsed out from the literal string, so that we don't try to
parse something whose type we already know but has the extraneous
suffix.

Co'ed with @tagraves