### PR TITLE
Intern all the layouts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3273,6 +3273,7 @@ dependencies = [
  "morphic_lib",
  "roc_collections",
  "roc_debug_flags",
+ "roc_intern",
  "roc_module",
  "roc_mono",
 ]
@@ -3646,6 +3647,7 @@ dependencies = [
  "roc_collections",
  "roc_debug_flags",
  "roc_error_macros",
+ "roc_intern",
  "roc_module",
  "roc_mono",
  "roc_region",

--- a/crates/compiler/alias_analysis/Cargo.toml
+++ b/crates/compiler/alias_analysis/Cargo.toml
@@ -8,6 +8,7 @@ version = "0.0.1"
 [dependencies]
 morphic_lib = {path = "../../vendor/morphic_lib"}
 roc_collections = {path = "../collections"}
+roc_intern = {path = "../intern"}
 roc_module = {path = "../module"}
 roc_mono = {path = "../mono"}
 roc_debug_flags = {path = "../debug_flags"}

--- a/crates/compiler/alias_analysis/src/lib.rs
+++ b/crates/compiler/alias_analysis/src/lib.rs
@@ -6,6 +6,7 @@ use morphic_lib::{
     TypeDefBuilder, TypeId, TypeName, UpdateModeVar, ValueId,
 };
 use roc_collections::all::{MutMap, MutSet};
+use roc_intern::Interner;
 use roc_module::low_level::LowLevel;
 use roc_module::symbol::Symbol;
 
@@ -1730,6 +1731,7 @@ fn layout_spec_help<'a>(
         }
 
         Boxed(inner_layout) => {
+            let inner_layout = interner.get(*inner_layout);
             let inner_type =
                 layout_spec_help(env, builder, interner, inner_layout, when_recursive)?;
             let cell_type = builder.add_heap_cell_type();

--- a/crates/compiler/build/src/program.rs
+++ b/crates/compiler/build/src/program.rs
@@ -470,7 +470,7 @@ fn gen_from_mono_module_dev_wasm32<'a>(
         module_id,
         procedures,
         mut interns,
-        layout_interner,
+        mut layout_interner,
         ..
     } = loaded;
 
@@ -483,7 +483,6 @@ fn gen_from_mono_module_dev_wasm32<'a>(
 
     let env = roc_gen_wasm::Env {
         arena,
-        layout_interner: &layout_interner,
         module_id,
         exposed_to_host,
         stack_bytes: wasm_dev_stack_bytes.unwrap_or(roc_gen_wasm::Env::DEFAULT_STACK_BYTES),
@@ -505,8 +504,13 @@ fn gen_from_mono_module_dev_wasm32<'a>(
         )
     });
 
-    let final_binary_bytes =
-        roc_gen_wasm::build_app_binary(&env, &mut interns, host_module, procedures);
+    let final_binary_bytes = roc_gen_wasm::build_app_binary(
+        &env,
+        &mut layout_interner,
+        &mut interns,
+        host_module,
+        procedures,
+    );
 
     let code_gen = code_gen_start.elapsed();
 
@@ -536,20 +540,20 @@ fn gen_from_mono_module_dev_assembly<'a>(
         procedures,
         mut interns,
         exposed_to_host,
-        layout_interner,
+        mut layout_interner,
         ..
     } = loaded;
 
     let env = roc_gen_dev::Env {
         arena,
-        layout_interner: &layout_interner,
         module_id,
         exposed_to_host: exposed_to_host.values.keys().copied().collect(),
         lazy_literals,
         generate_allocators,
     };
 
-    let module_object = roc_gen_dev::build_module(&env, &mut interns, target, procedures);
+    let module_object =
+        roc_gen_dev::build_module(&env, &mut interns, &mut layout_interner, target, procedures);
 
     let code_gen = code_gen_start.elapsed();
 

--- a/crates/compiler/gen_dev/src/generic64/aarch64.rs
+++ b/crates/compiler/gen_dev/src/generic64/aarch64.rs
@@ -4,7 +4,7 @@ use bumpalo::collections::Vec;
 use packed_struct::prelude::*;
 use roc_error_macros::internal_error;
 use roc_module::symbol::Symbol;
-use roc_mono::layout::Layout;
+use roc_mono::layout::{Layout, STLayoutInterner};
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Debug)]
 #[allow(dead_code)]
@@ -305,15 +305,17 @@ impl CallConv<AArch64GeneralReg, AArch64FloatReg, AArch64Assembler> for AArch64C
     }
 
     #[inline(always)]
-    fn load_args<'a>(
+    fn load_args<'a, 'r>(
         _buf: &mut Vec<'a, u8>,
         _storage_manager: &mut StorageManager<
             'a,
+            'r,
             AArch64GeneralReg,
             AArch64FloatReg,
             AArch64Assembler,
             AArch64Call,
         >,
+        layout_interner: &mut STLayoutInterner<'a>,
         _args: &'a [(Layout<'a>, Symbol)],
         _ret_layout: &Layout<'a>,
     ) {
@@ -321,15 +323,17 @@ impl CallConv<AArch64GeneralReg, AArch64FloatReg, AArch64Assembler> for AArch64C
     }
 
     #[inline(always)]
-    fn store_args<'a>(
+    fn store_args<'a, 'r>(
         _buf: &mut Vec<'a, u8>,
         _storage_manager: &mut StorageManager<
             'a,
+            'r,
             AArch64GeneralReg,
             AArch64FloatReg,
             AArch64Assembler,
             AArch64Call,
         >,
+        layout_interner: &mut STLayoutInterner<'a>,
         _dst: &Symbol,
         _args: &[Symbol],
         _arg_layouts: &[Layout<'a>],
@@ -338,30 +342,34 @@ impl CallConv<AArch64GeneralReg, AArch64FloatReg, AArch64Assembler> for AArch64C
         todo!("Storing args for AArch64");
     }
 
-    fn return_complex_symbol<'a>(
+    fn return_complex_symbol<'a, 'r>(
         _buf: &mut Vec<'a, u8>,
         _storage_manager: &mut StorageManager<
             'a,
+            'r,
             AArch64GeneralReg,
             AArch64FloatReg,
             AArch64Assembler,
             AArch64Call,
         >,
+        layout_interner: &mut STLayoutInterner<'a>,
         _sym: &Symbol,
         _layout: &Layout<'a>,
     ) {
         todo!("Returning complex symbols for AArch64");
     }
 
-    fn load_returned_complex_symbol<'a>(
+    fn load_returned_complex_symbol<'a, 'r>(
         _buf: &mut Vec<'a, u8>,
         _storage_manager: &mut StorageManager<
             'a,
+            'r,
             AArch64GeneralReg,
             AArch64FloatReg,
             AArch64Assembler,
             AArch64Call,
         >,
+        layout_interner: &mut STLayoutInterner<'a>,
         _sym: &Symbol,
         _layout: &Layout<'a>,
     ) {
@@ -443,9 +451,9 @@ impl Assembler<AArch64GeneralReg, AArch64FloatReg> for AArch64Assembler {
         todo!("register signed multiplication for AArch64");
     }
 
-    fn umul_reg64_reg64_reg64<'a, ASM, CC>(
+    fn umul_reg64_reg64_reg64<'a, 'r, ASM, CC>(
         _buf: &mut Vec<'a, u8>,
-        _storage_manager: &mut StorageManager<'a, AArch64GeneralReg, AArch64FloatReg, ASM, CC>,
+        _storage_manager: &mut StorageManager<'a, 'r, AArch64GeneralReg, AArch64FloatReg, ASM, CC>,
         _dst: AArch64GeneralReg,
         _src1: AArch64GeneralReg,
         _src2: AArch64GeneralReg,
@@ -456,9 +464,9 @@ impl Assembler<AArch64GeneralReg, AArch64FloatReg> for AArch64Assembler {
         todo!("register unsigned multiplication for AArch64");
     }
 
-    fn idiv_reg64_reg64_reg64<'a, ASM, CC>(
+    fn idiv_reg64_reg64_reg64<'a, 'r, ASM, CC>(
         _buf: &mut Vec<'a, u8>,
-        _storage_manager: &mut StorageManager<'a, AArch64GeneralReg, AArch64FloatReg, ASM, CC>,
+        _storage_manager: &mut StorageManager<'a, 'r, AArch64GeneralReg, AArch64FloatReg, ASM, CC>,
         _dst: AArch64GeneralReg,
         _src1: AArch64GeneralReg,
         _src2: AArch64GeneralReg,
@@ -469,9 +477,9 @@ impl Assembler<AArch64GeneralReg, AArch64FloatReg> for AArch64Assembler {
         todo!("register signed division for AArch64");
     }
 
-    fn udiv_reg64_reg64_reg64<'a, ASM, CC>(
+    fn udiv_reg64_reg64_reg64<'a, 'r, ASM, CC>(
         _buf: &mut Vec<'a, u8>,
-        _storage_manager: &mut StorageManager<'a, AArch64GeneralReg, AArch64FloatReg, ASM, CC>,
+        _storage_manager: &mut StorageManager<'a, 'r, AArch64GeneralReg, AArch64FloatReg, ASM, CC>,
         _dst: AArch64GeneralReg,
         _src1: AArch64GeneralReg,
         _src2: AArch64GeneralReg,

--- a/crates/compiler/gen_dev/src/generic64/aarch64.rs
+++ b/crates/compiler/gen_dev/src/generic64/aarch64.rs
@@ -315,7 +315,7 @@ impl CallConv<AArch64GeneralReg, AArch64FloatReg, AArch64Assembler> for AArch64C
             AArch64Assembler,
             AArch64Call,
         >,
-        layout_interner: &mut STLayoutInterner<'a>,
+        _layout_interner: &mut STLayoutInterner<'a>,
         _args: &'a [(Layout<'a>, Symbol)],
         _ret_layout: &Layout<'a>,
     ) {
@@ -333,7 +333,7 @@ impl CallConv<AArch64GeneralReg, AArch64FloatReg, AArch64Assembler> for AArch64C
             AArch64Assembler,
             AArch64Call,
         >,
-        layout_interner: &mut STLayoutInterner<'a>,
+        _layout_interner: &mut STLayoutInterner<'a>,
         _dst: &Symbol,
         _args: &[Symbol],
         _arg_layouts: &[Layout<'a>],
@@ -352,7 +352,7 @@ impl CallConv<AArch64GeneralReg, AArch64FloatReg, AArch64Assembler> for AArch64C
             AArch64Assembler,
             AArch64Call,
         >,
-        layout_interner: &mut STLayoutInterner<'a>,
+        _layout_interner: &mut STLayoutInterner<'a>,
         _sym: &Symbol,
         _layout: &Layout<'a>,
     ) {
@@ -369,7 +369,7 @@ impl CallConv<AArch64GeneralReg, AArch64FloatReg, AArch64Assembler> for AArch64C
             AArch64Assembler,
             AArch64Call,
         >,
-        layout_interner: &mut STLayoutInterner<'a>,
+        _layout_interner: &mut STLayoutInterner<'a>,
         _sym: &Symbol,
         _layout: &Layout<'a>,
     ) {

--- a/crates/compiler/gen_dev/src/generic64/storage.rs
+++ b/crates/compiler/gen_dev/src/generic64/storage.rs
@@ -10,7 +10,7 @@ use roc_error_macros::internal_error;
 use roc_module::symbol::Symbol;
 use roc_mono::{
     ir::{JoinPointId, Param},
-    layout::{Builtin, Layout, TagIdIntType, UnionLayout},
+    layout::{Builtin, Layout, STLayoutInterner, TagIdIntType, UnionLayout},
 };
 use roc_target::TargetInfo;
 use std::cmp::max;
@@ -79,6 +79,7 @@ enum Storage<GeneralReg: RegTrait, FloatReg: RegTrait> {
 #[derive(Clone)]
 pub struct StorageManager<
     'a,
+    'r,
     GeneralReg: RegTrait,
     FloatReg: RegTrait,
     ASM: Assembler<GeneralReg, FloatReg>,
@@ -86,7 +87,7 @@ pub struct StorageManager<
 > {
     phantom_cc: PhantomData<CC>,
     phantom_asm: PhantomData<ASM>,
-    pub(crate) env: &'a Env<'a>,
+    pub(crate) env: &'r Env<'a>,
     target_info: TargetInfo,
     // Data about where each symbol is stored.
     symbol_storage_map: MutMap<Symbol, Storage<GeneralReg, FloatReg>>,
@@ -127,14 +128,15 @@ pub struct StorageManager<
 
 pub fn new_storage_manager<
     'a,
+    'r,
     GeneralReg: RegTrait,
     FloatReg: RegTrait,
     ASM: Assembler<GeneralReg, FloatReg>,
     CC: CallConv<GeneralReg, FloatReg, ASM>,
 >(
-    env: &'a Env,
+    env: &'r Env<'a>,
     target_info: TargetInfo,
-) -> StorageManager<'a, GeneralReg, FloatReg, ASM, CC> {
+) -> StorageManager<'a, 'r, GeneralReg, FloatReg, ASM, CC> {
     StorageManager {
         phantom_asm: PhantomData,
         phantom_cc: PhantomData,
@@ -157,11 +159,12 @@ pub fn new_storage_manager<
 
 impl<
         'a,
+        'r,
         FloatReg: RegTrait,
         GeneralReg: RegTrait,
         ASM: Assembler<GeneralReg, FloatReg>,
         CC: CallConv<GeneralReg, FloatReg, ASM>,
-    > StorageManager<'a, GeneralReg, FloatReg, ASM, CC>
+    > StorageManager<'a, 'r, GeneralReg, FloatReg, ASM, CC>
 {
     pub fn reset(&mut self) {
         self.symbol_storage_map.clear();
@@ -526,6 +529,7 @@ impl<
     /// This is lazy by default. It will not copy anything around.
     pub fn load_field_at_index(
         &mut self,
+        layout_interner: &mut STLayoutInterner<'a>,
         sym: &Symbol,
         structure: &Symbol,
         index: u64,
@@ -541,12 +545,12 @@ impl<
                 let (base_offset, size) = (*base_offset, *size);
                 let mut data_offset = base_offset;
                 for layout in field_layouts.iter().take(index as usize) {
-                    let field_size = layout.stack_size(self.env.layout_interner, self.target_info);
+                    let field_size = layout.stack_size(layout_interner, self.target_info);
                     data_offset += field_size as i32;
                 }
                 debug_assert!(data_offset < base_offset + size as i32);
                 let layout = field_layouts[index as usize];
-                let size = layout.stack_size(self.env.layout_interner, self.target_info);
+                let size = layout.stack_size(layout_interner, self.target_info);
                 self.allocation_map.insert(*sym, owned_data);
                 self.symbol_storage_map.insert(
                     *sym,
@@ -578,6 +582,7 @@ impl<
 
     pub fn load_union_tag_id(
         &mut self,
+        layout_interner: &mut STLayoutInterner<'a>,
         _buf: &mut Vec<'a, u8>,
         sym: &Symbol,
         structure: &Symbol,
@@ -591,8 +596,8 @@ impl<
             UnionLayout::NonRecursive(_) => {
                 let (union_offset, _) = self.stack_offset_and_size(structure);
 
-                let (data_size, data_alignment) = union_layout
-                    .data_size_and_alignment(self.env.layout_interner, self.target_info);
+                let (data_size, data_alignment) =
+                    union_layout.data_size_and_alignment(layout_interner, self.target_info);
                 let id_offset = data_size - data_alignment;
                 let discriminant = union_layout.discriminant();
 
@@ -630,12 +635,13 @@ impl<
     /// Creates a struct on the stack, moving the data in fields into the struct.
     pub fn create_struct(
         &mut self,
+        layout_interner: &mut STLayoutInterner<'a>,
         buf: &mut Vec<'a, u8>,
         sym: &Symbol,
         layout: &Layout<'a>,
         fields: &'a [Symbol],
     ) {
-        let struct_size = layout.stack_size(self.env.layout_interner, self.target_info);
+        let struct_size = layout.stack_size(layout_interner, self.target_info);
         if struct_size == 0 {
             self.symbol_storage_map.insert(*sym, NoData);
             return;
@@ -645,21 +651,27 @@ impl<
         if let Layout::Struct { field_layouts, .. } = layout {
             let mut current_offset = base_offset;
             for (field, field_layout) in fields.iter().zip(field_layouts.iter()) {
-                self.copy_symbol_to_stack_offset(buf, current_offset, field, field_layout);
-                let field_size =
-                    field_layout.stack_size(self.env.layout_interner, self.target_info);
+                self.copy_symbol_to_stack_offset(
+                    layout_interner,
+                    buf,
+                    current_offset,
+                    field,
+                    field_layout,
+                );
+                let field_size = field_layout.stack_size(layout_interner, self.target_info);
                 current_offset += field_size as i32;
             }
         } else {
             // This is a single element struct. Just copy the single field to the stack.
             debug_assert_eq!(fields.len(), 1);
-            self.copy_symbol_to_stack_offset(buf, base_offset, &fields[0], layout);
+            self.copy_symbol_to_stack_offset(layout_interner, buf, base_offset, &fields[0], layout);
         }
     }
 
     /// Creates a union on the stack, moving the data in fields into the union and tagging it.
     pub fn create_union(
         &mut self,
+        layout_interner: &mut STLayoutInterner<'a>,
         buf: &mut Vec<'a, u8>,
         sym: &Symbol,
         union_layout: &UnionLayout<'a>,
@@ -668,8 +680,8 @@ impl<
     ) {
         match union_layout {
             UnionLayout::NonRecursive(field_layouts) => {
-                let (data_size, data_alignment) = union_layout
-                    .data_size_and_alignment(self.env.layout_interner, self.target_info);
+                let (data_size, data_alignment) =
+                    union_layout.data_size_and_alignment(layout_interner, self.target_info);
                 let id_offset = data_size - data_alignment;
                 if data_alignment < 8 || data_alignment % 8 != 0 {
                     todo!("small/unaligned tagging");
@@ -679,9 +691,14 @@ impl<
                 for (field, field_layout) in
                     fields.iter().zip(field_layouts[tag_id as usize].iter())
                 {
-                    self.copy_symbol_to_stack_offset(buf, current_offset, field, field_layout);
-                    let field_size =
-                        field_layout.stack_size(self.env.layout_interner, self.target_info);
+                    self.copy_symbol_to_stack_offset(
+                        layout_interner,
+                        buf,
+                        current_offset,
+                        field,
+                        field_layout,
+                    );
+                    let field_size = field_layout.stack_size(layout_interner, self.target_info);
                     current_offset += field_size as i32;
                 }
                 self.with_tmp_general_reg(buf, |_symbol_storage, buf, reg| {
@@ -719,6 +736,7 @@ impl<
     /// Always interact with the stack using aligned 64bit movement.
     pub fn copy_symbol_to_stack_offset(
         &mut self,
+        layout_interner: &mut STLayoutInterner<'a>,
         buf: &mut Vec<'a, u8>,
         to_offset: i32,
         sym: &Symbol,
@@ -735,19 +753,16 @@ impl<
                 let reg = self.load_to_float_reg(buf, sym);
                 ASM::mov_base32_freg64(buf, to_offset, reg);
             }
-            _ if layout.stack_size(self.env.layout_interner, self.target_info) == 0 => {}
+            _ if layout.stack_size(layout_interner, self.target_info) == 0 => {}
             // TODO: Verify this is always true.
             // The dev backend does not deal with refcounting and does not care about if data is safe to memcpy.
             // It is just temporarily storing the value due to needing to free registers.
             // Later, it will be reloaded and stored in refcounted as needed.
-            _ if layout.stack_size(self.env.layout_interner, self.target_info) > 8 => {
+            _ if layout.stack_size(layout_interner, self.target_info) > 8 => {
                 let (from_offset, size) = self.stack_offset_and_size(sym);
                 debug_assert!(from_offset % 8 == 0);
                 debug_assert!(size % 8 == 0);
-                debug_assert_eq!(
-                    size,
-                    layout.stack_size(self.env.layout_interner, self.target_info)
-                );
+                debug_assert_eq!(size, layout.stack_size(layout_interner, self.target_info));
                 self.with_tmp_general_reg(buf, |_storage_manager, buf, reg| {
                     for i in (0..size as i32).step_by(8) {
                         ASM::mov_reg64_base32(buf, reg, from_offset + i);
@@ -988,6 +1003,7 @@ impl<
     /// Later jumps to the join point can overwrite the stored locations to pass parameters.
     pub fn setup_joinpoint(
         &mut self,
+        layout_interner: &mut STLayoutInterner<'a>,
         _buf: &mut Vec<'a, u8>,
         id: &JoinPointId,
         params: &'a [Param<'a>],
@@ -1021,7 +1037,7 @@ impl<
                         .insert(*symbol, Rc::new((base_offset, 8)));
                 }
                 _ => {
-                    let stack_size = layout.stack_size(self.env.layout_interner, self.target_info);
+                    let stack_size = layout.stack_size(layout_interner, self.target_info);
                     if stack_size == 0 {
                         self.symbol_storage_map.insert(*symbol, NoData);
                     } else {
@@ -1038,6 +1054,7 @@ impl<
     /// This enables the jump to correctly passe arguments to the joinpoint.
     pub fn setup_jump(
         &mut self,
+        layout_interner: &mut STLayoutInterner<'a>,
         buf: &mut Vec<'a, u8>,
         id: &JoinPointId,
         args: &[Symbol],
@@ -1065,7 +1082,13 @@ impl<
                     // Maybe we want a more memcpy like method to directly get called here.
                     // That would also be capable of asserting the size.
                     // Maybe copy stack to stack or something.
-                    self.copy_symbol_to_stack_offset(buf, *base_offset, sym, layout);
+                    self.copy_symbol_to_stack_offset(
+                        layout_interner,
+                        buf,
+                        *base_offset,
+                        sym,
+                        layout,
+                    );
                 }
                 Stack(Primitive {
                     base_offset,

--- a/crates/compiler/gen_dev/src/generic64/x86_64.rs
+++ b/crates/compiler/gen_dev/src/generic64/x86_64.rs
@@ -803,7 +803,7 @@ impl CallConv<X86_64GeneralReg, X86_64FloatReg, X86_64Assembler> for X86_64Windo
             X86_64Assembler,
             X86_64WindowsFastcall,
         >,
-        layout_interner: &mut STLayoutInterner<'a>,
+        _layout_interner: &mut STLayoutInterner<'a>,
         _sym: &Symbol,
         _layout: &Layout<'a>,
     ) {
@@ -820,7 +820,7 @@ impl CallConv<X86_64GeneralReg, X86_64FloatReg, X86_64Assembler> for X86_64Windo
             X86_64Assembler,
             X86_64WindowsFastcall,
         >,
-        layout_interner: &mut STLayoutInterner<'a>,
+        _layout_interner: &mut STLayoutInterner<'a>,
         _sym: &Symbol,
         _layout: &Layout<'a>,
     ) {

--- a/crates/compiler/gen_dev/src/object_builder.rs
+++ b/crates/compiler/gen_dev/src/object_builder.rs
@@ -12,7 +12,7 @@ use roc_error_macros::internal_error;
 use roc_module::symbol;
 use roc_module::symbol::Interns;
 use roc_mono::ir::{Proc, ProcLayout};
-use roc_mono::layout::LayoutIds;
+use roc_mono::layout::{LayoutIds, STLayoutInterner};
 use roc_target::TargetInfo;
 use target_lexicon::{Architecture as TargetArch, BinaryFormat as TargetBF, Triple};
 
@@ -22,9 +22,10 @@ use target_lexicon::{Architecture as TargetArch, BinaryFormat as TargetBF, Tripl
 
 /// build_module is the high level builder/delegator.
 /// It takes the request to build a module and output the object file for the module.
-pub fn build_module<'a>(
-    env: &'a Env,
-    interns: &'a mut Interns,
+pub fn build_module<'a, 'r>(
+    env: &'r Env<'a>,
+    interns: &'r mut Interns,
+    layout_interner: &'r mut STLayoutInterner<'a>,
     target: &Triple,
     procedures: MutMap<(symbol::Symbol, ProcLayout<'a>), Proc<'a>>,
 ) -> Object<'a> {
@@ -39,7 +40,7 @@ pub fn build_module<'a>(
                 x86_64::X86_64FloatReg,
                 x86_64::X86_64Assembler,
                 x86_64::X86_64SystemV,
-            >(env, TargetInfo::default_x86_64(), interns);
+            >(env, TargetInfo::default_x86_64(), interns, layout_interner);
             build_object(
                 procedures,
                 backend,
@@ -56,7 +57,7 @@ pub fn build_module<'a>(
                 x86_64::X86_64FloatReg,
                 x86_64::X86_64Assembler,
                 x86_64::X86_64SystemV,
-            >(env, TargetInfo::default_x86_64(), interns);
+            >(env, TargetInfo::default_x86_64(), interns, layout_interner);
             build_object(
                 procedures,
                 backend,
@@ -72,12 +73,13 @@ pub fn build_module<'a>(
             binary_format: TargetBF::Elf,
             ..
         } if cfg!(feature = "target-aarch64") => {
-            let backend = new_backend_64bit::<
-                aarch64::AArch64GeneralReg,
-                aarch64::AArch64FloatReg,
-                aarch64::AArch64Assembler,
-                aarch64::AArch64Call,
-            >(env, TargetInfo::default_aarch64(), interns);
+            let backend =
+                new_backend_64bit::<
+                    aarch64::AArch64GeneralReg,
+                    aarch64::AArch64FloatReg,
+                    aarch64::AArch64Assembler,
+                    aarch64::AArch64Call,
+                >(env, TargetInfo::default_aarch64(), interns, layout_interner);
             build_object(
                 procedures,
                 backend,
@@ -89,12 +91,13 @@ pub fn build_module<'a>(
             binary_format: TargetBF::Macho,
             ..
         } if cfg!(feature = "target-aarch64") => {
-            let backend = new_backend_64bit::<
-                aarch64::AArch64GeneralReg,
-                aarch64::AArch64FloatReg,
-                aarch64::AArch64Assembler,
-                aarch64::AArch64Call,
-            >(env, TargetInfo::default_aarch64(), interns);
+            let backend =
+                new_backend_64bit::<
+                    aarch64::AArch64GeneralReg,
+                    aarch64::AArch64FloatReg,
+                    aarch64::AArch64Assembler,
+                    aarch64::AArch64Call,
+                >(env, TargetInfo::default_aarch64(), interns, layout_interner);
             build_object(
                 procedures,
                 backend,
@@ -245,11 +248,11 @@ fn build_object<'a, B: Backend<'a>>(
     let helper_procs = {
         let module_id = backend.env().module_id;
 
-        let (env, interns, helper_proc_gen) = backend.env_interns_helpers_mut();
+        let (module_id, _interner, interns, helper_proc_gen) = backend.module_interns_helpers_mut();
 
         let ident_ids = interns.all_ident_ids.get_mut(&module_id).unwrap();
         let helper_procs = helper_proc_gen.take_procs();
-        env.module_id.register_debug_idents(ident_ids);
+        module_id.register_debug_idents(ident_ids);
 
         helper_procs
     };

--- a/crates/compiler/gen_dev/src/object_builder.rs
+++ b/crates/compiler/gen_dev/src/object_builder.rs
@@ -246,8 +246,6 @@ fn build_object<'a, B: Backend<'a>>(
 
     // Generate IR for specialized helper procs (refcounting & equality)
     let helper_procs = {
-        let module_id = backend.env().module_id;
-
         let (module_id, _interner, interns, helper_proc_gen) = backend.module_interns_helpers_mut();
 
         let ident_ids = interns.all_ident_ids.get_mut(&module_id).unwrap();

--- a/crates/compiler/gen_llvm/Cargo.toml
+++ b/crates/compiler/gen_llvm/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 [dependencies]
 roc_alias_analysis = { path = "../alias_analysis" }
 roc_collections = { path = "../collections" }
+roc_intern = { path = "../intern" }
 roc_module = { path = "../module" }
 roc_builtins = { path = "../builtins" }
 roc_error_macros = { path = "../../error_macros" }

--- a/crates/compiler/gen_llvm/src/llvm/convert.rs
+++ b/crates/compiler/gen_llvm/src/llvm/convert.rs
@@ -5,6 +5,7 @@ use inkwell::types::{BasicType, BasicTypeEnum, FloatType, IntType, StructType};
 use inkwell::values::StructValue;
 use inkwell::AddressSpace;
 use roc_builtins::bitcode::{FloatWidth, IntWidth};
+use roc_intern::Interner;
 use roc_mono::layout::{round_up_to_alignment, Builtin, Layout, STLayoutInterner, UnionLayout};
 use roc_target::TargetInfo;
 
@@ -38,6 +39,7 @@ pub fn basic_type_from_layout<'a, 'ctx, 'env>(
             basic_type_from_layout(env, &lambda_set.runtime_representation(env.layout_interner))
         }
         Boxed(inner_layout) => {
+            let inner_layout = env.layout_interner.get(*inner_layout);
             let inner_type = basic_type_from_layout(env, inner_layout);
 
             inner_type.ptr_type(AddressSpace::Generic).into()

--- a/crates/compiler/gen_llvm/src/llvm/expect.rs
+++ b/crates/compiler/gen_llvm/src/llvm/expect.rs
@@ -9,6 +9,7 @@ use inkwell::types::{BasicMetadataTypeEnum, BasicType, BasicTypeEnum};
 use inkwell::values::{BasicValueEnum, FunctionValue, IntValue, PointerValue};
 use inkwell::AddressSpace;
 use roc_builtins::bitcode;
+use roc_intern::Interner;
 use roc_module::symbol::Symbol;
 use roc_mono::ir::LookupType;
 use roc_mono::layout::{Builtin, Layout, LayoutIds, UnionLayout};
@@ -348,6 +349,7 @@ fn build_clone<'a, 'ctx, 'env>(
             build_copy(env, ptr, cursors.offset, cursors.extra_offset.into());
 
             let source = value.into_pointer_value();
+            let inner_layout = env.layout_interner.get(inner_layout);
             let value = load_roc_value(env, *inner_layout, source, "inner");
 
             let inner_width = env.ptr_int().const_int(

--- a/crates/compiler/gen_llvm/src/llvm/refcounting.rs
+++ b/crates/compiler/gen_llvm/src/llvm/refcounting.rs
@@ -17,7 +17,7 @@ use inkwell::values::{
 use inkwell::{AddressSpace, IntPredicate};
 use roc_module::symbol::Interns;
 use roc_module::symbol::Symbol;
-use roc_mono::layout::{Builtin, Layout, LayoutIds, STLayoutInterner, UnionLayout};
+use roc_mono::layout::{Builtin, InLayout, Layout, LayoutIds, STLayoutInterner, UnionLayout};
 
 use super::build::{cast_if_necessary_for_opaque_recursive_pointers, load_roc_value, FunctionSpec};
 use super::convert::{argument_type_from_layout, argument_type_from_union_layout};
@@ -531,7 +531,7 @@ fn modify_refcount_layout_build_function<'a, 'ctx, 'env>(
         }
 
         Boxed(inner) => {
-            let function = modify_refcount_boxed(env, layout_ids, mode, inner);
+            let function = modify_refcount_boxed(env, layout_ids, mode, *inner);
 
             Some(function)
         }
@@ -851,7 +851,7 @@ fn modify_refcount_boxed<'a, 'ctx, 'env>(
     env: &Env<'a, 'ctx, 'env>,
     layout_ids: &mut LayoutIds<'a>,
     mode: Mode,
-    inner_layout: &'a Layout<'a>,
+    inner_layout: InLayout<'a>,
 ) -> FunctionValue<'ctx> {
     let block = env.builder.get_insert_block().expect("to be in a function");
     let di_location = env.builder.get_current_debug_location().unwrap();
@@ -889,7 +889,7 @@ fn modify_refcount_boxed<'a, 'ctx, 'env>(
 fn modify_refcount_box_help<'a, 'ctx, 'env>(
     env: &Env<'a, 'ctx, 'env>,
     mode: Mode,
-    inner_layout: &Layout<'a>,
+    inner_layout: InLayout<'a>,
     fn_val: FunctionValue<'ctx>,
 ) {
     let builder = env.builder;

--- a/crates/compiler/gen_wasm/src/low_level.rs
+++ b/crates/compiler/gen_wasm/src/low_level.rs
@@ -2,6 +2,7 @@ use bumpalo::collections::Vec;
 use bumpalo::Bump;
 use roc_builtins::bitcode::{self, FloatWidth, IntWidth};
 use roc_error_macros::internal_error;
+use roc_intern::Interner;
 use roc_module::low_level::LowLevel;
 use roc_module::symbol::Symbol;
 use roc_mono::code_gen_help::HelperOp;
@@ -34,7 +35,7 @@ enum CodeGenNumType {
 }
 
 impl CodeGenNumType {
-    pub fn for_symbol(backend: &WasmBackend<'_>, symbol: Symbol) -> Self {
+    pub fn for_symbol(backend: &WasmBackend<'_, '_>, symbol: Symbol) -> Self {
         Self::from(backend.storage.get(&symbol))
     }
 }
@@ -124,7 +125,7 @@ fn layout_is_signed_int(layout: &Layout) -> bool {
     }
 }
 
-fn symbol_is_signed_int(backend: &WasmBackend<'_>, symbol: Symbol) -> bool {
+fn symbol_is_signed_int(backend: &WasmBackend<'_, '_>, symbol: Symbol) -> bool {
     layout_is_signed_int(&backend.storage.symbol_layouts[&symbol])
 }
 
@@ -141,18 +142,18 @@ impl<'a> LowLevelCall<'a> {
     /// For numerical ops, this just pushes the arguments to the Wasm VM's value stack
     /// It implements the calling convention used by Zig for both numbers and structs
     /// Result is the type signature of the call
-    fn load_args(&self, backend: &mut WasmBackend<'a>) -> (usize, bool, bool) {
+    fn load_args(&self, backend: &mut WasmBackend<'a, '_>) -> (usize, bool, bool) {
         backend.storage.load_symbols_for_call(
             backend.env.arena,
             &mut backend.code_builder,
             self.arguments,
             self.ret_symbol,
-            &WasmLayout::new(backend.env.layout_interner, &self.ret_layout),
+            &WasmLayout::new(backend.layout_interner, &self.ret_layout),
             CallConv::Zig,
         )
     }
 
-    fn load_args_and_call_zig(&self, backend: &mut WasmBackend<'a>, name: &'a str) {
+    fn load_args_and_call_zig(&self, backend: &mut WasmBackend<'a, '_>, name: &'a str) {
         let (num_wasm_args, has_return_val, ret_zig_packed_struct) = self.load_args(backend);
         backend.call_host_fn_after_loading_args(name, num_wasm_args, has_return_val);
 
@@ -182,7 +183,7 @@ impl<'a> LowLevelCall<'a> {
     /// This may seem like deliberately introducing an error!
     /// But we want all targets to behave the same, and hash algos rely on wrapping.
     /// Discussion: https://github.com/roc-lang/roc/pull/2117#discussion_r760723063
-    fn wrap_small_int(&self, backend: &mut WasmBackend<'a>, int_width: IntWidth) {
+    fn wrap_small_int(&self, backend: &mut WasmBackend<'a, '_>, int_width: IntWidth) {
         let bits = 8 * int_width.stack_size() as i32;
         let shift = 32 - bits;
         if shift <= 0 {
@@ -200,7 +201,7 @@ impl<'a> LowLevelCall<'a> {
     }
 
     ///  Main entrypoint from WasmBackend
-    pub fn generate(&self, backend: &mut WasmBackend<'a>) {
+    pub fn generate(&self, backend: &mut WasmBackend<'a, '_>) {
         use CodeGenNumType::*;
         use LowLevel::*;
 
@@ -281,7 +282,7 @@ impl<'a> LowLevelCall<'a> {
                     &mut backend.code_builder,
                     self.arguments,
                     self.ret_symbol,
-                    &WasmLayout::new(backend.env.layout_interner, &self.ret_layout),
+                    &WasmLayout::new(backend.layout_interner, &self.ret_layout),
                     CallConv::Zig,
                 );
                 backend.code_builder.i32_const(UPDATE_MODE_IMMUTABLE);
@@ -360,7 +361,7 @@ impl<'a> LowLevelCall<'a> {
                     .load_symbols(&mut backend.code_builder, &[index]);
                 let elem_size = self
                     .ret_layout
-                    .stack_size(backend.env.layout_interner, TARGET_INFO);
+                    .stack_size(backend.layout_interner, TARGET_INFO);
                 backend.code_builder.i32_const(elem_size as i32);
                 backend.code_builder.i32_mul(); // index*size
 
@@ -418,7 +419,7 @@ impl<'a> LowLevelCall<'a> {
                     } if value_layout == *list_elem => {
                         let list_offset = 0;
                         let elem_offset = Layout::Builtin(Builtin::List(list_elem))
-                            .stack_size(backend.env.layout_interner, TARGET_INFO);
+                            .stack_size(backend.layout_interner, TARGET_INFO);
                         (list_offset, elem_offset, value_layout)
                     }
                     Layout::Struct {
@@ -426,7 +427,7 @@ impl<'a> LowLevelCall<'a> {
                         ..
                     } if value_layout == *list_elem => {
                         let list_offset =
-                            value_layout.stack_size(backend.env.layout_interner, TARGET_INFO);
+                            value_layout.stack_size(backend.layout_interner, TARGET_INFO);
                         let elem_offset = 0;
                         (list_offset, elem_offset, value_layout)
                     }
@@ -434,7 +435,7 @@ impl<'a> LowLevelCall<'a> {
                 };
 
                 let (elem_width, elem_alignment) =
-                    elem_layout.stack_size_and_alignment(backend.env.layout_interner, TARGET_INFO);
+                    elem_layout.stack_size_and_alignment(backend.layout_interner, TARGET_INFO);
 
                 // Ensure the new element is stored in memory so we can pass a pointer to Zig
                 let (new_elem_local, new_elem_offset, _) =
@@ -484,7 +485,7 @@ impl<'a> LowLevelCall<'a> {
                 let capacity: Symbol = self.arguments[0];
                 let elem_layout = unwrap_list_elem_layout(self.ret_layout);
                 let (elem_width, elem_align) =
-                    elem_layout.stack_size_and_alignment(backend.env.layout_interner, TARGET_INFO);
+                    elem_layout.stack_size_and_alignment(backend.layout_interner, TARGET_INFO);
 
                 // Zig arguments              Wasm types
                 //  (return pointer)           i32
@@ -515,14 +516,14 @@ impl<'a> LowLevelCall<'a> {
                     &mut backend.code_builder,
                     self.arguments,
                     self.ret_symbol,
-                    &WasmLayout::new(backend.env.layout_interner, &self.ret_layout),
+                    &WasmLayout::new(backend.layout_interner, &self.ret_layout),
                     CallConv::Zig,
                 );
 
                 // Load monomorphization constants
                 let elem_layout = unwrap_list_elem_layout(self.ret_layout);
                 let (elem_width, elem_align) =
-                    elem_layout.stack_size_and_alignment(backend.env.layout_interner, TARGET_INFO);
+                    elem_layout.stack_size_and_alignment(backend.layout_interner, TARGET_INFO);
                 backend.code_builder.i32_const(elem_align as i32);
                 backend.code_builder.i32_const(elem_width as i32);
 
@@ -537,7 +538,7 @@ impl<'a> LowLevelCall<'a> {
 
                 let elem_layout = unwrap_list_elem_layout(self.ret_layout);
                 let (elem_width, elem_align) =
-                    elem_layout.stack_size_and_alignment(backend.env.layout_interner, TARGET_INFO);
+                    elem_layout.stack_size_and_alignment(backend.layout_interner, TARGET_INFO);
                 let (spare_local, spare_offset, _) = ensure_symbol_is_in_memory(
                     backend,
                     spare,
@@ -559,7 +560,7 @@ impl<'a> LowLevelCall<'a> {
                     &mut backend.code_builder,
                     &[list],
                     self.ret_symbol,
-                    &WasmLayout::new(backend.env.layout_interner, &self.ret_layout),
+                    &WasmLayout::new(backend.layout_interner, &self.ret_layout),
                     CallConv::Zig,
                 );
 
@@ -585,7 +586,7 @@ impl<'a> LowLevelCall<'a> {
                 let elem: Symbol = self.arguments[1];
 
                 let elem_layout = unwrap_list_elem_layout(self.ret_layout);
-                let elem_width = elem_layout.stack_size(backend.env.layout_interner, TARGET_INFO);
+                let elem_width = elem_layout.stack_size(backend.layout_interner, TARGET_INFO);
                 let (elem_local, elem_offset, _) =
                     ensure_symbol_is_in_memory(backend, elem, *elem_layout, backend.env.arena);
 
@@ -601,7 +602,7 @@ impl<'a> LowLevelCall<'a> {
                     &mut backend.code_builder,
                     &[list],
                     self.ret_symbol,
-                    &WasmLayout::new(backend.env.layout_interner, &self.ret_layout),
+                    &WasmLayout::new(backend.layout_interner, &self.ret_layout),
                     CallConv::Zig,
                 );
 
@@ -623,7 +624,7 @@ impl<'a> LowLevelCall<'a> {
 
                 let elem_layout = unwrap_list_elem_layout(self.ret_layout);
                 let (elem_width, elem_align) =
-                    elem_layout.stack_size_and_alignment(backend.env.layout_interner, TARGET_INFO);
+                    elem_layout.stack_size_and_alignment(backend.layout_interner, TARGET_INFO);
                 let (elem_local, elem_offset, _) =
                     ensure_symbol_is_in_memory(backend, elem, *elem_layout, backend.env.arena);
 
@@ -640,7 +641,7 @@ impl<'a> LowLevelCall<'a> {
                     &mut backend.code_builder,
                     &[list],
                     self.ret_symbol,
-                    &WasmLayout::new(backend.env.layout_interner, &self.ret_layout),
+                    &WasmLayout::new(backend.layout_interner, &self.ret_layout),
                     CallConv::Zig,
                 );
 
@@ -665,7 +666,7 @@ impl<'a> LowLevelCall<'a> {
 
                 let elem_layout = unwrap_list_elem_layout(self.ret_layout);
                 let (elem_width, elem_align) =
-                    elem_layout.stack_size_and_alignment(backend.env.layout_interner, TARGET_INFO);
+                    elem_layout.stack_size_and_alignment(backend.layout_interner, TARGET_INFO);
 
                 // The refcount function receives a pointer to an element in the list
                 // This is the same as a Struct containing the element
@@ -690,7 +691,7 @@ impl<'a> LowLevelCall<'a> {
                     &mut backend.code_builder,
                     &[list],
                     self.ret_symbol,
-                    &WasmLayout::new(backend.env.layout_interner, &self.ret_layout),
+                    &WasmLayout::new(backend.layout_interner, &self.ret_layout),
                     CallConv::Zig,
                 );
 
@@ -710,7 +711,7 @@ impl<'a> LowLevelCall<'a> {
 
                 let elem_layout = unwrap_list_elem_layout(self.ret_layout);
                 let (elem_width, elem_align) =
-                    elem_layout.stack_size_and_alignment(backend.env.layout_interner, TARGET_INFO);
+                    elem_layout.stack_size_and_alignment(backend.layout_interner, TARGET_INFO);
 
                 // The refcount function receives a pointer to an element in the list
                 // This is the same as a Struct containing the element
@@ -735,7 +736,7 @@ impl<'a> LowLevelCall<'a> {
                     &mut backend.code_builder,
                     &[list],
                     self.ret_symbol,
-                    &WasmLayout::new(backend.env.layout_interner, &self.ret_layout),
+                    &WasmLayout::new(backend.layout_interner, &self.ret_layout),
                     CallConv::Zig,
                 );
 
@@ -756,7 +757,7 @@ impl<'a> LowLevelCall<'a> {
 
                 let elem_layout = unwrap_list_elem_layout(self.ret_layout);
                 let (elem_width, elem_align) =
-                    elem_layout.stack_size_and_alignment(backend.env.layout_interner, TARGET_INFO);
+                    elem_layout.stack_size_and_alignment(backend.layout_interner, TARGET_INFO);
 
                 // Zig arguments              Wasm types
                 //  (return pointer)           i32
@@ -773,7 +774,7 @@ impl<'a> LowLevelCall<'a> {
                     &mut backend.code_builder,
                     &[list],
                     self.ret_symbol,
-                    &WasmLayout::new(backend.env.layout_interner, &self.ret_layout),
+                    &WasmLayout::new(backend.layout_interner, &self.ret_layout),
                     CallConv::Zig,
                 );
 
@@ -1631,7 +1632,7 @@ impl<'a> LowLevelCall<'a> {
                         // We need to make that conversion explicit for i8 and i16, which use Wasm's i32 type.
                         let bit_width = 8 * self
                             .ret_layout
-                            .stack_size(backend.env.layout_interner, TARGET_INFO)
+                            .stack_size(backend.layout_interner, TARGET_INFO)
                             as i32;
                         if bit_width < 32 && !symbol_is_signed_int(backend, num) {
                             // Sign-extend the number by shifting left and right again
@@ -1680,7 +1681,7 @@ impl<'a> LowLevelCall<'a> {
                         // We need to make that conversion explicit for i8 and i16, which use Wasm's i32 type.
                         let bit_width = 8 * self
                             .ret_layout
-                            .stack_size(backend.env.layout_interner, TARGET_INFO);
+                            .stack_size(backend.layout_interner, TARGET_INFO);
                         if bit_width < 32 && symbol_is_signed_int(backend, num) {
                             let mask = (1 << bit_width) - 1;
 
@@ -1872,11 +1873,11 @@ impl<'a> LowLevelCall<'a> {
 
     /// Equality and inequality
     /// These can operate on any data type (except functions) so they're more complex than other operators.
-    fn eq_or_neq(&self, backend: &mut WasmBackend<'a>) {
+    fn eq_or_neq(&self, backend: &mut WasmBackend<'a, '_>) {
         let arg_layout = backend.storage.symbol_layouts[&self.arguments[0]]
-            .runtime_representation(backend.env.layout_interner);
+            .runtime_representation(backend.layout_interner);
         let other_arg_layout = backend.storage.symbol_layouts[&self.arguments[1]]
-            .runtime_representation(backend.env.layout_interner);
+            .runtime_representation(backend.layout_interner);
         debug_assert!(
             arg_layout == other_arg_layout,
             "Cannot do `==` comparison on different types: {:?} vs {:?}",
@@ -1941,7 +1942,7 @@ impl<'a> LowLevelCall<'a> {
         }
     }
 
-    fn eq_or_neq_number(&self, backend: &mut WasmBackend<'a>) {
+    fn eq_or_neq_number(&self, backend: &mut WasmBackend<'a, '_>) {
         use StoredValue::*;
 
         match backend.storage.get(&self.arguments[0]).to_owned() {
@@ -1986,7 +1987,7 @@ impl<'a> LowLevelCall<'a> {
     /// Takes care of loading the arguments
     fn eq_num128(
         &self,
-        backend: &mut WasmBackend<'a>,
+        backend: &mut WasmBackend<'a, '_>,
         format: StackMemoryFormat,
         locations: [StackMemoryLocation; 2],
     ) {
@@ -2004,7 +2005,7 @@ impl<'a> LowLevelCall<'a> {
     /// Check that two 128-bit numbers contain the same bytes
     /// Loads *half* an argument at a time
     /// (Don't call "load arguments" or "load symbols" helpers before this, it'll just waste instructions)
-    fn eq_num128_bytes(backend: &mut WasmBackend<'a>, locations: [StackMemoryLocation; 2]) {
+    fn eq_num128_bytes(backend: &mut WasmBackend<'a, '_>, locations: [StackMemoryLocation; 2]) {
         let (local0, offset0) = locations[0].local_and_offset(backend.storage.stack_frame_pointer);
         let (local1, offset1) = locations[1].local_and_offset(backend.storage.stack_frame_pointer);
 
@@ -2026,7 +2027,7 @@ impl<'a> LowLevelCall<'a> {
         backend.code_builder.i32_and();
     }
 
-    fn num_to_str(&self, backend: &mut WasmBackend<'a>) {
+    fn num_to_str(&self, backend: &mut WasmBackend<'a, '_>) {
         let arg_layout = backend.storage.symbol_layouts[&self.arguments[0]];
         match arg_layout {
             Layout::Builtin(Builtin::Int(width)) => {
@@ -2051,7 +2052,7 @@ impl<'a> LowLevelCall<'a> {
 }
 
 /// Helper for NumIsFinite op, and also part of Eq/NotEq
-fn num_is_finite(backend: &mut WasmBackend<'_>, argument: Symbol) {
+fn num_is_finite(backend: &mut WasmBackend<'_, '_>, argument: Symbol) {
     use StoredValue::*;
     let stored = backend.storage.get(&argument).to_owned();
     match stored {
@@ -2094,7 +2095,7 @@ fn num_is_finite(backend: &mut WasmBackend<'_>, argument: Symbol) {
 }
 
 pub fn call_higher_order_lowlevel<'a>(
-    backend: &mut WasmBackend<'a>,
+    backend: &mut WasmBackend<'a, '_>,
     return_sym: Symbol,
     return_layout: &Layout<'a>,
     higher_order: &'a HigherOrderLowLevel<'a>,
@@ -2131,12 +2132,9 @@ pub fn call_higher_order_lowlevel<'a>(
     let (closure_data_layout, closure_data_exists) =
         match backend.storage.symbol_layouts[captured_environment] {
             Layout::LambdaSet(lambda_set) => {
-                if lambda_set
-                    .is_represented(backend.env.layout_interner)
-                    .is_some()
-                {
+                if lambda_set.is_represented(backend.layout_interner).is_some() {
                     (
-                        lambda_set.runtime_representation(backend.env.layout_interner),
+                        lambda_set.runtime_representation(backend.layout_interner),
                         true,
                     )
                 } else {
@@ -2162,7 +2160,7 @@ pub fn call_higher_order_lowlevel<'a>(
         // make sure that the wrapping struct is available in stack memory, so we can hand out a
         // pointer to it.
         let wrapped_storage = backend.storage.allocate_var(
-            backend.env.layout_interner,
+            backend.layout_interner,
             wrapped_captures_layout,
             wrapped_closure_data_sym,
             crate::storage::StoredVarKind::Variable,
@@ -2226,17 +2224,19 @@ pub fn call_higher_order_lowlevel<'a>(
             argument_layouts.len()
         };
 
+        let boxed_closure_arg_layouts =
+            argument_layouts.iter().take(n_non_closure_args).map(|lay| {
+                let lay_in = backend.layout_interner.insert(lay);
+                Layout::Boxed(lay_in)
+            });
+
         wrapper_arg_layouts.push(wrapped_captures_layout);
-        wrapper_arg_layouts.extend(
-            argument_layouts
-                .iter()
-                .take(n_non_closure_args)
-                .map(Layout::Boxed),
-        );
+        wrapper_arg_layouts.extend(boxed_closure_arg_layouts);
 
         match helper_proc_source {
             ProcSource::HigherOrderMapper(_) => {
                 // Our convention for mappers is that they write to the heap via the last argument
+                let result_layout = backend.layout_interner.insert(result_layout);
                 wrapper_arg_layouts.push(Layout::Boxed(result_layout));
                 ProcLayout {
                     arguments: wrapper_arg_layouts.into_bump_slice(),
@@ -2326,7 +2326,7 @@ pub fn call_higher_order_lowlevel<'a>(
         ListSortWith { xs } => {
             let elem_layout = unwrap_list_elem_layout(backend.storage.symbol_layouts[xs]);
             let (element_width, alignment) =
-                elem_layout.stack_size_and_alignment(backend.env.layout_interner, TARGET_INFO);
+                elem_layout.stack_size_and_alignment(backend.layout_interner, TARGET_INFO);
 
             let cb = &mut backend.code_builder;
 
@@ -2371,7 +2371,7 @@ fn unwrap_list_elem_layout(list_layout: Layout<'_>) -> &Layout<'_> {
 #[allow(clippy::too_many_arguments)]
 fn list_map_n<'a>(
     zig_fn_name: &'static str,
-    backend: &mut WasmBackend<'a>,
+    backend: &mut WasmBackend<'a, '_>,
     arg_symbols: &[Symbol],
     return_sym: Symbol,
     return_layout: Layout<'a>,
@@ -2390,7 +2390,7 @@ fn list_map_n<'a>(
 
     let elem_ret = unwrap_list_elem_layout(return_layout);
     let (elem_ret_size, elem_ret_align) =
-        elem_ret.stack_size_and_alignment(backend.env.layout_interner, TARGET_INFO);
+        elem_ret.stack_size_and_alignment(backend.layout_interner, TARGET_INFO);
 
     let cb = &mut backend.code_builder;
 
@@ -2411,7 +2411,7 @@ fn list_map_n<'a>(
     cb.i32_const(owns_captured_environment as i32);
     cb.i32_const(elem_ret_align as i32);
     for el in arg_elem_layouts.iter() {
-        cb.i32_const(el.stack_size(backend.env.layout_interner, TARGET_INFO) as i32);
+        cb.i32_const(el.stack_size(backend.layout_interner, TARGET_INFO) as i32);
     }
     cb.i32_const(elem_ret_size as i32);
 
@@ -2438,7 +2438,7 @@ fn list_map_n<'a>(
 }
 
 fn ensure_symbol_is_in_memory<'a>(
-    backend: &mut WasmBackend<'a>,
+    backend: &mut WasmBackend<'a, '_>,
     symbol: Symbol,
     layout: Layout<'a>,
     arena: &'a Bump,
@@ -2451,7 +2451,7 @@ fn ensure_symbol_is_in_memory<'a>(
         }
         _ => {
             let (width, alignment) =
-                layout.stack_size_and_alignment(backend.env.layout_interner, TARGET_INFO);
+                layout.stack_size_and_alignment(backend.layout_interner, TARGET_INFO);
             let (frame_ptr, offset) = backend
                 .storage
                 .allocate_anonymous_stack_memory(width, alignment);

--- a/crates/compiler/load_internal/src/file.rs
+++ b/crates/compiler/load_internal/src/file.rs
@@ -3028,14 +3028,14 @@ fn update<'a>(
                         std::mem::swap(&mut state.layout_interner, &mut taken);
                         taken
                     };
-                    let layout_interner = layout_interner
+                    let mut layout_interner = layout_interner
                         .unwrap()
                         .expect("outstanding references to global layout interener, but we just drained all layout caches");
 
                     log!("specializations complete from {:?}", module_id);
 
                     debug_print_ir!(state, &layout_interner, ROC_PRINT_IR_AFTER_SPECIALIZATION);
-                    debug_check_ir!(state, arena, &layout_interner, ROC_CHECK_MONO_IR);
+                    debug_check_ir!(state, arena, &mut layout_interner, ROC_CHECK_MONO_IR);
 
                     let ident_ids = state.constrained_ident_ids.get_mut(&module_id).unwrap();
 

--- a/crates/compiler/load_internal/src/file.rs
+++ b/crates/compiler/load_internal/src/file.rs
@@ -3028,9 +3028,12 @@ fn update<'a>(
                         std::mem::swap(&mut state.layout_interner, &mut taken);
                         taken
                     };
-                    let mut layout_interner = layout_interner
+                    let layout_interner = layout_interner
                         .unwrap()
                         .expect("outstanding references to global layout interener, but we just drained all layout caches");
+
+                    #[cfg(debug_assertions)]
+                    let mut layout_interner = layout_interner;
 
                     log!("specializations complete from {:?}", module_id);
 

--- a/crates/compiler/load_internal/src/file.rs
+++ b/crates/compiler/load_internal/src/file.rs
@@ -2276,9 +2276,9 @@ macro_rules! debug_check_ir {
 
             let procedures = &$state.procedures;
 
-            let problems = check_procs($arena, $interner, procedures);
+            let problems = check_procs($arena, &mut $interner, procedures);
             if !problems.is_empty() {
-                let formatted = format_problems(&interns, $interner, problems);
+                let formatted = format_problems(&interns, &$interner, problems);
                 eprintln!("IR PROBLEMS FOUND:\n{formatted}");
             }
         })
@@ -3038,7 +3038,7 @@ fn update<'a>(
                     log!("specializations complete from {:?}", module_id);
 
                     debug_print_ir!(state, &layout_interner, ROC_PRINT_IR_AFTER_SPECIALIZATION);
-                    debug_check_ir!(state, arena, &mut layout_interner, ROC_CHECK_MONO_IR);
+                    debug_check_ir!(state, arena, layout_interner, ROC_CHECK_MONO_IR);
 
                     let ident_ids = state.constrained_ident_ids.get_mut(&module_id).unwrap();
 

--- a/crates/compiler/mono/src/code_gen_help/equality.rs
+++ b/crates/compiler/mono/src/code_gen_help/equality.rs
@@ -1,11 +1,12 @@
 use bumpalo::collections::vec::Vec;
+use roc_intern::Interner;
 use roc_module::low_level::LowLevel;
 use roc_module::symbol::{IdentIds, Symbol};
 
 use crate::ir::{
     BranchInfo, Call, CallType, Expr, JoinPointId, Literal, Param, Stmt, UpdateModeId,
 };
-use crate::layout::{Builtin, Layout, TagIdIntType, UnionLayout};
+use crate::layout::{Builtin, InLayout, Layout, STLayoutInterner, TagIdIntType, UnionLayout};
 
 use super::{let_lowlevel, CodeGenHelp, Context, LAYOUT_BOOL};
 
@@ -16,6 +17,7 @@ pub fn eq_generic<'a>(
     root: &mut CodeGenHelp<'a>,
     ident_ids: &mut IdentIds,
     ctx: &mut Context<'a>,
+    layout_interner: &mut STLayoutInterner<'a>,
     layout: Layout<'a>,
 ) -> Stmt<'a> {
     let main_body = match layout {
@@ -28,10 +30,18 @@ pub fn eq_generic<'a>(
         Layout::Builtin(Builtin::Str) => {
             unreachable!("No generated helper proc for `==` on Str. Use Zig function.")
         }
-        Layout::Builtin(Builtin::List(elem_layout)) => eq_list(root, ident_ids, ctx, elem_layout),
-        Layout::Struct { field_layouts, .. } => eq_struct(root, ident_ids, ctx, field_layouts),
-        Layout::Union(union_layout) => eq_tag_union(root, ident_ids, ctx, union_layout),
-        Layout::Boxed(inner_layout) => eq_boxed(root, ident_ids, ctx, inner_layout),
+        Layout::Builtin(Builtin::List(elem_layout)) => {
+            eq_list(root, ident_ids, ctx, layout_interner, elem_layout)
+        }
+        Layout::Struct { field_layouts, .. } => {
+            eq_struct(root, ident_ids, ctx, layout_interner, field_layouts)
+        }
+        Layout::Union(union_layout) => {
+            eq_tag_union(root, ident_ids, ctx, layout_interner, union_layout)
+        }
+        Layout::Boxed(inner_layout) => {
+            eq_boxed(root, ident_ids, ctx, layout_interner, inner_layout)
+        }
         Layout::LambdaSet(_) => unreachable!("`==` is not defined on functions"),
         Layout::RecursivePointer => {
             unreachable!(
@@ -129,6 +139,7 @@ fn eq_struct<'a>(
     root: &mut CodeGenHelp<'a>,
     ident_ids: &mut IdentIds,
     ctx: &mut Context<'a>,
+    layout_interner: &mut STLayoutInterner<'a>,
     field_layouts: &'a [Layout<'a>],
 ) -> Stmt<'a> {
     let mut else_stmt = Stmt::Ret(Symbol::BOOL_TRUE);
@@ -153,6 +164,7 @@ fn eq_struct<'a>(
             .call_specialized_op(
                 ident_ids,
                 ctx,
+                layout_interner,
                 *layout,
                 root.arena.alloc([field1_sym, field2_sym]),
             )
@@ -181,6 +193,7 @@ fn eq_tag_union<'a>(
     root: &mut CodeGenHelp<'a>,
     ident_ids: &mut IdentIds,
     ctx: &mut Context<'a>,
+    layout_interner: &mut STLayoutInterner<'a>,
     union_layout: UnionLayout<'a>,
 ) -> Stmt<'a> {
     use UnionLayout::*;
@@ -191,13 +204,37 @@ fn eq_tag_union<'a>(
     }
 
     let body = match union_layout {
-        NonRecursive(tags) => eq_tag_union_help(root, ident_ids, ctx, union_layout, tags, None),
+        NonRecursive(tags) => eq_tag_union_help(
+            root,
+            ident_ids,
+            ctx,
+            layout_interner,
+            union_layout,
+            tags,
+            None,
+        ),
 
-        Recursive(tags) => eq_tag_union_help(root, ident_ids, ctx, union_layout, tags, None),
+        Recursive(tags) => eq_tag_union_help(
+            root,
+            ident_ids,
+            ctx,
+            layout_interner,
+            union_layout,
+            tags,
+            None,
+        ),
 
         NonNullableUnwrapped(field_layouts) => {
             let tags = root.arena.alloc([field_layouts]);
-            eq_tag_union_help(root, ident_ids, ctx, union_layout, tags, None)
+            eq_tag_union_help(
+                root,
+                ident_ids,
+                ctx,
+                layout_interner,
+                union_layout,
+                tags,
+                None,
+            )
         }
 
         NullableWrapped {
@@ -207,6 +244,7 @@ fn eq_tag_union<'a>(
             root,
             ident_ids,
             ctx,
+            layout_interner,
             union_layout,
             other_tags,
             Some(nullable_id),
@@ -219,6 +257,7 @@ fn eq_tag_union<'a>(
             root,
             ident_ids,
             ctx,
+            layout_interner,
             union_layout,
             root.arena.alloc([other_fields]),
             Some(nullable_id as TagIdIntType),
@@ -234,6 +273,7 @@ fn eq_tag_union_help<'a>(
     root: &mut CodeGenHelp<'a>,
     ident_ids: &mut IdentIds,
     ctx: &mut Context<'a>,
+    layout_interner: &mut STLayoutInterner<'a>,
     union_layout: UnionLayout<'a>,
     tag_layouts: &'a [&'a [Layout<'a>]],
     nullable_id: Option<TagIdIntType>,
@@ -314,6 +354,7 @@ fn eq_tag_union_help<'a>(
             root,
             ident_ids,
             ctx,
+            layout_interner,
             tailrec_loop,
             union_layout,
             field_layouts,
@@ -335,6 +376,7 @@ fn eq_tag_union_help<'a>(
                 root,
                 ident_ids,
                 ctx,
+                layout_interner,
                 tailrec_loop,
                 union_layout,
                 tag_layouts.last().unwrap(),
@@ -395,6 +437,7 @@ fn eq_tag_fields<'a>(
     root: &mut CodeGenHelp<'a>,
     ident_ids: &mut IdentIds,
     ctx: &mut Context<'a>,
+    layout_interner: &mut STLayoutInterner<'a>,
     tailrec_loop: JoinPointId,
     union_layout: UnionLayout<'a>,
     field_layouts: &'a [Layout<'a>],
@@ -482,6 +525,7 @@ fn eq_tag_fields<'a>(
             .call_specialized_op(
                 ident_ids,
                 ctx,
+                layout_interner,
                 *layout,
                 root.arena.alloc([field1_sym, field2_sym]),
             )
@@ -530,8 +574,11 @@ fn eq_boxed<'a>(
     root: &mut CodeGenHelp<'a>,
     ident_ids: &mut IdentIds,
     ctx: &mut Context<'a>,
-    inner_layout: &'a Layout<'a>,
+    layout_interner: &mut STLayoutInterner<'a>,
+    inner_layout: InLayout<'a>,
 ) -> Stmt<'a> {
+    let inner_layout = layout_interner.get(inner_layout);
+
     let a = root.create_symbol(ident_ids, "a");
     let b = root.create_symbol(ident_ids, "b");
     let result = root.create_symbol(ident_ids, "result");
@@ -539,7 +586,13 @@ fn eq_boxed<'a>(
     let a_expr = Expr::ExprUnbox { symbol: ARG_1 };
     let b_expr = Expr::ExprUnbox { symbol: ARG_2 };
     let eq_call_expr = root
-        .call_specialized_op(ident_ids, ctx, *inner_layout, root.arena.alloc([a, b]))
+        .call_specialized_op(
+            ident_ids,
+            ctx,
+            layout_interner,
+            *inner_layout,
+            root.arena.alloc([a, b]),
+        )
         .unwrap();
 
     Stmt::Let(
@@ -576,6 +629,7 @@ fn eq_list<'a>(
     root: &mut CodeGenHelp<'a>,
     ident_ids: &mut IdentIds,
     ctx: &mut Context<'a>,
+    layout_interner: &mut STLayoutInterner<'a>,
     elem_layout: &Layout<'a>,
 ) -> Stmt<'a> {
     use LowLevel::*;
@@ -629,7 +683,7 @@ fn eq_list<'a>(
     // let size = literal int
     let size = root.create_symbol(ident_ids, "size");
     let size_expr = Expr::Literal(Literal::Int(
-        (elem_layout.stack_size(root.layout_interner, root.target_info) as i128).to_ne_bytes(),
+        (elem_layout.stack_size(layout_interner, root.target_info) as i128).to_ne_bytes(),
     ));
     let size_stmt = |next| Stmt::Let(size, size_expr, layout_isize, next);
 
@@ -703,7 +757,7 @@ fn eq_list<'a>(
     let eq_elems = root.create_symbol(ident_ids, "eq_elems");
     let eq_elems_args = root.arena.alloc([elem1, elem2]);
     let eq_elems_expr = root
-        .call_specialized_op(ident_ids, ctx, *elem_layout, eq_elems_args)
+        .call_specialized_op(ident_ids, ctx, layout_interner, *elem_layout, eq_elems_args)
         .unwrap();
 
     let eq_elems_stmt = |next| Stmt::Let(eq_elems, eq_elems_expr, LAYOUT_BOOL, next);

--- a/crates/compiler/mono/src/code_gen_help/refcount.rs
+++ b/crates/compiler/mono/src/code_gen_help/refcount.rs
@@ -9,7 +9,7 @@ use crate::code_gen_help::let_lowlevel;
 use crate::ir::{
     BranchInfo, Call, CallType, Expr, JoinPointId, Literal, ModifyRc, Param, Stmt, UpdateModeId,
 };
-use crate::layout::{Builtin, Layout, TagIdIntType, UnionLayout};
+use crate::layout::{Builtin, Layout, STLayoutInterner, TagIdIntType, UnionLayout};
 
 use super::{CodeGenHelp, Context, HelperOp};
 
@@ -24,6 +24,7 @@ pub fn refcount_stmt<'a>(
     root: &mut CodeGenHelp<'a>,
     ident_ids: &mut IdentIds,
     ctx: &mut Context<'a>,
+    layout_interner: &mut STLayoutInterner<'a>,
     layout: Layout<'a>,
     modify: &ModifyRc,
     following: &'a Stmt<'a>,
@@ -45,6 +46,7 @@ pub fn refcount_stmt<'a>(
                 .call_specialized_op(
                     ident_ids,
                     ctx,
+                    layout_interner,
                     layout,
                     arena.alloc([*structure, amount_sym]),
                 )
@@ -58,7 +60,13 @@ pub fn refcount_stmt<'a>(
             // Call helper proc, passing the Roc structure
             let call_result_empty = root.create_symbol(ident_ids, "call_result_empty");
             let call_expr = root
-                .call_specialized_op(ident_ids, ctx, layout, arena.alloc([*structure]))
+                .call_specialized_op(
+                    ident_ids,
+                    ctx,
+                    layout_interner,
+                    layout,
+                    arena.alloc([*structure]),
+                )
                 .unwrap();
             let call_stmt = Stmt::Let(call_result_empty, call_expr, LAYOUT_UNIT, following);
             arena.alloc(call_stmt)
@@ -69,7 +77,15 @@ pub fn refcount_stmt<'a>(
                 // Str has no children, so we might as well do what we normally do and call the helper.
                 Layout::Builtin(Builtin::Str) => {
                     ctx.op = HelperOp::Dec;
-                    refcount_stmt(root, ident_ids, ctx, layout, modify, following)
+                    refcount_stmt(
+                        root,
+                        ident_ids,
+                        ctx,
+                        layout_interner,
+                        layout,
+                        modify,
+                        following,
+                    )
                 }
 
                 // Struct and non-recursive Unions are stack-only, so DecRef is a no-op
@@ -80,7 +96,14 @@ pub fn refcount_stmt<'a>(
                 // and replace any return statements with jumps to the `following` statement.
                 _ => match ctx.op {
                     HelperOp::DecRef(jp_decref) => {
-                        let rc_stmt = refcount_generic(root, ident_ids, ctx, layout, *structure);
+                        let rc_stmt = refcount_generic(
+                            root,
+                            ident_ids,
+                            ctx,
+                            layout_interner,
+                            layout,
+                            *structure,
+                        );
                         let join = Stmt::Join {
                             id: jp_decref,
                             parameters: &[],
@@ -100,10 +123,11 @@ pub fn refcount_generic<'a>(
     root: &mut CodeGenHelp<'a>,
     ident_ids: &mut IdentIds,
     ctx: &mut Context<'a>,
+    layout_interner: &mut STLayoutInterner<'a>,
     layout: Layout<'a>,
     structure: Symbol,
 ) -> Stmt<'a> {
-    debug_assert!(is_rc_implemented_yet(root.layout_interner, &layout));
+    debug_assert!(is_rc_implemented_yet(layout_interner, &layout));
 
     match layout {
         Layout::Builtin(Builtin::Int(_) | Builtin::Float(_) | Builtin::Bool | Builtin::Decimal) => {
@@ -112,24 +136,56 @@ pub fn refcount_generic<'a>(
             rc_return_stmt(root, ident_ids, ctx)
         }
         Layout::Builtin(Builtin::Str) => refcount_str(root, ident_ids, ctx),
-        Layout::Builtin(Builtin::List(elem_layout)) => {
-            refcount_list(root, ident_ids, ctx, &layout, elem_layout, structure)
-        }
-        Layout::Struct { field_layouts, .. } => {
-            refcount_struct(root, ident_ids, ctx, field_layouts, structure)
-        }
-        Layout::Union(union_layout) => {
-            refcount_union(root, ident_ids, ctx, union_layout, structure)
-        }
+        Layout::Builtin(Builtin::List(elem_layout)) => refcount_list(
+            root,
+            ident_ids,
+            ctx,
+            layout_interner,
+            &layout,
+            elem_layout,
+            structure,
+        ),
+        Layout::Struct { field_layouts, .. } => refcount_struct(
+            root,
+            ident_ids,
+            ctx,
+            layout_interner,
+            field_layouts,
+            structure,
+        ),
+        Layout::Union(union_layout) => refcount_union(
+            root,
+            ident_ids,
+            ctx,
+            layout_interner,
+            union_layout,
+            structure,
+        ),
         Layout::LambdaSet(lambda_set) => {
-            let runtime_layout = lambda_set.runtime_representation(root.layout_interner);
-            refcount_generic(root, ident_ids, ctx, runtime_layout, structure)
+            let runtime_layout = lambda_set.runtime_representation(layout_interner);
+            refcount_generic(
+                root,
+                ident_ids,
+                ctx,
+                layout_interner,
+                runtime_layout,
+                structure,
+            )
         }
         Layout::RecursivePointer => unreachable!(
             "We should never call a refcounting helper on a RecursivePointer layout directly"
         ),
         Layout::Boxed(inner_layout) => {
-            refcount_boxed(root, ident_ids, ctx, &layout, inner_layout, structure)
+            let inner_layout = layout_interner.get(inner_layout);
+            refcount_boxed(
+                root,
+                ident_ids,
+                ctx,
+                layout_interner,
+                &layout,
+                inner_layout,
+                structure,
+            )
         }
     }
 }
@@ -138,6 +194,7 @@ pub fn refcount_reset_proc_body<'a>(
     root: &mut CodeGenHelp<'a>,
     ident_ids: &mut IdentIds,
     ctx: &mut Context<'a>,
+    layout_interner: &mut STLayoutInterner<'a>,
     layout: Layout<'a>,
     structure: Symbol,
 ) -> Stmt<'a> {
@@ -206,8 +263,7 @@ pub fn refcount_reset_proc_body<'a>(
         let alloc_addr_stmt = {
             let alignment = root.create_symbol(ident_ids, "alignment");
             let alignment_expr = Expr::Literal(Literal::Int(
-                (layout.alignment_bytes(root.layout_interner, root.target_info) as i128)
-                    .to_ne_bytes(),
+                (layout.alignment_bytes(layout_interner, root.target_info) as i128).to_ne_bytes(),
             ));
             let alloc_addr = root.create_symbol(ident_ids, "alloc_addr");
             let alloc_addr_expr = Expr::Call(Call {
@@ -241,6 +297,7 @@ pub fn refcount_reset_proc_body<'a>(
             root,
             ident_ids,
             ctx,
+            layout_interner,
             union_layout,
             tag_layouts,
             null_id,
@@ -260,7 +317,13 @@ pub fn refcount_reset_proc_body<'a>(
     let else_stmt = {
         let decrement_unit = root.create_symbol(ident_ids, "decrement_unit");
         let decrement_expr = root
-            .call_specialized_op(ident_ids, ctx, layout, root.arena.alloc([structure]))
+            .call_specialized_op(
+                ident_ids,
+                ctx,
+                layout_interner,
+                layout,
+                root.arena.alloc([structure]),
+            )
             .unwrap();
         let decrement_stmt = |next| Stmt::Let(decrement_unit, decrement_expr, LAYOUT_UNIT, next);
 
@@ -694,6 +757,7 @@ fn refcount_list<'a>(
     root: &mut CodeGenHelp<'a>,
     ident_ids: &mut IdentIds,
     ctx: &mut Context<'a>,
+    layout_interner: &mut STLayoutInterner<'a>,
     layout: &Layout,
     elem_layout: &'a Layout,
     structure: Symbol,
@@ -743,7 +807,7 @@ fn refcount_list<'a>(
     //
 
     let rc_ptr = root.create_symbol(ident_ids, "rc_ptr");
-    let alignment = layout.alignment_bytes(root.layout_interner, root.target_info);
+    let alignment = layout.alignment_bytes(layout_interner, root.target_info);
 
     let ret_stmt = rc_return_stmt(root, ident_ids, ctx);
     let modify_list = modify_refcount(
@@ -769,6 +833,7 @@ fn refcount_list<'a>(
             root,
             ident_ids,
             ctx,
+            layout_interner,
             elem_layout,
             LAYOUT_UNIT,
             box_union_layout,
@@ -819,6 +884,7 @@ fn refcount_list_elems<'a>(
     root: &mut CodeGenHelp<'a>,
     ident_ids: &mut IdentIds,
     ctx: &mut Context<'a>,
+    layout_interner: &mut STLayoutInterner<'a>,
     elem_layout: &Layout<'a>,
     ret_layout: Layout<'a>,
     box_union_layout: UnionLayout<'a>,
@@ -841,7 +907,7 @@ fn refcount_list_elems<'a>(
     // let size = literal int
     let elem_size = root.create_symbol(ident_ids, "elem_size");
     let elem_size_expr = Expr::Literal(Literal::Int(
-        (elem_layout.stack_size(root.layout_interner, root.target_info) as i128).to_ne_bytes(),
+        (elem_layout.stack_size(layout_interner, root.target_info) as i128).to_ne_bytes(),
     ));
     let elem_size_stmt = |next| Stmt::Let(elem_size, elem_size_expr, layout_isize, next);
 
@@ -901,7 +967,7 @@ fn refcount_list_elems<'a>(
     let mod_elem_unit = root.create_symbol(ident_ids, "mod_elem_unit");
     let mod_elem_args = refcount_args(root, ctx, elem);
     let mod_elem_expr = root
-        .call_specialized_op(ident_ids, ctx, *elem_layout, mod_elem_args)
+        .call_specialized_op(ident_ids, ctx, layout_interner, *elem_layout, mod_elem_args)
         .unwrap();
     let mod_elem_stmt = |next| Stmt::Let(mod_elem_unit, mod_elem_expr, LAYOUT_UNIT, next);
 
@@ -984,13 +1050,14 @@ fn refcount_struct<'a>(
     root: &mut CodeGenHelp<'a>,
     ident_ids: &mut IdentIds,
     ctx: &mut Context<'a>,
+    layout_interner: &mut STLayoutInterner<'a>,
     field_layouts: &'a [Layout<'a>],
     structure: Symbol,
 ) -> Stmt<'a> {
     let mut stmt = rc_return_stmt(root, ident_ids, ctx);
 
     for (i, field_layout) in field_layouts.iter().enumerate().rev() {
-        if field_layout.contains_refcounted(root.layout_interner) {
+        if field_layout.contains_refcounted(layout_interner) {
             let field_val = root.create_symbol(ident_ids, &format!("field_val_{}", i));
             let field_val_expr = Expr::StructAtIndex {
                 index: i as u64,
@@ -1002,7 +1069,7 @@ fn refcount_struct<'a>(
             let mod_unit = root.create_symbol(ident_ids, &format!("mod_field_{}", i));
             let mod_args = refcount_args(root, ctx, field_val);
             let mod_expr = root
-                .call_specialized_op(ident_ids, ctx, *field_layout, mod_args)
+                .call_specialized_op(ident_ids, ctx, layout_interner, *field_layout, mod_args)
                 .unwrap();
             let mod_stmt = |next| Stmt::Let(mod_unit, mod_expr, LAYOUT_UNIT, next);
 
@@ -1023,6 +1090,7 @@ fn refcount_union<'a>(
     root: &mut CodeGenHelp<'a>,
     ident_ids: &mut IdentIds,
     ctx: &mut Context<'a>,
+    layout_interner: &mut STLayoutInterner<'a>,
     union: UnionLayout<'a>,
     structure: Symbol,
 ) -> Stmt<'a> {
@@ -1034,14 +1102,41 @@ fn refcount_union<'a>(
     }
 
     let body = match union {
-        NonRecursive(tags) => refcount_union_nonrec(root, ident_ids, ctx, union, tags, structure),
+        NonRecursive(tags) => refcount_union_nonrec(
+            root,
+            ident_ids,
+            ctx,
+            layout_interner,
+            union,
+            tags,
+            structure,
+        ),
 
         Recursive(tags) => {
             let (is_tailrec, tail_idx) = root.union_tail_recursion_fields(union);
             if is_tailrec && !ctx.op.is_decref() {
-                refcount_union_tailrec(root, ident_ids, ctx, union, tags, None, tail_idx, structure)
+                refcount_union_tailrec(
+                    root,
+                    ident_ids,
+                    ctx,
+                    layout_interner,
+                    union,
+                    tags,
+                    None,
+                    tail_idx,
+                    structure,
+                )
             } else {
-                refcount_union_rec(root, ident_ids, ctx, union, tags, None, structure)
+                refcount_union_rec(
+                    root,
+                    ident_ids,
+                    ctx,
+                    layout_interner,
+                    union,
+                    tags,
+                    None,
+                    structure,
+                )
             }
         }
 
@@ -1051,7 +1146,16 @@ fn refcount_union<'a>(
             // a direct RecursionPointer is only possible if there's at least one non-recursive variant.
             // This nesting makes it harder to do tail recursion, so we just don't.
             let tags = root.arena.alloc([field_layouts]);
-            refcount_union_rec(root, ident_ids, ctx, union, tags, None, structure)
+            refcount_union_rec(
+                root,
+                ident_ids,
+                ctx,
+                layout_interner,
+                union,
+                tags,
+                None,
+                structure,
+            )
         }
 
         NullableWrapped {
@@ -1062,10 +1166,27 @@ fn refcount_union<'a>(
             let (is_tailrec, tail_idx) = root.union_tail_recursion_fields(union);
             if is_tailrec && !ctx.op.is_decref() {
                 refcount_union_tailrec(
-                    root, ident_ids, ctx, union, tags, null_id, tail_idx, structure,
+                    root,
+                    ident_ids,
+                    ctx,
+                    layout_interner,
+                    union,
+                    tags,
+                    null_id,
+                    tail_idx,
+                    structure,
                 )
             } else {
-                refcount_union_rec(root, ident_ids, ctx, union, tags, null_id, structure)
+                refcount_union_rec(
+                    root,
+                    ident_ids,
+                    ctx,
+                    layout_interner,
+                    union,
+                    tags,
+                    null_id,
+                    structure,
+                )
             }
         }
 
@@ -1078,10 +1199,27 @@ fn refcount_union<'a>(
             let (is_tailrec, tail_idx) = root.union_tail_recursion_fields(union);
             if is_tailrec && !ctx.op.is_decref() {
                 refcount_union_tailrec(
-                    root, ident_ids, ctx, union, tags, null_id, tail_idx, structure,
+                    root,
+                    ident_ids,
+                    ctx,
+                    layout_interner,
+                    union,
+                    tags,
+                    null_id,
+                    tail_idx,
+                    structure,
                 )
             } else {
-                refcount_union_rec(root, ident_ids, ctx, union, tags, null_id, structure)
+                refcount_union_rec(
+                    root,
+                    ident_ids,
+                    ctx,
+                    layout_interner,
+                    union,
+                    tags,
+                    null_id,
+                    structure,
+                )
             }
         }
     };
@@ -1095,6 +1233,7 @@ fn refcount_union_nonrec<'a>(
     root: &mut CodeGenHelp<'a>,
     ident_ids: &mut IdentIds,
     ctx: &mut Context<'a>,
+    layout_interner: &mut STLayoutInterner<'a>,
     union_layout: UnionLayout<'a>,
     tag_layouts: &'a [&'a [Layout<'a>]],
     structure: Symbol,
@@ -1120,6 +1259,7 @@ fn refcount_union_nonrec<'a>(
         root,
         ident_ids,
         ctx,
+        layout_interner,
         union_layout,
         tag_layouts,
         None,
@@ -1140,6 +1280,7 @@ fn refcount_union_contents<'a>(
     root: &mut CodeGenHelp<'a>,
     ident_ids: &mut IdentIds,
     ctx: &mut Context<'a>,
+    layout_interner: &mut STLayoutInterner<'a>,
     union_layout: UnionLayout<'a>,
     tag_layouts: &'a [&'a [Layout<'a>]],
     null_id: Option<TagIdIntType>,
@@ -1173,6 +1314,7 @@ fn refcount_union_contents<'a>(
             root,
             ident_ids,
             ctx,
+            layout_interner,
             union_layout,
             field_layouts,
             structure,
@@ -1207,6 +1349,7 @@ fn refcount_union_rec<'a>(
     root: &mut CodeGenHelp<'a>,
     ident_ids: &mut IdentIds,
     ctx: &mut Context<'a>,
+    layout_interner: &mut STLayoutInterner<'a>,
     union_layout: UnionLayout<'a>,
     tag_layouts: &'a [&'a [Layout<'a>]],
     null_id: Option<TagIdIntType>,
@@ -1231,7 +1374,7 @@ fn refcount_union_rec<'a>(
         let rc_ptr = root.create_symbol(ident_ids, "rc_ptr");
 
         let alignment =
-            Layout::Union(union_layout).alignment_bytes(root.layout_interner, root.target_info);
+            Layout::Union(union_layout).alignment_bytes(layout_interner, root.target_info);
         let ret_stmt = rc_return_stmt(root, ident_ids, ctx);
         let modify_structure_stmt = modify_refcount(
             root,
@@ -1259,6 +1402,7 @@ fn refcount_union_rec<'a>(
             root,
             ident_ids,
             ctx,
+            layout_interner,
             union_layout,
             tag_layouts,
             null_id,
@@ -1285,6 +1429,7 @@ fn refcount_union_tailrec<'a>(
     root: &mut CodeGenHelp<'a>,
     ident_ids: &mut IdentIds,
     ctx: &mut Context<'a>,
+    layout_interner: &mut STLayoutInterner<'a>,
     union_layout: UnionLayout<'a>,
     tag_layouts: &'a [&'a [Layout<'a>]],
     null_id: Option<TagIdIntType>,
@@ -1339,7 +1484,7 @@ fn refcount_union_tailrec<'a>(
             )
         };
 
-        let alignment = layout.alignment_bytes(root.layout_interner, root.target_info);
+        let alignment = layout.alignment_bytes(layout_interner, root.target_info);
         let modify_structure_stmt = modify_refcount(
             root,
             ident_ids,
@@ -1427,6 +1572,7 @@ fn refcount_union_tailrec<'a>(
                 root,
                 ident_ids,
                 ctx,
+                layout_interner,
                 union_layout,
                 non_tailrec_fields,
                 current,
@@ -1488,6 +1634,7 @@ fn refcount_tag_fields<'a>(
     root: &mut CodeGenHelp<'a>,
     ident_ids: &mut IdentIds,
     ctx: &mut Context<'a>,
+    layout_interner: &mut STLayoutInterner<'a>,
     union_layout: UnionLayout<'a>,
     field_layouts: &'a [Layout<'a>],
     structure: Symbol,
@@ -1497,7 +1644,7 @@ fn refcount_tag_fields<'a>(
     let mut stmt = following;
 
     for (i, field_layout) in field_layouts.iter().enumerate().rev() {
-        if field_layout.contains_refcounted(root.layout_interner) {
+        if field_layout.contains_refcounted(layout_interner) {
             let field_val = root.create_symbol(ident_ids, &format!("field_{}_{}", tag_id, i));
             let field_val_expr = Expr::UnionAtIndex {
                 union_layout,
@@ -1510,7 +1657,7 @@ fn refcount_tag_fields<'a>(
             let mod_unit = root.create_symbol(ident_ids, &format!("mod_field_{}_{}", tag_id, i));
             let mod_args = refcount_args(root, ctx, field_val);
             let mod_expr = root
-                .call_specialized_op(ident_ids, ctx, *field_layout, mod_args)
+                .call_specialized_op(ident_ids, ctx, layout_interner, *field_layout, mod_args)
                 .unwrap();
             let mod_stmt = |next| Stmt::Let(mod_unit, mod_expr, LAYOUT_UNIT, next);
 
@@ -1531,6 +1678,7 @@ fn refcount_boxed<'a>(
     root: &mut CodeGenHelp<'a>,
     ident_ids: &mut IdentIds,
     ctx: &mut Context<'a>,
+    layout_interner: &mut STLayoutInterner<'a>,
     layout: &Layout,
     inner_layout: &'a Layout,
     outer: Symbol,
@@ -1544,7 +1692,7 @@ fn refcount_boxed<'a>(
     //
 
     let rc_ptr = root.create_symbol(ident_ids, "rc_ptr");
-    let alignment = layout.alignment_bytes(root.layout_interner, root.target_info);
+    let alignment = layout.alignment_bytes(layout_interner, root.target_info);
     let ret_stmt = rc_return_stmt(root, ident_ids, ctx);
     let modify_outer = modify_refcount(
         root,
@@ -1571,7 +1719,13 @@ fn refcount_boxed<'a>(
         let mod_inner_unit = root.create_symbol(ident_ids, "mod_inner_unit");
         let mod_inner_args = refcount_args(root, ctx, inner);
         let mod_inner_expr = root
-            .call_specialized_op(ident_ids, ctx, *inner_layout, mod_inner_args)
+            .call_specialized_op(
+                ident_ids,
+                ctx,
+                layout_interner,
+                *inner_layout,
+                mod_inner_args,
+            )
             .unwrap();
 
         Stmt::Let(

--- a/crates/compiler/mono/src/code_gen_help/refcount.rs
+++ b/crates/compiler/mono/src/code_gen_help/refcount.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::too_many_arguments)]
+
 use bumpalo::collections::vec::Vec;
 use roc_builtins::bitcode::IntWidth;
 use roc_intern::Interner;
@@ -879,7 +881,6 @@ fn refcount_list<'a>(
     ))
 }
 
-#[allow(clippy::too_many_arguments)]
 fn refcount_list_elems<'a>(
     root: &mut CodeGenHelp<'a>,
     ident_ids: &mut IdentIds,
@@ -1275,7 +1276,6 @@ fn refcount_union_nonrec<'a>(
     ))
 }
 
-#[allow(clippy::too_many_arguments)]
 fn refcount_union_contents<'a>(
     root: &mut CodeGenHelp<'a>,
     ident_ids: &mut IdentIds,
@@ -1424,7 +1424,6 @@ fn refcount_union_rec<'a>(
 }
 
 // Refcount a recursive union using tail-call elimination to limit stack growth
-#[allow(clippy::too_many_arguments)]
 fn refcount_union_tailrec<'a>(
     root: &mut CodeGenHelp<'a>,
     ident_ids: &mut IdentIds,
@@ -1629,7 +1628,6 @@ fn refcount_union_tailrec<'a>(
     }
 }
 
-#[allow(clippy::too_many_arguments)]
 fn refcount_tag_fields<'a>(
     root: &mut CodeGenHelp<'a>,
     ident_ids: &mut IdentIds,

--- a/crates/compiler/mono/src/debug/checker.rs
+++ b/crates/compiler/mono/src/debug/checker.rs
@@ -529,7 +529,7 @@ impl<'a, 'r> Ctx<'a, 'r> {
                     }
                     let layout = resolve_recursive_layout(
                         ctx.arena,
-                        &mut ctx.interner,
+                        ctx.interner,
                         payloads[index as usize],
                         union_layout,
                     );

--- a/crates/compiler/mono/src/debug/checker.rs
+++ b/crates/compiler/mono/src/debug/checker.rs
@@ -2,6 +2,7 @@
 
 use bumpalo::Bump;
 use roc_collections::{MutMap, VecMap, VecSet};
+use roc_intern::Interner;
 use roc_module::symbol::Symbol;
 
 use crate::{
@@ -131,8 +132,8 @@ impl<'a> Problems<'a> {
 
 pub fn check_procs<'a>(
     arena: &'a Bump,
-    interner: &'a STLayoutInterner<'a>,
-    procs: &'a Procs<'a>,
+    interner: &mut STLayoutInterner<'a>,
+    procs: &Procs<'a>,
 ) -> Problems<'a> {
     let mut problems = Default::default();
 
@@ -161,9 +162,9 @@ type JoinPoints<'a> = VecMap<JoinPointId, (usize, &'a [Param<'a>])>;
 type CallSpecIds = VecMap<CallSpecId, usize>;
 struct Ctx<'a, 'r> {
     arena: &'a Bump,
-    interner: &'a STLayoutInterner<'a>,
+    interner: &'r mut STLayoutInterner<'a>,
     problems: &'r mut Vec<Problem<'a>>,
-    proc: &'a Proc<'a>,
+    proc: &'r Proc<'a>,
     proc_layout: ProcLayout<'a>,
     procs: &'r Procs<'a>,
     call_spec_ids: CallSpecIds,
@@ -180,7 +181,7 @@ impl<'a, 'r> Ctx<'a, 'r> {
 
     fn problem(&mut self, problem_kind: ProblemKind<'a>) {
         self.problems.push(Problem {
-            proc: self.proc,
+            proc: self.arena.alloc(self.proc.clone()),
             proc_layout: self.proc_layout,
             line: self.line,
             kind: problem_kind,
@@ -526,7 +527,8 @@ impl<'a, 'r> Ctx<'a, 'r> {
                         return None;
                     }
                     let layout = resolve_recursive_layout(
-                        self.arena,
+                        ctx.arena,
+                        &mut ctx.interner,
                         payloads[index as usize],
                         union_layout,
                     );
@@ -613,8 +615,12 @@ impl<'a, 'r> Ctx<'a, 'r> {
                     });
                 }
                 for (arg, wanted_layout) in arguments.iter().zip(payloads.iter()) {
-                    let wanted_layout =
-                        resolve_recursive_layout(self.arena, *wanted_layout, union_layout);
+                    let wanted_layout = resolve_recursive_layout(
+                        self.arena,
+                        self.interner,
+                        *wanted_layout,
+                        union_layout,
+                    );
                     self.check_sym_layout(*arg, wanted_layout, UseKind::TagPayloadArg);
                 }
             }
@@ -633,12 +639,13 @@ impl<'a, 'r> Ctx<'a, 'r> {
 
 fn resolve_recursive_layout<'a>(
     arena: &'a Bump,
+    interner: &mut STLayoutInterner<'a>,
     layout: Layout<'a>,
     when_recursive: UnionLayout<'a>,
 ) -> Layout<'a> {
     macro_rules! go {
         ($lay:expr) => {
-            resolve_recursive_layout(arena, $lay, when_recursive)
+            resolve_recursive_layout(arena, interner, $lay, when_recursive)
         };
     }
 
@@ -671,7 +678,7 @@ fn resolve_recursive_layout<'a>(
         } => {
             let field_layouts = field_layouts
                 .iter()
-                .map(|lay| resolve_recursive_layout(arena, *lay, when_recursive));
+                .map(|lay| resolve_recursive_layout(arena, interner, *lay, when_recursive));
             let field_layouts = arena.alloc_slice_fill_iter(field_layouts);
             Layout::Struct {
                 field_order_hash,
@@ -680,7 +687,12 @@ fn resolve_recursive_layout<'a>(
         }
         Layout::Builtin(builtin) => match builtin {
             Builtin::List(inner) => {
-                let inner = arena.alloc(resolve_recursive_layout(arena, *inner, when_recursive));
+                let inner = arena.alloc(resolve_recursive_layout(
+                    arena,
+                    interner,
+                    *inner,
+                    when_recursive,
+                ));
                 Layout::Builtin(Builtin::List(inner))
             }
             Builtin::Int(_)
@@ -694,7 +706,10 @@ fn resolve_recursive_layout<'a>(
             representation,
         }) => {
             let set = set.iter().map(|(symbol, captures)| {
-                let captures = captures.iter().map(|lay| go!(*lay));
+                let captures = captures.iter().map(|lay_in| {
+                    let new_lay = go!(*interner.get(*lay_in));
+                    interner.insert(arena.alloc(new_lay))
+                });
                 let captures = &*arena.alloc_slice_fill_iter(captures);
                 (*symbol, captures)
             });

--- a/crates/compiler/mono/src/debug/report.rs
+++ b/crates/compiler/mono/src/debug/report.rs
@@ -487,7 +487,7 @@ where
                 captures_niche
                     .0
                     .iter()
-                    .map(|c| c.to_doc(f, interner, Parens::NotNeeded)),
+                    .map(|&c| interner.get(c).to_doc(f, interner, Parens::NotNeeded)),
                 f.reflow(", "),
             ),
             f.reflow("})"),

--- a/crates/compiler/mono/src/ir.rs
+++ b/crates/compiler/mono/src/ir.rs
@@ -3533,10 +3533,12 @@ fn specialize_proc_help<'a>(
                             let ptr_bytes = env.target_info;
 
                             combined.sort_by(|(_, layout1), (_, layout2)| {
-                                let size1 =
-                                    layout1.alignment_bytes(&layout_cache.interner, ptr_bytes);
-                                let size2 =
-                                    layout2.alignment_bytes(&layout_cache.interner, ptr_bytes);
+                                let size1 = layout_cache
+                                    .get_in(**layout1)
+                                    .alignment_bytes(&layout_cache.interner, ptr_bytes);
+                                let size2 = layout_cache
+                                    .get_in(**layout2)
+                                    .alignment_bytes(&layout_cache.interner, ptr_bytes);
 
                                 size2.cmp(&size1)
                             });
@@ -3575,16 +3577,20 @@ fn specialize_proc_help<'a>(
                             let ptr_bytes = env.target_info;
 
                             combined.sort_by(|(_, layout1), (_, layout2)| {
-                                let size1 =
-                                    layout1.alignment_bytes(&layout_cache.interner, ptr_bytes);
-                                let size2 =
-                                    layout2.alignment_bytes(&layout_cache.interner, ptr_bytes);
+                                let size1 = layout_cache
+                                    .get_in(**layout1)
+                                    .alignment_bytes(&layout_cache.interner, ptr_bytes);
+                                let size2 = layout_cache
+                                    .get_in(**layout2)
+                                    .alignment_bytes(&layout_cache.interner, ptr_bytes);
 
                                 size2.cmp(&size1)
                             });
 
                             let ordered_field_layouts = Vec::from_iter_in(
-                                combined.iter().map(|(_, layout)| **layout),
+                                combined
+                                    .iter()
+                                    .map(|(_, layout)| *layout_cache.get_in(**layout)),
                                 env.arena,
                             );
                             let ordered_field_layouts = ordered_field_layouts.into_bump_slice();
@@ -3610,7 +3616,7 @@ fn specialize_proc_help<'a>(
                                 specialized_body = Stmt::Let(
                                     symbol,
                                     expr,
-                                    **layout,
+                                    *layout_cache.get_in(**layout),
                                     env.arena.alloc(specialized_body),
                                 );
                             }
@@ -5730,8 +5736,12 @@ where
             let ptr_bytes = env.target_info;
 
             combined.sort_by(|(_, layout1), (_, layout2)| {
-                let size1 = layout1.alignment_bytes(&layout_cache.interner, ptr_bytes);
-                let size2 = layout2.alignment_bytes(&layout_cache.interner, ptr_bytes);
+                let size1 = layout_cache
+                    .get_in(**layout1)
+                    .alignment_bytes(&layout_cache.interner, ptr_bytes);
+                let size2 = layout_cache
+                    .get_in(**layout2)
+                    .alignment_bytes(&layout_cache.interner, ptr_bytes);
 
                 size2.cmp(&size1)
             });
@@ -5760,16 +5770,23 @@ where
             let ptr_bytes = env.target_info;
 
             combined.sort_by(|(_, layout1), (_, layout2)| {
-                let size1 = layout1.alignment_bytes(&layout_cache.interner, ptr_bytes);
-                let size2 = layout2.alignment_bytes(&layout_cache.interner, ptr_bytes);
+                let size1 = layout_cache
+                    .get_in(**layout1)
+                    .alignment_bytes(&layout_cache.interner, ptr_bytes);
+                let size2 = layout_cache
+                    .get_in(**layout2)
+                    .alignment_bytes(&layout_cache.interner, ptr_bytes);
 
                 size2.cmp(&size1)
             });
 
             let symbols =
                 Vec::from_iter_in(combined.iter().map(|(a, _)| *a), env.arena).into_bump_slice();
-            let field_layouts =
-                Vec::from_iter_in(combined.iter().map(|(_, b)| **b), env.arena).into_bump_slice();
+            let field_layouts = Vec::from_iter_in(
+                combined.iter().map(|(_, b)| *layout_cache.get_in(**b)),
+                env.arena,
+            )
+            .into_bump_slice();
 
             debug_assert_eq!(
                 Layout::struct_no_name_order(field_layouts),

--- a/crates/compiler/mono/src/layout.rs
+++ b/crates/compiler/mono/src/layout.rs
@@ -1290,7 +1290,7 @@ pub enum ClosureRepresentation<'a> {
     /// We MUST sort these according to their stack size before code gen!
     AlphabeticOrderStruct(&'a [InLayout<'a>]),
     /// The closure is one function that captures a single identifier, whose value is unwrapped.
-    UnwrappedCapture(Layout<'a>),
+    UnwrappedCapture(InLayout<'a>),
     /// The closure dispatches to multiple functions, but none of them capture anything, so this is
     /// a boolean or integer flag.
     EnumDispatch(EnumDispatch),
@@ -1471,12 +1471,12 @@ impl<'a> LambdaSet<'a> {
         I: Interner<'a, Layout<'a>>,
         F: Fn(Symbol, &[InLayout]) -> bool,
     {
-        let repr = interner.get(self.representation);
-
         if self.has_unwrapped_capture_repr() {
             // Only one function, that captures one identifier.
-            return ClosureRepresentation::UnwrappedCapture(*repr);
+            return ClosureRepresentation::UnwrappedCapture(self.representation);
         }
+
+        let repr = interner.get(self.representation);
 
         match repr {
             Layout::Union(union) => {

--- a/crates/compiler/mono/src/layout.rs
+++ b/crates/compiler/mono/src/layout.rs
@@ -2351,41 +2351,6 @@ impl<'a> Layout<'a> {
         false // TODO this should use is_zero_sized once doing so doesn't break things!
     }
 
-    /// Like stack_size, but doesn't require target info because
-    /// whether something is zero sized is not target-dependent.
-    #[allow(dead_code)]
-    fn is_zero_sized(&self) -> bool {
-        match self {
-            // There are no zero-sized builtins
-            Layout::Builtin(_) => false,
-            // Functions are never zero-sized
-            Layout::LambdaSet(_) => false,
-            // Empty structs, or structs with all zero-sized fields, are zero-sized
-            Layout::Struct { field_layouts, .. } => field_layouts.iter().all(Self::is_zero_sized),
-            // A Box that points to nothing should be unwrapped
-            Layout::Boxed(content) => content.is_zero_sized(),
-            Layout::Union(union_layout) => match union_layout {
-                UnionLayout::NonRecursive(tags)
-                | UnionLayout::Recursive(tags)
-                | UnionLayout::NullableWrapped {
-                    other_tags: tags, ..
-                } => tags
-                    .iter()
-                    .all(|payloads| payloads.iter().all(Self::is_zero_sized)),
-                UnionLayout::NonNullableUnwrapped(tags)
-                | UnionLayout::NullableUnwrapped {
-                    other_fields: tags, ..
-                } => tags.iter().all(Self::is_zero_sized),
-            },
-            // Recursive pointers are considered zero-sized because
-            // if you have a recursive data structure where everything
-            // else but the recutsive pointer is zero-sized, then
-            // the whole thing is unnecessary at runtime and should
-            // be zero-sized.
-            Layout::RecursivePointer => true,
-        }
-    }
-
     pub fn is_passed_by_reference<I>(&self, interner: &I, target_info: TargetInfo) -> bool
     where
         I: Interner<'a, Layout<'a>>,

--- a/crates/compiler/test_gen/src/helpers/dev.rs
+++ b/crates/compiler/test_gen/src/helpers/dev.rs
@@ -77,7 +77,7 @@ pub fn helper(
         procedures,
         mut interns,
         exposed_to_host,
-        layout_interner,
+        mut layout_interner,
         ..
     } = loaded;
 
@@ -188,7 +188,6 @@ pub fn helper(
 
     let env = roc_gen_dev::Env {
         arena,
-        layout_interner: &layout_interner,
         module_id,
         exposed_to_host: exposed_to_host.values.keys().copied().collect(),
         lazy_literals,
@@ -196,7 +195,13 @@ pub fn helper(
     };
 
     let target = target_lexicon::Triple::host();
-    let module_object = roc_gen_dev::build_module(&env, &mut interns, &target, procedures);
+    let module_object = roc_gen_dev::build_module(
+        &env,
+        &mut interns,
+        &mut layout_interner,
+        &target,
+        procedures,
+    );
 
     let module_out = module_object
         .write()

--- a/crates/compiler/test_gen/src/helpers/wasm.rs
+++ b/crates/compiler/test_gen/src/helpers/wasm.rs
@@ -111,7 +111,7 @@ fn compile_roc_to_wasm_bytes<'a, T: Wasm32Result>(
         procedures,
         mut interns,
         exposed_to_host,
-        layout_interner,
+        mut layout_interner,
         ..
     } = loaded;
 
@@ -125,7 +125,6 @@ fn compile_roc_to_wasm_bytes<'a, T: Wasm32Result>(
 
     let env = roc_gen_wasm::Env {
         arena,
-        layout_interner: &layout_interner,
         module_id,
         exposed_to_host,
         stack_bytes: roc_gen_wasm::Env::DEFAULT_STACK_BYTES,
@@ -140,8 +139,13 @@ fn compile_roc_to_wasm_bytes<'a, T: Wasm32Result>(
         )
     });
 
-    let (mut module, mut called_fns, main_fn_index) =
-        roc_gen_wasm::build_app_module(&env, &mut interns, host_module, procedures);
+    let (mut module, mut called_fns, main_fn_index) = roc_gen_wasm::build_app_module(
+        &env,
+        &mut layout_interner,
+        &mut interns,
+        host_module,
+        procedures,
+    );
 
     T::insert_wrapper(arena, &mut module, TEST_WRAPPER_NAME, main_fn_index);
     called_fns.push(true);

--- a/crates/compiler/test_mono/generated/lambda_capture_niches_have_captured_function_in_closure.txt
+++ b/crates/compiler/test_mono/generated/lambda_capture_niches_have_captured_function_in_closure.txt
@@ -14,11 +14,11 @@ procedure Test.16 (Test.54):
     ret Test.56;
 
 procedure Test.2 (Test.7, Test.8):
-    let Test.30 : [C {} {}, C {} {}] = TagId(0) Test.7 Test.8;
+    let Test.30 : [C {} {}, C {} {}] = TagId(1) Test.7 Test.8;
     ret Test.30;
 
 procedure Test.2 (Test.7, Test.8):
-    let Test.44 : [C {} {}, C {} {}] = TagId(1) Test.7 Test.8;
+    let Test.44 : [C {} {}, C {} {}] = TagId(0) Test.7 Test.8;
     ret Test.44;
 
 procedure Test.3 (Test.17):
@@ -32,17 +32,6 @@ procedure Test.4 (Test.18):
 procedure Test.9 (Test.29, #Attr.12):
     let Test.8 : {} = UnionAtIndex (Id 0) (Index 1) #Attr.12;
     let Test.7 : {} = UnionAtIndex (Id 0) (Index 0) #Attr.12;
-    let Test.35 : {} = Struct {};
-    let Test.34 : Str = CallByName Test.15 Test.35;
-    let Test.31 : {} = CallByName Test.3 Test.34;
-    dec Test.34;
-    let Test.33 : {} = Struct {};
-    let Test.32 : Str = CallByName Test.11 Test.33;
-    ret Test.32;
-
-procedure Test.9 (Test.29, #Attr.12):
-    let Test.8 : {} = UnionAtIndex (Id 1) (Index 1) #Attr.12;
-    let Test.7 : {} = UnionAtIndex (Id 1) (Index 0) #Attr.12;
     let Test.49 : {} = Struct {};
     let Test.48 : Str = CallByName Test.16 Test.49;
     let Test.45 : Str = CallByName Test.4 Test.48;
@@ -50,6 +39,17 @@ procedure Test.9 (Test.29, #Attr.12):
     let Test.47 : {} = Struct {};
     let Test.46 : Str = CallByName Test.13 Test.47 Test.45;
     ret Test.46;
+
+procedure Test.9 (Test.29, #Attr.12):
+    let Test.8 : {} = UnionAtIndex (Id 1) (Index 1) #Attr.12;
+    let Test.7 : {} = UnionAtIndex (Id 1) (Index 0) #Attr.12;
+    let Test.35 : {} = Struct {};
+    let Test.34 : Str = CallByName Test.15 Test.35;
+    let Test.31 : {} = CallByName Test.3 Test.34;
+    dec Test.34;
+    let Test.33 : {} = Struct {};
+    let Test.32 : Str = CallByName Test.11 Test.33;
+    ret Test.32;
 
 procedure Test.0 ():
     let Test.5 : Int1 = true;

--- a/crates/compiler/test_mono/generated/lambda_capture_niches_with_non_capturing_function.txt
+++ b/crates/compiler/test_mono/generated/lambda_capture_niches_with_non_capturing_function.txt
@@ -1,9 +1,9 @@
 procedure Test.1 (Test.5):
-    let Test.19 : [C , C U64, C {}] = TagId(2) Test.5;
+    let Test.19 : [C , C {}, C U64] = TagId(1) Test.5;
     ret Test.19;
 
 procedure Test.1 (Test.5):
-    let Test.27 : [C , C U64, C {}] = TagId(1) Test.5;
+    let Test.27 : [C , C {}, C U64] = TagId(2) Test.5;
     ret Test.27;
 
 procedure Test.2 (Test.8):
@@ -11,12 +11,12 @@ procedure Test.2 (Test.8):
     ret Test.24;
 
 procedure Test.6 (Test.20, #Attr.12):
-    let Test.5 : U64 = UnionAtIndex (Id 1) (Index 0) #Attr.12;
+    let Test.5 : U64 = UnionAtIndex (Id 2) (Index 0) #Attr.12;
     let Test.30 : Str = "";
     ret Test.30;
 
 procedure Test.6 (Test.20, #Attr.12):
-    let Test.5 : {} = UnionAtIndex (Id 2) (Index 0) #Attr.12;
+    let Test.5 : {} = UnionAtIndex (Id 1) (Index 0) #Attr.12;
     let Test.22 : Str = "";
     ret Test.22;
 
@@ -45,15 +45,15 @@ procedure Test.0 ():
     switch Test.3:
         case 0:
             let Test.18 : {} = Struct {};
-            let Test.17 : [C , C U64, C {}] = CallByName Test.1 Test.18;
+            let Test.17 : [C , C {}, C U64] = CallByName Test.1 Test.18;
             jump Test.16 Test.17;
     
         case 1:
-            let Test.23 : [C , C U64, C {}] = TagId(0) ;
+            let Test.23 : [C , C {}, C U64] = TagId(0) ;
             jump Test.16 Test.23;
     
         default:
             let Test.26 : U64 = 1i64;
-            let Test.25 : [C , C U64, C {}] = CallByName Test.1 Test.26;
+            let Test.25 : [C , C {}, C U64] = CallByName Test.1 Test.26;
             jump Test.16 Test.25;
     

--- a/crates/compiler/test_mono/generated/lambda_capture_niches_with_other_lambda_capture.txt
+++ b/crates/compiler/test_mono/generated/lambda_capture_niches_with_other_lambda_capture.txt
@@ -1,23 +1,23 @@
 procedure Test.1 (Test.5):
-    let Test.20 : [C U64, C {}, C Str] = TagId(1) Test.5;
+    let Test.20 : [C {}, C U64, C Str] = TagId(0) Test.5;
     ret Test.20;
 
 procedure Test.1 (Test.5):
-    let Test.32 : [C U64, C {}, C Str] = TagId(0) Test.5;
+    let Test.32 : [C {}, C U64, C Str] = TagId(1) Test.5;
     ret Test.32;
 
 procedure Test.2 (Test.7):
-    let Test.26 : [C U64, C {}, C Str] = TagId(2) Test.7;
+    let Test.26 : [C {}, C U64, C Str] = TagId(2) Test.7;
     ret Test.26;
 
 procedure Test.6 (Test.21, #Attr.12):
-    let Test.5 : U64 = UnionAtIndex (Id 0) (Index 0) #Attr.12;
+    let Test.5 : U64 = UnionAtIndex (Id 1) (Index 0) #Attr.12;
     dec #Attr.12;
     let Test.35 : Str = "";
     ret Test.35;
 
 procedure Test.6 (Test.21, #Attr.12):
-    let Test.5 : {} = UnionAtIndex (Id 1) (Index 0) #Attr.12;
+    let Test.5 : {} = UnionAtIndex (Id 0) (Index 0) #Attr.12;
     dec #Attr.12;
     let Test.23 : Str = "";
     ret Test.23;
@@ -53,16 +53,16 @@ procedure Test.0 ():
     switch Test.3:
         case 0:
             let Test.19 : {} = Struct {};
-            let Test.18 : [C U64, C {}, C Str] = CallByName Test.1 Test.19;
+            let Test.18 : [C {}, C U64, C Str] = CallByName Test.1 Test.19;
             jump Test.17 Test.18;
     
         case 1:
             let Test.25 : Str = "foo";
-            let Test.24 : [C U64, C {}, C Str] = CallByName Test.2 Test.25;
+            let Test.24 : [C {}, C U64, C Str] = CallByName Test.2 Test.25;
             jump Test.17 Test.24;
     
         default:
             let Test.31 : U64 = 1i64;
-            let Test.30 : [C U64, C {}, C Str] = CallByName Test.1 Test.31;
+            let Test.30 : [C {}, C U64, C Str] = CallByName Test.1 Test.31;
             jump Test.17 Test.30;
     

--- a/crates/compiler/test_mono/src/tests.rs
+++ b/crates/compiler/test_mono/src/tests.rs
@@ -135,7 +135,7 @@ fn compiles_to_ir(test_name: &str, src: &str, mode: &str, no_check: bool) {
         module_id: home,
         procedures,
         exposed_to_host,
-        layout_interner,
+        mut layout_interner,
         interns,
         ..
     } = loaded;
@@ -152,7 +152,7 @@ fn compiles_to_ir(test_name: &str, src: &str, mode: &str, no_check: bool) {
     let main_fn_symbol = exposed_to_host.values.keys().copied().next();
 
     if !no_check {
-        check_procedures(arena, &interns, &layout_interner, &procedures);
+        check_procedures(arena, &interns, &mut layout_interner, &procedures);
     }
 
     verify_procedures(test_name, layout_interner, procedures, main_fn_symbol);
@@ -161,7 +161,7 @@ fn compiles_to_ir(test_name: &str, src: &str, mode: &str, no_check: bool) {
 fn check_procedures<'a>(
     arena: &'a Bump,
     interns: &Interns,
-    interner: &STLayoutInterner<'a>,
+    interner: &mut STLayoutInterner<'a>,
     procedures: &MutMap<(Symbol, ProcLayout<'a>), Proc<'a>>,
 ) {
     use roc_mono::debug::{check_procs, format_problems};

--- a/crates/glue/src/types.rs
+++ b/crates/glue/src/types.rs
@@ -1455,6 +1455,7 @@ fn add_tag_union<'a>(
             }
         }
         Layout::Boxed(elem_layout) => {
+            let elem_layout = env.layout_cache.get_in(elem_layout);
             let (tag_name, payload_fields) =
                 single_tag_payload_fields(union_tags, subs, &[*elem_layout], env, types);
 

--- a/crates/repl_eval/src/eval.rs
+++ b/crates/repl_eval/src/eval.rs
@@ -1,5 +1,6 @@
 use bumpalo::collections::Vec;
 use bumpalo::Bump;
+use roc_intern::Interner;
 use roc_types::types::AliasKind;
 use std::cmp::{max_by_key, min_by_key};
 
@@ -854,6 +855,7 @@ fn addr_to_ast<'a, M: ReplAppMemory>(
             let inner_var = env.subs[inner_var_index];
 
             let addr_of_inner = mem.deref_usize(addr);
+            let inner_layout = env.layout_cache.interner.get(*inner_layout);
             let inner_expr = addr_to_ast(
                 env,
                 mem,

--- a/crates/repl_wasm/src/repl.rs
+++ b/crates/repl_wasm/src/repl.rs
@@ -208,7 +208,7 @@ pub async fn entrypoint_from_js(src: String) -> Result<String, String> {
         mut interns,
         mut subs,
         exposed_to_host,
-        layout_interner,
+        mut layout_interner,
         ..
     } = mono;
 
@@ -234,7 +234,6 @@ pub async fn entrypoint_from_js(src: String) -> Result<String, String> {
     let app_module_bytes = {
         let env = roc_gen_wasm::Env {
             arena,
-            layout_interner: &layout_interner,
             module_id,
             stack_bytes: roc_gen_wasm::Env::DEFAULT_STACK_BYTES,
             exposed_to_host: exposed_to_host
@@ -248,6 +247,7 @@ pub async fn entrypoint_from_js(src: String) -> Result<String, String> {
             let host_module = roc_gen_wasm::parse_host(env.arena, PRE_LINKED_BINARY).unwrap();
             roc_gen_wasm::build_app_module(
                 &env,
+                &mut layout_interner,
                 &mut interns, // NOTE: must drop this mutable ref before jit_to_ast
                 host_module,
                 procedures,


### PR DESCRIPTION
The plan is to change all references to `Layout` to be `Interned<Layout>`. Builtin layouts, Union, etc. will be unaffected though (for now) since those are not very deep.

This should make certain things, like

- supporting multiple recursive pointers
- trying an experiment where lambda sets take args/return value again
- SoA layouts

much easier

This is just part 1, I don't want to make the sweeping change terrible to review so let's go in parts here. I suspect this will be the change with the largest area, since it makes the interner mutable across the backend (since the backends can add new layouts)

In particular boxed layouts and layouts of captures in closures are touched right now