### PR TITLE
Add default build to flake outputs

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,4 @@
-{ rev ? "a7855f2235a1876f97473a76151fec2afa02b287", # nixpkgs master. Keep up to date with flake.lock
+{ rev ? "a7855f2235a1876f97473a76151fec2afa02b287", # nixpkgs master. Keep up to date with "nixpkgs">"locked">"rev" in flake.lock
 nixpkgsSource ? builtins.fetchTarball {
   url = "https://github.com/nixos/nixpkgs/tarball/${rev}";
   sha256 = "sha256-5DGKX81wIPAAiLwUmUYECpA3vop94AHHR7WmGXSsQok=";

--- a/default.nix
+++ b/default.nix
@@ -1,9 +1,9 @@
-{ rev ? "541a3ca27c9a8220b46f4feb7dd8e94336a77f42", # nixpkgs master
+{ rev ? "a7855f2235a1876f97473a76151fec2afa02b287", # nixpkgs master. Keep up to date with flake.lock
 nixpkgsSource ? builtins.fetchTarball {
   url = "https://github.com/nixos/nixpkgs/tarball/${rev}";
-  sha256 = "sha256:1mxv0zigm98pawf05kd4s8ipvk1pvvdsn1yh978c5an97kz0ck5w";
+  sha256 = "sha256-5DGKX81wIPAAiLwUmUYECpA3vop94AHHR7WmGXSsQok=";
 }, pkgs ? import nixpkgsSource { }
-, cargoSha256 ? "sha256-treL2sWPcZ1NBwdab3FOb2FI2wT/Vt9tD4XRfJ8rYWA=", }:
+, cargoSha256 ? "sha256-F6UOJZ5oDOZ+80z70A21VzDR0YtmgD0dnEcjPgpicpo=", }:
 # we only this file to release a nix package, use flake.nix for development
 let
   rustPlatform = pkgs.rustPlatform;

--- a/flake.nix
+++ b/flake.nix
@@ -129,6 +129,7 @@
 
         formatter = pkgs.nixpkgs-fmt;
 
+        # You can build this package (the compiler) with the `nix build` command.
         packages.default = import ./. { inherit pkgs; };
       });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -128,5 +128,7 @@
         };
 
         formatter = pkgs.nixpkgs-fmt;
+
+        packages.default = import ./. { inherit pkgs; };
       });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -129,7 +129,7 @@
 
         formatter = pkgs.nixpkgs-fmt;
 
-        # You can build this package (the compiler) with the `nix build` command.
+        # You can build this package (the roc CLI) with the `nix build` command.
         packages.default = import ./. { inherit pkgs; };
       });
 }


### PR DESCRIPTION
Adds the ability to run `nix build` in the project, which will build the package derivation inside Nix.

I also changed the hashes in default.nix to match those in flake.lock - in fact, I'd consider removing them from default.nix and relying on flakes to do the build, but I didn't want to make possibly breaking changes.