### PR TITLE
Support bound and unbound extension variables in deriving

### DIFF
--- a/crates/compiler/derive_key/src/encoding.rs
+++ b/crates/compiler/derive_key/src/encoding.rs
@@ -2,10 +2,10 @@ use roc_module::{
     ident::{Lowercase, TagName},
     symbol::Symbol,
 };
-use roc_types::subs::{Content, FlatType, GetSubsSlice, Subs, Variable};
+use roc_types::subs::{Content, FlatType, Subs, Variable};
 
 use crate::{
-    util::{check_empty_ext_var, debug_name_record},
+    util::{check_derivable_ext_var, debug_name_record},
     DeriveError,
 };
 
@@ -63,12 +63,17 @@ impl FlatEncodable {
                     _ => Err(Underivable),
                 },
                 FlatType::Record(fields, ext) => {
-                    check_empty_ext_var(subs, ext, |ext| {
+                    let (fields_iter, ext) = fields.unsorted_iterator_and_ext(subs, ext);
+
+                    check_derivable_ext_var(subs, ext, |ext| {
                         matches!(ext, Content::Structure(FlatType::EmptyRecord))
                     })?;
 
-                    let mut field_names: Vec<_> =
-                        subs.get_subs_slice(fields.field_names()).to_vec();
+                    let mut field_names = Vec::with_capacity(fields.len());
+                    for (field_name, _) in fields_iter {
+                        field_names.push(field_name.clone());
+                    }
+
                     field_names.sort();
 
                     Ok(Key(FlatEncodableKey::Record(field_names)))
@@ -83,20 +88,23 @@ impl FlatEncodable {
                     //   [ A t1, B t1 t2 ] as R
                     // look the same on the surface, because `R` is only somewhere inside of the
                     // `t`-prefixed payload types.
-                    check_empty_ext_var(subs, ext, |ext| {
+                    let (tags_iter, ext) = tags.unsorted_tags_and_ext(subs, ext);
+
+                    check_derivable_ext_var(subs, ext, |ext| {
                         matches!(ext, Content::Structure(FlatType::EmptyTagUnion))
                     })?;
 
-                    let mut tag_names_and_payload_sizes: Vec<_> = tags
-                        .iter_all()
-                        .map(|(name_index, payload_slice_index)| {
-                            let payload_slice = subs[payload_slice_index];
-                            let payload_size = payload_slice.length;
-                            let name = &subs[name_index];
-                            (name.clone(), payload_size)
+                    let mut tag_names_and_payload_sizes: Vec<_> = tags_iter
+                        .tags
+                        .into_iter()
+                        .map(|(name, payload_slice)| {
+                            let payload_size = payload_slice.len();
+                            (name.clone(), payload_size as _)
                         })
                         .collect();
+
                     tag_names_and_payload_sizes.sort_by(|(t1, _), (t2, _)| t1.cmp(t2));
+
                     Ok(Key(FlatEncodableKey::TagUnion(tag_names_and_payload_sizes)))
                 }
                 FlatType::FunctionOrTagUnion(name_index, _, _) => Ok(Key(

--- a/crates/compiler/derive_key/src/util.rs
+++ b/crates/compiler/derive_key/src/util.rs
@@ -10,7 +10,17 @@ pub(crate) fn check_derivable_ext_var(
 ) -> Result<(), DeriveError> {
     let ext_content = subs.get_content_without_compacting(ext_var);
     if is_empty_ext(ext_content)
-        || matches!(ext_content, Content::FlexVar(_) | Content::RigidVar(_))
+        || matches!(
+            ext_content,
+            // It's fine to have either a flex/rigid or flex-able/rigid-able in the extension.
+            // Since we don't know the rest of the type concretely, any implementation (derived or
+            // not) would only be able to work on the concrete part of the type regardless. So,
+            // just admit them, and they will be excluded from the deriving scheme.
+            Content::FlexVar(_)
+                | Content::FlexAbleVar(..)
+                | Content::RigidVar(_)
+                | Content::RigidAbleVar(..)
+        )
     {
         Ok(())
     } else {

--- a/crates/compiler/derive_key/src/util.rs
+++ b/crates/compiler/derive_key/src/util.rs
@@ -3,13 +3,15 @@ use roc_types::subs::{Content, Subs, Variable};
 
 use crate::DeriveError;
 
-pub(crate) fn check_empty_ext_var(
+pub(crate) fn check_derivable_ext_var(
     subs: &Subs,
     ext_var: Variable,
     is_empty_ext: impl Fn(&Content) -> bool,
 ) -> Result<(), DeriveError> {
     let ext_content = subs.get_content_without_compacting(ext_var);
-    if is_empty_ext(ext_content) {
+    if is_empty_ext(ext_content)
+        || matches!(ext_content, Content::FlexVar(_) | Content::RigidVar(_))
+    {
         Ok(())
     } else {
         match ext_content {

--- a/crates/compiler/mono/src/layout.rs
+++ b/crates/compiler/mono/src/layout.rs
@@ -2610,7 +2610,7 @@ pub fn union_sorted_tags<'a>(
         //   x = A
         //   x
         // In such cases it's fine to drop the variable. We may be proven wrong in the future...
-        | Err((_, Content::FlexVar(_) | Content::RigidVar(_)))
+        | Err((_, Content::FlexVar(_) | Content::FlexAbleVar(..) |  Content::RigidVar(_) | Content::RigidAbleVar(..)))
         | Err((_, Content::RecursionVar { .. })) => {
             let opt_rec_var = get_recursion_var(subs, var);
             union_sorted_tags_help(arena, tags_vec, opt_rec_var, subs, target_info)
@@ -3251,9 +3251,17 @@ pub fn ext_var_is_empty_tag_union(subs: &Subs, ext_var: Variable) -> bool {
     // the ext_var is empty
     let mut ext_fields = std::vec::Vec::new();
     match roc_types::pretty_print::chase_ext_tag_union(subs, ext_var, &mut ext_fields) {
-        Ok(()) | Err((_, Content::FlexVar(_) | Content::RigidVar(_) | Content::Error)) => {
-            ext_fields.is_empty()
-        }
+        Ok(())
+        | Err((
+            _,
+            // Allow flex/rigid to decay away into nothing
+            Content::FlexVar(_)
+            | Content::FlexAbleVar(..)
+            | Content::RigidVar(_)
+            | Content::RigidAbleVar(..)
+            // So that we can continue compiling in the presence of errors
+            | Content::Error,
+        )) => ext_fields.is_empty(),
         Err(content) => panic!("invalid content in ext_var: {:?}", content),
     }
 }

--- a/crates/compiler/test_derive/src/decoding.rs
+++ b/crates/compiler/test_derive/src/decoding.rs
@@ -6,14 +6,14 @@
 
 use crate::{
     test_key_eq, test_key_neq,
-    util::{check_immediate, check_underivable, derive_test},
+    util::{check_derivable, check_immediate, check_underivable, derive_test},
     v,
 };
 use insta::assert_snapshot;
 use roc_module::symbol::Symbol;
 use roc_types::subs::Variable;
 
-use roc_derive_key::{DeriveBuiltin::Decoder, DeriveError};
+use roc_derive_key::{decoding::FlatDecodableKey, DeriveBuiltin::Decoder, DeriveError, DeriveKey};
 
 test_key_eq! {
     Decoder,
@@ -44,11 +44,6 @@ test_key_neq! {
 }
 
 #[test]
-fn optional_record_field_derive_error() {
-    check_underivable(Decoder, v!({ ?a: v!(U8), }), DeriveError::Underivable);
-}
-
-#[test]
 fn immediates() {
     check_immediate(Decoder, v!(U8), Symbol::DECODE_U8);
     check_immediate(Decoder, v!(U16), Symbol::DECODE_U16);
@@ -64,6 +59,29 @@ fn immediates() {
     check_immediate(Decoder, v!(F32), Symbol::DECODE_F32);
     check_immediate(Decoder, v!(F64), Symbol::DECODE_F64);
     check_immediate(Decoder, v!(STR), Symbol::DECODE_STRING);
+}
+
+#[test]
+fn optional_record_field_derive_error() {
+    check_underivable(Decoder, v!({ ?a: v!(U8), }), DeriveError::Underivable);
+}
+
+#[test]
+fn derivable_record_ext_flex_var() {
+    check_derivable(
+        Decoder,
+        v!({ a: v!(STR), }* ),
+        DeriveKey::Decoder(FlatDecodableKey::Record(vec!["a".into()])),
+    );
+}
+
+#[test]
+fn derivable_record_with_record_ext() {
+    check_derivable(
+        Decoder,
+        v!({ b: v!(STR), }{ a: v!(STR), } ),
+        DeriveKey::Decoder(FlatDecodableKey::Record(vec!["a".into(), "b".into()])),
+    );
 }
 
 #[test]

--- a/crates/compiler/test_derive/src/decoding.rs
+++ b/crates/compiler/test_derive/src/decoding.rs
@@ -76,6 +76,15 @@ fn derivable_record_ext_flex_var() {
 }
 
 #[test]
+fn derivable_record_ext_flex_able_var() {
+    check_derivable(
+        Decoder,
+        v!({ a: v!(STR), }a has Symbol::DECODE_DECODER ),
+        DeriveKey::Decoder(FlatDecodableKey::Record(vec!["a".into()])),
+    );
+}
+
+#[test]
 fn derivable_record_with_record_ext() {
     check_derivable(
         Decoder,

--- a/crates/compiler/test_derive/src/encoding.rs
+++ b/crates/compiler/test_derive/src/encoding.rs
@@ -8,10 +8,10 @@ use insta::assert_snapshot;
 
 use crate::{
     test_key_eq, test_key_neq,
-    util::{check_immediate, derive_test},
+    util::{check_derivable, check_immediate, derive_test},
     v,
 };
-use roc_derive_key::DeriveBuiltin::ToEncoder;
+use roc_derive_key::{encoding::FlatEncodableKey, DeriveBuiltin::ToEncoder, DeriveKey};
 use roc_module::symbol::Symbol;
 use roc_types::subs::Variable;
 
@@ -116,6 +116,45 @@ fn immediates() {
     check_immediate(ToEncoder, v!(F32), Symbol::ENCODE_F32);
     check_immediate(ToEncoder, v!(F64), Symbol::ENCODE_F64);
     check_immediate(ToEncoder, v!(STR), Symbol::ENCODE_STRING);
+}
+
+#[test]
+fn derivable_record_ext_flex_var() {
+    check_derivable(
+        ToEncoder,
+        v!({ a: v!(STR), }* ),
+        DeriveKey::ToEncoder(FlatEncodableKey::Record(vec!["a".into()])),
+    );
+}
+
+#[test]
+fn derivable_record_with_record_ext() {
+    check_derivable(
+        ToEncoder,
+        v!({ b: v!(STR), }{ a: v!(STR), } ),
+        DeriveKey::ToEncoder(FlatEncodableKey::Record(vec!["a".into(), "b".into()])),
+    );
+}
+
+#[test]
+fn derivable_tag_ext_flex_var() {
+    check_derivable(
+        ToEncoder,
+        v!([ A v!(STR) ]* ),
+        DeriveKey::ToEncoder(FlatEncodableKey::TagUnion(vec![("A".into(), 1)])),
+    );
+}
+
+#[test]
+fn derivable_tag_with_tag_ext() {
+    check_derivable(
+        ToEncoder,
+        v!([ B v!(STR) v!(U8) ][ A v!(STR) ]),
+        DeriveKey::ToEncoder(FlatEncodableKey::TagUnion(vec![
+            ("A".into(), 1),
+            ("B".into(), 2),
+        ])),
+    );
 }
 
 #[test]

--- a/crates/compiler/test_derive/src/encoding.rs
+++ b/crates/compiler/test_derive/src/encoding.rs
@@ -128,6 +128,15 @@ fn derivable_record_ext_flex_var() {
 }
 
 #[test]
+fn derivable_record_ext_flex_able_var() {
+    check_derivable(
+        ToEncoder,
+        v!({ a: v!(STR), }a has Symbol::ENCODE_TO_ENCODER),
+        DeriveKey::ToEncoder(FlatEncodableKey::Record(vec!["a".into()])),
+    );
+}
+
+#[test]
 fn derivable_record_with_record_ext() {
     check_derivable(
         ToEncoder,
@@ -141,6 +150,15 @@ fn derivable_tag_ext_flex_var() {
     check_derivable(
         ToEncoder,
         v!([ A v!(STR) ]* ),
+        DeriveKey::ToEncoder(FlatEncodableKey::TagUnion(vec![("A".into(), 1)])),
+    );
+}
+
+#[test]
+fn derivable_tag_ext_flex_able_var() {
+    check_derivable(
+        ToEncoder,
+        v!([ A v!(STR) ]a has Symbol::ENCODE_TO_ENCODER),
         DeriveKey::ToEncoder(FlatEncodableKey::TagUnion(vec![("A".into(), 1)])),
     );
 }

--- a/crates/compiler/test_gen/src/gen_abilities.rs
+++ b/crates/compiler/test_gen/src/gen_abilities.rs
@@ -554,7 +554,6 @@ fn encode_derived_tag_one_payload_string() {
                 provides [main] to "./platform"
 
             main =
-                x : [A Str]
                 x = A "foo"
                 result = Str.fromUtf8 (Encode.toBytes x Json.toUtf8)
                 when result is
@@ -578,7 +577,6 @@ fn encode_derived_tag_two_payloads_string() {
                 provides [main] to "./platform"
 
             main =
-                x : [A Str Str]
                 x = A "foo" "bar"
                 result = Str.fromUtf8 (Encode.toBytes x Json.toUtf8)
                 when result is
@@ -602,7 +600,6 @@ fn encode_derived_nested_tag_string() {
                 provides [main] to "./platform"
 
             main =
-                x : [A [B Str Str]]
                 x = A (B "foo" "bar")
                 encoded = Encode.toBytes x Json.toUtf8
                 result = Str.fromUtf8 encoded
@@ -627,7 +624,6 @@ fn encode_derived_nested_record_tag_record() {
                 provides [main] to "./platform"
 
             main =
-                x : {a: [B {c: Str}]}
                 x = {a: (B ({c: "foo"}))}
                 encoded = Encode.toBytes x Json.toUtf8
                 result = Str.fromUtf8 encoded

--- a/crates/compiler/types/src/pretty_print.rs
+++ b/crates/compiler/types/src/pretty_print.rs
@@ -921,7 +921,10 @@ impl<'a> ExtContent<'a> {
             Content::Structure(FlatType::EmptyTagUnion) => ExtContent::Empty,
             Content::Structure(FlatType::EmptyRecord) => ExtContent::Empty,
 
-            Content::FlexVar(_) | Content::RigidVar(_) => ExtContent::Content(ext, content),
+            Content::FlexVar(_)
+            | Content::FlexAbleVar(..)
+            | Content::RigidVar(_)
+            | Content::RigidAbleVar(..) => ExtContent::Content(ext, content),
 
             other => unreachable!("something weird ended up in an ext var: {:?}", other),
         }

--- a/crates/compiler/types/src/subs.rs
+++ b/crates/compiler/types/src/subs.rs
@@ -2863,7 +2863,7 @@ pub fn is_empty_tag_union(subs: &Subs, mut var: Variable) -> bool {
 
     loop {
         match subs.get_content_without_compacting(var) {
-            FlexVar(_) => return true,
+            FlexVar(_) | FlexAbleVar(..) => return true,
             Structure(EmptyTagUnion) => return true,
             Structure(TagUnion(sub_fields, sub_ext)) => {
                 if !sub_fields.is_empty() {

--- a/crates/compiler/types/src/types.rs
+++ b/crates/compiler/types/src/types.rs
@@ -2689,10 +2689,10 @@ pub fn gather_fields_unsorted_iter(
             }
 
             Structure(EmptyRecord) => break,
-            FlexVar(_) => break,
+            FlexVar(_) | FlexAbleVar(..) => break,
 
             // TODO investigate apparently this one pops up in the reporting tests!
-            RigidVar(_) => break,
+            RigidVar(_) | RigidAbleVar(..) => break,
 
             // Stop on errors in the record
             Error => break,

--- a/crates/compiler/types/src/types.rs
+++ b/crates/compiler/types/src/types.rs
@@ -2789,10 +2789,10 @@ pub fn gather_tags_unsorted_iter(
             }
 
             Structure(EmptyTagUnion) => break,
-            FlexVar(_) => break,
+            FlexVar(_) | FlexAbleVar(_, _) => break,
 
             // TODO investigate, this likely can happen when there is a type error
-            RigidVar(_) => break,
+            RigidVar(_) | RigidAbleVar(_, _) => break,
 
             Error => break,
 


### PR DESCRIPTION
A key thing about unbound extension variables is that they provide no information. For example, given a type `[A Str]b`, one cannot do anything with `b` until it is resolved to a concrete type. This applies to implementations of abilities as well. For encoding/decoding, the most we can do is work on the concrete part of the type. Since only ground types can be fed into derived implementations, doing this is fine.