### PR TITLE
refine relocation location

### DIFF
--- a/crates/compiler/build/src/link.rs
+++ b/crates/compiler/build/src/link.rs
@@ -201,7 +201,7 @@ pub fn build_zig_host_native(
     if let Some(shared_lib_path) = shared_lib_path {
         command.args(&[
             "build-exe",
-            "-fPIE",
+            // "-fPIE", PIE seems to fail on windows
             shared_lib_path.to_str().unwrap(),
             &bitcode::get_builtins_windows_obj_path(),
         ]);

--- a/crates/compiler/build/src/link.rs
+++ b/crates/compiler/build/src/link.rs
@@ -203,7 +203,7 @@ pub fn build_zig_host_native(
             "build-exe",
             "-fPIE",
             shared_lib_path.to_str().unwrap(),
-            &bitcode::get_builtins_host_obj_path(),
+            &bitcode::get_builtins_windows_obj_path(),
         ]);
     } else {
         command.args(&["build-obj", "-fPIC"]);
@@ -221,6 +221,7 @@ pub fn build_zig_host_native(
         // include libc
         "--library",
         "c",
+        "-dynamic",
         // cross-compile?
         "-target",
         target,

--- a/crates/linker/src/pe.rs
+++ b/crates/linker/src/pe.rs
@@ -1164,8 +1164,6 @@ fn write_image_base_relocation(
     // extra space that we'll use for the new relocations
     let shift_amount = relocations.len() * ENTRY_WIDTH;
 
-    crate::dbg_hex!(new_block_va, relocations);
-
     if block_has_relocation {
         // now, starting from the back, shift sections that need to be shifted and add the
         // new relocations to the right block
@@ -1231,8 +1229,6 @@ fn write_image_base_relocation(
         // sort by VA. Upper 4 bits store the relocation type
         entries.sort_unstable_by_key(|x| x & 0b0000_1111_1111_1111);
 
-        crate::dbg_hex!((next_block_start as usize + size_of_block) - reloc_section_start);
-
         size_of_block
     }
 }
@@ -1253,11 +1249,6 @@ fn relocate_dummy_dll_entries(executable: &mut [u8], md: &PeMetadata) {
     let relocations: Vec<_> = (0..md.dynamic_relocations.name_by_virtual_address.len())
         .map(|i| (thunks_offset_in_block as usize + 2 * i) as u16)
         .collect();
-
-    crate::dbg_hex!(
-        thunks_relocation_block_va,
-        md.rdata_virtual_address - md.image_base as u32,
-    );
 
     let added_reloc_bytes = write_image_base_relocation(
         executable,

--- a/crates/linker/src/pe.rs
+++ b/crates/linker/src/pe.rs
@@ -1292,17 +1292,17 @@ fn relocate_dummy_dll_entries(executable: &mut [u8], md: &PeMetadata) {
         "new .reloc section is too big, and runs into the next section!",
     );
 
-    //    // in the data directories, update the length of the base relocations
-    //    let dir = load_struct_inplace_mut::<pe::ImageDataDirectory>(
-    //        executable,
-    //        md.dynamic_relocations.data_directories_offset_in_file as usize
-    //            + object::pe::IMAGE_DIRECTORY_ENTRY_BASERELOC
-    //                * std::mem::size_of::<pe::ImageDataDirectory>(),
-    //    );
-    //
-    //    let old_dir_size = dir.size.get(LE);
-    //    debug_assert_eq!(old_section_size, old_dir_size);
-    //    dir.size.set(LE, new_virtual_size);
+    // in the data directories, update the length of the base relocations
+    let dir = load_struct_inplace_mut::<pe::ImageDataDirectory>(
+        executable,
+        md.dynamic_relocations.data_directories_offset_in_file as usize
+            + object::pe::IMAGE_DIRECTORY_ENTRY_BASERELOC
+                * std::mem::size_of::<pe::ImageDataDirectory>(),
+    );
+
+    let old_dir_size = dir.size.get(LE);
+    debug_assert_eq!(old_section_size, old_dir_size);
+    dir.size.set(LE, new_virtual_size);
 }
 
 #[cfg(test)]

--- a/crates/linker/src/pe.rs
+++ b/crates/linker/src/pe.rs
@@ -1292,17 +1292,17 @@ fn relocate_dummy_dll_entries(executable: &mut [u8], md: &PeMetadata) {
         "new .reloc section is too big, and runs into the next section!",
     );
 
-    // in the data directories, update the length of the base relocations
-    let dir = load_struct_inplace_mut::<pe::ImageDataDirectory>(
-        executable,
-        md.dynamic_relocations.data_directories_offset_in_file as usize
-            + object::pe::IMAGE_DIRECTORY_ENTRY_BASERELOC
-                * std::mem::size_of::<pe::ImageDataDirectory>(),
-    );
-
-    let old_dir_size = dir.size.get(LE);
-    debug_assert_eq!(old_section_size, old_dir_size);
-    dir.size.set(LE, new_virtual_size);
+    //    // in the data directories, update the length of the base relocations
+    //    let dir = load_struct_inplace_mut::<pe::ImageDataDirectory>(
+    //        executable,
+    //        md.dynamic_relocations.data_directories_offset_in_file as usize
+    //            + object::pe::IMAGE_DIRECTORY_ENTRY_BASERELOC
+    //                * std::mem::size_of::<pe::ImageDataDirectory>(),
+    //    );
+    //
+    //    let old_dir_size = dir.size.get(LE);
+    //    debug_assert_eq!(old_section_size, old_dir_size);
+    //    dir.size.set(LE, new_virtual_size);
 }
 
 #[cfg(test)]


### PR DESCRIPTION
math was incorrect if the `.rdata` section was bigger than 4k, and the `.dll` data is not in the first 4k page. 