### PR TITLE
Pass CPATH in to build_c_host_native to fix building the c platform under manual install

### DIFF
--- a/compiler/build/src/link.rs
+++ b/compiler/build/src/link.rs
@@ -313,6 +313,7 @@ pub fn build_zig_host_wasm32(
 pub fn build_c_host_native(
     env_path: &str,
     env_home: &str,
+    env_cpath: &str,
     dest: &str,
     sources: &[&str],
     opt_level: OptLevel,
@@ -322,6 +323,7 @@ pub fn build_c_host_native(
     command
         .env_clear()
         .env("PATH", &env_path)
+        .env("CPATH", &env_cpath)
         .env("HOME", &env_home)
         .args(sources)
         .args(&["-o", dest]);
@@ -417,6 +419,8 @@ pub fn rebuild_host(
 
     let env_path = env::var("PATH").unwrap_or_else(|_| "".to_string());
     let env_home = env::var("HOME").unwrap_or_else(|_| "".to_string());
+    let env_cpath = env::var("CPATH").unwrap_or_else(|_| "".to_string());
+
 
     if zig_host_src.exists() {
         // Compile host.zig
@@ -531,6 +535,7 @@ pub fn rebuild_host(
             let output = build_c_host_native(
                 &env_path,
                 &env_home,
+                &env_cpath,
                 c_host_dest.to_str().unwrap(),
                 &[c_host_src.to_str().unwrap()],
                 opt_level,
@@ -586,6 +591,7 @@ pub fn rebuild_host(
             let output = build_c_host_native(
                 &env_path,
                 &env_home,
+                &env_cpath,
                 host_dest.to_str().unwrap(),
                 &[
                     c_host_src.to_str().unwrap(),
@@ -599,6 +605,7 @@ pub fn rebuild_host(
             let output = build_c_host_native(
                 &env_path,
                 &env_home,
+                &env_cpath,
                 c_host_dest.to_str().unwrap(),
                 &[c_host_src.to_str().unwrap()],
                 opt_level,
@@ -639,6 +646,7 @@ pub fn rebuild_host(
         let output = build_c_host_native(
             &env_path,
             &env_home,
+            &env_cpath,
             host_dest.to_str().unwrap(),
             &[c_host_src.to_str().unwrap()],
             opt_level,


### PR DESCRIPTION
When doing the manual install on osx with brew-installed llvm, `clang` can't find the headers it needs.
The solution I found was to do `export CPATH=$(xcrun --show-sdk-path)/usr/include/` and then run the clang command, but roc wasn't forwarding that header on to clang.
Now it does!

## Test plan:
```
export CPATH=$(xcrun --show-sdk-path)/usr/include/
cargo run examples/hello-world/c-platform/helloC.roc
```
should work!