### PR TITLE
Fix for #4585

### DIFF
--- a/crates/compiler/fmt/src/expr.rs
+++ b/crates/compiler/fmt/src/expr.rs
@@ -556,8 +556,13 @@ pub fn fmt_str_literal<'buf>(buf: &mut Buf<'buf>, literal: StrLiteral, indent: u
 
             for segments in lines.iter() {
                 for seg in segments.iter() {
-                    buf.indent(indent);
-                    format_str_segment(seg, buf, indent);
+                    // only add indent if the line isn't empty
+                    if *seg != StrSegment::Plaintext("\n") {
+                        buf.indent(indent);
+                        format_str_segment(seg, buf, indent);
+                    } else {
+                        buf.newline();
+                    }
                 }
 
                 buf.newline();

--- a/crates/compiler/parse/tests/snapshots/pass/multiline_string.expr.formatted.roc
+++ b/crates/compiler/parse/tests/snapshots/pass/multiline_string.expr.formatted.roc
@@ -6,7 +6,7 @@ Hello,\n\nWorld!
 c =
     """
     Hello,
-    
+
     World!
     """
 

--- a/examples/cli/cli-platform/Arg.roc
+++ b/examples/cli/cli-platform/Arg.roc
@@ -574,7 +574,7 @@ formatHelpHelp = \n, cmdHelp ->
                     "\n\n"
 
             """
-            
+
             \(indented)COMMANDS:
             \(fmtCmdHelp)
             """
@@ -606,7 +606,7 @@ formatHelpHelp = \n, cmdHelp ->
                         |> Str.joinWith "\n"
 
                     """
-                    
+
                     \(indented)OPTIONS:
                     \(helpStr)
                     """
@@ -621,7 +621,7 @@ formatHelpHelp = \n, cmdHelp ->
                         |> Str.joinWith "\n"
 
                     """
-                    
+
                     \(indented)ARGS:
                     \(helpStr)
                     """
@@ -909,7 +909,7 @@ expect
     ==
     """
     test
-    
+
     OPTIONS:
         --foo    the foo option  (string)
         --bar, -B  (string)
@@ -936,13 +936,13 @@ expect
     ==
     """
     test
-    
+
     COMMANDS:
         login
             OPTIONS:
                 --user  (string)
                 --pw  (string)
-    
+
         publish
             OPTIONS:
                 --file  (string)
@@ -960,7 +960,7 @@ expect
     """
     test
     a test cli app
-    
+
     COMMANDS:
         login
     """


### PR DESCRIPTION
This is a fix for #4585.

The problem was that `roc_fmt::expr::fmt_str_literal()` was treating all the lines in a `StrSegment::Block` the same. Added logic to detect if a given segment is just `"\n"`.

I also had to change some of the files the tests run on to reflect the new format behavior.

This is also my first PR, so please let me know if there's anything I missed or did incorrectly. Any feedback is immensely appreciated.