### PR TITLE
Reword "host" to "platform" for app developers

### DIFF
--- a/.github/workflows/nix_macos_apple_silicon.yml
+++ b/.github/workflows/nix_macos_apple_silicon.yml
@@ -31,6 +31,6 @@ jobs:
       - name: execute tests with --release
         run: nix develop -c cargo test --locked --release
 
-      # we run the llvm wasm tests only on this machine because it is fast and wasm should be cross-platform
+      # we run the llvm wasm tests only on this machine because it is fast and wasm should be cross-target
       - name: execute llvm wasm tests with --release
         run: nix develop -c cargo test-gen-llvm-wasm --locked --release

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -24,7 +24,7 @@ editor = ["roc_editor"]
 
 run-wasm32 = ["wasmer", "wasmer-wasi"]
 
-# Compiling for a different platform than the host can cause linker errors.
+# Compiling for a different target than your machine can cause linker errors.
 target-arm = ["roc_build/target-arm", "roc_repl_cli/target-arm"]
 target-aarch64 = ["roc_build/target-aarch64", "roc_repl_cli/target-aarch64"]
 target-x86 = ["roc_build/target-x86", "roc_repl_cli/target-x86"]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -24,7 +24,7 @@ editor = ["roc_editor"]
 
 run-wasm32 = ["wasmer", "wasmer-wasi"]
 
-# Compiling for a different target than your machine can cause linker errors.
+# Compiling for a different target than the current machine can cause linker errors.
 target-arm = ["roc_build/target-arm", "roc_repl_cli/target-arm"]
 target-aarch64 = ["roc_build/target-aarch64", "roc_repl_cli/target-aarch64"]
 target-x86 = ["roc_build/target-x86", "roc_repl_cli/target-x86"]

--- a/crates/cli/src/build.rs
+++ b/crates/cli/src/build.rs
@@ -192,7 +192,7 @@ pub fn build_file<'a>(
     );
 
     // TODO try to move as much of this linking as possible to the precompiled
-    // platform, to minimize the amount of host-application linking required.
+    // platform, to minimize the amount of platform-application linking required.
     let app_o_file = Builder::new()
         .prefix("roc_app")
         .suffix(&format!(".{}", app_extension))

--- a/crates/cli/src/build.rs
+++ b/crates/cli/src/build.rs
@@ -151,7 +151,7 @@ pub fn build_file<'a>(
     // TODO this should probably be moved before load_and_monomorphize.
     // To do this we will need to preprocess files just for their exported symbols.
     // Also, we should no longer need to do this once we have platforms on
-    // a package repository, as we can then get precompiled hosts from there.
+    // a package repository, as we can then get precompiled platforms from there.
 
     let exposed_values = loaded
         .exposed_to_host
@@ -192,7 +192,7 @@ pub fn build_file<'a>(
     );
 
     // TODO try to move as much of this linking as possible to the precompiled
-    // host, to minimize the amount of host-application linking required.
+    // platform, to minimize the amount of host-application linking required.
     let app_o_file = Builder::new()
         .prefix("roc_app")
         .suffix(&format!(".{}", app_extension))
@@ -330,7 +330,7 @@ pub fn build_file<'a>(
         }
     }
 
-    // Step 2: link the precompiled host and compiled app
+    // Step 2: link the precompiled platform and compiled app
     let link_start = Instant::now();
     let problems = match (linking_strategy, link_type) {
         (LinkingStrategy::Surgical, _) => {

--- a/crates/cli/src/build.rs
+++ b/crates/cli/src/build.rs
@@ -261,7 +261,7 @@ pub fn build_file<'a>(
         let rebuild_duration = rebuild_thread.join().unwrap();
         if emit_timings && !prebuilt {
             println!(
-                "Finished rebuilding and preprocessing the host in {} ms\n",
+                "Finished rebuilding the platform in {} ms\n",
                 rebuild_duration
             );
         }
@@ -322,7 +322,7 @@ pub fn build_file<'a>(
         let rebuild_duration = thread.join().unwrap();
         if emit_timings && !prebuilt {
             println!(
-                "Finished rebuilding and preprocessing the host in {} ms\n",
+                "Finished rebuilding the platform in {} ms\n",
                 rebuild_duration
             );
         }

--- a/crates/cli/src/build.rs
+++ b/crates/cli/src/build.rs
@@ -151,7 +151,7 @@ pub fn build_file<'a>(
     // TODO this should probably be moved before load_and_monomorphize.
     // To do this we will need to preprocess files just for their exported symbols.
     // Also, we should no longer need to do this once we have platforms on
-    // a package repository, as we can then get precompiled platforms from there.
+    // a package repository, as we can then get prebuilt platforms from there.
 
     let exposed_values = loaded
         .exposed_to_host
@@ -191,8 +191,8 @@ pub fn build_file<'a>(
         exposed_closure_types,
     );
 
-    // TODO try to move as much of this linking as possible to the precompiled
-    // platform, to minimize the amount of platform-application linking required.
+    // TODO try to move as much of this linking as possible to the prebuilt platform,
+    // to minimize the amount of platform-application linking required.
     let app_o_file = Builder::new()
         .prefix("roc_app")
         .suffix(&format!(".{}", app_extension))
@@ -330,7 +330,7 @@ pub fn build_file<'a>(
         }
     }
 
-    // Step 2: link the precompiled platform and compiled app
+    // Step 2: link the prebuilt platform and compiled app
     let link_start = Instant::now();
     let problems = match (linking_strategy, link_type) {
         (LinkingStrategy::Surgical, _) => {

--- a/crates/cli/src/build.rs
+++ b/crates/cli/src/build.rs
@@ -408,7 +408,7 @@ fn spawn_rebuild_thread(
     let thread_local_target = target.clone();
     std::thread::spawn(move || {
         if !precompiled {
-            println!("🔨 Rebuilding host...");
+            println!("🔨 Rebuilding platform...");
         }
 
         let rebuild_host_start = Instant::now();

--- a/crates/cli/src/build.rs
+++ b/crates/cli/src/build.rs
@@ -408,7 +408,7 @@ fn spawn_rebuild_thread(
     let thread_local_target = target.clone();
     std::thread::spawn(move || {
         if !prebuilt {
-            println!("🔨 Rebuilding platform...");
+            eprintln!("🔨 Rebuilding platform...");
         }
 
         let rebuild_host_start = Instant::now();

--- a/crates/cli/src/build.rs
+++ b/crates/cli/src/build.rs
@@ -65,7 +65,7 @@ pub fn build_file<'a>(
     emit_timings: bool,
     link_type: LinkType,
     linking_strategy: LinkingStrategy,
-    precompiled: bool,
+    prebuilt: bool,
     threading: Threading,
     wasm_dev_stack_bytes: Option<u32>,
     order: BuildOrdering,
@@ -182,7 +182,7 @@ pub fn build_file<'a>(
     let rebuild_thread = spawn_rebuild_thread(
         opt_level,
         linking_strategy,
-        precompiled,
+        prebuilt,
         host_input_path.clone(),
         preprocessed_host_path.clone(),
         binary_path.clone(),
@@ -261,7 +261,7 @@ pub fn build_file<'a>(
 
     let rebuild_timing = if linking_strategy == LinkingStrategy::Additive {
         let rebuild_duration = rebuild_thread.join().unwrap();
-        if emit_timings && !precompiled {
+        if emit_timings && !prebuilt {
             println!(
                 "Finished rebuilding and preprocessing the host in {} ms\n",
                 rebuild_duration
@@ -322,7 +322,7 @@ pub fn build_file<'a>(
 
     if let HostRebuildTiming::ConcurrentWithApp(thread) = rebuild_timing {
         let rebuild_duration = thread.join().unwrap();
-        if emit_timings && !precompiled {
+        if emit_timings && !prebuilt {
             println!(
                 "Finished rebuilding and preprocessing the host in {} ms\n",
                 rebuild_duration
@@ -397,7 +397,7 @@ pub fn build_file<'a>(
 fn spawn_rebuild_thread(
     opt_level: OptLevel,
     linking_strategy: LinkingStrategy,
-    precompiled: bool,
+    prebuilt: bool,
     host_input_path: PathBuf,
     preprocessed_host_path: PathBuf,
     binary_path: PathBuf,
@@ -407,13 +407,13 @@ fn spawn_rebuild_thread(
 ) -> std::thread::JoinHandle<u128> {
     let thread_local_target = target.clone();
     std::thread::spawn(move || {
-        if !precompiled {
+        if !prebuilt {
             println!("🔨 Rebuilding platform...");
         }
 
         let rebuild_host_start = Instant::now();
 
-        if !precompiled {
+        if !prebuilt {
             match linking_strategy {
                 LinkingStrategy::Additive => {
                     let host_dest = rebuild_host(

--- a/crates/cli/src/build.rs
+++ b/crates/cli/src/build.rs
@@ -191,8 +191,6 @@ pub fn build_file<'a>(
         exposed_closure_types,
     );
 
-    // TODO try to move as much of this linking as possible to the prebuilt platform,
-    // to minimize the amount of platform-application linking required.
     let app_o_file = Builder::new()
         .prefix("roc_app")
         .suffix(&format!(".{}", app_extension))

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -54,7 +54,7 @@ pub const FLAG_NO_LINK: &str = "no-link";
 pub const FLAG_TARGET: &str = "target";
 pub const FLAG_TIME: &str = "time";
 pub const FLAG_LINKER: &str = "linker";
-pub const FLAG_PRECOMPILED: &str = "precompiled-host";
+pub const FLAG_PRECOMPILED: &str = "precompiled-platform";
 pub const FLAG_CHECK: &str = "check";
 pub const FLAG_WASM_STACK_SIZE_KB: &str = "wasm-stack-size-kb";
 pub const ROC_FILE: &str = "ROC_FILE";
@@ -106,7 +106,7 @@ pub fn build_app<'a>() -> Command<'a> {
 
     let flag_precompiled = Arg::new(FLAG_PRECOMPILED)
         .long(FLAG_PRECOMPILED)
-        .help("Assume the host has been precompiled and skip recompiling the host\n(This is enabled by default when using `roc build` with a --target other than `--target host`.)")
+        .help("Assume the platform has been precompiled and skip recompiling the platform\n(This is enabled by default when using `roc build` with a --target other than `--target host`.)")
         .possible_values(["true", "false"])
         .required(false);
 
@@ -502,7 +502,7 @@ pub fn build(
     let precompiled = if matches.is_present(FLAG_PRECOMPILED) {
         matches.value_of(FLAG_PRECOMPILED) == Some("true")
     } else {
-        // When compiling for a different target, default to assuming a precompiled host.
+        // When compiling for a different target, default to assuming a precompiled platform.
         // Otherwise compilation would most likely fail because many toolchains assume you're compiling for the host
         // We make an exception for Wasm, because cross-compiling is the norm in that case.
         triple != Triple::host() && !matches!(triple.architecture, Architecture::Wasm32)

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -499,7 +499,7 @@ pub fn build(
         LinkingStrategy::Surgical
     };
 
-    let precompiled = if matches.is_present(FLAG_PREBUILT) {
+    let prebuilt = if matches.is_present(FLAG_PREBUILT) {
         matches.value_of(FLAG_PREBUILT) == Some("true")
     } else {
         // When compiling for a different target, default to assuming a prebuilt platform.
@@ -547,7 +547,7 @@ pub fn build(
         emit_timings,
         link_type,
         linking_strategy,
-        precompiled,
+        prebuilt,
         threading,
         wasm_dev_stack_bytes,
         build_ordering,

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -54,7 +54,7 @@ pub const FLAG_NO_LINK: &str = "no-link";
 pub const FLAG_TARGET: &str = "target";
 pub const FLAG_TIME: &str = "time";
 pub const FLAG_LINKER: &str = "linker";
-pub const FLAG_PRECOMPILED: &str = "precompiled-platform";
+pub const FLAG_PREBUILT: &str = "prebuilt-platform";
 pub const FLAG_CHECK: &str = "check";
 pub const FLAG_WASM_STACK_SIZE_KB: &str = "wasm-stack-size-kb";
 pub const ROC_FILE: &str = "ROC_FILE";
@@ -104,9 +104,9 @@ pub fn build_app<'a>() -> Command<'a> {
         .possible_values(["surgical", "legacy"])
         .required(false);
 
-    let flag_precompiled = Arg::new(FLAG_PRECOMPILED)
-        .long(FLAG_PRECOMPILED)
-        .help("Assume the platform has been precompiled and skip recompiling the platform\n(This is enabled by default when using `roc build` with a --target other than `--target host`.)")
+    let flag_prebuilt = Arg::new(FLAG_PREBUILT)
+        .long(FLAG_PREBUILT)
+        .help("Assume the platform has been prebuilt and skip rebuilding the platform\n(This is enabled by default when using `roc build` with a --target other than `--target host`.)")
         .possible_values(["true", "false"])
         .required(false);
 
@@ -143,7 +143,7 @@ pub fn build_app<'a>() -> Command<'a> {
             .arg(flag_debug.clone())
             .arg(flag_time.clone())
             .arg(flag_linker.clone())
-            .arg(flag_precompiled.clone())
+            .arg(flag_prebuilt.clone())
             .arg(flag_wasm_stack_size_kb.clone())
             .arg(
                 Arg::new(FLAG_TARGET)
@@ -182,7 +182,7 @@ pub fn build_app<'a>() -> Command<'a> {
             .arg(flag_debug.clone())
             .arg(flag_time.clone())
             .arg(flag_linker.clone())
-            .arg(flag_precompiled.clone())
+            .arg(flag_prebuilt.clone())
             .arg(
                 Arg::new(ROC_FILE)
                     .help("The .roc file for the main module")
@@ -204,7 +204,7 @@ pub fn build_app<'a>() -> Command<'a> {
             .arg(flag_debug.clone())
             .arg(flag_time.clone())
             .arg(flag_linker.clone())
-            .arg(flag_precompiled.clone())
+            .arg(flag_prebuilt.clone())
             .arg(roc_file_to_run.clone())
             .arg(args_for_app.clone())
         )
@@ -217,7 +217,7 @@ pub fn build_app<'a>() -> Command<'a> {
             .arg(flag_debug.clone())
             .arg(flag_time.clone())
             .arg(flag_linker.clone())
-            .arg(flag_precompiled.clone())
+            .arg(flag_prebuilt.clone())
             .arg(roc_file_to_run.clone())
             .arg(args_for_app.clone())
         )
@@ -283,7 +283,7 @@ pub fn build_app<'a>() -> Command<'a> {
         .arg(flag_debug)
         .arg(flag_time)
         .arg(flag_linker)
-        .arg(flag_precompiled)
+        .arg(flag_prebuilt)
         .arg(roc_file_to_run.required(false))
         .arg(args_for_app);
 
@@ -499,10 +499,10 @@ pub fn build(
         LinkingStrategy::Surgical
     };
 
-    let precompiled = if matches.is_present(FLAG_PRECOMPILED) {
-        matches.value_of(FLAG_PRECOMPILED) == Some("true")
+    let precompiled = if matches.is_present(FLAG_PREBUILT) {
+        matches.value_of(FLAG_PREBUILT) == Some("true")
     } else {
-        // When compiling for a different target, default to assuming a precompiled platform.
+        // When compiling for a different target, default to assuming a prebuilt platform.
         // Otherwise compilation would most likely fail because many toolchains assume you're compiling for the host
         // We make an exception for Wasm, because cross-compiling is the norm in that case.
         triple != Triple::host() && !matches!(triple.architecture, Architecture::Wasm32)

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -106,7 +106,7 @@ pub fn build_app<'a>() -> Command<'a> {
 
     let flag_prebuilt = Arg::new(FLAG_PREBUILT)
         .long(FLAG_PREBUILT)
-        .help("Assume the platform has been prebuilt and skip rebuilding the platform\n(This is enabled by default when using `roc build` with a --target other than `--target host`.)")
+        .help("Assume the platform has been prebuilt and skip rebuilding the platform\n(This is enabled by default when using `roc build` with a --target other than `--target <your machine>`.)")
         .possible_values(["true", "false"])
         .required(false);
 
@@ -503,7 +503,7 @@ pub fn build(
         matches.value_of(FLAG_PREBUILT) == Some("true")
     } else {
         // When compiling for a different target, default to assuming a prebuilt platform.
-        // Otherwise compilation would most likely fail because many toolchains assume you're compiling for the host
+        // Otherwise compilation would most likely fail because many toolchains assume you're compiling for your machine.
         // We make an exception for Wasm, because cross-compiling is the norm in that case.
         triple != Triple::host() && !matches!(triple.architecture, Architecture::Wasm32)
     };

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -106,7 +106,7 @@ pub fn build_app<'a>() -> Command<'a> {
 
     let flag_prebuilt = Arg::new(FLAG_PREBUILT)
         .long(FLAG_PREBUILT)
-        .help("Assume the platform has been prebuilt and skip rebuilding the platform\n(This is enabled by default when using `roc build` with a --target other than `--target <your machine>`.)")
+        .help("Assume the platform has been prebuilt and skip rebuilding the platform\n(This is enabled by default when using `roc build` with a --target other than `--target <current machine>`.)")
         .possible_values(["true", "false"])
         .required(false);
 
@@ -503,7 +503,7 @@ pub fn build(
         matches.value_of(FLAG_PREBUILT) == Some("true")
     } else {
         // When compiling for a different target, default to assuming a prebuilt platform.
-        // Otherwise compilation would most likely fail because many toolchains assume you're compiling for your machine.
+        // Otherwise compilation would most likely fail because many toolchains assume you're compiling for the current machine.
         // We make an exception for Wasm, because cross-compiling is the norm in that case.
         triple != Triple::host() && !matches!(triple.architecture, Architecture::Wasm32)
     };

--- a/crates/cli/tests/cli_run.rs
+++ b/crates/cli/tests/cli_run.rs
@@ -27,7 +27,7 @@ mod cli_run {
     const OPTIMIZE_FLAG: &str = concatcp!("--", roc_cli::FLAG_OPTIMIZE);
     const LINKER_FLAG: &str = concatcp!("--", roc_cli::FLAG_LINKER);
     const CHECK_FLAG: &str = concatcp!("--", roc_cli::FLAG_CHECK);
-    const PRECOMPILED_HOST: &str = concatcp!("--", roc_cli::FLAG_PRECOMPILED, "=true");
+    const PRECOMPILED_PLATFORM: &str = concatcp!("--", roc_cli::FLAG_PRECOMPILED, "=true");
     #[allow(dead_code)]
     const TARGET_FLAG: &str = concatcp!("--", roc_cli::FLAG_TARGET);
 
@@ -586,8 +586,8 @@ mod cli_run {
                         ran_without_optimizations = true;
                     });
 
-                    // now we can pass the `PRECOMPILED_HOST` flag, because the `call_once` will
-                    // have compiled the host
+                    // now we can pass the `PRECOMPILED_PLATFORM` flag, because the `call_once` will
+                    // have compiled the platform
 
                     if !ran_without_optimizations {
                         // Check with and without optimizations
@@ -595,7 +595,7 @@ mod cli_run {
                             &file_name,
                             benchmark.stdin,
                             benchmark.executable_filename,
-                            &[PRECOMPILED_HOST],
+                            &[PRECOMPILED_PLATFORM],
                             &app_args,
                             benchmark.expected_ending,
                             benchmark.use_valgrind,
@@ -606,7 +606,7 @@ mod cli_run {
                         &file_name,
                         benchmark.stdin,
                         benchmark.executable_filename,
-                        &[PRECOMPILED_HOST, OPTIMIZE_FLAG],
+                        &[PRECOMPILED_PLATFORM, OPTIMIZE_FLAG],
                         &app_args,
                         benchmark.expected_ending,
                         benchmark.use_valgrind,

--- a/crates/cli/tests/cli_run.rs
+++ b/crates/cli/tests/cli_run.rs
@@ -104,14 +104,11 @@ mod cli_run {
             stdin,
         );
 
-        // If there is any stderr, it should be reporting the runtime and that's it!
-        if !(compile_out.stderr.is_empty()
-            || compile_out.stderr.starts_with("runtime: ") && compile_out.stderr.ends_with("ms\n"))
-        {
-            panic!(
-                "`roc` command had unexpected stderr: {}",
-                compile_out.stderr
-            );
+        let ignorable = "🔨 Rebuilding platform...\n";
+        let stderr = compile_out.stderr.replacen(ignorable, "", 1);
+        let is_reporting_runtime = stderr.starts_with("runtime: ") && stderr.ends_with("ms\n");
+        if !(stderr.is_empty() || is_reporting_runtime) {
+            panic!("`roc` command had unexpected stderr: {}", stderr);
         }
 
         assert!(compile_out.status.success(), "bad status {:?}", compile_out);

--- a/crates/cli/tests/cli_run.rs
+++ b/crates/cli/tests/cli_run.rs
@@ -27,7 +27,7 @@ mod cli_run {
     const OPTIMIZE_FLAG: &str = concatcp!("--", roc_cli::FLAG_OPTIMIZE);
     const LINKER_FLAG: &str = concatcp!("--", roc_cli::FLAG_LINKER);
     const CHECK_FLAG: &str = concatcp!("--", roc_cli::FLAG_CHECK);
-    const PRECOMPILED_PLATFORM: &str = concatcp!("--", roc_cli::FLAG_PRECOMPILED, "=true");
+    const PREBUILT_PLATFORM: &str = concatcp!("--", roc_cli::FLAG_PREBUILT, "=true");
     #[allow(dead_code)]
     const TARGET_FLAG: &str = concatcp!("--", roc_cli::FLAG_TARGET);
 
@@ -586,8 +586,8 @@ mod cli_run {
                         ran_without_optimizations = true;
                     });
 
-                    // now we can pass the `PRECOMPILED_PLATFORM` flag, because the `call_once` will
-                    // have compiled the platform
+                    // now we can pass the `PREBUILT_PLATFORM` flag, because the
+                    // `call_once` will have built the platform
 
                     if !ran_without_optimizations {
                         // Check with and without optimizations
@@ -595,7 +595,7 @@ mod cli_run {
                             &file_name,
                             benchmark.stdin,
                             benchmark.executable_filename,
-                            &[PRECOMPILED_PLATFORM],
+                            &[PREBUILT_PLATFORM],
                             &app_args,
                             benchmark.expected_ending,
                             benchmark.use_valgrind,
@@ -606,7 +606,7 @@ mod cli_run {
                         &file_name,
                         benchmark.stdin,
                         benchmark.executable_filename,
-                        &[PRECOMPILED_PLATFORM, OPTIMIZE_FLAG],
+                        &[PREBUILT_PLATFORM, OPTIMIZE_FLAG],
                         &app_args,
                         benchmark.expected_ending,
                         benchmark.use_valgrind,

--- a/crates/cli_utils/src/helpers.rs
+++ b/crates/cli_utils/src/helpers.rs
@@ -365,7 +365,7 @@ pub fn examples_dir(dir_name: &str) -> PathBuf {
 
     // Descend into examples/{dir_name}
     path.push("examples");
-    path.extend(dir_name.split("/")); // Make slashes cross-platform
+    path.extend(dir_name.split("/")); // Make slashes cross-target
 
     path
 }
@@ -388,7 +388,7 @@ pub fn fixtures_dir(dir_name: &str) -> PathBuf {
     path.push("cli");
     path.push("tests");
     path.push("fixtures");
-    path.extend(dir_name.split("/")); // Make slashes cross-platform
+    path.extend(dir_name.split("/")); // Make slashes cross-target
 
     path
 }

--- a/crates/compiler/build/src/program.rs
+++ b/crates/compiler/build/src/program.rs
@@ -495,7 +495,7 @@ fn gen_from_mono_module_dev_wasm32(
 
     let host_bytes = std::fs::read(preprocessed_host_path).unwrap_or_else(|_| {
         panic!(
-            "Failed to read host object file {}! Try setting --precompiled-host=false",
+            "Failed to read host object file {}! Try setting --precompiled-platform=false",
             preprocessed_host_path.display()
         )
     });

--- a/crates/compiler/build/src/program.rs
+++ b/crates/compiler/build/src/program.rs
@@ -495,7 +495,7 @@ fn gen_from_mono_module_dev_wasm32(
 
     let host_bytes = std::fs::read(preprocessed_host_path).unwrap_or_else(|_| {
         panic!(
-            "Failed to read host object file {}! Try setting --precompiled-platform=false",
+            "Failed to read host object file {}! Try setting --prebuilt-platform=false",
             preprocessed_host_path.display()
         )
     });

--- a/crates/compiler/gen_llvm/src/llvm/build.rs
+++ b/crates/compiler/gen_llvm/src/llvm/build.rs
@@ -3964,7 +3964,7 @@ fn expose_function_to_host_help_c_abi<'a, 'ctx, 'env>(
 }
 
 pub fn get_sjlj_buffer<'a, 'ctx, 'env>(env: &Env<'a, 'ctx, 'env>) -> PointerValue<'ctx> {
-    // The size of jump_buf is platform-dependent.
+    // The size of jump_buf is target-dependent.
     //   - AArch64 needs 3 machine-sized words
     //   - LLVM says the following about the SJLJ intrinsic:
     //
@@ -5895,7 +5895,7 @@ fn run_low_level<'a, 'ctx, 'env>(
                         bitcode::STR_GET_SCALAR_UNSAFE,
                     );
 
-                    // on 32-bit platforms, zig bitpacks the struct
+                    // on 32-bit targets, zig bitpacks the struct
                     match env.target_info.ptr_width() {
                         PtrWidth::Bytes8 => result,
                         PtrWidth::Bytes4 => {

--- a/crates/compiler/types/src/num.rs
+++ b/crates/compiler/types/src/num.rs
@@ -168,7 +168,7 @@ impl IntLitWidth {
             I32 => (Signed, 32),
             I64 => (Signed, 64),
             I128 => (Signed, 128),
-            // TODO: Nat is platform specific!
+            // TODO: Nat is target specific!
             Nat => (Unsigned, 64),
             F32 => (Signed, 24),
             F64 => (Signed, 53),
@@ -213,7 +213,7 @@ impl IntLitWidth {
             I32 => i32::MAX as u128,
             I64 => i64::MAX as u128,
             I128 => i128::MAX as u128,
-            // TODO: this is platform specific!
+            // TODO: this is target specific!
             Nat => u64::MAX as u128,
             // Max int value without losing precision: 2^24
             F32 => 16_777_216,
@@ -365,7 +365,7 @@ const ALL_INT_OR_FLOAT_VARIABLES: &[Variable] = &[
     Variable::U32,
     Variable::F64,
     Variable::I64,
-    Variable::NAT, // FIXME: Nat's order here depends on the platform
+    Variable::NAT, // FIXME: Nat's order here depends on the target
     Variable::U64,
     Variable::I128,
     Variable::DEC,
@@ -391,7 +391,7 @@ const ALL_INT_VARIABLES: &[Variable] = &[
     Variable::I32,
     Variable::U32,
     Variable::I64,
-    Variable::NAT, // FIXME: Nat's order here depends on the platform
+    Variable::NAT, // FIXME: Nat's order here depends on the target
     Variable::U64,
     Variable::I128,
     Variable::U128,

--- a/crates/editor/editor-ideas.md
+++ b/crates/editor/editor-ideas.md
@@ -360,7 +360,7 @@ Thoughts and ideas possibly taken from above inspirations or separate.
       Need of highcontrast
       Or Everything Magnified for me with no glasses.
       Or Total blindness where we need to trough sound to communicate to the user
-      Screen readers read trees of labeled elements. Each platform has different apis, but I think they are horrible. Just close your eyes and imagine listening to screen reader all day while you are using this majectic machines called computers.
+      Screen readers read trees of labeled elements. Each OS has different apis, but I think they are horrible. Just close your eyes and imagine listening to screen reader all day while you are using this majectic machines called computers.
       But blind people walk with a tool and they can react much better to sound/space relations than full on visal majority does. They are acute to sound as a spatial hint. And a hand for most of them is a very sensitive tool that can make sounds in space.
       Imagine if everytime for the user doesnt want to rely on shining rendered pixels on the screen for a feedback from machine, we make a acoustic room simulation, where with moving the "stick", either with mouse or with key arrows, we bump into one of the objects and that produces certain contextually appropriate sound (clean)*ding*
 

--- a/crates/error_macros/src/lib.rs
+++ b/crates/error_macros/src/lib.rs
@@ -49,7 +49,7 @@ macro_rules! assert_sizeof_wasm {
 }
 
 /// Assert that a type has the expected size on any target not covered above
-/// In practice we use this for x86_64, and add specific macros for other platforms
+/// In practice we use this for x86_64, and add specific macros for other targets
 #[macro_export]
 macro_rules! assert_sizeof_default {
     ($t: ty, $expected_size: expr) => {

--- a/crates/glue/tests/test_glue_cli.rs
+++ b/crates/glue/tests/test_glue_cli.rs
@@ -42,7 +42,9 @@ mod glue_cli_run {
                     let out = run_app(&dir.join("app.roc"), std::iter::empty());
 
                     assert!(out.status.success());
-                    assert_eq!(out.stderr, "");
+                    let ignorable = "🔨 Rebuilding platform...\n";
+                    let stderr = out.stderr.replacen(ignorable, "", 1);
+                    assert_eq!(stderr, "");
                     assert!(
                         out.stdout.ends_with($ends_with),
                         "Unexpected stdout ending\n\nexpected:\n\n{}\n\nbut stdout was:\n\n{}",
@@ -190,14 +192,11 @@ mod glue_cli_run {
             ),
         );
 
-        // If there is any stderr, it should be reporting the runtime and that's it!
-        if !(glue_out.stderr.is_empty()
-            || glue_out.stderr.starts_with("runtime: ") && glue_out.stderr.ends_with("ms\n"))
-        {
-            panic!(
-                "`roc glue` command had unexpected stderr: {}",
-                glue_out.stderr
-            );
+        let ignorable = "🔨 Rebuilding platform...\n";
+        let stderr = glue_out.stderr.replacen(ignorable, "", 1);
+        let is_reporting_runtime = stderr.starts_with("runtime: ") && stderr.ends_with("ms\n");
+        if !(stderr.is_empty() || is_reporting_runtime) {
+            panic!("`roc glue` command had unexpected stderr: {}", stderr);
         }
 
         assert!(glue_out.status.success(), "bad status {:?}", glue_out);
@@ -215,14 +214,11 @@ mod glue_cli_run {
             &[],
         );
 
-        // If there is any stderr, it should be reporting the runtime and that's it!
-        if !(compile_out.stderr.is_empty()
-            || compile_out.stderr.starts_with("runtime: ") && compile_out.stderr.ends_with("ms\n"))
-        {
-            panic!(
-                "`roc` command had unexpected stderr: {}",
-                compile_out.stderr
-            );
+        let ignorable = "🔨 Rebuilding platform...\n";
+        let stderr = compile_out.stderr.replacen(ignorable, "", 1);
+        let is_reporting_runtime = stderr.starts_with("runtime: ") && stderr.ends_with("ms\n");
+        if !(stderr.is_empty() || is_reporting_runtime) {
+            panic!("`roc` command had unexpected stderr: {}", stderr);
         }
 
         assert!(compile_out.status.success(), "bad status {:?}", compile_out);

--- a/crates/repl_test/src/tests.rs
+++ b/crates/repl_test/src/tests.rs
@@ -523,7 +523,7 @@ fn list_of_2_field_records() {
 
 #[test]
 fn three_element_record() {
-    // if this tests turns out to fail on 32-bit platforms, look at jit_to_ast_help
+    // if this tests turns out to fail on 32-bit targets, look at jit_to_ast_help
     expect_success(
         "{ a: 1, b: 2, c: 3 }",
         "{ a: 1, b: 2, c: 3 } : { a : Num *, b : Num *, c : Num * }",
@@ -532,7 +532,7 @@ fn three_element_record() {
 
 #[test]
 fn four_element_record() {
-    // if this tests turns out to fail on 32-bit platforms, look at jit_to_ast_help
+    // if this tests turns out to fail on 32-bit targets, look at jit_to_ast_help
     expect_success(
         "{ a: 1, b: 2, c: 3, d: 4 }",
         "{ a: 1, b: 2, c: 3, d: 4 } : { a : Num *, b : Num *, c : Num *, d : Num * }",

--- a/crates/reporting/src/report.rs
+++ b/crates/reporting/src/report.rs
@@ -184,7 +184,7 @@ impl<'b> Report<'b> {
 }
 
 /// This struct is a combination of several things
-/// 1. A set of StyleCodes suitable for the platform we're running on (web or terminal)
+/// 1. A set of StyleCodes suitable for the environment we're running in (web or terminal)
 /// 2. A set of colors we decided to use
 /// 3. A mapping from UI elements to the styles we use for them
 /// Note: This should really be called Theme! Usually a "palette" is just (2).
@@ -212,7 +212,7 @@ pub struct Palette {
 }
 
 /// Set the default styles for various semantic elements,
-/// given a set of StyleCodes for a platform (web or terminal).
+/// given a set of StyleCodes for an environment (web or terminal).
 const fn default_palette_from_style_codes(codes: StyleCodes) -> Palette {
     Palette {
         primary: codes.white,

--- a/www/public/repl/repl.js
+++ b/www/public/repl/repl.js
@@ -137,7 +137,7 @@ async function processInputQueue() {
 // ----------------------------------------------------------------------------
 
 // Create an executable Wasm instance from an array of bytes
-// (Browser validates the module and does the final compilation to the host's machine code.)
+// (Browser validates the module and does the final compilation to your machine's machine code.)
 async function js_create_app(wasm_module_bytes) {
   const wasiLinkObject = {}; // gives the WASI functions a reference to the app so they can write to its memory
   const importObj = getMockWasiImports(wasiLinkObject);

--- a/www/public/repl/repl.js
+++ b/www/public/repl/repl.js
@@ -137,7 +137,7 @@ async function processInputQueue() {
 // ----------------------------------------------------------------------------
 
 // Create an executable Wasm instance from an array of bytes
-// (Browser validates the module and does the final compilation to the current machine's machine code.)
+// (Browser validates the module and does the final compilation.)
 async function js_create_app(wasm_module_bytes) {
   const wasiLinkObject = {}; // gives the WASI functions a reference to the app so they can write to its memory
   const importObj = getMockWasiImports(wasiLinkObject);

--- a/www/public/repl/repl.js
+++ b/www/public/repl/repl.js
@@ -137,7 +137,7 @@ async function processInputQueue() {
 // ----------------------------------------------------------------------------
 
 // Create an executable Wasm instance from an array of bytes
-// (Browser validates the module and does the final compilation to your machine's machine code.)
+// (Browser validates the module and does the final compilation to the current machine's machine code.)
 async function js_create_app(wasm_module_bytes) {
   const wasiLinkObject = {}; // gives the WASI functions a reference to the app so they can write to its memory
   const importObj = getMockWasiImports(wasiLinkObject);


### PR DESCRIPTION
Closes #3630, plus various related rephrasings!

"Host" is an unclear word for Roc app developers - is it the platform? part of the platform? a language? a machine? a CPU architecture? The word "platform" is similarly unclear sometimes (is it a CPU architecture?), but at least in the context of Roc that word (when unaccompanied by any clarifying adjective) should be reserved to mean "Roc platform" (the "Roc" part should just be implied, similarly to how "app" without any adjective just means "Roc app").

There are various overloadings of these two words in the repo, so this PR seeks to make vocabulary significantly more consistent for app developers, platform developers, and compiler contributors (though not enforcing the same vocabulary across those three contexts).

Additionally, this PR increases the use of "target" to mean "CPU architecture / operating system" and introduces "your machine" to mean "the target that is running the Roc compiler/platform/app".

A Roc-wide glossary might be helpful in the future, but this doesn't commit to that.

See https://roc.zulipchat.com/#narrow/stream/231635-compiler-development/topic/.28Building.20vs.2E.20compiling.29.20a.20.28host.20vs.2E.20platform.29 for the discussion that led to this PR's choices.