### PR TITLE
www: handle empty input in web REPL

### DIFF
--- a/www/public/repl/repl.js
+++ b/www/public/repl/repl.js
@@ -42,7 +42,7 @@ const repl = {
 repl.elemSourceInput.addEventListener("change", onInputChange);
 repl.elemSourceInput.addEventListener("keyup", onInputKeyup);
 roc_repl_wasm.default("/repl/roc_repl_wasm_bg.wasm").then((instance) => {
-  repl.elemHistory.querySelector('#loading-message').remove();
+  repl.elemHistory.querySelector("#loading-message").remove();
   repl.elemSourceInput.disabled = false;
   repl.elemSourceInput.placeholder =
     "Type some Roc code and press Enter. (Use Shift+Enter for multi-line input)";
@@ -54,8 +54,7 @@ roc_repl_wasm.default("/repl/roc_repl_wasm_bg.wasm").then((instance) => {
 // ----------------------------------------------------------------------------
 
 function onInputChange(event) {
-  const inputText = event.target.value;
-  if (!inputText) return;
+  const inputText = event.target.value.trim();
 
   event.target.value = "";
 
@@ -122,13 +121,15 @@ async function processInputQueue() {
     repl.inputHistoryIndex = createHistoryEntry(inputText);
     repl.inputStash = "";
 
-    let outputText;
+    let outputText = "";
     let ok = true;
-    try {
-      outputText = await roc_repl_wasm.entrypoint_from_js(inputText);
-    } catch (e) {
-      outputText = `${e}`;
-      ok = false;
+    if (inputText) {
+      try {
+        outputText = await roc_repl_wasm.entrypoint_from_js(inputText);
+      } catch (e) {
+        outputText = `${e}`;
+        ok = false;
+      }
     }
 
     updateHistoryEntry(repl.inputHistoryIndex, ok, outputText);


### PR DESCRIPTION
Closes #4232

When you just hit Enter in the REPL, we try to turn the string `'\n'`, into a Roc program for the compiler, and it doesn't parse.
At some point in the past, hitting Enter used to give us an empty string rather than a newline, and repl.js was still handling the empty string. But at some point we added support for multi-line expressions and things changed.

The fix is to trim the input string before using it. I also decided to make it print an empty line in this case. You might want to put some space between your expressions.

## Before
<img width="966" alt="Screen Shot 2022-10-07 at 15 03 41" src="https://user-images.githubusercontent.com/2679227/194465724-147d59ee-edff-4b5c-83b0-a0db1af2cd52.png">

## After
![repl-empty-and-real-input](https://user-images.githubusercontent.com/4647158/194498633-57418e8b-dde8-4038-823d-1e7d0b585a48.png)

