### PR TITLE
Fix compiler crash when missing a comma in imports.

### DIFF
--- a/reporting/src/error/parse.rs
+++ b/reporting/src/error/parse.rs
@@ -3415,6 +3415,25 @@ fn to_imports_report<'a>(
             }
         }
 
+        EImports::ListEnd(pos) => {
+            let surroundings = Region::new(start, pos);
+            let region = LineColumnRegion::from_pos(lines.convert_pos(pos));
+
+            let doc = alloc.stack([
+                alloc.reflow(r"I am partway through parsing a imports list, but I got stuck here:"),
+                alloc.region_with_subregion(lines.convert_region(surroundings), region),
+                alloc.concat([alloc.reflow("I am expecting a comma or end of list, like")]),
+                alloc.parser_suggestion("imports [ Math, Util ]").indent(4),
+            ]);
+
+            Report {
+                filename,
+                doc,
+                title: "WEIRD IMPORTS".to_string(),
+                severity: Severity::RuntimeError,
+            }
+        }
+
         _ => todo!("unhandled parse error {:?}", parse_problem),
     }
 }

--- a/reporting/tests/test_reporting.rs
+++ b/reporting/tests/test_reporting.rs
@@ -9882,6 +9882,34 @@ I need all branches in an `if` to have the same type!
         )
     }
 
+    fn imports_missing_comma() {
+        new_report_problem_as(
+            "imports_missing_comma",
+            indoc!(
+                r#"
+                app "test-missing-comma"
+                    packages { pf: "platform" }
+                    imports [ pf.Task Base64 ]
+                    provides [ main, @Foo ] to pf
+                "#
+            ),
+            indoc!(
+                r#"
+                ── WEIRD IMPORTS ────────────────────────── tmp/imports_missing_comma/Test.roc ─
+
+                I am partway through parsing a imports list, but I got stuck here:
+
+                2│      packages { pf: "platform" }
+                3│      imports [ pf.Task Base64 ]
+                                          ^
+
+                I am expecting a comma or end of list, like
+
+                    imports [ Math, Util ]"#
+            ),
+        )
+    }
+
     #[test]
     fn not_enough_cases_for_open_union() {
         new_report_problem_as(


### PR DESCRIPTION
Closes https://github.com/rtfeldman/roc/issues/2864