### PR TITLE
patch deletion of zig-overlay repo

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -30,21 +30,6 @@
         "type": "github"
       }
     },
-    "flake-utils_3": {
-      "locked": {
-        "lastModified": 1629481132,
-        "narHash": "sha256-JHgasjPR0/J1J3DRm4KxM4zTyAj4IOJY8vIl75v/kPI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "997f7efcb746a9c140ce1f13c72263189225f482",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixgl": {
       "inputs": {
         "nixpkgs": [
@@ -86,8 +71,7 @@
         "flake-utils": "flake-utils",
         "nixgl": "nixgl",
         "nixpkgs": "nixpkgs",
-        "rust-overlay": "rust-overlay",
-        "zig": "zig"
+        "rust-overlay": "rust-overlay"
       }
     },
     "rust-overlay": {
@@ -108,27 +92,6 @@
       "original": {
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "type": "github"
-      }
-    },
-    "zig": {
-      "inputs": {
-        "flake-utils": "flake-utils_3",
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1651452199,
-        "narHash": "sha256-lq6mTsoPeOCsji/oMFf6953/uOtOhZZ7HSdtjNVDh6I=",
-        "owner": "roarkanize",
-        "repo": "zig-overlay",
-        "rev": "c3bd59086dbc731c240c924fd2bc3581720d0035",
-        "type": "github"
-      },
-      "original": {
-        "owner": "roarkanize",
-        "repo": "zig-overlay",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -9,11 +9,6 @@
       url = "github:oxalica/rust-overlay";
       inputs.nixpkgs.follows = "nixpkgs";
     };
-    # using an overlay allows for quick updates after zig releases
-    zig = {
-      url = "github:roarkanize/zig-overlay";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
     # to easily make configs for multiple architectures
     flake-utils.url = "github:numtide/flake-utils";
     # to be able to use vulkan system libs for editor graphics
@@ -23,7 +18,7 @@
     };
   };
 
-  outputs = { self, nixpkgs, rust-overlay, zig, flake-utils, nixgl }:
+  outputs = { self, nixpkgs, rust-overlay, flake-utils, nixgl }:
     let supportedSystems = [ "x86_64-linux" "x86_64-darwin" "aarch64-darwin" ];
     in flake-utils.lib.eachSystem supportedSystems (system:
       let
@@ -64,8 +59,6 @@
             Security
           ]);
 
-        zig-toolchain = zig.packages.${system}."0.9.1";
-
         # For debugging LLVM IR
         debugir = pkgs.stdenv.mkDerivation {
           name = "debugir";
@@ -98,7 +91,7 @@
           llvmPkgs.clang
           libxkbcommon
           pkg-config
-          zig-toolchain # roc builtins are implemented in zig, see compiler/builtins/bitcode/
+          zig # roc builtins are implemented in zig, see compiler/builtins/bitcode/
 
           # lib deps
           libffi


### PR DESCRIPTION
The zig-overlay repo was deleted, luckily zig on nixpkgs 22.05 is on the same version. So we can use the regular nix package for now.