### PR TITLE
Types SoA and Type -> Variable conversion via SoA

### DIFF
--- a/crates/compiler/collections/src/soa.rs
+++ b/crates/compiler/collections/src/soa.rs
@@ -1,9 +1,22 @@
 use std::usize;
 
-#[derive(PartialEq, Eq)]
 pub struct Index<T> {
     index: u32,
     _marker: std::marker::PhantomData<T>,
+}
+
+impl<T> Eq for Index<T> {}
+
+impl<T> PartialEq for Index<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.index == other.index
+    }
+}
+
+impl<T> std::hash::Hash for Index<T> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.index.hash(state);
+    }
 }
 
 impl<T> Clone for Index<T> {

--- a/crates/compiler/solve/src/solve.rs
+++ b/crates/compiler/solve/src/solve.rs
@@ -2819,7 +2819,7 @@ fn type_to_variable<'a>(
                     let lambda_set_vars_offset = type_arguments_offset + type_arguments.len();
                     let infer_ext_vars_offset = lambda_set_vars_offset + lambda_set_variables.len();
 
-                    for (((target_index, arg_type), arg_region), opt_ability) in
+                    for (((target_index, arg_type), arg_region), abilities) in
                         (new_variables.indices().skip(type_arguments_offset))
                             .zip(type_arguments.into_iter())
                             .zip(type_argument_regions.into_iter())
@@ -2827,9 +2827,9 @@ fn type_to_variable<'a>(
                     {
                         let copy_var = helper!(arg_type);
                         subs.variables[target_index] = copy_var;
-                        if types[opt_ability].is_some() {
+                        if !types[abilities].is_empty() {
                             let arg_region = types[arg_region];
-                            bind_to_abilities.push((Loc::at(arg_region, copy_var), opt_ability));
+                            bind_to_abilities.push((Loc::at(arg_region, copy_var), abilities));
                         }
                     }
 
@@ -2917,7 +2917,7 @@ fn type_to_variable<'a>(
 
                     let new_variables = VariableSubsSlice::reserve_into_subs(subs, all_vars_length);
 
-                    for (((target_index, typ), region), opt_abilities) in
+                    for (((target_index, typ), region), abilities) in
                         (new_variables.indices().skip(type_arguments_offset))
                             .zip(type_arguments.into_iter())
                             .zip(type_argument_regions.into_iter())
@@ -2925,9 +2925,9 @@ fn type_to_variable<'a>(
                     {
                         let copy_var = helper!(typ);
                         subs.variables[target_index] = copy_var;
-                        if types[opt_abilities].is_some() {
+                        if !types[abilities].is_empty() {
                             let region = types[region];
-                            bind_to_abilities.push((Loc::at(region, copy_var), opt_abilities));
+                            bind_to_abilities.push((Loc::at(region, copy_var), abilities));
                         }
                     }
 
@@ -3063,11 +3063,7 @@ fn type_to_variable<'a>(
     }
 
     for (Loc { value: var, region }, abilities) in bind_to_abilities {
-        // TODO: SoA represent as Some<Index<AbilitySet>>, not the other way
-        let abilities = types[abilities]
-            .as_ref()
-            .expect("should only have been added if it was Some");
-
+        let abilities = &types[abilities];
         match *subs.get_content_unchecked(var) {
             Content::RigidVar(a) => {
                 // TODO(multi-abilities): check run cache

--- a/crates/compiler/solve/src/solve.rs
+++ b/crates/compiler/solve/src/solve.rs
@@ -32,10 +32,9 @@ use roc_types::subs::{
     OptVariable, Rank, RecordFields, Subs, SubsIndex, SubsSlice, UlsOfVar, UnionLabels,
     UnionLambdas, UnionTags, Variable, VariableSubsSlice,
 };
-use roc_types::types::Type::{self, *};
 use roc_types::types::{
-    gather_fields_unsorted_iter, AliasCommon, AliasKind, AliasShared, Category, OptAbleType,
-    OptAbleVar, Polarity, Reason, RecordField, TypeExtension, TypeTag, Types, Uls,
+    gather_fields_unsorted_iter, AliasKind, AliasShared, Category, OptAbleVar, Polarity, Reason,
+    RecordField, Type, TypeExtension, TypeTag, Types, Uls,
 };
 use roc_unify::unify::{
     unify, unify_introduced_ability_specialization, Env as UEnv, Mode, Obligated,
@@ -2695,7 +2694,6 @@ fn type_to_variable<'a>(
                     .zip(field_tys.into_iter())
                 {
                     let field_var = {
-                        use roc_types::types::RecordField::*;
                         let t = helper!(field_type);
                         types[field_kind].replace(t)
                     };
@@ -2829,7 +2827,7 @@ fn type_to_variable<'a>(
                     {
                         let copy_var = helper!(arg_type);
                         subs.variables[target_index] = copy_var;
-                        if let Some(abilities) = &types[opt_ability] {
+                        if types[opt_ability].is_some() {
                             let arg_region = types[arg_region];
                             bind_to_abilities.push((Loc::at(arg_region, copy_var), opt_ability));
                         }
@@ -2927,7 +2925,7 @@ fn type_to_variable<'a>(
                     {
                         let copy_var = helper!(typ);
                         subs.variables[target_index] = copy_var;
-                        if let Some(abilities) = &types[opt_abilities] {
+                        if types[opt_abilities].is_some() {
                             let region = types[region];
                             bind_to_abilities.push((Loc::at(region, copy_var), opt_abilities));
                         }
@@ -2971,10 +2969,10 @@ fn type_to_variable<'a>(
             } => {
                 let AliasShared {
                     symbol,
-                    type_argument_abilities,
+                    type_argument_abilities: _,
                     type_argument_regions: _,
                     lambda_set_variables,
-                    infer_ext_in_output_variables,
+                    infer_ext_in_output_variables: _, // TODO
                 } = types[shared];
 
                 let type_arguments = types.get_type_arguments(typ);

--- a/crates/compiler/solve/src/solve.rs
+++ b/crates/compiler/solve/src/solve.rs
@@ -2444,7 +2444,7 @@ impl RegisterVariable {
     }
 
     #[inline(always)]
-    fn with_stack<'a>(
+    fn with_stack(
         subs: &mut Subs,
         rank: Rank,
         pools: &mut Pools,
@@ -3147,7 +3147,7 @@ fn type_to_variable<'a>(
 }
 
 #[inline(always)]
-fn roc_result_to_var<'a>(
+fn roc_result_to_var(
     subs: &mut Subs,
     rank: Rank,
     pools: &mut Pools,
@@ -3329,7 +3329,7 @@ fn find_tag_name_run(slice: &[TagName], subs: &mut Subs) -> Option<SubsSlice<Tag
 }
 
 #[inline(always)]
-fn register_tag_arguments<'a>(
+fn register_tag_arguments(
     subs: &mut Subs,
     rank: Rank,
     pools: &mut Pools,
@@ -3355,7 +3355,7 @@ fn register_tag_arguments<'a>(
 }
 
 /// Assumes that the tags are sorted and there are no duplicates!
-fn insert_tags_fast_path<'a>(
+fn insert_tags_fast_path(
     subs: &mut Subs,
     rank: Rank,
     pools: &mut Pools,
@@ -3427,7 +3427,7 @@ fn insert_tags_fast_path<'a>(
     }
 }
 
-fn insert_tags_slow_path<'a>(
+fn insert_tags_slow_path(
     subs: &mut Subs,
     rank: Rank,
     pools: &mut Pools,
@@ -3458,7 +3458,7 @@ fn insert_tags_slow_path<'a>(
     UnionTags::insert_slices_into_subs(subs, tag_vars)
 }
 
-fn type_to_union_tags<'a>(
+fn type_to_union_tags(
     subs: &mut Subs,
     rank: Rank,
     pools: &mut Pools,
@@ -3514,7 +3514,7 @@ fn type_to_union_tags<'a>(
     }
 }
 
-fn create_union_lambda<'a>(
+fn create_union_lambda(
     subs: &mut Subs,
     rank: Rank,
     pools: &mut Pools,

--- a/crates/compiler/solve/src/solve.rs
+++ b/crates/compiler/solve/src/solve.rs
@@ -34,7 +34,7 @@ use roc_types::subs::{
 use roc_types::types::Type::{self, *};
 use roc_types::types::{
     gather_fields_unsorted_iter, AliasCommon, AliasKind, Category, OptAbleType, OptAbleVar,
-    Polarity, Reason, RecordField, TypeExtension, Uls,
+    Polarity, Reason, RecordField, TypeExtension, Types, Uls,
 };
 use roc_unify::unify::{
     unify, unify_introduced_ability_specialization, Env as UEnv, Mode, Obligated,
@@ -300,6 +300,7 @@ impl Aliases {
         abilities_store: &AbilitiesStore,
         obligation_cache: &mut ObligationCache,
         arena: &bumpalo::Bump,
+        types: &Types,
         symbol: Symbol,
         alias_variables: AliasVariables,
     ) -> (Variable, AliasKind) {
@@ -425,6 +426,7 @@ impl Aliases {
                 obligation_cache,
                 arena,
                 self,
+                types,
                 &typ,
                 false,
             );
@@ -450,6 +452,7 @@ impl Aliases {
                 obligation_cache,
                 arena,
                 self,
+                types,
                 &t,
                 false,
             );
@@ -2368,6 +2371,7 @@ pub(crate) fn type_to_var(
         *var
     } else {
         let mut arena = take_scratchpad();
+        let types = Types::new();
 
         let var = type_to_variable(
             subs,
@@ -2378,6 +2382,7 @@ pub(crate) fn type_to_var(
             obligation_cache,
             &arena,
             aliases,
+            &types,
             typ,
             false,
         );
@@ -2536,6 +2541,7 @@ fn type_to_variable<'a>(
     obligation_cache: &mut ObligationCache,
     arena: &'a bumpalo::Bump,
     aliases: &mut Aliases,
+    types: &Types,
     typ: &Type,
     // Helpers for instantiating ambient functions of lambda set variables from type aliases.
     is_alias_lambda_set_arg: bool,
@@ -2813,6 +2819,7 @@ fn type_to_variable<'a>(
                             obligation_cache,
                             arena,
                             aliases,
+                            types,
                             &ls.0,
                             true,
                         );
@@ -2842,6 +2849,7 @@ fn type_to_variable<'a>(
                     abilities_store,
                     obligation_cache,
                     arena,
+                    types,
                     *symbol,
                     alias_variables,
                 );
@@ -2946,6 +2954,7 @@ fn type_to_variable<'a>(
                             obligation_cache,
                             arena,
                             aliases,
+                            types,
                             &ls.0,
                             true,
                         );
@@ -2970,6 +2979,7 @@ fn type_to_variable<'a>(
                     obligation_cache,
                     arena,
                     aliases,
+                    types,
                     alias_type,
                     false,
                 );

--- a/crates/compiler/solve/src/solve.rs
+++ b/crates/compiler/solve/src/solve.rs
@@ -3040,7 +3040,6 @@ fn type_to_variable<'a>(
                     alias_variable,
                     AliasKind::Structural,
                 );
-                // let result = register(subs, rank, pools, content);
                 let result = register_with_known_var(subs, destination, rank, pools, content);
 
                 // We only want to unify the actual_var with the alias once
@@ -3054,7 +3053,11 @@ fn type_to_variable<'a>(
                 result
             }
             Erroneous => {
-                let content = Content::Error;
+                // TODO: remove `Erroneous`, `Error` can always be used, and type problems known at
+                // this point can be reported during canonicalization.
+                let problem_index =
+                    SubsIndex::push_new(&mut subs.problems, types.get_problem(&typ).clone());
+                let content = Content::Structure(FlatType::Erroneous(problem_index));
 
                 register_with_known_var(subs, destination, rank, pools, content)
             }

--- a/crates/compiler/solve/src/specialize.rs
+++ b/crates/compiler/solve/src/specialize.rs
@@ -714,10 +714,11 @@ fn get_specialization_lambda_set_ambient_function<P: Phase>(
             let opaque_home = opaque.module_id();
             let external_specialized_lset =
                 phase.with_module_abilities_store(opaque_home, |abilities_store| {
-            let impl_key = roc_can::abilities::ImplKey {
-                opaque,
-                ability_member,
-            };
+                    let impl_key = roc_can::abilities::ImplKey {
+                        opaque,
+                        ability_member,
+                    };
+
                     let opt_specialization =
                         abilities_store.get_implementation(impl_key);
                     match opt_specialization {

--- a/crates/compiler/types/src/subs.rs
+++ b/crates/compiler/types/src/subs.rs
@@ -2657,10 +2657,10 @@ impl Label for Symbol {
 
 #[derive(Clone, Debug)]
 pub struct UnionLabels<L> {
-    length: u16,
-    labels_start: u32,
-    variables_start: u32,
-    _marker: std::marker::PhantomData<L>,
+    pub(crate) length: u16,
+    pub(crate) labels_start: u32,
+    pub(crate) values_start: u32,
+    pub(crate) _marker: std::marker::PhantomData<L>,
 }
 
 impl<L> Default for UnionLabels<L> {
@@ -2668,7 +2668,7 @@ impl<L> Default for UnionLabels<L> {
         Self {
             length: Default::default(),
             labels_start: Default::default(),
-            variables_start: Default::default(),
+            values_start: Default::default(),
             _marker: Default::default(),
         }
     }
@@ -2685,7 +2685,7 @@ where
             return false;
         }
 
-        let slice = subs.variable_slices[self.variables_start as usize];
+        let slice = subs.variable_slices[self.values_start as usize];
         slice.length == 1
     }
 
@@ -2708,7 +2708,7 @@ where
         Self {
             length: labels.len() as u16,
             labels_start: labels.start,
-            variables_start: variables.start,
+            values_start: variables.start,
             _marker: Default::default(),
         }
     }
@@ -2718,7 +2718,7 @@ where
     }
 
     pub fn variables(&self) -> SubsSlice<VariableSubsSlice> {
-        SubsSlice::new(self.variables_start, self.length)
+        SubsSlice::new(self.values_start, self.length)
     }
 
     pub fn len(&self) -> usize {
@@ -2764,7 +2764,7 @@ where
         Self {
             length: 1,
             labels_start: idx.index,
-            variables_start: 0,
+            values_start: 0,
             _marker: Default::default(),
         }
     }
@@ -2792,7 +2792,7 @@ where
         Self {
             length,
             labels_start,
-            variables_start,
+            values_start: variables_start,
             _marker: Default::default(),
         }
     }
@@ -3531,7 +3531,7 @@ fn explicit_substitute_union<L: Label>(
 
     let mut union_tags = tags;
     debug_assert_eq!(length, union_tags.len());
-    union_tags.variables_start = start;
+    union_tags.values_start = start;
     union_tags
 }
 
@@ -4382,7 +4382,7 @@ impl StorageSubs {
 
     fn offset_tag_union(offsets: &StorageSubsOffsets, mut union_tags: UnionTags) -> UnionTags {
         union_tags.labels_start += offsets.tag_names;
-        union_tags.variables_start += offsets.variable_slices;
+        union_tags.values_start += offsets.variable_slices;
 
         union_tags
     }
@@ -4392,7 +4392,7 @@ impl StorageSubs {
         mut union_lambdas: UnionLambdas,
     ) -> UnionLambdas {
         union_lambdas.labels_start += offsets.symbol_names;
-        union_lambdas.variables_start += offsets.variable_slices;
+        union_lambdas.values_start += offsets.variable_slices;
 
         union_lambdas
     }

--- a/crates/compiler/types/src/types.rs
+++ b/crates/compiler/types/src/types.rs
@@ -477,6 +477,12 @@ pub struct Types {
     single_tag_union_tag_names: VecMap<Index<TypeTag>, TagName>,
 }
 
+impl Default for Types {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Types {
     pub fn new() -> Self {
         Self {
@@ -571,6 +577,7 @@ impl Types {
         self.tags_slices[index.index()] = type_slice;
     }
 
+    #[allow(clippy::wrong_self_convention)]
     fn from_old_type_slice(&mut self, old: &[Type]) -> Slice<TypeTag> {
         let slice = self.reserve_type_tags(old.len());
 
@@ -661,12 +668,14 @@ impl Types {
         }
     }
 
+    #[allow(clippy::wrong_self_convention)]
     pub fn from_old_type(&mut self, old: &Type) -> Index<TypeTag> {
         let index = self.reserve_type_tag();
         self.from_old_type_at(index, old);
         index
     }
 
+    #[allow(clippy::wrong_self_convention)]
     fn from_old_type_at(&mut self, index: Index<TypeTag>, old: &Type) {
         match old {
             Type::EmptyRec => self.set_type_tag(index, TypeTag::EmptyRecord, Slice::default()),

--- a/crates/compiler/types/src/types.rs
+++ b/crates/compiler/types/src/types.rs
@@ -862,6 +862,14 @@ impl Polarity {
     }
 }
 
+impl std::ops::Index<Index<TypeTag>> for Types {
+    type Output = TypeTag;
+
+    fn index(&self, index: Index<TypeTag>) -> &Self::Output {
+        &self.tags[index.index()]
+    }
+}
+
 #[derive(PartialEq, Eq)]
 pub enum Type {
     EmptyRec,

--- a/crates/compiler/types/src/types.rs
+++ b/crates/compiler/types/src/types.rs
@@ -362,7 +362,7 @@ impl std::ops::Neg for Polarity {
 }
 
 #[allow(dead_code)]
-struct AliasShared {
+pub struct AliasShared {
     symbol: Symbol,
     type_argument_abilities: Slice<Option<AbilitySet>>,
     type_argument_regions: Slice<Region>,
@@ -371,8 +371,7 @@ struct AliasShared {
 }
 
 #[derive(Debug, Clone)]
-#[allow(dead_code)]
-enum TypeTag {
+pub enum TypeTag {
     EmptyRecord,
     EmptyTagUnion,
     Function(Index<TypeTag>, Index<TypeTag>),
@@ -421,8 +420,7 @@ enum TypeTag {
     Record(RecordFields),
 }
 
-#[allow(dead_code)]
-struct Types {
+pub struct Types {
     // main storage. Each type is represented by a tag, which is identified by its index.
     // `tags_slices` is a parallel array (so these two vectors always have the same size), that
     // allows storing a slice of types. This is used for storing the function argument types, or
@@ -450,10 +448,24 @@ struct Types {
     single_tag_union_tag_names: VecMap<Index<TypeTag>, TagName>,
 }
 
-#[allow(dead_code)]
 impl Types {
-    const EMPTY_RECORD: Index<TypeTag> = Index::new(0);
-    const EMPTY_TAG_UNION: Index<TypeTag> = Index::new(1);
+    pub const EMPTY_RECORD: Index<TypeTag> = Index::new(0);
+    pub const EMPTY_TAG_UNION: Index<TypeTag> = Index::new(1);
+
+    pub fn new() -> Self {
+        Self {
+            tags: vec![TypeTag::EmptyRecord, TypeTag::EmptyTagUnion],
+            tags_slices: Default::default(),
+            regions: Default::default(),
+            tag_names: Default::default(),
+            field_types: Default::default(),
+            field_names: Default::default(),
+            type_arg_abilities: Default::default(),
+            aliases: Default::default(),
+            problems: Default::default(),
+            single_tag_union_tag_names: Default::default(),
+        }
+    }
 
     fn reserve_type_tags(&mut self, length: usize) -> Slice<TypeTag> {
         use std::iter::repeat;
@@ -472,14 +484,6 @@ impl Types {
         self.tags_slices.push(Slice::default());
 
         Index::push_new(&mut self.tags, TypeTag::EmptyRecord)
-    }
-
-    fn push_type_tag(&mut self, tag: TypeTag, type_slice: Slice<TypeTag>) -> Index<TypeTag> {
-        debug_assert_eq!(self.tags.len(), self.tags_slices.len());
-
-        self.tags_slices.push(type_slice);
-
-        Index::push_new(&mut self.tags, tag)
     }
 
     fn set_type_tag(&mut self, index: Index<TypeTag>, tag: TypeTag, type_slice: Slice<TypeTag>) {

--- a/crates/compiler/types/src/types.rs
+++ b/crates/compiler/types/src/types.rs
@@ -377,7 +377,7 @@ pub struct AliasShared {
 pub enum TypeTag {
     EmptyRecord,
     EmptyTagUnion,
-    /// The arugments are implicit
+    /// The arguments are implicit
     Function(
         /// lambda set
         Index<TypeTag>,

--- a/crates/compiler/types/src/types.rs
+++ b/crates/compiler/types/src/types.rs
@@ -417,6 +417,7 @@ pub enum TypeTag {
     Variable(Variable),
     RangedNumber(NumericRange),
     /// A type error, which will code gen to a runtime error
+    /// The problem is at the index of the type tag
     Erroneous,
 
     // TypeExtension is implicit in the type slice
@@ -505,6 +506,11 @@ impl Types {
         self.single_tag_union_tag_names
             .get(typ)
             .expect("typ is not a single tag union")
+    }
+
+    #[track_caller]
+    pub fn get_problem(&self, typ: &Index<TypeTag>) -> &Problem {
+        self.problems.get(typ).expect("typ is not an error")
     }
 
     pub fn record_fields_slices(


### PR DESCRIPTION
This checks in the first pass of Types SoA and introduces it to the frontend by introducing variables only through the SoA representation. Next, we'll move down the SoA representation to constraining, and then even further down, until we completely replace `Type` with the new representation.