### PR TITLE
Fix tutorial toc links

### DIFF
--- a/www/public/tutorial/index.html
+++ b/www/public/tutorial/index.html
@@ -1217,6 +1217,7 @@ control flow. In fact, if you do <code>roc build</code>, they are not even inclu
 <p>If you try this code out, you may note that when an <code>expect</code> fails (either a top-level or inline
 one), the failure message includes the values of any named variables - such as <code>count</code> here.
 This leads to a useful technique, which we will see next.</p>
+<span id="modules"></span>
 <h2 id="interface-modules"><a href="#interface-modules">Interface modules</a></h2>
 <p>[This part of the tutorial has not been written yet. Coming soon!]</p>
 <h2 id="builtin-modules"><a href="#builtin-modules">Builtin modules</a></h2>

--- a/www/public/tutorial/index.html
+++ b/www/public/tutorial/index.html
@@ -46,7 +46,7 @@
             <li><a href="#crashing">Crashing</a></li>
             <li><a href="#tests-and-expectations">Tests and Expectations</a></li>
             <li><a href="#modules">Modules</a></li>
-            <li><a href="#modules">Platforms and Packages</a></li>
+            <li><a href="#platforms-and-packages">Platforms and Packages</a></li>
             <li><a href="#tasks">Tasks</a></li>
             <li><a href="#abilities">Abilities</a></li>
             <li><a href="#appendix-advanced-concepts">Advanced Concepts</a></li>
@@ -1241,6 +1241,7 @@ Roc compiler. That's why they're called "builtins!"</p>
 <li>They are always imported. You never need to add them to <code>imports</code>.</li>
 <li>All their types are imported unqualified automatically. So you never need to write <code>Num.Nat</code>, because it's as if the <code>Num</code> module was imported using <code>imports [Num.{ Nat }]</code> (and the same for all the other types in the <code>Num</code> module).</li>
 </ul>
+<span id="platforms-and-packages"></span>
 <h2 id="the-app-module-header"><a href="#the-app-module-header">The app module header</a></h2>
 <p>Let's take a closer look at the part of <code>main.roc</code> above the <code>main</code> def:</p>
 <samp><span class="hljs-selector-tag">app</span> "<span class="hljs-selector-tag">hello</span>"

--- a/www/public/tutorial/index.html
+++ b/www/public/tutorial/index.html
@@ -49,7 +49,7 @@
             <li><a href="#modules">Platforms and Packages</a></li>
             <li><a href="#tasks">Tasks</a></li>
             <li><a href="#abilities">Abilities</a></li>
-            <li><a href="#advanced-concepts">Advanced Concepts</a></li>
+            <li><a href="#appendix-advanced-concepts">Advanced Concepts</a></li>
             <li><a href="#operator-desugaring-table">Operator Desugaring Table</a></li>
         </ol>
     </nav>

--- a/www/public/tutorial/index.html
+++ b/www/public/tutorial/index.html
@@ -1451,6 +1451,8 @@ backpassing for all the <code>await</code> calls, like we had above:</p>
 <li>Backpassing syntax does not need to be used with <code>await</code> in particular. It can be used with any function.</li>
 <li>Roc's compiler treats functions defined with backpassing exactly the same way as functions defined the other way. The only difference between <code>\text <span class="op">-&gt;</span></code> and <code>text &lt;-</code> is how they look, so feel free to use whichever looks nicer to you!</li>
 </ul>
+<h2 id="abilities"><a href="#abilities">Abilities</a></h2>
+<p>[This part of the tutorial has not been written yet. Coming soon!]</p>
 <h2 id="appendix-advanced-concepts"><a href="#appendix-advanced-concepts">Appendix: Advanced Concepts</a></h2>
 <p>Here are some concepts you likely won't need as a beginner, but may want to know about eventually.
 This is listed as an appendix rather than the main tutorial, to emphasize that it's totally fine


### PR DESCRIPTION
This pull request  

* adds invisible anchor ids for `Modules` and `Platforms and Packages` to allow the user to jump to the down,
* inserts an `Abilities` section with a TODO comment, and 
* fixes the link to `Appendix: Advanced Concepts`

It relates to #4673 but does not add search functionality to the page.