### PR TITLE
keep app in memory

### DIFF
--- a/crates/compiler/build/src/program.rs
+++ b/crates/compiler/build/src/program.rs
@@ -463,7 +463,7 @@ pub fn gen_from_mono_module_dev(
     target: &target_lexicon::Triple,
     _host_input_path: &Path,
     _wasm_dev_stack_bytes: Option<u32>,
-) -> CodeGenTiming {
+) -> (CodeObject, CodeGenTiming) {
     use target_lexicon::Architecture;
 
     match target.architecture {

--- a/crates/linker/src/lib.rs
+++ b/crates/linker/src/lib.rs
@@ -119,11 +119,11 @@ pub fn build_and_preprocess_host(
 pub fn link_preprocessed_host(
     target: &Triple,
     host_input_path: &Path,
-    roc_app_obj: &Path,
+    roc_app_bytes: &[u8],
     binary_path: &Path,
 ) {
     let metadata = host_input_path.with_file_name("metadata");
-    surgery(roc_app_obj, &metadata, binary_path, false, false, target)
+    surgery(roc_app_bytes, &metadata, binary_path, false, false, target)
 }
 
 fn generate_dynamic_lib(
@@ -1973,7 +1973,7 @@ fn scan_elf_dynamic_deps(
 }
 
 fn surgery(
-    app_filename: &Path,
+    roc_app_bytes: &[u8],
     metadata_filename: &Path,
     out_filename: &Path,
     verbose: bool,
@@ -1983,7 +1983,7 @@ fn surgery(
     match target.binary_format {
         target_lexicon::BinaryFormat::Elf | target_lexicon::BinaryFormat::Macho => {
             surgery_elf_and_macho(
-                app_filename,
+                roc_app_bytes,
                 metadata_filename,
                 out_filename,
                 verbose,
@@ -1993,7 +1993,7 @@ fn surgery(
         }
 
         target_lexicon::BinaryFormat::Coff => {
-            crate::pe::surgery_pe(out_filename, metadata_filename, app_filename);
+            crate::pe::surgery_pe(out_filename, metadata_filename, roc_app_bytes);
         }
 
         target_lexicon::BinaryFormat::Wasm => {
@@ -2015,24 +2015,19 @@ fn surgery(
 }
 
 fn surgery_elf_and_macho(
-    app_path: &Path,
+    roc_app_bytes: &[u8],
     metadata_path: &Path,
     executable_path: &Path,
     verbose: bool,
     time: bool,
     target: &Triple,
 ) {
-    let app_parsing_start = Instant::now();
-    let app_mmap = open_mmap(app_path);
-    let app_data = &*app_mmap;
-    let app_obj = match object::File::parse(app_data) {
+    let app_obj = match object::File::parse(roc_app_bytes) {
         Ok(obj) => obj,
         Err(err) => {
             internal_error!("Failed to parse application file: {}", err);
         }
     };
-
-    let app_parsing_duration = app_parsing_start.elapsed();
 
     let total_start = Instant::now();
 
@@ -2041,19 +2036,17 @@ fn surgery_elf_and_macho(
     let loading_metadata_duration = loading_metadata_start.elapsed();
 
     let load_and_mmap_start = Instant::now();
-    let max_out_len = md.exec_len + app_data.len() as u64 + md.load_align_constraint;
+    let max_out_len = md.exec_len + roc_app_bytes.len() as u64 + md.load_align_constraint;
     let mut exec_mmap = open_mmap_mut(executable_path, max_out_len as usize);
-
     let load_and_mmap_duration = load_and_mmap_start.elapsed();
-    let out_gen_start = Instant::now();
 
+    let out_gen_start = Instant::now();
     let mut offset = 0;
     match target.binary_format {
         target_lexicon::BinaryFormat::Elf => {
             surgery_elf(verbose, &md, &mut exec_mmap, &mut offset, app_obj)
         }
         target_lexicon::BinaryFormat::Macho => surgery_macho(
-            app_path,
             metadata_path,
             executable_path,
             verbose,
@@ -2098,13 +2091,11 @@ fn surgery_elf_and_macho(
     if verbose || time {
         println!("\nTimings");
         report_timing("Loading Metadata", loading_metadata_duration);
-        report_timing("Application Parsing", app_parsing_duration);
         report_timing("Loading and mmap-ing", load_and_mmap_duration);
         report_timing("Output Generation", out_gen_duration);
         report_timing("Flushing Data to Disk", flushing_data_duration);
 
         let sum = loading_metadata_duration
-            + app_parsing_duration
             + load_and_mmap_duration
             + out_gen_duration
             + flushing_data_duration;
@@ -2116,7 +2107,6 @@ fn surgery_elf_and_macho(
 
 #[allow(clippy::too_many_arguments)]
 fn surgery_macho(
-    _app_filename: &Path,
     _metadata_filename: &Path,
     _out_filename: &Path,
     verbose: bool,

--- a/crates/linker/src/pe.rs
+++ b/crates/linker/src/pe.rs
@@ -190,11 +190,10 @@ pub(crate) fn preprocess_windows(
     Ok(())
 }
 
-pub(crate) fn surgery_pe(executable_path: &Path, metadata_path: &Path, app_path: &Path) {
+pub(crate) fn surgery_pe(executable_path: &Path, metadata_path: &Path, roc_app_bytes: &[u8]) {
     let md = PeMetadata::read_from_file(metadata_path);
-    let app_bytes = open_mmap(app_path);
 
-    let app_obj_sections = AppSections::from_data(&app_bytes);
+    let app_obj_sections = AppSections::from_data(roc_app_bytes);
     let mut symbols = app_obj_sections.symbols;
 
     let image_base: u64 = md.image_base;
@@ -278,7 +277,7 @@ pub(crate) fn surgery_pe(executable_path: &Path, metadata_path: &Path, app_path:
         let mut offset = section_file_offset;
         let it = app_obj_sections.sections.iter().filter(|s| s.kind == kind);
         for section in it {
-            let slice = &app_bytes[section.file_range.start..section.file_range.end];
+            let slice = &roc_app_bytes[section.file_range.start..section.file_range.end];
             executable[offset..][..slice.len()].copy_from_slice(slice);
 
             for (name, app_relocation) in section.relocations.iter() {


### PR DESCRIPTION
keeps the roc application bytes in memory for a bit longer. When using the surgical linker, they are never written to disk.