### PR TITLE
Refactor parser methods to not return State as part of ParseError

### DIFF
--- a/crates/cli/src/format.rs
+++ b/crates/cli/src/format.rs
@@ -157,9 +157,7 @@ fn parse_all<'a>(arena: &'a Bump, src: &'a str) -> Result<Ast<'a>, SyntaxError<'
     let (module, state) = module::parse_header(arena, State::new(src.as_bytes()))
         .map_err(|e| SyntaxError::Header(e.problem))?;
 
-    let (_, defs, _) = module_defs()
-        .parse(arena, state, 0)
-        .map_err(|(_, e, _)| e)?;
+    let (_, defs, _) = module_defs().parse(arena, state, 0).map_err(|(_, e)| e)?;
 
     Ok(Ast { module, defs })
 }

--- a/crates/compiler/load_internal/src/file.rs
+++ b/crates/compiler/load_internal/src/file.rs
@@ -4860,11 +4860,11 @@ fn parse<'a>(arena: &'a Bump, header: ModuleHeader<'a>) -> Result<Msg<'a>, Loadi
     let parse_start = Instant::now();
     let source = header.parse_state.original_bytes();
     let parse_state = header.parse_state;
-    let parsed_defs = match module_defs().parse(arena, parse_state, 0) {
+    let parsed_defs = match module_defs().parse(arena, parse_state.clone(), 0) {
         Ok((_, success, _state)) => success,
-        Err((_, fail, state)) => {
+        Err((_, fail)) => {
             return Err(LoadingProblem::ParsingFailed(
-                fail.into_file_error(header.module_path, &state),
+                fail.into_file_error(header.module_path, &parse_state),
             ));
         }
     };

--- a/crates/compiler/parse/src/blankspace.rs
+++ b/crates/compiler/parse/src/blankspace.rs
@@ -159,7 +159,7 @@ where
         if state.column() >= min_indent {
             Ok((NoProgress, (), state))
         } else {
-            Err((NoProgress, indent_problem(state.pos()), state))
+            Err((NoProgress, indent_problem(state.pos())))
         }
     }
 }
@@ -184,7 +184,6 @@ where
         FastSpaceState::HasTab(position) => Err((
             MadeProgress,
             E::space_problem(BadInputError::HasTab, position),
-            state,
         )),
         FastSpaceState::Good {
             newlines,
@@ -194,7 +193,7 @@ where
             if consumed == 0 {
                 Ok((NoProgress, &[] as &[_], state))
             } else if column < min_indent {
-                Err((MadeProgress, indent_problem(state.pos()), state))
+                Err((MadeProgress, indent_problem(state.pos())))
             } else {
                 let comments_and_newlines = Vec::with_capacity_in(newlines, arena);
                 let spaces = eat_spaces(state, comments_and_newlines);
@@ -218,7 +217,6 @@ where
         FastSpaceState::HasTab(position) => Err((
             MadeProgress,
             E::space_problem(BadInputError::HasTab, position),
-            state,
         )),
         FastSpaceState::Good {
             newlines,

--- a/crates/compiler/parse/src/expr.rs
+++ b/crates/compiler/parse/src/expr.rs
@@ -14,7 +14,7 @@ use crate::parser::{
     word1_indent, word2, EClosure, EExpect, EExpr, EIf, EInParens, EList, ENumber, EPattern,
     ERecord, EString, ETuple, EType, EWhen, Either, ParseResult, Parser,
 };
-use crate::pattern::{loc_closure_param, loc_has_parser};
+use crate::pattern::{closure_param, loc_has_parser};
 use crate::state::State;
 use crate::type_annotation;
 use bumpalo::collections::Vec;
@@ -30,7 +30,7 @@ fn expr_end<'a>() -> impl Parser<'a, (), EExpr<'a>> {
         if state.has_reached_end() {
             Ok((NoProgress, (), state))
         } else {
-            Err((NoProgress, EExpr::BadExprEnd(state.pos()), state))
+            Err((NoProgress, EExpr::BadExprEnd(state.pos())))
         }
     }
 }
@@ -44,7 +44,7 @@ pub fn test_parse_expr<'a>(
 
     match parser.parse(arena, state, min_indent) {
         Ok((_, expression, _)) => Ok(expression),
-        Err((_, fail, _)) => Err(fail),
+        Err((_, fail)) => Err(fail),
     }
 }
 
@@ -102,7 +102,7 @@ fn loc_expr_in_parens_help<'a>() -> impl Parser<'a, Loc<Expr<'a>>, EInParens<'a>
                     state,
                 ))
             } else if elements.is_empty() {
-                Err((NoProgress, EInParens::Empty(state.pos()), state))
+                Err((NoProgress, EInParens::Empty(state.pos())))
             } else {
                 // TODO: don't discard comments before/after
                 // (stored in the Collection)
@@ -157,7 +157,11 @@ fn loc_expr_in_parens_etc_help<'a>() -> impl Parser<'a, Loc<Expr<'a>>, EExpr<'a>
 }
 
 fn record_field_access_chain<'a>() -> impl Parser<'a, Vec<'a, &'a str>, EExpr<'a>> {
-    |arena, state, min_indent| match record_field_access().parse(arena, state, min_indent) {
+    |arena, state: State<'a>, min_indent| match record_field_access().parse(
+        arena,
+        state.clone(),
+        min_indent,
+    ) {
         Ok((_, initial, state)) => {
             let mut accesses = Vec::with_capacity_in(1, arena);
 
@@ -165,18 +169,18 @@ fn record_field_access_chain<'a>() -> impl Parser<'a, Vec<'a, &'a str>, EExpr<'a
 
             let mut loop_state = state;
             loop {
-                match record_field_access().parse(arena, loop_state, min_indent) {
+                match record_field_access().parse(arena, loop_state.clone(), min_indent) {
                     Ok((_, next, state)) => {
                         accesses.push(next);
                         loop_state = state;
                     }
-                    Err((MadeProgress, fail, state)) => return Err((MadeProgress, fail, state)),
-                    Err((NoProgress, _, state)) => return Ok((MadeProgress, accesses, state)),
+                    Err((MadeProgress, fail)) => return Err((MadeProgress, fail)),
+                    Err((NoProgress, _)) => return Ok((MadeProgress, accesses, loop_state)),
                 }
             }
         }
-        Err((MadeProgress, fail, state)) => Err((MadeProgress, fail, state)),
-        Err((NoProgress, _, state)) => Err((NoProgress, EExpr::Access(state.pos()), state)),
+        Err((MadeProgress, fail)) => Err((MadeProgress, fail)),
+        Err((NoProgress, _)) => Err((NoProgress, EExpr::Access(state.pos()))),
     }
 }
 
@@ -292,7 +296,7 @@ fn loc_possibly_negative_or_negated_term<'a>(
 }
 
 fn fail_expr_start_e<'a, T: 'a>() -> impl Parser<'a, T, EExpr<'a>> {
-    |_arena, state: State<'a>, _min_indent: u32| Err((NoProgress, EExpr::Start(state.pos()), state))
+    |_arena, state: State<'a>, _min_indent: u32| Err((NoProgress, EExpr::Start(state.pos())))
 }
 
 fn unary_negate<'a>() -> impl Parser<'a, (), EExpr<'a>> {
@@ -313,7 +317,7 @@ fn unary_negate<'a>() -> impl Parser<'a, (), EExpr<'a>> {
             Ok((MadeProgress, (), state))
         } else {
             // this is not a negated expression
-            Err((NoProgress, EExpr::UnaryNot(state.pos()), state))
+            Err((NoProgress, EExpr::UnaryNot(state.pos())))
         }
     }
 }
@@ -338,8 +342,8 @@ fn expr_operator_chain<'a>(options: ExprParseOptions) -> impl Parser<'a, Expr<'a
         let initial_state = state.clone();
         let end = state.pos();
 
-        match space0_e(EExpr::IndentEnd).parse(arena, state, min_indent) {
-            Err((_, _, state)) => Ok((MadeProgress, expr.value, state)),
+        match space0_e(EExpr::IndentEnd).parse(arena, state.clone(), min_indent) {
+            Err((_, _)) => Ok((MadeProgress, expr.value, state)),
             Ok((_, spaces_before_op, state)) => {
                 let expr_state = ExprState {
                     operators: Vec::new_in(arena),
@@ -570,14 +574,14 @@ pub fn parse_single_def<'a>(
     let spaces_before_current_start = state.pos();
 
     let state = match space0_e(EExpr::IndentStart).parse(arena, state, min_indent) {
-        Err((MadeProgress, _, s)) => {
-            return Err((MadeProgress, EExpr::DefMissingFinalExpr(s.pos()), s));
+        Err((MadeProgress, _)) => {
+            return Err((MadeProgress, EExpr::DefMissingFinalExpr(initial.pos())));
         }
         Ok((_, spaces, state)) => {
             spaces_before_current = spaces;
             state
         }
-        Err((NoProgress, _, state)) => state,
+        Err((NoProgress, _)) => initial.clone(),
     };
 
     let start = state.pos();
@@ -591,9 +595,9 @@ pub fn parse_single_def<'a>(
         state.clone(),
         min_indent,
     ) {
-        Err((NoProgress, _, _)) => {
+        Err((NoProgress, _)) => {
             match parse_expect.parse(arena, state, min_indent) {
-                Err((_, _, _)) => {
+                Err((_, _)) => {
                     // a hacky way to get expression-based error messages. TODO fix this
                     Ok((NoProgress, None, initial))
                 }
@@ -645,7 +649,7 @@ pub fn parse_single_def<'a>(
                 }
             }
         }
-        Err((MadeProgress, _, _)) => {
+        Err((MadeProgress, _)) => {
             // a hacky way to get expression-based error messages. TODO fix this
             Ok((NoProgress, None, initial))
         }
@@ -1014,7 +1018,7 @@ fn parse_defs_end<'a>(
                 next_state
             }
             Ok((progress, None, s)) => return Ok((progress, defs, s)),
-            Err((progress, err, s)) => return Err((progress, err, s)),
+            Err((progress, err)) => return Err((progress, err)),
         };
     }
 }
@@ -1038,12 +1042,11 @@ fn parse_defs_expr<'a>(
             // this is no def, because there is no `=` or `:`; parse as an expr
             let parse_final_expr = space0_before_e(loc_expr(), EExpr::IndentEnd);
 
-            match parse_final_expr.parse(arena, state, min_indent) {
-                Err((_, fail, state)) => {
+            match parse_final_expr.parse(arena, state.clone(), min_indent) {
+                Err((_, fail)) => {
                     return Err((
                         MadeProgress,
                         EExpr::DefMissingFinalExpr2(arena.alloc(fail), state.pos()),
-                        state,
                     ));
                 }
                 Ok((_, loc_ret, state)) => {
@@ -1104,7 +1107,7 @@ fn finish_parsing_alias_or_opaque<'a>(
 
     let (expr, arguments) = expr_state
         .validate_is_type_def(arena, loc_op, kind)
-        .map_err(|fail| (MadeProgress, fail, state.clone()))?;
+        .map_err(|fail| (MadeProgress, fail))?;
 
     let mut defs = Defs::default();
 
@@ -1180,8 +1183,8 @@ fn finish_parsing_alias_or_opaque<'a>(
                         ),
                     );
 
-                    match parser.parse(arena, state, min_indent) {
-                        Err((_, fail, state)) => return Err((MadeProgress, fail, state)),
+                    match parser.parse(arena, state.clone(), min_indent) {
+                        Err((_, fail)) => return Err((MadeProgress, fail)),
                         Ok((_, mut ann_type, state)) => {
                             // put the spaces from after the operator in front of the call
                             if !spaces_after_operator.is_empty() {
@@ -1209,7 +1212,7 @@ fn finish_parsing_alias_or_opaque<'a>(
                     };
                     let fail = EExpr::BadOperator(op, loc_op.region.start());
 
-                    return Err((MadeProgress, fail, state));
+                    return Err((MadeProgress, fail));
                 }
             }
         }
@@ -1261,12 +1264,10 @@ mod ability {
         indent: IndentLevel,
     ) -> impl Parser<'a, (u32, AbilityMember<'a>), EAbility<'a>> {
         move |arena, state: State<'a>, min_indent: u32| {
-            let initial = state.clone();
-
             // Put no restrictions on the indent after the spaces; we'll check it manually.
             match space0_e(EAbility::DemandName).parse(arena, state, 0) {
-                Err((MadeProgress, fail, _)) => Err((NoProgress, fail, initial)),
-                Err((NoProgress, fail, _)) => Err((NoProgress, fail, initial)),
+                Err((MadeProgress, fail)) => Err((NoProgress, fail)),
+                Err((NoProgress, fail)) => Err((NoProgress, fail)),
 
                 Ok((_progress, spaces, state)) => {
                     match indent {
@@ -1275,7 +1276,6 @@ mod ability {
                             Err((
                                 MadeProgress,
                                 EAbility::DemandAlignment(indent_difference, state.pos()),
-                                initial,
                             ))
                         }
                         IndentLevel::Exact(wanted) if state.column() < wanted => {
@@ -1286,7 +1286,6 @@ mod ability {
                                 // expression
                                 NoProgress,
                                 EAbility::DemandAlignment(indent_difference, state.pos()),
-                                initial,
                             ))
                         }
                         IndentLevel::Exact(wanted) if state.column() > wanted => {
@@ -1304,7 +1303,6 @@ mod ability {
                             Err((
                                 progress,
                                 EAbility::DemandAlignment(indent_difference, state.pos()),
-                                initial,
                             ))
                         }
                         _ => {
@@ -1312,14 +1310,12 @@ mod ability {
 
                             let parser = parse_demand_help();
 
-                            match parser.parse(arena, state, min_indent) {
-                                Err((MadeProgress, fail, state)) => {
-                                    Err((MadeProgress, fail, state))
-                                }
-                                Err((NoProgress, fail, _)) => {
+                            match parser.parse(arena, state.clone(), min_indent) {
+                                Err((MadeProgress, fail)) => Err((MadeProgress, fail)),
+                                Err((NoProgress, fail)) => {
                                     // We made progress relative to the entire ability definition,
                                     // so this is an error.
-                                    Err((MadeProgress, fail, initial))
+                                    Err((MadeProgress, fail))
                                 }
 
                                 Ok((_, mut demand, state)) => {
@@ -1355,12 +1351,11 @@ fn finish_parsing_ability_def_help<'a>(
 
     // Parse the first demand. This will determine the indentation level all the
     // other demands must observe.
+    let start = state.pos();
     let (_, (demand_indent_level, first_demand), mut state) =
         ability::parse_demand(ability::IndentLevel::PendingMin(min_indent_for_demand))
             .parse(arena, state, min_indent_for_demand)
-            .map_err(|(progress, err, state)| {
-                (progress, EExpr::Ability(err, state.pos()), state)
-            })?;
+            .map_err(|(progress, err)| (progress, EExpr::Ability(err, start)))?;
     demands.push(first_demand);
 
     let demand_indent = ability::IndentLevel::Exact(demand_indent_level);
@@ -1372,15 +1367,10 @@ fn finish_parsing_ability_def_help<'a>(
                 state = next_state;
                 demands.push(demand);
             }
-            Err((MadeProgress, problem, old_state)) => {
-                return Err((
-                    MadeProgress,
-                    EExpr::Ability(problem, old_state.pos()),
-                    old_state,
-                ));
+            Err((MadeProgress, problem)) => {
+                return Err((MadeProgress, EExpr::Ability(problem, state.pos())));
             }
-            Err((NoProgress, _, old_state)) => {
-                state = old_state;
+            Err((NoProgress, _)) => {
                 break;
             }
         }
@@ -1431,10 +1421,11 @@ fn parse_expr_operator<'a>(
 
             let initial_state = state.clone();
 
-            let (spaces, state) = match space0_e(EExpr::IndentEnd).parse(arena, state, min_indent) {
-                Err((_, _, state)) => (&[] as &[_], state),
-                Ok((_, spaces, state)) => (spaces, state),
-            };
+            let (spaces, state) =
+                match space0_e(EExpr::IndentEnd).parse(arena, state.clone(), min_indent) {
+                    Err((_, _)) => (&[] as &[_], state),
+                    Ok((_, spaces, state)) => (spaces, state),
+                };
 
             expr_state.arguments.push(arena.alloc(arg));
             expr_state.spaces_after = spaces;
@@ -1448,7 +1439,7 @@ fn parse_expr_operator<'a>(
 
             let call = expr_state
                 .validate_assignment_or_backpassing(arena, loc_op, EExpr::ElmStyleFunction)
-                .map_err(|fail| (MadeProgress, fail, state.clone()))?;
+                .map_err(|fail| (MadeProgress, fail))?;
 
             let (value_def, def_region, state) = {
                 match expr_to_pattern_help(arena, &call.value) {
@@ -1475,7 +1466,7 @@ fn parse_expr_operator<'a>(
                         // this `=` likely occurred inline; treat it as an invalid operator
                         let fail = EExpr::BadOperator(arena.alloc("="), loc_op.region.start());
 
-                        return Err((MadeProgress, fail, state));
+                        return Err((MadeProgress, fail));
                     }
                 }
             };
@@ -1493,7 +1484,7 @@ fn parse_expr_operator<'a>(
                 .validate_assignment_or_backpassing(arena, loc_op, |_, pos| {
                     EExpr::BadOperator("<-", pos)
                 })
-                .map_err(|fail| (MadeProgress, fail, state.clone()))?;
+                .map_err(|fail| (MadeProgress, fail))?;
 
             let (loc_pattern, loc_body, state) = {
                 match expr_to_pattern_help(arena, &call.value) {
@@ -1514,7 +1505,7 @@ fn parse_expr_operator<'a>(
                         // this `=` likely occurred inline; treat it as an invalid operator
                         let fail = EExpr::BadOperator("=", loc_op.region.start());
 
-                        return Err((MadeProgress, fail, state));
+                        return Err((MadeProgress, fail));
                     }
                 }
             };
@@ -1545,8 +1536,12 @@ fn parse_expr_operator<'a>(
                 _ => unreachable!(),
             },
         ),
-        _ => match loc_possibly_negative_or_negated_term(options).parse(arena, state, min_indent) {
-            Err((MadeProgress, f, s)) => Err((MadeProgress, f, s)),
+        _ => match loc_possibly_negative_or_negated_term(options).parse(
+            arena,
+            state.clone(),
+            min_indent,
+        ) {
+            Err((MadeProgress, f)) => Err((MadeProgress, f)),
             Ok((_, mut new_expr, state)) => {
                 let new_end = state.pos();
 
@@ -1559,8 +1554,8 @@ fn parse_expr_operator<'a>(
                         .with_spaces_before(spaces_after_operator, new_expr.region);
                 }
 
-                match space0_e(EExpr::IndentEnd).parse(arena, state, min_indent) {
-                    Err((_, _, state)) => {
+                match space0_e(EExpr::IndentEnd).parse(arena, state.clone(), min_indent) {
+                    Err((_, _)) => {
                         let args = std::mem::replace(&mut expr_state.arguments, Vec::new_in(arena));
 
                         let call = to_call(arena, args, expr_state.expr);
@@ -1588,8 +1583,8 @@ fn parse_expr_operator<'a>(
                     }
                 }
             }
-            Err((NoProgress, expr, e)) => {
-                todo!("{:?} {:?}", expr, e)
+            Err((NoProgress, expr)) => {
+                todo!("{:?} {:?}", expr, state)
             }
         },
     }
@@ -1609,7 +1604,7 @@ fn parse_expr_end<'a>(
     );
 
     match parser.parse(arena, state.clone(), min_indent) {
-        Err((MadeProgress, f, s)) => Err((MadeProgress, f, s)),
+        Err((MadeProgress, f)) => Err((MadeProgress, f)),
         Ok((
             _,
             has @ Loc {
@@ -1638,11 +1633,7 @@ fn parse_expr_end<'a>(
                     Err(_) => {
                         let start = argument.region.start();
                         let err = &*arena.alloc(EPattern::Start(start));
-                        return Err((
-                            MadeProgress,
-                            EExpr::Pattern(err, argument.region.start()),
-                            state,
-                        ));
+                        return Err((MadeProgress, EExpr::Pattern(err, argument.region.start())));
                     }
                 }
             }
@@ -1679,8 +1670,8 @@ fn parse_expr_end<'a>(
             }
             let initial_state = state.clone();
 
-            match space0_e(EExpr::IndentEnd).parse(arena, state, min_indent) {
-                Err((_, _, state)) => {
+            match space0_e(EExpr::IndentEnd).parse(arena, state.clone(), min_indent) {
+                Err((_, _)) => {
                     expr_state.arguments.push(arena.alloc(arg));
                     expr_state.end = new_end;
                     expr_state.spaces_after = &[];
@@ -1697,11 +1688,11 @@ fn parse_expr_end<'a>(
                 }
             }
         }
-        Err((NoProgress, _, _)) => {
+        Err((NoProgress, _)) => {
             let before_op = state.clone();
             // try an operator
-            match loc!(operator()).parse(arena, state, min_indent) {
-                Err((MadeProgress, f, s)) => Err((MadeProgress, f, s)),
+            match loc!(operator()).parse(arena, state.clone(), min_indent) {
+                Err((MadeProgress, f)) => Err((MadeProgress, f)),
                 Ok((_, loc_op, state)) => {
                     expr_state.consume_spaces(arena);
                     let initial_state = before_op;
@@ -1715,7 +1706,8 @@ fn parse_expr_end<'a>(
                         initial_state,
                     )
                 }
-                Err((NoProgress, _, mut state)) => {
+                Err((NoProgress, _)) => {
+                    let mut state = state;
                     // try multi-backpassing
                     if options.accept_multi_backpassing && state.bytes().starts_with(b",") {
                         state = state.advance(1);
@@ -1743,10 +1735,12 @@ fn parse_expr_end<'a>(
 
                         patterns.insert(0, loc_pattern);
 
-                        match word2(b'<', b'-', EExpr::BackpassArrow)
-                            .parse(arena, state, min_indent)
-                        {
-                            Err((_, fail, state)) => Err((MadeProgress, fail, state)),
+                        match word2(b'<', b'-', EExpr::BackpassArrow).parse(
+                            arena,
+                            state.clone(),
+                            min_indent,
+                        ) {
+                            Err((_, fail)) => Err((MadeProgress, fail)),
                             Ok((_, _, state)) => {
                                 let parse_body = space0_before_e(
                                     increment_min_indent(loc_expr()),
@@ -1771,7 +1765,7 @@ fn parse_expr_end<'a>(
                             }
                         }
                     } else if options.check_for_arrow && state.bytes().starts_with(b"->") {
-                        Err((MadeProgress, EExpr::BadOperator("->", state.pos()), state))
+                        Err((MadeProgress, EExpr::BadOperator("->", state.pos())))
                     } else {
                         let expr = parse_expr_final(expr_state, arena);
 
@@ -1998,7 +1992,7 @@ fn closure_help<'a>(options: ExprParseOptions) -> impl Parser<'a, Expr<'a>, EClo
                 sep_by1_e(
                     word1(b',', EClosure::Comma),
                     space0_around_ee(
-                        specialize(EClosure::Pattern, loc_closure_param()),
+                        specialize(EClosure::Pattern, closure_param()),
                         EClosure::IndentArg,
                         EClosure::IndentArrow,
                     ),
@@ -2090,11 +2084,7 @@ mod when {
                                 Ok((MadeProgress, (loc_patterns, loc_guard), state))
                             } else {
                                 let indent = pattern_indent_level - indent_column;
-                                Err((
-                                    MadeProgress,
-                                    EWhen::PatternAlignment(indent, state.pos()),
-                                    state,
-                                ))
+                                Err((MadeProgress, EWhen::PatternAlignment(indent, state.pos())))
                             }
                         },
                     ),
@@ -2111,18 +2101,16 @@ mod when {
             );
 
             while !state.bytes().is_empty() {
-                match branch_parser.parse(arena, state, min_indent) {
+                match branch_parser.parse(arena, state.clone(), min_indent) {
                     Ok((_, next_output, next_state)) => {
                         state = next_state;
 
                         branches.push(arena.alloc(next_output));
                     }
-                    Err((MadeProgress, problem, old_state)) => {
-                        return Err((MadeProgress, problem, old_state));
+                    Err((MadeProgress, problem)) => {
+                        return Err((MadeProgress, problem));
                     }
-                    Err((NoProgress, _, old_state)) => {
-                        state = old_state;
-
+                    Err((NoProgress, _)) => {
                         break;
                     }
                 }
@@ -2193,25 +2181,19 @@ mod when {
         pattern_indent_level: Option<u32>,
     ) -> impl Parser<'a, (u32, Vec<'a, Loc<Pattern<'a>>>), EWhen<'a>> {
         move |arena, state: State<'a>, min_indent: u32| {
-            let initial = state.clone();
-
             // put no restrictions on the indent after the spaces; we'll check it manually
             match space0_e(EWhen::IndentPattern).parse(arena, state, 0) {
-                Err((MadeProgress, fail, _)) => Err((NoProgress, fail, initial)),
-                Err((NoProgress, fail, _)) => Err((NoProgress, fail, initial)),
+                Err((MadeProgress, fail)) => Err((NoProgress, fail)),
+                Err((NoProgress, fail)) => Err((NoProgress, fail)),
                 Ok((_progress, spaces, state)) => {
                     match pattern_indent_level {
                         Some(wanted) if state.column() > wanted => {
                             // this branch is indented too much
-                            Err((NoProgress, EWhen::IndentPattern(state.pos()), initial))
+                            Err((NoProgress, EWhen::IndentPattern(state.pos())))
                         }
                         Some(wanted) if state.column() < wanted => {
                             let indent = wanted - state.column();
-                            Err((
-                                NoProgress,
-                                EWhen::PatternAlignment(indent, state.pos()),
-                                initial,
-                            ))
+                            Err((NoProgress, EWhen::PatternAlignment(indent, state.pos())))
                         }
                         _ => {
                             let pattern_indent =
@@ -2223,13 +2205,11 @@ mod when {
                             let parser =
                                 sep_by1(word1(b'|', EWhen::Bar), branch_single_alternative());
 
-                            match parser.parse(arena, state, pattern_indent) {
-                                Err((MadeProgress, fail, state)) => {
-                                    Err((MadeProgress, fail, state))
-                                }
-                                Err((NoProgress, fail, _)) => {
+                            match parser.parse(arena, state.clone(), pattern_indent) {
+                                Err((MadeProgress, fail)) => Err((MadeProgress, fail)),
+                                Err((NoProgress, fail)) => {
                                     // roll back space parsing if the pattern made no progress
-                                    Err((NoProgress, fail, initial))
+                                    Err((NoProgress, fail))
                                 }
 
                                 Ok((_, mut loc_patterns, state)) => {
@@ -2303,7 +2283,7 @@ fn expect_help<'a>(options: ExprParseOptions) -> impl Parser<'a, Expr<'a>, EExpe
             EExpect::IndentCondition,
         )
         .parse(arena, state, start_column + 1)
-        .map_err(|(_, f, s)| (MadeProgress, f, s))?;
+        .map_err(|(_, f)| (MadeProgress, f))?;
 
         let parse_cont = specialize_ref(
             EExpect::Continuation,
@@ -2340,8 +2320,8 @@ fn if_expr_help<'a>(options: ExprParseOptions) -> impl Parser<'a, Expr<'a>, EIf<
                 parser::keyword_e(keyword::IF, EIf::If)
             );
 
-            match optional_if.parse(arena, state, min_indent) {
-                Err((_, _, state)) => break state,
+            match optional_if.parse(arena, state.clone(), min_indent) {
+                Err((_, _)) => break state,
                 Ok((_, _, state)) => {
                     loop_state = state;
                     continue;
@@ -2354,7 +2334,7 @@ fn if_expr_help<'a>(options: ExprParseOptions) -> impl Parser<'a, Expr<'a>, EIf<
             EIf::IndentElseBranch,
         )
         .parse(arena, state_final_else, min_indent)
-        .map_err(|(_, f, s)| (MadeProgress, f, s))?;
+        .map_err(|(_, f)| (MadeProgress, f))?;
 
         let expr = Expr::If(branches.into_bump_slice(), arena.alloc(else_branch));
 
@@ -2711,12 +2691,12 @@ where
 
     macro_rules! bad_made_progress {
         ($op:expr) => {{
-            Err((MadeProgress, to_error($op, state.pos()), state))
+            Err((MadeProgress, to_error($op, state.pos())))
         }};
     }
 
     match chomped {
-        "" => Err((NoProgress, to_expectation(state.pos()), state)),
+        "" => Err((NoProgress, to_expectation(state.pos()))),
         "+" => good!(BinOp::Plus, 1),
         "-" => good!(BinOp::Minus, 1),
         "*" => good!(BinOp::Star, 1),
@@ -2727,7 +2707,7 @@ where
         "<" => good!(BinOp::LessThan, 1),
         "." => {
             // a `.` makes no progress, so it does not interfere with `.foo` access(or)
-            Err((NoProgress, to_error(".", state.pos()), state))
+            Err((NoProgress, to_error(".", state.pos())))
         }
         "=" => good!(BinOp::Assignment, 1),
         ":=" => good!(BinOp::IsOpaqueType, 2),
@@ -2742,7 +2722,7 @@ where
         "//" => good!(BinOp::DoubleSlash, 2),
         "->" => {
             // makes no progress, so it does not interfere with `_ if isGood -> ...`
-            Err((NoProgress, to_error("->", state.pos()), state))
+            Err((NoProgress, to_error("->", state.pos())))
         }
         "<-" => good!(BinOp::Backpassing, 2),
         _ => bad_made_progress!(chomped),

--- a/crates/compiler/parse/src/header.rs
+++ b/crates/compiler/parse/src/header.rs
@@ -312,8 +312,8 @@ pub fn package_name<'a>() -> impl Parser<'a, PackageName<'a>, EPackageName<'a>> 
             .parse(arena, state, min_indent)
             .and_then(|(progress, text, next_state)| match text {
                 StrLiteral::PlainLine(text) => Ok((progress, PackageName(text), next_state)),
-                StrLiteral::Line(_) => Err((progress, EPackageName::Escapes(pos), next_state)),
-                StrLiteral::Block(_) => Err((progress, EPackageName::Multiline(pos), next_state)),
+                StrLiteral::Line(_) => Err((progress, EPackageName::Escapes(pos))),
+                StrLiteral::Block(_) => Err((progress, EPackageName::Multiline(pos))),
             })
     }
 }

--- a/crates/compiler/parse/src/ident.rs
+++ b/crates/compiler/parse/src/ident.rs
@@ -88,10 +88,10 @@ impl<'a> Ident<'a> {
 /// * A named pattern match, e.g. "foo" in `foo =` or `foo ->` or `\foo ->`
 pub fn lowercase_ident<'a>() -> impl Parser<'a, &'a str, ()> {
     move |_, state: State<'a>, _min_indent: u32| match chomp_lowercase_part(state.bytes()) {
-        Err(progress) => Err((progress, (), state)),
+        Err(progress) => Err((progress, ())),
         Ok(ident) => {
             if crate::keyword::KEYWORDS.iter().any(|kw| &ident == kw) {
-                Err((NoProgress, (), state))
+                Err((NoProgress, ()))
             } else {
                 let width = ident.len();
                 Ok((MadeProgress, ident, state.advance(width)))
@@ -113,7 +113,7 @@ pub fn tag_name<'a>() -> impl Parser<'a, &'a str, ()> {
 /// * A tag
 pub fn uppercase<'a>() -> impl Parser<'a, UppercaseIdent<'a>, ()> {
     move |_, state: State<'a>, _min_indent: u32| match chomp_uppercase_part(state.bytes()) {
-        Err(progress) => Err((progress, (), state)),
+        Err(progress) => Err((progress, ())),
         Ok(ident) => {
             let width = ident.len();
             Ok((MadeProgress, ident.into(), state.advance(width)))
@@ -128,7 +128,7 @@ pub fn uppercase<'a>() -> impl Parser<'a, UppercaseIdent<'a>, ()> {
 /// * A tag
 pub fn uppercase_ident<'a>() -> impl Parser<'a, &'a str, ()> {
     move |_, state: State<'a>, _min_indent: u32| match chomp_uppercase_part(state.bytes()) {
-        Err(progress) => Err((progress, (), state)),
+        Err(progress) => Err((progress, ())),
         Ok(ident) => {
             let width = ident.len();
             Ok((MadeProgress, ident, state.advance(width)))
@@ -138,10 +138,10 @@ pub fn uppercase_ident<'a>() -> impl Parser<'a, &'a str, ()> {
 
 pub fn unqualified_ident<'a>() -> impl Parser<'a, &'a str, ()> {
     move |_, state: State<'a>, _min_indent: u32| match chomp_anycase_part(state.bytes()) {
-        Err(progress) => Err((progress, (), state)),
+        Err(progress) => Err((progress, ())),
         Ok(ident) => {
             if crate::keyword::KEYWORDS.iter().any(|kw| &ident == kw) {
-                Err((MadeProgress, (), state))
+                Err((MadeProgress, ()))
             } else {
                 let width = ident.len();
                 Ok((MadeProgress, ident, state.advance(width)))
@@ -163,27 +163,32 @@ pub fn parse_ident<'a>(
 ) -> ParseResult<'a, Ident<'a>, EExpr<'a>> {
     let initial = state.clone();
 
-    match parse_ident_help(arena, state) {
-        Ok((progress, ident, state)) => {
+    match chomp_identifier_chain(arena, state.bytes(), state.pos()) {
+        Ok((width, ident)) => {
+            let state = advance_state!(state, width as usize)?;
             if let Ident::Access { module_name, parts } = ident {
                 if module_name.is_empty() {
                     if let Some(first) = parts.first() {
                         for keyword in crate::keyword::KEYWORDS.iter() {
                             if first == keyword {
-                                return Err((NoProgress, EExpr::Start(initial.pos()), initial));
+                                return Err((NoProgress, EExpr::Start(initial.pos())));
                             }
                         }
                     }
                 }
             }
 
-            Ok((progress, ident, state))
+            Ok((MadeProgress, ident, state))
         }
-        Err((NoProgress, _, state)) => Err((NoProgress, EExpr::Start(state.pos()), state)),
-        Err((MadeProgress, fail, state)) => match fail {
-            BadIdent::Start(pos) => Err((NoProgress, EExpr::Start(pos), state)),
-            BadIdent::Space(e, pos) => Err((NoProgress, EExpr::Space(e, pos), state)),
-            _ => malformed_identifier(initial.bytes(), fail, state),
+        Err((0, _)) => Err((NoProgress, EExpr::Start(state.pos()))),
+        Err((width, fail)) => match fail {
+            BadIdent::Start(pos) => Err((NoProgress, EExpr::Start(pos))),
+            BadIdent::Space(e, pos) => Err((NoProgress, EExpr::Space(e, pos))),
+            _ => malformed_identifier(
+                initial.bytes(),
+                fail,
+                advance_state!(state, width as usize)?,
+            ),
         },
     }
 }
@@ -504,7 +509,7 @@ fn chomp_module_chain(buffer: &[u8]) -> Result<u32, Progress> {
 
 pub fn concrete_type<'a>() -> impl Parser<'a, (&'a str, &'a str), ()> {
     move |_, state: State<'a>, _min_indent: u32| match chomp_concrete_type(state.bytes()) {
-        Err(progress) => Err((progress, (), state)),
+        Err(progress) => Err((progress, ())),
         Ok((module_name, type_name, width)) => {
             Ok((MadeProgress, (module_name, type_name), state.advance(width)))
         }
@@ -572,22 +577,5 @@ fn chomp_access_chain<'a>(buffer: &'a [u8], parts: &mut Vec<'a, &'a str>) -> Res
         Err(0)
     } else {
         Ok(chomped as u32)
-    }
-}
-
-fn parse_ident_help<'a>(
-    arena: &'a Bump,
-    mut state: State<'a>,
-) -> ParseResult<'a, Ident<'a>, BadIdent> {
-    match chomp_identifier_chain(arena, state.bytes(), state.pos()) {
-        Ok((width, ident)) => {
-            state = advance_state!(state, width as usize)?;
-            Ok((MadeProgress, ident, state))
-        }
-        Err((0, fail)) => Err((NoProgress, fail, state)),
-        Err((width, fail)) => {
-            state = advance_state!(state, width as usize)?;
-            Err((MadeProgress, fail, state))
-        }
     }
 }

--- a/crates/compiler/parse/src/number_literal.rs
+++ b/crates/compiler/parse/src/number_literal.rs
@@ -20,7 +20,7 @@ pub fn positive_number_literal<'a>() -> impl Parser<'a, NumLiteral<'a>, ENumber>
             }
             _ => {
                 // this is not a number at all
-                Err((Progress::NoProgress, ENumber::End, state))
+                Err((Progress::NoProgress, ENumber::End))
             }
         }
     }
@@ -38,7 +38,7 @@ pub fn number_literal<'a>() -> impl Parser<'a, NumLiteral<'a>, ENumber> {
             }
             _ => {
                 // this is not a number at all
-                Err((Progress::NoProgress, ENumber::End, state))
+                Err((Progress::NoProgress, ENumber::End))
             }
         }
     }
@@ -89,12 +89,12 @@ fn chomp_number_dec<'a>(
 
     if is_negative && chomped == 0 {
         // we're probably actually looking at unary negation here
-        return Err((Progress::NoProgress, ENumber::End, state));
+        return Err((Progress::NoProgress, ENumber::End));
     }
 
     if !bytes.first().copied().unwrap_or_default().is_ascii_digit() {
         // we're probably actually looking at unary negation here
-        return Err((Progress::NoProgress, ENumber::End, state));
+        return Err((Progress::NoProgress, ENumber::End));
     }
 
     let string =

--- a/crates/compiler/parse/src/state.rs
+++ b/crates/compiler/parse/src/state.rs
@@ -58,9 +58,9 @@ impl<'a> State<'a> {
         &self,
         indent: u32,
         e: impl Fn(Position) -> E,
-    ) -> Result<u32, (Progress, E, State<'a>)> {
+    ) -> Result<u32, (Progress, E)> {
         if self.column() < indent {
-            Err((Progress::NoProgress, e(self.pos()), self.clone()))
+            Err((Progress::NoProgress, e(self.pos())))
         } else {
             Ok(std::cmp::max(indent, self.line_indent()))
         }

--- a/crates/compiler/parse/tests/test_parse.rs
+++ b/crates/compiler/parse/tests/test_parse.rs
@@ -846,7 +846,7 @@ mod test_parse {
             Ok((_, _, _state)) => {
                 // dbg!(_state);
             }
-            Err((_, _fail, _state)) => {
+            Err((_, _fail)) => {
                 // dbg!(_fail, _state);
                 panic!("Failed to parse!");
             }

--- a/crates/repl_cli/src/repl_state.rs
+++ b/crates/repl_cli/src/repl_state.rs
@@ -321,12 +321,12 @@ fn parse_src<'a>(arena: &'a Bump, line: &'a str) -> ParseOutcome<'a> {
             match roc_parse::expr::loc_expr().parse(arena, State::new(src_bytes), 0) {
                 Ok((_, loc_expr, _)) => ParseOutcome::Expr(loc_expr.value),
                 // Special case some syntax errors to allow for multi-line inputs
-                Err((_, EExpr::Closure(EClosure::Body(_, _), _), _))
-                | Err((_, EExpr::When(EWhen::Pattern(EPattern::Start(_), _), _), _))
-                | Err((_, EExpr::Start(_), _))
-                | Err((_, EExpr::IndentStart(_), _)) => ParseOutcome::Incomplete,
-                Err((_, EExpr::DefMissingFinalExpr(_), _))
-                | Err((_, EExpr::DefMissingFinalExpr2(_, _), _)) => {
+                Err((_, EExpr::Closure(EClosure::Body(_, _), _)))
+                | Err((_, EExpr::When(EWhen::Pattern(EPattern::Start(_), _), _)))
+                | Err((_, EExpr::Start(_)))
+                | Err((_, EExpr::IndentStart(_))) => ParseOutcome::Incomplete,
+                Err((_, EExpr::DefMissingFinalExpr(_)))
+                | Err((_, EExpr::DefMissingFinalExpr2(_, _))) => {
                     // This indicates that we had an attempted def; re-parse it as a single-line def.
                     match parse_single_def(
                         ExprParseOptions {

--- a/crates/reporting/src/error/parse.rs
+++ b/crates/reporting/src/error/parse.rs
@@ -1547,7 +1547,7 @@ fn to_unexpected_arrow_report<'a>(
         ),
         alloc.concat([
             alloc.reflow(r"It makes sense to see arrows around here, "),
-            alloc.reflow(r"so I suspect it is something earlier."),
+            alloc.reflow(r"so I suspect it is something earlier. "),
             alloc.reflow(
                 r"Maybe this pattern is indented a bit farther from the previous patterns?",
             ),

--- a/crates/reporting/tests/test_reporting.rs
+++ b/crates/reporting/tests/test_reporting.rs
@@ -5011,12 +5011,13 @@ mod test_reporting {
     I am parsing a `when` expression right now, but this arrow is confusing
     me:
 
+    5│          5 -> 2
     6│           _ -> 2
                    ^^
 
     It makes sense to see arrows around here, so I suspect it is something
-    earlier.Maybe this pattern is indented a bit farther from the previous
-    patterns?
+    earlier. Maybe this pattern is indented a bit farther from the
+    previous patterns?
 
     Note: Here is an example of a valid `when` expression for reference.
 
@@ -5047,12 +5048,13 @@ mod test_reporting {
     I am parsing a `when` expression right now, but this arrow is confusing
     me:
 
+    5│          5 -> Num.neg
     6│           2 -> 2
                    ^^
 
     It makes sense to see arrows around here, so I suspect it is something
-    earlier.Maybe this pattern is indented a bit farther from the previous
-    patterns?
+    earlier. Maybe this pattern is indented a bit farther from the
+    previous patterns?
 
     Note: Here is an example of a valid `when` expression for reference.
 
@@ -5295,6 +5297,7 @@ mod test_reporting {
 
     This multiline string is not sufficiently indented:
 
+    4│          """
     5│        testing
               ^
 
@@ -8069,6 +8072,7 @@ All branches in an `if` must have the same type!
         I was partway through parsing an ability definition, but I got stuck
         here:
 
+        4│      MEq has
         5│          eq b c : a, a -> U64 | a has MEq
                        ^
 


### PR DESCRIPTION
As previously discovered with #4464, it's easy to accidentally mis-use the State value returned on the Err path.

There were mixed assumptions about what that State represents: (1) the State where the error occurred, or (2) the State at the beginning of the thing we were just parsing.

I fixed this up to always mean (2) - at which point we don't actually need to return the State at all - so it's impossible for further discrepency to creep in.

I also took the liberty to refactor a few more methods to be purely combinator-based, rather than calling `parse` directly.