### PR TITLE
Lose rigidity of annotated optional fields before generalization

### DIFF
--- a/crates/compiler/solve/tests/solve_expr.rs
+++ b/crates/compiler/solve/tests/solve_expr.rs
@@ -7761,4 +7761,18 @@ mod solve_expr {
         "###
         );
     }
+
+    #[test]
+    fn unify_optional_record_fields_in_two_closed_records() {
+        infer_eq_without_problem(
+            indoc!(
+                r#"
+                f : { x ? Str, y ? Str } -> {}
+                
+                f {x : ""}
+                "#
+            ),
+            "{}",
+        );
+    }
 }

--- a/crates/reporting/tests/test_reporting.rs
+++ b/crates/reporting/tests/test_reporting.rs
@@ -6605,25 +6605,6 @@ All branches in an `if` must have the same type!
     Tip: To extract the `.inputs` field it must be non-optional, but the
     type says this field is optional. Learn more about optional fields at
     TODO.
-
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
-
-    This 1st argument to `job` has an unexpected type:
-
-    9│      job { inputs: ["build", "test"] }
-                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-    The argument is a record of type:
-
-        { inputs : List Str }
-
-    But `job` needs its 1st argument to be:
-
-        { inputs ? List Str }
-
-    Tip: To extract the `.inputs` field it must be non-optional, but the
-    type says this field is optional. Learn more about optional fields at
-    TODO.
     "###
     );
 


### PR DESCRIPTION
We have this idea of "rigid optional" fields to annotate record fields that must necessarily be optional. That avoids the admission of programs we cannot faithfully compile, like

```
f : {a: Str, b ? U64}
f = {a: "b", b: 1}
```

We want to lose the rigidity restriction when a generalized symbol is used as at a specialized site; for example it should be possible to call `f : {x ? Str} -> {}` with both `{}` and `{x : Str}`, neither of which have a rigidly optional field unless they were to be annotated.

Prior to this commit we would loosen the rigidity restriction upon specialization of a generalized type at a use site. However, what we really want to do is apply the loosening during calculation of generalization. The reason is that otherwise, we must make types that would be ground (like `{x ? Str} -> {}`) generalized just for the sake of the optional field annotation. But since the rigidity constraint is irrelevant after an annotated body has been checked, we can loosen the rigidity restriction then, which conveniently happens to coincide with the generalization calculation.

Closes #3955