### PR TITLE
Eta-reduced thunk niches

### DIFF
--- a/crates/compiler/alias_analysis/src/lib.rs
+++ b/crates/compiler/alias_analysis/src/lib.rs
@@ -14,7 +14,7 @@ use roc_mono::ir::{
     Literal, ModifyRc, OptLevel, Proc, ProcLayout, SingleEntryPoint, Stmt,
 };
 use roc_mono::layout::{
-    Builtin, CapturesNiche, FieldOrderHash, Layout, RawFunctionLayout, STLayoutInterner,
+    Builtin, CapturesNiche, FieldOrderHash, Layout, Niche, RawFunctionLayout, STLayoutInterner,
     UnionLayout,
 };
 
@@ -30,7 +30,7 @@ pub fn func_name_bytes(proc: &Proc) -> [u8; SIZE] {
     let bytes = func_name_bytes_help(
         proc.name.name(),
         proc.args.iter().map(|x| x.0),
-        proc.name.captures_niche(),
+        proc.name.niche(),
         &proc.ret_layout,
     );
     bytes
@@ -74,7 +74,7 @@ impl TagUnionId {
 pub fn func_name_bytes_help<'a, I>(
     symbol: Symbol,
     argument_layouts: I,
-    captures_niche: CapturesNiche<'a>,
+    niche: Niche<'a>,
     return_layout: &Layout<'a>,
 ) -> [u8; SIZE]
 where
@@ -93,7 +93,7 @@ where
             layout.hash(&mut hasher);
         }
 
-        captures_niche.hash(&mut hasher);
+        niche.hash(&mut hasher);
 
         return_layout.hash(&mut hasher);
 
@@ -188,22 +188,14 @@ where
                     match layout {
                         RawFunctionLayout::Function(_, _, _) => {
                             let it = top_level.arguments.iter().copied();
-                            let bytes = func_name_bytes_help(
-                                *symbol,
-                                it,
-                                CapturesNiche::no_niche(),
-                                &top_level.result,
-                            );
+                            let bytes =
+                                func_name_bytes_help(*symbol, it, Niche::NONE, &top_level.result);
 
                             host_exposed_functions.push((bytes, top_level.arguments));
                         }
                         RawFunctionLayout::ZeroArgumentThunk(_) => {
-                            let bytes = func_name_bytes_help(
-                                *symbol,
-                                [],
-                                CapturesNiche::no_niche(),
-                                &top_level.result,
-                            );
+                            let bytes =
+                                func_name_bytes_help(*symbol, [], Niche::NONE, &top_level.result);
 
                             host_exposed_functions.push((bytes, top_level.arguments));
                         }
@@ -236,7 +228,7 @@ where
                 let roc_main_bytes = func_name_bytes_help(
                     entry_point_symbol,
                     entry_point_layout.arguments.iter().copied(),
-                    CapturesNiche::no_niche(),
+                    Niche::NONE,
                     &entry_point_layout.result,
                 );
                 let roc_main = FuncName(&roc_main_bytes);
@@ -264,19 +256,14 @@ where
                         field_order_hash: FieldOrderHash::from_ordered_fields(&[]),
                         field_layouts: &[],
                     },
-                    captures_niche: CapturesNiche::no_niche(),
+                    niche: Niche::NONE,
                 };
 
                 let host_exposed: Vec<_> = symbols
                     .iter()
                     .map(|symbol| {
                         (
-                            func_name_bytes_help(
-                                *symbol,
-                                [],
-                                CapturesNiche::no_niche(),
-                                &layout.result,
-                            ),
+                            func_name_bytes_help(*symbol, [], Niche::NONE, &layout.result),
                             [].as_slice(),
                         )
                     })
@@ -807,7 +794,7 @@ fn call_spec<'a>(
 
             let arg_value_id = build_tuple_value(builder, env, block, call.arguments)?;
             let args_it = arg_layouts.iter().copied();
-            let captures_niche = name.captures_niche();
+            let captures_niche = name.niche();
             let bytes = func_name_bytes_help(name.name(), args_it, captures_niche, ret_layout);
             let name = FuncName(&bytes);
             let module = MOD_APP;
@@ -859,7 +846,7 @@ fn call_spec<'a>(
             let update_mode_var = UpdateModeVar(&mode);
 
             let args_it = passed_function.argument_layouts.iter().copied();
-            let captures_niche = passed_function.name.captures_niche();
+            let captures_niche = passed_function.name.niche();
             let bytes = func_name_bytes_help(
                 passed_function.name.name(),
                 args_it,

--- a/crates/compiler/alias_analysis/src/lib.rs
+++ b/crates/compiler/alias_analysis/src/lib.rs
@@ -14,8 +14,7 @@ use roc_mono::ir::{
     Literal, ModifyRc, OptLevel, Proc, ProcLayout, SingleEntryPoint, Stmt,
 };
 use roc_mono::layout::{
-    Builtin, CapturesNiche, FieldOrderHash, Layout, Niche, RawFunctionLayout, STLayoutInterner,
-    UnionLayout,
+    Builtin, FieldOrderHash, Layout, Niche, RawFunctionLayout, STLayoutInterner, UnionLayout,
 };
 
 // just using one module for now

--- a/crates/compiler/gen_llvm/src/llvm/build.rs
+++ b/crates/compiler/gen_llvm/src/llvm/build.rs
@@ -44,8 +44,8 @@ use roc_mono::ir::{
     OptLevel, ProcLayout, SingleEntryPoint,
 };
 use roc_mono::layout::{
-    Builtin, CapturesNiche, LambdaName, LambdaSet, Layout, LayoutIds, RawFunctionLayout,
-    STLayoutInterner, TagIdIntType, UnionLayout,
+    Builtin, LambdaName, LambdaSet, Layout, LayoutIds, Niche, RawFunctionLayout, STLayoutInterner,
+    TagIdIntType, UnionLayout,
 };
 use roc_std::RocDec;
 use roc_target::{PtrWidth, TargetInfo};
@@ -615,12 +615,8 @@ fn promote_to_main_function<'a, 'ctx, 'env>(
     top_level: ProcLayout<'a>,
 ) -> (&'static str, FunctionValue<'ctx>) {
     let it = top_level.arguments.iter().copied();
-    let bytes = roc_alias_analysis::func_name_bytes_help(
-        symbol,
-        it,
-        CapturesNiche::no_niche(),
-        &top_level.result,
-    );
+    let bytes =
+        roc_alias_analysis::func_name_bytes_help(symbol, it, Niche::NONE, &top_level.result);
     let func_name = FuncName(&bytes);
     let func_solutions = mod_solutions.func_solutions(func_name).unwrap();
 
@@ -632,14 +628,8 @@ fn promote_to_main_function<'a, 'ctx, 'env>(
     );
 
     // NOTE fake layout; it is only used for debug prints
-    let roc_main_fn = function_value_by_func_spec(
-        env,
-        *func_spec,
-        symbol,
-        &[],
-        CapturesNiche::no_niche(),
-        &Layout::UNIT,
-    );
+    let roc_main_fn =
+        function_value_by_func_spec(env, *func_spec, symbol, &[], Niche::NONE, &Layout::UNIT);
 
     let main_fn_name = "$Test.main";
 
@@ -674,12 +664,8 @@ fn promote_to_wasm_test_wrapper<'a, 'ctx, 'env>(
     let main_fn_name = "test_wrapper";
 
     let it = top_level.arguments.iter().copied();
-    let bytes = roc_alias_analysis::func_name_bytes_help(
-        symbol,
-        it,
-        CapturesNiche::no_niche(),
-        &top_level.result,
-    );
+    let bytes =
+        roc_alias_analysis::func_name_bytes_help(symbol, it, Niche::NONE, &top_level.result);
     let func_name = FuncName(&bytes);
     let func_solutions = mod_solutions.func_solutions(func_name).unwrap();
 
@@ -691,14 +677,8 @@ fn promote_to_wasm_test_wrapper<'a, 'ctx, 'env>(
     );
 
     // NOTE fake layout; it is only used for debug prints
-    let roc_main_fn = function_value_by_func_spec(
-        env,
-        *func_spec,
-        symbol,
-        &[],
-        CapturesNiche::no_niche(),
-        &Layout::UNIT,
-    );
+    let roc_main_fn =
+        function_value_by_func_spec(env, *func_spec, symbol, &[], Niche::NONE, &Layout::UNIT);
 
     let output_type = match roc_main_fn.get_type().get_return_type() {
         Some(return_type) => {
@@ -3344,7 +3324,7 @@ fn expose_function_to_host<'a, 'ctx, 'env>(
     symbol: Symbol,
     roc_function: FunctionValue<'ctx>,
     arguments: &'a [Layout<'a>],
-    captures_niche: CapturesNiche<'a>,
+    niche: Niche<'a>,
     return_layout: Layout<'a>,
     layout_ids: &mut LayoutIds<'a>,
 ) {
@@ -3353,7 +3333,7 @@ fn expose_function_to_host<'a, 'ctx, 'env>(
     let proc_layout = ProcLayout {
         arguments,
         result: return_layout,
-        captures_niche,
+        niche,
     };
 
     let c_function_name: String = layout_ids
@@ -4388,12 +4368,12 @@ pub fn build_procedures_expose_expects<'a, 'ctx, 'env>(
         Some(&std::env::temp_dir().join("test.ll")),
     );
 
-    let captures_niche = CapturesNiche::no_niche();
+    let captures_niche = Niche::NONE;
 
     let top_level = ProcLayout {
         arguments: &[],
         result: Layout::UNIT,
-        captures_niche,
+        niche: captures_niche,
     };
 
     let mut expect_names = Vec::with_capacity_in(expects.len(), env.arena);
@@ -4604,7 +4584,7 @@ fn build_proc_header<'a, 'ctx, 'env>(
             symbol,
             fn_val,
             arguments.into_bump_slice(),
-            proc.name.captures_niche(),
+            proc.name.niche(),
             proc.ret_layout,
             layout_ids,
         );
@@ -4651,7 +4631,7 @@ fn expose_alias_to_host<'a, 'ctx, 'env>(
             let bytes = roc_alias_analysis::func_name_bytes_help(
                 exposed_function_symbol,
                 it,
-                CapturesNiche::no_niche(),
+                Niche::NONE,
                 &top_level.result,
             );
             let func_name = FuncName(&bytes);
@@ -4670,7 +4650,7 @@ fn expose_alias_to_host<'a, 'ctx, 'env>(
                         *func_spec,
                         exposed_function_symbol,
                         top_level.arguments,
-                        CapturesNiche::no_niche(),
+                        Niche::NONE,
                         &top_level.result,
                     )
                 }
@@ -4989,19 +4969,19 @@ pub(crate) fn function_value_by_func_spec<'a, 'ctx, 'env>(
     func_spec: FuncSpec,
     symbol: Symbol,
     arguments: &[Layout<'a>],
-    captures_niche: CapturesNiche<'a>,
+    niche: Niche<'a>,
     result: &Layout<'a>,
 ) -> FunctionValue<'ctx> {
     let fn_name = func_spec_name(env.arena, &env.interns, symbol, func_spec);
     let fn_name = fn_name.as_str();
 
-    function_value_by_name_help(env, arguments, captures_niche, result, symbol, fn_name)
+    function_value_by_name_help(env, arguments, niche, result, symbol, fn_name)
 }
 
 fn function_value_by_name_help<'a, 'ctx, 'env>(
     env: &Env<'a, 'ctx, 'env>,
     arguments: &[Layout<'a>],
-    _captures_niche: CapturesNiche<'a>,
+    _niche: Niche<'a>,
     result: &Layout<'a>,
     symbol: Symbol,
     fn_name: &str,
@@ -5051,7 +5031,7 @@ fn roc_call_with_args<'a, 'ctx, 'env>(
         func_spec,
         name.name(),
         argument_layouts,
-        name.captures_niche(),
+        name.niche(),
         result_layout,
     );
 

--- a/crates/compiler/gen_llvm/src/llvm/lowlevel.rs
+++ b/crates/compiler/gen_llvm/src/llvm/lowlevel.rs
@@ -2252,7 +2252,7 @@ pub(crate) fn run_higher_order_low_level<'a, 'ctx, 'env>(
                 func_spec,
                 function_name.name(),
                 argument_layouts,
-                function_name.captures_niche(),
+                function_name.niche(),
                 return_layout,
             );
 

--- a/crates/compiler/gen_wasm/src/backend.rs
+++ b/crates/compiler/gen_wasm/src/backend.rs
@@ -1239,7 +1239,7 @@ impl<'a> WasmBackend<'a> {
                 let proc_layout = ProcLayout {
                     arguments: arg_layouts,
                     result: **result,
-                    captures_niche: func_sym.captures_niche(),
+                    niche: func_sym.niche(),
                 };
                 self.expr_call_by_name(
                     func_sym.name(),

--- a/crates/compiler/gen_wasm/src/low_level.rs
+++ b/crates/compiler/gen_wasm/src/low_level.rs
@@ -2199,7 +2199,7 @@ pub fn call_higher_order_lowlevel<'a>(
         let passed_proc_layout = ProcLayout {
             arguments: argument_layouts,
             result: *result_layout,
-            captures_niche: fn_name.captures_niche(),
+            niche: fn_name.niche(),
         };
         let passed_proc_index = backend
             .proc_lookup
@@ -2241,13 +2241,13 @@ pub fn call_higher_order_lowlevel<'a>(
                 ProcLayout {
                     arguments: wrapper_arg_layouts.into_bump_slice(),
                     result: Layout::UNIT,
-                    captures_niche: fn_name.captures_niche(),
+                    niche: fn_name.niche(),
                 }
             }
             ProcSource::HigherOrderCompare(_) => ProcLayout {
                 arguments: wrapper_arg_layouts.into_bump_slice(),
                 result: *result_layout,
-                captures_niche: fn_name.captures_niche(),
+                niche: fn_name.niche(),
             },
             ProcSource::Roc | ProcSource::Helper => {
                 internal_error!("Should never reach here for {:?}", helper_proc_source)

--- a/crates/compiler/load_internal/src/file.rs
+++ b/crates/compiler/load_internal/src/file.rs
@@ -35,9 +35,7 @@ use roc_mono::ir::{
     CapturedSymbols, ExternalSpecializations, PartialProc, Proc, ProcLayout, Procs, ProcsBase,
     UpdateModeIds,
 };
-use roc_mono::layout::{
-    CapturesNiche, LambdaName, Layout, LayoutCache, LayoutProblem, Niche, STLayoutInterner,
-};
+use roc_mono::layout::{LambdaName, Layout, LayoutCache, LayoutProblem, Niche, STLayoutInterner};
 use roc_packaging::cache::{self, RocCacheDir};
 #[cfg(not(target_family = "wasm"))]
 use roc_packaging::https::PackageMetadata;

--- a/crates/compiler/load_internal/src/file.rs
+++ b/crates/compiler/load_internal/src/file.rs
@@ -36,7 +36,7 @@ use roc_mono::ir::{
     UpdateModeIds,
 };
 use roc_mono::layout::{
-    CapturesNiche, LambdaName, Layout, LayoutCache, LayoutProblem, STLayoutInterner,
+    CapturesNiche, LambdaName, Layout, LayoutCache, LayoutProblem, Niche, STLayoutInterner,
 };
 use roc_packaging::cache::{self, RocCacheDir};
 #[cfg(not(target_family = "wasm"))]
@@ -3374,7 +3374,7 @@ fn proc_layout_for<'a>(
             roc_mono::ir::ProcLayout {
                 arguments: &[],
                 result: Layout::struct_no_name_order(&[]),
-                captures_niche: CapturesNiche::no_niche(),
+                niche: Niche::NONE,
             }
         }
     }

--- a/crates/compiler/mono/src/borrow.rs
+++ b/crates/compiler/mono/src/borrow.rs
@@ -1,7 +1,9 @@
 use std::collections::HashMap;
 use std::hash::Hash;
 
-use crate::ir::{Expr, HigherOrderLowLevel, JoinPointId, Param, Proc, ProcLayout, Stmt};
+use crate::ir::{
+    Expr, HigherOrderLowLevel, JoinPointId, Param, PassedFunction, Proc, ProcLayout, Stmt,
+};
 use crate::layout::Layout;
 use bumpalo::collections::Vec;
 use bumpalo::Bump;
@@ -976,7 +978,12 @@ fn call_info_call<'a>(call: &crate::ir::Call<'a>, info: &mut CallInfo<'a>) {
         }
         Foreign { .. } => {}
         LowLevel { .. } => {}
-        HigherOrder(_) => {}
+        HigherOrder(HigherOrderLowLevel {
+            passed_function: PassedFunction { name, .. },
+            ..
+        }) => {
+            info.keys.push(name.name());
+        }
     }
 }
 

--- a/crates/compiler/mono/src/borrow.rs
+++ b/crates/compiler/mono/src/borrow.rs
@@ -511,7 +511,7 @@ impl<'a> BorrowInfState<'a> {
                 ..
             } => {
                 let top_level =
-                    ProcLayout::new(self.arena, arg_layouts, name.captures_niche(), **ret_layout);
+                    ProcLayout::new(self.arena, arg_layouts, name.niche(), **ret_layout);
 
                 // get the borrow signature of the applied function
                 let ps = param_map
@@ -554,7 +554,7 @@ impl<'a> BorrowInfState<'a> {
                 let closure_layout = ProcLayout {
                     arguments: passed_function.argument_layouts,
                     result: passed_function.return_layout,
-                    captures_niche: passed_function.name.captures_niche(),
+                    niche: passed_function.name.niche(),
                 };
 
                 let function_ps =
@@ -737,8 +737,7 @@ impl<'a> BorrowInfState<'a> {
             Stmt::Ret(z),
         ) = (v, b)
         {
-            let top_level =
-                ProcLayout::new(self.arena, arg_layouts, g.captures_niche(), **ret_layout);
+            let top_level = ProcLayout::new(self.arena, arg_layouts, g.niche(), **ret_layout);
 
             if self.current_proc == g.name() && x == *z {
                 // anonymous functions (for which the ps may not be known)

--- a/crates/compiler/mono/src/code_gen_help/mod.rs
+++ b/crates/compiler/mono/src/code_gen_help/mod.rs
@@ -8,7 +8,9 @@ use crate::ir::{
     Call, CallSpecId, CallType, Expr, HostExposedLayouts, JoinPointId, ModifyRc, Proc, ProcLayout,
     SelfRecursive, Stmt, UpdateModeId,
 };
-use crate::layout::{Builtin, CapturesNiche, LambdaName, Layout, STLayoutInterner, UnionLayout};
+use crate::layout::{
+    Builtin, CapturesNiche, LambdaName, Layout, Niche, STLayoutInterner, UnionLayout,
+};
 
 mod equality;
 mod refcount;
@@ -382,23 +384,23 @@ impl<'a> CodeGenHelp<'a> {
             HelperOp::Inc => ProcLayout {
                 arguments: self.arena.alloc([*layout, self.layout_isize]),
                 result: LAYOUT_UNIT,
-                captures_niche: CapturesNiche::no_niche(),
+                niche: Niche::NONE,
             },
             HelperOp::Dec => ProcLayout {
                 arguments: self.arena.alloc([*layout]),
                 result: LAYOUT_UNIT,
-                captures_niche: CapturesNiche::no_niche(),
+                niche: Niche::NONE,
             },
             HelperOp::Reset => ProcLayout {
                 arguments: self.arena.alloc([*layout]),
                 result: *layout,
-                captures_niche: CapturesNiche::no_niche(),
+                niche: Niche::NONE,
             },
             HelperOp::DecRef(_) => unreachable!("No generated Proc for DecRef"),
             HelperOp::Eq => ProcLayout {
                 arguments: self.arena.alloc([*layout, *layout]),
                 result: LAYOUT_BOOL,
-                captures_niche: CapturesNiche::no_niche(),
+                niche: Niche::NONE,
             },
         };
 

--- a/crates/compiler/mono/src/code_gen_help/mod.rs
+++ b/crates/compiler/mono/src/code_gen_help/mod.rs
@@ -8,9 +8,7 @@ use crate::ir::{
     Call, CallSpecId, CallType, Expr, HostExposedLayouts, JoinPointId, ModifyRc, Proc, ProcLayout,
     SelfRecursive, Stmt, UpdateModeId,
 };
-use crate::layout::{
-    Builtin, CapturesNiche, LambdaName, Layout, Niche, STLayoutInterner, UnionLayout,
-};
+use crate::layout::{Builtin, LambdaName, Layout, Niche, STLayoutInterner, UnionLayout};
 
 mod equality;
 mod refcount;

--- a/crates/compiler/mono/src/debug/checker.rs
+++ b/crates/compiler/mono/src/debug/checker.rs
@@ -552,7 +552,7 @@ impl<'a, 'r> Ctx<'a, 'r> {
                 let proc_layout = ProcLayout {
                     arguments: arg_layouts,
                     result: **ret_layout,
-                    captures_niche: name.captures_niche(),
+                    niche: name.niche(),
                 };
                 if !self.procs.contains_key(&(name.name(), proc_layout)) {
                     let similar = self

--- a/crates/compiler/mono/src/debug/report.rs
+++ b/crates/compiler/mono/src/debug/report.rs
@@ -6,7 +6,7 @@ use ven_pretty::{Arena, DocAllocator, DocBuilder};
 
 use crate::{
     ir::{Parens, ProcLayout},
-    layout::{CapturesNiche, Layout},
+    layout::{Layout, Niche},
 };
 
 use super::{
@@ -465,7 +465,7 @@ where
     let ProcLayout {
         arguments,
         result,
-        captures_niche,
+        niche: captures_niche,
     } = proc_layout;
     let args = f.intersperse(
         arguments
@@ -478,20 +478,19 @@ where
         f.reflow(" -> "),
         result.to_doc(f, interner, Parens::NotNeeded),
     ]);
-    let niche = if captures_niche == CapturesNiche::no_niche() {
-        f.reflow("(no niche)")
-    } else {
-        f.concat([
+    let niche = match captures_niche {
+        Niche::NONE => f.reflow("(no niche)"),
+        Niche::Captures(captures_niche) => f.concat([
             f.reflow("(niche {"),
             f.intersperse(
                 captures_niche
-                    .0
+                    .captures()
                     .iter()
                     .map(|c| c.to_doc(f, interner, Parens::NotNeeded)),
                 f.reflow(", "),
             ),
             f.reflow("})"),
-        ])
+        ]),
     };
     f.concat([fun, f.space(), niche])
 }

--- a/crates/compiler/mono/src/debug/report.rs
+++ b/crates/compiler/mono/src/debug/report.rs
@@ -6,7 +6,7 @@ use ven_pretty::{Arena, DocAllocator, DocBuilder};
 
 use crate::{
     ir::{Parens, ProcLayout},
-    layout::{Layout, Niche},
+    layout::Layout,
 };
 
 use super::{
@@ -478,20 +478,9 @@ where
         f.reflow(" -> "),
         result.to_doc(f, interner, Parens::NotNeeded),
     ]);
-    let niche = match captures_niche {
-        Niche::NONE => f.reflow("(no niche)"),
-        Niche::Captures(captures_niche) => f.concat([
-            f.reflow("(niche {"),
-            f.intersperse(
-                captures_niche
-                    .captures()
-                    .iter()
-                    .map(|c| c.to_doc(f, interner, Parens::NotNeeded)),
-                f.reflow(", "),
-            ),
-            f.reflow("})"),
-        ]),
-    };
+    let niche = (f.text("("))
+        .append(captures_niche.to_doc(f, interner))
+        .append(f.text(")"));
     f.concat([fun, f.space(), niche])
 }
 

--- a/crates/compiler/mono/src/inc_dec.rs
+++ b/crates/compiler/mono/src/inc_dec.rs
@@ -595,7 +595,7 @@ impl<'a, 'i> Context<'a, 'i> {
                 ..
             } => {
                 let top_level =
-                    ProcLayout::new(self.arena, arg_layouts, name.captures_niche(), **ret_layout);
+                    ProcLayout::new(self.arena, arg_layouts, name.niche(), **ret_layout);
 
                 // get the borrow signature
                 let ps = self
@@ -645,7 +645,7 @@ impl<'a, 'i> Context<'a, 'i> {
         let function_layout = ProcLayout {
             arguments: passed_function.argument_layouts,
             result: passed_function.return_layout,
-            captures_niche: passed_function.name.captures_niche(),
+            niche: passed_function.name.niche(),
         };
 
         let function_ps = match self

--- a/crates/compiler/mono/src/ir.rs
+++ b/crates/compiler/mono/src/ir.rs
@@ -8578,7 +8578,6 @@ fn call_by_name<'a>(
                         fn_var,
                         proc_name,
                         raw_layout,
-                        env.arena.alloc(Layout::LambdaSet(lambda_set)),
                         layout_cache,
                         assigned,
                         hole,
@@ -8631,7 +8630,6 @@ fn call_by_name<'a>(
                         fn_var,
                         proc_name,
                         raw_layout,
-                        env.arena.alloc(Layout::LambdaSet(lambda_set)),
                         layout_cache,
                         closure_data_symbol,
                         env.arena.alloc(result),
@@ -8656,7 +8654,7 @@ fn call_by_name<'a>(
                 )
             }
         }
-        Ok(raw_layout @ RawFunctionLayout::ZeroArgumentThunk(ret_layout)) => {
+        Ok(raw_layout @ RawFunctionLayout::ZeroArgumentThunk(_)) => {
             if procs.is_module_thunk(proc_name) {
                 // here we turn a call to a module thunk into  forcing of that thunk
                 call_by_name_module_thunk(
@@ -8665,7 +8663,6 @@ fn call_by_name<'a>(
                     fn_var,
                     proc_name,
                     raw_layout,
-                    env.arena.alloc(ret_layout),
                     layout_cache,
                     assigned,
                     hole,
@@ -8987,7 +8984,6 @@ fn call_by_name_module_thunk<'a>(
     fn_var: Variable,
     proc_name: Symbol,
     raw_return_layout: RawFunctionLayout<'a>,
-    ret_layout: &'a Layout<'a>,
     layout_cache: &mut LayoutCache<'a>,
     assigned: Symbol,
     hole: &'a Stmt<'a>,

--- a/crates/compiler/mono/src/ir.rs
+++ b/crates/compiler/mono/src/ir.rs
@@ -1,9 +1,9 @@
 #![allow(clippy::manual_map)]
 
 use crate::layout::{
-    self, Builtin, CapturesNiche, ClosureCallOptions, ClosureRepresentation, EnumDispatch,
-    LambdaName, LambdaSet, Layout, LayoutCache, LayoutProblem, RawFunctionLayout, STLayoutInterner,
-    TagIdIntType, UnionLayout, WrappedVariant,
+    self, Builtin, ClosureCallOptions, ClosureRepresentation, EnumDispatch, LambdaName, LambdaSet,
+    Layout, LayoutCache, LayoutProblem, Niche, RawFunctionLayout, STLayoutInterner, TagIdIntType,
+    UnionLayout, WrappedVariant,
 };
 use bumpalo::collections::{CollectIn, Vec};
 use bumpalo::Bump;
@@ -3391,7 +3391,7 @@ fn specialize_proc_help<'a>(
                     let top_level = ProcLayout::new(
                         env.arena,
                         top_level_arguments.into_bump_slice(),
-                        CapturesNiche::no_niche(),
+                        Niche::NONE,
                         *return_layout,
                     );
 
@@ -3424,7 +3424,7 @@ fn specialize_proc_help<'a>(
                         *symbol,
                         (
                             name,
-                            ProcLayout::new(env.arena, &[], CapturesNiche::no_niche(), result),
+                            ProcLayout::new(env.arena, &[], Niche::NONE, result),
                             layout,
                         ),
                     );
@@ -3950,14 +3950,14 @@ fn specialize_variable<'a>(
 pub struct ProcLayout<'a> {
     pub arguments: &'a [Layout<'a>],
     pub result: Layout<'a>,
-    pub captures_niche: CapturesNiche<'a>,
+    pub niche: Niche<'a>,
 }
 
 impl<'a> ProcLayout<'a> {
     pub(crate) fn new(
         arena: &'a Bump,
         old_arguments: &'a [Layout<'a>],
-        old_captures_niche: CapturesNiche<'a>,
+        old_niche: Niche<'a>,
         result: Layout<'a>,
     ) -> Self {
         let mut arguments = Vec::with_capacity_in(old_arguments.len(), arena);
@@ -3972,7 +3972,7 @@ impl<'a> ProcLayout<'a> {
 
         ProcLayout {
             arguments: arguments.into_bump_slice(),
-            captures_niche: old_captures_niche,
+            niche: old_niche,
             result: new_result,
         }
     }
@@ -3986,10 +3986,10 @@ impl<'a> ProcLayout<'a> {
             RawFunctionLayout::Function(arguments, lambda_set, result) => {
                 let arguments =
                     lambda_set.extend_argument_list_for_named(arena, lambda_name, arguments);
-                ProcLayout::new(arena, arguments, lambda_name.captures_niche(), *result)
+                ProcLayout::new(arena, arguments, lambda_name.niche(), *result)
             }
             RawFunctionLayout::ZeroArgumentThunk(result) => {
-                ProcLayout::new(arena, &[], CapturesNiche::no_niche(), result)
+                ProcLayout::new(arena, &[], Niche::NONE, result)
             }
         }
     }
@@ -8359,8 +8359,7 @@ fn specialize_symbol<'a>(
                         // let layout = Layout::Closure(argument_layouts, lambda_set, ret_layout);
                         // panic!("suspicious");
                         let layout = Layout::LambdaSet(lambda_set);
-                        let top_level =
-                            ProcLayout::new(env.arena, &[], CapturesNiche::no_niche(), layout);
+                        let top_level = ProcLayout::new(env.arena, &[], Niche::NONE, layout);
                         procs.insert_passed_by_name(
                             env,
                             arg_var,
@@ -8404,8 +8403,7 @@ fn specialize_symbol<'a>(
                 }
                 RawFunctionLayout::ZeroArgumentThunk(ret_layout) => {
                     // this is a 0-argument thunk
-                    let top_level =
-                        ProcLayout::new(env.arena, &[], CapturesNiche::no_niche(), ret_layout);
+                    let top_level = ProcLayout::new(env.arena, &[], Niche::NONE, ret_layout);
                     procs.insert_passed_by_name(
                         env,
                         arg_var,
@@ -8733,12 +8731,7 @@ fn call_by_name_help<'a>(
     let top_level_layout = {
         let argument_layouts =
             lambda_set.extend_argument_list_for_named(env.arena, proc_name, argument_layouts);
-        ProcLayout::new(
-            env.arena,
-            argument_layouts,
-            proc_name.captures_niche(),
-            *ret_layout,
-        )
+        ProcLayout::new(env.arena, argument_layouts, proc_name.niche(), *ret_layout)
     };
 
     // the variables of the given arguments
@@ -8993,7 +8986,7 @@ fn call_by_name_module_thunk<'a>(
     assigned: Symbol,
     hole: &'a Stmt<'a>,
 ) -> Stmt<'a> {
-    let top_level_layout = ProcLayout::new(env.arena, &[], CapturesNiche::no_niche(), *ret_layout);
+    let top_level_layout = ProcLayout::new(env.arena, &[], Niche::NONE, *ret_layout);
 
     let inner_layout = *ret_layout;
 

--- a/crates/compiler/mono/src/layout.rs
+++ b/crates/compiler/mono/src/layout.rs
@@ -1204,9 +1204,9 @@ impl std::fmt::Debug for LambdaSet<'_> {
 ///
 /// See also https://github.com/roc-lang/roc/issues/3336.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
-pub struct CapturesNiche<'a>(&'a [Layout<'a>]);
+pub struct Captures<'a>(&'a [Layout<'a>]);
 
-impl<'a> CapturesNiche<'a> {
+impl<'a> Captures<'a> {
     pub(crate) fn captures(&self) -> &'a [Layout<'a>] {
         self.0
     }
@@ -1215,11 +1215,11 @@ impl<'a> CapturesNiche<'a> {
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum Niche<'a> {
     /// A niche for a proc are its captures.
-    Captures(CapturesNiche<'a>),
+    Captures(Captures<'a>),
 }
 
 impl<'a> Niche<'a> {
-    pub const NONE: Niche<'a> = Niche::Captures(CapturesNiche(&[]));
+    pub const NONE: Niche<'a> = Niche::Captures(Captures(&[]));
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
@@ -1353,7 +1353,7 @@ impl<'a> LambdaSet<'a> {
         self.set.iter().map(|(name, captures_layouts)| {
             let niche = match captures_layouts {
                 [] => Niche::NONE,
-                _ => Niche::Captures(CapturesNiche(captures_layouts)),
+                _ => Niche::Captures(Captures(captures_layouts)),
             };
             LambdaName { name: *name, niche }
         })
@@ -1435,7 +1435,7 @@ impl<'a> LambdaSet<'a> {
 
         LambdaName {
             name: *name,
-            niche: Niche::Captures(CapturesNiche(layouts)),
+            niche: Niche::Captures(Captures(layouts)),
         }
     }
 

--- a/crates/compiler/mono/src/layout.rs
+++ b/crates/compiler/mono/src/layout.rs
@@ -1184,42 +1184,57 @@ impl std::fmt::Debug for LambdaSet<'_> {
     }
 }
 
-/// Sometimes we can end up with lambdas of the same name and different captures in the same
-/// lambda set, like `fun` having lambda set `[[thunk U64, thunk U8]]` due to the following program:
-///
-/// ```roc
-/// capture : _ -> ({} -> Str)
-/// capture = \val ->
-///     thunk = \{} -> Num.toStr val
-///     thunk
-///
-/// fun = \x ->
-///     when x is
-///         True -> capture 123u64
-///         False -> capture 18u8
-/// ```
-///
-/// By recording the captures layouts this lambda expects in its identifier, we can distinguish
-/// between such differences when constructing closure capture data.
-///
-/// See also https://github.com/roc-lang/roc/issues/3336.
-#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
-pub struct Captures<'a>(&'a [Layout<'a>]);
-
-impl<'a> Captures<'a> {
-    pub(crate) fn captures(&self) -> &'a [Layout<'a>] {
-        self.0
-    }
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+enum NichePriv<'a> {
+    /// Sometimes we can end up with lambdas of the same name and different captures in the same
+    /// lambda set, like `fun` having lambda set `[[thunk U64, thunk U8]]` due to the following program:
+    ///
+    /// ```roc
+    /// capture : _ -> ({} -> Str)
+    /// capture = \val ->
+    ///     thunk = \{} -> Num.toStr val
+    ///     thunk
+    ///
+    /// fun = \x ->
+    ///     when x is
+    ///         True -> capture 123u64
+    ///         False -> capture 18u8
+    /// ```
+    ///
+    /// By recording the captures layouts this lambda expects in its identifier, we can distinguish
+    /// between such differences when constructing closure capture data.
+    ///
+    /// See also https://github.com/roc-lang/roc/issues/3336.
+    Captures(&'a [Layout<'a>]),
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum Niche<'a> {
-    /// A niche for a proc are its captures.
-    Captures(Captures<'a>),
-}
+#[repr(transparent)]
+pub struct Niche<'a>(NichePriv<'a>);
 
 impl<'a> Niche<'a> {
-    pub const NONE: Niche<'a> = Niche::Captures(Captures(&[]));
+    pub const NONE: Niche<'a> = Niche(NichePriv::Captures(&[]));
+
+    pub fn to_doc<'b, D, A, I>(self, alloc: &'b D, interner: &I) -> DocBuilder<'b, D, A>
+    where
+        D: DocAllocator<'b, A>,
+        D::Doc: Clone,
+        A: Clone,
+        I: Interner<'a, Layout<'a>>,
+    {
+        match self.0 {
+            NichePriv::Captures(captures) => alloc.concat([
+                alloc.reflow("(niche {"),
+                alloc.intersperse(
+                    captures
+                        .iter()
+                        .map(|c| c.to_doc(alloc, interner, Parens::NotNeeded)),
+                    alloc.reflow(", "),
+                ),
+                alloc.reflow("})"),
+            ]),
+        }
+    }
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
@@ -1241,9 +1256,8 @@ impl<'a> LambdaName<'a> {
 
     #[inline(always)]
     pub(crate) fn no_captures(&self) -> bool {
-        match self.niche {
-            Niche::NONE => true,
-            Niche::Captures(captures) => captures.0.is_empty(),
+        match self.niche.0 {
+            NichePriv::Captures(captures) => captures.is_empty(),
         }
     }
 
@@ -1353,7 +1367,7 @@ impl<'a> LambdaSet<'a> {
         self.set.iter().map(|(name, captures_layouts)| {
             let niche = match captures_layouts {
                 [] => Niche::NONE,
-                _ => Niche::Captures(Captures(captures_layouts)),
+                _ => Niche(NichePriv::Captures(captures_layouts)),
             };
             LambdaName { name: *name, niche }
         })
@@ -1379,9 +1393,7 @@ impl<'a> LambdaSet<'a> {
     {
         debug_assert!(self.contains(lambda_name.name));
 
-        let captures = match lambda_name.niche {
-            Niche::Captures(captures) => captures.0,
-        };
+        let NichePriv::Captures(captures) = lambda_name.niche.0;
 
         let comparator = |other_name: Symbol, other_captures_layouts: &[Layout]| {
             other_name == lambda_name.name
@@ -1435,7 +1447,7 @@ impl<'a> LambdaSet<'a> {
 
         LambdaName {
             name: *name,
-            niche: Niche::Captures(Captures(layouts)),
+            niche: Niche(NichePriv::Captures(layouts)),
         }
     }
 

--- a/crates/compiler/mono/src/layout.rs
+++ b/crates/compiler/mono/src/layout.rs
@@ -1381,7 +1381,6 @@ impl<'a> LambdaSet<'a> {
 
         let captures = match lambda_name.niche {
             Niche::Captures(captures) => captures.0,
-            Niche::NONE => &[],
         };
 
         let comparator = |other_name: Symbol, other_captures_layouts: &[Layout]| {

--- a/crates/compiler/mono/src/layout.rs
+++ b/crates/compiler/mono/src/layout.rs
@@ -1184,30 +1184,54 @@ impl std::fmt::Debug for LambdaSet<'_> {
     }
 }
 
+/// See [Niche].
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 enum NichePriv<'a> {
-    /// Sometimes we can end up with lambdas of the same name and different captures in the same
-    /// lambda set, like `fun` having lambda set `[[thunk U64, thunk U8]]` due to the following program:
-    ///
-    /// ```roc
-    /// capture : _ -> ({} -> Str)
-    /// capture = \val ->
-    ///     thunk = \{} -> Num.toStr val
-    ///     thunk
-    ///
-    /// fun = \x ->
-    ///     when x is
-    ///         True -> capture 123u64
-    ///         False -> capture 18u8
-    /// ```
-    ///
-    /// By recording the captures layouts this lambda expects in its identifier, we can distinguish
-    /// between such differences when constructing closure capture data.
-    ///
-    /// See also https://github.com/roc-lang/roc/issues/3336.
+    /// Distinguishes captures this proc takes, when it is a part of a lambda set that has multiple
+    /// lambdas of the same name, but different captures.
     Captures(&'a [Layout<'a>]),
 }
 
+/// Niches identify lambdas (including thunks) in ways that are not distinguishable solely by their
+/// [runtime function layout][RawFunctionLayout].
+///
+/// Currently, there are two kinds of niches.
+///
+/// # Captures niches
+///
+/// Captures niches identify a procedure's set of captured symbols. This is relevant when a
+/// procedure is part of a lambda set that has multiple lambdas of the procedure's name, but each
+/// has a different set of captures.
+///
+/// The capture set is identified only in the body of a procedure and not in its runtime layout.
+/// Any capturing lambda takes the whole lambda set as an argument, rather than just its captures.
+/// A captures niche can be attached to a [lambda name][LambdaName] to uniquely identify lambdas
+/// in these scenarios.
+///
+/// Procedure names with captures niches are typically produced by [find_lambda_name][LambdaSet::find_lambda_name].
+/// Captures niches are irrelevant for thunks.
+///
+/// ## Example
+///
+/// `fun` has lambda set `[[forcer U64, forcer U8]]` in the following program:
+///
+/// ```roc
+/// capture : _ -> ({} -> Str)
+/// capture = \val ->
+///     forcer = \{} -> Num.toStr val
+///     forcer
+///
+/// fun = \x ->
+///     when x is
+///         True -> capture 123u64
+///         False -> capture 18u8
+/// ```
+///
+/// By recording the captures layouts each `forcer` expects, we can distinguish
+/// between such differences when constructing the closure capture data that is
+/// return value of `fun`.
+///
+/// See also https://github.com/roc-lang/roc/issues/3336.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 #[repr(transparent)]
 pub struct Niche<'a>(NichePriv<'a>);

--- a/crates/compiler/mono/src/layout.rs
+++ b/crates/compiler/mono/src/layout.rs
@@ -1673,7 +1673,7 @@ impl<'a> LambdaSet<'a> {
         lambda_name: LambdaName<'a>,
         argument_layouts: &'a [Layout<'a>],
     ) -> &'a [Layout<'a>] {
-        let Niche::Captures(CapturesNiche(captures)) = lambda_name.niche;
+        let Niche(NichePriv::Captures(captures)) = lambda_name.niche;
         debug_assert!(
             self.set.contains(&(lambda_name.name, captures)),
             "{:?}",

--- a/crates/compiler/test_gen/src/wasm_linking.rs
+++ b/crates/compiler/test_gen/src/wasm_linking.rs
@@ -17,7 +17,7 @@ use roc_mono::ir::{
     Call, CallType, Expr, HostExposedLayouts, Literal, Proc, ProcLayout, SelfRecursive, Stmt,
     UpdateModeId,
 };
-use roc_mono::layout::{Builtin, Captures, LambdaName, Layout, STLayoutInterner};
+use roc_mono::layout::{Builtin, LambdaName, Layout, Niche, STLayoutInterner};
 use roc_wasm_interp::{wasi, ImportDispatcher, Instance, WasiDispatcher};
 use roc_wasm_module::{Value, WasmModule};
 
@@ -124,7 +124,7 @@ fn build_app_mono<'a>(
     let proc_layout = ProcLayout {
         arguments: &[],
         result: int_layout,
-        niche: Captures::no_niche(),
+        niche: Niche::NONE,
     };
 
     let mut app = MutMap::default();

--- a/crates/compiler/test_gen/src/wasm_linking.rs
+++ b/crates/compiler/test_gen/src/wasm_linking.rs
@@ -124,7 +124,7 @@ fn build_app_mono<'a>(
     let proc_layout = ProcLayout {
         arguments: &[],
         result: int_layout,
-        captures_niche: CapturesNiche::no_niche(),
+        niche: CapturesNiche::no_niche(),
     };
 
     let mut app = MutMap::default();

--- a/crates/compiler/test_gen/src/wasm_linking.rs
+++ b/crates/compiler/test_gen/src/wasm_linking.rs
@@ -17,7 +17,7 @@ use roc_mono::ir::{
     Call, CallType, Expr, HostExposedLayouts, Literal, Proc, ProcLayout, SelfRecursive, Stmt,
     UpdateModeId,
 };
-use roc_mono::layout::{Builtin, CapturesNiche, LambdaName, Layout, STLayoutInterner};
+use roc_mono::layout::{Builtin, Captures, LambdaName, Layout, STLayoutInterner};
 use roc_wasm_interp::{wasi, ImportDispatcher, Instance, WasiDispatcher};
 use roc_wasm_module::{Value, WasmModule};
 
@@ -124,7 +124,7 @@ fn build_app_mono<'a>(
     let proc_layout = ProcLayout {
         arguments: &[],
         result: int_layout,
-        niche: CapturesNiche::no_niche(),
+        niche: Captures::no_niche(),
     };
 
     let mut app = MutMap::default();

--- a/crates/repl_eval/src/eval.rs
+++ b/crates/repl_eval/src/eval.rs
@@ -61,7 +61,7 @@ pub fn jit_to_ast<'a, A: ReplApp<'a>>(
         ProcLayout {
             arguments: [],
             result,
-            captures_niche: _,
+            niche: _,
         } => {
             // This is a thunk, which cannot be defined in userspace, so we know
             // it's `main` and can be executed.

--- a/crates/repl_expect/src/lib.rs
+++ b/crates/repl_expect/src/lib.rs
@@ -5,7 +5,7 @@ use {
     roc_module::symbol::Interns,
     roc_mono::{
         ir::ProcLayout,
-        layout::{CapturesNiche, Layout, LayoutCache},
+        layout::{Layout, LayoutCache, Niche},
     },
     roc_parse::ast::Expr,
     roc_repl_eval::{eval::jit_to_ast, ReplAppMemory},
@@ -67,7 +67,7 @@ pub fn get_values<'a>(
             let proc_layout = ProcLayout {
                 arguments: &[],
                 result: layout,
-                captures_niche: CapturesNiche::no_niche(),
+                niche: Niche::NONE,
             };
 
             jit_to_ast(


### PR DESCRIPTION
An "eta-reduced thunk" is a top-level, non-capturing value (compiled as a thunk) that returns a specialized procedure. Had the value been eta-expanded, it would be a function that returns another function.

Because
  1. specialized functions are identified by their [function signature][RawFunctionLayout], consisting of arguments, lambda set, and return layout
  2. the runtime representation of a function is only its lambda set
  3. top-level, non-capturing values are identified only by their runtime representation

eta-reduced thunks lose information about the specialized procedures they resolve to, as their layout identification includes only the lambda set of the returned procedure, but that returned procedure is fully identified by its signature as described in (1).

To recover this information, eta-reduced thunks are installed a niche that is the [function signature][RawFunctionLayout] of the specialized procedure they return.

**Example**

Consider

```ignore(illustrative)
andThen = \{} ->
    x = 10
    \newFn -[5]-> Num.add (newFn {}) x

between = andThen {}

it = between \{} -[7]-> between \{} -[8]-> 10

main = it
```

Here `between` is an eta-reduced thunk, for which we want two specializations

```ignore(illustrative)
between : ({} -[[7]]-> U8) -[[5 U8]]-> U8
between : ({} -[[8]]-> U8) -[[5 U8]]-> U8
```

Since `between` always resolves to the function `-[5]->`, its layout identification is

```ignore(illustrative)
{} -> [[5 U8]]
```

But, the construction of that returned lambda set `[[5 U8]]` is different between the two specializations. To distinguish those differences, we attach the returned functions' layout as a niche to each specialization of the thunk.

```ignore(illustrative)
between spec 1: {} -> [[5 U8]] (niche: η({} -[[7]]-> U8) -[[5 U8]]-> U8)
between spec 1: {} -> [[5 U8]] (niche: η({} -[[8]]-> U8) -[[5 U8]]-> U8)
```

**Composing with multimorphic lambda sets**

Eta-reduced thunk niches compose with specializations involved in multimorphic lambda sets naturally, because the two concepts are disjoint.

Consider

```ignore(illustrative)
andThen = \x ->
    \newFn -[5]-> Str.concat (newFn {}) (Num.toStr x)

between = if Bool.true
    then andThen 11u8
    else andThen 22u16

it = between \{} -[7]-> between \{} -[8]-> "end"

main = it
```

For this program, we want two specializations of `between`

```ignore(illustrative)
between : ({} -[[7]]-> Str) -[[5 U16, 5 U8]]-> Str
between : ({} -[[8]]-> Str) -[[5 U16, 5 U8]]-> Str
```

It is again enough to specify that each `between` thunk returns a closure data of lambda set shape `[[5 U16, 5 U8]]`, with an appropriate eta-reduced thunk niche.

The thunk itself does not capture, and the disambiguation of procedures in the multimorphic lambda set is only relevant at the site of the construction of the lambda set (and its dispatch).

That is, the niches needed to distinguish the constructed procedures in the lambda set are only relevant
  - **inside** the body of `between` (specifically, inside the specialization of `andThen`)
  - OR, **outside** the body of `between`, when matching on it to make the calls in `it` And so, nothing extra is needed on the surface of the eta-reduced thunk's niche to identify this program correctly.

**References**

See also https://github.com/roc-lang/roc/issues/4734