### PR TITLE
Fix some layout reprs

### DIFF
--- a/crates/compiler/module/src/symbol.rs
+++ b/crates/compiler/module/src/symbol.rs
@@ -152,6 +152,7 @@ impl Symbol {
     }
 
     pub const fn to_ne_bytes(self) -> [u8; 8] {
+        // repr(packed(4)) is repr(c), and with the fields as defined will not having padding.
         unsafe { std::mem::transmute(self) }
     }
 

--- a/crates/compiler/types/src/subs.rs
+++ b/crates/compiler/types/src/subs.rs
@@ -66,6 +66,7 @@ struct ErrorTypeState {
     recursive_tag_unions_seen: Vec<Variable>,
 }
 
+#[repr(C)]
 #[derive(Clone, Copy, Debug)]
 struct SubsHeader {
     utable: u64,
@@ -99,10 +100,12 @@ impl SubsHeader {
     }
 
     fn to_array(self) -> [u8; std::mem::size_of::<Self>()] {
+        // Safety: With repr(c) all fields are in order and properly aligned without padding.
         unsafe { std::mem::transmute(self) }
     }
 
     fn from_array(array: [u8; std::mem::size_of::<Self>()]) -> Self {
+        // Safety: With repr(c) all fields are in order and properly aligned without padding.
         unsafe { std::mem::transmute(array) }
     }
 }

--- a/crates/editor/src/graphics/lowlevel/vertex.rs
+++ b/crates/editor/src/graphics/lowlevel/vertex.rs
@@ -6,11 +6,14 @@
 use cgmath::Vector2;
 
 #[derive(Copy, Clone)]
+#[repr(C)]
 pub struct Vertex {
     pub position: Vector2<f32>,
     pub color: [f32; 4],
 }
 
+// Safety: As defined, there is no padding
+// the type is repr(C), and Vector2 is repr(C)
 unsafe impl bytemuck::Pod for Vertex {}
 unsafe impl bytemuck::Zeroable for Vertex {}
 

--- a/examples/breakout/platform/src/graphics/lowlevel/quad.rs
+++ b/examples/breakout/platform/src/graphics/lowlevel/quad.rs
@@ -12,6 +12,10 @@ pub struct Quad {
     pub border_width: f32,
 }
 
+// Safety: Pod's contract says the type must
+// not have any padding, and must be repr(C).
+// As currrently defined, Quad does not have
+// any padding.
 unsafe impl bytemuck::Pod for Quad {}
 unsafe impl bytemuck::Zeroable for Quad {}
 

--- a/examples/breakout/platform/src/graphics/lowlevel/quad.rs
+++ b/examples/breakout/platform/src/graphics/lowlevel/quad.rs
@@ -2,6 +2,7 @@
 
 /// A polygon with 4 corners
 #[derive(Copy, Clone)]
+#[repr(C)]
 pub struct Quad {
     pub pos: [f32; 2],
     pub width: f32,

--- a/examples/gui/platform/src/graphics/lowlevel/quad.rs
+++ b/examples/gui/platform/src/graphics/lowlevel/quad.rs
@@ -1,6 +1,7 @@
 
 
 /// A polygon with 4 corners
+#[repr(C)]
 #[derive(Copy, Clone)]
 pub struct Quad {
     pub pos: [f32; 2],
@@ -11,6 +12,7 @@ pub struct Quad {
     pub border_width: f32,
 }
 
+// Safety: repr(C), and as defined will not having padding.
 unsafe impl bytemuck::Pod for Quad {}
 unsafe impl bytemuck::Zeroable for Quad {}
 


### PR DESCRIPTION
While looking through the code, one thing I checked that is easy to miss is just proper layout attributes.

Some of the layouts were used as if they were stable, and converted to byte arrays, or [had bytemuck's Pod trait implemented without fulfilling its contract.](https://docs.rs/bytemuck/latest/bytemuck/trait.Pod.html#safety)

[By default the representation is `repr(rust)`](https://doc.rust-lang.org/reference/type-layout.html#the-default-representation), which has no guarantees at all. It can reorder fields and insert padding at will, theoretically even between compilations. I added `repr(C)`, which is Rust's interpretation of a stable platform-specific layout where I saw it is needed and some safety comments.

A brief look at your CI shows you are not running it on nightly, but if you were you could add the flag `-Z randomize-layout` to help catch relying on unstable and unspecified layouts.