### PR TITLE
remove cargo bindgen as a dependency

### DIFF
--- a/BUILDING_FROM_SOURCE.md
+++ b/BUILDING_FROM_SOURCE.md
@@ -82,7 +82,6 @@ To build the compiler, you need these installed:
 - On Debian/Ubuntu `sudo apt-get install pkg-config`
 - LLVM, see below for version
 - [rust](https://rustup.rs/)
-- Also run `cargo install bindgen` after installing rust. You may need to open a new terminal.
 
 To run the test suite (via `cargo test`), you additionally need to install:
 

--- a/default.nix
+++ b/default.nix
@@ -52,7 +52,6 @@ rustPlatform.buildRustPackage {
     llvmPkgs.clang
     llvmPkgs.llvm.dev
     zig
-    rust-bindgen
   ]);
 
   buildInputs = (with pkgs;

--- a/flake.nix
+++ b/flake.nix
@@ -104,7 +104,6 @@
           llvmPkgs.lld
           debugir
           rust
-          rust-bindgen
           cargo-criterion # for benchmarks
           simple-http-server # to view roc website when trying out edits
         ]);


### PR DESCRIPTION
we needed this for wasm3, but that is not longer a dependency, so we don't need bindgen (directly) any more

@Anton-4 is this correct for the nix files, and did I catch all occurences? 