### PR TITLE
Wrap layout interners in own trait

### DIFF
--- a/crates/compiler/gen_wasm/src/wasm32_result.rs
+++ b/crates/compiler/gen_wasm/src/wasm32_result.rs
@@ -7,8 +7,7 @@ The user needs to analyse the Wasm module's memory to decode the result.
 use bumpalo::{collections::Vec, Bump};
 
 use roc_builtins::bitcode::{FloatWidth, IntWidth};
-use roc_intern::Interner;
-use roc_mono::layout::{Builtin, Layout, UnionLayout};
+use roc_mono::layout::{Builtin, Layout, LayoutInterner, UnionLayout};
 use roc_std::{RocDec, RocList, RocOrder, RocResult, RocStr, I128, U128};
 use roc_target::TargetInfo;
 use roc_wasm_module::{
@@ -39,7 +38,7 @@ pub trait Wasm32Result {
 /// Layout-driven wrapper generation
 pub fn insert_wrapper_for_layout<'a>(
     arena: &'a Bump,
-    interner: &impl Interner<'a, Layout<'a>>,
+    interner: &impl LayoutInterner<'a>,
     module: &mut WasmModule<'a>,
     wrapper_name: &'static str,
     main_fn_index: u32,

--- a/crates/compiler/mono/src/code_gen_help/refcount.rs
+++ b/crates/compiler/mono/src/code_gen_help/refcount.rs
@@ -11,7 +11,9 @@ use crate::code_gen_help::let_lowlevel;
 use crate::ir::{
     BranchInfo, Call, CallType, Expr, JoinPointId, Literal, ModifyRc, Param, Stmt, UpdateModeId,
 };
-use crate::layout::{Builtin, InLayout, Layout, STLayoutInterner, TagIdIntType, UnionLayout};
+use crate::layout::{
+    Builtin, InLayout, Layout, LayoutInterner, STLayoutInterner, TagIdIntType, UnionLayout,
+};
 
 use super::{CodeGenHelp, Context, HelperOp};
 
@@ -420,7 +422,7 @@ pub fn refcount_reset_proc_body<'a>(
 // progress incrementally. Kept in sync with generate_procs using assertions.
 pub fn is_rc_implemented_yet<'a, I>(interner: &I, layout: &Layout<'a>) -> bool
 where
-    I: Interner<'a, Layout<'a>>,
+    I: LayoutInterner<'a>,
 {
     use UnionLayout::*;
 

--- a/crates/compiler/mono/src/debug/report.rs
+++ b/crates/compiler/mono/src/debug/report.rs
@@ -1,12 +1,11 @@
 use std::fmt::Display;
 
-use roc_intern::Interner;
 use roc_module::symbol::{Interns, Symbol};
 use ven_pretty::{Arena, DocAllocator, DocBuilder};
 
 use crate::{
     ir::{Parens, ProcLayout},
-    layout::Layout,
+    layout::{Layout, LayoutInterner},
 };
 
 use super::{
@@ -20,7 +19,7 @@ pub fn format_problems<'a, I>(
     problems: Problems<'a>,
 ) -> impl Display
 where
-    I: Interner<'a, Layout<'a>>,
+    I: LayoutInterner<'a>,
 {
     let Problems(problems) = problems;
     let f = Arena::new();
@@ -44,7 +43,7 @@ fn format_problem<'a, 'd, I>(
 ) -> Doc<'d>
 where
     'a: 'd,
-    I: Interner<'a, Layout<'a>>,
+    I: LayoutInterner<'a>,
 {
     let Problem {
         proc,
@@ -118,7 +117,7 @@ fn format_kind<'a, 'd, I>(
     kind: ProblemKind<'a>,
 ) -> (&'static str, Vec<(usize, Doc<'d>)>, Doc<'d>)
 where
-    I: Interner<'a, Layout<'a>>,
+    I: LayoutInterner<'a>,
 {
     let title;
     let docs_before;
@@ -445,7 +444,7 @@ fn format_proc_spec<'a, 'd, I>(
     proc_layout: ProcLayout<'a>,
 ) -> Doc<'d>
 where
-    I: Interner<'a, Layout<'a>>,
+    I: LayoutInterner<'a>,
 {
     f.concat([
         f.as_string(symbol.as_str(interns)),
@@ -460,7 +459,7 @@ fn format_proc_layout<'a, 'd, I>(
     proc_layout: ProcLayout<'a>,
 ) -> Doc<'d>
 where
-    I: Interner<'a, Layout<'a>>,
+    I: LayoutInterner<'a>,
 {
     let ProcLayout {
         arguments,

--- a/crates/compiler/mono/src/decision_tree.rs
+++ b/crates/compiler/mono/src/decision_tree.rs
@@ -2,7 +2,7 @@ use crate::ir::{
     build_list_index_probe, BranchInfo, Call, CallType, DestructType, Env, Expr, JoinPointId,
     ListIndex, Literal, Param, Pattern, Procs, Stmt,
 };
-use crate::layout::{Builtin, Layout, LayoutCache, LayoutInterner, TagIdIntType, UnionLayout};
+use crate::layout::{Builtin, Layout, LayoutCache, TLLayoutInterner, TagIdIntType, UnionLayout};
 use roc_builtins::bitcode::{FloatWidth, IntWidth};
 use roc_collections::all::{MutMap, MutSet};
 use roc_error_macros::internal_error;
@@ -1359,7 +1359,7 @@ enum PathInstruction {
 
 fn path_to_expr_help<'a>(
     env: &mut Env<'a, '_>,
-    layout_interner: &LayoutInterner<'a>,
+    layout_interner: &TLLayoutInterner<'a>,
     mut symbol: Symbol,
     path: &[PathInstruction],
     mut layout: Layout<'a>,
@@ -1462,7 +1462,7 @@ fn path_to_expr_help<'a>(
 
 fn test_to_comparison<'a>(
     env: &mut Env<'a, '_>,
-    layout_interner: &LayoutInterner<'a>,
+    layout_interner: &TLLayoutInterner<'a>,
     cond_symbol: Symbol,
     cond_layout: &Layout<'a>,
     path: &[PathInstruction],
@@ -1619,7 +1619,7 @@ type Tests<'a> = std::vec::Vec<(
 
 fn stores_and_condition<'a>(
     env: &mut Env<'a, '_>,
-    layout_interner: &LayoutInterner<'a>,
+    layout_interner: &TLLayoutInterner<'a>,
     cond_symbol: Symbol,
     cond_layout: &Layout<'a>,
     test_chain: Vec<(Vec<PathInstruction>, Test<'a>)>,

--- a/crates/compiler/mono/src/ir.rs
+++ b/crates/compiler/mono/src/ir.rs
@@ -2,8 +2,8 @@
 
 use crate::layout::{
     self, Builtin, ClosureCallOptions, ClosureRepresentation, EnumDispatch, LambdaName, LambdaSet,
-    Layout, LayoutCache, LayoutProblem, Niche, RawFunctionLayout, STLayoutInterner, TagIdIntType,
-    UnionLayout, WrappedVariant,
+    Layout, LayoutCache, LayoutInterner, LayoutProblem, Niche, RawFunctionLayout, STLayoutInterner,
+    TagIdIntType, UnionLayout, WrappedVariant,
 };
 use bumpalo::collections::{CollectIn, Vec};
 use bumpalo::Bump;
@@ -22,7 +22,6 @@ use roc_debug_flags::{
 use roc_derive::SharedDerivedModule;
 use roc_error_macros::{internal_error, todo_abilities};
 use roc_exhaustive::{Ctor, CtorName, ListArity, RenderAs, TagId};
-use roc_intern::Interner;
 use roc_late_solve::storage::{ExternalModuleStorage, ExternalModuleStorageSnapshot};
 use roc_late_solve::{resolve_ability_specialization, AbilitiesView, Resolved, UnificationFailed};
 use roc_module::ident::{ForeignSymbol, Lowercase, TagName};
@@ -339,7 +338,7 @@ impl<'a> Proc<'a> {
         D: DocAllocator<'b, A>,
         D::Doc: Clone,
         A: Clone,
-        I: Interner<'a, Layout<'a>>,
+        I: LayoutInterner<'a>,
     {
         let args_doc = self.args.iter().map(|(layout, symbol)| {
             let arg_doc = symbol_to_doc(alloc, *symbol, pretty);
@@ -382,7 +381,7 @@ impl<'a> Proc<'a> {
 
     pub fn to_pretty<I>(&self, interner: &I, width: usize, pretty: bool) -> String
     where
-        I: Interner<'a, Layout<'a>>,
+        I: LayoutInterner<'a>,
     {
         let allocator = BoxAllocator;
         let mut w = std::vec::Vec::new();
@@ -2173,7 +2172,7 @@ impl<'a> Stmt<'a> {
         D: DocAllocator<'b, A>,
         D::Doc: Clone,
         A: Clone,
-        I: Interner<'a, Layout<'a>>,
+        I: LayoutInterner<'a>,
     {
         use Stmt::*;
 
@@ -2329,7 +2328,7 @@ impl<'a> Stmt<'a> {
 
     pub fn to_pretty<I>(&self, interner: &I, width: usize, pretty: bool) -> String
     where
-        I: Interner<'a, Layout<'a>>,
+        I: LayoutInterner<'a>,
     {
         let allocator = BoxAllocator;
         let mut w = std::vec::Vec::new();

--- a/crates/compiler/mono/src/layout.rs
+++ b/crates/compiler/mono/src/layout.rs
@@ -23,7 +23,7 @@ use std::hash::{Hash, Hasher};
 use ven_pretty::{DocAllocator, DocBuilder};
 
 mod intern;
-pub use intern::{STLayoutInterner, TLLayoutInterner};
+pub use intern::{GlobalLayoutInterner, LayoutInterner, STLayoutInterner, TLLayoutInterner};
 
 // if your changes cause this number to go down, great!
 // please change it to the lower number.

--- a/crates/compiler/mono/src/layout.rs
+++ b/crates/compiler/mono/src/layout.rs
@@ -743,7 +743,7 @@ impl<'a> UnionLayout<'a> {
         D: DocAllocator<'b, A>,
         D::Doc: Clone,
         A: Clone,
-        I: Interner<'a, Layout<'a>>,
+        I: LayoutInterner<'a>,
     {
         use UnionLayout::*;
 
@@ -982,7 +982,7 @@ impl<'a> UnionLayout<'a> {
         target_info: TargetInfo,
     ) -> u32
     where
-        I: Interner<'a, Layout<'a>>,
+        I: LayoutInterner<'a>,
     {
         tags.iter()
             .map(|field_layouts| {
@@ -994,7 +994,7 @@ impl<'a> UnionLayout<'a> {
 
     pub fn allocation_alignment_bytes<I>(&self, interner: &I, target_info: TargetInfo) -> u32
     where
-        I: Interner<'a, Layout<'a>>,
+        I: LayoutInterner<'a>,
     {
         let allocation = match self {
             UnionLayout::NonRecursive(tags) => {
@@ -1019,7 +1019,7 @@ impl<'a> UnionLayout<'a> {
     /// Size of the data in memory, whether it's stack or heap (for non-null tag ids)
     pub fn data_size_and_alignment<I>(&self, interner: &I, target_info: TargetInfo) -> (u32, u32)
     where
-        I: Interner<'a, Layout<'a>>,
+        I: LayoutInterner<'a>,
     {
         let (data_width, data_align) =
             self.data_size_and_alignment_help_match(interner, target_info);
@@ -1052,7 +1052,7 @@ impl<'a> UnionLayout<'a> {
     /// Returns None if the tag_id is not stored as data in the layout.
     pub fn data_size_without_tag_id<I>(&self, interner: &I, target_info: TargetInfo) -> Option<u32>
     where
-        I: Interner<'a, Layout<'a>>,
+        I: LayoutInterner<'a>,
     {
         if !self.stores_tag_id_as_data(target_info) {
             return None;
@@ -1070,7 +1070,7 @@ impl<'a> UnionLayout<'a> {
         target_info: TargetInfo,
     ) -> (u32, u32)
     where
-        I: Interner<'a, Layout<'a>>,
+        I: LayoutInterner<'a>,
     {
         match self {
             Self::NonRecursive(tags) => {
@@ -1093,7 +1093,7 @@ impl<'a> UnionLayout<'a> {
 
     pub fn tag_id_offset<I>(&self, interner: &I, target_info: TargetInfo) -> Option<u32>
     where
-        I: Interner<'a, Layout<'a>>,
+        I: LayoutInterner<'a>,
     {
         match self {
             UnionLayout::NonRecursive(tags)
@@ -1111,7 +1111,7 @@ impl<'a> UnionLayout<'a> {
         target_info: TargetInfo,
     ) -> u32
     where
-        I: Interner<'a, Layout<'a>>,
+        I: LayoutInterner<'a>,
     {
         let (data_width, data_align) =
             Layout::stack_size_and_alignment_slices(interner, layouts, target_info);
@@ -1122,7 +1122,7 @@ impl<'a> UnionLayout<'a> {
     /// Very important to use this when doing a memcpy!
     fn stack_size_without_alignment<I>(&self, interner: &I, target_info: TargetInfo) -> u32
     where
-        I: Interner<'a, Layout<'a>>,
+        I: LayoutInterner<'a>,
     {
         match self {
             UnionLayout::NonRecursive(_) => {
@@ -1281,7 +1281,7 @@ impl<'a> Niche<'a> {
         D: DocAllocator<'b, A>,
         D::Doc: Clone,
         A: Clone,
-        I: Interner<'a, Layout<'a>>,
+        I: LayoutInterner<'a>,
     {
         match self.0 {
             NichePriv::Captures(captures) => alloc.concat([
@@ -1394,7 +1394,7 @@ pub enum ClosureCallOptions<'a> {
 impl<'a> LambdaSet<'a> {
     pub fn runtime_representation<I>(&self, interner: &I) -> Layout<'a>
     where
-        I: Interner<'a, Layout<'a>>,
+        I: LayoutInterner<'a>,
     {
         *interner.get(self.representation)
     }
@@ -1406,7 +1406,7 @@ impl<'a> LambdaSet<'a> {
 
     pub fn is_represented<I>(&self, interner: &I) -> Option<Layout<'a>>
     where
-        I: Interner<'a, Layout<'a>>,
+        I: LayoutInterner<'a>,
     {
         if self.has_unwrapped_capture_repr() {
             let repr = interner.get(self.representation);
@@ -1450,7 +1450,7 @@ impl<'a> LambdaSet<'a> {
         lambda_name: LambdaName,
     ) -> ClosureRepresentation<'a>
     where
-        I: Interner<'a, Layout<'a>>,
+        I: LayoutInterner<'a>,
     {
         debug_assert!(self.contains(lambda_name.name));
 
@@ -1475,7 +1475,7 @@ impl<'a> LambdaSet<'a> {
         captures_layouts: &[Layout],
     ) -> LambdaName<'a>
     where
-        I: Interner<'a, Layout<'a>>,
+        I: LayoutInterner<'a>,
     {
         debug_assert!(
             self.contains(function_symbol),
@@ -1516,7 +1516,7 @@ impl<'a> LambdaSet<'a> {
     /// Resolves recursive pointers to the layout of the lambda set.
     fn capture_layouts_eq<I>(&self, interner: &I, left: &InLayout<'a>, right: &Layout) -> bool
     where
-        I: Interner<'a, Layout<'a>>,
+        I: LayoutInterner<'a>,
     {
         let left = interner.get(*left);
         if left == right {
@@ -1550,7 +1550,7 @@ impl<'a> LambdaSet<'a> {
 
     fn layout_for_member<I, F>(&self, interner: &I, comparator: F) -> ClosureRepresentation<'a>
     where
-        I: Interner<'a, Layout<'a>>,
+        I: LayoutInterner<'a>,
         F: Fn(Symbol, &[InLayout]) -> bool,
     {
         if self.has_unwrapped_capture_repr() {
@@ -1663,7 +1663,7 @@ impl<'a> LambdaSet<'a> {
 
     pub fn call_by_name_options<I>(&self, interner: &I) -> ClosureCallOptions<'a>
     where
-        I: Interner<'a, Layout<'a>>,
+        I: LayoutInterner<'a>,
     {
         let repr = interner.get(self.representation);
 
@@ -1907,7 +1907,7 @@ impl<'a> LambdaSet<'a> {
 
     pub fn stack_size<I>(&self, interner: &I, target_info: TargetInfo) -> u32
     where
-        I: Interner<'a, Layout<'a>>,
+        I: LayoutInterner<'a>,
     {
         interner
             .get(self.representation)
@@ -1915,7 +1915,7 @@ impl<'a> LambdaSet<'a> {
     }
     pub fn contains_refcounted<I>(&self, interner: &I) -> bool
     where
-        I: Interner<'a, Layout<'a>>,
+        I: LayoutInterner<'a>,
     {
         interner
             .get(self.representation)
@@ -1923,14 +1923,14 @@ impl<'a> LambdaSet<'a> {
     }
     pub fn safe_to_memcpy<I>(&self, interner: &I) -> bool
     where
-        I: Interner<'a, Layout<'a>>,
+        I: LayoutInterner<'a>,
     {
         interner.get(self.representation).safe_to_memcpy(interner)
     }
 
     pub fn alignment_bytes<I>(&self, interner: &I, target_info: TargetInfo) -> u32
     where
-        I: Interner<'a, Layout<'a>>,
+        I: LayoutInterner<'a>,
     {
         interner
             .get(self.representation)
@@ -2399,7 +2399,7 @@ impl<'a> Layout<'a> {
 
     pub fn safe_to_memcpy<I>(&self, interner: &I) -> bool
     where
-        I: Interner<'a, Layout<'a>>,
+        I: LayoutInterner<'a>,
     {
         use Layout::*;
 
@@ -2445,7 +2445,7 @@ impl<'a> Layout<'a> {
 
     pub fn is_passed_by_reference<I>(&self, interner: &I, target_info: TargetInfo) -> bool
     where
-        I: Interner<'a, Layout<'a>>,
+        I: LayoutInterner<'a>,
     {
         match self {
             Layout::Builtin(builtin) => {
@@ -2472,7 +2472,7 @@ impl<'a> Layout<'a> {
 
     pub fn stack_size<I>(&self, interner: &I, target_info: TargetInfo) -> u32
     where
-        I: Interner<'a, Layout<'a>>,
+        I: LayoutInterner<'a>,
     {
         let width = self.stack_size_without_alignment(interner, target_info);
         let alignment = self.alignment_bytes(interner, target_info);
@@ -2482,7 +2482,7 @@ impl<'a> Layout<'a> {
 
     pub fn stack_size_and_alignment<I>(&self, interner: &I, target_info: TargetInfo) -> (u32, u32)
     where
-        I: Interner<'a, Layout<'a>>,
+        I: LayoutInterner<'a>,
     {
         let width = self.stack_size_without_alignment(interner, target_info);
         let alignment = self.alignment_bytes(interner, target_info);
@@ -2494,7 +2494,7 @@ impl<'a> Layout<'a> {
     /// Very important to use this when doing a memcpy!
     pub fn stack_size_without_alignment<I>(&self, interner: &I, target_info: TargetInfo) -> u32
     where
-        I: Interner<'a, Layout<'a>>,
+        I: LayoutInterner<'a>,
     {
         use Layout::*;
 
@@ -2520,7 +2520,7 @@ impl<'a> Layout<'a> {
 
     pub fn alignment_bytes<I>(&self, interner: &I, target_info: TargetInfo) -> u32
     where
-        I: Interner<'a, Layout<'a>>,
+        I: LayoutInterner<'a>,
     {
         match self {
             Layout::Struct { field_layouts, .. } => field_layouts
@@ -2572,7 +2572,7 @@ impl<'a> Layout<'a> {
 
     pub fn allocation_alignment_bytes<I>(&self, interner: &I, target_info: TargetInfo) -> u32
     where
-        I: Interner<'a, Layout<'a>>,
+        I: LayoutInterner<'a>,
     {
         let ptr_width = target_info.ptr_width() as u32;
 
@@ -2598,7 +2598,7 @@ impl<'a> Layout<'a> {
         target_info: TargetInfo,
     ) -> (u32, u32)
     where
-        I: Interner<'a, Layout<'a>>,
+        I: LayoutInterner<'a>,
     {
         let mut data_align = 1;
         let mut data_width = 0;
@@ -2642,7 +2642,7 @@ impl<'a> Layout<'a> {
     /// goes out of scope, the refcount on those values/fields must  be decremented.
     pub fn contains_refcounted<I>(&self, interner: &I) -> bool
     where
-        I: Interner<'a, Layout<'a>>,
+        I: LayoutInterner<'a>,
     {
         use Layout::*;
 
@@ -2683,7 +2683,7 @@ impl<'a> Layout<'a> {
         D: DocAllocator<'b, A>,
         D::Doc: Clone,
         A: Clone,
-        I: Interner<'a, Layout<'a>>,
+        I: LayoutInterner<'a>,
     {
         use Layout::*;
 
@@ -2725,7 +2725,7 @@ impl<'a> Layout<'a> {
 
     pub fn runtime_representation<I>(&self, interner: &I) -> Self
     where
-        I: Interner<'a, Layout<'a>>,
+        I: LayoutInterner<'a>,
     {
         match self {
             Layout::LambdaSet(lambda_set) => lambda_set.runtime_representation(interner),
@@ -2927,7 +2927,7 @@ impl<'a> Builtin<'a> {
         D: DocAllocator<'b, A>,
         D::Doc: Clone,
         A: Clone,
-        I: Interner<'a, Layout<'a>>,
+        I: LayoutInterner<'a>,
     {
         use Builtin::*;
 
@@ -2973,7 +2973,7 @@ impl<'a> Builtin<'a> {
 
     pub fn allocation_alignment_bytes<I>(&self, interner: &I, target_info: TargetInfo) -> u32
     where
-        I: Interner<'a, Layout<'a>>,
+        I: LayoutInterner<'a>,
     {
         let ptr_width = target_info.ptr_width() as u32;
 
@@ -4377,7 +4377,7 @@ pub fn cmp_fields<'a, L: Ord, I>(
     target_info: TargetInfo,
 ) -> Ordering
 where
-    I: Interner<'a, Layout<'a>>,
+    I: LayoutInterner<'a>,
 {
     let size1 = layout1.alignment_bytes(interner, target_info);
     let size2 = layout2.alignment_bytes(interner, target_info);

--- a/crates/compiler/mono/src/layout/intern.rs
+++ b/crates/compiler/mono/src/layout/intern.rs
@@ -1,10 +1,57 @@
 use std::sync::Arc;
 
+use roc_builtins::bitcode::IntWidth;
 use roc_intern::{GlobalInterner, Interned, Interner, SingleThreadedInterner, ThreadLocalInterner};
 
-use super::Layout;
+use super::{Builtin, Layout};
 
-pub trait LayoutInterner<'a>: Interner<'a, Layout<'a>> {}
+macro_rules! cache_interned_layouts {
+    ($($i:literal, $name:ident, $layout:expr)*; $total_constants:literal) => {
+        pub trait LayoutInterner<'a>: Interner<'a, Layout<'a>> {
+            $(
+            const $name: Interned<Layout<'a>> = unsafe { Interned::from_reserved_index($i) };
+            )*
+        }
+
+        fn fill_reserved_layouts<'a>(interner: &mut STLayoutInterner<'a>) {
+            assert!(interner.0.is_empty());
+            $(
+            interner.0.insert(&$layout);
+            )*
+        }
+
+        const fn _are_constants_in_order_non_redundant() -> usize {
+            let mut total_seen = 0;
+            $(total_seen += ($i * 0) + 1;)*
+            match 0usize {
+                $($i => {})*
+                _ => {}
+            }
+            total_seen
+        }
+
+        const _ASSERT_NON_REDUNDANT_CONSTANTS: () =
+            assert!(_are_constants_in_order_non_redundant() == $total_constants);
+    }
+}
+
+cache_interned_layouts! {
+    0,  VOID, Layout::VOID
+    1,  UNIT, Layout::UNIT
+    2,  BOOL, Layout::Builtin(Builtin::Bool)
+    3,  U8,   Layout::Builtin(Builtin::Int(IntWidth::U8))
+    4,  U16,  Layout::Builtin(Builtin::Int(IntWidth::U16))
+    5,  U32,  Layout::Builtin(Builtin::Int(IntWidth::U32))
+    6,  U64,  Layout::Builtin(Builtin::Int(IntWidth::U64))
+    7,  U128, Layout::Builtin(Builtin::Int(IntWidth::U128))
+    8,  I8,   Layout::Builtin(Builtin::Int(IntWidth::I8))
+    9,  I16,  Layout::Builtin(Builtin::Int(IntWidth::I16))
+    10, I32,  Layout::Builtin(Builtin::Int(IntWidth::I32))
+    11, I64,  Layout::Builtin(Builtin::Int(IntWidth::I64))
+    12, I128, Layout::Builtin(Builtin::Int(IntWidth::I128))
+
+    ; 13
+}
 
 #[derive(Debug)]
 pub struct GlobalLayoutInterner<'a>(Arc<GlobalInterner<'a, Layout<'a>>>);
@@ -15,7 +62,7 @@ pub struct STLayoutInterner<'a>(SingleThreadedInterner<'a, Layout<'a>>);
 
 impl<'a> GlobalLayoutInterner<'a> {
     pub fn with_capacity(capacity: usize) -> Self {
-        Self(GlobalInterner::with_capacity(capacity))
+        STLayoutInterner::with_capacity(capacity).into_global()
     }
     pub fn fork(&self) -> TLLayoutInterner<'a> {
         TLLayoutInterner(self.0.fork())
@@ -30,7 +77,9 @@ impl<'a> GlobalLayoutInterner<'a> {
 
 impl<'a> STLayoutInterner<'a> {
     pub fn with_capacity(capacity: usize) -> Self {
-        Self(SingleThreadedInterner::with_capacity(capacity))
+        let mut interner = Self(SingleThreadedInterner::with_capacity(capacity));
+        fill_reserved_layouts(&mut interner);
+        interner
     }
     pub fn into_global(self) -> GlobalLayoutInterner<'a> {
         GlobalLayoutInterner(self.0.into_global())

--- a/crates/compiler/mono/src/layout/intern.rs
+++ b/crates/compiler/mono/src/layout/intern.rs
@@ -1,6 +1,60 @@
-use roc_intern::{SingleThreadedInterner, ThreadLocalInterner};
+use std::sync::Arc;
+
+use roc_intern::{GlobalInterner, Interned, Interner, SingleThreadedInterner, ThreadLocalInterner};
 
 use super::Layout;
 
-pub type TLLayoutInterner<'a> = ThreadLocalInterner<'a, Layout<'a>>;
-pub type STLayoutInterner<'a> = SingleThreadedInterner<'a, Layout<'a>>;
+pub trait LayoutInterner<'a>: Interner<'a, Layout<'a>> {}
+
+#[derive(Debug)]
+pub struct GlobalLayoutInterner<'a>(Arc<GlobalInterner<'a, Layout<'a>>>);
+#[derive(Debug)]
+pub struct TLLayoutInterner<'a>(ThreadLocalInterner<'a, Layout<'a>>);
+#[derive(Debug)]
+pub struct STLayoutInterner<'a>(SingleThreadedInterner<'a, Layout<'a>>);
+
+impl<'a> GlobalLayoutInterner<'a> {
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self(GlobalInterner::with_capacity(capacity))
+    }
+    pub fn fork(&self) -> TLLayoutInterner<'a> {
+        TLLayoutInterner(self.0.fork())
+    }
+    pub fn unwrap(self) -> Result<STLayoutInterner<'a>, Self> {
+        match self.0.unwrap() {
+            Ok(st) => Ok(STLayoutInterner(st)),
+            Err(global) => Err(Self(global)),
+        }
+    }
+}
+
+impl<'a> STLayoutInterner<'a> {
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self(SingleThreadedInterner::with_capacity(capacity))
+    }
+    pub fn into_global(self) -> GlobalLayoutInterner<'a> {
+        GlobalLayoutInterner(self.0.into_global())
+    }
+}
+
+impl<'a> Interner<'a, Layout<'a>> for TLLayoutInterner<'a> {
+    fn insert(&mut self, value: &'a Layout<'a>) -> Interned<Layout<'a>> {
+        self.0.insert(value)
+    }
+
+    fn get(&self, key: Interned<Layout<'a>>) -> &'a Layout<'a> {
+        self.0.get(key)
+    }
+}
+impl<'a> LayoutInterner<'a> for TLLayoutInterner<'a> {}
+
+impl<'a> Interner<'a, Layout<'a>> for STLayoutInterner<'a> {
+    fn insert(&mut self, value: &'a Layout<'a>) -> Interned<Layout<'a>> {
+        self.0.insert(value)
+    }
+
+    fn get(&self, key: Interned<Layout<'a>>) -> &'a Layout<'a> {
+        self.0.get(key)
+    }
+}
+impl<'a> LayoutInterner<'a> for STLayoutInterner<'a> {}

--- a/crates/compiler/mono/src/layout/intern.rs
+++ b/crates/compiler/mono/src/layout/intern.rs
@@ -1,0 +1,6 @@
+use roc_intern::{SingleThreadedInterner, ThreadLocalInterner};
+
+use super::Layout;
+
+pub type TLLayoutInterner<'a> = ThreadLocalInterner<'a, Layout<'a>>;
+pub type STLayoutInterner<'a> = SingleThreadedInterner<'a, Layout<'a>>;

--- a/crates/glue/src/load.rs
+++ b/crates/glue/src/load.rs
@@ -1,8 +1,8 @@
 use crate::rust_glue;
 use crate::types::{Env, Types};
 use bumpalo::Bump;
-use roc_intern::GlobalInterner;
 use roc_load::{ExecutionMode, LoadConfig, LoadedModule, LoadingProblem, Threading};
+use roc_mono::layout::GlobalLayoutInterner;
 use roc_packaging::cache::{self, RocCacheDir};
 use roc_reporting::report::{RenderTarget, DEFAULT_PALETTE};
 use roc_target::{Architecture, OperatingSystem, TargetInfo};
@@ -150,7 +150,7 @@ pub fn load_types(
         }
     });
 
-    let layout_interner = GlobalInterner::with_capacity(128);
+    let layout_interner = GlobalLayoutInterner::with_capacity(128);
 
     let architectures = Architecture::iter();
     let mut types_and_targets = Vec::with_capacity(architectures.len());

--- a/crates/glue/src/types.rs
+++ b/crates/glue/src/types.rs
@@ -13,7 +13,7 @@ use roc_module::{
 };
 use roc_mono::layout::{
     cmp_fields, ext_var_is_empty_tag_union, round_up_to_alignment, Builtin, Discriminant, Layout,
-    LayoutCache, LayoutInterner, UnionLayout,
+    LayoutCache, TLLayoutInterner, UnionLayout,
 };
 use roc_target::TargetInfo;
 use roc_types::{
@@ -362,7 +362,7 @@ impl Types {
 
     pub fn add_named<'a>(
         &mut self,
-        interner: &LayoutInterner<'a>,
+        interner: &TLLayoutInterner<'a>,
         name: String,
         typ: RocType,
         layout: Layout<'a>,
@@ -390,7 +390,7 @@ impl Types {
 
     pub fn add_anonymous<'a>(
         &mut self,
-        interner: &LayoutInterner<'a>,
+        interner: &TLLayoutInterner<'a>,
         typ: RocType,
         layout: Layout<'a>,
     ) -> TypeId {
@@ -674,7 +674,7 @@ impl<'a> Env<'a> {
         arena: &'a Bump,
         subs: &'a Subs,
         interns: &'a Interns,
-        layout_interner: LayoutInterner<'a>,
+        layout_interner: TLLayoutInterner<'a>,
         target: TargetInfo,
     ) -> Self {
         Env {

--- a/crates/repl_cli/src/cli_gen.rs
+++ b/crates/repl_cli/src/cli_gen.rs
@@ -6,10 +6,9 @@ use roc_collections::all::MutSet;
 use roc_gen_llvm::llvm::build::LlvmBackendMode;
 use roc_gen_llvm::llvm::externs::add_default_roc_externs;
 use roc_gen_llvm::{run_jit_function, run_jit_function_dynamic_type};
-use roc_intern::SingleThreadedInterner;
 use roc_load::{EntryPoint, MonomorphizedModule};
 use roc_mono::ir::OptLevel;
-use roc_mono::layout::Layout;
+use roc_mono::layout::STLayoutInterner;
 use roc_parse::ast::Expr;
 use roc_repl_eval::eval::jit_to_ast;
 use roc_repl_eval::gen::{compile_to_mono, format_answer, Problems, ReplOutput};
@@ -181,15 +180,7 @@ fn mono_module_to_dylib<'a>(
     target: Triple,
     loaded: MonomorphizedModule<'a>,
     opt_level: OptLevel,
-) -> Result<
-    (
-        libloading::Library,
-        &'a str,
-        Subs,
-        SingleThreadedInterner<'a, Layout<'a>>,
-    ),
-    libloading::Error,
-> {
+) -> Result<(libloading::Library, &'a str, Subs, STLayoutInterner<'a>), libloading::Error> {
     let target_info = TargetInfo::from(&target);
 
     let MonomorphizedModule {

--- a/crates/repl_eval/src/eval.rs
+++ b/crates/repl_eval/src/eval.rs
@@ -11,7 +11,7 @@ use roc_module::ident::TagName;
 use roc_module::symbol::{Interns, ModuleId, Symbol};
 use roc_mono::ir::ProcLayout;
 use roc_mono::layout::{
-    self, union_sorted_tags_pub, Builtin, InLayout, Layout, LayoutCache, LayoutInterner,
+    self, union_sorted_tags_pub, Builtin, InLayout, Layout, LayoutCache, TLLayoutInterner,
     UnionLayout, UnionVariant, WrappedVariant,
 };
 use roc_parse::ast::{AssignedField, Collection, Expr, Pattern, StrLiteral};
@@ -47,7 +47,7 @@ pub fn jit_to_ast<'a, A: ReplApp<'a>>(
     var: Variable,
     subs: &Subs,
     interns: &'a Interns,
-    layout_interner: LayoutInterner<'a>,
+    layout_interner: TLLayoutInterner<'a>,
     target_info: TargetInfo,
 ) -> Expr<'a> {
     let mut env = Env {

--- a/crates/repl_expect/src/lib.rs
+++ b/crates/repl_expect/src/lib.rs
@@ -1,17 +1,15 @@
 //! Supports evaluating `expect` and printing contextual information when they fail.
 #[cfg(not(windows))]
 use {
-    roc_intern::GlobalInterner,
     roc_module::symbol::Interns,
     roc_mono::{
         ir::ProcLayout,
-        layout::{Layout, LayoutCache, Niche},
+        layout::{GlobalLayoutInterner, LayoutCache, Niche},
     },
     roc_parse::ast::Expr,
     roc_repl_eval::{eval::jit_to_ast, ReplAppMemory},
     roc_target::TargetInfo,
     roc_types::subs::{Subs, Variable},
-    std::sync::Arc,
 };
 
 #[cfg(not(windows))]
@@ -29,7 +27,7 @@ pub fn get_values<'a>(
     arena: &'a bumpalo::Bump,
     subs: &Subs,
     interns: &'a Interns,
-    layout_interner: &Arc<GlobalInterner<'a, Layout<'a>>>,
+    layout_interner: &GlobalLayoutInterner<'a>,
     start: *const u8,
     start_offset: usize,
     number_of_lookups: usize,


### PR DESCRIPTION
These patches wrap the layout interners in their own trait `LayoutInterner` that we'll use for the purpose of keeping certain layouts as constant-interned values, like `VOID` and `UNIT` are currently constant-valued.

This is another step in a massive one-shot patch I'll need to land next to support interning the rest of layouts. It'll also make it easier for us to support things like `stack_size` and `alignment_bytes` dispatched on the interner, rather than a layout itself