### PR TITLE
Advertise larger Roc project ideas in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,19 @@
 
 We are committed to providing a friendly, safe and welcoming environment for all. Make sure to take a look at the [Code of Conduct](CodeOfConduct.md)!
 
+## How to contribute
+
+All contributions are appreciated! Typo fixes, bug fixes, feature requests,
+bug reports are all helpful for the project.
+
+If you are looking for a good place to start, consider reaching out on the `#contributing` channel on [Roc Zulip][roc-zulip].
+Before making your first pull request, definitely talk to an existing contributor on [Roc Zulip][roc-zulip] first about what you plan to do! This can not only avoid duplicated effort, it can also avoid making a whole PR only to discover it won't be accepted because the change doesn't fit with the goals of the language's design or implementation.
+
+If you are interested in larger, implementation- or research-heavy projects
+related to Roc, check out [Roc Project Ideas][project-ideas] and reach out to us
+on Zulip! These projects may be suitable for academic theses, independent
+research, or even just valuable projects to learn from and improve Roc with.
+
 ## Building from Source
 
 Check [Building from source](BUILDING_FROM_SOURCE.md) for instructions.
@@ -24,8 +37,7 @@ Execute `cargo fmt --all` to fix the formatting.
 
 - If you've never made a pull request on github before, [this](https://www.freecodecamp.org/news/how-to-make-your-first-pull-request-on-github-3/) will be a good place to start.
 - Create an issue if the purpose of a struct/field/type/function/... is not immediately clear from its name or nearby comments.
-- You can find good first issues [here](https://github.com/roc-lang/roc/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22).
-- Before making your first pull request, definitely talk to an existing contributor on [Roc Zulip](https://roc.zulipchat.com) first about what you plan to do! This can not only avoid duplicated effort, it can also avoid making a whole PR only to discover it won't be accepted because the change doesn't fit with the goals of the language's design or implementation.
+- You can find good first issues [here][good-first-issues].
 - [Fork](https://github.com/roc-lang/roc/fork) the repo so that you can apply your changes first on your own copy of the roc repo.
 - It's a good idea to open a draft pull request as you begin working on something. This way, others can see that you're working on it, which avoids duplicate effort, and others can give feedback sooner rather than later if they notice a problem in the direction things are going. Click the button "ready for review" when it's ready.
 - All your commits need to be signed to prevent impersonation:
@@ -41,3 +53,7 @@ Execute `cargo fmt --all` to fix the formatting.
 ## Can we do better?
 
 Feel free to open an issue if you think this document can be improved or is unclear in any way.
+
+[roc-zulip]: https://roc.zulipchat.com
+[good-first-issues]: https://github.com/roc-lang/roc/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22
+[project-ideas]: https://docs.google.com/document/d/1mMaxIi7vxyUyNAUCs98d68jYj6C9Fpq4JIZRU735Kwg/edit?usp=sharing

--- a/getting_started/README.md
+++ b/getting_started/README.md
@@ -44,3 +44,8 @@ been able to find beginner-friendly projects to get people up to speed gradually
 
 If you're interested in getting involved, check out
 [CONTRIBUTING.md](https://github.com/roc-lang/roc/blob/main/CONTRIBUTING.md)!
+
+If you're interested in substantial implementation- or research-heavy projects
+related to Roc, check out [Roc Project Ideas][project-ideas]!
+
+[project-ideas]: https://docs.google.com/document/d/1mMaxIi7vxyUyNAUCs98d68jYj6C9Fpq4JIZRU735Kwg/edit?usp=sharing


### PR DESCRIPTION
This document summarizes larger implementation- or research-heavy projects that may be suitable for someone who wants to contribute to Roc via a self-contained project. Most of these projects are expected to require sustained effort, which also makes them possibly suitable for academic theses.

Feel free to message me on Zulip to get edit rights to the document!