### PR TITLE
Specialize bodies with body var, not function var

### DIFF
--- a/compiler/load_internal/src/file.rs
+++ b/compiler/load_internal/src/file.rs
@@ -3859,6 +3859,7 @@ fn add_def_to_module<'a>(
                         // This is a top-level definition, so it cannot capture anything
                         captured_symbols: CapturedSymbols::None,
                         body,
+                        body_var: def.expr_var,
                         // This is a 0-arity thunk, so it cannot be recursive
                         is_self_recursive: false,
                     };

--- a/compiler/mono/src/ir.rs
+++ b/compiler/mono/src/ir.rs
@@ -195,6 +195,7 @@ pub struct PartialProc<'a> {
     pub pattern_symbols: &'a [Symbol],
     pub captured_symbols: CapturedSymbols<'a>,
     pub body: roc_can::expr::Expr,
+    pub body_var: Variable,
     pub is_self_recursive: bool,
 }
 
@@ -224,6 +225,7 @@ impl<'a> PartialProc<'a> {
                     pattern_symbols,
                     captured_symbols,
                     body: body.value,
+                    body_var: ret_var,
                     is_self_recursive,
                 }
             }
@@ -240,6 +242,7 @@ impl<'a> PartialProc<'a> {
                     pattern_symbols: pattern_symbols.into_bump_slice(),
                     captured_symbols: CapturedSymbols::None,
                     body: roc_can::expr::Expr::RuntimeError(error.value),
+                    body_var: ret_var,
                     is_self_recursive: false,
                 }
             }
@@ -902,6 +905,7 @@ impl<'a> Procs<'a> {
                                         pattern_symbols,
                                         captured_symbols,
                                         body: body.value,
+                                        body_var: ret_var,
                                         is_self_recursive,
                                     };
 
@@ -939,6 +943,7 @@ impl<'a> Procs<'a> {
                                     pattern_symbols,
                                     captured_symbols,
                                     body: body.value,
+                                    body_var: ret_var,
                                     is_self_recursive,
                                 };
 
@@ -2476,7 +2481,7 @@ fn specialize_external<'a>(
     };
 
     let body = partial_proc.body.clone();
-    let mut specialized_body = from_can(env, fn_var, body, procs, layout_cache);
+    let mut specialized_body = from_can(env, partial_proc.body_var, body, procs, layout_cache);
 
     match specialized {
         SpecializedLayout::FunctionPointerBody {

--- a/repl_test/src/tests.rs
+++ b/repl_test/src/tests.rs
@@ -1121,3 +1121,20 @@ fn issue_2582_specialize_result_value() {
         r"<function> : Num *, List Str -> Result Str [ ListWasEmpty ]*",
     )
 }
+
+#[test]
+#[cfg(not(feature = "wasm"))]
+fn issue_2818() {
+    expect_success(
+        indoc!(
+            r#"
+            f : {} -> List Str
+            f = \_ ->
+              x = []
+              x
+            f
+            "#
+        ),
+        r"<function> : {} -> List Str",
+    )
+}


### PR DESCRIPTION
I'm surprised code generation worked so well without this, before...

Closes #2818
