### PR TITLE
Give an error message when the surgical linker #3609

### DIFF
--- a/crates/linker/src/elf.rs
+++ b/crates/linker/src/elf.rs
@@ -985,6 +985,16 @@ pub(crate) fn surgery_elf(
         }
     };
 
+    if app_obj
+        .sections()
+        .flat_map(|sec| sec.relocations())
+        .any(|(_, reloc)| reloc.kind() == RelocationKind::Absolute)
+    {
+        eprintln!("The surgical linker currently has issue #3609 and would fail linking your app.");
+        eprintln!("Please use `--linker=legacy` to avoid the issue for now.");
+        std::process::exit(1);
+    }
+
     let total_start = Instant::now();
 
     let loading_metadata_start = total_start;


### PR DESCRIPTION
Just trying to help with the user experience and make it clearer when this bug comes up. That way we don't keep getting duplicate bugs and users have a clear idea how to work around the issue