### PR TITLE
Replace panic! with internal-error! in ast crate

### DIFF
--- a/crates/ast/src/canonicalization/canonicalize.rs
+++ b/crates/ast/src/canonicalization/canonicalize.rs
@@ -1,4 +1,5 @@
 use roc_collections::all::MutMap;
+use roc_error_macros::internal_error;
 use roc_problem::can::Problem;
 use roc_region::all::{Loc, Region};
 use roc_types::subs::Variable;
@@ -188,7 +189,7 @@ fn canonicalize_field<'a>(
         }
 
         Malformed(_string) => {
-            panic!("TODO canonicalize malformed record field");
+            internal_error!("TODO canonicalize malformed record field");
         }
     }
 }

--- a/crates/ast/src/canonicalization/canonicalize.rs
+++ b/crates/ast/src/canonicalization/canonicalize.rs
@@ -1,5 +1,4 @@
 use roc_collections::all::MutMap;
-use roc_error_macros::internal_error;
 use roc_problem::can::Problem;
 use roc_region::all::{Loc, Region};
 use roc_types::subs::Variable;
@@ -189,7 +188,7 @@ fn canonicalize_field<'a>(
         }
 
         Malformed(_string) => {
-            internal_error!("todo! canonicalize malformed record field");
+            todo!("canonicalize malformed record field");
         }
     }
 }

--- a/crates/ast/src/canonicalization/canonicalize.rs
+++ b/crates/ast/src/canonicalization/canonicalize.rs
@@ -189,7 +189,7 @@ fn canonicalize_field<'a>(
         }
 
         Malformed(_string) => {
-            internal_error!("TODO canonicalize malformed record field");
+            internal_error!("todo! canonicalize malformed record field");
         }
     }
 }

--- a/crates/ast/src/constrain.rs
+++ b/crates/ast/src/constrain.rs
@@ -1931,6 +1931,7 @@ pub mod test_constrain {
     use bumpalo::Bump;
     use roc_can::expected::Expected;
     use roc_collections::all::MutMap;
+    use roc_error_macros::internal_error;
     use roc_module::{
         ident::Lowercase,
         symbol::{IdentIds, Interns, ModuleIds, Symbol},
@@ -2064,7 +2065,7 @@ pub mod test_constrain {
 
                 assert_eq!(actual_str, expected_str);
             }
-            Err(e) => panic!("syntax error {:?}", e),
+            Err(e) => internal_error!("syntax error {:?}", e),
         }
     }
 

--- a/crates/ast/src/lang/core/def/def.rs
+++ b/crates/ast/src/lang/core/def/def.rs
@@ -536,7 +536,7 @@ fn canonicalize_pending_def<'a>(
                             // remove its generated name from the closure map.
                             let references =
                                 env.closures.remove(&closure_symbol).unwrap_or_else(|| {
-                            panic!( r"Tried to remove symbol {:?} from procedures, but it was not found: {:?}", closure_symbol, env.closures)
+                            internal_error!( r"Tried to remove symbol {:?} from procedures, but it was not found: {:?}", closure_symbol, env.closures)
                             });
 
                             // TODO should we re-insert this function into env.closures?
@@ -574,7 +574,7 @@ fn canonicalize_pending_def<'a>(
                                     ..
                                 } => {
                                     if arguments.len() != type_arguments.len() {
-                                        panic!("argument number mismatch");
+                                        internal_error!("argument number mismatch");
                                     }
 
                                     let it: Vec<_> = closure_args
@@ -705,7 +705,7 @@ fn canonicalize_pending_def<'a>(
                     // remove its generated name from the closure map.
                     let references =
                         env.closures.remove(&closure_symbol).unwrap_or_else(|| {
-                            panic!( r"Tried to remove symbol {:?} from procedures, but it was not found: {:?}", closure_symbol, env.closures)
+                            internal_error!( r"Tried to remove symbol {:?} from procedures, but it was not found: {:?}", closure_symbol, env.closures)
                         });
 
                     // TODO should we re-insert this function into env.closures?
@@ -1238,7 +1238,7 @@ pub fn sort_can_defs(
                     // )));
                     //
                     // declarations.push(Declaration::InvalidCycle(symbols_in_cycle, regions));
-                    panic!("Invalid Cycle");
+                    internal_error!("Invalid Cycle");
                 } else {
                     // slightly inefficient, because we know this becomes exactly one DeclareRec already
                     groups.push(cycle);

--- a/crates/ast/src/lang/core/def/def.rs
+++ b/crates/ast/src/lang/core/def/def.rs
@@ -13,7 +13,7 @@
 // use crate::pattern::{bindings_from_patterns, canonicalize_pattern, Pattern};
 // use crate::procedure::References;
 use roc_collections::all::{default_hasher, ImMap, MutMap, MutSet, SendMap};
-use roc_error_macros::{internal_error, todo_abilities};
+use roc_error_macros::{internal_error, todo_abilities, user_error};
 use roc_module::ident::Lowercase;
 use roc_module::symbol::Symbol;
 use roc_parse::ast::{self, CommentOrNewline, Defs, TypeDef, TypeHeader, ValueDef as AstValueDef};
@@ -574,7 +574,7 @@ fn canonicalize_pending_def<'a>(
                                     ..
                                 } => {
                                     if arguments.len() != type_arguments.len() {
-                                        internal_error!("argument number mismatch");
+                                        user_error!("argument number mismatch");
                                     }
 
                                     let it: Vec<_> = closure_args

--- a/crates/ast/src/lang/core/expr/expr_to_expr2.rs
+++ b/crates/ast/src/lang/core/expr/expr_to_expr2.rs
@@ -5,6 +5,7 @@ use roc_can::num::{
 };
 use roc_can::operator::desugar_expr;
 use roc_collections::all::MutSet;
+use roc_error_macros::internal_error;
 use roc_module::symbol::Symbol;
 use roc_parse::{ast::Expr, pattern::PatternType};
 use roc_problem::can::{Problem, RuntimeError};
@@ -667,31 +668,31 @@ pub fn expr_to_expr2<'a>(
         // Below this point, we shouln't see any of these nodes anymore because
         // operator desugaring should have removed them!
         bad_expr @ ParensAround(_) => {
-            panic!(
+            internal_error!(
                 "A ParensAround did not get removed during operator desugaring somehow: {:#?}",
                 bad_expr
             );
         }
         bad_expr @ SpaceBefore(_, _) => {
-            panic!(
+            internal_error!(
                 "A SpaceBefore did not get removed during operator desugaring somehow: {:#?}",
                 bad_expr
             );
         }
         bad_expr @ SpaceAfter(_, _) => {
-            panic!(
+            internal_error!(
                 "A SpaceAfter did not get removed during operator desugaring somehow: {:#?}",
                 bad_expr
             );
         }
         bad_expr @ BinOps { .. } => {
-            panic!(
+            internal_error!(
                 "A binary operator chain did not get desugared somehow: {:#?}",
                 bad_expr
             );
         }
         bad_expr @ UnaryOp(_, _) => {
-            panic!(
+            internal_error!(
                 "A unary operator did not get desugared somehow: {:#?}",
                 bad_expr
             );

--- a/crates/ast/src/module.rs
+++ b/crates/ast/src/module.rs
@@ -1,5 +1,5 @@
 use bumpalo::Bump;
-use roc_error_macros::internal_error;
+use roc_error_macros::{internal_error, user_error};
 use roc_load::{ExecutionMode, LoadConfig, LoadedModule, Threading};
 use roc_target::TargetInfo;
 use std::path::Path;
@@ -21,7 +21,7 @@ pub fn load_module(src_file: &Path, threading: Threading) -> LoadedModule {
     match loaded {
         Ok(x) => x,
         Err(roc_load::LoadingProblem::FormattedReport(report)) => {
-            internal_error!(
+            user_error!(
                 "Failed to load module from src_file: {:?}. Report: {}",
                 src_file,
                 report

--- a/crates/ast/src/module.rs
+++ b/crates/ast/src/module.rs
@@ -1,4 +1,5 @@
 use bumpalo::Bump;
+use roc_error_macros::internal_error;
 use roc_load::{ExecutionMode, LoadConfig, LoadedModule, Threading};
 use roc_target::TargetInfo;
 use std::path::Path;
@@ -20,14 +21,16 @@ pub fn load_module(src_file: &Path, threading: Threading) -> LoadedModule {
     match loaded {
         Ok(x) => x,
         Err(roc_load::LoadingProblem::FormattedReport(report)) => {
-            panic!(
+            internal_error!(
                 "Failed to load module from src_file: {:?}. Report: {}",
-                src_file, report
+                src_file,
+                report
             );
         }
-        Err(e) => panic!(
+        Err(e) => internal_error!(
             "Failed to load module from src_file {:?}: {:?}",
-            src_file, e
+            src_file,
+            e
         ),
     }
 }

--- a/crates/ast/src/solve_type.rs
+++ b/crates/ast/src/solve_type.rs
@@ -113,15 +113,15 @@ impl Pools {
     }
 
     pub fn get_mut(&mut self, rank: Rank) -> &mut Vec<Variable> {
-        self.0
-            .get_mut(rank.into_usize())
-            .unwrap_or_else(|| panic!("Compiler bug: could not find pool at rank {}", rank))
+        self.0.get_mut(rank.into_usize()).unwrap_or_else(|| {
+            internal_error!("Compiler bug: could not find pool at rank {}", rank)
+        })
     }
 
     pub fn get(&self, rank: Rank) -> &Vec<Variable> {
-        self.0
-            .get(rank.into_usize())
-            .unwrap_or_else(|| panic!("Compiler bug: could not find pool at rank {}", rank))
+        self.0.get(rank.into_usize()).unwrap_or_else(|| {
+            internal_error!("Compiler bug: could not find pool at rank {}", rank)
+        })
     }
 
     pub fn iter(&self) -> std::slice::Iter<'_, Vec<Variable>> {
@@ -131,7 +131,7 @@ impl Pools {
     pub fn split_last(&self) -> (&Vec<Variable>, &[Vec<Variable>]) {
         self.0
             .split_last()
-            .unwrap_or_else(|| panic!("Attempted to split_last() on non-empty Pools"))
+            .unwrap_or_else(|| internal_error!("Attempted to split_last() on non-empty Pools"))
     }
 
     pub fn extend_to(&mut self, n: usize) {

--- a/crates/ast/src/solve_type.rs
+++ b/crates/ast/src/solve_type.rs
@@ -120,7 +120,7 @@ impl Pools {
 
     pub fn get(&self, rank: Rank) -> &Vec<Variable> {
         self.0.get(rank.into_usize()).unwrap_or_else(|| {
-            internal_error!("Compiler bug: could not find pool at rank {}", rank)
+            internal_error!("could not find pool at rank {}", rank)
         })
     }
 

--- a/crates/ast/src/solve_type.rs
+++ b/crates/ast/src/solve_type.rs
@@ -113,9 +113,9 @@ impl Pools {
     }
 
     pub fn get_mut(&mut self, rank: Rank) -> &mut Vec<Variable> {
-        self.0.get_mut(rank.into_usize()).unwrap_or_else(|| {
-            internal_error!("Compiler bug: could not find pool at rank {}", rank)
-        })
+        self.0
+            .get_mut(rank.into_usize())
+            .unwrap_or_else(|| internal_error!("could not find pool at rank {}", rank))
     }
 
     pub fn get(&self, rank: Rank) -> &Vec<Variable> {


### PR DESCRIPTION
Hi,

I replaced `panic!` with `internal_error!`.
I started with only `panic!` and only inside the `ast` crate to keep this PR small.
Related to https://github.com/roc-lang/roc/issues/2046