### PR TITLE
Revise error message for Not Found

### DIFF
--- a/cli/tests/cli_run.rs
+++ b/cli/tests/cli_run.rs
@@ -907,7 +907,7 @@ mod cli_run {
                 r#"
                 ── UNRECOGNIZED NAME ─────────────────────────── tests/known_bad/TypeError.roc ─
 
-                I cannot find a `d` value
+                Nothing is named `d` in this scope.
 
                 10│      _ <- await (line d)
                                           ^

--- a/compiler/load_internal/tests/test_load.rs
+++ b/compiler/load_internal/tests/test_load.rs
@@ -857,7 +857,7 @@ mod test_load {
                         "
                         ── UNRECOGNIZED NAME ────────── tmp/issue_2863_module_type_does_not_exist/Main ─
 
-                        I cannot find a `DoesNotExist` value
+                        Nothing is named `DoesNotExist` in this scope.
 
                         5│  main : DoesNotExist
                                    ^^^^^^^^^^^^

--- a/reporting/src/error/canonicalize.rs
+++ b/reporting/src/error/canonicalize.rs
@@ -1166,14 +1166,7 @@ fn pretty_runtime_error<'b>(
         }
 
         RuntimeError::LookupNotInScope(loc_name, options) => {
-            doc = not_found(
-                alloc,
-                lines,
-                loc_name.region,
-                &loc_name.value,
-                "value",
-                options,
-            );
+            doc = not_found(alloc, lines, loc_name.region, &loc_name.value, options);
             title = UNRECOGNIZED_NAME;
         }
         RuntimeError::CircularDef(entries) => {
@@ -1766,7 +1759,6 @@ fn not_found<'b>(
     lines: &LineInfo,
     region: roc_region::all::Region,
     name: &Ident,
-    thing: &'b str,
     options: MutSet<Box<str>>,
 ) -> RocDocBuilder<'b> {
     let mut suggestions = suggest::sort(
@@ -1800,10 +1792,9 @@ fn not_found<'b>(
 
     alloc.stack([
         alloc.concat([
-            alloc.reflow("I cannot find a `"),
+            alloc.reflow("Nothing is named `"),
             alloc.string(name.to_string()),
-            alloc.reflow("` "),
-            alloc.reflow(thing),
+            alloc.reflow("` in this scope."),
         ]),
         alloc.region(lines.convert_region(region)),
         to_details(default_no, default_yes),

--- a/reporting/tests/test_reporting.rs
+++ b/reporting/tests/test_reporting.rs
@@ -670,7 +670,7 @@ mod test_reporting {
                 r#"
                 ── UNRECOGNIZED NAME ───────────────────────────────────── /code/proj/Main.roc ─
 
-                I cannot find a `bar` value
+                Nothing is named `bar` in this scope.
 
                 8│          4 -> bar baz "yay"
                                  ^^^
@@ -698,7 +698,7 @@ mod test_reporting {
                 r#"
                 ── UNRECOGNIZED NAME ───────────────────────────────────── /code/proj/Main.roc ─
 
-                I cannot find a `true` value
+                Nothing is named `true` in this scope.
 
                 1│  if true then 1 else 2
                        ^^^^
@@ -863,7 +863,7 @@ mod test_reporting {
                 r#"
                 <cyan>── UNRECOGNIZED NAME ───────────────────────────────────── /code/proj/Main.roc ─<reset>
 
-                I cannot find a `theAdmin` value
+                Nothing is named `theAdmin` in this scope.
 
                 <cyan>3<reset><cyan>│<reset>  <white>theAdmin<reset>
                     <red>^^^^^^^^<reset>
@@ -1775,7 +1775,7 @@ mod test_reporting {
                 r#"
                 ── UNRECOGNIZED NAME ───────────────────────────────────── /code/proj/Main.roc ─
 
-                I cannot find a `foo` value
+                Nothing is named `foo` in this scope.
 
                 2│      { foo: _ } -> foo
                                       ^^^
@@ -2232,7 +2232,7 @@ mod test_reporting {
                 r#"
                 ── UNRECOGNIZED NAME ───────────────────────────────────── /code/proj/Main.roc ─
 
-                I cannot find a `ok` value
+                Nothing is named `ok` in this scope.
 
                 2│  f = \_ -> ok 4
                               ^^
@@ -6071,7 +6071,7 @@ All branches in an `if` must have the same type!
                 r#"
                 ── UNRECOGNIZED NAME ───────────────────────────────────── /code/proj/Main.roc ─
 
-                I cannot find a `bar` value
+                Nothing is named `bar` in this scope.
 
                 1│  [ "foo", bar("") ]
                              ^^^
@@ -8762,7 +8762,7 @@ All branches in an `if` must have the same type!
                 r#"
                 ── UNRECOGNIZED NAME ───────────────────────────────────── /code/proj/Main.roc ─
 
-                I cannot find a `UnknownType` value
+                Nothing is named `UnknownType` in this scope.
 
                 1│  Type : [ Constructor UnknownType ]
                                          ^^^^^^^^^^^
@@ -8776,7 +8776,7 @@ All branches in an `if` must have the same type!
 
                 ── UNRECOGNIZED NAME ───────────────────────────────────── /code/proj/Main.roc ─
 
-                I cannot find a `UnknownType` value
+                Nothing is named `UnknownType` in this scope.
 
                 3│  insertHelper : UnknownType, Type -> Type
                                    ^^^^^^^^^^^


### PR DESCRIPTION
* No longer says "value" when sometimes it's a type
* No longer has the grammar problem of "a vs. an" - e.g. "cannot find a `d`"
* Mentions scope as a reminder to consider whether the name is defined in a different scope.