### PR TITLE
Add link for referenced issue

### DIFF
--- a/getting_started/windows.md
+++ b/getting_started/windows.md
@@ -1,2 +1,2 @@
-Windows is not yet supported, we have a big project in the works (see issue #2608) that will allow this.
+Windows is not yet supported, we have a big project in the works (see [issue #2608](https://github.com/rtfeldman/roc/issues/2608)) that will allow this.
 Until then we recommend using Ubuntu through the "Windows Subsystem for Linux".


### PR DESCRIPTION
I'm glad to see that there's a placeholder for the Windows Getting Started page. That will save time for people like me who are interested in this use case 👍

Apparently GitHub does not automatically link to referenced issues in all cases. (If you reference the issue in a [task list](https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists#about-task-lists), it does; I'm not sure if there are other contexts in which it works too.) I added the link to make it easier for readers to understand the context of the referenced issue.