### PR TITLE
Improve how builtin modules and their types are imported

### DIFF
--- a/crates/ast/src/lang/scope.rs
+++ b/crates/ast/src/lang/scope.rs
@@ -169,7 +169,7 @@ impl Scope {
             aliases.insert(symbol, alias);
         }
 
-        let idents = Symbol::default_in_scope();
+        let idents = Symbol::apply_types_in_scope();
         let idents: MutMap<_, _> = idents.into_iter().collect();
 
         Scope {

--- a/crates/compiler/can/src/scope.rs
+++ b/crates/compiler/can/src/scope.rs
@@ -695,9 +695,9 @@ mod test {
             &[
                 Ident::from("Str"),
                 Ident::from("List"),
+                Ident::from("Box"),
                 Ident::from("Ok"),
                 Ident::from("Err"),
-                Ident::from("Box"),
             ]
         );
     }
@@ -718,9 +718,9 @@ mod test {
             &[
                 Ident::from("Str"),
                 Ident::from("List"),
+                Ident::from("Box"),
                 Ident::from("Ok"),
                 Ident::from("Err"),
-                Ident::from("Box"),
             ]
         );
 

--- a/crates/compiler/can/src/scope.rs
+++ b/crates/compiler/can/src/scope.rs
@@ -47,10 +47,13 @@ impl Scope {
         initial_ident_ids: IdentIds,
         starting_abilities_store: PendingAbilitiesStore,
     ) -> Scope {
-        let imports = Symbol::default_in_scope()
-            .into_iter()
-            .map(|(a, (b, c))| (a, b, c))
-            .collect();
+        let default_imports =
+            // Add all `Apply` types.
+            (Symbol::apply_types_in_scope().into_iter())
+            // Add all tag names we might want to suggest as hints in error messages.
+            .chain(Symbol::symbols_in_scope_for_hints());
+
+        let default_imports = default_imports.map(|(a, (b, c))| (a, b, c)).collect();
 
         Scope {
             home,
@@ -59,7 +62,7 @@ impl Scope {
             aliases: VecMap::default(),
             abilities_store: starting_abilities_store,
             shadows: VecMap::default(),
-            imports,
+            imports: default_imports,
         }
     }
 

--- a/crates/compiler/can/src/scope.rs
+++ b/crates/compiler/can/src/scope.rs
@@ -284,14 +284,14 @@ impl Scope {
         &mut self,
         ident: &Ident,
         region: Region,
-    ) -> Result<Symbol, (Region, Loc<Ident>)> {
+    ) -> Result<Symbol, (Symbol, Region, Loc<Ident>)> {
         match self.introduce_help(ident.as_str(), region) {
-            Err((_, original_region)) => {
+            Err((symbol, original_region)) => {
                 let shadow = Loc {
                     value: ident.clone(),
                     region,
                 };
-                Err((original_region, shadow))
+                Err((symbol, original_region, shadow))
             }
             Ok(symbol) => Ok(symbol),
         }

--- a/crates/compiler/load_internal/src/file.rs
+++ b/crates/compiler/load_internal/src/file.rs
@@ -1988,12 +1988,12 @@ fn report_unused_imported_modules<'a>(
 
     for symbol in constrained_module.module.referenced_values.iter() {
         unused_imported_modules.remove(&symbol.module_id());
-        unused_imports.remove(&symbol);
+        unused_imports.remove(symbol);
     }
 
     for symbol in constrained_module.module.referenced_types.iter() {
         unused_imported_modules.remove(&symbol.module_id());
-        unused_imports.remove(&symbol);
+        unused_imports.remove(symbol);
     }
 
     let existing = match state.module_cache.can_problems.entry(module_id) {

--- a/crates/compiler/load_internal/src/file.rs
+++ b/crates/compiler/load_internal/src/file.rs
@@ -2013,7 +2013,7 @@ fn extend_header_with_builtin(header: &mut ModuleHeader, module: ModuleId) {
     header.imported_modules.insert(module, Region::zero());
 
     let types = Symbol::builtin_types_in_scope(module)
-        .into_iter()
+        .iter()
         .map(|(name, info)| (Ident::from(*name), *info));
     header.exposed_imports.extend(types);
 }
@@ -2126,7 +2126,7 @@ fn update<'a>(
                 extend_header_with_builtin(&mut header, ModuleId::NUM);
             }
 
-            if header.module_id != ModuleId::BOOL {
+            if ![ModuleId::BOOL].contains(&header.module_id) {
                 extend_header_with_builtin(&mut header, ModuleId::BOOL);
             }
 

--- a/crates/compiler/load_internal/tests/fixtures/build/app_with_deps/Primary.roc
+++ b/crates/compiler/load_internal/tests/fixtures/build/app_with_deps/Primary.roc
@@ -1,6 +1,6 @@
 interface Primary
     exposes [blah2, blah3, str, alwaysThree, identity, z, w, succeed, withDefault, yay]
-    imports [Dep1, Dep2.{ two, foo }, Dep3.Blah.{ bar }, Res]
+    imports [Dep1, Dep2.{ two }, Dep3.Blah.{ bar }, Res]
 
 blah2 = Dep2.two
 blah3 = bar

--- a/crates/compiler/load_internal/tests/fixtures/build/interface_with_deps/Primary.roc
+++ b/crates/compiler/load_internal/tests/fixtures/build/interface_with_deps/Primary.roc
@@ -1,6 +1,6 @@
 interface Primary
     exposes [blah2, blah3, str, alwaysThree, identity, z, w, succeed, withDefault, yay]
-    imports [Dep1, Dep2.{ two, foo }, Dep3.Blah.{ bar }, Res]
+    imports [Dep1, Dep2.{ two }, Dep3.Blah.{ bar }, Res]
 
 blah2 = Dep2.two
 blah3 = bar

--- a/crates/compiler/load_internal/tests/test_load.rs
+++ b/crates/compiler/load_internal/tests/test_load.rs
@@ -779,7 +779,7 @@ fn opaque_wrapped_unwrapped_outside_defining_module() {
                 is imported from another module:
 
                 1│  interface Main exposes [twenty, readAge] imports [Age.{ Age }]
-                                                                      ^^^^^^^^^^^
+                                                                            ^^^
 
                 Note: Opaque types can only be wrapped and unwrapped in the module they are defined in!
 
@@ -793,7 +793,7 @@ fn opaque_wrapped_unwrapped_outside_defining_module() {
                 is imported from another module:
 
                 1│  interface Main exposes [twenty, readAge] imports [Age.{ Age }]
-                                                                      ^^^^^^^^^^^
+                                                                            ^^^
 
                 Note: Opaque types can only be wrapped and unwrapped in the module they are defined in!
 

--- a/crates/compiler/module/src/symbol.rs
+++ b/crates/compiler/module/src/symbol.rs
@@ -791,7 +791,8 @@ macro_rules! define_builtins {
             $module_id:literal $module_const:ident: $module_name:literal => {
                 $(
                     $ident_id:literal $ident_const:ident: $ident_name:literal
-                    $(is_apply_type=$is_apply_type:literal)?
+                    $(exposed_apply_type=$exposed_apply_type:literal)?
+                    $(exposed_type=$exposed_type:literal)?
                     $(in_scope_for_hints=$in_scope_for_hints:literal)?
                 )*
             }
@@ -954,7 +955,7 @@ macro_rules! define_builtins {
                 $(
                     $(
                         $(
-                            if $is_apply_type {
+                            if $exposed_apply_type {
                                 scope.insert($ident_name.into(), (Symbol::new(ModuleId::$module_const, IdentId($ident_id)), Region::zero()));
                             }
                         )?
@@ -962,6 +963,30 @@ macro_rules! define_builtins {
                 )+
 
                 scope
+            }
+
+            /// Types from a builtin module that should always be added to the default scope.
+            #[track_caller]
+            pub fn builtin_types_in_scope(module_id: ModuleId) -> &'static [(&'static str, (Symbol, Region))] {
+                match module_id {
+                    $(
+                    ModuleId::$module_const => {
+                        const LIST : &'static [(&'static str, (Symbol, Region))] = &[
+                            $(
+                                $(
+                                    if $exposed_type {
+                                        ($ident_name, (Symbol::new(ModuleId::$module_const, IdentId($ident_id)), Region::zero()))
+                                    } else {
+                                        unreachable!()
+                                    },
+                                )?
+                            )*
+                        ];
+                        LIST
+                    }
+                    )+
+                    m => roc_error_macros::internal_error!("{:?} is not a builtin module!", m),
+                }
             }
 
             /// Symbols that should be added to the default scope, for hints as suggestions of
@@ -1056,21 +1081,21 @@ define_builtins! {
     2 DERIVED_GEN: "#Derived_gen" => {
     }
     3 NUM: "Num" => {
-        0 NUM_NUM: "Num"  // the Num.Num type alias
-        1 NUM_I128: "I128"  // the Num.I128 type alias
-        2 NUM_U128: "U128"  // the Num.U128 type alias
-        3 NUM_I64: "I64"  // the Num.I64 type alias
-        4 NUM_U64: "U64"  // the Num.U64 type alias
-        5 NUM_I32: "I32"  // the Num.I32 type alias
-        6 NUM_U32: "U32"  // the Num.U32 type alias
-        7 NUM_I16: "I16"  // the Num.I16 type alias
-        8 NUM_U16: "U16"  // the Num.U16 type alias
-        9 NUM_I8: "I8"  // the Num.I8 type alias
-        10 NUM_U8: "U8"  // the Num.U8 type alias
-        11 NUM_INTEGER: "Integer" // Int : Num Integer
-        12 NUM_F64: "F64"  // the Num.F64 type alias
-        13 NUM_F32: "F32"  // the Num.F32 type alias
-        14 NUM_FLOATINGPOINT: "FloatingPoint" // Float : Num FloatingPoint
+        0 NUM_NUM: "Num" exposed_type=true  // the Num.Num type alias
+        1 NUM_I128: "I128" exposed_type=true  // the Num.I128 type alias
+        2 NUM_U128: "U128" exposed_type=true  // the Num.U128 type alias
+        3 NUM_I64: "I64" exposed_type=true  // the Num.I64 type alias
+        4 NUM_U64: "U64" exposed_type=true  // the Num.U64 type alias
+        5 NUM_I32: "I32" exposed_type=true  // the Num.I32 type alias
+        6 NUM_U32: "U32" exposed_type=true  // the Num.U32 type alias
+        7 NUM_I16: "I16" exposed_type=true  // the Num.I16 type alias
+        8 NUM_U16: "U16" exposed_type=true  // the Num.U16 type alias
+        9 NUM_I8: "I8" exposed_type=true  // the Num.I8 type alias
+        10 NUM_U8: "U8" exposed_type=true  // the Num.U8 type alias
+        11 NUM_INTEGER: "Integer" exposed_type=true // Int : Num Integer
+        12 NUM_F64: "F64" exposed_type=true  // the Num.F64 type alias
+        13 NUM_F32: "F32" exposed_type=true  // the Num.F32 type alias
+        14 NUM_FLOATINGPOINT: "FloatingPoint" exposed_type=true // Float : Num FloatingPoint
         15 NUM_MAX_F32: "maxF32"
         16 NUM_MIN_F32: "minF32"
         17 NUM_ABS: "abs"
@@ -1113,18 +1138,18 @@ define_builtins! {
         54 NUM_ATAN: "atan"
         55 NUM_ACOS: "acos"
         56 NUM_ASIN: "asin"
-        57 NUM_SIGNED128: "Signed128"
-        58 NUM_SIGNED64: "Signed64"
-        59 NUM_SIGNED32: "Signed32"
-        60 NUM_SIGNED16: "Signed16"
-        61 NUM_SIGNED8: "Signed8"
-        62 NUM_UNSIGNED128: "Unsigned128"
-        63 NUM_UNSIGNED64: "Unsigned64"
-        64 NUM_UNSIGNED32: "Unsigned32"
-        65 NUM_UNSIGNED16: "Unsigned16"
-        66 NUM_UNSIGNED8: "Unsigned8"
-        67 NUM_BINARY64: "Binary64"
-        68 NUM_BINARY32: "Binary32"
+        57 NUM_SIGNED128: "Signed128" exposed_type=true
+        58 NUM_SIGNED64: "Signed64" exposed_type=true
+        59 NUM_SIGNED32: "Signed32" exposed_type=true
+        60 NUM_SIGNED16: "Signed16" exposed_type=true
+        61 NUM_SIGNED8: "Signed8" exposed_type=true
+        62 NUM_UNSIGNED128: "Unsigned128" exposed_type=true
+        63 NUM_UNSIGNED64: "Unsigned64" exposed_type=true
+        64 NUM_UNSIGNED32: "Unsigned32" exposed_type=true
+        65 NUM_UNSIGNED16: "Unsigned16" exposed_type=true
+        66 NUM_UNSIGNED8: "Unsigned8" exposed_type=true
+        67 NUM_BINARY64: "Binary64" exposed_type=true
+        68 NUM_BINARY32: "Binary32" exposed_type=true
         69 NUM_BITWISE_AND: "bitwiseAnd"
         70 NUM_BITWISE_XOR: "bitwiseXor"
         71 NUM_BITWISE_OR: "bitwiseOr"
@@ -1137,13 +1162,13 @@ define_builtins! {
         78 NUM_MUL_WRAP: "mulWrap"
         79 NUM_MUL_CHECKED: "mulChecked"
         80 NUM_MUL_SATURATED: "mulSaturated"
-        81 NUM_INT: "Int"
-        82 NUM_FRAC: "Frac"
-        83 NUM_NATURAL: "Natural"
-        84 NUM_NAT: "Nat"
+        81 NUM_INT: "Int" exposed_type=true
+        82 NUM_FRAC: "Frac" exposed_type=true
+        83 NUM_NATURAL: "Natural" exposed_type=true
+        84 NUM_NAT: "Nat" exposed_type=true
         85 NUM_INT_CAST: "intCast"
         86 NUM_IS_MULTIPLE_OF: "isMultipleOf"
-        87 NUM_DECIMAL: "Decimal"
+        87 NUM_DECIMAL: "Decimal" exposed_type=true
         88 NUM_DEC: "Dec"  // the Num.Dectype alias
         89 NUM_BYTES_TO_U16: "bytesToU16"
         90 NUM_BYTES_TO_U32: "bytesToU32"
@@ -1204,7 +1229,7 @@ define_builtins! {
         145 NUM_BYTES_TO_U32_LOWLEVEL: "bytesToU32Lowlevel"
     }
     4 BOOL: "Bool" => {
-        0 BOOL_BOOL: "Bool" // the Bool.Bool type alias
+        0 BOOL_BOOL: "Bool" exposed_type=true // the Bool.Bool type alias
         1 BOOL_FALSE: "false"
         2 BOOL_TRUE: "true"
         3 BOOL_AND: "and"
@@ -1215,7 +1240,7 @@ define_builtins! {
         8 BOOL_NEQ: "isNotEq"
     }
     5 STR: "Str" => {
-        0 STR_STR: "Str" is_apply_type=true // the Str.Str type alias
+        0 STR_STR: "Str" exposed_apply_type=true // the Str.Str type alias
         1 STR_IS_EMPTY: "isEmpty"
         2 STR_APPEND: "#append" // unused
         3 STR_CONCAT: "concat"
@@ -1270,7 +1295,7 @@ define_builtins! {
         52 STR_REPLACE_LAST: "replaceLast"
     }
     6 LIST: "List" => {
-        0 LIST_LIST: "List" is_apply_type=true // the List.List type alias
+        0 LIST_LIST: "List" exposed_apply_type=true // the List.List type alias
         1 LIST_IS_EMPTY: "isEmpty"
         2 LIST_GET: "get"
         3 LIST_SET: "set"
@@ -1347,7 +1372,7 @@ define_builtins! {
         74 LIST_MAP_TRY: "mapTry"
     }
     7 RESULT: "Result" => {
-        0 RESULT_RESULT: "Result" // the Result.Result type alias
+        0 RESULT_RESULT: "Result" exposed_type=true // the Result.Result type alias
         1 RESULT_OK: "Ok" in_scope_for_hints=true // Result.Result a e = [Ok a, Err e]
         2 RESULT_ERR: "Err" in_scope_for_hints=true // Result.Result a e = [Ok a, Err e]
         3 RESULT_MAP: "map"
@@ -1359,7 +1384,7 @@ define_builtins! {
         9 RESULT_ON_ERR: "onErr"
     }
     8 DICT: "Dict" => {
-        0 DICT_DICT: "Dict" // the Dict.Dict type alias
+        0 DICT_DICT: "Dict" exposed_type=true // the Dict.Dict type alias
         1 DICT_EMPTY: "empty"
         2 DICT_SINGLE: "single"
         3 DICT_GET: "get"
@@ -1381,7 +1406,7 @@ define_builtins! {
         16 DICT_CAPACITY: "capacity"
     }
     9 SET: "Set" => {
-        0 SET_SET: "Set" // the Set.Set type alias
+        0 SET_SET: "Set" exposed_type=true // the Set.Set type alias
         1 SET_EMPTY: "empty"
         2 SET_SINGLE: "single"
         3 SET_LEN: "len"
@@ -1399,15 +1424,15 @@ define_builtins! {
         15 SET_CAPACITY: "capacity"
     }
     10 BOX: "Box" => {
-        0 BOX_BOX_TYPE: "Box" is_apply_type=true // the Box.Box opaque type
+        0 BOX_BOX_TYPE: "Box" exposed_apply_type=true // the Box.Box opaque type
         1 BOX_BOX_FUNCTION: "box" // Box.box
         2 BOX_UNBOX: "unbox"
     }
     11 ENCODE: "Encode" => {
-        0 ENCODE_ENCODER: "Encoder"
-        1 ENCODE_ENCODING: "Encoding"
+        0 ENCODE_ENCODER: "Encoder" exposed_type=true
+        1 ENCODE_ENCODING: "Encoding" exposed_type=true
         2 ENCODE_TO_ENCODER: "toEncoder"
-        3 ENCODE_ENCODERFORMATTING: "EncoderFormatting"
+        3 ENCODE_ENCODERFORMATTING: "EncoderFormatting" exposed_type=true
         4 ENCODE_U8: "u8"
         5 ENCODE_U16: "u16"
         6 ENCODE_U32: "u32"
@@ -1432,12 +1457,12 @@ define_builtins! {
         25 ENCODE_TO_BYTES: "toBytes"
     }
     12 DECODE: "Decode" => {
-        0 DECODE_DECODE_ERROR: "DecodeError"
-        1 DECODE_DECODE_RESULT: "DecodeResult"
-        2 DECODE_DECODER_OPAQUE: "Decoder"
-        3 DECODE_DECODING: "Decoding"
+        0 DECODE_DECODE_ERROR: "DecodeError" exposed_type=true
+        1 DECODE_DECODE_RESULT: "DecodeResult" exposed_type=true
+        2 DECODE_DECODER_OPAQUE: "Decoder" exposed_type=true
+        3 DECODE_DECODING: "Decoding" exposed_type=true
         4 DECODE_DECODER: "decoder"
-        5 DECODE_DECODERFORMATTING: "DecoderFormatting"
+        5 DECODE_DECODERFORMATTING: "DecoderFormatting" exposed_type=true
         6 DECODE_U8: "u8"
         7 DECODE_U16: "u16"
         8 DECODE_U32: "u32"

--- a/crates/compiler/module/src/symbol.rs
+++ b/crates/compiler/module/src/symbol.rs
@@ -1169,7 +1169,7 @@ define_builtins! {
         85 NUM_INT_CAST: "intCast"
         86 NUM_IS_MULTIPLE_OF: "isMultipleOf"
         87 NUM_DECIMAL: "Decimal" exposed_type=true
-        88 NUM_DEC: "Dec"  // the Num.Dectype alias
+        88 NUM_DEC: "Dec" exposed_type=true  // the Num.Dectype alias
         89 NUM_BYTES_TO_U16: "bytesToU16"
         90 NUM_BYTES_TO_U32: "bytesToU32"
         91 NUM_CAST_TO_NAT: "#castToNat"

--- a/crates/compiler/problem/src/can.rs
+++ b/crates/compiler/problem/src/can.rs
@@ -31,7 +31,8 @@ pub enum ShadowKind {
 #[derive(Clone, Debug, PartialEq)]
 pub enum Problem {
     UnusedDef(Symbol, Region),
-    UnusedImport(ModuleId, Region),
+    UnusedImport(Symbol, Region),
+    UnusedModuleImport(ModuleId, Region),
     ExposedButNotDefined(Symbol),
     UnknownGeneratesWith(Loc<Ident>),
     /// First symbol is the name of the closure with that argument

--- a/crates/compiler/problem/src/can.rs
+++ b/crates/compiler/problem/src/can.rs
@@ -22,9 +22,9 @@ pub enum BadPattern {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ShadowKind {
     Variable,
-    Alias,
-    Opaque,
-    Ability,
+    Alias(Symbol),
+    Opaque(Symbol),
+    Ability(Symbol),
 }
 
 /// Problems that can occur in the course of canonicalization.

--- a/crates/compiler/test_gen/src/gen_abilities.rs
+++ b/crates/compiler/test_gen/src/gen_abilities.rs
@@ -328,7 +328,7 @@ fn encode_use_stdlib() {
         indoc!(
             r#"
             app "test"
-                imports [Encode.{ toEncoder }, Json]
+                imports [Encode, Json]
                 provides [main] to "./platform"
 
             HelloWorld := {} has [Encoding {toEncoder}]
@@ -356,7 +356,7 @@ fn encode_use_stdlib_without_wrapping_custom() {
         indoc!(
             r#"
             app "test"
-                imports [Encode.{ toEncoder }, Json]
+                imports [Encode, Json]
                 provides [main] to "./platform"
 
             HelloWorld := {} has [Encoding {toEncoder}]
@@ -381,7 +381,7 @@ fn to_encoder_encode_custom_has_capture() {
         indoc!(
             r#"
             app "test"
-                imports [Encode.{ toEncoder }, Json]
+                imports [Encode, Json]
                 provides [main] to "./platform"
 
             HelloWorld := Str has [Encoding {toEncoder}]
@@ -421,7 +421,7 @@ mod encode_immediate {
         assert_evals_to!(
             indoc!(
                 r#"
-                app "test" imports [Encode.{ toEncoder }, Json] provides [main] to "./platform"
+                app "test" imports [Encode, Json] provides [main] to "./platform"
 
                 main =
                     when Str.fromUtf8 (Encode.toBytes "foo" Json.toUtf8) is
@@ -442,7 +442,7 @@ mod encode_immediate {
                 assert_evals_to!(
                     &format!(indoc!(
                         r#"
-                        app "test" imports [Encode.{{ toEncoder }}, Json] provides [main] to "./platform"
+                        app "test" imports [Encode, Json] provides [main] to "./platform"
 
                         main =
                             when Str.fromUtf8 (Encode.toBytes {}{} Json.toUtf8) is
@@ -481,7 +481,7 @@ fn encode_derived_record_one_field_string() {
         indoc!(
             r#"
             app "test"
-                imports [Encode.{ toEncoder }, Json]
+                imports [Encode, Json]
                 provides [main] to "./platform"
 
             main =
@@ -503,7 +503,7 @@ fn encode_derived_record_two_fields_strings() {
         indoc!(
             r#"
             app "test"
-                imports [Encode.{ toEncoder }, Json]
+                imports [Encode, Json]
                 provides [main] to "./platform"
 
             main =
@@ -526,7 +526,7 @@ fn encode_derived_nested_record_string() {
         indoc!(
             r#"
             app "test"
-                imports [Encode.{ toEncoder }, Json]
+                imports [Encode, Json]
                 provides [main] to "./platform"
 
             main =
@@ -550,7 +550,7 @@ fn encode_derived_tag_one_payload_string() {
         indoc!(
             r#"
             app "test"
-                imports [Encode.{ toEncoder }, Json]
+                imports [Encode, Json]
                 provides [main] to "./platform"
 
             main =
@@ -573,7 +573,7 @@ fn encode_derived_tag_two_payloads_string() {
         indoc!(
             r#"
             app "test"
-                imports [Encode.{ toEncoder }, Json]
+                imports [Encode, Json]
                 provides [main] to "./platform"
 
             main =
@@ -596,7 +596,7 @@ fn encode_derived_nested_tag_string() {
         indoc!(
             r#"
             app "test"
-                imports [Encode.{ toEncoder }, Json]
+                imports [Encode, Json]
                 provides [main] to "./platform"
 
             main =
@@ -620,7 +620,7 @@ fn encode_derived_nested_record_tag_record() {
         indoc!(
             r#"
             app "test"
-                imports [Encode.{ toEncoder }, Json]
+                imports [Encode, Json]
                 provides [main] to "./platform"
 
             main =
@@ -644,7 +644,7 @@ fn encode_derived_list_string() {
         indoc!(
             r#"
             app "test"
-                imports [Encode.{ toEncoder }, Json]
+                imports [Encode, Json]
                 provides [main] to "./platform"
 
             main =
@@ -668,7 +668,7 @@ fn encode_derived_list_of_records() {
         indoc!(
             r#"
             app "test"
-                imports [Encode.{ toEncoder }, Json]
+                imports [Encode, Json]
                 provides [main] to "./platform"
 
             main =
@@ -692,7 +692,7 @@ fn encode_derived_list_of_lists_of_strings() {
         indoc!(
             r#"
             app "test"
-                imports [Encode.{ toEncoder }, Json]
+                imports [Encode, Json]
                 provides [main] to "./platform"
 
             main =
@@ -716,7 +716,7 @@ fn encode_derived_record_with_many_types() {
         indoc!(
             r#"
             app "test"
-                imports [Encode.{ toEncoder }, Json]
+                imports [Encode, Json]
                 provides [main] to "./platform"
 
             main =

--- a/crates/compiler/test_gen/src/helpers/dev.rs
+++ b/crates/compiler/test_gen/src/helpers/dev.rs
@@ -144,7 +144,7 @@ pub fn helper(
         for problem in can_problems.into_iter() {
             // Ignore "unused" problems
             match problem {
-                UnusedDef(_, _) | UnusedArgument(_, _, _, _) | UnusedImport(_, _) => {
+                UnusedDef(_, _) | UnusedArgument(_, _, _, _) | UnusedModuleImport(_, _) => {
                     delayed_errors.push(problem);
                     continue;
                 }

--- a/crates/compiler/test_gen/src/helpers/llvm.rs
+++ b/crates/compiler/test_gen/src/helpers/llvm.rs
@@ -129,7 +129,7 @@ fn create_llvm_module<'a>(
                 // Ignore "unused" problems
                 UnusedDef(_, _)
                 | UnusedArgument(_, _, _, _)
-                | UnusedImport(_, _)
+                | UnusedModuleImport(_, _)
                 | RuntimeError(_)
                 | UnsupportedPattern(_, _)
                 | ExposedButNotDefined(_) => {

--- a/crates/glue/tests/helpers/mod.rs
+++ b/crates/glue/tests/helpers/mod.rs
@@ -1,4 +1,4 @@
-use roc_glue::load::load_types;
+use roc_glue::load::{load_types, IgnoreErrors};
 use roc_glue::rust_glue;
 use roc_load::Threading;
 use std::env;
@@ -33,7 +33,12 @@ pub fn generate_bindings(decl_src: &str) -> String {
         let mut file = File::create(file_path).unwrap();
         writeln!(file, "{}", &src).unwrap();
 
-        let result = load_types(full_file_path, Threading::Single);
+        let result = load_types(
+            full_file_path,
+            Threading::Single,
+            // required `nothing` is unused; that error is okay
+            IgnoreErrors { can: true },
+        );
 
         dir.close().expect("Unable to close tempdir");
 

--- a/crates/reporting/src/error/canonicalize.rs
+++ b/crates/reporting/src/error/canonicalize.rs
@@ -87,7 +87,24 @@ pub fn can_problem<'b>(
             title = UNUSED_DEF.to_string();
             severity = Severity::Warning;
         }
-        Problem::UnusedImport(module_id, region) => {
+        Problem::UnusedImport(symbol, region) => {
+            doc = alloc.stack([
+                alloc.concat([
+                    alloc.symbol_qualified(symbol),
+                    alloc.reflow(" is not used in this module."),
+                ]),
+                alloc.region(lines.convert_region(region)),
+                alloc.concat([
+                    alloc.reflow("Since "),
+                    alloc.symbol_qualified(symbol),
+                    alloc.reflow(" isn't used, you don't need to import it."),
+                ]),
+            ]);
+
+            title = UNUSED_IMPORT.to_string();
+            severity = Severity::Warning;
+        }
+        Problem::UnusedModuleImport(module_id, region) => {
             doc = alloc.stack([
                 alloc.concat([
                     alloc.reflow("Nothing from "),

--- a/crates/reporting/src/error/canonicalize.rs
+++ b/crates/reporting/src/error/canonicalize.rs
@@ -257,9 +257,11 @@ pub fn can_problem<'b>(
             shadow,
             kind,
         } => {
-            doc = report_shadowing(alloc, lines, original_region, shadow, kind);
+            let (res_title, res_doc) =
+                report_shadowing(alloc, lines, original_region, shadow, kind);
 
-            title = DUPLICATE_NAME.to_string();
+            doc = res_doc;
+            title = res_title.to_string();
             severity = Severity::RuntimeError;
         }
         Problem::CyclicAlias(symbol, region, others, alias_kind) => {
@@ -1371,28 +1373,48 @@ fn report_shadowing<'b>(
     original_region: Region,
     shadow: Loc<Ident>,
     kind: ShadowKind,
-) -> RocDocBuilder<'b> {
-    let what = match kind {
-        ShadowKind::Variable => "variables",
-        ShadowKind::Alias => "aliases",
-        ShadowKind::Opaque => "opaques",
-        ShadowKind::Ability => "abilities",
+) -> (&'static str, RocDocBuilder<'b>) {
+    let (what, what_plural, is_builtin) = match kind {
+        ShadowKind::Variable => ("variable", "variables", false),
+        ShadowKind::Alias(sym) => ("alias", "aliases", sym.is_builtin()),
+        ShadowKind::Opaque(sym) => ("opaque type", "opaque types", sym.is_builtin()),
+        ShadowKind::Ability(sym) => ("ability", "abilities", sym.is_builtin()),
     };
 
-    alloc.stack([
-        alloc
-            .text("The ")
-            .append(alloc.ident(shadow.value))
-            .append(alloc.reflow(" name is first defined here:")),
-        alloc.region(lines.convert_region(original_region)),
-        alloc.reflow("But then it's defined a second time here:"),
-        alloc.region(lines.convert_region(shadow.region)),
-        alloc.concat([
-            alloc.reflow("Since these "),
-            alloc.reflow(what),
-            alloc.reflow(" have the same name, it's easy to use the wrong one on accident. Give one of them a new name."),
-        ]),
-    ])
+    let doc = if is_builtin {
+        alloc.stack([
+            alloc.concat([
+                alloc.reflow("This "),
+                alloc.reflow(what),
+                alloc.reflow(" has the same name as a builtin:"),
+            ]),
+            alloc.region(lines.convert_region(shadow.region)),
+            alloc.concat([
+                alloc.reflow("All builtin "),
+                alloc.reflow(what_plural),
+                alloc.reflow(" are in scope by default, so I need this "),
+                alloc.reflow(what),
+                alloc.reflow(" to have a different name!"),
+            ]),
+        ])
+    } else {
+        alloc.stack([
+            alloc
+                .text("The ")
+                .append(alloc.ident(shadow.value))
+                .append(alloc.reflow(" name is first defined here:")),
+            alloc.region(lines.convert_region(original_region)),
+            alloc.reflow("But then it's defined a second time here:"),
+            alloc.region(lines.convert_region(shadow.region)),
+            alloc.concat([
+                alloc.reflow("Since these "),
+                alloc.reflow(what_plural),
+                alloc.reflow(" have the same name, it's easy to use the wrong one on accident. Give one of them a new name."),
+            ]),
+        ])
+    };
+
+    (DUPLICATE_NAME, doc)
 }
 
 fn pretty_runtime_error<'b>(
@@ -1420,8 +1442,7 @@ fn pretty_runtime_error<'b>(
             shadow,
             kind,
         } => {
-            doc = report_shadowing(alloc, lines, original_region, shadow, kind);
-            title = DUPLICATE_NAME;
+            (title, doc) = report_shadowing(alloc, lines, original_region, shadow, kind);
         }
 
         RuntimeError::LookupNotInScope(loc_name, options) => {

--- a/crates/reporting/tests/test_reporting.rs
+++ b/crates/reporting/tests/test_reporting.rs
@@ -10717,4 +10717,32 @@ All branches in an `if` must have the same type!
     opaque type to have a different name!
     "###
     );
+
+    test_report!(
+        unnecessary_builtin_module_import,
+        indoc!(
+            r#"
+            app "test" imports [Str] provides [main] to "./platform"
+
+            main = Str.concat "" ""
+            "#
+        ),
+    @r###"
+    "###
+    );
+
+    test_report!(
+        unnecessary_builtin_type_import,
+        indoc!(
+            r#"
+            app "test" imports [Decode.{ DecodeError }] provides [main, E] to "./platform"
+
+            E : DecodeError
+
+            main = ""
+            "#
+        ),
+    @r###"
+    "###
+    );
 }

--- a/crates/reporting/tests/test_reporting.rs
+++ b/crates/reporting/tests/test_reporting.rs
@@ -6198,18 +6198,13 @@ All branches in an `if` must have the same type!
         @r###"
     ── DUPLICATE NAME ──────────────────────────────────────── /code/proj/Main.roc ─
 
-    The `Result` name is first defined here:
-
-    1│  app "test" provides [main] to "./platform"
-      
-
-    But then it's defined a second time here:
+    This alias has the same name as a builtin:
 
     4│      Result a b : [Ok a, Err b]
             ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-    Since these aliases have the same name, it's easy to use the wrong one
-    on accident. Give one of them a new name.
+    All builtin aliases are in scope by default, so I need this alias to
+    have a different name!
 
     ── TOO FEW TYPE ARGUMENTS ──────────────────────────────── /code/proj/Main.roc ─
 
@@ -6241,18 +6236,13 @@ All branches in an `if` must have the same type!
         @r###"
     ── DUPLICATE NAME ──────────────────────────────────────── /code/proj/Main.roc ─
 
-    The `Result` name is first defined here:
-
-    1│  app "test" provides [main] to "./platform"
-      
-
-    But then it's defined a second time here:
+    This alias has the same name as a builtin:
 
     4│      Result a b : [Ok a, Err b]
             ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-    Since these aliases have the same name, it's easy to use the wrong one
-    on accident. Give one of them a new name.
+    All builtin aliases are in scope by default, so I need this alias to
+    have a different name!
 
     ── TOO MANY TYPE ARGUMENTS ─────────────────────────────── /code/proj/Main.roc ─
 
@@ -7435,18 +7425,13 @@ All branches in an `if` must have the same type!
         @r###"
     ── DUPLICATE NAME ──────────────────────────────────────── /code/proj/Main.roc ─
 
-    The `Result` name is first defined here:
-
-    1│  app "test" provides [main] to "./platform"
-      
-
-    But then it's defined a second time here:
+    This alias has the same name as a builtin:
 
     4│      Result a b : [Ok a, Err b]
             ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-    Since these aliases have the same name, it's easy to use the wrong one
-    on accident. Give one of them a new name.
+    All builtin aliases are in scope by default, so I need this alias to
+    have a different name!
     "###
     );
 
@@ -10708,6 +10693,28 @@ All branches in an `if` must have the same type!
 
     It's impossible to create a value of this shape, so this pattern can
     be safely removed!
+    "###
+    );
+
+    test_report!(
+        custom_type_conflicts_with_builtin,
+        indoc!(
+            r#"
+            Nat := [ S Nat, Z ]
+
+            ""
+            "#
+        ),
+    @r###"
+    ── DUPLICATE NAME ──────────────────────────────────────── /code/proj/Main.roc ─
+
+    This opaque type has the same name as a builtin:
+
+    4│      Nat := [ S Nat, Z ]
+            ^^^^^^^^^^^^^^^^^^^
+
+    All builtin opaque types are in scope by default, so I need this
+    opaque type to have a different name!
     "###
     );
 }

--- a/crates/reporting/tests/test_reporting.rs
+++ b/crates/reporting/tests/test_reporting.rs
@@ -10740,6 +10740,7 @@ All branches in an `if` must have the same type!
     );
 
     test_report!(
+        #[ignore = "https://github.com/roc-lang/roc/issues/4096"]
         unnecessary_builtin_module_import,
         indoc!(
             r#"
@@ -10753,6 +10754,7 @@ All branches in an `if` must have the same type!
     );
 
     test_report!(
+        #[ignore = "https://github.com/roc-lang/roc/issues/4096"]
         unnecessary_builtin_type_import,
         indoc!(
             r#"

--- a/crates/reporting/tests/test_reporting.rs
+++ b/crates/reporting/tests/test_reporting.rs
@@ -10719,6 +10719,27 @@ All branches in an `if` must have the same type!
     );
 
     test_report!(
+        unused_value_import,
+        indoc!(
+            r#"
+            app "test" imports [List.{ concat }] provides [main] to "./platform"
+
+            main = ""
+            "#
+        ),
+    @r###"
+    ── UNUSED IMPORT ───────────────────────────────────────── /code/proj/Main.roc ─
+
+    `List.concat` is not used in this module.
+
+    1│  app "test" imports [List.{ concat }] provides [main] to "./platform"
+                                   ^^^^^^
+
+    Since `List.concat` isn't used, you don't need to import it.
+    "###
+    );
+
+    test_report!(
         unnecessary_builtin_module_import,
         indoc!(
             r#"

--- a/examples/interactive/args.roc
+++ b/examples/interactive/args.roc
@@ -1,6 +1,6 @@
 app "args"
     packages { pf: "cli-platform/main.roc" }
-    imports [pf.Stdout, pf.Arg, pf.Program.{ Program }]
+    imports [pf.Stdout, pf.Arg, pf.Program.{ Program, exitCode }]
     provides [main] to pf
 
 main : Program

--- a/examples/interactive/args.roc
+++ b/examples/interactive/args.roc
@@ -1,6 +1,6 @@
 app "args"
     packages { pf: "cli-platform/main.roc" }
-    imports [pf.Stdout, pf.Arg, pf.Program.{ Program, exitCode }]
+    imports [pf.Stdout, pf.Arg, pf.Program.{ Program }]
     provides [main] to pf
 
 main : Program

--- a/examples/parser/Parser/CSV.roc
+++ b/examples/parser/Parser/CSV.roc
@@ -13,8 +13,8 @@ interface Parser.CSV
         f64,
     ]
     imports [
-        Parser.Core.{ Parser, parse, buildPrimitiveParser, fail, const, alt, map, map2, apply, many, maybe, oneorMore, sepBy1, between, ignore, flatten, sepBy },
-        Parser.Str.{ RawStr, parseStrPartial, oneOf, codeunit, codeunitSatisfies, scalar, digits, strFromRaw },
+        Parser.Core.{ Parser, parse, buildPrimitiveParser, alt, map, many, sepBy1, between, ignore, flatten, sepBy },
+        Parser.Str.{ RawStr, oneOf, codeunit, codeunitSatisfies, strFromRaw },
     ]
 
 ## This is a CSV parser which follows RFC4180

--- a/examples/parser/Parser/Str.roc
+++ b/examples/parser/Parser/Str.roc
@@ -18,7 +18,7 @@ interface Parser.Str
         digits,
         strFromRaw,
     ]
-    imports [Parser.Core.{ Parser, ParseResult, const, fail, map, map2, apply, many, oneOrMore, parse, parsePartial, buildPrimitiveParser, between }]
+    imports [Parser.Core.{ Parser, ParseResult, map, oneOrMore, parse, parsePartial, buildPrimitiveParser }]
 
 # Specific string-based parsers:
 RawStr : List U8

--- a/examples/parser/parse-movies-csv.roc
+++ b/examples/parser/parse-movies-csv.roc
@@ -56,4 +56,3 @@ enumerate = \elements ->
     last
     |> List.prepend (inits |> Str.joinWith ", ")
     |> Str.joinWith " and "
-


### PR DESCRIPTION
Also adds new reporting for when you import a value but don't actually use it. There are additional things to do, see #4096, but I don't think they're important to do in this patch.