### PR TITLE
Unwrap layouts containing void layouts as newtypes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3892,6 +3892,7 @@ dependencies = [
 name = "roc_mono"
 version = "0.0.1"
 dependencies = [
+ "bitvec 1.0.1",
  "bumpalo",
  "hashbrown 0.12.3",
  "roc_builtins",

--- a/crates/compiler/builtins/roc/List.roc
+++ b/crates/compiler/builtins/roc/List.roc
@@ -393,11 +393,11 @@ contains = \list, needle ->
 ## `fold`, `foldLeft`, or `foldl`.
 walk : List elem, state, (state, elem -> state) -> state
 walk = \list, state, func ->
+    walkHelp : _, _ -> [Continue _, Break []]
     walkHelp = \currentState, element -> Continue (func currentState element)
 
     when List.iterate list state walkHelp is
         Continue newState -> newState
-        Break void -> List.unreachable void
 
 ## Note that in other languages, `walkBackwards` is sometimes called `reduceRight`,
 ## `fold`, `foldRight`, or `foldr`.
@@ -1006,6 +1006,3 @@ iterBackwardsHelp = \list, state, f, prevIndex ->
             Break b -> Break b
     else
         Continue state
-
-## useful for typechecking guaranteed-unreachable cases
-unreachable : [] -> a

--- a/crates/compiler/mono/Cargo.toml
+++ b/crates/compiler/mono/Cargo.toml
@@ -27,3 +27,4 @@ ven_pretty = { path = "../../vendor/pretty" }
 bumpalo = { version = "3.11.0", features = ["collections"] }
 hashbrown = { version = "0.12.3", features = [ "bumpalo" ] }
 static_assertions = "1.1.0"
+bitvec = "1.0.1"

--- a/crates/compiler/mono/src/decision_tree.rs
+++ b/crates/compiler/mono/src/decision_tree.rs
@@ -4,6 +4,7 @@ use crate::ir::{
 use crate::layout::{Builtin, Layout, LayoutCache, TagIdIntType, UnionLayout};
 use roc_builtins::bitcode::{FloatWidth, IntWidth};
 use roc_collections::all::{MutMap, MutSet};
+use roc_error_macros::internal_error;
 use roc_exhaustive::{Ctor, CtorName, RenderAs, TagId, Union};
 use roc_module::ident::TagName;
 use roc_module::low_level::LowLevel;
@@ -577,6 +578,8 @@ fn test_at_path<'a>(
                     arguments: arguments.to_vec(),
                 },
 
+                Voided { .. } => internal_error!("unreachable"),
+
                 OpaqueUnwrap { opaque, argument } => {
                     let union = Union {
                         render_as: RenderAs::Tag,
@@ -875,6 +878,7 @@ fn to_relevant_branch_help<'a>(
                 _ => None,
             }
         }
+        Voided { .. } => internal_error!("unreachable"),
         StrLiteral(string) => match test {
             IsStr(test_str) if string == *test_str => {
                 start.extend(end);
@@ -1018,6 +1022,8 @@ fn needs_tests(pattern: &Pattern) -> bool {
         | FloatLiteral(_, _)
         | DecimalLiteral(_)
         | StrLiteral(_) => true,
+
+        Voided { .. } => internal_error!("unreachable"),
     }
 }
 

--- a/crates/compiler/mono/src/ir.rs
+++ b/crates/compiler/mono/src/ir.rs
@@ -5781,6 +5781,41 @@ fn convert_tag_union<'a>(
             let iter = field_symbols_temp.into_iter().map(|(_, _, data)| data);
             assign_to_symbols(env, procs, layout_cache, iter, stmt)
         }
+        NewtypeByVoid {
+            data_tag_arguments: field_layouts,
+            data_tag_name,
+            ..
+        } => {
+            let dataful_tag = data_tag_name.expect_tag();
+
+            if dataful_tag != tag_name {
+                // this tag is not represented, and hence will never be reached, at runtime.
+                Stmt::RuntimeError("voided tag constructor is unreachable")
+            } else {
+                let field_symbols_temp = sorted_field_symbols(env, procs, layout_cache, args);
+
+                let mut field_symbols = Vec::with_capacity_in(field_layouts.len(), env.arena);
+                field_symbols.extend(field_symbols_temp.iter().map(|r| r.1));
+                let field_symbols = field_symbols.into_bump_slice();
+
+                // Layout will unpack this unwrapped tack if it only has one (non-zero-sized) field
+                let layout = layout_cache
+                    .from_var(env.arena, variant_var, env.subs)
+                    .unwrap_or_else(|err| panic!("TODO turn fn_var into a RuntimeError {:?}", err));
+
+                // even though this was originally a Tag, we treat it as a Struct from now on
+                let stmt = if let [only_field] = field_symbols {
+                    let mut hole = hole.clone();
+                    substitute_in_exprs(env.arena, &mut hole, assigned, *only_field);
+                    hole
+                } else {
+                    Stmt::Let(assigned, Expr::Struct(field_symbols), layout, hole)
+                };
+
+                let iter = field_symbols_temp.into_iter().map(|(_, _, data)| data);
+                assign_to_symbols(env, procs, layout_cache, iter, stmt)
+            }
+        }
         Wrapped(variant) => {
             let (tag_id, _) = variant.tag_name_to_id(&tag_name);
 
@@ -6520,7 +6555,11 @@ fn from_can_when<'a>(
     let arena = env.arena;
     let it = opt_branches
         .into_iter()
-        .map(|(pattern, opt_guard, can_expr)| {
+        .filter_map(|(pattern, opt_guard, can_expr)| {
+            if pattern.is_voided() {
+                return None;
+            }
+
             let branch_stmt = match join_point {
                 None => from_can(env, expr_var, can_expr, procs, layout_cache),
                 Some(id) => {
@@ -6548,7 +6587,7 @@ fn from_can_when<'a>(
                     jump,
                 );
 
-                (
+                Some((
                     pattern.clone(),
                     Guard::Guard {
                         id,
@@ -6556,9 +6595,9 @@ fn from_can_when<'a>(
                         stmt: guard_stmt,
                     },
                     branch_stmt,
-                )
+                ))
             } else {
-                (pattern, Guard::NoGuard, branch_stmt)
+                Some((pattern, Guard::NoGuard, branch_stmt))
             }
         });
     let mono_branches = Vec::from_iter_in(it, arena);
@@ -7085,6 +7124,10 @@ fn store_pattern_help<'a>(
                 stmt,
             );
         }
+        Voided { .. } => {
+            return StorePattern::NotProductive(stmt);
+        }
+
         OpaqueUnwrap { argument, .. } => {
             let (pattern, _layout) = &**argument;
             return store_pattern_help(env, procs, layout_cache, pattern, outer_symbol, stmt);
@@ -8676,10 +8719,54 @@ pub enum Pattern<'a> {
         layout: UnionLayout<'a>,
         union: roc_exhaustive::Union,
     },
+    Voided {
+        tag_name: TagName,
+    },
     OpaqueUnwrap {
         opaque: Symbol,
         argument: Box<(Pattern<'a>, Layout<'a>)>,
     },
+}
+
+impl<'a> Pattern<'a> {
+    /// This pattern contains a pattern match on Void (i.e. [], the empty tag union)
+    /// such branches are not reachable at runtime
+    pub fn is_voided(&self) -> bool {
+        let mut stack: std::vec::Vec<&Pattern> = vec![self];
+
+        while let Some(pattern) = stack.pop() {
+            match pattern {
+                Pattern::Identifier(_)
+                | Pattern::Underscore
+                | Pattern::IntLiteral(_, _)
+                | Pattern::FloatLiteral(_, _)
+                | Pattern::DecimalLiteral(_)
+                | Pattern::BitLiteral { .. }
+                | Pattern::EnumLiteral { .. }
+                | Pattern::StrLiteral(_) => { /* terminal */ }
+                Pattern::RecordDestructure(destructs, _) => {
+                    for destruct in destructs {
+                        match &destruct.typ {
+                            DestructType::Required(_) => { /* do nothing */ }
+                            DestructType::Guard(pattern) => {
+                                stack.push(pattern);
+                            }
+                        }
+                    }
+                }
+                Pattern::NewtypeDestructure { arguments, .. } => {
+                    stack.extend(arguments.iter().map(|(t, _)| t))
+                }
+                Pattern::Voided { .. } => return true,
+                Pattern::AppliedTag { arguments, .. } => {
+                    stack.extend(arguments.iter().map(|(t, _)| t))
+                }
+                Pattern::OpaqueUnwrap { argument, .. } => stack.push(&argument.0),
+            }
+        }
+
+        false
+    }
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -8907,6 +8994,57 @@ fn from_can_pattern_help<'a>(
                         arguments: mono_args,
                     }
                 }
+                NewtypeByVoid {
+                    data_tag_arguments,
+                    data_tag_name,
+                    ..
+                } => {
+                    let data_tag_name = data_tag_name.expect_tag();
+
+                    if tag_name != &data_tag_name {
+                        // this tag is not represented at runtime
+                        Pattern::Voided {
+                            tag_name: tag_name.clone(),
+                        }
+                    } else {
+                        let mut arguments = arguments.clone();
+
+                        arguments.sort_by(|arg1, arg2| {
+                            let size1 = layout_cache
+                                .from_var(env.arena, arg1.0, env.subs)
+                                .map(|x| x.alignment_bytes(&layout_cache.interner, env.target_info))
+                                .unwrap_or(0);
+
+                            let size2 = layout_cache
+                                .from_var(env.arena, arg2.0, env.subs)
+                                .map(|x| x.alignment_bytes(&layout_cache.interner, env.target_info))
+                                .unwrap_or(0);
+
+                            size2.cmp(&size1)
+                        });
+
+                        let mut mono_args = Vec::with_capacity_in(arguments.len(), env.arena);
+                        let it = arguments.iter().zip(data_tag_arguments.iter());
+                        for ((_, loc_pat), layout) in it {
+                            mono_args.push((
+                                from_can_pattern_help(
+                                    env,
+                                    procs,
+                                    layout_cache,
+                                    &loc_pat.value,
+                                    assignments,
+                                )?,
+                                *layout,
+                            ));
+                        }
+
+                        Pattern::NewtypeDestructure {
+                            tag_name: tag_name.clone(),
+                            arguments: mono_args,
+                        }
+                    }
+                }
+
                 Wrapped(variant) => {
                     let (tag_id, argument_layouts) = variant.tag_name_to_id(tag_name);
                     let number_of_tags = variant.number_of_tags();

--- a/crates/compiler/mono/src/ir.rs
+++ b/crates/compiler/mono/src/ir.rs
@@ -5731,7 +5731,7 @@ fn convert_tag_union<'a>(
             "The `[]` type has no constructors, source var {:?}",
             variant_var
         ),
-        Unit | UnitWithArguments => Stmt::Let(assigned, Expr::Struct(&[]), Layout::UNIT, hole),
+        Unit => Stmt::Let(assigned, Expr::Struct(&[]), Layout::UNIT, hole),
         BoolUnion { ttrue, .. } => Stmt::Let(
             assigned,
             Expr::Literal(Literal::Bool(&tag_name == ttrue.expect_tag_ref())),
@@ -8808,7 +8808,7 @@ fn from_can_pattern_help<'a>(
                     "there is no pattern of type `[]`, union var {:?}",
                     *whole_var
                 ),
-                Unit | UnitWithArguments => Pattern::EnumLiteral {
+                Unit => Pattern::EnumLiteral {
                     tag_id: 0,
                     tag_name: tag_name.clone(),
                     union: Union {

--- a/crates/compiler/test_gen/src/gen_list.rs
+++ b/crates/compiler/test_gen/src/gen_list.rs
@@ -262,8 +262,9 @@ fn list_map_try_ok() {
         r#"
             List.mapTry [1, 2, 3] \elem -> Ok elem
         "#,
-        RocResult::ok(RocList::<i64>::from_slice(&[1, 2, 3])),
-        RocResult<RocList<i64>, ()>
+        // Result I64 [] is unwrapped to just I64
+        RocList::<i64>::from_slice(&[1, 2, 3]),
+        RocList<i64>
     );
     assert_evals_to!(
         // Transformation
@@ -273,12 +274,13 @@ fn list_map_try_ok() {
 
                 Ok "\(str)!"
         "#,
-        RocResult::ok(RocList::<RocStr>::from_slice(&[
+        // Result Str [] is unwrapped to just Str
+        RocList::<RocStr>::from_slice(&[
             RocStr::from("2!"),
             RocStr::from("4!"),
             RocStr::from("6!"),
-        ])),
-        RocResult<RocList<RocStr>, ()>
+        ]),
+        RocList<RocStr>
     );
 }
 

--- a/crates/compiler/test_gen/src/gen_list.rs
+++ b/crates/compiler/test_gen/src/gen_list.rs
@@ -3006,8 +3006,10 @@ fn list_find_empty_layout() {
             List.findFirst [] \_ -> True
             "#
         ),
-        RocResult::err(()),
-        RocResult<(), ()>
+        // [Ok [], Err [NotFound]] gets unwrapped all the way to just [NotFound],
+        // which is the unit!
+        (),
+        ()
     );
 
     assert_evals_to!(
@@ -3016,8 +3018,10 @@ fn list_find_empty_layout() {
             List.findLast [] \_ -> True
             "#
         ),
-        RocResult::err(()),
-        RocResult<(), ()>
+        // [Ok [], Err [NotFound]] gets unwrapped all the way to just [NotFound],
+        // which is the unit!
+        (),
+        ()
     );
 }
 

--- a/crates/compiler/test_mono/generated/match_on_result_with_uninhabited_error_branch.txt
+++ b/crates/compiler/test_mono/generated/match_on_result_with_uninhabited_error_branch.txt
@@ -1,7 +1,3 @@
 procedure Test.0 ():
     let Test.5 : Str = "abc";
-    let Test.1 : [C [], C Str] = TagId(1) Test.5;
-    let Test.3 : Str = UnionAtIndex (Id 1) (Index 0) Test.1;
-    inc Test.3;
-    dec Test.1;
-    ret Test.3;
+    ret Test.5;

--- a/crates/compiler/test_mono/generated/unreachable_branch_is_eliminated_but_produces_lambda_specializations.txt
+++ b/crates/compiler/test_mono/generated/unreachable_branch_is_eliminated_but_produces_lambda_specializations.txt
@@ -1,0 +1,29 @@
+procedure Test.1 (Test.2):
+    let Test.3 : Int1 = false;
+    ret Test.3;
+
+procedure Test.3 (Test.13):
+    let Test.15 : Str = "t1";
+    ret Test.15;
+
+procedure Test.4 (Test.16):
+    let Test.18 : Str = "t2";
+    ret Test.18;
+
+procedure Test.0 ():
+    let Test.19 : Str = "abc";
+    let Test.6 : Int1 = CallByName Test.1 Test.19;
+    dec Test.19;
+    let Test.9 : {} = Struct {};
+    joinpoint Test.10 Test.8:
+        ret Test.8;
+    in
+    switch Test.6:
+        case 0:
+            let Test.11 : Str = CallByName Test.3 Test.9;
+            jump Test.10 Test.11;
+    
+        default:
+            let Test.12 : Str = CallByName Test.4 Test.9;
+            jump Test.10 Test.12;
+    

--- a/crates/compiler/test_mono/generated/unreachable_void_constructor.txt
+++ b/crates/compiler/test_mono/generated/unreachable_void_constructor.txt
@@ -1,0 +1,7 @@
+procedure Test.0 ():
+    let Test.7 : Int1 = true;
+    if Test.7 then
+        Error voided tag constructor is unreachable
+    else
+        let Test.6 : Str = "abc";
+        ret Test.6;

--- a/crates/compiler/test_mono/src/tests.rs
+++ b/crates/compiler/test_mono/src/tests.rs
@@ -1949,3 +1949,16 @@ fn match_on_result_with_uninhabited_error_branch() {
         "#
     )
 }
+
+#[mono_test]
+fn unreachable_void_constructor() {
+    indoc!(
+        r#"
+        app "test" provides [main] to "./platform"
+
+        x : []
+
+        main = if True then Ok x else Err "abc" 
+        "#
+    )
+}

--- a/examples/benchmarks/platform/host.zig
+++ b/examples/benchmarks/platform/host.zig
@@ -88,7 +88,8 @@ export fn roc_memset(dst: [*]u8, value: i32, size: usize) callconv(.C) void {
 const Unit = extern struct {};
 
 pub export fn main() callconv(.C) u8 {
-    const size = @intCast(usize, roc__mainForHost_size());
+    // The size might be zero; if so, make it at least 8 so that we don't have a nullptr
+    const size = std.math.max(@intCast(usize, roc__mainForHost_size()), 8);
     const raw_output = roc_alloc(@intCast(usize, size), @alignOf(u64)).?;
     var output = @ptrCast([*]u8, raw_output);
 
@@ -120,7 +121,8 @@ fn to_seconds(tms: std.os.timespec) f64 {
 fn call_the_closure(closure_data_pointer: [*]u8) void {
     const allocator = std.heap.page_allocator;
 
-    const size = roc__mainForHost_1__Fx_result_size();
+    // The size might be zero; if so, make it at least 8 so that we don't have a nullptr
+    const size = std.math.max(roc__mainForHost_1__Fx_result_size(), 8);
     const raw_output = allocator.allocAdvanced(u8, @alignOf(u64), @intCast(usize, size), .at_least) catch unreachable;
     var output = @ptrCast([*]u8, raw_output);
 


### PR DESCRIPTION
With this, we now eliminate layouts like `[Ok Str, Err []]` to exactly `Str` at runtime. So now zero-size tags are zero-cost.

Addresses the attempt to do so in https://github.com/roc-lang/roc/pull/3465

Blocked on #4073 