### PR TITLE
Allow `ZigVersion` enum to have dead code (unused case)

### DIFF
--- a/compiler/gen_wasm/src/layout.rs
+++ b/compiler/gen_wasm/src/layout.rs
@@ -138,6 +138,7 @@ impl WasmLayout {
     }
 }
 
+#[allow(dead_code)]
 #[derive(PartialEq, Eq)]
 pub enum ZigVersion {
     Zig8,


### PR DESCRIPTION
Quick and dirty PR to suppress warning when building / running compiler that says:
```rust
warning: variant is never constructed: `Zig8`
   --> compiler/gen_wasm/src/layout.rs:143:5
    |
143 |     Zig8,
    |     ^^^^
    |
    = note: `#[warn(dead_code)]` on by default
```
I'm guessing that the `Zig8` case will be used at some point, so outright deleting the case seemed hasteful to me.