### PR TITLE
Upgrade target-lexicon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4489,9 +4489,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9bffcddbc2458fa3e6058414599e3c838a022abae82e5c67b4f7f80298d5bff"
+checksum = "d7fa7e55043acb85fca6b3c01485a2eeb6b69c5d21002e273c79e465f43b7ac1"
 
 [[package]]
 name = "tempfile"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -66,7 +66,7 @@ const_format = "0.2.22"
 bumpalo = { version = "3.8.0", features = ["collections"] }
 mimalloc = { version = "0.1.26", default-features = false }
 
-target-lexicon = "0.12.2"
+target-lexicon = "0.12.3"
 tempfile = "3.2.0"
 wasmer-wasi = { version = "2.0.0", optional = true }
 

--- a/compiler/build/Cargo.toml
+++ b/compiler/build/Cargo.toml
@@ -30,7 +30,7 @@ bumpalo = { version = "3.8.0", features = ["collections"] }
 libloading = "0.7.1"
 tempfile = "3.2.0"
 inkwell = { path = "../../vendor/inkwell", optional = true }
-target-lexicon = "0.12.2"
+target-lexicon = "0.12.3"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 serde_json = "1.0.69"

--- a/compiler/gen_dev/Cargo.toml
+++ b/compiler/gen_dev/Cargo.toml
@@ -19,7 +19,7 @@ roc_mono = { path = "../mono" }
 roc_target = { path = "../roc_target" }
 roc_error_macros = { path = "../../error_macros" }
 bumpalo = { version = "3.8.0", features = ["collections"] }
-target-lexicon = "0.12.2"
+target-lexicon = "0.12.3"
 # TODO: Deal with the update of object to 0.27.
 # It looks like it breaks linking the generated objects.
 # Probably just need to specify an extra field that used to be implicit or something.

--- a/compiler/gen_llvm/Cargo.toml
+++ b/compiler/gen_llvm/Cargo.toml
@@ -18,4 +18,4 @@ roc_std = { path = "../../roc_std", default-features = false }
 morphic_lib = { path = "../../vendor/morphic_lib" }
 bumpalo = { version = "3.8.0", features = ["collections"] }
 inkwell = { path = "../../vendor/inkwell" }
-target-lexicon = "0.12.2"
+target-lexicon = "0.12.3"

--- a/compiler/roc_target/Cargo.toml
+++ b/compiler/roc_target/Cargo.toml
@@ -6,4 +6,4 @@ license = "UPL-1.0"
 edition = "2018"
 
 [dependencies]
-target-lexicon = "0.12.2"
+target-lexicon = "0.12.3"

--- a/compiler/test_gen/Cargo.toml
+++ b/compiler/test_gen/Cargo.toml
@@ -37,7 +37,7 @@ bumpalo = { version = "3.8.0", features = ["collections"] }
 either = "1.6.1"
 libc = "0.2.106"
 inkwell = { path = "../../vendor/inkwell" }
-target-lexicon = "0.12.2"
+target-lexicon = "0.12.3"
 libloading = "0.7.1"
 wasmer-wasi = "2.0.0"
 tempfile = "3.2.0"

--- a/linker/Cargo.toml
+++ b/linker/Cargo.toml
@@ -28,5 +28,5 @@ memmap2 = "0.5.3"
 object = { version = "0.26.2", features = ["read", "write"] }
 serde = { version = "1.0.130", features = ["derive"] }
 bincode = "1.3.3"
-target-lexicon = "0.12.2"
+target-lexicon = "0.12.3"
 tempfile = "3.2.0"


### PR DESCRIPTION
After a `cargo clean`, I started getting a build error for 0.12.2. Upgrading to 0.12.3 fixed it. 🤷 