### PR TITLE
Remove broken lldb from flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -96,7 +96,6 @@
 
           # faster builds - see https://github.com/rtfeldman/roc/blob/trunk/BUILDING_FROM_SOURCE.md#use-lld-for-the-linker
           llvmPkgs.lld
-          llvmPkgs.lldb
           debugir
           rust
         ]);


### PR DESCRIPTION
lldb was added by accident and creates problems on macOS.