### PR TITLE
Generate and host CLI platform example docs

### DIFF
--- a/examples/interactive/README.md
+++ b/examples/interactive/README.md
@@ -1,9 +1,11 @@
 # Interactive examples
 
-These are examples of how to make extremely basic
-CLI (command-line interface) and TUI (terminal user interface) apps in Roc.
+These are examples of how to make basic CLI (command-line interface) and TUI (terminal user interface) apps in Roc.
 
-There's not currently much documentation for the CLI platform (which also doesn't support many operations at this point!)
-but you can look at [the modules it includes](cli-platform) - for example,
-multiple other modules use the [`Task`](cli-platform/Task.roc) module, including the
-[`Stdin`](cli-platform/Stdin.roc) and [`Stdout`](cli-platform/Stdout.roc) modules.
+The  platform is a work in progress, but you can look at [the docs for its modules](https://www.roc-lang.org/examples/cli/Http),
+and [its source code](cli-platform) if you'd like to build your own CLI apps, perhaps using
+the examples in this directory as starting points!
+
+Feel free to ask [on Zulip](https://roc.zulipchat.com) in the `#beginners` channel if you have questions about making
+CLI apps, or if there are operations you'd like to see added to this example CLI platform (for
+an application you'd like to build in Roc).

--- a/examples/interactive/cli-platform/Path.roc
+++ b/examples/interactive/cli-platform/Path.roc
@@ -54,7 +54,7 @@ fromStr = \str ->
 ## is not valid Unicode (like a Roc [Str] is), but which is valid for a particular filesystem.
 ##
 ## Note that if the list contains any `0` bytes, sending this path to any file operations
-## (e.g. [File.read] or [WriteStream.openPath]) will fail.
+## (e.g. `File.read` or `WriteStream.openPath`) will fail.
 fromBytes : List U8 -> Path
 fromBytes = \bytes ->
     ArbitraryBytes bytes

--- a/examples/interactive/cli-platform/Stdin.roc
+++ b/examples/interactive/cli-platform/Stdin.roc
@@ -1,6 +1,6 @@
 interface Stdin
     exposes [line]
-    imports [pf.Effect, Task.{ Task }, InternalTask]
+    imports [Effect, Task.{ Task }, InternalTask]
 
 line : Task Str * [Read [Stdin]*]*
 line =

--- a/examples/interactive/cli-platform/Stdout.roc
+++ b/examples/interactive/cli-platform/Stdout.roc
@@ -1,6 +1,6 @@
 interface Stdout
     exposes [line]
-    imports [pf.Effect, Task.{ Task }, InternalTask]
+    imports [Effect, Task.{ Task }, InternalTask]
 
 line : Str -> Task {} * [Write [Stdout]*]*
 line = \str ->

--- a/www/build.sh
+++ b/www/build.sh
@@ -25,7 +25,7 @@ ls -lh repl
 popd
 
 pushd ..
-echo 'Generating docs...'
+echo 'Generating builtin docs...'
 cargo --version
 rustc --version
 
@@ -37,5 +37,18 @@ export ROC_DOCS_URL_ROOT=/builtins
 cargo run --bin roc-docs crates/compiler/builtins/roc/*.roc
 mv generated-docs/*.* www/build # move all the .js, .css, etc. files to build/
 mv generated-docs/ www/build/builtins # move all the folders to build/builtins/
+
+echo 'Generating CLI example platform docs...'
+# Change ROC_DOCS_ROOT_DIR=builtins so that links will be generated relative to
+# "/examples/cli/" rather than "/builtins/"
+export ROC_DOCS_URL_ROOT=/examples/cli
+
+# Until https://github.com/roc-lang/roc/issues/3280 is done,
+# manually exclude the Internal* modules and `main.roc`.
+ls examples/interactive/cli-platform/*.roc | grep -v Internal | grep -v main.roc | xargs cargo run --bin roc-docs
+
+mkdir www/build/examples
+rm generated-docs/*.* # we already copied over the *.js and *.css files earlier, so just drop these.
+mv generated-docs/ www/build/examples/cli # move all the folders to build/examples/cli
 
 popd

--- a/www/build.sh
+++ b/www/build.sh
@@ -45,7 +45,7 @@ export ROC_DOCS_URL_ROOT=/examples/cli
 
 # Until https://github.com/roc-lang/roc/issues/3280 is done,
 # manually exclude the Internal* modules and `main.roc`.
-ls examples/interactive/cli-platform/*.roc | grep -v Internal | grep -v main.roc | xargs cargo run --bin roc-docs
+ls examples/interactive/cli-platform/*.roc | grep -v Internal | grep -v main.roc | grep -v Effect.roc | xargs cargo run --bin roc-docs
 
 mkdir www/build/examples
 rm generated-docs/*.* # we already copied over the *.js and *.css files earlier, so just drop these.


### PR DESCRIPTION
For example: https://www.roc-lang.org/examples/cli/Http

These now get regenerated whenever we push an update the website!

Also added a link to the docs in the `examples/interactive` README.