### PR TITLE
Bitshift operator argument swap

### DIFF
--- a/crates/compiler/builtins/roc/Num.roc
+++ b/crates/compiler/builtins/roc/Num.roc
@@ -870,6 +870,9 @@ bitwiseOr : Int a, Int a -> Int a
 ## In some languages `shiftLeftBy` is implemented as a binary operator `<<`.
 shiftLeftBy : Int a, Int a -> Int a
 
+expect shiftLeftBy 0b0000_0011 2 == 0b0000_1100
+expect 0b0000_0101 |> shiftLeftBy 2 == 0b0000_1100
+
 ## Bitwise arithmetic shift of a number by another
 ##
 ## The most significand bits are copied from the current.
@@ -882,6 +885,10 @@ shiftLeftBy : Int a, Int a -> Int a
 ##
 ## In some languages `shiftRightBy` is implemented as a binary operator `>>>`.
 shiftRightBy : Int a, Int a -> Int a
+
+expect shiftRightBy 0b0000_0011 2 == 0b0000_1100
+expect 0b0000_0011 |> shiftRightBy 2 == 0b0000_1100
+expect 0b1001_0000 |> shiftRightBy 2 == 0b1110_0100
 
 ## Bitwise logical right shift of a number by another
 ##
@@ -896,6 +903,10 @@ shiftRightBy : Int a, Int a -> Int a
 ##
 ## In some languages `shiftRightBy` is implemented as a binary operator `>>`.
 shiftRightZfBy : Int a, Int a -> Int a
+
+expect shiftRightBy 0b0010_1000 2 == 0b0000_1010
+expect 0b0010_1000 |> shiftRightBy 2 == 0b0000_1010
+expect 0b1001_0000 |> shiftRightBy 2 == 0b0010_0100
 
 ## Round off the given fraction to the nearest integer.
 round : Frac * -> Int *

--- a/crates/compiler/builtins/roc/Num.roc
+++ b/crates/compiler/builtins/roc/Num.roc
@@ -860,7 +860,7 @@ bitwiseOr : Int a, Int a -> Int a
 
 ## Bitwise left shift of a number by another
 ##
-## The least significand bits always become 0. This means that shifting left is
+## The least significant bits always become 0. This means that shifting left is
 ## like multiplying by factors of two for unsigned integers.
 ##
 ## >>> shiftLeftBy 0b0000_0011 2 == 0b0000_1100
@@ -872,7 +872,7 @@ shiftLeftBy : Int a, Int a -> Int a
 
 ## Bitwise arithmetic shift of a number by another
 ##
-## The most significand bits are copied from the current.
+## The most significant bits are copied from the current.
 ##
 ## >>> shiftRightBy 0b0000_0011 2 == 0b0000_1100
 ##
@@ -885,7 +885,7 @@ shiftRightBy : Int a, Int a -> Int a
 
 ## Bitwise logical right shift of a number by another
 ##
-## The most significand bits always become 0. This means that shifting left is
+## The most significant bits always become 0. This means that shifting left is
 ## like dividing by factors of two for unsigned integers.
 ##
 ## >>> shiftRightBy 0b0010_1000 2 == 0b0000_1010

--- a/crates/compiler/builtins/roc/Num.roc
+++ b/crates/compiler/builtins/roc/Num.roc
@@ -857,8 +857,44 @@ isMultipleOf : Int a, Int a -> Bool
 bitwiseAnd : Int a, Int a -> Int a
 bitwiseXor : Int a, Int a -> Int a
 bitwiseOr : Int a, Int a -> Int a
+
+## Bitwise left shift of a number by another
+##
+## The least significand bits always become 0. This means that shifting left is
+## like multiplying by factors of two for unsigned integers.
+##
+## >>> shiftLeftBy 0b0000_0011 2 == 0b0000_1100
+##
+## >>> 0b0000_0101 |> shiftLeftBy 2 == 0b0000_1100
+##
+## In some languages `shiftLeftBy` is implemented as a binary operator `<<`.
 shiftLeftBy : Int a, Int a -> Int a
+
+## Bitwise arithmetic shift of a number by another
+##
+## The most significand bits are copied from the current.
+##
+## >>> shiftRightBy 0b0000_0011 2 == 0b0000_1100
+##
+## >>> 0b0001_0100 |> shiftRightBy 2 == 0b0000_0101
+##
+## >>> 0b1001_0000 |> shiftRightBy 2 == 0b1110_0100
+##
+## In some languages `shiftRightBy` is implemented as a binary operator `>>>`.
 shiftRightBy : Int a, Int a -> Int a
+
+## Bitwise logical right shift of a number by another
+##
+## The most significand bits always become 0. This means that shifting left is
+## like dividing by factors of two for unsigned integers.
+##
+## >>> shiftRightBy 0b0010_1000 2 == 0b0000_1010
+##
+## >>> 0b0010_1000 |> shiftRightBy 2 == 0b0000_1010
+##
+## >>> 0b1001_0000 |> shiftRightBy 2 == 0b0010_0100
+##
+## In some languages `shiftRightBy` is implemented as a binary operator `>>`.
 shiftRightZfBy : Int a, Int a -> Int a
 
 ## Round off the given fraction to the nearest integer.

--- a/crates/compiler/builtins/roc/Num.roc
+++ b/crates/compiler/builtins/roc/Num.roc
@@ -870,9 +870,6 @@ bitwiseOr : Int a, Int a -> Int a
 ## In some languages `shiftLeftBy` is implemented as a binary operator `<<`.
 shiftLeftBy : Int a, Int a -> Int a
 
-expect shiftLeftBy 0b0000_0011 2 == 0b0000_1100
-expect 0b0000_0101 |> shiftLeftBy 2 == 0b0000_1100
-
 ## Bitwise arithmetic shift of a number by another
 ##
 ## The most significand bits are copied from the current.
@@ -885,10 +882,6 @@ expect 0b0000_0101 |> shiftLeftBy 2 == 0b0000_1100
 ##
 ## In some languages `shiftRightBy` is implemented as a binary operator `>>>`.
 shiftRightBy : Int a, Int a -> Int a
-
-expect shiftRightBy 0b0000_0011 2 == 0b0000_1100
-expect 0b0000_0011 |> shiftRightBy 2 == 0b0000_1100
-expect 0b1001_0000 |> shiftRightBy 2 == 0b1110_0100
 
 ## Bitwise logical right shift of a number by another
 ##
@@ -903,10 +896,6 @@ expect 0b1001_0000 |> shiftRightBy 2 == 0b1110_0100
 ##
 ## In some languages `shiftRightBy` is implemented as a binary operator `>>`.
 shiftRightZfBy : Int a, Int a -> Int a
-
-expect shiftRightBy 0b0010_1000 2 == 0b0000_1010
-expect 0b0010_1000 |> shiftRightBy 2 == 0b0000_1010
-expect 0b1001_0000 |> shiftRightBy 2 == 0b0010_0100
 
 ## Round off the given fraction to the nearest integer.
 round : Frac * -> Int *

--- a/crates/compiler/gen_llvm/src/llvm/build.rs
+++ b/crates/compiler/gen_llvm/src/llvm/build.rs
@@ -7039,22 +7039,13 @@ fn build_int_binop<'a, 'ctx, 'env>(
         NumBitwiseAnd => bd.build_and(lhs, rhs, "int_bitwise_and").into(),
         NumBitwiseXor => bd.build_xor(lhs, rhs, "int_bitwise_xor").into(),
         NumBitwiseOr => bd.build_or(lhs, rhs, "int_bitwise_or").into(),
-        NumShiftLeftBy => {
-            // NOTE arguments are flipped;
-            // we write `assert_eq!(0b0000_0001 << 0, 0b0000_0001);`
-            // as `Num.shiftLeftBy 0 0b0000_0001
-            bd.build_left_shift(rhs, lhs, "int_shift_left").into()
-        }
-        NumShiftRightBy => {
-            // NOTE arguments are flipped;
-            bd.build_right_shift(rhs, lhs, true, "int_shift_right")
-                .into()
-        }
-        NumShiftRightZfBy => {
-            // NOTE arguments are flipped;
-            bd.build_right_shift(rhs, lhs, false, "int_shift_right_zf")
-                .into()
-        }
+        NumShiftLeftBy => bd.build_left_shift(lhs, rhs, "int_shift_left").into(),
+        NumShiftRightBy => bd
+            .build_right_shift(lhs, rhs, true, "int_shift_right")
+            .into(),
+        NumShiftRightZfBy => bd
+            .build_right_shift(lhs, rhs, false, "int_shift_right_zf")
+            .into(),
 
         _ => {
             unreachable!("Unrecognized int binary operation: {:?}", op);

--- a/crates/compiler/test_gen/src/gen_num.rs
+++ b/crates/compiler/test_gen/src/gen_num.rs
@@ -2091,9 +2091,9 @@ fn float_mul_checked() {
 #[test]
 #[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
 fn shift_left_by() {
-    assert_evals_to!("Num.shiftLeftBy 0 0b0000_0001", 0b0000_0001, i64);
-    assert_evals_to!("Num.shiftLeftBy 1 0b0000_0001", 0b0000_0010, i64);
-    assert_evals_to!("Num.shiftLeftBy 2 0b0000_0011", 0b0000_1100, i64);
+    assert_evals_to!("Num.shiftLeftBy 0b0000_0001 0", 0b0000_0001, i64);
+    assert_evals_to!("Num.shiftLeftBy 0b0000_0001 1", 0b0000_0010, i64);
+    assert_evals_to!("Num.shiftLeftBy 0b0000_0011 2", 0b0000_1100, i64);
 }
 
 #[test]
@@ -2105,43 +2105,43 @@ fn shift_right_by() {
 
     // FIXME (Brian) Something funny happening with 8-bit binary literals in tests
     assert_evals_to!(
-        "Num.shiftRightBy 2 (Num.toI8 0b1100_0000u8)",
+        "Num.shiftRightBy (Num.toI8 0b1100_0000u8) 2",
         0b1111_0000u8 as i8,
         i8
     );
-    assert_evals_to!("Num.shiftRightBy 2 0b0100_0000i8", 0b0001_0000i8, i8);
-    assert_evals_to!("Num.shiftRightBy 1 0b1110_0000u8", 0b1111_0000u8, u8);
-    assert_evals_to!("Num.shiftRightBy 2 0b1100_0000u8", 0b1111_0000u8, u8);
-    assert_evals_to!("Num.shiftRightBy 12 0b0100_0000u8", 0b0000_0000u8, u8);
+    assert_evals_to!("Num.shiftRightBy 0b0100_0000i8 2", 0b0001_0000i8, i8);
+    assert_evals_to!("Num.shiftRightBy 0b1110_0000u8 1", 0b1111_0000u8, u8);
+    assert_evals_to!("Num.shiftRightBy 0b1100_0000u8 2", 0b1111_0000u8, u8);
+    assert_evals_to!("Num.shiftRightBy 0b0100_0000u8 12", 0b0000_0000u8, u8);
 
     // LLVM in release mode returns 0 instead of -1 for some reason
     if !is_llvm_release_mode {
-        assert_evals_to!("Num.shiftRightBy 12 0b1000_0000u8", 0b1111_1111u8, u8);
+        assert_evals_to!("Num.shiftRightBy 0b1000_0000u8 12", 0b1111_1111u8, u8);
     }
-    assert_evals_to!("Num.shiftRightBy 0 12", 12, i64);
-    assert_evals_to!("Num.shiftRightBy 1 12", 6, i64);
-    assert_evals_to!("Num.shiftRightBy 1 -12", -6, i64);
-    assert_evals_to!("Num.shiftRightBy 8 12", 0, i64);
-    assert_evals_to!("Num.shiftRightBy 8 -12", -1, i64);
-    assert_evals_to!("Num.shiftRightBy -1 12", 0, i64);
+    assert_evals_to!("Num.shiftRightBy 12 0", 12, i64);
+    assert_evals_to!("Num.shiftRightBy 12 1", 6, i64);
+    assert_evals_to!("Num.shiftRightBy -12 1", -6, i64);
+    assert_evals_to!("Num.shiftRightBy 12 8", 0, i64);
+    assert_evals_to!("Num.shiftRightBy -12 8", -1, i64);
+    assert_evals_to!("Num.shiftRightBy 12 -1", 0, i64);
     assert_evals_to!("Num.shiftRightBy 0 0", 0, i64);
-    assert_evals_to!("Num.shiftRightBy 1 0", 0, i64);
+    assert_evals_to!("Num.shiftRightBy 0 1", 0, i64);
 
-    assert_evals_to!("Num.shiftRightBy 0 12i32", 12, i32);
-    assert_evals_to!("Num.shiftRightBy 1 12i32", 6, i32);
-    assert_evals_to!("Num.shiftRightBy 1 -12i32", -6, i32);
-    assert_evals_to!("Num.shiftRightBy 8 12i32", 0, i32);
-    assert_evals_to!("Num.shiftRightBy 8 -12i32", -1, i32);
+    assert_evals_to!("Num.shiftRightBy 12i32 0", 12, i32);
+    assert_evals_to!("Num.shiftRightBy 12i32 1", 6, i32);
+    assert_evals_to!("Num.shiftRightBy -12i32 1", -6, i32);
+    assert_evals_to!("Num.shiftRightBy 12i32 8", 0, i32);
+    assert_evals_to!("Num.shiftRightBy -12i32 8", -1, i32);
 
-    assert_evals_to!("Num.shiftRightBy 0 12i8", 12, i8);
-    assert_evals_to!("Num.shiftRightBy 1 12i8", 6, i8);
-    assert_evals_to!("Num.shiftRightBy 1 -12i8", -6, i8);
-    assert_evals_to!("Num.shiftRightBy 8 12i8", 0, i8);
+    assert_evals_to!("Num.shiftRightBy 12i8 0", 12, i8);
+    assert_evals_to!("Num.shiftRightBy 12i8 1", 6, i8);
+    assert_evals_to!("Num.shiftRightBy -12i8 1", -6, i8);
+    assert_evals_to!("Num.shiftRightBy 12i8 8", 0, i8);
 
     if !is_llvm_release_mode {
-        assert_evals_to!("Num.shiftRightBy -1 0", 0, i64);
-        assert_evals_to!("Num.shiftRightBy -1 -12", -1, i64);
-        assert_evals_to!("Num.shiftRightBy 8 -12i8", -1, i8);
+        assert_evals_to!("Num.shiftRightBy 0 -1", 0, i64);
+        assert_evals_to!("Num.shiftRightBy -12 -1", -1, i64);
+        assert_evals_to!("Num.shiftRightBy -12i8 8", -1, i8);
     }
 }
 
@@ -2150,14 +2150,14 @@ fn shift_right_by() {
 fn shift_right_zf_by() {
     // Logical Right Shift
     assert_evals_to!(
-        "Num.shiftRightZfBy 2 (Num.toI8 0b1100_0000u8)",
+        "Num.shiftRightZfBy (Num.toI8 0b1100_0000u8) 2",
         0b0011_0000i8,
         i8
     );
-    assert_evals_to!("Num.shiftRightZfBy 2 0b1100_0000u8", 0b0011_0000u8, u8);
-    assert_evals_to!("Num.shiftRightZfBy 1 0b0000_0010u8", 0b0000_0001u8, u8);
-    assert_evals_to!("Num.shiftRightZfBy 2 0b0000_1100u8", 0b0000_0011u8, u8);
-    assert_evals_to!("Num.shiftRightZfBy 12 0b1000_0000u8", 0b0000_0000u8, u8);
+    assert_evals_to!("Num.shiftRightZfBy 0b1100_0000u8 2", 0b0011_0000u8, u8);
+    assert_evals_to!("Num.shiftRightZfBy 0b0000_0010u8 1", 0b0000_0001u8, u8);
+    assert_evals_to!("Num.shiftRightZfBy 0b0000_1100u8 2", 0b0000_0011u8, u8);
+    assert_evals_to!("Num.shiftRightZfBy 0b1000_0000u8 12", 0b0000_0000u8, u8);
 }
 
 #[test]

--- a/examples/benchmarks/Base64/Decode.roc
+++ b/examples/benchmarks/Base64/Decode.roc
@@ -18,7 +18,7 @@ loopHelp = \{ remaining, string } ->
         b = Num.intCast y
         c : U32
         c = Num.intCast z
-        combined = Num.bitwiseOr (Num.bitwiseOr (Num.shiftLeftBy 16 a) (Num.shiftLeftBy 8 b)) c
+        combined = Num.bitwiseOr (Num.bitwiseOr (Num.shiftLeftBy a 16) (Num.shiftLeftBy b 8)) c
 
         Loop {
             remaining: remaining - 3,
@@ -33,7 +33,7 @@ loopHelp = \{ remaining, string } ->
         a = Num.intCast x
         b : U32
         b = Num.intCast y
-        combined = Num.bitwiseOr (Num.shiftLeftBy 16 a) (Num.shiftLeftBy 8 b)
+        combined = Num.bitwiseOr (Num.shiftLeftBy a 16) (Num.shiftLeftBy b 8)
 
         Done (Str.concat string (bitsToChars combined 1))
     else
@@ -43,7 +43,7 @@ loopHelp = \{ remaining, string } ->
         a : U32
         a = Num.intCast x
 
-        Done (Str.concat string (bitsToChars (Num.shiftLeftBy 16 a) 2))
+        Done (Str.concat string (bitsToChars (Num.shiftLeftBy a 16) 2))
 
 bitsToChars : U32, Int * -> Str
 bitsToChars = \bits, missing ->
@@ -62,17 +62,17 @@ bitsToCharsHelp = \bits, missing ->
     # with `0b111111` (which is 2^6 - 1 or 63) (so, 6 1s) to remove unwanted bits on the left.
     # any 6-bit number is a valid base64 digit, so this is actually safe
     p =
-        Num.shiftRightZfBy 18 bits
+        Num.shiftRightZfBy bits 18
         |> Num.intCast
         |> unsafeToChar
 
     q =
-        Num.bitwiseAnd (Num.shiftRightZfBy 12 bits) lowest6BitsMask
+        Num.bitwiseAnd (Num.shiftRightZfBy bits 12) lowest6BitsMask
         |> Num.intCast
         |> unsafeToChar
 
     r =
-        Num.bitwiseAnd (Num.shiftRightZfBy 6 bits) lowest6BitsMask
+        Num.bitwiseAnd (Num.shiftRightZfBy bits 6) lowest6BitsMask
         |> Num.intCast
         |> unsafeToChar
 

--- a/examples/benchmarks/Base64/Encode.roc
+++ b/examples/benchmarks/Base64/Encode.roc
@@ -80,11 +80,11 @@ encodeCharacters = \a, b, c, d ->
 
         if d == equals then
             if c == equals then
-                n = Num.bitwiseOr (Num.shiftLeftBy 18 x) (Num.shiftLeftBy 12 y)
+                n = Num.bitwiseOr (Num.shiftLeftBy x 18) (Num.shiftLeftBy y 12)
 
                 # masking higher bits is not needed, Encode.unsignedInt8 ignores higher bits
                 b1 : U8
-                b1 = Num.intCast (Num.shiftRightBy 16 n)
+                b1 = Num.intCast (Num.shiftRightBy n 16)
 
                 Ok (Bytes.Encode.u8 b1)
             else if !(isValidChar c) then
@@ -95,10 +95,10 @@ encodeCharacters = \a, b, c, d ->
                 z : U32
                 z = Num.intCast n3
 
-                n = Num.bitwiseOr (Num.bitwiseOr (Num.shiftLeftBy 18 x) (Num.shiftLeftBy 12 y)) (Num.shiftLeftBy 6 z)
+                n = Num.bitwiseOr (Num.bitwiseOr (Num.shiftLeftBy x 18) (Num.shiftLeftBy y 12)) (Num.shiftLeftBy z 6)
 
                 combined : U16
-                combined = Num.intCast (Num.shiftRightBy 8 n)
+                combined = Num.intCast (Num.shiftRightBy n 8)
 
                 Ok (Bytes.Encode.u16 BE combined)
         else if !(isValidChar d) then
@@ -115,14 +115,14 @@ encodeCharacters = \a, b, c, d ->
 
             n =
                 Num.bitwiseOr
-                    (Num.bitwiseOr (Num.shiftLeftBy 18 x) (Num.shiftLeftBy 12 y))
-                    (Num.bitwiseOr (Num.shiftLeftBy 6 z) w)
+                    (Num.bitwiseOr (Num.shiftLeftBy x 18) (Num.shiftLeftBy y 12))
+                    (Num.bitwiseOr (Num.shiftLeftBy z 6) w)
 
             b3 : U8
             b3 = Num.intCast n
 
             combined : U16
-            combined = Num.intCast (Num.shiftRightBy 8 n)
+            combined = Num.intCast (Num.shiftRightBy n 8)
 
             Ok (Bytes.Encode.sequence [Bytes.Encode.u16 BE combined, Bytes.Encode.u8 b3])
 

--- a/examples/benchmarks/Bytes/Encode.roc
+++ b/examples/benchmarks/Bytes/Encode.roc
@@ -71,7 +71,7 @@ encodeHelp = \encoder, offset, output ->
 
         Unsigned16 endianness value ->
             a : U8
-            a = Num.intCast (Num.shiftRightBy 8 value)
+            a = Num.intCast (Num.shiftRightBy value 8)
 
             b : U8
             b = Num.intCast value
@@ -95,7 +95,7 @@ encodeHelp = \encoder, offset, output ->
 
         Signed16 endianness value ->
             a : U8
-            a = Num.intCast (Num.shiftRightBy 8 value)
+            a = Num.intCast (Num.shiftRightBy value 8)
 
             b : U8
             b = Num.intCast value


### PR DESCRIPTION
The argument order of bitwise shift operators was swapped.
This was probably due to copying from elm.
For reference, see this zulip discussion:
https://roc.zulipchat.com/#narrow/stream/231634-beginners/topic/bit.20shift.20operations.20arguments.20swapped.3F