### PR TITLE
Misc hashing perf

### DIFF
--- a/crates/compiler/gen_llvm/src/llvm/build.rs
+++ b/crates/compiler/gen_llvm/src/llvm/build.rs
@@ -714,7 +714,7 @@ pub fn construct_optimization_passes<'a>(
         OptLevel::Optimize => {
             pmb.set_optimization_level(OptimizationLevel::Aggressive);
             // this threshold seems to do what we want
-            pmb.set_inliner_with_threshold(275);
+            pmb.set_inliner_with_threshold(750);
         }
     }
 


### PR DESCRIPTION
This makes List.takeFirst and List.takeLast better by improving List.sublist. Now it avoids allocations whenever possible so that it can reuse the capacity of the old list. Also increases the inline threshold to 750.