### PR TITLE
repl_test: use --release for wasm repl test

### DIFF
--- a/crates/repl_test/test_wasm.sh
+++ b/crates/repl_test/test_wasm.sh
@@ -10,4 +10,4 @@ set -euxo pipefail
 RUSTFLAGS="" cargo build --target wasm32-wasi -p roc_repl_wasm --no-default-features --features wasmer --release
 
 # Build & run the test code on *native* target, not WebAssembly
-cargo test -p repl_test --features wasm -- --test-threads=1
+cargo test -p repl_test --features wasm --release -- --test-threads=1


### PR DESCRIPTION
This is for comparison against https://github.com/roc-lang/roc/pull/4767
Let's compare the total times between the 2 PRs for the wasm repl test. This will include compile time.
