### PR TITLE
Have most constraining APIs take a type index rather than `Type`

### DIFF
--- a/crates/compiler/can/src/constraint.rs
+++ b/crates/compiler/can/src/constraint.rs
@@ -281,14 +281,12 @@ impl Constraints {
 
     pub fn equal_types_with_storage(
         &mut self,
-        typ: Type,
-        expected: Expected<Type>,
+        type_index: TypeOrVar,
+        expected_index: ExpectedTypeIndex,
         category: Category,
         region: Region,
         storage_var: Variable,
     ) -> Constraint {
-        let type_index = self.push_type(typ);
-        let expected_index = Index::push_new(&mut self.expectations, expected.map(Cell::new));
         let category_index = Self::push_category(self, category);
 
         let equal = Constraint::Eq(Eq(type_index, expected_index, category_index, region));

--- a/crates/compiler/can/src/constraint.rs
+++ b/crates/compiler/can/src/constraint.rs
@@ -215,6 +215,10 @@ impl Constraints {
         Index::push_new(&mut self.expectations, expected.map(Cell::new))
     }
 
+    pub fn push_pat_expected_type(&mut self, expected: PExpected<Type>) -> PExpectedTypeIndex {
+        Index::push_new(&mut self.pattern_expectations, expected.map(Cell::new))
+    }
+
     #[inline(always)]
     pub fn push_category(&mut self, category: Category) -> Index<Category> {
         match category {
@@ -306,14 +310,11 @@ impl Constraints {
 
     pub fn equal_pattern_types(
         &mut self,
-        typ: Type,
-        expected: PExpected<Type>,
+        type_index: TypeOrVar,
+        expected_index: PExpectedTypeIndex,
         category: PatternCategory,
         region: Region,
     ) -> Constraint {
-        let type_index = self.push_type(typ);
-        let expected_index =
-            Index::push_new(&mut self.pattern_expectations, expected.map(Cell::new));
         let category_index = Self::push_pattern_category(self, category);
 
         Constraint::Pattern(type_index, expected_index, category_index, region)

--- a/crates/compiler/can/src/constraint.rs
+++ b/crates/compiler/can/src/constraint.rs
@@ -336,25 +336,20 @@ impl Constraints {
         Constraint::IsOpenType(type_index)
     }
 
-    pub fn includes_tag<I>(
+    pub fn includes_tag(
         &mut self,
-        typ: Type,
+        type_index: TypeOrVar,
         tag_name: TagName,
-        types: I,
+        payloads: Slice<Variable>,
         category: PatternCategory,
         region: Region,
-    ) -> Constraint
-    where
-        I: IntoIterator<Item = Type>,
-    {
-        let type_index = Index::push_new(&mut self.types, Cell::new(typ));
+    ) -> Constraint {
         let category_index = Index::push_new(&mut self.pattern_categories, category);
-        let types_slice = Slice::extend_new(&mut self.types, types.into_iter().map(Cell::new));
 
         let includes_tag = IncludesTag {
             type_index,
             tag_name,
-            types: types_slice,
+            types: payloads,
             pattern_category: category_index,
             region,
         };
@@ -364,7 +359,7 @@ impl Constraints {
         Constraint::IncludesTag(includes_tag_index)
     }
 
-    fn variable_slice<I>(&mut self, it: I) -> Slice<Variable>
+    pub fn variable_slice<I>(&mut self, it: I) -> Slice<Variable>
     where
         I: IntoIterator<Item = Variable>,
     {
@@ -795,9 +790,9 @@ pub struct LetConstraint {
 
 #[derive(Debug, Clone)]
 pub struct IncludesTag {
-    pub type_index: TypeIndex,
+    pub type_index: TypeOrVar,
     pub tag_name: TagName,
-    pub types: Slice<Cell<Type>>,
+    pub types: Slice<Variable>,
     pub pattern_category: Index<PatternCategory>,
     pub region: Region,
 }

--- a/crates/compiler/can/src/constraint.rs
+++ b/crates/compiler/can/src/constraint.rs
@@ -332,9 +332,7 @@ impl Constraints {
         Constraint::PatternPresence(type_index, expected_index, category_index, region)
     }
 
-    pub fn is_open_type(&mut self, typ: Type) -> Constraint {
-        let type_index = self.push_type(typ);
-
+    pub fn is_open_type(&mut self, type_index: TypeOrVar) -> Constraint {
         Constraint::IsOpenType(type_index)
     }
 

--- a/crates/compiler/can/src/constraint.rs
+++ b/crates/compiler/can/src/constraint.rs
@@ -322,14 +322,11 @@ impl Constraints {
 
     pub fn pattern_presence(
         &mut self,
-        typ: Type,
-        expected: PExpected<Type>,
+        type_index: TypeOrVar,
+        expected_index: PExpectedTypeIndex,
         category: PatternCategory,
         region: Region,
     ) -> Constraint {
-        let type_index = self.push_type(typ);
-        let expected_index =
-            Index::push_new(&mut self.pattern_expectations, expected.map(Cell::new));
         let category_index = Index::push_new(&mut self.pattern_categories, category);
 
         Constraint::PatternPresence(type_index, expected_index, category_index, region)

--- a/crates/compiler/can/src/constraint.rs
+++ b/crates/compiler/can/src/constraint.rs
@@ -600,12 +600,11 @@ impl Constraints {
 
     pub fn store(
         &mut self,
-        typ: Type,
+        type_index: TypeOrVar,
         variable: Variable,
         filename: &'static str,
         line_number: u32,
     ) -> Constraint {
-        let type_index = self.push_type(typ);
         let string_index = Index::push_new(&mut self.strings, filename);
 
         Constraint::Store(type_index, variable, string_index, line_number)

--- a/crates/compiler/can/src/constraint.rs
+++ b/crates/compiler/can/src/constraint.rs
@@ -610,18 +610,6 @@ impl Constraints {
         Constraint::Store(type_index, variable, string_index, line_number)
     }
 
-    pub fn store_index(
-        &mut self,
-        type_index: TypeOrVar,
-        variable: Variable,
-        filename: &'static str,
-        line_number: u32,
-    ) -> Constraint {
-        let string_index = Index::push_new(&mut self.strings, filename);
-
-        Constraint::Store(type_index, variable, string_index, line_number)
-    }
-
     pub fn exhaustive(
         &mut self,
         real_var: Variable,

--- a/crates/compiler/can/src/constraint.rs
+++ b/crates/compiler/can/src/constraint.rs
@@ -269,12 +269,11 @@ impl Constraints {
     pub fn equal_types_var(
         &mut self,
         var: Variable,
-        expected: Expected<Type>,
+        expected_index: ExpectedTypeIndex,
         category: Category,
         region: Region,
     ) -> Constraint {
         let type_index = Self::push_type_variable(var);
-        let expected_index = Index::push_new(&mut self.expectations, expected.map(Cell::new));
         let category_index = Self::push_category(self, category);
 
         Constraint::Eq(Eq(type_index, expected_index, category_index, region))

--- a/crates/compiler/can/src/constraint.rs
+++ b/crates/compiler/can/src/constraint.rs
@@ -211,7 +211,7 @@ impl Constraints {
         EitherIndex::from_right(index)
     }
 
-    pub fn push_expected_type(&mut self, expected: Expected<Type>) -> Index<Expected<Cell<Type>>> {
+    pub fn push_expected_type(&mut self, expected: Expected<Type>) -> ExpectedTypeIndex {
         Index::push_new(&mut self.expectations, expected.map(Cell::new))
     }
 
@@ -256,13 +256,11 @@ impl Constraints {
 
     pub fn equal_types(
         &mut self,
-        typ: Type,
-        expected: Expected<Type>,
+        type_index: TypeOrVar,
+        expected_index: ExpectedTypeIndex,
         category: Category,
         region: Region,
     ) -> Constraint {
-        let type_index = self.push_type(typ);
-        let expected_index = Index::push_new(&mut self.expectations, expected.map(Cell::new));
         let category_index = Self::push_category(self, category);
 
         Constraint::Eq(Eq(type_index, expected_index, category_index, region))

--- a/crates/compiler/can/src/constraint.rs
+++ b/crates/compiler/can/src/constraint.rs
@@ -558,14 +558,10 @@ impl Constraints {
     pub fn lookup(
         &mut self,
         symbol: Symbol,
-        expected: Expected<Type>,
+        expected_index: ExpectedTypeIndex,
         region: Region,
     ) -> Constraint {
-        Constraint::Lookup(
-            symbol,
-            Index::push_new(&mut self.expectations, expected.map(Cell::new)),
-            region,
-        )
+        Constraint::Lookup(symbol, expected_index, region)
     }
 
     pub fn contains_save_the_environment(&self, constraint: &Constraint) -> bool {

--- a/crates/compiler/constrain/src/builtins.rs
+++ b/crates/compiler/constrain/src/builtins.rs
@@ -132,20 +132,23 @@ pub fn single_quote_literal(
         Category::Character,
     );
 
+    let num_type_index = constraints.push_type(num_type);
+    let expect_precision_var = constraints.push_expected_type(ForReason(
+        reason,
+        num_int(Type::Variable(precision_var)),
+        region,
+    ));
+
     constrs.extend([
+        constraints.equal_types(
+            num_type_index,
+            expect_precision_var,
+            Category::Character,
+            region,
+        ),
         {
-            let type_index = constraints.push_type(num_type.clone());
-            let expected_index = constraints.push_expected_type(ForReason(
-                reason,
-                num_int(Type::Variable(precision_var)),
-                region,
-            ));
-            constraints.equal_types(type_index, expected_index, Category::Character, region)
-        },
-        {
-            let type_index = constraints.push_type(num_type);
             let expected_index = constraints.push_expected_type(expected);
-            constraints.equal_types(type_index, expected_index, Category::Character, region)
+            constraints.equal_types(num_type_index, expected_index, Category::Character, region)
         },
     ]);
 
@@ -175,20 +178,18 @@ pub fn float_literal(
         Category::Frac,
     );
 
+    let num_type_index = constraints.push_type(num_type);
+    let expect_precision_var = constraints.push_expected_type(ForReason(
+        reason,
+        num_float(Type::Variable(precision_var)),
+        region,
+    ));
+
     constrs.extend([
+        constraints.equal_types(num_type_index, expect_precision_var, Category::Frac, region),
         {
-            let type_index = constraints.push_type(num_type.clone());
-            let expected_index = constraints.push_expected_type(ForReason(
-                reason,
-                num_float(Type::Variable(precision_var)),
-                region,
-            ));
-            constraints.equal_types(type_index, expected_index, Category::Frac, region)
-        },
-        {
-            let type_index = constraints.push_type(num_type);
             let expected_index = constraints.push_expected_type(expected);
-            constraints.equal_types(type_index, expected_index, Category::Frac, region)
+            constraints.equal_types(num_type_index, expected_index, Category::Frac, region)
         },
     ]);
 

--- a/crates/compiler/constrain/src/builtins.rs
+++ b/crates/compiler/constrain/src/builtins.rs
@@ -32,8 +32,10 @@ pub fn add_numeric_bound_constr(
         NumericBound::FloatExact(width) => {
             let actual_type = Variable(float_width_to_variable(width));
             let expected = Expected::ForReason(Reason::NumericLiteralSuffix, actual_type, region);
+            let type_index = constraints.push_type(Variable(num_var));
+            let expected_index = constraints.push_expected_type(expected);
             let because_suffix =
-                constraints.equal_types(Variable(num_var), expected, category, region);
+                constraints.equal_types(type_index, expected_index, category, region);
 
             num_constraints.extend([because_suffix]);
 
@@ -42,8 +44,10 @@ pub fn add_numeric_bound_constr(
         NumericBound::IntExact(width) => {
             let actual_type = Variable(int_lit_width_to_variable(width));
             let expected = Expected::ForReason(Reason::NumericLiteralSuffix, actual_type, region);
+            let type_index = constraints.push_type(Variable(num_var));
+            let expected_index = constraints.push_expected_type(expected);
             let because_suffix =
-                constraints.equal_types(Variable(num_var), expected, category, region);
+                constraints.equal_types(type_index, expected_index, category, region);
 
             num_constraints.extend([because_suffix]);
 
@@ -52,7 +56,9 @@ pub fn add_numeric_bound_constr(
         NumericBound::Range(range) => {
             let actual_type = Variable(precision_var);
             let expected = Expected::NoExpectation(RangedNumber(range));
-            let constr = constraints.equal_types(actual_type, expected, category, region);
+            let type_index = constraints.push_type(actual_type);
+            let expected_index = constraints.push_expected_type(expected);
+            let constr = constraints.equal_types(type_index, expected_index, category, region);
 
             num_constraints.extend([constr]);
 
@@ -84,14 +90,19 @@ pub fn int_literal(
         Category::Num,
     );
 
+    let num_type_index = constraints.push_type(num_type);
+    let expect_precision_var = constraints.push_expected_type(ForReason(
+        reason,
+        num_int(Type::Variable(precision_var)),
+        region,
+    ));
+
     constrs.extend([
-        constraints.equal_types(
-            num_type.clone(),
-            ForReason(reason, num_int(Type::Variable(precision_var)), region),
-            Category::Int,
-            region,
-        ),
-        constraints.equal_types(num_type, expected, Category::Int, region),
+        constraints.equal_types(num_type_index, expect_precision_var, Category::Int, region),
+        {
+            let expected_index = constraints.push_expected_type(expected);
+            constraints.equal_types(num_type_index, expected_index, Category::Int, region)
+        },
     ]);
 
     // TODO the precision_var is not part of the exists here; for float it is. Which is correct?
@@ -122,13 +133,20 @@ pub fn single_quote_literal(
     );
 
     constrs.extend([
-        constraints.equal_types(
-            num_type.clone(),
-            ForReason(reason, num_int(Type::Variable(precision_var)), region),
-            Category::Character,
-            region,
-        ),
-        constraints.equal_types(num_type, expected, Category::Character, region),
+        {
+            let type_index = constraints.push_type(num_type.clone());
+            let expected_index = constraints.push_expected_type(ForReason(
+                reason,
+                num_int(Type::Variable(precision_var)),
+                region,
+            ));
+            constraints.equal_types(type_index, expected_index, Category::Character, region)
+        },
+        {
+            let type_index = constraints.push_type(num_type);
+            let expected_index = constraints.push_expected_type(expected);
+            constraints.equal_types(type_index, expected_index, Category::Character, region)
+        },
     ]);
 
     let and_constraint = constraints.and_constraint(constrs);
@@ -158,13 +176,20 @@ pub fn float_literal(
     );
 
     constrs.extend([
-        constraints.equal_types(
-            num_type.clone(),
-            ForReason(reason, num_float(Type::Variable(precision_var)), region),
-            Category::Frac,
-            region,
-        ),
-        constraints.equal_types(num_type, expected, Category::Frac, region),
+        {
+            let type_index = constraints.push_type(num_type.clone());
+            let expected_index = constraints.push_expected_type(ForReason(
+                reason,
+                num_float(Type::Variable(precision_var)),
+                region,
+            ));
+            constraints.equal_types(type_index, expected_index, Category::Frac, region)
+        },
+        {
+            let type_index = constraints.push_type(num_type);
+            let expected_index = constraints.push_expected_type(expected);
+            constraints.equal_types(type_index, expected_index, Category::Frac, region)
+        },
     ]);
 
     let and_constraint = constraints.and_constraint(constrs);
@@ -190,7 +215,9 @@ pub fn num_literal(
         Category::Num,
     );
 
-    constrs.extend([constraints.equal_types(num_type, expected, Category::Num, region)]);
+    let type_index = constraints.push_type(num_type);
+    let expected_index = constraints.push_expected_type(expected);
+    constrs.extend([constraints.equal_types(type_index, expected_index, Category::Num, region)]);
 
     let and_constraint = constraints.and_constraint(constrs);
     constraints.exists([num_var], and_constraint)

--- a/crates/compiler/constrain/src/expr.rs
+++ b/crates/compiler/constrain/src/expr.rs
@@ -1642,7 +1642,7 @@ fn constrain_function_def(
                 AnnotationSource::TypedBody {
                     region: annotation.region,
                 },
-                ret_type.clone(),
+                ret_type,
             );
 
             let ret_constraint = constrain_expr(
@@ -2366,7 +2366,7 @@ fn constrain_typed_def(
                 AnnotationSource::TypedBody {
                     region: annotation.region,
                 },
-                ret_type.clone(),
+                ret_type,
             );
 
             let ret_constraint = constrain_expr(
@@ -3140,7 +3140,7 @@ fn constraint_recursive_function(
                 env,
                 loc_body_expr.region,
                 &loc_body_expr.value,
-                NoExpectation(ret_type.clone()),
+                NoExpectation(ret_type),
             );
             let expr_con = attach_resolution_constraints(constraints, env, expr_con);
 

--- a/crates/compiler/constrain/src/expr.rs
+++ b/crates/compiler/constrain/src/expr.rs
@@ -1966,16 +1966,17 @@ fn constrain_when_branch_help(
             state.headers.extend(partial_state.headers);
         } else {
             // Make sure the bound variables in the patterns on the same branch agree in their types.
-            for (sym, typ1) in state.headers.iter() {
-                if let Some(typ2) = partial_state.headers.get(sym) {
-                    let type_index = constraints.push_type(typ1.value.clone());
-                    let expected_index =
-                        constraints.push_expected_type(Expected::NoExpectation(typ2.value.clone()));
+            for (sym, all_branches_bound_typ) in state.headers.iter() {
+                if let Some(this_bound_typ) = partial_state.headers.get(sym) {
+                    let whole_typ = constraints.push_type(all_branches_bound_typ.value.clone());
+                    let this_typ = constraints
+                        .push_expected_type(Expected::NoExpectation(this_bound_typ.value.clone()));
+
                     state.constraints.push(constraints.equal_types(
-                        type_index,
-                        expected_index,
+                        whole_typ,
+                        this_typ,
                         Category::When,
-                        typ2.region,
+                        this_bound_typ.region,
                     ));
                 }
 

--- a/crates/compiler/constrain/src/expr.rs
+++ b/crates/compiler/constrain/src/expr.rs
@@ -1632,7 +1632,7 @@ fn constrain_function_def(
             let defs_constraint = constraints.and_constraint(argument_pattern_state.constraints);
 
             let signature_closure_type = *signature_closure_type.clone();
-            let signature_index = constraints.push_type(signature.clone());
+            let signature_index = constraints.push_type(signature);
             let cons = [
                 constraints.let_constraint(
                     [],

--- a/crates/compiler/constrain/src/expr.rs
+++ b/crates/compiler/constrain/src/expr.rs
@@ -1680,7 +1680,7 @@ fn constrain_function_def(
                     Category::ClosureSize,
                     region,
                 ),
-                constraints.store_index(signature_index, expr_var, std::file!(), std::line!()),
+                constraints.store(signature_index, expr_var, std::file!(), std::line!()),
                 constraints.store(ret_type_index, ret_var, std::file!(), std::line!()),
                 closure_constraint,
             ];
@@ -2404,8 +2404,8 @@ fn constrain_typed_def(
                     Category::ClosureSize,
                     region,
                 ),
-                constraints.store_index(signature_index, *fn_var, std::file!(), std::line!()),
-                constraints.store_index(signature_index, expr_var, std::file!(), std::line!()),
+                constraints.store(signature_index, *fn_var, std::file!(), std::line!()),
+                constraints.store(signature_index, expr_var, std::file!(), std::line!()),
                 constraints.store(ret_type_index, ret_var, std::file!(), std::line!()),
                 closure_constraint,
             ];
@@ -3163,7 +3163,7 @@ fn constraint_recursive_function(
                 },
                 // "fn_var is equal to the closure's type" - fn_var is used in code gen
                 // Store type into AST vars. We use Store so errors aren't reported twice
-                constraints.store_index(signature_index, expr_var, std::file!(), std::line!()),
+                constraints.store(signature_index, expr_var, std::file!(), std::line!()),
                 constraints.store(ret_type_index, ret_var, std::file!(), std::line!()),
                 closure_constraint,
             ];
@@ -3582,13 +3582,8 @@ fn rec_defs_help(
                             ),
                             // "fn_var is equal to the closure's type" - fn_var is used in code gen
                             // Store type into AST vars. We use Store so errors aren't reported twice
-                            constraints.store_index(
-                                signature_index,
-                                *fn_var,
-                                std::file!(),
-                                std::line!(),
-                            ),
-                            constraints.store_index(
+                            constraints.store(signature_index, *fn_var, std::file!(), std::line!()),
+                            constraints.store(
                                 signature_index,
                                 expr_var,
                                 std::file!(),

--- a/crates/compiler/constrain/src/module.rs
+++ b/crates/compiler/constrain/src/module.rs
@@ -69,18 +69,16 @@ fn constrain_symbols_from_requires(
                 // Otherwise, this symbol comes from an app module - we want to check that the type
                 // provided by the app is in fact what the package module requires.
                 let arity = loc_type.value.arity();
-                let provided_eq_requires_constr = constraints.lookup(
-                    loc_symbol.value,
-                    Expected::FromAnnotation(
-                        loc_symbol.map(|&s| Pattern::Identifier(s)),
-                        arity,
-                        AnnotationSource::RequiredSymbol {
-                            region: loc_type.region,
-                        },
-                        loc_type.value,
-                    ),
-                    loc_type.region,
-                );
+                let expected = constraints.push_expected_type(Expected::FromAnnotation(
+                    loc_symbol.map(|&s| Pattern::Identifier(s)),
+                    arity,
+                    AnnotationSource::RequiredSymbol {
+                        region: loc_type.region,
+                    },
+                    loc_type.value,
+                ));
+                let provided_eq_requires_constr =
+                    constraints.lookup(loc_symbol.value, expected, loc_type.region);
                 constraints.and_constraint([provided_eq_requires_constr, constraint])
             }
         })

--- a/crates/compiler/constrain/src/module.rs
+++ b/crates/compiler/constrain/src/module.rs
@@ -122,11 +122,14 @@ pub fn frontload_ability_constraints(
             let rigid_variables = vars.rigid_vars.iter().chain(vars.able_vars.iter()).copied();
             let infer_variables = vars.flex_vars.iter().copied();
 
+            let signature_expectation =
+                constraints.push_expected_type(Expected::NoExpectation(signature.clone()));
+
             def_pattern_state
                 .constraints
                 .push(constraints.equal_types_var(
                     signature_var,
-                    Expected::NoExpectation(signature.clone()),
+                    signature_expectation,
                     Category::Storage(file!(), line!()),
                     Region::zero(),
                 ));

--- a/crates/compiler/constrain/src/pattern.rs
+++ b/crates/compiler/constrain/src/pattern.rs
@@ -347,7 +347,7 @@ pub fn constrain_pattern(
             // Link the free num var with the int var and our expectation.
             let int_type = builtins::num_int(Type::Variable(precision_var));
 
-            let num_type_index = constraints.push_type(num_type.clone());
+            let num_type_index = constraints.push_type(num_type);
 
             state.constraints.push({
                 let expected_index =

--- a/crates/compiler/constrain/src/pattern.rs
+++ b/crates/compiler/constrain/src/pattern.rs
@@ -182,9 +182,11 @@ pub fn constrain_pattern(
             //     _ -> ""
             // so, we know that "x" (in this case, a tag union) must be open.
             if could_be_a_tag_union(expected.get_type_ref()) {
+                let type_index = constraints.push_type(expected.get_type());
+
                 state
                     .delayed_is_open_constraints
-                    .push(constraints.is_open_type(expected.get_type()));
+                    .push(constraints.is_open_type(type_index));
             }
         }
         UnsupportedPattern(_) | MalformedPattern(_, _) | OpaqueNotInScope(..) => {
@@ -193,9 +195,11 @@ pub fn constrain_pattern(
 
         Identifier(symbol) | Shadowed(_, _, symbol) => {
             if could_be_a_tag_union(expected.get_type_ref()) {
+                let type_index = constraints.push_type(expected.get_type_ref().clone());
+
                 state
                     .delayed_is_open_constraints
-                    .push(constraints.is_open_type(expected.get_type_ref().clone()));
+                    .push(constraints.is_open_type(type_index));
             }
 
             state.headers.insert(
@@ -212,9 +216,9 @@ pub fn constrain_pattern(
             specializes: _,
         } => {
             if could_be_a_tag_union(expected.get_type_ref()) {
-                state
-                    .constraints
-                    .push(constraints.is_open_type(expected.get_type_ref().clone()));
+                let type_index = constraints.push_type(expected.get_type_ref().clone());
+
+                state.constraints.push(constraints.is_open_type(type_index));
             }
 
             state.headers.insert(

--- a/crates/compiler/constrain/src/pattern.rs
+++ b/crates/compiler/constrain/src/pattern.rs
@@ -263,12 +263,12 @@ pub fn constrain_pattern(
             // Link the free num var with the int var and our expectation.
             let int_type = builtins::num_int(Type::Variable(precision_var));
 
-            state.constraints.push(constraints.equal_types(
-                num_type.clone(), // TODO check me if something breaks!
-                Expected::NoExpectation(int_type),
-                Category::Int,
-                region,
-            ));
+            state.constraints.push({
+                let type_index = constraints.push_type(num_type.clone()); // TODO check me if something breaks!
+                let expected_index =
+                    constraints.push_expected_type(Expected::NoExpectation(int_type));
+                constraints.equal_types(type_index, expected_index, Category::Int, region)
+            });
 
             // Also constrain the pattern against the num var, again to reuse aliases if they're present.
             state.constraints.push(constraints.equal_pattern_types(
@@ -295,12 +295,12 @@ pub fn constrain_pattern(
             // Link the free num var with the float var and our expectation.
             let float_type = builtins::num_float(Type::Variable(precision_var));
 
-            state.constraints.push(constraints.equal_types(
-                num_type.clone(), // TODO check me if something breaks!
-                Expected::NoExpectation(float_type),
-                Category::Frac,
-                region,
-            ));
+            state.constraints.push({
+                let type_index = constraints.push_type(num_type.clone()); // TODO check me if something breaks!
+                let expected_index =
+                    constraints.push_expected_type(Expected::NoExpectation(float_type));
+                constraints.equal_types(type_index, expected_index, Category::Frac, region)
+            });
 
             // Also constrain the pattern against the num var, again to reuse aliases if they're present.
             state.constraints.push(constraints.equal_pattern_types(
@@ -336,12 +336,17 @@ pub fn constrain_pattern(
             // Link the free num var with the int var and our expectation.
             let int_type = builtins::num_int(Type::Variable(precision_var));
 
-            state.constraints.push(constraints.equal_types(
-                num_type.clone(), // TODO check me if something breaks!
-                Expected::NoExpectation(int_type),
-                Category::Int,
-                region,
-            ));
+            state.constraints.push({
+                let type_index = constraints.push_type(num_type.clone());
+                let expected_index =
+                    constraints.push_expected_type(Expected::NoExpectation(int_type));
+                constraints.equal_types(
+                    type_index, // TODO check me if something breaks!
+                    expected_index,
+                    Category::Int,
+                    region,
+                )
+            });
 
             // Also constrain the pattern against the num var, again to reuse aliases if they're present.
             state.constraints.push(constraints.equal_pattern_types(
@@ -452,9 +457,12 @@ pub fn constrain_pattern(
 
             let record_type = Type::Record(field_types, TypeExtension::from_type(ext_type));
 
+            let whole_var_index = constraints.push_type(Type::Variable(*whole_var));
+            let expected_record =
+                constraints.push_expected_type(Expected::NoExpectation(record_type));
             let whole_con = constraints.equal_types(
-                Type::Variable(*whole_var),
-                Expected::NoExpectation(record_type),
+                whole_var_index,
+                expected_record,
                 Category::Storage(std::file!(), std::line!()),
                 region,
             );
@@ -561,9 +569,12 @@ pub fn constrain_pattern(
             );
 
             // Next, link `whole_var` to the opaque type of "@Id who"
+            let whole_var_index = constraints.push_type(Type::Variable(*whole_var));
+            let expected_opaque =
+                constraints.push_expected_type(Expected::NoExpectation(opaque_type));
             let whole_con = constraints.equal_types(
-                Type::Variable(*whole_var),
-                Expected::NoExpectation(opaque_type),
+                whole_var_index,
+                expected_opaque,
                 Category::Storage(std::file!(), std::line!()),
                 region,
             );

--- a/crates/compiler/constrain/src/pattern.rs
+++ b/crates/compiler/constrain/src/pattern.rs
@@ -506,12 +506,12 @@ pub fn constrain_pattern(
             tag_name,
             arguments,
         } => {
-            let mut argument_types = Vec::with_capacity(arguments.len());
+            let argument_types = constraints.variable_slice(arguments.iter().map(|(var, _)| *var));
+
             for (index, (pattern_var, loc_pattern)) in arguments.iter().enumerate() {
                 state.vars.push(*pattern_var);
 
                 let pattern_type = Type::Variable(*pattern_var);
-                argument_types.push(pattern_type.clone());
 
                 let expected = PExpected::ForReason(
                     PReason::TagArg {
@@ -532,11 +532,12 @@ pub fn constrain_pattern(
             }
 
             let pat_category = PatternCategory::Ctor(tag_name.clone());
+            let expected_type = constraints.push_type(expected.get_type_ref().clone());
 
             let whole_con = constraints.includes_tag(
-                expected.clone().get_type(),
+                expected_type,
                 tag_name.clone(),
-                argument_types.clone(),
+                argument_types,
                 pat_category.clone(),
                 region,
             );

--- a/crates/compiler/constrain/src/pattern.rs
+++ b/crates/compiler/constrain/src/pattern.rs
@@ -238,6 +238,9 @@ pub fn constrain_pattern(
                 region,
                 Category::Num,
             );
+            let num_type = constraints.push_type(num_type);
+
+            let expected = constraints.push_pat_expected_type(expected);
 
             state.constraints.push(constraints.equal_pattern_types(
                 num_type,
@@ -259,18 +262,19 @@ pub fn constrain_pattern(
                 region,
                 Category::Int,
             );
+            let num_type = constraints.push_type(num_type);
 
             // Link the free num var with the int var and our expectation.
             let int_type = builtins::num_int(Type::Variable(precision_var));
 
             state.constraints.push({
-                let type_index = constraints.push_type(num_type.clone()); // TODO check me if something breaks!
                 let expected_index =
                     constraints.push_expected_type(Expected::NoExpectation(int_type));
-                constraints.equal_types(type_index, expected_index, Category::Int, region)
+                constraints.equal_types(num_type, expected_index, Category::Int, region)
             });
 
             // Also constrain the pattern against the num var, again to reuse aliases if they're present.
+            let expected = constraints.push_pat_expected_type(expected);
             state.constraints.push(constraints.equal_pattern_types(
                 num_type,
                 expected,
@@ -294,17 +298,18 @@ pub fn constrain_pattern(
 
             // Link the free num var with the float var and our expectation.
             let float_type = builtins::num_float(Type::Variable(precision_var));
+            let num_type_index = constraints.push_type(num_type); // TODO check me if something breaks!
 
             state.constraints.push({
-                let type_index = constraints.push_type(num_type.clone()); // TODO check me if something breaks!
                 let expected_index =
                     constraints.push_expected_type(Expected::NoExpectation(float_type));
-                constraints.equal_types(type_index, expected_index, Category::Frac, region)
+                constraints.equal_types(num_type_index, expected_index, Category::Frac, region)
             });
 
             // Also constrain the pattern against the num var, again to reuse aliases if they're present.
+            let expected = constraints.push_pat_expected_type(expected);
             state.constraints.push(constraints.equal_pattern_types(
-                num_type, // TODO check me if something breaks!
+                num_type_index,
                 expected,
                 PatternCategory::Float,
                 region,
@@ -312,8 +317,10 @@ pub fn constrain_pattern(
         }
 
         StrLiteral(_) => {
+            let str_type = constraints.push_type(builtins::str_type());
+            let expected = constraints.push_pat_expected_type(expected);
             state.constraints.push(constraints.equal_pattern_types(
-                builtins::str_type(),
+                str_type,
                 expected,
                 PatternCategory::Str,
                 region,
@@ -336,12 +343,13 @@ pub fn constrain_pattern(
             // Link the free num var with the int var and our expectation.
             let int_type = builtins::num_int(Type::Variable(precision_var));
 
+            let num_type_index = constraints.push_type(num_type.clone());
+
             state.constraints.push({
-                let type_index = constraints.push_type(num_type.clone());
                 let expected_index =
                     constraints.push_expected_type(Expected::NoExpectation(int_type));
                 constraints.equal_types(
-                    type_index, // TODO check me if something breaks!
+                    num_type_index, // TODO check me if something breaks!
                     expected_index,
                     Category::Int,
                     region,
@@ -349,8 +357,9 @@ pub fn constrain_pattern(
             });
 
             // Also constrain the pattern against the num var, again to reuse aliases if they're present.
+            let expected = constraints.push_pat_expected_type(expected);
             state.constraints.push(constraints.equal_pattern_types(
-                num_type,
+                num_type_index,
                 expected,
                 PatternCategory::Character,
                 region,

--- a/crates/compiler/solve/src/solve.rs
+++ b/crates/compiler/solve/src/solve.rs
@@ -1323,40 +1323,29 @@ fn solve(
                     region,
                 } = includes_tag;
 
-                let typ_cell = &constraints.types[type_index.index()];
-                let tys_cells = &constraints.types[types.indices()];
                 let pattern_category = &constraints.pattern_categories[pattern_category.index()];
 
-                let actual = type_cell_to_var(
+                let actual = either_type_index_to_var(
+                    constraints,
                     subs,
                     rank,
+                    pools,
                     problems,
                     abilities_store,
                     obligation_cache,
-                    pools,
                     aliases,
-                    typ_cell,
+                    *type_index,
                 );
 
-                let tys = {
-                    let mut tys = Vec::with_capacity(tys_cells.len());
-                    for cell in tys_cells {
-                        let actual = type_cell_to_var(
-                            subs,
-                            rank,
-                            problems,
-                            abilities_store,
-                            obligation_cache,
-                            pools,
-                            aliases,
-                            cell,
-                        );
-                        tys.push(Type::Variable(actual));
-                    }
-                    tys
-                };
+                let payload_types = constraints.variables[types.indices()]
+                    .into_iter()
+                    .map(|v| Type::Variable(*v))
+                    .collect();
 
-                let tag_ty = Type::TagUnion(vec![(tag_name.clone(), tys)], TypeExtension::Closed);
+                let tag_ty = Type::TagUnion(
+                    vec![(tag_name.clone(), payload_types)],
+                    TypeExtension::Closed,
+                );
                 let includes = type_to_var(
                     subs,
                     rank,

--- a/crates/compiler/solve/src/solve.rs
+++ b/crates/compiler/solve/src/solve.rs
@@ -1338,7 +1338,7 @@ fn solve(
                 );
 
                 let payload_types = constraints.variables[types.indices()]
-                    .into_iter()
+                    .iter()
                     .map(|v| Type::Variable(*v))
                     .collect();
 


### PR DESCRIPTION
This is part 2/many of getting rid of type emplacement. With this patch, we have most of the surface API of constraining take `Index<Type>` rather than a `Type` directly. With #4398, and later Types SoA, this will mean that `Type`s will be reused in such positions, rather than instantiating fresh type variables.

A follow up or two will clean up the rest of the API surface two, but avoiding batching to make incremental landing easier.

Blocked on #4398