### PR TITLE
Propogate errors in record fields to layout error

### DIFF
--- a/compiler/mono/src/layout.rs
+++ b/compiler/mono/src/layout.rs
@@ -10,7 +10,7 @@ use roc_target::{PtrWidth, TargetInfo};
 use roc_types::subs::{
     Content, FlatType, RecordFields, Subs, UnionTags, UnsortedUnionTags, Variable,
 };
-use roc_types::types::{gather_fields_unsorted_iter, RecordField};
+use roc_types::types::{gather_fields_unsorted_iter, RecordField, RecordFieldsError};
 use std::collections::hash_map::{DefaultHasher, Entry};
 use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
@@ -1683,7 +1683,11 @@ fn layout_from_flat_type<'a>(
             // extract any values from the ext_var
 
             let mut pairs = Vec::with_capacity_in(fields.len(), arena);
-            for (label, field) in fields.unsorted_iterator(subs, ext_var) {
+            let it = match fields.unsorted_iterator(subs, ext_var) {
+                Ok(it) => it,
+                Err(RecordFieldsError) => return Err(LayoutProblem::Erroneous),
+            };
+            for (label, field) in it {
                 // drop optional fields
                 let var = match field {
                     RecordField::Optional(_) => continue,

--- a/compiler/types/src/subs.rs
+++ b/compiler/types/src/subs.rs
@@ -1,5 +1,7 @@
 #![deny(unsafe_op_in_unsafe_fn)]
-use crate::types::{name_type_var, AliasKind, ErrorType, Problem, RecordField, TypeExt};
+use crate::types::{
+    name_type_var, AliasKind, ErrorType, Problem, RecordField, RecordFieldsError, TypeExt,
+};
 use roc_collections::all::{ImMap, ImSet, MutSet, SendMap};
 use roc_module::ident::{Lowercase, TagName, Uppercase};
 use roc_module::symbol::Symbol;
@@ -2713,11 +2715,11 @@ impl RecordFields {
         &'a self,
         subs: &'a Subs,
         ext: Variable,
-    ) -> impl Iterator<Item = (&Lowercase, RecordField<Variable>)> + 'a {
-        let (it, _) = crate::types::gather_fields_unsorted_iter(subs, *self, ext)
-            .expect("Something weird ended up in a record type");
+    ) -> Result<impl Iterator<Item = (&Lowercase, RecordField<Variable>)> + 'a, RecordFieldsError>
+    {
+        let (it, _) = crate::types::gather_fields_unsorted_iter(subs, *self, ext)?;
 
-        it
+        Ok(it)
     }
 
     #[inline(always)]


### PR DESCRIPTION
Closes #2812

Unfortunately we don't have a great way to test this without scaffolding
a host since this happens while processing a variable exposed to the
host. In tests the root cause just yields a type error first and codegen
works, just bails during the runtime. But this works.
