### PR TITLE
Prepare Llvm 15 update

### DIFF
--- a/crates/compiler/gen_llvm/src/llvm/build.rs
+++ b/crates/compiler/gen_llvm/src/llvm/build.rs
@@ -5611,7 +5611,7 @@ pub fn add_func<'ctx>(
     fn_val
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub(crate) enum WhenRecursive<'a> {
     Unreachable,
     Loop(UnionLayout<'a>),

--- a/crates/compiler/gen_llvm/src/llvm/build_list.rs
+++ b/crates/compiler/gen_llvm/src/llvm/build_list.rs
@@ -326,7 +326,9 @@ pub(crate) fn list_replace_unsafe<'a, 'ctx, 'env>(
     };
 
     // Load the element and returned list into a struct.
-    let old_element = env.builder.build_load(element_ptr, "load_element");
+    let old_element = env
+        .builder
+        .new_build_load(element_type, element_ptr, "load_element");
 
     // the list has the same alignment as a usize / ptr. The element comes first in the struct if
     // its alignment is bigger than that of a list.
@@ -665,7 +667,9 @@ where
     {
         builder.position_at_end(loop_bb);
 
-        let current_index = builder.build_load(index_alloca, "index").into_int_value();
+        let current_index = builder
+            .new_build_load(env.ptr_int(), index_alloca, "index")
+            .into_int_value();
         let next_index = builder.build_int_add(current_index, one, "next_index");
         builder.build_store(index_alloca, next_index);
 

--- a/crates/compiler/gen_llvm/src/llvm/build_str.rs
+++ b/crates/compiler/gen_llvm/src/llvm/build_str.rs
@@ -6,6 +6,7 @@ use roc_mono::layout::Layout;
 use roc_target::PtrWidth;
 
 use super::bitcode::{call_str_bitcode_fn, BitcodeReturns};
+use super::build::BuilderExt;
 
 pub static CHAR_LAYOUT: Layout = Layout::u8();
 
@@ -36,7 +37,11 @@ pub(crate) fn decode_from_utf8_result<'a, 'ctx, 'env>(
             );
 
             builder
-                .build_load(result_ptr_cast, "load_utf8_validate_bytes_result")
+                .new_build_load(
+                    record_type,
+                    result_ptr_cast,
+                    "load_utf8_validate_bytes_result",
+                )
                 .into_struct_value()
         }
     }

--- a/crates/compiler/gen_llvm/src/llvm/compare.rs
+++ b/crates/compiler/gen_llvm/src/llvm/compare.rs
@@ -15,7 +15,7 @@ use roc_builtins::bitcode::{FloatWidth, IntWidth};
 use roc_module::symbol::Symbol;
 use roc_mono::layout::{Builtin, Layout, LayoutIds, UnionLayout};
 
-use super::build::{load_roc_value, use_roc_value};
+use super::build::{load_roc_value, use_roc_value, BuilderExt};
 use super::convert::argument_type_from_union_layout;
 use super::lowlevel::dec_binop_with_unchecked;
 
@@ -542,14 +542,16 @@ fn build_list_eq_help<'a, 'ctx, 'env>(
             builder.position_at_end(body_bb);
 
             let elem1 = {
-                let elem_ptr =
-                    unsafe { builder.build_in_bounds_gep(ptr1, &[curr_index], "load_index") };
+                let elem_ptr = unsafe {
+                    builder.new_build_in_bounds_gep(element_type, ptr1, &[curr_index], "load_index")
+                };
                 load_roc_value(env, *element_layout, elem_ptr, "get_elem")
             };
 
             let elem2 = {
-                let elem_ptr =
-                    unsafe { builder.build_in_bounds_gep(ptr2, &[curr_index], "load_index") };
+                let elem_ptr = unsafe {
+                    builder.new_build_in_bounds_gep(element_type, ptr2, &[curr_index], "load_index")
+                };
                 load_roc_value(env, *element_layout, elem_ptr, "get_elem")
             };
 

--- a/crates/compiler/gen_llvm/src/llvm/compare.rs
+++ b/crates/compiler/gen_llvm/src/llvm/compare.rs
@@ -527,7 +527,9 @@ fn build_list_eq_help<'a, 'ctx, 'env>(
         builder.build_unconditional_branch(loop_bb);
         builder.position_at_end(loop_bb);
 
-        let curr_index = builder.build_load(index_alloca, "index").into_int_value();
+        let curr_index = builder
+            .new_build_load(env.ptr_int(), index_alloca, "index")
+            .into_int_value();
 
         // #index < end
         let loop_end_cond =
@@ -1255,12 +1257,12 @@ fn eq_ptr_to_struct<'a, 'ctx, 'env>(
 
     let struct1 = env
         .builder
-        .build_load(struct1_ptr, "load_struct1")
+        .new_build_load(wrapper_type, struct1_ptr, "load_struct1")
         .into_struct_value();
 
     let struct2 = env
         .builder
-        .build_load(struct2_ptr, "load_struct2")
+        .new_build_load(wrapper_type, struct2_ptr, "load_struct2")
         .into_struct_value();
 
     build_struct_eq(

--- a/crates/compiler/gen_llvm/src/llvm/convert.rs
+++ b/crates/compiler/gen_llvm/src/llvm/convert.rs
@@ -1,4 +1,4 @@
-use crate::llvm::build::Env;
+use crate::llvm::build::{BuilderExt, Env};
 use bumpalo::collections::Vec;
 use inkwell::context::Context;
 use inkwell::types::{BasicType, BasicTypeEnum, FloatType, IntType, StructType};
@@ -53,18 +53,16 @@ pub fn basic_type_from_layout<'a, 'ctx, 'env>(
     }
 }
 
-pub fn basic_type_from_union_layout<'a, 'ctx, 'env>(
+pub fn struct_type_from_union_layout<'a, 'ctx, 'env>(
     env: &Env<'a, 'ctx, 'env>,
     union_layout: &UnionLayout<'_>,
-) -> BasicTypeEnum<'ctx> {
+) -> StructType<'ctx> {
     use UnionLayout::*;
 
     match union_layout {
         NonRecursive(tags) => {
-            //
             RocUnion::tagged_from_slices(env.layout_interner, env.context, tags, env.target_info)
                 .struct_type()
-                .into()
         }
         Recursive(tags)
         | NullableWrapped {
@@ -78,8 +76,6 @@ pub fn basic_type_from_union_layout<'a, 'ctx, 'env>(
                     env.target_info,
                 )
                 .struct_type()
-                .ptr_type(AddressSpace::Generic)
-                .into()
             } else {
                 RocUnion::untagged_from_slices(
                     env.layout_interner,
@@ -88,8 +84,6 @@ pub fn basic_type_from_union_layout<'a, 'ctx, 'env>(
                     env.target_info,
                 )
                 .struct_type()
-                .ptr_type(AddressSpace::Generic)
-                .into()
             }
         }
         NullableUnwrapped { other_fields, .. } => RocUnion::untagged_from_slices(
@@ -98,18 +92,31 @@ pub fn basic_type_from_union_layout<'a, 'ctx, 'env>(
             &[other_fields],
             env.target_info,
         )
-        .struct_type()
-        .ptr_type(AddressSpace::Generic)
-        .into(),
+        .struct_type(),
         NonNullableUnwrapped(fields) => RocUnion::untagged_from_slices(
             env.layout_interner,
             env.context,
             &[fields],
             env.target_info,
         )
-        .struct_type()
-        .ptr_type(AddressSpace::Generic)
-        .into(),
+        .struct_type(),
+    }
+}
+
+pub fn basic_type_from_union_layout<'a, 'ctx, 'env>(
+    env: &Env<'a, 'ctx, 'env>,
+    union_layout: &UnionLayout<'_>,
+) -> BasicTypeEnum<'ctx> {
+    use UnionLayout::*;
+
+    let struct_type = struct_type_from_union_layout(env, union_layout);
+
+    match union_layout {
+        NonRecursive(_) => struct_type.into(),
+        Recursive(_)
+        | NonNullableUnwrapped(_)
+        | NullableWrapped { .. }
+        | NullableUnwrapped { .. } => struct_type.ptr_type(AddressSpace::Generic).into(),
     }
 }
 
@@ -363,7 +370,12 @@ impl<'ctx> RocUnion<'ctx> {
 
         let data_buffer = env
             .builder
-            .build_struct_gep(tag_alloca, Self::TAG_DATA_INDEX, "data_buffer")
+            .new_build_struct_gep(
+                self.struct_type(),
+                tag_alloca,
+                Self::TAG_DATA_INDEX,
+                "data_buffer",
+            )
             .unwrap();
 
         let cast_pointer = env.builder.build_pointer_cast(
@@ -389,7 +401,12 @@ impl<'ctx> RocUnion<'ctx> {
 
             let tag_id_ptr = env
                 .builder
-                .build_struct_gep(tag_alloca, Self::TAG_ID_INDEX, "tag_id_ptr")
+                .new_build_struct_gep(
+                    self.struct_type(),
+                    tag_alloca,
+                    Self::TAG_ID_INDEX,
+                    "tag_id_ptr",
+                )
                 .unwrap();
 
             let tag_id = tag_id_type.const_int(tag_id as u64, false);

--- a/crates/compiler/gen_llvm/src/llvm/convert.rs
+++ b/crates/compiler/gen_llvm/src/llvm/convert.rs
@@ -415,7 +415,7 @@ impl<'ctx> RocUnion<'ctx> {
         }
 
         env.builder
-            .build_load(tag_alloca, "load_tag")
+            .new_build_load(self.struct_type(), tag_alloca, "load_tag")
             .into_struct_value()
     }
 }

--- a/crates/compiler/gen_llvm/src/llvm/expect.rs
+++ b/crates/compiler/gen_llvm/src/llvm/expect.rs
@@ -16,7 +16,7 @@ use roc_region::all::Region;
 
 use super::build::{
     add_func, load_roc_value, load_symbol_and_layout, use_roc_value, FunctionSpec, LlvmBackendMode,
-    Scope,
+    Scope, WhenRecursive,
 };
 
 pub(crate) struct SharedMemoryPointer<'ctx>(PointerValue<'ctx>);
@@ -265,13 +265,6 @@ pub(crate) fn clone_to_shared_memory<'a, 'ctx, 'env>(
     let one = env.ptr_int().const_int(1, false);
     let new_count = env.builder.build_int_add(count, one, "inc");
     write_state(env, original_ptr, new_count, offset)
-}
-
-#[derive(Clone, Debug, Copy)]
-enum WhenRecursive<'a> {
-    Unreachable,
-    #[allow(dead_code)]
-    Loop(UnionLayout<'a>),
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/crates/compiler/gen_llvm/src/llvm/expect.rs
+++ b/crates/compiler/gen_llvm/src/llvm/expect.rs
@@ -14,6 +14,7 @@ use roc_mono::ir::LookupType;
 use roc_mono::layout::{Builtin, Layout, LayoutIds, UnionLayout};
 use roc_region::all::Region;
 
+use super::build::BuilderExt;
 use super::build::{
     add_func, load_roc_value, load_symbol_and_layout, use_roc_value, FunctionSpec, LlvmBackendMode,
     Scope, WhenRecursive,
@@ -529,7 +530,12 @@ fn load_tag_data<'a, 'ctx, 'env>(
 ) -> BasicValueEnum<'ctx> {
     let raw_data_ptr = env
         .builder
-        .build_struct_gep(tag_value, RocUnion::TAG_DATA_INDEX, "tag_data")
+        .new_build_struct_gep(
+            tag_type.into_struct_type(),
+            tag_value,
+            RocUnion::TAG_DATA_INDEX,
+            "tag_data",
+        )
         .unwrap();
 
     let data_ptr = env.builder.build_pointer_cast(

--- a/crates/compiler/gen_llvm/src/llvm/expect.rs
+++ b/crates/compiler/gen_llvm/src/llvm/expect.rs
@@ -102,8 +102,10 @@ fn read_state<'a, 'ctx, 'env>(
     let one = env.ptr_int().const_int(1, false);
     let offset_ptr = pointer_at_offset(env.builder, env.ptr_int(), ptr, one);
 
-    let count = env.builder.build_load(ptr, "load_count");
-    let offset = env.builder.build_load(offset_ptr, "load_offset");
+    let count = env.builder.new_build_load(env.ptr_int(), ptr, "load_count");
+    let offset = env
+        .builder
+        .new_build_load(env.ptr_int(), offset_ptr, "load_offset");
 
     (count.into_int_value(), offset.into_int_value())
 }
@@ -1033,7 +1035,8 @@ fn build_clone_builtin<'a, 'ctx, 'env>(
                         bd.build_int_mul(element_stack_size, index, "current_offset");
                     let current_offset =
                         bd.build_int_add(elements_start_offset, current_offset, "current_offset");
-                    let current_extra_offset = bd.build_load(rest_offset, "element_offset");
+                    let current_extra_offset =
+                        bd.new_build_load(env.ptr_int(), rest_offset, "element_offset");
 
                     let offset = current_offset;
                     let extra_offset = current_extra_offset.into_int_value();
@@ -1064,7 +1067,7 @@ fn build_clone_builtin<'a, 'ctx, 'env>(
 
                 incrementing_elem_loop(env, parent, *elem, elements, len, "index", body);
 
-                bd.build_load(rest_offset, "rest_start_offset")
+                bd.new_build_load(env.ptr_int(), rest_offset, "rest_start_offset")
                     .into_int_value()
             }
         }

--- a/crates/compiler/gen_llvm/src/llvm/externs.rs
+++ b/crates/compiler/gen_llvm/src/llvm/externs.rs
@@ -1,6 +1,7 @@
 use crate::llvm::bitcode::call_void_bitcode_fn;
-use crate::llvm::build::{add_func, get_panic_msg_ptr, get_panic_tag_ptr, C_CALL_CONV};
+use crate::llvm::build::{add_func, get_panic_msg_ptr, get_panic_tag_ptr, BuilderExt, C_CALL_CONV};
 use crate::llvm::build::{CCReturn, Env, FunctionSpec};
+use crate::llvm::convert::zig_str_type;
 use inkwell::module::Linkage;
 use inkwell::types::BasicType;
 use inkwell::values::BasicValue;
@@ -217,7 +218,12 @@ pub fn add_sjlj_roc_panic(env: &Env<'_, '_, '_>) {
                 roc_target::PtrWidth::Bytes4 => roc_str_arg,
                 // On 64-bit we pass RocStrs by reference internally
                 roc_target::PtrWidth::Bytes8 => {
-                    builder.build_load(roc_str_arg.into_pointer_value(), "load_roc_str")
+                    let str_typ = zig_str_type(env);
+                    builder.new_build_load(
+                        str_typ,
+                        roc_str_arg.into_pointer_value(),
+                        "load_roc_str",
+                    )
                 }
             };
 

--- a/crates/compiler/gen_llvm/src/llvm/refcounting.rs
+++ b/crates/compiler/gen_llvm/src/llvm/refcounting.rs
@@ -60,7 +60,12 @@ impl<'ctx> PointerToRefcount<'ctx> {
         // get a pointer to index -1
         let index_intvalue = refcount_type.const_int(-1_i64 as u64, false);
         let refcount_ptr = unsafe {
-            builder.build_in_bounds_gep(ptr_as_usize_ptr, &[index_intvalue], "get_rc_ptr")
+            builder.new_build_in_bounds_gep(
+                env.ptr_int(),
+                ptr_as_usize_ptr,
+                &[index_intvalue],
+                "get_rc_ptr",
+            )
         };
 
         Self {


### PR DESCRIPTION
already pass types explicitly where we have to with llvm 15. This is actually convenient because we can still use `get_element_type()` to assert that the type is correct.