### PR TITLE
Docs updates

### DIFF
--- a/crates/docs/src/static/index.html
+++ b/crates/docs/src/static/index.html
@@ -15,7 +15,7 @@
 <body>
 <nav id="sidebar-nav">
     <input id="module-search" aria-labelledby="search-link" type="text" placeholder="Search" />
-    <label for="module-search" id="search-link"><span id="search-link-text">Search</span> <span id="search-link-hint">(shortcut: S)</span></label>
+    <label for="module-search" id="search-link"><span id="search-link-text">Search</span> <span id="search-link-hint">(press <span id="search-shortcut-key">s</span>)</span></label>
     <div class="module-links">
         <!-- Module links -->
     </div>

--- a/crates/docs/src/static/index.html
+++ b/crates/docs/src/static/index.html
@@ -24,7 +24,7 @@
     <!-- if the window gets big, this extends the purple bar on the top header to the left edge of the window -->
 </div>
 <header class="top-header">
-    <nav class="pkg-and-logo">
+    <div class="pkg-and-logo">
         <a class="logo" href="/" aria-labelledby="logo-link">
             <svg viewBox="0 -6 51 58" fill="none" xmlns="http://www.w3.org/2000/svg" aria-labelledby="logo-link" role="img">
                 <title id="logo-link">Return to Roc packages</title>
@@ -32,7 +32,7 @@
             </svg>
         </a>
         <!-- Package Name and Version -->
-    </nav>
+    </div>
     <div class="top-header-triangle">
         <!-- if the window gets big, this extends the purple bar on the top header to the left edge of the window -->
     </div>

--- a/crates/docs/src/static/styles.css
+++ b/crates/docs/src/static/styles.css
@@ -451,9 +451,17 @@ pre {
 }
 
 #search-link-hint {
-  font-style: italic;
   margin-left: 1em;
-  opacity: 0.7;
+  opacity: 0.6;
+}
+
+#search-shortcut-key {
+  font-family: monospace;
+  border: 1px solid #666;
+  padding: 1px 3px 3px;
+  font-style: normal;
+  border-radius: 4px;
+  line-height: 15px;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -480,6 +488,10 @@ pre {
 }
 
 @media only screen and (max-device-width: 480px) and (orientation: portrait) {
+  #search-link-hint {
+    display: none;
+  }
+
   .search-button {
     display: block; /* This is only visible in mobile. */
   }

--- a/www/build.sh
+++ b/www/build.sh
@@ -38,6 +38,9 @@ cargo run --bin roc-docs crates/compiler/builtins/roc/*.roc
 mv generated-docs/*.* www/build # move all the .js, .css, etc. files to build/
 mv generated-docs/ www/build/builtins # move all the folders to build/builtins/
 
+# Manually add this tip to all the builtin docs.
+find www/build/builtins -type f -name 'index.html' -exec sed -i 's!<div class="module-links">!<div class="module-links"><div style="padding: 1em;font-style: italic;line-height: 1.3em;"><strong>Tip:</strong> <a href="/different-names">Some names</a> differ from other languages.</div>!' {} \;
+
 echo 'Generating CLI example platform docs...'
 # Change ROC_DOCS_ROOT_DIR=builtins so that links will be generated relative to
 # "/examples/cli/" rather than "/builtins/"

--- a/www/build.sh
+++ b/www/build.sh
@@ -39,7 +39,7 @@ mv generated-docs/*.* www/build # move all the .js, .css, etc. files to build/
 mv generated-docs/ www/build/builtins # move all the folders to build/builtins/
 
 # Manually add this tip to all the builtin docs.
-find www/build/builtins -type f -name 'index.html' -exec sed -i 's!<div class="module-links">!<div class="module-links"><div style="padding: 1em;font-style: italic;line-height: 1.3em;"><strong>Tip:</strong> <a href="/different-names">Some names</a> differ from other languages.</div>!' {} \;
+find www/build/builtins -type f -name 'index.html' -exec sed -i 's!</nav>!<div style="padding: 1em;font-style: italic;line-height: 1.3em;"><strong>Tip:</strong> <a href="/different-names">Some names</a> differ from other languages.</div></nav>!' {} \;
 
 echo 'Generating CLI example platform docs...'
 # Change ROC_DOCS_ROOT_DIR=builtins so that links will be generated relative to

--- a/www/public/different-names/index.html
+++ b/www/public/different-names/index.html
@@ -1,0 +1,140 @@
+<!DOCTYPE html>
+
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+
+  <title>Different Names in Roc</title>
+  <meta name="description" content="Names of things in Roc that differ from other languages.">
+  <meta name="viewport" content="width=device-width">
+  <link rel="stylesheet" href="/homepage.css">
+  <link rel="icon" href="/favicon.svg">
+</head>
+
+<body>
+  <h1>Different Names</h1>
+  <p>Different programming languages sometimes choose different names for similar operations.
+    If you're new to Roc, you may be searching for a familiar operation and not find it because
+    that operation (or a similar one) goes by a different name in Roc.
+  </p>
+
+  <p>To help with this, here are some Roc operations along with some names found in other languages
+    for similar operations.
+  </p>
+
+  <table>
+    <thead>
+        <tr>
+            <th>Roc Name</th>
+            <th>Other Names</th>
+        </tr>
+    </thead>
+    <tbody id="different-names-body">
+        <tr>
+            <td><a href="/builtins/List#walk">List.walk</a></td>
+            <td>
+                <ul>
+                    <li>fold</li>
+                    <li>foldl</li>
+                    <li>foldLeft</li>
+                    <li>fold_left</li>
+                    <li>fold-left</li>
+                    <li>reduce</li>
+                    <li>lreduce</li>
+                    <li>array_reduce</li>
+                    <li>inject</li>
+                    <li>accumulate</li>
+                    <li>Aggregate</li>
+                </ul>
+            </td>
+        </tr>
+        <tr>
+            <td><a href="/builtins/List#walkBackwards">List.walkBackwards</a></td>
+            <td>
+                <ul>
+                    <li>foldr</li>
+                    <li>foldRight</li>
+                    <li>fold_right</li>
+                    <li>fold-right</li>
+                    <li>reduceRight</li>
+                    <li>rreduce</li>
+                </ul>
+            </td>
+        </tr>
+        <tr>
+            <td><a href="/builtins/List#join">List.first</a></td>
+            <td>
+                <ul>
+                    <li>head</li>
+                    <li>get(0)</li>
+                    <li>[0]</li>
+                </ul>
+            </td>
+        </tr>
+        <tr>
+            <td><a href="/builtins/List#keepIf">List.keepIf</a></td>
+            <td>
+                <ul>
+                    <li>filter</li>
+                    <li>select</li>
+                    <li>copy_if</li>
+                    <li>remove-if-not</li>
+                </ul>
+            </td>
+        </tr>
+        <tr>
+            <td><a href="/builtins/List#dropIf">List.dropIf</a></td>
+            <td>
+                <ul>
+                    <li>reject</li>
+                    <li>remove_copy_if</li>
+                    <li>remove-if</li>
+                </ul>
+            </td>
+        </tr>
+        <tr>
+            <td><a href="/builtins/List#join">List.join</a></td>
+            <td>
+                <ul>
+                    <li>flatten</li>
+                    <li>flat</li>
+                    <li>concat</li>
+                    <li>smoosh</li>
+                </ul>
+            </td>
+        </tr>
+        <tr>
+            <td><a href="/builtins/List#joinMap">List.joinMap</a></td>
+            <td>
+                <ul>
+                    <li>filterMap</li>
+                    <li>filter_map</li>
+                </ul>
+            </td>
+        </tr>
+        <tr>
+            <td><a href="/builtins/List#keepOks">List.keepOks</a></td>
+            <td>
+                <ul>
+                    <li>compact</li>
+                    <li>filterMap(identity)</li>
+                </ul>
+            </td>
+        </tr>
+        <tr>
+            <td><a href="/builtins/Result#try">Result.try</a></td>
+            <td>
+                <ul>
+                    <li>bind</li>
+                    <li>flatMap</li>
+                    <li>andThen</li>
+                    <li>(&gt;&gt;=)</li>
+                </ul>
+            </td>
+        </tr>
+    </tbody>
+  </table>
+</body>
+
+</html>

--- a/www/public/homepage.css
+++ b/www/public/homepage.css
@@ -13,3 +13,29 @@ li {
         margin: 24px auto;
     }
 }
+
+/* Used on on the different-names page. */
+
+th, td {
+    text-align: left;
+    padding-right: 24px;
+}
+
+#different-names-body a, #different-names-body li {
+    font-family: monospace;
+    font-size: 16px;
+}
+
+#different-names-body li {
+    display: inline;
+}
+
+#different-names-body li:not(:last-of-type)::after {
+    /* This is injected via CSS for accessibility, so to a screen reader it's a normal <li> */
+    content: ",";
+}
+
+#different-names-body ul {
+    padding: 0;
+    list-style-type: none;
+}

--- a/www/public/styles.css
+++ b/www/public/styles.css
@@ -7,7 +7,6 @@
   --body-bg-color: #fdfdfd;
   --border-color: #e9e9e9;
   --faded-color: #4c4c4c;
-  --monospace-font;
   --font-sans: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif;
   --font-mono: SFMono-Regular, Consolas, "Liberation Mono", Menlo, Courier, monospace;
   --top-header-height: 67px;


### PR DESCRIPTION
Based on feedback from @georgesboris, adds a to tip builtin docs, to help beginners who are searching for e.g. `reduce`:

<img width="317" alt="Screen Shot 2022-10-23 at 6 03 49 PM" src="https://user-images.githubusercontent.com/1094080/197422186-123f9286-7ae1-4f51-9882-241f466b90e8.png">

If you click that link, it takes you to this new page:

<img width="911" alt="Screen Shot 2022-10-23 at 6 55 57 PM" src="https://user-images.githubusercontent.com/1094080/197422241-b5c483c0-7cff-4a4b-99df-62fa3746db53.png">

We can expand this in the future, but this is a start!