### PR TITLE
Reuse symbol when opaque type wraps a known symbol

### DIFF
--- a/compiler/test_gen/src/gen_tags.rs
+++ b/compiler/test_gen/src/gen_tags.rs
@@ -1580,3 +1580,28 @@ fn issue_2725_alias_polymorphic_lambda() {
         i64
     )
 }
+
+#[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
+fn opaque_assign_to_symbol() {
+    assert_evals_to!(
+        indoc!(
+            r#"
+            app "test" provides [ out ] to "./platform"
+
+            Variable := U8
+
+            fromUtf8 : U8 -> Result Variable [ InvalidVariableUtf8 ]
+            fromUtf8 = \char ->
+                Ok ($Variable char)
+
+            out =
+                when fromUtf8 98 is
+                    Ok ($Variable n) -> n
+                    _ -> 1
+            "#
+        ),
+        98,
+        u8
+    )
+}

--- a/compiler/test_mono/generated/opaque_assign_to_symbol.txt
+++ b/compiler/test_mono/generated/opaque_assign_to_symbol.txt
@@ -1,0 +1,10 @@
+procedure : `#UserApp.fromUtf8` [C {}, C U8]
+procedure = `#UserApp.fromUtf8` (`#UserApp.char`):
+    let `#UserApp.3` : [C {}, C U8] = Ok `#UserApp.4`;
+    ret `#UserApp.3`;
+
+procedure : `#UserApp.out` [C {}, C U8]
+procedure = `#UserApp.out` ():
+    let `#UserApp.2` : U8 = 98i64;
+    let `#UserApp.1` : [C {}, C U8] = CallByName `#UserApp.fromUtf8` `#UserApp.2`;
+    ret `#UserApp.1`;

--- a/compiler/test_mono/src/tests.rs
+++ b/compiler/test_mono/src/tests.rs
@@ -1330,6 +1330,23 @@ fn specialize_ability_call() {
     )
 }
 
+#[mono_test]
+fn opaque_assign_to_symbol() {
+    indoc!(
+        r#"
+        app "test" provides [ out ] to "./platform"
+
+        Variable := U8
+
+        fromUtf8 : U8 -> Result Variable [ InvalidVariableUtf8 ]
+        fromUtf8 = \char ->
+            Ok ($Variable char)
+
+        out = fromUtf8 98
+        "#
+    )
+}
+
 // #[ignore]
 // #[mono_test]
 // fn static_str_closure() {


### PR DESCRIPTION
Opaques decay immediately into their argument during codegen, so we need
to handle something that's effectively variable aliasing correctly.

This bug popped up while migrating all current private tags to opaques.
