### PR TITLE
Fix comment between multiline annotation args

### DIFF
--- a/crates/compiler/fmt/src/annotation.rs
+++ b/crates/compiler/fmt/src/annotation.rs
@@ -207,9 +207,11 @@ impl<'a> Formattable for TypeAnnotation<'a> {
 
         match self {
             Function(arguments, result) => {
-                let write_parens = parens != Parens::NotNeeded;
+                let needs_parens = parens != Parens::NotNeeded;
 
-                if write_parens {
+                buf.indent(indent);
+
+                if needs_parens {
                     buf.push('(')
                 }
 
@@ -256,7 +258,7 @@ impl<'a> Formattable for TypeAnnotation<'a> {
                     indent,
                 );
 
-                if write_parens {
+                if needs_parens {
                     buf.push(')')
                 }
             }

--- a/crates/compiler/fmt/tests/test_fmt.rs
+++ b/crates/compiler/fmt/tests/test_fmt.rs
@@ -4277,6 +4277,21 @@ mod test_fmt {
     }
 
     #[test]
+    fn comment_between_multiline_ann_args() {
+        expr_formats_same(indoc!(
+            r#"
+                blah :
+                    Str,
+                    # comment
+                    (Str -> Str)
+                    -> Str
+
+                42
+            "#
+        ))
+    }
+
+    #[test]
     fn pipeline_apply_lambda_multiline() {
         expr_formats_same(indoc!(
             r#"


### PR DESCRIPTION
Quick formatting fix I ran into when working on `Path`