### PR TITLE
Add stale bot to close PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,21 @@
+name: 'Close stale PRs'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v5
+        with:
+          delete-branch: true
+          exempt-pr-labels: 'blocked'
+          days-before-issue-close: -1
+          days-before-pr-stale: 30
+          days-before-pr-close: 30
+          stale-pr-message: 'Thank you for your contribution! Sometimes PRs end up staying open for a long time without activity, which can make the list of open PRs get long and time-consuming to review. To keep things manageable for reviewers, this bot automatically closes PRs that haven’t had activity in 60 days. This PR hasn’t had activity in 30 days, so it will be automatically closed if there is no more activity in the next 30 days. Keep in mind that PRs marked `Closed` are not deleted, so no matter what, the PR will still be right here in the repo. You can always access it and reopen it anytime you like!'
+          stale-pr-label: 'inactive for 30 days'
+          close-pr-label: 'auto-closed'


### PR DESCRIPTION
Settings:
- Don't do anything with issues
- If a PR has had no activity (based on `updated_at` timestamp) for 60 days, close it and delete the branch.
- After a PR has had no activity for 30 days, leave a comment saying it's been inactive for 30 days and will be closed if it still has no activity for another 30 days.