### PR TITLE
add support for .data.rel.ro and absolute relocations to surgical linker

### DIFF
--- a/crates/linker/src/lib.rs
+++ b/crates/linker/src/lib.rs
@@ -2540,7 +2540,10 @@ pub fn surgery_elf(
     // in development builds for caching the results of top-level constants
     let rodata_sections: Vec<Section> = app_obj
         .sections()
-        .filter(|sec| sec.name().unwrap_or_default().starts_with(".rodata"))
+        .filter(|sec| {
+            sec.name().unwrap_or_default().starts_with(".rodata")
+                || sec.name().unwrap_or_default().starts_with(".data.rel.ro")
+        })
         .collect();
 
     // bss section is like rodata section, but it has zero file size and non-zero virtual size.
@@ -2683,6 +2686,7 @@ pub fn surgery_elf(
                             RelocationKind::Relative | RelocationKind::PltRelative => {
                                 target_offset - virt_base as i64 + rel.1.addend()
                             }
+                            RelocationKind::Absolute => target_offset + rel.1.addend(),
                             x => {
                                 internal_error!("Relocation Kind not yet support: {:?}", x);
                             }


### PR DESCRIPTION
This deals with bullet point 1 and 2 here: https://github.com/rtfeldman/roc/issues/3609#issuecomment-1193050272

I think it is correct, but I could only partially test. Once the other bullet points are fixed, we can double check this.