### PR TITLE
remove obsolete uses of lib dir

### DIFF
--- a/ci/benchmarks/prep_folder.sh
+++ b/ci/benchmarks/prep_folder.sh
@@ -14,12 +14,10 @@ cd crates/cli && cargo criterion --no-run && cd ../..
 mkdir -p bench-folder/crates/cli_testing_examples/benchmarks
 mkdir -p bench-folder/crates/compiler/builtins/bitcode/src
 mkdir -p bench-folder/target/release/deps
-mkdir -p bench-folder/target/release/lib
 cp "crates/cli_testing_examples/benchmarks/"*".roc" bench-folder/crates/cli_testing_examples/benchmarks/
 cp -r crates/cli_testing_examples/benchmarks/platform bench-folder/crates/cli_testing_examples/benchmarks/
 cp crates/compiler/builtins/bitcode/src/str.zig bench-folder/crates/compiler/builtins/bitcode/src
 cp target/release/roc bench-folder/target/release
-cp -r target/release/lib bench-folder/target/release
 
 # copy the most recent time bench to bench-folder
 cp target/release/deps/`ls -t target/release/deps/ | grep time_bench | head -n 1` bench-folder/target/release/deps/time_bench

--- a/ci/package_release.sh
+++ b/ci/package_release.sh
@@ -4,5 +4,4 @@
 set -euxo pipefail
 
 cp target/release/roc ./roc # to be able to exclude "target" later in the tar command
-cp -r target/release/lib ./lib
-tar -czvf $1 --exclude="target" --exclude="zig-cache" roc lib LICENSE LEGAL_DETAILS examples/helloWorld.roc examples/platform-switching examples/cli crates/roc_std
+tar -czvf $1 --exclude="target" --exclude="zig-cache" roc LICENSE LEGAL_DETAILS examples/helloWorld.roc examples/platform-switching examples/cli crates/roc_std


### PR DESCRIPTION
This should fix failures of the benchmarks workflow.