### PR TITLE
Type-check mono IR

### DIFF
--- a/crates/compiler/gen_wasm/src/backend.rs
+++ b/crates/compiler/gen_wasm/src/backend.rs
@@ -744,7 +744,7 @@ impl<'a> WasmBackend<'a> {
         let mut current_stmt = stmt;
         while let Stmt::Let(sym, expr, layout, following) = current_stmt {
             if DEBUG_SETTINGS.let_stmt_ir {
-                print!("\nlet {:?} = {}", sym, expr.to_pretty(200));
+                print!("\nlet {:?} = {}", sym, expr.to_pretty(200, true));
             }
 
             let kind = match following {
@@ -974,7 +974,7 @@ impl<'a> WasmBackend<'a> {
             self.register_symbol_debug_names();
             println!(
                 "## rc_stmt:\n{}\n{:?}",
-                rc_stmt.to_pretty(self.env.layout_interner, 200),
+                rc_stmt.to_pretty(self.env.layout_interner, 200, true),
                 rc_stmt
             );
         }
@@ -1078,7 +1078,7 @@ impl<'a> WasmBackend<'a> {
             Expr::Reset { symbol: arg, .. } => self.expr_reset(*arg, sym, storage),
 
             Expr::RuntimeErrorFunction(_) => {
-                todo!("Expression `{}`", expr.to_pretty(100))
+                todo!("Expression `{}`", expr.to_pretty(100, false))
             }
         }
     }

--- a/crates/compiler/gen_wasm/src/lib.rs
+++ b/crates/compiler/gen_wasm/src/lib.rs
@@ -143,7 +143,7 @@ pub fn build_app_module<'a>(
     if DEBUG_SETTINGS.user_procs_ir {
         println!("## procs");
         for proc in procs.iter() {
-            println!("{}", proc.to_pretty(env.layout_interner, 200));
+            println!("{}", proc.to_pretty(env.layout_interner, 200, true));
             // println!("{:?}", proc);
         }
     }
@@ -161,7 +161,7 @@ pub fn build_app_module<'a>(
     if DEBUG_SETTINGS.helper_procs_ir {
         println!("## helper_procs");
         for proc in helper_procs.iter() {
-            println!("{}", proc.to_pretty(env.layout_interner, 200));
+            println!("{}", proc.to_pretty(env.layout_interner, 200, true));
             // println!("{:#?}", proc);
         }
     }

--- a/crates/compiler/load_internal/src/file.rs
+++ b/crates/compiler/load_internal/src/file.rs
@@ -2177,7 +2177,7 @@ macro_rules! debug_print_ir {
             let procs_string = $state
                 .procedures
                 .values()
-                .map(|proc| proc.to_pretty($interner, 200))
+                .map(|proc| proc.to_pretty($interner, 200, true))
                 .collect::<Vec<_>>();
 
             let result = procs_string.join("\n");

--- a/crates/compiler/mono/src/checker.rs
+++ b/crates/compiler/mono/src/checker.rs
@@ -1,0 +1,638 @@
+//! Type-checking of the generated [ir][crate::ir::Proc].
+
+use bumpalo::Bump;
+use roc_collections::{MutMap, VecMap, VecSet};
+use roc_module::symbol::Symbol;
+
+use crate::{
+    ir::{
+        Call, CallSpecId, CallType, Expr, HigherOrderLowLevel, JoinPointId, ListLiteralElement,
+        ModifyRc, Param, Proc, ProcLayout, Stmt,
+    },
+    layout::{Builtin, Layout, TagIdIntType, UnionLayout},
+};
+
+pub enum UseKind {
+    Ret,
+    TagExpr,
+    TagReuse,
+    TagPayloadArg,
+    ListElemExpr,
+    CallArg,
+    JumpArg,
+    CrashArg,
+    SwitchCond,
+    ExpectCond,
+    ExpectLookup,
+}
+
+pub enum ProblemKind<'a> {
+    RedefinedSymbol {
+        symbol: Symbol,
+        old_line: usize,
+    },
+    NoSymbolInScope {
+        symbol: Symbol,
+    },
+    SymbolUseMismatch {
+        symbol: Symbol,
+        def_layout: Layout<'a>,
+        def_line: usize,
+        use_layout: Layout<'a>,
+        use_kind: UseKind,
+    },
+    SymbolDefMismatch {
+        symbol: Symbol,
+        def_layout: Layout<'a>,
+        expr_layout: Layout<'a>,
+    },
+    BadSwitchConditionLayout {
+        found_layout: Layout<'a>,
+    },
+    DuplicateSwitchBranch {},
+    RedefinedJoinPoint {
+        id: JoinPointId,
+        old_line: usize,
+    },
+    NoJoinPoint {
+        id: JoinPointId,
+    },
+    JumpArityMismatch {
+        def_line: usize,
+        num_needed: usize,
+        num_given: usize,
+    },
+    CallingUndefinedProc {
+        proc_layout: ProcLayout<'a>,
+        similar: Vec<ProcLayout<'a>>,
+    },
+    DuplicateCallSpecId {
+        old_call_line: usize,
+    },
+    StructIndexOOB {
+        structure: Symbol,
+        def_line: usize,
+        index: u64,
+        size: usize,
+    },
+    NotAStruct {
+        structure: Symbol,
+        def_line: usize,
+    },
+    IndexingTagIdNotInUnion {
+        structure: Symbol,
+        def_line: usize,
+        tag_id: u16,
+        union_layout: UnionLayout<'a>,
+    },
+    TagUnionStructIndexOOB {
+        structure: Symbol,
+        def_line: usize,
+        tag_id: u16,
+        index: u64,
+        size: usize,
+    },
+    IndexIntoNullableTag {
+        structure: Symbol,
+        def_line: usize,
+        tag_id: u16,
+        union_layout: UnionLayout<'a>,
+    },
+    UnboxNotABox {
+        symbol: Symbol,
+        def_line: usize,
+    },
+    CreatingTagIdNotInUnion {
+        tag_id: u16,
+        union_layout: UnionLayout<'a>,
+    },
+    CreateTagPayloadMismatch {
+        num_needed: usize,
+        num_given: usize,
+    },
+}
+
+pub struct Problem<'a> {
+    pub proc_key: (Symbol, ProcLayout<'a>),
+    pub line: usize,
+    pub kind: ProblemKind<'a>,
+}
+
+type Procs<'a> = MutMap<(Symbol, ProcLayout<'a>), Proc<'a>>;
+pub type Problems<'a> = Vec<Problem<'a>>;
+
+pub fn check_procs<'a>(arena: &'a Bump, procs: &Procs<'a>) -> Problems<'a> {
+    let mut problems = Default::default();
+    let mut call_spec_ids = Default::default();
+
+    for (proc_key, proc) in procs.iter() {
+        let mut ctx = Ctx {
+            arena,
+            proc_key: *proc_key,
+            ret_layout: proc.ret_layout,
+            problems: &mut problems,
+            call_spec_ids: &mut call_spec_ids,
+            procs,
+            venv: Default::default(),
+            joinpoints: Default::default(),
+            line: 0,
+        };
+        ctx.check_proc(proc);
+    }
+
+    problems
+}
+
+type VEnv<'a> = VecMap<Symbol, (usize, Layout<'a>)>;
+type JoinPoints<'a> = VecMap<JoinPointId, (usize, &'a [Param<'a>])>;
+type CallSpecIds = VecMap<CallSpecId, usize>;
+struct Ctx<'a, 'r> {
+    arena: &'a Bump,
+    problems: &'r mut Problems<'a>,
+    procs: &'r Procs<'a>,
+    call_spec_ids: &'r mut CallSpecIds,
+    proc_key: (Symbol, ProcLayout<'a>),
+    ret_layout: Layout<'a>,
+    venv: VEnv<'a>,
+    joinpoints: JoinPoints<'a>,
+    line: usize,
+}
+
+impl<'a, 'r> Ctx<'a, 'r> {
+    fn alloc<T>(&self, v: T) -> &'a T {
+        self.arena.alloc(v)
+    }
+
+    fn problem(&mut self, problem_kind: ProblemKind<'a>) {
+        self.problems.push(Problem {
+            proc_key: self.proc_key,
+            line: self.line,
+            kind: problem_kind,
+        })
+    }
+
+    fn in_scope<T>(&mut self, f: impl FnOnce(&mut Self) -> T) -> T {
+        let old_venv = self.venv.clone();
+        let r = f(self);
+        self.venv = old_venv;
+        r
+    }
+
+    fn insert(&mut self, symbol: Symbol, layout: Layout<'a>) {
+        if let Some((old_line, _)) = self.venv.insert(symbol, (self.line, layout)) {
+            self.problem(ProblemKind::RedefinedSymbol { symbol, old_line })
+        }
+    }
+
+    fn check_sym_exists(&mut self, symbol: Symbol) {
+        if !self.venv.contains_key(&symbol) {
+            self.problem(ProblemKind::NoSymbolInScope { symbol })
+        }
+    }
+
+    fn with_sym_layout<T>(
+        &mut self,
+        symbol: Symbol,
+        f: impl FnOnce(&mut Self, usize, Layout<'a>) -> Option<T>,
+    ) -> Option<T> {
+        if let Some(&(def_line, layout)) = self.venv.get(&symbol) {
+            f(self, def_line, layout)
+        } else {
+            self.problem(ProblemKind::NoSymbolInScope { symbol });
+            None
+        }
+    }
+
+    fn check_sym_layout(&mut self, symbol: Symbol, expected_layout: Layout<'a>, use_kind: UseKind) {
+        if let Some(&(def_line, layout)) = self.venv.get(&symbol) {
+            if layout != expected_layout {
+                self.problem(ProblemKind::SymbolUseMismatch {
+                    symbol,
+                    def_layout: layout,
+                    def_line,
+                    use_layout: expected_layout,
+                    use_kind,
+                });
+            }
+        } else {
+            self.problem(ProblemKind::NoSymbolInScope { symbol })
+        }
+    }
+
+    fn check_proc(&mut self, proc: &Proc<'a>) {
+        for (lay, arg) in proc.args.iter() {
+            self.insert(*arg, *lay);
+        }
+
+        self.check_stmt(&proc.body)
+    }
+
+    fn check_stmt(&mut self, body: &Stmt<'a>) {
+        self.line += 1;
+
+        match body {
+            Stmt::Let(x, e, x_layout, rest) => {
+                if let Some(e_layout) = self.check_expr(e) {
+                    if e_layout != *x_layout {
+                        self.problem(ProblemKind::SymbolDefMismatch {
+                            symbol: *x,
+                            def_layout: *x_layout,
+                            expr_layout: e_layout,
+                        })
+                    }
+                }
+                self.insert(*x, *x_layout);
+                self.check_stmt(rest);
+            }
+            Stmt::Switch {
+                cond_symbol,
+                cond_layout,
+                branches,
+                default_branch,
+                ret_layout: _,
+            } => {
+                self.check_sym_layout(*cond_symbol, *cond_layout, UseKind::SwitchCond);
+                match cond_layout {
+                    Layout::Builtin(Builtin::Int(int_width)) if !int_width.is_signed() => {}
+                    _ => self.problem(ProblemKind::BadSwitchConditionLayout {
+                        found_layout: *cond_layout,
+                    }),
+                }
+
+                // TODO: need to adjust line numbers as we step through, and depending on whether
+                // the switch is printed as true/false or a proper switch.
+                let mut seen_branches = VecSet::with_capacity(branches.len());
+                for (match_no, _branch_info, branch) in branches.iter() {
+                    if seen_branches.insert(match_no) {
+                        self.problem(ProblemKind::DuplicateSwitchBranch {});
+                    }
+                    self.in_scope(|ctx| ctx.check_stmt(branch));
+                }
+                let (_branch_info, default_branch) = default_branch;
+                self.in_scope(|ctx| ctx.check_stmt(default_branch));
+            }
+            &Stmt::Ret(sym) => self.check_sym_layout(sym, self.ret_layout, UseKind::Ret),
+            &Stmt::Refcounting(rc, rest) => {
+                self.check_modify_rc(rc);
+                self.check_stmt(rest);
+            }
+            &Stmt::Expect {
+                condition,
+                region: _,
+                lookups,
+                layouts,
+                remainder,
+            }
+            | &Stmt::ExpectFx {
+                condition,
+                region: _,
+                lookups,
+                layouts,
+                remainder,
+            } => {
+                self.check_sym_layout(
+                    condition,
+                    Layout::Builtin(Builtin::Bool),
+                    UseKind::ExpectCond,
+                );
+                for (sym, lay) in lookups.iter().zip(layouts) {
+                    self.check_sym_layout(*sym, *lay, UseKind::ExpectLookup);
+                }
+                self.check_stmt(remainder);
+            }
+            &Stmt::Join {
+                id,
+                parameters,
+                body,
+                remainder,
+            } => {
+                if let Some((old_line, _)) = self.joinpoints.insert(id, (self.line, parameters)) {
+                    self.problem(ProblemKind::RedefinedJoinPoint { id, old_line })
+                }
+                self.in_scope(|ctx| ctx.check_stmt(body));
+                self.check_stmt(remainder);
+            }
+            &Stmt::Jump(id, symbols) => {
+                if let Some(&(def_line, parameters)) = self.joinpoints.get(&id) {
+                    if symbols.len() != parameters.len() {
+                        self.problem(ProblemKind::JumpArityMismatch {
+                            def_line,
+                            num_needed: parameters.len(),
+                            num_given: symbols.len(),
+                        });
+                    }
+                    for (arg, param) in symbols.iter().zip(parameters.iter()) {
+                        let Param {
+                            symbol: _,
+                            borrow: _,
+                            layout,
+                        } = param;
+                        self.check_sym_layout(*arg, *layout, UseKind::JumpArg);
+                    }
+                } else {
+                    self.problem(ProblemKind::NoJoinPoint { id });
+                }
+            }
+            &Stmt::Crash(sym, _) => {
+                self.check_sym_layout(sym, Layout::Builtin(Builtin::Str), UseKind::CrashArg)
+            }
+        }
+    }
+
+    fn check_expr(&mut self, e: &Expr<'a>) -> Option<Layout<'a>> {
+        match e {
+            Expr::Literal(_) => None,
+            Expr::Call(call) => self.check_call(call),
+            &Expr::Tag {
+                tag_layout,
+                tag_id,
+                arguments,
+            } => {
+                self.check_tag_expr(tag_layout, tag_id, arguments);
+                Some(Layout::Union(tag_layout))
+            }
+            Expr::Struct(syms) => {
+                for sym in syms.iter() {
+                    self.check_sym_exists(*sym);
+                }
+                // TODO: pass the field order hash down, so we can check this
+                None
+            }
+            &Expr::StructAtIndex {
+                index,
+                // TODO: pass the field order hash down, so we can check this
+                field_layouts: _,
+                structure,
+            } => self.check_struct_at_index(structure, index),
+            Expr::GetTagId {
+                structure: _,
+                union_layout,
+            } => Some(union_layout.tag_id_layout()),
+            &Expr::UnionAtIndex {
+                structure,
+                tag_id,
+                union_layout,
+                index,
+            } => self.check_union_at_index(structure, union_layout, tag_id, index),
+            Expr::Array { elem_layout, elems } => {
+                for elem in elems.iter() {
+                    match elem {
+                        ListLiteralElement::Literal(_) => {}
+                        ListLiteralElement::Symbol(sym) => {
+                            self.check_sym_layout(*sym, *elem_layout, UseKind::ListElemExpr)
+                        }
+                    }
+                }
+                Some(Layout::Builtin(Builtin::List(self.alloc(*elem_layout))))
+            }
+            Expr::EmptyArray => {
+                // TODO don't know what the element layout is
+                None
+            }
+            &Expr::ExprBox { symbol } => self.with_sym_layout(symbol, |ctx, _def_line, layout| {
+                Some(Layout::Boxed(ctx.alloc(layout)))
+            }),
+            &Expr::ExprUnbox { symbol } => {
+                self.with_sym_layout(symbol, |ctx, def_line, layout| match layout {
+                    Layout::Boxed(inner) => Some(*inner),
+                    _ => {
+                        ctx.problem(ProblemKind::UnboxNotABox { symbol, def_line });
+                        None
+                    }
+                })
+            }
+            &Expr::Reuse {
+                symbol,
+                update_tag_id: _,
+                update_mode: _,
+                tag_layout,
+                tag_id: _,
+                arguments: _,
+            } => {
+                self.check_sym_layout(symbol, Layout::Union(tag_layout), UseKind::TagReuse);
+                // TODO also check update arguments
+                Some(Layout::Union(tag_layout))
+            }
+            &Expr::Reset {
+                symbol,
+                update_mode: _,
+            } => {
+                self.check_sym_exists(symbol);
+                None
+            }
+            Expr::RuntimeErrorFunction(_) => None,
+        }
+    }
+
+    fn check_struct_at_index(&mut self, structure: Symbol, index: u64) -> Option<Layout<'a>> {
+        self.with_sym_layout(structure, |ctx, def_line, layout| match layout {
+            Layout::Struct { field_layouts, .. } => {
+                if index as usize >= field_layouts.len() {
+                    ctx.problem(ProblemKind::StructIndexOOB {
+                        structure,
+                        def_line,
+                        index,
+                        size: field_layouts.len(),
+                    });
+                    None
+                } else {
+                    Some(field_layouts[index as usize])
+                }
+            }
+            _ => {
+                ctx.problem(ProblemKind::NotAStruct {
+                    structure,
+                    def_line,
+                });
+                None
+            }
+        })
+    }
+
+    fn check_union_at_index(
+        &mut self,
+        structure: Symbol,
+        union_layout: UnionLayout<'a>,
+        tag_id: u16,
+        index: u64,
+    ) -> Option<Layout<'a>> {
+        self.with_sym_layout(structure, |ctx, def_line, _layout| {
+            ctx.check_sym_layout(structure, Layout::Union(union_layout), UseKind::TagExpr);
+
+            match get_tag_id_payloads(union_layout, tag_id) {
+                TagPayloads::IdNotInUnion => {
+                    ctx.problem(ProblemKind::IndexingTagIdNotInUnion {
+                        structure,
+                        def_line,
+                        tag_id,
+                        union_layout,
+                    });
+                    None
+                }
+                TagPayloads::Payloads(payloads) => {
+                    if index as usize >= payloads.len() {
+                        ctx.problem(ProblemKind::TagUnionStructIndexOOB {
+                            structure,
+                            def_line,
+                            tag_id,
+                            index,
+                            size: payloads.len(),
+                        });
+                        None
+                    } else {
+                        Some(payloads[index as usize])
+                    }
+                }
+            }
+        })
+    }
+
+    fn check_call(&mut self, call: &Call<'a>) -> Option<Layout<'a>> {
+        let Call {
+            call_type,
+            arguments,
+        } = call;
+
+        match call_type {
+            CallType::ByName {
+                name,
+                ret_layout,
+                arg_layouts,
+                specialization_id,
+            } => {
+                let proc_layout = ProcLayout {
+                    arguments: arg_layouts,
+                    result: **ret_layout,
+                    captures_niche: name.captures_niche(),
+                };
+                if !self.procs.contains_key(&(name.name(), proc_layout)) {
+                    let similar = self
+                        .procs
+                        .keys()
+                        .filter(|(sym, _)| *sym == name.name())
+                        .map(|(_, lay)| *lay)
+                        .collect();
+                    self.problem(ProblemKind::CallingUndefinedProc {
+                        proc_layout,
+                        similar,
+                    });
+                }
+                for (arg, wanted_layout) in arguments.iter().zip(arg_layouts.iter()) {
+                    self.check_sym_layout(*arg, *wanted_layout, UseKind::CallArg);
+                }
+                if let Some(old_call_line) =
+                    self.call_spec_ids.insert(*specialization_id, self.line)
+                {
+                    self.problem(ProblemKind::DuplicateCallSpecId { old_call_line });
+                }
+                Some(**ret_layout)
+            }
+            CallType::HigherOrder(HigherOrderLowLevel {
+                op: _,
+                closure_env_layout: _,
+                update_mode: _,
+                passed_function: _,
+            }) => {
+                // TODO
+                None
+            }
+            CallType::Foreign {
+                foreign_symbol: _,
+                ret_layout,
+            } => Some(**ret_layout),
+            CallType::LowLevel {
+                op: _,
+                update_mode: _,
+            } => None,
+        }
+    }
+
+    fn check_tag_expr(&mut self, union_layout: UnionLayout<'a>, tag_id: u16, arguments: &[Symbol]) {
+        match get_tag_id_payloads(union_layout, tag_id) {
+            TagPayloads::IdNotInUnion => {
+                self.problem(ProblemKind::CreatingTagIdNotInUnion {
+                    tag_id,
+                    union_layout,
+                });
+            }
+            TagPayloads::Payloads(payloads) => {
+                if arguments.len() != payloads.len() {
+                    self.problem(ProblemKind::CreateTagPayloadMismatch {
+                        num_needed: payloads.len(),
+                        num_given: arguments.len(),
+                    });
+                }
+                for (arg, wanted_layout) in arguments.iter().zip(payloads.iter()) {
+                    self.check_sym_layout(*arg, *wanted_layout, UseKind::TagPayloadArg);
+                }
+            }
+        }
+    }
+
+    fn check_modify_rc(&mut self, rc: ModifyRc) {
+        match rc {
+            ModifyRc::Inc(sym, _) | ModifyRc::Dec(sym) | ModifyRc::DecRef(sym) => {
+                // TODO: also check that sym layout needs refcounting
+                self.check_sym_exists(sym);
+            }
+        }
+    }
+}
+
+enum TagPayloads<'a> {
+    IdNotInUnion,
+    Payloads(&'a [Layout<'a>]),
+}
+
+fn get_tag_id_payloads<'a>(union_layout: UnionLayout<'a>, tag_id: TagIdIntType) -> TagPayloads<'a> {
+    macro_rules! check_tag_id_oob {
+        ($len:expr) => {
+            if tag_id as usize >= $len {
+                return TagPayloads::IdNotInUnion;
+            }
+        };
+    }
+
+    match union_layout {
+        UnionLayout::NonRecursive(union) => {
+            check_tag_id_oob!(union.len());
+            let payloads = union[tag_id as usize];
+            TagPayloads::Payloads(payloads)
+        }
+        UnionLayout::Recursive(union) => {
+            check_tag_id_oob!(union.len());
+            let payloads = union[tag_id as usize];
+            TagPayloads::Payloads(payloads)
+        }
+        UnionLayout::NonNullableUnwrapped(payloads) => {
+            if tag_id != 0 {
+                TagPayloads::IdNotInUnion
+            } else {
+                TagPayloads::Payloads(payloads)
+            }
+        }
+        UnionLayout::NullableWrapped {
+            nullable_id,
+            other_tags,
+        } => {
+            if tag_id == nullable_id {
+                TagPayloads::IdNotInUnion
+            } else {
+                check_tag_id_oob!(other_tags.len());
+                let payloads = other_tags[tag_id as usize];
+                TagPayloads::Payloads(payloads)
+            }
+        }
+        UnionLayout::NullableUnwrapped {
+            nullable_id,
+            other_fields,
+        } => {
+            if tag_id == nullable_id as _ {
+                TagPayloads::IdNotInUnion
+            } else {
+                check_tag_id_oob!(2);
+                TagPayloads::Payloads(other_fields)
+            }
+        }
+    }
+}

--- a/crates/compiler/mono/src/debug.rs
+++ b/crates/compiler/mono/src/debug.rs
@@ -1,0 +1,5 @@
+mod checker;
+mod report;
+
+pub use checker::{check_procs, Problem, Problems};
+pub use report::format_problems;

--- a/crates/compiler/mono/src/debug/checker.rs
+++ b/crates/compiler/mono/src/debug/checker.rs
@@ -194,8 +194,16 @@ impl<'a, 'r> Ctx<'a, 'r> {
         r
     }
 
-    fn resolve(&mut self, layout: Layout<'a>) -> Layout<'a> {
-        layout.runtime_representation(self.interner)
+    fn resolve(&mut self, mut layout: Layout<'a>) -> Layout<'a> {
+        // Note that we are more aggressive than the usual `runtime_representation`
+        // here because we need strict equality, and so cannot unwrap lambda sets
+        // lazily.
+        loop {
+            match layout {
+                Layout::LambdaSet(ls) => layout = ls.runtime_representation(self.interner),
+                layout => return layout,
+            }
+        }
     }
 
     fn insert(&mut self, symbol: Symbol, layout: Layout<'a>) {

--- a/crates/compiler/mono/src/debug/report.rs
+++ b/crates/compiler/mono/src/debug/report.rs
@@ -72,7 +72,14 @@ where
     let header = format_header(f, title);
     let proc_loc = format_proc_spec(f, interns, interner, proc.name.name(), proc_layout);
 
-    stack(f, [header, proc_loc, interpolated_docs])
+    stack(
+        f,
+        [
+            header,
+            f.concat([f.reflow("in "), proc_loc]),
+            interpolated_docs,
+        ],
+    )
 }
 
 fn format_sourced_doc<'d>(f: &'d Arena<'d>, line: usize, source: &str, doc: Doc<'d>) -> Doc<'d> {
@@ -89,7 +96,7 @@ fn format_sourced_doc<'d>(f: &'d Arena<'d>, line: usize, source: &str, doc: Doc<
             .append(f.text(if line_no == line { "> " } else { "  " }))
             .append(f.text(line_src.to_string()))
     });
-    let pretty_lines = stack(f, pretty_lines);
+    let pretty_lines = f.intersperse(pretty_lines, f.hardline());
     stack(f, [pretty_lines, doc])
 }
 
@@ -463,7 +470,7 @@ where
         f.reflow(", "),
     );
     let fun = f.concat([
-        args,
+        f.concat([f.reflow("("), args, f.reflow(")")]),
         f.reflow(" -> "),
         result.to_doc(f, interner, Parens::NotNeeded),
     ]);

--- a/crates/compiler/mono/src/debug/report.rs
+++ b/crates/compiler/mono/src/debug/report.rs
@@ -1,0 +1,490 @@
+use std::fmt::Display;
+
+use roc_intern::Interner;
+use roc_module::symbol::{Interns, Symbol};
+use ven_pretty::{Arena, DocAllocator, DocBuilder};
+
+use crate::{
+    ir::{Parens, ProcLayout},
+    layout::{CapturesNiche, Layout},
+};
+
+use super::{
+    checker::{ProblemKind, UseKind},
+    Problem, Problems,
+};
+
+pub fn format_problems<'a, I>(
+    interns: &Interns,
+    interner: &I,
+    problems: Problems<'a>,
+) -> impl Display
+where
+    I: Interner<'a, Layout<'a>>,
+{
+    let Problems(problems) = problems;
+    let f = Arena::new();
+    let problem_docs = problems
+        .into_iter()
+        .map(|p| format_problem(&f, interns, interner, p));
+    let all = f.intersperse(problem_docs, f.hardline());
+    all.1.pretty(80).to_string()
+}
+
+type Doc<'d> = DocBuilder<'d, Arena<'d>>;
+
+const GUTTER_BAR: &str = "│";
+const HEADER_WIDTH: usize = 80;
+
+fn format_problem<'a, 'd, I>(
+    f: &'d Arena<'d>,
+    interns: &'d Interns,
+    interner: &'d I,
+    problem: Problem<'a>,
+) -> Doc<'d>
+where
+    'a: 'd,
+    I: Interner<'a, Layout<'a>>,
+{
+    let Problem {
+        proc,
+        proc_layout,
+        line,
+        kind,
+    } = problem;
+
+    let (title, mut docs, last_doc) = format_kind(f, interns, interner, kind);
+    docs.push((line, last_doc));
+    docs.sort_by_key(|(line, _)| *line);
+
+    let src = proc
+        .to_doc(f, interner, Parens::NotNeeded)
+        .1
+        .pretty(80)
+        .to_string();
+
+    let interpolated_docs = stack(
+        f,
+        docs.into_iter()
+            .map(|(line, doc)| format_sourced_doc(f, line, &src, doc)),
+    );
+
+    let header = format_header(f, title);
+    let proc_loc = format_proc_spec(f, interns, interner, proc.name.name(), proc_layout);
+
+    stack(f, [header, proc_loc, interpolated_docs])
+}
+
+fn format_sourced_doc<'d>(f: &'d Arena<'d>, line: usize, source: &str, doc: Doc<'d>) -> Doc<'d> {
+    let start_at = line.saturating_sub(1);
+    let source_lines = source.lines().skip(start_at).take(3);
+    let max_line_no_width = (start_at.to_string().len()).max((start_at + 3).to_string().len());
+    let pretty_lines = source_lines.enumerate().map(|(i, line_src)| {
+        let line_no = start_at + i;
+        let line_no_s = line_no.to_string();
+        let line_no_len = line_no_s.len();
+        f.text(line_no_s)
+            .append(f.text(" ".repeat(max_line_no_width - line_no_len)))
+            .append(f.text(GUTTER_BAR))
+            .append(f.text(if line_no == line { "> " } else { "  " }))
+            .append(f.text(line_src.to_string()))
+    });
+    let pretty_lines = stack(f, pretty_lines);
+    stack(f, [pretty_lines, doc])
+}
+
+fn format_header<'d>(f: &'d Arena<'d>, title: &str) -> Doc<'d> {
+    let title_width = title.len() + 4;
+    let header = f.text(format!(
+        "── {} {}",
+        title,
+        "─".repeat(HEADER_WIDTH - title_width)
+    ));
+    header
+}
+
+fn format_kind<'a, 'd, I>(
+    f: &'d Arena<'d>,
+    interns: &'d Interns,
+    interner: &I,
+    kind: ProblemKind<'a>,
+) -> (&'static str, Vec<(usize, Doc<'d>)>, Doc<'d>)
+where
+    I: Interner<'a, Layout<'a>>,
+{
+    let title;
+    let docs_before;
+    let doc = match kind {
+        ProblemKind::RedefinedSymbol { symbol, old_line } => {
+            title = "REDEFINED SYMBOL";
+            docs_before = vec![(
+                old_line,
+                f.concat([
+                    f.as_string(symbol.as_str(interns)),
+                    f.reflow(" first defined here"),
+                ]),
+            )];
+            f.concat([
+                f.as_string(symbol.as_str(interns)),
+                f.reflow(" re-defined here"),
+            ])
+        }
+        ProblemKind::NoSymbolInScope { symbol } => {
+            title = "SYMBOL NOT DEFINED";
+            docs_before = vec![];
+            f.concat([
+                f.as_string(symbol.as_str(interns)),
+                f.reflow(" not found in the present scope"),
+            ])
+        }
+        ProblemKind::SymbolUseMismatch {
+            symbol,
+            def_layout,
+            def_line,
+            use_layout,
+            use_kind,
+        } => {
+            title = "SYMBOL LAYOUT DOESN'T MATCH ITS USE";
+            docs_before = vec![(
+                def_line,
+                f.concat([
+                    f.as_string(symbol.as_str(interns)),
+                    f.reflow(" defined here with layout "),
+                    def_layout.to_doc(f, interner, Parens::NotNeeded),
+                ]),
+            )];
+            f.concat([
+                f.as_string(symbol.as_str(interns)),
+                f.reflow(" used as a "),
+                f.reflow(format_use_kind(use_kind)),
+                f.reflow(" here with layout "),
+                use_layout.to_doc(f, interner, Parens::NotNeeded),
+            ])
+        }
+        ProblemKind::SymbolDefMismatch {
+            symbol,
+            def_layout,
+            expr_layout,
+        } => {
+            title = "SYMBOL INITIALIZER HAS THE WRONG LAYOUT";
+            docs_before = vec![];
+            f.concat([
+                f.as_string(symbol.as_str(interns)),
+                f.reflow(" is defined as "),
+                def_layout.to_doc(f, interner, Parens::NotNeeded),
+                f.reflow(" but its initializer is "),
+                expr_layout.to_doc(f, interner, Parens::NotNeeded),
+            ])
+        }
+        ProblemKind::BadSwitchConditionLayout { found_layout } => {
+            title = "BAD SWITCH CONDITION LAYOUT";
+            docs_before = vec![];
+            f.concat([
+                f.reflow("This switch condition is a "),
+                found_layout.to_doc(f, interner, Parens::NotNeeded),
+            ])
+        }
+        ProblemKind::DuplicateSwitchBranch {} => {
+            title = "DUPLICATE SWITCH BRANCH";
+            docs_before = vec![];
+            f.reflow("The match of switch branch is reached earlier")
+        }
+        ProblemKind::RedefinedJoinPoint { id, old_line } => {
+            title = "DUPLICATE JOIN POINT";
+            docs_before = vec![(
+                old_line,
+                f.concat([
+                    f.reflow("The join point "),
+                    f.as_string(id.0),
+                    f.reflow(" was previously defined here"),
+                ]),
+            )];
+            f.reflow("and is redefined here")
+        }
+        ProblemKind::NoJoinPoint { id } => {
+            title = "JOIN POINT NOT DEFINED";
+            docs_before = vec![];
+            f.concat([
+                f.reflow("The join point "),
+                f.as_string(id.0),
+                f.reflow(" was not found in the present scope"),
+            ])
+        }
+        ProblemKind::JumpArityMismatch {
+            def_line,
+            num_needed,
+            num_given,
+        } => {
+            title = "WRONG NUMBER OF ARGUMENTS IN JUMP";
+            docs_before = vec![(
+                def_line,
+                f.concat([
+                    f.reflow("This join pont needs "),
+                    f.as_string(num_needed),
+                    f.reflow(" arguments"),
+                ]),
+            )];
+            f.concat([
+                f.reflow("but this jump only gives it "),
+                f.as_string(num_given),
+            ])
+        }
+        ProblemKind::CallingUndefinedProc {
+            symbol,
+            proc_layout,
+            similar,
+        } => {
+            title = "PROC SPECIALIZATION NOT DEFINED";
+            docs_before = vec![];
+            let no_spec_doc = stack(
+                f,
+                [
+                    f.reflow("No specialization"),
+                    format_proc_spec(f, interns, interner, symbol, proc_layout),
+                    f.reflow("was found"),
+                ],
+            );
+            let similar_doc = if similar.is_empty() {
+                f.nil()
+            } else {
+                let similars = similar
+                    .into_iter()
+                    .map(|other| format_proc_spec(f, interns, interner, symbol, other));
+                stack(
+                    f,
+                    [f.concat([
+                        f.reflow("The following specializations of "),
+                        f.as_string(symbol.as_str(interns)),
+                        f.reflow(" were built:"),
+                        stack(f, similars),
+                    ])],
+                )
+            };
+            stack(f, [no_spec_doc, similar_doc])
+        }
+        ProblemKind::DuplicateCallSpecId { old_call_line } => {
+            title = "DUPLICATE CALL SPEC ID";
+            docs_before = vec![(old_call_line, f.reflow("This call has a specialization ID"))];
+            f.reflow("...that is the same as the specialization ID of the call here")
+        }
+        ProblemKind::StructIndexOOB {
+            structure,
+            def_line,
+            index,
+            size,
+        } => {
+            title = "STRUCT INDEX IS OUT-OF-BOUNDS";
+            docs_before = vec![(
+                def_line,
+                f.concat([
+                    f.reflow("The struct "),
+                    f.as_string(structure.as_str(interns)),
+                    f.reflow(" defined here has "),
+                    f.as_string(size),
+                    f.reflow(" fields"),
+                ]),
+            )];
+            f.concat([
+                f.reflow("but is being indexed into field "),
+                f.as_string(index),
+            ])
+        }
+        ProblemKind::NotAStruct {
+            structure,
+            def_line,
+        } => {
+            title = "SYMBOL IS NOT A STRUCT";
+            docs_before = vec![(
+                def_line,
+                f.concat([
+                    f.reflow("The value "),
+                    f.as_string(structure.as_str(interns)),
+                    f.reflow(" defined here"),
+                ]),
+            )];
+            f.reflow("cannot be used as a structure here")
+        }
+        ProblemKind::IndexingTagIdNotInUnion {
+            structure,
+            def_line,
+            tag_id,
+            union_layout,
+        } => {
+            title = "TAG ID NOT IN UNION";
+            docs_before = vec![(
+                def_line,
+                f.concat([
+                    f.reflow("The union "),
+                    f.as_string(structure.as_str(interns)),
+                    f.reflow(" defined here has layout "),
+                    Layout::Union(union_layout).to_doc(f, interner, Parens::NotNeeded),
+                ]),
+            )];
+            f.concat([f.reflow("which has no tag of id "), f.as_string(tag_id)])
+        }
+        ProblemKind::TagUnionStructIndexOOB {
+            structure,
+            def_line,
+            tag_id,
+            index,
+            size,
+        } => {
+            title = "UNION ID AND PAYLOAD INDEX IS OUT-OF-BOUNDS";
+            docs_before = vec![(
+                def_line,
+                f.concat([
+                    f.reflow("The union "),
+                    f.as_string(structure.as_str(interns)),
+                    f.reflow(" defined here has "),
+                    f.as_string(size),
+                    f.reflow(" payloads at ID "),
+                    f.as_string(tag_id),
+                ]),
+            )];
+            f.concat([
+                f.reflow("but is being indexed into field "),
+                f.as_string(index),
+                f.reflow(" here"),
+            ])
+        }
+        ProblemKind::IndexIntoNullableTag {
+            structure,
+            def_line,
+            tag_id,
+            union_layout,
+        } => {
+            title = "INDEX INTO NULLABLE TAG";
+            docs_before = vec![(
+                def_line,
+                f.concat([
+                    f.reflow("The union "),
+                    f.as_string(structure.as_str(interns)),
+                    f.reflow(" defined here has layout "),
+                    Layout::Union(union_layout).to_doc(f, interner, Parens::NotNeeded),
+                ]),
+            )];
+            f.concat([
+                f.reflow("but is being indexed into the nullable variant "),
+                f.as_string(tag_id),
+                f.reflow(" here"),
+            ])
+        }
+        ProblemKind::UnboxNotABox { symbol, def_line } => {
+            title = "ATTEMPTING TO UNBOX A NON-BOX";
+            docs_before = vec![(
+                def_line,
+                f.concat([
+                    f.as_string(symbol.as_str(interns)),
+                    f.reflow(" is not a box"),
+                ]),
+            )];
+            f.reflow("but is being unboxed here")
+        }
+        ProblemKind::CreatingTagIdNotInUnion {
+            tag_id,
+            union_layout,
+        } => {
+            title = "NO SUCH ID FOR TAG UNION";
+            docs_before = vec![];
+            f.concat([
+                f.reflow("The variant "),
+                f.as_string(tag_id),
+                f.reflow(" is outside the target union layout "),
+                Layout::Union(union_layout).to_doc(f, interner, Parens::NotNeeded),
+            ])
+        }
+        ProblemKind::CreateTagPayloadMismatch {
+            num_needed,
+            num_given,
+        } => {
+            title = "WRONG NUMBER OF ARGUMENTS IN TAG UNION";
+            docs_before = vec![];
+            f.concat([
+                f.reflow("This tag union payload needs "),
+                f.as_string(num_needed),
+                f.reflow(" values, but is only given "),
+                f.as_string(num_given),
+            ])
+        }
+    };
+    (title, docs_before, doc)
+}
+
+fn format_use_kind(use_kind: UseKind) -> &'static str {
+    match use_kind {
+        UseKind::Ret => "return value",
+        UseKind::TagExpr => "tag constructor",
+        UseKind::TagReuse => "tag reuse",
+        UseKind::TagPayloadArg => "tag's payload",
+        UseKind::ListElemExpr => "list element",
+        UseKind::CallArg => "call argument",
+        UseKind::JumpArg => "jump argument",
+        UseKind::CrashArg => "crash message",
+        UseKind::SwitchCond => "switch condition",
+        UseKind::ExpectCond => "expect condition",
+        UseKind::ExpectLookup => "lookup for an expect",
+    }
+}
+
+fn format_proc_spec<'a, 'd, I>(
+    f: &'d Arena<'d>,
+    interns: &'d Interns,
+    interner: &I,
+    symbol: Symbol,
+    proc_layout: ProcLayout<'a>,
+) -> Doc<'d>
+where
+    I: Interner<'a, Layout<'a>>,
+{
+    f.concat([
+        f.as_string(symbol.as_str(interns)),
+        f.reflow(" : "),
+        format_proc_layout(f, interner, proc_layout),
+    ])
+}
+
+fn format_proc_layout<'a, 'd, I>(
+    f: &'d Arena<'d>,
+    interner: &I,
+    proc_layout: ProcLayout<'a>,
+) -> Doc<'d>
+where
+    I: Interner<'a, Layout<'a>>,
+{
+    let ProcLayout {
+        arguments,
+        result,
+        captures_niche,
+    } = proc_layout;
+    let args = f.intersperse(
+        arguments
+            .iter()
+            .map(|a| a.to_doc(f, interner, Parens::InFunction)),
+        f.reflow(", "),
+    );
+    let fun = f.concat([
+        args,
+        f.reflow(" -> "),
+        result.to_doc(f, interner, Parens::NotNeeded),
+    ]);
+    let niche = if captures_niche == CapturesNiche::no_niche() {
+        f.reflow("(no niche)")
+    } else {
+        f.concat([
+            f.reflow("(niche {"),
+            f.intersperse(
+                captures_niche
+                    .0
+                    .iter()
+                    .map(|c| c.to_doc(f, interner, Parens::NotNeeded)),
+                f.reflow(", "),
+            ),
+            f.reflow("})"),
+        ])
+    };
+    f.concat([fun, f.space(), niche])
+}
+
+fn stack<'d>(f: &'d Arena<'d>, docs: impl IntoIterator<Item = Doc<'d>>) -> Doc<'d> {
+    f.intersperse(docs, f.line().append(f.line()))
+}

--- a/crates/compiler/mono/src/debug/report.rs
+++ b/crates/compiler/mono/src/debug/report.rs
@@ -102,12 +102,11 @@ fn format_sourced_doc<'d>(f: &'d Arena<'d>, line: usize, source: &str, doc: Doc<
 
 fn format_header<'d>(f: &'d Arena<'d>, title: &str) -> Doc<'d> {
     let title_width = title.len() + 4;
-    let header = f.text(format!(
+    f.text(format!(
         "── {} {}",
         title,
         "─".repeat(HEADER_WIDTH - title_width)
-    ));
-    header
+    ))
 }
 
 fn format_kind<'a, 'd, I>(

--- a/crates/compiler/mono/src/layout.rs
+++ b/crates/compiler/mono/src/layout.rs
@@ -1154,7 +1154,7 @@ struct SetElement<'a> {
 
 impl std::fmt::Debug for SetElement<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let symbol_string = crate::ir::symbol_to_doc_string(self.symbol);
+        let symbol_string = crate::ir::symbol_to_doc_string(self.symbol, false);
 
         write!(f, "( {}, {:?})", symbol_string, self.layout)
     }

--- a/crates/compiler/mono/src/layout.rs
+++ b/crates/compiler/mono/src/layout.rs
@@ -1204,7 +1204,7 @@ impl std::fmt::Debug for LambdaSet<'_> {
 ///
 /// See also https://github.com/roc-lang/roc/issues/3336.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
-pub struct CapturesNiche<'a>(&'a [Layout<'a>]);
+pub struct CapturesNiche<'a>(pub(crate) &'a [Layout<'a>]);
 
 impl CapturesNiche<'_> {
     pub fn no_niche() -> Self {

--- a/crates/compiler/mono/src/lib.rs
+++ b/crates/compiler/mono/src/lib.rs
@@ -22,4 +22,4 @@ pub mod tail_recursion;
 //#[allow(clippy::ptr_arg)]
 pub mod decision_tree;
 
-pub mod checker;
+pub mod debug;

--- a/crates/compiler/mono/src/lib.rs
+++ b/crates/compiler/mono/src/lib.rs
@@ -21,3 +21,5 @@ pub mod tail_recursion;
 // For now, following this warning's advice will lead to nasty type inference errors.
 //#[allow(clippy::ptr_arg)]
 pub mod decision_tree;
+
+pub mod checker;

--- a/crates/compiler/test_mono/src/tests.rs
+++ b/crates/compiler/test_mono/src/tests.rs
@@ -180,7 +180,7 @@ fn verify_procedures<'a>(
 
     let mut procs_string = procedures
         .values()
-        .map(|proc| proc.to_pretty(&interner, 200))
+        .map(|proc| proc.to_pretty(&interner, 200, false))
         .collect::<Vec<_>>();
 
     let main_fn = procs_string.swap_remove(index);

--- a/crates/compiler/test_mono/src/tests.rs
+++ b/crates/compiler/test_mono/src/tests.rs
@@ -148,7 +148,7 @@ fn compiles_to_ir(test_name: &str, src: &str, no_check: bool) {
     let main_fn_symbol = exposed_to_host.values.keys().copied().next().unwrap();
 
     if !no_check {
-        check_procedures(&arena, &interns, &layout_interner, &procedures);
+        check_procedures(arena, &interns, &layout_interner, &procedures);
     }
 
     verify_procedures(test_name, layout_interner, procedures, main_fn_symbol);

--- a/crates/compiler/test_mono/src/tests.rs
+++ b/crates/compiler/test_mono/src/tests.rs
@@ -76,7 +76,7 @@ fn promote_expr_to_module(src: &str) -> String {
     buffer
 }
 
-fn compiles_to_ir(test_name: &str, src: &str) {
+fn compiles_to_ir(test_name: &str, src: &str, no_check: bool) {
     use roc_packaging::cache::RocCacheDir;
     use std::path::PathBuf;
 
@@ -147,7 +147,9 @@ fn compiles_to_ir(test_name: &str, src: &str) {
 
     let main_fn_symbol = exposed_to_host.values.keys().copied().next().unwrap();
 
-    check_procedures(&arena, &interns, &layout_interner, &procedures);
+    if !no_check {
+        check_procedures(&arena, &interns, &layout_interner, &procedures);
+    }
 
     verify_procedures(test_name, layout_interner, procedures, main_fn_symbol);
 }
@@ -583,7 +585,7 @@ fn record_optional_field_function_use_default() {
     "#
 }
 
-#[mono_test]
+#[mono_test(no_check)]
 fn quicksort_help() {
     // do we still need with_larger_debug_stack?
     r#"
@@ -1301,7 +1303,7 @@ fn issue_2583_specialize_errors_behind_unified_branches() {
     )
 }
 
-#[mono_test]
+#[mono_test(no_check)]
 fn issue_2810() {
     indoc!(
         r#"

--- a/crates/compiler/test_mono_macros/src/lib.rs
+++ b/crates/compiler/test_mono_macros/src/lib.rs
@@ -1,11 +1,14 @@
 //! Macros for use in `test_mono`.
 extern crate proc_macro;
 
-use proc_macro::TokenStream;
+use proc_macro::{TokenStream, TokenTree};
 use quote::quote;
 
 #[proc_macro_attribute]
-pub fn mono_test(_args: TokenStream, item: TokenStream) -> TokenStream {
+pub fn mono_test(args: TokenStream, item: TokenStream) -> TokenStream {
+    let no_check = args
+        .into_iter()
+        .any(|tok| matches!(tok, TokenTree::Ident(id) if id.to_string() == "no_check"));
     let task_fn = syn::parse_macro_input!(item as syn::ItemFn);
 
     let args = task_fn.sig.inputs.clone();
@@ -21,7 +24,7 @@ pub fn mono_test(_args: TokenStream, item: TokenStream) -> TokenStream {
         #[test]
         #(#attributes)*
         #visibility fn #name(#args) {
-            compiles_to_ir(#name_str, #body);
+            compiles_to_ir(#name_str, #body, #no_check);
 
         }
     };


### PR DESCRIPTION
Implements a type-checker for the IR. The checker is primarily concerned with making sure layouts align everywhere a symbol is defined and used.

The checker output is pretty; for example,

```
── SYMBOL LAYOUT DOESN'T MATCH ITS USE ─────────────────────────────────────────

in quicksortHelp : (List I64, I64, I64) -> List I64 (no niche)

8 │              let `#UserApp.IdentId(5)` : I64 = StructAtIndex 0 `#UserApp.IdentId(21)`;
9 │>             let `#UserApp.IdentId(6)` : List [] = StructAtIndex 1 `#UserApp.IdentId(21)`;
10│              inc `#UserApp.IdentId(6)`;

#UserApp.partitioned defined here with layout List []

13│              let `#UserApp.IdentId(19)` : I64 = CallByName `Num.sub` `#UserApp.IdentId(5)` `#UserApp.IdentId(20)`;
14│>             let `#UserApp.IdentId(16)` : List I64 = CallByName `#UserApp.f` `#UserApp.IdentId(6)` `#UserApp.x` `#UserApp.IdentId(19)`;
15│              let `#UserApp.IdentId(18)` : I64 = 1i64;

#UserApp.partitioned used as a call argument here with layout List I64
```

The goal is to turn this on for all mono tests (mostly done in this PR) and to check generated IR when a debug flag is enabled. I hope this will making debugging the IR easier.

Currently only two tests in mono have the checker disabled

- One (the example above) is an actual codegen bug we need to fix
- Another is a current limitation of a checker, where nested recursive pointers may not be fully expanded