### PR TITLE
Update error message to better explain `->`

### DIFF
--- a/crates/reporting/src/error/parse.rs
+++ b/crates/reporting/src/error/parse.rs
@@ -290,10 +290,12 @@ fn to_expr_report<'a>(
                                 ])
                                 .indent(4),
                             alloc.reflow("And to define a function:"),
-                            alloc.vcat(vec![
-                                alloc.text("increment : I64 -> I64"),
-                                alloc.text("increment = \\n -> n + 1"),
-                            ]).indent(4)
+                            alloc
+                                .vcat(vec![
+                                    alloc.text("increment : I64 -> I64"),
+                                    alloc.text("increment = \\n -> n + 1"),
+                                ])
+                                .indent(4),
                         ])]
                     }
                 },

--- a/crates/reporting/src/error/parse.rs
+++ b/crates/reporting/src/error/parse.rs
@@ -279,8 +279,8 @@ fn to_expr_report<'a>(
                                 alloc.reflow("The arrow "),
                                 alloc.parser_suggestion("->"),
                                 alloc.reflow(" is only used to define cases in a "),
-                                alloc.keyword("when"),
-                                alloc.reflow("."),
+                                alloc.keyword("`when`"),
+                                alloc.reflow("expression:"),
                             ]),
                             alloc
                                 .vcat(vec![
@@ -289,6 +289,8 @@ fn to_expr_report<'a>(
                                     alloc.text("Green -> \"go!\"").indent(4),
                                 ])
                                 .indent(4),
+                            alloc.reflow("And to define a function:"),
+                            alloc.reflow("increment = \\n -> n + 1").indent(4),
                         ])]
                     }
                 },

--- a/crates/reporting/src/error/parse.rs
+++ b/crates/reporting/src/error/parse.rs
@@ -290,7 +290,10 @@ fn to_expr_report<'a>(
                                 ])
                                 .indent(4),
                             alloc.reflow("And to define a function:"),
-                            alloc.reflow("increment = \\n -> n + 1").indent(4),
+                            alloc.vcat(vec![
+                                alloc.text("increment : I64 -> I64"),
+                                alloc.text("increment = \\n -> n + 1"),
+                            ]).indent(4)
                         ])]
                     }
                 },

--- a/crates/reporting/tests/test_reporting.rs
+++ b/crates/reporting/tests/test_reporting.rs
@@ -5645,11 +5645,16 @@ All branches in an `if` must have the same type!
     5│          1 -> True
                   ^^
 
-    The arrow -> is only used to define cases in a `when`.
+    The arrow -> is used to define cases in a `when` expression:
 
         when color is
             Red -> "stop!"
             Green -> "go!"
+
+    And defining functions:
+
+        increment = \n -> n + 1
+
     "###
     );
 

--- a/crates/reporting/tests/test_reporting.rs
+++ b/crates/reporting/tests/test_reporting.rs
@@ -5651,7 +5651,7 @@ All branches in an `if` must have the same type!
             Red -> "stop!"
             Green -> "go!"
 
-    And defining functions:
+    And to define a function:
 
         increment = \n -> n + 1
 

--- a/crates/reporting/tests/test_reporting.rs
+++ b/crates/reporting/tests/test_reporting.rs
@@ -5653,6 +5653,7 @@ All branches in an `if` must have the same type!
 
     And to define a function:
 
+        increment : I64 -> I64
         increment = \n -> n + 1
 
     "###


### PR DESCRIPTION
Closes #4647

This PR improves the error message for unexpected `->` in certain contexts by showing both correct areas to use it.
