### PR TITLE
Import Encode/Decode modules, and their types, in all scopes

### DIFF
--- a/crates/compiler/load_internal/src/file.rs
+++ b/crates/compiler/load_internal/src/file.rs
@@ -124,6 +124,14 @@ const MODULE_ENCODE_TYPES: &[(&str, Symbol)] = &[
     ("EncoderFormatting", Symbol::ENCODE_ENCODERFORMATTING),
 ];
 
+const MODULE_DECODE_TYPES: &[(&str, Symbol)] = &[
+    ("DecodeError", Symbol::DECODE_DECODE_ERROR),
+    ("DecodeResult", Symbol::DECODE_DECODE_RESULT),
+    ("Decoder", Symbol::DECODE_DECODER_OPAQUE),
+    ("Decoding", Symbol::DECODE_DECODING),
+    ("DecoderFormatting", Symbol::DECODE_DECODERFORMATTING),
+];
+
 macro_rules! log {
     ($($arg:tt)*) => (dbg_do!(ROC_PRINT_LOAD_LOG, println!($($arg)*)))
 }
@@ -2249,6 +2257,7 @@ fn update<'a>(
                     .imported_modules
                     .insert(ModuleId::LIST, Region::zero());
 
+                // ENCODE
                 header
                     .package_qualified_imported_modules
                     .insert(PackageQualified::Unqualified(ModuleId::ENCODE));
@@ -2258,6 +2267,21 @@ fn update<'a>(
                     .insert(ModuleId::ENCODE, Region::zero());
 
                 for (type_name, symbol) in MODULE_ENCODE_TYPES {
+                    header
+                        .exposed_imports
+                        .insert(Ident::from(*type_name), (*symbol, Region::zero()));
+                }
+
+                // DECODE
+                header
+                    .package_qualified_imported_modules
+                    .insert(PackageQualified::Unqualified(ModuleId::DECODE));
+
+                header
+                    .imported_modules
+                    .insert(ModuleId::DECODE, Region::zero());
+
+                for (type_name, symbol) in MODULE_DECODE_TYPES {
                     header
                         .exposed_imports
                         .insert(Ident::from(*type_name), (*symbol, Region::zero()));

--- a/crates/compiler/load_internal/src/file.rs
+++ b/crates/compiler/load_internal/src/file.rs
@@ -3911,14 +3911,21 @@ fn send_header_two<'a>(
         // Also build a list of imported_values_to_expose (like `bar` above.)
         for (qualified_module_name, exposed_idents, region) in imported.into_iter() {
             let cloned_module_name = qualified_module_name.module.clone();
-            let pq_module_name = match qualified_module_name.opt_package {
-                None => match opt_shorthand {
-                    Some(shorthand) => {
-                        PQModuleName::Qualified(shorthand, qualified_module_name.module)
-                    }
-                    None => PQModuleName::Unqualified(qualified_module_name.module),
-                },
-                Some(package) => PQModuleName::Qualified(package, cloned_module_name),
+            let pq_module_name = if qualified_module_name.is_builtin() {
+                // If this is a builtin, it must be unqualified, and we should *never* prefix it
+                // with the package shorthand! The user intended to import the module as-is here.
+                debug_assert!(qualified_module_name.opt_package.is_none());
+                PQModuleName::Unqualified(qualified_module_name.module)
+            } else {
+                match qualified_module_name.opt_package {
+                    None => match opt_shorthand {
+                        Some(shorthand) => {
+                            PQModuleName::Qualified(shorthand, qualified_module_name.module)
+                        }
+                        None => PQModuleName::Unqualified(qualified_module_name.module),
+                    },
+                    Some(package) => PQModuleName::Qualified(package, cloned_module_name),
+                }
             };
 
             let module_id = module_ids.get_or_insert(&pq_module_name);

--- a/crates/compiler/load_internal/src/file.rs
+++ b/crates/compiler/load_internal/src/file.rs
@@ -80,6 +80,8 @@ const MODULE_SEPARATOR: char = '.';
 
 const EXPANDED_STACK_SIZE: usize = 8 * 1024 * 1024;
 
+/// TODO: how can we populate these at compile/runtime from the standard library?
+/// Consider updating the macro in symbol to do this?
 const PRELUDE_TYPES: [(&str, Symbol); 33] = [
     ("Num", Symbol::NUM_NUM),
     ("Int", Symbol::NUM_INT),
@@ -114,6 +116,12 @@ const PRELUDE_TYPES: [(&str, Symbol); 33] = [
     ("F32", Symbol::NUM_F32),
     ("F64", Symbol::NUM_F64),
     ("Dec", Symbol::NUM_DEC),
+];
+
+const MODULE_ENCODE_TYPES: &[(&str, Symbol)] = &[
+    ("Encoder", Symbol::ENCODE_ENCODER),
+    ("Encoding", Symbol::ENCODE_ENCODING),
+    ("EncoderFormatting", Symbol::ENCODE_ENCODERFORMATTING),
 ];
 
 macro_rules! log {
@@ -2248,6 +2256,12 @@ fn update<'a>(
                 header
                     .imported_modules
                     .insert(ModuleId::ENCODE, Region::zero());
+
+                for (type_name, symbol) in MODULE_ENCODE_TYPES {
+                    header
+                        .exposed_imports
+                        .insert(Ident::from(*type_name), (*symbol, Region::zero()));
+                }
             }
 
             state

--- a/crates/compiler/load_internal/tests/test_load.rs
+++ b/crates/compiler/load_internal/tests/test_load.rs
@@ -872,3 +872,40 @@ fn issue_2863_module_type_does_not_exist() {
         Ok(_) => unreachable!("we expect failure here"),
     }
 }
+
+#[test]
+fn import_builtin_in_platform_and_check_app() {
+    let modules = vec![
+        (
+            "platform/main.roc",
+            indoc!(
+                r#"
+                    platform "testplatform"
+                        requires {} { main : Str }
+                        exposes []
+                        packages {}
+                        imports [Str]
+                        provides [mainForHost]
+
+                    mainForHost : Str
+                    mainForHost = main
+                    "#
+            ),
+        ),
+        (
+            "Main",
+            indoc!(
+                r#"
+                    app "test"
+                        packages { pf: "platform/main.roc" }
+                        provides [main] to pf
+
+                    main = ""
+                    "#
+            ),
+        ),
+    ];
+
+    let result = multiple_modules("issue_2863_module_type_does_not_exist", modules);
+    assert!(result.is_ok(), "should check");
+}

--- a/crates/compiler/load_internal/tests/test_load.rs
+++ b/crates/compiler/load_internal/tests/test_load.rs
@@ -861,10 +861,10 @@ fn issue_2863_module_type_does_not_exist() {
 
                         Did you mean one of these?
 
+                            Decoding
                             Result
                             Dict
-                            List
-                            Box
+                            DecodeError
                         "
                       )
                 )

--- a/crates/compiler/module/src/symbol.rs
+++ b/crates/compiler/module/src/symbol.rs
@@ -796,6 +796,12 @@ macro_rules! define_builtins {
         )+
         num_modules: $total:literal
     } => {
+        impl<'a> super::ident::QualifiedModuleName<'a> {
+            pub fn is_builtin(&self) -> bool {
+                self.opt_package.is_none() && ($($module_name == self.module.as_str() ||)+ false)
+            }
+        }
+
         impl IdentIds {
             pub fn exposed_builtins(extra_capacity: usize) -> IdentIdsByModule {
                 let mut exposed_idents_by_module = VecMap::with_capacity(extra_capacity + $total);

--- a/crates/compiler/solve/tests/solve_expr.rs
+++ b/crates/compiler/solve/tests/solve_expr.rs
@@ -6330,14 +6330,14 @@ mod solve_expr {
                 r#"
                 app "test" provides [zeroEncoder] to "./platform"
 
-                Encoder fmt := List U8, fmt -> List U8 | fmt has Format
+                MEncoder fmt := List U8, fmt -> List U8 | fmt has Format
 
                 Format has it : fmt -> {} | fmt has Format
 
-                zeroEncoder = @Encoder \lst, _ -> lst
+                zeroEncoder = @MEncoder \lst, _ -> lst
                 "#
             ),
-            "Encoder a | a has Format",
+            "MEncoder a | a has Format",
         )
     }
 
@@ -6348,27 +6348,27 @@ mod solve_expr {
                 r#"
                 app "test" provides [myU8Bytes] to "./platform"
 
-                Encoder fmt := List U8, fmt -> List U8 | fmt has Format
+                MEncoder fmt := List U8, fmt -> List U8 | fmt has Format
 
-                Encoding has
-                  toEncoder : val -> Encoder fmt | val has Encoding, fmt has Format
+                MEncoding has
+                  toEncoder : val -> MEncoder fmt | val has MEncoding, fmt has Format
 
                 Format has
-                  u8 : U8 -> Encoder fmt | fmt has Format
+                  u8 : U8 -> MEncoder fmt | fmt has Format
 
-                appendWith : List U8, Encoder fmt, fmt -> List U8 | fmt has Format
-                appendWith = \lst, (@Encoder doFormat), fmt -> doFormat lst fmt
+                appendWith : List U8, MEncoder fmt, fmt -> List U8 | fmt has Format
+                appendWith = \lst, (@MEncoder doFormat), fmt -> doFormat lst fmt
 
-                toBytes : val, fmt -> List U8 | val has Encoding, fmt has Format
+                toBytes : val, fmt -> List U8 | val has MEncoding, fmt has Format
                 toBytes = \val, fmt -> appendWith [] (toEncoder val) fmt
 
 
                 Linear := {} has [Format {u8}]
 
-                u8 = \n -> @Encoder (\lst, @Linear {} -> List.append lst n)
+                u8 = \n -> @MEncoder (\lst, @Linear {} -> List.append lst n)
                 #^^{-1}
 
-                MyU8 := U8 has [Encoding {toEncoder}]
+                MyU8 := U8 has [MEncoding {toEncoder}]
 
                 toEncoder = \@MyU8 n -> u8 n
                 #^^^^^^^^^{-1}
@@ -6378,8 +6378,8 @@ mod solve_expr {
                 "#
             ),
             @r###"
-        Linear#u8(10) : U8 -[[u8(10)]]-> Encoder Linear
-        MyU8#toEncoder(11) : MyU8 -[[toEncoder(11)]]-> Encoder fmt | fmt has Format
+        Linear#u8(10) : U8 -[[u8(10)]]-> MEncoder Linear
+        MyU8#toEncoder(11) : MyU8 -[[toEncoder(11)]]-> MEncoder fmt | fmt has Format
         myU8Bytes : List U8
         "###
         )
@@ -6537,7 +6537,7 @@ mod solve_expr {
             indoc!(
                 r#"
                 app "test"
-                    imports [Encode.{ toEncoder, Encoding, custom }]
+                    imports [Encode.{ toEncoder, custom }]
                     provides [main] to "./platform"
 
                 A := {} has [Encoding {toEncoder}]

--- a/crates/compiler/solve/tests/solve_expr.rs
+++ b/crates/compiler/solve/tests/solve_expr.rs
@@ -6494,7 +6494,7 @@ mod solve_expr {
             indoc!(
                 r#"
                 app "test"
-                    imports [Encode.{ Encoding, toEncoder }, Json]
+                    imports [Json]
                     provides [main] to "./platform"
 
                 HelloWorld := {} has [Encoding {toEncoder}]

--- a/crates/compiler/solve/tests/solve_expr.rs
+++ b/crates/compiler/solve/tests/solve_expr.rs
@@ -6392,21 +6392,21 @@ mod solve_expr {
                 r#"
                 app "test" provides [myU8] to "./platform"
 
-                DecodeError : [TooShort, Leftover (List U8)]
+                MDecodeError : [TooShort, Leftover (List U8)]
 
-                Decoder val fmt := List U8, fmt -> { result: Result val DecodeError, rest: List U8 } | fmt has DecoderFormatting
+                MDecoder val fmt := List U8, fmt -> { result: Result val MDecodeError, rest: List U8 } | fmt has MDecoderFormatting
 
-                Decoding has
-                    decoder : Decoder val fmt | val has Decoding, fmt has DecoderFormatting
+                MDecoding has
+                    decoder : MDecoder val fmt | val has MDecoding, fmt has MDecoderFormatting
 
-                DecoderFormatting has
-                    u8 : Decoder U8 fmt | fmt has DecoderFormatting
+                MDecoderFormatting has
+                    u8 : MDecoder U8 fmt | fmt has MDecoderFormatting
 
-                decodeWith : List U8, Decoder val fmt, fmt -> { result: Result val DecodeError, rest: List U8 } | fmt has DecoderFormatting
-                decodeWith = \lst, (@Decoder doDecode), fmt -> doDecode lst fmt
+                decodeWith : List U8, MDecoder val fmt, fmt -> { result: Result val MDecodeError, rest: List U8 } | fmt has MDecoderFormatting
+                decodeWith = \lst, (@MDecoder doDecode), fmt -> doDecode lst fmt
 
-                fromBytes : List U8, fmt -> Result val DecodeError
-                            | fmt has DecoderFormatting, val has Decoding
+                fromBytes : List U8, fmt -> Result val MDecodeError
+                            | fmt has MDecoderFormatting, val has MDecoding
                 fromBytes = \lst, fmt ->
                     when decodeWith lst decoder fmt is
                         { result, rest } ->
@@ -6415,17 +6415,17 @@ mod solve_expr {
                                 Err e -> Err e
 
 
-                Linear := {} has [DecoderFormatting {u8}]
+                Linear := {} has [MDecoderFormatting {u8}]
 
-                u8 = @Decoder \lst, @Linear {} ->
+                u8 = @MDecoder \lst, @Linear {} ->
                 #^^{-1}
                         when List.first lst is
                             Ok n -> { result: Ok n, rest: List.dropFirst lst }
                             Err _ -> { result: Err TooShort, rest: [] }
 
-                MyU8 := U8 has [Decoding {decoder}]
+                MyU8 := U8 has [MDecoding {decoder}]
 
-                decoder = @Decoder \lst, fmt ->
+                decoder = @MDecoder \lst, fmt ->
                 #^^^^^^^{-1}
                     when decodeWith lst u8 fmt is
                         { result, rest } ->
@@ -6436,11 +6436,11 @@ mod solve_expr {
                 #^^^^{-1}
                 "#
             ),
-            @r#"
-            Linear#u8(11) : Decoder U8 Linear
-            MyU8#decoder(12) : Decoder MyU8 fmt | fmt has DecoderFormatting
-            myU8 : Result MyU8 DecodeError
-            "#
+            @r###"
+        Linear#u8(11) : MDecoder U8 Linear
+        MyU8#decoder(12) : MDecoder MyU8 fmt | fmt has MDecoderFormatting
+        myU8 : Result MyU8 MDecodeError
+        "###
         )
     }
 

--- a/crates/compiler/test_gen/src/gen_abilities.rs
+++ b/crates/compiler/test_gen/src/gen_abilities.rs
@@ -227,29 +227,29 @@ fn encode() {
             r#"
             app "test" provides [myU8Bytes] to "./platform"
 
-            Encoder fmt := List U8, fmt -> List U8 | fmt has Format
+            MEncoder fmt := List U8, fmt -> List U8 | fmt has Format
 
-            Encoding has
-              toEncoder : val -> Encoder fmt | val has Encoding, fmt has Format
+            MEncoding has
+              toEncoder : val -> MEncoder fmt | val has MEncoding, fmt has Format
 
             Format has
-              u8 : U8 -> Encoder fmt | fmt has Format
+              u8 : U8 -> MEncoder fmt | fmt has Format
 
-            appendWith : List U8, Encoder fmt, fmt -> List U8 | fmt has Format
-            appendWith = \lst, (@Encoder doFormat), fmt -> doFormat lst fmt
+            appendWith : List U8, MEncoder fmt, fmt -> List U8 | fmt has Format
+            appendWith = \lst, (@MEncoder doFormat), fmt -> doFormat lst fmt
 
-            toBytes : val, fmt -> List U8 | val has Encoding, fmt has Format
+            toBytes : val, fmt -> List U8 | val has MEncoding, fmt has Format
             toBytes = \val, fmt -> appendWith [] (toEncoder val) fmt
 
 
             Linear := {} has [Format {u8}]
 
-            u8 = \n -> @Encoder (\lst, @Linear {} -> List.append lst n)
+            u8 = \n -> @MEncoder (\lst, @Linear {} -> List.append lst n)
 
-            Rgba := { r : U8, g : U8, b : U8, a : U8 } has [Encoding {toEncoder}]
+            Rgba := { r : U8, g : U8, b : U8, a : U8 } has [MEncoding {toEncoder}]
 
             toEncoder = \@Rgba {r, g, b, a} ->
-                @Encoder \lst, fmt -> lst
+                @MEncoder \lst, fmt -> lst
                     |> appendWith (u8 r) fmt
                     |> appendWith (u8 g) fmt
                     |> appendWith (u8 b) fmt
@@ -328,7 +328,7 @@ fn encode_use_stdlib() {
         indoc!(
             r#"
             app "test"
-                imports [Encode.{ Encoding, toEncoder }, Json]
+                imports [Encode.{ toEncoder }, Json]
                 provides [main] to "./platform"
 
             HelloWorld := {} has [Encoding {toEncoder}]
@@ -356,7 +356,7 @@ fn encode_use_stdlib_without_wrapping_custom() {
         indoc!(
             r#"
             app "test"
-                imports [Encode.{ Encoding, toEncoder }, Json]
+                imports [Encode.{ toEncoder }, Json]
                 provides [main] to "./platform"
 
             HelloWorld := {} has [Encoding {toEncoder}]
@@ -381,7 +381,7 @@ fn to_encoder_encode_custom_has_capture() {
         indoc!(
             r#"
             app "test"
-                imports [Encode.{ Encoding, toEncoder }, Json]
+                imports [Encode.{ toEncoder }, Json]
                 provides [main] to "./platform"
 
             HelloWorld := Str has [Encoding {toEncoder}]
@@ -915,7 +915,7 @@ fn encode_then_decode_list_of_strings() {
     assert_evals_to!(
         indoc!(
             r#"
-            app "test" imports [Encode, Decode, Json] provides [main] to "./platform"
+            app "test" imports [Decode, Json] provides [main] to "./platform"
 
             main =
                 when Encode.toBytes ["a", "b", "c"] Json.fromUtf8 |> Decode.fromBytes Json.fromUtf8 is
@@ -935,7 +935,7 @@ fn encode_then_decode_list_of_lists_of_strings() {
     assert_evals_to!(
         indoc!(
             r#"
-            app "test" imports [Encode, Decode, Json] provides [main] to "./platform"
+            app "test" imports [Decode, Json] provides [main] to "./platform"
 
             main =
                 when Encode.toBytes [["a", "b"], ["c", "d", "e"], ["f"]] Json.fromUtf8 |> Decode.fromBytes Json.fromUtf8 is
@@ -957,7 +957,7 @@ fn decode_record_two_fields() {
     assert_evals_to!(
         indoc!(
             r#"
-            app "test" imports [Encode, Decode, Json] provides [main] to "./platform"
+            app "test" imports [Decode, Json] provides [main] to "./platform"
 
             main =
                 when Str.toUtf8 "{\"first\":\"ab\",\"second\":\"cd\"}" |> Decode.fromBytes Json.fromUtf8 is
@@ -979,7 +979,7 @@ fn decode_record_two_fields_string_and_int() {
     assert_evals_to!(
         indoc!(
             r#"
-            app "test" imports [Encode, Decode, Json] provides [main] to "./platform"
+            app "test" imports [Decode, Json] provides [main] to "./platform"
 
             main =
                 when Str.toUtf8 "{\"first\":\"ab\",\"second\":10}" |> Decode.fromBytes Json.fromUtf8 is
@@ -1001,7 +1001,7 @@ fn decode_record_two_fields_string_and_string_infer() {
     assert_evals_to!(
         indoc!(
             r#"
-            app "test" imports [Encode, Decode, Json] provides [main] to "./platform"
+            app "test" imports [Decode, Json] provides [main] to "./platform"
 
             main =
                 when Str.toUtf8 "{\"first\":\"ab\",\"second\":\"cd\"}" |> Decode.fromBytes Json.fromUtf8 is
@@ -1067,7 +1067,7 @@ fn decode_empty_record() {
     assert_evals_to!(
         indoc!(
             r#"
-            app "test" imports [Encode, Decode, Json] provides [main] to "./platform"
+            app "test" imports [Decode, Json] provides [main] to "./platform"
 
             main =
                 when Str.toUtf8 "{}" |> Decode.fromBytes Json.fromUtf8 is
@@ -1090,7 +1090,7 @@ fn decode_record_of_record() {
     assert_evals_to!(
         indoc!(
             r#"
-            app "test" imports [Encode, Decode, Json] provides [main] to "./platform"
+            app "test" imports [Decode, Json] provides [main] to "./platform"
 
             main =
                 when Str.toUtf8 "{\"outer\":{\"inner\":\"a\"},\"other\":{\"one\":\"b\",\"two\":10}}" |> Decode.fromBytes Json.fromUtf8 is

--- a/crates/compiler/test_gen/src/gen_abilities.rs
+++ b/crates/compiler/test_gen/src/gen_abilities.rs
@@ -272,21 +272,21 @@ fn decode() {
             r#"
             app "test" provides [myU8] to "./platform"
 
-            DecodeError : [TooShort, Leftover (List U8)]
+            MDecodeError : [TooShort, Leftover (List U8)]
 
-            Decoder val fmt := List U8, fmt -> { result: Result val DecodeError, rest: List U8 } | fmt has DecoderFormatting
+            MDecoder val fmt := List U8, fmt -> { result: Result val MDecodeError, rest: List U8 } | fmt has MDecoderFormatting
 
-            Decoding has
-                decoder : Decoder val fmt | val has Decoding, fmt has DecoderFormatting
+            MDecoding has
+                decoder : MDecoder val fmt | val has MDecoding, fmt has MDecoderFormatting
 
-            DecoderFormatting has
-                u8 : Decoder U8 fmt | fmt has DecoderFormatting
+            MDecoderFormatting has
+                u8 : MDecoder U8 fmt | fmt has MDecoderFormatting
 
-            decodeWith : List U8, Decoder val fmt, fmt -> { result: Result val DecodeError, rest: List U8 } | fmt has DecoderFormatting
-            decodeWith = \lst, (@Decoder doDecode), fmt -> doDecode lst fmt
+            decodeWith : List U8, MDecoder val fmt, fmt -> { result: Result val MDecodeError, rest: List U8 } | fmt has MDecoderFormatting
+            decodeWith = \lst, (@MDecoder doDecode), fmt -> doDecode lst fmt
 
-            fromBytes : List U8, fmt -> Result val DecodeError
-                        | fmt has DecoderFormatting, val has Decoding
+            fromBytes : List U8, fmt -> Result val MDecodeError
+                        | fmt has MDecoderFormatting, val has MDecoding
             fromBytes = \lst, fmt ->
                 when decodeWith lst decoder fmt is
                     { result, rest } ->
@@ -296,17 +296,17 @@ fn decode() {
                             else Err (Leftover rest)
 
 
-            Linear := {} has [DecoderFormatting {u8}]
+            Linear := {} has [MDecoderFormatting {u8}]
 
-            u8 = @Decoder \lst, @Linear {} ->
+            u8 = @MDecoder \lst, @Linear {} ->
                     when List.first lst is
                         Ok n -> { result: Ok n, rest: List.dropFirst lst }
                         Err _ -> { result: Err TooShort, rest: [] }
 
-            MyU8 := U8 has [Decoding {decoder}]
+            MyU8 := U8 has [MDecoding {decoder}]
 
-            # impl Decoding for MyU8
-            decoder = @Decoder \lst, fmt ->
+            # impl MDecoding for MyU8
+            decoder = @MDecoder \lst, fmt ->
                 { result, rest } = decodeWith lst u8 fmt
                 { result: Result.map result (\n -> @MyU8 n), rest }
 
@@ -743,7 +743,7 @@ fn decode_use_stdlib() {
         indoc!(
             r#"
             app "test"
-                imports [Decode.{ Decoding }, Json]
+                imports [Json]
                 provides [main] to "./platform"
 
             MyNum := U8 has [Decoding {decoder: myDecoder}]
@@ -774,7 +774,7 @@ fn decode_use_stdlib_json_list() {
         indoc!(
             r#"
             app "test"
-                imports [Decode.{ Decoding }, Json]
+                imports [Json]
                 provides [main] to "./platform"
 
             MyNumList := List U8 has [Decoding {decoder: myDecoder}]
@@ -817,7 +817,7 @@ mod decode_immediate {
         assert_evals_to!(
             indoc!(
                 r#"
-                app "test" imports [Decode, Json] provides [main] to "./platform"
+                app "test" imports [Json] provides [main] to "./platform"
 
                 main =
                     when Str.toUtf8 "\"foo\"" |> Decode.fromBytes Json.fromUtf8 is
@@ -838,7 +838,7 @@ mod decode_immediate {
                 assert_evals_to!(
                     &format!(indoc!(
                         r#"
-                        app "test" imports [Decode, Json] provides [main] to "./platform"
+                        app "test" imports [Json] provides [main] to "./platform"
 
                         main =
                             when Num.toStr {}{} |> Str.toUtf8 |> Decode.fromBytes Json.fromUtf8 is
@@ -876,7 +876,7 @@ mod decode_immediate {
         assert_evals_to!(
             indoc!(
                 r#"
-                app "test" imports [Decode, Json] provides [main] to "./platform"
+                app "test" imports [Json] provides [main] to "./platform"
 
                 main =
                     when Num.toStr 17.23dec |> Str.toUtf8 |> Decode.fromBytes Json.fromUtf8 is
@@ -896,7 +896,7 @@ fn decode_list_of_strings() {
     assert_evals_to!(
         indoc!(
             r#"
-            app "test" imports [Decode, Json] provides [main] to "./platform"
+            app "test" imports [Json] provides [main] to "./platform"
 
             main =
                 when Str.toUtf8 "[\"a\",\"b\",\"c\"]" |> Decode.fromBytes Json.fromUtf8 is
@@ -915,7 +915,7 @@ fn encode_then_decode_list_of_strings() {
     assert_evals_to!(
         indoc!(
             r#"
-            app "test" imports [Decode, Json] provides [main] to "./platform"
+            app "test" imports [Json] provides [main] to "./platform"
 
             main =
                 when Encode.toBytes ["a", "b", "c"] Json.fromUtf8 |> Decode.fromBytes Json.fromUtf8 is
@@ -935,7 +935,7 @@ fn encode_then_decode_list_of_lists_of_strings() {
     assert_evals_to!(
         indoc!(
             r#"
-            app "test" imports [Decode, Json] provides [main] to "./platform"
+            app "test" imports [Json] provides [main] to "./platform"
 
             main =
                 when Encode.toBytes [["a", "b"], ["c", "d", "e"], ["f"]] Json.fromUtf8 |> Decode.fromBytes Json.fromUtf8 is
@@ -957,7 +957,7 @@ fn decode_record_two_fields() {
     assert_evals_to!(
         indoc!(
             r#"
-            app "test" imports [Decode, Json] provides [main] to "./platform"
+            app "test" imports [Json] provides [main] to "./platform"
 
             main =
                 when Str.toUtf8 "{\"first\":\"ab\",\"second\":\"cd\"}" |> Decode.fromBytes Json.fromUtf8 is
@@ -979,7 +979,7 @@ fn decode_record_two_fields_string_and_int() {
     assert_evals_to!(
         indoc!(
             r#"
-            app "test" imports [Decode, Json] provides [main] to "./platform"
+            app "test" imports [Json] provides [main] to "./platform"
 
             main =
                 when Str.toUtf8 "{\"first\":\"ab\",\"second\":10}" |> Decode.fromBytes Json.fromUtf8 is
@@ -1001,7 +1001,7 @@ fn decode_record_two_fields_string_and_string_infer() {
     assert_evals_to!(
         indoc!(
             r#"
-            app "test" imports [Decode, Json] provides [main] to "./platform"
+            app "test" imports [Json] provides [main] to "./platform"
 
             main =
                 when Str.toUtf8 "{\"first\":\"ab\",\"second\":\"cd\"}" |> Decode.fromBytes Json.fromUtf8 is
@@ -1023,7 +1023,7 @@ fn decode_record_two_fields_string_and_string_infer_local_var() {
     assert_evals_to!(
         indoc!(
             r#"
-            app "test" imports [Decode, Json] provides [main] to "./platform"
+            app "test" imports [Json] provides [main] to "./platform"
 
             main =
                 decoded = Str.toUtf8 "{\"first\":\"ab\",\"second\":\"cd\"}" |> Decode.fromBytes Json.fromUtf8
@@ -1046,7 +1046,7 @@ fn decode_record_two_fields_string_and_string_infer_local_var_destructured() {
     assert_evals_to!(
         indoc!(
             r#"
-            app "test" imports [Decode, Json] provides [main] to "./platform"
+            app "test" imports [Json] provides [main] to "./platform"
 
             main =
                 decoded = Str.toUtf8 "{\"first\":\"ab\",\"second\":\"cd\"}" |> Decode.fromBytes Json.fromUtf8
@@ -1067,7 +1067,7 @@ fn decode_empty_record() {
     assert_evals_to!(
         indoc!(
             r#"
-            app "test" imports [Decode, Json] provides [main] to "./platform"
+            app "test" imports [Json] provides [main] to "./platform"
 
             main =
                 when Str.toUtf8 "{}" |> Decode.fromBytes Json.fromUtf8 is
@@ -1090,7 +1090,7 @@ fn decode_record_of_record() {
     assert_evals_to!(
         indoc!(
             r#"
-            app "test" imports [Decode, Json] provides [main] to "./platform"
+            app "test" imports [Json] provides [main] to "./platform"
 
             main =
                 when Str.toUtf8 "{\"outer\":{\"inner\":\"a\"},\"other\":{\"one\":\"b\",\"two\":10}}" |> Decode.fromBytes Json.fromUtf8 is

--- a/crates/compiler/test_mono/generated/call_function_in_empty_list.txt
+++ b/crates/compiler/test_mono/generated/call_function_in_empty_list.txt
@@ -1,7 +1,7 @@
 procedure List.5 (#Attr.2, #Attr.3):
-    let List.381 : List {} = lowlevel ListMap { xs: `#Attr.#arg1` } #Attr.2 Test.2 #Attr.3;
+    let List.380 : List {} = lowlevel ListMap { xs: `#Attr.#arg1` } #Attr.2 Test.2 #Attr.3;
     decref #Attr.2;
-    ret List.381;
+    ret List.380;
 
 procedure Test.2 (Test.3):
     let Test.7 : {} = Struct {};

--- a/crates/compiler/test_mono/generated/call_function_in_empty_list_unbound.txt
+++ b/crates/compiler/test_mono/generated/call_function_in_empty_list_unbound.txt
@@ -1,7 +1,7 @@
 procedure List.5 (#Attr.2, #Attr.3):
-    let List.381 : List [] = lowlevel ListMap { xs: `#Attr.#arg1` } #Attr.2 Test.2 #Attr.3;
+    let List.380 : List [] = lowlevel ListMap { xs: `#Attr.#arg1` } #Attr.2 Test.2 #Attr.3;
     decref #Attr.2;
-    ret List.381;
+    ret List.380;
 
 procedure Test.2 (Test.3):
     let Test.7 : {} = Struct {};

--- a/crates/compiler/test_mono/generated/closure_in_list.txt
+++ b/crates/compiler/test_mono/generated/closure_in_list.txt
@@ -1,6 +1,6 @@
 procedure List.6 (#Attr.2):
-    let List.381 : U64 = lowlevel ListLen #Attr.2;
-    ret List.381;
+    let List.380 : U64 = lowlevel ListLen #Attr.2;
+    ret List.380;
 
 procedure Test.1 (Test.5):
     let Test.2 : I64 = 41i64;

--- a/crates/compiler/test_mono/generated/dict.txt
+++ b/crates/compiler/test_mono/generated/dict.txt
@@ -7,8 +7,8 @@ procedure Dict.7 (Dict.94):
     ret Dict.99;
 
 procedure List.6 (#Attr.2):
-    let List.381 : U64 = lowlevel ListLen #Attr.2;
-    ret List.381;
+    let List.380 : U64 = lowlevel ListLen #Attr.2;
+    ret List.380;
 
 procedure Test.0 ():
     let Test.2 : List {[], []} = CallByName Dict.1;

--- a/crates/compiler/test_mono/generated/empty_list_of_function_type.txt
+++ b/crates/compiler/test_mono/generated/empty_list_of_function_type.txt
@@ -3,24 +3,24 @@ procedure Bool.1 ():
     ret Bool.11;
 
 procedure List.2 (List.90, List.91):
-    let List.387 : U64 = CallByName List.6 List.90;
-    let List.383 : Int1 = CallByName Num.22 List.91 List.387;
-    if List.383 then
-        let List.385 : {} = CallByName List.66 List.90 List.91;
-        let List.384 : [C {}, C {}] = TagId(1) List.385;
-        ret List.384;
+    let List.386 : U64 = CallByName List.6 List.90;
+    let List.382 : Int1 = CallByName Num.22 List.91 List.386;
+    if List.382 then
+        let List.384 : {} = CallByName List.66 List.90 List.91;
+        let List.383 : [C {}, C {}] = TagId(1) List.384;
+        ret List.383;
     else
-        let List.382 : {} = Struct {};
-        let List.381 : [C {}, C {}] = TagId(0) List.382;
-        ret List.381;
+        let List.381 : {} = Struct {};
+        let List.380 : [C {}, C {}] = TagId(0) List.381;
+        ret List.380;
 
 procedure List.6 (#Attr.2):
-    let List.388 : U64 = lowlevel ListLen #Attr.2;
-    ret List.388;
+    let List.387 : U64 = lowlevel ListLen #Attr.2;
+    ret List.387;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.386 : {} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.386;
+    let List.385 : {} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.385;
 
 procedure Num.22 (#Attr.2, #Attr.3):
     let Num.257 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/encode.txt
+++ b/crates/compiler/test_mono/generated/encode.txt
@@ -1,16 +1,16 @@
 procedure List.4 (List.101, List.102):
-    let List.384 : U64 = 1i64;
-    let List.382 : List U8 = CallByName List.70 List.101 List.384;
-    let List.381 : List U8 = CallByName List.71 List.382 List.102;
-    ret List.381;
+    let List.383 : U64 = 1i64;
+    let List.381 : List U8 = CallByName List.70 List.101 List.383;
+    let List.380 : List U8 = CallByName List.71 List.381 List.102;
+    ret List.380;
 
 procedure List.70 (#Attr.2, #Attr.3):
-    let List.385 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
-    ret List.385;
+    let List.384 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
+    ret List.384;
 
 procedure List.71 (#Attr.2, #Attr.3):
-    let List.383 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
-    ret List.383;
+    let List.382 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
+    ret List.382;
 
 procedure Test.23 (Test.24, Test.35, Test.22):
     let Test.37 : List U8 = CallByName List.4 Test.24 Test.22;

--- a/crates/compiler/test_mono/generated/encode_derived_nested_record_string.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_nested_record_string.txt
@@ -205,154 +205,98 @@ procedure Json.97 (Json.98, Json.475, Json.96):
     ret Json.477;
 
 procedure List.133 (List.134, List.135, List.132):
-    let List.429 : {List U8, U64} = CallByName Json.115 List.134 List.135;
-    let List.428 : [C [], C {List U8, U64}] = TagId(1) List.429;
-    ret List.428;
+    let List.420 : {List U8, U64} = CallByName Json.115 List.134 List.135;
+    ret List.420;
 
 procedure List.133 (List.134, List.135, List.132):
-    let List.510 : {List U8, U64} = CallByName Json.115 List.134 List.135;
-    let List.509 : [C [], C {List U8, U64}] = TagId(1) List.510;
-    ret List.509;
-
-procedure List.18 (List.130, List.131, List.132):
-    let List.403 : [C [], C {List U8, U64}] = CallByName List.75 List.130 List.131 List.132;
-    let List.407 : U8 = 1i64;
-    let List.408 : U8 = GetTagId List.403;
-    let List.409 : Int1 = lowlevel Eq List.407 List.408;
-    if List.409 then
-        let List.137 : {List U8, U64} = UnionAtIndex (Id 1) (Index 0) List.403;
-        inc List.137;
-        dec List.403;
-        ret List.137;
-    else
-        let List.138 : [] = UnionAtIndex (Id 0) (Index 0) List.403;
-        dec List.403;
-        let List.405 : {List U8, U64} = CallByName List.69 List.138;
-        ret List.405;
-
-procedure List.18 (List.130, List.131, List.132):
-    let List.484 : [C [], C {List U8, U64}] = CallByName List.75 List.130 List.131 List.132;
-    let List.488 : U8 = 1i64;
-    let List.489 : U8 = GetTagId List.484;
-    let List.490 : Int1 = lowlevel Eq List.488 List.489;
-    if List.490 then
-        let List.137 : {List U8, U64} = UnionAtIndex (Id 1) (Index 0) List.484;
-        inc List.137;
-        dec List.484;
-        ret List.137;
-    else
-        let List.138 : [] = UnionAtIndex (Id 0) (Index 0) List.484;
-        dec List.484;
-        let List.486 : {List U8, U64} = CallByName List.69 List.138;
-        ret List.486;
-
-procedure List.4 (List.101, List.102):
-    let List.483 : U64 = 1i64;
-    let List.482 : List U8 = CallByName List.70 List.101 List.483;
-    let List.481 : List U8 = CallByName List.71 List.482 List.102;
-    ret List.481;
-
-procedure List.6 (#Attr.2):
-    let List.381 : U64 = lowlevel ListLen #Attr.2;
-    ret List.381;
-
-procedure List.6 (#Attr.2):
-    let List.431 : U64 = lowlevel ListLen #Attr.2;
-    ret List.431;
-
-procedure List.6 (#Attr.2):
-    let List.513 : U64 = lowlevel ListLen #Attr.2;
-    ret List.513;
-
-procedure List.66 (#Attr.2, #Attr.3):
-    let List.426 : {Str, Str} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.426;
-
-procedure List.66 (#Attr.2, #Attr.3):
-    let List.507 : {Str, Str} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.507;
-
-procedure List.69 (#Attr.2):
-    let List.487 : {List U8, U64} = lowlevel Unreachable #Attr.2;
-    ret List.487;
-
-procedure List.70 (#Attr.2, #Attr.3):
-    let List.462 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
-    ret List.462;
-
-procedure List.71 (#Attr.2, #Attr.3):
-    let List.460 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
-    ret List.460;
-
-procedure List.75 (List.357, List.358, List.359):
-    let List.412 : U64 = 0i64;
-    let List.413 : U64 = CallByName List.6 List.357;
-    let List.411 : [C [], C {List U8, U64}] = CallByName List.86 List.357 List.358 List.359 List.412 List.413;
-    ret List.411;
-
-procedure List.75 (List.357, List.358, List.359):
-    let List.493 : U64 = 0i64;
-    let List.494 : U64 = CallByName List.6 List.357;
-    let List.492 : [C [], C {List U8, U64}] = CallByName List.86 List.357 List.358 List.359 List.493 List.494;
+    let List.492 : {List U8, U64} = CallByName Json.115 List.134 List.135;
     ret List.492;
 
+procedure List.18 (List.130, List.131, List.132):
+    let List.402 : {List U8, U64} = CallByName List.75 List.130 List.131 List.132;
+    ret List.402;
+
+procedure List.18 (List.130, List.131, List.132):
+    let List.474 : {List U8, U64} = CallByName List.75 List.130 List.131 List.132;
+    ret List.474;
+
+procedure List.4 (List.101, List.102):
+    let List.473 : U64 = 1i64;
+    let List.472 : List U8 = CallByName List.70 List.101 List.473;
+    let List.471 : List U8 = CallByName List.71 List.472 List.102;
+    ret List.471;
+
+procedure List.6 (#Attr.2):
+    let List.380 : U64 = lowlevel ListLen #Attr.2;
+    ret List.380;
+
+procedure List.6 (#Attr.2):
+    let List.422 : U64 = lowlevel ListLen #Attr.2;
+    ret List.422;
+
+procedure List.6 (#Attr.2):
+    let List.495 : U64 = lowlevel ListLen #Attr.2;
+    ret List.495;
+
+procedure List.66 (#Attr.2, #Attr.3):
+    let List.417 : {Str, Str} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.417;
+
+procedure List.66 (#Attr.2, #Attr.3):
+    let List.489 : {Str, Str} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.489;
+
+procedure List.70 (#Attr.2, #Attr.3):
+    let List.452 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
+    ret List.452;
+
+procedure List.71 (#Attr.2, #Attr.3):
+    let List.450 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
+    ret List.450;
+
+procedure List.75 (List.356, List.357, List.358):
+    let List.406 : U64 = 0i64;
+    let List.407 : U64 = CallByName List.6 List.356;
+    let List.405 : {List U8, U64} = CallByName List.86 List.356 List.357 List.358 List.406 List.407;
+    ret List.405;
+
+procedure List.75 (List.356, List.357, List.358):
+    let List.478 : U64 = 0i64;
+    let List.479 : U64 = CallByName List.6 List.356;
+    let List.477 : {List U8, U64} = CallByName List.86 List.356 List.357 List.358 List.478 List.479;
+    ret List.477;
+
 procedure List.8 (#Attr.2, #Attr.3):
-    let List.512 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
-    ret List.512;
+    let List.494 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
+    ret List.494;
 
-procedure List.86 (List.442, List.443, List.444, List.445, List.446):
-    joinpoint List.414 List.360 List.361 List.362 List.363 List.364:
-        let List.416 : Int1 = CallByName Num.22 List.363 List.364;
-        if List.416 then
-            let List.425 : {Str, Str} = CallByName List.66 List.360 List.363;
-            let List.417 : [C [], C {List U8, U64}] = CallByName List.133 List.361 List.425 List.362;
-            let List.422 : U8 = 1i64;
-            let List.423 : U8 = GetTagId List.417;
-            let List.424 : Int1 = lowlevel Eq List.422 List.423;
-            if List.424 then
-                let List.365 : {List U8, U64} = UnionAtIndex (Id 1) (Index 0) List.417;
-                inc List.365;
-                dec List.417;
-                let List.420 : U64 = 1i64;
-                let List.419 : U64 = CallByName Num.19 List.363 List.420;
-                jump List.414 List.360 List.365 List.362 List.419 List.364;
-            else
-                let List.366 : [] = UnionAtIndex (Id 0) (Index 0) List.417;
-                dec List.417;
-                let List.421 : [C [], C {List U8, U64}] = TagId(0) List.366;
-                ret List.421;
+procedure List.86 (List.432, List.433, List.434, List.435, List.436):
+    joinpoint List.408 List.359 List.360 List.361 List.362 List.363:
+        let List.410 : Int1 = CallByName Num.22 List.362 List.363;
+        if List.410 then
+            let List.416 : {Str, Str} = CallByName List.66 List.359 List.362;
+            let List.411 : {List U8, U64} = CallByName List.133 List.360 List.416 List.361;
+            let List.414 : U64 = 1i64;
+            let List.413 : U64 = CallByName Num.19 List.362 List.414;
+            jump List.408 List.359 List.411 List.361 List.413 List.363;
         else
-            let List.415 : [C [], C {List U8, U64}] = TagId(1) List.361;
-            ret List.415;
+            ret List.360;
     in
-    jump List.414 List.442 List.443 List.444 List.445 List.446;
+    jump List.408 List.432 List.433 List.434 List.435 List.436;
 
-procedure List.86 (List.524, List.525, List.526, List.527, List.528):
-    joinpoint List.495 List.360 List.361 List.362 List.363 List.364:
-        let List.497 : Int1 = CallByName Num.22 List.363 List.364;
-        if List.497 then
-            let List.506 : {Str, Str} = CallByName List.66 List.360 List.363;
-            let List.498 : [C [], C {List U8, U64}] = CallByName List.133 List.361 List.506 List.362;
-            let List.503 : U8 = 1i64;
-            let List.504 : U8 = GetTagId List.498;
-            let List.505 : Int1 = lowlevel Eq List.503 List.504;
-            if List.505 then
-                let List.365 : {List U8, U64} = UnionAtIndex (Id 1) (Index 0) List.498;
-                inc List.365;
-                dec List.498;
-                let List.501 : U64 = 1i64;
-                let List.500 : U64 = CallByName Num.19 List.363 List.501;
-                jump List.495 List.360 List.365 List.362 List.500 List.364;
-            else
-                let List.366 : [] = UnionAtIndex (Id 0) (Index 0) List.498;
-                dec List.498;
-                let List.502 : [C [], C {List U8, U64}] = TagId(0) List.366;
-                ret List.502;
+procedure List.86 (List.505, List.506, List.507, List.508, List.509):
+    joinpoint List.480 List.359 List.360 List.361 List.362 List.363:
+        let List.482 : Int1 = CallByName Num.22 List.362 List.363;
+        if List.482 then
+            let List.488 : {Str, Str} = CallByName List.66 List.359 List.362;
+            let List.483 : {List U8, U64} = CallByName List.133 List.360 List.488 List.361;
+            let List.486 : U64 = 1i64;
+            let List.485 : U64 = CallByName Num.19 List.362 List.486;
+            jump List.480 List.359 List.483 List.361 List.485 List.363;
         else
-            let List.496 : [C [], C {List U8, U64}] = TagId(1) List.361;
-            ret List.496;
+            ret List.360;
     in
-    jump List.495 List.524 List.525 List.526 List.527 List.528;
+    jump List.480 List.505 List.506 List.507 List.508 List.509;
 
 procedure Num.123 (#Attr.2):
     let Num.283 : U8 = lowlevel NumIntCast #Attr.2;

--- a/crates/compiler/test_mono/generated/encode_derived_record_one_field_string.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_record_one_field_string.txt
@@ -118,92 +118,62 @@ procedure Json.97 (Json.98, Json.435, Json.96):
     ret Json.437;
 
 procedure List.133 (List.134, List.135, List.132):
-    let List.435 : {List U8, U64} = CallByName Json.115 List.134 List.135;
-    let List.434 : [C [], C {List U8, U64}] = TagId(1) List.435;
-    ret List.434;
+    let List.426 : {List U8, U64} = CallByName Json.115 List.134 List.135;
+    ret List.426;
 
 procedure List.18 (List.130, List.131, List.132):
-    let List.409 : [C [], C {List U8, U64}] = CallByName List.75 List.130 List.131 List.132;
-    let List.413 : U8 = 1i64;
-    let List.414 : U8 = GetTagId List.409;
-    let List.415 : Int1 = lowlevel Eq List.413 List.414;
-    if List.415 then
-        let List.137 : {List U8, U64} = UnionAtIndex (Id 1) (Index 0) List.409;
-        inc List.137;
-        dec List.409;
-        ret List.137;
-    else
-        let List.138 : [] = UnionAtIndex (Id 0) (Index 0) List.409;
-        dec List.409;
-        let List.411 : {List U8, U64} = CallByName List.69 List.138;
-        ret List.411;
+    let List.408 : {List U8, U64} = CallByName List.75 List.130 List.131 List.132;
+    ret List.408;
 
 procedure List.4 (List.101, List.102):
-    let List.408 : U64 = 1i64;
-    let List.407 : List U8 = CallByName List.70 List.101 List.408;
-    let List.406 : List U8 = CallByName List.71 List.407 List.102;
-    ret List.406;
+    let List.407 : U64 = 1i64;
+    let List.406 : List U8 = CallByName List.70 List.101 List.407;
+    let List.405 : List U8 = CallByName List.71 List.406 List.102;
+    ret List.405;
 
 procedure List.6 (#Attr.2):
-    let List.381 : U64 = lowlevel ListLen #Attr.2;
-    ret List.381;
+    let List.380 : U64 = lowlevel ListLen #Attr.2;
+    ret List.380;
 
 procedure List.6 (#Attr.2):
-    let List.438 : U64 = lowlevel ListLen #Attr.2;
-    ret List.438;
+    let List.429 : U64 = lowlevel ListLen #Attr.2;
+    ret List.429;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.432 : {Str, Str} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.432;
-
-procedure List.69 (#Attr.2):
-    let List.412 : {List U8, U64} = lowlevel Unreachable #Attr.2;
-    ret List.412;
+    let List.423 : {Str, Str} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.423;
 
 procedure List.70 (#Attr.2, #Attr.3):
-    let List.387 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
-    ret List.387;
+    let List.386 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
+    ret List.386;
 
 procedure List.71 (#Attr.2, #Attr.3):
-    let List.385 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
-    ret List.385;
+    let List.384 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
+    ret List.384;
 
-procedure List.75 (List.357, List.358, List.359):
-    let List.418 : U64 = 0i64;
-    let List.419 : U64 = CallByName List.6 List.357;
-    let List.417 : [C [], C {List U8, U64}] = CallByName List.86 List.357 List.358 List.359 List.418 List.419;
-    ret List.417;
+procedure List.75 (List.356, List.357, List.358):
+    let List.412 : U64 = 0i64;
+    let List.413 : U64 = CallByName List.6 List.356;
+    let List.411 : {List U8, U64} = CallByName List.86 List.356 List.357 List.358 List.412 List.413;
+    ret List.411;
 
 procedure List.8 (#Attr.2, #Attr.3):
-    let List.437 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
-    ret List.437;
+    let List.428 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
+    ret List.428;
 
-procedure List.86 (List.449, List.450, List.451, List.452, List.453):
-    joinpoint List.420 List.360 List.361 List.362 List.363 List.364:
-        let List.422 : Int1 = CallByName Num.22 List.363 List.364;
-        if List.422 then
-            let List.431 : {Str, Str} = CallByName List.66 List.360 List.363;
-            let List.423 : [C [], C {List U8, U64}] = CallByName List.133 List.361 List.431 List.362;
-            let List.428 : U8 = 1i64;
-            let List.429 : U8 = GetTagId List.423;
-            let List.430 : Int1 = lowlevel Eq List.428 List.429;
-            if List.430 then
-                let List.365 : {List U8, U64} = UnionAtIndex (Id 1) (Index 0) List.423;
-                inc List.365;
-                dec List.423;
-                let List.426 : U64 = 1i64;
-                let List.425 : U64 = CallByName Num.19 List.363 List.426;
-                jump List.420 List.360 List.365 List.362 List.425 List.364;
-            else
-                let List.366 : [] = UnionAtIndex (Id 0) (Index 0) List.423;
-                dec List.423;
-                let List.427 : [C [], C {List U8, U64}] = TagId(0) List.366;
-                ret List.427;
+procedure List.86 (List.439, List.440, List.441, List.442, List.443):
+    joinpoint List.414 List.359 List.360 List.361 List.362 List.363:
+        let List.416 : Int1 = CallByName Num.22 List.362 List.363;
+        if List.416 then
+            let List.422 : {Str, Str} = CallByName List.66 List.359 List.362;
+            let List.417 : {List U8, U64} = CallByName List.133 List.360 List.422 List.361;
+            let List.420 : U64 = 1i64;
+            let List.419 : U64 = CallByName Num.19 List.362 List.420;
+            jump List.414 List.359 List.417 List.361 List.419 List.363;
         else
-            let List.421 : [C [], C {List U8, U64}] = TagId(1) List.361;
-            ret List.421;
+            ret List.360;
     in
-    jump List.420 List.449 List.450 List.451 List.452 List.453;
+    jump List.414 List.439 List.440 List.441 List.442 List.443;
 
 procedure Num.123 (#Attr.2):
     let Num.264 : U8 = lowlevel NumIntCast #Attr.2;

--- a/crates/compiler/test_mono/generated/encode_derived_record_two_field_strings.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_record_two_field_strings.txt
@@ -126,92 +126,62 @@ procedure Json.97 (Json.98, Json.435, Json.96):
     ret Json.437;
 
 procedure List.133 (List.134, List.135, List.132):
-    let List.435 : {List U8, U64} = CallByName Json.115 List.134 List.135;
-    let List.434 : [C [], C {List U8, U64}] = TagId(1) List.435;
-    ret List.434;
+    let List.426 : {List U8, U64} = CallByName Json.115 List.134 List.135;
+    ret List.426;
 
 procedure List.18 (List.130, List.131, List.132):
-    let List.409 : [C [], C {List U8, U64}] = CallByName List.75 List.130 List.131 List.132;
-    let List.413 : U8 = 1i64;
-    let List.414 : U8 = GetTagId List.409;
-    let List.415 : Int1 = lowlevel Eq List.413 List.414;
-    if List.415 then
-        let List.137 : {List U8, U64} = UnionAtIndex (Id 1) (Index 0) List.409;
-        inc List.137;
-        dec List.409;
-        ret List.137;
-    else
-        let List.138 : [] = UnionAtIndex (Id 0) (Index 0) List.409;
-        dec List.409;
-        let List.411 : {List U8, U64} = CallByName List.69 List.138;
-        ret List.411;
+    let List.408 : {List U8, U64} = CallByName List.75 List.130 List.131 List.132;
+    ret List.408;
 
 procedure List.4 (List.101, List.102):
-    let List.408 : U64 = 1i64;
-    let List.407 : List U8 = CallByName List.70 List.101 List.408;
-    let List.406 : List U8 = CallByName List.71 List.407 List.102;
-    ret List.406;
+    let List.407 : U64 = 1i64;
+    let List.406 : List U8 = CallByName List.70 List.101 List.407;
+    let List.405 : List U8 = CallByName List.71 List.406 List.102;
+    ret List.405;
 
 procedure List.6 (#Attr.2):
-    let List.381 : U64 = lowlevel ListLen #Attr.2;
-    ret List.381;
+    let List.380 : U64 = lowlevel ListLen #Attr.2;
+    ret List.380;
 
 procedure List.6 (#Attr.2):
-    let List.438 : U64 = lowlevel ListLen #Attr.2;
-    ret List.438;
+    let List.429 : U64 = lowlevel ListLen #Attr.2;
+    ret List.429;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.432 : {Str, Str} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.432;
-
-procedure List.69 (#Attr.2):
-    let List.412 : {List U8, U64} = lowlevel Unreachable #Attr.2;
-    ret List.412;
+    let List.423 : {Str, Str} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.423;
 
 procedure List.70 (#Attr.2, #Attr.3):
-    let List.387 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
-    ret List.387;
+    let List.386 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
+    ret List.386;
 
 procedure List.71 (#Attr.2, #Attr.3):
-    let List.385 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
-    ret List.385;
+    let List.384 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
+    ret List.384;
 
-procedure List.75 (List.357, List.358, List.359):
-    let List.418 : U64 = 0i64;
-    let List.419 : U64 = CallByName List.6 List.357;
-    let List.417 : [C [], C {List U8, U64}] = CallByName List.86 List.357 List.358 List.359 List.418 List.419;
-    ret List.417;
+procedure List.75 (List.356, List.357, List.358):
+    let List.412 : U64 = 0i64;
+    let List.413 : U64 = CallByName List.6 List.356;
+    let List.411 : {List U8, U64} = CallByName List.86 List.356 List.357 List.358 List.412 List.413;
+    ret List.411;
 
 procedure List.8 (#Attr.2, #Attr.3):
-    let List.437 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
-    ret List.437;
+    let List.428 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
+    ret List.428;
 
-procedure List.86 (List.449, List.450, List.451, List.452, List.453):
-    joinpoint List.420 List.360 List.361 List.362 List.363 List.364:
-        let List.422 : Int1 = CallByName Num.22 List.363 List.364;
-        if List.422 then
-            let List.431 : {Str, Str} = CallByName List.66 List.360 List.363;
-            let List.423 : [C [], C {List U8, U64}] = CallByName List.133 List.361 List.431 List.362;
-            let List.428 : U8 = 1i64;
-            let List.429 : U8 = GetTagId List.423;
-            let List.430 : Int1 = lowlevel Eq List.428 List.429;
-            if List.430 then
-                let List.365 : {List U8, U64} = UnionAtIndex (Id 1) (Index 0) List.423;
-                inc List.365;
-                dec List.423;
-                let List.426 : U64 = 1i64;
-                let List.425 : U64 = CallByName Num.19 List.363 List.426;
-                jump List.420 List.360 List.365 List.362 List.425 List.364;
-            else
-                let List.366 : [] = UnionAtIndex (Id 0) (Index 0) List.423;
-                dec List.423;
-                let List.427 : [C [], C {List U8, U64}] = TagId(0) List.366;
-                ret List.427;
+procedure List.86 (List.439, List.440, List.441, List.442, List.443):
+    joinpoint List.414 List.359 List.360 List.361 List.362 List.363:
+        let List.416 : Int1 = CallByName Num.22 List.362 List.363;
+        if List.416 then
+            let List.422 : {Str, Str} = CallByName List.66 List.359 List.362;
+            let List.417 : {List U8, U64} = CallByName List.133 List.360 List.422 List.361;
+            let List.420 : U64 = 1i64;
+            let List.419 : U64 = CallByName Num.19 List.362 List.420;
+            jump List.414 List.359 List.417 List.361 List.419 List.363;
         else
-            let List.421 : [C [], C {List U8, U64}] = TagId(1) List.361;
-            ret List.421;
+            ret List.360;
     in
-    jump List.420 List.449 List.450 List.451 List.452 List.453;
+    jump List.414 List.439 List.440 List.441 List.442 List.443;
 
 procedure Num.123 (#Attr.2):
     let Num.264 : U8 = lowlevel NumIntCast #Attr.2;

--- a/crates/compiler/test_mono/generated/encode_derived_string.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_string.txt
@@ -31,26 +31,26 @@ procedure Json.97 (Json.98, Json.399, Json.96):
     ret Json.401;
 
 procedure List.4 (List.101, List.102):
-    let List.390 : U64 = 1i64;
-    let List.389 : List U8 = CallByName List.70 List.101 List.390;
-    let List.388 : List U8 = CallByName List.71 List.389 List.102;
-    ret List.388;
-
-procedure List.6 (#Attr.2):
-    let List.381 : U64 = lowlevel ListLen #Attr.2;
-    ret List.381;
-
-procedure List.70 (#Attr.2, #Attr.3):
-    let List.387 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
+    let List.389 : U64 = 1i64;
+    let List.388 : List U8 = CallByName List.70 List.101 List.389;
+    let List.387 : List U8 = CallByName List.71 List.388 List.102;
     ret List.387;
 
+procedure List.6 (#Attr.2):
+    let List.380 : U64 = lowlevel ListLen #Attr.2;
+    ret List.380;
+
+procedure List.70 (#Attr.2, #Attr.3):
+    let List.386 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
+    ret List.386;
+
 procedure List.71 (#Attr.2, #Attr.3):
-    let List.385 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
-    ret List.385;
+    let List.384 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
+    ret List.384;
 
 procedure List.8 (#Attr.2, #Attr.3):
-    let List.391 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
-    ret List.391;
+    let List.390 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
+    ret List.390;
 
 procedure Num.123 (#Attr.2):
     let Num.258 : U8 = lowlevel NumIntCast #Attr.2;

--- a/crates/compiler/test_mono/generated/encode_derived_tag_one_field_string.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_tag_one_field_string.txt
@@ -127,92 +127,62 @@ procedure Json.97 (Json.98, Json.440, Json.96):
     ret Json.442;
 
 procedure List.133 (List.134, List.135, List.132):
-    let List.441 : {List U8, U64} = CallByName Json.129 List.134 List.135;
-    let List.440 : [C [], C {List U8, U64}] = TagId(1) List.441;
-    ret List.440;
+    let List.432 : {List U8, U64} = CallByName Json.129 List.134 List.135;
+    ret List.432;
 
 procedure List.18 (List.130, List.131, List.132):
-    let List.415 : [C [], C {List U8, U64}] = CallByName List.75 List.130 List.131 List.132;
-    let List.419 : U8 = 1i64;
-    let List.420 : U8 = GetTagId List.415;
-    let List.421 : Int1 = lowlevel Eq List.419 List.420;
-    if List.421 then
-        let List.137 : {List U8, U64} = UnionAtIndex (Id 1) (Index 0) List.415;
-        inc List.137;
-        dec List.415;
-        ret List.137;
-    else
-        let List.138 : [] = UnionAtIndex (Id 0) (Index 0) List.415;
-        dec List.415;
-        let List.417 : {List U8, U64} = CallByName List.69 List.138;
-        ret List.417;
+    let List.414 : {List U8, U64} = CallByName List.75 List.130 List.131 List.132;
+    ret List.414;
 
 procedure List.4 (List.101, List.102):
-    let List.414 : U64 = 1i64;
-    let List.413 : List U8 = CallByName List.70 List.101 List.414;
-    let List.412 : List U8 = CallByName List.71 List.413 List.102;
-    ret List.412;
+    let List.413 : U64 = 1i64;
+    let List.412 : List U8 = CallByName List.70 List.101 List.413;
+    let List.411 : List U8 = CallByName List.71 List.412 List.102;
+    ret List.411;
 
 procedure List.6 (#Attr.2):
-    let List.381 : U64 = lowlevel ListLen #Attr.2;
-    ret List.381;
+    let List.380 : U64 = lowlevel ListLen #Attr.2;
+    ret List.380;
 
 procedure List.6 (#Attr.2):
-    let List.442 : U64 = lowlevel ListLen #Attr.2;
-    ret List.442;
+    let List.433 : U64 = lowlevel ListLen #Attr.2;
+    ret List.433;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.438 : Str = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.438;
-
-procedure List.69 (#Attr.2):
-    let List.418 : {List U8, U64} = lowlevel Unreachable #Attr.2;
-    ret List.418;
+    let List.429 : Str = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.429;
 
 procedure List.70 (#Attr.2, #Attr.3):
-    let List.387 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
-    ret List.387;
+    let List.386 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
+    ret List.386;
 
 procedure List.71 (#Attr.2, #Attr.3):
-    let List.385 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
-    ret List.385;
+    let List.384 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
+    ret List.384;
 
-procedure List.75 (List.357, List.358, List.359):
-    let List.424 : U64 = 0i64;
-    let List.425 : U64 = CallByName List.6 List.357;
-    let List.423 : [C [], C {List U8, U64}] = CallByName List.86 List.357 List.358 List.359 List.424 List.425;
-    ret List.423;
+procedure List.75 (List.356, List.357, List.358):
+    let List.418 : U64 = 0i64;
+    let List.419 : U64 = CallByName List.6 List.356;
+    let List.417 : {List U8, U64} = CallByName List.86 List.356 List.357 List.358 List.418 List.419;
+    ret List.417;
 
 procedure List.8 (#Attr.2, #Attr.3):
-    let List.444 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
-    ret List.444;
+    let List.435 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
+    ret List.435;
 
-procedure List.86 (List.455, List.456, List.457, List.458, List.459):
-    joinpoint List.426 List.360 List.361 List.362 List.363 List.364:
-        let List.428 : Int1 = CallByName Num.22 List.363 List.364;
-        if List.428 then
-            let List.437 : Str = CallByName List.66 List.360 List.363;
-            let List.429 : [C [], C {List U8, U64}] = CallByName List.133 List.361 List.437 List.362;
-            let List.434 : U8 = 1i64;
-            let List.435 : U8 = GetTagId List.429;
-            let List.436 : Int1 = lowlevel Eq List.434 List.435;
-            if List.436 then
-                let List.365 : {List U8, U64} = UnionAtIndex (Id 1) (Index 0) List.429;
-                inc List.365;
-                dec List.429;
-                let List.432 : U64 = 1i64;
-                let List.431 : U64 = CallByName Num.19 List.363 List.432;
-                jump List.426 List.360 List.365 List.362 List.431 List.364;
-            else
-                let List.366 : [] = UnionAtIndex (Id 0) (Index 0) List.429;
-                dec List.429;
-                let List.433 : [C [], C {List U8, U64}] = TagId(0) List.366;
-                ret List.433;
+procedure List.86 (List.445, List.446, List.447, List.448, List.449):
+    joinpoint List.420 List.359 List.360 List.361 List.362 List.363:
+        let List.422 : Int1 = CallByName Num.22 List.362 List.363;
+        if List.422 then
+            let List.428 : Str = CallByName List.66 List.359 List.362;
+            let List.423 : {List U8, U64} = CallByName List.133 List.360 List.428 List.361;
+            let List.426 : U64 = 1i64;
+            let List.425 : U64 = CallByName Num.19 List.362 List.426;
+            jump List.420 List.359 List.423 List.361 List.425 List.363;
         else
-            let List.427 : [C [], C {List U8, U64}] = TagId(1) List.361;
-            ret List.427;
+            ret List.360;
     in
-    jump List.426 List.455 List.456 List.457 List.458 List.459;
+    jump List.420 List.445 List.446 List.447 List.448 List.449;
 
 procedure Num.123 (#Attr.2):
     let Num.266 : U8 = lowlevel NumIntCast #Attr.2;

--- a/crates/compiler/test_mono/generated/encode_derived_tag_two_payloads_string.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_tag_two_payloads_string.txt
@@ -133,92 +133,62 @@ procedure Json.97 (Json.98, Json.440, Json.96):
     ret Json.442;
 
 procedure List.133 (List.134, List.135, List.132):
-    let List.441 : {List U8, U64} = CallByName Json.129 List.134 List.135;
-    let List.440 : [C [], C {List U8, U64}] = TagId(1) List.441;
-    ret List.440;
+    let List.432 : {List U8, U64} = CallByName Json.129 List.134 List.135;
+    ret List.432;
 
 procedure List.18 (List.130, List.131, List.132):
-    let List.415 : [C [], C {List U8, U64}] = CallByName List.75 List.130 List.131 List.132;
-    let List.419 : U8 = 1i64;
-    let List.420 : U8 = GetTagId List.415;
-    let List.421 : Int1 = lowlevel Eq List.419 List.420;
-    if List.421 then
-        let List.137 : {List U8, U64} = UnionAtIndex (Id 1) (Index 0) List.415;
-        inc List.137;
-        dec List.415;
-        ret List.137;
-    else
-        let List.138 : [] = UnionAtIndex (Id 0) (Index 0) List.415;
-        dec List.415;
-        let List.417 : {List U8, U64} = CallByName List.69 List.138;
-        ret List.417;
+    let List.414 : {List U8, U64} = CallByName List.75 List.130 List.131 List.132;
+    ret List.414;
 
 procedure List.4 (List.101, List.102):
-    let List.414 : U64 = 1i64;
-    let List.413 : List U8 = CallByName List.70 List.101 List.414;
-    let List.412 : List U8 = CallByName List.71 List.413 List.102;
-    ret List.412;
+    let List.413 : U64 = 1i64;
+    let List.412 : List U8 = CallByName List.70 List.101 List.413;
+    let List.411 : List U8 = CallByName List.71 List.412 List.102;
+    ret List.411;
 
 procedure List.6 (#Attr.2):
-    let List.381 : U64 = lowlevel ListLen #Attr.2;
-    ret List.381;
+    let List.380 : U64 = lowlevel ListLen #Attr.2;
+    ret List.380;
 
 procedure List.6 (#Attr.2):
-    let List.442 : U64 = lowlevel ListLen #Attr.2;
-    ret List.442;
+    let List.433 : U64 = lowlevel ListLen #Attr.2;
+    ret List.433;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.438 : Str = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.438;
-
-procedure List.69 (#Attr.2):
-    let List.418 : {List U8, U64} = lowlevel Unreachable #Attr.2;
-    ret List.418;
+    let List.429 : Str = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.429;
 
 procedure List.70 (#Attr.2, #Attr.3):
-    let List.387 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
-    ret List.387;
+    let List.386 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
+    ret List.386;
 
 procedure List.71 (#Attr.2, #Attr.3):
-    let List.385 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
-    ret List.385;
+    let List.384 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
+    ret List.384;
 
-procedure List.75 (List.357, List.358, List.359):
-    let List.424 : U64 = 0i64;
-    let List.425 : U64 = CallByName List.6 List.357;
-    let List.423 : [C [], C {List U8, U64}] = CallByName List.86 List.357 List.358 List.359 List.424 List.425;
-    ret List.423;
+procedure List.75 (List.356, List.357, List.358):
+    let List.418 : U64 = 0i64;
+    let List.419 : U64 = CallByName List.6 List.356;
+    let List.417 : {List U8, U64} = CallByName List.86 List.356 List.357 List.358 List.418 List.419;
+    ret List.417;
 
 procedure List.8 (#Attr.2, #Attr.3):
-    let List.444 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
-    ret List.444;
+    let List.435 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
+    ret List.435;
 
-procedure List.86 (List.455, List.456, List.457, List.458, List.459):
-    joinpoint List.426 List.360 List.361 List.362 List.363 List.364:
-        let List.428 : Int1 = CallByName Num.22 List.363 List.364;
-        if List.428 then
-            let List.437 : Str = CallByName List.66 List.360 List.363;
-            let List.429 : [C [], C {List U8, U64}] = CallByName List.133 List.361 List.437 List.362;
-            let List.434 : U8 = 1i64;
-            let List.435 : U8 = GetTagId List.429;
-            let List.436 : Int1 = lowlevel Eq List.434 List.435;
-            if List.436 then
-                let List.365 : {List U8, U64} = UnionAtIndex (Id 1) (Index 0) List.429;
-                inc List.365;
-                dec List.429;
-                let List.432 : U64 = 1i64;
-                let List.431 : U64 = CallByName Num.19 List.363 List.432;
-                jump List.426 List.360 List.365 List.362 List.431 List.364;
-            else
-                let List.366 : [] = UnionAtIndex (Id 0) (Index 0) List.429;
-                dec List.429;
-                let List.433 : [C [], C {List U8, U64}] = TagId(0) List.366;
-                ret List.433;
+procedure List.86 (List.445, List.446, List.447, List.448, List.449):
+    joinpoint List.420 List.359 List.360 List.361 List.362 List.363:
+        let List.422 : Int1 = CallByName Num.22 List.362 List.363;
+        if List.422 then
+            let List.428 : Str = CallByName List.66 List.359 List.362;
+            let List.423 : {List U8, U64} = CallByName List.133 List.360 List.428 List.361;
+            let List.426 : U64 = 1i64;
+            let List.425 : U64 = CallByName Num.19 List.362 List.426;
+            jump List.420 List.359 List.423 List.361 List.425 List.363;
         else
-            let List.427 : [C [], C {List U8, U64}] = TagId(1) List.361;
-            ret List.427;
+            ret List.360;
     in
-    jump List.426 List.455 List.456 List.457 List.458 List.459;
+    jump List.420 List.445 List.446 List.447 List.448 List.449;
 
 procedure Num.123 (#Attr.2):
     let Num.266 : U8 = lowlevel NumIntCast #Attr.2;

--- a/crates/compiler/test_mono/generated/ir_int_add.txt
+++ b/crates/compiler/test_mono/generated/ir_int_add.txt
@@ -1,6 +1,6 @@
 procedure List.6 (#Attr.2):
-    let List.381 : U64 = lowlevel ListLen #Attr.2;
-    ret List.381;
+    let List.380 : U64 = lowlevel ListLen #Attr.2;
+    ret List.380;
 
 procedure Num.19 (#Attr.2, #Attr.3):
     let Num.259 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/issue_2583_specialize_errors_behind_unified_branches.txt
+++ b/crates/compiler/test_mono/generated/issue_2583_specialize_errors_behind_unified_branches.txt
@@ -7,39 +7,39 @@ procedure Bool.7 (#Attr.2, #Attr.3):
     ret Bool.12;
 
 procedure List.2 (List.90, List.91):
-    let List.395 : U64 = CallByName List.6 List.90;
-    let List.391 : Int1 = CallByName Num.22 List.91 List.395;
-    if List.391 then
-        let List.393 : I64 = CallByName List.66 List.90 List.91;
-        let List.392 : [C {}, C I64] = TagId(1) List.393;
-        ret List.392;
+    let List.394 : U64 = CallByName List.6 List.90;
+    let List.390 : Int1 = CallByName Num.22 List.91 List.394;
+    if List.390 then
+        let List.392 : I64 = CallByName List.66 List.90 List.91;
+        let List.391 : [C {}, C I64] = TagId(1) List.392;
+        ret List.391;
     else
-        let List.390 : {} = Struct {};
-        let List.389 : [C {}, C I64] = TagId(0) List.390;
-        ret List.389;
+        let List.389 : {} = Struct {};
+        let List.388 : [C {}, C I64] = TagId(0) List.389;
+        ret List.388;
 
 procedure List.6 (#Attr.2):
-    let List.396 : U64 = lowlevel ListLen #Attr.2;
-    ret List.396;
+    let List.395 : U64 = lowlevel ListLen #Attr.2;
+    ret List.395;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.394 : I64 = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.394;
+    let List.393 : I64 = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.393;
 
-procedure List.9 (List.214):
-    let List.388 : U64 = 0i64;
-    let List.381 : [C {}, C I64] = CallByName List.2 List.214 List.388;
-    let List.385 : U8 = 1i64;
-    let List.386 : U8 = GetTagId List.381;
-    let List.387 : Int1 = lowlevel Eq List.385 List.386;
-    if List.387 then
-        let List.215 : I64 = UnionAtIndex (Id 1) (Index 0) List.381;
-        let List.382 : [C Int1, C I64] = TagId(1) List.215;
-        ret List.382;
+procedure List.9 (List.213):
+    let List.387 : U64 = 0i64;
+    let List.380 : [C {}, C I64] = CallByName List.2 List.213 List.387;
+    let List.384 : U8 = 1i64;
+    let List.385 : U8 = GetTagId List.380;
+    let List.386 : Int1 = lowlevel Eq List.384 List.385;
+    if List.386 then
+        let List.214 : I64 = UnionAtIndex (Id 1) (Index 0) List.380;
+        let List.381 : [C Int1, C I64] = TagId(1) List.214;
+        ret List.381;
     else
-        let List.384 : Int1 = true;
-        let List.383 : [C Int1, C I64] = TagId(0) List.384;
-        ret List.383;
+        let List.383 : Int1 = true;
+        let List.382 : [C Int1, C I64] = TagId(0) List.383;
+        ret List.382;
 
 procedure Num.22 (#Attr.2, #Attr.3):
     let Num.257 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/list_append.txt
+++ b/crates/compiler/test_mono/generated/list_append.txt
@@ -1,16 +1,16 @@
 procedure List.4 (List.101, List.102):
-    let List.384 : U64 = 1i64;
-    let List.382 : List I64 = CallByName List.70 List.101 List.384;
-    let List.381 : List I64 = CallByName List.71 List.382 List.102;
-    ret List.381;
+    let List.383 : U64 = 1i64;
+    let List.381 : List I64 = CallByName List.70 List.101 List.383;
+    let List.380 : List I64 = CallByName List.71 List.381 List.102;
+    ret List.380;
 
 procedure List.70 (#Attr.2, #Attr.3):
-    let List.385 : List I64 = lowlevel ListReserve #Attr.2 #Attr.3;
-    ret List.385;
+    let List.384 : List I64 = lowlevel ListReserve #Attr.2 #Attr.3;
+    ret List.384;
 
 procedure List.71 (#Attr.2, #Attr.3):
-    let List.383 : List I64 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
-    ret List.383;
+    let List.382 : List I64 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
+    ret List.382;
 
 procedure Test.0 ():
     let Test.2 : List I64 = Array [1i64];

--- a/crates/compiler/test_mono/generated/list_append_closure.txt
+++ b/crates/compiler/test_mono/generated/list_append_closure.txt
@@ -1,16 +1,16 @@
 procedure List.4 (List.101, List.102):
-    let List.384 : U64 = 1i64;
-    let List.382 : List I64 = CallByName List.70 List.101 List.384;
-    let List.381 : List I64 = CallByName List.71 List.382 List.102;
-    ret List.381;
+    let List.383 : U64 = 1i64;
+    let List.381 : List I64 = CallByName List.70 List.101 List.383;
+    let List.380 : List I64 = CallByName List.71 List.381 List.102;
+    ret List.380;
 
 procedure List.70 (#Attr.2, #Attr.3):
-    let List.385 : List I64 = lowlevel ListReserve #Attr.2 #Attr.3;
-    ret List.385;
+    let List.384 : List I64 = lowlevel ListReserve #Attr.2 #Attr.3;
+    ret List.384;
 
 procedure List.71 (#Attr.2, #Attr.3):
-    let List.383 : List I64 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
-    ret List.383;
+    let List.382 : List I64 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
+    ret List.382;
 
 procedure Test.1 (Test.2):
     let Test.6 : I64 = 42i64;

--- a/crates/compiler/test_mono/generated/list_cannot_update_inplace.txt
+++ b/crates/compiler/test_mono/generated/list_cannot_update_inplace.txt
@@ -1,27 +1,27 @@
 procedure List.3 (List.98, List.99, List.100):
-    let List.384 : {List I64, I64} = CallByName List.64 List.98 List.99 List.100;
-    let List.383 : List I64 = StructAtIndex 0 List.384;
-    inc List.383;
-    dec List.384;
-    ret List.383;
-
-procedure List.6 (#Attr.2):
-    let List.382 : U64 = lowlevel ListLen #Attr.2;
+    let List.383 : {List I64, I64} = CallByName List.64 List.98 List.99 List.100;
+    let List.382 : List I64 = StructAtIndex 0 List.383;
+    inc List.382;
+    dec List.383;
     ret List.382;
 
+procedure List.6 (#Attr.2):
+    let List.381 : U64 = lowlevel ListLen #Attr.2;
+    ret List.381;
+
 procedure List.64 (List.95, List.96, List.97):
-    let List.389 : U64 = CallByName List.6 List.95;
-    let List.386 : Int1 = CallByName Num.22 List.96 List.389;
-    if List.386 then
-        let List.387 : {List I64, I64} = CallByName List.67 List.95 List.96 List.97;
-        ret List.387;
+    let List.388 : U64 = CallByName List.6 List.95;
+    let List.385 : Int1 = CallByName Num.22 List.96 List.388;
+    if List.385 then
+        let List.386 : {List I64, I64} = CallByName List.67 List.95 List.96 List.97;
+        ret List.386;
     else
-        let List.385 : {List I64, I64} = Struct {List.95, List.97};
-        ret List.385;
+        let List.384 : {List I64, I64} = Struct {List.95, List.97};
+        ret List.384;
 
 procedure List.67 (#Attr.2, #Attr.3, #Attr.4):
-    let List.388 : {List I64, I64} = lowlevel ListReplaceUnsafe #Attr.2 #Attr.3 #Attr.4;
-    ret List.388;
+    let List.387 : {List I64, I64} = lowlevel ListReplaceUnsafe #Attr.2 #Attr.3 #Attr.4;
+    ret List.387;
 
 procedure Num.19 (#Attr.2, #Attr.3):
     let Num.257 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/list_get.txt
+++ b/crates/compiler/test_mono/generated/list_get.txt
@@ -1,22 +1,22 @@
 procedure List.2 (List.90, List.91):
-    let List.387 : U64 = CallByName List.6 List.90;
-    let List.383 : Int1 = CallByName Num.22 List.91 List.387;
-    if List.383 then
-        let List.385 : I64 = CallByName List.66 List.90 List.91;
-        let List.384 : [C {}, C I64] = TagId(1) List.385;
-        ret List.384;
+    let List.386 : U64 = CallByName List.6 List.90;
+    let List.382 : Int1 = CallByName Num.22 List.91 List.386;
+    if List.382 then
+        let List.384 : I64 = CallByName List.66 List.90 List.91;
+        let List.383 : [C {}, C I64] = TagId(1) List.384;
+        ret List.383;
     else
-        let List.382 : {} = Struct {};
-        let List.381 : [C {}, C I64] = TagId(0) List.382;
-        ret List.381;
+        let List.381 : {} = Struct {};
+        let List.380 : [C {}, C I64] = TagId(0) List.381;
+        ret List.380;
 
 procedure List.6 (#Attr.2):
-    let List.388 : U64 = lowlevel ListLen #Attr.2;
-    ret List.388;
+    let List.387 : U64 = lowlevel ListLen #Attr.2;
+    ret List.387;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.386 : I64 = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.386;
+    let List.385 : I64 = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.385;
 
 procedure Num.22 (#Attr.2, #Attr.3):
     let Num.257 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/list_len.txt
+++ b/crates/compiler/test_mono/generated/list_len.txt
@@ -1,10 +1,10 @@
 procedure List.6 (#Attr.2):
-    let List.381 : U64 = lowlevel ListLen #Attr.2;
-    ret List.381;
+    let List.380 : U64 = lowlevel ListLen #Attr.2;
+    ret List.380;
 
 procedure List.6 (#Attr.2):
-    let List.382 : U64 = lowlevel ListLen #Attr.2;
-    ret List.382;
+    let List.381 : U64 = lowlevel ListLen #Attr.2;
+    ret List.381;
 
 procedure Num.19 (#Attr.2, #Attr.3):
     let Num.257 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/list_map_closure_borrows.txt
+++ b/crates/compiler/test_mono/generated/list_map_closure_borrows.txt
@@ -1,26 +1,26 @@
 procedure List.2 (List.90, List.91):
-    let List.387 : U64 = CallByName List.6 List.90;
-    let List.383 : Int1 = CallByName Num.22 List.91 List.387;
-    if List.383 then
-        let List.385 : Str = CallByName List.66 List.90 List.91;
-        let List.384 : [C {}, C Str] = TagId(1) List.385;
-        ret List.384;
+    let List.386 : U64 = CallByName List.6 List.90;
+    let List.382 : Int1 = CallByName Num.22 List.91 List.386;
+    if List.382 then
+        let List.384 : Str = CallByName List.66 List.90 List.91;
+        let List.383 : [C {}, C Str] = TagId(1) List.384;
+        ret List.383;
     else
-        let List.382 : {} = Struct {};
-        let List.381 : [C {}, C Str] = TagId(0) List.382;
-        ret List.381;
+        let List.381 : {} = Struct {};
+        let List.380 : [C {}, C Str] = TagId(0) List.381;
+        ret List.380;
 
 procedure List.5 (#Attr.2, #Attr.3):
-    let List.389 : List Str = lowlevel ListMap { xs: `#Attr.#arg1` } #Attr.2 Test.3 #Attr.3;
-    ret List.389;
-
-procedure List.6 (#Attr.2):
-    let List.388 : U64 = lowlevel ListLen #Attr.2;
+    let List.388 : List Str = lowlevel ListMap { xs: `#Attr.#arg1` } #Attr.2 Test.3 #Attr.3;
     ret List.388;
 
+procedure List.6 (#Attr.2):
+    let List.387 : U64 = lowlevel ListLen #Attr.2;
+    ret List.387;
+
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.386 : Str = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.386;
+    let List.385 : Str = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.385;
 
 procedure Num.22 (#Attr.2, #Attr.3):
     let Num.257 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/list_map_closure_owns.txt
+++ b/crates/compiler/test_mono/generated/list_map_closure_owns.txt
@@ -1,28 +1,28 @@
 procedure List.2 (List.90, List.91):
-    let List.387 : U64 = CallByName List.6 List.90;
-    let List.383 : Int1 = CallByName Num.22 List.91 List.387;
-    if List.383 then
-        let List.385 : Str = CallByName List.66 List.90 List.91;
-        let List.384 : [C {}, C Str] = TagId(1) List.385;
-        ret List.384;
+    let List.386 : U64 = CallByName List.6 List.90;
+    let List.382 : Int1 = CallByName Num.22 List.91 List.386;
+    if List.382 then
+        let List.384 : Str = CallByName List.66 List.90 List.91;
+        let List.383 : [C {}, C Str] = TagId(1) List.384;
+        ret List.383;
     else
-        let List.382 : {} = Struct {};
-        let List.381 : [C {}, C Str] = TagId(0) List.382;
-        ret List.381;
+        let List.381 : {} = Struct {};
+        let List.380 : [C {}, C Str] = TagId(0) List.381;
+        ret List.380;
 
 procedure List.5 (#Attr.2, #Attr.3):
     inc #Attr.2;
-    let List.389 : List Str = lowlevel ListMap { xs: `#Attr.#arg1` } #Attr.2 Test.3 #Attr.3;
+    let List.388 : List Str = lowlevel ListMap { xs: `#Attr.#arg1` } #Attr.2 Test.3 #Attr.3;
     decref #Attr.2;
-    ret List.389;
-
-procedure List.6 (#Attr.2):
-    let List.388 : U64 = lowlevel ListLen #Attr.2;
     ret List.388;
 
+procedure List.6 (#Attr.2):
+    let List.387 : U64 = lowlevel ListLen #Attr.2;
+    ret List.387;
+
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.386 : Str = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.386;
+    let List.385 : Str = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.385;
 
 procedure Num.22 (#Attr.2, #Attr.3):
     let Num.257 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/list_pass_to_function.txt
+++ b/crates/compiler/test_mono/generated/list_pass_to_function.txt
@@ -1,27 +1,27 @@
 procedure List.3 (List.98, List.99, List.100):
-    let List.382 : {List I64, I64} = CallByName List.64 List.98 List.99 List.100;
-    let List.381 : List I64 = StructAtIndex 0 List.382;
-    inc List.381;
-    dec List.382;
-    ret List.381;
+    let List.381 : {List I64, I64} = CallByName List.64 List.98 List.99 List.100;
+    let List.380 : List I64 = StructAtIndex 0 List.381;
+    inc List.380;
+    dec List.381;
+    ret List.380;
 
 procedure List.6 (#Attr.2):
-    let List.388 : U64 = lowlevel ListLen #Attr.2;
-    ret List.388;
+    let List.387 : U64 = lowlevel ListLen #Attr.2;
+    ret List.387;
 
 procedure List.64 (List.95, List.96, List.97):
-    let List.387 : U64 = CallByName List.6 List.95;
-    let List.384 : Int1 = CallByName Num.22 List.96 List.387;
-    if List.384 then
-        let List.385 : {List I64, I64} = CallByName List.67 List.95 List.96 List.97;
-        ret List.385;
+    let List.386 : U64 = CallByName List.6 List.95;
+    let List.383 : Int1 = CallByName Num.22 List.96 List.386;
+    if List.383 then
+        let List.384 : {List I64, I64} = CallByName List.67 List.95 List.96 List.97;
+        ret List.384;
     else
-        let List.383 : {List I64, I64} = Struct {List.95, List.97};
-        ret List.383;
+        let List.382 : {List I64, I64} = Struct {List.95, List.97};
+        ret List.382;
 
 procedure List.67 (#Attr.2, #Attr.3, #Attr.4):
-    let List.386 : {List I64, I64} = lowlevel ListReplaceUnsafe #Attr.2 #Attr.3 #Attr.4;
-    ret List.386;
+    let List.385 : {List I64, I64} = lowlevel ListReplaceUnsafe #Attr.2 #Attr.3 #Attr.4;
+    ret List.385;
 
 procedure Num.22 (#Attr.2, #Attr.3):
     let Num.257 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/list_sort_asc.txt
+++ b/crates/compiler/test_mono/generated/list_sort_asc.txt
@@ -1,16 +1,16 @@
 procedure List.28 (#Attr.2, #Attr.3):
-    let List.383 : List I64 = lowlevel ListSortWith { xs: `#Attr.#arg1` } #Attr.2 Num.46 #Attr.3;
+    let List.382 : List I64 = lowlevel ListSortWith { xs: `#Attr.#arg1` } #Attr.2 Num.46 #Attr.3;
     let #Derived_gen.0 : Int1 = lowlevel ListIsUnique #Attr.2;
     if #Derived_gen.0 then
-        ret List.383;
+        ret List.382;
     else
         decref #Attr.2;
-        ret List.383;
+        ret List.382;
 
-procedure List.59 (List.209):
-    let List.382 : {} = Struct {};
-    let List.381 : List I64 = CallByName List.28 List.209 List.382;
-    ret List.381;
+procedure List.59 (List.208):
+    let List.381 : {} = Struct {};
+    let List.380 : List I64 = CallByName List.28 List.208 List.381;
+    ret List.380;
 
 procedure Num.46 (#Attr.2, #Attr.3):
     let Num.257 : U8 = lowlevel NumCompare #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/quicksort_swap.txt
+++ b/crates/compiler/test_mono/generated/quicksort_swap.txt
@@ -1,43 +1,43 @@
 procedure List.2 (List.90, List.91):
-    let List.403 : U64 = CallByName List.6 List.90;
-    let List.400 : Int1 = CallByName Num.22 List.91 List.403;
-    if List.400 then
-        let List.402 : I64 = CallByName List.66 List.90 List.91;
-        let List.401 : [C {}, C I64] = TagId(1) List.402;
-        ret List.401;
+    let List.402 : U64 = CallByName List.6 List.90;
+    let List.399 : Int1 = CallByName Num.22 List.91 List.402;
+    if List.399 then
+        let List.401 : I64 = CallByName List.66 List.90 List.91;
+        let List.400 : [C {}, C I64] = TagId(1) List.401;
+        ret List.400;
     else
-        let List.399 : {} = Struct {};
-        let List.398 : [C {}, C I64] = TagId(0) List.399;
-        ret List.398;
+        let List.398 : {} = Struct {};
+        let List.397 : [C {}, C I64] = TagId(0) List.398;
+        ret List.397;
 
 procedure List.3 (List.98, List.99, List.100):
-    let List.390 : {List I64, I64} = CallByName List.64 List.98 List.99 List.100;
-    let List.389 : List I64 = StructAtIndex 0 List.390;
-    inc List.389;
-    dec List.390;
-    ret List.389;
-
-procedure List.6 (#Attr.2):
-    let List.388 : U64 = lowlevel ListLen #Attr.2;
+    let List.389 : {List I64, I64} = CallByName List.64 List.98 List.99 List.100;
+    let List.388 : List I64 = StructAtIndex 0 List.389;
+    inc List.388;
+    dec List.389;
     ret List.388;
 
+procedure List.6 (#Attr.2):
+    let List.387 : U64 = lowlevel ListLen #Attr.2;
+    ret List.387;
+
 procedure List.64 (List.95, List.96, List.97):
-    let List.387 : U64 = CallByName List.6 List.95;
-    let List.384 : Int1 = CallByName Num.22 List.96 List.387;
-    if List.384 then
-        let List.385 : {List I64, I64} = CallByName List.67 List.95 List.96 List.97;
-        ret List.385;
+    let List.386 : U64 = CallByName List.6 List.95;
+    let List.383 : Int1 = CallByName Num.22 List.96 List.386;
+    if List.383 then
+        let List.384 : {List I64, I64} = CallByName List.67 List.95 List.96 List.97;
+        ret List.384;
     else
-        let List.383 : {List I64, I64} = Struct {List.95, List.97};
-        ret List.383;
+        let List.382 : {List I64, I64} = Struct {List.95, List.97};
+        ret List.382;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.396 : I64 = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.396;
+    let List.395 : I64 = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.395;
 
 procedure List.67 (#Attr.2, #Attr.3, #Attr.4):
-    let List.386 : {List I64, I64} = lowlevel ListReplaceUnsafe #Attr.2 #Attr.3 #Attr.4;
-    ret List.386;
+    let List.385 : {List I64, I64} = lowlevel ListReplaceUnsafe #Attr.2 #Attr.3 #Attr.4;
+    ret List.385;
 
 procedure Num.22 (#Attr.2, #Attr.3):
     let Num.259 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/rigids.txt
+++ b/crates/compiler/test_mono/generated/rigids.txt
@@ -1,43 +1,43 @@
 procedure List.2 (List.90, List.91):
-    let List.403 : U64 = CallByName List.6 List.90;
-    let List.400 : Int1 = CallByName Num.22 List.91 List.403;
-    if List.400 then
-        let List.402 : I64 = CallByName List.66 List.90 List.91;
-        let List.401 : [C {}, C I64] = TagId(1) List.402;
-        ret List.401;
+    let List.402 : U64 = CallByName List.6 List.90;
+    let List.399 : Int1 = CallByName Num.22 List.91 List.402;
+    if List.399 then
+        let List.401 : I64 = CallByName List.66 List.90 List.91;
+        let List.400 : [C {}, C I64] = TagId(1) List.401;
+        ret List.400;
     else
-        let List.399 : {} = Struct {};
-        let List.398 : [C {}, C I64] = TagId(0) List.399;
-        ret List.398;
+        let List.398 : {} = Struct {};
+        let List.397 : [C {}, C I64] = TagId(0) List.398;
+        ret List.397;
 
 procedure List.3 (List.98, List.99, List.100):
-    let List.390 : {List I64, I64} = CallByName List.64 List.98 List.99 List.100;
-    let List.389 : List I64 = StructAtIndex 0 List.390;
-    inc List.389;
-    dec List.390;
-    ret List.389;
-
-procedure List.6 (#Attr.2):
-    let List.388 : U64 = lowlevel ListLen #Attr.2;
+    let List.389 : {List I64, I64} = CallByName List.64 List.98 List.99 List.100;
+    let List.388 : List I64 = StructAtIndex 0 List.389;
+    inc List.388;
+    dec List.389;
     ret List.388;
 
+procedure List.6 (#Attr.2):
+    let List.387 : U64 = lowlevel ListLen #Attr.2;
+    ret List.387;
+
 procedure List.64 (List.95, List.96, List.97):
-    let List.387 : U64 = CallByName List.6 List.95;
-    let List.384 : Int1 = CallByName Num.22 List.96 List.387;
-    if List.384 then
-        let List.385 : {List I64, I64} = CallByName List.67 List.95 List.96 List.97;
-        ret List.385;
+    let List.386 : U64 = CallByName List.6 List.95;
+    let List.383 : Int1 = CallByName Num.22 List.96 List.386;
+    if List.383 then
+        let List.384 : {List I64, I64} = CallByName List.67 List.95 List.96 List.97;
+        ret List.384;
     else
-        let List.383 : {List I64, I64} = Struct {List.95, List.97};
-        ret List.383;
+        let List.382 : {List I64, I64} = Struct {List.95, List.97};
+        ret List.382;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.396 : I64 = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.396;
+    let List.395 : I64 = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.395;
 
 procedure List.67 (#Attr.2, #Attr.3, #Attr.4):
-    let List.386 : {List I64, I64} = lowlevel ListReplaceUnsafe #Attr.2 #Attr.3 #Attr.4;
-    ret List.386;
+    let List.385 : {List I64, I64} = lowlevel ListReplaceUnsafe #Attr.2 #Attr.3 #Attr.4;
+    ret List.385;
 
 procedure Num.22 (#Attr.2, #Attr.3):
     let Num.259 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/unreachable_void_constructor.txt
+++ b/crates/compiler/test_mono/generated/unreachable_void_constructor.txt
@@ -1,7 +1,11 @@
+procedure Bool.2 ():
+    let Bool.11 : Int1 = true;
+    ret Bool.11;
+
 procedure Test.0 ():
-    let Test.7 : Int1 = true;
-    if Test.7 then
+    let Test.6 : Int1 = CallByName Bool.2;
+    if Test.6 then
         Error voided tag constructor is unreachable
     else
-        let Test.6 : Str = "abc";
-        ret Test.6;
+        let Test.5 : Str = "abc";
+        ret Test.5;

--- a/crates/compiler/test_mono/src/tests.rs
+++ b/crates/compiler/test_mono/src/tests.rs
@@ -1958,7 +1958,7 @@ fn unreachable_void_constructor() {
 
         x : []
 
-        main = if True then Ok x else Err "abc" 
+        main = if Bool.true then Ok x else Err "abc" 
         "#
     )
 }

--- a/crates/compiler/test_mono/src/tests.rs
+++ b/crates/compiler/test_mono/src/tests.rs
@@ -1361,26 +1361,26 @@ fn encode() {
         r#"
         app "test" provides [myU8Bytes] to "./platform"
 
-        Encoder fmt := List U8, fmt -> List U8 | fmt has Format
+        MEncoder fmt := List U8, fmt -> List U8 | fmt has Format
 
-        Encoding has
-          toEncoder : val -> Encoder fmt | val has Encoding, fmt has Format
+        MEncoding has
+          toEncoder : val -> MEncoder fmt | val has MEncoding, fmt has Format
 
         Format has
-          u8 : U8 -> Encoder fmt | fmt has Format
+          u8 : U8 -> MEncoder fmt | fmt has Format
 
 
         Linear := {} has [Format {u8}]
 
-        u8 = \n -> @Encoder (\lst, @Linear {} -> List.append lst n)
+        u8 = \n -> @MEncoder (\lst, @Linear {} -> List.append lst n)
 
-        MyU8 := U8 has [Encoding {toEncoder}]
+        MyU8 := U8 has [MEncoding {toEncoder}]
 
         toEncoder = \@MyU8 n -> u8 n
 
         myU8Bytes =
             when toEncoder (@MyU8 15) is
-                @Encoder doEncode -> doEncode [] (@Linear {})
+                @MEncoder doEncode -> doEncode [] (@Linear {})
         "#
     )
 }

--- a/crates/repl_eval/src/eval.rs
+++ b/crates/repl_eval/src/eval.rs
@@ -380,8 +380,6 @@ fn jit_to_ast_help<'a, A: ReplApp<'a>>(
                     Ok(struct_to_ast(env, mem, addr, RecordFields::empty()))
                 }
                 Content::Structure(FlatType::TagUnion(tags, _)) => {
-                    debug_assert_eq!(tags.len(), 1);
-
                     let (tag_name, payload_vars) = unpack_single_element_tag_union(env.subs, *tags);
 
                     Ok(single_tag_union_to_ast(

--- a/crates/reporting/tests/test_reporting.rs
+++ b/crates/reporting/tests/test_reporting.rs
@@ -10186,7 +10186,7 @@ All branches in an `if` must have the same type!
         derive_decoding_for_function,
         indoc!(
             r#"
-            app "test" imports [Decode] provides [A] to "./platform"
+            app "test" imports [] provides [A] to "./platform"
 
             A a := a -> a has [Decode.Decoding]
             "#
@@ -10209,7 +10209,7 @@ All branches in an `if` must have the same type!
         derive_decoding_for_non_decoding_opaque,
         indoc!(
             r#"
-            app "test" imports [Decode] provides [A] to "./platform"
+            app "test" imports [] provides [A] to "./platform"
 
             A := B has [Decode.Decoding]
 
@@ -10235,7 +10235,7 @@ All branches in an `if` must have the same type!
         derive_decoding_for_other_has_decoding,
         indoc!(
             r#"
-            app "test" imports [Decode] provides [A] to "./platform"
+            app "test" imports [] provides [A] to "./platform"
 
             A := B has [Decode.Decoding]
 
@@ -10249,7 +10249,7 @@ All branches in an `if` must have the same type!
         derive_decoding_for_recursive_deriving,
         indoc!(
             r#"
-            app "test" imports [Decode] provides [MyNat] to "./platform"
+            app "test" imports [] provides [MyNat] to "./platform"
 
             MyNat := [S MyNat, Z] has [Decode.Decoding]
             "#
@@ -10261,7 +10261,7 @@ All branches in an `if` must have the same type!
         function_cannot_derive_encoding,
         indoc!(
             r#"
-            app "test" imports [Decode.{Decoder, DecoderFormatting, decoder}] provides [main] to "./platform"
+            app "test" imports [Decode.{decoder}] provides [main] to "./platform"
 
             main =
                 myDecoder : Decoder (a -> a) fmt | fmt has DecoderFormatting
@@ -10291,7 +10291,7 @@ All branches in an `if` must have the same type!
         nested_opaque_cannot_derive_encoding,
         indoc!(
             r#"
-            app "test" imports [Decode.{Decoder, DecoderFormatting, decoder}] provides [main] to "./platform"
+            app "test" imports [Decode.{decoder}] provides [main] to "./platform"
 
             A := {}
 
@@ -10475,7 +10475,7 @@ All branches in an `if` must have the same type!
         infer_decoded_record_error_with_function_field,
         indoc!(
             r#"
-            app "test" imports [Decode, Json] provides [main] to "./platform"
+            app "test" imports [Json] provides [main] to "./platform"
 
             main =
                 decoded = Str.toUtf8 "{\"first\":\"ab\",\"second\":\"cd\"}" |> Decode.fromBytes Json.fromUtf8
@@ -10505,7 +10505,7 @@ All branches in an `if` must have the same type!
         record_with_optional_field_types_cannot_derive_decoding,
         indoc!(
             r#"
-             app "test" imports [Decode.{Decoder, DecoderFormatting, decoder}] provides [main] to "./platform"
+             app "test" imports [Decode.{decoder}] provides [main] to "./platform"
 
              main =
                  myDecoder : Decoder {x : Str, y ? Str} fmt | fmt has DecoderFormatting

--- a/crates/reporting/tests/test_reporting.rs
+++ b/crates/reporting/tests/test_reporting.rs
@@ -9082,7 +9082,7 @@ All branches in an `if` must have the same type!
         function_does_not_implement_encoding,
         indoc!(
             r#"
-            app "test" imports [Encode] provides [main] to "./platform"
+            app "test" imports [] provides [main] to "./platform"
 
             main = Encode.toEncoder \x -> x
             "#
@@ -9108,7 +9108,7 @@ All branches in an `if` must have the same type!
         nested_opaque_does_not_implement_encoding,
         indoc!(
             r#"
-            app "test" imports [Encode] provides [main] to "./platform"
+            app "test" imports [] provides [main] to "./platform"
 
             A := {}
             main = Encode.toEncoder { x: @A {} }
@@ -9293,7 +9293,7 @@ All branches in an `if` must have the same type!
         indoc!(
             r#"
             app "test"
-                imports [Encode.{ Encoding }]
+                imports []
                 provides [A, myEncoder] to "./platform"
 
             A := U8 has [ Encoding {toEncoder ? myEncoder} ]
@@ -9482,7 +9482,7 @@ All branches in an `if` must have the same type!
         has_encoding_for_function,
         indoc!(
             r#"
-            app "test" imports [Encode] provides [A] to "./platform"
+            app "test" imports [] provides [A] to "./platform"
 
             A a := a -> a has [Encode.Encoding]
             "#
@@ -9505,7 +9505,7 @@ All branches in an `if` must have the same type!
         has_encoding_for_non_encoding_alias,
         indoc!(
             r#"
-            app "test" imports [Encode] provides [A] to "./platform"
+            app "test" imports [] provides [A] to "./platform"
 
             A := B has [Encode.Encoding]
 
@@ -9531,7 +9531,7 @@ All branches in an `if` must have the same type!
         has_encoding_for_other_has_encoding,
         indoc!(
             r#"
-            app "test" imports [Encode] provides [A] to "./platform"
+            app "test" imports [] provides [A] to "./platform"
 
             A := B has [Encode.Encoding]
 
@@ -9545,7 +9545,7 @@ All branches in an `if` must have the same type!
         has_encoding_for_recursive_deriving,
         indoc!(
             r#"
-            app "test" imports [Encode] provides [MyNat] to "./platform"
+            app "test" imports [] provides [MyNat] to "./platform"
 
             MyNat := [S MyNat, Z] has [Encode.Encoding]
             "#

--- a/examples/benchmarks/Base64/Decode.roc
+++ b/examples/benchmarks/Base64/Decode.roc
@@ -1,13 +1,13 @@
-interface Base64.Decode exposes [fromBytes] imports [Bytes.Decode.{ Decoder, DecodeProblem }]
+interface Base64.Decode exposes [fromBytes] imports [Bytes.Decode.{ ByteDecoder, DecodeProblem }]
 
 fromBytes : List U8 -> Result Str DecodeProblem
 fromBytes = \bytes ->
     Bytes.Decode.decode bytes (decodeBase64 (List.len bytes))
 
-decodeBase64 : Nat -> Decoder Str
+decodeBase64 : Nat -> ByteDecoder Str
 decodeBase64 = \width -> Bytes.Decode.loop loopHelp { remaining: width, string: "" }
 
-loopHelp : { remaining : Nat, string : Str } -> Decoder (Bytes.Decode.Step { remaining : Nat, string : Str } Str)
+loopHelp : { remaining : Nat, string : Str } -> ByteDecoder (Bytes.Decode.Step { remaining : Nat, string : Str } Str)
 loopHelp = \{ remaining, string } ->
     if remaining >= 3 then
         x, y, z <- Bytes.Decode.map3 Bytes.Decode.u8 Bytes.Decode.u8 Bytes.Decode.u8

--- a/examples/benchmarks/Base64/Encode.roc
+++ b/examples/benchmarks/Base64/Encode.roc
@@ -1,6 +1,6 @@
 interface Base64.Encode
     exposes [toBytes]
-    imports [Bytes.Encode.{ Encoder }]
+    imports [Bytes.Encode.{ ByteEncoder }]
 
 InvalidChar : U8
 
@@ -13,7 +13,7 @@ toBytes = \str ->
     |> Bytes.Encode.sequence
     |> Bytes.Encode.encode
 
-encodeChunks : List U8 -> List Encoder
+encodeChunks : List U8 -> List ByteEncoder
 encodeChunks = \bytes ->
     List.walk bytes { output: [], accum: None } folder
     |> encodeResidual
@@ -21,7 +21,7 @@ encodeChunks = \bytes ->
 coerce : Nat, a -> a
 coerce = \_, x -> x
 
-# folder : { output : List Encoder, accum : State }, U8 -> { output : List Encoder, accum : State }
+# folder : { output : List ByteEncoder, accum : State }, U8 -> { output : List ByteEncoder, accum : State }
 folder = \{ output, accum }, char ->
     when accum is
         Unreachable n -> coerce n { output, accum: Unreachable n }
@@ -40,7 +40,7 @@ folder = \{ output, accum }, char ->
                     { output, accum: None }
 
 #  SGVs bG8g V29y bGQ=
-# encodeResidual : { output : List Encoder, accum : State } -> List Encoder
+# encodeResidual : { output : List ByteEncoder, accum : State } -> List ByteEncoder
 encodeResidual = \{ output, accum } ->
     when accum is
         Unreachable _ -> output
@@ -59,8 +59,8 @@ encodeResidual = \{ output, accum } ->
 equals : U8
 equals = 61
 
-# Convert 4 characters to 24 bits (as an Encoder)
-encodeCharacters : U8, U8, U8, U8 -> Result Encoder InvalidChar
+# Convert 4 characters to 24 bits (as an ByteEncoder)
+encodeCharacters : U8, U8, U8, U8 -> Result ByteEncoder InvalidChar
 encodeCharacters = \a, b, c, d ->
     if !(isValidChar a) then
         Err a

--- a/examples/benchmarks/Bytes/Encode.roc
+++ b/examples/benchmarks/Bytes/Encode.roc
@@ -1,30 +1,30 @@
-interface Bytes.Encode exposes [Encoder, sequence, u8, u16, bytes, empty, encode] imports []
+interface Bytes.Encode exposes [ByteEncoder, sequence, u8, u16, bytes, empty, encode] imports []
 
 Endianness : [BE, LE]
 
-Encoder : [Signed8 I8, Unsigned8 U8, Signed16 Endianness I16, Unsigned16 Endianness U16, Sequence Nat (List Encoder), Bytes (List U8)]
+ByteEncoder : [Signed8 I8, Unsigned8 U8, Signed16 Endianness I16, Unsigned16 Endianness U16, Sequence Nat (List ByteEncoder), Bytes (List U8)]
 
-u8 : U8 -> Encoder
+u8 : U8 -> ByteEncoder
 u8 = \value -> Unsigned8 value
 
-empty : Encoder
+empty : ByteEncoder
 empty =
-    foo : List Encoder
+    foo : List ByteEncoder
     foo = []
 
     Sequence 0 foo
 
-u16 : Endianness, U16 -> Encoder
+u16 : Endianness, U16 -> ByteEncoder
 u16 = \endianness, value -> Unsigned16 endianness value
 
-bytes : List U8 -> Encoder
+bytes : List U8 -> ByteEncoder
 bytes = \bs -> Bytes bs
 
-sequence : List Encoder -> Encoder
+sequence : List ByteEncoder -> ByteEncoder
 sequence = \encoders ->
     Sequence (getWidths encoders 0) encoders
 
-getWidth : Encoder -> Nat
+getWidth : ByteEncoder -> Nat
 getWidth = \encoder ->
     when encoder is
         Signed8 _ -> 1
@@ -40,18 +40,18 @@ getWidth = \encoder ->
         Sequence w _ -> w
         Bytes bs -> List.len bs
 
-getWidths : List Encoder, Nat -> Nat
+getWidths : List ByteEncoder, Nat -> Nat
 getWidths = \encoders, initial ->
     List.walk encoders initial \accum, encoder -> accum + getWidth encoder
 
-encode : Encoder -> List U8
+encode : ByteEncoder -> List U8
 encode = \encoder ->
     output = List.repeat 0 (getWidth encoder)
 
     encodeHelp encoder 0 output
     |> .output
 
-encodeHelp : Encoder, Nat, List U8 -> { output : List U8, offset : Nat }
+encodeHelp : ByteEncoder, Nat, List U8 -> { output : List U8, offset : Nat }
 encodeHelp = \encoder, offset, output ->
     when encoder is
         Unsigned8 value ->


### PR DESCRIPTION
This PR fixes scope resolution so that the `Encoding` and `Decoding` modules are always imported in user module scopes, and moreover all of their types and abilities are imported by default.

In the next PR I'll make the resolution of types to import easier to manage, add errors for redundant imports of builtin types, and hopefully tests for all that.