### PR TITLE
Consolidate mono test behavior in debug and release modes

### DIFF
--- a/crates/compiler/module/src/symbol.rs
+++ b/crates/compiler/module/src/symbol.rs
@@ -44,7 +44,7 @@ const SYMBOL_HAS_NICHE: () =
 // register_debug_idents calls (which should be made in debug mode).
 // Set it to false if you want to see the raw ModuleId and IdentId ints,
 // but please set it back to true before checking in the result!
-#[cfg(debug_assertions)]
+#[cfg(any(debug_assertions, feature = "debug-symbols"))]
 const PRETTY_PRINT_DEBUG_SYMBOLS: bool = true;
 
 pub const DERIVABLE_ABILITIES: &[(Symbol, &[Symbol])] = &[
@@ -183,7 +183,7 @@ impl Symbol {
 ///
 /// `Foo.bar`
 impl fmt::Debug for Symbol {
-    #[cfg(debug_assertions)]
+    #[cfg(any(debug_assertions, feature = "debug-symbols"))]
     #[allow(clippy::print_in_format_impl)]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if PRETTY_PRINT_DEBUG_SYMBOLS {
@@ -216,7 +216,7 @@ impl fmt::Debug for Symbol {
         }
     }
 
-    #[cfg(not(debug_assertions))]
+    #[cfg(not(any(debug_assertions, feature = "debug-symbols")))]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fallback_debug_fmt(*self, f)
     }
@@ -256,7 +256,7 @@ fn fallback_debug_fmt(symbol: Symbol, f: &mut fmt::Formatter) -> fmt::Result {
 // end up using it in release builds anyway. Right? ...Right?
 lazy_static! {}
 
-#[cfg(debug_assertions)]
+#[cfg(any(debug_assertions, feature = "debug-symbols"))]
 lazy_static! {
     /// This is used in Debug builds only, to let us have a Debug instance
     /// which displays not only the Module ID, but also the Module Name which
@@ -399,7 +399,7 @@ impl fmt::Debug for ModuleId {
     /// needs a global mutex, so we don't do this in release builds. This means
     /// the Debug impl in release builds only shows the number, not the name (which
     /// it does not have available, due to having never stored it in the mutexed intern table.)
-    #[cfg(debug_assertions)]
+    #[cfg(any(debug_assertions, feature = "debug-symbols"))]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         // Originally, this printed both name and numeric ID, but the numeric ID
         // didn't seem to add anything useful. Feel free to temporarily re-add it
@@ -425,7 +425,7 @@ impl fmt::Debug for ModuleId {
     }
 
     /// In release builds, all we have access to is the number, so only display that.
-    #[cfg(not(debug_assertions))]
+    #[cfg(not(any(debug_assertions, feature = "debug-symbols")))]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.0.fmt(f)
     }
@@ -470,7 +470,7 @@ impl<'a> PackageModuleIds<'a> {
         // didn't find it, so we'll add it
         let module_id = ModuleId::from_zero_indexed(self.by_id.len());
         self.by_id.push(module_name.clone());
-        if cfg!(debug_assertions) {
+        if cfg!(any(debug_assertions, feature = "debug-symbols")) {
             Self::insert_debug_name(module_id, module_name);
         }
 
@@ -487,7 +487,7 @@ impl<'a> PackageModuleIds<'a> {
         ModuleIds { by_id }
     }
 
-    #[cfg(debug_assertions)]
+    #[cfg(any(debug_assertions, feature = "debug-symbols"))]
     fn insert_debug_name(module_id: ModuleId, module_name: &PQModuleName) {
         let mut names = DEBUG_MODULE_ID_NAMES.lock().expect("Failed to acquire lock for Debug interning into DEBUG_MODULE_ID_NAMES, presumably because a thread panicked.");
 
@@ -503,7 +503,7 @@ impl<'a> PackageModuleIds<'a> {
         }
     }
 
-    #[cfg(not(debug_assertions))]
+    #[cfg(not(any(debug_assertions, feature = "debug-symbols")))]
     fn insert_debug_name(_module_id: ModuleId, _module_name: &PQModuleName) {
         // By design, this is a no-op in release builds!
     }
@@ -557,14 +557,14 @@ impl ModuleIds {
         // didn't find it, so we'll add it
         let module_id = ModuleId::from_zero_indexed(self.by_id.len());
         self.by_id.push(module_name.clone());
-        if cfg!(debug_assertions) {
+        if cfg!(any(debug_assertions, feature = "debug-symbols")) {
             Self::insert_debug_name(module_id, module_name);
         }
 
         module_id
     }
 
-    #[cfg(debug_assertions)]
+    #[cfg(any(debug_assertions, feature = "debug-symbols"))]
     fn insert_debug_name(module_id: ModuleId, module_name: &ModuleName) {
         let mut names = DEBUG_MODULE_ID_NAMES.lock().expect("Failed to acquire lock for Debug interning into DEBUG_MODULE_ID_NAMES, presumably because a thread panicked.");
 
@@ -574,7 +574,7 @@ impl ModuleIds {
         }
     }
 
-    #[cfg(not(debug_assertions))]
+    #[cfg(not(any(debug_assertions, feature = "debug-symbols")))]
     fn insert_debug_name(_module_id: ModuleId, _module_name: &ModuleName) {
         // By design, this is a no-op in release builds!
     }
@@ -868,7 +868,7 @@ macro_rules! define_builtins {
                         IdentIds{ interner }
                     };
 
-                    if cfg!(debug_assertions) {
+                    if cfg!(any(debug_assertions, feature = "debug-symbols")) {
                         let name = PQModuleName::Unqualified($module_name.into());
                         PackageModuleIds::insert_debug_name(module_id, &name);
                         module_id.register_debug_idents(&ident_ids);
@@ -910,7 +910,7 @@ macro_rules! define_builtins {
                 let mut insert_both = |id: ModuleId, name_str: &'static str| {
                     let name: ModuleName = name_str.into();
 
-                    if cfg!(debug_assertions) {
+                    if cfg!(any(debug_assertions, feature = "debug-symbols")) {
                         Self::insert_debug_name(id, &name);
                     }
 
@@ -936,7 +936,7 @@ macro_rules! define_builtins {
                     let raw_name: IdentStr = name_str.into();
                     let name = PQModuleName::Unqualified(raw_name.into());
 
-                    if cfg!(debug_assertions) {
+                    if cfg!(any(debug_assertions, feature = "debug-symbols")) {
                         Self::insert_debug_name(id, &name);
                     }
 

--- a/crates/compiler/test_mono/Cargo.toml
+++ b/crates/compiler/test_mono/Cargo.toml
@@ -11,7 +11,7 @@ path = "src/tests.rs"
 
 [dev-dependencies]
 roc_collections = { path = "../collections" }
-roc_module = { path = "../module" }
+roc_module = { path = "../module", features = ["debug-symbols"] }
 roc_builtins = { path = "../builtins" }
 roc_load = { path = "../load" }
 roc_can = { path = "../can" }

--- a/crates/compiler/test_mono/generated/call_function_in_empty_list.txt
+++ b/crates/compiler/test_mono/generated/call_function_in_empty_list.txt
@@ -1,7 +1,7 @@
 procedure List.5 (#Attr.2, #Attr.3):
-    let List.380 : List {} = lowlevel ListMap { xs: `#Attr.#arg1` } #Attr.2 Test.2 #Attr.3;
+    let List.409 : List {} = lowlevel ListMap { xs: `#Attr.#arg1` } #Attr.2 Test.2 #Attr.3;
     decref #Attr.2;
-    ret List.380;
+    ret List.409;
 
 procedure Test.2 (Test.3):
     let Test.7 : {} = Struct {};

--- a/crates/compiler/test_mono/generated/call_function_in_empty_list_unbound.txt
+++ b/crates/compiler/test_mono/generated/call_function_in_empty_list_unbound.txt
@@ -1,7 +1,7 @@
 procedure List.5 (#Attr.2, #Attr.3):
-    let List.380 : List [] = lowlevel ListMap { xs: `#Attr.#arg1` } #Attr.2 Test.2 #Attr.3;
+    let List.409 : List [] = lowlevel ListMap { xs: `#Attr.#arg1` } #Attr.2 Test.2 #Attr.3;
     decref #Attr.2;
-    ret List.380;
+    ret List.409;
 
 procedure Test.2 (Test.3):
     let Test.7 : {} = Struct {};

--- a/crates/compiler/test_mono/generated/choose_i128_layout.txt
+++ b/crates/compiler/test_mono/generated/choose_i128_layout.txt
@@ -1,6 +1,6 @@
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.258 : I128 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.258;
+    let Num.257 : I128 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.257;
 
 procedure Test.0 ():
     let Test.6 : I128 = 18446744073709551616i64;

--- a/crates/compiler/test_mono/generated/choose_u128_layout.txt
+++ b/crates/compiler/test_mono/generated/choose_u128_layout.txt
@@ -1,6 +1,6 @@
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.257 : U128 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.257;
+    let Num.256 : U128 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.256;
 
 procedure Test.0 ():
     let Test.2 : U128 = 170141183460469231731687303715884105728u128;

--- a/crates/compiler/test_mono/generated/choose_u64_layout.txt
+++ b/crates/compiler/test_mono/generated/choose_u64_layout.txt
@@ -1,6 +1,6 @@
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.257 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.257;
+    let Num.256 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.256;
 
 procedure Test.0 ():
     let Test.2 : U64 = 9999999999999999999i64;

--- a/crates/compiler/test_mono/generated/closure_in_list.txt
+++ b/crates/compiler/test_mono/generated/closure_in_list.txt
@@ -1,6 +1,6 @@
 procedure List.6 (#Attr.2):
-    let List.380 : U64 = lowlevel ListLen #Attr.2;
-    ret List.380;
+    let List.409 : U64 = lowlevel ListLen #Attr.2;
+    ret List.409;
 
 procedure Test.1 (Test.5):
     let Test.2 : I64 = 41i64;

--- a/crates/compiler/test_mono/generated/dict.txt
+++ b/crates/compiler/test_mono/generated/dict.txt
@@ -1,14 +1,14 @@
 procedure Dict.1 ():
-    let Dict.100 : List {[], []} = Array [];
-    ret Dict.100;
+    let Dict.316 : List {[], []} = Array [];
+    ret Dict.316;
 
-procedure Dict.7 (Dict.94):
-    let Dict.99 : U64 = CallByName List.6 Dict.94;
-    ret Dict.99;
+procedure Dict.7 (Dict.310):
+    let Dict.315 : U64 = CallByName List.6 Dict.310;
+    ret Dict.315;
 
 procedure List.6 (#Attr.2):
-    let List.380 : U64 = lowlevel ListLen #Attr.2;
-    ret List.380;
+    let List.409 : U64 = lowlevel ListLen #Attr.2;
+    ret List.409;
 
 procedure Test.0 ():
     let Test.2 : List {[], []} = CallByName Dict.1;

--- a/crates/compiler/test_mono/generated/empty_list_of_function_type.txt
+++ b/crates/compiler/test_mono/generated/empty_list_of_function_type.txt
@@ -1,30 +1,30 @@
 procedure Bool.1 ():
-    let Bool.11 : Int1 = false;
-    ret Bool.11;
+    let Bool.23 : Int1 = false;
+    ret Bool.23;
 
-procedure List.2 (List.90, List.91):
-    let List.386 : U64 = CallByName List.6 List.90;
-    let List.382 : Int1 = CallByName Num.22 List.91 List.386;
-    if List.382 then
-        let List.384 : {} = CallByName List.66 List.90 List.91;
-        let List.383 : [C {}, C {}] = TagId(1) List.384;
-        ret List.383;
+procedure List.2 (List.94, List.95):
+    let List.415 : U64 = CallByName List.6 List.94;
+    let List.411 : Int1 = CallByName Num.22 List.95 List.415;
+    if List.411 then
+        let List.413 : {} = CallByName List.66 List.94 List.95;
+        let List.412 : [C {}, C {}] = TagId(1) List.413;
+        ret List.412;
     else
-        let List.381 : {} = Struct {};
-        let List.380 : [C {}, C {}] = TagId(0) List.381;
-        ret List.380;
+        let List.410 : {} = Struct {};
+        let List.409 : [C {}, C {}] = TagId(0) List.410;
+        ret List.409;
 
 procedure List.6 (#Attr.2):
-    let List.387 : U64 = lowlevel ListLen #Attr.2;
-    ret List.387;
+    let List.416 : U64 = lowlevel ListLen #Attr.2;
+    ret List.416;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.385 : {} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.385;
+    let List.414 : {} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.414;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.257 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.257;
+    let Num.256 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.256;
 
 procedure Test.2 (Test.5):
     let Test.17 : Str = "bar";

--- a/crates/compiler/test_mono/generated/encode.txt
+++ b/crates/compiler/test_mono/generated/encode.txt
@@ -1,16 +1,16 @@
-procedure List.4 (List.101, List.102):
-    let List.383 : U64 = 1i64;
-    let List.381 : List U8 = CallByName List.70 List.101 List.383;
-    let List.380 : List U8 = CallByName List.71 List.381 List.102;
-    ret List.380;
+procedure List.4 (List.105, List.106):
+    let List.412 : U64 = 1i64;
+    let List.410 : List U8 = CallByName List.70 List.105 List.412;
+    let List.409 : List U8 = CallByName List.71 List.410 List.106;
+    ret List.409;
 
 procedure List.70 (#Attr.2, #Attr.3):
-    let List.384 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
-    ret List.384;
+    let List.413 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
+    ret List.413;
 
 procedure List.71 (#Attr.2, #Attr.3):
-    let List.382 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
-    ret List.382;
+    let List.411 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
+    ret List.411;
 
 procedure Test.23 (Test.24, Test.35, Test.22):
     let Test.37 : List U8 = CallByName List.4 Test.24 Test.22;

--- a/crates/compiler/test_mono/generated/encode_derived_nested_record_string.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_nested_record_string.txt
@@ -44,7 +44,7 @@ procedure Encode.23 (Encode.94, Encode.102, Encode.96):
     ret Encode.106;
 
 procedure Encode.23 (Encode.94, Encode.102, Encode.96):
-    let Encode.113 : List U8 = CallByName Json.113 Encode.94 Encode.96 Encode.102;
+    let Encode.113 : List U8 = CallByName Json.112 Encode.94 Encode.96 Encode.102;
     ret Encode.113;
 
 procedure Encode.23 (Encode.94, Encode.102, Encode.96):
@@ -52,11 +52,11 @@ procedure Encode.23 (Encode.94, Encode.102, Encode.96):
     ret Encode.115;
 
 procedure Encode.23 (Encode.94, Encode.102, Encode.96):
-    let Encode.125 : List U8 = CallByName Json.113 Encode.94 Encode.96 Encode.102;
+    let Encode.125 : List U8 = CallByName Json.112 Encode.94 Encode.96 Encode.102;
     ret Encode.125;
 
 procedure Encode.23 (Encode.94, Encode.102, Encode.96):
-    let Encode.128 : List U8 = CallByName Json.97 Encode.94 Encode.96 Encode.102;
+    let Encode.128 : List U8 = CallByName Json.96 Encode.94 Encode.96 Encode.102;
     ret Encode.128;
 
 procedure Encode.25 (Encode.100, Encode.101):
@@ -66,284 +66,284 @@ procedure Encode.25 (Encode.100, Encode.101):
     ret Encode.103;
 
 procedure Json.1 ():
-    let Json.396 : {} = Struct {};
-    ret Json.396;
+    let Json.394 : {} = Struct {};
+    ret Json.394;
 
-procedure Json.113 (Json.114, Json.399, Json.112):
-    let Json.432 : I32 = 123i64;
-    let Json.431 : U8 = CallByName Num.123 Json.432;
-    let Json.116 : List U8 = CallByName List.4 Json.114 Json.431;
-    let Json.430 : U64 = CallByName List.6 Json.112;
-    let Json.407 : {List U8, U64} = Struct {Json.116, Json.430};
-    let Json.408 : {} = Struct {};
-    let Json.406 : {List U8, U64} = CallByName List.18 Json.112 Json.407 Json.408;
-    dec Json.112;
-    let Json.118 : List U8 = StructAtIndex 0 Json.406;
-    inc Json.118;
-    dec Json.406;
-    let Json.405 : I32 = 125i64;
-    let Json.404 : U8 = CallByName Num.123 Json.405;
-    let Json.403 : List U8 = CallByName List.4 Json.118 Json.404;
-    ret Json.403;
+procedure Json.112 (Json.113, Json.397, Json.111):
+    let Json.430 : I64 = 123i64;
+    let Json.429 : U8 = CallByName Num.125 Json.430;
+    let Json.115 : List U8 = CallByName List.4 Json.113 Json.429;
+    let Json.428 : U64 = CallByName List.6 Json.111;
+    let Json.405 : {List U8, U64} = Struct {Json.115, Json.428};
+    let Json.406 : {} = Struct {};
+    let Json.404 : {List U8, U64} = CallByName List.18 Json.111 Json.405 Json.406;
+    dec Json.111;
+    let Json.117 : List U8 = StructAtIndex 0 Json.404;
+    inc Json.117;
+    dec Json.404;
+    let Json.403 : I64 = 125i64;
+    let Json.402 : U8 = CallByName Num.125 Json.403;
+    let Json.401 : List U8 = CallByName List.4 Json.117 Json.402;
+    ret Json.401;
 
-procedure Json.113 (Json.114, Json.399, Json.112):
-    let Json.472 : I32 = 123i64;
-    let Json.471 : U8 = CallByName Num.123 Json.472;
-    let Json.116 : List U8 = CallByName List.4 Json.114 Json.471;
-    let Json.470 : U64 = CallByName List.6 Json.112;
-    let Json.447 : {List U8, U64} = Struct {Json.116, Json.470};
-    let Json.448 : {} = Struct {};
-    let Json.446 : {List U8, U64} = CallByName List.18 Json.112 Json.447 Json.448;
-    dec Json.112;
-    let Json.118 : List U8 = StructAtIndex 0 Json.446;
-    inc Json.118;
-    dec Json.446;
-    let Json.445 : I32 = 125i64;
-    let Json.444 : U8 = CallByName Num.123 Json.445;
-    let Json.443 : List U8 = CallByName List.4 Json.118 Json.444;
-    ret Json.443;
+procedure Json.112 (Json.113, Json.397, Json.111):
+    let Json.470 : I64 = 123i64;
+    let Json.469 : U8 = CallByName Num.125 Json.470;
+    let Json.115 : List U8 = CallByName List.4 Json.113 Json.469;
+    let Json.468 : U64 = CallByName List.6 Json.111;
+    let Json.445 : {List U8, U64} = Struct {Json.115, Json.468};
+    let Json.446 : {} = Struct {};
+    let Json.444 : {List U8, U64} = CallByName List.18 Json.111 Json.445 Json.446;
+    dec Json.111;
+    let Json.117 : List U8 = StructAtIndex 0 Json.444;
+    inc Json.117;
+    dec Json.444;
+    let Json.443 : I64 = 125i64;
+    let Json.442 : U8 = CallByName Num.125 Json.443;
+    let Json.441 : List U8 = CallByName List.4 Json.117 Json.442;
+    ret Json.441;
 
-procedure Json.115 (Json.401, Json.402):
-    let Json.121 : Str = StructAtIndex 0 Json.402;
+procedure Json.114 (Json.399, Json.400):
+    let Json.120 : Str = StructAtIndex 0 Json.400;
+    inc Json.120;
+    let Json.121 : Str = StructAtIndex 1 Json.400;
     inc Json.121;
-    let Json.122 : Str = StructAtIndex 1 Json.402;
-    inc Json.122;
-    dec Json.402;
-    let Json.119 : List U8 = StructAtIndex 0 Json.401;
-    inc Json.119;
-    let Json.120 : U64 = StructAtIndex 1 Json.401;
-    dec Json.401;
-    let Json.429 : I32 = 34i64;
-    let Json.428 : U8 = CallByName Num.123 Json.429;
-    let Json.426 : List U8 = CallByName List.4 Json.119 Json.428;
-    let Json.427 : List U8 = CallByName Str.12 Json.121;
-    let Json.423 : List U8 = CallByName List.8 Json.426 Json.427;
-    let Json.425 : I32 = 34i64;
-    let Json.424 : U8 = CallByName Num.123 Json.425;
-    let Json.420 : List U8 = CallByName List.4 Json.423 Json.424;
-    let Json.422 : I32 = 58i64;
-    let Json.421 : U8 = CallByName Num.123 Json.422;
-    let Json.418 : List U8 = CallByName List.4 Json.420 Json.421;
-    let Json.419 : {} = Struct {};
-    let Json.123 : List U8 = CallByName Encode.23 Json.418 Json.122 Json.419;
-    joinpoint Json.413 Json.124:
-        let Json.411 : U64 = 1i64;
-        let Json.410 : U64 = CallByName Num.20 Json.120 Json.411;
-        let Json.409 : {List U8, U64} = Struct {Json.124, Json.410};
-        ret Json.409;
+    dec Json.400;
+    let Json.118 : List U8 = StructAtIndex 0 Json.399;
+    inc Json.118;
+    let Json.119 : U64 = StructAtIndex 1 Json.399;
+    dec Json.399;
+    let Json.427 : I64 = 34i64;
+    let Json.426 : U8 = CallByName Num.125 Json.427;
+    let Json.424 : List U8 = CallByName List.4 Json.118 Json.426;
+    let Json.425 : List U8 = CallByName Str.12 Json.120;
+    let Json.421 : List U8 = CallByName List.8 Json.424 Json.425;
+    let Json.423 : I64 = 34i64;
+    let Json.422 : U8 = CallByName Num.125 Json.423;
+    let Json.418 : List U8 = CallByName List.4 Json.421 Json.422;
+    let Json.420 : I64 = 58i64;
+    let Json.419 : U8 = CallByName Num.125 Json.420;
+    let Json.416 : List U8 = CallByName List.4 Json.418 Json.419;
+    let Json.417 : {} = Struct {};
+    let Json.122 : List U8 = CallByName Encode.23 Json.416 Json.121 Json.417;
+    joinpoint Json.411 Json.123:
+        let Json.409 : U64 = 1i64;
+        let Json.408 : U64 = CallByName Num.20 Json.119 Json.409;
+        let Json.407 : {List U8, U64} = Struct {Json.123, Json.408};
+        ret Json.407;
     in
-    let Json.417 : U64 = 1i64;
-    let Json.414 : Int1 = CallByName Num.24 Json.120 Json.417;
-    if Json.414 then
-        let Json.416 : I32 = 44i64;
-        let Json.415 : U8 = CallByName Num.123 Json.416;
-        let Json.412 : List U8 = CallByName List.4 Json.123 Json.415;
-        jump Json.413 Json.412;
+    let Json.415 : U64 = 1i64;
+    let Json.412 : Int1 = CallByName Num.24 Json.119 Json.415;
+    if Json.412 then
+        let Json.414 : I64 = 44i64;
+        let Json.413 : U8 = CallByName Num.125 Json.414;
+        let Json.410 : List U8 = CallByName List.4 Json.122 Json.413;
+        jump Json.411 Json.410;
     else
-        jump Json.413 Json.123;
+        jump Json.411 Json.122;
 
-procedure Json.115 (Json.401, Json.402):
-    let Json.121 : Str = StructAtIndex 0 Json.402;
+procedure Json.114 (Json.399, Json.400):
+    let Json.120 : Str = StructAtIndex 0 Json.400;
+    inc Json.120;
+    let Json.121 : Str = StructAtIndex 1 Json.400;
     inc Json.121;
-    let Json.122 : Str = StructAtIndex 1 Json.402;
-    inc Json.122;
-    dec Json.402;
-    let Json.119 : List U8 = StructAtIndex 0 Json.401;
-    inc Json.119;
-    let Json.120 : U64 = StructAtIndex 1 Json.401;
-    dec Json.401;
-    let Json.469 : I32 = 34i64;
-    let Json.468 : U8 = CallByName Num.123 Json.469;
-    let Json.466 : List U8 = CallByName List.4 Json.119 Json.468;
-    let Json.467 : List U8 = CallByName Str.12 Json.121;
-    let Json.463 : List U8 = CallByName List.8 Json.466 Json.467;
-    let Json.465 : I32 = 34i64;
-    let Json.464 : U8 = CallByName Num.123 Json.465;
-    let Json.460 : List U8 = CallByName List.4 Json.463 Json.464;
-    let Json.462 : I32 = 58i64;
-    let Json.461 : U8 = CallByName Num.123 Json.462;
-    let Json.458 : List U8 = CallByName List.4 Json.460 Json.461;
-    let Json.459 : {} = Struct {};
-    let Json.123 : List U8 = CallByName Encode.23 Json.458 Json.122 Json.459;
-    joinpoint Json.453 Json.124:
-        let Json.451 : U64 = 1i64;
-        let Json.450 : U64 = CallByName Num.20 Json.120 Json.451;
-        let Json.449 : {List U8, U64} = Struct {Json.124, Json.450};
-        ret Json.449;
+    dec Json.400;
+    let Json.118 : List U8 = StructAtIndex 0 Json.399;
+    inc Json.118;
+    let Json.119 : U64 = StructAtIndex 1 Json.399;
+    dec Json.399;
+    let Json.467 : I64 = 34i64;
+    let Json.466 : U8 = CallByName Num.125 Json.467;
+    let Json.464 : List U8 = CallByName List.4 Json.118 Json.466;
+    let Json.465 : List U8 = CallByName Str.12 Json.120;
+    let Json.461 : List U8 = CallByName List.8 Json.464 Json.465;
+    let Json.463 : I64 = 34i64;
+    let Json.462 : U8 = CallByName Num.125 Json.463;
+    let Json.458 : List U8 = CallByName List.4 Json.461 Json.462;
+    let Json.460 : I64 = 58i64;
+    let Json.459 : U8 = CallByName Num.125 Json.460;
+    let Json.456 : List U8 = CallByName List.4 Json.458 Json.459;
+    let Json.457 : {} = Struct {};
+    let Json.122 : List U8 = CallByName Encode.23 Json.456 Json.121 Json.457;
+    joinpoint Json.451 Json.123:
+        let Json.449 : U64 = 1i64;
+        let Json.448 : U64 = CallByName Num.20 Json.119 Json.449;
+        let Json.447 : {List U8, U64} = Struct {Json.123, Json.448};
+        ret Json.447;
     in
-    let Json.457 : U64 = 1i64;
-    let Json.454 : Int1 = CallByName Num.24 Json.120 Json.457;
-    if Json.454 then
-        let Json.456 : I32 = 44i64;
-        let Json.455 : U8 = CallByName Num.123 Json.456;
-        let Json.452 : List U8 = CallByName List.4 Json.123 Json.455;
-        jump Json.453 Json.452;
+    let Json.455 : U64 = 1i64;
+    let Json.452 : Int1 = CallByName Num.24 Json.119 Json.455;
+    if Json.452 then
+        let Json.454 : I64 = 44i64;
+        let Json.453 : U8 = CallByName Num.125 Json.454;
+        let Json.450 : List U8 = CallByName List.4 Json.122 Json.453;
+        jump Json.451 Json.450;
     else
-        jump Json.453 Json.123;
+        jump Json.451 Json.122;
 
-procedure Json.18 (Json.96):
-    let Json.473 : Str = CallByName Encode.22 Json.96;
-    ret Json.473;
+procedure Json.18 (Json.95):
+    let Json.471 : Str = CallByName Encode.22 Json.95;
+    ret Json.471;
 
-procedure Json.20 (Json.112):
-    let Json.397 : List {Str, Str} = CallByName Encode.22 Json.112;
-    ret Json.397;
+procedure Json.20 (Json.111):
+    let Json.395 : List {Str, Str} = CallByName Encode.22 Json.111;
+    ret Json.395;
 
-procedure Json.20 (Json.112):
-    let Json.439 : List {Str, Str} = CallByName Encode.22 Json.112;
-    ret Json.439;
+procedure Json.20 (Json.111):
+    let Json.437 : List {Str, Str} = CallByName Encode.22 Json.111;
+    ret Json.437;
 
-procedure Json.97 (Json.98, Json.475, Json.96):
-    let Json.484 : I32 = 34i64;
-    let Json.483 : U8 = CallByName Num.123 Json.484;
-    let Json.481 : List U8 = CallByName List.4 Json.98 Json.483;
-    let Json.482 : List U8 = CallByName Str.12 Json.96;
-    let Json.478 : List U8 = CallByName List.8 Json.481 Json.482;
-    let Json.480 : I32 = 34i64;
-    let Json.479 : U8 = CallByName Num.123 Json.480;
-    let Json.477 : List U8 = CallByName List.4 Json.478 Json.479;
-    ret Json.477;
+procedure Json.96 (Json.97, Json.473, Json.95):
+    let Json.482 : I64 = 34i64;
+    let Json.481 : U8 = CallByName Num.125 Json.482;
+    let Json.479 : List U8 = CallByName List.4 Json.97 Json.481;
+    let Json.480 : List U8 = CallByName Str.12 Json.95;
+    let Json.476 : List U8 = CallByName List.8 Json.479 Json.480;
+    let Json.478 : I64 = 34i64;
+    let Json.477 : U8 = CallByName Num.125 Json.478;
+    let Json.475 : List U8 = CallByName List.4 Json.476 Json.477;
+    ret Json.475;
 
-procedure List.133 (List.134, List.135, List.132):
-    let List.420 : {List U8, U64} = CallByName Json.115 List.134 List.135;
-    ret List.420;
+procedure List.137 (List.138, List.139, List.136):
+    let List.449 : {List U8, U64} = CallByName Json.114 List.138 List.139;
+    ret List.449;
 
-procedure List.133 (List.134, List.135, List.132):
-    let List.492 : {List U8, U64} = CallByName Json.115 List.134 List.135;
-    ret List.492;
+procedure List.137 (List.138, List.139, List.136):
+    let List.521 : {List U8, U64} = CallByName Json.114 List.138 List.139;
+    ret List.521;
 
-procedure List.18 (List.130, List.131, List.132):
-    let List.402 : {List U8, U64} = CallByName List.75 List.130 List.131 List.132;
-    ret List.402;
+procedure List.18 (List.134, List.135, List.136):
+    let List.431 : {List U8, U64} = CallByName List.80 List.134 List.135 List.136;
+    ret List.431;
 
-procedure List.18 (List.130, List.131, List.132):
-    let List.474 : {List U8, U64} = CallByName List.75 List.130 List.131 List.132;
-    ret List.474;
+procedure List.18 (List.134, List.135, List.136):
+    let List.503 : {List U8, U64} = CallByName List.80 List.134 List.135 List.136;
+    ret List.503;
 
-procedure List.4 (List.101, List.102):
-    let List.473 : U64 = 1i64;
-    let List.472 : List U8 = CallByName List.70 List.101 List.473;
-    let List.471 : List U8 = CallByName List.71 List.472 List.102;
-    ret List.471;
-
-procedure List.6 (#Attr.2):
-    let List.380 : U64 = lowlevel ListLen #Attr.2;
-    ret List.380;
+procedure List.4 (List.105, List.106):
+    let List.502 : U64 = 1i64;
+    let List.501 : List U8 = CallByName List.70 List.105 List.502;
+    let List.500 : List U8 = CallByName List.71 List.501 List.106;
+    ret List.500;
 
 procedure List.6 (#Attr.2):
-    let List.422 : U64 = lowlevel ListLen #Attr.2;
-    ret List.422;
+    let List.409 : U64 = lowlevel ListLen #Attr.2;
+    ret List.409;
 
 procedure List.6 (#Attr.2):
-    let List.495 : U64 = lowlevel ListLen #Attr.2;
-    ret List.495;
+    let List.451 : U64 = lowlevel ListLen #Attr.2;
+    ret List.451;
+
+procedure List.6 (#Attr.2):
+    let List.524 : U64 = lowlevel ListLen #Attr.2;
+    ret List.524;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.417 : {Str, Str} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.417;
+    let List.446 : {Str, Str} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.446;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.489 : {Str, Str} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.489;
+    let List.518 : {Str, Str} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.518;
 
 procedure List.70 (#Attr.2, #Attr.3):
-    let List.452 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
-    ret List.452;
+    let List.481 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
+    ret List.481;
 
 procedure List.71 (#Attr.2, #Attr.3):
-    let List.450 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
-    ret List.450;
-
-procedure List.75 (List.356, List.357, List.358):
-    let List.406 : U64 = 0i64;
-    let List.407 : U64 = CallByName List.6 List.356;
-    let List.405 : {List U8, U64} = CallByName List.86 List.356 List.357 List.358 List.406 List.407;
-    ret List.405;
-
-procedure List.75 (List.356, List.357, List.358):
-    let List.478 : U64 = 0i64;
-    let List.479 : U64 = CallByName List.6 List.356;
-    let List.477 : {List U8, U64} = CallByName List.86 List.356 List.357 List.358 List.478 List.479;
-    ret List.477;
+    let List.479 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
+    ret List.479;
 
 procedure List.8 (#Attr.2, #Attr.3):
-    let List.494 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
-    ret List.494;
+    let List.523 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
+    ret List.523;
 
-procedure List.86 (List.432, List.433, List.434, List.435, List.436):
-    joinpoint List.408 List.359 List.360 List.361 List.362 List.363:
-        let List.410 : Int1 = CallByName Num.22 List.362 List.363;
-        if List.410 then
-            let List.416 : {Str, Str} = CallByName List.66 List.359 List.362;
-            let List.411 : {List U8, U64} = CallByName List.133 List.360 List.416 List.361;
-            let List.414 : U64 = 1i64;
-            let List.413 : U64 = CallByName Num.19 List.362 List.414;
-            jump List.408 List.359 List.411 List.361 List.413 List.363;
+procedure List.80 (List.385, List.386, List.387):
+    let List.435 : U64 = 0i64;
+    let List.436 : U64 = CallByName List.6 List.385;
+    let List.434 : {List U8, U64} = CallByName List.90 List.385 List.386 List.387 List.435 List.436;
+    ret List.434;
+
+procedure List.80 (List.385, List.386, List.387):
+    let List.507 : U64 = 0i64;
+    let List.508 : U64 = CallByName List.6 List.385;
+    let List.506 : {List U8, U64} = CallByName List.90 List.385 List.386 List.387 List.507 List.508;
+    ret List.506;
+
+procedure List.90 (List.461, List.462, List.463, List.464, List.465):
+    joinpoint List.437 List.388 List.389 List.390 List.391 List.392:
+        let List.439 : Int1 = CallByName Num.22 List.391 List.392;
+        if List.439 then
+            let List.445 : {Str, Str} = CallByName List.66 List.388 List.391;
+            let List.440 : {List U8, U64} = CallByName List.137 List.389 List.445 List.390;
+            let List.443 : U64 = 1i64;
+            let List.442 : U64 = CallByName Num.19 List.391 List.443;
+            jump List.437 List.388 List.440 List.390 List.442 List.392;
         else
-            ret List.360;
+            ret List.389;
     in
-    jump List.408 List.432 List.433 List.434 List.435 List.436;
+    jump List.437 List.461 List.462 List.463 List.464 List.465;
 
-procedure List.86 (List.505, List.506, List.507, List.508, List.509):
-    joinpoint List.480 List.359 List.360 List.361 List.362 List.363:
-        let List.482 : Int1 = CallByName Num.22 List.362 List.363;
-        if List.482 then
-            let List.488 : {Str, Str} = CallByName List.66 List.359 List.362;
-            let List.483 : {List U8, U64} = CallByName List.133 List.360 List.488 List.361;
-            let List.486 : U64 = 1i64;
-            let List.485 : U64 = CallByName Num.19 List.362 List.486;
-            jump List.480 List.359 List.483 List.361 List.485 List.363;
+procedure List.90 (List.534, List.535, List.536, List.537, List.538):
+    joinpoint List.509 List.388 List.389 List.390 List.391 List.392:
+        let List.511 : Int1 = CallByName Num.22 List.391 List.392;
+        if List.511 then
+            let List.517 : {Str, Str} = CallByName List.66 List.388 List.391;
+            let List.512 : {List U8, U64} = CallByName List.137 List.389 List.517 List.390;
+            let List.515 : U64 = 1i64;
+            let List.514 : U64 = CallByName Num.19 List.391 List.515;
+            jump List.509 List.388 List.512 List.390 List.514 List.392;
         else
-            ret List.360;
+            ret List.389;
     in
-    jump List.480 List.505 List.506 List.507 List.508 List.509;
+    jump List.509 List.534 List.535 List.536 List.537 List.538;
 
-procedure Num.123 (#Attr.2):
-    let Num.283 : U8 = lowlevel NumIntCast #Attr.2;
-    ret Num.283;
+procedure Num.125 (#Attr.2):
+    let Num.282 : U8 = lowlevel NumIntCast #Attr.2;
+    ret Num.282;
 
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.286 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.286;
-
-procedure Num.20 (#Attr.2, #Attr.3):
-    let Num.284 : U64 = lowlevel NumSub #Attr.2 #Attr.3;
-    ret Num.284;
-
-procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.287 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.287;
-
-procedure Num.24 (#Attr.2, #Attr.3):
-    let Num.285 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
+    let Num.285 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
     ret Num.285;
 
+procedure Num.20 (#Attr.2, #Attr.3):
+    let Num.283 : U64 = lowlevel NumSub #Attr.2 #Attr.3;
+    ret Num.283;
+
+procedure Num.22 (#Attr.2, #Attr.3):
+    let Num.286 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.286;
+
+procedure Num.24 (#Attr.2, #Attr.3):
+    let Num.284 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
+    ret Num.284;
+
 procedure Str.12 (#Attr.2):
-    let Str.268 : List U8 = lowlevel StrToUtf8 #Attr.2;
-    ret Str.268;
+    let Str.282 : List U8 = lowlevel StrToUtf8 #Attr.2;
+    ret Str.282;
 
 procedure Str.48 (#Attr.2, #Attr.3, #Attr.4):
-    let Str.260 : {U64, Str, Int1, U8} = lowlevel StrFromUtf8Range #Attr.2 #Attr.3 #Attr.4;
-    ret Str.260;
+    let Str.274 : {U64, Str, Int1, U8} = lowlevel StrFromUtf8Range #Attr.2 #Attr.3 #Attr.4;
+    ret Str.274;
 
-procedure Str.9 (Str.73):
-    let Str.258 : U64 = 0i64;
-    let Str.259 : U64 = CallByName List.6 Str.73;
-    let Str.74 : {U64, Str, Int1, U8} = CallByName Str.48 Str.73 Str.258 Str.259;
-    let Str.255 : Int1 = StructAtIndex 2 Str.74;
-    if Str.255 then
-        let Str.257 : Str = StructAtIndex 1 Str.74;
-        inc Str.257;
-        dec Str.74;
-        let Str.256 : [C {U64, U8}, C Str] = TagId(1) Str.257;
-        ret Str.256;
+procedure Str.9 (Str.76):
+    let Str.272 : U64 = 0i64;
+    let Str.273 : U64 = CallByName List.6 Str.76;
+    let Str.77 : {U64, Str, Int1, U8} = CallByName Str.48 Str.76 Str.272 Str.273;
+    let Str.269 : Int1 = StructAtIndex 2 Str.77;
+    if Str.269 then
+        let Str.271 : Str = StructAtIndex 1 Str.77;
+        inc Str.271;
+        dec Str.77;
+        let Str.270 : [C {U64, U8}, C Str] = TagId(1) Str.271;
+        ret Str.270;
     else
-        let Str.253 : U8 = StructAtIndex 3 Str.74;
-        let Str.254 : U64 = StructAtIndex 0 Str.74;
-        dec Str.74;
-        let Str.252 : {U64, U8} = Struct {Str.254, Str.253};
-        let Str.251 : [C {U64, U8}, C Str] = TagId(0) Str.252;
-        ret Str.251;
+        let Str.267 : U8 = StructAtIndex 3 Str.77;
+        let Str.268 : U64 = StructAtIndex 0 Str.77;
+        dec Str.77;
+        let Str.266 : {U64, U8} = Struct {Str.268, Str.267};
+        let Str.265 : [C {U64, U8}, C Str] = TagId(0) Str.266;
+        ret Str.265;
 
 procedure Test.0 ():
     let Test.12 : Str = "bar";

--- a/crates/compiler/test_mono/generated/encode_derived_record_one_field_string.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_record_one_field_string.txt
@@ -25,11 +25,11 @@ procedure Encode.23 (Encode.94, Encode.102, Encode.96):
     ret Encode.106;
 
 procedure Encode.23 (Encode.94, Encode.102, Encode.96):
-    let Encode.113 : List U8 = CallByName Json.113 Encode.94 Encode.96 Encode.102;
+    let Encode.113 : List U8 = CallByName Json.112 Encode.94 Encode.96 Encode.102;
     ret Encode.113;
 
 procedure Encode.23 (Encode.94, Encode.102, Encode.96):
-    let Encode.116 : List U8 = CallByName Json.97 Encode.94 Encode.96 Encode.102;
+    let Encode.116 : List U8 = CallByName Json.96 Encode.94 Encode.96 Encode.102;
     ret Encode.116;
 
 procedure Encode.25 (Encode.100, Encode.101):
@@ -39,188 +39,188 @@ procedure Encode.25 (Encode.100, Encode.101):
     ret Encode.103;
 
 procedure Json.1 ():
-    let Json.396 : {} = Struct {};
-    ret Json.396;
+    let Json.394 : {} = Struct {};
+    ret Json.394;
 
-procedure Json.113 (Json.114, Json.399, Json.112):
-    let Json.432 : I32 = 123i64;
-    let Json.431 : U8 = CallByName Num.123 Json.432;
-    let Json.116 : List U8 = CallByName List.4 Json.114 Json.431;
-    let Json.430 : U64 = CallByName List.6 Json.112;
-    let Json.407 : {List U8, U64} = Struct {Json.116, Json.430};
-    let Json.408 : {} = Struct {};
-    let Json.406 : {List U8, U64} = CallByName List.18 Json.112 Json.407 Json.408;
-    dec Json.112;
-    let Json.118 : List U8 = StructAtIndex 0 Json.406;
-    inc Json.118;
-    dec Json.406;
-    let Json.405 : I32 = 125i64;
-    let Json.404 : U8 = CallByName Num.123 Json.405;
-    let Json.403 : List U8 = CallByName List.4 Json.118 Json.404;
-    ret Json.403;
+procedure Json.112 (Json.113, Json.397, Json.111):
+    let Json.430 : I64 = 123i64;
+    let Json.429 : U8 = CallByName Num.125 Json.430;
+    let Json.115 : List U8 = CallByName List.4 Json.113 Json.429;
+    let Json.428 : U64 = CallByName List.6 Json.111;
+    let Json.405 : {List U8, U64} = Struct {Json.115, Json.428};
+    let Json.406 : {} = Struct {};
+    let Json.404 : {List U8, U64} = CallByName List.18 Json.111 Json.405 Json.406;
+    dec Json.111;
+    let Json.117 : List U8 = StructAtIndex 0 Json.404;
+    inc Json.117;
+    dec Json.404;
+    let Json.403 : I64 = 125i64;
+    let Json.402 : U8 = CallByName Num.125 Json.403;
+    let Json.401 : List U8 = CallByName List.4 Json.117 Json.402;
+    ret Json.401;
 
-procedure Json.115 (Json.401, Json.402):
-    let Json.121 : Str = StructAtIndex 0 Json.402;
+procedure Json.114 (Json.399, Json.400):
+    let Json.120 : Str = StructAtIndex 0 Json.400;
+    inc Json.120;
+    let Json.121 : Str = StructAtIndex 1 Json.400;
     inc Json.121;
-    let Json.122 : Str = StructAtIndex 1 Json.402;
-    inc Json.122;
-    dec Json.402;
-    let Json.119 : List U8 = StructAtIndex 0 Json.401;
-    inc Json.119;
-    let Json.120 : U64 = StructAtIndex 1 Json.401;
-    dec Json.401;
-    let Json.429 : I32 = 34i64;
-    let Json.428 : U8 = CallByName Num.123 Json.429;
-    let Json.426 : List U8 = CallByName List.4 Json.119 Json.428;
-    let Json.427 : List U8 = CallByName Str.12 Json.121;
-    let Json.423 : List U8 = CallByName List.8 Json.426 Json.427;
-    let Json.425 : I32 = 34i64;
-    let Json.424 : U8 = CallByName Num.123 Json.425;
-    let Json.420 : List U8 = CallByName List.4 Json.423 Json.424;
-    let Json.422 : I32 = 58i64;
-    let Json.421 : U8 = CallByName Num.123 Json.422;
-    let Json.418 : List U8 = CallByName List.4 Json.420 Json.421;
-    let Json.419 : {} = Struct {};
-    let Json.123 : List U8 = CallByName Encode.23 Json.418 Json.122 Json.419;
-    joinpoint Json.413 Json.124:
-        let Json.411 : U64 = 1i64;
-        let Json.410 : U64 = CallByName Num.20 Json.120 Json.411;
-        let Json.409 : {List U8, U64} = Struct {Json.124, Json.410};
-        ret Json.409;
+    dec Json.400;
+    let Json.118 : List U8 = StructAtIndex 0 Json.399;
+    inc Json.118;
+    let Json.119 : U64 = StructAtIndex 1 Json.399;
+    dec Json.399;
+    let Json.427 : I64 = 34i64;
+    let Json.426 : U8 = CallByName Num.125 Json.427;
+    let Json.424 : List U8 = CallByName List.4 Json.118 Json.426;
+    let Json.425 : List U8 = CallByName Str.12 Json.120;
+    let Json.421 : List U8 = CallByName List.8 Json.424 Json.425;
+    let Json.423 : I64 = 34i64;
+    let Json.422 : U8 = CallByName Num.125 Json.423;
+    let Json.418 : List U8 = CallByName List.4 Json.421 Json.422;
+    let Json.420 : I64 = 58i64;
+    let Json.419 : U8 = CallByName Num.125 Json.420;
+    let Json.416 : List U8 = CallByName List.4 Json.418 Json.419;
+    let Json.417 : {} = Struct {};
+    let Json.122 : List U8 = CallByName Encode.23 Json.416 Json.121 Json.417;
+    joinpoint Json.411 Json.123:
+        let Json.409 : U64 = 1i64;
+        let Json.408 : U64 = CallByName Num.20 Json.119 Json.409;
+        let Json.407 : {List U8, U64} = Struct {Json.123, Json.408};
+        ret Json.407;
     in
-    let Json.417 : U64 = 1i64;
-    let Json.414 : Int1 = CallByName Num.24 Json.120 Json.417;
-    if Json.414 then
-        let Json.416 : I32 = 44i64;
-        let Json.415 : U8 = CallByName Num.123 Json.416;
-        let Json.412 : List U8 = CallByName List.4 Json.123 Json.415;
-        jump Json.413 Json.412;
+    let Json.415 : U64 = 1i64;
+    let Json.412 : Int1 = CallByName Num.24 Json.119 Json.415;
+    if Json.412 then
+        let Json.414 : I64 = 44i64;
+        let Json.413 : U8 = CallByName Num.125 Json.414;
+        let Json.410 : List U8 = CallByName List.4 Json.122 Json.413;
+        jump Json.411 Json.410;
     else
-        jump Json.413 Json.123;
+        jump Json.411 Json.122;
 
-procedure Json.18 (Json.96):
-    let Json.433 : Str = CallByName Encode.22 Json.96;
-    ret Json.433;
+procedure Json.18 (Json.95):
+    let Json.431 : Str = CallByName Encode.22 Json.95;
+    ret Json.431;
 
-procedure Json.20 (Json.112):
-    let Json.397 : List {Str, Str} = CallByName Encode.22 Json.112;
-    ret Json.397;
+procedure Json.20 (Json.111):
+    let Json.395 : List {Str, Str} = CallByName Encode.22 Json.111;
+    ret Json.395;
 
-procedure Json.97 (Json.98, Json.435, Json.96):
-    let Json.444 : I32 = 34i64;
-    let Json.443 : U8 = CallByName Num.123 Json.444;
-    let Json.441 : List U8 = CallByName List.4 Json.98 Json.443;
-    let Json.442 : List U8 = CallByName Str.12 Json.96;
-    let Json.438 : List U8 = CallByName List.8 Json.441 Json.442;
-    let Json.440 : I32 = 34i64;
-    let Json.439 : U8 = CallByName Num.123 Json.440;
-    let Json.437 : List U8 = CallByName List.4 Json.438 Json.439;
-    ret Json.437;
+procedure Json.96 (Json.97, Json.433, Json.95):
+    let Json.442 : I64 = 34i64;
+    let Json.441 : U8 = CallByName Num.125 Json.442;
+    let Json.439 : List U8 = CallByName List.4 Json.97 Json.441;
+    let Json.440 : List U8 = CallByName Str.12 Json.95;
+    let Json.436 : List U8 = CallByName List.8 Json.439 Json.440;
+    let Json.438 : I64 = 34i64;
+    let Json.437 : U8 = CallByName Num.125 Json.438;
+    let Json.435 : List U8 = CallByName List.4 Json.436 Json.437;
+    ret Json.435;
 
-procedure List.133 (List.134, List.135, List.132):
-    let List.426 : {List U8, U64} = CallByName Json.115 List.134 List.135;
-    ret List.426;
+procedure List.137 (List.138, List.139, List.136):
+    let List.455 : {List U8, U64} = CallByName Json.114 List.138 List.139;
+    ret List.455;
 
-procedure List.18 (List.130, List.131, List.132):
-    let List.408 : {List U8, U64} = CallByName List.75 List.130 List.131 List.132;
-    ret List.408;
+procedure List.18 (List.134, List.135, List.136):
+    let List.437 : {List U8, U64} = CallByName List.80 List.134 List.135 List.136;
+    ret List.437;
 
-procedure List.4 (List.101, List.102):
-    let List.407 : U64 = 1i64;
-    let List.406 : List U8 = CallByName List.70 List.101 List.407;
-    let List.405 : List U8 = CallByName List.71 List.406 List.102;
-    ret List.405;
-
-procedure List.6 (#Attr.2):
-    let List.380 : U64 = lowlevel ListLen #Attr.2;
-    ret List.380;
+procedure List.4 (List.105, List.106):
+    let List.436 : U64 = 1i64;
+    let List.435 : List U8 = CallByName List.70 List.105 List.436;
+    let List.434 : List U8 = CallByName List.71 List.435 List.106;
+    ret List.434;
 
 procedure List.6 (#Attr.2):
-    let List.429 : U64 = lowlevel ListLen #Attr.2;
-    ret List.429;
+    let List.409 : U64 = lowlevel ListLen #Attr.2;
+    ret List.409;
+
+procedure List.6 (#Attr.2):
+    let List.458 : U64 = lowlevel ListLen #Attr.2;
+    ret List.458;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.423 : {Str, Str} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.423;
+    let List.452 : {Str, Str} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.452;
 
 procedure List.70 (#Attr.2, #Attr.3):
-    let List.386 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
-    ret List.386;
+    let List.415 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
+    ret List.415;
 
 procedure List.71 (#Attr.2, #Attr.3):
-    let List.384 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
-    ret List.384;
-
-procedure List.75 (List.356, List.357, List.358):
-    let List.412 : U64 = 0i64;
-    let List.413 : U64 = CallByName List.6 List.356;
-    let List.411 : {List U8, U64} = CallByName List.86 List.356 List.357 List.358 List.412 List.413;
-    ret List.411;
+    let List.413 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
+    ret List.413;
 
 procedure List.8 (#Attr.2, #Attr.3):
-    let List.428 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
-    ret List.428;
+    let List.457 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
+    ret List.457;
 
-procedure List.86 (List.439, List.440, List.441, List.442, List.443):
-    joinpoint List.414 List.359 List.360 List.361 List.362 List.363:
-        let List.416 : Int1 = CallByName Num.22 List.362 List.363;
-        if List.416 then
-            let List.422 : {Str, Str} = CallByName List.66 List.359 List.362;
-            let List.417 : {List U8, U64} = CallByName List.133 List.360 List.422 List.361;
-            let List.420 : U64 = 1i64;
-            let List.419 : U64 = CallByName Num.19 List.362 List.420;
-            jump List.414 List.359 List.417 List.361 List.419 List.363;
+procedure List.80 (List.385, List.386, List.387):
+    let List.441 : U64 = 0i64;
+    let List.442 : U64 = CallByName List.6 List.385;
+    let List.440 : {List U8, U64} = CallByName List.90 List.385 List.386 List.387 List.441 List.442;
+    ret List.440;
+
+procedure List.90 (List.468, List.469, List.470, List.471, List.472):
+    joinpoint List.443 List.388 List.389 List.390 List.391 List.392:
+        let List.445 : Int1 = CallByName Num.22 List.391 List.392;
+        if List.445 then
+            let List.451 : {Str, Str} = CallByName List.66 List.388 List.391;
+            let List.446 : {List U8, U64} = CallByName List.137 List.389 List.451 List.390;
+            let List.449 : U64 = 1i64;
+            let List.448 : U64 = CallByName Num.19 List.391 List.449;
+            jump List.443 List.388 List.446 List.390 List.448 List.392;
         else
-            ret List.360;
+            ret List.389;
     in
-    jump List.414 List.439 List.440 List.441 List.442 List.443;
+    jump List.443 List.468 List.469 List.470 List.471 List.472;
 
-procedure Num.123 (#Attr.2):
-    let Num.264 : U8 = lowlevel NumIntCast #Attr.2;
-    ret Num.264;
+procedure Num.125 (#Attr.2):
+    let Num.263 : U8 = lowlevel NumIntCast #Attr.2;
+    ret Num.263;
 
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.267 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.267;
-
-procedure Num.20 (#Attr.2, #Attr.3):
-    let Num.265 : U64 = lowlevel NumSub #Attr.2 #Attr.3;
-    ret Num.265;
-
-procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.268 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.268;
-
-procedure Num.24 (#Attr.2, #Attr.3):
-    let Num.266 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
+    let Num.266 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
     ret Num.266;
 
+procedure Num.20 (#Attr.2, #Attr.3):
+    let Num.264 : U64 = lowlevel NumSub #Attr.2 #Attr.3;
+    ret Num.264;
+
+procedure Num.22 (#Attr.2, #Attr.3):
+    let Num.267 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.267;
+
+procedure Num.24 (#Attr.2, #Attr.3):
+    let Num.265 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
+    ret Num.265;
+
 procedure Str.12 (#Attr.2):
-    let Str.266 : List U8 = lowlevel StrToUtf8 #Attr.2;
-    ret Str.266;
+    let Str.280 : List U8 = lowlevel StrToUtf8 #Attr.2;
+    ret Str.280;
 
 procedure Str.48 (#Attr.2, #Attr.3, #Attr.4):
-    let Str.260 : {U64, Str, Int1, U8} = lowlevel StrFromUtf8Range #Attr.2 #Attr.3 #Attr.4;
-    ret Str.260;
+    let Str.274 : {U64, Str, Int1, U8} = lowlevel StrFromUtf8Range #Attr.2 #Attr.3 #Attr.4;
+    ret Str.274;
 
-procedure Str.9 (Str.73):
-    let Str.258 : U64 = 0i64;
-    let Str.259 : U64 = CallByName List.6 Str.73;
-    let Str.74 : {U64, Str, Int1, U8} = CallByName Str.48 Str.73 Str.258 Str.259;
-    let Str.255 : Int1 = StructAtIndex 2 Str.74;
-    if Str.255 then
-        let Str.257 : Str = StructAtIndex 1 Str.74;
-        inc Str.257;
-        dec Str.74;
-        let Str.256 : [C {U64, U8}, C Str] = TagId(1) Str.257;
-        ret Str.256;
+procedure Str.9 (Str.76):
+    let Str.272 : U64 = 0i64;
+    let Str.273 : U64 = CallByName List.6 Str.76;
+    let Str.77 : {U64, Str, Int1, U8} = CallByName Str.48 Str.76 Str.272 Str.273;
+    let Str.269 : Int1 = StructAtIndex 2 Str.77;
+    if Str.269 then
+        let Str.271 : Str = StructAtIndex 1 Str.77;
+        inc Str.271;
+        dec Str.77;
+        let Str.270 : [C {U64, U8}, C Str] = TagId(1) Str.271;
+        ret Str.270;
     else
-        let Str.253 : U8 = StructAtIndex 3 Str.74;
-        let Str.254 : U64 = StructAtIndex 0 Str.74;
-        dec Str.74;
-        let Str.252 : {U64, U8} = Struct {Str.254, Str.253};
-        let Str.251 : [C {U64, U8}, C Str] = TagId(0) Str.252;
-        ret Str.251;
+        let Str.267 : U8 = StructAtIndex 3 Str.77;
+        let Str.268 : U64 = StructAtIndex 0 Str.77;
+        dec Str.77;
+        let Str.266 : {U64, U8} = Struct {Str.268, Str.267};
+        let Str.265 : [C {U64, U8}, C Str] = TagId(0) Str.266;
+        ret Str.265;
 
 procedure Test.0 ():
     let Test.11 : Str = "foo";

--- a/crates/compiler/test_mono/generated/encode_derived_record_two_field_strings.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_record_two_field_strings.txt
@@ -33,11 +33,11 @@ procedure Encode.23 (Encode.94, Encode.102, Encode.96):
     ret Encode.106;
 
 procedure Encode.23 (Encode.94, Encode.102, Encode.96):
-    let Encode.113 : List U8 = CallByName Json.113 Encode.94 Encode.96 Encode.102;
+    let Encode.113 : List U8 = CallByName Json.112 Encode.94 Encode.96 Encode.102;
     ret Encode.113;
 
 procedure Encode.23 (Encode.94, Encode.102, Encode.96):
-    let Encode.117 : List U8 = CallByName Json.97 Encode.94 Encode.96 Encode.102;
+    let Encode.117 : List U8 = CallByName Json.96 Encode.94 Encode.96 Encode.102;
     ret Encode.117;
 
 procedure Encode.25 (Encode.100, Encode.101):
@@ -47,188 +47,188 @@ procedure Encode.25 (Encode.100, Encode.101):
     ret Encode.103;
 
 procedure Json.1 ():
-    let Json.396 : {} = Struct {};
-    ret Json.396;
+    let Json.394 : {} = Struct {};
+    ret Json.394;
 
-procedure Json.113 (Json.114, Json.399, Json.112):
-    let Json.432 : I32 = 123i64;
-    let Json.431 : U8 = CallByName Num.123 Json.432;
-    let Json.116 : List U8 = CallByName List.4 Json.114 Json.431;
-    let Json.430 : U64 = CallByName List.6 Json.112;
-    let Json.407 : {List U8, U64} = Struct {Json.116, Json.430};
-    let Json.408 : {} = Struct {};
-    let Json.406 : {List U8, U64} = CallByName List.18 Json.112 Json.407 Json.408;
-    dec Json.112;
-    let Json.118 : List U8 = StructAtIndex 0 Json.406;
-    inc Json.118;
-    dec Json.406;
-    let Json.405 : I32 = 125i64;
-    let Json.404 : U8 = CallByName Num.123 Json.405;
-    let Json.403 : List U8 = CallByName List.4 Json.118 Json.404;
-    ret Json.403;
+procedure Json.112 (Json.113, Json.397, Json.111):
+    let Json.430 : I64 = 123i64;
+    let Json.429 : U8 = CallByName Num.125 Json.430;
+    let Json.115 : List U8 = CallByName List.4 Json.113 Json.429;
+    let Json.428 : U64 = CallByName List.6 Json.111;
+    let Json.405 : {List U8, U64} = Struct {Json.115, Json.428};
+    let Json.406 : {} = Struct {};
+    let Json.404 : {List U8, U64} = CallByName List.18 Json.111 Json.405 Json.406;
+    dec Json.111;
+    let Json.117 : List U8 = StructAtIndex 0 Json.404;
+    inc Json.117;
+    dec Json.404;
+    let Json.403 : I64 = 125i64;
+    let Json.402 : U8 = CallByName Num.125 Json.403;
+    let Json.401 : List U8 = CallByName List.4 Json.117 Json.402;
+    ret Json.401;
 
-procedure Json.115 (Json.401, Json.402):
-    let Json.121 : Str = StructAtIndex 0 Json.402;
+procedure Json.114 (Json.399, Json.400):
+    let Json.120 : Str = StructAtIndex 0 Json.400;
+    inc Json.120;
+    let Json.121 : Str = StructAtIndex 1 Json.400;
     inc Json.121;
-    let Json.122 : Str = StructAtIndex 1 Json.402;
-    inc Json.122;
-    dec Json.402;
-    let Json.119 : List U8 = StructAtIndex 0 Json.401;
-    inc Json.119;
-    let Json.120 : U64 = StructAtIndex 1 Json.401;
-    dec Json.401;
-    let Json.429 : I32 = 34i64;
-    let Json.428 : U8 = CallByName Num.123 Json.429;
-    let Json.426 : List U8 = CallByName List.4 Json.119 Json.428;
-    let Json.427 : List U8 = CallByName Str.12 Json.121;
-    let Json.423 : List U8 = CallByName List.8 Json.426 Json.427;
-    let Json.425 : I32 = 34i64;
-    let Json.424 : U8 = CallByName Num.123 Json.425;
-    let Json.420 : List U8 = CallByName List.4 Json.423 Json.424;
-    let Json.422 : I32 = 58i64;
-    let Json.421 : U8 = CallByName Num.123 Json.422;
-    let Json.418 : List U8 = CallByName List.4 Json.420 Json.421;
-    let Json.419 : {} = Struct {};
-    let Json.123 : List U8 = CallByName Encode.23 Json.418 Json.122 Json.419;
-    joinpoint Json.413 Json.124:
-        let Json.411 : U64 = 1i64;
-        let Json.410 : U64 = CallByName Num.20 Json.120 Json.411;
-        let Json.409 : {List U8, U64} = Struct {Json.124, Json.410};
-        ret Json.409;
+    dec Json.400;
+    let Json.118 : List U8 = StructAtIndex 0 Json.399;
+    inc Json.118;
+    let Json.119 : U64 = StructAtIndex 1 Json.399;
+    dec Json.399;
+    let Json.427 : I64 = 34i64;
+    let Json.426 : U8 = CallByName Num.125 Json.427;
+    let Json.424 : List U8 = CallByName List.4 Json.118 Json.426;
+    let Json.425 : List U8 = CallByName Str.12 Json.120;
+    let Json.421 : List U8 = CallByName List.8 Json.424 Json.425;
+    let Json.423 : I64 = 34i64;
+    let Json.422 : U8 = CallByName Num.125 Json.423;
+    let Json.418 : List U8 = CallByName List.4 Json.421 Json.422;
+    let Json.420 : I64 = 58i64;
+    let Json.419 : U8 = CallByName Num.125 Json.420;
+    let Json.416 : List U8 = CallByName List.4 Json.418 Json.419;
+    let Json.417 : {} = Struct {};
+    let Json.122 : List U8 = CallByName Encode.23 Json.416 Json.121 Json.417;
+    joinpoint Json.411 Json.123:
+        let Json.409 : U64 = 1i64;
+        let Json.408 : U64 = CallByName Num.20 Json.119 Json.409;
+        let Json.407 : {List U8, U64} = Struct {Json.123, Json.408};
+        ret Json.407;
     in
-    let Json.417 : U64 = 1i64;
-    let Json.414 : Int1 = CallByName Num.24 Json.120 Json.417;
-    if Json.414 then
-        let Json.416 : I32 = 44i64;
-        let Json.415 : U8 = CallByName Num.123 Json.416;
-        let Json.412 : List U8 = CallByName List.4 Json.123 Json.415;
-        jump Json.413 Json.412;
+    let Json.415 : U64 = 1i64;
+    let Json.412 : Int1 = CallByName Num.24 Json.119 Json.415;
+    if Json.412 then
+        let Json.414 : I64 = 44i64;
+        let Json.413 : U8 = CallByName Num.125 Json.414;
+        let Json.410 : List U8 = CallByName List.4 Json.122 Json.413;
+        jump Json.411 Json.410;
     else
-        jump Json.413 Json.123;
+        jump Json.411 Json.122;
 
-procedure Json.18 (Json.96):
-    let Json.445 : Str = CallByName Encode.22 Json.96;
-    ret Json.445;
+procedure Json.18 (Json.95):
+    let Json.443 : Str = CallByName Encode.22 Json.95;
+    ret Json.443;
 
-procedure Json.20 (Json.112):
-    let Json.397 : List {Str, Str} = CallByName Encode.22 Json.112;
-    ret Json.397;
+procedure Json.20 (Json.111):
+    let Json.395 : List {Str, Str} = CallByName Encode.22 Json.111;
+    ret Json.395;
 
-procedure Json.97 (Json.98, Json.435, Json.96):
-    let Json.444 : I32 = 34i64;
-    let Json.443 : U8 = CallByName Num.123 Json.444;
-    let Json.441 : List U8 = CallByName List.4 Json.98 Json.443;
-    let Json.442 : List U8 = CallByName Str.12 Json.96;
-    let Json.438 : List U8 = CallByName List.8 Json.441 Json.442;
-    let Json.440 : I32 = 34i64;
-    let Json.439 : U8 = CallByName Num.123 Json.440;
-    let Json.437 : List U8 = CallByName List.4 Json.438 Json.439;
-    ret Json.437;
+procedure Json.96 (Json.97, Json.433, Json.95):
+    let Json.442 : I64 = 34i64;
+    let Json.441 : U8 = CallByName Num.125 Json.442;
+    let Json.439 : List U8 = CallByName List.4 Json.97 Json.441;
+    let Json.440 : List U8 = CallByName Str.12 Json.95;
+    let Json.436 : List U8 = CallByName List.8 Json.439 Json.440;
+    let Json.438 : I64 = 34i64;
+    let Json.437 : U8 = CallByName Num.125 Json.438;
+    let Json.435 : List U8 = CallByName List.4 Json.436 Json.437;
+    ret Json.435;
 
-procedure List.133 (List.134, List.135, List.132):
-    let List.426 : {List U8, U64} = CallByName Json.115 List.134 List.135;
-    ret List.426;
+procedure List.137 (List.138, List.139, List.136):
+    let List.455 : {List U8, U64} = CallByName Json.114 List.138 List.139;
+    ret List.455;
 
-procedure List.18 (List.130, List.131, List.132):
-    let List.408 : {List U8, U64} = CallByName List.75 List.130 List.131 List.132;
-    ret List.408;
+procedure List.18 (List.134, List.135, List.136):
+    let List.437 : {List U8, U64} = CallByName List.80 List.134 List.135 List.136;
+    ret List.437;
 
-procedure List.4 (List.101, List.102):
-    let List.407 : U64 = 1i64;
-    let List.406 : List U8 = CallByName List.70 List.101 List.407;
-    let List.405 : List U8 = CallByName List.71 List.406 List.102;
-    ret List.405;
-
-procedure List.6 (#Attr.2):
-    let List.380 : U64 = lowlevel ListLen #Attr.2;
-    ret List.380;
+procedure List.4 (List.105, List.106):
+    let List.436 : U64 = 1i64;
+    let List.435 : List U8 = CallByName List.70 List.105 List.436;
+    let List.434 : List U8 = CallByName List.71 List.435 List.106;
+    ret List.434;
 
 procedure List.6 (#Attr.2):
-    let List.429 : U64 = lowlevel ListLen #Attr.2;
-    ret List.429;
+    let List.409 : U64 = lowlevel ListLen #Attr.2;
+    ret List.409;
+
+procedure List.6 (#Attr.2):
+    let List.458 : U64 = lowlevel ListLen #Attr.2;
+    ret List.458;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.423 : {Str, Str} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.423;
+    let List.452 : {Str, Str} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.452;
 
 procedure List.70 (#Attr.2, #Attr.3):
-    let List.386 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
-    ret List.386;
+    let List.415 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
+    ret List.415;
 
 procedure List.71 (#Attr.2, #Attr.3):
-    let List.384 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
-    ret List.384;
-
-procedure List.75 (List.356, List.357, List.358):
-    let List.412 : U64 = 0i64;
-    let List.413 : U64 = CallByName List.6 List.356;
-    let List.411 : {List U8, U64} = CallByName List.86 List.356 List.357 List.358 List.412 List.413;
-    ret List.411;
+    let List.413 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
+    ret List.413;
 
 procedure List.8 (#Attr.2, #Attr.3):
-    let List.428 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
-    ret List.428;
+    let List.457 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
+    ret List.457;
 
-procedure List.86 (List.439, List.440, List.441, List.442, List.443):
-    joinpoint List.414 List.359 List.360 List.361 List.362 List.363:
-        let List.416 : Int1 = CallByName Num.22 List.362 List.363;
-        if List.416 then
-            let List.422 : {Str, Str} = CallByName List.66 List.359 List.362;
-            let List.417 : {List U8, U64} = CallByName List.133 List.360 List.422 List.361;
-            let List.420 : U64 = 1i64;
-            let List.419 : U64 = CallByName Num.19 List.362 List.420;
-            jump List.414 List.359 List.417 List.361 List.419 List.363;
+procedure List.80 (List.385, List.386, List.387):
+    let List.441 : U64 = 0i64;
+    let List.442 : U64 = CallByName List.6 List.385;
+    let List.440 : {List U8, U64} = CallByName List.90 List.385 List.386 List.387 List.441 List.442;
+    ret List.440;
+
+procedure List.90 (List.468, List.469, List.470, List.471, List.472):
+    joinpoint List.443 List.388 List.389 List.390 List.391 List.392:
+        let List.445 : Int1 = CallByName Num.22 List.391 List.392;
+        if List.445 then
+            let List.451 : {Str, Str} = CallByName List.66 List.388 List.391;
+            let List.446 : {List U8, U64} = CallByName List.137 List.389 List.451 List.390;
+            let List.449 : U64 = 1i64;
+            let List.448 : U64 = CallByName Num.19 List.391 List.449;
+            jump List.443 List.388 List.446 List.390 List.448 List.392;
         else
-            ret List.360;
+            ret List.389;
     in
-    jump List.414 List.439 List.440 List.441 List.442 List.443;
+    jump List.443 List.468 List.469 List.470 List.471 List.472;
 
-procedure Num.123 (#Attr.2):
-    let Num.264 : U8 = lowlevel NumIntCast #Attr.2;
-    ret Num.264;
+procedure Num.125 (#Attr.2):
+    let Num.263 : U8 = lowlevel NumIntCast #Attr.2;
+    ret Num.263;
 
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.267 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.267;
-
-procedure Num.20 (#Attr.2, #Attr.3):
-    let Num.265 : U64 = lowlevel NumSub #Attr.2 #Attr.3;
-    ret Num.265;
-
-procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.268 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.268;
-
-procedure Num.24 (#Attr.2, #Attr.3):
-    let Num.266 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
+    let Num.266 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
     ret Num.266;
 
+procedure Num.20 (#Attr.2, #Attr.3):
+    let Num.264 : U64 = lowlevel NumSub #Attr.2 #Attr.3;
+    ret Num.264;
+
+procedure Num.22 (#Attr.2, #Attr.3):
+    let Num.267 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.267;
+
+procedure Num.24 (#Attr.2, #Attr.3):
+    let Num.265 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
+    ret Num.265;
+
 procedure Str.12 (#Attr.2):
-    let Str.266 : List U8 = lowlevel StrToUtf8 #Attr.2;
-    ret Str.266;
+    let Str.280 : List U8 = lowlevel StrToUtf8 #Attr.2;
+    ret Str.280;
 
 procedure Str.48 (#Attr.2, #Attr.3, #Attr.4):
-    let Str.260 : {U64, Str, Int1, U8} = lowlevel StrFromUtf8Range #Attr.2 #Attr.3 #Attr.4;
-    ret Str.260;
+    let Str.274 : {U64, Str, Int1, U8} = lowlevel StrFromUtf8Range #Attr.2 #Attr.3 #Attr.4;
+    ret Str.274;
 
-procedure Str.9 (Str.73):
-    let Str.258 : U64 = 0i64;
-    let Str.259 : U64 = CallByName List.6 Str.73;
-    let Str.74 : {U64, Str, Int1, U8} = CallByName Str.48 Str.73 Str.258 Str.259;
-    let Str.255 : Int1 = StructAtIndex 2 Str.74;
-    if Str.255 then
-        let Str.257 : Str = StructAtIndex 1 Str.74;
-        inc Str.257;
-        dec Str.74;
-        let Str.256 : [C {U64, U8}, C Str] = TagId(1) Str.257;
-        ret Str.256;
+procedure Str.9 (Str.76):
+    let Str.272 : U64 = 0i64;
+    let Str.273 : U64 = CallByName List.6 Str.76;
+    let Str.77 : {U64, Str, Int1, U8} = CallByName Str.48 Str.76 Str.272 Str.273;
+    let Str.269 : Int1 = StructAtIndex 2 Str.77;
+    if Str.269 then
+        let Str.271 : Str = StructAtIndex 1 Str.77;
+        inc Str.271;
+        dec Str.77;
+        let Str.270 : [C {U64, U8}, C Str] = TagId(1) Str.271;
+        ret Str.270;
     else
-        let Str.253 : U8 = StructAtIndex 3 Str.74;
-        let Str.254 : U64 = StructAtIndex 0 Str.74;
-        dec Str.74;
-        let Str.252 : {U64, U8} = Struct {Str.254, Str.253};
-        let Str.251 : [C {U64, U8}, C Str] = TagId(0) Str.252;
-        ret Str.251;
+        let Str.267 : U8 = StructAtIndex 3 Str.77;
+        let Str.268 : U64 = StructAtIndex 0 Str.77;
+        dec Str.77;
+        let Str.266 : {U64, U8} = Struct {Str.268, Str.267};
+        let Str.265 : [C {U64, U8}, C Str] = TagId(0) Str.266;
+        ret Str.265;
 
 procedure Test.0 ():
     let Test.11 : Str = "foo";

--- a/crates/compiler/test_mono/generated/encode_derived_string.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_string.txt
@@ -2,7 +2,7 @@ procedure Encode.22 (Encode.93):
     ret Encode.93;
 
 procedure Encode.23 (Encode.94, Encode.102, Encode.96):
-    let Encode.106 : List U8 = CallByName Json.97 Encode.94 Encode.96 Encode.102;
+    let Encode.106 : List U8 = CallByName Json.96 Encode.94 Encode.96 Encode.102;
     ret Encode.106;
 
 procedure Encode.25 (Encode.100, Encode.101):
@@ -12,76 +12,76 @@ procedure Encode.25 (Encode.100, Encode.101):
     ret Encode.103;
 
 procedure Json.1 ():
-    let Json.396 : {} = Struct {};
-    ret Json.396;
+    let Json.394 : {} = Struct {};
+    ret Json.394;
 
-procedure Json.18 (Json.96):
-    let Json.397 : Str = CallByName Encode.22 Json.96;
-    ret Json.397;
+procedure Json.18 (Json.95):
+    let Json.395 : Str = CallByName Encode.22 Json.95;
+    ret Json.395;
 
-procedure Json.97 (Json.98, Json.399, Json.96):
-    let Json.408 : I32 = 34i64;
-    let Json.407 : U8 = CallByName Num.123 Json.408;
-    let Json.405 : List U8 = CallByName List.4 Json.98 Json.407;
-    let Json.406 : List U8 = CallByName Str.12 Json.96;
-    let Json.402 : List U8 = CallByName List.8 Json.405 Json.406;
-    let Json.404 : I32 = 34i64;
-    let Json.403 : U8 = CallByName Num.123 Json.404;
-    let Json.401 : List U8 = CallByName List.4 Json.402 Json.403;
-    ret Json.401;
+procedure Json.96 (Json.97, Json.397, Json.95):
+    let Json.406 : I64 = 34i64;
+    let Json.405 : U8 = CallByName Num.125 Json.406;
+    let Json.403 : List U8 = CallByName List.4 Json.97 Json.405;
+    let Json.404 : List U8 = CallByName Str.12 Json.95;
+    let Json.400 : List U8 = CallByName List.8 Json.403 Json.404;
+    let Json.402 : I64 = 34i64;
+    let Json.401 : U8 = CallByName Num.125 Json.402;
+    let Json.399 : List U8 = CallByName List.4 Json.400 Json.401;
+    ret Json.399;
 
-procedure List.4 (List.101, List.102):
-    let List.389 : U64 = 1i64;
-    let List.388 : List U8 = CallByName List.70 List.101 List.389;
-    let List.387 : List U8 = CallByName List.71 List.388 List.102;
-    ret List.387;
+procedure List.4 (List.105, List.106):
+    let List.418 : U64 = 1i64;
+    let List.417 : List U8 = CallByName List.70 List.105 List.418;
+    let List.416 : List U8 = CallByName List.71 List.417 List.106;
+    ret List.416;
 
 procedure List.6 (#Attr.2):
-    let List.380 : U64 = lowlevel ListLen #Attr.2;
-    ret List.380;
+    let List.409 : U64 = lowlevel ListLen #Attr.2;
+    ret List.409;
 
 procedure List.70 (#Attr.2, #Attr.3):
-    let List.386 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
-    ret List.386;
+    let List.415 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
+    ret List.415;
 
 procedure List.71 (#Attr.2, #Attr.3):
-    let List.384 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
-    ret List.384;
+    let List.413 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
+    ret List.413;
 
 procedure List.8 (#Attr.2, #Attr.3):
-    let List.390 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
-    ret List.390;
+    let List.419 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
+    ret List.419;
 
-procedure Num.123 (#Attr.2):
-    let Num.258 : U8 = lowlevel NumIntCast #Attr.2;
-    ret Num.258;
+procedure Num.125 (#Attr.2):
+    let Num.257 : U8 = lowlevel NumIntCast #Attr.2;
+    ret Num.257;
 
 procedure Str.12 (#Attr.2):
-    let Str.265 : List U8 = lowlevel StrToUtf8 #Attr.2;
-    ret Str.265;
+    let Str.279 : List U8 = lowlevel StrToUtf8 #Attr.2;
+    ret Str.279;
 
 procedure Str.48 (#Attr.2, #Attr.3, #Attr.4):
-    let Str.260 : {U64, Str, Int1, U8} = lowlevel StrFromUtf8Range #Attr.2 #Attr.3 #Attr.4;
-    ret Str.260;
+    let Str.274 : {U64, Str, Int1, U8} = lowlevel StrFromUtf8Range #Attr.2 #Attr.3 #Attr.4;
+    ret Str.274;
 
-procedure Str.9 (Str.73):
-    let Str.258 : U64 = 0i64;
-    let Str.259 : U64 = CallByName List.6 Str.73;
-    let Str.74 : {U64, Str, Int1, U8} = CallByName Str.48 Str.73 Str.258 Str.259;
-    let Str.255 : Int1 = StructAtIndex 2 Str.74;
-    if Str.255 then
-        let Str.257 : Str = StructAtIndex 1 Str.74;
-        inc Str.257;
-        dec Str.74;
-        let Str.256 : [C {U64, U8}, C Str] = TagId(1) Str.257;
-        ret Str.256;
+procedure Str.9 (Str.76):
+    let Str.272 : U64 = 0i64;
+    let Str.273 : U64 = CallByName List.6 Str.76;
+    let Str.77 : {U64, Str, Int1, U8} = CallByName Str.48 Str.76 Str.272 Str.273;
+    let Str.269 : Int1 = StructAtIndex 2 Str.77;
+    if Str.269 then
+        let Str.271 : Str = StructAtIndex 1 Str.77;
+        inc Str.271;
+        dec Str.77;
+        let Str.270 : [C {U64, U8}, C Str] = TagId(1) Str.271;
+        ret Str.270;
     else
-        let Str.253 : U8 = StructAtIndex 3 Str.74;
-        let Str.254 : U64 = StructAtIndex 0 Str.74;
-        dec Str.74;
-        let Str.252 : {U64, U8} = Struct {Str.254, Str.253};
-        let Str.251 : [C {U64, U8}, C Str] = TagId(0) Str.252;
-        ret Str.251;
+        let Str.267 : U8 = StructAtIndex 3 Str.77;
+        let Str.268 : U64 = StructAtIndex 0 Str.77;
+        dec Str.77;
+        let Str.266 : {U64, U8} = Struct {Str.268, Str.267};
+        let Str.265 : [C {U64, U8}, C Str] = TagId(0) Str.266;
+        ret Str.265;
 
 procedure Test.0 ():
     let Test.9 : Str = "abc";

--- a/crates/compiler/test_mono/generated/encode_derived_tag_one_field_string.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_tag_one_field_string.txt
@@ -27,11 +27,11 @@ procedure Encode.23 (Encode.94, Encode.102, Encode.96):
     ret Encode.106;
 
 procedure Encode.23 (Encode.94, Encode.102, Encode.96):
-    let Encode.113 : List U8 = CallByName Json.127 Encode.94 Encode.96 Encode.102;
+    let Encode.113 : List U8 = CallByName Json.126 Encode.94 Encode.96 Encode.102;
     ret Encode.113;
 
 procedure Encode.23 (Encode.94, Encode.102, Encode.96):
-    let Encode.116 : List U8 = CallByName Json.97 Encode.94 Encode.96 Encode.102;
+    let Encode.116 : List U8 = CallByName Json.96 Encode.94 Encode.96 Encode.102;
     ret Encode.116;
 
 procedure Encode.25 (Encode.100, Encode.101):
@@ -41,195 +41,195 @@ procedure Encode.25 (Encode.100, Encode.101):
     ret Encode.103;
 
 procedure Json.1 ():
-    let Json.396 : {} = Struct {};
-    ret Json.396;
+    let Json.394 : {} = Struct {};
+    ret Json.394;
 
-procedure Json.127 (Json.128, Json.399, #Attr.12):
-    let Json.126 : List Str = StructAtIndex 1 #Attr.12;
-    inc Json.126;
-    let Json.125 : Str = StructAtIndex 0 #Attr.12;
+procedure Json.126 (Json.127, Json.397, #Attr.12):
+    let Json.125 : List Str = StructAtIndex 1 #Attr.12;
     inc Json.125;
+    let Json.124 : Str = StructAtIndex 0 #Attr.12;
+    inc Json.124;
     dec #Attr.12;
-    let Json.437 : I32 = 123i64;
-    let Json.436 : U8 = CallByName Num.123 Json.437;
-    let Json.433 : List U8 = CallByName List.4 Json.128 Json.436;
-    let Json.435 : I32 = 34i64;
-    let Json.434 : U8 = CallByName Num.123 Json.435;
-    let Json.431 : List U8 = CallByName List.4 Json.433 Json.434;
-    let Json.432 : List U8 = CallByName Str.12 Json.125;
-    let Json.428 : List U8 = CallByName List.8 Json.431 Json.432;
-    let Json.430 : I32 = 34i64;
-    let Json.429 : U8 = CallByName Num.123 Json.430;
-    let Json.425 : List U8 = CallByName List.4 Json.428 Json.429;
-    let Json.427 : I32 = 58i64;
-    let Json.426 : U8 = CallByName Num.123 Json.427;
-    let Json.422 : List U8 = CallByName List.4 Json.425 Json.426;
-    let Json.424 : I32 = 91i64;
-    let Json.423 : U8 = CallByName Num.123 Json.424;
-    let Json.130 : List U8 = CallByName List.4 Json.422 Json.423;
-    let Json.421 : U64 = CallByName List.6 Json.126;
-    let Json.409 : {List U8, U64} = Struct {Json.130, Json.421};
-    let Json.410 : {} = Struct {};
-    let Json.408 : {List U8, U64} = CallByName List.18 Json.126 Json.409 Json.410;
-    dec Json.126;
-    let Json.132 : List U8 = StructAtIndex 0 Json.408;
+    let Json.435 : I64 = 123i64;
+    let Json.434 : U8 = CallByName Num.125 Json.435;
+    let Json.431 : List U8 = CallByName List.4 Json.127 Json.434;
+    let Json.433 : I64 = 34i64;
+    let Json.432 : U8 = CallByName Num.125 Json.433;
+    let Json.429 : List U8 = CallByName List.4 Json.431 Json.432;
+    let Json.430 : List U8 = CallByName Str.12 Json.124;
+    let Json.426 : List U8 = CallByName List.8 Json.429 Json.430;
+    let Json.428 : I64 = 34i64;
+    let Json.427 : U8 = CallByName Num.125 Json.428;
+    let Json.423 : List U8 = CallByName List.4 Json.426 Json.427;
+    let Json.425 : I64 = 58i64;
+    let Json.424 : U8 = CallByName Num.125 Json.425;
+    let Json.420 : List U8 = CallByName List.4 Json.423 Json.424;
+    let Json.422 : I64 = 91i64;
+    let Json.421 : U8 = CallByName Num.125 Json.422;
+    let Json.129 : List U8 = CallByName List.4 Json.420 Json.421;
+    let Json.419 : U64 = CallByName List.6 Json.125;
+    let Json.407 : {List U8, U64} = Struct {Json.129, Json.419};
+    let Json.408 : {} = Struct {};
+    let Json.406 : {List U8, U64} = CallByName List.18 Json.125 Json.407 Json.408;
+    dec Json.125;
+    let Json.131 : List U8 = StructAtIndex 0 Json.406;
+    inc Json.131;
+    dec Json.406;
+    let Json.405 : I64 = 93i64;
+    let Json.404 : U8 = CallByName Num.125 Json.405;
+    let Json.401 : List U8 = CallByName List.4 Json.131 Json.404;
+    let Json.403 : I64 = 125i64;
+    let Json.402 : U8 = CallByName Num.125 Json.403;
+    let Json.400 : List U8 = CallByName List.4 Json.401 Json.402;
+    ret Json.400;
+
+procedure Json.128 (Json.399, Json.134):
+    let Json.132 : List U8 = StructAtIndex 0 Json.399;
     inc Json.132;
-    dec Json.408;
-    let Json.407 : I32 = 93i64;
-    let Json.406 : U8 = CallByName Num.123 Json.407;
-    let Json.403 : List U8 = CallByName List.4 Json.132 Json.406;
-    let Json.405 : I32 = 125i64;
-    let Json.404 : U8 = CallByName Num.123 Json.405;
-    let Json.402 : List U8 = CallByName List.4 Json.403 Json.404;
-    ret Json.402;
-
-procedure Json.129 (Json.401, Json.135):
-    let Json.133 : List U8 = StructAtIndex 0 Json.401;
-    inc Json.133;
-    let Json.134 : U64 = StructAtIndex 1 Json.401;
-    dec Json.401;
-    let Json.420 : {} = Struct {};
-    let Json.136 : List U8 = CallByName Encode.23 Json.133 Json.135 Json.420;
-    joinpoint Json.415 Json.137:
-        let Json.413 : U64 = 1i64;
-        let Json.412 : U64 = CallByName Num.20 Json.134 Json.413;
-        let Json.411 : {List U8, U64} = Struct {Json.137, Json.412};
-        ret Json.411;
+    let Json.133 : U64 = StructAtIndex 1 Json.399;
+    dec Json.399;
+    let Json.418 : {} = Struct {};
+    let Json.135 : List U8 = CallByName Encode.23 Json.132 Json.134 Json.418;
+    joinpoint Json.413 Json.136:
+        let Json.411 : U64 = 1i64;
+        let Json.410 : U64 = CallByName Num.20 Json.133 Json.411;
+        let Json.409 : {List U8, U64} = Struct {Json.136, Json.410};
+        ret Json.409;
     in
-    let Json.419 : U64 = 1i64;
-    let Json.416 : Int1 = CallByName Num.24 Json.134 Json.419;
-    if Json.416 then
-        let Json.418 : I32 = 44i64;
-        let Json.417 : U8 = CallByName Num.123 Json.418;
-        let Json.414 : List U8 = CallByName List.4 Json.136 Json.417;
-        jump Json.415 Json.414;
+    let Json.417 : U64 = 1i64;
+    let Json.414 : Int1 = CallByName Num.24 Json.133 Json.417;
+    if Json.414 then
+        let Json.416 : I64 = 44i64;
+        let Json.415 : U8 = CallByName Num.125 Json.416;
+        let Json.412 : List U8 = CallByName List.4 Json.135 Json.415;
+        jump Json.413 Json.412;
     else
-        jump Json.415 Json.136;
+        jump Json.413 Json.135;
 
-procedure Json.18 (Json.96):
-    let Json.438 : Str = CallByName Encode.22 Json.96;
-    ret Json.438;
+procedure Json.18 (Json.95):
+    let Json.436 : Str = CallByName Encode.22 Json.95;
+    ret Json.436;
 
-procedure Json.21 (Json.125, Json.126):
-    let Json.398 : {Str, List Str} = Struct {Json.125, Json.126};
-    let Json.397 : {Str, List Str} = CallByName Encode.22 Json.398;
-    ret Json.397;
+procedure Json.21 (Json.124, Json.125):
+    let Json.396 : {Str, List Str} = Struct {Json.124, Json.125};
+    let Json.395 : {Str, List Str} = CallByName Encode.22 Json.396;
+    ret Json.395;
 
-procedure Json.97 (Json.98, Json.440, Json.96):
-    let Json.449 : I32 = 34i64;
-    let Json.448 : U8 = CallByName Num.123 Json.449;
-    let Json.446 : List U8 = CallByName List.4 Json.98 Json.448;
-    let Json.447 : List U8 = CallByName Str.12 Json.96;
-    let Json.443 : List U8 = CallByName List.8 Json.446 Json.447;
-    let Json.445 : I32 = 34i64;
-    let Json.444 : U8 = CallByName Num.123 Json.445;
-    let Json.442 : List U8 = CallByName List.4 Json.443 Json.444;
-    ret Json.442;
+procedure Json.96 (Json.97, Json.438, Json.95):
+    let Json.447 : I64 = 34i64;
+    let Json.446 : U8 = CallByName Num.125 Json.447;
+    let Json.444 : List U8 = CallByName List.4 Json.97 Json.446;
+    let Json.445 : List U8 = CallByName Str.12 Json.95;
+    let Json.441 : List U8 = CallByName List.8 Json.444 Json.445;
+    let Json.443 : I64 = 34i64;
+    let Json.442 : U8 = CallByName Num.125 Json.443;
+    let Json.440 : List U8 = CallByName List.4 Json.441 Json.442;
+    ret Json.440;
 
-procedure List.133 (List.134, List.135, List.132):
-    let List.432 : {List U8, U64} = CallByName Json.129 List.134 List.135;
-    ret List.432;
+procedure List.137 (List.138, List.139, List.136):
+    let List.461 : {List U8, U64} = CallByName Json.128 List.138 List.139;
+    ret List.461;
 
-procedure List.18 (List.130, List.131, List.132):
-    let List.414 : {List U8, U64} = CallByName List.75 List.130 List.131 List.132;
-    ret List.414;
+procedure List.18 (List.134, List.135, List.136):
+    let List.443 : {List U8, U64} = CallByName List.80 List.134 List.135 List.136;
+    ret List.443;
 
-procedure List.4 (List.101, List.102):
-    let List.413 : U64 = 1i64;
-    let List.412 : List U8 = CallByName List.70 List.101 List.413;
-    let List.411 : List U8 = CallByName List.71 List.412 List.102;
-    ret List.411;
-
-procedure List.6 (#Attr.2):
-    let List.380 : U64 = lowlevel ListLen #Attr.2;
-    ret List.380;
+procedure List.4 (List.105, List.106):
+    let List.442 : U64 = 1i64;
+    let List.441 : List U8 = CallByName List.70 List.105 List.442;
+    let List.440 : List U8 = CallByName List.71 List.441 List.106;
+    ret List.440;
 
 procedure List.6 (#Attr.2):
-    let List.433 : U64 = lowlevel ListLen #Attr.2;
-    ret List.433;
+    let List.409 : U64 = lowlevel ListLen #Attr.2;
+    ret List.409;
+
+procedure List.6 (#Attr.2):
+    let List.462 : U64 = lowlevel ListLen #Attr.2;
+    ret List.462;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.429 : Str = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.429;
+    let List.458 : Str = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.458;
 
 procedure List.70 (#Attr.2, #Attr.3):
-    let List.386 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
-    ret List.386;
+    let List.415 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
+    ret List.415;
 
 procedure List.71 (#Attr.2, #Attr.3):
-    let List.384 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
-    ret List.384;
-
-procedure List.75 (List.356, List.357, List.358):
-    let List.418 : U64 = 0i64;
-    let List.419 : U64 = CallByName List.6 List.356;
-    let List.417 : {List U8, U64} = CallByName List.86 List.356 List.357 List.358 List.418 List.419;
-    ret List.417;
+    let List.413 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
+    ret List.413;
 
 procedure List.8 (#Attr.2, #Attr.3):
-    let List.435 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
-    ret List.435;
+    let List.464 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
+    ret List.464;
 
-procedure List.86 (List.445, List.446, List.447, List.448, List.449):
-    joinpoint List.420 List.359 List.360 List.361 List.362 List.363:
-        let List.422 : Int1 = CallByName Num.22 List.362 List.363;
-        if List.422 then
-            let List.428 : Str = CallByName List.66 List.359 List.362;
-            let List.423 : {List U8, U64} = CallByName List.133 List.360 List.428 List.361;
-            let List.426 : U64 = 1i64;
-            let List.425 : U64 = CallByName Num.19 List.362 List.426;
-            jump List.420 List.359 List.423 List.361 List.425 List.363;
+procedure List.80 (List.385, List.386, List.387):
+    let List.447 : U64 = 0i64;
+    let List.448 : U64 = CallByName List.6 List.385;
+    let List.446 : {List U8, U64} = CallByName List.90 List.385 List.386 List.387 List.447 List.448;
+    ret List.446;
+
+procedure List.90 (List.474, List.475, List.476, List.477, List.478):
+    joinpoint List.449 List.388 List.389 List.390 List.391 List.392:
+        let List.451 : Int1 = CallByName Num.22 List.391 List.392;
+        if List.451 then
+            let List.457 : Str = CallByName List.66 List.388 List.391;
+            let List.452 : {List U8, U64} = CallByName List.137 List.389 List.457 List.390;
+            let List.455 : U64 = 1i64;
+            let List.454 : U64 = CallByName Num.19 List.391 List.455;
+            jump List.449 List.388 List.452 List.390 List.454 List.392;
         else
-            ret List.360;
+            ret List.389;
     in
-    jump List.420 List.445 List.446 List.447 List.448 List.449;
+    jump List.449 List.474 List.475 List.476 List.477 List.478;
 
-procedure Num.123 (#Attr.2):
-    let Num.266 : U8 = lowlevel NumIntCast #Attr.2;
-    ret Num.266;
+procedure Num.125 (#Attr.2):
+    let Num.265 : U8 = lowlevel NumIntCast #Attr.2;
+    ret Num.265;
 
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.269 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.269;
-
-procedure Num.20 (#Attr.2, #Attr.3):
-    let Num.267 : U64 = lowlevel NumSub #Attr.2 #Attr.3;
-    ret Num.267;
-
-procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.270 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.270;
-
-procedure Num.24 (#Attr.2, #Attr.3):
-    let Num.268 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
+    let Num.268 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
     ret Num.268;
 
+procedure Num.20 (#Attr.2, #Attr.3):
+    let Num.266 : U64 = lowlevel NumSub #Attr.2 #Attr.3;
+    ret Num.266;
+
+procedure Num.22 (#Attr.2, #Attr.3):
+    let Num.269 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.269;
+
+procedure Num.24 (#Attr.2, #Attr.3):
+    let Num.267 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
+    ret Num.267;
+
 procedure Str.12 (#Attr.2):
-    let Str.266 : List U8 = lowlevel StrToUtf8 #Attr.2;
-    ret Str.266;
+    let Str.280 : List U8 = lowlevel StrToUtf8 #Attr.2;
+    ret Str.280;
 
 procedure Str.48 (#Attr.2, #Attr.3, #Attr.4):
-    let Str.260 : {U64, Str, Int1, U8} = lowlevel StrFromUtf8Range #Attr.2 #Attr.3 #Attr.4;
-    ret Str.260;
+    let Str.274 : {U64, Str, Int1, U8} = lowlevel StrFromUtf8Range #Attr.2 #Attr.3 #Attr.4;
+    ret Str.274;
 
-procedure Str.9 (Str.73):
-    let Str.258 : U64 = 0i64;
-    let Str.259 : U64 = CallByName List.6 Str.73;
-    let Str.74 : {U64, Str, Int1, U8} = CallByName Str.48 Str.73 Str.258 Str.259;
-    let Str.255 : Int1 = StructAtIndex 2 Str.74;
-    if Str.255 then
-        let Str.257 : Str = StructAtIndex 1 Str.74;
-        inc Str.257;
-        dec Str.74;
-        let Str.256 : [C {U64, U8}, C Str] = TagId(1) Str.257;
-        ret Str.256;
+procedure Str.9 (Str.76):
+    let Str.272 : U64 = 0i64;
+    let Str.273 : U64 = CallByName List.6 Str.76;
+    let Str.77 : {U64, Str, Int1, U8} = CallByName Str.48 Str.76 Str.272 Str.273;
+    let Str.269 : Int1 = StructAtIndex 2 Str.77;
+    if Str.269 then
+        let Str.271 : Str = StructAtIndex 1 Str.77;
+        inc Str.271;
+        dec Str.77;
+        let Str.270 : [C {U64, U8}, C Str] = TagId(1) Str.271;
+        ret Str.270;
     else
-        let Str.253 : U8 = StructAtIndex 3 Str.74;
-        let Str.254 : U64 = StructAtIndex 0 Str.74;
-        dec Str.74;
-        let Str.252 : {U64, U8} = Struct {Str.254, Str.253};
-        let Str.251 : [C {U64, U8}, C Str] = TagId(0) Str.252;
-        ret Str.251;
+        let Str.267 : U8 = StructAtIndex 3 Str.77;
+        let Str.268 : U64 = StructAtIndex 0 Str.77;
+        dec Str.77;
+        let Str.266 : {U64, U8} = Struct {Str.268, Str.267};
+        let Str.265 : [C {U64, U8}, C Str] = TagId(0) Str.266;
+        ret Str.265;
 
 procedure Test.0 ():
     let Test.12 : Str = "foo";

--- a/crates/compiler/test_mono/generated/encode_derived_tag_two_payloads_string.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_tag_two_payloads_string.txt
@@ -33,11 +33,11 @@ procedure Encode.23 (Encode.94, Encode.102, Encode.96):
     ret Encode.106;
 
 procedure Encode.23 (Encode.94, Encode.102, Encode.96):
-    let Encode.113 : List U8 = CallByName Json.127 Encode.94 Encode.96 Encode.102;
+    let Encode.113 : List U8 = CallByName Json.126 Encode.94 Encode.96 Encode.102;
     ret Encode.113;
 
 procedure Encode.23 (Encode.94, Encode.102, Encode.96):
-    let Encode.117 : List U8 = CallByName Json.97 Encode.94 Encode.96 Encode.102;
+    let Encode.117 : List U8 = CallByName Json.96 Encode.94 Encode.96 Encode.102;
     ret Encode.117;
 
 procedure Encode.25 (Encode.100, Encode.101):
@@ -47,195 +47,195 @@ procedure Encode.25 (Encode.100, Encode.101):
     ret Encode.103;
 
 procedure Json.1 ():
-    let Json.396 : {} = Struct {};
-    ret Json.396;
+    let Json.394 : {} = Struct {};
+    ret Json.394;
 
-procedure Json.127 (Json.128, Json.399, #Attr.12):
-    let Json.126 : List Str = StructAtIndex 1 #Attr.12;
-    inc Json.126;
-    let Json.125 : Str = StructAtIndex 0 #Attr.12;
+procedure Json.126 (Json.127, Json.397, #Attr.12):
+    let Json.125 : List Str = StructAtIndex 1 #Attr.12;
     inc Json.125;
+    let Json.124 : Str = StructAtIndex 0 #Attr.12;
+    inc Json.124;
     dec #Attr.12;
-    let Json.437 : I32 = 123i64;
-    let Json.436 : U8 = CallByName Num.123 Json.437;
-    let Json.433 : List U8 = CallByName List.4 Json.128 Json.436;
-    let Json.435 : I32 = 34i64;
-    let Json.434 : U8 = CallByName Num.123 Json.435;
-    let Json.431 : List U8 = CallByName List.4 Json.433 Json.434;
-    let Json.432 : List U8 = CallByName Str.12 Json.125;
-    let Json.428 : List U8 = CallByName List.8 Json.431 Json.432;
-    let Json.430 : I32 = 34i64;
-    let Json.429 : U8 = CallByName Num.123 Json.430;
-    let Json.425 : List U8 = CallByName List.4 Json.428 Json.429;
-    let Json.427 : I32 = 58i64;
-    let Json.426 : U8 = CallByName Num.123 Json.427;
-    let Json.422 : List U8 = CallByName List.4 Json.425 Json.426;
-    let Json.424 : I32 = 91i64;
-    let Json.423 : U8 = CallByName Num.123 Json.424;
-    let Json.130 : List U8 = CallByName List.4 Json.422 Json.423;
-    let Json.421 : U64 = CallByName List.6 Json.126;
-    let Json.409 : {List U8, U64} = Struct {Json.130, Json.421};
-    let Json.410 : {} = Struct {};
-    let Json.408 : {List U8, U64} = CallByName List.18 Json.126 Json.409 Json.410;
-    dec Json.126;
-    let Json.132 : List U8 = StructAtIndex 0 Json.408;
+    let Json.435 : I64 = 123i64;
+    let Json.434 : U8 = CallByName Num.125 Json.435;
+    let Json.431 : List U8 = CallByName List.4 Json.127 Json.434;
+    let Json.433 : I64 = 34i64;
+    let Json.432 : U8 = CallByName Num.125 Json.433;
+    let Json.429 : List U8 = CallByName List.4 Json.431 Json.432;
+    let Json.430 : List U8 = CallByName Str.12 Json.124;
+    let Json.426 : List U8 = CallByName List.8 Json.429 Json.430;
+    let Json.428 : I64 = 34i64;
+    let Json.427 : U8 = CallByName Num.125 Json.428;
+    let Json.423 : List U8 = CallByName List.4 Json.426 Json.427;
+    let Json.425 : I64 = 58i64;
+    let Json.424 : U8 = CallByName Num.125 Json.425;
+    let Json.420 : List U8 = CallByName List.4 Json.423 Json.424;
+    let Json.422 : I64 = 91i64;
+    let Json.421 : U8 = CallByName Num.125 Json.422;
+    let Json.129 : List U8 = CallByName List.4 Json.420 Json.421;
+    let Json.419 : U64 = CallByName List.6 Json.125;
+    let Json.407 : {List U8, U64} = Struct {Json.129, Json.419};
+    let Json.408 : {} = Struct {};
+    let Json.406 : {List U8, U64} = CallByName List.18 Json.125 Json.407 Json.408;
+    dec Json.125;
+    let Json.131 : List U8 = StructAtIndex 0 Json.406;
+    inc Json.131;
+    dec Json.406;
+    let Json.405 : I64 = 93i64;
+    let Json.404 : U8 = CallByName Num.125 Json.405;
+    let Json.401 : List U8 = CallByName List.4 Json.131 Json.404;
+    let Json.403 : I64 = 125i64;
+    let Json.402 : U8 = CallByName Num.125 Json.403;
+    let Json.400 : List U8 = CallByName List.4 Json.401 Json.402;
+    ret Json.400;
+
+procedure Json.128 (Json.399, Json.134):
+    let Json.132 : List U8 = StructAtIndex 0 Json.399;
     inc Json.132;
-    dec Json.408;
-    let Json.407 : I32 = 93i64;
-    let Json.406 : U8 = CallByName Num.123 Json.407;
-    let Json.403 : List U8 = CallByName List.4 Json.132 Json.406;
-    let Json.405 : I32 = 125i64;
-    let Json.404 : U8 = CallByName Num.123 Json.405;
-    let Json.402 : List U8 = CallByName List.4 Json.403 Json.404;
-    ret Json.402;
-
-procedure Json.129 (Json.401, Json.135):
-    let Json.133 : List U8 = StructAtIndex 0 Json.401;
-    inc Json.133;
-    let Json.134 : U64 = StructAtIndex 1 Json.401;
-    dec Json.401;
-    let Json.420 : {} = Struct {};
-    let Json.136 : List U8 = CallByName Encode.23 Json.133 Json.135 Json.420;
-    joinpoint Json.415 Json.137:
-        let Json.413 : U64 = 1i64;
-        let Json.412 : U64 = CallByName Num.20 Json.134 Json.413;
-        let Json.411 : {List U8, U64} = Struct {Json.137, Json.412};
-        ret Json.411;
+    let Json.133 : U64 = StructAtIndex 1 Json.399;
+    dec Json.399;
+    let Json.418 : {} = Struct {};
+    let Json.135 : List U8 = CallByName Encode.23 Json.132 Json.134 Json.418;
+    joinpoint Json.413 Json.136:
+        let Json.411 : U64 = 1i64;
+        let Json.410 : U64 = CallByName Num.20 Json.133 Json.411;
+        let Json.409 : {List U8, U64} = Struct {Json.136, Json.410};
+        ret Json.409;
     in
-    let Json.419 : U64 = 1i64;
-    let Json.416 : Int1 = CallByName Num.24 Json.134 Json.419;
-    if Json.416 then
-        let Json.418 : I32 = 44i64;
-        let Json.417 : U8 = CallByName Num.123 Json.418;
-        let Json.414 : List U8 = CallByName List.4 Json.136 Json.417;
-        jump Json.415 Json.414;
+    let Json.417 : U64 = 1i64;
+    let Json.414 : Int1 = CallByName Num.24 Json.133 Json.417;
+    if Json.414 then
+        let Json.416 : I64 = 44i64;
+        let Json.415 : U8 = CallByName Num.125 Json.416;
+        let Json.412 : List U8 = CallByName List.4 Json.135 Json.415;
+        jump Json.413 Json.412;
     else
-        jump Json.415 Json.136;
+        jump Json.413 Json.135;
 
-procedure Json.18 (Json.96):
-    let Json.450 : Str = CallByName Encode.22 Json.96;
-    ret Json.450;
+procedure Json.18 (Json.95):
+    let Json.448 : Str = CallByName Encode.22 Json.95;
+    ret Json.448;
 
-procedure Json.21 (Json.125, Json.126):
-    let Json.398 : {Str, List Str} = Struct {Json.125, Json.126};
-    let Json.397 : {Str, List Str} = CallByName Encode.22 Json.398;
-    ret Json.397;
+procedure Json.21 (Json.124, Json.125):
+    let Json.396 : {Str, List Str} = Struct {Json.124, Json.125};
+    let Json.395 : {Str, List Str} = CallByName Encode.22 Json.396;
+    ret Json.395;
 
-procedure Json.97 (Json.98, Json.440, Json.96):
-    let Json.449 : I32 = 34i64;
-    let Json.448 : U8 = CallByName Num.123 Json.449;
-    let Json.446 : List U8 = CallByName List.4 Json.98 Json.448;
-    let Json.447 : List U8 = CallByName Str.12 Json.96;
-    let Json.443 : List U8 = CallByName List.8 Json.446 Json.447;
-    let Json.445 : I32 = 34i64;
-    let Json.444 : U8 = CallByName Num.123 Json.445;
-    let Json.442 : List U8 = CallByName List.4 Json.443 Json.444;
-    ret Json.442;
+procedure Json.96 (Json.97, Json.438, Json.95):
+    let Json.447 : I64 = 34i64;
+    let Json.446 : U8 = CallByName Num.125 Json.447;
+    let Json.444 : List U8 = CallByName List.4 Json.97 Json.446;
+    let Json.445 : List U8 = CallByName Str.12 Json.95;
+    let Json.441 : List U8 = CallByName List.8 Json.444 Json.445;
+    let Json.443 : I64 = 34i64;
+    let Json.442 : U8 = CallByName Num.125 Json.443;
+    let Json.440 : List U8 = CallByName List.4 Json.441 Json.442;
+    ret Json.440;
 
-procedure List.133 (List.134, List.135, List.132):
-    let List.432 : {List U8, U64} = CallByName Json.129 List.134 List.135;
-    ret List.432;
+procedure List.137 (List.138, List.139, List.136):
+    let List.461 : {List U8, U64} = CallByName Json.128 List.138 List.139;
+    ret List.461;
 
-procedure List.18 (List.130, List.131, List.132):
-    let List.414 : {List U8, U64} = CallByName List.75 List.130 List.131 List.132;
-    ret List.414;
+procedure List.18 (List.134, List.135, List.136):
+    let List.443 : {List U8, U64} = CallByName List.80 List.134 List.135 List.136;
+    ret List.443;
 
-procedure List.4 (List.101, List.102):
-    let List.413 : U64 = 1i64;
-    let List.412 : List U8 = CallByName List.70 List.101 List.413;
-    let List.411 : List U8 = CallByName List.71 List.412 List.102;
-    ret List.411;
-
-procedure List.6 (#Attr.2):
-    let List.380 : U64 = lowlevel ListLen #Attr.2;
-    ret List.380;
+procedure List.4 (List.105, List.106):
+    let List.442 : U64 = 1i64;
+    let List.441 : List U8 = CallByName List.70 List.105 List.442;
+    let List.440 : List U8 = CallByName List.71 List.441 List.106;
+    ret List.440;
 
 procedure List.6 (#Attr.2):
-    let List.433 : U64 = lowlevel ListLen #Attr.2;
-    ret List.433;
+    let List.409 : U64 = lowlevel ListLen #Attr.2;
+    ret List.409;
+
+procedure List.6 (#Attr.2):
+    let List.462 : U64 = lowlevel ListLen #Attr.2;
+    ret List.462;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.429 : Str = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.429;
+    let List.458 : Str = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.458;
 
 procedure List.70 (#Attr.2, #Attr.3):
-    let List.386 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
-    ret List.386;
+    let List.415 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
+    ret List.415;
 
 procedure List.71 (#Attr.2, #Attr.3):
-    let List.384 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
-    ret List.384;
-
-procedure List.75 (List.356, List.357, List.358):
-    let List.418 : U64 = 0i64;
-    let List.419 : U64 = CallByName List.6 List.356;
-    let List.417 : {List U8, U64} = CallByName List.86 List.356 List.357 List.358 List.418 List.419;
-    ret List.417;
+    let List.413 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
+    ret List.413;
 
 procedure List.8 (#Attr.2, #Attr.3):
-    let List.435 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
-    ret List.435;
+    let List.464 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
+    ret List.464;
 
-procedure List.86 (List.445, List.446, List.447, List.448, List.449):
-    joinpoint List.420 List.359 List.360 List.361 List.362 List.363:
-        let List.422 : Int1 = CallByName Num.22 List.362 List.363;
-        if List.422 then
-            let List.428 : Str = CallByName List.66 List.359 List.362;
-            let List.423 : {List U8, U64} = CallByName List.133 List.360 List.428 List.361;
-            let List.426 : U64 = 1i64;
-            let List.425 : U64 = CallByName Num.19 List.362 List.426;
-            jump List.420 List.359 List.423 List.361 List.425 List.363;
+procedure List.80 (List.385, List.386, List.387):
+    let List.447 : U64 = 0i64;
+    let List.448 : U64 = CallByName List.6 List.385;
+    let List.446 : {List U8, U64} = CallByName List.90 List.385 List.386 List.387 List.447 List.448;
+    ret List.446;
+
+procedure List.90 (List.474, List.475, List.476, List.477, List.478):
+    joinpoint List.449 List.388 List.389 List.390 List.391 List.392:
+        let List.451 : Int1 = CallByName Num.22 List.391 List.392;
+        if List.451 then
+            let List.457 : Str = CallByName List.66 List.388 List.391;
+            let List.452 : {List U8, U64} = CallByName List.137 List.389 List.457 List.390;
+            let List.455 : U64 = 1i64;
+            let List.454 : U64 = CallByName Num.19 List.391 List.455;
+            jump List.449 List.388 List.452 List.390 List.454 List.392;
         else
-            ret List.360;
+            ret List.389;
     in
-    jump List.420 List.445 List.446 List.447 List.448 List.449;
+    jump List.449 List.474 List.475 List.476 List.477 List.478;
 
-procedure Num.123 (#Attr.2):
-    let Num.266 : U8 = lowlevel NumIntCast #Attr.2;
-    ret Num.266;
+procedure Num.125 (#Attr.2):
+    let Num.265 : U8 = lowlevel NumIntCast #Attr.2;
+    ret Num.265;
 
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.269 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.269;
-
-procedure Num.20 (#Attr.2, #Attr.3):
-    let Num.267 : U64 = lowlevel NumSub #Attr.2 #Attr.3;
-    ret Num.267;
-
-procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.270 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.270;
-
-procedure Num.24 (#Attr.2, #Attr.3):
-    let Num.268 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
+    let Num.268 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
     ret Num.268;
 
+procedure Num.20 (#Attr.2, #Attr.3):
+    let Num.266 : U64 = lowlevel NumSub #Attr.2 #Attr.3;
+    ret Num.266;
+
+procedure Num.22 (#Attr.2, #Attr.3):
+    let Num.269 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.269;
+
+procedure Num.24 (#Attr.2, #Attr.3):
+    let Num.267 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
+    ret Num.267;
+
 procedure Str.12 (#Attr.2):
-    let Str.266 : List U8 = lowlevel StrToUtf8 #Attr.2;
-    ret Str.266;
+    let Str.280 : List U8 = lowlevel StrToUtf8 #Attr.2;
+    ret Str.280;
 
 procedure Str.48 (#Attr.2, #Attr.3, #Attr.4):
-    let Str.260 : {U64, Str, Int1, U8} = lowlevel StrFromUtf8Range #Attr.2 #Attr.3 #Attr.4;
-    ret Str.260;
+    let Str.274 : {U64, Str, Int1, U8} = lowlevel StrFromUtf8Range #Attr.2 #Attr.3 #Attr.4;
+    ret Str.274;
 
-procedure Str.9 (Str.73):
-    let Str.258 : U64 = 0i64;
-    let Str.259 : U64 = CallByName List.6 Str.73;
-    let Str.74 : {U64, Str, Int1, U8} = CallByName Str.48 Str.73 Str.258 Str.259;
-    let Str.255 : Int1 = StructAtIndex 2 Str.74;
-    if Str.255 then
-        let Str.257 : Str = StructAtIndex 1 Str.74;
-        inc Str.257;
-        dec Str.74;
-        let Str.256 : [C {U64, U8}, C Str] = TagId(1) Str.257;
-        ret Str.256;
+procedure Str.9 (Str.76):
+    let Str.272 : U64 = 0i64;
+    let Str.273 : U64 = CallByName List.6 Str.76;
+    let Str.77 : {U64, Str, Int1, U8} = CallByName Str.48 Str.76 Str.272 Str.273;
+    let Str.269 : Int1 = StructAtIndex 2 Str.77;
+    if Str.269 then
+        let Str.271 : Str = StructAtIndex 1 Str.77;
+        inc Str.271;
+        dec Str.77;
+        let Str.270 : [C {U64, U8}, C Str] = TagId(1) Str.271;
+        ret Str.270;
     else
-        let Str.253 : U8 = StructAtIndex 3 Str.74;
-        let Str.254 : U64 = StructAtIndex 0 Str.74;
-        dec Str.74;
-        let Str.252 : {U64, U8} = Struct {Str.254, Str.253};
-        let Str.251 : [C {U64, U8}, C Str] = TagId(0) Str.252;
-        ret Str.251;
+        let Str.267 : U8 = StructAtIndex 3 Str.77;
+        let Str.268 : U64 = StructAtIndex 0 Str.77;
+        dec Str.77;
+        let Str.266 : {U64, U8} = Struct {Str.268, Str.267};
+        let Str.265 : [C {U64, U8}, C Str] = TagId(0) Str.266;
+        ret Str.265;
 
 procedure Test.0 ():
     let Test.13 : Str = "foo";

--- a/crates/compiler/test_mono/generated/factorial.txt
+++ b/crates/compiler/test_mono/generated/factorial.txt
@@ -1,10 +1,10 @@
 procedure Num.20 (#Attr.2, #Attr.3):
-    let Num.258 : I64 = lowlevel NumSub #Attr.2 #Attr.3;
-    ret Num.258;
+    let Num.257 : I64 = lowlevel NumSub #Attr.2 #Attr.3;
+    ret Num.257;
 
 procedure Num.21 (#Attr.2, #Attr.3):
-    let Num.257 : I64 = lowlevel NumMul #Attr.2 #Attr.3;
-    ret Num.257;
+    let Num.256 : I64 = lowlevel NumMul #Attr.2 #Attr.3;
+    ret Num.256;
 
 procedure Test.1 (Test.15, Test.16):
     joinpoint Test.7 Test.2 Test.3:

--- a/crates/compiler/test_mono/generated/guard_pattern_true.txt
+++ b/crates/compiler/test_mono/generated/guard_pattern_true.txt
@@ -1,6 +1,6 @@
 procedure Bool.1 ():
-    let Bool.11 : Int1 = false;
-    ret Bool.11;
+    let Bool.23 : Int1 = false;
+    ret Bool.23;
 
 procedure Test.1 (Test.2):
     let Test.5 : I64 = 2i64;

--- a/crates/compiler/test_mono/generated/if_guard_bind_variable_false.txt
+++ b/crates/compiler/test_mono/generated/if_guard_bind_variable_false.txt
@@ -1,6 +1,6 @@
-procedure Bool.7 (#Attr.2, #Attr.3):
-    let Bool.11 : Int1 = lowlevel Eq #Attr.2 #Attr.3;
-    ret Bool.11;
+procedure Bool.11 (#Attr.2, #Attr.3):
+    let Bool.23 : Int1 = lowlevel Eq #Attr.2 #Attr.3;
+    ret Bool.23;
 
 procedure Test.1 (Test.3):
     let Test.6 : I64 = 10i64;
@@ -13,7 +13,7 @@ procedure Test.1 (Test.3):
             ret Test.11;
     in
     let Test.10 : I64 = 5i64;
-    let Test.9 : Int1 = CallByName Bool.7 Test.6 Test.10;
+    let Test.9 : Int1 = CallByName Bool.11 Test.6 Test.10;
     jump Test.8 Test.9;
 
 procedure Test.0 ():

--- a/crates/compiler/test_mono/generated/if_multi_branch.txt
+++ b/crates/compiler/test_mono/generated/if_multi_branch.txt
@@ -1,10 +1,10 @@
 procedure Bool.1 ():
-    let Bool.11 : Int1 = false;
-    ret Bool.11;
+    let Bool.23 : Int1 = false;
+    ret Bool.23;
 
 procedure Bool.2 ():
-    let Bool.12 : Int1 = true;
-    ret Bool.12;
+    let Bool.24 : Int1 = true;
+    ret Bool.24;
 
 procedure Test.0 ():
     let Test.4 : Int1 = CallByName Bool.2;

--- a/crates/compiler/test_mono/generated/ir_int_add.txt
+++ b/crates/compiler/test_mono/generated/ir_int_add.txt
@@ -1,10 +1,10 @@
 procedure List.6 (#Attr.2):
-    let List.380 : U64 = lowlevel ListLen #Attr.2;
-    ret List.380;
+    let List.409 : U64 = lowlevel ListLen #Attr.2;
+    ret List.409;
 
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.259 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.259;
+    let Num.258 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.258;
 
 procedure Test.0 ():
     let Test.1 : List I64 = Array [1i64, 2i64];

--- a/crates/compiler/test_mono/generated/ir_plus.txt
+++ b/crates/compiler/test_mono/generated/ir_plus.txt
@@ -1,6 +1,6 @@
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.257 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.257;
+    let Num.256 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.256;
 
 procedure Test.0 ():
     let Test.2 : I64 = 1i64;

--- a/crates/compiler/test_mono/generated/ir_round.txt
+++ b/crates/compiler/test_mono/generated/ir_round.txt
@@ -1,6 +1,6 @@
 procedure Num.45 (#Attr.2):
-    let Num.257 : I64 = lowlevel NumRound #Attr.2;
-    ret Num.257;
+    let Num.256 : I64 = lowlevel NumRound #Attr.2;
+    ret Num.256;
 
 procedure Test.0 ():
     let Test.2 : Float64 = 3.6f64;

--- a/crates/compiler/test_mono/generated/ir_two_defs.txt
+++ b/crates/compiler/test_mono/generated/ir_two_defs.txt
@@ -1,6 +1,6 @@
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.257 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.257;
+    let Num.256 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.256;
 
 procedure Test.0 ():
     let Test.1 : I64 = 3i64;

--- a/crates/compiler/test_mono/generated/ir_when_idiv.txt
+++ b/crates/compiler/test_mono/generated/ir_when_idiv.txt
@@ -1,22 +1,22 @@
-procedure Bool.7 (#Attr.2, #Attr.3):
-    let Bool.11 : Int1 = lowlevel Eq #Attr.2 #Attr.3;
-    ret Bool.11;
+procedure Num.30 (#Attr.2):
+    let Num.263 : I64 = 0i64;
+    let Num.262 : Int1 = lowlevel Eq #Attr.2 Num.263;
+    ret Num.262;
 
 procedure Num.39 (#Attr.2, #Attr.3):
-    let Num.259 : I64 = lowlevel NumDivTruncUnchecked #Attr.2 #Attr.3;
-    ret Num.259;
+    let Num.258 : I64 = lowlevel NumDivTruncUnchecked #Attr.2 #Attr.3;
+    ret Num.258;
 
-procedure Num.40 (Num.229, Num.230):
-    let Num.263 : I64 = 0i64;
-    let Num.260 : Int1 = CallByName Bool.7 Num.230 Num.263;
-    if Num.260 then
-        let Num.262 : {} = Struct {};
-        let Num.261 : [C {}, C I64] = TagId(0) Num.262;
-        ret Num.261;
+procedure Num.40 (Num.228, Num.229):
+    let Num.259 : Int1 = CallByName Num.30 Num.229;
+    if Num.259 then
+        let Num.261 : {} = Struct {};
+        let Num.260 : [C {}, C I64] = TagId(0) Num.261;
+        ret Num.260;
     else
-        let Num.258 : I64 = CallByName Num.39 Num.229 Num.230;
-        let Num.257 : [C {}, C I64] = TagId(1) Num.258;
-        ret Num.257;
+        let Num.257 : I64 = CallByName Num.39 Num.228 Num.229;
+        let Num.256 : [C {}, C I64] = TagId(1) Num.257;
+        ret Num.256;
 
 procedure Test.0 ():
     let Test.8 : I64 = 1000i64;

--- a/crates/compiler/test_mono/generated/ir_when_just.txt
+++ b/crates/compiler/test_mono/generated/ir_when_just.txt
@@ -1,6 +1,6 @@
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.257 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.257;
+    let Num.256 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.256;
 
 procedure Test.0 ():
     let Test.10 : I64 = 41i64;

--- a/crates/compiler/test_mono/generated/is_nil.txt
+++ b/crates/compiler/test_mono/generated/is_nil.txt
@@ -1,10 +1,10 @@
 procedure Bool.1 ():
-    let Bool.12 : Int1 = false;
-    ret Bool.12;
+    let Bool.24 : Int1 = false;
+    ret Bool.24;
 
 procedure Bool.2 ():
-    let Bool.11 : Int1 = true;
-    ret Bool.11;
+    let Bool.23 : Int1 = true;
+    ret Bool.23;
 
 procedure Test.2 (Test.4):
     let Test.11 : U8 = 1i64;

--- a/crates/compiler/test_mono/generated/issue_2583_specialize_errors_behind_unified_branches.txt
+++ b/crates/compiler/test_mono/generated/issue_2583_specialize_errors_behind_unified_branches.txt
@@ -1,71 +1,71 @@
+procedure Bool.11 (#Attr.2, #Attr.3):
+    let Bool.24 : Int1 = lowlevel Eq #Attr.2 #Attr.3;
+    ret Bool.24;
+
 procedure Bool.2 ():
-    let Bool.11 : Int1 = true;
-    ret Bool.11;
+    let Bool.23 : Int1 = true;
+    ret Bool.23;
 
-procedure Bool.7 (#Attr.2, #Attr.3):
-    let Bool.12 : Int1 = lowlevel Eq #Attr.2 #Attr.3;
-    ret Bool.12;
-
-procedure List.2 (List.90, List.91):
-    let List.394 : U64 = CallByName List.6 List.90;
-    let List.390 : Int1 = CallByName Num.22 List.91 List.394;
-    if List.390 then
-        let List.392 : I64 = CallByName List.66 List.90 List.91;
-        let List.391 : [C {}, C I64] = TagId(1) List.392;
-        ret List.391;
+procedure List.2 (List.94, List.95):
+    let List.423 : U64 = CallByName List.6 List.94;
+    let List.419 : Int1 = CallByName Num.22 List.95 List.423;
+    if List.419 then
+        let List.421 : I64 = CallByName List.66 List.94 List.95;
+        let List.420 : [C {}, C I64] = TagId(1) List.421;
+        ret List.420;
     else
-        let List.389 : {} = Struct {};
-        let List.388 : [C {}, C I64] = TagId(0) List.389;
-        ret List.388;
+        let List.418 : {} = Struct {};
+        let List.417 : [C {}, C I64] = TagId(0) List.418;
+        ret List.417;
 
 procedure List.6 (#Attr.2):
-    let List.395 : U64 = lowlevel ListLen #Attr.2;
-    ret List.395;
+    let List.424 : U64 = lowlevel ListLen #Attr.2;
+    ret List.424;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.393 : I64 = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.393;
+    let List.422 : I64 = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.422;
 
-procedure List.9 (List.213):
-    let List.387 : U64 = 0i64;
-    let List.380 : [C {}, C I64] = CallByName List.2 List.213 List.387;
-    let List.384 : U8 = 1i64;
-    let List.385 : U8 = GetTagId List.380;
-    let List.386 : Int1 = lowlevel Eq List.384 List.385;
-    if List.386 then
-        let List.214 : I64 = UnionAtIndex (Id 1) (Index 0) List.380;
-        let List.381 : [C Int1, C I64] = TagId(1) List.214;
-        ret List.381;
+procedure List.9 (List.242):
+    let List.416 : U64 = 0i64;
+    let List.409 : [C {}, C I64] = CallByName List.2 List.242 List.416;
+    let List.413 : U8 = 1i64;
+    let List.414 : U8 = GetTagId List.409;
+    let List.415 : Int1 = lowlevel Eq List.413 List.414;
+    if List.415 then
+        let List.243 : I64 = UnionAtIndex (Id 1) (Index 0) List.409;
+        let List.410 : [C Int1, C I64] = TagId(1) List.243;
+        ret List.410;
     else
-        let List.383 : Int1 = true;
-        let List.382 : [C Int1, C I64] = TagId(0) List.383;
-        ret List.382;
+        let List.412 : Int1 = true;
+        let List.411 : [C Int1, C I64] = TagId(0) List.412;
+        ret List.411;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.257 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.257;
+    let Num.256 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.256;
 
-procedure Str.27 (Str.93):
-    let Str.251 : [C Int1, C I64] = CallByName Str.66 Str.93;
-    ret Str.251;
+procedure Str.27 (Str.96):
+    let Str.265 : [C Int1, C I64] = CallByName Str.69 Str.96;
+    ret Str.265;
 
 procedure Str.47 (#Attr.2):
-    let Str.259 : {I64, U8} = lowlevel StrToNum #Attr.2;
-    ret Str.259;
+    let Str.273 : {I64, U8} = lowlevel StrToNum #Attr.2;
+    ret Str.273;
 
-procedure Str.66 (Str.222):
-    let Str.223 : {I64, U8} = CallByName Str.47 Str.222;
-    let Str.257 : U8 = StructAtIndex 1 Str.223;
-    let Str.258 : U8 = 0i64;
-    let Str.254 : Int1 = CallByName Bool.7 Str.257 Str.258;
-    if Str.254 then
-        let Str.256 : I64 = StructAtIndex 0 Str.223;
-        let Str.255 : [C Int1, C I64] = TagId(1) Str.256;
-        ret Str.255;
+procedure Str.69 (Str.231):
+    let Str.232 : {I64, U8} = CallByName Str.47 Str.231;
+    let Str.271 : U8 = StructAtIndex 1 Str.232;
+    let Str.272 : U8 = 0i64;
+    let Str.268 : Int1 = CallByName Bool.11 Str.271 Str.272;
+    if Str.268 then
+        let Str.270 : I64 = StructAtIndex 0 Str.232;
+        let Str.269 : [C Int1, C I64] = TagId(1) Str.270;
+        ret Str.269;
     else
-        let Str.253 : Int1 = false;
-        let Str.252 : [C Int1, C I64] = TagId(0) Str.253;
-        ret Str.252;
+        let Str.267 : Int1 = false;
+        let Str.266 : [C Int1, C I64] = TagId(0) Str.267;
+        ret Str.266;
 
 procedure Test.0 ():
     let Test.3 : Int1 = CallByName Bool.2;

--- a/crates/compiler/test_mono/generated/issue_3669.txt
+++ b/crates/compiler/test_mono/generated/issue_3669.txt
@@ -1,6 +1,6 @@
-procedure Bool.7 (#Attr.2, #Attr.3):
-    let Bool.11 : Int1 = lowlevel Eq #Attr.2 #Attr.3;
-    ret Bool.11;
+procedure Bool.11 (#Attr.2, #Attr.3):
+    let Bool.23 : Int1 = lowlevel Eq #Attr.2 #Attr.3;
+    ret Bool.23;
 
 procedure Test.2 (Test.19):
     joinpoint Test.13 Test.7:
@@ -21,6 +21,6 @@ procedure Test.0 ():
     let Test.10 : {} = CallByName Test.2 Test.12;
     dec Test.12;
     let Test.11 : {} = Struct {};
-    let Test.8 : Int1 = CallByName Bool.7 Test.10 Test.11;
+    let Test.8 : Int1 = CallByName Bool.11 Test.10 Test.11;
     let Test.9 : Str = "";
     ret Test.9;

--- a/crates/compiler/test_mono/generated/lambda_capture_niche_u8_vs_u64.txt
+++ b/crates/compiler/test_mono/generated/lambda_capture_niche_u8_vs_u64.txt
@@ -1,10 +1,10 @@
 procedure Num.94 (#Attr.2):
-    let Num.257 : Str = lowlevel NumToStr #Attr.2;
-    ret Num.257;
+    let Num.256 : Str = lowlevel NumToStr #Attr.2;
+    ret Num.256;
 
 procedure Num.94 (#Attr.2):
-    let Num.258 : Str = lowlevel NumToStr #Attr.2;
-    ret Num.258;
+    let Num.257 : Str = lowlevel NumToStr #Attr.2;
+    ret Num.257;
 
 procedure Test.1 (Test.4):
     let Test.16 : [C U8, C U64] = TagId(1) Test.4;

--- a/crates/compiler/test_mono/generated/list_append.txt
+++ b/crates/compiler/test_mono/generated/list_append.txt
@@ -1,16 +1,16 @@
-procedure List.4 (List.101, List.102):
-    let List.383 : U64 = 1i64;
-    let List.381 : List I64 = CallByName List.70 List.101 List.383;
-    let List.380 : List I64 = CallByName List.71 List.381 List.102;
-    ret List.380;
+procedure List.4 (List.105, List.106):
+    let List.412 : U64 = 1i64;
+    let List.410 : List I64 = CallByName List.70 List.105 List.412;
+    let List.409 : List I64 = CallByName List.71 List.410 List.106;
+    ret List.409;
 
 procedure List.70 (#Attr.2, #Attr.3):
-    let List.384 : List I64 = lowlevel ListReserve #Attr.2 #Attr.3;
-    ret List.384;
+    let List.413 : List I64 = lowlevel ListReserve #Attr.2 #Attr.3;
+    ret List.413;
 
 procedure List.71 (#Attr.2, #Attr.3):
-    let List.382 : List I64 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
-    ret List.382;
+    let List.411 : List I64 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
+    ret List.411;
 
 procedure Test.0 ():
     let Test.2 : List I64 = Array [1i64];

--- a/crates/compiler/test_mono/generated/list_append_closure.txt
+++ b/crates/compiler/test_mono/generated/list_append_closure.txt
@@ -1,16 +1,16 @@
-procedure List.4 (List.101, List.102):
-    let List.383 : U64 = 1i64;
-    let List.381 : List I64 = CallByName List.70 List.101 List.383;
-    let List.380 : List I64 = CallByName List.71 List.381 List.102;
-    ret List.380;
+procedure List.4 (List.105, List.106):
+    let List.412 : U64 = 1i64;
+    let List.410 : List I64 = CallByName List.70 List.105 List.412;
+    let List.409 : List I64 = CallByName List.71 List.410 List.106;
+    ret List.409;
 
 procedure List.70 (#Attr.2, #Attr.3):
-    let List.384 : List I64 = lowlevel ListReserve #Attr.2 #Attr.3;
-    ret List.384;
+    let List.413 : List I64 = lowlevel ListReserve #Attr.2 #Attr.3;
+    ret List.413;
 
 procedure List.71 (#Attr.2, #Attr.3):
-    let List.382 : List I64 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
-    ret List.382;
+    let List.411 : List I64 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
+    ret List.411;
 
 procedure Test.1 (Test.2):
     let Test.6 : I64 = 42i64;

--- a/crates/compiler/test_mono/generated/list_cannot_update_inplace.txt
+++ b/crates/compiler/test_mono/generated/list_cannot_update_inplace.txt
@@ -1,35 +1,35 @@
-procedure List.3 (List.98, List.99, List.100):
-    let List.383 : {List I64, I64} = CallByName List.64 List.98 List.99 List.100;
-    let List.382 : List I64 = StructAtIndex 0 List.383;
-    inc List.382;
-    dec List.383;
-    ret List.382;
+procedure List.3 (List.102, List.103, List.104):
+    let List.412 : {List I64, I64} = CallByName List.64 List.102 List.103 List.104;
+    let List.411 : List I64 = StructAtIndex 0 List.412;
+    inc List.411;
+    dec List.412;
+    ret List.411;
 
 procedure List.6 (#Attr.2):
-    let List.381 : U64 = lowlevel ListLen #Attr.2;
-    ret List.381;
+    let List.410 : U64 = lowlevel ListLen #Attr.2;
+    ret List.410;
 
-procedure List.64 (List.95, List.96, List.97):
-    let List.388 : U64 = CallByName List.6 List.95;
-    let List.385 : Int1 = CallByName Num.22 List.96 List.388;
-    if List.385 then
-        let List.386 : {List I64, I64} = CallByName List.67 List.95 List.96 List.97;
-        ret List.386;
+procedure List.64 (List.99, List.100, List.101):
+    let List.417 : U64 = CallByName List.6 List.99;
+    let List.414 : Int1 = CallByName Num.22 List.100 List.417;
+    if List.414 then
+        let List.415 : {List I64, I64} = CallByName List.67 List.99 List.100 List.101;
+        ret List.415;
     else
-        let List.384 : {List I64, I64} = Struct {List.95, List.97};
-        ret List.384;
+        let List.413 : {List I64, I64} = Struct {List.99, List.101};
+        ret List.413;
 
 procedure List.67 (#Attr.2, #Attr.3, #Attr.4):
-    let List.387 : {List I64, I64} = lowlevel ListReplaceUnsafe #Attr.2 #Attr.3 #Attr.4;
-    ret List.387;
+    let List.416 : {List I64, I64} = lowlevel ListReplaceUnsafe #Attr.2 #Attr.3 #Attr.4;
+    ret List.416;
 
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.257 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.257;
+    let Num.256 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.256;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.258 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.258;
+    let Num.257 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.257;
 
 procedure Test.1 ():
     let Test.8 : List I64 = Array [1i64, 2i64, 3i64];

--- a/crates/compiler/test_mono/generated/list_get.txt
+++ b/crates/compiler/test_mono/generated/list_get.txt
@@ -1,26 +1,26 @@
-procedure List.2 (List.90, List.91):
-    let List.386 : U64 = CallByName List.6 List.90;
-    let List.382 : Int1 = CallByName Num.22 List.91 List.386;
-    if List.382 then
-        let List.384 : I64 = CallByName List.66 List.90 List.91;
-        let List.383 : [C {}, C I64] = TagId(1) List.384;
-        ret List.383;
+procedure List.2 (List.94, List.95):
+    let List.415 : U64 = CallByName List.6 List.94;
+    let List.411 : Int1 = CallByName Num.22 List.95 List.415;
+    if List.411 then
+        let List.413 : I64 = CallByName List.66 List.94 List.95;
+        let List.412 : [C {}, C I64] = TagId(1) List.413;
+        ret List.412;
     else
-        let List.381 : {} = Struct {};
-        let List.380 : [C {}, C I64] = TagId(0) List.381;
-        ret List.380;
+        let List.410 : {} = Struct {};
+        let List.409 : [C {}, C I64] = TagId(0) List.410;
+        ret List.409;
 
 procedure List.6 (#Attr.2):
-    let List.387 : U64 = lowlevel ListLen #Attr.2;
-    ret List.387;
+    let List.416 : U64 = lowlevel ListLen #Attr.2;
+    ret List.416;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.385 : I64 = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.385;
+    let List.414 : I64 = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.414;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.257 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.257;
+    let Num.256 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.256;
 
 procedure Test.1 (Test.2):
     let Test.6 : List I64 = Array [1i64, 2i64, 3i64];

--- a/crates/compiler/test_mono/generated/list_len.txt
+++ b/crates/compiler/test_mono/generated/list_len.txt
@@ -1,14 +1,14 @@
 procedure List.6 (#Attr.2):
-    let List.380 : U64 = lowlevel ListLen #Attr.2;
-    ret List.380;
+    let List.409 : U64 = lowlevel ListLen #Attr.2;
+    ret List.409;
 
 procedure List.6 (#Attr.2):
-    let List.381 : U64 = lowlevel ListLen #Attr.2;
-    ret List.381;
+    let List.410 : U64 = lowlevel ListLen #Attr.2;
+    ret List.410;
 
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.257 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.257;
+    let Num.256 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.256;
 
 procedure Test.0 ():
     let Test.1 : List I64 = Array [1i64, 2i64, 3i64];

--- a/crates/compiler/test_mono/generated/list_map_closure_borrows.txt
+++ b/crates/compiler/test_mono/generated/list_map_closure_borrows.txt
@@ -1,38 +1,38 @@
-procedure List.2 (List.90, List.91):
-    let List.386 : U64 = CallByName List.6 List.90;
-    let List.382 : Int1 = CallByName Num.22 List.91 List.386;
-    if List.382 then
-        let List.384 : Str = CallByName List.66 List.90 List.91;
-        let List.383 : [C {}, C Str] = TagId(1) List.384;
-        ret List.383;
+procedure List.2 (List.94, List.95):
+    let List.415 : U64 = CallByName List.6 List.94;
+    let List.411 : Int1 = CallByName Num.22 List.95 List.415;
+    if List.411 then
+        let List.413 : Str = CallByName List.66 List.94 List.95;
+        let List.412 : [C {}, C Str] = TagId(1) List.413;
+        ret List.412;
     else
-        let List.381 : {} = Struct {};
-        let List.380 : [C {}, C Str] = TagId(0) List.381;
-        ret List.380;
+        let List.410 : {} = Struct {};
+        let List.409 : [C {}, C Str] = TagId(0) List.410;
+        ret List.409;
 
 procedure List.5 (#Attr.2, #Attr.3):
-    let List.388 : List Str = lowlevel ListMap { xs: `#Attr.#arg1` } #Attr.2 Test.3 #Attr.3;
-    ret List.388;
+    let List.417 : List Str = lowlevel ListMap { xs: `#Attr.#arg1` } #Attr.2 Test.3 #Attr.3;
+    ret List.417;
 
 procedure List.6 (#Attr.2):
-    let List.387 : U64 = lowlevel ListLen #Attr.2;
-    ret List.387;
+    let List.416 : U64 = lowlevel ListLen #Attr.2;
+    ret List.416;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.385 : Str = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.385;
+    let List.414 : Str = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.414;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.257 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.257;
+    let Num.256 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.256;
 
 procedure Str.16 (#Attr.2, #Attr.3):
-    let Str.251 : Str = lowlevel StrRepeat #Attr.2 #Attr.3;
-    ret Str.251;
+    let Str.265 : Str = lowlevel StrRepeat #Attr.2 #Attr.3;
+    ret Str.265;
 
 procedure Str.3 (#Attr.2, #Attr.3):
-    let Str.252 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
-    ret Str.252;
+    let Str.266 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
+    ret Str.266;
 
 procedure Test.1 ():
     let Test.21 : Str = "lllllllllllllllllllllooooooooooong";

--- a/crates/compiler/test_mono/generated/list_map_closure_owns.txt
+++ b/crates/compiler/test_mono/generated/list_map_closure_owns.txt
@@ -1,36 +1,35 @@
-procedure List.2 (List.90, List.91):
-    let List.386 : U64 = CallByName List.6 List.90;
-    let List.382 : Int1 = CallByName Num.22 List.91 List.386;
-    if List.382 then
-        let List.384 : Str = CallByName List.66 List.90 List.91;
-        let List.383 : [C {}, C Str] = TagId(1) List.384;
-        ret List.383;
+procedure List.2 (List.94, List.95):
+    let List.415 : U64 = CallByName List.6 List.94;
+    let List.411 : Int1 = CallByName Num.22 List.95 List.415;
+    if List.411 then
+        let List.413 : Str = CallByName List.66 List.94 List.95;
+        let List.412 : [C {}, C Str] = TagId(1) List.413;
+        ret List.412;
     else
-        let List.381 : {} = Struct {};
-        let List.380 : [C {}, C Str] = TagId(0) List.381;
-        ret List.380;
+        let List.410 : {} = Struct {};
+        let List.409 : [C {}, C Str] = TagId(0) List.410;
+        ret List.409;
 
 procedure List.5 (#Attr.2, #Attr.3):
-    inc #Attr.2;
-    let List.388 : List Str = lowlevel ListMap { xs: `#Attr.#arg1` } #Attr.2 Test.3 #Attr.3;
+    let List.417 : List Str = lowlevel ListMap { xs: `#Attr.#arg1` } #Attr.2 Test.3 #Attr.3;
     decref #Attr.2;
-    ret List.388;
+    ret List.417;
 
 procedure List.6 (#Attr.2):
-    let List.387 : U64 = lowlevel ListLen #Attr.2;
-    ret List.387;
+    let List.416 : U64 = lowlevel ListLen #Attr.2;
+    ret List.416;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.385 : Str = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.385;
+    let List.414 : Str = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.414;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.257 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.257;
+    let Num.256 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.256;
 
 procedure Str.3 (#Attr.2, #Attr.3):
-    let Str.252 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
-    ret Str.252;
+    let Str.266 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
+    ret Str.266;
 
 procedure Test.1 ():
     let Test.21 : Str = "lllllllllllllllllllllooooooooooong";
@@ -44,7 +43,6 @@ procedure Test.2 ():
     let Test.15 : List Str = CallByName Test.1;
     let Test.16 : {} = Struct {};
     let Test.14 : List Str = CallByName List.5 Test.15 Test.16;
-    dec Test.15;
     ret Test.14;
 
 procedure Test.3 (Test.4):

--- a/crates/compiler/test_mono/generated/list_pass_to_function.txt
+++ b/crates/compiler/test_mono/generated/list_pass_to_function.txt
@@ -1,31 +1,31 @@
-procedure List.3 (List.98, List.99, List.100):
-    let List.381 : {List I64, I64} = CallByName List.64 List.98 List.99 List.100;
-    let List.380 : List I64 = StructAtIndex 0 List.381;
-    inc List.380;
-    dec List.381;
-    ret List.380;
+procedure List.3 (List.102, List.103, List.104):
+    let List.410 : {List I64, I64} = CallByName List.64 List.102 List.103 List.104;
+    let List.409 : List I64 = StructAtIndex 0 List.410;
+    inc List.409;
+    dec List.410;
+    ret List.409;
 
 procedure List.6 (#Attr.2):
-    let List.387 : U64 = lowlevel ListLen #Attr.2;
-    ret List.387;
+    let List.416 : U64 = lowlevel ListLen #Attr.2;
+    ret List.416;
 
-procedure List.64 (List.95, List.96, List.97):
-    let List.386 : U64 = CallByName List.6 List.95;
-    let List.383 : Int1 = CallByName Num.22 List.96 List.386;
-    if List.383 then
-        let List.384 : {List I64, I64} = CallByName List.67 List.95 List.96 List.97;
-        ret List.384;
+procedure List.64 (List.99, List.100, List.101):
+    let List.415 : U64 = CallByName List.6 List.99;
+    let List.412 : Int1 = CallByName Num.22 List.100 List.415;
+    if List.412 then
+        let List.413 : {List I64, I64} = CallByName List.67 List.99 List.100 List.101;
+        ret List.413;
     else
-        let List.382 : {List I64, I64} = Struct {List.95, List.97};
-        ret List.382;
+        let List.411 : {List I64, I64} = Struct {List.99, List.101};
+        ret List.411;
 
 procedure List.67 (#Attr.2, #Attr.3, #Attr.4):
-    let List.385 : {List I64, I64} = lowlevel ListReplaceUnsafe #Attr.2 #Attr.3 #Attr.4;
-    ret List.385;
+    let List.414 : {List I64, I64} = lowlevel ListReplaceUnsafe #Attr.2 #Attr.3 #Attr.4;
+    ret List.414;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.257 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.257;
+    let Num.256 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.256;
 
 procedure Test.2 (Test.3):
     let Test.6 : U64 = 0i64;

--- a/crates/compiler/test_mono/generated/list_sort_asc.txt
+++ b/crates/compiler/test_mono/generated/list_sort_asc.txt
@@ -1,20 +1,20 @@
 procedure List.28 (#Attr.2, #Attr.3):
-    let List.382 : List I64 = lowlevel ListSortWith { xs: `#Attr.#arg1` } #Attr.2 Num.46 #Attr.3;
+    let List.411 : List I64 = lowlevel ListSortWith { xs: `#Attr.#arg1` } #Attr.2 Num.46 #Attr.3;
     let #Derived_gen.0 : Int1 = lowlevel ListIsUnique #Attr.2;
     if #Derived_gen.0 then
-        ret List.382;
+        ret List.411;
     else
         decref #Attr.2;
-        ret List.382;
+        ret List.411;
 
-procedure List.59 (List.208):
-    let List.381 : {} = Struct {};
-    let List.380 : List I64 = CallByName List.28 List.208 List.381;
-    ret List.380;
+procedure List.59 (List.237):
+    let List.410 : {} = Struct {};
+    let List.409 : List I64 = CallByName List.28 List.237 List.410;
+    ret List.409;
 
 procedure Num.46 (#Attr.2, #Attr.3):
-    let Num.257 : U8 = lowlevel NumCompare #Attr.2 #Attr.3;
-    ret Num.257;
+    let Num.256 : U8 = lowlevel NumCompare #Attr.2 #Attr.3;
+    ret Num.256;
 
 procedure Test.0 ():
     let Test.2 : List I64 = Array [4i64, 3i64, 2i64, 1i64];

--- a/crates/compiler/test_mono/generated/monomorphized_tag_with_aliased_args.txt
+++ b/crates/compiler/test_mono/generated/monomorphized_tag_with_aliased_args.txt
@@ -1,6 +1,6 @@
 procedure Bool.1 ():
-    let Bool.12 : Int1 = false;
-    ret Bool.12;
+    let Bool.24 : Int1 = false;
+    ret Bool.24;
 
 procedure Test.4 (Test.6):
     let Test.8 : U64 = 1i64;

--- a/crates/compiler/test_mono/generated/nested_pattern_match.txt
+++ b/crates/compiler/test_mono/generated/nested_pattern_match.txt
@@ -1,6 +1,6 @@
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.257 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.257;
+    let Num.256 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.256;
 
 procedure Test.0 ():
     let Test.19 : I64 = 41i64;

--- a/crates/compiler/test_mono/generated/num_width_gt_u8_layout_as_float.txt
+++ b/crates/compiler/test_mono/generated/num_width_gt_u8_layout_as_float.txt
@@ -1,6 +1,6 @@
 procedure Num.37 (#Attr.2, #Attr.3):
-    let Num.257 : Float64 = lowlevel NumDivFrac #Attr.2 #Attr.3;
-    ret Num.257;
+    let Num.256 : Float64 = lowlevel NumDivFrac #Attr.2 #Attr.3;
+    ret Num.256;
 
 procedure Test.0 ():
     let Test.2 : Float64 = 1f64;

--- a/crates/compiler/test_mono/generated/optional_when.txt
+++ b/crates/compiler/test_mono/generated/optional_when.txt
@@ -1,6 +1,6 @@
 procedure Num.21 (#Attr.2, #Attr.3):
-    let Num.259 : I64 = lowlevel NumMul #Attr.2 #Attr.3;
-    ret Num.259;
+    let Num.258 : I64 = lowlevel NumMul #Attr.2 #Attr.3;
+    ret Num.258;
 
 procedure Test.1 (Test.6):
     let Test.21 : Int1 = false;

--- a/crates/compiler/test_mono/generated/quicksort_help.txt
+++ b/crates/compiler/test_mono/generated/quicksort_help.txt
@@ -1,14 +1,14 @@
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.257 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.257;
+    let Num.256 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.256;
 
 procedure Num.20 (#Attr.2, #Attr.3):
-    let Num.258 : I64 = lowlevel NumSub #Attr.2 #Attr.3;
-    ret Num.258;
+    let Num.257 : I64 = lowlevel NumSub #Attr.2 #Attr.3;
+    ret Num.257;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.259 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.259;
+    let Num.258 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.258;
 
 procedure Test.1 (Test.24, Test.25, Test.26):
     joinpoint Test.12 Test.2 Test.3 Test.4:

--- a/crates/compiler/test_mono/generated/quicksort_swap.txt
+++ b/crates/compiler/test_mono/generated/quicksort_swap.txt
@@ -1,47 +1,47 @@
-procedure List.2 (List.90, List.91):
-    let List.402 : U64 = CallByName List.6 List.90;
-    let List.399 : Int1 = CallByName Num.22 List.91 List.402;
-    if List.399 then
-        let List.401 : I64 = CallByName List.66 List.90 List.91;
-        let List.400 : [C {}, C I64] = TagId(1) List.401;
-        ret List.400;
+procedure List.2 (List.94, List.95):
+    let List.431 : U64 = CallByName List.6 List.94;
+    let List.428 : Int1 = CallByName Num.22 List.95 List.431;
+    if List.428 then
+        let List.430 : I64 = CallByName List.66 List.94 List.95;
+        let List.429 : [C {}, C I64] = TagId(1) List.430;
+        ret List.429;
     else
-        let List.398 : {} = Struct {};
-        let List.397 : [C {}, C I64] = TagId(0) List.398;
-        ret List.397;
+        let List.427 : {} = Struct {};
+        let List.426 : [C {}, C I64] = TagId(0) List.427;
+        ret List.426;
 
-procedure List.3 (List.98, List.99, List.100):
-    let List.389 : {List I64, I64} = CallByName List.64 List.98 List.99 List.100;
-    let List.388 : List I64 = StructAtIndex 0 List.389;
-    inc List.388;
-    dec List.389;
-    ret List.388;
+procedure List.3 (List.102, List.103, List.104):
+    let List.418 : {List I64, I64} = CallByName List.64 List.102 List.103 List.104;
+    let List.417 : List I64 = StructAtIndex 0 List.418;
+    inc List.417;
+    dec List.418;
+    ret List.417;
 
 procedure List.6 (#Attr.2):
-    let List.387 : U64 = lowlevel ListLen #Attr.2;
-    ret List.387;
+    let List.416 : U64 = lowlevel ListLen #Attr.2;
+    ret List.416;
 
-procedure List.64 (List.95, List.96, List.97):
-    let List.386 : U64 = CallByName List.6 List.95;
-    let List.383 : Int1 = CallByName Num.22 List.96 List.386;
-    if List.383 then
-        let List.384 : {List I64, I64} = CallByName List.67 List.95 List.96 List.97;
-        ret List.384;
+procedure List.64 (List.99, List.100, List.101):
+    let List.415 : U64 = CallByName List.6 List.99;
+    let List.412 : Int1 = CallByName Num.22 List.100 List.415;
+    if List.412 then
+        let List.413 : {List I64, I64} = CallByName List.67 List.99 List.100 List.101;
+        ret List.413;
     else
-        let List.382 : {List I64, I64} = Struct {List.95, List.97};
-        ret List.382;
+        let List.411 : {List I64, I64} = Struct {List.99, List.101};
+        ret List.411;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.395 : I64 = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.395;
+    let List.424 : I64 = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.424;
 
 procedure List.67 (#Attr.2, #Attr.3, #Attr.4):
-    let List.385 : {List I64, I64} = lowlevel ListReplaceUnsafe #Attr.2 #Attr.3 #Attr.4;
-    ret List.385;
+    let List.414 : {List I64, I64} = lowlevel ListReplaceUnsafe #Attr.2 #Attr.3 #Attr.4;
+    ret List.414;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.259 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.259;
+    let Num.258 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.258;
 
 procedure Test.1 (Test.2):
     let Test.28 : U64 = 0i64;

--- a/crates/compiler/test_mono/generated/record_optional_field_function_no_use_default.txt
+++ b/crates/compiler/test_mono/generated/record_optional_field_function_no_use_default.txt
@@ -1,6 +1,6 @@
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.257 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.257;
+    let Num.256 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.256;
 
 procedure Test.1 (Test.4):
     let Test.2 : I64 = StructAtIndex 0 Test.4;

--- a/crates/compiler/test_mono/generated/record_optional_field_function_use_default.txt
+++ b/crates/compiler/test_mono/generated/record_optional_field_function_use_default.txt
@@ -1,6 +1,6 @@
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.257 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.257;
+    let Num.256 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.256;
 
 procedure Test.1 (Test.4):
     let Test.2 : I64 = 10i64;

--- a/crates/compiler/test_mono/generated/record_optional_field_let_no_use_default.txt
+++ b/crates/compiler/test_mono/generated/record_optional_field_let_no_use_default.txt
@@ -1,6 +1,6 @@
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.257 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.257;
+    let Num.256 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.256;
 
 procedure Test.1 (Test.2):
     let Test.3 : I64 = StructAtIndex 0 Test.2;

--- a/crates/compiler/test_mono/generated/record_optional_field_let_use_default.txt
+++ b/crates/compiler/test_mono/generated/record_optional_field_let_use_default.txt
@@ -1,6 +1,6 @@
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.257 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.257;
+    let Num.256 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.256;
 
 procedure Test.1 (Test.2):
     let Test.3 : I64 = 10i64;

--- a/crates/compiler/test_mono/generated/recursive_call_capturing_function.txt
+++ b/crates/compiler/test_mono/generated/recursive_call_capturing_function.txt
@@ -1,10 +1,10 @@
 procedure Bool.2 ():
-    let Bool.11 : Int1 = true;
-    ret Bool.11;
+    let Bool.23 : Int1 = true;
+    ret Bool.23;
 
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.257 : U32 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.257;
+    let Num.256 : U32 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.256;
 
 procedure Test.1 (Test.2):
     let Test.8 : U32 = 0i64;

--- a/crates/compiler/test_mono/generated/rigids.txt
+++ b/crates/compiler/test_mono/generated/rigids.txt
@@ -1,47 +1,47 @@
-procedure List.2 (List.90, List.91):
-    let List.402 : U64 = CallByName List.6 List.90;
-    let List.399 : Int1 = CallByName Num.22 List.91 List.402;
-    if List.399 then
-        let List.401 : I64 = CallByName List.66 List.90 List.91;
-        let List.400 : [C {}, C I64] = TagId(1) List.401;
-        ret List.400;
+procedure List.2 (List.94, List.95):
+    let List.431 : U64 = CallByName List.6 List.94;
+    let List.428 : Int1 = CallByName Num.22 List.95 List.431;
+    if List.428 then
+        let List.430 : I64 = CallByName List.66 List.94 List.95;
+        let List.429 : [C {}, C I64] = TagId(1) List.430;
+        ret List.429;
     else
-        let List.398 : {} = Struct {};
-        let List.397 : [C {}, C I64] = TagId(0) List.398;
-        ret List.397;
+        let List.427 : {} = Struct {};
+        let List.426 : [C {}, C I64] = TagId(0) List.427;
+        ret List.426;
 
-procedure List.3 (List.98, List.99, List.100):
-    let List.389 : {List I64, I64} = CallByName List.64 List.98 List.99 List.100;
-    let List.388 : List I64 = StructAtIndex 0 List.389;
-    inc List.388;
-    dec List.389;
-    ret List.388;
+procedure List.3 (List.102, List.103, List.104):
+    let List.418 : {List I64, I64} = CallByName List.64 List.102 List.103 List.104;
+    let List.417 : List I64 = StructAtIndex 0 List.418;
+    inc List.417;
+    dec List.418;
+    ret List.417;
 
 procedure List.6 (#Attr.2):
-    let List.387 : U64 = lowlevel ListLen #Attr.2;
-    ret List.387;
+    let List.416 : U64 = lowlevel ListLen #Attr.2;
+    ret List.416;
 
-procedure List.64 (List.95, List.96, List.97):
-    let List.386 : U64 = CallByName List.6 List.95;
-    let List.383 : Int1 = CallByName Num.22 List.96 List.386;
-    if List.383 then
-        let List.384 : {List I64, I64} = CallByName List.67 List.95 List.96 List.97;
-        ret List.384;
+procedure List.64 (List.99, List.100, List.101):
+    let List.415 : U64 = CallByName List.6 List.99;
+    let List.412 : Int1 = CallByName Num.22 List.100 List.415;
+    if List.412 then
+        let List.413 : {List I64, I64} = CallByName List.67 List.99 List.100 List.101;
+        ret List.413;
     else
-        let List.382 : {List I64, I64} = Struct {List.95, List.97};
-        ret List.382;
+        let List.411 : {List I64, I64} = Struct {List.99, List.101};
+        ret List.411;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.395 : I64 = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.395;
+    let List.424 : I64 = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.424;
 
 procedure List.67 (#Attr.2, #Attr.3, #Attr.4):
-    let List.385 : {List I64, I64} = lowlevel ListReplaceUnsafe #Attr.2 #Attr.3 #Attr.4;
-    ret List.385;
+    let List.414 : {List I64, I64} = lowlevel ListReplaceUnsafe #Attr.2 #Attr.3 #Attr.4;
+    ret List.414;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.259 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.259;
+    let Num.258 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.258;
 
 procedure Test.1 (Test.2, Test.3, Test.4):
     let Test.29 : [C {}, C I64] = CallByName List.2 Test.4 Test.3;

--- a/crates/compiler/test_mono/generated/simple_if.txt
+++ b/crates/compiler/test_mono/generated/simple_if.txt
@@ -1,6 +1,6 @@
 procedure Bool.2 ():
-    let Bool.11 : Int1 = true;
-    ret Bool.11;
+    let Bool.23 : Int1 = true;
+    ret Bool.23;
 
 procedure Test.0 ():
     let Test.2 : Int1 = CallByName Bool.2;

--- a/crates/compiler/test_mono/generated/specialize_closures.txt
+++ b/crates/compiler/test_mono/generated/specialize_closures.txt
@@ -1,14 +1,14 @@
 procedure Bool.2 ():
-    let Bool.12 : Int1 = true;
-    ret Bool.12;
+    let Bool.24 : Int1 = true;
+    ret Bool.24;
 
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.258 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.258;
+    let Num.257 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.257;
 
 procedure Num.21 (#Attr.2, #Attr.3):
-    let Num.257 : I64 = lowlevel NumMul #Attr.2 #Attr.3;
-    ret Num.257;
+    let Num.256 : I64 = lowlevel NumMul #Attr.2 #Attr.3;
+    ret Num.256;
 
 procedure Test.1 (Test.2, Test.3):
     let Test.15 : U8 = GetTagId Test.2;

--- a/crates/compiler/test_mono/generated/specialize_lowlevel.txt
+++ b/crates/compiler/test_mono/generated/specialize_lowlevel.txt
@@ -1,14 +1,14 @@
 procedure Bool.2 ():
-    let Bool.11 : Int1 = true;
-    ret Bool.11;
+    let Bool.23 : Int1 = true;
+    ret Bool.23;
 
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.258 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.258;
+    let Num.257 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.257;
 
 procedure Num.21 (#Attr.2, #Attr.3):
-    let Num.257 : I64 = lowlevel NumMul #Attr.2 #Attr.3;
-    ret Num.257;
+    let Num.256 : I64 = lowlevel NumMul #Attr.2 #Attr.3;
+    ret Num.256;
 
 procedure Test.6 (Test.8, #Attr.12):
     let Test.4 : I64 = UnionAtIndex (Id 0) (Index 0) #Attr.12;

--- a/crates/compiler/test_mono/generated/tail_call_elimination.txt
+++ b/crates/compiler/test_mono/generated/tail_call_elimination.txt
@@ -1,10 +1,10 @@
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.257 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.257;
+    let Num.256 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.256;
 
 procedure Num.20 (#Attr.2, #Attr.3):
-    let Num.258 : I64 = lowlevel NumSub #Attr.2 #Attr.3;
-    ret Num.258;
+    let Num.257 : I64 = lowlevel NumSub #Attr.2 #Attr.3;
+    ret Num.257;
 
 procedure Test.1 (Test.15, Test.16):
     joinpoint Test.7 Test.2 Test.3:

--- a/crates/compiler/test_mono/generated/unreachable_void_constructor.txt
+++ b/crates/compiler/test_mono/generated/unreachable_void_constructor.txt
@@ -1,6 +1,6 @@
 procedure Bool.2 ():
-    let Bool.11 : Int1 = true;
-    ret Bool.11;
+    let Bool.23 : Int1 = true;
+    ret Bool.23;
 
 procedure Test.0 ():
     let Test.6 : Int1 = CallByName Bool.2;

--- a/crates/compiler/test_mono/generated/when_nested_maybe.txt
+++ b/crates/compiler/test_mono/generated/when_nested_maybe.txt
@@ -1,6 +1,6 @@
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.257 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.257;
+    let Num.256 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.256;
 
 procedure Test.0 ():
     let Test.19 : I64 = 41i64;

--- a/crates/compiler/test_mono/generated/when_on_record.txt
+++ b/crates/compiler/test_mono/generated/when_on_record.txt
@@ -1,6 +1,6 @@
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.257 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.257;
+    let Num.256 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.256;
 
 procedure Test.0 ():
     let Test.5 : I64 = 2i64;

--- a/crates/compiler/test_mono/generated/when_on_two_values.txt
+++ b/crates/compiler/test_mono/generated/when_on_two_values.txt
@@ -1,6 +1,6 @@
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.257 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.257;
+    let Num.256 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.256;
 
 procedure Test.0 ():
     let Test.15 : I64 = 3i64;

--- a/crates/compiler/test_mono/src/tests.rs
+++ b/crates/compiler/test_mono/src/tests.rs
@@ -143,7 +143,6 @@ fn compiles_to_ir(test_name: &str, src: &str) {
     verify_procedures(test_name, layout_interner, procedures, main_fn_symbol);
 }
 
-#[cfg(debug_assertions)]
 fn verify_procedures<'a>(
     test_name: &str,
     interner: STLayoutInterner<'a>,
@@ -199,19 +198,6 @@ fn verify_procedures<'a>(
         println!("{}", std::str::from_utf8(&has_changes.stdout).unwrap());
         panic!("Output changed: resolve conflicts and `git add` the file.");
     }
-}
-
-// NOTE because the Show instance of module names is different in --release mode,
-// these tests would all fail. In the future, when we do interesting optimizations,
-// we'll likely want some tests for --release too.
-#[cfg(not(debug_assertions))]
-fn verify_procedures(
-    _expected: &str,
-    _interner: STLayoutInterner<'_>,
-    _procedures: MutMap<(Symbol, ProcLayout<'_>), Proc<'_>>,
-    _main_fn_symbol: Symbol,
-) {
-    // Do nothing
 }
 
 #[mono_test]


### PR DESCRIPTION
Makes sure that we turn on `debug-symbols` in mono tests, and that this feature is fully respected in symbol generation, so that output in release + debug builds are the same.

Closes #4435