### PR TITLE
Use repr(transparent) for single-tag union glue

### DIFF
--- a/crates/glue/src/rust_glue.rs
+++ b/crates/glue/src/rust_glue.rs
@@ -576,7 +576,7 @@ fn add_tag_union(
                     None,
                     target_info,
                     format!(
-                        r#"
+                        r#"#[repr(transparent)]
 pub struct {name} {{
     pointer: *mut {union_name},
 }}


### PR DESCRIPTION
Fixes #3869