### PR TITLE
Fix unstable formatting of opaque tag unions

### DIFF
--- a/crates/compiler/fmt/src/def.rs
+++ b/crates/compiler/fmt/src/def.rs
@@ -95,8 +95,6 @@ impl<'a> Formattable for TypeDef<'a> {
                 let ann_is_where_clause =
                     matches!(ann.extract_spaces().item, TypeAnnotation::Where(..));
 
-                let ann_has_spaces_before = matches!(&ann.value, TypeAnnotation::SpaceBefore(..));
-
                 // Always put the has-derived clause on a newline if it is itself multiline, or
                 // the annotation has a where-has clause.
                 let derived_multiline = if let Some(derived) = derived {
@@ -106,12 +104,6 @@ impl<'a> Formattable for TypeDef<'a> {
                 };
 
                 let make_multiline = ann.is_multiline() || derived_multiline;
-
-                // If the annotation has spaces before, a newline will already be printed.
-                if make_multiline && !ann_has_spaces_before {
-                    buf.newline();
-                    buf.indent(indent + INDENT);
-                }
 
                 ann.format(buf, indent);
 

--- a/crates/compiler/fmt/tests/test_fmt.rs
+++ b/crates/compiler/fmt/tests/test_fmt.rs
@@ -5028,15 +5028,25 @@ mod test_fmt {
             "#
         ));
 
-        expr_formats_same(indoc!(
-            r#"
-            A :=
-                U8
-                has [Eq, Hash]
+        expr_formats_to(
+            indoc!(
+                r#"
+                A :=
+                    U8
+                    has [Eq, Hash]
 
-            0
-            "#
-        ));
+                0
+                "#
+            ),
+            indoc!(
+                r#"
+                A := U8
+                    has [Eq, Hash]
+
+                0
+                "#
+            ),
+        );
 
         expr_formats_to(
             indoc!(
@@ -5048,8 +5058,7 @@ mod test_fmt {
             ),
             indoc!(
                 r#"
-                A :=
-                    a | a has Hash
+                A := a | a has Hash
                     has [Eq, Hash]
 
                 0


### PR DESCRIPTION
This used to give an error for being unstable; now it doesn't!

Also made it so that if you have a single-line annotation after `:=`, it formats to being on the same line as the `:=` symbol.