### PR TITLE
windows cross compilation

### DIFF
--- a/crates/cli/src/build.rs
+++ b/crates/cli/src/build.rs
@@ -356,15 +356,8 @@ pub fn build_file<'a>(
             }
 
             let (mut child, _) =  // TODO use lld
-                link(
-                    target,
-                    binary_path.clone(),
-                    &inputs,
-                    link_type
-                )
-                .map_err(|_| {
-                    todo!("gracefully handle `ld` failing to spawn.")
-                })?;
+            link(target, binary_path.clone(), &inputs, link_type)
+                .map_err(|_| todo!("gracefully handle `ld` failing to spawn."))?;
 
             let exit_status = child
                 .wait()

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1203,6 +1203,7 @@ pub enum Target {
     System,
     Linux32,
     Linux64,
+    Windows64,
     Wasm32,
 }
 
@@ -1220,6 +1221,7 @@ impl Target {
             System => "system",
             Linux32 => "linux32",
             Linux64 => "linux64",
+            Windows64 => "windows64",
             Wasm32 => "wasm32",
         }
     }
@@ -1229,6 +1231,7 @@ impl Target {
         Target::System.as_str(),
         Target::Linux32.as_str(),
         Target::Linux64.as_str(),
+        Target::Windows64.as_str(),
         Target::Wasm32.as_str(),
     ];
 
@@ -1250,6 +1253,13 @@ impl Target {
                 operating_system: OperatingSystem::Linux,
                 environment: Environment::Musl,
                 binary_format: BinaryFormat::Elf,
+            },
+            Windows64 => Triple {
+                architecture: Architecture::X86_64,
+                vendor: Vendor::Unknown,
+                operating_system: OperatingSystem::Windows,
+                environment: Environment::Gnu,
+                binary_format: BinaryFormat::Coff,
             },
             Wasm32 => Triple {
                 architecture: Architecture::Wasm32,
@@ -1282,6 +1292,7 @@ impl std::str::FromStr for Target {
             "system" => Ok(Target::System),
             "linux32" => Ok(Target::Linux32),
             "linux64" => Ok(Target::Linux64),
+            "windows64" => Ok(Target::Windows64),
             "wasm32" => Ok(Target::Wasm32),
             _ => Err(format!("Roc does not know how to compile to {}", string)),
         }

--- a/crates/compiler/build/src/link.rs
+++ b/crates/compiler/build/src/link.rs
@@ -519,13 +519,19 @@ pub fn rebuild_host(
             }
             Architecture::X86_64 => {
                 let emit_bin = format!("-femit-bin={}", host_dest.to_str().unwrap());
+
+                let target = match target.operating_system {
+                    OperatingSystem::Windows => "x86_64-windows-gnu",
+                    _ => "native",
+                };
+
                 build_zig_host_native(
                     &env_path,
                     &env_home,
                     &emit_bin,
                     zig_host_src.to_str().unwrap(),
                     zig_str_path.to_str().unwrap(),
-                    "native",
+                    target,
                     opt_level,
                     shared_lib_path,
                 )
@@ -1185,11 +1191,7 @@ fn link_windows(
                     "-lc",
                     &format!("-femit-bin={}", output_path.to_str().unwrap()),
                     "-target",
-                    "native",
-                    "--pkg-begin",
-                    "str",
-                    zig_str_path.to_str().unwrap(),
-                    "--pkg-end",
+                    "x86_64-windows-gnu",
                     "--strip",
                     "-O",
                     "Debug",

--- a/crates/compiler/builtins/bitcode/build.zig
+++ b/crates/compiler/builtins/bitcode/build.zig
@@ -30,12 +30,14 @@ pub fn build(b: *Builder) void {
     });
     const linux32_target = makeLinux32Target();
     const linux64_target = makeLinux64Target();
+    const windows64_target = makeWindows64Target();
     const wasm32_target = makeWasm32Target();
 
     // LLVM IR
     generateLlvmIrFile(b, mode, host_target, main_path, "ir", "builtins-host");
     generateLlvmIrFile(b, mode, linux32_target, main_path, "ir-i386", "builtins-i386");
     generateLlvmIrFile(b, mode, linux64_target, main_path, "ir-x86_64", "builtins-x86_64");
+    generateLlvmIrFile(b, mode, windows64_target, main_path, "ir-windows-x86_64", "builtins-windows-x86_64");
     generateLlvmIrFile(b, mode, wasm32_target, main_path, "ir-wasm32", "builtins-wasm32");
 
     // Generate Object Files
@@ -106,6 +108,16 @@ fn makeLinux64Target() CrossTarget {
     target.cpu_arch = std.Target.Cpu.Arch.x86_64;
     target.os_tag = std.Target.Os.Tag.linux;
     target.abi = std.Target.Abi.musl;
+
+    return target;
+}
+
+fn makeWindows64Target() CrossTarget {
+    var target = CrossTarget.parse(.{}) catch unreachable;
+
+    target.cpu_arch = std.Target.Cpu.Arch.x86_64;
+    target.os_tag = std.Target.Os.Tag.windows;
+    target.abi = std.Target.Abi.gnu;
 
     return target;
 }

--- a/crates/compiler/builtins/build.rs
+++ b/crates/compiler/builtins/build.rs
@@ -44,8 +44,12 @@ fn main() {
     }
 
     generate_bc_file(&bitcode_path, "ir-i386", "builtins-i386");
-
     generate_bc_file(&bitcode_path, "ir-x86_64", "builtins-x86_64");
+    generate_bc_file(
+        &bitcode_path,
+        "ir-windows-x86_64",
+        "builtins-windows-x86_64",
+    );
 
     // OBJECT FILES
     #[cfg(windows)]

--- a/crates/compiler/gen_llvm/src/llvm/build.rs
+++ b/crates/compiler/gen_llvm/src/llvm/build.rs
@@ -480,6 +480,13 @@ pub fn module_from_builtins<'ctx>(
             } => {
                 include_bytes!("../../../builtins/bitcode/builtins-x86_64.bc")
             }
+            Triple {
+                architecture: Architecture::X86_64,
+                operating_system: OperatingSystem::Windows,
+                ..
+            } => {
+                include_bytes!("../../../builtins/bitcode/builtins-windows-x86_64.bc")
+            }
             _ => panic!(
                 "The zig builtins are not currently built for this target: {:?}",
                 target

--- a/examples/benchmarks/platform/host.zig
+++ b/examples/benchmarks/platform/host.zig
@@ -96,8 +96,7 @@ pub export fn main() callconv(.C) u8 {
         roc_dealloc(raw_output, @alignOf(u64));
     }
 
-    var ts1: std.os.timespec = undefined;
-    std.os.clock_gettime(std.os.CLOCK.REALTIME, &ts1) catch unreachable;
+    var timer = std.time.Timer.start() catch unreachable;
 
     roc__mainForHost_1_exposed_generic(output);
 
@@ -105,13 +104,11 @@ pub export fn main() callconv(.C) u8 {
 
     call_the_closure(closure_data_pointer);
 
-    var ts2: std.os.timespec = undefined;
-    std.os.clock_gettime(std.os.CLOCK.REALTIME, &ts2) catch unreachable;
-
-    const delta = to_seconds(ts2) - to_seconds(ts1);
+    const nanos = timer.read();
+    const seconds = (@intToFloat(f64, nanos) / 1_000_000_000.0);
 
     const stderr = std.io.getStdErr().writer();
-    stderr.print("runtime: {d:.3}ms\n", .{delta * 1000}) catch unreachable;
+    stderr.print("runtime: {d:.3}ms\n", .{seconds * 1000}) catch unreachable;
 
     return 0;
 }


### PR DESCRIPTION
attempt to compile for windows from any platform. 

This now works

```
target/debug/roc build --precompiled-host=false --linker=legacy --target=windows64 examples/platform-switching/zig-platform/rocLovesZig.roc
```

but running it does not yet work with wine, for me. It would be cool if someone on windows could compile this branch and run the above command within WSL, and then try to run the exe on windows.