### PR TITLE
Auto-derive ability implementations for opaques in canonicalization

### DIFF
--- a/crates/compiler/builtins/roc/Decode.roc
+++ b/crates/compiler/builtins/roc/Decode.roc
@@ -99,4 +99,4 @@ fromBytes = \bytes, fmt ->
                 Err (Leftover rest)
 
 mapResult : DecodeResult a, (a -> b) -> DecodeResult b
-mapResult = \{result, rest}, mapper -> {result: Result.map result mapper, rest}
+mapResult = \{ result, rest }, mapper -> { result: Result.map result mapper, rest }

--- a/crates/compiler/builtins/roc/Decode.roc
+++ b/crates/compiler/builtins/roc/Decode.roc
@@ -27,6 +27,7 @@ interface Decode
         decodeWith,
         fromBytesPartial,
         fromBytes,
+        mapResult,
     ]
     imports [
         List,
@@ -96,3 +97,6 @@ fromBytes = \bytes, fmt ->
                     Err TooShort -> Err TooShort
             else
                 Err (Leftover rest)
+
+mapResult : DecodeResult a, (a -> b) -> DecodeResult b
+mapResult = \{result, rest}, mapper -> {result: Result.map result mapper, rest}

--- a/crates/compiler/builtins/roc/Dict.roc
+++ b/crates/compiler/builtins/roc/Dict.roc
@@ -74,9 +74,7 @@ interface Dict
 ## When comparing two dictionaries for equality, they are `==` only if their both their contents and their
 ## orderings match. This preserves the property that if `dict1 == dict2`, you should be able to rely on
 ## `fn dict1 == fn dict2` also being `Bool.true`, even if `fn` relies on the dictionary's ordering.
-Dict k v := List [Pair k v] has [Eq { isEq: dictEq }]
-
-dictEq = \@Dict l1, @Dict l2 -> l1 == l2
+Dict k v := List [Pair k v] has [Eq]
 
 ## An empty dictionary.
 empty : Dict k v

--- a/crates/compiler/builtins/roc/Set.roc
+++ b/crates/compiler/builtins/roc/Set.roc
@@ -16,9 +16,7 @@ interface Set
     ]
     imports [List, Bool.{ Bool, Eq }, Dict.{ Dict }, Num.{ Nat }]
 
-Set k := Dict.Dict k {} has [Eq { isEq: setEq }]
-
-setEq = \@Set d1, @Set d2 -> d1 == d2
+Set k := Dict.Dict k {} has [Eq]
 
 fromDict : Dict k {} -> Set k
 fromDict = \dict -> @Set dict

--- a/crates/compiler/can/src/abilities.rs
+++ b/crates/compiler/can/src/abilities.rs
@@ -127,7 +127,6 @@ pub struct ImplKey {
 #[derive(Clone, Debug)]
 pub enum ResolvedImpl {
     Impl(MemberSpecializationInfo<Resolved>),
-    Derived,
     Error,
 }
 
@@ -452,7 +451,7 @@ impl IAbilitiesStore<Resolved> {
 
                     Ok(())
                 }
-                MemberImpl::Derived | MemberImpl::Error => Err(MarkError::ImplIsNotCustom),
+                MemberImpl::Error => Err(MarkError::ImplIsNotCustom),
             },
             None => Err(MarkError::NoDeclaredImpl),
         }
@@ -498,7 +497,6 @@ impl IAbilitiesStore<Pending> {
                 self.import_specialization(specialization);
                 MemberImpl::Impl(specialization.symbol)
             }
-            ResolvedImpl::Derived => MemberImpl::Derived,
             ResolvedImpl::Error => MemberImpl::Error,
         };
 
@@ -957,14 +955,12 @@ mod serialize {
     #[repr(C)]
     enum SerMemberImpl {
         Impl(Symbol),
-        Derived,
         Error,
     }
     impl From<&MemberImpl> for SerMemberImpl {
         fn from(k: &MemberImpl) -> Self {
             match k {
                 MemberImpl::Impl(s) => Self::Impl(*s),
-                MemberImpl::Derived => Self::Derived,
                 MemberImpl::Error => Self::Error,
             }
         }
@@ -973,7 +969,6 @@ mod serialize {
         fn from(k: &SerMemberImpl) -> Self {
             match k {
                 SerMemberImpl::Impl(s) => Self::Impl(*s),
-                SerMemberImpl::Derived => Self::Derived,
                 SerMemberImpl::Error => Self::Error,
             }
         }
@@ -1134,14 +1129,12 @@ mod serialize {
     #[repr(C)]
     enum SerResolvedImpl {
         Impl(SerMemberSpecInfo),
-        Derived,
         Error,
     }
     impl SerResolvedImpl {
         fn num_regions(&self) -> usize {
             match self {
                 SerResolvedImpl::Impl(spec) => spec.1.len(),
-                SerResolvedImpl::Derived => 0,
                 SerResolvedImpl::Error => 0,
             }
         }
@@ -1186,7 +1179,6 @@ mod serialize {
                             );
                             SerResolvedImpl::Impl(SerMemberSpecInfo(*symbol, regions, vars))
                         }
-                        ResolvedImpl::Derived => SerResolvedImpl::Derived,
                         ResolvedImpl::Error => SerResolvedImpl::Error,
                     };
 
@@ -1237,7 +1229,6 @@ mod serialize {
                             });
                             ResolvedImpl::Impl(spec_info)
                         }
-                        SerResolvedImpl::Derived => ResolvedImpl::Derived,
                         SerResolvedImpl::Error => ResolvedImpl::Error,
                     };
 
@@ -1310,7 +1301,7 @@ mod test {
 
             store.register_declared_implementations(
                 Symbol::ATTR_ATTR,
-                [(Symbol::ARG_5, MemberImpl::Derived)],
+                [(Symbol::ARG_5, MemberImpl::Error)],
             );
 
             store

--- a/crates/compiler/can/src/def.rs
+++ b/crates/compiler/can/src/def.rs
@@ -701,8 +701,8 @@ fn synthesize_derived_hash<'a>(
     // Hash.hash hasher payload
     let call_member = alloc_expr(ast::Expr::Apply(
         alloc_expr(ast::Expr::Var {
-            module_name: env.arena.alloc_str("Hash"),
-            ident: env.arena.alloc_str("hash"),
+            module_name: "Hash",
+            ident: "hash",
         }),
         &*env.arena.alloc([
             &*alloc_expr(ast::Expr::Var {
@@ -757,8 +757,8 @@ fn synthesize_derived_is_eq<'a>(
     // Bool.isEq payload1 payload2
     let call_member = alloc_expr(ast::Expr::Apply(
         alloc_expr(ast::Expr::Var {
-            module_name: env.arena.alloc_str("Bool"),
-            ident: env.arena.alloc_str("isEq"),
+            module_name: "Bool",
+            ident: "isEq",
         }),
         &*env.arena.alloc([
             &*alloc_expr(ast::Expr::Var {

--- a/crates/compiler/can/src/def.rs
+++ b/crates/compiler/can/src/def.rs
@@ -823,7 +823,7 @@ fn canonicalize_opaque<'a>(
                 let mut impls = Vec::with_capacity(num_members);
                 for &member in members.iter() {
                     let (derived_impl, impl_pat, impl_body) =
-                        derive::synthesize_member_impl(env, scope, name.value, name_str, member);
+                        derive::synthesize_member_impl(env, scope, name_str, member);
 
                     let derived_def = Loc::at(
                         derive::DERIVED_REGION,

--- a/crates/compiler/can/src/derive.rs
+++ b/crates/compiler/can/src/derive.rs
@@ -151,7 +151,6 @@ pub(crate) const DERIVED_REGION: Region = Region::zero();
 pub(crate) fn synthesize_member_impl<'a>(
     env: &mut Env<'a>,
     scope: &mut Scope,
-    opaque: Symbol,
     opaque_name: &'a str,
     ability_member: Symbol,
 ) -> (Symbol, Loc<Pattern>, &'a Loc<ast::Expr<'a>>) {

--- a/crates/compiler/can/src/derive.rs
+++ b/crates/compiler/can/src/derive.rs
@@ -1,0 +1,183 @@
+//! Derives parse trees for ability member impls of Opaques.
+//! These are derived at canonicalization time rather than type-checking time,
+//! as structural types are, due to the following reasons:
+//!   - Derived impls for opaques are not generalizable, and hence cannot be owned by the Derived
+//!     module, because they may require immediate specialization unknown to the Derived module.
+//!   - Derived impls for opaques are typically very small, effectively deferring the
+//!     implementation to the value they wrap.
+
+use roc_error_macros::internal_error;
+use roc_module::symbol::Symbol;
+use roc_parse::ast;
+use roc_region::all::{Loc, Region};
+
+use crate::{env::Env, pattern::Pattern, scope::Scope};
+
+fn to_encoder<'a>(env: &mut Env<'a>, at_opaque: &'a str) -> ast::Expr<'a> {
+    let alloc_pat = |it| env.arena.alloc(Loc::at(DERIVED_REGION, it));
+    let alloc_expr = |it| env.arena.alloc(Loc::at(DERIVED_REGION, it));
+
+    let payload = env.arena.alloc_str("#payload");
+
+    // \@Opaq payload
+    let opaque_ref = alloc_pat(ast::Pattern::OpaqueRef(at_opaque));
+    let opaque_apply_pattern = ast::Pattern::Apply(
+        opaque_ref,
+        &*env
+            .arena
+            .alloc([Loc::at(DERIVED_REGION, ast::Pattern::Identifier(payload))]),
+    );
+
+    // Encode.toEncoder payload
+    let call_member = alloc_expr(ast::Expr::Apply(
+        alloc_expr(ast::Expr::Var {
+            module_name: "Encode",
+            ident: "toEncoder",
+        }),
+        &*env.arena.alloc([&*alloc_expr(ast::Expr::Var {
+            module_name: "",
+            ident: payload,
+        })]),
+        roc_module::called_via::CalledVia::Space,
+    ));
+
+    // \@Opaq payload -> Encode.toEncoder payload
+    ast::Expr::Closure(
+        env.arena
+            .alloc([Loc::at(DERIVED_REGION, opaque_apply_pattern)]),
+        call_member,
+    )
+}
+
+fn hash<'a>(env: &mut Env<'a>, at_opaque: &'a str) -> ast::Expr<'a> {
+    let alloc_pat = |it| env.arena.alloc(Loc::at(DERIVED_REGION, it));
+    let alloc_expr = |it| env.arena.alloc(Loc::at(DERIVED_REGION, it));
+    let hasher = env.arena.alloc_str("#hasher");
+
+    let payload = env.arena.alloc_str("#payload");
+
+    // \@Opaq payload
+    let opaque_ref = alloc_pat(ast::Pattern::OpaqueRef(at_opaque));
+    let opaque_apply_pattern = ast::Pattern::Apply(
+        opaque_ref,
+        &*env
+            .arena
+            .alloc([Loc::at(DERIVED_REGION, ast::Pattern::Identifier(payload))]),
+    );
+
+    // Hash.hash hasher payload
+    let call_member = alloc_expr(ast::Expr::Apply(
+        alloc_expr(ast::Expr::Var {
+            module_name: "Hash",
+            ident: "hash",
+        }),
+        &*env.arena.alloc([
+            &*alloc_expr(ast::Expr::Var {
+                module_name: "",
+                ident: hasher,
+            }),
+            &*alloc_expr(ast::Expr::Var {
+                module_name: "",
+                ident: payload,
+            }),
+        ]),
+        roc_module::called_via::CalledVia::Space,
+    ));
+
+    // \hasher, @Opaq payload -> Hash.hash hasher payload
+    ast::Expr::Closure(
+        env.arena.alloc([
+            Loc::at(DERIVED_REGION, ast::Pattern::Identifier(hasher)),
+            Loc::at(DERIVED_REGION, opaque_apply_pattern),
+        ]),
+        call_member,
+    )
+}
+
+fn is_eq<'a>(env: &mut Env<'a>, at_opaque: &'a str) -> ast::Expr<'a> {
+    let alloc_pat = |it| env.arena.alloc(Loc::at(DERIVED_REGION, it));
+    let alloc_expr = |it| env.arena.alloc(Loc::at(DERIVED_REGION, it));
+
+    let payload1 = env.arena.alloc_str("#payload1");
+    let payload2 = env.arena.alloc_str("#payload2");
+
+    let opaque_ref = alloc_pat(ast::Pattern::OpaqueRef(at_opaque));
+    // \@Opaq payload1
+    let opaque1 = ast::Pattern::Apply(
+        opaque_ref,
+        &*env
+            .arena
+            .alloc([Loc::at(DERIVED_REGION, ast::Pattern::Identifier(payload1))]),
+    );
+    // \@Opaq payload2
+    let opaque2 = ast::Pattern::Apply(
+        opaque_ref,
+        &*env
+            .arena
+            .alloc([Loc::at(DERIVED_REGION, ast::Pattern::Identifier(payload2))]),
+    );
+
+    // Bool.isEq payload1 payload2
+    let call_member = alloc_expr(ast::Expr::Apply(
+        alloc_expr(ast::Expr::Var {
+            module_name: "Bool",
+            ident: "isEq",
+        }),
+        &*env.arena.alloc([
+            &*alloc_expr(ast::Expr::Var {
+                module_name: "",
+                ident: payload1,
+            }),
+            &*alloc_expr(ast::Expr::Var {
+                module_name: "",
+                ident: payload2,
+            }),
+        ]),
+        roc_module::called_via::CalledVia::Space,
+    ));
+
+    // \@Opaq payload1, @Opaq payload2 -> Bool.isEq payload1 payload2
+    ast::Expr::Closure(
+        env.arena.alloc([
+            Loc::at(DERIVED_REGION, opaque1),
+            Loc::at(DERIVED_REGION, opaque2),
+        ]),
+        call_member,
+    )
+}
+
+pub(crate) const DERIVED_REGION: Region = Region::zero();
+
+pub(crate) fn synthesize_member_impl<'a>(
+    env: &mut Env<'a>,
+    scope: &mut Scope,
+    opaque: Symbol,
+    opaque_name: &'a str,
+    ability_member: Symbol,
+) -> (Symbol, Loc<Pattern>, &'a Loc<ast::Expr<'a>>) {
+    // @Opaq
+    let at_opaque = env.arena.alloc_str(&format!("@{}", opaque_name));
+
+    let (impl_name, def_body): (String, ast::Expr<'a>) = match ability_member {
+        Symbol::ENCODE_TO_ENCODER => (
+            format!("#{}_toEncoder", opaque_name),
+            to_encoder(env, at_opaque),
+        ),
+        Symbol::DECODE_DECODER => (format!("#{}_decoder", opaque_name), todo!()),
+        Symbol::HASH_HASH => (format!("#{}_hash", opaque_name), hash(env, at_opaque)),
+        Symbol::BOOL_IS_EQ => (format!("#{}_isEq", opaque_name), is_eq(env, at_opaque)),
+        other => internal_error!("{:?} is not a derivable ability member!", other),
+    };
+
+    let impl_symbol = scope
+        .introduce_str(&impl_name, DERIVED_REGION)
+        .expect("this name is not unique");
+
+    let def_pattern = Pattern::Identifier(impl_symbol);
+
+    (
+        impl_symbol,
+        Loc::at(DERIVED_REGION, def_pattern),
+        env.arena.alloc(Loc::at(DERIVED_REGION, def_body)),
+    )
+}

--- a/crates/compiler/can/src/derive.rs
+++ b/crates/compiler/can/src/derive.rs
@@ -146,7 +146,7 @@ fn is_eq<'a>(env: &mut Env<'a>, at_opaque: &'a str) -> ast::Expr<'a> {
     )
 }
 
-pub(crate) const DERIVED_REGION: Region = Region::zero();
+pub const DERIVED_REGION: Region = Region::zero();
 
 pub(crate) fn synthesize_member_impl<'a>(
     env: &mut Env<'a>,

--- a/crates/compiler/can/src/derive.rs
+++ b/crates/compiler/can/src/derive.rs
@@ -17,7 +17,7 @@ fn to_encoder<'a>(env: &mut Env<'a>, at_opaque: &'a str) -> ast::Expr<'a> {
     let alloc_pat = |it| env.arena.alloc(Loc::at(DERIVED_REGION, it));
     let alloc_expr = |it| env.arena.alloc(Loc::at(DERIVED_REGION, it));
 
-    let payload = env.arena.alloc_str("#payload");
+    let payload = "#payload";
 
     // \@Opaq payload
     let opaque_ref = alloc_pat(ast::Pattern::OpaqueRef(at_opaque));
@@ -52,9 +52,9 @@ fn to_encoder<'a>(env: &mut Env<'a>, at_opaque: &'a str) -> ast::Expr<'a> {
 fn hash<'a>(env: &mut Env<'a>, at_opaque: &'a str) -> ast::Expr<'a> {
     let alloc_pat = |it| env.arena.alloc(Loc::at(DERIVED_REGION, it));
     let alloc_expr = |it| env.arena.alloc(Loc::at(DERIVED_REGION, it));
-    let hasher = env.arena.alloc_str("#hasher");
+    let hasher = "#hasher";
 
-    let payload = env.arena.alloc_str("#payload");
+    let payload = "#payload";
 
     // \@Opaq payload
     let opaque_ref = alloc_pat(ast::Pattern::OpaqueRef(at_opaque));
@@ -98,8 +98,8 @@ fn is_eq<'a>(env: &mut Env<'a>, at_opaque: &'a str) -> ast::Expr<'a> {
     let alloc_pat = |it| env.arena.alloc(Loc::at(DERIVED_REGION, it));
     let alloc_expr = |it| env.arena.alloc(Loc::at(DERIVED_REGION, it));
 
-    let payload1 = env.arena.alloc_str("#payload1");
-    let payload2 = env.arena.alloc_str("#payload2");
+    let payload1 = "#payload1";
+    let payload2 = "#payload2";
 
     let opaque_ref = alloc_pat(ast::Pattern::OpaqueRef(at_opaque));
     // \@Opaq payload1

--- a/crates/compiler/can/src/lib.rs
+++ b/crates/compiler/can/src/lib.rs
@@ -7,6 +7,7 @@ pub mod builtins;
 pub mod constraint;
 pub mod copy;
 pub mod def;
+mod derive;
 pub mod effect_module;
 pub mod env;
 pub mod exhaustive;

--- a/crates/compiler/can/src/lib.rs
+++ b/crates/compiler/can/src/lib.rs
@@ -21,3 +21,5 @@ pub mod procedure;
 pub mod scope;
 pub mod string;
 pub mod traverse;
+
+pub use derive::DERIVED_REGION;

--- a/crates/compiler/load_internal/src/file.rs
+++ b/crates/compiler/load_internal/src/file.rs
@@ -4464,7 +4464,7 @@ fn run_solve_solve(
                 .values()
                 .any(|resolved_impl| match resolved_impl {
                     ResolvedImpl::Impl(specialization) => specialization.symbol == sym,
-                    ResolvedImpl::Derived | ResolvedImpl::Error => false,
+                    ResolvedImpl::Error => false,
                 })
         };
 

--- a/crates/compiler/module/src/symbol.rs
+++ b/crates/compiler/module/src/symbol.rs
@@ -1518,6 +1518,7 @@ define_builtins! {
         24 DECODE_DECODE_WITH: "decodeWith"
         25 DECODE_FROM_BYTES_PARTIAL: "fromBytesPartial"
         26 DECODE_FROM_BYTES: "fromBytes"
+        27 DECODE_MAP_RESULT: "mapResult"
     }
     13 HASH: "Hash" => {
         0 HASH_HASH_ABILITY: "Hash" exposed_type=true

--- a/crates/compiler/solve/src/ability.rs
+++ b/crates/compiler/solve/src/ability.rs
@@ -1,7 +1,7 @@
 use roc_can::abilities::AbilitiesStore;
 use roc_can::expr::PendingDerives;
 use roc_collections::{VecMap, VecSet};
-use roc_error_macros::{internal_error, todo_abilities};
+use roc_error_macros::internal_error;
 use roc_module::symbol::Symbol;
 use roc_region::all::{Loc, Region};
 use roc_solve_problem::{
@@ -1237,9 +1237,6 @@ pub fn resolve_ability_specialization<R: AbilityResolver>(
             match resolver.get_implementation(impl_key)? {
                 roc_types::types::MemberImpl::Impl(spec_symbol) => {
                     Resolved::Specialization(spec_symbol)
-                }
-                roc_types::types::MemberImpl::Derived => {
-                    todo_abilities!("get type from obligated opaque")
                 }
                 // TODO this is not correct. We can replace `Resolved` with `MemberImpl` entirely,
                 // which will make this simpler.

--- a/crates/compiler/solve/src/module.rs
+++ b/crates/compiler/solve/src/module.rs
@@ -147,9 +147,6 @@ pub fn exposed_types_storage_subs(
                     stored_specialization_lambda_set_vars.insert(lset_var, imported_lset_var);
                 }
             }
-            ResolvedImpl::Derived => {
-                // nothing to do
-            }
             ResolvedImpl::Error => {
                 // nothing to do
             }
@@ -202,7 +199,6 @@ pub fn extract_module_owned_implementations(
                     );
                     ResolvedImpl::Impl(specialization.clone())
                 }
-                MemberImpl::Derived => ResolvedImpl::Derived,
                 MemberImpl::Error => ResolvedImpl::Error,
             };
 

--- a/crates/compiler/solve/src/specialize.rs
+++ b/crates/compiler/solve/src/specialize.rs
@@ -638,7 +638,7 @@ fn make_specialization_decision<P: Phase>(
                             // Doesn't specialize; an error will already be reported for this.
                             SpecializeDecision::Drop
                         }
-                        Some(MemberImpl::Error | MemberImpl::Derived) => {
+                        Some(MemberImpl::Error) => {
                             // TODO: probably not right, we may want to choose a derive decision!
                             SpecializeDecision::Specialize(Opaque(*opaque))
                         }
@@ -743,7 +743,6 @@ fn get_specialization_lambda_set_ambient_function<P: Phase>(
                                     .expect("lambda set region not resolved");
                                 Ok(specialized_lambda_set)
                             }
-                            MemberImpl::Derived => todo_abilities!(),
                             MemberImpl::Error => todo_abilities!(),
                         },
                     }

--- a/crates/compiler/solve/tests/solve_expr.rs
+++ b/crates/compiler/solve/tests/solve_expr.rs
@@ -8063,6 +8063,26 @@ mod solve_expr {
     }
 
     #[test]
+    fn derive_decoder_for_opaque() {
+        infer_queries!(
+            indoc!(
+                r#"
+                app "test" provides [main] to "./platform"
+
+                N := U8 has [Decoding]
+
+                main : Decoder N _
+                main = Decode.custom \bytes, fmt ->
+                    Decode.decodeWith bytes Decode.decoder fmt
+                #                           ^^^^^^^^^^^^^^
+                "#
+            ),
+            @"N#Decode.decoder(3) : List U8, fmt -[[7(7)]]-> { rest : List U8, result : [Err [TooShort], Ok U8] } | fmt has DecoderFormatting"
+            print_only_under_alias: true
+        );
+    }
+
+    #[test]
     fn derive_hash_for_opaque() {
         infer_queries!(
             indoc!(

--- a/crates/compiler/solve/tests/solve_expr.rs
+++ b/crates/compiler/solve/tests/solve_expr.rs
@@ -8061,4 +8061,21 @@ mod solve_expr {
             @"N#Hash.hash(3) : a, N -[[#N_hash(3)]]-> a | a has Hasher"
         );
     }
+
+    #[test]
+    fn derive_eq_for_opaque() {
+        infer_queries!(
+            indoc!(
+                r#"
+                app "test" provides [main] to "./platform"
+
+                N := U8 has [Eq]
+
+                main = Bool.isEq (@N 15) (@N 23)
+                #      ^^^^^^^^^
+                "#
+            ),
+            @"N#Bool.isEq(3) : N, N -[[#N_isEq(3)]]-> Bool"
+        );
+    }
 }

--- a/crates/compiler/solve/tests/solve_expr.rs
+++ b/crates/compiler/solve/tests/solve_expr.rs
@@ -8044,4 +8044,21 @@ mod solve_expr {
             "{} -> {}",
         );
     }
+
+    #[test]
+    fn derive_hash_for_opaque() {
+        infer_queries!(
+            indoc!(
+                r#"
+                app "test" provides [main] to "./platform"
+
+                N := U8 has [Hash]
+
+                main = \hasher, @N n -> Hash.hash hasher (@N n)
+                #                       ^^^^^^^^^
+                "#
+            ),
+            @"N#Hash.hash(3) : a, N -[[#N_hash(3)]]-> a | a has Hasher"
+        );
+    }
 }

--- a/crates/compiler/solve/tests/solve_expr.rs
+++ b/crates/compiler/solve/tests/solve_expr.rs
@@ -384,7 +384,7 @@ mod solve_expr {
                     );
                     Some((impl_key, specialization.clone()))
                 }
-                MemberImpl::Derived | MemberImpl::Error => None,
+                MemberImpl::Error => None,
             },
         );
 

--- a/crates/compiler/solve/tests/solve_expr.rs
+++ b/crates/compiler/solve/tests/solve_expr.rs
@@ -8046,6 +8046,23 @@ mod solve_expr {
     }
 
     #[test]
+    fn derive_to_encoder_for_opaque() {
+        infer_queries!(
+            indoc!(
+                r#"
+                app "test" provides [main] to "./platform"
+
+                N := U8 has [Encoding]
+
+                main = Encode.toEncoder (@N 15)
+                #      ^^^^^^^^^^^^^^^^
+                "#
+            ),
+            @"N#Encode.toEncoder(3) : N -[[#N_toEncoder(3)]]-> Encoder fmt | fmt has EncoderFormatting"
+        );
+    }
+
+    #[test]
     fn derive_hash_for_opaque() {
         infer_queries!(
             indoc!(

--- a/crates/compiler/test_gen/src/gen_abilities.rs
+++ b/crates/compiler/test_gen/src/gen_abilities.rs
@@ -792,6 +792,32 @@ fn decode_use_stdlib() {
 }
 
 #[test]
+#[cfg(all(
+    any(feature = "gen-llvm", feature = "gen-wasm"),
+    not(debug_assertions) // https://github.com/roc-lang/roc/issues/3898
+))]
+fn decode_derive_decoder_for_opaque() {
+    assert_evals_to!(
+        indoc!(
+            r#"
+            app "test"
+                imports [Json]
+                provides [main] to "./platform"
+
+            HelloWorld := { a: Str } has [Decoding]
+
+            main =
+                when Str.toUtf8 """{"a":"Hello, World!"}""" |> Decode.fromBytes Json.fromUtf8 is
+                    Ok (@HelloWorld {a}) -> a
+                    _ -> "FAIL"
+            "#
+        ),
+        RocStr::from(r#"Hello, World!"#),
+        RocStr
+    )
+}
+
+#[test]
 #[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
 fn decode_use_stdlib_json_list() {
     assert_evals_to!(

--- a/crates/compiler/test_gen/src/gen_abilities.rs
+++ b/crates/compiler/test_gen/src/gen_abilities.rs
@@ -1671,4 +1671,21 @@ mod eq {
             bool
         )
     }
+
+    #[test]
+    fn derive_structural_eq_for_opaque() {
+        assert_evals_to!(
+            indoc!(
+                r#"
+                app "test" provides [main] to "./platform"
+
+                Q := U8 has [Eq]
+
+                main = (@Q 15) == (@Q 15)
+                "#
+            ),
+            true,
+            bool
+        )
+    }
 }

--- a/crates/compiler/test_gen/src/gen_abilities.rs
+++ b/crates/compiler/test_gen/src/gen_abilities.rs
@@ -376,6 +376,30 @@ fn encode_use_stdlib_without_wrapping_custom() {
 
 #[test]
 #[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
+fn encode_derive_to_encoder_for_opaque() {
+    assert_evals_to!(
+        indoc!(
+            r#"
+            app "test"
+                imports [Json]
+                provides [main] to "./platform"
+
+            HelloWorld := { a: Str } has [Encoding]
+
+            main =
+                result = Str.fromUtf8 (Encode.toBytes (@HelloWorld { a: "Hello, World!" }) Json.toUtf8)
+                when result is
+                    Ok s -> s
+                    _ -> "<bad>"
+            "#
+        ),
+        RocStr::from(r#"{"a":"Hello, World!"}"#),
+        RocStr
+    )
+}
+
+#[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
 fn to_encoder_encode_custom_has_capture() {
     assert_evals_to!(
         indoc!(

--- a/crates/compiler/test_gen/src/gen_abilities.rs
+++ b/crates/compiler/test_gen/src/gen_abilities.rs
@@ -1590,6 +1590,33 @@ mod hash {
                 RocList<u8>
             )
         }
+
+        #[test]
+        fn derived_hash_for_opaque_record() {
+            assert_evals_to!(
+                &format!(
+                    indoc!(
+                        r#"
+                        app "test" provides [main] to "./platform"
+
+                        {}
+
+                        Q := {{ a: U8, b: U8, c: U8 }} has [Hash]
+
+                        q = @Q {{ a: 15, b: 27, c: 31 }}
+
+                        main =
+                            @THasher []
+                            |> Hash.hash q
+                            |> tRead
+                        "#
+                    ),
+                    TEST_HASHER,
+                ),
+                RocList::from_slice(&[15, 27, 31]),
+                RocList<u8>
+            )
+        }
     }
 }
 

--- a/crates/compiler/types/src/types.rs
+++ b/crates/compiler/types/src/types.rs
@@ -2139,8 +2139,6 @@ pub enum MemberImpl {
     /// The implementation is claimed to be at the given symbol.
     /// During solving we validate that the impl is really there.
     Impl(Symbol),
-    /// The implementation should be derived.
-    Derived,
     /// The implementation is not present or does not match the expected member type.
     Error,
 }

--- a/crates/reporting/src/error/type.rs
+++ b/crates/reporting/src/error/type.rs
@@ -141,6 +141,10 @@ pub fn type_problem<'b>(
             report(title, doc, filename)
         }
         BadExprMissingAbility(region, _category, _found, incomplete) => {
+            if region == roc_can::DERIVED_REGION {
+                return None;
+            }
+
             let incomplete = incomplete
                 .into_iter()
                 .map(|unfulfilled| report_unfulfilled_ability(alloc, lines, unfulfilled));

--- a/crates/reporting/tests/test_reporting.rs
+++ b/crates/reporting/tests/test_reporting.rs
@@ -11459,15 +11459,16 @@ All branches in an `if` must have the same type!
     );
 
     test_report!(
-        demanded_vs_optional_record_field,
-        indoc!(
-            r#"
+    <<<<<<< HEAD
+            demanded_vs_optional_record_field,
+            indoc!(
+                r#"
             foo : { a : Str } -> Str
             foo = \{ a ? "" } -> a
             foo
             "#
-        ),
-    @r###"
+            ),
+        @r###"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     The 1st argument to `foo` is weird:
@@ -11482,6 +11483,53 @@ All branches in an `if` must have the same type!
     But the annotation on `foo` says the 1st argument should be:
 
         { a : Str }
+    "###
+        );
+
+    test_report!(
+        underivable_opaque_doesnt_error_for_derived_bodies,
+        indoc!(
+            r#"
+            app "test" provides [main] to "./platform"
+
+            F := U8 -> U8 has [Hash, Eq, Encoding]
+
+            main = ""
+            "#
+        ),
+    @r###"
+    ── INCOMPLETE ABILITY IMPLEMENTATION ───────────────────── /code/proj/Main.roc ─
+
+    I can't derive an implementation of the `Hash` ability for `F`:
+
+    3│  F := U8 -> U8 has [Hash, Eq, Encoding]
+                           ^^^^
+
+    Note: `Hash` cannot be generated for functions.
+
+    Tip: You can define a custom implementation of `Hash` for `F`.
+
+    ── INCOMPLETE ABILITY IMPLEMENTATION ───────────────────── /code/proj/Main.roc ─
+
+    I can't derive an implementation of the `Eq` ability for `F`:
+
+    3│  F := U8 -> U8 has [Hash, Eq, Encoding]
+                                 ^^
+
+    Note: `Eq` cannot be generated for functions.
+
+    Tip: You can define a custom implementation of `Eq` for `F`.
+
+    ── INCOMPLETE ABILITY IMPLEMENTATION ───────────────────── /code/proj/Main.roc ─
+
+    I can't derive an implementation of the `Encoding` ability for `F`:
+
+    3│  F := U8 -> U8 has [Hash, Eq, Encoding]
+                                     ^^^^^^^^
+
+    Note: `Encoding` cannot be generated for functions.
+
+    Tip: You can define a custom implementation of `Encoding` for `F`.
     "###
     );
 }

--- a/crates/reporting/tests/test_reporting.rs
+++ b/crates/reporting/tests/test_reporting.rs
@@ -11459,16 +11459,15 @@ All branches in an `if` must have the same type!
     );
 
     test_report!(
-    <<<<<<< HEAD
-            demanded_vs_optional_record_field,
-            indoc!(
-                r#"
+        demanded_vs_optional_record_field,
+        indoc!(
+            r#"
             foo : { a : Str } -> Str
             foo = \{ a ? "" } -> a
             foo
             "#
-            ),
-        @r###"
+        ),
+    @r###"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     The 1st argument to `foo` is weird:
@@ -11484,7 +11483,7 @@ All branches in an `if` must have the same type!
 
         { a : Str }
     "###
-        );
+    );
 
     test_report!(
         underivable_opaque_doesnt_error_for_derived_bodies,


### PR DESCRIPTION
[As discussed on Zulip](https://roc.zulipchat.com/#narrow/stream/231635-compiler-development/topic/Deriving.20ability.20impls.20for.20opaques)

See individual commits for details. This adds deriving support for Hash, Eq, Decoding, and Encoding.

We take care not to print errors observed in derived implementations; see the reporting tests.

Closes https://github.com/roc-lang/roc/issues/4228