### PR TITLE
Fixes `List.range` segfaulting

### DIFF
--- a/crates/compiler/builtins/roc/List.roc
+++ b/crates/compiler/builtins/roc/List.roc
@@ -581,7 +581,7 @@ range = \start, end ->
         GT -> []
         EQ -> [start]
         LT ->
-            length = Num.intCast (start - end)
+            length = Num.intCast (end - start)
 
             rangeHelp (List.withCapacity length) start end
 


### PR DESCRIPTION
Fixes #3377: `List.range 0 3` was segfaulting because a negative amount of memory was allocated. 

- [x] Basic fix (instead of `length = start - end` do `length = end - start`)
- [x] Potentially add a new regression test
- [ ] Figure out why `test_gen/src/gen_list.rs#list_range()` which contains the example `List.range 0 5 == [0, 1, 2, 3 ,4]` did not trigger the problem.
- ~~? Do we want to do a bounds check on `List.withCapacity`?~~ -> Discussion in https://github.com/rtfeldman/roc/issues/3381