### PR TITLE
Use capacity better for realloc

### DIFF
--- a/crates/compiler/builtins/bitcode/src/str.zig
+++ b/crates/compiler/builtins/bitcode/src/str.zig
@@ -215,9 +215,12 @@ pub const RocStr = extern struct {
         return result;
     }
 
-    // NOTE: returns false for empty string!
     pub fn isSmallStr(self: RocStr) bool {
         return @bitCast(isize, self.str_capacity) < 0;
+    }
+
+    test "isSmallStr: returns true for empty string" {
+        try expect(isSmallStr(RocStr.empty()));
     }
 
     fn asArray(self: RocStr) [@sizeOf(RocStr)]u8 {

--- a/crates/compiler/builtins/bitcode/src/str.zig
+++ b/crates/compiler/builtins/bitcode/src/str.zig
@@ -1655,17 +1655,17 @@ pub fn strToUtf8C(arg: RocStr) callconv(.C) RocList {
 }
 
 inline fn strToBytes(arg: RocStr) RocList {
-    if (arg.isEmpty()) {
+    const length = arg.len();
+    if (length == 0) {
         return RocList.empty();
     } else if (arg.isSmallStr()) {
-        const length = arg.len();
         const ptr = utils.allocateWithRefcount(length, RocStr.alignment);
 
         @memcpy(ptr, arg.asU8ptr(), length);
 
         return RocList{ .length = length, .bytes = ptr, .capacity = length };
     } else {
-        return RocList{ .length = arg.len(), .bytes = arg.str_bytes, .capacity = arg.str_capacity };
+        return RocList{ .length = length, .bytes = arg.str_bytes, .capacity = arg.str_capacity };
     }
 }
 

--- a/crates/compiler/builtins/bitcode/src/utils.zig
+++ b/crates/compiler/builtins/bitcode/src/utils.zig
@@ -254,7 +254,7 @@ pub fn unsafeReallocate(
     const old_width = align_width + old_length * element_width;
     const new_width = align_width + new_length * element_width;
 
-    if (old_width == new_width) {
+    if (old_width >= new_width) {
         return source_ptr;
     }
 


### PR DESCRIPTION
I spotted a few places in our Zig builtins where we could make better use of the capacity field.

I decided to look at this while working on the HTML example project, which involves a lot of string concatenation. In that program I pre-calculate the size of string needed, and do one `Str.reserve` before doing all the `Str.concat` stuff.

But reading through the Zig code I could see we hadn't really implemented things yet for this to actually work. These changes should help.
