### PR TITLE
Do not permit implicitly-inferred-open extension vars to grow in tag width

### DIFF
--- a/crates/ast/src/solve_type.rs
+++ b/crates/ast/src/solve_type.rs
@@ -10,7 +10,7 @@ use roc_region::all::{Loc, Region};
 use roc_solve::module::Solved;
 use roc_types::subs::{
     self, AliasVariables, Content, Descriptor, FlatType, Mark, OptVariable, Rank, RecordFields,
-    Subs, SubsSlice, UnionLambdas, UnionTags, Variable, VariableSubsSlice,
+    Subs, SubsSlice, TagExt, UnionLambdas, UnionTags, Variable, VariableSubsSlice,
 };
 use roc_types::types::{
     gather_fields_unsorted_iter, Alias, AliasKind, Category, ErrorType, PatternCategory, Polarity,
@@ -683,7 +683,7 @@ fn solve<'a>(
             let mut new_desc = subs.get(actual);
             match new_desc.content {
                 Content::Structure(FlatType::TagUnion(tags, _)) => {
-                    let new_ext = subs.fresh_unnamed_flex_var();
+                    let new_ext = TagExt::Any(subs.fresh_unnamed_flex_var());
                     let new_union = Content::Structure(FlatType::TagUnion(tags, new_ext));
                     new_desc.content = new_union;
                     subs.set(actual, new_desc);
@@ -953,7 +953,7 @@ fn type_to_variable<'a>(
 
             let (union_tags, ext) =
                 type_to_union_tags(arena, mempool, subs, rank, pools, cached, tags, ext);
-            let content = Content::Structure(FlatType::TagUnion(union_tags, ext));
+            let content = Content::Structure(FlatType::TagUnion(union_tags, TagExt::Any(ext)));
 
             register(subs, rank, pools, content)
         }
@@ -1097,9 +1097,12 @@ fn type_to_union_tags<'a>(
     let temp_ext_var = type_to_variable(arena, mempool, subs, rank, pools, cached, ext);
 
     let ext = {
-        let (it, ext) =
-            roc_types::types::gather_tags_unsorted_iter(subs, UnionTags::default(), temp_ext_var)
-                .expect("not a tag union");
+        let (it, ext) = roc_types::types::gather_tags_unsorted_iter(
+            subs,
+            UnionTags::default(),
+            TagExt::Any(temp_ext_var),
+        )
+        .expect("not a tag union");
 
         tag_vars.extend(it.map(|(n, v)| (n.clone(), v)));
         tag_vars.sort_unstable_by(|(a, _), (b, _)| a.cmp(b));
@@ -1123,7 +1126,10 @@ fn type_to_union_tags<'a>(
         ext
     };
 
-    (UnionTags::insert_slices_into_subs(subs, tag_vars), ext)
+    (
+        UnionTags::insert_slices_into_subs(subs, tag_vars),
+        ext.var(),
+    )
 }
 
 fn check_for_infinite_type(
@@ -1165,7 +1171,7 @@ fn check_for_infinite_type(
                     new_tags.push((subs[name_index].clone(), new_vars));
                 }
 
-                let new_ext_var = subs.explicit_substitute(recursive, rec_var, ext_var);
+                let new_ext_var = ext_var.map(|v| subs.explicit_substitute(recursive, rec_var, v));
 
                 let new_tags = UnionTags::insert_into_subs(subs, new_tags);
 
@@ -1387,7 +1393,8 @@ fn adjust_rank_content(
                 }
 
                 TagUnion(tags, ext_var) => {
-                    let mut rank = adjust_rank(subs, young_mark, visit_mark, group_rank, *ext_var);
+                    let mut rank =
+                        adjust_rank(subs, young_mark, visit_mark, group_rank, ext_var.var());
 
                     for (_, index) in tags.iter_all() {
                         let slice = subs[index];
@@ -1402,11 +1409,12 @@ fn adjust_rank_content(
                 }
 
                 FunctionOrTagUnion(_, _, ext_var) => {
-                    adjust_rank(subs, young_mark, visit_mark, group_rank, *ext_var)
+                    adjust_rank(subs, young_mark, visit_mark, group_rank, ext_var.var())
                 }
 
                 RecursiveTagUnion(rec_var, tags, ext_var) => {
-                    let mut rank = adjust_rank(subs, young_mark, visit_mark, group_rank, *ext_var);
+                    let mut rank =
+                        adjust_rank(subs, young_mark, visit_mark, group_rank, ext_var.var());
 
                     for (_, index) in tags.iter_all() {
                         let slice = subs[index];
@@ -1584,11 +1592,11 @@ fn instantiate_rigids_help(
                         }
                     }
 
-                    instantiate_rigids_help(subs, max_rank, pools, ext_var);
+                    instantiate_rigids_help(subs, max_rank, pools, ext_var.var());
                 }
 
                 FunctionOrTagUnion(_tag_name, _symbol, ext_var) => {
-                    instantiate_rigids_help(subs, max_rank, pools, ext_var);
+                    instantiate_rigids_help(subs, max_rank, pools, ext_var.var());
                 }
 
                 RecursiveTagUnion(rec_var, tags, ext_var) => {
@@ -1602,7 +1610,7 @@ fn instantiate_rigids_help(
                         }
                     }
 
-                    instantiate_rigids_help(subs, max_rank, pools, ext_var);
+                    instantiate_rigids_help(subs, max_rank, pools, ext_var.var());
                 }
             };
         }
@@ -1815,14 +1823,14 @@ fn deep_copy_var_help(
 
                     let union_tags = UnionTags::from_slices(tags.labels(), new_variables);
 
-                    let new_ext = deep_copy_var_help(subs, max_rank, pools, ext_var);
+                    let new_ext = ext_var.map(|v| deep_copy_var_help(subs, max_rank, pools, v));
                     TagUnion(union_tags, new_ext)
                 }
 
                 FunctionOrTagUnion(tag_name, symbol, ext_var) => FunctionOrTagUnion(
                     tag_name,
                     symbol,
-                    deep_copy_var_help(subs, max_rank, pools, ext_var),
+                    ext_var.map(|v| deep_copy_var_help(subs, max_rank, pools, v)),
                 ),
 
                 RecursiveTagUnion(rec_var, tags, ext_var) => {
@@ -1853,7 +1861,7 @@ fn deep_copy_var_help(
 
                     let union_tags = UnionTags::from_slices(tags.labels(), new_variables);
 
-                    let new_ext = deep_copy_var_help(subs, max_rank, pools, ext_var);
+                    let new_ext = ext_var.map(|v| deep_copy_var_help(subs, max_rank, pools, v));
                     let new_rec_var = deep_copy_var_help(subs, max_rank, pools, rec_var);
                     FlatType::RecursiveTagUnion(new_rec_var, union_tags, new_ext)
                 }

--- a/crates/compiler/can/src/annotation.rs
+++ b/crates/compiler/can/src/annotation.rs
@@ -931,9 +931,9 @@ fn can_annotation_help(
             if tags.is_empty() {
                 match ext {
                     Some(_) => {
-                        // just `a` does not mean the same as `{}a`, so even
-                        // if there are no fields, still make this a `Record`,
-                        // not an EmptyRec
+                        // just `a` does not mean the same as `[]`, so even
+                        // if there are no fields, still make this a `TagUnion`,
+                        // not an EmptyTagUnion
                         Type::TagUnion(Default::default(), TypeExtension::from_type(ext_type))
                     }
 

--- a/crates/compiler/can/src/copy.rs
+++ b/crates/compiler/can/src/copy.rs
@@ -904,7 +904,7 @@ fn deep_copy_type_vars<C: CopyEnv>(
                     })
                 }
                 TagUnion(tags, ext_var) => {
-                    let new_ext_var = descend_var!(ext_var);
+                    let new_ext_var = ext_var.map(|v| descend_var!(v));
 
                     for variables_slice_index in tags.variables() {
                         let variables_slice = env.source()[variables_slice_index];
@@ -929,7 +929,7 @@ fn deep_copy_type_vars<C: CopyEnv>(
                     })
                 }
                 RecursiveTagUnion(rec_var, tags, ext_var) => {
-                    let new_ext_var = descend_var!(ext_var);
+                    let new_ext_var = ext_var.map(|v| descend_var!(v));
                     let new_rec_var = descend_var!(rec_var);
 
                     for variables_slice_index in tags.variables() {
@@ -956,7 +956,7 @@ fn deep_copy_type_vars<C: CopyEnv>(
                     })
                 }
                 FunctionOrTagUnion(tag_names, symbols, ext_var) => {
-                    let new_ext_var = descend_var!(ext_var);
+                    let new_ext_var = ext_var.map(|v| descend_var!(v));
                     let new_tag_names = env.clone_tag_names(tag_names);
                     let new_symbols = env.clone_lambda_names(symbols);
                     perform_clone!(Structure(FunctionOrTagUnion(

--- a/crates/compiler/can/src/exhaustive.rs
+++ b/crates/compiler/can/src/exhaustive.rs
@@ -613,7 +613,7 @@ fn convert_tag(subs: &Subs, whole_var: Variable, this_tag: &TagName) -> (Union, 
 
             // DEVIATION: model openness by attaching a #Open constructor, that can never
             // be matched unless there's an `Anything` pattern.
-            let opt_openness_tag = match subs.get_content_without_compacting(ext) {
+            let opt_openness_tag = match subs.get_content_without_compacting(ext.var()) {
                 FlexVar(_) | RigidVar(_) => {
                     let openness_tag = TagName(NONEXHAUSIVE_CTOR.into());
                     num_tags += 1;

--- a/crates/compiler/constrain/src/expr.rs
+++ b/crates/compiler/constrain/src/expr.rs
@@ -279,7 +279,7 @@ pub fn constrain_expr(
             let fields_type = {
                 let typ = types.from_old_type(&Type::Record(
                     fields,
-                    TypeExtension::from_type(Type::Variable(*ext_var)),
+                    TypeExtension::from_non_annotation_type(Type::Variable(*ext_var)),
                 ));
                 constraints.push_type(types, typ)
             };
@@ -1090,7 +1090,7 @@ pub fn constrain_expr(
             let record_type = {
                 let typ = types.from_old_type(&Type::Record(
                     rec_field_types,
-                    TypeExtension::from_type(ext_type),
+                    TypeExtension::from_non_annotation_type(ext_type),
                 ));
                 constraints.push_type(types, typ)
             };
@@ -1134,7 +1134,10 @@ pub fn constrain_expr(
             let mut field_types = SendMap::default();
             let label = field.clone();
             field_types.insert(label, RecordField::Demanded(field_type.clone()));
-            let record_type = Type::Record(field_types, TypeExtension::from_type(ext_type));
+            let record_type = Type::Record(
+                field_types,
+                TypeExtension::from_non_annotation_type(ext_type),
+            );
             let record_type_index = {
                 let typ = types.from_old_type(&record_type);
                 constraints.push_type(types, typ)
@@ -1267,7 +1270,7 @@ pub fn constrain_expr(
             let tag_union_type = {
                 let typ = types.from_old_type(&Type::TagUnion(
                     vec![(name.clone(), payload_types)],
-                    TypeExtension::from_type(Type::Variable(*ext_var)),
+                    TypeExtension::from_non_annotation_type(Type::Variable(*ext_var)),
                 ));
                 constraints.push_type(types, typ)
             };
@@ -1299,7 +1302,7 @@ pub fn constrain_expr(
                 let typ = types.from_old_type(&Type::FunctionOrTagUnion(
                     name.clone(),
                     *closure_name,
-                    TypeExtension::from_type(Type::Variable(*ext_var)),
+                    TypeExtension::from_non_annotation_type(Type::Variable(*ext_var)),
                 ));
                 constraints.push_type(types, typ)
             };

--- a/crates/compiler/constrain/src/pattern.rs
+++ b/crates/compiler/constrain/src/pattern.rs
@@ -578,7 +578,7 @@ pub fn constrain_pattern(
             let record_type = {
                 let typ = types.from_old_type(&Type::Record(
                     field_types,
-                    TypeExtension::from_type(ext_type),
+                    TypeExtension::from_non_annotation_type(ext_type),
                 ));
                 constraints.push_type(types, typ)
             };

--- a/crates/compiler/derive/src/decoding.rs
+++ b/crates/compiler/derive/src/decoding.rs
@@ -13,7 +13,7 @@ use roc_module::symbol::Symbol;
 use roc_region::all::{Loc, Region};
 use roc_types::subs::{
     Content, ExhaustiveMark, FlatType, GetSubsSlice, LambdaSet, OptVariable, RecordFields,
-    RedundantMark, SubsSlice, UnionLambdas, UnionTags, Variable,
+    RedundantMark, SubsSlice, TagExt, UnionLambdas, UnionTags, Variable,
 };
 use roc_types::types::{AliasKind, RecordField};
 
@@ -210,7 +210,7 @@ fn decoder_record_step_field(
                     ("Skip".into(), Default::default()),
                 ],
             ),
-            Variable::EMPTY_TAG_UNION,
+            TagExt::Any(Variable::EMPTY_TAG_UNION),
         );
 
         synth_var(env.subs, Content::Structure(flat_type))
@@ -257,7 +257,7 @@ fn decoder_record_step_field(
             let rec_dot_result = {
                 let tag_union = FlatType::TagUnion(
                     UnionTags::for_result(env.subs, field_var, decode_err_var),
-                    Variable::EMPTY_TAG_UNION,
+                    TagExt::Any(Variable::EMPTY_TAG_UNION),
                 );
 
                 synth_var(env.subs, Content::Structure(tag_union))
@@ -300,7 +300,7 @@ fn decoder_record_step_field(
             let when_expr_var = {
                 let flat_type = FlatType::TagUnion(
                     UnionTags::for_result(env.subs, state_record_var, decode_err_var),
-                    Variable::EMPTY_TAG_UNION,
+                    TagExt::Any(Variable::EMPTY_TAG_UNION),
                 );
 
                 synth_var(env.subs, Content::Structure(flat_type))
@@ -759,7 +759,7 @@ fn decoder_record_finalizer(
     let decode_err_var = {
         let flat_type = FlatType::TagUnion(
             UnionTags::tag_without_arguments(env.subs, "TooShort".into()),
-            Variable::EMPTY_TAG_UNION,
+            TagExt::Any(Variable::EMPTY_TAG_UNION),
         );
 
         synth_var(env.subs, Content::Structure(flat_type))
@@ -802,7 +802,7 @@ fn decoder_record_finalizer(
         return_type_var = {
             let flat_type = FlatType::TagUnion(
                 UnionTags::for_result(subs, done_record_var, decode_err_var),
-                Variable::EMPTY_TAG_UNION,
+                TagExt::Any(Variable::EMPTY_TAG_UNION),
             );
 
             synth_var(subs, Content::Structure(flat_type))
@@ -946,7 +946,10 @@ fn decoder_record_initial_state(
         let union_tags = UnionTags::tag_without_arguments(subs, no_field_label.into());
         let no_field_var = synth_var(
             subs,
-            Content::Structure(FlatType::TagUnion(union_tags, Variable::EMPTY_TAG_UNION)),
+            Content::Structure(FlatType::TagUnion(
+                union_tags,
+                TagExt::Any(Variable::EMPTY_TAG_UNION),
+            )),
         );
         let no_field = Expr::Tag {
             tag_union_var: no_field_var,
@@ -958,7 +961,10 @@ fn decoder_record_initial_state(
         let union_tags = UnionTags::for_result(subs, field_var, no_field_var);
         let result_var = synth_var(
             subs,
-            Content::Structure(FlatType::TagUnion(union_tags, Variable::EMPTY_TAG_UNION)),
+            Content::Structure(FlatType::TagUnion(
+                union_tags,
+                TagExt::Any(Variable::EMPTY_TAG_UNION),
+            )),
         );
         let field_expr = Expr::Tag {
             tag_union_var: result_var,

--- a/crates/compiler/derive/src/encoding.rs
+++ b/crates/compiler/derive/src/encoding.rs
@@ -14,7 +14,7 @@ use roc_module::symbol::Symbol;
 use roc_region::all::{Loc, Region};
 use roc_types::subs::{
     Content, ExhaustiveMark, FlatType, GetSubsSlice, LambdaSet, OptVariable, RecordFields,
-    RedundantMark, SubsSlice, UnionLambdas, UnionTags, Variable, VariableSubsSlice,
+    RedundantMark, SubsSlice, TagExt, UnionLambdas, UnionTags, Variable, VariableSubsSlice,
 };
 use roc_types::types::RecordField;
 
@@ -67,7 +67,10 @@ pub(crate) fn derive_to_encoder(
             let union_tags = UnionTags::insert_slices_into_subs(env.subs, flex_tag_labels);
             let tag_union_var = synth_var(
                 env.subs,
-                Content::Structure(FlatType::TagUnion(union_tags, Variable::EMPTY_TAG_UNION)),
+                Content::Structure(FlatType::TagUnion(
+                    union_tags,
+                    TagExt::Any(Variable::EMPTY_TAG_UNION),
+                )),
             );
 
             to_encoder_tag_union(env, tag_union_var, union_tags, def_symbol)

--- a/crates/compiler/derive/src/hash.rs
+++ b/crates/compiler/derive/src/hash.rs
@@ -19,7 +19,7 @@ use roc_types::{
     num::int_lit_width_to_variable,
     subs::{
         Content, ExhaustiveMark, FlatType, GetSubsSlice, LambdaSet, OptVariable, RecordFields,
-        RedundantMark, Subs, SubsIndex, SubsSlice, UnionLambdas, UnionTags, Variable,
+        RedundantMark, Subs, SubsIndex, SubsSlice, TagExt, UnionLambdas, UnionTags, Variable,
         VariableSubsSlice,
     },
     types::RecordField,
@@ -146,7 +146,10 @@ fn hash_tag_union(
         let union_tags = UnionTags::insert_slices_into_subs(env.subs, flex_tag_labels);
         let tag_union_var = synth_var(
             env.subs,
-            Content::Structure(FlatType::TagUnion(union_tags, Variable::EMPTY_TAG_UNION)),
+            Content::Structure(FlatType::TagUnion(
+                union_tags,
+                TagExt::Any(Variable::EMPTY_TAG_UNION),
+            )),
         );
 
         (tag_union_var, union_tags)
@@ -305,7 +308,10 @@ fn hash_newtype_tag_union(
         let union_tags = UnionTags::from_slices(tag_name_index.as_slice(), variables_slices_slice);
         let tag_union_var = synth_var(
             env.subs,
-            Content::Structure(FlatType::TagUnion(union_tags, Variable::EMPTY_TAG_UNION)),
+            Content::Structure(FlatType::TagUnion(
+                union_tags,
+                TagExt::Any(Variable::EMPTY_TAG_UNION),
+            )),
         );
 
         (

--- a/crates/compiler/derive_key/src/encoding.rs
+++ b/crates/compiler/derive_key/src/encoding.rs
@@ -78,7 +78,7 @@ impl FlatEncodable {
                     // `t`-prefixed payload types.
                     let (tags_iter, ext) = tags.unsorted_tags_and_ext(subs, ext);
 
-                    check_derivable_ext_var(subs, ext, |ext| {
+                    check_derivable_ext_var(subs, ext.var(), |ext| {
                         matches!(ext, Content::Structure(FlatType::EmptyTagUnion))
                     })?;
 

--- a/crates/compiler/derive_key/src/hash.rs
+++ b/crates/compiler/derive_key/src/hash.rs
@@ -77,7 +77,7 @@ impl FlatHash {
                     // `t`-prefixed payload types.
                     let (tags_iter, ext) = tags.unsorted_tags_and_ext(subs, ext);
 
-                    check_derivable_ext_var(subs, ext, |ext| {
+                    check_derivable_ext_var(subs, ext.var(), |ext| {
                         matches!(ext, Content::Structure(FlatType::EmptyTagUnion))
                     })?;
 

--- a/crates/compiler/mono/src/layout.rs
+++ b/crates/compiler/mono/src/layout.rs
@@ -11,7 +11,7 @@ use roc_problem::can::RuntimeError;
 use roc_target::{PtrWidth, TargetInfo};
 use roc_types::num::NumericRange;
 use roc_types::subs::{
-    self, Content, FlatType, GetSubsSlice, Label, OptVariable, RecordFields, Subs,
+    self, Content, FlatType, GetSubsSlice, Label, OptVariable, RecordFields, Subs, TagExt,
     UnsortedUnionLabels, Variable,
 };
 use roc_types::types::{gather_fields_unsorted_iter, RecordField, RecordFieldsError};
@@ -2061,7 +2061,7 @@ fn lambda_set_size(subs: &Subs, var: Variable) -> (usize, usize, usize) {
                     stack.push((*ext, depth_any + 1, depth_lset));
                 }
                 FlatType::FunctionOrTagUnion(_, _, ext) => {
-                    stack.push((*ext, depth_any + 1, depth_lset));
+                    stack.push((ext.var(), depth_any + 1, depth_lset));
                 }
                 FlatType::TagUnion(tags, ext) => {
                     for (_, payloads) in tags.iter_from_subs(subs) {
@@ -2069,7 +2069,7 @@ fn lambda_set_size(subs: &Subs, var: Variable) -> (usize, usize, usize) {
                             stack.push((*payload, depth_any + 1, depth_lset));
                         }
                     }
-                    stack.push((*ext, depth_any + 1, depth_lset));
+                    stack.push((ext.var(), depth_any + 1, depth_lset));
                 }
                 FlatType::RecursiveTagUnion(rec_var, tags, ext) => {
                     seen_rec_vars.insert(*rec_var);
@@ -2078,7 +2078,7 @@ fn lambda_set_size(subs: &Subs, var: Variable) -> (usize, usize, usize) {
                             stack.push((*payload, depth_any + 1, depth_lset));
                         }
                     }
-                    stack.push((*ext, depth_any + 1, depth_lset));
+                    stack.push((ext.var(), depth_any + 1, depth_lset));
                 }
                 FlatType::EmptyRecord | FlatType::EmptyTagUnion => {}
             },
@@ -4110,13 +4110,13 @@ pub fn ext_var_is_empty_record(_subs: &Subs, _ext_var: Variable) -> bool {
 }
 
 #[cfg(debug_assertions)]
-pub fn ext_var_is_empty_tag_union(subs: &Subs, ext_var: Variable) -> bool {
+pub fn ext_var_is_empty_tag_union(subs: &Subs, tag_ext: TagExt) -> bool {
     use roc_types::pretty_print::ChasedExt;
     use Content::*;
 
     // the ext_var is empty
     let mut ext_fields = std::vec::Vec::new();
-    match roc_types::pretty_print::chase_ext_tag_union(subs, ext_var, &mut ext_fields) {
+    match roc_types::pretty_print::chase_ext_tag_union(subs, tag_ext.var(), &mut ext_fields) {
         ChasedExt::Empty => ext_fields.is_empty(),
         ChasedExt::NonEmpty { content, .. } => {
             match content {

--- a/crates/compiler/mono/src/layout.rs
+++ b/crates/compiler/mono/src/layout.rs
@@ -4133,7 +4133,7 @@ pub fn ext_var_is_empty_tag_union(subs: &Subs, tag_ext: TagExt) -> bool {
 }
 
 #[cfg(not(debug_assertions))]
-pub fn ext_var_is_empty_tag_union(_: &Subs, _: Variable) -> bool {
+pub fn ext_var_is_empty_tag_union(_: &Subs, _: TagExt) -> bool {
     // This should only ever be used in debug_assert! macros
     unreachable!();
 }

--- a/crates/compiler/solve/src/ability.rs
+++ b/crates/compiler/solve/src/ability.rs
@@ -708,13 +708,13 @@ trait DerivableVisitor {
                             for i in tags.variables() {
                                 push_var_slice!(subs[i]);
                             }
-                            stack.push(ext);
+                            stack.push(ext.var());
                         }
                     }
                     FunctionOrTagUnion(_tag_name, _fn_name, ext) => {
                         let descend = Self::visit_function_or_tag_union(var)?;
                         if descend.0 {
-                            stack.push(ext);
+                            stack.push(ext.var());
                         }
                     }
                     RecursiveTagUnion(rec, tags, ext) => {
@@ -724,7 +724,7 @@ trait DerivableVisitor {
                             for i in tags.variables() {
                                 push_var_slice!(subs[i]);
                             }
-                            stack.push(ext);
+                            stack.push(ext.var());
                         }
                     }
                     EmptyRecord => Self::visit_empty_record(var)?,

--- a/crates/compiler/solve/src/solve.rs
+++ b/crates/compiler/solve/src/solve.rs
@@ -33,8 +33,8 @@ use roc_types::subs::{
     UnionTags, Variable, VariableSubsSlice,
 };
 use roc_types::types::{
-    gather_fields_unsorted_iter, AliasKind, AliasShared, Category, IsImplicitOpennessVar,
-    OptAbleVar, Polarity, Reason, RecordField, Type, TypeExtension, TypeTag, Types, Uls,
+    gather_fields_unsorted_iter, AliasKind, AliasShared, Category, ExtImplicitOpenness, OptAbleVar,
+    Polarity, Reason, RecordField, Type, TypeExtension, TypeTag, Types, Uls,
 };
 use roc_unify::unify::{
     unify, unify_introduced_ability_specialization, Env as UEnv, Mode, Obligated,
@@ -2688,11 +2688,7 @@ fn type_to_variable<'a>(
                 let temp_ext = match ext_slice.into_iter().next() {
                     Some(ext) => {
                         let var = helper!(ext);
-                        if ext_openness.0 {
-                            TagExt::Openness(var)
-                        } else {
-                            TagExt::Any(var)
-                        }
+                        TagExt::from_can(var, ext_openness)
                     }
                     None => TagExt::Any(roc_types::subs::Variable::EMPTY_TAG_UNION),
                 };
@@ -3408,7 +3404,7 @@ fn type_to_union_tags(
     types: &mut Types,
     union_tags: UnionTags,
     opt_ext_slice: Slice<TypeTag>,
-    ext_openness: IsImplicitOpennessVar,
+    ext_openness: ExtImplicitOpenness,
     stack: &mut bumpalo::collections::Vec<'_, TypeToVar>,
 ) -> (UnionTags, TagExt) {
     use bumpalo::collections::Vec;
@@ -3438,11 +3434,7 @@ fn type_to_union_tags(
             let temp_ext = {
                 let temp_ext_var =
                     RegisterVariable::with_stack(subs, rank, pools, arena, types, ext, stack);
-                if ext_openness.0 {
-                    TagExt::Openness(temp_ext_var)
-                } else {
-                    TagExt::Any(temp_ext_var)
-                }
+                TagExt::from_can(temp_ext_var, ext_openness)
             };
             let (it, ext) =
                 roc_types::types::gather_tags_unsorted_iter(subs, UnionTags::default(), temp_ext)

--- a/crates/compiler/solve/src/solve.rs
+++ b/crates/compiler/solve/src/solve.rs
@@ -29,7 +29,7 @@ use roc_region::all::Loc;
 use roc_solve_problem::TypeError;
 use roc_types::subs::{
     self, AliasVariables, Content, Descriptor, FlatType, GetSubsSlice, LambdaSet, Mark,
-    OptVariable, Rank, RecordFields, Subs, SubsSlice, UlsOfVar, UnionLabels, UnionLambdas,
+    OptVariable, Rank, RecordFields, Subs, SubsSlice, TagExt, UlsOfVar, UnionLabels, UnionLambdas,
     UnionTags, Variable, VariableSubsSlice,
 };
 use roc_types::types::{
@@ -217,7 +217,7 @@ impl Aliases {
             SubsSlice::extend_new(&mut subs.variable_slices, [err_slice, ok_slice]);
 
         let union_tags = UnionTags::from_slices(tag_names_slice, variable_slices);
-        let ext_var = Variable::EMPTY_TAG_UNION;
+        let ext_var = TagExt::Any(Variable::EMPTY_TAG_UNION);
         let flat_type = FlatType::TagUnion(union_tags, ext_var);
         let content = Content::Structure(flat_type);
 
@@ -1829,9 +1829,9 @@ fn open_tag_union(subs: &mut Subs, var: Variable) {
         let desc = subs.get(var);
         match desc.content {
             Structure(TagUnion(tags, ext)) => {
-                if let Structure(EmptyTagUnion) = subs.get_content_without_compacting(ext) {
-                    let new_ext = subs.fresh_unnamed_flex_var();
-                    subs.set_rank(new_ext, desc.rank);
+                if let Structure(EmptyTagUnion) = subs.get_content_without_compacting(ext.var()) {
+                    let new_ext = TagExt::Any(subs.fresh_unnamed_flex_var());
+                    subs.set_rank(new_ext.var(), desc.rank);
                     let new_union = Structure(TagUnion(tags, new_ext));
                     subs.set_content(var, new_union);
                 }
@@ -1880,12 +1880,15 @@ fn close_pattern_matched_tag_unions(subs: &mut Subs, var: Variable) {
             Structure(TagUnion(tags, mut ext)) => {
                 // Close the extension, chasing it as far as it goes.
                 loop {
-                    match subs.get_content_without_compacting(ext) {
+                    match subs.get_content_without_compacting(ext.var()) {
                         Structure(FlatType::EmptyTagUnion) => {
                             break;
                         }
                         FlexVar(..) | FlexAbleVar(..) => {
-                            subs.set_content_unchecked(ext, Structure(FlatType::EmptyTagUnion));
+                            subs.set_content_unchecked(
+                                ext.var(),
+                                Structure(FlatType::EmptyTagUnion),
+                            );
                             break;
                         }
                         RigidVar(..) | RigidAbleVar(..) => {
@@ -2682,7 +2685,7 @@ fn type_to_variable<'a>(
                 let (it, ext) = roc_types::types::gather_tags_unsorted_iter(
                     subs,
                     UnionTags::default(),
-                    temp_ext_var,
+                    TagExt::Any(temp_ext_var),
                 )
                 .expect("extension var could not be seen as a tag union");
 
@@ -3112,7 +3115,7 @@ fn roc_result_to_var(
                     subs.variable_slices.push(ok_slice);
 
                     let union_tags = UnionTags::from_slices(Subs::RESULT_TAG_NAMES, variables);
-                    let ext = Variable::EMPTY_TAG_UNION;
+                    let ext = TagExt::Any(Variable::EMPTY_TAG_UNION);
 
                     let content = Content::Structure(FlatType::TagUnion(union_tags, ext));
 
@@ -3383,7 +3386,7 @@ fn type_to_union_tags(
     union_tags: UnionTags,
     opt_ext_slice: Slice<TypeTag>,
     stack: &mut bumpalo::collections::Vec<'_, TypeToVar>,
-) -> (UnionTags, Variable) {
+) -> (UnionTags, TagExt) {
     use bumpalo::collections::Vec;
 
     let (tags, _) = types.union_tag_slices(union_tags);
@@ -3403,7 +3406,7 @@ fn type_to_union_tags(
                 insert_tags_slow_path(subs, rank, pools, arena, types, union_tags, tag_vars, stack)
             };
 
-            (union_tags, ext)
+            (union_tags, TagExt::Any(ext))
         }
         Some(ext) => {
             let mut tag_vars = Vec::with_capacity_in(tags.len(), arena);
@@ -3413,7 +3416,7 @@ fn type_to_union_tags(
             let (it, ext) = roc_types::types::gather_tags_unsorted_iter(
                 subs,
                 UnionTags::default(),
-                temp_ext_var,
+                TagExt::Any(temp_ext_var),
             )
             .expect("extension var could not be seen as tag union");
 
@@ -3745,7 +3748,8 @@ fn adjust_rank_content(
                 }
 
                 TagUnion(tags, ext_var) => {
-                    let mut rank = adjust_rank(subs, young_mark, visit_mark, group_rank, *ext_var);
+                    let mut rank =
+                        adjust_rank(subs, young_mark, visit_mark, group_rank, ext_var.var());
                     // For performance reasons, we only keep one representation of empty tag unions
                     // in subs. That representation exists at rank 0, which we don't always want to
                     // reflect the whole tag union as, because doing so may over-generalize free
@@ -3761,7 +3765,7 @@ fn adjust_rank_content(
                     // we'll wind up with [Z, S a]{}, but it will be at rank 0, and "a" will get
                     // over-generalized. Really, the empty tag union should be introduced at
                     // whatever current group rank we're at, and so that's how we encode it here.
-                    if *ext_var == Variable::EMPTY_TAG_UNION && rank.is_generalized() {
+                    if ext_var.var() == Variable::EMPTY_TAG_UNION && rank.is_generalized() {
                         rank = group_rank;
                     }
 
@@ -3778,11 +3782,12 @@ fn adjust_rank_content(
                 }
 
                 FunctionOrTagUnion(_, _, ext_var) => {
-                    adjust_rank(subs, young_mark, visit_mark, group_rank, *ext_var)
+                    adjust_rank(subs, young_mark, visit_mark, group_rank, ext_var.var())
                 }
 
                 RecursiveTagUnion(rec_var, tags, ext_var) => {
-                    let mut rank = adjust_rank(subs, young_mark, visit_mark, group_rank, *ext_var);
+                    let mut rank =
+                        adjust_rank(subs, young_mark, visit_mark, group_rank, ext_var.var());
 
                     for (_, index) in tags.iter_all() {
                         let slice = subs[index];
@@ -4136,17 +4141,17 @@ fn deep_copy_var_help(
                     TagUnion(tags, ext_var) => {
                         let union_tags = copy_union!(tags);
 
-                        TagUnion(union_tags, work!(ext_var))
+                        TagUnion(union_tags, ext_var.map(|v| work!(v)))
                     }
 
                     FunctionOrTagUnion(tag_name, symbol, ext_var) => {
-                        FunctionOrTagUnion(tag_name, symbol, work!(ext_var))
+                        FunctionOrTagUnion(tag_name, symbol, ext_var.map(|v| work!(v)))
                     }
 
                     RecursiveTagUnion(rec_var, tags, ext_var) => {
                         let union_tags = copy_union!(tags);
 
-                        RecursiveTagUnion(work!(rec_var), union_tags, work!(ext_var))
+                        RecursiveTagUnion(work!(rec_var), union_tags, ext_var.map(|v| work!(v)))
                     }
                 };
 

--- a/crates/compiler/solve/src/solve.rs
+++ b/crates/compiler/solve/src/solve.rs
@@ -4068,6 +4068,16 @@ fn deep_copy_var_help(
         }};
     }
 
+    // When generalizing annotations with `Openness` extensions
+    // we want to promote them to `Any`, so that usages at
+    // specialized sites can grow unboundedly and are not bound to
+    // openness-polymorphism.
+    macro_rules! copy_tag_ext {
+        ($ext:expr) => {
+            TagExt::Any(work!($ext.var()))
+        };
+    }
+
     while let Some(DeepCopyVarWork { source: var, copy }) = stack.pop() {
         visited.push(var);
         pool.push(copy);
@@ -4141,17 +4151,17 @@ fn deep_copy_var_help(
                     TagUnion(tags, ext_var) => {
                         let union_tags = copy_union!(tags);
 
-                        TagUnion(union_tags, ext_var.map(|v| work!(v)))
+                        TagUnion(union_tags, copy_tag_ext!(ext_var))
                     }
 
                     FunctionOrTagUnion(tag_name, symbol, ext_var) => {
-                        FunctionOrTagUnion(tag_name, symbol, ext_var.map(|v| work!(v)))
+                        FunctionOrTagUnion(tag_name, symbol, copy_tag_ext!(ext_var))
                     }
 
                     RecursiveTagUnion(rec_var, tags, ext_var) => {
                         let union_tags = copy_union!(tags);
 
-                        RecursiveTagUnion(work!(rec_var), union_tags, ext_var.map(|v| work!(v)))
+                        RecursiveTagUnion(work!(rec_var), union_tags, copy_tag_ext!(ext_var))
                     }
                 };
 

--- a/crates/compiler/test_derive/src/util.rs
+++ b/crates/compiler/test_derive/src/util.rs
@@ -90,7 +90,7 @@ macro_rules! v {
          }
      }};
      ([ $($tag:ident $($payload:expr)*),* ] as $rec_var:ident) => {{
-         use roc_types::subs::{Subs, SubsIndex, Variable, Content, FlatType, UnionTags};
+         use roc_types::subs::{Subs, SubsIndex, Variable, Content, FlatType, TagExt, UnionTags};
          use roc_module::ident::TagName;
          |subs: &mut Subs| {
              let $rec_var = subs.fresh_unnamed_flex_var();
@@ -101,7 +101,7 @@ macro_rules! v {
              let $tag = vec![ $( $payload(subs), )* ];
              )*
              let tags = UnionTags::insert_into_subs::<_, Vec<Variable>>(subs, vec![ $( (TagName(stringify!($tag).into()), $tag) ,)* ]);
-             let tag_union_var = roc_derive::synth_var(subs, Content::Structure(FlatType::RecursiveTagUnion($rec_var, tags, Variable::EMPTY_TAG_UNION)));
+             let tag_union_var = roc_derive::synth_var(subs, Content::Structure(FlatType::RecursiveTagUnion($rec_var, tags, TagExt::Any(Variable::EMPTY_TAG_UNION))));
 
              subs.set_content(
                  $rec_var,
@@ -115,7 +115,7 @@ macro_rules! v {
      }};
      ([ $($tag:ident $($payload:expr)*),* ]$( $($ext:tt)+ )?) => {{
          #[allow(unused)]
-         use roc_types::subs::{Subs, UnionTags, Content, FlatType, Variable};
+         use roc_types::subs::{Subs, UnionTags, Content, FlatType, TagExt, Variable};
          #[allow(unused)]
          use roc_module::ident::TagName;
          |subs: &mut Subs| {
@@ -128,7 +128,7 @@ macro_rules! v {
              let mut ext = Variable::EMPTY_TAG_UNION;
              $( ext = $crate::v!($($ext)+)(subs); )?
 
-             roc_derive::synth_var(subs, Content::Structure(FlatType::TagUnion(tags, ext)))
+             roc_derive::synth_var(subs, Content::Structure(FlatType::TagUnion(tags, TagExt::Any(ext))))
          }
      }};
      (Symbol::$sym:ident $($arg:expr)*) => {{

--- a/crates/compiler/types/src/pretty_print.rs
+++ b/crates/compiler/types/src/pretty_print.rs
@@ -242,7 +242,7 @@ fn find_names_needed(
             }
 
             find_names_needed(
-                *ext_var,
+                ext_var.var(),
                 subs,
                 roots,
                 root_appearances,
@@ -252,7 +252,7 @@ fn find_names_needed(
         }
         Structure(FunctionOrTagUnion(_, _, ext_var)) => {
             find_names_needed(
-                *ext_var,
+                ext_var.var(),
                 subs,
                 roots,
                 root_appearances,
@@ -277,7 +277,7 @@ fn find_names_needed(
             }
 
             find_names_needed(
-                *ext_var,
+                ext_var.var(),
                 subs,
                 roots,
                 root_appearances,
@@ -1209,7 +1209,7 @@ fn write_flat_type<'a>(
                 ctx,
                 subs,
                 buf,
-                ExtContent::for_tag(subs, new_ext_var, pol, &env.debug),
+                ExtContent::for_tag(subs, new_ext_var.var(), pol, &env.debug),
                 parens,
                 pol,
             )
@@ -1224,7 +1224,7 @@ fn write_flat_type<'a>(
                     .iter()
                     .map(|t| (t.clone(), vec![])),
             );
-            let ext_content = write_sorted_tags(env, ctx, subs, buf, &tags, *ext_var, pol);
+            let ext_content = write_sorted_tags(env, ctx, subs, buf, &tags, ext_var.var(), pol);
 
             buf.push(']');
 
@@ -1253,7 +1253,7 @@ fn write_flat_type<'a>(
                     ctx,
                     subs,
                     buf,
-                    ExtContent::for_tag(subs, new_ext_var, pol, &env.debug),
+                    ExtContent::for_tag(subs, new_ext_var.var(), pol, &env.debug),
                     parens,
                     pol,
                 );
@@ -1306,12 +1306,12 @@ pub fn chase_ext_tag_union(
         Content::Structure(EmptyTagUnion) => ChasedExt::Empty,
         Content::Structure(TagUnion(tags, ext_var)) => {
             push_union(subs, tags, fields);
-            chase_ext_tag_union(subs, *ext_var, fields)
+            chase_ext_tag_union(subs, ext_var.var(), fields)
         }
 
         Content::Structure(RecursiveTagUnion(_, tags, ext_var)) => {
             push_union(subs, tags, fields);
-            chase_ext_tag_union(subs, *ext_var, fields)
+            chase_ext_tag_union(subs, ext_var.var(), fields)
         }
         Content::Structure(FunctionOrTagUnion(tag_names, _, ext_var)) => {
             fields.extend(
@@ -1320,7 +1320,7 @@ pub fn chase_ext_tag_union(
                     .map(|t| (t.clone(), vec![])),
             );
 
-            chase_ext_tag_union(subs, *ext_var, fields)
+            chase_ext_tag_union(subs, ext_var.var(), fields)
         }
 
         Content::Alias(_, _, var, _) => chase_ext_tag_union(subs, *var, fields),

--- a/crates/compiler/types/src/subs.rs
+++ b/crates/compiler/types/src/subs.rs
@@ -1,7 +1,7 @@
 #![deny(unsafe_op_in_unsafe_fn)]
 use crate::types::{
-    name_type_var, AbilitySet, AliasKind, ErrorType, Polarity, RecordField, RecordFieldsError,
-    TypeExt, Uls,
+    name_type_var, AbilitySet, AliasKind, ErrorType, ExtImplicitOpenness, Polarity, RecordField,
+    RecordFieldsError, TypeExt, Uls,
 };
 use roc_collections::all::{FnvMap, ImMap, ImSet, MutSet, SendMap};
 use roc_collections::{VecMap, VecSet};
@@ -2548,6 +2548,13 @@ impl TagExt {
 
     pub fn is_any(&self) -> bool {
         matches!(self, Self::Any(..))
+    }
+
+    pub fn from_can(var: Variable, ext_openness: ExtImplicitOpenness) -> Self {
+        match ext_openness {
+            ExtImplicitOpenness::Yes => Self::Openness(var),
+            ExtImplicitOpenness::No => Self::Any(var),
+        }
     }
 }
 

--- a/crates/compiler/types/src/subs.rs
+++ b/crates/compiler/types/src/subs.rs
@@ -1017,7 +1017,7 @@ impl VarStore {
         let next = (subs.utable.len()) as u32;
         debug_assert!(next >= Variable::FIRST_USER_SPACE_VAR.0);
 
-        VarStore { next: next }
+        VarStore { next }
     }
 
     pub fn peek(&mut self) -> u32 {

--- a/crates/compiler/types/src/subs.rs
+++ b/crates/compiler/types/src/subs.rs
@@ -17,7 +17,7 @@ use crate::unification_table::{self, UnificationTable};
 // please change it to the lower number.
 // if it went up, maybe check that the change is really required
 roc_error_macros::assert_sizeof_all!(Descriptor, 5 * 8 + 4);
-roc_error_macros::assert_sizeof_all!(FlatType, 3 * 8);
+roc_error_macros::assert_sizeof_all!(FlatType, 3 * 8 + 4);
 roc_error_macros::assert_sizeof_all!(UnionTags, 12);
 roc_error_macros::assert_sizeof_all!(RecordFields, 2 * 8);
 
@@ -1007,17 +1007,17 @@ impl Default for VarStore {
 
 impl VarStore {
     #[inline(always)]
-    pub fn new(next_var: Variable) -> Self {
-        debug_assert!(next_var.0 >= Variable::FIRST_USER_SPACE_VAR.0);
+    pub fn new(next: Variable) -> Self {
+        debug_assert!(next.0 >= Variable::FIRST_USER_SPACE_VAR.0);
 
-        VarStore { next: next_var.0 }
+        VarStore { next: next.0 }
     }
 
     pub fn new_from_subs(subs: &Subs) -> Self {
-        let next_var = (subs.utable.len()) as u32;
-        debug_assert!(next_var >= Variable::FIRST_USER_SPACE_VAR.0);
+        let next = (subs.utable.len()) as u32;
+        debug_assert!(next >= Variable::FIRST_USER_SPACE_VAR.0);
 
-        VarStore { next: next_var }
+        VarStore { next: next }
     }
 
     pub fn peek(&mut self) -> u32 {
@@ -1745,7 +1745,7 @@ impl Subs {
         subs.set_content(Variable::BOOL_ENUM, {
             Content::Structure(FlatType::TagUnion(
                 bool_union_tags,
-                Variable::EMPTY_TAG_UNION,
+                TagExt::Any(Variable::EMPTY_TAG_UNION),
             ))
         });
 
@@ -1965,16 +1965,11 @@ impl Subs {
         result
     }
 
-    pub fn mark_tag_union_recursive(
-        &mut self,
-        recursive: Variable,
-        tags: UnionTags,
-        ext_var: Variable,
-    ) {
+    pub fn mark_tag_union_recursive(&mut self, recursive: Variable, tags: UnionTags, ext: TagExt) {
         let (rec_var, new_tags) = self.mark_union_recursive_help(recursive, tags);
 
-        let new_ext_var = self.explicit_substitute(recursive, rec_var, ext_var);
-        let flat_type = FlatType::RecursiveTagUnion(rec_var, new_tags, new_ext_var);
+        let new_ext = ext.map(|v| self.explicit_substitute(recursive, rec_var, v));
+        let flat_type = FlatType::RecursiveTagUnion(rec_var, new_tags, new_ext);
 
         self.set_content(recursive, Content::Structure(flat_type));
     }
@@ -2281,7 +2276,7 @@ impl From<Content> for Descriptor {
 roc_error_macros::assert_sizeof_all!(Content, 4 * 8);
 roc_error_macros::assert_sizeof_all!((Symbol, AliasVariables, Variable), 8 + 12 + 4);
 roc_error_macros::assert_sizeof_all!(AliasVariables, 12);
-roc_error_macros::assert_sizeof_all!(FlatType, 3 * 8);
+roc_error_macros::assert_sizeof_all!(FlatType, 3 * 8 + 4);
 roc_error_macros::assert_sizeof_all!(LambdaSet, 3 * 8 + 4);
 
 roc_error_macros::assert_sizeof_aarch64!((Variable, Option<Lowercase>), 4 * 8);
@@ -2515,18 +2510,60 @@ impl Content {
 }
 
 #[derive(Clone, Copy, Debug)]
+pub enum TagExt {
+    /// This tag extension variable measures polymorphism in the openness of the tag,
+    /// or the lack thereof. It can only be unified with
+    ///   - an empty tag union, or
+    ///   - a rigid extension variable
+    ///
+    /// Openness extensions are used when tag annotations are introduced, since tag union
+    /// annotations may contain hidden extension variables which we want to reflect openness,
+    /// but not growth in the monomorphic size of the tag. For example, openness extensions enable
+    /// catching
+    ///
+    /// ```ignore
+    /// f : [A]
+    /// f = if Bool.true then A else B
+    /// ```
+    ///
+    /// as an error rather than resolving as [A][B].
+    Openness(Variable),
+    /// This tag extension can grow unboundedly.
+    Any(Variable),
+}
+
+impl TagExt {
+    pub fn var(&self) -> Variable {
+        match self {
+            TagExt::Openness(v) | TagExt::Any(v) => *v,
+        }
+    }
+
+    pub fn map(&self, f: impl FnOnce(Variable) -> Variable) -> Self {
+        match self {
+            Self::Openness(v) => Self::Openness(f(*v)),
+            Self::Any(v) => Self::Any(f(*v)),
+        }
+    }
+
+    pub fn is_any(&self) -> bool {
+        matches!(self, Self::Any(..))
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
 pub enum FlatType {
     Apply(Symbol, VariableSubsSlice),
     Func(VariableSubsSlice, Variable, Variable),
     Record(RecordFields, Variable),
-    TagUnion(UnionTags, Variable),
+    TagUnion(UnionTags, TagExt),
 
     /// `A` might either be a function
     ///   x -> A x : a -> [A a, B a, C a]
     /// or a tag `[A, B, C]`
-    FunctionOrTagUnion(SubsSlice<TagName>, SubsSlice<Symbol>, Variable),
+    FunctionOrTagUnion(SubsSlice<TagName>, SubsSlice<Symbol>, TagExt),
 
-    RecursiveTagUnion(Variable, UnionTags, Variable),
+    RecursiveTagUnion(Variable, UnionTags, TagExt),
     EmptyRecord,
     EmptyTagUnion,
 }
@@ -2864,7 +2901,7 @@ impl UnionTags {
     pub fn unsorted_iterator<'a>(
         &'a self,
         subs: &'a Subs,
-        ext: Variable,
+        ext: TagExt,
     ) -> impl Iterator<Item = (&TagName, &[Variable])> + 'a {
         let (it, _) =
             crate::types::gather_tags_unsorted_iter(subs, *self, ext).expect("not a tag union");
@@ -2878,8 +2915,8 @@ impl UnionTags {
     pub fn unsorted_tags_and_ext<'a>(
         &'a self,
         subs: &'a Subs,
-        ext: Variable,
-    ) -> (UnsortedUnionLabels<'a, TagName>, Variable) {
+        ext: TagExt,
+    ) -> (UnsortedUnionLabels<'a, TagName>, TagExt) {
         let (it, ext) =
             crate::types::gather_tags_unsorted_iter(subs, *self, ext).expect("not a tag union");
         let f = move |(label, slice): (_, SubsSlice<Variable>)| (label, subs.get_subs_slice(slice));
@@ -2892,9 +2929,9 @@ impl UnionTags {
     pub fn sorted_iterator_and_ext<'a>(
         &'_ self,
         subs: &'a Subs,
-        ext: Variable,
-    ) -> (SortedTagsIterator<'a>, Variable) {
-        if is_empty_tag_union(subs, ext) {
+        ext: TagExt,
+    ) -> (SortedTagsIterator<'a>, TagExt) {
+        if is_empty_tag_union(subs, ext.var()) {
             (
                 Box::new(self.iter_all().map(move |(i1, i2)| {
                     let tag_name: &TagName = &subs[i1];
@@ -2921,9 +2958,9 @@ impl UnionTags {
     pub fn sorted_slices_iterator_and_ext<'a>(
         &'_ self,
         subs: &'a Subs,
-        ext: Variable,
-    ) -> (SortedTagsSlicesIterator<'a>, Variable) {
-        if is_empty_tag_union(subs, ext) {
+        ext: TagExt,
+    ) -> (SortedTagsSlicesIterator<'a>, TagExt) {
+        if is_empty_tag_union(subs, ext.var()) {
             (
                 Box::new(self.iter_all().map(move |(i1, i2)| {
                     let tag_name: &TagName = &subs[i1];
@@ -2990,14 +3027,14 @@ pub fn is_empty_tag_union(subs: &Subs, mut var: Variable) -> bool {
                     return false;
                 }
 
-                var = *sub_ext;
+                var = sub_ext.var();
             }
             Structure(RecursiveTagUnion(_, sub_fields, sub_ext)) => {
                 if !sub_fields.is_empty() {
                     return false;
                 }
 
-                var = *sub_ext;
+                var = sub_ext.var();
             }
 
             Alias(_, _, actual_var, _) => {
@@ -3274,24 +3311,23 @@ fn occurs(
                         .chain(subs.get_subs_slice(*arg_vars).iter());
                     short_circuit(subs, root_var, seen, it)
                 }
-                Record(vars_by_field, ext_var) => {
+                Record(vars_by_field, ext) => {
                     let slice = SubsSlice::new(vars_by_field.variables_start, vars_by_field.length);
-                    let it = once(ext_var).chain(subs.get_subs_slice(slice).iter());
+                    let it = once(ext).chain(subs.get_subs_slice(slice).iter());
                     short_circuit(subs, root_var, seen, it)
                 }
-                TagUnion(tags, ext_var) => {
+                TagUnion(tags, ext) => {
                     occurs_union(subs, root_var, seen, tags)?;
 
-                    short_circuit_help(subs, root_var, seen, *ext_var)
+                    short_circuit_help(subs, root_var, seen, ext.var())
                 }
-                FunctionOrTagUnion(_, _, ext_var) => {
-                    let it = once(ext_var);
-                    short_circuit(subs, root_var, seen, it)
+                FunctionOrTagUnion(_, _, ext) => {
+                    short_circuit(subs, root_var, seen, once(&ext.var()))
                 }
-                RecursiveTagUnion(_, tags, ext_var) => {
+                RecursiveTagUnion(_, tags, ext) => {
                     occurs_union(subs, root_var, seen, tags)?;
 
-                    short_circuit_help(subs, root_var, seen, *ext_var)
+                    short_circuit_help(subs, root_var, seen, ext.var())
                 }
                 EmptyRecord | EmptyTagUnion => Ok(()),
             },
@@ -3426,33 +3462,33 @@ fn explicit_substitute(
                             Structure(Func(arg_vars, new_closure_var, new_ret_var)),
                         );
                     }
-                    TagUnion(tags, ext_var) => {
-                        let new_ext_var = explicit_substitute(subs, from, to, ext_var, seen);
+                    TagUnion(tags, ext) => {
+                        let new_ext = ext.map(|v| explicit_substitute(subs, from, to, v, seen));
 
                         let union_tags = explicit_substitute_union(subs, from, to, tags, seen);
 
-                        subs.set_content(in_var, Structure(TagUnion(union_tags, new_ext_var)));
+                        subs.set_content(in_var, Structure(TagUnion(union_tags, new_ext)));
                     }
-                    FunctionOrTagUnion(tag_name, symbol, ext_var) => {
-                        let new_ext_var = explicit_substitute(subs, from, to, ext_var, seen);
+                    FunctionOrTagUnion(tag_name, symbol, ext) => {
+                        let new_ext = ext.map(|v| explicit_substitute(subs, from, to, v, seen));
                         subs.set_content(
                             in_var,
-                            Structure(FunctionOrTagUnion(tag_name, symbol, new_ext_var)),
+                            Structure(FunctionOrTagUnion(tag_name, symbol, new_ext)),
                         );
                     }
-                    RecursiveTagUnion(rec_var, tags, ext_var) => {
+                    RecursiveTagUnion(rec_var, tags, ext) => {
                         // NOTE rec_var is not substituted, verify that this is correct!
-                        let new_ext_var = explicit_substitute(subs, from, to, ext_var, seen);
+                        let new_ext = ext.map(|v| explicit_substitute(subs, from, to, v, seen));
 
                         let union_tags = explicit_substitute_union(subs, from, to, tags, seen);
 
                         subs.set_content(
                             in_var,
-                            Structure(RecursiveTagUnion(rec_var, union_tags, new_ext_var)),
+                            Structure(RecursiveTagUnion(rec_var, union_tags, new_ext)),
                         );
                     }
-                    Record(vars_by_field, ext_var) => {
-                        let new_ext_var = explicit_substitute(subs, from, to, ext_var, seen);
+                    Record(vars_by_field, ext) => {
+                        let new_ext = explicit_substitute(subs, from, to, ext, seen);
 
                         for index in vars_by_field.iter_variables() {
                             let var = subs[index];
@@ -3460,7 +3496,7 @@ fn explicit_substitute(
                             subs[index] = new_var;
                         }
 
-                        subs.set_content(in_var, Structure(Record(vars_by_field, new_ext_var)));
+                        subs.set_content(in_var, Structure(Record(vars_by_field, new_ext)));
                     }
 
                     EmptyRecord | EmptyTagUnion => {}
@@ -3648,8 +3684,8 @@ fn get_var_names(
 
                 FlatType::EmptyRecord | FlatType::EmptyTagUnion => taken_names,
 
-                FlatType::Record(vars_by_field, ext_var) => {
-                    let mut accum = get_var_names(subs, ext_var, taken_names);
+                FlatType::Record(vars_by_field, ext) => {
+                    let mut accum = get_var_names(subs, ext, taken_names);
 
                     for var_index in vars_by_field.iter_variables() {
                         let arg_var = subs[var_index];
@@ -3659,17 +3695,17 @@ fn get_var_names(
 
                     accum
                 }
-                FlatType::TagUnion(tags, ext_var) => {
-                    let taken_names = get_var_names(subs, ext_var, taken_names);
+                FlatType::TagUnion(tags, ext) => {
+                    let taken_names = get_var_names(subs, ext.var(), taken_names);
                     get_var_names_union(subs, tags, taken_names)
                 }
 
-                FlatType::FunctionOrTagUnion(_, _, ext_var) => {
-                    get_var_names(subs, ext_var, taken_names)
+                FlatType::FunctionOrTagUnion(_, _, ext) => {
+                    get_var_names(subs, ext.var(), taken_names)
                 }
 
-                FlatType::RecursiveTagUnion(rec_var, tags, ext_var) => {
-                    let taken_names = get_var_names(subs, ext_var, taken_names);
+                FlatType::RecursiveTagUnion(rec_var, tags, ext) => {
+                    let taken_names = get_var_names(subs, ext.var(), taken_names);
                     let taken_names = get_var_names(subs, rec_var, taken_names);
                     get_var_names_union(subs, tags, taken_names)
                 }
@@ -3934,7 +3970,7 @@ fn flat_type_to_err_type(
         EmptyRecord => ErrorType::Record(SendMap::default(), TypeExt::Closed),
         EmptyTagUnion => ErrorType::TagUnion(SendMap::default(), TypeExt::Closed, pol),
 
-        Record(vars_by_field, ext_var) => {
+        Record(vars_by_field, ext) => {
             let mut err_fields = SendMap::default();
 
             for (i1, i2, i3) in vars_by_field.iter_all() {
@@ -3956,7 +3992,7 @@ fn flat_type_to_err_type(
                 err_fields.insert(label, err_record_field);
             }
 
-            match var_to_err_type(subs, state, ext_var, pol).unwrap_structural_alias() {
+            match var_to_err_type(subs, state, ext, pol).unwrap_structural_alias() {
                 ErrorType::Record(sub_fields, sub_ext) => {
                     ErrorType::Record(sub_fields.union(err_fields), sub_ext)
                 }
@@ -3976,10 +4012,10 @@ fn flat_type_to_err_type(
             }
         }
 
-        TagUnion(tags, ext_var) => {
+        TagUnion(tags, ext) => {
             let err_tags = union_tags_to_err_tags(subs, state, tags, pol);
 
-            match var_to_err_type(subs, state, ext_var, pol).unwrap_structural_alias() {
+            match var_to_err_type(subs, state, ext.var(), pol).unwrap_structural_alias() {
                 ErrorType::TagUnion(sub_tags, sub_ext, pol) => {
                     ErrorType::TagUnion(sub_tags.union(err_tags), sub_ext, pol)
                 }
@@ -4002,14 +4038,14 @@ fn flat_type_to_err_type(
             }
         }
 
-        FunctionOrTagUnion(tag_names, _, ext_var) => {
+        FunctionOrTagUnion(tag_names, _, ext) => {
             let tag_names = subs.get_subs_slice(tag_names);
 
             let mut err_tags: SendMap<TagName, Vec<_>> = SendMap::default();
 
             err_tags.extend(tag_names.iter().map(|t| (t.clone(), vec![])));
 
-            match var_to_err_type(subs, state, ext_var, pol).unwrap_structural_alias() {
+            match var_to_err_type(subs, state, ext.var(), pol).unwrap_structural_alias() {
                 ErrorType::TagUnion(sub_tags, sub_ext, pol) => {
                     ErrorType::TagUnion(sub_tags.union(err_tags), sub_ext, pol)
                 }
@@ -4032,14 +4068,14 @@ fn flat_type_to_err_type(
             }
         }
 
-        RecursiveTagUnion(rec_var, tags, ext_var) => {
+        RecursiveTagUnion(rec_var, tags, ext) => {
             state.recursive_tag_unions_seen.push(rec_var);
 
             let err_tags = union_tags_to_err_tags(subs, state, tags, pol);
 
             let rec_error_type = Box::new(var_to_err_type(subs, state, rec_var, pol));
 
-            match var_to_err_type(subs, state, ext_var, pol).unwrap_structural_alias() {
+            match var_to_err_type(subs, state, ext.var(), pol).unwrap_structural_alias() {
                 ErrorType::RecursiveTagUnion(rec_var, sub_tags, sub_ext, pol) => {
                     debug_assert!(rec_var == rec_error_type);
                     ErrorType::RecursiveTagUnion(rec_error_type, sub_tags.union(err_tags), sub_ext, pol)
@@ -4328,17 +4364,17 @@ impl StorageSubs {
             ),
             FlatType::TagUnion(union_tags, ext) => FlatType::TagUnion(
                 Self::offset_tag_union(offsets, *union_tags),
-                Self::offset_variable(offsets, *ext),
+                ext.map(|v| Self::offset_variable(offsets, v)),
             ),
             FlatType::FunctionOrTagUnion(tag_names, symbol, ext) => FlatType::FunctionOrTagUnion(
                 Self::offset_tag_name_slice(offsets, *tag_names),
                 *symbol,
-                Self::offset_variable(offsets, *ext),
+                ext.map(|v| Self::offset_variable(offsets, v)),
             ),
             FlatType::RecursiveTagUnion(rec, union_tags, ext) => FlatType::RecursiveTagUnion(
                 Self::offset_variable(offsets, *rec),
                 Self::offset_tag_union(offsets, *union_tags),
-                Self::offset_variable(offsets, *ext),
+                ext.map(|v| Self::offset_variable(offsets, v)),
             ),
             FlatType::EmptyRecord => FlatType::EmptyRecord,
             FlatType::EmptyTagUnion => FlatType::EmptyTagUnion,
@@ -4629,7 +4665,7 @@ fn storage_copy_var_to_help(env: &mut StorageCopyVarToEnv<'_>, var: Variable) ->
 
                 same @ EmptyRecord | same @ EmptyTagUnion => same,
 
-                Record(fields, ext_var) => {
+                Record(fields, ext) => {
                     let record_fields = {
                         let new_variables =
                             VariableSubsSlice::reserve_into_subs(env.target, fields.len());
@@ -4661,17 +4697,17 @@ fn storage_copy_var_to_help(env: &mut StorageCopyVarToEnv<'_>, var: Variable) ->
                         }
                     };
 
-                    Record(record_fields, storage_copy_var_to_help(env, ext_var))
+                    Record(record_fields, storage_copy_var_to_help(env, ext))
                 }
 
-                TagUnion(tags, ext_var) => {
-                    let new_ext = storage_copy_var_to_help(env, ext_var);
+                TagUnion(tags, ext) => {
+                    let new_ext = ext.map(|v| storage_copy_var_to_help(env, v));
                     let union_tags = storage_copy_union(env, tags);
 
                     TagUnion(union_tags, new_ext)
                 }
 
-                FunctionOrTagUnion(tag_names, symbols, ext_var) => {
+                FunctionOrTagUnion(tag_names, symbols, ext) => {
                     let new_tag_names = SubsSlice::extend_new(
                         &mut env.target.tag_names,
                         env.source.get_subs_slice(tag_names).iter().cloned(),
@@ -4685,14 +4721,14 @@ fn storage_copy_var_to_help(env: &mut StorageCopyVarToEnv<'_>, var: Variable) ->
                     FunctionOrTagUnion(
                         new_tag_names,
                         new_symbols,
-                        storage_copy_var_to_help(env, ext_var),
+                        ext.map(|v| storage_copy_var_to_help(env, v)),
                     )
                 }
 
-                RecursiveTagUnion(rec_var, tags, ext_var) => {
+                RecursiveTagUnion(rec_var, tags, ext) => {
                     let union_tags = storage_copy_union(env, tags);
 
-                    let new_ext = storage_copy_var_to_help(env, ext_var);
+                    let new_ext = ext.map(|v| storage_copy_var_to_help(env, v));
                     let new_rec_var = storage_copy_var_to_help(env, rec_var);
 
                     RecursiveTagUnion(new_rec_var, union_tags, new_ext)
@@ -5077,7 +5113,7 @@ fn copy_import_to_help(env: &mut CopyImportEnv<'_>, max_rank: Rank, var: Variabl
 
                 same @ EmptyRecord | same @ EmptyTagUnion => same,
 
-                Record(fields, ext_var) => {
+                Record(fields, ext) => {
                     let record_fields = {
                         let new_variables =
                             VariableSubsSlice::reserve_into_subs(env.target, fields.len());
@@ -5109,18 +5145,18 @@ fn copy_import_to_help(env: &mut CopyImportEnv<'_>, max_rank: Rank, var: Variabl
                         }
                     };
 
-                    Record(record_fields, copy_import_to_help(env, max_rank, ext_var))
+                    Record(record_fields, copy_import_to_help(env, max_rank, ext))
                 }
 
-                TagUnion(tags, ext_var) => {
-                    let new_ext = copy_import_to_help(env, max_rank, ext_var);
+                TagUnion(tags, ext) => {
+                    let new_ext = ext.map(|v| copy_import_to_help(env, max_rank, v));
 
                     let union_tags = copy_union(env, max_rank, tags);
 
                     TagUnion(union_tags, new_ext)
                 }
 
-                FunctionOrTagUnion(tag_names, symbols, ext_var) => {
+                FunctionOrTagUnion(tag_names, symbols, ext) => {
                     let new_tag_names = SubsSlice::extend_new(
                         &mut env.target.tag_names,
                         env.source.get_subs_slice(tag_names).iter().cloned(),
@@ -5131,17 +5167,15 @@ fn copy_import_to_help(env: &mut CopyImportEnv<'_>, max_rank: Rank, var: Variabl
                         env.source.get_subs_slice(symbols).iter().cloned(),
                     );
 
-                    FunctionOrTagUnion(
-                        new_tag_names,
-                        new_symbols,
-                        copy_import_to_help(env, max_rank, ext_var),
-                    )
+                    let new_ext = ext.map(|v| copy_import_to_help(env, max_rank, v));
+
+                    FunctionOrTagUnion(new_tag_names, new_symbols, new_ext)
                 }
 
-                RecursiveTagUnion(rec_var, tags, ext_var) => {
+                RecursiveTagUnion(rec_var, tags, ext) => {
                     let union_tags = copy_union(env, max_rank, tags);
 
-                    let new_ext = copy_import_to_help(env, max_rank, ext_var);
+                    let new_ext = ext.map(|v| copy_import_to_help(env, max_rank, v));
                     let new_rec_var = copy_import_to_help(env, max_rank, rec_var);
 
                     RecursiveTagUnion(new_rec_var, union_tags, new_ext)
@@ -5412,31 +5446,31 @@ fn instantiate_rigids_help(subs: &mut Subs, max_rank: Rank, initial: Variable) {
                 EmptyRecord => (),
                 EmptyTagUnion => (),
 
-                Record(fields, ext_var) => {
+                Record(fields, ext) => {
                     let fields = *fields;
-                    let ext_var = *ext_var;
+                    let ext = *ext;
                     stack.extend(var_slice!(fields.variables()));
 
-                    stack.push(ext_var);
+                    stack.push(ext);
                 }
-                TagUnion(tags, ext_var) => {
+                TagUnion(tags, ext) => {
                     let tags = *tags;
-                    let ext_var = *ext_var;
+                    let ext = *ext;
 
                     for slice_index in tags.variables() {
                         let slice = subs.variable_slices[slice_index.index as usize];
                         stack.extend(var_slice!(slice));
                     }
 
-                    stack.push(ext_var);
+                    stack.push(ext.var());
                 }
-                FunctionOrTagUnion(_, _, ext_var) => {
-                    stack.push(*ext_var);
+                FunctionOrTagUnion(_, _, ext) => {
+                    stack.push(ext.var());
                 }
 
-                RecursiveTagUnion(rec_var, tags, ext_var) => {
+                RecursiveTagUnion(rec_var, tags, ext) => {
                     let tags = *tags;
-                    let ext_var = *ext_var;
+                    let ext = *ext;
                     let rec_var = *rec_var;
 
                     for slice_index in tags.variables() {
@@ -5444,7 +5478,7 @@ fn instantiate_rigids_help(subs: &mut Subs, max_rank: Rank, initial: Variable) {
                         stack.extend(var_slice!(slice));
                     }
 
-                    stack.push(ext_var);
+                    stack.push(ext.var());
                     stack.push(rec_var);
                 }
             },
@@ -5535,10 +5569,10 @@ pub fn get_member_lambda_sets_at_region(subs: &Subs, var: Variable, target_regio
                             .iter()
                             .flat_map(|slice| subs.get_subs_slice(*slice)),
                     );
-                    stack.push(*ext);
+                    stack.push(ext.var());
                 }
                 FlatType::FunctionOrTagUnion(_, _, ext) => {
-                    stack.push(*ext);
+                    stack.push(ext.var());
                 }
                 FlatType::RecursiveTagUnion(rec, tags, ext) => {
                     stack.push(*rec);
@@ -5547,7 +5581,7 @@ pub fn get_member_lambda_sets_at_region(subs: &Subs, var: Variable, target_regio
                             .iter()
                             .flat_map(|slice| subs.get_subs_slice(*slice)),
                     );
-                    stack.push(*ext);
+                    stack.push(ext.var());
                 }
                 FlatType::EmptyRecord | FlatType::EmptyTagUnion => {}
             },

--- a/crates/compiler/types/src/types.rs
+++ b/crates/compiler/types/src/types.rs
@@ -4263,9 +4263,18 @@ pub fn gather_tags_unsorted_iter(
 
     let mut stack = vec![other_fields];
 
+    #[cfg(debug_assertions)]
+    let mut seen_head_union = false;
+
     loop {
         match subs.get_content_without_compacting(var) {
             Structure(TagUnion(sub_fields, sub_ext)) => {
+                #[cfg(debug_assertions)]
+                {
+                    assert!(!seen_head_union, "extension variable is another tag union, but I expected it to be either open or closed!");
+                    seen_head_union = true;
+                }
+
                 stack.push(*sub_fields);
 
                 var = *sub_ext;

--- a/crates/compiler/unify/src/fix.rs
+++ b/crates/compiler/unify/src/fix.rs
@@ -268,7 +268,7 @@ fn find_chain(subs: &Subs, left: Variable, right: Variable) -> impl Iterator<Ite
                         subs.get_subs_slice(*left_sym),
                         subs.get_subs_slice(*right_sym)
                     );
-                    let mut chain = help(subs, needle, *left_var, *right_var)?;
+                    let mut chain = help(subs, needle, left_var.var(), right_var.var())?;
                     chain.push((left, right));
                     Ok(chain)
                 }

--- a/crates/compiler/unify/src/unify.rs
+++ b/crates/compiler/unify/src/unify.rs
@@ -2463,7 +2463,7 @@ fn unify_tag_unions<M: MetaCollector>(
                 return ext_outcome;
             }
 
-            let mut shared_tags_outcome = unify_shared_tags_new(
+            let mut shared_tags_outcome = unify_shared_tags(
                 env,
                 pool,
                 ctx,
@@ -2503,7 +2503,7 @@ fn unify_tag_unions<M: MetaCollector>(
                 return ext_outcome;
             }
 
-            let mut shared_tags_outcome = unify_shared_tags_new(
+            let mut shared_tags_outcome = unify_shared_tags(
                 env,
                 pool,
                 ctx,
@@ -2558,7 +2558,7 @@ fn unify_tag_unions<M: MetaCollector>(
             false
         };
 
-        let shared_tags_outcome = unify_shared_tags_new(
+        let shared_tags_outcome = unify_shared_tags(
             env,
             pool,
             ctx,
@@ -2628,7 +2628,7 @@ fn unify_tag_unions<M: MetaCollector>(
         env.subs.commit_snapshot(snapshot);
 
         let shared_tags_outcome =
-            unify_shared_tags_new(env, pool, ctx, shared_tags, other_tags, ext, recursion_var);
+            unify_shared_tags(env, pool, ctx, shared_tags, other_tags, ext, recursion_var);
         total_outcome.union(shared_tags_outcome);
         total_outcome
     }
@@ -2740,7 +2740,7 @@ fn choose_merged_var(subs: &Subs, var1: Variable, var2: Variable) -> Variable {
 }
 
 #[must_use]
-fn unify_shared_tags_new<M: MetaCollector>(
+fn unify_shared_tags<M: MetaCollector>(
     env: &mut Env,
     pool: &mut Pool,
     ctx: &Context,
@@ -2856,8 +2856,7 @@ fn unify_shared_tags_new<M: MetaCollector>(
             }
         };
 
-        let merge_outcome =
-            unify_shared_tags_merge_new(env, ctx, new_tags, new_ext_var, recursion_var);
+        let merge_outcome = unify_shared_tags_merge(env, ctx, new_tags, new_ext_var, recursion_var);
 
         total_outcome.union(merge_outcome);
         total_outcome
@@ -2871,7 +2870,7 @@ fn unify_shared_tags_new<M: MetaCollector>(
 }
 
 #[must_use]
-fn unify_shared_tags_merge_new<M: MetaCollector>(
+fn unify_shared_tags_merge<M: MetaCollector>(
     env: &mut Env,
     ctx: &Context,
     new_tags: UnionTags,

--- a/crates/compiler/unify/src/unify.rs
+++ b/crates/compiler/unify/src/unify.rs
@@ -2426,18 +2426,16 @@ fn unify_tag_ext<M: MetaCollector>(
             // Openness extensions can either unify with empty tag unions (marking them as closed),
             // or flex/rigids. Anything else is a change in the monomorphic size of the tag and not
             // a reflection of the polymorphism of the tag, an error.
-            match env.subs.get_content_without_compacting(var) {
-                FlexVar(..) | RigidVar(..) | FlexAbleVar(..) | RigidAbleVar(..) => true,
-                Structure(s) => match s {
-                    FlatType::EmptyTagUnion => true,
-                    _ => false,
-                },
-                Error => {
+            matches!(
+                env.subs.get_content_without_compacting(var),
+                FlexVar(..)
+                    | RigidVar(..)
+                    | FlexAbleVar(..)
+                    | RigidAbleVar(..)
+                    | Structure(FlatType::EmptyTagUnion)
                     // errors propagate
-                    true
-                }
-                _ => false,
-            }
+                    | Error,
+            )
         }
         TagExt::Any(_) => true,
     };

--- a/crates/compiler/unify/src/unify.rs
+++ b/crates/compiler/unify/src/unify.rs
@@ -2437,7 +2437,9 @@ fn unify_tag_ext<M: MetaCollector>(
             )
         }
         TagExt::Any(_) => true,
-    };
+    }
+    // Tag unions are always extendable during specialization
+    || M::IS_LATE;
     if legal_unification {
         if flip_for_unify {
             unify_pool(env, pool, var, ext.var(), mode)

--- a/crates/compiler/unify/src/unify.rs
+++ b/crates/compiler/unify/src/unify.rs
@@ -2423,8 +2423,8 @@ fn unify_tag_ext<M: MetaCollector>(
     };
     let legal_unification = match ext {
         TagExt::Openness(_) => {
-            // Openness extensions can either unify with empty tag unions (marking them as closed),
-            // or flex/rigids. Anything else is a change in the monomorphic size of the tag and not
+            // Openness extensions can only unify with flex/rigids.
+            // Anything else is a change in the monomorphic size of the tag and not
             // a reflection of the polymorphism of the tag, an error.
             matches!(
                 env.subs.get_content_without_compacting(var),
@@ -2432,7 +2432,6 @@ fn unify_tag_ext<M: MetaCollector>(
                     | RigidVar(..)
                     | FlexAbleVar(..)
                     | RigidAbleVar(..)
-                    | Structure(FlatType::EmptyTagUnion)
                     // errors propagate
                     | Error,
             )

--- a/crates/repl_eval/src/eval.rs
+++ b/crates/repl_eval/src/eval.rs
@@ -17,7 +17,9 @@ use roc_parse::ast::{AssignedField, Collection, Expr, Pattern, StrLiteral};
 use roc_region::all::{Loc, Region};
 use roc_std::RocDec;
 use roc_target::TargetInfo;
-use roc_types::subs::{Content, FlatType, GetSubsSlice, RecordFields, Subs, UnionTags, Variable};
+use roc_types::subs::{
+    Content, FlatType, GetSubsSlice, RecordFields, Subs, TagExt, UnionTags, Variable,
+};
 
 use crate::{ReplApp, ReplAppMemory};
 
@@ -116,7 +118,7 @@ fn get_newtype_tag_and_var(
     };
 
     let vars = tags
-        .unsorted_iterator(env.subs, Variable::EMPTY_TAG_UNION)
+        .unsorted_iterator(env.subs, TagExt::Any(Variable::EMPTY_TAG_UNION))
         .find(|(tag, _)| **tag == tag_name)
         .unwrap()
         .1;
@@ -244,7 +246,7 @@ fn get_tags_vars_and_variant<'a>(
     opt_rec_var: Option<Variable>,
 ) -> (MutMap<TagName, std::vec::Vec<Variable>>, UnionVariant<'a>) {
     let tags_vec: std::vec::Vec<(TagName, std::vec::Vec<Variable>)> = tags
-        .unsorted_iterator(env.subs, Variable::EMPTY_TAG_UNION)
+        .unsorted_iterator(env.subs, TagExt::Any(Variable::EMPTY_TAG_UNION))
         .map(|(a, b)| (a.clone(), b.to_vec()))
         .collect();
 
@@ -1286,7 +1288,7 @@ fn byte_to_ast<'a>(env: &mut Env<'a, '_>, value: u8, content: &Content) -> Expr<
                     debug_assert!(tags.len() > 2);
 
                     let tags_vec: std::vec::Vec<(TagName, std::vec::Vec<Variable>)> = tags
-                        .unsorted_iterator(env.subs, Variable::EMPTY_TAG_UNION)
+                        .unsorted_iterator(env.subs, TagExt::Any(Variable::EMPTY_TAG_UNION))
                         .map(|(a, b)| (a.clone(), b.to_vec()))
                         .collect();
 


### PR DESCRIPTION
Annotations like

```
f : {} -> [A]
```

are implicitly allowed to be used polymorphically in the output tag type.
Internally, we check this as equivalent to

```
f : {} -> [A]_
```

However, this is not quite right. This annotation allows the output type to grow in tag width, permitting code like

```
f : {} -> [A]
f = \{} -> if Bool.true A else B
```

to check, when it should not - we only want to allow the output tag to be polymorphic in its width, but not allow the type to invisibly grow in tag width.

The fix is to change the unification scheme so that when we have an implicitly-infer-openness variable like the extension variable here, we now instead model it as

```
f : {} -> [A]Openness(_)
```

where the variable under the `Openness` constraint can now only be unified with a polymorphic variable (flex/rigid var), or an empty tag union - and hence is representative of the openness-polymorphism. Everything else is an error.