### PR TITLE
Attempt occurs checks for recursive lambda sets only during monomorphization

### DIFF
--- a/crates/compiler/late_solve/src/lib.rs
+++ b/crates/compiler/late_solve/src/lib.rs
@@ -321,6 +321,7 @@ struct ChangedVariableCollector {
 
 impl MetaCollector for ChangedVariableCollector {
     const UNIFYING_SPECIALIZATION: bool = false;
+    const IS_LATE: bool = true;
 
     #[inline(always)]
     fn record_specialization_lambda_set(&mut self, _member: Symbol, _region: u8, _var: Variable) {}


### PR DESCRIPTION
See https://roc.zulipchat.com/#narrow/stream/231635-compiler-development/topic/compilation.20time/near/296454046. Minimal speedup elsewhere but nice for pathological cases. Regardless, it's always better to do less work.