### PR TITLE
Add Dict module to the testing CI

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,16 @@ cargo clippy --workspace --tests -- --deny warnings
 
 Execute `cargo fmt --all` to fix the formatting.
 
+## Generating Docs
+
+If you make changes to [Roc's Standard Library](https://www.roc-lang.org/builtins/Str), you can add comments to the code following [the CommonMark Spec](https://spec.commonmark.org/current/) to further explain your intentions. You can view these changes locally with:
+
+```sh
+cargo run docs crates/compiler/builtins/roc
+```
+
+This command will generate the documentation in the [`generated-docs`](generated-docs) directory.
+
 ## Contribution Tips
 
 - If you've never made a pull request on github before, [this](https://www.freecodecamp.org/news/how-to-make-your-first-pull-request-on-github-3/) will be a good place to start.

--- a/crates/compiler/builtins/roc/Dict.roc
+++ b/crates/compiler/builtins/roc/Dict.roc
@@ -128,6 +128,16 @@ remove = \@Dict list, key ->
             |> @Dict
 
 ## Insert or remove a value in a Dict based on its presence
+##
+##     alterValue : [Present Bool, Missing] -> [Present Bool, Missing]
+##     alterValue = \possibleValue ->
+##         when possibleValue is
+##             Missing -> Present Bool.false
+##             Present value -> if value then Missing else Present Bool.true
+##
+##     expect Dict.update Dict.empty "a" alterValue == Dict.single "a" Bool.false
+##     expect Dict.update (Dict.single "a" Bool.false) "a" alterValue == Dict.single "a" Bool.true
+##     expect Dict.update (Dict.single "a" Bool.true) "a" alterValue == Dict.empty
 update : Dict k v, k, ([Present v, Missing] -> [Present v, Missing]) -> Dict k v | k has Eq
 update = \dict, key, alter ->
     possibleValue =
@@ -144,8 +154,7 @@ alterValue : [Present Bool, Missing] -> [Present Bool, Missing]
 alterValue = \possibleValue ->
     when possibleValue is
         Missing -> Present Bool.false
-        Present value if Bool.not value -> Present Bool.true
-        Present _ -> Missing
+        Present value -> if value then Missing else Present Bool.true
 
 expect update empty "a" alterValue == single "a" Bool.false
 expect update (single "a" Bool.false) "a" alterValue == single "a" Bool.true

--- a/mlc_config.json
+++ b/mlc_config.json
@@ -1,6 +1,9 @@
 {
     "ignorePatterns": [
         {
+            "pattern": "generated-docs"
+        },
+        {
             "pattern": "http://127.0.0.1"
         },
         {


### PR DESCRIPTION
This MR adds a command for testing the Dict module in the CI. I also added an example of how to use `Dict.update` with instructions on how to add and view said comments.