### PR TITLE
Fix Str.splitLast for needle positioned last

### DIFF
--- a/crates/compiler/builtins/roc/Str.roc
+++ b/crates/compiler/builtins/roc/Str.roc
@@ -334,7 +334,7 @@ lastMatch : Str, Str -> [Some Nat, None]
 lastMatch = \haystack, needle ->
     haystackLength = Str.countUtf8Bytes haystack
     needleLength = Str.countUtf8Bytes needle
-    lastPossibleIndex = Num.subSaturated haystackLength (needleLength + 1)
+    lastPossibleIndex = Num.subSaturated haystackLength needleLength
 
     lastMatchHelp haystack needle lastPossibleIndex
 


### PR DESCRIPTION
This fixes the behavior of the function when the needle is positioned
last in the haystack.
```console
» Str.splitLast "ehllo,," ",,"

Ok { after: "", before: "ehllo" } : Result { after : Str, before : Str } [NotFound]*
```

Fixes #3685.