### PR TITLE
Refactor several parse methods to use more combinators

### DIFF
--- a/crates/compiler/parse/src/blankspace.rs
+++ b/crates/compiler/parse/src/blankspace.rs
@@ -14,10 +14,8 @@ pub fn space0_around_ee<'a, P, S, E>(
     indent_after_problem: fn(Position) -> E,
 ) -> impl Parser<'a, Loc<S>, E>
 where
-    S: Spaceable<'a>,
-    S: 'a,
-    P: Parser<'a, Loc<S>, E>,
-    P: 'a,
+    S: 'a + Spaceable<'a>,
+    P: 'a + Parser<'a, Loc<S>, E>,
     E: 'a + SpaceProblem,
 {
     parser::map_with_arena(
@@ -34,10 +32,8 @@ pub fn space0_around_e_no_after_indent_check<'a, P, S, E>(
     indent_before_problem: fn(Position) -> E,
 ) -> impl Parser<'a, Loc<S>, E>
 where
-    S: Spaceable<'a>,
-    S: 'a,
-    P: Parser<'a, Loc<S>, E>,
-    P: 'a,
+    S: 'a + Spaceable<'a>,
+    P: 'a + Parser<'a, Loc<S>, E>,
     E: 'a + SpaceProblem,
 {
     parser::map_with_arena(
@@ -55,10 +51,8 @@ pub fn space0_before_optional_after<'a, P, S, E>(
     indent_after_problem: fn(Position) -> E,
 ) -> impl Parser<'a, Loc<S>, E>
 where
-    S: Spaceable<'a>,
-    S: 'a,
-    P: Parser<'a, Loc<S>, E>,
-    P: 'a,
+    S: 'a + Spaceable<'a>,
+    P: 'a + Parser<'a, Loc<S>, E>,
     E: 'a + SpaceProblem,
 {
     parser::map_with_arena(
@@ -84,8 +78,7 @@ fn spaces_around_help<'a, S>(
     ),
 ) -> Loc<S>
 where
-    S: Spaceable<'a>,
-    S: 'a,
+    S: 'a + Spaceable<'a>,
 {
     let (spaces_before, (loc_val, spaces_after)) = tuples;
 
@@ -117,10 +110,8 @@ pub fn space0_before_e<'a, P, S, E>(
     indent_problem: fn(Position) -> E,
 ) -> impl Parser<'a, Loc<S>, E>
 where
-    S: Spaceable<'a>,
-    S: 'a,
-    P: Parser<'a, Loc<S>, E>,
-    P: 'a,
+    S: 'a + Spaceable<'a>,
+    P: 'a + Parser<'a, Loc<S>, E>,
     E: 'a + SpaceProblem,
 {
     parser::map_with_arena(
@@ -142,10 +133,8 @@ pub fn space0_after_e<'a, P, S, E>(
     indent_problem: fn(Position) -> E,
 ) -> impl Parser<'a, Loc<S>, E>
 where
-    S: Spaceable<'a>,
-    S: 'a,
-    P: Parser<'a, Loc<S>, E>,
-    P: 'a,
+    S: 'a + Spaceable<'a>,
+    P: 'a + Parser<'a, Loc<S>, E>,
     E: 'a + SpaceProblem,
 {
     parser::map_with_arena(

--- a/crates/compiler/parse/src/parser.rs
+++ b/crates/compiler/parse/src/parser.rs
@@ -470,7 +470,6 @@ pub enum EWhen<'a> {
     Condition(&'a EExpr<'a>, Position),
     Branch(&'a EExpr<'a>, Position),
 
-    IndentIs(Position),
     IndentCondition(Position),
     IndentPattern(Position),
     IndentArrow(Position),
@@ -869,13 +868,13 @@ where
     P1: Parser<'a, Before, E>,
     After: 'a,
     E: 'a,
-    F: Fn(&'a Bump, State<'a>, Progress, Before, u32) -> ParseResult<'a, After, E>,
+    F: Fn(&'a Bump, State<'a>, Progress, Before) -> ParseResult<'a, After, E>,
 {
     move |arena, state, min_indent| {
         parser
             .parse(arena, state, min_indent)
             .and_then(|(progress, output, next_state)| {
-                transform(arena, next_state, progress, output, min_indent)
+                transform(arena, next_state, progress, output)
             })
     }
 }
@@ -1376,6 +1375,64 @@ macro_rules! and {
     };
 }
 
+/// Similar to `and`, but we modify the min_indent of the second parser to be
+/// 1 greater than the line_indent() at the start of the first parser.
+#[macro_export]
+macro_rules! indented_seq {
+    ($p1:expr, $p2:expr) => {
+        move |arena: &'a bumpalo::Bump, state: $crate::state::State<'a>, _min_indent: u32| {
+            let start_indent = state.line_indent();
+
+            // TODO: we should account for min_indent here, but this doesn't currently work
+            // because min_indent is sometimes larger than it really should be, which is in turn
+            // due to uses of `increment_indent`.
+            //
+            // let p1_indent = std::cmp::max(start_indent, min_indent);
+
+            let p1_indent = start_indent;
+            let p2_indent = p1_indent + 1;
+
+            // We have to clone this because if the first parser passes and then
+            // the second one fails, we need to revert back to the original state.
+            let original_state = state.clone();
+
+            match $p1.parse(arena, state, p1_indent) {
+                Ok((p1, (), state)) => match $p2.parse(arena, state, p2_indent) {
+                    Ok((p2, out2, state)) => Ok((p1.or(p2), out2, state)),
+                    Err((p2, fail, _)) => Err((p1.or(p2), fail, original_state)),
+                },
+                Err((progress, fail, state)) => Err((progress, fail, state)),
+            }
+        }
+    };
+}
+
+/// Similar to `and`, but we modify the min_indent of the second parser to be
+/// 1 greater than the column() at the start of the first parser.
+#[macro_export]
+macro_rules! absolute_indented_seq {
+    ($p1:expr, $p2:expr) => {
+        move |arena: &'a bumpalo::Bump, state: $crate::state::State<'a>, _min_indent: u32| {
+            let start_indent = state.column();
+
+            let p1_indent = start_indent;
+            let p2_indent = p1_indent + 1;
+
+            // We have to clone this because if the first parser passes and then
+            // the second one fails, we need to revert back to the original state.
+            let original_state = state.clone();
+
+            match $p1.parse(arena, state, p1_indent) {
+                Ok((p1, out1, state)) => match $p2.parse(arena, state, p2_indent) {
+                    Ok((p2, out2, state)) => Ok((p1.or(p2), (out1, out2), state)),
+                    Err((p2, fail, _)) => Err((p1.or(p2), fail, original_state)),
+                },
+                Err((progress, fail, state)) => Err((progress, fail, state)),
+            }
+        }
+    };
+}
+
 #[macro_export]
 macro_rules! one_of {
     ($p1:expr, $p2:expr) => {
@@ -1450,6 +1507,16 @@ where
     move |arena, state, min_indent| parser.parse(arena, state, min_indent + 1)
 }
 
+pub fn line_min_indent<'a, P, T, X: 'a>(parser: P) -> impl Parser<'a, T, X>
+where
+    P: Parser<'a, T, X>,
+{
+    move |arena, state: State<'a>, min_indent| {
+        let min_indent = std::cmp::max(state.line_indent(), min_indent);
+        parser.parse(arena, state, min_indent)
+    }
+}
+
 pub fn absolute_column_min_indent<'a, P, T, X: 'a>(parser: P) -> impl Parser<'a, T, X>
 where
     P: Parser<'a, T, X>,
@@ -1517,28 +1584,25 @@ where
     }
 }
 
-pub fn parse_word1<'a, ToError, E>(
-    state: State<'a>,
-    min_indent: u32,
-    word: u8,
-    to_error: ToError,
-) -> ParseResult<'a, (), E>
+pub fn word1_indent<'a, ToError, E>(word: u8, to_error: ToError) -> impl Parser<'a, (), E>
 where
     ToError: Fn(Position) -> E,
     E: 'a,
 {
     debug_assert_ne!(word, b'\n');
 
-    if min_indent > state.column() {
-        return Err((NoProgress, to_error(state.pos()), state));
-    }
-
-    match state.bytes().first() {
-        Some(x) if *x == word => {
-            let state = state.advance(1);
-            Ok((MadeProgress, (), state))
+    move |_arena: &'a Bump, state: State<'a>, min_indent: u32| {
+        if min_indent > state.column() {
+            return Err((NoProgress, to_error(state.pos()), state));
         }
-        _ => Err((NoProgress, to_error(state.pos()), state)),
+
+        match state.bytes().first() {
+            Some(x) if *x == word => {
+                let state = state.advance(1);
+                Ok((MadeProgress, (), state))
+            }
+            _ => Err((NoProgress, to_error(state.pos()), state)),
+        }
     }
 }
 

--- a/crates/compiler/parse/src/pattern.rs
+++ b/crates/compiler/parse/src/pattern.rs
@@ -115,7 +115,7 @@ fn loc_tag_pattern_arg<'a>(
 pub fn loc_has_parser<'a>() -> impl Parser<'a, Loc<Has<'a>>, EPattern<'a>> {
     then(
         loc_tag_pattern_arg(false),
-        |_arena, state, progress, pattern, _min_indent| {
+        |_arena, state, progress, pattern| {
             if matches!(pattern.value, Pattern::Identifier("has")) {
                 Ok((progress, Loc::at(pattern.region, Has::Has), state))
             } else {
@@ -228,7 +228,7 @@ fn list_element_pattern<'a>() -> impl Parser<'a, Loc<Pattern<'a>>, PList<'a>> {
 fn three_list_rest_pattern_error<'a>() -> impl Parser<'a, Loc<Pattern<'a>>, PList<'a>> {
     then(
         loc!(word3(b'.', b'.', b'.', PList::Rest)),
-        |_arena, state, _progress, word, _min_indent| {
+        |_arena, state, _progress, word| {
             Err((MadeProgress, PList::Rest(word.region.start()), state))
         },
     )

--- a/crates/compiler/parse/src/type_annotation.rs
+++ b/crates/compiler/parse/src/type_annotation.rs
@@ -99,7 +99,7 @@ fn parse_type_alias_after_as<'a>() -> impl Parser<'a, TypeHeader<'a>, EType<'a>>
         space0_before_e(term(false), EType::TAsIndentStart),
         // TODO: introduce a better combinator for this.
         // `check_type_alias` doesn't need to modify the state or progress, but it needs to access `state.pos()`
-        |arena, state, progress, output, _min_indent| {
+        |arena, state, progress, output| {
             let res = check_type_alias(arena, output);
 
             match res {

--- a/crates/compiler/parse/tests/snapshots/fail/lambda_extra_comma.expr.result-ast
+++ b/crates/compiler/parse/tests/snapshots/fail/lambda_extra_comma.expr.result-ast
@@ -1,1 +1,1 @@
-Expr(Closure(Arg(@1), @1), @0)
+Expr(Closure(Arg(@1), @0), @0)

--- a/crates/compiler/parse/tests/snapshots/fail/lambda_missing_indent.expr.result-ast
+++ b/crates/compiler/parse/tests/snapshots/fail/lambda_missing_indent.expr.result-ast
@@ -1,1 +1,1 @@
-Expr(Closure(IndentBody(@5), @3), @0)
+Expr(Closure(IndentBody(@5), @0), @0)

--- a/crates/compiler/parse/tests/snapshots/fail/pattern_binds_keyword.expr.result-ast
+++ b/crates/compiler/parse/tests/snapshots/fail/pattern_binds_keyword.expr.result-ast
@@ -1,1 +1,1 @@
-Expr(When(Arrow(@24), @24), @0)
+Expr(When(Arrow(@24), @0), @0)

--- a/crates/compiler/parse/tests/snapshots/fail/when_missing_arrow.expr.result-ast
+++ b/crates/compiler/parse/tests/snapshots/fail/when_missing_arrow.expr.result-ast
@@ -1,1 +1,1 @@
-Expr(When(Arrow(@26), @20), @0)
+Expr(When(Arrow(@26), @0), @0)

--- a/crates/repl_cli/src/repl_state.rs
+++ b/crates/repl_cli/src/repl_state.rs
@@ -6,6 +6,7 @@ use roc_collections::MutSet;
 use roc_mono::ir::OptLevel;
 use roc_parse::ast::{Expr, Pattern, TypeDef, TypeHeader, ValueDef};
 use roc_parse::expr::{parse_single_def, ExprParseOptions, SingleDef};
+use roc_parse::parser::Parser;
 use roc_parse::parser::{EClosure, EExpr, EPattern};
 use roc_parse::parser::{EWhen, Either};
 use roc_parse::state::State;
@@ -317,7 +318,7 @@ fn parse_src<'a>(arena: &'a Bump, line: &'a str) -> ParseOutcome<'a> {
         _ => {
             let src_bytes = line.as_bytes();
 
-            match roc_parse::expr::parse_loc_expr(arena, State::new(src_bytes), 0) {
+            match roc_parse::expr::loc_expr().parse(arena, State::new(src_bytes), 0) {
                 Ok((_, loc_expr, _)) => ParseOutcome::Expr(loc_expr.value),
                 // Special case some syntax errors to allow for multi-line inputs
                 Err((_, EExpr::Closure(EClosure::Body(_, _), _), _))

--- a/crates/reporting/src/error/parse.rs
+++ b/crates/reporting/src/error/parse.rs
@@ -1384,7 +1384,7 @@ fn to_when_report<'a>(
         EWhen::IfToken(_pos) => unreachable!("the if-token is optional"),
         EWhen::When(_pos) => unreachable!("another branch would be taken"),
 
-        EWhen::Is(pos) | EWhen::IndentIs(pos) => to_unfinished_when_report(
+        EWhen::Is(pos) => to_unfinished_when_report(
             alloc,
             lines,
             filename,

--- a/crates/reporting/tests/test_reporting.rs
+++ b/crates/reporting/tests/test_reporting.rs
@@ -4851,6 +4851,7 @@ mod test_reporting {
 
     I am partway through parsing a `when` expression, but got stuck here:
 
+    4│      when Just 4 is
     5│          Just when ->
                      ^
 
@@ -4886,6 +4887,8 @@ mod test_reporting {
 
     I was partway through parsing a `when` expression, but I got stuck here:
 
+    4│      when 5 is
+    5│          1 -> 2
     6│          _
                  ^
 


### PR DESCRIPTION
Most notably, this converts closure, `when`, and some `if` parsing to fully use combinators instead of custom parsing.

On the upside, this change fixes some bugs with error positions - where previously some errors involving `when` didn't correctly indicate where the when expr started - but rather pointed to some arbitrary point inside the when body. You can see this change in a few `reporting` test updates - where the error now actually shows the full context of the `when` expr that has the error.