### PR TITLE
windows c calling convention

### DIFF
--- a/crates/compiler/gen_llvm/src/llvm/build.rs
+++ b/crates/compiler/gen_llvm/src/llvm/build.rs
@@ -6720,7 +6720,9 @@ impl<'ctx> FunctionSpec<'ctx> {
 pub fn to_cc_return<'a, 'ctx, 'env>(env: &Env<'a, 'ctx, 'env>, layout: &Layout<'a>) -> CCReturn {
     let return_size = layout.stack_size(env.layout_interner, env.target_info);
     let pass_result_by_pointer = match env.target_info.operating_system {
-        roc_target::OperatingSystem::Windows => return_size >= env.target_info.ptr_width() as u32,
+        roc_target::OperatingSystem::Windows => {
+            return_size >= 2 * env.target_info.ptr_width() as u32
+        }
         roc_target::OperatingSystem::Unix => return_size > 2 * env.target_info.ptr_width() as u32,
         roc_target::OperatingSystem::Wasi => unreachable!(),
     };

--- a/crates/compiler/gen_llvm/src/llvm/build.rs
+++ b/crates/compiler/gen_llvm/src/llvm/build.rs
@@ -6686,7 +6686,11 @@ impl<'ctx> FunctionSpec<'ctx> {
 /// According to the C ABI, how should we return a value with the given layout?
 pub fn to_cc_return<'a, 'ctx, 'env>(env: &Env<'a, 'ctx, 'env>, layout: &Layout<'a>) -> CCReturn {
     let return_size = layout.stack_size(env.target_info);
-    let pass_result_by_pointer = return_size > 2 * env.target_info.ptr_width() as u32;
+    let pass_result_by_pointer = match env.target_info.operating_system {
+        roc_target::OperatingSystem::Windows => return_size >= env.target_info.ptr_width() as u32,
+        roc_target::OperatingSystem::Unix => return_size > 2 * env.target_info.ptr_width() as u32,
+        roc_target::OperatingSystem::Wasi => unreachable!(),
+    };
 
     if return_size == 0 {
         CCReturn::Void


### PR DESCRIPTION
Windows seems to interpret the C calling convention rather differently. We're still using zig 0.9 which has some known bugs in how it handles calling conventions. So, this PR is tiny with an unscientific fix. Hopefully we can get some additional test coverage on windows with this fix. Whenever it does not work, it will fail loudly because the LLVM IR is not compatible. So this has upsides if it works, and no real downsides I think.

For future reference, the signature for 

```llvm
define void @roc_builtins.str.to_int.i64(%"num.NumParseResult(i64)"* noalias nocapture nonnull sret(%"num.NumParseResult(i64)") %0, %str.RocStr* nonnull byval(%str.RocStr) align 8 %1) local_unnamed_addr #1 {
```


whereas on unix this just returns a `{ i64, i8 }`.

to test, please run
```
> cargo test-gen-llvm gen_num::to_
```

hopefully these all pass. If not, please paste any errors.