### PR TITLE
keep dll loaded

### DIFF
--- a/crates/compiler/test_gen/src/helpers/llvm.rs
+++ b/crates/compiler/test_gen/src/helpers/llvm.rs
@@ -587,12 +587,12 @@ macro_rules! assert_llvm_evals_to {
                 #[allow(clippy::redundant_closure_call)]
                 let given = $transform(raw);
                 assert_eq!(&given, &$expected, "LLVM test failed");
-
-                // artificially extend the lifetime of `lib`
-                drop(lib);
             }
             Err(msg) => panic!("Roc failed with message: \"{}\"", msg),
         }
+
+        // artificially extend the lifetime of `lib`
+        let _ = lib;
     };
 
     ($src:expr, $expected:expr, $ty:ty) => {


### PR DESCRIPTION
extend the lifetime of a dll until after an assert. Hopefully this fixes segfaults on windows
