### PR TITLE
Single-quote literals behave like ranged numbers

### DIFF
--- a/crates/compiler/builtins/roc/Json.roc
+++ b/crates/compiler/builtins/roc/Json.roc
@@ -197,7 +197,7 @@ takeFloat = \bytes ->
     { taken: intPart, rest } = takeDigits bytes
 
     when List.get rest 0 is
-        Ok 46 -> # 46 = .
+        Ok '.' ->
             { taken: floatPart, rest: afterAll } = takeDigits (List.split rest 1).others
             builtFloat =
                 List.concat (List.append intPart '.') floatPart

--- a/crates/compiler/builtins/roc/Json.roc
+++ b/crates/compiler/builtins/roc/Json.roc
@@ -187,9 +187,8 @@ takeWhile = \list, predicate ->
 
     helper { taken: [], rest: list }
 
-asciiByte = \b -> Num.toU8 b
-
-digits = List.range (asciiByte '0') (asciiByte '9' + 1)
+digits : List U8
+digits = List.range '0' ('9' + 1)
 
 takeDigits = \bytes ->
     takeWhile bytes \n -> List.contains digits n
@@ -201,7 +200,7 @@ takeFloat = \bytes ->
         Ok 46 -> # 46 = .
             { taken: floatPart, rest: afterAll } = takeDigits (List.split rest 1).others
             builtFloat =
-                List.concat (List.append intPart (asciiByte '.')) floatPart
+                List.concat (List.append intPart '.') floatPart
 
             { taken: builtFloat, rest: afterAll }
 
@@ -305,14 +304,14 @@ decodeBool = Decode.custom \bytes, @Json {} ->
     # Note: this could be more performant by traversing both branches char-by-char.
     # Doing that would also make `rest` more correct in the erroring case.
     if
-        maybeFalse == [asciiByte 'f', asciiByte 'a', asciiByte 'l', asciiByte 's', asciiByte 'e']
+        maybeFalse == ['f', 'a', 'l', 's', 'e']
     then
         { result: Ok Bool.false, rest: afterFalse }
     else
         { before: maybeTrue, others: afterTrue } = List.split bytes 4
 
         if
-            maybeTrue == [asciiByte 't', asciiByte 'r', asciiByte 'u', asciiByte 'e']
+            maybeTrue == ['t', 'r', 'u', 'e']
         then
             { result: Ok Bool.true, rest: afterTrue }
         else
@@ -323,10 +322,10 @@ jsonString = \bytes ->
     { before, others: afterStartingQuote } = List.split bytes 1
 
     if
-        before == [asciiByte '"']
+        before == ['"']
     then
         # TODO: handle escape sequences
-        { taken: strSequence, rest } = takeWhile afterStartingQuote \n -> n != asciiByte '"'
+        { taken: strSequence, rest } = takeWhile afterStartingQuote \n -> n != '"'
 
         when Str.fromUtf8 strSequence is
             Ok s ->
@@ -351,7 +350,7 @@ decodeList = \decodeElem -> Decode.custom \bytes, @Json {} ->
                             { before: afterElem, others } = List.split rest 1
 
                             if
-                                afterElem == [asciiByte ',']
+                                afterElem == [',']
                             then
                                 decodeElems others (List.append accum val)
                             else
@@ -362,7 +361,7 @@ decodeList = \decodeElem -> Decode.custom \bytes, @Json {} ->
         { before, others: afterStartingBrace } = List.split bytes 1
 
         if
-            before == [asciiByte '[']
+            before == ['[']
         then
             # TODO: empty lists
             when decodeElems afterStartingBrace [] is
@@ -371,7 +370,7 @@ decodeList = \decodeElem -> Decode.custom \bytes, @Json {} ->
                     { before: maybeEndingBrace, others: afterEndingBrace } = List.split rest 1
 
                     if
-                        maybeEndingBrace == [asciiByte ']']
+                        maybeEndingBrace == [']']
                     then
                         { result: Ok vals, rest: afterEndingBrace }
                     else
@@ -393,10 +392,10 @@ parseExactChar = \bytes, char ->
         Err _ -> { result: Err TooShort, rest: bytes }
 
 openBrace : List U8 -> DecodeResult {}
-openBrace = \bytes -> parseExactChar bytes (asciiByte '{')
+openBrace = \bytes -> parseExactChar bytes '{'
 
 closingBrace : List U8 -> DecodeResult {}
-closingBrace = \bytes -> parseExactChar bytes (asciiByte '}')
+closingBrace = \bytes -> parseExactChar bytes '}'
 
 recordKey : List U8 -> DecodeResult Str
 recordKey = \bytes -> jsonString bytes
@@ -405,10 +404,10 @@ anything : List U8 -> DecodeResult {}
 anything = \bytes -> { result: Err TooShort, rest: bytes }
 
 colon : List U8 -> DecodeResult {}
-colon = \bytes -> parseExactChar bytes (asciiByte ':')
+colon = \bytes -> parseExactChar bytes ':'
 
 comma : List U8 -> DecodeResult {}
-comma = \bytes -> parseExactChar bytes (asciiByte ',')
+comma = \bytes -> parseExactChar bytes ','
 
 tryDecode : DecodeResult a, ({ val : a, rest : List U8 } -> DecodeResult b) -> DecodeResult b
 tryDecode = \{ result, rest }, mapper ->

--- a/crates/compiler/can/src/copy.rs
+++ b/crates/compiler/can/src/copy.rs
@@ -725,7 +725,7 @@ fn deep_copy_pattern_help<C: CopyEnv>(
             FloatLiteral(sub!(*v1), sub!(*v2), s.clone(), *n, *bound)
         }
         StrLiteral(s) => StrLiteral(s.clone()),
-        SingleQuote(c) => SingleQuote(*c),
+        SingleQuote(v1, v2, c, bound) => SingleQuote(sub!(*v1), sub!(*v2), *c, *bound),
         Underscore => Underscore,
         AbilityMemberSpecialization { ident, specializes } => AbilityMemberSpecialization {
             ident: *ident,

--- a/crates/compiler/can/src/copy.rs
+++ b/crates/compiler/can/src/copy.rs
@@ -259,7 +259,7 @@ fn deep_copy_expr_help<C: CopyEnv>(env: &mut C, copied: &mut Vec<Variable>, expr
         Int(v1, v2, str, val, bound) => Int(sub!(*v1), sub!(*v2), str.clone(), *val, *bound),
         Float(v1, v2, str, val, bound) => Float(sub!(*v1), sub!(*v2), str.clone(), *val, *bound),
         Str(str) => Str(str.clone()),
-        SingleQuote(char) => SingleQuote(*char),
+        SingleQuote(v1, v2, char, bound) => SingleQuote(sub!(*v1), sub!(*v2), *char, *bound),
         List {
             elem_var,
             loc_elems,

--- a/crates/compiler/can/src/def.rs
+++ b/crates/compiler/can/src/def.rs
@@ -1884,7 +1884,7 @@ fn pattern_to_vars_by_symbol(
         | IntLiteral(..)
         | FloatLiteral(..)
         | StrLiteral(_)
-        | SingleQuote(_)
+        | SingleQuote(..)
         | Underscore
         | MalformedPattern(_, _)
         | UnsupportedPattern(_)

--- a/crates/compiler/can/src/exhaustive.rs
+++ b/crates/compiler/can/src/exhaustive.rs
@@ -253,7 +253,7 @@ fn sketch_pattern(pattern: &crate::pattern::Pattern) -> SketchedPattern {
         }
         &FloatLiteral(_, _, _, f, _) => SP::Literal(Literal::Float(f64::to_bits(f))),
         StrLiteral(v) => SP::Literal(Literal::Str(v.clone())),
-        &SingleQuote(c) => SP::Literal(Literal::Byte(c as u8)),
+        &SingleQuote(_, _, c, _) => SP::Literal(Literal::Byte(c as u8)),
         RecordDestructure { destructs, .. } => {
             let tag_id = TagId(0);
             let mut patterns = std::vec::Vec::with_capacity(destructs.len());

--- a/crates/compiler/can/src/module.rs
+++ b/crates/compiler/can/src/module.rs
@@ -1038,7 +1038,7 @@ fn fix_values_captured_in_closure_expr(
         | Int(..)
         | Float(..)
         | Str(_)
-        | SingleQuote(_)
+        | SingleQuote(..)
         | Var(_)
         | AbilityMember(..)
         | EmptyRecord

--- a/crates/compiler/can/src/module.rs
+++ b/crates/compiler/can/src/module.rs
@@ -899,7 +899,7 @@ fn fix_values_captured_in_closure_pattern(
         | IntLiteral(..)
         | FloatLiteral(..)
         | StrLiteral(_)
-        | SingleQuote(_)
+        | SingleQuote(..)
         | Underscore
         | Shadowed(..)
         | MalformedPattern(_, _)

--- a/crates/compiler/can/src/pattern.rs
+++ b/crates/compiler/can/src/pattern.rs
@@ -12,6 +12,7 @@ use roc_parse::ast::{self, StrLiteral, StrSegment};
 use roc_parse::pattern::PatternType;
 use roc_problem::can::{MalformedPatternProblem, Problem, RuntimeError, ShadowKind};
 use roc_region::all::{Loc, Region};
+use roc_types::num::SingleQuoteBound;
 use roc_types::subs::{VarStore, Variable};
 use roc_types::types::{LambdaSet, OptAbleVar, PatternCategory, Type};
 
@@ -59,7 +60,7 @@ pub enum Pattern {
     IntLiteral(Variable, Variable, Box<str>, IntValue, IntBound),
     FloatLiteral(Variable, Variable, Box<str>, f64, FloatBound),
     StrLiteral(Box<str>),
-    SingleQuote(char),
+    SingleQuote(Variable, Variable, char, SingleQuoteBound),
     Underscore,
 
     /// An identifier that marks a specialization of an ability member.
@@ -95,7 +96,7 @@ impl Pattern {
             IntLiteral(var, ..) => Some(*var),
             FloatLiteral(var, ..) => Some(*var),
             StrLiteral(_) => None,
-            SingleQuote(_) => None,
+            SingleQuote(..) => None,
             Underscore => None,
 
             AbilityMemberSpecialization { .. } => None,
@@ -148,7 +149,7 @@ impl Pattern {
             IntLiteral(..) => C::Int,
             FloatLiteral(..) => C::Float,
             StrLiteral(_) => C::Str,
-            SingleQuote(_) => C::Character,
+            SingleQuote(..) => C::Character,
             Underscore => C::PatternDefault,
 
             AbilityMemberSpecialization { .. } => C::PatternDefault,
@@ -456,7 +457,12 @@ pub fn canonicalize_pattern<'a>(
             let mut it = string.chars().peekable();
             if let Some(char) = it.next() {
                 if it.peek().is_none() {
-                    Pattern::SingleQuote(char)
+                    Pattern::SingleQuote(
+                        var_store.fresh(),
+                        var_store.fresh(),
+                        char,
+                        SingleQuoteBound::from_char(char),
+                    )
                 } else {
                     // multiple chars is found
                     let problem = MalformedPatternProblem::MultipleCharsInSingleQuote;
@@ -724,7 +730,7 @@ impl<'a> BindingsFromPattern<'a> {
                         | IntLiteral(..)
                         | FloatLiteral(..)
                         | StrLiteral(_)
-                        | SingleQuote(_)
+                        | SingleQuote(..)
                         | Underscore
                         | Shadowed(_, _, _)
                         | MalformedPattern(_, _)

--- a/crates/compiler/constrain/src/builtins.rs
+++ b/crates/compiler/constrain/src/builtins.rs
@@ -4,7 +4,7 @@ use roc_can::expected::Expected::{self, *};
 use roc_can::num::{FloatBound, FloatWidth, IntBound, IntLitWidth, NumBound, SignDemand};
 use roc_module::symbol::Symbol;
 use roc_region::all::Region;
-use roc_types::num::NumericRange;
+use roc_types::num::{NumericRange, SingleQuoteBound};
 use roc_types::subs::Variable;
 use roc_types::types::Type::{self, *};
 use roc_types::types::{AliasKind, Category};
@@ -95,6 +95,42 @@ pub fn int_literal(
     ]);
 
     // TODO the precision_var is not part of the exists here; for float it is. Which is correct?
+    let and_constraint = constraints.and_constraint(constrs);
+    constraints.exists([num_var], and_constraint)
+}
+
+pub fn single_quote_literal(
+    constraints: &mut Constraints,
+    num_var: Variable,
+    precision_var: Variable,
+    expected: Expected<Type>,
+    region: Region,
+    bound: SingleQuoteBound,
+) -> Constraint {
+    let reason = Reason::IntLiteral;
+
+    // Always add the bound first; this improves the resolved type quality in case it's an alias like "U8".
+    let mut constrs = ArrayVec::<_, 3>::new();
+    let num_type = add_numeric_bound_constr(
+        constraints,
+        &mut constrs,
+        num_var,
+        precision_var,
+        bound,
+        region,
+        Category::Character,
+    );
+
+    constrs.extend([
+        constraints.equal_types(
+            num_type.clone(),
+            ForReason(reason, num_int(Type::Variable(precision_var)), region),
+            Category::Character,
+            region,
+        ),
+        constraints.equal_types(num_type, expected, Category::Character, region),
+    ]);
+
     let and_constraint = constraints.and_constraint(constrs);
     constraints.exists([num_var], and_constraint)
 }
@@ -328,6 +364,16 @@ impl TypedNumericBound for NumBound {
                 sign: SignDemand::Signed,
                 width,
             } => NumericBound::Range(NumericRange::NumAtLeastSigned(width)),
+        }
+    }
+}
+
+impl TypedNumericBound for SingleQuoteBound {
+    fn numeric_bound(&self) -> NumericBound {
+        match self {
+            &SingleQuoteBound::AtLeast { width } => {
+                NumericBound::Range(NumericRange::IntAtLeastEitherSign(width))
+            }
         }
     }
 }

--- a/crates/compiler/constrain/src/expr.rs
+++ b/crates/compiler/constrain/src/expr.rs
@@ -1,7 +1,8 @@
 use std::ops::Range;
 
 use crate::builtins::{
-    empty_list_type, float_literal, int_literal, list_type, num_literal, num_u32, str_type,
+    empty_list_type, float_literal, int_literal, list_type, num_literal, single_quote_literal,
+    str_type,
 };
 use crate::pattern::{constrain_pattern, PatternState};
 use roc_can::annotation::IntroducedVariables;
@@ -292,7 +293,14 @@ pub fn constrain_expr(
             constraints.exists(vars, and_constraint)
         }
         Str(_) => constraints.equal_types(str_type(), expected, Category::Str, region),
-        SingleQuote(_) => constraints.equal_types(num_u32(), expected, Category::Character, region),
+        SingleQuote(num_var, precision_var, _, bound) => single_quote_literal(
+            constraints,
+            *num_var,
+            *precision_var,
+            expected,
+            region,
+            *bound,
+        ),
         List {
             elem_var,
             loc_elems,

--- a/crates/compiler/mono/src/ir.rs
+++ b/crates/compiler/mono/src/ir.rs
@@ -4027,12 +4027,18 @@ pub fn with_hole<'a>(
             hole,
         ),
 
-        SingleQuote(character) => Stmt::Let(
-            assigned,
-            Expr::Literal(Literal::Int((character as i128).to_ne_bytes())),
-            Layout::int_width(IntWidth::I32),
-            hole,
-        ),
+        SingleQuote(_, _, character, _) => {
+            let layout = layout_cache
+                .from_var(env.arena, variable, env.subs)
+                .unwrap();
+
+            Stmt::Let(
+                assigned,
+                Expr::Literal(Literal::Int((character as i128).to_ne_bytes())),
+                layout,
+                hole,
+            )
+        }
         LetNonRec(def, cont) => from_can_let(
             env,
             procs,

--- a/crates/compiler/mono/src/ir.rs
+++ b/crates/compiler/mono/src/ir.rs
@@ -8889,10 +8889,12 @@ fn from_can_pattern_help<'a>(
             IntOrFloatValue::Float(*float),
         )),
         StrLiteral(v) => Ok(Pattern::StrLiteral(v.clone())),
-        SingleQuote(c) => Ok(Pattern::IntLiteral(
-            (*c as i128).to_ne_bytes(),
-            IntWidth::I32,
-        )),
+        SingleQuote(var, _, c, _) => match layout_cache.from_var(env.arena, *var, env.subs) {
+            Ok(Layout::Builtin(Builtin::Int(width))) => {
+                Ok(Pattern::IntLiteral((*c as i128).to_ne_bytes(), width))
+            }
+            o => internal_error!("an integer width was expected, but we found {:?}", o),
+        },
         Shadowed(region, ident, _new_symbol) => Err(RuntimeError::Shadowing {
             original_region: *region,
             shadow: ident.clone(),

--- a/crates/compiler/solve/tests/solve_expr.rs
+++ b/crates/compiler/solve/tests/solve_expr.rs
@@ -7841,4 +7841,49 @@ mod solve_expr {
             "hasher -> hasher | hasher has Hasher",
         );
     }
+
+    #[test]
+    fn check_char_as_u8() {
+        infer_eq_without_problem(
+            indoc!(
+                r#"
+                x : U8
+                x = '.'
+
+                x
+                "#
+            ),
+            "U8",
+        );
+    }
+
+    #[test]
+    fn check_char_as_u16() {
+        infer_eq_without_problem(
+            indoc!(
+                r#"
+                x : U16
+                x = '.'
+
+                x
+                "#
+            ),
+            "U16",
+        );
+    }
+
+    #[test]
+    fn check_char_as_u32() {
+        infer_eq_without_problem(
+            indoc!(
+                r#"
+                x : U32
+                x = '.'
+
+                x
+                "#
+            ),
+            "U32",
+        );
+    }
 }

--- a/crates/compiler/solve/tests/solve_expr.rs
+++ b/crates/compiler/solve/tests/solve_expr.rs
@@ -7886,4 +7886,58 @@ mod solve_expr {
             "U32",
         );
     }
+
+    #[test]
+    fn check_char_pattern_as_u8() {
+        infer_eq_without_problem(
+            indoc!(
+                r#"
+                f : U8 -> _
+                f = \c ->
+                    when c is
+                        '.' -> 'A'
+                        c1 -> c1
+
+                f
+                "#
+            ),
+            "U8 -> U8",
+        );
+    }
+
+    #[test]
+    fn check_char_pattern_as_u16() {
+        infer_eq_without_problem(
+            indoc!(
+                r#"
+                f : U16 -> _
+                f = \c ->
+                    when c is
+                        '.' -> 'A'
+                        c1 -> c1
+
+                f
+                "#
+            ),
+            "U16 -> U16",
+        );
+    }
+
+    #[test]
+    fn check_char_pattern_as_u32() {
+        infer_eq_without_problem(
+            indoc!(
+                r#"
+                f : U32 -> _
+                f = \c ->
+                    when c is
+                        '.' -> 'A'
+                        c1 -> c1
+
+                f
+                "#
+            ),
+            "U32 -> U32",
+        );
+    }
 }

--- a/crates/compiler/test_derive/src/pretty_print.rs
+++ b/crates/compiler/test_derive/src/pretty_print.rs
@@ -58,7 +58,7 @@ fn expr<'a>(c: &Ctx, p: EPrec, f: &'a Arena<'a>, e: &'a Expr) -> DocBuilder<'a, 
     match e {
         Num(_, n, _, _) | Int(_, _, n, _, _) | Float(_, _, n, _, _) => f.text(&**n),
         Str(s) => f.text(format!(r#""{}""#, s)),
-        SingleQuote(c) => f.text(format!("'{}'", c)),
+        SingleQuote(_, _, c, _) => f.text(format!("'{}'", c)),
         List {
             elem_var: _,
             loc_elems,

--- a/crates/compiler/test_derive/src/pretty_print.rs
+++ b/crates/compiler/test_derive/src/pretty_print.rs
@@ -366,7 +366,7 @@ fn pattern<'a>(
             f.text(&**n)
         }
         StrLiteral(s) => f.text(format!(r#""{}""#, s)),
-        SingleQuote(c) => f.text(format!("'{}'", c)),
+        SingleQuote(_, _, c, _) => f.text(format!("'{}'", c)),
         Underscore => f.text("_"),
 
         Shadowed(_, _, _) => todo!(),

--- a/crates/compiler/test_gen/src/gen_primitives.rs
+++ b/crates/compiler/test_gen/src/gen_primitives.rs
@@ -4067,3 +4067,21 @@ fn int_let_generalization() {
         RocStr
     );
 }
+
+#[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
+fn pattern_match_char() {
+    assert_evals_to!(
+        indoc!(
+            r#"
+            c = 'A'
+
+            when c is
+                'A' -> "okay"
+                _ -> "FAIL"
+            "#
+        ),
+        RocStr::from("okay"),
+        RocStr
+    );
+}

--- a/crates/compiler/types/src/num.rs
+++ b/crates/compiler/types/src/num.rs
@@ -328,6 +328,26 @@ pub enum NumBound {
     },
 }
 
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum SingleQuoteBound {
+    AtLeast { width: IntLitWidth },
+}
+
+impl SingleQuoteBound {
+    pub fn from_char(c: char) -> Self {
+        let n = c as u32;
+        let width = if n > u16::MAX as _ {
+            IntLitWidth::U32
+        } else if n > u8::MAX as _ {
+            IntLitWidth::U16
+        } else {
+            IntLitWidth::U8
+        };
+
+        Self::AtLeast { width }
+    }
+}
+
 pub const fn int_lit_width_to_variable(w: IntLitWidth) -> Variable {
     match w {
         IntLitWidth::U8 => Variable::U8,

--- a/crates/reporting/tests/test_reporting.rs
+++ b/crates/reporting/tests/test_reporting.rs
@@ -11100,4 +11100,36 @@ All branches in an `if` must have the same type!
         U8
     "###
     );
+
+    test_report!(
+        big_char_does_not_fit_in_u8_pattern,
+        indoc!(
+            r#"
+            x : U8
+            
+            when x is
+                '☃' -> ""
+                _ -> ""
+            "#
+        ),
+    @r###"
+    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+
+    The branches of this `when` expression don't match the condition:
+
+    6│>      when x is
+    7│           '☃' -> ""
+    8│           _ -> ""
+
+    This `x` value is a:
+
+        U8
+
+    But the branch patterns have type:
+
+        U16, I32, U32, I64, Nat, U64, I128, or U128
+
+    The branches must be cases of the `when` condition's type!
+    "###
+    );
 }

--- a/crates/reporting/tests/test_reporting.rs
+++ b/crates/reporting/tests/test_reporting.rs
@@ -11072,4 +11072,32 @@ All branches in an `if` must have the same type!
         U8
     "###
     );
+
+    test_report!(
+        big_char_does_not_fit_in_u8,
+        indoc!(
+            r#"
+            digits : List U8
+            digits = List.range '0' '9'
+
+            List.contains digits '☃'
+            "#
+        ),
+    @r###"
+    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+
+    This 2nd argument to `contains` has an unexpected type:
+
+    7│      List.contains digits '☃'
+                                 ^^^^^
+
+    The argument is a Unicode scalar value of type:
+
+        U16, I32, U32, I64, Nat, U64, I128, or U128
+
+    But `contains` needs its 2nd argument to be:
+
+        U8
+    "###
+    );
 }

--- a/examples/parser/Parser/CSV.roc
+++ b/examples/parser/Parser/CSV.roc
@@ -175,7 +175,7 @@ escapedCsvField = between escapedContents dquote dquote
 escapedContents = many
     (
         oneOf [
-            twodquotes |> map (\_ -> 34), # An escaped double quote
+            twodquotes |> map (\_ -> '"'),
             comma,
             cr,
             lf,
@@ -187,10 +187,10 @@ twodquotes = Parser.Str.string "\"\""
 
 nonescapedCsvField : Parser RawStr CSVField
 nonescapedCsvField = many textdata
-comma = codeunit 44 # ','
-dquote = codeunit 34 # '"'
+comma = codeunit ','
+dquote = codeunit '"'
 endOfLine = alt (ignore crlf) (ignore lf)
-cr = codeunit 13 # '\r'
-lf = codeunit 10 # '\n'
+cr = codeunit '\r'
+lf = codeunit '\n'
 crlf = Parser.Str.string "\r\n"
 textdata = codeunitSatisfies (\x -> (x >= 32 && x <= 33) || (x >= 35 && x <= 43) || (x >= 45 && x <= 126)) # Any printable char except " (34) and , (44)

--- a/examples/parser/Parser/Str.roc
+++ b/examples/parser/Parser/Str.roc
@@ -177,10 +177,9 @@ anyString = buildPrimitiveParser \fieldRawString ->
 digit : Parser RawStr U8
 digit =
     digitParsers =
-        List.range 0 10
+        List.range '0' ('9' + 1)
         |> List.map \digitNum ->
             digitNum
-            + 48
             |> codeunit
             |> map (\_ -> digitNum)
 


### PR DESCRIPTION
Pretty excited about this one. As discussed on Zulip and elsewhere previously, we'd like single quote literals to behave like ranged number literals - we give them a minimum bounded size, but the exact number type they take on can be determined from the context, as long as the contextual type is as least as large as the lower bound.

That means things like this are now possible:

```
digits : List U8
digits = List.range '0' ('9' + 1)

List.contains digits '5'
```

whereas before you would have to use a bunch of casts here. See the diff for how this gets rid of some utility code in the Json and CSV parsers, making things easier to read (and more performant, since we need less casts).

Closes #2672