### PR TITLE
windows surgical linker: call host functions from the app

### DIFF
--- a/crates/compiler/load_internal/tests/test_load.rs
+++ b/crates/compiler/load_internal/tests/test_load.rs
@@ -906,6 +906,6 @@ fn import_builtin_in_platform_and_check_app() {
         ),
     ];
 
-    let result = multiple_modules("issue_2863_module_type_does_not_exist", modules);
+    let result = multiple_modules("import_builtin_in_platform_and_check_app", modules);
     assert!(result.is_ok(), "should check");
 }

--- a/crates/linker/src/generate_dylib/pe.rs
+++ b/crates/linker/src/generate_dylib/pe.rs
@@ -147,8 +147,7 @@ pub fn synthetic_dll(custom_names: &[String]) -> Vec<u8> {
 
     // we store the export directory in a .rdata section
     let rdata_section: (_, Vec<u8>) = {
-        // not sure if that 0x40 is important, I took it from a .dll that zig produced
-        let characteristics = object::pe::IMAGE_SCN_MEM_READ | 0x40;
+        let characteristics = object::pe::IMAGE_SCN_MEM_READ | pe::IMAGE_SCN_CNT_INITIALIZED_DATA;
         let range = writer.reserve_section(
             *b".rdata\0\0",
             characteristics,

--- a/crates/linker/src/generate_dylib/pe.rs
+++ b/crates/linker/src/generate_dylib/pe.rs
@@ -36,6 +36,52 @@ fn synthetic_image_export_directory(
     }
 }
 
+fn synthetic_import_dir(virtual_address: u32, custom_names: &[String]) -> Vec<u8> {
+    use object::U32;
+
+    const W: usize = std::mem::size_of::<pe::ImageImportDescriptor>();
+
+    let mut vec = vec![0; 2 * W];
+
+    let name = "host.exe";
+
+    // write the .dll name, null-terminated
+    vec.extend(name.as_bytes());
+    vec.push(0);
+
+    let mut name_addresses = Vec::with_capacity(custom_names.len());
+
+    for name in custom_names {
+        name_addresses.push(virtual_address as u64 + vec.len() as u64);
+
+        let hint = 0u16;
+        vec.extend(&hint.to_le_bytes());
+        vec.extend(name.as_bytes());
+        vec.push(0);
+    }
+
+    let first_thunk = virtual_address + vec.len() as u32;
+
+    for name_address in name_addresses {
+        vec.extend(&name_address.to_le_bytes())
+    }
+
+    let descriptor = pe::ImageImportDescriptor {
+        original_first_thunk: U32::new(LE, first_thunk),
+        time_date_stamp: U32::new(LE, 0),
+        forwarder_chain: U32::new(LE, 0),
+        name: U32::new(LE, virtual_address + 2 * W as u32),
+        first_thunk: U32::new(LE, first_thunk),
+    };
+
+    unsafe {
+        let ptr = vec.as_mut_ptr();
+        std::ptr::write_unaligned(ptr as *mut pe::ImageImportDescriptor, descriptor);
+    }
+
+    vec
+}
+
 fn synthetic_export_dir(virtual_address: u32, custom_names: &[String]) -> Vec<u8> {
     let mut vec = vec![0; std::mem::size_of::<pe::ImageExportDirectory>()];
 
@@ -142,25 +188,39 @@ pub fn synthetic_dll(custom_names: &[String]) -> Vec<u8> {
         exports.len() as _,
     );
 
-    // it's fine if this changes, this is just here to catch any accidental changes
-    debug_assert_eq!(virtual_address, 0x138);
+    let virtual_address = writer.reserved_len() + exports.len() as u32;
 
-    // we store the export directory in a .rdata section
+    // let imports = synthetic_import_dir(virtual_address, &["roc_alloc".to_string()]);
+    let imports: Vec<u8> = Vec::new();
+
+    //    // there is also IMAGE_DIRECTORY_ENTRY_DELAY_IMPORT which may be helpful?
+    //    writer.set_data_directory(
+    //        pe::IMAGE_DIRECTORY_ENTRY_IMPORT,
+    //        virtual_address,
+    //        imports.len() as _,
+    //    );
+
+    // it's fine if this changes, this is just here to catch any accidental changes
+    // debug_assert_eq!(virtual_address, 0x138);
+
+    let mut data = exports;
+    data.extend(imports);
+
+    // we store the import & export directory in a .rdata section
     let rdata_section: (_, Vec<u8>) = {
-        // not sure if that 0x40 is important, I took it from a .dll that zig produced
-        let characteristics = object::pe::IMAGE_SCN_MEM_READ | 0x40;
+        let characteristics = object::pe::IMAGE_SCN_MEM_READ | pe::IMAGE_SCN_CNT_INITIALIZED_DATA;
         let range = writer.reserve_section(
             *b".rdata\0\0",
             characteristics,
             // virtual size
-            exports.len() as u32,
+            data.len() as u32,
             // size_of_raw_data
-            exports.len() as u32,
+            data.len() as u32,
         );
 
-        debug_assert_eq!(virtual_address, range.virtual_address);
+        // debug_assert_eq!(virtual_address, range.virtual_address);
 
-        (range.file_offset, exports)
+        (range.file_offset, data)
     };
 
     // Start writing.

--- a/crates/linker/src/lib.rs
+++ b/crates/linker/src/lib.rs
@@ -97,9 +97,14 @@ pub fn build_and_preprocess_host(
         host_input_path.with_file_name("libapp.so")
     };
 
+    let dynhost = if let target_lexicon::OperatingSystem::Windows = target.operating_system {
+        host_input_path.with_file_name("dynhost.exe")
+    } else {
+        host_input_path.with_file_name("dynhost")
+    };
+
     generate_dynamic_lib(target, exposed_to_host, exported_closure_types, &dummy_lib);
     rebuild_host(opt_level, target, host_input_path, Some(&dummy_lib));
-    let dynhost = host_input_path.with_file_name("dynhost");
     let metadata = host_input_path.with_file_name("metadata");
     // let prehost = host_input_path.with_file_name("preprocessedhost");
 

--- a/crates/linker/src/pe.rs
+++ b/crates/linker/src/pe.rs
@@ -1115,6 +1115,7 @@ mod test {
                 "-lc",
                 "-target",
                 "x86_64-windows-gnu",
+                "-rdynamic",
                 "--strip",
                 "-OReleaseFast",
             ])

--- a/crates/linker/src/pe.rs
+++ b/crates/linker/src/pe.rs
@@ -1009,6 +1009,10 @@ mod test {
             extern fn roc_magic1() callconv(.C) u64;
             extern fn roc_magic2() callconv(.C) u8;
 
+            pub export fn roc_alloc() u64 {
+                return 123456;
+            }
+
             pub fn main() !void {
                 const stdout = std.io.getStdOut().writer();
                 try stdout.print("Hello, {} {} {} {}!\n", .{roc_magic1(), roc_magic2(), roc_one, roc_three});
@@ -1045,6 +1049,7 @@ mod test {
                 "-target",
                 "x86_64-windows-gnu",
                 "--strip",
+                "-rdynamic",
                 "-OReleaseFast",
             ])
             .output()

--- a/crates/linker/src/pe.rs
+++ b/crates/linker/src/pe.rs
@@ -4,7 +4,7 @@ use memmap2::{Mmap, MmapMut};
 use object::{
     pe::{ImageImportDescriptor, ImageNtHeaders64, ImageSectionHeader, ImageThunkData64},
     read::pe::ImportTable,
-    LittleEndian as LE, SectionIndex,
+    LittleEndian as LE, RelocationTarget, SectionIndex,
 };
 use roc_collections::MutMap;
 use roc_error_macros::internal_error;
@@ -526,8 +526,8 @@ enum SectionKind {
 struct Section {
     /// File range of the section (in the app object)
     file_range: Range<usize>,
-
     kind: SectionKind,
+    relocations: MutMap<String, (u64, object::Relocation)>,
 }
 
 #[allow(dead_code)]
@@ -568,6 +568,24 @@ impl AppSections {
                 _ => continue,
             };
 
+            let mut relocations = MutMap::default();
+
+            for (offset_in_section, relocation) in section.relocations() {
+                match relocation.target() {
+                    RelocationTarget::Symbol(symbol_index) => {
+                        use object::ObjectSymbol;
+
+                        let name = file
+                            .symbol_by_index(symbol_index)
+                            .and_then(|s| s.name())
+                            .unwrap_or_default();
+
+                        relocations.insert(name.to_string(), (offset_in_section, relocation));
+                    }
+                    _ => todo!(),
+                }
+            }
+
             let (start, length) = section.file_range().unwrap();
             let file_range = start as usize..(start + length) as usize;
 
@@ -585,7 +603,11 @@ impl AppSections {
                 }
             }
 
-            let section = Section { file_range, kind };
+            let section = Section {
+                file_range,
+                kind,
+                relocations,
+            };
 
             sections.push(section);
         }
@@ -1013,6 +1035,10 @@ mod test {
                 return 123456;
             }
 
+            pub export fn roc_realloc() u64 {
+                return 111111;
+            }
+
             pub fn main() !void {
                 const stdout = std.io.getStdOut().writer();
                 try stdout.print("Hello, {} {} {} {}!\n", .{roc_magic1(), roc_magic2(), roc_one, roc_three});
@@ -1025,8 +1051,11 @@ mod test {
             export const roc_one: u64 = 1;
             export const roc_three: u64 = 3;
 
+            extern fn roc_alloc() u64;
+            extern fn roc_realloc() u64;
+
             export fn roc_magic1() u64 {
-                return 42;
+                return roc_alloc() + roc_realloc();
             }
 
             export fn roc_magic2() u8 {
@@ -1130,6 +1159,18 @@ mod test {
         let file = PeFile64::parse(executable.deref()).unwrap();
         let last_host_section = file.sections().nth(last_host_section_index).unwrap();
 
+        let exports: MutMap<String, i64> = file
+            .exports()
+            .unwrap()
+            .into_iter()
+            .map(|e| {
+                (
+                    String::from_utf8(e.name().to_vec()).unwrap(),
+                    (e.address() - image_base) as i64,
+                )
+            })
+            .collect();
+
         let optional_header_offset = file.dos_header().nt_headers_offset() as usize
             + std::mem::size_of::<u32>()
             + std::mem::size_of::<ImageFileHeader>();
@@ -1202,6 +1243,26 @@ mod test {
             for section in it {
                 let slice = &roc_app[section.file_range.start..section.file_range.end];
                 executable[offset..][..slice.len()].copy_from_slice(slice);
+
+                for (name, (offset_in_section, relocation)) in section.relocations.iter() {
+                    let destination = exports[name];
+
+                    match relocation.kind() {
+                        object::RelocationKind::Relative => {
+                            // we implicitly only do 32-bit relocations
+                            debug_assert_eq!(relocation.size(), 32);
+
+                            let delta =
+                                destination - virtual_address as i64 - *offset_in_section as i64
+                                    + relocation.addend();
+
+                            executable[offset + *offset_in_section as usize..][..4]
+                                .copy_from_slice(&(delta as i32).to_le_bytes());
+                        }
+                        _ => todo!(),
+                    }
+                }
+
                 offset += slice.len();
             }
 
@@ -1258,7 +1319,7 @@ mod test {
 
         let output = String::from_utf8_lossy(&output.stdout);
 
-        assert_eq!("Hello, 42 32 1 3!\n", output);
+        assert_eq!("Hello, 234567 32 1 3!\n", output);
     }
 
     #[ignore]
@@ -1286,6 +1347,6 @@ mod test {
 
         let output = String::from_utf8_lossy(&output.stdout);
 
-        assert_eq!("Hello, 42 32 1 3!\n", output);
+        assert_eq!("Hello, 234567 32 1 3!\n", output);
     }
 }


### PR DESCRIPTION
the magic sauce is the `-rdynamic` argument to zig, which ensures that host symbols are in the `.exe`s export section, and we can link them up with the code from the app.