### PR TITLE
Ignore vim-specific editor files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,9 @@ vgcore.*
 .idea/
 .vscode/
 .ignore
+.exrc
+.vimrc
+.nvimrc
 
 #files too big to track in git
 editor/benches/resources/100000_lines.roc


### PR DESCRIPTION
My nvimrc has been growing for a while, it would be nice for git to just ignore it.