### PR TITLE
Fix benchmarks

### DIFF
--- a/ci/bench-runner/src/main.rs
+++ b/ci/bench-runner/src/main.rs
@@ -227,7 +227,7 @@ fn calc_hashes_for_folder(benches_path_str: &str) -> HashMap<String, String> {
 }
 
 fn check_if_bench_executables_changed() -> bool {
-    let bench_folder_str = "/crates/cli_testing_examples/benchmarks/";
+    let bench_folder_str = "/examples/benchmarks/";
 
     let main_benches_path_str = [BENCH_FOLDER_MAIN, bench_folder_str].join("");
     let main_bench_hashes = calc_hashes_for_folder(&main_benches_path_str);

--- a/ci/bench-runner/src/main.rs
+++ b/ci/bench-runner/src/main.rs
@@ -227,7 +227,7 @@ fn calc_hashes_for_folder(benches_path_str: &str) -> HashMap<String, String> {
 }
 
 fn check_if_bench_executables_changed() -> bool {
-    let bench_folder_str = "/examples/benchmarks/";
+    let bench_folder_str = "/crates/cli_testing_examples/benchmarks/";
 
     let main_benches_path_str = [BENCH_FOLDER_MAIN, bench_folder_str].join("");
     let main_bench_hashes = calc_hashes_for_folder(&main_benches_path_str);

--- a/crates/cli_utils/src/bench_utils.rs
+++ b/crates/cli_utils/src/bench_utils.rs
@@ -18,7 +18,7 @@ fn exec_bench_w_input<T: Measurement>(
         &[stdin_str],
     );
 
-    if !compile_out.stderr.is_empty() {
+    if !compile_out.stderr.is_empty() && compile_out.stderr != "🔨 Rebuilding platform...\n" {
         panic!("{}", compile_out.stderr);
     }
 


### PR DESCRIPTION
The "🔨 Rebuilding platform...\n" message was recently modified to be sent to stderr so we can no longer just check if stderr was empty.