### PR TITLE
Bugfix compilation of rvalue-determined lambda sets

### DIFF
--- a/crates/compiler/mono/src/ir.rs
+++ b/crates/compiler/mono/src/ir.rs
@@ -2480,7 +2480,7 @@ fn from_can_let<'a>(
                 lower_rest!(variable, cont.value)
             }
             Var(original, _) | AbilityMember(original, _, _)
-                if !procs.get_partial_proc(original).is_some() =>
+                if procs.get_partial_proc(original).is_none() =>
             {
                 // a variable is aliased, e.g.
                 //

--- a/crates/compiler/mono/src/layout.rs
+++ b/crates/compiler/mono/src/layout.rs
@@ -1387,7 +1387,12 @@ impl<'a> LambdaSet<'a> {
     where
         I: Interner<'a, Layout<'a>>,
     {
-        debug_assert!(self.contains(function_symbol), "function symbol not in set");
+        debug_assert!(
+            self.contains(function_symbol),
+            "function symbol {:?} not in set {:?}",
+            function_symbol,
+            self
+        );
 
         let comparator = |other_name: Symbol, other_captures_layouts: &[Layout]| {
             other_name == function_symbol

--- a/crates/compiler/test_mono/generated/anonymous_closure_lifted_to_named_issue_2403.txt
+++ b/crates/compiler/test_mono/generated/anonymous_closure_lifted_to_named_issue_2403.txt
@@ -1,0 +1,8 @@
+procedure Test.4 (Test.5, Test.3):
+    ret Test.3;
+
+procedure Test.0 ():
+    let Test.3 : I64 = 1i64;
+    let Test.7 : {} = Struct {};
+    let Test.2 : I64 = CallByName Test.4 Test.7 Test.3;
+    ret Test.2;

--- a/crates/compiler/test_mono/generated/function_pointer_lambda_set.txt
+++ b/crates/compiler/test_mono/generated/function_pointer_lambda_set.txt
@@ -1,0 +1,13 @@
+procedure Test.1 (Test.5):
+    let Test.9 : U64 = 1i64;
+    ret Test.9;
+
+procedure Test.2 (Test.3):
+    let Test.8 : {} = Struct {};
+    let Test.7 : U64 = CallByName Test.1 Test.8;
+    ret Test.7;
+
+procedure Test.0 ():
+    let Test.4 : {} = Struct {};
+    let Test.6 : U64 = CallByName Test.2 Test.4;
+    ret Test.6;

--- a/crates/compiler/test_mono/generated/issue_2725_alias_polymorphic_lambda.txt
+++ b/crates/compiler/test_mono/generated/issue_2725_alias_polymorphic_lambda.txt
@@ -1,7 +1,8 @@
-procedure Test.2 (Test.3):
+procedure Test.1 (Test.3):
     ret Test.3;
 
 procedure Test.0 ():
+    let Test.2 : {} = Struct {};
     let Test.6 : I64 = 42i64;
-    let Test.5 : I64 = CallByName Test.2 Test.6;
+    let Test.5 : I64 = CallByName Test.1 Test.6;
     ret Test.5;

--- a/crates/compiler/test_mono/generated/lambda_capture_niches_have_captured_function_in_closure.txt
+++ b/crates/compiler/test_mono/generated/lambda_capture_niches_have_captured_function_in_closure.txt
@@ -14,12 +14,12 @@ procedure Test.16 (Test.54):
     ret Test.56;
 
 procedure Test.2 (Test.7, Test.8):
-    let Test.9 : [C {} {}, C {} {}] = TagId(0) Test.7 Test.8;
-    ret Test.9;
+    let Test.30 : [C {} {}, C {} {}] = TagId(0) Test.7 Test.8;
+    ret Test.30;
 
 procedure Test.2 (Test.7, Test.8):
-    let Test.9 : [C {} {}, C {} {}] = TagId(1) Test.7 Test.8;
-    ret Test.9;
+    let Test.44 : [C {} {}, C {} {}] = TagId(1) Test.7 Test.8;
+    ret Test.44;
 
 procedure Test.3 (Test.17):
     let Test.36 : {} = Struct {};

--- a/crates/compiler/test_mono/generated/lambda_capture_niches_with_non_capturing_function.txt
+++ b/crates/compiler/test_mono/generated/lambda_capture_niches_with_non_capturing_function.txt
@@ -49,8 +49,8 @@ procedure Test.0 ():
             jump Test.16 Test.17;
     
         case 1:
-            let Test.2 : [C , C U64, C {}] = TagId(0) ;
-            jump Test.16 Test.2;
+            let Test.23 : [C , C U64, C {}] = TagId(0) ;
+            jump Test.16 Test.23;
     
         default:
             let Test.26 : U64 = 1i64;

--- a/crates/compiler/test_mono/generated/specialize_closures.txt
+++ b/crates/compiler/test_mono/generated/specialize_closures.txt
@@ -50,8 +50,8 @@ procedure Test.0 ():
     in
     let Test.23 : Int1 = CallByName Bool.2;
     if Test.23 then
-        let Test.7 : [C I64, C I64 Int1] = TagId(0) Test.4;
-        jump Test.20 Test.7;
+        let Test.19 : [C I64, C I64 Int1] = TagId(0) Test.4;
+        jump Test.20 Test.19;
     else
-        let Test.8 : [C I64, C I64 Int1] = TagId(1) Test.5 Test.6;
-        jump Test.20 Test.8;
+        let Test.19 : [C I64, C I64 Int1] = TagId(1) Test.5 Test.6;
+        jump Test.20 Test.19;

--- a/crates/compiler/test_mono/generated/specialize_lowlevel.txt
+++ b/crates/compiler/test_mono/generated/specialize_lowlevel.txt
@@ -41,8 +41,8 @@ procedure Test.0 ():
     in
     let Test.20 : Int1 = CallByName Bool.2;
     if Test.20 then
-        let Test.6 : [C I64, C I64] = TagId(0) Test.4;
-        jump Test.18 Test.6;
+        let Test.17 : [C I64, C I64] = TagId(0) Test.4;
+        jump Test.18 Test.17;
     else
-        let Test.7 : [C I64, C I64] = TagId(1) Test.5;
-        jump Test.18 Test.7;
+        let Test.17 : [C I64, C I64] = TagId(1) Test.5;
+        jump Test.18 Test.17;

--- a/crates/compiler/test_mono/generated/unreachable_branch_is_eliminated_but_produces_lambda_specializations.txt
+++ b/crates/compiler/test_mono/generated/unreachable_branch_is_eliminated_but_produces_lambda_specializations.txt
@@ -1,6 +1,6 @@
 procedure Test.1 (Test.2):
-    let Test.3 : Int1 = false;
-    ret Test.3;
+    let Test.14 : Int1 = false;
+    ret Test.14;
 
 procedure Test.3 (Test.13):
     let Test.15 : Str = "t1";

--- a/crates/compiler/test_mono/src/tests.rs
+++ b/crates/compiler/test_mono/src/tests.rs
@@ -2049,3 +2049,20 @@ fn crash() {
         "#
     )
 }
+
+#[mono_test]
+fn function_pointer_lambda_set() {
+    indoc!(
+        r#"
+        app "test" provides [main] to "./platform"
+
+        number = \{} -> 1u64
+
+        parse = \parser -> parser {}
+
+        main =
+            parser = number
+            parse parser
+        "#
+    )
+}

--- a/crates/compiler/test_mono/src/tests.rs
+++ b/crates/compiler/test_mono/src/tests.rs
@@ -2066,3 +2066,19 @@ fn function_pointer_lambda_set() {
         "#
     )
 }
+
+#[mono_test]
+fn anonymous_closure_lifted_to_named_issue_2403() {
+    indoc!(
+        r#"
+        app "test" provides [main] to "./platform"
+
+        main =
+            f =
+                n = 1
+                \{} -> n
+            g = f {}
+            g
+        "#
+    )
+}


### PR DESCRIPTION
1. [Do not attempt to handle aliasing of procs in variable assignments](https://github.com/roc-lang/roc/commit/68e364d897ed3d35a74d09f9650a5dfa7eeb2333)

    Consider the aliasing of a scoped-defined lvalue

    ```
    bar = ""
    foo = bar
    ```

    We need to generate an IR that is free of local lvalue aliasing, as this aids in
    refcounting. As such, variable aliasing usually involves renaming the LHS in the
    rest of the program with the RHS (i.e. [foo->bar]).

    Previously, we also attempted to eliminate aliasing to procedures (either a
    function pointer or a thunk) here - for example in a program like

    ```
    f = \{} -> 1
    var = f {}
    ```

    This patch eliminates trying to handle such aliasing. The reasons are enumerated
    below.

    === 1.
                                                                                       
    Doing so is not necessary - if we have `var = f` where `f` is either a proc or
    thunk, in either case, `f` will be resolved to an rvalue, not an lvalue:
                                                                                       
    - If `f` is a proc, we assign to `var` its closure data (even if the lambda set
      of `f` is unary with no captures, we leave behind the empty closure data)
                                                                                       
    - If `f` is a thunk, we force the thunk and assign to `var` its value.
                                                                                       
    With this in mind, when `f` is a thunk or proper function, we are free to follow
    the usual (non-lvalue-aliasing) branch of assignment, and end up with correct
    code.
                                                                                       
    === 2.
                                                                                       
    Recording that an lvalue references a procedure or a thunk may open up
    opportunities for optimization - and indeed, recording this information may
    sometimes eliminate such unused lvalues, or inline closure data. However, in
    general, making sure this kind of aliasing works correctly is very difficult. As
    illustration, consider
                                                                                       
        getNum1 = \{} -> 1u64
        getNum2 = \{} -> 2u64
                                                                                       
        dispatch = \fun -> fun {}
                                                                                       
        main =
            myFun1 = getNum1
            myFun2 = getNum2
            dispatch (if Bool.true then myFun1 else myFun2)
                                                                                       
    Suppose we leave nothing behind for the assignments `myFun* = getNum*`, and
    instead simply associate that they reference procs. In the if-then-else
    expression, we then need to construct the closure data for both getNum1 and
    getNum2 - but we do not know what lambdas they represent, as we only have access
    to the symbols `myFun1` and `myFun2`.
                                                                                       
    While associations of `myFun1 -> getNum1` could be propogated, the story gets
    more complicated when the referenced proc itself resolves a lambda set with
    indirection; for example consider the amendment
                                                                                       
        getNum1 = @Dispatcher \{} -> 1u64
        getNum2 = @Dispatcher \{} -> 2u64
                                                                                       
    Now, even the association of `myFun1 -> getNum1` is not enough, as the lambda
    set of (if Bool.true then myFun1 else myFun2) would not be { getNum1, getNum2 }
    - it would be the binary lambda set of the anonymous closures created under the
    `@Dispatcher` wrappers.
                                                                                       
    Trying to keep all this information in line has been error prone, and is not
    attempted.


3. [Correctly compile rvalue closures defined in nested defines to lvalues](https://github.com/roc-lang/roc/commit/9181ed80921577533f0155c30abf40ed07bdd728)
    
    Previously, a program like
    
    ```
    main =
      f =
        n = 1
        \{} -[#lam]-> n  # suppose lambda set = #lam
      f {}
    ```
    
    would be transformed to
    
    ```
    main =
      n = 1
      f = \{} -[#lam]-> n
      f {}
    ```
    
    However, the IR lowering procedure is such that we would then associate
    `f` as definining the procedure given the lambda set `#lam`. This is not
    correct, as `f` is really a function pointer in this circumstance,
    rather than the definer of `#lam`.
    
    Instead, the transformation we want to perform is
    
    ```
    main =
      n = 1
      #lam = \{} -[#lam]-> n
      f = #lam
      f {}
    ```
    
    
    Closes https://github.com/roc-lang/roc/issues/2403