### PR TITLE
Define inline expects defs in their definition order 

### DIFF
--- a/crates/compiler/can/src/expr.rs
+++ b/crates/compiler/can/src/expr.rs
@@ -2995,7 +2995,7 @@ fn toplevel_expect_to_inline_expect_help(mut loc_expr: Loc<Expr>, has_effects: b
 
     let mut loc_expr = Loc::at(expect_region, expect);
 
-    for stored in stack {
+    for stored in stack.into_iter().rev() {
         match stored {
             StoredDef::NonRecursive(region, boxed_def) => {
                 loc_expr = Loc::at(region, Expr::LetNonRec(boxed_def, Box::new(loc_expr)));

--- a/crates/compiler/test_mono/generated/issue_4705.txt
+++ b/crates/compiler/test_mono/generated/issue_4705.txt
@@ -1,0 +1,14 @@
+procedure Bool.2 ():
+    let Bool.23 : Int1 = true;
+    ret Bool.23;
+
+procedure Test.0 (Test.4):
+    let Test.7 : Int1 = CallByName Bool.2;
+    ret Test.7;
+
+procedure Test.3 ():
+    let Test.1 : {} = Struct {};
+    let Test.2 : Int1 = CallByName Test.0 Test.1;
+    expect Test.2;
+    let Test.5 : {} = Struct {};
+    ret Test.5;

--- a/crates/compiler/test_mono/src/tests.rs
+++ b/crates/compiler/test_mono/src/tests.rs
@@ -184,14 +184,17 @@ fn verify_procedures<'a>(
         .map(|proc| proc.to_pretty(&interner, 200, false))
         .collect::<Vec<_>>();
 
-    procs_string.sort();
-
-    if let Some(main_fn_symbol) = opt_main_fn_symbol {
+    let opt_main_fn = opt_main_fn_symbol.map(|main_fn_symbol| {
         let index = procedures
             .keys()
             .position(|(s, _)| *s == main_fn_symbol)
             .unwrap();
-        let main_fn = procs_string.swap_remove(index);
+        procs_string.swap_remove(index)
+    });
+
+    procs_string.sort();
+
+    if let Some(main_fn) = opt_main_fn {
         procs_string.push(main_fn);
     }
 

--- a/crates/compiler/test_mono/src/tests.rs
+++ b/crates/compiler/test_mono/src/tests.rs
@@ -2139,3 +2139,20 @@ fn list_one_vs_one_spread_issue_4685() {
         "#
     )
 }
+
+#[mono_test(mode = "test")]
+fn issue_4705() {
+    indoc!(
+        r###"
+        interface Test exposes [] imports []
+
+        go : {} -> Bool
+        go = \{} -> Bool.true
+
+        expect
+            input = {}
+            x = go input
+            x
+        "###
+    )
+}


### PR DESCRIPTION
When we transform a top-level expect into an inline expect, we collect
all intermediate defs before the expect condition, then layer the defs
back on. Because the layering procedure builds an expression bottom-up,
we must layer on defs in reverse definition order.

Closes https://github.com/roc-lang/roc/issues/4705