### PR TITLE
Make sure self-recursive checks only happen after typechecking

### DIFF
--- a/crates/compiler/can/src/module.rs
+++ b/crates/compiler/can/src/module.rs
@@ -422,7 +422,7 @@ pub fn canonicalize_module_defs<'a>(
     };
 
     let (mut declarations, mut output) =
-        crate::def::sort_can_defs_new(&mut env, &mut scope, var_store, defs, new_output);
+        crate::def::sort_can_defs_new(&mut scope, var_store, defs, new_output);
 
     debug_assert!(
         output.pending_derives.is_empty(),

--- a/crates/compiler/can/tests/test_can.rs
+++ b/crates/compiler/can/tests/test_can.rs
@@ -918,37 +918,6 @@ mod test_can {
     }
 
     #[test]
-    fn invalid_self_recursion() {
-        let src = indoc!(
-            r#"
-                x = x
-
-                x
-            "#
-        );
-
-        let home = test_home();
-        let arena = Bump::new();
-        let CanExprOut {
-            loc_expr,
-            problems,
-            interns,
-            ..
-        } = can_expr_with(&arena, home, src);
-
-        let is_circular_def = matches!(loc_expr.value, RuntimeError(RuntimeError::CircularDef(_)));
-
-        let problem = Problem::RuntimeError(RuntimeError::CircularDef(vec![CycleEntry {
-            symbol: interns.symbol(home, "x".into()),
-            symbol_region: Region::new(Position::new(0), Position::new(1)),
-            expr_region: Region::new(Position::new(4), Position::new(5)),
-        }]));
-
-        assert_eq!(is_circular_def, true);
-        assert_eq!(problems, vec![problem]);
-    }
-
-    #[test]
     fn invalid_mutual_recursion() {
         let src = indoc!(
             r#"

--- a/crates/compiler/solve/tests/solve_expr.rs
+++ b/crates/compiler/solve/tests/solve_expr.rs
@@ -8009,4 +8009,39 @@ mod solve_expr {
             print_only_under_alias: true
         );
     }
+
+    #[test]
+    fn self_recursive_function_not_syntactically_a_function() {
+        infer_eq_without_problem(
+            indoc!(
+                r#"
+                app "test" provides [fx] to "./platform"
+
+                after : ({} -> a), ({} -> b) -> ({} -> b)
+
+                fx = after (\{} -> {}) \{} -> if Bool.true then fx {} else {}
+                "#
+            ),
+            "{} -> {}",
+        );
+    }
+
+    #[test]
+    fn self_recursive_function_not_syntactically_a_function_nested() {
+        infer_eq_without_problem(
+            indoc!(
+                r#"
+                app "test" provides [main] to "./platform"
+
+                main =
+                    after : ({} -> a), ({} -> b) -> ({} -> b)
+
+                    fx = after (\{} -> {}) \{} -> if Bool.true then fx {} else {}
+
+                    fx
+                "#
+            ),
+            "{} -> {}",
+        );
+    }
 }

--- a/crates/reporting/src/error/canonicalize.rs
+++ b/crates/reporting/src/error/canonicalize.rs
@@ -2035,11 +2035,7 @@ pub fn to_circular_def_doc<'b>(
                     alloc.reflow(" is defined directly in terms of itself:"),
                 ]),
                 alloc.region(lines.convert_region(Region::span_across(symbol_region, expr_region))),
-                alloc.concat([
-                    alloc.reflow("Since Roc evaluates values strict, running this program would create an infinite number of "),
-                    alloc.symbol_unqualified(*symbol),
-                    alloc.reflow(" values!"),
-                ]),
+                alloc.reflow("Roc evaluates values strictly, so running this program would enter an infinite loop!"),
                 alloc.hint("").append(alloc.concat([
                     alloc.reflow("Did you mean to define "),alloc.symbol_unqualified(*symbol),alloc.reflow(" as a function?"),
                 ])),

--- a/crates/reporting/tests/test_reporting.rs
+++ b/crates/reporting/tests/test_reporting.rs
@@ -10773,7 +10773,7 @@ All branches in an `if` must have the same type!
             app "test" imports [] provides [main] to "./platform"
 
             main =
-                if Bool.true then \{} -> {} else main
+                if Bool.true then {} else main
             "#
         ),
     @r###"
@@ -10782,7 +10782,7 @@ All branches in an `if` must have the same type!
     `main` is defined directly in terms of itself:
 
     3│>  main =
-    4│>      if Bool.true then \{} -> {} else main
+    4│>      if Bool.true then {} else main
 
     Since Roc evaluates values strict, running this program would create
     an infinite number of `main` values!

--- a/crates/reporting/tests/test_reporting.rs
+++ b/crates/reporting/tests/test_reporting.rs
@@ -2166,8 +2166,8 @@ mod test_reporting {
     4│      f = f
             ^^^^^
 
-    Since Roc evaluates values strict, running this program would create
-    an infinite number of `f` values!
+    Roc evaluates values strictly, so running this program would enter an
+    infinite loop!
 
     Hint: Did you mean to define `f` as a function?
     "###
@@ -10784,8 +10784,8 @@ All branches in an `if` must have the same type!
     3│>  main =
     4│>      if Bool.true then {} else main
 
-    Since Roc evaluates values strict, running this program would create
-    an infinite number of `main` values!
+    Roc evaluates values strictly, so running this program would enter an
+    infinite loop!
 
     Hint: Did you mean to define `main` as a function?
     "###


### PR DESCRIPTION
Programs like

```
after : ({} -> a), ({} -> b) -> ({} -> b)

fx = after (\{} -> {}) \{} -> if Bool.true then fx {} else {}
```

are legal because they always decay to functions, even if they may not
look like functions syntactically. Rather than using a syntactic check
to check for illegally-recursive functions, we should only perform such
checks after we know the types of values.

Closes #4291
