### PR TITLE
Allow inferred flex vars inside type constructors bound to an ability

### DIFF
--- a/crates/compiler/test_gen/src/gen_abilities.rs
+++ b/crates/compiler/test_gen/src/gen_abilities.rs
@@ -1012,6 +1012,26 @@ fn decode_record_two_fields_string_and_string_infer() {
 
 #[test]
 #[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
+fn decode_record_two_fields_string_and_string_infer_local_var() {
+    assert_evals_to!(
+        indoc!(
+            r#"
+            app "test" imports [Decode, Json] provides [main] to "./platform"
+
+            main =
+                decoded = Str.toUtf8 "{\"first\":\"ab\",\"second\":\"cd\"}" |> Decode.fromBytes Json.fromUtf8
+                when decoded is
+                    Ok rcd -> Str.concat rcd.first rcd.second
+                    _ -> "something went wrong"
+            "#
+        ),
+        RocStr::from("abcd"),
+        RocStr
+    )
+}
+
+#[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
 #[ignore = "json parsing impl must be fixed first"]
 fn decode_empty_record() {
     assert_evals_to!(

--- a/crates/compiler/test_gen/src/gen_abilities.rs
+++ b/crates/compiler/test_gen/src/gen_abilities.rs
@@ -993,6 +993,25 @@ fn decode_record_two_fields_string_and_int() {
 
 #[test]
 #[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
+fn decode_record_two_fields_string_and_string_infer() {
+    assert_evals_to!(
+        indoc!(
+            r#"
+            app "test" imports [Encode, Decode, Json] provides [main] to "./platform"
+
+            main =
+                when Str.toUtf8 "{\"first\":\"ab\",\"second\":\"cd\"}" |> Decode.fromBytes Json.fromUtf8 is
+                    Ok {first, second} -> Str.concat first second
+                    _ -> "something went wrong"
+            "#
+        ),
+        RocStr::from("abcd"),
+        RocStr
+    )
+}
+
+#[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
 #[ignore = "json parsing impl must be fixed first"]
 fn decode_empty_record() {
     assert_evals_to!(

--- a/crates/compiler/test_gen/src/gen_abilities.rs
+++ b/crates/compiler/test_gen/src/gen_abilities.rs
@@ -1032,6 +1032,26 @@ fn decode_record_two_fields_string_and_string_infer_local_var() {
 
 #[test]
 #[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
+fn decode_record_two_fields_string_and_string_infer_local_var_destructured() {
+    assert_evals_to!(
+        indoc!(
+            r#"
+            app "test" imports [Decode, Json] provides [main] to "./platform"
+
+            main =
+                decoded = Str.toUtf8 "{\"first\":\"ab\",\"second\":\"cd\"}" |> Decode.fromBytes Json.fromUtf8
+                when decoded is
+                    Ok {first, second} -> Str.concat first second
+                    _ -> "something went wrong"
+            "#
+        ),
+        RocStr::from("abcd"),
+        RocStr
+    )
+}
+
+#[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
 #[ignore = "json parsing impl must be fixed first"]
 fn decode_empty_record() {
     assert_evals_to!(

--- a/crates/reporting/tests/test_reporting.rs
+++ b/crates/reporting/tests/test_reporting.rs
@@ -10457,4 +10457,34 @@ All branches in an `if` must have the same type!
     "_foo", or replace it with just an "_".
     "###
     );
+
+    test_report!(
+        infer_decoded_record_error_with_function_field,
+        indoc!(
+            r#"
+            app "test" imports [Decode, Json] provides [main] to "./platform"
+
+            main =
+                decoded = Str.toUtf8 "{\"first\":\"ab\",\"second\":\"cd\"}" |> Decode.fromBytes Json.fromUtf8
+                when decoded is
+                    Ok rcd -> rcd.first rcd.second
+                    _ -> "something went wrong"
+            "#
+        ),
+    @r###"
+    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+
+    This expression has a type that does not implement the abilities it's expected to:
+
+    6│          Ok rcd -> rcd.first rcd.second
+                          ^^^^^^^^^
+
+    Roc can't generate an implementation of the `Decode.Decoding` ability
+    for
+
+        a -> b
+
+    Note: `Decoding` cannot be generated for functions.
+    "###
+    );
 }


### PR DESCRIPTION
Supports stuff like


```
decoded = Str.toUtf8 "{\"first\":\"ab\",\"second\":\"cd\"}" |> Decode.fromBytes Json.fromUtf8
when decoded is
    Ok rcd -> Str.concat rcd.first rcd.second
    _ -> "something went wrong"
```