### PR TITLE
Correctly check mutual functional recursion between opaque types

### DIFF
--- a/crates/compiler/solve/src/solve.rs
+++ b/crates/compiler/solve/src/solve.rs
@@ -1522,8 +1522,9 @@ fn solve(
 
                     symbols.iter().any(|(s, _)| {
                         let var = env.get_var_by_symbol(s).expect("Symbol not solved!");
-                        let content = subs.get_content_without_compacting(var);
-                        !matches!(content, Error | Structure(FlatType::Func(..)))
+                        let (_, underlying_content) = chase_alias_content(subs, var);
+
+                        !matches!(underlying_content, Error | Structure(FlatType::Func(..)))
                     })
                 };
 
@@ -1553,6 +1554,17 @@ fn solve(
     }
 
     state
+}
+
+fn chase_alias_content(subs: &Subs, mut var: Variable) -> (Variable, &Content) {
+    loop {
+        match subs.get_content_without_compacting(var) {
+            Content::Alias(_, _, real_var, _) => {
+                var = *real_var;
+            }
+            content => return (var, content),
+        }
+    }
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/crates/compiler/solve/tests/solve_expr.rs
+++ b/crates/compiler/solve/tests/solve_expr.rs
@@ -7940,4 +7940,22 @@ mod solve_expr {
             "U32 -> U32",
         );
     }
+
+    #[test]
+    fn issue_4246_admit_recursion_between_opaque_functions() {
+        infer_eq_without_problem(
+            indoc!(
+                r#"
+                app "test" provides [b] to "./platform"
+
+                O := {} -> {}
+
+                a = @O \{} -> ((\@O f -> f {}) b)
+
+                b = a
+                "#
+            ),
+            "O",
+        );
+    }
 }


### PR DESCRIPTION
The mutual-recursion checks does not admit types that are not function types; because Roc is strict, only functional values can be involved in mutual recursion. However, this check was exercised by checking the head constructor of a type, which is not the correct way to do it. Aliases and opaque types may in fact be function types as well, so we must chase their actual contents.

Closes #4246