### PR TITLE
Virtual DOM diff

### DIFF
--- a/examples/virtual-dom-wip/platform/Effect.roc
+++ b/examples/virtual-dom-wip/platform/Effect.roc
@@ -74,8 +74,8 @@ setStyle : NodeId, Str, Str -> Effect {}
 ## setListener nodeId eventType accessorsJson handlerId
 setListener : NodeId, EventType, List U8, HandlerId -> Effect {}
 
-## removeListener nodeId eventType
-removeListener : NodeId, EventType -> Effect {}
+## removeListener nodeId handlerId
+removeListener : NodeId, HandlerId -> Effect {}
 
 # Enable a special memory allocator for virtual DOM
 # This consists of two arenas, "even" and "odd", which alternately hold the "old" and "new" VDOM.

--- a/examples/virtual-dom-wip/platform/Html/Internal/Client.roc
+++ b/examples/virtual-dom-wip/platform/Html/Internal/Client.roc
@@ -288,15 +288,11 @@ diff = \{ rendered, patches }, newNode ->
                         }
                         { rendered: renderedAfterCreate, patches: patchesAfterCreate, ids: createdIds } =
                             List.walkFrom newChildren (List.len oldChildren) stateBeforeCreate createChildNode
-                        # Find the children again since they might have new node IDs!
-                        latestNode =
-                            List.get renderedAfterCreate.nodes root
-                            |> Result.withDefault (Ok RenderedNone)
-                            |> Result.withDefault (RenderedNone)
+                        # Look up the children again since they might have new node IDs!
                         nodeWithUpdatedChildren =
-                            when latestNode is
-                                RenderedElement n a c -> RenderedElement n a (List.concat c createdIds)
-                                _ -> latestNode # impossible
+                            when List.get renderedAfterCreate.nodes root is
+                                Ok (Ok (RenderedElement n a c)) -> RenderedElement n a (List.concat c createdIds)
+                                _ -> crash "Bug in virtual-dom framework: nodeWithUpdatedChildren not found"
                         updatedNodes =
                             List.set renderedAfterCreate.nodes root (Ok nodeWithUpdatedChildren)
 

--- a/examples/virtual-dom-wip/platform/Html/Internal/Client.roc
+++ b/examples/virtual-dom-wip/platform/Html/Internal/Client.roc
@@ -775,9 +775,7 @@ expect
 
     actual : DiffState State
     actual =
-        # COMPILER BUG? 'no lambdaset found'
-        # diff diffStateBefore newNode
-        expected # TODO: tests that actually test things
+        diff diffStateBefore newNode
 
     (actual.patches == expected.patches)
     && eqRenderedTree actual.rendered expected.rendered
@@ -818,9 +816,7 @@ expect
 
     initJson : List U8
     initJson =
-        # { answer: 42 } |> Encode.toBytes Json.toUtf8 # panics at mono/src/ir.rs:5739:56
-        "{ answer: 42 }" |> Str.toUtf8
-
+        { answer: 42 } |> Encode.toBytes Json.toUtf8 # panics at mono/src/ir.rs:5739:56
     expected : { state : State, rendered : RenderedTree State, patches : List Patch }
     expected = {
         state: { answer: 42 },
@@ -842,9 +838,7 @@ expect
 
     actual : { state : State, rendered : RenderedTree State, patches : List Patch }
     actual =
-        # COMPILER BUG? 'no lambdaset found'
-        # initClientAppHelp initJson app
-        expected # TODO: tests that actually test things
+        initClientAppHelp initJson app
 
     (actual.state == expected.state)
     && eqRenderedTree actual.rendered expected.rendered


### PR DESCRIPTION
Implements actual diffing on the virtual DOM. Up to now, it just re-rendered the view fresh every time.

I have still never actually run this code! To go further after this PR I will need to be able to debug it. So I think the next goal is to get all the compiler issues fixed so that the following commands all complete without a compiler crash.
```
$ roc build --target wasm32 examples/virtual-dom-wip/example-client.roc  
$ roc build examples/virtual-dom-wip/example-server.roc
$ roc test examples/virtual-dom-wip/platform/Html/Internal/Client.roc
```