### PR TITLE
Support using dbg/expect in polymorphic functions

### DIFF
--- a/crates/cli/tests/cli_run.rs
+++ b/crates/cli/tests/cli_run.rs
@@ -568,7 +568,7 @@ mod cli_run {
                 r#"
                 This expectation failed:
 
-                14│      expect x != x
+                18│      expect x != x
                                 ^^^^^^
 
                 When it failed, these variables had these values:
@@ -576,8 +576,11 @@ mod cli_run {
                 x : Num *
                 x = 42
 
-                [<ignored for tests> 15:9] 42
-                [<ignored for tests> 16:9] "Fjoer en ferdjer frieten oan dyn geve lea"
+                [<ignored for tests> 19:9] 42
+                [<ignored for tests> 20:9] "Fjoer en ferdjer frieten oan dyn geve lea"
+                [<ignored for tests> 13:9] "abc"
+                [<ignored for tests> 13:9] 10
+                [<ignored for tests> 13:9] A (B C)
                 Program finished!
                 "#
             ),

--- a/crates/cli_testing_examples/.gitignore
+++ b/crates/cli_testing_examples/.gitignore
@@ -4,3 +4,4 @@ libapp.so
 dynhost
 preprocessedhost
 metadata
+expects

--- a/crates/cli_testing_examples/expects/expects.roc
+++ b/crates/cli_testing_examples/expects/expects.roc
@@ -9,9 +9,17 @@ expect
 
     a == b
 
+polyDbg = \x ->
+    dbg x
+    x
+
 main =
     x = 42
     expect x != x
     dbg x
     dbg "Fjoer en ferdjer frieten oan dyn geve lea"
-    "Program finished!\n"
+
+    r = {x : polyDbg "abc", y: polyDbg 10u8, z : polyDbg (A (B C))}
+
+    when r is
+        _ -> "Program finished!\n"

--- a/crates/compiler/alias_analysis/src/lib.rs
+++ b/crates/compiler/alias_analysis/src/lib.rs
@@ -1287,6 +1287,14 @@ fn lowlevel_spec<'a>(
 
             builder.add_make_tuple(block, &[byte_index, string, is_ok, problem_code])
         }
+        Dbg => {
+            let arguments = [env.symbols[&arguments[0]]];
+
+            let result_type =
+                layout_spec(env, builder, interner, layout, &WhenRecursive::Unreachable)?;
+
+            builder.add_unknown_with(block, &arguments, result_type)
+        }
         _other => {
             // println!("missing {:?}", _other);
             // TODO overly pessimstic

--- a/crates/compiler/constrain/src/expr.rs
+++ b/crates/compiler/constrain/src/expr.rs
@@ -705,7 +705,7 @@ pub fn constrain_expr(
                 expected,
             );
 
-            constraints.exists_many([], [cond_con, continuation_con])
+            constraints.exists_many([*variable], [cond_con, continuation_con])
         }
 
         If {

--- a/crates/compiler/gen_llvm/src/llvm/build.rs
+++ b/crates/compiler/gen_llvm/src/llvm/build.rs
@@ -2586,7 +2586,7 @@ pub fn build_exp_stmt<'a, 'ctx, 'env>(
             condition: cond_symbol,
             region,
             lookups,
-            variables: _, // TODO
+            variables,
             remainder,
         } => {
             let bd = env.builder;
@@ -2621,6 +2621,7 @@ pub fn build_exp_stmt<'a, 'ctx, 'env>(
                             *cond_symbol,
                             *region,
                             lookups,
+                            variables,
                         );
 
                         if let LlvmBackendMode::BinaryDev = env.mode {
@@ -2655,7 +2656,7 @@ pub fn build_exp_stmt<'a, 'ctx, 'env>(
             condition: cond_symbol,
             region,
             lookups,
-            variables: _, // TODO
+            variables,
             remainder,
         } => {
             let bd = env.builder;
@@ -2690,6 +2691,7 @@ pub fn build_exp_stmt<'a, 'ctx, 'env>(
                             *cond_symbol,
                             *region,
                             lookups,
+                            variables,
                         );
 
                         bd.build_unconditional_branch(then_block);

--- a/crates/compiler/gen_llvm/src/llvm/build.rs
+++ b/crates/compiler/gen_llvm/src/llvm/build.rs
@@ -2586,6 +2586,7 @@ pub fn build_exp_stmt<'a, 'ctx, 'env>(
             condition: cond_symbol,
             region,
             lookups,
+            variables: _, // TODO
             remainder,
         } => {
             let bd = env.builder;
@@ -2654,6 +2655,7 @@ pub fn build_exp_stmt<'a, 'ctx, 'env>(
             condition: cond_symbol,
             region,
             lookups,
+            variables: _, // TODO
             remainder,
         } => {
             let bd = env.builder;

--- a/crates/compiler/gen_llvm/src/llvm/expect.rs
+++ b/crates/compiler/gen_llvm/src/llvm/expect.rs
@@ -158,6 +158,7 @@ pub(crate) fn notify_parent_dbg(env: &Env, shared_memory: &SharedMemoryPointer) 
 //     ..
 //     lookup_val_n  (varsize)
 //
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn clone_to_shared_memory<'a, 'ctx, 'env>(
     env: &Env<'a, 'ctx, 'env>,
     scope: &Scope<'a, 'ctx>,

--- a/crates/compiler/gen_llvm/src/llvm/lowlevel.rs
+++ b/crates/compiler/gen_llvm/src/llvm/lowlevel.rs
@@ -11,7 +11,7 @@ use roc_builtins::bitcode::{self, FloatWidth, IntWidth};
 use roc_error_macros::internal_error;
 use roc_module::{low_level::LowLevel, symbol::Symbol};
 use roc_mono::{
-    ir::HigherOrderLowLevel,
+    ir::{HigherOrderLowLevel, LookupType},
     layout::{Builtin, LambdaSet, Layout, LayoutIds},
 };
 use roc_target::PtrWidth;
@@ -1120,13 +1120,18 @@ pub(crate) fn run_low_level<'a, 'ctx, 'env>(
             }
         },
         Dbg => {
-            // now what
-            arguments!(condition);
+            assert_eq!(args.len(), 2);
+            let condition = load_symbol(scope, &args[0]);
+            let dbg_spec_var_symbol = args[1];
 
             if env.mode.runs_expects() {
                 let region = unsafe { std::mem::transmute::<_, roc_region::all::Region>(args[0]) };
 
                 let shared_memory = crate::llvm::expect::SharedMemoryPointer::get(env);
+
+                // HACK(dbg-spec-var): the specialized type variable is passed along as a fake symbol
+                let specialized_var =
+                    unsafe { LookupType::from_index(dbg_spec_var_symbol.ident_id().index() as _) };
 
                 crate::llvm::expect::clone_to_shared_memory(
                     env,
@@ -1136,7 +1141,7 @@ pub(crate) fn run_low_level<'a, 'ctx, 'env>(
                     args[0],
                     region,
                     &[args[0]],
-                    &[roc_mono::ir::LookupType::NULL], // TODO
+                    &[specialized_var],
                 );
 
                 crate::llvm::expect::notify_parent_dbg(env, &shared_memory);

--- a/crates/compiler/gen_llvm/src/llvm/lowlevel.rs
+++ b/crates/compiler/gen_llvm/src/llvm/lowlevel.rs
@@ -1136,6 +1136,7 @@ pub(crate) fn run_low_level<'a, 'ctx, 'env>(
                     args[0],
                     region,
                     &[args[0]],
+                    &[roc_mono::ir::LookupType::NULL], // TODO
                 );
 
                 crate::llvm::expect::notify_parent_dbg(env, &shared_memory);

--- a/crates/compiler/module/src/symbol.rs
+++ b/crates/compiler/module/src/symbol.rs
@@ -594,6 +594,13 @@ impl IdentId {
     pub const fn index(self) -> usize {
         self.0 as usize
     }
+
+    /// # Safety
+    ///
+    /// The index is not guaranteed to know to exist.
+    pub unsafe fn from_index(index: u32) -> Self {
+        Self(index)
+    }
 }
 
 /// Stores a mapping between Ident and IdentId.

--- a/crates/compiler/mono/src/borrow.rs
+++ b/crates/compiler/mono/src/borrow.rs
@@ -948,7 +948,7 @@ pub fn lowlevel_borrow_signature(arena: &Bump, op: LowLevel) -> &[bool] {
 
         ListIsUnique => arena.alloc_slice_copy(&[borrowed]),
 
-        Dbg => arena.alloc_slice_copy(&[borrowed]),
+        Dbg => arena.alloc_slice_copy(&[borrowed, /* dbg-spec-var */ irrelevant]),
 
         BoxExpr | UnboxExpr => {
             unreachable!("These lowlevel operations are turned into mono Expr's")

--- a/crates/compiler/mono/src/debug/checker.rs
+++ b/crates/compiler/mono/src/debug/checker.rs
@@ -309,12 +309,14 @@ impl<'a, 'r> Ctx<'a, 'r> {
                 condition,
                 region: _,
                 lookups,
+                variables: _,
                 remainder,
             }
             | &Stmt::ExpectFx {
                 condition,
                 region: _,
                 lookups,
+                variables: _,
                 remainder,
             } => {
                 self.check_sym_layout(

--- a/crates/compiler/mono/src/inc_dec.rs
+++ b/crates/compiler/mono/src/inc_dec.rs
@@ -555,7 +555,13 @@ impl<'a, 'i> Context<'a, 'i> {
         match &call_type {
             LowLevel { op, .. } => {
                 let ps = crate::borrow::lowlevel_borrow_signature(self.arena, *op);
-                let b = self.add_dec_after_lowlevel(arguments, ps, b, b_live_vars);
+                let b = match op {
+                    roc_module::low_level::LowLevel::Dbg => {
+                        // NB(dbg-spec-var) second var is the Variable
+                        self.add_dec_after_lowlevel(&arguments[..1], ps, b, b_live_vars)
+                    }
+                    _ => self.add_dec_after_lowlevel(arguments, ps, b, b_live_vars),
+                };
 
                 let v = Expr::Call(crate::ir::Call {
                     call_type,

--- a/crates/compiler/mono/src/inc_dec.rs
+++ b/crates/compiler/mono/src/inc_dec.rs
@@ -1199,6 +1199,7 @@ impl<'a, 'i> Context<'a, 'i> {
                 condition,
                 region,
                 lookups,
+                variables,
             } => {
                 let (b, mut b_live_vars) = self.visit_stmt(codegen, remainder);
 
@@ -1206,6 +1207,7 @@ impl<'a, 'i> Context<'a, 'i> {
                     condition: *condition,
                     region: *region,
                     lookups,
+                    variables,
                     remainder: b,
                 });
 
@@ -1221,6 +1223,7 @@ impl<'a, 'i> Context<'a, 'i> {
                 condition,
                 region,
                 lookups,
+                variables,
             } => {
                 let (b, mut b_live_vars) = self.visit_stmt(codegen, remainder);
 
@@ -1228,6 +1231,7 @@ impl<'a, 'i> Context<'a, 'i> {
                     condition: *condition,
                     region: *region,
                     lookups,
+                    variables,
                     remainder: b,
                 });
 

--- a/crates/compiler/mono/src/ir.rs
+++ b/crates/compiler/mono/src/ir.rs
@@ -1465,6 +1465,9 @@ impl<'a> Specializations<'a> {
 pub struct Env<'a, 'i> {
     pub arena: &'a Bump,
     pub subs: &'i mut Subs,
+    /// [Subs] to write specialized variables of lookups in expects.
+    /// [None] if this module doesn't produce any expects.
+    pub expectation_subs: Option<&'i mut Subs>,
     pub home: ModuleId,
     pub ident_ids: &'i mut IdentIds,
     pub target_info: TargetInfo,

--- a/crates/compiler/mono/src/ir.rs
+++ b/crates/compiler/mono/src/ir.rs
@@ -33,8 +33,8 @@ use roc_region::all::{Loc, Region};
 use roc_std::RocDec;
 use roc_target::TargetInfo;
 use roc_types::subs::{
-    instantiate_rigids, Content, ExhaustiveMark, FlatType, RedundantMark, StorageSubs, Subs,
-    Variable, VariableSubsSlice,
+    instantiate_rigids, storage_copy_var_to, Content, ExhaustiveMark, FlatType, RedundantMark,
+    StorageSubs, Subs, Variable, VariableSubsSlice,
 };
 use std::collections::HashMap;
 use ven_pretty::{BoxAllocator, DocAllocator, DocBuilder};
@@ -6576,7 +6576,7 @@ pub fn from_can<'a>(
                 symbol,
                 var,
                 ability_info,
-            } in lookups_in_cond
+            } in lookups_in_cond.iter().copied()
             {
                 let symbol = match ability_info {
                     Some(specialization_id) => late_resolve_ability_specialization(
@@ -6610,6 +6610,14 @@ pub fn from_can<'a>(
                 env.arena.alloc(stmt),
             );
 
+            let expectation_subs = env
+                .expectation_subs
+                .as_deref_mut()
+                .expect("if expects are compiled, their subs should be available");
+            for ExpectLookup { var, .. } in lookups_in_cond {
+                storage_copy_var_to(&mut Default::default(), env.subs, expectation_subs, var);
+            }
+
             stmt
         }
 
@@ -6627,7 +6635,7 @@ pub fn from_can<'a>(
                 symbol,
                 var,
                 ability_info,
-            } in lookups_in_cond
+            } in lookups_in_cond.iter().copied()
             {
                 let symbol = match ability_info {
                     Some(specialization_id) => late_resolve_ability_specialization(
@@ -6660,6 +6668,14 @@ pub fn from_can<'a>(
                 cond_symbol,
                 env.arena.alloc(stmt),
             );
+
+            let expectation_subs = env
+                .expectation_subs
+                .as_deref_mut()
+                .expect("if expects are compiled, their subs should be available");
+            for ExpectLookup { var, .. } in lookups_in_cond {
+                storage_copy_var_to(&mut Default::default(), env.subs, expectation_subs, var);
+            }
 
             stmt
         }

--- a/crates/compiler/mono/src/reset_reuse.rs
+++ b/crates/compiler/mono/src/reset_reuse.rs
@@ -195,6 +195,7 @@ fn function_s<'a, 'i>(
             condition,
             region,
             lookups,
+            variables,
             remainder,
         } => {
             let continuation: &Stmt = remainder;
@@ -207,6 +208,7 @@ fn function_s<'a, 'i>(
                     condition: *condition,
                     region: *region,
                     lookups,
+                    variables,
                     remainder: new_continuation,
                 };
 
@@ -218,6 +220,7 @@ fn function_s<'a, 'i>(
             condition,
             region,
             lookups,
+            variables,
             remainder,
         } => {
             let continuation: &Stmt = remainder;
@@ -230,6 +233,7 @@ fn function_s<'a, 'i>(
                     condition: *condition,
                     region: *region,
                     lookups,
+                    variables,
                     remainder: new_continuation,
                 };
 
@@ -438,6 +442,7 @@ fn function_d_main<'a, 'i>(
             condition,
             region,
             lookups,
+            variables,
             remainder,
         } => {
             let (b, found) = function_d_main(env, x, c, remainder);
@@ -447,6 +452,7 @@ fn function_d_main<'a, 'i>(
                     condition: *condition,
                     region: *region,
                     lookups,
+                    variables,
                     remainder: b,
                 };
 
@@ -458,6 +464,7 @@ fn function_d_main<'a, 'i>(
                     condition: *condition,
                     region: *region,
                     lookups,
+                    variables,
                     remainder: b,
                 };
 
@@ -468,6 +475,7 @@ fn function_d_main<'a, 'i>(
             condition,
             region,
             lookups,
+            variables,
             remainder,
         } => {
             let (b, found) = function_d_main(env, x, c, remainder);
@@ -477,6 +485,7 @@ fn function_d_main<'a, 'i>(
                     condition: *condition,
                     region: *region,
                     lookups,
+                    variables,
                     remainder: b,
                 };
 
@@ -488,6 +497,7 @@ fn function_d_main<'a, 'i>(
                     condition: *condition,
                     region: *region,
                     lookups,
+                    variables,
                     remainder: b,
                 };
 
@@ -650,6 +660,7 @@ fn function_r<'a, 'i>(env: &mut Env<'a, 'i>, stmt: &'a Stmt<'a>) -> &'a Stmt<'a>
             condition,
             region,
             lookups,
+            variables,
             remainder,
         } => {
             let b = function_r(env, remainder);
@@ -658,6 +669,7 @@ fn function_r<'a, 'i>(env: &mut Env<'a, 'i>, stmt: &'a Stmt<'a>) -> &'a Stmt<'a>
                 condition: *condition,
                 region: *region,
                 lookups,
+                variables,
                 remainder: b,
             };
 
@@ -668,6 +680,7 @@ fn function_r<'a, 'i>(env: &mut Env<'a, 'i>, stmt: &'a Stmt<'a>) -> &'a Stmt<'a>
             condition,
             region,
             lookups,
+            variables,
             remainder,
         } => {
             let b = function_r(env, remainder);
@@ -676,6 +689,7 @@ fn function_r<'a, 'i>(env: &mut Env<'a, 'i>, stmt: &'a Stmt<'a>) -> &'a Stmt<'a>
                 condition: *condition,
                 region: *region,
                 lookups,
+                variables,
                 remainder: b,
             };
 

--- a/crates/compiler/mono/src/tail_recursion.rs
+++ b/crates/compiler/mono/src/tail_recursion.rs
@@ -253,6 +253,7 @@ fn insert_jumps<'a>(
             condition,
             region,
             lookups,
+            variables,
             remainder,
         } => match insert_jumps(
             arena,
@@ -266,6 +267,7 @@ fn insert_jumps<'a>(
                 condition: *condition,
                 region: *region,
                 lookups,
+                variables,
                 remainder: cont,
             })),
             None => None,
@@ -275,6 +277,7 @@ fn insert_jumps<'a>(
             condition,
             region,
             lookups,
+            variables,
             remainder,
         } => match insert_jumps(
             arena,
@@ -288,6 +291,7 @@ fn insert_jumps<'a>(
                 condition: *condition,
                 region: *region,
                 lookups,
+                variables,
                 remainder: cont,
             })),
             None => None,

--- a/crates/compiler/solve/tests/solve_expr.rs
+++ b/crates/compiler/solve/tests/solve_expr.rs
@@ -8529,4 +8529,23 @@ mod solve_expr {
         print_can_decls: true
         );
     }
+
+    #[test]
+    fn constrain_dbg_flex_var() {
+        infer_queries!(
+            indoc!(
+                r#"
+                app "test" provides [main] to "./platform"
+
+                polyDbg = \x ->
+                #^^^^^^^{-1}
+                    dbg x
+                    x
+
+                main = polyDbg ""
+                "#
+            ),
+        @"polyDbg : a -[[polyDbg(1)]]-> a"
+        );
+    }
 }

--- a/crates/repl_expect/src/lib.rs
+++ b/crates/repl_expect/src/lib.rs
@@ -32,9 +32,10 @@ pub fn get_values<'a>(
     layout_interner: &Arc<GlobalInterner<'a, Layout<'a>>>,
     start: *const u8,
     start_offset: usize,
-    variables: &[Variable],
-) -> (usize, Vec<Expr<'a>>) {
-    let mut result = Vec::with_capacity(variables.len());
+    number_of_lookups: usize,
+) -> (usize, Vec<Expr<'a>>, Vec<Variable>) {
+    let mut result = Vec::with_capacity(number_of_lookups);
+    let mut result_vars = Vec::with_capacity(number_of_lookups);
 
     let memory = ExpectMemory { start };
 
@@ -45,7 +46,7 @@ pub fn get_values<'a>(
 
     let app = arena.alloc(app);
 
-    for (i, variable) in variables.iter().enumerate() {
+    for i in 0..number_of_lookups {
         let size_of_lookup_header = 8 /* pointer to value */ + 4 /* type variable */;
 
         let start = app
@@ -83,9 +84,10 @@ pub fn get_values<'a>(
         };
 
         result.push(expr);
+        result_vars.push(variable);
     }
 
-    (app.offset, result)
+    (app.offset, result, result_vars)
 }
 
 #[cfg(not(windows))]

--- a/crates/repl_expect/src/lib.rs
+++ b/crates/repl_expect/src/lib.rs
@@ -46,12 +46,19 @@ pub fn get_values<'a>(
     let app = arena.alloc(app);
 
     for (i, variable) in variables.iter().enumerate() {
-        let start = app.memory.deref_usize(start_offset + i * 8);
+        let size_of_lookup_header = 8 /* pointer to value */ + 4 /* type variable */;
+
+        let start = app
+            .memory
+            .deref_usize(start_offset + i * size_of_lookup_header);
+        let variable = app.memory.deref_u32(
+            start_offset + i * size_of_lookup_header + 8, /* skip the pointer */
+        );
+        let variable = unsafe { Variable::from_index(variable) };
+
         app.offset = start;
 
         let expr = {
-            let variable = *variable;
-
             // TODO: pass layout_cache to jit_to_ast directly
             let mut layout_cache = LayoutCache::new(layout_interner.fork(), target_info);
             let layout = layout_cache.from_var(arena, variable, subs).unwrap();

--- a/crates/repl_expect/src/run.rs
+++ b/crates/repl_expect/src/run.rs
@@ -574,14 +574,13 @@ fn render_expect_failure<'a>(
         None => panic!("region {failure_region:?} not in list of expects"),
         Some(current) => current,
     };
-    let subs = arena.alloc(&mut data.subs);
 
-    let (symbols, variables) = split_expect_lookups(subs, current);
+    let (symbols, variables) = split_expect_lookups(&data.subs, current);
 
     let (offset, expressions) = crate::get_values(
         target_info,
         arena,
-        subs,
+        &data.subs,
         interns,
         layout_interner,
         start,
@@ -591,7 +590,7 @@ fn render_expect_failure<'a>(
 
     renderer.render_failure(
         writer,
-        subs,
+        &mut data.subs,
         &symbols,
         &variables,
         &expressions,


### PR DESCRIPTION
Previously, with a function like

```
f = \x ->
  dbg x
  x
```

we would store the type of the the lookup `x` before specialization, and moreover, would not disambiguate uses of dbg in specialized calls of `f`. This meant that the type of `x` would always been seen as an unbound variable, and nothing meaningful would be printed.

To support this, we now flow each specialized type of `x` through the backend, and have

- mono store into subs storage all specialized lookups
- the child send the type variable index of the specialized type

An expect frame now contains the type variable that should be indexed as a u32 right after the pointer to the copied value.

I also believe this means we can get rid of storing variables on the `Expectations` struct, which now is not used for anything other than determining whether we should skip over a lookup because it's a function. However, that can be done in a follow-up.

Closes #4752 