### PR TITLE
fix build on macos and format all nix files with nixfmt

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -68,13 +68,13 @@ rustPlatform.buildRustPackage {
       xorg.libxcb
   ]
   ++ lib.optionals pkgs.stdenv.isDarwin [
-      AppKit
-      CoreFoundation
-      CoreServices
-      CoreVideo
-      Foundation
-      Metal
-      Security
+      pkgs.darwin.apple_sdk.frameworks.AppKit
+      pkgs.darwin.apple_sdk.frameworks.CoreFoundation
+      pkgs.darwin.apple_sdk.frameworks.CoreServices
+      pkgs.darwin.apple_sdk.frameworks.CoreVideo
+      pkgs.darwin.apple_sdk.frameworks.Foundation
+      pkgs.darwin.apple_sdk.frameworks.Metal
+      pkgs.darwin.apple_sdk.frameworks.Security
   ]);
 
   # cp: to copy str.zig,list.zig...

--- a/default.nix
+++ b/default.nix
@@ -1,10 +1,10 @@
 { }:
 # we only this file to release a nix package, use flake.nix for development
 let
-  rev = "f6342b8b9e7a4177c7e775cdbf38e1c1b43e7ab3"; # nixpkgs master
+  rev = "541a3ca27c9a8220b46f4feb7dd8e94336a77f42"; # nixpkgs master
   nixpkgs = builtins.fetchTarball {
     url = "https://github.com/nixos/nixpkgs/tarball/${rev}";
-    sha256 = "JTiKsBT1BwMbtSUsvtSl8ffkiirby8FaujJVGV766Q8=";
+    sha256 = "sha256:1mxv0zigm98pawf05kd4s8ipvk1pvvdsn1yh978c5an97kz0ck5w";
   };
   pkgs = import nixpkgs { };
   rustPlatform = pkgs.rustPlatform;

--- a/default.nix
+++ b/default.nix
@@ -4,6 +4,7 @@
     sha256 = "sha256:1mxv0zigm98pawf05kd4s8ipvk1pvvdsn1yh978c5an97kz0ck5w";
   },
   pkgs ? import nixpkgsSource { },
+  cargoSha256 ? "sha256-treL2sWPcZ1NBwdab3FOb2FI2wT/Vt9tD4XRfJ8rYWA=",
 }:
 # we only this file to release a nix package, use flake.nix for development
 let
@@ -18,7 +19,7 @@ rustPlatform.buildRustPackage {
 
   src = pkgs.nix-gitignore.gitignoreSource [] ./.;
 
-  cargoSha256 = "sha256-treL2sWPcZ1NBwdab3FOb2FI2wT/Vt9tD4XRfJ8rYWA=";
+  inherit cargoSha256;
 
   LLVM_SYS_130_PREFIX = "${llvmPkgs.llvm.dev}";
 

--- a/default.nix
+++ b/default.nix
@@ -1,30 +1,28 @@
 { rev ? "541a3ca27c9a8220b46f4feb7dd8e94336a77f42", # nixpkgs master
-  nixpkgsSource ? builtins.fetchTarball {
-    url = "https://github.com/nixos/nixpkgs/tarball/${rev}";
-    sha256 = "sha256:1mxv0zigm98pawf05kd4s8ipvk1pvvdsn1yh978c5an97kz0ck5w";
-  },
-  pkgs ? import nixpkgsSource { },
-  cargoSha256 ? "sha256-treL2sWPcZ1NBwdab3FOb2FI2wT/Vt9tD4XRfJ8rYWA=",
-}:
+nixpkgsSource ? builtins.fetchTarball {
+  url = "https://github.com/nixos/nixpkgs/tarball/${rev}";
+  sha256 = "sha256:1mxv0zigm98pawf05kd4s8ipvk1pvvdsn1yh978c5an97kz0ck5w";
+}, pkgs ? import nixpkgsSource { }
+, cargoSha256 ? "sha256-treL2sWPcZ1NBwdab3FOb2FI2wT/Vt9tD4XRfJ8rYWA=", }:
 # we only this file to release a nix package, use flake.nix for development
 let
   rustPlatform = pkgs.rustPlatform;
   llvmPkgs = pkgs.llvmPackages_13;
   # nix does not store libs in /usr/lib or /lib
   nixGlibcPath = if pkgs.stdenv.isLinux then "${pkgs.glibc.out}/lib" else "";
-in
-rustPlatform.buildRustPackage {
+in rustPlatform.buildRustPackage {
   pname = "roc";
   version = "0.0.1";
 
-  src = pkgs.nix-gitignore.gitignoreSource [] ./.;
+  src = pkgs.nix-gitignore.gitignoreSource [ ] ./.;
 
   inherit cargoSha256;
 
   LLVM_SYS_130_PREFIX = "${llvmPkgs.llvm.dev}";
 
   # required for zig
-  XDG_CACHE_HOME = "xdg_cache"; # prevents zig AccessDenied error github.com/ziglang/zig/issues/6810
+  XDG_CACHE_HOME =
+    "xdg_cache"; # prevents zig AccessDenied error github.com/ziglang/zig/issues/6810
   # want to see backtrace in case of failure
   RUST_BACKTRACE = 1;
 
@@ -45,17 +43,17 @@ rustPlatform.buildRustPackage {
     rust-bindgen
   ]);
 
-  buildInputs = (with pkgs; [
-    libffi
-    libiconv
-    libxkbcommon
-    libxml2
-    ncurses
-    zlib
-    cargo
-    makeWrapper # necessary for postBuild wrapProgram
-  ]
-  ++ lib.optionals pkgs.stdenv.isLinux [
+  buildInputs = (with pkgs;
+    [
+      libffi
+      libiconv
+      libxkbcommon
+      libxml2
+      ncurses
+      zlib
+      cargo
+      makeWrapper # necessary for postBuild wrapProgram
+    ] ++ lib.optionals pkgs.stdenv.isLinux [
       alsa-lib
       valgrind
       vulkan-headers
@@ -67,8 +65,7 @@ rustPlatform.buildRustPackage {
       xorg.libXi
       xorg.libXrandr
       xorg.libxcb
-  ]
-  ++ lib.optionals pkgs.stdenv.isDarwin [
+    ] ++ lib.optionals pkgs.stdenv.isDarwin [
       pkgs.darwin.apple_sdk.frameworks.AppKit
       pkgs.darwin.apple_sdk.frameworks.CoreFoundation
       pkgs.darwin.apple_sdk.frameworks.CoreServices
@@ -76,15 +73,19 @@ rustPlatform.buildRustPackage {
       pkgs.darwin.apple_sdk.frameworks.Foundation
       pkgs.darwin.apple_sdk.frameworks.Metal
       pkgs.darwin.apple_sdk.frameworks.Security
-  ]);
+    ]);
 
   # cp: to copy str.zig,list.zig...
   # wrapProgram pkgs.stdenv.cc: to make ld available for compiler/build/src/link.rs
   postInstall = if pkgs.stdenv.isLinux then ''
     cp -r target/x86_64-unknown-linux-gnu/release/lib/. $out/lib
-    wrapProgram $out/bin/roc --set NIX_GLIBC_PATH ${nixGlibcPath} --prefix PATH : ${pkgs.lib.makeBinPath [ pkgs.stdenv.cc ]}
+    wrapProgram $out/bin/roc --set NIX_GLIBC_PATH ${nixGlibcPath} --prefix PATH : ${
+      pkgs.lib.makeBinPath [ pkgs.stdenv.cc ]
+    }
   '' else ''
     cp -r target/aarch64-apple-darwin/release/lib/. $out/lib
-    wrapProgram $out/bin/roc --prefix PATH : ${pkgs.lib.makeBinPath [ pkgs.stdenv.cc ]}
+    wrapProgram $out/bin/roc --prefix PATH : ${
+      pkgs.lib.makeBinPath [ pkgs.stdenv.cc ]
+    }
   '';
 }

--- a/default.nix
+++ b/default.nix
@@ -18,7 +18,7 @@ rustPlatform.buildRustPackage {
 
   src = pkgs.nix-gitignore.gitignoreSource [] ./.;
 
-  cargoSha256 = "sha256-Pd84GGtW1ecrP03uiCVcybIUtWCSDGfLl+fbbdmFyiE=";
+  cargoSha256 = "sha256-treL2sWPcZ1NBwdab3FOb2FI2wT/Vt9tD4XRfJ8rYWA=";
 
   LLVM_SYS_130_PREFIX = "${llvmPkgs.llvm.dev}";
 

--- a/default.nix
+++ b/default.nix
@@ -1,12 +1,12 @@
-{ }:
-# we only this file to release a nix package, use flake.nix for development
-let
-  rev = "541a3ca27c9a8220b46f4feb7dd8e94336a77f42"; # nixpkgs master
-  nixpkgs = builtins.fetchTarball {
+{ rev ? "541a3ca27c9a8220b46f4feb7dd8e94336a77f42", # nixpkgs master
+  nixpkgsSource ? builtins.fetchTarball {
     url = "https://github.com/nixos/nixpkgs/tarball/${rev}";
     sha256 = "sha256:1mxv0zigm98pawf05kd4s8ipvk1pvvdsn1yh978c5an97kz0ck5w";
-  };
-  pkgs = import nixpkgs { };
+  },
+  pkgs ? import nixpkgsSource { },
+}:
+# we only this file to release a nix package, use flake.nix for development
+let
   rustPlatform = pkgs.rustPlatform;
   llvmPkgs = pkgs.llvmPackages_13;
   # nix does not store libs in /usr/lib or /lib

--- a/devtools/vscodeflake.nix
+++ b/devtools/vscodeflake.nix
@@ -8,10 +8,8 @@
     flake-utils.url = "github:numtide/flake-utils";
   };
   outputs = { self, roc, flake-utils }:
-    let
-      supportedSystems = [ "x86_64-linux" "x86_64-darwin" "aarch64-darwin" ];
-    in
-    flake-utils.lib.eachSystem supportedSystems (system:
+    let supportedSystems = [ "x86_64-linux" "x86_64-darwin" "aarch64-darwin" ];
+    in flake-utils.lib.eachSystem supportedSystems (system:
       let
         pkgs = import roc.inputs.nixpkgs {
           inherit system;
@@ -19,28 +17,19 @@
         };
 
         rocShell = roc.devShell.${system};
-      in
-      {
+      in {
         devShell = pkgs.mkShell {
-          packages  = 
-              let
-                devInputs = (with pkgs; [
-                  less
-                  gdb
-                ]);
-                vscodeWithExtensions = pkgs.vscode-with-extensions.override {
-                  vscodeExtensions = with pkgs.vscode-extensions; [
-                    matklad.rust-analyzer
-                    eamodio.gitlens
-                    bbenoist.nix
-                    vadimcn.vscode-lldb
-                  ];
-                };
-              in
-                [
-                  vscodeWithExtensions
-                  devInputs
-                ];
+          packages = let
+            devInputs = (with pkgs; [ less gdb ]);
+            vscodeWithExtensions = pkgs.vscode-with-extensions.override {
+              vscodeExtensions = with pkgs.vscode-extensions; [
+                matklad.rust-analyzer
+                eamodio.gitlens
+                bbenoist.nix
+                vadimcn.vscode-lldb
+              ];
+            };
+          in [ vscodeWithExtensions devInputs ];
 
           inputsFrom = [ rocShell ];
 


### PR DESCRIPTION
I didn't want to run my editor formatter when doing #3763 but maybe it'd be nice to have the same style across the repo? Looks like `flake.nix` is already formatted with `nixfmt` (or it just happens to not have any diff, I suppose.)

If this is something we want, should I make a PR to change CI as well?

(based on #3763 but it doesn't look like I know how to make a PR stack across forks! Please only pay attention to f25786c, the only new commit on this branch.)