### PR TITLE
Wasm interp function calls

### DIFF
--- a/crates/wasm_interp/src/call_stack.rs
+++ b/crates/wasm_interp/src/call_stack.rs
@@ -1,9 +1,7 @@
 use bitvec::vec::BitVec;
 use bumpalo::{collections::Vec, Bump};
-use roc_wasm_module::{parse::Parse, ValueType};
+use roc_wasm_module::{parse::Parse, Value, ValueType};
 use std::iter::repeat;
-
-use crate::Value;
 
 /// Struct-of-Arrays storage for the call stack.
 /// Type info is packed to avoid wasting space on padding.

--- a/crates/wasm_interp/src/execute.rs
+++ b/crates/wasm_interp/src/execute.rs
@@ -106,9 +106,9 @@ impl<'a> ExecutionState<'a> {
         if let Some((return_addr, block_depth)) = self.call_stack.pop_frame() {
             self.program_counter = return_addr as usize;
             self.block_depth = block_depth;
-            return Action::Continue;
+            Action::Continue
         } else {
-            return Action::Break;
+            Action::Break
         }
     }
 

--- a/crates/wasm_interp/src/execute.rs
+++ b/crates/wasm_interp/src/execute.rs
@@ -14,7 +14,7 @@ pub struct ExecutionState<'a> {
     memory: Vec<'a, u8>,
 
     #[allow(dead_code)]
-    call_stack: CallStack<'a>,
+    pub call_stack: CallStack<'a>,
 
     pub value_stack: ValueStack<'a>,
     program_counter: usize,
@@ -29,6 +29,10 @@ impl<'a> ExecutionState<'a> {
             value_stack: ValueStack::new(arena),
             program_counter,
         }
+    }
+
+    fn fetch_immediate_u32(&mut self, module: &WasmModule<'a>) -> u32 {
+        u32::parse((), &module.code.bytes, &mut self.program_counter).unwrap()
     }
 
     pub fn execute_next_instruction(&mut self, module: &WasmModule<'a>) {
@@ -82,13 +86,19 @@ impl<'a> ExecutionState<'a> {
                 todo!("{:?}", op_code);
             }
             GETLOCAL => {
-                todo!("{:?}", op_code);
+                let index = self.fetch_immediate_u32(module);
+                let value = self.call_stack.get_local(index);
+                self.value_stack.push(value);
             }
             SETLOCAL => {
-                todo!("{:?}", op_code);
+                let index = self.fetch_immediate_u32(module);
+                let value = self.value_stack.pop();
+                self.call_stack.set_local(index, value);
             }
             TEELOCAL => {
-                todo!("{:?}", op_code);
+                let index = self.fetch_immediate_u32(module);
+                let value = self.value_stack.peek();
+                self.call_stack.set_local(index, value);
             }
             GETGLOBAL => {
                 todo!("{:?}", op_code);

--- a/crates/wasm_interp/src/execute.rs
+++ b/crates/wasm_interp/src/execute.rs
@@ -2,6 +2,7 @@ use bumpalo::{collections::Vec, Bump};
 use roc_wasm_module::opcodes::OpCode;
 use roc_wasm_module::parse::Parse;
 use roc_wasm_module::sections::MemorySection;
+use roc_wasm_module::Value;
 use roc_wasm_module::WasmModule;
 
 use crate::call_stack::CallStack;

--- a/crates/wasm_interp/src/execute.rs
+++ b/crates/wasm_interp/src/execute.rs
@@ -78,10 +78,17 @@ impl<'a> ExecutionState<'a> {
                 todo!("{:?}", op_code);
             }
             RETURN => {
-                todo!("{:?}", op_code);
+                self.program_counter = self.call_stack.pop_frame() as usize;
             }
             CALL => {
-                todo!("{:?}", op_code);
+                let index = self.fetch_immediate_u32(module) as usize;
+                let return_addr = self.program_counter as u32;
+                self.program_counter = module.code.function_offsets[index] as usize;
+                self.call_stack.push_frame(
+                    return_addr,
+                    &module.code.bytes,
+                    &mut self.program_counter,
+                )
             }
             CALLINDIRECT => {
                 todo!("{:?}", op_code);

--- a/crates/wasm_interp/src/lib.rs
+++ b/crates/wasm_interp/src/lib.rs
@@ -4,5 +4,5 @@ mod value_stack;
 
 // Exposed for testing only. Should eventually become private.
 pub use call_stack::CallStack;
-pub use execute::ExecutionState;
+pub use execute::{Action, ExecutionState};
 pub use value_stack::ValueStack;

--- a/crates/wasm_interp/src/lib.rs
+++ b/crates/wasm_interp/src/lib.rs
@@ -6,11 +6,3 @@ mod value_stack;
 pub use call_stack::CallStack;
 pub use execute::ExecutionState;
 pub use value_stack::ValueStack;
-
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub enum Value {
-    I32(i32),
-    I64(i64),
-    F32(f32),
-    F64(f64),
-}

--- a/crates/wasm_interp/src/value_stack.rs
+++ b/crates/wasm_interp/src/value_stack.rs
@@ -1,9 +1,7 @@
 use bitvec::vec::BitVec;
 use bumpalo::{collections::Vec, Bump};
-use roc_wasm_module::ValueType;
+use roc_wasm_module::{Value, ValueType};
 use std::{fmt::Debug, mem::size_of};
-
-use crate::Value;
 
 /// Memory-efficient Struct-of-Arrays storage for the value stack.
 /// Pack the values and their types as densely as possible,

--- a/crates/wasm_interp/src/value_stack.rs
+++ b/crates/wasm_interp/src/value_stack.rs
@@ -36,6 +36,10 @@ impl<'a> ValueStack<'a> {
         self.is_64.len()
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.is_64.is_empty()
+    }
+
     pub fn push(&mut self, value: Value) {
         match value {
             Value::I32(x) => {

--- a/crates/wasm_interp/src/value_stack.rs
+++ b/crates/wasm_interp/src/value_stack.rs
@@ -34,6 +34,10 @@ impl<'a> ValueStack<'a> {
         }
     }
 
+    pub fn len(&self) -> usize {
+        self.is_64.len()
+    }
+
     pub fn push(&mut self, value: Value) {
         match value {
             Value::I32(x) => {
@@ -67,6 +71,14 @@ impl<'a> ValueStack<'a> {
         let value = self.get(is_64, is_float, bytes_idx);
         self.bytes.truncate(bytes_idx);
         value
+    }
+
+    pub fn peek(&self) -> Value {
+        let is_64 = self.is_64[self.is_64.len() - 1];
+        let is_float = self.is_float[self.is_float.len() - 1];
+        let size = if is_64 { 8 } else { 4 };
+        let bytes_idx = self.bytes.len() - size;
+        self.get(is_64, is_float, bytes_idx)
     }
 
     fn get(&self, is_64: bool, is_float: bool, bytes_idx: usize) -> Value {

--- a/crates/wasm_interp/tests/test_opcodes.rs
+++ b/crates/wasm_interp/tests/test_opcodes.rs
@@ -2,7 +2,7 @@
 
 use bumpalo::Bump;
 use roc_wasm_interp::{ExecutionState, Value};
-use roc_wasm_module::{opcodes::OpCode, SerialBuffer, ValueType, WasmModule};
+use roc_wasm_module::{opcodes::OpCode, SerialBuffer, Serialize, ValueType, WasmModule};
 
 fn default_state<'a>(arena: &'a Bump) -> ExecutionState {
     let pages = 1;
@@ -56,13 +56,16 @@ fn test_set_get_local() {
     let mut state = default_state(&arena);
     let mut module = WasmModule::new(&arena);
 
-    let local_decls = [
-        (1, ValueType::F32),
-        (1, ValueType::F64),
-        (1, ValueType::I32),
-        (1, ValueType::I64),
-    ];
-    state.call_stack.push_frame(0x1234, &local_decls);
+    let mut buffer = vec![];
+    let mut cursor = 0;
+    [
+        (1u32, ValueType::F32),
+        (1u32, ValueType::F64),
+        (1u32, ValueType::I32),
+        (1u32, ValueType::I64),
+    ]
+    .serialize(&mut buffer);
+    state.call_stack.push_frame(0x1234, &buffer, &mut cursor);
 
     module.code.bytes.push(OpCode::I32CONST as u8);
     module.code.bytes.encode_i32(12345);
@@ -85,13 +88,16 @@ fn test_tee_get_local() {
     let mut state = default_state(&arena);
     let mut module = WasmModule::new(&arena);
 
-    let local_decls = [
-        (1, ValueType::F32),
-        (1, ValueType::F64),
-        (1, ValueType::I32),
-        (1, ValueType::I64),
-    ];
-    state.call_stack.push_frame(0x1234, &local_decls);
+    let mut buffer = vec![];
+    let mut cursor = 0;
+    [
+        (1u32, ValueType::F32),
+        (1u32, ValueType::F64),
+        (1u32, ValueType::I32),
+        (1u32, ValueType::I64),
+    ]
+    .serialize(&mut buffer);
+    state.call_stack.push_frame(0x1234, &buffer, &mut cursor);
 
     module.code.bytes.push(OpCode::I32CONST as u8);
     module.code.bytes.encode_i32(12345);

--- a/crates/wasm_interp/tests/test_opcodes.rs
+++ b/crates/wasm_interp/tests/test_opcodes.rs
@@ -4,8 +4,12 @@ use bumpalo::Bump;
 use roc_wasm_interp::{ExecutionState, Value};
 use roc_wasm_module::{opcodes::OpCode, SerialBuffer, ValueType, WasmModule};
 
-const DEFAULT_MEMORY_PAGES: u32 = 1;
-const DEFAULT_PROGRAM_COUNTER: usize = 0;
+fn default_state<'a>(arena: &'a Bump) -> ExecutionState {
+    let pages = 1;
+    let program_counter = 0;
+    let globals = [];
+    ExecutionState::new(&arena, pages, program_counter, globals)
+}
 
 // #[test]
 // fn test_block() {}
@@ -49,7 +53,7 @@ const DEFAULT_PROGRAM_COUNTER: usize = 0;
 #[test]
 fn test_set_get_local() {
     let arena = Bump::new();
-    let mut state = ExecutionState::new(&arena, DEFAULT_MEMORY_PAGES, DEFAULT_PROGRAM_COUNTER, []);
+    let mut state = default_state(&arena);
     let mut module = WasmModule::new(&arena);
 
     let local_decls = [
@@ -78,7 +82,7 @@ fn test_set_get_local() {
 #[test]
 fn test_tee_get_local() {
     let arena = Bump::new();
-    let mut state = ExecutionState::new(&arena, DEFAULT_MEMORY_PAGES, DEFAULT_PROGRAM_COUNTER, []);
+    let mut state = default_state(&arena);
     let mut module = WasmModule::new(&arena);
 
     let local_decls = [
@@ -108,12 +112,10 @@ fn test_tee_get_local() {
 #[test]
 fn test_global() {
     let arena = Bump::new();
-    let mut state = ExecutionState::new(
-        &arena,
-        DEFAULT_MEMORY_PAGES,
-        DEFAULT_PROGRAM_COUNTER,
-        [Value::F64(1.11), Value::I32(222), Value::F64(3.33)],
-    );
+    let mut state = default_state(&arena);
+    state
+        .globals
+        .extend_from_slice(&[Value::F64(1.11), Value::I32(222), Value::F64(3.33)]);
     let mut module = WasmModule::new(&arena);
 
     module.code.bytes.push(OpCode::GETGLOBAL as u8);
@@ -212,7 +214,7 @@ fn test_global() {
 #[test]
 fn test_i32const() {
     let arena = Bump::new();
-    let mut state = ExecutionState::new(&arena, DEFAULT_MEMORY_PAGES, DEFAULT_PROGRAM_COUNTER, []);
+    let mut state = default_state(&arena);
     let mut module = WasmModule::new(&arena);
 
     module.code.bytes.push(OpCode::I32CONST as u8);
@@ -225,7 +227,7 @@ fn test_i32const() {
 #[test]
 fn test_i64const() {
     let arena = Bump::new();
-    let mut state = ExecutionState::new(&arena, DEFAULT_MEMORY_PAGES, DEFAULT_PROGRAM_COUNTER, []);
+    let mut state = default_state(&arena);
     let mut module = WasmModule::new(&arena);
 
     module.code.bytes.push(OpCode::I64CONST as u8);
@@ -238,7 +240,7 @@ fn test_i64const() {
 #[test]
 fn test_f32const() {
     let arena = Bump::new();
-    let mut state = ExecutionState::new(&arena, DEFAULT_MEMORY_PAGES, DEFAULT_PROGRAM_COUNTER, []);
+    let mut state = default_state(&arena);
     let mut module = WasmModule::new(&arena);
 
     module.code.bytes.push(OpCode::F32CONST as u8);
@@ -251,7 +253,7 @@ fn test_f32const() {
 #[test]
 fn test_f64const() {
     let arena = Bump::new();
-    let mut state = ExecutionState::new(&arena, DEFAULT_MEMORY_PAGES, DEFAULT_PROGRAM_COUNTER, []);
+    let mut state = default_state(&arena);
     let mut module = WasmModule::new(&arena);
 
     module.code.bytes.push(OpCode::F64CONST as u8);
@@ -375,7 +377,7 @@ fn test_f64const() {
 #[test]
 fn test_i32add() {
     let arena = Bump::new();
-    let mut state = ExecutionState::new(&arena, DEFAULT_MEMORY_PAGES, DEFAULT_PROGRAM_COUNTER, []);
+    let mut state = default_state(&arena);
     let mut module = WasmModule::new(&arena);
 
     module.code.bytes.push(OpCode::I32CONST as u8);
@@ -393,7 +395,7 @@ fn test_i32add() {
 #[test]
 fn test_i32sub() {
     let arena = Bump::new();
-    let mut state = ExecutionState::new(&arena, DEFAULT_MEMORY_PAGES, DEFAULT_PROGRAM_COUNTER, []);
+    let mut state = default_state(&arena);
     let mut module = WasmModule::new(&arena);
 
     module.code.bytes.push(OpCode::I32CONST as u8);
@@ -411,7 +413,7 @@ fn test_i32sub() {
 #[test]
 fn test_i32mul() {
     let arena = Bump::new();
-    let mut state = ExecutionState::new(&arena, DEFAULT_MEMORY_PAGES, DEFAULT_PROGRAM_COUNTER, []);
+    let mut state = default_state(&arena);
     let mut module = WasmModule::new(&arena);
 
     module.code.bytes.push(OpCode::I32CONST as u8);

--- a/crates/wasm_interp/tests/test_opcodes.rs
+++ b/crates/wasm_interp/tests/test_opcodes.rs
@@ -6,11 +6,11 @@ use roc_wasm_module::{
     opcodes::OpCode, SerialBuffer, Serialize, Signature, Value, ValueType, WasmModule,
 };
 
-fn default_state<'a>(arena: &'a Bump) -> ExecutionState {
+fn default_state(arena: &Bump) -> ExecutionState {
     let pages = 1;
     let program_counter = 0;
     let globals = [];
-    ExecutionState::new(&arena, pages, program_counter, globals)
+    ExecutionState::new(arena, pages, program_counter, globals)
 }
 
 // #[test]

--- a/crates/wasm_interp/tests/test_opcodes.rs
+++ b/crates/wasm_interp/tests/test_opcodes.rs
@@ -8,12 +8,6 @@ const DEFAULT_MEMORY_PAGES: u32 = 1;
 const DEFAULT_PROGRAM_COUNTER: usize = 0;
 
 // #[test]
-// fn test_unreachable() {}
-
-// #[test]
-// fn test_nop() {}
-
-// #[test]
 // fn test_block() {}
 
 // #[test]
@@ -55,7 +49,7 @@ const DEFAULT_PROGRAM_COUNTER: usize = 0;
 #[test]
 fn test_set_get_local() {
     let arena = Bump::new();
-    let mut state = ExecutionState::new(&arena, DEFAULT_MEMORY_PAGES, DEFAULT_PROGRAM_COUNTER);
+    let mut state = ExecutionState::new(&arena, DEFAULT_MEMORY_PAGES, DEFAULT_PROGRAM_COUNTER, []);
     let mut module = WasmModule::new(&arena);
 
     let local_decls = [
@@ -84,7 +78,7 @@ fn test_set_get_local() {
 #[test]
 fn test_tee_get_local() {
     let arena = Bump::new();
-    let mut state = ExecutionState::new(&arena, DEFAULT_MEMORY_PAGES, DEFAULT_PROGRAM_COUNTER);
+    let mut state = ExecutionState::new(&arena, DEFAULT_MEMORY_PAGES, DEFAULT_PROGRAM_COUNTER, []);
     let mut module = WasmModule::new(&arena);
 
     let local_decls = [
@@ -111,11 +105,34 @@ fn test_tee_get_local() {
     assert_eq!(state.value_stack.pop(), Value::I32(12345));
 }
 
-// #[test]
-// fn test_getglobal() {}
+#[test]
+fn test_global() {
+    let arena = Bump::new();
+    let mut state = ExecutionState::new(
+        &arena,
+        DEFAULT_MEMORY_PAGES,
+        DEFAULT_PROGRAM_COUNTER,
+        [Value::F64(1.11), Value::I32(222), Value::F64(3.33)],
+    );
+    let mut module = WasmModule::new(&arena);
 
-// #[test]
-// fn test_setglobal() {}
+    module.code.bytes.push(OpCode::GETGLOBAL as u8);
+    module.code.bytes.encode_u32(1);
+    module.code.bytes.push(OpCode::I32CONST as u8);
+    module.code.bytes.encode_i32(555);
+    module.code.bytes.push(OpCode::SETGLOBAL as u8);
+    module.code.bytes.encode_u32(1);
+    module.code.bytes.push(OpCode::GETGLOBAL as u8);
+    module.code.bytes.encode_u32(1);
+
+    state.execute_next_instruction(&module);
+    state.execute_next_instruction(&module);
+    state.execute_next_instruction(&module);
+    state.execute_next_instruction(&module);
+    assert_eq!(state.value_stack.len(), 2);
+    assert_eq!(state.value_stack.pop(), Value::I32(555));
+    assert_eq!(state.value_stack.pop(), Value::I32(222));
+}
 
 // #[test]
 // fn test_i32load() {}
@@ -195,7 +212,7 @@ fn test_tee_get_local() {
 #[test]
 fn test_i32const() {
     let arena = Bump::new();
-    let mut state = ExecutionState::new(&arena, DEFAULT_MEMORY_PAGES, DEFAULT_PROGRAM_COUNTER);
+    let mut state = ExecutionState::new(&arena, DEFAULT_MEMORY_PAGES, DEFAULT_PROGRAM_COUNTER, []);
     let mut module = WasmModule::new(&arena);
 
     module.code.bytes.push(OpCode::I32CONST as u8);
@@ -208,7 +225,7 @@ fn test_i32const() {
 #[test]
 fn test_i64const() {
     let arena = Bump::new();
-    let mut state = ExecutionState::new(&arena, DEFAULT_MEMORY_PAGES, DEFAULT_PROGRAM_COUNTER);
+    let mut state = ExecutionState::new(&arena, DEFAULT_MEMORY_PAGES, DEFAULT_PROGRAM_COUNTER, []);
     let mut module = WasmModule::new(&arena);
 
     module.code.bytes.push(OpCode::I64CONST as u8);
@@ -221,7 +238,7 @@ fn test_i64const() {
 #[test]
 fn test_f32const() {
     let arena = Bump::new();
-    let mut state = ExecutionState::new(&arena, DEFAULT_MEMORY_PAGES, DEFAULT_PROGRAM_COUNTER);
+    let mut state = ExecutionState::new(&arena, DEFAULT_MEMORY_PAGES, DEFAULT_PROGRAM_COUNTER, []);
     let mut module = WasmModule::new(&arena);
 
     module.code.bytes.push(OpCode::F32CONST as u8);
@@ -234,7 +251,7 @@ fn test_f32const() {
 #[test]
 fn test_f64const() {
     let arena = Bump::new();
-    let mut state = ExecutionState::new(&arena, DEFAULT_MEMORY_PAGES, DEFAULT_PROGRAM_COUNTER);
+    let mut state = ExecutionState::new(&arena, DEFAULT_MEMORY_PAGES, DEFAULT_PROGRAM_COUNTER, []);
     let mut module = WasmModule::new(&arena);
 
     module.code.bytes.push(OpCode::F64CONST as u8);
@@ -358,7 +375,7 @@ fn test_f64const() {
 #[test]
 fn test_i32add() {
     let arena = Bump::new();
-    let mut state = ExecutionState::new(&arena, DEFAULT_MEMORY_PAGES, DEFAULT_PROGRAM_COUNTER);
+    let mut state = ExecutionState::new(&arena, DEFAULT_MEMORY_PAGES, DEFAULT_PROGRAM_COUNTER, []);
     let mut module = WasmModule::new(&arena);
 
     module.code.bytes.push(OpCode::I32CONST as u8);
@@ -376,7 +393,7 @@ fn test_i32add() {
 #[test]
 fn test_i32sub() {
     let arena = Bump::new();
-    let mut state = ExecutionState::new(&arena, DEFAULT_MEMORY_PAGES, DEFAULT_PROGRAM_COUNTER);
+    let mut state = ExecutionState::new(&arena, DEFAULT_MEMORY_PAGES, DEFAULT_PROGRAM_COUNTER, []);
     let mut module = WasmModule::new(&arena);
 
     module.code.bytes.push(OpCode::I32CONST as u8);
@@ -394,7 +411,7 @@ fn test_i32sub() {
 #[test]
 fn test_i32mul() {
     let arena = Bump::new();
-    let mut state = ExecutionState::new(&arena, DEFAULT_MEMORY_PAGES, DEFAULT_PROGRAM_COUNTER);
+    let mut state = ExecutionState::new(&arena, DEFAULT_MEMORY_PAGES, DEFAULT_PROGRAM_COUNTER, []);
     let mut module = WasmModule::new(&arena);
 
     module.code.bytes.push(OpCode::I32CONST as u8);

--- a/crates/wasm_module/src/lib.rs
+++ b/crates/wasm_module/src/lib.rs
@@ -658,6 +658,14 @@ impl Parse<()> for (u32, ValueType) {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum Value {
+    I32(i32),
+    I64(i64),
+    F32(f32),
+    F64(f64),
+}
+
 /// Wasm memory alignment for load/store instructions.
 /// Rust representation matches Wasm encoding.
 /// It's an error to specify alignment higher than the "natural" alignment of the instruction

--- a/crates/wasm_module/src/lib.rs
+++ b/crates/wasm_module/src/lib.rs
@@ -642,6 +642,22 @@ impl From<u8> for ValueType {
     }
 }
 
+impl Parse<()> for ValueType {
+    fn parse(_: (), bytes: &[u8], cursor: &mut usize) -> Result<Self, ParseError> {
+        let byte = u8::parse((), bytes, cursor)?;
+        Ok(ValueType::from(byte))
+    }
+}
+
+// A group of local variable declarations
+impl Parse<()> for (u32, ValueType) {
+    fn parse(_: (), bytes: &[u8], cursor: &mut usize) -> Result<Self, ParseError> {
+        let count = u32::parse((), bytes, cursor)?;
+        let ty = ValueType::parse((), bytes, cursor)?;
+        Ok((count, ty))
+    }
+}
+
 /// Wasm memory alignment for load/store instructions.
 /// Rust representation matches Wasm encoding.
 /// It's an error to specify alignment higher than the "natural" alignment of the instruction

--- a/crates/wasm_module/src/opcodes.rs
+++ b/crates/wasm_module/src/opcodes.rs
@@ -1,3 +1,5 @@
+use crate::Serialize;
+
 use super::parse::{Parse, ParseError, SkipBytes};
 
 #[repr(u8)]
@@ -493,5 +495,11 @@ impl SkipBytes for OpCode {
             }
         }
         Ok(())
+    }
+}
+
+impl Serialize for OpCode {
+    fn serialize<T: crate::SerialBuffer>(&self, buffer: &mut T) {
+        (*self as u8).serialize(buffer)
     }
 }

--- a/crates/wasm_module/src/sections.rs
+++ b/crates/wasm_module/src/sections.rs
@@ -256,6 +256,12 @@ impl<'a> TypeSection<'a> {
     pub fn is_empty(&self) -> bool {
         self.bytes.is_empty()
     }
+
+    pub fn look_up_arg_count(&self, sig_index: u32) -> u32 {
+        let mut offset = self.offsets[sig_index as usize];
+        offset += 1; // separator
+        u32::parse((), &self.bytes, &mut offset).unwrap()
+    }
 }
 
 impl<'a> Section<'a> for TypeSection<'a> {

--- a/crates/wasm_module/src/sections.rs
+++ b/crates/wasm_module/src/sections.rs
@@ -1221,7 +1221,7 @@ impl<'a> Serialize for ElementSection<'a> {
 pub struct CodeSection<'a> {
     pub function_count: u32,
     pub bytes: Vec<'a, u8>,
-    /// The start of each preloaded function
+    /// The start of each function
     pub function_offsets: Vec<'a, u32>,
     /// Dead imports are replaced with dummy functions in CodeSection
     pub dead_import_dummy_count: u32,

--- a/crates/wasm_module/src/sections.rs
+++ b/crates/wasm_module/src/sections.rs
@@ -4,7 +4,7 @@ use bumpalo::collections::vec::Vec;
 use bumpalo::Bump;
 use roc_error_macros::internal_error;
 
-use crate::DUMMY_FUNCTION;
+use crate::{Value, DUMMY_FUNCTION};
 
 use super::linking::{LinkingSection, SymInfo, WasmObjectSymbol};
 use super::opcodes::OpCode;
@@ -771,6 +771,15 @@ impl<'a> MemorySection<'a> {
             MemorySection { count: 1, bytes }
         }
     }
+
+    pub fn min_bytes(&self) -> Result<u32, ParseError> {
+        let mut cursor = 0;
+        let memory_limits = Limits::parse((), &self.bytes, &mut cursor)?;
+        let min_pages = match memory_limits {
+            Limits::Min(pages) | Limits::MinMax(pages, _) => pages,
+        };
+        Ok(min_pages * MemorySection::PAGE_SIZE)
+    }
 }
 
 section_impl!(MemorySection, SectionId::Memory);
@@ -852,6 +861,59 @@ impl ConstExpr {
             _ => internal_error!("Expected ConstExpr to be I32"),
         }
     }
+
+    // ConstExpr and Value are separate types in case we ever need to support
+    // arbitrary constant expressions, rather than just i32.const and friends.
+    fn as_value(&self) -> Value {
+        match self {
+            ConstExpr::I32(x) => Value::I32(*x),
+            ConstExpr::I64(x) => Value::I64(*x),
+            ConstExpr::F32(x) => Value::F32(*x),
+            ConstExpr::F64(x) => Value::F64(*x),
+        }
+    }
+}
+
+impl Parse<()> for ConstExpr {
+    fn parse(_ctx: (), bytes: &[u8], cursor: &mut usize) -> Result<Self, ParseError> {
+        let opcode = OpCode::from(bytes[*cursor]);
+        *cursor += 1;
+
+        let result = match opcode {
+            OpCode::I32CONST => {
+                let x = i32::parse((), bytes, cursor)?;
+                Ok(ConstExpr::I32(x))
+            }
+            OpCode::I64CONST => {
+                let x = i64::parse((), bytes, cursor)?;
+                Ok(ConstExpr::I64(x))
+            }
+            OpCode::F32CONST => {
+                let mut b = [0; 4];
+                b.copy_from_slice(&bytes[*cursor..][..4]);
+                Ok(ConstExpr::F32(f32::from_le_bytes(b)))
+            }
+            OpCode::F64CONST => {
+                let mut b = [0; 8];
+                b.copy_from_slice(&bytes[*cursor..][..8]);
+                Ok(ConstExpr::F64(f64::from_le_bytes(b)))
+            }
+            _ => Err(ParseError {
+                offset: *cursor,
+                message: format!("Unsupported opcode {:?} in constant expression.", opcode),
+            }),
+        };
+
+        if bytes[*cursor] != OpCode::END as u8 {
+            return Err(ParseError {
+                offset: *cursor,
+                message: "Expected END opcode in constant expression.".into(),
+            });
+        }
+        *cursor += 1;
+
+        result
+    }
 }
 
 impl Serialize for ConstExpr {
@@ -930,6 +992,17 @@ impl<'a> GlobalSection<'a> {
     pub fn append(&mut self, global: Global) {
         global.serialize(&mut self.bytes);
         self.count += 1;
+    }
+
+    pub fn initial_values<'b>(&self, arena: &'b Bump) -> Vec<'b, Value> {
+        let mut cursor = 0;
+        let iter = (0..self.count)
+            .map(|_| {
+                GlobalType::skip_bytes(&self.bytes, &mut cursor)?;
+                ConstExpr::parse((), &self.bytes, &mut cursor).map(|x| x.as_value())
+            })
+            .filter_map(|r| r.ok());
+        Vec::from_iter_in(iter, arena)
     }
 }
 


### PR DESCRIPTION
Implement function calls in the Wasm interpreter

When a function is called, we look up the `WasmModule` to find how many arguments it has and pop that many values off the `ValueStack`. We then create a new frame on the `CallStack` and insert the arguments as local variables there, along with the declared local variables.

When we load arguments, we just load whatever is there on the `ValueStack` without checking the value types. But we could add this check later. It might be useful for debugging compiler code gen issues.

We're also detecting `return` instructions and the implicit `return` that happens when we reach the end of the function. I decided to use an enum with `Break` and `Continue` and have the caller implement the actual loop. It's nice for testing and debugging to have a function that executes a single instruction.