### PR TITLE
Turn on concurrency groups for GitHub CI

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -2,6 +2,10 @@ on: [pull_request]
 
 name: Benchmarks
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   RUST_BACKTRACE: 1
   ROC_NUM_WORKERS: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,10 @@ on: [pull_request]
 
 name: CI
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   RUST_BACKTRACE: 1
 

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -2,6 +2,10 @@ on: [pull_request]
 
 name: SpellCheck
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   RUST_BACKTRACE: 1
 


### PR DESCRIPTION
This ensures that we only one set of workflows is running for an active
GH ref (usually a PR). Stale workflows will be term'd when a new one
associated with the same PR is kicked off.

See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency