### PR TITLE
Correct output type of flapping test

### DIFF
--- a/compiler/test_gen/src/gen_num.rs
+++ b/compiler/test_gen/src/gen_num.rs
@@ -3225,7 +3225,7 @@ fn upcast_of_int_checked_is_zext() {
             "#
         ),
         1,
-        u16
+        u8
     )
 }
 


### PR DESCRIPTION
The Roc program in this test returns a U8, but the tested type is marked
as a U16, so it's possible we were just picking up garbage bytes.

Closes #2997
