### PR TITLE
roc docs add feature to focus search box using ⌘F, CTRL F, or F3 

### DIFF
--- a/crates/docs/src/static/search.js
+++ b/crates/docs/src/static/search.js
@@ -45,11 +45,20 @@
 
   search();
 
-  window.addEventListener("keydown", (e) => {
-    if (e.code === 'F3' || ((e.ctrlKey || e.metaKey) && e.code === 'KeyF')) { 
-      e.preventDefault();
+  // Capture '/' keypress for quick search 
+  window.addEventListener("keyup", (e) => {
+
+    if (e.code === "Slash") {
+      e.preventDefault;
       searchBox.focus();
+      searchBox.value = "";
     }
+
+    if (e.code === "Escape" && document.activeElement === searchBox) {
+      e.preventDefault;
+      searchBox.blur();
+    }
+
   });
-  
+
 })();

--- a/crates/docs/src/static/search.js
+++ b/crates/docs/src/static/search.js
@@ -44,4 +44,12 @@
   searchBox.addEventListener("input", search);
 
   search();
+
+  window.addEventListener("keydown", (e) => {
+    if (e.code === 'F3' || ((e.ctrlKey || e.metaKey) && e.code === 'KeyF')) { 
+      e.preventDefault();
+      searchBox.focus();
+    }
+  });
+  
 })();


### PR DESCRIPTION
I thought it maybe helpful to focus the search box in Docs. I find I am constantly scrolling back and forth so being able to immediately focus the search box helps to find the function I am looking for. 