### PR TITLE
Fix `Str.split` edge case when string and delimiter are equal

### DIFF
--- a/crates/compiler/builtins/bitcode/src/str.zig
+++ b/crates/compiler/builtins/bitcode/src/str.zig
@@ -987,9 +987,7 @@ test "strSplitHelp: string equals delimiter" {
 
     strSplitHelp(array_ptr, str_delimiter, str_delimiter);
 
-    var expected = [2]RocStr{
-        RocStr.empty(), RocStr.empty()
-    };
+    var expected = [2]RocStr{ RocStr.empty(), RocStr.empty() };
 
     defer {
         for (array) |rocStr| {


### PR DESCRIPTION
Both `countSegments` and `strSplitHelp` check for the string length to be strictly greater than the delimiter length, skipping most of the logic if that is not the case. By allowing the string to be the same length as the delimiter, we are getting the expected result `Str.split "/" "/" = ["", ""]`.

This PR adds tests for the case `string == delimiter`, and also a missing test when the delimiter is at the beginning of the string.
 
Closes #3640.