### PR TITLE
remove explicit closing of dylib when testing

### DIFF
--- a/crates/compiler/test_gen/src/helpers/llvm.rs
+++ b/crates/compiler/test_gen/src/helpers/llvm.rs
@@ -613,9 +613,6 @@ macro_rules! assert_llvm_evals_to {
                 CrashTag::User => panic!(r#"User crash with message: "{}""#, msg),
             },
         }
-
-        // artificially extend the lifetime of `lib`
-        lib.close().unwrap();
     };
 
     ($src:expr, $expected:expr, $ty:ty) => {


### PR DESCRIPTION
This stops test from failing when dlclose has an error.