### PR TITLE
Allow any numeric range to become a float

### DIFF
--- a/crates/compiler/mono/src/layout.rs
+++ b/crates/compiler/mono/src/layout.rs
@@ -2177,7 +2177,7 @@ pub fn is_unresolved_var(subs: &Subs, var: Variable) -> bool {
 
 #[inline(always)]
 pub fn is_any_float_range(subs: &Subs, var: Variable) -> bool {
-    use {roc_types::num::IntLitWidth::*, Content::*, NumericRange::*};
+    use {Content::*, NumericRange::*};
     let content = subs.get_content_without_compacting(var);
     matches!(
         content,

--- a/crates/compiler/mono/src/layout.rs
+++ b/crates/compiler/mono/src/layout.rs
@@ -2181,7 +2181,7 @@ pub fn is_any_float_range(subs: &Subs, var: Variable) -> bool {
     let content = subs.get_content_without_compacting(var);
     matches!(
         content,
-        RangedNumber(NumAtLeastEitherSign(I8) | NumAtLeastSigned(I8)),
+        RangedNumber(NumAtLeastEitherSign(..) | NumAtLeastSigned(..)),
     )
 }
 

--- a/crates/compiler/test_mono/generated/num_width_gt_u8_layout_as_float.txt
+++ b/crates/compiler/test_mono/generated/num_width_gt_u8_layout_as_float.txt
@@ -1,0 +1,9 @@
+procedure Num.37 (#Attr.2, #Attr.3):
+    let Num.257 : Float64 = lowlevel NumDivFrac #Attr.2 #Attr.3;
+    ret Num.257;
+
+procedure Test.0 ():
+    let Test.2 : Float64 = 1f64;
+    let Test.3 : Float64 = 200f64;
+    let Test.1 : Float64 = CallByName Num.37 Test.2 Test.3;
+    ret Test.1;

--- a/crates/compiler/test_mono/src/tests.rs
+++ b/crates/compiler/test_mono/src/tests.rs
@@ -1927,3 +1927,12 @@ fn issue_3669() {
         "#
     )
 }
+
+#[mono_test]
+fn num_width_gt_u8_layout_as_float() {
+    indoc!(
+        r#"
+        1 / 200
+        "#
+    )
+}


### PR DESCRIPTION
Currently things like `1 / 200` lead to a miscompilation because we type
`200` (and as a result, both `1` and the division result) as a ranged
number with width >= U8. During mono that forces the number to become an
`I64` because our logic was that a ranged number can only become a float
if it's at least as wide as an I8. But this is incorrect; as long as the
type is wrapped in `Frac` constructor and it's a ranged number (and not
a ranged int), it should become a fractional type.

```
» 1 / 200

0.005 : Float *
```

Closes #4047
