### PR TITLE
Web REPL: ensure we only try to append to DOM Elements, not text nodes

### DIFF
--- a/www/public/repl/repl.js
+++ b/www/public/repl/repl.js
@@ -212,7 +212,7 @@ function updateHistoryEntry(index, ok, outputText) {
   outputElem.classList.add("output");
   outputElem.classList.add(ok ? "output-ok" : "output-error");
 
-  const historyItem = repl.elemHistory.childNodes[index];
+  const historyItem = repl.elemHistory.children[index];
   historyItem.appendChild(outputElem);
 
   repl.elemHistory.scrollTop = repl.elemHistory.scrollHeight;


### PR DESCRIPTION
One line in the Web REPL was using the wrong DOM property, which caused it to silently throw an exception whenever it tried to append a new REPL output! Thankfully someone reported it in Zulip.

A DOM node can be either a Text node or an Element. `.childNodes` contains both, but `.children` only contains Elements. I was using `.childNodes` but assuming it would always be an Element. Switching to `.children` fixes it.

I'm not sure when this stopped working! The last PR added a loading state so I guess it was probably then. I definitely tested it at the time. 🤔 Maybe I reformatted the HTML just before pushing it, and ended up inserting a whitespace Text node by accident. 🤷 

After this is merged we should also update www from main.