### PR TITLE
don't populate Scope with aliases (except for tests)

### DIFF
--- a/reporting/tests/helpers/mod.rs
+++ b/reporting/tests/helpers/mod.rs
@@ -151,7 +151,7 @@ pub fn can_expr_with<'a>(
     // rules multiple times unnecessarily.
     let loc_expr = operator::desugar_expr(arena, &loc_expr);
 
-    let mut scope = Scope::new(home, &mut var_store);
+    let mut scope = Scope::new_with_aliases(home, &mut var_store);
     let dep_idents = IdentIds::exposed_builtins(0);
     let mut env = Env::new(home, &dep_idents, &module_ids, IdentIds::default());
     let (loc_expr, output) = canonicalize_expr(


### PR DESCRIPTION
these are now properly imported. For testing reporting we still need a way to provide them without resolving imports (just for speed)