### PR TITLE
Introduce `record!` combinator

### DIFF
--- a/crates/compiler/fmt/src/annotation.rs
+++ b/crates/compiler/fmt/src/annotation.rs
@@ -63,9 +63,7 @@ pub trait Formattable {
         _parens: Parens,
         _newlines: Newlines,
         indent: u16,
-    ) {
-        self.format(buf, indent);
-    }
+    );
 
     fn format<'buf>(&self, buf: &mut Buf<'buf>, indent: u16) {
         self.format_with_options(buf, Parens::NotNeeded, Newlines::No, indent);
@@ -96,18 +94,13 @@ where
     }
 }
 
-impl<'a, T> Formattable for Collection<'a, T>
-where
-    T: Formattable,
-{
-    fn is_multiline(&self) -> bool {
-        // if there are any comments, they must go on their own line
-        // because otherwise they'd comment out the closing delimiter
-        !self.final_comments().is_empty() ||
-        // if any of the items in the collection are multiline,
-        // then the whole collection must be multiline
-        self.items.iter().any(Formattable::is_multiline)
-    }
+pub fn is_collection_multiline<T: Formattable>(collection: &Collection<'_, T>) -> bool {
+    // if there are any comments, they must go on their own line
+    // because otherwise they'd comment out the closing delimiter
+    !collection.final_comments().is_empty() ||
+    // if any of the items in the collection are multiline,
+    // then the whole collection must be multiline
+    collection.items.iter().any(Formattable::is_multiline)
 }
 
 /// A Located formattable value is also formattable
@@ -577,7 +570,7 @@ impl<'a> Formattable for HasImpls<'a> {
     fn is_multiline(&self) -> bool {
         match self {
             HasImpls::SpaceBefore(_, _) | HasImpls::SpaceAfter(_, _) => true,
-            HasImpls::HasImpls(impls) => impls.is_multiline(),
+            HasImpls::HasImpls(impls) => is_collection_multiline(impls),
         }
     }
 
@@ -657,7 +650,7 @@ impl<'a> Formattable for HasAbilities<'a> {
     fn is_multiline(&self) -> bool {
         match self {
             HasAbilities::SpaceAfter(..) | HasAbilities::SpaceBefore(..) => true,
-            HasAbilities::Has(has_abilities) => has_abilities.is_multiline(),
+            HasAbilities::Has(has_abilities) => is_collection_multiline(has_abilities),
         }
     }
 

--- a/crates/compiler/fmt/src/collection.rs
+++ b/crates/compiler/fmt/src/collection.rs
@@ -1,7 +1,7 @@
 use roc_parse::ast::{Collection, CommentOrNewline, ExtractSpaces};
 
 use crate::{
-    annotation::{Formattable, Newlines},
+    annotation::{is_collection_multiline, Formattable, Newlines},
     spaces::{fmt_comments_only, NewlineAt, INDENT},
     Buf,
 };
@@ -34,7 +34,7 @@ pub fn fmt_collection<'a, 'buf, T: ExtractSpaces<'a> + Formattable>(
         Braces::Square => ']',
     };
 
-    if items.is_multiline() {
+    if is_collection_multiline(&items) {
         let braces_indent = indent;
         let item_indent = braces_indent + INDENT;
         if newline == Newlines::Yes {

--- a/crates/compiler/parse/src/ast.rs
+++ b/crates/compiler/parse/src/ast.rs
@@ -8,7 +8,7 @@ use roc_collections::soa::{EitherIndex, Index, Slice};
 use roc_module::called_via::{BinOp, CalledVia, UnaryOp};
 use roc_region::all::{Loc, Position, Region};
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Spaces<'a, T> {
     pub before: &'a [CommentOrNewline<'a>],
     pub item: T,
@@ -81,11 +81,17 @@ impl<'a, T: ExtractSpaces<'a>> ExtractSpaces<'a> for Loc<T> {
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub enum Module<'a> {
-    Interface { header: InterfaceHeader<'a> },
-    App { header: AppHeader<'a> },
-    Platform { header: PlatformHeader<'a> },
-    Hosted { header: HostedHeader<'a> },
+pub struct Module<'a> {
+    pub comments: &'a [CommentOrNewline<'a>],
+    pub header: Header<'a>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum Header<'a> {
+    Interface(InterfaceHeader<'a>),
+    App(AppHeader<'a>),
+    Platform(PlatformHeader<'a>),
+    Hosted(HostedHeader<'a>),
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]

--- a/crates/compiler/parse/src/expr.rs
+++ b/crates/compiler/parse/src/expr.rs
@@ -1089,10 +1089,10 @@ fn opaque_signature_with_space_before<'a>(
                 EType::TIndentStart,
             ),
         ),
-        optional(specialize(
+        optional(backtrackable(specialize(
             EExpr::Type,
             space0_before_e(type_annotation::has_abilities(), EType::TIndentStart,),
-        ))
+        )))
     )
 }
 
@@ -2557,7 +2557,7 @@ fn record_help<'a>() -> impl Parser<
         and!(
             // You can optionally have an identifier followed by an '&' to
             // make this a record update, e.g. { Foo.user & username: "blah" }.
-            optional(skip_second!(
+            optional(backtrackable(skip_second!(
                 space0_around_ee(
                     // We wrap the ident in an Expr here,
                     // so that we have a Spaceable value to work with,
@@ -2568,7 +2568,7 @@ fn record_help<'a>() -> impl Parser<
                     ERecord::IndentAmpersand,
                 ),
                 word1(b'&', ERecord::Ampersand)
-            )),
+            ))),
             loc!(skip_first!(
                 // We specifically allow space characters inside here, so that
                 // `{  }` can be successfully parsed as an empty record, and then

--- a/crates/compiler/parse/src/module.rs
+++ b/crates/compiler/parse/src/module.rs
@@ -1,8 +1,10 @@
-use crate::ast::{Collection, CommentOrNewline, Defs, Module, Spaced};
+use crate::ast::{Collection, Defs, Header, Module, Spaced, Spaces};
 use crate::blankspace::{space0_around_ee, space0_before_e, space0_e};
 use crate::header::{
-    package_entry, package_name, AppHeader, ExposedName, HostedHeader, ImportsEntry,
-    InterfaceHeader, ModuleName, PackageEntry, PlatformHeader, PlatformRequires, To, TypedIdent,
+    package_entry, package_name, AppHeader, ExposedName, ExposesKeyword, GeneratesKeyword,
+    HostedHeader, ImportsEntry, ImportsKeyword, InterfaceHeader, Keyword, KeywordItem, ModuleName,
+    PackageEntry, PackagesKeyword, PlatformHeader, PlatformRequires, ProvidesKeyword, ProvidesTo,
+    RequiresKeyword, To, ToKeyword, TypedIdent, WithKeyword,
 };
 use crate::ident::{self, lowercase_ident, unqualified_ident, uppercase, UppercaseIdent};
 use crate::parser::Progress::{self, *};
@@ -48,132 +50,63 @@ pub fn parse_header<'a>(
 fn header<'a>() -> impl Parser<'a, Module<'a>, EHeader<'a>> {
     use crate::parser::keyword_e;
 
-    type Clos<'b> = Box<(dyn FnOnce(&'b [CommentOrNewline]) -> Module<'b> + 'b)>;
-
-    map!(
-        and!(
-            space0_e(EHeader::IndentStart),
-            one_of![
-                map!(
-                    skip_first!(
-                        keyword_e("interface", EHeader::Start),
-                        increment_min_indent(interface_header())
-                    ),
-                    |mut header: InterfaceHeader<'a>| -> Clos<'a> {
-                        Box::new(|spaces| {
-                            header.before_header = spaces;
-                            Module::Interface { header }
-                        })
-                    }
+    record!(Module {
+        comments: space0_e(EHeader::IndentStart),
+        header: one_of![
+            map!(
+                skip_first!(
+                    keyword_e("interface", EHeader::Start),
+                    increment_min_indent(interface_header())
                 ),
-                map!(
-                    skip_first!(
-                        keyword_e("app", EHeader::Start),
-                        increment_min_indent(app_header())
-                    ),
-                    |mut header: AppHeader<'a>| -> Clos<'a> {
-                        Box::new(|spaces| {
-                            header.before_header = spaces;
-                            Module::App { header }
-                        })
-                    }
+                Header::Interface
+            ),
+            map!(
+                skip_first!(
+                    keyword_e("app", EHeader::Start),
+                    increment_min_indent(app_header())
                 ),
-                map!(
-                    skip_first!(
-                        keyword_e("platform", EHeader::Start),
-                        increment_min_indent(platform_header())
-                    ),
-                    |mut header: PlatformHeader<'a>| -> Clos<'a> {
-                        Box::new(|spaces| {
-                            header.before_header = spaces;
-                            Module::Platform { header }
-                        })
-                    }
+                Header::App
+            ),
+            map!(
+                skip_first!(
+                    keyword_e("platform", EHeader::Start),
+                    increment_min_indent(platform_header())
                 ),
-                map!(
-                    skip_first!(
-                        keyword_e("hosted", EHeader::Start),
-                        increment_min_indent(hosted_header())
-                    ),
-                    |mut header: HostedHeader<'a>| -> Clos<'a> {
-                        Box::new(|spaces| {
-                            header.before_header = spaces;
-                            Module::Hosted { header }
-                        })
-                    }
-                )
-            ]
-        ),
-        |(spaces, make_header): (&'a [CommentOrNewline], Clos<'a>)| { make_header(spaces) }
-    )
+                Header::Platform
+            ),
+            map!(
+                skip_first!(
+                    keyword_e("hosted", EHeader::Start),
+                    increment_min_indent(hosted_header())
+                ),
+                Header::Hosted
+            ),
+        ]
+    })
 }
 
 #[inline(always)]
 fn interface_header<'a>() -> impl Parser<'a, InterfaceHeader<'a>, EHeader<'a>> {
-    |arena, state, min_indent: u32| {
-        let (_, after_interface_keyword, state) =
-            space0_e(EHeader::IndentStart).parse(arena, state, min_indent)?;
-        let (_, name, state) =
-            loc!(module_name_help(EHeader::ModuleName)).parse(arena, state, min_indent)?;
-
-        let (_, ((before_exposes, after_exposes), exposes), state) =
-            specialize(EHeader::Exposes, exposes_values()).parse(arena, state, min_indent)?;
-        let (_, ((before_imports, after_imports), imports), state) =
-            specialize(EHeader::Imports, imports()).parse(arena, state, min_indent)?;
-
-        let header = InterfaceHeader {
-            name,
-            exposes,
-            imports,
-            before_header: &[] as &[_],
-            after_interface_keyword,
-            before_exposes,
-            after_exposes,
-            before_imports,
-            after_imports,
-        };
-
-        Ok((MadeProgress, header, state))
-    }
+    record!(InterfaceHeader {
+        before_name: space0_e(EHeader::IndentStart),
+        name: loc!(module_name_help(EHeader::ModuleName)),
+        exposes: specialize(EHeader::Exposes, exposes_values()),
+        imports: specialize(EHeader::Imports, imports()),
+    })
+    .trace("interface_header")
 }
 
 #[inline(always)]
 fn hosted_header<'a>() -> impl Parser<'a, HostedHeader<'a>, EHeader<'a>> {
-    |arena, state, min_indent: u32| {
-        let (_, after_hosted_keyword, state) =
-            space0_e(EHeader::IndentStart).parse(arena, state, min_indent)?;
-        let (_, name, state) =
-            loc!(module_name_help(EHeader::ModuleName)).parse(arena, state, min_indent)?;
-
-        let (_, ((before_exposes, after_exposes), exposes), state) =
-            specialize(EHeader::Exposes, exposes_values()).parse(arena, state, min_indent)?;
-        let (_, ((before_imports, after_imports), imports), state) =
-            specialize(EHeader::Imports, imports()).parse(arena, state, min_indent)?;
-        let (_, ((before_generates, after_generates), generates), state) =
-            specialize(EHeader::Generates, generates()).parse(arena, state, min_indent)?;
-        let (_, ((before_with, after_with), generates_with), state) =
-            specialize(EHeader::GeneratesWith, generates_with()).parse(arena, state, min_indent)?;
-
-        let header = HostedHeader {
-            name,
-            exposes,
-            imports,
-            generates,
-            generates_with,
-            before_header: &[] as &[_],
-            after_hosted_keyword,
-            before_exposes,
-            after_exposes,
-            before_imports,
-            after_imports,
-            before_generates,
-            after_generates,
-            before_with,
-            after_with,
-        };
-
-        Ok((MadeProgress, header, state))
-    }
+    record!(HostedHeader {
+        before_name: space0_e(EHeader::IndentStart),
+        name: loc!(module_name_help(EHeader::ModuleName)),
+        exposes: specialize(EHeader::Exposes, exposes_values()),
+        imports: specialize(EHeader::Imports, imports()),
+        generates: specialize(EHeader::Generates, generates()),
+        generates_with: specialize(EHeader::GeneratesWith, generates_with()),
+    })
+    .trace("hosted_header")
 }
 
 fn chomp_module_name(buffer: &[u8]) -> Result<&str, Progress> {
@@ -237,127 +170,31 @@ fn module_name<'a>() -> impl Parser<'a, ModuleName<'a>, ()> {
 
 #[inline(always)]
 fn app_header<'a>() -> impl Parser<'a, AppHeader<'a>, EHeader<'a>> {
-    |arena, state, min_indent: u32| {
-        let (_, after_app_keyword, state) =
-            space0_e(EHeader::IndentStart).parse(arena, state, min_indent)?;
-        let (_, name, state) = loc!(crate::parser::specialize(
+    record!(AppHeader {
+        before_name: space0_e(EHeader::IndentStart),
+        name: loc!(crate::parser::specialize(
             EHeader::AppName,
             string_literal::parse()
-        ))
-        .parse(arena, state, min_indent)?;
-
-        let (_, opt_pkgs, state) =
-            maybe!(specialize(EHeader::Packages, packages())).parse(arena, state, min_indent)?;
-        let (_, opt_imports, state) =
-            maybe!(specialize(EHeader::Imports, imports())).parse(arena, state, min_indent)?;
-        let (_, provides, state) =
-            specialize(EHeader::Provides, provides_to()).parse(arena, state, min_indent)?;
-
-        let (before_packages, after_packages, packages) = match opt_pkgs {
-            Some(pkgs) => {
-                let pkgs: Packages<'a> = pkgs; // rustc must be told the type here
-
-                (
-                    pkgs.before_packages_keyword,
-                    pkgs.after_packages_keyword,
-                    pkgs.entries,
-                )
-            }
-            None => (&[] as _, &[] as _, Collection::empty()),
-        };
-
-        // rustc must be told the type here
-        #[allow(clippy::type_complexity)]
-        let opt_imports: Option<(
-            (&'a [CommentOrNewline<'a>], &'a [CommentOrNewline<'a>]),
-            Collection<'a, Loc<Spaced<'a, ImportsEntry<'a>>>>,
-        )> = opt_imports;
-
-        let ((before_imports, after_imports), imports) =
-            opt_imports.unwrap_or_else(|| ((&[] as _, &[] as _), Collection::empty()));
-        let provides: ProvidesTo<'a> = provides; // rustc must be told the type here
-
-        let header = AppHeader {
-            name,
-            packages,
-            imports,
-            provides: provides.entries,
-            provides_types: provides.types,
-            to: provides.to,
-            before_header: &[] as &[_],
-            after_app_keyword,
-            before_packages,
-            after_packages,
-            before_imports,
-            after_imports,
-            before_provides: provides.before_provides_keyword,
-            after_provides: provides.after_provides_keyword,
-            before_to: provides.before_to_keyword,
-            after_to: provides.after_to_keyword,
-        };
-
-        Ok((MadeProgress, header, state))
-    }
+        )),
+        packages: optional(specialize(EHeader::Packages, packages())),
+        imports: optional(specialize(EHeader::Imports, imports())),
+        provides: specialize(EHeader::Provides, provides_to()),
+    })
+    .trace("app_header")
 }
 
 #[inline(always)]
 fn platform_header<'a>() -> impl Parser<'a, PlatformHeader<'a>, EHeader<'a>> {
-    |arena, state, min_indent: u32| {
-        let (_, after_platform_keyword, state) =
-            space0_e(EHeader::IndentStart).parse(arena, state, min_indent)?;
-        let (_, name, state) = loc!(specialize(EHeader::PlatformName, package_name()))
-            .parse(arena, state, min_indent)?;
-
-        let (_, ((before_requires, after_requires), requires), state) =
-            specialize(EHeader::Requires, requires()).parse(arena, state, min_indent)?;
-
-        let (_, ((before_exposes, after_exposes), exposes), state) =
-            specialize(EHeader::Exposes, exposes_modules()).parse(arena, state, min_indent)?;
-
-        let (_, packages, state) =
-            specialize(EHeader::Packages, packages()).parse(arena, state, min_indent)?;
-
-        let (_, ((before_imports, after_imports), imports), state) =
-            specialize(EHeader::Imports, imports()).parse(arena, state, min_indent)?;
-
-        let (_, ((before_provides, after_provides), (provides, _provides_type)), state) =
-            specialize(EHeader::Provides, provides_without_to()).parse(arena, state, min_indent)?;
-
-        let header = PlatformHeader {
-            name,
-            requires,
-            exposes,
-            packages: packages.entries,
-            imports,
-            provides,
-            before_header: &[] as &[_],
-            after_platform_keyword,
-            before_requires,
-            after_requires,
-            before_exposes,
-            after_exposes,
-            before_packages: packages.before_packages_keyword,
-            after_packages: packages.after_packages_keyword,
-            before_imports,
-            after_imports,
-            before_provides,
-            after_provides,
-        };
-
-        Ok((MadeProgress, header, state))
-    }
-}
-
-#[derive(Debug)]
-struct ProvidesTo<'a> {
-    entries: Collection<'a, Loc<Spaced<'a, ExposedName<'a>>>>,
-    types: Option<Collection<'a, Loc<Spaced<'a, UppercaseIdent<'a>>>>>,
-    to: Loc<To<'a>>,
-
-    before_provides_keyword: &'a [CommentOrNewline<'a>],
-    after_provides_keyword: &'a [CommentOrNewline<'a>],
-    before_to_keyword: &'a [CommentOrNewline<'a>],
-    after_to_keyword: &'a [CommentOrNewline<'a>],
+    record!(PlatformHeader {
+        before_name: space0_e(EHeader::IndentStart),
+        name: loc!(specialize(EHeader::PlatformName, package_name())),
+        requires: specialize(EHeader::Requires, requires()),
+        exposes: specialize(EHeader::Exposes, exposes_modules()),
+        packages: specialize(EHeader::Packages, packages()),
+        imports: specialize(EHeader::Imports, imports()),
+        provides: specialize(EHeader::Provides, provides_exposed()),
+    })
+    .trace("platform_header")
 }
 
 fn provides_to_package<'a>() -> impl Parser<'a, To<'a>, EProvides<'a>> {
@@ -372,68 +209,54 @@ fn provides_to_package<'a>() -> impl Parser<'a, To<'a>, EProvides<'a>> {
 
 #[inline(always)]
 fn provides_to<'a>() -> impl Parser<'a, ProvidesTo<'a>, EProvides<'a>> {
-    map!(
-        and!(
-            provides_without_to(),
-            and!(
-                spaces_around_keyword(
-                    "to",
-                    EProvides::To,
-                    EProvides::IndentTo,
-                    EProvides::IndentListStart
-                ),
-                loc!(provides_to_package())
-            )
-        ),
-        |(
-            ((before_provides_keyword, after_provides_keyword), (entries, provides_types)),
-            ((before_to_keyword, after_to_keyword), to),
-        )| {
-            ProvidesTo {
-                entries,
-                types: provides_types,
-                to,
-                before_provides_keyword,
-                after_provides_keyword,
-                before_to_keyword,
-                after_to_keyword,
-            }
-        }
-    )
-}
-
-#[inline(always)]
-fn provides_without_to<'a>() -> impl Parser<
-    'a,
-    (
-        (&'a [CommentOrNewline<'a>], &'a [CommentOrNewline<'a>]),
-        (
-            Collection<'a, Loc<Spaced<'a, ExposedName<'a>>>>,
-            Option<Collection<'a, Loc<Spaced<'a, UppercaseIdent<'a>>>>>,
-        ),
-    ),
-    EProvides<'a>,
-> {
-    and!(
-        spaces_around_keyword(
-            "provides",
+    record!(ProvidesTo {
+        provides_keyword: spaces_around_keyword(
+            ProvidesKeyword,
             EProvides::Provides,
             EProvides::IndentProvides,
             EProvides::IndentListStart
         ),
-        and!(
-            collection_trailing_sep_e!(
-                word1(b'[', EProvides::ListStart),
-                exposes_entry(EProvides::Identifier),
-                word1(b',', EProvides::ListEnd),
-                word1(b']', EProvides::ListEnd),
-                EProvides::IndentListEnd,
-                Spaced::SpaceBefore
-            ),
-            // Optionally
-            optional(provides_types())
-        )
-    )
+        entries: collection_trailing_sep_e!(
+            word1(b'[', EProvides::ListStart),
+            exposes_entry(EProvides::Identifier),
+            word1(b',', EProvides::ListEnd),
+            word1(b']', EProvides::ListEnd),
+            EProvides::IndentListEnd,
+            Spaced::SpaceBefore
+        ),
+        types: optional(backtrackable(provides_types())),
+        to_keyword: spaces_around_keyword(
+            ToKeyword,
+            EProvides::To,
+            EProvides::IndentTo,
+            EProvides::IndentListStart
+        ),
+        to: loc!(provides_to_package()),
+    })
+    .trace("provides_to")
+}
+
+fn provides_exposed<'a>() -> impl Parser<
+    'a,
+    KeywordItem<'a, ProvidesKeyword, Collection<'a, Loc<Spaced<'a, ExposedName<'a>>>>>,
+    EProvides<'a>,
+> {
+    record!(KeywordItem {
+        keyword: spaces_around_keyword(
+            ProvidesKeyword,
+            EProvides::Provides,
+            EProvides::IndentProvides,
+            EProvides::IndentListStart
+        ),
+        item: collection_trailing_sep_e!(
+            word1(b'[', EProvides::ListStart),
+            exposes_entry(EProvides::Identifier),
+            word1(b',', EProvides::ListEnd),
+            word1(b']', EProvides::ListEnd),
+            EProvides::IndentListEnd,
+            Spaced::SpaceBefore
+        ),
+    })
 }
 
 #[inline(always)]
@@ -491,34 +314,25 @@ where
 }
 
 #[inline(always)]
-fn requires<'a>() -> impl Parser<
-    'a,
-    (
-        (&'a [CommentOrNewline<'a>], &'a [CommentOrNewline<'a>]),
-        PlatformRequires<'a>,
-    ),
-    ERequires<'a>,
-> {
-    and!(
-        spaces_around_keyword(
-            "requires",
+fn requires<'a>(
+) -> impl Parser<'a, KeywordItem<'a, RequiresKeyword, PlatformRequires<'a>>, ERequires<'a>> {
+    record!(KeywordItem {
+        keyword: spaces_around_keyword(
+            RequiresKeyword,
             ERequires::Requires,
             ERequires::IndentRequires,
             ERequires::IndentListStart
         ),
-        platform_requires()
-    )
+        item: platform_requires(),
+    })
 }
 
 #[inline(always)]
 fn platform_requires<'a>() -> impl Parser<'a, PlatformRequires<'a>, ERequires<'a>> {
-    map!(
-        and!(
-            skip_second!(requires_rigids(), space0_e(ERequires::ListStart)),
-            requires_typed_ident()
-        ),
-        |(rigids, signature)| { PlatformRequires { rigids, signature } }
-    )
+    record!(PlatformRequires {
+        rigids: skip_second!(requires_rigids(), space0_e(ERequires::ListStart)),
+        signature: requires_typed_ident()
+    })
 }
 
 #[inline(always)]
@@ -555,20 +369,17 @@ fn requires_typed_ident<'a>() -> impl Parser<'a, Loc<Spaced<'a, TypedIdent<'a>>>
 #[inline(always)]
 fn exposes_values<'a>() -> impl Parser<
     'a,
-    (
-        (&'a [CommentOrNewline<'a>], &'a [CommentOrNewline<'a>]),
-        Collection<'a, Loc<Spaced<'a, ExposedName<'a>>>>,
-    ),
+    KeywordItem<'a, ExposesKeyword, Collection<'a, Loc<Spaced<'a, ExposedName<'a>>>>>,
     EExposes,
 > {
-    and!(
-        spaces_around_keyword(
-            "exposes",
+    record!(KeywordItem {
+        keyword: spaces_around_keyword(
+            ExposesKeyword,
             EExposes::Exposes,
             EExposes::IndentExposes,
             EExposes::IndentListStart
         ),
-        collection_trailing_sep_e!(
+        item: collection_trailing_sep_e!(
             word1(b'[', EExposes::ListStart),
             exposes_entry(EExposes::Identifier),
             word1(b',', EExposes::ListEnd),
@@ -576,52 +387,58 @@ fn exposes_values<'a>() -> impl Parser<
             EExposes::IndentListEnd,
             Spaced::SpaceBefore
         )
-    )
+    })
 }
 
-fn spaces_around_keyword<'a, E>(
-    keyword: &'static str,
+fn spaces_around_keyword<'a, K: Keyword, E>(
+    keyword_item: K,
     expectation: fn(Position) -> E,
     indent_problem1: fn(Position) -> E,
     indent_problem2: fn(Position) -> E,
-) -> impl Parser<'a, (&'a [CommentOrNewline<'a>], &'a [CommentOrNewline<'a>]), E>
+) -> impl Parser<'a, Spaces<'a, K>, E>
 where
     E: 'a + SpaceProblem,
 {
-    and!(
-        skip_second!(
-            backtrackable(space0_e(indent_problem1)),
-            crate::parser::keyword_e(keyword, expectation)
+    map!(
+        and!(
+            skip_second!(
+                backtrackable(space0_e(indent_problem1)),
+                crate::parser::keyword_e(K::KEYWORD, expectation)
+            ),
+            space0_e(indent_problem2)
         ),
-        space0_e(indent_problem2)
+        |(before, after)| {
+            Spaces {
+                before,
+                item: keyword_item,
+                after,
+            }
+        }
     )
 }
 
 #[inline(always)]
 fn exposes_modules<'a>() -> impl Parser<
     'a,
-    (
-        (&'a [CommentOrNewline<'a>], &'a [CommentOrNewline<'a>]),
-        Collection<'a, Loc<Spaced<'a, ModuleName<'a>>>>,
-    ),
+    KeywordItem<'a, ExposesKeyword, Collection<'a, Loc<Spaced<'a, ModuleName<'a>>>>>,
     EExposes,
 > {
-    and!(
-        spaces_around_keyword(
-            "exposes",
+    record!(KeywordItem {
+        keyword: spaces_around_keyword(
+            ExposesKeyword,
             EExposes::Exposes,
             EExposes::IndentExposes,
             EExposes::IndentListStart
         ),
-        collection_trailing_sep_e!(
+        item: collection_trailing_sep_e!(
             word1(b'[', EExposes::ListStart),
             exposes_module(EExposes::Identifier),
             word1(b',', EExposes::ListEnd),
             word1(b']', EExposes::ListEnd),
             EExposes::IndentListEnd,
             Spaced::SpaceBefore
-        )
-    )
+        ),
+    })
 }
 
 fn exposes_module<'a, F, E>(
@@ -638,82 +455,58 @@ where
     ))
 }
 
-#[derive(Debug)]
-struct Packages<'a> {
-    entries: Collection<'a, Loc<Spaced<'a, PackageEntry<'a>>>>,
-    before_packages_keyword: &'a [CommentOrNewline<'a>],
-    after_packages_keyword: &'a [CommentOrNewline<'a>],
-}
-
 #[inline(always)]
-fn packages<'a>() -> impl Parser<'a, Packages<'a>, EPackages<'a>> {
-    map!(
-        and!(
-            spaces_around_keyword(
-                "packages",
-                EPackages::Packages,
-                EPackages::IndentPackages,
-                EPackages::IndentListStart
-            ),
-            collection_trailing_sep_e!(
-                word1(b'{', EPackages::ListStart),
-                specialize(EPackages::PackageEntry, loc!(package_entry())),
-                word1(b',', EPackages::ListEnd),
-                word1(b'}', EPackages::ListEnd),
-                EPackages::IndentListEnd,
-                Spaced::SpaceBefore
-            )
-        ),
-        |((before_packages_keyword, after_packages_keyword), entries): (
-            (_, _),
-            Collection<'a, _>
-        )| {
-            Packages {
-                entries,
-                before_packages_keyword,
-                after_packages_keyword,
-            }
-        }
-    )
-}
-
-#[inline(always)]
-fn generates<'a>() -> impl Parser<
+fn packages<'a>() -> impl Parser<
     'a,
-    (
-        (&'a [CommentOrNewline<'a>], &'a [CommentOrNewline<'a>]),
-        UppercaseIdent<'a>,
-    ),
-    EGenerates,
+    KeywordItem<'a, PackagesKeyword, Collection<'a, Loc<Spaced<'a, PackageEntry<'a>>>>>,
+    EPackages<'a>,
 > {
-    and!(
-        spaces_around_keyword(
-            "generates",
+    record!(KeywordItem {
+        keyword: spaces_around_keyword(
+            PackagesKeyword,
+            EPackages::Packages,
+            EPackages::IndentPackages,
+            EPackages::IndentListStart
+        ),
+        item: collection_trailing_sep_e!(
+            word1(b'{', EPackages::ListStart),
+            specialize(EPackages::PackageEntry, loc!(package_entry())),
+            word1(b',', EPackages::ListEnd),
+            word1(b'}', EPackages::ListEnd),
+            EPackages::IndentListEnd,
+            Spaced::SpaceBefore
+        )
+    })
+}
+
+#[inline(always)]
+fn generates<'a>(
+) -> impl Parser<'a, KeywordItem<'a, GeneratesKeyword, UppercaseIdent<'a>>, EGenerates> {
+    record!(KeywordItem {
+        keyword: spaces_around_keyword(
+            GeneratesKeyword,
             EGenerates::Generates,
             EGenerates::IndentGenerates,
             EGenerates::IndentTypeStart
         ),
-        specialize(|(), pos| EGenerates::Identifier(pos), uppercase())
-    )
+        item: specialize(|(), pos| EGenerates::Identifier(pos), uppercase())
+    })
 }
 
 #[inline(always)]
 fn generates_with<'a>() -> impl Parser<
     'a,
-    (
-        (&'a [CommentOrNewline<'a>], &'a [CommentOrNewline<'a>]),
-        Collection<'a, Loc<Spaced<'a, ExposedName<'a>>>>,
-    ),
+    KeywordItem<'a, WithKeyword, Collection<'a, Loc<Spaced<'a, ExposedName<'a>>>>>,
     EGeneratesWith,
 > {
-    and!(
-        spaces_around_keyword(
-            "with",
+    record!(KeywordItem {
+        keyword: spaces_around_keyword(
+            WithKeyword,
             EGeneratesWith::With,
             EGeneratesWith::IndentWith,
             EGeneratesWith::IndentListStart
         ),
-        collection_trailing_sep_e!(
+        item: collection_trailing_sep_e!(
             word1(b'[', EGeneratesWith::ListStart),
             exposes_entry(EGeneratesWith::Identifier),
             word1(b',', EGeneratesWith::ListEnd),
@@ -721,26 +514,23 @@ fn generates_with<'a>() -> impl Parser<
             EGeneratesWith::IndentListEnd,
             Spaced::SpaceBefore
         )
-    )
+    })
 }
 
 #[inline(always)]
 fn imports<'a>() -> impl Parser<
     'a,
-    (
-        (&'a [CommentOrNewline<'a>], &'a [CommentOrNewline<'a>]),
-        Collection<'a, Loc<Spaced<'a, ImportsEntry<'a>>>>,
-    ),
+    KeywordItem<'a, ImportsKeyword, Collection<'a, Loc<Spaced<'a, ImportsEntry<'a>>>>>,
     EImports,
 > {
-    and!(
-        spaces_around_keyword(
-            "imports",
+    record!(KeywordItem {
+        keyword: spaces_around_keyword(
+            ImportsKeyword,
             EImports::Imports,
             EImports::IndentImports,
             EImports::IndentListStart
         ),
-        collection_trailing_sep_e!(
+        item: collection_trailing_sep_e!(
             word1(b'[', EImports::ListStart),
             loc!(imports_entry()),
             word1(b',', EImports::ListEnd),
@@ -748,7 +538,8 @@ fn imports<'a>() -> impl Parser<
             EImports::IndentListEnd,
             Spaced::SpaceBefore
         )
-    )
+    })
+    .trace("imports")
 }
 
 #[inline(always)]
@@ -810,15 +601,15 @@ fn imports_entry<'a>() -> impl Parser<'a, Spaced<'a, ImportsEntry<'a>>, EImports
         and!(
             and!(
                 // e.g. `pf.`
-                maybe!(skip_second!(
+                optional(backtrackable(skip_second!(
                     shortname(),
                     word1(b'.', EImports::ShorthandDot)
-                )),
+                ))),
                 // e.g. `Task`
                 module_name_help(EImports::ModuleName)
             ),
             // e.g. `.{ Task, after}`
-            maybe!(skip_first!(
+            optional(skip_first!(
                 word1(b'.', EImports::ExposingDot),
                 collection_trailing_sep_e!(
                     word1(b'{', EImports::SetStart),
@@ -842,4 +633,5 @@ fn imports_entry<'a>() -> impl Parser<'a, Spaced<'a, ImportsEntry<'a>>, EImports
             Spaced::Item(entry)
         }
     )
+    .trace("imports_entry")
 }

--- a/crates/compiler/parse/tests/snapshots/pass/empty_app_header.header.result-ast
+++ b/crates/compiler/parse/tests/snapshots/pass/empty_app_header.header.result-ast
@@ -1,24 +1,48 @@
-App {
-    header: AppHeader {
-        name: @4-14 PlainLine(
-            "test-app",
-        ),
-        packages: [],
-        imports: [],
-        provides: [],
-        provides_types: None,
-        to: @53-57 ExistingPackage(
-            "blah",
-        ),
-        before_header: [],
-        after_app_keyword: [],
-        before_packages: [],
-        after_packages: [],
-        before_imports: [],
-        after_imports: [],
-        before_provides: [],
-        after_provides: [],
-        before_to: [],
-        after_to: [],
-    },
+Module {
+    comments: [],
+    header: App(
+        AppHeader {
+            before_name: [],
+            name: @4-14 PlainLine(
+                "test-app",
+            ),
+            packages: Some(
+                KeywordItem {
+                    keyword: Spaces {
+                        before: [],
+                        item: PackagesKeyword,
+                        after: [],
+                    },
+                    item: [],
+                },
+            ),
+            imports: Some(
+                KeywordItem {
+                    keyword: Spaces {
+                        before: [],
+                        item: ImportsKeyword,
+                        after: [],
+                    },
+                    item: [],
+                },
+            ),
+            provides: ProvidesTo {
+                provides_keyword: Spaces {
+                    before: [],
+                    item: ProvidesKeyword,
+                    after: [],
+                },
+                entries: [],
+                types: None,
+                to_keyword: Spaces {
+                    before: [],
+                    item: ToKeyword,
+                    after: [],
+                },
+                to: @53-57 ExistingPackage(
+                    "blah",
+                ),
+            },
+        },
+    ),
 }

--- a/crates/compiler/parse/tests/snapshots/pass/empty_hosted_header.header.result-ast
+++ b/crates/compiler/parse/tests/snapshots/pass/empty_hosted_header.header.result-ast
@@ -1,23 +1,45 @@
-Hosted {
-    header: HostedHeader {
-        name: @7-10 ModuleName(
-            "Foo",
-        ),
-        exposes: [],
-        imports: [],
-        generates: UppercaseIdent(
-            "Bar",
-        ),
-        generates_with: [],
-        before_header: [],
-        after_hosted_keyword: [],
-        before_exposes: [],
-        after_exposes: [],
-        before_imports: [],
-        after_imports: [],
-        before_generates: [],
-        after_generates: [],
-        before_with: [],
-        after_with: [],
-    },
+Module {
+    comments: [],
+    header: Hosted(
+        HostedHeader {
+            before_name: [],
+            name: @7-10 ModuleName(
+                "Foo",
+            ),
+            exposes: KeywordItem {
+                keyword: Spaces {
+                    before: [],
+                    item: ExposesKeyword,
+                    after: [],
+                },
+                item: [],
+            },
+            imports: KeywordItem {
+                keyword: Spaces {
+                    before: [],
+                    item: ImportsKeyword,
+                    after: [],
+                },
+                item: [],
+            },
+            generates: KeywordItem {
+                keyword: Spaces {
+                    before: [],
+                    item: GeneratesKeyword,
+                    after: [],
+                },
+                item: UppercaseIdent(
+                    "Bar",
+                ),
+            },
+            generates_with: KeywordItem {
+                keyword: Spaces {
+                    before: [],
+                    item: WithKeyword,
+                    after: [],
+                },
+                item: [],
+            },
+        },
+    ),
 }

--- a/crates/compiler/parse/tests/snapshots/pass/empty_interface_header.header.result-ast
+++ b/crates/compiler/parse/tests/snapshots/pass/empty_interface_header.header.result-ast
@@ -1,15 +1,27 @@
-Interface {
-    header: InterfaceHeader {
-        name: @10-13 ModuleName(
-            "Foo",
-        ),
-        exposes: [],
-        imports: [],
-        before_header: [],
-        after_interface_keyword: [],
-        before_exposes: [],
-        after_exposes: [],
-        before_imports: [],
-        after_imports: [],
-    },
+Module {
+    comments: [],
+    header: Interface(
+        InterfaceHeader {
+            before_name: [],
+            name: @10-13 ModuleName(
+                "Foo",
+            ),
+            exposes: KeywordItem {
+                keyword: Spaces {
+                    before: [],
+                    item: ExposesKeyword,
+                    after: [],
+                },
+                item: [],
+            },
+            imports: KeywordItem {
+                keyword: Spaces {
+                    before: [],
+                    item: ImportsKeyword,
+                    after: [],
+                },
+                item: [],
+            },
+        },
+    ),
 }

--- a/crates/compiler/parse/tests/snapshots/pass/empty_platform_header.header.result-ast
+++ b/crates/compiler/parse/tests/snapshots/pass/empty_platform_header.header.result-ast
@@ -1,34 +1,61 @@
-Platform {
-    header: PlatformHeader {
-        name: @9-25 PackageName(
-            "rtfeldman/blah",
-        ),
-        requires: PlatformRequires {
-            rigids: [],
-            signature: @40-49 TypedIdent {
-                ident: @40-44 "main",
-                spaces_before_colon: [],
-                ann: @47-49 Record {
-                    fields: [],
-                    ext: None,
+Module {
+    comments: [],
+    header: Platform(
+        PlatformHeader {
+            before_name: [],
+            name: @9-25 PackageName(
+                "rtfeldman/blah",
+            ),
+            requires: KeywordItem {
+                keyword: Spaces {
+                    before: [],
+                    item: RequiresKeyword,
+                    after: [],
+                },
+                item: PlatformRequires {
+                    rigids: [],
+                    signature: @40-49 TypedIdent {
+                        ident: @40-44 "main",
+                        spaces_before_colon: [],
+                        ann: @47-49 Record {
+                            fields: [],
+                            ext: None,
+                        },
+                    },
                 },
             },
+            exposes: KeywordItem {
+                keyword: Spaces {
+                    before: [],
+                    item: ExposesKeyword,
+                    after: [],
+                },
+                item: [],
+            },
+            packages: KeywordItem {
+                keyword: Spaces {
+                    before: [],
+                    item: PackagesKeyword,
+                    after: [],
+                },
+                item: [],
+            },
+            imports: KeywordItem {
+                keyword: Spaces {
+                    before: [],
+                    item: ImportsKeyword,
+                    after: [],
+                },
+                item: [],
+            },
+            provides: KeywordItem {
+                keyword: Spaces {
+                    before: [],
+                    item: ProvidesKeyword,
+                    after: [],
+                },
+                item: [],
+            },
         },
-        exposes: [],
-        packages: [],
-        imports: [],
-        provides: [],
-        before_header: [],
-        after_platform_keyword: [],
-        before_requires: [],
-        after_requires: [],
-        before_exposes: [],
-        after_exposes: [],
-        before_packages: [],
-        after_packages: [],
-        before_imports: [],
-        after_imports: [],
-        before_provides: [],
-        after_provides: [],
-    },
+    ),
 }

--- a/crates/compiler/parse/tests/snapshots/pass/full_app_header.header.result-ast
+++ b/crates/compiler/parse/tests/snapshots/pass/full_app_header.header.result-ast
@@ -1,50 +1,74 @@
-App {
-    header: AppHeader {
-        name: @4-15 PlainLine(
-            "quicksort",
-        ),
-        packages: [
-            @31-47 PackageEntry {
-                shorthand: "pf",
-                spaces_after_shorthand: [],
-                package_name: @35-47 PackageName(
-                    "./platform",
-                ),
-            },
-        ],
-        imports: [
-            @64-75 Package(
-                "foo",
-                ModuleName(
-                    "Bar.Baz",
-                ),
-                [],
-            ),
-        ],
-        provides: [
-            @93-102 ExposedName(
+Module {
+    comments: [],
+    header: App(
+        AppHeader {
+            before_name: [],
+            name: @4-15 PlainLine(
                 "quicksort",
             ),
-        ],
-        provides_types: None,
-        to: @108-110 ExistingPackage(
-            "pf",
-        ),
-        before_header: [],
-        after_app_keyword: [],
-        before_packages: [
-            Newline,
-        ],
-        after_packages: [],
-        before_imports: [
-            Newline,
-        ],
-        after_imports: [],
-        before_provides: [
-            Newline,
-        ],
-        after_provides: [],
-        before_to: [],
-        after_to: [],
-    },
+            packages: Some(
+                KeywordItem {
+                    keyword: Spaces {
+                        before: [
+                            Newline,
+                        ],
+                        item: PackagesKeyword,
+                        after: [],
+                    },
+                    item: [
+                        @31-47 PackageEntry {
+                            shorthand: "pf",
+                            spaces_after_shorthand: [],
+                            package_name: @35-47 PackageName(
+                                "./platform",
+                            ),
+                        },
+                    ],
+                },
+            ),
+            imports: Some(
+                KeywordItem {
+                    keyword: Spaces {
+                        before: [
+                            Newline,
+                        ],
+                        item: ImportsKeyword,
+                        after: [],
+                    },
+                    item: [
+                        @64-75 Package(
+                            "foo",
+                            ModuleName(
+                                "Bar.Baz",
+                            ),
+                            [],
+                        ),
+                    ],
+                },
+            ),
+            provides: ProvidesTo {
+                provides_keyword: Spaces {
+                    before: [
+                        Newline,
+                    ],
+                    item: ProvidesKeyword,
+                    after: [],
+                },
+                entries: [
+                    @93-102 ExposedName(
+                        "quicksort",
+                    ),
+                ],
+                types: None,
+                to_keyword: Spaces {
+                    before: [],
+                    item: ToKeyword,
+                    after: [],
+                },
+                to: @108-110 ExistingPackage(
+                    "pf",
+                ),
+            },
+        },
+    ),
 }

--- a/crates/compiler/parse/tests/snapshots/pass/full_app_header_trailing_commas.header.result-ast
+++ b/crates/compiler/parse/tests/snapshots/pass/full_app_header_trailing_commas.header.result-ast
@@ -1,75 +1,99 @@
-App {
-    header: AppHeader {
-        name: @4-15 PlainLine(
-            "quicksort",
-        ),
-        packages: [
-            @31-47 PackageEntry {
-                shorthand: "pf",
-                spaces_after_shorthand: [],
-                package_name: @35-47 PackageName(
-                    "./platform",
-                ),
-            },
-        ],
-        imports: [
-            @65-141 Package(
-                "foo",
-                ModuleName(
-                    "Bar",
-                ),
-                Collection {
-                    items: [
-                        @83-86 SpaceBefore(
-                            ExposedName(
-                                "Baz",
+Module {
+    comments: [],
+    header: App(
+        AppHeader {
+            before_name: [],
+            name: @4-15 PlainLine(
+                "quicksort",
+            ),
+            packages: Some(
+                KeywordItem {
+                    keyword: Spaces {
+                        before: [
+                            Newline,
+                        ],
+                        item: PackagesKeyword,
+                        after: [],
+                    },
+                    item: [
+                        @31-47 PackageEntry {
+                            shorthand: "pf",
+                            spaces_after_shorthand: [],
+                            package_name: @35-47 PackageName(
+                                "./platform",
                             ),
-                            [
-                                Newline,
-                            ],
-                        ),
-                        @96-104 SpaceBefore(
-                            ExposedName(
-                                "FortyTwo",
-                            ),
-                            [
-                                Newline,
-                            ],
-                        ),
+                        },
                     ],
-                    final_comments: [
-                        Newline,
-                        LineComment(
-                            " I'm a happy comment",
+                },
+            ),
+            imports: Some(
+                KeywordItem {
+                    keyword: Spaces {
+                        before: [
+                            Newline,
+                        ],
+                        item: ImportsKeyword,
+                        after: [],
+                    },
+                    item: [
+                        @65-141 Package(
+                            "foo",
+                            ModuleName(
+                                "Bar",
+                            ),
+                            Collection {
+                                items: [
+                                    @83-86 SpaceBefore(
+                                        ExposedName(
+                                            "Baz",
+                                        ),
+                                        [
+                                            Newline,
+                                        ],
+                                    ),
+                                    @96-104 SpaceBefore(
+                                        ExposedName(
+                                            "FortyTwo",
+                                        ),
+                                        [
+                                            Newline,
+                                        ],
+                                    ),
+                                ],
+                                final_comments: [
+                                    Newline,
+                                    LineComment(
+                                        " I'm a happy comment",
+                                    ),
+                                ],
+                            },
                         ),
                     ],
                 },
             ),
-        ],
-        provides: [
-            @159-168 ExposedName(
-                "quicksort",
-            ),
-        ],
-        provides_types: None,
-        to: @175-177 ExistingPackage(
-            "pf",
-        ),
-        before_header: [],
-        after_app_keyword: [],
-        before_packages: [
-            Newline,
-        ],
-        after_packages: [],
-        before_imports: [
-            Newline,
-        ],
-        after_imports: [],
-        before_provides: [
-            Newline,
-        ],
-        after_provides: [],
-        before_to: [],
-        after_to: [],
-    },
+            provides: ProvidesTo {
+                provides_keyword: Spaces {
+                    before: [
+                        Newline,
+                    ],
+                    item: ProvidesKeyword,
+                    after: [],
+                },
+                entries: [
+                    @159-168 ExposedName(
+                        "quicksort",
+                    ),
+                ],
+                types: None,
+                to_keyword: Spaces {
+                    before: [],
+                    item: ToKeyword,
+                    after: [],
+                },
+                to: @175-177 ExistingPackage(
+                    "pf",
+                ),
+            },
+        },
+    ),
 }

--- a/crates/compiler/parse/tests/snapshots/pass/function_effect_types.header.result-ast
+++ b/crates/compiler/parse/tests/snapshots/pass/function_effect_types.header.result-ast
@@ -1,71 +1,98 @@
-Platform {
-    header: PlatformHeader {
-        name: @9-14 PackageName(
-            "cli",
-        ),
-        requires: PlatformRequires {
-            rigids: [],
-            signature: @32-49 TypedIdent {
-                ident: @32-36 "main",
-                spaces_before_colon: [],
-                ann: @39-49 Apply(
-                    "",
-                    "Task",
-                    [
-                        @44-46 Record {
-                            fields: [],
-                            ext: None,
-                        },
-                        @47-49 TagUnion {
-                            ext: None,
-                            tags: [],
-                        },
+Module {
+    comments: [],
+    header: Platform(
+        PlatformHeader {
+            before_name: [],
+            name: @9-14 PackageName(
+                "cli",
+            ),
+            requires: KeywordItem {
+                keyword: Spaces {
+                    before: [
+                        Newline,
                     ],
-                ),
+                    item: RequiresKeyword,
+                    after: [],
+                },
+                item: PlatformRequires {
+                    rigids: [],
+                    signature: @32-49 TypedIdent {
+                        ident: @32-36 "main",
+                        spaces_before_colon: [],
+                        ann: @39-49 Apply(
+                            "",
+                            "Task",
+                            [
+                                @44-46 Record {
+                                    fields: [],
+                                    ext: None,
+                                },
+                                @47-49 TagUnion {
+                                    ext: None,
+                                    tags: [],
+                                },
+                            ],
+                        ),
+                    },
+                },
             },
-        },
-        exposes: [],
-        packages: [],
-        imports: [
-            @110-123 Module(
-                ModuleName(
-                    "Task",
-                ),
-                [
-                    @117-121 ExposedName(
-                        "Task",
+            exposes: KeywordItem {
+                keyword: Spaces {
+                    before: [
+                        LineComment(
+                            " TODO FIXME",
+                        ),
+                    ],
+                    item: ExposesKeyword,
+                    after: [],
+                },
+                item: [],
+            },
+            packages: KeywordItem {
+                keyword: Spaces {
+                    before: [
+                        Newline,
+                    ],
+                    item: PackagesKeyword,
+                    after: [],
+                },
+                item: [],
+            },
+            imports: KeywordItem {
+                keyword: Spaces {
+                    before: [
+                        Newline,
+                    ],
+                    item: ImportsKeyword,
+                    after: [],
+                },
+                item: [
+                    @110-123 Module(
+                        ModuleName(
+                            "Task",
+                        ),
+                        [
+                            @117-121 ExposedName(
+                                "Task",
+                            ),
+                        ],
                     ),
                 ],
-            ),
-        ],
-        provides: [
-            @141-152 ExposedName(
-                "mainForHost",
-            ),
-        ],
-        before_header: [],
-        after_platform_keyword: [],
-        before_requires: [
-            Newline,
-        ],
-        after_requires: [],
-        before_exposes: [
-            LineComment(
-                " TODO FIXME",
-            ),
-        ],
-        after_exposes: [],
-        before_packages: [
-            Newline,
-        ],
-        after_packages: [],
-        before_imports: [
-            Newline,
-        ],
-        after_imports: [],
-        before_provides: [
-            Newline,
-        ],
-        after_provides: [],
-    },
+            },
+            provides: KeywordItem {
+                keyword: Spaces {
+                    before: [
+                        Newline,
+                    ],
+                    item: ProvidesKeyword,
+                    after: [],
+                },
+                item: [
+                    @141-152 ExposedName(
+                        "mainForHost",
+                    ),
+                ],
+            },
+        },
+    ),
 }

--- a/crates/compiler/parse/tests/snapshots/pass/interface_with_newline.header.result-ast
+++ b/crates/compiler/parse/tests/snapshots/pass/interface_with_newline.header.result-ast
@@ -1,15 +1,27 @@
-Interface {
-    header: InterfaceHeader {
-        name: @10-11 ModuleName(
-            "T",
-        ),
-        exposes: [],
-        imports: [],
-        before_header: [],
-        after_interface_keyword: [],
-        before_exposes: [],
-        after_exposes: [],
-        before_imports: [],
-        after_imports: [],
-    },
+Module {
+    comments: [],
+    header: Interface(
+        InterfaceHeader {
+            before_name: [],
+            name: @10-11 ModuleName(
+                "T",
+            ),
+            exposes: KeywordItem {
+                keyword: Spaces {
+                    before: [],
+                    item: ExposesKeyword,
+                    after: [],
+                },
+                item: [],
+            },
+            imports: KeywordItem {
+                keyword: Spaces {
+                    before: [],
+                    item: ImportsKeyword,
+                    after: [],
+                },
+                item: [],
+            },
+        },
+    ),
 }

--- a/crates/compiler/parse/tests/snapshots/pass/minimal_app_header.header.result-ast
+++ b/crates/compiler/parse/tests/snapshots/pass/minimal_app_header.header.result-ast
@@ -1,26 +1,32 @@
-App {
-    header: AppHeader {
-        name: @4-14 PlainLine(
-            "test-app",
-        ),
-        packages: [],
-        imports: [],
-        provides: [],
-        provides_types: None,
-        to: @30-38 NewPackage(
-            PackageName(
-                "./blah",
+Module {
+    comments: [],
+    header: App(
+        AppHeader {
+            before_name: [],
+            name: @4-14 PlainLine(
+                "test-app",
             ),
-        ),
-        before_header: [],
-        after_app_keyword: [],
-        before_packages: [],
-        after_packages: [],
-        before_imports: [],
-        after_imports: [],
-        before_provides: [],
-        after_provides: [],
-        before_to: [],
-        after_to: [],
-    },
+            packages: None,
+            imports: None,
+            provides: ProvidesTo {
+                provides_keyword: Spaces {
+                    before: [],
+                    item: ProvidesKeyword,
+                    after: [],
+                },
+                entries: [],
+                types: None,
+                to_keyword: Spaces {
+                    before: [],
+                    item: ToKeyword,
+                    after: [],
+                },
+                to: @30-38 NewPackage(
+                    PackageName(
+                        "./blah",
+                    ),
+                ),
+            },
+        },
+    ),
 }

--- a/crates/compiler/parse/tests/snapshots/pass/nested_module.header.result-ast
+++ b/crates/compiler/parse/tests/snapshots/pass/nested_module.header.result-ast
@@ -1,15 +1,27 @@
-Interface {
-    header: InterfaceHeader {
-        name: @10-21 ModuleName(
-            "Foo.Bar.Baz",
-        ),
-        exposes: [],
-        imports: [],
-        before_header: [],
-        after_interface_keyword: [],
-        before_exposes: [],
-        after_exposes: [],
-        before_imports: [],
-        after_imports: [],
-    },
+Module {
+    comments: [],
+    header: Interface(
+        InterfaceHeader {
+            before_name: [],
+            name: @10-21 ModuleName(
+                "Foo.Bar.Baz",
+            ),
+            exposes: KeywordItem {
+                keyword: Spaces {
+                    before: [],
+                    item: ExposesKeyword,
+                    after: [],
+                },
+                item: [],
+            },
+            imports: KeywordItem {
+                keyword: Spaces {
+                    before: [],
+                    item: ImportsKeyword,
+                    after: [],
+                },
+                item: [],
+            },
+        },
+    ),
 }

--- a/crates/compiler/parse/tests/snapshots/pass/nonempty_hosted_header.header.result-ast
+++ b/crates/compiler/parse/tests/snapshots/pass/nonempty_hosted_header.header.result-ast
@@ -1,130 +1,152 @@
-Hosted {
-    header: HostedHeader {
-        name: @7-10 ModuleName(
-            "Foo",
-        ),
-        exposes: Collection {
-            items: [
-                @45-50 SpaceBefore(
-                    ExposedName(
-                        "Stuff",
-                    ),
-                    [
+Module {
+    comments: [],
+    header: Hosted(
+        HostedHeader {
+            before_name: [],
+            name: @7-10 ModuleName(
+                "Foo",
+            ),
+            exposes: KeywordItem {
+                keyword: Spaces {
+                    before: [
                         Newline,
                     ],
-                ),
-                @64-70 SpaceBefore(
-                    ExposedName(
-                        "Things",
-                    ),
-                    [
+                    item: ExposesKeyword,
+                    after: [
                         Newline,
                     ],
-                ),
-                @84-97 SpaceBefore(
-                    ExposedName(
-                        "somethingElse",
-                    ),
-                    [
-                        Newline,
-                    ],
-                ),
-            ],
-            final_comments: [
-                Newline,
-            ],
-        },
-        imports: Collection {
-            items: [
-                @143-147 SpaceBefore(
-                    Module(
-                        ModuleName(
-                            "Blah",
-                        ),
-                        [],
-                    ),
-                    [
-                        Newline,
-                    ],
-                ),
-                @161-182 SpaceBefore(
-                    Module(
-                        ModuleName(
-                            "Baz",
-                        ),
-                        [
-                            @167-172 ExposedName(
-                                "stuff",
+                },
+                item: Collection {
+                    items: [
+                        @45-50 SpaceBefore(
+                            ExposedName(
+                                "Stuff",
                             ),
-                            @174-180 ExposedName(
-                                "things",
+                            [
+                                Newline,
+                            ],
+                        ),
+                        @64-70 SpaceBefore(
+                            ExposedName(
+                                "Things",
                             ),
-                        ],
-                    ),
-                    [
+                            [
+                                Newline,
+                            ],
+                        ),
+                        @84-97 SpaceBefore(
+                            ExposedName(
+                                "somethingElse",
+                            ),
+                            [
+                                Newline,
+                            ],
+                        ),
+                    ],
+                    final_comments: [
                         Newline,
                     ],
+                },
+            },
+            imports: KeywordItem {
+                keyword: Spaces {
+                    before: [
+                        Newline,
+                    ],
+                    item: ImportsKeyword,
+                    after: [
+                        Newline,
+                    ],
+                },
+                item: Collection {
+                    items: [
+                        @143-147 SpaceBefore(
+                            Module(
+                                ModuleName(
+                                    "Blah",
+                                ),
+                                [],
+                            ),
+                            [
+                                Newline,
+                            ],
+                        ),
+                        @161-182 SpaceBefore(
+                            Module(
+                                ModuleName(
+                                    "Baz",
+                                ),
+                                [
+                                    @167-172 ExposedName(
+                                        "stuff",
+                                    ),
+                                    @174-180 ExposedName(
+                                        "things",
+                                    ),
+                                ],
+                            ),
+                            [
+                                Newline,
+                            ],
+                        ),
+                    ],
+                    final_comments: [
+                        Newline,
+                    ],
+                },
+            },
+            generates: KeywordItem {
+                keyword: Spaces {
+                    before: [
+                        Newline,
+                    ],
+                    item: GeneratesKeyword,
+                    after: [],
+                },
+                item: UppercaseIdent(
+                    "Bar",
                 ),
-            ],
-            final_comments: [
-                Newline,
-            ],
+            },
+            generates_with: KeywordItem {
+                keyword: Spaces {
+                    before: [],
+                    item: WithKeyword,
+                    after: [
+                        Newline,
+                    ],
+                },
+                item: Collection {
+                    items: [
+                        @239-242 SpaceBefore(
+                            ExposedName(
+                                "map",
+                            ),
+                            [
+                                Newline,
+                            ],
+                        ),
+                        @256-261 SpaceBefore(
+                            ExposedName(
+                                "after",
+                            ),
+                            [
+                                Newline,
+                            ],
+                        ),
+                        @275-279 SpaceBefore(
+                            ExposedName(
+                                "loop",
+                            ),
+                            [
+                                Newline,
+                            ],
+                        ),
+                    ],
+                    final_comments: [
+                        Newline,
+                    ],
+                },
+            },
         },
-        generates: UppercaseIdent(
-            "Bar",
-        ),
-        generates_with: Collection {
-            items: [
-                @239-242 SpaceBefore(
-                    ExposedName(
-                        "map",
-                    ),
-                    [
-                        Newline,
-                    ],
-                ),
-                @256-261 SpaceBefore(
-                    ExposedName(
-                        "after",
-                    ),
-                    [
-                        Newline,
-                    ],
-                ),
-                @275-279 SpaceBefore(
-                    ExposedName(
-                        "loop",
-                    ),
-                    [
-                        Newline,
-                    ],
-                ),
-            ],
-            final_comments: [
-                Newline,
-            ],
-        },
-        before_header: [],
-        after_hosted_keyword: [],
-        before_exposes: [
-            Newline,
-        ],
-        after_exposes: [
-            Newline,
-        ],
-        before_imports: [
-            Newline,
-        ],
-        after_imports: [
-            Newline,
-        ],
-        before_generates: [
-            Newline,
-        ],
-        after_generates: [],
-        before_with: [],
-        after_with: [
-            Newline,
-        ],
-    },
+    ),
 }

--- a/crates/compiler/parse/tests/snapshots/pass/nonempty_platform_header.header.result-ast
+++ b/crates/compiler/parse/tests/snapshots/pass/nonempty_platform_header.header.result-ast
@@ -1,60 +1,87 @@
-Platform {
-    header: PlatformHeader {
-        name: @9-21 PackageName(
-            "foo/barbaz",
-        ),
-        requires: PlatformRequires {
-            rigids: [
-                @36-41 UppercaseIdent(
-                    "Model",
-                ),
-            ],
-            signature: @45-54 TypedIdent {
-                ident: @45-49 "main",
-                spaces_before_colon: [],
-                ann: @52-54 Record {
-                    fields: [],
-                    ext: None,
+Module {
+    comments: [],
+    header: Platform(
+        PlatformHeader {
+            before_name: [],
+            name: @9-21 PackageName(
+                "foo/barbaz",
+            ),
+            requires: KeywordItem {
+                keyword: Spaces {
+                    before: [
+                        Newline,
+                    ],
+                    item: RequiresKeyword,
+                    after: [],
+                },
+                item: PlatformRequires {
+                    rigids: [
+                        @36-41 UppercaseIdent(
+                            "Model",
+                        ),
+                    ],
+                    signature: @45-54 TypedIdent {
+                        ident: @45-49 "main",
+                        spaces_before_colon: [],
+                        ann: @52-54 Record {
+                            fields: [],
+                            ext: None,
+                        },
+                    },
                 },
             },
-        },
-        exposes: [],
-        packages: [
-            @87-99 PackageEntry {
-                shorthand: "foo",
-                spaces_after_shorthand: [],
-                package_name: @92-99 PackageName(
-                    "./foo",
-                ),
+            exposes: KeywordItem {
+                keyword: Spaces {
+                    before: [
+                        Newline,
+                    ],
+                    item: ExposesKeyword,
+                    after: [],
+                },
+                item: [],
             },
-        ],
-        imports: [],
-        provides: [
-            @132-143 ExposedName(
-                "mainForHost",
-            ),
-        ],
-        before_header: [],
-        after_platform_keyword: [],
-        before_requires: [
-            Newline,
-        ],
-        after_requires: [],
-        before_exposes: [
-            Newline,
-        ],
-        after_exposes: [],
-        before_packages: [
-            Newline,
-        ],
-        after_packages: [],
-        before_imports: [
-            Newline,
-        ],
-        after_imports: [],
-        before_provides: [
-            Newline,
-        ],
-        after_provides: [],
-    },
+            packages: KeywordItem {
+                keyword: Spaces {
+                    before: [
+                        Newline,
+                    ],
+                    item: PackagesKeyword,
+                    after: [],
+                },
+                item: [
+                    @87-99 PackageEntry {
+                        shorthand: "foo",
+                        spaces_after_shorthand: [],
+                        package_name: @92-99 PackageName(
+                            "./foo",
+                        ),
+                    },
+                ],
+            },
+            imports: KeywordItem {
+                keyword: Spaces {
+                    before: [
+                        Newline,
+                    ],
+                    item: ImportsKeyword,
+                    after: [],
+                },
+                item: [],
+            },
+            provides: KeywordItem {
+                keyword: Spaces {
+                    before: [
+                        Newline,
+                    ],
+                    item: ProvidesKeyword,
+                    after: [],
+                },
+                item: [
+                    @132-143 ExposedName(
+                        "mainForHost",
+                    ),
+                ],
+            },
+        },
+    ),
 }

--- a/crates/compiler/parse/tests/snapshots/pass/provides_type.header.result-ast
+++ b/crates/compiler/parse/tests/snapshots/pass/provides_type.header.result-ast
@@ -1,59 +1,83 @@
-App {
-    header: AppHeader {
-        name: @4-10 PlainLine(
-            "test",
-        ),
-        packages: [
-            @26-42 PackageEntry {
-                shorthand: "pf",
-                spaces_after_shorthand: [],
-                package_name: @30-42 PackageName(
-                    "./platform",
+Module {
+    comments: [],
+    header: App(
+        AppHeader {
+            before_name: [],
+            name: @4-10 PlainLine(
+                "test",
+            ),
+            packages: Some(
+                KeywordItem {
+                    keyword: Spaces {
+                        before: [
+                            Newline,
+                        ],
+                        item: PackagesKeyword,
+                        after: [],
+                    },
+                    item: [
+                        @26-42 PackageEntry {
+                            shorthand: "pf",
+                            spaces_after_shorthand: [],
+                            package_name: @30-42 PackageName(
+                                "./platform",
+                            ),
+                        },
+                    ],
+                },
+            ),
+            imports: Some(
+                KeywordItem {
+                    keyword: Spaces {
+                        before: [
+                            Newline,
+                        ],
+                        item: ImportsKeyword,
+                        after: [],
+                    },
+                    item: [
+                        @59-70 Package(
+                            "foo",
+                            ModuleName(
+                                "Bar.Baz",
+                            ),
+                            [],
+                        ),
+                    ],
+                },
+            ),
+            provides: ProvidesTo {
+                provides_keyword: Spaces {
+                    before: [
+                        Newline,
+                    ],
+                    item: ProvidesKeyword,
+                    after: [],
+                },
+                entries: [
+                    @88-97 ExposedName(
+                        "quicksort",
+                    ),
+                ],
+                types: Some(
+                    [
+                        @102-107 UppercaseIdent(
+                            "Flags",
+                        ),
+                        @109-114 UppercaseIdent(
+                            "Model",
+                        ),
+                    ],
+                ),
+                to_keyword: Spaces {
+                    before: [],
+                    item: ToKeyword,
+                    after: [],
+                },
+                to: @121-123 ExistingPackage(
+                    "pf",
                 ),
             },
-        ],
-        imports: [
-            @59-70 Package(
-                "foo",
-                ModuleName(
-                    "Bar.Baz",
-                ),
-                [],
-            ),
-        ],
-        provides: [
-            @88-97 ExposedName(
-                "quicksort",
-            ),
-        ],
-        provides_types: Some(
-            [
-                @102-107 UppercaseIdent(
-                    "Flags",
-                ),
-                @109-114 UppercaseIdent(
-                    "Model",
-                ),
-            ],
-        ),
-        to: @121-123 ExistingPackage(
-            "pf",
-        ),
-        before_header: [],
-        after_app_keyword: [],
-        before_packages: [
-            Newline,
-        ],
-        after_packages: [],
-        before_imports: [
-            Newline,
-        ],
-        after_imports: [],
-        before_provides: [
-            Newline,
-        ],
-        after_provides: [],
-        before_to: [],
-        after_to: [],
-    },
+        },
+    ),
 }

--- a/crates/compiler/parse/tests/snapshots/pass/requires_type.header.result-ast
+++ b/crates/compiler/parse/tests/snapshots/pass/requires_type.header.result-ast
@@ -1,67 +1,94 @@
-Platform {
-    header: PlatformHeader {
-        name: @9-21 PackageName(
-            "test/types",
-        ),
-        requires: PlatformRequires {
-            rigids: [
-                @37-42 UppercaseIdent(
-                    "Flags",
-                ),
-                @44-49 UppercaseIdent(
-                    "Model",
-                ),
-            ],
-            signature: @55-77 TypedIdent {
-                ident: @55-59 "main",
-                spaces_before_colon: [],
-                ann: @62-77 Apply(
-                    "",
-                    "App",
-                    [
-                        @66-71 Apply(
-                            "",
+Module {
+    comments: [],
+    header: Platform(
+        PlatformHeader {
+            before_name: [],
+            name: @9-21 PackageName(
+                "test/types",
+            ),
+            requires: KeywordItem {
+                keyword: Spaces {
+                    before: [
+                        Newline,
+                    ],
+                    item: RequiresKeyword,
+                    after: [],
+                },
+                item: PlatformRequires {
+                    rigids: [
+                        @37-42 UppercaseIdent(
                             "Flags",
-                            [],
                         ),
-                        @72-77 Apply(
-                            "",
+                        @44-49 UppercaseIdent(
                             "Model",
-                            [],
                         ),
                     ],
-                ),
+                    signature: @55-77 TypedIdent {
+                        ident: @55-59 "main",
+                        spaces_before_colon: [],
+                        ann: @62-77 Apply(
+                            "",
+                            "App",
+                            [
+                                @66-71 Apply(
+                                    "",
+                                    "Flags",
+                                    [],
+                                ),
+                                @72-77 Apply(
+                                    "",
+                                    "Model",
+                                    [],
+                                ),
+                            ],
+                        ),
+                    },
+                },
+            },
+            exposes: KeywordItem {
+                keyword: Spaces {
+                    before: [
+                        Newline,
+                    ],
+                    item: ExposesKeyword,
+                    after: [],
+                },
+                item: [],
+            },
+            packages: KeywordItem {
+                keyword: Spaces {
+                    before: [
+                        Newline,
+                    ],
+                    item: PackagesKeyword,
+                    after: [],
+                },
+                item: [],
+            },
+            imports: KeywordItem {
+                keyword: Spaces {
+                    before: [
+                        Newline,
+                    ],
+                    item: ImportsKeyword,
+                    after: [],
+                },
+                item: [],
+            },
+            provides: KeywordItem {
+                keyword: Spaces {
+                    before: [
+                        Newline,
+                    ],
+                    item: ProvidesKeyword,
+                    after: [],
+                },
+                item: [
+                    @141-152 ExposedName(
+                        "mainForHost",
+                    ),
+                ],
             },
         },
-        exposes: [],
-        packages: [],
-        imports: [],
-        provides: [
-            @141-152 ExposedName(
-                "mainForHost",
-            ),
-        ],
-        before_header: [],
-        after_platform_keyword: [],
-        before_requires: [
-            Newline,
-        ],
-        after_requires: [],
-        before_exposes: [
-            Newline,
-        ],
-        after_exposes: [],
-        before_packages: [
-            Newline,
-        ],
-        after_packages: [],
-        before_imports: [
-            Newline,
-        ],
-        after_imports: [],
-        before_provides: [
-            Newline,
-        ],
-        after_provides: [],
-    },
+    ),
 }

--- a/crates/packaging/src/tarball.rs
+++ b/crates/packaging/src/tarball.rs
@@ -1,7 +1,7 @@
 use brotli::enc::BrotliEncoderParams;
 use bumpalo::Bump;
 use flate2::write::GzEncoder;
-use roc_parse::ast::Module;
+use roc_parse::ast::{Header, Module};
 use roc_parse::header::PlatformHeader;
 use roc_parse::module::parse_header;
 use roc_parse::state::State;
@@ -124,22 +124,20 @@ fn write_archive<W: Write>(path: &Path, writer: W) -> io::Result<()> {
     let arena = Bump::new();
     let mut buf = Vec::new();
 
-    let _other_modules: &[Module<'_>] = match read_header(&arena, &mut buf, path)? {
-        Module::Interface { .. } => {
+    let _other_modules: &[Module<'_>] = match read_header(&arena, &mut buf, path)?.header {
+        Header::Interface(_) => {
             todo!();
             // TODO report error
         }
-        Module::App { .. } => {
+        Header::App(_) => {
             todo!();
             // TODO report error
         }
-        Module::Hosted { .. } => {
+        Header::Hosted(_) => {
             todo!();
             // TODO report error
         }
-        Module::Platform {
-            header: PlatformHeader { imports: _, .. },
-        } => {
+        Header::Platform(PlatformHeader { imports: _, .. }) => {
             use walkdir::WalkDir;
 
             // Add all the prebuilt host files to the archive.


### PR DESCRIPTION
... and refactor header parser to fully use combinators, in support of future combinator-based superpowers.

To make the parser a bit cleaner, I combined many of the pairs of `*_before` / `*_after` fields in the various header types with some variant of a zero-size `*Keyword` newtype, `Spaces`, and sometimes `KeywordItem` - to indicate some sort of item introduced by keyword.

I also removed the `maybe!` combinator that did exactly the same job as `optional`, and made all the cases that `optional` needed to allow backtracking explicit - by adding a `backtrackable` combinator.