### PR TITLE
Add a few assertions to MadeSpecializations

### DIFF
--- a/compiler/load_internal/src/file.rs
+++ b/compiler/load_internal/src/file.rs
@@ -2249,10 +2249,16 @@ fn update<'a>(
                 .notify(module_id, Phase::MakeSpecializations);
 
             if work.is_empty() && state.dependencies.solved_all() {
-                if !external_specializations_requested.is_empty() {
+                if !external_specializations_requested.is_empty()
+                    || !state
+                        .module_cache
+                        .external_specializations_requested
+                        .is_empty()
+                {
                     internal_error!(
-                        "No more work left, but external specializations left over: {:?}",
-                        external_specializations_requested
+                        "No more work left, but external specializations left over: {:?}, {:?}",
+                        external_specializations_requested,
+                        state.module_cache.external_specializations_requested
                     )
                 }
 


### PR DESCRIPTION
1. MadeSpecializations can only be hit when our target phase is to make
   specializations
2. Once all work is done, there can be no more requested external
   specializations
