### PR TITLE
Fix Roc.range to be inclusive

### DIFF
--- a/crates/compiler/builtins/roc/List.roc
+++ b/crates/compiler/builtins/roc/List.roc
@@ -612,13 +612,13 @@ range = \start, end ->
         GT -> []
         EQ -> [start]
         LT ->
-            length = Num.intCast (end - start)
+            length = Num.intCast (end - start + 1)
 
             rangeHelp (List.withCapacity length) start end
 
 rangeHelp : List (Int a), Int a, Int a -> List (Int a)
 rangeHelp = \accum, start, end ->
-    if end <= start then
+    if start > end then
         accum
     else
         rangeHelp (List.appendUnsafe accum start) (start + 1) end

--- a/crates/compiler/test_gen/src/gen_list.rs
+++ b/crates/compiler/test_gen/src/gen_list.rs
@@ -2720,7 +2720,7 @@ fn list_range() {
     assert_evals_to!("List.range 0 0", RocList::from_slice(&[0]), RocList<i64>);
     assert_evals_to!(
         "List.range 0 5",
-        RocList::from_slice(&[0, 1, 2, 3, 4]),
+        RocList::from_slice(&[0, 1, 2, 3, 4, 5]),
         RocList<i64>
     );
 }


### PR DESCRIPTION
Closes #4196 

- Capacity was one less than needed to be inclusive.
- The final element was not being included

UPDATE: The test was incorrect too? 🤔 Is Roc.range actually supposed to be inclusive?