### PR TITLE
Fix checking of recursive layouts in the ir-checker

### DIFF
--- a/crates/compiler/mono/src/layout.rs
+++ b/crates/compiler/mono/src/layout.rs
@@ -1254,9 +1254,9 @@ impl<'a> LambdaName<'a> {
 #[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct LambdaSet<'a> {
     /// collection of function names and their closure arguments
-    set: &'a [(Symbol, &'a [Layout<'a>])],
+    pub(crate) set: &'a [(Symbol, &'a [Layout<'a>])],
     /// how the closure will be represented at runtime
-    representation: Interned<Layout<'a>>,
+    pub(crate) representation: Interned<Layout<'a>>,
 }
 
 #[derive(Debug)]

--- a/crates/compiler/test_mono/src/tests.rs
+++ b/crates/compiler/test_mono/src/tests.rs
@@ -593,7 +593,7 @@ fn record_optional_field_function_use_default() {
     "#
 }
 
-#[mono_test(no_check)]
+#[mono_test(no_check = "https://github.com/roc-lang/roc/issues/4694")]
 fn quicksort_help() {
     // do we still need with_larger_debug_stack?
     r#"

--- a/crates/compiler/test_mono/src/tests.rs
+++ b/crates/compiler/test_mono/src/tests.rs
@@ -1311,7 +1311,7 @@ fn issue_2583_specialize_errors_behind_unified_branches() {
     )
 }
 
-#[mono_test(no_check)]
+#[mono_test]
 fn issue_2810() {
     indoc!(
         r#"
@@ -1530,7 +1530,7 @@ fn encode_derived_record() {
     )
 }
 
-#[mono_test(no_check)]
+#[mono_test]
 fn choose_correct_recursion_var_under_record() {
     indoc!(
         r#"
@@ -1925,7 +1925,7 @@ fn encode_derived_tag_one_field_string() {
     )
 }
 
-#[mono_test(no_check)]
+#[mono_test]
 fn polymorphic_expression_unification() {
     indoc!(
         r#"
@@ -2224,7 +2224,7 @@ fn issue_4749() {
     )
 }
 
-#[mono_test(mode = "test", no_check)]
+#[mono_test(mode = "test")]
 fn lambda_set_with_imported_toplevels_issue_4733() {
     indoc!(
         r###"

--- a/crates/compiler/test_mono_macros/src/lib.rs
+++ b/crates/compiler/test_mono_macros/src/lib.rs
@@ -10,9 +10,6 @@ pub fn mono_test(args: TokenStream, item: TokenStream) -> TokenStream {
     let mut mode = "exec".to_owned();
     for arg in syn::parse_macro_input!(args as syn::AttributeArgs) {
         use syn::{Lit, Meta, MetaNameValue, NestedMeta};
-        if matches!(&arg, NestedMeta::Meta(Meta::Path(p)) if p.is_ident("no_check")) {
-            no_check = true;
-        }
         if let NestedMeta::Meta(Meta::NameValue(MetaNameValue {
             path,
             eq_token: _,
@@ -21,6 +18,9 @@ pub fn mono_test(args: TokenStream, item: TokenStream) -> TokenStream {
         {
             if path.is_ident("mode") {
                 mode = s.value();
+            }
+            if path.is_ident("no_check") {
+                no_check = true;
             }
         }
     }


### PR DESCRIPTION
Follow layouts so that no recursive pointers appear in a layout without being wrapped by a recursive union, when comparing layouts in the IR checker.