### PR TITLE
Add newline-less `Stdout.write` & `Stderr.write` to `cli-platform`

### DIFF
--- a/examples/cli/cli-platform/Effect.roc
+++ b/examples/cli/cli-platform/Effect.roc
@@ -16,6 +16,7 @@ hosted Effect
         stdoutLine,
         stdoutWrite,
         stderrLine,
+        stderrWrite,
         stdinLine,
         sendRequest,
         fileReadBytes,
@@ -29,6 +30,7 @@ hosted Effect
 stdoutLine : Str -> Effect {}
 stdoutWrite : Str -> Effect {}
 stderrLine : Str -> Effect {}
+stderrWrite : Str -> Effect {}
 stdinLine : Effect Str
 
 fileWriteBytes : List U8, List U8 -> Effect (Result {} InternalFile.WriteErr)

--- a/examples/cli/cli-platform/Effect.roc
+++ b/examples/cli/cli-platform/Effect.roc
@@ -14,6 +14,7 @@ hosted Effect
         setCwd,
         exePath,
         stdoutLine,
+        stdoutWrite,
         stderrLine,
         stdinLine,
         sendRequest,
@@ -26,6 +27,7 @@ hosted Effect
     generates Effect with [after, map, always, forever, loop]
 
 stdoutLine : Str -> Effect {}
+stdoutWrite : Str -> Effect {}
 stderrLine : Str -> Effect {}
 stdinLine : Effect Str
 

--- a/examples/cli/cli-platform/Stderr.roc
+++ b/examples/cli/cli-platform/Stderr.roc
@@ -1,8 +1,15 @@
 interface Stderr
-    exposes [line]
+    exposes [line, write]
     imports [Effect, Task.{ Task }, InternalTask]
 
 line : Str -> Task {} * [Write [Stderr]*]*
 line = \str ->
-    Effect.map (Effect.stderrLine str) (\_ -> Ok {})
+    Effect.stderrLine str
+    |> Effect.map (\_ -> Ok {})
+    |> InternalTask.fromEffect
+
+write : Str -> Task {} * [Write [Stderr]*]*
+write = \str ->
+    Effect.stderrWrite str
+    |> Effect.map (\_ -> Ok {})
     |> InternalTask.fromEffect

--- a/examples/cli/cli-platform/Stdout.roc
+++ b/examples/cli/cli-platform/Stdout.roc
@@ -1,8 +1,15 @@
 interface Stdout
-    exposes [line]
+    exposes [line, write]
     imports [Effect, Task.{ Task }, InternalTask]
 
 line : Str -> Task {} * [Write [Stdout]*]*
 line = \str ->
-    Effect.map (Effect.stdoutLine str) (\_ -> Ok {})
+    Effect.stdoutLine str
+    |> Effect.map (\_ -> Ok {})
+    |> InternalTask.fromEffect
+
+write : Str -> Task {} * [Write [Stdout]*]*
+write = \str ->
+    Effect.stdoutWrite str
+    |> Effect.map (\_ -> Ok {})
     |> InternalTask.fromEffect

--- a/examples/cli/cli-platform/src/lib.rs
+++ b/examples/cli/cli-platform/src/lib.rs
@@ -290,6 +290,13 @@ pub extern "C" fn roc_fx_stderrLine(line: &RocStr) {
     eprintln!("{}", string);
 }
 
+#[no_mangle]
+pub extern "C" fn roc_fx_stderrWrite(text: &RocStr) {
+    let string = text.as_str();
+    eprint!("{}", string);
+    io::stderr().flush().unwrap();
+}
+
 // #[no_mangle]
 // pub extern "C" fn roc_fx_fileWriteUtf8(
 //     roc_path: &RocList<u8>,

--- a/examples/cli/cli-platform/src/lib.rs
+++ b/examples/cli/cli-platform/src/lib.rs
@@ -12,6 +12,7 @@ use roc_std::{RocDict, RocList, RocResult, RocStr};
 use std::borrow::Borrow;
 use std::ffi::{CStr, OsStr};
 use std::fs::File;
+use std::io::{self, Write};
 use std::os::raw::c_char;
 use std::path::Path;
 use std::time::Duration;
@@ -274,6 +275,13 @@ pub extern "C" fn roc_fx_stdinLine() -> RocStr {
 pub extern "C" fn roc_fx_stdoutLine(line: &RocStr) {
     let string = line.as_str();
     println!("{}", string);
+}
+
+#[no_mangle]
+pub extern "C" fn roc_fx_stdoutWrite(text: &RocStr) {
+    let string = text.as_str();
+    print!("{}", string);
+    io::stdout().flush().unwrap();
 }
 
 #[no_mangle]


### PR DESCRIPTION
Closes #4120 