### PR TITLE
collapse void

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3803,6 +3803,7 @@ dependencies = [
 name = "roc_mono"
 version = "0.1.0"
 dependencies = [
+ "bitvec 1.0.0",
  "bumpalo",
  "hashbrown 0.12.1",
  "roc_builtins",

--- a/crates/compiler/mono/Cargo.toml
+++ b/crates/compiler/mono/Cargo.toml
@@ -24,3 +24,4 @@ ven_pretty = { path = "../../vendor/pretty" }
 bumpalo = { version = "3.8.0", features = ["collections"] }
 hashbrown = { version = "0.12.1", features = [ "bumpalo" ] }
 static_assertions = "1.1.0"
+bitvec = "1.0"

--- a/crates/compiler/mono/src/decision_tree.rs
+++ b/crates/compiler/mono/src/decision_tree.rs
@@ -334,6 +334,8 @@ fn flatten<'a>(
     path_patterns: &mut Vec<(Vec<PathInstruction>, Pattern<'a>)>,
 ) {
     match path_pattern.1 {
+        Pattern::Voided { .. } => {}
+
         Pattern::AppliedTag {
             union,
             arguments,
@@ -560,6 +562,19 @@ fn test_at_path<'a>(
                     arguments: arguments.to_vec(),
                 },
 
+                Voided {
+                    tag_name,
+                    tag_id,
+                    arguments,
+                    union,
+                    ..
+                } => IsCtor {
+                    tag_id: *tag_id,
+                    ctor_name: CtorName::Tag(tag_name.clone()),
+                    union: union.clone(),
+                    arguments: arguments.to_vec(),
+                },
+
                 OpaqueUnwrap { opaque, argument } => {
                     let union = Union {
                         render_as: RenderAs::Tag,
@@ -768,6 +783,8 @@ fn to_relevant_branch_help<'a>(
 
             _ => None,
         },
+
+        Voided { .. } => None,
 
         AppliedTag {
             tag_name,
@@ -981,6 +998,7 @@ fn needs_tests(pattern: &Pattern) -> bool {
         RecordDestructure(_, _)
         | NewtypeDestructure { .. }
         | AppliedTag { .. }
+        | Voided { .. }
         | OpaqueUnwrap { .. }
         | BitLiteral { .. }
         | EnumLiteral { .. }

--- a/crates/compiler/mono/src/decision_tree.rs
+++ b/crates/compiler/mono/src/decision_tree.rs
@@ -334,7 +334,7 @@ fn flatten<'a>(
     path_patterns: &mut Vec<(Vec<PathInstruction>, Pattern<'a>)>,
 ) {
     match path_pattern.1 {
-        Pattern::Voided { .. } => {}
+        Pattern::Voided { .. } => unreachable!(),
 
         Pattern::AppliedTag {
             union,
@@ -562,18 +562,7 @@ fn test_at_path<'a>(
                     arguments: arguments.to_vec(),
                 },
 
-                Voided {
-                    tag_name,
-                    tag_id,
-                    arguments,
-                    union,
-                    ..
-                } => IsCtor {
-                    tag_id: *tag_id,
-                    ctor_name: CtorName::Tag(tag_name.clone()),
-                    union: union.clone(),
-                    arguments: arguments.to_vec(),
-                },
+                Voided { .. } => unreachable!(),
 
                 OpaqueUnwrap { opaque, argument } => {
                     let union = Union {
@@ -784,7 +773,7 @@ fn to_relevant_branch_help<'a>(
             _ => None,
         },
 
-        Voided { .. } => None,
+        Voided { .. } => unreachable!(),
 
         AppliedTag {
             tag_name,

--- a/crates/compiler/mono/src/ir.rs
+++ b/crates/compiler/mono/src/ir.rs
@@ -5369,7 +5369,7 @@ fn convert_tag_union<'a>(
             let iter = field_symbols_temp.into_iter().map(|(_, _, data)| data);
             assign_to_symbols(env, procs, layout_cache, iter, stmt)
         }
-        NewtypeByVoid { sorted_tag_layouts } => {
+        NewtypeByVoid { sorted_tag_layouts, .. } => {
             let (tag_id, _) = {
                 let (tag_id, (_, argument_layouts)) = sorted_tag_layouts
                     .iter()
@@ -8409,6 +8409,7 @@ fn from_can_pattern_help<'a>(
                 }
                 NewtypeByVoid {
                     sorted_tag_layouts: tags,
+                    ..
                 } => {
                     let (tag_id, argument_layouts) = {
                         let (tag_id, (_, argument_layouts)) = tags

--- a/crates/compiler/mono/src/ir.rs
+++ b/crates/compiler/mono/src/ir.rs
@@ -5319,7 +5319,7 @@ fn convert_tag_union<'a>(
             "The `[]` type has no constructors, source var {:?}",
             variant_var
         ),
-        Unit | UnitWithArguments => Stmt::Let(assigned, Expr::Struct(&[]), Layout::UNIT, hole),
+        Unit => Stmt::Let(assigned, Expr::Struct(&[]), Layout::UNIT, hole),
         BoolUnion { ttrue, .. } => Stmt::Let(
             assigned,
             Expr::Literal(Literal::Bool(&tag_name == ttrue.expect_tag_ref())),
@@ -8250,7 +8250,7 @@ fn from_can_pattern_help<'a>(
                     "there is no pattern of type `[]`, union var {:?}",
                     *whole_var
                 ),
-                Unit | UnitWithArguments => Pattern::EnumLiteral {
+                Unit => Pattern::EnumLiteral {
                     tag_id: 0,
                     tag_name: tag_name.clone(),
                     union: Union {

--- a/crates/compiler/mono/src/ir.rs
+++ b/crates/compiler/mono/src/ir.rs
@@ -8187,9 +8187,6 @@ pub enum Pattern<'a> {
     Voided {
         tag_name: TagName,
         tag_id: TagIdIntType,
-        arguments: Vec<'a, (Pattern<'a>, Layout<'a>)>,
-        layout: UnionLayout<'a>,
-        union: roc_exhaustive::Union,
     },
     AppliedTag {
         tag_name: TagName,
@@ -8226,7 +8223,7 @@ pub struct WhenBranch<'a> {
 }
 
 impl<'a> Pattern<'a> {
-    /// This pattern contains a pattern match on Void (i.e. [], the empty tag union) 
+    /// This pattern contains a pattern match on Void (i.e. [], the empty tag union)
     /// such branches are not reachable at runtime
     pub fn is_voided(&self) -> bool {
         let mut stack: std::vec::Vec<&Pattern> = vec![self];
@@ -8465,7 +8462,7 @@ fn from_can_pattern_help<'a>(
                 }
                 NewtypeByVoid {
                     sorted_tag_layouts: tags,
-                    data_tag_name,
+                    data_tag_name: _,
                     data_tag_id,
                     ..
                 } => {
@@ -8562,9 +8559,6 @@ fn from_can_pattern_help<'a>(
                         Pattern::Voided {
                             tag_name: tag_name.clone(),
                             tag_id: tag_id as _,
-                            arguments: mono_args,
-                            union,
-                            layout,
                         }
                     }
                 }

--- a/crates/compiler/mono/src/layout.rs
+++ b/crates/compiler/mono/src/layout.rs
@@ -1073,6 +1073,7 @@ impl<'a> LambdaSet<'a> {
             } => Layout::struct_no_name_order(layouts.into_bump_slice()),
             NewtypeByVoid {
                 sorted_tag_layouts: tags,
+                ..
             } => {
                 debug_assert!(tags.len() > 1);
 
@@ -2298,6 +2299,8 @@ pub enum UnionVariant<'a> {
         arguments: Vec<'a, Layout<'a>>,
     },
     NewtypeByVoid {
+        data_tag_name: TagOrClosure,
+        data_tag_id: TagIdIntType,
         sorted_tag_layouts: Vec<'a, (TagOrClosure, &'a [Layout<'a>])>,
     },
     Wrapped(WrappedVariant<'a>),
@@ -2932,6 +2935,7 @@ where
         }
         NewtypeByVoid {
             sorted_tag_layouts: tags,
+            ..
         } => {
             let mut tag_layouts = Vec::with_capacity_in(tags.len(), env.arena);
             tag_layouts.extend(tags.iter().map(|r| r.1));

--- a/crates/compiler/mono/src/layout.rs
+++ b/crates/compiler/mono/src/layout.rs
@@ -2511,6 +2511,7 @@ where
             let mut has_any_arguments = false;
 
             let mut nullable: Option<(TagIdIntType, TagOrClosure)> = None;
+            let mut voided_tag_ids = bitvec::vec::BitVec::<usize>::repeat(false, num_tags);
 
             // only recursive tag unions can be nullable
             let is_recursive = opt_rec_var.is_some();
@@ -2545,6 +2546,10 @@ where
                                         .get_root_key_without_compacting(opt_rec_var.unwrap())
                                 && is_recursive_tag_union(&layout);
 
+                            if layout == Layout::VOID {
+                                voided_tag_ids.set(answer.len(), true);
+                            }
+
                             if self_recursion {
                                 arg_layouts.push(Layout::RecursivePointer);
                             } else {
@@ -2573,6 +2578,15 @@ where
 
                 answer.push((tag_name.clone().into(), arg_layouts.into_bump_slice()));
             }
+
+            //            if num_tags == voided_tag_ids.count_ones() + 1 && !is_recursive {
+            //                let kept = answer.remove(voided_tag_ids.leading_ones());
+            //
+            //                return UnionVariant::NewtypeByVoid {
+            //                    tag_name: kept.0,
+            //                    arguments: Vec::from_iter_in(kept.1.iter().copied(), env.arena),
+            //                };
+            //            }
 
             match num_tags {
                 2 if !has_any_arguments => {
@@ -2708,6 +2722,7 @@ where
             let mut has_any_arguments = false;
 
             let mut nullable = None;
+            let mut voided_tag_ids = bitvec::vec::BitVec::<usize>::repeat(false, num_tags);
 
             // only recursive tag unions can be nullable
             let is_recursive = opt_rec_var.is_some();
@@ -2740,6 +2755,10 @@ where
                                     == subs.get_root_key_without_compacting(opt_rec_var.unwrap())
                                 && is_recursive_tag_union(&layout);
 
+                            if layout == Layout::VOID {
+                                voided_tag_ids.set(answer.len(), true);
+                            }
+
                             if self_recursion {
                                 arg_layouts.push(Layout::RecursivePointer);
                             } else {
@@ -2769,6 +2788,15 @@ where
 
                 answer.push((tag_name.into(), arg_layouts.into_bump_slice()));
             }
+
+            //            if num_tags == voided_tag_ids.count_ones() + 1 && !is_recursive {
+            //                let kept = answer.remove(voided_tag_ids.leading_ones());
+            //
+            //                return UnionVariant::NewtypeByVoid {
+            //                    tag_name: kept.0,
+            //                    arguments: Vec::from_iter_in(kept.1.iter().copied(), env.arena),
+            //                };
+            //            }
 
             match num_tags {
                 2 if !has_any_arguments => {

--- a/crates/compiler/mono/src/layout.rs
+++ b/crates/compiler/mono/src/layout.rs
@@ -2600,14 +2600,16 @@ where
                 answer.push((tag_name.clone().into(), arg_layouts.into_bump_slice()));
             }
 
-            //            if num_tags == voided_tag_ids.count_ones() + 1 && !is_recursive {
-            //                let kept = answer.remove(voided_tag_ids.leading_ones());
-            //
-            //                return UnionVariant::NewtypeByVoid {
-            //                    tag_name: kept.0,
-            //                    arguments: Vec::from_iter_in(kept.1.iter().copied(), env.arena),
-            //                };
-            //            }
+            if num_tags == voided_tag_ids.count_ones() + 1 && !is_recursive {
+                let kept_tag_id = voided_tag_ids.leading_ones();
+                let kept = answer.get(kept_tag_id).unwrap();
+
+                return UnionVariant::NewtypeByVoid {
+                    data_tag_name: kept.0.clone(),
+                    data_tag_id: kept_tag_id as _,
+                    sorted_tag_layouts: answer,
+                };
+            }
 
             match num_tags {
                 2 if !has_any_arguments => {
@@ -2810,14 +2812,16 @@ where
                 answer.push((tag_name.into(), arg_layouts.into_bump_slice()));
             }
 
-            //            if num_tags == voided_tag_ids.count_ones() + 1 && !is_recursive {
-            //                let kept = answer.remove(voided_tag_ids.leading_ones());
-            //
-            //                return UnionVariant::NewtypeByVoid {
-            //                    tag_name: kept.0,
-            //                    arguments: Vec::from_iter_in(kept.1.iter().copied(), env.arena),
-            //                };
-            //            }
+            if num_tags == voided_tag_ids.count_ones() + 1 && !is_recursive {
+                let kept_tag_id = voided_tag_ids.leading_ones();
+                let kept = answer.get(kept_tag_id).unwrap();
+
+                return UnionVariant::NewtypeByVoid {
+                    data_tag_name: kept.0.clone(),
+                    data_tag_id: kept_tag_id as _,
+                    sorted_tag_layouts: answer,
+                };
+            }
 
             match num_tags {
                 2 if !has_any_arguments => {


### PR DESCRIPTION
When just one of the variants of a tag union does not contain `[]` (the empty tag union), then we can collapse it into a newtype wrapper 

- get rid of UnitWithArguments
- recognize cases where void arguments create a newtype from a non-recursive union
- special case for NewtypeByVoid
- add some extra info to newtypebyvoid
- thread voided into decision tree
- filter voidable branches out
- remove some data from Voided patterns
- cleanup
