### PR TITLE
Fix test_mono

### DIFF
--- a/crates/compiler/test_mono/generated/dict.txt
+++ b/crates/compiler/test_mono/generated/dict.txt
@@ -1,10 +1,10 @@
 procedure Dict.1 ():
-    let Dict.316 : List {[], []} = Array [];
-    ret Dict.316;
+    let Dict.318 : List {[], []} = Array [];
+    ret Dict.318;
 
-procedure Dict.7 (Dict.310):
-    let Dict.315 : U64 = CallByName List.6 Dict.310;
-    ret Dict.315;
+procedure Dict.7 (Dict.312):
+    let Dict.317 : U64 = CallByName List.6 Dict.312;
+    ret Dict.317;
 
 procedure List.6 (#Attr.2):
     let List.409 : U64 = lowlevel ListLen #Attr.2;

--- a/crates/compiler/test_mono/generated/encode_derived_nested_record_string.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_nested_record_string.txt
@@ -213,11 +213,11 @@ procedure List.137 (List.138, List.139, List.136):
     ret List.521;
 
 procedure List.18 (List.134, List.135, List.136):
-    let List.431 : {List U8, U64} = CallByName List.80 List.134 List.135 List.136;
+    let List.431 : {List U8, U64} = CallByName List.89 List.134 List.135 List.136;
     ret List.431;
 
 procedure List.18 (List.134, List.135, List.136):
-    let List.503 : {List U8, U64} = CallByName List.80 List.134 List.135 List.136;
+    let List.503 : {List U8, U64} = CallByName List.89 List.134 List.135 List.136;
     ret List.503;
 
 procedure List.4 (List.105, List.106):
@@ -258,13 +258,13 @@ procedure List.8 (#Attr.2, #Attr.3):
     let List.523 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
     ret List.523;
 
-procedure List.80 (List.385, List.386, List.387):
+procedure List.89 (List.385, List.386, List.387):
     let List.435 : U64 = 0i64;
     let List.436 : U64 = CallByName List.6 List.385;
     let List.434 : {List U8, U64} = CallByName List.90 List.385 List.386 List.387 List.435 List.436;
     ret List.434;
 
-procedure List.80 (List.385, List.386, List.387):
+procedure List.89 (List.385, List.386, List.387):
     let List.507 : U64 = 0i64;
     let List.508 : U64 = CallByName List.6 List.385;
     let List.506 : {List U8, U64} = CallByName List.90 List.385 List.386 List.387 List.507 List.508;

--- a/crates/compiler/test_mono/generated/encode_derived_record_one_field_string.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_record_one_field_string.txt
@@ -122,7 +122,7 @@ procedure List.137 (List.138, List.139, List.136):
     ret List.455;
 
 procedure List.18 (List.134, List.135, List.136):
-    let List.437 : {List U8, U64} = CallByName List.80 List.134 List.135 List.136;
+    let List.437 : {List U8, U64} = CallByName List.89 List.134 List.135 List.136;
     ret List.437;
 
 procedure List.4 (List.105, List.106):
@@ -155,7 +155,7 @@ procedure List.8 (#Attr.2, #Attr.3):
     let List.457 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
     ret List.457;
 
-procedure List.80 (List.385, List.386, List.387):
+procedure List.89 (List.385, List.386, List.387):
     let List.441 : U64 = 0i64;
     let List.442 : U64 = CallByName List.6 List.385;
     let List.440 : {List U8, U64} = CallByName List.90 List.385 List.386 List.387 List.441 List.442;

--- a/crates/compiler/test_mono/generated/encode_derived_record_two_field_strings.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_record_two_field_strings.txt
@@ -130,7 +130,7 @@ procedure List.137 (List.138, List.139, List.136):
     ret List.455;
 
 procedure List.18 (List.134, List.135, List.136):
-    let List.437 : {List U8, U64} = CallByName List.80 List.134 List.135 List.136;
+    let List.437 : {List U8, U64} = CallByName List.89 List.134 List.135 List.136;
     ret List.437;
 
 procedure List.4 (List.105, List.106):
@@ -163,7 +163,7 @@ procedure List.8 (#Attr.2, #Attr.3):
     let List.457 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
     ret List.457;
 
-procedure List.80 (List.385, List.386, List.387):
+procedure List.89 (List.385, List.386, List.387):
     let List.441 : U64 = 0i64;
     let List.442 : U64 = CallByName List.6 List.385;
     let List.440 : {List U8, U64} = CallByName List.90 List.385 List.386 List.387 List.441 List.442;

--- a/crates/compiler/test_mono/generated/encode_derived_tag_one_field_string.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_tag_one_field_string.txt
@@ -131,7 +131,7 @@ procedure List.137 (List.138, List.139, List.136):
     ret List.461;
 
 procedure List.18 (List.134, List.135, List.136):
-    let List.443 : {List U8, U64} = CallByName List.80 List.134 List.135 List.136;
+    let List.443 : {List U8, U64} = CallByName List.89 List.134 List.135 List.136;
     ret List.443;
 
 procedure List.4 (List.105, List.106):
@@ -164,7 +164,7 @@ procedure List.8 (#Attr.2, #Attr.3):
     let List.464 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
     ret List.464;
 
-procedure List.80 (List.385, List.386, List.387):
+procedure List.89 (List.385, List.386, List.387):
     let List.447 : U64 = 0i64;
     let List.448 : U64 = CallByName List.6 List.385;
     let List.446 : {List U8, U64} = CallByName List.90 List.385 List.386 List.387 List.447 List.448;

--- a/crates/compiler/test_mono/generated/encode_derived_tag_two_payloads_string.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_tag_two_payloads_string.txt
@@ -137,7 +137,7 @@ procedure List.137 (List.138, List.139, List.136):
     ret List.461;
 
 procedure List.18 (List.134, List.135, List.136):
-    let List.443 : {List U8, U64} = CallByName List.80 List.134 List.135 List.136;
+    let List.443 : {List U8, U64} = CallByName List.89 List.134 List.135 List.136;
     ret List.443;
 
 procedure List.4 (List.105, List.106):
@@ -170,7 +170,7 @@ procedure List.8 (#Attr.2, #Attr.3):
     let List.464 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
     ret List.464;
 
-procedure List.80 (List.385, List.386, List.387):
+procedure List.89 (List.385, List.386, List.387):
     let List.447 : U64 = 0i64;
     let List.448 : U64 = CallByName List.6 List.385;
     let List.446 : {List U8, U64} = CallByName List.90 List.385 List.386 List.387 List.447 List.448;


### PR DESCRIPTION
Just committing the changes made when running the tests.

I think this broke due to a race between #4307 (which introduced a change without making updates to the mono tests), and #4451 (which enabled the mono tests).