### PR TITLE
Improve file problem msg

### DIFF
--- a/crates/compiler/load_internal/src/file.rs
+++ b/crates/compiler/load_internal/src/file.rs
@@ -44,7 +44,7 @@ use roc_parse::ident::UppercaseIdent;
 use roc_parse::module::module_defs;
 use roc_parse::parser::{FileError, Parser, SyntaxError};
 use roc_region::all::{LineInfo, Loc, Region};
-use roc_reporting::report::RenderTarget;
+use roc_reporting::report::{RenderTarget, Annotation};
 use roc_solve::module::{extract_module_owned_implementations, Solved, SolvedModule};
 use roc_solve_problem::TypeError;
 use roc_target::TargetInfo;
@@ -5645,13 +5645,14 @@ fn to_file_problem_report(filename: &Path, error: io::ErrorKind) -> String {
             let doc = alloc.stack([
                 alloc.reflow(r"I tried to read this file:"),
                 alloc
-                    .parser_suggestion(filename.to_str().unwrap())
+                    .text(filename.to_str().unwrap())
+                    .annotate(Annotation::Error)
                     .indent(4),
-                alloc.concat([
-                    alloc.reflow(r#"But ran into a ""#),
-                    alloc.text(formatted),
-                    alloc.reflow(r#"" problem."#),
-                ]),
+                alloc.reflow(r"But ran into:"),
+                alloc
+                    .text(formatted)
+                    .annotate(Annotation::Error)
+                    .indent(4),
             ]);
 
             Report {

--- a/crates/compiler/load_internal/src/file.rs
+++ b/crates/compiler/load_internal/src/file.rs
@@ -5648,9 +5648,9 @@ fn to_file_problem_report(filename: &Path, error: io::ErrorKind) -> String {
                     .parser_suggestion(filename.to_str().unwrap())
                     .indent(4),
                 alloc.concat([
-                    alloc.reflow(r"But ran into a "),
+                    alloc.reflow(r#"But ran into a ""#),
                     alloc.text(formatted),
-                    alloc.reflow(r" problem."),
+                    alloc.reflow(r#"" problem."#),
                 ]),
             ]);
 

--- a/crates/compiler/load_internal/src/file.rs
+++ b/crates/compiler/load_internal/src/file.rs
@@ -44,7 +44,7 @@ use roc_parse::ident::UppercaseIdent;
 use roc_parse::module::module_defs;
 use roc_parse::parser::{FileError, Parser, SyntaxError};
 use roc_region::all::{LineInfo, Loc, Region};
-use roc_reporting::report::{RenderTarget, Annotation};
+use roc_reporting::report::{Annotation, RenderTarget};
 use roc_solve::module::{extract_module_owned_implementations, Solved, SolvedModule};
 use roc_solve_problem::TypeError;
 use roc_target::TargetInfo;
@@ -5649,10 +5649,7 @@ fn to_file_problem_report(filename: &Path, error: io::ErrorKind) -> String {
                     .annotate(Annotation::Error)
                     .indent(4),
                 alloc.reflow(r"But ran into:"),
-                alloc
-                    .text(formatted)
-                    .annotate(Annotation::Error)
-                    .indent(4),
+                alloc.text(formatted).annotate(Annotation::Error).indent(4),
             ]);
 
             Report {


### PR DESCRIPTION
I tried out a recently improved error message and improved it further :)
- before:

![file-error-before](https://user-images.githubusercontent.com/17049058/192098824-8f858493-ebcc-42ae-b010-f565e64a4fa5.png)

- after:

![file-error-after](https://user-images.githubusercontent.com/17049058/192098828-0b0d01d9-9a2e-4672-bba1-23c09cc614c7.png)