### PR TITLE
Correct pattern matching of nullable wrapped tag unions 

### DIFF
--- a/crates/compiler/mono/src/debug/checker.rs
+++ b/crates/compiler/mono/src/debug/checker.rs
@@ -746,8 +746,13 @@ fn get_tag_id_payloads(union_layout: UnionLayout, tag_id: TagIdIntType) -> TagPa
             if tag_id == nullable_id {
                 TagPayloads::Payloads(&[])
             } else {
-                check_tag_id_oob!(other_tags.len());
-                let payloads = other_tags[tag_id as usize];
+                check_tag_id_oob!(other_tags.len() + 1);
+                let tag_id_idx = if tag_id > nullable_id {
+                    tag_id - 1
+                } else {
+                    tag_id
+                };
+                let payloads = other_tags[tag_id_idx as usize];
                 TagPayloads::Payloads(payloads)
             }
         }

--- a/crates/compiler/mono/src/debug/checker.rs
+++ b/crates/compiler/mono/src/debug/checker.rs
@@ -746,7 +746,9 @@ fn get_tag_id_payloads(union_layout: UnionLayout, tag_id: TagIdIntType) -> TagPa
             if tag_id == nullable_id {
                 TagPayloads::Payloads(&[])
             } else {
-                check_tag_id_oob!(other_tags.len() + 1);
+                let num_tags = other_tags.len() + 1;
+                check_tag_id_oob!(num_tags);
+
                 let tag_id_idx = if tag_id > nullable_id {
                     tag_id - 1
                 } else {

--- a/crates/compiler/mono/src/ir.rs
+++ b/crates/compiler/mono/src/ir.rs
@@ -9786,36 +9786,21 @@ fn from_can_pattern_help<'a>(
                         } => {
                             debug_assert!(!tags.is_empty());
 
-                            let mut i = 0;
-                            for (tag_name, args) in tags.iter() {
+                            for (i, (tag_name, args)) in tags.iter().enumerate() {
                                 if i == nullable_id as usize {
+                                    debug_assert!(args.is_empty());
                                     ctors.push(Ctor {
                                         tag_id: TagId(i as _),
                                         name: CtorName::Tag(nullable_name.expect_tag_ref().clone()),
-                                        // don't include tag discriminant in arity
                                         arity: 0,
                                     });
-
-                                    i += 1;
+                                } else {
+                                    ctors.push(Ctor {
+                                        tag_id: TagId(i as _),
+                                        name: CtorName::Tag(tag_name.expect_tag_ref().clone()),
+                                        arity: args.len(),
+                                    });
                                 }
-
-                                ctors.push(Ctor {
-                                    tag_id: TagId(i as _),
-                                    name: CtorName::Tag(tag_name.expect_tag_ref().clone()),
-                                    // don't include tag discriminant in arity
-                                    arity: args.len() - 1,
-                                });
-
-                                i += 1;
-                            }
-
-                            if i == nullable_id as usize {
-                                ctors.push(Ctor {
-                                    tag_id: TagId(i as _),
-                                    name: CtorName::Tag(nullable_name.expect_tag_ref().clone()),
-                                    // don't include tag discriminant in arity
-                                    arity: 0,
-                                });
                             }
 
                             let union = roc_exhaustive::Union {

--- a/crates/compiler/mono/src/ir.rs
+++ b/crates/compiler/mono/src/ir.rs
@@ -9698,8 +9698,7 @@ fn from_can_pattern_help<'a>(
                                 ctors.push(Ctor {
                                     tag_id: TagId(i as _),
                                     name: CtorName::Tag(tag_name.expect_tag_ref().clone()),
-                                    // don't include tag discriminant in arity
-                                    arity: args.len() - 1,
+                                    arity: args.len(),
                                 })
                             }
 
@@ -9855,8 +9854,7 @@ fn from_can_pattern_help<'a>(
                             ctors.push(Ctor {
                                 tag_id: TagId(!nullable_id as _),
                                 name: CtorName::Tag(nullable_name.expect_tag_ref().clone()),
-                                // FIXME drop tag
-                                arity: other_fields.len() - 1,
+                                arity: other_fields.len(),
                             });
 
                             let union = roc_exhaustive::Union {
@@ -9869,7 +9867,6 @@ fn from_can_pattern_help<'a>(
                             let it = if tag_name == nullable_name.expect_tag_ref() {
                                 [].iter()
                             } else {
-                                // FIXME drop tag
                                 argument_layouts.iter()
                             };
 

--- a/crates/compiler/mono/src/layout.rs
+++ b/crates/compiler/mono/src/layout.rs
@@ -805,7 +805,32 @@ impl<'a> UnionLayout<'a> {
                     .append(tags_doc)
                     .append(alloc.text("]"))
             }
-            _ => alloc.text("TODO"),
+            NullableWrapped {
+                nullable_id,
+                other_tags,
+            } => {
+                let nullable_id = nullable_id as usize;
+                let tags_docs = (0..(other_tags.len() + 1)).map(|i| {
+                    if i == nullable_id {
+                        alloc.text("<null>")
+                    } else {
+                        let idx = if i > nullable_id { i - 1 } else { i };
+                        alloc.text("C ").append(
+                            alloc.intersperse(
+                                other_tags[idx]
+                                    .iter()
+                                    .map(|x| x.to_doc(alloc, interner, Parens::InTypeParam)),
+                                " ",
+                            ),
+                        )
+                    }
+                });
+                let tags_docs = alloc.intersperse(tags_docs, alloc.text(", "));
+                alloc
+                    .text("[<rnw>")
+                    .append(tags_docs)
+                    .append(alloc.text("]"))
+            }
         }
     }
 

--- a/crates/compiler/test_gen/src/gen_tags.rs
+++ b/crates/compiler/test_gen/src/gen_tags.rs
@@ -2133,3 +2133,34 @@ fn non_unary_union_with_lambda_set_with_imported_toplevels_issue_4733() {
         i64
     );
 }
+
+#[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
+fn nullable_wrapped_with_non_nullable_singleton_tags() {
+    assert_evals_to!(
+        indoc!(
+            r#"
+            app "test" provides [main] to "./platform"
+
+            F : [
+                A F,
+                B,
+                C,
+            ]
+
+            g : F -> Str
+            g = \f -> when f is
+                    A _ -> "A"
+                    B -> "B"
+                    C -> "C"
+
+            main =
+                g (A (B))
+                |> Str.concat (g B)
+                |> Str.concat (g C)
+            "#
+        ),
+        RocStr::from("ABC"),
+        RocStr
+    );
+}

--- a/crates/compiler/test_mono/generated/nullable_wrapped_with_non_nullable_singleton_tags.txt
+++ b/crates/compiler/test_mono/generated/nullable_wrapped_with_non_nullable_singleton_tags.txt
@@ -1,0 +1,36 @@
+procedure Str.3 (#Attr.2, #Attr.3):
+    let Str.266 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
+    ret Str.266;
+
+procedure Test.2 (Test.4):
+    let Test.16 : U8 = GetTagId Test.4;
+    switch Test.16:
+        case 0:
+            let Test.13 : Str = "A";
+            ret Test.13;
+    
+        case 1:
+            let Test.14 : Str = "B";
+            ret Test.14;
+    
+        default:
+            let Test.15 : Str = "C";
+            ret Test.15;
+    
+
+procedure Test.0 ():
+    let Test.21 : [<rnw>C *self, <null>, C ] = TagId(1) ;
+    let Test.20 : [<rnw>C *self, <null>, C ] = TagId(0) Test.21;
+    let Test.17 : Str = CallByName Test.2 Test.20;
+    dec Test.20;
+    let Test.19 : [<rnw>C *self, <null>, C ] = TagId(1) ;
+    let Test.18 : Str = CallByName Test.2 Test.19;
+    dec Test.19;
+    let Test.10 : Str = CallByName Str.3 Test.17 Test.18;
+    dec Test.18;
+    let Test.12 : [<rnw>C *self, <null>, C ] = TagId(2) ;
+    let Test.11 : Str = CallByName Test.2 Test.12;
+    dec Test.12;
+    let Test.9 : Str = CallByName Str.3 Test.10 Test.11;
+    dec Test.11;
+    ret Test.9;

--- a/crates/compiler/test_mono/src/tests.rs
+++ b/crates/compiler/test_mono/src/tests.rs
@@ -2314,3 +2314,29 @@ fn issue_4557() {
         "###
     )
 }
+
+#[mono_test]
+fn nullable_wrapped_with_non_nullable_singleton_tags() {
+    indoc!(
+        r###"
+        app "test" provides [main] to "./platform"
+
+        F : [
+            A F,
+            B,
+            C,
+        ]
+
+        g : F -> Str
+        g = \f -> when f is
+                A _ -> "A"
+                B -> "B"
+                C -> "C"
+
+        main =
+            g (A (B))
+            |> Str.concat (g B)
+            |> Str.concat (g C)
+        "###
+    )
+}


### PR DESCRIPTION
The nullable ID always has zero tags. For everything else, we should
just match with the arity of the number of arguments, which doesn't
include the tag ID.


As @joshuawarner32 found in https://roc.zulipchat.com/#narrow/stream/231635-compiler-development/topic/.22attempt.20to.20subtract.20with.20overflow.22.20in.20ir.2Ers