### PR TITLE
fix: site.css font-family broken sources

### DIFF
--- a/www/public/site.css
+++ b/www/public/site.css
@@ -367,8 +367,8 @@ h4 {
   font-family: 'Permanent Marker';
   font-style: normal;
   font-weight: 400;
-  src: url('../fonts/permanent-marker-v16-latin/permanent-marker-v16-latin-regular.woff2') format('woff2'),
-       url('../fonts/permanent-marker-v16-latin/permanent-marker-v16-latin-regular.woff') format('woff'),
+  src: url('/fonts/permanent-marker-v16-latin/permanent-marker-v16-latin-regular.woff2') format('woff2'),
+       url('/fonts/permanent-marker-v16-latin/permanent-marker-v16-latin-regular.woff') format('woff');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 
@@ -377,8 +377,8 @@ h4 {
   font-family: 'Merriweather';
   font-style: normal;
   font-weight: 400;
-  src: url('../fonts/merriweather-v30-latin-ext_latin/merriweather-v30-latin-ext_latin-regular.woff2') format('woff2'), 
-       url('../fonts/merriweather-v30-latin-ext_latin/merriweather-v30-latin-ext_latin-regular.woff') format('woff'),
+  src: url('/fonts/merriweather-v30-latin-ext_latin/merriweather-v30-latin-ext_latin-regular.woff2') format('woff2'),
+       url('/fonts/merriweather-v30-latin-ext_latin/merriweather-v30-latin-ext_latin-regular.woff') format('woff');
   unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 
@@ -387,8 +387,8 @@ h4 {
   font-family: 'Merriweather';
   font-style: normal;
   font-weight: 400;
-  src: url('../fonts/merriweather-v30-latin/merriweather-v30-latin-regular.woff2') format('woff2'), 
-       url('../fonts/merriweather-v30-latin/merriweather-v30-latin-regular.woff') format('woff'),
+  src: url('/fonts/merriweather-v30-latin/merriweather-v30-latin-regular.woff2') format('woff2'),
+       url('/fonts/merriweather-v30-latin/merriweather-v30-latin-regular.woff') format('woff');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 
@@ -397,8 +397,8 @@ h4 {
   font-family: 'Merriweather Sans';
   font-style: normal;
   font-weight: 400;
-  src: url('../fonts/merriweather-sans-v22-latin-ext_latin/merriweather-sans-v22-latin-ext_latin-regular.woff2') format('woff2'), 
-       url('../fonts/merriweather-sans-v22-latin-ext_latin/merriweather-sans-v22-latin-ext_latin-regular.woff') format('woff'),
+  src: url('/fonts/merriweather-sans-v22-latin-ext_latin/merriweather-sans-v22-latin-ext_latin-regular.woff2') format('woff2'),
+       url('/fonts/merriweather-sans-v22-latin-ext_latin/merriweather-sans-v22-latin-ext_latin-regular.woff') format('woff');
   unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 /* latin */
@@ -406,8 +406,8 @@ h4 {
   font-family: 'Merriweather Sans';
   font-style: normal;
   font-weight: 400;
-  src: url('../fonts/merriweather-sans-v22-latin/merriweather-sans-v22-latin-regular.woff2') format('woff2'), 
-       url('../fonts/merriweather-sans-v22-latin/merriweather-sans-v22-latin-regular.woff') format('woff'),
+  src: url('/fonts/merriweather-sans-v22-latin/merriweather-sans-v22-latin-regular.woff2') format('woff2'),
+       url('/fonts/merriweather-sans-v22-latin/merriweather-sans-v22-latin-regular.woff') format('woff');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 
@@ -416,8 +416,8 @@ h4 {
   font-family: 'Lato';
   font-style: normal;
   font-weight: 400;
-  src: url('../fonts/lato-v23-latin-ext_latin/lato-v23-latin-ext_latin-regular.woff2') format('woff2'), 
-       url('../fonts/lato-v23-latin-ext_latin/lato-v23-latin-ext_latin-regular.woff') format('woff'),
+  src: url('/fonts/lato-v23-latin-ext_latin/lato-v23-latin-ext_latin-regular.woff2') format('woff2'),
+       url('/fonts/lato-v23-latin-ext_latin/lato-v23-latin-ext_latin-regular.woff') format('woff');
   unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 /* latin */
@@ -425,8 +425,8 @@ h4 {
   font-family: 'Lato';
   font-style: normal;
   font-weight: 400;
-  src: url('../fonts/lato-v23-latin/lato-v23-latin-regular.woff2') format('woff2'), 
-       url('../fonts/lato-v23-latin/lato-v23-latin-regular.woff') format('woff'),
+  src: url('/fonts/lato-v23-latin/lato-v23-latin-regular.woff2') format('woff2'),
+       url('/fonts/lato-v23-latin/lato-v23-latin-regular.woff') format('woff');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 
@@ -435,8 +435,8 @@ h4 {
   font-family: 'Source Code Pro';
   font-style: normal;
   font-weight: 400;
-  src: url('../fonts/source-code-pro-v22-latin-ext_latin/source-code-pro-v22-latin-ext_latin-regular.woff2') format('woff2'), 
-       url('../fonts/source-code-pro-v22-latin-ext_latin/source-code-pro-v22-latin-ext_latin-regular.woff') format('woff'),
+  src: url('/fonts/source-code-pro-v22-latin-ext_latin/source-code-pro-v22-latin-ext_latin-regular.woff2') format('woff2'),
+       url('/fonts/source-code-pro-v22-latin-ext_latin/source-code-pro-v22-latin-ext_latin-regular.woff') format('woff');
   unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 /* latin */
@@ -444,8 +444,8 @@ h4 {
   font-family: 'Source Code Pro';
   font-style: normal;
   font-weight: 400;
-  src: url('../fonts/source-code-pro-v22-latin/source-code-pro-v22-latin-regular.woff2') format('woff2'), 
-       url('../fonts/source-code-pro-v22-latin/source-code-pro-v22-latin-regular.woff') format('woff'),
+  src: url('/fonts/source-code-pro-v22-latin/source-code-pro-v22-latin-regular.woff2') format('woff2'),
+       url('/fonts/source-code-pro-v22-latin/source-code-pro-v22-latin-regular.woff') format('woff');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 


### PR DESCRIPTION
The last change on https://github.com/roc-lang/roc/pull/4539 ended up breaking the src declaration (I've left a trailing `,` there instead of a `;` - sorry! 😅)

This PR fixes that and future-proofs the srcs for usage in other pages as well (since we were using relative src paths).