### PR TITLE
Refactor and document the "niche" concept

### DIFF
--- a/crates/compiler/alias_analysis/src/lib.rs
+++ b/crates/compiler/alias_analysis/src/lib.rs
@@ -15,8 +15,7 @@ use roc_mono::ir::{
     Literal, ModifyRc, OptLevel, Proc, ProcLayout, SingleEntryPoint, Stmt,
 };
 use roc_mono::layout::{
-    Builtin, CapturesNiche, FieldOrderHash, Layout, Niche, RawFunctionLayout, STLayoutInterner,
-    UnionLayout,
+    Builtin, FieldOrderHash, Layout, Niche, RawFunctionLayout, STLayoutInterner, UnionLayout,
 };
 
 // just using one module for now

--- a/crates/compiler/gen_llvm/src/llvm/lowlevel.rs
+++ b/crates/compiler/gen_llvm/src/llvm/lowlevel.rs
@@ -2308,7 +2308,7 @@ pub(crate) fn run_higher_order_low_level<'a, 'ctx, 'env>(
                 func_spec,
                 function_name.name(),
                 argument_layouts,
-                function_name.captures_niche(),
+                function_name.niche(),
                 return_layout,
             );
 

--- a/crates/compiler/gen_wasm/src/backend.rs
+++ b/crates/compiler/gen_wasm/src/backend.rs
@@ -1249,7 +1249,7 @@ impl<'a, 'r> WasmBackend<'a, 'r> {
                 let proc_layout = ProcLayout {
                     arguments: arg_layouts,
                     result: **result,
-                    captures_niche: func_sym.captures_niche(),
+                    niche: func_sym.niche(),
                 };
                 self.expr_call_by_name(
                     func_sym.name(),

--- a/crates/compiler/gen_wasm/src/low_level.rs
+++ b/crates/compiler/gen_wasm/src/low_level.rs
@@ -2205,7 +2205,7 @@ pub fn call_higher_order_lowlevel<'a>(
         let passed_proc_layout = ProcLayout {
             arguments: argument_layouts,
             result: *result_layout,
-            captures_niche: fn_name.captures_niche(),
+            niche: fn_name.niche(),
         };
         let passed_proc_index = backend
             .proc_lookup
@@ -2249,13 +2249,13 @@ pub fn call_higher_order_lowlevel<'a>(
                 ProcLayout {
                     arguments: wrapper_arg_layouts.into_bump_slice(),
                     result: Layout::UNIT,
-                    captures_niche: fn_name.captures_niche(),
+                    niche: fn_name.niche(),
                 }
             }
             ProcSource::HigherOrderCompare(_) => ProcLayout {
                 arguments: wrapper_arg_layouts.into_bump_slice(),
                 result: *result_layout,
-                captures_niche: fn_name.captures_niche(),
+                niche: fn_name.niche(),
             },
             ProcSource::Roc | ProcSource::Helper => {
                 internal_error!("Should never reach here for {:?}", helper_proc_source)

--- a/crates/compiler/load_internal/src/file.rs
+++ b/crates/compiler/load_internal/src/file.rs
@@ -36,7 +36,7 @@ use roc_mono::ir::{
     UpdateModeIds,
 };
 use roc_mono::layout::{
-    CapturesNiche, LambdaName, Layout, LayoutCache, LayoutProblem, STLayoutInterner,
+    CapturesNiche, LambdaName, Layout, LayoutCache, LayoutProblem, Niche, STLayoutInterner,
 };
 use roc_packaging::cache::{self, RocCacheDir};
 #[cfg(not(target_family = "wasm"))]
@@ -3426,7 +3426,7 @@ fn proc_layout_for<'a>(
             roc_mono::ir::ProcLayout {
                 arguments: &[],
                 result: Layout::struct_no_name_order(&[]),
-                captures_niche: CapturesNiche::no_niche(),
+                niche: Niche::NONE,
             }
         }
     }

--- a/crates/compiler/load_internal/src/file.rs
+++ b/crates/compiler/load_internal/src/file.rs
@@ -35,9 +35,7 @@ use roc_mono::ir::{
     CapturedSymbols, ExternalSpecializations, PartialProc, Proc, ProcLayout, Procs, ProcsBase,
     UpdateModeIds,
 };
-use roc_mono::layout::{
-    CapturesNiche, LambdaName, Layout, LayoutCache, LayoutProblem, Niche, STLayoutInterner,
-};
+use roc_mono::layout::{LambdaName, Layout, LayoutCache, LayoutProblem, Niche, STLayoutInterner};
 use roc_packaging::cache::{self, RocCacheDir};
 #[cfg(not(target_family = "wasm"))]
 use roc_packaging::https::PackageMetadata;

--- a/crates/compiler/mono/src/borrow.rs
+++ b/crates/compiler/mono/src/borrow.rs
@@ -513,7 +513,7 @@ impl<'a> BorrowInfState<'a> {
                 ..
             } => {
                 let top_level =
-                    ProcLayout::new(self.arena, arg_layouts, name.captures_niche(), **ret_layout);
+                    ProcLayout::new(self.arena, arg_layouts, name.niche(), **ret_layout);
 
                 // get the borrow signature of the applied function
                 let ps = param_map
@@ -556,7 +556,7 @@ impl<'a> BorrowInfState<'a> {
                 let closure_layout = ProcLayout {
                     arguments: passed_function.argument_layouts,
                     result: passed_function.return_layout,
-                    captures_niche: passed_function.name.captures_niche(),
+                    niche: passed_function.name.niche(),
                 };
 
                 let function_ps =
@@ -739,8 +739,7 @@ impl<'a> BorrowInfState<'a> {
             Stmt::Ret(z),
         ) = (v, b)
         {
-            let top_level =
-                ProcLayout::new(self.arena, arg_layouts, g.captures_niche(), **ret_layout);
+            let top_level = ProcLayout::new(self.arena, arg_layouts, g.niche(), **ret_layout);
 
             if self.current_proc == g.name() && x == *z {
                 // anonymous functions (for which the ps may not be known)

--- a/crates/compiler/mono/src/code_gen_help/mod.rs
+++ b/crates/compiler/mono/src/code_gen_help/mod.rs
@@ -9,9 +9,7 @@ use crate::ir::{
     Call, CallSpecId, CallType, Expr, HostExposedLayouts, JoinPointId, ModifyRc, Proc, ProcLayout,
     SelfRecursive, Stmt, UpdateModeId,
 };
-use crate::layout::{
-    Builtin, CapturesNiche, LambdaName, Layout, Niche, STLayoutInterner, UnionLayout,
-};
+use crate::layout::{Builtin, LambdaName, Layout, Niche, STLayoutInterner, UnionLayout};
 
 mod equality;
 mod refcount;

--- a/crates/compiler/mono/src/code_gen_help/mod.rs
+++ b/crates/compiler/mono/src/code_gen_help/mod.rs
@@ -9,7 +9,9 @@ use crate::ir::{
     Call, CallSpecId, CallType, Expr, HostExposedLayouts, JoinPointId, ModifyRc, Proc, ProcLayout,
     SelfRecursive, Stmt, UpdateModeId,
 };
-use crate::layout::{Builtin, CapturesNiche, LambdaName, Layout, STLayoutInterner, UnionLayout};
+use crate::layout::{
+    Builtin, CapturesNiche, LambdaName, Layout, Niche, STLayoutInterner, UnionLayout,
+};
 
 mod equality;
 mod refcount;
@@ -404,23 +406,23 @@ impl<'a> CodeGenHelp<'a> {
             HelperOp::Inc => ProcLayout {
                 arguments: self.arena.alloc([*layout, self.layout_isize]),
                 result: LAYOUT_UNIT,
-                captures_niche: CapturesNiche::no_niche(),
+                niche: Niche::NONE,
             },
             HelperOp::Dec => ProcLayout {
                 arguments: self.arena.alloc([*layout]),
                 result: LAYOUT_UNIT,
-                captures_niche: CapturesNiche::no_niche(),
+                niche: Niche::NONE,
             },
             HelperOp::Reset => ProcLayout {
                 arguments: self.arena.alloc([*layout]),
                 result: *layout,
-                captures_niche: CapturesNiche::no_niche(),
+                niche: Niche::NONE,
             },
             HelperOp::DecRef(_) => unreachable!("No generated Proc for DecRef"),
             HelperOp::Eq => ProcLayout {
                 arguments: self.arena.alloc([*layout, *layout]),
                 result: LAYOUT_BOOL,
-                captures_niche: CapturesNiche::no_niche(),
+                niche: Niche::NONE,
             },
         };
 

--- a/crates/compiler/mono/src/debug/checker.rs
+++ b/crates/compiler/mono/src/debug/checker.rs
@@ -556,7 +556,7 @@ impl<'a, 'r> Ctx<'a, 'r> {
                 let proc_layout = ProcLayout {
                     arguments: arg_layouts,
                     result: **ret_layout,
-                    captures_niche: name.captures_niche(),
+                    niche: name.niche(),
                 };
                 if !self.procs.contains_key(&(name.name(), proc_layout)) {
                     let similar = self

--- a/crates/compiler/mono/src/debug/report.rs
+++ b/crates/compiler/mono/src/debug/report.rs
@@ -6,7 +6,7 @@ use ven_pretty::{Arena, DocAllocator, DocBuilder};
 
 use crate::{
     ir::{Parens, ProcLayout},
-    layout::{Layout, Niche},
+    layout::Layout,
 };
 
 use super::{
@@ -478,20 +478,9 @@ where
         f.reflow(" -> "),
         result.to_doc(f, interner, Parens::NotNeeded),
     ]);
-    let niche = match captures_niche {
-        Niche::NONE => f.reflow("(no niche)"),
-        Niche::Captures(captures_niche) => f.concat([
-            f.reflow("(niche {"),
-            f.intersperse(
-                captures_niche
-                    .captures()
-                    .iter()
-                    .map(|&c| interner.get(c).to_doc(f, interner, Parens::NotNeeded)),
-                f.reflow(", "),
-            ),
-            f.reflow("})"),
-        ]),
-    };
+    let niche = (f.text("("))
+        .append(captures_niche.to_doc(f, interner))
+        .append(f.text(")"));
     f.concat([fun, f.space(), niche])
 }
 

--- a/crates/compiler/mono/src/debug/report.rs
+++ b/crates/compiler/mono/src/debug/report.rs
@@ -6,7 +6,7 @@ use ven_pretty::{Arena, DocAllocator, DocBuilder};
 
 use crate::{
     ir::{Parens, ProcLayout},
-    layout::{CapturesNiche, Layout},
+    layout::{Layout, Niche},
 };
 
 use super::{
@@ -465,7 +465,7 @@ where
     let ProcLayout {
         arguments,
         result,
-        captures_niche,
+        niche: captures_niche,
     } = proc_layout;
     let args = f.intersperse(
         arguments
@@ -478,20 +478,19 @@ where
         f.reflow(" -> "),
         result.to_doc(f, interner, Parens::NotNeeded),
     ]);
-    let niche = if captures_niche == CapturesNiche::no_niche() {
-        f.reflow("(no niche)")
-    } else {
-        f.concat([
+    let niche = match captures_niche {
+        Niche::NONE => f.reflow("(no niche)"),
+        Niche::Captures(captures_niche) => f.concat([
             f.reflow("(niche {"),
             f.intersperse(
                 captures_niche
-                    .0
+                    .captures()
                     .iter()
                     .map(|&c| interner.get(c).to_doc(f, interner, Parens::NotNeeded)),
                 f.reflow(", "),
             ),
             f.reflow("})"),
-        ])
+        ]),
     };
     f.concat([fun, f.space(), niche])
 }

--- a/crates/compiler/mono/src/inc_dec.rs
+++ b/crates/compiler/mono/src/inc_dec.rs
@@ -595,7 +595,7 @@ impl<'a, 'i> Context<'a, 'i> {
                 ..
             } => {
                 let top_level =
-                    ProcLayout::new(self.arena, arg_layouts, name.captures_niche(), **ret_layout);
+                    ProcLayout::new(self.arena, arg_layouts, name.niche(), **ret_layout);
 
                 // get the borrow signature
                 let ps = self
@@ -645,7 +645,7 @@ impl<'a, 'i> Context<'a, 'i> {
         let function_layout = ProcLayout {
             arguments: passed_function.argument_layouts,
             result: passed_function.return_layout,
-            captures_niche: passed_function.name.captures_niche(),
+            niche: passed_function.name.niche(),
         };
 
         let function_ps = match self

--- a/crates/compiler/mono/src/layout.rs
+++ b/crates/compiler/mono/src/layout.rs
@@ -1289,7 +1289,7 @@ impl<'a> Niche<'a> {
                 alloc.intersperse(
                     captures
                         .iter()
-                        .map(|c| c.to_doc(alloc, interner, Parens::NotNeeded)),
+                        .map(|c| interner.get(*c).to_doc(alloc, interner, Parens::NotNeeded)),
                     alloc.reflow(", "),
                 ),
                 alloc.reflow("})"),

--- a/crates/compiler/mono/src/layout.rs
+++ b/crates/compiler/mono/src/layout.rs
@@ -1241,18 +1241,28 @@ impl std::fmt::Debug for LambdaSet<'_> {
 ///
 /// See also https://github.com/roc-lang/roc/issues/3336.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
-pub struct CapturesNiche<'a>(pub(crate) &'a [InLayout<'a>]);
+pub struct CapturesNiche<'a>(&'a [InLayout<'a>]);
 
-impl CapturesNiche<'_> {
-    pub fn no_niche() -> Self {
-        Self(&[])
+impl<'a> CapturesNiche<'a> {
+    pub(crate) fn captures(&self) -> &'a [Layout<'a>] {
+        self.0
     }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub enum Niche<'a> {
+    /// A niche for a proc are its captures.
+    Captures(CapturesNiche<'a>),
+}
+
+impl<'a> Niche<'a> {
+    pub const NONE: Niche<'a> = Niche::Captures(CapturesNiche(&[]));
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub struct LambdaName<'a> {
     name: Symbol,
-    captures_niche: CapturesNiche<'a>,
+    niche: Niche<'a>,
 }
 
 impl<'a> LambdaName<'a> {
@@ -1262,29 +1272,29 @@ impl<'a> LambdaName<'a> {
     }
 
     #[inline(always)]
-    pub fn captures_niche(&self) -> CapturesNiche<'a> {
-        self.captures_niche
+    pub fn niche(&self) -> Niche<'a> {
+        self.niche
     }
 
     #[inline(always)]
-    pub fn no_captures(&self) -> bool {
-        self.captures_niche.0.is_empty()
+    pub(crate) fn no_captures(&self) -> bool {
+        match self.niche {
+            Niche::NONE => true,
+            Niche::Captures(captures) => captures.0.is_empty(),
+        }
     }
 
     #[inline(always)]
     pub fn no_niche(name: Symbol) -> Self {
         Self {
             name,
-            captures_niche: CapturesNiche::no_niche(),
+            niche: Niche::NONE,
         }
     }
 
     #[inline(always)]
-    pub fn replace_name(&self, name: Symbol) -> Self {
-        Self {
-            name,
-            captures_niche: self.captures_niche,
-        }
+    pub(crate) fn replace_name(&self, name: Symbol) -> Self {
+        Self { name, ..*self }
     }
 }
 
@@ -1377,9 +1387,12 @@ impl<'a> LambdaSet<'a> {
     }
 
     pub fn iter_set(&self) -> impl ExactSizeIterator<Item = LambdaName<'a>> {
-        self.set.iter().map(|(name, captures_layouts)| LambdaName {
-            name: *name,
-            captures_niche: CapturesNiche(captures_layouts),
+        self.set.iter().map(|(name, captures_layouts)| {
+            let niche = match captures_layouts {
+                [] => Niche::NONE,
+                _ => Niche::Captures(CapturesNiche(captures_layouts)),
+            };
+            LambdaName { name: *name, niche }
         })
     }
 
@@ -1403,12 +1416,17 @@ impl<'a> LambdaSet<'a> {
     {
         debug_assert!(self.contains(lambda_name.name));
 
+        let captures = match lambda_name.niche {
+            Niche::Captures(captures) => captures.0,
+            Niche::NONE => &[],
+        };
+
         let comparator = |other_name: Symbol, other_captures_layouts: &[InLayout]| {
             other_name == lambda_name.name
                 // Make sure all captures are equal
                 && other_captures_layouts
                     .iter()
-                    .eq(lambda_name.captures_niche.0)
+                    .eq(captures)
         };
 
         self.layout_for_member(interner, comparator)
@@ -1455,7 +1473,7 @@ impl<'a> LambdaSet<'a> {
 
         LambdaName {
             name: *name,
-            captures_niche: CapturesNiche(layouts),
+            niche: Niche::Captures(CapturesNiche(layouts)),
         }
     }
 
@@ -1658,6 +1676,7 @@ impl<'a> LambdaSet<'a> {
         lambda_name: LambdaName<'a>,
         argument_layouts: &'a [Layout<'a>],
     ) -> &'a [Layout<'a>] {
+        let Niche::Captures(CapturesNiche(captures)) = lambda_name.niche;
         // TODO(https://github.com/roc-lang/roc/issues/4831): we should turn on this debug-assert;
         // however, currently it causes false-positives, because host-exposed functions that are
         // function pointers to platform-exposed functions are compiled as if they are proper
@@ -1674,7 +1693,7 @@ impl<'a> LambdaSet<'a> {
         // );
 
         // If we don't capture, there is nothing to extend.
-        if lambda_name.captures_niche.0.is_empty() {
+        if captures.is_empty() {
             argument_layouts
         } else {
             let mut arguments = Vec::with_capacity_in(argument_layouts.len() + 1, arena);

--- a/crates/compiler/mono/src/layout.rs
+++ b/crates/compiler/mono/src/layout.rs
@@ -1418,7 +1418,6 @@ impl<'a> LambdaSet<'a> {
 
         let captures = match lambda_name.niche {
             Niche::Captures(captures) => captures.0,
-            Niche::NONE => &[],
         };
 
         let comparator = |other_name: Symbol, other_captures_layouts: &[InLayout]| {

--- a/crates/compiler/mono/src/layout.rs
+++ b/crates/compiler/mono/src/layout.rs
@@ -1241,9 +1241,9 @@ impl std::fmt::Debug for LambdaSet<'_> {
 ///
 /// See also https://github.com/roc-lang/roc/issues/3336.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
-pub struct CapturesNiche<'a>(&'a [InLayout<'a>]);
+pub struct Captures<'a>(&'a [InLayout<'a>]);
 
-impl<'a> CapturesNiche<'a> {
+impl<'a> Captures<'a> {
     pub(crate) fn captures(&self) -> &'a [Layout<'a>] {
         self.0
     }
@@ -1252,11 +1252,11 @@ impl<'a> CapturesNiche<'a> {
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum Niche<'a> {
     /// A niche for a proc are its captures.
-    Captures(CapturesNiche<'a>),
+    Captures(Captures<'a>),
 }
 
 impl<'a> Niche<'a> {
-    pub const NONE: Niche<'a> = Niche::Captures(CapturesNiche(&[]));
+    pub const NONE: Niche<'a> = Niche::Captures(Captures(&[]));
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
@@ -1390,7 +1390,7 @@ impl<'a> LambdaSet<'a> {
         self.set.iter().map(|(name, captures_layouts)| {
             let niche = match captures_layouts {
                 [] => Niche::NONE,
-                _ => Niche::Captures(CapturesNiche(captures_layouts)),
+                _ => Niche::Captures(Captures(captures_layouts)),
             };
             LambdaName { name: *name, niche }
         })
@@ -1472,7 +1472,7 @@ impl<'a> LambdaSet<'a> {
 
         LambdaName {
             name: *name,
-            niche: Niche::Captures(CapturesNiche(layouts)),
+            niche: Niche::Captures(Captures(layouts)),
         }
     }
 

--- a/crates/compiler/mono/src/layout.rs
+++ b/crates/compiler/mono/src/layout.rs
@@ -1711,7 +1711,7 @@ impl<'a> LambdaSet<'a> {
         lambda_name: LambdaName<'a>,
         argument_layouts: &'a [Layout<'a>],
     ) -> &'a [Layout<'a>] {
-        let Niche::Captures(CapturesNiche(captures)) = lambda_name.niche;
+        let Niche(NichePriv::Captures(captures)) = lambda_name.niche;
         // TODO(https://github.com/roc-lang/roc/issues/4831): we should turn on this debug-assert;
         // however, currently it causes false-positives, because host-exposed functions that are
         // function pointers to platform-exposed functions are compiled as if they are proper

--- a/crates/compiler/test_gen/src/wasm_linking.rs
+++ b/crates/compiler/test_gen/src/wasm_linking.rs
@@ -17,7 +17,7 @@ use roc_mono::ir::{
     Call, CallType, Expr, HostExposedLayouts, Literal, Proc, ProcLayout, SelfRecursive, Stmt,
     UpdateModeId,
 };
-use roc_mono::layout::{Builtin, Captures, LambdaName, Layout, STLayoutInterner};
+use roc_mono::layout::{Builtin, LambdaName, Layout, Niche, STLayoutInterner};
 use roc_wasm_interp::{wasi, ImportDispatcher, Instance, WasiDispatcher};
 use roc_wasm_module::{Value, WasmModule};
 
@@ -124,7 +124,7 @@ fn build_app_mono<'a>(
     let proc_layout = ProcLayout {
         arguments: &[],
         result: int_layout,
-        niche: Captures::no_niche(),
+        niche: Niche::NONE,
     };
 
     let mut app = MutMap::default();

--- a/crates/compiler/test_gen/src/wasm_linking.rs
+++ b/crates/compiler/test_gen/src/wasm_linking.rs
@@ -124,7 +124,7 @@ fn build_app_mono<'a>(
     let proc_layout = ProcLayout {
         arguments: &[],
         result: int_layout,
-        captures_niche: CapturesNiche::no_niche(),
+        niche: CapturesNiche::no_niche(),
     };
 
     let mut app = MutMap::default();

--- a/crates/compiler/test_gen/src/wasm_linking.rs
+++ b/crates/compiler/test_gen/src/wasm_linking.rs
@@ -17,7 +17,7 @@ use roc_mono::ir::{
     Call, CallType, Expr, HostExposedLayouts, Literal, Proc, ProcLayout, SelfRecursive, Stmt,
     UpdateModeId,
 };
-use roc_mono::layout::{Builtin, CapturesNiche, LambdaName, Layout, STLayoutInterner};
+use roc_mono::layout::{Builtin, Captures, LambdaName, Layout, STLayoutInterner};
 use roc_wasm_interp::{wasi, ImportDispatcher, Instance, WasiDispatcher};
 use roc_wasm_module::{Value, WasmModule};
 
@@ -124,7 +124,7 @@ fn build_app_mono<'a>(
     let proc_layout = ProcLayout {
         arguments: &[],
         result: int_layout,
-        niche: CapturesNiche::no_niche(),
+        niche: Captures::no_niche(),
     };
 
     let mut app = MutMap::default();

--- a/crates/repl_eval/src/eval.rs
+++ b/crates/repl_eval/src/eval.rs
@@ -62,7 +62,7 @@ pub fn jit_to_ast<'a, A: ReplApp<'a>>(
         ProcLayout {
             arguments: [],
             result,
-            captures_niche: _,
+            niche: _,
         } => {
             // This is a thunk, which cannot be defined in userspace, so we know
             // it's `main` and can be executed.

--- a/crates/repl_expect/src/lib.rs
+++ b/crates/repl_expect/src/lib.rs
@@ -5,7 +5,7 @@ use {
     roc_module::symbol::Interns,
     roc_mono::{
         ir::ProcLayout,
-        layout::{CapturesNiche, Layout, LayoutCache},
+        layout::{Layout, LayoutCache, Niche},
     },
     roc_parse::ast::Expr,
     roc_repl_eval::{eval::jit_to_ast, ReplAppMemory},
@@ -67,7 +67,7 @@ pub fn get_values<'a>(
             let proc_layout = ProcLayout {
                 arguments: &[],
                 result: layout,
-                captures_niche: CapturesNiche::no_niche(),
+                niche: Niche::NONE,
             };
 
             jit_to_ast(


### PR DESCRIPTION
Renames `CaptureNiche` to the more generic `Niche` so that we can model other distinguishing factors in the future, adds documentation better describing what this is all about and why we need it, and hides the internal representation from everyone but layout.