### PR TITLE
Change refcounts to assume overflows are impossible

### DIFF
--- a/crates/compiler/builtins/bitcode/src/utils.zig
+++ b/crates/compiler/builtins/bitcode/src/utils.zig
@@ -197,7 +197,7 @@ inline fn decref_ptr_to_refcount(
     if (refcount != REFCOUNT_MAX_ISIZE) {
         switch (RC_TYPE) {
             Refcount.normal => {
-                refcount_ptr[0] = refcount - 1;
+                refcount_ptr[0] = refcount -% 1;
                 if (refcount == REFCOUNT_ONE_ISIZE) {
                     dealloc(@ptrCast([*]u8, refcount_ptr) - (extra_bytes - @sizeOf(usize)), alignment);
                 }


### PR DESCRIPTION
So the wins are smaller than I expected (mostly for atomics) because my original version turned out to have a valgrind issue. After fixing it, it cut some into the wins. That being said, this is still an all around improvement.

We could get much more wins (especially for atomics) if we can remove this if statement: https://github.com/rtfeldman/roc/blob/e47c836d8091f5853d9c53b823f255f79bbec91d/crates/compiler/builtins/bitcode/src/utils.zig#L197

The ways I can think to do this:
1. Simply make constants be stored in writable memory. That way we can just update their refcount. We still would never be able to decrement them so much that we would free the constant or increment them so much that we overflow. So it would have the same semantics to current Roc.
2. Store if the refcount if constant on the stack in free bits (if we have any), maybe in the pointer. This way we can do the check locally instead of reading memory for the check. Might not be possible for all types, but would be an improvement for types that can support it.

For running a cksum running on the false interpreter, removing that branch represents a win of about 20% in execution speed.

Any other ideas? Or are we stuck with this branch.