### PR TITLE
Pretty-printer for debug representation of SoA types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4136,6 +4136,7 @@ dependencies = [
  "roc_region",
  "roc_serialize",
  "static_assertions",
+ "ven_pretty",
 ]
 
 [[package]]

--- a/crates/compiler/types/Cargo.toml
+++ b/crates/compiler/types/Cargo.toml
@@ -15,3 +15,4 @@ roc_debug_flags = {path="../debug_flags"}
 roc_serialize = {path="../serialize"}
 bumpalo = { version = "3.11.0", features = ["collections"] }
 static_assertions = "1.1.0"
+ven_pretty = { path = "../../vendor/pretty" }

--- a/crates/compiler/types/src/num.rs
+++ b/crates/compiler/types/src/num.rs
@@ -36,7 +36,7 @@ impl NumericRange {
         width.signedness_and_width().1 >= at_least_width.signedness_and_width().1
     }
 
-    fn width(&self) -> IntLitWidth {
+    pub(crate) fn width(&self) -> IntLitWidth {
         use NumericRange::*;
         match self {
             IntAtLeastSigned(w)


### PR DESCRIPTION
```
[roc_load 0.0.1] [crates/compiler/solve/src/solve.rs:331] types.dbg(typ) = (`List.List` (`Num.U8`)), 68 -70->
[roc_load 0.0.1]   (`Decode.DecodeResult` 69
[roc_load 0.0.1]     ==> {result!: `Result.Result` 69 (`Decode.DecodeError` ==> [TooShort]73),
[roc_load 0.0.1]          rest!: `List.List` (`Num.U8`)})
```