### PR TITLE
skip `str_append_scalar` test on macos x86_64 nightly build

### DIFF
--- a/.github/workflows/nightly_macos_x86_64.yml
+++ b/.github/workflows/nightly_macos_x86_64.yml
@@ -16,7 +16,7 @@ jobs:
         run: ./ci/write_version.sh
           
       - name: execute rust tests
-        run: cargo test --release --locked -- --skip opaque_wrap_function --skip bool_list_literal --skip platform_switching_swift --skip swift_ui
+        run: cargo test --release --locked -- --skip opaque_wrap_function --skip bool_list_literal --skip platform_switching_swift --skip swift_ui --skip str_append_scalar
         # swift tests are skipped because of "Could not find or use auto-linked library 'swiftCompatibilityConcurrency'" on macos-11 x86_64 CI machine
         # this issue may be caused by using older versions of XCode
 


### PR DESCRIPTION
to allow nightlies to build until #4865 is resolved