### PR TITLE
Update Tutorial Link from getting_started

### DIFF
--- a/getting_started/README.md
+++ b/getting_started/README.md
@@ -4,7 +4,7 @@ Roc is a language for making delightful software. It does not have an 0.1 releas
 certainly don't recommend using it in production in its current state! However, it can be fun to
 play around with as long as you have a high tolerance for missing features and compiler bugs. :)
 
-The [tutorial](TUTORIAL.md) is the best place to learn about how to use the language - it assumes no prior knowledge of Roc or similar languages. (If you already know [Elm](https://elm-lang.org/), then [Roc for Elm Programmers](https://github.com/roc-lang/roc/blob/main/roc-for-elm-programmers.md) may be of interest.)
+The [tutorial](../TUTORIAL.md) is the best place to learn about how to use the language - it assumes no prior knowledge of Roc or similar languages. (If you already know [Elm](https://elm-lang.org/), then [Roc for Elm Programmers](https://github.com/roc-lang/roc/blob/main/roc-for-elm-programmers.md) may be of interest.)
 
 There's also a folder of [examples](https://github.com/roc-lang/roc/tree/main/examples) - the [CLI form example](https://github.com/roc-lang/roc/tree/main/examples/interactive/form.roc) in particular is a reasonable starting point to build on.
 


### PR DESCRIPTION
I looked over the issues and couldn't find someone who has this covered.

Looking at https://github.com/roc-lang/roc/issues/3291 it seems you prefer to link to files, but it's not clear do you want Tutorial to be in the same directory or just link, hence I just fix the link.


Maybe even move TUTORIAL.md to getting_started.

Signed-off-by: Marko Vujanic <crashxx@gmail.com>