### PR TITLE
Add directory path to error message when trying to read directory

### DIFF
--- a/crates/compiler/load_internal/src/file.rs
+++ b/crates/compiler/load_internal/src/file.rs
@@ -5642,10 +5642,16 @@ fn to_file_problem_report(filename: &Path, error: io::ErrorKind) -> String {
         _ => {
             let error = std::io::Error::from(error);
             let formatted = format!("{}", error);
-            let doc = alloc.concat([
-                alloc.reflow(r"I tried to read this file, but ran into a "),
-                alloc.text(formatted),
-                alloc.reflow(r" problem."),
+            let doc = alloc.stack([
+                alloc.reflow(r"I tried to read this file:"),
+                alloc
+                    .parser_suggestion(filename.to_str().unwrap())
+                    .indent(4),
+                alloc.concat([
+                    alloc.reflow(r"But ran into a "),
+                    alloc.text(formatted),
+                    alloc.reflow(r" problem."),
+                ])
             ]);
 
             Report {

--- a/crates/compiler/load_internal/src/file.rs
+++ b/crates/compiler/load_internal/src/file.rs
@@ -5651,7 +5651,7 @@ fn to_file_problem_report(filename: &Path, error: io::ErrorKind) -> String {
                     alloc.reflow(r"But ran into a "),
                     alloc.text(formatted),
                     alloc.reflow(r" problem."),
-                ])
+                ]),
             ]);
 
             Report {


### PR DESCRIPTION
[#4052](https://github.com/roc-lang/roc/issues/4052)

Improve error message by adding the directory path when trying to read a directory