### PR TITLE
auto use preferred color format

### DIFF
--- a/code_markup/src/colors.rs
+++ b/code_markup/src/colors.rs
@@ -1,4 +1,4 @@
-use palette::{FromColor, Hsv, Srgb};
+use palette::{FromColor, Hsv, LinSrgb, Srgb};
 
 pub type RgbaTup = (f32, f32, f32, f32);
 pub const WHITE: RgbaTup = (1.0, 1.0, 1.0, 1.0);
@@ -12,11 +12,11 @@ pub fn from_hsb(hue: usize, saturation: usize, brightness: usize) -> RgbaTup {
 }
 
 pub fn from_hsba(hue: usize, saturation: usize, brightness: usize, alpha: f32) -> RgbaTup {
-    let rgb = Srgb::from_color(Hsv::new(
+    let rgb = LinSrgb::from(Srgb::from_color(Hsv::new(
         hue as f32,
         (saturation as f32) / 100.0,
         (brightness as f32) / 100.0,
-    ));
+    )));
 
     (rgb.red, rgb.green, rgb.blue, alpha)
 }

--- a/editor/src/editor/main.rs
+++ b/editor/src/editor/main.rs
@@ -74,7 +74,7 @@ fn run_event_loop(project_dir_path_opt: Option<&Path>) -> Result<(), Box<dyn Err
     let surface = unsafe { instance.create_surface(&window) };
 
     // Initialize GPU
-    let (gpu_device, cmd_queue) = futures::executor::block_on(async {
+    let (gpu_device, cmd_queue, color_format) = futures::executor::block_on(async {
         create_device(
             &instance,
             &surface,
@@ -101,13 +101,11 @@ fn run_event_loop(project_dir_path_opt: Option<&Path>) -> Result<(), Box<dyn Err
     let mut local_pool = futures::executor::LocalPool::new();
     let local_spawner = local_pool.spawner();
 
-    // Prepare swap chain
-    let render_format = wgpu::TextureFormat::Bgra8Unorm;
     let mut size = window.inner_size();
 
     let surface_config = wgpu::SurfaceConfiguration {
         usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
-        format: render_format,
+        format: color_format,
         width: size.width,
         height: size.height,
         present_mode: wgpu::PresentMode::Mailbox,
@@ -117,7 +115,7 @@ fn run_event_loop(project_dir_path_opt: Option<&Path>) -> Result<(), Box<dyn Err
 
     let rect_resources = pipelines::make_rect_pipeline(&gpu_device, &surface_config);
 
-    let mut glyph_brush = build_glyph_brush(&gpu_device, render_format)?;
+    let mut glyph_brush = build_glyph_brush(&gpu_device, color_format)?;
 
     let is_animating = true;
 
@@ -210,7 +208,7 @@ fn run_event_loop(project_dir_path_opt: Option<&Path>) -> Result<(), Box<dyn Err
                     &gpu_device,
                     &wgpu::SurfaceConfiguration {
                         usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
-                        format: render_format,
+                        format: color_format,
                         width: size.width,
                         height: size.height,
                         present_mode: wgpu::PresentMode::Mailbox,
@@ -402,7 +400,7 @@ async fn create_device(
     surface: &wgpu::Surface,
     power_preference: wgpu::PowerPreference,
     force_fallback_adapter: bool,
-) -> Result<(wgpu::Device, wgpu::Queue), wgpu::RequestDeviceError> {
+) -> Result<(wgpu::Device, wgpu::Queue, wgpu::TextureFormat), wgpu::RequestDeviceError> {
     if force_fallback_adapter {
         log::error!("Falling back to software renderer. GPU acceleration has been disabled.");
     }
@@ -418,7 +416,13 @@ async fn create_device(
             If you're running this from inside nix, follow the instructions here to resolve this: https://github.com/rtfeldman/roc/blob/trunk/BUILDING_FROM_SOURCE.md#editor
             "#);
 
-    adapter
+    let color_format = surface.get_preferred_format(&adapter).unwrap();
+
+    if color_format != wgpu::TextureFormat::Bgra8UnormSrgb {
+        log::warn!("Your preferred TextureFormat {:?} is different than expected. Colors may look different, please report this issue on github and tag @Anton-4.", color_format);
+    }
+
+    let request_res = adapter
         .request_device(
             &wgpu::DeviceDescriptor {
                 label: None,
@@ -427,7 +431,12 @@ async fn create_device(
             },
             None,
         )
-        .await
+        .await;
+
+    match request_res {
+        Ok((device, queue)) => Ok((device, queue, color_format)),
+        Err(err) => Err(err),
+    }
 }
 
 fn draw_rects(

--- a/editor/src/graphics/colors.rs
+++ b/editor/src/graphics/colors.rs
@@ -1,4 +1,4 @@
-use palette::{FromColor, Hsv, Srgb};
+use palette::{FromColor, Hsv, LinSrgb, Srgb};
 
 pub type RgbaTup = (f32, f32, f32, f32);
 pub const WHITE: RgbaTup = (1.0, 1.0, 1.0, 1.0);
@@ -21,11 +21,11 @@ pub fn from_hsb(hue: usize, saturation: usize, brightness: usize) -> RgbaTup {
 }
 
 pub fn from_hsba(hue: usize, saturation: usize, brightness: usize, alpha: f32) -> RgbaTup {
-    let rgb = Srgb::from_color(Hsv::new(
+    let rgb = LinSrgb::from(Srgb::from_color(Hsv::new(
         hue as f32,
         (saturation as f32) / 100.0,
         (brightness as f32) / 100.0,
-    ));
+    )));
 
     (rgb.red, rgb.green, rgb.blue, alpha)
 }


### PR DESCRIPTION
Opening the editor used to panic if the `wgpu::Textureformat` `Bgra8Unorm` was not supported, we now default to the preferred format of the graphics hardware and report a warning if it is not `Bgra8UnormSrgb`. Colors will look different but no panic will occur.