### PR TITLE
windows build cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3592,6 +3592,7 @@ name = "roc_docs_cli"
 version = "0.0.1"
 dependencies = [
  "clap 3.2.11",
+ "libc",
  "roc_docs",
 ]
 

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -59,7 +59,6 @@ roc_error_macros = { path = "../error_macros" }
 roc_editor = { path = "../editor", optional = true }
 roc_linker = { path = "../linker" }
 roc_repl_cli = { path = "../repl_cli", optional = true }
-roc_repl_expect = { path = "../repl_expect" }
 roc_tracing = { path = "../tracing" }
 clap = { version = "3.1.15", default-features = false, features = ["std", "color", "suggestions"] }
 const_format = { version = "0.2.23", features = ["const_generics"] }
@@ -80,6 +79,10 @@ signal-hook = "0.3.14"
 
 [target.'cfg(windows)'.dependencies]
 memexec = "0.2.0"
+
+# for now, uses unix/libc functions that windows does not support
+[target.'cfg(not(windows))'.dependencies]
+roc_repl_expect = { path = "../repl_expect" }
 
 # Wasmer singlepass compiler only works on x86_64.
 [target.'cfg(target_arch = "x86_64")'.dependencies]

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -11,7 +11,6 @@ use roc_gen_llvm::llvm::build::LlvmBackendMode;
 use roc_load::{ExecutionMode, Expectations, LoadConfig, LoadingProblem, Threading};
 use roc_module::symbol::{Interns, ModuleId};
 use roc_mono::ir::OptLevel;
-use roc_repl_expect::run::expect_mono_module_to_dylib;
 use roc_target::TargetInfo;
 use std::env;
 use std::ffi::{CString, OsStr};
@@ -318,6 +317,12 @@ pub enum FormatMode {
     CheckOnly,
 }
 
+#[cfg(windows)]
+pub fn test(_matches: &ArgMatches, _triple: Triple) -> io::Result<i32> {
+    todo!("running tests does not work on windows right now")
+}
+
+#[cfg(not(windows))]
 pub fn test(matches: &ArgMatches, triple: Triple) -> io::Result<i32> {
     let start_time = Instant::now();
     let arena = Bump::new();
@@ -389,7 +394,7 @@ pub fn test(matches: &ArgMatches, triple: Triple) -> io::Result<i32> {
 
     let interns = loaded.interns.clone();
 
-    let (lib, expects) = expect_mono_module_to_dylib(
+    let (lib, expects) = roc_repl_expect::run::expect_mono_module_to_dylib(
         arena,
         target.clone(),
         loaded,

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1191,3 +1191,37 @@ impl std::str::FromStr for Target {
         }
     }
 }
+
+#[cfg(windows)]
+use windows_roc_platform_functions::*;
+
+#[cfg(windows)]
+mod windows_roc_platform_functions {
+    use core::ffi::c_void;
+
+    /// # Safety
+    /// The Roc application needs this.
+    #[no_mangle]
+    pub unsafe fn roc_alloc(size: usize, _alignment: u32) -> *mut c_void {
+        libc::malloc(size)
+    }
+
+    /// # Safety
+    /// The Roc application needs this.
+    #[no_mangle]
+    pub unsafe fn roc_realloc(
+        c_ptr: *mut c_void,
+        new_size: usize,
+        _old_size: usize,
+        _alignment: u32,
+    ) -> *mut c_void {
+        libc::realloc(c_ptr, new_size)
+    }
+
+    /// # Safety
+    /// The Roc application needs this.
+    #[no_mangle]
+    pub unsafe fn roc_dealloc(c_ptr: *mut c_void, _alignment: u32) {
+        libc::free(c_ptr)
+    }
+}

--- a/crates/compiler/load/src/lib.rs
+++ b/crates/compiler/load/src/lib.rs
@@ -177,7 +177,7 @@ fn read_cached_subs() -> MutMap<ModuleId, (Subs, Vec<(Symbol, Variable)>)> {
 
     // Wasm seems to re-order definitions between build time and runtime, but only in release mode.
     // That is very strange, but we can solve it separately
-    if !cfg!(target_family = "wasm") && !SKIP_SUBS_CACHE {
+    if !cfg!(target_family = "wasm") && !cfg!(windows) && !SKIP_SUBS_CACHE {
         output.insert(ModuleId::BOOL, deserialize_help(BOOL));
         output.insert(ModuleId::RESULT, deserialize_help(RESULT));
         output.insert(ModuleId::NUM, deserialize_help(NUM));

--- a/crates/docs_cli/Cargo.toml
+++ b/crates/docs_cli/Cargo.toml
@@ -19,3 +19,6 @@ bench = false
 [dependencies]
 roc_docs = { path = "../docs" }
 clap = { version = "3.1.15", default-features = false, features = ["std", "color", "suggestions", "derive"] }
+
+[target.'cfg(windows)'.dependencies]
+libc = "0.2.106"

--- a/crates/docs_cli/src/main.rs
+++ b/crates/docs_cli/src/main.rs
@@ -48,3 +48,40 @@ fn roc_files_recursive<P: AsRef<Path>>(
 
     Ok(())
 }
+
+// These functions don't end up in the final Roc binary but Windows linker needs a definition inside the crate.
+// On Windows, there seems to be less dead-code-elimination than on Linux or MacOS, or maybe it's done later.
+#[cfg(windows)]
+#[allow(unused_imports)]
+use windows_roc_platform_functions::*;
+
+#[cfg(windows)]
+mod windows_roc_platform_functions {
+    use core::ffi::c_void;
+
+    /// # Safety
+    /// The Roc application needs this.
+    #[no_mangle]
+    pub unsafe fn roc_alloc(size: usize, _alignment: u32) -> *mut c_void {
+        libc::malloc(size)
+    }
+
+    /// # Safety
+    /// The Roc application needs this.
+    #[no_mangle]
+    pub unsafe fn roc_realloc(
+        c_ptr: *mut c_void,
+        new_size: usize,
+        _old_size: usize,
+        _alignment: u32,
+    ) -> *mut c_void {
+        libc::realloc(c_ptr, new_size)
+    }
+
+    /// # Safety
+    /// The Roc application needs this.
+    #[no_mangle]
+    pub unsafe fn roc_dealloc(c_ptr: *mut c_void, _alignment: u32) {
+        libc::free(c_ptr)
+    }
+}

--- a/crates/repl_expect/src/lib.rs
+++ b/crates/repl_expect/src/lib.rs
@@ -11,11 +11,15 @@ use roc_repl_eval::{
 use roc_target::TargetInfo;
 use roc_types::subs::{Subs, Variable};
 
+#[cfg(not(windows))]
 mod app;
+#[cfg(not(windows))]
 pub mod run;
 
+#[cfg(not(windows))]
 use app::{ExpectMemory, ExpectReplApp};
 
+#[cfg(not(windows))]
 #[allow(clippy::too_many_arguments)]
 pub fn get_values<'a>(
     target_info: TargetInfo,
@@ -75,6 +79,7 @@ pub fn get_values<'a>(
     Ok((app.offset, result))
 }
 
+#[cfg(not(windows))]
 #[cfg(test)]
 mod test {
     use indoc::indoc;

--- a/crates/repl_expect/src/lib.rs
+++ b/crates/repl_expect/src/lib.rs
@@ -1,15 +1,18 @@
-use roc_module::symbol::Interns;
-use roc_mono::{
-    ir::ProcLayout,
-    layout::{CapturesNiche, LayoutCache},
+#[cfg(not(windows))]
+use {
+    roc_module::symbol::Interns,
+    roc_mono::{
+        ir::ProcLayout,
+        layout::{CapturesNiche, LayoutCache},
+    },
+    roc_parse::ast::Expr,
+    roc_repl_eval::{
+        eval::{jit_to_ast, ToAstProblem},
+        ReplAppMemory,
+    },
+    roc_target::TargetInfo,
+    roc_types::subs::{Subs, Variable},
 };
-use roc_parse::ast::Expr;
-use roc_repl_eval::{
-    eval::{jit_to_ast, ToAstProblem},
-    ReplAppMemory,
-};
-use roc_target::TargetInfo;
-use roc_types::subs::{Subs, Variable};
 
 #[cfg(not(windows))]
 mod app;


### PR DESCRIPTION
- boilerplate
- more boilerplate
- thread fx expects to the runner
- expect-fx runner implementation
- get expect-fx to actually run
- improve how we deal with the expect memory buffer
- fix compile error in test
- fix linux nightly, update checkout action
- re-enable cron
- fix merge conflict
- macos m1 nightly cron tests
- yml formatting fix
- need checkout for ci script
- typo
- more exact grep pattern
- change trigger from PR to cron
- Change repl behavior and instructions around quit
- mention recommended forking strategy
- Replace snapshot of subs/layout directly with "TypeState" snapshots
- Get rid of a redundant subs snapshot
- improved lib dir error msg
- clippy
- Add Mostly Void to Authors
- Remove duplicate AUTHORS entry
- put important text in bold
- disable subs caching on windows statically
- attempt to disable roc_repl_expect on windows
- define roc_alloc and friends in cli/src/lib.rs on windows
