### PR TITLE
Implement weakening of variables introduced in branch patterns

### DIFF
--- a/crates/compiler/constrain/src/expr.rs
+++ b/crates/compiler/constrain/src/expr.rs
@@ -1055,7 +1055,8 @@ pub fn constrain_expr(
                 pattern_headers,
                 pattern_constraints,
                 body_constraints,
-                Generalizable(false),
+                // TODO(weakening)
+                Generalizable(true),
             );
 
             let result_con =
@@ -2282,7 +2283,8 @@ fn constrain_when_branch_help(
                 [],
                 guard_constraint,
                 ret_constraint,
-                Generalizable(false),
+                // TODO(weakening)
+                Generalizable(true),
             );
 
             (state_constraints, delayed_is_open_constraints, inner)
@@ -2399,7 +2401,8 @@ pub fn constrain_decls(
                     [],
                     expect_constraint,
                     constraint,
-                    Generalizable(false),
+                    // TODO(weakening)
+                    Generalizable(true),
                 )
             }
             ExpectationFx => {
@@ -2427,7 +2430,8 @@ pub fn constrain_decls(
                     [],
                     expect_constraint,
                     constraint,
-                    Generalizable(false),
+                    // TODO(weakening)
+                    Generalizable(true),
                 )
             }
             Function(function_def_index) => {
@@ -3604,7 +3608,8 @@ pub fn rec_defs_help_simple(
             }
             _ => true, // this must be a function
         });
-        Generalizable(generalizable)
+        // TODO(weakening)
+        Generalizable(generalizable || true)
     };
 
     for index in range {
@@ -3816,15 +3821,17 @@ pub fn rec_defs_help_simple(
 /// A let-bound expression is generalizable if it is
 ///   - a syntactic function under an opaque wrapper
 ///   - a number literal under an opaque wrapper
-fn is_generalizable_expr(mut expr: &Expr) -> bool {
-    loop {
-        match expr {
-            Num(..) | Int(..) | Float(..) => return true,
-            Closure(_) => return true,
-            OpaqueRef { argument, .. } => expr = &argument.1.value,
-            _ => return false,
-        }
-    }
+fn is_generalizable_expr(_expr: &Expr) -> bool {
+    // TODO(weakening)
+    // loop {
+    //     match expr {
+    //         Num(..) | Int(..) | Float(..) => return true,
+    //         Closure(_) => return true,
+    //         OpaqueRef { argument, .. } => expr = &argument.1.value,
+    //         _ => return false,
+    //     }
+    // }
+    true
 }
 
 fn constrain_recursive_defs(
@@ -3858,7 +3865,8 @@ fn rec_defs_help(
         let generalizable = defs
             .iter()
             .all(|d| is_generalizable_expr(&d.loc_expr.value));
-        Generalizable(generalizable)
+        // TODO(weakening)
+        Generalizable(generalizable || true)
     };
 
     for def in defs {

--- a/crates/compiler/constrain/src/expr.rs
+++ b/crates/compiler/constrain/src/expr.rs
@@ -1055,7 +1055,17 @@ pub fn constrain_expr(
                 pattern_headers,
                 pattern_constraints,
                 body_constraints,
-                // TODO(weakening)
+                // NB(weakening): ideally we never explicitly mark generalizability here, but we
+                // must currently do so to handle cases like
+                //
+                // ```
+                // \x -> when x is
+                //     Red -> Red
+                // ```
+                //
+                // because we ultimately want `[Red]*` to be generalized at the level the function
+                // argument `x` is and not pulled down into a lower rank. However we don't yet have
+                // a way to express that requirement.
                 Generalizable(true),
             );
 
@@ -2283,7 +2293,17 @@ fn constrain_when_branch_help(
                 [],
                 guard_constraint,
                 ret_constraint,
-                // TODO(weakening)
+                // NB(weakening): ideally we never explicitly mark generalizability here, but we
+                // must currently do so to handle cases like
+                //
+                // ```
+                // \x -> when x is
+                //     Red -> Red
+                // ```
+                //
+                // because we ultimately want `[Red]*` to be generalized at the level the function
+                // argument `x` is and not pulled down into a lower rank. However we don't yet have
+                // a way to express that requirement.
                 Generalizable(true),
             );
 

--- a/crates/compiler/constrain/src/expr.rs
+++ b/crates/compiler/constrain/src/expr.rs
@@ -3609,6 +3609,7 @@ pub fn rec_defs_help_simple(
             _ => true, // this must be a function
         });
         // TODO(weakening)
+        #[allow(clippy::logic_bug)]
         Generalizable(generalizable || true)
     };
 
@@ -3866,6 +3867,7 @@ fn rec_defs_help(
             .iter()
             .all(|d| is_generalizable_expr(&d.loc_expr.value));
         // TODO(weakening)
+        #[allow(clippy::logic_bug)]
         Generalizable(generalizable || true)
     };
 

--- a/crates/compiler/constrain/src/expr.rs
+++ b/crates/compiler/constrain/src/expr.rs
@@ -1055,18 +1055,8 @@ pub fn constrain_expr(
                 pattern_headers,
                 pattern_constraints,
                 body_constraints,
-                // NB(weakening): ideally we never explicitly mark generalizability here, but we
-                // must currently do so to handle cases like
-                //
-                // ```
-                // \x -> when x is
-                //     Red -> Red
-                // ```
-                //
-                // because we ultimately want `[Red]*` to be generalized at the level the function
-                // argument `x` is and not pulled down into a lower rank. However we don't yet have
-                // a way to express that requirement.
-                Generalizable(true),
+                // Never generalize identifiers introduced in branch-patterns
+                Generalizable(false),
             );
 
             let result_con =
@@ -2293,18 +2283,8 @@ fn constrain_when_branch_help(
                 [],
                 guard_constraint,
                 ret_constraint,
-                // NB(weakening): ideally we never explicitly mark generalizability here, but we
-                // must currently do so to handle cases like
-                //
-                // ```
-                // \x -> when x is
-                //     Red -> Red
-                // ```
-                //
-                // because we ultimately want `[Red]*` to be generalized at the level the function
-                // argument `x` is and not pulled down into a lower rank. However we don't yet have
-                // a way to express that requirement.
-                Generalizable(true),
+                // Never generalize identifiers introduced in branch guards
+                Generalizable(false),
             );
 
             (state_constraints, delayed_is_open_constraints, inner)

--- a/crates/compiler/solve/src/solve.rs
+++ b/crates/compiler/solve/src/solve.rs
@@ -3615,15 +3615,14 @@ fn adjust_rank(
     let desc_mark = subs.get_mark_unchecked(var);
 
     if desc_mark == young_mark {
-        let content = {
-            let ptr = subs.get_content_unchecked(var) as *const _;
-            unsafe { &*ptr }
-        };
+        let content = *subs.get_content_unchecked(var);
 
         // Mark the variable as visited before adjusting content, as it may be cyclic.
         subs.set_mark_unchecked(var, visit_mark);
 
-        let max_rank = adjust_rank_content(subs, young_mark, visit_mark, group_rank, content);
+        // Adjust the nested types' ranks, making sure that no nested unbound type variable is at a
+        // higher rank than the group rank this `var` is at
+        let max_rank = adjust_rank_content(subs, young_mark, visit_mark, group_rank, &content);
 
         subs.set_rank_unchecked(var, max_rank);
         subs.set_mark_unchecked(var, visit_mark);

--- a/crates/compiler/solve/src/solve.rs
+++ b/crates/compiler/solve/src/solve.rs
@@ -790,7 +790,16 @@ fn solve(
                     let_con.def_types,
                 );
 
-                pools.get_mut(next_rank).extend(pool_variables);
+                // If the let-binding can be generalized, introduce all variables at the next rank;
+                // those that persist at the next rank after rank-adjustment will be generalized.
+                //
+                // Otherwise, introduce all variables at the current rank; since none of them will
+                // end up at the next rank, none will be generalized.
+                if let_con.generalizable.0 {
+                    pools.get_mut(next_rank).extend(pool_variables);
+                } else {
+                    pools.get_mut(rank).extend(pool_variables);
+                }
 
                 debug_assert_eq!(
                     // Check that no variable ended up in a higher rank than the next rank.. that

--- a/crates/compiler/solve/tests/solve_expr.rs
+++ b/crates/compiler/solve/tests/solve_expr.rs
@@ -8674,4 +8674,27 @@ mod solve_expr {
         @"main : (a -[[]]-> b) -[[main(0)]]-> (a -[[y(2) (a -[[]]-> b)]]-> b)"
         );
     }
+
+    #[test]
+    fn when_branch_variables_not_generalized() {
+        infer_queries!(
+            indoc!(
+                r#"
+                app "test" provides [main] to "./platform"
+
+                main = \{} -> when Red is
+                #^^^^{-1}
+                    x ->
+                        y : [Red]_
+                        y = x
+
+                        z : [Red, Green]_
+                        z = x
+
+                        {y, z}
+                "#
+            ),
+        @"main : {}* -[[main(0)]]-> { y : [Green, Red]a, z : [Green, Red]a }"
+        );
+    }
 }


### PR DESCRIPTION
Variables introduced in branch patterns should never be generalized in
the new weakening model. This implements that. The strategy is:

- when we have a let-binding that should be weakened, do not introduce
  its bound variables in a new (higher) rank
- instead, introduce them at the current rank, and also solve the
  let-binding at the current rank
- if any of those variables should then be generalized relative to the
  current rank, they will be so when the current rank is popped and
  generalized
