### PR TITLE
make dbg transparent to refcounting

### DIFF
--- a/crates/compiler/alias_analysis/src/lib.rs
+++ b/crates/compiler/alias_analysis/src/lib.rs
@@ -611,6 +611,7 @@ fn stmt_spec<'a>(
 
             builder.add_choice(block, &cases)
         }
+        Dbg { remainder, .. } => stmt_spec(builder, interner, env, block, layout, remainder),
         Expect { remainder, .. } => stmt_spec(builder, interner, env, block, layout, remainder),
         ExpectFx { remainder, .. } => stmt_spec(builder, interner, env, block, layout, remainder),
         Ret(symbol) => Ok(env.symbols[symbol]),

--- a/crates/compiler/alias_analysis/src/lib.rs
+++ b/crates/compiler/alias_analysis/src/lib.rs
@@ -1288,14 +1288,6 @@ fn lowlevel_spec<'a>(
 
             builder.add_make_tuple(block, &[byte_index, string, is_ok, problem_code])
         }
-        Dbg => {
-            let arguments = [env.symbols[&arguments[0]]];
-
-            let result_type =
-                layout_spec(env, builder, interner, layout, &WhenRecursive::Unreachable)?;
-
-            builder.add_unknown_with(block, &arguments, result_type)
-        }
         _other => {
             // println!("missing {:?}", _other);
             // TODO overly pessimstic

--- a/crates/compiler/can/src/builtins.rs
+++ b/crates/compiler/can/src/builtins.rs
@@ -87,7 +87,6 @@ macro_rules! map_symbol_to_lowlevel_and_arity {
                 LowLevel::PtrCast => unimplemented!(),
                 LowLevel::RefCountInc => unimplemented!(),
                 LowLevel::RefCountDec => unimplemented!(),
-                LowLevel::Dbg => unimplemented!(),
 
                 // these are not implemented, not sure why
                 LowLevel::StrFromInt => unimplemented!(),

--- a/crates/compiler/gen_dev/src/lib.rs
+++ b/crates/compiler/gen_dev/src/lib.rs
@@ -1107,6 +1107,7 @@ trait Backend<'a> {
                 }
             }
 
+            Stmt::Dbg { .. } => todo!("dbg not implemented in the dev backend"),
             Stmt::Expect { .. } => todo!("expect is not implemented in the dev backend"),
             Stmt::ExpectFx { .. } => todo!("expect-fx is not implemented in the dev backend"),
 

--- a/crates/compiler/gen_llvm/src/llvm/build.rs
+++ b/crates/compiler/gen_llvm/src/llvm/build.rs
@@ -2661,6 +2661,39 @@ pub fn build_exp_stmt<'a, 'ctx, 'env>(
             }
         }
 
+        Dbg {
+            symbol,
+            variable: specialized_var,
+            remainder,
+        } => {
+            if env.mode.runs_expects() {
+                let shared_memory = crate::llvm::expect::SharedMemoryPointer::get(env);
+                let region = unsafe { std::mem::transmute::<_, roc_region::all::Region>(*symbol) };
+
+                crate::llvm::expect::clone_to_shared_memory(
+                    env,
+                    scope,
+                    layout_ids,
+                    &shared_memory,
+                    *symbol,
+                    region,
+                    &[*symbol],
+                    &[*specialized_var],
+                );
+
+                crate::llvm::expect::notify_parent_dbg(env, &shared_memory);
+            }
+
+            build_exp_stmt(
+                env,
+                layout_ids,
+                func_spec_solutions,
+                scope,
+                parent,
+                remainder,
+            )
+        }
+
         Expect {
             condition: cond_symbol,
             region,

--- a/crates/compiler/gen_llvm/src/llvm/lowlevel.rs
+++ b/crates/compiler/gen_llvm/src/llvm/lowlevel.rs
@@ -11,7 +11,7 @@ use roc_builtins::bitcode::{self, FloatWidth, IntWidth};
 use roc_error_macros::internal_error;
 use roc_module::{low_level::LowLevel, symbol::Symbol};
 use roc_mono::{
-    ir::{HigherOrderLowLevel, LookupType},
+    ir::HigherOrderLowLevel,
     layout::{Builtin, LambdaSet, Layout, LayoutIds},
 };
 use roc_target::PtrWidth;
@@ -1149,36 +1149,6 @@ pub(crate) fn run_low_level<'a, 'ctx, 'env>(
                 ptr.into()
             }
         },
-        Dbg => {
-            assert_eq!(args.len(), 2);
-            let condition = load_symbol(scope, &args[0]);
-            let dbg_spec_var_symbol = args[1];
-
-            if env.mode.runs_expects() {
-                let region = unsafe { std::mem::transmute::<_, roc_region::all::Region>(args[0]) };
-
-                let shared_memory = crate::llvm::expect::SharedMemoryPointer::get(env);
-
-                // HACK(dbg-spec-var): the specialized type variable is passed along as a fake symbol
-                let specialized_var =
-                    unsafe { LookupType::from_index(dbg_spec_var_symbol.ident_id().index() as _) };
-
-                crate::llvm::expect::clone_to_shared_memory(
-                    env,
-                    scope,
-                    layout_ids,
-                    &shared_memory,
-                    args[0],
-                    region,
-                    &[args[0]],
-                    &[specialized_var],
-                );
-
-                crate::llvm::expect::notify_parent_dbg(env, &shared_memory);
-            }
-
-            condition
-        }
     }
 }
 

--- a/crates/compiler/gen_wasm/src/backend.rs
+++ b/crates/compiler/gen_wasm/src/backend.rs
@@ -714,6 +714,7 @@ impl<'a> WasmBackend<'a> {
 
             Stmt::Refcounting(modify, following) => self.stmt_refcounting(modify, following),
 
+            Stmt::Dbg { .. } => todo!("dbg is not implemented in the wasm backend"),
             Stmt::Expect { .. } => todo!("expect is not implemented in the wasm backend"),
             Stmt::ExpectFx { .. } => todo!("expect-fx is not implemented in the wasm backend"),
 

--- a/crates/compiler/gen_wasm/src/low_level.rs
+++ b/crates/compiler/gen_wasm/src/low_level.rs
@@ -1867,8 +1867,6 @@ impl<'a> LowLevelCall<'a> {
                 },
                 StoredValue::StackMemory { .. } => { /* do nothing */ }
             },
-
-            Dbg => todo!("{:?}", self.lowlevel),
         }
     }
 

--- a/crates/compiler/module/src/low_level.rs
+++ b/crates/compiler/module/src/low_level.rs
@@ -112,7 +112,6 @@ pub enum LowLevel {
     RefCountDec,
     BoxExpr,
     UnboxExpr,
-    Dbg,
     Unreachable,
 }
 
@@ -215,7 +214,6 @@ macro_rules! map_symbol_to_lowlevel {
                 LowLevel::PtrCast => unimplemented!(),
                 LowLevel::RefCountInc => unimplemented!(),
                 LowLevel::RefCountDec => unimplemented!(),
-                LowLevel::Dbg => unreachable!(),
 
                 // these are not implemented, not sure why
                 LowLevel::StrFromInt => unimplemented!(),

--- a/crates/compiler/mono/src/borrow.rs
+++ b/crates/compiler/mono/src/borrow.rs
@@ -314,6 +314,7 @@ impl<'a> ParamMap<'a> {
                     stack.push(cont);
                 }
 
+                Dbg { remainder, .. } => stack.push(remainder),
                 Expect { remainder, .. } => stack.push(remainder),
                 ExpectFx { remainder, .. } => stack.push(remainder),
 
@@ -823,6 +824,10 @@ impl<'a> BorrowInfState<'a> {
                 self.collect_stmt(param_map, default_branch.1);
             }
 
+            Dbg { remainder, .. } => {
+                self.collect_stmt(param_map, remainder);
+            }
+
             Expect { remainder, .. } => {
                 self.collect_stmt(param_map, remainder);
             }
@@ -1007,6 +1012,7 @@ fn call_info_stmt<'a>(arena: &'a Bump, stmt: &Stmt<'a>, info: &mut CallInfo<'a>)
                 stack.push(default_branch.1);
             }
 
+            Dbg { remainder, .. } => stack.push(remainder),
             Expect { remainder, .. } => stack.push(remainder),
             ExpectFx { remainder, .. } => stack.push(remainder),
 

--- a/crates/compiler/mono/src/borrow.rs
+++ b/crates/compiler/mono/src/borrow.rs
@@ -953,8 +953,6 @@ pub fn lowlevel_borrow_signature(arena: &Bump, op: LowLevel) -> &[bool] {
 
         ListIsUnique => arena.alloc_slice_copy(&[borrowed]),
 
-        Dbg => arena.alloc_slice_copy(&[borrowed, /* dbg-spec-var */ irrelevant]),
-
         BoxExpr | UnboxExpr => {
             unreachable!("These lowlevel operations are turned into mono Expr's")
         }

--- a/crates/compiler/mono/src/debug/checker.rs
+++ b/crates/compiler/mono/src/debug/checker.rs
@@ -305,6 +305,9 @@ impl<'a, 'r> Ctx<'a, 'r> {
                 self.check_modify_rc(rc);
                 self.check_stmt(rest);
             }
+            &Stmt::Dbg { remainder, .. } => {
+                self.check_stmt(remainder);
+            }
             &Stmt::Expect {
                 condition,
                 region: _,

--- a/crates/compiler/mono/src/inc_dec.rs
+++ b/crates/compiler/mono/src/inc_dec.rs
@@ -562,13 +562,7 @@ impl<'a, 'i> Context<'a, 'i> {
         match &call_type {
             LowLevel { op, .. } => {
                 let ps = crate::borrow::lowlevel_borrow_signature(self.arena, *op);
-                let b = match op {
-                    roc_module::low_level::LowLevel::Dbg => {
-                        // NB(dbg-spec-var) second var is the Variable
-                        self.add_dec_after_lowlevel(&arguments[..1], ps, b, b_live_vars)
-                    }
-                    _ => self.add_dec_after_lowlevel(arguments, ps, b, b_live_vars),
-                };
+                let b = self.add_dec_after_lowlevel(arguments, ps, b, b_live_vars);
 
                 let v = Expr::Call(crate::ir::Call {
                     call_type,

--- a/crates/compiler/mono/src/reset_reuse.rs
+++ b/crates/compiler/mono/src/reset_reuse.rs
@@ -191,6 +191,27 @@ fn function_s<'a, 'i>(
             }
         }
 
+        Dbg {
+            symbol,
+            variable,
+            remainder,
+        } => {
+            let continuation: &Stmt = remainder;
+            let new_continuation = function_s(env, w, c, continuation);
+
+            if std::ptr::eq(continuation, new_continuation) || continuation == new_continuation {
+                stmt
+            } else {
+                let new_refcounting = Dbg {
+                    symbol: *symbol,
+                    variable: *variable,
+                    remainder: new_continuation,
+                };
+
+                arena.alloc(new_refcounting)
+            }
+        }
+
         Expect {
             condition,
             region,
@@ -438,6 +459,34 @@ fn function_d_main<'a, 'i>(
             }
         }
 
+        Dbg {
+            symbol,
+            variable,
+            remainder,
+        } => {
+            let (b, found) = function_d_main(env, x, c, remainder);
+
+            if found || *symbol != x {
+                let refcounting = Dbg {
+                    symbol: *symbol,
+                    variable: *variable,
+                    remainder: b,
+                };
+
+                (arena.alloc(refcounting), found)
+            } else {
+                let b = try_function_s(env, x, c, b);
+
+                let refcounting = Dbg {
+                    symbol: *symbol,
+                    variable: *variable,
+                    remainder: b,
+                };
+
+                (arena.alloc(refcounting), found)
+            }
+        }
+
         Expect {
             condition,
             region,
@@ -656,6 +705,22 @@ fn function_r<'a, 'i>(env: &mut Env<'a, 'i>, stmt: &'a Stmt<'a>) -> &'a Stmt<'a>
             arena.alloc(Refcounting(*modify_rc, b))
         }
 
+        Dbg {
+            symbol,
+            variable,
+            remainder,
+        } => {
+            let b = function_r(env, remainder);
+
+            let expect = Dbg {
+                symbol: *symbol,
+                variable: *variable,
+                remainder: b,
+            };
+
+            arena.alloc(expect)
+        }
+
         Expect {
             condition,
             region,
@@ -726,6 +791,9 @@ fn has_live_var<'a>(jp_live_vars: &JPLiveVarMap, stmt: &'a Stmt<'a>, needle: Sym
         Refcounting(modify_rc, cont) => {
             modify_rc.get_symbol() == needle || has_live_var(jp_live_vars, cont, needle)
         }
+        Dbg {
+            symbol, remainder, ..
+        } => *symbol == needle || has_live_var(jp_live_vars, remainder, needle),
         Expect {
             condition,
             remainder,

--- a/crates/compiler/mono/src/tail_recursion.rs
+++ b/crates/compiler/mono/src/tail_recursion.rs
@@ -249,6 +249,26 @@ fn insert_jumps<'a>(
             }
         }
 
+        Dbg {
+            symbol,
+            variable,
+            remainder,
+        } => match insert_jumps(
+            arena,
+            remainder,
+            goal_id,
+            needle,
+            needle_arguments,
+            needle_result,
+        ) {
+            Some(cont) => Some(arena.alloc(Dbg {
+                symbol: *symbol,
+                variable: *variable,
+                remainder: cont,
+            })),
+            None => None,
+        },
+
         Expect {
             condition,
             region,


### PR DESCRIPTION
previously `dbg` messed up refcounting, leading to use-after-free. Now we have more code, but it basically does nothing, which is what we want.