### PR TITLE
Fallback to deep copy if `rename` fails when unpacking package tarball

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4157,6 +4157,7 @@ dependencies = [
  "brotli",
  "bumpalo",
  "flate2",
+ "fs_extra",
  "indoc",
  "pretty_assertions",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,7 @@ distance = "0.4.0"
 encode_unicode = "1.0.0"
 errno = "0.2.8"
 fnv = "1.0.7"
+fs_extra = "1.2.0"
 hashbrown = { version = "0.12.3", features = [ "bumpalo" ] }
 iced-x86 = { version = "1.15.0", default-features = false, features = ["std", "decoder", "op_code_info", "instr_info"] }
 im    = "15.0.0"

--- a/crates/editor/Cargo.toml
+++ b/crates/editor/Cargo.toml
@@ -57,9 +57,10 @@ confy = { git = 'https://github.com/rust-cli/confy', features = [
 ], default-features = false }
 serde = { version = "1.0.144", features = ["derive"] }
 nonempty = "0.8.0"
-fs_extra = "1.2.0"
 rodio = { version = "0.15.0", optional = true } # to play sounds
 threadpool = "1.8.1"
+
+fs_extra.workspace = true
 
 [dependencies.bytemuck]
 version = "1.12.1"

--- a/crates/packaging/Cargo.toml
+++ b/crates/packaging/Cargo.toml
@@ -19,6 +19,7 @@ blake3 = "1.3.1"
 base64-url = "1.4.13"
 
 bumpalo.workspace = true
+fs_extra.workspace = true
 tempfile.workspace = true
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]

--- a/crates/packaging/src/https.rs
+++ b/crates/packaging/src/https.rs
@@ -111,6 +111,7 @@ pub enum Problem {
         actual: String,
     },
     IoErr(io::Error),
+    FsExtraErr(fs_extra::error::Error),
     HttpErr(reqwest::Error),
     InvalidUrl(UrlProblem),
     /// The Content-Length header of the response exceeded max_download_bytes


### PR DESCRIPTION
This attempts to work around a problem [people have encountered on NixOS](https://roc.zulipchat.com/#narrow/stream/358903-Advent-of-Code/topic/Setting.20up.20environment.20.28nix.29/near/313333430).

I can't reproduce the problem locally, so...hopefully this fixes it in context!