### PR TITLE
Example parser for HTTP messages

### DIFF
--- a/crates/cli/tests/cli_run.rs
+++ b/crates/cli/tests/cli_run.rs
@@ -331,6 +331,13 @@ mod cli_run {
         }
     }
 
+    // when you want to run `roc test` to execute `expect`s, perhaps on a library rather than an application.
+    fn test_roc_expect(dir_name: &str, roc_filename: &str) {
+        let path = file_path_from_root(dir_name, roc_filename);
+        let out = run_roc(&[CMD_TEST, path.to_str().unwrap()], &[], &[]);
+        assert!(out.status.success());
+    }
+
     // when you don't need args, stdin or extra_env
     fn test_roc_app_slim(
         dir_name: &str,
@@ -859,6 +866,12 @@ mod cli_run {
             "Parse success!\n",
             UseValgrind::No,
         )
+    }
+
+    #[test]
+    #[cfg_attr(windows, ignore)]
+    fn parse_http() {
+        test_roc_expect("examples/parser/Parser", "Http.roc")
     }
 
     // TODO not sure if this cfg should still be here: #[cfg(not(debug_assertions))]

--- a/examples/parser/Parser/Core.roc
+++ b/examples/parser/Parser/Core.roc
@@ -8,6 +8,7 @@ interface Parser.Core
         const,
         alt,
         apply,
+        skip,
         oneOf,
         map,
         map2,
@@ -141,6 +142,24 @@ apply = \funParser, valParser ->
             { val: funVal val, input: rest2 }
 
     buildPrimitiveParser combined
+
+## Skip over a parsed item as part of a pipeline
+##
+## This is useful if you are using a pipeline of parsers with `apply` but
+## some parsed items are not part of the final result
+##
+## >>> const (\x -> \y -> \z -> Triple x y z)
+## >>> |> apply Parser.Str.nat
+## >>> |> skip (codeunit ',')
+## >>> |> apply Parser.Str.nat
+## >>> |> skip (codeunit ',')
+## >>> |> apply Parser.Str.nat
+##
+skip : Parser input kept, Parser input skipped -> Parser input kept
+skip = \kept, skipped ->
+    const (\k -> \_ -> k)
+    |> apply kept
+    |> apply skipped
 
 # Internal utility function. Not exposed to users, since usage is discouraged!
 #

--- a/examples/parser/Parser/Http.roc
+++ b/examples/parser/Parser/Http.roc
@@ -24,12 +24,6 @@ Method : [Options, Get, Post, Put, Delete, Head, Trace, Connect, Patch]
 
 HttpVersion : Str
 
-RequestStartLine : {
-    method : Method,
-    uri : RequestUri,
-    httpVersion : HttpVersion,
-}
-
 Request : {
     method : Method,
     uri : Str,
@@ -80,36 +74,6 @@ httpVersion =
     |> apply digits
     |> skip (codeunit '.')
     |> apply digits
-
-requestStartLine : Parser RawStr RequestStartLine
-requestStartLine =
-    const (\m -> \u -> \hv -> { method: m, uri: u, httpVersion: hv })
-    |> apply method
-    |> skip sp
-    |> apply requestUri
-    |> skip sp
-    |> apply httpVersion
-    |> skip crlf
-
-expect
-    actual = parseStr requestStartLine "GET / HTTP/1.1\r\n"
-    expected = Ok { method: Get, uri: "/", httpVersion: "1.1" }
-    actual == expected
-
-expect
-    actual = parseStr requestStartLine "GET /things?id=1 HTTP/1.1\r\n"
-    expected = Ok { method: Get, uri: "/things?id=1", httpVersion: "1.1" }
-    actual == expected
-
-expect
-    actual = parseStr requestStartLine "POST /things HTTP/1.1\r\n"
-    expected = Ok { method: Post, uri: "/things", httpVersion: "1.1" }
-    actual == expected
-
-expect
-    actual = parseStr requestStartLine "OPTIONS * HTTP/1.1\r\n"
-    expected = Ok { method: Options, uri: "*", httpVersion: "1.1" }
-    actual == expected
 
 Header : [Header Str Str]
 

--- a/examples/parser/Parser/Http.roc
+++ b/examples/parser/Parser/Http.roc
@@ -1,0 +1,111 @@
+interface Parser.Http
+    exposes [
+        Request,
+        # Response,
+        # parseRequest,
+        # parseResponse,
+    ]
+    imports [
+        Parser.Core.{ Parser, ParseResult, map, apply, const, oneOrMore },
+        Parser.Str.{
+            RawStr,
+            oneOf,
+            string,
+            codeunit,
+            parseStr,
+            codeunitSatisfies,
+            strFromRaw,
+        },
+    ]
+
+# https://www.ietf.org/rfc/rfc2616.txt
+Method : [Options, Get, Post, Put, Delete, Head, Trace, Connect, Patch]
+
+HttpVersion : Str
+
+RequestStartLine : {
+    method : Method,
+    uri : RequestUri,
+    httpVersion : HttpVersion,
+}
+
+Request : {
+    method : Method,
+    uri : Str,
+    httpVersion : HttpVersion,
+    headers : List [Header Str Str],
+    body : List U8,
+}
+
+method : Parser RawStr Method
+method =
+    oneOf [
+        string "OPTIONS" |> map \_ -> Options,
+        string "GET" |> map \_ -> Get,
+        string "POST" |> map \_ -> Post,
+        string "PUT" |> map \_ -> Put,
+        string "DELETE" |> map \_ -> Delete,
+        string "HEAD" |> map \_ -> Head,
+        string "TRACE" |> map \_ -> Trace,
+        string "CONNECT" |> map \_ -> Connect,
+        string "PATCH" |> map \_ -> Patch,
+    ]
+
+expect parseStr method "GET" == Ok Get
+expect parseStr method "DELETE" == Ok Delete
+
+# TODO: do we want more structure in the URI, or is Str actually what programs want anyway?
+# This is not a full URL!
+#        Request-URI    = "*" | absoluteURI | abs_path | authority
+RequestUri : Str
+
+requestUri : Parser RawStr RequestUri
+requestUri =
+    codeunitSatisfies \c -> c != ' '
+    |> oneOrMore
+    |> map strFromRaw
+
+sp = codeunit ' '
+crlf = string "\r\n"
+
+# TODO: The 'digit' and 'digits' from Parser.Str are causing repl.expect to blow up
+digit = codeunitSatisfies \c -> c >= '0' && c <= '9'
+digits = digit |> oneOrMore |> map strFromRaw
+
+httpVersion : Parser RawStr HttpVersion
+httpVersion =
+    const (\_ -> \major -> \dot -> \minor -> "\(major).\(minor)")
+    |> apply (string "HTTP/")
+    |> apply digits
+    |> apply (codeunit '.')
+    |> apply digits
+
+requestStartLine : Parser RawStr RequestStartLine
+requestStartLine =
+    const (\m -> \_ -> \u -> \_ -> \hv -> \_ -> { method: m, uri: u, httpVersion: hv })
+    |> apply method
+    |> apply sp
+    |> apply requestUri
+    |> apply sp
+    |> apply httpVersion
+    |> apply crlf
+
+expect
+    actual = parseStr requestStartLine "GET / HTTP/1.1\r\n"
+    expected = Ok { method: Get, uri: "/", httpVersion: "1.1" }
+    actual == expected
+
+expect
+    actual = parseStr requestStartLine "GET /things?id=1 HTTP/1.1\r\n"
+    expected = Ok { method: Get, uri: "/things?id=1", httpVersion: "1.1" }
+    actual == expected
+
+expect
+    actual = parseStr requestStartLine "POST /things HTTP/1.1\r\n"
+    expected = Ok { method: Post, uri: "/things", httpVersion: "1.1" }
+    actual == expected
+
+expect
+    actual = parseStr requestStartLine "OPTIONS * HTTP/1.1\r\n"
+    expected = Ok { method: Options, uri: "*", httpVersion: "1.1" }
+    actual == expected

--- a/examples/parser/Parser/Http.roc
+++ b/examples/parser/Parser/Http.roc
@@ -6,7 +6,7 @@ interface Parser.Http
         # parseResponse,
     ]
     imports [
-        Parser.Core.{ Parser, ParseResult, map, apply, const, oneOrMore },
+        Parser.Core.{ Parser, ParseResult, map, apply, skip, const, oneOrMore },
         Parser.Str.{
             RawStr,
             oneOf,
@@ -74,21 +74,21 @@ digits = digit |> oneOrMore |> map strFromRaw
 
 httpVersion : Parser RawStr HttpVersion
 httpVersion =
-    const (\_ -> \major -> \dot -> \minor -> "\(major).\(minor)")
-    |> apply (string "HTTP/")
+    const (\major -> \minor -> "\(major).\(minor)")
+    |> skip (string "HTTP/")
     |> apply digits
-    |> apply (codeunit '.')
+    |> skip (codeunit '.')
     |> apply digits
 
 requestStartLine : Parser RawStr RequestStartLine
 requestStartLine =
-    const (\m -> \_ -> \u -> \_ -> \hv -> \_ -> { method: m, uri: u, httpVersion: hv })
+    const (\m -> \u -> \hv -> { method: m, uri: u, httpVersion: hv })
     |> apply method
-    |> apply sp
+    |> skip sp
     |> apply requestUri
-    |> apply sp
+    |> skip sp
     |> apply httpVersion
-    |> apply crlf
+    |> skip crlf
 
 expect
     actual = parseStr requestStartLine "GET / HTTP/1.1\r\n"

--- a/examples/parser/Parser/Http.roc
+++ b/examples/parser/Parser/Http.roc
@@ -6,7 +6,7 @@ interface Parser.Http
         # parseResponse,
     ]
     imports [
-        Parser.Core.{ Parser, ParseResult, map, apply, skip, const, oneOrMore },
+        Parser.Core.{ Parser, ParseResult, map, apply, skip, const, oneOrMore, many },
         Parser.Str.{
             RawStr,
             oneOf,
@@ -15,6 +15,7 @@ interface Parser.Http
             parseStr,
             codeunitSatisfies,
             strFromRaw,
+            anyRawString,
         },
     ]
 
@@ -108,4 +109,102 @@ expect
 expect
     actual = parseStr requestStartLine "OPTIONS * HTTP/1.1\r\n"
     expected = Ok { method: Options, uri: "*", httpVersion: "1.1" }
+    actual == expected
+
+Header : [Header Str Str]
+
+headerKey : Parser RawStr Str
+headerKey =
+    codeunitSatisfies \c -> c != ':'
+    |> oneOrMore
+    |> map strFromRaw
+
+headerValue : Parser RawStr Str
+headerValue =
+    codeunitSatisfies \c -> c != '\r'
+    |> oneOrMore
+    |> map strFromRaw
+
+header : Parser RawStr Header
+header =
+    const (\k -> \v -> Header k v)
+    |> apply headerKey
+    |> skip (string ": ")
+    |> apply headerValue
+    |> skip crlf
+
+expect
+    actual = parseStr header "Accept-Encoding: gzip, deflate\r\n"
+    expected = Ok (Header "Accept-Encoding" "gzip, deflate")
+    actual == expected
+
+request : Parser RawStr Request
+request =
+    const (\m -> \u -> \hv -> \hs -> \b -> { method: m, uri: u, httpVersion: hv, headers: hs, body: b })
+    |> apply method
+    |> skip sp
+    |> apply requestUri
+    |> skip sp
+    |> apply httpVersion
+    |> skip crlf
+    |> apply (many header)
+    |> skip crlf
+    |> apply anyRawString
+
+expect
+    httpText =
+        """
+        GET /things?id=1 HTTP/1.1\r
+        Host: bar.example\r
+        Accept-Encoding: gzip, deflate\r
+        \r
+        Hello, world!
+        """
+
+    actual = parseStr request httpText
+    expected = Ok {
+        method: Get,
+        uri: "/things?id=1",
+        httpVersion: "1.1",
+        headers: [
+            Header "Host" "bar.example",
+            Header "Accept-Encoding" "gzip, deflate",
+        ],
+        body: "Hello, world!" |> Str.toUtf8,
+    }
+
+    actual == expected
+
+expect
+    httpText =
+        """
+        OPTIONS /resources/post-here/ HTTP/1.1\r
+        Host: bar.example\r
+        Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8\r
+        Accept-Language: en-us,en;q=0.5\r
+        Accept-Encoding: gzip,deflate\r
+        Connection: keep-alive\r
+        Origin: https://foo.example\r
+        Access-Control-Request-Method: POST\r
+        Access-Control-Request-Headers: X-PINGOTHER, Content-Type\r
+        \r\n
+        """
+    actual = parseStr request httpText
+    expected = Ok {
+        method: Options,
+        uri: "/resources/post-here/",
+        httpVersion: "1.1",
+        headers: [
+            Header "Host" "bar.example",
+            Header "Accept" "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+            Header "Accept-Language" "en-us,en;q=0.5",
+            Header "Accept-Encoding" "gzip,deflate",
+            Header "Connection" "keep-alive",
+            Header "Origin" "https://foo.example",
+            Header "Access-Control-Request-Method" "POST",
+            Header "Access-Control-Request-Headers" "X-PINGOTHER, Content-Type",
+        ],
+        body: [],
+    }
+
     actual == expected


### PR DESCRIPTION
Another example of parsing in Roc, using a familiar format.
One day this could maybe form the lowest level of a web server framework! 🦄 

The only compiler issues I ran into were to do with `expect` evaluation.
- It tends to crash if the two sides of the `expect` don't match. For example if you compare two lists of different lengths, it often crashes. Often it's out-of-memory panics in bumpalo.
- Other times, when I do `expect actual == expected`, and `actual` is wrong, a corrupted String is printed for `expected`, containing UTF-8 replacement characters.

I couldn't get the `digits` parser to work without crashing, so for now I am leaving all of the numbers as strings. For example, instead of the OK status being `200`, it's `"200"`, for now!
