### PR TITLE
Only allow dependabot to send security-based updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,5 @@ updates:
       day: "monday"
       time: "07:00"
       timezone: "Europe/Brussels"
+    # Disable all version updates, only critical security updates will be submitted
+    open-pull-requests-limit: 0


### PR DESCRIPTION
As discussed previously on Zulip. I think we should either do this, or have all Dependabot PRs be batched. Right now it's way too noisy.

Signed-off-by: Ayaz <20735482+ayazhafiz@users.noreply.github.com>