### PR TITLE
Fix inline expects on macos

### DIFF
--- a/crates/compiler/builtins/bitcode/src/expect.zig
+++ b/crates/compiler/builtins/bitcode/src/expect.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 const builtin = @import("builtin");
 
-const SIGUSR1: c_int = 10;
+const SIGUSR1: c_int = if (builtin.os.tag.isDarwin()) 30 else 10;
 
 const O_RDWR: c_int = 2;
 const O_CREAT: c_int = 64;

--- a/examples/platform-switching/c-platform/host.c
+++ b/examples/platform-switching/c-platform/host.c
@@ -1,8 +1,11 @@
 #include <errno.h>
+#include <signal.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
 #include <unistd.h>
 #include <sys/shm.h> // shm_open
 #include <sys/mman.h> // for mmap


### PR DESCRIPTION
MacOS SIGUSR1 is signal 30, not 10 as it is on Linux. At least on MacOS clang, we need the added headers to the c platform's host to compile correctly.