### PR TITLE
Reword "for examples" to "for apps" in installation guides

### DIFF
--- a/getting_started/linux_x86.md
+++ b/getting_started/linux_x86.md
@@ -2,6 +2,9 @@
 
 ## How to install Roc
 
+In order to develop in Roc, you need to install the Roc CLI,
+which includes the Roc compiler and various helpful utilities.
+
 1. Download the latest nightly from the assets [here](https://github.com/roc-lang/roc/releases).
 
 1. Untar the archive:
@@ -10,7 +13,10 @@
     tar -xf roc_nightly-linux_x86_64-<VERSION>.tar.gz
     ```
 
-## How to install `examples/` dependencies
+## How to install Roc platform dependencies
+
+In order to compile Roc apps (either in `examples/` or in your own projects),
+you need to install one or more of these platform language compilers, too.
 
 1. Install the Rust compiler, for apps with Rust-based platforms:
 

--- a/getting_started/linux_x86.md
+++ b/getting_started/linux_x86.md
@@ -12,13 +12,13 @@
 
 ## How to install `examples/` dependencies
 
-1. Install the Rust compiler, for examples with Rust-based platforms:
+1. Install the Rust compiler, for apps with Rust-based platforms:
 
     ```sh
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
     ```
 
-1. Install the Zig compiler, for examples with Zig-based platforms:
+1. Install the Zig compiler, for apps with Zig-based platforms:
 
     ```sh
     wget https://ziglang.org/download/0.9.1/zig-linux-x86_64-0.9.1.tar.xz
@@ -26,7 +26,7 @@
     sudo ln -s  $(pwd)/zig-linux-x86_64-0.9.1/zig /usr/local/bin/zig
     ```
 
-1. Install a C compiler, for examples with C-based platforms:
+1. Install a C compiler, for apps with C-based platforms:
 
     ```sh
     # On a Debian-based distro like Ubuntu

--- a/getting_started/macos_apple_silicon.md
+++ b/getting_started/macos_apple_silicon.md
@@ -2,6 +2,9 @@
 
 ## How to install Roc
 
+In order to develop in Roc, you need to install the Roc CLI,
+which includes the Roc compiler and various helpful utilities.
+
 1. Download the latest nightly from the assets [here](https://github.com/roc-lang/roc/releases).
 
 1. To prevent "roc can't be opened because Apple can't check it...":
@@ -16,7 +19,10 @@
     roc_nightly-darwin_apple_silicon-<VERSION>.tar.gz
     ```
 
-## How to install `examples/` dependencies
+## How to install Roc platform dependencies
+
+In order to compile Roc apps (either in `examples/` or in your own projects),
+you need to install one or more of these platform language compilers, too.
 
 1. Install the Rust compiler, for apps with Rust-based platforms:
 

--- a/getting_started/macos_apple_silicon.md
+++ b/getting_started/macos_apple_silicon.md
@@ -18,13 +18,13 @@
 
 ## How to install `examples/` dependencies
 
-1. Install the Rust compiler, for examples with Rust-based platforms:
+1. Install the Rust compiler, for apps with Rust-based platforms:
 
     ```sh
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
     ```
 
-1. Install the Zig compiler, for examples with Zig-based platforms:
+1. Install the Zig compiler, for apps with Zig-based platforms:
 
     ```sh
     brew install zig

--- a/getting_started/macos_x86.md
+++ b/getting_started/macos_x86.md
@@ -2,6 +2,9 @@
 
 ## How to install Roc
 
+In order to develop in Roc, you need to install the Roc CLI,
+which includes the Roc compiler and various helpful utilities.
+
 1. Download the latest nightly from the assets [here](https://github.com/roc-lang/roc/releases).
 
 1. To prevent "roc can't be opened because Apple can't check it...":
@@ -16,7 +19,10 @@
     roc_nightly-macos_x86_64-<VERSION>.tar.gz
     ```
 
-## How to install `examples/` dependencies
+## How to install Roc platform dependencies
+
+In order to compile Roc apps (either in `examples/` or in your own projects),
+you need to install one or more of these platform language compilers, too.
 
 1. Install the Rust compiler, for apps with Rust-based platforms:
 

--- a/getting_started/macos_x86.md
+++ b/getting_started/macos_x86.md
@@ -18,13 +18,13 @@
 
 ## How to install `examples/` dependencies
 
-1. Install the Rust compiler, for examples with Rust-based platforms:
+1. Install the Rust compiler, for apps with Rust-based platforms:
 
     ```sh
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
     ```
 
-1. Install the Zig compiler, for examples with Zig-based platforms:
+1. Install the Zig compiler, for apps with Zig-based platforms:
 
     ```sh
     brew install zig


### PR DESCRIPTION
These installation steps are not just for examples, they're for all apps!