### PR TITLE
Remove `Erroneous` type and `Problem` for type

### DIFF
--- a/crates/ast/src/builtin_aliases.rs
+++ b/crates/ast/src/builtin_aliases.rs
@@ -3,7 +3,7 @@ use roc_module::ident::{Lowercase, TagName};
 use roc_module::symbol::Symbol;
 use roc_region::all::{Loc, Region};
 use roc_types::subs::{VarId, Variable};
-use roc_types::types::{AliasKind, Problem, RecordField};
+use roc_types::types::{AliasKind, RecordField};
 use std::collections::HashMap;
 
 #[derive(Debug, Clone)]
@@ -44,7 +44,7 @@ pub enum SolvedType {
     EmptyTagUnion,
     /// A type from an Invalid module
     #[allow(unused)]
-    Erroneous(Problem),
+    Erroneous,
 
     Alias(
         Symbol,

--- a/crates/ast/src/lang/core/def/def.rs
+++ b/crates/ast/src/lang/core/def/def.rs
@@ -323,7 +323,7 @@ fn from_pending_alias<'a>(
     let symbol = name.value;
 
     match to_annotation2(env, scope, &ann.value, ann.region) {
-        Annotation2::Erroneous(_) => todo!(),
+        Annotation2::Erroneous => todo!(),
         Annotation2::Annotation {
             named_rigids,
             unnamed_rigids,
@@ -419,7 +419,7 @@ fn canonicalize_pending_def<'a>(
             // but the rigids can show up in type error messages, so still register them
 
             match to_annotation2(env, scope, &loc_ann.value, loc_ann.region) {
-                Annotation2::Erroneous(_) => todo!(),
+                Annotation2::Erroneous => todo!(),
                 Annotation2::Annotation {
                     named_rigids,
                     unnamed_rigids,
@@ -468,7 +468,7 @@ fn canonicalize_pending_def<'a>(
 
         TypedBody(loc_pattern, loc_can_pattern, loc_ann, loc_expr) => {
             match to_annotation2(env, scope, &loc_ann.value, loc_ann.region) {
-                Annotation2::Erroneous(_) => todo!(),
+                Annotation2::Erroneous => todo!(),
                 Annotation2::Annotation {
                     named_rigids,
                     unnamed_rigids,

--- a/crates/ast/src/lang/core/types.rs
+++ b/crates/ast/src/lang/core/types.rs
@@ -7,7 +7,7 @@ use roc_error_macros::todo_abilities;
 use roc_module::ident::{Ident, Lowercase, TagName, Uppercase};
 use roc_module::symbol::Symbol;
 use roc_region::all::{Loc, Region};
-use roc_types::types::{AliasKind, Problem, RecordField};
+use roc_types::types::{AliasKind, RecordField};
 use roc_types::{subs::Variable, types::ErrorType};
 
 use crate::lang::env::Env;
@@ -185,7 +185,7 @@ pub enum Annotation2 {
         symbols: MutSet<Symbol>,
         signature: Signature,
     },
-    Erroneous(roc_types::types::Problem),
+    Erroneous,
 }
 
 pub fn to_annotation2<'a>(
@@ -346,8 +346,8 @@ pub fn to_type2<'a>(
                     references.symbols.insert(symbol);
                     Type2::Alias(symbol, args, actual)
                 }
-                TypeApply::Erroneous(_problem) => {
-                    // Type2::Erroneous(problem)
+                TypeApply::Erroneous => {
+                    // Type2::Erroneous
                     todo!()
                 }
             }
@@ -721,7 +721,7 @@ fn can_tags<'a>(
 enum TypeApply {
     Apply(Symbol, PoolVec<Type2>),
     Alias(Symbol, PoolVec<TypeId>, TypeId),
-    Erroneous(roc_types::types::Problem),
+    Erroneous,
 }
 
 #[inline(always)]
@@ -744,7 +744,7 @@ fn to_type_apply<'a>(
             Err(problem) => {
                 env.problem(roc_problem::can::Problem::RuntimeError(problem));
 
-                return TypeApply::Erroneous(Problem::CanonicalizationProblem);
+                return TypeApply::Erroneous;
             }
         }
     } else {
@@ -755,7 +755,7 @@ fn to_type_apply<'a>(
                 // it was imported but it doesn't expose this ident.
                 env.problem(roc_problem::can::Problem::RuntimeError(problem));
 
-                return TypeApply::Erroneous(Problem::CanonicalizationProblem);
+                return TypeApply::Erroneous;
             }
         }
     };
@@ -775,14 +775,7 @@ fn to_type_apply<'a>(
             let mut substitutions: MutMap<Variable, TypeId> = MutMap::default();
 
             if alias.targs.len() != args.len() {
-                let error = TypeApply::Erroneous(Problem::BadTypeArguments {
-                    symbol,
-                    region,
-                    alias_needs: alias.targs.len() as u8,
-                    type_got: args.len() as u8,
-                    alias_kind: AliasKind::Structural,
-                });
-                return error;
+                return TypeApply::Erroneous;
             }
 
             let arguments = PoolVec::with_capacity(type_arguments.len() as u32, env.pool);

--- a/crates/ast/src/lang/core/types.rs
+++ b/crates/ast/src/lang/core/types.rs
@@ -744,7 +744,7 @@ fn to_type_apply<'a>(
             Err(problem) => {
                 env.problem(roc_problem::can::Problem::RuntimeError(problem));
 
-                return TypeApply::Erroneous(Problem::UnrecognizedIdent(ident.into()));
+                return TypeApply::Erroneous(Problem::CanonicalizationProblem);
             }
         }
     } else {
@@ -755,7 +755,7 @@ fn to_type_apply<'a>(
                 // it was imported but it doesn't expose this ident.
                 env.problem(roc_problem::can::Problem::RuntimeError(problem));
 
-                return TypeApply::Erroneous(Problem::UnrecognizedIdent((*ident).into()));
+                return TypeApply::Erroneous(Problem::CanonicalizationProblem);
             }
         }
     };

--- a/crates/ast/src/solve_type.rs
+++ b/crates/ast/src/solve_type.rs
@@ -82,7 +82,6 @@ pub enum TypeError {
     BadExpr(Region, Category, ErrorType, Expected<ErrorType>),
     BadPattern(Region, PatternCategory, ErrorType, PExpected<ErrorType>),
     CircularType(Region, Symbol, ErrorType),
-    BadType(roc_types::types::Problem),
     UnexposedLookup(Symbol),
 }
 
@@ -260,13 +259,6 @@ fn solve<'a>(
 
                     state
                 }
-                BadType(vars, problem) => {
-                    introduce(subs, rank, pools, &vars);
-
-                    problems.push(TypeError::BadType(problem));
-
-                    state
-                }
             }
         }
         //        Store(source, target, _filename, _linenr) => {
@@ -366,13 +358,6 @@ fn solve<'a>(
 
                             state
                         }
-                        BadType(vars, problem) => {
-                            introduce(subs, rank, pools, &vars);
-
-                            problems.push(TypeError::BadType(problem));
-
-                            state
-                        }
                     }
                 }
                 None => {
@@ -445,13 +430,6 @@ fn solve<'a>(
                     );
 
                     problems.push(problem);
-
-                    state
-                }
-                BadType(vars, problem) => {
-                    introduce(subs, rank, pools, &vars);
-
-                    problems.push(TypeError::BadType(problem));
 
                     state
                 }
@@ -766,13 +744,6 @@ fn solve<'a>(
                     );
 
                     problems.push(problem);
-
-                    state
-                }
-                BadType(vars, problem) => {
-                    introduce(subs, rank, pools, &vars);
-
-                    problems.push(TypeError::BadType(problem));
 
                     state
                 }
@@ -1215,7 +1186,7 @@ fn circular_error(
     loc_var: &Loc<Variable>,
 ) {
     let var = loc_var.value;
-    let (error_type, _) = subs.var_to_error_type(var, Polarity::Pos);
+    let error_type = subs.var_to_error_type(var, Polarity::Pos);
     let problem = TypeError::CircularType(loc_var.region, symbol, error_type);
 
     subs.set_content(var, Content::Error);

--- a/crates/ast/src/solve_type.rs
+++ b/crates/ast/src/solve_type.rs
@@ -1455,8 +1455,6 @@ fn adjust_rank_content(
 
                     rank
                 }
-
-                Erroneous(_) => group_rank,
             }
         }
 
@@ -1595,7 +1593,7 @@ fn instantiate_rigids_help(
                     }
                 }
 
-                EmptyRecord | EmptyTagUnion | Erroneous(_) => {}
+                EmptyRecord | EmptyTagUnion => {}
 
                 Record(fields, ext_var) => {
                     for index in fields.iter_variables() {
@@ -1775,7 +1773,7 @@ fn deep_copy_var_help(
                     Func(arg_vars, new_closure_var, new_ret_var)
                 }
 
-                same @ EmptyRecord | same @ EmptyTagUnion | same @ Erroneous(_) => same,
+                same @ EmptyRecord | same @ EmptyTagUnion => same,
 
                 Record(fields, ext_var) => {
                     let record_fields = {

--- a/crates/compiler/can/src/annotation.rs
+++ b/crates/compiler/can/src/annotation.rs
@@ -1064,7 +1064,7 @@ fn canonicalize_has_clause(
         let shadow = Loc::at(region, var_name_ident);
         env.problem(roc_problem::can::Problem::Shadowing {
             original_region: shadowing.first_seen(),
-            shadow: shadow.clone(),
+            shadow,
             kind: ShadowKind::Variable,
         });
         return Err(Type::Error);

--- a/crates/compiler/can/src/annotation.rs
+++ b/crates/compiler/can/src/annotation.rs
@@ -625,15 +625,13 @@ fn can_annotation_help(
                     // use a known alias
 
                     if alias.type_variables.len() != args.len() {
-                        env.problem(roc_problem::can::Problem::BadType(
-                            Problem::BadTypeArguments {
-                                symbol,
-                                region,
-                                alias_needs: alias.type_variables.len() as u8,
-                                type_got: args.len() as u8,
-                                alias_kind: alias.kind,
-                            },
-                        ));
+                        env.problem(roc_problem::can::Problem::BadTypeArguments {
+                            symbol,
+                            region,
+                            alias_needs: alias.type_variables.len() as u8,
+                            type_got: args.len() as u8,
+                            alias_kind: alias.kind,
+                        });
                         return Type::Erroneous;
                     }
 

--- a/crates/compiler/can/src/annotation.rs
+++ b/crates/compiler/can/src/annotation.rs
@@ -391,8 +391,7 @@ pub(crate) fn make_apply_symbol(
             Err(problem) => {
                 env.problem(roc_problem::can::Problem::RuntimeError(problem));
 
-                let ident: Ident = (*ident).into();
-                Err(Type::Erroneous(Problem::UnrecognizedIdent(ident)))
+                Err(Type::Erroneous)
             }
         }
     } else {
@@ -405,7 +404,7 @@ pub(crate) fn make_apply_symbol(
 
                 // A failed import should have already been reported through
                 // roc_can::env::Env::qualified_lookup's checks
-                Err(Type::Erroneous(Problem::SolvedTypeError))
+                Err(Type::Erroneous)
             }
         }
     }
@@ -626,14 +625,16 @@ fn can_annotation_help(
                     // use a known alias
 
                     if alias.type_variables.len() != args.len() {
-                        let error = Type::Erroneous(Problem::BadTypeArguments {
-                            symbol,
-                            region,
-                            alias_needs: alias.type_variables.len() as u8,
-                            type_got: args.len() as u8,
-                            alias_kind: alias.kind,
-                        });
-                        return error;
+                        env.problem(roc_problem::can::Problem::BadType(
+                            Problem::BadTypeArguments {
+                                symbol,
+                                region,
+                                alias_needs: alias.type_variables.len() as u8,
+                                type_got: args.len() as u8,
+                                alias_kind: alias.kind,
+                            },
+                        ));
+                        return Type::Erroneous;
                     }
 
                     let mut type_var_to_arg = Vec::new();
@@ -717,15 +718,13 @@ fn can_annotation_help(
                 Ok(symbol) => symbol,
 
                 Err((shadowed_symbol, shadow, _new_symbol)) => {
-                    let problem = Problem::Shadowed(shadowed_symbol.region, shadow.clone());
-
                     env.problem(roc_problem::can::Problem::Shadowing {
                         original_region: shadowed_symbol.region,
                         shadow,
                         kind: ShadowKind::Variable,
                     });
 
-                    return Type::Erroneous(problem);
+                    return Type::Erroneous;
                 }
             };
 
@@ -992,7 +991,7 @@ fn can_annotation_help(
                 region: Region::across_all(clauses.iter().map(|clause| &clause.region)),
             });
 
-            Type::Erroneous(Problem::CanonicalizationProblem)
+            Type::Erroneous
         }
         Malformed(string) => {
             malformed(env, region, string);
@@ -1044,13 +1043,13 @@ fn canonicalize_has_clause(
                 && !scope.abilities_store.is_ability(symbol)
                 {
                     env.problem(roc_problem::can::Problem::HasClauseIsNotAbility { region });
-                    return Err(Type::Erroneous(Problem::HasClauseIsNotAbility(region)));
+                    return Err(Type::Erroneous);
                 }
                 symbol
             }
             _ => {
                 env.problem(roc_problem::can::Problem::HasClauseIsNotAbility { region });
-                return Err(Type::Erroneous(Problem::HasClauseIsNotAbility(region)));
+                return Err(Type::Erroneous);
             }
         };
 
@@ -1070,10 +1069,7 @@ fn canonicalize_has_clause(
             shadow: shadow.clone(),
             kind: ShadowKind::Variable,
         });
-        return Err(Type::Erroneous(Problem::Shadowed(
-            shadowing.first_seen(),
-            shadow,
-        )));
+        return Err(Type::Erroneous);
     }
 
     let var = var_store.fresh();
@@ -1099,13 +1095,13 @@ fn can_extension_type<'a>(
         // Include erroneous types so that we don't overreport errors.
         matches!(
             typ,
-            Type::EmptyRec | Type::Record(..) | Type::Variable(..) | Type::Erroneous(..)
+            Type::EmptyRec | Type::Record(..) | Type::Variable(..) | Type::Erroneous
         )
     }
     fn valid_tag_ext_type(typ: &Type) -> bool {
         matches!(
             typ,
-            Type::EmptyTagUnion | Type::TagUnion(..) | Type::Variable(..) | Type::Erroneous(..)
+            Type::EmptyTagUnion | Type::TagUnion(..) | Type::Variable(..) | Type::Erroneous
         )
     }
 

--- a/crates/compiler/can/src/annotation.rs
+++ b/crates/compiler/can/src/annotation.rs
@@ -391,7 +391,7 @@ pub(crate) fn make_apply_symbol(
             Err(problem) => {
                 env.problem(roc_problem::can::Problem::RuntimeError(problem));
 
-                Err(Type::Erroneous)
+                Err(Type::Error)
             }
         }
     } else {
@@ -404,7 +404,7 @@ pub(crate) fn make_apply_symbol(
 
                 // A failed import should have already been reported through
                 // roc_can::env::Env::qualified_lookup's checks
-                Err(Type::Erroneous)
+                Err(Type::Error)
             }
         }
     }
@@ -632,7 +632,7 @@ fn can_annotation_help(
                             type_got: args.len() as u8,
                             alias_kind: alias.kind,
                         });
-                        return Type::Erroneous;
+                        return Type::Error;
                     }
 
                     let mut type_var_to_arg = Vec::new();
@@ -722,7 +722,7 @@ fn can_annotation_help(
                         kind: ShadowKind::Variable,
                     });
 
-                    return Type::Erroneous;
+                    return Type::Error;
                 }
             };
 
@@ -989,7 +989,7 @@ fn can_annotation_help(
                 region: Region::across_all(clauses.iter().map(|clause| &clause.region)),
             });
 
-            Type::Erroneous
+            Type::Error
         }
         Malformed(string) => {
             malformed(env, region, string);
@@ -1041,13 +1041,13 @@ fn canonicalize_has_clause(
                 && !scope.abilities_store.is_ability(symbol)
                 {
                     env.problem(roc_problem::can::Problem::HasClauseIsNotAbility { region });
-                    return Err(Type::Erroneous);
+                    return Err(Type::Error);
                 }
                 symbol
             }
             _ => {
                 env.problem(roc_problem::can::Problem::HasClauseIsNotAbility { region });
-                return Err(Type::Erroneous);
+                return Err(Type::Error);
             }
         };
 
@@ -1067,7 +1067,7 @@ fn canonicalize_has_clause(
             shadow: shadow.clone(),
             kind: ShadowKind::Variable,
         });
-        return Err(Type::Erroneous);
+        return Err(Type::Error);
     }
 
     let var = var_store.fresh();
@@ -1093,13 +1093,13 @@ fn can_extension_type<'a>(
         // Include erroneous types so that we don't overreport errors.
         matches!(
             typ,
-            Type::EmptyRec | Type::Record(..) | Type::Variable(..) | Type::Erroneous
+            Type::EmptyRec | Type::Record(..) | Type::Variable(..) | Type::Error
         )
     }
     fn valid_tag_ext_type(typ: &Type) -> bool {
         matches!(
             typ,
-            Type::EmptyTagUnion | Type::TagUnion(..) | Type::Variable(..) | Type::Erroneous
+            Type::EmptyTagUnion | Type::TagUnion(..) | Type::Variable(..) | Type::Error
         )
     }
 

--- a/crates/compiler/can/src/annotation.rs
+++ b/crates/compiler/can/src/annotation.rs
@@ -10,7 +10,7 @@ use roc_region::all::{Loc, Region};
 use roc_types::subs::{VarStore, Variable};
 use roc_types::types::{
     name_type_var, AbilitySet, Alias, AliasCommon, AliasKind, AliasVar, LambdaSet, OptAbleType,
-    OptAbleVar, Problem, RecordField, Type, TypeExtension,
+    OptAbleVar, RecordField, Type, TypeExtension,
 };
 
 #[derive(Clone, Debug)]

--- a/crates/compiler/can/src/copy.rs
+++ b/crates/compiler/can/src/copy.rs
@@ -844,7 +844,7 @@ fn deep_copy_type_vars<C: CopyEnv>(
 
             // Everything else is a mechanical descent.
             Structure(flat_type) => match flat_type {
-                EmptyRecord | EmptyTagUnion | Erroneous(_) => Structure(flat_type),
+                EmptyRecord | EmptyTagUnion => Structure(flat_type),
                 Apply(symbol, arguments) => {
                     descend_slice!(arguments);
 

--- a/crates/compiler/can/src/def.rs
+++ b/crates/compiler/can/src/def.rs
@@ -3109,7 +3109,7 @@ fn mark_cyclic_alias<'a>(
     others: Vec<Symbol>,
     report: bool,
 ) {
-    *typ = Type::Erroneous;
+    *typ = Type::Error;
 
     if report {
         let problem = Problem::CyclicAlias(symbol, region, others, alias_kind);

--- a/crates/compiler/can/src/def.rs
+++ b/crates/compiler/can/src/def.rs
@@ -2819,6 +2819,7 @@ fn correct_mutual_recursive_type_alias<'a>(
             alias_type.instantiate_aliases(
                 alias_region,
                 &can_instantiate_symbol,
+                &mut |problem| env.problems.push(Problem::BadType(problem)),
                 var_store,
                 &mut new_lambda_sets,
                 &mut new_infer_ext_vars,
@@ -3109,8 +3110,7 @@ fn mark_cyclic_alias<'a>(
     others: Vec<Symbol>,
     report: bool,
 ) {
-    let problem = roc_types::types::Problem::CyclicAlias(symbol, region, others.clone());
-    *typ = Type::Erroneous(problem);
+    *typ = Type::Erroneous;
 
     if report {
         let problem = Problem::CyclicAlias(symbol, region, others, alias_kind);

--- a/crates/compiler/can/src/def.rs
+++ b/crates/compiler/can/src/def.rs
@@ -2819,7 +2819,6 @@ fn correct_mutual_recursive_type_alias<'a>(
             alias_type.instantiate_aliases(
                 alias_region,
                 &can_instantiate_symbol,
-                &mut |problem| env.problems.push(Problem::BadType(problem)),
                 var_store,
                 &mut new_lambda_sets,
                 &mut new_infer_ext_vars,

--- a/crates/compiler/can/src/exhaustive.rs
+++ b/crates/compiler/can/src/exhaustive.rs
@@ -148,7 +148,6 @@ fn index_var(
                 FlatType::Func(_, _, _) | FlatType::FunctionOrTagUnion(_, _, _) => {
                     return Err(TypeError)
                 }
-                FlatType::Erroneous(_) => return Err(TypeError),
                 FlatType::Apply(Symbol::LIST_LIST, args) => {
                     match (subs.get_subs_slice(*args), ctor) {
                         ([elem_var], IndexCtor::List) => {

--- a/crates/compiler/derive/src/util.rs
+++ b/crates/compiler/derive/src/util.rs
@@ -91,7 +91,7 @@ impl Env<'_> {
                     internal_error!("Did not expect derivers to need to specialize unspecialized lambda sets, but we got some: {:?}", lambda_sets_to_specialize)
                 }
             }
-            Unified::Failure(..) | Unified::BadType(..) => {
+            Unified::Failure(..) => {
                 internal_error!("Unification failed in deriver - that's a deriver bug!")
             }
         }
@@ -156,7 +156,7 @@ impl Env<'_> {
                 }
                 specialization_lsets
             }
-            Unified::Failure(..) | Unified::BadType(..) => {
+            Unified::Failure(..) => {
                 internal_error!("Unification failed in deriver - that's a deriver bug!")
             }
         }

--- a/crates/compiler/derive_key/src/decoding.rs
+++ b/crates/compiler/derive_key/src/decoding.rs
@@ -72,7 +72,6 @@ impl FlatDecodable {
                     Err(Underivable) // yet
                 }
                 //
-                FlatType::Erroneous(_) => Err(Underivable),
                 FlatType::Func(..) => Err(Underivable),
             },
             Content::Alias(sym, _, real_var, _) => match sym {

--- a/crates/compiler/derive_key/src/encoding.rs
+++ b/crates/compiler/derive_key/src/encoding.rs
@@ -106,7 +106,6 @@ impl FlatEncodable {
                 FlatType::EmptyRecord => Ok(Key(FlatEncodableKey::Record(vec![]))),
                 FlatType::EmptyTagUnion => Ok(Key(FlatEncodableKey::TagUnion(vec![]))),
                 //
-                FlatType::Erroneous(_) => Err(Underivable),
                 FlatType::Func(..) => Err(Underivable),
             },
             Content::Alias(sym, _, real_var, _) => match sym {

--- a/crates/compiler/derive_key/src/hash.rs
+++ b/crates/compiler/derive_key/src/hash.rs
@@ -103,7 +103,6 @@ impl FlatHash {
                 FlatType::EmptyRecord => Ok(Key(FlatHashKey::Record(vec![]))),
                 FlatType::EmptyTagUnion => Ok(Key(FlatHashKey::TagUnion(vec![]))),
                 //
-                FlatType::Erroneous(_) => Err(Underivable),
                 FlatType::Func(..) => Err(Underivable),
             },
             Content::Alias(sym, _, real_var, _) => match sym {

--- a/crates/compiler/late_solve/src/lib.rs
+++ b/crates/compiler/late_solve/src/lib.rs
@@ -401,6 +401,6 @@ pub fn unify(
 
             Ok(extra_metadata.changed)
         }
-        Unified::Failure(..) | Unified::BadType(..) => Err(UnificationFailed),
+        Unified::Failure(..) => Err(UnificationFailed),
     }
 }

--- a/crates/compiler/mono/src/layout.rs
+++ b/crates/compiler/mono/src/layout.rs
@@ -1979,7 +1979,7 @@ fn lambda_set_size(subs: &Subs, var: Variable) -> (usize, usize, usize) {
                     }
                     stack.push((*ext, depth_any + 1, depth_lset));
                 }
-                FlatType::Erroneous(_) | FlatType::EmptyRecord | FlatType::EmptyTagUnion => {}
+                FlatType::EmptyRecord | FlatType::EmptyTagUnion => {}
             },
             Content::FlexVar(_)
             | Content::RigidVar(_)
@@ -3188,7 +3188,6 @@ fn layout_from_flat_type<'a>(
             layout_from_recursive_union(env, rec_var, &tags)
         }
         EmptyTagUnion => cacheable(Ok(Layout::VOID)),
-        Erroneous(_) => cacheable(Err(LayoutProblem::Erroneous)),
         EmptyRecord => cacheable(Ok(Layout::UNIT)),
     }
 }

--- a/crates/compiler/mono/src/layout_soa.rs
+++ b/crates/compiler/mono/src/layout_soa.rs
@@ -162,8 +162,6 @@ impl FunctionLayout {
         subs: &Subs,
         flat_type: &FlatType,
     ) -> Result<Self, LayoutError> {
-        use LayoutError::*;
-
         match flat_type {
             FlatType::Func(arguments, lambda_set, result) => {
                 let slice = Slice::reserve(layouts, arguments.len() + 1);
@@ -740,8 +738,6 @@ impl Layout {
         subs: &Subs,
         flat_type: &FlatType,
     ) -> Result<Layout, LayoutError> {
-        use LayoutError::*;
-
         match flat_type {
             FlatType::Apply(Symbol::LIST_LIST, arguments) => {
                 debug_assert_eq!(arguments.len(), 1);

--- a/crates/compiler/mono/src/layout_soa.rs
+++ b/crates/compiler/mono/src/layout_soa.rs
@@ -189,8 +189,6 @@ impl FunctionLayout {
                 })
             }
 
-            FlatType::Erroneous(_) => Err(TypeError(())),
-
             _ => todo!(),
         }
     }
@@ -867,7 +865,6 @@ impl Layout {
 
                 Ok(Layout::UnionRecursive(slices))
             }
-            FlatType::Erroneous(_) => Err(TypeError(())),
             FlatType::EmptyRecord => Ok(Layout::UNIT),
             FlatType::EmptyTagUnion => Ok(Layout::VOID),
         }

--- a/crates/compiler/problem/src/can.rs
+++ b/crates/compiler/problem/src/can.rs
@@ -188,7 +188,13 @@ pub enum Problem {
     MultipleListRestPattern {
         region: Region,
     },
-    BadType(roc_types::types::Problem),
+    BadTypeArguments {
+        symbol: Symbol,
+        region: Region,
+        alias_needs: u8,
+        type_got: u8,
+        alias_kind: AliasKind,
+    },
 }
 
 impl Problem {
@@ -318,6 +324,7 @@ impl Problem {
                 ..
             }
             | Problem::MultipleListRestPattern { region }
+            | Problem::BadTypeArguments { region, .. }
             | Problem::UnnecessaryOutputWildcard { region } => Some(*region),
             Problem::RuntimeError(RuntimeError::CircularDef(cycle_entries))
             | Problem::BadRecursion(cycle_entries) => {
@@ -331,7 +338,6 @@ impl Problem {
             | Problem::RuntimeError(RuntimeError::ExposedButNotDefined(_))
             | Problem::RuntimeError(RuntimeError::NoImplementationNamed { .. })
             | Problem::ExposedButNotDefined(_) => None,
-            Problem::BadType(..) => None,
         }
     }
 }

--- a/crates/compiler/problem/src/can.rs
+++ b/crates/compiler/problem/src/can.rs
@@ -188,6 +188,7 @@ pub enum Problem {
     MultipleListRestPattern {
         region: Region,
     },
+    BadType(roc_types::types::Problem),
 }
 
 impl Problem {
@@ -330,6 +331,7 @@ impl Problem {
             | Problem::RuntimeError(RuntimeError::ExposedButNotDefined(_))
             | Problem::RuntimeError(RuntimeError::NoImplementationNamed { .. })
             | Problem::ExposedButNotDefined(_) => None,
+            Problem::BadType(..) => None,
         }
     }
 }

--- a/crates/compiler/solve/src/ability.rs
+++ b/crates/compiler/solve/src/ability.rs
@@ -715,13 +715,6 @@ trait DerivableVisitor {
                     }
                     EmptyRecord => Self::visit_empty_record(var)?,
                     EmptyTagUnion => Self::visit_empty_tag_union(var)?,
-
-                    Erroneous(_) => {
-                        return Err(NotDerivable {
-                            var,
-                            context: NotDerivableContext::NoContext,
-                        })
-                    }
                 },
                 Alias(
                     Symbol::NUM_NUM | Symbol::NUM_INTEGER | Symbol::NUM_FLOATINGPOINT,

--- a/crates/compiler/solve/src/ability.rs
+++ b/crates/compiler/solve/src/ability.rs
@@ -191,8 +191,7 @@ impl ObligationCache {
                     // Demote the bad variable that exposed this problem to an error, both so
                     // that we have an ErrorType to report and so that codegen knows to deal
                     // with the error later.
-                    let (error_type, _moar_ghosts_n_stuff) =
-                        subs.var_to_error_type(var, Polarity::OF_VALUE);
+                    let error_type = subs.var_to_error_type(var, Polarity::OF_VALUE);
                     problems.push(TypeError::BadExprMissingAbility(
                         region,
                         category,
@@ -209,8 +208,7 @@ impl ObligationCache {
                     // Demote the bad variable that exposed this problem to an error, both so
                     // that we have an ErrorType to report and so that codegen knows to deal
                     // with the error later.
-                    let (error_type, _moar_ghosts_n_stuff) =
-                        subs.var_to_error_type(var, Polarity::OF_PATTERN);
+                    let error_type = subs.var_to_error_type(var, Polarity::OF_PATTERN);
                     problems.push(TypeError::BadPatternMissingAbility(
                         region,
                         category,
@@ -311,15 +309,14 @@ impl ObligationCache {
             })) => Some(if failure_var == var {
                 UnderivableReason::SurfaceNotDerivable(context)
             } else {
-                let (error_type, _skeletons) =
-                    subs.var_to_error_type(failure_var, Polarity::OF_VALUE);
+                let error_type = subs.var_to_error_type(failure_var, Polarity::OF_VALUE);
                 UnderivableReason::NestedNotDerivable(error_type, context)
             }),
             None => Some(UnderivableReason::NotABuiltin),
         };
 
         if let Some(underivable_reason) = opt_underivable {
-            let (error_type, _skeletons) = subs.var_to_error_type(var, Polarity::OF_VALUE);
+            let error_type = subs.var_to_error_type(var, Polarity::OF_VALUE);
 
             Err(Unfulfilled::AdhocUnderivable {
                 typ: error_type,

--- a/crates/compiler/solve/src/solve.rs
+++ b/crates/compiler/solve/src/solve.rs
@@ -2980,11 +2980,7 @@ fn type_to_variable<'a>(
                 result
             }
             Erroneous => {
-                // TODO: remove `Erroneous`, `Error` can always be used, and type problems known at
-                // this point can be reported during canonicalization.
-                let problem_index =
-                    SubsIndex::push_new(&mut subs.problems, types.get_problem(&typ).clone());
-                let content = Content::Structure(FlatType::Erroneous(problem_index));
+                let content = Content::Error;
 
                 register_with_known_var(subs, destination, rank, pools, content)
             }

--- a/crates/compiler/solve/src/solve.rs
+++ b/crates/compiler/solve/src/solve.rs
@@ -1490,13 +1490,7 @@ fn solve(
                 let branches_content = subs.get_content_without_compacting(branches_var);
                 let already_have_error = matches!(
                     (real_content, branches_content),
-                    (
-                        Content::Error | Content::Structure(FlatType::Erroneous(_)),
-                        _
-                    ) | (
-                        _,
-                        Content::Error | Content::Structure(FlatType::Erroneous(_))
-                    )
+                    (Content::Error, _) | (_, Content::Error)
                 );
 
                 let snapshot = subs.snapshot();
@@ -3826,8 +3820,6 @@ fn adjust_rank_content(
 
                     rank
                 }
-
-                Erroneous(_) => group_rank,
             }
         }
 
@@ -4076,7 +4068,7 @@ fn deep_copy_var_help(
                         Func(new_arguments, new_closure_var, new_ret_var)
                     }
 
-                    same @ EmptyRecord | same @ EmptyTagUnion | same @ Erroneous(_) => same,
+                    same @ EmptyRecord | same @ EmptyTagUnion => same,
 
                     Record(fields, ext_var) => {
                         let record_fields = {

--- a/crates/compiler/solve/src/solve.rs
+++ b/crates/compiler/solve/src/solve.rs
@@ -945,13 +945,6 @@ fn solve(
 
                         state
                     }
-                    BadType(vars, problem) => {
-                        introduce(subs, rank, pools, &vars);
-
-                        problems.push(TypeError::BadType(problem));
-
-                        state
-                    }
                 }
             }
             Store(source_index, target, _filename, _linenr) => {
@@ -1069,13 +1062,6 @@ fn solve(
 
                                 state
                             }
-                            BadType(vars, problem) => {
-                                introduce(subs, rank, pools, &vars);
-
-                                problems.push(TypeError::BadType(problem));
-
-                                state
-                            }
                         }
                     }
                     None => {
@@ -1180,13 +1166,6 @@ fn solve(
                         );
 
                         problems.push(problem);
-
-                        state
-                    }
-                    BadType(vars, problem) => {
-                        introduce(subs, rank, pools, &vars);
-
-                        problems.push(TypeError::BadType(problem));
 
                         state
                     }
@@ -1403,13 +1382,6 @@ fn solve(
 
                         state
                     }
-                    BadType(vars, problem) => {
-                        introduce(subs, rank, pools, &vars);
-
-                        problems.push(TypeError::BadType(problem));
-
-                        state
-                    }
                 }
             }
             &Exhaustive(eq, sketched_rows, context, exhaustive_mark) => {
@@ -1608,15 +1580,6 @@ fn solve(
                                 _ => internal_error!("Must be failure"),
                             }
                         }
-                    }
-                    BadType(vars, problem) => {
-                        subs.commit_snapshot(snapshot);
-
-                        introduce(subs, rank, pools, &vars);
-
-                        problems.push(TypeError::BadType(problem));
-
-                        should_check_exhaustiveness = false;
                     }
                 }
 
@@ -2098,14 +2061,6 @@ fn check_ability_specialization(
                 );
 
                 problems.push(problem);
-
-                Err(())
-            }
-            BadType(vars, problem) => {
-                subs.commit_snapshot(snapshot);
-                introduce(subs, rank, pools, &vars);
-
-                problems.push(TypeError::BadType(problem));
 
                 Err(())
             }
@@ -3045,11 +3000,6 @@ fn type_to_variable<'a>(
                         );
 
                         problems.push(problem);
-                    }
-                    BadType(_vars, problem) => {
-                        // No introduction needed
-
-                        problems.push(TypeError::BadType(problem));
                     }
                 }
             }

--- a/crates/compiler/solve/src/solve.rs
+++ b/crates/compiler/solve/src/solve.rs
@@ -2013,7 +2013,7 @@ fn check_ability_specialization(
                             // Commit so that the bad signature and its error persists in subs.
                             subs.commit_snapshot(snapshot);
 
-                            let (_typ, _problems) =
+                            let _typ =
                                 subs.var_to_error_type(symbol_loc_var.value, Polarity::OF_VALUE);
 
                             let problem = TypeError::WrongSpecialization {
@@ -2034,7 +2034,7 @@ fn check_ability_specialization(
                         // Commit so that `var` persists in subs.
                         subs.commit_snapshot(snapshot);
 
-                        let (typ, _problems) = subs.var_to_error_type(var, Polarity::OF_VALUE);
+                        let typ = subs.var_to_error_type(var, Polarity::OF_VALUE);
 
                         let problem = TypeError::StructuralSpecialization {
                             region: symbol_loc_var.region,
@@ -2056,9 +2056,9 @@ fn check_ability_specialization(
                         // so we can have two separate error types.
                         subs.rollback_to(snapshot);
 
-                        let (expected_type, _problems) =
+                        let expected_type =
                             subs.var_to_error_type(root_signature_var, Polarity::OF_VALUE);
-                        let (actual_type, _problems) =
+                        let actual_type =
                             subs.var_to_error_type(symbol_loc_var.value, Polarity::OF_VALUE);
 
                         let reason = Reason::GeneralizedAbilityMemberSpecialization {
@@ -3492,7 +3492,7 @@ fn circular_error(
     loc_var: &Loc<Variable>,
 ) {
     let var = loc_var.value;
-    let (error_type, _) = subs.var_to_error_type(var, Polarity::OF_VALUE);
+    let error_type = subs.var_to_error_type(var, Polarity::OF_VALUE);
     let problem = TypeError::CircularType(loc_var.region, symbol, error_type);
 
     subs.set_content(var, Content::Error);

--- a/crates/compiler/solve/src/solve.rs
+++ b/crates/compiler/solve/src/solve.rs
@@ -29,8 +29,8 @@ use roc_region::all::Loc;
 use roc_solve_problem::TypeError;
 use roc_types::subs::{
     self, AliasVariables, Content, Descriptor, FlatType, GetSubsSlice, LambdaSet, Mark,
-    OptVariable, Rank, RecordFields, Subs, SubsIndex, SubsSlice, UlsOfVar, UnionLabels,
-    UnionLambdas, UnionTags, Variable, VariableSubsSlice,
+    OptVariable, Rank, RecordFields, Subs, SubsSlice, UlsOfVar, UnionLabels, UnionLambdas,
+    UnionTags, Variable, VariableSubsSlice,
 };
 use roc_types::types::{
     gather_fields_unsorted_iter, AliasKind, AliasShared, Category, OptAbleVar, Polarity, Reason,
@@ -2928,7 +2928,7 @@ fn type_to_variable<'a>(
 
                 result
             }
-            Erroneous => {
+            Error => {
                 let content = Content::Error;
 
                 register_with_known_var(subs, destination, rank, pools, content)

--- a/crates/compiler/solve_problem/src/lib.rs
+++ b/crates/compiler/solve_problem/src/lib.rs
@@ -12,7 +12,6 @@ pub enum TypeError {
     BadPattern(Region, PatternCategory, ErrorType, PExpected<ErrorType>),
     CircularType(Region, Symbol, ErrorType),
     CircularDef(Vec<CycleEntry>),
-    BadType(roc_types::types::Problem),
     UnexposedLookup(Symbol),
     UnfulfilledAbility(Unfulfilled),
     BadExprMissingAbility(Region, Category, ErrorType, Vec<Unfulfilled>),

--- a/crates/compiler/types/src/pretty_print.rs
+++ b/crates/compiler/types/src/pretty_print.rs
@@ -408,7 +408,7 @@ fn find_names_needed(
                 find_under_alias,
             );
         }
-        Error | Structure(Erroneous(_)) | Structure(EmptyRecord) | Structure(EmptyTagUnion) => {
+        Error | Structure(EmptyRecord) | Structure(EmptyTagUnion) => {
             // Errors and empty records don't need names.
         }
     }
@@ -1284,7 +1284,6 @@ fn write_flat_type<'a>(
                 )
             })
         }
-        Erroneous(problem) => write!(buf, "<Type Mismatch: {:?}>", problem).unwrap(),
     }
 }
 

--- a/crates/compiler/types/src/pretty_print.rs
+++ b/crates/compiler/types/src/pretty_print.rs
@@ -10,7 +10,6 @@ use crate::types::{
 use roc_collections::all::MutMap;
 use roc_module::ident::{Lowercase, TagName};
 use roc_module::symbol::{Interns, ModuleId, Symbol};
-use std::fmt::Write;
 
 pub static WILDCARD: &str = "*";
 static EMPTY_RECORD: &str = "{}";

--- a/crates/compiler/types/src/subs.rs
+++ b/crates/compiler/types/src/subs.rs
@@ -84,10 +84,6 @@ struct SubsHeader {
 
 impl SubsHeader {
     fn from_subs(subs: &Subs, exposed_vars_by_symbol: usize) -> Self {
-        // TODO what do we do with problems? they should
-        // be reported and then removed from Subs I think
-        debug_assert!(subs.problems.is_empty(), "{:?}", &subs.problems);
-
         Self {
             utable: subs.utable.len() as u64,
             variables: subs.variables.len() as u64,
@@ -252,7 +248,6 @@ impl Subs {
                     variable_slices: variable_slices.to_vec(),
                     unspecialized_lambda_sets: unspecialized_lambda_sets.to_vec(),
                     tag_name_cache: Default::default(),
-                    problems: Default::default(),
                     uls_of_var,
                 },
                 exposed_vars_by_symbol,
@@ -385,7 +380,6 @@ pub struct Subs {
     pub variable_slices: Vec<VariableSubsSlice>,
     pub unspecialized_lambda_sets: Vec<Uls>,
     pub tag_name_cache: TagNameCache,
-    pub problems: Vec<Problem>,
     pub uls_of_var: UlsOfVar,
 }
 
@@ -1723,7 +1717,6 @@ impl Subs {
             variable_slices: vec![VariableSubsSlice::default()],
             unspecialized_lambda_sets: Vec::new(),
             tag_name_cache: Default::default(),
-            problems: Vec::new(),
             uls_of_var: Default::default(),
         };
 
@@ -4118,7 +4111,6 @@ struct StorageSubsOffsets {
     record_fields: u32,
     variable_slices: u32,
     unspecialized_lambda_sets: u32,
-    problems: u32,
 }
 
 #[derive(Clone, Debug)]
@@ -4202,7 +4194,6 @@ impl StorageSubs {
             record_fields: self.subs.record_fields.len() as u32,
             variable_slices: self.subs.variable_slices.len() as u32,
             unspecialized_lambda_sets: self.subs.unspecialized_lambda_sets.len() as u32,
-            problems: self.subs.problems.len() as u32,
         };
 
         let offsets = StorageSubsOffsets {
@@ -4214,7 +4205,6 @@ impl StorageSubs {
             record_fields: target.record_fields.len() as u32,
             variable_slices: target.variable_slices.len() as u32,
             unspecialized_lambda_sets: target.unspecialized_lambda_sets.len() as u32,
-            problems: target.problems.len() as u32,
         };
 
         // The first Variable::NUM_RESERVED_VARS are the same in every subs,
@@ -4263,7 +4253,6 @@ impl StorageSubs {
         target
             .unspecialized_lambda_sets
             .extend(self.subs.unspecialized_lambda_sets);
-        target.problems.extend(self.subs.problems);
 
         debug_assert_eq!(
             target.utable.len(),
@@ -4425,15 +4414,6 @@ impl StorageSubs {
         slice.start += offsets.unspecialized_lambda_sets;
 
         slice
-    }
-
-    fn offset_problem(
-        offsets: &StorageSubsOffsets,
-        mut problem_index: SubsIndex<Problem>,
-    ) -> SubsIndex<Problem> {
-        problem_index.index += offsets.problems;
-
-        problem_index
     }
 }
 

--- a/crates/compiler/types/src/subs.rs
+++ b/crates/compiler/types/src/subs.rs
@@ -62,7 +62,6 @@ pub enum ErrorTypeContext {
 struct ErrorTypeState {
     taken: MutSet<Lowercase>,
     letters_used: u32,
-    problems: Vec<crate::types::Problem>,
     context: ErrorTypeContext,
     recursive_tag_unions_seen: Vec<Variable>,
 }
@@ -2066,15 +2065,11 @@ impl Subs {
         let mut state = ErrorTypeState {
             taken,
             letters_used: 0,
-            problems: Vec::new(),
             context,
             recursive_tag_unions_seen: Vec::new(),
         };
 
-        (
-            var_to_err_type(self, &mut state, var, observed_pol),
-            state.problems,
-        )
+        (var_to_err_type(self, &mut state, var, observed_pol), vec![])
     }
 
     pub fn len(&self) -> usize {

--- a/crates/compiler/types/src/subs.rs
+++ b/crates/compiler/types/src/subs.rs
@@ -2041,11 +2041,7 @@ impl Subs {
         explicit_substitute(self, x, y, z, &mut seen)
     }
 
-    pub fn var_to_error_type(
-        &mut self,
-        var: Variable,
-        observed_pol: Polarity,
-    ) -> (ErrorType, Vec<Problem>) {
+    pub fn var_to_error_type(&mut self, var: Variable, observed_pol: Polarity) -> ErrorType {
         self.var_to_error_type_contextual(var, ErrorTypeContext::None, observed_pol)
     }
 
@@ -2054,7 +2050,7 @@ impl Subs {
         var: Variable,
         context: ErrorTypeContext,
         observed_pol: Polarity,
-    ) -> (ErrorType, Vec<Problem>) {
+    ) -> ErrorType {
         let names = get_var_names(self, var, ImMap::default());
         let mut taken = MutSet::default();
 
@@ -2069,7 +2065,7 @@ impl Subs {
             recursive_tag_unions_seen: Vec::new(),
         };
 
-        (var_to_err_type(self, &mut state, var, observed_pol), vec![])
+        var_to_err_type(self, &mut state, var, observed_pol)
     }
 
     pub fn len(&self) -> usize {

--- a/crates/compiler/types/src/subs.rs
+++ b/crates/compiler/types/src/subs.rs
@@ -21,7 +21,7 @@ roc_error_macros::assert_sizeof_all!(FlatType, 3 * 8);
 roc_error_macros::assert_sizeof_all!(UnionTags, 12);
 roc_error_macros::assert_sizeof_all!(RecordFields, 2 * 8);
 
-roc_error_macros::assert_sizeof_aarch64!(Problem, 6 * 8);
+roc_error_macros::assert_sizeof_aarch64!(Problem, 5 * 8);
 roc_error_macros::assert_sizeof_wasm!(Problem, 32);
 roc_error_macros::assert_sizeof_default!(Problem, 6 * 8);
 
@@ -4040,12 +4040,7 @@ fn flat_type_to_err_type(
             }
         }
 
-        Erroneous(problem_index) => {
-            let problem = subs.problems[problem_index.index as usize].clone();
-            state.problems.push(problem);
-
-            ErrorType::Error
-        }
+        Erroneous(_) => ErrorType::Error,
     }
 }
 

--- a/crates/compiler/types/src/subs.rs
+++ b/crates/compiler/types/src/subs.rs
@@ -1,7 +1,7 @@
 #![deny(unsafe_op_in_unsafe_fn)]
 use crate::types::{
-    name_type_var, AbilitySet, AliasKind, ErrorType, Polarity, Problem, RecordField,
-    RecordFieldsError, TypeExt, Uls,
+    name_type_var, AbilitySet, AliasKind, ErrorType, Polarity, RecordField, RecordFieldsError,
+    TypeExt, Uls,
 };
 use roc_collections::all::{FnvMap, ImMap, ImSet, MutSet, SendMap};
 use roc_collections::{VecMap, VecSet};
@@ -20,10 +20,6 @@ roc_error_macros::assert_sizeof_all!(Descriptor, 5 * 8 + 4);
 roc_error_macros::assert_sizeof_all!(FlatType, 3 * 8);
 roc_error_macros::assert_sizeof_all!(UnionTags, 12);
 roc_error_macros::assert_sizeof_all!(RecordFields, 2 * 8);
-
-roc_error_macros::assert_sizeof_aarch64!(Problem, 5 * 8);
-roc_error_macros::assert_sizeof_wasm!(Problem, 32);
-roc_error_macros::assert_sizeof_default!(Problem, 6 * 8);
 
 #[derive(Clone, Copy, Hash, PartialEq, Eq)]
 pub struct Mark(i32);

--- a/crates/compiler/types/src/types.rs
+++ b/crates/compiler/types/src/types.rs
@@ -173,7 +173,6 @@ impl RecordField<Type> {
         &mut self,
         region: Region,
         aliases: &'a F,
-        push_problem: &mut impl FnMut(Problem),
         var_store: &mut VarStore,
         new_lambda_sets: &mut ImSet<Variable>,
         new_infer_ext_vars: &mut ImSet<Variable>,
@@ -183,7 +182,6 @@ impl RecordField<Type> {
         self.as_inner_mut().instantiate_aliases(
             region,
             aliases,
-            push_problem,
             var_store,
             new_lambda_sets,
             new_infer_ext_vars,
@@ -230,7 +228,6 @@ impl LambdaSet {
         &mut self,
         region: Region,
         aliases: &'a F,
-        push_problem: &mut impl FnMut(Problem),
         var_store: &mut VarStore,
         new_lambda_sets: &mut ImSet<Variable>,
         new_infer_ext_vars: &mut ImSet<Variable>,
@@ -240,7 +237,6 @@ impl LambdaSet {
         self.0.instantiate_aliases(
             region,
             aliases,
-            push_problem,
             var_store,
             new_lambda_sets,
             new_infer_ext_vars,
@@ -2293,7 +2289,6 @@ impl Type {
         &mut self,
         region: Region,
         aliases: &'a F,
-        push_problem: &mut impl FnMut(Problem),
         var_store: &mut VarStore,
         new_lambda_set_variables: &mut ImSet<Variable>,
         new_infer_ext_vars: &mut ImSet<Variable>,
@@ -2308,7 +2303,6 @@ impl Type {
                     arg.instantiate_aliases(
                         region,
                         aliases,
-                        push_problem,
                         var_store,
                         new_lambda_set_variables,
                         new_infer_ext_vars,
@@ -2317,7 +2311,6 @@ impl Type {
                 closure.instantiate_aliases(
                     region,
                     aliases,
-                    push_problem,
                     var_store,
                     new_lambda_set_variables,
                     new_infer_ext_vars,
@@ -2325,7 +2318,6 @@ impl Type {
                 ret.instantiate_aliases(
                     region,
                     aliases,
-                    push_problem,
                     var_store,
                     new_lambda_set_variables,
                     new_infer_ext_vars,
@@ -2336,7 +2328,6 @@ impl Type {
                     ext.instantiate_aliases(
                         region,
                         aliases,
-                        push_problem,
                         var_store,
                         new_lambda_set_variables,
                         new_infer_ext_vars,
@@ -2349,7 +2340,6 @@ impl Type {
                         x.instantiate_aliases(
                             region,
                             aliases,
-                            push_problem,
                             var_store,
                             new_lambda_set_variables,
                             new_infer_ext_vars,
@@ -2361,7 +2351,6 @@ impl Type {
                     ext.instantiate_aliases(
                         region,
                         aliases,
-                        push_problem,
                         var_store,
                         new_lambda_set_variables,
                         new_infer_ext_vars,
@@ -2373,7 +2362,6 @@ impl Type {
                     x.instantiate_aliases(
                         region,
                         aliases,
-                        push_problem,
                         var_store,
                         new_lambda_set_variables,
                         new_infer_ext_vars,
@@ -2384,7 +2372,6 @@ impl Type {
                     ext.instantiate_aliases(
                         region,
                         aliases,
-                        push_problem,
                         var_store,
                         new_lambda_set_variables,
                         new_infer_ext_vars,
@@ -2407,7 +2394,6 @@ impl Type {
                     t.value.typ.instantiate_aliases(
                         region,
                         aliases,
-                        push_problem,
                         var_store,
                         new_lambda_set_variables,
                         new_infer_ext_vars,
@@ -2424,7 +2410,6 @@ impl Type {
                     arg.instantiate_aliases(
                         region,
                         aliases,
-                        push_problem,
                         var_store,
                         new_lambda_set_variables,
                         new_infer_ext_vars,
@@ -2435,7 +2420,6 @@ impl Type {
                     arg.instantiate_aliases(
                         region,
                         aliases,
-                        push_problem,
                         var_store,
                         new_lambda_set_variables,
                         new_infer_ext_vars,
@@ -2445,7 +2429,6 @@ impl Type {
                 actual_type.instantiate_aliases(
                     region,
                     aliases,
-                    push_problem,
                     var_store,
                     new_lambda_set_variables,
                     new_infer_ext_vars,
@@ -2461,7 +2444,6 @@ impl Type {
                     arg.typ.instantiate_aliases(
                         region,
                         aliases,
-                        push_problem,
                         var_store,
                         new_lambda_set_variables,
                         new_infer_ext_vars,
@@ -2472,7 +2454,6 @@ impl Type {
                     arg.instantiate_aliases(
                         region,
                         aliases,
-                        push_problem,
                         var_store,
                         new_lambda_set_variables,
                         new_infer_ext_vars,
@@ -2482,7 +2463,6 @@ impl Type {
                 actual_type.instantiate_aliases(
                     region,
                     aliases,
-                    push_problem,
                     var_store,
                     new_lambda_set_variables,
                     new_infer_ext_vars,
@@ -2536,13 +2516,6 @@ impl Type {
                         *self = alias;
                     } else {
                         if args.len() != alias.type_variables.len() {
-                            push_problem(Problem::BadTypeArguments {
-                                symbol: *symbol,
-                                region,
-                                type_got: args.len() as u8,
-                                alias_needs: alias.type_variables.len() as u8,
-                                alias_kind: AliasKind::Structural,
-                            });
                             *self = Type::Erroneous;
                             return;
                         }
@@ -2570,7 +2543,6 @@ impl Type {
                             filler.value.instantiate_aliases(
                                 region,
                                 aliases,
-                                push_problem,
                                 var_store,
                                 new_lambda_set_variables,
                                 new_infer_ext_vars,
@@ -2607,7 +2579,6 @@ impl Type {
                         actual.instantiate_aliases(
                             region,
                             aliases,
-                            push_problem,
                             var_store,
                             new_lambda_set_variables,
                             new_infer_ext_vars,
@@ -2648,7 +2619,6 @@ impl Type {
                         x.value.instantiate_aliases(
                             region,
                             aliases,
-                            push_problem,
                             var_store,
                             new_lambda_set_variables,
                             new_infer_ext_vars,

--- a/crates/compiler/types/src/types.rs
+++ b/crates/compiler/types/src/types.rs
@@ -2516,6 +2516,7 @@ impl Type {
                         *self = alias;
                     } else {
                         if args.len() != alias.type_variables.len() {
+                            // We will have already reported an error during canonicalization.
                             *self = Type::Erroneous;
                             return;
                         }

--- a/crates/compiler/types/src/types.rs
+++ b/crates/compiler/types/src/types.rs
@@ -8,7 +8,7 @@ use roc_collections::soa::{Index, Slice};
 use roc_collections::VecMap;
 use roc_error_macros::internal_error;
 use roc_module::called_via::CalledVia;
-use roc_module::ident::{ForeignSymbol, Ident, Lowercase, TagName};
+use roc_module::ident::{ForeignSymbol, Lowercase, TagName};
 use roc_module::low_level::LowLevel;
 use roc_module::symbol::{Interns, Symbol};
 use roc_region::all::{Loc, Region};

--- a/crates/compiler/types/src/types.rs
+++ b/crates/compiler/types/src/types.rs
@@ -3301,22 +3301,6 @@ impl Alias {
     }
 }
 
-#[derive(PartialEq, Eq, Debug, Clone, Hash)]
-pub enum Problem {
-    CanonicalizationProblem,
-    CircularType(Symbol, Box<ErrorType>, Region),
-    Shadowed(Region, Loc<Ident>),
-    BadTypeArguments {
-        symbol: Symbol,
-        region: Region,
-        type_got: u8,
-        alias_needs: u8,
-        alias_kind: AliasKind,
-    },
-    InvalidModule,
-    HasClauseIsNotAbility(Region),
-}
-
 #[derive(PartialEq, Eq, Debug, Clone)]
 pub enum Mismatch {
     TypeMismatch,

--- a/crates/compiler/types/src/types.rs
+++ b/crates/compiler/types/src/types.rs
@@ -1332,7 +1332,7 @@ pub enum Type {
     Variable(Variable),
     RangedNumber(NumericRange),
     /// A type error, which will code gen to a runtime error
-    Erroneous,
+    Error,
 }
 
 /// A lambda set under an arrow in a ability member signature. For example, in
@@ -1428,7 +1428,7 @@ impl Clone for Type {
             Self::Apply(arg0, arg1, arg2) => Self::Apply(*arg0, arg1.clone(), *arg2),
             Self::Variable(arg0) => Self::Variable(*arg0),
             Self::RangedNumber(arg1) => Self::RangedNumber(*arg1),
-            Self::Erroneous => Self::Erroneous,
+            Self::Error => Self::Error,
         }
     }
 }
@@ -1544,7 +1544,7 @@ impl fmt::Debug for Type {
 
                 write!(f, ")")
             }
-            Type::Erroneous => write!(f, "Erroneous"),
+            Type::Error => write!(f, "Erroneous"),
             Type::DelayedAlias(AliasCommon {
                 symbol,
                 type_arguments,
@@ -1904,7 +1904,7 @@ impl Type {
                     );
                 }
 
-                EmptyRec | EmptyTagUnion | Erroneous => {}
+                EmptyRec | EmptyTagUnion | Error => {}
             }
         }
     }
@@ -2034,7 +2034,7 @@ impl Type {
                     );
                 }
 
-                EmptyRec | EmptyTagUnion | Erroneous => {}
+                EmptyRec | EmptyTagUnion | Error => {}
             }
         }
     }
@@ -2137,7 +2137,7 @@ impl Type {
             }
             RangedNumber(_) => Ok(()),
             UnspecializedLambdaSet { .. } => Ok(()),
-            EmptyRec | EmptyTagUnion | ClosureTag { .. } | Erroneous | Variable(_) => Ok(()),
+            EmptyRec | EmptyTagUnion | ClosureTag { .. } | Error | Variable(_) => Ok(()),
         }
     }
 
@@ -2199,7 +2199,7 @@ impl Type {
             UnspecializedLambdaSet {
                 unspecialized: Uls(_, sym, _),
             } => *sym == rep_symbol,
-            EmptyRec | EmptyTagUnion | ClosureTag { .. } | Erroneous | Variable(_) => false,
+            EmptyRec | EmptyTagUnion | ClosureTag { .. } | Error | Variable(_) => false,
         }
     }
 
@@ -2255,7 +2255,7 @@ impl Type {
                 .iter()
                 .any(|arg| arg.value.contains_variable(rep_variable)),
             RangedNumber(_) => false,
-            EmptyRec | EmptyTagUnion | Erroneous => false,
+            EmptyRec | EmptyTagUnion | Error => false,
         }
     }
 
@@ -2517,7 +2517,7 @@ impl Type {
                     } else {
                         if args.len() != alias.type_variables.len() {
                             // We will have already reported an error during canonicalization.
-                            *self = Type::Erroneous;
+                            *self = Type::Error;
                             return;
                         }
 
@@ -2629,7 +2629,7 @@ impl Type {
             }
             RangedNumber(_) => {}
             UnspecializedLambdaSet { .. } => {}
-            EmptyRec | EmptyTagUnion | ClosureTag { .. } | Erroneous | Variable(_) => {}
+            EmptyRec | EmptyTagUnion | ClosureTag { .. } | Error | Variable(_) => {}
         }
     }
 
@@ -2765,7 +2765,7 @@ fn symbols_help(initial: &Type) -> Vec<Symbol> {
             } => {
                 // ignore the member symbol because unspecialized lambda sets are internal-only
             }
-            EmptyRec | EmptyTagUnion | ClosureTag { .. } | Erroneous | Variable(_) => {}
+            EmptyRec | EmptyTagUnion | ClosureTag { .. } | Error | Variable(_) => {}
         }
     }
 
@@ -2779,7 +2779,7 @@ fn variables_help(tipe: &Type, accum: &mut ImSet<Variable>) {
     use Type::*;
 
     match tipe {
-        EmptyRec | EmptyTagUnion | Erroneous => (),
+        EmptyRec | EmptyTagUnion | Error => (),
 
         Variable(v) => {
             accum.insert(*v);
@@ -2909,7 +2909,7 @@ fn variables_help_detailed(tipe: &Type, accum: &mut VariableDetail) {
     use Type::*;
 
     match tipe {
-        EmptyRec | EmptyTagUnion | Erroneous => (),
+        EmptyRec | EmptyTagUnion | Error => (),
 
         Variable(v) => {
             accum.type_variables.insert(*v);
@@ -4118,7 +4118,7 @@ fn instantiate_lambda_sets_as_unspecialized(
             }
             Type::Variable(_) => {}
             Type::RangedNumber(_) => {}
-            Type::Erroneous => {}
+            Type::Error => {}
         }
     }
 }

--- a/crates/compiler/unify/src/unify.rs
+++ b/crates/compiler/unify/src/unify.rs
@@ -419,35 +419,29 @@ fn unify_help<M: MetaCollector>(
             ErrorTypeContext::None
         };
 
-        let (type1, mut problems) =
-            env.subs
-                .var_to_error_type_contextual(var1, error_context, observed_pol);
-        let (type2, problems2) =
-            env.subs
-                .var_to_error_type_contextual(var2, error_context, observed_pol);
-
-        problems.extend(problems2);
+        let type1 = env
+            .subs
+            .var_to_error_type_contextual(var1, error_context, observed_pol);
+        let type2 = env
+            .subs
+            .var_to_error_type_contextual(var2, error_context, observed_pol);
 
         env.subs.union(var1, var2, Content::Error.into());
 
-        if !problems.is_empty() {
-            Unified::BadType(vars, problems.remove(0))
-        } else {
-            let do_not_implement_ability = mismatches
-                .into_iter()
-                .filter_map(|mismatch| match mismatch {
-                    Mismatch::DoesNotImplementAbiity(var, ab) => {
-                        let (err_type, _new_problems) =
-                            env.subs
-                                .var_to_error_type_contextual(var, error_context, observed_pol);
-                        Some((err_type, ab))
-                    }
-                    _ => None,
-                })
-                .collect();
+        let do_not_implement_ability = mismatches
+            .into_iter()
+            .filter_map(|mismatch| match mismatch {
+                Mismatch::DoesNotImplementAbiity(var, ab) => {
+                    let err_type =
+                        env.subs
+                            .var_to_error_type_contextual(var, error_context, observed_pol);
+                    Some((err_type, ab))
+                }
+                _ => None,
+            })
+            .collect();
 
-            Unified::Failure(vars, type1, type2, do_not_implement_ability)
-        }
+        Unified::Failure(vars, type1, type2, do_not_implement_ability)
     }
 }
 

--- a/crates/compiler/unify/src/unify.rs
+++ b/crates/compiler/unify/src/unify.rs
@@ -225,7 +225,6 @@ pub enum Unified<M: MetaCollector = NoCollector> {
         extra_metadata: M,
     },
     Failure(Pool, ErrorType, ErrorType, DoesNotImplementAbility),
-    BadType(Pool, roc_types::types::Problem),
 }
 
 impl<M: MetaCollector> Unified<M> {

--- a/crates/glue/src/types.rs
+++ b/crates/glue/src/types.rs
@@ -866,7 +866,6 @@ fn add_type_help<'a>(
         Content::Structure(FlatType::FunctionOrTagUnion(_, _, _)) => {
             todo!()
         }
-        Content::Structure(FlatType::Erroneous(_)) => todo!(),
         Content::Structure(FlatType::EmptyRecord) => {
             types.add_anonymous(&env.layout_cache.interner, RocType::Unit, layout)
         }

--- a/crates/reporting/src/error/canonicalize.rs
+++ b/crates/reporting/src/error/canonicalize.rs
@@ -1037,53 +1037,46 @@ pub fn can_problem<'b>(
             title = "MULTIPLE LIST REST PATTERNS".to_string();
             severity = Severity::RuntimeError;
         }
-        Problem::BadType(type_problem) => {
-            use roc_types::types::Problem::*;
-            match type_problem {
-                BadTypeArguments {
-                    symbol,
-                    region,
-                    type_got,
-                    alias_needs,
-                    alias_kind,
-                } => {
-                    let needed_arguments = if alias_needs == 1 {
-                        alloc.reflow("1 type argument")
-                    } else {
-                        alloc
-                            .text(alias_needs.to_string())
-                            .append(alloc.reflow(" type arguments"))
-                    };
+        Problem::BadTypeArguments {
+            symbol,
+            region,
+            type_got,
+            alias_needs,
+            alias_kind,
+        } => {
+            let needed_arguments = if alias_needs == 1 {
+                alloc.reflow("1 type argument")
+            } else {
+                alloc
+                    .text(alias_needs.to_string())
+                    .append(alloc.reflow(" type arguments"))
+            };
 
-                    let found_arguments = alloc.text(type_got.to_string());
+            let found_arguments = alloc.text(type_got.to_string());
 
-                    doc = alloc.stack([
-                        alloc.concat([
-                            alloc.reflow("The "),
-                            alloc.symbol_unqualified(symbol),
-                            alloc.reflow(" "),
-                            alloc.reflow(alias_kind.as_str()),
-                            alloc.reflow(" expects "),
-                            needed_arguments,
-                            alloc.reflow(", but it got "),
-                            found_arguments,
-                            alloc.reflow(" instead:"),
-                        ]),
-                        alloc.region(lines.convert_region(region)),
-                        alloc.reflow("Are there missing parentheses?"),
-                    ]);
+            doc = alloc.stack([
+                alloc.concat([
+                    alloc.reflow("The "),
+                    alloc.symbol_unqualified(symbol),
+                    alloc.reflow(" "),
+                    alloc.reflow(alias_kind.as_str()),
+                    alloc.reflow(" expects "),
+                    needed_arguments,
+                    alloc.reflow(", but it got "),
+                    found_arguments,
+                    alloc.reflow(" instead:"),
+                ]),
+                alloc.region(lines.convert_region(region)),
+                alloc.reflow("Are there missing parentheses?"),
+            ]);
 
-                    title = if type_got > alias_needs {
-                        "TOO MANY TYPE ARGUMENTS".to_string()
-                    } else {
-                        "TOO FEW TYPE ARGUMENTS".to_string()
-                    };
+            title = if type_got > alias_needs {
+                "TOO MANY TYPE ARGUMENTS".to_string()
+            } else {
+                "TOO FEW TYPE ARGUMENTS".to_string()
+            };
 
-                    severity = Severity::RuntimeError;
-                }
-
-                other => panic!("unhandled bad type: {:?}", other),
-            }
+            severity = Severity::RuntimeError;
         }
     };
 

--- a/crates/reporting/src/error/canonicalize.rs
+++ b/crates/reporting/src/error/canonicalize.rs
@@ -1037,6 +1037,54 @@ pub fn can_problem<'b>(
             title = "MULTIPLE LIST REST PATTERNS".to_string();
             severity = Severity::RuntimeError;
         }
+        Problem::BadType(type_problem) => {
+            use roc_types::types::Problem::*;
+            match type_problem {
+                BadTypeArguments {
+                    symbol,
+                    region,
+                    type_got,
+                    alias_needs,
+                    alias_kind,
+                } => {
+                    let needed_arguments = if alias_needs == 1 {
+                        alloc.reflow("1 type argument")
+                    } else {
+                        alloc
+                            .text(alias_needs.to_string())
+                            .append(alloc.reflow(" type arguments"))
+                    };
+
+                    let found_arguments = alloc.text(type_got.to_string());
+
+                    doc = alloc.stack([
+                        alloc.concat([
+                            alloc.reflow("The "),
+                            alloc.symbol_unqualified(symbol),
+                            alloc.reflow(" "),
+                            alloc.reflow(alias_kind.as_str()),
+                            alloc.reflow(" expects "),
+                            needed_arguments,
+                            alloc.reflow(", but it got "),
+                            found_arguments,
+                            alloc.reflow(" instead:"),
+                        ]),
+                        alloc.region(lines.convert_region(region)),
+                        alloc.reflow("Are there missing parentheses?"),
+                    ]);
+
+                    title = if type_got > alias_needs {
+                        "TOO MANY TYPE ARGUMENTS".to_string()
+                    } else {
+                        "TOO FEW TYPE ARGUMENTS".to_string()
+                    };
+
+                    severity = Severity::RuntimeError;
+                }
+
+                other => panic!("unhandled bad type: {:?}", other),
+            }
+        }
     };
 
     Report {

--- a/crates/reporting/src/error/expect.rs
+++ b/crates/reporting/src/error/expect.rs
@@ -83,7 +83,7 @@ impl<'a> Renderer<'a> {
                 .zip(variables)
                 .zip(expressions)
                 .map(|((symbol, variable), expr)| {
-                    let (error_type, _) = subs.var_to_error_type(*variable, Polarity::OF_VALUE);
+                    let error_type = subs.var_to_error_type(*variable, Polarity::OF_VALUE);
                     self.render_lookup(*symbol, expr, error_type)
                 });
 

--- a/crates/reporting/src/error/type.rs
+++ b/crates/reporting/src/error/type.rs
@@ -126,12 +126,6 @@ pub fn type_problem<'b>(
                     report(title, doc, filename)
                 }
 
-                SolvedTypeError => None, // Don't re-report cascading errors - see https://github.com/roc-lang/roc/pull/1711
-
-                // We'll also report these as a canonicalization problem, no need to re-report them.
-                CyclicAlias(..) => None,
-                UnrecognizedIdent(..) => None,
-
                 other => panic!("unhandled bad type: {:?}", other),
             }
         }

--- a/crates/reporting/src/error/type.rs
+++ b/crates/reporting/src/error/type.rs
@@ -75,60 +75,6 @@ pub fn type_problem<'b>(
 
             report(title, doc, filename)
         }
-        BadType(type_problem) => {
-            use roc_types::types::Problem::*;
-            match type_problem {
-                BadTypeArguments {
-                    symbol,
-                    region,
-                    type_got,
-                    alias_needs,
-                    alias_kind,
-                } => {
-                    let needed_arguments = if alias_needs == 1 {
-                        alloc.reflow("1 type argument")
-                    } else {
-                        alloc
-                            .text(alias_needs.to_string())
-                            .append(alloc.reflow(" type arguments"))
-                    };
-
-                    let found_arguments = alloc.text(type_got.to_string());
-
-                    let doc = alloc.stack([
-                        alloc.concat([
-                            alloc.reflow("The "),
-                            alloc.symbol_unqualified(symbol),
-                            alloc.reflow(" "),
-                            alloc.reflow(alias_kind.as_str()),
-                            alloc.reflow(" expects "),
-                            needed_arguments,
-                            alloc.reflow(", but it got "),
-                            found_arguments,
-                            alloc.reflow(" instead:"),
-                        ]),
-                        alloc.region(lines.convert_region(region)),
-                        alloc.reflow("Are there missing parentheses?"),
-                    ]);
-
-                    let title = if type_got > alias_needs {
-                        "TOO MANY TYPE ARGUMENTS".to_string()
-                    } else {
-                        "TOO FEW TYPE ARGUMENTS".to_string()
-                    };
-
-                    report(title, doc, filename)
-                }
-                Shadowed(original_region, shadow) => {
-                    let doc = report_shadowing(alloc, lines, original_region, shadow);
-                    let title = DUPLICATE_NAME.to_string();
-
-                    report(title, doc, filename)
-                }
-
-                other => panic!("unhandled bad type: {:?}", other),
-            }
-        }
         UnfulfilledAbility(incomplete) => {
             let title = "INCOMPLETE ABILITY IMPLEMENTATION".to_string();
 

--- a/crates/reporting/src/error/type.rs
+++ b/crates/reporting/src/error/type.rs
@@ -6,9 +6,9 @@ use roc_collections::VecMap;
 use roc_error_macros::internal_error;
 use roc_exhaustive::{CtorName, ListArity};
 use roc_module::called_via::{BinOp, CalledVia};
-use roc_module::ident::{Ident, IdentStr, Lowercase, TagName};
+use roc_module::ident::{IdentStr, Lowercase, TagName};
 use roc_module::symbol::Symbol;
-use roc_region::all::{LineInfo, Loc, Region};
+use roc_region::all::{LineInfo, Region};
 use roc_solve_problem::{
     NotDerivableContext, NotDerivableDecode, NotDerivableEq, TypeError, UnderivableReason,
     Unfulfilled,
@@ -22,7 +22,6 @@ use roc_types::types::{
 use std::path::PathBuf;
 use ven_pretty::DocAllocator;
 
-const DUPLICATE_NAME: &str = "DUPLICATE NAME";
 const ADD_ANNOTATIONS: &str = r#"Can more type annotations be added? Type annotations always help me give more specific messages, and I think they could help a lot in this case"#;
 
 const OPAQUE_NUM_SYMBOLS: &[Symbol] = &[
@@ -393,26 +392,6 @@ fn underivable_hint<'b>(
             }
         },
     }
-}
-
-fn report_shadowing<'b>(
-    alloc: &'b RocDocAllocator<'b>,
-    lines: &LineInfo,
-    original_region: Region,
-    shadow: Loc<Ident>,
-) -> RocDocBuilder<'b> {
-    let line = r#"Since these types have the same name, it's easy to use the wrong one on accident. Give one of them a new name."#;
-
-    alloc.stack([
-        alloc
-            .text("The ")
-            .append(alloc.ident(shadow.value))
-            .append(alloc.reflow(" name is first defined here:")),
-        alloc.region(lines.convert_region(original_region)),
-        alloc.reflow("But then it's defined a second time here:"),
-        alloc.region(lines.convert_region(shadow.region)),
-        alloc.reflow(line),
-    ])
 }
 
 pub fn cyclic_alias<'b>(


### PR DESCRIPTION
All the cases where `Erroneous` was used can be covered by canonicalization errors.