### PR TITLE
add missing includes for clang 14

### DIFF
--- a/examples/parser/platform/host.c
+++ b/examples/parser/platform/host.c
@@ -5,6 +5,9 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <sys/shm.h> // shm_open
+#include <sys/mman.h> // for mmap
+#include <signal.h> // for kill
 
 //#define ROC_PLATFORM_DEBUG
 

--- a/examples/platform-switching/c-platform/host.c
+++ b/examples/platform-switching/c-platform/host.c
@@ -4,6 +4,9 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <sys/shm.h> // shm_open
+#include <sys/mman.h> // for mmap
+#include <signal.h> // for kill
 
 void* roc_alloc(size_t size, unsigned int alignment) { return malloc(size); }
 

--- a/examples/ruby-interop/platform/host.c
+++ b/examples/ruby-interop/platform/host.c
@@ -4,6 +4,9 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <sys/shm.h> // shm_open
+#include <sys/mman.h> // for mmap
+#include <signal.h> // for kill
 
 void* roc_alloc(size_t size, unsigned int alignment) { return malloc(size); }
 


### PR DESCRIPTION
I believe implicit declarations(=missing headers) used to be a warning in clang 13 but are now an error in clang 14.

This was the error caused by issue:
```
---- cli_run::platform_switching_main stdout ----
thread 'cli_run::platform_switching_main' panicked at '`roc` command had unexpected stderr: An internal compiler expectation was broken.
This is definitely a compiler bug.
Please file an issue here: https://github.com/roc-lang/roc/issues/new/choose
thread '<unnamed>' panicked at 'Error:
    Failed to rebuild host.c:
        The executed command was:
            "clang" "/Users/runner/work/roc/roc/examples/platform-switching/c-platform/host.c" "-o" "/Users/runner/work/roc/roc/examples/platform-switching/c-platform/host.o" "-fPIC" "-c"
        stderr of that command:
            /Users/runner/work/roc/roc/examples/platform-switching/c-platform/host.c:31:48: error: implicit declaration of function 'kill' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
int roc_send_signal(int pid, int sig) { return kill(pid, sig); }
                                               ^
/Users/runner/work/roc/roc/examples/platform-switching/c-platform/host.c:32:60: error: implicit declaration of function 'shm_open' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
int roc_shm_open(char* name, int oflag, int mode) { return shm_open(name, oflag, mode); }
                                                           ^
/Users/runner/work/roc/roc/examples/platform-switching/c-platform/host.c:33:90: error: implicit declaration of function 'mmap' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
void* roc_mmap(void* addr, int length, int prot, int flags, int fd, int offset) { return mmap(addr, length, prot, flags, fd, offset); }
                                                                                         ^
/Users/runner/work/roc/roc/examples/platform-switching/c-platform/host.c:33:90: warning: incompatible integer to pointer conversion returning 'int' from a function with result type 'void *' [-Wint-conversion]
void* roc_mmap(void* addr, int length, int prot, int flags, int fd, int offset) { return mmap(addr, length, prot, flags, fd, offset); }
                                                                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 warning and 3 errors generated.
', crates/compiler/build/src/link.rs:1363:27
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
thread 'main' panicked at 'Failed to (re)build platform.: Any { .. }', crates/cli/src/build.rs:301:46
', crates/cli/tests/cli_run.rs:118:13
```
This issue happened on the [macos x86_64 CI machine outside of nix](https://github.com/roc-lang/roc/actions/runs/3426784521/jobs/5710485040#step:8:915).
