### PR TITLE
Windows surgical cross compiling

### DIFF
--- a/crates/compiler/build/src/link.rs
+++ b/crates/compiler/build/src/link.rs
@@ -482,15 +482,29 @@ pub fn rebuild_host(
             host_input_path.with_file_name("host.bc")
         }
     } else {
-        host_input_path.with_file_name(if shared_lib_path.is_some() {
-            "dynhost"
+        let os = roc_target::OperatingSystem::from(target.operating_system);
+
+        if shared_lib_path.is_some() {
+            let extension = match os {
+                roc_target::OperatingSystem::Windows => "exe",
+                roc_target::OperatingSystem::Unix => "",
+                roc_target::OperatingSystem::Wasi => "",
+            };
+
+            host_input_path
+                .with_file_name("dynhost")
+                .with_extension(extension)
         } else {
-            match roc_target::OperatingSystem::from(target.operating_system) {
-                roc_target::OperatingSystem::Windows => "host.obj",
-                roc_target::OperatingSystem::Unix => "host.o",
-                roc_target::OperatingSystem::Wasi => "host.o",
-            }
-        })
+            let extension = match os {
+                roc_target::OperatingSystem::Windows => "obj",
+                roc_target::OperatingSystem::Unix => "o",
+                roc_target::OperatingSystem::Wasi => "o",
+            };
+
+            host_input_path
+                .with_file_name("host")
+                .with_extension(extension)
+        }
     };
 
     let env_path = env::var("PATH").unwrap_or_else(|_| "".to_string());

--- a/crates/compiler/build/src/link.rs
+++ b/crates/compiler/build/src/link.rs
@@ -121,11 +121,20 @@ pub fn build_zig_host_native(
         .env("HOME", env_home);
 
     if let Some(shared_lib_path) = shared_lib_path {
+        // with LLVM, the builtins are already part of the roc app,
+        // but with the dev backend, they are missing. To minimize work,
+        // we link them as part of the host executable
+        let builtins_obj = if target.contains("windows") {
+            bitcode::get_builtins_windows_obj_path()
+        } else {
+            bitcode::get_builtins_host_obj_path()
+        };
+
         command.args(&[
             "build-exe",
             "-fPIE",
             shared_lib_path.to_str().unwrap(),
-            &bitcode::get_builtins_host_obj_path(),
+            &builtins_obj,
         ]);
     } else {
         command.args(&["build-obj", "-fPIC"]);

--- a/crates/compiler/builtins/bitcode/build.zig
+++ b/crates/compiler/builtins/bitcode/build.zig
@@ -42,6 +42,7 @@ pub fn build(b: *Builder) void {
 
     // Generate Object Files
     generateObjectFile(b, mode, host_target, main_path, "object", "builtins-host");
+    generateObjectFile(b, mode, windows64_target, main_path, "windows-x86_64-object", "builtins-windows-x86_64");
     generateObjectFile(b, mode, wasm32_target, main_path, "wasm32-object", "builtins-wasm32");
 
     removeInstallSteps(b);

--- a/crates/compiler/builtins/bitcode/src/main.zig
+++ b/crates/compiler/builtins/bitcode/src/main.zig
@@ -253,7 +253,9 @@ test "" {
 
 // Export it as weak incase it is already linked in by something else.
 comptime {
-    @export(__muloti4, .{ .name = "__muloti4", .linkage = .Weak });
+    if (builtin.target.os.tag != .windows) {
+        @export(__muloti4, .{ .name = "__muloti4", .linkage = .Weak });
+    }
 }
 fn __muloti4(a: i128, b: i128, overflow: *c_int) callconv(.C) i128 {
     // @setRuntimeSafety(std.builtin.is_test);

--- a/crates/compiler/builtins/build.rs
+++ b/crates/compiler/builtins/build.rs
@@ -60,6 +60,12 @@ fn main() {
 
     generate_object_file(&bitcode_path, "object", BUILTINS_HOST_FILE);
 
+    generate_object_file(
+        &bitcode_path,
+        "windows-x86_64-object",
+        "builtins-windows-x86_64.obj",
+    );
+
     generate_object_file(&bitcode_path, "wasm32-object", "builtins-wasm32.o");
 
     copy_zig_builtins_to_target_dir(&bitcode_path);

--- a/crates/compiler/builtins/src/bitcode.rs
+++ b/crates/compiler/builtins/src/bitcode.rs
@@ -14,6 +14,17 @@ pub fn get_builtins_host_obj_path() -> String {
         .expect("Failed to convert builtins_host_path to str")
 }
 
+pub fn get_builtins_windows_obj_path() -> String {
+    let builtins_host_path = get_lib_path()
+        .expect(LIB_DIR_ERROR)
+        .join("builtins-windows-x86_64.obj");
+
+    builtins_host_path
+        .into_os_string()
+        .into_string()
+        .expect("Failed to convert builtins_host_path to str")
+}
+
 pub fn get_builtins_wasm32_obj_path() -> String {
     let builtins_wasm32_path = get_lib_path()
         .expect(LIB_DIR_ERROR)

--- a/crates/linker/src/lib.rs
+++ b/crates/linker/src/lib.rs
@@ -154,6 +154,10 @@ fn generate_dynamic_lib(
         }
     }
 
+    // on windows (PE) binary search is used on the symbols,
+    // so they must be in alphabetical order
+    custom_names.sort_unstable();
+
     let bytes = crate::generate_dylib::generate(target, &custom_names)
         .unwrap_or_else(|e| internal_error!("{}", e));
 


### PR DESCRIPTION
get some infrastructure set up to use the surgical linker in cross-compilation to windows. This is not enabled by default yet: you have to toggle a boolean in the linker code to use it.

also we don't have working surgical linking yet, so this process will panic in the linker code.