### PR TITLE
Refactor repl_eval to avoid allocations

### DIFF
--- a/repl_eval/src/eval.rs
+++ b/repl_eval/src/eval.rs
@@ -5,7 +5,7 @@ use std::cmp::{max_by_key, min_by_key};
 use roc_builtins::bitcode::{FloatWidth, IntWidth};
 use roc_collections::all::MutMap;
 use roc_module::called_via::CalledVia;
-use roc_module::ident::{Lowercase, TagName};
+use roc_module::ident::TagName;
 use roc_module::symbol::{Interns, ModuleId, Symbol};
 use roc_mono::ir::ProcLayout;
 use roc_mono::layout::{


### PR DESCRIPTION
- Avoid a `.collect()` that creates a `Vec`, and instead just use the iterator directly
- Avoid some intermediate allocations in the `.len() == 1` path for structs
- Remove a hashmap that turned out not to be necessary after all
- Use `.into_inner()` over `.as_inner()` plus dereference (`as_inner` returns a reference, unlike `into_inner`)