### PR TITLE
Wasm interp branching

### DIFF
--- a/crates/compiler/gen_wasm/src/code_builder.rs
+++ b/crates/compiler/gen_wasm/src/code_builder.rs
@@ -20,8 +20,6 @@ macro_rules! log_instruction {
     };
 }
 
-const BLOCK_NO_RESULT: u8 = 0x40;
-
 /// A control block in our model of the VM
 /// Child blocks cannot "see" values from their parent block
 struct VmBlock<'a> {
@@ -531,7 +529,7 @@ impl<'a> CodeBuilder<'a> {
         self.inst_base(opcode, pops, false);
 
         // We don't support block result types. Too hard to track types through arbitrary control flow.
-        self.code.push(BLOCK_NO_RESULT);
+        self.code.push(ValueType::VOID);
 
         // Start a new block with a fresh value stack
         self.vm_block_stack.push(VmBlock {

--- a/crates/compiler/gen_wasm/src/code_builder.rs
+++ b/crates/compiler/gen_wasm/src/code_builder.rs
@@ -529,6 +529,7 @@ impl<'a> CodeBuilder<'a> {
         self.inst_base(opcode, pops, false);
 
         // We don't support block result types. Too hard to track types through arbitrary control flow.
+        // This results in slightly more instructions but not much. (Rust does the same thing!)
         self.code.push(ValueType::VOID);
 
         // Start a new block with a fresh value stack

--- a/crates/wasm_interp/src/call_stack.rs
+++ b/crates/wasm_interp/src/call_stack.rs
@@ -11,7 +11,7 @@ use crate::ValueStack;
 #[derive(Debug)]
 pub struct CallStack<'a> {
     /// return addresses and nested block depths (one entry per frame)
-    return_addrs_and_block_depths: Vec<'a, (u32, u32)>,
+    return_addrs: Vec<'a, u32>,
     /// frame offsets into the `locals`, `is_float`, and `is_64` vectors (one entry per frame)
     frame_offsets: Vec<'a, u32>,
     /// base size of the value stack before executing (one entry per frame)
@@ -37,7 +37,7 @@ Not clear if this would be better! Stack access pattern is pretty cache-friendly
 impl<'a> CallStack<'a> {
     pub fn new(arena: &'a Bump) -> Self {
         CallStack {
-            return_addrs_and_block_depths: Vec::with_capacity_in(256, arena),
+            return_addrs: Vec::with_capacity_in(256, arena),
             frame_offsets: Vec::with_capacity_in(256, arena),
             value_stack_bases: Vec::with_capacity_in(256, arena),
             locals_data: Vec::with_capacity_in(16 * 256, arena),
@@ -50,14 +50,12 @@ impl<'a> CallStack<'a> {
     pub fn push_frame(
         &mut self,
         return_addr: u32,
-        return_block_depth: u32,
         arg_type_bytes: &[u8],
         value_stack: &mut ValueStack<'a>,
         code_bytes: &[u8],
         pc: &mut usize,
     ) {
-        self.return_addrs_and_block_depths
-            .push((return_addr, return_block_depth));
+        self.return_addrs.push(return_addr);
         let frame_offset = self.is_64.len();
         self.frame_offsets.push(frame_offset as u32);
         let mut total = 0;
@@ -92,13 +90,13 @@ impl<'a> CallStack<'a> {
     }
 
     /// On returning from a Wasm call, drop its locals and retrieve the return address
-    pub fn pop_frame(&mut self) -> Option<(u32, u32)> {
+    pub fn pop_frame(&mut self) -> Option<u32> {
         let frame_offset = self.frame_offsets.pop()? as usize;
         self.value_stack_bases.pop()?;
         self.locals_data.truncate(frame_offset);
         self.is_64.truncate(frame_offset);
         self.is_64.truncate(frame_offset);
-        self.return_addrs_and_block_depths.pop()
+        self.return_addrs.pop()
     }
 
     pub fn get_local(&self, local_index: u32) -> Value {
@@ -180,13 +178,13 @@ mod tests {
 
         // Push a other few frames before the test frame, just to make the scenario more typical.
         [(1u32, ValueType::I32)].serialize(&mut buffer);
-        call_stack.push_frame(0x11111, 0, &[], &mut vs, &buffer, &mut cursor);
+        call_stack.push_frame(0x11111, &[], &mut vs, &buffer, &mut cursor);
 
         [(2u32, ValueType::I32)].serialize(&mut buffer);
-        call_stack.push_frame(0x22222, 0, &[], &mut vs, &buffer, &mut cursor);
+        call_stack.push_frame(0x22222, &[], &mut vs, &buffer, &mut cursor);
 
         [(3u32, ValueType::I32)].serialize(&mut buffer);
-        call_stack.push_frame(0x33333, 0, &[], &mut vs, &buffer, &mut cursor);
+        call_stack.push_frame(0x33333, &[], &mut vs, &buffer, &mut cursor);
 
         // Create a test call frame with local variables of every type
         [
@@ -196,7 +194,7 @@ mod tests {
             (1u32, ValueType::F64),
         ]
         .serialize(&mut buffer);
-        call_stack.push_frame(RETURN_ADDR, 0, &[], &mut vs, &buffer, &mut cursor);
+        call_stack.push_frame(RETURN_ADDR, &[], &mut vs, &buffer, &mut cursor);
     }
 
     #[test]
@@ -223,7 +221,7 @@ mod tests {
         test_get_set(&mut call_stack, 14, Value::F64(f64::MIN));
         test_get_set(&mut call_stack, 14, Value::F64(f64::MAX));
 
-        assert_eq!(call_stack.pop_frame(), Some((RETURN_ADDR, 0)));
+        assert_eq!(call_stack.pop_frame(), Some(RETURN_ADDR));
     }
 
     #[test]

--- a/crates/wasm_interp/src/execute.rs
+++ b/crates/wasm_interp/src/execute.rs
@@ -574,7 +574,12 @@ impl<'a> ExecutionState<'a> {
             I32EQZ => todo!("{:?} @ {:#x}", op_code, file_offset),
             I32EQ => todo!("{:?} @ {:#x}", op_code, file_offset),
             I32NE => todo!("{:?} @ {:#x}", op_code, file_offset),
-            I32LTS => todo!("{:?} @ {:#x}", op_code, file_offset),
+            I32LTS => {
+                let second = self.value_stack.pop_i32();
+                let first = self.value_stack.pop_i32();
+                let result: bool = first < second;
+                self.value_stack.push(Value::I32(result as i32));
+            }
             I32LTU => todo!("{:?} @ {:#x}", op_code, file_offset),
             I32GTS => todo!("{:?} @ {:#x}", op_code, file_offset),
             I32GTU => todo!("{:?} @ {:#x}", op_code, file_offset),

--- a/crates/wasm_interp/src/execute.rs
+++ b/crates/wasm_interp/src/execute.rs
@@ -42,7 +42,7 @@ impl<'a> ExecutionState<'a> {
             program_counter,
             block_depth: 0,
             import_signatures: Vec::new_in(arena),
-            debug_string: None,
+            debug_string: Some(String::new()),
         }
     }
 

--- a/crates/wasm_interp/src/main.rs
+++ b/crates/wasm_interp/src/main.rs
@@ -1,5 +1,4 @@
 use bumpalo::Bump;
-use clap::parser::ValuesRef;
 use clap::ArgAction;
 use clap::{Arg, Command};
 use roc_wasm_interp::Action;
@@ -66,7 +65,7 @@ fn main() -> io::Result<()> {
     let is_hex_format = matches.get_flag(FLAG_HEX);
     let start_arg_strings = matches
         .get_many::<String>(ARGS_FOR_APP)
-        .unwrap_or(ValuesRef::default())
+        .unwrap_or_default()
         .map(|s| s.as_str());
 
     // Load the WebAssembly binary file

--- a/crates/wasm_interp/tests/test_opcodes.rs
+++ b/crates/wasm_interp/tests/test_opcodes.rs
@@ -93,7 +93,6 @@ fn test_loop_help(end: i32, expected: i32) {
     let mut state = default_state(&arena);
     state.call_stack.push_frame(
         0,
-        0,
         &[],
         &mut state.value_stack,
         &module.code.bytes,
@@ -160,7 +159,6 @@ fn test_if_else_help(condition: i32, expected: i32) {
 
     let mut state = default_state(&arena);
     state.call_stack.push_frame(
-        0,
         0,
         &[],
         &mut state.value_stack,
@@ -249,7 +247,6 @@ fn test_br() {
     buf.push(OpCode::END as u8);
 
     state.call_stack.push_frame(
-        0,
         0,
         &[],
         &mut state.value_stack,
@@ -347,7 +344,6 @@ fn test_br_if_help(condition: i32, expected: i32) {
     buf.push(OpCode::END as u8);
 
     state.call_stack.push_frame(
-        0,
         0,
         &[],
         &mut state.value_stack,
@@ -451,7 +447,6 @@ fn test_br_table_help(condition: i32, expected: i32) {
     println!("{:02x?}", buf);
 
     state.call_stack.push_frame(
-        0,
         0,
         &[],
         &mut state.value_stack,
@@ -586,7 +581,7 @@ fn test_set_get_local() {
     .serialize(&mut buffer);
     state
         .call_stack
-        .push_frame(0x1234, 0, &[], &mut vs, &buffer, &mut cursor);
+        .push_frame(0x1234, &[], &mut vs, &buffer, &mut cursor);
 
     module.code.bytes.push(OpCode::I32CONST as u8);
     module.code.bytes.encode_i32(12345);
@@ -621,7 +616,7 @@ fn test_tee_get_local() {
     .serialize(&mut buffer);
     state
         .call_stack
-        .push_frame(0x1234, 0, &[], &mut vs, &buffer, &mut cursor);
+        .push_frame(0x1234, &[], &mut vs, &buffer, &mut cursor);
 
     module.code.bytes.push(OpCode::I32CONST as u8);
     module.code.bytes.encode_i32(12345);
@@ -1209,7 +1204,6 @@ fn test_i32_compare_help(op: OpCode, x: i32, y: i32, expected: bool) {
 
     let mut state = default_state(&arena);
     state.call_stack.push_frame(
-        0,
         0,
         &[],
         &mut state.value_stack,

--- a/crates/wasm_interp/tests/test_opcodes.rs
+++ b/crates/wasm_interp/tests/test_opcodes.rs
@@ -117,8 +117,103 @@ fn test_br() {
     assert_eq!(state.value_stack.pop(), Value::I32(111))
 }
 
-// #[test]
-// fn test_brif() {}
+#[test]
+fn test_br_if() {
+    test_br_if_help(0, 222);
+    test_br_if_help(1, 111);
+}
+
+fn test_br_if_help(condition: i32, expected: i32) {
+    let arena = Bump::new();
+    let mut state = default_state(&arena);
+    let mut module = WasmModule::new(&arena);
+    let buf = &mut module.code.bytes;
+
+    // (local i32)
+    buf.encode_u32(1);
+    buf.encode_u32(1);
+    buf.push(ValueType::I32 as u8);
+
+    // i32.const 111
+    buf.push(OpCode::I32CONST as u8);
+    buf.encode_i32(111);
+
+    // local.set 0
+    buf.push(OpCode::SETLOCAL as u8);
+    buf.encode_u32(0);
+
+    // block  ;; label = @1
+    buf.push(OpCode::BLOCK as u8);
+    buf.push(ValueType::VOID);
+
+    //     block  ;; label = @2
+    buf.push(OpCode::BLOCK as u8);
+    buf.push(ValueType::VOID);
+
+    //     block  ;; label = @3
+    buf.push(OpCode::BLOCK as u8);
+    buf.push(ValueType::VOID);
+
+    //         i32.const <condition>
+    buf.push(OpCode::I32CONST as u8);
+    buf.encode_i32(condition);
+
+    //         br_if 2 (;@1;)
+    buf.push(OpCode::BRIF as u8);
+    buf.encode_u32(2);
+
+    //         i32.const 444
+    buf.push(OpCode::I32CONST as u8);
+    buf.encode_i32(444);
+
+    //         local.set 0
+    buf.push(OpCode::SETLOCAL as u8);
+    buf.encode_u32(0);
+
+    //     end
+    buf.push(OpCode::END as u8);
+
+    //     i32.const 333
+    buf.push(OpCode::I32CONST as u8);
+    buf.encode_i32(333);
+
+    //     local.set 0
+    buf.push(OpCode::SETLOCAL as u8);
+    buf.encode_u32(0);
+
+    //     end
+    buf.push(OpCode::END as u8);
+
+    //     i32.const 222
+    buf.push(OpCode::I32CONST as u8);
+    buf.encode_i32(222);
+
+    //     local.set 0
+    buf.push(OpCode::SETLOCAL as u8);
+    buf.encode_u32(0);
+
+    // end
+    buf.push(OpCode::END as u8);
+
+    // local.get 0)
+    buf.push(OpCode::GETLOCAL as u8);
+    buf.encode_u32(0);
+
+    buf.push(OpCode::END as u8);
+
+    state.call_stack.push_frame(
+        0,
+        0,
+        0,
+        &mut state.value_stack,
+        &module.code.bytes,
+        &mut state.program_counter,
+    );
+
+    while let Action::Continue = state.execute_next_instruction(&module) {}
+
+    assert_eq!(state.value_stack.pop(), Value::I32(expected))
+}
 
 // #[test]
 // fn test_brtable() {}

--- a/crates/wasm_interp/tests/test_opcodes.rs
+++ b/crates/wasm_interp/tests/test_opcodes.rs
@@ -106,7 +106,7 @@ fn test_br() {
     state.call_stack.push_frame(
         0,
         0,
-        0,
+        &[],
         &mut state.value_stack,
         &module.code.bytes,
         &mut state.program_counter,
@@ -204,7 +204,7 @@ fn test_br_if_help(condition: i32, expected: i32) {
     state.call_stack.push_frame(
         0,
         0,
-        0,
+        &[],
         &mut state.value_stack,
         &module.code.bytes,
         &mut state.program_counter,
@@ -223,8 +223,6 @@ fn test_br_table() {
 }
 
 fn test_br_table_help(condition: i32, expected: i32) {
-    dbg!(condition, expected);
-
     let arena = Bump::new();
     let mut state = default_state(&arena);
     let mut module = WasmModule::new(&arena);
@@ -310,7 +308,7 @@ fn test_br_table_help(condition: i32, expected: i32) {
     state.call_stack.push_frame(
         0,
         0,
-        0,
+        &[],
         &mut state.value_stack,
         &module.code.bytes,
         &mut state.program_counter,
@@ -443,7 +441,7 @@ fn test_set_get_local() {
     .serialize(&mut buffer);
     state
         .call_stack
-        .push_frame(0x1234, 0, 0, &mut vs, &buffer, &mut cursor);
+        .push_frame(0x1234, 0, &[], &mut vs, &buffer, &mut cursor);
 
     module.code.bytes.push(OpCode::I32CONST as u8);
     module.code.bytes.encode_i32(12345);
@@ -478,7 +476,7 @@ fn test_tee_get_local() {
     .serialize(&mut buffer);
     state
         .call_stack
-        .push_frame(0x1234, 0, 0, &mut vs, &buffer, &mut cursor);
+        .push_frame(0x1234, 0, &[], &mut vs, &buffer, &mut cursor);
 
     module.code.bytes.push(OpCode::I32CONST as u8);
     module.code.bytes.encode_i32(12345);
@@ -588,7 +586,7 @@ fn test_load(load_op: OpCode, ty: ValueType, data: &[u8], addr: u32, offset: u32
     }
 
     let mut state =
-        ExecutionState::for_module(&arena, &module, start_fn_name, is_debug_mode).unwrap();
+        ExecutionState::for_module(&arena, &module, start_fn_name, is_debug_mode, []).unwrap();
 
     while let Action::Continue = state.execute_next_instruction(&module) {}
 
@@ -787,7 +785,7 @@ fn test_store<'a>(
     });
 
     let mut state =
-        ExecutionState::for_module(arena, module, start_fn_name, is_debug_mode).unwrap();
+        ExecutionState::for_module(arena, module, start_fn_name, is_debug_mode, []).unwrap();
 
     while let Action::Continue = state.execute_next_instruction(module) {}
 

--- a/crates/wasm_interp/tests/test_opcodes.rs
+++ b/crates/wasm_interp/tests/test_opcodes.rs
@@ -215,8 +215,111 @@ fn test_br_if_help(condition: i32, expected: i32) {
     assert_eq!(state.value_stack.pop(), Value::I32(expected))
 }
 
-// #[test]
-// fn test_brtable() {}
+#[test]
+fn test_br_table() {
+    test_br_table_help(0, 333);
+    test_br_table_help(1, 222);
+    test_br_table_help(2, 111);
+}
+
+fn test_br_table_help(condition: i32, expected: i32) {
+    dbg!(condition, expected);
+
+    let arena = Bump::new();
+    let mut state = default_state(&arena);
+    let mut module = WasmModule::new(&arena);
+    let buf = &mut module.code.bytes;
+
+    // (local i32)
+    buf.encode_u32(1);
+    buf.encode_u32(1);
+    buf.push(ValueType::I32 as u8);
+
+    // i32.const 111
+    buf.push(OpCode::I32CONST as u8);
+    buf.encode_i32(111);
+
+    // local.set 0
+    buf.push(OpCode::SETLOCAL as u8);
+    buf.encode_u32(0);
+
+    // block  ;; label = @1
+    buf.push(OpCode::BLOCK as u8);
+    buf.push(ValueType::VOID);
+
+    //     block  ;; label = @2
+    buf.push(OpCode::BLOCK as u8);
+    buf.push(ValueType::VOID);
+
+    //     block  ;; label = @3
+    buf.push(OpCode::BLOCK as u8);
+    buf.push(ValueType::VOID);
+
+    //         i32.const <condition>
+    buf.push(OpCode::I32CONST as u8);
+    buf.encode_i32(condition);
+
+    //         br_table 0 1 2 (;@1;)
+    buf.push(OpCode::BRTABLE as u8);
+    buf.encode_u32(2); // number of non-fallback branches
+    buf.encode_u32(0);
+    buf.encode_u32(1);
+    buf.encode_u32(2);
+
+    //     end
+    buf.push(OpCode::END as u8);
+
+    //         i32.const 333
+    buf.push(OpCode::I32CONST as u8);
+    buf.encode_i32(333);
+
+    //         local.set 0
+    buf.push(OpCode::SETLOCAL as u8);
+    buf.encode_u32(0);
+
+    //         br 1
+    buf.push(OpCode::BR as u8);
+    buf.encode_u32(1);
+
+    //     end
+    buf.push(OpCode::END as u8);
+
+    //     i32.const 222
+    buf.push(OpCode::I32CONST as u8);
+    buf.encode_i32(222);
+
+    //     local.set 0
+    buf.push(OpCode::SETLOCAL as u8);
+    buf.encode_u32(0);
+
+    //         br 0
+    buf.push(OpCode::BR as u8);
+    buf.encode_u32(0);
+
+    //     end
+    buf.push(OpCode::END as u8);
+
+    // local.get 0)
+    buf.push(OpCode::GETLOCAL as u8);
+    buf.encode_u32(0);
+
+    buf.push(OpCode::END as u8);
+
+    println!("{:02x?}", buf);
+
+    state.call_stack.push_frame(
+        0,
+        0,
+        0,
+        &mut state.value_stack,
+        &module.code.bytes,
+        &mut state.program_counter,
+    );
+
+    while let Action::Continue = state.execute_next_instruction(&module) {}
+
+    assert_eq!(state.value_stack.pop(), Value::I32(expected))
+}
 
 #[test]
 fn test_call_return_no_args() {

--- a/crates/wasm_module/src/lib.rs
+++ b/crates/wasm_module/src/lib.rs
@@ -659,6 +659,17 @@ impl From<u8> for ValueType {
     }
 }
 
+impl From<Value> for ValueType {
+    fn from(x: Value) -> Self {
+        match x {
+            Value::I32(_) => Self::I32,
+            Value::I64(_) => Self::I64,
+            Value::F32(_) => Self::F32,
+            Value::F64(_) => Self::F64,
+        }
+    }
+}
+
 impl Parse<()> for ValueType {
     fn parse(_: (), bytes: &[u8], cursor: &mut usize) -> Result<Self, ParseError> {
         let byte = u8::parse((), bytes, cursor)?;

--- a/crates/wasm_module/src/lib.rs
+++ b/crates/wasm_module/src/lib.rs
@@ -637,6 +637,10 @@ pub enum ValueType {
     F64 = 0x7c,
 }
 
+impl ValueType {
+    pub const VOID: u8 = 0x40;
+}
+
 impl Serialize for ValueType {
     fn serialize<T: SerialBuffer>(&self, buffer: &mut T) {
         buffer.append_u8(*self as u8);

--- a/crates/wasm_module/src/sections.rs
+++ b/crates/wasm_module/src/sections.rs
@@ -258,10 +258,11 @@ impl<'a> TypeSection<'a> {
         self.bytes.is_empty()
     }
 
-    pub fn look_up_arg_count(&self, sig_index: u32) -> u32 {
+    pub fn look_up_arg_type_bytes(&self, sig_index: u32) -> &[u8] {
         let mut offset = self.offsets[sig_index as usize];
         offset += 1; // separator
-        u32::parse((), &self.bytes, &mut offset).unwrap()
+        let count = u32::parse((), &self.bytes, &mut offset).unwrap() as usize;
+        &self.bytes[offset..][..count]
     }
 }
 


### PR DESCRIPTION
- Implement block instructions `block`, `loop`, `if`, and `else`
- Implement branching instructions `br`, `br_if`, `br_table`
- Implement `i32.lt_s` (less than) because we need a comparison to make a loop!
- We now need to remember the address where each `loop` begins, so that we can jump backwards to it. This meant a change in how we keep track of nested blocks.
   - Previously `ExecutionState` only knew the `block_depth` for the current function and `CallStack` kept track of block depths inside of `return_addrs_and_block_depths`
   - But now `ExecutionState` has a full vector `block_loop_addrs` instead of just a depth. ~~So there's no need for `CallStack` to store block depths any more.~~ `CallStack` still keeps track of which blocks belong to which function.

## Bonus features
- CLI can now pass arguments to Wasm functions. This is handy for my development work, and a nice feature generally.
- Added a panic for type mismatch on function arguments. It was easy after the CLI changes. `CallStack::push_frame` takes `arg_type_bytes` instead of just `n_args`.
