### PR TITLE
[Super easy review] fix stub lib path

### DIFF
--- a/crates/linker/src/lib.rs
+++ b/crates/linker/src/lib.rs
@@ -158,11 +158,6 @@ pub fn generate_stub_lib(
         .collect();
 
     if let EntryPoint::Executable { platform_path, .. } = &loaded.entry_point {
-        let platform_path = input_path
-            .to_path_buf()
-            .parent()
-            .unwrap()
-            .join(platform_path);
         let stub_lib = if let target_lexicon::OperatingSystem::Windows = triple.operating_system {
             platform_path.with_file_name("libapp.obj")
         } else {


### PR DESCRIPTION
platform-path is relative to the execution folder, not the input path