### PR TITLE
Windows preprocess link

### DIFF
--- a/crates/linker/src/pe.rs
+++ b/crates/linker/src/pe.rs
@@ -916,4 +916,163 @@ mod test {
 
         assert_eq!("Hello, 42!\n", output);
     }
+
+    fn foobar_help(dir: &Path) {
+        use object::ObjectSection;
+
+        let host_zig = indoc!(
+            r#"
+            const std = @import("std");
+
+            extern fn magic() callconv(.C) u64;
+
+            pub fn main() !void {
+                const stdout = std.io.getStdOut().writer();
+                try stdout.print("Hello, {}!\n", .{magic()});
+            }
+            "#
+        );
+
+        let app_zig = indoc!(
+            r#"
+            export fn magic() u64 {
+                return 42;
+            }
+            "#
+        );
+
+        let zig = std::env::var("ROC_ZIG").unwrap_or_else(|_| "zig".into());
+
+        std::fs::write(dir.join("host.zig"), host_zig.as_bytes()).unwrap();
+        std::fs::write(dir.join("app.zig"), app_zig.as_bytes()).unwrap();
+
+        let dylib_bytes = crate::generate_dylib::synthetic_dll(&["magic".into()]);
+        std::fs::write(dir.join("libapp.obj"), dylib_bytes).unwrap();
+
+        let output = std::process::Command::new(&zig)
+            .current_dir(dir)
+            .args(&[
+                "build-exe",
+                "libapp.obj",
+                "host.zig",
+                "-lc",
+                "-target",
+                "x86_64-windows-gnu",
+                "--strip",
+                "-OReleaseFast",
+            ])
+            .output()
+            .unwrap();
+
+        if !output.status.success() {
+            use std::io::Write;
+
+            std::io::stdout().write_all(&output.stdout).unwrap();
+            std::io::stderr().write_all(&output.stderr).unwrap();
+
+            panic!("zig build-exe failed");
+        }
+
+        let data = std::fs::read(dir.join("host.exe")).unwrap();
+        let new_sections = [*b".text\0\0\0"];
+        increase_number_of_sections_help(&data, &new_sections, &dir.join("dynhost.exe"));
+
+        let output = std::process::Command::new(&zig)
+            .current_dir(dir)
+            .args(&[
+                "build-obj",
+                "app.zig",
+                "-target",
+                "x86_64-windows-gnu",
+                "--strip",
+                "-OReleaseFast",
+            ])
+            .output()
+            .unwrap();
+
+        if !output.status.success() {
+            use std::io::Write;
+
+            std::io::stdout().write_all(&output.stdout).unwrap();
+            std::io::stderr().write_all(&output.stderr).unwrap();
+
+            panic!("zig build-obj failed");
+        }
+
+        let mut app = std::fs::read(dir.join("dynhost.exe")).unwrap();
+        let dynamic_relocations = DynamicRelocationsPe::new(&app);
+
+        // Here we manually add the app.obj assembly to the host's .text section
+        // We can "just" do this because the space reserved for this section is bigger
+        // than what is actually used (because PE rounds up sections to a big alignment,
+        // here 0x200)
+        //
+        // So, we append the bytes at the end of the current .text section, redirect the call
+        // to `magic` to the virtual address of the .text section (so right before the new
+        // assembly bytes that we added) and then update the length of the .text section
+
+        let file = PeFile64::parse(app.as_slice()).unwrap();
+        let text_section = file.sections().next().unwrap();
+
+        // end of the code section as an offset into the file
+        let code_section_end =
+            (text_section.file_range().unwrap().0 + text_section.size()) as usize;
+
+        // the virtual address of the end of the text section
+        let code_section_end_virtual = text_section.address() + text_section.size();
+
+        // this is cheating a little bit: these bytes are copied from the `app.obj`
+        // we could get them out programatically of course.
+        let app_bytes: &[u8] = &[0xb8, 0x2a, 0, 0, 0, 0xc3];
+
+        // put our new code into the existing .text section
+        app[code_section_end..][..app_bytes.len()].copy_from_slice(app_bytes);
+
+        redirect_dummy_dll_functions(&mut app, &dynamic_relocations, &[code_section_end_virtual]);
+
+        remove_dummy_dll_import_table(
+            &mut app,
+            dynamic_relocations.data_directories_offset_in_file,
+            dynamic_relocations.imports_offset_in_file,
+            dynamic_relocations.dummy_import_index,
+        );
+
+        // again, a constant that we could get programatically
+        let section_table_offset = 384;
+
+        // update the size of the .text section (which is the first section header)
+        let p = load_struct_inplace_mut::<ImageSectionHeader>(&mut app, section_table_offset);
+        p.virtual_size
+            .set(LE, p.virtual_size.get(LE) + app_bytes.len() as u32);
+
+        std::fs::write(dir.join("hostapp.exe"), app).unwrap()
+    }
+
+    #[test]
+    fn foobar() {
+        // let dir = tempfile::tempdir().unwrap();
+        // let dir = dir.path();
+        let dir = Path::new("/tmp/wlink");
+
+        foobar_help(dir);
+
+        let output = std::process::Command::new("wine")
+            .current_dir(dir)
+            .args(&["hostapp.exe"])
+            .output()
+            .unwrap();
+
+        if !output.status.success() {
+            use std::io::Write;
+
+            std::io::stdout().write_all(&output.stdout).unwrap();
+            std::io::stderr().write_all(&output.stderr).unwrap();
+
+            panic!("wine failed");
+        }
+
+        let output = String::from_utf8_lossy(&output.stdout);
+
+        assert_eq!("Hello, 42!\n", output);
+    }
 }

--- a/crates/linker/src/pe.rs
+++ b/crates/linker/src/pe.rs
@@ -493,9 +493,9 @@ fn redirect_dummy_dll_functions(
 ) {
     // it could be that a symbol exposed by the app is not used by the host. We must skip unused symbols
     let mut targets = function_definition_vas.iter();
-    'outer: for (i, name) in imports.iter().enumerate() {
-        for (target_name, target_va) in targets.by_ref() {
-            if name == target_name {
+    'outer: for (i, host_name) in imports.iter().enumerate() {
+        for (roc_app_target_name, roc_app_target_va) in targets.by_ref() {
+            if host_name == roc_app_target_name {
                 // addresses are 64-bit values
                 let address_bytes = &mut executable[thunks_start_offset + i * 8..][..8];
 
@@ -506,7 +506,7 @@ fn redirect_dummy_dll_functions(
                 }
 
                 // update the address to a function VA
-                address_bytes.copy_from_slice(&target_va.to_le_bytes());
+                address_bytes.copy_from_slice(&roc_app_target_va.to_le_bytes());
 
                 continue 'outer;
             }

--- a/crates/linker/src/pe.rs
+++ b/crates/linker/src/pe.rs
@@ -1128,6 +1128,7 @@ mod test {
                 .map(|s| s.file_range.end - s.file_range.start)
                 .sum();
 
+            // offset_in_section now becomes a proper virtual address
             for symbol in symbols.iter_mut() {
                 if symbol.section_kind == kind {
                     symbol.offset_in_section += image_base as usize + virtual_address as usize;
@@ -1136,8 +1137,6 @@ mod test {
 
             let virtual_size = length as u32;
             let size_of_raw_data = next_multiple_of(length, file_alignment) as u32;
-
-            file_bytes_added += next_multiple_of(length, section_alignment) as u32;
 
             match kind {
                 SectionKind::Text => {
@@ -1181,6 +1180,7 @@ mod test {
             section_header_start += std::mem::size_of::<ImageSectionHeader>();
             section_file_offset += size_of_raw_data as usize;
             virtual_address += next_multiple_of(length, section_alignment) as u32;
+            file_bytes_added += next_multiple_of(length, section_alignment) as u32;
         }
 
         update_optional_header(


### PR DESCRIPTION
removes a bunch of hardcoding and extracts logic into functions.

In particular, we now preprocess the host. That adds two (at the moment) extra sections to the section table: .text (code) and .rdata (read-only data). 

Next we open up the app and find what symbols it exposes, and collect all the sections that we want to copy over to the host binary. We join all text sections into one, and all rdata sections into one. 

These are then copied, and a bunch of numbers need to be updated (and these need to be rounded to particular alignments).

I think this is all functionality we need for the `app -> host` direction. We might need the `.data` section too, but I don't think we need it? anyhow it's easy to add.

Next up, fighting the system linker to make the "host -> app" direction work.