### PR TITLE
Simplify constructor recovery

### DIFF
--- a/crates/reporting/tests/test_reporting.rs
+++ b/crates/reporting/tests/test_reporting.rs
@@ -12266,8 +12266,7 @@ All branches in an `if` must have the same type!
 
         [[B, ..]]
         [_, .., []]
-        [[], .., [.., A]]
-        [[_, ..], .., [.., A]]
+        [_, .., [.., A]]
 
     I would have to crash if I saw one of those! Add branches for them!
     "###
@@ -12383,5 +12382,19 @@ All branches in an `if` must have the same type!
     Any value of this shape will be handled by a previous pattern, so this
     one should be removed.
     "###
+    );
+
+    test_no_problem!(
+        list_match_with_guard,
+        indoc!(
+            r#"
+            l : List [A]
+
+            when l is
+                [ A, .. ] if Bool.true -> ""
+                [ A, .. ] -> ""
+                _ -> ""
+            "#
+        )
     );
 }


### PR DESCRIPTION
This fixes a bug in the list pattern matching code that caused crashes
in the presence of list guards, and simplifies the pattern splitting
algorithm to avoid complexity and allocations. Previously we would place
arguments-to-be-matched of constructors and lists at the front of
specialized rows for exhaustiveness checking, but at the back for
redundancy checking. Now, we always place them at the back - this avoids
needless allocation, and is not any worse, since we can still recover
the non-exhaustive witnesses by looking at the end of a list, instead of
the front.
