### PR TITLE
Use lto=fat on release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ exclude = [
     # The tests will still correctly build them.
     "cli_utils",
     "compiler/test_mono_macros",
-    # `cargo build` would cause roc_std to be built with default features which errors on windows 
+    # `cargo build` would cause roc_std to be built with default features which errors on windows
     "roc_std",
 ]
 # Needed to be able to run `cargo run -p roc_cli --no-default-features` -
@@ -64,7 +64,7 @@ resolver = "2"
 
 # Optimizations based on https://deterministic.space/high-performance-rust.html
 [profile.release]
-lto = "thin"
+lto = "fat"
 codegen-units = 1
 
 # debug = true # enable when profiling

--- a/examples/gui/platform/Cargo.toml
+++ b/examples/gui/platform/Cargo.toml
@@ -67,7 +67,7 @@ features = ["derive"]
 
 # Optimizations based on https://deterministic.space/high-performance-rust.html
 [profile.release]
-lto = "thin"
+lto = "fat"
 codegen-units = 1
 
 # debug = true # enable when profiling

--- a/examples/hello-world/rust-platform/Cargo.toml
+++ b/examples/hello-world/rust-platform/Cargo.toml
@@ -20,3 +20,8 @@ roc_std = { path = "../../../roc_std" }
 libc = "0.2"
 
 [workspace]
+
+# Optimizations based on https://deterministic.space/high-performance-rust.html
+[profile.release]
+lto = "fat"
+codegen-units = 1


### PR DESCRIPTION
`lto=fat` does link-time optimization across all crates in the project, instead of only some of them!