### PR TITLE
Fix prefetch links in the Standard Library page

### DIFF
--- a/crates/docs/src/lib.rs
+++ b/crates/docs/src/lib.rs
@@ -134,10 +134,8 @@ pub fn generate_docs_html(filenames: Vec<PathBuf>) {
 }
 
 fn sidebar_link_url(module: &ModuleDocumentation) -> String {
-    let mut href_buf = base_url();
-    href_buf.push_str(module.name.as_str());
-
-    href_buf
+    let url = format!("{baseUrl}{moduleName}/", baseUrl = base_url(), moduleName = module.name.as_str());
+    url
 }
 
 // converts plain-text code to highlighted html

--- a/crates/docs/src/lib.rs
+++ b/crates/docs/src/lib.rs
@@ -134,7 +134,7 @@ pub fn generate_docs_html(filenames: Vec<PathBuf>) {
 }
 
 fn sidebar_link_url(module: &ModuleDocumentation) -> String {
-    let url = format!("{baseUrl}{moduleName}/", baseUrl = base_url(), moduleName = module.name.as_str());
+    let url = format!("{}{}/", base_url(), module.name.as_str());
     url
 }
 


### PR DESCRIPTION
# Before with failing links

<img width="1904" alt="Screen Shot 2022-10-11 at 7 47 50 AM" src="https://user-images.githubusercontent.com/1977082/195084282-7cb6301f-0c65-41be-b8ef-6a3d30316a5a.png">

# After

<img width="1904" alt="Screen Shot 2022-10-11 at 7 48 32 AM" src="https://user-images.githubusercontent.com/1977082/195084357-28858b47-66b8-43f2-b5a9-490bd35cbc64.png">
