### PR TITLE
Reduce layout intern allocations

### DIFF
--- a/crates/compiler/alias_analysis/src/lib.rs
+++ b/crates/compiler/alias_analysis/src/lib.rs
@@ -895,7 +895,7 @@ fn call_spec<'a>(
                         &WhenRecursive::Unreachable,
                     )?;
 
-                    let return_layout = interner.insert(return_layout);
+                    let return_layout = interner.insert(*return_layout);
 
                     let state_layout = Layout::Builtin(Builtin::List(return_layout));
                     let state_type = layout_spec(
@@ -928,7 +928,7 @@ fn call_spec<'a>(
                         with_new_heap_cell(builder, block, bag)
                     };
 
-                    let arg0_layout = interner.insert(&argument_layouts[0]);
+                    let arg0_layout = interner.insert(argument_layouts[0]);
 
                     let state_layout = Layout::Builtin(Builtin::List(arg0_layout));
                     let state_type = layout_spec(
@@ -969,7 +969,7 @@ fn call_spec<'a>(
                         &WhenRecursive::Unreachable,
                     )?;
 
-                    let return_layout = interner.insert(return_layout);
+                    let return_layout = interner.insert(*return_layout);
 
                     let state_layout = Layout::Builtin(Builtin::List(return_layout));
                     let state_type = layout_spec(
@@ -1016,7 +1016,7 @@ fn call_spec<'a>(
                         &WhenRecursive::Unreachable,
                     )?;
 
-                    let return_layout = interner.insert(return_layout);
+                    let return_layout = interner.insert(*return_layout);
 
                     let state_layout = Layout::Builtin(Builtin::List(return_layout));
                     let state_type = layout_spec(
@@ -1069,7 +1069,7 @@ fn call_spec<'a>(
                         &WhenRecursive::Unreachable,
                     )?;
 
-                    let return_layout = interner.insert(return_layout);
+                    let return_layout = interner.insert(*return_layout);
 
                     let state_layout = Layout::Builtin(Builtin::List(return_layout));
                     let state_type = layout_spec(
@@ -1246,7 +1246,7 @@ fn lowlevel_spec<'a>(
                         env,
                         builder,
                         interner,
-                        element_layout,
+                        &element_layout,
                         &WhenRecursive::Unreachable,
                     )?;
                     new_list(builder, block, type_id)
@@ -1585,7 +1585,7 @@ fn expr_spec<'a>(
                     env,
                     builder,
                     interner,
-                    element_layout,
+                    &element_layout,
                     &WhenRecursive::Unreachable,
                 )?;
                 new_list(builder, block, type_id)
@@ -1731,7 +1731,7 @@ fn layout_spec_help<'a>(
         Boxed(inner_layout) => {
             let inner_layout = interner.get(*inner_layout);
             let inner_type =
-                layout_spec_help(env, builder, interner, inner_layout, when_recursive)?;
+                layout_spec_help(env, builder, interner, &inner_layout, when_recursive)?;
             let cell_type = builder.add_heap_cell_type();
 
             builder.add_tuple_type(&[cell_type, inner_type])
@@ -1772,7 +1772,7 @@ fn builtin_spec<'a>(
         List(element_layout) => {
             let element_layout = interner.get(*element_layout);
             let element_type =
-                layout_spec_help(env, builder, interner, element_layout, when_recursive)?;
+                layout_spec_help(env, builder, interner, &element_layout, when_recursive)?;
 
             let cell = builder.add_heap_cell_type();
             let bag = builder.add_bag_type(element_type)?;

--- a/crates/compiler/gen_llvm/src/llvm/build_list.rs
+++ b/crates/compiler/gen_llvm/src/llvm/build_list.rs
@@ -118,8 +118,8 @@ pub(crate) fn list_with_capacity<'a, 'ctx, 'env>(
         &[],
         &[
             capacity.into(),
-            env.alignment_intvalue(layout_interner, element_layout),
-            layout_width(env, layout_interner, element_layout),
+            env.alignment_intvalue(layout_interner, &element_layout),
+            layout_width(env, layout_interner, &element_layout),
         ],
         BitcodeReturns::List,
         bitcode::LIST_WITH_CAPACITY,
@@ -137,7 +137,7 @@ pub(crate) fn list_get_unsafe<'a, 'ctx, 'env>(
     let builder = env.builder;
 
     let element_layout = layout_interner.get(element_layout);
-    let elem_type = basic_type_from_layout(env, layout_interner, element_layout);
+    let elem_type = basic_type_from_layout(env, layout_interner, &element_layout);
     let ptr_type = elem_type.ptr_type(AddressSpace::Generic);
     // Load the pointer to the array data
     let array_data_ptr = load_list_ptr(builder, wrapper_struct, ptr_type);
@@ -156,12 +156,12 @@ pub(crate) fn list_get_unsafe<'a, 'ctx, 'env>(
     let result = load_roc_value(
         env,
         layout_interner,
-        *element_layout,
+        element_layout,
         elem_ptr,
         "list_get_load_element",
     );
 
-    increment_refcount_layout(env, layout_interner, layout_ids, 1, result, element_layout);
+    increment_refcount_layout(env, layout_interner, layout_ids, 1, result, &element_layout);
 
     result
 }
@@ -180,9 +180,9 @@ pub(crate) fn list_reserve<'a, 'ctx, 'env>(
         env,
         list.into_struct_value(),
         &[
-            env.alignment_intvalue(layout_interner, element_layout),
+            env.alignment_intvalue(layout_interner, &element_layout),
             spare,
-            layout_width(env, layout_interner, element_layout),
+            layout_width(env, layout_interner, &element_layout),
             pass_update_mode(env, update_mode),
         ],
         bitcode::LIST_RESERVE,
@@ -243,8 +243,8 @@ pub(crate) fn list_swap<'a, 'ctx, 'env>(
         env,
         original_wrapper,
         &[
-            env.alignment_intvalue(layout_interner, element_layout),
-            layout_width(env, layout_interner, element_layout),
+            env.alignment_intvalue(layout_interner, &element_layout),
+            layout_width(env, layout_interner, &element_layout),
             index_1.into(),
             index_2.into(),
             pass_update_mode(env, update_mode),
@@ -264,13 +264,13 @@ pub(crate) fn list_sublist<'a, 'ctx, 'env>(
     element_layout: InLayout<'a>,
 ) -> BasicValueEnum<'ctx> {
     let element_layout = layout_interner.get(element_layout);
-    let dec_element_fn = build_dec_wrapper(env, layout_interner, layout_ids, element_layout);
+    let dec_element_fn = build_dec_wrapper(env, layout_interner, layout_ids, &element_layout);
     call_list_bitcode_fn_1(
         env,
         original_wrapper,
         &[
-            env.alignment_intvalue(layout_interner, element_layout),
-            layout_width(env, layout_interner, element_layout),
+            env.alignment_intvalue(layout_interner, &element_layout),
+            layout_width(env, layout_interner, &element_layout),
             start.into(),
             len.into(),
             dec_element_fn.as_global_value().as_pointer_value().into(),
@@ -289,13 +289,13 @@ pub(crate) fn list_drop_at<'a, 'ctx, 'env>(
     element_layout: InLayout<'a>,
 ) -> BasicValueEnum<'ctx> {
     let element_layout = layout_interner.get(element_layout);
-    let dec_element_fn = build_dec_wrapper(env, layout_interner, layout_ids, element_layout);
+    let dec_element_fn = build_dec_wrapper(env, layout_interner, layout_ids, &element_layout);
     call_list_bitcode_fn_1(
         env,
         original_wrapper,
         &[
-            env.alignment_intvalue(layout_interner, element_layout),
-            layout_width(env, layout_interner, element_layout),
+            env.alignment_intvalue(layout_interner, &element_layout),
+            layout_width(env, layout_interner, &element_layout),
             count.into(),
             dec_element_fn.as_global_value().as_pointer_value().into(),
         ],
@@ -624,8 +624,8 @@ pub(crate) fn list_concat<'a, 'ctx, 'env>(
         env,
         &[list1.into_struct_value(), list2.into_struct_value()],
         &[
-            env.alignment_intvalue(layout_interner, element_layout),
-            layout_width(env, layout_interner, element_layout),
+            env.alignment_intvalue(layout_interner, &element_layout),
+            layout_width(env, layout_interner, &element_layout),
         ],
         BitcodeReturns::List,
         bitcode::LIST_CONCAT,

--- a/crates/compiler/gen_llvm/src/llvm/compare.rs
+++ b/crates/compiler/gen_llvm/src/llvm/compare.rs
@@ -435,7 +435,7 @@ fn build_list_eq<'a, 'ctx, 'env>(
 
     let symbol = Symbol::LIST_EQ;
     let element_layout = layout_interner.get(element_layout);
-    let element_layout = when_recursive.unwrap_recursive_pointer(*element_layout);
+    let element_layout = when_recursive.unwrap_recursive_pointer(element_layout);
     let fn_name = layout_ids
         .get(symbol, &element_layout)
         .to_symbol_string(symbol, &env.interns);
@@ -1458,8 +1458,8 @@ fn build_box_eq_help<'a, 'ctx, 'env>(
 
     let inner_layout = layout_interner.get(inner_layout);
 
-    let value1 = load_roc_value(env, layout_interner, *inner_layout, box1, "load_box1");
-    let value2 = load_roc_value(env, layout_interner, *inner_layout, box2, "load_box2");
+    let value1 = load_roc_value(env, layout_interner, inner_layout, box1, "load_box1");
+    let value2 = load_roc_value(env, layout_interner, inner_layout, box2, "load_box2");
 
     let is_equal = build_eq(
         env,
@@ -1467,8 +1467,8 @@ fn build_box_eq_help<'a, 'ctx, 'env>(
         layout_ids,
         value1,
         value2,
-        inner_layout,
-        inner_layout,
+        &inner_layout,
+        &inner_layout,
         when_recursive,
     );
 

--- a/crates/compiler/gen_llvm/src/llvm/convert.rs
+++ b/crates/compiler/gen_llvm/src/llvm/convert.rs
@@ -45,7 +45,7 @@ pub fn basic_type_from_layout<'a, 'ctx, 'env>(
         ),
         Boxed(inner_layout) => {
             let inner_layout = layout_interner.get(*inner_layout);
-            let inner_type = basic_type_from_layout(env, layout_interner, inner_layout);
+            let inner_type = basic_type_from_layout(env, layout_interner, &inner_layout);
 
             inner_type.ptr_type(AddressSpace::Generic).into()
         }

--- a/crates/compiler/gen_llvm/src/llvm/expect.rs
+++ b/crates/compiler/gen_llvm/src/llvm/expect.rs
@@ -353,7 +353,7 @@ fn build_clone<'a, 'ctx, 'env>(
 
             let source = value.into_pointer_value();
             let inner_layout = layout_interner.get(inner_layout);
-            let value = load_roc_value(env, layout_interner, *inner_layout, source, "inner");
+            let value = load_roc_value(env, layout_interner, inner_layout, source, "inner");
 
             let inner_width = env.ptr_int().const_int(
                 inner_layout.stack_size(layout_interner, env.target_info) as u64,
@@ -376,7 +376,7 @@ fn build_clone<'a, 'ctx, 'env>(
                 ptr,
                 cursors,
                 value,
-                *inner_layout,
+                inner_layout,
                 when_recursive,
             )
         }
@@ -1063,7 +1063,7 @@ fn build_clone_builtin<'a, 'ctx, 'env>(
                 // We cloned the elements into the extra_offset address.
                 let elements_start_offset = cursors.extra_offset;
 
-                let element_type = basic_type_from_layout(env, layout_interner, elem);
+                let element_type = basic_type_from_layout(env, layout_interner, &elem);
                 let elements = bd.build_pointer_cast(
                     elements,
                     element_type.ptr_type(AddressSpace::Generic),
@@ -1107,7 +1107,7 @@ fn build_clone_builtin<'a, 'ctx, 'env>(
                         ptr,
                         cursors,
                         element,
-                        *elem,
+                        elem,
                         when_recursive,
                     );
 
@@ -1124,7 +1124,7 @@ fn build_clone_builtin<'a, 'ctx, 'env>(
                     env,
                     layout_interner,
                     parent,
-                    *elem,
+                    elem,
                     elements,
                     len,
                     "index",

--- a/crates/compiler/gen_llvm/src/llvm/lowlevel.rs
+++ b/crates/compiler/gen_llvm/src/llvm/lowlevel.rs
@@ -2333,7 +2333,7 @@ pub(crate) fn run_higher_order_low_level<'a, 'ctx, 'env>(
                     let element_layout = layout_interner.get(*element_layout);
                     let result_layout = layout_interner.get(*result_layout);
 
-                    let argument_layouts = &[*element_layout];
+                    let argument_layouts = &[element_layout];
 
                     let roc_function_call = roc_function_call(
                         env,
@@ -2344,7 +2344,7 @@ pub(crate) fn run_higher_order_low_level<'a, 'ctx, 'env>(
                         closure_layout,
                         function_owns_closure_data,
                         argument_layouts,
-                        *result_layout,
+                        result_layout,
                     );
 
                     list_map(
@@ -2352,8 +2352,8 @@ pub(crate) fn run_higher_order_low_level<'a, 'ctx, 'env>(
                         layout_interner,
                         roc_function_call,
                         list,
-                        element_layout,
-                        result_layout,
+                        &element_layout,
+                        &result_layout,
                     )
                 }
                 _ => unreachable!("invalid list layout"),
@@ -2375,7 +2375,7 @@ pub(crate) fn run_higher_order_low_level<'a, 'ctx, 'env>(
                     let element2_layout = layout_interner.get(*element2_layout);
                     let result_layout = layout_interner.get(*result_layout);
 
-                    let argument_layouts = &[*element1_layout, *element2_layout];
+                    let argument_layouts = &[element1_layout, element2_layout];
 
                     let roc_function_call = roc_function_call(
                         env,
@@ -2386,7 +2386,7 @@ pub(crate) fn run_higher_order_low_level<'a, 'ctx, 'env>(
                         closure_layout,
                         function_owns_closure_data,
                         argument_layouts,
-                        *result_layout,
+                        result_layout,
                     );
 
                     list_map2(
@@ -2396,9 +2396,9 @@ pub(crate) fn run_higher_order_low_level<'a, 'ctx, 'env>(
                         roc_function_call,
                         list1,
                         list2,
-                        element1_layout,
-                        element2_layout,
-                        result_layout,
+                        &element1_layout,
+                        &element2_layout,
+                        &result_layout,
                     )
                 }
                 _ => unreachable!("invalid list layout"),
@@ -2423,7 +2423,7 @@ pub(crate) fn run_higher_order_low_level<'a, 'ctx, 'env>(
                     let element3_layout = layout_interner.get(*element3_layout);
                     let result_layout = layout_interner.get(*result_layout);
 
-                    let argument_layouts = &[*element1_layout, *element2_layout, *element3_layout];
+                    let argument_layouts = &[element1_layout, element2_layout, element3_layout];
 
                     let roc_function_call = roc_function_call(
                         env,
@@ -2434,7 +2434,7 @@ pub(crate) fn run_higher_order_low_level<'a, 'ctx, 'env>(
                         closure_layout,
                         function_owns_closure_data,
                         argument_layouts,
-                        *result_layout,
+                        result_layout,
                     );
 
                     list_map3(
@@ -2445,10 +2445,10 @@ pub(crate) fn run_higher_order_low_level<'a, 'ctx, 'env>(
                         list1,
                         list2,
                         list3,
-                        element1_layout,
-                        element2_layout,
-                        element3_layout,
-                        result_layout,
+                        &element1_layout,
+                        &element2_layout,
+                        &element3_layout,
+                        &result_layout,
                     )
                 }
                 _ => unreachable!("invalid list layout"),
@@ -2483,10 +2483,10 @@ pub(crate) fn run_higher_order_low_level<'a, 'ctx, 'env>(
                     let result_layout = layout_interner.get(*result_layout);
 
                     let argument_layouts = &[
-                        *element1_layout,
-                        *element2_layout,
-                        *element3_layout,
-                        *element4_layout,
+                        element1_layout,
+                        element2_layout,
+                        element3_layout,
+                        element4_layout,
                     ];
 
                     let roc_function_call = roc_function_call(
@@ -2498,7 +2498,7 @@ pub(crate) fn run_higher_order_low_level<'a, 'ctx, 'env>(
                         closure_layout,
                         function_owns_closure_data,
                         argument_layouts,
-                        *result_layout,
+                        result_layout,
                     );
 
                     list_map4(
@@ -2510,11 +2510,11 @@ pub(crate) fn run_higher_order_low_level<'a, 'ctx, 'env>(
                         list2,
                         list3,
                         list4,
-                        element1_layout,
-                        element2_layout,
-                        element3_layout,
-                        element4_layout,
-                        result_layout,
+                        &element1_layout,
+                        &element2_layout,
+                        &element3_layout,
+                        &element4_layout,
+                        &result_layout,
                     )
                 }
                 _ => unreachable!("invalid list layout"),
@@ -2532,14 +2532,14 @@ pub(crate) fn run_higher_order_low_level<'a, 'ctx, 'env>(
 
                     let element_layout = layout_interner.get(*element_layout);
 
-                    let argument_layouts = &[*element_layout, *element_layout];
+                    let argument_layouts = &[element_layout, element_layout];
 
                     let compare_wrapper = build_compare_wrapper(
                         env,
                         layout_interner,
                         function,
                         closure_layout,
-                        element_layout,
+                        &element_layout,
                     )
                     .as_global_value()
                     .as_pointer_value();
@@ -2562,7 +2562,7 @@ pub(crate) fn run_higher_order_low_level<'a, 'ctx, 'env>(
                         roc_function_call,
                         compare_wrapper,
                         list,
-                        element_layout,
+                        &element_layout,
                     )
                 }
                 _ => unreachable!("invalid list layout"),

--- a/crates/compiler/gen_llvm/src/llvm/refcounting.rs
+++ b/crates/compiler/gen_llvm/src/llvm/refcounting.rs
@@ -682,8 +682,8 @@ fn modify_refcount_list<'a, 'ctx, 'env>(
     let di_location = env.builder.get_current_debug_location().unwrap();
 
     let element_layout = layout_interner.get(element_layout);
-    let element_layout = when_recursive.unwrap_recursive_pointer(*element_layout);
-    let element_layout = layout_interner.insert(env.arena.alloc(element_layout));
+    let element_layout = when_recursive.unwrap_recursive_pointer(element_layout);
+    let element_layout = layout_interner.insert(element_layout);
     let list_layout = &Layout::Builtin(Builtin::List(element_layout));
     let (_, fn_name) = function_name_from_mode(
         layout_ids,
@@ -777,7 +777,7 @@ fn modify_refcount_list_help<'a, 'ctx, 'env>(
 
     let element_layout = layout_interner.get(element_layout);
     if element_layout.contains_refcounted(layout_interner) {
-        let ptr_type = basic_type_from_layout(env, layout_interner, element_layout)
+        let ptr_type = basic_type_from_layout(env, layout_interner, &element_layout)
             .ptr_type(AddressSpace::Generic);
 
         let (len, ptr) = load_list(env.builder, original_wrapper, ptr_type);
@@ -790,7 +790,7 @@ fn modify_refcount_list_help<'a, 'ctx, 'env>(
                 mode.to_call_mode(fn_val),
                 when_recursive,
                 element,
-                element_layout,
+                &element_layout,
             );
         };
 
@@ -798,7 +798,7 @@ fn modify_refcount_list_help<'a, 'ctx, 'env>(
             env,
             layout_interner,
             parent,
-            *element_layout,
+            element_layout,
             ptr,
             len,
             "modify_rc_index",

--- a/crates/compiler/gen_wasm/src/backend.rs
+++ b/crates/compiler/gen_wasm/src/backend.rs
@@ -506,7 +506,7 @@ impl<'a, 'r> WasmBackend<'a, 'r> {
         let heap_return_ptr_id = LocalId(wrapper_arg_layouts.len() as u32 - 1);
         let inner_ret_layout = match wrapper_arg_layouts.last() {
             Some(Layout::Boxed(inner)) => {
-                WasmLayout::new(self.layout_interner, self.layout_interner.get(*inner))
+                WasmLayout::new(self.layout_interner, &self.layout_interner.get(*inner))
             }
             x => internal_error!("Higher-order wrapper: invalid return layout {:?}", x),
         };
@@ -548,7 +548,7 @@ impl<'a, 'r> WasmBackend<'a, 'r> {
             // Load the argument pointer. If it's a primitive value, dereference it too.
             n_inner_wasm_args += 1;
             self.code_builder.get_local(LocalId(i as u32));
-            self.dereference_boxed_value(inner_layout);
+            self.dereference_boxed_value(&inner_layout);
         }
 
         // If the inner function has closure data, it's the last arg of the inner fn
@@ -638,9 +638,9 @@ impl<'a, 'r> WasmBackend<'a, 'r> {
             x => internal_error!("Expected a Boxed layout, got {:?}", x),
         };
         self.code_builder.get_local(LocalId(1));
-        self.dereference_boxed_value(inner_layout);
+        self.dereference_boxed_value(&inner_layout);
         self.code_builder.get_local(LocalId(2));
-        self.dereference_boxed_value(inner_layout);
+        self.dereference_boxed_value(&inner_layout);
 
         // Call the wrapped inner function
         let inner_wasm_fn_index = self.fn_index_offset + inner_lookup_idx as u32;

--- a/crates/compiler/mono/src/code_gen_help/equality.rs
+++ b/crates/compiler/mono/src/code_gen_help/equality.rs
@@ -592,7 +592,7 @@ fn eq_boxed<'a>(
             ident_ids,
             ctx,
             layout_interner,
-            *inner_layout,
+            inner_layout,
             root.arena.alloc([a, b]),
         )
         .unwrap();
@@ -600,13 +600,13 @@ fn eq_boxed<'a>(
     Stmt::Let(
         a,
         a_expr,
-        *inner_layout,
+        inner_layout,
         root.arena.alloc(
             //
             Stmt::Let(
                 b,
                 b_expr,
-                *inner_layout,
+                inner_layout,
                 root.arena.alloc(
                     //
                     Stmt::Let(
@@ -641,7 +641,7 @@ fn eq_list<'a>(
     let elem_layout = layout_interner.get(elem_layout);
 
     // A "Box" layout (heap pointer to a single list element)
-    let box_union_layout = UnionLayout::NonNullableUnwrapped(root.arena.alloc([*elem_layout]));
+    let box_union_layout = UnionLayout::NonNullableUnwrapped(root.arena.alloc([elem_layout]));
     let box_layout = Layout::Union(box_union_layout);
 
     // Compare lengths
@@ -754,14 +754,14 @@ fn eq_list<'a>(
         tag_id: 0,
         index: 0,
     };
-    let elem1_stmt = |next| Stmt::Let(elem1, elem1_expr, *elem_layout, next);
-    let elem2_stmt = |next| Stmt::Let(elem2, elem2_expr, *elem_layout, next);
+    let elem1_stmt = |next| Stmt::Let(elem1, elem1_expr, elem_layout, next);
+    let elem2_stmt = |next| Stmt::Let(elem2, elem2_expr, elem_layout, next);
 
     // Compare the two current elements
     let eq_elems = root.create_symbol(ident_ids, "eq_elems");
     let eq_elems_args = root.arena.alloc([elem1, elem2]);
     let eq_elems_expr = root
-        .call_specialized_op(ident_ids, ctx, layout_interner, *elem_layout, eq_elems_args)
+        .call_specialized_op(ident_ids, ctx, layout_interner, elem_layout, eq_elems_args)
         .unwrap();
 
     let eq_elems_stmt = |next| Stmt::Let(eq_elems, eq_elems_expr, LAYOUT_BOOL, next);

--- a/crates/compiler/mono/src/code_gen_help/mod.rs
+++ b/crates/compiler/mono/src/code_gen_help/mod.rs
@@ -446,8 +446,8 @@ impl<'a> CodeGenHelp<'a> {
     ) -> Layout<'a> {
         match layout {
             Layout::Builtin(Builtin::List(v)) => {
-                let v = self.replace_rec_ptr(ctx, layout_interner, *layout_interner.get(v));
-                let v = layout_interner.insert(self.arena.alloc(v));
+                let v = self.replace_rec_ptr(ctx, layout_interner, layout_interner.get(v));
+                let v = layout_interner.insert(v);
                 Layout::Builtin(Builtin::List(v))
             }
 
@@ -487,9 +487,7 @@ impl<'a> CodeGenHelp<'a> {
 
             Layout::Boxed(inner) => {
                 let inner = layout_interner.get(inner);
-                let inner = self
-                    .arena
-                    .alloc(self.replace_rec_ptr(ctx, layout_interner, *inner));
+                let inner = self.replace_rec_ptr(ctx, layout_interner, inner);
                 let inner = layout_interner.insert(inner);
                 Layout::Boxed(inner)
             }

--- a/crates/compiler/mono/src/code_gen_help/refcount.rs
+++ b/crates/compiler/mono/src/code_gen_help/refcount.rs
@@ -187,7 +187,7 @@ pub fn refcount_generic<'a>(
                 ctx,
                 layout_interner,
                 &layout,
-                inner_layout,
+                &inner_layout,
                 structure,
             )
         }
@@ -429,7 +429,7 @@ where
     match layout {
         Layout::Builtin(Builtin::List(elem_layout)) => {
             let elem_layout = interner.get(*elem_layout);
-            is_rc_implemented_yet(interner, elem_layout)
+            is_rc_implemented_yet(interner, &elem_layout)
         }
         Layout::Builtin(_) => true,
         Layout::Struct { field_layouts, .. } => field_layouts
@@ -775,7 +775,7 @@ fn refcount_list<'a>(
     let elem_layout = layout_interner.get(elem_layout);
 
     // A "Box" layout (heap pointer to a single list element)
-    let box_union_layout = UnionLayout::NonNullableUnwrapped(arena.alloc([*elem_layout]));
+    let box_union_layout = UnionLayout::NonNullableUnwrapped(arena.alloc([elem_layout]));
     let box_layout = Layout::Union(box_union_layout);
 
     //
@@ -843,7 +843,7 @@ fn refcount_list<'a>(
             ident_ids,
             ctx,
             layout_interner,
-            elem_layout,
+            &elem_layout,
             LAYOUT_UNIT,
             box_union_layout,
             len,
@@ -1684,8 +1684,8 @@ fn refcount_boxed<'a>(
     ident_ids: &mut IdentIds,
     ctx: &mut Context<'a>,
     layout_interner: &mut STLayoutInterner<'a>,
-    layout: &Layout,
-    inner_layout: &'a Layout,
+    layout: &Layout<'a>,
+    inner_layout: &Layout<'a>,
     outer: Symbol,
 ) -> Stmt<'a> {
     let arena = root.arena;

--- a/crates/compiler/mono/src/debug/checker.rs
+++ b/crates/compiler/mono/src/debug/checker.rs
@@ -703,6 +703,7 @@ fn resolve_recursive_layout<'a>(
         Layout::LambdaSet(LambdaSet {
             set,
             representation,
+            full_layout,
         }) => {
             let set = set.iter().map(|(symbol, captures)| {
                 let captures = captures.iter().map(|lay_in| {
@@ -714,8 +715,9 @@ fn resolve_recursive_layout<'a>(
             });
             let set = arena.alloc_slice_fill_iter(set);
             Layout::LambdaSet(LambdaSet {
-                set,
+                set: arena.alloc(&*set),
                 representation,
+                full_layout,
             })
         }
     }

--- a/crates/compiler/mono/src/decision_tree.rs
+++ b/crates/compiler/mono/src/decision_tree.rs
@@ -1448,9 +1448,9 @@ fn path_to_expr_help<'a>(
 
                         let elem_layout = layout_interner.get(elem_layout);
 
-                        stores.push((load_sym, *elem_layout, load_expr));
+                        stores.push((load_sym, elem_layout, load_expr));
 
-                        layout = *elem_layout;
+                        layout = elem_layout;
                         symbol = load_sym;
                     }
                     _ => internal_error!("not a list"),

--- a/crates/compiler/mono/src/ir.rs
+++ b/crates/compiler/mono/src/ir.rs
@@ -3592,7 +3592,7 @@ fn specialize_proc_help<'a>(
                             let ordered_field_layouts = Vec::from_iter_in(
                                 combined
                                     .iter()
-                                    .map(|(_, layout)| *layout_cache.get_in(**layout)),
+                                    .map(|(_, layout)| layout_cache.get_in(**layout)),
                                 env.arena,
                             );
                             let ordered_field_layouts = ordered_field_layouts.into_bump_slice();
@@ -3618,7 +3618,7 @@ fn specialize_proc_help<'a>(
                                 specialized_body = Stmt::Let(
                                     symbol,
                                     expr,
-                                    *layout_cache.get_in(**layout),
+                                    layout_cache.get_in(**layout),
                                     env.arena.alloc(specialized_body),
                                 );
                             }
@@ -4634,7 +4634,7 @@ pub fn with_hole<'a>(
                 Ok(elem_layout) => {
                     let expr = Expr::EmptyArray;
                     // TODO don't alloc once elem_layout is interned
-                    let elem_layout = layout_cache.put_in(env.arena.alloc(elem_layout));
+                    let elem_layout = layout_cache.put_in(elem_layout);
                     Stmt::Let(
                         assigned,
                         expr,
@@ -4645,7 +4645,7 @@ pub fn with_hole<'a>(
                 Err(LayoutProblem::UnresolvedTypeVar(_)) => {
                     let expr = Expr::EmptyArray;
                     // TODO don't alloc once elem_layout is interned
-                    let elem_layout = layout_cache.put_in(env.arena.alloc(Layout::VOID));
+                    let elem_layout = layout_cache.put_in(Layout::VOID);
                     Stmt::Let(
                         assigned,
                         expr,
@@ -4694,7 +4694,7 @@ pub fn with_hole<'a>(
                 elems: elements.into_bump_slice(),
             };
 
-            let elem_layout = layout_cache.put_in(env.arena.alloc(elem_layout));
+            let elem_layout = layout_cache.put_in(elem_layout);
 
             let stmt = Stmt::Let(
                 assigned,
@@ -5791,7 +5791,7 @@ where
             let symbols =
                 Vec::from_iter_in(combined.iter().map(|(a, _)| *a), env.arena).into_bump_slice();
             let field_layouts = Vec::from_iter_in(
-                combined.iter().map(|(_, b)| *layout_cache.get_in(**b)),
+                combined.iter().map(|(_, b)| layout_cache.get_in(**b)),
                 env.arena,
             )
             .into_bump_slice();

--- a/crates/glue/src/types.rs
+++ b/crates/glue/src/types.rs
@@ -1098,7 +1098,7 @@ fn add_builtin_type<'a>(
             debug_assert_eq!(args.len(), 1);
 
             let elem_layout = env.layout_cache.get_in(elem_layout);
-            let elem_id = add_type_help(env, *elem_layout, args[0], opt_name, types);
+            let elem_id = add_type_help(env, elem_layout, args[0], opt_name, types);
             let list_id = types.add_anonymous(
                 &env.layout_cache.interner,
                 RocType::RocList(elem_id),
@@ -1114,7 +1114,7 @@ fn add_builtin_type<'a>(
             Alias(Symbol::DICT_DICT, _alias_variables, alias_var, AliasKind::Opaque),
         ) => {
             match (
-                *env.layout_cache.get_in(elem_layout),
+                env.layout_cache.get_in(elem_layout),
                 env.subs.get_content_without_compacting(*alias_var),
             ) {
                 (
@@ -1458,7 +1458,7 @@ fn add_tag_union<'a>(
         Layout::Boxed(elem_layout) => {
             let elem_layout = env.layout_cache.get_in(elem_layout);
             let (tag_name, payload_fields) =
-                single_tag_payload_fields(union_tags, subs, &[*elem_layout], env, types);
+                single_tag_payload_fields(union_tags, subs, &[elem_layout], env, types);
 
             RocTagUnion::SingleTagStruct {
                 name: name.clone(),

--- a/crates/repl_eval/src/eval.rs
+++ b/crates/repl_eval/src/eval.rs
@@ -859,7 +859,7 @@ fn addr_to_ast<'a, M: ReplAppMemory>(
                 env,
                 mem,
                 addr_of_inner,
-                inner_layout,
+                &inner_layout,
                 WhenRecursive::Unreachable,
                 inner_var,
             );
@@ -911,7 +911,7 @@ fn list_to_ast<'a, M: ReplAppMemory>(
 
     let arena = env.arena;
     let mut output = Vec::with_capacity_in(len, arena);
-    let elem_layout = *env.layout_cache.get_in(elem_layout);
+    let elem_layout = env.layout_cache.get_in(elem_layout);
     let elem_size = elem_layout.stack_size(&env.layout_cache.interner, env.target_info) as usize;
 
     for index in 0..len {


### PR DESCRIPTION
- [Do not require allocating Layouts in arena before interning](https://github.com/roc-lang/roc/commit/14a98f024c213fe93affcb18020e9837322f7192)
- [Store interned wrapped layout of lambda set on LambdaSet struct](https://github.com/roc-lang/roc/commit/8f669ebe5b008bb5d550b2b9fad794b4faf1918b)
  The `LambdaSet` struct is frequently used independently to examine how a
  lambda set should be packed or unpacked. However, it is also often
  converted into a full layout via `Layout::LambdaSet(LambdaSet)` to be a
  part of function arguments, for example.
  
  In preparing to intern all layouts, we need a way to cheaply go from a
  `lambda_set` to an interned `Layout::LambdaSet(lambda_set)`, since this
  is a very common operation. The proposed solution is to keep the wrapped
  layout cached on `LambdaSet` itself, which this PR does.
  
  The tricky bit of inserting a lambda set is we need to fill in the
  interned `full_layout` only after the lambda set is inserted,
  but we don't want to allocate a new interned slot if the same lambda set
  layout has already been inserted with a different `full_layout` slot.
  
  For example, if we insert `LambdaSet { set : [A] }` twice in two
  different threads, we want the `full_layout` they map to to be the same.
  So we nede to check if an interned representation with a full_layout
  exists, before we allocate a new full_layout and insert a fresh lambda
  set.
  
  So,
    - check if the "normalized" lambda set (with a void full_layout slot) maps to an
      inserted lambda set in
      - in a thread-local cache, or globally
    - if so, use that one immediately
    - otherwise, allocate a new (global) slot, intern the lambda set, and then fill the slot in
      - save the interned layout and lambda set mapping thread-locally

  @folkertdev I would appreciate if you could take a look at this commit especially. We will need to do something similar in order to support recursive pointers pointing back to their parent layout.