### PR TITLE
Include rust-src in rust-toolchain for nix

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,7 @@
 [toolchain]
 channel = "1.60.0" # make sure to update the rust version in Earthfile as well
 profile = "default"
+components = [
+    # for usages of rust-analyzer or similar tools inside `nix develop`
+    "rust-src"
+]


### PR DESCRIPTION
My development setup now is I launch `nix develop` and open a vim instance from inside that shell. Rust-analyzer is unable to find rust-src in the nix store, so include it in the toolchain file that's used by nix develop to make sure it's pulled in.