### PR TITLE
use atomics for expect/dbg

### DIFF
--- a/crates/cli/tests/fixtures/multi-dep-str/platform/host.zig
+++ b/crates/cli/tests/fixtures/multi-dep-str/platform/host.zig
@@ -78,9 +78,6 @@ fn roc_getppid_windows_stub() callconv(.C) c_int {
     return 0;
 }
 
-fn roc_send_signal(pid: c_int, sig: c_int) callconv(.C) c_int {
-    return kill(pid, sig);
-}
 fn roc_shm_open(name: *const i8, oflag: c_int, mode: c_uint) callconv(.C) c_int {
     return shm_open(name, oflag, mode);
 }
@@ -92,7 +89,6 @@ comptime {
     if (builtin.os.tag == .macos or builtin.os.tag == .linux) {
         @export(roc_getppid, .{ .name = "roc_getppid", .linkage = .Strong });
         @export(roc_mmap, .{ .name = "roc_mmap", .linkage = .Strong });
-        @export(roc_send_signal, .{ .name = "roc_send_signal", .linkage = .Strong });
         @export(roc_shm_open, .{ .name = "roc_shm_open", .linkage = .Strong });
     }
 

--- a/crates/cli/tests/fixtures/multi-dep-thunk/platform/host.zig
+++ b/crates/cli/tests/fixtures/multi-dep-thunk/platform/host.zig
@@ -77,9 +77,6 @@ fn roc_getppid_windows_stub() callconv(.C) c_int {
     return 0;
 }
 
-fn roc_send_signal(pid: c_int, sig: c_int) callconv(.C) c_int {
-    return kill(pid, sig);
-}
 fn roc_shm_open(name: *const i8, oflag: c_int, mode: c_uint) callconv(.C) c_int {
     return shm_open(name, oflag, mode);
 }
@@ -91,7 +88,6 @@ comptime {
     if (builtin.os.tag == .macos or builtin.os.tag == .linux) {
         @export(roc_getppid, .{ .name = "roc_getppid", .linkage = .Strong });
         @export(roc_mmap, .{ .name = "roc_mmap", .linkage = .Strong });
-        @export(roc_send_signal, .{ .name = "roc_send_signal", .linkage = .Strong });
         @export(roc_shm_open, .{ .name = "roc_shm_open", .linkage = .Strong });
     }
 

--- a/crates/cli_testing_examples/algorithms/fibonacci-platform/host.zig
+++ b/crates/cli_testing_examples/algorithms/fibonacci-platform/host.zig
@@ -94,9 +94,6 @@ fn roc_getppid_windows_stub() callconv(.C) c_int {
     return 0;
 }
 
-fn roc_send_signal(pid: c_int, sig: c_int) callconv(.C) c_int {
-    return kill(pid, sig);
-}
 fn roc_shm_open(name: *const i8, oflag: c_int, mode: c_uint) callconv(.C) c_int {
     return shm_open(name, oflag, mode);
 }
@@ -108,7 +105,6 @@ comptime {
     if (builtin.os.tag == .macos or builtin.os.tag == .linux) {
         @export(roc_getppid, .{ .name = "roc_getppid", .linkage = .Strong });
         @export(roc_mmap, .{ .name = "roc_mmap", .linkage = .Strong });
-        @export(roc_send_signal, .{ .name = "roc_send_signal", .linkage = .Strong });
         @export(roc_shm_open, .{ .name = "roc_shm_open", .linkage = .Strong });
     }
 

--- a/crates/cli_testing_examples/algorithms/quicksort-platform/host.zig
+++ b/crates/cli_testing_examples/algorithms/quicksort-platform/host.zig
@@ -93,9 +93,6 @@ fn roc_getppid_windows_stub() callconv(.C) c_int {
     return 0;
 }
 
-fn roc_send_signal(pid: c_int, sig: c_int) callconv(.C) c_int {
-    return kill(pid, sig);
-}
 fn roc_shm_open(name: *const i8, oflag: c_int, mode: c_uint) callconv(.C) c_int {
     return shm_open(name, oflag, mode);
 }
@@ -107,7 +104,6 @@ comptime {
     if (builtin.os.tag == .macos or builtin.os.tag == .linux) {
         @export(roc_getppid, .{ .name = "roc_getppid", .linkage = .Strong });
         @export(roc_mmap, .{ .name = "roc_mmap", .linkage = .Strong });
-        @export(roc_send_signal, .{ .name = "roc_send_signal", .linkage = .Strong });
         @export(roc_shm_open, .{ .name = "roc_shm_open", .linkage = .Strong });
     }
 

--- a/crates/cli_testing_examples/benchmarks/platform/host.zig
+++ b/crates/cli_testing_examples/benchmarks/platform/host.zig
@@ -98,9 +98,6 @@ fn roc_getppid_windows_stub() callconv(.C) c_int {
     return 0;
 }
 
-fn roc_send_signal(pid: c_int, sig: c_int) callconv(.C) c_int {
-    return kill(pid, sig);
-}
 fn roc_shm_open(name: *const i8, oflag: c_int, mode: c_uint) callconv(.C) c_int {
     return shm_open(name, oflag, mode);
 }
@@ -112,7 +109,6 @@ comptime {
     if (builtin.os.tag == .macos or builtin.os.tag == .linux) {
         @export(roc_getppid, .{ .name = "roc_getppid", .linkage = .Strong });
         @export(roc_mmap, .{ .name = "roc_mmap", .linkage = .Strong });
-        @export(roc_send_signal, .{ .name = "roc_send_signal", .linkage = .Strong });
         @export(roc_shm_open, .{ .name = "roc_shm_open", .linkage = .Strong });
     }
 

--- a/crates/compiler/builtins/bitcode/src/main.zig
+++ b/crates/compiler/builtins/bitcode/src/main.zig
@@ -172,8 +172,8 @@ comptime {
     if (builtin.target.cpu.arch != .wasm32) {
         exportUtilsFn(expect.expectFailedStartSharedBuffer, "expect_failed_start_shared_buffer");
         exportUtilsFn(expect.expectFailedStartSharedFile, "expect_failed_start_shared_file");
-        exportUtilsFn(expect.expectFailedFinalize, "expect_failed_finalize");
-        exportUtilsFn(expect.sendDbg, "send_dbg");
+        exportUtilsFn(expect.notifyParentExpect, "notify_parent_expect");
+        exportUtilsFn(expect.notifyParentDbg, "notify_parent_dbg");
 
         // sets the buffer used for expect failures
         @export(expect.setSharedBuffer, .{ .name = "set_shared_buffer", .linkage = .Weak });

--- a/crates/compiler/builtins/bitcode/src/utils.zig
+++ b/crates/compiler/builtins/bitcode/src/utils.zig
@@ -32,9 +32,6 @@ fn roc_getppid_windows_stub() callconv(.C) c_int {
     return 0;
 }
 
-fn testing_roc_send_signal(pid: c_int, sig: c_int) callconv(.C) c_int {
-    return kill(pid, sig);
-}
 fn testing_roc_shm_open(name: *const i8, oflag: c_int, mode: c_uint) callconv(.C) c_int {
     return shm_open(name, oflag, mode);
 }
@@ -55,7 +52,6 @@ comptime {
         if (builtin.os.tag == .macos or builtin.os.tag == .linux) {
             @export(testing_roc_getppid, .{ .name = "roc_getppid", .linkage = .Strong });
             @export(testing_roc_mmap, .{ .name = "roc_mmap", .linkage = .Strong });
-            @export(testing_roc_send_signal, .{ .name = "roc_send_signal", .linkage = .Strong });
             @export(testing_roc_shm_open, .{ .name = "roc_shm_open", .linkage = .Strong });
         }
     }

--- a/crates/compiler/builtins/src/bitcode.rs
+++ b/crates/compiler/builtins/src/bitcode.rs
@@ -424,9 +424,9 @@ pub const UTILS_EXPECT_FAILED_START_SHARED_BUFFER: &str =
     "roc_builtins.utils.expect_failed_start_shared_buffer";
 pub const UTILS_EXPECT_FAILED_START_SHARED_FILE: &str =
     "roc_builtins.utils.expect_failed_start_shared_file";
-pub const UTILS_EXPECT_FAILED_FINALIZE: &str = "roc_builtins.utils.expect_failed_finalize";
 pub const UTILS_EXPECT_READ_ENV_SHARED_BUFFER: &str = "roc_builtins.utils.read_env_shared_buffer";
-pub const UTILS_SEND_DBG: &str = "roc_builtins.utils.send_dbg";
+pub const NOTIFY_PARENT_EXPECT: &str = "roc_builtins.utils.notify_parent_expect";
+pub const NOTIFY_PARENT_DBG: &str = "roc_builtins.utils.notify_parent_dbg";
 
 pub const UTILS_LONGJMP: &str = "longjmp";
 pub const UTILS_SETJMP: &str = "setjmp";

--- a/crates/compiler/gen_llvm/src/llvm/externs.rs
+++ b/crates/compiler/gen_llvm/src/llvm/externs.rs
@@ -158,7 +158,6 @@ pub fn add_default_roc_externs(env: &Env<'_, '_, '_>) {
 
         unreachable_function(env, "roc_getppid");
         unreachable_function(env, "roc_mmap");
-        unreachable_function(env, "roc_send_signal");
         unreachable_function(env, "roc_shm_open");
 
         add_sjlj_roc_panic(env)
@@ -168,7 +167,10 @@ pub fn add_default_roc_externs(env: &Env<'_, '_, '_>) {
 fn unreachable_function(env: &Env, name: &str) {
     // The type of this function (but not the implementation) should have
     // already been defined by the builtins, which rely on it.
-    let fn_val = env.module.get_function(name).unwrap();
+    let fn_val = match env.module.get_function(name) {
+        Some(f) => f,
+        None => panic!("extern function {name} is not defined by the bulitins"),
+    };
 
     // Add a basic block for the entry point
     let entry = env.context.append_basic_block(fn_val, "entry");

--- a/crates/compiler/gen_llvm/src/llvm/externs.rs
+++ b/crates/compiler/gen_llvm/src/llvm/externs.rs
@@ -169,7 +169,7 @@ fn unreachable_function(env: &Env, name: &str) {
     // already been defined by the builtins, which rely on it.
     let fn_val = match env.module.get_function(name) {
         Some(f) => f,
-        None => panic!("extern function {name} is not defined by the bulitins"),
+        None => panic!("extern function {name} is not defined by the builtins"),
     };
 
     // Add a basic block for the entry point

--- a/crates/compiler/gen_llvm/src/llvm/lowlevel.rs
+++ b/crates/compiler/gen_llvm/src/llvm/lowlevel.rs
@@ -1126,16 +1126,19 @@ pub(crate) fn run_low_level<'a, 'ctx, 'env>(
             if env.mode.runs_expects() {
                 let region = unsafe { std::mem::transmute::<_, roc_region::all::Region>(args[0]) };
 
+                let shared_memory = crate::llvm::expect::SharedMemoryPointer::get(env);
+
                 crate::llvm::expect::clone_to_shared_memory(
                     env,
                     scope,
                     layout_ids,
+                    &shared_memory,
                     args[0],
                     region,
                     &[args[0]],
                 );
 
-                crate::llvm::expect::send_dbg(env);
+                crate::llvm::expect::notify_parent_dbg(env, &shared_memory);
             }
 
             condition

--- a/crates/linker/src/elf.rs
+++ b/crates/linker/src/elf.rs
@@ -85,7 +85,6 @@ fn collect_roc_definitions<'a>(object: &object::File<'a, &'a [u8]>) -> MutMap<St
             // for expects
             "roc_mmap" => Some("mmap"),
             "roc_getppid" => Some("getppid"),
-            "roc_send_signal" => Some("kill"),
             "roc_shm_open" => Some("shm_open"),
 
             _ => None,

--- a/crates/repl_expect/src/run.rs
+++ b/crates/repl_expect/src/run.rs
@@ -1,4 +1,10 @@
-use std::{os::unix::process::parent_id, sync::Arc};
+use std::{
+    os::unix::process::parent_id,
+    sync::{
+        atomic::{AtomicBool, AtomicU32},
+        Arc,
+    },
+};
 
 use bumpalo::collections::Vec as BumpVec;
 use bumpalo::Bump;
@@ -104,6 +110,16 @@ impl<'a> ExpectMemory<'a> {
         let set_shared_buffer = run_roc_dylib!(lib, "set_shared_buffer", (*mut u8, usize), ());
         let mut result = RocCallResult::default();
         unsafe { set_shared_buffer((self.ptr, self.length), &mut result) };
+    }
+
+    pub fn wait_for_child(&self, sigchld: Arc<AtomicBool>) -> ChildProcessMsg {
+        let sequence = ExpectSequence { ptr: self.ptr };
+        sequence.wait_for_child(sigchld)
+    }
+
+    pub fn reset(&mut self) {
+        let mut sequence = ExpectSequence { ptr: self.ptr };
+        sequence.reset();
     }
 }
 
@@ -591,16 +607,18 @@ struct ExpectSequence {
 }
 
 impl ExpectSequence {
-    const START_OFFSET: usize = 16;
+    const START_OFFSET: usize = 8 + 8 + 8;
 
     const COUNT_INDEX: usize = 0;
     const OFFSET_INDEX: usize = 1;
+    const LOCK_INDEX: usize = 2;
 
     fn new(ptr: *mut u8) -> Self {
         unsafe {
             let ptr = ptr as *mut usize;
             std::ptr::write_unaligned(ptr.add(Self::COUNT_INDEX), 0);
             std::ptr::write_unaligned(ptr.add(Self::OFFSET_INDEX), Self::START_OFFSET);
+            std::ptr::write_unaligned(ptr.add(Self::LOCK_INDEX), 0);
         }
 
         Self {
@@ -611,11 +629,47 @@ impl ExpectSequence {
     fn count_failures(&self) -> usize {
         unsafe { *(self.ptr as *const usize).add(Self::COUNT_INDEX) }
     }
+
+    fn wait_for_child(&self, sigchld: Arc<AtomicBool>) -> ChildProcessMsg {
+        use std::sync::atomic::Ordering;
+        let ptr = self.ptr as *const u32;
+        let atomic_ptr: *const AtomicU32 = unsafe { ptr.add(5).cast() };
+        let atomic = unsafe { &*atomic_ptr };
+
+        loop {
+            if sigchld.load(Ordering::Relaxed) {
+                break ChildProcessMsg::Terminate;
+            }
+
+            match atomic.load(Ordering::Acquire) {
+                0 => std::hint::spin_loop(),
+                1 => break ChildProcessMsg::Expect,
+                2 => break ChildProcessMsg::Dbg,
+                n => panic!("invalid atomic value set by the child: {:#x}", n),
+            }
+        }
+    }
+
+    fn reset(&mut self) {
+        unsafe {
+            let ptr = self.ptr as *mut usize;
+            std::ptr::write_unaligned(ptr.add(Self::COUNT_INDEX), 0);
+            std::ptr::write_unaligned(ptr.add(Self::OFFSET_INDEX), Self::START_OFFSET);
+            std::ptr::write_unaligned(ptr.add(Self::LOCK_INDEX), 0);
+        }
+    }
+}
+
+pub enum ChildProcessMsg {
+    Expect = 1,
+    Dbg = 2,
+    Terminate = 3,
 }
 
 struct ExpectFrame {
     region: Region,
     module_id: ModuleId,
+
     start_offset: usize,
 }
 
@@ -627,8 +681,8 @@ impl ExpectFrame {
         let module_id_bytes: [u8; 4] = unsafe { *(start.add(offset + 8).cast()) };
         let module_id: ModuleId = unsafe { std::mem::transmute(module_id_bytes) };
 
-        // skip to frame, 8 bytes for region, 4 for module id
-        let start_offset = offset + 12;
+        // skip to frame
+        let start_offset = offset + 8 + 4;
 
         Self {
             region,

--- a/examples/cli/cli-platform/src/lib.rs
+++ b/examples/cli/cli-platform/src/lib.rs
@@ -105,12 +105,6 @@ pub unsafe extern "C" fn roc_shm_open(
     libc::shm_open(name, oflag, mode as libc::c_uint)
 }
 
-#[cfg(unix)]
-#[no_mangle]
-pub unsafe extern "C" fn roc_send_signal(pid: libc::pid_t, sig: libc::c_int) -> libc::c_int {
-    libc::kill(pid, sig)
-}
-
 fn print_backtrace() {
     eprintln!("Here is the call stack that led to the crash:\n");
 

--- a/examples/cli/effects-platform/host.zig
+++ b/examples/cli/effects-platform/host.zig
@@ -97,9 +97,6 @@ fn roc_getppid_windows_stub() callconv(.C) c_int {
     return 0;
 }
 
-fn roc_send_signal(pid: c_int, sig: c_int) callconv(.C) c_int {
-    return kill(pid, sig);
-}
 fn roc_shm_open(name: *const i8, oflag: c_int, mode: c_uint) callconv(.C) c_int {
     return shm_open(name, oflag, mode);
 }
@@ -111,7 +108,6 @@ comptime {
     if (builtin.os.tag == .macos or builtin.os.tag == .linux) {
         @export(roc_getppid, .{ .name = "roc_getppid", .linkage = .Strong });
         @export(roc_mmap, .{ .name = "roc_mmap", .linkage = .Strong });
-        @export(roc_send_signal, .{ .name = "roc_send_signal", .linkage = .Strong });
         @export(roc_shm_open, .{ .name = "roc_shm_open", .linkage = .Strong });
     }
 

--- a/examples/cli/false-interpreter/platform/src/lib.rs
+++ b/examples/cli/false-interpreter/platform/src/lib.rs
@@ -101,12 +101,6 @@ pub unsafe extern "C" fn roc_shm_open(
     libc::shm_open(name, oflag, mode as libc::c_uint)
 }
 
-#[cfg(unix)]
-#[no_mangle]
-pub unsafe extern "C" fn roc_send_signal(pid: libc::pid_t, sig: libc::c_int) -> libc::c_int {
-    libc::kill(pid, sig)
-}
-
 #[no_mangle]
 pub extern "C" fn rust_main() -> i32 {
     let arg = env::args()

--- a/examples/cli/tui-platform/host.zig
+++ b/examples/cli/tui-platform/host.zig
@@ -157,9 +157,6 @@ fn roc_getppid_windows_stub() callconv(.C) c_int {
     return 0;
 }
 
-fn roc_send_signal(pid: c_int, sig: c_int) callconv(.C) c_int {
-    return kill(pid, sig);
-}
 fn roc_shm_open(name: *const i8, oflag: c_int, mode: c_uint) callconv(.C) c_int {
     return shm_open(name, oflag, mode);
 }
@@ -171,7 +168,6 @@ comptime {
     if (builtin.os.tag == .macos or builtin.os.tag == .linux) {
         @export(roc_getppid, .{ .name = "roc_getppid", .linkage = .Strong });
         @export(roc_mmap, .{ .name = "roc_mmap", .linkage = .Strong });
-        @export(roc_send_signal, .{ .name = "roc_send_signal", .linkage = .Strong });
         @export(roc_shm_open, .{ .name = "roc_shm_open", .linkage = .Strong });
     }
 

--- a/examples/parser/platform/host.zig
+++ b/examples/parser/platform/host.zig
@@ -105,9 +105,6 @@ fn roc_getppid_windows_stub() callconv(.C) c_int {
     return 0;
 }
 
-fn roc_send_signal(pid: c_int, sig: c_int) callconv(.C) c_int {
-    return kill(pid, sig);
-}
 fn roc_shm_open(name: *const i8, oflag: c_int, mode: c_uint) callconv(.C) c_int {
     return shm_open(name, oflag, mode);
 }
@@ -119,7 +116,6 @@ comptime {
     if (builtin.os.tag == .macos or builtin.os.tag == .linux) {
         @export(roc_getppid, .{ .name = "roc_getppid", .linkage = .Strong });
         @export(roc_mmap, .{ .name = "roc_mmap", .linkage = .Strong });
-        @export(roc_send_signal, .{ .name = "roc_send_signal", .linkage = .Strong });
         @export(roc_shm_open, .{ .name = "roc_shm_open", .linkage = .Strong });
     }
 

--- a/examples/platform-switching/c-platform/host.c
+++ b/examples/platform-switching/c-platform/host.c
@@ -36,27 +36,18 @@ void* roc_memcpy(void* dest, const void* src, size_t n) {
 
 void* roc_memset(void* str, int c, size_t n) { return memset(str, c, n); }
 
-
-int roc_send_signal(int pid, int sig) { 
+int roc_shm_open(char* name, int oflag, int mode) {
 #ifdef _WIN32
     return 0;
 #else
-    return kill(pid, sig); 
+    return shm_open(name, oflag, mode);
 #endif
 }
-
-int roc_shm_open(char* name, int oflag, int mode) { 
-#ifdef _WIN32
-    return 0;
-#else
-    return shm_open(name, oflag, mode); 
-#endif
-}
-void* roc_mmap(void* addr, int length, int prot, int flags, int fd, int offset) { 
+void* roc_mmap(void* addr, int length, int prot, int flags, int fd, int offset) {
 #ifdef _WIN32
     return addr;
 #else
-    return mmap(addr, length, prot, flags, fd, offset); 
+    return mmap(addr, length, prot, flags, fd, offset);
 #endif
 }
 

--- a/examples/platform-switching/rust-platform/src/lib.rs
+++ b/examples/platform-switching/rust-platform/src/lib.rs
@@ -83,12 +83,6 @@ pub unsafe extern "C" fn roc_shm_open(
     libc::shm_open(name, oflag, mode as libc::c_uint)
 }
 
-#[cfg(unix)]
-#[no_mangle]
-pub unsafe extern "C" fn roc_send_signal(pid: libc::pid_t, sig: libc::c_int) -> libc::c_int {
-    libc::kill(pid, sig)
-}
-
 #[no_mangle]
 pub extern "C" fn rust_main() -> i32 {
     let mut roc_str = RocStr::default();

--- a/examples/platform-switching/zig-platform/host.zig
+++ b/examples/platform-switching/zig-platform/host.zig
@@ -88,9 +88,6 @@ fn roc_getppid_windows_stub() callconv(.C) c_int {
     return 0;
 }
 
-fn roc_send_signal(pid: c_int, sig: c_int) callconv(.C) c_int {
-    return kill(pid, sig);
-}
 fn roc_shm_open(name: *const i8, oflag: c_int, mode: c_uint) callconv(.C) c_int {
     return shm_open(name, oflag, mode);
 }
@@ -102,7 +99,6 @@ comptime {
     if (builtin.os.tag == .macos or builtin.os.tag == .linux) {
         @export(roc_getppid, .{ .name = "roc_getppid", .linkage = .Strong });
         @export(roc_mmap, .{ .name = "roc_mmap", .linkage = .Strong });
-        @export(roc_send_signal, .{ .name = "roc_send_signal", .linkage = .Strong });
         @export(roc_shm_open, .{ .name = "roc_shm_open", .linkage = .Strong });
     }
 

--- a/examples/ruby-interop/platform/host.c
+++ b/examples/ruby-interop/platform/host.c
@@ -30,26 +30,18 @@ void* roc_memcpy(void* dest, const void* src, size_t n) {
 
 void* roc_memset(void* str, int c, size_t n) { return memset(str, c, n); }
 
-int roc_send_signal(int pid, int sig) { 
+int roc_shm_open(char* name, int oflag, int mode) {
 #ifdef _WIN32
     return 0;
 #else
-    return kill(pid, sig); 
+    return shm_open(name, oflag, mode);
 #endif
 }
-
-int roc_shm_open(char* name, int oflag, int mode) { 
-#ifdef _WIN32
-    return 0;
-#else
-    return shm_open(name, oflag, mode); 
-#endif
-}
-void* roc_mmap(void* addr, int length, int prot, int flags, int fd, int offset) { 
+void* roc_mmap(void* addr, int length, int prot, int flags, int fd, int offset) {
 #ifdef _WIN32
     return addr;
 #else
-    return mmap(addr, length, prot, flags, fd, offset); 
+    return mmap(addr, length, prot, flags, fd, offset);
 #endif
 }
 

--- a/www/public/tutorial/index.html
+++ b/www/public/tutorial/index.html
@@ -301,7 +301,6 @@ on the same line, although the convention is to use the original version's style
 </p>
 </section>
 <section><h2 id="debugging"><a href="#debugging">Debugging</a></h2>
-<p><code>dbg doesn't work yet on MacOS x86_64</code></p>
 <p><a href="https://en.wikipedia.org/wiki/Debugging#Techniques">Print debugging</a> is the most
 common debugging technique in the history of programming, and Roc has a <code>dbg</code>
 keyword to facilitate it. Here's an example of how to use <code>dbg</code>:</p>


### PR DESCRIPTION
the child is now locked while the parent prints the expect/dbg. That means that the printing happens at the right moment (e.g. in relation to the roc app printing to stdout itself with effects) and we can do multiple prints in sequence.

