### PR TITLE
De-bump all v0.1.0 Roc packages to v0.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -484,7 +484,7 @@ checksum = "4bfbf56724aa9eca8afa4fcfadeb479e722935bb2a0900c2d37e0cc477af0688"
 
 [[package]]
 name = "cli_utils"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "bumpalo",
  "criterion",
@@ -3291,7 +3291,7 @@ dependencies = [
 
 [[package]]
 name = "roc_ast"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "arrayvec 0.7.2",
  "bumpalo",
@@ -3386,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "roc_cli"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "bumpalo",
  "clap 3.2.20",
@@ -3436,7 +3436,7 @@ dependencies = [
 
 [[package]]
 name = "roc_code_markup"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "bumpalo",
  "palette",

--- a/ci/bench-runner/Cargo.lock
+++ b/ci/bench-runner/Cargo.lock
@@ -30,7 +30,7 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "bench-runner"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "clap",
  "data-encoding",

--- a/ci/bench-runner/Cargo.toml
+++ b/ci/bench-runner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bench-runner"
-version = "0.1.0"
+version = "0.0.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/ast/Cargo.toml
+++ b/crates/ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "roc_ast"
-version = "0.1.0"
+version = "0.0.1"
 authors = ["The Roc Contributors"]
 license = "UPL-1.0"
 edition = "2021"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "roc_cli"
-version = "0.1.0"
+version = "0.0.1"
 authors = ["The Roc Contributors"]
 license = "UPL-1.0"
 repository = "https://github.com/roc-lang/roc"

--- a/crates/cli_utils/Cargo.lock
+++ b/crates/cli_utils/Cargo.lock
@@ -382,7 +382,7 @@ dependencies = [
 
 [[package]]
 name = "cli_utils"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "bumpalo",
  "criterion",
@@ -2534,7 +2534,7 @@ dependencies = [
 
 [[package]]
 name = "roc_alias_analysis"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "morphic_lib",
  "roc_collections",
@@ -2545,7 +2545,7 @@ dependencies = [
 
 [[package]]
 name = "roc_ast"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "arrayvec 0.7.2",
  "bumpalo",
@@ -2571,7 +2571,7 @@ dependencies = [
 
 [[package]]
 name = "roc_build"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "bumpalo",
  "inkwell 0.1.0",
@@ -2604,7 +2604,7 @@ dependencies = [
 
 [[package]]
 name = "roc_builtins"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "dunce",
  "lazy_static",
@@ -2617,7 +2617,7 @@ dependencies = [
 
 [[package]]
 name = "roc_can"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "bitvec 1.0.0",
  "bumpalo",
@@ -2634,7 +2634,7 @@ dependencies = [
 
 [[package]]
 name = "roc_cli"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "bumpalo",
  "clap 3.1.17",
@@ -2663,7 +2663,7 @@ dependencies = [
 
 [[package]]
 name = "roc_code_markup"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "bumpalo",
  "itertools 0.10.1",
@@ -2677,7 +2677,7 @@ dependencies = [
 
 [[package]]
 name = "roc_collections"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "bumpalo",
  "hashbrown 0.11.2",
@@ -2688,7 +2688,7 @@ dependencies = [
 
 [[package]]
 name = "roc_constrain"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "arrayvec 0.7.2",
  "roc_builtins",
@@ -2703,11 +2703,11 @@ dependencies = [
 
 [[package]]
 name = "roc_debug_flags"
-version = "0.1.0"
+version = "0.0.1"
 
 [[package]]
 name = "roc_docs"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "bumpalo",
  "peg",
@@ -2730,7 +2730,7 @@ dependencies = [
 
 [[package]]
 name = "roc_editor"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "arrayvec 0.7.2",
  "bumpalo",
@@ -2775,11 +2775,11 @@ dependencies = [
 
 [[package]]
 name = "roc_error_macros"
-version = "0.1.0"
+version = "0.0.1"
 
 [[package]]
 name = "roc_exhaustive"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "roc_collections",
  "roc_module",
@@ -2789,7 +2789,7 @@ dependencies = [
 
 [[package]]
 name = "roc_fmt"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "bumpalo",
  "roc_collections",
@@ -2800,7 +2800,7 @@ dependencies = [
 
 [[package]]
 name = "roc_gen_dev"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "bumpalo",
  "object 0.26.2",
@@ -2821,7 +2821,7 @@ dependencies = [
 
 [[package]]
 name = "roc_gen_llvm"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "bumpalo",
  "inkwell 0.1.0",
@@ -2840,7 +2840,7 @@ dependencies = [
 
 [[package]]
 name = "roc_gen_wasm"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "bumpalo",
  "roc_builtins",
@@ -2854,7 +2854,7 @@ dependencies = [
 
 [[package]]
 name = "roc_highlight"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "peg",
  "roc_code_markup",
@@ -2862,11 +2862,11 @@ dependencies = [
 
 [[package]]
 name = "roc_ident"
-version = "0.1.0"
+version = "0.0.1"
 
 [[package]]
 name = "roc_linker"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "bincode",
  "bumpalo",
@@ -2884,7 +2884,7 @@ dependencies = [
 
 [[package]]
 name = "roc_load"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "bumpalo",
  "roc_builtins",
@@ -2899,7 +2899,7 @@ dependencies = [
 
 [[package]]
 name = "roc_load_internal"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "bumpalo",
  "crossbeam",
@@ -2926,7 +2926,7 @@ dependencies = [
 
 [[package]]
 name = "roc_module"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -2940,7 +2940,7 @@ dependencies = [
 
 [[package]]
 name = "roc_mono"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "bumpalo",
  "hashbrown 0.11.2",
@@ -2965,7 +2965,7 @@ dependencies = [
 
 [[package]]
 name = "roc_parse"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "bumpalo",
  "encode_unicode",
@@ -2976,7 +2976,7 @@ dependencies = [
 
 [[package]]
 name = "roc_problem"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "roc_collections",
  "roc_module",
@@ -2987,14 +2987,14 @@ dependencies = [
 
 [[package]]
 name = "roc_region"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "static_assertions 1.1.0",
 ]
 
 [[package]]
 name = "roc_repl_cli"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "bumpalo",
  "const_format",
@@ -3019,7 +3019,7 @@ dependencies = [
 
 [[package]]
 name = "roc_repl_eval"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "bumpalo",
  "roc_builtins",
@@ -3039,7 +3039,7 @@ dependencies = [
 
 [[package]]
 name = "roc_reporting"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "bumpalo",
  "distance",
@@ -3057,7 +3057,7 @@ dependencies = [
 
 [[package]]
 name = "roc_solve"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "arrayvec 0.7.2",
  "bumpalo",
@@ -3074,21 +3074,21 @@ dependencies = [
 
 [[package]]
 name = "roc_std"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "static_assertions 0.1.1",
 ]
 
 [[package]]
 name = "roc_target"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "target-lexicon",
 ]
 
 [[package]]
 name = "roc_types"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "bumpalo",
  "roc_collections",
@@ -3102,7 +3102,7 @@ dependencies = [
 
 [[package]]
 name = "roc_unify"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "bitflags",
  "roc_collections",
@@ -3114,7 +3114,7 @@ dependencies = [
 
 [[package]]
 name = "roc_utils"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "snafu",
 ]

--- a/crates/cli_utils/Cargo.toml
+++ b/crates/cli_utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cli_utils"
-version = "0.1.0"
+version = "0.0.1"
 authors = ["The Roc Contributors"]
 license = "UPL-1.0"
 repository = "https://github.com/roc-lang/roc"

--- a/crates/code_markup/Cargo.toml
+++ b/crates/code_markup/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "roc_code_markup"
-version = "0.1.0"
+version = "0.0.1"
 authors = ["The Roc Contributors"]
 license = "UPL-1.0"
 edition = "2021"

--- a/crates/compiler/test_mono_macros/Cargo.lock
+++ b/crates/compiler/test_mono_macros/Cargo.lock
@@ -33,7 +33,7 @@ dependencies = [
 
 [[package]]
 name = "test_mono_macros"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/glue/tests/fixture-templates/rust/Cargo.lock
+++ b/crates/glue/tests/fixture-templates/rust/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "host"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "indoc",
  "libc",
@@ -25,7 +25,7 @@ checksum = "56d855069fafbb9b344c0f962150cd2c1187975cb1c22c1522c240d8c4986714"
 
 [[package]]
 name = "roc_std"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "static_assertions",
 ]

--- a/crates/glue/tests/fixture-templates/rust/Cargo.toml
+++ b/crates/glue/tests/fixture-templates/rust/Cargo.toml
@@ -11,7 +11,7 @@
 
 [package]
 name = "host"
-version = "0.1.0"
+version = "0.0.1"
 authors = ["The Roc Contributors"]
 license = "UPL-1.0"
 edition = "2018"


### PR DESCRIPTION
I'm a Rustling, but I think this better aligns with our current project status. Sometimes I see lots of version numbers in stdout, and the versions seem to alternate randomly between v0.1.0 and v0.0.1 - I hope this makes it more consistent, as well as obvious which packages are Roc's.