### PR TITLE
centralized commands, better errors, link build command refactoring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -496,6 +496,7 @@ dependencies = [
  "roc_load",
  "roc_module",
  "roc_reporting",
+ "roc_utils",
  "serde",
  "serde-xml-rs",
  "strip-ansi-escapes",
@@ -3572,6 +3573,7 @@ dependencies = [
  "roc_solve",
  "roc_types",
  "roc_unify",
+ "roc_utils",
  "rodio",
  "serde",
  "snafu",
@@ -3991,6 +3993,7 @@ dependencies = [
  "roc_reporting",
  "roc_target",
  "roc_types",
+ "roc_utils",
  "wasi_libc_sys",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -4858,6 +4861,7 @@ dependencies = [
  "roc_target",
  "roc_types",
  "roc_unify",
+ "roc_utils",
  "target-lexicon",
  "tempfile",
  "wasi_libc_sys",
@@ -5260,6 +5264,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 [[package]]
 name = "wasi_libc_sys"
 version = "0.0.1"
+dependencies = [
+ "roc_utils",
+]
 
 [[package]]
 name = "wasm-bindgen"

--- a/crates/cli/src/build.rs
+++ b/crates/cli/src/build.rs
@@ -252,7 +252,9 @@ pub fn build_file<'a>(
     }
 
     let rebuild_timing = if linking_strategy == LinkingStrategy::Additive {
-        let rebuild_duration = rebuild_thread.join().unwrap();
+        let rebuild_duration = rebuild_thread
+            .join()
+            .expect("Failed to (re)build platform.");
         if emit_timings && !prebuilt {
             println!(
                 "Finished rebuilding the platform in {} ms\n",
@@ -304,7 +306,7 @@ pub fn build_file<'a>(
     }
 
     if let HostRebuildTiming::ConcurrentWithApp(thread) = rebuild_timing {
-        let rebuild_duration = thread.join().unwrap();
+        let rebuild_duration = thread.join().expect("Failed to (re)build platform.");
         if emit_timings && !prebuilt {
             println!(
                 "Finished rebuilding the platform in {} ms\n",

--- a/crates/cli_utils/Cargo.toml
+++ b/crates/cli_utils/Cargo.toml
@@ -14,6 +14,7 @@ roc_collections = { path = "../compiler/collections" }
 roc_reporting = { path = "../reporting" }
 roc_load = { path = "../compiler/load" }
 roc_module = { path = "../compiler/module" }
+roc_utils = { path = "../utils" }
 bumpalo = { version = "3.8.0", features = ["collections"] }
 criterion = { git = "https://github.com/Anton-4/criterion.rs"}
 serde = { version = "1.0.130", features = ["derive"] }

--- a/crates/cli_utils/src/helpers.rs
+++ b/crates/cli_utils/src/helpers.rs
@@ -4,6 +4,7 @@ extern crate roc_load;
 extern crate roc_module;
 extern crate tempfile;
 
+use roc_utils::cargo;
 use serde::Deserialize;
 use serde_xml_rs::from_str;
 use std::env;
@@ -48,7 +49,7 @@ where
             vec!["build", "--release", "--bin", "roc"]
         };
 
-        let output = Command::new("cargo")
+        let output = cargo()
             .current_dir(root_project_dir)
             .args(args)
             .output()

--- a/crates/compiler/builtins/Cargo.toml
+++ b/crates/compiler/builtins/Cargo.toml
@@ -16,6 +16,7 @@ lazy_static = "1.4.0"
 [build-dependencies]
 # dunce can be removed once ziglang/zig#5109 is fixed
 dunce = "1.0.3"
+roc_utils = { path = "../../utils" }
 
 [target.'cfg(target_os = "macos")'.build-dependencies]
 tempfile = "3.2.0"

--- a/crates/compiler/test_gen/Cargo.toml
+++ b/crates/compiler/test_gen/Cargo.toml
@@ -11,6 +11,7 @@ path = "src/tests.rs"
 
 [build-dependencies]
 roc_builtins = { path = "../builtins" }
+roc_utils = { path = "../../utils" }
 wasi_libc_sys = { path = "../../wasi-libc-sys" }
 
 [dev-dependencies]
@@ -25,6 +26,7 @@ roc_types = { path = "../types" }
 roc_builtins = { path = "../builtins" }
 roc_constrain = { path = "../constrain" }
 roc_unify = { path = "../unify" }
+roc_utils = { path = "../../utils" }
 roc_solve = { path = "../solve" }
 roc_mono = { path = "../mono" }
 roc_reporting = { path = "../../reporting" }

--- a/crates/compiler/test_gen/src/helpers/llvm.rs
+++ b/crates/compiler/test_gen/src/helpers/llvm.rs
@@ -12,6 +12,7 @@ use roc_load::{EntryPoint, ExecutionMode, LoadConfig, Threading};
 use roc_mono::ir::OptLevel;
 use roc_region::all::LineInfo;
 use roc_reporting::report::RenderTarget;
+use roc_utils::zig;
 use target_lexicon::Triple;
 
 #[cfg(feature = "gen-llvm-wasm")]
@@ -456,9 +457,7 @@ fn llvm_module_to_wasm_file(
         .write_to_file(llvm_module, file_type, &test_a_path)
         .unwrap();
 
-    use std::process::Command;
-
-    let output = Command::new(&crate::helpers::zig_executable())
+    let output = zig()
         .current_dir(dir_path)
         .args(&[
             "wasm-ld",

--- a/crates/compiler/test_gen/src/helpers/mod.rs
+++ b/crates/compiler/test_gen/src/helpers/mod.rs
@@ -11,14 +11,6 @@ pub mod llvm;
 pub mod wasm;
 
 #[allow(dead_code)]
-pub fn zig_executable() -> String {
-    match std::env::var("ROC_ZIG") {
-        Ok(path) => path,
-        Err(_) => "zig".into(),
-    }
-}
-
-#[allow(dead_code)]
 pub(crate) fn src_hash(src: &str) -> u64 {
     use std::collections::hash_map::DefaultHasher;
     use std::hash::{Hash, Hasher};

--- a/crates/editor/Cargo.toml
+++ b/crates/editor/Cargo.toml
@@ -30,6 +30,7 @@ roc_problem = { path = "../compiler/problem" }
 roc_types = { path = "../compiler/types" }
 roc_unify = { path = "../compiler/unify" }
 roc_reporting = { path = "../reporting" }
+roc_utils = { path = "../utils" }
 roc_solve = { path = "../compiler/solve" }
 ven_graph = { path = "../vendor/pathfinding" }
 bumpalo = { version = "3.11.0", features = ["collections"] }

--- a/crates/editor/src/editor/mvc/ed_update.rs
+++ b/crates/editor/src/editor/mvc/ed_update.rs
@@ -1,6 +1,5 @@
 #![allow(dead_code)]
 
-use std::process::Command;
 use std::process::Stdio;
 
 use crate::editor::code_lines::CodeLines;
@@ -63,6 +62,7 @@ use roc_solve::module::Solved;
 use roc_types::pretty_print::name_and_print_var;
 use roc_types::pretty_print::DebugPrint;
 use roc_types::subs::{Subs, VarStore, Variable};
+use roc_utils::cargo;
 use snafu::OptionExt;
 use threadpool::ThreadPool;
 use winit::event::VirtualKeyCode;
@@ -622,7 +622,7 @@ impl<'a> EdModel<'a> {
 
         let roc_file_str = path_to_string(self.file_path);
 
-        let cmd_out = Command::new("cargo")
+        let cmd_out = cargo()
             .arg("run")
             .arg("check")
             .arg(roc_file_str)
@@ -641,7 +641,7 @@ impl<'a> EdModel<'a> {
 
         let roc_file_str = path_to_string(self.file_path);
 
-        Command::new("cargo")
+        cargo()
             .arg("run")
             .arg(roc_file_str)
             .stdout(Stdio::inherit())

--- a/crates/repl_wasm/Cargo.toml
+++ b/crates/repl_wasm/Cargo.toml
@@ -10,6 +10,7 @@ crate-type = ["cdylib"]
 
 [build-dependencies]
 roc_builtins = {path = "../compiler/builtins"}
+roc_utils = {path = "../utils"}
 wasi_libc_sys = { path = "../wasi-libc-sys" }
 
 [dependencies]

--- a/crates/wasi-libc-sys/Cargo.toml
+++ b/crates/wasi-libc-sys/Cargo.toml
@@ -6,3 +6,6 @@ license = "UPL-1.0"
 name = "wasi_libc_sys"
 repository = "https://github.com/roc-lang/roc"
 version = "0.0.1"
+
+[build-dependencies]
+roc_utils = {path = "../utils"}

--- a/crates/wasi-libc-sys/build.rs
+++ b/crates/wasi-libc-sys/build.rs
@@ -1,8 +1,8 @@
+use roc_utils::zig;
 use std::env;
 use std::ffi::OsString;
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::process::Command;
 
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
@@ -13,7 +13,7 @@ fn main() {
     let out_file = PathBuf::from(&out_dir).join("wasi-libc.a");
 
     // Compile a dummy C program with Zig, with our own private cache directory
-    Command::new(&zig_executable())
+    zig()
         .args([
             "build-exe",
             "-target",
@@ -49,13 +49,6 @@ fn main() {
         "cargo:rustc-env=WASI_COMPILER_RT_PATH={}",
         compiler_rt_path.to_str().unwrap()
     );
-}
-
-fn zig_executable() -> String {
-    match std::env::var("ROC_ZIG") {
-        Ok(path) => path,
-        Err(_) => "zig".into(),
-    }
 }
 
 fn find(dir: &Path, filename: &OsString) -> std::io::Result<Option<PathBuf>> {


### PR DESCRIPTION
- Closes #4423: centralized commands for cargo, zig, and clang.
- Closes #3631: nice error messages for when rust, zig, or clang is not installed.
- Refactoring of `validate_output`; error messages now print the entire command with all arguments.