### PR TITLE
Switch to more expressive list.range

### DIFF
--- a/crates/compiler/builtins/roc/Json.roc
+++ b/crates/compiler/builtins/roc/Json.roc
@@ -205,7 +205,7 @@ takeWhile = \list, predicate ->
     helper { taken: [], rest: list }
 
 digits : List U8
-digits = List.range {start: At '0', end: At '9'}
+digits = List.range { start: At '0', end: At '9' }
 
 takeDigits = \bytes ->
     takeWhile bytes \n -> List.contains digits n

--- a/crates/compiler/builtins/roc/Json.roc
+++ b/crates/compiler/builtins/roc/Json.roc
@@ -205,7 +205,7 @@ takeWhile = \list, predicate ->
     helper { taken: [], rest: list }
 
 digits : List U8
-digits = List.range '0' ('9' + 1)
+digits = List.range {start: At '0', end: At '9'}
 
 takeDigits = \bytes ->
     takeWhile bytes \n -> List.contains digits n

--- a/crates/compiler/test_gen/src/gen_list.rs
+++ b/crates/compiler/test_gen/src/gen_list.rs
@@ -2810,22 +2810,6 @@ fn cleanup_because_exception() {
 
 #[test]
 #[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
-fn list_range() {
-    assert_evals_to!(
-        "List.range 0 -1",
-        RocList::<i64>::from_slice(&[]),
-        RocList<i64>
-    );
-    assert_evals_to!("List.range 0 0", RocList::from_slice(&[0]), RocList<i64>);
-    assert_evals_to!(
-        "List.range 0 5",
-        RocList::from_slice(&[0, 1, 2, 3, 4]),
-        RocList<i64>
-    );
-}
-
-#[test]
-#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
 fn list_sort_with() {
     assert_evals_to!(
         "List.sortWith [] Num.compare",

--- a/crates/compiler/test_mono/generated/call_function_in_empty_list.txt
+++ b/crates/compiler/test_mono/generated/call_function_in_empty_list.txt
@@ -1,7 +1,7 @@
 procedure List.5 (#Attr.2, #Attr.3):
-    let List.409 : List {} = lowlevel ListMap { xs: `#Attr.#arg1` } #Attr.2 Test.2 #Attr.3;
+    let List.478 : List {} = lowlevel ListMap { xs: `#Attr.#arg1` } #Attr.2 Test.2 #Attr.3;
     decref #Attr.2;
-    ret List.409;
+    ret List.478;
 
 procedure Test.2 (Test.3):
     let Test.7 : {} = Struct {};

--- a/crates/compiler/test_mono/generated/call_function_in_empty_list_unbound.txt
+++ b/crates/compiler/test_mono/generated/call_function_in_empty_list_unbound.txt
@@ -1,7 +1,7 @@
 procedure List.5 (#Attr.2, #Attr.3):
-    let List.409 : List [] = lowlevel ListMap { xs: `#Attr.#arg1` } #Attr.2 Test.2 #Attr.3;
+    let List.478 : List [] = lowlevel ListMap { xs: `#Attr.#arg1` } #Attr.2 Test.2 #Attr.3;
     decref #Attr.2;
-    ret List.409;
+    ret List.478;
 
 procedure Test.2 (Test.3):
     let Test.7 : {} = Struct {};

--- a/crates/compiler/test_mono/generated/closure_in_list.txt
+++ b/crates/compiler/test_mono/generated/closure_in_list.txt
@@ -1,6 +1,6 @@
 procedure List.6 (#Attr.2):
-    let List.409 : U64 = lowlevel ListLen #Attr.2;
-    ret List.409;
+    let List.478 : U64 = lowlevel ListLen #Attr.2;
+    ret List.478;
 
 procedure Test.1 (Test.5):
     let Test.2 : I64 = 41i64;

--- a/crates/compiler/test_mono/generated/dict.txt
+++ b/crates/compiler/test_mono/generated/dict.txt
@@ -19,59 +19,59 @@ procedure Dict.4 (Dict.505):
     dec Dict.505;
     ret Dict.85;
 
-procedure List.11 (List.113, List.114):
-    let List.410 : List I8 = CallByName List.68 List.114;
-    let List.409 : List I8 = CallByName List.80 List.113 List.114 List.410;
-    ret List.409;
+procedure List.11 (List.114, List.115):
+    let List.479 : List I8 = CallByName List.68 List.115;
+    let List.478 : List I8 = CallByName List.80 List.114 List.115 List.479;
+    ret List.478;
 
-procedure List.11 (List.113, List.114):
-    let List.422 : List U64 = CallByName List.68 List.114;
-    let List.421 : List U64 = CallByName List.80 List.113 List.114 List.422;
-    ret List.421;
-
-procedure List.68 (#Attr.2):
-    let List.420 : List I8 = lowlevel ListWithCapacity #Attr.2;
-    ret List.420;
+procedure List.11 (List.114, List.115):
+    let List.491 : List U64 = CallByName List.68 List.115;
+    let List.490 : List U64 = CallByName List.80 List.114 List.115 List.491;
+    ret List.490;
 
 procedure List.68 (#Attr.2):
-    let List.432 : List U64 = lowlevel ListWithCapacity #Attr.2;
-    ret List.432;
+    let List.489 : List I8 = lowlevel ListWithCapacity #Attr.2;
+    ret List.489;
+
+procedure List.68 (#Attr.2):
+    let List.501 : List U64 = lowlevel ListWithCapacity #Attr.2;
+    ret List.501;
 
 procedure List.71 (#Attr.2, #Attr.3):
-    let List.417 : List I8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
-    ret List.417;
+    let List.486 : List I8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
+    ret List.486;
 
 procedure List.71 (#Attr.2, #Attr.3):
-    let List.429 : List U64 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
-    ret List.429;
+    let List.498 : List U64 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
+    ret List.498;
 
-procedure List.80 (List.433, List.434, List.435):
-    joinpoint List.411 List.115 List.116 List.117:
-        let List.419 : U64 = 0i64;
-        let List.413 : Int1 = CallByName Num.24 List.116 List.419;
-        if List.413 then
-            let List.418 : U64 = 1i64;
-            let List.415 : U64 = CallByName Num.20 List.116 List.418;
-            let List.416 : List I8 = CallByName List.71 List.117 List.115;
-            jump List.411 List.115 List.415 List.416;
+procedure List.80 (List.502, List.503, List.504):
+    joinpoint List.480 List.116 List.117 List.118:
+        let List.488 : U64 = 0i64;
+        let List.482 : Int1 = CallByName Num.24 List.117 List.488;
+        if List.482 then
+            let List.487 : U64 = 1i64;
+            let List.484 : U64 = CallByName Num.20 List.117 List.487;
+            let List.485 : List I8 = CallByName List.71 List.118 List.116;
+            jump List.480 List.116 List.484 List.485;
         else
-            ret List.117;
+            ret List.118;
     in
-    jump List.411 List.433 List.434 List.435;
+    jump List.480 List.502 List.503 List.504;
 
-procedure List.80 (List.441, List.442, List.443):
-    joinpoint List.423 List.115 List.116 List.117:
-        let List.431 : U64 = 0i64;
-        let List.425 : Int1 = CallByName Num.24 List.116 List.431;
-        if List.425 then
-            let List.430 : U64 = 1i64;
-            let List.427 : U64 = CallByName Num.20 List.116 List.430;
-            let List.428 : List U64 = CallByName List.71 List.117 List.115;
-            jump List.423 List.115 List.427 List.428;
+procedure List.80 (List.510, List.511, List.512):
+    joinpoint List.492 List.116 List.117 List.118:
+        let List.500 : U64 = 0i64;
+        let List.494 : Int1 = CallByName Num.24 List.117 List.500;
+        if List.494 then
+            let List.499 : U64 = 1i64;
+            let List.496 : U64 = CallByName Num.20 List.117 List.499;
+            let List.497 : List U64 = CallByName List.71 List.118 List.116;
+            jump List.492 List.116 List.496 List.497;
         else
-            ret List.117;
+            ret List.118;
     in
-    jump List.423 List.441 List.442 List.443;
+    jump List.492 List.510 List.511 List.512;
 
 procedure Num.20 (#Attr.2, #Attr.3):
     let Num.257 : U64 = lowlevel NumSub #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/empty_list_of_function_type.txt
+++ b/crates/compiler/test_mono/generated/empty_list_of_function_type.txt
@@ -2,25 +2,25 @@ procedure Bool.1 ():
     let Bool.23 : Int1 = false;
     ret Bool.23;
 
-procedure List.2 (List.94, List.95):
-    let List.415 : U64 = CallByName List.6 List.94;
-    let List.411 : Int1 = CallByName Num.22 List.95 List.415;
-    if List.411 then
-        let List.413 : {} = CallByName List.66 List.94 List.95;
-        let List.412 : [C {}, C {}] = TagId(1) List.413;
-        ret List.412;
+procedure List.2 (List.95, List.96):
+    let List.484 : U64 = CallByName List.6 List.95;
+    let List.480 : Int1 = CallByName Num.22 List.96 List.484;
+    if List.480 then
+        let List.482 : {} = CallByName List.66 List.95 List.96;
+        let List.481 : [C {}, C {}] = TagId(1) List.482;
+        ret List.481;
     else
-        let List.410 : {} = Struct {};
-        let List.409 : [C {}, C {}] = TagId(0) List.410;
-        ret List.409;
+        let List.479 : {} = Struct {};
+        let List.478 : [C {}, C {}] = TagId(0) List.479;
+        ret List.478;
 
 procedure List.6 (#Attr.2):
-    let List.416 : U64 = lowlevel ListLen #Attr.2;
-    ret List.416;
+    let List.485 : U64 = lowlevel ListLen #Attr.2;
+    ret List.485;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.414 : {} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.414;
+    let List.483 : {} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.483;
 
 procedure Num.22 (#Attr.2, #Attr.3):
     let Num.256 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/encode.txt
+++ b/crates/compiler/test_mono/generated/encode.txt
@@ -1,16 +1,16 @@
-procedure List.4 (List.105, List.106):
-    let List.412 : U64 = 1i64;
-    let List.410 : List U8 = CallByName List.70 List.105 List.412;
-    let List.409 : List U8 = CallByName List.71 List.410 List.106;
-    ret List.409;
+procedure List.4 (List.106, List.107):
+    let List.481 : U64 = 1i64;
+    let List.479 : List U8 = CallByName List.70 List.106 List.481;
+    let List.478 : List U8 = CallByName List.71 List.479 List.107;
+    ret List.478;
 
 procedure List.70 (#Attr.2, #Attr.3):
-    let List.413 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
-    ret List.413;
+    let List.482 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
+    ret List.482;
 
 procedure List.71 (#Attr.2, #Attr.3):
-    let List.411 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
-    ret List.411;
+    let List.480 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
+    ret List.480;
 
 procedure Test.23 (Test.24, Test.35, Test.22):
     let Test.37 : List U8 = CallByName List.4 Test.24 Test.22;

--- a/crates/compiler/test_mono/generated/encode_derived_nested_record_string.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_nested_record_string.txt
@@ -66,237 +66,237 @@ procedure Encode.25 (Encode.100, Encode.101):
     ret Encode.103;
 
 procedure Json.1 ():
-    let Json.394 : {} = Struct {};
-    ret Json.394;
+    let Json.396 : {} = Struct {};
+    ret Json.396;
 
-procedure Json.112 (Json.113, Json.397, Json.111):
-    let Json.430 : I64 = 123i64;
-    let Json.429 : U8 = CallByName Num.125 Json.430;
-    let Json.115 : List U8 = CallByName List.4 Json.113 Json.429;
-    let Json.428 : U64 = CallByName List.6 Json.111;
-    let Json.405 : {List U8, U64} = Struct {Json.115, Json.428};
-    let Json.406 : {} = Struct {};
-    let Json.404 : {List U8, U64} = CallByName List.18 Json.111 Json.405 Json.406;
+procedure Json.112 (Json.113, Json.399, Json.111):
+    let Json.432 : I64 = 123i64;
+    let Json.431 : U8 = CallByName Num.125 Json.432;
+    let Json.115 : List U8 = CallByName List.4 Json.113 Json.431;
+    let Json.430 : U64 = CallByName List.6 Json.111;
+    let Json.407 : {List U8, U64} = Struct {Json.115, Json.430};
+    let Json.408 : {} = Struct {};
+    let Json.406 : {List U8, U64} = CallByName List.18 Json.111 Json.407 Json.408;
     dec Json.111;
-    let Json.117 : List U8 = StructAtIndex 0 Json.404;
+    let Json.117 : List U8 = StructAtIndex 0 Json.406;
     inc Json.117;
-    dec Json.404;
-    let Json.403 : I64 = 125i64;
-    let Json.402 : U8 = CallByName Num.125 Json.403;
-    let Json.401 : List U8 = CallByName List.4 Json.117 Json.402;
-    ret Json.401;
+    dec Json.406;
+    let Json.405 : I64 = 125i64;
+    let Json.404 : U8 = CallByName Num.125 Json.405;
+    let Json.403 : List U8 = CallByName List.4 Json.117 Json.404;
+    ret Json.403;
 
-procedure Json.112 (Json.113, Json.397, Json.111):
-    let Json.470 : I64 = 123i64;
-    let Json.469 : U8 = CallByName Num.125 Json.470;
-    let Json.115 : List U8 = CallByName List.4 Json.113 Json.469;
-    let Json.468 : U64 = CallByName List.6 Json.111;
-    let Json.445 : {List U8, U64} = Struct {Json.115, Json.468};
-    let Json.446 : {} = Struct {};
-    let Json.444 : {List U8, U64} = CallByName List.18 Json.111 Json.445 Json.446;
+procedure Json.112 (Json.113, Json.399, Json.111):
+    let Json.472 : I64 = 123i64;
+    let Json.471 : U8 = CallByName Num.125 Json.472;
+    let Json.115 : List U8 = CallByName List.4 Json.113 Json.471;
+    let Json.470 : U64 = CallByName List.6 Json.111;
+    let Json.447 : {List U8, U64} = Struct {Json.115, Json.470};
+    let Json.448 : {} = Struct {};
+    let Json.446 : {List U8, U64} = CallByName List.18 Json.111 Json.447 Json.448;
     dec Json.111;
-    let Json.117 : List U8 = StructAtIndex 0 Json.444;
+    let Json.117 : List U8 = StructAtIndex 0 Json.446;
     inc Json.117;
-    dec Json.444;
-    let Json.443 : I64 = 125i64;
-    let Json.442 : U8 = CallByName Num.125 Json.443;
-    let Json.441 : List U8 = CallByName List.4 Json.117 Json.442;
-    ret Json.441;
+    dec Json.446;
+    let Json.445 : I64 = 125i64;
+    let Json.444 : U8 = CallByName Num.125 Json.445;
+    let Json.443 : List U8 = CallByName List.4 Json.117 Json.444;
+    ret Json.443;
 
-procedure Json.114 (Json.399, Json.400):
-    let Json.120 : Str = StructAtIndex 0 Json.400;
+procedure Json.114 (Json.401, Json.402):
+    let Json.120 : Str = StructAtIndex 0 Json.402;
     inc Json.120;
-    let Json.121 : Str = StructAtIndex 1 Json.400;
+    let Json.121 : Str = StructAtIndex 1 Json.402;
     inc Json.121;
-    dec Json.400;
-    let Json.118 : List U8 = StructAtIndex 0 Json.399;
+    dec Json.402;
+    let Json.118 : List U8 = StructAtIndex 0 Json.401;
     inc Json.118;
-    let Json.119 : U64 = StructAtIndex 1 Json.399;
-    dec Json.399;
-    let Json.427 : I64 = 34i64;
-    let Json.426 : U8 = CallByName Num.125 Json.427;
-    let Json.424 : List U8 = CallByName List.4 Json.118 Json.426;
-    let Json.425 : List U8 = CallByName Str.12 Json.120;
-    let Json.421 : List U8 = CallByName List.8 Json.424 Json.425;
-    let Json.423 : I64 = 34i64;
-    let Json.422 : U8 = CallByName Num.125 Json.423;
-    let Json.418 : List U8 = CallByName List.4 Json.421 Json.422;
-    let Json.420 : I64 = 58i64;
-    let Json.419 : U8 = CallByName Num.125 Json.420;
-    let Json.416 : List U8 = CallByName List.4 Json.418 Json.419;
-    let Json.417 : {} = Struct {};
-    let Json.122 : List U8 = CallByName Encode.23 Json.416 Json.121 Json.417;
-    joinpoint Json.411 Json.123:
-        let Json.409 : U64 = 1i64;
-        let Json.408 : U64 = CallByName Num.20 Json.119 Json.409;
-        let Json.407 : {List U8, U64} = Struct {Json.123, Json.408};
-        ret Json.407;
+    let Json.119 : U64 = StructAtIndex 1 Json.401;
+    dec Json.401;
+    let Json.429 : I64 = 34i64;
+    let Json.428 : U8 = CallByName Num.125 Json.429;
+    let Json.426 : List U8 = CallByName List.4 Json.118 Json.428;
+    let Json.427 : List U8 = CallByName Str.12 Json.120;
+    let Json.423 : List U8 = CallByName List.8 Json.426 Json.427;
+    let Json.425 : I64 = 34i64;
+    let Json.424 : U8 = CallByName Num.125 Json.425;
+    let Json.420 : List U8 = CallByName List.4 Json.423 Json.424;
+    let Json.422 : I64 = 58i64;
+    let Json.421 : U8 = CallByName Num.125 Json.422;
+    let Json.418 : List U8 = CallByName List.4 Json.420 Json.421;
+    let Json.419 : {} = Struct {};
+    let Json.122 : List U8 = CallByName Encode.23 Json.418 Json.121 Json.419;
+    joinpoint Json.413 Json.123:
+        let Json.411 : U64 = 1i64;
+        let Json.410 : U64 = CallByName Num.20 Json.119 Json.411;
+        let Json.409 : {List U8, U64} = Struct {Json.123, Json.410};
+        ret Json.409;
     in
-    let Json.415 : U64 = 1i64;
-    let Json.412 : Int1 = CallByName Num.24 Json.119 Json.415;
-    if Json.412 then
-        let Json.414 : I64 = 44i64;
-        let Json.413 : U8 = CallByName Num.125 Json.414;
-        let Json.410 : List U8 = CallByName List.4 Json.122 Json.413;
-        jump Json.411 Json.410;
+    let Json.417 : U64 = 1i64;
+    let Json.414 : Int1 = CallByName Num.24 Json.119 Json.417;
+    if Json.414 then
+        let Json.416 : I64 = 44i64;
+        let Json.415 : U8 = CallByName Num.125 Json.416;
+        let Json.412 : List U8 = CallByName List.4 Json.122 Json.415;
+        jump Json.413 Json.412;
     else
-        jump Json.411 Json.122;
+        jump Json.413 Json.122;
 
-procedure Json.114 (Json.399, Json.400):
-    let Json.120 : Str = StructAtIndex 0 Json.400;
+procedure Json.114 (Json.401, Json.402):
+    let Json.120 : Str = StructAtIndex 0 Json.402;
     inc Json.120;
-    let Json.121 : Str = StructAtIndex 1 Json.400;
+    let Json.121 : Str = StructAtIndex 1 Json.402;
     inc Json.121;
-    dec Json.400;
-    let Json.118 : List U8 = StructAtIndex 0 Json.399;
+    dec Json.402;
+    let Json.118 : List U8 = StructAtIndex 0 Json.401;
     inc Json.118;
-    let Json.119 : U64 = StructAtIndex 1 Json.399;
-    dec Json.399;
-    let Json.467 : I64 = 34i64;
-    let Json.466 : U8 = CallByName Num.125 Json.467;
-    let Json.464 : List U8 = CallByName List.4 Json.118 Json.466;
-    let Json.465 : List U8 = CallByName Str.12 Json.120;
-    let Json.461 : List U8 = CallByName List.8 Json.464 Json.465;
-    let Json.463 : I64 = 34i64;
-    let Json.462 : U8 = CallByName Num.125 Json.463;
-    let Json.458 : List U8 = CallByName List.4 Json.461 Json.462;
-    let Json.460 : I64 = 58i64;
-    let Json.459 : U8 = CallByName Num.125 Json.460;
-    let Json.456 : List U8 = CallByName List.4 Json.458 Json.459;
-    let Json.457 : {} = Struct {};
-    let Json.122 : List U8 = CallByName Encode.23 Json.456 Json.121 Json.457;
-    joinpoint Json.451 Json.123:
-        let Json.449 : U64 = 1i64;
-        let Json.448 : U64 = CallByName Num.20 Json.119 Json.449;
-        let Json.447 : {List U8, U64} = Struct {Json.123, Json.448};
-        ret Json.447;
+    let Json.119 : U64 = StructAtIndex 1 Json.401;
+    dec Json.401;
+    let Json.469 : I64 = 34i64;
+    let Json.468 : U8 = CallByName Num.125 Json.469;
+    let Json.466 : List U8 = CallByName List.4 Json.118 Json.468;
+    let Json.467 : List U8 = CallByName Str.12 Json.120;
+    let Json.463 : List U8 = CallByName List.8 Json.466 Json.467;
+    let Json.465 : I64 = 34i64;
+    let Json.464 : U8 = CallByName Num.125 Json.465;
+    let Json.460 : List U8 = CallByName List.4 Json.463 Json.464;
+    let Json.462 : I64 = 58i64;
+    let Json.461 : U8 = CallByName Num.125 Json.462;
+    let Json.458 : List U8 = CallByName List.4 Json.460 Json.461;
+    let Json.459 : {} = Struct {};
+    let Json.122 : List U8 = CallByName Encode.23 Json.458 Json.121 Json.459;
+    joinpoint Json.453 Json.123:
+        let Json.451 : U64 = 1i64;
+        let Json.450 : U64 = CallByName Num.20 Json.119 Json.451;
+        let Json.449 : {List U8, U64} = Struct {Json.123, Json.450};
+        ret Json.449;
     in
-    let Json.455 : U64 = 1i64;
-    let Json.452 : Int1 = CallByName Num.24 Json.119 Json.455;
-    if Json.452 then
-        let Json.454 : I64 = 44i64;
-        let Json.453 : U8 = CallByName Num.125 Json.454;
-        let Json.450 : List U8 = CallByName List.4 Json.122 Json.453;
-        jump Json.451 Json.450;
+    let Json.457 : U64 = 1i64;
+    let Json.454 : Int1 = CallByName Num.24 Json.119 Json.457;
+    if Json.454 then
+        let Json.456 : I64 = 44i64;
+        let Json.455 : U8 = CallByName Num.125 Json.456;
+        let Json.452 : List U8 = CallByName List.4 Json.122 Json.455;
+        jump Json.453 Json.452;
     else
-        jump Json.451 Json.122;
+        jump Json.453 Json.122;
 
 procedure Json.18 (Json.95):
-    let Json.471 : Str = CallByName Encode.22 Json.95;
-    ret Json.471;
+    let Json.473 : Str = CallByName Encode.22 Json.95;
+    ret Json.473;
 
 procedure Json.20 (Json.111):
-    let Json.395 : List {Str, Str} = CallByName Encode.22 Json.111;
-    ret Json.395;
+    let Json.397 : List {Str, Str} = CallByName Encode.22 Json.111;
+    ret Json.397;
 
 procedure Json.20 (Json.111):
-    let Json.437 : List {Str, Str} = CallByName Encode.22 Json.111;
-    ret Json.437;
+    let Json.439 : List {Str, Str} = CallByName Encode.22 Json.111;
+    ret Json.439;
 
-procedure Json.96 (Json.97, Json.473, Json.95):
-    let Json.482 : I64 = 34i64;
-    let Json.481 : U8 = CallByName Num.125 Json.482;
-    let Json.479 : List U8 = CallByName List.4 Json.97 Json.481;
-    let Json.480 : List U8 = CallByName Str.12 Json.95;
-    let Json.476 : List U8 = CallByName List.8 Json.479 Json.480;
-    let Json.478 : I64 = 34i64;
-    let Json.477 : U8 = CallByName Num.125 Json.478;
-    let Json.475 : List U8 = CallByName List.4 Json.476 Json.477;
-    ret Json.475;
+procedure Json.96 (Json.97, Json.475, Json.95):
+    let Json.484 : I64 = 34i64;
+    let Json.483 : U8 = CallByName Num.125 Json.484;
+    let Json.481 : List U8 = CallByName List.4 Json.97 Json.483;
+    let Json.482 : List U8 = CallByName Str.12 Json.95;
+    let Json.478 : List U8 = CallByName List.8 Json.481 Json.482;
+    let Json.480 : I64 = 34i64;
+    let Json.479 : U8 = CallByName Num.125 Json.480;
+    let Json.477 : List U8 = CallByName List.4 Json.478 Json.479;
+    ret Json.477;
 
-procedure List.137 (List.138, List.139, List.136):
-    let List.450 : {List U8, U64} = CallByName Json.114 List.138 List.139;
-    ret List.450;
+procedure List.138 (List.139, List.140, List.137):
+    let List.519 : {List U8, U64} = CallByName Json.114 List.139 List.140;
+    ret List.519;
 
-procedure List.137 (List.138, List.139, List.136):
-    let List.523 : {List U8, U64} = CallByName Json.114 List.138 List.139;
-    ret List.523;
+procedure List.138 (List.139, List.140, List.137):
+    let List.592 : {List U8, U64} = CallByName Json.114 List.139 List.140;
+    ret List.592;
 
-procedure List.18 (List.134, List.135, List.136):
-    let List.431 : {List U8, U64} = CallByName List.89 List.134 List.135 List.136;
-    ret List.431;
+procedure List.18 (List.135, List.136, List.137):
+    let List.500 : {List U8, U64} = CallByName List.90 List.135 List.136 List.137;
+    ret List.500;
 
-procedure List.18 (List.134, List.135, List.136):
-    let List.504 : {List U8, U64} = CallByName List.89 List.134 List.135 List.136;
-    ret List.504;
+procedure List.18 (List.135, List.136, List.137):
+    let List.573 : {List U8, U64} = CallByName List.90 List.135 List.136 List.137;
+    ret List.573;
 
-procedure List.4 (List.105, List.106):
-    let List.503 : U64 = 1i64;
-    let List.502 : List U8 = CallByName List.70 List.105 List.503;
-    let List.501 : List U8 = CallByName List.71 List.502 List.106;
-    ret List.501;
-
-procedure List.6 (#Attr.2):
-    let List.409 : U64 = lowlevel ListLen #Attr.2;
-    ret List.409;
+procedure List.4 (List.106, List.107):
+    let List.572 : U64 = 1i64;
+    let List.571 : List U8 = CallByName List.70 List.106 List.572;
+    let List.570 : List U8 = CallByName List.71 List.571 List.107;
+    ret List.570;
 
 procedure List.6 (#Attr.2):
-    let List.452 : U64 = lowlevel ListLen #Attr.2;
-    ret List.452;
+    let List.478 : U64 = lowlevel ListLen #Attr.2;
+    ret List.478;
 
 procedure List.6 (#Attr.2):
-    let List.526 : U64 = lowlevel ListLen #Attr.2;
-    ret List.526;
+    let List.521 : U64 = lowlevel ListLen #Attr.2;
+    ret List.521;
+
+procedure List.6 (#Attr.2):
+    let List.595 : U64 = lowlevel ListLen #Attr.2;
+    ret List.595;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.447 : {Str, Str} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.447;
+    let List.516 : {Str, Str} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.516;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.520 : {Str, Str} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.520;
+    let List.589 : {Str, Str} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.589;
 
 procedure List.70 (#Attr.2, #Attr.3):
-    let List.482 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
-    ret List.482;
+    let List.551 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
+    ret List.551;
 
 procedure List.71 (#Attr.2, #Attr.3):
-    let List.480 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
-    ret List.480;
+    let List.549 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
+    ret List.549;
 
 procedure List.8 (#Attr.2, #Attr.3):
-    let List.525 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
-    ret List.525;
+    let List.594 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
+    ret List.594;
 
-procedure List.89 (List.385, List.386, List.387):
-    let List.435 : U64 = 0i64;
-    let List.436 : U64 = CallByName List.6 List.385;
-    let List.434 : {List U8, U64} = CallByName List.90 List.385 List.386 List.387 List.435 List.436;
-    ret List.434;
+procedure List.90 (List.426, List.427, List.428):
+    let List.504 : U64 = 0i64;
+    let List.505 : U64 = CallByName List.6 List.426;
+    let List.503 : {List U8, U64} = CallByName List.91 List.426 List.427 List.428 List.504 List.505;
+    ret List.503;
 
-procedure List.89 (List.385, List.386, List.387):
-    let List.508 : U64 = 0i64;
-    let List.509 : U64 = CallByName List.6 List.385;
-    let List.507 : {List U8, U64} = CallByName List.90 List.385 List.386 List.387 List.508 List.509;
-    ret List.507;
+procedure List.90 (List.426, List.427, List.428):
+    let List.577 : U64 = 0i64;
+    let List.578 : U64 = CallByName List.6 List.426;
+    let List.576 : {List U8, U64} = CallByName List.91 List.426 List.427 List.428 List.577 List.578;
+    ret List.576;
 
-procedure List.90 (List.462, List.463, List.464, List.465, List.466):
-    joinpoint List.437 List.388 List.389 List.390 List.391 List.392:
-        let List.439 : Int1 = CallByName Num.22 List.391 List.392;
-        if List.439 then
-            let List.446 : {Str, Str} = CallByName List.66 List.388 List.391;
-            let List.440 : {List U8, U64} = CallByName List.137 List.389 List.446 List.390;
-            let List.443 : U64 = 1i64;
-            let List.442 : U64 = CallByName Num.19 List.391 List.443;
-            jump List.437 List.388 List.440 List.390 List.442 List.392;
+procedure List.91 (List.531, List.532, List.533, List.534, List.535):
+    joinpoint List.506 List.429 List.430 List.431 List.432 List.433:
+        let List.508 : Int1 = CallByName Num.22 List.432 List.433;
+        if List.508 then
+            let List.515 : {Str, Str} = CallByName List.66 List.429 List.432;
+            let List.509 : {List U8, U64} = CallByName List.138 List.430 List.515 List.431;
+            let List.512 : U64 = 1i64;
+            let List.511 : U64 = CallByName Num.19 List.432 List.512;
+            jump List.506 List.429 List.509 List.431 List.511 List.433;
         else
-            ret List.389;
+            ret List.430;
     in
-    jump List.437 List.462 List.463 List.464 List.465 List.466;
+    jump List.506 List.531 List.532 List.533 List.534 List.535;
 
-procedure List.90 (List.536, List.537, List.538, List.539, List.540):
-    joinpoint List.510 List.388 List.389 List.390 List.391 List.392:
-        let List.512 : Int1 = CallByName Num.22 List.391 List.392;
-        if List.512 then
-            let List.519 : {Str, Str} = CallByName List.66 List.388 List.391;
-            let List.513 : {List U8, U64} = CallByName List.137 List.389 List.519 List.390;
-            let List.516 : U64 = 1i64;
-            let List.515 : U64 = CallByName Num.19 List.391 List.516;
-            jump List.510 List.388 List.513 List.390 List.515 List.392;
+procedure List.91 (List.605, List.606, List.607, List.608, List.609):
+    joinpoint List.579 List.429 List.430 List.431 List.432 List.433:
+        let List.581 : Int1 = CallByName Num.22 List.432 List.433;
+        if List.581 then
+            let List.588 : {Str, Str} = CallByName List.66 List.429 List.432;
+            let List.582 : {List U8, U64} = CallByName List.138 List.430 List.588 List.431;
+            let List.585 : U64 = 1i64;
+            let List.584 : U64 = CallByName Num.19 List.432 List.585;
+            jump List.579 List.429 List.582 List.431 List.584 List.433;
         else
-            ret List.389;
+            ret List.430;
     in
-    jump List.510 List.536 List.537 List.538 List.539 List.540;
+    jump List.579 List.605 List.606 List.607 List.608 List.609;
 
 procedure Num.125 (#Attr.2):
     let Num.282 : U8 = lowlevel NumIntCast #Attr.2;

--- a/crates/compiler/test_mono/generated/encode_derived_record_one_field_string.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_record_one_field_string.txt
@@ -39,141 +39,141 @@ procedure Encode.25 (Encode.100, Encode.101):
     ret Encode.103;
 
 procedure Json.1 ():
-    let Json.394 : {} = Struct {};
-    ret Json.394;
+    let Json.396 : {} = Struct {};
+    ret Json.396;
 
-procedure Json.112 (Json.113, Json.397, Json.111):
-    let Json.430 : I64 = 123i64;
-    let Json.429 : U8 = CallByName Num.125 Json.430;
-    let Json.115 : List U8 = CallByName List.4 Json.113 Json.429;
-    let Json.428 : U64 = CallByName List.6 Json.111;
-    let Json.405 : {List U8, U64} = Struct {Json.115, Json.428};
-    let Json.406 : {} = Struct {};
-    let Json.404 : {List U8, U64} = CallByName List.18 Json.111 Json.405 Json.406;
+procedure Json.112 (Json.113, Json.399, Json.111):
+    let Json.432 : I64 = 123i64;
+    let Json.431 : U8 = CallByName Num.125 Json.432;
+    let Json.115 : List U8 = CallByName List.4 Json.113 Json.431;
+    let Json.430 : U64 = CallByName List.6 Json.111;
+    let Json.407 : {List U8, U64} = Struct {Json.115, Json.430};
+    let Json.408 : {} = Struct {};
+    let Json.406 : {List U8, U64} = CallByName List.18 Json.111 Json.407 Json.408;
     dec Json.111;
-    let Json.117 : List U8 = StructAtIndex 0 Json.404;
+    let Json.117 : List U8 = StructAtIndex 0 Json.406;
     inc Json.117;
-    dec Json.404;
-    let Json.403 : I64 = 125i64;
-    let Json.402 : U8 = CallByName Num.125 Json.403;
-    let Json.401 : List U8 = CallByName List.4 Json.117 Json.402;
-    ret Json.401;
+    dec Json.406;
+    let Json.405 : I64 = 125i64;
+    let Json.404 : U8 = CallByName Num.125 Json.405;
+    let Json.403 : List U8 = CallByName List.4 Json.117 Json.404;
+    ret Json.403;
 
-procedure Json.114 (Json.399, Json.400):
-    let Json.120 : Str = StructAtIndex 0 Json.400;
+procedure Json.114 (Json.401, Json.402):
+    let Json.120 : Str = StructAtIndex 0 Json.402;
     inc Json.120;
-    let Json.121 : Str = StructAtIndex 1 Json.400;
+    let Json.121 : Str = StructAtIndex 1 Json.402;
     inc Json.121;
-    dec Json.400;
-    let Json.118 : List U8 = StructAtIndex 0 Json.399;
+    dec Json.402;
+    let Json.118 : List U8 = StructAtIndex 0 Json.401;
     inc Json.118;
-    let Json.119 : U64 = StructAtIndex 1 Json.399;
-    dec Json.399;
-    let Json.427 : I64 = 34i64;
-    let Json.426 : U8 = CallByName Num.125 Json.427;
-    let Json.424 : List U8 = CallByName List.4 Json.118 Json.426;
-    let Json.425 : List U8 = CallByName Str.12 Json.120;
-    let Json.421 : List U8 = CallByName List.8 Json.424 Json.425;
-    let Json.423 : I64 = 34i64;
-    let Json.422 : U8 = CallByName Num.125 Json.423;
-    let Json.418 : List U8 = CallByName List.4 Json.421 Json.422;
-    let Json.420 : I64 = 58i64;
-    let Json.419 : U8 = CallByName Num.125 Json.420;
-    let Json.416 : List U8 = CallByName List.4 Json.418 Json.419;
-    let Json.417 : {} = Struct {};
-    let Json.122 : List U8 = CallByName Encode.23 Json.416 Json.121 Json.417;
-    joinpoint Json.411 Json.123:
-        let Json.409 : U64 = 1i64;
-        let Json.408 : U64 = CallByName Num.20 Json.119 Json.409;
-        let Json.407 : {List U8, U64} = Struct {Json.123, Json.408};
-        ret Json.407;
+    let Json.119 : U64 = StructAtIndex 1 Json.401;
+    dec Json.401;
+    let Json.429 : I64 = 34i64;
+    let Json.428 : U8 = CallByName Num.125 Json.429;
+    let Json.426 : List U8 = CallByName List.4 Json.118 Json.428;
+    let Json.427 : List U8 = CallByName Str.12 Json.120;
+    let Json.423 : List U8 = CallByName List.8 Json.426 Json.427;
+    let Json.425 : I64 = 34i64;
+    let Json.424 : U8 = CallByName Num.125 Json.425;
+    let Json.420 : List U8 = CallByName List.4 Json.423 Json.424;
+    let Json.422 : I64 = 58i64;
+    let Json.421 : U8 = CallByName Num.125 Json.422;
+    let Json.418 : List U8 = CallByName List.4 Json.420 Json.421;
+    let Json.419 : {} = Struct {};
+    let Json.122 : List U8 = CallByName Encode.23 Json.418 Json.121 Json.419;
+    joinpoint Json.413 Json.123:
+        let Json.411 : U64 = 1i64;
+        let Json.410 : U64 = CallByName Num.20 Json.119 Json.411;
+        let Json.409 : {List U8, U64} = Struct {Json.123, Json.410};
+        ret Json.409;
     in
-    let Json.415 : U64 = 1i64;
-    let Json.412 : Int1 = CallByName Num.24 Json.119 Json.415;
-    if Json.412 then
-        let Json.414 : I64 = 44i64;
-        let Json.413 : U8 = CallByName Num.125 Json.414;
-        let Json.410 : List U8 = CallByName List.4 Json.122 Json.413;
-        jump Json.411 Json.410;
+    let Json.417 : U64 = 1i64;
+    let Json.414 : Int1 = CallByName Num.24 Json.119 Json.417;
+    if Json.414 then
+        let Json.416 : I64 = 44i64;
+        let Json.415 : U8 = CallByName Num.125 Json.416;
+        let Json.412 : List U8 = CallByName List.4 Json.122 Json.415;
+        jump Json.413 Json.412;
     else
-        jump Json.411 Json.122;
+        jump Json.413 Json.122;
 
 procedure Json.18 (Json.95):
-    let Json.431 : Str = CallByName Encode.22 Json.95;
-    ret Json.431;
+    let Json.433 : Str = CallByName Encode.22 Json.95;
+    ret Json.433;
 
 procedure Json.20 (Json.111):
-    let Json.395 : List {Str, Str} = CallByName Encode.22 Json.111;
-    ret Json.395;
+    let Json.397 : List {Str, Str} = CallByName Encode.22 Json.111;
+    ret Json.397;
 
-procedure Json.96 (Json.97, Json.433, Json.95):
-    let Json.442 : I64 = 34i64;
-    let Json.441 : U8 = CallByName Num.125 Json.442;
-    let Json.439 : List U8 = CallByName List.4 Json.97 Json.441;
-    let Json.440 : List U8 = CallByName Str.12 Json.95;
-    let Json.436 : List U8 = CallByName List.8 Json.439 Json.440;
-    let Json.438 : I64 = 34i64;
-    let Json.437 : U8 = CallByName Num.125 Json.438;
-    let Json.435 : List U8 = CallByName List.4 Json.436 Json.437;
-    ret Json.435;
+procedure Json.96 (Json.97, Json.435, Json.95):
+    let Json.444 : I64 = 34i64;
+    let Json.443 : U8 = CallByName Num.125 Json.444;
+    let Json.441 : List U8 = CallByName List.4 Json.97 Json.443;
+    let Json.442 : List U8 = CallByName Str.12 Json.95;
+    let Json.438 : List U8 = CallByName List.8 Json.441 Json.442;
+    let Json.440 : I64 = 34i64;
+    let Json.439 : U8 = CallByName Num.125 Json.440;
+    let Json.437 : List U8 = CallByName List.4 Json.438 Json.439;
+    ret Json.437;
 
-procedure List.137 (List.138, List.139, List.136):
-    let List.456 : {List U8, U64} = CallByName Json.114 List.138 List.139;
-    ret List.456;
+procedure List.138 (List.139, List.140, List.137):
+    let List.525 : {List U8, U64} = CallByName Json.114 List.139 List.140;
+    ret List.525;
 
-procedure List.18 (List.134, List.135, List.136):
-    let List.437 : {List U8, U64} = CallByName List.89 List.134 List.135 List.136;
-    ret List.437;
+procedure List.18 (List.135, List.136, List.137):
+    let List.506 : {List U8, U64} = CallByName List.90 List.135 List.136 List.137;
+    ret List.506;
 
-procedure List.4 (List.105, List.106):
-    let List.436 : U64 = 1i64;
-    let List.435 : List U8 = CallByName List.70 List.105 List.436;
-    let List.434 : List U8 = CallByName List.71 List.435 List.106;
-    ret List.434;
-
-procedure List.6 (#Attr.2):
-    let List.409 : U64 = lowlevel ListLen #Attr.2;
-    ret List.409;
+procedure List.4 (List.106, List.107):
+    let List.505 : U64 = 1i64;
+    let List.504 : List U8 = CallByName List.70 List.106 List.505;
+    let List.503 : List U8 = CallByName List.71 List.504 List.107;
+    ret List.503;
 
 procedure List.6 (#Attr.2):
-    let List.459 : U64 = lowlevel ListLen #Attr.2;
-    ret List.459;
+    let List.478 : U64 = lowlevel ListLen #Attr.2;
+    ret List.478;
+
+procedure List.6 (#Attr.2):
+    let List.528 : U64 = lowlevel ListLen #Attr.2;
+    ret List.528;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.453 : {Str, Str} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.453;
+    let List.522 : {Str, Str} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.522;
 
 procedure List.70 (#Attr.2, #Attr.3):
-    let List.415 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
-    ret List.415;
+    let List.484 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
+    ret List.484;
 
 procedure List.71 (#Attr.2, #Attr.3):
-    let List.413 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
-    ret List.413;
+    let List.482 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
+    ret List.482;
 
 procedure List.8 (#Attr.2, #Attr.3):
-    let List.458 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
-    ret List.458;
+    let List.527 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
+    ret List.527;
 
-procedure List.89 (List.385, List.386, List.387):
-    let List.441 : U64 = 0i64;
-    let List.442 : U64 = CallByName List.6 List.385;
-    let List.440 : {List U8, U64} = CallByName List.90 List.385 List.386 List.387 List.441 List.442;
-    ret List.440;
+procedure List.90 (List.426, List.427, List.428):
+    let List.510 : U64 = 0i64;
+    let List.511 : U64 = CallByName List.6 List.426;
+    let List.509 : {List U8, U64} = CallByName List.91 List.426 List.427 List.428 List.510 List.511;
+    ret List.509;
 
-procedure List.90 (List.469, List.470, List.471, List.472, List.473):
-    joinpoint List.443 List.388 List.389 List.390 List.391 List.392:
-        let List.445 : Int1 = CallByName Num.22 List.391 List.392;
-        if List.445 then
-            let List.452 : {Str, Str} = CallByName List.66 List.388 List.391;
-            let List.446 : {List U8, U64} = CallByName List.137 List.389 List.452 List.390;
-            let List.449 : U64 = 1i64;
-            let List.448 : U64 = CallByName Num.19 List.391 List.449;
-            jump List.443 List.388 List.446 List.390 List.448 List.392;
+procedure List.91 (List.538, List.539, List.540, List.541, List.542):
+    joinpoint List.512 List.429 List.430 List.431 List.432 List.433:
+        let List.514 : Int1 = CallByName Num.22 List.432 List.433;
+        if List.514 then
+            let List.521 : {Str, Str} = CallByName List.66 List.429 List.432;
+            let List.515 : {List U8, U64} = CallByName List.138 List.430 List.521 List.431;
+            let List.518 : U64 = 1i64;
+            let List.517 : U64 = CallByName Num.19 List.432 List.518;
+            jump List.512 List.429 List.515 List.431 List.517 List.433;
         else
-            ret List.389;
+            ret List.430;
     in
-    jump List.443 List.469 List.470 List.471 List.472 List.473;
+    jump List.512 List.538 List.539 List.540 List.541 List.542;
 
 procedure Num.125 (#Attr.2):
     let Num.263 : U8 = lowlevel NumIntCast #Attr.2;

--- a/crates/compiler/test_mono/generated/encode_derived_record_two_field_strings.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_record_two_field_strings.txt
@@ -47,141 +47,141 @@ procedure Encode.25 (Encode.100, Encode.101):
     ret Encode.103;
 
 procedure Json.1 ():
-    let Json.394 : {} = Struct {};
-    ret Json.394;
+    let Json.396 : {} = Struct {};
+    ret Json.396;
 
-procedure Json.112 (Json.113, Json.397, Json.111):
-    let Json.430 : I64 = 123i64;
-    let Json.429 : U8 = CallByName Num.125 Json.430;
-    let Json.115 : List U8 = CallByName List.4 Json.113 Json.429;
-    let Json.428 : U64 = CallByName List.6 Json.111;
-    let Json.405 : {List U8, U64} = Struct {Json.115, Json.428};
-    let Json.406 : {} = Struct {};
-    let Json.404 : {List U8, U64} = CallByName List.18 Json.111 Json.405 Json.406;
+procedure Json.112 (Json.113, Json.399, Json.111):
+    let Json.432 : I64 = 123i64;
+    let Json.431 : U8 = CallByName Num.125 Json.432;
+    let Json.115 : List U8 = CallByName List.4 Json.113 Json.431;
+    let Json.430 : U64 = CallByName List.6 Json.111;
+    let Json.407 : {List U8, U64} = Struct {Json.115, Json.430};
+    let Json.408 : {} = Struct {};
+    let Json.406 : {List U8, U64} = CallByName List.18 Json.111 Json.407 Json.408;
     dec Json.111;
-    let Json.117 : List U8 = StructAtIndex 0 Json.404;
+    let Json.117 : List U8 = StructAtIndex 0 Json.406;
     inc Json.117;
-    dec Json.404;
-    let Json.403 : I64 = 125i64;
-    let Json.402 : U8 = CallByName Num.125 Json.403;
-    let Json.401 : List U8 = CallByName List.4 Json.117 Json.402;
-    ret Json.401;
+    dec Json.406;
+    let Json.405 : I64 = 125i64;
+    let Json.404 : U8 = CallByName Num.125 Json.405;
+    let Json.403 : List U8 = CallByName List.4 Json.117 Json.404;
+    ret Json.403;
 
-procedure Json.114 (Json.399, Json.400):
-    let Json.120 : Str = StructAtIndex 0 Json.400;
+procedure Json.114 (Json.401, Json.402):
+    let Json.120 : Str = StructAtIndex 0 Json.402;
     inc Json.120;
-    let Json.121 : Str = StructAtIndex 1 Json.400;
+    let Json.121 : Str = StructAtIndex 1 Json.402;
     inc Json.121;
-    dec Json.400;
-    let Json.118 : List U8 = StructAtIndex 0 Json.399;
+    dec Json.402;
+    let Json.118 : List U8 = StructAtIndex 0 Json.401;
     inc Json.118;
-    let Json.119 : U64 = StructAtIndex 1 Json.399;
-    dec Json.399;
-    let Json.427 : I64 = 34i64;
-    let Json.426 : U8 = CallByName Num.125 Json.427;
-    let Json.424 : List U8 = CallByName List.4 Json.118 Json.426;
-    let Json.425 : List U8 = CallByName Str.12 Json.120;
-    let Json.421 : List U8 = CallByName List.8 Json.424 Json.425;
-    let Json.423 : I64 = 34i64;
-    let Json.422 : U8 = CallByName Num.125 Json.423;
-    let Json.418 : List U8 = CallByName List.4 Json.421 Json.422;
-    let Json.420 : I64 = 58i64;
-    let Json.419 : U8 = CallByName Num.125 Json.420;
-    let Json.416 : List U8 = CallByName List.4 Json.418 Json.419;
-    let Json.417 : {} = Struct {};
-    let Json.122 : List U8 = CallByName Encode.23 Json.416 Json.121 Json.417;
-    joinpoint Json.411 Json.123:
-        let Json.409 : U64 = 1i64;
-        let Json.408 : U64 = CallByName Num.20 Json.119 Json.409;
-        let Json.407 : {List U8, U64} = Struct {Json.123, Json.408};
-        ret Json.407;
+    let Json.119 : U64 = StructAtIndex 1 Json.401;
+    dec Json.401;
+    let Json.429 : I64 = 34i64;
+    let Json.428 : U8 = CallByName Num.125 Json.429;
+    let Json.426 : List U8 = CallByName List.4 Json.118 Json.428;
+    let Json.427 : List U8 = CallByName Str.12 Json.120;
+    let Json.423 : List U8 = CallByName List.8 Json.426 Json.427;
+    let Json.425 : I64 = 34i64;
+    let Json.424 : U8 = CallByName Num.125 Json.425;
+    let Json.420 : List U8 = CallByName List.4 Json.423 Json.424;
+    let Json.422 : I64 = 58i64;
+    let Json.421 : U8 = CallByName Num.125 Json.422;
+    let Json.418 : List U8 = CallByName List.4 Json.420 Json.421;
+    let Json.419 : {} = Struct {};
+    let Json.122 : List U8 = CallByName Encode.23 Json.418 Json.121 Json.419;
+    joinpoint Json.413 Json.123:
+        let Json.411 : U64 = 1i64;
+        let Json.410 : U64 = CallByName Num.20 Json.119 Json.411;
+        let Json.409 : {List U8, U64} = Struct {Json.123, Json.410};
+        ret Json.409;
     in
-    let Json.415 : U64 = 1i64;
-    let Json.412 : Int1 = CallByName Num.24 Json.119 Json.415;
-    if Json.412 then
-        let Json.414 : I64 = 44i64;
-        let Json.413 : U8 = CallByName Num.125 Json.414;
-        let Json.410 : List U8 = CallByName List.4 Json.122 Json.413;
-        jump Json.411 Json.410;
+    let Json.417 : U64 = 1i64;
+    let Json.414 : Int1 = CallByName Num.24 Json.119 Json.417;
+    if Json.414 then
+        let Json.416 : I64 = 44i64;
+        let Json.415 : U8 = CallByName Num.125 Json.416;
+        let Json.412 : List U8 = CallByName List.4 Json.122 Json.415;
+        jump Json.413 Json.412;
     else
-        jump Json.411 Json.122;
+        jump Json.413 Json.122;
 
 procedure Json.18 (Json.95):
-    let Json.443 : Str = CallByName Encode.22 Json.95;
-    ret Json.443;
+    let Json.445 : Str = CallByName Encode.22 Json.95;
+    ret Json.445;
 
 procedure Json.20 (Json.111):
-    let Json.395 : List {Str, Str} = CallByName Encode.22 Json.111;
-    ret Json.395;
+    let Json.397 : List {Str, Str} = CallByName Encode.22 Json.111;
+    ret Json.397;
 
-procedure Json.96 (Json.97, Json.433, Json.95):
-    let Json.442 : I64 = 34i64;
-    let Json.441 : U8 = CallByName Num.125 Json.442;
-    let Json.439 : List U8 = CallByName List.4 Json.97 Json.441;
-    let Json.440 : List U8 = CallByName Str.12 Json.95;
-    let Json.436 : List U8 = CallByName List.8 Json.439 Json.440;
-    let Json.438 : I64 = 34i64;
-    let Json.437 : U8 = CallByName Num.125 Json.438;
-    let Json.435 : List U8 = CallByName List.4 Json.436 Json.437;
-    ret Json.435;
+procedure Json.96 (Json.97, Json.435, Json.95):
+    let Json.444 : I64 = 34i64;
+    let Json.443 : U8 = CallByName Num.125 Json.444;
+    let Json.441 : List U8 = CallByName List.4 Json.97 Json.443;
+    let Json.442 : List U8 = CallByName Str.12 Json.95;
+    let Json.438 : List U8 = CallByName List.8 Json.441 Json.442;
+    let Json.440 : I64 = 34i64;
+    let Json.439 : U8 = CallByName Num.125 Json.440;
+    let Json.437 : List U8 = CallByName List.4 Json.438 Json.439;
+    ret Json.437;
 
-procedure List.137 (List.138, List.139, List.136):
-    let List.456 : {List U8, U64} = CallByName Json.114 List.138 List.139;
-    ret List.456;
+procedure List.138 (List.139, List.140, List.137):
+    let List.525 : {List U8, U64} = CallByName Json.114 List.139 List.140;
+    ret List.525;
 
-procedure List.18 (List.134, List.135, List.136):
-    let List.437 : {List U8, U64} = CallByName List.89 List.134 List.135 List.136;
-    ret List.437;
+procedure List.18 (List.135, List.136, List.137):
+    let List.506 : {List U8, U64} = CallByName List.90 List.135 List.136 List.137;
+    ret List.506;
 
-procedure List.4 (List.105, List.106):
-    let List.436 : U64 = 1i64;
-    let List.435 : List U8 = CallByName List.70 List.105 List.436;
-    let List.434 : List U8 = CallByName List.71 List.435 List.106;
-    ret List.434;
-
-procedure List.6 (#Attr.2):
-    let List.409 : U64 = lowlevel ListLen #Attr.2;
-    ret List.409;
+procedure List.4 (List.106, List.107):
+    let List.505 : U64 = 1i64;
+    let List.504 : List U8 = CallByName List.70 List.106 List.505;
+    let List.503 : List U8 = CallByName List.71 List.504 List.107;
+    ret List.503;
 
 procedure List.6 (#Attr.2):
-    let List.459 : U64 = lowlevel ListLen #Attr.2;
-    ret List.459;
+    let List.478 : U64 = lowlevel ListLen #Attr.2;
+    ret List.478;
+
+procedure List.6 (#Attr.2):
+    let List.528 : U64 = lowlevel ListLen #Attr.2;
+    ret List.528;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.453 : {Str, Str} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.453;
+    let List.522 : {Str, Str} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.522;
 
 procedure List.70 (#Attr.2, #Attr.3):
-    let List.415 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
-    ret List.415;
+    let List.484 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
+    ret List.484;
 
 procedure List.71 (#Attr.2, #Attr.3):
-    let List.413 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
-    ret List.413;
+    let List.482 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
+    ret List.482;
 
 procedure List.8 (#Attr.2, #Attr.3):
-    let List.458 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
-    ret List.458;
+    let List.527 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
+    ret List.527;
 
-procedure List.89 (List.385, List.386, List.387):
-    let List.441 : U64 = 0i64;
-    let List.442 : U64 = CallByName List.6 List.385;
-    let List.440 : {List U8, U64} = CallByName List.90 List.385 List.386 List.387 List.441 List.442;
-    ret List.440;
+procedure List.90 (List.426, List.427, List.428):
+    let List.510 : U64 = 0i64;
+    let List.511 : U64 = CallByName List.6 List.426;
+    let List.509 : {List U8, U64} = CallByName List.91 List.426 List.427 List.428 List.510 List.511;
+    ret List.509;
 
-procedure List.90 (List.469, List.470, List.471, List.472, List.473):
-    joinpoint List.443 List.388 List.389 List.390 List.391 List.392:
-        let List.445 : Int1 = CallByName Num.22 List.391 List.392;
-        if List.445 then
-            let List.452 : {Str, Str} = CallByName List.66 List.388 List.391;
-            let List.446 : {List U8, U64} = CallByName List.137 List.389 List.452 List.390;
-            let List.449 : U64 = 1i64;
-            let List.448 : U64 = CallByName Num.19 List.391 List.449;
-            jump List.443 List.388 List.446 List.390 List.448 List.392;
+procedure List.91 (List.538, List.539, List.540, List.541, List.542):
+    joinpoint List.512 List.429 List.430 List.431 List.432 List.433:
+        let List.514 : Int1 = CallByName Num.22 List.432 List.433;
+        if List.514 then
+            let List.521 : {Str, Str} = CallByName List.66 List.429 List.432;
+            let List.515 : {List U8, U64} = CallByName List.138 List.430 List.521 List.431;
+            let List.518 : U64 = 1i64;
+            let List.517 : U64 = CallByName Num.19 List.432 List.518;
+            jump List.512 List.429 List.515 List.431 List.517 List.433;
         else
-            ret List.389;
+            ret List.430;
     in
-    jump List.443 List.469 List.470 List.471 List.472 List.473;
+    jump List.512 List.538 List.539 List.540 List.541 List.542;
 
 procedure Num.125 (#Attr.2):
     let Num.263 : U8 = lowlevel NumIntCast #Attr.2;

--- a/crates/compiler/test_mono/generated/encode_derived_string.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_string.txt
@@ -12,45 +12,45 @@ procedure Encode.25 (Encode.100, Encode.101):
     ret Encode.103;
 
 procedure Json.1 ():
-    let Json.394 : {} = Struct {};
-    ret Json.394;
+    let Json.396 : {} = Struct {};
+    ret Json.396;
 
 procedure Json.18 (Json.95):
-    let Json.395 : Str = CallByName Encode.22 Json.95;
-    ret Json.395;
+    let Json.397 : Str = CallByName Encode.22 Json.95;
+    ret Json.397;
 
-procedure Json.96 (Json.97, Json.397, Json.95):
-    let Json.406 : I64 = 34i64;
-    let Json.405 : U8 = CallByName Num.125 Json.406;
-    let Json.403 : List U8 = CallByName List.4 Json.97 Json.405;
-    let Json.404 : List U8 = CallByName Str.12 Json.95;
-    let Json.400 : List U8 = CallByName List.8 Json.403 Json.404;
-    let Json.402 : I64 = 34i64;
-    let Json.401 : U8 = CallByName Num.125 Json.402;
-    let Json.399 : List U8 = CallByName List.4 Json.400 Json.401;
-    ret Json.399;
+procedure Json.96 (Json.97, Json.399, Json.95):
+    let Json.408 : I64 = 34i64;
+    let Json.407 : U8 = CallByName Num.125 Json.408;
+    let Json.405 : List U8 = CallByName List.4 Json.97 Json.407;
+    let Json.406 : List U8 = CallByName Str.12 Json.95;
+    let Json.402 : List U8 = CallByName List.8 Json.405 Json.406;
+    let Json.404 : I64 = 34i64;
+    let Json.403 : U8 = CallByName Num.125 Json.404;
+    let Json.401 : List U8 = CallByName List.4 Json.402 Json.403;
+    ret Json.401;
 
-procedure List.4 (List.105, List.106):
-    let List.418 : U64 = 1i64;
-    let List.417 : List U8 = CallByName List.70 List.105 List.418;
-    let List.416 : List U8 = CallByName List.71 List.417 List.106;
-    ret List.416;
+procedure List.4 (List.106, List.107):
+    let List.487 : U64 = 1i64;
+    let List.486 : List U8 = CallByName List.70 List.106 List.487;
+    let List.485 : List U8 = CallByName List.71 List.486 List.107;
+    ret List.485;
 
 procedure List.6 (#Attr.2):
-    let List.409 : U64 = lowlevel ListLen #Attr.2;
-    ret List.409;
+    let List.478 : U64 = lowlevel ListLen #Attr.2;
+    ret List.478;
 
 procedure List.70 (#Attr.2, #Attr.3):
-    let List.415 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
-    ret List.415;
+    let List.484 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
+    ret List.484;
 
 procedure List.71 (#Attr.2, #Attr.3):
-    let List.413 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
-    ret List.413;
+    let List.482 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
+    ret List.482;
 
 procedure List.8 (#Attr.2, #Attr.3):
-    let List.419 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
-    ret List.419;
+    let List.488 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
+    ret List.488;
 
 procedure Num.125 (#Attr.2):
     let Num.257 : U8 = lowlevel NumIntCast #Attr.2;

--- a/crates/compiler/test_mono/generated/encode_derived_tag_one_field_string.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_tag_one_field_string.txt
@@ -41,148 +41,148 @@ procedure Encode.25 (Encode.100, Encode.101):
     ret Encode.103;
 
 procedure Json.1 ():
-    let Json.394 : {} = Struct {};
-    ret Json.394;
+    let Json.396 : {} = Struct {};
+    ret Json.396;
 
-procedure Json.126 (Json.127, Json.397, #Attr.12):
+procedure Json.126 (Json.127, Json.399, #Attr.12):
     let Json.125 : List Str = StructAtIndex 1 #Attr.12;
     inc Json.125;
     let Json.124 : Str = StructAtIndex 0 #Attr.12;
     inc Json.124;
     dec #Attr.12;
-    let Json.435 : I64 = 123i64;
+    let Json.437 : I64 = 123i64;
+    let Json.436 : U8 = CallByName Num.125 Json.437;
+    let Json.433 : List U8 = CallByName List.4 Json.127 Json.436;
+    let Json.435 : I64 = 34i64;
     let Json.434 : U8 = CallByName Num.125 Json.435;
-    let Json.431 : List U8 = CallByName List.4 Json.127 Json.434;
-    let Json.433 : I64 = 34i64;
-    let Json.432 : U8 = CallByName Num.125 Json.433;
-    let Json.429 : List U8 = CallByName List.4 Json.431 Json.432;
-    let Json.430 : List U8 = CallByName Str.12 Json.124;
-    let Json.426 : List U8 = CallByName List.8 Json.429 Json.430;
-    let Json.428 : I64 = 34i64;
-    let Json.427 : U8 = CallByName Num.125 Json.428;
-    let Json.423 : List U8 = CallByName List.4 Json.426 Json.427;
-    let Json.425 : I64 = 58i64;
-    let Json.424 : U8 = CallByName Num.125 Json.425;
-    let Json.420 : List U8 = CallByName List.4 Json.423 Json.424;
-    let Json.422 : I64 = 91i64;
-    let Json.421 : U8 = CallByName Num.125 Json.422;
-    let Json.129 : List U8 = CallByName List.4 Json.420 Json.421;
-    let Json.419 : U64 = CallByName List.6 Json.125;
-    let Json.407 : {List U8, U64} = Struct {Json.129, Json.419};
-    let Json.408 : {} = Struct {};
-    let Json.406 : {List U8, U64} = CallByName List.18 Json.125 Json.407 Json.408;
+    let Json.431 : List U8 = CallByName List.4 Json.433 Json.434;
+    let Json.432 : List U8 = CallByName Str.12 Json.124;
+    let Json.428 : List U8 = CallByName List.8 Json.431 Json.432;
+    let Json.430 : I64 = 34i64;
+    let Json.429 : U8 = CallByName Num.125 Json.430;
+    let Json.425 : List U8 = CallByName List.4 Json.428 Json.429;
+    let Json.427 : I64 = 58i64;
+    let Json.426 : U8 = CallByName Num.125 Json.427;
+    let Json.422 : List U8 = CallByName List.4 Json.425 Json.426;
+    let Json.424 : I64 = 91i64;
+    let Json.423 : U8 = CallByName Num.125 Json.424;
+    let Json.129 : List U8 = CallByName List.4 Json.422 Json.423;
+    let Json.421 : U64 = CallByName List.6 Json.125;
+    let Json.409 : {List U8, U64} = Struct {Json.129, Json.421};
+    let Json.410 : {} = Struct {};
+    let Json.408 : {List U8, U64} = CallByName List.18 Json.125 Json.409 Json.410;
     dec Json.125;
-    let Json.131 : List U8 = StructAtIndex 0 Json.406;
+    let Json.131 : List U8 = StructAtIndex 0 Json.408;
     inc Json.131;
-    dec Json.406;
-    let Json.405 : I64 = 93i64;
+    dec Json.408;
+    let Json.407 : I64 = 93i64;
+    let Json.406 : U8 = CallByName Num.125 Json.407;
+    let Json.403 : List U8 = CallByName List.4 Json.131 Json.406;
+    let Json.405 : I64 = 125i64;
     let Json.404 : U8 = CallByName Num.125 Json.405;
-    let Json.401 : List U8 = CallByName List.4 Json.131 Json.404;
-    let Json.403 : I64 = 125i64;
-    let Json.402 : U8 = CallByName Num.125 Json.403;
-    let Json.400 : List U8 = CallByName List.4 Json.401 Json.402;
-    ret Json.400;
+    let Json.402 : List U8 = CallByName List.4 Json.403 Json.404;
+    ret Json.402;
 
-procedure Json.128 (Json.399, Json.134):
-    let Json.132 : List U8 = StructAtIndex 0 Json.399;
+procedure Json.128 (Json.401, Json.134):
+    let Json.132 : List U8 = StructAtIndex 0 Json.401;
     inc Json.132;
-    let Json.133 : U64 = StructAtIndex 1 Json.399;
-    dec Json.399;
-    let Json.418 : {} = Struct {};
-    let Json.135 : List U8 = CallByName Encode.23 Json.132 Json.134 Json.418;
-    joinpoint Json.413 Json.136:
-        let Json.411 : U64 = 1i64;
-        let Json.410 : U64 = CallByName Num.20 Json.133 Json.411;
-        let Json.409 : {List U8, U64} = Struct {Json.136, Json.410};
-        ret Json.409;
+    let Json.133 : U64 = StructAtIndex 1 Json.401;
+    dec Json.401;
+    let Json.420 : {} = Struct {};
+    let Json.135 : List U8 = CallByName Encode.23 Json.132 Json.134 Json.420;
+    joinpoint Json.415 Json.136:
+        let Json.413 : U64 = 1i64;
+        let Json.412 : U64 = CallByName Num.20 Json.133 Json.413;
+        let Json.411 : {List U8, U64} = Struct {Json.136, Json.412};
+        ret Json.411;
     in
-    let Json.417 : U64 = 1i64;
-    let Json.414 : Int1 = CallByName Num.24 Json.133 Json.417;
-    if Json.414 then
-        let Json.416 : I64 = 44i64;
-        let Json.415 : U8 = CallByName Num.125 Json.416;
-        let Json.412 : List U8 = CallByName List.4 Json.135 Json.415;
-        jump Json.413 Json.412;
+    let Json.419 : U64 = 1i64;
+    let Json.416 : Int1 = CallByName Num.24 Json.133 Json.419;
+    if Json.416 then
+        let Json.418 : I64 = 44i64;
+        let Json.417 : U8 = CallByName Num.125 Json.418;
+        let Json.414 : List U8 = CallByName List.4 Json.135 Json.417;
+        jump Json.415 Json.414;
     else
-        jump Json.413 Json.135;
+        jump Json.415 Json.135;
 
 procedure Json.18 (Json.95):
-    let Json.436 : Str = CallByName Encode.22 Json.95;
-    ret Json.436;
+    let Json.438 : Str = CallByName Encode.22 Json.95;
+    ret Json.438;
 
 procedure Json.21 (Json.124, Json.125):
-    let Json.396 : {Str, List Str} = Struct {Json.124, Json.125};
-    let Json.395 : {Str, List Str} = CallByName Encode.22 Json.396;
-    ret Json.395;
+    let Json.398 : {Str, List Str} = Struct {Json.124, Json.125};
+    let Json.397 : {Str, List Str} = CallByName Encode.22 Json.398;
+    ret Json.397;
 
-procedure Json.96 (Json.97, Json.438, Json.95):
-    let Json.447 : I64 = 34i64;
-    let Json.446 : U8 = CallByName Num.125 Json.447;
-    let Json.444 : List U8 = CallByName List.4 Json.97 Json.446;
-    let Json.445 : List U8 = CallByName Str.12 Json.95;
-    let Json.441 : List U8 = CallByName List.8 Json.444 Json.445;
-    let Json.443 : I64 = 34i64;
-    let Json.442 : U8 = CallByName Num.125 Json.443;
-    let Json.440 : List U8 = CallByName List.4 Json.441 Json.442;
-    ret Json.440;
+procedure Json.96 (Json.97, Json.440, Json.95):
+    let Json.449 : I64 = 34i64;
+    let Json.448 : U8 = CallByName Num.125 Json.449;
+    let Json.446 : List U8 = CallByName List.4 Json.97 Json.448;
+    let Json.447 : List U8 = CallByName Str.12 Json.95;
+    let Json.443 : List U8 = CallByName List.8 Json.446 Json.447;
+    let Json.445 : I64 = 34i64;
+    let Json.444 : U8 = CallByName Num.125 Json.445;
+    let Json.442 : List U8 = CallByName List.4 Json.443 Json.444;
+    ret Json.442;
 
-procedure List.137 (List.138, List.139, List.136):
-    let List.462 : {List U8, U64} = CallByName Json.128 List.138 List.139;
-    ret List.462;
+procedure List.138 (List.139, List.140, List.137):
+    let List.531 : {List U8, U64} = CallByName Json.128 List.139 List.140;
+    ret List.531;
 
-procedure List.18 (List.134, List.135, List.136):
-    let List.443 : {List U8, U64} = CallByName List.89 List.134 List.135 List.136;
-    ret List.443;
+procedure List.18 (List.135, List.136, List.137):
+    let List.512 : {List U8, U64} = CallByName List.90 List.135 List.136 List.137;
+    ret List.512;
 
-procedure List.4 (List.105, List.106):
-    let List.442 : U64 = 1i64;
-    let List.441 : List U8 = CallByName List.70 List.105 List.442;
-    let List.440 : List U8 = CallByName List.71 List.441 List.106;
-    ret List.440;
-
-procedure List.6 (#Attr.2):
-    let List.409 : U64 = lowlevel ListLen #Attr.2;
-    ret List.409;
+procedure List.4 (List.106, List.107):
+    let List.511 : U64 = 1i64;
+    let List.510 : List U8 = CallByName List.70 List.106 List.511;
+    let List.509 : List U8 = CallByName List.71 List.510 List.107;
+    ret List.509;
 
 procedure List.6 (#Attr.2):
-    let List.463 : U64 = lowlevel ListLen #Attr.2;
-    ret List.463;
+    let List.478 : U64 = lowlevel ListLen #Attr.2;
+    ret List.478;
+
+procedure List.6 (#Attr.2):
+    let List.532 : U64 = lowlevel ListLen #Attr.2;
+    ret List.532;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.459 : Str = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.459;
+    let List.528 : Str = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.528;
 
 procedure List.70 (#Attr.2, #Attr.3):
-    let List.415 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
-    ret List.415;
+    let List.484 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
+    ret List.484;
 
 procedure List.71 (#Attr.2, #Attr.3):
-    let List.413 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
-    ret List.413;
+    let List.482 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
+    ret List.482;
 
 procedure List.8 (#Attr.2, #Attr.3):
-    let List.465 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
-    ret List.465;
+    let List.534 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
+    ret List.534;
 
-procedure List.89 (List.385, List.386, List.387):
-    let List.447 : U64 = 0i64;
-    let List.448 : U64 = CallByName List.6 List.385;
-    let List.446 : {List U8, U64} = CallByName List.90 List.385 List.386 List.387 List.447 List.448;
-    ret List.446;
+procedure List.90 (List.426, List.427, List.428):
+    let List.516 : U64 = 0i64;
+    let List.517 : U64 = CallByName List.6 List.426;
+    let List.515 : {List U8, U64} = CallByName List.91 List.426 List.427 List.428 List.516 List.517;
+    ret List.515;
 
-procedure List.90 (List.475, List.476, List.477, List.478, List.479):
-    joinpoint List.449 List.388 List.389 List.390 List.391 List.392:
-        let List.451 : Int1 = CallByName Num.22 List.391 List.392;
-        if List.451 then
-            let List.458 : Str = CallByName List.66 List.388 List.391;
-            let List.452 : {List U8, U64} = CallByName List.137 List.389 List.458 List.390;
-            let List.455 : U64 = 1i64;
-            let List.454 : U64 = CallByName Num.19 List.391 List.455;
-            jump List.449 List.388 List.452 List.390 List.454 List.392;
+procedure List.91 (List.544, List.545, List.546, List.547, List.548):
+    joinpoint List.518 List.429 List.430 List.431 List.432 List.433:
+        let List.520 : Int1 = CallByName Num.22 List.432 List.433;
+        if List.520 then
+            let List.527 : Str = CallByName List.66 List.429 List.432;
+            let List.521 : {List U8, U64} = CallByName List.138 List.430 List.527 List.431;
+            let List.524 : U64 = 1i64;
+            let List.523 : U64 = CallByName Num.19 List.432 List.524;
+            jump List.518 List.429 List.521 List.431 List.523 List.433;
         else
-            ret List.389;
+            ret List.430;
     in
-    jump List.449 List.475 List.476 List.477 List.478 List.479;
+    jump List.518 List.544 List.545 List.546 List.547 List.548;
 
 procedure Num.125 (#Attr.2):
     let Num.265 : U8 = lowlevel NumIntCast #Attr.2;

--- a/crates/compiler/test_mono/generated/encode_derived_tag_two_payloads_string.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_tag_two_payloads_string.txt
@@ -47,148 +47,148 @@ procedure Encode.25 (Encode.100, Encode.101):
     ret Encode.103;
 
 procedure Json.1 ():
-    let Json.394 : {} = Struct {};
-    ret Json.394;
+    let Json.396 : {} = Struct {};
+    ret Json.396;
 
-procedure Json.126 (Json.127, Json.397, #Attr.12):
+procedure Json.126 (Json.127, Json.399, #Attr.12):
     let Json.125 : List Str = StructAtIndex 1 #Attr.12;
     inc Json.125;
     let Json.124 : Str = StructAtIndex 0 #Attr.12;
     inc Json.124;
     dec #Attr.12;
-    let Json.435 : I64 = 123i64;
+    let Json.437 : I64 = 123i64;
+    let Json.436 : U8 = CallByName Num.125 Json.437;
+    let Json.433 : List U8 = CallByName List.4 Json.127 Json.436;
+    let Json.435 : I64 = 34i64;
     let Json.434 : U8 = CallByName Num.125 Json.435;
-    let Json.431 : List U8 = CallByName List.4 Json.127 Json.434;
-    let Json.433 : I64 = 34i64;
-    let Json.432 : U8 = CallByName Num.125 Json.433;
-    let Json.429 : List U8 = CallByName List.4 Json.431 Json.432;
-    let Json.430 : List U8 = CallByName Str.12 Json.124;
-    let Json.426 : List U8 = CallByName List.8 Json.429 Json.430;
-    let Json.428 : I64 = 34i64;
-    let Json.427 : U8 = CallByName Num.125 Json.428;
-    let Json.423 : List U8 = CallByName List.4 Json.426 Json.427;
-    let Json.425 : I64 = 58i64;
-    let Json.424 : U8 = CallByName Num.125 Json.425;
-    let Json.420 : List U8 = CallByName List.4 Json.423 Json.424;
-    let Json.422 : I64 = 91i64;
-    let Json.421 : U8 = CallByName Num.125 Json.422;
-    let Json.129 : List U8 = CallByName List.4 Json.420 Json.421;
-    let Json.419 : U64 = CallByName List.6 Json.125;
-    let Json.407 : {List U8, U64} = Struct {Json.129, Json.419};
-    let Json.408 : {} = Struct {};
-    let Json.406 : {List U8, U64} = CallByName List.18 Json.125 Json.407 Json.408;
+    let Json.431 : List U8 = CallByName List.4 Json.433 Json.434;
+    let Json.432 : List U8 = CallByName Str.12 Json.124;
+    let Json.428 : List U8 = CallByName List.8 Json.431 Json.432;
+    let Json.430 : I64 = 34i64;
+    let Json.429 : U8 = CallByName Num.125 Json.430;
+    let Json.425 : List U8 = CallByName List.4 Json.428 Json.429;
+    let Json.427 : I64 = 58i64;
+    let Json.426 : U8 = CallByName Num.125 Json.427;
+    let Json.422 : List U8 = CallByName List.4 Json.425 Json.426;
+    let Json.424 : I64 = 91i64;
+    let Json.423 : U8 = CallByName Num.125 Json.424;
+    let Json.129 : List U8 = CallByName List.4 Json.422 Json.423;
+    let Json.421 : U64 = CallByName List.6 Json.125;
+    let Json.409 : {List U8, U64} = Struct {Json.129, Json.421};
+    let Json.410 : {} = Struct {};
+    let Json.408 : {List U8, U64} = CallByName List.18 Json.125 Json.409 Json.410;
     dec Json.125;
-    let Json.131 : List U8 = StructAtIndex 0 Json.406;
+    let Json.131 : List U8 = StructAtIndex 0 Json.408;
     inc Json.131;
-    dec Json.406;
-    let Json.405 : I64 = 93i64;
+    dec Json.408;
+    let Json.407 : I64 = 93i64;
+    let Json.406 : U8 = CallByName Num.125 Json.407;
+    let Json.403 : List U8 = CallByName List.4 Json.131 Json.406;
+    let Json.405 : I64 = 125i64;
     let Json.404 : U8 = CallByName Num.125 Json.405;
-    let Json.401 : List U8 = CallByName List.4 Json.131 Json.404;
-    let Json.403 : I64 = 125i64;
-    let Json.402 : U8 = CallByName Num.125 Json.403;
-    let Json.400 : List U8 = CallByName List.4 Json.401 Json.402;
-    ret Json.400;
+    let Json.402 : List U8 = CallByName List.4 Json.403 Json.404;
+    ret Json.402;
 
-procedure Json.128 (Json.399, Json.134):
-    let Json.132 : List U8 = StructAtIndex 0 Json.399;
+procedure Json.128 (Json.401, Json.134):
+    let Json.132 : List U8 = StructAtIndex 0 Json.401;
     inc Json.132;
-    let Json.133 : U64 = StructAtIndex 1 Json.399;
-    dec Json.399;
-    let Json.418 : {} = Struct {};
-    let Json.135 : List U8 = CallByName Encode.23 Json.132 Json.134 Json.418;
-    joinpoint Json.413 Json.136:
-        let Json.411 : U64 = 1i64;
-        let Json.410 : U64 = CallByName Num.20 Json.133 Json.411;
-        let Json.409 : {List U8, U64} = Struct {Json.136, Json.410};
-        ret Json.409;
+    let Json.133 : U64 = StructAtIndex 1 Json.401;
+    dec Json.401;
+    let Json.420 : {} = Struct {};
+    let Json.135 : List U8 = CallByName Encode.23 Json.132 Json.134 Json.420;
+    joinpoint Json.415 Json.136:
+        let Json.413 : U64 = 1i64;
+        let Json.412 : U64 = CallByName Num.20 Json.133 Json.413;
+        let Json.411 : {List U8, U64} = Struct {Json.136, Json.412};
+        ret Json.411;
     in
-    let Json.417 : U64 = 1i64;
-    let Json.414 : Int1 = CallByName Num.24 Json.133 Json.417;
-    if Json.414 then
-        let Json.416 : I64 = 44i64;
-        let Json.415 : U8 = CallByName Num.125 Json.416;
-        let Json.412 : List U8 = CallByName List.4 Json.135 Json.415;
-        jump Json.413 Json.412;
+    let Json.419 : U64 = 1i64;
+    let Json.416 : Int1 = CallByName Num.24 Json.133 Json.419;
+    if Json.416 then
+        let Json.418 : I64 = 44i64;
+        let Json.417 : U8 = CallByName Num.125 Json.418;
+        let Json.414 : List U8 = CallByName List.4 Json.135 Json.417;
+        jump Json.415 Json.414;
     else
-        jump Json.413 Json.135;
+        jump Json.415 Json.135;
 
 procedure Json.18 (Json.95):
-    let Json.448 : Str = CallByName Encode.22 Json.95;
-    ret Json.448;
+    let Json.450 : Str = CallByName Encode.22 Json.95;
+    ret Json.450;
 
 procedure Json.21 (Json.124, Json.125):
-    let Json.396 : {Str, List Str} = Struct {Json.124, Json.125};
-    let Json.395 : {Str, List Str} = CallByName Encode.22 Json.396;
-    ret Json.395;
+    let Json.398 : {Str, List Str} = Struct {Json.124, Json.125};
+    let Json.397 : {Str, List Str} = CallByName Encode.22 Json.398;
+    ret Json.397;
 
-procedure Json.96 (Json.97, Json.438, Json.95):
-    let Json.447 : I64 = 34i64;
-    let Json.446 : U8 = CallByName Num.125 Json.447;
-    let Json.444 : List U8 = CallByName List.4 Json.97 Json.446;
-    let Json.445 : List U8 = CallByName Str.12 Json.95;
-    let Json.441 : List U8 = CallByName List.8 Json.444 Json.445;
-    let Json.443 : I64 = 34i64;
-    let Json.442 : U8 = CallByName Num.125 Json.443;
-    let Json.440 : List U8 = CallByName List.4 Json.441 Json.442;
-    ret Json.440;
+procedure Json.96 (Json.97, Json.440, Json.95):
+    let Json.449 : I64 = 34i64;
+    let Json.448 : U8 = CallByName Num.125 Json.449;
+    let Json.446 : List U8 = CallByName List.4 Json.97 Json.448;
+    let Json.447 : List U8 = CallByName Str.12 Json.95;
+    let Json.443 : List U8 = CallByName List.8 Json.446 Json.447;
+    let Json.445 : I64 = 34i64;
+    let Json.444 : U8 = CallByName Num.125 Json.445;
+    let Json.442 : List U8 = CallByName List.4 Json.443 Json.444;
+    ret Json.442;
 
-procedure List.137 (List.138, List.139, List.136):
-    let List.462 : {List U8, U64} = CallByName Json.128 List.138 List.139;
-    ret List.462;
+procedure List.138 (List.139, List.140, List.137):
+    let List.531 : {List U8, U64} = CallByName Json.128 List.139 List.140;
+    ret List.531;
 
-procedure List.18 (List.134, List.135, List.136):
-    let List.443 : {List U8, U64} = CallByName List.89 List.134 List.135 List.136;
-    ret List.443;
+procedure List.18 (List.135, List.136, List.137):
+    let List.512 : {List U8, U64} = CallByName List.90 List.135 List.136 List.137;
+    ret List.512;
 
-procedure List.4 (List.105, List.106):
-    let List.442 : U64 = 1i64;
-    let List.441 : List U8 = CallByName List.70 List.105 List.442;
-    let List.440 : List U8 = CallByName List.71 List.441 List.106;
-    ret List.440;
-
-procedure List.6 (#Attr.2):
-    let List.409 : U64 = lowlevel ListLen #Attr.2;
-    ret List.409;
+procedure List.4 (List.106, List.107):
+    let List.511 : U64 = 1i64;
+    let List.510 : List U8 = CallByName List.70 List.106 List.511;
+    let List.509 : List U8 = CallByName List.71 List.510 List.107;
+    ret List.509;
 
 procedure List.6 (#Attr.2):
-    let List.463 : U64 = lowlevel ListLen #Attr.2;
-    ret List.463;
+    let List.478 : U64 = lowlevel ListLen #Attr.2;
+    ret List.478;
+
+procedure List.6 (#Attr.2):
+    let List.532 : U64 = lowlevel ListLen #Attr.2;
+    ret List.532;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.459 : Str = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.459;
+    let List.528 : Str = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.528;
 
 procedure List.70 (#Attr.2, #Attr.3):
-    let List.415 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
-    ret List.415;
+    let List.484 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
+    ret List.484;
 
 procedure List.71 (#Attr.2, #Attr.3):
-    let List.413 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
-    ret List.413;
+    let List.482 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
+    ret List.482;
 
 procedure List.8 (#Attr.2, #Attr.3):
-    let List.465 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
-    ret List.465;
+    let List.534 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
+    ret List.534;
 
-procedure List.89 (List.385, List.386, List.387):
-    let List.447 : U64 = 0i64;
-    let List.448 : U64 = CallByName List.6 List.385;
-    let List.446 : {List U8, U64} = CallByName List.90 List.385 List.386 List.387 List.447 List.448;
-    ret List.446;
+procedure List.90 (List.426, List.427, List.428):
+    let List.516 : U64 = 0i64;
+    let List.517 : U64 = CallByName List.6 List.426;
+    let List.515 : {List U8, U64} = CallByName List.91 List.426 List.427 List.428 List.516 List.517;
+    ret List.515;
 
-procedure List.90 (List.475, List.476, List.477, List.478, List.479):
-    joinpoint List.449 List.388 List.389 List.390 List.391 List.392:
-        let List.451 : Int1 = CallByName Num.22 List.391 List.392;
-        if List.451 then
-            let List.458 : Str = CallByName List.66 List.388 List.391;
-            let List.452 : {List U8, U64} = CallByName List.137 List.389 List.458 List.390;
-            let List.455 : U64 = 1i64;
-            let List.454 : U64 = CallByName Num.19 List.391 List.455;
-            jump List.449 List.388 List.452 List.390 List.454 List.392;
+procedure List.91 (List.544, List.545, List.546, List.547, List.548):
+    joinpoint List.518 List.429 List.430 List.431 List.432 List.433:
+        let List.520 : Int1 = CallByName Num.22 List.432 List.433;
+        if List.520 then
+            let List.527 : Str = CallByName List.66 List.429 List.432;
+            let List.521 : {List U8, U64} = CallByName List.138 List.430 List.527 List.431;
+            let List.524 : U64 = 1i64;
+            let List.523 : U64 = CallByName Num.19 List.432 List.524;
+            jump List.518 List.429 List.521 List.431 List.523 List.433;
         else
-            ret List.389;
+            ret List.430;
     in
-    jump List.449 List.475 List.476 List.477 List.478 List.479;
+    jump List.518 List.544 List.545 List.546 List.547 List.548;
 
 procedure Num.125 (#Attr.2):
     let Num.265 : U8 = lowlevel NumIntCast #Attr.2;

--- a/crates/compiler/test_mono/generated/ir_int_add.txt
+++ b/crates/compiler/test_mono/generated/ir_int_add.txt
@@ -1,6 +1,6 @@
 procedure List.6 (#Attr.2):
-    let List.409 : U64 = lowlevel ListLen #Attr.2;
-    ret List.409;
+    let List.478 : U64 = lowlevel ListLen #Attr.2;
+    ret List.478;
 
 procedure Num.19 (#Attr.2, #Attr.3):
     let Num.258 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/issue_2583_specialize_errors_behind_unified_branches.txt
+++ b/crates/compiler/test_mono/generated/issue_2583_specialize_errors_behind_unified_branches.txt
@@ -6,40 +6,40 @@ procedure Bool.2 ():
     let Bool.23 : Int1 = true;
     ret Bool.23;
 
-procedure List.2 (List.94, List.95):
-    let List.423 : U64 = CallByName List.6 List.94;
-    let List.419 : Int1 = CallByName Num.22 List.95 List.423;
-    if List.419 then
-        let List.421 : I64 = CallByName List.66 List.94 List.95;
-        let List.420 : [C {}, C I64] = TagId(1) List.421;
-        ret List.420;
+procedure List.2 (List.95, List.96):
+    let List.492 : U64 = CallByName List.6 List.95;
+    let List.488 : Int1 = CallByName Num.22 List.96 List.492;
+    if List.488 then
+        let List.490 : I64 = CallByName List.66 List.95 List.96;
+        let List.489 : [C {}, C I64] = TagId(1) List.490;
+        ret List.489;
     else
-        let List.418 : {} = Struct {};
-        let List.417 : [C {}, C I64] = TagId(0) List.418;
-        ret List.417;
+        let List.487 : {} = Struct {};
+        let List.486 : [C {}, C I64] = TagId(0) List.487;
+        ret List.486;
 
 procedure List.6 (#Attr.2):
-    let List.424 : U64 = lowlevel ListLen #Attr.2;
-    ret List.424;
+    let List.493 : U64 = lowlevel ListLen #Attr.2;
+    ret List.493;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.422 : I64 = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.422;
+    let List.491 : I64 = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.491;
 
-procedure List.9 (List.242):
-    let List.416 : U64 = 0i64;
-    let List.409 : [C {}, C I64] = CallByName List.2 List.242 List.416;
-    let List.413 : U8 = 1i64;
-    let List.414 : U8 = GetTagId List.409;
-    let List.415 : Int1 = lowlevel Eq List.413 List.414;
-    if List.415 then
-        let List.243 : I64 = UnionAtIndex (Id 1) (Index 0) List.409;
-        let List.410 : [C Int1, C I64] = TagId(1) List.243;
-        ret List.410;
+procedure List.9 (List.283):
+    let List.485 : U64 = 0i64;
+    let List.478 : [C {}, C I64] = CallByName List.2 List.283 List.485;
+    let List.482 : U8 = 1i64;
+    let List.483 : U8 = GetTagId List.478;
+    let List.484 : Int1 = lowlevel Eq List.482 List.483;
+    if List.484 then
+        let List.284 : I64 = UnionAtIndex (Id 1) (Index 0) List.478;
+        let List.479 : [C Int1, C I64] = TagId(1) List.284;
+        ret List.479;
     else
-        let List.412 : Int1 = true;
-        let List.411 : [C Int1, C I64] = TagId(0) List.412;
-        ret List.411;
+        let List.481 : Int1 = true;
+        let List.480 : [C Int1, C I64] = TagId(0) List.481;
+        ret List.480;
 
 procedure Num.22 (#Attr.2, #Attr.3):
     let Num.256 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/list_append.txt
+++ b/crates/compiler/test_mono/generated/list_append.txt
@@ -1,16 +1,16 @@
-procedure List.4 (List.105, List.106):
-    let List.412 : U64 = 1i64;
-    let List.410 : List I64 = CallByName List.70 List.105 List.412;
-    let List.409 : List I64 = CallByName List.71 List.410 List.106;
-    ret List.409;
+procedure List.4 (List.106, List.107):
+    let List.481 : U64 = 1i64;
+    let List.479 : List I64 = CallByName List.70 List.106 List.481;
+    let List.478 : List I64 = CallByName List.71 List.479 List.107;
+    ret List.478;
 
 procedure List.70 (#Attr.2, #Attr.3):
-    let List.413 : List I64 = lowlevel ListReserve #Attr.2 #Attr.3;
-    ret List.413;
+    let List.482 : List I64 = lowlevel ListReserve #Attr.2 #Attr.3;
+    ret List.482;
 
 procedure List.71 (#Attr.2, #Attr.3):
-    let List.411 : List I64 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
-    ret List.411;
+    let List.480 : List I64 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
+    ret List.480;
 
 procedure Test.0 ():
     let Test.2 : List I64 = Array [1i64];

--- a/crates/compiler/test_mono/generated/list_append_closure.txt
+++ b/crates/compiler/test_mono/generated/list_append_closure.txt
@@ -1,16 +1,16 @@
-procedure List.4 (List.105, List.106):
-    let List.412 : U64 = 1i64;
-    let List.410 : List I64 = CallByName List.70 List.105 List.412;
-    let List.409 : List I64 = CallByName List.71 List.410 List.106;
-    ret List.409;
+procedure List.4 (List.106, List.107):
+    let List.481 : U64 = 1i64;
+    let List.479 : List I64 = CallByName List.70 List.106 List.481;
+    let List.478 : List I64 = CallByName List.71 List.479 List.107;
+    ret List.478;
 
 procedure List.70 (#Attr.2, #Attr.3):
-    let List.413 : List I64 = lowlevel ListReserve #Attr.2 #Attr.3;
-    ret List.413;
+    let List.482 : List I64 = lowlevel ListReserve #Attr.2 #Attr.3;
+    ret List.482;
 
 procedure List.71 (#Attr.2, #Attr.3):
-    let List.411 : List I64 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
-    ret List.411;
+    let List.480 : List I64 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
+    ret List.480;
 
 procedure Test.1 (Test.2):
     let Test.6 : I64 = 42i64;

--- a/crates/compiler/test_mono/generated/list_cannot_update_inplace.txt
+++ b/crates/compiler/test_mono/generated/list_cannot_update_inplace.txt
@@ -1,27 +1,27 @@
-procedure List.3 (List.102, List.103, List.104):
-    let List.412 : {List I64, I64} = CallByName List.64 List.102 List.103 List.104;
-    let List.411 : List I64 = StructAtIndex 0 List.412;
-    inc List.411;
-    dec List.412;
-    ret List.411;
+procedure List.3 (List.103, List.104, List.105):
+    let List.481 : {List I64, I64} = CallByName List.64 List.103 List.104 List.105;
+    let List.480 : List I64 = StructAtIndex 0 List.481;
+    inc List.480;
+    dec List.481;
+    ret List.480;
 
 procedure List.6 (#Attr.2):
-    let List.410 : U64 = lowlevel ListLen #Attr.2;
-    ret List.410;
+    let List.479 : U64 = lowlevel ListLen #Attr.2;
+    ret List.479;
 
-procedure List.64 (List.99, List.100, List.101):
-    let List.417 : U64 = CallByName List.6 List.99;
-    let List.414 : Int1 = CallByName Num.22 List.100 List.417;
-    if List.414 then
-        let List.415 : {List I64, I64} = CallByName List.67 List.99 List.100 List.101;
-        ret List.415;
+procedure List.64 (List.100, List.101, List.102):
+    let List.486 : U64 = CallByName List.6 List.100;
+    let List.483 : Int1 = CallByName Num.22 List.101 List.486;
+    if List.483 then
+        let List.484 : {List I64, I64} = CallByName List.67 List.100 List.101 List.102;
+        ret List.484;
     else
-        let List.413 : {List I64, I64} = Struct {List.99, List.101};
-        ret List.413;
+        let List.482 : {List I64, I64} = Struct {List.100, List.102};
+        ret List.482;
 
 procedure List.67 (#Attr.2, #Attr.3, #Attr.4):
-    let List.416 : {List I64, I64} = lowlevel ListReplaceUnsafe #Attr.2 #Attr.3 #Attr.4;
-    ret List.416;
+    let List.485 : {List I64, I64} = lowlevel ListReplaceUnsafe #Attr.2 #Attr.3 #Attr.4;
+    ret List.485;
 
 procedure Num.19 (#Attr.2, #Attr.3):
     let Num.256 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/list_get.txt
+++ b/crates/compiler/test_mono/generated/list_get.txt
@@ -1,22 +1,22 @@
-procedure List.2 (List.94, List.95):
-    let List.415 : U64 = CallByName List.6 List.94;
-    let List.411 : Int1 = CallByName Num.22 List.95 List.415;
-    if List.411 then
-        let List.413 : I64 = CallByName List.66 List.94 List.95;
-        let List.412 : [C {}, C I64] = TagId(1) List.413;
-        ret List.412;
+procedure List.2 (List.95, List.96):
+    let List.484 : U64 = CallByName List.6 List.95;
+    let List.480 : Int1 = CallByName Num.22 List.96 List.484;
+    if List.480 then
+        let List.482 : I64 = CallByName List.66 List.95 List.96;
+        let List.481 : [C {}, C I64] = TagId(1) List.482;
+        ret List.481;
     else
-        let List.410 : {} = Struct {};
-        let List.409 : [C {}, C I64] = TagId(0) List.410;
-        ret List.409;
+        let List.479 : {} = Struct {};
+        let List.478 : [C {}, C I64] = TagId(0) List.479;
+        ret List.478;
 
 procedure List.6 (#Attr.2):
-    let List.416 : U64 = lowlevel ListLen #Attr.2;
-    ret List.416;
+    let List.485 : U64 = lowlevel ListLen #Attr.2;
+    ret List.485;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.414 : I64 = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.414;
+    let List.483 : I64 = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.483;
 
 procedure Num.22 (#Attr.2, #Attr.3):
     let Num.256 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/list_len.txt
+++ b/crates/compiler/test_mono/generated/list_len.txt
@@ -1,10 +1,10 @@
 procedure List.6 (#Attr.2):
-    let List.409 : U64 = lowlevel ListLen #Attr.2;
-    ret List.409;
+    let List.478 : U64 = lowlevel ListLen #Attr.2;
+    ret List.478;
 
 procedure List.6 (#Attr.2):
-    let List.410 : U64 = lowlevel ListLen #Attr.2;
-    ret List.410;
+    let List.479 : U64 = lowlevel ListLen #Attr.2;
+    ret List.479;
 
 procedure Num.19 (#Attr.2, #Attr.3):
     let Num.256 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/list_map_closure_borrows.txt
+++ b/crates/compiler/test_mono/generated/list_map_closure_borrows.txt
@@ -1,26 +1,26 @@
-procedure List.2 (List.94, List.95):
-    let List.415 : U64 = CallByName List.6 List.94;
-    let List.411 : Int1 = CallByName Num.22 List.95 List.415;
-    if List.411 then
-        let List.413 : Str = CallByName List.66 List.94 List.95;
-        let List.412 : [C {}, C Str] = TagId(1) List.413;
-        ret List.412;
+procedure List.2 (List.95, List.96):
+    let List.484 : U64 = CallByName List.6 List.95;
+    let List.480 : Int1 = CallByName Num.22 List.96 List.484;
+    if List.480 then
+        let List.482 : Str = CallByName List.66 List.95 List.96;
+        let List.481 : [C {}, C Str] = TagId(1) List.482;
+        ret List.481;
     else
-        let List.410 : {} = Struct {};
-        let List.409 : [C {}, C Str] = TagId(0) List.410;
-        ret List.409;
+        let List.479 : {} = Struct {};
+        let List.478 : [C {}, C Str] = TagId(0) List.479;
+        ret List.478;
 
 procedure List.5 (#Attr.2, #Attr.3):
-    let List.417 : List Str = lowlevel ListMap { xs: `#Attr.#arg1` } #Attr.2 Test.3 #Attr.3;
-    ret List.417;
+    let List.486 : List Str = lowlevel ListMap { xs: `#Attr.#arg1` } #Attr.2 Test.3 #Attr.3;
+    ret List.486;
 
 procedure List.6 (#Attr.2):
-    let List.416 : U64 = lowlevel ListLen #Attr.2;
-    ret List.416;
+    let List.485 : U64 = lowlevel ListLen #Attr.2;
+    ret List.485;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.414 : Str = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.414;
+    let List.483 : Str = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.483;
 
 procedure Num.22 (#Attr.2, #Attr.3):
     let Num.256 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/list_map_closure_owns.txt
+++ b/crates/compiler/test_mono/generated/list_map_closure_owns.txt
@@ -1,27 +1,27 @@
-procedure List.2 (List.94, List.95):
-    let List.415 : U64 = CallByName List.6 List.94;
-    let List.411 : Int1 = CallByName Num.22 List.95 List.415;
-    if List.411 then
-        let List.413 : Str = CallByName List.66 List.94 List.95;
-        let List.412 : [C {}, C Str] = TagId(1) List.413;
-        ret List.412;
+procedure List.2 (List.95, List.96):
+    let List.484 : U64 = CallByName List.6 List.95;
+    let List.480 : Int1 = CallByName Num.22 List.96 List.484;
+    if List.480 then
+        let List.482 : Str = CallByName List.66 List.95 List.96;
+        let List.481 : [C {}, C Str] = TagId(1) List.482;
+        ret List.481;
     else
-        let List.410 : {} = Struct {};
-        let List.409 : [C {}, C Str] = TagId(0) List.410;
-        ret List.409;
+        let List.479 : {} = Struct {};
+        let List.478 : [C {}, C Str] = TagId(0) List.479;
+        ret List.478;
 
 procedure List.5 (#Attr.2, #Attr.3):
-    let List.417 : List Str = lowlevel ListMap { xs: `#Attr.#arg1` } #Attr.2 Test.3 #Attr.3;
+    let List.486 : List Str = lowlevel ListMap { xs: `#Attr.#arg1` } #Attr.2 Test.3 #Attr.3;
     decref #Attr.2;
-    ret List.417;
+    ret List.486;
 
 procedure List.6 (#Attr.2):
-    let List.416 : U64 = lowlevel ListLen #Attr.2;
-    ret List.416;
+    let List.485 : U64 = lowlevel ListLen #Attr.2;
+    ret List.485;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.414 : Str = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.414;
+    let List.483 : Str = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.483;
 
 procedure Num.22 (#Attr.2, #Attr.3):
     let Num.256 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/list_pass_to_function.txt
+++ b/crates/compiler/test_mono/generated/list_pass_to_function.txt
@@ -1,27 +1,27 @@
-procedure List.3 (List.102, List.103, List.104):
-    let List.410 : {List I64, I64} = CallByName List.64 List.102 List.103 List.104;
-    let List.409 : List I64 = StructAtIndex 0 List.410;
-    inc List.409;
-    dec List.410;
-    ret List.409;
+procedure List.3 (List.103, List.104, List.105):
+    let List.479 : {List I64, I64} = CallByName List.64 List.103 List.104 List.105;
+    let List.478 : List I64 = StructAtIndex 0 List.479;
+    inc List.478;
+    dec List.479;
+    ret List.478;
 
 procedure List.6 (#Attr.2):
-    let List.416 : U64 = lowlevel ListLen #Attr.2;
-    ret List.416;
+    let List.485 : U64 = lowlevel ListLen #Attr.2;
+    ret List.485;
 
-procedure List.64 (List.99, List.100, List.101):
-    let List.415 : U64 = CallByName List.6 List.99;
-    let List.412 : Int1 = CallByName Num.22 List.100 List.415;
-    if List.412 then
-        let List.413 : {List I64, I64} = CallByName List.67 List.99 List.100 List.101;
-        ret List.413;
+procedure List.64 (List.100, List.101, List.102):
+    let List.484 : U64 = CallByName List.6 List.100;
+    let List.481 : Int1 = CallByName Num.22 List.101 List.484;
+    if List.481 then
+        let List.482 : {List I64, I64} = CallByName List.67 List.100 List.101 List.102;
+        ret List.482;
     else
-        let List.411 : {List I64, I64} = Struct {List.99, List.101};
-        ret List.411;
+        let List.480 : {List I64, I64} = Struct {List.100, List.102};
+        ret List.480;
 
 procedure List.67 (#Attr.2, #Attr.3, #Attr.4):
-    let List.414 : {List I64, I64} = lowlevel ListReplaceUnsafe #Attr.2 #Attr.3 #Attr.4;
-    ret List.414;
+    let List.483 : {List I64, I64} = lowlevel ListReplaceUnsafe #Attr.2 #Attr.3 #Attr.4;
+    ret List.483;
 
 procedure Num.22 (#Attr.2, #Attr.3):
     let Num.256 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/list_sort_asc.txt
+++ b/crates/compiler/test_mono/generated/list_sort_asc.txt
@@ -1,16 +1,16 @@
 procedure List.28 (#Attr.2, #Attr.3):
-    let List.411 : List I64 = lowlevel ListSortWith { xs: `#Attr.#arg1` } #Attr.2 Num.46 #Attr.3;
+    let List.480 : List I64 = lowlevel ListSortWith { xs: `#Attr.#arg1` } #Attr.2 Num.46 #Attr.3;
     let #Derived_gen.0 : Int1 = lowlevel ListIsUnique #Attr.2;
     if #Derived_gen.0 then
-        ret List.411;
+        ret List.480;
     else
         decref #Attr.2;
-        ret List.411;
+        ret List.480;
 
-procedure List.59 (List.237):
-    let List.410 : {} = Struct {};
-    let List.409 : List I64 = CallByName List.28 List.237 List.410;
-    ret List.409;
+procedure List.59 (List.278):
+    let List.479 : {} = Struct {};
+    let List.478 : List I64 = CallByName List.28 List.278 List.479;
+    ret List.478;
 
 procedure Num.46 (#Attr.2, #Attr.3):
     let Num.256 : U8 = lowlevel NumCompare #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/quicksort_swap.txt
+++ b/crates/compiler/test_mono/generated/quicksort_swap.txt
@@ -1,43 +1,43 @@
-procedure List.2 (List.94, List.95):
-    let List.431 : U64 = CallByName List.6 List.94;
-    let List.428 : Int1 = CallByName Num.22 List.95 List.431;
-    if List.428 then
-        let List.430 : I64 = CallByName List.66 List.94 List.95;
-        let List.429 : [C {}, C I64] = TagId(1) List.430;
-        ret List.429;
+procedure List.2 (List.95, List.96):
+    let List.500 : U64 = CallByName List.6 List.95;
+    let List.497 : Int1 = CallByName Num.22 List.96 List.500;
+    if List.497 then
+        let List.499 : I64 = CallByName List.66 List.95 List.96;
+        let List.498 : [C {}, C I64] = TagId(1) List.499;
+        ret List.498;
     else
-        let List.427 : {} = Struct {};
-        let List.426 : [C {}, C I64] = TagId(0) List.427;
-        ret List.426;
+        let List.496 : {} = Struct {};
+        let List.495 : [C {}, C I64] = TagId(0) List.496;
+        ret List.495;
 
-procedure List.3 (List.102, List.103, List.104):
-    let List.418 : {List I64, I64} = CallByName List.64 List.102 List.103 List.104;
-    let List.417 : List I64 = StructAtIndex 0 List.418;
-    inc List.417;
-    dec List.418;
-    ret List.417;
+procedure List.3 (List.103, List.104, List.105):
+    let List.487 : {List I64, I64} = CallByName List.64 List.103 List.104 List.105;
+    let List.486 : List I64 = StructAtIndex 0 List.487;
+    inc List.486;
+    dec List.487;
+    ret List.486;
 
 procedure List.6 (#Attr.2):
-    let List.416 : U64 = lowlevel ListLen #Attr.2;
-    ret List.416;
+    let List.485 : U64 = lowlevel ListLen #Attr.2;
+    ret List.485;
 
-procedure List.64 (List.99, List.100, List.101):
-    let List.415 : U64 = CallByName List.6 List.99;
-    let List.412 : Int1 = CallByName Num.22 List.100 List.415;
-    if List.412 then
-        let List.413 : {List I64, I64} = CallByName List.67 List.99 List.100 List.101;
-        ret List.413;
+procedure List.64 (List.100, List.101, List.102):
+    let List.484 : U64 = CallByName List.6 List.100;
+    let List.481 : Int1 = CallByName Num.22 List.101 List.484;
+    if List.481 then
+        let List.482 : {List I64, I64} = CallByName List.67 List.100 List.101 List.102;
+        ret List.482;
     else
-        let List.411 : {List I64, I64} = Struct {List.99, List.101};
-        ret List.411;
+        let List.480 : {List I64, I64} = Struct {List.100, List.102};
+        ret List.480;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.424 : I64 = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.424;
+    let List.493 : I64 = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.493;
 
 procedure List.67 (#Attr.2, #Attr.3, #Attr.4):
-    let List.414 : {List I64, I64} = lowlevel ListReplaceUnsafe #Attr.2 #Attr.3 #Attr.4;
-    ret List.414;
+    let List.483 : {List I64, I64} = lowlevel ListReplaceUnsafe #Attr.2 #Attr.3 #Attr.4;
+    ret List.483;
 
 procedure Num.22 (#Attr.2, #Attr.3):
     let Num.258 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/rigids.txt
+++ b/crates/compiler/test_mono/generated/rigids.txt
@@ -1,43 +1,43 @@
-procedure List.2 (List.94, List.95):
-    let List.431 : U64 = CallByName List.6 List.94;
-    let List.428 : Int1 = CallByName Num.22 List.95 List.431;
-    if List.428 then
-        let List.430 : I64 = CallByName List.66 List.94 List.95;
-        let List.429 : [C {}, C I64] = TagId(1) List.430;
-        ret List.429;
+procedure List.2 (List.95, List.96):
+    let List.500 : U64 = CallByName List.6 List.95;
+    let List.497 : Int1 = CallByName Num.22 List.96 List.500;
+    if List.497 then
+        let List.499 : I64 = CallByName List.66 List.95 List.96;
+        let List.498 : [C {}, C I64] = TagId(1) List.499;
+        ret List.498;
     else
-        let List.427 : {} = Struct {};
-        let List.426 : [C {}, C I64] = TagId(0) List.427;
-        ret List.426;
+        let List.496 : {} = Struct {};
+        let List.495 : [C {}, C I64] = TagId(0) List.496;
+        ret List.495;
 
-procedure List.3 (List.102, List.103, List.104):
-    let List.418 : {List I64, I64} = CallByName List.64 List.102 List.103 List.104;
-    let List.417 : List I64 = StructAtIndex 0 List.418;
-    inc List.417;
-    dec List.418;
-    ret List.417;
+procedure List.3 (List.103, List.104, List.105):
+    let List.487 : {List I64, I64} = CallByName List.64 List.103 List.104 List.105;
+    let List.486 : List I64 = StructAtIndex 0 List.487;
+    inc List.486;
+    dec List.487;
+    ret List.486;
 
 procedure List.6 (#Attr.2):
-    let List.416 : U64 = lowlevel ListLen #Attr.2;
-    ret List.416;
+    let List.485 : U64 = lowlevel ListLen #Attr.2;
+    ret List.485;
 
-procedure List.64 (List.99, List.100, List.101):
-    let List.415 : U64 = CallByName List.6 List.99;
-    let List.412 : Int1 = CallByName Num.22 List.100 List.415;
-    if List.412 then
-        let List.413 : {List I64, I64} = CallByName List.67 List.99 List.100 List.101;
-        ret List.413;
+procedure List.64 (List.100, List.101, List.102):
+    let List.484 : U64 = CallByName List.6 List.100;
+    let List.481 : Int1 = CallByName Num.22 List.101 List.484;
+    if List.481 then
+        let List.482 : {List I64, I64} = CallByName List.67 List.100 List.101 List.102;
+        ret List.482;
     else
-        let List.411 : {List I64, I64} = Struct {List.99, List.101};
-        ret List.411;
+        let List.480 : {List I64, I64} = Struct {List.100, List.102};
+        ret List.480;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.424 : I64 = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.424;
+    let List.493 : I64 = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.493;
 
 procedure List.67 (#Attr.2, #Attr.3, #Attr.4):
-    let List.414 : {List I64, I64} = lowlevel ListReplaceUnsafe #Attr.2 #Attr.3 #Attr.4;
-    ret List.414;
+    let List.483 : {List I64, I64} = lowlevel ListReplaceUnsafe #Attr.2 #Attr.3 #Attr.4;
+    ret List.483;
 
 procedure Num.22 (#Attr.2, #Attr.3):
     let Num.258 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;

--- a/crates/reporting/tests/test_reporting.rs
+++ b/crates/reporting/tests/test_reporting.rs
@@ -11119,7 +11119,7 @@ I recommend using camelCase. It's the standard style in Roc code!
         indoc!(
             r#"
             digits : List U8
-            digits = List.range '0' '9'
+            digits = List.range { start: At '0', end: At '9' }
 
             List.contains digits '☃'
             "#

--- a/examples/gui/breakout/breakout.roc
+++ b/examples/gui/breakout/breakout.roc
@@ -95,7 +95,7 @@ render : Model -> List Elem
 render = \model ->
 
     blocks = List.map
-        (List.range 0 numBlocks)
+        (List.range {start: At 0, end: Length numBlocks})
         \index ->
             col =
                 Num.rem index numCols

--- a/examples/gui/breakout/breakout.roc
+++ b/examples/gui/breakout/breakout.roc
@@ -95,7 +95,7 @@ render : Model -> List Elem
 render = \model ->
 
     blocks = List.map
-        (List.range {start: At 0, end: Length numBlocks})
+        (List.range { start: At 0, end: Length numBlocks })
         \index ->
             col =
                 Num.rem index numCols

--- a/examples/parser/Parser/Str.roc
+++ b/examples/parser/Parser/Str.roc
@@ -177,7 +177,7 @@ anyString = buildPrimitiveParser \fieldRawString ->
 digit : Parser RawStr U8
 digit =
     digitParsers =
-        List.range {start: At '0', end: At '9'}
+        List.range { start: At '0', end: At '9' }
         |> List.map \digitNum ->
             digitNum
             |> codeunit

--- a/examples/parser/Parser/Str.roc
+++ b/examples/parser/Parser/Str.roc
@@ -177,7 +177,7 @@ anyString = buildPrimitiveParser \fieldRawString ->
 digit : Parser RawStr U8
 digit =
     digitParsers =
-        List.range '0' ('9' + 1)
+        List.range {start: At '0', end: At '9'}
         |> List.map \digitNum ->
             digitNum
             |> codeunit


### PR DESCRIPTION
Fixes #4169
Closes #4196

So this version doesn't panic instead it returns `[]` for examples like `List.range { start: At 0i8, end: At 128i8, step: -16 }`. Are you fine with that, @rtfeldman? The reason I went for this is that it simplifies the logic. Otherwise, we can add some extra conditionals for the case that the step is positive, but the start is after the end (and the reverse case). Probably could just directly make it panic instead of having the overflow panic.