### PR TITLE
Don't build tutorial.html from .md on Netlify

### DIFF
--- a/www/build.sh
+++ b/www/build.sh
@@ -52,10 +52,11 @@ mv generated-docs/ www/build/builtins # move all the folders to build/builtins/
 # Manually add this tip to all the builtin docs.
 find www/build/builtins -type f -name 'index.html' -exec sed -i 's!</nav>!<div class="builtins-tip"><b>Tip:</b> <a href="/different-names">Some names</a> differ from other languages.</div></nav>!' {} \;
 
-echo 'Building tutorial.html from tutorial.md...'
-mkdir www/build/tutorial
-cargo run --release run www/generate_tutorial/src/tutorial.roc -- www/generate_tutorial/src/input/ www/build/tutorial/
-mv www/build/tutorial/tutorial.html www/build/tutorial/index.html
+# TODO to enable this, we either need to install LLVM on Netlify or get it working using the dev backend.
+# echo 'Building tutorial.html from tutorial.md...'
+# mkdir www/build/tutorial
+# cargo run --release run www/generate_tutorial/src/tutorial.roc -- www/generate_tutorial/src/input/ www/build/tutorial/
+# mv www/build/tutorial/tutorial.html www/build/tutorial/index.html
 
 echo 'Generating CLI example platform docs...'
 # Change ROC_DOCS_ROOT_DIR=builtins so that links will be generated relative to


### PR DESCRIPTION
We can't run Roc code in our Netlify build yet because the Netlify build server doesn't have LLVM installed. (Installing it is possible, but challenging, and would eat up a lot of minutes; regardless, we don't have it at the moment.)

As such, this currently makes all our Netlify builds fail with:

<img width="971" alt="Screen Shot 2022-12-26 at 3 20 41 PM" src="https://user-images.githubusercontent.com/1094080/209581107-30fb7e54-7e1c-4241-b594-0644414f46a1.png">

We can fix this in the future, but for now this PR reverts the change so we can have deploys working again!