### PR TITLE
increase macos x86 nightly timelimit

### DIFF
--- a/.github/workflows/nightly_macos_x86_64.yml
+++ b/.github/workflows/nightly_macos_x86_64.yml
@@ -12,7 +12,7 @@ jobs:
   test-build-upload:
     name: build, test, package and upload nightly release
     runs-on: [macos-12]
-    timeout-minutes: 90
+    timeout-minutes: 120
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
The latest nightly timed out running the tests.