### PR TITLE
Correct generalization of imported specializations

### DIFF
--- a/crates/compiler/can/src/constraint.rs
+++ b/crates/compiler/can/src/constraint.rs
@@ -488,17 +488,19 @@ impl Constraints {
     /// then need to find their way to the pool, and a convenient approach turned out to be to
     /// tag them onto the `Let` that we used to add the imported values.
     #[inline(always)]
-    pub fn let_import_constraint<I1, I2>(
+    pub fn let_import_constraint<I1, I2, I3>(
         &mut self,
         rigid_vars: I1,
-        def_types: I2,
+        flex_vars: I2,
+        def_types: I3,
         module_constraint: Constraint,
         pool_variables: &[Variable],
     ) -> Constraint
     where
         I1: IntoIterator<Item = Variable>,
-        I2: IntoIterator<Item = (Symbol, Loc<TypeOrVar>)>,
-        I2::IntoIter: ExactSizeIterator,
+        I2: IntoIterator<Item = Variable>,
+        I3: IntoIterator<Item = (Symbol, Loc<TypeOrVar>)>,
+        I3::IntoIter: ExactSizeIterator,
     {
         // defs and ret constraint are stored consequtively, so we only need to store one index
         let defs_and_ret_constraint = Index::new(self.constraints.len() as _);
@@ -508,7 +510,7 @@ impl Constraints {
 
         let let_contraint = LetConstraint {
             rigid_vars: self.variable_slice(rigid_vars),
-            flex_vars: Slice::default(),
+            flex_vars: self.variable_slice(flex_vars),
             def_types: self.def_types_slice(def_types),
             defs_and_ret_constraint,
         };

--- a/crates/compiler/load_internal/src/file.rs
+++ b/crates/compiler/load_internal/src/file.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::too_many_arguments)]
+
 use crate::docs::ModuleDocumentation;
 use bumpalo::Bump;
 use crossbeam::channel::{bounded, Sender};
@@ -4663,6 +4665,7 @@ pub fn add_imports(
                     .storage_subs
                     .export_variable_to(ctx.subs, *var);
 
+                #[allow(clippy::let_and_return)]
                 let copied_import_var = extend_imports_data_with_copied_import(
                     copied_import,
                     ctx.imported_variables,

--- a/crates/compiler/load_internal/src/file.rs
+++ b/crates/compiler/load_internal/src/file.rs
@@ -976,7 +976,6 @@ impl<'a> State<'a> {
         self.exec_mode.goal_phase()
     }
 
-    #[allow(clippy::too_many_arguments)]
     fn new(
         root_id: ModuleId,
         target_info: TargetInfo,
@@ -1221,7 +1220,6 @@ fn enqueue_task<'a>(
     Ok(())
 }
 
-#[allow(clippy::too_many_arguments)]
 pub fn load_and_typecheck_str<'a>(
     arena: &'a Bump,
     filename: PathBuf,
@@ -1508,7 +1506,6 @@ pub enum Threading {
 ///     and then linking them together, and possibly caching them by the hash of their
 ///     specializations, so if none of their specializations changed, we don't even need
 ///     to rebuild the module and can link in the cached one directly.)
-#[allow(clippy::too_many_arguments)]
 pub fn load<'a>(
     arena: &'a Bump,
     load_start: LoadStart<'a>,
@@ -1569,7 +1566,6 @@ pub fn load<'a>(
 }
 
 /// Load using only a single thread; used when compiling to webassembly
-#[allow(clippy::too_many_arguments)]
 pub fn load_single_threaded<'a>(
     arena: &'a Bump,
     load_start: LoadStart<'a>,
@@ -1834,7 +1830,6 @@ fn state_thread_step<'a>(
     }
 }
 
-#[allow(clippy::too_many_arguments)]
 fn load_multi_threaded<'a>(
     arena: &'a Bump,
     load_start: LoadStart<'a>,
@@ -2010,7 +2005,6 @@ fn load_multi_threaded<'a>(
     .unwrap()
 }
 
-#[allow(clippy::too_many_arguments)]
 fn worker_task_step<'a>(
     worker_arena: &'a Bump,
     worker: &Worker<BuildTask<'a>>,
@@ -2085,7 +2079,6 @@ fn worker_task_step<'a>(
     }
 }
 
-#[allow(clippy::too_many_arguments)]
 fn worker_task<'a>(
     worker_arena: &'a Bump,
     worker: Worker<BuildTask<'a>>,
@@ -3214,7 +3207,6 @@ fn finish_specialization<'a>(
     })
 }
 
-#[allow(clippy::too_many_arguments)]
 fn finish(
     mut state: State,
     solved: Solved<Subs>,
@@ -3653,7 +3645,6 @@ fn verify_interface_matches_file_path<'a>(
     Err(problem)
 }
 
-#[allow(clippy::too_many_arguments)]
 fn parse_header<'a>(
     arena: &'a Bump,
     read_file_duration: Duration,
@@ -3940,7 +3931,6 @@ fn parse_header<'a>(
 }
 
 /// Load a module by its filename
-#[allow(clippy::too_many_arguments)]
 fn load_filename<'a>(
     arena: &'a Bump,
     filename: PathBuf,
@@ -3979,7 +3969,6 @@ fn load_filename<'a>(
 
 /// Load a module from a str
 /// the `filename` is never read, but used for the module name
-#[allow(clippy::too_many_arguments)]
 fn load_from_str<'a>(
     arena: &'a Bump,
     filename: PathBuf,
@@ -4019,7 +4008,6 @@ struct HeaderInfo<'a> {
     extra: HeaderFor<'a>,
 }
 
-#[allow(clippy::too_many_arguments)]
 fn build_header<'a>(
     info: HeaderInfo<'a>,
     parse_state: roc_parse::state::State<'a>,
@@ -4245,7 +4233,6 @@ struct PlatformHeaderInfo<'a> {
 }
 
 // TODO refactor so more logic is shared with `send_header`
-#[allow(clippy::too_many_arguments)]
 fn send_header_two<'a>(
     info: PlatformHeaderInfo<'a>,
     parse_state: roc_parse::state::State<'a>,
@@ -4497,7 +4484,6 @@ fn send_header_two<'a>(
 
 impl<'a> BuildTask<'a> {
     // TODO trim down these arguments - possibly by moving Constraint into Module
-    #[allow(clippy::too_many_arguments)]
     fn solve_module(
         module: Module,
         ident_ids: IdentIds,
@@ -4895,7 +4881,6 @@ fn run_solve_solve(
     )
 }
 
-#[allow(clippy::too_many_arguments)]
 fn run_solve<'a>(
     module: Module,
     ident_ids: IdentIds,
@@ -5009,7 +4994,6 @@ fn unspace<'a, T: Copy>(arena: &'a Bump, items: &[Loc<Spaced<'a, T>>]) -> &'a [L
     .into_bump_slice()
 }
 
-#[allow(clippy::too_many_arguments)]
 fn fabricate_platform_module<'a>(
     arena: &'a Bump,
     opt_shorthand: Option<&'a str>,
@@ -5049,7 +5033,6 @@ fn fabricate_platform_module<'a>(
     )
 }
 
-#[allow(clippy::too_many_arguments)]
 #[allow(clippy::unnecessary_wraps)]
 fn canonicalize_and_constrain<'a>(
     arena: &'a Bump,
@@ -5323,7 +5306,6 @@ fn ident_from_exposed(entry: &Spaced<'_, ExposedName<'_>>) -> Ident {
     entry.extract_spaces().item.as_str().into()
 }
 
-#[allow(clippy::too_many_arguments)]
 fn make_specializations<'a>(
     arena: &'a Bump,
     home: ModuleId,
@@ -5400,7 +5382,6 @@ fn make_specializations<'a>(
     }
 }
 
-#[allow(clippy::too_many_arguments)]
 fn build_pending_specializations<'a>(
     arena: &'a Bump,
     solved_subs: Solved<Subs>,
@@ -5831,7 +5812,6 @@ fn build_pending_specializations<'a>(
 /// their specializations.
 // TODO: right now, this runs sequentially, and no other modules are mono'd in parallel to the
 // derived module.
-#[allow(clippy::too_many_arguments)]
 fn load_derived_partial_procs<'a>(
     home: ModuleId,
     arena: &'a Bump,

--- a/crates/compiler/solve/tests/solve_expr.rs
+++ b/crates/compiler/solve/tests/solve_expr.rs
@@ -8431,4 +8431,29 @@ mod solve_expr {
         @"n : Dec"
         );
     }
+
+    #[test]
+    fn resolve_set_eq_issue_4671() {
+        infer_queries!(
+            indoc!(
+                r#"
+                app "test" provides [main] to "./platform"
+
+                main =
+                    s1 : Set U8
+                    s1 = Set.empty
+
+                    s2 : Set Str
+                    s2 = Set.empty
+
+                    Bool.isEq s1 s1 && Bool.isEq s2 s2
+                #   ^^^^^^^^^          ^^^^^^^^^
+                "#
+            ),
+        @r###"
+        Set#Bool.isEq(17) : Set U8, Set U8 -[[Set.isEq(17)]]-> Bool
+        Set#Bool.isEq(17) : Set Str, Set Str -[[Set.isEq(17)]]-> Bool
+        "###
+        );
+    }
 }

--- a/crates/compiler/test_derive/src/util.rs
+++ b/crates/compiler/test_derive/src/util.rs
@@ -378,6 +378,7 @@ fn check_derived_typechecks_and_golden(
     );
     let mut def_types = Default::default();
     let mut rigid_vars = Default::default();
+    let mut flex_vars = Default::default();
     let (import_variables, abilities_store) = add_imports(
         test_module,
         &mut constraints,
@@ -386,9 +387,15 @@ fn check_derived_typechecks_and_golden(
         &exposed_for_module,
         &mut def_types,
         &mut rigid_vars,
+        &mut flex_vars,
     );
-    let constr =
-        constraints.let_import_constraint(rigid_vars, def_types, constr, &import_variables);
+    let constr = constraints.let_import_constraint(
+        rigid_vars,
+        flex_vars,
+        def_types,
+        constr,
+        &import_variables,
+    );
 
     // run the solver, print and fail if we have errors
     dbg_do!(

--- a/crates/compiler/test_gen/src/gen_dict.rs
+++ b/crates/compiler/test_gen/src/gen_dict.rs
@@ -1,4 +1,7 @@
-#![cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
+#![cfg(all(
+    any(feature = "gen-llvm", feature = "gen-wasm"),
+    not(debug_assertions) // https://github.com/roc-lang/roc/issues/3898
+))]
 
 #[cfg(feature = "gen-llvm")]
 use crate::helpers::llvm::assert_evals_to;

--- a/crates/compiler/test_gen/src/gen_set.rs
+++ b/crates/compiler/test_gen/src/gen_set.rs
@@ -284,3 +284,26 @@ fn from_list_result() {
         i64
     );
 }
+
+#[test]
+#[cfg(any(feature = "gen-llvm"))]
+fn resolve_set_eq_issue_4671() {
+    assert_evals_to!(
+        indoc!(
+            r#"
+            app "test" provides [main] to "./platform"
+
+            main =
+                s1 : Set U8
+                s1 = Set.fromList [1, 2, 3]
+
+                s2 : Set U8
+                s2 = Set.fromList [3, 2, 1]
+
+                s1 == s2
+            "#
+        ),
+        true,
+        bool
+    );
+}

--- a/crates/compiler/test_gen/src/gen_set.rs
+++ b/crates/compiler/test_gen/src/gen_set.rs
@@ -1,4 +1,7 @@
-#![cfg(feature = "gen-llvm")]
+#![cfg(all(
+    any(feature = "gen-llvm"),
+    not(debug_assertions) // https://github.com/roc-lang/roc/issues/3898
+))]
 
 #[cfg(feature = "gen-llvm")]
 use crate::helpers::llvm::assert_evals_to;


### PR DESCRIPTION
When ability specializations are statically known in the dependency graph, we inject a module dependencies' specializations prior to solving the module types. This injection copies the specialization lambda sets and ambient functions from module-independent storage into the host module's Subs.

Copying a dependent module's types out of storage "loses" rank information of the type in the original source module. This is by design, because the exported type may be at a level that is never reached in the module being imported into. Instead, imported types are imported at a constant rank (Rank::import), and then run through the standard generalization algorithm for let-bindings. This makes sure that imported variables available for generalization are lifted up to the generalization rank (Rank 0).

Prior to this commit imported ability specializations weren't included in the set of variables targeted for candidate generalization at the constant import rank. This patch makes sure that is done, and refactors the import-copying procedure to be easier to read.

Closes #4671
Closes #4676