### PR TITLE
Fix concat of non-unique list with unique list

### DIFF
--- a/crates/compiler/builtins/bitcode/src/list.zig
+++ b/crates/compiler/builtins/bitcode/src/list.zig
@@ -772,7 +772,7 @@ pub fn listConcat(list_a: RocList, list_b: RocList, alignment: u32, element_widt
         // This first call must use mem.copy because the slices might overlap.
         const byte_count_a = list_a.len() * element_width;
         const byte_count_b = list_b.len() * element_width;
-        mem.copy(u8, source_b[byte_count_a .. byte_count_a + byte_count_b], source_b[0..byte_count_b]);
+        mem.copyBackwards(u8, source_b[byte_count_a .. byte_count_a + byte_count_b], source_b[0..byte_count_b]);
         @memcpy(source_b, source_a, byte_count_a);
 
         // decrement list a.
@@ -869,7 +869,7 @@ test "listConcat: non-unique with unique overlapping" {
     defer unique.deinit(u8);
 
     var concatted = listConcat(nonUnique, unique, 1, 1);
-    var wanted = RocList.fromSlice(u8, ([_]u8{ 1, 2, 2, 2 })[0..]);
+    var wanted = RocList.fromSlice(u8, ([_]u8{ 1, 2, 3, 4 })[0..]);
     defer wanted.deinit(u8);
 
     try expect(concatted.eql(wanted));

--- a/crates/compiler/test_gen/src/gen_list.rs
+++ b/crates/compiler/test_gen/src/gen_list.rs
@@ -3563,6 +3563,27 @@ fn list_walk_from_until_sum() {
 
 #[test]
 #[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
+fn concat_unique_to_nonunique_overlapping_issue_4697() {
+    assert_evals_to!(
+        r#"
+        # originalList is shared, but others is unique.
+        # When we concat originalList with others, others should be re-used.
+
+        originalList = [1u8]
+        others = [2u8, 3u8, 4u8]
+        new = List.concat originalList others
+        {a: originalList, b: new}
+        "#,
+        (
+            RocList::from_slice(&[1u8]),
+            RocList::from_slice(&[1u8, 2, 3, 4]),
+        ),
+        (RocList<u8>, RocList<u8>)
+    );
+}
+
+#[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
 fn list_walk_from_even_prefix_sum() {
     assert_evals_to!(
         r#"


### PR DESCRIPTION
When we concat a non-unique list with a unique list, we reuse the unique list, and start by moving all of its owned items to the end of the list. Previously, we used Zig's `mem.copy`, which expects that the copy destination is before the copy source - but this is incorrect for our case. Instead we need `mem.copyBackwards`.

Closes #4697 