### PR TITLE
Disable Web REPL input until the compiler .wasm has loaded

### DIFF
--- a/crates/repl_wasm/build-www.sh
+++ b/crates/repl_wasm/build-www.sh
@@ -12,7 +12,7 @@ set -euxo pipefail
 
 if ! which wasm-pack
 then
-    echo "To build the Web REPL, you need to run `cargo install wasm-pack`"
+    echo "To build the Web REPL, you need to run 'cargo install wasm-pack'"
     exit 1
 fi
 

--- a/www/public/repl/index.html
+++ b/www/public/repl/index.html
@@ -14,7 +14,11 @@
 
       <section class="history">
         <div class="scroll-wrap">
-          <div id="history-text" class="scroll code"></div>
+          <div id="history-text" class="scroll code">
+            <div id="loading-message">
+              Loading Roc compiler as a WebAssembly module... please wait!
+            </div>
+          </div>
         </div>
       </section>
 
@@ -24,7 +28,8 @@
           autofocus
           id="source-input"
           class="code"
-          placeholder="Type some Roc code and press Enter. (Use Shift+Enter for multi-line input)"
+          placeholder="You can enter Roc code here after the compiler is loaded!"
+          disabled
         ></textarea>
       </section>
     </div>

--- a/www/public/repl/repl.css
+++ b/www/public/repl/repl.css
@@ -43,6 +43,9 @@ section.history {
   margin: 16px 0;
   padding: 8px;
 }
+#loading-message {
+  margin: 40% 10%;
+}
 .history-item {
   margin-bottom: 24px;
 }

--- a/www/public/repl/repl.js
+++ b/www/public/repl/repl.js
@@ -41,7 +41,11 @@ const repl = {
 // Initialise
 repl.elemSourceInput.addEventListener("change", onInputChange);
 repl.elemSourceInput.addEventListener("keyup", onInputKeyup);
-roc_repl_wasm.default('/repl/roc_repl_wasm_bg.wasm').then((instance) => {
+roc_repl_wasm.default("/repl/roc_repl_wasm_bg.wasm").then((instance) => {
+  repl.elemHistory.querySelector('#loading-message').remove();
+  repl.elemSourceInput.disabled = false;
+  repl.elemSourceInput.placeholder =
+    "Type some Roc code and press Enter. (Use Shift+Enter for multi-line input)";
   repl.compiler = instance;
 });
 


### PR DESCRIPTION
It turns out that the Roc compiler .wasm module can take a while to load. It's 1.4MB compressed. If you try to use the REPL in that time, you just see a JavaScript error in the "console" panel. Not great.
Instead let's disable the input during that time, and show a loading message.

Closes #4025 

![www-repl-loading](https://user-images.githubusercontent.com/4647158/189767183-ef72872b-0958-4260-af60-a9fd7353128a.png)
