### PR TITLE
Less U128 special-casing

### DIFF
--- a/compiler/mono/src/exhaustive.rs
+++ b/compiler/mono/src/exhaustive.rs
@@ -13,7 +13,6 @@ fn simplify(pattern: &crate::ir::Pattern) -> Pattern {
 
     match pattern {
         IntLiteral(v, _) => Literal(Literal::Int(*v)),
-        U128Literal(v) => Literal(Literal::U128(*v)),
         FloatLiteral(v, _) => Literal(Literal::Float(*v)),
         DecimalLiteral(v) => Literal(Literal::Decimal(*v)),
         StrLiteral(v) => Literal(Literal::Str(v.clone())),


### PR DESCRIPTION
Now that we represent both `I128` and `U128` in various IRs as `[u8; 16]` we don't need separate variants for them in so many places.