### PR TITLE
windows linker preprocess exe

### DIFF
--- a/crates/linker/src/pe.rs
+++ b/crates/linker/src/pe.rs
@@ -599,14 +599,4 @@ mod test {
 
         assert_eq!(new_sections, names.as_slice());
     }
-
-    //    fn actually_do_the_thing() {
-    //        let data = include_bytes!("/home/folkertdev/roc/roc/examples/double/simple.exe");
-    //
-    //        let new_sections = [*b".text\0\0\0", *b".rdata\0\0"];
-    //
-    //        let path = Path::new("/home/folkertdev/roc/roc/examples/double/modified.exe");
-    //
-    //        let _mmap = Preprocessor::preprocess(path, data, &new_sections);
-    //    }
 }

--- a/crates/linker/src/pe.rs
+++ b/crates/linker/src/pe.rs
@@ -600,14 +600,13 @@ mod test {
         assert_eq!(new_sections, names.as_slice());
     }
 
-    #[test]
-    fn actually_do_the_thing() {
-        let data = include_bytes!("/home/folkertdev/roc/roc/examples/double/simple.exe");
-
-        let new_sections = [*b".text\0\0\0", *b".rdata\0\0"];
-
-        let path = Path::new("/home/folkertdev/roc/roc/examples/double/modified.exe");
-
-        let _mmap = Preprocessor::preprocess(path, data, &new_sections);
-    }
+    //    fn actually_do_the_thing() {
+    //        let data = include_bytes!("/home/folkertdev/roc/roc/examples/double/simple.exe");
+    //
+    //        let new_sections = [*b".text\0\0\0", *b".rdata\0\0"];
+    //
+    //        let path = Path::new("/home/folkertdev/roc/roc/examples/double/modified.exe");
+    //
+    //        let _mmap = Preprocessor::preprocess(path, data, &new_sections);
+    //    }
 }

--- a/crates/linker/src/pe.rs
+++ b/crates/linker/src/pe.rs
@@ -89,20 +89,20 @@ impl DynamicRelocationsPe {
         Ok(None)
     }
 
-    /// Appends the functions (e.g. mainForHost) that the host needs from the app
+    /// Append metadata for the functions (e.g. mainForHost) that the host needs from the app
     fn append_roc_imports(
         &mut self,
         import_table: &ImportTable,
-        descriptor: &ImageImportDescriptor,
+        roc_dll_descriptor: &ImageImportDescriptor,
     ) -> object::read::Result<()> {
         use object::LittleEndian as LE;
 
         // offset of first thunk from the start of the section
         let thunk_start_offset =
-            descriptor.original_first_thunk.get(LE) - self.section_virtual_address;
+            roc_dll_descriptor.original_first_thunk.get(LE) - self.section_virtual_address;
         let mut thunk_offset = 0;
 
-        let mut thunks = import_table.thunks(descriptor.original_first_thunk.get(LE))?;
+        let mut thunks = import_table.thunks(roc_dll_descriptor.original_first_thunk.get(LE))?;
         while let Some(thunk_data) = thunks.next::<ImageNtHeaders64>()? {
             use object::read::pe::ImageThunkData;
 
@@ -111,7 +111,7 @@ impl DynamicRelocationsPe {
             let name = String::from_utf8_lossy(name).to_string();
 
             let offset_in_file = self.section_offset_in_file + thunk_start_offset + thunk_offset;
-            let virtual_address = descriptor.original_first_thunk.get(LE) + thunk_offset;
+            let virtual_address = roc_dll_descriptor.original_first_thunk.get(LE) + thunk_offset;
 
             self.name_by_virtual_address
                 .insert(virtual_address, name.clone());

--- a/crates/linker/src/pe.rs
+++ b/crates/linker/src/pe.rs
@@ -192,6 +192,12 @@ fn remove_dummy_dll_import_table(
     }
 }
 
+/// Preprocess the host's .exe to make space for extra sections
+///
+/// We will later take code and data sections from the app and concatenate them with this
+/// preprocessed host. That means we need to do some bookkeeping: add extra entries to the
+/// section table, update the header with the new section count, and (because we added data)
+/// update existing section headers to point to a different (shifted) location in the file
 #[allow(dead_code)]
 struct Preprocessor<'a> {
     data: &'a [u8],


### PR DESCRIPTION
preprocess the host .exe to make space for code and data sections from the app

This pass produces a working binary (verified with wine) that has the dummy sections 