### PR TITLE
Fixes for WebAssembly platform-switching example

### DIFF
--- a/examples/platform-switching/web-assembly-platform/README.md
+++ b/examples/platform-switching/web-assembly-platform/README.md
@@ -3,20 +3,25 @@
 To run this website, first compile either of these identical apps:
 
 ```bash
-# Option A: Compile examples/platform-switching/rocLovesWebAssembly.roc
-cargo run -- build --target=wasm32 examples/platform-switching/rocLovesWebAssembly.roc
-
-# Option B: Compile examples/platform-switching/main.roc with `pf: "web-assembly-platform/main.roc"` and move the result
-cargo run -- build --target=wasm32 examples/platform-switching/main.roc
-(cd examples/platform-switching && mv rocLovesPlatforms.wasm web-assembly-platform/rocLovesWebAssembly.wasm)
+# Build roc compiler if you have not done so already
+cargo build
+# Compile the app that uses the Wasm platform
+target/debug/roc build --target=wasm32 examples/platform-switching/rocLovesWebAssembly.roc
+# Go to the directory where index.html is
+cd examples/platform-switching/web-assembly-platform/
+# Move the .wasm file so that it's beside index.html
+mv ../rocLovesWebAssembly.wasm .
 ```
 
-Then `cd` into the website directory
-and run any web server that can handle WebAssembly.
-For example, with `http-server`:
+In the directory where index.html is, run any web server on localhost.
 
+For example if you have Python3 on your system, you can use `http.server`:
 ```bash
-cd examples/platform-switching/web-assembly-platform
+python3 -m http.server 8080
+```
+
+Or if you have npm, you can use `http-server`
+```bash
 npm install -g http-server
 http-server
 ```

--- a/examples/platform-switching/web-assembly-platform/README.md
+++ b/examples/platform-switching/web-assembly-platform/README.md
@@ -1,12 +1,19 @@
 # Hello, World!
 
-To run this website, first compile either of these identical apps:
+To run this website, we first compile the app that uses the Wasm platform:
 
+- If you use the nightly roc release:
+```bash
+./roc build --target=wasm32 examples/platform-switching/rocLovesWebAssembly.roc
+```
+- If you start from the compiler source code:
 ```bash
 # Build roc compiler if you have not done so already
 cargo build
-# Compile the app that uses the Wasm platform
 target/debug/roc build --target=wasm32 examples/platform-switching/rocLovesWebAssembly.roc
+```
+We then move the file:
+```bash
 # Go to the directory where index.html is
 cd examples/platform-switching/web-assembly-platform/
 # Move the .wasm file so that it's beside index.html

--- a/examples/platform-switching/web-assembly-platform/host.zig
+++ b/examples/platform-switching/web-assembly-platform/host.zig
@@ -1,22 +1,10 @@
-const std = @import("std");
 const str = @import("str");
 const builtin = @import("builtin");
 const RocStr = str.RocStr;
-const testing = std.testing;
-const expectEqual = testing.expectEqual;
-const expect = testing.expect;
 
 comptime {
-    // This is a workaround for https://github.com/ziglang/zig/issues/8218
-    // which is only necessary on macOS.
-    //
-    // Once that issue is fixed, we can undo the changes in
-    // 177cf12e0555147faa4d436e52fc15175c2c4ff0 and go back to passing
-    // -fcompiler-rt in link.rs instead of doing this. Note that this
-    // workaround is present in many host.zig files, so make sure to undo
-    // it everywhere!
-    if (builtin.os.tag == .macos) {
-        _ = @import("compiler_rt");
+    if (builtin.target.cpu.arch != .wasm32) {
+        @compileError("This platform is for WebAssembly only. You need to pass `--target wasm32` to the Roc compiler.");
     }
 }
 
@@ -51,12 +39,7 @@ export fn roc_memcpy(dest: *anyopaque, src: *anyopaque, count: usize) callconv(.
 
 // NOTE roc_panic is provided in the JS file, so it can throw an exception
 
-const mem = std.mem;
-const Allocator = mem.Allocator;
-
 extern fn roc__mainForHost_1_exposed(*RocStr) void;
-
-const Unit = extern struct {};
 
 extern fn js_display_roc_string(str_bytes: ?[*]u8, str_len: usize) void;
 


### PR DESCRIPTION
Cleaning up our Wasm example app.

- The readme instructions were wrong and didn't work! They also only gave an example of running a local http server with `npm`, so I added an option for Python too.
- The JavaScript mentioned that the WebAssembly streaming API was faster but didn't actually take full advantage of that! Fixed it and added comments.
- The Zig host contained a lot of unused code due to copy-pasting. This included some MacOS specific `comptime` code, which makes no sense in a host that only works on Wasm anyway.
