### PR TITLE
fix building wasm repl

### DIFF
--- a/crates/compiler/fmt/Cargo.toml
+++ b/crates/compiler/fmt/Cargo.toml
@@ -11,10 +11,10 @@ roc_collections = { path = "../collections" }
 roc_region = { path = "../region" }
 roc_module = { path = "../module" }
 roc_parse = { path = "../parse" }
-roc_test_utils = { path = "../../test_utils" }
 bumpalo.workspace = true 
 
 [dev-dependencies]
+roc_test_utils = { path = "../../test_utils" }
 pretty_assertions.workspace = true
 indoc.workspace = true
 walkdir.workspace = true

--- a/crates/compiler/fmt/src/lib.rs
+++ b/crates/compiler/fmt/src/lib.rs
@@ -9,7 +9,6 @@ pub mod expr;
 pub mod module;
 pub mod pattern;
 pub mod spaces;
-pub mod test_helpers;
 
 use bumpalo::{collections::String, Bump};
 use roc_parse::ast::Module;

--- a/crates/compiler/fmt/src/test_fmt.rs
+++ b/crates/compiler/fmt/src/test_fmt.rs
@@ -10,7 +10,6 @@ mod test_fmt {
     use bumpalo::Bump;
     use roc_fmt::def::fmt_defs;
     use roc_fmt::module::fmt_module;
-    use roc_fmt::test_helpers::expr_formats;
     use roc_fmt::Buf;
     use roc_parse::ast::Module;
     use roc_parse::module::{self, module_defs};

--- a/crates/compiler/fmt/src/test_helpers.rs
+++ b/crates/compiler/fmt/src/test_helpers.rs
@@ -1,77 +1,82 @@
-use bumpalo::Bump;
-use roc_test_utils::assert_multiline_str_eq;
 
-use crate::{
-    annotation::{Formattable, Newlines, Parens},
-    Buf,
-};
 
-/// Parse and re-format the given input, and pass the output to `check_formatting`
-/// for verification.  The expectation is that `check_formatting` assert the result matches
-/// expectations (or, overwrite the expectation based on a command-line flag)
-/// Optionally, based on the value of `check_idempotency`, also verify that the formatting
-/// is idempotent - that if we reformat the output, we get the same result.
-pub fn expr_formats(input: &str, check_formatting: impl Fn(&str), check_idempotency: bool) {
-    let arena = Bump::new();
-    let input = input.trim();
+#[cfg(test)]
+pub mod test_helpers {
+    use bumpalo::Bump;
+    use roc_test_utils::assert_multiline_str_eq;
 
-    match roc_parse::test_helpers::parse_expr_with(&arena, input) {
-        Ok(actual) => {
-            use crate::spaces::RemoveSpaces;
+    use crate::{
+        annotation::{Formattable, Newlines, Parens},
+        Buf,
+    };
 
-            let mut buf = Buf::new_in(&arena);
+    /// Parse and re-format the given input, and pass the output to `check_formatting`
+    /// for verification.  The expectation is that `check_formatting` assert the result matches
+    /// expectations (or, overwrite the expectation based on a command-line flag)
+    /// Optionally, based on the value of `check_idempotency`, also verify that the formatting
+    /// is idempotent - that if we reformat the output, we get the same result.
+    pub fn expr_formats(input: &str, check_formatting: impl Fn(&str), check_idempotency: bool) {
+        let arena = Bump::new();
+        let input = input.trim();
 
-            actual.format_with_options(&mut buf, Parens::NotNeeded, Newlines::Yes, 0);
+        match roc_parse::test_helpers::parse_expr_with(&arena, input) {
+            Ok(actual) => {
+                use crate::spaces::RemoveSpaces;
 
-            let output = buf.as_str();
+                let mut buf = Buf::new_in(&arena);
 
-            check_formatting(output);
+                actual.format_with_options(&mut buf, Parens::NotNeeded, Newlines::Yes, 0);
 
-            let reparsed_ast = roc_parse::test_helpers::parse_expr_with(&arena, output).unwrap_or_else(|err| {
-                panic!(
-                    "After formatting, the source code no longer parsed!\n\n\
-                    Parse error was: {:?}\n\n\
-                    The code that failed to parse:\n\n{}\n\n\
-                    The original ast was:\n\n{:#?}\n\n",
-                    err, output, actual
-                );
-            });
+                let output = buf.as_str();
 
-            let ast_normalized = actual.remove_spaces(&arena);
-            let reparsed_ast_normalized = reparsed_ast.remove_spaces(&arena);
+                check_formatting(output);
 
-            // HACK!
-            // We compare the debug format strings of the ASTs, because I'm finding in practice that _somewhere_ deep inside the ast,
-            // the PartialEq implementation is returning `false` even when the Debug-formatted impl is exactly the same.
-            // I don't have the patience to debug this right now, so let's leave it for another day...
-            // TODO: fix PartialEq impl on ast types
-            if format!("{:?}", ast_normalized) != format!("{:?}", reparsed_ast_normalized) {
-                panic!(
-                    "Formatting bug; formatting didn't reparse to the same AST (after removing spaces)\n\n\
-                    * * * Source code before formatting:\n{}\n\n\
-                    * * * Source code after formatting:\n{}\n\n\
-                    * * * AST before formatting:\n{:#?}\n\n\
-                    * * * AST after formatting:\n{:#?}\n\n",
-                    input,
-                    output,
-                    ast_normalized,
-                    reparsed_ast_normalized
-                );
-            }
+                let reparsed_ast = roc_parse::test_helpers::parse_expr_with(&arena, output).unwrap_or_else(|err| {
+                    panic!(
+                        "After formatting, the source code no longer parsed!\n\n\
+                        Parse error was: {:?}\n\n\
+                        The code that failed to parse:\n\n{}\n\n\
+                        The original ast was:\n\n{:#?}\n\n",
+                        err, output, actual
+                    );
+                });
 
-            // Now verify that the resultant formatting is _idempotent_ - i.e. that it doesn't change again if re-formatted
-            if check_idempotency {
-                let mut reformatted_buf = Buf::new_in(&arena);
-                reparsed_ast.format_with_options(&mut reformatted_buf, Parens::NotNeeded, Newlines::Yes, 0);
+                let ast_normalized = actual.remove_spaces(&arena);
+                let reparsed_ast_normalized = reparsed_ast.remove_spaces(&arena);
 
-                if output != reformatted_buf.as_str() {
-                    eprintln!("Formatting bug; formatting is not stable.\nOriginal code:\n{}\n\nFormatted code:\n{}\n\n", input, output);
-                    eprintln!("Reformatting the formatted code changed it again, as follows:\n\n");
+                // HACK!
+                // We compare the debug format strings of the ASTs, because I'm finding in practice that _somewhere_ deep inside the ast,
+                // the PartialEq implementation is returning `false` even when the Debug-formatted impl is exactly the same.
+                // I don't have the patience to debug this right now, so let's leave it for another day...
+                // TODO: fix PartialEq impl on ast types
+                if format!("{:?}", ast_normalized) != format!("{:?}", reparsed_ast_normalized) {
+                    panic!(
+                        "Formatting bug; formatting didn't reparse to the same AST (after removing spaces)\n\n\
+                        * * * Source code before formatting:\n{}\n\n\
+                        * * * Source code after formatting:\n{}\n\n\
+                        * * * AST before formatting:\n{:#?}\n\n\
+                        * * * AST after formatting:\n{:#?}\n\n",
+                        input,
+                        output,
+                        ast_normalized,
+                        reparsed_ast_normalized
+                    );
+                }
 
-                    assert_multiline_str_eq!(output, reformatted_buf.as_str());
+                // Now verify that the resultant formatting is _idempotent_ - i.e. that it doesn't change again if re-formatted
+                if check_idempotency {
+                    let mut reformatted_buf = Buf::new_in(&arena);
+                    reparsed_ast.format_with_options(&mut reformatted_buf, Parens::NotNeeded, Newlines::Yes, 0);
+
+                    if output != reformatted_buf.as_str() {
+                        eprintln!("Formatting bug; formatting is not stable.\nOriginal code:\n{}\n\nFormatted code:\n{}\n\n", input, output);
+                        eprintln!("Reformatting the formatted code changed it again, as follows:\n\n");
+
+                        assert_multiline_str_eq!(output, reformatted_buf.as_str());
+                    }
                 }
             }
-        }
-        Err(error) => panic!("Unexpected parse failure when parsing this for formatting:\n\n{}\n\nParse error was:\n\n{:?}\n\n", input, error)
-    };
+            Err(error) => panic!("Unexpected parse failure when parsing this for formatting:\n\n{}\n\nParse error was:\n\n{:?}\n\n", input, error)
+        };
+    }
 }

--- a/crates/test_utils/Cargo.toml
+++ b/crates/test_utils/Cargo.toml
@@ -8,6 +8,9 @@ description = "Utility functions used all over the code base."
 
 [dependencies]
 pretty_assertions = "1.3.0"
+
+# wasm doesn't use directories
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
 remove_dir_all = "0.7.0"
 
 [dev-dependencies]

--- a/crates/test_utils/src/lib.rs
+++ b/crates/test_utils/src/lib.rs
@@ -23,10 +23,12 @@ macro_rules! assert_multiline_str_eq {
 /**
  * Creates a temporary empty directory that gets deleted when this goes out of scope.
  */
+#[cfg(not(target_family = "wasm"))]
 pub struct TmpDir {
     path: std::path::PathBuf,
 }
 
+#[cfg(not(target_family = "wasm"))]
 impl TmpDir {
     pub fn new(dir: &str) -> TmpDir {
         let path = std::path::Path::new(dir);


### PR DESCRIPTION
Original error:
```
> wasm-pack build --profiling --target web -- --features console_error_panic_hook
2022-12-23T09:13:18.6004478Z [INFO]: Checking for the Wasm target...
2022-12-23T09:13:18.6429592Z [INFO]: Compiling to Wasm...
2022-12-23T09:13:18.9558246Z    Compiling libc v0.2.135
2022-12-23T09:13:18.9558748Z    Compiling version_check v0.9.4
2022-12-23T09:13:18.9559487Z    Compiling proc-macro2 v1.0.40
2022-12-23T09:13:18.9560051Z    Compiling cfg-if v1.0.0
2022-12-23T09:13:18.9560660Z    Compiling unicode-ident v1.0.1
...
2022-12-23T09:13:34.0773740Z    Compiling matchers v0.1.0
2022-12-23T09:13:34.1658207Z error[E0425]: cannot find value `EISDIR` in crate `libc`
2022-12-23T09:13:34.1658825Z  --> /home/big-ci-user/.cargo/registry/src/github.com-1ecc6299db9ec823/remove_dir_all-0.7.0/src/unix.rs:8:50
2022-12-23T09:13:34.1658913Z   |
2022-12-23T09:13:34.1673668Z 8 |         Err(e) if e.raw_os_error() == Some(libc::EISDIR) =>
2022-12-23T09:13:34.1673837Z   |                                                  ^^^^^^ not found in `libc`
2022-12-23T09:13:34.1673855Z
2022-12-23T09:13:34.1722461Z For more information about this error, try `rustc --explain E0425`.
2022-12-23T09:13:34.1768674Z error: could not compile `remove_dir_all` due to previous error
2022-12-23T09:13:34.1769130Z warning: build failed, waiting for other jobs to finish...
2022-12-23T09:13:36.3050960Z Error: Compiling your crate to WebAssembly failed
2022-12-23T09:13:36.3051416Z Caused by: failed to execute `cargo build`: exited with exit status: 101
2022-12-23T09:13:36.3052686Z   full command: "cargo" "build" "--lib" "--release" "--target" "wasm32-unknown-unknown" "--features" "console_error_panic_hook
```

I've moved some things so that `roc_test_utils` is a `dev_depencency` again and I've added a cfg around the use of remove_dir_all to ignore it for wasm.