### PR TITLE
Don't require pattern matching branches that are uninhabited 

### DIFF
--- a/crates/compiler/can/src/exhaustive.rs
+++ b/crates/compiler/can/src/exhaustive.rs
@@ -327,12 +327,15 @@ fn to_nonredundant_rows(subs: &Subs, rows: SketchedRows) -> NonRedundantSummary 
     let mut redundancies = vec![];
     let mut errors = vec![];
 
-    for SketchedRow {
-        patterns,
-        guard,
-        region,
-        redundant_mark,
-    } in rows.into_iter()
+    for (
+        row_number,
+        SketchedRow {
+            patterns,
+            guard,
+            region,
+            redundant_mark,
+        },
+    ) in rows.into_iter().enumerate()
     {
         let next_row: Vec<Pattern> = patterns
             .into_iter()
@@ -358,7 +361,7 @@ fn to_nonredundant_rows(subs: &Subs, rows: SketchedRows) -> NonRedundantSummary 
                 errors.push(Error::Redundant {
                     overall_region,
                     branch_region: region,
-                    index: HumanIndex::zero_based(checked_rows.len()),
+                    index: HumanIndex::zero_based(row_number),
                     reason,
                 });
             }

--- a/crates/compiler/can/src/exhaustive.rs
+++ b/crates/compiler/can/src/exhaustive.rs
@@ -6,8 +6,11 @@ use roc_exhaustive::{
     is_useful, Ctor, CtorName, Error, Guard, Literal, Pattern, RenderAs, TagId, Union,
 };
 use roc_module::ident::{TagIdIntType, TagName};
+use roc_module::symbol::ModuleId;
 use roc_region::all::{Loc, Region};
-use roc_types::subs::{Content, FlatType, RedundantMark, Subs, SubsFmtContent, Variable};
+use roc_types::subs::{
+    Content, FlatType, GetSubsSlice, RedundantMark, Subs, SubsFmtContent, Variable,
+};
 use roc_types::types::AliasKind;
 
 pub use roc_exhaustive::Context as ExhaustiveContext;
@@ -354,6 +357,64 @@ fn to_nonredundant_rows(subs: &Subs, rows: SketchedRows) -> NonRedundantSummary 
     }
 }
 
+/// Returns true iff the given type is inhabited by at least one value.
+fn is_inhabited(subs: &Subs, var: Variable) -> bool {
+    let mut stack = vec![var];
+    while let Some(var) = stack.pop() {
+        match subs.get_content_without_compacting(var) {
+            Content::FlexVar(_)
+            | Content::RigidVar(_)
+            | Content::FlexAbleVar(_, _)
+            | Content::RigidAbleVar(_, _)
+            // We don't need to look into recursion vars here, because if they show up in this
+            // position, they *must* belong to an inhabited type. That's because
+            //   - if the recursion var was inferred from a value, then we know there is a value of
+            //     the given type.
+            //   - if the recursion var comes from an explicit annotation, then it must be an a tag
+            //     union of the form `Rec : [ R1 Rec, R2 Rec, ..., Rn Rec ]`. However, such annotations
+            //     are determined as illegal and reported during canonicalization, because you
+            //     cannot have a tag union without a non-recursive variant.
+            | Content::RecursionVar { .. } => {}
+            Content::LambdaSet(_) => {}
+            Content::Structure(structure) => match structure {
+                FlatType::Apply(_, args) => stack.extend(subs.get_subs_slice(*args)),
+                FlatType::Func(args, _, ret) => {
+                    stack.extend(subs.get_subs_slice(*args));
+                    stack.push(*ret);
+                }
+                FlatType::Record(fields, ext) => {
+                    if let Ok(iter) = fields.unsorted_iterator(subs, *ext) {
+                        let field_vars = iter.map(|(_, field)| *field.as_inner());
+                        stack.extend(field_vars)
+                    }
+                }
+                FlatType::TagUnion(tags, ext) | FlatType::RecursiveTagUnion(_, tags, ext) => {
+                    let mut has_no_tags = true;
+                    for (_tag, vars) in tags.unsorted_iterator(subs, *ext) {
+                        has_no_tags = false;
+                        stack.extend(vars);
+                    }
+                    if has_no_tags {
+                        return false;
+                    }
+                }
+                FlatType::FunctionOrTagUnion(_, _, _) => {}
+                FlatType::Erroneous(_) => {}
+                FlatType::EmptyRecord => {}
+                FlatType::EmptyTagUnion => {
+                    return false;
+                }
+            },
+            Content::Alias(name, _, var, _) if name.module_id() == ModuleId::NUM => {},
+            Content::Alias(_, _, var, _) => stack.push(*var),
+            Content::RangedNumber(_) => {}
+            Content::Error => {}
+        }
+    }
+
+    true
+}
+
 fn convert_tag(subs: &Subs, whole_var: Variable, this_tag: &TagName) -> (Union, TagId) {
     let content = subs.get_content_without_compacting(whole_var);
 
@@ -385,6 +446,13 @@ fn convert_tag(subs: &Subs, whole_var: Variable, this_tag: &TagName) -> (Union, 
             let alternatives_iter = sorted_tags.into_iter().chain(opt_openness_tag.into_iter());
 
             for (index, (tag, args)) in alternatives_iter.enumerate() {
+                let is_inhabited = args.iter().all(|v| is_inhabited(subs, *v));
+
+                if !is_inhabited {
+                    // This constructor is not material; we don't need to match over it!
+                    continue;
+                }
+
                 let tag_id = TagId(index as TagIdIntType);
                 if this_tag == &tag {
                     my_tag_id = tag_id;

--- a/crates/compiler/can/src/exhaustive.rs
+++ b/crates/compiler/can/src/exhaustive.rs
@@ -405,7 +405,7 @@ fn is_inhabited(subs: &Subs, var: Variable) -> bool {
                     return false;
                 }
             },
-            Content::Alias(name, _, var, _) if name.module_id() == ModuleId::NUM => {},
+            Content::Alias(name, _, _, _) if name.module_id() == ModuleId::NUM => {},
             Content::Alias(_, _, var, _) => stack.push(*var),
             Content::RangedNumber(_) => {}
             Content::Error => {}

--- a/crates/compiler/exhaustive/src/lib.rs
+++ b/crates/compiler/exhaustive/src/lib.rs
@@ -92,7 +92,14 @@ pub enum Error {
         overall_region: Region,
         branch_region: Region,
         index: HumanIndex,
+        reason: RedundantReason,
     },
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum RedundantReason {
+    PreviouslyCovered,
+    Uninhabited,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/crates/compiler/exhaustive/src/lib.rs
+++ b/crates/compiler/exhaustive/src/lib.rs
@@ -92,14 +92,12 @@ pub enum Error {
         overall_region: Region,
         branch_region: Region,
         index: HumanIndex,
-        reason: RedundantReason,
     },
-}
-
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub enum RedundantReason {
-    PreviouslyCovered,
-    Uninhabited,
+    Unmatchable {
+        overall_region: Region,
+        branch_region: Region,
+        index: HumanIndex,
+    },
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/crates/compiler/solve/tests/solve_expr.rs
+++ b/crates/compiler/solve/tests/solve_expr.rs
@@ -4275,7 +4275,7 @@ mod solve_expr {
                             x
                 "#
             ),
-            "[Empty, Foo Bar I64]",
+            "[Empty, Foo [Bar] I64]",
         );
     }
 
@@ -7788,7 +7788,7 @@ mod solve_expr {
                     Ok s -> s
                 "#
             ),
-            "",
+            "Str",
         );
     }
 }

--- a/crates/compiler/solve/tests/solve_expr.rs
+++ b/crates/compiler/solve/tests/solve_expr.rs
@@ -7775,4 +7775,20 @@ mod solve_expr {
             "{}",
         );
     }
+
+    #[test]
+    fn match_on_result_with_uninhabited_error_branch() {
+        infer_eq_without_problem(
+            indoc!(
+                r#"
+                x : Result Str []
+                x = Ok "abc"
+
+                when x is
+                    Ok s -> s
+                "#
+            ),
+            "",
+        );
+    }
 }

--- a/crates/compiler/test_gen/src/gen_tags.rs
+++ b/crates/compiler/test_gen/src/gen_tags.rs
@@ -1064,12 +1064,8 @@ fn result_never() {
                 res : Result I64 []
                 res = Ok 4
 
-                # we should provide this in the stdlib
-                never : [] -> a
-
                 when res is
                     Ok v -> v
-                    Err empty -> never empty
                 #"
         ),
         4,
@@ -1987,6 +1983,24 @@ fn fit_recursive_union_in_struct_into_recursive_pointer() {
             "#
         ),
         RocStr::from("abcdefgh"),
+        RocStr
+    );
+}
+
+#[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
+fn match_on_result_with_uninhabited_error_branch() {
+    assert_evals_to!(
+        indoc!(
+            r#"
+            x : Result Str []
+            x = Ok "abc"
+
+            when x is
+                Ok s -> s
+            "#
+        ),
+        RocStr::from("abc"),
         RocStr
     );
 }

--- a/crates/compiler/test_mono/generated/match_on_result_with_uninhabited_error_branch.txt
+++ b/crates/compiler/test_mono/generated/match_on_result_with_uninhabited_error_branch.txt
@@ -1,0 +1,7 @@
+procedure Test.0 ():
+    let Test.5 : Str = "abc";
+    let Test.1 : [C [], C Str] = TagId(1) Test.5;
+    let Test.3 : Str = UnionAtIndex (Id 1) (Index 0) Test.1;
+    inc Test.3;
+    dec Test.1;
+    ret Test.3;

--- a/crates/compiler/test_mono/src/tests.rs
+++ b/crates/compiler/test_mono/src/tests.rs
@@ -1936,3 +1936,16 @@ fn num_width_gt_u8_layout_as_float() {
         "#
     )
 }
+
+#[mono_test]
+fn match_on_result_with_uninhabited_error_branch() {
+    indoc!(
+        r#"
+        x : Result Str []
+        x = Ok "abc"
+
+        when x is
+            Ok s -> s
+        "#
+    )
+}

--- a/crates/compiler/types/src/subs.rs
+++ b/crates/compiler/types/src/subs.rs
@@ -5444,12 +5444,16 @@ fn is_inhabited(subs: &Subs, var: Variable) -> bool {
                     }
                 }
                 FlatType::TagUnion(tags, ext) | FlatType::RecursiveTagUnion(_, tags, ext) => {
-                    let mut has_no_tags = true;
+                    let mut is_uninhabited = true;
+                    // If any tag is inhabited, the union is inhabited!
                     for (_tag, vars) in tags.unsorted_iterator(subs, *ext) {
-                        has_no_tags = false;
-                        stack.extend(vars);
+                        // Sadly we must recurse here...
+                        let this_tag_is_inhabited = vars.iter().all(|v| is_inhabited(subs, *v));
+                        if this_tag_is_inhabited {
+                            is_uninhabited = false;
+                        }
                     }
-                    if has_no_tags {
+                    if is_uninhabited {
                         return false;
                     }
                 }

--- a/crates/compiler/types/src/subs.rs
+++ b/crates/compiler/types/src/subs.rs
@@ -6,7 +6,7 @@ use roc_collections::all::{FnvMap, ImMap, ImSet, MutSet, SendMap};
 use roc_collections::{VecMap, VecSet};
 use roc_error_macros::internal_error;
 use roc_module::ident::{Lowercase, TagName, Uppercase};
-use roc_module::symbol::Symbol;
+use roc_module::symbol::{ModuleId, Symbol};
 use std::fmt;
 use std::iter::{once, Iterator, Map};
 
@@ -2116,6 +2116,11 @@ impl Subs {
                 utable.root_key_without_compacting(*cand_var) == root_var
             })
             .flat_map(|(_, lambda_set_vars)| lambda_set_vars.into_iter())
+    }
+
+    /// Returns true iff the given type is inhabited by at least one value.
+    pub fn is_inhabited(&self, var: Variable) -> bool {
+        is_inhabited(self, var)
     }
 }
 
@@ -5405,4 +5410,62 @@ pub fn get_member_lambda_sets_at_region(subs: &Subs, var: Variable, target_regio
     }
 
     internal_error!("No lambda set at region {} found", target_region);
+}
+
+/// Returns true iff the given type is inhabited by at least one value.
+fn is_inhabited(subs: &Subs, var: Variable) -> bool {
+    let mut stack = vec![var];
+    while let Some(var) = stack.pop() {
+        match subs.get_content_without_compacting(var) {
+            Content::FlexVar(_)
+            | Content::RigidVar(_)
+            | Content::FlexAbleVar(_, _)
+            | Content::RigidAbleVar(_, _)
+            // We don't need to look into recursion vars here, because if they show up in this
+            // position, they *must* belong to an inhabited type. That's because
+            //   - if the recursion var was inferred from a value, then we know there is a value of
+            //     the given type.
+            //   - if the recursion var comes from an explicit annotation, then it must be an a tag
+            //     union of the form `Rec : [ R1 Rec, R2 Rec, ..., Rn Rec ]`. However, such annotations
+            //     are determined as illegal and reported during canonicalization, because you
+            //     cannot have a tag union without a non-recursive variant.
+            | Content::RecursionVar { .. } => {}
+            Content::LambdaSet(_) => {}
+            Content::Structure(structure) => match structure {
+                FlatType::Apply(_, args) => stack.extend(subs.get_subs_slice(*args)),
+                FlatType::Func(args, _, ret) => {
+                    stack.extend(subs.get_subs_slice(*args));
+                    stack.push(*ret);
+                }
+                FlatType::Record(fields, ext) => {
+                    if let Ok(iter) = fields.unsorted_iterator(subs, *ext) {
+                        let field_vars = iter.map(|(_, field)| *field.as_inner());
+                        stack.extend(field_vars)
+                    }
+                }
+                FlatType::TagUnion(tags, ext) | FlatType::RecursiveTagUnion(_, tags, ext) => {
+                    let mut has_no_tags = true;
+                    for (_tag, vars) in tags.unsorted_iterator(subs, *ext) {
+                        has_no_tags = false;
+                        stack.extend(vars);
+                    }
+                    if has_no_tags {
+                        return false;
+                    }
+                }
+                FlatType::FunctionOrTagUnion(_, _, _) => {}
+                FlatType::Erroneous(_) => {}
+                FlatType::EmptyRecord => {}
+                FlatType::EmptyTagUnion => {
+                    return false;
+                }
+            },
+            Content::Alias(name, _, _, _) if name.module_id() == ModuleId::NUM => {},
+            Content::Alias(_, _, var, _) => stack.push(*var),
+            Content::RangedNumber(_) => {}
+            Content::Error => {}
+        }
+    }
+
+    true
 }

--- a/crates/reporting/src/error/type.rs
+++ b/crates/reporting/src/error/type.rs
@@ -3889,6 +3889,7 @@ fn exhaustive_problem<'a>(
             overall_region,
             branch_region,
             index,
+            reason: _,
         } => {
             let doc = alloc.stack([
                 alloc.concat([

--- a/crates/reporting/src/error/type.rs
+++ b/crates/reporting/src/error/type.rs
@@ -3889,7 +3889,6 @@ fn exhaustive_problem<'a>(
             overall_region,
             branch_region,
             index,
-            reason: _,
         } => {
             let doc = alloc.stack([
                 alloc.concat([
@@ -3910,6 +3909,34 @@ fn exhaustive_problem<'a>(
             Report {
                 filename,
                 title: "REDUNDANT PATTERN".to_string(),
+                doc,
+                severity: Severity::Warning,
+            }
+        }
+        Unmatchable {
+            overall_region,
+            branch_region,
+            index,
+        } => {
+            let doc = alloc.stack([
+                alloc.concat([
+                    alloc.reflow("The "),
+                    alloc.string(index.ordinal()),
+                    alloc.reflow(" pattern will never be matched:"),
+                ]),
+                alloc.region_with_subregion(
+                    lines.convert_region(overall_region),
+                    lines.convert_region(branch_region),
+                ),
+                alloc.reflow(
+                    "It's impossible to create a value of this shape, \
+                so this pattern can be safely removed!",
+                ),
+            ]);
+
+            Report {
+                filename,
+                title: "UNMATCHABLE PATTERN".to_string(),
                 doc,
                 severity: Severity::Warning,
             }

--- a/crates/reporting/tests/test_reporting.rs
+++ b/crates/reporting/tests/test_reporting.rs
@@ -10611,17 +10611,17 @@ All branches in an `if` must have the same type!
             "#
         ),
     @r###"
-    ── REDUNDANT PATTERN ───────────────────────────────────── /code/proj/Main.roc ─
-    
-    The 2nd pattern is redundant:
-    
+    ── UNMATCHABLE PATTERN ─────────────────────────────────── /code/proj/Main.roc ─
+
+    The 2nd pattern will never be matched:
+
     6│      when x is
     7│          Ok {} -> ""
     8│          Err _ -> ""
                 ^^^^^
-    
-    Any value of this shape will be handled by a previous pattern, so this
-    one should be removed.
+
+    It's impossible to create a value of this shape, so this pattern can
+    be safely removed!
     "###
     );
 
@@ -10638,21 +10638,21 @@ All branches in an `if` must have the same type!
             "#
         ),
     @r###"
-    ── REDUNDANT PATTERN ───────────────────────────────────── /code/proj/Main.roc ─
+    ── UNMATCHABLE PATTERN ─────────────────────────────────── /code/proj/Main.roc ─
 
-    The 2nd pattern is redundant:
+    The 2nd pattern will never be matched:
 
     6│       when x is
     7│           Ok (Ok {}) -> ""
     8│>          Ok (Err _) -> ""
     9│           Err _ -> ""
 
-    Any value of this shape will be handled by a previous pattern, so this
-    one should be removed.
+    It's impossible to create a value of this shape, so this pattern can
+    be safely removed!
 
-    ── REDUNDANT PATTERN ───────────────────────────────────── /code/proj/Main.roc ─
+    ── UNMATCHABLE PATTERN ─────────────────────────────────── /code/proj/Main.roc ─
 
-    The 3rd pattern is redundant:
+    The 3rd pattern will never be matched:
 
     6│      when x is
     7│          Ok (Ok {}) -> ""
@@ -10660,8 +10660,8 @@ All branches in an `if` must have the same type!
     9│          Err _ -> ""
                 ^^^^^
 
-    Any value of this shape will be handled by a previous pattern, so this
-    one should be removed.
+    It's impossible to create a value of this shape, so this pattern can
+    be safely removed!
     "###
     );
 }

--- a/crates/reporting/tests/test_reporting.rs
+++ b/crates/reporting/tests/test_reporting.rs
@@ -10545,7 +10545,57 @@ All branches in an `if` must have the same type!
                 Ok {} -> ""
             "#
         ),
+    // no problem!
     @r###"
+    "###
+    );
+
+    test_report!(
+        uninhabited_type_is_trivially_exhaustive_nested,
+        indoc!(
+            r#"
+            x : Result (Result [A, B] []) []
+
+            when x is
+                Ok (Ok A) -> ""
+                Ok (Ok B) -> ""
+            "#
+        ),
+    // no problem!
+    @r###"
+    "###
+    );
+
+    test_report!(
+        #[ignore = "TODO https://github.com/roc-lang/roc/issues/4068"]
+        branch_patterns_missing_nested_case,
+        indoc!(
+            r#"
+            x : Result (Result [A, B] {}) {}
+
+            when x is
+                Ok (Ok A) -> ""
+                Err _ -> ""
+            "#
+        ),
+    @r###"
+    TODO
+    "###
+    );
+
+    test_report!(
+        #[ignore = "TODO https://github.com/roc-lang/roc/issues/4068"]
+        branch_patterns_missing_nested_case_with_trivially_exhausted_variant,
+        indoc!(
+            r#"
+            x : Result (Result [A, B] []) []
+
+            when x is
+                Ok (Ok A) -> ""
+            "#
+        ),
+    @r###"
+    TODO
     "###
     );
 
@@ -10570,6 +10620,46 @@ All branches in an `if` must have the same type!
     8│          Err _ -> ""
                 ^^^^^
     
+    Any value of this shape will be handled by a previous pattern, so this
+    one should be removed.
+    "###
+    );
+
+    test_report!(
+        uninhabited_err_branch_is_redundant_when_err_is_matched_nested,
+        indoc!(
+            r#"
+            x : Result (Result {} []) []
+
+            when x is
+                Ok (Ok {}) -> ""
+                Ok (Err _) -> ""
+                Err _ -> ""
+            "#
+        ),
+    @r###"
+    ── REDUNDANT PATTERN ───────────────────────────────────── /code/proj/Main.roc ─
+
+    The 2nd pattern is redundant:
+
+    6│       when x is
+    7│           Ok (Ok {}) -> ""
+    8│>          Ok (Err _) -> ""
+    9│           Err _ -> ""
+
+    Any value of this shape will be handled by a previous pattern, so this
+    one should be removed.
+
+    ── REDUNDANT PATTERN ───────────────────────────────────── /code/proj/Main.roc ─
+
+    The 2nd pattern is redundant:
+
+    6│      when x is
+    7│          Ok (Ok {}) -> ""
+    8│          Ok (Err _) -> ""
+    9│          Err _ -> ""
+                ^^^^^
+
     Any value of this shape will be handled by a previous pattern, so this
     one should be removed.
     "###

--- a/crates/reporting/tests/test_reporting.rs
+++ b/crates/reporting/tests/test_reporting.rs
@@ -10652,7 +10652,7 @@ All branches in an `if` must have the same type!
 
     ── REDUNDANT PATTERN ───────────────────────────────────── /code/proj/Main.roc ─
 
-    The 2nd pattern is redundant:
+    The 3rd pattern is redundant:
 
     6│      when x is
     7│          Ok (Ok {}) -> ""

--- a/crates/reporting/tests/test_reporting.rs
+++ b/crates/reporting/tests/test_reporting.rs
@@ -10534,4 +10534,18 @@ All branches in an `if` must have the same type!
      Maybe you wanted to use a `Result`?
      "###
     );
+
+    test_report!(
+        uninhabited_type_is_trivially_exhaustive,
+        indoc!(
+            r#"
+            x : Result {} []
+
+            when x is
+                Ok {} -> ""
+            "#
+        ),
+    @r###"
+    "###
+    );
 }

--- a/crates/reporting/tests/test_reporting.rs
+++ b/crates/reporting/tests/test_reporting.rs
@@ -10548,4 +10548,30 @@ All branches in an `if` must have the same type!
     @r###"
     "###
     );
+
+    test_report!(
+        uninhabited_err_branch_is_redundant_when_err_is_matched,
+        indoc!(
+            r#"
+            x : Result {} []
+
+            when x is
+                Ok {} -> ""
+                Err _ -> ""
+            "#
+        ),
+    @r###"
+    ── REDUNDANT PATTERN ───────────────────────────────────── /code/proj/Main.roc ─
+    
+    The 2nd pattern is redundant:
+    
+    6│      when x is
+    7│          Ok {} -> ""
+    8│          Err _ -> ""
+                ^^^^^
+    
+    Any value of this shape will be handled by a previous pattern, so this
+    one should be removed.
+    "###
+    );
 }


### PR DESCRIPTION
This PR makes it so that programs like

```
x : Result Str []
x = Ok "bluetrapese"

when x is
  Ok s -> s
```

Now typecheck and compile, when previously they would yield an error that the `Err _` branch is not covered. In situations like the above, the `Err _` branch need not be covered, because that branch has an uninhabitable constructor - since the type of `x` is `[Ok Str, Err []]`, only values of constructor `Ok` can ever be created!

Closes #4054