### PR TITLE
Improvements to hash deriving for tag unions

### DIFF
--- a/crates/compiler/can/src/builtins.rs
+++ b/crates/compiler/can/src/builtins.rs
@@ -84,7 +84,6 @@ macro_rules! map_symbol_to_lowlevel_and_arity {
                 LowLevel::PtrCast => unimplemented!(),
                 LowLevel::RefCountInc => unimplemented!(),
                 LowLevel::RefCountDec => unimplemented!(),
-                LowLevel::TagDiscriminant => unimplemented!(),
 
                 // these are not implemented, not sure why
                 LowLevel::StrFromInt => unimplemented!(),

--- a/crates/compiler/derive_key/src/hash.rs
+++ b/crates/compiler/derive_key/src/hash.rs
@@ -140,7 +140,8 @@ impl FlatHash {
             },
             Content::RangedNumber(_) => Err(Underivable),
             //
-            Content::RecursionVar { .. } => Err(Underivable),
+            Content::RecursionVar { structure, .. } => Self::from_var(subs, structure),
+            //
             Content::Error => Err(Underivable),
             Content::FlexVar(_)
             | Content::RigidVar(_)

--- a/crates/compiler/gen_llvm/src/llvm/build.rs
+++ b/crates/compiler/gen_llvm/src/llvm/build.rs
@@ -6575,7 +6575,7 @@ fn run_low_level<'a, 'ctx, 'env>(
             unreachable!("these are higher order, and are handled elsewhere")
         }
 
-        BoxExpr | UnboxExpr | TagDiscriminant => {
+        BoxExpr | UnboxExpr => {
             unreachable!("The {:?} operation is turned into mono Expr", op)
         }
 

--- a/crates/compiler/gen_wasm/src/low_level.rs
+++ b/crates/compiler/gen_wasm/src/low_level.rs
@@ -1858,7 +1858,7 @@ impl<'a> LowLevelCall<'a> {
 
             Eq | NotEq => self.eq_or_neq(backend),
 
-            BoxExpr | UnboxExpr | TagDiscriminant => {
+            BoxExpr | UnboxExpr => {
                 unreachable!("The {:?} operation is turned into mono Expr", self.lowlevel)
             }
 

--- a/crates/compiler/module/src/low_level.rs
+++ b/crates/compiler/module/src/low_level.rs
@@ -111,7 +111,6 @@ pub enum LowLevel {
     BoxExpr,
     UnboxExpr,
     Unreachable,
-    TagDiscriminant,
 }
 
 macro_rules! higher_order {
@@ -212,7 +211,6 @@ macro_rules! map_symbol_to_lowlevel {
                 LowLevel::PtrCast => unimplemented!(),
                 LowLevel::RefCountInc => unimplemented!(),
                 LowLevel::RefCountDec => unimplemented!(),
-                LowLevel::TagDiscriminant => unimplemented!(),
 
                 // these are not implemented, not sure why
                 LowLevel::StrFromInt => unimplemented!(),

--- a/crates/compiler/mono/src/borrow.rs
+++ b/crates/compiler/mono/src/borrow.rs
@@ -935,7 +935,7 @@ pub fn lowlevel_borrow_signature(arena: &Bump, op: LowLevel) -> &[bool] {
 
         ListIsUnique => arena.alloc_slice_copy(&[borrowed]),
 
-        BoxExpr | UnboxExpr | TagDiscriminant => {
+        BoxExpr | UnboxExpr => {
             unreachable!("These lowlevel operations are turned into mono Expr's")
         }
 

--- a/crates/compiler/mono/src/ir.rs
+++ b/crates/compiler/mono/src/ir.rs
@@ -5444,13 +5444,6 @@ pub fn with_hole<'a>(
 
                     Stmt::Let(assigned, Expr::ExprUnbox { symbol: x }, layout, hole)
                 }
-                TagDiscriminant => {
-                    debug_assert_eq!(arg_symbols.len(), 1);
-                    let tag = arg_symbols[0];
-                    let tag_var = args[0].0;
-
-                    build_tag_discriminant_expr(env, layout_cache, assigned, tag, tag_var, hole)
-                }
                 _ => {
                     let call = self::Call {
                         call_type: CallType::LowLevel {
@@ -5473,76 +5466,6 @@ pub fn with_hole<'a>(
         }
         TypedHole(_) => Stmt::RuntimeError("Hit a blank"),
         RuntimeError(e) => Stmt::RuntimeError(env.arena.alloc(e.runtime_message())),
-    }
-}
-
-fn build_tag_discriminant_expr<'a>(
-    env: &mut Env<'a, '_>,
-    layout_cache: &mut LayoutCache<'a>,
-    assigned: Symbol,
-    tag_sym: Symbol,
-    tag_var: Variable,
-    hole: &'a Stmt<'a>,
-) -> Stmt<'a> {
-    use crate::layout::UnionVariant::*;
-
-    let union_variant = {
-        let mut layout_env =
-            layout::Env::from_components(layout_cache, env.subs, env.arena, env.target_info);
-        crate::layout::union_sorted_tags(&mut layout_env, tag_var)
-            .expect("TagDiscriminant only built in derived impls, which must type-check")
-    };
-
-    let build_cast_to_u16 = |env: &mut Env<'a, '_>, tag_id_sym| self::Call {
-        call_type: CallType::LowLevel {
-            op: LowLevel::NumIntCast,
-            update_mode: env.next_update_mode_id(),
-        },
-        arguments: env.arena.alloc([tag_id_sym]),
-    };
-
-    match union_variant {
-        Never | Unit | Newtype { .. } | NewtypeByVoid { .. } => {
-            // All trivial unions decay into `0` for their discriminant.
-            Stmt::Let(
-                assigned,
-                Expr::Literal(Literal::Int(0u128.to_ne_bytes())),
-                Layout::u16(),
-                hole,
-            )
-        }
-        BoolUnion { .. } | ByteUnion(..) => {
-            // These are represented as integers at runtime, so we just need to cast them.
-            let cast_to_u16 = build_cast_to_u16(env, tag_sym);
-
-            Stmt::Let(assigned, Expr::Call(cast_to_u16), Layout::u16(), hole)
-        }
-        Wrapped(..) => {
-            let tag_layout = layout_cache.from_var(env.arena, tag_var, env.subs).unwrap();
-            let tag_union_layout = match tag_layout {
-                Layout::Union(un) => un,
-                _ => internal_error!(
-                    "Somehow this is a `Wrapped` variant, but its layout is not a union"
-                ),
-            };
-
-            let tag_id_layout = tag_union_layout.tag_id_layout();
-            debug_assert!(tag_id_layout == Layout::u8() || tag_id_layout == Layout::u16());
-
-            let tag_id_sym = env.unique_symbol();
-            let cast_to_u16 = build_cast_to_u16(env, tag_id_sym);
-
-            let hole = Stmt::Let(assigned, Expr::Call(cast_to_u16), Layout::u16(), hole);
-            Stmt::Let(
-                tag_id_sym,
-                Expr::GetTagId {
-                    structure: tag_sym,
-                    union_layout: tag_union_layout,
-                },
-                tag_id_layout,
-                env.arena.alloc(hole),
-            )
-        }
     }
 }
 

--- a/crates/compiler/solve/src/specialize.rs
+++ b/crates/compiler/solve/src/specialize.rs
@@ -655,7 +655,7 @@ fn make_specialization_decision<P: Phase>(
                 })
             }
         }
-        Structure(_) | Alias(_, _, _, _) => {
+        Structure(_) | Alias(_, _, _, _) | RecursionVar { .. } => {
             let builtin = match ability_member.try_into() {
                 Ok(builtin) => builtin,
                 Err(_) => return SpecializeDecision::Drop,
@@ -691,7 +691,6 @@ fn make_specialization_decision<P: Phase>(
         | RigidAbleVar(..)
         | FlexVar(..)
         | RigidVar(..)
-        | RecursionVar { .. }
         | LambdaSet(..)
         | RangedNumber(..) => {
             internal_error!("unexpected")

--- a/crates/compiler/test_derive/src/hash.rs
+++ b/crates/compiler/test_derive/src/hash.rs
@@ -244,14 +244,14 @@ fn tag_two_labels() {
         #   @<1>: [[hash_[A 3,B 1](0)]]
         #Derived.hash_[A 3,B 1] =
           \#Derived.hasher, #Derived.union ->
-            #Derived.discrHasher =
-              Hash.hash #Derived.hasher (@tag_discriminant #Derived.union)
             when #Derived.union is
-              A #Derived.4 #Derived.5 #Derived.6 ->
+              A #Derived.3 #Derived.4 #Derived.5 ->
                 Hash.hash
-                  (Hash.hash (Hash.hash #Derived.discrHasher #Derived.4) #Derived.5)
-                  #Derived.6
-              B #Derived.7 -> Hash.hash #Derived.discrHasher #Derived.7
+                  (Hash.hash
+                    (Hash.hash (Hash.addU8 #Derived.hasher 0) #Derived.3)
+                    #Derived.4)
+                  #Derived.5
+              B #Derived.6 -> Hash.hash (Hash.addU8 #Derived.hasher 1) #Derived.6
         "###
         )
     })
@@ -268,11 +268,9 @@ fn tag_two_labels_no_payloads() {
         #   @<1>: [[hash_[A 0,B 0](0)]]
         #Derived.hash_[A 0,B 0] =
           \#Derived.hasher, #Derived.union ->
-            #Derived.discrHasher =
-              Hash.hash #Derived.hasher (@tag_discriminant #Derived.union)
             when #Derived.union is
-              A -> #Derived.discrHasher
-              B -> #Derived.discrHasher
+              A -> Hash.addU8 #Derived.hasher 0
+              B -> Hash.addU8 #Derived.hasher 1
         "###
         )
     })
@@ -289,12 +287,12 @@ fn recursive_tag_union() {
         #   @<1>: [[hash_[Cons 2,Nil 0](0)]]
         #Derived.hash_[Cons 2,Nil 0] =
           \#Derived.hasher, #Derived.union ->
-            #Derived.discrHasher =
-              Hash.hash #Derived.hasher (@tag_discriminant #Derived.union)
             when #Derived.union is
-              Cons #Derived.4 #Derived.5 ->
-                Hash.hash (Hash.hash #Derived.discrHasher #Derived.4) #Derived.5
-              Nil -> #Derived.discrHasher
+              Cons #Derived.3 #Derived.4 ->
+                Hash.hash
+                  (Hash.hash (Hash.addU8 #Derived.hasher 0) #Derived.3)
+                  #Derived.4
+              Nil -> Hash.addU8 #Derived.hasher 1
         "###
         )
     })

--- a/crates/compiler/test_derive/src/hash.rs
+++ b/crates/compiler/test_derive/src/hash.rs
@@ -206,16 +206,11 @@ fn tag_one_label_no_payloads() {
     derive_test(Hash, v!([A]), |golden| {
         assert_snapshot!(golden, @r###"
         # derived for [A]
-        # a, [A] -[[hash_[A 0](0)]]-> a | a has Hasher
-        # a, [A] -[[hash_[A 0](0)]]-> a | a has Hasher
+        # hasher, [A] -[[hash_[A 0](0)]]-> hasher | hasher has Hasher
+        # hasher, [A] -[[hash_[A 0](0)]]-> hasher | hasher has Hasher
         # Specialization lambda sets:
         #   @<1>: [[hash_[A 0](0)]]
-        #Derived.hash_[A 0] =
-          \#Derived.hasher, #Derived.union ->
-            #Derived.discrHasher =
-              Hash.hash #Derived.hasher (@tag_discriminant #Derived.union)
-            when #Derived.union is
-              A -> #Derived.discrHasher
+        #Derived.hash_[A 0] = \#Derived.hasher, A -> #Derived.hasher
         "###
         )
     })
@@ -226,17 +221,13 @@ fn tag_one_label_newtype() {
     derive_test(Hash, v!([A v!(U8) v!(STR)]), |golden| {
         assert_snapshot!(golden, @r###"
         # derived for [A U8 Str]
-        # a, [A a1 a2] -[[hash_[A 2](0)]]-> a | a has Hasher, a1 has Hash, a2 has Hash
-        # a, [A a1 a2] -[[hash_[A 2](0)]]-> a | a has Hasher, a1 has Hash, a2 has Hash
+        # hasher, [A a a1] -[[hash_[A 2](0)]]-> hasher | a has Hash, a1 has Hash, hasher has Hasher
+        # hasher, [A a a1] -[[hash_[A 2](0)]]-> hasher | a has Hash, a1 has Hash, hasher has Hasher
         # Specialization lambda sets:
         #   @<1>: [[hash_[A 2](0)]]
         #Derived.hash_[A 2] =
-          \#Derived.hasher, #Derived.union ->
-            #Derived.discrHasher =
-              Hash.hash #Derived.hasher (@tag_discriminant #Derived.union)
-            when #Derived.union is
-              A #Derived.4 #Derived.5 ->
-                Hash.hash (Hash.hash #Derived.discrHasher #Derived.4) #Derived.5
+          \#Derived.hasher, A #Derived.2 #Derived.3 ->
+            Hash.hash (Hash.hash #Derived.hasher #Derived.2) #Derived.3
         "###
         )
     })

--- a/crates/compiler/test_derive/src/pretty_print.rs
+++ b/crates/compiler/test_derive/src/pretty_print.rs
@@ -5,7 +5,6 @@ use roc_can::expr::Expr::{self, *};
 use roc_can::expr::{ClosureData, OpaqueWrapFunctionData, WhenBranch};
 use roc_can::pattern::{Pattern, RecordDestruct};
 
-use roc_module::low_level::LowLevel;
 use roc_module::symbol::Interns;
 
 use ven_pretty::{Arena, DocAllocator, DocBuilder};

--- a/crates/compiler/test_derive/src/pretty_print.rs
+++ b/crates/compiler/test_derive/src/pretty_print.rs
@@ -163,11 +163,8 @@ fn expr<'a>(c: &Ctx, p: EPrec, f: &'a Arena<'a>, e: &'a Expr) -> DocBuilder<'a, 
                     .nest(2)
             )
         }
-        RunLowLevel { op, args, .. } => {
-            let op = match op {
-                LowLevel::TagDiscriminant => "@tag_discriminant",
-                _ => unreachable!(),
-            };
+        RunLowLevel { args, .. } => {
+            let op = "LowLevel";
 
             maybe_paren!(
                 Free,

--- a/crates/compiler/test_gen/src/gen_abilities.rs
+++ b/crates/compiler/test_gen/src/gen_abilities.rs
@@ -1394,7 +1394,9 @@ mod hash {
                     ),
                     TEST_HASHER,
                 ),
-                RocList::from_slice(&[0, 0]),
+                RocList::from_slice(&[
+                    // hash nothing because this is a newtype of a unit layout.
+                ] as &[u8]),
                 RocList<u8>
             )
         }
@@ -1489,7 +1491,7 @@ mod hash {
                     TEST_HASHER,
                 ),
                 RocList::from_slice(&[
-                    0, 0, // A
+                    // discriminant is skipped because it's a newtype
                     15, 23, 47
                 ]),
                 RocList<u8>
@@ -1519,7 +1521,7 @@ mod hash {
                 ),
                 RocList::from_slice(&[
                     0, 0, // Ok
-                    0, 0, // A
+                    // A is skipped because it is a newtype
                     15, 23, 47
                 ]),
                 RocList<u8>

--- a/crates/compiler/test_gen/src/gen_abilities.rs
+++ b/crates/compiler/test_gen/src/gen_abilities.rs
@@ -1427,8 +1427,8 @@ mod hash {
                     TEST_HASHER,
                 ),
                 RocList::from_slice(&[
-                    0, 0, // A
-                    1, 0, // B
+                    0, // A
+                    1, // B
                 ]),
                 RocList<u8>
             )
@@ -1456,14 +1456,14 @@ mod hash {
                     TEST_HASHER,
                 ),
                 RocList::from_slice(&[
-                    0, 0, // A
-                    1, 0, // B
-                    2, 0, // C
-                    3, 0, // D
-                    4, 0, // E
-                    5, 0, // F
-                    6, 0, // G
-                    7, 0, // H
+                    0, // A
+                    1, // B
+                    2, // C
+                    3, // D
+                    4, // E
+                    5, // F
+                    6, // G
+                    7, // H
                 ]),
                 RocList<u8>
             )
@@ -1520,7 +1520,7 @@ mod hash {
                     TEST_HASHER,
                 ),
                 RocList::from_slice(&[
-                    0, 0, // Ok
+                    1, // Ok
                     // A is skipped because it is a newtype
                     15, 23, 47
                 ]),
@@ -1558,11 +1558,11 @@ mod hash {
                     TEST_HASHER,
                 ),
                 RocList::from_slice(&[
-                    0, 0, // dicsr A
+                    0, // dicsr A
                     15, 23, // payloads A
-                    1, 0,  // discr B
+                    1,  // discr B
                     37, // payloads B
-                    2, 0, // discr C
+                    2,  // discr C
                     97, 98, 99 // payloads C
                 ]),
                 RocList<u8>
@@ -1593,9 +1593,9 @@ mod hash {
                     TEST_HASHER,
                 ),
                 RocList::from_slice(&[
-                    0, 0, 1, // Cons 1
-                    0, 0, 2, // Cons 2
-                    1, 0, // Nil
+                    0, 1, // Cons 1
+                    0, 2, // Cons 2
+                    1, // Nil
                 ]),
                 RocList<u8>
             )

--- a/crates/compiler/test_gen/src/gen_abilities.rs
+++ b/crates/compiler/test_gen/src/gen_abilities.rs
@@ -1568,7 +1568,6 @@ mod hash {
         }
 
         #[test]
-        #[ignore = "TODO"]
         fn hash_recursive_tag_union() {
             assert_evals_to!(
                 &format!(
@@ -1591,7 +1590,11 @@ mod hash {
                     ),
                     TEST_HASHER,
                 ),
-                RocList::from_slice(&[0]),
+                RocList::from_slice(&[
+                    0, 0, 1, // Cons 1
+                    0, 0, 2, // Cons 2
+                    1, 0, // Nil
+                ]),
                 RocList<u8>
             )
         }

--- a/crates/compiler/unify/src/unify.rs
+++ b/crates/compiler/unify/src/unify.rs
@@ -2937,7 +2937,6 @@ fn unify_flex_able<M: MetaCollector>(
         }
 
         RigidVar(_) => mismatch!("FlexAble can never unify with non-able Rigid"),
-        RecursionVar { .. } => mismatch!("FlexAble with RecursionVar"),
         LambdaSet(..) => mismatch!("FlexAble with LambdaSet"),
 
         Alias(name, _args, _real_var, AliasKind::Opaque) => {
@@ -2952,7 +2951,10 @@ fn unify_flex_able<M: MetaCollector>(
             )
         }
 
-        Structure(_) | Alias(_, _, _, AliasKind::Structural) | RangedNumber(..) => {
+        RecursionVar { .. }
+        | Structure(_)
+        | Alias(_, _, _, AliasKind::Structural)
+        | RangedNumber(..) => {
             // Structural type wins.
             merge_flex_able_with_concrete(
                 env,
@@ -3035,9 +3037,21 @@ fn unify_recursion<M: MetaCollector>(
             mismatch!("RecursionVar {:?} with rigid {:?}", ctx.first, &other)
         }
 
-        FlexAbleVar(..) | RigidAbleVar(..) => {
+        RigidAbleVar(..) => {
             mismatch!("RecursionVar {:?} with able var {:?}", ctx.first, &other)
         }
+
+        FlexAbleVar(_, ability) => merge_flex_able_with_concrete(
+            env,
+            ctx,
+            ctx.second,
+            *ability,
+            RecursionVar {
+                structure,
+                opt_name: *opt_name,
+            },
+            Obligated::Adhoc(ctx.first),
+        ),
 
         FlexVar(_) => merge(
             env,


### PR DESCRIPTION
This PR builds upon #4209 to implement more performant hashers for tag unions. The main changes are:

- Derive hashing for recursive tag unions correctly (2517695ce4406532b67c64be906e179cff965d76)
- Do not hash discriminants for tags that are newtypes. In such cases the discriminant doesn't exist, or can be seen as constant, so hashing it provides no value to the hash. (a308ebb38c8a206987a4f9a1b75ba90947b2b1a6)
- Implement hashing discriminants for tags that need them in the derived implementation itself, rather than relying on a LowLevel. There are two benefits to this - (1) we can choose a smaller byte size (u8) for the discriminant in the common case, rather than having to always hash the upper bound of discriminant sizes, and (2) it gets rid of a low-level that we otherwise don't need. (cb96a6425934d2e926a33e14e258efd030755644 and 792afe5457b71e7e748854a5719a1e5cd7872749)

Blocked on #4209