### PR TITLE
Don't suggest removing variable when it's bound in a branch pattern

### DIFF
--- a/crates/compiler/can/src/expr.rs
+++ b/crates/compiler/can/src/expr.rs
@@ -1414,7 +1414,7 @@ fn canonicalize_when_branch<'a>(
         if output.references.has_value_lookup(symbol) {
             pattern_bound_symbols_body_needs.insert(symbol);
         } else {
-            env.problem(Problem::UnusedDef(symbol, region));
+            env.problem(Problem::UnusedBranchDef(symbol, region));
         }
     }
 

--- a/crates/compiler/problem/src/can.rs
+++ b/crates/compiler/problem/src/can.rs
@@ -38,6 +38,7 @@ pub enum Problem {
     /// Bool is whether the closure is anonymous
     /// Second symbol is the name of the argument that is unused
     UnusedArgument(Symbol, bool, Symbol, Region),
+    UnusedBranchDef(Symbol, Region),
     PrecedenceProblem(PrecedenceProblem),
     // Example: (5 = 1 + 2) is an unsupported pattern in an assignment; Int patterns aren't allowed in assignments!
     UnsupportedPattern(BadPattern, Region),

--- a/crates/compiler/solve/tests/solve_expr.rs
+++ b/crates/compiler/solve/tests/solve_expr.rs
@@ -182,7 +182,13 @@ mod solve_expr {
 
         // Disregard UnusedDef problems, because those are unavoidable when
         // returning a function from the test expression.
-        can_problems.retain(|prob| !matches!(prob, roc_problem::can::Problem::UnusedDef(_, _)));
+        can_problems.retain(|prob| {
+            !matches!(
+                prob,
+                roc_problem::can::Problem::UnusedDef(_, _)
+                    | roc_problem::can::Problem::UnusedBranchDef(..)
+            )
+        });
 
         let (can_problems, type_problems) =
             format_problems(&src, home, &interns, can_problems, type_problems);

--- a/crates/reporting/src/error/canonicalize.rs
+++ b/crates/reporting/src/error/canonicalize.rs
@@ -171,6 +171,27 @@ pub fn can_problem<'b>(
             title = UNUSED_ARG.to_string();
             severity = Severity::Warning;
         }
+        Problem::UnusedBranchDef(symbol, region) => {
+            doc = alloc.stack([
+                alloc.concat([
+                    alloc.symbol_unqualified(symbol),
+                    alloc.reflow(" is not used in this "),
+                    alloc.keyword("when"),
+                    alloc.reflow(" branch."),
+                ]),
+                alloc.region(lines.convert_region(region)),
+                alloc.concat([
+                    alloc.reflow("If you don't need to use "),
+                    alloc.symbol_unqualified(symbol),
+                    alloc.reflow(", prefix it with an underscore, like \"_"),
+                    alloc.reflow(symbol.as_str(alloc.interns)),
+                    alloc.reflow("\", or replace it with just an \"_\"."),
+                ]),
+            ]);
+
+            title = UNUSED_DEF.to_string();
+            severity = Severity::Warning;
+        }
         Problem::PrecedenceProblem(BothNonAssociative(region, left_bin_op, right_bin_op)) => {
             doc = alloc.stack([
                 if left_bin_op.value == right_bin_op.value {

--- a/crates/reporting/tests/test_reporting.rs
+++ b/crates/reporting/tests/test_reporting.rs
@@ -9895,13 +9895,13 @@ All branches in an `if` must have the same type!
 
         ── UNUSED DEFINITION ───────────────────────────────────── /code/proj/Main.roc ─
 
-        `y` is not used anywhere in your code.
+        `y` is not used in this `when` branch.
 
         5│          A x | B y -> x
                             ^
 
-        If you didn't intend on using `y` then remove it so future readers of
-        your code don't wonder why it is there.
+        If you don't need to use `y`, prefix it with an underscore, like "_y",
+        or replace it with just an "_".
         "###
     );
 
@@ -10434,6 +10434,27 @@ All branches in an `if` must have the same type!
         { a : Str, b ? Str }
 
     Tip: Looks like the b field is missing.
+    "###
+    );
+
+    test_report!(
+        unused_def_in_branch_pattern,
+        indoc!(
+            r#"
+            when A "" is
+                A foo -> ""
+            "#
+        ),
+    @r###"
+    ── UNUSED DEFINITION ───────────────────────────────────── /code/proj/Main.roc ─
+
+    `foo` is not used in this `when` branch.
+
+    5│          A foo -> ""
+                  ^^^
+
+    If you don't need to use `foo`, prefix it with an underscore, like
+    "_foo", or replace it with just an "_".
     "###
     );
 }


### PR DESCRIPTION
Instead, suggest prefixing it with an underscore, or replacing with an
underscore.

Closes #3820
