### PR TITLE
Go back to downloading Web REPL from external URL

### DIFF
--- a/www/build.sh
+++ b/www/build.sh
@@ -14,15 +14,21 @@ cp -r public/ build/
 # grab the source code and copy it to Netlify's server; if it's not there, fail the build.
 pushd build
 wget https://github.com/rtfeldman/elm-css/files/8849069/roc-source-code.zip
+
+# Download the latest pre-built Web REPL as a zip file. (Build takes longer than Netlify's timeout.)
+# TODO: When roc repo is public, download it from nightly builds.
+wget https://github.com/brian-carroll/mock-repl/archive/refs/heads/deploy.zip
+unzip deploy.zip
+mv mock-repl-deploy/* .
+rmdir mock-repl-deploy
+rm deploy.zip
+
 popd
 
 pushd ..
 echo 'Generating docs...'
 cargo --version
 rustc --version
-
-# removing `-C link-arg=-fuse-ld=lld` from RUSTFLAGS because this causes an error when compiling `roc_repl_wasm`
-RUSTFLAGS="-C target-cpu=native"
 
 # We set ROC_DOCS_ROOT_DIR=builtins so that links will be generated relative to
 # "/builtins/" rather than "/" - which is what we want based on how the server
@@ -32,11 +38,5 @@ export ROC_DOCS_URL_ROOT=/builtins
 cargo run --bin roc-docs compiler/builtins/roc/*.roc
 mv generated-docs/*.* www/build # move all the .js, .css, etc. files to build/
 mv generated-docs/ www/build/builtins # move all the folders to build/builtins/
-
-echo "Building Web REPL..."
-repl_www/build.sh www/build
-
-echo "Asset sizes:"
-ls -lh www/build/*
 
 popd

--- a/www/netlify.sh
+++ b/www/netlify.sh
@@ -6,19 +6,11 @@ set -euxo pipefail
 
 rustup update
 rustup default stable
-rustup target add wasm32-unknown-unknown wasm32-wasi
 
 ZIG_DIRNAME="zig-linux-x86_64-0.9.1"
 wget https://ziglang.org/download/0.9.1/${ZIG_DIRNAME}.tar.xz
 tar --extract --xz --file=${ZIG_DIRNAME}.tar.xz
 PATH="$(pwd)/${ZIG_DIRNAME}:${PATH}"
-
-# Work around an issue with wasm-pack where it fails to install wasm-opt (from binaryen) on some CI systems
-# https://github.com/rustwasm/wasm-pack/issues/864
-BINARYEN_DIRNAME="binaryen-version_108-x86_64-linux"
-wget https://github.com/WebAssembly/binaryen/releases/download/version_108/${BINARYEN_DIRNAME}.tar.gz
-tar --extract --gzip --file=${BINARYEN_DIRNAME}.tar.gz
-PATH="$(pwd)/${BINARYEN_DIRNAME}/bin:${PATH}"
 
 export PATH
 bash build.sh


### PR DESCRIPTION
Netlify build was timing out!

I just changed to a fully dev build to see what happens and it was 1.1MB with Brotli compression, up from 968kB. So.. meh, that's fine.
The one thing I left in there was `-Copt-level=s` in the Cargo config file. It's supposed to mean that any optimizations should focus more on size than speed. I'm not sure if there are any minimal optimizations happening for dev builds but if there are, then this makes sense. I didn't test with and without it, just left it in.
