### PR TITLE
Refactor Parser trait to pass min_indent

### DIFF
--- a/crates/cli/src/format.rs
+++ b/crates/cli/src/format.rs
@@ -157,7 +157,9 @@ fn parse_all<'a>(arena: &'a Bump, src: &'a str) -> Result<Ast<'a>, SyntaxError<'
     let (module, state) = module::parse_header(arena, State::new(src.as_bytes()))
         .map_err(|e| SyntaxError::Header(e.problem))?;
 
-    let (_, defs, _) = module_defs().parse(arena, state).map_err(|(_, e, _)| e)?;
+    let (_, defs, _) = module_defs()
+        .parse(arena, state, 0)
+        .map_err(|(_, e, _)| e)?;
 
     Ok(Ast { module, defs })
 }

--- a/crates/compiler/fmt/tests/test_fmt.rs
+++ b/crates/compiler/fmt/tests/test_fmt.rs
@@ -86,7 +86,7 @@ mod test_fmt {
     ) {
         fmt_module(buf, module);
 
-        match module_defs().parse(arena, state) {
+        match module_defs().parse(arena, state, 0) {
             Ok((_, loc_defs, _)) => {
                 fmt_defs(buf, &loc_defs, 0);
             }

--- a/crates/compiler/load_internal/src/file.rs
+++ b/crates/compiler/load_internal/src/file.rs
@@ -4824,7 +4824,7 @@ fn parse<'a>(arena: &'a Bump, header: ModuleHeader<'a>) -> Result<Msg<'a>, Loadi
     let parse_start = Instant::now();
     let source = header.parse_state.original_bytes();
     let parse_state = header.parse_state;
-    let parsed_defs = match module_defs().parse(arena, parse_state) {
+    let parsed_defs = match module_defs().parse(arena, parse_state, 0) {
         Ok((_, success, _state)) => success,
         Err((_, fail, state)) => {
             return Err(LoadingProblem::ParsingFailed(

--- a/crates/compiler/parse/benches/bench_parse.rs
+++ b/crates/compiler/parse/benches/bench_parse.rs
@@ -23,8 +23,9 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             let (_actual, state) =
                 module::parse_header(&arena, State::new(src.as_bytes())).unwrap();
 
+            let min_indent = 0;
             let res = module_defs()
-                .parse(&arena, state)
+                .parse(&arena, state, min_indent)
                 .map(|tuple| tuple.1)
                 .unwrap();
 

--- a/crates/compiler/parse/src/expr.rs
+++ b/crates/compiler/parse/src/expr.rs
@@ -8,9 +8,10 @@ use crate::blankspace::{
 use crate::ident::{lowercase_ident, parse_ident, Ident};
 use crate::keyword;
 use crate::parser::{
-    self, backtrackable, optional, parse_word1, sep_by1, sep_by1_e, specialize, specialize_ref,
-    then, trailing_sep_by0, word1, word2, EClosure, EExpect, EExpr, EIf, EInParens, EList, ENumber,
-    EPattern, ERecord, EString, EType, EWhen, Either, ParseResult, Parser,
+    self, backtrackable, increment_min_indent, optional, parse_word1, reset_min_indent, sep_by1,
+    sep_by1_e, set_min_indent, specialize, specialize_ref, then, trailing_sep_by0, word1, word2,
+    EClosure, EExpect, EExpr, EIf, EInParens, EList, ENumber, EPattern, ERecord, EString, EType,
+    EWhen, Either, ParseResult, Parser,
 };
 use crate::pattern::{loc_closure_param, loc_has_parser};
 use crate::state::State;
@@ -24,7 +25,7 @@ use roc_region::all::{Loc, Position, Region};
 use crate::parser::Progress::{self, *};
 
 fn expr_end<'a>() -> impl Parser<'a, (), EExpr<'a>> {
-    |_arena, state: State<'a>| {
+    |_arena, state: State<'a>, _min_indent: u32| {
         if state.has_reached_end() {
             Ok((NoProgress, (), state))
         } else {
@@ -39,15 +40,11 @@ pub fn test_parse_expr<'a>(
     state: State<'a>,
 ) -> Result<Loc<Expr<'a>>, EExpr<'a>> {
     let parser = skip_second!(
-        space0_before_e(
-            move |a, s| parse_loc_expr(min_indent, a, s),
-            min_indent,
-            EExpr::IndentStart,
-        ),
+        space0_before_e(parse_loc_expr, EExpr::IndentStart,),
         expr_end()
     );
 
-    match parser.parse(arena, state) {
+    match parser.parse(arena, state, min_indent) {
         Ok((_, expression, _)) => Ok(expression),
         Err((_, fail, _)) => Err(fail),
     }
@@ -77,15 +74,16 @@ impl Default for ExprParseOptions {
     }
 }
 
-pub fn expr_help<'a>(min_indent: u32) -> impl Parser<'a, Expr<'a>, EExpr<'a>> {
-    move |arena, state: State<'a>| {
-        parse_loc_expr(min_indent, arena, state).map(|(a, b, c)| (a, b.value, c))
+pub fn expr_help<'a>() -> impl Parser<'a, Expr<'a>, EExpr<'a>> {
+    move |arena, state: State<'a>, min_indent: u32| {
+        parse_loc_expr(arena, state, min_indent).map(|(a, b, c)| (a, b.value, c))
     }
 }
 
-fn loc_expr_in_parens_help<'a>(min_indent: u32) -> impl Parser<'a, Loc<Expr<'a>>, EInParens<'a>> {
-    move |arena, state| {
-        let (_, loc_expr, state) = loc_expr_in_parens_help_help(min_indent).parse(arena, state)?;
+fn loc_expr_in_parens_help<'a>() -> impl Parser<'a, Loc<Expr<'a>>, EInParens<'a>> {
+    move |arena, state, min_indent| {
+        let (_, loc_expr, state) =
+            loc_expr_in_parens_help_help().parse(arena, state, min_indent)?;
 
         Ok((
             MadeProgress,
@@ -98,16 +96,11 @@ fn loc_expr_in_parens_help<'a>(min_indent: u32) -> impl Parser<'a, Loc<Expr<'a>>
     }
 }
 
-fn loc_expr_in_parens_help_help<'a>(
-    min_indent: u32,
-) -> impl Parser<'a, Loc<Expr<'a>>, EInParens<'a>> {
+fn loc_expr_in_parens_help_help<'a>() -> impl Parser<'a, Loc<Expr<'a>>, EInParens<'a>> {
     between!(
         word1(b'(', EInParens::Open),
         space0_around_ee(
-            specialize_ref(EInParens::Expr, move |arena, state| parse_loc_expr(
-                min_indent, arena, state
-            )),
-            min_indent,
+            specialize_ref(EInParens::Expr, parse_loc_expr),
             EInParens::IndentOpen,
             EInParens::IndentEnd,
         ),
@@ -115,11 +108,11 @@ fn loc_expr_in_parens_help_help<'a>(
     )
 }
 
-fn loc_expr_in_parens_etc_help<'a>(min_indent: u32) -> impl Parser<'a, Loc<Expr<'a>>, EExpr<'a>> {
-    move |arena, state: State<'a>| {
+fn loc_expr_in_parens_etc_help<'a>() -> impl Parser<'a, Loc<Expr<'a>>, EExpr<'a>> {
+    move |arena, state: State<'a>, min_indent: u32| {
         let parser = loc!(and!(
-            specialize(EExpr::InParens, loc_expr_in_parens_help(min_indent)),
-            one_of![record_field_access_chain(), |a, s| Ok((
+            specialize(EExpr::InParens, loc_expr_in_parens_help()),
+            one_of![record_field_access_chain(), |a, s, _m| Ok((
                 NoProgress,
                 Vec::new_in(a),
                 s
@@ -133,7 +126,7 @@ fn loc_expr_in_parens_etc_help<'a>(min_indent: u32) -> impl Parser<'a, Loc<Expr<
                 value: (loc_expr, field_accesses),
             },
             state,
-        ) = parser.parse(arena, state)?;
+        ) = parser.parse(arena, state, min_indent)?;
 
         let mut value = loc_expr.value;
 
@@ -157,7 +150,7 @@ fn loc_expr_in_parens_etc_help<'a>(min_indent: u32) -> impl Parser<'a, Loc<Expr<
 }
 
 fn record_field_access_chain<'a>() -> impl Parser<'a, Vec<'a, &'a str>, EExpr<'a>> {
-    |arena, state| match record_field_access().parse(arena, state) {
+    |arena, state, min_indent| match record_field_access().parse(arena, state, min_indent) {
         Ok((_, initial, state)) => {
             let mut accesses = Vec::with_capacity_in(1, arena);
 
@@ -165,7 +158,7 @@ fn record_field_access_chain<'a>() -> impl Parser<'a, Vec<'a, &'a str>, EExpr<'a
 
             let mut loop_state = state;
             loop {
-                match record_field_access().parse(arena, loop_state) {
+                match record_field_access().parse(arena, loop_state, min_indent) {
                     Ok((_, next, state)) => {
                         accesses.push(next);
                         loop_state = state;
@@ -196,28 +189,22 @@ fn parse_loc_term_or_underscore_or_conditional<'a>(
     state: State<'a>,
 ) -> ParseResult<'a, Loc<Expr<'a>>, EExpr<'a>> {
     one_of!(
-        loc_expr_in_parens_etc_help(min_indent),
-        loc!(specialize(EExpr::If, if_expr_help(min_indent, options))),
-        loc!(specialize(
-            EExpr::When,
-            when::expr_help(min_indent, options)
-        )),
+        loc_expr_in_parens_etc_help(),
+        loc!(specialize(EExpr::If, if_expr_help(options))),
+        loc!(specialize(EExpr::When, when::expr_help(options))),
         loc!(specialize(EExpr::Str, string_literal_help())),
         loc!(specialize(EExpr::SingleQuote, single_quote_literal_help())),
         loc!(specialize(EExpr::Number, positive_number_literal_help())),
-        loc!(specialize(
-            EExpr::Closure,
-            closure_help(min_indent, options)
-        )),
+        loc!(specialize(EExpr::Closure, closure_help(options))),
         loc!(underscore_expression()),
-        loc!(record_literal_help(min_indent)),
-        loc!(specialize(EExpr::List, list_literal_help(min_indent))),
+        loc!(record_literal_help()),
+        loc!(specialize(EExpr::List, list_literal_help())),
         loc!(map_with_arena!(
             assign_or_destructure_identifier(),
             ident_to_expr
         )),
     )
-    .parse(arena, state)
+    .parse(arena, state, min_indent)
 }
 
 /// In some contexts we want to parse the `_` as an expression, so it can then be turned into a
@@ -229,23 +216,20 @@ fn parse_loc_term_or_underscore<'a>(
     state: State<'a>,
 ) -> ParseResult<'a, Loc<Expr<'a>>, EExpr<'a>> {
     one_of!(
-        loc_expr_in_parens_etc_help(min_indent),
+        loc_expr_in_parens_etc_help(),
         loc!(specialize(EExpr::Str, string_literal_help())),
         loc!(specialize(EExpr::SingleQuote, single_quote_literal_help())),
         loc!(specialize(EExpr::Number, positive_number_literal_help())),
-        loc!(specialize(
-            EExpr::Closure,
-            closure_help(min_indent, options)
-        )),
+        loc!(specialize(EExpr::Closure, closure_help(options))),
         loc!(underscore_expression()),
-        loc!(record_literal_help(min_indent)),
-        loc!(specialize(EExpr::List, list_literal_help(min_indent))),
+        loc!(record_literal_help()),
+        loc!(specialize(EExpr::List, list_literal_help())),
         loc!(map_with_arena!(
             assign_or_destructure_identifier(),
             ident_to_expr
         )),
     )
-    .parse(arena, state)
+    .parse(arena, state, min_indent)
 }
 
 fn parse_loc_term<'a>(
@@ -255,33 +239,31 @@ fn parse_loc_term<'a>(
     state: State<'a>,
 ) -> ParseResult<'a, Loc<Expr<'a>>, EExpr<'a>> {
     one_of!(
-        loc_expr_in_parens_etc_help(min_indent),
+        loc_expr_in_parens_etc_help(),
         loc!(specialize(EExpr::Str, string_literal_help())),
         loc!(specialize(EExpr::SingleQuote, single_quote_literal_help())),
         loc!(specialize(EExpr::Number, positive_number_literal_help())),
-        loc!(specialize(
-            EExpr::Closure,
-            closure_help(min_indent, options)
-        )),
-        loc!(record_literal_help(min_indent)),
-        loc!(specialize(EExpr::List, list_literal_help(min_indent))),
+        loc!(specialize(EExpr::Closure, closure_help(options))),
+        loc!(record_literal_help()),
+        loc!(specialize(EExpr::List, list_literal_help())),
         loc!(map_with_arena!(
             assign_or_destructure_identifier(),
             ident_to_expr
         )),
     )
-    .parse(arena, state)
+    .parse(arena, state, min_indent)
 }
 
 fn underscore_expression<'a>() -> impl Parser<'a, Expr<'a>, EExpr<'a>> {
-    move |arena: &'a Bump, state: State<'a>| {
+    move |arena: &'a Bump, state: State<'a>, min_indent: u32| {
         let start = state.pos();
 
-        let (_, _, next_state) = word1(b'_', EExpr::Underscore).parse(arena, state)?;
+        let (_, _, next_state) = word1(b'_', EExpr::Underscore).parse(arena, state, min_indent)?;
 
         let lowercase_ident_expr = { specialize(move |_, _| EExpr::End(start), lowercase_ident()) };
 
-        let (_, output, final_state) = optional(lowercase_ident_expr).parse(arena, next_state)?;
+        let (_, output, final_state) =
+            optional(lowercase_ident_expr).parse(arena, next_state, min_indent)?;
 
         match output {
             Some(name) => Ok((MadeProgress, Expr::Underscore(name), final_state)),
@@ -291,17 +273,17 @@ fn underscore_expression<'a>() -> impl Parser<'a, Expr<'a>, EExpr<'a>> {
 }
 
 fn loc_possibly_negative_or_negated_term<'a>(
-    min_indent: u32,
     options: ExprParseOptions,
 ) -> impl Parser<'a, Loc<Expr<'a>>, EExpr<'a>> {
     one_of![
-        |arena, state: State<'a>| {
+        |arena, state: State<'a>, min_indent: u32| {
             let initial = state.clone();
 
-            let (_, (loc_op, loc_expr), state) = and!(loc!(unary_negate()), |a, s| parse_loc_term(
-                min_indent, options, a, s
-            ))
-            .parse(arena, state)?;
+            let (_, (loc_op, loc_expr), state) =
+                and!(loc!(unary_negate()), |a, s, m| parse_loc_term(
+                    m, options, a, s
+                ))
+                .parse(arena, state, min_indent)?;
 
             let loc_expr = numeric_negate_expression(arena, initial, loc_op, loc_expr, &[]);
 
@@ -310,25 +292,25 @@ fn loc_possibly_negative_or_negated_term<'a>(
         // this will parse negative numbers, which the unary negate thing up top doesn't (for now)
         loc!(specialize(EExpr::Number, number_literal_help())),
         loc!(map_with_arena!(
-            and!(loc!(word1(b'!', EExpr::Start)), |a, s| {
-                parse_loc_term(min_indent, options, a, s)
+            and!(loc!(word1(b'!', EExpr::Start)), |a, s, m| {
+                parse_loc_term(m, options, a, s)
             }),
             |arena: &'a Bump, (loc_op, loc_expr): (Loc<_>, _)| {
                 Expr::UnaryOp(arena.alloc(loc_expr), Loc::at(loc_op.region, UnaryOp::Not))
             }
         )),
-        |arena, state| {
+        |arena, state, min_indent: u32| {
             parse_loc_term_or_underscore_or_conditional(min_indent, options, arena, state)
         }
     ]
 }
 
 fn fail_expr_start_e<'a, T: 'a>() -> impl Parser<'a, T, EExpr<'a>> {
-    |_arena, state: State<'a>| Err((NoProgress, EExpr::Start(state.pos()), state))
+    |_arena, state: State<'a>, _min_indent: u32| Err((NoProgress, EExpr::Start(state.pos()), state))
 }
 
 fn unary_negate<'a>() -> impl Parser<'a, (), EExpr<'a>> {
-    move |_arena: &'a Bump, state: State<'a>| {
+    move |_arena: &'a Bump, state: State<'a>, _min_indent: u32| {
         // a minus is unary iff
         //
         // - it is preceded by whitespace (spaces, newlines, comments)
@@ -357,20 +339,14 @@ fn parse_expr_start<'a>(
     state: State<'a>,
 ) -> ParseResult<'a, Loc<Expr<'a>>, EExpr<'a>> {
     one_of![
-        loc!(specialize(EExpr::If, if_expr_help(min_indent, options))),
-        loc!(specialize(
-            EExpr::When,
-            when::expr_help(min_indent, options)
-        )),
-        loc!(specialize(EExpr::Expect, expect_help(min_indent, options))),
-        loc!(specialize(
-            EExpr::Closure,
-            closure_help(min_indent, options)
-        )),
-        loc!(move |a, s| parse_expr_operator_chain(min_indent, options, a, s)),
+        loc!(specialize(EExpr::If, if_expr_help(options))),
+        loc!(specialize(EExpr::When, when::expr_help(options))),
+        loc!(specialize(EExpr::Expect, expect_help(options))),
+        loc!(specialize(EExpr::Closure, closure_help(options))),
+        loc!(move |a, s, m| parse_expr_operator_chain(m, options, a, s)),
         fail_expr_start_e()
     ]
-    .parse(arena, state)
+    .parse(arena, state, min_indent)
 }
 
 fn parse_expr_operator_chain<'a>(
@@ -382,12 +358,12 @@ fn parse_expr_operator_chain<'a>(
     let min_indent = state.check_indent(min_indent, EExpr::IndentStart)?;
 
     let (_, expr, state) =
-        loc_possibly_negative_or_negated_term(min_indent, options).parse(arena, state)?;
+        loc_possibly_negative_or_negated_term(options).parse(arena, state, min_indent)?;
 
     let initial = state.clone();
     let end = state.pos();
 
-    match space0_e(min_indent, EExpr::IndentEnd).parse(arena, state) {
+    match space0_e(EExpr::IndentEnd).parse(arena, state, min_indent) {
         Err((_, _, state)) => Ok((MadeProgress, expr.value, state)),
         Ok((_, spaces_before_op, state)) => {
             let expr_state = ExprState {
@@ -625,7 +601,7 @@ pub fn parse_single_def<'a>(
     let mut spaces_before_current = &[] as &[_];
     let spaces_before_current_start = state.pos();
 
-    let state = match space0_e(min_indent, EExpr::IndentStart).parse(arena, state) {
+    let state = match space0_e(EExpr::IndentStart).parse(arena, state, min_indent) {
         Err((MadeProgress, _, s)) => {
             return Err((MadeProgress, EExpr::DefMissingFinalExpr(s.pos()), s));
         }
@@ -642,27 +618,23 @@ pub fn parse_single_def<'a>(
     let parse_expect_fx = crate::parser::keyword_e(crate::keyword::EXPECT_FX, EExpect::Expect);
     let parse_expect = either!(parse_expect_fx, parse_expect_vanilla);
 
-    match space0_after_e(
-        crate::pattern::loc_pattern_help(min_indent),
+    match space0_after_e(crate::pattern::loc_pattern_help(), EPattern::IndentEnd).parse(
+        arena,
+        state.clone(),
         min_indent,
-        EPattern::IndentEnd,
-    )
-    .parse(arena, state.clone())
-    {
+    ) {
         Err((NoProgress, _, _)) => {
-            match parse_expect.parse(arena, state) {
+            match parse_expect.parse(arena, state, min_indent) {
                 Err((_, _, _)) => {
                     // a hacky way to get expression-based error messages. TODO fix this
                     Ok((NoProgress, None, initial))
                 }
                 Ok((_, expect_flavor, state)) => {
-                    let parse_def_expr = space0_before_e(
-                        move |a, s| parse_loc_expr(min_indent + 1, a, s),
-                        min_indent,
-                        EExpr::IndentEnd,
-                    );
+                    let parse_def_expr =
+                        space0_before_e(increment_min_indent(parse_loc_expr), EExpr::IndentEnd);
 
-                    let (_, loc_def_expr, state) = parse_def_expr.parse(arena, state)?;
+                    let (_, loc_def_expr, state) =
+                        parse_def_expr.parse(arena, state, min_indent)?;
                     let end = loc_def_expr.region.end();
                     let region = Region::new(start, end);
 
@@ -726,7 +698,7 @@ pub fn parse_single_def<'a>(
 
             if let Some((name, name_region, args)) = opt_tag_and_args {
                 if let Ok((_, loc_has, state)) =
-                    loc_has_parser(min_indent).parse(arena, state.clone())
+                    loc_has_parser().parse(arena, state.clone(), min_indent)
                 {
                     let (_, (type_def, def_region), state) = finish_parsing_ability_def_help(
                         min_indent,
@@ -750,15 +722,13 @@ pub fn parse_single_def<'a>(
             }
 
             // Otherwise, this is a def or alias.
-            match operator().parse(arena, state) {
+            match operator().parse(arena, state, min_indent) {
                 Ok((_, BinOp::Assignment, state)) => {
-                    let parse_def_expr = space0_before_e(
-                        move |a, s| parse_loc_expr(min_indent + 1, a, s),
-                        min_indent,
-                        EExpr::IndentEnd,
-                    );
+                    let parse_def_expr =
+                        space0_before_e(increment_min_indent(parse_loc_expr), EExpr::IndentEnd);
 
-                    let (_, loc_def_expr, state) = parse_def_expr.parse(arena, state)?;
+                    let (_, loc_def_expr, state) =
+                        parse_def_expr.parse(arena, state, min_indent)?;
                     let value_def =
                         ValueDef::Body(arena.alloc(loc_pattern), &*arena.alloc(loc_def_expr));
                     let region = Region::span_across(&loc_pattern.region, &loc_def_expr.region);
@@ -774,8 +744,8 @@ pub fn parse_single_def<'a>(
                     ))
                 }
                 Ok((_, BinOp::IsAliasType, state)) => {
-                    let (_, ann_type, state) =
-                        alias_signature_with_space_before(min_indent + 1).parse(arena, state)?;
+                    let (_, ann_type, state) = alias_signature_with_space_before(min_indent + 1)
+                        .parse(arena, state, min_indent)?;
                     let region = Region::span_across(&loc_pattern.region, &ann_type.region);
 
                     match &loc_pattern.value {
@@ -847,7 +817,7 @@ pub fn parse_single_def<'a>(
                 }
                 Ok((_, BinOp::IsOpaqueType, state)) => {
                     let (_, (signature, derived), state) =
-                        opaque_signature_with_space_before(min_indent + 1).parse(arena, state)?;
+                        opaque_signature_with_space_before().parse(arena, state, min_indent + 1)?;
                     let region = Region::span_across(&loc_pattern.region, &signature.region);
 
                     match &loc_pattern.value {
@@ -1066,13 +1036,9 @@ fn parse_defs_expr<'a>(
         Err(bad) => Err(bad),
         Ok((_, def_state, state)) => {
             // this is no def, because there is no `=` or `:`; parse as an expr
-            let parse_final_expr = space0_before_e(
-                move |a, s| parse_loc_expr(min_indent, a, s),
-                min_indent,
-                EExpr::IndentEnd,
-            );
+            let parse_final_expr = space0_before_e(parse_loc_expr, EExpr::IndentEnd);
 
-            match parse_final_expr.parse(arena, state) {
+            match parse_final_expr.parse(arena, state, min_indent) {
                 Err((_, fail, state)) => {
                     return Err((
                         MadeProgress,
@@ -1094,35 +1060,31 @@ fn parse_defs_expr<'a>(
 fn alias_signature_with_space_before<'a>(
     min_indent: u32,
 ) -> impl Parser<'a, Loc<TypeAnnotation<'a>>, EExpr<'a>> {
-    specialize(
-        EExpr::Type,
-        space0_before_e(
-            type_annotation::located(min_indent + 1, false),
-            min_indent + 1,
-            EType::TIndentStart,
-        ),
-    )
+    move |arena, state, _min_indent| {
+        specialize(
+            EExpr::Type,
+            space0_before_e(
+                set_min_indent(min_indent + 1, type_annotation::located(false)),
+                EType::TIndentStart,
+            ),
+        )
+        .parse(arena, state, min_indent + 1)
+    }
 }
 
 fn opaque_signature_with_space_before<'a>(
-    min_indent: u32,
 ) -> impl Parser<'a, (Loc<TypeAnnotation<'a>>, Option<Loc<HasAbilities<'a>>>), EExpr<'a>> {
     and!(
         specialize(
             EExpr::Type,
             space0_before_e(
-                type_annotation::located_opaque_signature(min_indent, true),
-                min_indent,
+                type_annotation::located_opaque_signature(true),
                 EType::TIndentStart,
             ),
         ),
         optional(specialize(
             EExpr::Type,
-            space0_before_e(
-                type_annotation::has_abilities(min_indent),
-                min_indent,
-                EType::TIndentStart,
-            ),
+            space0_before_e(type_annotation::has_abilities(), EType::TIndentStart,),
         ))
     )
 }
@@ -1168,8 +1130,8 @@ fn finish_parsing_alias_or_opaque<'a>(
 
             match kind {
                 AliasOrOpaque::Alias => {
-                    let (_, signature, state) =
-                        alias_signature_with_space_before(indented_more).parse(arena, state)?;
+                    let (_, signature, state) = alias_signature_with_space_before(indented_more)
+                        .parse(arena, state, min_indent)?;
 
                     let def_region = Region::span_across(&expr.region, &signature.region);
 
@@ -1190,7 +1152,7 @@ fn finish_parsing_alias_or_opaque<'a>(
 
                 AliasOrOpaque::Opaque => {
                     let (_, (signature, derived), state) =
-                        opaque_signature_with_space_before(indented_more).parse(arena, state)?;
+                        opaque_signature_with_space_before().parse(arena, state, indented_more)?;
 
                     let def_region = Region::span_across(&expr.region, &signature.region);
 
@@ -1220,13 +1182,12 @@ fn finish_parsing_alias_or_opaque<'a>(
                     let parser = specialize(
                         EExpr::Type,
                         space0_before_e(
-                            type_annotation::located(indented_more, false),
-                            min_indent,
+                            set_min_indent(indented_more, type_annotation::located(false)),
                             EType::TIndentStart,
                         ),
                     );
 
-                    match parser.parse(arena, state) {
+                    match parser.parse(arena, state, min_indent) {
                         Err((_, fail, state)) => return Err((MadeProgress, fail, state)),
                         Ok((_, mut ann_type, state)) => {
                             // put the spaces from after the operator in front of the call
@@ -1281,13 +1242,13 @@ mod ability {
                 skip_first!(
                     and!(
                         // TODO: do we get anything from picking up spaces here?
-                        space0_e(start_column, EAbility::DemandName),
+                        space0_e(EAbility::DemandName),
                         word1(b':', EAbility::DemandColon)
                     ),
                     specialize(
                         EAbility::Type,
                         // Require the type to be more indented than the name
-                        type_annotation::located(start_column + 1, true)
+                        set_min_indent(start_column + 1, type_annotation::located(true))
                     )
                 )
             ),
@@ -1311,11 +1272,11 @@ mod ability {
     pub fn parse_demand<'a>(
         indent: IndentLevel,
     ) -> impl Parser<'a, (u32, AbilityMember<'a>), EAbility<'a>> {
-        move |arena, state: State<'a>| {
+        move |arena, state: State<'a>, min_indent: u32| {
             let initial = state.clone();
 
             // Put no restrictions on the indent after the spaces; we'll check it manually.
-            match space0_e(0, EAbility::DemandName).parse(arena, state) {
+            match space0_e(EAbility::DemandName).parse(arena, state, 0) {
                 Err((MadeProgress, fail, _)) => Err((NoProgress, fail, initial)),
                 Err((NoProgress, fail, _)) => Err((NoProgress, fail, initial)),
 
@@ -1363,7 +1324,7 @@ mod ability {
 
                             let parser = parse_demand_help(indent_column);
 
-                            match parser.parse(arena, state) {
+                            match parser.parse(arena, state, min_indent) {
                                 Err((MadeProgress, fail, state)) => {
                                     Err((MadeProgress, fail, state))
                                 }
@@ -1408,7 +1369,7 @@ fn finish_parsing_ability_def_help<'a>(
     // other demands must observe.
     let (_, (demand_indent_level, first_demand), mut state) =
         ability::parse_demand(ability::IndentLevel::PendingMin(min_indent_for_demand))
-            .parse(arena, state)
+            .parse(arena, state, min_indent_for_demand)
             .map_err(|(progress, err, state)| {
                 (progress, EExpr::Ability(err, state.pos()), state)
             })?;
@@ -1418,7 +1379,7 @@ fn finish_parsing_ability_def_help<'a>(
     let demand_parser = ability::parse_demand(demand_indent);
 
     loop {
-        match demand_parser.parse(arena, state.clone()) {
+        match demand_parser.parse(arena, state.clone(), min_indent_for_demand) {
             Ok((_, (_indent, demand), next_state)) => {
                 state = next_state;
                 demands.push(demand);
@@ -1456,7 +1417,7 @@ fn parse_expr_operator<'a>(
     state: State<'a>,
 ) -> ParseResult<'a, Expr<'a>, EExpr<'a>> {
     let (_, spaces_after_operator, state) =
-        space0_e(min_indent, EExpr::IndentEnd).parse(arena, state)?;
+        space0_e(EExpr::IndentEnd).parse(arena, state, min_indent)?;
 
     // a `-` is unary if it is preceded by a space and not followed by a space
 
@@ -1481,7 +1442,7 @@ fn parse_expr_operator<'a>(
 
             expr_state.initial = state.clone();
 
-            let (spaces, state) = match space0_e(min_indent, EExpr::IndentEnd).parse(arena, state) {
+            let (spaces, state) = match space0_e(EExpr::IndentEnd).parse(arena, state, min_indent) {
                 Err((_, _, state)) => (&[] as &[_], state),
                 Ok((_, spaces, state)) => (spaces, state),
             };
@@ -1503,7 +1464,7 @@ fn parse_expr_operator<'a>(
             let (value_def, def_region, state) = {
                 match expr_to_pattern_help(arena, &call.value) {
                     Ok(good) => {
-                        let (_, mut body, state) = parse_loc_expr(indented_more, arena, state)?;
+                        let (_, mut body, state) = parse_loc_expr(arena, state, indented_more)?;
 
                         // put the spaces from after the operator in front of the call
                         if !spaces_after_operator.is_empty() {
@@ -1548,7 +1509,7 @@ fn parse_expr_operator<'a>(
             let (loc_pattern, loc_body, state) = {
                 match expr_to_pattern_help(arena, &call.value) {
                     Ok(good) => {
-                        let (_, mut ann_type, state) = parse_loc_expr(indented_more, arena, state)?;
+                        let (_, mut ann_type, state) = parse_loc_expr(arena, state, indented_more)?;
 
                         // put the spaces from after the operator in front of the call
                         if !spaces_after_operator.is_empty() {
@@ -1568,13 +1529,9 @@ fn parse_expr_operator<'a>(
                 }
             };
 
-            let parse_cont = space0_before_e(
-                move |a, s| parse_loc_expr(min_indent, a, s),
-                min_indent,
-                EExpr::IndentEnd,
-            );
+            let parse_cont = space0_before_e(parse_loc_expr, EExpr::IndentEnd);
 
-            let (_, loc_cont, state) = parse_cont.parse(arena, state)?;
+            let (_, loc_cont, state) = parse_cont.parse(arena, state, min_indent)?;
 
             let ret = Expr::Backpassing(
                 arena.alloc([loc_pattern]),
@@ -1598,7 +1555,7 @@ fn parse_expr_operator<'a>(
                 _ => unreachable!(),
             },
         ),
-        _ => match loc_possibly_negative_or_negated_term(min_indent, options).parse(arena, state) {
+        _ => match loc_possibly_negative_or_negated_term(options).parse(arena, state, min_indent) {
             Err((MadeProgress, f, s)) => Err((MadeProgress, f, s)),
             Ok((_, mut new_expr, state)) => {
                 let new_end = state.pos();
@@ -1612,7 +1569,7 @@ fn parse_expr_operator<'a>(
                         .with_spaces_before(spaces_after_operator, new_expr.region);
                 }
 
-                match space0_e(min_indent, EExpr::IndentEnd).parse(arena, state) {
+                match space0_e(EExpr::IndentEnd).parse(arena, state, min_indent) {
                     Err((_, _, state)) => {
                         let args = std::mem::replace(&mut expr_state.arguments, Vec::new_in(arena));
 
@@ -1655,11 +1612,11 @@ fn parse_expr_end<'a>(
     state: State<'a>,
 ) -> ParseResult<'a, Expr<'a>, EExpr<'a>> {
     let parser = skip_first!(
-        crate::blankspace::check_indent(min_indent, EExpr::IndentEnd),
-        move |a, s| parse_loc_term_or_underscore(min_indent, options, a, s)
+        crate::blankspace::check_indent(EExpr::IndentEnd),
+        move |a, s, m| parse_loc_term_or_underscore(m, options, a, s)
     );
 
-    match parser.parse(arena, state.clone()) {
+    match parser.parse(arena, state.clone(), min_indent) {
         Err((MadeProgress, f, s)) => Err((MadeProgress, f, s)),
         Ok((
             _,
@@ -1730,7 +1687,7 @@ fn parse_expr_end<'a>(
             }
             expr_state.initial = state.clone();
 
-            match space0_e(min_indent, EExpr::IndentEnd).parse(arena, state) {
+            match space0_e(EExpr::IndentEnd).parse(arena, state, min_indent) {
                 Err((_, _, state)) => {
                     expr_state.arguments.push(arena.alloc(arg));
                     expr_state.end = new_end;
@@ -1750,7 +1707,7 @@ fn parse_expr_end<'a>(
         Err((NoProgress, _, _)) => {
             let before_op = state.clone();
             // try an operator
-            match loc!(operator()).parse(arena, state) {
+            match loc!(operator()).parse(arena, state, min_indent) {
                 Err((MadeProgress, f, s)) => Err((MadeProgress, f, s)),
                 Ok((_, loc_op, state)) => {
                     expr_state.consume_spaces(arena);
@@ -1767,14 +1724,13 @@ fn parse_expr_end<'a>(
                             crate::parser::sep_by0(
                                 word1(b',', EPattern::Start),
                                 space0_around_ee(
-                                    crate::pattern::loc_pattern_help(min_indent),
-                                    min_indent,
+                                    crate::pattern::loc_pattern_help(),
                                     EPattern::Start,
                                     EPattern::IndentEnd,
                                 ),
                             ),
                         )
-                        .parse(arena, state)?;
+                        .parse(arena, state, min_indent)?;
 
                         expr_state.consume_spaces(arena);
                         let call = to_call(arena, expr_state.arguments, expr_state.expr);
@@ -1786,24 +1742,23 @@ fn parse_expr_end<'a>(
 
                         patterns.insert(0, loc_pattern);
 
-                        match word2(b'<', b'-', EExpr::BackpassArrow).parse(arena, state) {
+                        match word2(b'<', b'-', EExpr::BackpassArrow)
+                            .parse(arena, state, min_indent)
+                        {
                             Err((_, fail, state)) => Err((MadeProgress, fail, state)),
                             Ok((_, _, state)) => {
                                 let parse_body = space0_before_e(
-                                    move |a, s| parse_loc_expr(min_indent + 1, a, s),
-                                    min_indent,
+                                    increment_min_indent(parse_loc_expr),
                                     EExpr::IndentEnd,
                                 );
 
-                                let (_, loc_body, state) = parse_body.parse(arena, state)?;
+                                let (_, loc_body, state) =
+                                    parse_body.parse(arena, state, min_indent)?;
 
-                                let parse_cont = space0_before_e(
-                                    move |a, s| parse_loc_expr(min_indent, a, s),
-                                    min_indent,
-                                    EExpr::IndentEnd,
-                                );
+                                let parse_cont = space0_before_e(parse_loc_expr, EExpr::IndentEnd);
 
-                                let (_, loc_cont, state) = parse_cont.parse(arena, state)?;
+                                let (_, loc_cont, state) =
+                                    parse_cont.parse(arena, state, min_indent)?;
 
                                 let ret = Expr::Backpassing(
                                     patterns.into_bump_slice(),
@@ -1829,9 +1784,9 @@ fn parse_expr_end<'a>(
 }
 
 pub fn parse_loc_expr<'a>(
-    min_indent: u32,
     arena: &'a Bump,
     state: State<'a>,
+    min_indent: u32,
 ) -> ParseResult<'a, Loc<Expr<'a>>, EExpr<'a>> {
     parse_loc_expr_with_options(
         min_indent,
@@ -1844,20 +1799,18 @@ pub fn parse_loc_expr<'a>(
     )
 }
 
-pub fn parse_loc_expr_no_multi_backpassing<'a>(
-    min_indent: u32,
-    arena: &'a Bump,
-    state: State<'a>,
-) -> ParseResult<'a, Loc<Expr<'a>>, EExpr<'a>> {
-    parse_loc_expr_with_options(
-        min_indent,
-        ExprParseOptions {
-            accept_multi_backpassing: false,
-            ..Default::default()
-        },
-        arena,
-        state,
-    )
+pub fn loc_expr_no_multi_backpassing<'a>() -> impl Parser<'a, Loc<Expr<'a>>, EExpr<'a>> {
+    move |arena, state, min_indent| {
+        parse_loc_expr_with_options(
+            min_indent,
+            ExprParseOptions {
+                accept_multi_backpassing: false,
+                ..Default::default()
+            },
+            arena,
+            state,
+        )
+    }
 }
 
 fn parse_loc_expr_with_options<'a>(
@@ -2004,10 +1957,10 @@ fn assigned_expr_field_to_pattern_help<'a>(
     })
 }
 
-pub fn toplevel_defs<'a>(min_indent: u32) -> impl Parser<'a, Defs<'a>, EExpr<'a>> {
-    move |arena, state: State<'a>| {
+pub fn toplevel_defs<'a>() -> impl Parser<'a, Defs<'a>, EExpr<'a>> {
+    move |arena, state: State<'a>, min_indent: u32| {
         let (_, initial_space, state) =
-            space0_e(min_indent, EExpr::IndentEnd).parse(arena, state)?;
+            space0_e(EExpr::IndentEnd).parse(arena, state, min_indent)?;
 
         let start_column = state.column();
 
@@ -2022,7 +1975,7 @@ pub fn toplevel_defs<'a>(min_indent: u32) -> impl Parser<'a, Defs<'a>, EExpr<'a>
         let (_, mut output, state) = parse_defs_end(options, start_column, output, arena, state)?;
 
         let (_, final_space, state) =
-            space0_e(start_column, EExpr::IndentEnd).parse(arena, state)?;
+            space0_e(EExpr::IndentEnd).parse(arena, state, start_column)?;
 
         if !output.tags.is_empty() {
             // add surrounding whitespace
@@ -2042,11 +1995,8 @@ pub fn toplevel_defs<'a>(min_indent: u32) -> impl Parser<'a, Defs<'a>, EExpr<'a>
 
 // PARSER HELPERS
 
-fn closure_help<'a>(
-    min_indent: u32,
-    options: ExprParseOptions,
-) -> impl Parser<'a, Expr<'a>, EClosure<'a>> {
-    move |arena, state| parse_closure_help(arena, state, min_indent, options)
+fn closure_help<'a>(options: ExprParseOptions) -> impl Parser<'a, Expr<'a>, EClosure<'a>> {
+    move |arena, state, min_indent| parse_closure_help(arena, state, min_indent, options)
 }
 
 fn parse_closure_help<'a>(
@@ -2073,14 +2023,13 @@ fn parse_closure_help<'a>(
     let (_, params, state) = sep_by1_e(
         word1(b',', EClosure::Comma),
         space0_around_ee(
-            specialize(EClosure::Pattern, loc_closure_param(min_indent)),
-            min_indent,
+            specialize(EClosure::Pattern, loc_closure_param()),
             EClosure::IndentArg,
             EClosure::IndentArrow,
         ),
         EClosure::Arg,
     )
-    .parse(arena, state)
+    .parse(arena, state, min_indent)
     .map_err(|(_p, e, s)| (MadeProgress, e, s))?;
 
     let (_, loc_body, state) = skip_first!(
@@ -2088,14 +2037,13 @@ fn parse_closure_help<'a>(
         word2(b'-', b'>', EClosure::Arrow),
         // Parse the body
         space0_before_e(
-            specialize_ref(EClosure::Body, move |arena, state| {
+            specialize_ref(EClosure::Body, move |arena, state, min_indent| {
                 parse_loc_expr_with_options(min_indent, options, arena, state)
             }),
-            min_indent,
             EClosure::IndentBody
         )
     )
-    .parse(arena, state)
+    .parse(arena, state, min_indent)
     .map_err(|(_p, e, s)| (MadeProgress, e, s))?;
 
     let params: Vec<'a, Loc<Pattern<'a>>> = params;
@@ -2113,26 +2061,22 @@ mod when {
     use crate::ast::WhenBranch;
 
     /// Parser for when expressions.
-    pub fn expr_help<'a>(
-        min_indent: u32,
-        options: ExprParseOptions,
-    ) -> impl Parser<'a, Expr<'a>, EWhen<'a>> {
+    pub fn expr_help<'a>(options: ExprParseOptions) -> impl Parser<'a, Expr<'a>, EWhen<'a>> {
         then(
             and!(
                 when_with_indent(),
                 skip_second!(
                     space0_around_ee(
-                        specialize_ref(EWhen::Condition, move |arena, state| {
+                        specialize_ref(EWhen::Condition, move |arena, state, min_indent| {
                             parse_loc_expr_with_options(min_indent, options, arena, state)
                         }),
-                        min_indent,
                         EWhen::IndentCondition,
                         EWhen::IndentIs,
                     ),
                     parser::keyword_e(keyword::IS, EWhen::Is)
                 )
             ),
-            move |arena, state, progress, (case_indent, loc_condition)| {
+            move |arena, state, progress, (case_indent, loc_condition), min_indent| {
                 if case_indent < min_indent {
                     return Err((
                         progress,
@@ -2145,7 +2089,7 @@ mod when {
                 // Everything in the branches must be indented at least as much as the case itself.
                 let min_indent = case_indent;
 
-                let (p1, branches, state) = branches(min_indent, options).parse(arena, state)?;
+                let (p1, branches, state) = branches(options).parse(arena, state, min_indent)?;
 
                 Ok((
                     progress.or(p1),
@@ -2158,19 +2102,18 @@ mod when {
 
     /// Parsing when with indentation.
     fn when_with_indent<'a>() -> impl Parser<'a, u32, EWhen<'a>> {
-        move |arena, state: State<'a>| {
+        move |arena, state: State<'a>, _min_indent: u32| {
             let min_indent = state.line_indent() + 1;
             parser::keyword_e(keyword::WHEN, EWhen::When)
-                .parse(arena, state)
+                .parse(arena, state, min_indent)
                 .map(|(progress, (), state)| (progress, min_indent, state))
         }
     }
 
     fn branches<'a>(
-        min_indent: u32,
         options: ExprParseOptions,
     ) -> impl Parser<'a, Vec<'a, &'a WhenBranch<'a>>, EWhen<'a>> {
-        move |arena, state: State<'a>| {
+        move |arena, state: State<'a>, min_indent: u32| {
             let mut branches: Vec<'a, &'a WhenBranch<'a>> = Vec::with_capacity_in(2, arena);
 
             // 1. Parse the first branch and get its indentation level. (It must be >= min_indent.)
@@ -2180,13 +2123,13 @@ mod when {
                 _,
                 ((_, _), _),
                 State<'a>,
-            ) = branch_alternatives(min_indent, options, None).parse(arena, state)?;
+            ) = branch_alternatives(options, None).parse(arena, state, min_indent)?;
 
             let original_indent = pattern_indent_level;
 
             // Parse the first "->" and the expression after it.
             let (_, loc_first_expr, mut state) =
-                branch_result(original_indent + 1).parse(arena, state)?;
+                branch_result(original_indent + 1).parse(arena, state, original_indent + 1)?;
 
             // Record this as the first branch, then optionally parse additional branches.
             branches.push(arena.alloc(WhenBranch {
@@ -2198,8 +2141,12 @@ mod when {
             let branch_parser = map!(
                 and!(
                     then(
-                        branch_alternatives(min_indent, options, Some(pattern_indent_level)),
-                        move |_arena, state, _, ((indent_column, loc_patterns), loc_guard)| {
+                        branch_alternatives(options, Some(pattern_indent_level)),
+                        move |_arena,
+                              state,
+                              _,
+                              ((indent_column, loc_patterns), loc_guard),
+                              _min_indent| {
                             if pattern_indent_level == indent_column {
                                 Ok((MadeProgress, (loc_patterns, loc_guard), state))
                             } else {
@@ -2225,7 +2172,7 @@ mod when {
             );
 
             while !state.bytes().is_empty() {
-                match branch_parser.parse(arena, state) {
+                match branch_parser.parse(arena, state, min_indent) {
                     Ok((_, next_output, next_state)) => {
                         state = next_state;
 
@@ -2248,7 +2195,6 @@ mod when {
 
     /// Parsing alternative patterns in `when` branches.
     fn branch_alternatives<'a>(
-        min_indent: u32,
         options: ExprParseOptions,
         pattern_indent_level: Option<u32>,
     ) -> impl Parser<'a, ((u32, Vec<'a, Loc<Pattern<'a>>>), Option<Loc<Expr<'a>>>), EWhen<'a>> {
@@ -2257,41 +2203,37 @@ mod when {
             ..options
         };
         and!(
-            branch_alternatives_help(min_indent, pattern_indent_level),
+            branch_alternatives_help(pattern_indent_level),
             one_of![
                 map!(
                     skip_first!(
                         parser::keyword_e(keyword::IF, EWhen::IfToken),
                         // TODO we should require space before the expression but not after
                         space0_around_ee(
-                            specialize_ref(EWhen::IfGuard, move |arena, state| {
+                            specialize_ref(EWhen::IfGuard, move |arena, state, min_indent| {
                                 parse_loc_expr_with_options(min_indent + 1, options, arena, state)
                             }),
-                            min_indent,
                             EWhen::IndentIfGuard,
                             EWhen::IndentArrow,
                         )
                     ),
                     Some
                 ),
-                |_, s| Ok((NoProgress, None, s))
+                |_, s, _| Ok((NoProgress, None, s))
             ]
         )
     }
 
-    fn branch_single_alternative<'a>(
-        min_indent: u32,
-    ) -> impl Parser<'a, Loc<Pattern<'a>>, EWhen<'a>> {
-        move |arena, state| {
+    fn branch_single_alternative<'a>() -> impl Parser<'a, Loc<Pattern<'a>>, EWhen<'a>> {
+        move |arena, state, min_indent| {
             let (_, spaces, state) =
-                backtrackable(space0_e(min_indent, EWhen::IndentPattern)).parse(arena, state)?;
+                backtrackable(space0_e(EWhen::IndentPattern)).parse(arena, state, min_indent)?;
 
             let (_, loc_pattern, state) = space0_after_e(
-                specialize(EWhen::Pattern, crate::pattern::loc_pattern_help(min_indent)),
-                min_indent,
+                specialize(EWhen::Pattern, crate::pattern::loc_pattern_help()),
                 EWhen::IndentPattern,
             )
-            .parse(arena, state)?;
+            .parse(arena, state, min_indent)?;
 
             Ok((
                 MadeProgress,
@@ -2308,14 +2250,13 @@ mod when {
     }
 
     fn branch_alternatives_help<'a>(
-        min_indent: u32,
         pattern_indent_level: Option<u32>,
     ) -> impl Parser<'a, (u32, Vec<'a, Loc<Pattern<'a>>>), EWhen<'a>> {
-        move |arena, state: State<'a>| {
+        move |arena, state: State<'a>, min_indent: u32| {
             let initial = state.clone();
 
             // put no restrictions on the indent after the spaces; we'll check it manually
-            match space0_e(0, EWhen::IndentPattern).parse(arena, state) {
+            match space0_e(EWhen::IndentPattern).parse(arena, state, 0) {
                 Err((MadeProgress, fail, _)) => Err((NoProgress, fail, initial)),
                 Err((NoProgress, fail, _)) => Err((NoProgress, fail, initial)),
                 Ok((_progress, spaces, state)) => {
@@ -2339,12 +2280,10 @@ mod when {
                             // parentheses around patterns
                             let pattern_indent_column = state.column();
 
-                            let parser = sep_by1(
-                                word1(b'|', EWhen::Bar),
-                                branch_single_alternative(pattern_indent),
-                            );
+                            let parser =
+                                sep_by1(word1(b'|', EWhen::Bar), branch_single_alternative());
 
-                            match parser.parse(arena, state) {
+                            match parser.parse(arena, state, pattern_indent) {
                                 Err((MadeProgress, fail, state)) => {
                                     Err((MadeProgress, fail, state))
                                 }
@@ -2375,86 +2314,76 @@ mod when {
 
     /// Parsing the righthandside of a branch in a when conditional.
     fn branch_result<'a>(indent: u32) -> impl Parser<'a, Loc<Expr<'a>>, EWhen<'a>> {
-        skip_first!(
-            word2(b'-', b'>', EWhen::Arrow),
-            space0_before_e(
-                specialize_ref(EWhen::Branch, move |arena, state| parse_loc_expr(
-                    indent, arena, state
-                )),
-                indent,
-                EWhen::IndentBranch,
+        move |arena, state, _min_indent| {
+            skip_first!(
+                word2(b'-', b'>', EWhen::Arrow),
+                space0_before_e(
+                    specialize_ref(EWhen::Branch, parse_loc_expr),
+                    EWhen::IndentBranch,
+                )
             )
-        )
+            .parse(arena, state, indent)
+        }
     }
 }
 
-fn if_branch<'a>(min_indent: u32) -> impl Parser<'a, (Loc<Expr<'a>>, Loc<Expr<'a>>), EIf<'a>> {
-    move |arena, state| {
+fn if_branch<'a>() -> impl Parser<'a, (Loc<Expr<'a>>, Loc<Expr<'a>>), EIf<'a>> {
+    move |arena, state, min_indent| {
         // NOTE: only parse spaces before the expression
         let (_, cond, state) = space0_around_ee(
-            specialize_ref(EIf::Condition, move |arena, state| {
-                parse_loc_expr(min_indent, arena, state)
+            specialize_ref(EIf::Condition, move |arena, state, min_indent| {
+                parse_loc_expr(arena, state, min_indent)
             }),
-            min_indent,
             EIf::IndentCondition,
             EIf::IndentThenToken,
         )
-        .parse(arena, state)
+        .parse(arena, state, min_indent)
         .map_err(|(_, f, s)| (MadeProgress, f, s))?;
 
         let (_, _, state) = parser::keyword_e(keyword::THEN, EIf::Then)
-            .parse(arena, state)
+            .parse(arena, state, min_indent)
             .map_err(|(_, f, s)| (MadeProgress, f, s))?;
 
         let (_, then_branch, state) = space0_around_ee(
-            specialize_ref(EIf::ThenBranch, move |arena, state| {
-                parse_loc_expr(min_indent, arena, state)
+            specialize_ref(EIf::ThenBranch, move |arena, state, min_indent| {
+                parse_loc_expr(arena, state, min_indent)
             }),
-            min_indent,
             EIf::IndentThenBranch,
             EIf::IndentElseToken,
         )
-        .parse(arena, state)
+        .parse(arena, state, min_indent)
         .map_err(|(_, f, s)| (MadeProgress, f, s))?;
 
         let (_, _, state) = parser::keyword_e(keyword::ELSE, EIf::Else)
-            .parse(arena, state)
+            .parse(arena, state, min_indent)
             .map_err(|(_, f, s)| (MadeProgress, f, s))?;
 
         Ok((MadeProgress, (cond, then_branch), state))
     }
 }
 
-fn expect_help<'a>(
-    min_indent: u32,
-    options: ExprParseOptions,
-) -> impl Parser<'a, Expr<'a>, EExpect<'a>> {
-    move |arena: &'a Bump, state: State<'a>| {
+fn expect_help<'a>(options: ExprParseOptions) -> impl Parser<'a, Expr<'a>, EExpect<'a>> {
+    move |arena: &'a Bump, state: State<'a>, min_indent| {
         let start_column = state.column();
 
         let (_, _, state) =
-            parser::keyword_e(keyword::EXPECT, EExpect::Expect).parse(arena, state)?;
+            parser::keyword_e(keyword::EXPECT, EExpect::Expect).parse(arena, state, min_indent)?;
 
         let (_, condition, state) = space0_before_e(
-            specialize_ref(EExpect::Condition, move |arena, state| {
+            specialize_ref(EExpect::Condition, move |arena, state, _m| {
                 parse_loc_expr_with_options(start_column + 1, options, arena, state)
             }),
-            start_column + 1,
             EExpect::IndentCondition,
         )
-        .parse(arena, state)
+        .parse(arena, state, start_column + 1)
         .map_err(|(_, f, s)| (MadeProgress, f, s))?;
 
         let parse_cont = specialize_ref(
             EExpect::Continuation,
-            space0_before_e(
-                move |a, s| parse_loc_expr(min_indent, a, s),
-                min_indent,
-                EExpr::IndentEnd,
-            ),
+            space0_before_e(parse_loc_expr, EExpr::IndentEnd),
         );
 
-        let (_, loc_cont, state) = parse_cont.parse(arena, state)?;
+        let (_, loc_cont, state) = parse_cont.parse(arena, state, min_indent)?;
 
         let expr = Expr::Expect(arena.alloc(condition), arena.alloc(loc_cont));
 
@@ -2462,30 +2391,29 @@ fn expect_help<'a>(
     }
 }
 
-fn if_expr_help<'a>(
-    min_indent: u32,
-    options: ExprParseOptions,
-) -> impl Parser<'a, Expr<'a>, EIf<'a>> {
-    move |arena: &'a Bump, state| {
-        let (_, _, state) = parser::keyword_e(keyword::IF, EIf::If).parse(arena, state)?;
+fn if_expr_help<'a>(options: ExprParseOptions) -> impl Parser<'a, Expr<'a>, EIf<'a>> {
+    move |arena: &'a Bump, state, min_indent| {
+        let (_, _, state) =
+            parser::keyword_e(keyword::IF, EIf::If).parse(arena, state, min_indent)?;
 
         let mut branches = Vec::with_capacity_in(1, arena);
 
         let mut loop_state = state;
 
         let state_final_else = loop {
-            let (_, (cond, then_branch), state) = if_branch(min_indent).parse(arena, loop_state)?;
+            let (_, (cond, then_branch), state) =
+                if_branch().parse(arena, loop_state, min_indent)?;
 
             branches.push((cond, then_branch));
 
             // try to parse another `if`
             // NOTE this drops spaces between the `else` and the `if`
             let optional_if = and!(
-                backtrackable(space0_e(min_indent, EIf::IndentIf)),
+                backtrackable(space0_e(EIf::IndentIf)),
                 parser::keyword_e(keyword::IF, EIf::If)
             );
 
-            match optional_if.parse(arena, state) {
+            match optional_if.parse(arena, state, min_indent) {
                 Err((_, _, state)) => break state,
                 Ok((_, _, state)) => {
                     loop_state = state;
@@ -2495,13 +2423,12 @@ fn if_expr_help<'a>(
         };
 
         let (_, else_branch, state) = space0_before_e(
-            specialize_ref(EIf::ElseBranch, move |arena, state| {
+            specialize_ref(EIf::ElseBranch, move |arena, state, min_indent| {
                 parse_loc_expr_with_options(min_indent, options, arena, state)
             }),
-            min_indent,
             EIf::IndentElseBranch,
         )
-        .parse(arena, state_final_else)
+        .parse(arena, state_final_else, min_indent)
         .map_err(|(_, f, s)| (MadeProgress, f, s))?;
 
         let expr = Expr::If(branches.into_bump_slice(), arena.alloc(else_branch));
@@ -2542,10 +2469,10 @@ where
     P: Parser<'a, T, E>,
     E: 'a,
 {
-    move |arena, state: State<'a>| {
+    move |arena, state: State<'a>, min_indent: u32| {
         let indent_column = state.column();
 
-        let (progress, _, state) = parser.parse(arena, state)?;
+        let (progress, _, state) = parser.parse(arena, state, min_indent)?;
 
         Ok((progress, indent_column, state))
     }
@@ -2583,22 +2510,18 @@ fn ident_to_expr<'a>(arena: &'a Bump, src: Ident<'a>) -> Expr<'a> {
     }
 }
 
-fn list_literal_help<'a>(min_indent: u32) -> impl Parser<'a, Expr<'a>, EList<'a>> {
-    move |arena, state| {
+fn list_literal_help<'a>() -> impl Parser<'a, Expr<'a>, EList<'a>> {
+    move |arena, state, min_indent| {
         let (_, elements, state) = collection_trailing_sep_e!(
             word1(b'[', EList::Open),
-            specialize_ref(
-                EList::Expr,
-                move |a, s| parse_loc_expr_no_multi_backpassing(min_indent, a, s)
-            ),
+            specialize_ref(EList::Expr, loc_expr_no_multi_backpassing()),
             word1(b',', EList::End),
             word1(b']', EList::End),
-            min_indent,
             EList::Open,
             EList::IndentEnd,
             Expr::SpaceBefore
         )
-        .parse(arena, state)?;
+        .parse(arena, state, min_indent)?;
 
         let elements = elements.ptrify_items(arena);
         let expr = Expr::List(elements);
@@ -2607,19 +2530,17 @@ fn list_literal_help<'a>(min_indent: u32) -> impl Parser<'a, Expr<'a>, EList<'a>
     }
 }
 
-pub fn record_value_field<'a>(
-    min_indent: u32,
-) -> impl Parser<'a, AssignedField<'a, Expr<'a>>, ERecord<'a>> {
+pub fn record_value_field<'a>() -> impl Parser<'a, AssignedField<'a, Expr<'a>>, ERecord<'a>> {
     use AssignedField::*;
 
-    move |arena, state: State<'a>| {
+    move |arena, state: State<'a>, min_indent| {
         // You must have a field name, e.g. "email"
         let (progress, loc_label, state) =
             specialize(|_, pos| ERecord::Field(pos), loc!(lowercase_ident()))
-                .parse(arena, state)?;
+                .parse(arena, state, min_indent)?;
         debug_assert_eq!(progress, MadeProgress);
 
-        let (_, spaces, state) = space0_e(min_indent, ERecord::IndentColon).parse(arena, state)?;
+        let (_, spaces, state) = space0_e(ERecord::IndentColon).parse(arena, state, min_indent)?;
 
         // Having a value is optional; both `{ email }` and `{ email: blah }` work.
         // (This is true in both literals and types.)
@@ -2629,14 +2550,11 @@ pub fn record_value_field<'a>(
                 word1(b'?', ERecord::QuestionMark)
             ),
             space0_before_e(
-                specialize_ref(ERecord::Expr, move |a, s| {
-                    parse_loc_expr_no_multi_backpassing(min_indent, a, s)
-                }),
-                min_indent,
+                specialize_ref(ERecord::Expr, loc_expr_no_multi_backpassing()),
                 ERecord::IndentEnd,
             )
         ))
-        .parse(arena, state)?;
+        .parse(arena, state, min_indent)?;
 
         let answer = match opt_loc_val {
             Some((Either::First(_), loc_val)) => {
@@ -2669,9 +2587,7 @@ fn record_updateable_identifier<'a>() -> impl Parser<'a, Expr<'a>, ERecord<'a>> 
     )
 }
 
-fn record_help<'a>(
-    min_indent: u32,
-) -> impl Parser<
+fn record_help<'a>() -> impl Parser<
     'a,
     (
         Option<Loc<Expr<'a>>>,
@@ -2694,7 +2610,6 @@ fn record_help<'a>(
                     // and then in canonicalization verify that it's an Expr::Var
                     // (and not e.g. an `Expr::Access`) and extract its string.
                     loc!(record_updateable_identifier()),
-                    min_indent,
                     ERecord::IndentEnd,
                     ERecord::IndentAmpersand,
                 ),
@@ -2710,14 +2625,13 @@ fn record_help<'a>(
                         trailing_sep_by0(
                             word1(b',', ERecord::End),
                             space0_before_optional_after(
-                                loc!(record_value_field(min_indent)),
-                                min_indent,
+                                loc!(record_value_field()),
                                 ERecord::IndentEnd,
                                 ERecord::IndentEnd
                             ),
                         ),
                         // Allow outdented closing braces
-                        space0_e(0, ERecord::IndentEnd)
+                        reset_min_indent(space0_e(ERecord::IndentEnd))
                     ),
                     word1(b'}', ERecord::End)
                 )
@@ -2726,10 +2640,10 @@ fn record_help<'a>(
     )
 }
 
-fn record_literal_help<'a>(min_indent: u32) -> impl Parser<'a, Expr<'a>, EExpr<'a>> {
+fn record_literal_help<'a>() -> impl Parser<'a, Expr<'a>, EExpr<'a>> {
     then(
-        loc!(specialize(EExpr::Record, record_help(min_indent))),
-        move |arena, state, _, loc_record| {
+        loc!(specialize(EExpr::Record, record_help())),
+        move |arena, state, _, loc_record, min_indent| {
             let (opt_update, loc_assigned_fields_with_comments) = loc_record.value;
 
             // This is a record literal, not a destructure.
@@ -2750,7 +2664,8 @@ fn record_literal_help<'a>(min_indent: u32) -> impl Parser<'a, Expr<'a>, EExpr<'
             };
 
             // there can be field access, e.g. `{ x : 4 }.x`
-            let (_, accesses, state) = optional(record_field_access_chain()).parse(arena, state)?;
+            let (_, accesses, state) =
+                optional(record_field_access_chain()).parse(arena, state, min_indent)?;
 
             if let Some(fields) = accesses {
                 for field in fields {
@@ -2838,7 +2753,7 @@ const BINOP_CHAR_MASK: [bool; 125] = {
 };
 
 fn operator<'a>() -> impl Parser<'a, BinOp, EExpr<'a>> {
-    |_, state| operator_help(EExpr::Start, EExpr::BadOperator, state)
+    |_, state, _m| operator_help(EExpr::Start, EExpr::BadOperator, state)
 }
 
 #[inline(always)]

--- a/crates/compiler/parse/src/number_literal.rs
+++ b/crates/compiler/parse/src/number_literal.rs
@@ -13,7 +13,7 @@ pub enum NumLiteral<'a> {
 }
 
 pub fn positive_number_literal<'a>() -> impl Parser<'a, NumLiteral<'a>, ENumber> {
-    move |_arena, state: State<'a>| {
+    move |_arena, state: State<'a>, _min_indent: u32| {
         match state.bytes().first() {
             Some(first_byte) if (*first_byte as char).is_ascii_digit() => {
                 parse_number_base(false, state.bytes(), state)
@@ -27,7 +27,7 @@ pub fn positive_number_literal<'a>() -> impl Parser<'a, NumLiteral<'a>, ENumber>
 }
 
 pub fn number_literal<'a>() -> impl Parser<'a, NumLiteral<'a>, ENumber> {
-    move |_arena, state: State<'a>| {
+    move |_arena, state: State<'a>, _min_indent: u32| {
         match state.bytes().first() {
             Some(first_byte) if *first_byte == b'-' => {
                 // drop the minus

--- a/crates/compiler/parse/src/test_helpers.rs
+++ b/crates/compiler/parse/src/test_helpers.rs
@@ -34,7 +34,9 @@ pub fn parse_loc_with<'a>(
 pub fn parse_defs_with<'a>(arena: &'a Bump, input: &'a str) -> Result<Defs<'a>, SyntaxError<'a>> {
     let state = State::new(input.trim().as_bytes());
 
-    match module_defs().parse(arena, state) {
+    let min_indent = 0;
+
+    match module_defs().parse(arena, state, min_indent) {
         Ok(tuple) => Ok(tuple.1),
         Err(tuple) => Err(tuple.1),
     }

--- a/crates/compiler/parse/src/type_annotation.rs
+++ b/crates/compiler/parse/src/type_annotation.rs
@@ -9,54 +9,52 @@ use crate::expr::record_value_field;
 use crate::ident::lowercase_ident;
 use crate::keyword;
 use crate::parser::{
-    allocated, backtrackable, optional, specialize, specialize_ref, word1, word2, word3, EType,
-    ETypeApply, ETypeInParens, ETypeInlineAlias, ETypeRecord, ETypeTagUnion, ParseResult, Parser,
+    absolute_column_min_indent, increment_min_indent, then, ERecord, ETypeAbilityImpl,
+};
+use crate::parser::{
+    allocated, backtrackable, fail, optional, specialize, specialize_ref, word1, word2, word3,
+    EType, ETypeApply, ETypeInParens, ETypeInlineAlias, ETypeRecord, ETypeTagUnion, Parser,
     Progress::{self, *},
 };
-use crate::parser::{then, ERecord, ETypeAbilityImpl};
 use crate::state::State;
 use bumpalo::collections::vec::Vec;
 use bumpalo::Bump;
 use roc_region::all::{Loc, Position, Region};
 
 pub fn located<'a>(
-    min_indent: u32,
     is_trailing_comma_valid: bool,
 ) -> impl Parser<'a, Loc<TypeAnnotation<'a>>, EType<'a>> {
-    expression(min_indent, is_trailing_comma_valid, false)
+    expression(is_trailing_comma_valid, false)
 }
 
 pub fn located_opaque_signature<'a>(
-    min_indent: u32,
     is_trailing_comma_valid: bool,
 ) -> impl Parser<'a, Loc<TypeAnnotation<'a>>, EType<'a>> {
-    expression(min_indent, is_trailing_comma_valid, true)
+    expression(is_trailing_comma_valid, true)
 }
 
 #[inline(always)]
 fn tag_union_type<'a>(
-    min_indent: u32,
     stop_at_surface_has: bool,
 ) -> impl Parser<'a, TypeAnnotation<'a>, ETypeTagUnion<'a>> {
-    move |arena, state| {
+    move |arena, state, min_indent| {
         let (_, tags, state) = collection_trailing_sep_e!(
             word1(b'[', ETypeTagUnion::Open),
-            loc!(tag_type(min_indent, false)),
+            loc!(tag_type(false)),
             word1(b',', ETypeTagUnion::End),
             word1(b']', ETypeTagUnion::End),
-            min_indent,
             ETypeTagUnion::Open,
             ETypeTagUnion::IndentEnd,
             Tag::SpaceBefore
         )
-        .parse(arena, state)?;
+        .parse(arena, state, min_indent)?;
 
         // This could be an open tag union, e.g. `[Foo, Bar]a`
         let (_, ext, state) = optional(allocated(specialize_ref(
             ETypeTagUnion::Type,
-            term(min_indent, stop_at_surface_has),
+            term(stop_at_surface_has),
         )))
-        .parse(arena, state)?;
+        .parse(arena, state, min_indent)?;
 
         let result = TypeAnnotation::TagUnion { tags, ext };
 
@@ -64,11 +62,11 @@ fn tag_union_type<'a>(
     }
 }
 
-fn check_type_alias(
-    p: Progress,
-    annot: Loc<TypeAnnotation>,
-) -> impl Parser<TypeHeader, ETypeInlineAlias> {
-    move |arena, state| match annot.value {
+fn check_type_alias<'a>(
+    arena: &'a Bump,
+    annot: Loc<TypeAnnotation<'a>>,
+) -> Result<TypeHeader<'a>, ETypeInlineAlias> {
+    match annot.value {
         TypeAnnotation::Apply("", tag_name, vars) => {
             let mut var_names = Vec::new_in(arena);
             var_names.reserve(vars.len());
@@ -76,11 +74,7 @@ fn check_type_alias(
                 if let TypeAnnotation::BoundVariable(v) = var.value {
                     var_names.push(Loc::at(var.region, Pattern::Identifier(v)));
                 } else {
-                    return Err((
-                        p,
-                        ETypeInlineAlias::ArgumentNotLowercase(var.region.start()),
-                        state,
-                    ));
+                    return Err(ETypeInlineAlias::ArgumentNotLowercase(var.region.start()));
                 }
             }
 
@@ -93,64 +87,58 @@ fn check_type_alias(
                 vars: var_names.into_bump_slice(),
             };
 
-            Ok((p, header, state))
+            Ok(header)
         }
-        TypeAnnotation::Apply(_, _, _) => {
-            Err((p, ETypeInlineAlias::Qualified(annot.region.start()), state))
-        }
-        _ => Err((p, ETypeInlineAlias::NotAnAlias(annot.region.start()), state)),
+        TypeAnnotation::Apply(_, _, _) => Err(ETypeInlineAlias::Qualified(annot.region.start())),
+        _ => Err(ETypeInlineAlias::NotAnAlias(annot.region.start())),
     }
 }
 
-fn parse_type_alias_after_as<'a>(min_indent: u32) -> impl Parser<'a, TypeHeader<'a>, EType<'a>> {
-    move |arena, state| {
-        space0_before_e(term(min_indent, false), min_indent, EType::TAsIndentStart)
-            .parse(arena, state)
-            .and_then(|(p, annot, state)| {
-                specialize(EType::TInlineAlias, check_type_alias(p, annot)).parse(arena, state)
-            })
-    }
+fn parse_type_alias_after_as<'a>() -> impl Parser<'a, TypeHeader<'a>, EType<'a>> {
+    then(
+        space0_before_e(term(false), EType::TAsIndentStart),
+        // TODO: introduce a better combinator for this.
+        // `check_type_alias` doesn't need to modify the state or progress, but it needs to access `state.pos()`
+        |arena, state, progress, output, _min_indent| {
+            let res = check_type_alias(arena, output);
+
+            match res {
+                Ok(header) => Ok((progress, header, state)),
+                Err(err) => Err((progress, EType::TInlineAlias(err, state.pos()), state)),
+            }
+        },
+    )
 }
 
-fn fail_type_start<'a, T: 'a>() -> impl Parser<'a, T, EType<'a>> {
-    |_arena, state: State<'a>| Err((NoProgress, EType::TStart(state.pos()), state))
-}
-
-fn term<'a>(
-    min_indent: u32,
-    stop_at_surface_has: bool,
-) -> impl Parser<'a, Loc<TypeAnnotation<'a>>, EType<'a>> {
+fn term<'a>(stop_at_surface_has: bool) -> impl Parser<'a, Loc<TypeAnnotation<'a>>, EType<'a>> {
     map_with_arena!(
         and!(
             one_of!(
                 loc_wildcard(),
                 loc_inferred(),
-                specialize(EType::TInParens, loc_type_in_parens(min_indent)),
-                loc!(specialize(
-                    EType::TRecord,
-                    record_type(min_indent, stop_at_surface_has)
-                )),
+                specialize(EType::TInParens, loc_type_in_parens()),
+                loc!(specialize(EType::TRecord, record_type(stop_at_surface_has))),
                 loc!(specialize(
                     EType::TTagUnion,
-                    tag_union_type(min_indent, stop_at_surface_has)
+                    tag_union_type(stop_at_surface_has)
                 )),
-                loc!(applied_type(min_indent, stop_at_surface_has)),
+                loc!(applied_type(stop_at_surface_has)),
                 loc!(parse_type_variable(stop_at_surface_has)),
-                fail_type_start(),
+                fail(EType::TStart),
             ),
             // Inline alias notation, e.g. [Nil, Cons a (List a)] as List a
             one_of![
                 map!(
                     and!(
                         skip_second!(
-                            backtrackable(space0_e(min_indent, EType::TIndentEnd)),
+                            backtrackable(space0_e(EType::TIndentEnd)),
                             crate::parser::keyword_e(keyword::AS, EType::TEnd)
                         ),
-                        parse_type_alias_after_as(min_indent)
+                        parse_type_alias_after_as()
                     ),
                     Some
                 ),
-                |_, state| Ok((NoProgress, None, state))
+                succeed!(None)
             ]
         ),
         |arena: &'a Bump,
@@ -187,27 +175,23 @@ fn loc_inferred<'a>() -> impl Parser<'a, Loc<TypeAnnotation<'a>>, EType<'a>> {
 }
 
 fn loc_applied_arg<'a>(
-    min_indent: u32,
     stop_at_surface_has: bool,
 ) -> impl Parser<'a, Loc<TypeAnnotation<'a>>, EType<'a>> {
     use crate::ast::Spaceable;
 
     map_with_arena!(
         and!(
-            backtrackable(space0_e(min_indent, EType::TIndentStart)),
+            backtrackable(space0_e(EType::TIndentStart)),
             one_of!(
                 loc_wildcard(),
                 loc_inferred(),
-                specialize(EType::TInParens, loc_type_in_parens(min_indent)),
-                loc!(specialize(
-                    EType::TRecord,
-                    record_type(min_indent, stop_at_surface_has)
-                )),
+                specialize(EType::TInParens, loc_type_in_parens()),
+                loc!(specialize(EType::TRecord, record_type(stop_at_surface_has))),
                 loc!(specialize(
                     EType::TTagUnion,
-                    tag_union_type(min_indent, stop_at_surface_has)
+                    tag_union_type(stop_at_surface_has)
                 )),
-                loc!(specialize(EType::TApply, parse_concrete_type)),
+                loc!(specialize(EType::TApply, concrete_type())),
                 loc!(parse_type_variable(stop_at_surface_has))
             )
         ),
@@ -222,18 +206,11 @@ fn loc_applied_arg<'a>(
     )
 }
 
-fn loc_type_in_parens<'a>(
-    min_indent: u32,
-) -> impl Parser<'a, Loc<TypeAnnotation<'a>>, ETypeInParens<'a>> {
+fn loc_type_in_parens<'a>() -> impl Parser<'a, Loc<TypeAnnotation<'a>>, ETypeInParens<'a>> {
     between!(
         word1(b'(', ETypeInParens::Open),
         space0_around_ee(
-            move |arena, state| specialize_ref(
-                ETypeInParens::Type,
-                expression(min_indent, true, false)
-            )
-            .parse(arena, state),
-            min_indent,
+            specialize_ref(ETypeInParens::Type, expression(true, false)),
             ETypeInParens::IndentOpen,
             ETypeInParens::IndentEnd,
         ),
@@ -242,18 +219,14 @@ fn loc_type_in_parens<'a>(
 }
 
 #[inline(always)]
-fn tag_type<'a>(
-    min_indent: u32,
-    stop_at_surface_has: bool,
-) -> impl Parser<'a, Tag<'a>, ETypeTagUnion<'a>> {
-    move |arena, state: State<'a>| {
-        let (_, name, state) = loc!(parse_tag_name(ETypeTagUnion::End)).parse(arena, state)?;
+fn tag_type<'a>(stop_at_surface_has: bool) -> impl Parser<'a, Tag<'a>, ETypeTagUnion<'a>> {
+    move |arena, state: State<'a>, min_indent: u32| {
+        let (_, name, state) =
+            loc!(parse_tag_name(ETypeTagUnion::End)).parse(arena, state, min_indent)?;
 
-        let (_, args, state) = specialize_ref(
-            ETypeTagUnion::Type,
-            loc_applied_args_e(min_indent, stop_at_surface_has),
-        )
-        .parse(arena, state)?;
+        let (_, args, state) =
+            specialize_ref(ETypeTagUnion::Type, loc_applied_args_e(stop_at_surface_has))
+                .parse(arena, state, min_indent)?;
 
         let result = Tag::Apply {
             name,
@@ -269,19 +242,20 @@ where
     F: Fn(Position) -> E,
     E: 'a,
 {
-    move |arena, state: State<'a>| match crate::ident::tag_name().parse(arena, state) {
+    move |arena, state: State<'a>, min_indent: u32| match crate::ident::tag_name()
+        .parse(arena, state, min_indent)
+    {
         Ok(good) => Ok(good),
         Err((progress, _, state)) => Err((progress, to_problem(state.pos()), state)),
     }
 }
 
-fn record_type_field<'a>(
-    min_indent: u32,
-) -> impl Parser<'a, AssignedField<'a, TypeAnnotation<'a>>, ETypeRecord<'a>> {
+fn record_type_field<'a>() -> impl Parser<'a, AssignedField<'a, TypeAnnotation<'a>>, ETypeRecord<'a>>
+{
     use crate::parser::Either::*;
     use AssignedField::*;
 
-    (move |arena, state: State<'a>| {
+    (move |arena, state: State<'a>, min_indent: u32| {
         // You must have a field name, e.g. "email"
         // using the initial pos is important for error reporting
         let pos = state.pos();
@@ -289,11 +263,11 @@ fn record_type_field<'a>(
             move |_, _| ETypeRecord::Field(pos),
             lowercase_ident()
         ))
-        .parse(arena, state)?;
+        .parse(arena, state, min_indent)?;
         debug_assert_eq!(progress, MadeProgress);
 
         let (_, spaces, state) =
-            space0_e(min_indent, ETypeRecord::IndentEnd).parse(arena, state)?;
+            space0_e(ETypeRecord::IndentEnd).parse(arena, state, min_indent)?;
 
         // Having a value is optional; both `{ email }` and `{ email: blah }` work.
         // (This is true in both literals and types.)
@@ -301,15 +275,14 @@ fn record_type_field<'a>(
             word1(b':', ETypeRecord::Colon),
             word1(b'?', ETypeRecord::Optional)
         ))
-        .parse(arena, state)?;
+        .parse(arena, state, min_indent)?;
 
-        let val_parser = specialize_ref(ETypeRecord::Type, expression(min_indent, true, false));
+        let val_parser = specialize_ref(ETypeRecord::Type, expression(true, false));
 
         match opt_loc_val {
             Some(First(_)) => {
-                let (_, loc_val, state) =
-                    space0_before_e(val_parser, min_indent, ETypeRecord::IndentColon)
-                        .parse(arena, state)?;
+                let (_, loc_val, state) = space0_before_e(val_parser, ETypeRecord::IndentColon)
+                    .parse(arena, state, min_indent)?;
 
                 Ok((
                     MadeProgress,
@@ -318,9 +291,8 @@ fn record_type_field<'a>(
                 ))
             }
             Some(Second(_)) => {
-                let (_, loc_val, state) =
-                    space0_before_e(val_parser, min_indent, ETypeRecord::IndentOptional)
-                        .parse(arena, state)?;
+                let (_, loc_val, state) = space0_before_e(val_parser, ETypeRecord::IndentOptional)
+                    .parse(arena, state, min_indent)?;
 
                 Ok((
                     MadeProgress,
@@ -346,28 +318,26 @@ fn record_type_field<'a>(
 
 #[inline(always)]
 fn record_type<'a>(
-    min_indent: u32,
     stop_at_surface_has: bool,
 ) -> impl Parser<'a, TypeAnnotation<'a>, ETypeRecord<'a>> {
     use crate::type_annotation::TypeAnnotation::*;
 
-    (move |arena, state| {
+    (move |arena, state, min_indent| {
         let (_, fields, state) = collection_trailing_sep_e!(
             // word1_check_indent!(b'{', TRecord::Open, min_indent, TRecord::IndentOpen),
             word1(b'{', ETypeRecord::Open),
-            loc!(record_type_field(min_indent)),
+            loc!(record_type_field()),
             word1(b',', ETypeRecord::End),
             // word1_check_indent!(b'}', TRecord::End, min_indent, TRecord::IndentEnd),
             word1(b'}', ETypeRecord::End),
-            min_indent,
             ETypeRecord::Open,
             ETypeRecord::IndentEnd,
             AssignedField::SpaceBefore
         )
-        .parse(arena, state)?;
+        .parse(arena, state, min_indent)?;
 
-        let field_term = specialize_ref(ETypeRecord::Type, term(min_indent, stop_at_surface_has));
-        let (_, ext, state) = optional(allocated(field_term)).parse(arena, state)?;
+        let field_term = specialize_ref(ETypeRecord::Type, term(stop_at_surface_has));
+        let (_, ext, state) = optional(allocated(field_term)).parse(arena, state, min_indent)?;
 
         let result = Record { fields, ext };
 
@@ -376,16 +346,13 @@ fn record_type<'a>(
     .trace("type_annotation:record_type")
 }
 
-fn applied_type<'a>(
-    min_indent: u32,
-    stop_at_surface_has: bool,
-) -> impl Parser<'a, TypeAnnotation<'a>, EType<'a>> {
+fn applied_type<'a>(stop_at_surface_has: bool) -> impl Parser<'a, TypeAnnotation<'a>, EType<'a>> {
     map!(
         and!(
-            specialize(EType::TApply, parse_concrete_type),
+            specialize(EType::TApply, concrete_type()),
             // Optionally parse space-separated arguments for the constructor,
             // e.g. `Str Float` in `Map Str Float`
-            loc_applied_args_e(min_indent, stop_at_surface_has)
+            loc_applied_args_e(stop_at_surface_has)
         ),
         |(ctor, args): (TypeAnnotation<'a>, Vec<'a, Loc<TypeAnnotation<'a>>>)| {
             match &ctor {
@@ -406,29 +373,24 @@ fn applied_type<'a>(
 }
 
 fn loc_applied_args_e<'a>(
-    min_indent: u32,
     stop_at_surface_has: bool,
 ) -> impl Parser<'a, Vec<'a, Loc<TypeAnnotation<'a>>>, EType<'a>> {
-    zero_or_more!(loc_applied_arg(min_indent, stop_at_surface_has))
+    zero_or_more!(loc_applied_arg(stop_at_surface_has))
 }
 
 // Hash & Eq & ...
-fn ability_chain<'a>(
-    min_indent: u32,
-) -> impl Parser<'a, Vec<'a, Loc<TypeAnnotation<'a>>>, EType<'a>> {
+fn ability_chain<'a>() -> impl Parser<'a, Vec<'a, Loc<TypeAnnotation<'a>>>, EType<'a>> {
     map!(
         and!(
             space0_before_optional_after(
-                specialize(EType::TApply, loc!(parse_concrete_type)),
-                min_indent,
+                specialize(EType::TApply, loc!(concrete_type())),
                 EType::TIndentStart,
                 EType::TIndentEnd,
             ),
             zero_or_more!(skip_first!(
                 word1(b'&', EType::THasClause),
                 space0_before_optional_after(
-                    specialize(EType::TApply, loc!(parse_concrete_type)),
-                    min_indent,
+                    specialize(EType::TApply, loc!(concrete_type())),
                     EType::TIndentStart,
                     EType::TIndentEnd,
                 )
@@ -444,7 +406,7 @@ fn ability_chain<'a>(
     )
 }
 
-fn has_clause<'a>(min_indent: u32) -> impl Parser<'a, Loc<HasClause<'a>>, EType<'a>> {
+fn has_clause<'a>() -> impl Parser<'a, Loc<HasClause<'a>>, EType<'a>> {
     map!(
         // Suppose we are trying to parse "a has Hash"
         and!(
@@ -454,17 +416,14 @@ fn has_clause<'a>(min_indent: u32) -> impl Parser<'a, Loc<HasClause<'a>>, EType<
                     |_, pos| EType::TBadTypeVariable(pos),
                     loc!(map!(lowercase_ident(), Spaced::Item)),
                 ),
-                min_indent,
                 EType::TIndentStart,
                 EType::TIndentEnd
             ),
-            then(
+            skip_first!(
                 // Parse "has"; we don't care about this keyword
                 word3(b'h', b'a', b's', EType::THasClause),
                 // Parse "Hash & ..."; this may be qualified from another module like "Hash.Hash"
-                |arena, state, _progress, _output| {
-                    ability_chain(state.column() + 1).parse(arena, state)
-                }
+                absolute_column_min_indent(ability_chain())
             )
         ),
         |(var, abilities): (Loc<Spaced<'a, &'a str>>, Vec<'a, Loc<TypeAnnotation<'a>>>)| {
@@ -485,24 +444,18 @@ fn has_clause<'a>(min_indent: u32) -> impl Parser<'a, Loc<HasClause<'a>>, EType<
 /// Parse a chain of `has` clauses, e.g. " | a has Hash, b has Eq".
 /// Returns the clauses and spaces before the starting "|", if there were any.
 fn has_clause_chain<'a>(
-    min_indent: u32,
 ) -> impl Parser<'a, (&'a [CommentOrNewline<'a>], &'a [Loc<HasClause<'a>>]), EType<'a>> {
-    move |arena, state: State<'a>| {
-        let (_, (spaces_before, ()), state) = and!(
-            space0_e(min_indent, EType::TIndentStart),
-            word1(b'|', EType::TWhereBar)
-        )
-        .parse(arena, state)?;
+    move |arena, state: State<'a>, min_indent: u32| {
+        let (_, (spaces_before, ()), state) =
+            and!(space0_e(EType::TIndentStart), word1(b'|', EType::TWhereBar))
+                .parse(arena, state, min_indent)?;
 
-        let min_demand_indent = state.column() + 1;
         // Parse the first clause (there must be one), then the rest
-        let (_, first_clause, state) = has_clause(min_demand_indent).parse(arena, state)?;
+        let (_, first_clause, state) = has_clause().parse(arena, state, min_indent)?;
 
-        let (_, mut clauses, state) = zero_or_more!(skip_first!(
-            word1(b',', EType::THasClause),
-            has_clause(min_demand_indent)
-        ))
-        .parse(arena, state)?;
+        let (_, mut clauses, state) =
+            zero_or_more!(skip_first!(word1(b',', EType::THasClause), has_clause()))
+                .parse(arena, state, min_indent)?;
 
         // Usually the number of clauses shouldn't be too large, so this is okay
         clauses.insert(0, first_clause);
@@ -516,8 +469,8 @@ fn has_clause_chain<'a>(
 }
 
 /// Parse a has-abilities clause, e.g. `has [Eq, Hash]`.
-pub fn has_abilities<'a>(min_indent: u32) -> impl Parser<'a, Loc<HasAbilities<'a>>, EType<'a>> {
-    skip_first!(
+pub fn has_abilities<'a>() -> impl Parser<'a, Loc<HasAbilities<'a>>, EType<'a>> {
+    increment_min_indent(skip_first!(
         // Parse "has"; we don't care about this keyword
         word3(b'h', b'a', b's', EType::THasClause),
         // Parse "Hash"; this may be qualified from another module like "Hash.Hash"
@@ -525,39 +478,33 @@ pub fn has_abilities<'a>(min_indent: u32) -> impl Parser<'a, Loc<HasAbilities<'a
             loc!(map!(
                 collection_trailing_sep_e!(
                     word1(b'[', EType::TStart),
-                    loc!(parse_has_ability(min_indent)),
+                    loc!(parse_has_ability()),
                     word1(b',', EType::TEnd),
                     word1(b']', EType::TEnd),
-                    min_indent + 1,
                     EType::TStart,
                     EType::TIndentEnd,
                     HasAbility::SpaceBefore
                 ),
                 HasAbilities::Has
             )),
-            min_indent + 1,
             EType::TIndentEnd,
         )
-    )
+    ))
 }
 
-fn parse_has_ability<'a>(min_indent: u32) -> impl Parser<'a, HasAbility<'a>, EType<'a>> {
-    map!(
+fn parse_has_ability<'a>() -> impl Parser<'a, HasAbility<'a>, EType<'a>> {
+    increment_min_indent(map!(
         and!(
-            loc!(specialize(EType::TApply, parse_concrete_type)),
+            loc!(specialize(EType::TApply, concrete_type())),
             optional(space0_before_e(
                 loc!(map!(
                     specialize(
                         EType::TAbilityImpl,
                         collection_trailing_sep_e!(
                             word1(b'{', ETypeAbilityImpl::Open),
-                            specialize(
-                                |e: ERecord<'_>, _| e.into(),
-                                loc!(record_value_field(min_indent + 1))
-                            ),
+                            specialize(|e: ERecord<'_>, _| e.into(), loc!(record_value_field())),
                             word1(b',', ETypeAbilityImpl::End),
                             word1(b'}', ETypeAbilityImpl::End),
-                            min_indent,
                             ETypeAbilityImpl::Open,
                             ETypeAbilityImpl::IndentEnd,
                             AssignedField::SpaceBefore
@@ -565,63 +512,49 @@ fn parse_has_ability<'a>(min_indent: u32) -> impl Parser<'a, HasAbility<'a>, ETy
                     ),
                     HasImpls::HasImpls
                 )),
-                min_indent + 1,
                 EType::TIndentEnd
             ))
         ),
         |(ability, impls): (_, Option<_>)| { HasAbility::HasAbility { ability, impls } }
-    )
+    ))
 }
 
 fn expression<'a>(
-    min_indent: u32,
     is_trailing_comma_valid: bool,
     stop_at_surface_has: bool,
 ) -> impl Parser<'a, Loc<TypeAnnotation<'a>>, EType<'a>> {
-    (move |arena, state: State<'a>| {
-        let (p1, first, state) = space0_before_e(
-            term(min_indent, stop_at_surface_has),
-            min_indent,
-            EType::TIndentStart,
-        )
-        .parse(arena, state)?;
+    (move |arena, state: State<'a>, min_indent: u32| {
+        let (p1, first, state) = space0_before_e(term(stop_at_surface_has), EType::TIndentStart)
+            .parse(arena, state, min_indent)?;
 
         let result = and![
             zero_or_more!(skip_first!(
                 word1(b',', EType::TFunctionArgument),
                 one_of![
                     space0_around_ee(
-                        term(min_indent, stop_at_surface_has),
-                        min_indent,
+                        term(stop_at_surface_has),
                         EType::TIndentStart,
                         EType::TIndentEnd
                     ),
-                    |_, state: State<'a>| Err((
-                        NoProgress,
-                        EType::TFunctionArgument(state.pos()),
-                        state
-                    ))
+                    fail(EType::TFunctionArgument)
                 ]
             ))
             .trace("type_annotation:expression:rest_args"),
             // TODO this space0 is dropped, so newlines just before the function arrow when there
             // is only one argument are not seen by the formatter. Can we do better?
             skip_second!(
-                space0_e(min_indent, EType::TIndentStart),
+                space0_e(EType::TIndentStart),
                 word2(b'-', b'>', EType::TStart)
             )
             .trace("type_annotation:expression:arrow")
         ]
-        .parse(arena, state.clone());
+        .parse(arena, state.clone(), min_indent);
 
         let (progress, annot, state) = match result {
             Ok((p2, (rest, _dropped_spaces), state)) => {
-                let (p3, return_type, state) = space0_before_e(
-                    term(min_indent, stop_at_surface_has),
-                    min_indent,
-                    EType::TIndentStart,
-                )
-                .parse(arena, state)?;
+                let (p3, return_type, state) =
+                    space0_before_e(term(stop_at_surface_has), EType::TIndentStart)
+                        .parse(arena, state, min_indent)?;
 
                 let region = Region::span_across(&first.region, &return_type.region);
 
@@ -641,11 +574,11 @@ fn expression<'a>(
             Err(err) => {
                 if !is_trailing_comma_valid {
                     let (_, comma, _) = optional(skip_first!(
-                        space0_e(min_indent, EType::TIndentStart),
+                        space0_e(EType::TIndentStart),
                         word1(b',', EType::TStart)
                     ))
                     .trace("check trailing comma")
-                    .parse(arena, state.clone())?;
+                    .parse(arena, state.clone(), min_indent)?;
 
                     if comma.is_some() {
                         // If the surrounding scope has declared that a trailing comma is not a valid state
@@ -663,8 +596,7 @@ fn expression<'a>(
 
         // Finally, try to parse a where clause if there is one.
         // The where clause must be at least as deep as where the type annotation started.
-        let min_where_clause_indent = min_indent;
-        match has_clause_chain(min_where_clause_indent).parse(arena, state.clone()) {
+        match has_clause_chain().parse(arena, state.clone(), min_indent) {
             Ok((where_progress, (spaces_before, has_chain), state)) => {
                 use crate::ast::Spaceable;
 
@@ -709,30 +641,29 @@ fn expression<'a>(
 // /// A bound type variable, e.g. `a` in `(a -> a)`
 // BoundVariable(&'a str),
 
-fn parse_concrete_type<'a>(
-    arena: &'a Bump,
-    state: State<'a>,
-) -> ParseResult<'a, TypeAnnotation<'a>, ETypeApply> {
-    let initial_bytes = state.bytes();
+fn concrete_type<'a>() -> impl Parser<'a, TypeAnnotation<'a>, ETypeApply> {
+    move |arena: &'a Bump, state: State<'a>, min_indent: u32| {
+        let initial_bytes = state.bytes();
 
-    match crate::ident::concrete_type().parse(arena, state) {
-        Ok((_, (module_name, type_name), state)) => {
-            let answer = TypeAnnotation::Apply(module_name, type_name, &[]);
+        match crate::ident::concrete_type().parse(arena, state, min_indent) {
+            Ok((_, (module_name, type_name), state)) => {
+                let answer = TypeAnnotation::Apply(module_name, type_name, &[]);
 
-            Ok((MadeProgress, answer, state))
-        }
-        Err((NoProgress, _, state)) => Err((NoProgress, ETypeApply::End(state.pos()), state)),
-        Err((MadeProgress, _, mut state)) => {
-            // we made some progress, but ultimately failed.
-            // that means a malformed type name
-            let chomped = crate::ident::chomp_malformed(state.bytes());
-            let delta = initial_bytes.len() - state.bytes().len();
-            let parsed_str =
-                unsafe { std::str::from_utf8_unchecked(&initial_bytes[..chomped + delta]) };
+                Ok((MadeProgress, answer, state))
+            }
+            Err((NoProgress, _, state)) => Err((NoProgress, ETypeApply::End(state.pos()), state)),
+            Err((MadeProgress, _, mut state)) => {
+                // we made some progress, but ultimately failed.
+                // that means a malformed type name
+                let chomped = crate::ident::chomp_malformed(state.bytes());
+                let delta = initial_bytes.len() - state.bytes().len();
+                let parsed_str =
+                    unsafe { std::str::from_utf8_unchecked(&initial_bytes[..chomped + delta]) };
 
-            state = state.advance(chomped);
+                state = state.advance(chomped);
 
-            Ok((MadeProgress, TypeAnnotation::Malformed(parsed_str), state))
+                Ok((MadeProgress, TypeAnnotation::Malformed(parsed_str), state))
+            }
         }
     }
 }
@@ -740,7 +671,9 @@ fn parse_concrete_type<'a>(
 fn parse_type_variable<'a>(
     stop_at_surface_has: bool,
 ) -> impl Parser<'a, TypeAnnotation<'a>, EType<'a>> {
-    move |arena, state: State<'a>| match crate::ident::lowercase_ident().parse(arena, state) {
+    move |arena, state: State<'a>, min_indent: u32| match crate::ident::lowercase_ident()
+        .parse(arena, state, min_indent)
+    {
         Ok((_, name, state)) => {
             if name == "has" && stop_at_surface_has {
                 Err((NoProgress, EType::TEnd(state.pos()), state))

--- a/crates/compiler/parse/tests/test_parse.rs
+++ b/crates/compiler/parse/tests/test_parse.rs
@@ -37,7 +37,7 @@ mod test_parse {
         };
         (module => $arena:expr, $input:expr) => {
             module_defs()
-                .parse($arena, State::new($input.as_bytes()))
+                .parse($arena, State::new($input.as_bytes()), 0)
                 .map(|tuple| tuple.1)
         };
     }
@@ -802,7 +802,7 @@ mod test_parse {
             "#
         );
         let actual = module_defs()
-            .parse(&arena, State::new(src.as_bytes()))
+            .parse(&arena, State::new(src.as_bytes()), 0)
             .map(|tuple| tuple.1);
 
         // It should occur twice in the debug output - once for the pattern,
@@ -828,7 +828,7 @@ mod test_parse {
 
         let state = State::new(src.as_bytes());
         let parser = module_defs();
-        let parsed = parser.parse(arena, state);
+        let parsed = parser.parse(arena, state, 0);
         match parsed {
             Ok((_, _, _state)) => {
                 // dbg!(_state);

--- a/crates/docs/src/lib.rs
+++ b/crates/docs/src/lib.rs
@@ -870,7 +870,7 @@ fn markdown_to_html(
                 // more memory as we iterate through these.
                 arena.reset();
 
-                match parse_ident(&arena, state) {
+                match parse_ident(&arena, state, 0) {
                     Ok((_, Ident::Access { module_name, parts }, _)) => {
                         let mut iter = parts.iter();
 

--- a/crates/repl_cli/src/lib.rs
+++ b/crates/repl_cli/src/lib.rs
@@ -137,7 +137,7 @@ impl Validator for InputValidator {
             let arena = bumpalo::Bump::new();
             let state = roc_parse::state::State::new(ctx.input().trim().as_bytes());
 
-            match roc_parse::expr::parse_loc_expr(0, &arena, state) {
+            match roc_parse::expr::parse_loc_expr(&arena, state, 0) {
                 // Special case some syntax errors to allow for multi-line inputs
                 Err((_, EExpr::DefMissingFinalExpr(_), _))
                 | Err((_, EExpr::DefMissingFinalExpr2(_, _), _))


### PR DESCRIPTION
This removes the need to explicitly pass min_indent when using the parser combinators (as opposed to explicit `parse_` methods or closures).

In cases where we need to pass a _different_ `min_indent` to a nested parser, I introduce a variety of combinators - `reset_min_indent`, `set_min_indent`, `increment_min_indent`, and `absolute_column_min_indent`.

Note that this is purely a refactor, and doesn't change parser behavior. Eventually I'm planning on applying the rule described in #3655 more broadly, via a new combinator to replace many/most usages of `and!`.

My ultimate goal here is to evolve the current parser closer toward a purely combinator-based parser, at which point we can more easily transition smoothly to a formal(ish) grammar, or expand the meanings of combinators to include things like:
* Incremental (re)parsing
* Unified parsing and formatting code
* Better error recovery
* Using the main parser directly for syntax highlighting