### PR TITLE
Fix invalid multiline string output in REPL

### DIFF
--- a/crates/repl_test/src/tests.rs
+++ b/crates/repl_test/src/tests.rs
@@ -542,7 +542,18 @@ fn four_element_record() {
 #[test]
 fn multiline_string() {
     // If a string contains newlines, format it as a multiline string in the output
-    expect_success(r#""\n\nhi!\n\n""#, "\"\n\nhi!\n\n\" : Str");
+    expect_success(
+        r#""\n\nhi!\n\n""#,
+        indoc!(
+            r#""""
+
+            
+                hi!
+            
+
+                """ : Str"#
+        ),
+    );
 }
 
 #[test]


### PR DESCRIPTION
REPL inputs are being parsed as `PlainLine`. This PR formats `PlainLine` string literals containing `\n` as triple-quoted block strings.

This works (as far as I can see) because the regular code formatting will parse `"\n"` as a `Line` containing `EscapedChar`, so the source code formatting will not be impacted by this change.

Closes #3793.