### PR TITLE
gen_dev: Support all number types in NumSub

### DIFF
--- a/crates/compiler/gen_dev/src/generic64/mod.rs
+++ b/crates/compiler/gen_dev/src/generic64/mod.rs
@@ -1035,19 +1035,9 @@ impl<
     }
 
     fn build_num_sub(&mut self, dst: &Symbol, src1: &Symbol, src2: &Symbol, layout: &InLayout<'a>) {
-        match self.layout_interner.get(*layout) {
-            Layout::Builtin(Builtin::Int(IntWidth::I64 | IntWidth::U64)) => {
-                let dst_reg = self.storage_manager.claim_general_reg(&mut self.buf, dst);
-                let src1_reg = self
-                    .storage_manager
-                    .load_to_general_reg(&mut self.buf, src1);
-                let src2_reg = self
-                    .storage_manager
-                    .load_to_general_reg(&mut self.buf, src2);
-                ASM::sub_reg64_reg64_reg64(&mut self.buf, dst_reg, src1_reg, src2_reg);
-            }
-            x => todo!("NumSub: layout, {:?}", x),
-        }
+        // for the time being, `num_sub` is implemented as wrapping subtraction. In roc, the normal
+        // `sub` should panic on overflow, but we just don't do that yet
+        self.build_num_sub_wrap(dst, src1, src2, layout)
     }
 
     fn build_num_sub_wrap(
@@ -1058,7 +1048,7 @@ impl<
         layout: &InLayout<'a>,
     ) {
         match self.layout_interner.get(*layout) {
-            Layout::Builtin(Builtin::Int(IntWidth::I64 | IntWidth::U64)) => {
+            Layout::Builtin(Builtin::Int(quadword_and_smaller!())) => {
                 let dst_reg = self.storage_manager.claim_general_reg(&mut self.buf, dst);
                 let src1_reg = self
                     .storage_manager

--- a/crates/compiler/test_gen/src/gen_num.rs
+++ b/crates/compiler/test_gen/src/gen_num.rs
@@ -1083,34 +1083,6 @@ fn gen_sub_dec() {
 
 #[test]
 #[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
-fn gen_sub_f64() {
-    assert_evals_to!(
-        indoc!(
-            r#"
-                    1.5 - 2.4 - 3
-                "#
-        ),
-        -3.9,
-        f64
-    );
-}
-
-#[test]
-#[cfg(any(feature = "gen-llvm", feature = "gen-dev", feature = "gen-wasm"))]
-fn gen_sub_i64() {
-    assert_evals_to!(
-        indoc!(
-            r#"
-                    1 - 2 - 3
-                "#
-        ),
-        -4,
-        i64
-    );
-}
-
-#[test]
-#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
 fn gen_mul_dec() {
     assert_evals_to!(
         indoc!(
@@ -1130,6 +1102,60 @@ fn gen_mul_dec() {
         RocDec::from_str_to_i128_unsafe("48.0"),
         i128
     );
+}
+
+#[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
+fn gen_sub_f64() {
+    assert_evals_to!("1.5f64 - 2.4 - 3", -3.9, f64);
+}
+
+#[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
+fn gen_sub_f32() {
+    assert_evals_to!("1.5f32 - 2.4 - 3", -3.9, f32);
+}
+
+#[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-dev", feature = "gen-wasm"))]
+fn gen_sub_i8() {
+    assert_evals_to!("1i8 - 2i8 - 3i8", -4, i8);
+}
+
+#[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-dev", feature = "gen-wasm"))]
+fn gen_sub_u8() {
+    assert_evals_to!("8u8 - 2u8 - 3u8", 3, u8);
+}
+
+#[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-dev", feature = "gen-wasm"))]
+fn gen_sub_i16() {
+    assert_evals_to!("1i16 - 2i16 - 3i16", -4, i16);
+}
+
+#[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-dev", feature = "gen-wasm"))]
+fn gen_sub_u16() {
+    assert_evals_to!("8u16 - 2u16 - 3u16", 3, u16);
+}
+
+#[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-dev", feature = "gen-wasm"))]
+fn gen_sub_i32() {
+    assert_evals_to!("1i32 - 2i32 - 3i32", -4, i32);
+}
+
+#[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-dev", feature = "gen-wasm"))]
+fn gen_sub_u32() {
+    assert_evals_to!("8u32 - 2u32 - 3u32", 3, u32);
+}
+
+#[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-dev", feature = "gen-wasm"))]
+fn gen_sub_i64() {
+    assert_evals_to!("1 - 2 - 3", -4, i64);
 }
 
 #[test]
@@ -1869,29 +1895,19 @@ fn float_add_overflow() {
 #[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
 #[should_panic(expected = r#"Roc failed with message: "integer subtraction overflowed!"#)]
 fn int_sub_overflow() {
-    assert_evals_to!(
-        indoc!(
-            r#"
-                -9_223_372_036_854_775_808 - 1
-                "#
-        ),
-        0,
-        i64
-    );
+    assert_evals_to!("-9_223_372_036_854_775_808 - 1", 0, i64);
 }
 
 #[test]
 #[cfg(any(feature = "gen-llvm", feature = "gen-dev", feature = "gen-wasm"))]
 fn int_sub_wrap() {
     assert_evals_to!(
-        indoc!(
-            r#"
-                Num.subWrap -9_223_372_036_854_775_808 1
-                "#
-        ),
+        "Num.subWrap -9_223_372_036_854_775_808 1",
         std::i64::MAX,
         i64
     );
+
+    assert_evals_to!("Num.subWrap -128i8 1", std::i8::MAX, i8);
 }
 
 #[test]


### PR DESCRIPTION
@bhansconnect I tried adding tests first, and expected the new tests to fail because I had not extended `build_num_sub` yet, but `cargo test gen_sub` passes on my machine. Am I missing something?

Closes #3792.
