### PR TITLE
re-enable surgical linker for cli_run tests

### DIFF
--- a/crates/cli/tests/cli_run.rs
+++ b/crates/cli/tests/cli_run.rs
@@ -324,7 +324,7 @@ mod cli_run {
                         &file_name,
                         example.stdin,
                         example.executable_filename,
-                        &[LINKER_FLAG, "legacy"], // remove LINKER_FLAG, "legacy" once #3540 is fixed
+                        &[],
                         example.input_file.and_then(|file| Some(example_file(dir_name, file))),
                         example.expected_ending,
                         example.use_valgrind,


### PR DESCRIPTION
PR #3539 fixed #3540 so the surgical linker can be re-enabled.