### PR TITLE
Do not attempt to lookup functions in `expect`s

### DIFF
--- a/crates/compiler/mono/src/ir.rs
+++ b/crates/compiler/mono/src/ir.rs
@@ -6368,10 +6368,13 @@ pub fn from_can<'a>(
                     ),
                     None => symbol,
                 };
-                lookups.push(symbol);
                 let res_layout = layout_cache.from_var(env.arena, var, env.subs);
                 let layout = return_on_layout_error!(env, res_layout, "Expect");
-                layouts.push(layout);
+                if !matches!(layout, Layout::LambdaSet(..)) {
+                    // Exclude functions from lookups
+                    lookups.push(symbol);
+                    layouts.push(layout);
+                }
             }
 
             let mut stmt = Stmt::Expect {
@@ -6421,10 +6424,13 @@ pub fn from_can<'a>(
                     ),
                     None => symbol,
                 };
-                lookups.push(symbol);
                 let res_layout = layout_cache.from_var(env.arena, var, env.subs);
                 let layout = return_on_layout_error!(env, res_layout, "Expect");
-                layouts.push(layout);
+                if !matches!(layout, Layout::LambdaSet(..)) {
+                    // Exclude functions from lookups
+                    lookups.push(symbol);
+                    layouts.push(layout);
+                }
             }
 
             let mut stmt = Stmt::ExpectFx {

--- a/crates/compiler/types/src/subs.rs
+++ b/crates/compiler/types/src/subs.rs
@@ -2115,6 +2115,26 @@ impl Subs {
     pub fn is_inhabited(&self, var: Variable) -> bool {
         is_inhabited(self, var)
     }
+
+    pub fn is_function(&self, mut var: Variable) -> bool {
+        loop {
+            match self.get_content_without_compacting(var) {
+                Content::FlexVar(_)
+                | Content::RigidVar(_)
+                | Content::FlexAbleVar(_, _)
+                | Content::RigidAbleVar(_, _)
+                | Content::RecursionVar { .. }
+                | Content::RangedNumber(_)
+                | Content::Error => return false,
+                Content::LambdaSet(_) => return true,
+                Content::Structure(FlatType::Func(..)) => return true,
+                Content::Structure(_) => return false,
+                Content::Alias(_, _, real_var, _) => {
+                    var = *real_var;
+                }
+            }
+        }
+    }
 }
 
 #[inline(always)]

--- a/crates/repl_expect/src/lib.rs
+++ b/crates/repl_expect/src/lib.rs
@@ -923,11 +923,32 @@ mod test {
 
                 When it failed, these variables had these values:
 
-                forcer : Str -> U8
-                forcer = <function>
-
                 case : Str
                 case = ""
+                "#
+            ),
+        );
+    }
+
+    #[test]
+    fn issue_i4389() {
+        run_expect_test(
+            indoc!(
+                r#"
+                interface Test exposes [] imports []
+
+                expect
+                    totalCount = \{} -> 1u8
+                    totalCount {} == 96u8
+                "#
+            ),
+            indoc!(
+                r#"
+                This expectation failed:
+
+                3│>  expect
+                4│>      totalCount = \{} -> 1u8
+                5│>      totalCount {} == 96u8
                 "#
             ),
         );

--- a/crates/repl_expect/src/run.rs
+++ b/crates/repl_expect/src/run.rs
@@ -18,6 +18,7 @@ use roc_mono::{ir::OptLevel, layout::Layout};
 use roc_region::all::Region;
 use roc_reporting::{error::expect::Renderer, report::RenderTarget};
 use roc_target::TargetInfo;
+use roc_types::subs::{Subs, Variable};
 use target_lexicon::Triple;
 
 pub(crate) struct ExpectMemory<'a> {
@@ -361,6 +362,27 @@ pub fn roc_dev_expect<'a>(
     )
 }
 
+fn split_expect_lookups(subs: &Subs, lookups: &[ExpectLookup]) -> (Vec<Symbol>, Vec<Variable>) {
+    lookups
+        .iter()
+        .filter_map(
+            |ExpectLookup {
+                 symbol,
+                 var,
+                 ability_info: _,
+             }| {
+                // mono will have dropped lookups that resolve to functions, so we should not keep
+                // them either.
+                if subs.is_function(*var) {
+                    None
+                } else {
+                    Some((*symbol, *var))
+                }
+            },
+        )
+        .unzip()
+}
+
 #[allow(clippy::too_many_arguments)]
 fn render_expect_failure<'a>(
     writer: &mut impl std::io::Write,
@@ -390,16 +412,7 @@ fn render_expect_failure<'a>(
     };
     let subs = arena.alloc(&mut data.subs);
 
-    let (symbols, variables): (Vec<_>, Vec<_>) = current
-        .iter()
-        .map(
-            |ExpectLookup {
-                 symbol,
-                 var,
-                 ability_info: _,
-             }| (*symbol, *var),
-        )
-        .unzip();
+    let (symbols, variables) = split_expect_lookups(subs, current);
 
     let (offset, expressions) = crate::get_values(
         target_info,


### PR DESCRIPTION
Functions are not useful to print in expect results, because they are only printed opaquely as `<function>`. Moreover, their transformation to closure sets during mono can be extremely lossy, up to and including the elision of symbols for function closure symbols. As such, simply do not attempt to lookup or print functions referenced in expects.

Closes #4389