### PR TITLE
update vscode flake

### DIFF
--- a/devtools/README.md
+++ b/devtools/README.md
@@ -3,23 +3,21 @@
 To make rust-analyzer and other vscode extensions work well you want them using the same rustc, glibc, zig... as specified in the roc nix flake.
 The easiest way to do this is to use another flake for all your dev tools that takes the roc flake as an input.
 
-Use the flake in this folder that uses your editor of choice as a starting template. If your editor is not listed, feel free to make a PR and add your flake.
+The flake in this folder is meant for vscode, feel free to create a PR if you'like to add a flake for a different editor.
 
 Further steps:
 
-1. Copy the flake for your favorite editor to a new folder outside of the roc repo folder.
+1. Copy the flake.nix and flake.lock file to a new folder outside of the roc repo folder.
 1. Run `git init` in the new folder.
-1. Rename the copied flake to `flake.nix`.
 1. Execute `git add flake.nix`, nix will error if you don't do this.
-1. Change `roc.url = "path:/home/anton/gitrepos/roc3/roc";` to the location of the roc folder on your machine.
+1. Change `roc.url = "path:/home/username/gitrepos/roc1/roc";` to the location of the roc folder on your machine.
 1. Follow instructions about vscode extensions [here](#extensions).
 1. add other dev tools you like in the `devInputs` list. You can search for those [here](https://search.nixos.org/packages).
-1. From the roc folder run `nix develop path-to-your-dev-flake-folder`.
-1. Run the `code` command to start vscode.
+1. Run `nix develop`.
+1. `cd` to the folder of the roc repo
+1. Run `code .` to start vscode.
 
 vscode is able to share settings between this nix version and your regular vscode so there is no need to set everything up from scratch.
-
-I recommend creating a git repository to save this custom flake.
 
 If you use lorri or direnv it is possible to load the dev flake instead of the roc flake.
 For lorri:

--- a/devtools/flake.lock
+++ b/devtools/flake.lock
@@ -1,0 +1,150 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "locked": {
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_3": {
+      "locked": {
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_4": {
+      "locked": {
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixgl": {
+      "inputs": {
+        "flake-utils": "flake-utils_3",
+        "nixpkgs": [
+          "roc",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1672992692,
+        "narHash": "sha256-/eLQLSNIa22ARTZbk+x8i0iE8khe1eiHWkuxgTVXZ7g=",
+        "owner": "guibou",
+        "repo": "nixGL",
+        "rev": "643e730efb981ffaf8478f441ec9b9aeea1c89f5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "guibou",
+        "repo": "nixGL",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1673134516,
+        "narHash": "sha256-mAZQKqkNQbBmJnmUU0blOfkKlgMSSVyPHdeWeuKad8U=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "f6f44561884c3470e2b783683d5dbac42dfc833b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "roc": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "nixgl": "nixgl",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      },
+      "locked": {
+        "lastModified": 1673266343,
+        "narHash": "sha256-HQGjNhCte1wgvo5/SUL1OjIpfoUCQ8vC/2k0gi7UtmQ=",
+        "path": "/home/username/gitrepos/roc1/roc",
+        "type": "path"
+      },
+      "original": {
+        "path": "/home/username/gitrepos/roc1/roc",
+        "type": "path"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "roc": "roc"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": "flake-utils_4",
+        "nixpkgs": [
+          "roc",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1673231106,
+        "narHash": "sha256-Tbw4N/TL+nHmxF8RBoOJbl/6DRRzado/9/ttPEzkGr8=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "3488cec01351c2f1086b02a3a61808be7a25103e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/devtools/flake.nix
+++ b/devtools/flake.nix
@@ -3,7 +3,7 @@
 
   inputs = {
     # change this path to the path of your roc folder
-    roc.url = "path:/home/anton/gitrepos/roc3/roc";
+    roc.url = "path:/home/username/gitrepos/roc1/roc";
     # to easily make configs for multiple architectures
     flake-utils.url = "github:numtide/flake-utils";
   };
@@ -20,23 +20,24 @@
       in {
         devShell = pkgs.mkShell {
           packages = let
-            devInputs = (with pkgs; [ less gdb ]);
+            devInputs = (with pkgs; [ less gdb bashInteractive]);
             vscodeWithExtensions = pkgs.vscode-with-extensions.override {
               vscodeExtensions = with pkgs.vscode-extensions; [
                 matklad.rust-analyzer
                 eamodio.gitlens
                 bbenoist.nix
                 vadimcn.vscode-lldb
+                tamasfe.even-better-toml
               ]
-                  #++ pkgs.vscode-utils.extensionsFromVscodeMarketplace [
-                  #   {
-                  #      name = "";
-                  #      publisher = "";
-                  #      version = "";
+                  ++ pkgs.vscode-utils.extensionsFromVscodeMarketplace [
+                     {
+                        name = "roc-lang-support";
+                        publisher = "benjamin-thomas";
+                        version = "0.0.3";
                         # keep this sha for the first run, nix will tell you the correct one to change it to
-                  #      sha256 = "I1kTVTBZXvp9x3sB+59OgIc1Ttq0WAZy8VCZhEtwrm4=";
-                  #    }
-                  #  ]
+                        sha256 = "sha256-mabNegZ+XPQ6EIHFk6jz2mAPLHAU6Pm3w0SiFB7IE+s=";
+                      }
+                    ]
                   ;
 
             };
@@ -52,4 +53,3 @@
         };
       });
 }
-


### PR DESCRIPTION
- fixes issue where square brackets are shown escaped(`\`) in the vscode terminal, thanks to the addition of `bashInteractive`
- adds toml extension
- adds roc syntax highlighting extension
- improved readme
- added flake.lock to pin dependencies