### PR TITLE
Reformat the "getting started" guides for clarity & cleanliness

### DIFF
--- a/getting_started/README.md
+++ b/getting_started/README.md
@@ -22,9 +22,9 @@ If you have a specific question, the [FAQ](../FAQ.md) might have an answer, alth
 
 You can run examples as follows:
 
-```
-$ cd examples/hello-world
-$ roc run
+```sh
+cd examples/hello-world
+roc run
 ```
 
 Some examples like `examples/benchmarks/NQueens.roc` require input after running.

--- a/getting_started/linux_x86.md
+++ b/getting_started/linux_x86.md
@@ -1,34 +1,46 @@
-0. Download the latest nightly from the assets [here](https://github.com/roc-lang/roc/releases).
-0. Untar the archive:
-    ```
+# Roc installation guide for x86 Linux systems
+
+## How to install Roc
+
+1. Download the latest nightly from the assets [here](https://github.com/roc-lang/roc/releases).
+
+1. Untar the archive:
+
+    ```sh
     tar -xf roc_nightly-linux_x86_64-<VERSION>.tar.gz
     ```
-0. To be able to run examples:
-    - for the Rust example:
-    ```
+
+## How to install `examples/` dependencies
+
+1. Install the Rust compiler, for examples with Rust-based platforms:
+
+    ```sh
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
     ```
-    - for the zig example:
-    ```
+
+1. Install the Zig compiler, for examples with Zig-based platforms:
+
+    ```sh
     wget https://ziglang.org/download/0.9.1/zig-linux-x86_64-0.9.1.tar.xz
     tar -xf zig-linux-x86_64-0.9.1.tar.xz
     sudo ln -s  $(pwd)/zig-linux-x86_64-0.9.1/zig /usr/local/bin/zig
     ```
-    - for the C example:
-    ```
+
+1. Install a C compiler, for examples with C-based platforms:
+
+    ```sh
     # On a Debian-based distro like Ubuntu
     sudo apt update && sudo apt install build-essential clang
     
     # On an RPM-based distro like Fedora
     sudo dnf check-update && sudo dnf install clang
     ```
-0. Run examples with:
-    ```
-    # Rust. If you installed rust in this terminal you'll need to open a new one first!
+
+    ```sh
+    # Note: If you installed Rust in this terminal session, you'll need to open a new one first!
     ./roc examples/platform-switching/rust-platform/rocLovesRust.roc
-    # Zig
+
     ./roc examples/platform-switching/zig-platform/rocLovesZig.roc
-    # C
+
     ./roc examples/platform-switching/c-platform/rocLovesC.roc
     ```
-0. See [here](../README.md#examples) for the other examples.

--- a/getting_started/macos_apple_silicon.md
+++ b/getting_started/macos_apple_silicon.md
@@ -1,28 +1,42 @@
-0. Download the latest nightly from the assets [here](https://github.com/roc-lang/roc/releases).
-0. To prevent "roc can't be opened because Apple can't check it...":
-    ```
+# Roc installation guide for Apple silicon systems
+
+## How to install Roc
+
+1. Download the latest nightly from the assets [here](https://github.com/roc-lang/roc/releases).
+
+1. To prevent "roc can't be opened because Apple can't check it...":
+
+    ```sh
     xattr -d com.apple.quarantine roc_nightly-darwin_apple_silicon-<VERSION>.tar.gz
     ```
-0. Untar the archive:
-    ```
+
+1. Untar the archive:
+
+    ```sh
     roc_nightly-darwin_apple_silicon-<VERSION>.tar.gz
     ```
-0. To be able to run examples:
-    - for the Rust example:
-    ```
+
+## How to install `examples/` dependencies
+
+1. Install the Rust compiler, for examples with Rust-based platforms:
+
+    ```sh
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
     ```
-    - for the zig example:
-    ```
+
+1. Install the Zig compiler, for examples with Zig-based platforms:
+
+    ```sh
     brew install zig
     ```
-0. Run examples with:
+
+1. Run examples:
+
+    ```sh
+    # Note: If you installed rust in this terminal session, you'll need to open a new one first!
+    ./roc examples/platform-switching/rust-platform/rocLovesRust.roc
+
+    ./roc examples/platform-switching/zig-platform/rocLovesZig.roc
+
+    ./roc examples/platform-switching/c-platform/rocLovesC.roc
     ```
-    # Rust. If you installed rust in this terminal you'll need to open a new one first!
-    ./roc examples/hello-world/rust-platform/helloRust.roc
-    # Zig
-    ./roc examples/hello-world/zig-platform/helloZig.roc
-    # C
-    ./roc examples/hello-world/c-platform/helloC.roc
-    ```
-0. See [here](../README.md#examples) for the other examples.

--- a/getting_started/macos_x86.md
+++ b/getting_started/macos_x86.md
@@ -1,26 +1,42 @@
-0. Download the latest nightly from the assets [here](https://github.com/roc-lang/roc/releases).
-0. To prevent "roc can't be opened because Apple can't check it...":
-    ```
+# Roc installation guide for x86 macOS systems
+
+## How to install Roc
+
+1. Download the latest nightly from the assets [here](https://github.com/roc-lang/roc/releases).
+
+1. To prevent "roc can't be opened because Apple can't check it...":
+
+    ```sh
     xattr -d com.apple.quarantine roc_nightly-macos_x86_64-<VERSION>.tar.gz
     ```
-0. Untar the archive:
-    ```
+
+1. Untar the archive:
+
+    ```sh
     roc_nightly-macos_x86_64-<VERSION>.tar.gz
     ```
-0. To be able to run examples:
-    - for the Rust example:
-    ```
+
+## How to install `examples/` dependencies
+
+1. Install the Rust compiler, for examples with Rust-based platforms:
+
+    ```sh
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
     ```
-    - for the zig example:
-    ```
+
+1. Install the Zig compiler, for examples with Zig-based platforms:
+
+    ```sh
     brew install zig
     ```
-0. Run examples with:
+
+1. Run examples:
+
+    ```sh
+    # Note: If you installed rust in this terminal session, you'll need to open a new one first!
+    ./roc examples/platform-switching/rust-platform/rocLovesRust.roc
+
+    ./roc examples/platform-switching/zig-platform/rocLovesZig.roc
+
+    ./roc examples/platform-switching/c-platform/rocLovesC.roc
     ```
-    # Rust. If you installed rust in this terminal you'll need to open a new one first!
-    ./roc examples/hello-world/rust-platform/helloRust.roc
-    # Zig
-    ./roc examples/hello-world/zig-platform/helloZig.roc
-    ```
-0. See [here](../README.md#examples) for the other examples.

--- a/getting_started/other.md
+++ b/getting_started/other.md
@@ -1,14 +1,17 @@
+# Roc installation guide for other systems
 
 1. [Install Rust](https://rustup.rs/)
-2. [Build roc from source](../BUILDING_FROM_SOURCE.md)
-3. Run examples with:
-    ```
-    # Rust
+
+1. [Build Roc from source](../BUILDING_FROM_SOURCE.md)
+
+1. Run examples:
+
+    ```sh
     cargo run examples/platform-switching/rust-platform/rocLovesRust.roc
-    # Zig
+
+    # This requires installing the Zig compiler, too.
     cargo run examples/platform-switching/zig-platform/rocLovesZig.roc
-    # C
+
+    # This requires installing the `clang` C compiler, too.
     cargo run examples/platform-switching/c-platform/rocLovesC.roc
     ```
-4. See [here](../README.md#examples) for the other examples.
-

--- a/getting_started/windows.md
+++ b/getting_started/windows.md
@@ -1,2 +1,4 @@
+# Roc installation guide for Windows systems
+
 Windows is not yet supported, we have a big project in the works (see [issue #2608](https://github.com/roc-lang/roc/issues/2608)) that will allow this.
 Until then we recommend using Ubuntu through the "Windows Subsystem for Linux".


### PR DESCRIPTION
- Adhere to [this Markdown style
guide](https://github.com/DavidAnson/markdownlint).
- Simplify & clarify various steps.