### PR TITLE
nixFlakes has been renamed to nixVersions.stable

### DIFF
--- a/BUILDING_FROM_SOURCE.md
+++ b/BUILDING_FROM_SOURCE.md
@@ -31,7 +31,7 @@ sh <(curl -L https://nixos.org/nix/install) --daemon
 Open a new terminal and install nixFlakes in your environment:
 
 ```sh
-nix-env -iA nixpkgs.nixFlakes
+nix-env -iA nixpkgs.nixVersions.stable
 ```
 
 Edit either `~/.config/nix/nix.conf` or `/etc/nix/nix.conf` and add:


### PR DESCRIPTION
<img width="892" alt="Screen Shot 2022-10-04 at 4 42 59 pm" src="https://user-images.githubusercontent.com/2679227/193749968-d94bc6aa-9daf-406c-9015-d50b35ec31cb.png">
