### PR TITLE
Amend `List.walk` documentation with latest syntax

### DIFF
--- a/crates/compiler/builtins/roc/List.roc
+++ b/crates/compiler/builtins/roc/List.roc
@@ -368,30 +368,26 @@ contains = \list, needle ->
 ## You can use it in a pipeline:
 ##
 ##     [2, 4, 8]
-##         |> List.walk { start: 0, step: Num.add }
+##         |> List.walk 0 Num.add
 ##
 ## This returns 14 because:
-## * `state` starts at 0 (because of `start: 0`)
+## * `state` starts at 0
 ## * Each `step` runs `Num.add state elem`, and the return value becomes the new `state`.
 ##
 ## Here is a table of how `state` changes as [List.walk] walks over the elements
-## `[2, 4, 8]` using #Num.add as its `step` function to determine the next `state`.
+## `[2, 4, 8]` using [Num.add] as its `step` function to determine the next `state`.
 ##
-## `state` | `elem` | `step state elem` (`Num.add state elem`)
-## --------+--------+-----------------------------------------
-## 0       |        |
-## 0       | 2      | 2
-## 2       | 4      | 6
-## 6       | 8      | 14
+## state | elem  | Num.add state elem
+## :---: | :---: | :----------------:
+## 0     |       |
+## 0     | 2     | 2
+## 2     | 4     | 6
+## 6     | 8     | 14
 ##
-## So `state` goes through these changes:
-## 1. `0` (because of `start: 0`)
-## 2. `1` (because of `Num.add state elem` with `state` = 0 and `elem` = 1
+## The following returns -6:
 ##
 ##     [1, 2, 3]
-##         |> List.walk { start: 0, step: Num.sub }
-##
-## This returns -6 because
+##         |> List.walk 0 Num.sub
 ##
 ## Note that in other languages, `walk` is sometimes called `reduce`,
 ## `fold`, `foldLeft`, or `foldl`.

--- a/crates/docs/src/lib.rs
+++ b/crates/docs/src/lib.rs
@@ -918,7 +918,7 @@ fn markdown_to_html(
         }
     };
 
-    let markdown_options = pulldown_cmark::Options::empty();
+    let markdown_options = pulldown_cmark::Options::ENABLE_TABLES;
 
     let mut expecting_code_block = false;
 

--- a/crates/docs/src/static/styles.css
+++ b/crates/docs/src/static/styles.css
@@ -37,6 +37,10 @@ a {
   color: #972395;
 }
 
+table tr th, table tr td {
+  padding: 6px 13px;
+}
+
 .logo {
   padding: 2px 8px;
 }


### PR DESCRIPTION
# Before
<img width="1904" alt="Screen Shot 2022-10-23 at 5 48 11 PM" src="https://user-images.githubusercontent.com/1977082/197419809-b437cb41-d900-4988-bbe5-9d284b02ea55.png">

# After
<img width="1904" alt="Screen Shot 2022-10-23 at 5 43 18 PM" src="https://user-images.githubusercontent.com/1977082/197419793-e75a4ec4-e97d-443d-a925-f037e7e7897e.png">
