### PR TITLE
Do not mark whether a module has specialization deps incrementally

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5860,7 +5860,7 @@ dependencies = [
 [[package]]
 name = "wasm3"
 version = "0.5.0"
-source = "git+https://github.com/roc-lang/wasm3-rs?rev=e43d8115dcf2d0825226819b24f555941b862d22#e43d8115dcf2d0825226819b24f555941b862d22"
+source = "git+https://github.com/roc-lang/wasm3-rs?rev=ba0cdab7404f7f2995a8c18e614ce020dabd6da0#ba0cdab7404f7f2995a8c18e614ce020dabd6da0"
 dependencies = [
  "cty",
  "wasm3-sys",
@@ -5869,7 +5869,7 @@ dependencies = [
 [[package]]
 name = "wasm3-sys"
 version = "0.5.0"
-source = "git+https://github.com/roc-lang/wasm3-rs?rev=e43d8115dcf2d0825226819b24f555941b862d22#e43d8115dcf2d0825226819b24f555941b862d22"
+source = "git+https://github.com/roc-lang/wasm3-rs?rev=ba0cdab7404f7f2995a8c18e614ce020dabd6da0#ba0cdab7404f7f2995a8c18e614ce020dabd6da0"
 dependencies = [
  "cc",
  "cty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,7 +112,7 @@ target-lexicon = "0.12.3"
 tempfile = "3.2.0"
 unicode-segmentation = "1.10.0"
 walkdir = "2.3.2"
-wasm3 = { git = "https://github.com/roc-lang/wasm3-rs", rev = "e43d8115dcf2d0825226819b24f555941b862d22" }
+wasm3 = { git = "https://github.com/roc-lang/wasm3-rs", rev = "ba0cdab7404f7f2995a8c18e614ce020dabd6da0" }
 wyhash = "0.5.0"
 
 # TODO: Deal with the update of object to 0.27.

--- a/crates/cli/tests/cli_run.rs
+++ b/crates/cli/tests/cli_run.rs
@@ -235,14 +235,7 @@ mod cli_run {
                         )
                     }
                 }
-                CliMode::Roc => {
-                    if !extra_env.is_empty() {
-                        // TODO: `roc` and `roc dev` are currently buggy for `env.roc`
-                        continue;
-                    }
-
-                    run_roc_on(file, flags.clone(), stdin, roc_app_args, extra_env)
-                }
+                CliMode::Roc => run_roc_on(file, flags.clone(), stdin, roc_app_args, extra_env),
                 CliMode::RocRun => run_roc_on(
                     file,
                     iter::once(CMD_RUN).chain(flags.clone()),

--- a/crates/compiler/load_internal/src/file.rs
+++ b/crates/compiler/load_internal/src/file.rs
@@ -3003,7 +3003,10 @@ fn update<'a>(
                         );
                     }
 
-                    log!("re-launching specializations pass");
+                    log!(
+                        "re-launching make-specializations: pass {}",
+                        state.make_specializations_pass.current_pass() + 1
+                    );
 
                     state.make_specializations_pass.inc();
 

--- a/crates/compiler/load_internal/src/work.rs
+++ b/crates/compiler/load_internal/src/work.rs
@@ -454,6 +454,8 @@ impl<'a> Dependencies<'a> {
     pub fn load_find_and_make_specializations_after_check(&mut self) -> MutSet<(ModuleId, Phase)> {
         let mut output = MutSet::default();
 
+        // Take out the specialization dependency graph, as this should not be modified as we
+        // reload the build graph. We'll make sure the state is unaffected at the end of this call.
         let mut make_specializations_dependents = MakeSpecializationsDependents::default();
         let default_make_specializations_dependents_len = make_specializations_dependents.0.len();
         std::mem::swap(
@@ -484,8 +486,9 @@ impl<'a> Dependencies<'a> {
                 self.add_dependency(module_dep, module, Phase::MakeSpecializations);
                 self.add_dependency(ModuleId::DERIVED_GEN, module, Phase::MakeSpecializations);
 
-                // `module_dep` can't make its specializations until the current module does.
-                info.has_pred = true;
+                // That `module_dep` can't make its specializations until the current module does
+                // should already be accounted for in `make_specializations_dependents`, which we
+                // populated when initially building the graph.
             }
 
             if module != ModuleId::DERIVED_GEN {


### PR DESCRIPTION
Whether a module has a dependency on another module for specialization
is already accounted for when the build graph was initially populated,
and should not be modified again.

Closes https://github.com/roc-lang/roc/issues/4622