### PR TITLE
windows RocDec & Zig 

### DIFF
--- a/crates/compiler/gen_llvm/src/llvm/build_str.rs
+++ b/crates/compiler/gen_llvm/src/llvm/build_str.rs
@@ -46,30 +46,6 @@ pub(crate) fn decode_from_utf8_result<'a, 'ctx, 'env>(
 }
 
 /// Dec.toStr : Dec -> Str
-pub(crate) fn dec_to_str<'a, 'ctx, 'env>(
-    env: &Env<'a, 'ctx, 'env>,
-    dec: BasicValueEnum<'ctx>,
-) -> BasicValueEnum<'ctx> {
-    let dec = dec.into_int_value();
-
-    let int_64 = env.context.i128_type().const_int(64, false);
-    let int_64_type = env.context.i64_type();
-
-    let dec_right_shift = env
-        .builder
-        .build_right_shift(dec, int_64, false, "dec_left_bits");
-
-    let right_bits = env.builder.build_int_cast(dec, int_64_type, "");
-    let left_bits = env.builder.build_int_cast(dec_right_shift, int_64_type, "");
-
-    call_str_bitcode_fn(
-        env,
-        &[],
-        &[right_bits.into(), left_bits.into()],
-        BitcodeReturns::Str,
-        bitcode::DEC_TO_STR,
-    )
-}
 
 /// Str.equal : Str, Str -> Bool
 pub(crate) fn str_equal<'a, 'ctx, 'env>(

--- a/crates/compiler/gen_llvm/src/llvm/convert.rs
+++ b/crates/compiler/gen_llvm/src/llvm/convert.rs
@@ -420,6 +420,10 @@ pub fn zig_str_type<'a, 'ctx, 'env>(env: &Env<'a, 'ctx, 'env>) -> StructType<'ct
     env.module.get_struct_type("str.RocStr").unwrap()
 }
 
+pub fn zig_dec_type<'a, 'ctx, 'env>(env: &Env<'a, 'ctx, 'env>) -> StructType<'ctx> {
+    env.module.get_struct_type("dec.RocDec").unwrap()
+}
+
 pub fn zig_has_tag_id_type<'a, 'ctx, 'env>(env: &Env<'a, 'ctx, 'env>) -> StructType<'ctx> {
     let u8_ptr_t = env.context.i8_type().ptr_type(AddressSpace::Generic);
 

--- a/crates/compiler/test_gen/src/gen_records.rs
+++ b/crates/compiler/test_gen/src/gen_records.rs
@@ -536,7 +536,7 @@ fn optional_field_let_no_use_default_nested() {
                     { x ? 10, y } = r
                     x + y
 
-                f { x: 4, y: 9 }
+                f { y: 9, x: 4 }
                 "#
         ),
         13,

--- a/crates/compiler/test_gen/src/helpers/llvm.rs
+++ b/crates/compiler/test_gen/src/helpers/llvm.rs
@@ -43,7 +43,7 @@ fn promote_expr_to_module(src: &str) -> String {
 }
 
 #[allow(clippy::too_many_arguments)]
-pub(crate) fn create_llvm_module<'a>(
+fn create_llvm_module<'a>(
     arena: &'a bumpalo::Bump,
     src: &str,
     config: HelperConfig,
@@ -311,9 +311,7 @@ pub fn helper<'a>(
     src: &str,
     context: &'a inkwell::context::Context,
 ) -> (&'static str, String, Library) {
-    let mut target = target_lexicon::Triple::host();
-
-    target.operating_system = target_lexicon::OperatingSystem::Windows;
+    let target = target_lexicon::Triple::host();
 
     let (main_fn_name, delayed_errors, module) =
         create_llvm_module(arena, src, config, context, &target);

--- a/crates/compiler/test_gen/src/helpers/llvm.rs
+++ b/crates/compiler/test_gen/src/helpers/llvm.rs
@@ -562,35 +562,26 @@ macro_rules! assert_llvm_evals_to {
             opt_level: $crate::helpers::llvm::OPT_LEVEL,
         };
 
-        if false {
-            let (main_fn_name, errors, lib) =
-                $crate::helpers::llvm::helper(&arena, config, $src, &context);
+        let (main_fn_name, errors, lib) =
+            $crate::helpers::llvm::helper(&arena, config, $src, &context);
 
-            let transform = |success| {
-                let expected = $expected;
-                #[allow(clippy::redundant_closure_call)]
-                let given = $transform(success);
-                assert_eq!(&given, &expected, "LLVM test failed");
-            };
+        let transform = |success| {
+            let expected = $expected;
+            #[allow(clippy::redundant_closure_call)]
+            let given = $transform(success);
+            assert_eq!(&given, &expected, "LLVM test failed");
+        };
 
-            let result = try_run_jit_function!(lib, main_fn_name, $ty, transform, errors);
+        let result = try_run_jit_function!(lib, main_fn_name, $ty, transform, errors);
 
-            match result {
-                Ok(raw) => {
-                    // only if there are no exceptions thrown, check for errors
-                    assert!(errors.is_empty(), "Encountered errors:\n{}", errors);
+        match result {
+            Ok(raw) => {
+                // only if there are no exceptions thrown, check for errors
+                assert!(errors.is_empty(), "Encountered errors:\n{}", errors);
 
-                    transform(raw)
-                }
-                Err(msg) => panic!("Roc failed with message: \"{}\"", msg),
+                transform(raw)
             }
-        } else {
-            let mut target = target_lexicon::Triple::host();
-
-            target.operating_system = target_lexicon::OperatingSystem::Windows;
-
-            let (_main_fn_name, _delayed_errors, _module) =
-                $crate::helpers::llvm::create_llvm_module(&arena, $src, config, &context, &target);
+            Err(msg) => panic!("Roc failed with message: \"{}\"", msg),
         }
     };
 
@@ -608,6 +599,14 @@ macro_rules! assert_llvm_evals_to {
         $crate::helpers::llvm::assert_llvm_evals_to!($src, $expected, $ty, $transform, false);
     };
 }
+
+// windows testing code
+//   let mut target = target_lexicon::Triple::host();
+//
+//   target.operating_system = target_lexicon::OperatingSystem::Windows;
+//
+//   let (_main_fn_name, _delayed_errors, _module) =
+//       $crate::helpers::llvm::create_llvm_module(&arena, $src, config, &context, &target);
 
 #[allow(unused_macros)]
 macro_rules! assert_evals_to {

--- a/crates/compiler/test_gen/src/helpers/llvm.rs
+++ b/crates/compiler/test_gen/src/helpers/llvm.rs
@@ -311,7 +311,9 @@ pub fn helper<'a>(
     src: &str,
     context: &'a inkwell::context::Context,
 ) -> (&'static str, String, Library) {
-    let target = target_lexicon::Triple::host();
+    let mut target = target_lexicon::Triple::host();
+
+    target.operating_system = target_lexicon::OperatingSystem::Windows;
 
     let (main_fn_name, delayed_errors, module) =
         create_llvm_module(arena, src, config, context, &target);


### PR DESCRIPTION
`RocDec` is passed differently on windows. I also found and fixed some other llvm IR mismatches on windows