### PR TITLE
Add `roc dev` subcommand

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -39,6 +39,7 @@ const DEFAULT_ROC_FILENAME: &str = "main.roc";
 
 pub const CMD_BUILD: &str = "build";
 pub const CMD_RUN: &str = "run";
+pub const CMD_DEV: &str = "dev";
 pub const CMD_REPL: &str = "repl";
 pub const CMD_EDIT: &str = "edit";
 pub const CMD_DOCS: &str = "docs";
@@ -201,6 +202,19 @@ pub fn build_app<'a>() -> Command<'a> {
         )
         .subcommand(Command::new(CMD_RUN)
             .about("Run a .roc file even if it has build errors")
+            .arg(flag_optimize.clone())
+            .arg(flag_max_threads.clone())
+            .arg(flag_opt_size.clone())
+            .arg(flag_dev.clone())
+            .arg(flag_debug.clone())
+            .arg(flag_time.clone())
+            .arg(flag_linker.clone())
+            .arg(flag_precompiled.clone())
+            .arg(roc_file_to_run.clone())
+            .arg(args_for_app.clone())
+        )
+        .subcommand(Command::new(CMD_DEV)
+            .about("`check` a .roc file, and then run it if there were no errors.")
             .arg(flag_optimize.clone())
             .arg(flag_max_threads.clone())
             .arg(flag_opt_size.clone())

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,9 +1,10 @@
 use roc_build::link::LinkType;
 use roc_cli::build::check_file;
 use roc_cli::{
-    build_app, format, test, BuildConfig, FormatMode, Target, CMD_BUILD, CMD_CHECK, CMD_DOCS,
-    CMD_EDIT, CMD_FORMAT, CMD_GLUE, CMD_REPL, CMD_RUN, CMD_TEST, CMD_VERSION, DIRECTORY_OR_FILES,
-    FLAG_CHECK, FLAG_LIB, FLAG_NO_LINK, FLAG_TARGET, FLAG_TIME, GLUE_FILE, ROC_FILE,
+    build_app, format, test, BuildConfig, FormatMode, Target, CMD_BUILD, CMD_CHECK, CMD_DEV,
+    CMD_DOCS, CMD_EDIT, CMD_FORMAT, CMD_GLUE, CMD_REPL, CMD_RUN, CMD_TEST, CMD_VERSION,
+    DIRECTORY_OR_FILES, FLAG_CHECK, FLAG_LIB, FLAG_NO_LINK, FLAG_TARGET, FLAG_TIME, GLUE_FILE,
+    ROC_FILE,
 };
 use roc_docs::generate_docs_html;
 use roc_error_macros::user_error;
@@ -60,6 +61,20 @@ fn main() -> io::Result<()> {
                 test(matches, Triple::host())
             } else {
                 eprintln!("What .roc file do you want to test? Specify it at the end of the `roc test` command.");
+
+                Ok(1)
+            }
+        }
+        Some((CMD_DEV, matches)) => {
+            if matches.is_present(ROC_FILE) {
+                build(
+                    matches,
+                    BuildConfig::BuildAndRunIfNoErrors,
+                    Triple::host(),
+                    LinkType::Executable,
+                )
+            } else {
+                eprintln!("What .roc file do you want to build? Specify it at the end of the `roc run` command.");
 
                 Ok(1)
             }


### PR DESCRIPTION
This makes `roc dev` do the "build and then only run if there were no errors" logic which currently the plain `roc` command does.

The reason to split them out is so that the plain `roc` command can be reserved for `#!/usr/bin/env roc` scripts - which need to be in that format (no subcommands allowed, because some `env` implementations don't support passing through arguments to the specified executable).

Now we can say "use `roc dev` for normal development" and optimize the plain `roc` command for the scripting use case (e.g. have it ignore `expect`s, whereas `roc dev` should use them).