### PR TITLE
Add a third type param to Task in CLI example

### DIFF
--- a/examples/interactive/cli-platform/InternalTask.roc
+++ b/examples/interactive/cli-platform/InternalTask.roc
@@ -1,0 +1,11 @@
+interface InternalTask
+    exposes [Task, fromEffect, toEffect]
+    imports [pf.Effect.{ Effect }]
+
+Task ok err fx := Effect (Result ok err)
+
+fromEffect : Effect (Result ok err) -> Task ok err *
+fromEffect = \effect -> @Task effect
+
+toEffect : Task ok err * -> Effect (Result ok err)
+toEffect = \@Task effect -> effect

--- a/examples/interactive/cli-platform/Stdin.roc
+++ b/examples/interactive/cli-platform/Stdin.roc
@@ -1,6 +1,9 @@
 interface Stdin
     exposes [line]
-    imports [pf.Effect, Task]
+    imports [pf.Effect, Task.{ Task }, InternalTask]
 
-line : Task.Task Str *
-line = Effect.after Effect.getLine Task.succeed # TODO FIXME Effect.getLine should suffice
+line : Task Str * [Read [Stdin]*]*
+line =
+    Effect.getLine
+        |> Effect.map Ok
+        |> InternalTask.fromEffect

--- a/examples/interactive/cli-platform/Stdout.roc
+++ b/examples/interactive/cli-platform/Stdout.roc
@@ -1,6 +1,8 @@
 interface Stdout
     exposes [line]
-    imports [pf.Effect, Task.{ Task }]
+    imports [pf.Effect, Task.{ Task }, InternalTask]
 
-line : Str -> Task {} *
-line = \str -> Effect.map (Effect.putLine str) (\_ -> Ok {})
+line : Str -> Task {} * [Write [Stdout]*]*
+line = \str ->
+    Effect.map (Effect.putLine str) (\_ -> Ok {})
+        |> InternalTask.fromEffect

--- a/examples/interactive/cli-platform/main.roc
+++ b/examples/interactive/cli-platform/main.roc
@@ -1,9 +1,9 @@
 platform "cli"
-    requires {} { main : Task {} [] }
+    requires {} { main : Task {} [] * }
     exposes []
     packages {}
-    imports [Task.{ Task }]
+    imports [Task.{ Task }, InternalTask, Effect.{ Effect }]
     provides [mainForHost]
 
-mainForHost : Task {} [] as Fx
-mainForHost = main
+mainForHost : Effect (Result {} []) as Fx
+mainForHost = InternalTask.toEffect main

--- a/examples/interactive/echo.roc
+++ b/examples/interactive/echo.roc
@@ -3,12 +3,12 @@ app "echo"
     imports [pf.Stdin, pf.Stdout, pf.Task]
     provides [main] to pf
 
-main : Task.Task {} []
+main : Task.Task {} [] [Read [Stdin], Write [Stdout]]
 main =
     _ <- Task.await (Stdout.line "🗣  Shout into this cave and hear the echo! 👂👂👂")
     Task.loop {} (\_ -> Task.map tick Step)
 
-tick : Task.Task {} []
+tick : Task.Task {} [] [Read [Stdin]*, Write [Stdout]*]*
 tick =
     shout <- Task.await Stdin.line
     Stdout.line (echo shout)

--- a/examples/interactive/form.roc
+++ b/examples/interactive/form.roc
@@ -3,7 +3,7 @@ app "form"
     imports [pf.Stdin, pf.Stdout, pf.Task.{ await, Task }]
     provides [main] to pf
 
-main : Task {} *
+main : Task {} * [Read [Stdin], Write [Stdout]]
 main =
     _ <- await (Stdout.line "What's your first name?")
     firstName <- await Stdin.line


### PR DESCRIPTION
This makes it so that effect types are tracked in the type, and `main` has to include all the ones that get used!

<img width="904" alt="fx" src="https://user-images.githubusercontent.com/1094080/177793421-adb511ea-6fa9-4d78-a2e9-a0e3685b8468.png">
