### PR TITLE
Crash

### DIFF
--- a/crates/compiler/alias_analysis/src/lib.rs
+++ b/crates/compiler/alias_analysis/src/lib.rs
@@ -645,6 +645,14 @@ fn stmt_spec<'a>(
 
             builder.add_terminate(block, type_id)
         }
+        Crash(msg, _) => {
+            // Model this as a foreign call rather than TERMINATE because
+            // we want ownership of the message.
+            let result_type =
+                layout_spec(env, builder, interner, layout, &WhenRecursive::Unreachable)?;
+
+            builder.add_unknown_with(block, &[env.symbols[msg]], result_type)
+        }
     }
 }
 

--- a/crates/compiler/alias_analysis/src/lib.rs
+++ b/crates/compiler/alias_analysis/src/lib.rs
@@ -640,11 +640,6 @@ fn stmt_spec<'a>(
             let jpid = env.join_points[id];
             builder.add_jump(block, jpid, argument, ret_type_id)
         }
-        RuntimeError(_) => {
-            let type_id = layout_spec(env, builder, interner, layout, &WhenRecursive::Unreachable)?;
-
-            builder.add_terminate(block, type_id)
-        }
         Crash(msg, _) => {
             // Model this as a foreign call rather than TERMINATE because
             // we want ownership of the message.

--- a/crates/compiler/builtins/bitcode/src/dec.zig
+++ b/crates/compiler/builtins/bitcode/src/dec.zig
@@ -7,7 +7,7 @@ const math = std.math;
 const always_inline = std.builtin.CallOptions.Modifier.always_inline;
 const RocStr = str.RocStr;
 const WithOverflow = utils.WithOverflow;
-const roc_panic = utils.panic;
+const roc_panic = @import("panic.zig").panic_help;
 const U256 = num_.U256;
 const mul_u128 = num_.mul_u128;
 

--- a/crates/compiler/builtins/bitcode/src/dec.zig
+++ b/crates/compiler/builtins/bitcode/src/dec.zig
@@ -233,7 +233,7 @@ pub const RocDec = extern struct {
         const answer = RocDec.addWithOverflow(self, other);
 
         if (answer.has_overflowed) {
-            roc_panic("Decimal addition overflowed!", 1);
+            roc_panic("Decimal addition overflowed!", 0);
             unreachable;
         } else {
             return answer.value;
@@ -265,7 +265,7 @@ pub const RocDec = extern struct {
         const answer = RocDec.subWithOverflow(self, other);
 
         if (answer.has_overflowed) {
-            roc_panic("Decimal subtraction overflowed!", 1);
+            roc_panic("Decimal subtraction overflowed!", 0);
             unreachable;
         } else {
             return answer.value;
@@ -329,7 +329,7 @@ pub const RocDec = extern struct {
         const answer = RocDec.mulWithOverflow(self, other);
 
         if (answer.has_overflowed) {
-            roc_panic("Decimal multiplication overflowed!", 1);
+            roc_panic("Decimal multiplication overflowed!", 0);
             unreachable;
         } else {
             return answer.value;

--- a/crates/compiler/builtins/bitcode/src/main.zig
+++ b/crates/compiler/builtins/bitcode/src/main.zig
@@ -3,6 +3,7 @@ const builtin = @import("builtin");
 const math = std.math;
 const utils = @import("utils.zig");
 const expect = @import("expect.zig");
+const panic_utils = @import("panic.zig");
 
 const ROC_BUILTINS = "roc_builtins";
 const NUM = "num";
@@ -166,7 +167,7 @@ comptime {
     exportUtilsFn(utils.decrefCheckNullC, "decref_check_null");
     exportUtilsFn(utils.allocateWithRefcountC, "allocate_with_refcount");
 
-    @export(utils.panic, .{ .name = "roc_builtins.utils." ++ "panic", .linkage = .Weak });
+    @export(panic_utils.panic, .{ .name = "roc_builtins.utils." ++ "panic", .linkage = .Weak });
 
     if (builtin.target.cpu.arch != .wasm32) {
         exportUtilsFn(expect.expectFailedStartSharedBuffer, "expect_failed_start_shared_buffer");

--- a/crates/compiler/builtins/bitcode/src/num.zig
+++ b/crates/compiler/builtins/bitcode/src/num.zig
@@ -284,7 +284,7 @@ pub fn exportAddOrPanic(comptime T: type, comptime name: []const u8) void {
         fn func(self: T, other: T) callconv(.C) T {
             const result = addWithOverflow(T, self, other);
             if (result.has_overflowed) {
-                roc_panic("integer addition overflowed!", 1);
+                roc_panic("integer addition overflowed!", 0);
                 unreachable;
             } else {
                 return result.value;
@@ -343,7 +343,7 @@ pub fn exportSubOrPanic(comptime T: type, comptime name: []const u8) void {
         fn func(self: T, other: T) callconv(.C) T {
             const result = subWithOverflow(T, self, other);
             if (result.has_overflowed) {
-                roc_panic("integer subtraction overflowed!", 1);
+                roc_panic("integer subtraction overflowed!", 0);
                 unreachable;
             } else {
                 return result.value;
@@ -451,7 +451,7 @@ pub fn exportMulOrPanic(comptime T: type, comptime W: type, comptime name: []con
         fn func(self: T, other: T) callconv(.C) T {
             const result = @call(.{ .modifier = always_inline }, mulWithOverflow, .{ T, W, self, other });
             if (result.has_overflowed) {
-                roc_panic("integer multiplication overflowed!", 1);
+                roc_panic("integer multiplication overflowed!", 0);
                 unreachable;
             } else {
                 return result.value;

--- a/crates/compiler/builtins/bitcode/src/num.zig
+++ b/crates/compiler/builtins/bitcode/src/num.zig
@@ -4,7 +4,7 @@ const math = std.math;
 const RocList = @import("list.zig").RocList;
 const RocStr = @import("str.zig").RocStr;
 const WithOverflow = @import("utils.zig").WithOverflow;
-const roc_panic = @import("utils.zig").panic;
+const roc_panic = @import("panic.zig").panic_help;
 
 pub fn NumParseResult(comptime T: type) type {
     // on the roc side we sort by alignment; putting the errorcode last

--- a/crates/compiler/builtins/bitcode/src/panic.zig
+++ b/crates/compiler/builtins/bitcode/src/panic.zig
@@ -1,0 +1,16 @@
+const std = @import("std");
+const RocStr = @import("str.zig").RocStr;
+const always_inline = std.builtin.CallOptions.Modifier.always_inline;
+
+// Signals to the host that the program has panicked
+extern fn roc_panic(msg: *const RocStr, tag_id: u32) callconv(.C) void;
+
+pub fn panic_help(msg: []const u8, tag_id: u32) void {
+    var str = RocStr.init(msg.ptr, msg.len);
+    roc_panic(&str, tag_id);
+}
+
+// must export this explicitly because right now it is not used from zig code
+pub fn panic(msg: *const RocStr, alignment: u32) callconv(.C) void {
+    return @call(.{ .modifier = always_inline }, roc_panic, .{ msg, alignment });
+}

--- a/crates/compiler/builtins/bitcode/src/utils.zig
+++ b/crates/compiler/builtins/bitcode/src/utils.zig
@@ -16,9 +16,6 @@ extern fn roc_realloc(c_ptr: *anyopaque, new_size: usize, old_size: usize, align
 // This should never be passed a null pointer.
 extern fn roc_dealloc(c_ptr: *anyopaque, alignment: u32) callconv(.C) void;
 
-// Signals to the host that the program has panicked
-extern fn roc_panic(c_ptr: *const anyopaque, tag_id: u32) callconv(.C) void;
-
 // should work just like libc memcpy (we can't assume libc is present)
 extern fn roc_memcpy(dst: [*]u8, src: [*]u8, size: usize) callconv(.C) void;
 
@@ -106,11 +103,6 @@ pub fn realloc(c_ptr: [*]u8, new_size: usize, old_size: usize, alignment: u32) [
 
 pub fn dealloc(c_ptr: [*]u8, alignment: u32) void {
     return @call(.{ .modifier = always_inline }, roc_dealloc, .{ c_ptr, alignment });
-}
-
-// must export this explicitly because right now it is not used from zig code
-pub fn panic(c_ptr: *const anyopaque, alignment: u32) callconv(.C) void {
-    return @call(.{ .modifier = always_inline }, roc_panic, .{ c_ptr, alignment });
 }
 
 pub fn memcpy(dst: [*]u8, src: [*]u8, size: usize) void {

--- a/crates/compiler/can/src/copy.rs
+++ b/crates/compiler/can/src/copy.rs
@@ -376,7 +376,10 @@ fn deep_copy_expr_help<C: CopyEnv>(env: &mut C, copied: &mut Vec<Variable>, expr
                 *called_via,
             )
         }
-        Crash => Crash,
+        Crash { msg, ret_var } => Crash {
+            msg: Box::new(msg.map(|m| go_help!(m))),
+            ret_var: sub!(*ret_var),
+        },
         RunLowLevel { op, args, ret_var } => RunLowLevel {
             op: *op,
             args: args

--- a/crates/compiler/can/src/copy.rs
+++ b/crates/compiler/can/src/copy.rs
@@ -376,6 +376,7 @@ fn deep_copy_expr_help<C: CopyEnv>(env: &mut C, copied: &mut Vec<Variable>, expr
                 *called_via,
             )
         }
+        Crash => Crash,
         RunLowLevel { op, args, ret_var } => RunLowLevel {
             op: *op,
             args: args

--- a/crates/compiler/can/src/expr.rs
+++ b/crates/compiler/can/src/expr.rs
@@ -2883,6 +2883,7 @@ fn get_lookup_symbols(expr: &Expr) -> Vec<ExpectLookup> {
                 // Intentionally ignore the lookups in the nested `expect` condition itself,
                 // because they couldn't possibly influence the outcome of this `expect`!
             }
+            Expr::Crash { msg, .. } => stack.push(&msg.value),
             Expr::Num(_, _, _, _)
             | Expr::Float(_, _, _, _, _)
             | Expr::Int(_, _, _, _, _)

--- a/crates/compiler/can/src/expr.rs
+++ b/crates/compiler/can/src/expr.rs
@@ -166,6 +166,9 @@ pub enum Expr {
     /// Empty record constant
     EmptyRecord,
 
+    /// The "crash" keyword
+    Crash,
+
     /// Look up exactly one field on a record, e.g. (expr).foo.
     Access {
         record_var: Variable,
@@ -309,6 +312,7 @@ impl Expr {
             }
             Self::Expect { .. } => Category::Expect,
             Self::ExpectFx { .. } => Category::Expect,
+            Self::Crash => Category::Crash,
 
             Self::Dbg { .. } => Category::Expect,
 
@@ -874,6 +878,7 @@ pub fn canonicalize_expr<'a>(
 
             (RuntimeError(problem), Output::default())
         }
+        ast::Expr::Crash => (Crash, Output::default()),
         ast::Expr::Defs(loc_defs, loc_ret) => {
             // The body expression gets a new scope for canonicalization,
             scope.inner_scope(|inner_scope| {
@@ -1720,7 +1725,8 @@ pub fn inline_calls(var_store: &mut VarStore, expr: Expr) -> Expr {
         | other @ RunLowLevel { .. }
         | other @ TypedHole { .. }
         | other @ ForeignCall { .. }
-        | other @ OpaqueWrapFunction(_) => other,
+        | other @ OpaqueWrapFunction(_)
+        | other @ Crash => other,
 
         List {
             elem_var,
@@ -2828,7 +2834,8 @@ fn get_lookup_symbols(expr: &Expr) -> Vec<ExpectLookup> {
             | Expr::EmptyRecord
             | Expr::TypedHole(_)
             | Expr::RuntimeError(_)
-            | Expr::OpaqueWrapFunction(_) => {}
+            | Expr::OpaqueWrapFunction(_)
+            | Expr::Crash => {}
         }
     }
 

--- a/crates/compiler/can/src/module.rs
+++ b/crates/compiler/can/src/module.rs
@@ -981,6 +981,14 @@ fn fix_values_captured_in_closure_expr(
             );
         }
 
+        Crash { msg, ret_var: _ } => {
+            fix_values_captured_in_closure_expr(
+                &mut msg.value,
+                no_capture_symbols,
+                closure_captures,
+            );
+        }
+
         Closure(ClosureData {
             captured_symbols,
             name,
@@ -1056,8 +1064,7 @@ fn fix_values_captured_in_closure_expr(
         | TypedHole { .. }
         | RuntimeError(_)
         | ZeroArgumentTag { .. }
-        | Accessor { .. }
-        | Crash => {}
+        | Accessor { .. } => {}
 
         List { loc_elems, .. } => {
             for elem in loc_elems.iter_mut() {

--- a/crates/compiler/can/src/module.rs
+++ b/crates/compiler/can/src/module.rs
@@ -1056,7 +1056,8 @@ fn fix_values_captured_in_closure_expr(
         | TypedHole { .. }
         | RuntimeError(_)
         | ZeroArgumentTag { .. }
-        | Accessor { .. } => {}
+        | Accessor { .. }
+        | Crash => {}
 
         List { loc_elems, .. } => {
             for elem in loc_elems.iter_mut() {

--- a/crates/compiler/can/src/operator.rs
+++ b/crates/compiler/can/src/operator.rs
@@ -138,7 +138,8 @@ pub fn desugar_expr<'a>(arena: &'a Bump, loc_expr: &'a Loc<Expr<'a>>) -> &'a Loc
         | MalformedClosure
         | PrecedenceConflict { .. }
         | Tag(_)
-        | OpaqueRef(_) => loc_expr,
+        | OpaqueRef(_)
+        | Crash => loc_expr,
 
         TupleAccess(_sub_expr, _paths) => todo!("Handle TupleAccess"),
         RecordAccess(sub_expr, paths) => {

--- a/crates/compiler/can/src/traverse.rs
+++ b/crates/compiler/can/src/traverse.rs
@@ -185,7 +185,6 @@ pub fn walk_expr<V: Visitor>(visitor: &mut V, expr: &Expr, var: Variable) {
         }
         Expr::Var(..) => { /* terminal */ }
         Expr::AbilityMember(..) => { /* terminal */ }
-        Expr::Crash => { /* terminal */ }
         Expr::If {
             cond_var,
             branches,
@@ -203,6 +202,9 @@ pub fn walk_expr<V: Visitor>(visitor: &mut V, expr: &Expr, var: Variable) {
         Expr::Call(f, args, _called_via) => {
             let (fn_var, loc_fn, _closure_var, _ret_var) = &**f;
             walk_call(visitor, *fn_var, loc_fn, args);
+        }
+        Expr::Crash { msg, .. } => {
+            visitor.visit_expr(&msg.value, msg.region, Variable::STR);
         }
         Expr::RunLowLevel {
             op: _,

--- a/crates/compiler/can/src/traverse.rs
+++ b/crates/compiler/can/src/traverse.rs
@@ -185,6 +185,7 @@ pub fn walk_expr<V: Visitor>(visitor: &mut V, expr: &Expr, var: Variable) {
         }
         Expr::Var(..) => { /* terminal */ }
         Expr::AbilityMember(..) => { /* terminal */ }
+        Expr::Crash => { /* terminal */ }
         Expr::If {
             cond_var,
             branches,

--- a/crates/compiler/constrain/src/expr.rs
+++ b/crates/compiler/constrain/src/expr.rs
@@ -482,6 +482,12 @@ pub fn constrain_expr(
             let and_constraint = constraints.and_constraint(and_cons);
             constraints.exists(vars, and_constraint)
         }
+        Expr::Crash => {
+            let crash_type_index = constraints.push_type(Type::Crash);
+            let expected_index = constraints.push_expected_type(expected);
+
+            constraints.equal_types(crash_type_index, expected_index, Category::Crash, region)
+        }
         Var(symbol, variable) => {
             // Save the expectation in the variable, then lookup the symbol's type in the environment
             let expected_type = *constraints[expected].get_type_ref();

--- a/crates/compiler/constrain/src/expr.rs
+++ b/crates/compiler/constrain/src/expr.rs
@@ -483,12 +483,22 @@ pub fn constrain_expr(
             constraints.exists(vars, and_constraint)
         }
         Expr::Crash { msg, ret_var } => {
-            let expected_msg = Expected::ForReason(Reason::CrashArg, str_type(), msg.region);
-            let expected_ret = constraints.push_expected_type(expected);
+            let str_index = constraints.push_type(types, Types::STR);
+            let expected_msg = constraints.push_expected_type(Expected::ForReason(
+                Reason::CrashArg,
+                str_index,
+                msg.region,
+            ));
 
-            let msg_is_str = constrain_expr(constraints, env, msg.region, &msg.value, expected_msg);
-            let magic =
-                constraints.equal_types_var(*ret_var, expected_ret, Category::Crash, region);
+            let msg_is_str = constrain_expr(
+                types,
+                constraints,
+                env,
+                msg.region,
+                &msg.value,
+                expected_msg,
+            );
+            let magic = constraints.equal_types_var(*ret_var, expected, Category::Crash, region);
 
             let and = constraints.and_constraint([msg_is_str, magic]);
 

--- a/crates/compiler/constrain/src/expr.rs
+++ b/crates/compiler/constrain/src/expr.rs
@@ -482,11 +482,17 @@ pub fn constrain_expr(
             let and_constraint = constraints.and_constraint(and_cons);
             constraints.exists(vars, and_constraint)
         }
-        Expr::Crash => {
-            let crash_type_index = constraints.push_type(Type::Crash);
-            let expected_index = constraints.push_expected_type(expected);
+        Expr::Crash { msg, ret_var } => {
+            let expected_msg = Expected::ForReason(Reason::CrashArg, str_type(), msg.region);
+            let expected_ret = constraints.push_expected_type(expected);
 
-            constraints.equal_types(crash_type_index, expected_index, Category::Crash, region)
+            let msg_is_str = constrain_expr(constraints, env, msg.region, &msg.value, expected_msg);
+            let magic =
+                constraints.equal_types_var(*ret_var, expected_ret, Category::Crash, region);
+
+            let and = constraints.and_constraint([msg_is_str, magic]);
+
+            constraints.exists([*ret_var], and)
         }
         Var(symbol, variable) => {
             // Save the expectation in the variable, then lookup the symbol's type in the environment

--- a/crates/compiler/fmt/src/expr.rs
+++ b/crates/compiler/fmt/src/expr.rs
@@ -43,7 +43,8 @@ impl<'a> Formattable for Expr<'a> {
             | MalformedIdent(_, _)
             | MalformedClosure
             | Tag(_)
-            | OpaqueRef(_) => false,
+            | OpaqueRef(_)
+            | Crash => false,
 
             // These expressions always have newlines
             Defs(_, _) | When(_, _) => true,
@@ -190,6 +191,10 @@ impl<'a> Formattable for Expr<'a> {
                 buf.indent(indent);
                 buf.push('_');
                 buf.push_str(name);
+            }
+            Crash => {
+                buf.indent(indent);
+                buf.push_str("crash");
             }
             Apply(loc_expr, loc_args, _) => {
                 buf.indent(indent);

--- a/crates/compiler/fmt/src/spaces.rs
+++ b/crates/compiler/fmt/src/spaces.rs
@@ -666,6 +666,7 @@ impl<'a> RemoveSpaces<'a> for Expr<'a> {
                 arena.alloc(a.remove_spaces(arena)),
                 arena.alloc(b.remove_spaces(arena)),
             ),
+            Expr::Crash => Expr::Crash,
             Expr::Defs(a, b) => {
                 let mut defs = a.clone();
                 defs.space_before = vec![Default::default(); defs.len()];

--- a/crates/compiler/fmt/tests/test_fmt.rs
+++ b/crates/compiler/fmt/tests/test_fmt.rs
@@ -5829,6 +5829,42 @@ mod test_fmt {
         );
     }
 
+    #[test]
+    fn format_crash() {
+        expr_formats_same(indoc!(
+            r#"
+            _ = crash
+            _ = crash ""
+
+            crash "" ""
+            "#
+        ));
+
+        expr_formats_to(
+            indoc!(
+                r#"
+                _ = crash
+                _ = crash    ""
+                _ = crash   ""   ""
+                try
+                    foo
+                    (\_ ->   crash "")
+                "#
+            ),
+            indoc!(
+                r#"
+                _ = crash
+                _ = crash ""
+                _ = crash "" ""
+
+                try
+                    foo
+                    (\_ -> crash "")
+                "#
+            ),
+        );
+    }
+
     // this is a parse error atm
     //    #[test]
     //    fn multiline_apply() {

--- a/crates/compiler/gen_dev/src/lib.rs
+++ b/crates/compiler/gen_dev/src/lib.rs
@@ -1110,7 +1110,6 @@ trait Backend<'a> {
             Stmt::Expect { .. } => todo!("expect is not implemented in the dev backend"),
             Stmt::ExpectFx { .. } => todo!("expect-fx is not implemented in the dev backend"),
 
-            Stmt::RuntimeError(..) => todo!("runtime-error is not implemented in the dev backend"),
             Stmt::Crash(..) => todo!("crash is not implemented in the dev backend"),
         }
     }

--- a/crates/compiler/gen_dev/src/lib.rs
+++ b/crates/compiler/gen_dev/src/lib.rs
@@ -1110,7 +1110,8 @@ trait Backend<'a> {
             Stmt::Expect { .. } => todo!("expect is not implemented in the dev backend"),
             Stmt::ExpectFx { .. } => todo!("expect-fx is not implemented in the dev backend"),
 
-            Stmt::RuntimeError(_) => {}
+            Stmt::RuntimeError(..) => todo!("runtime-error is not implemented in the dev backend"),
+            Stmt::Crash(..) => todo!("crash is not implemented in the dev backend"),
         }
     }
 

--- a/crates/compiler/gen_llvm/src/llvm/build.rs
+++ b/crates/compiler/gen_llvm/src/llvm/build.rs
@@ -2715,6 +2715,7 @@ pub fn build_exp_stmt<'a, 'ctx, 'env>(
             let zero = env.context.i64_type().const_zero();
             zero.into()
         }
+        Crash(_, _) => todo!(),
     }
 }
 

--- a/crates/compiler/gen_llvm/src/llvm/build.rs
+++ b/crates/compiler/gen_llvm/src/llvm/build.rs
@@ -185,7 +185,7 @@ pub struct Env<'a, 'ctx, 'env> {
 
 #[repr(u32)]
 pub enum PanicTagId {
-    NullTerminatedString = 0,
+    RocPanic = 0,
 }
 
 impl std::convert::TryFrom<u32> for PanicTagId {
@@ -193,7 +193,7 @@ impl std::convert::TryFrom<u32> for PanicTagId {
 
     fn try_from(value: u32) -> Result<Self, Self::Error> {
         match value {
-            0 => Ok(PanicTagId::NullTerminatedString),
+            0 => Ok(PanicTagId::RocPanic),
             _ => Err(()),
         }
     }
@@ -5529,7 +5529,7 @@ pub(crate) fn throw_exception<'a, 'ctx, 'env>(
 
     let str = build_string_literal(env, parent, message);
 
-    env.call_panic(str, PanicTagId::NullTerminatedString);
+    env.call_panic(str, PanicTagId::RocPanic);
 
     builder.build_unreachable();
 }

--- a/crates/compiler/gen_llvm/src/llvm/build.rs
+++ b/crates/compiler/gen_llvm/src/llvm/build.rs
@@ -2718,7 +2718,7 @@ pub fn build_exp_stmt<'a, 'ctx, 'env>(
             zero.into()
         }
         Crash(sym, _) => {
-            throw_user_exception(env, scope, parent, sym);
+            throw_user_exception(env, scope, sym);
 
             // unused value (must return a BasicValue)
             let zero = env.context.i64_type().const_zero();
@@ -5563,7 +5563,6 @@ pub(crate) fn throw_exception<'a, 'ctx, 'env>(
 pub(crate) fn throw_user_exception<'a, 'ctx, 'env>(
     env: &Env<'a, 'ctx, 'env>,
     scope: &mut Scope<'a, 'ctx>,
-    parent: FunctionValue<'ctx>,
     message: &Symbol,
 ) {
     let msg_val = load_symbol(scope, message);

--- a/crates/compiler/gen_llvm/src/llvm/build.rs
+++ b/crates/compiler/gen_llvm/src/llvm/build.rs
@@ -195,6 +195,7 @@ impl std::convert::TryFrom<u32> for PanicTagId {
     fn try_from(value: u32) -> Result<Self, Self::Error> {
         match value {
             0 => Ok(PanicTagId::RocPanic),
+            1 => Ok(PanicTagId::UserPanic),
             _ => Err(()),
         }
     }

--- a/crates/compiler/gen_llvm/src/llvm/build.rs
+++ b/crates/compiler/gen_llvm/src/llvm/build.rs
@@ -750,7 +750,7 @@ pub fn build_exp_literal<'a, 'ctx, 'env>(
         }
         Bool(b) => env.context.bool_type().const_int(*b as u64, false).into(),
         Byte(b) => env.context.i8_type().const_int(*b as u64, false).into(),
-        Str(str_literal) => build_string_literal(env, parent, &str_literal),
+        Str(str_literal) => build_string_literal(env, parent, str_literal),
     }
 }
 
@@ -3927,11 +3927,8 @@ fn set_jump_and_catch_long_jump<'a, 'ctx, 'env>(
     {
         builder.position_at_end(catch_block);
 
-        let error_msg_ptr = {
-            // RocStr* global
-            let ptr_roc_str = get_panic_msg_ptr(env);
-            ptr_roc_str
-        };
+        // RocStr* global
+        let error_msg_ptr = get_panic_msg_ptr(env);
 
         let return_value = {
             let v1 = call_result_type.const_zero();
@@ -5520,30 +5517,6 @@ fn define_global_str_literal<'a, 'ctx, 'env>(
 
             global
         }
-    }
-}
-
-fn define_global_error_str<'a, 'ctx, 'env>(
-    env: &Env<'a, 'ctx, 'env>,
-    message: &str,
-) -> inkwell::values::GlobalValue<'ctx> {
-    let module = env.module;
-
-    // hash the name so we don't re-define existing messages
-    let name = {
-        use std::collections::hash_map::DefaultHasher;
-        use std::hash::{Hash, Hasher};
-
-        let mut hasher = DefaultHasher::new();
-        message.hash(&mut hasher);
-        let hash = hasher.finish();
-
-        format!("_Error_message_{}", hash)
-    };
-
-    match module.get_global(&name) {
-        Some(current) => current,
-        None => unsafe { env.builder.build_global_string(message, name.as_str()) },
     }
 }
 

--- a/crates/compiler/gen_llvm/src/llvm/build.rs
+++ b/crates/compiler/gen_llvm/src/llvm/build.rs
@@ -750,25 +750,30 @@ pub fn build_exp_literal<'a, 'ctx, 'env>(
         }
         Bool(b) => env.context.bool_type().const_int(*b as u64, false).into(),
         Byte(b) => env.context.i8_type().const_int(*b as u64, false).into(),
-        Str(str_literal) => {
-            if str_literal.len() < env.small_str_bytes() as usize {
-                match env.small_str_bytes() {
-                    24 => small_str_ptr_width_8(env, parent, str_literal).into(),
-                    12 => small_str_ptr_width_4(env, str_literal).into(),
-                    _ => unreachable!("incorrect small_str_bytes"),
-                }
-            } else {
-                let ptr = define_global_str_literal_ptr(env, str_literal);
-                let number_of_elements = env.ptr_int().const_int(str_literal.len() as u64, false);
+        Str(str_literal) => build_string_literal(env, parent, &str_literal),
+    }
+}
 
-                let alloca =
-                    const_str_alloca_ptr(env, parent, ptr, number_of_elements, number_of_elements);
+fn build_string_literal<'a, 'ctx, 'env>(
+    env: &Env<'a, 'ctx, 'env>,
+    parent: FunctionValue<'ctx>,
+    str_literal: &str,
+) -> BasicValueEnum<'ctx> {
+    if str_literal.len() < env.small_str_bytes() as usize {
+        match env.small_str_bytes() {
+            24 => small_str_ptr_width_8(env, parent, str_literal).into(),
+            12 => small_str_ptr_width_4(env, str_literal).into(),
+            _ => unreachable!("incorrect small_str_bytes"),
+        }
+    } else {
+        let ptr = define_global_str_literal_ptr(env, str_literal);
+        let number_of_elements = env.ptr_int().const_int(str_literal.len() as u64, false);
 
-                match env.target_info.ptr_width() {
-                    PtrWidth::Bytes4 => env.builder.build_load(alloca, "load_const_str"),
-                    PtrWidth::Bytes8 => alloca.into(),
-                }
-            }
+        let alloca = const_str_alloca_ptr(env, parent, ptr, number_of_elements, number_of_elements);
+
+        match env.target_info.ptr_width() {
+            PtrWidth::Bytes4 => env.builder.build_load(alloca, "load_const_str"),
+            PtrWidth::Bytes8 => alloca.into(),
         }
     }
 }

--- a/crates/compiler/gen_llvm/src/llvm/lowlevel.rs
+++ b/crates/compiler/gen_llvm/src/llvm/lowlevel.rs
@@ -41,9 +41,9 @@ use crate::llvm::{
     },
 };
 
-use super::convert::zig_with_overflow_roc_dec;
+use super::{build::throw_internal_exception, convert::zig_with_overflow_roc_dec};
 use super::{
-    build::{load_symbol, load_symbol_and_layout, throw_exception, Env, Scope},
+    build::{load_symbol, load_symbol_and_layout, Env, Scope},
     convert::zig_dec_type,
 };
 
@@ -1557,7 +1557,7 @@ fn throw_on_overflow<'a, 'ctx, 'env>(
 
     bd.position_at_end(throw_block);
 
-    throw_exception(env, parent, message);
+    throw_internal_exception(env, parent, message);
 
     bd.position_at_end(then_block);
 
@@ -2003,7 +2003,7 @@ fn int_neg_raise_on_overflow<'a, 'ctx, 'env>(
 
     builder.position_at_end(then_block);
 
-    throw_exception(
+    throw_internal_exception(
         env,
         parent,
         "integer negation overflowed because its argument is the minimum value",
@@ -2034,7 +2034,7 @@ fn int_abs_raise_on_overflow<'a, 'ctx, 'env>(
 
     builder.position_at_end(then_block);
 
-    throw_exception(
+    throw_internal_exception(
         env,
         parent,
         "integer absolute overflowed because its argument is the minimum value",

--- a/crates/compiler/gen_llvm/src/llvm/lowlevel.rs
+++ b/crates/compiler/gen_llvm/src/llvm/lowlevel.rs
@@ -1557,7 +1557,7 @@ fn throw_on_overflow<'a, 'ctx, 'env>(
 
     bd.position_at_end(throw_block);
 
-    throw_exception(env, message);
+    throw_exception(env, parent, message);
 
     bd.position_at_end(then_block);
 
@@ -2005,6 +2005,7 @@ fn int_neg_raise_on_overflow<'a, 'ctx, 'env>(
 
     throw_exception(
         env,
+        parent,
         "integer negation overflowed because its argument is the minimum value",
     );
 
@@ -2035,6 +2036,7 @@ fn int_abs_raise_on_overflow<'a, 'ctx, 'env>(
 
     throw_exception(
         env,
+        parent,
         "integer absolute overflowed because its argument is the minimum value",
     );
 

--- a/crates/compiler/gen_llvm/src/run_roc.rs
+++ b/crates/compiler/gen_llvm/src/run_roc.rs
@@ -119,7 +119,7 @@ macro_rules! run_jit_function {
 
                 $transform(success)
             }
-            Err(error_msg) => {
+            Err((error_msg, _)) => {
                 eprintln!("This Roc code crashed with: \"{error_msg}\"");
 
                 Expr::MalformedClosure

--- a/crates/compiler/gen_llvm/src/run_roc.rs
+++ b/crates/compiler/gen_llvm/src/run_roc.rs
@@ -32,13 +32,13 @@ impl<T: Default> Default for RocCallResult<T> {
     }
 }
 
-impl<T: Sized> From<RocCallResult<T>> for Result<T, String> {
+impl<T: Sized> From<RocCallResult<T>> for Result<T, (String, u32)> {
     fn from(call_result: RocCallResult<T>) -> Self {
         match call_result.tag {
             0 => Ok(unsafe { call_result.value.assume_init() }),
-            _ => Err({
+            n => Err({
                 let msg: &RocStr = unsafe { &*call_result.error_msg };
-                msg.as_str().to_owned()
+                (msg.as_str().to_owned(), (n - 1) as _)
             }),
         }
     }

--- a/crates/compiler/gen_llvm/src/run_roc.rs
+++ b/crates/compiler/gen_llvm/src/run_roc.rs
@@ -1,6 +1,4 @@
-use std::ffi::CStr;
 use std::mem::MaybeUninit;
-use std::os::raw::c_char;
 
 use roc_std::RocStr;
 

--- a/crates/compiler/gen_wasm/src/backend.rs
+++ b/crates/compiler/gen_wasm/src/backend.rs
@@ -988,17 +988,27 @@ impl<'a> WasmBackend<'a> {
     }
 
     pub fn stmt_runtime_error(&mut self, msg: &'a str) {
-        // Create a zero-terminated version of the message string
-        let mut bytes = Vec::with_capacity_in(msg.len() + 1, self.env.arena);
-        bytes.extend_from_slice(msg.as_bytes());
-        bytes.push(0);
+        let msg_sym = self.create_symbol("panic_str");
+        let msg_storage = self.storage.allocate_var(
+            self.env.layout_interner,
+            Layout::Builtin(Builtin::Str),
+            msg_sym,
+            StoredVarKind::Variable,
+        );
 
-        // Store it in the app's data section
-        let elements_addr = self.store_bytes_in_data_section(&bytes);
+        // Store the message as a RocStr on the stack
+        let (local_id, offset) = match msg_storage {
+            StoredValue::StackMemory { location, .. } => {
+                location.local_and_offset(self.storage.stack_frame_pointer)
+            }
+            _ => internal_error!("String must always have stack memory"),
+        };
+        self.expr_string_literal(msg, local_id, offset);
 
-        // Pass its address to roc_panic
         let tag_id = 0;
-        self.code_builder.i32_const(elements_addr as i32);
+        // load the pointer
+        self.storage
+            .load_symbols(&mut self.code_builder, &[msg_sym]);
         self.code_builder.i32_const(tag_id);
         self.call_host_fn_after_loading_args("roc_panic", 2, false);
 

--- a/crates/compiler/gen_wasm/src/backend.rs
+++ b/crates/compiler/gen_wasm/src/backend.rs
@@ -987,34 +987,6 @@ impl<'a> WasmBackend<'a> {
         self.stmt(rc_stmt);
     }
 
-    pub fn stmt_runtime_error(&mut self, msg: &'a str) {
-        let msg_sym = self.create_symbol("panic_str");
-        let msg_storage = self.storage.allocate_var(
-            self.env.layout_interner,
-            Layout::Builtin(Builtin::Str),
-            msg_sym,
-            StoredVarKind::Variable,
-        );
-
-        // Store the message as a RocStr on the stack
-        let (local_id, offset) = match msg_storage {
-            StoredValue::StackMemory { location, .. } => {
-                location.local_and_offset(self.storage.stack_frame_pointer)
-            }
-            _ => internal_error!("String must always have stack memory"),
-        };
-        self.expr_string_literal(msg, local_id, offset);
-
-        let tag_id = 0;
-        // load the pointer
-        self.storage
-            .load_symbols(&mut self.code_builder, &[msg_sym]);
-        self.code_builder.i32_const(tag_id);
-        self.call_host_fn_after_loading_args("roc_panic", 2, false);
-
-        self.code_builder.unreachable_();
-    }
-
     pub fn stmt_crash(&mut self, msg: Symbol, tag: CrashTag) {
         // load the pointer
         self.storage.load_symbols(&mut self.code_builder, &[msg]);

--- a/crates/compiler/gen_wasm/src/backend.rs
+++ b/crates/compiler/gen_wasm/src/backend.rs
@@ -718,7 +718,7 @@ impl<'a> WasmBackend<'a> {
             Stmt::ExpectFx { .. } => todo!("expect-fx is not implemented in the wasm backend"),
 
             Stmt::RuntimeError(msg) => self.stmt_runtime_error(msg),
-            Stmt::Crash(_, _) => todo!(),
+            Stmt::Crash(sym, _) => self.stmt_crash(*sym),
         }
     }
 
@@ -1010,6 +1010,16 @@ impl<'a> WasmBackend<'a> {
         // load the pointer
         self.storage
             .load_symbols(&mut self.code_builder, &[msg_sym]);
+        self.code_builder.i32_const(tag_id);
+        self.call_host_fn_after_loading_args("roc_panic", 2, false);
+
+        self.code_builder.unreachable_();
+    }
+
+    pub fn stmt_crash(&mut self, msg: Symbol) {
+        let tag_id = 1;
+        // load the pointer
+        self.storage.load_symbols(&mut self.code_builder, &[msg]);
         self.code_builder.i32_const(tag_id);
         self.call_host_fn_after_loading_args("roc_panic", 2, false);
 

--- a/crates/compiler/gen_wasm/src/backend.rs
+++ b/crates/compiler/gen_wasm/src/backend.rs
@@ -718,6 +718,7 @@ impl<'a> WasmBackend<'a> {
             Stmt::ExpectFx { .. } => todo!("expect-fx is not implemented in the wasm backend"),
 
             Stmt::RuntimeError(msg) => self.stmt_runtime_error(msg),
+            Stmt::Crash(_, _) => todo!(),
         }
     }
 

--- a/crates/compiler/gen_wasm/src/low_level.rs
+++ b/crates/compiler/gen_wasm/src/low_level.rs
@@ -1362,7 +1362,7 @@ impl<'a> LowLevelCall<'a> {
                         backend.code_builder.i32_const(i32::MIN);
                         backend.code_builder.i32_eq();
                         backend.code_builder.if_();
-                        backend.stmt_runtime_error(PANIC_MSG);
+                        backend.stmt_internal_error(PANIC_MSG);
                         backend.code_builder.end();
 
                         // x
@@ -1388,7 +1388,7 @@ impl<'a> LowLevelCall<'a> {
                         backend.code_builder.i64_const(i64::MIN);
                         backend.code_builder.i64_eq();
                         backend.code_builder.if_();
-                        backend.stmt_runtime_error(PANIC_MSG);
+                        backend.stmt_internal_error(PANIC_MSG);
                         backend.code_builder.end();
 
                         // x
@@ -1422,7 +1422,7 @@ impl<'a> LowLevelCall<'a> {
                         backend.code_builder.i32_const(i32::MIN);
                         backend.code_builder.i32_eq();
                         backend.code_builder.if_();
-                        backend.stmt_runtime_error(PANIC_MSG);
+                        backend.stmt_internal_error(PANIC_MSG);
                         backend.code_builder.end();
 
                         backend.code_builder.i32_const(0);
@@ -1433,7 +1433,7 @@ impl<'a> LowLevelCall<'a> {
                         backend.code_builder.i64_const(i64::MIN);
                         backend.code_builder.i64_eq();
                         backend.code_builder.if_();
-                        backend.stmt_runtime_error(PANIC_MSG);
+                        backend.stmt_internal_error(PANIC_MSG);
                         backend.code_builder.end();
 
                         backend.code_builder.i64_const(0);

--- a/crates/compiler/mono/src/borrow.rs
+++ b/crates/compiler/mono/src/borrow.rs
@@ -321,7 +321,7 @@ impl<'a> ParamMap<'a> {
                 }
                 Refcounting(_, _) => unreachable!("these have not been introduced yet"),
 
-                Ret(_) | Jump(_, _) | RuntimeError(_) | Crash(..) => {
+                Ret(_) | Jump(_, _) | Crash(..) => {
                     // these are terminal, do nothing
                 }
             }
@@ -832,7 +832,7 @@ impl<'a> BorrowInfState<'a> {
                 self.own_var(*msg);
             }
 
-            Ret(_) | RuntimeError(_) => {
+            Ret(_) => {
                 // these are terminal, do nothing
             }
         }
@@ -1006,7 +1006,7 @@ fn call_info_stmt<'a>(arena: &'a Bump, stmt: &Stmt<'a>, info: &mut CallInfo<'a>)
 
             Refcounting(_, _) => unreachable!("these have not been introduced yet"),
 
-            Ret(_) | Jump(_, _) | RuntimeError(_) | Crash(..) => {
+            Ret(_) | Jump(_, _) | Crash(..) => {
                 // these are terminal, do nothing
             }
         }

--- a/crates/compiler/mono/src/borrow.rs
+++ b/crates/compiler/mono/src/borrow.rs
@@ -321,7 +321,7 @@ impl<'a> ParamMap<'a> {
                 }
                 Refcounting(_, _) => unreachable!("these have not been introduced yet"),
 
-                Ret(_) | Jump(_, _) | RuntimeError(_) => {
+                Ret(_) | Jump(_, _) | RuntimeError(_) | Crash(..) => {
                     // these are terminal, do nothing
                 }
             }
@@ -827,6 +827,11 @@ impl<'a> BorrowInfState<'a> {
 
             Refcounting(_, _) => unreachable!("these have not been introduced yet"),
 
+            Crash(msg, _) => {
+                // Crash is a foreign call, so we must own the argument.
+                self.own_var(*msg);
+            }
+
             Ret(_) | RuntimeError(_) => {
                 // these are terminal, do nothing
             }
@@ -1001,7 +1006,7 @@ fn call_info_stmt<'a>(arena: &'a Bump, stmt: &Stmt<'a>, info: &mut CallInfo<'a>)
 
             Refcounting(_, _) => unreachable!("these have not been introduced yet"),
 
-            Ret(_) | Jump(_, _) | RuntimeError(_) => {
+            Ret(_) | Jump(_, _) | RuntimeError(_) | Crash(..) => {
                 // these are terminal, do nothing
             }
         }

--- a/crates/compiler/mono/src/inc_dec.rs
+++ b/crates/compiler/mono/src/inc_dec.rs
@@ -161,8 +161,6 @@ pub fn occurring_variables(stmt: &Stmt<'_>) -> (MutSet<Symbol>, MutSet<Symbol>) 
             Crash(sym, _) => {
                 result.insert(*sym);
             }
-
-            RuntimeError(_) => {}
         }
     }
 
@@ -1257,7 +1255,7 @@ impl<'a, 'i> Context<'a, 'i> {
                 }
             }
 
-            RuntimeError(_) | Refcounting(_, _) => (stmt, MutSet::default()),
+            Refcounting(_, _) => (stmt, MutSet::default()),
         }
     }
 }
@@ -1432,8 +1430,6 @@ pub fn collect_stmt(
             vars.insert(*m);
             vars
         }
-
-        RuntimeError(_) => vars,
     }
 }
 

--- a/crates/compiler/mono/src/ir.rs
+++ b/crates/compiler/mono/src/ir.rs
@@ -5562,7 +5562,7 @@ pub fn with_hole<'a>(
         }
         TypedHole(_) => Stmt::RuntimeError("Hit a blank"),
         RuntimeError(e) => Stmt::RuntimeError(env.arena.alloc(e.runtime_message())),
-        Crash => todo!(),
+        Crash { .. } => todo!(),
     }
 }
 

--- a/crates/compiler/mono/src/ir.rs
+++ b/crates/compiler/mono/src/ir.rs
@@ -1660,7 +1660,7 @@ pub enum Stmt<'a> {
     Crash(Symbol, CrashTag),
 }
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CrashTag {
     User,
 }

--- a/crates/compiler/mono/src/ir.rs
+++ b/crates/compiler/mono/src/ir.rs
@@ -5562,6 +5562,7 @@ pub fn with_hole<'a>(
         }
         TypedHole(_) => Stmt::RuntimeError("Hit a blank"),
         RuntimeError(e) => Stmt::RuntimeError(env.arena.alloc(e.runtime_message())),
+        Crash => todo!(),
     }
 }
 

--- a/crates/compiler/mono/src/ir.rs
+++ b/crates/compiler/mono/src/ir.rs
@@ -2338,7 +2338,7 @@ impl<'a> Stmt<'a> {
                 }
             }
 
-            Crash(s, _src) => alloc.text(format!("Crash {:?}", s)),
+            Crash(s, _src) => alloc.text("Crash ").append(symbol_to_doc(alloc, *s)),
 
             Join {
                 id,

--- a/crates/compiler/mono/src/ir.rs
+++ b/crates/compiler/mono/src/ir.rs
@@ -5571,18 +5571,16 @@ pub fn with_hole<'a>(
         TypedHole(_) => Stmt::RuntimeError("Hit a blank"),
         RuntimeError(e) => Stmt::RuntimeError(env.arena.alloc(e.runtime_message())),
         Crash { msg, ret_var: _ } => {
-            let msg_sym = env.unique_symbol();
-            let stmt = Stmt::Crash(msg_sym, CrashTag::User);
-
-            with_hole(
+            let msg_sym = possible_reuse_symbol_or_specialize(
                 env,
-                msg.value,
-                Variable::STR,
                 procs,
                 layout_cache,
-                msg_sym,
-                env.arena.alloc(stmt),
-            )
+                &msg.value,
+                Variable::STR,
+            );
+            let stmt = Stmt::Crash(msg_sym, CrashTag::User);
+
+            assign_to_symbol(env, procs, layout_cache, Variable::STR, *msg, msg_sym, stmt)
         }
     }
 }

--- a/crates/compiler/mono/src/ir.rs
+++ b/crates/compiler/mono/src/ir.rs
@@ -1668,14 +1668,29 @@ pub enum Stmt<'a> {
         remainder: &'a Stmt<'a>,
     },
     Jump(JoinPointId, &'a [Symbol]),
-    RuntimeError(&'a str),
     Crash(Symbol, CrashTag),
 }
 
+/// Source of crash, and its runtime representation to roc_panic.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u32)]
 pub enum CrashTag {
-    Roc,
-    User,
+    /// The crash is due to Roc, either via a builtin or type error.
+    Roc = 0,
+    /// The crash is user-defined.
+    User = 1,
+}
+
+impl TryFrom<u32> for CrashTag {
+    type Error = ();
+
+    fn try_from(value: u32) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(Self::Roc),
+            1 => Ok(Self::User),
+            _ => Err(()),
+        }
+    }
 }
 
 /// in the block below, symbol `scrutinee` is assumed be be of shape `tag_id`
@@ -2323,7 +2338,6 @@ impl<'a> Stmt<'a> {
                 }
             }
 
-            RuntimeError(s) => alloc.text(format!("Error {}", s)),
             Crash(s, _src) => alloc.text(format!("Crash {:?}", s)),
 
             Join {
@@ -3173,7 +3187,7 @@ fn generate_runtime_error_function<'a>(
         );
     });
 
-    let runtime_error = Stmt::RuntimeError(msg.into_bump_str());
+    let runtime_error = runtime_error(env, msg.into_bump_str());
 
     let (args, ret_layout) = match layout {
         RawFunctionLayout::Function(arg_layouts, lambda_set, ret_layout) => {
@@ -4321,7 +4335,7 @@ pub fn with_hole<'a>(
             };
             let sorted_fields = match sorted_fields_result {
                 Ok(fields) => fields,
-                Err(_) => return Stmt::RuntimeError("Can't create record with improper layout"),
+                Err(_) => return runtime_error(env, "Can't create record with improper layout"),
             };
 
             let mut field_symbols = Vec::with_capacity_in(fields.len(), env.arena);
@@ -4373,7 +4387,7 @@ pub fn with_hole<'a>(
             // creating a record from the var will unpack it if it's just a single field.
             let layout = match layout_cache.from_var(env.arena, record_var, env.subs) {
                 Ok(layout) => layout,
-                Err(_) => return Stmt::RuntimeError("Can't create record with improper layout"),
+                Err(_) => return runtime_error(env, "Can't create record with improper layout"),
             };
 
             let field_symbols = field_symbols.into_bump_slice();
@@ -4552,8 +4566,8 @@ pub fn with_hole<'a>(
                         }
                     }
                 }
-                (Err(_), _) => Stmt::RuntimeError("invalid ret_layout"),
-                (_, Err(_)) => Stmt::RuntimeError("invalid cond_layout"),
+                (Err(_), _) => runtime_error(env, "invalid ret_layout"),
+                (_, Err(_)) => runtime_error(env, "invalid cond_layout"),
             }
         }
 
@@ -4719,7 +4733,7 @@ pub fn with_hole<'a>(
             };
             let sorted_fields = match sorted_fields_result {
                 Ok(fields) => fields,
-                Err(_) => return Stmt::RuntimeError("Can't access record with improper layout"),
+                Err(_) => return runtime_error(env, "Can't access record with improper layout"),
             };
 
             let mut index = None;
@@ -4837,7 +4851,8 @@ pub fn with_hole<'a>(
                     }
                 }
 
-                Err(_error) => Stmt::RuntimeError(
+                Err(_error) => runtime_error(
+                    env,
                     "TODO convert anonymous function error to a RuntimeError string",
                 ),
             }
@@ -4893,7 +4908,8 @@ pub fn with_hole<'a>(
                     }
                 }
 
-                Err(_error) => Stmt::RuntimeError(
+                Err(_error) => runtime_error(
+                    env,
                     "TODO convert anonymous function error to a RuntimeError string",
                 ),
             }
@@ -4928,7 +4944,7 @@ pub fn with_hole<'a>(
 
             let sorted_fields = match sorted_fields_result {
                 Ok(fields) => fields,
-                Err(_) => return Stmt::RuntimeError("Can't update record with improper layout"),
+                Err(_) => return runtime_error(env, "Can't update record with improper layout"),
             };
 
             let mut field_layouts = Vec::with_capacity_in(sorted_fields.len(), env.arena);
@@ -5114,10 +5130,10 @@ pub fn with_hole<'a>(
                         layout_cache,
                     );
 
-                    if let Err(runtime_error) = inserted {
-                        return Stmt::RuntimeError(
-                            env.arena
-                                .alloc(format!("RuntimeError: {:?}", runtime_error,)),
+                    if let Err(e) = inserted {
+                        return runtime_error(
+                            env,
+                            env.arena.alloc(format!("RuntimeError: {:?}", e,)),
                         );
                     } else {
                         drop(inserted);
@@ -5581,8 +5597,8 @@ pub fn with_hole<'a>(
                 }
             }
         }
-        TypedHole(_) => Stmt::RuntimeError("Hit a blank"),
-        RuntimeError(e) => Stmt::RuntimeError(env.arena.alloc(e.runtime_message())),
+        TypedHole(_) => runtime_error(env, "Hit a blank"),
+        RuntimeError(e) => runtime_error(env, env.arena.alloc(e.runtime_message())),
         Crash { msg, ret_var: _ } => {
             let msg_sym = possible_reuse_symbol_or_specialize(
                 env,
@@ -5853,16 +5869,22 @@ fn convert_tag_union<'a>(
     let variant = match res_variant {
         Ok(cached) => cached,
         Err(LayoutProblem::UnresolvedTypeVar(_)) => {
-            return Stmt::RuntimeError(env.arena.alloc(format!(
-                "Unresolved type variable for tag {}",
-                tag_name.0.as_str()
-            )))
+            return runtime_error(
+                env,
+                env.arena.alloc(format!(
+                    "Unresolved type variable for tag {}",
+                    tag_name.0.as_str()
+                )),
+            )
         }
         Err(LayoutProblem::Erroneous) => {
-            return Stmt::RuntimeError(env.arena.alloc(format!(
-                "Tag {} was part of a type error!",
-                tag_name.0.as_str()
-            )));
+            return runtime_error(
+                env,
+                env.arena.alloc(format!(
+                    "Tag {} was part of a type error!",
+                    tag_name.0.as_str()
+                )),
+            );
         }
     };
 
@@ -5890,7 +5912,7 @@ fn convert_tag_union<'a>(
                     Layout::Builtin(Builtin::Int(IntWidth::U8)),
                     hole,
                 ),
-                None => Stmt::RuntimeError("tag must be in its own type"),
+                None => runtime_error(env, "tag must be in its own type"),
             }
         }
 
@@ -5930,7 +5952,7 @@ fn convert_tag_union<'a>(
 
             if dataful_tag != tag_name {
                 // this tag is not represented, and hence will never be reached, at runtime.
-                Stmt::RuntimeError("voided tag constructor is unreachable")
+                runtime_error(env, "voided tag constructor is unreachable")
             } else {
                 let field_symbols_temp = sorted_field_symbols(env, procs, layout_cache, args);
 
@@ -6194,10 +6216,13 @@ fn tag_union_to_function<'a>(
             }
         }
 
-        Err(runtime_error) => Stmt::RuntimeError(env.arena.alloc(format!(
-            "Could not produce tag function due to a runtime error: {:?}",
-            runtime_error,
-        ))),
+        Err(e) => runtime_error(
+            env,
+            env.arena.alloc(format!(
+                "Could not produce tag function due to a runtime error: {:?}",
+                e,
+            )),
+        ),
     }
 }
 
@@ -6747,7 +6772,7 @@ fn from_can_when<'a>(
     if branches.is_empty() {
         // A when-expression with no branches is a runtime error.
         // We can't know what to return!
-        return Stmt::RuntimeError("Hit a 0-branch when expression");
+        return runtime_error(env, "Hit a 0-branch when expression");
     }
     let opt_branches = to_opt_branches(env, procs, branches, exhaustive_mark, layout_cache);
 
@@ -7050,8 +7075,6 @@ fn substitute_in_stmt_help<'a>(
                 None
             }
         }
-
-        RuntimeError(_) => None,
         Crash(msg, tag) => substitute(subs, *msg).map(|new| &*arena.alloc(Crash(new, *tag))),
     }
 }
@@ -8435,7 +8458,7 @@ fn evaluate_arguments_then_runtime_error<'a>(
     let arena = env.arena;
 
     // eventually we will throw this runtime error
-    let result = Stmt::RuntimeError(env.arena.alloc(msg));
+    let result = runtime_error(env, env.arena.alloc(msg));
 
     // but, we also still evaluate and specialize the arguments to give better error messages
     let arg_symbols = Vec::from_iter_in(
@@ -8660,7 +8683,7 @@ fn call_by_name_help<'a>(
             Err(_) => {
                 // One of this function's arguments code gens to a runtime error,
                 // so attempting to call it will immediately crash.
-                return Stmt::RuntimeError("TODO runtime error for invalid layout");
+                return runtime_error(env, "TODO runtime error for invalid layout");
             }
         }
     }
@@ -10159,7 +10182,7 @@ where
     ToLowLevelCall: Fn(ToLowLevelCallArguments<'a>) -> Call<'a> + Copy,
 {
     match lambda_set.call_by_name_options(&layout_cache.interner) {
-        ClosureCallOptions::Void => empty_lambda_set_error(),
+        ClosureCallOptions::Void => empty_lambda_set_error(env),
         ClosureCallOptions::Union(union_layout) => {
             let closure_tag_id_symbol = env.unique_symbol();
 
@@ -10338,9 +10361,9 @@ where
     }
 }
 
-fn empty_lambda_set_error() -> Stmt<'static> {
+fn empty_lambda_set_error<'a>(env: &mut Env<'a, '_>) -> Stmt<'a> {
     let msg = "a Lambda Set is empty. Most likely there is a type error in your program.";
-    Stmt::RuntimeError(msg)
+    runtime_error(env, msg)
 }
 
 /// Use the lambda set to figure out how to make a call-by-name
@@ -10358,7 +10381,7 @@ fn match_on_lambda_set<'a>(
     hole: &'a Stmt<'a>,
 ) -> Stmt<'a> {
     match lambda_set.call_by_name_options(&layout_cache.interner) {
-        ClosureCallOptions::Void => empty_lambda_set_error(),
+        ClosureCallOptions::Void => empty_lambda_set_error(env),
         ClosureCallOptions::Union(union_layout) => {
             let closure_tag_id_symbol = env.unique_symbol();
 
@@ -10512,7 +10535,7 @@ fn union_lambda_set_to_switch<'a>(
         // there is really nothing we can do here. We generate a runtime error here which allows
         // code gen to proceed. We then assume that we hit another (more descriptive) error before
         // hitting this one
-        return empty_lambda_set_error();
+        return empty_lambda_set_error(env);
     }
 
     let join_point_id = JoinPointId(env.unique_symbol());

--- a/crates/compiler/mono/src/reset_reuse.rs
+++ b/crates/compiler/mono/src/reset_reuse.rs
@@ -241,7 +241,7 @@ fn function_s<'a, 'i>(
             }
         }
 
-        Ret(_) | Jump(_, _) | RuntimeError(_) | Crash(..) => stmt,
+        Ret(_) | Jump(_, _) | Crash(..) => stmt,
     }
 }
 
@@ -535,9 +535,7 @@ fn function_d_main<'a, 'i>(
 
             (arena.alloc(new_join), found)
         }
-        Ret(_) | Jump(_, _) | RuntimeError(_) | Crash(..) => {
-            (stmt, has_live_var(&env.jp_live_vars, stmt, x))
-        }
+        Ret(_) | Jump(_, _) | Crash(..) => (stmt, has_live_var(&env.jp_live_vars, stmt, x)),
     }
 }
 
@@ -698,7 +696,7 @@ fn function_r<'a, 'i>(env: &mut Env<'a, 'i>, stmt: &'a Stmt<'a>) -> &'a Stmt<'a>
             arena.alloc(expect)
         }
 
-        Ret(_) | Jump(_, _) | RuntimeError(_) | Crash(..) => {
+        Ret(_) | Jump(_, _) | Crash(..) => {
             // terminals
             stmt
         }
@@ -764,7 +762,6 @@ fn has_live_var<'a>(jp_live_vars: &JPLiveVarMap, stmt: &'a Stmt<'a>, needle: Sym
             arguments.iter().any(|s| *s == needle) || jp_live_vars[id].contains(&needle)
         }
         Crash(m, _) => *m == needle,
-        RuntimeError(_) => false,
     }
 }
 

--- a/crates/compiler/mono/src/reset_reuse.rs
+++ b/crates/compiler/mono/src/reset_reuse.rs
@@ -241,7 +241,7 @@ fn function_s<'a, 'i>(
             }
         }
 
-        Ret(_) | Jump(_, _) | RuntimeError(_) => stmt,
+        Ret(_) | Jump(_, _) | RuntimeError(_) | Crash(..) => stmt,
     }
 }
 
@@ -535,7 +535,9 @@ fn function_d_main<'a, 'i>(
 
             (arena.alloc(new_join), found)
         }
-        Ret(_) | Jump(_, _) | RuntimeError(_) => (stmt, has_live_var(&env.jp_live_vars, stmt, x)),
+        Ret(_) | Jump(_, _) | RuntimeError(_) | Crash(..) => {
+            (stmt, has_live_var(&env.jp_live_vars, stmt, x))
+        }
     }
 }
 
@@ -696,7 +698,7 @@ fn function_r<'a, 'i>(env: &mut Env<'a, 'i>, stmt: &'a Stmt<'a>) -> &'a Stmt<'a>
             arena.alloc(expect)
         }
 
-        Ret(_) | Jump(_, _) | RuntimeError(_) => {
+        Ret(_) | Jump(_, _) | RuntimeError(_) | Crash(..) => {
             // terminals
             stmt
         }
@@ -761,6 +763,7 @@ fn has_live_var<'a>(jp_live_vars: &JPLiveVarMap, stmt: &'a Stmt<'a>, needle: Sym
         Jump(id, arguments) => {
             arguments.iter().any(|s| *s == needle) || jp_live_vars[id].contains(&needle)
         }
+        Crash(m, _) => *m == needle,
         RuntimeError(_) => false,
     }
 }

--- a/crates/compiler/mono/src/tail_recursion.rs
+++ b/crates/compiler/mono/src/tail_recursion.rs
@@ -300,5 +300,6 @@ fn insert_jumps<'a>(
         Ret(_) => None,
         Jump(_, _) => None,
         RuntimeError(_) => None,
+        Crash(..) => None,
     }
 }

--- a/crates/compiler/mono/src/tail_recursion.rs
+++ b/crates/compiler/mono/src/tail_recursion.rs
@@ -299,7 +299,6 @@ fn insert_jumps<'a>(
 
         Ret(_) => None,
         Jump(_, _) => None,
-        RuntimeError(_) => None,
         Crash(..) => None,
     }
 }

--- a/crates/compiler/parse/src/ast.rs
+++ b/crates/compiler/parse/src/ast.rs
@@ -196,6 +196,9 @@ pub enum Expr<'a> {
 
     Underscore(&'a str),
 
+    // The "crash" keyword
+    Crash,
+
     // Tags
     Tag(&'a str),
 

--- a/crates/compiler/parse/src/expr.rs
+++ b/crates/compiler/parse/src/expr.rs
@@ -204,6 +204,7 @@ fn loc_term_or_underscore_or_conditional<'a>(
         loc!(specialize(EExpr::SingleQuote, single_quote_literal_help())),
         loc!(specialize(EExpr::Number, positive_number_literal_help())),
         loc!(specialize(EExpr::Closure, closure_help(options))),
+        loc!(crash_kw()),
         loc!(underscore_expression()),
         loc!(record_literal_help()),
         loc!(specialize(EExpr::List, list_literal_help())),
@@ -266,6 +267,15 @@ fn underscore_expression<'a>() -> impl Parser<'a, Expr<'a>, EExpr<'a>> {
             Some(name) => Ok((MadeProgress, Expr::Underscore(name), final_state)),
             None => Ok((MadeProgress, Expr::Underscore(""), final_state)),
         }
+    }
+}
+
+fn crash_kw<'a>() -> impl Parser<'a, Expr<'a>, EExpr<'a>> {
+    move |arena: &'a Bump, state: State<'a>, min_indent: u32| {
+        let (_, _, next_state) = crate::parser::keyword_e(crate::keyword::CRASH, EExpr::Crash)
+            .parse(arena, state, min_indent)?;
+
+        Ok((MadeProgress, Expr::Crash, next_state))
     }
 }
 
@@ -1917,7 +1927,8 @@ fn expr_to_pattern_help<'a>(arena: &'a Bump, expr: &Expr<'a>) -> Result<Pattern<
         | Expr::MalformedClosure
         | Expr::PrecedenceConflict { .. }
         | Expr::RecordUpdate { .. }
-        | Expr::UnaryOp(_, _) => Err(()),
+        | Expr::UnaryOp(_, _)
+        | Expr::Crash => Err(()),
 
         Expr::Str(string) => Ok(Pattern::StrLiteral(*string)),
         Expr::SingleQuote(string) => Ok(Pattern::SingleQuote(string)),

--- a/crates/compiler/parse/src/keyword.rs
+++ b/crates/compiler/parse/src/keyword.rs
@@ -9,4 +9,4 @@ pub const EXPECT: &str = "expect";
 pub const EXPECT_FX: &str = "expect-fx";
 pub const CRASH: &str = "crash";
 
-pub const KEYWORDS: [&str; 9] = [IF, THEN, ELSE, WHEN, AS, IS, EXPECT, EXPECT_FX, CRASH];
+pub const KEYWORDS: [&str; 9] = [IF, THEN, ELSE, WHEN, AS, IS, DBG, EXPECT, EXPECT_FX, CRASH];

--- a/crates/compiler/parse/src/keyword.rs
+++ b/crates/compiler/parse/src/keyword.rs
@@ -7,5 +7,6 @@ pub const IS: &str = "is";
 pub const DBG: &str = "dbg";
 pub const EXPECT: &str = "expect";
 pub const EXPECT_FX: &str = "expect-fx";
+pub const CRASH: &str = "crash";
 
-pub const KEYWORDS: [&str; 8] = [IF, THEN, ELSE, WHEN, AS, IS, EXPECT, EXPECT_FX];
+pub const KEYWORDS: [&str; 9] = [IF, THEN, ELSE, WHEN, AS, IS, EXPECT, EXPECT_FX, CRASH];

--- a/crates/compiler/parse/src/keyword.rs
+++ b/crates/compiler/parse/src/keyword.rs
@@ -9,4 +9,4 @@ pub const EXPECT: &str = "expect";
 pub const EXPECT_FX: &str = "expect-fx";
 pub const CRASH: &str = "crash";
 
-pub const KEYWORDS: [&str; 9] = [IF, THEN, ELSE, WHEN, AS, IS, DBG, EXPECT, EXPECT_FX, CRASH];
+pub const KEYWORDS: [&str; 10] = [IF, THEN, ELSE, WHEN, AS, IS, DBG, EXPECT, EXPECT_FX, CRASH];

--- a/crates/compiler/parse/src/parser.rs
+++ b/crates/compiler/parse/src/parser.rs
@@ -358,6 +358,7 @@ pub enum EExpr<'a> {
 
     Closure(EClosure<'a>, Position),
     Underscore(Position),
+    Crash(Position),
 
     InParens(EInParens<'a>, Position),
     Record(ERecord<'a>, Position),

--- a/crates/compiler/parse/tests/snapshots/pass/crash.expr.formatted.roc
+++ b/crates/compiler/parse/tests/snapshots/pass/crash.expr.formatted.roc
@@ -1,0 +1,10 @@
+_ = crash ""
+_ = crash "" ""
+_ = crash 15 123
+_ = try foo (\_ -> crash "")
+_ =
+    _ = crash ""
+
+    crash
+
+{ f: crash "" }

--- a/crates/compiler/parse/tests/snapshots/pass/crash.expr.result-ast
+++ b/crates/compiler/parse/tests/snapshots/pass/crash.expr.result-ast
@@ -1,0 +1,210 @@
+Defs(
+    Defs {
+        tags: [
+            Index(2147483648),
+            Index(2147483649),
+            Index(2147483650),
+            Index(2147483651),
+            Index(2147483652),
+        ],
+        regions: [
+            @0-12,
+            @13-28,
+            @29-45,
+            @46-74,
+            @75-101,
+        ],
+        space_before: [
+            Slice(start = 0, length = 0),
+            Slice(start = 0, length = 1),
+            Slice(start = 1, length = 1),
+            Slice(start = 2, length = 1),
+            Slice(start = 3, length = 1),
+        ],
+        space_after: [
+            Slice(start = 0, length = 0),
+            Slice(start = 1, length = 0),
+            Slice(start = 2, length = 0),
+            Slice(start = 3, length = 0),
+            Slice(start = 4, length = 0),
+        ],
+        spaces: [
+            Newline,
+            Newline,
+            Newline,
+            Newline,
+        ],
+        type_defs: [],
+        value_defs: [
+            Body(
+                @0-1 Underscore(
+                    "",
+                ),
+                @4-12 Apply(
+                    @4-9 Crash,
+                    [
+                        @10-12 Str(
+                            PlainLine(
+                                "",
+                            ),
+                        ),
+                    ],
+                    Space,
+                ),
+            ),
+            Body(
+                @13-14 Underscore(
+                    "",
+                ),
+                @17-28 Apply(
+                    @17-22 Crash,
+                    [
+                        @23-25 Str(
+                            PlainLine(
+                                "",
+                            ),
+                        ),
+                        @26-28 Str(
+                            PlainLine(
+                                "",
+                            ),
+                        ),
+                    ],
+                    Space,
+                ),
+            ),
+            Body(
+                @29-30 Underscore(
+                    "",
+                ),
+                @33-45 Apply(
+                    @33-38 Crash,
+                    [
+                        @39-41 Num(
+                            "15",
+                        ),
+                        @42-45 Num(
+                            "123",
+                        ),
+                    ],
+                    Space,
+                ),
+            ),
+            Body(
+                @46-47 Underscore(
+                    "",
+                ),
+                @50-74 Apply(
+                    @50-53 Var {
+                        module_name: "",
+                        ident: "try",
+                    },
+                    [
+                        @54-57 Var {
+                            module_name: "",
+                            ident: "foo",
+                        },
+                        @59-73 ParensAround(
+                            Closure(
+                                [
+                                    @60-61 Underscore(
+                                        "",
+                                    ),
+                                ],
+                                @65-73 Apply(
+                                    @65-70 Crash,
+                                    [
+                                        @71-73 Str(
+                                            PlainLine(
+                                                "",
+                                            ),
+                                        ),
+                                    ],
+                                    Space,
+                                ),
+                            ),
+                        ),
+                    ],
+                    Space,
+                ),
+            ),
+            Body(
+                @75-76 Underscore(
+                    "",
+                ),
+                @81-101 SpaceBefore(
+                    Defs(
+                        Defs {
+                            tags: [
+                                Index(2147483648),
+                            ],
+                            regions: [
+                                @81-93,
+                            ],
+                            space_before: [
+                                Slice(start = 0, length = 0),
+                            ],
+                            space_after: [
+                                Slice(start = 0, length = 0),
+                            ],
+                            spaces: [],
+                            type_defs: [],
+                            value_defs: [
+                                Body(
+                                    @81-82 Underscore(
+                                        "",
+                                    ),
+                                    @85-93 Apply(
+                                        @85-90 Crash,
+                                        [
+                                            @91-93 Str(
+                                                PlainLine(
+                                                    "",
+                                                ),
+                                            ),
+                                        ],
+                                        Space,
+                                    ),
+                                ),
+                            ],
+                        },
+                        @96-101 SpaceBefore(
+                            Crash,
+                            [
+                                Newline,
+                            ],
+                        ),
+                    ),
+                    [
+                        Newline,
+                    ],
+                ),
+            ),
+        ],
+    },
+    @103-118 SpaceBefore(
+        Record(
+            [
+                @105-116 RequiredValue(
+                    @105-106 "f",
+                    [],
+                    @108-116 Apply(
+                        @108-113 Crash,
+                        [
+                            @114-116 Str(
+                                PlainLine(
+                                    "",
+                                ),
+                            ),
+                        ],
+                        Space,
+                    ),
+                ),
+            ],
+        ),
+        [
+            Newline,
+            Newline,
+        ],
+    ),
+)

--- a/crates/compiler/parse/tests/snapshots/pass/crash.expr.roc
+++ b/crates/compiler/parse/tests/snapshots/pass/crash.expr.roc
@@ -1,0 +1,9 @@
+_ = crash ""
+_ = crash "" ""
+_ = crash 15 123
+_ = try foo (\_ -> crash "")
+_ =
+  _ = crash ""
+  crash
+
+{ f: crash "" }

--- a/crates/compiler/parse/tests/test_parse.rs
+++ b/crates/compiler/parse/tests/test_parse.rs
@@ -156,6 +156,7 @@ mod test_parse {
         pass/comment_before_op.expr,
         pass/comment_inside_empty_list.expr,
         pass/comment_with_non_ascii.expr,
+        pass/crash.expr,
         pass/destructure_tag_assignment.expr,
         pass/empty_app_header.header,
         pass/empty_hosted_header.header,

--- a/crates/compiler/problem/src/can.rs
+++ b/crates/compiler/problem/src/can.rs
@@ -195,6 +195,12 @@ pub enum Problem {
         type_got: u8,
         alias_kind: AliasKind,
     },
+    UnappliedCrash {
+        region: Region,
+    },
+    OverAppliedCrash {
+        region: Region,
+    },
 }
 
 impl Problem {
@@ -325,7 +331,9 @@ impl Problem {
             }
             | Problem::MultipleListRestPattern { region }
             | Problem::BadTypeArguments { region, .. }
-            | Problem::UnnecessaryOutputWildcard { region } => Some(*region),
+            | Problem::UnnecessaryOutputWildcard { region }
+            | Problem::OverAppliedCrash { region }
+            | Problem::UnappliedCrash { region } => Some(*region),
             Problem::RuntimeError(RuntimeError::CircularDef(cycle_entries))
             | Problem::BadRecursion(cycle_entries) => {
                 cycle_entries.first().map(|entry| entry.expr_region)

--- a/crates/compiler/solve/src/solve.rs
+++ b/crates/compiler/solve/src/solve.rs
@@ -2961,27 +2961,6 @@ fn type_to_variable<'a>(
 
                 register_with_known_var(subs, destination, rank, pools, content)
             }
-            Crash => {
-                let magic_return = subs.fresh(Descriptor {
-                    content: Content::FlexVar(None),
-                    rank,
-                    mark: Mark::NONE,
-                    copy: OptVariable::NONE,
-                });
-                let magic_lambda_set = subs.fresh(Descriptor {
-                    content: Content::FlexVar(None),
-                    rank,
-                    mark: Mark::NONE,
-                    copy: OptVariable::NONE,
-                });
-                let magic_crash = Content::Structure(FlatType::Func(
-                    Subs::STR_SLICE,
-                    magic_lambda_set,
-                    magic_return,
-                ));
-
-                register_with_known_var(subs, destination, rank, pools, magic_crash)
-            }
         };
     }
 

--- a/crates/compiler/solve/src/solve.rs
+++ b/crates/compiler/solve/src/solve.rs
@@ -2961,6 +2961,27 @@ fn type_to_variable<'a>(
 
                 register_with_known_var(subs, destination, rank, pools, content)
             }
+            Crash => {
+                let magic_return = subs.fresh(Descriptor {
+                    content: Content::FlexVar(None),
+                    rank,
+                    mark: Mark::NONE,
+                    copy: OptVariable::NONE,
+                });
+                let magic_lambda_set = subs.fresh(Descriptor {
+                    content: Content::FlexVar(None),
+                    rank,
+                    mark: Mark::NONE,
+                    copy: OptVariable::NONE,
+                });
+                let magic_crash = Content::Structure(FlatType::Func(
+                    Subs::STR_SLICE,
+                    magic_lambda_set,
+                    magic_return,
+                ));
+
+                register_with_known_var(subs, destination, rank, pools, magic_crash)
+            }
         };
     }
 

--- a/crates/compiler/solve/tests/solve_expr.rs
+++ b/crates/compiler/solve/tests/solve_expr.rs
@@ -8352,4 +8352,20 @@ mod solve_expr {
         @"translateStatic : [Element (List a)] as a -[[translateStatic(0)]]-> [Element (List b)]* as b"
         )
     }
+
+    #[test]
+    fn infer_contextual_crash() {
+        infer_eq_without_problem(
+            indoc!(
+                r#"
+                app "test" provides [getInfallible] to "./platform"
+
+                getInfallible = \result -> when result is
+                    Ok x -> x
+                    _ -> crash "turns out this was fallible"
+                "#
+            ),
+            "[Ok a]* -> a",
+        );
+    }
 }

--- a/crates/compiler/test_derive/src/pretty_print.rs
+++ b/crates/compiler/test_derive/src/pretty_print.rs
@@ -279,6 +279,7 @@ fn expr<'a>(c: &Ctx, p: EPrec, f: &'a Arena<'a>, e: &'a Expr) -> DocBuilder<'a, 
                 )
                 .group()
         ),
+        Crash => f.text("crash"),
         ZeroArgumentTag { .. } => todo!(),
         OpaqueRef { .. } => todo!(),
         Dbg { .. } => todo!(),

--- a/crates/compiler/test_derive/src/pretty_print.rs
+++ b/crates/compiler/test_derive/src/pretty_print.rs
@@ -279,7 +279,7 @@ fn expr<'a>(c: &Ctx, p: EPrec, f: &'a Arena<'a>, e: &'a Expr) -> DocBuilder<'a, 
                 )
                 .group()
         ),
-        Crash => f.text("crash"),
+        Crash { .. } => todo!(),
         ZeroArgumentTag { .. } => todo!(),
         OpaqueRef { .. } => todo!(),
         Dbg { .. } => todo!(),

--- a/crates/compiler/test_gen/src/gen_panic.rs
+++ b/crates/compiler/test_gen/src/gen_panic.rs
@@ -14,10 +14,10 @@ fn crash_literal() {
     assert_evals_to!(
         indoc!(
             r#"
-        app "test" provides [main] to "./platform"
+            app "test" provides [main] to "./platform"
 
-        main = if Bool.true then crash "hello crash" else 1u8
-        "#
+            main = if Bool.true then crash "hello crash" else 1u8
+            "#
         ),
         1u8,
         u8
@@ -31,12 +31,12 @@ fn crash_variable() {
     assert_evals_to!(
         indoc!(
             r#"
-        app "test" provides [main] to "./platform"
+            app "test" provides [main] to "./platform"
 
-        main =
-            msg = "hello crash"
-            if Bool.true then crash msg else 1u8
-        "#
+            main =
+                msg = "hello crash"
+                if Bool.true then crash msg else 1u8
+            "#
         ),
         1u8,
         u8
@@ -50,17 +50,17 @@ fn crash_in_call() {
     assert_evals_to!(
         indoc!(
             r#"
-        app "test" provides [main] to "./platform"
+            app "test" provides [main] to "./platform"
 
-        getInfallible = \result -> when result is
-            Ok x -> x
-            _ -> crash "turns out this was fallible"
+            getInfallible = \result -> when result is
+                Ok x -> x
+                _ -> crash "turns out this was fallible"
 
-        main =
-            x : [Ok U64, Err Str]
-            x = Err ""
-            getInfallible x
-        "#
+            main =
+                x : [Ok U64, Err Str]
+                x = Err ""
+                getInfallible x
+            "#
         ),
         1u64,
         u64

--- a/crates/compiler/test_gen/src/gen_panic.rs
+++ b/crates/compiler/test_gen/src/gen_panic.rs
@@ -7,7 +7,7 @@ use crate::helpers::llvm::expect_runtime_error_panic;
 use crate::helpers::wasm::expect_runtime_error_panic;
 
 #[test]
-#[cfg(any(feature = "gen-llvm"))]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
 #[should_panic = r#"User crash with message: "hello crash""#]
 fn crash_literal() {
     expect_runtime_error_panic!(indoc!(
@@ -20,7 +20,7 @@ fn crash_literal() {
 }
 
 #[test]
-#[cfg(any(feature = "gen-llvm"))]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
 #[should_panic = r#"User crash with message: "hello crash""#]
 fn crash_variable() {
     expect_runtime_error_panic!(indoc!(
@@ -35,7 +35,7 @@ fn crash_variable() {
 }
 
 #[test]
-#[cfg(any(feature = "gen-llvm"))]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
 #[should_panic = r#"User crash with message: "turns out this was fallible""#]
 fn crash_in_call() {
     expect_runtime_error_panic!(indoc!(
@@ -55,7 +55,7 @@ fn crash_in_call() {
 }
 
 #[test]
-#[cfg(any(feature = "gen-llvm"))]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
 #[should_panic = r#"User crash with message: "no new even primes""#]
 fn crash_in_passed_closure() {
     expect_runtime_error_panic!(indoc!(

--- a/crates/compiler/test_gen/src/gen_panic.rs
+++ b/crates/compiler/test_gen/src/gen_panic.rs
@@ -1,45 +1,55 @@
 use indoc::indoc;
+use roc_std::RocList;
 
 #[cfg(feature = "gen-llvm")]
-use crate::helpers::llvm::expect_runtime_error_panic;
+use crate::helpers::llvm::assert_evals_to;
 
 #[cfg(feature = "gen-wasm")]
-use crate::helpers::wasm::expect_runtime_error_panic;
+use crate::helpers::wasm::assert_evals_to;
 
 #[test]
 #[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
 #[should_panic = r#"User crash with message: "hello crash""#]
 fn crash_literal() {
-    expect_runtime_error_panic!(indoc!(
-        r#"
+    assert_evals_to!(
+        indoc!(
+            r#"
         app "test" provides [main] to "./platform"
 
         main = if Bool.true then crash "hello crash" else 1u8
         "#
-    ));
+        ),
+        1u8,
+        u8
+    );
 }
 
 #[test]
 #[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
 #[should_panic = r#"User crash with message: "hello crash""#]
 fn crash_variable() {
-    expect_runtime_error_panic!(indoc!(
-        r#"
+    assert_evals_to!(
+        indoc!(
+            r#"
         app "test" provides [main] to "./platform"
 
         main =
             msg = "hello crash"
             if Bool.true then crash msg else 1u8
         "#
-    ));
+        ),
+        1u8,
+        u8
+    );
 }
 
 #[test]
 #[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
 #[should_panic = r#"User crash with message: "turns out this was fallible""#]
 fn crash_in_call() {
-    expect_runtime_error_panic!(indoc!(
-        r#"
+    assert_evals_to!(
+        indoc!(
+            r#"
         app "test" provides [main] to "./platform"
 
         getInfallible = \result -> when result is
@@ -51,19 +61,25 @@ fn crash_in_call() {
             x = Err ""
             getInfallible x
         "#
-    ));
+        ),
+        1u64,
+        u64
+    );
 }
 
 #[test]
-#[cfg(any(feature = "gen-llvm"))]
-// wasm: blocked on "compiling function underran the stack" in wasm3
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
 #[should_panic = r#"User crash with message: "no new even primes""#]
 fn crash_in_passed_closure() {
-    expect_runtime_error_panic!(indoc!(
-        r#"
-        app "test" provides [main] to "./platform"
+    assert_evals_to!(
+        indoc!(
+            r#"
+            app "test" provides [main] to "./platform"
 
-        main = List.map [1, 2, 3] \n -> if n == 2 then crash "no new even primes" else ""
-        "#
-    ));
+            main = List.map [1, 2, 3] \n -> if n == 2 then crash "no new even primes" else ""
+            "#
+        ),
+        RocList::from_slice(&[1u8]),
+        RocList<u8>
+    );
 }

--- a/crates/compiler/test_gen/src/gen_panic.rs
+++ b/crates/compiler/test_gen/src/gen_panic.rs
@@ -8,7 +8,7 @@ use crate::helpers::wasm::expect_runtime_error_panic;
 
 #[test]
 #[cfg(any(feature = "gen-llvm"))]
-#[should_panic = r#"Roc failed with message: "hello crash""#]
+#[should_panic = r#"User crash with message: "hello crash""#]
 fn crash_literal() {
     expect_runtime_error_panic!(indoc!(
         r#"
@@ -21,7 +21,7 @@ fn crash_literal() {
 
 #[test]
 #[cfg(any(feature = "gen-llvm"))]
-#[should_panic = r#"Roc failed with message: "hello crash""#]
+#[should_panic = r#"User crash with message: "hello crash""#]
 fn crash_variable() {
     expect_runtime_error_panic!(indoc!(
         r#"
@@ -36,7 +36,7 @@ fn crash_variable() {
 
 #[test]
 #[cfg(any(feature = "gen-llvm"))]
-#[should_panic = r#"Roc failed with message: "turns out this was fallible""#]
+#[should_panic = r#"User crash with message: "turns out this was fallible""#]
 fn crash_in_call() {
     expect_runtime_error_panic!(indoc!(
         r#"
@@ -56,7 +56,7 @@ fn crash_in_call() {
 
 #[test]
 #[cfg(any(feature = "gen-llvm"))]
-#[should_panic = r#"Roc failed with message: "no new even primes""#]
+#[should_panic = r#"User crash with message: "no new even primes""#]
 fn crash_in_passed_closure() {
     expect_runtime_error_panic!(indoc!(
         r#"

--- a/crates/compiler/test_gen/src/gen_panic.rs
+++ b/crates/compiler/test_gen/src/gen_panic.rs
@@ -55,7 +55,8 @@ fn crash_in_call() {
 }
 
 #[test]
-#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
+#[cfg(any(feature = "gen-llvm"))]
+// wasm: blocked on "compiling function underran the stack" in wasm3
 #[should_panic = r#"User crash with message: "no new even primes""#]
 fn crash_in_passed_closure() {
     expect_runtime_error_panic!(indoc!(

--- a/crates/compiler/test_gen/src/gen_panic.rs
+++ b/crates/compiler/test_gen/src/gen_panic.rs
@@ -1,0 +1,68 @@
+use indoc::indoc;
+
+#[cfg(feature = "gen-llvm")]
+use crate::helpers::llvm::expect_runtime_error_panic;
+
+#[cfg(feature = "gen-wasm")]
+use crate::helpers::wasm::expect_runtime_error_panic;
+
+#[test]
+#[cfg(any(feature = "gen-llvm"))]
+#[should_panic = r#"Roc failed with message: "hello crash""#]
+fn crash_literal() {
+    expect_runtime_error_panic!(indoc!(
+        r#"
+        app "test" provides [main] to "./platform"
+
+        main = if Bool.true then crash "hello crash" else 1u8
+        "#
+    ));
+}
+
+#[test]
+#[cfg(any(feature = "gen-llvm"))]
+#[should_panic = r#"Roc failed with message: "hello crash""#]
+fn crash_variable() {
+    expect_runtime_error_panic!(indoc!(
+        r#"
+        app "test" provides [main] to "./platform"
+
+        main =
+            msg = "hello crash"
+            if Bool.true then crash msg else 1u8
+        "#
+    ));
+}
+
+#[test]
+#[cfg(any(feature = "gen-llvm"))]
+#[should_panic = r#"Roc failed with message: "turns out this was fallible""#]
+fn crash_in_call() {
+    expect_runtime_error_panic!(indoc!(
+        r#"
+        app "test" provides [main] to "./platform"
+
+        getInfallible = \result -> when result is
+            Ok x -> x
+            _ -> crash "turns out this was fallible"
+
+        main =
+            x : [Ok U64, Err Str]
+            x = Err ""
+            getInfallible x
+        "#
+    ));
+}
+
+#[test]
+#[cfg(any(feature = "gen-llvm"))]
+#[should_panic = r#"Roc failed with message: "no new even primes""#]
+fn crash_in_passed_closure() {
+    expect_runtime_error_panic!(indoc!(
+        r#"
+        app "test" provides [main] to "./platform"
+
+        main = List.map [1, 2, 3] \n -> if n == 2 then crash "no new even primes" else ""
+        "#
+    ));
+}

--- a/crates/compiler/test_gen/src/gen_records.rs
+++ b/crates/compiler/test_gen/src/gen_records.rs
@@ -1031,7 +1031,9 @@ fn call_with_bad_record_runtime_error() {
             "#
         ),
         true,
-        bool
+        bool,
+        |x| x,
+        true // ignore type errors
     )
 }
 

--- a/crates/compiler/test_gen/src/gen_records.rs
+++ b/crates/compiler/test_gen/src/gen_records.rs
@@ -472,11 +472,11 @@ fn optional_field_when_no_use_default_nested() {
     assert_evals_to!(
         indoc!(
             r#"
-                f = \r ->
+                fn = \r ->
                     { x ? 10, y } = r
                     x + y
 
-                f { x: 4, y: 9 }
+                fn { x: 4, y: 9 }
                 "#
         ),
         13,
@@ -1056,9 +1056,9 @@ fn update_record_that_is_a_thunk() {
             app "test" provides [main] to "./platform"
 
             main = Num.toStr fromOriginal.birds
-            
+
             original = { birds: 5, iguanas: 7, zebras: 2, goats: 1 }
-            
+
             fromOriginal = { original & birds: 4, iguanas: 3 }
             "#
         ),
@@ -1076,9 +1076,9 @@ fn update_record_that_is_a_thunk_single_field() {
             app "test" provides [main] to "./platform"
 
             main = Num.toStr fromOriginal.birds
-            
+
             original = { birds: 5 }
-            
+
             fromOriginal = { original & birds: 4 }
             "#
         ),

--- a/crates/compiler/test_gen/src/gen_records.rs
+++ b/crates/compiler/test_gen/src/gen_records.rs
@@ -1,11 +1,11 @@
 #[cfg(feature = "gen-llvm")]
-use crate::helpers::llvm::{assert_evals_to, expect_runtime_error_panic};
+use crate::helpers::llvm::assert_evals_to;
 
 #[cfg(feature = "gen-dev")]
 use crate::helpers::dev::assert_evals_to;
 
 #[cfg(feature = "gen-wasm")]
-use crate::helpers::wasm::{assert_evals_to, expect_runtime_error_panic};
+use crate::helpers::wasm::assert_evals_to;
 
 // use crate::assert_wasm_evals_to as assert_evals_to;
 use indoc::indoc;
@@ -1019,8 +1019,9 @@ fn different_proc_types_specialized_to_same_layout() {
 #[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
 #[should_panic(expected = r#"Roc failed with message: "Can't create record with improper layout""#)]
 fn call_with_bad_record_runtime_error() {
-    expect_runtime_error_panic!(indoc!(
-        r#"
+    assert_evals_to!(
+        indoc!(
+            r#"
             app "test" provides [main] to "./platform"
 
             main =
@@ -1028,7 +1029,10 @@ fn call_with_bad_record_runtime_error() {
                 get = \{a} -> a
                 get {b: ""}
             "#
-    ))
+        ),
+        true,
+        bool
+    )
 }
 
 #[test]

--- a/crates/compiler/test_gen/src/gen_records.rs
+++ b/crates/compiler/test_gen/src/gen_records.rs
@@ -447,7 +447,7 @@ fn optional_field_when_use_default_nested() {
 
 #[test]
 #[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
-fn optional_field_when_no_use_default() {
+fn optional_field_destructure_module() {
     assert_evals_to!(
         indoc!(
             r#"
@@ -468,7 +468,7 @@ fn optional_field_when_no_use_default() {
 
 #[test]
 #[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
-fn optional_field_when_no_use_default_nested() {
+fn optional_field_destructure_expr() {
     assert_evals_to!(
         indoc!(
             r#"

--- a/crates/compiler/test_gen/src/helpers/llvm.rs
+++ b/crates/compiler/test_gen/src/helpers/llvm.rs
@@ -662,29 +662,6 @@ macro_rules! assert_evals_to {
     }};
 }
 
-#[allow(unused_macros)]
-macro_rules! expect_runtime_error_panic {
-    ($src:expr) => {{
-        #[cfg(feature = "gen-llvm-wasm")]
-        $crate::helpers::llvm::assert_wasm_evals_to!(
-            $src,
-            false, // fake value/type for eval
-            bool,
-            $crate::helpers::llvm::identity,
-            true // ignore problems
-        );
-
-        #[cfg(not(feature = "gen-llvm-wasm"))]
-        $crate::helpers::llvm::assert_llvm_evals_to!(
-            $src,
-            false, // fake value/type for eval
-            bool,
-            $crate::helpers::llvm::identity,
-            true // ignore problems
-        );
-    }};
-}
-
 #[allow(dead_code)]
 pub fn identity<T>(value: T) -> T {
     value
@@ -696,5 +673,3 @@ pub(crate) use assert_evals_to;
 pub(crate) use assert_llvm_evals_to;
 #[allow(unused_imports)]
 pub(crate) use assert_wasm_evals_to;
-#[allow(unused_imports)]
-pub(crate) use expect_runtime_error_panic;

--- a/crates/compiler/test_gen/src/helpers/platform_functions.rs
+++ b/crates/compiler/test_gen/src/helpers/platform_functions.rs
@@ -1,5 +1,6 @@
 use core::ffi::c_void;
 
+use roc_mono::ir::CrashTag;
 use roc_std::RocStr;
 
 /// # Safety
@@ -39,14 +40,12 @@ pub unsafe fn roc_dealloc(c_ptr: *mut c_void, _alignment: u32) {
 /// The Roc application needs this.
 #[no_mangle]
 pub unsafe fn roc_panic(msg: &RocStr, tag_id: u32) {
-    use roc_gen_llvm::llvm::build::PanicTagId;
-
-    match PanicTagId::try_from(tag_id) {
-        Ok(PanicTagId::RocPanic) => {
+    match CrashTag::try_from(tag_id) {
+        Ok(CrashTag::Roc) => {
             eprintln!("Roc hit a panic: {}", msg);
             std::process::exit(1);
         }
-        Ok(PanicTagId::UserPanic) => {
+        Ok(CrashTag::User) => {
             eprintln!("User panic: {}", msg);
             std::process::exit(1);
         }

--- a/crates/compiler/test_gen/src/helpers/platform_functions.rs
+++ b/crates/compiler/test_gen/src/helpers/platform_functions.rs
@@ -41,9 +41,6 @@ pub unsafe fn roc_dealloc(c_ptr: *mut c_void, _alignment: u32) {
 pub unsafe fn roc_panic(msg: &RocStr, tag_id: u32) {
     use roc_gen_llvm::llvm::build::PanicTagId;
 
-    use std::ffi::CStr;
-    use std::os::raw::c_char;
-
     match PanicTagId::try_from(tag_id) {
         Ok(PanicTagId::RocPanic) => {
             eprintln!("Roc hit a panic: {}", msg);

--- a/crates/compiler/test_gen/src/helpers/platform_functions.rs
+++ b/crates/compiler/test_gen/src/helpers/platform_functions.rs
@@ -1,8 +1,5 @@
 use core::ffi::c_void;
 
-use roc_mono::ir::CrashTag;
-use roc_std::RocStr;
-
 /// # Safety
 /// The Roc application needs this.
 #[no_mangle]
@@ -34,21 +31,4 @@ pub unsafe fn roc_realloc(
 #[no_mangle]
 pub unsafe fn roc_dealloc(c_ptr: *mut c_void, _alignment: u32) {
     libc::free(c_ptr)
-}
-
-/// # Safety
-/// The Roc application needs this.
-#[no_mangle]
-pub unsafe fn roc_panic(msg: &RocStr, tag_id: u32) {
-    match CrashTag::try_from(tag_id) {
-        Ok(CrashTag::Roc) => {
-            eprintln!("Roc hit a panic: {}", msg);
-            std::process::exit(1);
-        }
-        Ok(CrashTag::User) => {
-            eprintln!("User panic: {}", msg);
-            std::process::exit(1);
-        }
-        Err(_) => unreachable!(),
-    }
 }

--- a/crates/compiler/test_gen/src/helpers/platform_functions.rs
+++ b/crates/compiler/test_gen/src/helpers/platform_functions.rs
@@ -43,7 +43,7 @@ pub unsafe fn roc_panic(c_ptr: *mut c_void, tag_id: u32) {
     use std::os::raw::c_char;
 
     match PanicTagId::try_from(tag_id) {
-        Ok(PanicTagId::NullTerminatedString) => {
+        Ok(PanicTagId::RocPanic) => {
             let slice = CStr::from_ptr(c_ptr as *const c_char);
             let string = slice.to_str().unwrap();
             eprintln!("Roc hit a panic: {}", string);

--- a/crates/compiler/test_gen/src/helpers/wasm.rs
+++ b/crates/compiler/test_gen/src/helpers/wasm.rs
@@ -397,19 +397,6 @@ macro_rules! assert_evals_to {
     }};
 }
 
-#[allow(unused_macros)]
-macro_rules! expect_runtime_error_panic {
-    ($src:expr) => {{
-        $crate::helpers::wasm::assert_evals_to!(
-            $src,
-            false, // fake value/type for eval
-            bool,
-            $crate::helpers::wasm::identity,
-            true // ignore problems
-        );
-    }};
-}
-
 #[allow(dead_code)]
 pub fn identity<T>(value: T) -> T {
     value
@@ -436,9 +423,6 @@ macro_rules! assert_refcounts {
 
 #[allow(unused_imports)]
 pub(crate) use assert_evals_to;
-
-#[allow(unused_imports)]
-pub(crate) use expect_runtime_error_panic;
 
 #[allow(unused_imports)]
 pub(crate) use assert_refcounts;

--- a/crates/compiler/test_gen/src/helpers/wasm_test_platform.c
+++ b/crates/compiler/test_gen/src/helpers/wasm_test_platform.c
@@ -123,12 +123,11 @@ void roc_dealloc(void *ptr, unsigned int alignment)
 
 //--------------------------
 
-extern void send_panic_msg_to_rust(char* msg, int len);
+extern void send_panic_msg_to_rust(void* msg);
 
-void roc_panic(char *msg, unsigned int tag_id)
+void roc_panic(void* msg, unsigned int tag_id)
 {
-    int len = strlen(msg);
-    send_panic_msg_to_rust(msg, len);
+    send_panic_msg_to_rust(msg);
     exit(101);
 }
 

--- a/crates/compiler/test_gen/src/helpers/wasm_test_platform.c
+++ b/crates/compiler/test_gen/src/helpers/wasm_test_platform.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -123,11 +124,11 @@ void roc_dealloc(void *ptr, unsigned int alignment)
 
 //--------------------------
 
-extern void send_panic_msg_to_rust(void* msg);
+extern void send_panic_msg_to_rust(void* msg, uint32_t tag_id);
 
 void roc_panic(void* msg, unsigned int tag_id)
 {
-    send_panic_msg_to_rust(msg);
+    send_panic_msg_to_rust(msg, tag_id);
     exit(101);
 }
 

--- a/crates/compiler/test_gen/src/tests.rs
+++ b/crates/compiler/test_gen/src/tests.rs
@@ -9,6 +9,7 @@ pub mod gen_compare;
 pub mod gen_dict;
 pub mod gen_list;
 pub mod gen_num;
+pub mod gen_panic;
 pub mod gen_primitives;
 pub mod gen_records;
 pub mod gen_refcount;

--- a/crates/compiler/test_mono/generated/call_function_in_empty_list.txt
+++ b/crates/compiler/test_mono/generated/call_function_in_empty_list.txt
@@ -5,7 +5,8 @@ procedure List.5 (#Attr.2, #Attr.3):
 
 procedure Test.2 (Test.3):
     let Test.7 : {} = Struct {};
-    Error a Lambda Set is empty. Most likely there is a type error in your program.
+    let Test.8 : Str = "a Lambda Set is empty. Most likely there is a type error in your program.";
+    Crash `#UserApp.8`
 
 procedure Test.0 ():
     let Test.1 : List [] = Array [];

--- a/crates/compiler/test_mono/generated/call_function_in_empty_list.txt
+++ b/crates/compiler/test_mono/generated/call_function_in_empty_list.txt
@@ -6,7 +6,7 @@ procedure List.5 (#Attr.2, #Attr.3):
 procedure Test.2 (Test.3):
     let Test.7 : {} = Struct {};
     let Test.8 : Str = "a Lambda Set is empty. Most likely there is a type error in your program.";
-    Crash `#UserApp.8`
+    Crash Test.8
 
 procedure Test.0 ():
     let Test.1 : List [] = Array [];

--- a/crates/compiler/test_mono/generated/call_function_in_empty_list_unbound.txt
+++ b/crates/compiler/test_mono/generated/call_function_in_empty_list_unbound.txt
@@ -6,7 +6,7 @@ procedure List.5 (#Attr.2, #Attr.3):
 procedure Test.2 (Test.3):
     let Test.7 : {} = Struct {};
     let Test.8 : Str = "a Lambda Set is empty. Most likely there is a type error in your program.";
-    Crash `#UserApp.IdentId(8)`
+    Crash Test.8
 
 procedure Test.0 ():
     let Test.1 : List [] = Array [];

--- a/crates/compiler/test_mono/generated/call_function_in_empty_list_unbound.txt
+++ b/crates/compiler/test_mono/generated/call_function_in_empty_list_unbound.txt
@@ -5,7 +5,8 @@ procedure List.5 (#Attr.2, #Attr.3):
 
 procedure Test.2 (Test.3):
     let Test.7 : {} = Struct {};
-    Error a Lambda Set is empty. Most likely there is a type error in your program.
+    let Test.8 : Str = "a Lambda Set is empty. Most likely there is a type error in your program.";
+    Crash `#UserApp.IdentId(8)`
 
 procedure Test.0 ():
     let Test.1 : List [] = Array [];

--- a/crates/compiler/test_mono/generated/crash.txt
+++ b/crates/compiler/test_mono/generated/crash.txt
@@ -1,0 +1,18 @@
+procedure Test.1 (Test.2):
+    let Test.10 : U8 = 1i64;
+    let Test.11 : U8 = GetTagId Test.2;
+    let Test.12 : Int1 = lowlevel Eq Test.10 Test.11;
+    if Test.12 then
+        let Test.3 : U64 = UnionAtIndex (Id 1) (Index 0) Test.2;
+        dec Test.2;
+        ret Test.3;
+    else
+        dec Test.2;
+        let Test.9 : Str = "turns out this was fallible";
+        Crash `#UserApp.9`
+
+procedure Test.0 ():
+    let Test.13 : U64 = 78i64;
+    let Test.4 : [C Str, C U64] = TagId(1) Test.13;
+    let Test.6 : U64 = CallByName Test.1 Test.4;
+    ret Test.6;

--- a/crates/compiler/test_mono/generated/crash.txt
+++ b/crates/compiler/test_mono/generated/crash.txt
@@ -9,7 +9,7 @@ procedure Test.1 (Test.2):
     else
         dec Test.2;
         let Test.9 : Str = "turns out this was fallible";
-        Crash `#UserApp.IdentId(9)`
+        Crash Test.9
 
 procedure Test.0 ():
     let Test.13 : U64 = 78i64;

--- a/crates/compiler/test_mono/generated/crash.txt
+++ b/crates/compiler/test_mono/generated/crash.txt
@@ -9,7 +9,7 @@ procedure Test.1 (Test.2):
     else
         dec Test.2;
         let Test.9 : Str = "turns out this was fallible";
-        Crash `#UserApp.9`
+        Crash `#UserApp.IdentId(9)`
 
 procedure Test.0 ():
     let Test.13 : U64 = 78i64;

--- a/crates/compiler/test_mono/generated/encode_derived_nested_record_string.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_nested_record_string.txt
@@ -205,58 +205,58 @@ procedure Json.96 (Json.97, Json.473, Json.95):
     ret Json.475;
 
 procedure List.137 (List.138, List.139, List.136):
-    let List.449 : {List U8, U64} = CallByName Json.114 List.138 List.139;
-    ret List.449;
+    let List.450 : {List U8, U64} = CallByName Json.114 List.138 List.139;
+    ret List.450;
 
 procedure List.137 (List.138, List.139, List.136):
-    let List.521 : {List U8, U64} = CallByName Json.114 List.138 List.139;
-    ret List.521;
+    let List.523 : {List U8, U64} = CallByName Json.114 List.138 List.139;
+    ret List.523;
 
 procedure List.18 (List.134, List.135, List.136):
     let List.431 : {List U8, U64} = CallByName List.89 List.134 List.135 List.136;
     ret List.431;
 
 procedure List.18 (List.134, List.135, List.136):
-    let List.503 : {List U8, U64} = CallByName List.89 List.134 List.135 List.136;
-    ret List.503;
+    let List.504 : {List U8, U64} = CallByName List.89 List.134 List.135 List.136;
+    ret List.504;
 
 procedure List.4 (List.105, List.106):
-    let List.502 : U64 = 1i64;
-    let List.501 : List U8 = CallByName List.70 List.105 List.502;
-    let List.500 : List U8 = CallByName List.71 List.501 List.106;
-    ret List.500;
+    let List.503 : U64 = 1i64;
+    let List.502 : List U8 = CallByName List.70 List.105 List.503;
+    let List.501 : List U8 = CallByName List.71 List.502 List.106;
+    ret List.501;
 
 procedure List.6 (#Attr.2):
     let List.409 : U64 = lowlevel ListLen #Attr.2;
     ret List.409;
 
 procedure List.6 (#Attr.2):
-    let List.451 : U64 = lowlevel ListLen #Attr.2;
-    ret List.451;
+    let List.452 : U64 = lowlevel ListLen #Attr.2;
+    ret List.452;
 
 procedure List.6 (#Attr.2):
-    let List.524 : U64 = lowlevel ListLen #Attr.2;
-    ret List.524;
+    let List.526 : U64 = lowlevel ListLen #Attr.2;
+    ret List.526;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.446 : {Str, Str} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.446;
+    let List.447 : {Str, Str} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.447;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.518 : {Str, Str} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.518;
+    let List.520 : {Str, Str} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.520;
 
 procedure List.70 (#Attr.2, #Attr.3):
-    let List.481 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
-    ret List.481;
+    let List.482 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
+    ret List.482;
 
 procedure List.71 (#Attr.2, #Attr.3):
-    let List.479 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
-    ret List.479;
+    let List.480 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
+    ret List.480;
 
 procedure List.8 (#Attr.2, #Attr.3):
-    let List.523 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
-    ret List.523;
+    let List.525 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
+    ret List.525;
 
 procedure List.89 (List.385, List.386, List.387):
     let List.435 : U64 = 0i64;
@@ -265,38 +265,38 @@ procedure List.89 (List.385, List.386, List.387):
     ret List.434;
 
 procedure List.89 (List.385, List.386, List.387):
-    let List.507 : U64 = 0i64;
-    let List.508 : U64 = CallByName List.6 List.385;
-    let List.506 : {List U8, U64} = CallByName List.90 List.385 List.386 List.387 List.507 List.508;
-    ret List.506;
+    let List.508 : U64 = 0i64;
+    let List.509 : U64 = CallByName List.6 List.385;
+    let List.507 : {List U8, U64} = CallByName List.90 List.385 List.386 List.387 List.508 List.509;
+    ret List.507;
 
-procedure List.90 (List.461, List.462, List.463, List.464, List.465):
+procedure List.90 (List.462, List.463, List.464, List.465, List.466):
     joinpoint List.437 List.388 List.389 List.390 List.391 List.392:
         let List.439 : Int1 = CallByName Num.22 List.391 List.392;
         if List.439 then
-            let List.445 : {Str, Str} = CallByName List.66 List.388 List.391;
-            let List.440 : {List U8, U64} = CallByName List.137 List.389 List.445 List.390;
+            let List.446 : {Str, Str} = CallByName List.66 List.388 List.391;
+            let List.440 : {List U8, U64} = CallByName List.137 List.389 List.446 List.390;
             let List.443 : U64 = 1i64;
             let List.442 : U64 = CallByName Num.19 List.391 List.443;
             jump List.437 List.388 List.440 List.390 List.442 List.392;
         else
             ret List.389;
     in
-    jump List.437 List.461 List.462 List.463 List.464 List.465;
+    jump List.437 List.462 List.463 List.464 List.465 List.466;
 
-procedure List.90 (List.534, List.535, List.536, List.537, List.538):
-    joinpoint List.509 List.388 List.389 List.390 List.391 List.392:
-        let List.511 : Int1 = CallByName Num.22 List.391 List.392;
-        if List.511 then
-            let List.517 : {Str, Str} = CallByName List.66 List.388 List.391;
-            let List.512 : {List U8, U64} = CallByName List.137 List.389 List.517 List.390;
-            let List.515 : U64 = 1i64;
-            let List.514 : U64 = CallByName Num.19 List.391 List.515;
-            jump List.509 List.388 List.512 List.390 List.514 List.392;
+procedure List.90 (List.536, List.537, List.538, List.539, List.540):
+    joinpoint List.510 List.388 List.389 List.390 List.391 List.392:
+        let List.512 : Int1 = CallByName Num.22 List.391 List.392;
+        if List.512 then
+            let List.519 : {Str, Str} = CallByName List.66 List.388 List.391;
+            let List.513 : {List U8, U64} = CallByName List.137 List.389 List.519 List.390;
+            let List.516 : U64 = 1i64;
+            let List.515 : U64 = CallByName Num.19 List.391 List.516;
+            jump List.510 List.388 List.513 List.390 List.515 List.392;
         else
             ret List.389;
     in
-    jump List.509 List.534 List.535 List.536 List.537 List.538;
+    jump List.510 List.536 List.537 List.538 List.539 List.540;
 
 procedure Num.125 (#Attr.2):
     let Num.282 : U8 = lowlevel NumIntCast #Attr.2;

--- a/crates/compiler/test_mono/generated/encode_derived_record_one_field_string.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_record_one_field_string.txt
@@ -118,8 +118,8 @@ procedure Json.96 (Json.97, Json.433, Json.95):
     ret Json.435;
 
 procedure List.137 (List.138, List.139, List.136):
-    let List.455 : {List U8, U64} = CallByName Json.114 List.138 List.139;
-    ret List.455;
+    let List.456 : {List U8, U64} = CallByName Json.114 List.138 List.139;
+    ret List.456;
 
 procedure List.18 (List.134, List.135, List.136):
     let List.437 : {List U8, U64} = CallByName List.89 List.134 List.135 List.136;
@@ -136,12 +136,12 @@ procedure List.6 (#Attr.2):
     ret List.409;
 
 procedure List.6 (#Attr.2):
-    let List.458 : U64 = lowlevel ListLen #Attr.2;
-    ret List.458;
+    let List.459 : U64 = lowlevel ListLen #Attr.2;
+    ret List.459;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.452 : {Str, Str} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.452;
+    let List.453 : {Str, Str} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.453;
 
 procedure List.70 (#Attr.2, #Attr.3):
     let List.415 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
@@ -152,8 +152,8 @@ procedure List.71 (#Attr.2, #Attr.3):
     ret List.413;
 
 procedure List.8 (#Attr.2, #Attr.3):
-    let List.457 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
-    ret List.457;
+    let List.458 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
+    ret List.458;
 
 procedure List.89 (List.385, List.386, List.387):
     let List.441 : U64 = 0i64;
@@ -161,19 +161,19 @@ procedure List.89 (List.385, List.386, List.387):
     let List.440 : {List U8, U64} = CallByName List.90 List.385 List.386 List.387 List.441 List.442;
     ret List.440;
 
-procedure List.90 (List.468, List.469, List.470, List.471, List.472):
+procedure List.90 (List.469, List.470, List.471, List.472, List.473):
     joinpoint List.443 List.388 List.389 List.390 List.391 List.392:
         let List.445 : Int1 = CallByName Num.22 List.391 List.392;
         if List.445 then
-            let List.451 : {Str, Str} = CallByName List.66 List.388 List.391;
-            let List.446 : {List U8, U64} = CallByName List.137 List.389 List.451 List.390;
+            let List.452 : {Str, Str} = CallByName List.66 List.388 List.391;
+            let List.446 : {List U8, U64} = CallByName List.137 List.389 List.452 List.390;
             let List.449 : U64 = 1i64;
             let List.448 : U64 = CallByName Num.19 List.391 List.449;
             jump List.443 List.388 List.446 List.390 List.448 List.392;
         else
             ret List.389;
     in
-    jump List.443 List.468 List.469 List.470 List.471 List.472;
+    jump List.443 List.469 List.470 List.471 List.472 List.473;
 
 procedure Num.125 (#Attr.2):
     let Num.263 : U8 = lowlevel NumIntCast #Attr.2;

--- a/crates/compiler/test_mono/generated/encode_derived_record_two_field_strings.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_record_two_field_strings.txt
@@ -126,8 +126,8 @@ procedure Json.96 (Json.97, Json.433, Json.95):
     ret Json.435;
 
 procedure List.137 (List.138, List.139, List.136):
-    let List.455 : {List U8, U64} = CallByName Json.114 List.138 List.139;
-    ret List.455;
+    let List.456 : {List U8, U64} = CallByName Json.114 List.138 List.139;
+    ret List.456;
 
 procedure List.18 (List.134, List.135, List.136):
     let List.437 : {List U8, U64} = CallByName List.89 List.134 List.135 List.136;
@@ -144,12 +144,12 @@ procedure List.6 (#Attr.2):
     ret List.409;
 
 procedure List.6 (#Attr.2):
-    let List.458 : U64 = lowlevel ListLen #Attr.2;
-    ret List.458;
+    let List.459 : U64 = lowlevel ListLen #Attr.2;
+    ret List.459;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.452 : {Str, Str} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.452;
+    let List.453 : {Str, Str} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.453;
 
 procedure List.70 (#Attr.2, #Attr.3):
     let List.415 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
@@ -160,8 +160,8 @@ procedure List.71 (#Attr.2, #Attr.3):
     ret List.413;
 
 procedure List.8 (#Attr.2, #Attr.3):
-    let List.457 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
-    ret List.457;
+    let List.458 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
+    ret List.458;
 
 procedure List.89 (List.385, List.386, List.387):
     let List.441 : U64 = 0i64;
@@ -169,19 +169,19 @@ procedure List.89 (List.385, List.386, List.387):
     let List.440 : {List U8, U64} = CallByName List.90 List.385 List.386 List.387 List.441 List.442;
     ret List.440;
 
-procedure List.90 (List.468, List.469, List.470, List.471, List.472):
+procedure List.90 (List.469, List.470, List.471, List.472, List.473):
     joinpoint List.443 List.388 List.389 List.390 List.391 List.392:
         let List.445 : Int1 = CallByName Num.22 List.391 List.392;
         if List.445 then
-            let List.451 : {Str, Str} = CallByName List.66 List.388 List.391;
-            let List.446 : {List U8, U64} = CallByName List.137 List.389 List.451 List.390;
+            let List.452 : {Str, Str} = CallByName List.66 List.388 List.391;
+            let List.446 : {List U8, U64} = CallByName List.137 List.389 List.452 List.390;
             let List.449 : U64 = 1i64;
             let List.448 : U64 = CallByName Num.19 List.391 List.449;
             jump List.443 List.388 List.446 List.390 List.448 List.392;
         else
             ret List.389;
     in
-    jump List.443 List.468 List.469 List.470 List.471 List.472;
+    jump List.443 List.469 List.470 List.471 List.472 List.473;
 
 procedure Num.125 (#Attr.2):
     let Num.263 : U8 = lowlevel NumIntCast #Attr.2;

--- a/crates/compiler/test_mono/generated/encode_derived_tag_one_field_string.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_tag_one_field_string.txt
@@ -127,8 +127,8 @@ procedure Json.96 (Json.97, Json.438, Json.95):
     ret Json.440;
 
 procedure List.137 (List.138, List.139, List.136):
-    let List.461 : {List U8, U64} = CallByName Json.128 List.138 List.139;
-    ret List.461;
+    let List.462 : {List U8, U64} = CallByName Json.128 List.138 List.139;
+    ret List.462;
 
 procedure List.18 (List.134, List.135, List.136):
     let List.443 : {List U8, U64} = CallByName List.89 List.134 List.135 List.136;
@@ -145,12 +145,12 @@ procedure List.6 (#Attr.2):
     ret List.409;
 
 procedure List.6 (#Attr.2):
-    let List.462 : U64 = lowlevel ListLen #Attr.2;
-    ret List.462;
+    let List.463 : U64 = lowlevel ListLen #Attr.2;
+    ret List.463;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.458 : Str = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.458;
+    let List.459 : Str = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.459;
 
 procedure List.70 (#Attr.2, #Attr.3):
     let List.415 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
@@ -161,8 +161,8 @@ procedure List.71 (#Attr.2, #Attr.3):
     ret List.413;
 
 procedure List.8 (#Attr.2, #Attr.3):
-    let List.464 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
-    ret List.464;
+    let List.465 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
+    ret List.465;
 
 procedure List.89 (List.385, List.386, List.387):
     let List.447 : U64 = 0i64;
@@ -170,19 +170,19 @@ procedure List.89 (List.385, List.386, List.387):
     let List.446 : {List U8, U64} = CallByName List.90 List.385 List.386 List.387 List.447 List.448;
     ret List.446;
 
-procedure List.90 (List.474, List.475, List.476, List.477, List.478):
+procedure List.90 (List.475, List.476, List.477, List.478, List.479):
     joinpoint List.449 List.388 List.389 List.390 List.391 List.392:
         let List.451 : Int1 = CallByName Num.22 List.391 List.392;
         if List.451 then
-            let List.457 : Str = CallByName List.66 List.388 List.391;
-            let List.452 : {List U8, U64} = CallByName List.137 List.389 List.457 List.390;
+            let List.458 : Str = CallByName List.66 List.388 List.391;
+            let List.452 : {List U8, U64} = CallByName List.137 List.389 List.458 List.390;
             let List.455 : U64 = 1i64;
             let List.454 : U64 = CallByName Num.19 List.391 List.455;
             jump List.449 List.388 List.452 List.390 List.454 List.392;
         else
             ret List.389;
     in
-    jump List.449 List.474 List.475 List.476 List.477 List.478;
+    jump List.449 List.475 List.476 List.477 List.478 List.479;
 
 procedure Num.125 (#Attr.2):
     let Num.265 : U8 = lowlevel NumIntCast #Attr.2;

--- a/crates/compiler/test_mono/generated/encode_derived_tag_two_payloads_string.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_tag_two_payloads_string.txt
@@ -133,8 +133,8 @@ procedure Json.96 (Json.97, Json.438, Json.95):
     ret Json.440;
 
 procedure List.137 (List.138, List.139, List.136):
-    let List.461 : {List U8, U64} = CallByName Json.128 List.138 List.139;
-    ret List.461;
+    let List.462 : {List U8, U64} = CallByName Json.128 List.138 List.139;
+    ret List.462;
 
 procedure List.18 (List.134, List.135, List.136):
     let List.443 : {List U8, U64} = CallByName List.89 List.134 List.135 List.136;
@@ -151,12 +151,12 @@ procedure List.6 (#Attr.2):
     ret List.409;
 
 procedure List.6 (#Attr.2):
-    let List.462 : U64 = lowlevel ListLen #Attr.2;
-    ret List.462;
+    let List.463 : U64 = lowlevel ListLen #Attr.2;
+    ret List.463;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.458 : Str = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.458;
+    let List.459 : Str = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.459;
 
 procedure List.70 (#Attr.2, #Attr.3):
     let List.415 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
@@ -167,8 +167,8 @@ procedure List.71 (#Attr.2, #Attr.3):
     ret List.413;
 
 procedure List.8 (#Attr.2, #Attr.3):
-    let List.464 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
-    ret List.464;
+    let List.465 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
+    ret List.465;
 
 procedure List.89 (List.385, List.386, List.387):
     let List.447 : U64 = 0i64;
@@ -176,19 +176,19 @@ procedure List.89 (List.385, List.386, List.387):
     let List.446 : {List U8, U64} = CallByName List.90 List.385 List.386 List.387 List.447 List.448;
     ret List.446;
 
-procedure List.90 (List.474, List.475, List.476, List.477, List.478):
+procedure List.90 (List.475, List.476, List.477, List.478, List.479):
     joinpoint List.449 List.388 List.389 List.390 List.391 List.392:
         let List.451 : Int1 = CallByName Num.22 List.391 List.392;
         if List.451 then
-            let List.457 : Str = CallByName List.66 List.388 List.391;
-            let List.452 : {List U8, U64} = CallByName List.137 List.389 List.457 List.390;
+            let List.458 : Str = CallByName List.66 List.388 List.391;
+            let List.452 : {List U8, U64} = CallByName List.137 List.389 List.458 List.390;
             let List.455 : U64 = 1i64;
             let List.454 : U64 = CallByName Num.19 List.391 List.455;
             jump List.449 List.388 List.452 List.390 List.454 List.392;
         else
             ret List.389;
     in
-    jump List.449 List.474 List.475 List.476 List.477 List.478;
+    jump List.449 List.475 List.476 List.477 List.478 List.479;
 
 procedure Num.125 (#Attr.2):
     let Num.265 : U8 = lowlevel NumIntCast #Attr.2;

--- a/crates/compiler/test_mono/generated/unreachable_void_constructor.txt
+++ b/crates/compiler/test_mono/generated/unreachable_void_constructor.txt
@@ -6,7 +6,7 @@ procedure Test.0 ():
     let Test.6 : Int1 = CallByName Bool.2;
     if Test.6 then
         let Test.8 : Str = "voided tag constructor is unreachable";
-        Crash `#UserApp.IdentId(8)`
+        Crash Test.8
     else
         let Test.5 : Str = "abc";
         ret Test.5;

--- a/crates/compiler/test_mono/generated/unreachable_void_constructor.txt
+++ b/crates/compiler/test_mono/generated/unreachable_void_constructor.txt
@@ -5,7 +5,8 @@ procedure Bool.2 ():
 procedure Test.0 ():
     let Test.6 : Int1 = CallByName Bool.2;
     if Test.6 then
-        Error voided tag constructor is unreachable
+        let Test.8 : Str = "voided tag constructor is unreachable";
+        Crash `#UserApp.IdentId(8)`
     else
         let Test.5 : Str = "abc";
         ret Test.5;

--- a/crates/compiler/test_mono/src/tests.rs
+++ b/crates/compiler/test_mono/src/tests.rs
@@ -2030,3 +2030,16 @@ fn recursive_function_and_union_with_inference_hole() {
         "#
     )
 }
+
+#[mono_test]
+fn crash() {
+    indoc!(
+        r#"
+        app "test" provides [getInfallible] to "./platform"
+
+        getInfallible = \result -> when result is
+            Ok x -> x
+            _ -> crash "turns out this was fallible"
+        "#
+    )
+}

--- a/crates/compiler/test_mono/src/tests.rs
+++ b/crates/compiler/test_mono/src/tests.rs
@@ -2035,11 +2035,16 @@ fn recursive_function_and_union_with_inference_hole() {
 fn crash() {
     indoc!(
         r#"
-        app "test" provides [getInfallible] to "./platform"
+        app "test" provides [main] to "./platform"
 
         getInfallible = \result -> when result is
             Ok x -> x
             _ -> crash "turns out this was fallible"
+
+        main =
+            x : [Ok U64, Err Str]
+            x = Ok 78
+            getInfallible x
         "#
     )
 }

--- a/crates/compiler/types/src/subs.rs
+++ b/crates/compiler/types/src/subs.rs
@@ -1667,6 +1667,8 @@ impl Subs {
     pub const TAG_NAME_BAD_UTF_8: SubsIndex<TagName> = SubsIndex::new(3);
     pub const TAG_NAME_OUT_OF_BOUNDS: SubsIndex<TagName> = SubsIndex::new(4);
 
+    pub const STR_SLICE: VariableSubsSlice = SubsSlice::new(0, 1);
+
     #[rustfmt::skip]
     pub const AB_ENCODING: SubsSlice<Symbol> = SubsSlice::new(0, 1);
     #[rustfmt::skip]
@@ -1704,14 +1706,18 @@ impl Subs {
 
         let mut subs = Subs {
             utable: UnificationTable::default(),
-            variables: Vec::new(),
+            variables: vec![
+                // Used for STR_SLICE
+                Variable::STR,
+            ],
             tag_names,
             symbol_names,
             field_names: Vec::new(),
             record_fields: Vec::new(),
-            // store an empty slice at the first position
-            // used for "TagOrFunction"
-            variable_slices: vec![VariableSubsSlice::default()],
+            variable_slices: vec![
+                // used for "TagOrFunction"
+                VariableSubsSlice::default(),
+            ],
             unspecialized_lambda_sets: Vec::new(),
             tag_name_cache: Default::default(),
             uls_of_var: Default::default(),

--- a/crates/compiler/types/src/types.rs
+++ b/crates/compiler/types/src/types.rs
@@ -3529,6 +3529,8 @@ pub enum Category {
 
     AbilityMemberSpecialization(Symbol),
 
+    Crash,
+
     Expect,
     Dbg,
     Unknown,

--- a/crates/repl_expect/src/run.rs
+++ b/crates/repl_expect/src/run.rs
@@ -235,7 +235,7 @@ fn run_expect_pure<'a, W: std::io::Write>(
 
     let sequence = ExpectSequence::new(shared_memory.ptr.cast());
 
-    let result: Result<(), (String, u32)> = try_run_jit_function!(lib, expect.name, (), |v: ()| v);
+    let result: Result<(), (String, _)> = try_run_jit_function!(lib, expect.name, (), |v: ()| v);
 
     let shared_memory_ptr: *const u8 = shared_memory.ptr.cast();
 
@@ -305,7 +305,7 @@ fn run_expect_fx<'a, W: std::io::Write>(
 
             child_memory.set_shared_buffer(lib);
 
-            let result: Result<(), (String, u32)> =
+            let result: Result<(), (String, _)> =
                 try_run_jit_function!(lib, expect.name, (), |v: ()| v);
 
             if let Err((msg, _)) = result {

--- a/crates/repl_expect/src/run.rs
+++ b/crates/repl_expect/src/run.rs
@@ -235,7 +235,7 @@ fn run_expect_pure<'a, W: std::io::Write>(
 
     let sequence = ExpectSequence::new(shared_memory.ptr.cast());
 
-    let result: Result<(), String> = try_run_jit_function!(lib, expect.name, (), |v: ()| v);
+    let result: Result<(), (String, u32)> = try_run_jit_function!(lib, expect.name, (), |v: ()| v);
 
     let shared_memory_ptr: *const u8 = shared_memory.ptr.cast();
 
@@ -249,7 +249,7 @@ fn run_expect_pure<'a, W: std::io::Write>(
 
         let renderer = Renderer::new(arena, interns, render_target, module_id, filename, &source);
 
-        if let Err(roc_panic_message) = result {
+        if let Err((roc_panic_message, _roc_panic_tag)) = result {
             renderer.render_panic(writer, &roc_panic_message, expect.region)?;
         } else {
             let mut offset = ExpectSequence::START_OFFSET;
@@ -305,9 +305,10 @@ fn run_expect_fx<'a, W: std::io::Write>(
 
             child_memory.set_shared_buffer(lib);
 
-            let result: Result<(), String> = try_run_jit_function!(lib, expect.name, (), |v: ()| v);
+            let result: Result<(), (String, u32)> =
+                try_run_jit_function!(lib, expect.name, (), |v: ()| v);
 
-            if let Err(msg) = result {
+            if let Err((msg, _)) = result {
                 panic!("roc panic {}", msg);
             }
 

--- a/crates/reporting/src/error/canonicalize.rs
+++ b/crates/reporting/src/error/canonicalize.rs
@@ -1086,7 +1086,36 @@ pub fn can_problem<'b>(
             } else {
                 "TOO FEW TYPE ARGUMENTS".to_string()
             };
-
+            severity = Severity::RuntimeError;
+        }
+        Problem::UnappliedCrash { region } => {
+            doc = alloc.stack([
+                alloc.concat([
+                    alloc.reflow("This "), alloc.keyword("crash"), alloc.reflow(" doesn't have a message given to it:")
+                ]),
+                alloc.region(lines.convert_region(region)),
+                alloc.concat([
+                    alloc.keyword("crash"), alloc.reflow(" must be passed a message to crash with at the exact place it's used. "),
+                    alloc.keyword("crash"), alloc.reflow(" can't be used as a value that's passed around, like functions can be - it must be applied immediately!"),
+                ])
+            ]);
+            title = "UNAPPLIED CRASH".to_string();
+            severity = Severity::RuntimeError;
+        }
+        Problem::OverAppliedCrash { region } => {
+            doc = alloc.stack([
+                alloc.concat([
+                    alloc.reflow("This "),
+                    alloc.keyword("crash"),
+                    alloc.reflow(" has too many values given to it:"),
+                ]),
+                alloc.region(lines.convert_region(region)),
+                alloc.concat([
+                    alloc.keyword("crash"),
+                    alloc.reflow(" must be given exacly one message to crash with."),
+                ]),
+            ]);
+            title = "OVERAPPLIED CRASH".to_string();
             severity = Severity::RuntimeError;
         }
     };

--- a/crates/reporting/src/error/type.rs
+++ b/crates/reporting/src/error/type.rs
@@ -1375,6 +1375,42 @@ fn to_expr_report<'b>(
                 }
             }
 
+            Reason::CrashArg => {
+                let this_is = alloc.reflow("The value is");
+
+                let wanted = alloc.concat([
+                    alloc.reflow("But I can only "),
+                    alloc.keyword("crash"),
+                    alloc.reflow(" with messages of type"),
+                ]);
+
+                let details = None;
+
+                let lines = [
+                    alloc
+                        .reflow("This value passed to ")
+                        .append(alloc.keyword("crash"))
+                        .append(alloc.reflow(" is not a string:")),
+                    alloc.region(lines.convert_region(region)),
+                    type_comparison(
+                        alloc,
+                        found,
+                        expected_type,
+                        ExpectationContext::WhenCondition,
+                        add_category(alloc, this_is, &category),
+                        wanted,
+                        details,
+                    ),
+                ];
+
+                Report {
+                    filename,
+                    title: "TYPE MISMATCH".to_string(),
+                    doc: alloc.stack(lines),
+                    severity: Severity::RuntimeError,
+                }
+            }
+
             Reason::LowLevelOpArg { op, arg_index } => {
                 panic!(
                     "Compiler bug: argument #{} to low-level operation {:?} was the wrong type!",

--- a/crates/reporting/src/error/type.rs
+++ b/crates/reporting/src/error/type.rs
@@ -1680,6 +1680,10 @@ fn format_category<'b>(
             alloc.concat([this_is, alloc.text(" an uniqueness attribute")]),
             alloc.text(" of type:"),
         ),
+        Crash => {
+            internal_error!("calls to crash should be unconditionally admitted in any context, unexpected reachability!");
+        }
+
         Storage(..) | Unknown => (
             alloc.concat([this_is, alloc.text(" a value")]),
             alloc.text(" of type:"),

--- a/crates/reporting/tests/test_reporting.rs
+++ b/crates/reporting/tests/test_reporting.rs
@@ -12431,16 +12431,16 @@ All branches in an `if` must have the same type!
     @r###"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
-    This 1st argument to this function has an unexpected type:
+    This value passed to `crash` is not a string:
 
     4│      crash {}
                   ^^
 
-    The argument is a record of type:
+    The value is a record of type:
 
         {}
 
-    But this function needs its 1st argument to be:
+    But I can only `crash` with messages of type
 
         Str
     "###
@@ -12454,6 +12454,16 @@ All branches in an `if` must have the same type!
             "#
         ),
     @r###"
+    ── UNAPPLIED CRASH ─────────────────────────────────────── /code/proj/Main.roc ─
+
+    This `crash` doesn't have a message given to it:
+
+    4│      crash
+            ^^^^^
+
+    `crash` must be passed a message to crash with at the exact place it's
+    used. `crash` can't be used as a value that's passed around, like
+    functions can be - it must be applied immediately!
     "###
     );
 
@@ -12465,14 +12475,14 @@ All branches in an `if` must have the same type!
             "#
         ),
     @r###"
-    ── TOO MANY ARGS ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── OVERAPPLIED CRASH ───────────────────────────────────── /code/proj/Main.roc ─
 
-    This function expects 1 argument, but it got 2 instead:
+    This `crash` has too many values given to it:
 
     4│      crash "" ""
-            ^^^^^
+                  ^^^^^
 
-    Are there any missing commas? Or missing parentheses?
+    `crash` must be given exacly one message to crash with.
     "###
     );
 }

--- a/crates/reporting/tests/test_reporting.rs
+++ b/crates/reporting/tests/test_reporting.rs
@@ -12420,4 +12420,59 @@ All branches in an `if` must have the same type!
     to be more general?
     "###
     );
+
+    test_report!(
+        crash_given_non_string,
+        indoc!(
+            r#"
+            crash {}
+            "#
+        ),
+    @r###"
+    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+
+    This 1st argument to this function has an unexpected type:
+
+    4│      crash {}
+                  ^^
+
+    The argument is a record of type:
+
+        {}
+
+    But this function needs its 1st argument to be:
+
+        Str
+    "###
+    );
+
+    test_report!(
+        crash_unapplied,
+        indoc!(
+            r#"
+            crash
+            "#
+        ),
+    @r###"
+    "###
+    );
+
+    test_report!(
+        crash_overapplied,
+        indoc!(
+            r#"
+            crash "" ""
+            "#
+        ),
+    @r###"
+    ── TOO MANY ARGS ───────────────────────────────────────── /code/proj/Main.roc ─
+
+    This function expects 1 argument, but it got 2 instead:
+
+    4│      crash "" ""
+            ^^^^^
+
+    Are there any missing commas? Or missing parentheses?
+    "###
+    );
 }

--- a/examples/cli/cli-platform/src/lib.rs
+++ b/examples/cli/cli-platform/src/lib.rs
@@ -58,12 +58,10 @@ pub unsafe extern "C" fn roc_dealloc(c_ptr: *mut c_void, _alignment: u32) {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn roc_panic(c_ptr: *mut c_void, tag_id: u32) {
+pub unsafe extern "C" fn roc_panic(msg: &RocStr, tag_id: u32) {
     match tag_id {
         0 => {
-            let slice = CStr::from_ptr(c_ptr as *const c_char);
-            let string = slice.to_str().unwrap();
-            eprintln!("Roc crashed with:\n\n\t{}\n", string);
+            eprintln!("Roc crashed with:\n\n\t{}\n", msg.as_str());
 
             print_backtrace();
             std::process::exit(1);

--- a/examples/cli/cli-platform/src/lib.rs
+++ b/examples/cli/cli-platform/src/lib.rs
@@ -66,6 +66,12 @@ pub unsafe extern "C" fn roc_panic(msg: &RocStr, tag_id: u32) {
             print_backtrace();
             std::process::exit(1);
         }
+        1 => {
+            eprintln!("The program crashed with:\n\n\t{}\n", msg.as_str());
+
+            print_backtrace();
+            std::process::exit(1);
+        }
         _ => todo!(),
     }
 }


### PR DESCRIPTION
Implements crash. It lets you force a userland crash of a Roc program.

Breaking changes: `roc_panic` now has signature `roc_panic(RocStr*, u32)` on all archs, 32 bit and 64 bit.

```
#[test]
#[cfg(any(feature = "gen-llvm"))]
#[should_panic = r#"User crash with message: "no new even primes""#]
fn crash_in_passed_closure() {
    expect_runtime_error_panic!(indoc!(
        r#"
        app "test" provides [main] to "./platform"

        main = List.map [1, 2, 3] \n -> if n == 2 then crash "no new even primes" else ""
        "#
    ));
}
```