### PR TITLE
`test` has `dev` behavior, and `dev` does not exit if there are warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3880,6 +3880,7 @@ dependencies = [
  "roc_collections",
  "roc_error_macros",
  "roc_module",
+ "roc_problem",
  "roc_region",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4248,6 +4248,7 @@ dependencies = [
  "roc_mono",
  "roc_packaging",
  "roc_parse",
+ "roc_problem",
  "roc_region",
  "roc_reporting",
  "roc_std",

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -360,7 +360,7 @@ pub fn test(_matches: &ArgMatches, _triple: Triple) -> io::Result<i32> {
 #[cfg(not(windows))]
 pub fn test(matches: &ArgMatches, triple: Triple) -> io::Result<i32> {
     use roc_gen_llvm::llvm::build::LlvmBackendMode;
-    use roc_load::{ExecutionMode, LoadConfig};
+    use roc_load::{ExecutionMode, LoadConfig, LoadMonomorphizedError};
     use roc_packaging::cache;
     use roc_target::TargetInfo;
 
@@ -425,16 +425,24 @@ pub fn test(matches: &ArgMatches, triple: Triple) -> io::Result<i32> {
         threading,
         exec_mode: ExecutionMode::Test,
     };
-    let loaded = roc_load::load_and_monomorphize(
+    let load_result = roc_load::load_and_monomorphize(
         arena,
         path.to_path_buf(),
         subs_by_module,
         RocCacheDir::Persistent(cache::roc_cache_dir().as_path()),
         load_config,
-    )
-    .unwrap();
+    );
 
-    let mut loaded = loaded;
+    let mut loaded = match load_result {
+        Ok(loaded) => loaded,
+        Err(LoadMonomorphizedError::LoadingProblem(problem)) => {
+            return handle_loading_problem(problem);
+        }
+        Err(LoadMonomorphizedError::ErrorModule(module)) => {
+            return handle_error_module(module, start_time.elapsed(), filename, false);
+        }
+    };
+
     let mut expectations = std::mem::take(&mut loaded.expectations);
     let loaded = loaded;
 
@@ -733,35 +741,51 @@ pub fn build(
                 }
             }
         }
-        Err(BuildFileError::ErrorModule {
-            mut module,
-            total_time,
-        }) => {
-            debug_assert!(module.total_problems() > 0);
-
-            let problems = roc_build::program::report_problems_typechecked(&mut module);
-
-            print_problems(problems, total_time);
-
-            print!(".\n\nYou can run the program anyway with \x1B[32mroc run");
-
-            // If you're running "main.roc" then you can just do `roc run`
-            // to re-run the program.
-            if filename != DEFAULT_ROC_FILENAME {
-                print!(" {}", &filename.to_string_lossy());
-            }
-
-            println!("\x1B[39m");
-
-            Ok(problems.exit_code())
+        Err(BuildFileError::ErrorModule { module, total_time }) => {
+            handle_error_module(module, total_time, filename, true)
         }
-        Err(BuildFileError::LoadingProblem(LoadingProblem::FormattedReport(report))) => {
-            print!("{}", report);
+        Err(BuildFileError::LoadingProblem(problem)) => handle_loading_problem(problem),
+    }
+}
 
+fn handle_error_module(
+    mut module: roc_load::LoadedModule,
+    total_time: std::time::Duration,
+    filename: &OsStr,
+    print_run_anyway_hint: bool,
+) -> io::Result<i32> {
+    debug_assert!(module.total_problems() > 0);
+
+    let problems = roc_build::program::report_problems_typechecked(&mut module);
+
+    print_problems(problems, total_time);
+
+    if print_run_anyway_hint {
+        // If you're running "main.roc" then you can just do `roc run`
+        // to re-run the program.
+        print!(".\n\nYou can run the program anyway with \x1B[32mroc run");
+
+        if filename != DEFAULT_ROC_FILENAME {
+            print!(" {}", &filename.to_string_lossy());
+        }
+
+        println!("\x1B[39m");
+    }
+
+    Ok(problems.exit_code())
+}
+
+fn handle_loading_problem(problem: LoadingProblem) -> io::Result<i32> {
+    match problem {
+        LoadingProblem::FormattedReport(report) => {
+            print!("{}", report);
             Ok(1)
         }
-        Err(other) => {
-            panic!("build_file failed with error:\n{:?}", other);
+        _ => {
+            // TODO: tighten up the types here, we should always end up with a
+            // formatted report from load.
+            print!("Failed with error: {:?}", problem);
+            Ok(1)
         }
     }
 }

--- a/crates/compiler/exhaustive/Cargo.toml
+++ b/crates/compiler/exhaustive/Cargo.toml
@@ -11,3 +11,4 @@ roc_collections = { path = "../collections" }
 roc_region = { path = "../region" }
 roc_module = { path = "../module" }
 roc_error_macros = { path = "../../error_macros" }
+roc_problem = { path = "../problem" }

--- a/crates/compiler/exhaustive/src/lib.rs
+++ b/crates/compiler/exhaustive/src/lib.rs
@@ -7,6 +7,7 @@ use roc_module::{
     ident::{Lowercase, TagIdIntType, TagName},
     symbol::Symbol,
 };
+use roc_problem::Severity;
 use roc_region::all::Region;
 
 use self::Pattern::*;
@@ -147,6 +148,17 @@ pub enum Error {
         branch_region: Region,
         index: HumanIndex,
     },
+}
+
+impl Error {
+    pub fn severity(&self) -> Severity {
+        use Severity::*;
+        match self {
+            Error::Incomplete(..) => RuntimeError,
+            Error::Redundant { .. } => Warning,
+            Error::Unmatchable { .. } => Warning,
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/crates/compiler/load/src/lib.rs
+++ b/crates/compiler/load/src/lib.rs
@@ -101,14 +101,14 @@ pub fn load_and_monomorphize_from_str<'a>(
     exposed_types: ExposedByModule,
     roc_cache_dir: RocCacheDir<'_>,
     load_config: LoadConfig,
-) -> Result<MonomorphizedModule<'a>, LoadingProblem<'a>> {
+) -> Result<MonomorphizedModule<'a>, LoadMonomorphizedError<'a>> {
     use LoadResult::*;
 
     let load_start = LoadStart::from_str(arena, filename, src, roc_cache_dir, src_dir)?;
 
     match load(arena, load_start, exposed_types, roc_cache_dir, load_config)? {
         Monomorphized(module) => Ok(module),
-        TypeChecked(_) => unreachable!(""),
+        TypeChecked(module) => Err(LoadMonomorphizedError::ErrorModule(module)),
     }
 }
 

--- a/crates/compiler/load_internal/src/file.rs
+++ b/crates/compiler/load_internal/src/file.rs
@@ -45,8 +45,9 @@ use roc_parse::header::{HeaderFor, ModuleNameEnum, PackageName};
 use roc_parse::ident::UppercaseIdent;
 use roc_parse::module::module_defs;
 use roc_parse::parser::{FileError, Parser, SourceError, SyntaxError};
+use roc_problem::Severity;
 use roc_region::all::{LineInfo, Loc, Region};
-use roc_reporting::report::{Annotation, Palette, RenderTarget, Severity};
+use roc_reporting::report::{Annotation, Palette, RenderTarget};
 use roc_solve::module::{extract_module_owned_implementations, Solved, SolvedModule};
 use roc_solve_problem::TypeError;
 use roc_target::TargetInfo;
@@ -2786,7 +2787,10 @@ fn update<'a>(
             layout_cache,
             ..
         } => {
-            debug_assert!(state.goal_phase() == Phase::MakeSpecializations || state.exec_mode.build_if_checks());
+            debug_assert!(
+                state.goal_phase() == Phase::MakeSpecializations
+                    || state.exec_mode.build_if_checks()
+            );
 
             log!("made specializations for {:?}", module_id);
 
@@ -5988,7 +5992,7 @@ fn run_task<'a>(
 }
 
 fn to_file_problem_report(filename: &Path, error: io::ErrorKind) -> String {
-    use roc_reporting::report::{Report, RocDocAllocator, Severity, DEFAULT_PALETTE};
+    use roc_reporting::report::{Report, RocDocAllocator, DEFAULT_PALETTE};
     use ven_pretty::DocAllocator;
 
     let src_lines: Vec<&str> = Vec::new();
@@ -6075,7 +6079,7 @@ fn to_import_cycle_report(
     filename: PathBuf,
     render: RenderTarget,
 ) -> String {
-    use roc_reporting::report::{Report, RocDocAllocator, Severity, DEFAULT_PALETTE};
+    use roc_reporting::report::{Report, RocDocAllocator, DEFAULT_PALETTE};
     use ven_pretty::DocAllocator;
 
     // import_cycle looks like CycleModule, Import1, ..., ImportN, CycleModule
@@ -6135,7 +6139,7 @@ fn to_incorrect_module_name_report<'a>(
     src: &'a [u8],
     render: RenderTarget,
 ) -> String {
-    use roc_reporting::report::{Report, RocDocAllocator, Severity, DEFAULT_PALETTE};
+    use roc_reporting::report::{Report, RocDocAllocator, DEFAULT_PALETTE};
     use ven_pretty::DocAllocator;
 
     let IncorrectModuleName {
@@ -6221,7 +6225,7 @@ fn to_parse_problem_report<'a>(
 }
 
 fn to_missing_platform_report(module_id: ModuleId, other: PlatformPath) -> String {
-    use roc_reporting::report::{Report, RocDocAllocator, Severity, DEFAULT_PALETTE};
+    use roc_reporting::report::{Report, RocDocAllocator, DEFAULT_PALETTE};
     use ven_pretty::DocAllocator;
     use PlatformPath::*;
 

--- a/crates/compiler/load_internal/src/file.rs
+++ b/crates/compiler/load_internal/src/file.rs
@@ -46,7 +46,7 @@ use roc_parse::ident::UppercaseIdent;
 use roc_parse::module::module_defs;
 use roc_parse::parser::{FileError, Parser, SourceError, SyntaxError};
 use roc_region::all::{LineInfo, Loc, Region};
-use roc_reporting::report::{Annotation, Palette, RenderTarget};
+use roc_reporting::report::{Annotation, Palette, RenderTarget, Severity};
 use roc_solve::module::{extract_module_owned_implementations, Solved, SolvedModule};
 use roc_solve_problem::TypeError;
 use roc_target::TargetInfo;

--- a/crates/compiler/problem/src/can.rs
+++ b/crates/compiler/problem/src/can.rs
@@ -214,7 +214,7 @@ impl Problem {
             Problem::UnusedDef(_, _) => Warning,
             Problem::UnusedImport(_, _) => Warning,
             Problem::UnusedModuleImport(_, _) => Warning,
-            Problem::ExposedButNotDefined(_) => Warning,
+            Problem::ExposedButNotDefined(_) => RuntimeError,
             Problem::UnknownGeneratesWith(_) => RuntimeError,
             Problem::UnusedArgument(_, _, _, _) => Warning,
             Problem::UnusedBranchDef(_, _) => Warning,

--- a/crates/compiler/problem/src/can.rs
+++ b/crates/compiler/problem/src/can.rs
@@ -7,6 +7,8 @@ use roc_parse::pattern::PatternType;
 use roc_region::all::{Loc, Region};
 use roc_types::types::AliasKind;
 
+use crate::Severity;
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct CycleEntry {
     pub symbol: Symbol,
@@ -205,6 +207,70 @@ pub enum Problem {
 }
 
 impl Problem {
+    pub fn severity(&self) -> Severity {
+        use Severity::{RuntimeError, Warning};
+
+        match self {
+            Problem::UnusedDef(_, _) => Warning,
+            Problem::UnusedImport(_, _) => Warning,
+            Problem::UnusedModuleImport(_, _) => Warning,
+            Problem::ExposedButNotDefined(_) => Warning,
+            Problem::UnknownGeneratesWith(_) => RuntimeError,
+            Problem::UnusedArgument(_, _, _, _) => Warning,
+            Problem::UnusedBranchDef(_, _) => Warning,
+            Problem::PrecedenceProblem(_) => RuntimeError,
+            Problem::UnsupportedPattern(_, _) => RuntimeError,
+            Problem::Shadowing { .. } => RuntimeError,
+            Problem::CyclicAlias(..) => RuntimeError,
+            Problem::BadRecursion(_) => RuntimeError,
+            Problem::PhantomTypeArgument { .. } => Warning,
+            Problem::UnboundTypeVariable { .. } => RuntimeError,
+            Problem::DuplicateRecordFieldValue { .. } => Warning,
+            Problem::DuplicateRecordFieldType { .. } => RuntimeError,
+            Problem::InvalidOptionalValue { .. } => RuntimeError,
+            Problem::DuplicateTag { .. } => RuntimeError,
+            Problem::RuntimeError(_) => RuntimeError,
+            Problem::SignatureDefMismatch { .. } => RuntimeError,
+            Problem::InvalidAliasRigid { .. } => RuntimeError,
+            Problem::InvalidInterpolation(_) => RuntimeError,
+            Problem::InvalidHexadecimal(_) => RuntimeError,
+            Problem::InvalidUnicodeCodePt(_) => RuntimeError,
+            Problem::NestedDatatype { .. } => RuntimeError,
+            Problem::InvalidExtensionType { .. } => RuntimeError,
+            Problem::AbilityHasTypeVariables { .. } => RuntimeError,
+            Problem::HasClauseIsNotAbility { .. } => RuntimeError,
+            Problem::IllegalHasClause { .. } => RuntimeError,
+            Problem::DuplicateHasAbility { .. } => Warning,
+            Problem::AbilityMemberMissingHasClause { .. } => RuntimeError,
+            Problem::AbilityMemberMultipleBoundVars { .. } => RuntimeError,
+            Problem::AbilityNotOnToplevel { .. } => RuntimeError, // Ideally, could be compiled
+            Problem::AbilityUsedAsType(_, _, _) => RuntimeError,
+            Problem::NestedSpecialization(_, _) => RuntimeError, // Ideally, could be compiled
+            Problem::IllegalDerivedAbility(_) => RuntimeError,
+            Problem::ImplementationNotFound { .. } => RuntimeError,
+            Problem::NotAnAbilityMember { .. } => RuntimeError,
+            Problem::OptionalAbilityImpl { .. } => RuntimeError,
+            Problem::QualifiedAbilityImpl { .. } => RuntimeError,
+            Problem::AbilityImplNotIdent { .. } => RuntimeError,
+            Problem::DuplicateImpl { .. } => Warning, // First impl is used at runtime
+            Problem::NotAnAbility(_) => Warning,
+            Problem::ImplementsNonRequired { .. } => Warning,
+            Problem::DoesNotImplementAbility { .. } => RuntimeError,
+            Problem::NotBoundInAllPatterns { .. } => RuntimeError,
+            Problem::NoIdentifiersIntroduced(_) => Warning,
+            Problem::OverloadedSpecialization { .. } => Warning, // Ideally, will compile
+            Problem::UnnecessaryOutputWildcard { .. } => Warning,
+            // TODO: sometimes this can just be a warning, e.g. if you have [1, .., .., 2] but we
+            // don't catch that yet.
+            Problem::MultipleListRestPattern { .. } => RuntimeError,
+            Problem::BadTypeArguments { .. } => RuntimeError,
+            // TODO: this can be a warning instead if we recover the program by
+            // injecting a crash message
+            Problem::UnappliedCrash { .. } => RuntimeError,
+            Problem::OverAppliedCrash { .. } => RuntimeError,
+        }
+    }
+
     /// Returns a Region value from the Problem, if possible.
     /// Some problems have more than one region; in those cases,
     /// this tries to pick the one that's closest to the original

--- a/crates/compiler/problem/src/can.rs
+++ b/crates/compiler/problem/src/can.rs
@@ -268,6 +268,7 @@ impl Problem {
             // injecting a crash message
             Problem::UnappliedCrash { .. } => RuntimeError,
             Problem::OverAppliedCrash { .. } => RuntimeError,
+            Problem::DefsOnlyUsedInRecursion(_, _) => Warning,
         }
     }
 

--- a/crates/compiler/problem/src/lib.rs
+++ b/crates/compiler/problem/src/lib.rs
@@ -3,3 +3,15 @@
 // See github.com/roc-lang/roc/issues/800 for discussion of the large_enum_variant check.
 #![allow(clippy::large_enum_variant)]
 pub mod can;
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum Severity {
+    /// This will cause a runtime error if some code get srun
+    /// (e.g. type mismatch, naming error)
+    RuntimeError,
+
+    /// This will never cause the code to misbehave,
+    /// but should be cleaned up
+    /// (e.g. unused def, unused import)
+    Warning,
+}

--- a/crates/compiler/solve_problem/src/lib.rs
+++ b/crates/compiler/solve_problem/src/lib.rs
@@ -1,7 +1,7 @@
 //! Provides types to describe problems that can occur during solving.
 use roc_can::expected::{Expected, PExpected};
 use roc_module::{ident::Lowercase, symbol::Symbol};
-use roc_problem::can::CycleEntry;
+use roc_problem::{can::CycleEntry, Severity};
 use roc_region::all::Region;
 
 use roc_types::types::{Category, ErrorType, PatternCategory};
@@ -29,6 +29,27 @@ pub enum TypeError {
         expected_opaque: Symbol,
         found_opaque: Symbol,
     },
+}
+
+impl TypeError {
+    pub fn severity(&self) -> Severity {
+        use Severity::*;
+        match self {
+            TypeError::BadExpr(..) => RuntimeError,
+            TypeError::BadPattern(..) => RuntimeError,
+            TypeError::CircularType(..) => RuntimeError,
+            TypeError::CircularDef(_) => RuntimeError,
+            TypeError::UnexposedLookup(_) => RuntimeError,
+            TypeError::UnfulfilledAbility(_) => RuntimeError,
+            TypeError::BadExprMissingAbility(_, _, _, _) => RuntimeError,
+            TypeError::BadPatternMissingAbility(_, _, _, _) => RuntimeError,
+            // NB: if bidirectional exhaustiveness checking is implemented, the other direction
+            // is also not a runtime error.
+            TypeError::Exhaustive(exhtv) => exhtv.severity(),
+            TypeError::StructuralSpecialization { .. } => RuntimeError,
+            TypeError::WrongSpecialization { .. } => RuntimeError,
+        }
+    }
 }
 
 #[derive(PartialEq, Eq, Debug, Clone)]

--- a/crates/compiler/test_gen/src/helpers/llvm.rs
+++ b/crates/compiler/test_gen/src/helpers/llvm.rs
@@ -7,7 +7,7 @@ use roc_build::link::llvm_module_to_dylib;
 use roc_collections::all::MutSet;
 use roc_gen_llvm::llvm::externs::add_default_roc_externs;
 use roc_gen_llvm::{llvm::build::LlvmBackendMode, run_roc::RocCallResult};
-use roc_load::{EntryPoint, ExecutionMode, LoadConfig, Threading};
+use roc_load::{EntryPoint, ExecutionMode, LoadConfig, LoadMonomorphizedError, Threading};
 use roc_mono::ir::{CrashTag, OptLevel};
 use roc_packaging::cache::RocCacheDir;
 use roc_region::all::LineInfo;
@@ -87,7 +87,9 @@ fn create_llvm_module<'a>(
 
     let mut loaded = match loaded {
         Ok(x) => x,
-        Err(roc_load::LoadingProblem::FormattedReport(report)) => {
+        Err(LoadMonomorphizedError::LoadingProblem(roc_load::LoadingProblem::FormattedReport(
+            report,
+        ))) => {
             println!("{}", report);
             panic!();
         }

--- a/crates/compiler/test_mono/src/tests.rs
+++ b/crates/compiler/test_mono/src/tests.rs
@@ -16,6 +16,7 @@ const EXPANDED_STACK_SIZE: usize = 8 * 1024 * 1024;
 use roc_collections::all::MutMap;
 use roc_load::ExecutionMode;
 use roc_load::LoadConfig;
+use roc_load::LoadMonomorphizedError;
 use roc_load::Threading;
 use roc_module::symbol::Symbol;
 use roc_mono::ir::Proc;
@@ -113,7 +114,9 @@ fn compiles_to_ir(test_name: &str, src: &str) {
 
     let mut loaded = match loaded {
         Ok(x) => x,
-        Err(roc_load::LoadingProblem::FormattedReport(report)) => {
+        Err(LoadMonomorphizedError::LoadingProblem(roc_load::LoadingProblem::FormattedReport(
+            report,
+        ))) => {
             println!("{}", report);
             panic!();
         }

--- a/crates/repl_eval/Cargo.toml
+++ b/crates/repl_eval/Cargo.toml
@@ -20,6 +20,7 @@ roc_load = {path = "../compiler/load"}
 roc_module = {path = "../compiler/module"}
 roc_mono = {path = "../compiler/mono"}
 roc_parse = {path = "../compiler/parse"}
+roc_problem = {path = "../compiler/problem"}
 roc_region = {path = "../compiler/region"}
 roc_packaging = {path = "../packaging"}
 roc_reporting = {path = "../reporting"}

--- a/crates/repl_eval/src/gen.rs
+++ b/crates/repl_eval/src/gen.rs
@@ -1,7 +1,8 @@
 use bumpalo::Bump;
 use roc_load::{ExecutionMode, LoadConfig, Threading};
 use roc_packaging::cache::{self, RocCacheDir};
-use roc_reporting::report::{Palette, Severity};
+use roc_problem::Severity;
+use roc_reporting::report::Palette;
 use std::path::PathBuf;
 
 use roc_fmt::annotation::Formattable;

--- a/crates/repl_eval/src/gen.rs
+++ b/crates/repl_eval/src/gen.rs
@@ -1,5 +1,5 @@
 use bumpalo::Bump;
-use roc_load::{ExecutionMode, LoadConfig, Threading};
+use roc_load::{ExecutionMode, LoadConfig, LoadMonomorphizedError, Threading};
 use roc_packaging::cache::{self, RocCacheDir};
 use roc_problem::Severity;
 use roc_reporting::report::Palette;
@@ -73,7 +73,13 @@ pub fn compile_to_mono<'a, 'i, I: Iterator<Item = &'i str>>(
 
     let mut loaded = match loaded {
         Ok(v) => v,
-        Err(LoadingProblem::FormattedReport(report)) => {
+        Err(LoadMonomorphizedError::ErrorModule(m)) => {
+            todo!(
+                "error while loading module: {:?}",
+                (m.can_problems, m.type_problems)
+            );
+        }
+        Err(LoadMonomorphizedError::LoadingProblem(LoadingProblem::FormattedReport(report))) => {
             return (
                 None,
                 Problems {

--- a/crates/reporting/src/cli.rs
+++ b/crates/reporting/src/cli.rs
@@ -29,9 +29,8 @@ pub fn report_problems(
     can_problems: &mut MutMap<ModuleId, Vec<roc_problem::can::Problem>>,
     type_problems: &mut MutMap<ModuleId, Vec<TypeError>>,
 ) -> Problems {
-    use crate::report::{
-        can_problem, type_problem, Report, RocDocAllocator, Severity::*, DEFAULT_PALETTE,
-    };
+    use crate::report::{can_problem, type_problem, Report, RocDocAllocator, DEFAULT_PALETTE};
+    use roc_problem::Severity::*;
     let palette = DEFAULT_PALETTE;
 
     // This will often over-allocate total memory, but it means we definitely

--- a/crates/reporting/src/error/canonicalize.rs
+++ b/crates/reporting/src/error/canonicalize.rs
@@ -131,7 +131,6 @@ pub fn can_problem<'b>(
             ]);
 
             title = "DEFINITION ONLY USED IN RECURSION".to_string();
-            severity = Severity::Warning;
         }
         Problem::DefsOnlyUsedInRecursion(n, region) => {
             doc = alloc.stack([
@@ -147,7 +146,6 @@ pub fn can_problem<'b>(
             ]);
 
             title = "DEFINITIONs ONLY USED IN RECURSION".to_string();
-            severity = Severity::Warning;
         }
         Problem::ExposedButNotDefined(symbol) => {
             doc = alloc.stack([

--- a/crates/reporting/src/error/expect.rs
+++ b/crates/reporting/src/error/expect.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 use bumpalo::Bump;
 use roc_module::symbol::{Interns, ModuleId, Symbol};
 use roc_parse::ast::Expr;
+use roc_problem::Severity;
 use roc_region::all::{LineColumnRegion, LineInfo, Region};
 use roc_types::{
     subs::{Subs, Variable},
@@ -154,7 +155,7 @@ impl<'a> Renderer<'a> {
             title: "EXPECT FAILED".into(),
             doc,
             filename: self.filename.clone(),
-            severity: crate::report::Severity::RuntimeError,
+            severity: Severity::RuntimeError,
         };
 
         let mut buf = String::new();
@@ -225,7 +226,7 @@ impl<'a> Renderer<'a> {
             title: "EXPECT PANICKED".into(),
             doc,
             filename: self.filename.clone(),
-            severity: crate::report::Severity::RuntimeError,
+            severity: Severity::RuntimeError,
         };
 
         let mut buf = String::new();

--- a/crates/reporting/src/error/parse.rs
+++ b/crates/reporting/src/error/parse.rs
@@ -1,8 +1,9 @@
 use roc_parse::parser::{ENumber, FileError, PList, SyntaxError};
+use roc_problem::Severity;
 use roc_region::all::{LineColumn, LineColumnRegion, LineInfo, Position, Region};
 use std::path::PathBuf;
 
-use crate::report::{Report, RocDocAllocator, RocDocBuilder, Severity};
+use crate::report::{Report, RocDocAllocator, RocDocBuilder};
 use ven_pretty::DocAllocator;
 
 pub fn parse_problem<'a>(

--- a/crates/reporting/src/error/type.rs
+++ b/crates/reporting/src/error/type.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::too_many_arguments)]
+
 use crate::error::canonicalize::{to_circular_def_doc, CIRCULAR_DEF};
 use crate::report::{Annotation, Report, RocDocAllocator, RocDocBuilder};
 use roc_can::expected::{Expected, PExpected};
@@ -455,7 +457,6 @@ pub fn cyclic_alias<'b>(
     (doc, "CYCLIC ALIAS".to_string())
 }
 
-#[allow(clippy::too_many_arguments)]
 fn report_mismatch<'b>(
     alloc: &'b RocDocAllocator<'b>,
     lines: &LineInfo,
@@ -501,7 +502,6 @@ fn report_mismatch<'b>(
     }
 }
 
-#[allow(clippy::too_many_arguments)]
 fn report_bad_type<'b>(
     alloc: &'b RocDocAllocator<'b>,
     lines: &LineInfo,
@@ -4102,7 +4102,6 @@ fn type_problem_to_pretty<'b>(
     }
 }
 
-#[allow(clippy::too_many_arguments)]
 fn report_record_field_typo<'b>(
     alloc: &'b RocDocAllocator<'b>,
     lines: &LineInfo,

--- a/crates/reporting/src/error/type.rs
+++ b/crates/reporting/src/error/type.rs
@@ -1,5 +1,5 @@
 use crate::error::canonicalize::{to_circular_def_doc, CIRCULAR_DEF};
-use crate::report::{Annotation, Report, RocDocAllocator, RocDocBuilder, Severity};
+use crate::report::{Annotation, Report, RocDocAllocator, RocDocBuilder};
 use roc_can::expected::{Expected, PExpected};
 use roc_collections::all::{HumanIndex, MutSet, SendMap};
 use roc_collections::VecMap;
@@ -8,6 +8,7 @@ use roc_exhaustive::{CtorName, ListArity};
 use roc_module::called_via::{BinOp, CalledVia};
 use roc_module::ident::{IdentStr, Lowercase, TagName};
 use roc_module::symbol::Symbol;
+use roc_problem::Severity;
 use roc_region::all::{LineInfo, Region};
 use roc_solve_problem::{
     NotDerivableContext, NotDerivableDecode, NotDerivableEq, TypeError, UnderivableReason,

--- a/crates/reporting/src/report.rs
+++ b/crates/reporting/src/report.rs
@@ -1,6 +1,7 @@
 use roc_module::ident::Ident;
 use roc_module::ident::{Lowercase, ModuleName, TagName, Uppercase};
 use roc_module::symbol::{Interns, ModuleId, PQModuleName, PackageQualified, Symbol};
+use roc_problem::Severity;
 use roc_region::all::LineColumnRegion;
 use std::fmt;
 use std::path::{Path, PathBuf};
@@ -97,18 +98,6 @@ pub fn pretty_header_with_path(title: &str, path: &Path) -> String {
     );
 
     header
-}
-
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub enum Severity {
-    /// This will cause a runtime error if some code get srun
-    /// (e.g. type mismatch, naming error)
-    RuntimeError,
-
-    /// This will never cause the code to misbehave,
-    /// but should be cleaned up
-    /// (e.g. unused def, unused import)
-    Warning,
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/crates/reporting/tests/test_reporting.rs
+++ b/crates/reporting/tests/test_reporting.rs
@@ -19,9 +19,10 @@ mod test_reporting {
     use roc_parse::module::parse_header;
     use roc_parse::state::State;
     use roc_parse::test_helpers::parse_expr_with;
+    use roc_problem::Severity;
     use roc_region::all::LineInfo;
     use roc_reporting::report::{
-        can_problem, parse_problem, type_problem, RenderTarget, Report, Severity, ANSI_STYLE_CODES,
+        can_problem, parse_problem, type_problem, RenderTarget, Report, ANSI_STYLE_CODES,
         DEFAULT_PALETTE,
     };
     use roc_reporting::report::{RocDocAllocator, RocDocBuilder};

--- a/examples/cli/env.roc
+++ b/examples/cli/env.roc
@@ -5,6 +5,8 @@ app "env"
 
 main : Task {} []
 main =
+    f = ""
+
     task =
         Env.decode "EDITOR"
         |> Task.await (\editor -> Stdout.line "Your favorite editor is \(editor)!")


### PR DESCRIPTION
- Move `roc test` to have the behavior of `roc dev` in that it exits early if there are errors, but not warnings. That way in the short term people can get used to using `roc test` and it'll likely do what they want while minimizing compiler crashes, rather than instilling a habit of `roc check && roc test`. Once spurious crashes are minimized, moving `roc test` back to the test-even-with-errors mode will be natural.

- `roc dev` and `roc test` should stop only if there are errors, but continue if there are only warnings

I verified this works with several issues in the tracker and other experiments locally. Lets add tests after https://github.com/roc-lang/roc/pull/4659 lands, since Folkert is changing cli_run to better support test/dev in that PR.

Closes #4242
Closes #4484
Closes #4587 