### PR TITLE
Decision tree compilation of list pattern matches

### DIFF
--- a/crates/compiler/can/src/exhaustive.rs
+++ b/crates/compiler/can/src/exhaustive.rs
@@ -1,5 +1,5 @@
 use crate::expr::{self, IntValue, WhenBranch};
-use crate::pattern::{DestructType, ListPatterns};
+use crate::pattern::DestructType;
 use roc_collections::all::HumanIndex;
 use roc_collections::VecMap;
 use roc_error_macros::internal_error;
@@ -344,23 +344,19 @@ fn sketch_pattern(pattern: &crate::pattern::Pattern) -> SketchedPattern {
         }
 
         List {
-            patterns: ListPatterns { patterns, opt_rest },
+            patterns,
             list_var: _,
             elem_var: _,
         } => {
-            let list_arity = match opt_rest {
-                Some(i) => {
-                    let before = *i;
-                    let after = patterns.len() - before;
-                    ListArity::Slice(before, after)
-                }
-                None => ListArity::Exact(patterns.len()),
-            };
+            let arity = patterns.arity();
 
-            let sketched_elem_patterns =
-                patterns.iter().map(|p| sketch_pattern(&p.value)).collect();
+            let sketched_elem_patterns = patterns
+                .patterns
+                .iter()
+                .map(|p| sketch_pattern(&p.value))
+                .collect();
 
-            SP::List(list_arity, sketched_elem_patterns)
+            SP::List(arity, sketched_elem_patterns)
         }
 
         AppliedTag {

--- a/crates/compiler/can/src/pattern.rs
+++ b/crates/compiler/can/src/pattern.rs
@@ -6,6 +6,7 @@ use crate::num::{
     ParsedNumResult,
 };
 use crate::scope::{PendingAbilitiesInScope, Scope};
+use roc_exhaustive::ListArity;
 use roc_module::ident::{Ident, Lowercase, TagName};
 use roc_module::symbol::Symbol;
 use roc_parse::ast::{self, StrLiteral, StrSegment};
@@ -188,6 +189,17 @@ impl ListPatterns {
     /// Is this list pattern the trivially-exhaustive pattern `[..]`?
     fn surely_exhaustive(&self) -> bool {
         self.patterns.is_empty() && matches!(self.opt_rest, Some(0))
+    }
+
+    pub fn arity(&self) -> ListArity {
+        match self.opt_rest {
+            Some(i) => {
+                let before = i;
+                let after = self.patterns.len() - before;
+                ListArity::Slice(before, after)
+            }
+            None => ListArity::Exact(self.patterns.len()),
+        }
     }
 }
 

--- a/crates/compiler/exhaustive/src/lib.rs
+++ b/crates/compiler/exhaustive/src/lib.rs
@@ -93,7 +93,7 @@ impl ListArity {
     /// The trivially-exhaustive list pattern `[..]`
     const ANY: ListArity = ListArity::Slice(0, 0);
 
-    fn min_len(&self) -> usize {
+    pub fn min_len(&self) -> usize {
         match self {
             ListArity::Exact(n) => *n,
             ListArity::Slice(l, r) => l + r,

--- a/crates/compiler/exhaustive/src/lib.rs
+++ b/crates/compiler/exhaustive/src/lib.rs
@@ -102,22 +102,19 @@ impl ListArity {
 
     /// Could this list pattern include list pattern arity `other`?
     fn covers_arities_of(&self, other: &Self) -> bool {
-        match (self, other) {
-            (ListArity::Exact(l), ListArity::Exact(r)) => l == r,
-            (ListArity::Exact(this_exact), ListArity::Slice(other_left, other_right)) => {
-                // [_, _, _] can only cover [_, _, .., _]
-                *this_exact == (other_left + other_right)
+        self.covers_length(other.min_len())
+    }
+
+    pub fn covers_length(&self, length: usize) -> bool {
+        match self {
+            ListArity::Exact(l) => {
+                // [_, _, _] can only cover [_, _, _]
+                *l == length
             }
-            (ListArity::Slice(this_left, this_right), ListArity::Exact(other_exact)) => {
-                // [_, _, .., _] can cover [_, _, _], [_, _, _, _], [_, _, _, _, _], and so on
-                (this_left + this_right) <= *other_exact
-            }
-            (
-                ListArity::Slice(this_left, this_right),
-                ListArity::Slice(other_left, other_right),
-            ) => {
-                // [_, _, .., _] can cover [_, _, .., _], [_, .., _, _], [_, _, .., _, _], [_, _, _, .., _, _], and so on
-                (this_left + this_right) <= (other_left + other_right)
+            ListArity::Slice(head, tail) => {
+                // [_, _, .., _] can cover infinite arities >=3 , including
+                // [_, _, .., _], [_, .., _, _], [_, _, .., _, _], [_, _, _, .., _, _], and so on
+                head + tail <= length
             }
         }
     }

--- a/crates/compiler/mono/src/decision_tree.rs
+++ b/crates/compiler/mono/src/decision_tree.rs
@@ -796,18 +796,7 @@ fn to_relevant_branch_help<'a>(
             elements,
             element_layout: _,
         } => match test {
-            IsListLen { bound, len }
-                if (match (bound, my_arity) {
-                    (ListLenBound::Exact, ListArity::Exact(my_len)) => my_len == *len as _,
-                    (ListLenBound::Exact, ListArity::Slice(my_head, my_tail)) => {
-                        my_head + my_tail <= *len as _
-                    }
-                    (ListLenBound::AtLeast, ListArity::Exact(my_len)) => my_len == *len as _,
-                    (ListLenBound::AtLeast, ListArity::Slice(my_head, my_tail)) => {
-                        my_head + my_tail <= *len as _
-                    }
-                }) =>
-            {
+            IsListLen { bound: _, len } if my_arity.covers_length(*len as _) => {
                 let sub_positions = elements.into_iter().enumerate().map(|(index, elem_pat)| {
                     let mut new_path = path.to_vec();
 

--- a/crates/compiler/mono/src/decision_tree.rs
+++ b/crates/compiler/mono/src/decision_tree.rs
@@ -1454,6 +1454,7 @@ fn path_to_expr_help<'a>(
                         stores.push((load_sym, *elem_layout, load_expr));
 
                         layout = *elem_layout;
+                        symbol = load_sym;
                     }
                     _ => internal_error!("not a list"),
                 }

--- a/crates/compiler/mono/src/decision_tree.rs
+++ b/crates/compiler/mono/src/decision_tree.rs
@@ -1617,6 +1617,7 @@ fn stores_and_condition<'a>(
     tests
 }
 
+#[allow(clippy::too_many_arguments)]
 fn compile_test<'a>(
     env: &mut Env<'a, '_>,
     ret_layout: Layout<'a>,

--- a/crates/compiler/test_gen/src/gen_list.rs
+++ b/crates/compiler/test_gen/src/gen_list.rs
@@ -3653,27 +3653,60 @@ mod pattern_match {
     }
 
     #[test]
+    fn ranged_matches_tail() {
+        assert_evals_to!(
+            r#"
+            helper = \l -> when l is
+                [] -> 1u8
+                [A] -> 2u8
+                [.., A, A] -> 3u8
+                [.., B, A] -> 4u8
+                [.., B] -> 5u8
+
+            [
+                helper [],
+                helper [A],
+                helper [A, A], helper [A, A, A], helper [B, A, A], helper [A, B, A, A],
+                helper [B, A], helper [A, B, A], helper [B, B, A], helper [B, A, B, A],
+                helper [B], helper [A, B], helper [B, B], helper [B, A, B, B],
+            ]
+            "#,
+            RocList::from_slice(&[
+                1, //
+                2, //
+                3, 3, 3, 3, //
+                4, 4, 4, 4, //
+                5, 5, 5, 5, //
+            ]),
+            RocList<u8>
+        )
+    }
+
+    #[test]
     fn bind_variables() {
         assert_evals_to!(
             r#"
-            helper : List U8 -> U8
+            helper : List U16 -> U16
             helper = \l -> when l is
-                [] -> 1u8
+                [] -> 1
                 [x] -> x
+                [.., w, x, y, z] -> w * x * y * z
                 [x, y, ..] -> x * y
 
             [
                 helper [],
                 helper [5],
-                helper [3, 5], helper [3, 5, 7], helper [3, 5, 7, 11],
+                helper [3, 5], helper [3, 5, 7],
+                helper [2, 3, 5, 7], helper [11, 2, 3, 5, 7], helper [13, 11, 2, 3, 5, 7],
             ]
             "#,
             RocList::from_slice(&[
                 1, //
                 5, //
-                15, 15, 15 //
+                15, 15, //
+                210, 210, 210, //
             ]),
-            RocList<u8>
+            RocList<u16>
         )
     }
 }

--- a/crates/compiler/test_mono/generated/match_list.txt
+++ b/crates/compiler/test_mono/generated/match_list.txt
@@ -1,67 +1,46 @@
 procedure Test.0 ():
-    let Test.42 : Int1 = false;
-    let Test.43 : Int1 = true;
-    let Test.1 : List Int1 = Array [Test.42, Test.43];
-    joinpoint Test.16:
+    let Test.29 : Int1 = false;
+    let Test.30 : Int1 = true;
+    let Test.1 : List Int1 = Array [Test.29, Test.30];
+    joinpoint Test.19:
         let Test.8 : Str = "E";
         ret Test.8;
     in
-    joinpoint Test.10:
+    joinpoint Test.17:
+        let Test.7 : Str = "D";
+        ret Test.7;
+    in
+    joinpoint Test.14:
+        let Test.6 : Str = "C";
+        ret Test.6;
+    in
+    joinpoint Test.11:
         let Test.5 : Str = "B";
         ret Test.5;
     in
-    let Test.39 : U64 = lowlevel ListLen Test.1;
-    let Test.40 : U64 = 0i64;
-    let Test.41 : Int1 = lowlevel Eq Test.39 Test.40;
-    if Test.41 then
-        dec Test.1;
+    joinpoint Test.9:
         let Test.4 : Str = "A";
         ret Test.4;
+    in
+    let Test.26 : U64 = lowlevel ListLen Test.1;
+    let Test.27 : U64 = 0i64;
+    let Test.28 : Int1 = lowlevel Eq Test.26 Test.27;
+    if Test.28 then
+        dec Test.1;
+        jump Test.9;
     else
-        let Test.36 : U64 = lowlevel ListLen Test.1;
-        let Test.37 : U64 = 1i64;
-        let Test.38 : Int1 = lowlevel Eq Test.36 Test.37;
-        if Test.38 then
-            let Test.17 : U64 = 0i64;
-            let Test.18 : Int1 = lowlevel ListGetUnsafe Test.1 Test.17;
+        let Test.23 : U64 = lowlevel ListLen Test.1;
+        let Test.24 : U64 = 1i64;
+        let Test.25 : Int1 = lowlevel Eq Test.23 Test.24;
+        if Test.25 then
             dec Test.1;
-            let Test.19 : Int1 = false;
-            let Test.20 : Int1 = lowlevel Eq Test.19 Test.18;
-            if Test.20 then
-                jump Test.10;
-            else
-                jump Test.16;
+            jump Test.9;
         else
-            let Test.33 : U64 = lowlevel ListLen Test.1;
-            let Test.34 : U64 = 2i64;
-            let Test.35 : Int1 = lowlevel NumGte Test.33 Test.34;
-            if Test.35 then
-                let Test.25 : U64 = 0i64;
-                let Test.26 : Int1 = lowlevel ListGetUnsafe Test.1 Test.25;
-                let Test.27 : Int1 = false;
-                let Test.28 : Int1 = lowlevel Eq Test.27 Test.26;
-                if Test.28 then
-                    let Test.21 : U64 = 1i64;
-                    let Test.22 : Int1 = lowlevel ListGetUnsafe Test.1 Test.21;
-                    dec Test.1;
-                    let Test.23 : Int1 = false;
-                    let Test.24 : Int1 = lowlevel Eq Test.23 Test.22;
-                    if Test.24 then
-                        let Test.6 : Str = "C";
-                        ret Test.6;
-                    else
-                        let Test.7 : Str = "D";
-                        ret Test.7;
-                else
-                    dec Test.1;
-                    jump Test.16;
+            let Test.20 : U64 = lowlevel ListLen Test.1;
+            dec Test.1;
+            let Test.21 : U64 = 2i64;
+            let Test.22 : Int1 = lowlevel NumGte Test.20 Test.21;
+            if Test.22 then
+                jump Test.9;
             else
-                let Test.29 : U64 = 0i64;
-                let Test.30 : Int1 = lowlevel ListGetUnsafe Test.1 Test.29;
-                dec Test.1;
-                let Test.31 : Int1 = false;
-                let Test.32 : Int1 = lowlevel Eq Test.31 Test.30;
-                if Test.32 then
-                    jump Test.10;
-                else
-                    jump Test.16;
+                jump Test.9;

--- a/crates/compiler/test_mono/generated/match_list.txt
+++ b/crates/compiler/test_mono/generated/match_list.txt
@@ -1,0 +1,67 @@
+procedure Test.0 ():
+    let Test.42 : Int1 = false;
+    let Test.43 : Int1 = true;
+    let Test.1 : List Int1 = Array [Test.42, Test.43];
+    joinpoint Test.16:
+        let Test.8 : Str = "E";
+        ret Test.8;
+    in
+    joinpoint Test.10:
+        let Test.5 : Str = "B";
+        ret Test.5;
+    in
+    let Test.39 : U64 = lowlevel ListLen Test.1;
+    let Test.40 : U64 = 0i64;
+    let Test.41 : Int1 = lowlevel Eq Test.39 Test.40;
+    if Test.41 then
+        dec Test.1;
+        let Test.4 : Str = "A";
+        ret Test.4;
+    else
+        let Test.36 : U64 = lowlevel ListLen Test.1;
+        let Test.37 : U64 = 1i64;
+        let Test.38 : Int1 = lowlevel Eq Test.36 Test.37;
+        if Test.38 then
+            let Test.17 : U64 = 0i64;
+            let Test.18 : Int1 = lowlevel ListGetUnsafe Test.1 Test.17;
+            let Test.19 : Int1 = false;
+            let Test.20 : Int1 = lowlevel Eq Test.19 Test.1;
+            dec Test.1;
+            if Test.20 then
+                jump Test.10;
+            else
+                jump Test.16;
+        else
+            let Test.33 : U64 = lowlevel ListLen Test.1;
+            let Test.34 : U64 = 2i64;
+            let Test.35 : Int1 = lowlevel NumGte Test.33 Test.34;
+            if Test.35 then
+                let Test.25 : U64 = 0i64;
+                let Test.26 : Int1 = lowlevel ListGetUnsafe Test.1 Test.25;
+                let Test.27 : Int1 = false;
+                let Test.28 : Int1 = lowlevel Eq Test.27 Test.1;
+                if Test.28 then
+                    let Test.21 : U64 = 1i64;
+                    let Test.22 : Int1 = lowlevel ListGetUnsafe Test.1 Test.21;
+                    let Test.23 : Int1 = false;
+                    let Test.24 : Int1 = lowlevel Eq Test.23 Test.1;
+                    dec Test.1;
+                    if Test.24 then
+                        let Test.6 : Str = "C";
+                        ret Test.6;
+                    else
+                        let Test.7 : Str = "D";
+                        ret Test.7;
+                else
+                    dec Test.1;
+                    jump Test.16;
+            else
+                let Test.29 : U64 = 0i64;
+                let Test.30 : Int1 = lowlevel ListGetUnsafe Test.1 Test.29;
+                let Test.31 : Int1 = false;
+                let Test.32 : Int1 = lowlevel Eq Test.31 Test.1;
+                dec Test.1;
+                if Test.32 then
+                    jump Test.10;
+                else
+                    jump Test.16;

--- a/crates/compiler/test_mono/generated/match_list.txt
+++ b/crates/compiler/test_mono/generated/match_list.txt
@@ -1,46 +1,67 @@
 procedure Test.0 ():
-    let Test.29 : Int1 = false;
-    let Test.30 : Int1 = true;
-    let Test.1 : List Int1 = Array [Test.29, Test.30];
-    joinpoint Test.19:
+    let Test.36 : Int1 = false;
+    let Test.37 : Int1 = true;
+    let Test.1 : List Int1 = Array [Test.36, Test.37];
+    joinpoint Test.10:
         let Test.8 : Str = "E";
         ret Test.8;
     in
-    joinpoint Test.17:
-        let Test.7 : Str = "D";
-        ret Test.7;
-    in
-    joinpoint Test.14:
-        let Test.6 : Str = "C";
-        ret Test.6;
-    in
-    joinpoint Test.11:
+    joinpoint Test.9:
         let Test.5 : Str = "B";
         ret Test.5;
     in
-    joinpoint Test.9:
+    let Test.33 : U64 = lowlevel ListLen Test.1;
+    let Test.34 : U64 = 0i64;
+    let Test.35 : Int1 = lowlevel Eq Test.33 Test.34;
+    if Test.35 then
+        dec Test.1;
         let Test.4 : Str = "A";
         ret Test.4;
-    in
-    let Test.26 : U64 = lowlevel ListLen Test.1;
-    let Test.27 : U64 = 0i64;
-    let Test.28 : Int1 = lowlevel Eq Test.26 Test.27;
-    if Test.28 then
-        dec Test.1;
-        jump Test.9;
     else
-        let Test.23 : U64 = lowlevel ListLen Test.1;
-        let Test.24 : U64 = 1i64;
-        let Test.25 : Int1 = lowlevel Eq Test.23 Test.24;
-        if Test.25 then
+        let Test.30 : U64 = lowlevel ListLen Test.1;
+        let Test.31 : U64 = 1i64;
+        let Test.32 : Int1 = lowlevel Eq Test.30 Test.31;
+        if Test.32 then
+            let Test.11 : U64 = 0i64;
+            let Test.12 : Int1 = lowlevel ListGetUnsafe Test.1 Test.11;
             dec Test.1;
-            jump Test.9;
-        else
-            let Test.20 : U64 = lowlevel ListLen Test.1;
-            dec Test.1;
-            let Test.21 : U64 = 2i64;
-            let Test.22 : Int1 = lowlevel NumGte Test.20 Test.21;
-            if Test.22 then
+            let Test.13 : Int1 = false;
+            let Test.14 : Int1 = lowlevel Eq Test.13 Test.12;
+            if Test.14 then
                 jump Test.9;
             else
-                jump Test.9;
+                jump Test.10;
+        else
+            let Test.27 : U64 = lowlevel ListLen Test.1;
+            let Test.28 : U64 = 2i64;
+            let Test.29 : Int1 = lowlevel NumGte Test.27 Test.28;
+            if Test.29 then
+                let Test.19 : U64 = 0i64;
+                let Test.20 : Int1 = lowlevel ListGetUnsafe Test.1 Test.19;
+                let Test.21 : Int1 = false;
+                let Test.22 : Int1 = lowlevel Eq Test.21 Test.20;
+                if Test.22 then
+                    let Test.15 : U64 = 1i64;
+                    let Test.16 : Int1 = lowlevel ListGetUnsafe Test.1 Test.15;
+                    dec Test.1;
+                    let Test.17 : Int1 = false;
+                    let Test.18 : Int1 = lowlevel Eq Test.17 Test.16;
+                    if Test.18 then
+                        let Test.6 : Str = "C";
+                        ret Test.6;
+                    else
+                        let Test.7 : Str = "D";
+                        ret Test.7;
+                else
+                    dec Test.1;
+                    jump Test.10;
+            else
+                let Test.23 : U64 = 0i64;
+                let Test.24 : Int1 = lowlevel ListGetUnsafe Test.1 Test.23;
+                dec Test.1;
+                let Test.25 : Int1 = false;
+                let Test.26 : Int1 = lowlevel Eq Test.25 Test.24;
+                if Test.26 then
+                    jump Test.9;
+                else
+                    jump Test.10;

--- a/crates/compiler/test_mono/generated/match_list.txt
+++ b/crates/compiler/test_mono/generated/match_list.txt
@@ -24,9 +24,9 @@ procedure Test.0 ():
         if Test.38 then
             let Test.17 : U64 = 0i64;
             let Test.18 : Int1 = lowlevel ListGetUnsafe Test.1 Test.17;
-            let Test.19 : Int1 = false;
-            let Test.20 : Int1 = lowlevel Eq Test.19 Test.1;
             dec Test.1;
+            let Test.19 : Int1 = false;
+            let Test.20 : Int1 = lowlevel Eq Test.19 Test.18;
             if Test.20 then
                 jump Test.10;
             else
@@ -39,13 +39,13 @@ procedure Test.0 ():
                 let Test.25 : U64 = 0i64;
                 let Test.26 : Int1 = lowlevel ListGetUnsafe Test.1 Test.25;
                 let Test.27 : Int1 = false;
-                let Test.28 : Int1 = lowlevel Eq Test.27 Test.1;
+                let Test.28 : Int1 = lowlevel Eq Test.27 Test.26;
                 if Test.28 then
                     let Test.21 : U64 = 1i64;
                     let Test.22 : Int1 = lowlevel ListGetUnsafe Test.1 Test.21;
-                    let Test.23 : Int1 = false;
-                    let Test.24 : Int1 = lowlevel Eq Test.23 Test.1;
                     dec Test.1;
+                    let Test.23 : Int1 = false;
+                    let Test.24 : Int1 = lowlevel Eq Test.23 Test.22;
                     if Test.24 then
                         let Test.6 : Str = "C";
                         ret Test.6;
@@ -58,9 +58,9 @@ procedure Test.0 ():
             else
                 let Test.29 : U64 = 0i64;
                 let Test.30 : Int1 = lowlevel ListGetUnsafe Test.1 Test.29;
-                let Test.31 : Int1 = false;
-                let Test.32 : Int1 = lowlevel Eq Test.31 Test.1;
                 dec Test.1;
+                let Test.31 : Int1 = false;
+                let Test.32 : Int1 = lowlevel Eq Test.31 Test.30;
                 if Test.32 then
                     jump Test.10;
                 else

--- a/crates/compiler/test_mono/src/tests.rs
+++ b/crates/compiler/test_mono/src/tests.rs
@@ -2000,3 +2000,19 @@ fn unreachable_branch_is_eliminated_but_produces_lambda_specializations() {
         "#
     )
 }
+
+#[mono_test]
+fn match_list() {
+    indoc!(
+        r#"
+        l = [A, B]
+
+        when l is
+            [] -> "A"
+            [A] -> "B"
+            [A, A, ..] -> "C"
+            [A, B, ..] -> "D"
+            [B, ..] -> "E"
+        "#
+    )
+}


### PR DESCRIPTION
Supports code generation of list pattern matches via decision trees.

Decision tree branches are guarded as follows:

- For exact-size list patterns, we match against the exact length of the list under question
- For slice patterns, we check whether the length of the list under question >= the minimum arity of the slice pattern

Indexing into a list just calls `List.getUnsafe` for the relevant elements we want to index, since after the guard succeeds, we know the list length is bounded.

Closes #4171