### PR TITLE
fix macos x86_64 build target

### DIFF
--- a/.github/workflows/nightly_macos_x86_64.yml
+++ b/.github/workflows/nightly_macos_x86_64.yml
@@ -1,6 +1,6 @@
-on:
-  schedule:
-    - cron:  '0 9 * * *' # 9=9am utc+0
+on: pull_request
+  #schedule:
+  #  - cron:  '0 9 * * *' # 9=9am utc+0
 
 name: Nightly Release macOS x86_64
 
@@ -14,16 +14,15 @@ jobs:
           
       - name: write version to file
         run: ./ci/write_version.sh
-        
-      # build has to be done before tests #2572
-      - name: build release
-        run: RUSTFLAGS="-C target-cpu=x86-64" cargo build --features with_sound --release --locked
-        # target-cpu=x86-64 -> For maximal compatibility for all CPU's. Note that this setting will likely make the compiler slower.
           
       - name: execute rust tests
         run: cargo test --release --locked -- --skip opaque_wrap_function --skip bool_list_literal --skip platform_switching_swift --skip swift_ui
         # swift tests are skipped because of "Could not find or use auto-linked library 'swiftCompatibilityConcurrency'" on macos-11 x86_64 CI machine
         # this issue may be caused by using older versions of XCode
+
+      - name: build release
+        run: RUSTFLAGS="-C target-cpu=x86-64" cargo build --features with_sound --release --locked
+        # target-cpu=x86-64 -> For maximal compatibility for all CPU's. Note that this setting will likely make the compiler slower.
           
       - name: get commit SHA
         run:  echo "SHA=$(git rev-parse --short "$GITHUB_SHA")" >> $GITHUB_ENV

--- a/.github/workflows/nightly_macos_x86_64.yml
+++ b/.github/workflows/nightly_macos_x86_64.yml
@@ -1,6 +1,6 @@
-on: pull_request
-  #schedule:
-  #  - cron:  '0 9 * * *' # 9=9am utc+0
+on:
+  schedule:
+    - cron:  '0 9 * * *' # 9=9am utc+0
 
 name: Nightly Release macOS x86_64
 


### PR DESCRIPTION
Tests were creating another release with a different CPU target which caused the `Illegal instruction: 4` error on macos github CI servers.