### PR TITLE
Str splitfirst bugfix

### DIFF
--- a/crates/compiler/builtins/roc/Str.roc
+++ b/crates/compiler/builtins/roc/Str.roc
@@ -351,6 +351,9 @@ expect Str.splitLast "foo" "o" == Ok { before: "fo", after: "" }
 # splitLast with multi-byte needle
 expect Str.splitLast "hullabaloo" "ab" == Ok { before: "hull", after: "aloo" }
 
+# splitLast when needle is haystack
+expect Str.splitLast "foo" "foo" == Ok { before: "", after: "" }
+
 lastMatch : Str, Str -> [Some Nat, None]
 lastMatch = \haystack, needle ->
     haystackLength = Str.countUtf8Bytes haystack

--- a/crates/compiler/builtins/roc/Str.roc
+++ b/crates/compiler/builtins/roc/Str.roc
@@ -294,6 +294,18 @@ splitFirst = \haystack, needle ->
         None ->
             Err NotFound
 
+# splitFirst when needle isn't in haystack
+expect splitFirst "foo" "z" == Err NotFound
+
+# splitFirst when haystack ends with needle repeated
+expect splitFirst "foo" "o" == Ok { before: "f", after: "o" }
+
+# splitFirst with multi-byte needle
+expect splitFirst "hullabaloo" "ab" == Ok { before: "hull", after: "aloo" }
+
+# splitFirst when needle is haystack
+expect splitFirst "foo" "foo" == Ok { before: "", after: "" }
+
 firstMatch : Str, Str -> [Some Nat, None]
 firstMatch = \haystack, needle ->
     haystackLength = Str.countUtf8Bytes haystack

--- a/crates/compiler/builtins/roc/Str.roc
+++ b/crates/compiler/builtins/roc/Str.roc
@@ -304,7 +304,7 @@ firstMatch = \haystack, needle ->
 
 firstMatchHelp : Str, Str, Nat, Nat -> [Some Nat, None]
 firstMatchHelp = \haystack, needle, index, lastPossible ->
-    if index < lastPossible then
+    if index <= lastPossible then
         if matchesAt haystack index needle then
             Some index
         else

--- a/crates/compiler/test_gen/src/gen_str.rs
+++ b/crates/compiler/test_gen/src/gen_str.rs
@@ -1700,7 +1700,7 @@ fn to_scalar_4_byte() {
 
 #[test]
 #[cfg(any(feature = "gen-llvm"))]
-fn str_split_first() {
+fn str_split_first_one_char() {
     assert_evals_to!(
         indoc!(
             r#"
@@ -1710,6 +1710,48 @@ fn str_split_first() {
         // the result is a { before, after } record, and because of
         // alphabetic ordering the fields here are flipped
         RocResult::ok((RocStr::from("bar/baz"), RocStr::from("foo"))),
+        RocResult<(RocStr, RocStr), ()>
+    );
+}
+
+#[test]
+#[cfg(any(feature = "gen-llvm"))]
+fn str_split_first_multiple_chars() {
+    assert_evals_to!(
+        indoc!(
+            r#"
+            Str.splitFirst "foo//bar//baz" "//"
+            "#
+        ),
+        RocResult::ok((RocStr::from("bar//baz"), RocStr::from("foo"))),
+        RocResult<(RocStr, RocStr), ()>
+    );
+}
+
+#[test]
+#[cfg(any(feature = "gen-llvm"))]
+fn str_split_first_entire_input() {
+    assert_evals_to!(
+        indoc!(
+            r#"
+            Str.splitFirst "foo" "foo"
+            "#
+        ),
+        RocResult::ok((RocStr::from(""), RocStr::from(""))),
+        RocResult<(RocStr, RocStr), ()>
+    );
+}
+
+#[test]
+#[cfg(any(feature = "gen-llvm"))]
+fn str_split_first_not_found() {
+    assert_evals_to!(
+        indoc!(
+            r#"
+            Str.splitFirst "foo" "bar"
+            "#
+        ),
+        RocResult::err(()),
         RocResult<(RocStr, RocStr), ()>
     );
 }

--- a/crates/compiler/test_gen/src/gen_str.rs
+++ b/crates/compiler/test_gen/src/gen_str.rs
@@ -1758,7 +1758,7 @@ fn str_split_first_not_found() {
 
 #[test]
 #[cfg(any(feature = "gen-llvm"))]
-fn str_split_last() {
+fn str_split_last_one_char() {
     assert_evals_to!(
         indoc!(
             r#"
@@ -1766,6 +1766,48 @@ fn str_split_last() {
             "#
         ),
         RocResult::ok((RocStr::from("baz"), RocStr::from("foo/bar"))),
+        RocResult<(RocStr, RocStr), ()>
+    );
+}
+
+#[test]
+#[cfg(any(feature = "gen-llvm"))]
+fn str_split_last_multiple_chars() {
+    assert_evals_to!(
+        indoc!(
+            r#"
+            Str.splitLast "foo//bar//baz" "//"
+            "#
+        ),
+        RocResult::ok((RocStr::from("baz"), RocStr::from("foo//bar"))),
+        RocResult<(RocStr, RocStr), ()>
+    );
+}
+
+#[test]
+#[cfg(any(feature = "gen-llvm"))]
+fn str_split_last_entire_input() {
+    assert_evals_to!(
+        indoc!(
+            r#"
+            Str.splitLast "foo" "foo"
+            "#
+        ),
+        RocResult::ok((RocStr::from(""), RocStr::from(""))),
+        RocResult<(RocStr, RocStr), ()>
+    );
+}
+
+#[test]
+#[cfg(any(feature = "gen-llvm"))]
+fn str_split_last_not_found() {
+    assert_evals_to!(
+        indoc!(
+            r#"
+            Str.splitFirst "foo" "bar"
+            "#
+        ),
+        RocResult::err(()),
         RocResult<(RocStr, RocStr), ()>
     );
 }


### PR DESCRIPTION
`Str.splitFirst` had a bug where if you passed the same string twice, it returned `Err NotFound`.

e.g.
it was:
```
Str.splitFirst "foo" "foo" == Err NotFound
```

With this fix it is:
```
Str.splitFirst "foo" "foo" == { before: "", after: "" }
```

I also added tests to both splitFirst and splitLast to catch this bug in the future.

[this](https://roc.zulipchat.com/#narrow/stream/231634-beginners/topic/splitFirst.20doesn't.20work.20properly) zulip topic has more info.