### PR TITLE
Docs UI: Style the type signature headers

### DIFF
--- a/docs/src/static/styles.css
+++ b/docs/src/static/styles.css
@@ -81,6 +81,7 @@ a {
 
 .entry-name a {
   font-weight: bold;
+  color: var(--type-signature-color);
 }
 
 .pkg-full-name a {
@@ -437,10 +438,6 @@ pre {
 
   html {
     scrollbar-color: #444444 #2f2f2f;
-  }
-
-  .entry-name a {
-    color: var(--type-signature-color);
   }
 }
 


### PR DESCRIPTION
Light mode:
<img width="728" alt="Screenshot 2022-06-27 at 21 02 15" src="https://user-images.githubusercontent.com/50708034/176027531-7ed058dd-84d8-4ca3-b142-5ed082a4585a.png">

Dark mode:
<img width="723" alt="Screenshot 2022-06-27 at 21 02 39" src="https://user-images.githubusercontent.com/50708034/176027518-54fa27a6-3422-46a7-8c11-925f34e1d5b4.png">

_Reference: [Our docs UI mockup](https://www.figma.com/file/hhadpVs587eRpM3hkJt0Ej/Roc?node-id=601%3A661)_