### PR TITLE
Docs UI: Work on body background color for light and dark mode

### DIFF
--- a/docs/src/static/styles.css
+++ b/docs/src/static/styles.css
@@ -315,6 +315,11 @@ code {
   display: inline-block;
 }
 
+p code {
+  padding: 0 8px;
+  border-radius: 4px;
+}
+
 code a, a code {
   text-decoration: none;
   color: var(--code-link-color);


### PR DESCRIPTION
_Style reference: [our docs UI mockup](https://www.figma.com/file/hhadpVs587eRpM3hkJt0Ej/Roc)_

This PR makes the background color of the body element consistent with what we have in the mockup. The appearance of code fencing elements is also tweaked in this PR -- would have looked awkward otherwise.

* Code block in light mode and dark mode:

<img width="928" alt="Screenshot 2022-06-28 at 13 59 16" src="https://user-images.githubusercontent.com/50708034/176187373-0ebc31c3-9fb8-445f-a62c-b0df8dba3b5b.png">

<img width="930" alt="Screenshot 2022-06-28 at 13 59 01" src="https://user-images.githubusercontent.com/50708034/176187357-7ae25f7f-e6c0-4404-b164-7d454a74356d.png">

* Inline code elements in light mode and dark mode (look to the, gulp, far right):

<img width="392" alt="Screenshot 2022-06-28 at 13 59 51" src="https://user-images.githubusercontent.com/50708034/176187420-969efe65-f140-40b9-9070-0e6ca029b336.png">

<img width="398" alt="Screenshot 2022-06-28 at 14 00 09" src="https://user-images.githubusercontent.com/50708034/176187442-0b0fd114-33c2-4e0a-8fcc-9de3d0ffda2b.png">
