### PR TITLE
Wasm interp: WASI and stack trace

### DIFF
--- a/crates/wasm_interp/Cargo.toml
+++ b/crates/wasm_interp/Cargo.toml
@@ -2,6 +2,9 @@
 name = "roc_wasm_interp"
 version = "0.1.0"
 edition = "2021"
+authors = ["The Roc Contributors"]
+license = "UPL-1.0"
+description = "A WebAssembly interpreter for testing the compiler."
 
 [[bin]]
 name = "roc_wasm_interp"

--- a/crates/wasm_interp/src/instance.rs
+++ b/crates/wasm_interp/src/instance.rs
@@ -154,7 +154,7 @@ impl<'a, I: ImportDispatcher> Instance<'a, I> {
         let arg_type_bytes = self.prepare_to_call_export(module, fn_name)?;
 
         for (value_str, type_byte) in arg_strings
-            .into_iter()
+            .iter()
             .skip(1) // first string is the .wasm filename
             .zip(arg_type_bytes.iter().copied())
         {
@@ -1516,7 +1516,7 @@ impl<'a, I: ImportDispatcher> Instance<'a, I> {
                 let fn_index = pc_to_fn_index(self.program_counter, module);
                 eprintln!("returning to function {}\n", fn_index);
             } else if op_code == CALL || op_code == CALLINDIRECT {
-                eprintln!("");
+                eprintln!();
             }
         }
 

--- a/crates/wasm_interp/src/instance.rs
+++ b/crates/wasm_interp/src/instance.rs
@@ -749,10 +749,14 @@ impl<'a, I: ImportDispatcher> Instance<'a, I> {
                 target.copy_from_slice(&unwrapped.to_le_bytes()[..4]);
             }
             CURRENTMEMORY => {
+                let memory_index = self.fetch_immediate_u32(module);
+                assert_eq!(memory_index, 0);
                 let size = self.memory.len() as i32 / MemorySection::PAGE_SIZE as i32;
                 self.value_stack.push(Value::I32(size));
             }
             GROWMEMORY => {
+                let memory_index = self.fetch_immediate_u32(module);
+                assert_eq!(memory_index, 0);
                 let old_bytes = self.memory.len() as u32;
                 let old_pages = old_bytes / MemorySection::PAGE_SIZE as u32;
                 let grow_pages = self.value_stack.pop_u32()?;

--- a/crates/wasm_interp/src/instance.rs
+++ b/crates/wasm_interp/src/instance.rs
@@ -541,8 +541,8 @@ impl<'a, I: ImportDispatcher> Instance<'a, I> {
                 self.do_call(None, fn_index, module);
             }
             CALLINDIRECT => {
-                let table_index = self.fetch_immediate_u32(module);
                 let expected_signature = self.fetch_immediate_u32(module);
+                let table_index = self.fetch_immediate_u32(module);
                 let element_index = self.value_stack.pop_u32()?;
 
                 // So far, all compilers seem to be emitting MVP-compatible code. (Rust, Zig, Roc...)

--- a/crates/wasm_interp/src/instance.rs
+++ b/crates/wasm_interp/src/instance.rs
@@ -153,7 +153,11 @@ impl<'a, I: ImportDispatcher> Instance<'a, I> {
     ) -> Result<Option<Value>, String> {
         let arg_type_bytes = self.prepare_to_call_export(module, fn_name)?;
 
-        for (value_str, type_byte) in arg_strings.into_iter().zip(arg_type_bytes.iter().copied()) {
+        for (value_str, type_byte) in arg_strings
+            .into_iter()
+            .skip(1) // first string is the .wasm filename
+            .zip(arg_type_bytes.iter().copied())
+        {
             use ValueType::*;
             let value = match ValueType::from(type_byte) {
                 I32 => Value::I32(value_str.parse::<i32>().map_err(|e| e.to_string())?),

--- a/crates/wasm_interp/src/instance.rs
+++ b/crates/wasm_interp/src/instance.rs
@@ -251,7 +251,7 @@ impl<'a, I: ImportDispatcher> Instance<'a, I> {
                         }
                     };
                     self.call_stack
-                        .dump(
+                        .dump_trace(
                             module,
                             &self.value_stack,
                             self.program_counter,

--- a/crates/wasm_interp/src/instance.rs
+++ b/crates/wasm_interp/src/instance.rs
@@ -276,6 +276,8 @@ impl<'a, I: ImportDispatcher> Instance<'a, I> {
     }
 
     fn do_return(&mut self) -> Action {
+        self.block_loop_addrs
+            .truncate(self.outermost_block as usize);
         if let Some((return_addr, block_depth)) = self.call_stack.pop_frame() {
             if self.call_stack.is_empty() {
                 // We just popped the stack frame for the entry function. Terminate the program.

--- a/crates/wasm_interp/src/instance.rs
+++ b/crates/wasm_interp/src/instance.rs
@@ -10,7 +10,7 @@ use roc_wasm_module::{Value, ValueType};
 
 use crate::call_stack::CallStack;
 use crate::value_stack::ValueStack;
-use crate::ImportDispatcher;
+use crate::{Error, ImportDispatcher};
 
 pub enum Action {
     Continue,
@@ -218,7 +218,26 @@ impl<'a, I: ImportDispatcher> Instance<'a, I> {
             &mut self.program_counter,
         );
 
-        while let Action::Continue = self.execute_next_instruction(module) {}
+        loop {
+            match self.execute_next_instruction(module) {
+                Ok(Action::Continue) => {}
+                Ok(Action::Break) => {
+                    break;
+                }
+                Err(Error::ValueStackType(expected, actual)) => {
+                    return Err(format!(
+                        "I found a type mismatch in the Value Stack at file offset {:#x}. Expected {:?}, but found {:?}.", 
+                        self.program_counter + module.code.section_offset as usize, expected, actual
+                    ));
+                }
+                Err(Error::ValueStackEmpty) => {
+                    return Err(format!(
+                        "I tried to pop a value from the Value Stack at file offset {:#x}, but it was empty.",
+                        self.program_counter + module.code.section_offset as usize
+                    ));
+                }
+            }
+        }
 
         let return_value = if !self.value_stack.is_empty() {
             Some(self.value_stack.pop())
@@ -253,26 +272,26 @@ impl<'a, I: ImportDispatcher> Instance<'a, I> {
         }
     }
 
-    fn get_load_address(&mut self, module: &WasmModule<'a>) -> u32 {
+    fn get_load_address(&mut self, module: &WasmModule<'a>) -> Result<u32, Error> {
         // Alignment is not used in the execution steps from the spec! Maybe it's just an optimization hint?
         // https://webassembly.github.io/spec/core/exec/instructions.html#memory-instructions
         // Also note: in the text format we can specify the useless `align=` but not the useful `offset=`!
         let _alignment = self.fetch_immediate_u32(module);
         let offset = self.fetch_immediate_u32(module);
-        let base_addr = self.value_stack.pop_u32();
-        base_addr + offset
+        let base_addr = self.value_stack.pop_u32()?;
+        Ok(base_addr + offset)
     }
 
-    fn get_store_addr_value(&mut self, module: &WasmModule<'a>) -> (usize, Value) {
+    fn get_store_addr_value(&mut self, module: &WasmModule<'a>) -> Result<(usize, Value), Error> {
         // Alignment is not used in the execution steps from the spec! Maybe it's just an optimization hint?
         // https://webassembly.github.io/spec/core/exec/instructions.html#memory-instructions
         // Also note: in the text format we can specify the useless `align=` but not the useful `offset=`!
         let _alignment = self.fetch_immediate_u32(module);
         let offset = self.fetch_immediate_u32(module);
         let value = self.value_stack.pop();
-        let base_addr = self.value_stack.pop_u32();
+        let base_addr = self.value_stack.pop_u32()?;
         let addr = (base_addr + offset) as usize;
-        (addr, value)
+        Ok((addr, value))
     }
 
     fn write_debug<T: fmt::Debug>(&mut self, value: T) {
@@ -394,7 +413,10 @@ impl<'a, I: ImportDispatcher> Instance<'a, I> {
         }
     }
 
-    pub fn execute_next_instruction(&mut self, module: &WasmModule<'a>) -> Action {
+    pub(crate) fn execute_next_instruction(
+        &mut self,
+        module: &WasmModule<'a>,
+    ) -> Result<Action, Error> {
         use OpCode::*;
 
         let file_offset = self.program_counter as u32 + module.code.section_offset;
@@ -428,7 +450,7 @@ impl<'a, I: ImportDispatcher> Instance<'a, I> {
             }
             IF => {
                 self.fetch_immediate_u32(module); // blocktype (ignored)
-                let condition = self.value_stack.pop_i32();
+                let condition = self.value_stack.pop_i32()?;
                 self.block_loop_addrs.push(None);
                 if condition == 0 {
                     let mut depth = self.block_loop_addrs.len();
@@ -473,13 +495,13 @@ impl<'a, I: ImportDispatcher> Instance<'a, I> {
             }
             BRIF => {
                 let relative_blocks_outward = self.fetch_immediate_u32(module);
-                let condition = self.value_stack.pop_i32();
+                let condition = self.value_stack.pop_i32()?;
                 if condition != 0 {
                     self.do_break(relative_blocks_outward, module);
                 }
             }
             BRTABLE => {
-                let selector = self.value_stack.pop_u32();
+                let selector = self.value_stack.pop_u32()?;
                 let nondefault_condition_count = self.fetch_immediate_u32(module);
                 let mut selected = None;
                 for i in 0..nondefault_condition_count {
@@ -502,7 +524,7 @@ impl<'a, I: ImportDispatcher> Instance<'a, I> {
             CALLINDIRECT => {
                 let table_index = self.fetch_immediate_u32(module);
                 let expected_signature = self.fetch_immediate_u32(module);
-                let element_index = self.value_stack.pop_u32();
+                let element_index = self.value_stack.pop_u32()?;
 
                 // So far, all compilers seem to be emitting MVP-compatible code. (Rust, Zig, Roc...)
                 assert_eq!(
@@ -525,10 +547,14 @@ impl<'a, I: ImportDispatcher> Instance<'a, I> {
                 self.value_stack.pop();
             }
             SELECT => {
-                let c = self.value_stack.pop_i32();
+                let c = self.value_stack.pop_i32()?;
                 let val2 = self.value_stack.pop();
                 let val1 = self.value_stack.pop();
-                assert_eq!(ValueType::from(val1), ValueType::from(val2));
+                let actual = ValueType::from(val2);
+                let expected = ValueType::from(val1);
+                if actual != expected {
+                    return Err(Error::ValueStackType(expected, actual));
+                }
                 let result = if c != 0 { val1 } else { val2 };
                 self.value_stack.push(result);
             }
@@ -556,149 +582,149 @@ impl<'a, I: ImportDispatcher> Instance<'a, I> {
                 self.globals[index as usize] = self.value_stack.pop();
             }
             I32LOAD => {
-                let addr = self.get_load_address(module) as usize;
+                let addr = self.get_load_address(module)? as usize;
                 let mut bytes = [0; 4];
                 bytes.copy_from_slice(&self.memory[addr..][..4]);
                 let value = i32::from_le_bytes(bytes);
                 self.value_stack.push(Value::I32(value));
             }
             I64LOAD => {
-                let addr = self.get_load_address(module) as usize;
+                let addr = self.get_load_address(module)? as usize;
                 let mut bytes = [0; 8];
                 bytes.copy_from_slice(&self.memory[addr..][..8]);
                 let value = i64::from_le_bytes(bytes);
                 self.value_stack.push(Value::I64(value));
             }
             F32LOAD => {
-                let addr = self.get_load_address(module) as usize;
+                let addr = self.get_load_address(module)? as usize;
                 let mut bytes = [0; 4];
                 bytes.copy_from_slice(&self.memory[addr..][..4]);
                 let value = f32::from_le_bytes(bytes);
                 self.value_stack.push(Value::F32(value));
             }
             F64LOAD => {
-                let addr = self.get_load_address(module) as usize;
+                let addr = self.get_load_address(module)? as usize;
                 let mut bytes = [0; 8];
                 bytes.copy_from_slice(&self.memory[addr..][..8]);
                 let value = f64::from_le_bytes(bytes);
                 self.value_stack.push(Value::F64(value));
             }
             I32LOAD8S => {
-                let addr = self.get_load_address(module) as usize;
+                let addr = self.get_load_address(module)? as usize;
                 let mut bytes = [0; 1];
                 bytes.copy_from_slice(&self.memory[addr..][..1]);
                 let value = i8::from_le_bytes(bytes);
                 self.value_stack.push(Value::I32(value as i32));
             }
             I32LOAD8U => {
-                let addr = self.get_load_address(module) as usize;
+                let addr = self.get_load_address(module)? as usize;
                 let value = self.memory[addr];
                 self.value_stack.push(Value::I32(value as i32));
             }
             I32LOAD16S => {
-                let addr = self.get_load_address(module) as usize;
+                let addr = self.get_load_address(module)? as usize;
                 let mut bytes = [0; 2];
                 bytes.copy_from_slice(&self.memory[addr..][..2]);
                 let value = i16::from_le_bytes(bytes);
                 self.value_stack.push(Value::I32(value as i32));
             }
             I32LOAD16U => {
-                let addr = self.get_load_address(module) as usize;
+                let addr = self.get_load_address(module)? as usize;
                 let mut bytes = [0; 2];
                 bytes.copy_from_slice(&self.memory[addr..][..2]);
                 let value = u16::from_le_bytes(bytes);
                 self.value_stack.push(Value::I32(value as i32));
             }
             I64LOAD8S => {
-                let addr = self.get_load_address(module) as usize;
+                let addr = self.get_load_address(module)? as usize;
                 let mut bytes = [0; 1];
                 bytes.copy_from_slice(&self.memory[addr..][..1]);
                 let value = i8::from_le_bytes(bytes);
                 self.value_stack.push(Value::I64(value as i64));
             }
             I64LOAD8U => {
-                let addr = self.get_load_address(module) as usize;
+                let addr = self.get_load_address(module)? as usize;
                 let value = self.memory[addr];
                 self.value_stack.push(Value::I64(value as i64));
             }
             I64LOAD16S => {
-                let addr = self.get_load_address(module) as usize;
+                let addr = self.get_load_address(module)? as usize;
                 let mut bytes = [0; 2];
                 bytes.copy_from_slice(&self.memory[addr..][..2]);
                 let value = i16::from_le_bytes(bytes);
                 self.value_stack.push(Value::I64(value as i64));
             }
             I64LOAD16U => {
-                let addr = self.get_load_address(module) as usize;
+                let addr = self.get_load_address(module)? as usize;
                 let mut bytes = [0; 2];
                 bytes.copy_from_slice(&self.memory[addr..][..2]);
                 let value = u16::from_le_bytes(bytes);
                 self.value_stack.push(Value::I64(value as i64));
             }
             I64LOAD32S => {
-                let addr = self.get_load_address(module) as usize;
+                let addr = self.get_load_address(module)? as usize;
                 let mut bytes = [0; 4];
                 bytes.copy_from_slice(&self.memory[addr..][..4]);
                 let value = i32::from_le_bytes(bytes);
                 self.value_stack.push(Value::I64(value as i64));
             }
             I64LOAD32U => {
-                let addr = self.get_load_address(module) as usize;
+                let addr = self.get_load_address(module)? as usize;
                 let mut bytes = [0; 4];
                 bytes.copy_from_slice(&self.memory[addr..][..4]);
                 let value = u32::from_le_bytes(bytes);
                 self.value_stack.push(Value::I64(value as i64));
             }
             I32STORE => {
-                let (addr, value) = self.get_store_addr_value(module);
+                let (addr, value) = self.get_store_addr_value(module)?;
                 let unwrapped = value.unwrap_i32();
                 let target = &mut self.memory[addr..][..4];
                 target.copy_from_slice(&unwrapped.to_le_bytes());
             }
             I64STORE => {
-                let (addr, value) = self.get_store_addr_value(module);
+                let (addr, value) = self.get_store_addr_value(module)?;
                 let unwrapped = value.unwrap_i64();
                 let target = &mut self.memory[addr..][..8];
                 target.copy_from_slice(&unwrapped.to_le_bytes());
             }
             F32STORE => {
-                let (addr, value) = self.get_store_addr_value(module);
+                let (addr, value) = self.get_store_addr_value(module)?;
                 let unwrapped = value.unwrap_f32();
                 let target = &mut self.memory[addr..][..4];
                 target.copy_from_slice(&unwrapped.to_le_bytes());
             }
             F64STORE => {
-                let (addr, value) = self.get_store_addr_value(module);
+                let (addr, value) = self.get_store_addr_value(module)?;
                 let unwrapped = value.unwrap_f64();
                 let target = &mut self.memory[addr..][..8];
                 target.copy_from_slice(&unwrapped.to_le_bytes());
             }
             I32STORE8 => {
-                let (addr, value) = self.get_store_addr_value(module);
+                let (addr, value) = self.get_store_addr_value(module)?;
                 let unwrapped = value.unwrap_i32();
                 let target = &mut self.memory[addr..][..1];
                 target.copy_from_slice(&unwrapped.to_le_bytes()[..1]);
             }
             I32STORE16 => {
-                let (addr, value) = self.get_store_addr_value(module);
+                let (addr, value) = self.get_store_addr_value(module)?;
                 let unwrapped = value.unwrap_i32();
                 let target = &mut self.memory[addr..][..2];
                 target.copy_from_slice(&unwrapped.to_le_bytes()[..2]);
             }
             I64STORE8 => {
-                let (addr, value) = self.get_store_addr_value(module);
+                let (addr, value) = self.get_store_addr_value(module)?;
                 let unwrapped = value.unwrap_i64();
                 let target = &mut self.memory[addr..][..1];
                 target.copy_from_slice(&unwrapped.to_le_bytes()[..1]);
             }
             I64STORE16 => {
-                let (addr, value) = self.get_store_addr_value(module);
+                let (addr, value) = self.get_store_addr_value(module)?;
                 let unwrapped = value.unwrap_i64();
                 let target = &mut self.memory[addr..][..2];
                 target.copy_from_slice(&unwrapped.to_le_bytes()[..2]);
             }
             I64STORE32 => {
-                let (addr, value) = self.get_store_addr_value(module);
+                let (addr, value) = self.get_store_addr_value(module)?;
                 let unwrapped = value.unwrap_i64();
                 let target = &mut self.memory[addr..][..4];
                 target.copy_from_slice(&unwrapped.to_le_bytes()[..4]);
@@ -710,7 +736,7 @@ impl<'a, I: ImportDispatcher> Instance<'a, I> {
             GROWMEMORY => {
                 let old_bytes = self.memory.len() as u32;
                 let old_pages = old_bytes / MemorySection::PAGE_SIZE as u32;
-                let grow_pages = self.value_stack.pop_u32();
+                let grow_pages = self.value_stack.pop_u32()?;
                 let grow_bytes = grow_pages * MemorySection::PAGE_SIZE;
                 let new_bytes = old_bytes + grow_bytes;
 
@@ -754,424 +780,424 @@ impl<'a, I: ImportDispatcher> Instance<'a, I> {
             }
 
             I32EQZ => {
-                let arg = self.value_stack.pop_i32();
+                let arg = self.value_stack.pop_i32()?;
                 let result: bool = arg == 0;
                 self.value_stack.push(Value::I32(result as i32));
             }
             I32EQ => {
-                let arg2 = self.value_stack.pop_i32();
-                let arg1 = self.value_stack.pop_i32();
+                let arg2 = self.value_stack.pop_i32()?;
+                let arg1 = self.value_stack.pop_i32()?;
                 let result: bool = arg1 == arg2;
                 self.value_stack.push(Value::I32(result as i32));
             }
             I32NE => {
-                let arg2 = self.value_stack.pop_i32();
-                let arg1 = self.value_stack.pop_i32();
+                let arg2 = self.value_stack.pop_i32()?;
+                let arg1 = self.value_stack.pop_i32()?;
                 let result: bool = arg1 != arg2;
                 self.value_stack.push(Value::I32(result as i32));
             }
             I32LTS => {
-                let arg2 = self.value_stack.pop_i32();
-                let arg1 = self.value_stack.pop_i32();
+                let arg2 = self.value_stack.pop_i32()?;
+                let arg1 = self.value_stack.pop_i32()?;
                 let result: bool = arg1 < arg2;
                 self.value_stack.push(Value::I32(result as i32));
             }
             I32LTU => {
-                let arg2 = self.value_stack.pop_u32();
-                let arg1 = self.value_stack.pop_u32();
+                let arg2 = self.value_stack.pop_u32()?;
+                let arg1 = self.value_stack.pop_u32()?;
                 let result: bool = arg1 < arg2;
                 self.value_stack.push(Value::I32(result as i32));
             }
             I32GTS => {
-                let arg2 = self.value_stack.pop_i32();
-                let arg1 = self.value_stack.pop_i32();
+                let arg2 = self.value_stack.pop_i32()?;
+                let arg1 = self.value_stack.pop_i32()?;
                 let result: bool = arg1 > arg2;
                 self.value_stack.push(Value::I32(result as i32));
             }
             I32GTU => {
-                let arg2 = self.value_stack.pop_u32();
-                let arg1 = self.value_stack.pop_u32();
+                let arg2 = self.value_stack.pop_u32()?;
+                let arg1 = self.value_stack.pop_u32()?;
                 let result: bool = arg1 > arg2;
                 self.value_stack.push(Value::I32(result as i32));
             }
             I32LES => {
-                let arg2 = self.value_stack.pop_i32();
-                let arg1 = self.value_stack.pop_i32();
+                let arg2 = self.value_stack.pop_i32()?;
+                let arg1 = self.value_stack.pop_i32()?;
                 let result: bool = arg1 <= arg2;
                 self.value_stack.push(Value::I32(result as i32));
             }
             I32LEU => {
-                let arg2 = self.value_stack.pop_u32();
-                let arg1 = self.value_stack.pop_u32();
+                let arg2 = self.value_stack.pop_u32()?;
+                let arg1 = self.value_stack.pop_u32()?;
                 let result: bool = arg1 <= arg2;
                 self.value_stack.push(Value::I32(result as i32));
             }
             I32GES => {
-                let arg2 = self.value_stack.pop_i32();
-                let arg1 = self.value_stack.pop_i32();
+                let arg2 = self.value_stack.pop_i32()?;
+                let arg1 = self.value_stack.pop_i32()?;
                 let result: bool = arg1 >= arg2;
                 self.value_stack.push(Value::I32(result as i32));
             }
             I32GEU => {
-                let arg2 = self.value_stack.pop_u32();
-                let arg1 = self.value_stack.pop_u32();
+                let arg2 = self.value_stack.pop_u32()?;
+                let arg1 = self.value_stack.pop_u32()?;
                 let result: bool = arg1 >= arg2;
                 self.value_stack.push(Value::I32(result as i32));
             }
 
             I64EQZ => {
-                let arg = self.value_stack.pop_i64();
+                let arg = self.value_stack.pop_i64()?;
                 let result: bool = arg == 0;
                 self.value_stack.push(Value::I32(result as i32));
             }
             I64EQ => {
-                let arg2 = self.value_stack.pop_i64();
-                let arg1 = self.value_stack.pop_i64();
+                let arg2 = self.value_stack.pop_i64()?;
+                let arg1 = self.value_stack.pop_i64()?;
                 let result: bool = arg1 == arg2;
                 self.value_stack.push(Value::I32(result as i32));
             }
             I64NE => {
-                let arg2 = self.value_stack.pop_i64();
-                let arg1 = self.value_stack.pop_i64();
+                let arg2 = self.value_stack.pop_i64()?;
+                let arg1 = self.value_stack.pop_i64()?;
                 let result: bool = arg1 != arg2;
                 self.value_stack.push(Value::I32(result as i32));
             }
             I64LTS => {
-                let arg2 = self.value_stack.pop_i64();
-                let arg1 = self.value_stack.pop_i64();
+                let arg2 = self.value_stack.pop_i64()?;
+                let arg1 = self.value_stack.pop_i64()?;
                 let result: bool = arg1 < arg2;
                 self.value_stack.push(Value::I32(result as i32));
             }
             I64LTU => {
-                let arg2 = self.value_stack.pop_u64();
-                let arg1 = self.value_stack.pop_u64();
+                let arg2 = self.value_stack.pop_u64()?;
+                let arg1 = self.value_stack.pop_u64()?;
                 let result: bool = arg1 < arg2;
                 self.value_stack.push(Value::I32(result as i32));
             }
             I64GTS => {
-                let arg2 = self.value_stack.pop_i64();
-                let arg1 = self.value_stack.pop_i64();
+                let arg2 = self.value_stack.pop_i64()?;
+                let arg1 = self.value_stack.pop_i64()?;
                 let result: bool = arg1 > arg2;
                 self.value_stack.push(Value::I32(result as i32));
             }
             I64GTU => {
-                let arg2 = self.value_stack.pop_u64();
-                let arg1 = self.value_stack.pop_u64();
+                let arg2 = self.value_stack.pop_u64()?;
+                let arg1 = self.value_stack.pop_u64()?;
                 let result: bool = arg1 > arg2;
                 self.value_stack.push(Value::I32(result as i32));
             }
             I64LES => {
-                let arg2 = self.value_stack.pop_i64();
-                let arg1 = self.value_stack.pop_i64();
+                let arg2 = self.value_stack.pop_i64()?;
+                let arg1 = self.value_stack.pop_i64()?;
                 let result: bool = arg1 <= arg2;
                 self.value_stack.push(Value::I32(result as i32));
             }
             I64LEU => {
-                let arg2 = self.value_stack.pop_u64();
-                let arg1 = self.value_stack.pop_u64();
+                let arg2 = self.value_stack.pop_u64()?;
+                let arg1 = self.value_stack.pop_u64()?;
                 let result: bool = arg1 <= arg2;
                 self.value_stack.push(Value::I32(result as i32));
             }
             I64GES => {
-                let arg2 = self.value_stack.pop_i64();
-                let arg1 = self.value_stack.pop_i64();
+                let arg2 = self.value_stack.pop_i64()?;
+                let arg1 = self.value_stack.pop_i64()?;
                 let result: bool = arg1 >= arg2;
                 self.value_stack.push(Value::I32(result as i32));
             }
             I64GEU => {
-                let arg2 = self.value_stack.pop_u64();
-                let arg1 = self.value_stack.pop_u64();
+                let arg2 = self.value_stack.pop_u64()?;
+                let arg1 = self.value_stack.pop_u64()?;
                 let result: bool = arg1 >= arg2;
                 self.value_stack.push(Value::I32(result as i32));
             }
 
             F32EQ => {
-                let arg2 = self.value_stack.pop_f32();
-                let arg1 = self.value_stack.pop_f32();
+                let arg2 = self.value_stack.pop_f32()?;
+                let arg1 = self.value_stack.pop_f32()?;
                 let result: bool = arg1 == arg2;
                 self.value_stack.push(Value::I32(result as i32));
             }
             F32NE => {
-                let arg2 = self.value_stack.pop_f32();
-                let arg1 = self.value_stack.pop_f32();
+                let arg2 = self.value_stack.pop_f32()?;
+                let arg1 = self.value_stack.pop_f32()?;
                 let result: bool = arg1 != arg2;
                 self.value_stack.push(Value::I32(result as i32));
             }
             F32LT => {
-                let arg2 = self.value_stack.pop_f32();
-                let arg1 = self.value_stack.pop_f32();
+                let arg2 = self.value_stack.pop_f32()?;
+                let arg1 = self.value_stack.pop_f32()?;
                 let result: bool = arg1 < arg2;
                 self.value_stack.push(Value::I32(result as i32));
             }
             F32GT => {
-                let arg2 = self.value_stack.pop_f32();
-                let arg1 = self.value_stack.pop_f32();
+                let arg2 = self.value_stack.pop_f32()?;
+                let arg1 = self.value_stack.pop_f32()?;
                 let result: bool = arg1 > arg2;
                 self.value_stack.push(Value::I32(result as i32));
             }
             F32LE => {
-                let arg2 = self.value_stack.pop_f32();
-                let arg1 = self.value_stack.pop_f32();
+                let arg2 = self.value_stack.pop_f32()?;
+                let arg1 = self.value_stack.pop_f32()?;
                 let result: bool = arg1 <= arg2;
                 self.value_stack.push(Value::I32(result as i32));
             }
             F32GE => {
-                let arg2 = self.value_stack.pop_f32();
-                let arg1 = self.value_stack.pop_f32();
+                let arg2 = self.value_stack.pop_f32()?;
+                let arg1 = self.value_stack.pop_f32()?;
                 let result: bool = arg1 >= arg2;
                 self.value_stack.push(Value::I32(result as i32));
             }
 
             F64EQ => {
-                let arg2 = self.value_stack.pop_f64();
-                let arg1 = self.value_stack.pop_f64();
+                let arg2 = self.value_stack.pop_f64()?;
+                let arg1 = self.value_stack.pop_f64()?;
                 let result: bool = arg1 == arg2;
                 self.value_stack.push(Value::I32(result as i32));
             }
             F64NE => {
-                let arg2 = self.value_stack.pop_f64();
-                let arg1 = self.value_stack.pop_f64();
+                let arg2 = self.value_stack.pop_f64()?;
+                let arg1 = self.value_stack.pop_f64()?;
                 let result: bool = arg1 != arg2;
                 self.value_stack.push(Value::I32(result as i32));
             }
             F64LT => {
-                let arg2 = self.value_stack.pop_f64();
-                let arg1 = self.value_stack.pop_f64();
+                let arg2 = self.value_stack.pop_f64()?;
+                let arg1 = self.value_stack.pop_f64()?;
                 let result: bool = arg1 < arg2;
                 self.value_stack.push(Value::I32(result as i32));
             }
             F64GT => {
-                let arg2 = self.value_stack.pop_f64();
-                let arg1 = self.value_stack.pop_f64();
+                let arg2 = self.value_stack.pop_f64()?;
+                let arg1 = self.value_stack.pop_f64()?;
                 let result: bool = arg1 > arg2;
                 self.value_stack.push(Value::I32(result as i32));
             }
             F64LE => {
-                let arg2 = self.value_stack.pop_f64();
-                let arg1 = self.value_stack.pop_f64();
+                let arg2 = self.value_stack.pop_f64()?;
+                let arg1 = self.value_stack.pop_f64()?;
                 let result: bool = arg1 <= arg2;
                 self.value_stack.push(Value::I32(result as i32));
             }
             F64GE => {
-                let arg2 = self.value_stack.pop_f64();
-                let arg1 = self.value_stack.pop_f64();
+                let arg2 = self.value_stack.pop_f64()?;
+                let arg1 = self.value_stack.pop_f64()?;
                 let result: bool = arg1 >= arg2;
                 self.value_stack.push(Value::I32(result as i32));
             }
 
             I32CLZ => {
-                let arg = self.value_stack.pop_u32();
+                let arg = self.value_stack.pop_u32()?;
                 self.value_stack.push(Value::from(arg.leading_zeros()));
             }
             I32CTZ => {
-                let arg = self.value_stack.pop_u32();
+                let arg = self.value_stack.pop_u32()?;
                 self.value_stack.push(Value::from(arg.trailing_zeros()));
             }
             I32POPCNT => {
-                let arg = self.value_stack.pop_u32();
+                let arg = self.value_stack.pop_u32()?;
                 self.value_stack.push(Value::from(arg.count_ones()));
             }
             I32ADD => {
-                let arg2 = self.value_stack.pop_i32();
-                let arg1 = self.value_stack.pop_i32();
+                let arg2 = self.value_stack.pop_i32()?;
+                let arg1 = self.value_stack.pop_i32()?;
                 self.value_stack.push(Value::from(arg1.wrapping_add(arg2)));
             }
             I32SUB => {
-                let arg2 = self.value_stack.pop_i32();
-                let arg1 = self.value_stack.pop_i32();
+                let arg2 = self.value_stack.pop_i32()?;
+                let arg1 = self.value_stack.pop_i32()?;
                 self.value_stack.push(Value::from(arg1.wrapping_sub(arg2)));
             }
             I32MUL => {
-                let arg2 = self.value_stack.pop_i32();
-                let arg1 = self.value_stack.pop_i32();
+                let arg2 = self.value_stack.pop_i32()?;
+                let arg1 = self.value_stack.pop_i32()?;
                 self.value_stack.push(Value::from(arg1.wrapping_mul(arg2)));
             }
             I32DIVS => {
-                let arg2 = self.value_stack.pop_i32();
-                let arg1 = self.value_stack.pop_i32();
+                let arg2 = self.value_stack.pop_i32()?;
+                let arg1 = self.value_stack.pop_i32()?;
                 self.value_stack.push(Value::from(arg1.wrapping_div(arg2)));
             }
             I32DIVU => {
-                let arg2 = self.value_stack.pop_u32();
-                let arg1 = self.value_stack.pop_u32();
+                let arg2 = self.value_stack.pop_u32()?;
+                let arg1 = self.value_stack.pop_u32()?;
                 self.value_stack.push(Value::from(arg1.wrapping_div(arg2)));
             }
             I32REMS => {
-                let arg2 = self.value_stack.pop_i32();
-                let arg1 = self.value_stack.pop_i32();
+                let arg2 = self.value_stack.pop_i32()?;
+                let arg1 = self.value_stack.pop_i32()?;
                 self.value_stack.push(Value::from(arg1.wrapping_rem(arg2)));
             }
             I32REMU => {
-                let arg2 = self.value_stack.pop_u32();
-                let arg1 = self.value_stack.pop_u32();
+                let arg2 = self.value_stack.pop_u32()?;
+                let arg1 = self.value_stack.pop_u32()?;
                 self.value_stack.push(Value::from(arg1.wrapping_rem(arg2)));
             }
             I32AND => {
-                let arg2 = self.value_stack.pop_u32();
-                let arg1 = self.value_stack.pop_u32();
+                let arg2 = self.value_stack.pop_u32()?;
+                let arg1 = self.value_stack.pop_u32()?;
                 self.value_stack.push(Value::from(arg1 & arg2));
             }
             I32OR => {
-                let arg2 = self.value_stack.pop_u32();
-                let arg1 = self.value_stack.pop_u32();
+                let arg2 = self.value_stack.pop_u32()?;
+                let arg1 = self.value_stack.pop_u32()?;
                 self.value_stack.push(Value::from(arg1 | arg2));
             }
             I32XOR => {
-                let arg2 = self.value_stack.pop_u32();
-                let arg1 = self.value_stack.pop_u32();
+                let arg2 = self.value_stack.pop_u32()?;
+                let arg1 = self.value_stack.pop_u32()?;
                 self.value_stack.push(Value::from(arg1 ^ arg2));
             }
             I32SHL => {
-                let arg2 = self.value_stack.pop_u32();
-                let arg1 = self.value_stack.pop_u32();
+                let arg2 = self.value_stack.pop_u32()?;
+                let arg1 = self.value_stack.pop_u32()?;
                 // Take modulo N as per the spec https://webassembly.github.io/spec/core/exec/numerics.html#op-ishl
                 let k = arg2 % 32;
                 self.value_stack.push(Value::from(arg1 << k));
             }
             I32SHRS => {
-                let arg2 = self.value_stack.pop_i32();
-                let arg1 = self.value_stack.pop_i32();
+                let arg2 = self.value_stack.pop_i32()?;
+                let arg1 = self.value_stack.pop_i32()?;
                 let k = arg2 % 32;
                 self.value_stack.push(Value::from(arg1 >> k));
             }
             I32SHRU => {
-                let arg2 = self.value_stack.pop_u32();
-                let arg1 = self.value_stack.pop_u32();
+                let arg2 = self.value_stack.pop_u32()?;
+                let arg1 = self.value_stack.pop_u32()?;
                 let k = arg2 % 32;
                 self.value_stack.push(Value::from(arg1 >> k));
             }
             I32ROTL => {
-                let arg2 = self.value_stack.pop_u32();
-                let arg1 = self.value_stack.pop_u32();
+                let arg2 = self.value_stack.pop_u32()?;
+                let arg1 = self.value_stack.pop_u32()?;
                 let k = arg2 % 32;
                 self.value_stack.push(Value::from(arg1.rotate_left(k)));
             }
             I32ROTR => {
-                let arg2 = self.value_stack.pop_u32();
-                let arg1 = self.value_stack.pop_u32();
+                let arg2 = self.value_stack.pop_u32()?;
+                let arg1 = self.value_stack.pop_u32()?;
                 let k = arg2 % 32;
                 self.value_stack.push(Value::from(arg1.rotate_right(k)));
             }
 
             I64CLZ => {
-                let arg = self.value_stack.pop_u64();
+                let arg = self.value_stack.pop_u64()?;
                 self.value_stack
                     .push(Value::from(arg.leading_zeros() as u64));
             }
             I64CTZ => {
-                let arg = self.value_stack.pop_u64();
+                let arg = self.value_stack.pop_u64()?;
                 self.value_stack
                     .push(Value::from(arg.trailing_zeros() as u64));
             }
             I64POPCNT => {
-                let arg = self.value_stack.pop_u64();
+                let arg = self.value_stack.pop_u64()?;
                 self.value_stack.push(Value::from(arg.count_ones() as u64));
             }
             I64ADD => {
-                let arg2 = self.value_stack.pop_i64();
-                let arg1 = self.value_stack.pop_i64();
+                let arg2 = self.value_stack.pop_i64()?;
+                let arg1 = self.value_stack.pop_i64()?;
                 self.value_stack.push(Value::from(arg1.wrapping_add(arg2)));
             }
             I64SUB => {
-                let arg2 = self.value_stack.pop_i64();
-                let arg1 = self.value_stack.pop_i64();
+                let arg2 = self.value_stack.pop_i64()?;
+                let arg1 = self.value_stack.pop_i64()?;
                 self.value_stack.push(Value::from(arg1.wrapping_sub(arg2)));
             }
             I64MUL => {
-                let arg2 = self.value_stack.pop_i64();
-                let arg1 = self.value_stack.pop_i64();
+                let arg2 = self.value_stack.pop_i64()?;
+                let arg1 = self.value_stack.pop_i64()?;
                 self.value_stack.push(Value::from(arg1.wrapping_mul(arg2)));
             }
             I64DIVS => {
-                let arg2 = self.value_stack.pop_i64();
-                let arg1 = self.value_stack.pop_i64();
+                let arg2 = self.value_stack.pop_i64()?;
+                let arg1 = self.value_stack.pop_i64()?;
                 self.value_stack.push(Value::from(arg1.wrapping_div(arg2)));
             }
             I64DIVU => {
-                let arg2 = self.value_stack.pop_u64();
-                let arg1 = self.value_stack.pop_u64();
+                let arg2 = self.value_stack.pop_u64()?;
+                let arg1 = self.value_stack.pop_u64()?;
                 self.value_stack.push(Value::from(arg1.wrapping_div(arg2)));
             }
             I64REMS => {
-                let arg2 = self.value_stack.pop_i64();
-                let arg1 = self.value_stack.pop_i64();
+                let arg2 = self.value_stack.pop_i64()?;
+                let arg1 = self.value_stack.pop_i64()?;
                 self.value_stack.push(Value::from(arg1.wrapping_rem(arg2)));
             }
             I64REMU => {
-                let arg2 = self.value_stack.pop_u64();
-                let arg1 = self.value_stack.pop_u64();
+                let arg2 = self.value_stack.pop_u64()?;
+                let arg1 = self.value_stack.pop_u64()?;
                 self.value_stack.push(Value::from(arg1.wrapping_rem(arg2)));
             }
             I64AND => {
-                let arg2 = self.value_stack.pop_u64();
-                let arg1 = self.value_stack.pop_u64();
+                let arg2 = self.value_stack.pop_u64()?;
+                let arg1 = self.value_stack.pop_u64()?;
                 self.value_stack.push(Value::from(arg1 & arg2));
             }
             I64OR => {
-                let arg2 = self.value_stack.pop_u64();
-                let arg1 = self.value_stack.pop_u64();
+                let arg2 = self.value_stack.pop_u64()?;
+                let arg1 = self.value_stack.pop_u64()?;
                 self.value_stack.push(Value::from(arg1 | arg2));
             }
             I64XOR => {
-                let arg2 = self.value_stack.pop_u64();
-                let arg1 = self.value_stack.pop_u64();
+                let arg2 = self.value_stack.pop_u64()?;
+                let arg1 = self.value_stack.pop_u64()?;
                 self.value_stack.push(Value::from(arg1 ^ arg2));
             }
             I64SHL => {
-                let arg2 = self.value_stack.pop_u64();
-                let arg1 = self.value_stack.pop_u64();
+                let arg2 = self.value_stack.pop_u64()?;
+                let arg1 = self.value_stack.pop_u64()?;
                 // Take modulo N as per the spec https://webassembly.github.io/spec/core/exec/numerics.html#op-ishl
                 let k = arg2 % 64;
                 self.value_stack.push(Value::from(arg1 << k));
             }
             I64SHRS => {
-                let arg2 = self.value_stack.pop_i64();
-                let arg1 = self.value_stack.pop_i64();
+                let arg2 = self.value_stack.pop_i64()?;
+                let arg1 = self.value_stack.pop_i64()?;
                 let k = arg2 % 64;
                 self.value_stack.push(Value::from(arg1 >> k));
             }
             I64SHRU => {
-                let arg2 = self.value_stack.pop_u64();
-                let arg1 = self.value_stack.pop_u64();
+                let arg2 = self.value_stack.pop_u64()?;
+                let arg1 = self.value_stack.pop_u64()?;
                 let k = arg2 % 64;
                 self.value_stack.push(Value::from(arg1 >> k));
             }
             I64ROTL => {
-                let arg2 = self.value_stack.pop_u64();
-                let arg1 = self.value_stack.pop_u64();
+                let arg2 = self.value_stack.pop_u64()?;
+                let arg1 = self.value_stack.pop_u64()?;
                 let k = (arg2 % 64) as u32;
                 self.value_stack.push(Value::from(arg1.rotate_left(k)));
             }
             I64ROTR => {
-                let arg2 = self.value_stack.pop_u64();
-                let arg1 = self.value_stack.pop_u64();
+                let arg2 = self.value_stack.pop_u64()?;
+                let arg1 = self.value_stack.pop_u64()?;
                 let k = (arg2 % 64) as u32;
                 self.value_stack.push(Value::from(arg1.rotate_right(k)));
             }
 
             F32ABS => {
-                let arg = self.value_stack.pop_f32();
+                let arg = self.value_stack.pop_f32()?;
                 self.value_stack.push(Value::F32(arg.abs()));
             }
             F32NEG => {
-                let arg = self.value_stack.pop_f32();
+                let arg = self.value_stack.pop_f32()?;
                 self.value_stack.push(Value::F32(-arg));
             }
             F32CEIL => {
-                let arg = self.value_stack.pop_f32();
+                let arg = self.value_stack.pop_f32()?;
                 self.value_stack.push(Value::F32(arg.ceil()));
             }
             F32FLOOR => {
-                let arg = self.value_stack.pop_f32();
+                let arg = self.value_stack.pop_f32()?;
                 self.value_stack.push(Value::F32(arg.floor()));
             }
             F32TRUNC => {
-                let arg = self.value_stack.pop_f32();
+                let arg = self.value_stack.pop_f32()?;
                 self.value_stack.push(Value::F32(arg.trunc()));
             }
             F32NEAREST => {
                 // https://webassembly.github.io/spec/core/exec/numerics.html#op-fnearest
-                let arg = self.value_stack.pop_f32();
+                let arg = self.value_stack.pop_f32()?;
                 let rounded = arg.round(); // "Rounds half-way cases away from 0.0"
                 let frac = arg - rounded;
                 let result = if frac == 0.5 || frac == -0.5 {
@@ -1190,44 +1216,44 @@ impl<'a, I: ImportDispatcher> Instance<'a, I> {
                 self.value_stack.push(Value::F32(result));
             }
             F32SQRT => {
-                let arg = self.value_stack.pop_f32();
+                let arg = self.value_stack.pop_f32()?;
                 self.value_stack.push(Value::F32(arg.sqrt()));
             }
             F32ADD => {
-                let arg2 = self.value_stack.pop_f32();
-                let arg1 = self.value_stack.pop_f32();
+                let arg2 = self.value_stack.pop_f32()?;
+                let arg1 = self.value_stack.pop_f32()?;
                 self.value_stack.push(Value::F32(arg1 + arg2));
             }
             F32SUB => {
-                let arg2 = self.value_stack.pop_f32();
-                let arg1 = self.value_stack.pop_f32();
+                let arg2 = self.value_stack.pop_f32()?;
+                let arg1 = self.value_stack.pop_f32()?;
                 self.value_stack.push(Value::F32(arg1 - arg2));
             }
             F32MUL => {
-                let arg2 = self.value_stack.pop_f32();
-                let arg1 = self.value_stack.pop_f32();
+                let arg2 = self.value_stack.pop_f32()?;
+                let arg1 = self.value_stack.pop_f32()?;
                 self.value_stack.push(Value::F32(arg1 * arg2));
             }
             F32DIV => {
-                let arg2 = self.value_stack.pop_f32();
-                let arg1 = self.value_stack.pop_f32();
+                let arg2 = self.value_stack.pop_f32()?;
+                let arg1 = self.value_stack.pop_f32()?;
                 self.value_stack.push(Value::F32(arg1 / arg2));
             }
             F32MIN => {
-                let arg2 = self.value_stack.pop_f32();
-                let arg1 = self.value_stack.pop_f32();
+                let arg2 = self.value_stack.pop_f32()?;
+                let arg1 = self.value_stack.pop_f32()?;
                 let result = if arg1 < arg2 { arg1 } else { arg2 };
                 self.value_stack.push(Value::F32(result));
             }
             F32MAX => {
-                let arg2 = self.value_stack.pop_f32();
-                let arg1 = self.value_stack.pop_f32();
+                let arg2 = self.value_stack.pop_f32()?;
+                let arg1 = self.value_stack.pop_f32()?;
                 let result = if arg1 > arg2 { arg1 } else { arg2 };
                 self.value_stack.push(Value::F32(result));
             }
             F32COPYSIGN => {
-                let arg2 = self.value_stack.pop_f32();
-                let arg1 = self.value_stack.pop_f32();
+                let arg2 = self.value_stack.pop_f32()?;
+                let arg1 = self.value_stack.pop_f32()?;
                 let result = if arg1.is_sign_negative() == arg2.is_sign_negative() {
                     arg1
                 } else {
@@ -1237,28 +1263,28 @@ impl<'a, I: ImportDispatcher> Instance<'a, I> {
             }
 
             F64ABS => {
-                let arg = self.value_stack.pop_f64();
+                let arg = self.value_stack.pop_f64()?;
                 self.value_stack.push(Value::F64(arg.abs()));
             }
             F64NEG => {
-                let arg = self.value_stack.pop_f64();
+                let arg = self.value_stack.pop_f64()?;
                 self.value_stack.push(Value::F64(-arg));
             }
             F64CEIL => {
-                let arg = self.value_stack.pop_f64();
+                let arg = self.value_stack.pop_f64()?;
                 self.value_stack.push(Value::F64(arg.ceil()));
             }
             F64FLOOR => {
-                let arg = self.value_stack.pop_f64();
+                let arg = self.value_stack.pop_f64()?;
                 self.value_stack.push(Value::F64(arg.floor()));
             }
             F64TRUNC => {
-                let arg = self.value_stack.pop_f64();
+                let arg = self.value_stack.pop_f64()?;
                 self.value_stack.push(Value::F64(arg.trunc()));
             }
             F64NEAREST => {
                 // https://webassembly.github.io/spec/core/exec/numerics.html#op-fnearest
-                let arg = self.value_stack.pop_f64();
+                let arg = self.value_stack.pop_f64()?;
                 let rounded = arg.round(); // "Rounds half-way cases away from 0.0"
                 let frac = arg - rounded;
                 let result = if frac == 0.5 || frac == -0.5 {
@@ -1277,44 +1303,44 @@ impl<'a, I: ImportDispatcher> Instance<'a, I> {
                 self.value_stack.push(Value::F64(result));
             }
             F64SQRT => {
-                let arg = self.value_stack.pop_f64();
+                let arg = self.value_stack.pop_f64()?;
                 self.value_stack.push(Value::F64(arg.sqrt()));
             }
             F64ADD => {
-                let arg2 = self.value_stack.pop_f64();
-                let arg1 = self.value_stack.pop_f64();
+                let arg2 = self.value_stack.pop_f64()?;
+                let arg1 = self.value_stack.pop_f64()?;
                 self.value_stack.push(Value::F64(arg1 + arg2));
             }
             F64SUB => {
-                let arg2 = self.value_stack.pop_f64();
-                let arg1 = self.value_stack.pop_f64();
+                let arg2 = self.value_stack.pop_f64()?;
+                let arg1 = self.value_stack.pop_f64()?;
                 self.value_stack.push(Value::F64(arg1 - arg2));
             }
             F64MUL => {
-                let arg2 = self.value_stack.pop_f64();
-                let arg1 = self.value_stack.pop_f64();
+                let arg2 = self.value_stack.pop_f64()?;
+                let arg1 = self.value_stack.pop_f64()?;
                 self.value_stack.push(Value::F64(arg1 * arg2));
             }
             F64DIV => {
-                let arg2 = self.value_stack.pop_f64();
-                let arg1 = self.value_stack.pop_f64();
+                let arg2 = self.value_stack.pop_f64()?;
+                let arg1 = self.value_stack.pop_f64()?;
                 self.value_stack.push(Value::F64(arg1 / arg2));
             }
             F64MIN => {
-                let arg2 = self.value_stack.pop_f64();
-                let arg1 = self.value_stack.pop_f64();
+                let arg2 = self.value_stack.pop_f64()?;
+                let arg1 = self.value_stack.pop_f64()?;
                 let result = if arg1 < arg2 { arg1 } else { arg2 };
                 self.value_stack.push(Value::F64(result));
             }
             F64MAX => {
-                let arg2 = self.value_stack.pop_f64();
-                let arg1 = self.value_stack.pop_f64();
+                let arg2 = self.value_stack.pop_f64()?;
+                let arg1 = self.value_stack.pop_f64()?;
                 let result = if arg1 > arg2 { arg1 } else { arg2 };
                 self.value_stack.push(Value::F64(result));
             }
             F64COPYSIGN => {
-                let arg2 = self.value_stack.pop_f64();
-                let arg1 = self.value_stack.pop_f64();
+                let arg2 = self.value_stack.pop_f64()?;
+                let arg1 = self.value_stack.pop_f64()?;
                 let result = if arg1.is_sign_negative() == arg2.is_sign_negative() {
                     arg1
                 } else {
@@ -1324,132 +1350,132 @@ impl<'a, I: ImportDispatcher> Instance<'a, I> {
             }
 
             I32WRAPI64 => {
-                let arg = self.value_stack.pop_u64();
+                let arg = self.value_stack.pop_u64()?;
                 let wrapped: u32 = (arg & 0xffff_ffff) as u32;
                 self.value_stack.push(Value::from(wrapped));
             }
             I32TRUNCSF32 => {
-                let arg = self.value_stack.pop_f32();
+                let arg = self.value_stack.pop_f32()?;
                 if arg < i32::MIN as f32 || arg > i32::MAX as f32 {
                     panic!("Cannot truncate {} from F32 to I32", arg);
                 }
                 self.value_stack.push(Value::I32(arg as i32));
             }
             I32TRUNCUF32 => {
-                let arg = self.value_stack.pop_f32();
+                let arg = self.value_stack.pop_f32()?;
                 if arg < u32::MIN as f32 || arg > u32::MAX as f32 {
                     panic!("Cannot truncate {} from F32 to unsigned I32", arg);
                 }
                 self.value_stack.push(Value::from(arg as u32));
             }
             I32TRUNCSF64 => {
-                let arg = self.value_stack.pop_f64();
+                let arg = self.value_stack.pop_f64()?;
                 if arg < i32::MIN as f64 || arg > i32::MAX as f64 {
                     panic!("Cannot truncate {} from F64 to I32", arg);
                 }
                 self.value_stack.push(Value::I32(arg as i32));
             }
             I32TRUNCUF64 => {
-                let arg = self.value_stack.pop_f64();
+                let arg = self.value_stack.pop_f64()?;
                 if arg < u32::MIN as f64 || arg > u32::MAX as f64 {
                     panic!("Cannot truncate {} from F64 to unsigned I32", arg);
                 }
                 self.value_stack.push(Value::from(arg as u32));
             }
             I64EXTENDSI32 => {
-                let arg = self.value_stack.pop_i32();
+                let arg = self.value_stack.pop_i32()?;
                 self.value_stack.push(Value::I64(arg as i64));
             }
             I64EXTENDUI32 => {
-                let arg = self.value_stack.pop_u32();
+                let arg = self.value_stack.pop_u32()?;
                 self.value_stack.push(Value::from(arg as u64));
             }
             I64TRUNCSF32 => {
-                let arg = self.value_stack.pop_f32();
+                let arg = self.value_stack.pop_f32()?;
                 if arg < i64::MIN as f32 || arg > i64::MAX as f32 {
                     panic!("Cannot truncate {} from F32 to I64", arg);
                 }
                 self.value_stack.push(Value::I64(arg as i64));
             }
             I64TRUNCUF32 => {
-                let arg = self.value_stack.pop_f32();
+                let arg = self.value_stack.pop_f32()?;
                 if arg < u64::MIN as f32 || arg > u64::MAX as f32 {
                     panic!("Cannot truncate {} from F32 to unsigned I64", arg);
                 }
                 self.value_stack.push(Value::from(arg as u64));
             }
             I64TRUNCSF64 => {
-                let arg = self.value_stack.pop_f64();
+                let arg = self.value_stack.pop_f64()?;
                 if arg < i64::MIN as f64 || arg > i64::MAX as f64 {
                     panic!("Cannot truncate {} from F64 to I64", arg);
                 }
                 self.value_stack.push(Value::I64(arg as i64));
             }
             I64TRUNCUF64 => {
-                let arg = self.value_stack.pop_f64();
+                let arg = self.value_stack.pop_f64()?;
                 if arg < u64::MIN as f64 || arg > u64::MAX as f64 {
                     panic!("Cannot truncate {} from F64 to unsigned I64", arg);
                 }
                 self.value_stack.push(Value::from(arg as u64));
             }
             F32CONVERTSI32 => {
-                let arg = self.value_stack.pop_i32();
+                let arg = self.value_stack.pop_i32()?;
                 self.value_stack.push(Value::F32(arg as f32));
             }
             F32CONVERTUI32 => {
-                let arg = self.value_stack.pop_u32();
+                let arg = self.value_stack.pop_u32()?;
                 self.value_stack.push(Value::F32(arg as f32));
             }
             F32CONVERTSI64 => {
-                let arg = self.value_stack.pop_i64();
+                let arg = self.value_stack.pop_i64()?;
                 self.value_stack.push(Value::F32(arg as f32));
             }
             F32CONVERTUI64 => {
-                let arg = self.value_stack.pop_u64();
+                let arg = self.value_stack.pop_u64()?;
                 self.value_stack.push(Value::F32(arg as f32));
             }
             F32DEMOTEF64 => {
-                let arg = self.value_stack.pop_f64();
+                let arg = self.value_stack.pop_f64()?;
                 self.value_stack.push(Value::F32(arg as f32));
             }
             F64CONVERTSI32 => {
-                let arg = self.value_stack.pop_i32();
+                let arg = self.value_stack.pop_i32()?;
                 self.value_stack.push(Value::F64(arg as f64));
             }
             F64CONVERTUI32 => {
-                let arg = self.value_stack.pop_u32();
+                let arg = self.value_stack.pop_u32()?;
                 self.value_stack.push(Value::F64(arg as f64));
             }
             F64CONVERTSI64 => {
-                let arg = self.value_stack.pop_i64();
+                let arg = self.value_stack.pop_i64()?;
                 self.value_stack.push(Value::F64(arg as f64));
             }
             F64CONVERTUI64 => {
-                let arg = self.value_stack.pop_u64();
+                let arg = self.value_stack.pop_u64()?;
                 self.value_stack.push(Value::F64(arg as f64));
             }
             F64PROMOTEF32 => {
-                let arg = self.value_stack.pop_f32();
+                let arg = self.value_stack.pop_f32()?;
                 self.value_stack.push(Value::F64(arg as f64));
             }
 
             I32REINTERPRETF32 => {
-                let x = self.value_stack.pop_f32();
+                let x = self.value_stack.pop_f32()?;
                 self.value_stack
                     .push(Value::I32(i32::from_ne_bytes(x.to_ne_bytes())));
             }
             I64REINTERPRETF64 => {
-                let x = self.value_stack.pop_f64();
+                let x = self.value_stack.pop_f64()?;
                 self.value_stack
                     .push(Value::I64(i64::from_ne_bytes(x.to_ne_bytes())));
             }
             F32REINTERPRETI32 => {
-                let x = self.value_stack.pop_i32();
+                let x = self.value_stack.pop_i32()?;
                 self.value_stack
                     .push(Value::F32(f32::from_ne_bytes(x.to_ne_bytes())));
             }
             F64REINTERPRETI64 => {
-                let x = self.value_stack.pop_i64();
+                let x = self.value_stack.pop_i64()?;
                 self.value_stack
                     .push(Value::F64(f64::from_ne_bytes(x.to_ne_bytes())));
             }
@@ -1473,6 +1499,6 @@ impl<'a, I: ImportDispatcher> Instance<'a, I> {
             }
         }
 
-        action
+        Ok(action)
     }
 }

--- a/crates/wasm_interp/src/lib.rs
+++ b/crates/wasm_interp/src/lib.rs
@@ -7,7 +7,7 @@ pub mod wasi;
 // Main external interface
 pub use instance::Instance;
 
-use roc_wasm_module::Value;
+use roc_wasm_module::{Value, ValueType};
 use value_stack::ValueStack;
 use wasi::WasiDispatcher;
 
@@ -54,5 +54,23 @@ impl<'a> ImportDispatcher for DefaultImportDispatcher<'a> {
                 module_name, function_name
             );
         }
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub(crate) enum Error {
+    ValueStackType(ValueType, ValueType),
+    ValueStackEmpty,
+}
+
+impl Error {
+    fn value_stack_type(expected: ValueType, is_float: bool, is_64: bool) -> Self {
+        let ty = match (is_float, is_64) {
+            (false, false) => ValueType::I32,
+            (false, true) => ValueType::I64,
+            (true, false) => ValueType::F32,
+            (true, true) => ValueType::F64,
+        };
+        Error::ValueStackType(expected, ty)
     }
 }

--- a/crates/wasm_interp/src/lib.rs
+++ b/crates/wasm_interp/src/lib.rs
@@ -61,6 +61,7 @@ impl<'a> ImportDispatcher for DefaultImportDispatcher<'a> {
 pub(crate) enum Error {
     ValueStackType(ValueType, ValueType),
     ValueStackEmpty,
+    UnreachableOp,
 }
 
 impl Error {

--- a/crates/wasm_interp/src/lib.rs
+++ b/crates/wasm_interp/src/lib.rs
@@ -9,6 +9,7 @@ pub use instance::Instance;
 
 use roc_wasm_module::Value;
 use value_stack::ValueStack;
+use wasi::WasiDispatcher;
 
 pub trait ImportDispatcher {
     /// Dispatch a call from WebAssembly to your own code, based on module and function name.
@@ -21,11 +22,23 @@ pub trait ImportDispatcher {
     ) -> Option<Value>;
 }
 
-pub const DEFAULT_IMPORTS: DefaultImportDispatcher = DefaultImportDispatcher {};
+pub const DEFAULT_IMPORTS: DefaultImportDispatcher = DefaultImportDispatcher {
+    wasi: WasiDispatcher { args: &[] },
+};
 
-pub struct DefaultImportDispatcher {}
+pub struct DefaultImportDispatcher<'a> {
+    wasi: WasiDispatcher<'a>,
+}
 
-impl ImportDispatcher for DefaultImportDispatcher {
+impl<'a> DefaultImportDispatcher<'a> {
+    pub fn new(args: &'a [&'a String]) -> Self {
+        DefaultImportDispatcher {
+            wasi: WasiDispatcher { args },
+        }
+    }
+}
+
+impl<'a> ImportDispatcher for DefaultImportDispatcher<'a> {
     fn dispatch(
         &mut self,
         module_name: &str,
@@ -34,7 +47,7 @@ impl ImportDispatcher for DefaultImportDispatcher {
         memory: &mut [u8],
     ) -> Option<Value> {
         if module_name == wasi::MODULE_NAME {
-            wasi::dispatch(function_name, arguments, memory)
+            self.wasi.dispatch(function_name, arguments, memory)
         } else {
             panic!(
                 "DefaultImportDispatcher does not implement {}.{}",

--- a/crates/wasm_interp/src/main.rs
+++ b/crates/wasm_interp/src/main.rs
@@ -42,10 +42,9 @@ fn main() -> io::Result<()> {
         .required(true);
 
     let args_for_app = Arg::new(ARGS_FOR_APP)
-        .help("Arguments to pass into the WebAssembly app\ne.g. `roc_wasm_interp app.wasm -- 123 123.45`")
+        .help("Arguments to pass into the WebAssembly app\ne.g. `roc_wasm_interp app.wasm 123 123.45`")
         .multiple_values(true)
-        .takes_value(true)
-        .last(true);
+        .takes_value(true);
 
     let app = Command::new("roc_wasm_interp")
         .about("Run the given .wasm file")

--- a/crates/wasm_interp/src/tests/test_basics.rs
+++ b/crates/wasm_interp/src/tests/test_basics.rs
@@ -93,9 +93,9 @@ fn test_loop_help(end: i32, expected: i32) {
         &mut state.program_counter,
     );
 
-    while let Action::Continue = state.execute_next_instruction(&module) {}
+    while let Ok(Action::Continue) = state.execute_next_instruction(&module) {}
 
-    assert_eq!(state.value_stack.pop_i32(), expected);
+    assert_eq!(state.value_stack.pop_i32(), Ok(expected));
 }
 
 #[test]
@@ -161,9 +161,9 @@ fn test_if_else_help(condition: i32, expected: i32) {
         &mut state.program_counter,
     );
 
-    while let Action::Continue = state.execute_next_instruction(&module) {}
+    while let Ok(Action::Continue) = state.execute_next_instruction(&module) {}
 
-    assert_eq!(state.value_stack.pop_i32(), expected);
+    assert_eq!(state.value_stack.pop_i32(), Ok(expected));
 }
 
 #[test]
@@ -250,7 +250,7 @@ fn test_br() {
         &mut state.program_counter,
     );
 
-    while let Action::Continue = state.execute_next_instruction(&module) {}
+    while let Ok(Action::Continue) = state.execute_next_instruction(&module) {}
 
     assert_eq!(state.value_stack.pop(), Value::I32(111))
 }
@@ -348,7 +348,7 @@ fn test_br_if_help(condition: i32, expected: i32) {
         &mut state.program_counter,
     );
 
-    while let Action::Continue = state.execute_next_instruction(&module) {}
+    while let Ok(Action::Continue) = state.execute_next_instruction(&module) {}
 
     assert_eq!(state.value_stack.pop(), Value::I32(expected))
 }
@@ -452,7 +452,7 @@ fn test_br_table_help(condition: i32, expected: i32) {
         &mut state.program_counter,
     );
 
-    while let Action::Continue = state.execute_next_instruction(&module) {}
+    while let Ok(Action::Continue) = state.execute_next_instruction(&module) {}
 
     assert_eq!(state.value_stack.pop(), Value::I32(expected))
 }
@@ -664,7 +664,7 @@ fn test_call_return_with_args() {
 
     state.program_counter = func0_first_instruction as usize;
 
-    while let Action::Continue = state.execute_next_instruction(&module) {}
+    while let Ok(Action::Continue) = state.execute_next_instruction(&module) {}
 
     assert_eq!(state.value_stack.peek(), Value::I32(4));
 }
@@ -785,7 +785,7 @@ fn test_select_help(first: Value, second: Value, condition: i32, expected: Value
         &mut state.program_counter,
     );
 
-    while let Action::Continue = state.execute_next_instruction(&module) {}
+    while let Ok(Action::Continue) = state.execute_next_instruction(&module) {}
 
     assert_eq!(state.value_stack.pop(), expected);
 }
@@ -818,9 +818,9 @@ fn test_set_get_local() {
     module.code.bytes.push(OpCode::GETLOCAL as u8);
     module.code.bytes.encode_u32(2);
 
-    state.execute_next_instruction(&module);
-    state.execute_next_instruction(&module);
-    state.execute_next_instruction(&module);
+    state.execute_next_instruction(&module).unwrap();
+    state.execute_next_instruction(&module).unwrap();
+    state.execute_next_instruction(&module).unwrap();
     assert_eq!(state.value_stack.len(), 1);
     assert_eq!(state.value_stack.pop(), Value::I32(12345));
 }
@@ -853,9 +853,9 @@ fn test_tee_get_local() {
     module.code.bytes.push(OpCode::GETLOCAL as u8);
     module.code.bytes.encode_u32(2);
 
-    state.execute_next_instruction(&module);
-    state.execute_next_instruction(&module);
-    state.execute_next_instruction(&module);
+    state.execute_next_instruction(&module).unwrap();
+    state.execute_next_instruction(&module).unwrap();
+    state.execute_next_instruction(&module).unwrap();
     assert_eq!(state.value_stack.len(), 2);
     assert_eq!(state.value_stack.pop(), Value::I32(12345));
     assert_eq!(state.value_stack.pop(), Value::I32(12345));
@@ -879,10 +879,10 @@ fn test_global() {
     module.code.bytes.push(OpCode::GETGLOBAL as u8);
     module.code.bytes.encode_u32(1);
 
-    state.execute_next_instruction(&module);
-    state.execute_next_instruction(&module);
-    state.execute_next_instruction(&module);
-    state.execute_next_instruction(&module);
+    state.execute_next_instruction(&module).unwrap();
+    state.execute_next_instruction(&module).unwrap();
+    state.execute_next_instruction(&module).unwrap();
+    state.execute_next_instruction(&module).unwrap();
     assert_eq!(state.value_stack.len(), 2);
     assert_eq!(state.value_stack.pop(), Value::I32(555));
     assert_eq!(state.value_stack.pop(), Value::I32(222));
@@ -897,7 +897,7 @@ fn test_i32const() {
     module.code.bytes.push(OpCode::I32CONST as u8);
     module.code.bytes.encode_i32(12345);
 
-    state.execute_next_instruction(&module);
+    state.execute_next_instruction(&module).unwrap();
     assert_eq!(state.value_stack.pop(), Value::I32(12345))
 }
 
@@ -910,7 +910,7 @@ fn test_i64const() {
     module.code.bytes.push(OpCode::I64CONST as u8);
     module.code.bytes.encode_i64(1234567890);
 
-    state.execute_next_instruction(&module);
+    state.execute_next_instruction(&module).unwrap();
     assert_eq!(state.value_stack.pop(), Value::I64(1234567890))
 }
 
@@ -923,7 +923,7 @@ fn test_f32const() {
     module.code.bytes.push(OpCode::F32CONST as u8);
     module.code.bytes.encode_f32(123.45);
 
-    state.execute_next_instruction(&module);
+    state.execute_next_instruction(&module).unwrap();
     assert_eq!(state.value_stack.pop(), Value::F32(123.45))
 }
 
@@ -936,6 +936,6 @@ fn test_f64const() {
     module.code.bytes.push(OpCode::F64CONST as u8);
     module.code.bytes.encode_f64(12345.67890);
 
-    state.execute_next_instruction(&module);
+    state.execute_next_instruction(&module).unwrap();
     assert_eq!(state.value_stack.pop(), Value::F64(12345.67890))
 }

--- a/crates/wasm_interp/src/tests/test_basics.rs
+++ b/crates/wasm_interp/src/tests/test_basics.rs
@@ -709,8 +709,8 @@ fn test_call_indirect_help(table_index: u32, elem_index: u32) -> Value {
         buf.append_u8(OpCode::I32CONST as u8);
         buf.encode_u32(elem_index);
         buf.append_u8(OpCode::CALLINDIRECT as u8);
-        buf.encode_u32(table_index);
         buf.encode_u32(0); // signature index
+        buf.encode_u32(table_index);
         buf.append_u8(OpCode::END as u8);
     });
 

--- a/crates/wasm_interp/src/tests/test_mem.rs
+++ b/crates/wasm_interp/src/tests/test_mem.rs
@@ -16,6 +16,7 @@ fn test_currentmemory() {
     let pc = 0;
     module.memory = MemorySection::new(&arena, pages * MemorySection::PAGE_SIZE);
     module.code.bytes.push(OpCode::CURRENTMEMORY as u8);
+    module.code.bytes.encode_i32(0);
 
     let mut state = Instance::new(&arena, pages, pc, [], DEFAULT_IMPORTS);
     state.execute_next_instruction(&module).unwrap();
@@ -34,6 +35,7 @@ fn test_growmemory() {
     module.code.bytes.push(OpCode::I32CONST as u8);
     module.code.bytes.encode_i32(grow_pages);
     module.code.bytes.push(OpCode::GROWMEMORY as u8);
+    module.code.bytes.encode_i32(0);
 
     let mut state = Instance::new(&arena, existing_pages, pc, [], DEFAULT_IMPORTS);
     state.execute_next_instruction(&module).unwrap();

--- a/crates/wasm_interp/src/tests/test_mem.rs
+++ b/crates/wasm_interp/src/tests/test_mem.rs
@@ -18,7 +18,7 @@ fn test_currentmemory() {
     module.code.bytes.push(OpCode::CURRENTMEMORY as u8);
 
     let mut state = Instance::new(&arena, pages, pc, [], DEFAULT_IMPORTS);
-    state.execute_next_instruction(&module);
+    state.execute_next_instruction(&module).unwrap();
     assert_eq!(state.value_stack.pop(), Value::I32(3))
 }
 
@@ -36,8 +36,8 @@ fn test_growmemory() {
     module.code.bytes.push(OpCode::GROWMEMORY as u8);
 
     let mut state = Instance::new(&arena, existing_pages, pc, [], DEFAULT_IMPORTS);
-    state.execute_next_instruction(&module);
-    state.execute_next_instruction(&module);
+    state.execute_next_instruction(&module).unwrap();
+    state.execute_next_instruction(&module).unwrap();
     assert_eq!(state.memory.len(), 5 * MemorySection::PAGE_SIZE as usize);
 }
 

--- a/crates/wasm_interp/src/wasi.rs
+++ b/crates/wasm_interp/src/wasi.rs
@@ -1,5 +1,6 @@
 use roc_wasm_module::Value;
 use std::io::{self, Write};
+use std::process::exit;
 
 pub const MODULE_NAME: &str = "wasi_snapshot_preview1";
 
@@ -149,7 +150,10 @@ impl<'a> WasiDispatcher<'a> {
             "path_symlink" => todo!("WASI {}({:?})", function_name, arguments),
             "path_unlink_file" => todo!("WASI {}({:?})", function_name, arguments),
             "poll_oneoff" => todo!("WASI {}({:?})", function_name, arguments),
-            "proc_exit" => todo!("WASI {}({:?})", function_name, arguments),
+            "proc_exit" => {
+                let exit_code = arguments[0].unwrap_i32();
+                exit(exit_code);
+            }
             "proc_raise" => todo!("WASI {}({:?})", function_name, arguments),
             "sched_yield" => todo!("WASI {}({:?})", function_name, arguments),
             "random_get" => todo!("WASI {}({:?})", function_name, arguments),

--- a/crates/wasm_interp/src/wasi.rs
+++ b/crates/wasm_interp/src/wasi.rs
@@ -1,54 +1,345 @@
 use roc_wasm_module::Value;
+use std::io::{self, Write};
 
 pub const MODULE_NAME: &str = "wasi_snapshot_preview1";
 
-pub fn dispatch(function_name: &str, arguments: &[Value], _memory: &mut [u8]) -> Option<Value> {
-    match function_name {
-        "args_get" => todo!("WASI {}({:?})", function_name, arguments),
-        "args_sizes_get" => todo!("WASI {}({:?})", function_name, arguments),
-        "environ_get" => todo!("WASI {}({:?})", function_name, arguments),
-        "environ_sizes_get" => todo!("WASI {}({:?})", function_name, arguments),
-        "clock_res_get" => todo!("WASI {}({:?})", function_name, arguments),
-        "clock_time_get" => todo!("WASI {}({:?})", function_name, arguments),
-        "fd_advise" => todo!("WASI {}({:?})", function_name, arguments),
-        "fd_allocate" => todo!("WASI {}({:?})", function_name, arguments),
-        "fd_close" => todo!("WASI {}({:?})", function_name, arguments),
-        "fd_datasync" => todo!("WASI {}({:?})", function_name, arguments),
-        "fd_fdstat_get" => todo!("WASI {}({:?})", function_name, arguments),
-        "fd_fdstat_set_flags" => todo!("WASI {}({:?})", function_name, arguments),
-        "fd_fdstat_set_rights" => todo!("WASI {}({:?})", function_name, arguments),
-        "fd_filestat_get" => todo!("WASI {}({:?})", function_name, arguments),
-        "fd_filestat_set_size" => todo!("WASI {}({:?})", function_name, arguments),
-        "fd_filestat_set_times" => todo!("WASI {}({:?})", function_name, arguments),
-        "fd_pread" => todo!("WASI {}({:?})", function_name, arguments),
-        "fd_prestat_get" => todo!("WASI {}({:?})", function_name, arguments),
-        "fd_prestat_dir_name" => todo!("WASI {}({:?})", function_name, arguments),
-        "fd_pwrite" => todo!("WASI {}({:?})", function_name, arguments),
-        "fd_read" => todo!("WASI {}({:?})", function_name, arguments),
-        "fd_readdir" => todo!("WASI {}({:?})", function_name, arguments),
-        "fd_renumber" => todo!("WASI {}({:?})", function_name, arguments),
-        "fd_seek" => todo!("WASI {}({:?})", function_name, arguments),
-        "fd_sync" => todo!("WASI {}({:?})", function_name, arguments),
-        "fd_tell" => todo!("WASI {}({:?})", function_name, arguments),
-        "fd_write" => todo!("WASI {}({:?})", function_name, arguments),
-        "path_create_directory" => todo!("WASI {}({:?})", function_name, arguments),
-        "path_filestat_get" => todo!("WASI {}({:?})", function_name, arguments),
-        "path_filestat_set_times" => todo!("WASI {}({:?})", function_name, arguments),
-        "path_link" => todo!("WASI {}({:?})", function_name, arguments),
-        "path_open" => todo!("WASI {}({:?})", function_name, arguments),
-        "path_readlink" => todo!("WASI {}({:?})", function_name, arguments),
-        "path_remove_directory" => todo!("WASI {}({:?})", function_name, arguments),
-        "path_rename" => todo!("WASI {}({:?})", function_name, arguments),
-        "path_symlink" => todo!("WASI {}({:?})", function_name, arguments),
-        "path_unlink_file" => todo!("WASI {}({:?})", function_name, arguments),
-        "poll_oneoff" => todo!("WASI {}({:?})", function_name, arguments),
-        "proc_exit" => todo!("WASI {}({:?})", function_name, arguments),
-        "proc_raise" => todo!("WASI {}({:?})", function_name, arguments),
-        "sched_yield" => todo!("WASI {}({:?})", function_name, arguments),
-        "random_get" => todo!("WASI {}({:?})", function_name, arguments),
-        "sock_recv" => todo!("WASI {}({:?})", function_name, arguments),
-        "sock_send" => todo!("WASI {}({:?})", function_name, arguments),
-        "sock_shutdown" => todo!("WASI {}({:?})", function_name, arguments),
-        _ => panic!("Unknown WASI function {}({:?})", function_name, arguments),
+pub struct WasiDispatcher<'a> {
+    pub args: &'a [&'a String],
+}
+
+/// Implementation of WASI syscalls
+/// References for other engines:
+/// https://github.com/wasmerio/wasmer/blob/ef8d2f651ed29b4b06fdc2070eb8189922c54d82/lib/wasi/src/syscalls/mod.rs
+/// https://github.com/wasm3/wasm3/blob/045040a97345e636b8be4f3086e6db59cdcc785f/source/extra/wasi_core.h
+impl<'a> WasiDispatcher<'a> {
+    pub fn new(args: &'a [&'a String]) -> Self {
+        WasiDispatcher { args }
     }
+
+    pub fn dispatch(
+        &mut self,
+        function_name: &str,
+        arguments: &[Value],
+        memory: &mut [u8],
+    ) -> Option<Value> {
+        let success_code = Some(Value::I32(Errno::Success as i32));
+
+        match function_name {
+            "args_get" => {
+                // uint8_t ** argv,
+                let mut ptr_ptr_argv = arguments[0].unwrap_i32() as usize;
+                // uint8_t * argv_buf
+                let mut ptr_argv_buf = arguments[1].unwrap_i32() as usize;
+
+                for arg in self.args {
+                    write_u32(memory, ptr_ptr_argv, ptr_argv_buf as u32);
+                    let bytes_target = &mut memory[ptr_argv_buf..][..arg.len()];
+                    bytes_target.copy_from_slice(arg.as_bytes());
+                    memory[ptr_argv_buf + arg.len()] = 0; // C string zero termination
+                    ptr_argv_buf += arg.len() + 1;
+                    ptr_ptr_argv += 4;
+                }
+
+                success_code
+            }
+            "args_sizes_get" => {
+                // (i32, i32) -> i32
+
+                // number of string arguments
+                let ptr_argc = arguments[0].unwrap_i32() as usize;
+                // size of string arguments buffer
+                let ptr_argv_buf_size = arguments[1].unwrap_i32() as usize;
+
+                let argc = self.args.len() as u32;
+                write_u32(memory, ptr_argc, argc);
+
+                let argv_buf_size: u32 = self.args.iter().map(|a| 1 + a.len() as u32).sum();
+                write_u32(memory, ptr_argv_buf_size, argv_buf_size);
+
+                success_code
+            }
+            "environ_get" => todo!("WASI {}({:?})", function_name, arguments),
+            "environ_sizes_get" => todo!("WASI {}({:?})", function_name, arguments),
+            "clock_res_get" => todo!("WASI {}({:?})", function_name, arguments),
+            "clock_time_get" => todo!("WASI {}({:?})", function_name, arguments),
+            "fd_advise" => todo!("WASI {}({:?})", function_name, arguments),
+            "fd_allocate" => todo!("WASI {}({:?})", function_name, arguments),
+            "fd_close" => todo!("WASI {}({:?})", function_name, arguments),
+            "fd_datasync" => todo!("WASI {}({:?})", function_name, arguments),
+            "fd_fdstat_get" => todo!("WASI {}({:?})", function_name, arguments),
+            "fd_fdstat_set_flags" => todo!("WASI {}({:?})", function_name, arguments),
+            "fd_fdstat_set_rights" => todo!("WASI {}({:?})", function_name, arguments),
+            "fd_filestat_get" => todo!("WASI {}({:?})", function_name, arguments),
+            "fd_filestat_set_size" => todo!("WASI {}({:?})", function_name, arguments),
+            "fd_filestat_set_times" => todo!("WASI {}({:?})", function_name, arguments),
+            "fd_pread" => todo!("WASI {}({:?})", function_name, arguments),
+            "fd_prestat_get" => todo!("WASI {}({:?})", function_name, arguments),
+            "fd_prestat_dir_name" => todo!("WASI {}({:?})", function_name, arguments),
+            "fd_pwrite" => todo!("WASI {}({:?})", function_name, arguments),
+            "fd_read" => todo!("WASI {}({:?})", function_name, arguments),
+            "fd_readdir" => todo!("WASI {}({:?})", function_name, arguments),
+            "fd_renumber" => todo!("WASI {}({:?})", function_name, arguments),
+            "fd_seek" => todo!("WASI {}({:?})", function_name, arguments),
+            "fd_sync" => todo!("WASI {}({:?})", function_name, arguments),
+            "fd_tell" => todo!("WASI {}({:?})", function_name, arguments),
+            "fd_write" => {
+                // file descriptor
+                let fd = arguments[0].unwrap_i32();
+                // Array of IO vectors
+                let ptr_iovs = arguments[1].unwrap_i32() as usize;
+                // Length of array
+                let iovs_len = arguments[2].unwrap_i32();
+                // Out param: number of bytes written
+                let ptr_nwritten = arguments[3].unwrap_i32() as usize;
+
+                let mut write_lock = match fd {
+                    1 => Ok(io::stdout().lock()),
+                    2 => Err(io::stderr().lock()),
+                    _ => return Some(Value::I32(Errno::Inval as i32)),
+                };
+
+                let mut n_written: i32 = 0;
+                let mut negative_length_count = 0;
+                for _ in 0..iovs_len {
+                    // https://man7.org/linux/man-pages/man2/readv.2.html
+                    // struct iovec {
+                    //     void  *iov_base;    /* Starting address */
+                    //     size_t iov_len;     /* Number of bytes to transfer */
+                    // };
+                    let iov_base = read_u32(memory, ptr_iovs) as usize;
+                    let iov_len = read_i32(memory, ptr_iovs + 4);
+                    if iov_len < 0 {
+                        // I found negative-length iov's when I implemented this in JS for the web REPL (see wasi.js)
+                        // I'm not sure why, but this solution worked, and it's the same WASI libc - there's only one.
+                        n_written += iov_len;
+                        negative_length_count += 1;
+                        continue;
+                    }
+                    let bytes = &memory[iov_base..][..iov_len as usize];
+
+                    match &mut write_lock {
+                        Ok(stdout) => {
+                            n_written += stdout.write(bytes).unwrap() as i32;
+                        }
+                        Err(stderr) => {
+                            n_written += stderr.write(bytes).unwrap() as i32;
+                        }
+                    }
+                }
+
+                write_i32(memory, ptr_nwritten, n_written);
+                if negative_length_count > 0 {
+                    // Let's see if we ever get this message. If not, we can remove this negative-length stuff.
+                    eprintln!(
+                        "WASI DEV INFO: found {} negative-length iovecs.",
+                        negative_length_count
+                    );
+                }
+
+                success_code
+            }
+            "path_create_directory" => todo!("WASI {}({:?})", function_name, arguments),
+            "path_filestat_get" => todo!("WASI {}({:?})", function_name, arguments),
+            "path_filestat_set_times" => todo!("WASI {}({:?})", function_name, arguments),
+            "path_link" => todo!("WASI {}({:?})", function_name, arguments),
+            "path_open" => todo!("WASI {}({:?})", function_name, arguments),
+            "path_readlink" => todo!("WASI {}({:?})", function_name, arguments),
+            "path_remove_directory" => todo!("WASI {}({:?})", function_name, arguments),
+            "path_rename" => todo!("WASI {}({:?})", function_name, arguments),
+            "path_symlink" => todo!("WASI {}({:?})", function_name, arguments),
+            "path_unlink_file" => todo!("WASI {}({:?})", function_name, arguments),
+            "poll_oneoff" => todo!("WASI {}({:?})", function_name, arguments),
+            "proc_exit" => todo!("WASI {}({:?})", function_name, arguments),
+            "proc_raise" => todo!("WASI {}({:?})", function_name, arguments),
+            "sched_yield" => todo!("WASI {}({:?})", function_name, arguments),
+            "random_get" => todo!("WASI {}({:?})", function_name, arguments),
+            "sock_recv" => todo!("WASI {}({:?})", function_name, arguments),
+            "sock_send" => todo!("WASI {}({:?})", function_name, arguments),
+            "sock_shutdown" => todo!("WASI {}({:?})", function_name, arguments),
+            _ => panic!("Unknown WASI function {}({:?})", function_name, arguments),
+        }
+    }
+}
+
+fn read_u32(memory: &mut [u8], addr: usize) -> u32 {
+    let mut bytes = [0; 4];
+    bytes.copy_from_slice(&memory[addr..][..4]);
+    u32::from_le_bytes(bytes)
+}
+
+fn read_i32(memory: &mut [u8], addr: usize) -> i32 {
+    let mut bytes = [0; 4];
+    bytes.copy_from_slice(&memory[addr..][..4]);
+    i32::from_le_bytes(bytes)
+}
+
+fn write_u32(memory: &mut [u8], addr: usize, value: u32) {
+    memory[addr..][..4].copy_from_slice(&value.to_le_bytes());
+}
+
+fn write_i32(memory: &mut [u8], addr: usize, value: i32) {
+    memory[addr..][..4].copy_from_slice(&value.to_le_bytes());
+}
+
+/// Error codes returned by functions.
+/// Not all of these error codes are returned by the functions provided by this
+/// API; some are used in higher-level library layers, and others are provided
+/// merely for alignment with POSIX.
+#[repr(u8)]
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum Errno {
+    /// No error occurred. System call completed successfully.
+    Success,
+    /// Argument list too long.
+    Toobig,
+    /// Permission denied.
+    Access,
+    /// Address in use.
+    Addrinuse,
+    /// Address not available.
+    Addrnotavail,
+    /// Address family not supported.
+    Afnosupport,
+    /// Resource unavailable, or operation would block.
+    Again,
+    /// Connection already in progress.
+    Already,
+    /// Bad file descriptor.
+    Badf,
+    /// Bad message.
+    Badmsg,
+    /// Device or resource busy.
+    Busy,
+    /// Operation canceled.
+    Canceled,
+    /// No child processes.
+    Child,
+    /// Connection aborted.
+    Connaborted,
+    /// Connection refused.
+    Connrefused,
+    /// Connection reset.
+    Connreset,
+    /// Resource deadlock would occur.
+    Deadlk,
+    /// Destination address required.
+    Destaddrreq,
+    /// Mathematics argument out of domain of function.
+    Dom,
+    /// Reserved.
+    Dquot,
+    /// File exists.
+    Exist,
+    /// Bad address.
+    Fault,
+    /// File too large.
+    Fbig,
+    /// Host is unreachable.
+    Hostunreach,
+    /// Identifier removed.
+    Idrm,
+    /// Illegal byte sequence.
+    Ilseq,
+    /// Operation in progress.
+    Inprogress,
+    /// Interrupted function.
+    Intr,
+    /// Invalid argument.
+    Inval,
+    /// I/O error.
+    Io,
+    /// Socket is connected.
+    Isconn,
+    /// Is a directory.
+    Isdir,
+    /// Too many levels of symbolic links.
+    Loop,
+    /// File descriptor value too large.
+    Mfile,
+    /// Too many links.
+    Mlink,
+    /// Message too large.
+    Msgsize,
+    /// Reserved.
+    Multihop,
+    /// Filename too long.
+    Nametoolong,
+    /// Network is down.
+    Netdown,
+    /// Connection aborted by network.
+    Netreset,
+    /// Network unreachable.
+    Netunreach,
+    /// Too many files open in system.
+    Nfile,
+    /// No buffer space available.
+    Nobufs,
+    /// No such device.
+    Nodev,
+    /// No such file or directory.
+    Noent,
+    /// Executable file format error.
+    Noexec,
+    /// No locks available.
+    Nolck,
+    /// Reserved.
+    Nolink,
+    /// Not enough space.
+    Nomem,
+    /// No message of the desired type.
+    Nomsg,
+    /// Protocol not available.
+    Noprotoopt,
+    /// No space left on device.
+    Nospc,
+    /// Function not supported.
+    Nosys,
+    /// The socket is not connected.
+    Notconn,
+    /// Not a directory or a symbolic link to a directory.
+    Notdir,
+    /// Directory not empty.
+    Notempty,
+    /// State not recoverable.
+    Notrecoverable,
+    /// Not a socket.
+    Notsock,
+    /// Not supported, or operation not supported on socket.
+    Notsup,
+    /// Inappropriate I/O control operation.
+    Notty,
+    /// No such device or address.
+    Nxio,
+    /// Value too large to be stored in data type.
+    Overflow,
+    /// Previous owner died.
+    Ownerdead,
+    /// Operation not permitted.
+    Perm,
+    /// Broken pipe.
+    Pipe,
+    /// Protocol error.
+    Proto,
+    /// Protocol not supported.
+    Protonosupport,
+    /// Protocol wrong type for socket.
+    Prototype,
+    /// Result too large.
+    Range,
+    /// Read-only file system.
+    Rofs,
+    /// Invalid seek.
+    Spipe,
+    /// No such process.
+    Srch,
+    /// Reserved.
+    Stale,
+    /// Connection timed out.
+    Timedout,
+    /// Text file busy.
+    Txtbsy,
+    /// Cross-device link.
+    Xdev,
+    /// Extension: Capabilities insufficient.
+    Notcapable,
 }

--- a/crates/wasm_module/src/sections.rs
+++ b/crates/wasm_module/src/sections.rs
@@ -1537,6 +1537,7 @@ impl<'a> DataSection<'a> {
             target_slice
                 .write(&self.bytes[cursor..][..len])
                 .map_err(|e| format!("{:?}", e))?;
+            cursor += len;
         }
         Ok(())
     }


### PR DESCRIPTION
Start implementing WASI, and a Wasm stack trace, and fix some bugs.
These changes were enough to get some initial Zig builtin tests working.

### Summary

- Implement some basic WASI syscalls
    - `args_sizes_get`, `args_get`, `fd_write`, `proc_exit`
- Change the CLI to be compatible with other engines and `zig test`
    - Don't require `--` before the Wasm arguments
    - Make sure the WASI app sees its own path as `argv[0]`. (Interpreter removes its own `argv[0]`, its own flags, etc. before passing the rest down.)
- Implement a stack trace dump for the Wasm app
    - At this stage, when debugging, I usually find I want a stack trace of the Wasm app, not the interpreter.
    - Create an `Error` enum and convert lots of panics to `Result` and `?`.
    - There are still panics for some things though. We'll see how it evolves.
- General bugfixes. See individual commits.