### PR TITLE
Fix a comment in Str.roc

### DIFF
--- a/crates/compiler/builtins/roc/Str.roc
+++ b/crates/compiler/builtins/roc/Str.roc
@@ -172,11 +172,11 @@ countGraphemes : Str -> Nat
 ## **Performance Note:** This runs slightly faster than [Str.startsWith], so
 ## if you want to check whether a string begins with something that's representable
 ## in a single code point, you can use (for example) `Str.startsWithScalar '鹏'`
-## instead of `Str.startsWithScalar "鹏"`. ('鹏' evaluates to the [U32]
-## value `40527`.) This will not work for graphemes which take up multiple code
-## points, however; `Str.startsWithScalar '👩‍👩‍👦‍👦'` would be a compiler error
-## because 👩‍👩‍👦‍👦 takes up multiple code points and cannot be represented as a
-## single [U32]. You'd need to use `Str.startsWithScalar "🕊"` instead.
+## instead of `Str.startsWith "鹏"`. ('鹏' evaluates to the [U32] value `40527`.)
+## This will not work for graphemes which take up multiple code points, however;
+## `Str.startsWithScalar '👩‍👩‍👦‍👦'` would be a compiler error because 👩‍👩‍👦‍👦 takes up
+## multiple code points and cannot be represented as a single [U32].
+## You'd need to use `Str.startsWithScalar "🕊"` instead.
 startsWithScalar : Str, U32 -> Bool
 
 ## Return a [List] of the [unicode scalar values](https://unicode.org/glossary/#unicode_scalar_value)


### PR DESCRIPTION
This comment says you can use `Str.startsWithScalar` instead of `Str.startsWithScalar` in a certain situation.
It should say that you can use `Str.startsWithScalar` instead of `Str.startsWith`.
