### PR TITLE
Send safe roc list

### DIFF
--- a/crates/roc_std/src/lib.rs
+++ b/crates/roc_std/src/lib.rs
@@ -19,9 +19,9 @@ mod storage;
 
 pub use roc_box::RocBox;
 pub use roc_dict::RocDict;
-pub use roc_list::RocList;
+pub use roc_list::{RocList, SendSafeRocList};
 pub use roc_set::RocSet;
-pub use roc_str::{InteriorNulError, RocStr};
+pub use roc_str::{InteriorNulError, RocStr, SendSafeRocStr};
 pub use storage::Storage;
 
 // A list of C functions that are being imported

--- a/crates/roc_std/src/roc_list.rs
+++ b/crates/roc_std/src/roc_list.rs
@@ -121,9 +121,20 @@ impl<T> RocList<T> {
         }
     }
 
-    // Marks a list as readonly. This means that it will be leaked.
-    // For constants passed in from platform to application, this may be reasonable.
-    // Marked unsafe because it should not be used lightly.
+    /// Marks a list as readonly. This means that it will be leaked.
+    /// For constants passed in from platform to application, this may be reasonable.
+    ///
+    /// # Safety
+    ///
+    /// A value can be read-only in Roc for 3 reasons:
+    ///   1. The value is stored in read-only memory like a constant in the app.
+    ///   2. Our refcounting maxes out. When that happens, we saturate to read-only.
+    ///   3. This function is called
+    ///
+    /// Any value that is set to read-only will be leaked.
+    /// There is no way to tell how many references it has and if it is safe to free.
+    /// As such, only values that should have a static lifetime for the entire application run
+    /// should be considered for marking read-only.
     pub unsafe fn set_readonly(&self) {
         if let Some((_, storage)) = self.elements_and_storage() {
             storage.set(Storage::Readonly);

--- a/crates/roc_std/src/roc_list.rs
+++ b/crates/roc_std/src/roc_list.rs
@@ -121,6 +121,15 @@ impl<T> RocList<T> {
         }
     }
 
+    // Marks a list as readonly. This means that it will be leaked.
+    // For constants passed in from platform to application, this may be reasonable.
+    // Marked unsafe because it should not be used lightly.
+    pub unsafe fn set_readonly(&self) {
+        if let Some((_, storage)) = self.elements_and_storage() {
+            storage.set(Storage::Readonly);
+        }
+    }
+
     /// Note that there is no way to convert directly to a Vec.
     ///
     /// This is because RocList values are not allocated using the system allocator, so

--- a/crates/roc_std/src/roc_list.rs
+++ b/crates/roc_std/src/roc_list.rs
@@ -619,6 +619,20 @@ pub struct SendSafeRocList<T>(RocList<T>);
 
 unsafe impl<T> Send for SendSafeRocList<T> where T: Send {}
 
+impl<T> Clone for SendSafeRocList<T>
+where
+    T: Clone,
+{
+    fn clone(&self) -> Self {
+        if self.0.is_readonly() {
+            SendSafeRocList(self.0.clone())
+        } else {
+            // To keep self send safe, this must copy.
+            SendSafeRocList(RocList::from_slice(&self.0))
+        }
+    }
+}
+
 impl<T> From<RocList<T>> for SendSafeRocList<T>
 where
     T: Clone,

--- a/crates/roc_std/src/roc_str.rs
+++ b/crates/roc_std/src/roc_str.rs
@@ -123,6 +123,16 @@ impl RocStr {
         }
     }
 
+    // Marks a str as readonly. This means that it will be leaked.
+    // For constants passed in from platform to application, this may be reasonable.
+    // Marked unsafe because it should not be used lightly.
+    pub unsafe fn set_readonly(&self) {
+        match self.as_enum_ref() {
+            RocStrInnerRef::HeapAllocated(roc_list) => unsafe { roc_list.set_readonly() },
+            RocStrInnerRef::SmallString(_) => {}
+        }
+    }
+
     /// Note that there is no way to convert directly to a String.
     ///
     /// This is because RocStr values are not allocated using the system allocator, so

--- a/crates/roc_std/src/roc_str.rs
+++ b/crates/roc_std/src/roc_str.rs
@@ -123,9 +123,20 @@ impl RocStr {
         }
     }
 
-    // Marks a str as readonly. This means that it will be leaked.
-    // For constants passed in from platform to application, this may be reasonable.
-    // Marked unsafe because it should not be used lightly.
+    /// Marks a str as readonly. This means that it will be leaked.
+    /// For constants passed in from platform to application, this may be reasonable.
+    ///
+    /// # Safety
+    ///
+    /// A value can be read-only in Roc for 3 reasons:
+    ///   1. The value is stored in read-only memory like a constant in the app.
+    ///   2. Our refcounting maxes out. When that happens, we saturate to read-only.
+    ///   3. This function is called
+    ///
+    /// Any value that is set to read-only will be leaked.
+    /// There is no way to tell how many references it has and if it is safe to free.
+    /// As such, only values that should have a static lifetime for the entire application run
+    /// should be considered for marking read-only.
     pub unsafe fn set_readonly(&self) {
         match self.as_enum_ref() {
             RocStrInnerRef::HeapAllocated(roc_list) => unsafe { roc_list.set_readonly() },

--- a/crates/roc_std/src/roc_str.rs
+++ b/crates/roc_std/src/roc_str.rs
@@ -657,6 +657,17 @@ pub struct SendSafeRocStr(RocStr);
 
 unsafe impl Send for SendSafeRocStr {}
 
+impl Clone for SendSafeRocStr {
+    fn clone(&self) -> Self {
+        if self.0.is_readonly() {
+            SendSafeRocStr(self.0.clone())
+        } else {
+            // To keep self send safe, this must copy.
+            SendSafeRocStr(RocStr::from(self.0.as_str()))
+        }
+    }
+}
+
 impl From<RocStr> for SendSafeRocStr {
     fn from(s: RocStr) -> Self {
         if s.is_unique() || s.is_readonly() {

--- a/crates/roc_std/tests/test_roc_std.rs
+++ b/crates/roc_std/tests/test_roc_std.rs
@@ -59,7 +59,7 @@ pub unsafe extern "C" fn roc_memset(dst: *mut c_void, c: i32, n: usize) -> *mut 
 
 #[cfg(test)]
 mod test_roc_std {
-    use roc_std::{RocBox, RocDec, RocList, RocResult, RocStr};
+    use roc_std::{RocBox, RocDec, RocList, RocResult, RocStr, SendSafeRocList, SendSafeRocStr};
 
     fn roc_str_byte_representation(string: &RocStr) -> [u8; RocStr::SIZE] {
         unsafe { core::mem::transmute_copy(string) }
@@ -126,7 +126,7 @@ mod test_roc_std {
 
         roc_str.reserve(42);
 
-        assert_gte!(roc_str.capacity(), 42);
+        assert_eq!(roc_str.capacity() >= 42, true);
     }
 
     #[test]
@@ -135,7 +135,7 @@ mod test_roc_std {
 
         roc_str.reserve(5000);
 
-        assert_gte!(roc_str.capacity(), 5000);
+        assert_eq!(roc_str.capacity() >= 5000, true);
     }
 
     #[test]
@@ -295,6 +295,80 @@ mod test_roc_std {
 
         let example = RocDec::from_str("1234.5678").unwrap();
         assert_eq!(format!("{}", example), "1234.5678");
+    }
+
+    #[test]
+    fn safe_send_no_copy() {
+        let x = RocStr::from("This is a long string but still unique. Yay!!!");
+        assert_eq!(x.is_unique(), true);
+
+        let safe_x = SendSafeRocStr::from(x);
+        let new_x = RocStr::from(safe_x);
+        assert_eq!(new_x.is_unique(), true);
+        assert_eq!(
+            new_x.as_str(),
+            "This is a long string but still unique. Yay!!!"
+        );
+    }
+
+    #[test]
+    fn safe_send_requires_copy() {
+        let x = RocStr::from("This is a long string but still unique. Yay!!!");
+        let y = x.clone();
+        let z = y.clone();
+        assert_eq!(x.is_unique(), false);
+        assert_eq!(y.is_unique(), false);
+        assert_eq!(z.is_unique(), false);
+
+        let safe_x = SendSafeRocStr::from(x);
+        let new_x = RocStr::from(safe_x);
+        assert_eq!(new_x.is_unique(), true);
+        assert_eq!(y.is_unique(), false);
+        assert_eq!(z.is_unique(), false);
+        assert_eq!(
+            new_x.as_str(),
+            "This is a long string but still unique. Yay!!!"
+        );
+    }
+
+    #[test]
+    fn safe_send_small_str() {
+        let x = RocStr::from("short");
+        let y = x.clone();
+        let z = y.clone();
+        assert_eq!(x.is_unique(), true);
+        assert_eq!(y.is_unique(), true);
+        assert_eq!(z.is_unique(), true);
+
+        let safe_x = SendSafeRocStr::from(x);
+        let new_x = RocStr::from(safe_x);
+        assert_eq!(new_x.is_unique(), true);
+        assert_eq!(y.is_unique(), true);
+        assert_eq!(z.is_unique(), true);
+        assert_eq!(new_x.as_str(), "short");
+    }
+
+    #[test]
+    fn empty_list_is_unique() {
+        let roc_list = RocList::<RocStr>::empty();
+        assert_eq!(roc_list.is_unique(), true);
+    }
+
+    #[test]
+    fn readonly_list_is_sendsafe() {
+        let x = RocList::from_slice(&[1, 2, 3, 4, 5]);
+        unsafe { x.set_readonly() };
+        assert_eq!(x.is_readonly(), true);
+
+        let y = x.clone();
+        let z = y.clone();
+
+        let safe_x = SendSafeRocList::from(x);
+        let new_x = RocList::from(safe_x);
+        assert_eq!(new_x.is_readonly(), true);
+        assert_eq!(y.is_readonly(), true);
+        assert_eq!(z.is_readonly(), true);
+        assert_eq!(new_x.as_slice(), &[1, 2, 3, 4, 5]);
     }
 }
 


### PR DESCRIPTION
This was a request that came up when using Roc types with threads and async. They get quite inconvenient to pass from one thread to the next. These Wrappers should make that simpler.