### PR TITLE
add os version macos nightly

### DIFF
--- a/.github/workflows/nightly_macos_apple_silicon.yml
+++ b/.github/workflows/nightly_macos_apple_silicon.yml
@@ -29,7 +29,7 @@ jobs:
         env:
             DATE: ${{ env.DATE }}
             SHA: ${{ env.SHA }}
-        run: echo "RELEASE_TAR_FILENAME=roc_nightly-macos_apple_silicon-$DATE-$SHA.tar.gz" >> $GITHUB_ENV  
+        run: echo "RELEASE_TAR_FILENAME=roc_nightly-macos_12_apple_silicon-$DATE-$SHA.tar.gz" >> $GITHUB_ENV  
 
       - name: write version to file
         run: ./ci/write_version.sh


### PR DESCRIPTION
I added the version to the filename for macos x86_64 so I think it's good to add it to the apple silicon release as well for consistency and clarity.