### PR TITLE
Begin Types SoA in constraining

### DIFF
--- a/crates/compiler/can/src/constraint.rs
+++ b/crates/compiler/can/src/constraint.rs
@@ -8,7 +8,7 @@ use roc_module::ident::TagName;
 use roc_module::symbol::{ModuleId, Symbol};
 use roc_region::all::{Loc, Region};
 use roc_types::subs::{ExhaustiveMark, IllegalCycleMark, Variable};
-use roc_types::types::{Category, PatternCategory, Type, TypeTag, Types};
+use roc_types::types::{Category, PatternCategory, TypeTag, Types};
 
 pub struct Constraints {
     pub constraints: Vec<Constraint>,

--- a/crates/compiler/collections/src/soa.rs
+++ b/crates/compiler/collections/src/soa.rs
@@ -88,15 +88,15 @@ impl<T> std::fmt::Debug for Slice<T> {
 
 impl<T> Default for Slice<T> {
     fn default() -> Self {
-        Self {
-            start: Default::default(),
-            length: Default::default(),
-            _marker: Default::default(),
-        }
+        Self::empty()
     }
 }
 
 impl<T> Slice<T> {
+    pub const fn empty() -> Self {
+        Self::new(0, 0)
+    }
+
     pub const fn new(start: u32, length: u16) -> Self {
         Self {
             start,

--- a/crates/compiler/constrain/src/builtins.rs
+++ b/crates/compiler/constrain/src/builtins.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::too_many_arguments)]
+
 use arrayvec::ArrayVec;
 use roc_can::constraint::{Constraint, Constraints, ExpectedTypeIndex};
 use roc_can::expected::Expected::{self, *};

--- a/crates/compiler/constrain/src/builtins.rs
+++ b/crates/compiler/constrain/src/builtins.rs
@@ -56,9 +56,10 @@ pub fn add_numeric_bound_constr(
         }
         NumericBound::Range(range) => {
             let precision_type = constraints.push_variable(precision_var);
-            let expected = Expected::NoExpectation(
-                constraints.push_type(types, types.from_old_type(&RangedNumber(range))),
-            );
+            let expected = {
+                let typ = types.from_old_type(&RangedNumber(range));
+                Expected::NoExpectation(constraints.push_type(types, typ))
+            };
             let expected_index = constraints.push_expected_type(expected);
             let constr = constraints.equal_types(precision_type, expected_index, category, region);
 
@@ -94,11 +95,14 @@ pub fn int_literal(
         Category::Num,
     );
 
-    let num_type_index = constraints.push_type(types, types.from_old_type(&num_type));
-    let int_precision_type = constraints.push_type(
-        types,
-        types.from_old_type(&num_int(Type::Variable(precision_var))),
-    );
+    let num_type_index = {
+        let typ = types.from_old_type(&num_type);
+        constraints.push_type(types, typ)
+    };
+    let int_precision_type = {
+        let typ = types.from_old_type(&num_int(Type::Variable(precision_var)));
+        constraints.push_type(types, typ)
+    };
 
     let expect_precision_var =
         constraints.push_expected_type(ForReason(reason, int_precision_type, region));
@@ -137,11 +141,14 @@ pub fn single_quote_literal(
         Category::Character,
     );
 
-    let num_type_index = constraints.push_type(types, types.from_old_type(&num_type));
-    let int_precision_type = constraints.push_type(
-        types,
-        types.from_old_type(&num_int(Type::Variable(precision_var))),
-    );
+    let num_type_index = {
+        let typ = types.from_old_type(&num_type);
+        constraints.push_type(types, typ)
+    };
+    let int_precision_type = {
+        let typ = types.from_old_type(&num_int(Type::Variable(precision_var)));
+        constraints.push_type(types, typ)
+    };
 
     let expect_precision_var =
         constraints.push_expected_type(ForReason(reason, int_precision_type, region));
@@ -184,11 +191,14 @@ pub fn float_literal(
         Category::Frac,
     );
 
-    let num_type_index = constraints.push_type(types, types.from_old_type(&num_type));
-    let float_precision_type = constraints.push_type(
-        types,
-        types.from_old_type(&num_float(Type::Variable(precision_var))),
-    );
+    let num_type_index = {
+        let typ = types.from_old_type(&num_type);
+        constraints.push_type(types, typ)
+    };
+    let float_precision_type = {
+        let typ = types.from_old_type(&num_float(Type::Variable(precision_var)));
+        constraints.push_type(types, typ)
+    };
 
     let expect_precision_var =
         constraints.push_expected_type(ForReason(reason, float_precision_type, region));
@@ -223,7 +233,10 @@ pub fn num_literal(
         Category::Num,
     );
 
-    let type_index = constraints.push_type(types, types.from_old_type(&num_type));
+    let type_index = {
+        let typ = types.from_old_type(&num_type);
+        constraints.push_type(types, typ)
+    };
     constrs.extend([constraints.equal_types(type_index, expected, Category::Num, region)]);
 
     let and_constraint = constraints.and_constraint(constrs);

--- a/crates/compiler/constrain/src/builtins.rs
+++ b/crates/compiler/constrain/src/builtins.rs
@@ -305,52 +305,12 @@ pub(crate) fn num_floatingpoint(range: Type) -> Type {
 }
 
 #[cfg_attr(not(debug_assertions), inline(always))]
-pub(crate) fn num_u32() -> Type {
-    builtin_num_alias(
-        Symbol::NUM_U32,
-        vec![],
-        Box::new(num_int(num_unsigned32())),
-        AliasKind::Structural,
-    )
-}
-
-#[cfg_attr(not(debug_assertions), inline(always))]
-fn num_unsigned32() -> Type {
-    builtin_num_alias(
-        Symbol::NUM_UNSIGNED32,
-        vec![],
-        Box::new(Type::EmptyTagUnion),
-        AliasKind::Opaque,
-    )
-}
-
-#[cfg_attr(not(debug_assertions), inline(always))]
-pub(crate) fn num_binary64() -> Type {
-    builtin_num_alias(
-        Symbol::NUM_BINARY64,
-        vec![],
-        Box::new(Type::EmptyTagUnion),
-        AliasKind::Opaque,
-    )
-}
-
-#[cfg_attr(not(debug_assertions), inline(always))]
 pub(crate) fn num_int(range: Type) -> Type {
     builtin_num_alias(
         Symbol::NUM_INT,
         vec![OptAbleType::unbound(range.clone())],
         Box::new(num_num(num_integer(range))),
         AliasKind::Structural,
-    )
-}
-
-#[cfg_attr(not(debug_assertions), inline(always))]
-pub(crate) fn num_signed64() -> Type {
-    builtin_num_alias(
-        Symbol::NUM_SIGNED64,
-        vec![],
-        Box::new(Type::EmptyTagUnion),
-        AliasKind::Opaque,
     )
 }
 

--- a/crates/compiler/constrain/src/builtins.rs
+++ b/crates/compiler/constrain/src/builtins.rs
@@ -13,7 +13,7 @@ use roc_types::types::{AliasKind, Category, Types};
 use roc_types::types::{OptAbleType, Reason};
 
 #[inline(always)]
-pub fn add_numeric_bound_constr(
+pub(crate) fn add_numeric_bound_constr(
     types: &mut Types,
     constraints: &mut Constraints,
     num_constraints: &mut impl Extend<Constraint>,
@@ -73,7 +73,7 @@ pub fn add_numeric_bound_constr(
 }
 
 #[inline(always)]
-pub fn int_literal(
+pub(crate) fn int_literal(
     types: &mut Types,
     constraints: &mut Constraints,
     num_var: Variable,
@@ -119,7 +119,7 @@ pub fn int_literal(
     constraints.exists([num_var], and_constraint)
 }
 
-pub fn single_quote_literal(
+pub(crate) fn single_quote_literal(
     types: &mut Types,
     constraints: &mut Constraints,
     num_var: Variable,
@@ -170,7 +170,7 @@ pub fn single_quote_literal(
 }
 
 #[inline(always)]
-pub fn float_literal(
+pub(crate) fn float_literal(
     types: &mut Types,
     constraints: &mut Constraints,
     num_var: Variable,
@@ -215,7 +215,7 @@ pub fn float_literal(
 }
 
 #[inline(always)]
-pub fn num_literal(
+pub(crate) fn num_literal(
     types: &mut Types,
     constraints: &mut Constraints,
     num_var: Variable,
@@ -249,7 +249,7 @@ pub fn num_literal(
 // Inlining these tiny leaf functions can lead to death by a thousand cuts,
 // where we end up with huge stack frames in non-tail-recursive functions.
 #[cfg_attr(not(debug_assertions), inline(always))]
-pub fn builtin_type(symbol: Symbol, args: Vec<Type>) -> Type {
+pub(crate) fn builtin_type(symbol: Symbol, args: Vec<Type>) -> Type {
     Type::Apply(
         symbol,
         args.into_iter().map(Loc::at_zero).collect(),
@@ -258,12 +258,12 @@ pub fn builtin_type(symbol: Symbol, args: Vec<Type>) -> Type {
 }
 
 #[cfg_attr(not(debug_assertions), inline(always))]
-pub fn empty_list_type(var: Variable) -> Type {
+pub(crate) fn empty_list_type(var: Variable) -> Type {
     list_type(Type::Variable(var))
 }
 
 #[cfg_attr(not(debug_assertions), inline(always))]
-pub fn list_type(typ: Type) -> Type {
+pub(crate) fn list_type(typ: Type) -> Type {
     builtin_type(Symbol::LIST_LIST, vec![typ])
 }
 
@@ -285,7 +285,7 @@ fn builtin_num_alias(
 }
 
 #[cfg_attr(not(debug_assertions), inline(always))]
-pub fn num_float(range: Type) -> Type {
+pub(crate) fn num_float(range: Type) -> Type {
     builtin_num_alias(
         Symbol::NUM_FRAC,
         vec![OptAbleType::unbound(range.clone())],
@@ -295,7 +295,7 @@ pub fn num_float(range: Type) -> Type {
 }
 
 #[cfg_attr(not(debug_assertions), inline(always))]
-pub fn num_floatingpoint(range: Type) -> Type {
+pub(crate) fn num_floatingpoint(range: Type) -> Type {
     builtin_num_alias(
         Symbol::NUM_FLOATINGPOINT,
         vec![OptAbleType::unbound(range.clone())],
@@ -305,7 +305,7 @@ pub fn num_floatingpoint(range: Type) -> Type {
 }
 
 #[cfg_attr(not(debug_assertions), inline(always))]
-pub fn num_u32() -> Type {
+pub(crate) fn num_u32() -> Type {
     builtin_num_alias(
         Symbol::NUM_U32,
         vec![],
@@ -325,7 +325,7 @@ fn num_unsigned32() -> Type {
 }
 
 #[cfg_attr(not(debug_assertions), inline(always))]
-pub fn num_binary64() -> Type {
+pub(crate) fn num_binary64() -> Type {
     builtin_num_alias(
         Symbol::NUM_BINARY64,
         vec![],
@@ -335,7 +335,7 @@ pub fn num_binary64() -> Type {
 }
 
 #[cfg_attr(not(debug_assertions), inline(always))]
-pub fn num_int(range: Type) -> Type {
+pub(crate) fn num_int(range: Type) -> Type {
     builtin_num_alias(
         Symbol::NUM_INT,
         vec![OptAbleType::unbound(range.clone())],
@@ -345,7 +345,7 @@ pub fn num_int(range: Type) -> Type {
 }
 
 #[cfg_attr(not(debug_assertions), inline(always))]
-pub fn num_signed64() -> Type {
+pub(crate) fn num_signed64() -> Type {
     builtin_num_alias(
         Symbol::NUM_SIGNED64,
         vec![],
@@ -355,7 +355,7 @@ pub fn num_signed64() -> Type {
 }
 
 #[cfg_attr(not(debug_assertions), inline(always))]
-pub fn num_integer(range: Type) -> Type {
+pub(crate) fn num_integer(range: Type) -> Type {
     builtin_num_alias(
         Symbol::NUM_INTEGER,
         vec![OptAbleType::unbound(range.clone())],
@@ -365,7 +365,7 @@ pub fn num_integer(range: Type) -> Type {
 }
 
 #[cfg_attr(not(debug_assertions), inline(always))]
-pub fn num_num(typ: Type) -> Type {
+pub(crate) fn num_num(typ: Type) -> Type {
     builtin_num_alias(
         Symbol::NUM_NUM,
         vec![OptAbleType::unbound(typ.clone())],

--- a/crates/compiler/constrain/src/builtins.rs
+++ b/crates/compiler/constrain/src/builtins.rs
@@ -268,11 +268,6 @@ pub fn list_type(typ: Type) -> Type {
 }
 
 #[cfg_attr(not(debug_assertions), inline(always))]
-pub fn str_type() -> Type {
-    builtin_type(Symbol::STR_STR, Vec::new())
-}
-
-#[cfg_attr(not(debug_assertions), inline(always))]
 fn builtin_num_alias(
     symbol: Symbol,
     type_arguments: Vec<OptAbleType>,

--- a/crates/compiler/constrain/src/expr.rs
+++ b/crates/compiler/constrain/src/expr.rs
@@ -2679,11 +2679,7 @@ fn constrain_typed_function_arguments(
     let it = arguments.iter().zip(arg_types.into_iter()).enumerate();
     for (index, ((pattern_var, annotated_mark, loc_pattern), ann)) in it {
         let pattern_var_index = constraints.push_variable(*pattern_var);
-        let ann_index = {
-            // TODO(types-soa) remove clone
-            let typ = types.clone_with_variable_substitutions(ann, &Default::default());
-            constraints.push_type(types, typ)
-        };
+        let ann_index = constraints.push_type(types, ann);
 
         if loc_pattern.value.surely_exhaustive() {
             // OPT: we don't need to perform any type-level exhaustiveness checking.

--- a/crates/compiler/constrain/src/expr.rs
+++ b/crates/compiler/constrain/src/expr.rs
@@ -1,8 +1,9 @@
+#![allow(clippy::too_many_arguments)]
+
 use std::ops::Range;
 
 use crate::builtins::{
     empty_list_type, float_literal, int_literal, list_type, num_literal, single_quote_literal,
-    str_type,
 };
 use crate::pattern::{constrain_pattern, PatternState};
 use roc_can::annotation::IntroducedVariables;
@@ -102,7 +103,6 @@ fn constrain_untyped_args(
     (vars, pattern_state, function_type)
 }
 
-#[allow(clippy::too_many_arguments)]
 fn constrain_untyped_closure(
     types: &mut Types,
     constraints: &mut Constraints,
@@ -166,7 +166,7 @@ fn constrain_untyped_closure(
 
     let function_type = {
         let typ = types.from_old_type(&function_type);
-        constraints.push_type(&types, typ)
+        constraints.push_type(types, typ)
     };
 
     let cons = [
@@ -233,7 +233,7 @@ pub fn constrain_expr(
                 let record_type = {
                     let typ =
                         types.from_old_type(&Type::Record(field_types, TypeExtension::Closed));
-                    constraints.push_type(&types, typ)
+                    constraints.push_type(types, typ)
                 };
 
                 let record_con = constraints.equal_types_with_storage(
@@ -280,11 +280,11 @@ pub fn constrain_expr(
                     fields,
                     TypeExtension::from_type(Type::Variable(*ext_var)),
                 ));
-                constraints.push_type(&types, typ)
+                constraints.push_type(types, typ)
             };
             let record_type = {
                 let typ = types.from_old_type(&Type::Variable(*record_var));
-                constraints.push_type(&types, typ)
+                constraints.push_type(types, typ)
             };
 
             // NOTE from elm compiler: fields_type is separate so that Error propagates better
@@ -376,7 +376,7 @@ pub fn constrain_expr(
 
                 let elem_type_index = {
                     let typ = types.from_old_type(&list_type(list_elem_type));
-                    constraints.push_type(&types, typ)
+                    constraints.push_type(types, typ)
                 };
                 list_constraints.push(constraints.equal_types(
                     elem_type_index,
@@ -1606,7 +1606,7 @@ fn constrain_function_def(
                 &mut ftv,
             );
 
-            let signature_index = constraints.push_type(types, signature.clone());
+            let signature_index = constraints.push_type(types, signature);
 
             let (arg_types, signature_closure_type, ret_type) = match types[signature] {
                 TypeTag::Function(signature_closure_type, ret_type) => (
@@ -2492,7 +2492,7 @@ fn constrain_typed_def(
 
     let signature_index = {
         // TODO(types-soa) get rid of clone
-        let typ = types.clone_with_variable_substitutions(signature.clone(), &Default::default());
+        let typ = types.clone_with_variable_substitutions(signature, &Default::default());
         constraints.push_type(types, typ)
     };
 
@@ -2705,7 +2705,7 @@ fn constrain_typed_function_arguments(
         let pattern_var_index = constraints.push_variable(*pattern_var);
         let ann_index = {
             // TODO(types-soa) remove clone
-            let typ = types.clone_with_variable_substitutions(ann.clone(), &Default::default());
+            let typ = types.clone_with_variable_substitutions(ann, &Default::default());
             constraints.push_type(types, typ)
         };
 
@@ -3024,7 +3024,6 @@ pub(crate) fn constrain_def_make_constraint(
     )
 }
 
-#[allow(clippy::too_many_arguments)]
 fn constrain_value_def_make_constraint(
     constraints: &mut Constraints,
     new_rigid_variables: Vec<Variable>,
@@ -3273,7 +3272,6 @@ fn constrain_recursive_declarations(
     )
 }
 
-#[allow(clippy::too_many_arguments)]
 fn constraint_recursive_function(
     types: &mut Types,
     constraints: &mut Constraints,
@@ -3481,7 +3479,6 @@ fn constraint_recursive_function(
     }
 }
 
-#[allow(clippy::too_many_arguments)]
 pub fn rec_defs_help_simple(
     types: &mut Types,
     constraints: &mut Constraints,
@@ -3567,10 +3564,8 @@ pub fn rec_defs_help_simple(
 
                         let signature_index = {
                             // TODO(types-soa) remove clone
-                            let typ = types.clone_with_variable_substitutions(
-                                signature.clone(),
-                                &Default::default(),
-                            );
+                            let typ = types
+                                .clone_with_variable_substitutions(signature, &Default::default());
                             constraints.push_type(types, typ)
                         };
 
@@ -3792,8 +3787,8 @@ fn rec_defs_help(
                 hybrid_and_flex_info.vars.extend(new_infer_variables);
 
                 let signature_index = {
-                    let typ = types
-                        .clone_with_variable_substitutions(signature.clone(), &Default::default());
+                    let typ =
+                        types.clone_with_variable_substitutions(signature, &Default::default());
                     constraints.push_type(
                         types, // TODO(types-soa) remove clone
                         typ,

--- a/crates/compiler/constrain/src/expr.rs
+++ b/crates/compiler/constrain/src/expr.rs
@@ -1804,14 +1804,8 @@ fn constrain_function_def(
             let defs_constraint = constraints.and_constraint(argument_pattern_state.constraints);
 
             let signature_closure_type = {
-                let signature_closure_type_index = {
-                    // TODO(types-soa) get rid of clone
-                    let typ = types.clone_with_variable_substitutions(
-                        signature_closure_type,
-                        &Default::default(),
-                    );
-                    constraints.push_type(types, typ)
-                };
+                let signature_closure_type_index =
+                    constraints.push_type(types, signature_closure_type);
                 constraints.push_expected_type(Expected::FromAnnotation(
                     loc_pattern,
                     arity,

--- a/crates/compiler/constrain/src/expr.rs
+++ b/crates/compiler/constrain/src/expr.rs
@@ -1717,11 +1717,7 @@ fn constrain_function_def(
             let ret_var = function_def.return_type;
             let closure_var = function_def.closure_type;
 
-            let ret_type_index = {
-                // TODO(types-soa) get rid of clone
-                let typ = types.clone_with_variable_substitutions(ret_type, &Default::default());
-                constraints.push_type(types, typ)
-            };
+            let ret_type_index = constraints.push_type(types, ret_type);
 
             vars.push(ret_var);
             vars.push(closure_var);

--- a/crates/compiler/constrain/src/expr.rs
+++ b/crates/compiler/constrain/src/expr.rs
@@ -3144,6 +3144,7 @@ fn instantiate_rigids(
     if !rigid_substitution.is_empty() {
         annotation.substitute_variables(&rigid_substitution);
     }
+    let annotation_index = types.from_old_type(&annotation);
 
     // TODO investigate when we can skip this. It seems to only be required for correctness
     // for recursive functions. For non-recursive functions the final type is correct, but
@@ -3152,10 +3153,7 @@ fn instantiate_rigids(
     // Skipping all of this cloning here would be neat!
     let loc_annotation_ref = Loc::at(loc_pattern.region, &annotation);
     if let Pattern::Identifier(symbol) = loc_pattern.value {
-        let annotation_index = {
-            let typ = types.from_old_type(&annotation);
-            constraints.push_type(types, typ)
-        };
+        let annotation_index = constraints.push_type(types, annotation_index);
         headers.insert(symbol, Loc::at(loc_pattern.region, annotation_index));
     } else if let Some(new_headers) = crate::pattern::headers_from_annotation(
         types,
@@ -3167,8 +3165,7 @@ fn instantiate_rigids(
     }
 
     InstantiateRigids {
-        // TODO(types-soa) coalesce with types.from_old_type(annotation) above
-        signature: types.from_old_type(&annotation),
+        signature: annotation_index,
         new_rigid_variables,
         new_infer_variables,
     }

--- a/crates/compiler/constrain/src/expr.rs
+++ b/crates/compiler/constrain/src/expr.rs
@@ -3393,9 +3393,7 @@ fn constraint_recursive_function(
             let fn_type = {
                 // TODO(types-soa) optimize for Variable
                 let lambda_set = types.from_old_type(&Type::Variable(closure_var));
-                // TODO(types-soa) remove clone
-                let ret = types.clone_with_variable_substitutions(ret_type, &Default::default());
-                let typ = types.function(pattern_types, lambda_set, ret);
+                let typ = types.function(pattern_types, lambda_set, ret_type);
                 constraints.push_type(types, typ)
             };
 

--- a/crates/compiler/constrain/src/expr.rs
+++ b/crates/compiler/constrain/src/expr.rs
@@ -1388,7 +1388,7 @@ pub fn constrain_expr(
                     constraints.push_type(types, typ)
                 };
                 let specialized_type_index = {
-                    let typ = types.from_old_type(&(*specialized_def_type));
+                    let typ = types.from_old_type(specialized_def_type);
                     constraints.push_type(types, typ)
                 };
                 let expected_specialized =

--- a/crates/compiler/constrain/src/expr.rs
+++ b/crates/compiler/constrain/src/expr.rs
@@ -2534,11 +2534,7 @@ fn constrain_typed_def(
             let mut vars = Vec::with_capacity(argument_pattern_state.vars.capacity() + 1);
             let ret_var = *ret_var;
             let closure_var = *closure_var;
-            let ret_type_index = {
-                // TODO(types-soa) get rid of clone
-                let typ = types.clone_with_variable_substitutions(ret_type, &Default::default());
-                constraints.push_type(types, typ)
-            };
+            let ret_type_index = constraints.push_type(types, ret_type);
 
             vars.push(ret_var);
             vars.push(closure_var);

--- a/crates/compiler/constrain/src/expr.rs
+++ b/crates/compiler/constrain/src/expr.rs
@@ -2584,14 +2584,8 @@ fn constrain_typed_def(
             let defs_constraint = constraints.and_constraint(argument_pattern_state.constraints);
 
             let signature_closure_type = {
-                let signature_closure_type_index = {
-                    // TODO(types-soa) get rid of clone
-                    let typ = types.clone_with_variable_substitutions(
-                        signature_closure_type,
-                        &Default::default(),
-                    );
-                    constraints.push_type(types, typ)
-                };
+                let signature_closure_type_index =
+                    constraints.push_type(types, signature_closure_type);
                 constraints.push_expected_type(Expected::FromAnnotation(
                     def.loc_pattern.clone(),
                     arity,

--- a/crates/compiler/constrain/src/expr.rs
+++ b/crates/compiler/constrain/src/expr.rs
@@ -3796,14 +3796,7 @@ fn rec_defs_help(
                         let mut vars = Vec::with_capacity(state.vars.capacity() + 1);
                         let ret_var = *ret_var;
                         let closure_var = *closure_var;
-                        let ret_type_index = {
-                            let typ = types
-                                .clone_with_variable_substitutions(ret_type, &Default::default());
-                            constraints.push_type(
-                                types, // TODO(types-soa) remove clone
-                                typ,
-                            )
-                        };
+                        let ret_type_index = constraints.push_type(types, ret_type);
 
                         vars.push(ret_var);
                         vars.push(closure_var);

--- a/crates/compiler/constrain/src/expr.rs
+++ b/crates/compiler/constrain/src/expr.rs
@@ -2480,11 +2480,7 @@ fn constrain_typed_def(
         rigids: ftv,
     };
 
-    let signature_index = {
-        // TODO(types-soa) get rid of clone
-        let typ = types.clone_with_variable_substitutions(signature, &Default::default());
-        constraints.push_type(types, typ)
-    };
+    let signature_index = constraints.push_type(types, signature);
 
     let annotation_expected = constraints.push_expected_type(FromAnnotation(
         def.loc_pattern.clone(),

--- a/crates/compiler/constrain/src/expr.rs
+++ b/crates/compiler/constrain/src/expr.rs
@@ -3748,14 +3748,7 @@ fn rec_defs_help(
 
                 hybrid_and_flex_info.vars.extend(new_infer_variables);
 
-                let signature_index = {
-                    let typ =
-                        types.clone_with_variable_substitutions(signature, &Default::default());
-                    constraints.push_type(
-                        types, // TODO(types-soa) remove clone
-                        typ,
-                    )
-                };
+                let signature_index = constraints.push_type(types, signature);
 
                 let annotation_expected = FromAnnotation(
                     def.loc_pattern.clone(),

--- a/crates/compiler/constrain/src/expr.rs
+++ b/crates/compiler/constrain/src/expr.rs
@@ -3529,12 +3529,7 @@ pub fn rec_defs_help_simple(
 
                         hybrid_and_flex_info.vars.extend(new_infer_variables);
 
-                        let signature_index = {
-                            // TODO(types-soa) remove clone
-                            let typ = types
-                                .clone_with_variable_substitutions(signature, &Default::default());
-                            constraints.push_type(types, typ)
-                        };
+                        let signature_index = constraints.push_type(types, signature);
 
                         let annotation_expected = FromAnnotation(
                             loc_pattern.clone(),

--- a/crates/compiler/constrain/src/expr.rs
+++ b/crates/compiler/constrain/src/expr.rs
@@ -3826,11 +3826,9 @@ fn rec_defs_help(
                         );
 
                         let fn_type_index = {
+                            // TODO(types-soa) optimize for variable
                             let lambda_set = types.from_old_type(&Type::Variable(closure_var));
-                            // TODO(types-soa) remove clone
-                            let ret = types
-                                .clone_with_variable_substitutions(ret_type, &Default::default());
-                            let typ = types.function(pattern_types, lambda_set, ret);
+                            let typ = types.function(pattern_types, lambda_set, ret_type);
                             constraints.push_type(types, typ)
                         };
                         let body_type =

--- a/crates/compiler/constrain/src/module.rs
+++ b/crates/compiler/constrain/src/module.rs
@@ -58,7 +58,10 @@ fn constrain_symbols_from_requires(
                 };
                 let pattern = Loc::at_zero(roc_can::pattern::Pattern::Identifier(loc_symbol.value));
 
-                let type_index = constraints.push_type(types, types.from_old_type(&loc_type.value));
+                let type_index = {
+                    let typ = types.from_old_type(&loc_type.value);
+                    constraints.push_type(types, typ)
+                };
                 let def_pattern_state =
                     constrain_def_pattern(types, constraints, &mut env, &pattern, type_index);
 
@@ -79,7 +82,10 @@ fn constrain_symbols_from_requires(
                 // provided by the app is in fact what the package module requires.
                 let arity = loc_type.value.arity();
                 let typ = loc_type.value;
-                let type_index = constraints.push_type(types, types.from_old_type(&typ));
+                let type_index = {
+                    let typ = types.from_old_type(&typ);
+                    constraints.push_type(types, typ)
+                };
                 let expected = constraints.push_expected_type(Expected::FromAnnotation(
                     loc_symbol.map(|&s| Pattern::Identifier(s)),
                     arity,
@@ -118,8 +124,10 @@ pub fn frontload_ability_constraints(
             };
             let pattern = Loc::at_zero(roc_can::pattern::Pattern::Identifier(*member_name));
 
-            let signature_index =
-                constraints.push_type(types, types.from_old_type(&signature.clone()));
+            let signature_index = {
+                let typ = types.from_old_type(&signature.clone());
+                constraints.push_type(types, typ)
+            };
 
             let mut def_pattern_state =
                 constrain_def_pattern(types, constraints, &mut env, &pattern, signature_index);

--- a/crates/compiler/constrain/src/module.rs
+++ b/crates/compiler/constrain/src/module.rs
@@ -6,19 +6,26 @@ use roc_can::expr::Declarations;
 use roc_can::pattern::Pattern;
 use roc_module::symbol::{ModuleId, Symbol};
 use roc_region::all::{Loc, Region};
-use roc_types::types::{AnnotationSource, Category, Type};
+use roc_types::types::{AnnotationSource, Category, Type, Types};
 
 pub fn constrain_module(
+    types: &mut Types,
     constraints: &mut Constraints,
     symbols_from_requires: Vec<(Loc<Symbol>, Loc<Type>)>,
     abilities_store: &PendingAbilitiesStore,
     declarations: &Declarations,
     home: ModuleId,
 ) -> Constraint {
-    let constraint = crate::expr::constrain_decls(constraints, home, declarations);
+    let constraint = crate::expr::constrain_decls(types, constraints, home, declarations);
+    let constraint = constrain_symbols_from_requires(
+        types,
+        constraints,
+        symbols_from_requires,
+        home,
+        constraint,
+    );
     let constraint =
-        constrain_symbols_from_requires(constraints, symbols_from_requires, home, constraint);
-    let constraint = frontload_ability_constraints(constraints, abilities_store, home, constraint);
+        frontload_ability_constraints(types, constraints, abilities_store, home, constraint);
 
     // The module constraint should always save the environment at the end.
     debug_assert!(constraints.contains_save_the_environment(&constraint));
@@ -27,6 +34,7 @@ pub fn constrain_module(
 }
 
 fn constrain_symbols_from_requires(
+    types: &mut Types,
     constraints: &mut Constraints,
     symbols_from_requires: Vec<(Loc<Symbol>, Loc<Type>)>,
     home: ModuleId,
@@ -50,9 +58,9 @@ fn constrain_symbols_from_requires(
                 };
                 let pattern = Loc::at_zero(roc_can::pattern::Pattern::Identifier(loc_symbol.value));
 
-                let type_index = constraints.push_type(loc_type.value);
+                let type_index = constraints.push_type(types, types.from_old_type(&loc_type.value));
                 let def_pattern_state =
-                    constrain_def_pattern(constraints, &mut env, &pattern, type_index);
+                    constrain_def_pattern(types, constraints, &mut env, &pattern, type_index);
 
                 debug_assert!(env.resolutions_to_make.is_empty());
 
@@ -71,7 +79,7 @@ fn constrain_symbols_from_requires(
                 // provided by the app is in fact what the package module requires.
                 let arity = loc_type.value.arity();
                 let typ = loc_type.value;
-                let type_index = constraints.push_type(typ);
+                let type_index = constraints.push_type(types, types.from_old_type(&typ));
                 let expected = constraints.push_expected_type(Expected::FromAnnotation(
                     loc_symbol.map(|&s| Pattern::Identifier(s)),
                     arity,
@@ -88,6 +96,7 @@ fn constrain_symbols_from_requires(
 }
 
 pub fn frontload_ability_constraints(
+    types: &mut Types,
     constraints: &mut Constraints,
     abilities_store: &PendingAbilitiesStore,
     home: ModuleId,
@@ -109,10 +118,11 @@ pub fn frontload_ability_constraints(
             };
             let pattern = Loc::at_zero(roc_can::pattern::Pattern::Identifier(*member_name));
 
-            let signature_index = constraints.push_type(signature.clone());
+            let signature_index =
+                constraints.push_type(types, types.from_old_type(&signature.clone()));
 
             let mut def_pattern_state =
-                constrain_def_pattern(constraints, &mut env, &pattern, signature_index);
+                constrain_def_pattern(types, constraints, &mut env, &pattern, signature_index);
 
             debug_assert!(env.resolutions_to_make.is_empty());
 

--- a/crates/compiler/constrain/src/pattern.rs
+++ b/crates/compiler/constrain/src/pattern.rs
@@ -65,7 +65,7 @@ fn headers_from_annotation_help(
             ident: symbol,
             specializes: _,
         } => {
-            let annotation_index = { let typ = types.from_old_type(&annotation.value); constraints.push_type(types, typ) };
+            let annotation_index = { let typ = types.from_old_type(annotation.value); constraints.push_type(types, typ) };
             let typ = Loc::at(annotation.region, annotation_index);
             headers.insert(*symbol, typ);
             true
@@ -165,7 +165,7 @@ fn headers_from_annotation_help(
                 && type_arguments.len() == pat_type_arguments.len()
                 && lambda_set_variables.len() == pat_lambda_set_variables.len() =>
             {
-                let annotation_index = { let typ = types.from_old_type( &annotation.value ); constraints.push_type(types, typ) };
+                let annotation_index = { let typ = types.from_old_type(annotation.value); constraints.push_type(types, typ) };
                 let typ = Loc::at(annotation.region, annotation_index);
                 headers.insert(*opaque, typ);
 

--- a/crates/compiler/constrain/src/pattern.rs
+++ b/crates/compiler/constrain/src/pattern.rs
@@ -358,11 +358,7 @@ pub fn constrain_pattern(
         }
 
         StrLiteral(_) => {
-            // TODO(types-soa) use Types::STR
-            let str_type = {
-                let typ = types.from_old_type(&builtins::str_type());
-                constraints.push_type(types, typ)
-            };
+            let str_type = constraints.push_type(types, Types::STR);
             state.constraints.push(constraints.equal_pattern_types(
                 str_type,
                 expected,

--- a/crates/compiler/constrain/src/pattern.rs
+++ b/crates/compiler/constrain/src/pattern.rs
@@ -435,9 +435,7 @@ pub fn constrain_pattern(
             } in destructs
             {
                 let pat_type = Type::Variable(*var);
-                let pat_type_index =
-                    // TODO(types-soa) use variable here instead
-                    { let typ = types.from_old_type(&pat_type.clone()); constraints.push_type(types, typ) };
+                let pat_type_index = constraints.push_variable(*var);
                 let expected =
                     constraints.push_pat_expected_type(PExpected::NoExpectation(pat_type_index));
 

--- a/crates/compiler/constrain/src/pattern.rs
+++ b/crates/compiler/constrain/src/pattern.rs
@@ -65,7 +65,7 @@ fn headers_from_annotation_help(
             ident: symbol,
             specializes: _,
         } => {
-            let annotation_index = constraints.push_type(types, types.from_old_type(&annotation.value));
+            let annotation_index = { let typ = types.from_old_type(&annotation.value); constraints.push_type(types, typ) };
             let typ = Loc::at(annotation.region, annotation_index);
             headers.insert(*symbol, typ);
             true
@@ -93,7 +93,7 @@ fn headers_from_annotation_help(
                     // `{ x ? 0 } = rec` or `{ x: 5 } -> ...` in all cases
                     // the type of `x` within the binding itself is the same.
                     if let Some(field_type) = fields.get(&destruct.label) {
-                        let field_type_index = constraints.push_type(types, types.from_old_type(&field_type.as_inner().clone()));
+                        let field_type_index = { let typ = types.from_old_type(&field_type.as_inner().clone()); constraints.push_type(types, typ) };
                         headers.insert(
                             destruct.symbol,
                             Loc::at(annotation.region, field_type_index),
@@ -165,7 +165,7 @@ fn headers_from_annotation_help(
                 && type_arguments.len() == pat_type_arguments.len()
                 && lambda_set_variables.len() == pat_lambda_set_variables.len() =>
             {
-                let annotation_index = constraints.push_type(types, types.from_old_type( &annotation.value ));
+                let annotation_index = { let typ = types.from_old_type( &annotation.value ); constraints.push_type(types, typ) };
                 let typ = Loc::at(annotation.region, annotation_index);
                 headers.insert(*opaque, typ);
 
@@ -266,7 +266,10 @@ pub fn constrain_pattern(
                 region,
                 Category::Num,
             );
-            let num_type = constraints.push_type(types, types.from_old_type(&num_type));
+            let num_type = {
+                let typ = types.from_old_type(&num_type);
+                constraints.push_type(types, typ)
+            };
 
             state.constraints.push(constraints.equal_pattern_types(
                 num_type,
@@ -289,13 +292,16 @@ pub fn constrain_pattern(
                 region,
                 Category::Int,
             );
-            let num_type = constraints.push_type(types, types.from_old_type(&num_type));
+            let num_type = {
+                let typ = types.from_old_type(&num_type);
+                constraints.push_type(types, typ)
+            };
 
             // Link the free num var with the int var and our expectation.
-            let int_type = constraints.push_type(
-                types,
-                types.from_old_type(&builtins::num_int(Type::Variable(precision_var))),
-            );
+            let int_type = {
+                let typ = types.from_old_type(&builtins::num_int(Type::Variable(precision_var)));
+                constraints.push_type(types, typ)
+            };
 
             state.constraints.push({
                 let expected_index =
@@ -325,13 +331,16 @@ pub fn constrain_pattern(
                 region,
                 Category::Frac,
             );
-            let num_type_index = constraints.push_type(types, types.from_old_type(&num_type)); // NOTE: check me if something breaks!
+            let num_type_index = {
+                let typ = types.from_old_type(&num_type);
+                constraints.push_type(types, typ)
+            }; // NOTE: check me if something breaks!
 
             // Link the free num var with the float var and our expectation.
-            let float_type = constraints.push_type(
-                types,
-                types.from_old_type(&builtins::num_float(Type::Variable(precision_var))),
-            );
+            let float_type = {
+                let typ = types.from_old_type(&builtins::num_float(Type::Variable(precision_var)));
+                constraints.push_type(types, typ)
+            };
 
             state.constraints.push({
                 let expected_index =
@@ -350,7 +359,10 @@ pub fn constrain_pattern(
 
         StrLiteral(_) => {
             // TODO(types-soa) use Types::STR
-            let str_type = constraints.push_type(types, types.from_old_type(&builtins::str_type()));
+            let str_type = {
+                let typ = types.from_old_type(&builtins::str_type());
+                constraints.push_type(types, typ)
+            };
             state.constraints.push(constraints.equal_pattern_types(
                 str_type,
                 expected,
@@ -373,13 +385,16 @@ pub fn constrain_pattern(
                 Category::Int,
             );
 
-            let num_type_index = constraints.push_type(types, types.from_old_type(&num_type));
+            let num_type_index = {
+                let typ = types.from_old_type(&num_type);
+                constraints.push_type(types, typ)
+            };
 
             // Link the free num var with the int var and our expectation.
-            let int_type = constraints.push_type(
-                types,
-                types.from_old_type(&builtins::num_int(Type::Variable(precision_var))),
-            );
+            let int_type = {
+                let typ = types.from_old_type(&builtins::num_int(Type::Variable(precision_var)));
+                constraints.push_type(types, typ)
+            };
 
             state.constraints.push({
                 let expected_index =
@@ -426,7 +441,7 @@ pub fn constrain_pattern(
                 let pat_type = Type::Variable(*var);
                 let pat_type_index =
                     // TODO(types-soa) use variable here instead
-                    constraints.push_type(types, types.from_old_type(&pat_type.clone()));
+                    { let typ = types.from_old_type(&pat_type.clone()); constraints.push_type(types, typ) };
                 let expected =
                     constraints.push_pat_expected_type(PExpected::NoExpectation(pat_type_index));
 
@@ -513,13 +528,13 @@ pub fn constrain_pattern(
                 state.vars.push(*var);
             }
 
-            let record_type = constraints.push_type(
-                types,
-                types.from_old_type(&Type::Record(
+            let record_type = {
+                let typ = types.from_old_type(&Type::Record(
                     field_types,
                     TypeExtension::from_type(ext_type),
-                )),
-            );
+                ));
+                constraints.push_type(types, typ)
+            };
 
             let whole_var_index = constraints.push_variable(*whole_var);
             let expected_record =
@@ -572,14 +587,14 @@ pub fn constrain_pattern(
             }
 
             let list_var_index = constraints.push_variable(*list_var);
-            let solved_list = constraints.push_type(
-                types,
-                types.from_old_type(&Type::Apply(
+            let solved_list = {
+                let typ = types.from_old_type(&Type::Apply(
                     Symbol::LIST_LIST,
                     vec![Loc::at(region, Type::Variable(*elem_var))],
                     region,
-                )),
-            );
+                ));
+                constraints.push_type(types, typ)
+            };
             let store_solved_list = constraints.store(solved_list, *list_var, file!(), line!());
 
             let expected_constraint = constraints.pattern_presence(
@@ -661,9 +676,8 @@ pub fn constrain_pattern(
             let arg_pattern_type = Type::Variable(*arg_pattern_var);
             let arg_pattern_type_index = constraints.push_variable(*arg_pattern_var);
 
-            let opaque_type = constraints.push_type(
-                types,
-                types.from_old_type(&Type::Alias {
+            let opaque_type = {
+                let typ = types.from_old_type(&Type::Alias {
                     symbol: *opaque,
                     type_arguments: type_arguments
                         .iter()
@@ -676,8 +690,9 @@ pub fn constrain_pattern(
                     infer_ext_in_output_types: vec![],
                     actual: Box::new(arg_pattern_type.clone()),
                     kind: AliasKind::Opaque,
-                }),
-            );
+                });
+                constraints.push_type(types, typ)
+            };
 
             // First, add a constraint for the argument "who"
             let arg_pattern_expected = constraints
@@ -716,13 +731,15 @@ pub fn constrain_pattern(
             // This must **always** be a presence constraint, that is enforcing
             // `[A k1, B k1] += typeof (A s)`, because we are in a destructure position and not
             // all constructors are covered in this branch!
-            let arg_pattern_type = constraints.push_type(
-                types,
+            let arg_pattern_type = {
                 // TODO(types-soa) this is just a variable
-                types.from_old_type(&arg_pattern_type),
-            );
-            let specialized_type_index =
-                constraints.push_type(types, types.from_old_type(&(**specialized_def_type)));
+                let typ = types.from_old_type(&arg_pattern_type);
+                constraints.push_type(types, typ)
+            };
+            let specialized_type_index = {
+                let typ = types.from_old_type(&(**specialized_def_type));
+                constraints.push_type(types, typ)
+            };
             let specialized_type_expected = constraints
                 .push_pat_expected_type(PExpected::NoExpectation(specialized_type_index));
 

--- a/crates/compiler/constrain/src/pattern.rs
+++ b/crates/compiler/constrain/src/pattern.rs
@@ -667,7 +667,6 @@ pub fn constrain_pattern(
         } => {
             // Suppose we are constraining the pattern \@Id who, where Id n := [Id U64 n]
             let (arg_pattern_var, loc_arg_pattern) = &**argument;
-            let arg_pattern_type = Type::Variable(*arg_pattern_var);
             let arg_pattern_type_index = constraints.push_variable(*arg_pattern_var);
 
             let opaque_type = {
@@ -682,7 +681,7 @@ pub fn constrain_pattern(
                         .collect(),
                     lambda_set_variables: lambda_set_variables.clone(),
                     infer_ext_in_output_types: vec![],
-                    actual: Box::new(arg_pattern_type.clone()),
+                    actual: Box::new(Type::Variable(*arg_pattern_var)),
                     kind: AliasKind::Opaque,
                 });
                 constraints.push_type(types, typ)

--- a/crates/compiler/constrain/src/pattern.rs
+++ b/crates/compiler/constrain/src/pattern.rs
@@ -725,11 +725,7 @@ pub fn constrain_pattern(
             // This must **always** be a presence constraint, that is enforcing
             // `[A k1, B k1] += typeof (A s)`, because we are in a destructure position and not
             // all constructors are covered in this branch!
-            let arg_pattern_type = {
-                // TODO(types-soa) this is just a variable
-                let typ = types.from_old_type(&arg_pattern_type);
-                constraints.push_type(types, typ)
-            };
+            let arg_pattern_type = constraints.push_variable(*arg_pattern_var);
             let specialized_type_index = {
                 let typ = types.from_old_type(&(**specialized_def_type));
                 constraints.push_type(types, typ)

--- a/crates/compiler/load_internal/src/file.rs
+++ b/crates/compiler/load_internal/src/file.rs
@@ -4713,7 +4713,7 @@ fn canonicalize_and_constrain<'a>(
         &symbols_from_requires,
         &mut var_store,
     );
-    let types = Types::new();
+    let mut types = Types::new();
 
     // _after has an underscore because it's unused in --release builds
     let _after = roc_types::types::get_type_clone_count();

--- a/crates/compiler/load_internal/src/file.rs
+++ b/crates/compiler/load_internal/src/file.rs
@@ -49,7 +49,7 @@ use roc_solve::module::{extract_module_owned_implementations, Solved, SolvedModu
 use roc_solve_problem::TypeError;
 use roc_target::TargetInfo;
 use roc_types::subs::{ExposedTypesStorageSubs, Subs, VarStore, Variable};
-use roc_types::types::{Alias, AliasKind};
+use roc_types::types::{Alias, AliasKind, Types};
 use std::collections::hash_map::Entry::{Occupied, Vacant};
 use std::collections::HashMap;
 use std::env::current_dir;
@@ -646,6 +646,7 @@ struct ConstrainedModule {
     var_store: VarStore,
     dep_idents: IdentIdsByModule,
     module_timing: ModuleTiming,
+    types: Types,
     // Rather than adding pending derives as constraints, hand them directly to solve because they
     // must be solved at the end of a module.
     pending_derives: PendingDerives,
@@ -4703,6 +4704,7 @@ fn canonicalize_and_constrain<'a>(
         &symbols_from_requires,
         &mut var_store,
     );
+    let types = Types::new();
 
     // _after has an underscore because it's unused in --release builds
     let _after = roc_types::types::get_type_clone_count();
@@ -4817,6 +4819,7 @@ fn canonicalize_and_constrain<'a>(
         ident_ids: module_output.scope.locals.ident_ids,
         dep_idents,
         module_timing,
+        types,
         pending_derives: module_output.pending_derives,
     };
 

--- a/crates/compiler/load_internal/src/file.rs
+++ b/crates/compiler/load_internal/src/file.rs
@@ -4409,7 +4409,7 @@ pub fn add_imports(
 #[allow(clippy::complexity)]
 fn run_solve_solve(
     exposed_for_module: ExposedForModule,
-    types: Types,
+    mut types: Types,
     mut constraints: Constraints,
     constraint: ConstraintSoa,
     pending_derives: PendingDerives,
@@ -4451,7 +4451,7 @@ fn run_solve_solve(
 
     let mut solve_aliases = roc_solve::solve::Aliases::with_capacity(aliases.len());
     for (name, (_, alias)) in aliases.iter() {
-        solve_aliases.insert(*name, alias.clone());
+        solve_aliases.insert(&mut types, *name, alias.clone());
     }
 
     let (solved_subs, solved_implementations, exposed_vars_by_symbol, problems, abilities_store) = {

--- a/crates/compiler/load_internal/src/file.rs
+++ b/crates/compiler/load_internal/src/file.rs
@@ -4282,8 +4282,6 @@ pub fn add_imports(
     def_types: &mut Vec<(Symbol, Loc<TypeOrVar>)>,
     rigid_vars: &mut Vec<Variable>,
 ) -> (Vec<Variable>, AbilitiesStore) {
-    use roc_types::types::Type;
-
     let mut import_variables = Vec::new();
 
     let mut cached_symbol_vars = VecMap::default();

--- a/crates/compiler/load_internal/src/file.rs
+++ b/crates/compiler/load_internal/src/file.rs
@@ -384,6 +384,7 @@ fn start_phase<'a>(
                     declarations,
                     dep_idents,
                     pending_derives,
+                    types,
                     ..
                 } = constrained;
 
@@ -393,6 +394,7 @@ fn start_phase<'a>(
                     module,
                     ident_ids,
                     module_timing,
+                    types,
                     constraints,
                     constraint,
                     pending_derives,
@@ -1096,6 +1098,7 @@ enum BuildTask<'a> {
         ident_ids: IdentIds,
         exposed_for_module: ExposedForModule,
         module_timing: ModuleTiming,
+        types: Types,
         constraints: Constraints,
         constraint: ConstraintSoa,
         pending_derives: PendingDerives,
@@ -4195,6 +4198,7 @@ impl<'a> BuildTask<'a> {
         module: Module,
         ident_ids: IdentIds,
         module_timing: ModuleTiming,
+        types: Types,
         constraints: Constraints,
         constraint: ConstraintSoa,
         pending_derives: PendingDerives,
@@ -4216,6 +4220,7 @@ impl<'a> BuildTask<'a> {
             module,
             ident_ids,
             exposed_for_module,
+            types,
             constraints,
             constraint,
             pending_derives,
@@ -4404,6 +4409,7 @@ pub fn add_imports(
 #[allow(clippy::complexity)]
 fn run_solve_solve(
     exposed_for_module: ExposedForModule,
+    types: Types,
     mut constraints: Constraints,
     constraint: ConstraintSoa,
     pending_derives: PendingDerives,
@@ -4454,6 +4460,7 @@ fn run_solve_solve(
 
         let (solved_subs, solved_env, problems, abilities_store) = roc_solve::module::run_solve(
             module_id,
+            types,
             &constraints,
             actual_constraint,
             rigid_variables,
@@ -4512,6 +4519,7 @@ fn run_solve<'a>(
     ident_ids: IdentIds,
     mut module_timing: ModuleTiming,
     exposed_for_module: ExposedForModule,
+    types: Types,
     constraints: Constraints,
     constraint: ConstraintSoa,
     pending_derives: PendingDerives,
@@ -4537,6 +4545,7 @@ fn run_solve<'a>(
             match cached_types.lock().remove(&module_id) {
                 None => run_solve_solve(
                     exposed_for_module,
+                    types,
                     constraints,
                     constraint,
                     pending_derives,
@@ -4560,6 +4569,7 @@ fn run_solve<'a>(
         } else {
             run_solve_solve(
                 exposed_for_module,
+                types,
                 constraints,
                 constraint,
                 pending_derives,
@@ -5590,6 +5600,7 @@ fn run_task<'a>(
             module,
             module_timing,
             exposed_for_module,
+            types,
             constraints,
             constraint,
             pending_derives,
@@ -5604,6 +5615,7 @@ fn run_task<'a>(
             ident_ids,
             module_timing,
             exposed_for_module,
+            types,
             constraints,
             constraint,
             pending_derives,

--- a/crates/compiler/load_internal/src/file.rs
+++ b/crates/compiler/load_internal/src/file.rs
@@ -4449,7 +4449,7 @@ fn run_solve_solve(
     let actual_constraint =
         constraints.let_import_constraint(rigid_vars, def_types, constraint, &import_variables);
 
-    let mut solve_aliases = roc_solve::solve::Aliases::default();
+    let mut solve_aliases = roc_solve::solve::Aliases::with_capacity(aliases.len());
     for (name, (_, alias)) in aliases.iter() {
         solve_aliases.insert(*name, alias.clone());
     }

--- a/crates/compiler/load_internal/src/file.rs
+++ b/crates/compiler/load_internal/src/file.rs
@@ -4308,7 +4308,7 @@ pub fn add_imports(
                     };
 
                     let copied_import = exposed_types.storage_subs.export_variable_to($subs, variable);
-                    let copied_import_index = constraints.push_type(Type::Variable(copied_import.variable));
+                    let copied_import_index = constraints.push_variable(copied_import.variable);
 
                     def_types.push((
                         $symbol,
@@ -4343,7 +4343,7 @@ pub fn add_imports(
     if my_module == ModuleId::NUM {
         // Num needs List.len, but List imports Num.
         let list_len_type_var = synth_list_len_type(subs);
-        let list_len_type_index = constraints.push_type(Type::Variable(list_len_type_var));
+        let list_len_type_index = constraints.push_variable(list_len_type_var);
         def_types.push((Symbol::LIST_LEN, Loc::at_zero(list_len_type_index)));
         import_variables.push(list_len_type_var);
     }
@@ -4757,6 +4757,7 @@ fn canonicalize_and_constrain<'a>(
         roc_can::constraint::Constraint::True
     } else {
         constrain_module(
+            &mut types,
             &mut constraints,
             module_output.symbols_from_requires,
             &module_output.scope.abilities_store,

--- a/crates/compiler/solve/src/ability.rs
+++ b/crates/compiler/solve/src/ability.rs
@@ -13,7 +13,7 @@ use roc_types::subs::{
     instantiate_rigids, Content, FlatType, GetSubsSlice, Rank, RecordFields, Subs, SubsSlice,
     Variable,
 };
-use roc_types::types::{AliasKind, Category, MemberImpl, PatternCategory, Polarity};
+use roc_types::types::{AliasKind, Category, MemberImpl, PatternCategory, Polarity, Types};
 use roc_unify::unify::{Env, MustImplementConstraints};
 use roc_unify::unify::{MustImplementAbility, Obligated};
 
@@ -53,6 +53,7 @@ pub struct PendingDerivesTable(
 impl PendingDerivesTable {
     pub fn new(
         subs: &mut Subs,
+        types: &mut Types,
         aliases: &mut Aliases,
         pending_derives: PendingDerives,
         problems: &mut Vec<TypeError>,
@@ -81,6 +82,7 @@ impl PendingDerivesTable {
                     abilities_store,
                     obligation_cache,
                     &mut Pools::default(),
+                    types,
                     aliases,
                     &typ,
                 );

--- a/crates/compiler/solve/src/ability.rs
+++ b/crates/compiler/solve/src/ability.rs
@@ -75,6 +75,7 @@ impl PendingDerivesTable {
                 let derive_key = RequestedDeriveKey { opaque, ability };
 
                 // Neither rank nor pools should matter here.
+                let typ = types.from_old_type(&typ);
                 let opaque_var = type_to_var(
                     subs,
                     Rank::toplevel(),
@@ -84,7 +85,7 @@ impl PendingDerivesTable {
                     &mut Pools::default(),
                     types,
                     aliases,
-                    &typ,
+                    typ,
                 );
                 let real_var = match subs.get_content_without_compacting(opaque_var) {
                     Content::Alias(_, _, real_var, AliasKind::Opaque) => real_var,

--- a/crates/compiler/solve/src/module.rs
+++ b/crates/compiler/solve/src/module.rs
@@ -10,7 +10,7 @@ use roc_error_macros::internal_error;
 use roc_module::symbol::{ModuleId, Symbol};
 use roc_solve_problem::TypeError;
 use roc_types::subs::{Content, ExposedTypesStorageSubs, FlatType, StorageSubs, Subs, Variable};
-use roc_types::types::{Alias, MemberImpl};
+use roc_types::types::{Alias, MemberImpl, Types};
 
 /// A marker that a given Subs has been solved.
 /// The only way to obtain a Solved<Subs> is by running the solver on it.
@@ -56,6 +56,7 @@ pub struct SolvedModule {
 #[allow(clippy::too_many_arguments)] // TODO: put params in a context/env var
 pub fn run_solve(
     home: ModuleId,
+    types: Types,
     constraints: &Constraints,
     constraint: ConstraintSoa,
     rigid_variables: RigidVariables,
@@ -85,6 +86,7 @@ pub fn run_solve(
     // Run the solver to populate Subs.
     let (solved_subs, solved_env) = solve::run(
         home,
+        types,
         constraints,
         &mut problems,
         subs,

--- a/crates/compiler/solve/src/solve.rs
+++ b/crates/compiler/solve/src/solve.rs
@@ -287,6 +287,18 @@ impl Aliases {
 
                 Some((num_content_var, AliasKind::Structural))
             }
+            Symbol::NUM_SIGNED8 => Some((Variable::SIGNED8, AliasKind::Opaque)),
+            Symbol::NUM_SIGNED16 => Some((Variable::SIGNED16, AliasKind::Opaque)),
+            Symbol::NUM_SIGNED32 => Some((Variable::SIGNED32, AliasKind::Opaque)),
+            Symbol::NUM_SIGNED64 => Some((Variable::SIGNED64, AliasKind::Opaque)),
+            Symbol::NUM_SIGNED128 => Some((Variable::SIGNED128, AliasKind::Opaque)),
+            Symbol::NUM_UNSIGNED8 => Some((Variable::UNSIGNED8, AliasKind::Opaque)),
+            Symbol::NUM_UNSIGNED16 => Some((Variable::UNSIGNED16, AliasKind::Opaque)),
+            Symbol::NUM_UNSIGNED32 => Some((Variable::UNSIGNED32, AliasKind::Opaque)),
+            Symbol::NUM_UNSIGNED64 => Some((Variable::UNSIGNED64, AliasKind::Opaque)),
+            Symbol::NUM_UNSIGNED128 => Some((Variable::UNSIGNED128, AliasKind::Opaque)),
+            Symbol::NUM_BINARY32 => Some((Variable::BINARY32, AliasKind::Opaque)),
+            Symbol::NUM_BINARY64 => Some((Variable::BINARY64, AliasKind::Opaque)),
             _ => None,
         }
     }

--- a/crates/compiler/solve/src/solve.rs
+++ b/crates/compiler/solve/src/solve.rs
@@ -143,6 +143,13 @@ pub struct Aliases {
 }
 
 impl Aliases {
+    pub fn with_capacity(cap: usize) -> Self {
+        Self {
+            aliases: Vec::with_capacity(cap),
+            variables: Vec::with_capacity(cap * 2),
+        }
+    }
+
     pub fn insert(&mut self, symbol: Symbol, alias: Alias) {
         let alias_variables =
             {

--- a/crates/compiler/solve/src/solve.rs
+++ b/crates/compiler/solve/src/solve.rs
@@ -2263,7 +2263,7 @@ fn type_cell_to_var(
     pools: &mut Pools,
     types: &mut Types,
     aliases: &mut Aliases,
-    typ_cell: &Cell<Type>,
+    typ_cell: &Cell<Index<TypeTag>>,
 ) -> Variable {
     let typ = typ_cell.replace(Type::EmptyTagUnion);
     let var = type_to_var(

--- a/crates/compiler/test_derive/src/util.rs
+++ b/crates/compiler/test_derive/src/util.rs
@@ -20,7 +20,7 @@ use roc_constrain::expr::constrain_decls;
 use roc_debug_flags::dbg_do;
 use roc_derive::DerivedModule;
 use roc_derive_key::{DeriveBuiltin, DeriveError, DeriveKey, Derived};
-use roc_load_internal::file::{add_imports, default_aliases, LoadedModule, Threading};
+use roc_load_internal::file::{add_imports, LoadedModule, Threading};
 use roc_module::symbol::{IdentIds, Interns, ModuleId, Symbol};
 use roc_region::all::LineInfo;
 use roc_reporting::report::{type_problem, RocDocAllocator};
@@ -399,7 +399,7 @@ fn check_derived_typechecks_and_golden(
         constr,
         RigidVariables::default(),
         test_subs,
-        default_aliases(),
+        Default::default(),
         abilities_store,
         Default::default(),
         &exposed_for_module.exposed_by_module,

--- a/crates/compiler/test_derive/src/util.rs
+++ b/crates/compiler/test_derive/src/util.rs
@@ -27,6 +27,7 @@ use roc_reporting::report::{type_problem, RocDocAllocator};
 use roc_types::{
     pretty_print::{name_and_print_var, DebugPrint},
     subs::{ExposedTypesStorageSubs, Subs, Variable},
+    types::Types,
 };
 
 const DERIVED_MODULE: ModuleId = ModuleId::DERIVED_SYNTH;
@@ -343,11 +344,12 @@ fn check_derived_typechecks_and_golden(
     check_golden: impl Fn(&str),
 ) {
     // constrain the derived
+    let mut types = Types::new();
     let mut constraints = Constraints::new();
     let def_var = derived_def.expr_var;
     let mut decls = Declarations::new();
     decls.push_def(derived_def);
-    let constr = constrain_decls(&mut constraints, test_module, &decls);
+    let constr = constrain_decls(&mut types, &mut constraints, test_module, &decls);
 
     // the derived implementation on stuff from the builtin module, so
     //   - we need to add those dependencies as imported on the constraint
@@ -394,7 +396,7 @@ fn check_derived_typechecks_and_golden(
     );
     let (mut solved_subs, _, problems, _) = roc_solve::module::run_solve(
         test_module,
-        Default::default(),
+        types,
         &constraints,
         constr,
         RigidVariables::default(),

--- a/crates/compiler/test_derive/src/util.rs
+++ b/crates/compiler/test_derive/src/util.rs
@@ -394,6 +394,7 @@ fn check_derived_typechecks_and_golden(
     );
     let (mut solved_subs, _, problems, _) = roc_solve::module::run_solve(
         test_module,
+        Default::default(),
         &constraints,
         constr,
         RigidVariables::default(),

--- a/crates/compiler/test_gen/src/gen_primitives.rs
+++ b/crates/compiler/test_gen/src/gen_primitives.rs
@@ -4031,25 +4031,6 @@ fn mutually_recursive_captures() {
 
 #[test]
 #[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
-fn monomorphization_sees_polymorphic_recursion() {
-    assert_evals_to!(
-        indoc!(
-            r#"
-            foo : a, Bool -> Str
-            foo = \in, b -> if b then "done" else bar in
-
-            bar = \_ -> foo {} Bool.true
-
-            foo "" Bool.false
-            "#
-        ),
-        RocStr::from("done"),
-        RocStr
-    );
-}
-
-#[test]
-#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
 fn int_let_generalization() {
     assert_evals_to!(
         indoc!(

--- a/crates/compiler/types/src/types.rs
+++ b/crates/compiler/types/src/types.rs
@@ -365,6 +365,7 @@ impl std::ops::Neg for Polarity {
     }
 }
 
+#[derive(Debug)]
 pub struct AliasShared {
     pub symbol: Symbol,
     pub type_argument_abilities: Slice<AbilitySet>,
@@ -456,6 +457,7 @@ impl AsideTypeSlice {
 /// the [type solving representation][crate::subs::Content] of types.
 ///
 /// See [TypeTag].
+#[derive(Debug)]
 pub struct Types {
     // main storage. Each type is represented by a tag, which is identified by its index.
     // `tags_slices` is a parallel array (so these two vectors always have the same size), that

--- a/crates/compiler/types/src/types.rs
+++ b/crates/compiler/types/src/types.rs
@@ -586,6 +586,13 @@ impl Types {
         (tags, payload_slices)
     }
 
+    /// # Safety
+    ///
+    /// May only be called if `var` is known to represent the type at `index`.
+    pub unsafe fn set_variable(&mut self, index: Index<TypeTag>, var: Variable) {
+        self.tags[index.index()] = TypeTag::Variable(var);
+    }
+
     fn reserve_type_tags(&mut self, length: usize) -> Slice<TypeTag> {
         use std::iter::repeat;
 

--- a/crates/compiler/types/src/types.rs
+++ b/crates/compiler/types/src/types.rs
@@ -620,8 +620,9 @@ impl Types {
     }
 
     #[allow(clippy::wrong_self_convention)]
-    pub fn from_old_type_slice<'a, B>(
+    pub fn from_old_type_slice<B>(
         &mut self,
+        // evil, but allows us to emulate reference-polymorphism
         old: impl ExactSizeIterator<Item = B>,
     ) -> Slice<TypeTag>
     where

--- a/crates/compiler/types/src/types.rs
+++ b/crates/compiler/types/src/types.rs
@@ -375,7 +375,7 @@ pub struct AliasShared {
 }
 
 /// The tag (head constructor) of a canonical type stored in [Types].
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub enum TypeTag {
     EmptyRecord,
     EmptyTagUnion,
@@ -613,14 +613,17 @@ impl Types {
     }
 
     #[allow(clippy::wrong_self_convention)]
-    pub fn from_old_type_slice<'a>(
+    pub fn from_old_type_slice<'a, B>(
         &mut self,
-        old: impl ExactSizeIterator<Item = &'a Type>,
-    ) -> Slice<TypeTag> {
+        old: impl ExactSizeIterator<Item = B>,
+    ) -> Slice<TypeTag>
+    where
+        B: std::borrow::Borrow<Type>,
+    {
         let slice = self.reserve_type_tags(old.len());
 
         for (index, argument) in slice.into_iter().zip(old) {
-            self.from_old_type_at(index, argument);
+            self.from_old_type_at(index, argument.borrow());
         }
 
         slice

--- a/crates/reporting/tests/helpers/mod.rs
+++ b/crates/reporting/tests/helpers/mod.rs
@@ -143,11 +143,12 @@ pub fn can_expr_with<'a>(
         }
     };
 
+    let mut types = Types::new();
     let mut constraints = Constraints::new();
 
     let mut var_store = VarStore::default();
     let var = var_store.fresh();
-    let var_index = constraints.push_type(Type::Variable(var));
+    let var_index = constraints.push_variable(var);
     let expected = constraints.push_expected_type(Expected::NoExpectation(var_index));
     let mut module_ids = ModuleIds::default();
 
@@ -176,6 +177,7 @@ pub fn can_expr_with<'a>(
     );
 
     let constraint = constrain_expr(
+        &mut types,
         &mut constraints,
         &mut roc_constrain::expr::Env {
             rigids: MutMap::default(),
@@ -205,7 +207,7 @@ pub fn can_expr_with<'a>(
         var,
         constraint,
         constraints,
-        types: Default::default(),
+        types,
     })
 }
 

--- a/crates/reporting/tests/helpers/mod.rs
+++ b/crates/reporting/tests/helpers/mod.rs
@@ -41,6 +41,7 @@ pub fn infer_expr(
 ) -> (Content, Subs) {
     let (solved, _) = solve::run(
         ModuleId::ATTR,
+        Default::default(),
         constraints,
         problems,
         subs,

--- a/crates/reporting/tests/helpers/mod.rs
+++ b/crates/reporting/tests/helpers/mod.rs
@@ -18,7 +18,7 @@ use roc_region::all::Loc;
 use roc_solve::solve::{self, Aliases};
 use roc_solve_problem::TypeError;
 use roc_types::subs::{Content, Subs, VarStore, Variable};
-use roc_types::types::{Type, Types};
+use roc_types::types::Types;
 use std::hash::Hash;
 use std::path::{Path, PathBuf};
 

--- a/crates/reporting/tests/helpers/mod.rs
+++ b/crates/reporting/tests/helpers/mod.rs
@@ -18,7 +18,7 @@ use roc_region::all::Loc;
 use roc_solve::solve::{self, Aliases};
 use roc_solve_problem::TypeError;
 use roc_types::subs::{Content, Subs, VarStore, Variable};
-use roc_types::types::Type;
+use roc_types::types::{Type, Types};
 use std::hash::Hash;
 use std::path::{Path, PathBuf};
 
@@ -31,6 +31,7 @@ pub fn test_home() -> ModuleId {
 pub fn infer_expr(
     subs: Subs,
     problems: &mut Vec<TypeError>,
+    types: Types,
     constraints: &Constraints,
     constraint: &Constraint,
     pending_derives: PendingDerives,
@@ -41,7 +42,7 @@ pub fn infer_expr(
 ) -> (Content, Subs) {
     let (solved, _) = solve::run(
         ModuleId::ATTR,
-        Default::default(),
+        types,
         constraints,
         problems,
         subs,
@@ -113,6 +114,7 @@ pub struct CanExprOut {
     pub var: Variable,
     pub constraint: Constraint,
     pub constraints: Constraints,
+    pub types: Types,
 }
 
 #[derive(Debug)]
@@ -203,6 +205,7 @@ pub fn can_expr_with<'a>(
         var,
         constraint,
         constraints,
+        types: Default::default(),
     })
 }
 

--- a/crates/reporting/tests/test_reporting.rs
+++ b/crates/reporting/tests/test_reporting.rs
@@ -1143,20 +1143,20 @@ mod test_reporting {
         @r###"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
-    This expression is used in an unexpected way:
+    This 1st argument to `f` has an unexpected type:
 
     7│      g = \x -> f [x]
-                      ^^^^^
+                        ^^^
 
-    This `f` call produces:
-
-        List List b
-
-    But you are trying to use it as:
+    The argument is a list of type:
 
         List b
 
-    Tip: The type annotation uses the type variable `b` to say that this
+    But `f` needs its 1st argument to be:
+
+        a
+
+    Tip: The type annotation uses the type variable `a` to say that this
     definition can produce any type of value. But in the body I see that
     it will only produce a `List` value of a single specific type. Maybe
     change the type annotation to be more specific? Maybe change the code

--- a/crates/reporting/tests/test_reporting.rs
+++ b/crates/reporting/tests/test_reporting.rs
@@ -12415,4 +12415,40 @@ All branches in an `if` must have the same type!
             "#
         )
     );
+
+    test_report!(
+        polymorphic_recursion_forces_ungeneralized_type,
+        indoc!(
+            r#"
+            foo : a, Bool -> Str
+            foo = \in, b -> if b then "done" else bar in
+
+            bar = \_ -> foo {} Bool.true
+
+            foo "" Bool.false
+            "#
+        ),
+    @r###"
+    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+
+    This 1st argument to `foo` has an unexpected type:
+
+    9│      foo "" Bool.false
+                ^^
+
+    The argument is a string of type:
+
+        Str
+
+    But `foo` needs its 1st argument to be:
+
+        a
+
+    Tip: The type annotation uses the type variable `a` to say that this
+    definition can produce any type of value. But in the body I see that
+    it will only produce a `Str` value of a single specific type. Maybe
+    change the type annotation to be more specific? Maybe change the code
+    to be more general?
+    "###
+    );
 }

--- a/crates/reporting/tests/test_reporting.rs
+++ b/crates/reporting/tests/test_reporting.rs
@@ -202,6 +202,7 @@ mod test_reporting {
             home,
             interns,
             problems: can_problems,
+            mut types,
             ..
         } = can_expr(arena, expr_src)?;
         let mut subs = Subs::new_from_varstore(var_store);
@@ -217,7 +218,7 @@ mod test_reporting {
         let mut solve_aliases = roc_solve::solve::Aliases::default();
 
         for (name, alias) in output.aliases {
-            solve_aliases.insert(name, alias);
+            solve_aliases.insert(&mut types, name, alias);
         }
 
         let mut unify_problems = Vec::new();
@@ -225,6 +226,7 @@ mod test_reporting {
         let (_content, _subs) = infer_expr(
             subs,
             &mut unify_problems,
+            types,
             &constraints,
             &constraint,
             // Use `new_report_problem_as` in order to get proper derives.


### PR DESCRIPTION
Pushes the SoA representation of types even earlier, so that types are now stored into the SoA representation during constraining. The next step is to do this during canonicalization, at which point we can eliminate `Index<Type>` in constraining, apply the `EitherIndex` Variable optimization in types SoA, and hopefully have solved the type emplacement problem.