### PR TITLE
Exhaustiveness checking for list pattern matches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3593,6 +3593,7 @@ name = "roc_exhaustive"
 version = "0.0.1"
 dependencies = [
  "roc_collections",
+ "roc_error_macros",
  "roc_module",
  "roc_region",
 ]

--- a/crates/compiler/can/src/exhaustive.rs
+++ b/crates/compiler/can/src/exhaustive.rs
@@ -197,7 +197,7 @@ fn index_var(
                     return Ok(vars);
                 }
                 FlatType::EmptyRecord => {
-                    debug_assert!(matches!(ctor, IndexCtor::Record(&[])));
+                    debug_assert!(matches!(ctor, IndexCtor::Record(..)));
                     // If there are optional record fields we don't unify them, but we need to
                     // cover them. Since optional fields correspond to "any" patterns, we can pass
                     // through arbitrary types.

--- a/crates/compiler/can/src/exhaustive.rs
+++ b/crates/compiler/can/src/exhaustive.rs
@@ -27,8 +27,8 @@ pub struct ExhaustiveSummary {
 
 /// Exhaustiveness-checks [sketched rows][SketchedRows] against an expected type.
 ///
-/// Returns an error if the sketch has a type error, in which case exhautiveness checking should
-/// not be performed.
+/// Returns an error if the sketch has a type error, in which case exhautiveness checking will not
+/// have been performed.
 pub fn check(
     subs: &Subs,
     real_var: Variable,

--- a/crates/compiler/constrain/src/pattern.rs
+++ b/crates/compiler/constrain/src/pattern.rs
@@ -520,8 +520,11 @@ pub fn constrain_pattern(
                 },
         } => {
             for loc_pat in patterns.iter() {
-                let expected =
-                    PExpected::ForReason(PReason::ListElem, Type::Variable(*elem_var), region);
+                let expected = PExpected::ForReason(
+                    PReason::ListElem,
+                    Type::Variable(*elem_var),
+                    loc_pat.region,
+                );
 
                 constrain_pattern(
                     constraints,

--- a/crates/compiler/exhaustive/Cargo.toml
+++ b/crates/compiler/exhaustive/Cargo.toml
@@ -9,3 +9,4 @@ edition = "2021"
 roc_collections = { path = "../collections" }
 roc_region = { path = "../region" }
 roc_module = { path = "../module" }
+roc_error_macros = { path = "../../error_macros" }

--- a/crates/compiler/exhaustive/src/lib.rs
+++ b/crates/compiler/exhaustive/src/lib.rs
@@ -371,7 +371,7 @@ pub fn is_useful(mut old_matrix: PatternMatrix, mut vector: Row) -> bool {
                             vector.extend(args);
                         } else {
                             // TODO turn this into an iteration over the outer loop rather than bouncing
-                            vector.extend(args.clone());
+                            vector.extend(args);
                             for list_ctor in spec_list_ctors {
                                 let mut old_matrix = old_matrix.clone();
                                 let mut spec_matrix = Vec::with_capacity(old_matrix.len());
@@ -667,7 +667,7 @@ enum CollectedCtors {
     Ctors(MutMap<TagId, Union>),
 }
 
-fn collect_ctors<'a>(matrix: &'a RefPatternMatrix) -> CollectedCtors {
+fn collect_ctors(matrix: &RefPatternMatrix) -> CollectedCtors {
     if matrix.is_empty() {
         return CollectedCtors::NonExhaustiveAny;
     }
@@ -699,7 +699,7 @@ fn collect_ctors<'a>(matrix: &'a RefPatternMatrix) -> CollectedCtors {
             }
         }
     } else {
-        return CollectedCtors::NonExhaustiveAny;
+        CollectedCtors::NonExhaustiveAny
     }
 }
 
@@ -871,9 +871,7 @@ fn build_list_ctors_covering_patterns(
     }
 }
 
-fn filter_matrix_list_ctors<'a>(
-    matrix: &'a RefPatternMatrix,
-) -> impl Iterator<Item = ListArity> + 'a {
+fn filter_matrix_list_ctors(matrix: &RefPatternMatrix) -> impl Iterator<Item = ListArity> + '_ {
     matrix.iter().filter_map(|ctor| match ctor.last() {
         Some(List(ar, _)) => Some(*ar),
         _ => None,

--- a/crates/compiler/solve/src/solve.rs
+++ b/crates/compiler/solve/src/solve.rs
@@ -1896,6 +1896,11 @@ fn open_tag_union(subs: &mut Subs, var: Variable) {
                 stack.extend(subs.get_subs_slice(fields.variables()));
             }
 
+            Structure(Apply(Symbol::LIST_LIST, args)) => {
+                // Open up nested tag unions.
+                stack.extend(subs.get_subs_slice(args));
+            }
+
             _ => {
                 // Everything else is not a structural type that can be opened
                 // (i.e. cannot be matched in a pattern-match)
@@ -1956,8 +1961,13 @@ fn close_pattern_matched_tag_unions(subs: &mut Subs, var: Variable) {
             }
 
             Structure(Record(fields, _)) => {
-                // Open up all nested tag unions.
+                // Close up all nested tag unions.
                 stack.extend(subs.get_subs_slice(fields.variables()));
+            }
+
+            Structure(Apply(Symbol::LIST_LIST, args)) => {
+                // Close up nested tag unions.
+                stack.extend(subs.get_subs_slice(args));
             }
 
             Alias(_, _, real_var, _) => {

--- a/crates/compiler/unify/src/unify.rs
+++ b/crates/compiler/unify/src/unify.rs
@@ -2788,7 +2788,7 @@ fn unify_flat_type<M: MetaCollector>(
         }
 
         (Apply(l_symbol, l_args), Apply(r_symbol, r_args)) if l_symbol == r_symbol => {
-            let mut outcome = unify_zip_slices(env, pool, *l_args, *r_args);
+            let mut outcome = unify_zip_slices(env, pool, *l_args, *r_args, ctx.mode);
 
             if outcome.mismatches.is_empty() {
                 outcome.union(merge(env, ctx, Structure(Apply(*r_symbol, *r_args))));
@@ -2799,7 +2799,7 @@ fn unify_flat_type<M: MetaCollector>(
         (Func(l_args, l_closure, l_ret), Func(r_args, r_closure, r_ret))
             if l_args.len() == r_args.len() =>
         {
-            let arg_outcome = unify_zip_slices(env, pool, *l_args, *r_args);
+            let arg_outcome = unify_zip_slices(env, pool, *l_args, *r_args, ctx.mode);
             let ret_outcome = unify_pool(env, pool, *l_ret, *r_ret, ctx.mode);
             let closure_outcome = unify_pool(env, pool, *l_closure, *r_closure, ctx.mode);
 
@@ -2926,6 +2926,7 @@ fn unify_zip_slices<M: MetaCollector>(
     pool: &mut Pool,
     left: SubsSlice<Variable>,
     right: SubsSlice<Variable>,
+    mode: Mode,
 ) -> Outcome<M> {
     let mut outcome = Outcome::default();
 
@@ -2935,7 +2936,7 @@ fn unify_zip_slices<M: MetaCollector>(
         let l_var = env.subs[l_index];
         let r_var = env.subs[r_index];
 
-        outcome.union(unify_pool(env, pool, l_var, r_var, Mode::EQ));
+        outcome.union(unify_pool(env, pool, l_var, r_var, mode));
     }
 
     outcome

--- a/crates/reporting/src/error/type.rs
+++ b/crates/reporting/src/error/type.rs
@@ -4388,23 +4388,25 @@ fn pattern_to_doc_help<'b>(
                         .map(|p| pattern_to_doc_help(alloc, p, false)),
                     alloc.text(",").append(alloc.space()),
                 ),
-                ListArity::Slice(before, _) => {
+                ListArity::Slice(num_before, num_after) => {
                     let mut all_patterns = patterns
                         .into_iter()
                         .map(|p| pattern_to_doc_help(alloc, p, in_type_param));
 
-                    let before = all_patterns.by_ref().take(before);
-                    let prefix = alloc.intersperse(before, alloc.text(",").append(alloc.space()));
-
                     let spread = alloc.text("..");
+                    let comma_space = alloc.text(",").append(alloc.space());
 
-                    let after = all_patterns;
-                    let suffix = alloc.intersperse(after, alloc.text(",").append(alloc.space()));
+                    let mut list = alloc.intersperse(
+                        all_patterns.by_ref().take(num_before).chain([spread]),
+                        comma_space.clone(),
+                    );
 
-                    alloc.intersperse(
-                        [prefix, spread, suffix],
-                        alloc.text(",").append(alloc.space()),
-                    )
+                    if num_after > 0 {
+                        let after = all_patterns;
+                        list = alloc.intersperse([list].into_iter().chain(after), comma_space);
+                    }
+
+                    list
                 }
             };
             alloc.concat([alloc.text("["), inner, alloc.text("]")])

--- a/crates/reporting/src/error/type.rs
+++ b/crates/reporting/src/error/type.rs
@@ -1945,7 +1945,34 @@ fn to_pattern_report<'b>(
                     severity: Severity::RuntimeError,
                 }
             }
-            PReason::TagArg { .. } | PReason::PatternGuard | PReason::ListElem => {
+            PReason::ListElem => {
+                let doc = alloc.stack([
+                    alloc.concat([alloc.reflow("This list element doesn't match the types of other elements in the pattern:")]),
+                    alloc.region(lines.convert_region(region)),
+                    pattern_type_comparison(
+                        alloc,
+                        found,
+                        expected_type,
+                        add_pattern_category(
+                            alloc,
+                            alloc.text("It matches"),
+                            &category,
+                        ),
+                        alloc.concat([
+                            alloc.text("But the other elements in this list pattern match")
+                        ]),
+                        vec![],
+                    ),
+                ]);
+
+                Report {
+                    filename,
+                    title: "TYPE MISMATCH".to_string(),
+                    doc,
+                    severity: Severity::RuntimeError,
+                }
+            }
+            PReason::TagArg { .. } | PReason::PatternGuard => {
                 internal_error!("We didn't think this could trigger. Please tell us about it on Zulip if it does!")
             }
         },

--- a/crates/reporting/tests/test_reporting.rs
+++ b/crates/reporting/tests/test_reporting.rs
@@ -11831,6 +11831,21 @@ All branches in an `if` must have the same type!
             "#
         ),
     @r###"
+    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+
+    This list element doesn't match the types of other elements in the
+    pattern:
+
+    5│          [A, 1u8] -> ""
+                    ^^^
+
+    It matches integers:
+
+        U8
+
+    But the other elements in this list pattern match
+
+        [A]
     "###
     );
 
@@ -11843,6 +11858,22 @@ All branches in an `if` must have the same type!
             "#
         ),
     @r###"
+    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+
+    The branches of this `when` expression don't match the condition:
+
+    4│>      when [A, B] is
+    5│           ["foo", "bar"] -> ""
+
+    The `when` condition is a list of type:
+
+        List [A, B]
+
+    But the branch patterns have type:
+
+        List Str
+
+    The branches must be cases of the `when` condition's type!
     "###
     );
 }

--- a/crates/reporting/tests/test_reporting.rs
+++ b/crates/reporting/tests/test_reporting.rs
@@ -12108,6 +12108,88 @@ All branches in an `if` must have the same type!
     "###
     );
 
+    test_no_problem!(
+        list_match_exhaustive_empty_and_rest_with_exhausted_head_and_tail,
+        indoc!(
+            r#"
+            l : List [A, B]
+
+            when l is
+                [] -> ""
+                [A] -> ""
+                [B] -> ""
+                [A, .., A] -> ""
+                [A, .., B] -> ""
+                [B, .., A] -> ""
+                [B, .., B] -> ""
+            "#
+        )
+    );
+
+    test_report!(
+        list_match_exhaustive_empty_and_rest_with_nonexhaustive_head_and_tail,
+        indoc!(
+            r#"
+            l : List [A, B]
+
+            when l is
+                [] -> ""
+                [_] -> ""
+                [A, .., B] -> ""
+                [B, .., A] -> ""
+            "#
+        ),
+    @r###"
+    ── UNSAFE PATTERN ──────────────────────────────────────── /code/proj/Main.roc ─
+
+    This `when` does not cover all the possibilities:
+
+     6│>      when l is
+     7│>          [] -> ""
+     8│>          [_] -> ""
+     9│>          [A, .., B] -> ""
+    10│>          [B, .., A] -> ""
+
+    Other possibilities include:
+
+        [_, .., _]
+
+    I would have to crash if I saw one of those! Add branches for them!
+    "###
+    );
+
+    test_report!(
+        list_match_no_small_sizes_and_non_exhaustive_head_and_tail,
+        indoc!(
+            r#"
+            l : List [A, B]
+
+            when l is
+                [A, .., B] -> ""
+                [B, .., A] -> ""
+                [B, .., B] -> ""
+            "#
+        ),
+    @r###"
+    ── UNSAFE PATTERN ──────────────────────────────────────── /code/proj/Main.roc ─
+
+    This `when` does not cover all the possibilities:
+
+    6│>      when l is
+    7│>          [A, .., B] -> ""
+    8│>          [B, .., A] -> ""
+    9│>          [B, .., B] -> ""
+
+    Other possibilities include:
+
+        []
+        [_]
+        [A, .., A]
+
+    I would have to crash if I saw one of those! Add branches for them!
+    "###
+    );
+
     test_report!(
         list_match_exhaustive_big_sizes_but_not_small_sizes,
         indoc!(

--- a/crates/reporting/tests/test_reporting.rs
+++ b/crates/reporting/tests/test_reporting.rs
@@ -12190,4 +12190,116 @@ All branches in an `if` must have the same type!
     I would have to crash if I saw one of those! Add branches for them!
     "###
     );
+
+    test_report!(
+        list_match_redundant_exact_size,
+        indoc!(
+            r#"
+            l : List [A]
+
+            when l is
+                [] -> ""
+                [_] -> ""
+                [_] -> ""
+                [..] -> ""
+            "#
+        ),
+    @r###"
+    ── REDUNDANT PATTERN ───────────────────────────────────── /code/proj/Main.roc ─
+
+    The 3rd pattern is redundant:
+
+     6│       when l is
+     7│           [] -> ""
+     8│           [_] -> ""
+     9│>          [_] -> ""
+    10│           [..] -> ""
+
+    Any value of this shape will be handled by a previous pattern, so this
+    one should be removed.
+    "###
+    );
+
+    test_report!(
+        list_match_redundant_any_slice,
+        indoc!(
+            r#"
+            l : List [A]
+
+            when l is
+                [] -> ""
+                [_, ..] -> ""
+                [..] -> ""
+            "#
+        ),
+    @r###"
+    ── REDUNDANT PATTERN ───────────────────────────────────── /code/proj/Main.roc ─
+
+    The 3rd pattern is redundant:
+
+    6│      when l is
+    7│          [] -> ""
+    8│          [_, ..] -> ""
+    9│          [..] -> ""
+                ^^^^
+
+    Any value of this shape will be handled by a previous pattern, so this
+    one should be removed.
+    "###
+    );
+
+    test_report!(
+        list_match_redundant_suffix_slice_with_sized_prefix,
+        indoc!(
+            r#"
+            l : List [A]
+
+            when l is
+                [] -> ""
+                [_, ..] -> ""
+                [.., _] -> ""
+            "#
+        ),
+    @r###"
+    ── REDUNDANT PATTERN ───────────────────────────────────── /code/proj/Main.roc ─
+
+    The 3rd pattern is redundant:
+
+    6│      when l is
+    7│          [] -> ""
+    8│          [_, ..] -> ""
+    9│          [.., _] -> ""
+                ^^^^^^^
+
+    Any value of this shape will be handled by a previous pattern, so this
+    one should be removed.
+    "###
+    );
+
+    test_report!(
+        list_match_redundant_based_on_ctors,
+        indoc!(
+            r#"
+            l : List {}
+
+            when l is
+                [{}, .., _] -> ""
+                [_, .., {}] -> ""
+                [..] -> ""
+            "#
+        ),
+    @r###"
+    ── REDUNDANT PATTERN ───────────────────────────────────── /code/proj/Main.roc ─
+
+    The 2nd pattern is redundant:
+
+    6│       when l is
+    7│           [{}, .., _] -> ""
+    8│>          [_, .., {}] -> ""
+    9│           [..] -> ""
+
+    Any value of this shape will be handled by a previous pattern, so this
+    one should be removed.
+    "###
+    );
 }

--- a/crates/reporting/tests/test_reporting.rs
+++ b/crates/reporting/tests/test_reporting.rs
@@ -11823,7 +11823,6 @@ All branches in an `if` must have the same type!
     );
 
     test_report!(
-        #[ignore = "must implement exhaustiveness sketching for lists first"]
         mismatch_within_list_pattern,
         indoc!(
             r#"
@@ -11836,7 +11835,6 @@ All branches in an `if` must have the same type!
     );
 
     test_report!(
-        #[ignore = "must implement exhaustiveness sketching for lists first"]
         mismatch_list_pattern_vs_condition,
         indoc!(
             r#"


### PR DESCRIPTION
Title says it all.

I've enumerated the algorithm I've used in the doc comments of `build_list_ctors_covering_patterns` in `exhaustive/src/lib.rs`. Please refer to that for documentation and an explanation of what this PR does.

Here are a few interesting uses and error messages:

```
» l : List [A, B]
…
… when l is
…     [] -> ""
…     [.., A] -> ""

── UNSAFE PATTERN ──────────────────────────────────────────────────────────────

This when does not cover all the possibilities:

6│>      when l is
7│>          [] -> ""
8│>          [.., A] -> ""

Other possibilities include:

    [.., B]

I would have to crash if I saw one of those! Add branches for them!
```

```
» l : List {}
…
… when l is
…     [{}, .., _] -> ""
…     [_, .., {}] -> ""
…     [..] -> ""

── REDUNDANT PATTERN ───────────────────────────────────────────────────────────

The 2nd pattern is redundant:

6│       when l is
7│           [{}, .., _] -> ""
8│>          [_, .., {}] -> ""
9│           [..] -> ""

Any value of this shape will be handled by a previous pattern, so this
one should be removed.
```