### PR TITLE
use `&str` instead of Ident for lookups

### DIFF
--- a/compiler/can/src/annotation.rs
+++ b/compiler/can/src/annotation.rs
@@ -330,13 +330,13 @@ fn make_apply_symbol(
     if module_name.is_empty() {
         // Since module_name was empty, this is an unqualified type.
         // Look it up in scope!
-        let ident: Ident = (*ident).into();
 
-        match scope.lookup(&ident, region) {
+        match scope.lookup_str(ident, region) {
             Ok(symbol) => Ok(symbol),
             Err(problem) => {
                 env.problem(roc_problem::can::Problem::RuntimeError(problem));
 
+                let ident: Ident = (*ident).into();
                 Err(Type::Erroneous(Problem::UnrecognizedIdent(ident)))
             }
         }

--- a/compiler/can/src/expr.rs
+++ b/compiler/can/src/expr.rs
@@ -1320,7 +1320,7 @@ fn canonicalize_var_lookup(
     let can_expr = if module_name.is_empty() {
         // Since module_name was empty, this is an unqualified var.
         // Look it up in scope!
-        match scope.lookup(&(*ident).into(), region) {
+        match scope.lookup_str(ident, region) {
             Ok(symbol) => {
                 output.references.insert_value_lookup(symbol);
 

--- a/compiler/can/src/scope.rs
+++ b/compiler/can/src/scope.rs
@@ -50,15 +50,19 @@ impl Scope {
     }
 
     pub fn lookup(&self, ident: &Ident, region: Region) -> Result<Symbol, RuntimeError> {
+        self.lookup_str(ident.as_str(), region)
+    }
+
+    pub fn lookup_str(&self, ident: &str, region: Region) -> Result<Symbol, RuntimeError> {
         use ContainsIdent::*;
 
-        match self.scope_contains_ident(ident.as_str()) {
+        match self.scope_contains_ident(ident) {
             InScope(symbol, _) => Ok(symbol),
             NotInScope(_) | NotPresent => {
                 let error = RuntimeError::LookupNotInScope(
                     Loc {
                         region,
-                        value: ident.clone(),
+                        value: Ident::from(ident),
                     },
                     self.idents_in_scope().map(|v| v.as_ref().into()).collect(),
                 );

--- a/docs/src/lib.rs
+++ b/docs/src/lib.rs
@@ -734,7 +734,7 @@ fn doc_url<'a>(
     if module_name.is_empty() {
         // This is an unqualified lookup, so look for the ident
         // in scope!
-        match scope.lookup(&ident.into(), Region::zero()) {
+        match scope.lookup_str(ident, Region::zero()) {
             Ok(symbol) => {
                 // Get the exact module_name from scope. It could be the
                 // current module's name, but it also could be a different


### PR DESCRIPTION
this saves a significant number of allocations
