### PR TITLE
Fix multi-line function type annotations for annotated bodies

### DIFF
--- a/compiler/fmt/tests/test_fmt.rs
+++ b/compiler/fmt/tests/test_fmt.rs
@@ -4487,6 +4487,19 @@ mod test_fmt {
             "#
         ));
 
+        expr_formats_same(indoc!(
+            r#"
+            foo :
+                (Str -> Bool),
+                Str
+                -> Bool
+            foo = \bar, baz ->
+                42
+
+            42
+            "#
+        ));
+
         expr_formats_to(
             indoc!(
                 r#"
@@ -4501,6 +4514,56 @@ mod test_fmt {
                 foo :
                     (Str -> Bool)
                     -> Bool
+
+                42
+                "#
+            ),
+        );
+
+        expr_formats_to(
+            indoc!(
+                r#"
+                foo :
+                    (Str -> Bool), Str -> Bool
+                foo = \bar, baz ->
+                    42
+
+                42
+                "#
+            ),
+            indoc!(
+                r#"
+                foo :
+                    (Str -> Bool),
+                    Str
+                    -> Bool
+                foo = \bar, baz ->
+                    42
+
+                42
+                "#
+            ),
+        );
+
+        expr_formats_to(
+            indoc!(
+                r#"
+                foo :
+                    (Str -> Bool), Str -> Bool # comment
+                foo = \bar, baz ->
+                    42
+
+                42
+                "#
+            ),
+            indoc!(
+                r#"
+                foo :
+                    (Str -> Bool),
+                    Str
+                    -> Bool # comment
+                foo = \bar, baz ->
+                    42
 
                 42
                 "#


### PR DESCRIPTION
This PR attempts to fix the bug mentioned here https://github.com/rtfeldman/roc/issues/2586#issuecomment-1073008996 in issue #2586 

Example of new formatting:
```
foo :
    (Str -> Bool), Str -> Bool
foo = \bar, baz ->
    42

42
```
will now format into:
```
foo :
    (Str -> Bool),
    Str
    -> Bool
foo = \bar, baz ->
    42

42
```

Resolves #2586 