### PR TITLE
Add allow(clippy::unused_unit) to glue header

### DIFF
--- a/crates/glue/templates/header.rs
+++ b/crates/glue/templates/header.rs
@@ -5,4 +5,5 @@
 #![allow(non_snake_case)]
 #![allow(non_camel_case_types)]
 #![allow(non_upper_case_globals)]
+#![allow(clippy::unused_unit)]
 #![allow(clippy::undocumented_unsafe_blocks)]


### PR DESCRIPTION
Signed-off-by: Richard Feldman <oss@rtfeldman.com>