### PR TITLE
[Easy Review] Remove RocResult from utils.zig

### DIFF
--- a/crates/compiler/builtins/bitcode/src/list.zig
+++ b/crates/compiler/builtins/bitcode/src/list.zig
@@ -1,6 +1,5 @@
 const std = @import("std");
 const utils = @import("utils.zig");
-const RocResult = utils.RocResult;
 const UpdateMode = utils.UpdateMode;
 const mem = std.mem;
 const math = std.math;

--- a/crates/compiler/builtins/bitcode/src/utils.zig
+++ b/crates/compiler/builtins/bitcode/src/utils.zig
@@ -267,25 +267,6 @@ pub fn unsafeReallocate(
     return new_source;
 }
 
-pub const RocResult = extern struct {
-    bytes: ?[*]u8,
-
-    pub fn isOk(self: RocResult) bool {
-        // assumptions
-        //
-        // - the tag is the first field
-        // - the tag is usize bytes wide
-        // - Ok has tag_id 1, because Err < Ok
-        const usizes: [*]usize = @ptrCast([*]usize, @alignCast(@alignOf(usize), self.bytes));
-
-        return usizes[0] == 1;
-    }
-
-    pub fn isErr(self: RocResult) bool {
-        return !self.isOk();
-    }
-};
-
 pub const Ordering = enum(u8) {
     EQ = 0,
     GT = 1,


### PR DESCRIPTION
It is implemented wrong and not used anywhere. Just removing it to clean up. Can be added correctly later if it is needed.