### PR TITLE
Allow invalid UTF-8 for `roc format` argument

### DIFF
--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -157,7 +157,8 @@ pub fn build_app<'a>() -> Command<'a> {
                 Arg::new(DIRECTORY_OR_FILES)
                     .index(1)
                     .multiple_values(true)
-                    .required(false))
+                    .required(false)
+                    .allow_invalid_utf8(true))
             .arg(
                 Arg::new(FLAG_CHECK)
                     .long(FLAG_CHECK)


### PR DESCRIPTION
Presumably with a new version of clap that was introduced, we must now
specify that invalid-utf8 is permitted in order to run `matches.values_of_os`
as we do on line 174 of cli/src/main.rs:

```rust
        Some((CMD_FORMAT, matches)) => {
            let maybe_values = matches.values_of_os(DIRECTORY_OR_FILES);
```

Otherwise, clap panics:

```
thread 'main' panicked at 'Must use `Arg::allow_invalid_utf8` with `_os` lookups at `DIRECTORY_OR_FILES`', cli/src/main.rs:174:40
```
