### PR TITLE
Fully remove `Type` from the surface API of constraining

### DIFF
--- a/crates/compiler/can/src/constraint.rs
+++ b/crates/compiler/can/src/constraint.rs
@@ -615,8 +615,8 @@ impl Constraints {
         real_var: Variable,
         real_region: Region,
         category_and_expectation: Result<
-            (Category, Expected<Type>),
-            (PatternCategory, PExpected<Type>),
+            (Category, ExpectedTypeIndex),
+            (PatternCategory, PExpectedTypeIndex),
         >,
         sketched_rows: SketchedRows,
         context: ExhaustiveContext,
@@ -628,15 +628,12 @@ impl Constraints {
         let equality = match category_and_expectation {
             Ok((category, expected)) => {
                 let category = Index::push_new(&mut self.categories, category);
-                let expected = Index::push_new(&mut self.expectations, expected.map(Cell::new));
                 let equality = Eq(real_var, expected, category, real_region);
                 let equality = Index::push_new(&mut self.eq, equality);
                 Ok(equality)
             }
             Err((category, expected)) => {
                 let category = Index::push_new(&mut self.pattern_categories, category);
-                let expected =
-                    Index::push_new(&mut self.pattern_expectations, expected.map(Cell::new));
                 let equality = PatternEq(real_var, expected, category, real_region);
                 let equality = Index::push_new(&mut self.pattern_eq, equality);
                 Err(equality)

--- a/crates/compiler/can/src/constraint.rs
+++ b/crates/compiler/can/src/constraint.rs
@@ -510,7 +510,7 @@ impl Constraints {
     ) -> Constraint
     where
         I1: IntoIterator<Item = Variable>,
-        I2: IntoIterator<Item = (Symbol, Loc<Type>)>,
+        I2: IntoIterator<Item = (Symbol, Loc<TypeOrVar>)>,
         I2::IntoIter: ExactSizeIterator,
     {
         // defs and ret constraint are stored consequtively, so we only need to store one index
@@ -519,27 +519,10 @@ impl Constraints {
         self.constraints.push(Constraint::True);
         self.constraints.push(module_constraint);
 
-        let def_types = {
-            let types = def_types
-                .into_iter()
-                .map(|(sym, Loc { region, value })| {
-                    let type_index = self.push_type(value);
-                    (
-                        sym,
-                        Loc {
-                            region,
-                            value: type_index,
-                        },
-                    )
-                })
-                .collect::<Vec<_>>();
-            self.def_types_slice(types)
-        };
-
         let let_contraint = LetConstraint {
             rigid_vars: self.variable_slice(rigid_vars),
             flex_vars: Slice::default(),
-            def_types,
+            def_types: self.def_types_slice(def_types),
             defs_and_ret_constraint,
         };
 

--- a/crates/compiler/can/src/constraint.rs
+++ b/crates/compiler/can/src/constraint.rs
@@ -20,7 +20,7 @@ pub struct Constraints {
     pub categories: Vec<Category>,
     pub pattern_categories: Vec<PatternCategory>,
     pub expectations: Vec<Expected<TypeOrVar>>,
-    pub pattern_expectations: Vec<PExpected<Cell<Type>>>,
+    pub pattern_expectations: Vec<PExpected<TypeOrVar>>,
     pub includes_tags: Vec<IncludesTag>,
     pub strings: Vec<&'static str>,
     pub sketched_rows: Vec<SketchedRows>,
@@ -58,9 +58,8 @@ impl Default for Constraints {
     }
 }
 
-pub type TypeIndex = Index<Cell<Type>>;
 pub type ExpectedTypeIndex = Index<Expected<TypeOrVar>>;
-pub type PExpectedTypeIndex = Index<PExpected<Cell<Type>>>;
+pub type PExpectedTypeIndex = Index<PExpected<TypeOrVar>>;
 pub type TypeOrVar = EitherIndex<Cell<Type>, Variable>;
 
 impl Constraints {
@@ -219,8 +218,8 @@ impl Constraints {
         Index::push_new(&mut self.expectations, expected)
     }
 
-    pub fn push_pat_expected_type(&mut self, expected: PExpected<Type>) -> PExpectedTypeIndex {
-        Index::push_new(&mut self.pattern_expectations, expected.map(Cell::new))
+    pub fn push_pat_expected_type(&mut self, expected: PExpected<TypeOrVar>) -> PExpectedTypeIndex {
+        Index::push_new(&mut self.pattern_expectations, expected)
     }
 
     #[inline(always)]

--- a/crates/compiler/constrain/src/builtins.rs
+++ b/crates/compiler/constrain/src/builtins.rs
@@ -1,5 +1,5 @@
 use arrayvec::ArrayVec;
-use roc_can::constraint::{Constraint, Constraints};
+use roc_can::constraint::{Constraint, Constraints, TypeOrVar};
 use roc_can::expected::Expected::{self, *};
 use roc_can::num::{FloatBound, FloatWidth, IntBound, IntLitWidth, NumBound, SignDemand};
 use roc_module::symbol::Symbol;
@@ -30,7 +30,7 @@ pub fn add_numeric_bound_constr(
             num_num(Variable(num_var))
         }
         NumericBound::FloatExact(width) => {
-            let actual_type = Variable(float_width_to_variable(width));
+            let actual_type = constraints.push_type(Variable(float_width_to_variable(width)));
             let expected = Expected::ForReason(Reason::NumericLiteralSuffix, actual_type, region);
             let type_index = constraints.push_type(Variable(num_var));
             let expected_index = constraints.push_expected_type(expected);
@@ -42,7 +42,7 @@ pub fn add_numeric_bound_constr(
             Variable(num_var)
         }
         NumericBound::IntExact(width) => {
-            let actual_type = Variable(int_lit_width_to_variable(width));
+            let actual_type = constraints.push_type(Variable(int_lit_width_to_variable(width)));
             let expected = Expected::ForReason(Reason::NumericLiteralSuffix, actual_type, region);
             let type_index = constraints.push_type(Variable(num_var));
             let expected_index = constraints.push_expected_type(expected);
@@ -54,11 +54,10 @@ pub fn add_numeric_bound_constr(
             Variable(num_var)
         }
         NumericBound::Range(range) => {
-            let actual_type = Variable(precision_var);
-            let expected = Expected::NoExpectation(RangedNumber(range));
-            let type_index = constraints.push_type(actual_type);
+            let precision_type = constraints.push_type(Variable(precision_var));
+            let expected = Expected::NoExpectation(constraints.push_type(RangedNumber(range)));
             let expected_index = constraints.push_expected_type(expected);
-            let constr = constraints.equal_types(type_index, expected_index, category, region);
+            let constr = constraints.equal_types(precision_type, expected_index, category, region);
 
             num_constraints.extend([constr]);
 
@@ -72,7 +71,7 @@ pub fn int_literal(
     constraints: &mut Constraints,
     num_var: Variable,
     precision_var: Variable,
-    expected: Expected<Type>,
+    expected: Expected<TypeOrVar>,
     region: Region,
     bound: IntBound,
 ) -> Constraint {
@@ -91,11 +90,10 @@ pub fn int_literal(
     );
 
     let num_type_index = constraints.push_type(num_type);
-    let expect_precision_var = constraints.push_expected_type(ForReason(
-        reason,
-        num_int(Type::Variable(precision_var)),
-        region,
-    ));
+    let int_precision_type = constraints.push_type(num_int(Type::Variable(precision_var)));
+
+    let expect_precision_var =
+        constraints.push_expected_type(ForReason(reason, int_precision_type, region));
 
     constrs.extend([
         constraints.equal_types(num_type_index, expect_precision_var, Category::Int, region),
@@ -114,7 +112,7 @@ pub fn single_quote_literal(
     constraints: &mut Constraints,
     num_var: Variable,
     precision_var: Variable,
-    expected: Expected<Type>,
+    expected: Expected<TypeOrVar>,
     region: Region,
     bound: SingleQuoteBound,
 ) -> Constraint {
@@ -133,11 +131,10 @@ pub fn single_quote_literal(
     );
 
     let num_type_index = constraints.push_type(num_type);
-    let expect_precision_var = constraints.push_expected_type(ForReason(
-        reason,
-        num_int(Type::Variable(precision_var)),
-        region,
-    ));
+    let int_precision_type = constraints.push_type(num_int(Type::Variable(precision_var)));
+
+    let expect_precision_var =
+        constraints.push_expected_type(ForReason(reason, int_precision_type, region));
 
     constrs.extend([
         constraints.equal_types(
@@ -161,7 +158,7 @@ pub fn float_literal(
     constraints: &mut Constraints,
     num_var: Variable,
     precision_var: Variable,
-    expected: Expected<Type>,
+    expected: Expected<TypeOrVar>,
     region: Region,
     bound: FloatBound,
 ) -> Constraint {
@@ -179,11 +176,10 @@ pub fn float_literal(
     );
 
     let num_type_index = constraints.push_type(num_type);
-    let expect_precision_var = constraints.push_expected_type(ForReason(
-        reason,
-        num_float(Type::Variable(precision_var)),
-        region,
-    ));
+    let float_precision_type = constraints.push_type(num_float(Type::Variable(precision_var)));
+
+    let expect_precision_var =
+        constraints.push_expected_type(ForReason(reason, float_precision_type, region));
 
     constrs.extend([
         constraints.equal_types(num_type_index, expect_precision_var, Category::Frac, region),
@@ -201,7 +197,7 @@ pub fn float_literal(
 pub fn num_literal(
     constraints: &mut Constraints,
     num_var: Variable,
-    expected: Expected<Type>,
+    expected: Expected<TypeOrVar>,
     region: Region,
     bound: NumBound,
 ) -> Constraint {

--- a/crates/compiler/constrain/src/expr.rs
+++ b/crates/compiler/constrain/src/expr.rs
@@ -1692,8 +1692,7 @@ fn constrain_function_def(
                 AnnotationSource::TypedBody {
                     region: annotation.region,
                 },
-                // TODO coalesce with other ret_type index
-                constraints.push_type(ret_type.clone()),
+                ret_type_index,
             );
 
             let ret_constraint = constrain_expr(

--- a/crates/compiler/constrain/src/expr.rs
+++ b/crates/compiler/constrain/src/expr.rs
@@ -902,13 +902,15 @@ pub fn constrain_expr(
 
             // Now check the condition against the type expected by the branches.
             let sketched_rows = sketch_when_branches(branches_region, branches);
+            let expected_by_branches = constraints.push_expected_type(Expected::ForReason(
+                Reason::WhenBranches,
+                branches_cond_type,
+                branches_region,
+            ));
             let cond_matches_branches_constraint = constraints.exhaustive(
                 real_cond_var,
                 loc_cond.region,
-                Ok((
-                    loc_cond.value.category(),
-                    Expected::ForReason(Reason::WhenBranches, branches_cond_type, branches_region),
-                )),
+                Ok((loc_cond.value.category(), expected_by_branches)),
                 sketched_rows,
                 ExhaustiveContext::BadCase,
                 *exhaustive,
@@ -2562,14 +2564,14 @@ fn constrain_typed_function_arguments(
                 // annotation wants.
                 let sketched_rows = sketch_pattern_to_rows(loc_pattern.region, &loc_pattern.value);
                 let category = loc_pattern.value.category();
-                let expected = PExpected::ForReason(
+                let expected = constraints.push_pat_expected_type(PExpected::ForReason(
                     PReason::TypedArg {
                         index: HumanIndex::zero_based(index),
                         opt_name: opt_label,
                     },
                     Type::Variable(*pattern_var),
                     loc_pattern.region,
-                );
+                ));
                 let exhaustive_constraint = constraints.exhaustive(
                     annotation_var,
                     loc_pattern.region,
@@ -2677,14 +2679,14 @@ fn constrain_typed_function_arguments_simple(
                 // annotation wants.
                 let sketched_rows = sketch_pattern_to_rows(loc_pattern.region, &loc_pattern.value);
                 let category = loc_pattern.value.category();
-                let expected = PExpected::ForReason(
+                let expected = constraints.push_pat_expected_type(PExpected::ForReason(
                     PReason::TypedArg {
                         index: HumanIndex::zero_based(index),
                         opt_name: Some(symbol),
                     },
                     Type::Variable(*pattern_var),
                     loc_pattern.region,
-                );
+                ));
                 let exhaustive_constraint = constraints.exhaustive(
                     annotation_var,
                     loc_pattern.region,

--- a/crates/compiler/constrain/src/expr.rs
+++ b/crates/compiler/constrain/src/expr.rs
@@ -2340,7 +2340,6 @@ fn constrain_typed_def(
         rigids: ftv,
     };
 
-    // TODO there is a signature_index below, can we coalesce it here?
     let signature_index = constraints.push_type(signature.clone());
 
     let annotation_expected = FromAnnotation(
@@ -2456,7 +2455,6 @@ fn constrain_typed_def(
                     signature_closure_type_index,
                 ))
             };
-            let signature_index = constraints.push_type(signature);
             let cons = [
                 constraints.let_constraint(
                     [],

--- a/crates/compiler/constrain/src/expr.rs
+++ b/crates/compiler/constrain/src/expr.rs
@@ -3132,14 +3132,15 @@ fn constraint_recursive_function(
 
             flex_info.vars.extend(new_infer_variables);
 
+            let signature_index = constraints.push_type(signature.clone());
+
             let annotation_expected = FromAnnotation(
                 loc_pattern,
                 arity,
                 AnnotationSource::TypedBody {
                     region: annotation.region,
                 },
-                // TODO coalesce with other signature_index
-                constraints.push_type(signature.clone()),
+                signature_index,
             );
 
             let (arg_types, _signature_closure_type, ret_type) = match &signature {
@@ -3225,8 +3226,6 @@ fn constraint_recursive_function(
             let expr_con = attach_resolution_constraints(constraints, env, expr_con);
 
             vars.push(expr_var);
-
-            let signature_index = constraints.push_type(signature.clone());
 
             let state_constraints = constraints.and_constraint(argument_pattern_state.constraints);
             let cons = [

--- a/crates/compiler/constrain/src/expr.rs
+++ b/crates/compiler/constrain/src/expr.rs
@@ -1826,14 +1826,15 @@ fn constrain_destructure_def(
                 resolutions_to_make: vec![],
             };
 
+            let signature_index = constraints.push_type(signature);
+
             let annotation_expected = FromAnnotation(
                 loc_pattern.clone(),
                 arity,
                 AnnotationSource::TypedBody {
                     region: annotation.region,
                 },
-                // TODO coalesce with other signatures
-                constraints.push_type(signature.clone()),
+                signature_index,
             );
 
             // This will fill in inference variables in the `signature` as well, so that we can
@@ -1846,8 +1847,6 @@ fn constrain_destructure_def(
                 &loc_expr.value,
                 annotation_expected,
             );
-
-            let signature_index = constraints.push_type(signature);
 
             let cons = [
                 ret_constraint,

--- a/crates/compiler/constrain/src/expr.rs
+++ b/crates/compiler/constrain/src/expr.rs
@@ -2657,11 +2657,9 @@ fn constrain_typed_function_arguments_simple(
     let it = arguments.iter().zip(arg_types.iter()).enumerate();
     for (index, ((pattern_var, annotated_mark, loc_pattern), ann)) in it {
         let pattern_var_index = constraints.push_type(Variable(*pattern_var));
+        let ann_index = constraints.push_type(ann.clone());
 
         if loc_pattern.value.surely_exhaustive() {
-            // TODO coalesce
-            let ann_index = constraints.push_type(ann.clone());
-
             // OPT: we don't need to perform any type-level exhaustiveness checking.
             // Check instead only that the pattern unifies with the annotation type.
             let pattern_expected = PExpected::ForReason(
@@ -2687,7 +2685,6 @@ fn constrain_typed_function_arguments_simple(
                 // this constraint must be to the def_pattern_state's constraints
                 def_pattern_state.vars.push(*pattern_var);
 
-                let ann_index = constraints.push_type(ann.clone());
                 let ann_expected =
                     constraints.push_expected_type(Expected::NoExpectation(ann_index));
                 let pattern_con = constraints.equal_types_var(
@@ -2725,7 +2722,6 @@ fn constrain_typed_function_arguments_simple(
 
             {
                 // Store the actual type in a variable.
-                let ann_index = constraints.push_type(ann.clone());
                 let expected_annotation =
                     constraints.push_expected_type(Expected::NoExpectation(ann_index));
                 argument_pattern_state

--- a/crates/compiler/constrain/src/expr.rs
+++ b/crates/compiler/constrain/src/expr.rs
@@ -1621,8 +1621,7 @@ fn constrain_function_def(
             let ret_var = function_def.return_type;
             let closure_var = function_def.closure_type;
 
-            let ret_type = *ret_type.clone();
-            let ret_type_index = constraints.push_type(ret_type.clone());
+            let ret_type_index = constraints.push_type(*ret_type.clone());
 
             vars.push(ret_var);
             vars.push(closure_var);

--- a/crates/compiler/constrain/src/expr.rs
+++ b/crates/compiler/constrain/src/expr.rs
@@ -2530,11 +2530,9 @@ fn constrain_typed_function_arguments(
     let it = arguments.iter().zip(arg_types.iter()).enumerate();
     for (index, ((pattern_var, annotated_mark, loc_pattern), ann)) in it {
         let pattern_var_index = constraints.push_type(Variable(*pattern_var));
+        let ann_index = constraints.push_type(ann.clone());
 
         if loc_pattern.value.surely_exhaustive() {
-            // TODO coalesce with ann_index below
-            let ann_index = constraints.push_type(ann.clone());
-
             // OPT: we don't need to perform any type-level exhaustiveness checking.
             // Check instead only that the pattern unifies with the annotation type.
             let pattern_expected = PExpected::ForReason(
@@ -2559,8 +2557,6 @@ fn constrain_typed_function_arguments(
                 // NOTE: because we perform an equality with part of the signature
                 // this constraint must be to the def_pattern_state's constraints
                 def_pattern_state.vars.push(*pattern_var);
-
-                let ann_index = constraints.push_type(ann.clone());
 
                 let ann_expected =
                     constraints.push_expected_type(Expected::NoExpectation(ann_index));
@@ -2599,7 +2595,6 @@ fn constrain_typed_function_arguments(
 
             {
                 // Store the actual type in a variable.
-                let ann_index = constraints.push_type(ann.clone());
                 let ann_expected =
                     constraints.push_expected_type(Expected::NoExpectation(ann_index));
                 argument_pattern_state

--- a/crates/compiler/constrain/src/expr.rs
+++ b/crates/compiler/constrain/src/expr.rs
@@ -1513,6 +1513,8 @@ fn constrain_function_def(
                 &mut ftv,
             );
 
+            let signature_index = constraints.push_type(signature.clone());
+
             let (arg_types, signature_closure_type, ret_type) = match &signature {
                 Type::Function(arg_types, signature_closure_type, ret_type) => {
                     (arg_types, signature_closure_type, ret_type)
@@ -1528,8 +1530,7 @@ fn constrain_function_def(
                             Loc {
                                 region: loc_function_def.region,
                                 // todo can we use Type::Variable(expr_var) here?
-                                // TODO coalesce with other signatures
-                                value: constraints.push_type(signature.clone()),
+                                value: signature_index,
                             },
                         );
 
@@ -1541,8 +1542,7 @@ fn constrain_function_def(
                             AnnotationSource::TypedBody {
                                 region: annotation.region,
                             },
-                            // TODO coalesce with other signatures
-                            constraints.push_type(signature.clone()),
+                            signature_index,
                         );
 
                         {
@@ -1565,8 +1565,7 @@ fn constrain_function_def(
                         AnnotationSource::TypedBody {
                             region: annotation.region,
                         },
-                        // TODO coalesce with other signature indeces
-                        constraints.push_type(signature.clone()),
+                        signature_index,
                     );
 
                     let ret_constraint = constrain_untyped_closure(
@@ -1653,8 +1652,7 @@ fn constrain_function_def(
                 AnnotationSource::TypedBody {
                     region: annotation.region,
                 },
-                // TODO coalesce with other signature indices
-                constraints.push_type(signature.clone()),
+                signature_index,
             );
 
             {

--- a/crates/compiler/constrain/src/expr.rs
+++ b/crates/compiler/constrain/src/expr.rs
@@ -1585,8 +1585,6 @@ fn constrain_function_def(
                     let ret_constraint =
                         attach_resolution_constraints(constraints, env, ret_constraint);
 
-                    let signature_index = constraints.push_type(signature.clone());
-
                     let cons = [
                         ret_constraint,
                         // Store type into AST vars. We use Store so errors aren't reported twice

--- a/crates/compiler/constrain/src/expr.rs
+++ b/crates/compiler/constrain/src/expr.rs
@@ -3597,8 +3597,7 @@ fn rec_defs_help(
                         let mut vars = Vec::with_capacity(state.vars.capacity() + 1);
                         let ret_var = *ret_var;
                         let closure_var = *closure_var;
-                        let ret_type = *ret_type.clone();
-                        let ret_type_index = constraints.push_type(ret_type.clone());
+                        let ret_type_index = constraints.push_type(*ret_type.clone());
 
                         vars.push(ret_var);
                         vars.push(closure_var);
@@ -3627,7 +3626,7 @@ fn rec_defs_help(
                         let fn_type_index = constraints.push_type(Type::Function(
                             pattern_types,
                             Box::new(Type::Variable(closure_var)),
-                            Box::new(ret_type.clone()),
+                            Box::new(*ret_type.clone()),
                         ));
                         let body_type = NoExpectation(ret_type_index);
                         let expr_con = constrain_expr(

--- a/crates/compiler/constrain/src/expr.rs
+++ b/crates/compiler/constrain/src/expr.rs
@@ -3551,7 +3551,6 @@ fn rec_defs_help(
 
                 hybrid_and_flex_info.vars.extend(new_infer_variables);
 
-                // TODO there is a signature_index below, can we coalesce?
                 let signature_index = constraints.push_type(signature.clone());
 
                 let annotation_expected = FromAnnotation(
@@ -3642,7 +3641,6 @@ fn rec_defs_help(
 
                         vars.push(*fn_var);
 
-                        let signature_index = constraints.push_type(signature);
                         let state_constraints = constraints.and_constraint(state.constraints);
                         let expected_index = constraints.push_expected_type(expected);
                         let cons = [
@@ -3709,8 +3707,6 @@ fn rec_defs_help(
                         );
                         let ret_constraint =
                             attach_resolution_constraints(constraints, env, ret_constraint);
-
-                        let signature_index = constraints.push_type(signature);
 
                         let cons = [
                             ret_constraint,

--- a/crates/compiler/constrain/src/module.rs
+++ b/crates/compiler/constrain/src/module.rs
@@ -50,8 +50,9 @@ fn constrain_symbols_from_requires(
                 };
                 let pattern = Loc::at_zero(roc_can::pattern::Pattern::Identifier(loc_symbol.value));
 
+                let type_index = constraints.push_type(loc_type.value);
                 let def_pattern_state =
-                    constrain_def_pattern(constraints, &mut env, &pattern, loc_type.value);
+                    constrain_def_pattern(constraints, &mut env, &pattern, type_index);
 
                 debug_assert!(env.resolutions_to_make.is_empty());
 
@@ -108,12 +109,11 @@ pub fn frontload_ability_constraints(
             };
             let pattern = Loc::at_zero(roc_can::pattern::Pattern::Identifier(*member_name));
 
-            let mut def_pattern_state = constrain_def_pattern(
-                constraints,
-                &mut env,
-                &pattern,
-                Type::Variable(signature_var),
-            );
+            // TODO coalesce
+            let signature_index = constraints.push_type(signature.clone());
+
+            let mut def_pattern_state =
+                constrain_def_pattern(constraints, &mut env, &pattern, signature_index);
 
             debug_assert!(env.resolutions_to_make.is_empty());
 

--- a/crates/compiler/constrain/src/module.rs
+++ b/crates/compiler/constrain/src/module.rs
@@ -69,13 +69,15 @@ fn constrain_symbols_from_requires(
                 // Otherwise, this symbol comes from an app module - we want to check that the type
                 // provided by the app is in fact what the package module requires.
                 let arity = loc_type.value.arity();
+                let typ = loc_type.value;
+                let type_index = constraints.push_type(typ);
                 let expected = constraints.push_expected_type(Expected::FromAnnotation(
                     loc_symbol.map(|&s| Pattern::Identifier(s)),
                     arity,
                     AnnotationSource::RequiredSymbol {
                         region: loc_type.region,
                     },
-                    loc_type.value,
+                    type_index,
                 ));
                 let provided_eq_requires_constr =
                     constraints.lookup(loc_symbol.value, expected, loc_type.region);
@@ -120,8 +122,9 @@ pub fn frontload_ability_constraints(
             let rigid_variables = vars.rigid_vars.iter().chain(vars.able_vars.iter()).copied();
             let infer_variables = vars.flex_vars.iter().copied();
 
+            let signature_index = constraints.push_type(signature.clone());
             let signature_expectation =
-                constraints.push_expected_type(Expected::NoExpectation(signature.clone()));
+                constraints.push_expected_type(Expected::NoExpectation(signature_index));
 
             def_pattern_state
                 .constraints

--- a/crates/compiler/constrain/src/module.rs
+++ b/crates/compiler/constrain/src/module.rs
@@ -109,7 +109,6 @@ pub fn frontload_ability_constraints(
             };
             let pattern = Loc::at_zero(roc_can::pattern::Pattern::Identifier(*member_name));
 
-            // TODO coalesce
             let signature_index = constraints.push_type(signature.clone());
 
             let mut def_pattern_state =
@@ -122,7 +121,6 @@ pub fn frontload_ability_constraints(
             let rigid_variables = vars.rigid_vars.iter().chain(vars.able_vars.iter()).copied();
             let infer_variables = vars.flex_vars.iter().copied();
 
-            let signature_index = constraints.push_type(signature.clone());
             let signature_expectation =
                 constraints.push_expected_type(Expected::NoExpectation(signature_index));
 

--- a/crates/compiler/constrain/src/pattern.rs
+++ b/crates/compiler/constrain/src/pattern.rs
@@ -532,12 +532,11 @@ pub fn constrain_pattern(
                     opt_rest: _,
                 },
         } => {
+            let elem_var_index = constraints.push_type(Type::Variable(*elem_var));
+
             for loc_pat in patterns.iter() {
-                let expected = PExpected::ForReason(
-                    PReason::ListElem,
-                    Type::Variable(*elem_var),
-                    loc_pat.region,
-                );
+                let expected =
+                    PExpected::ForReason(PReason::ListElem, elem_var_index, loc_pat.region);
 
                 constrain_pattern(
                     constraints,

--- a/crates/compiler/constrain/src/pattern.rs
+++ b/crates/compiler/constrain/src/pattern.rs
@@ -1,6 +1,6 @@
 use crate::builtins;
 use crate::expr::{constrain_expr, Env};
-use roc_can::constraint::{Constraint, Constraints};
+use roc_can::constraint::{Constraint, Constraints, TypeOrVar};
 use roc_can::expected::{Expected, PExpected};
 use roc_can::pattern::Pattern::{self, *};
 use roc_can::pattern::{DestructType, ListPatterns, RecordDestruct};
@@ -17,7 +17,7 @@ use roc_types::types::{
 
 #[derive(Default, Debug)]
 pub struct PatternState {
-    pub headers: VecMap<Symbol, Loc<Type>>,
+    pub headers: VecMap<Symbol, Loc<TypeOrVar>>,
     pub vars: Vec<Variable>,
     pub constraints: Vec<Constraint>,
     pub delayed_is_open_constraints: Vec<Constraint>,
@@ -31,14 +31,16 @@ pub struct PatternState {
 /// Would add `x => <42>` to the headers (i.e., symbol points to a type variable). If the
 /// definition has an annotation, we instead now add `x => Int`.
 pub fn headers_from_annotation(
+    constraints: &mut Constraints,
     pattern: &Pattern,
     annotation: &Loc<&Type>,
-) -> Option<VecMap<Symbol, Loc<Type>>> {
+) -> Option<VecMap<Symbol, Loc<TypeOrVar>>> {
     let mut headers = VecMap::default();
     // Check that the annotation structurally agrees with the pattern, preventing e.g. `{ x, y } : Int`
     // in such incorrect cases we don't put the full annotation in headers, just a variable, and let
     // inference generate a proper error.
-    let is_structurally_valid = headers_from_annotation_help(pattern, annotation, &mut headers);
+    let is_structurally_valid =
+        headers_from_annotation_help(constraints, pattern, annotation, &mut headers);
 
     if is_structurally_valid {
         Some(headers)
@@ -48,9 +50,10 @@ pub fn headers_from_annotation(
 }
 
 fn headers_from_annotation_help(
+    constraints: &mut Constraints,
     pattern: &Pattern,
     annotation: &Loc<&Type>,
-    headers: &mut VecMap<Symbol, Loc<Type>>,
+    headers: &mut VecMap<Symbol, Loc<TypeOrVar>>,
 ) -> bool {
     match pattern {
         Identifier(symbol)
@@ -60,7 +63,8 @@ fn headers_from_annotation_help(
             ident: symbol,
             specializes: _,
         } => {
-            let typ = Loc::at(annotation.region, annotation.value.clone());
+            let annotation_index = constraints.push_type(annotation.value.clone());
+            let typ = Loc::at(annotation.region, annotation_index);
             headers.insert(*symbol, typ);
             true
         }
@@ -87,9 +91,10 @@ fn headers_from_annotation_help(
                     // `{ x ? 0 } = rec` or `{ x: 5 } -> ...` in all cases
                     // the type of `x` within the binding itself is the same.
                     if let Some(field_type) = fields.get(&destruct.label) {
+                        let field_type_index = constraints.push_type(field_type.as_inner().clone());
                         headers.insert(
                             destruct.symbol,
-                            Loc::at(annotation.region, field_type.clone().into_inner()),
+                            Loc::at(annotation.region, field_type_index),
                         );
                     } else {
                         return false;
@@ -125,6 +130,7 @@ fn headers_from_annotation_help(
                         .zip(arg_types.iter())
                         .all(|(arg_pattern, arg_type)| {
                             headers_from_annotation_help(
+                                constraints,
                                 &arg_pattern.1.value,
                                 &Loc::at(annotation.region, arg_type),
                                 headers,
@@ -156,11 +162,13 @@ fn headers_from_annotation_help(
                 && type_arguments.len() == pat_type_arguments.len()
                 && lambda_set_variables.len() == pat_lambda_set_variables.len() =>
             {
-                let typ = Loc::at(annotation.region, annotation.value.clone());
+                let annotation_index = constraints.push_type(annotation.value.clone());
+                let typ = Loc::at(annotation.region, annotation_index);
                 headers.insert(*opaque, typ);
 
                 let (_, argument_pat) = &**argument;
                 headers_from_annotation_help(
+                                constraints,
                     &argument_pat.value,
                     &Loc::at(annotation.region, actual),
                     headers,
@@ -203,9 +211,9 @@ pub fn constrain_pattern(
         }
 
         Identifier(symbol) | Shadowed(_, _, symbol) => {
-            if could_be_a_tag_union(expected.get_type_ref()) {
-                let type_index = constraints.push_type(expected.get_type_ref().clone());
+            let type_index = constraints.push_type(expected.get_type_ref().clone());
 
+            if could_be_a_tag_union(expected.get_type_ref()) {
                 state
                     .delayed_is_open_constraints
                     .push(constraints.is_open_type(type_index));
@@ -215,7 +223,7 @@ pub fn constrain_pattern(
                 *symbol,
                 Loc {
                     region,
-                    value: expected.get_type(),
+                    value: type_index,
                 },
             );
         }
@@ -224,9 +232,9 @@ pub fn constrain_pattern(
             ident: symbol,
             specializes: _,
         } => {
-            if could_be_a_tag_union(expected.get_type_ref()) {
-                let type_index = constraints.push_type(expected.get_type_ref().clone());
+            let type_index = constraints.push_type(expected.get_type_ref().clone());
 
+            if could_be_a_tag_union(expected.get_type_ref()) {
                 state.constraints.push(constraints.is_open_type(type_index));
             }
 
@@ -234,7 +242,7 @@ pub fn constrain_pattern(
                 *symbol,
                 Loc {
                     region,
-                    value: expected.get_type(),
+                    value: type_index,
                 },
             );
         }
@@ -278,7 +286,7 @@ pub fn constrain_pattern(
             let num_type = constraints.push_type(num_type);
 
             // Link the free num var with the int var and our expectation.
-            let int_type = builtins::num_int(Type::Variable(precision_var));
+            let int_type = constraints.push_type(builtins::num_int(Type::Variable(precision_var)));
 
             state.constraints.push({
                 let expected_index =
@@ -308,10 +316,11 @@ pub fn constrain_pattern(
                 region,
                 Category::Frac,
             );
+            let num_type_index = constraints.push_type(num_type); // TODO check me if something breaks!
 
             // Link the free num var with the float var and our expectation.
-            let float_type = builtins::num_float(Type::Variable(precision_var));
-            let num_type_index = constraints.push_type(num_type); // TODO check me if something breaks!
+            let float_type =
+                constraints.push_type(builtins::num_float(Type::Variable(precision_var)));
 
             state.constraints.push({
                 let expected_index =
@@ -353,10 +362,10 @@ pub fn constrain_pattern(
                 Category::Int,
             );
 
-            // Link the free num var with the int var and our expectation.
-            let int_type = builtins::num_int(Type::Variable(precision_var));
-
             let num_type_index = constraints.push_type(num_type);
+
+            // Link the free num var with the int var and our expectation.
+            let int_type = constraints.push_type(builtins::num_int(Type::Variable(precision_var)));
 
             state.constraints.push({
                 let expected_index =
@@ -402,12 +411,13 @@ pub fn constrain_pattern(
             } in destructs
             {
                 let pat_type = Type::Variable(*var);
+                let pat_type_index = constraints.push_type(pat_type.clone());
                 let expected = PExpected::NoExpectation(pat_type.clone());
 
                 if !state.headers.contains_key(symbol) {
                     state
                         .headers
-                        .insert(*symbol, Loc::at(region, pat_type.clone()));
+                        .insert(*symbol, Loc::at(region, pat_type_index));
                 }
 
                 let field_type = match typ {
@@ -459,7 +469,7 @@ pub fn constrain_pattern(
 
                         let expr_expected = Expected::ForReason(
                             Reason::RecordDefaultField(label.clone()),
-                            pat_type.clone(),
+                            pat_type_index,
                             loc_expr.region,
                         );
 
@@ -485,7 +495,10 @@ pub fn constrain_pattern(
                 state.vars.push(*var);
             }
 
-            let record_type = Type::Record(field_types, TypeExtension::from_type(ext_type));
+            let record_type = constraints.push_type(Type::Record(
+                field_types,
+                TypeExtension::from_type(ext_type),
+            ));
 
             let whole_var_index = constraints.push_type(Type::Variable(*whole_var));
             let expected_record =
@@ -623,7 +636,7 @@ pub fn constrain_pattern(
             let (arg_pattern_var, loc_arg_pattern) = &**argument;
             let arg_pattern_type = Type::Variable(*arg_pattern_var);
 
-            let opaque_type = Type::Alias {
+            let opaque_type = constraints.push_type(Type::Alias {
                 symbol: *opaque,
                 type_arguments: type_arguments
                     .iter()
@@ -636,7 +649,7 @@ pub fn constrain_pattern(
                 infer_ext_in_output_types: vec![],
                 actual: Box::new(arg_pattern_type.clone()),
                 kind: AliasKind::Opaque,
-            };
+            });
 
             // First, add a constraint for the argument "who"
             let arg_pattern_expected = PExpected::NoExpectation(arg_pattern_type.clone());

--- a/crates/compiler/solve/src/solve.rs
+++ b/crates/compiler/solve/src/solve.rs
@@ -2247,21 +2247,22 @@ impl LocalDefVarsVec<(Symbol, Loc<Variable>)> {
         subs: &mut Subs,
         def_types_slice: roc_can::constraint::DefTypes,
     ) -> Self {
-        let types_slice = &constraints.types[def_types_slice.types.indices()];
+        let type_indices_slice = &constraints.type_slices[def_types_slice.types.indices()];
         let loc_symbols_slice = &constraints.loc_symbols[def_types_slice.loc_symbols.indices()];
 
-        let mut local_def_vars = Self::with_length(types_slice.len());
+        let mut local_def_vars = Self::with_length(type_indices_slice.len());
 
-        for (&(symbol, region), typ_cell) in (loc_symbols_slice.iter()).zip(types_slice) {
-            let var = type_cell_to_var(
+        for (&(symbol, region), typ_index) in (loc_symbols_slice.iter()).zip(type_indices_slice) {
+            let var = either_type_index_to_var(
+                constraints,
                 subs,
                 rank,
+                pools,
                 problems,
                 abilities_store,
                 obligation_cache,
-                pools,
                 aliases,
-                typ_cell,
+                *typ_index,
             );
 
             local_def_vars.push((symbol, Loc { value: var, region }));

--- a/crates/compiler/solve/src/solve.rs
+++ b/crates/compiler/solve/src/solve.rs
@@ -1180,15 +1180,16 @@ fn solve(
                 );
 
                 let expectation = &constraints.pattern_expectations[expectation_index.index()];
-                let expected = type_cell_to_var(
+                let expected = either_type_index_to_var(
+                    constraints,
                     subs,
                     rank,
+                    pools,
                     problems,
                     abilities_store,
                     obligation_cache,
-                    pools,
                     aliases,
-                    expectation.get_type_ref(),
+                    *expectation.get_type_ref(),
                 );
 
                 let mode = match constraint {
@@ -1495,22 +1496,10 @@ fn solve(
                             constraints.eq[eq.index()];
                         let expected = &constraints.expectations[expected.index()];
 
-                        let branches_var = either_type_index_to_var(
-                            constraints,
-                            subs,
-                            rank,
-                            pools,
-                            problems,
-                            abilities_store,
-                            obligation_cache,
-                            aliases,
-                            *expected.get_type_ref(),
-                        );
-
                         (
                             real_var,
                             real_region,
-                            branches_var,
+                            *expected.get_type_ref(),
                             Ok((category, expected)),
                         )
                     }
@@ -1523,21 +1512,10 @@ fn solve(
                         ) = constraints.pattern_eq[peq.index()];
                         let expected = &constraints.pattern_expectations[expected.index()];
 
-                        let branches_var = type_cell_to_var(
-                            subs,
-                            rank,
-                            problems,
-                            abilities_store,
-                            obligation_cache,
-                            pools,
-                            aliases,
-                            expected.get_type_ref(),
-                        );
-
                         (
                             real_var,
                             real_region,
-                            branches_var,
+                            *expected.get_type_ref(),
                             Err((category, expected)),
                         )
                     }
@@ -1555,15 +1533,16 @@ fn solve(
                     real_var,
                 );
 
-                let branches_var = type_cell_to_var(
+                let branches_var = either_type_index_to_var(
+                    constraints,
                     subs,
                     rank,
+                    pools,
                     problems,
                     abilities_store,
                     obligation_cache,
-                    pools,
                     aliases,
-                    expected_type,
+                    branches_var,
                 );
 
                 let cond_source_is_likely_positive_value = category_and_expected.is_ok();

--- a/crates/compiler/solve/tests/solve_expr.rs
+++ b/crates/compiler/solve/tests/solve_expr.rs
@@ -4590,7 +4590,7 @@ mod solve_expr {
                     removeHelp 1i64 Empty
                 "#
             ),
-            "RBTree I64 I64",
+            "RBTree (Key (Integer Signed64)) I64",
         );
     }
 

--- a/crates/compiler/test_derive/src/util.rs
+++ b/crates/compiler/test_derive/src/util.rs
@@ -375,6 +375,7 @@ fn check_derived_typechecks_and_golden(
     let mut rigid_vars = Default::default();
     let (import_variables, abilities_store) = add_imports(
         test_module,
+        &mut constraints,
         &mut test_subs,
         pending_abilities,
         &exposed_for_module,

--- a/crates/reporting/tests/helpers/mod.rs
+++ b/crates/reporting/tests/helpers/mod.rs
@@ -140,9 +140,12 @@ pub fn can_expr_with<'a>(
         }
     };
 
+    let mut constraints = Constraints::new();
+
     let mut var_store = VarStore::default();
     let var = var_store.fresh();
-    let expected = Expected::NoExpectation(Type::Variable(var));
+    let var_index = constraints.push_type(Type::Variable(var));
+    let expected = Expected::NoExpectation(var_index);
     let mut module_ids = ModuleIds::default();
 
     // ensure the Test module is accessible in our tests
@@ -169,7 +172,6 @@ pub fn can_expr_with<'a>(
         &loc_expr.value,
     );
 
-    let mut constraints = Constraints::new();
     let constraint = constrain_expr(
         &mut constraints,
         &mut roc_constrain::expr::Env {


### PR DESCRIPTION
Part 3/many of eliminating type emplacement. This patch adds on to #4399 by eliminating direct references to `Type` in the constraining API entirely; you can now only use constrained types via a `Index<Type>`, which in turn corresponds to exactly one type variable generated during solving, rather than possibly multiple.

Next we'll want to enforce that we eliminate `Type` to an `Index<Type>` at canonicalization, with types SoA.