### PR TITLE
Only compile and run expects that belong to the same package

### DIFF
--- a/crates/compiler/load_internal/src/file.rs
+++ b/crates/compiler/load_internal/src/file.rs
@@ -466,7 +466,6 @@ fn start_phase<'a>(
 
                 BuildTask::BuildPendingSpecializations {
                     layout_cache,
-                    execution_mode: state.exec_mode,
                     module_id,
                     module_timing,
                     solved_subs,
@@ -1120,7 +1119,6 @@ enum BuildTask<'a> {
     },
     BuildPendingSpecializations {
         module_timing: ModuleTiming,
-        execution_mode: ExecutionMode,
         layout_cache: LayoutCache<'a>,
         solved_subs: Solved<Subs>,
         imported_module_thunks: &'a [Symbol],
@@ -4820,7 +4818,6 @@ fn make_specializations<'a>(
 #[allow(clippy::too_many_arguments)]
 fn build_pending_specializations<'a>(
     arena: &'a Bump,
-    execution_mode: ExecutionMode,
     solved_subs: Solved<Subs>,
     imported_module_thunks: &'a [Symbol],
     home: ModuleId,
@@ -5429,7 +5426,6 @@ fn run_task<'a>(
         )),
         BuildPendingSpecializations {
             module_id,
-            execution_mode,
             ident_ids,
             decls,
             module_timing,
@@ -5443,7 +5439,6 @@ fn run_task<'a>(
             build_expects,
         } => Ok(build_pending_specializations(
             arena,
-            execution_mode,
             solved_subs,
             imported_module_thunks,
             module_id,

--- a/crates/compiler/module/src/symbol.rs
+++ b/crates/compiler/module/src/symbol.rs
@@ -512,6 +512,20 @@ impl<'a> PackageModuleIds<'a> {
     pub fn available_modules(&self) -> impl Iterator<Item = &PQModuleName> {
         self.by_id.iter()
     }
+
+    /// Returns true iff two modules belong to the same package.
+    /// Returns [None] if one module is unknown.
+    pub fn package_eq(&self, left: ModuleId, right: ModuleId) -> Option<bool> {
+        if left.is_builtin() ^ right.is_builtin() {
+            return Some(false);
+        }
+        let result = match (self.get_name(left)?, self.get_name(right)?) {
+            (PQModuleName::Unqualified(_), PQModuleName::Unqualified(_)) => true,
+            (PQModuleName::Qualified(pkg1, _), PQModuleName::Qualified(pkg2, _)) => pkg1 == pkg2,
+            _ => false,
+        };
+        Some(result)
+    }
 }
 
 /// Stores a mapping between ModuleId and InlinableString.


### PR DESCRIPTION
In particular, don't run expects that come from modules with a different
package qualification (including subpackages; we can loosen this
restriction later), or builtins when run on userspace apps/interfaces.

Closes #3722