### PR TITLE
make RocDict FFI-safe

### DIFF
--- a/crates/roc_std/src/roc_dict.rs
+++ b/crates/roc_std/src/roc_dict.rs
@@ -140,7 +140,7 @@ impl<K, V> RocDictItem<K, V> {
     }
 }
 
-impl<K,V> Drop for RocDictItem<K, V> {
+impl<K, V> Drop for RocDictItem<K, V> {
     fn drop(&mut self) {
         if align_of::<K>() >= align_of::<V>() {
             unsafe { ManuallyDrop::drop(&mut self.key_first) }
@@ -158,18 +158,20 @@ impl<K: PartialEq, V: PartialEq> PartialEq for RocDictItem<K, V> {
 
 impl<K: PartialOrd, V: PartialOrd> PartialOrd for RocDictItem<K, V> {
     fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
-        self.key()
-            .partial_cmp(other.key())
-            .map(|key_cmp| match self.value().partial_cmp(other.value()) {
+        self.key().partial_cmp(other.key()).map(|key_cmp| {
+            match self.value().partial_cmp(other.value()) {
                 Some(value_cmp) => key_cmp.then(value_cmp),
                 None => key_cmp,
-            })
+            }
+        })
     }
 }
 
 impl<K: Ord, V: Ord> Ord for RocDictItem<K, V> {
     fn cmp(&self, other: &Self) -> core::cmp::Ordering {
-        self.key().cmp(other.key()).then(self.value().cmp(other.value()))
+        self.key()
+            .cmp(other.key())
+            .then(self.value().cmp(other.value()))
     }
 }
 

--- a/crates/roc_std/src/roc_dict.rs
+++ b/crates/roc_std/src/roc_dict.rs
@@ -18,6 +18,10 @@ impl<K, V> RocDict<K, V> {
         self.0.len()
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
     pub fn with_capacity(capacity: usize) -> Self {
         Self(RocList::with_capacity(capacity))
     }

--- a/crates/roc_std/src/roc_dict.rs
+++ b/crates/roc_std/src/roc_dict.rs
@@ -65,7 +65,7 @@ impl<'a, K, V> IntoIterator for &'a RocDict<K, V> {
     fn into_iter(self) -> Self::IntoIter {
         IntoIter {
             index: 0,
-            items: &self,
+            items: self,
         }
     }
 }

--- a/crates/roc_std/src/roc_dict.rs
+++ b/crates/roc_std/src/roc_dict.rs
@@ -58,6 +58,39 @@ impl<K: Hash, V> RocDict<K, V> {
     }
 }
 
+impl<'a, K, V> IntoIterator for &'a RocDict<K, V> {
+    type Item = (&'a K, &'a V);
+    type IntoIter = IntoIter<'a, K, V>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        IntoIter {
+            index: 0,
+            items: &self,
+        }
+    }
+}
+
+pub struct IntoIter<'a, K, V> {
+    index: usize,
+    items: &'a RocDict<K, V>,
+}
+
+impl<'a, K, V> Iterator for IntoIter<'a, K, V> {
+    type Item = (&'a K, &'a V);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let item = self
+            .items
+            .0
+            .get(self.index)
+            .map(|item| (&item.key, &item.value));
+
+        self.index += 1;
+
+        item
+    }
+}
+
 impl<K: Debug, V: Debug> Debug for RocDict<K, V> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("RocDict ")?;

--- a/crates/roc_std/src/roc_dict.rs
+++ b/crates/roc_std/src/roc_dict.rs
@@ -2,16 +2,11 @@ use crate::roc_list::RocList;
 use core::{
     fmt::{self, Debug},
     hash::Hash,
+    mem::{align_of, ManuallyDrop},
 };
 
 #[derive(Default, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct RocDict<K, V>(RocList<RocDictItem<K, V>>);
-
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-struct RocDictItem<K, V> {
-    key: K,
-    value: V,
-}
 
 impl<K, V> RocDict<K, V> {
     pub fn len(&self) -> usize {
@@ -27,15 +22,15 @@ impl<K, V> RocDict<K, V> {
     }
 
     pub fn iter(&self) -> impl Iterator<Item = (&K, &V)> {
-        self.0.iter().map(|item| (&item.key, &item.value))
+        self.0.iter().map(|item| (item.key(), item.value()))
     }
 
     pub fn iter_keys(&self) -> impl Iterator<Item = &K> {
-        self.0.iter().map(|item| &item.key)
+        self.0.iter().map(|item| item.key())
     }
 
     pub fn iter_values(&self) -> impl Iterator<Item = &V> {
-        self.0.iter().map(|item| &item.value)
+        self.0.iter().map(|item| item.value())
     }
 }
 
@@ -83,7 +78,7 @@ impl<'a, K, V> Iterator for IntoIter<'a, K, V> {
             .items
             .0
             .get(self.index)
-            .map(|item| (&item.key, &item.value));
+            .map(|item| (item.key(), item.value()));
 
         self.index += 1;
 
@@ -104,5 +99,73 @@ impl<K: Debug, V: Debug> Debug for RocDict<K, V> {
         f.debug_map()
             .entries(self.iter().map(|(k, v)| (k, v)))
             .finish()
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[repr(C)]
+struct KeyFirst<K, V> {
+    key: K,
+    value: V,
+}
+
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[repr(C)]
+struct ValueFirst<K, V> {
+    value: V,
+    key: K,
+}
+
+#[derive(Eq)]
+union RocDictItem<K, V> {
+    key_first: ManuallyDrop<KeyFirst<K, V>>,
+    value_first: ManuallyDrop<ValueFirst<K, V>>,
+}
+
+impl<K, V> RocDictItem<K, V> {
+    fn key(&self) -> &K {
+        if align_of::<K>() >= align_of::<V>() {
+            unsafe { &self.key_first.key }
+        } else {
+            unsafe { &self.value_first.key }
+        }
+    }
+
+    fn value(&self) -> &V {
+        if align_of::<K>() >= align_of::<V>() {
+            unsafe { &self.key_first.value }
+        } else {
+            unsafe { &self.value_first.value }
+        }
+    }
+}
+
+impl<K: PartialEq, V: PartialEq> PartialEq for RocDictItem<K, V> {
+    fn eq(&self, other: &Self) -> bool {
+        self.key() == other.key() && self.value() == other.value()
+    }
+}
+
+impl<K: PartialOrd, V: PartialOrd> PartialOrd for RocDictItem<K, V> {
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+        self.key()
+            .partial_cmp(other.key())
+            .map(|key_cmp| match self.value().partial_cmp(other.value()) {
+                Some(value_cmp) => key_cmp.then(value_cmp),
+                None => key_cmp,
+            })
+    }
+}
+
+impl<K: Ord, V: Ord> Ord for RocDictItem<K, V> {
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+        self.key().cmp(other.key()).then(self.value().cmp(other.value()))
+    }
+}
+
+impl<K: Hash, V: Hash> Hash for RocDictItem<K, V> {
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
+        self.key().hash(state);
+        self.value().hash(state);
     }
 }

--- a/crates/roc_std/src/roc_dict.rs
+++ b/crates/roc_std/src/roc_dict.rs
@@ -140,6 +140,16 @@ impl<K, V> RocDictItem<K, V> {
     }
 }
 
+impl<K,V> Drop for RocDictItem<K, V> {
+    fn drop(&mut self) {
+        if align_of::<K>() >= align_of::<V>() {
+            unsafe { ManuallyDrop::drop(&mut self.key_first) }
+        } else {
+            unsafe { ManuallyDrop::drop(&mut self.value_first) }
+        }
+    }
+}
+
 impl<K: PartialEq, V: PartialEq> PartialEq for RocDictItem<K, V> {
     fn eq(&self, other: &Self) -> bool {
         self.key() == other.key() && self.value() == other.value()

--- a/crates/roc_std/src/roc_dict.rs
+++ b/crates/roc_std/src/roc_dict.rs
@@ -89,6 +89,12 @@ impl<'a, K, V> Iterator for IntoIter<'a, K, V> {
 
         item
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let remaining = self.items.0.len() - self.index;
+
+        (remaining, Some(remaining))
+    }
 }
 
 impl<K: Debug, V: Debug> Debug for RocDict<K, V> {

--- a/crates/roc_std/src/roc_dict.rs
+++ b/crates/roc_std/src/roc_dict.rs
@@ -1,11 +1,17 @@
-use crate::roc_list::{self, RocList};
+use crate::roc_list::RocList;
 use core::{
     fmt::{self, Debug},
     hash::Hash,
 };
 
 #[derive(Default, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct RocDict<K, V>(RocList<(K, V)>);
+pub struct RocDict<K, V>(RocList<RocDictItem<K, V>>);
+
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+struct RocDictItem<K, V> {
+    key: K,
+    value: V,
+}
 
 impl<K, V> RocDict<K, V> {
     pub fn len(&self) -> usize {
@@ -16,16 +22,16 @@ impl<K, V> RocDict<K, V> {
         Self(RocList::with_capacity(capacity))
     }
 
-    pub fn iter(&self) -> impl Iterator<Item = &(K, V)> {
-        self.into_iter()
+    pub fn iter(&self) -> impl Iterator<Item = (&K, &V)> {
+        self.0.iter().map(|item| (&item.key, &item.value))
     }
 
     pub fn iter_keys(&self) -> impl Iterator<Item = &K> {
-        self.0.iter().map(|(key, _)| key)
+        self.0.iter().map(|item| &item.key)
     }
 
     pub fn iter_values(&self) -> impl Iterator<Item = &V> {
-        self.0.iter().map(|(_, val)| val)
+        self.0.iter().map(|item| &item.value)
     }
 }
 
@@ -55,23 +61,5 @@ impl<K: Debug, V: Debug> Debug for RocDict<K, V> {
         f.debug_map()
             .entries(self.iter().map(|(k, v)| (k, v)))
             .finish()
-    }
-}
-
-impl<K, V> IntoIterator for RocDict<K, V> {
-    type Item = (K, V);
-    type IntoIter = roc_list::IntoIter<(K, V)>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.0.into_iter()
-    }
-}
-
-impl<'a, K, V> IntoIterator for &'a RocDict<K, V> {
-    type Item = &'a (K, V);
-    type IntoIter = core::slice::Iter<'a, (K, V)>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.0.as_slice().iter()
     }
 }

--- a/crates/roc_std/src/roc_list.rs
+++ b/crates/roc_std/src/roc_list.rs
@@ -56,7 +56,7 @@ impl<T> RocList<T> {
     }
 
     pub fn iter(&self) -> impl Iterator<Item = &T> {
-        self.into_iter()
+        self.as_slice().iter()
     }
 
     /// Used for both roc_alloc and roc_realloc - given the number of elements,

--- a/crates/roc_std/src/roc_list.rs
+++ b/crates/roc_std/src/roc_list.rs
@@ -103,6 +103,18 @@ impl<T> RocList<T> {
         self.len() == 0
     }
 
+    pub fn get(&self, index: usize) -> Option<&T> {
+        if self.len() <= index {
+            return None;
+        }
+
+        let elements = self.elements?;
+        let element_ptr = unsafe { elements.as_ptr().add(index) };
+
+        // Return the element.
+        Some(unsafe { ManuallyDrop::into_inner(element_ptr.cast::<ManuallyDrop<&T>>().read()) })
+    }
+
     /// Note that there is no way to convert directly to a Vec.
     ///
     /// This is because RocList values are not allocated using the system allocator, so

--- a/crates/roc_std/src/roc_list.rs
+++ b/crates/roc_std/src/roc_list.rs
@@ -501,62 +501,6 @@ impl<T, const SIZE: usize> From<[T; SIZE]> for RocList<T> {
     }
 }
 
-impl<'a, T> IntoIterator for &'a RocList<T> {
-    type Item = &'a T;
-    type IntoIter = core::slice::Iter<'a, T>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.as_slice().iter()
-    }
-}
-
-impl<T> IntoIterator for RocList<T> {
-    type Item = T;
-    type IntoIter = IntoIter<T>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        IntoIter { list: self, idx: 0 }
-    }
-}
-
-pub struct IntoIter<T> {
-    list: RocList<T>,
-    idx: usize,
-}
-
-impl<T> Iterator for IntoIter<T> {
-    type Item = T;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.list.len() <= self.idx {
-            return None;
-        }
-
-        let elements = self.list.elements?;
-        let element_ptr = unsafe { elements.as_ptr().add(self.idx) };
-        self.idx += 1;
-
-        // Return the element.
-        Some(unsafe { ManuallyDrop::into_inner(element_ptr.read()) })
-    }
-}
-
-impl<T> Drop for IntoIter<T> {
-    fn drop(&mut self) {
-        // If there are any elements left that need to be dropped, drop them.
-        if let Some(elements) = self.list.elements {
-            // Set the list's length to zero to prevent double-frees.
-            // Note that this leaks if dropping any of the elements panics.
-            let len = mem::take(&mut self.list.length);
-
-            // Drop the elements that haven't been returned from the iterator.
-            for i in self.idx..len {
-                mem::drop::<T>(unsafe { ManuallyDrop::take(&mut *elements.as_ptr().add(i)) })
-            }
-        }
-    }
-}
-
 impl<T: Hash> Hash for RocList<T> {
     fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
         // This is the same as Rust's Vec implementation, which

--- a/crates/roc_std/src/roc_list.rs
+++ b/crates/roc_std/src/roc_list.rs
@@ -56,7 +56,7 @@ impl<T> RocList<T> {
     }
 
     pub fn iter(&self) -> impl Iterator<Item = &T> {
-        self.as_slice().iter()
+        self.into_iter()
     }
 
     /// Used for both roc_alloc and roc_realloc - given the number of elements,
@@ -498,6 +498,15 @@ where
 impl<T, const SIZE: usize> From<[T; SIZE]> for RocList<T> {
     fn from(array: [T; SIZE]) -> Self {
         Self::from_iter(array)
+    }
+}
+
+impl<'a, T> IntoIterator for &'a RocList<T> {
+    type Item = &'a T;
+    type IntoIter = core::slice::Iter<'a, T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.as_slice().iter()
     }
 }
 

--- a/crates/roc_std/src/roc_set.rs
+++ b/crates/roc_std/src/roc_set.rs
@@ -12,6 +12,10 @@ impl<T> RocSet<T> {
         self.0.len()
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
     #[allow(unused)]
     pub fn with_capacity(capacity: usize) -> Self {
         Self(RocDict::with_capacity(capacity))


### PR DESCRIPTION
`RocDict` used a tuple of `(K, V)`, which wasn't FFI-safe (the error messages say that tuples have an unspecified layout.) This changes to structs, which do have a specified layout.

I was able to use this to get environment variable working in rbt, but I'm not sure what other kinds of testing would be appropriate here.
