### PR TITLE
Windows preprocessing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3793,6 +3793,7 @@ dependencies = [
  "clap 3.2.20",
  "iced-x86",
  "indoc",
+ "libc",
  "mach_object",
  "memmap2 0.5.7",
  "object 0.29.0",

--- a/crates/linker/Cargo.toml
+++ b/crates/linker/Cargo.toml
@@ -30,3 +30,4 @@ tempfile = "3.2.0"
 
 [dev-dependencies]
 indoc = "1.0.7"
+libc = "0.2.133"

--- a/crates/linker/src/lib.rs
+++ b/crates/linker/src/lib.rs
@@ -399,3 +399,42 @@ macro_rules! dbg_hex {
         ($($crate::dbg_hex!($val)),+,)
     };
 }
+
+// These functions don't end up in the final Roc binary but Windows linker needs a definition inside the crate.
+// On Windows, there seems to be less dead-code-elimination than on Linux or MacOS, or maybe it's done later.
+#[cfg(test)]
+#[cfg(windows)]
+#[allow(unused_imports)]
+use windows_roc_platform_functions::*;
+
+#[cfg(test)]
+#[cfg(windows)]
+mod windows_roc_platform_functions {
+    use core::ffi::c_void;
+
+    /// # Safety
+    /// The Roc application needs this.
+    #[no_mangle]
+    pub unsafe fn roc_alloc(size: usize, _alignment: u32) -> *mut c_void {
+        libc::malloc(size)
+    }
+
+    /// # Safety
+    /// The Roc application needs this.
+    #[no_mangle]
+    pub unsafe fn roc_realloc(
+        c_ptr: *mut c_void,
+        new_size: usize,
+        _old_size: usize,
+        _alignment: u32,
+    ) -> *mut c_void {
+        libc::realloc(c_ptr, new_size)
+    }
+
+    /// # Safety
+    /// The Roc application needs this.
+    #[no_mangle]
+    pub unsafe fn roc_dealloc(c_ptr: *mut c_void, _alignment: u32) {
+        libc::free(c_ptr)
+    }
+}

--- a/crates/linker/src/pe.rs
+++ b/crates/linker/src/pe.rs
@@ -662,6 +662,15 @@ impl Preprocessor {
             .size_of_headers
             .set(LE, self.new_headers_size as u32);
 
+        // this is required to run the intermediate product, the final surgery process will
+        // overwrite this again. But we want to run the intermediate product (the preprocessedhost)
+        // to be runnable for debugging purposes.
+        nt_headers.optional_header.size_of_image.set(
+            LE,
+            nt_headers.optional_header.size_of_image.get(LE)
+                + (self.section_alignment * extra_sections.len()) as u32,
+        );
+
         // update the section file offsets
         //
         // Sections:

--- a/crates/linker/src/pe.rs
+++ b/crates/linker/src/pe.rs
@@ -520,6 +520,7 @@ struct Preprocessor {
     new_section_count: usize,
     old_headers_size: usize,
     new_headers_size: usize,
+    section_alignment: usize,
 }
 
 impl Preprocessor {
@@ -552,6 +553,7 @@ impl Preprocessor {
         // next multiple of `file_alignment`.
         let old_headers_size = nt_headers.optional_header.size_of_headers.get(LE) as usize;
         let file_alignment = nt_headers.optional_header.file_alignment.get(LE) as usize;
+        let section_alignment = nt_headers.optional_header.section_alignment.get(LE) as usize;
         let extra_sections_width = extra_sections.len() * Self::SECTION_HEADER_WIDTH;
 
         // in a better world `extra_sections_width.div_ceil(file_alignment)` would be stable
@@ -573,6 +575,7 @@ impl Preprocessor {
             new_section_count: sections.len() + extra_sections.len(),
             old_headers_size,
             new_headers_size,
+            section_alignment,
         }
     }
 

--- a/crates/linker/src/pe.rs
+++ b/crates/linker/src/pe.rs
@@ -1462,7 +1462,7 @@ mod test {
 
         runner(dir);
 
-        let output = std::process::Command::new("app.exe")
+        let output = std::process::Command::new(&dir.join("app.exe"))
             .current_dir(dir)
             .output()
             .unwrap();
@@ -1563,8 +1563,8 @@ mod test {
         assert_eq!("Hello, 234567 32 1 3!\n", windows_test(test_basics))
     }
 
-    #[ignore]
     #[test]
+    #[ignore]
     fn basics_wine() {
         assert_eq!("Hello, 234567 32 1 3!\n", wine_test(test_basics))
     }

--- a/crates/linker/src/pe.rs
+++ b/crates/linker/src/pe.rs
@@ -1559,6 +1559,7 @@ mod test {
 
     #[cfg(windows)]
     #[test]
+    #[ignore = "does not work yet"]
     fn basics_windows() {
         assert_eq!("Hello, 234567 32 1 3!\n", windows_test(test_basics))
     }


### PR DESCRIPTION
turns out that actual windows is stricter than wine when it comes to loading programs. The current examples that work with wine don't run on actual windows, so I'm trying to validate our code piece-by-piece. 

This PR improves the preprocessing code so we can produce a runnable `preprocessedhost`. Normally that does not make sense, because that binary misses functions from the app. But if we don't even link an app, we now at least produce a valid binary.