### PR TITLE
fix for 's' keypress in search, and escape behaviour to reset sidebar…

### DIFF
--- a/crates/docs/src/static/search.js
+++ b/crates/docs/src/static/search.js
@@ -47,7 +47,7 @@
 
   // Capture '/' keypress for quick search
   window.addEventListener("keyup", (e) => {
-    if (e.key === "s") {
+    if (e.key === "s" && document.activeElement !== searchBox) {
       e.preventDefault;
       searchBox.focus();
       searchBox.value = "";
@@ -55,7 +55,13 @@
 
     if (e.key === "Escape" && document.activeElement === searchBox) {
       e.preventDefault;
+
+      // De-focus input box
       searchBox.blur();
+
+      // Reset sidebar state
+      search();
+
     }
   });
 


### PR DESCRIPTION
You can now use ```s``` key in the search input box, and it correctly resets sidebar on ```escape``` keypress. 