### PR TITLE
Exclude filename from repl reports.

### DIFF
--- a/repl_eval/src/gen.rs
+++ b/repl_eval/src/gen.rs
@@ -47,7 +47,7 @@ pub fn compile_to_mono<'a>(
     target_info: TargetInfo,
     palette: Palette,
 ) -> Result<MonomorphizedModule<'a>, Vec<String>> {
-    let filename = PathBuf::from("REPL.roc");
+    let filename = PathBuf::from("");
     let src_dir = Path::new("fake/test/path");
 
     let module_src = arena.alloc(promote_expr_to_module(src));

--- a/repl_test/src/tests.rs
+++ b/repl_test/src/tests.rs
@@ -575,7 +575,7 @@ fn too_few_args() {
         "Num.add 2",
         indoc!(
             r#"
-                ── TOO FEW ARGS ───────────────────────────────────────────────────── REPL.roc ─
+                ── TOO FEW ARGS ────────────────────────────────────────────────────────────────
 
                 The add function expects 2 arguments, but it got only 1:
 
@@ -596,7 +596,7 @@ fn type_problem() {
         "1 + \"\"",
         indoc!(
             r#"
-                ── TYPE MISMATCH ──────────────────────────────────────────────────── REPL.roc ─
+                ── TYPE MISMATCH ───────────────────────────────────────────────────────────────
 
                 The 2nd argument to add is not what I expect:
 
@@ -882,7 +882,7 @@ fn parse_problem() {
         "add m n = m + n",
         indoc!(
             r#"
-                ── ARGUMENTS BEFORE EQUALS ────────────────────────────────────────── REPL.roc ─
+                ── ARGUMENTS BEFORE EQUALS ─────────────────────────────────────────────────────
 
                 I am partway through parsing a definition, but I got stuck here:
 
@@ -912,7 +912,7 @@ fn mono_problem() {
             "#,
         indoc!(
             r#"
-                ── UNSAFE PATTERN ─────────────────────────────────────────────────── REPL.roc ─
+                ── UNSAFE PATTERN ──────────────────────────────────────────────────────────────
 
                 This when does not cover all the possibilities:
 
@@ -948,7 +948,7 @@ fn issue_2343_complete_mono_with_shadowed_vars() {
         ),
         indoc!(
             r#"
-                ── DUPLICATE NAME ─────────────────────────────────────────────────── REPL.roc ─
+                ── DUPLICATE NAME ──────────────────────────────────────────────────────────────
 
                 The b name is first defined here:
 


### PR DESCRIPTION
I considered a few options for excluding `─ REPL.roc ─` from repl reports.

1. Have `pretty_header` exclude the path if it matches "REPL.roc" or maybe some repl-specific filename like "!REPL!" or "".
2. Let report include the path, but then the repl code strips it out after-the-fact.
3. Make different versions of `render_color_terminal`, `pretty`, and `pretty_header` that don't print the file name.

Option 2 could be okay. Option 3 seems like too much duplication or awkward splitting of code. I decided to try Option 1 (don't include path if it's empty). There's precedent with `pretty` checking if `title` is empty, and so far nothing seems to explode when using an empty path.