### PR TITLE
Docs UI: Style the currently active nav link

### DIFF
--- a/crates/docs/src/static/search.js
+++ b/crates/docs/src/static/search.js
@@ -14,7 +14,10 @@
 
       sidebar.querySelectorAll(".sidebar-entry").forEach((entry) => {
         let entryName = entry.querySelector('.sidebar-module-link').textContent;
-        if (currentModuleName === entryName) return;
+        if (currentModuleName === entryName) {
+          entry.firstChild.classList.add("active");
+          return;
+        };
         entry.querySelectorAll(".sidebar-sub-entries a").forEach((subEntry) => subEntry.classList.add("hidden"));
       })
     } else {

--- a/crates/docs/src/static/styles.css
+++ b/crates/docs/src/static/styles.css
@@ -303,6 +303,10 @@ footer p {
   text-overflow: ellipsis;
 }
 
+.sidebar-module-link.active {
+  font-weight: bold;
+}
+
 a, a:visited {
   color: var(--link-color);
 }


### PR DESCRIPTION
Makes the currently active navigation link appear bolder than the others.

<img width="512" alt="Screenshot 2022-07-04 at 04 35 07" src="https://user-images.githubusercontent.com/50708034/177077191-4be235cf-371a-4d2e-a97f-f95b071563d9.png">

<img width="628" alt="Screenshot 2022-07-04 at 04 36 00" src="https://user-images.githubusercontent.com/50708034/177077206-2150ee8e-5f40-4189-81ac-b2aeaa40d3a8.png">