### PR TITLE
Lift constraining expectation indices up a level

### DIFF
--- a/crates/compiler/can/src/constraint.rs
+++ b/crates/compiler/can/src/constraint.rs
@@ -676,6 +676,22 @@ impl Constraints {
 roc_error_macros::assert_sizeof_default!(Constraint, 3 * 8);
 roc_error_macros::assert_sizeof_aarch64!(Constraint, 3 * 8);
 
+impl std::ops::Index<ExpectedTypeIndex> for Constraints {
+    type Output = Expected<TypeOrVar>;
+
+    fn index(&self, index: ExpectedTypeIndex) -> &Self::Output {
+        &self.expectations[index.index()]
+    }
+}
+
+impl std::ops::Index<PExpectedTypeIndex> for Constraints {
+    type Output = PExpected<TypeOrVar>;
+
+    fn index(&self, index: PExpectedTypeIndex) -> &Self::Output {
+        &self.pattern_expectations[index.index()]
+    }
+}
+
 #[derive(Clone, Copy, Debug)]
 pub struct Eq(
     pub TypeOrVar,

--- a/crates/compiler/constrain/src/builtins.rs
+++ b/crates/compiler/constrain/src/builtins.rs
@@ -1,5 +1,5 @@
 use arrayvec::ArrayVec;
-use roc_can::constraint::{Constraint, Constraints, TypeOrVar};
+use roc_can::constraint::{Constraint, Constraints, ExpectedTypeIndex};
 use roc_can::expected::Expected::{self, *};
 use roc_can::num::{FloatBound, FloatWidth, IntBound, IntLitWidth, NumBound, SignDemand};
 use roc_module::symbol::Symbol;
@@ -71,7 +71,7 @@ pub fn int_literal(
     constraints: &mut Constraints,
     num_var: Variable,
     precision_var: Variable,
-    expected: Expected<TypeOrVar>,
+    expected: ExpectedTypeIndex,
     region: Region,
     bound: IntBound,
 ) -> Constraint {
@@ -97,10 +97,7 @@ pub fn int_literal(
 
     constrs.extend([
         constraints.equal_types(num_type_index, expect_precision_var, Category::Int, region),
-        {
-            let expected_index = constraints.push_expected_type(expected);
-            constraints.equal_types(num_type_index, expected_index, Category::Int, region)
-        },
+        constraints.equal_types(num_type_index, expected, Category::Int, region),
     ]);
 
     // TODO the precision_var is not part of the exists here; for float it is. Which is correct?
@@ -112,7 +109,7 @@ pub fn single_quote_literal(
     constraints: &mut Constraints,
     num_var: Variable,
     precision_var: Variable,
-    expected: Expected<TypeOrVar>,
+    expected: ExpectedTypeIndex,
     region: Region,
     bound: SingleQuoteBound,
 ) -> Constraint {
@@ -143,10 +140,7 @@ pub fn single_quote_literal(
             Category::Character,
             region,
         ),
-        {
-            let expected_index = constraints.push_expected_type(expected);
-            constraints.equal_types(num_type_index, expected_index, Category::Character, region)
-        },
+        constraints.equal_types(num_type_index, expected, Category::Character, region),
     ]);
 
     let and_constraint = constraints.and_constraint(constrs);
@@ -158,7 +152,7 @@ pub fn float_literal(
     constraints: &mut Constraints,
     num_var: Variable,
     precision_var: Variable,
-    expected: Expected<TypeOrVar>,
+    expected: ExpectedTypeIndex,
     region: Region,
     bound: FloatBound,
 ) -> Constraint {
@@ -183,10 +177,7 @@ pub fn float_literal(
 
     constrs.extend([
         constraints.equal_types(num_type_index, expect_precision_var, Category::Frac, region),
-        {
-            let expected_index = constraints.push_expected_type(expected);
-            constraints.equal_types(num_type_index, expected_index, Category::Frac, region)
-        },
+        constraints.equal_types(num_type_index, expected, Category::Frac, region),
     ]);
 
     let and_constraint = constraints.and_constraint(constrs);
@@ -197,7 +188,7 @@ pub fn float_literal(
 pub fn num_literal(
     constraints: &mut Constraints,
     num_var: Variable,
-    expected: Expected<TypeOrVar>,
+    expected: ExpectedTypeIndex,
     region: Region,
     bound: NumBound,
 ) -> Constraint {
@@ -213,8 +204,7 @@ pub fn num_literal(
     );
 
     let type_index = constraints.push_type(num_type);
-    let expected_index = constraints.push_expected_type(expected);
-    constrs.extend([constraints.equal_types(type_index, expected_index, Category::Num, region)]);
+    constrs.extend([constraints.equal_types(type_index, expected, Category::Num, region)]);
 
     let and_constraint = constraints.and_constraint(constrs);
     constraints.exists([num_var], and_constraint)

--- a/crates/compiler/constrain/src/expr.rs
+++ b/crates/compiler/constrain/src/expr.rs
@@ -76,7 +76,8 @@ fn constrain_untyped_args(
 
         let pattern_type = Variable(*pattern_var);
         let pattern_type_index = constraints.push_type(Variable(*pattern_var));
-        let pattern_expected = PExpected::NoExpectation(pattern_type_index);
+        let pattern_expected =
+            constraints.push_pat_expected_type(PExpected::NoExpectation(pattern_type_index));
 
         pattern_types.push(pattern_type);
 
@@ -2004,8 +2005,10 @@ fn constrain_when_branch_help(
     };
 
     for (i, loc_pattern) in when_branch.patterns.iter().enumerate() {
-        let pattern_expected =
-            pattern_expected(HumanIndex::zero_based(i), loc_pattern.pattern.region);
+        let pattern_expected = constraints.push_pat_expected_type(pattern_expected(
+            HumanIndex::zero_based(i),
+            loc_pattern.pattern.region,
+        ));
 
         let mut partial_state = PatternState::default();
         constrain_pattern(
@@ -2255,7 +2258,7 @@ pub(crate) fn constrain_def_pattern(
     loc_pattern: &Loc<Pattern>,
     expr_type: TypeOrVar,
 ) -> PatternState {
-    let pattern_expected = PExpected::NoExpectation(expr_type);
+    let pattern_expected = constraints.push_pat_expected_type(PExpected::NoExpectation(expr_type));
 
     let mut state = PatternState {
         headers: VecMap::default(),
@@ -2512,14 +2515,14 @@ fn constrain_typed_function_arguments(
         if loc_pattern.value.surely_exhaustive() {
             // OPT: we don't need to perform any type-level exhaustiveness checking.
             // Check instead only that the pattern unifies with the annotation type.
-            let pattern_expected = PExpected::ForReason(
+            let pattern_expected = constraints.push_pat_expected_type(PExpected::ForReason(
                 PReason::TypedArg {
                     index: HumanIndex::zero_based(index),
                     opt_name: opt_label,
                 },
                 ann_index,
                 loc_pattern.region,
-            );
+            ));
 
             constrain_pattern(
                 constraints,
@@ -2559,7 +2562,8 @@ fn constrain_typed_function_arguments(
             {
                 // First, solve the type that the pattern is expecting to match in this
                 // position.
-                let pattern_expected = PExpected::NoExpectation(pattern_var_index);
+                let pattern_expected =
+                    constraints.push_pat_expected_type(PExpected::NoExpectation(pattern_var_index));
                 constrain_pattern(
                     constraints,
                     env,
@@ -2639,14 +2643,14 @@ fn constrain_typed_function_arguments_simple(
         if loc_pattern.value.surely_exhaustive() {
             // OPT: we don't need to perform any type-level exhaustiveness checking.
             // Check instead only that the pattern unifies with the annotation type.
-            let pattern_expected = PExpected::ForReason(
+            let pattern_expected = constraints.push_pat_expected_type(PExpected::ForReason(
                 PReason::TypedArg {
                     index: HumanIndex::zero_based(index),
                     opt_name: Some(symbol),
                 },
                 ann_index,
                 loc_pattern.region,
-            );
+            ));
 
             constrain_pattern(
                 constraints,
@@ -2686,7 +2690,8 @@ fn constrain_typed_function_arguments_simple(
             {
                 // First, solve the type that the pattern is expecting to match in this
                 // position.
-                let pattern_expected = PExpected::NoExpectation(pattern_var_index);
+                let pattern_expected =
+                    constraints.push_pat_expected_type(PExpected::NoExpectation(pattern_var_index));
                 constrain_pattern(
                     constraints,
                     env,

--- a/crates/compiler/constrain/src/expr.rs
+++ b/crates/compiler/constrain/src/expr.rs
@@ -450,7 +450,6 @@ pub fn constrain_expr(
         &AbilityMember(symbol, specialization_id, specialization_var) => {
             // Save the expectation in the `specialization_var` so we know what to specialize, then
             // lookup the member in the environment.
-            // TODO don't rewrap expectation
             let expected_type = *constraints.expectations[expected.index()].get_type_ref();
             let store_expected =
                 constraints.store(expected_type, specialization_var, file!(), line!());

--- a/crates/compiler/constrain/src/expr.rs
+++ b/crates/compiler/constrain/src/expr.rs
@@ -451,8 +451,7 @@ pub fn constrain_expr(
             // Save the expectation in the `specialization_var` so we know what to specialize, then
             // lookup the member in the environment.
             // TODO don't rewrap expectation
-            let expected = constraints.expectations[expected.index()].clone();
-            let expected_type = *expected.get_type_ref();
+            let expected_type = *constraints.expectations[expected.index()].get_type_ref();
             let store_expected =
                 constraints.store(expected_type, specialization_var, file!(), line!());
 

--- a/crates/compiler/constrain/src/expr.rs
+++ b/crates/compiler/constrain/src/expr.rs
@@ -1445,10 +1445,7 @@ pub fn constrain_expr(
             // Instead, trivially equate the expected type to itself. This will never yield
             // unification errors but it will catch errors in type translation, including ability
             // obligations.
-            // TODO: simpl
-            let expected = constraints.expectations[expected.index()].clone();
-            let trivial_type = *expected.get_type_ref();
-            let expected = constraints.push_expected_type(expected);
+            let trivial_type = *constraints.expectations[expected.index()].get_type_ref();
             constraints.equal_types(trivial_type, expected, Category::Unknown, region)
         }
     }

--- a/crates/compiler/constrain/src/expr.rs
+++ b/crates/compiler/constrain/src/expr.rs
@@ -441,7 +441,7 @@ pub fn constrain_expr(
         }
         Var(symbol, variable) => {
             // Save the expectation in the variable, then lookup the symbol's type in the environment
-            let expected_type = *constraints.expectations[expected.index()].get_type_ref();
+            let expected_type = *constraints[expected].get_type_ref();
             let store_expected = constraints.store(expected_type, *variable, file!(), line!());
 
             let lookup_constr = constraints.lookup(*symbol, expected, region);
@@ -451,7 +451,7 @@ pub fn constrain_expr(
         &AbilityMember(symbol, specialization_id, specialization_var) => {
             // Save the expectation in the `specialization_var` so we know what to specialize, then
             // lookup the member in the environment.
-            let expected_type = *constraints.expectations[expected.index()].get_type_ref();
+            let expected_type = *constraints[expected].get_type_ref();
             let store_expected =
                 constraints.store(expected_type, specialization_var, file!(), line!());
 
@@ -636,7 +636,7 @@ pub fn constrain_expr(
 
             branch_cons.push(cond_var_is_bool_con);
 
-            let expected = constraints.expectations[expected.index()].clone();
+            let expected = constraints[expected].clone();
             match expected {
                 FromAnnotation(name, arity, ann_source, tipe) => {
                     let num_branches = branches.len() + 1;
@@ -860,7 +860,7 @@ pub fn constrain_expr(
                     when_branch,
                     expected_pattern,
                     branch_expr_reason(
-                        &constraints.expectations[expected.index()],
+                        &constraints[expected],
                         HumanIndex::zero_based(index),
                         when_branch.value.region,
                     ),
@@ -1446,7 +1446,7 @@ pub fn constrain_expr(
             // Instead, trivially equate the expected type to itself. This will never yield
             // unification errors but it will catch errors in type translation, including ability
             // obligations.
-            let trivial_type = *constraints.expectations[expected.index()].get_type_ref();
+            let trivial_type = *constraints[expected].get_type_ref();
             constraints.equal_types(trivial_type, expected, Category::Unknown, region)
         }
     }

--- a/crates/compiler/constrain/src/expr.rs
+++ b/crates/compiler/constrain/src/expr.rs
@@ -440,15 +440,10 @@ pub fn constrain_expr(
         }
         Var(symbol, variable) => {
             // Save the expectation in the variable, then lookup the symbol's type in the environment
-            // TODO don't rewrap expectation
-            let expected = constraints.expectations[expected.index()].clone();
-            let expected_type = *expected.get_type_ref();
+            let expected_type = *constraints.expectations[expected.index()].get_type_ref();
             let store_expected = constraints.store(expected_type, *variable, file!(), line!());
 
-            let stored_index = constraints.push_type(Variable(*variable));
-            let stored_type = constraints.push_expected_type(expected.replace(stored_index));
-
-            let lookup_constr = constraints.lookup(*symbol, stored_type, region);
+            let lookup_constr = constraints.lookup(*symbol, expected, region);
 
             constraints.and_constraint([store_expected, lookup_constr])
         }

--- a/crates/compiler/constrain/src/pattern.rs
+++ b/crates/compiler/constrain/src/pattern.rs
@@ -1,6 +1,6 @@
 use crate::builtins;
 use crate::expr::{constrain_expr, Env};
-use roc_can::constraint::{Constraint, Constraints, TypeOrVar};
+use roc_can::constraint::{Constraint, Constraints, PExpectedTypeIndex, TypeOrVar};
 use roc_can::expected::{Expected, PExpected};
 use roc_can::pattern::Pattern::{self, *};
 use roc_can::pattern::{DestructType, ListPatterns, RecordDestruct};
@@ -187,7 +187,7 @@ pub fn constrain_pattern(
     env: &mut Env,
     pattern: &Pattern,
     region: Region,
-    expected: PExpected<TypeOrVar>,
+    expected: PExpectedTypeIndex,
     state: &mut PatternState,
 ) {
     match pattern {
@@ -198,12 +198,11 @@ pub fn constrain_pattern(
             //     A -> ""
             //     _ -> ""
             // so, we know that "x" (in this case, a tag union) must be open.
-            if could_be_a_tag_union(constraints, *expected.get_type_ref()) {
-                let type_index = expected.get_type();
-
+            let expected_type = *constraints.pattern_expectations[expected.index()].get_type_ref();
+            if could_be_a_tag_union(constraints, expected_type) {
                 state
                     .delayed_is_open_constraints
-                    .push(constraints.is_open_type(type_index));
+                    .push(constraints.is_open_type(expected_type));
             }
         }
         UnsupportedPattern(_) | MalformedPattern(_, _) | OpaqueNotInScope(..) => {
@@ -211,6 +210,7 @@ pub fn constrain_pattern(
         }
 
         Identifier(symbol) | Shadowed(_, _, symbol) => {
+            let expected = &constraints.pattern_expectations[expected.index()];
             let type_index = *expected.get_type_ref();
 
             if could_be_a_tag_union(constraints, type_index) {
@@ -232,6 +232,7 @@ pub fn constrain_pattern(
             ident: symbol,
             specializes: _,
         } => {
+            let expected = &constraints.pattern_expectations[expected.index()];
             let type_index = *expected.get_type_ref();
 
             if could_be_a_tag_union(constraints, type_index) {
@@ -260,8 +261,6 @@ pub fn constrain_pattern(
                 Category::Num,
             );
             let num_type = constraints.push_type(num_type);
-
-            let expected = constraints.push_pat_expected_type(expected);
 
             state.constraints.push(constraints.equal_pattern_types(
                 num_type,
@@ -295,7 +294,6 @@ pub fn constrain_pattern(
             });
 
             // Also constrain the pattern against the num var, again to reuse aliases if they're present.
-            let expected = constraints.push_pat_expected_type(expected);
             state.constraints.push(constraints.equal_pattern_types(
                 num_type,
                 expected,
@@ -329,7 +327,6 @@ pub fn constrain_pattern(
             });
 
             // Also constrain the pattern against the num var, again to reuse aliases if they're present.
-            let expected = constraints.push_pat_expected_type(expected);
             state.constraints.push(constraints.equal_pattern_types(
                 num_type_index,
                 expected,
@@ -340,7 +337,6 @@ pub fn constrain_pattern(
 
         StrLiteral(_) => {
             let str_type = constraints.push_type(builtins::str_type());
-            let expected = constraints.push_pat_expected_type(expected);
             state.constraints.push(constraints.equal_pattern_types(
                 str_type,
                 expected,
@@ -379,7 +375,6 @@ pub fn constrain_pattern(
             });
 
             // Also constrain the pattern against the num var, again to reuse aliases if they're present.
-            let expected = constraints.push_pat_expected_type(expected);
             state.constraints.push(constraints.equal_pattern_types(
                 num_type_index,
                 expected,
@@ -412,7 +407,8 @@ pub fn constrain_pattern(
             {
                 let pat_type = Type::Variable(*var);
                 let pat_type_index = constraints.push_type(pat_type.clone());
-                let expected = PExpected::NoExpectation(pat_type_index);
+                let expected =
+                    constraints.push_pat_expected_type(PExpected::NoExpectation(pat_type_index));
 
                 if !state.headers.contains_key(symbol) {
                     state
@@ -510,8 +506,6 @@ pub fn constrain_pattern(
                 region,
             );
 
-            let expected = constraints.push_pat_expected_type(expected);
-
             let record_con = constraints.pattern_presence(
                 whole_var_index,
                 expected,
@@ -535,8 +529,11 @@ pub fn constrain_pattern(
             let elem_var_index = constraints.push_type(Type::Variable(*elem_var));
 
             for loc_pat in patterns.iter() {
-                let expected =
-                    PExpected::ForReason(PReason::ListElem, elem_var_index, loc_pat.region);
+                let expected = constraints.push_pat_expected_type(PExpected::ForReason(
+                    PReason::ListElem,
+                    elem_var_index,
+                    loc_pat.region,
+                ));
 
                 constrain_pattern(
                     constraints,
@@ -556,7 +553,6 @@ pub fn constrain_pattern(
             ));
             let store_solved_list = constraints.store(solved_list, *list_var, file!(), line!());
 
-            let expected = constraints.push_pat_expected_type(expected);
             let expected_constraint = constraints.pattern_presence(
                 list_var_index,
                 expected,
@@ -583,14 +579,14 @@ pub fn constrain_pattern(
 
                 let pattern_type = constraints.push_type(Type::Variable(*pattern_var));
 
-                let expected = PExpected::ForReason(
+                let expected = constraints.push_pat_expected_type(PExpected::ForReason(
                     PReason::TagArg {
                         tag_name: tag_name.clone(),
                         index: HumanIndex::zero_based(index),
                     },
                     pattern_type,
                     region,
-                );
+                ));
                 constrain_pattern(
                     constraints,
                     env,
@@ -602,7 +598,7 @@ pub fn constrain_pattern(
             }
 
             let pat_category = PatternCategory::Ctor(tag_name.clone());
-            let expected_type = *expected.get_type_ref();
+            let expected_type = *constraints.pattern_expectations[expected.index()].get_type_ref();
 
             let whole_con = constraints.includes_tag(
                 expected_type,
@@ -613,7 +609,6 @@ pub fn constrain_pattern(
             );
 
             let whole_type = constraints.push_type(Type::Variable(*whole_var));
-            let expected = constraints.push_pat_expected_type(expected);
 
             let tag_con = constraints.pattern_presence(whole_type, expected, pat_category, region);
 
@@ -652,7 +647,8 @@ pub fn constrain_pattern(
             });
 
             // First, add a constraint for the argument "who"
-            let arg_pattern_expected = PExpected::NoExpectation(arg_pattern_type_index);
+            let arg_pattern_expected = constraints
+                .push_pat_expected_type(PExpected::NoExpectation(arg_pattern_type_index));
             constrain_pattern(
                 constraints,
                 env,
@@ -700,7 +696,6 @@ pub fn constrain_pattern(
 
             // Next, link `whole_var` (the type of "@Id who") to the expected type
             let whole_type = constraints.push_type(Type::Variable(*whole_var));
-            let expected = constraints.push_pat_expected_type(expected);
             let opaque_pattern_con = constraints.pattern_presence(
                 whole_type,
                 expected,

--- a/crates/compiler/constrain/src/pattern.rs
+++ b/crates/compiler/constrain/src/pattern.rs
@@ -198,7 +198,7 @@ pub fn constrain_pattern(
             //     A -> ""
             //     _ -> ""
             // so, we know that "x" (in this case, a tag union) must be open.
-            let expected_type = *constraints.pattern_expectations[expected.index()].get_type_ref();
+            let expected_type = *constraints[expected].get_type_ref();
             if could_be_a_tag_union(constraints, expected_type) {
                 state
                     .delayed_is_open_constraints
@@ -210,7 +210,7 @@ pub fn constrain_pattern(
         }
 
         Identifier(symbol) | Shadowed(_, _, symbol) => {
-            let expected = &constraints.pattern_expectations[expected.index()];
+            let expected = &constraints[expected];
             let type_index = *expected.get_type_ref();
 
             if could_be_a_tag_union(constraints, type_index) {
@@ -232,7 +232,7 @@ pub fn constrain_pattern(
             ident: symbol,
             specializes: _,
         } => {
-            let expected = &constraints.pattern_expectations[expected.index()];
+            let expected = &constraints[expected];
             let type_index = *expected.get_type_ref();
 
             if could_be_a_tag_union(constraints, type_index) {
@@ -598,7 +598,7 @@ pub fn constrain_pattern(
             }
 
             let pat_category = PatternCategory::Ctor(tag_name.clone());
-            let expected_type = *constraints.pattern_expectations[expected.index()].get_type_ref();
+            let expected_type = *constraints[expected].get_type_ref();
 
             let whole_con = constraints.includes_tag(
                 expected_type,

--- a/crates/compiler/constrain/src/pattern.rs
+++ b/crates/compiler/constrain/src/pattern.rs
@@ -467,11 +467,11 @@ pub fn constrain_pattern(
 
                         state.vars.push(*expr_var);
 
-                        let expr_expected = Expected::ForReason(
+                        let expr_expected = constraints.push_expected_type(Expected::ForReason(
                             Reason::RecordDefaultField(label.clone()),
                             pat_type_index,
                             loc_expr.region,
-                        );
+                        ));
 
                         let expr_con = constrain_expr(
                             constraints,

--- a/crates/reporting/tests/helpers/mod.rs
+++ b/crates/reporting/tests/helpers/mod.rs
@@ -145,7 +145,7 @@ pub fn can_expr_with<'a>(
     let mut var_store = VarStore::default();
     let var = var_store.fresh();
     let var_index = constraints.push_type(Type::Variable(var));
-    let expected = Expected::NoExpectation(var_index);
+    let expected = constraints.push_expected_type(Expected::NoExpectation(var_index));
     let mut module_ids = ModuleIds::default();
 
     // ensure the Test module is accessible in our tests


### PR DESCRIPTION
Rather than creating an `Index` in the constrainer at use site, provide an `Index<Expectation>` when constraining an expression directly. Less copying.