### PR TITLE
Emplace variables after converting SoA types, and remove types from constraining

### DIFF
--- a/crates/compiler/can/src/constraint.rs
+++ b/crates/compiler/can/src/constraint.rs
@@ -8,7 +8,7 @@ use roc_module::ident::TagName;
 use roc_module::symbol::{ModuleId, Symbol};
 use roc_region::all::{Loc, Region};
 use roc_types::subs::{ExhaustiveMark, IllegalCycleMark, Variable};
-use roc_types::types::{Category, PatternCategory, TypeCell, TypeTag, Types};
+use roc_types::types::{Category, PatternCategory, TypeTag, Types};
 
 pub struct Constraints {
     pub constraints: Vec<Constraint>,
@@ -59,7 +59,7 @@ impl Default for Constraints {
 
 pub type ExpectedTypeIndex = Index<Expected<TypeOrVar>>;
 pub type PExpectedTypeIndex = Index<PExpected<TypeOrVar>>;
-pub type TypeOrVar = EitherIndex<TypeCell, Variable>;
+pub type TypeOrVar = EitherIndex<TypeTag, Variable>;
 
 impl Constraints {
     pub fn new() -> Self {
@@ -129,9 +129,9 @@ impl Constraints {
         }
     }
 
-    pub const EMPTY_RECORD: Index<Cell<Index<TypeCell>>> = Index::new(0);
-    pub const EMPTY_TAG_UNION: Index<Cell<Index<TypeCell>>> = Index::new(1);
-    pub const STR: Index<Cell<Index<TypeCell>>> = Index::new(2);
+    pub const EMPTY_RECORD: Index<Cell<Index<TypeTag>>> = Index::new(0);
+    pub const EMPTY_TAG_UNION: Index<Cell<Index<TypeTag>>> = Index::new(1);
+    pub const STR: Index<Cell<Index<TypeTag>>> = Index::new(2);
 
     pub const CATEGORY_RECORD: Index<Category> = Index::new(0);
     pub const CATEGORY_FOREIGNCALL: Index<Category> = Index::new(1);
@@ -161,8 +161,8 @@ impl Constraints {
     pub const PCATEGORY_CHARACTER: Index<PatternCategory> = Index::new(10);
 
     #[inline(always)]
-    pub fn push_type(&mut self, types: &Types, typ: Index<TypeCell>) -> TypeOrVar {
-        if let TypeTag::Variable(var) = types[typ].get() {
+    pub fn push_type(&mut self, types: &Types, typ: Index<TypeTag>) -> TypeOrVar {
+        if let TypeTag::Variable(var) = types[typ] {
             Self::push_type_variable(var)
         } else {
             EitherIndex::from_left(typ)

--- a/crates/compiler/can/src/constraint.rs
+++ b/crates/compiler/can/src/constraint.rs
@@ -8,11 +8,11 @@ use roc_module::ident::TagName;
 use roc_module::symbol::{ModuleId, Symbol};
 use roc_region::all::{Loc, Region};
 use roc_types::subs::{ExhaustiveMark, IllegalCycleMark, Variable};
-use roc_types::types::{Category, PatternCategory, TypeTag, Types};
+use roc_types::types::{Category, PatternCategory, TypeCell, TypeTag, Types};
 
 pub struct Constraints {
     pub constraints: Vec<Constraint>,
-    pub types: Vec<Cell<Index<TypeTag>>>,
+    pub types: Vec<Cell<Index<TypeCell>>>,
     pub type_slices: Vec<TypeOrVar>,
     pub variables: Vec<Variable>,
     pub loc_symbols: Vec<(Symbol, Region)>,
@@ -60,7 +60,7 @@ impl Default for Constraints {
 
 pub type ExpectedTypeIndex = Index<Expected<TypeOrVar>>;
 pub type PExpectedTypeIndex = Index<PExpected<TypeOrVar>>;
-pub type TypeOrVar = EitherIndex<Cell<Index<TypeTag>>, Variable>;
+pub type TypeOrVar = EitherIndex<Cell<Index<TypeCell>>, Variable>;
 
 impl Constraints {
     pub fn new() -> Self {
@@ -138,9 +138,9 @@ impl Constraints {
         }
     }
 
-    pub const EMPTY_RECORD: Index<Cell<Index<TypeTag>>> = Index::new(0);
-    pub const EMPTY_TAG_UNION: Index<Cell<Index<TypeTag>>> = Index::new(1);
-    pub const STR: Index<Cell<Index<TypeTag>>> = Index::new(2);
+    pub const EMPTY_RECORD: Index<Cell<Index<TypeCell>>> = Index::new(0);
+    pub const EMPTY_TAG_UNION: Index<Cell<Index<TypeCell>>> = Index::new(1);
+    pub const STR: Index<Cell<Index<TypeCell>>> = Index::new(2);
 
     pub const CATEGORY_RECORD: Index<Category> = Index::new(0);
     pub const CATEGORY_FOREIGNCALL: Index<Category> = Index::new(1);
@@ -173,9 +173,9 @@ impl Constraints {
     pub fn push_type(
         &mut self,
         types: &Types,
-        typ: Index<TypeTag>,
-    ) -> EitherIndex<Cell<Index<TypeTag>>, Variable> {
-        match types[typ] {
+        typ: Index<TypeCell>,
+    ) -> EitherIndex<Cell<Index<TypeCell>>, Variable> {
+        match types[typ].get() {
             TypeTag::EmptyRecord => EitherIndex::from_left(Self::EMPTY_RECORD),
             TypeTag::EmptyTagUnion => EitherIndex::from_left(Self::EMPTY_TAG_UNION),
             TypeTag::Apply {
@@ -184,7 +184,7 @@ impl Constraints {
             } => EitherIndex::from_left(Self::STR),
             TypeTag::Variable(var) => Self::push_type_variable(var),
             _ => {
-                let index: Index<Cell<Index<TypeTag>>> =
+                let index: Index<Cell<Index<TypeCell>>> =
                     Index::push_new(&mut self.types, Cell::new(typ));
                 EitherIndex::from_left(index)
             }

--- a/crates/compiler/constrain/src/expr.rs
+++ b/crates/compiler/constrain/src/expr.rs
@@ -30,7 +30,7 @@ use roc_region::all::{Loc, Region};
 use roc_types::subs::{IllegalCycleMark, Variable};
 use roc_types::types::Type::{self, *};
 use roc_types::types::{
-    AliasKind, AnnotationSource, Category, OptAbleType, PReason, Reason, RecordField, TypeCell,
+    AliasKind, AnnotationSource, Category, OptAbleType, PReason, Reason, RecordField,
     TypeExtension, TypeTag, Types,
 };
 
@@ -1608,7 +1608,7 @@ fn constrain_function_def(
 
             let signature_index = constraints.push_type(types, signature);
 
-            let (arg_types, signature_closure_type, ret_type) = match types[signature].get() {
+            let (arg_types, signature_closure_type, ret_type) = match types[signature] {
                 TypeTag::Function(signature_closure_type, ret_type) => (
                     types.get_type_arguments(signature),
                     signature_closure_type,
@@ -2503,7 +2503,7 @@ fn constrain_typed_def(
     //
     // This means we get errors like "the first argument of `f` is weird"
     // instead of the more generic "something is wrong with the body of `f`"
-    match (&def.loc_expr.value, types[signature].get()) {
+    match (&def.loc_expr.value, types[signature]) {
         (
             Closure(ClosureData {
                 function_type: fn_var,
@@ -2667,7 +2667,7 @@ fn constrain_typed_function_arguments(
     def_pattern_state: &mut PatternState,
     argument_pattern_state: &mut PatternState,
     arguments: &[(Variable, AnnotatedMark, Loc<Pattern>)],
-    arg_types: Slice<TypeCell>,
+    arg_types: Slice<TypeTag>,
 ) {
     // ensure type matches the one in the annotation
     let opt_label = if let Pattern::Identifier(label) = def.loc_pattern.value {
@@ -2805,7 +2805,7 @@ fn constrain_typed_function_arguments_simple(
     def_pattern_state: &mut PatternState,
     argument_pattern_state: &mut PatternState,
     arguments: &[(Variable, AnnotatedMark, Loc<Pattern>)],
-    arg_types: Slice<TypeCell>,
+    arg_types: Slice<TypeTag>,
 ) {
     let it = arguments.iter().zip(arg_types.into_iter()).enumerate();
     for (index, ((pattern_var, annotated_mark, loc_pattern), ann)) in it {
@@ -3094,7 +3094,7 @@ fn constrain_closure_size(
 }
 
 pub struct InstantiateRigids {
-    pub signature: Index<TypeCell>,
+    pub signature: Index<TypeTag>,
     pub new_rigid_variables: Vec<Variable>,
     pub new_infer_variables: Vec<Variable>,
 }
@@ -3321,7 +3321,7 @@ fn constraint_recursive_function(
                 signature_index,
             ));
 
-            let (arg_types, _signature_closure_type, ret_type) = match types[signature].get() {
+            let (arg_types, _signature_closure_type, ret_type) = match types[signature] {
                 TypeTag::Function(signature_closure_type, ret_type) => (
                     types.get_type_arguments(signature),
                     signature_closure_type,
@@ -3764,7 +3764,7 @@ fn rec_defs_help(
                 //
                 // This means we get errors like "the first argument of `f` is weird"
                 // instead of the more generic "something is wrong with the body of `f`"
-                match (&def.loc_expr.value, types[signature].get()) {
+                match (&def.loc_expr.value, types[signature]) {
                     (
                         Closure(ClosureData {
                             function_type: fn_var,

--- a/crates/compiler/constrain/src/pattern.rs
+++ b/crates/compiler/constrain/src/pattern.rs
@@ -769,7 +769,7 @@ pub fn constrain_pattern(
 fn could_be_a_tag_union(types: &Types, typ: TypeOrVar) -> bool {
     match typ.split() {
         Ok(typ_index) => !matches!(
-            types[typ_index].get(),
+            types[typ_index],
             TypeTag::Apply { .. } | TypeTag::Function(..) | TypeTag::Record(..)
         ),
         Err(_) => {

--- a/crates/compiler/constrain/src/pattern.rs
+++ b/crates/compiler/constrain/src/pattern.rs
@@ -771,7 +771,7 @@ fn could_be_a_tag_union(types: &Types, constraints: &mut Constraints, typ: TypeO
         Ok(typ_index) => {
             let typ_cell = &mut constraints.types[typ_index.index()];
             !matches!(
-                types[*typ_cell.get_mut()],
+                types[*typ_cell.get_mut()].get(),
                 TypeTag::Apply { .. } | TypeTag::Function(..) | TypeTag::Record(..)
             )
         }

--- a/crates/compiler/constrain/src/pattern.rs
+++ b/crates/compiler/constrain/src/pattern.rs
@@ -204,7 +204,7 @@ pub fn constrain_pattern(
             //     _ -> ""
             // so, we know that "x" (in this case, a tag union) must be open.
             let expected_type = *constraints[expected].get_type_ref();
-            if could_be_a_tag_union(types, constraints, expected_type) {
+            if could_be_a_tag_union(types, expected_type) {
                 state
                     .delayed_is_open_constraints
                     .push(constraints.is_open_type(expected_type));
@@ -218,7 +218,7 @@ pub fn constrain_pattern(
             let expected = &constraints[expected];
             let type_index = *expected.get_type_ref();
 
-            if could_be_a_tag_union(types, constraints, type_index) {
+            if could_be_a_tag_union(types, type_index) {
                 state
                     .delayed_is_open_constraints
                     .push(constraints.is_open_type(type_index));
@@ -240,7 +240,7 @@ pub fn constrain_pattern(
             let expected = &constraints[expected];
             let type_index = *expected.get_type_ref();
 
-            if could_be_a_tag_union(types, constraints, type_index) {
+            if could_be_a_tag_union(types, type_index) {
                 state.constraints.push(constraints.is_open_type(type_index));
             }
 
@@ -766,15 +766,12 @@ pub fn constrain_pattern(
     }
 }
 
-fn could_be_a_tag_union(types: &Types, constraints: &mut Constraints, typ: TypeOrVar) -> bool {
+fn could_be_a_tag_union(types: &Types, typ: TypeOrVar) -> bool {
     match typ.split() {
-        Ok(typ_index) => {
-            let typ_cell = &mut constraints.types[typ_index.index()];
-            !matches!(
-                types[*typ_cell.get_mut()].get(),
-                TypeTag::Apply { .. } | TypeTag::Function(..) | TypeTag::Record(..)
-            )
-        }
+        Ok(typ_index) => !matches!(
+            types[typ_index].get(),
+            TypeTag::Apply { .. } | TypeTag::Function(..) | TypeTag::Record(..)
+        ),
         Err(_) => {
             // Variables are opaque at this point, assume yes
             true

--- a/crates/compiler/solve/src/solve.rs
+++ b/crates/compiler/solve/src/solve.rs
@@ -896,7 +896,6 @@ fn solve(
                 let category = &constraints.categories[category_index.index()];
 
                 let actual = either_type_index_to_var(
-                    constraints,
                     subs,
                     rank,
                     pools,
@@ -910,7 +909,6 @@ fn solve(
 
                 let expectation = &constraints.expectations[expectation_index.index()];
                 let expected = either_type_index_to_var(
-                    constraints,
                     subs,
                     rank,
                     pools,
@@ -980,7 +978,6 @@ fn solve(
                 // a special version of Eq that is used to store types in the AST.
                 // IT DOES NOT REPORT ERRORS!
                 let actual = either_type_index_to_var(
-                    constraints,
                     subs,
                     rank,
                     pools,
@@ -1024,7 +1021,6 @@ fn solve(
                         let expectation = &constraints.expectations[expectation_index.index()];
 
                         let expected = either_type_index_to_var(
-                            constraints,
                             subs,
                             rank,
                             pools,
@@ -1119,7 +1115,6 @@ fn solve(
                 let category = &constraints.pattern_categories[category_index.index()];
 
                 let actual = either_type_index_to_var(
-                    constraints,
                     subs,
                     rank,
                     pools,
@@ -1133,7 +1128,6 @@ fn solve(
 
                 let expectation = &constraints.pattern_expectations[expectation_index.index()];
                 let expected = either_type_index_to_var(
-                    constraints,
                     subs,
                     rank,
                     pools,
@@ -1300,7 +1294,6 @@ fn solve(
             }
             IsOpenType(type_index) => {
                 let actual = either_type_index_to_var(
-                    constraints,
                     subs,
                     rank,
                     pools,
@@ -1330,7 +1323,6 @@ fn solve(
                 let pattern_category = &constraints.pattern_categories[pattern_category.index()];
 
                 let actual = either_type_index_to_var(
-                    constraints,
                     subs,
                     rank,
                     pools,
@@ -1464,7 +1456,6 @@ fn solve(
                 };
 
                 let real_var = either_type_index_to_var(
-                    constraints,
                     subs,
                     rank,
                     pools,
@@ -1477,7 +1468,6 @@ fn solve(
                 );
 
                 let branches_var = either_type_index_to_var(
-                    constraints,
                     subs,
                     rank,
                     pools,
@@ -2182,7 +2172,6 @@ impl LocalDefVarsVec<(Symbol, Loc<Variable>)> {
 
         for (&(symbol, region), typ_index) in (loc_symbols_slice.iter()).zip(type_indices_slice) {
             let var = either_type_index_to_var(
-                constraints,
                 subs,
                 rank,
                 pools,
@@ -2201,7 +2190,7 @@ impl LocalDefVarsVec<(Symbol, Loc<Variable>)> {
     }
 }
 
-use std::cell::{Cell, RefCell};
+use std::cell::RefCell;
 use std::ops::ControlFlow;
 std::thread_local! {
     /// Scratchpad arena so we don't need to allocate a new one all the time
@@ -2219,7 +2208,6 @@ fn put_scratchpad(scratchpad: bumpalo::Bump) {
 }
 
 fn either_type_index_to_var(
-    constraints: &Constraints,
     subs: &mut Subs,
     rank: Rank,
     pools: &mut Pools,
@@ -2232,9 +2220,8 @@ fn either_type_index_to_var(
 ) -> Variable {
     match either_type_index.split() {
         Ok(type_index) => {
-            let typ_cell = &constraints.types[type_index.index()];
-
-            type_cell_to_var(
+            // Converts the celled type to a variable, emplacing the new variable for re-use.
+            let var = type_to_var(
                 subs,
                 rank,
                 problems,
@@ -2243,45 +2230,19 @@ fn either_type_index_to_var(
                 pools,
                 types,
                 aliases,
-                typ_cell,
-            )
+                type_index,
+            );
+            unsafe {
+                types.emplace_variable(type_index, var);
+            }
+
+            var
         }
         Err(var_index) => {
             // we cheat, and  store the variable directly in the index
             unsafe { Variable::from_index(var_index.index() as _) }
         }
     }
-}
-
-/// Converts a type in a cell to a variable, leaving the converted variable behind for re-use.
-fn type_cell_to_var(
-    subs: &mut Subs,
-    rank: Rank,
-    problems: &mut Vec<TypeError>,
-    abilities_store: &mut AbilitiesStore,
-    obligation_cache: &mut ObligationCache,
-    pools: &mut Pools,
-    types: &mut Types,
-    aliases: &mut Aliases,
-    typ_cell: &Cell<Index<TypeCell>>,
-) -> Variable {
-    let typ = typ_cell.get();
-    let var = type_to_var(
-        subs,
-        rank,
-        problems,
-        abilities_store,
-        obligation_cache,
-        pools,
-        types,
-        aliases,
-        typ,
-    );
-    unsafe {
-        types.emplace_variable(typ, var);
-    }
-
-    var
 }
 
 pub(crate) fn type_to_var(

--- a/crates/compiler/types/src/types.rs
+++ b/crates/compiler/types/src/types.rs
@@ -560,11 +560,11 @@ impl Types {
     }
 
     #[cfg(debug_assertions)]
-    pub fn dbg(&self, tag: Index<TypeTag>) -> impl std::fmt::Debug + '_ {
+    pub fn dbg(&self, tag: Index<TypeCell>) -> impl std::fmt::Debug + '_ {
         debug_types::DebugTag(self, tag)
     }
 
-    pub fn get_type_arguments(&self, tag: Index<TypeTag>) -> Slice<TypeTag> {
+    pub fn get_type_arguments(&self, tag: Index<TypeCell>) -> Slice<TypeCell> {
         self.tags_slices[tag.index()]
     }
 
@@ -1296,12 +1296,12 @@ mod debug_types {
         types::{AliasShared, RecordField, Uls},
     };
 
-    use super::{TypeTag, Types};
+    use super::{TypeCell, TypeTag, Types};
     use roc_collections::soa::{Index, Slice};
     use roc_module::ident::TagName;
     use ven_pretty::{Arena, DocAllocator, DocBuilder};
 
-    pub struct DebugTag<'a>(pub &'a Types, pub Index<TypeTag>);
+    pub struct DebugTag<'a>(pub &'a Types, pub Index<TypeCell>);
 
     impl<'a> std::fmt::Debug for DebugTag<'a> {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -1334,10 +1334,10 @@ mod debug_types {
         types: &'a Types,
         f: &'a Arena<'a>,
         p: TPrec,
-        tag: Index<TypeTag>,
+        tag: Index<TypeCell>,
     ) -> DocBuilder<'a, Arena<'a>> {
         use TPrec::*;
-        let group = match types[tag] {
+        let group = match types[tag].get() {
             TypeTag::EmptyRecord => f.text("{}"),
             TypeTag::EmptyTagUnion => f.text("[]"),
             TypeTag::Function(clos, ret) => {
@@ -1469,7 +1469,7 @@ mod debug_types {
     fn ext<'a>(
         types: &'a Types,
         f: &'a Arena<'a>,
-        ext_slice: Slice<TypeTag>,
+        ext_slice: Slice<TypeCell>,
     ) -> DocBuilder<'a, Arena<'a>> {
         f.intersperse(
             ext_slice.into_iter().map(|e| typ(types, f, TPrec::Free, e)),
@@ -1483,7 +1483,7 @@ mod debug_types {
         f: &'a Arena<'a>,
         prefix: DocBuilder<'a, Arena<'a>>,
         tags: UnionLabels<TagName>,
-        ext_slice: Slice<TypeTag>,
+        ext_slice: Slice<TypeCell>,
     ) -> DocBuilder<'a, Arena<'a>> {
         let (tags, payload_slices) = types.union_tag_slices(tags);
         let fmt_tags =
@@ -1512,7 +1512,7 @@ mod debug_types {
     fn alias<'a>(
         types: &'a Types,
         f: &'a Arena<'a>,
-        tag: Index<TypeTag>,
+        tag: Index<TypeCell>,
         shared: Index<AliasShared>,
     ) -> DocBuilder<'a, Arena<'a>> {
         use TPrec::*;

--- a/crates/compiler/types/src/types.rs
+++ b/crates/compiler/types/src/types.rs
@@ -518,19 +518,19 @@ impl Default for Types {
 
 impl Types {
     pub const EMPTY_RECORD: Index<TypeCell> = Index::new(0);
-    const EMPTY_RECORD_TAG: TypeCell = TypeCell::new(TypeTag::EmptyRecord);
+    #[allow(clippy::declare_interior_mutable_const)] // variables in type cells will never be moved
+    const EMPTY_RECORD_TAG: TypeCell = TypeCell::new(TypeTag::Variable(Variable::EMPTY_RECORD));
     const EMPTY_RECORD_ARGS: Slice<TypeCell> = Slice::empty();
 
     pub const EMPTY_TAG_UNION: Index<TypeCell> = Index::new(1);
-    const EMPTY_TAG_UNION_TAG: TypeCell = TypeCell::new(TypeTag::EmptyTagUnion);
+    #[allow(clippy::declare_interior_mutable_const)] // variables in type cells will never be moved
+    const EMPTY_TAG_UNION_TAG: TypeCell =
+        TypeCell::new(TypeTag::Variable(Variable::EMPTY_TAG_UNION));
     const EMPTY_TAG_UNION_ARGS: Slice<TypeCell> = Slice::empty();
 
     pub const STR: Index<TypeCell> = Index::new(2);
-    const STR_TAG: TypeCell = TypeCell::new(TypeTag::Apply {
-        symbol: Symbol::STR_STR,
-        type_argument_regions: Slice::empty(),
-        region: Region::zero(),
-    });
+    #[allow(clippy::declare_interior_mutable_const)] // variables in type cells will never be moved
+    const STR_TAG: TypeCell = TypeCell::new(TypeTag::Variable(Variable::STR));
     const STR_ARGS: Slice<TypeCell> = Slice::empty();
 
     pub fn new() -> Self {


### PR DESCRIPTION
In this PR,

- SoA types now index into a `Cell`; after we convert a type to a variable, the variable is emplaced into the cell for re-use.
- We eliminate traces of `type` in constraining, since that is no longer relevant - types are always stored in `Types`. There are still some vestiges that will be removed later.

Blocked on #4491