### PR TITLE
fix(reporting): print Num.(Floating->Frac, Integer->Int)

### DIFF
--- a/reporting/src/error/type.rs
+++ b/reporting/src/error/type.rs
@@ -2231,6 +2231,28 @@ fn to_doc_help<'b>(
                 .collect(),
         ),
 
+        Alias(Symbol::NUM_NUM, mut args, _, _) => {
+            debug_assert!(args.len() == 1);
+            let type_arg = args.remove(0);
+
+            let (symbol, args) = match type_arg {
+                Alias(Symbol::NUM_FLOATINGPOINT, inner_args, _, _) => {
+                    (Symbol::NUM_FRAC, inner_args)
+                }
+                Alias(Symbol::NUM_INTEGER, inner_args, _, _) => (Symbol::NUM_INT, inner_args),
+                _ => (Symbol::NUM_NUM, vec![type_arg]),
+            };
+
+            report_text::apply(
+                alloc,
+                parens,
+                alloc.symbol_foreign_qualified(symbol),
+                args.into_iter()
+                    .map(|arg| to_doc_help(ctx, alloc, Parens::InTypeParam, arg))
+                    .collect(),
+            )
+        }
+
         Alias(symbol, args, _, _) => report_text::apply(
             alloc,
             parens,

--- a/reporting/tests/test_reporting.rs
+++ b/reporting/tests/test_reporting.rs
@@ -1127,6 +1127,40 @@ mod test_reporting {
     }
 
     #[test]
+    fn unwrap_num_elem_in_list() {
+        report_problem_as(
+            indoc!(
+                r#"
+                [1, 2.2, 0x3]
+                "#
+            ),
+            indoc!(
+                r#"
+                ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+
+                This list contains elements with different types:
+
+                1│  [1, 2.2, 0x3]
+                             ^^^
+
+                Its 3rd element is an integer of type:
+
+                    Int a
+
+                However, the preceding elements in the list all have the type:
+
+                    Frac a
+
+                Every element in a list must have the same type!
+
+                Tip: You can convert between Int and Frac using functions like
+                `Num.toFrac` and `Num.round`.
+                "#
+            ),
+        )
+    }
+
+    #[test]
     fn record_update_value() {
         report_problem_as(
             indoc!(
@@ -2673,7 +2707,7 @@ mod test_reporting {
 
                 But `add` needs the 2nd argument to be:
 
-                    Num (Integer a)
+                    Int a
                 "#
             ),
         )
@@ -2702,7 +2736,7 @@ mod test_reporting {
 
                 But `add` needs the 2nd argument to be:
 
-                    Num (Integer a)
+                    Int a
 
                 Tip: You can convert between Int and Frac using functions like
                 `Num.toFrac` and `Num.round`.
@@ -3794,7 +3828,7 @@ mod test_reporting {
 
                 This `ACons` tag application has the type:
 
-                    [ACons (Num (Integer Signed64)) [BCons (Num (Integer Signed64)) [ACons Str [BCons I64 [ACons I64 (BList I64 I64),
+                    [ACons (Int Signed64) [BCons (Int Signed64) [ACons Str [BCons I64 [ACons I64 (BList I64 I64),
                     ANil] as ∞, BNil], ANil], BNil], ANil]
 
                 But the type annotation on `x` says it should be:


### PR DESCRIPTION
A stab at cleaning up the `Num (NUM_X a)` nesting in reporting.  Originally surfaced in lists, but the in the course of fixing that in what seemed like the most appropriate place, the tests flagged other locations where the same class of issue would occur. 

Those changes seemed to be consistent with this one and https://github.com/rtfeldman/roc/issues/472#issuecomment-1164748863, so I updated those tests, added one for the specific case in the issue.

fixes #472
