### PR TITLE
Give guidance about nix-shell's PATH inside BUILDING_FROM_SOURCE.md

### DIFF
--- a/BUILDING_FROM_SOURCE.md
+++ b/BUILDING_FROM_SOURCE.md
@@ -39,7 +39,7 @@ Use `cargo run help` to see all subcommands.
 To use the `repl` subcommand, execute `cargo run repl`.
 Use `cargo build` to build the whole project.
 
-> In the nix-shell, make sure that inside your `PATH` variable `usr/bin` comes after all the nix-related components. Otherwise you might get some nasty rust compilation errors!
+> When using `nix-shell`, make sure that if you start `nix-shell` and then run `echo "$PATH" | tr ':' '\n'`, you see the `usr/bin` path listed after all the `/nix/…` paths. Otherwise you might get some nasty rust compilation errors!
 
 #### Extra tips
 


### PR DESCRIPTION
Compilation of `roc_cli` was failing with an obscure error about linking with `cc` and not being able to find `-ltinfo`. Turns out the fix is as trivial as rearranging nix-shell's `PATH` a little --- `usr/bin` has to come after all the nix-related components.

This head-scratching error was only solved thanks to @ayazhafiz 's insight. I feel like nix-shell will become the default for many users who prefer delegating the necessary setup to the repo's script, and I definitely wish I had known about this when I was starting out.

Is this the right place to mention this or should it be somewhere else in the document?