### PR TITLE
Reporting tweaks

### DIFF
--- a/crates/repl_expect/src/lib.rs
+++ b/crates/repl_expect/src/lib.rs
@@ -182,7 +182,8 @@ mod test {
             // changes between test runs
             let p = actual.bytes().position(|c| c == b'\n').unwrap();
             let (_, x) = actual.split_at(p);
-            let x = x.trim_start();
+            let x = x.trim();
+            let expected = expected.trim_end();
 
             if x != expected {
                 println!("{}", x);
@@ -856,14 +857,14 @@ mod test {
                     First Str U8,
                     Next (List { item: Str, rest: NonEmpty }),
                 ]
-                
+
                 expect
                     nonEmpty =
                         a = "abcdefgh"
                         b = @NonEmpty (First "ijkl" 67u8)
                         c = Next [{ item: a, rest: b }]
                         @NonEmpty c
-                
+
                     when nonEmpty is
                         _ -> Bool.false
                 "#
@@ -871,7 +872,7 @@ mod test {
             indoc!(
                 r#"
                 This expectation failed:
-                
+
                  8│>  expect
                  9│>      nonEmpty =
                 10│>          a = "abcdefgh"
@@ -881,9 +882,9 @@ mod test {
                 14│>
                 15│>      when nonEmpty is
                 16│>          _ -> Bool.false
-                
+
                 When it failed, these variables had these values:
-                
+
                 nonEmpty : NonEmpty
                 nonEmpty = @NonEmpty (Next [{ item: "abcdefgh", rest: @NonEmpty (First "ijkl" 67) }])
                 "#

--- a/crates/reporting/src/error/canonicalize.rs
+++ b/crates/reporting/src/error/canonicalize.rs
@@ -1017,9 +1017,20 @@ pub fn can_problem<'b>(
         }
         Problem::UnnecessaryOutputWildcard { region } => {
             doc = alloc.stack([
-                alloc.reflow("I see you annotated a wildcard in a place where it's not needed:"),
+                alloc.concat([
+                    alloc.reflow("This type annotation has a wildcard type variable ("),
+                    alloc.keyword("*"),
+                    alloc.reflow(") that isn't needed."),
+                ]),
                 alloc.region(lines.convert_region(region)),
-                alloc.reflow("Tag unions that are constants, or the return values of functions, are always inferred to be open by default! You can remove this annotation safely."),
+                alloc.concat([
+                    alloc.reflow("Annotations for tag unions which are constants, or which are returned from functions, work the same way with or without a "),
+                    alloc.keyword("*"),
+                    alloc.reflow(" at the end. (The "),
+                    alloc.keyword("*"),
+                    alloc.reflow(" means something different when the tag union is an argument to a function, though!)"),
+                ]),
+                alloc.reflow("You can safely remove this to make the code more concise without changing what it means."),
             ]);
             title = "UNNECESSARY WILDCARD".to_string();
             severity = Severity::Warning;

--- a/crates/reporting/src/error/expect.rs
+++ b/crates/reporting/src/error/expect.rs
@@ -94,11 +94,13 @@ impl<'a> Renderer<'a> {
                 self.alloc
                     .text("When it failed, these variables had these values:"),
                 self.alloc.stack(it),
+                self.alloc.text(""), // Blank line at the end
             ])
         } else {
             self.alloc.stack([
                 self.alloc.text("This expectation failed:"),
                 self.alloc.region(line_col_region),
+                self.alloc.text(""), // Blank line at the end
             ])
         }
     }

--- a/crates/reporting/tests/test_reporting.rs
+++ b/crates/reporting/tests/test_reporting.rs
@@ -11772,14 +11772,19 @@ All branches in an `if` must have the same type!
     @r###"
     ── UNNECESSARY WILDCARD ────────────────────────────────── /code/proj/Main.roc ─
 
-    I see you annotated a wildcard in a place where it's not needed:
+    This type annotation has a wildcard type variable (`*`) that isn't
+    needed.
 
     4│      f : {} -> [A, B]*
                             ^
 
-    Tag unions that are constants, or the return values of functions, are
-    always inferred to be open by default! You can remove this annotation
-    safely.
+    Annotations for tag unions which are constants, or which are returned
+    from functions, work the same way with or without a `*` at the end. (The
+    `*` means something different when the tag union is an argument to a
+    function, though!)
+
+    You can safely remove this to make the code more concise without
+    changing what it means.
     "###
     );
 


### PR DESCRIPTION
- Added a newline after failed inline `expect` reports
- Revised wording for `UNNECESSARY WILDCARD` warnings