### PR TITLE
Rust roc_alloc rather than allocator in benchmarks platform

### DIFF
--- a/examples/benchmarks/platform/host.zig
+++ b/examples/benchmarks/platform/host.zig
@@ -88,14 +88,12 @@ export fn roc_memset(dst: [*]u8, value: i32, size: usize) callconv(.C) void {
 const Unit = extern struct {};
 
 pub export fn main() callconv(.C) u8 {
-    const allocator = std.heap.page_allocator;
-
     const size = @intCast(usize, roc__mainForHost_size());
-    const raw_output = allocator.allocAdvanced(u8, @alignOf(u64), @intCast(usize, size), .at_least) catch unreachable;
+    const raw_output = roc_alloc(@intCast(usize, size), @alignOf(u64)).?;
     var output = @ptrCast([*]u8, raw_output);
 
     defer {
-        allocator.free(raw_output);
+        roc_dealloc(raw_output, @alignOf(u64));
     }
 
     var ts1: std.os.timespec = undefined;


### PR DESCRIPTION
This is good style (I think?) and in #2226, the effect closures become
0-sized, which presently causes the ptrCast here to panic because it's
casting a nullptr. Aside of #3336 I think this is the last thing to get
the lazy effects working.