### PR TITLE
Docs UI: Work on site text color(s)

### DIFF
--- a/docs/src/static/styles.css
+++ b/docs/src/static/styles.css
@@ -249,6 +249,11 @@ footer p {
   font-family: var(--font-mono);
 }
 
+.sidebar-entry a,
+.sidebar-entry a:visited {
+  color: var(--text-color);
+}
+
 .sidebar-sub-entries a {
   display: block;
   line-height: 24px;
@@ -276,7 +281,6 @@ footer p {
   font-size: 18px;
   line-height: 24px;
   font-family: var(--font-mono);
-  font-weight: bold;
   display: block;
   width: 100%;
   padding: 8px 0;
@@ -422,7 +426,6 @@ pre {
   padding: 12px 16px;
   height: 48px;
   cursor: pointer;
-  color: var(--link-color);
 }
 
 #search-link:hover {


### PR DESCRIPTION
_Style reference: [our docs UI mockup](https://www.figma.com/file/hhadpVs587eRpM3hkJt0Ej/Roc)_

Things to check:
* Text color in main content section is consistent with what is in the mockup.
* Links in the navigation section have the same color as the text in the main content section -- even when visited.

<img width="928" alt="Screenshot 2022-06-28 at 20 56 02" src="https://user-images.githubusercontent.com/50708034/176275176-ba41d74f-a8c5-4c24-872e-338c614ac978.png">

<img width="911" alt="Screenshot 2022-06-28 at 20 57 11" src="https://user-images.githubusercontent.com/50708034/176275210-230b4505-7acc-4ff8-88f4-5dedff2f63fe.png">

---

**Note for Improvement:** When building the html we need to add a class to the currently active link in the navigation section so we can style it differently -- as per the mockup.