### PR TITLE
adding crates/README.md for rust docs

### DIFF
--- a/crates/README.md
+++ b/crates/README.md
@@ -1,0 +1,140 @@
+
+# Roc Internals
+
+Roc has different crates for various binaries and libraries used by the toolset. These are described below to help get you started. If you see something here that is out of date, please correct it or follow up in the [Zulip chat](https://roc.zulipchat.com/).
+
+Use `cargo doc` to generate docs for most crates; e.g. ```cargo doc --package roc_ast --open```.
+
+## Roc AST `roc_ast`
+
+The AST is used by the editor and (soon) docs. In contrast to the compiler, the types in AST do not keep track of a location in a file.
+
+## Roc CLI `roc_cli` and `roc` binary
+
+Builds the `roc` binary that brings together all of functionality in the Roc toolset.
+
+## Roc CLI Utils `cli_utils`
+
+Provides shared code for cli tests and benchmarks
+
+## Roc Markup `roc_code_markup`
+
+Roc's very own markup language. This library is used by the editor and docs.
+
+## Roc Compiler
+
+Take a `.roc` file and compile into an executable binary. See [compiler/README.md](./compiler/README.md) for more information.
+
+The compiles includes the following sub-crates;
+- `roc_alias_analysis` TODO - Need assistance
+- `arena-pool` TODO - Need assistance
+- `roc_build` TODO - Need assistance
+- `roc_builtins` provdes the Roc functions and modules that are implicitly imported into every modulesee. See [README.md](./compiler/builtins/README.md) for more information.
+- `roc_can` TODO - Need assistance
+- `roc_collections` TODO - Need assistance
+- `roc_constrain` TODO - Need assistance
+- `roc_debug_flags` TODO - Need assistance
+- `roc_derive` provides auto-derivers?
+- `roc_exhaustive` provides exhaustiveness checking for Roc 
+- `roc_fmt` TODO - Need assistance
+- `roc_gen_dev` provides the development backend to generate Roc binaries extremely fast. See [README.md](./compiler/gen_dev/README.md) for more information.
+- `roc_gen_llvm` provides the LLVM backend to generate Roc binaries.
+- `roc_gen_wasm` provides the WASM backend to generate Roc binaries. See [README.md](./compiler/gen_wasm/README.md) for more information.
+- `roc_ident` provides identifiers
+- `roc_intern` provides generic interners for concurrent and single-thread use cases.
+- `roc_late_solve` provides type unification and solving primitives from the perspective of the compiler backend.
+- `roc_load` used to load a `.roc` file and typecheck
+- `roc_load_internal` TODO - Need assistance
+- `roc_module` TODO - Need assistance
+- `roc_mono` TODO - Need assistance
+- `roc_parse` TODO - Need assistance
+- `roc_problem` provides types to describe problems that can occur when compiling `.roc` code
+- `roc_region` TODO - Need assistance
+- `roc_target` provides types and helpers for compiler targets such as `default_x86_64`
+- `roc_serialize` provides helpers for serializing and deserializing bytes
+- `roc_solve` see [Ambient Lambda Set Specialization](./compiler/solve/docs/ambient_lambda_set_specialization.md) for more information on how polymorphic lambda sets are specialized and resolved in the compiler's type solver. 
+- `roc_solve_problem` provides types to describe problems that can occur during solving
+- `roc_str` provides `Roc` styled collection reference counting. See [README.md](./compiler/str/README.md) for more information.
+- `test_derive` TODO - Need assistance
+- `test_gen` containes all of Roc's generation tests. See [README.md](./compiler/test_gen/README.md) for more information.
+- `test_mono` TODO - Need assistance
+- `test_mono_macros` TODO - Need assistance
+- `roc_types` TODO - Need assistance
+- `roc_unify` TODO - Need assistance
+
+## Roc Docs `roc_docs`
+
+Provides the functionality for generating html documentation from Roc files.
+
+## Roc Docs CLI `roc_docs_cli` and `roc-docs` binary
+
+Provides a binary that is only used for static build servers.
+
+## Roc Editor `roc_editor`
+
+Provdes the functionality for editing Roc files. See [README.md](./editor/README.md) for more information.
+
+## Roc Error Macros `roc_error_macros`
+
+Provides macros for consistent reporting of errors in Roc's rust code.
+
+## Roc Glue `roc_glue`
+
+The `roc_glue` crate generates rust code to connect a Roc app with a rust platform. This tool is not necessary for writing a platform in another language, however, it's an added convenience for rust platform devs.
+
+## Roc Highlight `roc_highlight`
+
+Provides syntax highlighting for Roc by transforming a string and to markup nodes.
+
+## Roc Surgical Linker `roc_linker`
+
+Provides the Roc surgical linker which linkes platforms to Roc applications. See [README.md](./linker/README.md) for more information.
+
+## Roc REPL CLI `roc_repl_cli`
+
+Provides the command line interface functionality for the REPL.
+
+## Roc REPL Eval `roc_repl_eval`
+
+Provides the functioanlity for the REPL to evaluate Roc expressions.
+
+## Roc REPL Expect `roc_repl_expect`
+
+TODO - Need assistance
+
+## Roc REPL Test `repl_test`
+
+TODO - Need assistance
+
+## Roc REPL WASM `roc_repl_wasm`
+
+Provides a build of the REPL for the Roc website using WASM. See [README.md](./repl_wasm/README.md) for more information.
+
+## Roc Reporting `roc_reporting`
+
+TODO - Need assistance
+
+## Roc Std Library `roc_std`
+
+Provides Rust representations of Roc data structures.
+
+## Roc Test Utilities `roc_test_utils`
+
+Provides testing utility functions for use throughout the Rust code base.
+
+## Roc Tracing `roc_tracing`
+
+Provides tracing utility functions for tracing various executable entry points.
+
+## Roc Utilities `roc_utils`
+
+Provides assorted utility functions used all over the code base.
+
+## Vendored Code `./vendor/`
+
+These are files that were originally obtained somewhere else (e.g. crates.io) but which we needed to fork for some Roc-specific reason. See [README.md](./vendor/README.md) for more information.
+
+## Roc WASI Libc `wasi_libc_sys`
+
+Provides a Rust wrapper for the WebAssembly test platform built on libc and is primarily used for testing purposes.
+

--- a/crates/README.md
+++ b/crates/README.md
@@ -1,9 +1,12 @@
-
 # Roc Internals
 
-Roc has different rust crates for various binaries and libraries. These are described below to help give you an overview. If you see something here that is out of date, please correct it or discuss it in the [Zulip chat](https://roc.zulipchat.com/).
+Roc has different rust crates for various binaries and libraries. Their roles are briefly described below. If you'd like to learn more, have any questions, or suspect something is out of date, please start a discussion on the [Roc Zulip](https://roc.zulipchat.com/)!
 
-Use `cargo doc` to generate docs; e.g. ```cargo doc --package roc_ast --open```.
+You can use `cargo doc` to generate docs for a specific package; e.g.
+
+```
+cargo doc --package roc_ast --open
+```
 
 ## `ast/` - `roc_ast`
 
@@ -21,9 +24,9 @@ Provides shared code for cli tests and benchmarks.
 
 ## `code_markup/` - `roc_code_markup`
 
-Roc's very own [markup language](https://en.wikipedia.org/wiki/Markup_language). This library is used by the editor to display good-looking roc code. 
+A [markup language](https://en.wikipedia.org/wiki/Markup_language) to display Roc code in the editor.
 
-## `compile/`
+## `compiler/`
 
 Compiles `.roc` files and combines them with their platform into an executable binary. See [compiler/README.md](./compiler/README.md) for more information.
 
@@ -40,7 +43,7 @@ The compiler includes the following sub-crates;
 - `roc_constrain` Responsible for building the set of constraints that are used during type inference of a program, and for gathering context needed for pleasant error messages when a type error occurs.
 - `roc_debug_flags` Environment variables that can be toggled to aid debugging of the compiler itself.
 - `roc_derive` provides auto-derivers for builtin abilities like `Hash` and `Decode`.
-- `roc_exhaustive` provides exhaustiveness checking for Roc 
+- `roc_exhaustive` provides exhaustiveness checking for Roc.
 - `roc_fmt` The roc code formatter.
 - `roc_gen_dev` provides the compiler backend to generate Roc binaries fast, for a nice developer experience. See [README.md](./compiler/gen_dev/README.md) for more information.
 - `roc_gen_llvm` provides the LLVM backend to generate Roc binaries. Used to generate a binary with the fastest possible execution speed.
@@ -63,7 +66,7 @@ The compiler includes the following sub-crates;
 - `test_derive` Tests Roc's auto-derivers.
 - `test_gen` contains all of Roc's code generation tests. See [README.md](./compiler/test_gen/README.md) for more information.
 - `test_mono` Tests Roc's generation of the mono intermediate representation.
-- `test_mono_macros` Macros for use in test_mono
+- `test_mono_macros` Macros for use in test_mono.
 - `roc_types` Various representations and utilities for dealing with types in the Roc compiler.
 - `roc_unify` Implements Roc's unification algorithm, the heartstone of Roc's type inference.
 
@@ -78,7 +81,7 @@ Provides a binary that is only used for static build servers.
 
 ## `editor/` - `roc_editor`
 
-For editing Roc files (Work In Progress). See [README.md](./editor/README.md) for more information.
+Roc's editor. See [README.md](./editor/README.md) for more information.
 
 ## `error_macros/` - `roc_error_macros`
 
@@ -86,7 +89,7 @@ Provides macros for consistent reporting of errors in Roc's rust code.
 
 ## `glue/` - `roc_glue`
 
-The `roc_glue` crate generates rust code to connect a Roc app with a rust platform. This tool is not necessary for writing a platform in another language, however, it's an added convenience for rust platform devs.
+The `roc_glue` crate generates code needed for platform hosts to communicate with Roc apps. This tool is not necessary for writing a platform in another language, however, it's a great convenience! Currently supports Rust platforms, and the plan is to support any language via a plugin model.
 
 ## `highlight/` - `roc_highlight`
 
@@ -94,9 +97,7 @@ Provides syntax highlighting for the editor by transforming a string to markup n
 
 ## `linker/` - `roc_linker`
 
-Surgical linker that links platforms to Roc applications.
-We created our own linker for speed and because regular linkers add a lot of problems and complexity. Because we want roc to manage the build system and final linking of the executable, it is significantly less practical to use a regular linker. This can be seen in how many arbitrary libraries we link with the legacy linker because we have no idea what libraries the application is actually using.
-See [README.md](./linker/README.md) for more information.
+Surgical linker that links platforms to Roc applications. We created our own linker for performance, since regular linkers add complexity that is not needed for linking Roc apps. Because we want `roc` to manage the build system and final linking of the executable, it is significantly less practical to use a regular linker. See [README.md](./linker/README.md) for more information.
 
 ## `repl_cli/` - `roc_repl_cli`
 

--- a/crates/README.md
+++ b/crates/README.md
@@ -34,16 +34,16 @@ TODO explain what "compiler frontend" is
 TODO explain what "compiler backend" is
 
 The compiler includes the following sub-crates;
-- `roc_alias_analysis` Performs analysis and optimizations to remove unneeded reference counts at runtime, and supports in-place mutation.
-- `arena-pool` An implementation of an arena allocator designed for the compiler's workloads.
+- `roc_alias_analysis` Performs analysis and optimizations to remove unneeded [reference counts](https://en.wikipedia.org/wiki/Reference_counting) at runtime, and supports in-place mutation.
+- `arena-pool` An implementation of an [arena allocator](https://mgravell.github.io/Pipelines.Sockets.Unofficial/docs/arenas.html) designed for the compiler's workloads.
 - `roc_build` Responsible for coordinating building and linking of a Roc app with its host.
 - `roc_builtins` provides the Roc functions and modules that are implicitly imported into every module. See [README.md](./compiler/builtins/README.md) for more information.
-- `roc_can` Canonicalize a roc abstract syntax tree, resolving symbols, re-ordering definitions, and preparing a module for type inference.
+- `roc_can` [Canonicalize](https://en.wikipedia.org/wiki/Canonicalization) a roc [abstract syntax tree](https://en.wikipedia.org/wiki/Abstract_syntax_tree), [resolving symbols](https://stackoverflow.com/a/1175493/4200103), [re-ordering definitions](https://www.oreilly.com/library/view/c-high-performance/9781787120952/546b5677-9157-4333-bc90-16db696436ac.xhtml), and preparing a module for [type inference](https://en.wikipedia.org/wiki/Type_inference).
 - `roc_collections` Domain-specific collections created for the needs of the compiler.
-- `roc_constrain` Responsible for building the set of constraints that are used during type inference of a program, and for gathering context needed for pleasant error messages when a type error occurs.
+- `roc_constrain` Responsible for building the set of constraints that are used during [type inference](https://en.wikipedia.org/wiki/Type_inference) of a program, and for gathering context needed for pleasant error messages when a type error occurs.
 - `roc_debug_flags` Environment variables that can be toggled to aid debugging of the compiler itself.
 - `roc_derive` provides auto-derivers for builtin abilities like `Hash` and `Decode`.
-- `roc_exhaustive` provides exhaustiveness checking for Roc.
+- `roc_exhaustive` provides [exhaustiveness](https://dev.to/babak/exhaustive-type-checking-with-typescript-4l3f) checking for Roc.
 - `roc_fmt` The roc code formatter.
 - `roc_gen_dev` provides the compiler backend to generate Roc binaries fast, for a nice developer experience. See [README.md](./compiler/gen_dev/README.md) for more information.
 - `roc_gen_llvm` provides the LLVM backend to generate Roc binaries. Used to generate a binary with the fastest possible execution speed.
@@ -51,24 +51,24 @@ The compiler includes the following sub-crates;
 - `roc_ident` Implements data structures used for efficiently representing small strings, like identifiers.
 - `roc_intern` provides generic interners for concurrent and single-thread use cases.
 - `roc_late_solve` provides type unification and solving primitives from the perspective of the compiler backend.
-- `roc_load` Used to load a .roc file and coordinate the compiler pipeline, including parsing, type checking, and code generation.
+- `roc_load` Used to load a .roc file and coordinate the compiler pipeline, including parsing, type checking, and [code generation](https://en.wikipedia.org/wiki/Code_generation_(compiler)).
 - `roc_load_internal` The internal implementation of roc_load, separate from roc_load to support caching.
 - `roc_module` Implements data structures used for efficiently representing unique modules and identifiers in Roc programs.
-- `roc_mono` Roc's main intermediate representation (IR), which is responsible for monomorphization, defunctionalization, inserting ref-count instructions, and transforming a Roc program into a form that is easy to consume by a backend.
-- `roc_parse` Implements the Roc parser, which transforms a textual representation of a Roc program to an abstract syntax tree.
+- `roc_mono` Roc's main intermediate representation (IR), which is responsible for [monomorphization](https://en.wikipedia.org/wiki/Monomorphization), defunctionalization, inserting [ref-count](https://en.wikipedia.org/wiki/Reference_counting) instructions, and transforming a Roc program into a form that is easy to consume by a backend.
+- `roc_parse` Implements the Roc parser, which transforms a textual representation of a Roc program to an [abstract syntax tree](https://en.wikipedia.org/wiki/Abstract_syntax_tree).
 - `roc_problem` provides types to describe problems that can occur when compiling `.roc` code.
 - `roc_region` Data structures for storing source-code-location information, used heavily for contextual error messages.
 - `roc_target` provides types and helpers for compiler targets such as `default_x86_64`.
 - `roc_serialize` provides helpers for serializing and deserializing to/from bytes.
-- `roc_solve` The entry point of Roc's type inference system. Implements type inference and specialization of abilities.
+- `roc_solve` The entry point of Roc's [type inference](https://en.wikipedia.org/wiki/Type_inference) system. Implements type inference and specialization of abilities.
 - `roc_solve_problem` provides types to describe problems that can occur during solving.
-- `roc_str` provides `Roc` styled collection reference counting. See [README.md](./compiler/str/README.md) for more information.
+- `roc_str` provides `Roc` styled collection [reference counting](https://en.wikipedia.org/wiki/Reference_counting). See [README.md](./compiler/str/README.md) for more information.
 - `test_derive` Tests Roc's auto-derivers.
-- `test_gen` contains all of Roc's code generation tests. See [README.md](./compiler/test_gen/README.md) for more information.
+- `test_gen` contains all of Roc's [code generation](https://en.wikipedia.org/wiki/Code_generation_(compiler)) tests. See [README.md](./compiler/test_gen/README.md) for more information.
 - `test_mono` Tests Roc's generation of the mono intermediate representation.
-- `test_mono_macros` Macros for use in test_mono.
+- `test_mono_macros` Macros for use in `test_mono`.
 - `roc_types` Various representations and utilities for dealing with types in the Roc compiler.
-- `roc_unify` Implements Roc's unification algorithm, the heartstone of Roc's type inference.
+- `roc_unify` Implements Roc's unification algorithm, the heartstone of Roc's [type inference](https://en.wikipedia.org/wiki/Type_inference).
 
 ## `docs/` - `roc_docs`
 

--- a/crates/README.md
+++ b/crates/README.md
@@ -1,35 +1,40 @@
 
 # Roc Internals
 
-Roc has different crates for various binaries and libraries used by the toolset. These are described below to help get you started. If you see something here that is out of date, please correct it or follow up in the [Zulip chat](https://roc.zulipchat.com/).
+Roc has different rust crates for various binaries and libraries. These are described below to help give you an overview. If you see something here that is out of date, please correct it or discuss it in the [Zulip chat](https://roc.zulipchat.com/).
 
-Use `cargo doc` to generate docs for most crates; e.g. ```cargo doc --package roc_ast --open```.
+Use `cargo doc` to generate docs; e.g. ```cargo doc --package roc_ast --open```.
 
-## Roc AST `roc_ast`
+## `ast/` - `roc_ast`
 
-The AST is used by the editor and (soon) docs. In contrast to the compiler, the types in AST do not keep track of a location in a file.
+Code to represent the [Abstract Syntax Tree](https://en.wikipedia.org/wiki/Abstract_syntax_tree) as used by the editor.
+In contrast to the compiler, the types in this AST do not keep track of the location of the matching code in the source file.
 
-## Roc CLI `roc_cli` and `roc` binary
 
-Builds the `roc` binary that brings together all of functionality in the Roc toolset.
+## `cli/` - `roc_cli`
 
-## Roc CLI Utils `cli_utils`
+The `roc` binary that brings together all functionality in the Roc toolset.
 
-Provides shared code for cli tests and benchmarks
+## `cli_utils/` - `cli_utils`
 
-## Roc Markup `roc_code_markup`
+Provides shared code for cli tests and benchmarks.
 
-Roc's very own markup language. This library is used by the editor and docs.
+## `code_markup/` - `roc_code_markup`
 
-## Roc Compiler
+Roc's very own [markup language](https://en.wikipedia.org/wiki/Markup_language). This library is used by the editor to display good-looking roc code. 
 
-Take a `.roc` file and compile into an executable binary. See [compiler/README.md](./compiler/README.md) for more information.
+## `compile/`
 
-The compiles includes the following sub-crates;
+Compiles `.roc` files and combine them with their platform into an executable binary. See [compiler/README.md](./compiler/README.md) for more information.
+
+TODO explain what "compiler frontend" is
+TODO explain what "compiler backend" is
+
+The compiler includes the following sub-crates;
 - `roc_alias_analysis` TODO - Need assistance
 - `arena-pool` TODO - Need assistance
 - `roc_build` TODO - Need assistance
-- `roc_builtins` provdes the Roc functions and modules that are implicitly imported into every modulesee. See [README.md](./compiler/builtins/README.md) for more information.
+- `roc_builtins` provdes the Roc functions and modules that are implicitly imported into every module. See [README.md](./compiler/builtins/README.md) for more information.
 - `roc_can` TODO - Need assistance
 - `roc_collections` TODO - Need assistance
 - `roc_constrain` TODO - Need assistance
@@ -37,104 +42,106 @@ The compiles includes the following sub-crates;
 - `roc_derive` provides auto-derivers?
 - `roc_exhaustive` provides exhaustiveness checking for Roc 
 - `roc_fmt` TODO - Need assistance
-- `roc_gen_dev` provides the development backend to generate Roc binaries extremely fast. See [README.md](./compiler/gen_dev/README.md) for more information.
-- `roc_gen_llvm` provides the LLVM backend to generate Roc binaries.
+- `roc_gen_dev` provides the compiler backend to generate Roc binaries fast, for a nice developer experience. See [README.md](./compiler/gen_dev/README.md) for more information.
+- `roc_gen_llvm` provides the LLVM backend to generate Roc binaries. Used to generate a binary with the fastest possible execution speed.
 - `roc_gen_wasm` provides the WASM backend to generate Roc binaries. See [README.md](./compiler/gen_wasm/README.md) for more information.
 - `roc_ident` provides identifiers
 - `roc_intern` provides generic interners for concurrent and single-thread use cases.
 - `roc_late_solve` provides type unification and solving primitives from the perspective of the compiler backend.
-- `roc_load` used to load a `.roc` file and typecheck
+- `roc_load` used to load a `.roc` file and typecheck it.
 - `roc_load_internal` TODO - Need assistance
 - `roc_module` TODO - Need assistance
 - `roc_mono` TODO - Need assistance
 - `roc_parse` TODO - Need assistance
-- `roc_problem` provides types to describe problems that can occur when compiling `.roc` code
+- `roc_problem` provides types to describe problems that can occur when compiling `.roc` code.
 - `roc_region` TODO - Need assistance
-- `roc_target` provides types and helpers for compiler targets such as `default_x86_64`
-- `roc_serialize` provides helpers for serializing and deserializing bytes
+- `roc_target` provides types and helpers for compiler targets such as `default_x86_64`.
+- `roc_serialize` provides helpers for serializing and deserializing to/from bytes.
 - `roc_solve` see [Ambient Lambda Set Specialization](./compiler/solve/docs/ambient_lambda_set_specialization.md) for more information on how polymorphic lambda sets are specialized and resolved in the compiler's type solver. 
-- `roc_solve_problem` provides types to describe problems that can occur during solving
+- `roc_solve_problem` provides types to describe problems that can occur during solving.
 - `roc_str` provides `Roc` styled collection reference counting. See [README.md](./compiler/str/README.md) for more information.
 - `test_derive` TODO - Need assistance
-- `test_gen` containes all of Roc's generation tests. See [README.md](./compiler/test_gen/README.md) for more information.
+- `test_gen` contains all of Roc's code generation tests. See [README.md](./compiler/test_gen/README.md) for more information.
 - `test_mono` TODO - Need assistance
 - `test_mono_macros` TODO - Need assistance
 - `roc_types` TODO - Need assistance
 - `roc_unify` TODO - Need assistance
 
-## Roc Docs `roc_docs`
+## `docs/` - `roc_docs`
 
-Provides the functionality for generating html documentation from Roc files.
+Generates html documentation from Roc files.
+Used for [roc-lang.org/builtins/Num](https://www.roc-lang.org/builtins/Num).
 
-## Roc Docs CLI `roc_docs_cli` and `roc-docs` binary
+## `docs_cli/` - `roc_docs_cli` library and `roc-docs` binary
 
 Provides a binary that is only used for static build servers.
 
-## Roc Editor `roc_editor`
+## `editor/` - `roc_editor`
 
-Provdes the functionality for editing Roc files. See [README.md](./editor/README.md) for more information.
+For editing Roc files (Work In Progress). See [README.md](./editor/README.md) for more information.
 
-## Roc Error Macros `roc_error_macros`
+## `error_macros/` - `roc_error_macros`
 
 Provides macros for consistent reporting of errors in Roc's rust code.
 
-## Roc Glue `roc_glue`
+## `glue/` - `roc_glue`
 
 The `roc_glue` crate generates rust code to connect a Roc app with a rust platform. This tool is not necessary for writing a platform in another language, however, it's an added convenience for rust platform devs.
 
-## Roc Highlight `roc_highlight`
+## `highlight/` - `roc_highlight`
 
-Provides syntax highlighting for Roc by transforming a string and to markup nodes.
+Provides syntax highlighting for the editor by transforming a string to markup nodes.
 
-## Roc Surgical Linker `roc_linker`
+## `linker/` - `roc_linker`
 
-Provides the Roc surgical linker which linkes platforms to Roc applications. See [README.md](./linker/README.md) for more information.
+Surgical linker that links platforms to Roc applications.
+We created our own linker for speed and because regular linkers add a lot of problems and complexity. Because we want roc to manage the build system and final linking of the executable, it is significantly less practical to use a regular linker. This can be seen in how many arbitrary libraries we link with the legacy linker because we have no idea what libraries the application is actually using.
+See [README.md](./linker/README.md) for more information.
 
-## Roc REPL CLI `roc_repl_cli`
+## `repl_cli/` - `roc_repl_cli`
 
-Provides the command line interface functionality for the REPL.
+Command Line Interface(CLI) functionality for the Read-Evaluate-Print-Loop (REPL).
 
-## Roc REPL Eval `roc_repl_eval`
+## `repl_eval/` - `roc_repl_eval`
 
-Provides the functioanlity for the REPL to evaluate Roc expressions.
+Provides the functionality for the REPL to evaluate Roc expressions.
 
-## Roc REPL Expect `roc_repl_expect`
-
-TODO - Need assistance
-
-## Roc REPL Test `repl_test`
+## `repl_expect/` - `roc_repl_expect`
 
 TODO - Need assistance
 
-## Roc REPL WASM `roc_repl_wasm`
-
-Provides a build of the REPL for the Roc website using WASM. See [README.md](./repl_wasm/README.md) for more information.
-
-## Roc Reporting `roc_reporting`
+## `repl_test/` - `repl_test`
 
 TODO - Need assistance
 
-## Roc Std Library `roc_std`
+## `repl_wasm/` - `roc_repl_wasm`
+
+Provides a build of the REPL for the Roc website using WebAssembly. See [README.md](./repl_wasm/README.md) for more information.
+
+## `reporting/` - `roc_reporting`
+
+TODO - Need assistance
+
+## `roc_std/` - `roc_std`
 
 Provides Rust representations of Roc data structures.
 
-## Roc Test Utilities `roc_test_utils`
+## `test_utils/` - `roc_test_utils`
 
 Provides testing utility functions for use throughout the Rust code base.
 
-## Roc Tracing `roc_tracing`
+## `tracing/` - `roc_tracing`
 
-Provides tracing utility functions for tracing various executable entry points.
+Provides tracing utility functions for various executable entry points.
 
-## Roc Utilities `roc_utils`
+## `utils/` - `roc_utils`
 
-Provides assorted utility functions used all over the code base.
+Provides utility functions used all over the code base.
 
-## Vendored Code `./vendor/`
+## `vendor/`
 
 These are files that were originally obtained somewhere else (e.g. crates.io) but which we needed to fork for some Roc-specific reason. See [README.md](./vendor/README.md) for more information.
 
-## Roc WASI Libc `wasi_libc_sys`
+## `wasi-libc-sys/` - `wasi_libc_sys`
 
 Provides a Rust wrapper for the WebAssembly test platform built on libc and is primarily used for testing purposes.
-

--- a/crates/README.md
+++ b/crates/README.md
@@ -25,47 +25,47 @@ Roc's very own [markup language](https://en.wikipedia.org/wiki/Markup_language).
 
 ## `compile/`
 
-Compiles `.roc` files and combine them with their platform into an executable binary. See [compiler/README.md](./compiler/README.md) for more information.
+Compiles `.roc` files and combines them with their platform into an executable binary. See [compiler/README.md](./compiler/README.md) for more information.
 
 TODO explain what "compiler frontend" is
 TODO explain what "compiler backend" is
 
 The compiler includes the following sub-crates;
-- `roc_alias_analysis` TODO - Need assistance
-- `arena-pool` TODO - Need assistance
-- `roc_build` TODO - Need assistance
-- `roc_builtins` provdes the Roc functions and modules that are implicitly imported into every module. See [README.md](./compiler/builtins/README.md) for more information.
-- `roc_can` TODO - Need assistance
-- `roc_collections` TODO - Need assistance
-- `roc_constrain` TODO - Need assistance
-- `roc_debug_flags` TODO - Need assistance
-- `roc_derive` provides auto-derivers?
+- `roc_alias_analysis` Performs analysis and optimizations to remove unneeded reference counts at runtime, and supports in-place mutation.
+- `arena-pool` An implementation of an arena allocator designed for the compiler's workloads.
+- `roc_build` Responsible for coordinating building and linking of a Roc app with its host.
+- `roc_builtins` provides the Roc functions and modules that are implicitly imported into every module. See [README.md](./compiler/builtins/README.md) for more information.
+- `roc_can` Canonicalize a roc abstract syntax tree, resolving symbols, re-ordering definitions, and preparing a module for type inference.
+- `roc_collections` Domain-specific collections created for the needs of the compiler.
+- `roc_constrain` Responsible for building the set of constraints that are used during type inference of a program, and for gathering context needed for pleasant error messages when a type error occurs.
+- `roc_debug_flags` Environment variables that can be toggled to aid debugging of the compiler itself.
+- `roc_derive` provides auto-derivers for builtin abilities like `Hash` and `Decode`.
 - `roc_exhaustive` provides exhaustiveness checking for Roc 
-- `roc_fmt` TODO - Need assistance
+- `roc_fmt` The roc code formatter.
 - `roc_gen_dev` provides the compiler backend to generate Roc binaries fast, for a nice developer experience. See [README.md](./compiler/gen_dev/README.md) for more information.
 - `roc_gen_llvm` provides the LLVM backend to generate Roc binaries. Used to generate a binary with the fastest possible execution speed.
 - `roc_gen_wasm` provides the WASM backend to generate Roc binaries. See [README.md](./compiler/gen_wasm/README.md) for more information.
-- `roc_ident` provides identifiers
+- `roc_ident` Implements data structures used for efficiently representing small strings, like identifiers.
 - `roc_intern` provides generic interners for concurrent and single-thread use cases.
 - `roc_late_solve` provides type unification and solving primitives from the perspective of the compiler backend.
-- `roc_load` used to load a `.roc` file and typecheck it.
-- `roc_load_internal` TODO - Need assistance
-- `roc_module` TODO - Need assistance
-- `roc_mono` TODO - Need assistance
-- `roc_parse` TODO - Need assistance
+- `roc_load` Used to load a .roc file and coordinate the compiler pipeline, including parsing, type checking, and code generation.
+- `roc_load_internal` The internal implementation of roc_load, separate from roc_load to support caching.
+- `roc_module` Implements data structures used for efficiently representing unique modules and identifiers in Roc programs.
+- `roc_mono` Roc's main intermediate representation (IR), which is responsible for monomorphization, defunctionalization, inserting ref-count instructions, and transforming a Roc program into a form that is easy to consume by a backend.
+- `roc_parse` Implements the Roc parser, which transforms a textual representation of a Roc program to an abstract syntax tree.
 - `roc_problem` provides types to describe problems that can occur when compiling `.roc` code.
-- `roc_region` TODO - Need assistance
+- `roc_region` Data structures for storing source-code-location information, used heavily for contextual error messages.
 - `roc_target` provides types and helpers for compiler targets such as `default_x86_64`.
 - `roc_serialize` provides helpers for serializing and deserializing to/from bytes.
-- `roc_solve` see [Ambient Lambda Set Specialization](./compiler/solve/docs/ambient_lambda_set_specialization.md) for more information on how polymorphic lambda sets are specialized and resolved in the compiler's type solver. 
+- `roc_solve` The entry point of Roc's type inference system. Implements type inference and specialization of abilities.
 - `roc_solve_problem` provides types to describe problems that can occur during solving.
 - `roc_str` provides `Roc` styled collection reference counting. See [README.md](./compiler/str/README.md) for more information.
-- `test_derive` TODO - Need assistance
+- `test_derive` Tests Roc's auto-derivers.
 - `test_gen` contains all of Roc's code generation tests. See [README.md](./compiler/test_gen/README.md) for more information.
-- `test_mono` TODO - Need assistance
-- `test_mono_macros` TODO - Need assistance
-- `roc_types` TODO - Need assistance
-- `roc_unify` TODO - Need assistance
+- `test_mono` Tests Roc's generation of the mono intermediate representation.
+- `test_mono_macros` Macros for use in test_mono
+- `roc_types` Various representations and utilities for dealing with types in the Roc compiler.
+- `roc_unify` Implements Roc's unification algorithm, the heartstone of Roc's type inference.
 
 ## `docs/` - `roc_docs`
 
@@ -108,11 +108,11 @@ Provides the functionality for the REPL to evaluate Roc expressions.
 
 ## `repl_expect/` - `roc_repl_expect`
 
-TODO - Need assistance
+Supports evaluating `expect` and printing contextual information when they fail.
 
 ## `repl_test/` - `repl_test`
 
-TODO - Need assistance
+Tests the roc REPL.
 
 ## `repl_wasm/` - `roc_repl_wasm`
 
@@ -120,7 +120,7 @@ Provides a build of the REPL for the Roc website using WebAssembly. See [README.
 
 ## `reporting/` - `roc_reporting`
 
-TODO - Need assistance
+Responsible for generating warning and error messages.
 
 ## `roc_std/` - `roc_std`
 

--- a/crates/ast/src/lib.rs
+++ b/crates/ast/src/lib.rs
@@ -1,8 +1,8 @@
 //! Library to represent the [Abstract Syntax Tree](https://en.wikipedia.org/wiki/Abstract_syntax_tree).
 //!  
-//! Used by roc_editor. In contrast to the compiler,
-//! In contrast to the compiler, the types in this
-//! AST do not keep track of the location of the matching code in the source file.
+//! Used by roc_editor.
+//! In contrast to the compiler, the types in this AST do not
+//! keep track of the location of the matching code in the source file.
 pub mod ast_error;
 mod builtin_aliases;
 mod canonicalization;

--- a/crates/ast/src/lib.rs
+++ b/crates/ast/src/lib.rs
@@ -1,6 +1,6 @@
 //! Library to represent the [Abstract Syntax Tree](https://en.wikipedia.org/wiki/Abstract_syntax_tree).
 //!  
-//! Used by roc_editor. In contrast to the compiler, 
+//! Used by roc_editor. In contrast to the compiler,
 //! In contrast to the compiler, the types in this
 //! AST do not keep track of the location of the matching code in the source file.
 pub mod ast_error;

--- a/crates/ast/src/lib.rs
+++ b/crates/ast/src/lib.rs
@@ -1,3 +1,7 @@
+//! Provides AST library for Roc
+//!  
+//! AST is used by roc_editor and (soon) roc_docs. In contrast to the compiler, 
+//! these types do not keep track of a location in a file.
 pub mod ast_error;
 mod builtin_aliases;
 mod canonicalization;

--- a/crates/ast/src/lib.rs
+++ b/crates/ast/src/lib.rs
@@ -1,7 +1,8 @@
-//! Provides AST library for Roc
+//! Library to represent the [Abstract Syntax Tree](https://en.wikipedia.org/wiki/Abstract_syntax_tree).
 //!  
-//! AST is used by roc_editor and (soon) roc_docs. In contrast to the compiler, 
-//! these types do not keep track of a location in a file.
+//! Used by roc_editor. In contrast to the compiler, 
+//! In contrast to the compiler, the types in this
+//! AST do not keep track of the location of the matching code in the source file.
 pub mod ast_error;
 mod builtin_aliases;
 mod canonicalization;

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1,3 +1,5 @@
+//! Provides the core CLI functionality for the `roc` binary
+
 #[macro_use]
 extern crate const_format;
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,4 +1,4 @@
-//! Builds the `roc` binary
+//! the `roc` binary
 use roc_build::link::LinkType;
 use roc_cli::build::check_file;
 use roc_cli::{

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,3 +1,4 @@
+//! Builds the `roc` binary
 use roc_build::link::LinkType;
 use roc_cli::build::check_file;
 use roc_cli::{

--- a/crates/cli_utils/src/lib.rs
+++ b/crates/cli_utils/src/lib.rs
@@ -1,2 +1,3 @@
+//! Provides shared code for cli tests and benchmarks
 pub mod bench_utils;
 pub mod helpers;


### PR DESCRIPTION
WIP - Need assistance. 

I've created a README.md for the Rust crates folder and linked to all of the sub-crates. Where I can I have added a brief description for each library. However it is difficult for me to piece it all together. 

I would appreciate any assistance you can provide adding to this. 

I have ran the the following with no issues.
```
cargo test
cargo fmt --all -- --check
cargo clippy --workspace --tests -- --deny warnings
```