### PR TITLE
`x86` should be `x86_64`

### DIFF
--- a/getting_started/README.md
+++ b/getting_started/README.md
@@ -12,9 +12,9 @@ If you have a specific question, the [FAQ](../FAQ.md) might have an answer, alth
 
 ## Installation
 
-- [Linux x86](linux_x86.md)
+- [Linux x86_64](linux_x86_64.md)
 - [MacOS Apple Silicon](macos_apple_silicon.md)
-- [MacOS x86](macos_x86.md)
+- [MacOS x86_64](macos_x86_64.md)
 - [Windows](windows.md)
 - [Other](other.md)
 

--- a/getting_started/linux_x86_64.md
+++ b/getting_started/linux_x86_64.md
@@ -1,4 +1,4 @@
-# Roc installation guide for x86 macOS systems
+# Roc installation guide for x86_64 Linux systems
 
 ## How to install Roc
 
@@ -7,17 +7,10 @@ which includes the Roc compiler and various helpful utilities.
 
 1. Download the latest nightly from the assets [here](https://github.com/roc-lang/roc/releases).
 
-1. To prevent "roc can't be opened because Apple can't check it...":
-
-    ```sh
-    xattr -d com.apple.quarantine roc_nightly-macos_x86_64-<VERSION>.tar.gz
-    ```
-
 1. Untar the archive:
 
     ```sh
-    mkdir roc_nightly-macos_x86_64-<VERSION>
-    tar xf roc_nightly-macos_x86_64-<VERSION>.tar.gz --directory roc_nightly-macos_x86_64-<VERSION>
+    tar -xf roc_nightly-linux_x86_64-<VERSION>.tar.gz --one-top-level
     cd roc_night<TAB TO AUTOCOMPLETE>
     ```
 
@@ -35,13 +28,23 @@ you need to install one or more of these platform language compilers, too.
 1. Install the Zig compiler, for apps with Zig-based platforms:
 
     ```sh
-    brew install zig
+    wget https://ziglang.org/download/0.9.1/zig-linux-x86_64-0.9.1.tar.xz
+    tar -xf zig-linux-x86_64-0.9.1.tar.xz
+    sudo ln -s  $(pwd)/zig-linux-x86_64-0.9.1/zig /usr/local/bin/zig
     ```
 
-1. Run examples:
+1. Install a C compiler, for apps with C-based platforms:
 
     ```sh
-    # Note: If you installed rust in this terminal session, you'll need to open a new one first!
+    # On a Debian-based distro like Ubuntu
+    sudo apt update && sudo apt install build-essential clang
+    
+    # On an RPM-based distro like Fedora
+    sudo dnf check-update && sudo dnf install clang
+    ```
+
+    ```sh
+    # Note: If you installed Rust in this terminal session, you'll need to open a new one first!
     ./roc crates/cli_testing_examples/platform-switching/rocLovesRust.roc
 
     ./roc crates/cli_testing_examples/platform-switching/rocLovesZig.roc

--- a/getting_started/macos_x86_64.md
+++ b/getting_started/macos_x86_64.md
@@ -1,4 +1,4 @@
-# Roc installation guide for x86 Linux systems
+# Roc installation guide for x86_64 macOS systems
 
 ## How to install Roc
 
@@ -7,10 +7,17 @@ which includes the Roc compiler and various helpful utilities.
 
 1. Download the latest nightly from the assets [here](https://github.com/roc-lang/roc/releases).
 
+1. To prevent "roc can't be opened because Apple can't check it...":
+
+    ```sh
+    xattr -d com.apple.quarantine roc_nightly-macos_x86_64-<VERSION>.tar.gz
+    ```
+
 1. Untar the archive:
 
     ```sh
-    tar -xf roc_nightly-linux_x86_64-<VERSION>.tar.gz --one-top-level
+    mkdir roc_nightly-macos_x86_64-<VERSION>
+    tar xf roc_nightly-macos_x86_64-<VERSION>.tar.gz --directory roc_nightly-macos_x86_64-<VERSION>
     cd roc_night<TAB TO AUTOCOMPLETE>
     ```
 
@@ -28,23 +35,13 @@ you need to install one or more of these platform language compilers, too.
 1. Install the Zig compiler, for apps with Zig-based platforms:
 
     ```sh
-    wget https://ziglang.org/download/0.9.1/zig-linux-x86_64-0.9.1.tar.xz
-    tar -xf zig-linux-x86_64-0.9.1.tar.xz
-    sudo ln -s  $(pwd)/zig-linux-x86_64-0.9.1/zig /usr/local/bin/zig
+    brew install zig
     ```
 
-1. Install a C compiler, for apps with C-based platforms:
+1. Run examples:
 
     ```sh
-    # On a Debian-based distro like Ubuntu
-    sudo apt update && sudo apt install build-essential clang
-    
-    # On an RPM-based distro like Fedora
-    sudo dnf check-update && sudo dnf install clang
-    ```
-
-    ```sh
-    # Note: If you installed Rust in this terminal session, you'll need to open a new one first!
+    # Note: If you installed rust in this terminal session, you'll need to open a new one first!
     ./roc crates/cli_testing_examples/platform-switching/rocLovesRust.roc
 
     ./roc crates/cli_testing_examples/platform-switching/rocLovesZig.roc


### PR DESCRIPTION
In the `getting_started` doc I accidentally wrote `x86` where I meant `x86_64`.