### PR TITLE
Implemented unsigned int comparisons.

### DIFF
--- a/compiler/gen_llvm/src/llvm/build.rs
+++ b/compiler/gen_llvm/src/llvm/build.rs
@@ -6574,10 +6574,34 @@ fn build_int_binop<'a, 'ctx, 'env>(
             &LLVM_MUL_WITH_OVERFLOW[int_width],
             &[lhs.into(), rhs.into()],
         ),
-        NumGt => bd.build_int_compare(SGT, lhs, rhs, "int_gt").into(),
-        NumGte => bd.build_int_compare(SGE, lhs, rhs, "int_gte").into(),
-        NumLt => bd.build_int_compare(SLT, lhs, rhs, "int_lt").into(),
-        NumLte => bd.build_int_compare(SLE, lhs, rhs, "int_lte").into(),
+        NumGt => {
+            if int_width.is_signed() {
+                bd.build_int_compare(SGT, lhs, rhs, "gt_int").into()
+            } else {
+                bd.build_int_compare(UGT, lhs, rhs, "gt_uint").into()
+            }
+        }
+        NumGte => {
+            if int_width.is_signed() {
+                bd.build_int_compare(SGE, lhs, rhs, "gte_int").into()
+            } else {
+                bd.build_int_compare(UGE, lhs, rhs, "gte_uint").into()
+            }
+        }
+        NumLt => {
+            if int_width.is_signed() {
+                bd.build_int_compare(SLT, lhs, rhs, "lt_int").into()
+            } else {
+                bd.build_int_compare(ULT, lhs, rhs, "lt_uint").into()
+            }
+        }
+        NumLte => {
+            if int_width.is_signed() {
+                bd.build_int_compare(SLE, lhs, rhs, "lte_int").into()
+            } else {
+                bd.build_int_compare(ULE, lhs, rhs, "lte_uint").into()
+            }
+        }
         NumRemUnchecked => {
             if int_width.is_signed() {
                 bd.build_int_signed_rem(lhs, rhs, "rem_int").into()

--- a/compiler/test_gen/src/gen_num.rs
+++ b/compiler/test_gen/src/gen_num.rs
@@ -1212,6 +1212,86 @@ fn bitwise_or() {
 
 #[test]
 #[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
+fn lt_u8() {
+    assert_evals_to!("1u8 < 2u8", true, bool);
+    assert_evals_to!("1u8 < 1u8", false, bool);
+    assert_evals_to!("2u8 < 1u8", false, bool);
+    assert_evals_to!("0u8 < 0u8", false, bool);
+    assert_evals_to!("128u8 < 0u8", false, bool);
+}
+
+#[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
+fn lte_u8() {
+    assert_evals_to!("1u8 <= 1u8", true, bool);
+    assert_evals_to!("2u8 <= 1u8", false, bool);
+    assert_evals_to!("1u8 <= 2u8", true, bool);
+    assert_evals_to!("0u8 <= 0u8", true, bool);
+    assert_evals_to!("128u8 <= 0u8", false, bool);
+}
+
+#[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
+fn gt_u8() {
+    assert_evals_to!("2u8 > 1u8", true, bool);
+    assert_evals_to!("2u8 > 2u8", false, bool);
+    assert_evals_to!("1u8 > 1u8", false, bool);
+    assert_evals_to!("0u8 > 0u8", false, bool);
+    assert_evals_to!("0u8 > 128u8", false, bool);
+}
+
+#[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
+fn gte_u8() {
+    assert_evals_to!("1u8 >= 1u8", true, bool);
+    assert_evals_to!("1u8 >= 2u8", false, bool);
+    assert_evals_to!("2u8 >= 1u8", true, bool);
+    assert_evals_to!("0u8 >= 0u8", true, bool);
+    assert_evals_to!("0u8 >= 128u8", false, bool);
+}
+
+#[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
+fn lt_u64() {
+    assert_evals_to!("1u64 < 2u64", true, bool);
+    assert_evals_to!("1u64 < 1u64", false, bool);
+    assert_evals_to!("2u64 < 1u64", false, bool);
+    assert_evals_to!("0u64 < 0u64", false, bool);
+    assert_evals_to!("9223372036854775808u64 < 0u64", false, bool);
+}
+
+#[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
+fn lte_u64() {
+    assert_evals_to!("1u64 <= 1u64", true, bool);
+    assert_evals_to!("2u64 <= 1u64", false, bool);
+    assert_evals_to!("1u64 <= 2u64", true, bool);
+    assert_evals_to!("0u64 <= 0u64", true, bool);
+    assert_evals_to!("9223372036854775808u64 <= 0u64", false, bool);
+}
+
+#[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
+fn gt_u64() {
+    assert_evals_to!("2u64 > 1u64", true, bool);
+    assert_evals_to!("2u64 > 2u64", false, bool);
+    assert_evals_to!("1u64 > 1u64", false, bool);
+    assert_evals_to!("0u64 > 0u64", false, bool);
+    assert_evals_to!("0u64 > 9223372036854775808u64", false, bool);
+}
+
+#[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
+fn gte_u64() {
+    assert_evals_to!("1u64 >= 1u64", true, bool);
+    assert_evals_to!("1u64 >= 2u64", false, bool);
+    assert_evals_to!("2u64 >= 1u64", true, bool);
+    assert_evals_to!("0u64 >= 0u64", true, bool);
+    assert_evals_to!("0u64 >= 9223372036854775808u64", false, bool);
+}
+
+#[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
 fn lt_i64() {
     assert_evals_to!("1 < 2", true, bool);
     assert_evals_to!("1 < 1", false, bool);


### PR DESCRIPTION
Closes https://github.com/rtfeldman/roc/issues/2793

I also renamed `int_gt` et. al. to `gt_int` to match others (`rem_int`, `mul_int`). I assume these names are just for debugging and that's fine?