### PR TITLE
Create `to_exposed_symbol_string` helper function for all backends

### DIFF
--- a/compiler/gen_dev/src/object_builder.rs
+++ b/compiler/gen_dev/src/object_builder.rs
@@ -330,7 +330,9 @@ fn build_proc_symbol<'a, B: Backend<'a>>(
     let base_name = backend.symbol_to_string(sym, layout_id);
 
     let fn_name = if backend.env().exposed_to_host.contains(&sym) {
-        format!("roc_{}_exposed", base_name)
+        layout_ids
+            .get_toplevel(sym, &layout)
+            .to_exposed_symbol_string(sym, backend.interns())
     } else {
         base_name
     };

--- a/compiler/gen_wasm/src/backend.rs
+++ b/compiler/gen_wasm/src/backend.rs
@@ -257,6 +257,8 @@ impl<'a> WasmBackend<'a> {
             .to_symbol_string(symbol, self.interns);
         let name = String::from_str_in(&name, self.env.arena).into_bump_str();
 
+        // dbg!(name);
+
         self.proc_lookup.push(ProcLookupData {
             name: symbol,
             layout,

--- a/compiler/gen_wasm/src/lib.rs
+++ b/compiler/gen_wasm/src/lib.rs
@@ -84,7 +84,7 @@ pub fn build_app_module<'a>(
     host_module: WasmModule<'a>,
     procedures: MutMap<(Symbol, ProcLayout<'a>), Proc<'a>>,
 ) -> (WasmModule<'a>, Vec<'a, u32>, u32) {
-    let layout_ids = LayoutIds::default();
+    let mut layout_ids = LayoutIds::default();
     let mut procs = Vec::with_capacity_in(procedures.len(), env.arena);
     let mut proc_lookup = Vec::with_capacity_in(procedures.len() * 2, env.arena);
     let mut host_to_app_map = Vec::with_capacity_in(env.exposed_to_host.len(), env.arena);
@@ -109,10 +109,13 @@ pub fn build_app_module<'a>(
         if env.exposed_to_host.contains(&sym) {
             maybe_main_fn_index = Some(fn_index);
 
-            // Assumption: there is only one specialization of a host-exposed function
-            let ident_string = sym.as_str(interns);
-            let c_function_name = bumpalo::format!(in env.arena, "roc__{}_1_exposed", ident_string);
-            host_to_app_map.push((c_function_name.into_bump_str(), fn_index));
+            let exposed_name = layout_ids
+                .get_toplevel(sym, &proc_layout)
+                .to_exposed_symbol_string(sym, interns);
+
+            let exposed_name_bump: &'a str = env.arena.alloc_str(&exposed_name);
+
+            host_to_app_map.push((exposed_name_bump, fn_index));
         }
 
         proc_lookup.push(ProcLookupData {

--- a/compiler/mono/src/layout.rs
+++ b/compiler/mono/src/layout.rs
@@ -2913,12 +2913,19 @@ pub fn list_layout_from_elem<'a>(
 pub struct LayoutId(u32);
 
 impl LayoutId {
-    // Returns something like "foo#1" when given a symbol that interns to "foo"
+    // Returns something like "#UserApp_foo_1" when given a symbol that interns to "foo"
     // and a LayoutId of 1.
     pub fn to_symbol_string(self, symbol: Symbol, interns: &Interns) -> String {
         let ident_string = symbol.as_str(interns);
         let module_string = interns.module_ids.get_name(symbol.module_id()).unwrap();
         format!("{}_{}_{}", module_string, ident_string, self.0)
+    }
+
+    // Returns something like "roc__foo_1_exposed" when given a symbol that interns to "foo"
+    // and a LayoutId of 1.
+    pub fn to_exposed_symbol_string(self, symbol: Symbol, interns: &Interns) -> String {
+        let ident_string = symbol.as_str(interns);
+        format!("roc__{}_{}_exposed", ident_string, self.0)
     }
 }
 

--- a/compiler/test_gen/src/helpers/dev.rs
+++ b/compiler/test_gen/src/helpers/dev.rs
@@ -98,11 +98,9 @@ pub fn helper(
     let main_fn_layout = loaded.entry_point.layout;
 
     let mut layout_ids = roc_mono::layout::LayoutIds::default();
-    let main_fn_name_base = layout_ids
+    let main_fn_name = layout_ids
         .get_toplevel(main_fn_symbol, &main_fn_layout)
-        .to_symbol_string(main_fn_symbol, &interns);
-
-    let main_fn_name = format!("roc_{}_exposed", main_fn_name_base);
+        .to_exposed_symbol_string(main_fn_symbol, &interns);
 
     let mut lines = Vec::new();
     // errors whose reporting we delay (so we can see that code gen generates runtime errors)


### PR DESCRIPTION
Previously, the LLVM and Wasm backends were assuming a layout ID of `1` and hardcoding it rather than generating it.
`gen_dev` was generating the layout ID properly but using a different number of underscores.
Now they're all consistent.
