### PR TITLE
Add capacity growth to RocStr

### DIFF
--- a/crates/compiler/builtins/bitcode/src/list.zig
+++ b/crates/compiler/builtins/bitcode/src/list.zig
@@ -125,53 +125,6 @@ pub const RocList = extern struct {
         return new_list;
     }
 
-    // We follow roughly the [fbvector](https://github.com/facebook/folly/blob/main/folly/docs/FBVector.md) when it comes to growing a RocList.
-    // Here is [their growth strategy](https://github.com/facebook/folly/blob/3e0525988fd444201b19b76b390a5927c15cb697/folly/FBVector.h#L1128) for push_back:
-    //
-    // (1) initial size
-    //     Instead of growing to size 1 from empty, fbvector allocates at least
-    //     64 bytes. You may still use reserve to reserve a lesser amount of
-    //     memory.
-    // (2) 1.5x
-    //     For medium-sized vectors, the growth strategy is 1.5x. See the docs
-    //     for details.
-    //     This does not apply to very small or very large fbvectors. This is a
-    //     heuristic.
-    //
-    // In our case, we exposed allocate and reallocate, which will use a smart growth stategy.
-    // We also expose allocateExact and reallocateExact for case where a specific number of elements is requested.
-
-    // calculateCapacity should only be called in cases the list will be growing.
-    // requested_length should always be greater than old_capacity.
-    inline fn calculateCapacity(
-        old_capacity: usize,
-        requested_length: usize,
-        element_width: usize,
-    ) usize {
-        // TODO: there are two adjustments that would likely lead to better results for Roc.
-        // 1. Deal with the fact we allocate an extra u64 for refcount.
-        //    This may lead to allocating page size + 8 bytes.
-        //    That could mean allocating an entire page for 8 bytes of data which isn't great.
-        // 2. Deal with the fact that we can request more than 1 element at a time.
-        //    fbvector assumes just appending 1 element at a time when using this algorithm.
-        //    As such, they will generally grow in a way that should better match certain memory multiple.
-        //    This is also the normal case for roc, but we could also grow by a much larger amount.
-        //    We may want to round to multiples of 2 or something similar.
-        var new_capacity: usize = 0;
-        if (element_width == 0) {
-            return requested_length;
-        } else if (old_capacity == 0) {
-            new_capacity = 64 / element_width;
-        } else if (old_capacity < 4096 / element_width) {
-            new_capacity = old_capacity * 2;
-        } else if (old_capacity > 4096 * 32 / element_width) {
-            new_capacity = old_capacity * 2;
-        } else {
-            new_capacity = (old_capacity * 3 + 1) / 2;
-        }
-        return @maximum(new_capacity, requested_length);
-    }
-
     pub fn allocate(
         alignment: u32,
         length: usize,
@@ -181,29 +134,12 @@ pub const RocList = extern struct {
             return empty();
         }
 
-        const capacity = calculateCapacity(0, length, element_width);
+        const capacity = utils.calculateCapacity(0, length, element_width);
         const data_bytes = capacity * element_width;
         return RocList{
             .bytes = utils.allocateWithRefcount(data_bytes, alignment),
             .length = length,
             .capacity = capacity,
-        };
-    }
-
-    pub fn allocateExact(
-        alignment: u32,
-        length: usize,
-        element_width: usize,
-    ) RocList {
-        if (length == 0) {
-            return empty();
-        }
-
-        const data_bytes = length * element_width;
-        return RocList{
-            .bytes = utils.allocateWithRefcount(data_bytes, alignment),
-            .length = length,
-            .capacity = length,
         };
     }
 
@@ -218,37 +154,14 @@ pub const RocList = extern struct {
                 if (self.capacity >= new_length) {
                     return RocList{ .bytes = self.bytes, .length = new_length, .capacity = self.capacity };
                 } else {
-                    const new_capacity = calculateCapacity(self.capacity, new_length, element_width);
+                    const new_capacity = utils.calculateCapacity(self.capacity, new_length, element_width);
                     const new_source = utils.unsafeReallocate(source_ptr, alignment, self.len(), new_capacity, element_width);
                     return RocList{ .bytes = new_source, .length = new_length, .capacity = new_capacity };
                 }
             }
-            // TODO: Investigate the performance of this.
-            // Maybe we should just always reallocate to the new_length instead of expanding capacity?
-            const new_capacity = if (self.capacity >= new_length) self.capacity else calculateCapacity(self.capacity, new_length, element_width);
-            return self.reallocateFresh(alignment, new_length, new_capacity, element_width);
+            return self.reallocateFresh(alignment, new_length, element_width);
         }
         return RocList.allocate(alignment, new_length, element_width);
-    }
-
-    pub fn reallocateExact(
-        self: RocList,
-        alignment: u32,
-        new_length: usize,
-        element_width: usize,
-    ) RocList {
-        if (self.bytes) |source_ptr| {
-            if (self.isUnique()) {
-                if (self.capacity >= new_length) {
-                    return RocList{ .bytes = self.bytes, .length = new_length, .capacity = self.capacity };
-                } else {
-                    const new_source = utils.unsafeReallocate(source_ptr, alignment, self.len(), new_length, element_width);
-                    return RocList{ .bytes = new_source, .length = new_length, .capacity = new_length };
-                }
-            }
-            return self.reallocateFresh(alignment, new_length, new_length, element_width);
-        }
-        return RocList.allocateExact(alignment, new_length, element_width);
     }
 
     /// reallocate by explicitly making a new allocation and copying elements over
@@ -256,28 +169,20 @@ pub const RocList = extern struct {
         self: RocList,
         alignment: u32,
         new_length: usize,
-        new_capacity: usize,
         element_width: usize,
     ) RocList {
         const old_length = self.length;
         const delta_length = new_length - old_length;
 
-        const data_bytes = new_capacity * element_width;
-        const first_slot = utils.allocateWithRefcount(data_bytes, alignment);
+        const result = RocList.allocate(alignment, new_length, element_width);
 
         // transfer the memory
         if (self.bytes) |source_ptr| {
-            const dest_ptr = first_slot;
+            const dest_ptr = result.bytes orelse unreachable;
 
             @memcpy(dest_ptr, source_ptr, old_length * element_width);
             @memset(dest_ptr + old_length * element_width, 0, delta_length * element_width);
         }
-
-        const result = RocList{
-            .bytes = first_slot,
-            .length = new_length,
-            .capacity = new_capacity,
-        };
 
         utils.decref(self.bytes, old_length * element_width, alignment);
 
@@ -503,7 +408,7 @@ pub fn listWithCapacity(
     alignment: u32,
     element_width: usize,
 ) callconv(.C) RocList {
-    var output = RocList.allocateExact(alignment, capacity, element_width);
+    var output = RocList.allocate(alignment, capacity, element_width);
     output.length = 0;
     return output;
 }

--- a/crates/compiler/builtins/bitcode/src/str.zig
+++ b/crates/compiler/builtins/bitcode/src/str.zig
@@ -157,27 +157,27 @@ pub const RocStr = extern struct {
         const element_width = 1;
         const old_capacity = self.getCapacity();
 
+        if (self.isSmallStr() or !self.isUnique()) {
+            return self.reallocateFresh(new_length);
+        }
+
         if (self.str_bytes) |source_ptr| {
-            const unique = self.isUnique();
-            if (unique and old_capacity > new_length) {
+            if (old_capacity > new_length) {
                 var output = self;
                 output.setLen(new_length);
                 return output;
             }
-            if (unique and !self.isSmallStr()) {
-                const new_capacity = utils.calculateCapacity(old_capacity, new_length, element_width);
-                const new_source = utils.unsafeReallocate(
-                    source_ptr,
-                    RocStr.alignment,
-                    old_capacity,
-                    new_capacity,
-                    element_width,
-                );
+            const new_capacity = utils.calculateCapacity(old_capacity, new_length, element_width);
+            const new_source = utils.unsafeReallocate(
+                source_ptr,
+                RocStr.alignment,
+                old_capacity,
+                new_capacity,
+                element_width,
+            );
 
-                return RocStr{ .str_bytes = new_source, .str_len = new_length, .str_capacity = new_capacity };
-            }
+            return RocStr{ .str_bytes = new_source, .str_len = new_length, .str_capacity = new_capacity };
         }
-
         return self.reallocateFresh(new_length);
     }
 

--- a/crates/compiler/builtins/bitcode/src/utils.zig
+++ b/crates/compiler/builtins/bitcode/src/utils.zig
@@ -213,6 +213,53 @@ inline fn decref_ptr_to_refcount(
     }
 }
 
+// We follow roughly the [fbvector](https://github.com/facebook/folly/blob/main/folly/docs/FBVector.md) when it comes to growing a RocList.
+// Here is [their growth strategy](https://github.com/facebook/folly/blob/3e0525988fd444201b19b76b390a5927c15cb697/folly/FBVector.h#L1128) for push_back:
+//
+// (1) initial size
+//     Instead of growing to size 1 from empty, fbvector allocates at least
+//     64 bytes. You may still use reserve to reserve a lesser amount of
+//     memory.
+// (2) 1.5x
+//     For medium-sized vectors, the growth strategy is 1.5x. See the docs
+//     for details.
+//     This does not apply to very small or very large fbvectors. This is a
+//     heuristic.
+//
+// In our case, we exposed allocate and reallocate, which will use a smart growth stategy.
+// We also expose allocateExact and reallocateExact for case where a specific number of elements is requested.
+
+// calculateCapacity should only be called in cases the list will be growing.
+// requested_length should always be greater than old_capacity.
+pub inline fn calculateCapacity(
+    old_capacity: usize,
+    requested_length: usize,
+    element_width: usize,
+) usize {
+    // TODO: there are two adjustments that would likely lead to better results for Roc.
+    // 1. Deal with the fact we allocate an extra u64 for refcount.
+    //    This may lead to allocating page size + 8 bytes.
+    //    That could mean allocating an entire page for 8 bytes of data which isn't great.
+    // 2. Deal with the fact that we can request more than 1 element at a time.
+    //    fbvector assumes just appending 1 element at a time when using this algorithm.
+    //    As such, they will generally grow in a way that should better match certain memory multiple.
+    //    This is also the normal case for roc, but we could also grow by a much larger amount.
+    //    We may want to round to multiples of 2 or something similar.
+    var new_capacity: usize = 0;
+    if (element_width == 0) {
+        return requested_length;
+    } else if (old_capacity == 0) {
+        new_capacity = 64 / element_width;
+    } else if (old_capacity < 4096 / element_width) {
+        new_capacity = old_capacity * 2;
+    } else if (old_capacity > 4096 * 32 / element_width) {
+        new_capacity = old_capacity * 2;
+    } else {
+        new_capacity = (old_capacity * 3 + 1) / 2;
+    }
+    return @maximum(new_capacity, requested_length);
+}
+
 pub fn allocateWithRefcountC(
     data_bytes: usize,
     element_alignment: u32,

--- a/crates/compiler/builtins/roc/Str.roc
+++ b/crates/compiler/builtins/roc/Str.roc
@@ -299,7 +299,7 @@ replaceEach = \haystack, needle, flower ->
         Ok { before, after } ->
             # We found at least one needle, so start the buffer off with
             # `before` followed by the first replacement flower.
-            Str.reserve "" (Str.countUtf8Bytes haystack)
+            Str.withCapacity (Str.countUtf8Bytes haystack)
             |> Str.concat before
             |> Str.concat flower
             |> replaceEachHelp after needle flower
@@ -504,7 +504,7 @@ walkUtf8WithIndexHelp = \string, state, step, index, length ->
     else
         state
 
-## Make sure at least some number of bytes fit in this string without reallocating
+## Enlarge the Str for at least capacity additional bytes
 reserve : Str, Nat -> Str
 
 ## is UB when the scalar is invalid

--- a/crates/compiler/test_gen/src/gen_str.rs
+++ b/crates/compiler/test_gen/src/gen_str.rs
@@ -1876,9 +1876,9 @@ fn llvm_wasm_str_layout() {
                 |> Str.reserve 42
             "#
         ),
-        [0, 5, 42],
+        [0, 5, 1],
         [u32; 3],
-        |[_ptr, len, cap]: [u32; 3]| [0, len, cap]
+        |[_ptr, len, cap]: [u32; 3]| [0, len, if cap >= 42 { 1 } else { 0 }]
     )
 }
 

--- a/crates/roc_std/tests/test_roc_std.rs
+++ b/crates/roc_std/tests/test_roc_std.rs
@@ -126,7 +126,7 @@ mod test_roc_std {
 
         roc_str.reserve(42);
 
-        assert_eq!(roc_str.capacity(), 42);
+        assert_gte!(roc_str.capacity(), 42);
     }
 
     #[test]
@@ -135,7 +135,7 @@ mod test_roc_std {
 
         roc_str.reserve(5000);
 
-        assert_eq!(roc_str.capacity(), 5000);
+        assert_gte!(roc_str.capacity(), 5000);
     }
 
     #[test]


### PR DESCRIPTION
Also, cleans up the alloc and realloc api for both list and str.
Updates Str.reserve to match List.reserve.