### PR TITLE
Fix AST normalization of TypeHeaders in Aliases for CLI formatter

### DIFF
--- a/compiler/fmt/src/spaces.rs
+++ b/compiler/fmt/src/spaces.rs
@@ -690,9 +690,14 @@ impl<'a> RemoveSpaces<'a> for TypeAnnotation<'a> {
             ),
             TypeAnnotation::Apply(a, b, c) => TypeAnnotation::Apply(a, b, c.remove_spaces(arena)),
             TypeAnnotation::BoundVariable(a) => TypeAnnotation::BoundVariable(a),
-            TypeAnnotation::As(a, _, c) => {
-                TypeAnnotation::As(arena.alloc(a.remove_spaces(arena)), &[], c)
-            }
+            TypeAnnotation::As(a, _, TypeHeader { name, vars }) => TypeAnnotation::As(
+                arena.alloc(a.remove_spaces(arena)),
+                &[],
+                TypeHeader {
+                    name: name.remove_spaces(arena),
+                    vars: vars.remove_spaces(arena),
+                },
+            ),
             TypeAnnotation::Record { fields, ext } => TypeAnnotation::Record {
                 fields: fields.remove_spaces(arena),
                 ext: ext.remove_spaces(arena),


### PR DESCRIPTION
This PR attempts to resolve the issue described in #3012.

* It seems that the AST was not being fully normalized for TypeHeaders in Aliases when running the CLI formatter. Which would result in panics because some of the `Loc` data types were still present in the AST, and there would be minor difference with `Loc` data. Now the AST normalization calls `remove_spaces` for the TypeHeader fields inside an Alias.

* There is already a test for this use case and a Roc example.

Resolves #3012 