### PR TITLE
Allow naming type variables with a basis hint

### DIFF
--- a/crates/compiler/solve/tests/solve_expr.rs
+++ b/crates/compiler/solve/tests/solve_expr.rs
@@ -3451,7 +3451,7 @@ mod solve_expr {
                 { id1, id2 }
                 "#
             ),
-            "{ id1 : q -> q, id2 : a -> a }",
+            "{ id1 : q -> q, id2 : q1 -> q1 }",
         );
     }
 
@@ -3966,7 +3966,7 @@ mod solve_expr {
                     { a, b }
                 "#
             ),
-            "{ a : { x : I64, y : I64, z : Num c }, b : { blah : Str, x : I64, y : I64, z : Num a } }",
+            "{ a : { x : I64, y : I64, z : Num c }, b : { blah : Str, x : I64, y : I64, z : Num c1 } }",
         );
     }
 
@@ -3997,7 +3997,7 @@ mod solve_expr {
                     { a, b }
                 "#
             ),
-            "{ a : { x : Num *, y : Float *, z : c }, b : { blah : Str, x : Num *, y : Float *, z : a } }",
+            "{ a : { x : Num *, y : Float *, z : c }, b : { blah : Str, x : Num *, y : Float *, z : c1 } }",
         );
     }
 
@@ -6157,7 +6157,7 @@ mod solve_expr {
                 hashEq = \x, y -> hash x == hash y
                 "#
             ),
-            "a, b -> Bool | a has Hash, b has Hash",
+            "a, a1 -> Bool | a has Hash, a1 has Hash",
         )
     }
 

--- a/crates/compiler/types/src/types.rs
+++ b/crates/compiler/types/src/types.rs
@@ -2566,6 +2566,7 @@ fn write_type_ext(ext: TypeExt, buf: &mut String) {
 
 static THE_LETTER_A: u32 = 'a' as u32;
 
+/// Generates a fresh type variable name, composed of lowercase alphabetic characters in sequence.
 pub fn name_type_var<I, F: FnMut(&I, &str) -> bool>(
     letters_used: u32,
     taken: &mut impl Iterator<Item = I>,
@@ -2593,6 +2594,28 @@ pub fn name_type_var<I, F: FnMut(&I, &str) -> bool>(
         name_type_var(letters_used + 1, taken, predicate)
     } else {
         (buf.into(), letters_used + 1)
+    }
+}
+
+/// Generates a fresh type variable name given a hint, composed of the hint as a prefix and a
+/// number as a suffix. For example, given hint `a` we'll name the variable `a`, `a1`, or `a27`.
+pub fn name_type_var_with_hint<I, F: FnMut(&I, &str) -> bool>(
+    hint: &str,
+    taken: &mut impl Iterator<Item = I>,
+    mut predicate: F,
+) -> Lowercase {
+    if !taken.any(|item| predicate(&item, hint)) {
+        return hint.into();
+    }
+
+    let mut i = 0;
+    loop {
+        i += 1;
+        let cand = format!("{}{}", hint, i);
+
+        if !taken.any(|item| predicate(&item, &cand)) {
+            return cand.into();
+        }
     }
 }
 


### PR DESCRIPTION
I think this makes it easier to read type variables when they come from
flex/rigid vars with pre-existing names, just give them a number suffix
to differentiate them.