### PR TITLE
Fix multiline string formatting

### DIFF
--- a/crates/compiler/fmt/src/expr.rs
+++ b/crates/compiler/fmt/src/expr.rs
@@ -484,24 +484,20 @@ pub fn fmt_str_literal<'buf>(buf: &mut Buf<'buf>, literal: StrLiteral, indent: u
     buf.push('"');
     match literal {
         PlainLine(string) => {
-            // When a PlainLine contains "\n" it is formatted as a block string using """
-            let mut lines = string.split('\n');
-            match (lines.next(), lines.next()) {
-                (Some(first), Some(second)) => {
-                    buf.push_str("\"\"");
-                    buf.newline();
-
-                    for line in [first, second].into_iter().chain(lines) {
-                        buf.indent(indent);
-                        buf.push_str_allow_spaces(line);
-                        buf.newline();
-                    }
-
+            // When a PlainLine contains '\n' or '"', format as a block string
+            if string.contains('"') || string.contains('\n') {
+                buf.push_str("\"\"");
+                buf.newline();
+                for line in string.split('\n') {
                     buf.indent(indent);
-                    buf.push_str("\"\"");
+                    buf.push_str_allow_spaces(line);
+                    buf.newline();
                 }
-                _ => buf.push_str_allow_spaces(string),
-            }
+                buf.indent(indent);
+                buf.push_str("\"\"");
+            } else {
+                buf.push_str_allow_spaces(string);
+            };
         }
         Line(segments) => {
             for seg in segments.iter() {

--- a/crates/compiler/fmt/tests/test_fmt.rs
+++ b/crates/compiler/fmt/tests/test_fmt.rs
@@ -1098,47 +1098,114 @@ mod test_fmt {
         ));
     }
 
-    // #[test]
-    // fn empty_block_string() {
-    //     expr_formats_same(indoc!(
-    //         r#"
-    //         """"""
-    //         "#
-    //     ));
-    // }
+    #[test]
+    fn empty_block_string() {
+        expr_formats_same(indoc!(
+            r#"
+            """
+            """
+            "#
+        ));
+    }
 
-    // #[test]
-    // fn basic_block_string() {
-    //     expr_formats_same(indoc!(
-    //         r#"
-    //         """blah"""
-    //         "#
-    //     ));
-    // }
+    #[test]
+    fn oneline_empty_block_string() {
+        expr_formats_to(
+            indoc!(
+                r#"
+                """"""
+                "#
+            ),
+            indoc!(
+                r#"
+                """
+                """
+                "#
+            ),
+        );
+    }
 
-    // #[test]
-    // fn newlines_block_string() {
-    //     expr_formats_same(indoc!(
-    //         r#"
-    //         """blah
-    //                 spam
-    //         foo"""
-    //         "#
-    //     ));
-    // }
+    #[test]
+    fn basic_block_string() {
+        expr_formats_to(
+            indoc!(
+                r#"
+                """griffin"""
+                "#
+            ),
+            indoc!(
+                r#"
+                "griffin"
+                "#
+            ),
+        );
+    }
 
-    // #[test]
-    // fn quotes_block_string() {
-    //     expr_formats_same(indoc!(
-    //         r#"
-    //         """
+    #[test]
+    fn multiline_basic_block_string() {
+        expr_formats_to(
+            indoc!(
+                r#"
+                """griffin
+                harpy"""
+                "#
+            ),
+            indoc!(
+                r#"
+                """
+                griffin
+                harpy
+                """
+                "#
+            ),
+        );
+    }
 
-    //         "" \""" ""\"
+    #[test]
+    fn newlines_block_string() {
+        expr_formats_to(
+            indoc!(
+                r#"
+                """griffin
+                        harpy
+                phoenix"""
+                "#
+            ),
+            indoc!(
+                r#"
+                """
+                griffin
+                        harpy
+                phoenix
+                """
+                "#
+            ),
+        );
+    }
 
-    //         """
-    //         "#
-    //     ));
-    // }
+    #[test]
+    fn quotes_block_string_single_segment() {
+        expr_formats_same(indoc!(
+            r#"
+            """
+            "griffin"
+            """
+            "#
+        ));
+    }
+
+    #[test]
+    fn quotes_block_string() {
+        expr_formats_same(indoc!(
+            r#"
+            """
+
+            "" \""" ""\"
+
+            """
+            "#
+        ));
+    }
 
     #[test]
     fn zero() {


### PR DESCRIPTION
## Description

As mentioned in this [Zulip topic ("Multiline string formatter bug")](https://roc.zulipchat.com/#narrow/stream/231634-beginners/topic/Multiline.20strings.20formater.20bug), formatting multi-line strings leads to invalid code. For example:

```
renderTree = \node ->
    when node is
        Data load ->
            """
            \(load.text)
            text!
            """
        Link load ->
            """
            Link!
            Link!
            """
        Tag load ->
            """
            Tag!
            Tag!
            """
```

is formatted to

```
renderTree = \node ->
    when node is
        Data load ->
            """\(load.text)
text!"""

        Link load ->
            """Link!
Link!"""

        Tag load ->
            """Tag!
Tag!"""
```

## Details

This PR will always put `"""` on separate lines and therefore always format multi-line strings on multiple lines. The single-line block string case is removed completely.

While multi-line strings are parsed as `Plaintext` containing a `\n` at the end of each line (expect for the last line) so that they are displayed with line breaks, this does not ensure the correct indentation level. We strip the newlines, and add the proper `.newline()` and `.indent` to the buffer. This works because any `"\n"` in the original string literal will be parsed as `EscapedChar` instead of `Plaintext`.