### PR TITLE
remove mention linux aarch64

### DIFF
--- a/BUILDING_FROM_SOURCE.md
+++ b/BUILDING_FROM_SOURCE.md
@@ -8,7 +8,7 @@ On Macos and Linux, we highly recommend Using [nix](https://nixos.org/download.h
 
 :warning: If you tried to run `cargo` in the repo folder before installing nix, make sure to execute `cargo clean` first. To prevent you from executing `cargo` outside of nix, tools like [direnv](https://github.com/nix-community/nix-direnv) and [lorri](https://github.com/nix-community/lorri) can put you in a nix shell automatically when you `cd` into the directory.
 
-### On Linux x86_64/aarch64 or MacOS aarch64/arm64/x86_64
+### On Linux x86_64 or MacOS aarch64/arm64/x86_64
 
 #### Install
 


### PR DESCRIPTION
linux aarch64 is untested so we should avoid giving the impression that it is supported.