### PR TITLE
build nightly on ubuntu 20.04

### DIFF
--- a/.github/workflows/nightly_linux_x86_64.yml
+++ b/.github/workflows/nightly_linux_x86_64.yml
@@ -3,10 +3,6 @@ on: [pull_request]
 #    - cron:  '0 9 * * *'
 
 name: Nightly Release Linux x86_64
-
-defaults:
-  run:
-    shell: . "$HOME/.cargo/env" && export PATH=$PATH:/home/anton/Downloads/zig-linux-x86_64-0.9.1
     
 jobs:
   build:

--- a/.github/workflows/nightly_linux_x86_64.yml
+++ b/.github/workflows/nightly_linux_x86_64.yml
@@ -21,8 +21,8 @@ jobs:
       - name: create version.txt
         run: ./ci/write_version.sh
         
-      - name: cargo version
-        run: cargo --version
+      - name: print PATH
+        run: echo $PATH
 
       - name: build release
         run: RUSTFLAGS="-C target-cpu=x86-64" cargo build --features with_sound --release --locked

--- a/.github/workflows/nightly_linux_x86_64.yml
+++ b/.github/workflows/nightly_linux_x86_64.yml
@@ -24,14 +24,23 @@ jobs:
         run: RUSTFLAGS="-C target-cpu=x86-64" cargo build --features with_sound --release --locked
         # target-cpu=x86-64 -> For maximal compatibility for all CPU's. Note that this setting will likely make the compiler slower.
 
-      - name: Make release tar archive
-        run: ./ci/package_release.sh roc_linux_x86_64.tar.gz
+      - name: get commit SHA
+        run:  echo "SHA=$(git rev-parse --short "$GITHUB_SHA")" >> $GITHUB_ENV
+        
+      - name: get date
+        run: echo 'DATE=date "+%Y-%m-%d"' >> $GITHUB_ENV
+        
+      - name: build file name
+        run: echo "RELEASE_TAR_FILENAME=roc_nightly-linux_x86_64-$DATE-$SHA.tar.gz" >> $GITHUB_ENV
+       
+      - name: Make nightly release tar archive
+        run: ./ci/package_release.sh $RELEASE_TAR_FILENAME
 
       - name: Upload roc nightly tar. Actually uploading to github releases has to be done manually.
         uses: actions/upload-artifact@v3
         with:
-           name: roc_nightly-linux_x86_64.tar.gz
-           path: roc_linux_x86_64.tar.gz
+           name: $RELEASE_TAR_FILENAME
+           path: $RELEASE_TAR_FILENAME
            retention-days: 4
 
       - name: build wasm repl

--- a/.github/workflows/nightly_linux_x86_64.yml
+++ b/.github/workflows/nightly_linux_x86_64.yml
@@ -1,6 +1,6 @@
-on: [pull_request]
-#  schedule:
-#    - cron:  '0 9 * * *'
+on:
+  schedule:
+    - cron:  '0 9 * * *'
 
 name: Nightly Release Linux x86_64
     
@@ -30,8 +30,6 @@ jobs:
             DATE: ${{ env.DATE }}
             SHA: ${{ env.SHA }}
         run: echo "RELEASE_TAR_FILENAME=roc_nightly-linux_x86_64-$DATE-$SHA.tar.gz" >> $GITHUB_ENV
-        
-      - run: echo ${{ env.RELEASE_TAR_FILENAME }}
        
       - name: Make nightly release tar archive
         run: ./ci/package_release.sh ${{ env.RELEASE_TAR_FILENAME }}

--- a/.github/workflows/nightly_linux_x86_64.yml
+++ b/.github/workflows/nightly_linux_x86_64.yml
@@ -4,6 +4,10 @@ on: [pull_request]
 
 name: Nightly Release Linux x86_64
 
+defaults:
+  run:
+    shell: . "$HOME/.cargo/env" && export PATH=$PATH:/home/anton/Downloads/zig-linux-x86_64-0.9.1
+    
 jobs:
   build:
     name: Rust tests, build and package nightly release

--- a/.github/workflows/nightly_linux_x86_64.yml
+++ b/.github/workflows/nightly_linux_x86_64.yml
@@ -9,16 +9,11 @@ jobs:
     name: Rust tests, build and package nightly release
     runs-on: [self-hosted, i7-6700K]
     timeout-minutes: 90
-    env:
-      FORCE_COLOR: 1 # for earthly logging
     steps:
       - uses: actions/checkout@v3
 
       - name: create version.txt
         run: ./ci/write_version.sh
-        
-      - name: print PATH
-        run: echo $PATH
 
       - name: build release
         run: RUSTFLAGS="-C target-cpu=x86-64" cargo build --features with_sound --release --locked
@@ -28,19 +23,24 @@ jobs:
         run:  echo "SHA=$(git rev-parse --short "$GITHUB_SHA")" >> $GITHUB_ENV
         
       - name: get date
-        run: echo 'DATE=date "+%Y-%m-%d"' >> $GITHUB_ENV
+        run: echo 'DATE=$(date "+%Y-%m-%d")' >> $GITHUB_ENV
         
       - name: build file name
+        env:
+            DATE: ${{ env.DATE }}
+            SHA: ${{ env.SHA }}
         run: echo "RELEASE_TAR_FILENAME=roc_nightly-linux_x86_64-$DATE-$SHA.tar.gz" >> $GITHUB_ENV
+        
+      - run: echo ${{ env.RELEASE_TAR_FILENAME }}
        
       - name: Make nightly release tar archive
-        run: ./ci/package_release.sh $RELEASE_TAR_FILENAME
+        run: ./ci/package_release.sh ${{ env.RELEASE_TAR_FILENAME }}
 
       - name: Upload roc nightly tar. Actually uploading to github releases has to be done manually.
         uses: actions/upload-artifact@v3
         with:
-           name: $RELEASE_TAR_FILENAME
-           path: $RELEASE_TAR_FILENAME
+           name: ${{ env.RELEASE_TAR_FILENAME }}
+           path: ${{ env.RELEASE_TAR_FILENAME }}
            retention-days: 4
 
       - name: build wasm repl

--- a/.github/workflows/nightly_linux_x86_64.yml
+++ b/.github/workflows/nightly_linux_x86_64.yml
@@ -1,13 +1,13 @@
-on:
-  schedule:
-    - cron:  '0 9 * * *'
+on: [pull_request]
+#  schedule:
+#    - cron:  '0 9 * * *'
 
 name: Nightly Release Linux x86_64
 
 jobs:
   build:
     name: Rust tests, build and package nightly release
-    runs-on: [self-hosted, i5-4690K]
+    runs-on: [self-hosted, i7-6700K]
     timeout-minutes: 90
     env:
       FORCE_COLOR: 1 # for earthly logging

--- a/.github/workflows/nightly_linux_x86_64.yml
+++ b/.github/workflows/nightly_linux_x86_64.yml
@@ -23,7 +23,7 @@ jobs:
         run:  echo "SHA=$(git rev-parse --short "$GITHUB_SHA")" >> $GITHUB_ENV
         
       - name: get date
-        run: echo 'DATE=$(date "+%Y-%m-%d")' >> $GITHUB_ENV
+        run: echo "DATE=$(date "+%Y-%m-%d")" >> $GITHUB_ENV
         
       - name: build file name
         env:

--- a/.github/workflows/nightly_linux_x86_64.yml
+++ b/.github/workflows/nightly_linux_x86_64.yml
@@ -16,6 +16,9 @@ jobs:
 
       - name: create version.txt
         run: ./ci/write_version.sh
+        
+      - name: cargo version
+        run: cargo --version
 
       - name: build release
         run: RUSTFLAGS="-C target-cpu=x86-64" cargo build --features with_sound --release --locked


### PR DESCRIPTION
Building it on 22.04 uses a newer libc than available on 20.04, which doesn't work.
Building on 20.04 does also work on 22.04.

- Also includes SHA and date in filename again.