### PR TITLE
Delete llvm feature from roc_build and roc_cli

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -15,13 +15,10 @@ test = false
 bench = false
 
 [features]
-default = ["target-aarch64", "target-x86_64", "target-wasm32", "editor", "llvm"]
+default = ["target-aarch64", "target-x86_64", "target-wasm32", "editor"]
 
 wasm32-cli-run = ["target-wasm32", "run-wasm32"]
 i386-cli-run = ["target-x86"]
-
-# TODO: change to roc_repl_cli/llvm once roc_repl can run without llvm.
-llvm = ["roc_build/llvm", "roc_repl_cli"]
 
 editor = ["roc_editor"]
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -136,16 +136,12 @@ fn main() -> io::Result<()> {
             }
         }
         Some((CMD_REPL, _)) => {
-            #[cfg(feature = "llvm")]
             {
                 roc_repl_cli::main()?;
 
                 // Exit 0 if the repl exited normally
                 Ok(0)
             }
-
-            #[cfg(not(feature = "llvm"))]
-            todo!("enable roc repl without llvm");
         }
         Some((CMD_EDIT, matches)) => {
             match matches

--- a/compiler/build/Cargo.toml
+++ b/compiler/build/Cargo.toml
@@ -20,8 +20,8 @@ roc_solve = { path = "../solve" }
 roc_mono = { path = "../mono" }
 roc_load = { path = "../load" }
 roc_target = { path = "../roc_target" }
-roc_gen_llvm = { path = "../gen_llvm", optional = true }
-roc_gen_wasm = { path = "../gen_wasm", optional = true }
+roc_gen_llvm = { path = "../gen_llvm" }
+roc_gen_wasm = { path = "../gen_wasm" }
 roc_gen_dev = { path = "../gen_dev", default-features = false }
 roc_reporting = { path = "../../reporting" }
 roc_error_macros = { path = "../../error_macros" }
@@ -29,7 +29,7 @@ roc_std = { path = "../../roc_std", default-features = false }
 bumpalo = { version = "3.8.0", features = ["collections"] }
 libloading = "0.7.1"
 tempfile = "3.2.0"
-inkwell = { path = "../../vendor/inkwell", optional = true }
+inkwell = { path = "../../vendor/inkwell" }
 target-lexicon = "0.12.3"
 wasi_libc_sys = { path = "../../wasi-libc-sys" }
 
@@ -41,8 +41,4 @@ target-arm = []
 target-aarch64 = ["roc_gen_dev/target-aarch64"]
 target-x86 = []
 target-x86_64 = ["roc_gen_dev/target-x86_64"]
-target-wasm32 = ["roc_gen_wasm"]
-
-# This is a separate feature because when we generate docs on Netlify,
-# it doesn't have LLVM installed. (Also, it doesn't need to do code gen.)
-llvm = ["inkwell", "roc_gen_llvm"]
+target-wasm32 = []

--- a/compiler/build/src/link.rs
+++ b/compiler/build/src/link.rs
@@ -1,9 +1,7 @@
 use crate::target::{arch_str, target_zig_str};
-#[cfg(feature = "llvm")]
 use libloading::{Error, Library};
 use roc_builtins::bitcode;
 use roc_error_macros::internal_error;
-// #[cfg(feature = "llvm")]
 use roc_mono::ir::OptLevel;
 use std::collections::HashMap;
 use std::env;
@@ -1061,7 +1059,6 @@ fn link_windows(
     todo!("Add windows support to the surgical linker. See issue #2608.")
 }
 
-#[cfg(feature = "llvm")]
 pub fn module_to_dylib(
     module: &inkwell::module::Module,
     target: &Triple,

--- a/compiler/build/src/program.rs
+++ b/compiler/build/src/program.rs
@@ -1,6 +1,4 @@
-#[cfg(feature = "llvm")]
 use roc_gen_llvm::llvm::build::module_from_builtins;
-#[cfg(feature = "llvm")]
 pub use roc_gen_llvm::llvm::build::FunctionIterator;
 use roc_load::{LoadedModule, MonomorphizedModule};
 use roc_module::symbol::{Interns, ModuleId};
@@ -156,27 +154,6 @@ fn report_problems_help(
     }
 }
 
-#[cfg(not(feature = "llvm"))]
-pub fn gen_from_mono_module(
-    arena: &bumpalo::Bump,
-    loaded: MonomorphizedModule,
-    _roc_file_path: &Path,
-    target: &target_lexicon::Triple,
-    app_o_file: &Path,
-    opt_level: OptLevel,
-    _emit_debug_info: bool,
-) -> CodeGenTiming {
-    match opt_level {
-        OptLevel::Optimize | OptLevel::Size => {
-            todo!("Return this error message in a better way: optimized builds not supported without llvm backend");
-        }
-        OptLevel::Normal | OptLevel::Development => {
-            gen_from_mono_module_dev(arena, loaded, target, app_o_file)
-        }
-    }
-}
-
-#[cfg(feature = "llvm")]
 pub fn gen_from_mono_module(
     arena: &bumpalo::Bump,
     loaded: MonomorphizedModule,
@@ -203,7 +180,6 @@ pub fn gen_from_mono_module(
 // TODO how should imported modules factor into this? What if those use builtins too?
 // TODO this should probably use more helper functions
 // TODO make this polymorphic in the llvm functions so it can be reused for another backend.
-#[cfg(feature = "llvm")]
 pub fn gen_from_mono_module_llvm(
     arena: &bumpalo::Bump,
     loaded: MonomorphizedModule,

--- a/compiler/build/src/target.rs
+++ b/compiler/build/src/target.rs
@@ -1,9 +1,7 @@
-#[cfg(feature = "llvm")]
 use inkwell::{
     targets::{CodeModel, InitializationConfig, RelocMode, Target, TargetMachine, TargetTriple},
     OptimizationLevel,
 };
-#[cfg(feature = "llvm")]
 use roc_mono::ir::OptLevel;
 use target_lexicon::{Architecture, Environment, OperatingSystem, Triple};
 
@@ -98,7 +96,6 @@ pub fn target_zig_str(target: &Triple) -> &'static str {
     }
 }
 
-#[cfg(feature = "llvm")]
 pub fn init_arch(target: &Triple) {
     match target.architecture {
         Architecture::X86_64 | Architecture::X86_32(_)
@@ -142,7 +139,6 @@ pub fn arch_str(target: &Triple) -> &'static str {
     }
 }
 
-#[cfg(feature = "llvm")]
 pub fn target_machine(
     target: &Triple,
     opt: OptimizationLevel,
@@ -172,7 +168,6 @@ pub fn target_machine(
     )
 }
 
-#[cfg(feature = "llvm")]
 pub fn convert_opt_level(level: OptLevel) -> OptimizationLevel {
     match level {
         OptLevel::Development | OptLevel::Normal => OptimizationLevel::None,

--- a/compiler/test_gen/Cargo.toml
+++ b/compiler/test_gen/Cargo.toml
@@ -52,7 +52,7 @@ wasmer = { version = "2.2.1", default-features = false, features = ["cranelift",
 
 [features]
 default = ["gen-llvm"]
-gen-llvm = ["roc_build/llvm"]
+gen-llvm = []
 gen-dev = []
 gen-wasm = []
 wasm-cli-run = []

--- a/repl_cli/Cargo.toml
+++ b/repl_cli/Cargo.toml
@@ -23,7 +23,7 @@ rustyline-derive = {git = "https://github.com/rtfeldman/rustyline", rev = "e7433
 target-lexicon = "0.12.2"
 
 # TODO: make llvm optional
-roc_build = {path = "../compiler/build", features = ["llvm"]}
+roc_build = {path = "../compiler/build"}
 roc_builtins = {path = "../compiler/builtins"}
 roc_collections = {path = "../compiler/collections"}
 roc_gen_llvm = {path = "../compiler/gen_llvm"}


### PR DESCRIPTION
I checked locally to make sure that `repl_www/build.sh` runs without errors and produces a .wasm file the same size as before (898kB with Brotli compression)