### PR TITLE
Move exposed module types data structures to can

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3899,8 +3899,8 @@ version = "0.1.0"
 dependencies = [
  "bumpalo",
  "roc_builtins",
+ "roc_can",
  "roc_collections",
- "roc_constrain",
  "roc_load_internal",
  "roc_module",
  "roc_reporting",

--- a/compiler/can/src/module.rs
+++ b/compiler/can/src/module.rs
@@ -1,4 +1,4 @@
-use crate::abilities::PendingAbilitiesStore;
+use crate::abilities::{PendingAbilitiesStore, ResolvedSpecializations};
 use crate::annotation::canonicalize_annotation;
 use crate::def::{canonicalize_defs, sort_can_defs, Declaration, Def};
 use crate::effect_module::HostedGeneratedFunctions;
@@ -9,6 +9,7 @@ use crate::pattern::Pattern;
 use crate::scope::Scope;
 use bumpalo::Bump;
 use roc_collections::{MutMap, SendMap, VecSet};
+use roc_error_macros::internal_error;
 use roc_module::ident::Ident;
 use roc_module::ident::Lowercase;
 use roc_module::symbol::{IdentIds, IdentIdsByModule, ModuleId, ModuleIds, Symbol};
@@ -17,8 +18,99 @@ use roc_parse::header::HeaderFor;
 use roc_parse::pattern::PatternType;
 use roc_problem::can::{Problem, RuntimeError};
 use roc_region::all::{Loc, Region};
-use roc_types::subs::{VarStore, Variable};
+use roc_types::subs::{ExposedTypesStorageSubs, VarStore, Variable};
 use roc_types::types::{Alias, AliasKind, AliasVar, Type};
+
+/// The types of all exposed values/functions of a collection of modules
+#[derive(Clone, Debug, Default)]
+pub struct ExposedByModule {
+    exposed: MutMap<ModuleId, ExposedModuleTypes>,
+}
+
+impl ExposedByModule {
+    pub fn insert(&mut self, module_id: ModuleId, exposed: ExposedModuleTypes) {
+        self.exposed.insert(module_id, exposed);
+    }
+
+    pub fn get(&self, module_id: &ModuleId) -> Option<&ExposedModuleTypes> {
+        self.exposed.get(module_id)
+    }
+
+    /// Convenient when you need mutable access to the StorageSubs in the ExposedModuleTypes
+    pub fn get_mut(&mut self, module_id: &ModuleId) -> Option<&mut ExposedModuleTypes> {
+        self.exposed.get_mut(module_id)
+    }
+
+    /// Create a clone of `self` that has just a subset of the modules
+    ///
+    /// Useful when we know what modules a particular module imports, and want just
+    /// the exposed types for those exposed modules.
+    pub fn retain_modules<'a>(&self, it: impl Iterator<Item = &'a ModuleId>) -> Self {
+        let mut output = Self::default();
+
+        for module_id in it {
+            match self.exposed.get(module_id) {
+                None => {
+                    internal_error!("Module {:?} did not register its exposed values", module_id)
+                }
+                Some(exposed_types) => {
+                    output.exposed.insert(*module_id, exposed_types.clone());
+                }
+            }
+        }
+
+        output
+    }
+
+    pub fn iter_all(&self) -> impl Iterator<Item = (&ModuleId, &ExposedModuleTypes)> {
+        self.exposed.iter()
+    }
+
+    /// # Safety
+    ///
+    /// May only be called when the exposed types of a modules are no longer needed, or may be
+    /// transitioned into another context.
+    pub unsafe fn remove(&mut self, module_id: &ModuleId) -> Option<ExposedModuleTypes> {
+        self.exposed.remove(module_id)
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct ExposedForModule {
+    pub exposed_by_module: ExposedByModule,
+    pub imported_values: Vec<Symbol>,
+}
+
+impl ExposedForModule {
+    pub fn new<'a>(
+        it: impl Iterator<Item = &'a Symbol>,
+        exposed_by_module: ExposedByModule,
+    ) -> Self {
+        let mut imported_values = Vec::new();
+
+        for symbol in it {
+            let module = exposed_by_module.exposed.get(&symbol.module_id());
+            if let Some(ExposedModuleTypes { .. }) = module {
+                imported_values.push(*symbol);
+            } else {
+                continue;
+            }
+        }
+
+        Self {
+            imported_values,
+            exposed_by_module,
+        }
+    }
+}
+
+/// The types of all exposed values/functions of a module. This includes ability member
+/// specializations.
+#[derive(Clone, Debug)]
+pub struct ExposedModuleTypes {
+    pub exposed_types_storage_subs: ExposedTypesStorageSubs,
+    pub resolved_specializations: ResolvedSpecializations,
+}
 
 #[derive(Debug)]
 pub struct Module {

--- a/compiler/constrain/src/module.rs
+++ b/compiler/constrain/src/module.rs
@@ -1,108 +1,15 @@
 use crate::expr::{constrain_def_make_constraint, constrain_def_pattern, Env};
 use roc_builtins::std::StdLib;
-use roc_can::abilities::{PendingAbilitiesStore, PendingMemberType, ResolvedSpecializations};
+use roc_can::abilities::{PendingAbilitiesStore, PendingMemberType};
 use roc_can::constraint::{Constraint, Constraints};
 use roc_can::def::Declaration;
 use roc_can::expected::Expected;
 use roc_can::pattern::Pattern;
-use roc_collections::all::MutMap;
-use roc_error_macros::internal_error;
 use roc_module::symbol::{ModuleId, Symbol};
 use roc_region::all::{Loc, Region};
 use roc_types::solved_types::{FreeVars, SolvedType};
-use roc_types::subs::{ExposedTypesStorageSubs, VarStore, Variable};
+use roc_types::subs::{VarStore, Variable};
 use roc_types::types::{AnnotationSource, Category, Type};
-
-/// The types of all exposed values/functions of a collection of modules
-#[derive(Clone, Debug, Default)]
-pub struct ExposedByModule {
-    exposed: MutMap<ModuleId, ExposedModuleTypes>,
-}
-
-impl ExposedByModule {
-    pub fn insert(&mut self, module_id: ModuleId, exposed: ExposedModuleTypes) {
-        self.exposed.insert(module_id, exposed);
-    }
-
-    pub fn get(&self, module_id: &ModuleId) -> Option<&ExposedModuleTypes> {
-        self.exposed.get(module_id)
-    }
-
-    /// Convenient when you need mutable access to the StorageSubs in the ExposedModuleTypes
-    pub fn get_mut(&mut self, module_id: &ModuleId) -> Option<&mut ExposedModuleTypes> {
-        self.exposed.get_mut(module_id)
-    }
-
-    /// Create a clone of `self` that has just a subset of the modules
-    ///
-    /// Useful when we know what modules a particular module imports, and want just
-    /// the exposed types for those exposed modules.
-    pub fn retain_modules<'a>(&self, it: impl Iterator<Item = &'a ModuleId>) -> Self {
-        let mut output = Self::default();
-
-        for module_id in it {
-            match self.exposed.get(module_id) {
-                None => {
-                    internal_error!("Module {:?} did not register its exposed values", module_id)
-                }
-                Some(exposed_types) => {
-                    output.exposed.insert(*module_id, exposed_types.clone());
-                }
-            }
-        }
-
-        output
-    }
-
-    pub fn iter_all(&self) -> impl Iterator<Item = (&ModuleId, &ExposedModuleTypes)> {
-        self.exposed.iter()
-    }
-
-    /// # Safety
-    ///
-    /// May only be called when the exposed types of a modules are no longer needed, or may be
-    /// transitioned into another context.
-    pub unsafe fn remove(&mut self, module_id: &ModuleId) -> Option<ExposedModuleTypes> {
-        self.exposed.remove(module_id)
-    }
-}
-
-#[derive(Clone, Debug, Default)]
-pub struct ExposedForModule {
-    pub exposed_by_module: ExposedByModule,
-    pub imported_values: Vec<Symbol>,
-}
-
-impl ExposedForModule {
-    pub fn new<'a>(
-        it: impl Iterator<Item = &'a Symbol>,
-        exposed_by_module: ExposedByModule,
-    ) -> Self {
-        let mut imported_values = Vec::new();
-
-        for symbol in it {
-            let module = exposed_by_module.exposed.get(&symbol.module_id());
-            if let Some(ExposedModuleTypes { .. }) = module {
-                imported_values.push(*symbol);
-            } else {
-                continue;
-            }
-        }
-
-        Self {
-            imported_values,
-            exposed_by_module,
-        }
-    }
-}
-
-/// The types of all exposed values/functions of a module. This includes ability member
-/// specializations.
-#[derive(Clone, Debug)]
-pub struct ExposedModuleTypes {
-    pub exposed_types_storage_subs: ExposedTypesStorageSubs,
-    pub resolved_specializations: ResolvedSpecializations,
-}
 
 pub fn constrain_module(
     constraints: &mut Constraints,

--- a/compiler/load/Cargo.toml
+++ b/compiler/load/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 roc_load_internal = { path = "../load_internal" }
 bumpalo = { version = "3.8.0", features = ["collections"] }
 roc_target = { path = "../roc_target" }
-roc_constrain= { path = "../constrain" }
+roc_can = { path = "../can" }
 roc_types = { path = "../types" }
 roc_module = { path = "../module" }
 roc_collections = { path = "../collections" }

--- a/compiler/load/src/lib.rs
+++ b/compiler/load/src/lib.rs
@@ -1,8 +1,8 @@
 pub use roc_load_internal::file::Threading;
 
 use bumpalo::Bump;
+use roc_can::module::ExposedByModule;
 use roc_collections::all::MutMap;
-use roc_constrain::module::ExposedByModule;
 use roc_module::symbol::{ModuleId, Symbol};
 use roc_reporting::report::RenderTarget;
 use roc_target::TargetInfo;

--- a/compiler/load_internal/src/file.rs
+++ b/compiler/load_internal/src/file.rs
@@ -10,12 +10,11 @@ use roc_can::abilities::{AbilitiesStore, PendingAbilitiesStore, ResolvedSpeciali
 use roc_can::constraint::{Constraint as ConstraintSoa, Constraints};
 use roc_can::def::Declaration;
 use roc_can::expr::PendingDerives;
-use roc_can::module::{canonicalize_module_defs, Module};
-use roc_collections::{default_hasher, BumpMap, MutMap, MutSet, VecMap, VecSet};
-use roc_constrain::module::{
-    constrain_builtin_imports, constrain_module, ExposedByModule, ExposedForModule,
-    ExposedModuleTypes,
+use roc_can::module::{
+    canonicalize_module_defs, ExposedByModule, ExposedForModule, ExposedModuleTypes, Module,
 };
+use roc_collections::{default_hasher, BumpMap, MutMap, MutSet, VecMap, VecSet};
+use roc_constrain::module::{constrain_builtin_imports, constrain_module};
 use roc_debug_flags::dbg_do;
 #[cfg(debug_assertions)]
 use roc_debug_flags::{

--- a/compiler/load_internal/tests/test_load.rs
+++ b/compiler/load_internal/tests/test_load.rs
@@ -18,7 +18,7 @@ mod test_load {
     use bumpalo::Bump;
     use roc_can::def::Declaration::*;
     use roc_can::def::Def;
-    use roc_constrain::module::ExposedByModule;
+    use roc_can::module::ExposedByModule;
     use roc_load_internal::file::Threading;
     use roc_load_internal::file::{LoadResult, LoadStart, LoadedModule, LoadingProblem, Phase};
     use roc_module::ident::ModuleName;

--- a/compiler/test_derive/src/encoding.rs
+++ b/compiler/test_derive/src/encoding.rs
@@ -17,13 +17,10 @@ use roc_can::{
     constraint::Constraints,
     expected::Expected,
     expr::Expr,
-    module::RigidVariables,
+    module::{ExposedByModule, ExposedForModule, ExposedModuleTypes, RigidVariables},
 };
 use roc_collections::VecSet;
-use roc_constrain::{
-    expr::constrain_expr,
-    module::{ExposedByModule, ExposedForModule, ExposedModuleTypes},
-};
+use roc_constrain::expr::constrain_expr;
 use roc_debug_flags::dbg_do;
 use roc_derive_key::{encoding::FlatEncodableKey, Derived};
 use roc_load_internal::file::{add_imports, default_aliases, LoadedModule, Threading};


### PR DESCRIPTION
Derivers will need this, but they don't need to rely on `constrain`. In any case, this feels like a data structure better fit in more fundamental crates.