### PR TITLE
Tutorial style tweaks

### DIFF
--- a/www/public/site.css
+++ b/www/public/site.css
@@ -21,10 +21,13 @@
 }
 
 html {
-    font-family: 'Lato', sans-serif;
     line-height: 1.5rem;
     background: var(--body-bg);
     color: var(--text-color);
+}
+
+html, #tutorial-toc-toggle-label {
+    font-family: 'Lato', sans-serif;
 }
 
 html, body {
@@ -293,18 +296,16 @@ td:last-child {
     font-size: inherit;
 }
 
-#top-bar-links label.tutorial-toc-toggle {
-    display: none;
-    width: 60px;
-    color: transparent;
-    background-position: center;
-    background-repeat: no-repeat;
-    background-size: 20px 20px;
-    background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0Ij48cGF0aCBmaWxsPSIjZmZmIiBkPSJNOS4xNDUgMTguMjljLTUuMDQyIDAtOS4xNDUtNC4xMDItOS4xNDUtOS4xNDVzNC4xMDMtOS4xNDUgOS4xNDUtOS4xNDUgOS4xNDUgNC4xMDMgOS4xNDUgOS4xNDUtNC4xMDIgOS4xNDUtOS4xNDUgOS4xNDV6bTAtMTUuMTY3Yy0zLjMyMSAwLTYuMDIyIDIuNzAyLTYuMDIyIDYuMDIyczIuNzAyIDYuMDIyIDYuMDIyIDYuMDIyIDYuMDIzLTIuNzAyIDYuMDIzLTYuMDIyLTIuNzAyLTYuMDIyLTYuMDIzLTYuMDIyem05LjI2MyAxMi40NDNjLS44MTcgMS4xNzYtMS44NTIgMi4xODgtMy4wNDYgMi45ODFsNS40NTIgNS40NTMgMy4wMTQtMy4wMTMtNS40Mi01LjQyMXoiLz48L3N2Zz4=');
+#tutorial-toc-toggle, #tutorial-toc-toggle-label, #close-tutorial-toc {
+    display: none; /* This may be overridden on mobile-friendly screen widths */
 }
 
-.tutorial-toc-inner-toggle {
-    display: none;
+#tutorial-toc-toggle, #tutorial-toc-toggle-label {
+    font-size: 1.1rem;
+    float: right;
+}
+
+#close-tutorial-toc {
     position: absolute;
     top: 20px;
     right: 8px;
@@ -312,9 +313,10 @@ td:last-child {
     padding: 12px 24px;
 }
 
+/* Mobile-friendly screen width */
 @media screen and (max-width: 900px) {
-    #top-bar-links label.tutorial-toc-toggle,
-    .tutorial-toc-inner-toggle {
+    #tutorial-toc-toggle-label,
+    #close-tutorial-toc {
         display: block;
     }
     #tutorial-toc-toggle:checked + #tutorial-toc {
@@ -377,6 +379,15 @@ h1, h2, h3, h4, h5 {
     line-height: 1rem;
     margin-top: 1.75rem;
     margin-bottom: 0;
+}
+
+#tutorial-toc-toggle-label, #close-tutorial-toc {
+    color: var(--header-link-color);
+}
+
+#tutorial-toc-toggle-label:hover, #close-tutorial-toc:hover {
+    color: var(--header-link-hover);
+    cursor: pointer;
 }
 
 h1 a, h2 a, h3 a, h4 a, h5 a {

--- a/www/public/site.css
+++ b/www/public/site.css
@@ -511,13 +511,13 @@ h4 {
 @media (prefers-color-scheme: dark) {
     :root {
         --text-color: #cdcdcd;
-        --top-bar-bg: #8d51f6;
+        --top-bar-bg: #2a2a2a;
         --header-link-color: hsl(258, 73%, 70%);
         --header-link-hover: #ddd;
         --h1-color: #1bc6bd;
         --link-color: #1bc6bd;
         --repl-prompt: #0ff4f4;
-        --body-bg: #161519;
+        --body-bg: #0e0e0f;
         --code-bg: #303030;
         --snippet-bg: #1a1a1a;
         --snippet-border: #444;

--- a/www/public/site.css
+++ b/www/public/site.css
@@ -181,7 +181,7 @@ samp .dim {
 }
 
 samp .comment {
-    color: green;
+    color: #88c796;
 }
 samp .comment .kw,
 samp .comment .str,

--- a/www/public/site.css
+++ b/www/public/site.css
@@ -183,12 +183,7 @@ samp .dim {
 }
 
 samp .comment {
-    color: #88c796;
-}
-samp .comment .kw,
-samp .comment .str,
-samp .comment .number {
-    color: inherit;
+    color: #2b9d44;
 }
 
 /* Tables */
@@ -563,5 +558,9 @@ h4 {
     samp .str {
         /* string literals */
         color: #26b2b9;
+    }
+
+    samp .comment {
+        color: #88c796;
     }
 }

--- a/www/public/site.css
+++ b/www/public/site.css
@@ -111,7 +111,6 @@ code {
     background: var(--code-bg);
     padding: 0.1rem 0.5rem;
     border-radius: 4px;
-    white-space: nowrap;
 }
 
 code, samp {

--- a/www/public/site.css
+++ b/www/public/site.css
@@ -121,7 +121,7 @@ code, samp {
     color: var(--code-color);
 }
 
-code.snippet, samp {
+.snippet, samp {
     display: block;
     overflow: auto;
     white-space: pre;
@@ -315,6 +315,10 @@ td:last-child {
 
 /* Mobile-friendly screen width */
 @media screen and (max-width: 900px) {
+    p, code, samp, .snippet {
+        font-size: 16px;
+    }
+
     #tutorial-toc-toggle-label,
     #close-tutorial-toc {
         display: block;

--- a/www/public/site.css
+++ b/www/public/site.css
@@ -111,6 +111,7 @@ code {
     background: var(--code-bg);
     padding: 0.1rem 0.5rem;
     border-radius: 4px;
+    white-space: nowrap;
 }
 
 code, samp {

--- a/www/public/tutorial/index.html
+++ b/www/public/tutorial/index.html
@@ -367,15 +367,15 @@ If we were to use <code>counts.note</code> inside <code>addAndStringify</code>, 
 because <code>total</code> is calling <code>addAndStringify</code> passing a record that doesn't have a <code>note</code> field.</p>
 <h3 id="comments"><a href="#comments">Comments</a></h3>
 <p>By the way, this is a comment in Roc:</p>
-<samp class="comment"># The `name` field is unused by addAndStringify</samp>
+<samp><span class="comment"># The `name` field is unused by addAndStringify</span></samp>
 <p>Whenever you write <code>#</code> it means that the rest of the line is a comment,
 and will not affect the program.</p>
 <h3 id="doc-comments"><a href="#doc-comments">Doc Comments</a></h2>
 <p>Comments that begin with <code>##</code> will be included in generated documentation (<code>roc docs</code>). They can include code blocks by adding five spaces after <code>##</code>. </p>
-<samp><span class="comment">## This is a comment for documentation, and includes a <span class="kw">code</span> block.</span>
-<span class="comment">##</span>
-<span class="comment">##     x <span class="op">=</span> <span class="number">2</span></span>
-<span class="comment">##     expect x <span class="op">==</span> <span class="number">2</span></span>
+<samp><span class="comment">## This is a comment for documentation, and includes a code block.
+##
+##     x = 2
+##     expect x == 2</span>
 </samp>
 <p>Roc does not have multiline comment syntax.</p>
 <h3 id="record-shorthands"><a href="#record-shorthands">Record shorthands</a></h3>

--- a/www/public/tutorial/index.html
+++ b/www/public/tutorial/index.html
@@ -22,15 +22,14 @@
             <a href="/install">install</a>
             <a href="/repl">repl</a>
             <a href="/builtins/Bool">docs</a>
-            <label class="tutorial-toc-toggle" for="tutorial-toc-toggle">menu</label>
         </div>
     </nav>
 </div>
 <main>
 <div id="tutorial-start">
-    <input id="tutorial-toc-toggle" name="tutorial-toc-toggle" type="checkbox" style="display: none" />
+    <input id="tutorial-toc-toggle" name="tutorial-toc-toggle" type="checkbox" />
     <nav id="tutorial-toc">
-        <label class="tutorial-toc-inner-toggle" for="tutorial-toc-toggle">Close</label>
+        <label id="close-tutorial-toc" for="tutorial-toc-toggle">close</label>
         <input id="toc-search" type="text" placeholder="Search">
         <ol>
             <li><a href="#installation">Installation</a></li>
@@ -56,7 +55,9 @@
     </nav>
     <div id="tutorial-intro">
         <section>
-            <h1>Tutorial</h1>
+            <h1>Tutorial
+                <label id="tutorial-toc-toggle-label" for="tutorial-toc-toggle">contents</label>
+            </h1>
 
             <p>Welcome to Roc!</p>
 


### PR DESCRIPTION
A few tweaks to `/tutorial` styles:
* Use `font-size: 16px` on mobile
* Use a better color for comments
* There was an inline `display:none` that was blocked by our content-security policy on Netlify; this is now in site.css
* Moved the table of contents toggle next to the "Tutorial" heading so it's only on /tutorial and not in the site-wide nav bar
* Went back to the previous header and background colors; after looking at it both ways, I think the docs pages should actually adopt these styles rather than the other way around! 😃 

<img width="365" alt="Screen Shot 2022-11-28 at 4 48 22 PM" src="https://user-images.githubusercontent.com/1094080/204388208-490e1eda-798b-4d69-b9f5-27c8a0aa5651.png">

<img width="388" alt="Screen Shot 2022-11-28 at 4 48 27 PM" src="https://user-images.githubusercontent.com/1094080/204388203-4d5e9975-f4eb-48eb-889b-8c65d59e51f7.png">