### PR TITLE
Cleanup/refactoring of lambda set layout generation

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -59,7 +59,7 @@ test-zig:
 
 build-rust-test:
     FROM +copy-dirs
-    RUN echo "deb http://deb.debian.org/debian testing main contrib non-free" >> /etc/apt/sources.list # to get gcc 10.3
+    RUN echo "deb http://deb.debian.org/debian testing" >> /etc/apt/sources.list # to get gcc 10.3
     RUN apt -y update
     RUN apt -y install gcc-10 g++-10 && rm /usr/bin/gcc && ln -s /usr/bin/gcc-10 /usr/bin/gcc # gcc-9 maybe causes segfault
     RUN gcc --version

--- a/Earthfile
+++ b/Earthfile
@@ -59,7 +59,7 @@ test-zig:
 
 build-rust-test:
     FROM +copy-dirs
-    RUN echo "deb http://deb.debian.org/debian testing" >> /etc/apt/sources.list # to get gcc 10.3
+    RUN echo "deb http://deb.debian.org/debian testing main contrib non-free" >> /etc/apt/sources.list # to get gcc 10.3
     RUN apt -y update
     RUN apt -y install gcc-10 g++-10 && rm /usr/bin/gcc && ln -s /usr/bin/gcc-10 /usr/bin/gcc # gcc-9 maybe causes segfault
     RUN gcc --version

--- a/crates/compiler/gen_llvm/src/llvm/build.rs
+++ b/crates/compiler/gen_llvm/src/llvm/build.rs
@@ -6411,11 +6411,11 @@ fn to_cc_type<'a, 'ctx, 'env>(
     env: &Env<'a, 'ctx, 'env>,
     layout: &Layout<'a>,
 ) -> BasicTypeEnum<'ctx> {
-    match layout {
-        Layout::Builtin(builtin) => to_cc_type_builtin(env, builtin),
-        _ => {
+    match layout.runtime_representation() {
+        Layout::Builtin(builtin) => to_cc_type_builtin(env, &builtin),
+        layout => {
             // TODO this is almost certainly incorrect for bigger structs
-            basic_type_from_layout(env, layout)
+            basic_type_from_layout(env, &layout)
         }
     }
 }

--- a/crates/compiler/gen_wasm/src/backend.rs
+++ b/crates/compiler/gen_wasm/src/backend.rs
@@ -1886,7 +1886,7 @@ impl<'a> WasmBackend<'a> {
     /// If the data size is known at compile time, pass it in comptime_data_size.
     /// If size is only known at runtime, push *data* size to the VM stack first.
     /// Leaves the *data* address on the VM stack
-    pub fn allocate_with_refcount(
+    fn allocate_with_refcount(
         &mut self,
         comptime_data_size: Option<u32>,
         alignment_bytes: u32,

--- a/crates/compiler/gen_wasm/src/low_level.rs
+++ b/crates/compiler/gen_wasm/src/low_level.rs
@@ -2161,7 +2161,7 @@ pub fn call_higher_order_lowlevel<'a>(
         let boxed_local_id = match backend.storage.ensure_value_has_local(
             &mut backend.code_builder,
             boxed_sym,
-            boxed_storage.clone(),
+            boxed_storage,
         ) {
             StoredValue::Local { local_id, .. } => local_id,
             _ => internal_error!("Expected a local"),

--- a/crates/compiler/gen_wasm/src/low_level.rs
+++ b/crates/compiler/gen_wasm/src/low_level.rs
@@ -1857,11 +1857,15 @@ impl<'a> LowLevelCall<'a> {
     /// Equality and inequality
     /// These can operate on any data type (except functions) so they're more complex than other operators.
     fn eq_or_neq(&self, backend: &mut WasmBackend<'a>) {
-        let arg_layout = backend.storage.symbol_layouts[&self.arguments[0]];
-        let other_arg_layout = backend.storage.symbol_layouts[&self.arguments[1]];
+        let arg_layout =
+            backend.storage.symbol_layouts[&self.arguments[0]].runtime_representation();
+        let other_arg_layout =
+            backend.storage.symbol_layouts[&self.arguments[1]].runtime_representation();
         debug_assert!(
             arg_layout == other_arg_layout,
-            "Cannot do `==` comparison on different types"
+            "Cannot do `==` comparison on different types: {:?} vs {:?}",
+            arg_layout,
+            other_arg_layout
         );
 
         let invert_result = matches!(self.lowlevel, LowLevel::NotEq);

--- a/crates/compiler/gen_wasm/src/storage.rs
+++ b/crates/compiler/gen_wasm/src/storage.rs
@@ -719,13 +719,10 @@ impl<'a> Storage<'a> {
             ) => {
                 debug_assert!(to_value_type == from_value_type);
                 debug_assert!(to_size == from_size);
+                // Note: load_symbols will not destroy the value, so we can use it again later.
+                // It will leave a Popped marker in the VM stack model in CodeBuilder
                 self.load_symbols(code_builder, &[from_symbol]);
                 code_builder.set_local(*to_local_id);
-
-                // Do not repoint the stack memory to the local variable, because it is
-                // possible that other code paths will use the stack memory before this copy.
-                // For example, if the copy happens behind a branch, the local variable may not be
-                // assigned the stack content.
             }
 
             (

--- a/crates/compiler/gen_wasm/src/storage.rs
+++ b/crates/compiler/gen_wasm/src/storage.rs
@@ -721,7 +721,11 @@ impl<'a> Storage<'a> {
                 debug_assert!(to_size == from_size);
                 self.load_symbols(code_builder, &[from_symbol]);
                 code_builder.set_local(*to_local_id);
-                self.symbol_storage_map.insert(from_symbol, to.clone());
+
+                // Do not repoint the stack memory to the local variable, because it is
+                // possible that other code paths will use the stack memory before this copy.
+                // For example, if the copy happens behind a branch, the local variable may not be
+                // assigned the stack content.
             }
 
             (

--- a/crates/compiler/mono/src/ir.rs
+++ b/crates/compiler/mono/src/ir.rs
@@ -9609,26 +9609,19 @@ fn union_lambda_set_branch_help<'a>(
             lambda_set,
             closure_data_symbol,
         } => {
-            if lambda_set.is_represented().is_none() {
-                (argument_layouts_slice, argument_symbols_slice)
-            } else {
-                // extend layouts with the layout of the closure environment
-                let mut argument_layouts =
-                    Vec::with_capacity_in(argument_layouts_slice.len() + 1, env.arena);
-                argument_layouts.extend(argument_layouts_slice);
-                argument_layouts.push(Layout::LambdaSet(lambda_set));
-
+            let argument_layouts =
+                lambda_set.extend_argument_list(env.arena, argument_layouts_slice);
+            let argument_symbols = if argument_layouts.len() > argument_layouts_slice.len() {
                 // extend symbols with the symbol of the closure environment
                 let mut argument_symbols =
                     Vec::with_capacity_in(argument_symbols_slice.len() + 1, env.arena);
                 argument_symbols.extend(argument_symbols_slice);
                 argument_symbols.push(closure_data_symbol);
-
-                (
-                    argument_layouts.into_bump_slice(),
-                    argument_symbols.into_bump_slice(),
-                )
-            }
+                argument_symbols.into_bump_slice()
+            } else {
+                argument_symbols_slice
+            };
+            (argument_layouts, argument_symbols)
         }
         ClosureInfo::DoesNotCapture => {
             // sometimes unification causes a function that does not itself capture anything

--- a/crates/compiler/mono/src/ir.rs
+++ b/crates/compiler/mono/src/ir.rs
@@ -3238,7 +3238,7 @@ fn specialize_external<'a>(
 
                         ClosureRepresentation::UnwrappedCapture(_layout) => {
                             debug_assert_eq!(captured.len(), 1);
-                            let (captured_symbol, _) = captured[0];
+                            let (captured_symbol, _captured_layout) = captured[0];
 
                             // The capture set is unwrapped, so simply replace the closure argument
                             // to the function with the unwrapped capture name.

--- a/crates/compiler/mono/src/ir.rs
+++ b/crates/compiler/mono/src/ir.rs
@@ -5439,7 +5439,7 @@ where
             EnumDispatch::Bool => {
                 debug_assert_eq!(symbols.len(), 0);
 
-                debug_assert_eq!(lambda_set.set.len(), 2);
+                debug_assert_eq!(lambda_set.len(), 2);
                 let tag_id = name.name() != lambda_set.iter_set().next().unwrap().name();
                 let expr = Expr::Literal(Literal::Bool(tag_id));
 
@@ -5448,7 +5448,7 @@ where
             EnumDispatch::U8 => {
                 debug_assert_eq!(symbols.len(), 0);
 
-                debug_assert!(lambda_set.set.len() > 2);
+                debug_assert!(lambda_set.len() > 2);
                 let tag_id = lambda_set
                     .iter_set()
                     .position(|s| s.name() == name.name())
@@ -9477,7 +9477,7 @@ fn union_lambda_set_to_switch<'a>(
     assigned: Symbol,
     hole: &'a Stmt<'a>,
 ) -> Stmt<'a> {
-    if lambda_set.set.is_empty() {
+    if lambda_set.is_empty() {
         // NOTE this can happen if there is a type error somewhere. Since the lambda set is empty,
         // there is really nothing we can do here. We generate a runtime error here which allows
         // code gen to proceed. We then assume that we hit another (more descriptive) error before
@@ -9487,7 +9487,7 @@ fn union_lambda_set_to_switch<'a>(
 
     let join_point_id = JoinPointId(env.unique_symbol());
 
-    let mut branches = Vec::with_capacity_in(lambda_set.set.len(), env.arena);
+    let mut branches = Vec::with_capacity_in(lambda_set.len(), env.arena);
 
     for (i, lambda_name) in lambda_set.iter_set().enumerate() {
         let closure_info = if lambda_name.no_captures() {

--- a/crates/compiler/mono/src/layout.rs
+++ b/crates/compiler/mono/src/layout.rs
@@ -783,7 +783,7 @@ impl<'a> LambdaName<'a> {
 #[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct LambdaSet<'a> {
     /// collection of function names and their closure arguments
-    pub set: &'a [(Symbol, &'a [Layout<'a>])],
+    set: &'a [(Symbol, &'a [Layout<'a>])],
     /// how the closure will be represented at runtime
     representation: &'a Layout<'a>,
 }
@@ -865,6 +865,16 @@ impl<'a> LambdaSet<'a> {
             name: *name,
             captures_niche: CapturesNiche(captures_layouts),
         })
+    }
+
+    #[inline(always)]
+    pub fn len(&self) -> usize {
+        self.set.len()
+    }
+
+    #[inline(always)]
+    pub fn is_empty(&self) -> bool {
+        self.set.is_empty()
     }
 
     pub fn layout_for_member_with_lambda_name(

--- a/crates/compiler/mono/src/layout.rs
+++ b/crates/compiler/mono/src/layout.rs
@@ -840,13 +840,17 @@ impl<'a> LambdaSet<'a> {
     }
 
     pub fn is_represented(&self) -> Option<Layout<'a>> {
-        match self.representation {
-            Layout::Struct {
-                field_layouts: &[], ..
+        if self.has_unwrapped_capture_repr() {
+            Some(*self.representation)
+        } else if self.has_multi_dispatch_repr() {
+            None
+        } else {
+            match self.representation {
+                Layout::Struct {
+                    field_layouts: &[], ..
+                } => None,
+                repr => Some(*repr),
             }
-            | Layout::Builtin(Builtin::Bool)
-            | Layout::Builtin(Builtin::Int(..)) => None,
-            repr => Some(*repr),
         }
     }
 

--- a/crates/compiler/mono/src/layout.rs
+++ b/crates/compiler/mono/src/layout.rs
@@ -1825,6 +1825,13 @@ impl<'a> Layout<'a> {
             }
         }
     }
+
+    pub fn runtime_representation(&self) -> Self {
+        match self {
+            Layout::LambdaSet(lambda_set) => lambda_set.runtime_representation(),
+            other => *other,
+        }
+    }
 }
 
 /// Avoid recomputing Layout from Variable multiple times.

--- a/crates/compiler/test_gen/src/gen_primitives.rs
+++ b/crates/compiler/test_gen/src/gen_primitives.rs
@@ -1234,8 +1234,8 @@ fn return_wrapped_closure() {
             main = foo
             "#
         ),
-        [5],
-        [i64; 1]
+        5,
+        i64
     );
 }
 

--- a/crates/compiler/test_mono/generated/closure_in_list.txt
+++ b/crates/compiler/test_mono/generated/closure_in_list.txt
@@ -4,14 +4,14 @@ procedure List.6 (#Attr.2):
 
 procedure Test.1 (Test.5):
     let Test.2 : I64 = 41i64;
-    let Test.10 : I64 = StructAtIndex 0 Test.13;
     let Test.13 : {I64} = Struct {Test.2};
+    let Test.10 : I64 = StructAtIndex 0 Test.13;
     let Test.9 : List I64 = Array [Test.10];
     ret Test.9;
 
 procedure Test.3 (Test.8, #Attr.12):
-    let Test.2 : I64 = StructAtIndex 0 Test.12;
     let Test.12 : {I64} = Struct {#Attr.12};
+    let Test.2 : I64 = StructAtIndex 0 Test.12;
     ret Test.2;
 
 procedure Test.0 ():

--- a/crates/compiler/test_mono/generated/closure_in_list.txt
+++ b/crates/compiler/test_mono/generated/closure_in_list.txt
@@ -4,17 +4,19 @@ procedure List.6 (#Attr.2):
 
 procedure Test.1 (Test.5):
     let Test.2 : I64 = 41i64;
-    let Test.10 : {I64} = Struct {Test.2};
-    let Test.9 : List {I64} = Array [Test.10];
+    let Test.10 : I64 = StructAtIndex 0 Test.13;
+    let Test.13 : {I64} = Struct {Test.2};
+    let Test.9 : List I64 = Array [Test.10];
     ret Test.9;
 
 procedure Test.3 (Test.8, #Attr.12):
-    let Test.2 : I64 = StructAtIndex 0 #Attr.12;
+    let Test.2 : I64 = StructAtIndex 0 Test.12;
+    let Test.12 : {I64} = Struct {#Attr.12};
     ret Test.2;
 
 procedure Test.0 ():
     let Test.7 : {} = Struct {};
-    let Test.4 : List {I64} = CallByName Test.1 Test.7;
+    let Test.4 : List I64 = CallByName Test.1 Test.7;
     let Test.6 : U64 = CallByName List.6 Test.4;
     dec Test.4;
     ret Test.6;

--- a/crates/compiler/test_mono/generated/closure_in_list.txt
+++ b/crates/compiler/test_mono/generated/closure_in_list.txt
@@ -4,14 +4,10 @@ procedure List.6 (#Attr.2):
 
 procedure Test.1 (Test.5):
     let Test.2 : I64 = 41i64;
-    let Test.13 : {I64} = Struct {Test.2};
-    let Test.10 : I64 = StructAtIndex 0 Test.13;
-    let Test.9 : List I64 = Array [Test.10];
+    let Test.9 : List I64 = Array [Test.2];
     ret Test.9;
 
-procedure Test.3 (Test.8, #Attr.12):
-    let Test.12 : {I64} = Struct {#Attr.12};
-    let Test.2 : I64 = StructAtIndex 0 Test.12;
+procedure Test.3 (Test.8, Test.2):
     ret Test.2;
 
 procedure Test.0 ():

--- a/crates/compiler/test_mono/generated/encode.txt
+++ b/crates/compiler/test_mono/generated/encode.txt
@@ -12,16 +12,12 @@ procedure List.71 (#Attr.2, #Attr.3):
     let List.388 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
     ret List.388;
 
-procedure Test.23 (Test.24, Test.35, #Attr.12):
-    let Test.38 : {U8} = Struct {#Attr.12};
-    let Test.22 : U8 = StructAtIndex 0 Test.38;
+procedure Test.23 (Test.24, Test.35, Test.22):
     let Test.37 : List U8 = CallByName List.4 Test.24 Test.22;
     ret Test.37;
 
 procedure Test.8 (Test.22):
-    let Test.39 : {U8} = Struct {Test.22};
-    let Test.34 : U8 = StructAtIndex 0 Test.39;
-    ret Test.34;
+    ret Test.22;
 
 procedure Test.9 (Test.27):
     let Test.33 : U8 = CallByName Test.8 Test.27;

--- a/crates/compiler/test_mono/generated/encode.txt
+++ b/crates/compiler/test_mono/generated/encode.txt
@@ -13,21 +13,23 @@ procedure List.71 (#Attr.2, #Attr.3):
     ret List.388;
 
 procedure Test.23 (Test.24, Test.35, #Attr.12):
-    let Test.22 : U8 = StructAtIndex 0 #Attr.12;
+    let Test.38 : {U8} = Struct {#Attr.12};
+    let Test.22 : U8 = StructAtIndex 0 Test.38;
     let Test.37 : List U8 = CallByName List.4 Test.24 Test.22;
     ret Test.37;
 
 procedure Test.8 (Test.22):
-    let Test.34 : {U8} = Struct {Test.22};
+    let Test.39 : {U8} = Struct {Test.22};
+    let Test.34 : U8 = StructAtIndex 0 Test.39;
     ret Test.34;
 
 procedure Test.9 (Test.27):
-    let Test.33 : {U8} = CallByName Test.8 Test.27;
+    let Test.33 : U8 = CallByName Test.8 Test.27;
     ret Test.33;
 
 procedure Test.0 ():
     let Test.32 : U8 = 15i64;
-    let Test.28 : {U8} = CallByName Test.9 Test.32;
+    let Test.28 : U8 = CallByName Test.9 Test.32;
     let Test.30 : List U8 = Array [];
     let Test.31 : {} = Struct {};
     let Test.29 : List U8 = CallByName Test.23 Test.30 Test.31 Test.28;

--- a/crates/compiler/test_mono/generated/encode_derived_nested_record_string.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_nested_record_string.txt
@@ -1,16 +1,16 @@
 procedure #Derived.0 (#Derived.1):
+    let #Derived_gen.2 : {Str} = Struct {#Derived.1};
     let #Derived_gen.1 : Str = StructAtIndex 0 #Derived_gen.2;
     inc #Derived_gen.1;
     dec #Derived_gen.2;
-    let #Derived_gen.2 : {Str} = Struct {#Derived.1};
     let #Derived_gen.0 : Str = CallByName Encode.22 #Derived_gen.1;
     ret #Derived_gen.0;
 
 procedure #Derived.2 (#Derived.3, #Derived.4, #Attr.12):
+    let #Derived_gen.11 : {Str} = Struct {#Attr.12};
     let #Derived.1 : Str = StructAtIndex 0 #Derived_gen.11;
     inc #Derived.1;
     dec #Derived_gen.11;
-    let #Derived_gen.11 : {Str} = Struct {#Attr.12};
     let #Derived_gen.8 : Str = "a";
     let #Derived_gen.9 : Str = CallByName #Derived.5 #Derived.1;
     let #Derived_gen.7 : {Str, Str} = Struct {#Derived_gen.8, #Derived_gen.9};
@@ -20,18 +20,18 @@ procedure #Derived.2 (#Derived.3, #Derived.4, #Attr.12):
     ret #Derived_gen.4;
 
 procedure #Derived.5 (#Derived.6):
+    let #Derived_gen.18 : {Str} = Struct {#Derived.6};
     let #Derived_gen.17 : Str = StructAtIndex 0 #Derived_gen.18;
     inc #Derived_gen.17;
     dec #Derived_gen.18;
-    let #Derived_gen.18 : {Str} = Struct {#Derived.6};
     let #Derived_gen.16 : Str = CallByName Encode.22 #Derived_gen.17;
     ret #Derived_gen.16;
 
 procedure #Derived.7 (#Derived.8, #Derived.9, #Attr.12):
+    let #Derived_gen.27 : {Str} = Struct {#Attr.12};
     let #Derived.6 : Str = StructAtIndex 0 #Derived_gen.27;
     inc #Derived.6;
     dec #Derived_gen.27;
-    let #Derived_gen.27 : {Str} = Struct {#Attr.12};
     let #Derived_gen.24 : Str = "b";
     let #Derived_gen.25 : Str = CallByName Json.18 #Derived.6;
     let #Derived_gen.23 : {Str, Str} = Struct {#Derived_gen.24, #Derived_gen.25};
@@ -86,10 +86,10 @@ procedure Json.1 ():
     ret Json.318;
 
 procedure Json.103 (Json.104, Json.321, #Attr.12):
+    let Json.356 : {List {Str, Str}} = Struct {#Attr.12};
     let Json.102 : List {Str, Str} = StructAtIndex 0 Json.356;
     inc Json.102;
     dec Json.356;
-    let Json.356 : {List {Str, Str}} = Struct {#Attr.12};
     let Json.355 : I32 = 123i64;
     let Json.354 : U8 = CallByName Num.123 Json.355;
     let Json.106 : List U8 = CallByName List.4 Json.104 Json.354;
@@ -107,10 +107,10 @@ procedure Json.103 (Json.104, Json.321, #Attr.12):
     ret Json.326;
 
 procedure Json.103 (Json.104, Json.321, #Attr.12):
+    let Json.402 : {List {Str, Str}} = Struct {#Attr.12};
     let Json.102 : List {Str, Str} = StructAtIndex 0 Json.402;
     inc Json.102;
     dec Json.402;
-    let Json.402 : {List {Str, Str}} = Struct {#Attr.12};
     let Json.401 : I32 = 123i64;
     let Json.400 : U8 = CallByName Num.123 Json.401;
     let Json.106 : List U8 = CallByName List.4 Json.104 Json.400;
@@ -206,34 +206,34 @@ procedure Json.105 (Json.324, Json.325):
         jump Json.382 Json.113;
 
 procedure Json.18 (Json.86):
+    let Json.370 : {Str} = Struct {Json.86};
     let Json.368 : Str = StructAtIndex 0 Json.370;
     inc Json.368;
     dec Json.370;
-    let Json.370 : {Str} = Struct {Json.86};
     let Json.367 : Str = CallByName Encode.22 Json.368;
     ret Json.367;
 
 procedure Json.20 (Json.102):
+    let Json.322 : {List {Str, Str}} = Struct {Json.102};
     let Json.320 : List {Str, Str} = StructAtIndex 0 Json.322;
     inc Json.320;
     dec Json.322;
-    let Json.322 : {List {Str, Str}} = Struct {Json.102};
     let Json.319 : List {Str, Str} = CallByName Encode.22 Json.320;
     ret Json.319;
 
 procedure Json.20 (Json.102):
+    let Json.366 : {List {Str, Str}} = Struct {Json.102};
     let Json.364 : List {Str, Str} = StructAtIndex 0 Json.366;
     inc Json.364;
     dec Json.366;
-    let Json.366 : {List {Str, Str}} = Struct {Json.102};
     let Json.363 : List {Str, Str} = CallByName Encode.22 Json.364;
     ret Json.363;
 
 procedure Json.87 (Json.88, Json.369, #Attr.12):
+    let Json.412 : {Str} = Struct {#Attr.12};
     let Json.86 : Str = StructAtIndex 0 Json.412;
     inc Json.86;
     dec Json.412;
-    let Json.412 : {Str} = Struct {#Attr.12};
     let Json.411 : I32 = 34i64;
     let Json.410 : U8 = CallByName Num.123 Json.411;
     let Json.408 : List U8 = CallByName List.4 Json.88 Json.410;
@@ -245,22 +245,22 @@ procedure Json.87 (Json.88, Json.369, #Attr.12):
     ret Json.404;
 
 procedure List.133 (List.134, List.135, #Attr.12):
-    let List.132 : {} = StructAtIndex 0 List.436;
     let List.436 : {{}} = Struct {#Attr.12};
+    let List.132 : {} = StructAtIndex 0 List.436;
     let List.435 : {List U8, U64} = CallByName Json.105 List.134 List.135;
     let List.434 : [C [], C {List U8, U64}] = TagId(1) List.435;
     ret List.434;
 
 procedure List.133 (List.134, List.135, #Attr.12):
-    let List.132 : {} = StructAtIndex 0 List.519;
     let List.519 : {{}} = Struct {#Attr.12};
+    let List.132 : {} = StructAtIndex 0 List.519;
     let List.518 : {List U8, U64} = CallByName Json.105 List.134 List.135;
     let List.517 : [C [], C {List U8, U64}] = TagId(1) List.518;
     ret List.517;
 
 procedure List.18 (List.130, List.131, List.132):
-    let List.411 : {} = StructAtIndex 0 List.412;
     let List.412 : {{}} = Struct {List.132};
+    let List.411 : {} = StructAtIndex 0 List.412;
     let List.405 : [C [], C {List U8, U64}] = CallByName List.75 List.130 List.131 List.411;
     let List.408 : U8 = 1i64;
     let List.409 : U8 = GetTagId List.405;
@@ -277,8 +277,8 @@ procedure List.18 (List.130, List.131, List.132):
         ret List.407;
 
 procedure List.18 (List.130, List.131, List.132):
-    let List.493 : {} = StructAtIndex 0 List.494;
     let List.494 : {{}} = Struct {List.132};
+    let List.493 : {} = StructAtIndex 0 List.494;
     let List.487 : [C [], C {List U8, U64}] = CallByName List.75 List.130 List.131 List.493;
     let List.490 : U8 = 1i64;
     let List.491 : U8 = GetTagId List.487;

--- a/crates/compiler/test_mono/generated/encode_derived_nested_record_string.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_nested_record_string.txt
@@ -1,36 +1,44 @@
 procedure #Derived.0 (#Derived.1):
-    let #Derived_gen.1 : {Str} = Struct {#Derived.1};
-    let #Derived_gen.0 : {Str} = CallByName Encode.22 #Derived_gen.1;
+    let #Derived_gen.1 : Str = StructAtIndex 0 #Derived_gen.2;
+    inc #Derived_gen.1;
+    dec #Derived_gen.2;
+    let #Derived_gen.2 : {Str} = Struct {#Derived.1};
+    let #Derived_gen.0 : Str = CallByName Encode.22 #Derived_gen.1;
     ret #Derived_gen.0;
 
 procedure #Derived.2 (#Derived.3, #Derived.4, #Attr.12):
-    let #Derived.1 : Str = StructAtIndex 0 #Attr.12;
+    let #Derived.1 : Str = StructAtIndex 0 #Derived_gen.11;
     inc #Derived.1;
-    dec #Attr.12;
-    let #Derived_gen.7 : Str = "a";
-    let #Derived_gen.8 : {Str} = CallByName #Derived.5 #Derived.1;
-    let #Derived_gen.6 : {Str, {Str}} = Struct {#Derived_gen.7, #Derived_gen.8};
-    let #Derived_gen.5 : List {Str, {Str}} = Array [#Derived_gen.6];
-    let #Derived_gen.4 : {List {Str, {Str}}} = CallByName Json.20 #Derived_gen.5;
-    let #Derived_gen.3 : List U8 = CallByName Encode.23 #Derived.3 #Derived_gen.4 #Derived.4;
-    ret #Derived_gen.3;
+    dec #Derived_gen.11;
+    let #Derived_gen.11 : {Str} = Struct {#Attr.12};
+    let #Derived_gen.8 : Str = "a";
+    let #Derived_gen.9 : Str = CallByName #Derived.5 #Derived.1;
+    let #Derived_gen.7 : {Str, Str} = Struct {#Derived_gen.8, #Derived_gen.9};
+    let #Derived_gen.6 : List {Str, Str} = Array [#Derived_gen.7];
+    let #Derived_gen.5 : List {Str, Str} = CallByName Json.20 #Derived_gen.6;
+    let #Derived_gen.4 : List U8 = CallByName Encode.23 #Derived.3 #Derived_gen.5 #Derived.4;
+    ret #Derived_gen.4;
 
 procedure #Derived.5 (#Derived.6):
-    let #Derived_gen.15 : {Str} = Struct {#Derived.6};
-    let #Derived_gen.14 : {Str} = CallByName Encode.22 #Derived_gen.15;
-    ret #Derived_gen.14;
+    let #Derived_gen.17 : Str = StructAtIndex 0 #Derived_gen.18;
+    inc #Derived_gen.17;
+    dec #Derived_gen.18;
+    let #Derived_gen.18 : {Str} = Struct {#Derived.6};
+    let #Derived_gen.16 : Str = CallByName Encode.22 #Derived_gen.17;
+    ret #Derived_gen.16;
 
 procedure #Derived.7 (#Derived.8, #Derived.9, #Attr.12):
-    let #Derived.6 : Str = StructAtIndex 0 #Attr.12;
+    let #Derived.6 : Str = StructAtIndex 0 #Derived_gen.27;
     inc #Derived.6;
-    dec #Attr.12;
-    let #Derived_gen.21 : Str = "b";
-    let #Derived_gen.22 : {Str} = CallByName Json.18 #Derived.6;
-    let #Derived_gen.20 : {Str, {Str}} = Struct {#Derived_gen.21, #Derived_gen.22};
-    let #Derived_gen.19 : List {Str, {Str}} = Array [#Derived_gen.20];
-    let #Derived_gen.18 : {List {Str, {Str}}} = CallByName Json.20 #Derived_gen.19;
-    let #Derived_gen.17 : List U8 = CallByName Encode.23 #Derived.8 #Derived_gen.18 #Derived.9;
-    ret #Derived_gen.17;
+    dec #Derived_gen.27;
+    let #Derived_gen.27 : {Str} = Struct {#Attr.12};
+    let #Derived_gen.24 : Str = "b";
+    let #Derived_gen.25 : Str = CallByName Json.18 #Derived.6;
+    let #Derived_gen.23 : {Str, Str} = Struct {#Derived_gen.24, #Derived_gen.25};
+    let #Derived_gen.22 : List {Str, Str} = Array [#Derived_gen.23];
+    let #Derived_gen.21 : List {Str, Str} = CallByName Json.20 #Derived_gen.22;
+    let #Derived_gen.20 : List U8 = CallByName Encode.23 #Derived.8 #Derived_gen.21 #Derived.9;
+    ret #Derived_gen.20;
 
 procedure Encode.22 (Encode.93):
     ret Encode.93;
@@ -69,7 +77,7 @@ procedure Encode.23 (Encode.94, Encode.102, Encode.96):
 
 procedure Encode.25 (Encode.100, Encode.101):
     let Encode.104 : List U8 = Array [];
-    let Encode.105 : {Str} = CallByName #Derived.0 Encode.100;
+    let Encode.105 : Str = CallByName #Derived.0 Encode.100;
     let Encode.103 : List U8 = CallByName Encode.23 Encode.104 Encode.105 Encode.101;
     ret Encode.103;
 
@@ -78,166 +86,181 @@ procedure Json.1 ():
     ret Json.318;
 
 procedure Json.103 (Json.104, Json.321, #Attr.12):
-    let Json.102 : List {Str, {Str}} = StructAtIndex 0 #Attr.12;
+    let Json.102 : List {Str, Str} = StructAtIndex 0 Json.356;
     inc Json.102;
-    dec #Attr.12;
-    let Json.354 : I32 = 123i64;
-    let Json.353 : U8 = CallByName Num.123 Json.354;
-    let Json.106 : List U8 = CallByName List.4 Json.104 Json.353;
-    let Json.352 : U64 = CallByName List.6 Json.102;
-    let Json.329 : {List U8, U64} = Struct {Json.106, Json.352};
-    let Json.330 : {} = Struct {};
-    let Json.328 : {List U8, U64} = CallByName List.18 Json.102 Json.329 Json.330;
+    dec Json.356;
+    let Json.356 : {List {Str, Str}} = Struct {#Attr.12};
+    let Json.355 : I32 = 123i64;
+    let Json.354 : U8 = CallByName Num.123 Json.355;
+    let Json.106 : List U8 = CallByName List.4 Json.104 Json.354;
+    let Json.353 : U64 = CallByName List.6 Json.102;
+    let Json.330 : {List U8, U64} = Struct {Json.106, Json.353};
+    let Json.331 : {} = Struct {};
+    let Json.329 : {List U8, U64} = CallByName List.18 Json.102 Json.330 Json.331;
     dec Json.102;
-    let Json.108 : List U8 = StructAtIndex 0 Json.328;
+    let Json.108 : List U8 = StructAtIndex 0 Json.329;
     inc Json.108;
-    dec Json.328;
-    let Json.327 : I32 = 125i64;
-    let Json.326 : U8 = CallByName Num.123 Json.327;
-    let Json.325 : List U8 = CallByName List.4 Json.108 Json.326;
-    ret Json.325;
+    dec Json.329;
+    let Json.328 : I32 = 125i64;
+    let Json.327 : U8 = CallByName Num.123 Json.328;
+    let Json.326 : List U8 = CallByName List.4 Json.108 Json.327;
+    ret Json.326;
 
 procedure Json.103 (Json.104, Json.321, #Attr.12):
-    let Json.102 : List {Str, {Str}} = StructAtIndex 0 #Attr.12;
+    let Json.102 : List {Str, Str} = StructAtIndex 0 Json.402;
     inc Json.102;
-    dec #Attr.12;
-    let Json.397 : I32 = 123i64;
-    let Json.396 : U8 = CallByName Num.123 Json.397;
-    let Json.106 : List U8 = CallByName List.4 Json.104 Json.396;
-    let Json.395 : U64 = CallByName List.6 Json.102;
-    let Json.372 : {List U8, U64} = Struct {Json.106, Json.395};
-    let Json.373 : {} = Struct {};
-    let Json.371 : {List U8, U64} = CallByName List.18 Json.102 Json.372 Json.373;
+    dec Json.402;
+    let Json.402 : {List {Str, Str}} = Struct {#Attr.12};
+    let Json.401 : I32 = 123i64;
+    let Json.400 : U8 = CallByName Num.123 Json.401;
+    let Json.106 : List U8 = CallByName List.4 Json.104 Json.400;
+    let Json.399 : U64 = CallByName List.6 Json.102;
+    let Json.376 : {List U8, U64} = Struct {Json.106, Json.399};
+    let Json.377 : {} = Struct {};
+    let Json.375 : {List U8, U64} = CallByName List.18 Json.102 Json.376 Json.377;
     dec Json.102;
-    let Json.108 : List U8 = StructAtIndex 0 Json.371;
+    let Json.108 : List U8 = StructAtIndex 0 Json.375;
     inc Json.108;
-    dec Json.371;
-    let Json.370 : I32 = 125i64;
-    let Json.369 : U8 = CallByName Num.123 Json.370;
-    let Json.368 : List U8 = CallByName List.4 Json.108 Json.369;
-    ret Json.368;
+    dec Json.375;
+    let Json.374 : I32 = 125i64;
+    let Json.373 : U8 = CallByName Num.123 Json.374;
+    let Json.372 : List U8 = CallByName List.4 Json.108 Json.373;
+    ret Json.372;
 
-procedure Json.105 (Json.323, Json.324):
-    let Json.111 : Str = StructAtIndex 0 Json.324;
+procedure Json.105 (Json.324, Json.325):
+    let Json.111 : Str = StructAtIndex 0 Json.325;
     inc Json.111;
-    let Json.112 : {Str} = StructAtIndex 1 Json.324;
+    let Json.112 : Str = StructAtIndex 1 Json.325;
     inc Json.112;
-    dec Json.324;
-    let Json.109 : List U8 = StructAtIndex 0 Json.323;
+    dec Json.325;
+    let Json.109 : List U8 = StructAtIndex 0 Json.324;
     inc Json.109;
-    let Json.110 : U64 = StructAtIndex 1 Json.323;
-    dec Json.323;
-    let Json.351 : I32 = 34i64;
-    let Json.350 : U8 = CallByName Num.123 Json.351;
-    let Json.348 : List U8 = CallByName List.4 Json.109 Json.350;
-    let Json.349 : List U8 = CallByName Str.12 Json.111;
-    let Json.345 : List U8 = CallByName List.8 Json.348 Json.349;
-    let Json.347 : I32 = 34i64;
-    let Json.346 : U8 = CallByName Num.123 Json.347;
-    let Json.342 : List U8 = CallByName List.4 Json.345 Json.346;
-    let Json.344 : I32 = 58i64;
-    let Json.343 : U8 = CallByName Num.123 Json.344;
-    let Json.340 : List U8 = CallByName List.4 Json.342 Json.343;
-    let Json.341 : {} = Struct {};
-    let Json.113 : List U8 = CallByName Encode.23 Json.340 Json.112 Json.341;
-    joinpoint Json.335 Json.114:
-        let Json.333 : U64 = 1i64;
-        let Json.332 : U64 = CallByName Num.20 Json.110 Json.333;
-        let Json.331 : {List U8, U64} = Struct {Json.114, Json.332};
-        ret Json.331;
+    let Json.110 : U64 = StructAtIndex 1 Json.324;
+    dec Json.324;
+    let Json.352 : I32 = 34i64;
+    let Json.351 : U8 = CallByName Num.123 Json.352;
+    let Json.349 : List U8 = CallByName List.4 Json.109 Json.351;
+    let Json.350 : List U8 = CallByName Str.12 Json.111;
+    let Json.346 : List U8 = CallByName List.8 Json.349 Json.350;
+    let Json.348 : I32 = 34i64;
+    let Json.347 : U8 = CallByName Num.123 Json.348;
+    let Json.343 : List U8 = CallByName List.4 Json.346 Json.347;
+    let Json.345 : I32 = 58i64;
+    let Json.344 : U8 = CallByName Num.123 Json.345;
+    let Json.341 : List U8 = CallByName List.4 Json.343 Json.344;
+    let Json.342 : {} = Struct {};
+    let Json.113 : List U8 = CallByName Encode.23 Json.341 Json.112 Json.342;
+    joinpoint Json.336 Json.114:
+        let Json.334 : U64 = 1i64;
+        let Json.333 : U64 = CallByName Num.20 Json.110 Json.334;
+        let Json.332 : {List U8, U64} = Struct {Json.114, Json.333};
+        ret Json.332;
     in
-    let Json.339 : U64 = 1i64;
-    let Json.336 : Int1 = CallByName Num.24 Json.110 Json.339;
-    if Json.336 then
-        let Json.338 : I32 = 44i64;
-        let Json.337 : U8 = CallByName Num.123 Json.338;
-        let Json.334 : List U8 = CallByName List.4 Json.113 Json.337;
-        jump Json.335 Json.334;
+    let Json.340 : U64 = 1i64;
+    let Json.337 : Int1 = CallByName Num.24 Json.110 Json.340;
+    if Json.337 then
+        let Json.339 : I32 = 44i64;
+        let Json.338 : U8 = CallByName Num.123 Json.339;
+        let Json.335 : List U8 = CallByName List.4 Json.113 Json.338;
+        jump Json.336 Json.335;
     else
-        jump Json.335 Json.113;
+        jump Json.336 Json.113;
 
-procedure Json.105 (Json.323, Json.324):
-    let Json.111 : Str = StructAtIndex 0 Json.324;
+procedure Json.105 (Json.324, Json.325):
+    let Json.111 : Str = StructAtIndex 0 Json.325;
     inc Json.111;
-    let Json.112 : {Str} = StructAtIndex 1 Json.324;
+    let Json.112 : Str = StructAtIndex 1 Json.325;
     inc Json.112;
-    dec Json.324;
-    let Json.109 : List U8 = StructAtIndex 0 Json.323;
+    dec Json.325;
+    let Json.109 : List U8 = StructAtIndex 0 Json.324;
     inc Json.109;
-    let Json.110 : U64 = StructAtIndex 1 Json.323;
-    dec Json.323;
+    let Json.110 : U64 = StructAtIndex 1 Json.324;
+    dec Json.324;
+    let Json.398 : I32 = 34i64;
+    let Json.397 : U8 = CallByName Num.123 Json.398;
+    let Json.395 : List U8 = CallByName List.4 Json.109 Json.397;
+    let Json.396 : List U8 = CallByName Str.12 Json.111;
+    let Json.392 : List U8 = CallByName List.8 Json.395 Json.396;
     let Json.394 : I32 = 34i64;
     let Json.393 : U8 = CallByName Num.123 Json.394;
-    let Json.391 : List U8 = CallByName List.4 Json.109 Json.393;
-    let Json.392 : List U8 = CallByName Str.12 Json.111;
-    let Json.388 : List U8 = CallByName List.8 Json.391 Json.392;
-    let Json.390 : I32 = 34i64;
-    let Json.389 : U8 = CallByName Num.123 Json.390;
-    let Json.385 : List U8 = CallByName List.4 Json.388 Json.389;
-    let Json.387 : I32 = 58i64;
-    let Json.386 : U8 = CallByName Num.123 Json.387;
-    let Json.383 : List U8 = CallByName List.4 Json.385 Json.386;
-    let Json.384 : {} = Struct {};
-    let Json.113 : List U8 = CallByName Encode.23 Json.383 Json.112 Json.384;
-    joinpoint Json.378 Json.114:
-        let Json.376 : U64 = 1i64;
-        let Json.375 : U64 = CallByName Num.20 Json.110 Json.376;
-        let Json.374 : {List U8, U64} = Struct {Json.114, Json.375};
-        ret Json.374;
+    let Json.389 : List U8 = CallByName List.4 Json.392 Json.393;
+    let Json.391 : I32 = 58i64;
+    let Json.390 : U8 = CallByName Num.123 Json.391;
+    let Json.387 : List U8 = CallByName List.4 Json.389 Json.390;
+    let Json.388 : {} = Struct {};
+    let Json.113 : List U8 = CallByName Encode.23 Json.387 Json.112 Json.388;
+    joinpoint Json.382 Json.114:
+        let Json.380 : U64 = 1i64;
+        let Json.379 : U64 = CallByName Num.20 Json.110 Json.380;
+        let Json.378 : {List U8, U64} = Struct {Json.114, Json.379};
+        ret Json.378;
     in
-    let Json.382 : U64 = 1i64;
-    let Json.379 : Int1 = CallByName Num.24 Json.110 Json.382;
-    if Json.379 then
-        let Json.381 : I32 = 44i64;
-        let Json.380 : U8 = CallByName Num.123 Json.381;
-        let Json.377 : List U8 = CallByName List.4 Json.113 Json.380;
-        jump Json.378 Json.377;
+    let Json.386 : U64 = 1i64;
+    let Json.383 : Int1 = CallByName Num.24 Json.110 Json.386;
+    if Json.383 then
+        let Json.385 : I32 = 44i64;
+        let Json.384 : U8 = CallByName Num.123 Json.385;
+        let Json.381 : List U8 = CallByName List.4 Json.113 Json.384;
+        jump Json.382 Json.381;
     else
-        jump Json.378 Json.113;
+        jump Json.382 Json.113;
 
 procedure Json.18 (Json.86):
-    let Json.365 : {Str} = Struct {Json.86};
-    let Json.364 : {Str} = CallByName Encode.22 Json.365;
-    ret Json.364;
+    let Json.368 : Str = StructAtIndex 0 Json.370;
+    inc Json.368;
+    dec Json.370;
+    let Json.370 : {Str} = Struct {Json.86};
+    let Json.367 : Str = CallByName Encode.22 Json.368;
+    ret Json.367;
 
 procedure Json.20 (Json.102):
-    let Json.320 : {List {Str, {Str}}} = Struct {Json.102};
-    let Json.319 : {List {Str, {Str}}} = CallByName Encode.22 Json.320;
+    let Json.320 : List {Str, Str} = StructAtIndex 0 Json.322;
+    inc Json.320;
+    dec Json.322;
+    let Json.322 : {List {Str, Str}} = Struct {Json.102};
+    let Json.319 : List {Str, Str} = CallByName Encode.22 Json.320;
     ret Json.319;
 
 procedure Json.20 (Json.102):
-    let Json.362 : {List {Str, {Str}}} = Struct {Json.102};
-    let Json.361 : {List {Str, {Str}}} = CallByName Encode.22 Json.362;
-    ret Json.361;
+    let Json.364 : List {Str, Str} = StructAtIndex 0 Json.366;
+    inc Json.364;
+    dec Json.366;
+    let Json.366 : {List {Str, Str}} = Struct {Json.102};
+    let Json.363 : List {Str, Str} = CallByName Encode.22 Json.364;
+    ret Json.363;
 
-procedure Json.87 (Json.88, Json.366, #Attr.12):
-    let Json.86 : Str = StructAtIndex 0 #Attr.12;
+procedure Json.87 (Json.88, Json.369, #Attr.12):
+    let Json.86 : Str = StructAtIndex 0 Json.412;
     inc Json.86;
-    dec #Attr.12;
-    let Json.406 : I32 = 34i64;
-    let Json.405 : U8 = CallByName Num.123 Json.406;
-    let Json.403 : List U8 = CallByName List.4 Json.88 Json.405;
-    let Json.404 : List U8 = CallByName Str.12 Json.86;
-    let Json.400 : List U8 = CallByName List.8 Json.403 Json.404;
-    let Json.402 : I32 = 34i64;
-    let Json.401 : U8 = CallByName Num.123 Json.402;
-    let Json.399 : List U8 = CallByName List.4 Json.400 Json.401;
-    ret Json.399;
+    dec Json.412;
+    let Json.412 : {Str} = Struct {#Attr.12};
+    let Json.411 : I32 = 34i64;
+    let Json.410 : U8 = CallByName Num.123 Json.411;
+    let Json.408 : List U8 = CallByName List.4 Json.88 Json.410;
+    let Json.409 : List U8 = CallByName Str.12 Json.86;
+    let Json.405 : List U8 = CallByName List.8 Json.408 Json.409;
+    let Json.407 : I32 = 34i64;
+    let Json.406 : U8 = CallByName Num.123 Json.407;
+    let Json.404 : List U8 = CallByName List.4 Json.405 Json.406;
+    ret Json.404;
 
 procedure List.133 (List.134, List.135, #Attr.12):
-    let List.132 : {} = StructAtIndex 0 #Attr.12;
-    let List.434 : {List U8, U64} = CallByName Json.105 List.134 List.135;
-    let List.433 : [C [], C {List U8, U64}] = TagId(1) List.434;
-    ret List.433;
+    let List.132 : {} = StructAtIndex 0 List.436;
+    let List.436 : {{}} = Struct {#Attr.12};
+    let List.435 : {List U8, U64} = CallByName Json.105 List.134 List.135;
+    let List.434 : [C [], C {List U8, U64}] = TagId(1) List.435;
+    ret List.434;
 
 procedure List.133 (List.134, List.135, #Attr.12):
-    let List.132 : {} = StructAtIndex 0 #Attr.12;
-    let List.515 : {List U8, U64} = CallByName Json.105 List.134 List.135;
-    let List.514 : [C [], C {List U8, U64}] = TagId(1) List.515;
-    ret List.514;
+    let List.132 : {} = StructAtIndex 0 List.519;
+    let List.519 : {{}} = Struct {#Attr.12};
+    let List.518 : {List U8, U64} = CallByName Json.105 List.134 List.135;
+    let List.517 : [C [], C {List U8, U64}] = TagId(1) List.518;
+    ret List.517;
 
 procedure List.18 (List.130, List.131, List.132):
-    let List.411 : {{}} = Struct {List.132};
+    let List.411 : {} = StructAtIndex 0 List.412;
+    let List.412 : {{}} = Struct {List.132};
     let List.405 : [C [], C {List U8, U64}] = CallByName List.75 List.130 List.131 List.411;
     let List.408 : U8 = 1i64;
     let List.409 : U8 = GetTagId List.405;
@@ -254,129 +277,130 @@ procedure List.18 (List.130, List.131, List.132):
         ret List.407;
 
 procedure List.18 (List.130, List.131, List.132):
-    let List.491 : {{}} = Struct {List.132};
-    let List.485 : [C [], C {List U8, U64}] = CallByName List.75 List.130 List.131 List.491;
-    let List.488 : U8 = 1i64;
-    let List.489 : U8 = GetTagId List.485;
-    let List.490 : Int1 = lowlevel Eq List.488 List.489;
-    if List.490 then
-        let List.137 : {List U8, U64} = UnionAtIndex (Id 1) (Index 0) List.485;
+    let List.493 : {} = StructAtIndex 0 List.494;
+    let List.494 : {{}} = Struct {List.132};
+    let List.487 : [C [], C {List U8, U64}] = CallByName List.75 List.130 List.131 List.493;
+    let List.490 : U8 = 1i64;
+    let List.491 : U8 = GetTagId List.487;
+    let List.492 : Int1 = lowlevel Eq List.490 List.491;
+    if List.492 then
+        let List.137 : {List U8, U64} = UnionAtIndex (Id 1) (Index 0) List.487;
         inc List.137;
-        dec List.485;
+        dec List.487;
         ret List.137;
     else
-        let List.138 : [] = UnionAtIndex (Id 0) (Index 0) List.485;
-        dec List.485;
-        let List.487 : {List U8, U64} = CallByName List.69 List.138;
-        ret List.487;
+        let List.138 : [] = UnionAtIndex (Id 0) (Index 0) List.487;
+        dec List.487;
+        let List.489 : {List U8, U64} = CallByName List.69 List.138;
+        ret List.489;
 
 procedure List.4 (List.101, List.102):
-    let List.484 : U64 = 1i64;
-    let List.483 : List U8 = CallByName List.70 List.101 List.484;
-    let List.482 : List U8 = CallByName List.71 List.483 List.102;
-    ret List.482;
+    let List.486 : U64 = 1i64;
+    let List.485 : List U8 = CallByName List.70 List.101 List.486;
+    let List.484 : List U8 = CallByName List.71 List.485 List.102;
+    ret List.484;
 
 procedure List.6 (#Attr.2):
     let List.385 : U64 = lowlevel ListLen #Attr.2;
     ret List.385;
 
 procedure List.6 (#Attr.2):
-    let List.413 : U64 = lowlevel ListLen #Attr.2;
-    ret List.413;
+    let List.414 : U64 = lowlevel ListLen #Attr.2;
+    ret List.414;
 
 procedure List.6 (#Attr.2):
-    let List.494 : U64 = lowlevel ListLen #Attr.2;
-    ret List.494;
-
-procedure List.66 (#Attr.2, #Attr.3):
-    let List.432 : {Str, {Str}} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.432;
-
-procedure List.66 (#Attr.2, #Attr.3):
-    let List.513 : {Str, {Str}} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.513;
-
-procedure List.69 (#Attr.2):
-    let List.497 : {List U8, U64} = lowlevel Unreachable #Attr.2;
+    let List.497 : U64 = lowlevel ListLen #Attr.2;
     ret List.497;
 
+procedure List.66 (#Attr.2, #Attr.3):
+    let List.433 : {Str, Str} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.433;
+
+procedure List.66 (#Attr.2, #Attr.3):
+    let List.516 : {Str, Str} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.516;
+
+procedure List.69 (#Attr.2):
+    let List.500 : {List U8, U64} = lowlevel Unreachable #Attr.2;
+    ret List.500;
+
 procedure List.70 (#Attr.2, #Attr.3):
-    let List.496 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
-    ret List.496;
+    let List.499 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
+    ret List.499;
 
 procedure List.71 (#Attr.2, #Attr.3):
-    let List.495 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
-    ret List.495;
-
-procedure List.75 (List.361, List.362, List.363):
-    let List.418 : U64 = 0i64;
-    let List.419 : U64 = CallByName List.6 List.361;
-    let List.417 : [C [], C {List U8, U64}] = CallByName List.86 List.361 List.362 List.363 List.418 List.419;
-    ret List.417;
-
-procedure List.75 (List.361, List.362, List.363):
-    let List.499 : U64 = 0i64;
-    let List.500 : U64 = CallByName List.6 List.361;
-    let List.498 : [C [], C {List U8, U64}] = CallByName List.86 List.361 List.362 List.363 List.499 List.500;
+    let List.498 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
     ret List.498;
 
+procedure List.75 (List.361, List.362, List.363):
+    let List.419 : U64 = 0i64;
+    let List.420 : U64 = CallByName List.6 List.361;
+    let List.418 : [C [], C {List U8, U64}] = CallByName List.86 List.361 List.362 List.363 List.419 List.420;
+    ret List.418;
+
+procedure List.75 (List.361, List.362, List.363):
+    let List.502 : U64 = 0i64;
+    let List.503 : U64 = CallByName List.6 List.361;
+    let List.501 : [C [], C {List U8, U64}] = CallByName List.86 List.361 List.362 List.363 List.502 List.503;
+    ret List.501;
+
 procedure List.8 (#Attr.2, #Attr.3):
-    let List.493 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
-    ret List.493;
+    let List.496 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
+    ret List.496;
 
-procedure List.86 (List.448, List.449, List.450, List.451, List.452):
-    joinpoint List.420 List.364 List.365 List.366 List.367 List.368:
-        let List.422 : Int1 = CallByName Num.22 List.367 List.368;
-        if List.422 then
-            let List.431 : {Str, {Str}} = CallByName List.66 List.364 List.367;
-            let List.423 : [C [], C {List U8, U64}] = CallByName List.133 List.365 List.431 List.366;
-            let List.428 : U8 = 1i64;
-            let List.429 : U8 = GetTagId List.423;
-            let List.430 : Int1 = lowlevel Eq List.428 List.429;
-            if List.430 then
-                let List.369 : {List U8, U64} = UnionAtIndex (Id 1) (Index 0) List.423;
+procedure List.86 (List.450, List.451, List.452, List.453, List.454):
+    joinpoint List.421 List.364 List.365 List.366 List.367 List.368:
+        let List.423 : Int1 = CallByName Num.22 List.367 List.368;
+        if List.423 then
+            let List.432 : {Str, Str} = CallByName List.66 List.364 List.367;
+            let List.424 : [C [], C {List U8, U64}] = CallByName List.133 List.365 List.432 List.366;
+            let List.429 : U8 = 1i64;
+            let List.430 : U8 = GetTagId List.424;
+            let List.431 : Int1 = lowlevel Eq List.429 List.430;
+            if List.431 then
+                let List.369 : {List U8, U64} = UnionAtIndex (Id 1) (Index 0) List.424;
                 inc List.369;
-                dec List.423;
-                let List.426 : U64 = 1i64;
-                let List.425 : U64 = CallByName Num.19 List.367 List.426;
-                jump List.420 List.364 List.369 List.366 List.425 List.368;
+                dec List.424;
+                let List.427 : U64 = 1i64;
+                let List.426 : U64 = CallByName Num.19 List.367 List.427;
+                jump List.421 List.364 List.369 List.366 List.426 List.368;
             else
-                let List.370 : [] = UnionAtIndex (Id 0) (Index 0) List.423;
-                dec List.423;
-                let List.427 : [C [], C {List U8, U64}] = TagId(0) List.370;
-                ret List.427;
+                let List.370 : [] = UnionAtIndex (Id 0) (Index 0) List.424;
+                dec List.424;
+                let List.428 : [C [], C {List U8, U64}] = TagId(0) List.370;
+                ret List.428;
         else
-            let List.421 : [C [], C {List U8, U64}] = TagId(1) List.365;
-            ret List.421;
+            let List.422 : [C [], C {List U8, U64}] = TagId(1) List.365;
+            ret List.422;
     in
-    jump List.420 List.448 List.449 List.450 List.451 List.452;
+    jump List.421 List.450 List.451 List.452 List.453 List.454;
 
-procedure List.86 (List.529, List.530, List.531, List.532, List.533):
-    joinpoint List.501 List.364 List.365 List.366 List.367 List.368:
-        let List.503 : Int1 = CallByName Num.22 List.367 List.368;
-        if List.503 then
-            let List.512 : {Str, {Str}} = CallByName List.66 List.364 List.367;
-            let List.504 : [C [], C {List U8, U64}] = CallByName List.133 List.365 List.512 List.366;
-            let List.509 : U8 = 1i64;
-            let List.510 : U8 = GetTagId List.504;
-            let List.511 : Int1 = lowlevel Eq List.509 List.510;
-            if List.511 then
-                let List.369 : {List U8, U64} = UnionAtIndex (Id 1) (Index 0) List.504;
+procedure List.86 (List.533, List.534, List.535, List.536, List.537):
+    joinpoint List.504 List.364 List.365 List.366 List.367 List.368:
+        let List.506 : Int1 = CallByName Num.22 List.367 List.368;
+        if List.506 then
+            let List.515 : {Str, Str} = CallByName List.66 List.364 List.367;
+            let List.507 : [C [], C {List U8, U64}] = CallByName List.133 List.365 List.515 List.366;
+            let List.512 : U8 = 1i64;
+            let List.513 : U8 = GetTagId List.507;
+            let List.514 : Int1 = lowlevel Eq List.512 List.513;
+            if List.514 then
+                let List.369 : {List U8, U64} = UnionAtIndex (Id 1) (Index 0) List.507;
                 inc List.369;
-                dec List.504;
-                let List.507 : U64 = 1i64;
-                let List.506 : U64 = CallByName Num.19 List.367 List.507;
-                jump List.501 List.364 List.369 List.366 List.506 List.368;
+                dec List.507;
+                let List.510 : U64 = 1i64;
+                let List.509 : U64 = CallByName Num.19 List.367 List.510;
+                jump List.504 List.364 List.369 List.366 List.509 List.368;
             else
-                let List.370 : [] = UnionAtIndex (Id 0) (Index 0) List.504;
-                dec List.504;
-                let List.508 : [C [], C {List U8, U64}] = TagId(0) List.370;
-                ret List.508;
+                let List.370 : [] = UnionAtIndex (Id 0) (Index 0) List.507;
+                dec List.507;
+                let List.511 : [C [], C {List U8, U64}] = TagId(0) List.370;
+                ret List.511;
         else
-            let List.502 : [C [], C {List U8, U64}] = TagId(1) List.365;
-            ret List.502;
+            let List.505 : [C [], C {List U8, U64}] = TagId(1) List.365;
+            ret List.505;
     in
-    jump List.501 List.529 List.530 List.531 List.532 List.533;
+    jump List.504 List.533 List.534 List.535 List.536 List.537;
 
 procedure Num.123 (#Attr.2):
     let Num.283 : U8 = lowlevel NumIntCast #Attr.2;

--- a/crates/compiler/test_mono/generated/encode_derived_nested_record_string.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_nested_record_string.txt
@@ -1,44 +1,28 @@
 procedure #Derived.0 (#Derived.1):
-    let #Derived_gen.2 : {Str} = Struct {#Derived.1};
-    let #Derived_gen.1 : Str = StructAtIndex 0 #Derived_gen.2;
-    inc #Derived_gen.1;
-    dec #Derived_gen.2;
-    let #Derived_gen.0 : Str = CallByName Encode.22 #Derived_gen.1;
+    let #Derived_gen.0 : Str = CallByName Encode.22 #Derived.1;
     ret #Derived_gen.0;
 
-procedure #Derived.2 (#Derived.3, #Derived.4, #Attr.12):
-    let #Derived_gen.11 : {Str} = Struct {#Attr.12};
-    let #Derived.1 : Str = StructAtIndex 0 #Derived_gen.11;
-    inc #Derived.1;
-    dec #Derived_gen.11;
-    let #Derived_gen.8 : Str = "a";
-    let #Derived_gen.9 : Str = CallByName #Derived.5 #Derived.1;
-    let #Derived_gen.7 : {Str, Str} = Struct {#Derived_gen.8, #Derived_gen.9};
-    let #Derived_gen.6 : List {Str, Str} = Array [#Derived_gen.7];
-    let #Derived_gen.5 : List {Str, Str} = CallByName Json.20 #Derived_gen.6;
-    let #Derived_gen.4 : List U8 = CallByName Encode.23 #Derived.3 #Derived_gen.5 #Derived.4;
-    ret #Derived_gen.4;
+procedure #Derived.2 (#Derived.3, #Derived.4, #Derived.1):
+    let #Derived_gen.7 : Str = "a";
+    let #Derived_gen.8 : Str = CallByName #Derived.5 #Derived.1;
+    let #Derived_gen.6 : {Str, Str} = Struct {#Derived_gen.7, #Derived_gen.8};
+    let #Derived_gen.5 : List {Str, Str} = Array [#Derived_gen.6];
+    let #Derived_gen.4 : List {Str, Str} = CallByName Json.20 #Derived_gen.5;
+    let #Derived_gen.3 : List U8 = CallByName Encode.23 #Derived.3 #Derived_gen.4 #Derived.4;
+    ret #Derived_gen.3;
 
 procedure #Derived.5 (#Derived.6):
-    let #Derived_gen.18 : {Str} = Struct {#Derived.6};
-    let #Derived_gen.17 : Str = StructAtIndex 0 #Derived_gen.18;
-    inc #Derived_gen.17;
-    dec #Derived_gen.18;
-    let #Derived_gen.16 : Str = CallByName Encode.22 #Derived_gen.17;
-    ret #Derived_gen.16;
+    let #Derived_gen.14 : Str = CallByName Encode.22 #Derived.6;
+    ret #Derived_gen.14;
 
-procedure #Derived.7 (#Derived.8, #Derived.9, #Attr.12):
-    let #Derived_gen.27 : {Str} = Struct {#Attr.12};
-    let #Derived.6 : Str = StructAtIndex 0 #Derived_gen.27;
-    inc #Derived.6;
-    dec #Derived_gen.27;
-    let #Derived_gen.24 : Str = "b";
-    let #Derived_gen.25 : Str = CallByName Json.18 #Derived.6;
-    let #Derived_gen.23 : {Str, Str} = Struct {#Derived_gen.24, #Derived_gen.25};
-    let #Derived_gen.22 : List {Str, Str} = Array [#Derived_gen.23];
-    let #Derived_gen.21 : List {Str, Str} = CallByName Json.20 #Derived_gen.22;
-    let #Derived_gen.20 : List U8 = CallByName Encode.23 #Derived.8 #Derived_gen.21 #Derived.9;
-    ret #Derived_gen.20;
+procedure #Derived.7 (#Derived.8, #Derived.9, #Derived.6):
+    let #Derived_gen.21 : Str = "b";
+    let #Derived_gen.22 : Str = CallByName Json.18 #Derived.6;
+    let #Derived_gen.20 : {Str, Str} = Struct {#Derived_gen.21, #Derived_gen.22};
+    let #Derived_gen.19 : List {Str, Str} = Array [#Derived_gen.20];
+    let #Derived_gen.18 : List {Str, Str} = CallByName Json.20 #Derived_gen.19;
+    let #Derived_gen.17 : List U8 = CallByName Encode.23 #Derived.8 #Derived_gen.18 #Derived.9;
+    ret #Derived_gen.17;
 
 procedure Encode.22 (Encode.93):
     ret Encode.93;
@@ -85,183 +69,153 @@ procedure Json.1 ():
     let Json.318 : {} = Struct {};
     ret Json.318;
 
-procedure Json.103 (Json.104, Json.321, #Attr.12):
-    let Json.356 : {List {Str, Str}} = Struct {#Attr.12};
-    let Json.102 : List {Str, Str} = StructAtIndex 0 Json.356;
-    inc Json.102;
-    dec Json.356;
-    let Json.355 : I32 = 123i64;
-    let Json.354 : U8 = CallByName Num.123 Json.355;
-    let Json.106 : List U8 = CallByName List.4 Json.104 Json.354;
-    let Json.353 : U64 = CallByName List.6 Json.102;
-    let Json.330 : {List U8, U64} = Struct {Json.106, Json.353};
-    let Json.331 : {} = Struct {};
-    let Json.329 : {List U8, U64} = CallByName List.18 Json.102 Json.330 Json.331;
+procedure Json.103 (Json.104, Json.321, Json.102):
+    let Json.354 : I32 = 123i64;
+    let Json.353 : U8 = CallByName Num.123 Json.354;
+    let Json.106 : List U8 = CallByName List.4 Json.104 Json.353;
+    let Json.352 : U64 = CallByName List.6 Json.102;
+    let Json.329 : {List U8, U64} = Struct {Json.106, Json.352};
+    let Json.330 : {} = Struct {};
+    let Json.328 : {List U8, U64} = CallByName List.18 Json.102 Json.329 Json.330;
     dec Json.102;
-    let Json.108 : List U8 = StructAtIndex 0 Json.329;
+    let Json.108 : List U8 = StructAtIndex 0 Json.328;
     inc Json.108;
-    dec Json.329;
-    let Json.328 : I32 = 125i64;
-    let Json.327 : U8 = CallByName Num.123 Json.328;
-    let Json.326 : List U8 = CallByName List.4 Json.108 Json.327;
-    ret Json.326;
+    dec Json.328;
+    let Json.327 : I32 = 125i64;
+    let Json.326 : U8 = CallByName Num.123 Json.327;
+    let Json.325 : List U8 = CallByName List.4 Json.108 Json.326;
+    ret Json.325;
 
-procedure Json.103 (Json.104, Json.321, #Attr.12):
-    let Json.402 : {List {Str, Str}} = Struct {#Attr.12};
-    let Json.102 : List {Str, Str} = StructAtIndex 0 Json.402;
-    inc Json.102;
-    dec Json.402;
-    let Json.401 : I32 = 123i64;
-    let Json.400 : U8 = CallByName Num.123 Json.401;
-    let Json.106 : List U8 = CallByName List.4 Json.104 Json.400;
-    let Json.399 : U64 = CallByName List.6 Json.102;
-    let Json.376 : {List U8, U64} = Struct {Json.106, Json.399};
-    let Json.377 : {} = Struct {};
-    let Json.375 : {List U8, U64} = CallByName List.18 Json.102 Json.376 Json.377;
+procedure Json.103 (Json.104, Json.321, Json.102):
+    let Json.397 : I32 = 123i64;
+    let Json.396 : U8 = CallByName Num.123 Json.397;
+    let Json.106 : List U8 = CallByName List.4 Json.104 Json.396;
+    let Json.395 : U64 = CallByName List.6 Json.102;
+    let Json.372 : {List U8, U64} = Struct {Json.106, Json.395};
+    let Json.373 : {} = Struct {};
+    let Json.371 : {List U8, U64} = CallByName List.18 Json.102 Json.372 Json.373;
     dec Json.102;
-    let Json.108 : List U8 = StructAtIndex 0 Json.375;
+    let Json.108 : List U8 = StructAtIndex 0 Json.371;
     inc Json.108;
-    dec Json.375;
-    let Json.374 : I32 = 125i64;
-    let Json.373 : U8 = CallByName Num.123 Json.374;
-    let Json.372 : List U8 = CallByName List.4 Json.108 Json.373;
-    ret Json.372;
+    dec Json.371;
+    let Json.370 : I32 = 125i64;
+    let Json.369 : U8 = CallByName Num.123 Json.370;
+    let Json.368 : List U8 = CallByName List.4 Json.108 Json.369;
+    ret Json.368;
 
-procedure Json.105 (Json.324, Json.325):
-    let Json.111 : Str = StructAtIndex 0 Json.325;
+procedure Json.105 (Json.323, Json.324):
+    let Json.111 : Str = StructAtIndex 0 Json.324;
     inc Json.111;
-    let Json.112 : Str = StructAtIndex 1 Json.325;
+    let Json.112 : Str = StructAtIndex 1 Json.324;
     inc Json.112;
-    dec Json.325;
-    let Json.109 : List U8 = StructAtIndex 0 Json.324;
-    inc Json.109;
-    let Json.110 : U64 = StructAtIndex 1 Json.324;
     dec Json.324;
-    let Json.352 : I32 = 34i64;
-    let Json.351 : U8 = CallByName Num.123 Json.352;
-    let Json.349 : List U8 = CallByName List.4 Json.109 Json.351;
-    let Json.350 : List U8 = CallByName Str.12 Json.111;
-    let Json.346 : List U8 = CallByName List.8 Json.349 Json.350;
-    let Json.348 : I32 = 34i64;
-    let Json.347 : U8 = CallByName Num.123 Json.348;
-    let Json.343 : List U8 = CallByName List.4 Json.346 Json.347;
-    let Json.345 : I32 = 58i64;
-    let Json.344 : U8 = CallByName Num.123 Json.345;
-    let Json.341 : List U8 = CallByName List.4 Json.343 Json.344;
-    let Json.342 : {} = Struct {};
-    let Json.113 : List U8 = CallByName Encode.23 Json.341 Json.112 Json.342;
-    joinpoint Json.336 Json.114:
-        let Json.334 : U64 = 1i64;
-        let Json.333 : U64 = CallByName Num.20 Json.110 Json.334;
-        let Json.332 : {List U8, U64} = Struct {Json.114, Json.333};
-        ret Json.332;
+    let Json.109 : List U8 = StructAtIndex 0 Json.323;
+    inc Json.109;
+    let Json.110 : U64 = StructAtIndex 1 Json.323;
+    dec Json.323;
+    let Json.351 : I32 = 34i64;
+    let Json.350 : U8 = CallByName Num.123 Json.351;
+    let Json.348 : List U8 = CallByName List.4 Json.109 Json.350;
+    let Json.349 : List U8 = CallByName Str.12 Json.111;
+    let Json.345 : List U8 = CallByName List.8 Json.348 Json.349;
+    let Json.347 : I32 = 34i64;
+    let Json.346 : U8 = CallByName Num.123 Json.347;
+    let Json.342 : List U8 = CallByName List.4 Json.345 Json.346;
+    let Json.344 : I32 = 58i64;
+    let Json.343 : U8 = CallByName Num.123 Json.344;
+    let Json.340 : List U8 = CallByName List.4 Json.342 Json.343;
+    let Json.341 : {} = Struct {};
+    let Json.113 : List U8 = CallByName Encode.23 Json.340 Json.112 Json.341;
+    joinpoint Json.335 Json.114:
+        let Json.333 : U64 = 1i64;
+        let Json.332 : U64 = CallByName Num.20 Json.110 Json.333;
+        let Json.331 : {List U8, U64} = Struct {Json.114, Json.332};
+        ret Json.331;
     in
-    let Json.340 : U64 = 1i64;
-    let Json.337 : Int1 = CallByName Num.24 Json.110 Json.340;
-    if Json.337 then
-        let Json.339 : I32 = 44i64;
-        let Json.338 : U8 = CallByName Num.123 Json.339;
-        let Json.335 : List U8 = CallByName List.4 Json.113 Json.338;
-        jump Json.336 Json.335;
+    let Json.339 : U64 = 1i64;
+    let Json.336 : Int1 = CallByName Num.24 Json.110 Json.339;
+    if Json.336 then
+        let Json.338 : I32 = 44i64;
+        let Json.337 : U8 = CallByName Num.123 Json.338;
+        let Json.334 : List U8 = CallByName List.4 Json.113 Json.337;
+        jump Json.335 Json.334;
     else
-        jump Json.336 Json.113;
+        jump Json.335 Json.113;
 
-procedure Json.105 (Json.324, Json.325):
-    let Json.111 : Str = StructAtIndex 0 Json.325;
+procedure Json.105 (Json.323, Json.324):
+    let Json.111 : Str = StructAtIndex 0 Json.324;
     inc Json.111;
-    let Json.112 : Str = StructAtIndex 1 Json.325;
+    let Json.112 : Str = StructAtIndex 1 Json.324;
     inc Json.112;
-    dec Json.325;
-    let Json.109 : List U8 = StructAtIndex 0 Json.324;
-    inc Json.109;
-    let Json.110 : U64 = StructAtIndex 1 Json.324;
     dec Json.324;
-    let Json.398 : I32 = 34i64;
-    let Json.397 : U8 = CallByName Num.123 Json.398;
-    let Json.395 : List U8 = CallByName List.4 Json.109 Json.397;
-    let Json.396 : List U8 = CallByName Str.12 Json.111;
-    let Json.392 : List U8 = CallByName List.8 Json.395 Json.396;
+    let Json.109 : List U8 = StructAtIndex 0 Json.323;
+    inc Json.109;
+    let Json.110 : U64 = StructAtIndex 1 Json.323;
+    dec Json.323;
     let Json.394 : I32 = 34i64;
     let Json.393 : U8 = CallByName Num.123 Json.394;
-    let Json.389 : List U8 = CallByName List.4 Json.392 Json.393;
-    let Json.391 : I32 = 58i64;
-    let Json.390 : U8 = CallByName Num.123 Json.391;
-    let Json.387 : List U8 = CallByName List.4 Json.389 Json.390;
-    let Json.388 : {} = Struct {};
-    let Json.113 : List U8 = CallByName Encode.23 Json.387 Json.112 Json.388;
-    joinpoint Json.382 Json.114:
-        let Json.380 : U64 = 1i64;
-        let Json.379 : U64 = CallByName Num.20 Json.110 Json.380;
-        let Json.378 : {List U8, U64} = Struct {Json.114, Json.379};
-        ret Json.378;
+    let Json.391 : List U8 = CallByName List.4 Json.109 Json.393;
+    let Json.392 : List U8 = CallByName Str.12 Json.111;
+    let Json.388 : List U8 = CallByName List.8 Json.391 Json.392;
+    let Json.390 : I32 = 34i64;
+    let Json.389 : U8 = CallByName Num.123 Json.390;
+    let Json.385 : List U8 = CallByName List.4 Json.388 Json.389;
+    let Json.387 : I32 = 58i64;
+    let Json.386 : U8 = CallByName Num.123 Json.387;
+    let Json.383 : List U8 = CallByName List.4 Json.385 Json.386;
+    let Json.384 : {} = Struct {};
+    let Json.113 : List U8 = CallByName Encode.23 Json.383 Json.112 Json.384;
+    joinpoint Json.378 Json.114:
+        let Json.376 : U64 = 1i64;
+        let Json.375 : U64 = CallByName Num.20 Json.110 Json.376;
+        let Json.374 : {List U8, U64} = Struct {Json.114, Json.375};
+        ret Json.374;
     in
-    let Json.386 : U64 = 1i64;
-    let Json.383 : Int1 = CallByName Num.24 Json.110 Json.386;
-    if Json.383 then
-        let Json.385 : I32 = 44i64;
-        let Json.384 : U8 = CallByName Num.123 Json.385;
-        let Json.381 : List U8 = CallByName List.4 Json.113 Json.384;
-        jump Json.382 Json.381;
+    let Json.382 : U64 = 1i64;
+    let Json.379 : Int1 = CallByName Num.24 Json.110 Json.382;
+    if Json.379 then
+        let Json.381 : I32 = 44i64;
+        let Json.380 : U8 = CallByName Num.123 Json.381;
+        let Json.377 : List U8 = CallByName List.4 Json.113 Json.380;
+        jump Json.378 Json.377;
     else
-        jump Json.382 Json.113;
+        jump Json.378 Json.113;
 
 procedure Json.18 (Json.86):
-    let Json.370 : {Str} = Struct {Json.86};
-    let Json.368 : Str = StructAtIndex 0 Json.370;
-    inc Json.368;
-    dec Json.370;
-    let Json.367 : Str = CallByName Encode.22 Json.368;
-    ret Json.367;
+    let Json.364 : Str = CallByName Encode.22 Json.86;
+    ret Json.364;
 
 procedure Json.20 (Json.102):
-    let Json.322 : {List {Str, Str}} = Struct {Json.102};
-    let Json.320 : List {Str, Str} = StructAtIndex 0 Json.322;
-    inc Json.320;
-    dec Json.322;
-    let Json.319 : List {Str, Str} = CallByName Encode.22 Json.320;
+    let Json.319 : List {Str, Str} = CallByName Encode.22 Json.102;
     ret Json.319;
 
 procedure Json.20 (Json.102):
-    let Json.366 : {List {Str, Str}} = Struct {Json.102};
-    let Json.364 : List {Str, Str} = StructAtIndex 0 Json.366;
-    inc Json.364;
-    dec Json.366;
-    let Json.363 : List {Str, Str} = CallByName Encode.22 Json.364;
-    ret Json.363;
+    let Json.361 : List {Str, Str} = CallByName Encode.22 Json.102;
+    ret Json.361;
 
-procedure Json.87 (Json.88, Json.369, #Attr.12):
-    let Json.412 : {Str} = Struct {#Attr.12};
-    let Json.86 : Str = StructAtIndex 0 Json.412;
-    inc Json.86;
-    dec Json.412;
-    let Json.411 : I32 = 34i64;
-    let Json.410 : U8 = CallByName Num.123 Json.411;
-    let Json.408 : List U8 = CallByName List.4 Json.88 Json.410;
-    let Json.409 : List U8 = CallByName Str.12 Json.86;
-    let Json.405 : List U8 = CallByName List.8 Json.408 Json.409;
-    let Json.407 : I32 = 34i64;
-    let Json.406 : U8 = CallByName Num.123 Json.407;
-    let Json.404 : List U8 = CallByName List.4 Json.405 Json.406;
-    ret Json.404;
+procedure Json.87 (Json.88, Json.366, Json.86):
+    let Json.406 : I32 = 34i64;
+    let Json.405 : U8 = CallByName Num.123 Json.406;
+    let Json.403 : List U8 = CallByName List.4 Json.88 Json.405;
+    let Json.404 : List U8 = CallByName Str.12 Json.86;
+    let Json.400 : List U8 = CallByName List.8 Json.403 Json.404;
+    let Json.402 : I32 = 34i64;
+    let Json.401 : U8 = CallByName Num.123 Json.402;
+    let Json.399 : List U8 = CallByName List.4 Json.400 Json.401;
+    ret Json.399;
 
-procedure List.133 (List.134, List.135, #Attr.12):
-    let List.436 : {{}} = Struct {#Attr.12};
-    let List.132 : {} = StructAtIndex 0 List.436;
-    let List.435 : {List U8, U64} = CallByName Json.105 List.134 List.135;
-    let List.434 : [C [], C {List U8, U64}] = TagId(1) List.435;
-    ret List.434;
+procedure List.133 (List.134, List.135, List.132):
+    let List.434 : {List U8, U64} = CallByName Json.105 List.134 List.135;
+    let List.433 : [C [], C {List U8, U64}] = TagId(1) List.434;
+    ret List.433;
 
-procedure List.133 (List.134, List.135, #Attr.12):
-    let List.519 : {{}} = Struct {#Attr.12};
-    let List.132 : {} = StructAtIndex 0 List.519;
-    let List.518 : {List U8, U64} = CallByName Json.105 List.134 List.135;
-    let List.517 : [C [], C {List U8, U64}] = TagId(1) List.518;
-    ret List.517;
+procedure List.133 (List.134, List.135, List.132):
+    let List.515 : {List U8, U64} = CallByName Json.105 List.134 List.135;
+    let List.514 : [C [], C {List U8, U64}] = TagId(1) List.515;
+    ret List.514;
 
 procedure List.18 (List.130, List.131, List.132):
-    let List.412 : {{}} = Struct {List.132};
-    let List.411 : {} = StructAtIndex 0 List.412;
-    let List.405 : [C [], C {List U8, U64}] = CallByName List.75 List.130 List.131 List.411;
+    let List.405 : [C [], C {List U8, U64}] = CallByName List.75 List.130 List.131 List.132;
     let List.408 : U8 = 1i64;
     let List.409 : U8 = GetTagId List.405;
     let List.410 : Int1 = lowlevel Eq List.408 List.409;
@@ -277,130 +231,128 @@ procedure List.18 (List.130, List.131, List.132):
         ret List.407;
 
 procedure List.18 (List.130, List.131, List.132):
-    let List.494 : {{}} = Struct {List.132};
-    let List.493 : {} = StructAtIndex 0 List.494;
-    let List.487 : [C [], C {List U8, U64}] = CallByName List.75 List.130 List.131 List.493;
-    let List.490 : U8 = 1i64;
-    let List.491 : U8 = GetTagId List.487;
-    let List.492 : Int1 = lowlevel Eq List.490 List.491;
-    if List.492 then
-        let List.137 : {List U8, U64} = UnionAtIndex (Id 1) (Index 0) List.487;
+    let List.485 : [C [], C {List U8, U64}] = CallByName List.75 List.130 List.131 List.132;
+    let List.488 : U8 = 1i64;
+    let List.489 : U8 = GetTagId List.485;
+    let List.490 : Int1 = lowlevel Eq List.488 List.489;
+    if List.490 then
+        let List.137 : {List U8, U64} = UnionAtIndex (Id 1) (Index 0) List.485;
         inc List.137;
-        dec List.487;
+        dec List.485;
         ret List.137;
     else
-        let List.138 : [] = UnionAtIndex (Id 0) (Index 0) List.487;
-        dec List.487;
-        let List.489 : {List U8, U64} = CallByName List.69 List.138;
-        ret List.489;
+        let List.138 : [] = UnionAtIndex (Id 0) (Index 0) List.485;
+        dec List.485;
+        let List.487 : {List U8, U64} = CallByName List.69 List.138;
+        ret List.487;
 
 procedure List.4 (List.101, List.102):
-    let List.486 : U64 = 1i64;
-    let List.485 : List U8 = CallByName List.70 List.101 List.486;
-    let List.484 : List U8 = CallByName List.71 List.485 List.102;
-    ret List.484;
+    let List.484 : U64 = 1i64;
+    let List.483 : List U8 = CallByName List.70 List.101 List.484;
+    let List.482 : List U8 = CallByName List.71 List.483 List.102;
+    ret List.482;
 
 procedure List.6 (#Attr.2):
     let List.385 : U64 = lowlevel ListLen #Attr.2;
     ret List.385;
 
 procedure List.6 (#Attr.2):
-    let List.414 : U64 = lowlevel ListLen #Attr.2;
-    ret List.414;
+    let List.413 : U64 = lowlevel ListLen #Attr.2;
+    ret List.413;
 
 procedure List.6 (#Attr.2):
-    let List.497 : U64 = lowlevel ListLen #Attr.2;
-    ret List.497;
+    let List.494 : U64 = lowlevel ListLen #Attr.2;
+    ret List.494;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.433 : {Str, Str} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.433;
+    let List.432 : {Str, Str} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.432;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.516 : {Str, Str} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.516;
+    let List.513 : {Str, Str} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.513;
 
 procedure List.69 (#Attr.2):
-    let List.500 : {List U8, U64} = lowlevel Unreachable #Attr.2;
-    ret List.500;
+    let List.497 : {List U8, U64} = lowlevel Unreachable #Attr.2;
+    ret List.497;
 
 procedure List.70 (#Attr.2, #Attr.3):
-    let List.499 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
-    ret List.499;
-
-procedure List.71 (#Attr.2, #Attr.3):
-    let List.498 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
-    ret List.498;
-
-procedure List.75 (List.361, List.362, List.363):
-    let List.419 : U64 = 0i64;
-    let List.420 : U64 = CallByName List.6 List.361;
-    let List.418 : [C [], C {List U8, U64}] = CallByName List.86 List.361 List.362 List.363 List.419 List.420;
-    ret List.418;
-
-procedure List.75 (List.361, List.362, List.363):
-    let List.502 : U64 = 0i64;
-    let List.503 : U64 = CallByName List.6 List.361;
-    let List.501 : [C [], C {List U8, U64}] = CallByName List.86 List.361 List.362 List.363 List.502 List.503;
-    ret List.501;
-
-procedure List.8 (#Attr.2, #Attr.3):
-    let List.496 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
+    let List.496 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
     ret List.496;
 
-procedure List.86 (List.450, List.451, List.452, List.453, List.454):
-    joinpoint List.421 List.364 List.365 List.366 List.367 List.368:
-        let List.423 : Int1 = CallByName Num.22 List.367 List.368;
-        if List.423 then
-            let List.432 : {Str, Str} = CallByName List.66 List.364 List.367;
-            let List.424 : [C [], C {List U8, U64}] = CallByName List.133 List.365 List.432 List.366;
-            let List.429 : U8 = 1i64;
-            let List.430 : U8 = GetTagId List.424;
-            let List.431 : Int1 = lowlevel Eq List.429 List.430;
-            if List.431 then
-                let List.369 : {List U8, U64} = UnionAtIndex (Id 1) (Index 0) List.424;
-                inc List.369;
-                dec List.424;
-                let List.427 : U64 = 1i64;
-                let List.426 : U64 = CallByName Num.19 List.367 List.427;
-                jump List.421 List.364 List.369 List.366 List.426 List.368;
-            else
-                let List.370 : [] = UnionAtIndex (Id 0) (Index 0) List.424;
-                dec List.424;
-                let List.428 : [C [], C {List U8, U64}] = TagId(0) List.370;
-                ret List.428;
-        else
-            let List.422 : [C [], C {List U8, U64}] = TagId(1) List.365;
-            ret List.422;
-    in
-    jump List.421 List.450 List.451 List.452 List.453 List.454;
+procedure List.71 (#Attr.2, #Attr.3):
+    let List.495 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
+    ret List.495;
 
-procedure List.86 (List.533, List.534, List.535, List.536, List.537):
-    joinpoint List.504 List.364 List.365 List.366 List.367 List.368:
-        let List.506 : Int1 = CallByName Num.22 List.367 List.368;
-        if List.506 then
-            let List.515 : {Str, Str} = CallByName List.66 List.364 List.367;
-            let List.507 : [C [], C {List U8, U64}] = CallByName List.133 List.365 List.515 List.366;
-            let List.512 : U8 = 1i64;
-            let List.513 : U8 = GetTagId List.507;
-            let List.514 : Int1 = lowlevel Eq List.512 List.513;
-            if List.514 then
-                let List.369 : {List U8, U64} = UnionAtIndex (Id 1) (Index 0) List.507;
+procedure List.75 (List.361, List.362, List.363):
+    let List.418 : U64 = 0i64;
+    let List.419 : U64 = CallByName List.6 List.361;
+    let List.417 : [C [], C {List U8, U64}] = CallByName List.86 List.361 List.362 List.363 List.418 List.419;
+    ret List.417;
+
+procedure List.75 (List.361, List.362, List.363):
+    let List.499 : U64 = 0i64;
+    let List.500 : U64 = CallByName List.6 List.361;
+    let List.498 : [C [], C {List U8, U64}] = CallByName List.86 List.361 List.362 List.363 List.499 List.500;
+    ret List.498;
+
+procedure List.8 (#Attr.2, #Attr.3):
+    let List.493 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
+    ret List.493;
+
+procedure List.86 (List.448, List.449, List.450, List.451, List.452):
+    joinpoint List.420 List.364 List.365 List.366 List.367 List.368:
+        let List.422 : Int1 = CallByName Num.22 List.367 List.368;
+        if List.422 then
+            let List.431 : {Str, Str} = CallByName List.66 List.364 List.367;
+            let List.423 : [C [], C {List U8, U64}] = CallByName List.133 List.365 List.431 List.366;
+            let List.428 : U8 = 1i64;
+            let List.429 : U8 = GetTagId List.423;
+            let List.430 : Int1 = lowlevel Eq List.428 List.429;
+            if List.430 then
+                let List.369 : {List U8, U64} = UnionAtIndex (Id 1) (Index 0) List.423;
                 inc List.369;
-                dec List.507;
-                let List.510 : U64 = 1i64;
-                let List.509 : U64 = CallByName Num.19 List.367 List.510;
-                jump List.504 List.364 List.369 List.366 List.509 List.368;
+                dec List.423;
+                let List.426 : U64 = 1i64;
+                let List.425 : U64 = CallByName Num.19 List.367 List.426;
+                jump List.420 List.364 List.369 List.366 List.425 List.368;
             else
-                let List.370 : [] = UnionAtIndex (Id 0) (Index 0) List.507;
-                dec List.507;
-                let List.511 : [C [], C {List U8, U64}] = TagId(0) List.370;
-                ret List.511;
+                let List.370 : [] = UnionAtIndex (Id 0) (Index 0) List.423;
+                dec List.423;
+                let List.427 : [C [], C {List U8, U64}] = TagId(0) List.370;
+                ret List.427;
         else
-            let List.505 : [C [], C {List U8, U64}] = TagId(1) List.365;
-            ret List.505;
+            let List.421 : [C [], C {List U8, U64}] = TagId(1) List.365;
+            ret List.421;
     in
-    jump List.504 List.533 List.534 List.535 List.536 List.537;
+    jump List.420 List.448 List.449 List.450 List.451 List.452;
+
+procedure List.86 (List.529, List.530, List.531, List.532, List.533):
+    joinpoint List.501 List.364 List.365 List.366 List.367 List.368:
+        let List.503 : Int1 = CallByName Num.22 List.367 List.368;
+        if List.503 then
+            let List.512 : {Str, Str} = CallByName List.66 List.364 List.367;
+            let List.504 : [C [], C {List U8, U64}] = CallByName List.133 List.365 List.512 List.366;
+            let List.509 : U8 = 1i64;
+            let List.510 : U8 = GetTagId List.504;
+            let List.511 : Int1 = lowlevel Eq List.509 List.510;
+            if List.511 then
+                let List.369 : {List U8, U64} = UnionAtIndex (Id 1) (Index 0) List.504;
+                inc List.369;
+                dec List.504;
+                let List.507 : U64 = 1i64;
+                let List.506 : U64 = CallByName Num.19 List.367 List.507;
+                jump List.501 List.364 List.369 List.366 List.506 List.368;
+            else
+                let List.370 : [] = UnionAtIndex (Id 0) (Index 0) List.504;
+                dec List.504;
+                let List.508 : [C [], C {List U8, U64}] = TagId(0) List.370;
+                ret List.508;
+        else
+            let List.502 : [C [], C {List U8, U64}] = TagId(1) List.365;
+            ret List.502;
+    in
+    jump List.501 List.529 List.530 List.531 List.532 List.533;
 
 procedure Num.123 (#Attr.2):
     let Num.283 : U8 = lowlevel NumIntCast #Attr.2;

--- a/crates/compiler/test_mono/generated/encode_derived_record_one_field_string.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_record_one_field_string.txt
@@ -1,16 +1,16 @@
 procedure #Derived.0 (#Derived.1):
+    let #Derived_gen.2 : {Str} = Struct {#Derived.1};
     let #Derived_gen.1 : Str = StructAtIndex 0 #Derived_gen.2;
     inc #Derived_gen.1;
     dec #Derived_gen.2;
-    let #Derived_gen.2 : {Str} = Struct {#Derived.1};
     let #Derived_gen.0 : Str = CallByName Encode.22 #Derived_gen.1;
     ret #Derived_gen.0;
 
 procedure #Derived.2 (#Derived.3, #Derived.4, #Attr.12):
+    let #Derived_gen.11 : {Str} = Struct {#Attr.12};
     let #Derived.1 : Str = StructAtIndex 0 #Derived_gen.11;
     inc #Derived.1;
     dec #Derived_gen.11;
-    let #Derived_gen.11 : {Str} = Struct {#Attr.12};
     let #Derived_gen.8 : Str = "a";
     let #Derived_gen.9 : Str = CallByName Json.18 #Derived.1;
     let #Derived_gen.7 : {Str, Str} = Struct {#Derived_gen.8, #Derived_gen.9};
@@ -51,10 +51,10 @@ procedure Json.1 ():
     ret Json.318;
 
 procedure Json.103 (Json.104, Json.321, #Attr.12):
+    let Json.360 : {List {Str, Str}} = Struct {#Attr.12};
     let Json.102 : List {Str, Str} = StructAtIndex 0 Json.360;
     inc Json.102;
     dec Json.360;
-    let Json.360 : {List {Str, Str}} = Struct {#Attr.12};
     let Json.359 : I32 = 123i64;
     let Json.358 : U8 = CallByName Num.123 Json.359;
     let Json.106 : List U8 = CallByName List.4 Json.104 Json.358;
@@ -111,26 +111,26 @@ procedure Json.105 (Json.328, Json.329):
         jump Json.340 Json.113;
 
 procedure Json.18 (Json.86):
+    let Json.326 : {Str} = Struct {Json.86};
     let Json.324 : Str = StructAtIndex 0 Json.326;
     inc Json.324;
     dec Json.326;
-    let Json.326 : {Str} = Struct {Json.86};
     let Json.323 : Str = CallByName Encode.22 Json.324;
     ret Json.323;
 
 procedure Json.20 (Json.102):
+    let Json.322 : {List {Str, Str}} = Struct {Json.102};
     let Json.320 : List {Str, Str} = StructAtIndex 0 Json.322;
     inc Json.320;
     dec Json.322;
-    let Json.322 : {List {Str, Str}} = Struct {Json.102};
     let Json.319 : List {Str, Str} = CallByName Encode.22 Json.320;
     ret Json.319;
 
 procedure Json.87 (Json.88, Json.325, #Attr.12):
+    let Json.370 : {Str} = Struct {#Attr.12};
     let Json.86 : Str = StructAtIndex 0 Json.370;
     inc Json.86;
     dec Json.370;
-    let Json.370 : {Str} = Struct {#Attr.12};
     let Json.369 : I32 = 34i64;
     let Json.368 : U8 = CallByName Num.123 Json.369;
     let Json.366 : List U8 = CallByName List.4 Json.88 Json.368;
@@ -142,15 +142,15 @@ procedure Json.87 (Json.88, Json.325, #Attr.12):
     ret Json.362;
 
 procedure List.133 (List.134, List.135, #Attr.12):
-    let List.132 : {} = StructAtIndex 0 List.443;
     let List.443 : {{}} = Struct {#Attr.12};
+    let List.132 : {} = StructAtIndex 0 List.443;
     let List.442 : {List U8, U64} = CallByName Json.105 List.134 List.135;
     let List.441 : [C [], C {List U8, U64}] = TagId(1) List.442;
     ret List.441;
 
 procedure List.18 (List.130, List.131, List.132):
-    let List.417 : {} = StructAtIndex 0 List.418;
     let List.418 : {{}} = Struct {List.132};
+    let List.417 : {} = StructAtIndex 0 List.418;
     let List.411 : [C [], C {List U8, U64}] = CallByName List.75 List.130 List.131 List.417;
     let List.414 : U8 = 1i64;
     let List.415 : U8 = GetTagId List.411;

--- a/crates/compiler/test_mono/generated/encode_derived_record_one_field_string.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_record_one_field_string.txt
@@ -1,19 +1,23 @@
 procedure #Derived.0 (#Derived.1):
-    let #Derived_gen.1 : {Str} = Struct {#Derived.1};
-    let #Derived_gen.0 : {Str} = CallByName Encode.22 #Derived_gen.1;
+    let #Derived_gen.1 : Str = StructAtIndex 0 #Derived_gen.2;
+    inc #Derived_gen.1;
+    dec #Derived_gen.2;
+    let #Derived_gen.2 : {Str} = Struct {#Derived.1};
+    let #Derived_gen.0 : Str = CallByName Encode.22 #Derived_gen.1;
     ret #Derived_gen.0;
 
 procedure #Derived.2 (#Derived.3, #Derived.4, #Attr.12):
-    let #Derived.1 : Str = StructAtIndex 0 #Attr.12;
+    let #Derived.1 : Str = StructAtIndex 0 #Derived_gen.11;
     inc #Derived.1;
-    dec #Attr.12;
-    let #Derived_gen.7 : Str = "a";
-    let #Derived_gen.8 : {Str} = CallByName Json.18 #Derived.1;
-    let #Derived_gen.6 : {Str, {Str}} = Struct {#Derived_gen.7, #Derived_gen.8};
-    let #Derived_gen.5 : List {Str, {Str}} = Array [#Derived_gen.6];
-    let #Derived_gen.4 : {List {Str, {Str}}} = CallByName Json.20 #Derived_gen.5;
-    let #Derived_gen.3 : List U8 = CallByName Encode.23 #Derived.3 #Derived_gen.4 #Derived.4;
-    ret #Derived_gen.3;
+    dec #Derived_gen.11;
+    let #Derived_gen.11 : {Str} = Struct {#Attr.12};
+    let #Derived_gen.8 : Str = "a";
+    let #Derived_gen.9 : Str = CallByName Json.18 #Derived.1;
+    let #Derived_gen.7 : {Str, Str} = Struct {#Derived_gen.8, #Derived_gen.9};
+    let #Derived_gen.6 : List {Str, Str} = Array [#Derived_gen.7];
+    let #Derived_gen.5 : List {Str, Str} = CallByName Json.20 #Derived_gen.6;
+    let #Derived_gen.4 : List U8 = CallByName Encode.23 #Derived.3 #Derived_gen.5 #Derived.4;
+    ret #Derived_gen.4;
 
 procedure Encode.22 (Encode.93):
     ret Encode.93;
@@ -38,7 +42,7 @@ procedure Encode.23 (Encode.94, Encode.102, Encode.96):
 
 procedure Encode.25 (Encode.100, Encode.101):
     let Encode.104 : List U8 = Array [];
-    let Encode.105 : {Str} = CallByName #Derived.0 Encode.100;
+    let Encode.105 : Str = CallByName #Derived.0 Encode.100;
     let Encode.103 : List U8 = CallByName Encode.23 Encode.104 Encode.105 Encode.101;
     ret Encode.103;
 
@@ -47,96 +51,106 @@ procedure Json.1 ():
     ret Json.318;
 
 procedure Json.103 (Json.104, Json.321, #Attr.12):
-    let Json.102 : List {Str, {Str}} = StructAtIndex 0 #Attr.12;
+    let Json.102 : List {Str, Str} = StructAtIndex 0 Json.360;
     inc Json.102;
-    dec #Attr.12;
-    let Json.357 : I32 = 123i64;
-    let Json.356 : U8 = CallByName Num.123 Json.357;
-    let Json.106 : List U8 = CallByName List.4 Json.104 Json.356;
-    let Json.355 : U64 = CallByName List.6 Json.102;
-    let Json.332 : {List U8, U64} = Struct {Json.106, Json.355};
-    let Json.333 : {} = Struct {};
-    let Json.331 : {List U8, U64} = CallByName List.18 Json.102 Json.332 Json.333;
+    dec Json.360;
+    let Json.360 : {List {Str, Str}} = Struct {#Attr.12};
+    let Json.359 : I32 = 123i64;
+    let Json.358 : U8 = CallByName Num.123 Json.359;
+    let Json.106 : List U8 = CallByName List.4 Json.104 Json.358;
+    let Json.357 : U64 = CallByName List.6 Json.102;
+    let Json.334 : {List U8, U64} = Struct {Json.106, Json.357};
+    let Json.335 : {} = Struct {};
+    let Json.333 : {List U8, U64} = CallByName List.18 Json.102 Json.334 Json.335;
     dec Json.102;
-    let Json.108 : List U8 = StructAtIndex 0 Json.331;
+    let Json.108 : List U8 = StructAtIndex 0 Json.333;
     inc Json.108;
-    dec Json.331;
-    let Json.330 : I32 = 125i64;
-    let Json.329 : U8 = CallByName Num.123 Json.330;
-    let Json.328 : List U8 = CallByName List.4 Json.108 Json.329;
-    ret Json.328;
+    dec Json.333;
+    let Json.332 : I32 = 125i64;
+    let Json.331 : U8 = CallByName Num.123 Json.332;
+    let Json.330 : List U8 = CallByName List.4 Json.108 Json.331;
+    ret Json.330;
 
-procedure Json.105 (Json.326, Json.327):
-    let Json.111 : Str = StructAtIndex 0 Json.327;
+procedure Json.105 (Json.328, Json.329):
+    let Json.111 : Str = StructAtIndex 0 Json.329;
     inc Json.111;
-    let Json.112 : {Str} = StructAtIndex 1 Json.327;
+    let Json.112 : Str = StructAtIndex 1 Json.329;
     inc Json.112;
-    dec Json.327;
-    let Json.109 : List U8 = StructAtIndex 0 Json.326;
+    dec Json.329;
+    let Json.109 : List U8 = StructAtIndex 0 Json.328;
     inc Json.109;
-    let Json.110 : U64 = StructAtIndex 1 Json.326;
-    dec Json.326;
-    let Json.354 : I32 = 34i64;
-    let Json.353 : U8 = CallByName Num.123 Json.354;
-    let Json.351 : List U8 = CallByName List.4 Json.109 Json.353;
-    let Json.352 : List U8 = CallByName Str.12 Json.111;
-    let Json.348 : List U8 = CallByName List.8 Json.351 Json.352;
-    let Json.350 : I32 = 34i64;
-    let Json.349 : U8 = CallByName Num.123 Json.350;
-    let Json.345 : List U8 = CallByName List.4 Json.348 Json.349;
-    let Json.347 : I32 = 58i64;
-    let Json.346 : U8 = CallByName Num.123 Json.347;
-    let Json.343 : List U8 = CallByName List.4 Json.345 Json.346;
-    let Json.344 : {} = Struct {};
-    let Json.113 : List U8 = CallByName Encode.23 Json.343 Json.112 Json.344;
-    joinpoint Json.338 Json.114:
-        let Json.336 : U64 = 1i64;
-        let Json.335 : U64 = CallByName Num.20 Json.110 Json.336;
-        let Json.334 : {List U8, U64} = Struct {Json.114, Json.335};
-        ret Json.334;
+    let Json.110 : U64 = StructAtIndex 1 Json.328;
+    dec Json.328;
+    let Json.356 : I32 = 34i64;
+    let Json.355 : U8 = CallByName Num.123 Json.356;
+    let Json.353 : List U8 = CallByName List.4 Json.109 Json.355;
+    let Json.354 : List U8 = CallByName Str.12 Json.111;
+    let Json.350 : List U8 = CallByName List.8 Json.353 Json.354;
+    let Json.352 : I32 = 34i64;
+    let Json.351 : U8 = CallByName Num.123 Json.352;
+    let Json.347 : List U8 = CallByName List.4 Json.350 Json.351;
+    let Json.349 : I32 = 58i64;
+    let Json.348 : U8 = CallByName Num.123 Json.349;
+    let Json.345 : List U8 = CallByName List.4 Json.347 Json.348;
+    let Json.346 : {} = Struct {};
+    let Json.113 : List U8 = CallByName Encode.23 Json.345 Json.112 Json.346;
+    joinpoint Json.340 Json.114:
+        let Json.338 : U64 = 1i64;
+        let Json.337 : U64 = CallByName Num.20 Json.110 Json.338;
+        let Json.336 : {List U8, U64} = Struct {Json.114, Json.337};
+        ret Json.336;
     in
-    let Json.342 : U64 = 1i64;
-    let Json.339 : Int1 = CallByName Num.24 Json.110 Json.342;
-    if Json.339 then
-        let Json.341 : I32 = 44i64;
-        let Json.340 : U8 = CallByName Num.123 Json.341;
-        let Json.337 : List U8 = CallByName List.4 Json.113 Json.340;
-        jump Json.338 Json.337;
+    let Json.344 : U64 = 1i64;
+    let Json.341 : Int1 = CallByName Num.24 Json.110 Json.344;
+    if Json.341 then
+        let Json.343 : I32 = 44i64;
+        let Json.342 : U8 = CallByName Num.123 Json.343;
+        let Json.339 : List U8 = CallByName List.4 Json.113 Json.342;
+        jump Json.340 Json.339;
     else
-        jump Json.338 Json.113;
+        jump Json.340 Json.113;
 
 procedure Json.18 (Json.86):
-    let Json.323 : {Str} = Struct {Json.86};
-    let Json.322 : {Str} = CallByName Encode.22 Json.323;
-    ret Json.322;
+    let Json.324 : Str = StructAtIndex 0 Json.326;
+    inc Json.324;
+    dec Json.326;
+    let Json.326 : {Str} = Struct {Json.86};
+    let Json.323 : Str = CallByName Encode.22 Json.324;
+    ret Json.323;
 
 procedure Json.20 (Json.102):
-    let Json.320 : {List {Str, {Str}}} = Struct {Json.102};
-    let Json.319 : {List {Str, {Str}}} = CallByName Encode.22 Json.320;
+    let Json.320 : List {Str, Str} = StructAtIndex 0 Json.322;
+    inc Json.320;
+    dec Json.322;
+    let Json.322 : {List {Str, Str}} = Struct {Json.102};
+    let Json.319 : List {Str, Str} = CallByName Encode.22 Json.320;
     ret Json.319;
 
-procedure Json.87 (Json.88, Json.324, #Attr.12):
-    let Json.86 : Str = StructAtIndex 0 #Attr.12;
+procedure Json.87 (Json.88, Json.325, #Attr.12):
+    let Json.86 : Str = StructAtIndex 0 Json.370;
     inc Json.86;
-    dec #Attr.12;
-    let Json.366 : I32 = 34i64;
-    let Json.365 : U8 = CallByName Num.123 Json.366;
-    let Json.363 : List U8 = CallByName List.4 Json.88 Json.365;
-    let Json.364 : List U8 = CallByName Str.12 Json.86;
-    let Json.360 : List U8 = CallByName List.8 Json.363 Json.364;
-    let Json.362 : I32 = 34i64;
-    let Json.361 : U8 = CallByName Num.123 Json.362;
-    let Json.359 : List U8 = CallByName List.4 Json.360 Json.361;
-    ret Json.359;
+    dec Json.370;
+    let Json.370 : {Str} = Struct {#Attr.12};
+    let Json.369 : I32 = 34i64;
+    let Json.368 : U8 = CallByName Num.123 Json.369;
+    let Json.366 : List U8 = CallByName List.4 Json.88 Json.368;
+    let Json.367 : List U8 = CallByName Str.12 Json.86;
+    let Json.363 : List U8 = CallByName List.8 Json.366 Json.367;
+    let Json.365 : I32 = 34i64;
+    let Json.364 : U8 = CallByName Num.123 Json.365;
+    let Json.362 : List U8 = CallByName List.4 Json.363 Json.364;
+    ret Json.362;
 
 procedure List.133 (List.134, List.135, #Attr.12):
-    let List.132 : {} = StructAtIndex 0 #Attr.12;
-    let List.441 : {List U8, U64} = CallByName Json.105 List.134 List.135;
-    let List.440 : [C [], C {List U8, U64}] = TagId(1) List.441;
-    ret List.440;
+    let List.132 : {} = StructAtIndex 0 List.443;
+    let List.443 : {{}} = Struct {#Attr.12};
+    let List.442 : {List U8, U64} = CallByName Json.105 List.134 List.135;
+    let List.441 : [C [], C {List U8, U64}] = TagId(1) List.442;
+    ret List.441;
 
 procedure List.18 (List.130, List.131, List.132):
-    let List.417 : {{}} = Struct {List.132};
+    let List.417 : {} = StructAtIndex 0 List.418;
+    let List.418 : {{}} = Struct {List.132};
     let List.411 : [C [], C {List U8, U64}] = CallByName List.75 List.130 List.131 List.417;
     let List.414 : U8 = 1i64;
     let List.415 : U8 = GetTagId List.411;
@@ -163,61 +177,61 @@ procedure List.6 (#Attr.2):
     ret List.385;
 
 procedure List.6 (#Attr.2):
-    let List.420 : U64 = lowlevel ListLen #Attr.2;
-    ret List.420;
-
-procedure List.66 (#Attr.2, #Attr.3):
-    let List.439 : {Str, {Str}} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.439;
-
-procedure List.69 (#Attr.2):
-    let List.423 : {List U8, U64} = lowlevel Unreachable #Attr.2;
-    ret List.423;
-
-procedure List.70 (#Attr.2, #Attr.3):
-    let List.422 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
-    ret List.422;
-
-procedure List.71 (#Attr.2, #Attr.3):
-    let List.421 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
+    let List.421 : U64 = lowlevel ListLen #Attr.2;
     ret List.421;
 
-procedure List.75 (List.361, List.362, List.363):
-    let List.425 : U64 = 0i64;
-    let List.426 : U64 = CallByName List.6 List.361;
-    let List.424 : [C [], C {List U8, U64}] = CallByName List.86 List.361 List.362 List.363 List.425 List.426;
+procedure List.66 (#Attr.2, #Attr.3):
+    let List.440 : {Str, Str} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.440;
+
+procedure List.69 (#Attr.2):
+    let List.424 : {List U8, U64} = lowlevel Unreachable #Attr.2;
     ret List.424;
 
-procedure List.8 (#Attr.2, #Attr.3):
-    let List.419 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
-    ret List.419;
+procedure List.70 (#Attr.2, #Attr.3):
+    let List.423 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
+    ret List.423;
 
-procedure List.86 (List.455, List.456, List.457, List.458, List.459):
-    joinpoint List.427 List.364 List.365 List.366 List.367 List.368:
-        let List.429 : Int1 = CallByName Num.22 List.367 List.368;
-        if List.429 then
-            let List.438 : {Str, {Str}} = CallByName List.66 List.364 List.367;
-            let List.430 : [C [], C {List U8, U64}] = CallByName List.133 List.365 List.438 List.366;
-            let List.435 : U8 = 1i64;
-            let List.436 : U8 = GetTagId List.430;
-            let List.437 : Int1 = lowlevel Eq List.435 List.436;
-            if List.437 then
-                let List.369 : {List U8, U64} = UnionAtIndex (Id 1) (Index 0) List.430;
+procedure List.71 (#Attr.2, #Attr.3):
+    let List.422 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
+    ret List.422;
+
+procedure List.75 (List.361, List.362, List.363):
+    let List.426 : U64 = 0i64;
+    let List.427 : U64 = CallByName List.6 List.361;
+    let List.425 : [C [], C {List U8, U64}] = CallByName List.86 List.361 List.362 List.363 List.426 List.427;
+    ret List.425;
+
+procedure List.8 (#Attr.2, #Attr.3):
+    let List.420 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
+    ret List.420;
+
+procedure List.86 (List.457, List.458, List.459, List.460, List.461):
+    joinpoint List.428 List.364 List.365 List.366 List.367 List.368:
+        let List.430 : Int1 = CallByName Num.22 List.367 List.368;
+        if List.430 then
+            let List.439 : {Str, Str} = CallByName List.66 List.364 List.367;
+            let List.431 : [C [], C {List U8, U64}] = CallByName List.133 List.365 List.439 List.366;
+            let List.436 : U8 = 1i64;
+            let List.437 : U8 = GetTagId List.431;
+            let List.438 : Int1 = lowlevel Eq List.436 List.437;
+            if List.438 then
+                let List.369 : {List U8, U64} = UnionAtIndex (Id 1) (Index 0) List.431;
                 inc List.369;
-                dec List.430;
-                let List.433 : U64 = 1i64;
-                let List.432 : U64 = CallByName Num.19 List.367 List.433;
-                jump List.427 List.364 List.369 List.366 List.432 List.368;
+                dec List.431;
+                let List.434 : U64 = 1i64;
+                let List.433 : U64 = CallByName Num.19 List.367 List.434;
+                jump List.428 List.364 List.369 List.366 List.433 List.368;
             else
-                let List.370 : [] = UnionAtIndex (Id 0) (Index 0) List.430;
-                dec List.430;
-                let List.434 : [C [], C {List U8, U64}] = TagId(0) List.370;
-                ret List.434;
+                let List.370 : [] = UnionAtIndex (Id 0) (Index 0) List.431;
+                dec List.431;
+                let List.435 : [C [], C {List U8, U64}] = TagId(0) List.370;
+                ret List.435;
         else
-            let List.428 : [C [], C {List U8, U64}] = TagId(1) List.365;
-            ret List.428;
+            let List.429 : [C [], C {List U8, U64}] = TagId(1) List.365;
+            ret List.429;
     in
-    jump List.427 List.455 List.456 List.457 List.458 List.459;
+    jump List.428 List.457 List.458 List.459 List.460 List.461;
 
 procedure Num.123 (#Attr.2):
     let Num.264 : U8 = lowlevel NumIntCast #Attr.2;

--- a/crates/compiler/test_mono/generated/encode_derived_record_one_field_string.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_record_one_field_string.txt
@@ -1,23 +1,15 @@
 procedure #Derived.0 (#Derived.1):
-    let #Derived_gen.2 : {Str} = Struct {#Derived.1};
-    let #Derived_gen.1 : Str = StructAtIndex 0 #Derived_gen.2;
-    inc #Derived_gen.1;
-    dec #Derived_gen.2;
-    let #Derived_gen.0 : Str = CallByName Encode.22 #Derived_gen.1;
+    let #Derived_gen.0 : Str = CallByName Encode.22 #Derived.1;
     ret #Derived_gen.0;
 
-procedure #Derived.2 (#Derived.3, #Derived.4, #Attr.12):
-    let #Derived_gen.11 : {Str} = Struct {#Attr.12};
-    let #Derived.1 : Str = StructAtIndex 0 #Derived_gen.11;
-    inc #Derived.1;
-    dec #Derived_gen.11;
-    let #Derived_gen.8 : Str = "a";
-    let #Derived_gen.9 : Str = CallByName Json.18 #Derived.1;
-    let #Derived_gen.7 : {Str, Str} = Struct {#Derived_gen.8, #Derived_gen.9};
-    let #Derived_gen.6 : List {Str, Str} = Array [#Derived_gen.7];
-    let #Derived_gen.5 : List {Str, Str} = CallByName Json.20 #Derived_gen.6;
-    let #Derived_gen.4 : List U8 = CallByName Encode.23 #Derived.3 #Derived_gen.5 #Derived.4;
-    ret #Derived_gen.4;
+procedure #Derived.2 (#Derived.3, #Derived.4, #Derived.1):
+    let #Derived_gen.7 : Str = "a";
+    let #Derived_gen.8 : Str = CallByName Json.18 #Derived.1;
+    let #Derived_gen.6 : {Str, Str} = Struct {#Derived_gen.7, #Derived_gen.8};
+    let #Derived_gen.5 : List {Str, Str} = Array [#Derived_gen.6];
+    let #Derived_gen.4 : List {Str, Str} = CallByName Json.20 #Derived_gen.5;
+    let #Derived_gen.3 : List U8 = CallByName Encode.23 #Derived.3 #Derived_gen.4 #Derived.4;
+    ret #Derived_gen.3;
 
 procedure Encode.22 (Encode.93):
     ret Encode.93;
@@ -50,108 +42,88 @@ procedure Json.1 ():
     let Json.318 : {} = Struct {};
     ret Json.318;
 
-procedure Json.103 (Json.104, Json.321, #Attr.12):
-    let Json.360 : {List {Str, Str}} = Struct {#Attr.12};
-    let Json.102 : List {Str, Str} = StructAtIndex 0 Json.360;
-    inc Json.102;
-    dec Json.360;
-    let Json.359 : I32 = 123i64;
-    let Json.358 : U8 = CallByName Num.123 Json.359;
-    let Json.106 : List U8 = CallByName List.4 Json.104 Json.358;
-    let Json.357 : U64 = CallByName List.6 Json.102;
-    let Json.334 : {List U8, U64} = Struct {Json.106, Json.357};
-    let Json.335 : {} = Struct {};
-    let Json.333 : {List U8, U64} = CallByName List.18 Json.102 Json.334 Json.335;
+procedure Json.103 (Json.104, Json.321, Json.102):
+    let Json.357 : I32 = 123i64;
+    let Json.356 : U8 = CallByName Num.123 Json.357;
+    let Json.106 : List U8 = CallByName List.4 Json.104 Json.356;
+    let Json.355 : U64 = CallByName List.6 Json.102;
+    let Json.332 : {List U8, U64} = Struct {Json.106, Json.355};
+    let Json.333 : {} = Struct {};
+    let Json.331 : {List U8, U64} = CallByName List.18 Json.102 Json.332 Json.333;
     dec Json.102;
-    let Json.108 : List U8 = StructAtIndex 0 Json.333;
+    let Json.108 : List U8 = StructAtIndex 0 Json.331;
     inc Json.108;
-    dec Json.333;
-    let Json.332 : I32 = 125i64;
-    let Json.331 : U8 = CallByName Num.123 Json.332;
-    let Json.330 : List U8 = CallByName List.4 Json.108 Json.331;
-    ret Json.330;
+    dec Json.331;
+    let Json.330 : I32 = 125i64;
+    let Json.329 : U8 = CallByName Num.123 Json.330;
+    let Json.328 : List U8 = CallByName List.4 Json.108 Json.329;
+    ret Json.328;
 
-procedure Json.105 (Json.328, Json.329):
-    let Json.111 : Str = StructAtIndex 0 Json.329;
+procedure Json.105 (Json.326, Json.327):
+    let Json.111 : Str = StructAtIndex 0 Json.327;
     inc Json.111;
-    let Json.112 : Str = StructAtIndex 1 Json.329;
+    let Json.112 : Str = StructAtIndex 1 Json.327;
     inc Json.112;
-    dec Json.329;
-    let Json.109 : List U8 = StructAtIndex 0 Json.328;
+    dec Json.327;
+    let Json.109 : List U8 = StructAtIndex 0 Json.326;
     inc Json.109;
-    let Json.110 : U64 = StructAtIndex 1 Json.328;
-    dec Json.328;
-    let Json.356 : I32 = 34i64;
-    let Json.355 : U8 = CallByName Num.123 Json.356;
-    let Json.353 : List U8 = CallByName List.4 Json.109 Json.355;
-    let Json.354 : List U8 = CallByName Str.12 Json.111;
-    let Json.350 : List U8 = CallByName List.8 Json.353 Json.354;
-    let Json.352 : I32 = 34i64;
-    let Json.351 : U8 = CallByName Num.123 Json.352;
-    let Json.347 : List U8 = CallByName List.4 Json.350 Json.351;
-    let Json.349 : I32 = 58i64;
-    let Json.348 : U8 = CallByName Num.123 Json.349;
-    let Json.345 : List U8 = CallByName List.4 Json.347 Json.348;
-    let Json.346 : {} = Struct {};
-    let Json.113 : List U8 = CallByName Encode.23 Json.345 Json.112 Json.346;
-    joinpoint Json.340 Json.114:
-        let Json.338 : U64 = 1i64;
-        let Json.337 : U64 = CallByName Num.20 Json.110 Json.338;
-        let Json.336 : {List U8, U64} = Struct {Json.114, Json.337};
-        ret Json.336;
+    let Json.110 : U64 = StructAtIndex 1 Json.326;
+    dec Json.326;
+    let Json.354 : I32 = 34i64;
+    let Json.353 : U8 = CallByName Num.123 Json.354;
+    let Json.351 : List U8 = CallByName List.4 Json.109 Json.353;
+    let Json.352 : List U8 = CallByName Str.12 Json.111;
+    let Json.348 : List U8 = CallByName List.8 Json.351 Json.352;
+    let Json.350 : I32 = 34i64;
+    let Json.349 : U8 = CallByName Num.123 Json.350;
+    let Json.345 : List U8 = CallByName List.4 Json.348 Json.349;
+    let Json.347 : I32 = 58i64;
+    let Json.346 : U8 = CallByName Num.123 Json.347;
+    let Json.343 : List U8 = CallByName List.4 Json.345 Json.346;
+    let Json.344 : {} = Struct {};
+    let Json.113 : List U8 = CallByName Encode.23 Json.343 Json.112 Json.344;
+    joinpoint Json.338 Json.114:
+        let Json.336 : U64 = 1i64;
+        let Json.335 : U64 = CallByName Num.20 Json.110 Json.336;
+        let Json.334 : {List U8, U64} = Struct {Json.114, Json.335};
+        ret Json.334;
     in
-    let Json.344 : U64 = 1i64;
-    let Json.341 : Int1 = CallByName Num.24 Json.110 Json.344;
-    if Json.341 then
-        let Json.343 : I32 = 44i64;
-        let Json.342 : U8 = CallByName Num.123 Json.343;
-        let Json.339 : List U8 = CallByName List.4 Json.113 Json.342;
-        jump Json.340 Json.339;
+    let Json.342 : U64 = 1i64;
+    let Json.339 : Int1 = CallByName Num.24 Json.110 Json.342;
+    if Json.339 then
+        let Json.341 : I32 = 44i64;
+        let Json.340 : U8 = CallByName Num.123 Json.341;
+        let Json.337 : List U8 = CallByName List.4 Json.113 Json.340;
+        jump Json.338 Json.337;
     else
-        jump Json.340 Json.113;
+        jump Json.338 Json.113;
 
 procedure Json.18 (Json.86):
-    let Json.326 : {Str} = Struct {Json.86};
-    let Json.324 : Str = StructAtIndex 0 Json.326;
-    inc Json.324;
-    dec Json.326;
-    let Json.323 : Str = CallByName Encode.22 Json.324;
-    ret Json.323;
+    let Json.322 : Str = CallByName Encode.22 Json.86;
+    ret Json.322;
 
 procedure Json.20 (Json.102):
-    let Json.322 : {List {Str, Str}} = Struct {Json.102};
-    let Json.320 : List {Str, Str} = StructAtIndex 0 Json.322;
-    inc Json.320;
-    dec Json.322;
-    let Json.319 : List {Str, Str} = CallByName Encode.22 Json.320;
+    let Json.319 : List {Str, Str} = CallByName Encode.22 Json.102;
     ret Json.319;
 
-procedure Json.87 (Json.88, Json.325, #Attr.12):
-    let Json.370 : {Str} = Struct {#Attr.12};
-    let Json.86 : Str = StructAtIndex 0 Json.370;
-    inc Json.86;
-    dec Json.370;
-    let Json.369 : I32 = 34i64;
-    let Json.368 : U8 = CallByName Num.123 Json.369;
-    let Json.366 : List U8 = CallByName List.4 Json.88 Json.368;
-    let Json.367 : List U8 = CallByName Str.12 Json.86;
-    let Json.363 : List U8 = CallByName List.8 Json.366 Json.367;
-    let Json.365 : I32 = 34i64;
-    let Json.364 : U8 = CallByName Num.123 Json.365;
-    let Json.362 : List U8 = CallByName List.4 Json.363 Json.364;
-    ret Json.362;
+procedure Json.87 (Json.88, Json.324, Json.86):
+    let Json.366 : I32 = 34i64;
+    let Json.365 : U8 = CallByName Num.123 Json.366;
+    let Json.363 : List U8 = CallByName List.4 Json.88 Json.365;
+    let Json.364 : List U8 = CallByName Str.12 Json.86;
+    let Json.360 : List U8 = CallByName List.8 Json.363 Json.364;
+    let Json.362 : I32 = 34i64;
+    let Json.361 : U8 = CallByName Num.123 Json.362;
+    let Json.359 : List U8 = CallByName List.4 Json.360 Json.361;
+    ret Json.359;
 
-procedure List.133 (List.134, List.135, #Attr.12):
-    let List.443 : {{}} = Struct {#Attr.12};
-    let List.132 : {} = StructAtIndex 0 List.443;
-    let List.442 : {List U8, U64} = CallByName Json.105 List.134 List.135;
-    let List.441 : [C [], C {List U8, U64}] = TagId(1) List.442;
-    ret List.441;
+procedure List.133 (List.134, List.135, List.132):
+    let List.441 : {List U8, U64} = CallByName Json.105 List.134 List.135;
+    let List.440 : [C [], C {List U8, U64}] = TagId(1) List.441;
+    ret List.440;
 
 procedure List.18 (List.130, List.131, List.132):
-    let List.418 : {{}} = Struct {List.132};
-    let List.417 : {} = StructAtIndex 0 List.418;
-    let List.411 : [C [], C {List U8, U64}] = CallByName List.75 List.130 List.131 List.417;
+    let List.411 : [C [], C {List U8, U64}] = CallByName List.75 List.130 List.131 List.132;
     let List.414 : U8 = 1i64;
     let List.415 : U8 = GetTagId List.411;
     let List.416 : Int1 = lowlevel Eq List.414 List.415;
@@ -177,61 +149,61 @@ procedure List.6 (#Attr.2):
     ret List.385;
 
 procedure List.6 (#Attr.2):
-    let List.421 : U64 = lowlevel ListLen #Attr.2;
-    ret List.421;
-
-procedure List.66 (#Attr.2, #Attr.3):
-    let List.440 : {Str, Str} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.440;
-
-procedure List.69 (#Attr.2):
-    let List.424 : {List U8, U64} = lowlevel Unreachable #Attr.2;
-    ret List.424;
-
-procedure List.70 (#Attr.2, #Attr.3):
-    let List.423 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
-    ret List.423;
-
-procedure List.71 (#Attr.2, #Attr.3):
-    let List.422 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
-    ret List.422;
-
-procedure List.75 (List.361, List.362, List.363):
-    let List.426 : U64 = 0i64;
-    let List.427 : U64 = CallByName List.6 List.361;
-    let List.425 : [C [], C {List U8, U64}] = CallByName List.86 List.361 List.362 List.363 List.426 List.427;
-    ret List.425;
-
-procedure List.8 (#Attr.2, #Attr.3):
-    let List.420 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
+    let List.420 : U64 = lowlevel ListLen #Attr.2;
     ret List.420;
 
-procedure List.86 (List.457, List.458, List.459, List.460, List.461):
-    joinpoint List.428 List.364 List.365 List.366 List.367 List.368:
-        let List.430 : Int1 = CallByName Num.22 List.367 List.368;
-        if List.430 then
-            let List.439 : {Str, Str} = CallByName List.66 List.364 List.367;
-            let List.431 : [C [], C {List U8, U64}] = CallByName List.133 List.365 List.439 List.366;
-            let List.436 : U8 = 1i64;
-            let List.437 : U8 = GetTagId List.431;
-            let List.438 : Int1 = lowlevel Eq List.436 List.437;
-            if List.438 then
-                let List.369 : {List U8, U64} = UnionAtIndex (Id 1) (Index 0) List.431;
+procedure List.66 (#Attr.2, #Attr.3):
+    let List.439 : {Str, Str} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.439;
+
+procedure List.69 (#Attr.2):
+    let List.423 : {List U8, U64} = lowlevel Unreachable #Attr.2;
+    ret List.423;
+
+procedure List.70 (#Attr.2, #Attr.3):
+    let List.422 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
+    ret List.422;
+
+procedure List.71 (#Attr.2, #Attr.3):
+    let List.421 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
+    ret List.421;
+
+procedure List.75 (List.361, List.362, List.363):
+    let List.425 : U64 = 0i64;
+    let List.426 : U64 = CallByName List.6 List.361;
+    let List.424 : [C [], C {List U8, U64}] = CallByName List.86 List.361 List.362 List.363 List.425 List.426;
+    ret List.424;
+
+procedure List.8 (#Attr.2, #Attr.3):
+    let List.419 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
+    ret List.419;
+
+procedure List.86 (List.455, List.456, List.457, List.458, List.459):
+    joinpoint List.427 List.364 List.365 List.366 List.367 List.368:
+        let List.429 : Int1 = CallByName Num.22 List.367 List.368;
+        if List.429 then
+            let List.438 : {Str, Str} = CallByName List.66 List.364 List.367;
+            let List.430 : [C [], C {List U8, U64}] = CallByName List.133 List.365 List.438 List.366;
+            let List.435 : U8 = 1i64;
+            let List.436 : U8 = GetTagId List.430;
+            let List.437 : Int1 = lowlevel Eq List.435 List.436;
+            if List.437 then
+                let List.369 : {List U8, U64} = UnionAtIndex (Id 1) (Index 0) List.430;
                 inc List.369;
-                dec List.431;
-                let List.434 : U64 = 1i64;
-                let List.433 : U64 = CallByName Num.19 List.367 List.434;
-                jump List.428 List.364 List.369 List.366 List.433 List.368;
+                dec List.430;
+                let List.433 : U64 = 1i64;
+                let List.432 : U64 = CallByName Num.19 List.367 List.433;
+                jump List.427 List.364 List.369 List.366 List.432 List.368;
             else
-                let List.370 : [] = UnionAtIndex (Id 0) (Index 0) List.431;
-                dec List.431;
-                let List.435 : [C [], C {List U8, U64}] = TagId(0) List.370;
-                ret List.435;
+                let List.370 : [] = UnionAtIndex (Id 0) (Index 0) List.430;
+                dec List.430;
+                let List.434 : [C [], C {List U8, U64}] = TagId(0) List.370;
+                ret List.434;
         else
-            let List.429 : [C [], C {List U8, U64}] = TagId(1) List.365;
-            ret List.429;
+            let List.428 : [C [], C {List U8, U64}] = TagId(1) List.365;
+            ret List.428;
     in
-    jump List.428 List.457 List.458 List.459 List.460 List.461;
+    jump List.427 List.455 List.456 List.457 List.458 List.459;
 
 procedure Num.123 (#Attr.2):
     let Num.264 : U8 = lowlevel NumIntCast #Attr.2;

--- a/crates/compiler/test_mono/generated/encode_derived_record_two_field_strings.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_record_two_field_strings.txt
@@ -1,31 +1,23 @@
 procedure #Derived.0 (#Derived.1):
-    let #Derived_gen.2 : {{Str, Str}} = Struct {#Derived.1};
-    let #Derived_gen.1 : {Str, Str} = StructAtIndex 0 #Derived_gen.2;
-    inc #Derived_gen.1;
-    dec #Derived_gen.2;
-    let #Derived_gen.0 : {Str, Str} = CallByName Encode.22 #Derived_gen.1;
+    let #Derived_gen.0 : {Str, Str} = CallByName Encode.22 #Derived.1;
     ret #Derived_gen.0;
 
-procedure #Derived.2 (#Derived.3, #Derived.4, #Attr.12):
-    let #Derived_gen.15 : {{Str, Str}} = Struct {#Attr.12};
-    let #Derived.1 : {Str, Str} = StructAtIndex 0 #Derived_gen.15;
-    inc #Derived.1;
-    dec #Derived_gen.15;
-    let #Derived_gen.12 : Str = "a";
-    let #Derived_gen.14 : Str = StructAtIndex 0 #Derived.1;
-    inc #Derived_gen.14;
-    let #Derived_gen.13 : Str = CallByName Json.18 #Derived_gen.14;
-    let #Derived_gen.7 : {Str, Str} = Struct {#Derived_gen.12, #Derived_gen.13};
-    let #Derived_gen.9 : Str = "b";
-    let #Derived_gen.11 : Str = StructAtIndex 1 #Derived.1;
-    inc #Derived_gen.11;
+procedure #Derived.2 (#Derived.3, #Derived.4, #Derived.1):
+    let #Derived_gen.11 : Str = "a";
+    let #Derived_gen.13 : Str = StructAtIndex 0 #Derived.1;
+    inc #Derived_gen.13;
+    let #Derived_gen.12 : Str = CallByName Json.18 #Derived_gen.13;
+    let #Derived_gen.6 : {Str, Str} = Struct {#Derived_gen.11, #Derived_gen.12};
+    let #Derived_gen.8 : Str = "b";
+    let #Derived_gen.10 : Str = StructAtIndex 1 #Derived.1;
+    inc #Derived_gen.10;
     dec #Derived.1;
-    let #Derived_gen.10 : Str = CallByName Json.18 #Derived_gen.11;
-    let #Derived_gen.8 : {Str, Str} = Struct {#Derived_gen.9, #Derived_gen.10};
-    let #Derived_gen.6 : List {Str, Str} = Array [#Derived_gen.7, #Derived_gen.8];
-    let #Derived_gen.5 : List {Str, Str} = CallByName Json.20 #Derived_gen.6;
-    let #Derived_gen.4 : List U8 = CallByName Encode.23 #Derived.3 #Derived_gen.5 #Derived.4;
-    ret #Derived_gen.4;
+    let #Derived_gen.9 : Str = CallByName Json.18 #Derived_gen.10;
+    let #Derived_gen.7 : {Str, Str} = Struct {#Derived_gen.8, #Derived_gen.9};
+    let #Derived_gen.5 : List {Str, Str} = Array [#Derived_gen.6, #Derived_gen.7];
+    let #Derived_gen.4 : List {Str, Str} = CallByName Json.20 #Derived_gen.5;
+    let #Derived_gen.3 : List U8 = CallByName Encode.23 #Derived.3 #Derived_gen.4 #Derived.4;
+    ret #Derived_gen.3;
 
 procedure Encode.22 (Encode.93):
     ret Encode.93;
@@ -58,108 +50,88 @@ procedure Json.1 ():
     let Json.318 : {} = Struct {};
     ret Json.318;
 
-procedure Json.103 (Json.104, Json.321, #Attr.12):
-    let Json.364 : {List {Str, Str}} = Struct {#Attr.12};
-    let Json.102 : List {Str, Str} = StructAtIndex 0 Json.364;
-    inc Json.102;
-    dec Json.364;
-    let Json.363 : I32 = 123i64;
-    let Json.362 : U8 = CallByName Num.123 Json.363;
-    let Json.106 : List U8 = CallByName List.4 Json.104 Json.362;
-    let Json.361 : U64 = CallByName List.6 Json.102;
-    let Json.338 : {List U8, U64} = Struct {Json.106, Json.361};
-    let Json.339 : {} = Struct {};
-    let Json.337 : {List U8, U64} = CallByName List.18 Json.102 Json.338 Json.339;
-    dec Json.102;
-    let Json.108 : List U8 = StructAtIndex 0 Json.337;
-    inc Json.108;
-    dec Json.337;
-    let Json.336 : I32 = 125i64;
-    let Json.335 : U8 = CallByName Num.123 Json.336;
-    let Json.334 : List U8 = CallByName List.4 Json.108 Json.335;
-    ret Json.334;
-
-procedure Json.105 (Json.332, Json.333):
-    let Json.111 : Str = StructAtIndex 0 Json.333;
-    inc Json.111;
-    let Json.112 : Str = StructAtIndex 1 Json.333;
-    inc Json.112;
-    dec Json.333;
-    let Json.109 : List U8 = StructAtIndex 0 Json.332;
-    inc Json.109;
-    let Json.110 : U64 = StructAtIndex 1 Json.332;
-    dec Json.332;
-    let Json.360 : I32 = 34i64;
+procedure Json.103 (Json.104, Json.321, Json.102):
+    let Json.360 : I32 = 123i64;
     let Json.359 : U8 = CallByName Num.123 Json.360;
-    let Json.357 : List U8 = CallByName List.4 Json.109 Json.359;
-    let Json.358 : List U8 = CallByName Str.12 Json.111;
-    let Json.354 : List U8 = CallByName List.8 Json.357 Json.358;
-    let Json.356 : I32 = 34i64;
-    let Json.355 : U8 = CallByName Num.123 Json.356;
-    let Json.351 : List U8 = CallByName List.4 Json.354 Json.355;
-    let Json.353 : I32 = 58i64;
+    let Json.106 : List U8 = CallByName List.4 Json.104 Json.359;
+    let Json.358 : U64 = CallByName List.6 Json.102;
+    let Json.335 : {List U8, U64} = Struct {Json.106, Json.358};
+    let Json.336 : {} = Struct {};
+    let Json.334 : {List U8, U64} = CallByName List.18 Json.102 Json.335 Json.336;
+    dec Json.102;
+    let Json.108 : List U8 = StructAtIndex 0 Json.334;
+    inc Json.108;
+    dec Json.334;
+    let Json.333 : I32 = 125i64;
+    let Json.332 : U8 = CallByName Num.123 Json.333;
+    let Json.331 : List U8 = CallByName List.4 Json.108 Json.332;
+    ret Json.331;
+
+procedure Json.105 (Json.329, Json.330):
+    let Json.111 : Str = StructAtIndex 0 Json.330;
+    inc Json.111;
+    let Json.112 : Str = StructAtIndex 1 Json.330;
+    inc Json.112;
+    dec Json.330;
+    let Json.109 : List U8 = StructAtIndex 0 Json.329;
+    inc Json.109;
+    let Json.110 : U64 = StructAtIndex 1 Json.329;
+    dec Json.329;
+    let Json.357 : I32 = 34i64;
+    let Json.356 : U8 = CallByName Num.123 Json.357;
+    let Json.354 : List U8 = CallByName List.4 Json.109 Json.356;
+    let Json.355 : List U8 = CallByName Str.12 Json.111;
+    let Json.351 : List U8 = CallByName List.8 Json.354 Json.355;
+    let Json.353 : I32 = 34i64;
     let Json.352 : U8 = CallByName Num.123 Json.353;
-    let Json.349 : List U8 = CallByName List.4 Json.351 Json.352;
-    let Json.350 : {} = Struct {};
-    let Json.113 : List U8 = CallByName Encode.23 Json.349 Json.112 Json.350;
-    joinpoint Json.344 Json.114:
-        let Json.342 : U64 = 1i64;
-        let Json.341 : U64 = CallByName Num.20 Json.110 Json.342;
-        let Json.340 : {List U8, U64} = Struct {Json.114, Json.341};
-        ret Json.340;
+    let Json.348 : List U8 = CallByName List.4 Json.351 Json.352;
+    let Json.350 : I32 = 58i64;
+    let Json.349 : U8 = CallByName Num.123 Json.350;
+    let Json.346 : List U8 = CallByName List.4 Json.348 Json.349;
+    let Json.347 : {} = Struct {};
+    let Json.113 : List U8 = CallByName Encode.23 Json.346 Json.112 Json.347;
+    joinpoint Json.341 Json.114:
+        let Json.339 : U64 = 1i64;
+        let Json.338 : U64 = CallByName Num.20 Json.110 Json.339;
+        let Json.337 : {List U8, U64} = Struct {Json.114, Json.338};
+        ret Json.337;
     in
-    let Json.348 : U64 = 1i64;
-    let Json.345 : Int1 = CallByName Num.24 Json.110 Json.348;
-    if Json.345 then
-        let Json.347 : I32 = 44i64;
-        let Json.346 : U8 = CallByName Num.123 Json.347;
-        let Json.343 : List U8 = CallByName List.4 Json.113 Json.346;
-        jump Json.344 Json.343;
+    let Json.345 : U64 = 1i64;
+    let Json.342 : Int1 = CallByName Num.24 Json.110 Json.345;
+    if Json.342 then
+        let Json.344 : I32 = 44i64;
+        let Json.343 : U8 = CallByName Num.123 Json.344;
+        let Json.340 : List U8 = CallByName List.4 Json.113 Json.343;
+        jump Json.341 Json.340;
     else
-        jump Json.344 Json.113;
+        jump Json.341 Json.113;
 
 procedure Json.18 (Json.86):
-    let Json.330 : {Str} = Struct {Json.86};
-    let Json.328 : Str = StructAtIndex 0 Json.330;
-    inc Json.328;
-    dec Json.330;
-    let Json.327 : Str = CallByName Encode.22 Json.328;
-    ret Json.327;
+    let Json.325 : Str = CallByName Encode.22 Json.86;
+    ret Json.325;
 
 procedure Json.20 (Json.102):
-    let Json.322 : {List {Str, Str}} = Struct {Json.102};
-    let Json.320 : List {Str, Str} = StructAtIndex 0 Json.322;
-    inc Json.320;
-    dec Json.322;
-    let Json.319 : List {Str, Str} = CallByName Encode.22 Json.320;
+    let Json.319 : List {Str, Str} = CallByName Encode.22 Json.102;
     ret Json.319;
 
-procedure Json.87 (Json.88, Json.325, #Attr.12):
-    let Json.374 : {Str} = Struct {#Attr.12};
-    let Json.86 : Str = StructAtIndex 0 Json.374;
-    inc Json.86;
-    dec Json.374;
-    let Json.373 : I32 = 34i64;
-    let Json.372 : U8 = CallByName Num.123 Json.373;
-    let Json.370 : List U8 = CallByName List.4 Json.88 Json.372;
-    let Json.371 : List U8 = CallByName Str.12 Json.86;
-    let Json.367 : List U8 = CallByName List.8 Json.370 Json.371;
+procedure Json.87 (Json.88, Json.324, Json.86):
     let Json.369 : I32 = 34i64;
     let Json.368 : U8 = CallByName Num.123 Json.369;
-    let Json.366 : List U8 = CallByName List.4 Json.367 Json.368;
-    ret Json.366;
+    let Json.366 : List U8 = CallByName List.4 Json.88 Json.368;
+    let Json.367 : List U8 = CallByName Str.12 Json.86;
+    let Json.363 : List U8 = CallByName List.8 Json.366 Json.367;
+    let Json.365 : I32 = 34i64;
+    let Json.364 : U8 = CallByName Num.123 Json.365;
+    let Json.362 : List U8 = CallByName List.4 Json.363 Json.364;
+    ret Json.362;
 
-procedure List.133 (List.134, List.135, #Attr.12):
-    let List.443 : {{}} = Struct {#Attr.12};
-    let List.132 : {} = StructAtIndex 0 List.443;
-    let List.442 : {List U8, U64} = CallByName Json.105 List.134 List.135;
-    let List.441 : [C [], C {List U8, U64}] = TagId(1) List.442;
-    ret List.441;
+procedure List.133 (List.134, List.135, List.132):
+    let List.441 : {List U8, U64} = CallByName Json.105 List.134 List.135;
+    let List.440 : [C [], C {List U8, U64}] = TagId(1) List.441;
+    ret List.440;
 
 procedure List.18 (List.130, List.131, List.132):
-    let List.418 : {{}} = Struct {List.132};
-    let List.417 : {} = StructAtIndex 0 List.418;
-    let List.411 : [C [], C {List U8, U64}] = CallByName List.75 List.130 List.131 List.417;
+    let List.411 : [C [], C {List U8, U64}] = CallByName List.75 List.130 List.131 List.132;
     let List.414 : U8 = 1i64;
     let List.415 : U8 = GetTagId List.411;
     let List.416 : Int1 = lowlevel Eq List.414 List.415;
@@ -185,61 +157,61 @@ procedure List.6 (#Attr.2):
     ret List.385;
 
 procedure List.6 (#Attr.2):
-    let List.421 : U64 = lowlevel ListLen #Attr.2;
-    ret List.421;
-
-procedure List.66 (#Attr.2, #Attr.3):
-    let List.440 : {Str, Str} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.440;
-
-procedure List.69 (#Attr.2):
-    let List.424 : {List U8, U64} = lowlevel Unreachable #Attr.2;
-    ret List.424;
-
-procedure List.70 (#Attr.2, #Attr.3):
-    let List.423 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
-    ret List.423;
-
-procedure List.71 (#Attr.2, #Attr.3):
-    let List.422 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
-    ret List.422;
-
-procedure List.75 (List.361, List.362, List.363):
-    let List.426 : U64 = 0i64;
-    let List.427 : U64 = CallByName List.6 List.361;
-    let List.425 : [C [], C {List U8, U64}] = CallByName List.86 List.361 List.362 List.363 List.426 List.427;
-    ret List.425;
-
-procedure List.8 (#Attr.2, #Attr.3):
-    let List.420 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
+    let List.420 : U64 = lowlevel ListLen #Attr.2;
     ret List.420;
 
-procedure List.86 (List.457, List.458, List.459, List.460, List.461):
-    joinpoint List.428 List.364 List.365 List.366 List.367 List.368:
-        let List.430 : Int1 = CallByName Num.22 List.367 List.368;
-        if List.430 then
-            let List.439 : {Str, Str} = CallByName List.66 List.364 List.367;
-            let List.431 : [C [], C {List U8, U64}] = CallByName List.133 List.365 List.439 List.366;
-            let List.436 : U8 = 1i64;
-            let List.437 : U8 = GetTagId List.431;
-            let List.438 : Int1 = lowlevel Eq List.436 List.437;
-            if List.438 then
-                let List.369 : {List U8, U64} = UnionAtIndex (Id 1) (Index 0) List.431;
+procedure List.66 (#Attr.2, #Attr.3):
+    let List.439 : {Str, Str} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.439;
+
+procedure List.69 (#Attr.2):
+    let List.423 : {List U8, U64} = lowlevel Unreachable #Attr.2;
+    ret List.423;
+
+procedure List.70 (#Attr.2, #Attr.3):
+    let List.422 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
+    ret List.422;
+
+procedure List.71 (#Attr.2, #Attr.3):
+    let List.421 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
+    ret List.421;
+
+procedure List.75 (List.361, List.362, List.363):
+    let List.425 : U64 = 0i64;
+    let List.426 : U64 = CallByName List.6 List.361;
+    let List.424 : [C [], C {List U8, U64}] = CallByName List.86 List.361 List.362 List.363 List.425 List.426;
+    ret List.424;
+
+procedure List.8 (#Attr.2, #Attr.3):
+    let List.419 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
+    ret List.419;
+
+procedure List.86 (List.455, List.456, List.457, List.458, List.459):
+    joinpoint List.427 List.364 List.365 List.366 List.367 List.368:
+        let List.429 : Int1 = CallByName Num.22 List.367 List.368;
+        if List.429 then
+            let List.438 : {Str, Str} = CallByName List.66 List.364 List.367;
+            let List.430 : [C [], C {List U8, U64}] = CallByName List.133 List.365 List.438 List.366;
+            let List.435 : U8 = 1i64;
+            let List.436 : U8 = GetTagId List.430;
+            let List.437 : Int1 = lowlevel Eq List.435 List.436;
+            if List.437 then
+                let List.369 : {List U8, U64} = UnionAtIndex (Id 1) (Index 0) List.430;
                 inc List.369;
-                dec List.431;
-                let List.434 : U64 = 1i64;
-                let List.433 : U64 = CallByName Num.19 List.367 List.434;
-                jump List.428 List.364 List.369 List.366 List.433 List.368;
+                dec List.430;
+                let List.433 : U64 = 1i64;
+                let List.432 : U64 = CallByName Num.19 List.367 List.433;
+                jump List.427 List.364 List.369 List.366 List.432 List.368;
             else
-                let List.370 : [] = UnionAtIndex (Id 0) (Index 0) List.431;
-                dec List.431;
-                let List.435 : [C [], C {List U8, U64}] = TagId(0) List.370;
-                ret List.435;
+                let List.370 : [] = UnionAtIndex (Id 0) (Index 0) List.430;
+                dec List.430;
+                let List.434 : [C [], C {List U8, U64}] = TagId(0) List.370;
+                ret List.434;
         else
-            let List.429 : [C [], C {List U8, U64}] = TagId(1) List.365;
-            ret List.429;
+            let List.428 : [C [], C {List U8, U64}] = TagId(1) List.365;
+            ret List.428;
     in
-    jump List.428 List.457 List.458 List.459 List.460 List.461;
+    jump List.427 List.455 List.456 List.457 List.458 List.459;
 
 procedure Num.123 (#Attr.2):
     let Num.264 : U8 = lowlevel NumIntCast #Attr.2;

--- a/crates/compiler/test_mono/generated/encode_derived_record_two_field_strings.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_record_two_field_strings.txt
@@ -1,16 +1,16 @@
 procedure #Derived.0 (#Derived.1):
+    let #Derived_gen.2 : {{Str, Str}} = Struct {#Derived.1};
     let #Derived_gen.1 : {Str, Str} = StructAtIndex 0 #Derived_gen.2;
     inc #Derived_gen.1;
     dec #Derived_gen.2;
-    let #Derived_gen.2 : {{Str, Str}} = Struct {#Derived.1};
     let #Derived_gen.0 : {Str, Str} = CallByName Encode.22 #Derived_gen.1;
     ret #Derived_gen.0;
 
 procedure #Derived.2 (#Derived.3, #Derived.4, #Attr.12):
+    let #Derived_gen.15 : {{Str, Str}} = Struct {#Attr.12};
     let #Derived.1 : {Str, Str} = StructAtIndex 0 #Derived_gen.15;
     inc #Derived.1;
     dec #Derived_gen.15;
-    let #Derived_gen.15 : {{Str, Str}} = Struct {#Attr.12};
     let #Derived_gen.12 : Str = "a";
     let #Derived_gen.14 : Str = StructAtIndex 0 #Derived.1;
     inc #Derived_gen.14;
@@ -59,10 +59,10 @@ procedure Json.1 ():
     ret Json.318;
 
 procedure Json.103 (Json.104, Json.321, #Attr.12):
+    let Json.364 : {List {Str, Str}} = Struct {#Attr.12};
     let Json.102 : List {Str, Str} = StructAtIndex 0 Json.364;
     inc Json.102;
     dec Json.364;
-    let Json.364 : {List {Str, Str}} = Struct {#Attr.12};
     let Json.363 : I32 = 123i64;
     let Json.362 : U8 = CallByName Num.123 Json.363;
     let Json.106 : List U8 = CallByName List.4 Json.104 Json.362;
@@ -119,26 +119,26 @@ procedure Json.105 (Json.332, Json.333):
         jump Json.344 Json.113;
 
 procedure Json.18 (Json.86):
+    let Json.330 : {Str} = Struct {Json.86};
     let Json.328 : Str = StructAtIndex 0 Json.330;
     inc Json.328;
     dec Json.330;
-    let Json.330 : {Str} = Struct {Json.86};
     let Json.327 : Str = CallByName Encode.22 Json.328;
     ret Json.327;
 
 procedure Json.20 (Json.102):
+    let Json.322 : {List {Str, Str}} = Struct {Json.102};
     let Json.320 : List {Str, Str} = StructAtIndex 0 Json.322;
     inc Json.320;
     dec Json.322;
-    let Json.322 : {List {Str, Str}} = Struct {Json.102};
     let Json.319 : List {Str, Str} = CallByName Encode.22 Json.320;
     ret Json.319;
 
 procedure Json.87 (Json.88, Json.325, #Attr.12):
+    let Json.374 : {Str} = Struct {#Attr.12};
     let Json.86 : Str = StructAtIndex 0 Json.374;
     inc Json.86;
     dec Json.374;
-    let Json.374 : {Str} = Struct {#Attr.12};
     let Json.373 : I32 = 34i64;
     let Json.372 : U8 = CallByName Num.123 Json.373;
     let Json.370 : List U8 = CallByName List.4 Json.88 Json.372;
@@ -150,15 +150,15 @@ procedure Json.87 (Json.88, Json.325, #Attr.12):
     ret Json.366;
 
 procedure List.133 (List.134, List.135, #Attr.12):
-    let List.132 : {} = StructAtIndex 0 List.443;
     let List.443 : {{}} = Struct {#Attr.12};
+    let List.132 : {} = StructAtIndex 0 List.443;
     let List.442 : {List U8, U64} = CallByName Json.105 List.134 List.135;
     let List.441 : [C [], C {List U8, U64}] = TagId(1) List.442;
     ret List.441;
 
 procedure List.18 (List.130, List.131, List.132):
-    let List.417 : {} = StructAtIndex 0 List.418;
     let List.418 : {{}} = Struct {List.132};
+    let List.417 : {} = StructAtIndex 0 List.418;
     let List.411 : [C [], C {List U8, U64}] = CallByName List.75 List.130 List.131 List.417;
     let List.414 : U8 = 1i64;
     let List.415 : U8 = GetTagId List.411;

--- a/crates/compiler/test_mono/generated/encode_derived_record_two_field_strings.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_record_two_field_strings.txt
@@ -1,27 +1,31 @@
 procedure #Derived.0 (#Derived.1):
-    let #Derived_gen.1 : {{Str, Str}} = Struct {#Derived.1};
-    let #Derived_gen.0 : {{Str, Str}} = CallByName Encode.22 #Derived_gen.1;
+    let #Derived_gen.1 : {Str, Str} = StructAtIndex 0 #Derived_gen.2;
+    inc #Derived_gen.1;
+    dec #Derived_gen.2;
+    let #Derived_gen.2 : {{Str, Str}} = Struct {#Derived.1};
+    let #Derived_gen.0 : {Str, Str} = CallByName Encode.22 #Derived_gen.1;
     ret #Derived_gen.0;
 
 procedure #Derived.2 (#Derived.3, #Derived.4, #Attr.12):
-    let #Derived.1 : {Str, Str} = StructAtIndex 0 #Attr.12;
+    let #Derived.1 : {Str, Str} = StructAtIndex 0 #Derived_gen.15;
     inc #Derived.1;
-    dec #Attr.12;
-    let #Derived_gen.11 : Str = "a";
-    let #Derived_gen.13 : Str = StructAtIndex 0 #Derived.1;
-    inc #Derived_gen.13;
-    let #Derived_gen.12 : {Str} = CallByName Json.18 #Derived_gen.13;
-    let #Derived_gen.6 : {Str, {Str}} = Struct {#Derived_gen.11, #Derived_gen.12};
-    let #Derived_gen.8 : Str = "b";
-    let #Derived_gen.10 : Str = StructAtIndex 1 #Derived.1;
-    inc #Derived_gen.10;
+    dec #Derived_gen.15;
+    let #Derived_gen.15 : {{Str, Str}} = Struct {#Attr.12};
+    let #Derived_gen.12 : Str = "a";
+    let #Derived_gen.14 : Str = StructAtIndex 0 #Derived.1;
+    inc #Derived_gen.14;
+    let #Derived_gen.13 : Str = CallByName Json.18 #Derived_gen.14;
+    let #Derived_gen.7 : {Str, Str} = Struct {#Derived_gen.12, #Derived_gen.13};
+    let #Derived_gen.9 : Str = "b";
+    let #Derived_gen.11 : Str = StructAtIndex 1 #Derived.1;
+    inc #Derived_gen.11;
     dec #Derived.1;
-    let #Derived_gen.9 : {Str} = CallByName Json.18 #Derived_gen.10;
-    let #Derived_gen.7 : {Str, {Str}} = Struct {#Derived_gen.8, #Derived_gen.9};
-    let #Derived_gen.5 : List {Str, {Str}} = Array [#Derived_gen.6, #Derived_gen.7];
-    let #Derived_gen.4 : {List {Str, {Str}}} = CallByName Json.20 #Derived_gen.5;
-    let #Derived_gen.3 : List U8 = CallByName Encode.23 #Derived.3 #Derived_gen.4 #Derived.4;
-    ret #Derived_gen.3;
+    let #Derived_gen.10 : Str = CallByName Json.18 #Derived_gen.11;
+    let #Derived_gen.8 : {Str, Str} = Struct {#Derived_gen.9, #Derived_gen.10};
+    let #Derived_gen.6 : List {Str, Str} = Array [#Derived_gen.7, #Derived_gen.8];
+    let #Derived_gen.5 : List {Str, Str} = CallByName Json.20 #Derived_gen.6;
+    let #Derived_gen.4 : List U8 = CallByName Encode.23 #Derived.3 #Derived_gen.5 #Derived.4;
+    ret #Derived_gen.4;
 
 procedure Encode.22 (Encode.93):
     ret Encode.93;
@@ -46,7 +50,7 @@ procedure Encode.23 (Encode.94, Encode.102, Encode.96):
 
 procedure Encode.25 (Encode.100, Encode.101):
     let Encode.104 : List U8 = Array [];
-    let Encode.105 : {{Str, Str}} = CallByName #Derived.0 Encode.100;
+    let Encode.105 : {Str, Str} = CallByName #Derived.0 Encode.100;
     let Encode.103 : List U8 = CallByName Encode.23 Encode.104 Encode.105 Encode.101;
     ret Encode.103;
 
@@ -55,96 +59,106 @@ procedure Json.1 ():
     ret Json.318;
 
 procedure Json.103 (Json.104, Json.321, #Attr.12):
-    let Json.102 : List {Str, {Str}} = StructAtIndex 0 #Attr.12;
+    let Json.102 : List {Str, Str} = StructAtIndex 0 Json.364;
     inc Json.102;
-    dec #Attr.12;
-    let Json.360 : I32 = 123i64;
-    let Json.359 : U8 = CallByName Num.123 Json.360;
-    let Json.106 : List U8 = CallByName List.4 Json.104 Json.359;
-    let Json.358 : U64 = CallByName List.6 Json.102;
-    let Json.335 : {List U8, U64} = Struct {Json.106, Json.358};
-    let Json.336 : {} = Struct {};
-    let Json.334 : {List U8, U64} = CallByName List.18 Json.102 Json.335 Json.336;
+    dec Json.364;
+    let Json.364 : {List {Str, Str}} = Struct {#Attr.12};
+    let Json.363 : I32 = 123i64;
+    let Json.362 : U8 = CallByName Num.123 Json.363;
+    let Json.106 : List U8 = CallByName List.4 Json.104 Json.362;
+    let Json.361 : U64 = CallByName List.6 Json.102;
+    let Json.338 : {List U8, U64} = Struct {Json.106, Json.361};
+    let Json.339 : {} = Struct {};
+    let Json.337 : {List U8, U64} = CallByName List.18 Json.102 Json.338 Json.339;
     dec Json.102;
-    let Json.108 : List U8 = StructAtIndex 0 Json.334;
+    let Json.108 : List U8 = StructAtIndex 0 Json.337;
     inc Json.108;
-    dec Json.334;
-    let Json.333 : I32 = 125i64;
-    let Json.332 : U8 = CallByName Num.123 Json.333;
-    let Json.331 : List U8 = CallByName List.4 Json.108 Json.332;
-    ret Json.331;
+    dec Json.337;
+    let Json.336 : I32 = 125i64;
+    let Json.335 : U8 = CallByName Num.123 Json.336;
+    let Json.334 : List U8 = CallByName List.4 Json.108 Json.335;
+    ret Json.334;
 
-procedure Json.105 (Json.329, Json.330):
-    let Json.111 : Str = StructAtIndex 0 Json.330;
+procedure Json.105 (Json.332, Json.333):
+    let Json.111 : Str = StructAtIndex 0 Json.333;
     inc Json.111;
-    let Json.112 : {Str} = StructAtIndex 1 Json.330;
+    let Json.112 : Str = StructAtIndex 1 Json.333;
     inc Json.112;
-    dec Json.330;
-    let Json.109 : List U8 = StructAtIndex 0 Json.329;
+    dec Json.333;
+    let Json.109 : List U8 = StructAtIndex 0 Json.332;
     inc Json.109;
-    let Json.110 : U64 = StructAtIndex 1 Json.329;
-    dec Json.329;
-    let Json.357 : I32 = 34i64;
-    let Json.356 : U8 = CallByName Num.123 Json.357;
-    let Json.354 : List U8 = CallByName List.4 Json.109 Json.356;
-    let Json.355 : List U8 = CallByName Str.12 Json.111;
-    let Json.351 : List U8 = CallByName List.8 Json.354 Json.355;
-    let Json.353 : I32 = 34i64;
+    let Json.110 : U64 = StructAtIndex 1 Json.332;
+    dec Json.332;
+    let Json.360 : I32 = 34i64;
+    let Json.359 : U8 = CallByName Num.123 Json.360;
+    let Json.357 : List U8 = CallByName List.4 Json.109 Json.359;
+    let Json.358 : List U8 = CallByName Str.12 Json.111;
+    let Json.354 : List U8 = CallByName List.8 Json.357 Json.358;
+    let Json.356 : I32 = 34i64;
+    let Json.355 : U8 = CallByName Num.123 Json.356;
+    let Json.351 : List U8 = CallByName List.4 Json.354 Json.355;
+    let Json.353 : I32 = 58i64;
     let Json.352 : U8 = CallByName Num.123 Json.353;
-    let Json.348 : List U8 = CallByName List.4 Json.351 Json.352;
-    let Json.350 : I32 = 58i64;
-    let Json.349 : U8 = CallByName Num.123 Json.350;
-    let Json.346 : List U8 = CallByName List.4 Json.348 Json.349;
-    let Json.347 : {} = Struct {};
-    let Json.113 : List U8 = CallByName Encode.23 Json.346 Json.112 Json.347;
-    joinpoint Json.341 Json.114:
-        let Json.339 : U64 = 1i64;
-        let Json.338 : U64 = CallByName Num.20 Json.110 Json.339;
-        let Json.337 : {List U8, U64} = Struct {Json.114, Json.338};
-        ret Json.337;
+    let Json.349 : List U8 = CallByName List.4 Json.351 Json.352;
+    let Json.350 : {} = Struct {};
+    let Json.113 : List U8 = CallByName Encode.23 Json.349 Json.112 Json.350;
+    joinpoint Json.344 Json.114:
+        let Json.342 : U64 = 1i64;
+        let Json.341 : U64 = CallByName Num.20 Json.110 Json.342;
+        let Json.340 : {List U8, U64} = Struct {Json.114, Json.341};
+        ret Json.340;
     in
-    let Json.345 : U64 = 1i64;
-    let Json.342 : Int1 = CallByName Num.24 Json.110 Json.345;
-    if Json.342 then
-        let Json.344 : I32 = 44i64;
-        let Json.343 : U8 = CallByName Num.123 Json.344;
-        let Json.340 : List U8 = CallByName List.4 Json.113 Json.343;
-        jump Json.341 Json.340;
+    let Json.348 : U64 = 1i64;
+    let Json.345 : Int1 = CallByName Num.24 Json.110 Json.348;
+    if Json.345 then
+        let Json.347 : I32 = 44i64;
+        let Json.346 : U8 = CallByName Num.123 Json.347;
+        let Json.343 : List U8 = CallByName List.4 Json.113 Json.346;
+        jump Json.344 Json.343;
     else
-        jump Json.341 Json.113;
+        jump Json.344 Json.113;
 
 procedure Json.18 (Json.86):
-    let Json.326 : {Str} = Struct {Json.86};
-    let Json.325 : {Str} = CallByName Encode.22 Json.326;
-    ret Json.325;
+    let Json.328 : Str = StructAtIndex 0 Json.330;
+    inc Json.328;
+    dec Json.330;
+    let Json.330 : {Str} = Struct {Json.86};
+    let Json.327 : Str = CallByName Encode.22 Json.328;
+    ret Json.327;
 
 procedure Json.20 (Json.102):
-    let Json.320 : {List {Str, {Str}}} = Struct {Json.102};
-    let Json.319 : {List {Str, {Str}}} = CallByName Encode.22 Json.320;
+    let Json.320 : List {Str, Str} = StructAtIndex 0 Json.322;
+    inc Json.320;
+    dec Json.322;
+    let Json.322 : {List {Str, Str}} = Struct {Json.102};
+    let Json.319 : List {Str, Str} = CallByName Encode.22 Json.320;
     ret Json.319;
 
-procedure Json.87 (Json.88, Json.324, #Attr.12):
-    let Json.86 : Str = StructAtIndex 0 #Attr.12;
+procedure Json.87 (Json.88, Json.325, #Attr.12):
+    let Json.86 : Str = StructAtIndex 0 Json.374;
     inc Json.86;
-    dec #Attr.12;
+    dec Json.374;
+    let Json.374 : {Str} = Struct {#Attr.12};
+    let Json.373 : I32 = 34i64;
+    let Json.372 : U8 = CallByName Num.123 Json.373;
+    let Json.370 : List U8 = CallByName List.4 Json.88 Json.372;
+    let Json.371 : List U8 = CallByName Str.12 Json.86;
+    let Json.367 : List U8 = CallByName List.8 Json.370 Json.371;
     let Json.369 : I32 = 34i64;
     let Json.368 : U8 = CallByName Num.123 Json.369;
-    let Json.366 : List U8 = CallByName List.4 Json.88 Json.368;
-    let Json.367 : List U8 = CallByName Str.12 Json.86;
-    let Json.363 : List U8 = CallByName List.8 Json.366 Json.367;
-    let Json.365 : I32 = 34i64;
-    let Json.364 : U8 = CallByName Num.123 Json.365;
-    let Json.362 : List U8 = CallByName List.4 Json.363 Json.364;
-    ret Json.362;
+    let Json.366 : List U8 = CallByName List.4 Json.367 Json.368;
+    ret Json.366;
 
 procedure List.133 (List.134, List.135, #Attr.12):
-    let List.132 : {} = StructAtIndex 0 #Attr.12;
-    let List.441 : {List U8, U64} = CallByName Json.105 List.134 List.135;
-    let List.440 : [C [], C {List U8, U64}] = TagId(1) List.441;
-    ret List.440;
+    let List.132 : {} = StructAtIndex 0 List.443;
+    let List.443 : {{}} = Struct {#Attr.12};
+    let List.442 : {List U8, U64} = CallByName Json.105 List.134 List.135;
+    let List.441 : [C [], C {List U8, U64}] = TagId(1) List.442;
+    ret List.441;
 
 procedure List.18 (List.130, List.131, List.132):
-    let List.417 : {{}} = Struct {List.132};
+    let List.417 : {} = StructAtIndex 0 List.418;
+    let List.418 : {{}} = Struct {List.132};
     let List.411 : [C [], C {List U8, U64}] = CallByName List.75 List.130 List.131 List.417;
     let List.414 : U8 = 1i64;
     let List.415 : U8 = GetTagId List.411;
@@ -171,61 +185,61 @@ procedure List.6 (#Attr.2):
     ret List.385;
 
 procedure List.6 (#Attr.2):
-    let List.420 : U64 = lowlevel ListLen #Attr.2;
-    ret List.420;
-
-procedure List.66 (#Attr.2, #Attr.3):
-    let List.439 : {Str, {Str}} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.439;
-
-procedure List.69 (#Attr.2):
-    let List.423 : {List U8, U64} = lowlevel Unreachable #Attr.2;
-    ret List.423;
-
-procedure List.70 (#Attr.2, #Attr.3):
-    let List.422 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
-    ret List.422;
-
-procedure List.71 (#Attr.2, #Attr.3):
-    let List.421 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
+    let List.421 : U64 = lowlevel ListLen #Attr.2;
     ret List.421;
 
-procedure List.75 (List.361, List.362, List.363):
-    let List.425 : U64 = 0i64;
-    let List.426 : U64 = CallByName List.6 List.361;
-    let List.424 : [C [], C {List U8, U64}] = CallByName List.86 List.361 List.362 List.363 List.425 List.426;
+procedure List.66 (#Attr.2, #Attr.3):
+    let List.440 : {Str, Str} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.440;
+
+procedure List.69 (#Attr.2):
+    let List.424 : {List U8, U64} = lowlevel Unreachable #Attr.2;
     ret List.424;
 
-procedure List.8 (#Attr.2, #Attr.3):
-    let List.419 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
-    ret List.419;
+procedure List.70 (#Attr.2, #Attr.3):
+    let List.423 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
+    ret List.423;
 
-procedure List.86 (List.455, List.456, List.457, List.458, List.459):
-    joinpoint List.427 List.364 List.365 List.366 List.367 List.368:
-        let List.429 : Int1 = CallByName Num.22 List.367 List.368;
-        if List.429 then
-            let List.438 : {Str, {Str}} = CallByName List.66 List.364 List.367;
-            let List.430 : [C [], C {List U8, U64}] = CallByName List.133 List.365 List.438 List.366;
-            let List.435 : U8 = 1i64;
-            let List.436 : U8 = GetTagId List.430;
-            let List.437 : Int1 = lowlevel Eq List.435 List.436;
-            if List.437 then
-                let List.369 : {List U8, U64} = UnionAtIndex (Id 1) (Index 0) List.430;
+procedure List.71 (#Attr.2, #Attr.3):
+    let List.422 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
+    ret List.422;
+
+procedure List.75 (List.361, List.362, List.363):
+    let List.426 : U64 = 0i64;
+    let List.427 : U64 = CallByName List.6 List.361;
+    let List.425 : [C [], C {List U8, U64}] = CallByName List.86 List.361 List.362 List.363 List.426 List.427;
+    ret List.425;
+
+procedure List.8 (#Attr.2, #Attr.3):
+    let List.420 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
+    ret List.420;
+
+procedure List.86 (List.457, List.458, List.459, List.460, List.461):
+    joinpoint List.428 List.364 List.365 List.366 List.367 List.368:
+        let List.430 : Int1 = CallByName Num.22 List.367 List.368;
+        if List.430 then
+            let List.439 : {Str, Str} = CallByName List.66 List.364 List.367;
+            let List.431 : [C [], C {List U8, U64}] = CallByName List.133 List.365 List.439 List.366;
+            let List.436 : U8 = 1i64;
+            let List.437 : U8 = GetTagId List.431;
+            let List.438 : Int1 = lowlevel Eq List.436 List.437;
+            if List.438 then
+                let List.369 : {List U8, U64} = UnionAtIndex (Id 1) (Index 0) List.431;
                 inc List.369;
-                dec List.430;
-                let List.433 : U64 = 1i64;
-                let List.432 : U64 = CallByName Num.19 List.367 List.433;
-                jump List.427 List.364 List.369 List.366 List.432 List.368;
+                dec List.431;
+                let List.434 : U64 = 1i64;
+                let List.433 : U64 = CallByName Num.19 List.367 List.434;
+                jump List.428 List.364 List.369 List.366 List.433 List.368;
             else
-                let List.370 : [] = UnionAtIndex (Id 0) (Index 0) List.430;
-                dec List.430;
-                let List.434 : [C [], C {List U8, U64}] = TagId(0) List.370;
-                ret List.434;
+                let List.370 : [] = UnionAtIndex (Id 0) (Index 0) List.431;
+                dec List.431;
+                let List.435 : [C [], C {List U8, U64}] = TagId(0) List.370;
+                ret List.435;
         else
-            let List.428 : [C [], C {List U8, U64}] = TagId(1) List.365;
-            ret List.428;
+            let List.429 : [C [], C {List U8, U64}] = TagId(1) List.365;
+            ret List.429;
     in
-    jump List.427 List.455 List.456 List.457 List.458 List.459;
+    jump List.428 List.457 List.458 List.459 List.460 List.461;
 
 procedure Num.123 (#Attr.2):
     let Num.264 : U8 = lowlevel NumIntCast #Attr.2;

--- a/crates/compiler/test_mono/generated/encode_derived_string.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_string.txt
@@ -16,18 +16,18 @@ procedure Json.1 ():
     ret Json.318;
 
 procedure Json.18 (Json.86):
+    let Json.322 : {Str} = Struct {Json.86};
     let Json.320 : Str = StructAtIndex 0 Json.322;
     inc Json.320;
     dec Json.322;
-    let Json.322 : {Str} = Struct {Json.86};
     let Json.319 : Str = CallByName Encode.22 Json.320;
     ret Json.319;
 
 procedure Json.87 (Json.88, Json.321, #Attr.12):
+    let Json.332 : {Str} = Struct {#Attr.12};
     let Json.86 : Str = StructAtIndex 0 Json.332;
     inc Json.86;
     dec Json.332;
-    let Json.332 : {Str} = Struct {#Attr.12};
     let Json.331 : I32 = 34i64;
     let Json.330 : U8 = CallByName Num.123 Json.331;
     let Json.328 : List U8 = CallByName List.4 Json.88 Json.330;

--- a/crates/compiler/test_mono/generated/encode_derived_string.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_string.txt
@@ -16,27 +16,19 @@ procedure Json.1 ():
     ret Json.318;
 
 procedure Json.18 (Json.86):
-    let Json.322 : {Str} = Struct {Json.86};
-    let Json.320 : Str = StructAtIndex 0 Json.322;
-    inc Json.320;
-    dec Json.322;
-    let Json.319 : Str = CallByName Encode.22 Json.320;
+    let Json.319 : Str = CallByName Encode.22 Json.86;
     ret Json.319;
 
-procedure Json.87 (Json.88, Json.321, #Attr.12):
-    let Json.332 : {Str} = Struct {#Attr.12};
-    let Json.86 : Str = StructAtIndex 0 Json.332;
-    inc Json.86;
-    dec Json.332;
-    let Json.331 : I32 = 34i64;
-    let Json.330 : U8 = CallByName Num.123 Json.331;
-    let Json.328 : List U8 = CallByName List.4 Json.88 Json.330;
-    let Json.329 : List U8 = CallByName Str.12 Json.86;
-    let Json.325 : List U8 = CallByName List.8 Json.328 Json.329;
-    let Json.327 : I32 = 34i64;
-    let Json.326 : U8 = CallByName Num.123 Json.327;
-    let Json.324 : List U8 = CallByName List.4 Json.325 Json.326;
-    ret Json.324;
+procedure Json.87 (Json.88, Json.321, Json.86):
+    let Json.330 : I32 = 34i64;
+    let Json.329 : U8 = CallByName Num.123 Json.330;
+    let Json.327 : List U8 = CallByName List.4 Json.88 Json.329;
+    let Json.328 : List U8 = CallByName Str.12 Json.86;
+    let Json.324 : List U8 = CallByName List.8 Json.327 Json.328;
+    let Json.326 : I32 = 34i64;
+    let Json.325 : U8 = CallByName Num.123 Json.326;
+    let Json.323 : List U8 = CallByName List.4 Json.324 Json.325;
+    ret Json.323;
 
 procedure List.4 (List.101, List.102):
     let List.392 : U64 = 1i64;

--- a/crates/compiler/test_mono/generated/encode_derived_string.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_string.txt
@@ -7,7 +7,7 @@ procedure Encode.23 (Encode.94, Encode.102, Encode.96):
 
 procedure Encode.25 (Encode.100, Encode.101):
     let Encode.104 : List U8 = Array [];
-    let Encode.105 : {Str} = CallByName Json.18 Encode.100;
+    let Encode.105 : Str = CallByName Json.18 Encode.100;
     let Encode.103 : List U8 = CallByName Encode.23 Encode.104 Encode.105 Encode.101;
     ret Encode.103;
 
@@ -16,23 +16,27 @@ procedure Json.1 ():
     ret Json.318;
 
 procedure Json.18 (Json.86):
-    let Json.320 : {Str} = Struct {Json.86};
-    let Json.319 : {Str} = CallByName Encode.22 Json.320;
+    let Json.320 : Str = StructAtIndex 0 Json.322;
+    inc Json.320;
+    dec Json.322;
+    let Json.322 : {Str} = Struct {Json.86};
+    let Json.319 : Str = CallByName Encode.22 Json.320;
     ret Json.319;
 
 procedure Json.87 (Json.88, Json.321, #Attr.12):
-    let Json.86 : Str = StructAtIndex 0 #Attr.12;
+    let Json.86 : Str = StructAtIndex 0 Json.332;
     inc Json.86;
-    dec #Attr.12;
-    let Json.330 : I32 = 34i64;
-    let Json.329 : U8 = CallByName Num.123 Json.330;
-    let Json.327 : List U8 = CallByName List.4 Json.88 Json.329;
-    let Json.328 : List U8 = CallByName Str.12 Json.86;
-    let Json.324 : List U8 = CallByName List.8 Json.327 Json.328;
-    let Json.326 : I32 = 34i64;
-    let Json.325 : U8 = CallByName Num.123 Json.326;
-    let Json.323 : List U8 = CallByName List.4 Json.324 Json.325;
-    ret Json.323;
+    dec Json.332;
+    let Json.332 : {Str} = Struct {#Attr.12};
+    let Json.331 : I32 = 34i64;
+    let Json.330 : U8 = CallByName Num.123 Json.331;
+    let Json.328 : List U8 = CallByName List.4 Json.88 Json.330;
+    let Json.329 : List U8 = CallByName Str.12 Json.86;
+    let Json.325 : List U8 = CallByName List.8 Json.328 Json.329;
+    let Json.327 : I32 = 34i64;
+    let Json.326 : U8 = CallByName Num.123 Json.327;
+    let Json.324 : List U8 = CallByName List.4 Json.325 Json.326;
+    ret Json.324;
 
 procedure List.4 (List.101, List.102):
     let List.392 : U64 = 1i64;

--- a/crates/compiler/test_mono/generated/encode_derived_tag_one_field_string.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_tag_one_field_string.txt
@@ -1,25 +1,17 @@
 procedure #Derived.0 (#Derived.1):
-    let #Derived_gen.2 : {Str} = Struct {#Derived.1};
-    let #Derived_gen.1 : Str = StructAtIndex 0 #Derived_gen.2;
-    inc #Derived_gen.1;
-    dec #Derived_gen.2;
-    let #Derived_gen.0 : Str = CallByName Encode.22 #Derived_gen.1;
+    let #Derived_gen.0 : Str = CallByName Encode.22 #Derived.1;
     ret #Derived_gen.0;
 
-procedure #Derived.3 (#Derived.4, #Derived.5, #Attr.12):
-    let #Derived_gen.11 : {Str} = Struct {#Attr.12};
-    let #Derived.1 : Str = StructAtIndex 0 #Derived_gen.11;
-    inc #Derived.1;
-    dec #Derived_gen.11;
-    joinpoint #Derived_gen.6 #Derived_gen.5:
-        let #Derived_gen.4 : List U8 = CallByName Encode.23 #Derived.4 #Derived_gen.5 #Derived.5;
-        ret #Derived_gen.4;
+procedure #Derived.3 (#Derived.4, #Derived.5, #Derived.1):
+    joinpoint #Derived_gen.5 #Derived_gen.4:
+        let #Derived_gen.3 : List U8 = CallByName Encode.23 #Derived.4 #Derived_gen.4 #Derived.5;
+        ret #Derived_gen.3;
     in
-    let #Derived_gen.8 : Str = "A";
-    let #Derived_gen.10 : Str = CallByName Json.18 #Derived.1;
-    let #Derived_gen.9 : List Str = Array [#Derived_gen.10];
-    let #Derived_gen.7 : {Str, List Str} = CallByName Json.21 #Derived_gen.8 #Derived_gen.9;
-    jump #Derived_gen.6 #Derived_gen.7;
+    let #Derived_gen.7 : Str = "A";
+    let #Derived_gen.9 : Str = CallByName Json.18 #Derived.1;
+    let #Derived_gen.8 : List Str = Array [#Derived_gen.9];
+    let #Derived_gen.6 : {Str, List Str} = CallByName Json.21 #Derived_gen.7 #Derived_gen.8;
+    jump #Derived_gen.5 #Derived_gen.6;
 
 procedure Encode.22 (Encode.93):
     ret Encode.93;
@@ -58,68 +50,64 @@ procedure Json.117 (Json.118, Json.321, #Attr.12):
     let Json.115 : Str = StructAtIndex 0 #Attr.12;
     inc Json.115;
     dec #Attr.12;
-    let Json.363 : I32 = 123i64;
-    let Json.362 : U8 = CallByName Num.123 Json.363;
-    let Json.359 : List U8 = CallByName List.4 Json.118 Json.362;
-    let Json.361 : I32 = 34i64;
-    let Json.360 : U8 = CallByName Num.123 Json.361;
-    let Json.357 : List U8 = CallByName List.4 Json.359 Json.360;
-    let Json.358 : List U8 = CallByName Str.12 Json.115;
-    let Json.354 : List U8 = CallByName List.8 Json.357 Json.358;
-    let Json.356 : I32 = 34i64;
-    let Json.355 : U8 = CallByName Num.123 Json.356;
-    let Json.351 : List U8 = CallByName List.4 Json.354 Json.355;
-    let Json.353 : I32 = 58i64;
-    let Json.352 : U8 = CallByName Num.123 Json.353;
-    let Json.348 : List U8 = CallByName List.4 Json.351 Json.352;
-    let Json.350 : I32 = 91i64;
-    let Json.349 : U8 = CallByName Num.123 Json.350;
-    let Json.120 : List U8 = CallByName List.4 Json.348 Json.349;
-    let Json.347 : U64 = CallByName List.6 Json.116;
-    let Json.335 : {List U8, U64} = Struct {Json.120, Json.347};
-    let Json.336 : {} = Struct {};
-    let Json.334 : {List U8, U64} = CallByName List.18 Json.116 Json.335 Json.336;
+    let Json.362 : I32 = 123i64;
+    let Json.361 : U8 = CallByName Num.123 Json.362;
+    let Json.358 : List U8 = CallByName List.4 Json.118 Json.361;
+    let Json.360 : I32 = 34i64;
+    let Json.359 : U8 = CallByName Num.123 Json.360;
+    let Json.356 : List U8 = CallByName List.4 Json.358 Json.359;
+    let Json.357 : List U8 = CallByName Str.12 Json.115;
+    let Json.353 : List U8 = CallByName List.8 Json.356 Json.357;
+    let Json.355 : I32 = 34i64;
+    let Json.354 : U8 = CallByName Num.123 Json.355;
+    let Json.350 : List U8 = CallByName List.4 Json.353 Json.354;
+    let Json.352 : I32 = 58i64;
+    let Json.351 : U8 = CallByName Num.123 Json.352;
+    let Json.347 : List U8 = CallByName List.4 Json.350 Json.351;
+    let Json.349 : I32 = 91i64;
+    let Json.348 : U8 = CallByName Num.123 Json.349;
+    let Json.120 : List U8 = CallByName List.4 Json.347 Json.348;
+    let Json.346 : U64 = CallByName List.6 Json.116;
+    let Json.334 : {List U8, U64} = Struct {Json.120, Json.346};
+    let Json.335 : {} = Struct {};
+    let Json.333 : {List U8, U64} = CallByName List.18 Json.116 Json.334 Json.335;
     dec Json.116;
-    let Json.122 : List U8 = StructAtIndex 0 Json.334;
+    let Json.122 : List U8 = StructAtIndex 0 Json.333;
     inc Json.122;
-    dec Json.334;
-    let Json.333 : I32 = 93i64;
-    let Json.332 : U8 = CallByName Num.123 Json.333;
-    let Json.329 : List U8 = CallByName List.4 Json.122 Json.332;
-    let Json.331 : I32 = 125i64;
-    let Json.330 : U8 = CallByName Num.123 Json.331;
-    let Json.328 : List U8 = CallByName List.4 Json.329 Json.330;
-    ret Json.328;
+    dec Json.333;
+    let Json.332 : I32 = 93i64;
+    let Json.331 : U8 = CallByName Num.123 Json.332;
+    let Json.328 : List U8 = CallByName List.4 Json.122 Json.331;
+    let Json.330 : I32 = 125i64;
+    let Json.329 : U8 = CallByName Num.123 Json.330;
+    let Json.327 : List U8 = CallByName List.4 Json.328 Json.329;
+    ret Json.327;
 
-procedure Json.119 (Json.327, Json.125):
-    let Json.123 : List U8 = StructAtIndex 0 Json.327;
+procedure Json.119 (Json.326, Json.125):
+    let Json.123 : List U8 = StructAtIndex 0 Json.326;
     inc Json.123;
-    let Json.124 : U64 = StructAtIndex 1 Json.327;
-    dec Json.327;
-    let Json.346 : {} = Struct {};
-    let Json.126 : List U8 = CallByName Encode.23 Json.123 Json.125 Json.346;
-    joinpoint Json.341 Json.127:
-        let Json.339 : U64 = 1i64;
-        let Json.338 : U64 = CallByName Num.20 Json.124 Json.339;
-        let Json.337 : {List U8, U64} = Struct {Json.127, Json.338};
-        ret Json.337;
+    let Json.124 : U64 = StructAtIndex 1 Json.326;
+    dec Json.326;
+    let Json.345 : {} = Struct {};
+    let Json.126 : List U8 = CallByName Encode.23 Json.123 Json.125 Json.345;
+    joinpoint Json.340 Json.127:
+        let Json.338 : U64 = 1i64;
+        let Json.337 : U64 = CallByName Num.20 Json.124 Json.338;
+        let Json.336 : {List U8, U64} = Struct {Json.127, Json.337};
+        ret Json.336;
     in
-    let Json.345 : U64 = 1i64;
-    let Json.342 : Int1 = CallByName Num.24 Json.124 Json.345;
-    if Json.342 then
-        let Json.344 : I32 = 44i64;
-        let Json.343 : U8 = CallByName Num.123 Json.344;
-        let Json.340 : List U8 = CallByName List.4 Json.126 Json.343;
-        jump Json.341 Json.340;
+    let Json.344 : U64 = 1i64;
+    let Json.341 : Int1 = CallByName Num.24 Json.124 Json.344;
+    if Json.341 then
+        let Json.343 : I32 = 44i64;
+        let Json.342 : U8 = CallByName Num.123 Json.343;
+        let Json.339 : List U8 = CallByName List.4 Json.126 Json.342;
+        jump Json.340 Json.339;
     else
-        jump Json.341 Json.126;
+        jump Json.340 Json.126;
 
 procedure Json.18 (Json.86):
-    let Json.325 : {Str} = Struct {Json.86};
-    let Json.323 : Str = StructAtIndex 0 Json.325;
-    inc Json.323;
-    dec Json.325;
-    let Json.322 : Str = CallByName Encode.22 Json.323;
+    let Json.322 : Str = CallByName Encode.22 Json.86;
     ret Json.322;
 
 procedure Json.21 (Json.115, Json.116):
@@ -127,32 +115,24 @@ procedure Json.21 (Json.115, Json.116):
     let Json.319 : {Str, List Str} = CallByName Encode.22 Json.320;
     ret Json.319;
 
-procedure Json.87 (Json.88, Json.324, #Attr.12):
-    let Json.373 : {Str} = Struct {#Attr.12};
-    let Json.86 : Str = StructAtIndex 0 Json.373;
-    inc Json.86;
-    dec Json.373;
-    let Json.372 : I32 = 34i64;
-    let Json.371 : U8 = CallByName Num.123 Json.372;
-    let Json.369 : List U8 = CallByName List.4 Json.88 Json.371;
-    let Json.370 : List U8 = CallByName Str.12 Json.86;
-    let Json.366 : List U8 = CallByName List.8 Json.369 Json.370;
-    let Json.368 : I32 = 34i64;
-    let Json.367 : U8 = CallByName Num.123 Json.368;
-    let Json.365 : List U8 = CallByName List.4 Json.366 Json.367;
-    ret Json.365;
+procedure Json.87 (Json.88, Json.324, Json.86):
+    let Json.371 : I32 = 34i64;
+    let Json.370 : U8 = CallByName Num.123 Json.371;
+    let Json.368 : List U8 = CallByName List.4 Json.88 Json.370;
+    let Json.369 : List U8 = CallByName Str.12 Json.86;
+    let Json.365 : List U8 = CallByName List.8 Json.368 Json.369;
+    let Json.367 : I32 = 34i64;
+    let Json.366 : U8 = CallByName Num.123 Json.367;
+    let Json.364 : List U8 = CallByName List.4 Json.365 Json.366;
+    ret Json.364;
 
-procedure List.133 (List.134, List.135, #Attr.12):
-    let List.449 : {{}} = Struct {#Attr.12};
-    let List.132 : {} = StructAtIndex 0 List.449;
-    let List.448 : {List U8, U64} = CallByName Json.119 List.134 List.135;
-    let List.447 : [C [], C {List U8, U64}] = TagId(1) List.448;
-    ret List.447;
+procedure List.133 (List.134, List.135, List.132):
+    let List.447 : {List U8, U64} = CallByName Json.119 List.134 List.135;
+    let List.446 : [C [], C {List U8, U64}] = TagId(1) List.447;
+    ret List.446;
 
 procedure List.18 (List.130, List.131, List.132):
-    let List.424 : {{}} = Struct {List.132};
-    let List.423 : {} = StructAtIndex 0 List.424;
-    let List.417 : [C [], C {List U8, U64}] = CallByName List.75 List.130 List.131 List.423;
+    let List.417 : [C [], C {List U8, U64}] = CallByName List.75 List.130 List.131 List.132;
     let List.420 : U8 = 1i64;
     let List.421 : U8 = GetTagId List.417;
     let List.422 : Int1 = lowlevel Eq List.420 List.421;
@@ -178,61 +158,61 @@ procedure List.6 (#Attr.2):
     ret List.385;
 
 procedure List.6 (#Attr.2):
-    let List.425 : U64 = lowlevel ListLen #Attr.2;
-    ret List.425;
+    let List.424 : U64 = lowlevel ListLen #Attr.2;
+    ret List.424;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.446 : Str = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.446;
+    let List.445 : Str = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.445;
 
 procedure List.69 (#Attr.2):
-    let List.430 : {List U8, U64} = lowlevel Unreachable #Attr.2;
-    ret List.430;
-
-procedure List.70 (#Attr.2, #Attr.3):
-    let List.429 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
+    let List.429 : {List U8, U64} = lowlevel Unreachable #Attr.2;
     ret List.429;
 
-procedure List.71 (#Attr.2, #Attr.3):
-    let List.428 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
+procedure List.70 (#Attr.2, #Attr.3):
+    let List.428 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
     ret List.428;
 
-procedure List.75 (List.361, List.362, List.363):
-    let List.432 : U64 = 0i64;
-    let List.433 : U64 = CallByName List.6 List.361;
-    let List.431 : [C [], C {List U8, U64}] = CallByName List.86 List.361 List.362 List.363 List.432 List.433;
-    ret List.431;
-
-procedure List.8 (#Attr.2, #Attr.3):
-    let List.427 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
+procedure List.71 (#Attr.2, #Attr.3):
+    let List.427 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
     ret List.427;
 
-procedure List.86 (List.463, List.464, List.465, List.466, List.467):
-    joinpoint List.434 List.364 List.365 List.366 List.367 List.368:
-        let List.436 : Int1 = CallByName Num.22 List.367 List.368;
-        if List.436 then
-            let List.445 : Str = CallByName List.66 List.364 List.367;
-            let List.437 : [C [], C {List U8, U64}] = CallByName List.133 List.365 List.445 List.366;
-            let List.442 : U8 = 1i64;
-            let List.443 : U8 = GetTagId List.437;
-            let List.444 : Int1 = lowlevel Eq List.442 List.443;
-            if List.444 then
-                let List.369 : {List U8, U64} = UnionAtIndex (Id 1) (Index 0) List.437;
+procedure List.75 (List.361, List.362, List.363):
+    let List.431 : U64 = 0i64;
+    let List.432 : U64 = CallByName List.6 List.361;
+    let List.430 : [C [], C {List U8, U64}] = CallByName List.86 List.361 List.362 List.363 List.431 List.432;
+    ret List.430;
+
+procedure List.8 (#Attr.2, #Attr.3):
+    let List.426 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
+    ret List.426;
+
+procedure List.86 (List.461, List.462, List.463, List.464, List.465):
+    joinpoint List.433 List.364 List.365 List.366 List.367 List.368:
+        let List.435 : Int1 = CallByName Num.22 List.367 List.368;
+        if List.435 then
+            let List.444 : Str = CallByName List.66 List.364 List.367;
+            let List.436 : [C [], C {List U8, U64}] = CallByName List.133 List.365 List.444 List.366;
+            let List.441 : U8 = 1i64;
+            let List.442 : U8 = GetTagId List.436;
+            let List.443 : Int1 = lowlevel Eq List.441 List.442;
+            if List.443 then
+                let List.369 : {List U8, U64} = UnionAtIndex (Id 1) (Index 0) List.436;
                 inc List.369;
-                dec List.437;
-                let List.440 : U64 = 1i64;
-                let List.439 : U64 = CallByName Num.19 List.367 List.440;
-                jump List.434 List.364 List.369 List.366 List.439 List.368;
+                dec List.436;
+                let List.439 : U64 = 1i64;
+                let List.438 : U64 = CallByName Num.19 List.367 List.439;
+                jump List.433 List.364 List.369 List.366 List.438 List.368;
             else
-                let List.370 : [] = UnionAtIndex (Id 0) (Index 0) List.437;
-                dec List.437;
-                let List.441 : [C [], C {List U8, U64}] = TagId(0) List.370;
-                ret List.441;
+                let List.370 : [] = UnionAtIndex (Id 0) (Index 0) List.436;
+                dec List.436;
+                let List.440 : [C [], C {List U8, U64}] = TagId(0) List.370;
+                ret List.440;
         else
-            let List.435 : [C [], C {List U8, U64}] = TagId(1) List.365;
-            ret List.435;
+            let List.434 : [C [], C {List U8, U64}] = TagId(1) List.365;
+            ret List.434;
     in
-    jump List.434 List.463 List.464 List.465 List.466 List.467;
+    jump List.433 List.461 List.462 List.463 List.464 List.465;
 
 procedure Num.123 (#Attr.2):
     let Num.266 : U8 = lowlevel NumIntCast #Attr.2;

--- a/crates/compiler/test_mono/generated/encode_derived_tag_one_field_string.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_tag_one_field_string.txt
@@ -1,16 +1,16 @@
 procedure #Derived.0 (#Derived.1):
+    let #Derived_gen.2 : {Str} = Struct {#Derived.1};
     let #Derived_gen.1 : Str = StructAtIndex 0 #Derived_gen.2;
     inc #Derived_gen.1;
     dec #Derived_gen.2;
-    let #Derived_gen.2 : {Str} = Struct {#Derived.1};
     let #Derived_gen.0 : Str = CallByName Encode.22 #Derived_gen.1;
     ret #Derived_gen.0;
 
 procedure #Derived.3 (#Derived.4, #Derived.5, #Attr.12):
+    let #Derived_gen.11 : {Str} = Struct {#Attr.12};
     let #Derived.1 : Str = StructAtIndex 0 #Derived_gen.11;
     inc #Derived.1;
     dec #Derived_gen.11;
-    let #Derived_gen.11 : {Str} = Struct {#Attr.12};
     joinpoint #Derived_gen.6 #Derived_gen.5:
         let #Derived_gen.4 : List U8 = CallByName Encode.23 #Derived.4 #Derived_gen.5 #Derived.5;
         ret #Derived_gen.4;
@@ -115,10 +115,10 @@ procedure Json.119 (Json.327, Json.125):
         jump Json.341 Json.126;
 
 procedure Json.18 (Json.86):
+    let Json.325 : {Str} = Struct {Json.86};
     let Json.323 : Str = StructAtIndex 0 Json.325;
     inc Json.323;
     dec Json.325;
-    let Json.325 : {Str} = Struct {Json.86};
     let Json.322 : Str = CallByName Encode.22 Json.323;
     ret Json.322;
 
@@ -128,10 +128,10 @@ procedure Json.21 (Json.115, Json.116):
     ret Json.319;
 
 procedure Json.87 (Json.88, Json.324, #Attr.12):
+    let Json.373 : {Str} = Struct {#Attr.12};
     let Json.86 : Str = StructAtIndex 0 Json.373;
     inc Json.86;
     dec Json.373;
-    let Json.373 : {Str} = Struct {#Attr.12};
     let Json.372 : I32 = 34i64;
     let Json.371 : U8 = CallByName Num.123 Json.372;
     let Json.369 : List U8 = CallByName List.4 Json.88 Json.371;
@@ -143,15 +143,15 @@ procedure Json.87 (Json.88, Json.324, #Attr.12):
     ret Json.365;
 
 procedure List.133 (List.134, List.135, #Attr.12):
-    let List.132 : {} = StructAtIndex 0 List.449;
     let List.449 : {{}} = Struct {#Attr.12};
+    let List.132 : {} = StructAtIndex 0 List.449;
     let List.448 : {List U8, U64} = CallByName Json.119 List.134 List.135;
     let List.447 : [C [], C {List U8, U64}] = TagId(1) List.448;
     ret List.447;
 
 procedure List.18 (List.130, List.131, List.132):
-    let List.423 : {} = StructAtIndex 0 List.424;
     let List.424 : {{}} = Struct {List.132};
+    let List.423 : {} = StructAtIndex 0 List.424;
     let List.417 : [C [], C {List U8, U64}] = CallByName List.75 List.130 List.131 List.423;
     let List.420 : U8 = 1i64;
     let List.421 : U8 = GetTagId List.417;

--- a/crates/compiler/test_mono/generated/encode_derived_tag_one_field_string.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_tag_one_field_string.txt
@@ -1,21 +1,25 @@
 procedure #Derived.0 (#Derived.1):
-    let #Derived_gen.1 : {Str} = Struct {#Derived.1};
-    let #Derived_gen.0 : {Str} = CallByName Encode.22 #Derived_gen.1;
+    let #Derived_gen.1 : Str = StructAtIndex 0 #Derived_gen.2;
+    inc #Derived_gen.1;
+    dec #Derived_gen.2;
+    let #Derived_gen.2 : {Str} = Struct {#Derived.1};
+    let #Derived_gen.0 : Str = CallByName Encode.22 #Derived_gen.1;
     ret #Derived_gen.0;
 
 procedure #Derived.3 (#Derived.4, #Derived.5, #Attr.12):
-    let #Derived.1 : Str = StructAtIndex 0 #Attr.12;
+    let #Derived.1 : Str = StructAtIndex 0 #Derived_gen.11;
     inc #Derived.1;
-    dec #Attr.12;
-    joinpoint #Derived_gen.5 #Derived_gen.4:
-        let #Derived_gen.3 : List U8 = CallByName Encode.23 #Derived.4 #Derived_gen.4 #Derived.5;
-        ret #Derived_gen.3;
+    dec #Derived_gen.11;
+    let #Derived_gen.11 : {Str} = Struct {#Attr.12};
+    joinpoint #Derived_gen.6 #Derived_gen.5:
+        let #Derived_gen.4 : List U8 = CallByName Encode.23 #Derived.4 #Derived_gen.5 #Derived.5;
+        ret #Derived_gen.4;
     in
-    let #Derived_gen.7 : Str = "A";
-    let #Derived_gen.9 : {Str} = CallByName Json.18 #Derived.1;
-    let #Derived_gen.8 : List {Str} = Array [#Derived_gen.9];
-    let #Derived_gen.6 : {Str, List {Str}} = CallByName Json.21 #Derived_gen.7 #Derived_gen.8;
-    jump #Derived_gen.5 #Derived_gen.6;
+    let #Derived_gen.8 : Str = "A";
+    let #Derived_gen.10 : Str = CallByName Json.18 #Derived.1;
+    let #Derived_gen.9 : List Str = Array [#Derived_gen.10];
+    let #Derived_gen.7 : {Str, List Str} = CallByName Json.21 #Derived_gen.8 #Derived_gen.9;
+    jump #Derived_gen.6 #Derived_gen.7;
 
 procedure Encode.22 (Encode.93):
     ret Encode.93;
@@ -40,7 +44,7 @@ procedure Encode.23 (Encode.94, Encode.102, Encode.96):
 
 procedure Encode.25 (Encode.100, Encode.101):
     let Encode.104 : List U8 = Array [];
-    let Encode.105 : {Str} = CallByName #Derived.0 Encode.100;
+    let Encode.105 : Str = CallByName #Derived.0 Encode.100;
     let Encode.103 : List U8 = CallByName Encode.23 Encode.104 Encode.105 Encode.101;
     ret Encode.103;
 
@@ -49,99 +53,105 @@ procedure Json.1 ():
     ret Json.318;
 
 procedure Json.117 (Json.118, Json.321, #Attr.12):
-    let Json.116 : List {Str} = StructAtIndex 1 #Attr.12;
+    let Json.116 : List Str = StructAtIndex 1 #Attr.12;
     inc Json.116;
     let Json.115 : Str = StructAtIndex 0 #Attr.12;
     inc Json.115;
     dec #Attr.12;
-    let Json.362 : I32 = 123i64;
-    let Json.361 : U8 = CallByName Num.123 Json.362;
-    let Json.358 : List U8 = CallByName List.4 Json.118 Json.361;
-    let Json.360 : I32 = 34i64;
-    let Json.359 : U8 = CallByName Num.123 Json.360;
-    let Json.356 : List U8 = CallByName List.4 Json.358 Json.359;
-    let Json.357 : List U8 = CallByName Str.12 Json.115;
-    let Json.353 : List U8 = CallByName List.8 Json.356 Json.357;
-    let Json.355 : I32 = 34i64;
-    let Json.354 : U8 = CallByName Num.123 Json.355;
-    let Json.350 : List U8 = CallByName List.4 Json.353 Json.354;
-    let Json.352 : I32 = 58i64;
-    let Json.351 : U8 = CallByName Num.123 Json.352;
-    let Json.347 : List U8 = CallByName List.4 Json.350 Json.351;
-    let Json.349 : I32 = 91i64;
-    let Json.348 : U8 = CallByName Num.123 Json.349;
-    let Json.120 : List U8 = CallByName List.4 Json.347 Json.348;
-    let Json.346 : U64 = CallByName List.6 Json.116;
-    let Json.334 : {List U8, U64} = Struct {Json.120, Json.346};
-    let Json.335 : {} = Struct {};
-    let Json.333 : {List U8, U64} = CallByName List.18 Json.116 Json.334 Json.335;
+    let Json.363 : I32 = 123i64;
+    let Json.362 : U8 = CallByName Num.123 Json.363;
+    let Json.359 : List U8 = CallByName List.4 Json.118 Json.362;
+    let Json.361 : I32 = 34i64;
+    let Json.360 : U8 = CallByName Num.123 Json.361;
+    let Json.357 : List U8 = CallByName List.4 Json.359 Json.360;
+    let Json.358 : List U8 = CallByName Str.12 Json.115;
+    let Json.354 : List U8 = CallByName List.8 Json.357 Json.358;
+    let Json.356 : I32 = 34i64;
+    let Json.355 : U8 = CallByName Num.123 Json.356;
+    let Json.351 : List U8 = CallByName List.4 Json.354 Json.355;
+    let Json.353 : I32 = 58i64;
+    let Json.352 : U8 = CallByName Num.123 Json.353;
+    let Json.348 : List U8 = CallByName List.4 Json.351 Json.352;
+    let Json.350 : I32 = 91i64;
+    let Json.349 : U8 = CallByName Num.123 Json.350;
+    let Json.120 : List U8 = CallByName List.4 Json.348 Json.349;
+    let Json.347 : U64 = CallByName List.6 Json.116;
+    let Json.335 : {List U8, U64} = Struct {Json.120, Json.347};
+    let Json.336 : {} = Struct {};
+    let Json.334 : {List U8, U64} = CallByName List.18 Json.116 Json.335 Json.336;
     dec Json.116;
-    let Json.122 : List U8 = StructAtIndex 0 Json.333;
+    let Json.122 : List U8 = StructAtIndex 0 Json.334;
     inc Json.122;
-    dec Json.333;
-    let Json.332 : I32 = 93i64;
-    let Json.331 : U8 = CallByName Num.123 Json.332;
-    let Json.328 : List U8 = CallByName List.4 Json.122 Json.331;
-    let Json.330 : I32 = 125i64;
-    let Json.329 : U8 = CallByName Num.123 Json.330;
-    let Json.327 : List U8 = CallByName List.4 Json.328 Json.329;
-    ret Json.327;
+    dec Json.334;
+    let Json.333 : I32 = 93i64;
+    let Json.332 : U8 = CallByName Num.123 Json.333;
+    let Json.329 : List U8 = CallByName List.4 Json.122 Json.332;
+    let Json.331 : I32 = 125i64;
+    let Json.330 : U8 = CallByName Num.123 Json.331;
+    let Json.328 : List U8 = CallByName List.4 Json.329 Json.330;
+    ret Json.328;
 
-procedure Json.119 (Json.326, Json.125):
-    let Json.123 : List U8 = StructAtIndex 0 Json.326;
+procedure Json.119 (Json.327, Json.125):
+    let Json.123 : List U8 = StructAtIndex 0 Json.327;
     inc Json.123;
-    let Json.124 : U64 = StructAtIndex 1 Json.326;
-    dec Json.326;
-    let Json.345 : {} = Struct {};
-    let Json.126 : List U8 = CallByName Encode.23 Json.123 Json.125 Json.345;
-    joinpoint Json.340 Json.127:
-        let Json.338 : U64 = 1i64;
-        let Json.337 : U64 = CallByName Num.20 Json.124 Json.338;
-        let Json.336 : {List U8, U64} = Struct {Json.127, Json.337};
-        ret Json.336;
+    let Json.124 : U64 = StructAtIndex 1 Json.327;
+    dec Json.327;
+    let Json.346 : {} = Struct {};
+    let Json.126 : List U8 = CallByName Encode.23 Json.123 Json.125 Json.346;
+    joinpoint Json.341 Json.127:
+        let Json.339 : U64 = 1i64;
+        let Json.338 : U64 = CallByName Num.20 Json.124 Json.339;
+        let Json.337 : {List U8, U64} = Struct {Json.127, Json.338};
+        ret Json.337;
     in
-    let Json.344 : U64 = 1i64;
-    let Json.341 : Int1 = CallByName Num.24 Json.124 Json.344;
-    if Json.341 then
-        let Json.343 : I32 = 44i64;
-        let Json.342 : U8 = CallByName Num.123 Json.343;
-        let Json.339 : List U8 = CallByName List.4 Json.126 Json.342;
-        jump Json.340 Json.339;
+    let Json.345 : U64 = 1i64;
+    let Json.342 : Int1 = CallByName Num.24 Json.124 Json.345;
+    if Json.342 then
+        let Json.344 : I32 = 44i64;
+        let Json.343 : U8 = CallByName Num.123 Json.344;
+        let Json.340 : List U8 = CallByName List.4 Json.126 Json.343;
+        jump Json.341 Json.340;
     else
-        jump Json.340 Json.126;
+        jump Json.341 Json.126;
 
 procedure Json.18 (Json.86):
-    let Json.323 : {Str} = Struct {Json.86};
-    let Json.322 : {Str} = CallByName Encode.22 Json.323;
+    let Json.323 : Str = StructAtIndex 0 Json.325;
+    inc Json.323;
+    dec Json.325;
+    let Json.325 : {Str} = Struct {Json.86};
+    let Json.322 : Str = CallByName Encode.22 Json.323;
     ret Json.322;
 
 procedure Json.21 (Json.115, Json.116):
-    let Json.320 : {Str, List {Str}} = Struct {Json.115, Json.116};
-    let Json.319 : {Str, List {Str}} = CallByName Encode.22 Json.320;
+    let Json.320 : {Str, List Str} = Struct {Json.115, Json.116};
+    let Json.319 : {Str, List Str} = CallByName Encode.22 Json.320;
     ret Json.319;
 
 procedure Json.87 (Json.88, Json.324, #Attr.12):
-    let Json.86 : Str = StructAtIndex 0 #Attr.12;
+    let Json.86 : Str = StructAtIndex 0 Json.373;
     inc Json.86;
-    dec #Attr.12;
-    let Json.371 : I32 = 34i64;
-    let Json.370 : U8 = CallByName Num.123 Json.371;
-    let Json.368 : List U8 = CallByName List.4 Json.88 Json.370;
-    let Json.369 : List U8 = CallByName Str.12 Json.86;
-    let Json.365 : List U8 = CallByName List.8 Json.368 Json.369;
-    let Json.367 : I32 = 34i64;
-    let Json.366 : U8 = CallByName Num.123 Json.367;
-    let Json.364 : List U8 = CallByName List.4 Json.365 Json.366;
-    ret Json.364;
+    dec Json.373;
+    let Json.373 : {Str} = Struct {#Attr.12};
+    let Json.372 : I32 = 34i64;
+    let Json.371 : U8 = CallByName Num.123 Json.372;
+    let Json.369 : List U8 = CallByName List.4 Json.88 Json.371;
+    let Json.370 : List U8 = CallByName Str.12 Json.86;
+    let Json.366 : List U8 = CallByName List.8 Json.369 Json.370;
+    let Json.368 : I32 = 34i64;
+    let Json.367 : U8 = CallByName Num.123 Json.368;
+    let Json.365 : List U8 = CallByName List.4 Json.366 Json.367;
+    ret Json.365;
 
 procedure List.133 (List.134, List.135, #Attr.12):
-    let List.132 : {} = StructAtIndex 0 #Attr.12;
-    let List.447 : {List U8, U64} = CallByName Json.119 List.134 List.135;
-    let List.446 : [C [], C {List U8, U64}] = TagId(1) List.447;
-    ret List.446;
+    let List.132 : {} = StructAtIndex 0 List.449;
+    let List.449 : {{}} = Struct {#Attr.12};
+    let List.448 : {List U8, U64} = CallByName Json.119 List.134 List.135;
+    let List.447 : [C [], C {List U8, U64}] = TagId(1) List.448;
+    ret List.447;
 
 procedure List.18 (List.130, List.131, List.132):
-    let List.423 : {{}} = Struct {List.132};
+    let List.423 : {} = StructAtIndex 0 List.424;
+    let List.424 : {{}} = Struct {List.132};
     let List.417 : [C [], C {List U8, U64}] = CallByName List.75 List.130 List.131 List.423;
     let List.420 : U8 = 1i64;
     let List.421 : U8 = GetTagId List.417;
@@ -168,61 +178,61 @@ procedure List.6 (#Attr.2):
     ret List.385;
 
 procedure List.6 (#Attr.2):
-    let List.424 : U64 = lowlevel ListLen #Attr.2;
-    ret List.424;
+    let List.425 : U64 = lowlevel ListLen #Attr.2;
+    ret List.425;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.445 : {Str} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.445;
+    let List.446 : Str = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.446;
 
 procedure List.69 (#Attr.2):
-    let List.429 : {List U8, U64} = lowlevel Unreachable #Attr.2;
-    ret List.429;
-
-procedure List.70 (#Attr.2, #Attr.3):
-    let List.428 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
-    ret List.428;
-
-procedure List.71 (#Attr.2, #Attr.3):
-    let List.427 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
-    ret List.427;
-
-procedure List.75 (List.361, List.362, List.363):
-    let List.431 : U64 = 0i64;
-    let List.432 : U64 = CallByName List.6 List.361;
-    let List.430 : [C [], C {List U8, U64}] = CallByName List.86 List.361 List.362 List.363 List.431 List.432;
+    let List.430 : {List U8, U64} = lowlevel Unreachable #Attr.2;
     ret List.430;
 
-procedure List.8 (#Attr.2, #Attr.3):
-    let List.426 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
-    ret List.426;
+procedure List.70 (#Attr.2, #Attr.3):
+    let List.429 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
+    ret List.429;
 
-procedure List.86 (List.461, List.462, List.463, List.464, List.465):
-    joinpoint List.433 List.364 List.365 List.366 List.367 List.368:
-        let List.435 : Int1 = CallByName Num.22 List.367 List.368;
-        if List.435 then
-            let List.444 : {Str} = CallByName List.66 List.364 List.367;
-            let List.436 : [C [], C {List U8, U64}] = CallByName List.133 List.365 List.444 List.366;
-            let List.441 : U8 = 1i64;
-            let List.442 : U8 = GetTagId List.436;
-            let List.443 : Int1 = lowlevel Eq List.441 List.442;
-            if List.443 then
-                let List.369 : {List U8, U64} = UnionAtIndex (Id 1) (Index 0) List.436;
+procedure List.71 (#Attr.2, #Attr.3):
+    let List.428 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
+    ret List.428;
+
+procedure List.75 (List.361, List.362, List.363):
+    let List.432 : U64 = 0i64;
+    let List.433 : U64 = CallByName List.6 List.361;
+    let List.431 : [C [], C {List U8, U64}] = CallByName List.86 List.361 List.362 List.363 List.432 List.433;
+    ret List.431;
+
+procedure List.8 (#Attr.2, #Attr.3):
+    let List.427 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
+    ret List.427;
+
+procedure List.86 (List.463, List.464, List.465, List.466, List.467):
+    joinpoint List.434 List.364 List.365 List.366 List.367 List.368:
+        let List.436 : Int1 = CallByName Num.22 List.367 List.368;
+        if List.436 then
+            let List.445 : Str = CallByName List.66 List.364 List.367;
+            let List.437 : [C [], C {List U8, U64}] = CallByName List.133 List.365 List.445 List.366;
+            let List.442 : U8 = 1i64;
+            let List.443 : U8 = GetTagId List.437;
+            let List.444 : Int1 = lowlevel Eq List.442 List.443;
+            if List.444 then
+                let List.369 : {List U8, U64} = UnionAtIndex (Id 1) (Index 0) List.437;
                 inc List.369;
-                dec List.436;
-                let List.439 : U64 = 1i64;
-                let List.438 : U64 = CallByName Num.19 List.367 List.439;
-                jump List.433 List.364 List.369 List.366 List.438 List.368;
+                dec List.437;
+                let List.440 : U64 = 1i64;
+                let List.439 : U64 = CallByName Num.19 List.367 List.440;
+                jump List.434 List.364 List.369 List.366 List.439 List.368;
             else
-                let List.370 : [] = UnionAtIndex (Id 0) (Index 0) List.436;
-                dec List.436;
-                let List.440 : [C [], C {List U8, U64}] = TagId(0) List.370;
-                ret List.440;
+                let List.370 : [] = UnionAtIndex (Id 0) (Index 0) List.437;
+                dec List.437;
+                let List.441 : [C [], C {List U8, U64}] = TagId(0) List.370;
+                ret List.441;
         else
-            let List.434 : [C [], C {List U8, U64}] = TagId(1) List.365;
-            ret List.434;
+            let List.435 : [C [], C {List U8, U64}] = TagId(1) List.365;
+            ret List.435;
     in
-    jump List.433 List.461 List.462 List.463 List.464 List.465;
+    jump List.434 List.463 List.464 List.465 List.466 List.467;
 
 procedure Num.123 (#Attr.2):
     let Num.266 : U8 = lowlevel NumIntCast #Attr.2;

--- a/crates/compiler/test_mono/generated/encode_derived_tag_two_payloads_string.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_tag_two_payloads_string.txt
@@ -1,31 +1,23 @@
 procedure #Derived.0 (#Derived.1):
-    let #Derived_gen.2 : {{Str, Str}} = Struct {#Derived.1};
-    let #Derived_gen.1 : {Str, Str} = StructAtIndex 0 #Derived_gen.2;
-    inc #Derived_gen.1;
-    dec #Derived_gen.2;
-    let #Derived_gen.0 : {Str, Str} = CallByName Encode.22 #Derived_gen.1;
+    let #Derived_gen.0 : {Str, Str} = CallByName Encode.22 #Derived.1;
     ret #Derived_gen.0;
 
-procedure #Derived.4 (#Derived.5, #Derived.6, #Attr.12):
-    let #Derived_gen.12 : {{Str, Str}} = Struct {#Attr.12};
-    let #Derived.1 : {Str, Str} = StructAtIndex 0 #Derived_gen.12;
-    inc #Derived.1;
-    dec #Derived_gen.12;
-    joinpoint #Derived_gen.6 #Derived_gen.5:
-        let #Derived_gen.4 : List U8 = CallByName Encode.23 #Derived.5 #Derived_gen.5 #Derived.6;
-        ret #Derived_gen.4;
+procedure #Derived.4 (#Derived.5, #Derived.6, #Derived.1):
+    joinpoint #Derived_gen.5 #Derived_gen.4:
+        let #Derived_gen.3 : List U8 = CallByName Encode.23 #Derived.5 #Derived_gen.4 #Derived.6;
+        ret #Derived_gen.3;
     in
     let #Derived.2 : Str = StructAtIndex 0 #Derived.1;
     inc #Derived.2;
     let #Derived.3 : Str = StructAtIndex 1 #Derived.1;
     inc #Derived.3;
     dec #Derived.1;
-    let #Derived_gen.8 : Str = "A";
-    let #Derived_gen.10 : Str = CallByName Json.18 #Derived.2;
-    let #Derived_gen.11 : Str = CallByName Json.18 #Derived.3;
-    let #Derived_gen.9 : List Str = Array [#Derived_gen.10, #Derived_gen.11];
-    let #Derived_gen.7 : {Str, List Str} = CallByName Json.21 #Derived_gen.8 #Derived_gen.9;
-    jump #Derived_gen.6 #Derived_gen.7;
+    let #Derived_gen.7 : Str = "A";
+    let #Derived_gen.9 : Str = CallByName Json.18 #Derived.2;
+    let #Derived_gen.10 : Str = CallByName Json.18 #Derived.3;
+    let #Derived_gen.8 : List Str = Array [#Derived_gen.9, #Derived_gen.10];
+    let #Derived_gen.6 : {Str, List Str} = CallByName Json.21 #Derived_gen.7 #Derived_gen.8;
+    jump #Derived_gen.5 #Derived_gen.6;
 
 procedure Encode.22 (Encode.93):
     ret Encode.93;
@@ -64,101 +56,89 @@ procedure Json.117 (Json.118, Json.321, #Attr.12):
     let Json.115 : Str = StructAtIndex 0 #Attr.12;
     inc Json.115;
     dec #Attr.12;
-    let Json.367 : I32 = 123i64;
-    let Json.366 : U8 = CallByName Num.123 Json.367;
-    let Json.363 : List U8 = CallByName List.4 Json.118 Json.366;
-    let Json.365 : I32 = 34i64;
+    let Json.365 : I32 = 123i64;
     let Json.364 : U8 = CallByName Num.123 Json.365;
-    let Json.361 : List U8 = CallByName List.4 Json.363 Json.364;
-    let Json.362 : List U8 = CallByName Str.12 Json.115;
-    let Json.358 : List U8 = CallByName List.8 Json.361 Json.362;
-    let Json.360 : I32 = 34i64;
-    let Json.359 : U8 = CallByName Num.123 Json.360;
-    let Json.355 : List U8 = CallByName List.4 Json.358 Json.359;
-    let Json.357 : I32 = 58i64;
-    let Json.356 : U8 = CallByName Num.123 Json.357;
-    let Json.352 : List U8 = CallByName List.4 Json.355 Json.356;
-    let Json.354 : I32 = 91i64;
-    let Json.353 : U8 = CallByName Num.123 Json.354;
-    let Json.120 : List U8 = CallByName List.4 Json.352 Json.353;
-    let Json.351 : U64 = CallByName List.6 Json.116;
-    let Json.339 : {List U8, U64} = Struct {Json.120, Json.351};
-    let Json.340 : {} = Struct {};
-    let Json.338 : {List U8, U64} = CallByName List.18 Json.116 Json.339 Json.340;
+    let Json.361 : List U8 = CallByName List.4 Json.118 Json.364;
+    let Json.363 : I32 = 34i64;
+    let Json.362 : U8 = CallByName Num.123 Json.363;
+    let Json.359 : List U8 = CallByName List.4 Json.361 Json.362;
+    let Json.360 : List U8 = CallByName Str.12 Json.115;
+    let Json.356 : List U8 = CallByName List.8 Json.359 Json.360;
+    let Json.358 : I32 = 34i64;
+    let Json.357 : U8 = CallByName Num.123 Json.358;
+    let Json.353 : List U8 = CallByName List.4 Json.356 Json.357;
+    let Json.355 : I32 = 58i64;
+    let Json.354 : U8 = CallByName Num.123 Json.355;
+    let Json.350 : List U8 = CallByName List.4 Json.353 Json.354;
+    let Json.352 : I32 = 91i64;
+    let Json.351 : U8 = CallByName Num.123 Json.352;
+    let Json.120 : List U8 = CallByName List.4 Json.350 Json.351;
+    let Json.349 : U64 = CallByName List.6 Json.116;
+    let Json.337 : {List U8, U64} = Struct {Json.120, Json.349};
+    let Json.338 : {} = Struct {};
+    let Json.336 : {List U8, U64} = CallByName List.18 Json.116 Json.337 Json.338;
     dec Json.116;
-    let Json.122 : List U8 = StructAtIndex 0 Json.338;
+    let Json.122 : List U8 = StructAtIndex 0 Json.336;
     inc Json.122;
-    dec Json.338;
-    let Json.337 : I32 = 93i64;
-    let Json.336 : U8 = CallByName Num.123 Json.337;
-    let Json.333 : List U8 = CallByName List.4 Json.122 Json.336;
-    let Json.335 : I32 = 125i64;
+    dec Json.336;
+    let Json.335 : I32 = 93i64;
     let Json.334 : U8 = CallByName Num.123 Json.335;
-    let Json.332 : List U8 = CallByName List.4 Json.333 Json.334;
-    ret Json.332;
+    let Json.331 : List U8 = CallByName List.4 Json.122 Json.334;
+    let Json.333 : I32 = 125i64;
+    let Json.332 : U8 = CallByName Num.123 Json.333;
+    let Json.330 : List U8 = CallByName List.4 Json.331 Json.332;
+    ret Json.330;
 
-procedure Json.119 (Json.331, Json.125):
-    let Json.123 : List U8 = StructAtIndex 0 Json.331;
+procedure Json.119 (Json.329, Json.125):
+    let Json.123 : List U8 = StructAtIndex 0 Json.329;
     inc Json.123;
-    let Json.124 : U64 = StructAtIndex 1 Json.331;
-    dec Json.331;
-    let Json.350 : {} = Struct {};
-    let Json.126 : List U8 = CallByName Encode.23 Json.123 Json.125 Json.350;
-    joinpoint Json.345 Json.127:
-        let Json.343 : U64 = 1i64;
-        let Json.342 : U64 = CallByName Num.20 Json.124 Json.343;
-        let Json.341 : {List U8, U64} = Struct {Json.127, Json.342};
-        ret Json.341;
+    let Json.124 : U64 = StructAtIndex 1 Json.329;
+    dec Json.329;
+    let Json.348 : {} = Struct {};
+    let Json.126 : List U8 = CallByName Encode.23 Json.123 Json.125 Json.348;
+    joinpoint Json.343 Json.127:
+        let Json.341 : U64 = 1i64;
+        let Json.340 : U64 = CallByName Num.20 Json.124 Json.341;
+        let Json.339 : {List U8, U64} = Struct {Json.127, Json.340};
+        ret Json.339;
     in
-    let Json.349 : U64 = 1i64;
-    let Json.346 : Int1 = CallByName Num.24 Json.124 Json.349;
-    if Json.346 then
-        let Json.348 : I32 = 44i64;
-        let Json.347 : U8 = CallByName Num.123 Json.348;
-        let Json.344 : List U8 = CallByName List.4 Json.126 Json.347;
-        jump Json.345 Json.344;
+    let Json.347 : U64 = 1i64;
+    let Json.344 : Int1 = CallByName Num.24 Json.124 Json.347;
+    if Json.344 then
+        let Json.346 : I32 = 44i64;
+        let Json.345 : U8 = CallByName Num.123 Json.346;
+        let Json.342 : List U8 = CallByName List.4 Json.126 Json.345;
+        jump Json.343 Json.342;
     else
-        jump Json.345 Json.126;
+        jump Json.343 Json.126;
 
 procedure Json.18 (Json.86):
-    let Json.329 : {Str} = Struct {Json.86};
-    let Json.327 : Str = StructAtIndex 0 Json.329;
-    inc Json.327;
-    dec Json.329;
-    let Json.326 : Str = CallByName Encode.22 Json.327;
-    ret Json.326;
+    let Json.325 : Str = CallByName Encode.22 Json.86;
+    ret Json.325;
 
 procedure Json.21 (Json.115, Json.116):
     let Json.320 : {Str, List Str} = Struct {Json.115, Json.116};
     let Json.319 : {Str, List Str} = CallByName Encode.22 Json.320;
     ret Json.319;
 
-procedure Json.87 (Json.88, Json.324, #Attr.12):
-    let Json.377 : {Str} = Struct {#Attr.12};
-    let Json.86 : Str = StructAtIndex 0 Json.377;
-    inc Json.86;
-    dec Json.377;
-    let Json.376 : I32 = 34i64;
-    let Json.375 : U8 = CallByName Num.123 Json.376;
-    let Json.373 : List U8 = CallByName List.4 Json.88 Json.375;
-    let Json.374 : List U8 = CallByName Str.12 Json.86;
-    let Json.370 : List U8 = CallByName List.8 Json.373 Json.374;
-    let Json.372 : I32 = 34i64;
-    let Json.371 : U8 = CallByName Num.123 Json.372;
-    let Json.369 : List U8 = CallByName List.4 Json.370 Json.371;
-    ret Json.369;
+procedure Json.87 (Json.88, Json.324, Json.86):
+    let Json.374 : I32 = 34i64;
+    let Json.373 : U8 = CallByName Num.123 Json.374;
+    let Json.371 : List U8 = CallByName List.4 Json.88 Json.373;
+    let Json.372 : List U8 = CallByName Str.12 Json.86;
+    let Json.368 : List U8 = CallByName List.8 Json.371 Json.372;
+    let Json.370 : I32 = 34i64;
+    let Json.369 : U8 = CallByName Num.123 Json.370;
+    let Json.367 : List U8 = CallByName List.4 Json.368 Json.369;
+    ret Json.367;
 
-procedure List.133 (List.134, List.135, #Attr.12):
-    let List.449 : {{}} = Struct {#Attr.12};
-    let List.132 : {} = StructAtIndex 0 List.449;
-    let List.448 : {List U8, U64} = CallByName Json.119 List.134 List.135;
-    let List.447 : [C [], C {List U8, U64}] = TagId(1) List.448;
-    ret List.447;
+procedure List.133 (List.134, List.135, List.132):
+    let List.447 : {List U8, U64} = CallByName Json.119 List.134 List.135;
+    let List.446 : [C [], C {List U8, U64}] = TagId(1) List.447;
+    ret List.446;
 
 procedure List.18 (List.130, List.131, List.132):
-    let List.424 : {{}} = Struct {List.132};
-    let List.423 : {} = StructAtIndex 0 List.424;
-    let List.417 : [C [], C {List U8, U64}] = CallByName List.75 List.130 List.131 List.423;
+    let List.417 : [C [], C {List U8, U64}] = CallByName List.75 List.130 List.131 List.132;
     let List.420 : U8 = 1i64;
     let List.421 : U8 = GetTagId List.417;
     let List.422 : Int1 = lowlevel Eq List.420 List.421;
@@ -184,61 +164,61 @@ procedure List.6 (#Attr.2):
     ret List.385;
 
 procedure List.6 (#Attr.2):
-    let List.425 : U64 = lowlevel ListLen #Attr.2;
-    ret List.425;
+    let List.424 : U64 = lowlevel ListLen #Attr.2;
+    ret List.424;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.446 : Str = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.446;
+    let List.445 : Str = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.445;
 
 procedure List.69 (#Attr.2):
-    let List.430 : {List U8, U64} = lowlevel Unreachable #Attr.2;
-    ret List.430;
-
-procedure List.70 (#Attr.2, #Attr.3):
-    let List.429 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
+    let List.429 : {List U8, U64} = lowlevel Unreachable #Attr.2;
     ret List.429;
 
-procedure List.71 (#Attr.2, #Attr.3):
-    let List.428 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
+procedure List.70 (#Attr.2, #Attr.3):
+    let List.428 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
     ret List.428;
 
-procedure List.75 (List.361, List.362, List.363):
-    let List.432 : U64 = 0i64;
-    let List.433 : U64 = CallByName List.6 List.361;
-    let List.431 : [C [], C {List U8, U64}] = CallByName List.86 List.361 List.362 List.363 List.432 List.433;
-    ret List.431;
-
-procedure List.8 (#Attr.2, #Attr.3):
-    let List.427 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
+procedure List.71 (#Attr.2, #Attr.3):
+    let List.427 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
     ret List.427;
 
-procedure List.86 (List.463, List.464, List.465, List.466, List.467):
-    joinpoint List.434 List.364 List.365 List.366 List.367 List.368:
-        let List.436 : Int1 = CallByName Num.22 List.367 List.368;
-        if List.436 then
-            let List.445 : Str = CallByName List.66 List.364 List.367;
-            let List.437 : [C [], C {List U8, U64}] = CallByName List.133 List.365 List.445 List.366;
-            let List.442 : U8 = 1i64;
-            let List.443 : U8 = GetTagId List.437;
-            let List.444 : Int1 = lowlevel Eq List.442 List.443;
-            if List.444 then
-                let List.369 : {List U8, U64} = UnionAtIndex (Id 1) (Index 0) List.437;
+procedure List.75 (List.361, List.362, List.363):
+    let List.431 : U64 = 0i64;
+    let List.432 : U64 = CallByName List.6 List.361;
+    let List.430 : [C [], C {List U8, U64}] = CallByName List.86 List.361 List.362 List.363 List.431 List.432;
+    ret List.430;
+
+procedure List.8 (#Attr.2, #Attr.3):
+    let List.426 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
+    ret List.426;
+
+procedure List.86 (List.461, List.462, List.463, List.464, List.465):
+    joinpoint List.433 List.364 List.365 List.366 List.367 List.368:
+        let List.435 : Int1 = CallByName Num.22 List.367 List.368;
+        if List.435 then
+            let List.444 : Str = CallByName List.66 List.364 List.367;
+            let List.436 : [C [], C {List U8, U64}] = CallByName List.133 List.365 List.444 List.366;
+            let List.441 : U8 = 1i64;
+            let List.442 : U8 = GetTagId List.436;
+            let List.443 : Int1 = lowlevel Eq List.441 List.442;
+            if List.443 then
+                let List.369 : {List U8, U64} = UnionAtIndex (Id 1) (Index 0) List.436;
                 inc List.369;
-                dec List.437;
-                let List.440 : U64 = 1i64;
-                let List.439 : U64 = CallByName Num.19 List.367 List.440;
-                jump List.434 List.364 List.369 List.366 List.439 List.368;
+                dec List.436;
+                let List.439 : U64 = 1i64;
+                let List.438 : U64 = CallByName Num.19 List.367 List.439;
+                jump List.433 List.364 List.369 List.366 List.438 List.368;
             else
-                let List.370 : [] = UnionAtIndex (Id 0) (Index 0) List.437;
-                dec List.437;
-                let List.441 : [C [], C {List U8, U64}] = TagId(0) List.370;
-                ret List.441;
+                let List.370 : [] = UnionAtIndex (Id 0) (Index 0) List.436;
+                dec List.436;
+                let List.440 : [C [], C {List U8, U64}] = TagId(0) List.370;
+                ret List.440;
         else
-            let List.435 : [C [], C {List U8, U64}] = TagId(1) List.365;
-            ret List.435;
+            let List.434 : [C [], C {List U8, U64}] = TagId(1) List.365;
+            ret List.434;
     in
-    jump List.434 List.463 List.464 List.465 List.466 List.467;
+    jump List.433 List.461 List.462 List.463 List.464 List.465;
 
 procedure Num.123 (#Attr.2):
     let Num.266 : U8 = lowlevel NumIntCast #Attr.2;

--- a/crates/compiler/test_mono/generated/encode_derived_tag_two_payloads_string.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_tag_two_payloads_string.txt
@@ -1,27 +1,31 @@
 procedure #Derived.0 (#Derived.1):
-    let #Derived_gen.1 : {{Str, Str}} = Struct {#Derived.1};
-    let #Derived_gen.0 : {{Str, Str}} = CallByName Encode.22 #Derived_gen.1;
+    let #Derived_gen.1 : {Str, Str} = StructAtIndex 0 #Derived_gen.2;
+    inc #Derived_gen.1;
+    dec #Derived_gen.2;
+    let #Derived_gen.2 : {{Str, Str}} = Struct {#Derived.1};
+    let #Derived_gen.0 : {Str, Str} = CallByName Encode.22 #Derived_gen.1;
     ret #Derived_gen.0;
 
 procedure #Derived.4 (#Derived.5, #Derived.6, #Attr.12):
-    let #Derived.1 : {Str, Str} = StructAtIndex 0 #Attr.12;
+    let #Derived.1 : {Str, Str} = StructAtIndex 0 #Derived_gen.12;
     inc #Derived.1;
-    dec #Attr.12;
-    joinpoint #Derived_gen.5 #Derived_gen.4:
-        let #Derived_gen.3 : List U8 = CallByName Encode.23 #Derived.5 #Derived_gen.4 #Derived.6;
-        ret #Derived_gen.3;
+    dec #Derived_gen.12;
+    let #Derived_gen.12 : {{Str, Str}} = Struct {#Attr.12};
+    joinpoint #Derived_gen.6 #Derived_gen.5:
+        let #Derived_gen.4 : List U8 = CallByName Encode.23 #Derived.5 #Derived_gen.5 #Derived.6;
+        ret #Derived_gen.4;
     in
     let #Derived.2 : Str = StructAtIndex 0 #Derived.1;
     inc #Derived.2;
     let #Derived.3 : Str = StructAtIndex 1 #Derived.1;
     inc #Derived.3;
     dec #Derived.1;
-    let #Derived_gen.7 : Str = "A";
-    let #Derived_gen.9 : {Str} = CallByName Json.18 #Derived.2;
-    let #Derived_gen.10 : {Str} = CallByName Json.18 #Derived.3;
-    let #Derived_gen.8 : List {Str} = Array [#Derived_gen.9, #Derived_gen.10];
-    let #Derived_gen.6 : {Str, List {Str}} = CallByName Json.21 #Derived_gen.7 #Derived_gen.8;
-    jump #Derived_gen.5 #Derived_gen.6;
+    let #Derived_gen.8 : Str = "A";
+    let #Derived_gen.10 : Str = CallByName Json.18 #Derived.2;
+    let #Derived_gen.11 : Str = CallByName Json.18 #Derived.3;
+    let #Derived_gen.9 : List Str = Array [#Derived_gen.10, #Derived_gen.11];
+    let #Derived_gen.7 : {Str, List Str} = CallByName Json.21 #Derived_gen.8 #Derived_gen.9;
+    jump #Derived_gen.6 #Derived_gen.7;
 
 procedure Encode.22 (Encode.93):
     ret Encode.93;
@@ -46,7 +50,7 @@ procedure Encode.23 (Encode.94, Encode.102, Encode.96):
 
 procedure Encode.25 (Encode.100, Encode.101):
     let Encode.104 : List U8 = Array [];
-    let Encode.105 : {{Str, Str}} = CallByName #Derived.0 Encode.100;
+    let Encode.105 : {Str, Str} = CallByName #Derived.0 Encode.100;
     let Encode.103 : List U8 = CallByName Encode.23 Encode.104 Encode.105 Encode.101;
     ret Encode.103;
 
@@ -55,99 +59,105 @@ procedure Json.1 ():
     ret Json.318;
 
 procedure Json.117 (Json.118, Json.321, #Attr.12):
-    let Json.116 : List {Str} = StructAtIndex 1 #Attr.12;
+    let Json.116 : List Str = StructAtIndex 1 #Attr.12;
     inc Json.116;
     let Json.115 : Str = StructAtIndex 0 #Attr.12;
     inc Json.115;
     dec #Attr.12;
-    let Json.365 : I32 = 123i64;
+    let Json.367 : I32 = 123i64;
+    let Json.366 : U8 = CallByName Num.123 Json.367;
+    let Json.363 : List U8 = CallByName List.4 Json.118 Json.366;
+    let Json.365 : I32 = 34i64;
     let Json.364 : U8 = CallByName Num.123 Json.365;
-    let Json.361 : List U8 = CallByName List.4 Json.118 Json.364;
-    let Json.363 : I32 = 34i64;
-    let Json.362 : U8 = CallByName Num.123 Json.363;
-    let Json.359 : List U8 = CallByName List.4 Json.361 Json.362;
-    let Json.360 : List U8 = CallByName Str.12 Json.115;
-    let Json.356 : List U8 = CallByName List.8 Json.359 Json.360;
-    let Json.358 : I32 = 34i64;
-    let Json.357 : U8 = CallByName Num.123 Json.358;
-    let Json.353 : List U8 = CallByName List.4 Json.356 Json.357;
-    let Json.355 : I32 = 58i64;
-    let Json.354 : U8 = CallByName Num.123 Json.355;
-    let Json.350 : List U8 = CallByName List.4 Json.353 Json.354;
-    let Json.352 : I32 = 91i64;
-    let Json.351 : U8 = CallByName Num.123 Json.352;
-    let Json.120 : List U8 = CallByName List.4 Json.350 Json.351;
-    let Json.349 : U64 = CallByName List.6 Json.116;
-    let Json.337 : {List U8, U64} = Struct {Json.120, Json.349};
-    let Json.338 : {} = Struct {};
-    let Json.336 : {List U8, U64} = CallByName List.18 Json.116 Json.337 Json.338;
+    let Json.361 : List U8 = CallByName List.4 Json.363 Json.364;
+    let Json.362 : List U8 = CallByName Str.12 Json.115;
+    let Json.358 : List U8 = CallByName List.8 Json.361 Json.362;
+    let Json.360 : I32 = 34i64;
+    let Json.359 : U8 = CallByName Num.123 Json.360;
+    let Json.355 : List U8 = CallByName List.4 Json.358 Json.359;
+    let Json.357 : I32 = 58i64;
+    let Json.356 : U8 = CallByName Num.123 Json.357;
+    let Json.352 : List U8 = CallByName List.4 Json.355 Json.356;
+    let Json.354 : I32 = 91i64;
+    let Json.353 : U8 = CallByName Num.123 Json.354;
+    let Json.120 : List U8 = CallByName List.4 Json.352 Json.353;
+    let Json.351 : U64 = CallByName List.6 Json.116;
+    let Json.339 : {List U8, U64} = Struct {Json.120, Json.351};
+    let Json.340 : {} = Struct {};
+    let Json.338 : {List U8, U64} = CallByName List.18 Json.116 Json.339 Json.340;
     dec Json.116;
-    let Json.122 : List U8 = StructAtIndex 0 Json.336;
+    let Json.122 : List U8 = StructAtIndex 0 Json.338;
     inc Json.122;
-    dec Json.336;
-    let Json.335 : I32 = 93i64;
+    dec Json.338;
+    let Json.337 : I32 = 93i64;
+    let Json.336 : U8 = CallByName Num.123 Json.337;
+    let Json.333 : List U8 = CallByName List.4 Json.122 Json.336;
+    let Json.335 : I32 = 125i64;
     let Json.334 : U8 = CallByName Num.123 Json.335;
-    let Json.331 : List U8 = CallByName List.4 Json.122 Json.334;
-    let Json.333 : I32 = 125i64;
-    let Json.332 : U8 = CallByName Num.123 Json.333;
-    let Json.330 : List U8 = CallByName List.4 Json.331 Json.332;
-    ret Json.330;
+    let Json.332 : List U8 = CallByName List.4 Json.333 Json.334;
+    ret Json.332;
 
-procedure Json.119 (Json.329, Json.125):
-    let Json.123 : List U8 = StructAtIndex 0 Json.329;
+procedure Json.119 (Json.331, Json.125):
+    let Json.123 : List U8 = StructAtIndex 0 Json.331;
     inc Json.123;
-    let Json.124 : U64 = StructAtIndex 1 Json.329;
-    dec Json.329;
-    let Json.348 : {} = Struct {};
-    let Json.126 : List U8 = CallByName Encode.23 Json.123 Json.125 Json.348;
-    joinpoint Json.343 Json.127:
-        let Json.341 : U64 = 1i64;
-        let Json.340 : U64 = CallByName Num.20 Json.124 Json.341;
-        let Json.339 : {List U8, U64} = Struct {Json.127, Json.340};
-        ret Json.339;
+    let Json.124 : U64 = StructAtIndex 1 Json.331;
+    dec Json.331;
+    let Json.350 : {} = Struct {};
+    let Json.126 : List U8 = CallByName Encode.23 Json.123 Json.125 Json.350;
+    joinpoint Json.345 Json.127:
+        let Json.343 : U64 = 1i64;
+        let Json.342 : U64 = CallByName Num.20 Json.124 Json.343;
+        let Json.341 : {List U8, U64} = Struct {Json.127, Json.342};
+        ret Json.341;
     in
-    let Json.347 : U64 = 1i64;
-    let Json.344 : Int1 = CallByName Num.24 Json.124 Json.347;
-    if Json.344 then
-        let Json.346 : I32 = 44i64;
-        let Json.345 : U8 = CallByName Num.123 Json.346;
-        let Json.342 : List U8 = CallByName List.4 Json.126 Json.345;
-        jump Json.343 Json.342;
+    let Json.349 : U64 = 1i64;
+    let Json.346 : Int1 = CallByName Num.24 Json.124 Json.349;
+    if Json.346 then
+        let Json.348 : I32 = 44i64;
+        let Json.347 : U8 = CallByName Num.123 Json.348;
+        let Json.344 : List U8 = CallByName List.4 Json.126 Json.347;
+        jump Json.345 Json.344;
     else
-        jump Json.343 Json.126;
+        jump Json.345 Json.126;
 
 procedure Json.18 (Json.86):
-    let Json.326 : {Str} = Struct {Json.86};
-    let Json.325 : {Str} = CallByName Encode.22 Json.326;
-    ret Json.325;
+    let Json.327 : Str = StructAtIndex 0 Json.329;
+    inc Json.327;
+    dec Json.329;
+    let Json.329 : {Str} = Struct {Json.86};
+    let Json.326 : Str = CallByName Encode.22 Json.327;
+    ret Json.326;
 
 procedure Json.21 (Json.115, Json.116):
-    let Json.320 : {Str, List {Str}} = Struct {Json.115, Json.116};
-    let Json.319 : {Str, List {Str}} = CallByName Encode.22 Json.320;
+    let Json.320 : {Str, List Str} = Struct {Json.115, Json.116};
+    let Json.319 : {Str, List Str} = CallByName Encode.22 Json.320;
     ret Json.319;
 
 procedure Json.87 (Json.88, Json.324, #Attr.12):
-    let Json.86 : Str = StructAtIndex 0 #Attr.12;
+    let Json.86 : Str = StructAtIndex 0 Json.377;
     inc Json.86;
-    dec #Attr.12;
-    let Json.374 : I32 = 34i64;
-    let Json.373 : U8 = CallByName Num.123 Json.374;
-    let Json.371 : List U8 = CallByName List.4 Json.88 Json.373;
-    let Json.372 : List U8 = CallByName Str.12 Json.86;
-    let Json.368 : List U8 = CallByName List.8 Json.371 Json.372;
-    let Json.370 : I32 = 34i64;
-    let Json.369 : U8 = CallByName Num.123 Json.370;
-    let Json.367 : List U8 = CallByName List.4 Json.368 Json.369;
-    ret Json.367;
+    dec Json.377;
+    let Json.377 : {Str} = Struct {#Attr.12};
+    let Json.376 : I32 = 34i64;
+    let Json.375 : U8 = CallByName Num.123 Json.376;
+    let Json.373 : List U8 = CallByName List.4 Json.88 Json.375;
+    let Json.374 : List U8 = CallByName Str.12 Json.86;
+    let Json.370 : List U8 = CallByName List.8 Json.373 Json.374;
+    let Json.372 : I32 = 34i64;
+    let Json.371 : U8 = CallByName Num.123 Json.372;
+    let Json.369 : List U8 = CallByName List.4 Json.370 Json.371;
+    ret Json.369;
 
 procedure List.133 (List.134, List.135, #Attr.12):
-    let List.132 : {} = StructAtIndex 0 #Attr.12;
-    let List.447 : {List U8, U64} = CallByName Json.119 List.134 List.135;
-    let List.446 : [C [], C {List U8, U64}] = TagId(1) List.447;
-    ret List.446;
+    let List.132 : {} = StructAtIndex 0 List.449;
+    let List.449 : {{}} = Struct {#Attr.12};
+    let List.448 : {List U8, U64} = CallByName Json.119 List.134 List.135;
+    let List.447 : [C [], C {List U8, U64}] = TagId(1) List.448;
+    ret List.447;
 
 procedure List.18 (List.130, List.131, List.132):
-    let List.423 : {{}} = Struct {List.132};
+    let List.423 : {} = StructAtIndex 0 List.424;
+    let List.424 : {{}} = Struct {List.132};
     let List.417 : [C [], C {List U8, U64}] = CallByName List.75 List.130 List.131 List.423;
     let List.420 : U8 = 1i64;
     let List.421 : U8 = GetTagId List.417;
@@ -174,61 +184,61 @@ procedure List.6 (#Attr.2):
     ret List.385;
 
 procedure List.6 (#Attr.2):
-    let List.424 : U64 = lowlevel ListLen #Attr.2;
-    ret List.424;
+    let List.425 : U64 = lowlevel ListLen #Attr.2;
+    ret List.425;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.445 : {Str} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.445;
+    let List.446 : Str = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.446;
 
 procedure List.69 (#Attr.2):
-    let List.429 : {List U8, U64} = lowlevel Unreachable #Attr.2;
-    ret List.429;
-
-procedure List.70 (#Attr.2, #Attr.3):
-    let List.428 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
-    ret List.428;
-
-procedure List.71 (#Attr.2, #Attr.3):
-    let List.427 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
-    ret List.427;
-
-procedure List.75 (List.361, List.362, List.363):
-    let List.431 : U64 = 0i64;
-    let List.432 : U64 = CallByName List.6 List.361;
-    let List.430 : [C [], C {List U8, U64}] = CallByName List.86 List.361 List.362 List.363 List.431 List.432;
+    let List.430 : {List U8, U64} = lowlevel Unreachable #Attr.2;
     ret List.430;
 
-procedure List.8 (#Attr.2, #Attr.3):
-    let List.426 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
-    ret List.426;
+procedure List.70 (#Attr.2, #Attr.3):
+    let List.429 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
+    ret List.429;
 
-procedure List.86 (List.461, List.462, List.463, List.464, List.465):
-    joinpoint List.433 List.364 List.365 List.366 List.367 List.368:
-        let List.435 : Int1 = CallByName Num.22 List.367 List.368;
-        if List.435 then
-            let List.444 : {Str} = CallByName List.66 List.364 List.367;
-            let List.436 : [C [], C {List U8, U64}] = CallByName List.133 List.365 List.444 List.366;
-            let List.441 : U8 = 1i64;
-            let List.442 : U8 = GetTagId List.436;
-            let List.443 : Int1 = lowlevel Eq List.441 List.442;
-            if List.443 then
-                let List.369 : {List U8, U64} = UnionAtIndex (Id 1) (Index 0) List.436;
+procedure List.71 (#Attr.2, #Attr.3):
+    let List.428 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
+    ret List.428;
+
+procedure List.75 (List.361, List.362, List.363):
+    let List.432 : U64 = 0i64;
+    let List.433 : U64 = CallByName List.6 List.361;
+    let List.431 : [C [], C {List U8, U64}] = CallByName List.86 List.361 List.362 List.363 List.432 List.433;
+    ret List.431;
+
+procedure List.8 (#Attr.2, #Attr.3):
+    let List.427 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
+    ret List.427;
+
+procedure List.86 (List.463, List.464, List.465, List.466, List.467):
+    joinpoint List.434 List.364 List.365 List.366 List.367 List.368:
+        let List.436 : Int1 = CallByName Num.22 List.367 List.368;
+        if List.436 then
+            let List.445 : Str = CallByName List.66 List.364 List.367;
+            let List.437 : [C [], C {List U8, U64}] = CallByName List.133 List.365 List.445 List.366;
+            let List.442 : U8 = 1i64;
+            let List.443 : U8 = GetTagId List.437;
+            let List.444 : Int1 = lowlevel Eq List.442 List.443;
+            if List.444 then
+                let List.369 : {List U8, U64} = UnionAtIndex (Id 1) (Index 0) List.437;
                 inc List.369;
-                dec List.436;
-                let List.439 : U64 = 1i64;
-                let List.438 : U64 = CallByName Num.19 List.367 List.439;
-                jump List.433 List.364 List.369 List.366 List.438 List.368;
+                dec List.437;
+                let List.440 : U64 = 1i64;
+                let List.439 : U64 = CallByName Num.19 List.367 List.440;
+                jump List.434 List.364 List.369 List.366 List.439 List.368;
             else
-                let List.370 : [] = UnionAtIndex (Id 0) (Index 0) List.436;
-                dec List.436;
-                let List.440 : [C [], C {List U8, U64}] = TagId(0) List.370;
-                ret List.440;
+                let List.370 : [] = UnionAtIndex (Id 0) (Index 0) List.437;
+                dec List.437;
+                let List.441 : [C [], C {List U8, U64}] = TagId(0) List.370;
+                ret List.441;
         else
-            let List.434 : [C [], C {List U8, U64}] = TagId(1) List.365;
-            ret List.434;
+            let List.435 : [C [], C {List U8, U64}] = TagId(1) List.365;
+            ret List.435;
     in
-    jump List.433 List.461 List.462 List.463 List.464 List.465;
+    jump List.434 List.463 List.464 List.465 List.466 List.467;
 
 procedure Num.123 (#Attr.2):
     let Num.266 : U8 = lowlevel NumIntCast #Attr.2;

--- a/crates/compiler/test_mono/generated/encode_derived_tag_two_payloads_string.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_tag_two_payloads_string.txt
@@ -1,16 +1,16 @@
 procedure #Derived.0 (#Derived.1):
+    let #Derived_gen.2 : {{Str, Str}} = Struct {#Derived.1};
     let #Derived_gen.1 : {Str, Str} = StructAtIndex 0 #Derived_gen.2;
     inc #Derived_gen.1;
     dec #Derived_gen.2;
-    let #Derived_gen.2 : {{Str, Str}} = Struct {#Derived.1};
     let #Derived_gen.0 : {Str, Str} = CallByName Encode.22 #Derived_gen.1;
     ret #Derived_gen.0;
 
 procedure #Derived.4 (#Derived.5, #Derived.6, #Attr.12):
+    let #Derived_gen.12 : {{Str, Str}} = Struct {#Attr.12};
     let #Derived.1 : {Str, Str} = StructAtIndex 0 #Derived_gen.12;
     inc #Derived.1;
     dec #Derived_gen.12;
-    let #Derived_gen.12 : {{Str, Str}} = Struct {#Attr.12};
     joinpoint #Derived_gen.6 #Derived_gen.5:
         let #Derived_gen.4 : List U8 = CallByName Encode.23 #Derived.5 #Derived_gen.5 #Derived.6;
         ret #Derived_gen.4;
@@ -121,10 +121,10 @@ procedure Json.119 (Json.331, Json.125):
         jump Json.345 Json.126;
 
 procedure Json.18 (Json.86):
+    let Json.329 : {Str} = Struct {Json.86};
     let Json.327 : Str = StructAtIndex 0 Json.329;
     inc Json.327;
     dec Json.329;
-    let Json.329 : {Str} = Struct {Json.86};
     let Json.326 : Str = CallByName Encode.22 Json.327;
     ret Json.326;
 
@@ -134,10 +134,10 @@ procedure Json.21 (Json.115, Json.116):
     ret Json.319;
 
 procedure Json.87 (Json.88, Json.324, #Attr.12):
+    let Json.377 : {Str} = Struct {#Attr.12};
     let Json.86 : Str = StructAtIndex 0 Json.377;
     inc Json.86;
     dec Json.377;
-    let Json.377 : {Str} = Struct {#Attr.12};
     let Json.376 : I32 = 34i64;
     let Json.375 : U8 = CallByName Num.123 Json.376;
     let Json.373 : List U8 = CallByName List.4 Json.88 Json.375;
@@ -149,15 +149,15 @@ procedure Json.87 (Json.88, Json.324, #Attr.12):
     ret Json.369;
 
 procedure List.133 (List.134, List.135, #Attr.12):
-    let List.132 : {} = StructAtIndex 0 List.449;
     let List.449 : {{}} = Struct {#Attr.12};
+    let List.132 : {} = StructAtIndex 0 List.449;
     let List.448 : {List U8, U64} = CallByName Json.119 List.134 List.135;
     let List.447 : [C [], C {List U8, U64}] = TagId(1) List.448;
     ret List.447;
 
 procedure List.18 (List.130, List.131, List.132):
-    let List.423 : {} = StructAtIndex 0 List.424;
     let List.424 : {{}} = Struct {List.132};
+    let List.423 : {} = StructAtIndex 0 List.424;
     let List.417 : [C [], C {List U8, U64}] = CallByName List.75 List.130 List.131 List.423;
     let List.420 : U8 = 1i64;
     let List.421 : U8 = GetTagId List.417;

--- a/crates/compiler/test_mono/generated/lambda_capture_niches_have_captured_function_in_closure.txt
+++ b/crates/compiler/test_mono/generated/lambda_capture_niches_have_captured_function_in_closure.txt
@@ -3,10 +3,10 @@ procedure Test.11 (Test.37):
     ret Test.38;
 
 procedure Test.13 (Test.51, #Attr.12):
+    let Test.54 : {Str} = Struct {#Attr.12};
     let Test.12 : Str = StructAtIndex 0 Test.54;
     inc Test.12;
     dec Test.54;
-    let Test.54 : {Str} = Struct {#Attr.12};
     ret Test.12;
 
 procedure Test.15 (Test.39):
@@ -30,10 +30,10 @@ procedure Test.3 (Test.17):
     ret Test.36;
 
 procedure Test.4 (Test.18):
+    let Test.55 : {Str} = Struct {Test.18};
     let Test.50 : Str = StructAtIndex 0 Test.55;
     inc Test.50;
     dec Test.55;
-    let Test.55 : {Str} = Struct {Test.18};
     ret Test.50;
 
 procedure Test.9 (Test.29, #Attr.12):

--- a/crates/compiler/test_mono/generated/lambda_capture_niches_have_captured_function_in_closure.txt
+++ b/crates/compiler/test_mono/generated/lambda_capture_niches_have_captured_function_in_closure.txt
@@ -2,20 +2,16 @@ procedure Test.11 (Test.37):
     let Test.38 : Str = "";
     ret Test.38;
 
-procedure Test.13 (Test.51, #Attr.12):
-    let Test.54 : {Str} = Struct {#Attr.12};
-    let Test.12 : Str = StructAtIndex 0 Test.54;
-    inc Test.12;
-    dec Test.54;
+procedure Test.13 (Test.51, Test.12):
     ret Test.12;
 
 procedure Test.15 (Test.39):
     let Test.40 : Str = "";
     ret Test.40;
 
-procedure Test.16 (Test.56):
-    let Test.58 : Str = "s1";
-    ret Test.58;
+procedure Test.16 (Test.54):
+    let Test.56 : Str = "s1";
+    ret Test.56;
 
 procedure Test.2 (Test.7, Test.8):
     let Test.9 : [C {} {}, C {} {}] = TagId(0) Test.7 Test.8;
@@ -30,11 +26,8 @@ procedure Test.3 (Test.17):
     ret Test.36;
 
 procedure Test.4 (Test.18):
-    let Test.55 : {Str} = Struct {Test.18};
-    let Test.50 : Str = StructAtIndex 0 Test.55;
-    inc Test.50;
-    dec Test.55;
-    ret Test.50;
+    inc Test.18;
+    ret Test.18;
 
 procedure Test.9 (Test.29, #Attr.12):
     let Test.8 : {} = UnionAtIndex (Id 0) (Index 1) #Attr.12;
@@ -53,6 +46,7 @@ procedure Test.9 (Test.29, #Attr.12):
     let Test.49 : {} = Struct {};
     let Test.48 : Str = CallByName Test.16 Test.49;
     let Test.45 : Str = CallByName Test.4 Test.48;
+    dec Test.48;
     let Test.47 : {} = Struct {};
     let Test.46 : Str = CallByName Test.13 Test.47 Test.45;
     ret Test.46;
@@ -75,9 +69,9 @@ procedure Test.0 ():
                 jump Test.22 Test.24;
         
     in
-    let Test.59 : Int1 = true;
-    let Test.60 : Int1 = lowlevel Eq Test.59 Test.5;
-    if Test.60 then
+    let Test.57 : Int1 = true;
+    let Test.58 : Int1 = lowlevel Eq Test.57 Test.5;
+    if Test.58 then
         let Test.27 : {} = Struct {};
         let Test.28 : {} = Struct {};
         let Test.26 : [C {} {}, C {} {}] = CallByName Test.2 Test.27 Test.28;

--- a/crates/compiler/test_mono/generated/lambda_capture_niches_have_captured_function_in_closure.txt
+++ b/crates/compiler/test_mono/generated/lambda_capture_niches_have_captured_function_in_closure.txt
@@ -3,18 +3,19 @@ procedure Test.11 (Test.37):
     ret Test.38;
 
 procedure Test.13 (Test.51, #Attr.12):
-    let Test.12 : Str = StructAtIndex 0 #Attr.12;
+    let Test.12 : Str = StructAtIndex 0 Test.54;
     inc Test.12;
-    dec #Attr.12;
+    dec Test.54;
+    let Test.54 : {Str} = Struct {#Attr.12};
     ret Test.12;
 
 procedure Test.15 (Test.39):
     let Test.40 : Str = "";
     ret Test.40;
 
-procedure Test.16 (Test.54):
-    let Test.56 : Str = "s1";
-    ret Test.56;
+procedure Test.16 (Test.56):
+    let Test.58 : Str = "s1";
+    ret Test.58;
 
 procedure Test.2 (Test.7, Test.8):
     let Test.9 : [C {} {}, C {} {}] = TagId(0) Test.7 Test.8;
@@ -29,7 +30,10 @@ procedure Test.3 (Test.17):
     ret Test.36;
 
 procedure Test.4 (Test.18):
-    let Test.50 : {Str} = Struct {Test.18};
+    let Test.50 : Str = StructAtIndex 0 Test.55;
+    inc Test.50;
+    dec Test.55;
+    let Test.55 : {Str} = Struct {Test.18};
     ret Test.50;
 
 procedure Test.9 (Test.29, #Attr.12):
@@ -48,7 +52,7 @@ procedure Test.9 (Test.29, #Attr.12):
     let Test.7 : {} = UnionAtIndex (Id 1) (Index 0) #Attr.12;
     let Test.49 : {} = Struct {};
     let Test.48 : Str = CallByName Test.16 Test.49;
-    let Test.45 : {Str} = CallByName Test.4 Test.48;
+    let Test.45 : Str = CallByName Test.4 Test.48;
     let Test.47 : {} = Struct {};
     let Test.46 : Str = CallByName Test.13 Test.47 Test.45;
     ret Test.46;
@@ -71,9 +75,9 @@ procedure Test.0 ():
                 jump Test.22 Test.24;
         
     in
-    let Test.57 : Int1 = true;
-    let Test.58 : Int1 = lowlevel Eq Test.57 Test.5;
-    if Test.58 then
+    let Test.59 : Int1 = true;
+    let Test.60 : Int1 = lowlevel Eq Test.59 Test.5;
+    if Test.60 then
         let Test.27 : {} = Struct {};
         let Test.28 : {} = Struct {};
         let Test.26 : [C {} {}, C {} {}] = CallByName Test.2 Test.27 Test.28;

--- a/crates/compiler/test_mono/generated/lambda_set_niche_same_layout_different_constructor.txt
+++ b/crates/compiler/test_mono/generated/lambda_set_niche_same_layout_different_constructor.txt
@@ -1,11 +1,15 @@
 procedure Test.1 (Test.4):
-    let Test.5 : {Str} = Struct {Test.4};
+    let Test.5 : Str = StructAtIndex 0 Test.16;
+    inc Test.5;
+    dec Test.16;
+    let Test.16 : {Str} = Struct {Test.4};
     ret Test.5;
 
 procedure Test.5 (Test.12, #Attr.12):
-    let Test.4 : Str = StructAtIndex 0 #Attr.12;
+    let Test.4 : Str = StructAtIndex 0 Test.15;
     inc Test.4;
-    dec #Attr.12;
+    dec Test.15;
+    let Test.15 : {Str} = Struct {#Attr.12};
     let Test.14 : Str = "";
     ret Test.14;
 
@@ -14,13 +18,13 @@ procedure Test.0 ():
     joinpoint Test.9 Test.3:
         ret Test.3;
     in
-    let Test.19 : Int1 = true;
-    let Test.20 : Int1 = lowlevel Eq Test.19 Test.2;
-    if Test.20 then
-        let Test.15 : Str = "";
-        let Test.10 : {Str} = CallByName Test.1 Test.15;
+    let Test.21 : Int1 = true;
+    let Test.22 : Int1 = lowlevel Eq Test.21 Test.2;
+    if Test.22 then
+        let Test.17 : Str = "";
+        let Test.10 : Str = CallByName Test.1 Test.17;
         jump Test.9 Test.10;
     else
-        let Test.18 : Str = "";
-        let Test.16 : {Str} = CallByName Test.1 Test.18;
-        jump Test.9 Test.16;
+        let Test.20 : Str = "";
+        let Test.18 : Str = CallByName Test.1 Test.20;
+        jump Test.9 Test.18;

--- a/crates/compiler/test_mono/generated/lambda_set_niche_same_layout_different_constructor.txt
+++ b/crates/compiler/test_mono/generated/lambda_set_niche_same_layout_different_constructor.txt
@@ -1,15 +1,15 @@
 procedure Test.1 (Test.4):
+    let Test.16 : {Str} = Struct {Test.4};
     let Test.5 : Str = StructAtIndex 0 Test.16;
     inc Test.5;
     dec Test.16;
-    let Test.16 : {Str} = Struct {Test.4};
     ret Test.5;
 
 procedure Test.5 (Test.12, #Attr.12):
+    let Test.15 : {Str} = Struct {#Attr.12};
     let Test.4 : Str = StructAtIndex 0 Test.15;
     inc Test.4;
     dec Test.15;
-    let Test.15 : {Str} = Struct {#Attr.12};
     let Test.14 : Str = "";
     ret Test.14;
 

--- a/crates/compiler/test_mono/generated/lambda_set_niche_same_layout_different_constructor.txt
+++ b/crates/compiler/test_mono/generated/lambda_set_niche_same_layout_different_constructor.txt
@@ -1,15 +1,9 @@
 procedure Test.1 (Test.4):
-    let Test.16 : {Str} = Struct {Test.4};
-    let Test.5 : Str = StructAtIndex 0 Test.16;
-    inc Test.5;
-    dec Test.16;
-    ret Test.5;
-
-procedure Test.5 (Test.12, #Attr.12):
-    let Test.15 : {Str} = Struct {#Attr.12};
-    let Test.4 : Str = StructAtIndex 0 Test.15;
     inc Test.4;
-    dec Test.15;
+    ret Test.4;
+
+procedure Test.5 (Test.12, Test.4):
+    dec Test.4;
     let Test.14 : Str = "";
     ret Test.14;
 
@@ -18,13 +12,15 @@ procedure Test.0 ():
     joinpoint Test.9 Test.3:
         ret Test.3;
     in
-    let Test.21 : Int1 = true;
-    let Test.22 : Int1 = lowlevel Eq Test.21 Test.2;
-    if Test.22 then
-        let Test.17 : Str = "";
-        let Test.10 : Str = CallByName Test.1 Test.17;
+    let Test.19 : Int1 = true;
+    let Test.20 : Int1 = lowlevel Eq Test.19 Test.2;
+    if Test.20 then
+        let Test.15 : Str = "";
+        let Test.10 : Str = CallByName Test.1 Test.15;
+        dec Test.15;
         jump Test.9 Test.10;
     else
-        let Test.20 : Str = "";
-        let Test.18 : Str = CallByName Test.1 Test.20;
-        jump Test.9 Test.18;
+        let Test.18 : Str = "";
+        let Test.16 : Str = CallByName Test.1 Test.18;
+        dec Test.18;
+        jump Test.9 Test.16;

--- a/crates/compiler/test_mono/generated/nested_closure.txt
+++ b/crates/compiler/test_mono/generated/nested_closure.txt
@@ -1,12 +1,12 @@
 procedure Test.1 (Test.5):
     let Test.2 : I64 = 42i64;
-    let Test.3 : I64 = StructAtIndex 0 Test.13;
     let Test.13 : {I64} = Struct {Test.2};
+    let Test.3 : I64 = StructAtIndex 0 Test.13;
     ret Test.3;
 
 procedure Test.3 (Test.9, #Attr.12):
-    let Test.2 : I64 = StructAtIndex 0 Test.12;
     let Test.12 : {I64} = Struct {#Attr.12};
+    let Test.2 : I64 = StructAtIndex 0 Test.12;
     ret Test.2;
 
 procedure Test.0 ():

--- a/crates/compiler/test_mono/generated/nested_closure.txt
+++ b/crates/compiler/test_mono/generated/nested_closure.txt
@@ -1,15 +1,17 @@
 procedure Test.1 (Test.5):
     let Test.2 : I64 = 42i64;
-    let Test.3 : {I64} = Struct {Test.2};
+    let Test.3 : I64 = StructAtIndex 0 Test.13;
+    let Test.13 : {I64} = Struct {Test.2};
     ret Test.3;
 
 procedure Test.3 (Test.9, #Attr.12):
-    let Test.2 : I64 = StructAtIndex 0 #Attr.12;
+    let Test.2 : I64 = StructAtIndex 0 Test.12;
+    let Test.12 : {I64} = Struct {#Attr.12};
     ret Test.2;
 
 procedure Test.0 ():
     let Test.8 : {} = Struct {};
-    let Test.4 : {I64} = CallByName Test.1 Test.8;
+    let Test.4 : I64 = CallByName Test.1 Test.8;
     let Test.7 : {} = Struct {};
     let Test.6 : I64 = CallByName Test.3 Test.7 Test.4;
     ret Test.6;

--- a/crates/compiler/test_mono/generated/nested_closure.txt
+++ b/crates/compiler/test_mono/generated/nested_closure.txt
@@ -1,12 +1,8 @@
 procedure Test.1 (Test.5):
     let Test.2 : I64 = 42i64;
-    let Test.13 : {I64} = Struct {Test.2};
-    let Test.3 : I64 = StructAtIndex 0 Test.13;
-    ret Test.3;
+    ret Test.2;
 
-procedure Test.3 (Test.9, #Attr.12):
-    let Test.12 : {I64} = Struct {#Attr.12};
-    let Test.2 : I64 = StructAtIndex 0 Test.12;
+procedure Test.3 (Test.9, Test.2):
     ret Test.2;
 
 procedure Test.0 ():

--- a/crates/compiler/test_mono/generated/recursive_call_capturing_function.txt
+++ b/crates/compiler/test_mono/generated/recursive_call_capturing_function.txt
@@ -4,22 +4,22 @@ procedure Num.19 (#Attr.2, #Attr.3):
 
 procedure Test.1 (Test.2):
     let Test.9 : U32 = 0i64;
-    let Test.18 : U32 = StructAtIndex 0 Test.19;
     let Test.19 : {U32} = Struct {Test.2};
+    let Test.18 : U32 = StructAtIndex 0 Test.19;
     let Test.8 : U32 = CallByName Test.3 Test.9 Test.18;
     ret Test.8;
 
 procedure Test.3 (Test.21, Test.22):
     joinpoint Test.10 Test.4 #Attr.12:
-        let Test.2 : U32 = StructAtIndex 0 Test.17;
         let Test.17 : {U32} = Struct {#Attr.12};
+        let Test.2 : U32 = StructAtIndex 0 Test.17;
         let Test.15 : Int1 = true;
         if Test.15 then
             ret Test.4;
         else
             let Test.12 : U32 = CallByName Num.19 Test.4 Test.2;
-            let Test.13 : U32 = StructAtIndex 0 Test.14;
             let Test.14 : {U32} = Struct {Test.2};
+            let Test.13 : U32 = StructAtIndex 0 Test.14;
             jump Test.10 Test.12 Test.13;
     in
     jump Test.10 Test.21 Test.22;

--- a/crates/compiler/test_mono/generated/recursive_call_capturing_function.txt
+++ b/crates/compiler/test_mono/generated/recursive_call_capturing_function.txt
@@ -4,25 +4,19 @@ procedure Num.19 (#Attr.2, #Attr.3):
 
 procedure Test.1 (Test.2):
     let Test.9 : U32 = 0i64;
-    let Test.19 : {U32} = Struct {Test.2};
-    let Test.18 : U32 = StructAtIndex 0 Test.19;
-    let Test.8 : U32 = CallByName Test.3 Test.9 Test.18;
+    let Test.8 : U32 = CallByName Test.3 Test.9 Test.2;
     ret Test.8;
 
-procedure Test.3 (Test.21, Test.22):
-    joinpoint Test.10 Test.4 #Attr.12:
-        let Test.17 : {U32} = Struct {#Attr.12};
-        let Test.2 : U32 = StructAtIndex 0 Test.17;
-        let Test.15 : Int1 = true;
-        if Test.15 then
+procedure Test.3 (Test.18, Test.19):
+    joinpoint Test.10 Test.4 Test.2:
+        let Test.14 : Int1 = true;
+        if Test.14 then
             ret Test.4;
         else
             let Test.12 : U32 = CallByName Num.19 Test.4 Test.2;
-            let Test.14 : {U32} = Struct {Test.2};
-            let Test.13 : U32 = StructAtIndex 0 Test.14;
-            jump Test.10 Test.12 Test.13;
+            jump Test.10 Test.12 Test.2;
     in
-    jump Test.10 Test.21 Test.22;
+    jump Test.10 Test.18 Test.19;
 
 procedure Test.0 ():
     let Test.7 : U32 = 6i64;

--- a/crates/compiler/test_mono/generated/recursive_call_capturing_function.txt
+++ b/crates/compiler/test_mono/generated/recursive_call_capturing_function.txt
@@ -4,22 +4,25 @@ procedure Num.19 (#Attr.2, #Attr.3):
 
 procedure Test.1 (Test.2):
     let Test.9 : U32 = 0i64;
-    let Test.16 : {U32} = Struct {Test.2};
-    let Test.8 : U32 = CallByName Test.3 Test.9 Test.16;
+    let Test.18 : U32 = StructAtIndex 0 Test.19;
+    let Test.19 : {U32} = Struct {Test.2};
+    let Test.8 : U32 = CallByName Test.3 Test.9 Test.18;
     ret Test.8;
 
-procedure Test.3 (Test.18, Test.19):
+procedure Test.3 (Test.21, Test.22):
     joinpoint Test.10 Test.4 #Attr.12:
-        let Test.2 : U32 = StructAtIndex 0 #Attr.12;
-        let Test.14 : Int1 = true;
-        if Test.14 then
+        let Test.2 : U32 = StructAtIndex 0 Test.17;
+        let Test.17 : {U32} = Struct {#Attr.12};
+        let Test.15 : Int1 = true;
+        if Test.15 then
             ret Test.4;
         else
             let Test.12 : U32 = CallByName Num.19 Test.4 Test.2;
-            let Test.13 : {U32} = Struct {Test.2};
+            let Test.13 : U32 = StructAtIndex 0 Test.14;
+            let Test.14 : {U32} = Struct {Test.2};
             jump Test.10 Test.12 Test.13;
     in
-    jump Test.10 Test.18 Test.19;
+    jump Test.10 Test.21 Test.22;
 
 procedure Test.0 ():
     let Test.7 : U32 = 6i64;


### PR DESCRIPTION
This patch consolidates how lambda sets' layouts are generated with how tag union layouts are generated. In the process I also made more explicit how you might call different lambda set layouts with a new `ClosureCallOptions` enum. The new representation should be faster in some cases, particularly when the lambda set can be represented as an unwrapped tag union.

Full list (see also individual commits)
- use tag union/recursive tag union layout generation for lambda sets
- add an enum to describe how to switch over calling a lambda
- be more explicit about cases where lambda sets are an enum over functions that don't capture anything
- always use `extend_argument_list` to decide whether or not a closure argument should be passed in a call
- use new enum variants to decide whether a lambda set actually represents captures or not, rather than checking the runtime layout