### PR TITLE
Finish weakening let-bindings

### DIFF
--- a/crates/compiler/constrain/src/expr.rs
+++ b/crates/compiler/constrain/src/expr.rs
@@ -3860,9 +3860,10 @@ fn is_generalizable_expr(mut expr: &Expr) -> bool {
             | TypedHole(_)
             | RuntimeError(..)
             | ZeroArgumentTag { .. }
-            | Tag { .. } => return false,
+            | Tag { .. }
+            | AbilityMember(_, _, _) => return false,
             // TODO(weakening)
-            Var(_, _) | AbilityMember(_, _, _) => return true,
+            Var(_, _) => return true,
         }
     }
 }

--- a/crates/compiler/constrain/src/expr.rs
+++ b/crates/compiler/constrain/src/expr.rs
@@ -3861,9 +3861,8 @@ fn is_generalizable_expr(mut expr: &Expr) -> bool {
             | RuntimeError(..)
             | ZeroArgumentTag { .. }
             | Tag { .. }
-            | AbilityMember(_, _, _) => return false,
-            // TODO(weakening)
-            Var(_, _) => return true,
+            | AbilityMember(..)
+            | Var(..) => return false,
         }
     }
 }

--- a/crates/compiler/constrain/src/expr.rs
+++ b/crates/compiler/constrain/src/expr.rs
@@ -3606,9 +3606,7 @@ pub fn rec_defs_help_simple(
             }
             _ => true, // this must be a function
         });
-        // TODO(weakening)
-        #[allow(clippy::logic_bug)]
-        Generalizable(generalizable || true)
+        Generalizable(generalizable)
     };
 
     for index in range {

--- a/crates/compiler/constrain/src/expr.rs
+++ b/crates/compiler/constrain/src/expr.rs
@@ -3858,11 +3858,10 @@ fn is_generalizable_expr(mut expr: &Expr) -> bool {
             | ExpectFx { .. }
             | Dbg { .. }
             | TypedHole(_)
-            | RuntimeError(..) => return false,
+            | RuntimeError(..)
+            | ZeroArgumentTag { .. } => return false,
             // TODO(weakening)
-            Var(_, _) | AbilityMember(_, _, _) | Tag { .. } | ZeroArgumentTag { .. } => {
-                return true
-            }
+            Var(_, _) | AbilityMember(_, _, _) | Tag { .. } => return true,
         }
     }
 }

--- a/crates/compiler/constrain/src/expr.rs
+++ b/crates/compiler/constrain/src/expr.rs
@@ -3896,9 +3896,7 @@ fn rec_defs_help(
         let generalizable = defs
             .iter()
             .all(|d| is_generalizable_expr(&d.loc_expr.value));
-        // TODO(weakening)
-        #[allow(clippy::logic_bug)]
-        Generalizable(generalizable || true)
+        Generalizable(generalizable)
     };
 
     for def in defs {

--- a/crates/compiler/constrain/src/expr.rs
+++ b/crates/compiler/constrain/src/expr.rs
@@ -3859,9 +3859,10 @@ fn is_generalizable_expr(mut expr: &Expr) -> bool {
             | Dbg { .. }
             | TypedHole(_)
             | RuntimeError(..)
-            | ZeroArgumentTag { .. } => return false,
+            | ZeroArgumentTag { .. }
+            | Tag { .. } => return false,
             // TODO(weakening)
-            Var(_, _) | AbilityMember(_, _, _) | Tag { .. } => return true,
+            Var(_, _) | AbilityMember(_, _, _) => return true,
         }
     }
 }

--- a/crates/compiler/load_internal/tests/test_load.rs
+++ b/crates/compiler/load_internal/tests/test_load.rs
@@ -429,7 +429,7 @@ fn test_load_and_typecheck() {
             "constantNum" => "Num *",
             "divisionTest" => "F64",
             "divDep1ByDep2" => "Float a",
-            "fromDep2" => "Float *",
+            "fromDep2" => "Float a",
         },
     );
 }

--- a/crates/compiler/solve/tests/solve_expr.rs
+++ b/crates/compiler/solve/tests/solve_expr.rs
@@ -943,12 +943,14 @@ mod solve_expr {
         infer_eq_without_problem(
             indoc!(
                 r#"
-                foo = Foo
+                foo0 = Foo
+                foo1 = Foo
+                foo2 = Foo
 
                 {
-                    x: [foo, Foo],
-                    y: [foo, \x -> Foo x],
-                    z: [foo, \x,y  -> Foo x y]
+                    x: [foo0, Foo],
+                    y: [foo1, \x -> Foo x],
+                    z: [foo2, \x,y  -> Foo x y]
                 }
                 "#
             ),
@@ -3101,7 +3103,6 @@ mod solve_expr {
 
     #[test]
     fn rigid_in_letrec_ignored() {
-        // re-enable when we don't capture local things that don't need to be!
         infer_eq_without_problem(
             indoc!(
                 r#"
@@ -3109,7 +3110,7 @@ mod solve_expr {
 
                     toEmpty : ConsList a -> ConsList a
                     toEmpty = \_ ->
-                        result : ConsList a
+                        result : ConsList _   # TODO to enable using `a` we need scoped variables
                         result = Nil
 
                         toEmpty result
@@ -3132,7 +3133,7 @@ mod solve_expr {
 
                 toEmpty : ConsList a -> ConsList a
                 toEmpty = \_ ->
-                    result : ConsList a
+                    result : ConsList _   # TODO to enable using `a` we need scoped variables
                     result = Nil
 
                     toEmpty result
@@ -4353,12 +4354,12 @@ mod solve_expr {
                 RBTree k v : [Node NodeColor k v (RBTree k v) (RBTree k v), Empty]
 
                 # Create an empty dictionary.
-                empty : RBTree k v
-                empty =
+                empty : {} -> RBTree k v
+                empty = \{} ->
                     Empty
 
                 foo : RBTree I64 I64
-                foo = empty
+                foo = empty {}
 
                 main : RBTree I64 I64
                 main =

--- a/crates/compiler/solve/tests/solve_expr.rs
+++ b/crates/compiler/solve/tests/solve_expr.rs
@@ -2557,10 +2557,10 @@ mod solve_expr {
         infer_eq(
             indoc!(
                 r#"
-                    ok : Result I64 *
+                    ok : Result I64 _
                     ok = Ok 5
 
-                    err : Result * Str
+                    err : Result _ Str
                     err = Err "blah"
 
                     if 1 > 0 then
@@ -6992,7 +6992,7 @@ mod solve_expr {
                 "#
             ),
             @r#"
-            foo : [Named Str (List a)]* as a
+            foo : [Named Str (List a)] as a
             Named name outerList : [Named Str (List a)] as a
             name : Str
             outerList : List ([Named Str (List a)] as a)

--- a/crates/compiler/test_gen/src/gen_num.rs
+++ b/crates/compiler/test_gen/src/gen_num.rs
@@ -3507,9 +3507,9 @@ fn monomorphized_ints_aliased() {
             app "test" provides [main] to "./platform"
 
             main =
-                y = 100
-                w1 = y
-                w2 = y
+                y = \{} -> 100
+                w1 = \{} -> y {}
+                w2 = \{} -> y {}
 
                 f1 : U8, U32 -> U8
                 f1 = \_, _ -> 1
@@ -3517,7 +3517,7 @@ fn monomorphized_ints_aliased() {
                 f2 : U32, U8 -> U8
                 f2 = \_, _ -> 2
 
-                f1 w1 w2 + f2 w1 w2
+                f1 (w1 {}) (w2 {}) + f2 (w1 {}) (w2 {})
             "#
         ),
         3,

--- a/crates/compiler/test_gen/src/gen_primitives.rs
+++ b/crates/compiler/test_gen/src/gen_primitives.rs
@@ -1255,8 +1255,8 @@ fn linked_list_is_singleton() {
 
             ConsList a : [Cons a (ConsList a), Nil]
 
-            empty : ConsList a
-            empty = Nil
+            empty : {} -> ConsList a
+            empty = \{} -> Nil
 
             isSingleton : ConsList a -> Bool
             isSingleton = \list ->
@@ -1270,7 +1270,7 @@ fn linked_list_is_singleton() {
             main : Bool
             main =
                 myList : ConsList I64
-                myList = empty
+                myList = empty {}
 
                 isSingleton myList
             "#
@@ -1290,8 +1290,8 @@ fn linked_list_is_empty_1() {
 
             ConsList a : [Cons a (ConsList a), Nil]
 
-            empty : ConsList a
-            empty = Nil
+            empty : {} -> ConsList a
+            empty = \{} -> Nil
 
             isEmpty : ConsList a -> Bool
             isEmpty = \list ->
@@ -1304,8 +1304,8 @@ fn linked_list_is_empty_1() {
 
             main : Bool
             main =
-                myList : ConsList (Int *)
-                myList = empty
+                myList : ConsList U8
+                myList = empty {}
 
                 isEmpty myList
             "#

--- a/crates/compiler/test_gen/src/gen_tags.rs
+++ b/crates/compiler/test_gen/src/gen_tags.rs
@@ -1237,10 +1237,10 @@ fn monomorphized_tag() {
     assert_evals_to!(
         indoc!(
             r#"
-            b = Bar
+            b = \{} -> Bar
             f : [Foo, Bar], [Bar, Baz] -> U8
             f = \_, _ -> 18
-            f b b
+            f (b {}) (b {})
             "#
         ),
         18,
@@ -1279,8 +1279,8 @@ fn monomorphized_tag_with_polymorphic_arg() {
             app "test" provides [main] to "./platform"
 
             main =
-                a = A
-                wrap = Wrapped a
+                a = \{} -> A
+                wrap = \{} -> Wrapped (a {})
 
                 useWrap1 : [Wrapped [A], Other] -> U8
                 useWrap1 =
@@ -1294,7 +1294,7 @@ fn monomorphized_tag_with_polymorphic_arg() {
                         Wrapped A -> 5
                         Wrapped B -> 7
 
-                useWrap1 wrap * useWrap2 wrap
+                useWrap1 (wrap {}) * useWrap2 (wrap {})
             "#
         ),
         10,
@@ -1313,8 +1313,8 @@ fn monomorphized_tag_with_polymorphic_arg_and_monomorphic_arg() {
             main =
                 mono : U8
                 mono = 15
-                poly = A
-                wrap = Wrapped poly mono
+                poly = \{} -> A
+                wrap = \{} -> Wrapped (poly {}) mono
 
                 useWrap1 : [Wrapped [A] U8, Other] -> U8
                 useWrap1 =
@@ -1328,7 +1328,7 @@ fn monomorphized_tag_with_polymorphic_arg_and_monomorphic_arg() {
                         Wrapped A n -> n
                         Wrapped B _ -> 0
 
-                useWrap1 wrap * useWrap2 wrap
+                useWrap1 (wrap {}) * useWrap2 (wrap {})
             "#
         ),
         225,
@@ -1428,7 +1428,7 @@ fn issue_2445() {
             r#"
             app "test" provides [main] to "./platform"
 
-            none : [None, Update a]
+            none : [None, Update _]
             none = None
 
             press : [None, Update U8]

--- a/crates/compiler/test_mono/generated/instantiate_annotated_as_recursive_alias_multiple_polymorphic_expr.txt
+++ b/crates/compiler/test_mono/generated/instantiate_annotated_as_recursive_alias_multiple_polymorphic_expr.txt
@@ -1,5 +1,5 @@
 procedure Test.0 ():
-    let Test.4 : [<rnu><null>, C List *self] = TagId(1) ;
-    let Test.5 : [C List [<rnu><null>, C List *self], C U16, C ] = TagId(2) ;
-    let Test.12 : {[<rnu><null>, C List *self], [C List [<rnu><null>, C List *self], C U16, C ]} = Struct {Test.4, Test.5};
+    let Test.4 : [<rnw>C List *self, C U16, <null>] = TagId(2) ;
+    inc Test.4;
+    let Test.12 : {[<rnw>C List *self, C U16, <null>], [<rnw>C List *self, C U16, <null>]} = Struct {Test.4, Test.4};
     ret Test.12;

--- a/crates/compiler/test_mono/generated/monomorphized_tag.txt
+++ b/crates/compiler/test_mono/generated/monomorphized_tag.txt
@@ -1,8 +1,15 @@
-procedure Test.2 (Test.4, Test.5):
-    let Test.7 : U8 = 18i64;
-    ret Test.7;
+procedure Test.1 (Test.4):
+    let Test.12 : Int1 = false;
+    ret Test.12;
+
+procedure Test.2 (Test.5, Test.6):
+    let Test.10 : U8 = 18i64;
+    ret Test.10;
 
 procedure Test.0 ():
-    let Test.1 : Int1 = false;
-    let Test.6 : U8 = CallByName Test.2 Test.1 Test.1;
-    ret Test.6;
+    let Test.13 : {} = Struct {};
+    let Test.8 : Int1 = CallByName Test.1 Test.13;
+    let Test.11 : {} = Struct {};
+    let Test.9 : Int1 = CallByName Test.1 Test.11;
+    let Test.7 : U8 = CallByName Test.2 Test.8 Test.9;
+    ret Test.7;

--- a/crates/compiler/test_mono/generated/quicksort_help.txt
+++ b/crates/compiler/test_mono/generated/quicksort_help.txt
@@ -15,11 +15,11 @@ procedure Test.1 (Test.24, Test.25, Test.26):
         let Test.14 : Int1 = CallByName Num.22 Test.3 Test.4;
         if Test.14 then
             dec Test.2;
-            let Test.23 : List [] = Array [];
+            let Test.23 : List I64 = Array [];
             let Test.22 : I64 = 0i64;
-            let Test.21 : {I64, List []} = Struct {Test.22, Test.23};
+            let Test.21 : {I64, List I64} = Struct {Test.22, Test.23};
             let Test.5 : I64 = StructAtIndex 0 Test.21;
-            let Test.6 : List [] = StructAtIndex 1 Test.21;
+            let Test.6 : List I64 = StructAtIndex 1 Test.21;
             inc Test.6;
             dec Test.21;
             let Test.20 : I64 = 1i64;

--- a/crates/compiler/test_mono/src/tests.rs
+++ b/crates/compiler/test_mono/src/tests.rs
@@ -1199,10 +1199,10 @@ fn monomorphized_tag() {
         app "test" provides [main] to "./platform"
 
         main =
-            b = Bar
+            b = \{} -> Bar
             f : [Foo, Bar], [Bar, Baz] -> U8
             f = \_, _ -> 18
-            f b b
+            f (b {}) (b {})
         "#
     )
 }
@@ -1800,7 +1800,7 @@ fn instantiate_annotated_as_recursive_alias_toplevel() {
 
         Value : [Nil, Array (List Value)]
 
-        foo : [Nil]*
+        foo : [Nil]_
         foo = Nil
 
         it : Value
@@ -1818,7 +1818,7 @@ fn instantiate_annotated_as_recursive_alias_polymorphic_expr() {
         main =
             Value : [Nil, Array (List Value)]
 
-            foo : [Nil]*
+            foo : [Nil]_
             foo = Nil
 
             it : Value
@@ -1838,7 +1838,7 @@ fn instantiate_annotated_as_recursive_alias_multiple_polymorphic_expr() {
         main =
             Value : [Nil, Array (List Value)]
 
-            foo : [Nil]*
+            foo : [Nil]_
             foo = Nil
 
             v1 : Value

--- a/crates/repl_expect/src/lib.rs
+++ b/crates/repl_expect/src/lib.rs
@@ -666,10 +666,10 @@ mod test {
 
                 When it failed, these variables had these values:
 
-                a : [Ok Str]
+                a : [Err Str, Ok Str]
                 a = Ok "Astra mortemque praestare gradatim"
 
-                b : [Err Str]
+                b : [Err Str, Ok Str]
                 b = Err "Profundum et fundamentum"
                 "#
             ),


### PR DESCRIPTION
This series of patches completes the type-level implementation of let-binding weakening as in the proposed document. That is, now, only let-bindings to syntactic functions or number literals are permitted to be generalized; all other expressions are weakened.

The relatively small surface of impacted code should be a sign that this is not too disruptive a change. As in #4885, the largest change continues to be with the change to `Dict.empty`/`Set.empty`'s interface to now necessarily be a thunk.

This is not the end of the story for weakening. As described in the document, there are several other designs that still need to be implemented. In particular, I'd like us to capture the following after this PR:

- The restriction that weakened type variables cannot appear in exposed values (https://www.notion.so/rwx/Let-generalization-Let-s-not-742a3ab23ff742619129dcc848a271cf#1f049e45d7a94d28b3411cdd62456414)
- Better error messages for weak variables that eventually become concrete (https://www.notion.so/rwx/Let-generalization-Let-s-not-742a3ab23ff742619129dcc848a271cf#0929c77b98ab47b0be4f534d7ec4dc04)
- Implement the even-stricter higher-region restriction, which we need to eliminate a class of abilities bugs
- Rip out polymorphic-expression-compilation stuff from mono, which we now only need for number literals
- Add tests for the bugs/usages the full weakening should now resolve

Needs #4885