### PR TITLE
Properly import builtin modules in platforms

### DIFF
--- a/crates/compiler/load_internal/src/file.rs
+++ b/crates/compiler/load_internal/src/file.rs
@@ -3911,14 +3911,21 @@ fn send_header_two<'a>(
         // Also build a list of imported_values_to_expose (like `bar` above.)
         for (qualified_module_name, exposed_idents, region) in imported.into_iter() {
             let cloned_module_name = qualified_module_name.module.clone();
-            let pq_module_name = match qualified_module_name.opt_package {
-                None => match opt_shorthand {
-                    Some(shorthand) => {
-                        PQModuleName::Qualified(shorthand, qualified_module_name.module)
-                    }
-                    None => PQModuleName::Unqualified(qualified_module_name.module),
-                },
-                Some(package) => PQModuleName::Qualified(package, cloned_module_name),
+            let pq_module_name = if qualified_module_name.is_builtin() {
+                // If this is a builtin, it must be unqualified, and we should *never* prefix it
+                // with the package shorthand! The user intended to import the module as-is here.
+                debug_assert!(qualified_module_name.opt_package.is_none());
+                PQModuleName::Unqualified(qualified_module_name.module)
+            } else {
+                match qualified_module_name.opt_package {
+                    None => match opt_shorthand {
+                        Some(shorthand) => {
+                            PQModuleName::Qualified(shorthand, qualified_module_name.module)
+                        }
+                        None => PQModuleName::Unqualified(qualified_module_name.module),
+                    },
+                    Some(package) => PQModuleName::Qualified(package, cloned_module_name),
+                }
             };
 
             let module_id = module_ids.get_or_insert(&pq_module_name);

--- a/crates/compiler/load_internal/tests/test_load.rs
+++ b/crates/compiler/load_internal/tests/test_load.rs
@@ -872,3 +872,40 @@ fn issue_2863_module_type_does_not_exist() {
         Ok(_) => unreachable!("we expect failure here"),
     }
 }
+
+#[test]
+fn import_builtin_in_platform_and_check_app() {
+    let modules = vec![
+        (
+            "platform/main.roc",
+            indoc!(
+                r#"
+                    platform "testplatform"
+                        requires {} { main : Str }
+                        exposes []
+                        packages {}
+                        imports [Str]
+                        provides [mainForHost]
+
+                    mainForHost : Str
+                    mainForHost = main
+                    "#
+            ),
+        ),
+        (
+            "Main",
+            indoc!(
+                r#"
+                    app "test"
+                        packages { pf: "platform/main.roc" }
+                        provides [main] to pf
+
+                    main = ""
+                    "#
+            ),
+        ),
+    ];
+
+    let result = multiple_modules("issue_2863_module_type_does_not_exist", modules);
+    assert!(result.is_ok(), "should check");
+}

--- a/crates/compiler/module/src/symbol.rs
+++ b/crates/compiler/module/src/symbol.rs
@@ -796,6 +796,12 @@ macro_rules! define_builtins {
         )+
         num_modules: $total:literal
     } => {
+        impl<'a> super::ident::QualifiedModuleName<'a> {
+            pub fn is_builtin(&self) -> bool {
+                self.opt_package.is_none() && ($($module_name == self.module.as_str() ||)+ false)
+            }
+        }
+
         impl IdentIds {
             pub fn exposed_builtins(extra_capacity: usize) -> IdentIdsByModule {
                 let mut exposed_idents_by_module = VecMap::with_capacity(extra_capacity + $total);


### PR DESCRIPTION
Previously, all unqualified modules imported in a platform would be prefixed with the platform shorthand. This is incorrect for builtins, which should always resolve to the builtin module unless they have an explicit namespace.

Closes #4084

Note: the linked #4084 mentions other issues that I'll break out into separate issues and patches. The changes are related but different in their sources, so I want to unblock folks with this patch, and address the other problems OOB.