### PR TITLE
Ensure ability-bound variables are registered in their generalization pool

### DIFF
--- a/crates/compiler/solve/src/solve.rs
+++ b/crates/compiler/solve/src/solve.rs
@@ -2960,12 +2960,13 @@ fn type_to_variable<'a>(
             _ => {
                 let abilities_slice =
                     SubsSlice::extend_new(&mut subs.symbol_names, abilities.sorted_iter().copied());
-                let flex_ability = subs.fresh(Descriptor {
-                    content: Content::FlexAbleVar(None, abilities_slice),
+
+                let flex_ability = register(
+                    subs,
                     rank,
-                    mark: Mark::NONE,
-                    copy: OptVariable::NONE,
-                });
+                    pools,
+                    Content::FlexAbleVar(None, abilities_slice),
+                );
 
                 let category = Category::OpaqueArg;
                 match unify(

--- a/crates/compiler/solve/tests/solve_expr.rs
+++ b/crates/compiler/solve/tests/solve_expr.rs
@@ -8220,4 +8220,26 @@ mod solve_expr {
             "{} -> Task",
         )
     }
+
+    #[test]
+    fn generalize_inferred_opaque_variable_bound_to_ability_issue_4408() {
+        infer_eq_without_problem(
+            indoc!(
+                r#"
+                app "test" provides [top] to "./platform"
+
+                MDict u := (List u) | u has Eq
+
+                bot : MDict k -> MDict k
+                bot = \@MDict data ->
+                    when {} is
+                        {} -> @MDict data
+
+                top : MDict v -> MDict v
+                top = \x -> bot x
+                "#
+            ),
+            "MDict v -> MDict v | v has Eq",
+        );
+    }
 }

--- a/crates/compiler/types/src/subs.rs
+++ b/crates/compiler/types/src/subs.rs
@@ -798,8 +798,10 @@ fn subs_fmt_content(this: &Content, subs: &Subs, f: &mut fmt::Formatter) -> fmt:
             };
             write!(f, "FlexAble({}, {:?})", name, subs.get_subs_slice(*symbols))
         }
-        Content::RigidVar(name) => write!(f, "Rigid({:?})", name),
-        Content::RigidAbleVar(name, symbol) => write!(f, "RigidAble({:?}, {:?})", name, symbol),
+        Content::RigidVar(name) => write!(f, "Rigid({})", subs[*name].as_str()),
+        Content::RigidAbleVar(name, symbol) => {
+            write!(f, "RigidAble({}, {:?})", subs[*name].as_str(), symbol)
+        }
         Content::RecursionVar {
             structure,
             opt_name,


### PR DESCRIPTION
When we attempt to bind a type argument to an ability in an alias/opaque
instantiation, we create a fresh flex var to represent satisfaction of
the ability, and then unify the type argument with that flex var.
Previously, we did not register this fresh var in the appropriate rank
pool.

Usually this is not a problem; however, our generalization algorithm is
such that we skip adjusting the rank of redundant variables. Redundant
variables are those that are in the same unification tree, but are not
the root of the unification trees.

This means that if such a flex able var becomes the root of a
unification tree with the type argument, and the type argument is itself
generalized, we will have missed generalization of the argument.

The fix is simple - make sure to register the flex able var into the
appropriate rank pool.

Closes https://github.com/roc-lang/roc/issues/4408