### PR TITLE
Remove compiler-file/line-dependent runtime error messages

### DIFF
--- a/crates/compiler/mono/src/ir.rs
+++ b/crates/compiler/mono/src/ir.rs
@@ -80,18 +80,15 @@ macro_rules! return_on_layout_error_help {
     ($env:expr, $error:expr, $context_msg:expr) => {{
         match $error {
             LayoutProblem::UnresolvedTypeVar(_) => {
-                return Stmt::RuntimeError($env.arena.alloc(format!(
-                    "UnresolvedTypeVar {} at {}",
-                    file!(),
-                    $context_msg,
-                )));
+                return Stmt::RuntimeError(
+                    $env.arena
+                        .alloc(format!("UnresolvedTypeVar: {}", $context_msg,)),
+                );
             }
             LayoutProblem::Erroneous => {
-                return Stmt::RuntimeError($env.arena.alloc(format!(
-                    "Erroneous {} at {}",
-                    file!(),
-                    $context_msg,
-                )));
+                return Stmt::RuntimeError(
+                    $env.arena.alloc(format!("Erroneous: {}", $context_msg,)),
+                );
             }
         }
     }};
@@ -4599,12 +4596,10 @@ pub fn with_hole<'a>(
                     );
 
                     if let Err(runtime_error) = inserted {
-                        return Stmt::RuntimeError(env.arena.alloc(format!(
-                            "RuntimeError {} line {} {:?}",
-                            file!(),
-                            line!(),
-                            runtime_error,
-                        )));
+                        return Stmt::RuntimeError(
+                            env.arena
+                                .alloc(format!("RuntimeError: {:?}", runtime_error,)),
+                        );
                     } else {
                         drop(inserted);
                     }
@@ -5322,16 +5317,14 @@ fn convert_tag_union<'a>(
         Ok(cached) => cached,
         Err(LayoutProblem::UnresolvedTypeVar(_)) => {
             return Stmt::RuntimeError(env.arena.alloc(format!(
-                "UnresolvedTypeVar {} line {}",
-                file!(),
-                line!()
+                "Unresolved type variable for tag {}",
+                tag_name.0.as_str()
             )))
         }
         Err(LayoutProblem::Erroneous) => {
             return Stmt::RuntimeError(env.arena.alloc(format!(
-                "Erroneous {} line {}",
-                file!(),
-                line!()
+                "Tag {} was part of a type error!",
+                tag_name.0.as_str()
             )));
         }
     };
@@ -5614,9 +5607,7 @@ fn tag_union_to_function<'a>(
         }
 
         Err(runtime_error) => Stmt::RuntimeError(env.arena.alloc(format!(
-            "RuntimeError {} line {} {:?}",
-            file!(),
-            line!(),
+            "Could not produce tag function due to a runtime error: {:?}",
             runtime_error,
         ))),
     }

--- a/crates/compiler/test_mono/generated/call_function_in_empty_list_unbound.txt
+++ b/crates/compiler/test_mono/generated/call_function_in_empty_list_unbound.txt
@@ -1,6 +1,6 @@
 procedure List.5 (#Attr.2, #Attr.3):
-    Error UnresolvedTypeVar crates/compiler/mono/src/ir.rs at match_on_closure_argument
+    Error UnresolvedTypeVar: match_on_closure_argument
 
 procedure Test.0 ():
     let Test.1 : List [] = Array [];
-    Error UnresolvedTypeVar crates/compiler/mono/src/ir.rs at Expr::Closure
+    Error UnresolvedTypeVar: Expr::Closure


### PR DESCRIPTION
This will help avoid the diff changes we've been running into often when
changes to mono line numbers change test results.
