### PR TITLE
Wasm interp imports

### DIFF
--- a/crates/wasm_interp/src/instance.rs
+++ b/crates/wasm_interp/src/instance.rs
@@ -377,7 +377,6 @@ impl<'a, I: ImportDispatcher> Instance<'a, I> {
             if let Some(return_val) = optional_return_val {
                 self.value_stack.push(return_val);
             }
-            return;
         } else {
             // call an internal Wasm function
             let return_addr = self.program_counter as u32;

--- a/crates/wasm_interp/src/lib.rs
+++ b/crates/wasm_interp/src/lib.rs
@@ -2,9 +2,25 @@ mod call_stack;
 mod instance;
 pub mod test_utils;
 mod value_stack;
-mod wasi;
+pub mod wasi;
+
+// Main external interface
+pub use instance::Instance;
 
 // Exposed for testing only. Should eventually become private.
 pub use call_stack::CallStack;
-pub use instance::{Action, Instance};
+pub use instance::Action;
 pub use value_stack::ValueStack;
+
+use roc_wasm_module::Value;
+
+pub trait ImportDispatcher {
+    /// Dispatch a call from WebAssembly to your own code, based on module and function name.
+    fn dispatch(
+        &mut self,
+        module_name: &str,
+        function_name: &str,
+        arguments: &[Value],
+        memory: &mut [u8],
+    ) -> Option<Value>;
+}

--- a/crates/wasm_interp/src/lib.rs
+++ b/crates/wasm_interp/src/lib.rs
@@ -2,6 +2,7 @@ mod call_stack;
 mod instance;
 pub mod test_utils;
 mod value_stack;
+mod wasi;
 
 // Exposed for testing only. Should eventually become private.
 pub use call_stack::CallStack;

--- a/crates/wasm_interp/src/lib.rs
+++ b/crates/wasm_interp/src/lib.rs
@@ -24,3 +24,26 @@ pub trait ImportDispatcher {
         memory: &mut [u8],
     ) -> Option<Value>;
 }
+
+pub const DEFAULT_IMPORTS: DefaultImportDispatcher = DefaultImportDispatcher {};
+
+pub struct DefaultImportDispatcher {}
+
+impl ImportDispatcher for DefaultImportDispatcher {
+    fn dispatch(
+        &mut self,
+        module_name: &str,
+        function_name: &str,
+        arguments: &[Value],
+        memory: &mut [u8],
+    ) -> Option<Value> {
+        if module_name == wasi::MODULE_NAME {
+            wasi::dispatch(function_name, arguments, memory)
+        } else {
+            panic!(
+                "DefaultImportDispatcher does not implement {}.{}",
+                module_name, function_name
+            );
+        }
+    }
+}

--- a/crates/wasm_interp/src/main.rs
+++ b/crates/wasm_interp/src/main.rs
@@ -6,7 +6,7 @@ use std::fs;
 use std::io;
 use std::process;
 
-use roc_wasm_interp::Instance;
+use roc_wasm_interp::{Instance, DEFAULT_IMPORTS};
 use roc_wasm_module::WasmModule;
 
 pub const FLAG_FUNCTION: &str = "function";
@@ -88,10 +88,11 @@ fn main() -> io::Result<()> {
 
     // Create an execution instance
 
-    let mut inst = Instance::for_module(&arena, &module, is_debug_mode).unwrap_or_else(|e| {
-        eprintln!("{}", e);
-        process::exit(2);
-    });
+    let mut inst = Instance::for_module(&arena, &module, DEFAULT_IMPORTS, is_debug_mode)
+        .unwrap_or_else(|e| {
+            eprintln!("{}", e);
+            process::exit(2);
+        });
 
     // Run
 

--- a/crates/wasm_interp/src/main.rs
+++ b/crates/wasm_interp/src/main.rs
@@ -1,7 +1,6 @@
 use bumpalo::Bump;
 use clap::ArgAction;
 use clap::{Arg, Command};
-use roc_wasm_interp::Action;
 use std::ffi::OsString;
 use std::fs;
 use std::io;
@@ -87,41 +86,31 @@ fn main() -> io::Result<()> {
         }
     };
 
-    // Initialise the execution state
+    // Create an execution instance
 
-    let mut state = Instance::for_module(
-        &arena,
-        &module,
-        start_fn_name,
-        is_debug_mode,
-        start_arg_strings,
-    )
-    .unwrap_or_else(|e| {
+    let mut inst = Instance::for_module(&arena, &module, is_debug_mode).unwrap_or_else(|e| {
         eprintln!("{}", e);
         process::exit(2);
     });
 
     // Run
 
-    while let Action::Continue = state.execute_next_instruction(&module) {}
+    let result = inst.call_export_from_cli(&module, start_fn_name, start_arg_strings);
 
-    // Print out return value(s), if any
+    // Print out return value, if any
 
-    match state.value_stack.len() {
-        0 => {}
-        1 => {
+    match result {
+        Ok(Some(val)) => {
             if is_hex_format {
-                println!("{:#x?}", state.value_stack.pop())
+                println!("{:#x?}", val)
             } else {
-                println!("{:?}", state.value_stack.pop())
+                println!("{:?}", val)
             }
         }
-        _ => {
-            if is_hex_format {
-                println!("{:#x?}", &state.value_stack)
-            } else {
-                println!("{:?}", &state.value_stack)
-            }
+        Ok(None) => {}
+        Err(e) => {
+            eprintln!("{}", e);
+            process::exit(3);
         }
     }
 

--- a/crates/wasm_interp/src/test_utils.rs
+++ b/crates/wasm_interp/src/test_utils.rs
@@ -1,4 +1,4 @@
-use crate::{Action, Instance};
+use crate::Instance;
 use bumpalo::{collections::Vec, Bump};
 use roc_wasm_module::{
     opcodes::OpCode, Export, ExportType, SerialBuffer, Signature, Value, ValueType, WasmModule,
@@ -75,11 +75,11 @@ where
         std::fs::write(&filename, outfile_buf).unwrap();
     }
 
-    let mut state = Instance::for_module(&arena, &module, "test", true, []).unwrap();
+    let mut inst = Instance::for_module(&arena, &module, true).unwrap();
 
-    while let Action::Continue = state.execute_next_instruction(&module) {}
+    let return_val = inst.call_export(&module, "test", []).unwrap().unwrap();
 
-    assert_eq!(state.value_stack.pop(), expected);
+    assert_eq!(return_val, expected);
 }
 
 pub fn create_exported_function_no_locals<'a, F>(

--- a/crates/wasm_interp/src/test_utils.rs
+++ b/crates/wasm_interp/src/test_utils.rs
@@ -1,14 +1,14 @@
-use crate::Instance;
+use crate::{DefaultImportDispatcher, Instance, DEFAULT_IMPORTS};
 use bumpalo::{collections::Vec, Bump};
 use roc_wasm_module::{
     opcodes::OpCode, Export, ExportType, SerialBuffer, Signature, Value, ValueType, WasmModule,
 };
 
-pub fn default_state(arena: &Bump) -> Instance {
+pub fn default_state(arena: &Bump) -> Instance<DefaultImportDispatcher> {
     let pages = 1;
     let program_counter = 0;
     let globals = [];
-    Instance::new(arena, pages, program_counter, globals)
+    Instance::new(arena, pages, program_counter, globals, DEFAULT_IMPORTS)
 }
 
 pub fn const_value(buf: &mut Vec<'_, u8>, value: Value) {
@@ -75,7 +75,7 @@ where
         std::fs::write(&filename, outfile_buf).unwrap();
     }
 
-    let mut inst = Instance::for_module(&arena, &module, true).unwrap();
+    let mut inst = Instance::for_module(&arena, &module, DEFAULT_IMPORTS, true).unwrap();
 
     let return_val = inst.call_export(&module, "test", []).unwrap().unwrap();
 

--- a/crates/wasm_interp/src/wasi.rs
+++ b/crates/wasm_interp/src/wasi.rs
@@ -1,88 +1,54 @@
 use roc_wasm_module::Value;
 
-pub trait ImportDispatcher {
-    /// Dispatch a call from WebAssembly to your own code, based on module and function name.
-    /// The call arguments are passed in, along with a mutable pointer to WebAssembly memory.
-    fn dispatch(
-        &mut self,
-        module_name: &str,
-        function_name: &str,
-        arguments: &[Value],
-        memory: &mut [u8],
-    ) -> Option<Value>;
-}
+pub const MODULE_NAME: &'static str = "wasi_snapshot_preview1";
 
-pub trait ImportDispatcherModule {
-    const NAME: &'static str;
-
-    /// Dispatch a call from WebAssembly to your own code, based on the function name.
-    /// The call arguments are passed in, along with a mutable pointer to WebAssembly memory.
-    fn dispatch(
-        &mut self,
-        function_name: &str,
-        arguments: &[Value],
-        memory: &mut [u8],
-    ) -> Option<Value>;
-}
-
-pub struct WasiDispatcher {}
-
-impl ImportDispatcherModule for WasiDispatcher {
-    const NAME: &'static str = "wasi_snapshot_preview1";
-
-    fn dispatch(
-        &mut self,
-        function_name: &str,
-        arguments: &[Value],
-        _memory: &mut [u8],
-    ) -> Option<Value> {
-        match function_name {
-            "args_get" => todo!("WASI {}({:?})", function_name, arguments),
-            "args_sizes_get" => todo!("WASI {}({:?})", function_name, arguments),
-            "environ_get" => todo!("WASI {}({:?})", function_name, arguments),
-            "environ_sizes_get" => todo!("WASI {}({:?})", function_name, arguments),
-            "clock_res_get" => todo!("WASI {}({:?})", function_name, arguments),
-            "clock_time_get" => todo!("WASI {}({:?})", function_name, arguments),
-            "fd_advise" => todo!("WASI {}({:?})", function_name, arguments),
-            "fd_allocate" => todo!("WASI {}({:?})", function_name, arguments),
-            "fd_close" => todo!("WASI {}({:?})", function_name, arguments),
-            "fd_datasync" => todo!("WASI {}({:?})", function_name, arguments),
-            "fd_fdstat_get" => todo!("WASI {}({:?})", function_name, arguments),
-            "fd_fdstat_set_flags" => todo!("WASI {}({:?})", function_name, arguments),
-            "fd_fdstat_set_rights" => todo!("WASI {}({:?})", function_name, arguments),
-            "fd_filestat_get" => todo!("WASI {}({:?})", function_name, arguments),
-            "fd_filestat_set_size" => todo!("WASI {}({:?})", function_name, arguments),
-            "fd_filestat_set_times" => todo!("WASI {}({:?})", function_name, arguments),
-            "fd_pread" => todo!("WASI {}({:?})", function_name, arguments),
-            "fd_prestat_get" => todo!("WASI {}({:?})", function_name, arguments),
-            "fd_prestat_dir_name" => todo!("WASI {}({:?})", function_name, arguments),
-            "fd_pwrite" => todo!("WASI {}({:?})", function_name, arguments),
-            "fd_read" => todo!("WASI {}({:?})", function_name, arguments),
-            "fd_readdir" => todo!("WASI {}({:?})", function_name, arguments),
-            "fd_renumber" => todo!("WASI {}({:?})", function_name, arguments),
-            "fd_seek" => todo!("WASI {}({:?})", function_name, arguments),
-            "fd_sync" => todo!("WASI {}({:?})", function_name, arguments),
-            "fd_tell" => todo!("WASI {}({:?})", function_name, arguments),
-            "fd_write" => todo!("WASI {}({:?})", function_name, arguments),
-            "path_create_directory" => todo!("WASI {}({:?})", function_name, arguments),
-            "path_filestat_get" => todo!("WASI {}({:?})", function_name, arguments),
-            "path_filestat_set_times" => todo!("WASI {}({:?})", function_name, arguments),
-            "path_link" => todo!("WASI {}({:?})", function_name, arguments),
-            "path_open" => todo!("WASI {}({:?})", function_name, arguments),
-            "path_readlink" => todo!("WASI {}({:?})", function_name, arguments),
-            "path_remove_directory" => todo!("WASI {}({:?})", function_name, arguments),
-            "path_rename" => todo!("WASI {}({:?})", function_name, arguments),
-            "path_symlink" => todo!("WASI {}({:?})", function_name, arguments),
-            "path_unlink_file" => todo!("WASI {}({:?})", function_name, arguments),
-            "poll_oneoff" => todo!("WASI {}({:?})", function_name, arguments),
-            "proc_exit" => todo!("WASI {}({:?})", function_name, arguments),
-            "proc_raise" => todo!("WASI {}({:?})", function_name, arguments),
-            "sched_yield" => todo!("WASI {}({:?})", function_name, arguments),
-            "random_get" => todo!("WASI {}({:?})", function_name, arguments),
-            "sock_recv" => todo!("WASI {}({:?})", function_name, arguments),
-            "sock_send" => todo!("WASI {}({:?})", function_name, arguments),
-            "sock_shutdown" => todo!("WASI {}({:?})", function_name, arguments),
-            _ => panic!("Unknown WASI function {}({:?})", function_name, arguments),
-        }
+pub fn dispatch(function_name: &str, arguments: &[Value], _memory: &mut [u8]) -> Option<Value> {
+    match function_name {
+        "args_get" => todo!("WASI {}({:?})", function_name, arguments),
+        "args_sizes_get" => todo!("WASI {}({:?})", function_name, arguments),
+        "environ_get" => todo!("WASI {}({:?})", function_name, arguments),
+        "environ_sizes_get" => todo!("WASI {}({:?})", function_name, arguments),
+        "clock_res_get" => todo!("WASI {}({:?})", function_name, arguments),
+        "clock_time_get" => todo!("WASI {}({:?})", function_name, arguments),
+        "fd_advise" => todo!("WASI {}({:?})", function_name, arguments),
+        "fd_allocate" => todo!("WASI {}({:?})", function_name, arguments),
+        "fd_close" => todo!("WASI {}({:?})", function_name, arguments),
+        "fd_datasync" => todo!("WASI {}({:?})", function_name, arguments),
+        "fd_fdstat_get" => todo!("WASI {}({:?})", function_name, arguments),
+        "fd_fdstat_set_flags" => todo!("WASI {}({:?})", function_name, arguments),
+        "fd_fdstat_set_rights" => todo!("WASI {}({:?})", function_name, arguments),
+        "fd_filestat_get" => todo!("WASI {}({:?})", function_name, arguments),
+        "fd_filestat_set_size" => todo!("WASI {}({:?})", function_name, arguments),
+        "fd_filestat_set_times" => todo!("WASI {}({:?})", function_name, arguments),
+        "fd_pread" => todo!("WASI {}({:?})", function_name, arguments),
+        "fd_prestat_get" => todo!("WASI {}({:?})", function_name, arguments),
+        "fd_prestat_dir_name" => todo!("WASI {}({:?})", function_name, arguments),
+        "fd_pwrite" => todo!("WASI {}({:?})", function_name, arguments),
+        "fd_read" => todo!("WASI {}({:?})", function_name, arguments),
+        "fd_readdir" => todo!("WASI {}({:?})", function_name, arguments),
+        "fd_renumber" => todo!("WASI {}({:?})", function_name, arguments),
+        "fd_seek" => todo!("WASI {}({:?})", function_name, arguments),
+        "fd_sync" => todo!("WASI {}({:?})", function_name, arguments),
+        "fd_tell" => todo!("WASI {}({:?})", function_name, arguments),
+        "fd_write" => todo!("WASI {}({:?})", function_name, arguments),
+        "path_create_directory" => todo!("WASI {}({:?})", function_name, arguments),
+        "path_filestat_get" => todo!("WASI {}({:?})", function_name, arguments),
+        "path_filestat_set_times" => todo!("WASI {}({:?})", function_name, arguments),
+        "path_link" => todo!("WASI {}({:?})", function_name, arguments),
+        "path_open" => todo!("WASI {}({:?})", function_name, arguments),
+        "path_readlink" => todo!("WASI {}({:?})", function_name, arguments),
+        "path_remove_directory" => todo!("WASI {}({:?})", function_name, arguments),
+        "path_rename" => todo!("WASI {}({:?})", function_name, arguments),
+        "path_symlink" => todo!("WASI {}({:?})", function_name, arguments),
+        "path_unlink_file" => todo!("WASI {}({:?})", function_name, arguments),
+        "poll_oneoff" => todo!("WASI {}({:?})", function_name, arguments),
+        "proc_exit" => todo!("WASI {}({:?})", function_name, arguments),
+        "proc_raise" => todo!("WASI {}({:?})", function_name, arguments),
+        "sched_yield" => todo!("WASI {}({:?})", function_name, arguments),
+        "random_get" => todo!("WASI {}({:?})", function_name, arguments),
+        "sock_recv" => todo!("WASI {}({:?})", function_name, arguments),
+        "sock_send" => todo!("WASI {}({:?})", function_name, arguments),
+        "sock_shutdown" => todo!("WASI {}({:?})", function_name, arguments),
+        _ => panic!("Unknown WASI function {}({:?})", function_name, arguments),
     }
 }

--- a/crates/wasm_interp/src/wasi.rs
+++ b/crates/wasm_interp/src/wasi.rs
@@ -1,182 +1,88 @@
 use roc_wasm_module::Value;
 
-pub trait ImportDispatcher<ImportId: Sized> {
-    /// Translate a module name and function name into your own ImportId enum.
-    /// On Instance construction, the interpreter will check that all imports have
-    /// some ImportId, and fail otherwise.
-    fn get_function_id(module_name: &str, function_name: &str) -> Option<ImportId>;
-
-    /// Dispatch a call from the WebAssembly module to your own code, based on the ImportId.
+pub trait ImportDispatcher {
+    /// Dispatch a call from WebAssembly to your own code, based on module and function name.
     /// The call arguments are passed in, along with a mutable pointer to WebAssembly memory.
     fn dispatch(
         &mut self,
-        import_id: ImportId,
+        module_name: &str,
+        function_name: &str,
         arguments: &[Value],
         memory: &mut [u8],
     ) -> Option<Value>;
 }
 
-#[repr(u8)]
-#[derive(Debug)]
-enum WasiFunctionId {
-    ArgsGet,
-    ArgsSizesGet,
-    EnvironGet,
-    EnvironSizesGet,
-    ClockResGet,
-    ClockTimeGet,
-    FdAdvise,
-    FdAllocate,
-    FdClose,
-    FdDatasync,
-    FdFdstatGet,
-    FdFdstatSetFlags,
-    FdFdstatSetRights,
-    FdFilestatGet,
-    FdFilestatSetSize,
-    FdFilestatSetTimes,
-    FdPread,
-    FdPrestatGet,
-    FdPrestatDirName,
-    FdPwrite,
-    FdRead,
-    FdReaddir,
-    FdRenumber,
-    FdSeek,
-    FdSync,
-    FdTell,
-    FdWrite,
-    PathCreateDirectory,
-    PathFilestatGet,
-    PathFilestatSetTimes,
-    PathLink,
-    PathOpen,
-    PathReadlink,
-    PathRemoveDirectory,
-    PathRename,
-    PathSymlink,
-    PathUnlinkFile,
-    PollOneoff,
-    ProcExit,
-    ProcRaise,
-    SchedYield,
-    RandomGet,
-    SockRecv,
-    SockSend,
-    SockShutdown,
+pub trait ImportDispatcherModule {
+    const NAME: &'static str;
+
+    /// Dispatch a call from WebAssembly to your own code, based on the function name.
+    /// The call arguments are passed in, along with a mutable pointer to WebAssembly memory.
+    fn dispatch(
+        &mut self,
+        function_name: &str,
+        arguments: &[Value],
+        memory: &mut [u8],
+    ) -> Option<Value>;
 }
 
-pub struct WasiImportDispatcher {}
+pub struct WasiDispatcher {}
 
-impl ImportDispatcher<WasiFunctionId> for WasiImportDispatcher {
-    fn get_function_id(module_name: &str, function_name: &str) -> Option<WasiFunctionId> {
-        use WasiFunctionId::*;
-        assert_eq!(module_name, "wasi_snapshot_preview1");
-        match function_name {
-            "args_get" => Some(ArgsGet),
-            "args_sizes_get" => Some(ArgsSizesGet),
-            "environ_get" => Some(EnvironGet),
-            "environ_sizes_get" => Some(EnvironSizesGet),
-            "clock_res_get" => Some(ClockResGet),
-            "clock_time_get" => Some(ClockTimeGet),
-            "fd_advise" => Some(FdAdvise),
-            "fd_allocate" => Some(FdAllocate),
-            "fd_close" => Some(FdClose),
-            "fd_datasync" => Some(FdDatasync),
-            "fd_fdstat_get" => Some(FdFdstatGet),
-            "fd_fdstat_set_flags" => Some(FdFdstatSetFlags),
-            "fd_fdstat_set_rights" => Some(FdFdstatSetRights),
-            "fd_filestat_get" => Some(FdFilestatGet),
-            "fd_filestat_set_size" => Some(FdFilestatSetSize),
-            "fd_filestat_set_times" => Some(FdFilestatSetTimes),
-            "fd_pread" => Some(FdPread),
-            "fd_prestat_get" => Some(FdPrestatGet),
-            "fd_prestat_dir_name" => Some(FdPrestatDirName),
-            "fd_pwrite" => Some(FdPwrite),
-            "fd_read" => Some(FdRead),
-            "fd_readdir" => Some(FdReaddir),
-            "fd_renumber" => Some(FdRenumber),
-            "fd_seek" => Some(FdSeek),
-            "fd_sync" => Some(FdSync),
-            "fd_tell" => Some(FdTell),
-            "fd_write" => Some(FdWrite),
-            "path_create_directory" => Some(PathCreateDirectory),
-            "path_filestat_get" => Some(PathFilestatGet),
-            "path_filestat_set_times" => Some(PathFilestatSetTimes),
-            "path_link" => Some(PathLink),
-            "path_open" => Some(PathOpen),
-            "path_readlink" => Some(PathReadlink),
-            "path_remove_directory" => Some(PathRemoveDirectory),
-            "path_rename" => Some(PathRename),
-            "path_symlink" => Some(PathSymlink),
-            "path_unlink_file" => Some(PathUnlinkFile),
-            "poll_oneoff" => Some(PollOneoff),
-            "proc_exit" => Some(ProcExit),
-            "proc_raise" => Some(ProcRaise),
-            "sched_yield" => Some(SchedYield),
-            "random_get" => Some(RandomGet),
-            "sock_recv" => Some(SockRecv),
-            "sock_send" => Some(SockSend),
-            "sock_shutdown" => Some(SockShutdown),
-            _ => None,
-        }
-    }
+impl ImportDispatcherModule for WasiDispatcher {
+    const NAME: &'static str = "wasi_snapshot_preview1";
 
     fn dispatch(
         &mut self,
-        import_id: WasiFunctionId,
-        _arguments: &[Value],
+        function_name: &str,
+        arguments: &[Value],
         _memory: &mut [u8],
     ) -> Option<Value> {
-        use WasiFunctionId::*;
-
-        match import_id {
-            ArgsGet => eprintln!("Called WASI {:?}", import_id),
-            ArgsSizesGet => eprintln!("Called WASI {:?}", import_id),
-            EnvironGet => eprintln!("Called WASI {:?}", import_id),
-            EnvironSizesGet => eprintln!("Called WASI {:?}", import_id),
-            ClockResGet => eprintln!("Called WASI {:?}", import_id),
-            ClockTimeGet => eprintln!("Called WASI {:?}", import_id),
-            FdAdvise => eprintln!("Called WASI {:?}", import_id),
-            FdAllocate => eprintln!("Called WASI {:?}", import_id),
-            FdClose => eprintln!("Called WASI {:?}", import_id),
-            FdDatasync => eprintln!("Called WASI {:?}", import_id),
-            FdFdstatGet => eprintln!("Called WASI {:?}", import_id),
-            FdFdstatSetFlags => eprintln!("Called WASI {:?}", import_id),
-            FdFdstatSetRights => eprintln!("Called WASI {:?}", import_id),
-            FdFilestatGet => eprintln!("Called WASI {:?}", import_id),
-            FdFilestatSetSize => eprintln!("Called WASI {:?}", import_id),
-            FdFilestatSetTimes => eprintln!("Called WASI {:?}", import_id),
-            FdPread => eprintln!("Called WASI {:?}", import_id),
-            FdPrestatGet => eprintln!("Called WASI {:?}", import_id),
-            FdPrestatDirName => eprintln!("Called WASI {:?}", import_id),
-            FdPwrite => eprintln!("Called WASI {:?}", import_id),
-            FdRead => eprintln!("Called WASI {:?}", import_id),
-            FdReaddir => eprintln!("Called WASI {:?}", import_id),
-            FdRenumber => eprintln!("Called WASI {:?}", import_id),
-            FdSeek => eprintln!("Called WASI {:?}", import_id),
-            FdSync => eprintln!("Called WASI {:?}", import_id),
-            FdTell => eprintln!("Called WASI {:?}", import_id),
-            FdWrite => eprintln!("Called WASI {:?}", import_id),
-            PathCreateDirectory => eprintln!("Called WASI {:?}", import_id),
-            PathFilestatGet => eprintln!("Called WASI {:?}", import_id),
-            PathFilestatSetTimes => eprintln!("Called WASI {:?}", import_id),
-            PathLink => eprintln!("Called WASI {:?}", import_id),
-            PathOpen => eprintln!("Called WASI {:?}", import_id),
-            PathReadlink => eprintln!("Called WASI {:?}", import_id),
-            PathRemoveDirectory => eprintln!("Called WASI {:?}", import_id),
-            PathRename => eprintln!("Called WASI {:?}", import_id),
-            PathSymlink => eprintln!("Called WASI {:?}", import_id),
-            PathUnlinkFile => eprintln!("Called WASI {:?}", import_id),
-            PollOneoff => eprintln!("Called WASI {:?}", import_id),
-            ProcExit => eprintln!("Called WASI {:?}", import_id),
-            ProcRaise => eprintln!("Called WASI {:?}", import_id),
-            SchedYield => eprintln!("Called WASI {:?}", import_id),
-            RandomGet => eprintln!("Called WASI {:?}", import_id),
-            SockRecv => eprintln!("Called WASI {:?}", import_id),
-            SockSend => eprintln!("Called WASI {:?}", import_id),
-            SockShutdown => eprintln!("Called WASI {:?}", import_id),
+        match function_name {
+            "args_get" => todo!("WASI {}({:?})", function_name, arguments),
+            "args_sizes_get" => todo!("WASI {}({:?})", function_name, arguments),
+            "environ_get" => todo!("WASI {}({:?})", function_name, arguments),
+            "environ_sizes_get" => todo!("WASI {}({:?})", function_name, arguments),
+            "clock_res_get" => todo!("WASI {}({:?})", function_name, arguments),
+            "clock_time_get" => todo!("WASI {}({:?})", function_name, arguments),
+            "fd_advise" => todo!("WASI {}({:?})", function_name, arguments),
+            "fd_allocate" => todo!("WASI {}({:?})", function_name, arguments),
+            "fd_close" => todo!("WASI {}({:?})", function_name, arguments),
+            "fd_datasync" => todo!("WASI {}({:?})", function_name, arguments),
+            "fd_fdstat_get" => todo!("WASI {}({:?})", function_name, arguments),
+            "fd_fdstat_set_flags" => todo!("WASI {}({:?})", function_name, arguments),
+            "fd_fdstat_set_rights" => todo!("WASI {}({:?})", function_name, arguments),
+            "fd_filestat_get" => todo!("WASI {}({:?})", function_name, arguments),
+            "fd_filestat_set_size" => todo!("WASI {}({:?})", function_name, arguments),
+            "fd_filestat_set_times" => todo!("WASI {}({:?})", function_name, arguments),
+            "fd_pread" => todo!("WASI {}({:?})", function_name, arguments),
+            "fd_prestat_get" => todo!("WASI {}({:?})", function_name, arguments),
+            "fd_prestat_dir_name" => todo!("WASI {}({:?})", function_name, arguments),
+            "fd_pwrite" => todo!("WASI {}({:?})", function_name, arguments),
+            "fd_read" => todo!("WASI {}({:?})", function_name, arguments),
+            "fd_readdir" => todo!("WASI {}({:?})", function_name, arguments),
+            "fd_renumber" => todo!("WASI {}({:?})", function_name, arguments),
+            "fd_seek" => todo!("WASI {}({:?})", function_name, arguments),
+            "fd_sync" => todo!("WASI {}({:?})", function_name, arguments),
+            "fd_tell" => todo!("WASI {}({:?})", function_name, arguments),
+            "fd_write" => todo!("WASI {}({:?})", function_name, arguments),
+            "path_create_directory" => todo!("WASI {}({:?})", function_name, arguments),
+            "path_filestat_get" => todo!("WASI {}({:?})", function_name, arguments),
+            "path_filestat_set_times" => todo!("WASI {}({:?})", function_name, arguments),
+            "path_link" => todo!("WASI {}({:?})", function_name, arguments),
+            "path_open" => todo!("WASI {}({:?})", function_name, arguments),
+            "path_readlink" => todo!("WASI {}({:?})", function_name, arguments),
+            "path_remove_directory" => todo!("WASI {}({:?})", function_name, arguments),
+            "path_rename" => todo!("WASI {}({:?})", function_name, arguments),
+            "path_symlink" => todo!("WASI {}({:?})", function_name, arguments),
+            "path_unlink_file" => todo!("WASI {}({:?})", function_name, arguments),
+            "poll_oneoff" => todo!("WASI {}({:?})", function_name, arguments),
+            "proc_exit" => todo!("WASI {}({:?})", function_name, arguments),
+            "proc_raise" => todo!("WASI {}({:?})", function_name, arguments),
+            "sched_yield" => todo!("WASI {}({:?})", function_name, arguments),
+            "random_get" => todo!("WASI {}({:?})", function_name, arguments),
+            "sock_recv" => todo!("WASI {}({:?})", function_name, arguments),
+            "sock_send" => todo!("WASI {}({:?})", function_name, arguments),
+            "sock_shutdown" => todo!("WASI {}({:?})", function_name, arguments),
+            _ => panic!("Unknown WASI function {}({:?})", function_name, arguments),
         }
-        Some(Value::I32(0))
     }
 }

--- a/crates/wasm_interp/src/wasi.rs
+++ b/crates/wasm_interp/src/wasi.rs
@@ -1,0 +1,182 @@
+use roc_wasm_module::Value;
+
+pub trait ImportDispatcher<ImportId: Sized> {
+    /// Translate a module name and function name into your own ImportId enum.
+    /// On Instance construction, the interpreter will check that all imports have
+    /// some ImportId, and fail otherwise.
+    fn get_function_id(module_name: &str, function_name: &str) -> Option<ImportId>;
+
+    /// Dispatch a call from the WebAssembly module to your own code, based on the ImportId.
+    /// The call arguments are passed in, along with a mutable pointer to WebAssembly memory.
+    fn dispatch(
+        &mut self,
+        import_id: ImportId,
+        arguments: &[Value],
+        memory: &mut [u8],
+    ) -> Option<Value>;
+}
+
+#[repr(u8)]
+#[derive(Debug)]
+enum WasiFunctionId {
+    ArgsGet,
+    ArgsSizesGet,
+    EnvironGet,
+    EnvironSizesGet,
+    ClockResGet,
+    ClockTimeGet,
+    FdAdvise,
+    FdAllocate,
+    FdClose,
+    FdDatasync,
+    FdFdstatGet,
+    FdFdstatSetFlags,
+    FdFdstatSetRights,
+    FdFilestatGet,
+    FdFilestatSetSize,
+    FdFilestatSetTimes,
+    FdPread,
+    FdPrestatGet,
+    FdPrestatDirName,
+    FdPwrite,
+    FdRead,
+    FdReaddir,
+    FdRenumber,
+    FdSeek,
+    FdSync,
+    FdTell,
+    FdWrite,
+    PathCreateDirectory,
+    PathFilestatGet,
+    PathFilestatSetTimes,
+    PathLink,
+    PathOpen,
+    PathReadlink,
+    PathRemoveDirectory,
+    PathRename,
+    PathSymlink,
+    PathUnlinkFile,
+    PollOneoff,
+    ProcExit,
+    ProcRaise,
+    SchedYield,
+    RandomGet,
+    SockRecv,
+    SockSend,
+    SockShutdown,
+}
+
+pub struct WasiImportDispatcher {}
+
+impl ImportDispatcher<WasiFunctionId> for WasiImportDispatcher {
+    fn get_function_id(module_name: &str, function_name: &str) -> Option<WasiFunctionId> {
+        use WasiFunctionId::*;
+        assert_eq!(module_name, "wasi_snapshot_preview1");
+        match function_name {
+            "args_get" => Some(ArgsGet),
+            "args_sizes_get" => Some(ArgsSizesGet),
+            "environ_get" => Some(EnvironGet),
+            "environ_sizes_get" => Some(EnvironSizesGet),
+            "clock_res_get" => Some(ClockResGet),
+            "clock_time_get" => Some(ClockTimeGet),
+            "fd_advise" => Some(FdAdvise),
+            "fd_allocate" => Some(FdAllocate),
+            "fd_close" => Some(FdClose),
+            "fd_datasync" => Some(FdDatasync),
+            "fd_fdstat_get" => Some(FdFdstatGet),
+            "fd_fdstat_set_flags" => Some(FdFdstatSetFlags),
+            "fd_fdstat_set_rights" => Some(FdFdstatSetRights),
+            "fd_filestat_get" => Some(FdFilestatGet),
+            "fd_filestat_set_size" => Some(FdFilestatSetSize),
+            "fd_filestat_set_times" => Some(FdFilestatSetTimes),
+            "fd_pread" => Some(FdPread),
+            "fd_prestat_get" => Some(FdPrestatGet),
+            "fd_prestat_dir_name" => Some(FdPrestatDirName),
+            "fd_pwrite" => Some(FdPwrite),
+            "fd_read" => Some(FdRead),
+            "fd_readdir" => Some(FdReaddir),
+            "fd_renumber" => Some(FdRenumber),
+            "fd_seek" => Some(FdSeek),
+            "fd_sync" => Some(FdSync),
+            "fd_tell" => Some(FdTell),
+            "fd_write" => Some(FdWrite),
+            "path_create_directory" => Some(PathCreateDirectory),
+            "path_filestat_get" => Some(PathFilestatGet),
+            "path_filestat_set_times" => Some(PathFilestatSetTimes),
+            "path_link" => Some(PathLink),
+            "path_open" => Some(PathOpen),
+            "path_readlink" => Some(PathReadlink),
+            "path_remove_directory" => Some(PathRemoveDirectory),
+            "path_rename" => Some(PathRename),
+            "path_symlink" => Some(PathSymlink),
+            "path_unlink_file" => Some(PathUnlinkFile),
+            "poll_oneoff" => Some(PollOneoff),
+            "proc_exit" => Some(ProcExit),
+            "proc_raise" => Some(ProcRaise),
+            "sched_yield" => Some(SchedYield),
+            "random_get" => Some(RandomGet),
+            "sock_recv" => Some(SockRecv),
+            "sock_send" => Some(SockSend),
+            "sock_shutdown" => Some(SockShutdown),
+            _ => None,
+        }
+    }
+
+    fn dispatch(
+        &mut self,
+        import_id: WasiFunctionId,
+        _arguments: &[Value],
+        _memory: &mut [u8],
+    ) -> Option<Value> {
+        use WasiFunctionId::*;
+
+        match import_id {
+            ArgsGet => eprintln!("Called WASI {:?}", import_id),
+            ArgsSizesGet => eprintln!("Called WASI {:?}", import_id),
+            EnvironGet => eprintln!("Called WASI {:?}", import_id),
+            EnvironSizesGet => eprintln!("Called WASI {:?}", import_id),
+            ClockResGet => eprintln!("Called WASI {:?}", import_id),
+            ClockTimeGet => eprintln!("Called WASI {:?}", import_id),
+            FdAdvise => eprintln!("Called WASI {:?}", import_id),
+            FdAllocate => eprintln!("Called WASI {:?}", import_id),
+            FdClose => eprintln!("Called WASI {:?}", import_id),
+            FdDatasync => eprintln!("Called WASI {:?}", import_id),
+            FdFdstatGet => eprintln!("Called WASI {:?}", import_id),
+            FdFdstatSetFlags => eprintln!("Called WASI {:?}", import_id),
+            FdFdstatSetRights => eprintln!("Called WASI {:?}", import_id),
+            FdFilestatGet => eprintln!("Called WASI {:?}", import_id),
+            FdFilestatSetSize => eprintln!("Called WASI {:?}", import_id),
+            FdFilestatSetTimes => eprintln!("Called WASI {:?}", import_id),
+            FdPread => eprintln!("Called WASI {:?}", import_id),
+            FdPrestatGet => eprintln!("Called WASI {:?}", import_id),
+            FdPrestatDirName => eprintln!("Called WASI {:?}", import_id),
+            FdPwrite => eprintln!("Called WASI {:?}", import_id),
+            FdRead => eprintln!("Called WASI {:?}", import_id),
+            FdReaddir => eprintln!("Called WASI {:?}", import_id),
+            FdRenumber => eprintln!("Called WASI {:?}", import_id),
+            FdSeek => eprintln!("Called WASI {:?}", import_id),
+            FdSync => eprintln!("Called WASI {:?}", import_id),
+            FdTell => eprintln!("Called WASI {:?}", import_id),
+            FdWrite => eprintln!("Called WASI {:?}", import_id),
+            PathCreateDirectory => eprintln!("Called WASI {:?}", import_id),
+            PathFilestatGet => eprintln!("Called WASI {:?}", import_id),
+            PathFilestatSetTimes => eprintln!("Called WASI {:?}", import_id),
+            PathLink => eprintln!("Called WASI {:?}", import_id),
+            PathOpen => eprintln!("Called WASI {:?}", import_id),
+            PathReadlink => eprintln!("Called WASI {:?}", import_id),
+            PathRemoveDirectory => eprintln!("Called WASI {:?}", import_id),
+            PathRename => eprintln!("Called WASI {:?}", import_id),
+            PathSymlink => eprintln!("Called WASI {:?}", import_id),
+            PathUnlinkFile => eprintln!("Called WASI {:?}", import_id),
+            PollOneoff => eprintln!("Called WASI {:?}", import_id),
+            ProcExit => eprintln!("Called WASI {:?}", import_id),
+            ProcRaise => eprintln!("Called WASI {:?}", import_id),
+            SchedYield => eprintln!("Called WASI {:?}", import_id),
+            RandomGet => eprintln!("Called WASI {:?}", import_id),
+            SockRecv => eprintln!("Called WASI {:?}", import_id),
+            SockSend => eprintln!("Called WASI {:?}", import_id),
+            SockShutdown => eprintln!("Called WASI {:?}", import_id),
+        }
+        Some(Value::I32(0))
+    }
+}

--- a/crates/wasm_interp/src/wasi.rs
+++ b/crates/wasm_interp/src/wasi.rs
@@ -1,6 +1,6 @@
 use roc_wasm_module::Value;
 
-pub const MODULE_NAME: &'static str = "wasi_snapshot_preview1";
+pub const MODULE_NAME: &str = "wasi_snapshot_preview1";
 
 pub fn dispatch(function_name: &str, arguments: &[Value], _memory: &mut [u8]) -> Option<Value> {
     match function_name {

--- a/crates/wasm_interp/tests/test_basics.rs
+++ b/crates/wasm_interp/tests/test_basics.rs
@@ -517,11 +517,14 @@ fn test_call_return_no_args() {
         println!("Wrote to {}", filename);
     }
 
-    let mut state = Instance::for_module(&arena, &module, start_fn_name, true, []).unwrap();
+    let mut inst = Instance::for_module(&arena, &module, true).unwrap();
 
-    while let Action::Continue = state.execute_next_instruction(&module) {}
+    let return_val = inst
+        .call_export(&module, start_fn_name, [])
+        .unwrap()
+        .unwrap();
 
-    assert_eq!(state.value_stack.peek(), Value::I32(42));
+    assert_eq!(return_val, Value::I32(42));
 }
 
 #[test]
@@ -653,12 +656,10 @@ fn test_call_indirect_help(table_index: u32, elem_index: u32) -> Value {
         .unwrap();
     }
 
-    let mut state =
-        Instance::for_module(&arena, &module, start_fn_name, is_debug_mode, []).unwrap();
-
-    while let Action::Continue = state.execute_next_instruction(&module) {}
-
-    state.value_stack.pop()
+    let mut inst = Instance::for_module(&arena, &module, is_debug_mode).unwrap();
+    inst.call_export(&module, start_fn_name, [])
+        .unwrap()
+        .unwrap()
 }
 
 // #[test]

--- a/crates/wasm_interp/tests/test_basics.rs
+++ b/crates/wasm_interp/tests/test_basics.rs
@@ -2,7 +2,7 @@
 
 use bumpalo::{collections::Vec, Bump};
 use roc_wasm_interp::test_utils::{const_value, create_exported_function_no_locals, default_state};
-use roc_wasm_interp::{Action, Instance, ValueStack};
+use roc_wasm_interp::{Action, Instance, ValueStack, DEFAULT_IMPORTS};
 use roc_wasm_module::{
     opcodes::OpCode, sections::ElementSegment, Export, ExportType, SerialBuffer, Serialize,
     Signature, Value, ValueType, WasmModule,
@@ -517,7 +517,7 @@ fn test_call_return_no_args() {
         println!("Wrote to {}", filename);
     }
 
-    let mut inst = Instance::for_module(&arena, &module, true).unwrap();
+    let mut inst = Instance::for_module(&arena, &module, DEFAULT_IMPORTS, true).unwrap();
 
     let return_val = inst
         .call_export(&module, start_fn_name, [])
@@ -656,7 +656,7 @@ fn test_call_indirect_help(table_index: u32, elem_index: u32) -> Value {
         .unwrap();
     }
 
-    let mut inst = Instance::for_module(&arena, &module, is_debug_mode).unwrap();
+    let mut inst = Instance::for_module(&arena, &module, DEFAULT_IMPORTS, is_debug_mode).unwrap();
     inst.call_export(&module, start_fn_name, [])
         .unwrap()
         .unwrap()

--- a/crates/wasm_interp/tests/test_mem.rs
+++ b/crates/wasm_interp/tests/test_mem.rs
@@ -1,5 +1,5 @@
 use bumpalo::{collections::Vec, Bump};
-use roc_wasm_interp::{test_utils::create_exported_function_no_locals, Action, Instance};
+use roc_wasm_interp::{test_utils::create_exported_function_no_locals, Instance};
 use roc_wasm_module::{
     opcodes::OpCode,
     sections::{DataMode, DataSegment, MemorySection},
@@ -76,12 +76,10 @@ fn test_load(load_op: OpCode, ty: ValueType, data: &[u8], addr: u32, offset: u32
         std::fs::write("/tmp/roc/interp_load_test.wasm", outfile_buf).unwrap();
     }
 
-    let mut state =
-        Instance::for_module(&arena, &module, start_fn_name, is_debug_mode, []).unwrap();
-
-    while let Action::Continue = state.execute_next_instruction(&module) {}
-
-    state.value_stack.pop()
+    let mut inst = Instance::for_module(&arena, &module, is_debug_mode).unwrap();
+    inst.call_export(&module, start_fn_name, [])
+        .unwrap()
+        .unwrap()
 }
 
 #[test]
@@ -275,11 +273,10 @@ fn test_store<'a>(
         buf.append_u8(OpCode::END as u8);
     });
 
-    let mut state = Instance::for_module(arena, module, start_fn_name, is_debug_mode, []).unwrap();
+    let mut inst = Instance::for_module(&arena, &module, is_debug_mode).unwrap();
+    inst.call_export(&module, start_fn_name, []).unwrap();
 
-    while let Action::Continue = state.execute_next_instruction(module) {}
-
-    state.memory
+    inst.memory
 }
 
 #[test]

--- a/crates/wasm_interp/tests/test_mem.rs
+++ b/crates/wasm_interp/tests/test_mem.rs
@@ -273,8 +273,8 @@ fn test_store<'a>(
         buf.append_u8(OpCode::END as u8);
     });
 
-    let mut inst = Instance::for_module(&arena, &module, DEFAULT_IMPORTS, is_debug_mode).unwrap();
-    inst.call_export(&module, start_fn_name, []).unwrap();
+    let mut inst = Instance::for_module(arena, module, DEFAULT_IMPORTS, is_debug_mode).unwrap();
+    inst.call_export(module, start_fn_name, []).unwrap();
 
     inst.memory
 }

--- a/crates/wasm_interp/tests/test_mem.rs
+++ b/crates/wasm_interp/tests/test_mem.rs
@@ -1,5 +1,5 @@
 use bumpalo::{collections::Vec, Bump};
-use roc_wasm_interp::{test_utils::create_exported_function_no_locals, Instance};
+use roc_wasm_interp::{test_utils::create_exported_function_no_locals, Instance, DEFAULT_IMPORTS};
 use roc_wasm_module::{
     opcodes::OpCode,
     sections::{DataMode, DataSegment, MemorySection},
@@ -16,7 +16,7 @@ fn test_currentmemory() {
     module.memory = MemorySection::new(&arena, pages * MemorySection::PAGE_SIZE);
     module.code.bytes.push(OpCode::CURRENTMEMORY as u8);
 
-    let mut state = Instance::new(&arena, pages, pc, []);
+    let mut state = Instance::new(&arena, pages, pc, [], DEFAULT_IMPORTS);
     state.execute_next_instruction(&module);
     assert_eq!(state.value_stack.pop(), Value::I32(3))
 }
@@ -34,7 +34,7 @@ fn test_growmemory() {
     module.code.bytes.encode_i32(grow_pages);
     module.code.bytes.push(OpCode::GROWMEMORY as u8);
 
-    let mut state = Instance::new(&arena, existing_pages, pc, []);
+    let mut state = Instance::new(&arena, existing_pages, pc, [], DEFAULT_IMPORTS);
     state.execute_next_instruction(&module);
     state.execute_next_instruction(&module);
     assert_eq!(state.memory.len(), 5 * MemorySection::PAGE_SIZE as usize);
@@ -76,7 +76,7 @@ fn test_load(load_op: OpCode, ty: ValueType, data: &[u8], addr: u32, offset: u32
         std::fs::write("/tmp/roc/interp_load_test.wasm", outfile_buf).unwrap();
     }
 
-    let mut inst = Instance::for_module(&arena, &module, is_debug_mode).unwrap();
+    let mut inst = Instance::for_module(&arena, &module, DEFAULT_IMPORTS, is_debug_mode).unwrap();
     inst.call_export(&module, start_fn_name, [])
         .unwrap()
         .unwrap()
@@ -273,7 +273,7 @@ fn test_store<'a>(
         buf.append_u8(OpCode::END as u8);
     });
 
-    let mut inst = Instance::for_module(&arena, &module, is_debug_mode).unwrap();
+    let mut inst = Instance::for_module(&arena, &module, DEFAULT_IMPORTS, is_debug_mode).unwrap();
     inst.call_export(&module, start_fn_name, []).unwrap();
 
     inst.memory


### PR DESCRIPTION
Add functionality to call external Rust code from Wasm
I've decided to do this differently than other interpreters, because of all the frustration I've had with the usual way they do it.

They normally base it on the JS version, where you import an object of objects of functions. (The nesting allows you to have separate modules of functions)

The Rust translation of that architecture tends not to work so well. It ends up being a complex data structure with lambdas. Lambdas are a bit awkward in Rust and it's hard to maintain external state outside the Wasm module. But we _always_ want to do that!
Also they always make it really difficult or `unsafe` to access memory as plain bytes. I guess because they want to be multi-threaded. But don't think we care about that. We will just use a separate instance per test anyway.

I am completely exasperated from dealing with it all. See the wasm REPL tests for example. Full of thread locals and lazy statics and weird macros and workarounds.

As a result I am going with my own weirdo design that is really plain and simple and dumb.
Instead of trying to make a JavaScript-ish object-of-functions in Rust I just have a single "dispatcher" function that takes two string arguments and figures out what to do, maybe using a `match`. The string comparisons might be slow in other use cases, but our tests are short and we will probably not do many look-ups on each one. (I have ideas how to make it faster if we need to.)
It also uses a Rust trait instead of lambdas, and a `&mut self` argument. This should make it easier to maintain state.
The arguments to the import are passed as an enum of I32, I64, F32 or F64, and need to be unwrapped to the expected type. Unwrapping is OK because we're using this interpreter for tests anyway, so a panic is a failed test.
The Wasm memory is just passed as a `&mut [u8]` so you can do what you like. No weird `Pointer` types.

I think this design makes tradeoffs that other engines can't really make, but that will simplify a lot of test code and get rid of a lot of `unsafe` code.