### PR TITLE
Obligation checking for the `Hash` ability

### DIFF
--- a/crates/compiler/builtins/roc/Hash.roc
+++ b/crates/compiler/builtins/roc/Hash.roc
@@ -22,7 +22,7 @@ Hash has
     ## Hashes a value into a [Hasher].
     ## Note that [hash] does not produce a hash value itself; the hasher must be
     ## [complete]d in order to extract the hash value.
-    hash : a, hasher -> hasher | a has Hash, hasher has Hasher
+    hash : hasher, a -> hasher | a has Hash, hasher has Hasher
 
 ## Describes a hashing algorithm that is fed bytes and produces an integer hash.
 ##

--- a/crates/compiler/module/src/symbol.rs
+++ b/crates/compiler/module/src/symbol.rs
@@ -50,6 +50,7 @@ const PRETTY_PRINT_DEBUG_SYMBOLS: bool = true;
 pub const DERIVABLE_ABILITIES: &[(Symbol, &[Symbol])] = &[
     (Symbol::ENCODE_ENCODING, &[Symbol::ENCODE_TO_ENCODER]),
     (Symbol::DECODE_DECODING, &[Symbol::DECODE_DECODER]),
+    (Symbol::HASH_HASH_ABILITY, &[Symbol::HASH_HASH]),
 ];
 
 /// In Debug builds only, Symbol has a name() method that lets

--- a/crates/compiler/solve/tests/solve_expr.rs
+++ b/crates/compiler/solve/tests/solve_expr.rs
@@ -7833,9 +7833,9 @@ mod solve_expr {
 
                 Noop := {} has [Hash {hash}]
 
-                hash = \@Noop {}, hasher -> hasher
+                hash = \hasher, @Noop {} -> hasher
 
-                main = \hasher -> hash (@Noop {}) hasher
+                main = \hasher -> hash hasher (@Noop {})
                 "#
             ),
             "hasher -> hasher | hasher has Hasher",

--- a/crates/compiler/types/src/subs.rs
+++ b/crates/compiler/types/src/subs.rs
@@ -3868,11 +3868,11 @@ fn flat_type_to_err_type(
                     ErrorType::TagUnion(sub_tags.union(err_tags), sub_ext)
                 }
 
-                ErrorType::FlexVar(var) => {
+                ErrorType::FlexVar(var) | ErrorType::FlexAbleVar(var, _) => {
                     ErrorType::TagUnion(err_tags, TypeExt::FlexOpen(var))
                 }
 
-                ErrorType::RigidVar(var) => {
+                ErrorType::RigidVar(var) | ErrorType::RigidAbleVar(var, _)=> {
                     ErrorType::TagUnion(err_tags, TypeExt::RigidOpen(var))
                 }
 
@@ -3896,11 +3896,11 @@ fn flat_type_to_err_type(
                     ErrorType::TagUnion(sub_tags.union(err_tags), sub_ext)
                 }
 
-                ErrorType::FlexVar(var) => {
+                ErrorType::FlexVar(var) | ErrorType::FlexAbleVar(var, _) => {
                     ErrorType::TagUnion(err_tags, TypeExt::FlexOpen(var))
                 }
 
-                ErrorType::RigidVar(var) => {
+                ErrorType::RigidVar(var) | ErrorType::RigidAbleVar(var, _)=> {
                     ErrorType::TagUnion(err_tags, TypeExt::RigidOpen(var))
                 }
 

--- a/crates/reporting/tests/test_reporting.rs
+++ b/crates/reporting/tests/test_reporting.rs
@@ -10992,6 +10992,25 @@ All branches in an `if` must have the same type!
              main = foo (A (\x -> x) B)
              "#
         ),
-        @""
+        @r###"
+    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+
+    This expression has a type that does not implement the abilities it's expected to:
+
+    5│  main = foo (A (\x -> x) B)
+                    ^^^^^^^^^^^^^
+
+    Roc can't generate an implementation of the `Hash.Hash` ability for
+
+        [A (a -> a) [B]a]b
+
+    In particular, an implementation for
+
+        a -> a
+
+    cannot be generated.
+
+    Note: `Hash` cannot be generated for functions.
+    "###
     );
 }

--- a/crates/reporting/tests/test_reporting.rs
+++ b/crates/reporting/tests/test_reporting.rs
@@ -10848,4 +10848,150 @@ All branches in an `if` must have the same type!
     Tip: Did you mean to use `Bool.false` rather than `False`?
     "###
     );
+
+    test_report!(
+        derive_hash_for_function,
+        indoc!(
+            r#"
+             app "test" provides [A] to "./platform"
+
+             A a := a -> a has [Hash]
+             "#
+        ),
+        @r###"
+    ── INCOMPLETE ABILITY IMPLEMENTATION ───────────────────── /code/proj/Main.roc ─
+
+    Roc can't derive an implementation of the `Hash.Hash` for `A`:
+
+    3│  A a := a -> a has [Hash]
+                           ^^^^
+
+    Note: `Hash` cannot be generated for functions.
+
+    Tip: You can define a custom implementation of `Hash.Hash` for `A`.
+    "###
+    );
+
+    test_report!(
+        derive_hash_for_non_hash_opaque,
+        indoc!(
+            r#"
+             app "test" provides [A] to "./platform"
+
+             A := B has [Hash]
+
+             B := {}
+             "#
+        ),
+        @r###"
+    ── INCOMPLETE ABILITY IMPLEMENTATION ───────────────────── /code/proj/Main.roc ─
+
+    Roc can't derive an implementation of the `Hash.Hash` for `A`:
+
+    3│  A := B has [Hash]
+                    ^^^^
+
+    Tip: `B` does not implement `Hash`. Consider adding a custom
+    implementation or `has Hash.Hash` to the definition of `B`.
+
+    Tip: You can define a custom implementation of `Hash.Hash` for `A`.
+    "###
+    );
+
+    test_report!(
+        derive_hash_for_other_has_hash,
+        indoc!(
+            r#"
+             app "test" provides [A] to "./platform"
+
+             A := B has [Hash]
+
+             B := {} has [Hash]
+             "#
+        ),
+        @"" // no error
+    );
+
+    test_report!(
+        derive_hash_for_recursive_deriving,
+        indoc!(
+            r#"
+             app "test" provides [MyNat] to "./platform"
+
+             MyNat := [S MyNat, Z] has [Hash]
+             "#
+        ),
+        @"" // no error
+    );
+
+    test_report!(
+        derive_hash_for_record,
+        indoc!(
+            r#"
+             app "test" provides [main] to "./platform"
+
+             foo : a -> {} | a has Hash
+
+             main = foo {a: "", b: 1}
+             "#
+        ),
+        @"" // no error
+    );
+
+    test_report!(
+        derive_hash_for_tag,
+        indoc!(
+            r#"
+             app "test" provides [main] to "./platform"
+
+             foo : a -> {} | a has Hash
+
+             t : [A {}, B U8 U64, C Str]
+
+             main = foo t
+             "#
+        ),
+        @"" // no error
+    );
+
+    test_report!(
+        cannot_derive_hash_for_function,
+        indoc!(
+            r#"
+             app "test" provides [main] to "./platform"
+
+             foo : a -> {} | a has Hash
+
+             main = foo (\x -> x)
+             "#
+        ),
+        @r###"
+    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+
+    This expression has a type that does not implement the abilities it's expected to:
+
+    5│  main = foo (\x -> x)
+                    ^^^^^^^
+
+    Roc can't generate an implementation of the `Hash.Hash` ability for
+
+        a -> a
+
+    Note: `Hash` cannot be generated for functions.
+    "###
+    );
+
+    test_report!(
+        cannot_derive_hash_for_structure_containing_function,
+        indoc!(
+            r#"
+             app "test" provides [main] to "./platform"
+
+             foo : a -> {} | a has Hash
+
+             main = foo (A (\x -> x) B)
+             "#
+        ),
+        @""
+    );
 }


### PR DESCRIPTION
This implements type-level checks that types can and cannot implement the `Hash` ability.

Part of #4195