### PR TITLE
Search docs with S instead of /

### DIFF
--- a/crates/docs/src/static/index.html
+++ b/crates/docs/src/static/index.html
@@ -15,7 +15,7 @@
 <body>
 <nav id="sidebar-nav">
     <input id="module-search" aria-labelledby="search-link" type="text" placeholder="Search" />
-    <label for="module-search" id="search-link">Search</label>
+    <label for="module-search" id="search-link"><span id="search-link-text">Search</span> <span id="search-link-hint">(shortcut: S)</span></label>
     <div class="module-links">
         <!-- Module links -->
     </div>

--- a/crates/docs/src/static/search.js
+++ b/crates/docs/src/static/search.js
@@ -45,20 +45,18 @@
 
   search();
 
-  // Capture '/' keypress for quick search 
+  // Capture '/' keypress for quick search
   window.addEventListener("keyup", (e) => {
-
-    if (e.code === "Slash") {
+    if (e.key === "s") {
       e.preventDefault;
       searchBox.focus();
       searchBox.value = "";
     }
 
-    if (e.code === "Escape" && document.activeElement === searchBox) {
+    if (e.key === "Escape" && document.activeElement === searchBox) {
       e.preventDefault;
       searchBox.blur();
     }
-
   });
 
 })();

--- a/crates/docs/src/static/styles.css
+++ b/crates/docs/src/static/styles.css
@@ -446,8 +446,14 @@ pre {
   cursor: pointer;
 }
 
-#search-link:hover {
+#search-link:hover #search-link-text {
   text-decoration: underline;
+}
+
+#search-link-hint {
+  font-style: italic;
+  margin-left: 1em;
+  opacity: 0.7;
 }
 
 @media (prefers-color-scheme: dark) {


### PR DESCRIPTION
It turns out `/` on Firefox is already search, and we don't want to override that.

Also adds a tip to make the shortcut discoverable:

<img width="288" alt="Screen Shot 2022-10-09 at 4 27 40 AM" src="https://user-images.githubusercontent.com/1094080/194746249-5bfa2dd7-ebf1-4830-b602-f8eda8cc0546.png">