### PR TITLE
fixed temp dir removal panic

### DIFF
--- a/test_utils/src/lib.rs
+++ b/test_utils/src/lib.rs
@@ -43,6 +43,6 @@ impl TmpDir {
 
 impl Drop for TmpDir {
     fn drop(&mut self) {
-        remove_dir_all::remove_dir_all(&self.path).unwrap();
+        let _ = remove_dir_all::remove_dir_all(&self.path);
     }
 }


### PR DESCRIPTION
`cargo test --release -p roc_reporting --test test_reporting` regularly(not always) fails on my machine:
```
...
test test_reporting::issue_2778_specialization_is_not_a_redundant_pattern ... ok
test test_reporting::not_enough_cases_for_open_union ... FAILED
test test_reporting::expression_generalization_to_ability_is_an_error ... ok

failures:

---- test_reporting::not_enough_cases_for_open_union stdout ----
thread 'test_reporting::not_enough_cases_for_open_union' panicked at 'called `Result::unwrap()` on an `Err` value: Os { code: 2, kind: NotFound, message: "No such file or directory" }', test_utils/src/lib.rs:46:52
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    test_reporting::not_enough_cases_for_open_union

test result: FAILED. 327 passed; 1 failed; 3 ignored; 0 measured; 0 filtered out; finished in 0.60s

error: test failed, to rerun pass '-p roc_reporting --test test_reporting'
```
I changed the `remove_dir_all` line to work the same way it does in [tempfile](https://docs.rs/tempfile/latest/src/tempfile/dir.rs.html#NaN). It is allowed to fail because that means the dir no longer exists. It's not obvious to me how this error would occur but I don't think this fix will create any problems.