### PR TITLE
Add traces for external specializations, specialization storage subs, and lambda set depths.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4143,6 +4143,7 @@ name = "roc_tracing"
 version = "0.0.1"
 dependencies = [
  "tracing",
+ "tracing-appender",
  "tracing-subscriber",
 ]
 
@@ -5078,6 +5079,17 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09d48f71a791638519505cefafe162606f706c25592e4bde4d97600c0195312e"
+dependencies = [
+ "crossbeam-channel",
+ "time 0.3.11",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -25,7 +25,7 @@ use std::ffi::{OsStr, OsString};
 use roc_cli::build;
 
 fn main() -> io::Result<()> {
-    roc_tracing::setup_tracing!();
+    let _tracing_guards = roc_tracing::setup_tracing!();
 
     let matches = build_app().get_matches();
 

--- a/crates/compiler/mono/src/layout.rs
+++ b/crates/compiler/mono/src/layout.rs
@@ -1142,7 +1142,7 @@ impl<'a> LambdaSet<'a> {
         closure_var: Variable,
         target_info: TargetInfo,
     ) -> Result<Self, LayoutProblem> {
-        roc_tracing::debug!(size = ?lambda_set_size(subs, closure_var), "building lambda set layout");
+        roc_tracing::debug!(var = ?closure_var, size = ?lambda_set_size(subs, closure_var), "building lambda set layout");
 
         match resolve_lambda_set(subs, closure_var) {
             ResolvedLambdaSet::Set(mut lambdas, opt_recursion_var) => {

--- a/crates/tracing/Cargo.toml
+++ b/crates/tracing/Cargo.toml
@@ -9,3 +9,4 @@ description = "Utilities for setting up tracing at various executable entry poin
 [dependencies]
 tracing = { version = "0.1.36", features = ["release_max_level_off"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }
+tracing-appender = "0.2.2"

--- a/crates/tracing/src/lib.rs
+++ b/crates/tracing/src/lib.rs
@@ -1,6 +1,10 @@
 //! Utilities for turning on tracing in user-facing or test executables of the Roc compiler.
 //!
-//! Tracing always writes to stderr, and is controlled with the ROC_LOG environment variable.
+//! Tracing is controlled with the ROC_LOG environment variable.
+//! If ROC_LOG is specified, logs are written to stderr. If ROC_LOGTO=<filepath> is also specified,
+//! logs are instead written to <filepath>.
+//!
+//! See [directive-syntax] for the filtering directive syntax.
 //!
 //! Rather than using the Rust `tracing` crate (or any other tracing crate) directly,
 //! you should use the exposed members of `roc_tracing` for your tracing needs.
@@ -8,19 +12,21 @@
 //!
 //! Tracing is only turned on in debug builds. Use the provided [setup_tracing] macro to turn on
 //! tracing at an executable's entry point.
+//!
+//! [directive-syntax]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives
 
-/// Sets up tracing of a Roc executable.
+/// Sets up tracing of a Roc executable. The value of this macro must be bound to a variable that
+/// is not dropped until tracing has completed.
 ///
 /// This macro should only be invoked at an executable's entry point.
 /// Tracing will only be enabled in debug builds.
-/// Tracing is controlled with the `ROC_LOG` environment variable. See [directive-syntax] for the filtering directive syntax.
-///
-/// [directive-syntax]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives
 #[macro_export]
 macro_rules! setup_tracing {
     () => {
         if cfg!(debug_assertions) {
-            $crate::setup_tracing();
+            $crate::setup_tracing()
+        } else {
+            $crate::TracingGuards::NONE
         }
     };
 }
@@ -29,14 +35,44 @@ pub use tracing::debug;
 pub use tracing::info;
 
 const ENV_FILTER: &str = "ROC_LOG";
+const LOGTO_VAR: &str = "ROC_LOGTO";
 
 use tracing_subscriber::{fmt, prelude::*, EnvFilter, Layer, Registry};
 
-#[doc(hidden)]
-pub fn setup_tracing() {
-    let stderr_layer = fmt::Layer::default()
-        .with_writer(std::io::stderr)
-        .with_filter(EnvFilter::from_env(ENV_FILTER));
+/// Guards issued by the underlying library used for tracing.
+/// Must not be dropped until all tracing is complete.
+pub struct TracingGuards {
+    _file_appender_guard: Option<tracing_appender::non_blocking::WorkerGuard>,
+}
 
-    Registry::default().with(stderr_layer).init();
+impl TracingGuards {
+    pub const NONE: TracingGuards = TracingGuards {
+        _file_appender_guard: None,
+    };
+}
+
+#[must_use]
+pub fn setup_tracing() -> TracingGuards {
+    if let Ok(file) = std::env::var(LOGTO_VAR) {
+        let file_appender = tracing_appender::rolling::never(".", file);
+        let (non_blocking, guard) = tracing_appender::non_blocking(file_appender);
+        let file_layer = fmt::Layer::default()
+            .with_writer(non_blocking)
+            .with_ansi(false)
+            .with_filter(EnvFilter::from_env(ENV_FILTER));
+
+        Registry::default().with(file_layer).init();
+
+        TracingGuards {
+            _file_appender_guard: Some(guard),
+        }
+    } else {
+        let stderr_layer = fmt::Layer::default()
+            .with_writer(std::io::stderr)
+            .with_filter(EnvFilter::from_env(ENV_FILTER));
+
+        Registry::default().with(stderr_layer).init();
+
+        TracingGuards::NONE
+    }
 }

--- a/crates/tracing/src/lib.rs
+++ b/crates/tracing/src/lib.rs
@@ -54,6 +54,7 @@ impl TracingGuards {
 #[must_use]
 pub fn setup_tracing() -> TracingGuards {
     if let Ok(file) = std::env::var(LOGTO_VAR) {
+        let _ = std::fs::remove_file(&file);
         let file_appender = tracing_appender::rolling::never(".", file);
         let (non_blocking, guard) = tracing_appender::non_blocking(file_appender);
         let file_layer = fmt::Layer::default()


### PR DESCRIPTION
Already starting to learn some interesting stuff. For example the sizes of massive lambda sets in false-interpreter:

```
2022-08-23T20:39:38.708260Z DEBUG roc_mono::layout: building lambda set layout var=66 size=(39, 14, 686)
2022-08-23T20:39:38.722131Z DEBUG roc_mono::layout: building lambda set layout var=3941 size=(37, 13, 677)
2022-08-23T20:39:38.722159Z DEBUG roc_mono::layout: building lambda set layout var=5519 size=(5, 3, 6)
2022-08-23T20:39:38.722176Z DEBUG roc_mono::layout: building lambda set layout var=5544 size=(3, 2, 3)
2022-08-23T20:39:38.722189Z DEBUG roc_mono::layout: building lambda set layout var=5550 size=(1, 1, 1)
2022-08-23T20:39:38.722216Z DEBUG roc_mono::layout: building lambda set layout var=5548 size=(1, 1, 1)
2022-08-23T20:39:38.722257Z DEBUG roc_mono::layout: building lambda set layout var=5550 size=(1, 1, 1)
2022-08-23T20:39:38.722273Z DEBUG roc_mono::layout: building lambda set layout var=5548 size=(1, 1, 1)
2022-08-23T20:39:38.722300Z DEBUG roc_mono::layout: building lambda set layout var=5526 size=(1, 1, 1)
2022-08-23T20:39:38.722319Z DEBUG roc_mono::layout: building lambda set layout var=5544 size=(3, 2, 3)
2022-08-23T20:39:38.722331Z DEBUG roc_mono::layout: building lambda set layout var=5550 size=(1, 1, 1)
2022-08-23T20:39:38.722342Z DEBUG roc_mono::layout: building lambda set layout var=5548 size=(1, 1, 1)
2022-08-23T20:39:38.722354Z DEBUG roc_mono::layout: building lambda set layout var=5550 size=(1, 1, 1)
2022-08-23T20:39:38.722366Z DEBUG roc_mono::layout: building lambda set layout var=5548 size=(1, 1, 1)
2022-08-23T20:39:38.722378Z DEBUG roc_mono::layout: building lambda set layout var=5526 size=(1, 1, 1)
2022-08-23T20:39:38.732926Z DEBUG roc_mono::layout: building lambda set layout var=3948 size=(35, 12, 493)
2022-08-23T20:39:38.739635Z DEBUG roc_mono::layout: building lambda set layout var=5303 size=(33, 11, 315)
2022-08-23T20:39:38.743099Z DEBUG roc_mono::layout: building lambda set layout var=5309 size=(31, 10, 158)
2022-08-23T20:39:38.743124Z DEBUG roc_mono::layout: building lambda set layout var=5322 size=(1, 1, 1)
2022-08-23T20:39:38.743143Z DEBUG roc_mono::layout: building lambda set layout var=5322 size=(1, 1, 1)
2022-08-23T20:39:38.746617Z DEBUG roc_mono::layout: building lambda set layout var=5309 size=(31, 10, 158)
2022-08-23T20:39:38.746632Z DEBUG roc_mono::layout: building lambda set layout var=5322 size=(1, 1, 1)
2022-08-23T20:39:38.746648Z DEBUG roc_mono::layout: building lambda set layout var=5322 size=(1, 1, 1)
2022-08-23T20:39:38.753584Z DEBUG roc_mono::layout: building lambda set layout var=5303 size=(33, 11, 315)
2022-08-23T20:39:38.757058Z DEBUG roc_mono::layout: building lambda set layout var=5309 size=(31, 10, 158)
2022-08-23T20:39:38.757071Z DEBUG roc_mono::layout: building lambda set layout var=5322 size=(1, 1, 1)
2022-08-23T20:39:38.757083Z DEBUG roc_mono::layout: building lambda set layout var=5322 size=(1, 1, 1)
2022-08-23T20:39:38.760544Z DEBUG roc_mono::layout: building lambda set layout var=5309 size=(31, 10, 158)
```