### PR TITLE
fix Dict's IntoIterator

### DIFF
--- a/crates/compiler/test_mono/generated/unreachable_void_constructor.txt
+++ b/crates/compiler/test_mono/generated/unreachable_void_constructor.txt
@@ -1,7 +1,11 @@
+procedure Bool.2 ():
+    let Bool.11 : Int1 = true;
+    ret Bool.11;
+
 procedure Test.0 ():
-    let Test.7 : Int1 = true;
-    if Test.7 then
+    let Test.6 : Int1 = CallByName Bool.2;
+    if Test.6 then
         Error voided tag constructor is unreachable
     else
-        let Test.6 : Str = "abc";
-        ret Test.6;
+        let Test.5 : Str = "abc";
+        ret Test.5;

--- a/crates/compiler/test_mono/src/tests.rs
+++ b/crates/compiler/test_mono/src/tests.rs
@@ -1958,7 +1958,7 @@ fn unreachable_void_constructor() {
 
         x : []
 
-        main = if True then Ok x else Err "abc" 
+        main = if Bool.true then Ok x else Err "abc" 
         "#
     )
 }

--- a/crates/roc_std/src/roc_dict.rs
+++ b/crates/roc_std/src/roc_dict.rs
@@ -76,14 +76,14 @@ impl<'a, K, V> IntoIterator for &'a RocDict<K, V> {
     fn into_iter(self) -> Self::IntoIter {
         IntoIter {
             index: 0,
-            items: self,
+            items: self.0.as_slice(),
         }
     }
 }
 
 pub struct IntoIter<'a, K, V> {
     index: usize,
-    items: &'a RocDict<K, V>,
+    items: &'a [RocDictItem<K, V>],
 }
 
 impl<'a, K, V> Iterator for IntoIter<'a, K, V> {
@@ -92,7 +92,6 @@ impl<'a, K, V> Iterator for IntoIter<'a, K, V> {
     fn next(&mut self) -> Option<Self::Item> {
         let item = self
             .items
-            .0
             .get(self.index)
             .map(|item| (item.key(), item.value()));
 
@@ -102,7 +101,7 @@ impl<'a, K, V> Iterator for IntoIter<'a, K, V> {
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let remaining = self.items.0.len() - self.index;
+        let remaining = self.items.len() - self.index;
 
         (remaining, Some(remaining))
     }

--- a/crates/roc_std/src/roc_list.rs
+++ b/crates/roc_std/src/roc_list.rs
@@ -103,18 +103,6 @@ impl<T> RocList<T> {
         self.len() == 0
     }
 
-    pub fn get(&self, index: usize) -> Option<&T> {
-        if self.len() <= index {
-            return None;
-        }
-
-        let elements = self.elements?;
-        let element_ptr = unsafe { elements.as_ptr().add(index) };
-
-        // Return the element.
-        Some(unsafe { ManuallyDrop::into_inner(element_ptr.cast::<ManuallyDrop<&T>>().read()) })
-    }
-
     /// Note that there is no way to convert directly to a Vec.
     ///
     /// This is because RocList values are not allocated using the system allocator, so


### PR DESCRIPTION
It turns out that `RocDict`'s `IntoIterator` was broken: it segfaulted when reading values! After some experimentation, it turns out that `RocList.get` was accessing the wrong memory (it appears to have been wrong for short lists, at least?)

In `RocDict`'s case, however, iterating over a slice of the list instead of manipulating memory directly works fine, so I've just done that and dropped the problematic `get` implementation for now (as `RocDict`'s' `IntoIterator` was the only consumer.) If some brave soul wants to try implementing `get` again, great! But that's not me right now, and I don't want to leave broken code in the codebase waiting to bite someone else.

@zwilias: this fixes the segfault we saw yesterday!
