### PR TITLE
use single-threaded mode for gen tests

### DIFF
--- a/compiler/test_gen/src/helpers/llvm.rs
+++ b/compiler/test_gen/src/helpers/llvm.rs
@@ -60,7 +60,7 @@ fn create_llvm_module<'a>(
         Default::default(),
         target_info,
         RenderTarget::ColorTerminal,
-        Threading::AllAvailable,
+        Threading::Single,
     );
 
     let mut loaded = match loaded {


### PR DESCRIPTION
this makes e.g. running the primitive tests 3X faster. It's slightly slower for an individual test (10ms maybe, in most cases) but because there is less fighting over who gets which thread it's much faster when running many tests.