### PR TITLE
wasm_interp: indirect_call

### DIFF
--- a/crates/wasm_interp/src/execute.rs
+++ b/crates/wasm_interp/src/execute.rs
@@ -406,12 +406,14 @@ impl<'a> ExecutionState<'a> {
                 );
 
                 // Dereference the function pointer (look up the element index in the function table)
-                let fn_index = module.element.lookup(element_index).expect(&format!(
-                    "Indirect function call failed. There is no function with element index {}",
-                    element_index
-                )) as usize;
+                let fn_index = module.element.lookup(element_index).unwrap_or_else(|| {
+                    panic!(
+                        "Indirect function call failed. There is no function with element index {}",
+                        element_index
+                    )
+                });
 
-                self.do_call(Some(expected_signature), fn_index, module);
+                self.do_call(Some(expected_signature), fn_index as usize, module);
             }
             DROP => {
                 self.value_stack.pop();

--- a/crates/wasm_interp/src/execute.rs
+++ b/crates/wasm_interp/src/execute.rs
@@ -249,6 +249,47 @@ impl<'a> ExecutionState<'a> {
         self.block_loop_addrs.truncate(target_block_depth);
     }
 
+    fn do_call(
+        &mut self,
+        expected_signature: Option<u32>,
+        fn_index: usize,
+        module: &WasmModule<'a>,
+    ) {
+        let n_imports = self.import_signatures.len();
+        let signature_index: u32 = if fn_index < n_imports {
+            self.import_signatures[fn_index]
+        } else {
+            module.function.signatures[fn_index - n_imports]
+        };
+
+        if let Some(expected) = expected_signature {
+            assert_eq!(
+                expected, signature_index,
+                "Indirect function call failed. Expected signature {} but found {}",
+                expected, signature_index,
+            );
+        }
+
+        let arg_type_bytes = module.types.look_up_arg_type_bytes(signature_index);
+
+        let return_addr = self.program_counter as u32;
+        self.program_counter = module.code.function_offsets[fn_index] as usize;
+
+        let return_block_depth = self.outermost_block;
+        self.outermost_block = self.block_loop_addrs.len() as u32;
+
+        let _function_byte_length =
+            u32::parse((), &module.code.bytes, &mut self.program_counter).unwrap();
+        self.call_stack.push_frame(
+            return_addr,
+            return_block_depth,
+            arg_type_bytes,
+            &mut self.value_stack,
+            &module.code.bytes,
+            &mut self.program_counter,
+        );
+    }
+
     pub fn execute_next_instruction(&mut self, module: &WasmModule<'a>) -> Action {
         use OpCode::*;
 
@@ -349,34 +390,29 @@ impl<'a> ExecutionState<'a> {
                 action = self.do_return();
             }
             CALL => {
-                let index = self.fetch_immediate_u32(module) as usize;
-
-                let signature_index = if index < self.import_signatures.len() {
-                    self.import_signatures[index]
-                } else {
-                    let internal_fn_index = index - self.import_signatures.len();
-                    module.function.signatures[internal_fn_index]
-                };
-                let arg_type_bytes = module.types.look_up_arg_type_bytes(signature_index);
-
-                let return_addr = self.program_counter as u32;
-                self.program_counter = module.code.function_offsets[index] as usize;
-
-                let return_block_depth = self.outermost_block;
-                self.outermost_block = self.block_loop_addrs.len() as u32;
-
-                let _function_byte_length =
-                    u32::parse((), &module.code.bytes, &mut self.program_counter).unwrap();
-                self.call_stack.push_frame(
-                    return_addr,
-                    return_block_depth,
-                    arg_type_bytes,
-                    &mut self.value_stack,
-                    &module.code.bytes,
-                    &mut self.program_counter,
-                );
+                let fn_index = self.fetch_immediate_u32(module) as usize;
+                self.do_call(None, fn_index, module);
             }
-            CALLINDIRECT => todo!("{:?} @ {:#x}", op_code, file_offset),
+            CALLINDIRECT => {
+                let table_index = self.fetch_immediate_u32(module);
+                let expected_signature = self.fetch_immediate_u32(module);
+                let element_index = self.value_stack.pop_u32();
+
+                // So far, all compilers seem to be emitting MVP-compatible code. (Rust, Zig, Roc...)
+                assert_eq!(
+                    table_index, 0,
+                    "Table index {} not supported at file offset {:#x}. This interpreter only supports Wasm MVP.",
+                    table_index, file_offset
+                );
+
+                // Dereference the function pointer (look up the element index in the function table)
+                let fn_index = module.element.lookup(element_index).expect(&format!(
+                    "Indirect function call failed. There is no function with element index {}",
+                    element_index
+                )) as usize;
+
+                self.do_call(Some(expected_signature), fn_index, module);
+            }
             DROP => {
                 self.value_stack.pop();
             }

--- a/crates/wasm_interp/tests/test_opcodes.rs
+++ b/crates/wasm_interp/tests/test_opcodes.rs
@@ -4,7 +4,7 @@ use bumpalo::{collections::Vec, Bump};
 use roc_wasm_interp::{Action, ExecutionState, ValueStack};
 use roc_wasm_module::{
     opcodes::OpCode,
-    sections::{DataMode, DataSegment, MemorySection},
+    sections::{DataMode, DataSegment, ElementSegment, MemorySection},
     ConstExpr, Export, ExportType, SerialBuffer, Serialize, Signature, Value, ValueType,
     WasmModule,
 };
@@ -583,8 +583,91 @@ fn test_call_return_with_args() {
     assert_eq!(state.value_stack.peek(), Value::I32(4));
 }
 
-// #[test]
-// fn test_callindirect() {}
+#[test]
+fn test_call_indirect_ok() {
+    let result = test_call_indirect_help(0, 0);
+    assert_eq!(result, Value::I32(111));
+}
+
+#[test]
+#[should_panic(expected = "Expected signature")]
+fn test_call_indirect_wrong_signature() {
+    test_call_indirect_help(0, 1);
+}
+
+#[test]
+#[should_panic(expected = "element index")]
+fn test_call_indirect_index_out_of_bounds() {
+    test_call_indirect_help(0, 2);
+}
+
+#[test]
+#[should_panic(expected = "Table index")]
+fn test_call_indirect_unsupported_table() {
+    test_call_indirect_help(1, 0);
+}
+
+fn test_call_indirect_help(table_index: u32, elem_index: u32) -> Value {
+    let arena = Bump::new();
+    let mut module = WasmModule::new(&arena);
+
+    let is_debug_mode = true;
+    let start_fn_name = "test";
+
+    // function 0: caller
+    let signature0 = Signature {
+        param_types: bumpalo::vec![in &arena],
+        ret_type: Some(ValueType::I32),
+    };
+    create_exported_function_no_locals(&mut module, start_fn_name, signature0.clone(), |buf| {
+        buf.append_u8(OpCode::I32CONST as u8);
+        buf.encode_u32(elem_index);
+        buf.append_u8(OpCode::CALLINDIRECT as u8);
+        buf.encode_u32(table_index);
+        buf.encode_u32(0); // signature index
+        buf.append_u8(OpCode::END as u8);
+    });
+
+    // function 1: callee, right signature
+    create_exported_function_no_locals(&mut module, "callee1", signature0, |buf| {
+        buf.append_u8(OpCode::I32CONST as u8);
+        buf.encode_i32(111);
+        buf.append_u8(OpCode::END as u8);
+    });
+
+    // function 2: callee, wrong signature
+    let signature1 = Signature {
+        param_types: bumpalo::vec![in &arena],
+        ret_type: Some(ValueType::F32),
+    };
+    create_exported_function_no_locals(&mut module, "callee2", signature1, |buf| {
+        buf.append_u8(OpCode::F32CONST as u8);
+        buf.encode_f32(2.22);
+        buf.append_u8(OpCode::END as u8);
+    });
+
+    // Put functions 1 and 2 in the function table
+    module.element.segments.push(ElementSegment::new(&arena));
+    assert_eq!(module.element.get_or_insert_fn(1), 0);
+    assert_eq!(module.element.get_or_insert_fn(2), 1);
+
+    if false {
+        let mut outfile_buf = Vec::new_in(&arena);
+        module.serialize(&mut outfile_buf);
+        std::fs::write(
+            format!("/tmp/roc/call_indirect_{}_{}.wasm", table_index, elem_index),
+            outfile_buf,
+        )
+        .unwrap();
+    }
+
+    let mut state =
+        ExecutionState::for_module(&arena, &module, start_fn_name, is_debug_mode, []).unwrap();
+
+    while let Action::Continue = state.execute_next_instruction(&module) {}
+
+    state.value_stack.pop()
+}
 
 // #[test]
 // fn test_drop() {}

--- a/crates/wasm_interp/tests/test_opcodes.rs
+++ b/crates/wasm_interp/tests/test_opcodes.rs
@@ -615,11 +615,11 @@ fn test_call_indirect_help(table_index: u32, elem_index: u32) -> Value {
     let start_fn_name = "test";
 
     // function 0: caller
-    let signature0 = Signature {
+    let signature0 = || Signature {
         param_types: bumpalo::vec![in &arena],
         ret_type: Some(ValueType::I32),
     };
-    create_exported_function_no_locals(&mut module, start_fn_name, signature0.clone(), |buf| {
+    create_exported_function_no_locals(&mut module, start_fn_name, signature0(), |buf| {
         buf.append_u8(OpCode::I32CONST as u8);
         buf.encode_u32(elem_index);
         buf.append_u8(OpCode::CALLINDIRECT as u8);
@@ -629,7 +629,7 @@ fn test_call_indirect_help(table_index: u32, elem_index: u32) -> Value {
     });
 
     // function 1: callee, right signature
-    create_exported_function_no_locals(&mut module, "callee1", signature0, |buf| {
+    create_exported_function_no_locals(&mut module, "callee1", signature0(), |buf| {
         buf.append_u8(OpCode::I32CONST as u8);
         buf.encode_i32(111);
         buf.append_u8(OpCode::END as u8);

--- a/crates/wasm_module/src/sections.rs
+++ b/crates/wasm_module/src/sections.rs
@@ -194,7 +194,7 @@ pub fn update_section_size<T: SerialBuffer>(buffer: &mut T, header_indices: Sect
  *
  *******************************************************************/
 
-#[derive(PartialEq, Eq, Debug, Clone)]
+#[derive(PartialEq, Eq, Debug)]
 pub struct Signature<'a> {
     pub param_types: Vec<'a, ValueType>,
     pub ret_type: Option<ValueType>,

--- a/crates/wasm_module/src/sections.rs
+++ b/crates/wasm_module/src/sections.rs
@@ -194,7 +194,7 @@ pub fn update_section_size<T: SerialBuffer>(buffer: &mut T, header_indices: Sect
  *
  *******************************************************************/
 
-#[derive(PartialEq, Eq, Debug)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Signature<'a> {
     pub param_types: Vec<'a, ValueType>,
     pub ret_type: Option<ValueType>,
@@ -1165,6 +1165,13 @@ pub struct ElementSegment<'a> {
 }
 
 impl<'a> ElementSegment<'a> {
+    pub fn new(arena: &'a Bump) -> Self {
+        ElementSegment {
+            offset: ConstExpr::I32(0),
+            fn_indices: Vec::new_in(arena),
+        }
+    }
+
     fn size(&self) -> usize {
         let variant_id = 1;
         let constexpr_opcode = 1;
@@ -1266,6 +1273,14 @@ impl<'a> ElementSection<'a> {
 
     pub fn is_empty(&self) -> bool {
         self.segments.iter().all(|seg| seg.fn_indices.is_empty())
+    }
+
+    /// Look up a "function pointer" (element index) and return the function index.
+    pub fn lookup(&self, element_index: u32) -> Option<u32> {
+        self.segments.iter().find_map(|seg| {
+            let adjusted_index = element_index as usize - seg.offset.unwrap_i32() as usize;
+            seg.fn_indices.get(adjusted_index).copied()
+        })
     }
 }
 


### PR DESCRIPTION
Indirect function calls
Wasm doesn't allow the program to access real code memory addresses, for security reasons.
Instead, the Wasm module has a table listing all functions that are passed around as "pointers" in the program. The "address" in the is actually an index into that table.
To implement the `call_indirect` instruction we need to implement those table lookups.

After this, the only remaining "big feature" is foreign function imports. Our tests use ~3 WASI imports and some user-defined imports.

Then it's a matter of working through the remaining ops one by one.
- I32/I64 ops: 25 each
- F32/F64 ops: 19 each
- conversion ops: 25
