### PR TITLE
Cache variables sent to a module's external specializations in mono

### DIFF
--- a/crates/compiler/collections/src/vec_map.rs
+++ b/crates/compiler/collections/src/vec_map.rs
@@ -210,7 +210,7 @@ impl<K, V> ExactSizeIterator for IntoIter<K, V> {
     }
 }
 
-impl<K: Ord, V> std::iter::FromIterator<(K, V)> for VecMap<K, V> {
+impl<K: PartialEq, V> std::iter::FromIterator<(K, V)> for VecMap<K, V> {
     fn from_iter<T: IntoIterator<Item = (K, V)>>(iter: T) -> Self {
         let mut this = Self::default();
         this.extend(iter);

--- a/crates/compiler/late_solve/src/lib.rs
+++ b/crates/compiler/late_solve/src/lib.rs
@@ -22,6 +22,8 @@ use roc_unify::unify::{Env, Mode, Unified};
 pub use roc_solve::ability::Resolved;
 pub use roc_types::subs::instantiate_rigids;
 
+pub mod storage;
+
 #[derive(Debug)]
 pub struct UnificationFailed;
 

--- a/crates/compiler/late_solve/src/storage.rs
+++ b/crates/compiler/late_solve/src/storage.rs
@@ -1,0 +1,75 @@
+use roc_types::subs::StorageSubs;
+use roc_types::subs::{storage_copy_var_to, Subs, Variable, VariableMapCache};
+use std::iter::Iterator;
+
+/// Storage for types to be sent to an external module, and written to only by one module's subs.
+/// Maintains a cache so that independent writes can re-use types previously inserted into the
+/// storage.
+#[derive(Clone, Debug)]
+pub struct ExternalModuleStorage {
+    storage: StorageSubs,
+    /// Variable they expose -> variable we record into storage
+    variable_mapping_cache: VariableMapCache,
+}
+
+pub struct ExternalModuleStorageSnapshot {
+    mapping_cache_len: usize,
+}
+
+impl ExternalModuleStorage {
+    pub fn new(subs: Subs) -> Self {
+        Self {
+            storage: StorageSubs::new(subs),
+            variable_mapping_cache: VariableMapCache::new(),
+        }
+    }
+
+    pub fn extend_with_variable(&mut self, source: &Subs, variable: Variable) -> Variable {
+        storage_copy_var_to(
+            &mut self.variable_mapping_cache,
+            source,
+            &mut self.storage.as_inner_mut(),
+            variable,
+        )
+    }
+
+    pub fn into_storage_subs(self) -> StorageSubs {
+        self.storage
+    }
+
+    /// Invalidates the whole cache given a sequence of variables that should no longer be indexed
+    /// from the cache.
+    pub fn invalidate_cache(&mut self, changed_variables: &[Variable]) {
+        for var in changed_variables {
+            for cache in self.variable_mapping_cache.0.iter_mut().rev() {
+                cache.remove(var);
+            }
+        }
+    }
+
+    /// Invalidates the whole cache.
+    /// Should only be called if you need to invalidate the cache but don't have a snapshot.
+    /// Generally you should prefer to create a snapshot and invalidate that snapshot, which avoids
+    /// unnecessary cache invalidation.
+    pub fn invalidate_whole_cache(&mut self) {
+        debug_assert_eq!(self.variable_mapping_cache.0.len(), 1);
+        self.variable_mapping_cache.0.last_mut().unwrap().clear();
+    }
+
+    /// Creates a snapshot of the cache, making it suitable for new ephemeral entries.
+    /// The cache can be rolled back to the state it was in prior to the snapshot with [rollback_cache].
+    pub fn snapshot_cache(&mut self) -> ExternalModuleStorageSnapshot {
+        self.variable_mapping_cache.0.push(Default::default());
+        ExternalModuleStorageSnapshot {
+            mapping_cache_len: self.variable_mapping_cache.0.len(),
+        }
+    }
+
+    pub fn rollback_cache(&mut self, snapshot: ExternalModuleStorageSnapshot) {
+        debug_assert_eq!(
+            self.variable_mapping_cache.0.len(),
+            snapshot.mapping_cache_len
+        );
+        self.variable_mapping_cache.0.pop();
+    }
+}

--- a/crates/compiler/late_solve/src/storage.rs
+++ b/crates/compiler/late_solve/src/storage.rs
@@ -28,7 +28,7 @@ impl ExternalModuleStorage {
         storage_copy_var_to(
             &mut self.variable_mapping_cache,
             source,
-            &mut self.storage.as_inner_mut(),
+            self.storage.as_inner_mut(),
             variable,
         )
     }

--- a/crates/compiler/late_solve/src/storage.rs
+++ b/crates/compiler/late_solve/src/storage.rs
@@ -20,7 +20,7 @@ impl ExternalModuleStorage {
     pub fn new(subs: Subs) -> Self {
         Self {
             storage: StorageSubs::new(subs),
-            variable_mapping_cache: VariableMapCache::new(),
+            variable_mapping_cache: VariableMapCache::default(),
         }
     }
 

--- a/crates/compiler/types/src/subs.rs
+++ b/crates/compiler/types/src/subs.rs
@@ -4017,11 +4017,13 @@ struct StorageSubsOffsets {
 #[derive(Clone, Debug)]
 pub struct VariableMapCache(pub Vec<FnvMap<Variable, Variable>>);
 
-impl VariableMapCache {
-    pub fn new() -> Self {
+impl Default for VariableMapCache {
+    fn default() -> Self {
         Self(vec![Default::default()])
     }
+}
 
+impl VariableMapCache {
     fn get(&self, v: &Variable) -> Option<&Variable> {
         self.0.iter().rev().find_map(|cache| cache.get(v))
     }
@@ -4050,7 +4052,7 @@ impl StorageSubs {
 
     pub fn extend_with_variable(&mut self, source: &Subs, variable: Variable) -> Variable {
         storage_copy_var_to(
-            &mut VariableMapCache::new(),
+            &mut VariableMapCache::default(),
             source,
             &mut self.subs,
             variable,


### PR DESCRIPTION
This PR makes sure that when a module A exports a type to a module B, we reuse type variables already-exported to module B. Especially when there is a lack of let-generalization, this yields a nice speedup for modules that require a lot of similarly-related types from other modules. That is, the pathological case I've been working with halves in compile-time; for other programs there I could actually measure no difference, but the compile time doesn't get worse, so I think this is strictly positive. Benchmarks below.

```
$ hyperfine --warmup 10 'target/release/roc build examples/false-interpreter/False.roc --precompiled-host true' '../roc2/target/release/roc build examples/false-interpreter/False.roc --preco
mpiled-host true'
Benchmark 1: target/release/roc build examples/false-interpreter/False.roc --precompiled-host true
  Time (mean ± σ):      1.349 s ±  0.014 s    [User: 1.382 s, System: 0.068 s]
  Range (min … max):    1.324 s …  1.370 s    10 runs

Benchmark 2: ../roc2/target/release/roc build examples/false-interpreter/False.roc --precompiled-host true
  Time (mean ± σ):      1.358 s ±  0.014 s    [User: 1.389 s, System: 0.069 s]
  Range (min … max):    1.346 s …  1.395 s    10 runs

Summary
  'target/release/roc build examples/false-interpreter/False.roc --precompiled-host true' ran
    1.01 ± 0.01 times faster than '../roc2/target/release/roc build examples/false-interpreter/False.roc --precompiled-host true'

$ hyperfine --warmup 10 'target/release/roc build examples/interactive/http-get.roc --precompiled-host true' '../roc2/target/release/roc build examples/interactive/http-get.roc --precompiled
-host true'
Benchmark 1: target/release/roc build examples/interactive/http-get.roc --precompiled-host true
  Time (mean ± σ):     357.2 ms ±  10.5 ms    [User: 335.7 ms, System: 57.0 ms]
  Range (min … max):   344.6 ms … 374.2 ms    10 runs

Benchmark 2: ../roc2/target/release/roc build examples/interactive/http-get.roc --precompiled-host true
  Time (mean ± σ):     359.4 ms ±  15.5 ms    [User: 333.8 ms, System: 58.1 ms]
  Range (min … max):   338.4 ms … 384.0 ms    10 runs

Summary
  'target/release/roc build examples/interactive/http-get.roc --precompiled-host true' ran
    1.01 ± 0.05 times faster than '../roc2/target/release/roc build examples/interactive/http-get.roc --precompiled-host true'

$ hyperfine --warmup 10 'target/release/roc build examples/interactive/lambda-scratch.roc --precompiled-host true' '../roc2/target/release/roc build examples/interactive/lambda-scratch.roc -
-precompiled-host true'
Benchmark 1: target/release/roc build examples/interactive/lambda-scratch.roc --precompiled-host true
  Time (mean ± σ):     840.6 ms ±   9.1 ms    [User: 1206.1 ms, System: 92.8 ms]
  Range (min … max):   828.6 ms … 862.4 ms    10 runs

Benchmark 2: ../roc2/target/release/roc build examples/interactive/lambda-scratch.roc --precompiled-host true
  Time (mean ± σ):      1.641 s ±  0.031 s    [User: 2.716 s, System: 0.128 s]
  Range (min … max):    1.605 s …  1.714 s    10 runs

Summary
  'target/release/roc build examples/interactive/lambda-scratch.roc --precompiled-host true' ran
    1.95 ± 0.04 times faster than '../roc2/target/release/roc build examples/interactive/lambda-scratch.roc --precompiled-host true'
```

With this I think we should wrap up current perf tuning related to lambda sets + monomorphization.
Closes #3978.
