### PR TITLE
Leave variables behind when converting `Type`s to variables

### DIFF
--- a/crates/compiler/can/src/expected.rs
+++ b/crates/compiler/can/src/expected.rs
@@ -38,6 +38,16 @@ impl<T> PExpected<T> {
         }
     }
 
+    #[inline(always)]
+    pub fn map<U>(self, f: impl FnOnce(T) -> U) -> PExpected<U> {
+        match self {
+            PExpected::NoExpectation(val) => PExpected::NoExpectation(f(val)),
+            PExpected::ForReason(reason, val, region) => {
+                PExpected::ForReason(reason, f(val), region)
+            }
+        }
+    }
+
     pub fn replace<U>(self, new: U) -> PExpected<U> {
         match self {
             PExpected::NoExpectation(_val) => PExpected::NoExpectation(new),
@@ -86,6 +96,17 @@ impl<T> Expected<T> {
                 Some(*region)
             }
             _ => None,
+        }
+    }
+
+    #[inline(always)]
+    pub fn map<U>(self, f: impl FnOnce(T) -> U) -> Expected<U> {
+        match self {
+            Expected::NoExpectation(val) => Expected::NoExpectation(f(val)),
+            Expected::ForReason(reason, val, region) => Expected::ForReason(reason, f(val), region),
+            Expected::FromAnnotation(pattern, size, source, val) => {
+                Expected::FromAnnotation(pattern, size, source, f(val))
+            }
         }
     }
 

--- a/crates/compiler/solve/src/solve.rs
+++ b/crates/compiler/solve/src/solve.rs
@@ -919,7 +919,7 @@ fn solve(
                     obligation_cache,
                     pools,
                     aliases,
-                    &expectation.get_type_ref(),
+                    expectation.get_type_ref(),
                 );
 
                 match unify(&mut UEnv::new(subs), actual, expected, Mode::EQ) {
@@ -1031,7 +1031,7 @@ fn solve(
                             obligation_cache,
                             pools,
                             aliases,
-                            &expectation.get_type_ref(),
+                            expectation.get_type_ref(),
                         );
 
                         match unify(&mut UEnv::new(subs), actual, expected, Mode::EQ) {
@@ -1138,7 +1138,7 @@ fn solve(
                     obligation_cache,
                     pools,
                     aliases,
-                    &expectation.get_type_ref(),
+                    expectation.get_type_ref(),
                 );
 
                 let mode = match constraint {
@@ -1349,7 +1349,7 @@ fn solve(
                             obligation_cache,
                             pools,
                             aliases,
-                            &cell,
+                            cell,
                         );
                         tys.push(Type::Variable(actual));
                     }
@@ -1487,7 +1487,7 @@ fn solve(
                     obligation_cache,
                     pools,
                     aliases,
-                    &expected_type,
+                    expected_type,
                 );
 
                 let real_content = subs.get_content_without_compacting(real_var);

--- a/crates/compiler/solve/src/solve.rs
+++ b/crates/compiler/solve/src/solve.rs
@@ -911,7 +911,7 @@ fn solve(
                 );
 
                 let expectation = &constraints.expectations[expectation_index.index()];
-                let expected = type_to_var(
+                let expected = type_cell_to_var(
                     subs,
                     rank,
                     problems,
@@ -919,7 +919,7 @@ fn solve(
                     obligation_cache,
                     pools,
                     aliases,
-                    expectation.get_type_ref(),
+                    &expectation.get_type_ref(),
                 );
 
                 match unify(&mut UEnv::new(subs), actual, expected, Mode::EQ) {
@@ -961,7 +961,7 @@ fn solve(
                             *region,
                             category.clone(),
                             actual_type,
-                            expectation.clone().replace(expected_type),
+                            expectation.replace_ref(expected_type),
                         );
 
                         problems.push(problem);
@@ -1023,7 +1023,7 @@ fn solve(
                         let actual = deep_copy_var_in(subs, rank, pools, var, arena);
                         let expectation = &constraints.expectations[expectation_index.index()];
 
-                        let expected = type_to_var(
+                        let expected = type_cell_to_var(
                             subs,
                             rank,
                             problems,
@@ -1031,7 +1031,7 @@ fn solve(
                             obligation_cache,
                             pools,
                             aliases,
-                            expectation.get_type_ref(),
+                            &expectation.get_type_ref(),
                         );
 
                         match unify(&mut UEnv::new(subs), actual, expected, Mode::EQ) {
@@ -1078,7 +1078,7 @@ fn solve(
                                     *region,
                                     Category::Lookup(*symbol),
                                     actual_type,
-                                    expectation.clone().replace(expected_type),
+                                    expectation.replace_ref(expected_type),
                                 );
 
                                 problems.push(problem);
@@ -1130,7 +1130,7 @@ fn solve(
                 );
 
                 let expectation = &constraints.pattern_expectations[expectation_index.index()];
-                let expected = type_to_var(
+                let expected = type_cell_to_var(
                     subs,
                     rank,
                     problems,
@@ -1138,7 +1138,7 @@ fn solve(
                     obligation_cache,
                     pools,
                     aliases,
-                    expectation.get_type_ref(),
+                    &expectation.get_type_ref(),
                 );
 
                 let mode = match constraint {
@@ -1185,7 +1185,7 @@ fn solve(
                             *region,
                             category.clone(),
                             actual_type,
-                            expectation.clone().replace(expected_type),
+                            expectation.replace_ref(expected_type),
                         );
 
                         problems.push(problem);
@@ -1479,7 +1479,7 @@ fn solve(
                     real_var,
                 );
 
-                let branches_var = type_to_var(
+                let branches_var = type_cell_to_var(
                     subs,
                     rank,
                     problems,
@@ -1487,7 +1487,7 @@ fn solve(
                     obligation_cache,
                     pools,
                     aliases,
-                    expected_type,
+                    &expected_type,
                 );
 
                 let real_content = subs.get_content_without_compacting(real_var);


### PR DESCRIPTION
This is part one of addressing the present issues with emplacing type directly where type variables should be reused. Now, when an `Index<Type>` is converted to a variable in solving, we leave the converted variable in the `Type`'s place. Specifically, we keep an index to a `Cell<Type>`.

Note that this transformation is only temporary, it will be removed once we merge this with the `Type` SoA representation, but it is needed in the meantime as I transform the `Constrain` API to get rid of type-emplacement.