### PR TITLE
ci: create a CI script to include the web REPL in nightly builds

### DIFF
--- a/.github/workflows/nightly_linux_x86_64.yml
+++ b/.github/workflows/nightly_linux_x86_64.yml
@@ -1,6 +1,6 @@
-on: [pull_request]
-#  schedule:
-#    - cron:  '0 9 * * *'
+on:
+  schedule:
+    - cron:  '0 9 * * *'
 
 name: Nightly Release Linux x86_64
 

--- a/.github/workflows/nightly_linux_x86_64.yml
+++ b/.github/workflows/nightly_linux_x86_64.yml
@@ -1,6 +1,6 @@
-on:
-  schedule:
-    - cron:  '0 9 * * *'
+on: [pull_request]
+#  schedule:
+#    - cron:  '0 9 * * *'
 
 name: Nightly Release Linux x86_64
 
@@ -24,10 +24,19 @@ jobs:
       - name: Make release tar archive
         run: ./ci/package_release.sh roc_linux_x86_64.tar.gz
 
-      - name: Upload artifact. Actually uploading to github releases has to be done manually.
+      - name: Upload roc nightly tar. Actually uploading to github releases has to be done manually.
         uses: actions/upload-artifact@v3
         with:
            name: roc_nightly-linux_x86_64.tar.gz
            path: roc_linux_x86_64.tar.gz
            retention-days: 4
 
+      - name: build wasm repl
+        run: ./ci/www-repl.sh
+
+      - name: Upload wasm repl tar. Actually uploading to github releases has to be done manually.
+        uses: actions/upload-artifact@v3
+        with:
+           name: roc_repl_wasm.tar.gz
+           path: roc_repl_wasm.tar.gz
+           retention-days: 4

--- a/Earthfile
+++ b/Earthfile
@@ -129,8 +129,6 @@ build-nightly-release:
     RUN RUSTFLAGS="-C target-cpu=x86-64" cargo build --features with_sound --release
     RUN ./ci/package_release.sh roc_linux_x86_64.tar.gz
     SAVE ARTIFACT ./roc_linux_x86_64.tar.gz AS LOCAL roc_linux_x86_64.tar.gz
-    RUN ./ci/www-repl.sh
-    SAVE ARTIFACT ./roc_repl_wasm.tar.gz AS LOCAL roc_repl_wasm.tar.gz
 
 # compile everything needed for benchmarks and output a self-contained dir from which benchmarks can be run.
 prep-bench-folder:

--- a/Earthfile
+++ b/Earthfile
@@ -129,6 +129,8 @@ build-nightly-release:
     RUN RUSTFLAGS="-C target-cpu=x86-64" cargo build --features with_sound --release
     RUN ./ci/package_release.sh roc_linux_x86_64.tar.gz
     SAVE ARTIFACT ./roc_linux_x86_64.tar.gz AS LOCAL roc_linux_x86_64.tar.gz
+    RUN ./ci/www-repl.sh
+    SAVE ARTIFACT ./roc_repl_wasm.tar.gz AS LOCAL roc_repl_wasm.tar.gz
 
 # compile everything needed for benchmarks and output a self-contained dir from which benchmarks can be run.
 prep-bench-folder:

--- a/ci/www-repl.sh
+++ b/ci/www-repl.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+crates/repl_wasm/build-www.sh `pwd`/roc_repl_wasm.tar.gz

--- a/crates/repl_wasm/build-www.sh
+++ b/crates/repl_wasm/build-www.sh
@@ -43,5 +43,9 @@ echo 'var __wbg_star0 = { now: Date.now };' > build/$BINDGEN_FILE
 grep -v '^import' pkg/$BINDGEN_FILE >> build/$BINDGEN_FILE
 
 # As of July 2022, the .wasm file is ~4MB, shrinking to ~1MB with Brotli compression (which Netlify does)
-echo "Generated website assets for deployment:"
+echo "Generated REPL assets for website:"
 ls -l build
+
+TARFILE=${1:-roc_repl_wasm.tar.gz}
+cd build
+tar cvzf $TARFILE *


### PR DESCRIPTION
The current process is:
- I build the web REPL every so often by running a script in the repo.
- This produces a .wasm and a .js file
- I commit those to a branch on one of my unused GitHub repos and push it
- Whenever our website is deployed, Netlify runs `www/build.sh`, which grabs a .zip from my repo, unzips the .wasm and a .js file, and moves them to a certain folder under www/build

After this PR
- Our nightly build adds an extra step to build that archive along with the various other artifacts
- We change the Netlify deployment script to download the archive from the Roc releases, instead of my repo (this wasn't possible when Roc was private)
