### PR TITLE
Formatter: add newlines between parens for multiline expressions

### DIFF
--- a/compiler/fmt/tests/test_fmt.rs
+++ b/compiler/fmt/tests/test_fmt.rs
@@ -4648,6 +4648,57 @@ mod test_fmt {
                 )
             "#
         ));
+
+        expr_formats_to(
+            indoc!(
+                r#"
+                    Task.fromResult
+                        (a, b <- binaryOp ctx
+                            if a == b then
+                                -1
+                            else
+                                0
+                            )
+                "#
+            ),
+            indoc!(
+                r#"
+                    Task.fromResult
+                        (
+                            a, b <- binaryOp ctx
+                            if a == b then
+                                -1
+                            else
+                                0
+                        )
+                "#
+            ),
+        );
+
+        expr_formats_to(
+            indoc!(
+                r#"
+                    Task.fromResult
+                        (a, b <- binaryOp ctx
+                            if a == b then
+                                -1
+                            else
+                                0)
+                "#
+            ),
+            indoc!(
+                r#"
+                    Task.fromResult
+                        (
+                            a, b <- binaryOp ctx
+                            if a == b then
+                                -1
+                            else
+                                0
+                        )
+                "#
+            ),
+        );
     }
 
     #[test]

--- a/examples/false-interpreter/False.roc
+++ b/examples/false-interpreter/False.roc
@@ -386,7 +386,8 @@ stepExecCtx = \ctx, char ->
         0x3D ->
             # `=` equals
             Task.fromResult
-                (a, b <- binaryOp ctx
+                (
+                    a, b <- binaryOp ctx
                     if a == b then
                         -1
                     else
@@ -395,7 +396,8 @@ stepExecCtx = \ctx, char ->
         0x3E ->
             # `>` greater than
             Task.fromResult
-                (a, b <- binaryOp ctx
+                (
+                    a, b <- binaryOp ctx
                     if a > b then
                         -1
                     else


### PR DESCRIPTION
This PR attempts to implement the formatting describe in issue #2123.

Resolves #2123