### PR TITLE
Windows rust platforms

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -341,7 +341,6 @@ pub fn test(_matches: &ArgMatches, _triple: Triple) -> io::Result<i32> {
 
 #[cfg(not(windows))]
 pub fn test(matches: &ArgMatches, triple: Triple) -> io::Result<i32> {
-    panic!();
     use roc_gen_llvm::llvm::build::LlvmBackendMode;
     use roc_load::{ExecutionMode, LoadConfig};
     use roc_target::TargetInfo;

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -341,6 +341,7 @@ pub fn test(_matches: &ArgMatches, _triple: Triple) -> io::Result<i32> {
 
 #[cfg(not(windows))]
 pub fn test(matches: &ArgMatches, triple: Triple) -> io::Result<i32> {
+    panic!();
     use roc_gen_llvm::llvm::build::LlvmBackendMode;
     use roc_load::{ExecutionMode, LoadConfig};
     use roc_target::TargetInfo;

--- a/crates/cli/tests/cli_run.rs
+++ b/crates/cli/tests/cli_run.rs
@@ -155,6 +155,9 @@ mod cli_run {
 
         let cli_commands = if test_many_cli_commands {
             vec![CliMode::RocBuild, CliMode::RocRun, CliMode::Roc]
+        } else if cfg!(windows) {
+            // TODO: expects don't currently work on windows
+            vec![CliMode::RocRun]
         } else {
             vec![CliMode::Roc]
         };
@@ -238,10 +241,6 @@ mod cli_run {
                     if !extra_env.is_empty() {
                         // TODO: `roc` and `roc dev` are currently buggy for `env.roc`
                         continue;
-                    }
-
-                    if cfg!(windows) {
-                        // TODO: `roc dev` does not currently work on windows
                     }
 
                     run_roc_on(file, flags.clone(), stdin, roc_app_args, extra_env)

--- a/crates/cli/tests/cli_run.rs
+++ b/crates/cli/tests/cli_run.rs
@@ -527,6 +527,7 @@ mod cli_run {
     }
 
     #[test]
+    #[cfg_attr(windows, ignore = "missing __udivdi3 and some other symbols")]
     #[serial(cli_platform)]
     fn cli_args() {
         test_roc_app(
@@ -580,6 +581,7 @@ mod cli_run {
     }
 
     #[test]
+    #[cfg_attr(windows, ignore = "overflows the stack on windows")]
     fn false_interpreter() {
         test_roc_app(
             "examples/cli/false-interpreter",

--- a/crates/cli/tests/cli_run.rs
+++ b/crates/cli/tests/cli_run.rs
@@ -239,6 +239,11 @@ mod cli_run {
                         // TODO: `roc` and `roc dev` are currently buggy for `env.roc`
                         continue;
                     }
+
+                    if cfg!(windows) {
+                        // TODO: `roc dev` does not currently work on windows
+                    }
+
                     run_roc_on(file, flags.clone(), stdin, roc_app_args, extra_env)
                 }
                 CliMode::RocRun => run_roc_on(

--- a/crates/cli/tests/fixtures/multi-dep-str/platform/host.zig
+++ b/crates/cli/tests/fixtures/multi-dep-str/platform/host.zig
@@ -74,6 +74,10 @@ fn roc_getppid() callconv(.C) c_int {
     return getppid();
 }
 
+fn roc_getppid_windows_stub() callconv(.C) c_int {
+    return 0;
+}
+
 fn roc_send_signal(pid: c_int, sig: c_int) callconv(.C) c_int {
     return kill(pid, sig);
 }
@@ -90,6 +94,10 @@ comptime {
         @export(roc_mmap, .{ .name = "roc_mmap", .linkage = .Strong });
         @export(roc_send_signal, .{ .name = "roc_send_signal", .linkage = .Strong });
         @export(roc_shm_open, .{ .name = "roc_shm_open", .linkage = .Strong });
+    }
+
+    if (builtin.os.tag == .windows) {
+        @export(roc_getppid_windows_stub, .{ .name = "roc_getppid", .linkage = .Strong });
     }
 }
 

--- a/crates/cli/tests/fixtures/multi-dep-thunk/platform/host.zig
+++ b/crates/cli/tests/fixtures/multi-dep-thunk/platform/host.zig
@@ -73,6 +73,10 @@ fn roc_getppid() callconv(.C) c_int {
     return getppid();
 }
 
+fn roc_getppid_windows_stub() callconv(.C) c_int {
+    return 0;
+}
+
 fn roc_send_signal(pid: c_int, sig: c_int) callconv(.C) c_int {
     return kill(pid, sig);
 }
@@ -89,6 +93,10 @@ comptime {
         @export(roc_mmap, .{ .name = "roc_mmap", .linkage = .Strong });
         @export(roc_send_signal, .{ .name = "roc_send_signal", .linkage = .Strong });
         @export(roc_shm_open, .{ .name = "roc_shm_open", .linkage = .Strong });
+    }
+
+    if (builtin.os.tag == .windows) {
+        @export(roc_getppid_windows_stub, .{ .name = "roc_getppid", .linkage = .Strong });
     }
 }
 

--- a/crates/cli_testing_examples/algorithms/fibonacci-platform/host.zig
+++ b/crates/cli_testing_examples/algorithms/fibonacci-platform/host.zig
@@ -90,6 +90,10 @@ fn roc_getppid() callconv(.C) c_int {
     return getppid();
 }
 
+fn roc_getppid_windows_stub() callconv(.C) c_int {
+    return 0;
+}
+
 fn roc_send_signal(pid: c_int, sig: c_int) callconv(.C) c_int {
     return kill(pid, sig);
 }

--- a/crates/cli_testing_examples/algorithms/fibonacci-platform/host.zig
+++ b/crates/cli_testing_examples/algorithms/fibonacci-platform/host.zig
@@ -111,6 +111,10 @@ comptime {
         @export(roc_send_signal, .{ .name = "roc_send_signal", .linkage = .Strong });
         @export(roc_shm_open, .{ .name = "roc_shm_open", .linkage = .Strong });
     }
+
+    if (builtin.os.tag == .windows) {
+        @export(roc_getppid_windows_stub, .{ .name = "roc_getppid", .linkage = .Strong });
+    }
 }
 
 pub export fn main() u8 {

--- a/crates/cli_testing_examples/algorithms/quicksort-platform/host.zig
+++ b/crates/cli_testing_examples/algorithms/quicksort-platform/host.zig
@@ -89,6 +89,10 @@ fn roc_getppid() callconv(.C) c_int {
     return getppid();
 }
 
+fn roc_getppid_windows_stub() callconv(.C) c_int {
+    return 0;
+}
+
 fn roc_send_signal(pid: c_int, sig: c_int) callconv(.C) c_int {
     return kill(pid, sig);
 }
@@ -105,6 +109,10 @@ comptime {
         @export(roc_mmap, .{ .name = "roc_mmap", .linkage = .Strong });
         @export(roc_send_signal, .{ .name = "roc_send_signal", .linkage = .Strong });
         @export(roc_shm_open, .{ .name = "roc_shm_open", .linkage = .Strong });
+    }
+
+    if (builtin.os.tag == .windows) {
+        @export(roc_getppid_windows_stub, .{ .name = "roc_getppid", .linkage = .Strong });
     }
 }
 

--- a/crates/cli_testing_examples/benchmarks/platform/host.zig
+++ b/crates/cli_testing_examples/benchmarks/platform/host.zig
@@ -94,6 +94,10 @@ fn roc_getppid() callconv(.C) c_int {
     return getppid();
 }
 
+fn roc_getppid_windows_stub() callconv(.C) c_int {
+    return 0;
+}
+
 fn roc_send_signal(pid: c_int, sig: c_int) callconv(.C) c_int {
     return kill(pid, sig);
 }
@@ -110,6 +114,10 @@ comptime {
         @export(roc_mmap, .{ .name = "roc_mmap", .linkage = .Strong });
         @export(roc_send_signal, .{ .name = "roc_send_signal", .linkage = .Strong });
         @export(roc_shm_open, .{ .name = "roc_shm_open", .linkage = .Strong });
+    }
+
+    if (builtin.os.tag == .windows) {
+        @export(roc_getppid_windows_stub, .{ .name = "roc_getppid", .linkage = .Strong });
     }
 }
 

--- a/crates/compiler/build/src/link.rs
+++ b/crates/compiler/build/src/link.rs
@@ -416,7 +416,7 @@ pub fn build_c_host_native(
                 return build_zig_host_native(
                     env_path,
                     env_home,
-                    &format!("-femit-bin={}", dest),
+                    dest,
                     sources[0],
                     find_zig_str_path().to_str().unwrap(),
                     "x86_64-windows-gnu",

--- a/crates/compiler/build/src/link.rs
+++ b/crates/compiler/build/src/link.rs
@@ -633,6 +633,12 @@ pub fn rebuild_host(
         );
 
         let mut cargo_cmd = cargo();
+
+        if cfg!(windows) {
+            // on windows, we need the `+nightly` toolchain so we can use `-Z export-executable-symbols`
+            cargo_cmd.arg("+nightly");
+        }
+
         cargo_cmd.arg("build").current_dir(cargo_dir);
         // Rust doesn't expose size without editing the cargo.toml. Instead just use release.
         if matches!(opt_level, OptLevel::Optimize | OptLevel::Size) {

--- a/crates/compiler/build/src/link.rs
+++ b/crates/compiler/build/src/link.rs
@@ -3,8 +3,8 @@ use libloading::{Error, Library};
 use roc_builtins::bitcode;
 use roc_error_macros::internal_error;
 use roc_mono::ir::OptLevel;
-use roc_utils::get_lib_path;
 use roc_utils::{cargo, clang, zig};
+use roc_utils::{get_lib_path, rustup};
 use std::collections::HashMap;
 use std::env;
 use std::io;
@@ -632,11 +632,11 @@ pub fn rebuild_host(
             },
         );
 
-        let mut cargo_cmd = cargo();
+        let mut cargo_cmd = if cfg!(windows) { rustup() } else { cargo() };
 
         if cfg!(windows) {
             // on windows, we need the `+nightly` toolchain so we can use `-Z export-executable-symbols`
-            cargo_cmd.arg("+nightly");
+            cargo_cmd.args(["run", "nightly", "cargo"]);
         }
 
         cargo_cmd.arg("build").current_dir(cargo_dir);

--- a/crates/compiler/build/src/link.rs
+++ b/crates/compiler/build/src/link.rs
@@ -200,7 +200,7 @@ pub fn build_zig_host_native(
             &bitcode::get_builtins_windows_obj_path(),
         ]);
     } else {
-        zig_cmd.args(&["build-obj", "-fPIC"]);
+        zig_cmd.args(&["build-obj"]);
     }
 
     zig_cmd.args(&[
@@ -295,7 +295,7 @@ pub fn build_zig_host_native(
             &bitcode::get_builtins_host_obj_path(),
         ]);
     } else {
-        zig_cmd.args(&["build-obj", "-fPIC"]);
+        zig_cmd.args(&["build-obj"]);
     }
     zig_cmd.args(&[
         zig_host_src,

--- a/crates/compiler/build/src/link.rs
+++ b/crates/compiler/build/src/link.rs
@@ -632,12 +632,16 @@ pub fn rebuild_host(
             },
         );
 
-        let mut cargo_cmd = if cfg!(windows) { rustup() } else { cargo() };
+        let mut cargo_cmd = if cfg!(windows) {
+            // on windows, we need the nightly toolchain so we can use `-Z export-executable-symbols`
+            // using `+nightly` only works when running cargo through rustup
+            let mut cmd = rustup();
+            cmd.args(["run", "nightly", "cargo"]);
 
-        if cfg!(windows) {
-            // on windows, we need the `+nightly` toolchain so we can use `-Z export-executable-symbols`
-            cargo_cmd.args(["run", "nightly", "cargo"]);
-        }
+            cmd
+        } else {
+            cargo()
+        };
 
         cargo_cmd.arg("build").current_dir(cargo_dir);
         // Rust doesn't expose size without editing the cargo.toml. Instead just use release.

--- a/crates/compiler/build/src/link.rs
+++ b/crates/compiler/build/src/link.rs
@@ -646,7 +646,12 @@ pub fn rebuild_host(
         }
 
         let source_file = if shared_lib_path.is_some() {
-            cargo_cmd.env("RUSTFLAGS", "-C link-dead-code");
+            let rust_flags = if cfg!(windows) {
+                "-Z export-executable-symbols"
+            } else {
+                "-C link-dead-code"
+            };
+            cargo_cmd.env("RUSTFLAGS", rust_flags);
             cargo_cmd.args(["--bin", "host"]);
             "src/main.rs"
         } else {

--- a/crates/compiler/builtins/bitcode/src/utils.zig
+++ b/crates/compiler/builtins/bitcode/src/utils.zig
@@ -30,6 +30,11 @@ extern fn getppid() c_int;
 fn testing_roc_getppid() callconv(.C) c_int {
     return getppid();
 }
+
+fn roc_getppid_windows_stub() callconv(.C) c_int {
+    return 0;
+}
+
 fn testing_roc_send_signal(pid: c_int, sig: c_int) callconv(.C) c_int {
     return kill(pid, sig);
 }

--- a/crates/linker/src/pe.rs
+++ b/crates/linker/src/pe.rs
@@ -428,8 +428,6 @@ pub(crate) fn surgery_pe(executable_path: &Path, metadata_path: &Path, roc_app_b
                         );
                     }
 
-                    dbg!(&name);
-
                     match relocation.kind() {
                         object::RelocationKind::Relative => {
                             // we implicitly only do 32-bit relocations
@@ -1933,5 +1931,14 @@ mod test {
     #[ignore]
     fn preprocessing_wine() {
         assert_eq!("Hello there\n", wine_test(preprocessing_help))
+    }
+
+    #[test]
+    fn rust_app_data() {
+        let data = include_bytes!("/tmp/roc/echo.obj");
+
+        AppSections::from_data(data);
+
+        panic!();
     }
 }

--- a/crates/linker/src/pe.rs
+++ b/crates/linker/src/pe.rs
@@ -364,6 +364,7 @@ pub(crate) fn surgery_pe(executable_path: &Path, metadata_path: &Path, roc_app_b
                 } = app_relocation;
 
                 if let Some(destination) = md.exports.get(name) {
+                    dbg!(&name);
                     match relocation.kind() {
                         object::RelocationKind::Relative => {
                             // we implicitly only do 32-bit relocations
@@ -382,6 +383,8 @@ pub(crate) fn surgery_pe(executable_path: &Path, metadata_path: &Path, roc_app_b
                 } else if let Some(destination) = inter_app_relocations.get(name) {
                     // we implicitly only do 32-bit relocations
                     debug_assert_eq!(relocation.size(), 32);
+
+                    dbg!(&name);
 
                     let delta =
                         destination - section_virtual_address as i64 - *offset_in_section as i64
@@ -410,6 +413,8 @@ pub(crate) fn surgery_pe(executable_path: &Path, metadata_path: &Path, roc_app_b
                             name
                         );
                     }
+
+                    dbg!(&name);
 
                     match relocation.kind() {
                         object::RelocationKind::Relative => {

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -126,7 +126,14 @@ pub fn get_lib_path() -> Option<PathBuf> {
 /// Gives a friendly error if cargo is not installed.
 /// Also makes it easy to track where we use cargo in the codebase.
 pub fn cargo() -> Command {
-    let command_str = "cargo";
+    let command_str = if cfg!(windows) {
+        // on windows, we need the version of cargo installed by rustup. The meaning of `cargo` is
+        // different within a process that runs rust. So we need to explicitly refer to where
+        // rustup put the binary
+        r"%HOMEPATH%\.cargo\bin\cargo.exe"
+    } else {
+        "cargo"
+    };
 
     if check_command_available(command_str) {
         Command::new(command_str)

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -126,11 +126,7 @@ pub fn get_lib_path() -> Option<PathBuf> {
 /// Gives a friendly error if cargo is not installed.
 /// Also makes it easy to track where we use cargo in the codebase.
 pub fn cargo() -> Command {
-    let command_str = if cfg!(windows) {
-        r"%HOMEPATH%\.cargo\bin\cargo.exe"
-    } else {
-        "cargo"
-    };
+    let command_str = "cargo";
 
     if check_command_available(command_str) {
         Command::new(command_str)

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -127,9 +127,6 @@ pub fn get_lib_path() -> Option<PathBuf> {
 /// Also makes it easy to track where we use cargo in the codebase.
 pub fn cargo() -> Command {
     let command_str = if cfg!(windows) {
-        // on windows, we need the version of cargo installed by rustup. The meaning of `cargo` is
-        // different within a process that runs rust. So we need to explicitly refer to where
-        // rustup put the binary
         r"%HOMEPATH%\.cargo\bin\cargo.exe"
     } else {
         "cargo"
@@ -139,6 +136,21 @@ pub fn cargo() -> Command {
         Command::new(command_str)
     } else {
         panic!("I could not find the cargo command.\nVisit https://rustup.rs/ to install cargo.",)
+    }
+}
+
+/// Gives a friendly error if cargo is not installed.
+/// Also makes it easy to track where we use cargo in the codebase.
+pub fn rustup() -> Command {
+    // on windows, we need the version of cargo installed by rustup. The meaning of `cargo` is
+    // different within a process that runs rust. So we need to explicitly refer to where
+    // rustup put the binary
+    let command_str = "rustup";
+
+    if check_command_available(command_str) {
+        Command::new(command_str)
+    } else {
+        panic!("I could not find the rustup command.\nVisit https://rustup.rs/ to install cargo.",)
     }
 }
 

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -135,8 +135,8 @@ pub fn cargo() -> Command {
     }
 }
 
-/// Gives a friendly error if cargo is not installed.
-/// Also makes it easy to track where we use cargo in the codebase.
+/// Gives a friendly error if rustup is not installed.
+/// Also makes it easy to track where we use rustup in the codebase.
 pub fn rustup() -> Command {
     // on windows, we need the version of cargo installed by rustup. The meaning of `cargo` is
     // different within a process that runs rust. So we need to explicitly refer to where
@@ -146,7 +146,7 @@ pub fn rustup() -> Command {
     if check_command_available(command_str) {
         Command::new(command_str)
     } else {
-        panic!("I could not find the rustup command.\nVisit https://rustup.rs/ to install cargo.",)
+        panic!("I could not find the rustup command.\nVisit https://rustup.rs/ to install rustup.",)
     }
 }
 

--- a/examples/cli/effects-platform/host.zig
+++ b/examples/cli/effects-platform/host.zig
@@ -35,7 +35,11 @@ extern fn malloc(size: usize) callconv(.C) ?*align(Align) anyopaque;
 extern fn realloc(c_ptr: [*]align(Align) u8, size: usize) callconv(.C) ?*anyopaque;
 extern fn free(c_ptr: [*]align(Align) u8) callconv(.C) void;
 extern fn memcpy(dst: [*]u8, src: [*]u8, size: usize) callconv(.C) void;
-extern fn memset(dst: [*]u8, value: i32, size: usize) callconv(.C) void;
+extern fn memset(dst: [*]u8, value: i32, size: usize) void;
+extern fn kill(pid: c_int, sig: c_int) c_int;
+extern fn shm_open(name: *const i8, oflag: c_int, mode: c_uint) c_int;
+extern fn mmap(addr: ?*anyopaque, length: c_uint, prot: c_int, flags: c_int, fd: c_int, offset: c_uint) *anyopaque;
+extern fn getppid() c_int;
 
 const DEBUG: bool = false;
 
@@ -85,13 +89,12 @@ export fn roc_memset(dst: [*]u8, value: i32, size: usize) callconv(.C) void {
     return memset(dst, value, size);
 }
 
-extern fn kill(pid: c_int, sig: c_int) c_int;
-extern fn shm_open(name: *const i8, oflag: c_int, mode: c_uint) c_int;
-extern fn mmap(addr: ?*anyopaque, length: c_uint, prot: c_int, flags: c_int, fd: c_int, offset: c_uint) *anyopaque;
-extern fn getppid() c_int;
-
 fn roc_getppid() callconv(.C) c_int {
     return getppid();
+}
+
+fn roc_getppid_windows_stub() callconv(.C) c_int {
+    return 0;
 }
 
 fn roc_send_signal(pid: c_int, sig: c_int) callconv(.C) c_int {
@@ -110,6 +113,10 @@ comptime {
         @export(roc_mmap, .{ .name = "roc_mmap", .linkage = .Strong });
         @export(roc_send_signal, .{ .name = "roc_send_signal", .linkage = .Strong });
         @export(roc_shm_open, .{ .name = "roc_shm_open", .linkage = .Strong });
+    }
+
+    if (builtin.os.tag == .windows) {
+        @export(roc_getppid_windows_stub, .{ .name = "roc_getppid", .linkage = .Strong });
     }
 }
 

--- a/examples/cli/tui-platform/host.zig
+++ b/examples/cli/tui-platform/host.zig
@@ -153,6 +153,10 @@ fn roc_getppid() callconv(.C) c_int {
     return getppid();
 }
 
+fn roc_getppid_windows_stub() callconv(.C) c_int {
+    return 0;
+}
+
 fn roc_send_signal(pid: c_int, sig: c_int) callconv(.C) c_int {
     return kill(pid, sig);
 }
@@ -169,6 +173,10 @@ comptime {
         @export(roc_mmap, .{ .name = "roc_mmap", .linkage = .Strong });
         @export(roc_send_signal, .{ .name = "roc_send_signal", .linkage = .Strong });
         @export(roc_shm_open, .{ .name = "roc_shm_open", .linkage = .Strong });
+    }
+
+    if (builtin.os.tag == .windows) {
+        @export(roc_getppid_windows_stub, .{ .name = "roc_getppid", .linkage = .Strong });
     }
 }
 

--- a/examples/parser/platform/host.c
+++ b/examples/parser/platform/host.c
@@ -95,10 +95,36 @@ void *roc_memset(void *str, int c, size_t n) {
   return memset(str, c, n);
 }
 
-int roc_send_signal(int pid, int sig) { return kill(pid, sig); }
-int roc_shm_open(char* name, int oflag, int mode) { return shm_open(name, oflag, mode); }
-void* roc_mmap(void* addr, int length, int prot, int flags, int fd, int offset) { return mmap(addr, length, prot, flags, fd, offset); }
-int roc_getppid() { return getppid(); }
+int roc_send_signal(int pid, int sig) { 
+#ifdef _WIN32
+    return 0;
+#else
+    return kill(pid, sig); 
+#endif
+}
+
+int roc_shm_open(char* name, int oflag, int mode) { 
+#ifdef _WIN32
+    return 0;
+#else
+    return shm_open(name, oflag, mode); 
+#endif
+}
+void* roc_mmap(void* addr, int length, int prot, int flags, int fd, int offset) { 
+#ifdef _WIN32
+    return addr;
+#else
+    return mmap(addr, length, prot, flags, fd, offset); 
+#endif
+}
+
+int roc_getppid() {
+#ifdef _WIN32
+    return 0;
+#else
+    return getppid();
+#endif
+}
 
 struct RocStr {
   char *bytes;

--- a/examples/platform-switching/c-platform/host.c
+++ b/examples/platform-switching/c-platform/host.c
@@ -27,14 +27,34 @@ void* roc_memcpy(void* dest, const void* src, size_t n) {
 void* roc_memset(void* str, int c, size_t n) { return memset(str, c, n); }
 
 
-int roc_send_signal(int pid, int sig) { return kill(pid, sig); }
-int roc_shm_open(char* name, int oflag, int mode) { return shm_open(name, oflag, mode); }
-void* roc_mmap(void* addr, int length, int prot, int flags, int fd, int offset) { return mmap(addr, length, prot, flags, fd, offset); }
+int roc_send_signal(int pid, int sig) { 
+#ifdef _WIN32
+    return 0;
+#else
+    return kill(pid, sig); 
+#endif
+}
+
+int roc_shm_open(char* name, int oflag, int mode) { 
+#ifdef _WIN32
+    return 0;
+#else
+    return shm_open(name, oflag, mode); 
+#endif
+}
+void* roc_mmap(void* addr, int length, int prot, int flags, int fd, int offset) { 
+#ifdef _WIN32
+    return addr;
+#else
+    return mmap(addr, length, prot, flags, fd, offset); 
+#endif
+}
+
 int roc_getppid() {
 #ifdef _WIN32
-    return getppid();
-#else
     return 0;
+#else
+    return getppid();
 #endif
 }
 

--- a/examples/platform-switching/c-platform/host.c
+++ b/examples/platform-switching/c-platform/host.c
@@ -7,8 +7,7 @@
 
 void* roc_alloc(size_t size, unsigned int alignment) { return malloc(size); }
 
-void* roc_realloc(void* ptr, size_t new_size, size_t old_size,
-                  unsigned int alignment) {
+void* roc_realloc(void* ptr, size_t new_size, size_t old_size, unsigned int alignment) {
   return realloc(ptr, new_size);
 }
 
@@ -31,7 +30,13 @@ void* roc_memset(void* str, int c, size_t n) { return memset(str, c, n); }
 int roc_send_signal(int pid, int sig) { return kill(pid, sig); }
 int roc_shm_open(char* name, int oflag, int mode) { return shm_open(name, oflag, mode); }
 void* roc_mmap(void* addr, int length, int prot, int flags, int fd, int offset) { return mmap(addr, length, prot, flags, fd, offset); }
-int roc_getppid() { return getppid(); }
+int roc_getppid() {
+#ifdef _WIN32
+    return getppid();
+#else
+    return 0;
+#endif
+}
 
 struct RocStr {
   char* bytes;

--- a/examples/platform-switching/zig-platform/host.zig
+++ b/examples/platform-switching/zig-platform/host.zig
@@ -84,6 +84,10 @@ fn roc_getppid() callconv(.C) c_int {
     return getppid();
 }
 
+fn roc_getppid_windows_stub() callconv(.C) c_int {
+    return 0;
+}
+
 fn roc_send_signal(pid: c_int, sig: c_int) callconv(.C) c_int {
     return kill(pid, sig);
 }
@@ -100,6 +104,10 @@ comptime {
         @export(roc_mmap, .{ .name = "roc_mmap", .linkage = .Strong });
         @export(roc_send_signal, .{ .name = "roc_send_signal", .linkage = .Strong });
         @export(roc_shm_open, .{ .name = "roc_shm_open", .linkage = .Strong });
+    }
+
+    if (builtin.os.tag == .windows) {
+        @export(roc_getppid_windows_stub, .{ .name = "roc_getppid", .linkage = .Strong });
     }
 }
 

--- a/examples/ruby-interop/platform/host.c
+++ b/examples/ruby-interop/platform/host.c
@@ -27,10 +27,36 @@ void* roc_memcpy(void* dest, const void* src, size_t n) {
 
 void* roc_memset(void* str, int c, size_t n) { return memset(str, c, n); }
 
-int roc_send_signal(int pid, int sig) { return kill(pid, sig); }
-int roc_shm_open(char* name, int oflag, int mode) { return shm_open(name, oflag, mode); }
-void* roc_mmap(void* addr, int length, int prot, int flags, int fd, int offset) { return mmap(addr, length, prot, flags, fd, offset); }
-int roc_getppid() { return getppid(); }
+int roc_send_signal(int pid, int sig) { 
+#ifdef _WIN32
+    return 0;
+#else
+    return kill(pid, sig); 
+#endif
+}
+
+int roc_shm_open(char* name, int oflag, int mode) { 
+#ifdef _WIN32
+    return 0;
+#else
+    return shm_open(name, oflag, mode); 
+#endif
+}
+void* roc_mmap(void* addr, int length, int prot, int flags, int fd, int offset) { 
+#ifdef _WIN32
+    return addr;
+#else
+    return mmap(addr, length, prot, flags, fd, offset); 
+#endif
+}
+
+int roc_getppid() {
+#ifdef _WIN32
+    return 0;
+#else
+    return getppid();
+#endif
+}
 
 struct RocStr {
   char* bytes;


### PR DESCRIPTION
Uses the nightly rust compiler to have executable expose symbols. We need these for surgical linking. Hopefully we can stabilize this flag, but until then,  using nightly for platforms on windows is fine.