### PR TITLE
add lib folder to nightly releases

### DIFF
--- a/ci/package_release.sh
+++ b/ci/package_release.sh
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
 cp target/release/roc ./roc # to be able to exclude "target" later in the tar command
-tar -czvf $1 --exclude="target" --exclude="zig-cache" roc LICENSE LEGAL_DETAILS examples/hello-world crates/compiler/builtins/bitcode/src/ crates/roc_std
+cp -r target/release/lib ./lib
+tar -czvf $1 --exclude="target" --exclude="zig-cache" roc lib LICENSE LEGAL_DETAILS examples/hello-world crates/roc_std


### PR DESCRIPTION
The lib folder was previously introduced to prevent needing `crates/compiler/builtins/bitcode/src` but the nightly releases did not make use of it yet. Now they do :)