### PR TITLE
Fix dylib name generation on macOS

### DIFF
--- a/crates/compiler/build/src/link.rs
+++ b/crates/compiler/build/src/link.rs
@@ -1000,11 +1000,11 @@ fn link_macos(
     let (link_type_arg, output_path) = match link_type {
         LinkType::Executable => ("-execute", output_path),
         LinkType::Dylib => {
-            let mut output_path = output_path;
+            let mut file_name: PathBuf = output_path.file_name().unwrap_or_default().into();
 
-            output_path.set_extension("dylib");
+            file_name.set_extension("dylib");
 
-            ("-dylib", output_path)
+            ("-dylib", file_name)
         }
         LinkType::None => internal_error!("link_macos should not be called with link type of none"),
     };


### PR DESCRIPTION
Turns out whatever you pass to `-dylib` is considered the *name* of the library, not the path to it. So we should use only the filename here!