### PR TITLE
macos m1 nightly cron tests

### DIFF
--- a/.github/workflows/test_nightlies.yml
+++ b/.github/workflows/test_nightlies.yml
@@ -22,10 +22,10 @@ jobs:
         run: curl -OL ${{ env.RELEASE_URL }}
         
       - name: remove everything in this dir except the tar # we want to test like a user who would have downloaded the release, so we clean up all files from the repo checkout
-        run: ls | grep -v tar | xargs rm -rf
+        run: ls | grep -v "roc_nightly.*tar\.gz" | xargs rm -rf
 
       - name: decompress the tar
-        run: ls | grep tar | xargs tar -xzvf
+        run: ls | grep "roc_nightly.*tar\.gz" | xargs tar -xzvf
 
       - name: test roc hello world
         run: ./roc examples/hello-world/main.roc

--- a/.github/workflows/test_nightlies.yml
+++ b/.github/workflows/test_nightlies.yml
@@ -16,7 +16,7 @@ jobs:
         run: curl https://api.github.com/repos/roc-lang/roc/releases > roc_releases.json
 
       - name: get the url of today`s release for macos apple silicon
-        run: echo "RELEASE_URL=$(./ci/get_latest_release.sh)" >> $GITHUB_ENV
+        run: echo "RELEASE_URL=$(./ci/get_latest_release_url.sh)" >> $GITHUB_ENV
 
       - name: get the archive from the url
         run: curl -OL ${{ env.RELEASE_URL }}

--- a/.github/workflows/test_nightlies.yml
+++ b/.github/workflows/test_nightlies.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: [self-hosted, macOS, ARM64]
     timeout-minutes: 90
     steps:
+      - uses: actions/checkout@v3
+      
       - name: fetch releases data and save to file
         run: curl https://api.github.com/repos/roc-lang/roc/releases > roc_releases.json
 
@@ -18,6 +20,9 @@ jobs:
 
       - name: get the archive from the url
         run: curl -OL ${{ env.RELEASE_URL }}
+        
+      - name: remove everything in this dir except the tar # we want to test like a user who would have downloaded the release, so we clean up all files from the repo checkout
+        run: ls | grep -v tar | xargs rm -rf
 
       - name: decompress the tar
         run: ls | grep tar | xargs tar -xzvf

--- a/.github/workflows/test_nightlies.yml
+++ b/.github/workflows/test_nightlies.yml
@@ -10,20 +10,20 @@ jobs:
     runs-on: [self-hosted, macOS, ARM64]
     timeout-minutes: 90
     steps:
-      name: fetch releases data and save to file
-      run: curl https://api.github.com/repos/roc-lang/roc/releases > roc_releases.json
+      - name: fetch releases data and save to file
+        run: curl https://api.github.com/repos/roc-lang/roc/releases > roc_releases.json
 
-      name: get the url of today's release for macos apple silicon
-      run: echo "RELEASE_URL=$(./ci/get_latest_release.sh)" >> $GITHUB_ENV
+      - name: get the url of today`s release for macos apple silicon
+        run: echo "RELEASE_URL=$(./ci/get_latest_release.sh)" >> $GITHUB_ENV
 
-      name: get the archive from the url
-      run: curl -OL ${{ env.RELEASE_URL }}
+      - name: get the archive from the url
+        run: curl -OL ${{ env.RELEASE_URL }}
 
-      name: decompress the tar
-      run: ls | grep tar | xargs tar -xzvf
+      - name: decompress the tar
+        run: ls | grep tar | xargs tar -xzvf
 
-      name: test roc hello world
-      run: ./roc examples/hello-world/main.roc
+      - name: test roc hello world
+        run: ./roc examples/hello-world/main.roc
 
 
         

--- a/.github/workflows/test_nightlies.yml
+++ b/.github/workflows/test_nightlies.yml
@@ -1,0 +1,29 @@
+on: [pull_request]
+#  schedule:
+#    - cron:  '0 15 * * *'
+
+name: Test latest nightly release for macOS Apple Silicon
+
+jobs:
+  test-and-build:
+    name: test nightly macos aarch64
+    runs-on: [self-hosted, macOS, ARM64]
+    timeout-minutes: 90
+    steps:
+      name: fetch releases data and save to file
+      run: curl https://api.github.com/repos/roc-lang/roc/releases > roc_releases.json
+
+      name: get the url of today's release for macos apple silicon
+      run: echo "RELEASE_URL=$(./ci/get_latest_release.sh)" >> $GITHUB_ENV
+
+      name: get the archive from the url
+      run: curl -OL ${{ env.RELEASE_URL }}
+
+      name: decompress the tar
+      run: ls | grep tar | xargs tar -xzvf
+
+      name: test roc hello world
+      run: ./roc examples/hello-world/main.roc
+
+
+        

--- a/.github/workflows/test_nightlies.yml
+++ b/.github/workflows/test_nightlies.yml
@@ -1,6 +1,6 @@
-on: [pull_request]
-#  schedule:
-#    - cron:  '0 15 * * *'
+on:
+  schedule:
+    - cron:  '0 13 * * *'
 
 name: Test latest nightly release for macOS Apple Silicon
 

--- a/ci/get_latest_release_url.sh
+++ b/ci/get_latest_release_url.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# assumes roc_releases.json is present
+
+LATEST_RELEASE_URL=`cat roc_releases.json | jq --arg today $(date +'%Y-%m-%d') '.[0] | .assets | map(.browser_download_url) | map(select(. | contains("silicon-\($today)"))) | .[0]'`
+
+if [[ "$LATEST_RELEASE_URL" == "null" ]]
+then
+  echo "I expected to get a url but I got null instead. Today's release may not have been uploaded?"
+  exit 1
+else
+  echo $LATEST_RELEASE_URL | sed s/\"//g
+fi


### PR DESCRIPTION
Downloads the latest nightly release for macos apple silicon and checks if the hello world example can be built and run successfully.