### PR TITLE
use fallible (instead of panicking) arg getter

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -525,7 +525,9 @@ pub fn build(
     }
 
     let wasm_dev_stack_bytes: Option<u32> = matches
-        .value_of(FLAG_WASM_STACK_SIZE_KB)
+        .try_get_one::<&str>(FLAG_WASM_STACK_SIZE_KB)
+        .ok()
+        .flatten()
         .and_then(|s| s.parse::<u32>().ok())
         .map(|x| x * 1024);
 


### PR DESCRIPTION
In 91489ce, we got `--wasm-stack-size-kb`, which is only valid when using `roc build` but read from in all subcommands. Since that flag isn't valid for other cases (like, say, `roc run`) the compiler panics.

One solution is to use `try_get_one` from Clap and just discard the error value if one exists. We could also check the subcommand if we need some more safety here.
