### PR TITLE
Don't specify a default value for --precompiled-host

### DIFF
--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -128,7 +128,6 @@ pub fn build_app<'a>() -> App<'a> {
                     .long(FLAG_PRECOMPILED)
                     .about("Assumes the host has been precompiled and skips recompiling the host. (Enabled by default when using a --target other than `--target host`)")
                     .possible_values(["true", "false"])
-                    .default_value("false")
                     .required(false),
             )
             .arg(
@@ -234,7 +233,6 @@ pub fn build_app<'a>() -> App<'a> {
                 .long(FLAG_PRECOMPILED)
                 .about("Assumes the host has been precompiled and skips recompiling the host. (Enabled by default when using a --target other than `--target host`)")
                 .possible_values(["true", "false"])
-                .default_value("false")
                 .required(false),
         )
         .arg(


### PR DESCRIPTION
If we do, it's treated as always present even if it's not passed in, which overrides the default of "infer based on target."

This caused a bug where attempting to cross-compile with `--linux64` would actually assume no precompiled host even though we have logic explicitly telling it to infer that!