### PR TITLE
Begin weakening let-bindings to non-function, non-number expressions

### DIFF
--- a/crates/compiler/constrain/src/expr.rs
+++ b/crates/compiler/constrain/src/expr.rs
@@ -3829,11 +3829,11 @@ fn is_generalizable_expr(mut expr: &Expr) -> bool {
             | Str(_)
             | List { .. }
             | SingleQuote(_, _, _, _)
+            | When { .. }
                 => return false,
             // TODO(weakening)
             | Var(_, _)
             | AbilityMember(_, _, _)
-            | When { .. }
             | If { .. }
             | LetRec(_, _, _)
             | LetNonRec(_, _)

--- a/crates/compiler/constrain/src/expr.rs
+++ b/crates/compiler/constrain/src/expr.rs
@@ -3820,17 +3820,41 @@ pub fn rec_defs_help_simple(
 /// A let-bound expression is generalizable if it is
 ///   - a syntactic function under an opaque wrapper
 ///   - a number literal under an opaque wrapper
-fn is_generalizable_expr(_expr: &Expr) -> bool {
-    // TODO(weakening)
-    // loop {
-    //     match expr {
-    //         Num(..) | Int(..) | Float(..) => return true,
-    //         Closure(_) => return true,
-    //         OpaqueRef { argument, .. } => expr = &argument.1.value,
-    //         _ => return false,
-    //     }
-    // }
-    true
+fn is_generalizable_expr(mut expr: &Expr) -> bool {
+    loop {
+        match expr {
+            Num(..) | Int(..) | Float(..) => return true,
+            Closure(_) => return true,
+            OpaqueRef { argument, .. } => expr = &argument.1.value,
+            | Str(_) => return false,
+            // TODO(weakening)
+            | SingleQuote(_, _, _, _)
+            | List { .. }
+            | Var(_, _)
+            | AbilityMember(_, _, _)
+            | When { .. }
+            | If { .. }
+            | LetRec(_, _, _)
+            | LetNonRec(_, _)
+            | Call(_, _, _)
+            | RunLowLevel { .. }
+            | ForeignCall { .. }
+            | Expr::Record { .. }
+            | EmptyRecord
+            | Crash { .. }
+            | Access { .. }
+            | Accessor(_)
+            | Update { .. }
+            | Tag { .. }
+            | ZeroArgumentTag { .. }
+            | OpaqueWrapFunction(_)
+            | Expect { .. }
+            | ExpectFx { .. }
+            | Dbg { .. }
+            | TypedHole(_)
+            | RuntimeError(_) => return true,
+        }
+    }
 }
 
 fn constrain_recursive_defs(

--- a/crates/compiler/constrain/src/expr.rs
+++ b/crates/compiler/constrain/src/expr.rs
@@ -3830,11 +3830,11 @@ fn is_generalizable_expr(mut expr: &Expr) -> bool {
             | List { .. }
             | SingleQuote(_, _, _, _)
             | When { .. }
+            | If { .. }
                 => return false,
             // TODO(weakening)
             | Var(_, _)
             | AbilityMember(_, _, _)
-            | If { .. }
             | LetRec(_, _, _)
             | LetNonRec(_, _)
             | Call(_, _, _)

--- a/crates/compiler/constrain/src/expr.rs
+++ b/crates/compiler/constrain/src/expr.rs
@@ -2401,8 +2401,7 @@ pub fn constrain_decls(
                     [],
                     expect_constraint,
                     constraint,
-                    // TODO(weakening)
-                    Generalizable(true),
+                    Generalizable(false),
                 )
             }
             ExpectationFx => {
@@ -2430,8 +2429,7 @@ pub fn constrain_decls(
                     [],
                     expect_constraint,
                     constraint,
-                    // TODO(weakening)
-                    Generalizable(true),
+                    Generalizable(false),
                 )
             }
             Function(function_def_index) => {

--- a/crates/compiler/constrain/src/expr.rs
+++ b/crates/compiler/constrain/src/expr.rs
@@ -3826,10 +3826,11 @@ fn is_generalizable_expr(mut expr: &Expr) -> bool {
             Num(..) | Int(..) | Float(..) => return true,
             Closure(_) => return true,
             OpaqueRef { argument, .. } => expr = &argument.1.value,
-            | Str(_) => return false,
+            | Str(_)
+            | List { .. }
+                => return false,
             // TODO(weakening)
             | SingleQuote(_, _, _, _)
-            | List { .. }
             | Var(_, _)
             | AbilityMember(_, _, _)
             | When { .. }

--- a/crates/compiler/constrain/src/expr.rs
+++ b/crates/compiler/constrain/src/expr.rs
@@ -3826,14 +3826,11 @@ fn is_generalizable_expr(mut expr: &Expr) -> bool {
             Num(..) | Int(..) | Float(..) => return true,
             Closure(_) => return true,
             OpaqueRef { argument, .. } => expr = &argument.1.value,
-            | Str(_)
-            | List { .. }
-            | SingleQuote(_, _, _, _)
-            | When { .. }
-            | If { .. }
-                => return false,
+            Str(_) | List { .. } | SingleQuote(_, _, _, _) | When { .. } | If { .. } => {
+                return false
+            }
             // TODO(weakening)
-            | Var(_, _)
+            Var(_, _)
             | AbilityMember(_, _, _)
             | LetRec(_, _, _)
             | LetNonRec(_, _)

--- a/crates/compiler/constrain/src/expr.rs
+++ b/crates/compiler/constrain/src/expr.rs
@@ -3828,9 +3828,9 @@ fn is_generalizable_expr(mut expr: &Expr) -> bool {
             OpaqueRef { argument, .. } => expr = &argument.1.value,
             | Str(_)
             | List { .. }
+            | SingleQuote(_, _, _, _)
                 => return false,
             // TODO(weakening)
-            | SingleQuote(_, _, _, _)
             | Var(_, _)
             | AbilityMember(_, _, _)
             | When { .. }

--- a/crates/compiler/gen_llvm/src/llvm/build.rs
+++ b/crates/compiler/gen_llvm/src/llvm/build.rs
@@ -3768,8 +3768,12 @@ fn expose_function_to_host_help_c_abi_gen_test<'a, 'ctx, 'env>(
         } else {
             match layout {
                 Layout::Builtin(Builtin::List(_)) => {
+                    let list_type = arg_type
+                        .into_pointer_type()
+                        .get_element_type()
+                        .into_struct_type();
                     let loaded = env.builder.new_build_load(
-                        arg_type,
+                        list_type,
                         arg.into_pointer_value(),
                         "load_list_pointer",
                     );

--- a/crates/compiler/solve/tests/solve_expr.rs
+++ b/crates/compiler/solve/tests/solve_expr.rs
@@ -620,22 +620,6 @@ mod solve_expr {
     }
 
     #[test]
-    fn concat_different_types() {
-        infer_eq(
-            indoc!(
-                r#"
-                empty = []
-                one = List.concat [1] empty
-                str = List.concat ["blah"] empty
-
-                empty
-            "#
-            ),
-            "List *",
-        );
-    }
-
-    #[test]
     fn list_of_one_int() {
         infer_eq(
             indoc!(
@@ -3959,11 +3943,11 @@ mod solve_expr {
                 f : List a -> List a
                 f = \input ->
                     # let-polymorphism at work
-                    x : List b
-                    x = []
+                    x : {} -> List b
+                    x = \{} -> []
 
                     when List.get input 0 is
-                        Ok val -> List.append x val
+                        Ok val -> List.append (x {}) val
                         Err _ -> input
                 f
                 "#
@@ -6951,7 +6935,7 @@ mod solve_expr {
                 #^^^^^^^^^^^^^^^^^^^^^^{-1}
                 "#
             ),
-            @r###"[\{} -> {}, \{} -> {}] : List ({}* -[[1, 2]]-> {})"###
+            @r###"[\{} -> {}, \{} -> {}] : List ({}w_a -[[1, 2]]-> {})"###
         )
     }
 
@@ -7678,7 +7662,7 @@ mod solve_expr {
                         A _ C -> ""
                 "#
             ),
-            @r#"x : [A [B]* [C]*]"#
+            @r#"x : [A [B]w_a [C]w_b]"#
             allow_errors: true
         );
     }
@@ -7694,7 +7678,7 @@ mod solve_expr {
                         _ -> ""
                 "#
             ),
-            @r#"x : { a : [A { b : [B]* }*]* }*"#
+            @"x : { a : [A { b : [B]w_a }*]w_b }*"
         );
     }
 
@@ -8695,6 +8679,21 @@ mod solve_expr {
                 "#
             ),
         @"main : {}* -[[main(0)]]-> { y : [Green, Red]a, z : [Green, Red]a }"
+        );
+    }
+
+    #[test]
+    fn weakened_list() {
+        infer_queries!(
+            indoc!(
+                r#"
+                app "test" provides [main] to "./platform"
+
+                main = []
+                #^^^^{-1}
+                "#
+            ),
+        @"main : List w_a"
         );
     }
 }

--- a/crates/compiler/solve/tests/solve_expr.rs
+++ b/crates/compiler/solve/tests/solve_expr.rs
@@ -6672,6 +6672,7 @@ mod solve_expr {
                 main =
                     choice : [T, U]
 
+                    # Should not get generalized
                     idChoice =
                     #^^^^^^^^{-1}
                         when choice is
@@ -6685,7 +6686,7 @@ mod solve_expr {
             @r###"
         A#id(4) : A -[[id(4)]]-> A
         idNotAbility : a -[[idNotAbility(5)]]-> a
-        idChoice : a -[[idNotAbility(5)] + a:id(2):1]-> a | a has Id
+        idChoice : A -[[id(4), idNotAbility(5)]]-> A
         idChoice : A -[[id(4), idNotAbility(5)]]-> A
         "###
         )
@@ -6707,6 +6708,7 @@ mod solve_expr {
                 main =
                     choice : [T, U]
 
+                    # Should not get generalized
                     idChoice =
                     #^^^^^^^^{-1}
                         when choice is
@@ -6719,7 +6721,7 @@ mod solve_expr {
             ),
             @r#"
             A#id(4) : A -[[id(4)]]-> A
-            idChoice : a -[[] + a:id(2):1]-> a | a has Id
+            idChoice : A -[[id(4)]]-> A
             idChoice : A -[[id(4)]]-> A
             "#
         )
@@ -8582,8 +8584,8 @@ mod solve_expr {
                 "#
             ),
         @r###"
-        a : [A Str]*
-        b : [A Str]*
+        a : [A Str]w_a
+        b : [A Str]w_a
         "###
         );
     }

--- a/crates/compiler/test_gen/src/gen_list.rs
+++ b/crates/compiler/test_gen/src/gen_list.rs
@@ -3461,11 +3461,11 @@ fn issue_3530_uninitialized_capacity_in_list_literal() {
 
 #[test]
 #[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
-fn list_let_generalization() {
+fn list_infer_usage() {
     assert_evals_to!(
         indoc!(
             r#"
-            empty : List a
+            empty : List _
             empty = []
 
             xs : List Str

--- a/crates/compiler/test_gen/src/gen_list.rs
+++ b/crates/compiler/test_gen/src/gen_list.rs
@@ -3349,12 +3349,12 @@ fn monomorphized_lists() {
     assert_evals_to!(
         indoc!(
             r#"
-            l = [1, 2, 3]
+            l = \{} -> [1, 2, 3]
 
             f : List U8, List U16 -> Nat
             f = \_, _ -> 18
 
-            f l l
+            f (l {}) (l {})
             "#
         ),
         18,

--- a/crates/compiler/test_gen/src/gen_primitives.rs
+++ b/crates/compiler/test_gen/src/gen_primitives.rs
@@ -3418,7 +3418,9 @@ fn polymorphic_lambda_set_multiple_specializations() {
             r#"
             id1 = \x -> x
             id2 = \y -> y
-            id = if Bool.true then id1 else id2
+            id = \z ->
+                f = if Bool.true then id1 else id2
+                f z
 
             (id 9u8) + Num.toU8 (id 16u16)
             "#

--- a/crates/compiler/test_mono/generated/monomorphized_list.txt
+++ b/crates/compiler/test_mono/generated/monomorphized_list.txt
@@ -1,11 +1,21 @@
-procedure Test.2 (Test.3, Test.4):
-    let Test.7 : U64 = 18i64;
-    ret Test.7;
+procedure Test.1 (Test.3):
+    let Test.11 : List U16 = Array [1i64, 2i64, 3i64];
+    ret Test.11;
+
+procedure Test.1 (Test.3):
+    let Test.13 : List U8 = Array [1i64, 2i64, 3i64];
+    ret Test.13;
+
+procedure Test.2 (Test.4, Test.5):
+    let Test.9 : U64 = 18i64;
+    ret Test.9;
 
 procedure Test.0 ():
-    let Test.6 : List U16 = Array [1i64, 2i64, 3i64];
-    let Test.1 : List U8 = Array [1i64, 2i64, 3i64];
-    let Test.5 : U64 = CallByName Test.2 Test.1 Test.6;
-    dec Test.6;
-    dec Test.1;
-    ret Test.5;
+    let Test.12 : {} = Struct {};
+    let Test.7 : List U8 = CallByName Test.1 Test.12;
+    let Test.10 : {} = Struct {};
+    let Test.8 : List U16 = CallByName Test.1 Test.10;
+    let Test.6 : U64 = CallByName Test.2 Test.7 Test.8;
+    dec Test.8;
+    dec Test.7;
+    ret Test.6;

--- a/crates/compiler/test_mono/src/tests.rs
+++ b/crates/compiler/test_mono/src/tests.rs
@@ -1231,12 +1231,12 @@ fn monomorphized_list() {
         app "test" provides [main] to "./platform"
 
         main =
-            l = [1, 2, 3]
+            l = \{} -> [1, 2, 3]
 
             f : List U8, List U16 -> Nat
             f = \_, _ -> 18
 
-            f l l
+            f (l {}) (l {})
         "#
     )
 }

--- a/crates/compiler/types/src/pretty_print.rs
+++ b/crates/compiler/types/src/pretty_print.rs
@@ -413,6 +413,8 @@ fn name_all_type_vars(variable: Variable, subs: &mut Subs, debug_print: DebugPri
                 {
                     recursion_structs_to_expand.push(*structure);
                     letters_used = name_root(letters_used, root, subs, &mut taken, debug_print);
+                } else if debug_print.print_weakened_vars && is_weakened_unbound(subs, root) {
+                    letters_used = name_root(letters_used, root, subs, &mut taken, debug_print);
                 }
             }
             _ => {}
@@ -428,7 +430,7 @@ fn is_weakened_unbound(subs: &Subs, var: Variable) -> bool {
     use Content::*;
     let desc = subs.get_without_compacting(var);
     !desc.rank.is_generalized()
-        && !matches!(
+        && matches!(
             desc.content,
             FlexVar(_) | RigidVar(_) | FlexAbleVar(..) | RigidAbleVar(..)
         )

--- a/crates/repl_expect/src/lib.rs
+++ b/crates/repl_expect/src/lib.rs
@@ -389,7 +389,7 @@ mod test {
 
                 When it failed, these variables had these values:
 
-                items : List (Num *)
+                items : List (Int Signed64)
                 items = [0, 1]
 
                 expected : Result I64 [OutOfBounds]

--- a/crates/reporting/tests/test_reporting.rs
+++ b/crates/reporting/tests/test_reporting.rs
@@ -12817,4 +12817,34 @@ I recommend using camelCase. It's the standard style in Roc code!
     @r###"
     "###
     );
+
+    // TODO(weakening-reports)
+    test_report!(
+        concat_different_types,
+        indoc!(
+            r#"
+            empty = []
+            one = List.concat [1] empty
+            str = List.concat ["blah"] empty
+
+            {one, str}
+        "#
+        ),
+    @r###"
+    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+
+    This 2nd argument to `concat` has an unexpected type:
+
+    6│      str = List.concat ["blah"] empty
+                                       ^^^^^
+
+    This `empty` value is a:
+
+        List (Num *)
+
+    But `concat` needs its 2nd argument to be:
+
+        List Str
+    "###
+    );
 }


### PR DESCRIPTION
Enforces no generalization of let-bindings to

- strings
- chars
- lists
- when expressions
- if expressions

taking this slow to make sure it's right, things like `Var` and `AbilityMember` will also touch many places I think