### PR TITLE
Don't symlink known_bad tests

### DIFF
--- a/crates/cli/tests/known_bad/TypeError.roc
+++ b/crates/cli/tests/known_bad/TypeError.roc
@@ -1,5 +1,5 @@
 app "type-error"
-    packages { pf: "platform/main.roc" }
+    packages { pf: "../../../../examples/interactive/cli-platform/main.roc" }
     imports [pf.Stdout.{ line }, pf.Task.{ await }]
     provides [main] to pf
 

--- a/crates/cli/tests/known_bad/platform
+++ b/crates/cli/tests/known_bad/platform
@@ -1,1 +1,0 @@
-../../../../examples/interactive/cli-platform


### PR DESCRIPTION
Whenever I searched for things in the CLI platform I'd get duplicate results from this symlink, so now instead it just uses the path to the platform instead of symlinking the whole directory. 😄 