### PR TITLE
Fix missing parameter in to_relevant_branch_help

### DIFF
--- a/crates/compiler/mono/src/decision_tree.rs
+++ b/crates/compiler/mono/src/decision_tree.rs
@@ -748,7 +748,7 @@ fn to_relevant_branch_help<'a>(
         Identifier(_) | Underscore => Some(branch.clone()),
 
         As(subpattern, _symbol) => {
-            to_relevant_branch_help(test, path, start, end, branch, *subpattern)
+            to_relevant_branch_help(interner, test, path, start, end, branch, *subpattern)
         }
 
         RecordDestructure(destructs, _) => match test {


### PR DESCRIPTION
main is currently broken because of a non-conflicting diff that landed
before the interner change landed.
