### PR TITLE
macos x86 nightly releases

### DIFF
--- a/.github/workflows/nightly_macos_x86_64.yml
+++ b/.github/workflows/nightly_macos_x86_64.yml
@@ -1,10 +1,8 @@
-on: [pull_request]
+on:
+  schedule:
+    - cron:  '0 9 * * 1' # 9=9am utc+0, 1=monday
 
 name: Nightly Release macOS x86_64
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
 
 env:
   ZIG_VERSION: 0.9.1

--- a/wasi-libc-sys/build.rs
+++ b/wasi-libc-sys/build.rs
@@ -1,4 +1,3 @@
-use core::panic;
 use std::env;
 use std::ffi::OsString;
 use std::fs;
@@ -13,15 +12,8 @@ fn main() {
     let zig_cache_dir = PathBuf::from(&out_dir).join("zig-cache");
     let out_file = PathBuf::from(&out_dir).join("wasi-libc.a");
 
-    println!("clang --version: {:?}", Command::new("clang")
-        .args([
-            "--version",
-        ])
-        .output()
-        .unwrap());
-
     // Compile a dummy C program with Zig, with our own private cache directory
-    println!("zig build-exe output: {:?}", Command::new(&zig_executable())
+    Command::new(&zig_executable())
         .args([
             "build-exe",
             "-target",
@@ -35,16 +27,10 @@ fn main() {
             &format!("-femit-bin={}/dummy.wasm", out_dir),
         ])
         .output()
-        .unwrap());
-
-    //panic!("DONE");
+        .unwrap();
 
     let libc_path = find(&zig_cache_dir, &OsString::from("libc.a"))
         .unwrap()
-        .or(
-            find(&zig_cache_dir, &OsString::from("libc.a"))
-            .unwrap()
-        )
         .unwrap();
 
     let compiler_rt_path = find(&zig_cache_dir, &OsString::from("compiler_rt.o"))


### PR DESCRIPTION
Runs macOS x86_64 nightly releases once a week (Monday) due to expensive CI minutes. See also #3343.