### PR TITLE
fix `nix-build` on macos

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -68,13 +68,13 @@ rustPlatform.buildRustPackage {
       xorg.libxcb
   ]
   ++ lib.optionals pkgs.stdenv.isDarwin [
-      AppKit
-      CoreFoundation
-      CoreServices
-      CoreVideo
-      Foundation
-      Metal
-      Security
+      pkgs.darwin.apple_sdk.frameworks.AppKit
+      pkgs.darwin.apple_sdk.frameworks.CoreFoundation
+      pkgs.darwin.apple_sdk.frameworks.CoreServices
+      pkgs.darwin.apple_sdk.frameworks.CoreVideo
+      pkgs.darwin.apple_sdk.frameworks.Foundation
+      pkgs.darwin.apple_sdk.frameworks.Metal
+      pkgs.darwin.apple_sdk.frameworks.Security
   ]);
 
   # cp: to copy str.zig,list.zig...

--- a/default.nix
+++ b/default.nix
@@ -1,10 +1,10 @@
 { }:
 # we only this file to release a nix package, use flake.nix for development
 let
-  rev = "f6342b8b9e7a4177c7e775cdbf38e1c1b43e7ab3"; # nixpkgs master
+  rev = "541a3ca27c9a8220b46f4feb7dd8e94336a77f42"; # nixpkgs master
   nixpkgs = builtins.fetchTarball {
     url = "https://github.com/nixos/nixpkgs/tarball/${rev}";
-    sha256 = "JTiKsBT1BwMbtSUsvtSl8ffkiirby8FaujJVGV766Q8=";
+    sha256 = "sha256:1mxv0zigm98pawf05kd4s8ipvk1pvvdsn1yh978c5an97kz0ck5w";
   };
   pkgs = import nixpkgs { };
   rustPlatform = pkgs.rustPlatform;

--- a/default.nix
+++ b/default.nix
@@ -4,6 +4,7 @@
     sha256 = "sha256:1mxv0zigm98pawf05kd4s8ipvk1pvvdsn1yh978c5an97kz0ck5w";
   },
   pkgs ? import nixpkgsSource { },
+  cargoSha256 ? "sha256-treL2sWPcZ1NBwdab3FOb2FI2wT/Vt9tD4XRfJ8rYWA=",
 }:
 # we only this file to release a nix package, use flake.nix for development
 let
@@ -18,7 +19,7 @@ rustPlatform.buildRustPackage {
 
   src = pkgs.nix-gitignore.gitignoreSource [] ./.;
 
-  cargoSha256 = "sha256-treL2sWPcZ1NBwdab3FOb2FI2wT/Vt9tD4XRfJ8rYWA=";
+  inherit cargoSha256;
 
   LLVM_SYS_130_PREFIX = "${llvmPkgs.llvm.dev}";
 

--- a/default.nix
+++ b/default.nix
@@ -18,7 +18,7 @@ rustPlatform.buildRustPackage {
 
   src = pkgs.nix-gitignore.gitignoreSource [] ./.;
 
-  cargoSha256 = "sha256-Pd84GGtW1ecrP03uiCVcybIUtWCSDGfLl+fbbdmFyiE=";
+  cargoSha256 = "sha256-treL2sWPcZ1NBwdab3FOb2FI2wT/Vt9tD4XRfJ8rYWA=";
 
   LLVM_SYS_130_PREFIX = "${llvmPkgs.llvm.dev}";
 

--- a/default.nix
+++ b/default.nix
@@ -1,12 +1,12 @@
-{ }:
-# we only this file to release a nix package, use flake.nix for development
-let
-  rev = "541a3ca27c9a8220b46f4feb7dd8e94336a77f42"; # nixpkgs master
-  nixpkgs = builtins.fetchTarball {
+{ rev ? "541a3ca27c9a8220b46f4feb7dd8e94336a77f42", # nixpkgs master
+  nixpkgsSource ? builtins.fetchTarball {
     url = "https://github.com/nixos/nixpkgs/tarball/${rev}";
     sha256 = "sha256:1mxv0zigm98pawf05kd4s8ipvk1pvvdsn1yh978c5an97kz0ck5w";
-  };
-  pkgs = import nixpkgs { };
+  },
+  pkgs ? import nixpkgsSource { },
+}:
+# we only this file to release a nix package, use flake.nix for development
+let
   rustPlatform = pkgs.rustPlatform;
   llvmPkgs = pkgs.llvmPackages_13;
   # nix does not store libs in /usr/lib or /lib


### PR DESCRIPTION
also took the opportunity to move a few things into the incoming attrset so they can be overridden when we submit to nixpkgs.