### PR TITLE
www: fix REPL link

### DIFF
--- a/www/public/index.html
+++ b/www/public/index.html
@@ -179,7 +179,7 @@
   results. It remembers recent expressions entered in the current session (if you press the up arrow),
   but it can't yet execute effects, and any named variables you define currently exist only for the
   next expression it evaluates; they don't yet persist for the remainder of the session. You can try
-  out the REPL in a browser at <a href="roc-lang.org/repl">roc-lang.org/repl</a> - it uses a
+  out the REPL in a browser at <a href="https://roc-lang.org/repl">roc-lang.org/repl</a> - it uses a
   WebAssembly build of Roc's compiler, and compiles the code you write to WebAssembly on the fly,
   which it then executes in the browser to display the answer.</p>
 


### PR DESCRIPTION
The link to the web REPL results in a 404 because the `href` isn't specific enough and the browser interprets it as a relative URL.
