### PR TITLE
Cleanup `abilities_in_scope` and rename to `pending_abilities_in_scope`

### DIFF
--- a/compiler/can/src/annotation.rs
+++ b/compiler/can/src/annotation.rs
@@ -267,7 +267,7 @@ pub fn canonicalize_annotation(
     annotation: &TypeAnnotation,
     region: Region,
     var_store: &mut VarStore,
-    abilities_in_scope: &[Symbol],
+    pending_abilities_in_scope: &[Symbol],
 ) -> Annotation {
     let mut introduced_variables = IntroducedVariables::default();
     let mut references = VecSet::default();
@@ -284,7 +284,7 @@ pub fn canonicalize_annotation(
                     var_store,
                     &mut introduced_variables,
                     clause,
-                    abilities_in_scope,
+                    pending_abilities_in_scope,
                     &mut references,
                 );
                 if let Err(err_type) = opt_err {
@@ -908,7 +908,7 @@ fn canonicalize_has_clause(
     var_store: &mut VarStore,
     introduced_variables: &mut IntroducedVariables,
     clause: &Loc<roc_parse::ast::HasClause<'_>>,
-    abilities_in_local_scope: &[Symbol],
+    pending_abilities_in_scope: &[Symbol],
     references: &mut VecSet<Symbol>,
 ) -> Result<(), Type> {
     let Loc {
@@ -929,7 +929,7 @@ fn canonicalize_has_clause(
             let symbol = make_apply_symbol(env, ability.region, scope, module_name, ident)?;
 
             // Ability defined locally, whose members we are constructing right now...
-            if !abilities_in_local_scope.contains(&symbol)
+            if !pending_abilities_in_scope.contains(&symbol)
                 // or an ability that was imported from elsewhere
                 && !scope.abilities_store.is_ability(symbol)
             {

--- a/compiler/can/src/expr.rs
+++ b/compiler/can/src/expr.rs
@@ -31,7 +31,6 @@ pub struct Output {
     pub introduced_variables: IntroducedVariables,
     pub aliases: VecMap<Symbol, Alias>,
     pub non_closures: VecSet<Symbol>,
-    pub abilities_in_scope: Vec<Symbol>,
 }
 
 impl Output {

--- a/compiler/can/src/module.rs
+++ b/compiler/can/src/module.rs
@@ -357,13 +357,16 @@ pub fn canonicalize_module_defs<'a>(
     let symbols_from_requires = symbols_from_requires
         .iter()
         .map(|(symbol, loc_ann)| {
+            // We've already canonicalized the module, so there are no pending abilities.
+            let pending_abilities_in_scope = &[];
+
             let ann = canonicalize_annotation(
                 &mut env,
                 &mut scope,
                 &loc_ann.value,
                 loc_ann.region,
                 var_store,
-                &output.abilities_in_scope,
+                pending_abilities_in_scope,
             );
 
             ann.add_to(


### PR DESCRIPTION
`abilities_in_scope` is a buffer we use to keep track of locally-defined
abilities before we've fully resolved them. We do this because we
canonicalize ability members signatures before we've registered an
ability to the abilities store, and canonicalization of signatures must
report `has` bounds that don't reference abilities.

So, this buffer is more appropriately named `pending_abilities_in_scope`.
There is also no reason to export it, because it is only relevant
during canonicalization of type defs in a module.
