### PR TITLE
Serialize the abilities store and solved implementations for builtins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4028,6 +4028,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "roc_serialize"
+version = "0.0.1"
+dependencies = [
+ "roc_collections",
+]
+
+[[package]]
 name = "roc_solve"
 version = "0.0.1"
 dependencies = [
@@ -4117,6 +4124,7 @@ dependencies = [
  "roc_error_macros",
  "roc_module",
  "roc_region",
+ "roc_serialize",
  "static_assertions",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3380,6 +3380,7 @@ dependencies = [
  "roc_parse",
  "roc_problem",
  "roc_region",
+ "roc_serialize",
  "roc_types",
  "static_assertions",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ members = [
     "crates/compiler/test_gen",
     "crates/compiler/roc_target",
     "crates/compiler/debug_flags",
+    "crates/compiler/serialize",
     "crates/vendor/inkwell",
     "crates/vendor/pathfinding",
     "crates/vendor/pretty",

--- a/crates/compiler/can/Cargo.toml
+++ b/crates/compiler/can/Cargo.toml
@@ -14,6 +14,7 @@ roc_module = { path = "../module" }
 roc_parse = { path = "../parse" }
 roc_problem = { path = "../problem" }
 roc_types = { path = "../types" }
+roc_serialize = { path = "../serialize" }
 bumpalo = { version = "3.11.0", features = ["collections"] }
 static_assertions = "1.1.0"
 bitvec = "1"

--- a/crates/compiler/can/src/abilities.rs
+++ b/crates/compiler/can/src/abilities.rs
@@ -9,6 +9,14 @@ use roc_types::{
     types::{MemberImpl, Type},
 };
 
+/// During type solving and monomorphization, a module must know how its imported ability
+/// implementations are resolved - are they derived, or have a concrete implementation?
+///
+/// Unfortunately we cannot keep this information opaque, as it's important for properly
+/// restoring specialization lambda sets. As such, we need to export implementation information,
+/// which is the job of this structure.
+pub type ResolvedImplementations = VecMap<ImplKey, ResolvedImpl>;
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MemberVariables {
     pub able_vars: Vec<Variable>,
@@ -475,10 +483,13 @@ impl IAbilitiesStore<Resolved> {
         serialize::serialize(self, writer)
     }
 
-    pub fn deserialize(bytes: &[u8]) -> Self {
+    pub fn deserialize(bytes: &[u8]) -> (Self, usize) {
         serialize::deserialize(bytes)
     }
 }
+
+pub use serialize::deserialize_solved_implementations;
+pub use serialize::serialize_solved_implementations;
 
 impl IAbilitiesStore<Pending> {
     pub fn import_implementation(&mut self, impl_key: ImplKey, resolved_impl: &ResolvedImpl) {
@@ -682,7 +693,7 @@ mod serialize {
 
     use super::{
         AbilitiesStore, AbilityMemberData, ImplKey, MemberSpecializationInfo, Resolved,
-        ResolvedMemberType, SpecializationId,
+        ResolvedImpl, ResolvedImplementations, ResolvedMemberType, SpecializationId,
     };
 
     use std::io::{self, Write};
@@ -760,7 +771,7 @@ mod serialize {
         Ok(written)
     }
 
-    pub(super) fn deserialize(bytes: &[u8]) -> AbilitiesStore {
+    pub(super) fn deserialize(bytes: &[u8]) -> (AbilitiesStore, usize) {
         let mut offset = 0;
 
         let header_slice = &bytes[..std::mem::size_of::<Header>()];
@@ -786,17 +797,18 @@ mod serialize {
             offset,
         );
 
-        let _ = offset;
-
-        AbilitiesStore {
-            members_of_ability,
-            specialization_to_root,
-            ability_members,
-            declared_implementations,
-            specializations,
-            next_specialization_id: (header.next_specialization_id as u32).try_into().unwrap(),
-            resolved_specializations,
-        }
+        (
+            AbilitiesStore {
+                members_of_ability,
+                specialization_to_root,
+                ability_members,
+                declared_implementations,
+                specializations,
+                next_specialization_id: (header.next_specialization_id as u32).try_into().unwrap(),
+                resolved_specializations,
+            },
+            offset,
+        )
     }
 
     fn serialize_members_of_ability(
@@ -1113,6 +1125,127 @@ mod serialize {
             offset,
         )
     }
+
+    #[derive(Copy, Clone)]
+    #[repr(C)]
+    enum SerResolvedImpl {
+        Impl(SerMemberSpecInfo),
+        Derived,
+        Error,
+    }
+    impl SerResolvedImpl {
+        fn num_regions(&self) -> usize {
+            match self {
+                SerResolvedImpl::Impl(spec) => spec.1.len(),
+                SerResolvedImpl::Derived => 0,
+                SerResolvedImpl::Error => 0,
+            }
+        }
+    }
+
+    pub fn serialize_solved_implementations(
+        solved_impls: &ResolvedImplementations,
+        writer: &mut impl std::io::Write,
+    ) -> std::io::Result<usize> {
+        let len = solved_impls.len() as u64;
+
+        let written = bytes::serialize_slice(&[len], writer, 0)?;
+
+        bytes::serialize_vec_map(
+            solved_impls,
+            |keys, writer, written| {
+                bytes::serialize_slice(
+                    &keys.iter().map(SerImplKey::from).collect::<Vec<_>>(),
+                    writer,
+                    written,
+                )
+            },
+            |resolved_impls, writer, written| {
+                let mut spec_lambda_sets_regions: Vec<u8> = Vec::new();
+                let mut spec_lambda_sets_vars: Vec<Variable> = Vec::new();
+                let mut ser_resolved_impls: Vec<SerResolvedImpl> = Vec::new();
+
+                for resolved_impl in resolved_impls {
+                    let ser_resolved_impl = match resolved_impl {
+                        ResolvedImpl::Impl(MemberSpecializationInfo {
+                            _phase: _,
+                            symbol,
+                            specialization_lambda_sets,
+                        }) => {
+                            let regions = SubsSlice::extend_new(
+                                &mut spec_lambda_sets_regions,
+                                specialization_lambda_sets.keys().copied(),
+                            );
+                            let vars = SubsSlice::extend_new(
+                                &mut spec_lambda_sets_vars,
+                                specialization_lambda_sets.values().copied(),
+                            );
+                            SerResolvedImpl::Impl(SerMemberSpecInfo(*symbol, regions, vars))
+                        }
+                        ResolvedImpl::Derived => SerResolvedImpl::Derived,
+                        ResolvedImpl::Error => SerResolvedImpl::Error,
+                    };
+
+                    ser_resolved_impls.push(ser_resolved_impl);
+                }
+
+                let written = bytes::serialize_slice(&ser_resolved_impls, writer, written)?;
+                let written = bytes::serialize_slice(&spec_lambda_sets_regions, writer, written)?;
+                let written = bytes::serialize_slice(&spec_lambda_sets_vars, writer, written)?;
+
+                Ok(written)
+            },
+            writer,
+            written,
+        )
+    }
+
+    pub fn deserialize_solved_implementations(bytes: &[u8]) -> (ResolvedImplementations, usize) {
+        let (len_slice, offset) = bytes::deserialize_slice::<u64>(bytes, 1, 0);
+        let length = len_slice[0];
+
+        bytes::deserialize_vec_map(
+            bytes,
+            |bytes, length, offset| {
+                let (slice, offset) = bytes::deserialize_slice::<SerImplKey>(bytes, length, offset);
+                (slice.iter().map(ImplKey::from).collect(), offset)
+            },
+            |bytes, length, offset| {
+                let (serialized_slices, offset) =
+                    bytes::deserialize_slice::<SerResolvedImpl>(bytes, length, offset);
+
+                let total_num_regions = serialized_slices.iter().map(|s| s.num_regions()).sum();
+
+                let (regions_slice, offset) =
+                    bytes::deserialize_slice::<u8>(bytes, total_num_regions, offset);
+
+                let (vars_slice, offset) =
+                    { bytes::deserialize_slice::<Variable>(bytes, total_num_regions, offset) };
+
+                let mut all_resolved: Vec<ResolvedImpl> = Vec::with_capacity(length);
+                for ser_resolved in serialized_slices {
+                    let resolved = match ser_resolved {
+                        SerResolvedImpl::Impl(SerMemberSpecInfo(symbol, regions, vars)) => {
+                            let regions = regions_slice[regions.indices()].to_vec();
+                            let lset_vars = vars_slice[vars.indices()].to_vec();
+                            let spec_info = MemberSpecializationInfo::new(*symbol, unsafe {
+                                VecMap::zip(regions, lset_vars)
+                            });
+                            ResolvedImpl::Impl(spec_info)
+                        }
+                        SerResolvedImpl::Derived => ResolvedImpl::Derived,
+                        SerResolvedImpl::Error => ResolvedImpl::Error,
+                    };
+
+                    all_resolved.push(resolved);
+                }
+
+                (all_resolved, offset)
+            },
+            length as _,
+            offset,
+        )
+    }
 }
 
 #[cfg(test)]
@@ -1231,7 +1364,9 @@ mod test {
             resolved_specializations,
         } = store;
 
-        let de_store = AbilitiesStore::deserialize(&bytes);
+        let (de_store, offset) = AbilitiesStore::deserialize(&bytes);
+
+        assert_eq!(bytes.len(), offset);
 
         assert_eq!(members_of_ability, de_store.members_of_ability);
         assert_eq!(specialization_to_root, de_store.specialization_to_root);

--- a/crates/compiler/collections/src/vec_map.rs
+++ b/crates/compiler/collections/src/vec_map.rs
@@ -25,6 +25,14 @@ impl<K, V> VecMap<K, V> {
 
         (k, v)
     }
+
+    pub fn unzip(self) -> (Vec<K>, Vec<V>) {
+        (self.keys, self.values)
+    }
+
+    pub fn unzip_slices(&self) -> (&[K], &[V]) {
+        (&self.keys, &self.values)
+    }
 }
 
 impl<K: PartialEq, V> VecMap<K, V> {
@@ -112,14 +120,6 @@ impl<K: PartialEq, V> VecMap<K, V> {
     pub fn truncate(&mut self, len: usize) {
         self.keys.truncate(len);
         self.values.truncate(len);
-    }
-
-    pub fn unzip(self) -> (Vec<K>, Vec<V>) {
-        (self.keys, self.values)
-    }
-
-    pub fn unzip_slices(&self) -> (&[K], &[V]) {
-        (&self.keys, &self.values)
     }
 
     /// # Safety

--- a/crates/compiler/collections/src/vec_map.rs
+++ b/crates/compiler/collections/src/vec_map.rs
@@ -250,6 +250,31 @@ where
     }
 }
 
+impl<K, V> PartialEq for VecMap<K, V>
+where
+    K: PartialEq,
+    V: PartialEq,
+{
+    fn eq(&self, other: &Self) -> bool {
+        if self.len() != other.len() {
+            return false;
+        }
+
+        for (k, v) in self.iter() {
+            match other.get(k) {
+                Some(v1) => {
+                    if v != v1 {
+                        return false;
+                    }
+                }
+                None => return false,
+            }
+        }
+
+        true
+    }
+}
+
 #[cfg(test)]
 mod test_drain_filter {
     use crate::VecMap;

--- a/crates/compiler/collections/src/vec_set.rs
+++ b/crates/compiler/collections/src/vec_set.rs
@@ -1,4 +1,4 @@
-use std::iter::FromIterator;
+use std::{borrow::Borrow, iter::FromIterator};
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct VecSet<T> {
@@ -129,5 +129,19 @@ impl<T> IntoIterator for VecSet<T> {
 
     fn into_iter(self) -> Self::IntoIter {
         self.elements.into_iter()
+    }
+}
+
+impl<T> Borrow<[T]> for VecSet<T> {
+    fn borrow(&self) -> &[T] {
+        &self.elements
+    }
+}
+
+impl<T> From<Vec<T>> for VecSet<T> {
+    fn from(elements: Vec<T>) -> Self {
+        // Not totally safe, but good enough for our purposes - also, duplicates in the VecSet are
+        // fine, just inefficient.
+        Self { elements }
     }
 }

--- a/crates/compiler/load/Cargo.toml
+++ b/crates/compiler/load/Cargo.toml
@@ -20,6 +20,7 @@ roc_builtins = { path = "../builtins" }
 roc_module = { path = "../module" }
 roc_reporting = { path = "../../reporting" }
 roc_target = { path = "../roc_target" }
+roc_can = { path = "../can" }
 bumpalo = { version = "3.11.0", features = ["collections"] }
 
 [target.'cfg(not(windows))'.build-dependencies]

--- a/crates/compiler/load/build.rs
+++ b/crates/compiler/load/build.rs
@@ -11,6 +11,7 @@ const SKIP_SUBS_CACHE: bool = {
     }
 };
 
+// IFTTT: crates/compiler/load/src/lib.rs
 const MODULES: &[(ModuleId, &str)] = &[
     (ModuleId::BOOL, "Bool.roc"),
     (ModuleId::RESULT, "Result.roc"),

--- a/crates/compiler/load/build.rs
+++ b/crates/compiler/load/build.rs
@@ -46,26 +46,27 @@ fn write_subs_for_module(module_id: ModuleId, filename: &str) {
 
     #[cfg(not(windows))]
     if SKIP_SUBS_CACHE {
-        write_subs_for_module_dummy(&output_path)
+        write_types_for_module_dummy(&output_path)
     } else {
-        write_subs_for_module_real(module_id, filename, &output_path)
+        write_types_for_module_real(module_id, filename, &output_path)
     }
 
     #[cfg(windows)]
     {
         let _ = SKIP_SUBS_CACHE;
         let _ = module_id;
-        write_subs_for_module_dummy(&output_path)
+        write_types_for_module_dummy(&output_path)
     }
 }
 
-fn write_subs_for_module_dummy(output_path: &Path) {
+fn write_types_for_module_dummy(output_path: &Path) {
     // write out a dummy file
     std::fs::write(output_path, &[]).unwrap();
 }
 
 #[cfg(not(windows))]
-fn write_subs_for_module_real(module_id: ModuleId, filename: &str, output_path: &Path) {
+fn write_types_for_module_real(module_id: ModuleId, filename: &str, output_path: &Path) {
+    use roc_can::module::TypeState;
     use roc_load_internal::file::{LoadingProblem, Threading};
 
     let arena = Bump::new();
@@ -94,9 +95,19 @@ fn write_subs_for_module_real(module_id: ModuleId, filename: &str, output_path: 
         }
     };
 
-    let subs = module.solved.inner();
+    let subs = module.solved.into_inner();
     let exposed_vars_by_symbol: Vec<_> = module.exposed_to_host.into_iter().collect();
+    let abilities = module.abilities_store;
+    let solved_implementations = module.resolved_implementations;
 
     let mut file = std::fs::File::create(&output_path).unwrap();
-    subs.serialize(&exposed_vars_by_symbol, &mut file).unwrap();
+
+    let type_state = TypeState {
+        subs,
+        exposed_vars_by_symbol,
+        abilities,
+        solved_implementations,
+    };
+
+    type_state.serialize(&mut file).unwrap();
 }

--- a/crates/compiler/load/src/lib.rs
+++ b/crates/compiler/load/src/lib.rs
@@ -156,14 +156,18 @@ pub fn load_and_typecheck_str<'a>(
     }
 }
 
+// IFTTT: crates/compiler/load/build.rs
 const BOOL: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/Bool.dat")) as &[_];
 const RESULT: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/Result.dat")) as &[_];
+const NUM: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/Num.dat")) as &[_];
 const LIST: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/List.dat")) as &[_];
 const STR: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/Str.dat")) as &[_];
 const DICT: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/Dict.dat")) as &[_];
 const SET: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/Set.dat")) as &[_];
 const BOX: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/Box.dat")) as &[_];
-const NUM: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/Num.dat")) as &[_];
+const ENCODE: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/Encode.dat")) as &[_];
+const DECODE: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/Decode.dat")) as &[_];
+const HASH: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/Hash.dat")) as &[_];
 
 fn deserialize_help(bytes: &[u8]) -> TypeState {
     let (state, _offset) = TypeState::deserialize(bytes);
@@ -188,6 +192,11 @@ fn read_cached_types() -> MutMap<ModuleId, TypeState> {
 
         output.insert(ModuleId::SET, deserialize_help(SET));
         output.insert(ModuleId::BOX, deserialize_help(BOX));
+
+        output.insert(ModuleId::ENCODE, deserialize_help(ENCODE));
+        output.insert(ModuleId::DECODE, deserialize_help(DECODE));
+
+        output.insert(ModuleId::HASH, deserialize_help(HASH));
     }
 
     output

--- a/crates/compiler/load/src/lib.rs
+++ b/crates/compiler/load/src/lib.rs
@@ -1,10 +1,9 @@
 use bumpalo::Bump;
-use roc_can::module::ExposedByModule;
+use roc_can::module::{ExposedByModule, TypeState};
 use roc_collections::all::MutMap;
-use roc_module::symbol::{ModuleId, Symbol};
+use roc_module::symbol::ModuleId;
 use roc_reporting::report::RenderTarget;
 use roc_target::TargetInfo;
-use roc_types::subs::{Subs, Variable};
 use std::path::PathBuf;
 
 const SKIP_SUBS_CACHE: bool = {
@@ -27,9 +26,9 @@ fn load<'a>(
     exposed_types: ExposedByModule,
     load_config: LoadConfig,
 ) -> Result<LoadResult<'a>, LoadingProblem<'a>> {
-    let cached_subs = read_cached_subs();
+    let cached_types = read_cached_types();
 
-    roc_load_internal::file::load(arena, load_start, exposed_types, cached_subs, load_config)
+    roc_load_internal::file::load(arena, load_start, exposed_types, cached_types, load_config)
 }
 
 /// Load using only a single thread; used when compiling to webassembly
@@ -41,7 +40,7 @@ pub fn load_single_threaded<'a>(
     render: RenderTarget,
     exec_mode: ExecutionMode,
 ) -> Result<LoadResult<'a>, LoadingProblem<'a>> {
-    let cached_subs = read_cached_subs();
+    let cached_subs = read_cached_types();
 
     roc_load_internal::file::load_single_threaded(
         arena,
@@ -166,13 +165,14 @@ const SET: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/Set.dat")) as &[_];
 const BOX: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/Box.dat")) as &[_];
 const NUM: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/Num.dat")) as &[_];
 
-fn deserialize_help(bytes: &[u8]) -> (Subs, Vec<(Symbol, Variable)>) {
-    let (subs, slice) = Subs::deserialize(bytes);
+fn deserialize_help(bytes: &[u8]) -> TypeState {
+    let (state, _offset) = TypeState::deserialize(bytes);
+    debug_assert_eq!(bytes.len(), _offset);
 
-    (subs, slice.to_vec())
+    state
 }
 
-fn read_cached_subs() -> MutMap<ModuleId, (Subs, Vec<(Symbol, Variable)>)> {
+fn read_cached_types() -> MutMap<ModuleId, TypeState> {
     let mut output = MutMap::default();
 
     // Wasm seems to re-order definitions between build time and runtime, but only in release mode.

--- a/crates/compiler/load_internal/src/lib.rs
+++ b/crates/compiler/load_internal/src/lib.rs
@@ -1,9 +1,26 @@
 #![warn(clippy::dbg_macro)]
 // See github.com/roc-lang/roc/issues/800 for discussion of the large_enum_variant check.
 #![allow(clippy::large_enum_variant)]
+
+use roc_module::symbol::ModuleId;
 pub mod docs;
 pub mod file;
 mod work;
 
 #[cfg(target_family = "wasm")]
 mod wasm_instant;
+
+pub const BUILTIN_MODULES: &[(ModuleId, &str)] = &[
+    (ModuleId::BOOL, "Bool"),
+    (ModuleId::RESULT, "Result"),
+    (ModuleId::NUM, "Num"),
+    (ModuleId::LIST, "List"),
+    (ModuleId::STR, "Str"),
+    (ModuleId::DICT, "Dict"),
+    (ModuleId::SET, "Set"),
+    (ModuleId::BOX, "Box"),
+    (ModuleId::ENCODE, "Encode"),
+    (ModuleId::DECODE, "Decode"),
+    (ModuleId::HASH, "Hash"),
+    (ModuleId::JSON, "Json"),
+];

--- a/crates/compiler/serialize/Cargo.toml
+++ b/crates/compiler/serialize/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "roc_serialize"
+version = "0.0.1"
+authors = ["The Roc Contributors"]
+license = "UPL-1.0"
+edition = "2021"
+
+[dependencies]
+roc_collections = { path = "../collections" }

--- a/crates/compiler/serialize/src/bytes.rs
+++ b/crates/compiler/serialize/src/bytes.rs
@@ -1,0 +1,283 @@
+use std::{
+    borrow::Borrow,
+    io::{self, Write},
+};
+
+use roc_collections::MutMap;
+
+pub fn serialize_slice<T: Copy>(
+    slice: &[T],
+    writer: &mut impl Write,
+    written: usize,
+) -> io::Result<usize> {
+    let alignment = std::mem::align_of::<T>();
+    let padding_bytes = round_to_multiple_of(written, alignment) - written;
+
+    for _ in 0..padding_bytes {
+        writer.write_all(&[0])?;
+    }
+
+    let bytes_slice = unsafe { slice_as_bytes(slice) };
+    writer.write_all(bytes_slice)?;
+
+    Ok(written + padding_bytes + bytes_slice.len())
+}
+
+pub fn deserialize_slice<T: Copy>(bytes: &[u8], length: usize, mut offset: usize) -> (&[T], usize) {
+    let alignment = std::mem::align_of::<T>();
+    let size = std::mem::size_of::<T>();
+
+    offset = round_to_multiple_of(offset, alignment);
+
+    let byte_length = length * size;
+    let byte_slice = &bytes[offset..][..byte_length];
+
+    let slice = unsafe { std::slice::from_raw_parts(byte_slice.as_ptr() as *const T, length) };
+
+    (slice, offset + byte_length)
+}
+
+pub fn deserialize_vec<T: Clone + Copy>(
+    bytes: &[u8],
+    length: usize,
+    offset: usize,
+) -> (Vec<T>, usize) {
+    let (slice, offset) = deserialize_slice(bytes, length, offset);
+    (slice.to_vec(), offset)
+}
+
+#[derive(Copy, Clone)]
+struct VecSlice<T> {
+    pub start: u32,
+    pub length: u16,
+    _marker: std::marker::PhantomData<T>,
+}
+
+impl<T> VecSlice<T> {
+    const fn len(&self) -> usize {
+        self.length as usize
+    }
+
+    fn indices(&self) -> std::ops::Range<usize> {
+        self.start as usize..(self.start as usize + self.length as usize)
+    }
+
+    fn extend_new(vec: &mut Vec<T>, it: impl IntoIterator<Item = T>) -> Self {
+        let start = vec.len();
+
+        vec.extend(it);
+
+        let end = vec.len();
+
+        Self {
+            start: start as u32,
+            length: (end - start) as u16,
+            _marker: Default::default(),
+        }
+    }
+}
+
+pub fn serialize_slice_of_slices<'a, T, U>(
+    slice_of_slices: &[U],
+    writer: &mut impl Write,
+    written: usize,
+) -> io::Result<usize>
+where
+    T: 'a + Copy,
+    U: 'a + Borrow<[T]> + Sized,
+{
+    let mut item_buf: Vec<T> = Vec::new();
+    let mut serialized_slices: Vec<VecSlice<T>> = Vec::new();
+
+    for slice in slice_of_slices {
+        let slice = VecSlice::extend_new(&mut item_buf, slice.borrow().iter().copied());
+        serialized_slices.push(slice);
+    }
+
+    let written = serialize_slice(&serialized_slices, writer, written)?;
+    serialize_slice(&item_buf, writer, written)
+}
+
+pub fn deserialize_slice_of_slices<T: Clone + Copy>(
+    bytes: &[u8],
+    length: usize,
+    offset: usize,
+) -> (Vec<Vec<T>>, usize) {
+    let (serialized_slices, offset) = deserialize_slice::<VecSlice<T>>(bytes, length, offset);
+
+    let (vars_slice, offset) = {
+        let total_items = serialized_slices.iter().map(|s| s.len()).sum();
+        deserialize_slice::<T>(bytes, total_items, offset)
+    };
+
+    let mut slice_of_slices = Vec::with_capacity(length);
+    for slice in serialized_slices {
+        let deserialized_slice = &vars_slice[slice.indices()];
+        slice_of_slices.push(deserialized_slice.to_vec())
+    }
+
+    (slice_of_slices, offset)
+}
+
+pub fn serialize_map<K: Clone, V: Clone, W: Write>(
+    map: &MutMap<K, V>,
+    ser_keys: fn(&[K], &mut W, usize) -> io::Result<usize>,
+    ser_values: fn(&[V], &mut W, usize) -> io::Result<usize>,
+    writer: &mut W,
+    written: usize,
+) -> io::Result<usize> {
+    let keys = map.keys().cloned().collect::<Vec<_>>();
+    let values = map.values().cloned().collect::<Vec<_>>();
+
+    let written = ser_keys(keys.as_slice(), writer, written)?;
+    let written = ser_values(values.as_slice(), writer, written)?;
+
+    Ok(written)
+}
+
+#[allow(clippy::type_complexity)]
+pub fn deserialize_map<K, V>(
+    bytes: &[u8],
+    deser_keys: fn(&[u8], usize, usize) -> (Vec<K>, usize),
+    deser_values: fn(&[u8], usize, usize) -> (Vec<V>, usize),
+    length: usize,
+    offset: usize,
+) -> (MutMap<K, V>, usize)
+where
+    K: Clone + std::hash::Hash + Eq,
+    V: Clone,
+{
+    let (keys, offset) = deser_keys(bytes, length, offset);
+    let (values, offset) = deser_values(bytes, length, offset);
+
+    (
+        MutMap::from_iter((keys.iter().cloned()).zip(values.iter().cloned())),
+        offset,
+    )
+}
+
+unsafe fn slice_as_bytes<T>(slice: &[T]) -> &[u8] {
+    let ptr = slice.as_ptr();
+    let byte_length = std::mem::size_of::<T>() * slice.len();
+
+    std::slice::from_raw_parts(ptr as *const u8, byte_length)
+}
+
+fn round_to_multiple_of(value: usize, base: usize) -> usize {
+    (value + (base - 1)) / base * base
+}
+
+#[cfg(test)]
+mod test {
+    use roc_collections::MutMap;
+
+    use super::{
+        deserialize_map, deserialize_slice, deserialize_slice_of_slices, deserialize_vec,
+        serialize_map, serialize_slice, serialize_slice_of_slices,
+    };
+
+    #[test]
+    fn serde_empty_slice() {
+        let mut buf = vec![];
+        serialize_slice(&[] as &[u8], &mut buf, 0).unwrap();
+        assert!(buf.is_empty());
+
+        let (out, size) = deserialize_slice::<u8>(&buf, 0, 0);
+        assert!(out.is_empty());
+        assert_eq!(size, 0);
+    }
+
+    #[test]
+    fn serde_slice() {
+        let input: &[u64] = &[15u64, 23, 37, 89];
+
+        let mut buf = vec![];
+        serialize_slice(input, &mut buf, 0).unwrap();
+        assert!(!buf.is_empty());
+
+        let (out, size) = deserialize_slice::<u64>(&buf, 4, 0);
+        assert_eq!(out, input);
+        assert_eq!(size, 4 * 8);
+    }
+
+    #[test]
+    fn serde_vec() {
+        let input: &[u64] = &[15u64, 23, 37, 89];
+
+        let mut buf = vec![];
+        serialize_slice(input, &mut buf, 0).unwrap();
+        assert!(!buf.is_empty());
+
+        let (out, size) = deserialize_vec::<u64>(&buf, 4, 0);
+        assert_eq!(out, input);
+        assert_eq!(size, buf.len());
+    }
+
+    #[test]
+    fn serde_empty_slice_of_slices() {
+        let input: &[&[u64]] = &[];
+
+        let mut buf = vec![];
+        serialize_slice_of_slices(input, &mut buf, 0).unwrap();
+        assert!(buf.is_empty());
+
+        let (out, size) = deserialize_slice_of_slices::<u64>(&buf, 0, 0);
+        assert!(out.is_empty());
+        assert_eq!(size, 0);
+    }
+
+    #[test]
+    fn serde_slice_of_slices() {
+        let input: &[&[u64]] = &[&[15, 23, 47], &[61, 72], &[85, 91]];
+
+        let mut buf = vec![];
+        serialize_slice_of_slices(input, &mut buf, 0).unwrap();
+        assert!(!buf.is_empty());
+
+        let (out, size) = deserialize_slice_of_slices::<u64>(&buf, 3, 0);
+        assert_eq!(out, input);
+        assert_eq!(size, buf.len());
+    }
+
+    #[test]
+    fn serde_empty_map() {
+        let input: MutMap<u64, u64> = Default::default();
+
+        let mut buf = vec![];
+        serialize_map(&input, serialize_slice, serialize_slice, &mut buf, 0).unwrap();
+        assert!(buf.is_empty());
+
+        let (out, size) = deserialize_map::<u64, u64>(&buf, deserialize_vec, deserialize_vec, 0, 0);
+        assert!(out.is_empty());
+        assert_eq!(size, 0);
+    }
+
+    #[test]
+    fn serde_map() {
+        let mut input: MutMap<u64, Vec<u64>> = Default::default();
+        input.insert(51, vec![15, 23, 37]);
+        input.insert(39, vec![17, 91, 43]);
+        input.insert(82, vec![90, 35, 76]);
+
+        let mut buf = vec![];
+        serialize_map(
+            &input,
+            serialize_slice,
+            serialize_slice_of_slices,
+            &mut buf,
+            0,
+        )
+        .unwrap();
+        assert!(!buf.is_empty());
+
+        let (out, size) = deserialize_map::<u64, Vec<u64>>(
+            &buf,
+            deserialize_vec,
+            deserialize_slice_of_slices,
+            3,
+            0,
+        );
+        assert_eq!(out, input);
+        assert_eq!(size, buf.len());
+    }
+}

--- a/crates/compiler/serialize/src/lib.rs
+++ b/crates/compiler/serialize/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod bytes;

--- a/crates/compiler/types/Cargo.toml
+++ b/crates/compiler/types/Cargo.toml
@@ -11,5 +11,6 @@ roc_region = { path = "../region" }
 roc_module = { path = "../module" }
 roc_error_macros = {path="../../error_macros"}
 roc_debug_flags = {path="../debug_flags"}
+roc_serialize = {path="../serialize"}
 bumpalo = { version = "3.11.0", features = ["collections"] }
 static_assertions = "1.1.0"

--- a/crates/compiler/types/src/subs.rs
+++ b/crates/compiler/types/src/subs.rs
@@ -211,6 +211,7 @@ impl Subs {
         (UlsOfVar(vec_map), offset)
     }
 
+    #[allow(clippy::type_complexity)]
     pub fn deserialize(bytes: &[u8]) -> ((Self, &[(Symbol, Variable)]), usize) {
         let mut offset = 0;
         let header_slice = &bytes[..std::mem::size_of::<SubsHeader>()];

--- a/crates/compiler/types/src/subs.rs
+++ b/crates/compiler/types/src/subs.rs
@@ -211,7 +211,7 @@ impl Subs {
         (UlsOfVar(vec_map), offset)
     }
 
-    pub fn deserialize(bytes: &[u8]) -> (Self, &[(Symbol, Variable)]) {
+    pub fn deserialize(bytes: &[u8]) -> ((Self, &[(Symbol, Variable)]), usize) {
         let mut offset = 0;
         let header_slice = &bytes[..std::mem::size_of::<SubsHeader>()];
         offset += header_slice.len();
@@ -235,24 +235,27 @@ impl Subs {
             bytes::deserialize_slice(bytes, header.unspecialized_lambda_sets as usize, offset);
         let (uls_of_var, offset) =
             Self::deserialize_uls_of_var(bytes, header.uls_of_var as usize, offset);
-        let (exposed_vars_by_symbol, _) =
+        let (exposed_vars_by_symbol, offset) =
             bytes::deserialize_slice(bytes, header.exposed_vars_by_symbol as usize, offset);
 
         (
-            Self {
-                utable,
-                variables: variables.to_vec(),
-                tag_names: tag_names.to_vec(),
-                closure_names: closure_names.to_vec(),
-                field_names,
-                record_fields: record_fields.to_vec(),
-                variable_slices: variable_slices.to_vec(),
-                unspecialized_lambda_sets: unspecialized_lambda_sets.to_vec(),
-                tag_name_cache: Default::default(),
-                problems: Default::default(),
-                uls_of_var,
-            },
-            exposed_vars_by_symbol,
+            (
+                Self {
+                    utable,
+                    variables: variables.to_vec(),
+                    tag_names: tag_names.to_vec(),
+                    closure_names: closure_names.to_vec(),
+                    field_names,
+                    record_fields: record_fields.to_vec(),
+                    variable_slices: variable_slices.to_vec(),
+                    unspecialized_lambda_sets: unspecialized_lambda_sets.to_vec(),
+                    tag_name_cache: Default::default(),
+                    problems: Default::default(),
+                    uls_of_var,
+                },
+                exposed_vars_by_symbol,
+            ),
+            offset,
         )
     }
 

--- a/crates/compiler/types/src/unification_table.rs
+++ b/crates/compiler/types/src/unification_table.rs
@@ -1,6 +1,7 @@
 use std::hint::unreachable_unchecked;
 
 use crate::subs::{Content, Descriptor, Mark, OptVariable, Rank, Variable, VariableSubsSlice};
+use roc_serialize::bytes;
 
 #[derive(Clone, Default)]
 pub struct UnificationTable {
@@ -376,9 +377,7 @@ impl UnificationTable {
         writer: &mut impl std::io::Write,
         mut written: usize,
     ) -> std::io::Result<usize> {
-        use crate::subs::Subs;
-
-        written = Subs::serialize_slice(&self.contents, writer, written)?;
+        written = bytes::serialize_slice(&self.contents, writer, written)?;
 
         let mut ranks = Vec::new();
         let mut marks = Vec::new();
@@ -406,22 +405,20 @@ impl UnificationTable {
             }
         }
 
-        written = Subs::serialize_slice(&ranks, writer, written)?;
-        written = Subs::serialize_slice(&marks, writer, written)?;
-        written = Subs::serialize_slice(&copies, writer, written)?;
-        written = Subs::serialize_slice(&redirects, writer, written)?;
+        written = bytes::serialize_slice(&ranks, writer, written)?;
+        written = bytes::serialize_slice(&marks, writer, written)?;
+        written = bytes::serialize_slice(&copies, writer, written)?;
+        written = bytes::serialize_slice(&redirects, writer, written)?;
 
         Ok(written)
     }
 
     pub(crate) fn deserialize(bytes: &[u8], length: usize, offset: usize) -> (Self, usize) {
-        use crate::subs::Subs;
-
-        let (contents, offset) = Subs::deserialize_slice::<Content>(bytes, length, offset);
-        let (ranks, offset) = Subs::deserialize_slice::<Rank>(bytes, length, offset);
-        let (marks, offset) = Subs::deserialize_slice::<Mark>(bytes, length, offset);
-        let (copies, offset) = Subs::deserialize_slice::<OptVariable>(bytes, length, offset);
-        let (redirects, offset) = Subs::deserialize_slice::<OptVariable>(bytes, length, offset);
+        let (contents, offset) = bytes::deserialize_slice::<Content>(bytes, length, offset);
+        let (ranks, offset) = bytes::deserialize_slice::<Rank>(bytes, length, offset);
+        let (marks, offset) = bytes::deserialize_slice::<Mark>(bytes, length, offset);
+        let (copies, offset) = bytes::deserialize_slice::<OptVariable>(bytes, length, offset);
+        let (redirects, offset) = bytes::deserialize_slice::<OptVariable>(bytes, length, offset);
 
         let mut metadata = Vec::with_capacity(ranks.len());
 


### PR DESCRIPTION
Currently, we only cache the `Subs` of builtin modules during the solve phase. But the type information for a solved module consists of more than Subs; it also includes the abilities store for the module, which is the cornerstone of how abilities work. This patch adds a custom serialization of the abilities store to a byte scheme so that we can cache and resolve modules that expose abilities or ability implementations as well. Caching for `Encode`, `Decode`, and `Hash` is turned on as a result.

@folkertdev and I talked about the approach here briefly. Initially we thought about bringing in serde, but after looking at that for a short while, I realized that's not the way to go, because serde is very viral and will require a bunch of base crates in the compiler to depend on it. The flat encoding scheme used here is better suited for `Subs` than the abilities store, but eventually we will move the store to a SoA model where this serialization scheme will be better. In the meantime, I will maintain this.