### PR TITLE
Use include_bytes! so builtin hosts live in binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3993,6 +3993,7 @@ dependencies = [
  "roc_target",
  "roc_types",
  "roc_utils",
+ "tempfile",
  "wasi_libc_sys",
  "wasm-bindgen",
  "wasm-bindgen-futures",

--- a/crates/cli/src/build.rs
+++ b/crates/cli/src/build.rs
@@ -341,14 +341,18 @@ pub fn build_file<'a>(
                 app_o_file.to_str().unwrap(),
             ];
 
-            let builtins_host_tempfile = tempfile::Builder::new()
-                .prefix("host_bitcode")
-                .suffix(".o")
-                .rand_bytes(5)
-                .tempfile()
-                .unwrap();
-            std::fs::write(builtins_host_tempfile.path(), bitcode::HOST_UNIX)
-                .expect("failed to write host builtins object to tempfile");
+            let builtins_host_tempfile = {
+                #[cfg(unix)]
+                {
+                    bitcode::host_unix_tempfile()
+                }
+
+                #[cfg(windows)]
+                {
+                    bitcode::host_windows_tempfile()
+                }
+            }
+            .expect("failed to write host builtins object to tempfile");
 
             if matches!(code_gen_options.backend, program::CodeGenBackend::Assembly) {
                 inputs.push(builtins_host_tempfile.path().to_str().unwrap());

--- a/crates/cli/src/build.rs
+++ b/crates/cli/src/build.rs
@@ -342,10 +342,12 @@ pub fn build_file<'a>(
                 app_o_file.to_str().unwrap(),
             ];
 
-            let str_host_obj_path = bitcode::get_builtins_host_obj_path();
+            let builtins_host_file = tempfile::NamedTempFile::new().unwrap();
+            std::fs::write(builtins_host_file.path(), bitcode::HOST_UNIX)
+                .expect("failed to write host builtins object to tempfile");
 
             if matches!(code_gen_options.backend, program::CodeGenBackend::Assembly) {
-                inputs.push(&str_host_obj_path);
+                inputs.push(builtins_host_file.path().to_str().unwrap());
             }
 
             let (mut child, _) =  // TODO use lld

--- a/crates/cli/src/build.rs
+++ b/crates/cli/src/build.rs
@@ -342,7 +342,12 @@ pub fn build_file<'a>(
                 app_o_file.to_str().unwrap(),
             ];
 
-            let builtins_host_file = tempfile::NamedTempFile::new().unwrap();
+            let builtins_host_file = tempfile::Builder::new()
+                .prefix("host_bitcode")
+                .suffix(".o")
+                .rand_bytes(5)
+                .tempfile()
+                .unwrap();
             std::fs::write(builtins_host_file.path(), bitcode::HOST_UNIX)
                 .expect("failed to write host builtins object to tempfile");
 

--- a/crates/compiler/build/src/link.rs
+++ b/crates/compiler/build/src/link.rs
@@ -155,7 +155,7 @@ pub fn build_zig_host_native(
             "-fPIE",
             "-rdynamic", // make sure roc_alloc and friends are exposed
             shared_lib_path.to_str().unwrap(),
-            builtins_host_file.path(),
+            builtins_host_file.path().to_str().unwrap(),
         ]);
     } else {
         zig_cmd.args(["build-obj", "-fPIC"]);

--- a/crates/compiler/build/src/link.rs
+++ b/crates/compiler/build/src/link.rs
@@ -323,13 +323,20 @@ pub fn build_zig_host_native(
         .env("PATH", &env_path)
         .env("HOME", &env_home);
     if let Some(shared_lib_path) = shared_lib_path {
+        let native_bitcode;
+        let builtins_ext;
+
         #[cfg(windows)]
-        let native_bitcode = bitcode::HOST_WINDOWS;
-        let builtins_ext = ".obj";
+        {
+            native_bitcode = bitcode::HOST_WINDOWS;
+            builtins_ext = ".obj";
+        }
 
         #[cfg(unix)]
-        let native_bitcode = bitcode::HOST_UNIX;
-        let builtins_ext = ".o";
+        {
+            native_bitcode = bitcode::HOST_UNIX;
+            builtins_ext = ".o";
+        }
 
         let builtins_host_file = tempfile::Builder::new()
             .prefix("host_bitcode")

--- a/crates/compiler/build/src/link.rs
+++ b/crates/compiler/build/src/link.rs
@@ -119,9 +119,29 @@ pub fn build_zig_host_native(
         // but with the dev backend, they are missing. To minimize work,
         // we link them as part of the host executable
         let builtins_bytes = if target.contains("windows") {
-            bitcode::HOST_WINDOWS
+            #[cfg(windows)]
+            {
+                bitcode::HOST_WINDOWS
+            }
+
+            #[cfg(not(windows))]
+            {
+                panic!(
+                    "Building shared libraries for other operating systemes is not supported yet!"
+                );
+            }
         } else {
-            bitcode::HOST_UNIX
+            #[cfg(unix)]
+            {
+                bitcode::HOST_UNIX
+            }
+
+            #[cfg(not(unix))]
+            {
+                panic!(
+                    "Building shared libraries for other operating systemes is not supported yet!"
+                );
+            }
         };
 
         // TODO in the future when we have numbered releases, this

--- a/crates/compiler/build/src/link.rs
+++ b/crates/compiler/build/src/link.rs
@@ -197,7 +197,7 @@ pub fn build_zig_host_native(
             "build-exe",
             // "-fPIE", PIE seems to fail on windows
             shared_lib_path.to_str().unwrap(),
-            builtins_host_path,
+            builtins_host_path.to_str().unwrap(),
         ]);
     } else {
         zig_cmd.args(&["build-obj"]);

--- a/crates/compiler/build/src/link.rs
+++ b/crates/compiler/build/src/link.rs
@@ -126,7 +126,7 @@ pub fn build_zig_host_native(
 
         // TODO in the future when we have numbered releases, this
         // can go in ~/.cache/roc instead of writing it to a tempdir every time.
-        let builtins_host_file = tempfile::tempfile().unwrap();
+        let builtins_host_file = tempfile::NamedTempFile::new().unwrap();
         std::fs::write(builtins_host_file.path(), builtins_bytes)
             .expect("failed to write host builtins object to tempfile");
 

--- a/crates/compiler/build/src/link.rs
+++ b/crates/compiler/build/src/link.rs
@@ -124,7 +124,7 @@ pub fn build_zig_host_native(
             "-fPIE",
             "-rdynamic", // make sure roc_alloc and friends are exposed
             shared_lib_path.to_str().unwrap(),
-            builtins_host_path,
+            builtins_host_path.to_str().unwrap(),
         ]);
     } else {
         zig_cmd.args(["build-obj", "-fPIC"]);

--- a/crates/compiler/builtins/Cargo.toml
+++ b/crates/compiler/builtins/Cargo.toml
@@ -12,6 +12,7 @@ roc_region = { path = "../region" }
 roc_module = { path = "../module" }
 roc_target = { path = "../roc_target" }
 roc_utils = { path = "../../utils" }
+tempfile.workspace = true
 
 [build-dependencies]
 # dunce can be removed once ziglang/zig#5109 is fixed
@@ -19,4 +20,4 @@ dunce = "1.0.3"
 roc_utils = { path = "../../utils" }
 
 [target.'cfg(target_os = "macos")'.build-dependencies]
-tempfile = "3.2.0"
+tempfile.workspace = true

--- a/crates/compiler/builtins/bitcode/.gitignore
+++ b/crates/compiler/builtins/bitcode/.gitignore
@@ -1,7 +1,4 @@
 zig-cache
 src/zig-cache
 benchmark/zig-cache
-builtins.ll
-builtins.bc
-builtins.o
 dec

--- a/crates/compiler/builtins/build.rs
+++ b/crates/compiler/builtins/build.rs
@@ -138,7 +138,7 @@ pub fn get_lib_dir() -> PathBuf {
     let dir = PathBuf::from(env::var_os("OUT_DIR").unwrap()).join("bitcode");
 
     // create dir if it does not exist
-    fs::create_dir_all(&dir).expect("Failed to make lib dir.");
+    fs::create_dir_all(&dir).expect("Failed to make $OUT_DIR/bitcode dir.");
 
     dir
 }

--- a/crates/compiler/builtins/build.rs
+++ b/crates/compiler/builtins/build.rs
@@ -121,7 +121,7 @@ fn generate_bc_file(bitcode_path: &Path, zig_object: &str, file_name: &str) {
 
     // workaround for github.com/ziglang/zig/issues/9711
     #[cfg(target_os = "macos")]
-    let _ = fs::remove_dir_all("./bitcode/zig-cache");
+    let _ = fs::remove_dir_all(bitcode_path.join("zig-cache"));
 
     let mut zig_cmd = zig();
 
@@ -134,24 +134,17 @@ fn generate_bc_file(bitcode_path: &Path, zig_object: &str, file_name: &str) {
 
 pub fn get_lib_dir() -> PathBuf {
     // Currently we have the OUT_DIR variable which points to `/target/debug/build/roc_builtins-*/out/`.
-    // So we just need to shed a 3 of the outer layers to get `/target/debug/` and then add `lib`.
-    let out_dir = env::var_os("OUT_DIR").unwrap();
+    // So we just need to add "/bitcode" to that.
+    let dir = PathBuf::from(env::var_os("OUT_DIR").unwrap()).join("bitcode");
 
-    let lib_path = Path::new(&out_dir)
-        .parent()
-        .and_then(|path| path.parent())
-        .and_then(|path| path.parent())
-        .unwrap()
-        .join("lib");
+    // create dir if it does not exist
+    fs::create_dir_all(&dir).expect("Failed to make lib dir.");
 
-    // create dir of it does not exist
-    fs::create_dir_all(lib_path.clone()).expect("Failed to make lib dir.");
-
-    lib_path
+    dir
 }
 
 fn copy_zig_builtins_to_target_dir(bitcode_path: &Path) {
-    // To enable roc to find the zig biultins, we want them to be moved to a folder next to the roc executable.
+    // To enable roc to find the zig builtins, we want them to be moved to a folder next to the roc executable.
     // So if <roc_folder>/roc is the executable. The zig files will be in <roc_folder>/lib/*.zig
     let target_profile_dir = get_lib_dir();
 

--- a/crates/compiler/builtins/build.rs
+++ b/crates/compiler/builtins/build.rs
@@ -121,7 +121,7 @@ fn generate_bc_file(bitcode_path: &Path, zig_object: &str, file_name: &str) {
 
     // workaround for github.com/ziglang/zig/issues/9711
     #[cfg(target_os = "macos")]
-    let _ = fs::remove_dir_all(bitcode_path.join("zig-cache"));
+    let _ = fs::remove_dir_all("./bitcode/zig-cache");
 
     let mut zig_cmd = zig();
 

--- a/crates/compiler/builtins/src/bitcode.rs
+++ b/crates/compiler/builtins/src/bitcode.rs
@@ -1,40 +1,17 @@
 use roc_module::symbol::Symbol;
 use roc_target::TargetInfo;
-use roc_utils::get_lib_path;
 use std::ops::Index;
 
-const LIB_DIR_ERROR: &str = "Failed to find the lib directory. Did you copy the roc binary without also copying the lib directory?\nIf you built roc from source, the lib dir should be in target/release.\nIf not, the lib dir should be included in the release tar.gz file.";
-
-pub fn get_builtins_host_obj_path() -> String {
-    let builtins_host_path = get_lib_path().expect(LIB_DIR_ERROR).join("builtins-host.o");
-
-    builtins_host_path
-        .into_os_string()
-        .into_string()
-        .expect("Failed to convert builtins_host_path to str")
-}
-
-pub fn get_builtins_windows_obj_path() -> String {
-    let builtins_host_path = get_lib_path()
-        .expect(LIB_DIR_ERROR)
-        .join("builtins-windows-x86_64.obj");
-
-    builtins_host_path
-        .into_os_string()
-        .into_string()
-        .expect("Failed to convert builtins_host_path to str")
-}
-
-pub fn get_builtins_wasm32_obj_path() -> String {
-    let builtins_wasm32_path = get_lib_path()
-        .expect(LIB_DIR_ERROR)
-        .join("builtins-wasm32.o");
-
-    builtins_wasm32_path
-        .into_os_string()
-        .into_string()
-        .expect("Failed to convert builtins_wasm32_path to str")
-}
+pub const HOST_WASM: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/bitcode/builtins-wasm32.o"));
+// TODO: in the future, we should use Zig's cross-compilation to generate and store these
+// for all targets, so that we can do cross-compilation!
+#[cfg(unix)]
+pub const HOST_UNIX: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/bitcode/builtins-host.o"));
+#[cfg(windows)]
+pub const HOST_WINDOWS: &[u8] = include_bytes!(concat!(
+    env!("OUT_DIR"),
+    "/bitcode/builtins-windows-x86_64.obj"
+));
 
 #[derive(Debug, Default, Copy, Clone)]
 pub struct IntrinsicName {

--- a/crates/compiler/builtins/src/bitcode.rs
+++ b/crates/compiler/builtins/src/bitcode.rs
@@ -1,6 +1,7 @@
 use roc_module::symbol::Symbol;
 use roc_target::TargetInfo;
 use std::ops::Index;
+use tempfile::NamedTempFile;
 
 pub const HOST_WASM: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/bitcode/builtins-wasm32.o"));
 // TODO: in the future, we should use Zig's cross-compilation to generate and store these
@@ -12,6 +13,44 @@ pub const HOST_WINDOWS: &[u8] = include_bytes!(concat!(
     env!("OUT_DIR"),
     "/bitcode/builtins-windows-x86_64.obj"
 ));
+
+pub fn host_wasm_tempfile() -> std::io::Result<NamedTempFile> {
+    let tempfile = tempfile::Builder::new()
+        .prefix("host_bitcode")
+        .suffix(".wasm")
+        .rand_bytes(8)
+        .tempfile()?;
+
+    std::fs::write(tempfile.path(), HOST_WASM)?;
+
+    Ok(tempfile)
+}
+
+#[cfg(unix)]
+pub fn host_unix_tempfile() -> std::io::Result<NamedTempFile> {
+    let tempfile = tempfile::Builder::new()
+        .prefix("host_bitcode")
+        .suffix(".o")
+        .rand_bytes(8)
+        .tempfile()?;
+
+    std::fs::write(tempfile.path(), HOST_UNIX)?;
+
+    Ok(tempfile)
+}
+
+#[cfg(windows)]
+pub fn host_windows_tempfile() -> std::io::Result<NamedTempFile> {
+    let tempfile = tempfile::Builder::new()
+        .prefix("host_bitcode")
+        .suffix(".obj")
+        .rand_bytes(8)
+        .tempfile()?;
+
+    std::fs::write(tempfile.path(), HOST_WINDOWS)?;
+
+    Ok(tempfile)
+}
 
 #[derive(Debug, Default, Copy, Clone)]
 pub struct IntrinsicName {

--- a/crates/compiler/test_gen/Cargo.toml
+++ b/crates/compiler/test_gen/Cargo.toml
@@ -14,6 +14,7 @@ path = "src/tests.rs"
 roc_builtins = { path = "../builtins" }
 roc_utils = { path = "../../utils" }
 wasi_libc_sys = { path = "../../wasi-libc-sys" }
+tempfile.workspace = true
 
 [dev-dependencies]
 roc_gen_llvm = { path = "../gen_llvm" }

--- a/crates/compiler/test_gen/build.rs
+++ b/crates/compiler/test_gen/build.rs
@@ -100,9 +100,13 @@ fn build_wasm_test_host() {
     let mut outfile = PathBuf::from(&out_dir).join(PLATFORM_FILENAME);
     outfile.set_extension("wasm");
 
+    let builtins_host_file = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(builtins_host_file.path(), bitcode::HOST_WASM)
+        .expect("failed to write host builtins object to tempfile");
+
     run_zig(&[
         "wasm-ld",
-        &bitcode::get_builtins_wasm32_obj_path(),
+        builtins_host_file.path().to_str().unwrap(),
         platform_path.to_str().unwrap(),
         WASI_COMPILER_RT_PATH,
         WASI_LIBC_PATH,

--- a/crates/compiler/test_gen/build.rs
+++ b/crates/compiler/test_gen/build.rs
@@ -100,7 +100,12 @@ fn build_wasm_test_host() {
     let mut outfile = PathBuf::from(&out_dir).join(PLATFORM_FILENAME);
     outfile.set_extension("wasm");
 
-    let builtins_host_file = tempfile::NamedTempFile::new().unwrap();
+    let builtins_host_file = tempfile::Builder::new()
+        .prefix("host_bitcode")
+        .suffix(".wasm")
+        .rand_bytes(5)
+        .tempfile()
+        .unwrap();
     std::fs::write(builtins_host_file.path(), bitcode::HOST_WASM)
         .expect("failed to write host builtins object to tempfile");
 

--- a/crates/compiler/test_gen/build.rs
+++ b/crates/compiler/test_gen/build.rs
@@ -100,14 +100,8 @@ fn build_wasm_test_host() {
     let mut outfile = PathBuf::from(&out_dir).join(PLATFORM_FILENAME);
     outfile.set_extension("wasm");
 
-    let builtins_host_tempfile = tempfile::Builder::new()
-        .prefix("host_bitcode")
-        .suffix(".wasm")
-        .rand_bytes(5)
-        .tempfile()
-        .unwrap();
-    std::fs::write(builtins_host_tempfile.path(), bitcode::HOST_WASM)
-        .expect("failed to write host builtins object to tempfile");
+    let builtins_host_tempfile =
+        bitcode::host_wasm_tempfile().expect("failed to write host builtins object to tempfile");
 
     run_zig(&[
         "wasm-ld",

--- a/crates/compiler/test_gen/src/helpers/dev.rs
+++ b/crates/compiler/test_gen/src/helpers/dev.rs
@@ -193,17 +193,16 @@ pub fn helper(
         .expect("failed to build output object");
     std::fs::write(&app_o_file, module_out).expect("failed to write object to file");
 
-    // std::fs::copy(&app_o_file, "/tmp/app.o").unwrap();
+    let builtins_host_file = tempfile::tempfile().unwrap();
+    std::fs::write(builtins_host_file.path(), bitcode::HOST_UNIX)
+        .expect("failed to write host builtins object to tempfile");
 
     let (mut child, dylib_path) = link(
         &target,
         app_o_file.clone(),
         // Long term we probably want a smarter way to link in zig builtins.
         // With the current method all methods are kept and it adds about 100k to all outputs.
-        &[
-            app_o_file.to_str().unwrap(),
-            &bitcode::get_builtins_host_obj_path(),
-        ],
+        &[app_o_file.to_str().unwrap(), &builtins_host_file.path()],
         LinkType::Dylib,
     )
     .expect("failed to link dynamic library");

--- a/crates/compiler/test_gen/src/helpers/dev.rs
+++ b/crates/compiler/test_gen/src/helpers/dev.rs
@@ -202,7 +202,10 @@ pub fn helper(
         app_o_file.clone(),
         // Long term we probably want a smarter way to link in zig builtins.
         // With the current method all methods are kept and it adds about 100k to all outputs.
-        &[app_o_file.to_str().unwrap(), &builtins_host_file.path()],
+        &[
+            app_o_file.to_str().unwrap(),
+            builtins_host_file.path().to_str().unwrap(),
+        ],
         LinkType::Dylib,
     )
     .expect("failed to link dynamic library");

--- a/crates/compiler/test_gen/src/helpers/dev.rs
+++ b/crates/compiler/test_gen/src/helpers/dev.rs
@@ -193,7 +193,7 @@ pub fn helper(
         .expect("failed to build output object");
     std::fs::write(&app_o_file, module_out).expect("failed to write object to file");
 
-    let builtins_host_file = tempfile::tempfile().unwrap();
+    let builtins_host_file = tempfile::NamedTempFile::new().unwrap();
     std::fs::write(builtins_host_file.path(), bitcode::HOST_UNIX)
         .expect("failed to write host builtins object to tempfile");
 

--- a/crates/compiler/test_gen/src/helpers/dev.rs
+++ b/crates/compiler/test_gen/src/helpers/dev.rs
@@ -193,7 +193,12 @@ pub fn helper(
         .expect("failed to build output object");
     std::fs::write(&app_o_file, module_out).expect("failed to write object to file");
 
-    let builtins_host_file = tempfile::NamedTempFile::new().unwrap();
+    let builtins_host_file = tempfile::Builder::new()
+        .prefix("host_bitcode")
+        .suffix(".o")
+        .rand_bytes(5)
+        .tempfile()
+        .unwrap();
     std::fs::write(builtins_host_file.path(), bitcode::HOST_UNIX)
         .expect("failed to write host builtins object to tempfile");
 

--- a/crates/compiler/test_gen/src/helpers/dev.rs
+++ b/crates/compiler/test_gen/src/helpers/dev.rs
@@ -193,14 +193,8 @@ pub fn helper(
         .expect("failed to build output object");
     std::fs::write(&app_o_file, module_out).expect("failed to write object to file");
 
-    let builtins_host_tempfile = tempfile::Builder::new()
-        .prefix("host_bitcode")
-        .suffix(".o")
-        .rand_bytes(5)
-        .tempfile()
-        .unwrap();
-    std::fs::write(builtins_host_tempfile.path(), bitcode::HOST_UNIX)
-        .expect("failed to write host builtins object to tempfile");
+    let builtins_host_tempfile =
+        bitcode::host_unix_tempfile().expect("failed to write host builtins object to tempfile");
 
     let (mut child, dylib_path) = link(
         &target,

--- a/crates/repl_wasm/Cargo.toml
+++ b/crates/repl_wasm/Cargo.toml
@@ -13,9 +13,10 @@ crate-type = ["cdylib"]
 roc_builtins = {path = "../compiler/builtins"}
 roc_utils = {path = "../utils"}
 wasi_libc_sys = { path = "../wasi-libc-sys" }
+tempfile.workspace = true
 
 [dependencies]
-bumpalo.workspace = true 
+bumpalo.workspace = true
 console_error_panic_hook = {version = "0.1.7", optional = true}
 futures = {version = "0.3.24", optional = true}
 js-sys = "0.3.60"

--- a/crates/repl_wasm/build.rs
+++ b/crates/repl_wasm/build.rs
@@ -23,19 +23,19 @@ fn main() {
     pre_linked_binary_path.extend(["pre_linked_binary"]);
     pre_linked_binary_path.set_extension("o");
 
-    let builtins_host_file = tempfile::Builder::new()
+    let builtins_host_tempfile = tempfile::Builder::new()
         .prefix("host_bitcode")
         .suffix(".wasm")
         .rand_bytes(5)
         .tempfile()
         .unwrap();
-    std::fs::write(builtins_host_file.path(), bitcode::HOST_WASM)
+    std::fs::write(builtins_host_tempfile.path(), bitcode::HOST_WASM)
         .expect("failed to write host builtins object to tempfile");
 
     let output = Command::new(&zig_executable())
         .args([
             "wasm-ld",
-            builtins_host_file.path().to_str().unwrap(),
+            builtins_host_tempfile.path().to_str().unwrap(),
             platform_obj.to_str().unwrap(),
             WASI_COMPILER_RT_PATH,
             WASI_LIBC_PATH,
@@ -47,6 +47,10 @@ fn main() {
         ])
         .output()
         .unwrap();
+
+    // Extend the lifetime of the tempfile so it doesn't get dropped
+    // (and thus deleted) before the Zig process is done using it!
+    let _ = builtins_host_tempfile;
 
     assert!(output.status.success(), "{:#?}", output);
     assert!(output.stdout.is_empty(), "{:#?}", output);

--- a/crates/repl_wasm/build.rs
+++ b/crates/repl_wasm/build.rs
@@ -23,7 +23,12 @@ fn main() {
     pre_linked_binary_path.extend(["pre_linked_binary"]);
     pre_linked_binary_path.set_extension("o");
 
-    let builtins_host_file = tempfile::NamedTempFile::new().unwrap();
+    let builtins_host_file = tempfile::Builder::new()
+        .prefix("host_bitcode")
+        .suffix(".wasm")
+        .rand_bytes(5)
+        .tempfile()
+        .unwrap();
     std::fs::write(builtins_host_file.path(), bitcode::HOST_WASM)
         .expect("failed to write host builtins object to tempfile");
 

--- a/crates/repl_wasm/build.rs
+++ b/crates/repl_wasm/build.rs
@@ -23,10 +23,14 @@ fn main() {
     pre_linked_binary_path.extend(["pre_linked_binary"]);
     pre_linked_binary_path.set_extension("o");
 
+    let builtins_host_file = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(builtins_host_file.path(), bitcode::HOST_WASM)
+        .expect("failed to write host builtins object to tempfile");
+
     let output = Command::new(&zig_executable())
         .args([
             "wasm-ld",
-            &bitcode::get_builtins_wasm32_obj_path(),
+            builtins_host_file.path().to_str().unwrap(),
             platform_obj.to_str().unwrap(),
             WASI_COMPILER_RT_PATH,
             WASI_LIBC_PATH,

--- a/crates/repl_wasm/build.rs
+++ b/crates/repl_wasm/build.rs
@@ -23,14 +23,8 @@ fn main() {
     pre_linked_binary_path.extend(["pre_linked_binary"]);
     pre_linked_binary_path.set_extension("o");
 
-    let builtins_host_tempfile = tempfile::Builder::new()
-        .prefix("host_bitcode")
-        .suffix(".wasm")
-        .rand_bytes(5)
-        .tempfile()
-        .unwrap();
-    std::fs::write(builtins_host_tempfile.path(), bitcode::HOST_WASM)
-        .expect("failed to write host builtins object to tempfile");
+    let builtins_host_tempfile =
+        bitcode::host_wasm_tempfile().expect("failed to write host builtins object to tempfile");
 
     let output = Command::new(&zig_executable())
         .args([

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -102,7 +102,7 @@ pub fn first_last_index_of<T: ::std::fmt::Debug + std::cmp::Eq>(
 }
 
 // get the path of the lib folder
-// runtime dependencies like zig files, builtin_host.o are put in the lib folder
+// runtime dependencies like zig files, Windows dylib builds, are put in the lib folder
 pub fn get_lib_path() -> Option<PathBuf> {
     let exe_relative_str_path_opt = std::env::current_exe().ok();
 


### PR DESCRIPTION
This should mean that nobody needs a `lib/` dir locally anymore, and can run `roc` from any directory without needing anything else downloaded for builtins to work properly (except in the specific case of when building wasm in `--optimize` mode, because at the moment we still need `zig` for that due to Zig not being able to generate `.bc` files for wasm yet. Also when building `--lib` on Windows, we use `zig build-lib` at the moment, and that depends on `str.zig` which is in `lib/`. Removing that Windows-specific dependency isn't blocked on any Zig features, we just don't have the surgical linker doing Windows DLL linking yet).

I verified that this works by doing a fresh checkout of this repo, building a `roc` binary, moving it to a freshly created empty dir with the `examples/` from the fresh checkout, and verifying that this `roc` executable was able to build things.

Final `roc` uncompressed executable size (built with `--release`), before and after this change:

`61_259_568` before
`61_991_664` after

So, about 730K of the 61M binary is precompiled builtin object files. This is currently only including the builtins for wasm and for the native host (e.g. UNIX builtin object on UNIX systems, Windows on Windows) but eventually we should include both so that we can do cross-compilation.

For now, this writes the builtins to a tempfile wherever we were previously looking for something already on the filesystem. With the surgical linker, we should be able to read it directly out of the running program's memory (since we now just have a `&[u8]` of the entire object file that we can reference as a constant), but that's a further improvement we can make in the future!