### PR TITLE
Remove references to todo_opaques

### DIFF
--- a/crates/ast/src/lang/core/def/def.rs
+++ b/crates/ast/src/lang/core/def/def.rs
@@ -13,7 +13,7 @@
 // use crate::pattern::{bindings_from_patterns, canonicalize_pattern, Pattern};
 // use crate::procedure::References;
 use roc_collections::all::{default_hasher, ImMap, MutMap, MutSet, SendMap};
-use roc_error_macros::{todo_abilities, todo_opaques};
+use roc_error_macros::{internal_error, todo_abilities};
 use roc_module::ident::Lowercase;
 use roc_module::symbol::Symbol;
 use roc_parse::ast::{self, CommentOrNewline, Defs, TypeDef, TypeHeader, ValueDef as AstValueDef};
@@ -274,7 +274,7 @@ fn to_pending_def<'a>(
             }
         }
 
-        Type(TypeDef::Opaque { .. }) => todo_opaques!(),
+        Type(TypeDef::Opaque { .. }) => internal_error!("opaques not implemented"),
         Type(TypeDef::Ability { .. }) => todo_abilities!(),
 
         Value(AstValueDef::Expect { .. }) => todo!(),

--- a/crates/ast/src/lang/core/pattern.rs
+++ b/crates/ast/src/lang/core/pattern.rs
@@ -8,7 +8,7 @@ use roc_can::num::{
     finish_parsing_base, finish_parsing_float, finish_parsing_num, ParsedNumResult,
 };
 use roc_collections::all::BumpMap;
-use roc_error_macros::todo_opaques;
+use roc_error_macros::internal_error;
 use roc_module::symbol::{Interns, Symbol};
 use roc_parse::ast::{StrLiteral, StrSegment};
 use roc_parse::pattern::PatternType;
@@ -272,7 +272,7 @@ pub fn to_pattern2<'a>(
             }
         }
 
-        OpaqueRef(..) => todo_opaques!(),
+        OpaqueRef(..) => internal_error!("opaques not implemented"),
 
         Apply(tag, patterns) => {
             let can_patterns = PoolVec::with_capacity(patterns.len() as u32, env.pool);

--- a/crates/error_macros/src/lib.rs
+++ b/crates/error_macros/src/lib.rs
@@ -115,14 +115,4 @@ macro_rules! todo_abilities {
     };
 }
 
-#[macro_export]
-macro_rules! todo_opaques {
-    () => {
-        $crate::_incomplete_project!("Abilities (opaques)", 2463)
-    };
-    ($($arg:tt)+) => {
-        $crate::_incomplete_project!("Abilities (opaques)", 2463, $($arg)+)
-    };
-}
-
 // END LARGE SCALE PROJECTS


### PR DESCRIPTION
Opaque types are now fully implemented so this can be removed. roc_ast
is going away in favor of can, so references there have been replaced
with internal_error.
