### PR TITLE
Collect references to functions passed to HOLLs in borrow inference

### DIFF
--- a/crates/compiler/mono/src/borrow.rs
+++ b/crates/compiler/mono/src/borrow.rs
@@ -1,7 +1,9 @@
 use std::collections::HashMap;
 use std::hash::Hash;
 
-use crate::ir::{Expr, HigherOrderLowLevel, JoinPointId, Param, Proc, ProcLayout, Stmt};
+use crate::ir::{
+    Expr, HigherOrderLowLevel, JoinPointId, Param, PassedFunction, Proc, ProcLayout, Stmt,
+};
 use crate::layout::Layout;
 use bumpalo::collections::Vec;
 use bumpalo::Bump;
@@ -977,7 +979,12 @@ fn call_info_call<'a>(call: &crate::ir::Call<'a>, info: &mut CallInfo<'a>) {
         }
         Foreign { .. } => {}
         LowLevel { .. } => {}
-        HigherOrder(_) => {}
+        HigherOrder(HigherOrderLowLevel {
+            passed_function: PassedFunction { name, .. },
+            ..
+        }) => {
+            info.keys.push(name.name());
+        }
     }
 }
 


### PR DESCRIPTION
During borrow inference, SCCs of references between procs are first
constructed. Previously we didn't collect any references for HOLL calls,
but since such calls pass a Roc-function, we need to include a reference
to the Roc function.
