### PR TITLE
added macos x86_64 PR workflow

### DIFF
--- a/.github/workflows/macos_x86_64.yml
+++ b/.github/workflows/macos_x86_64.yml
@@ -1,0 +1,33 @@
+on: [pull_request]
+
+name: CI
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  RUST_BACKTRACE: 1
+
+jobs:
+  test-zig-rust-wasm:
+    name: test zig, rust, wasm...
+    runs-on: [self-hosted, macOS, X64]
+    timeout-minutes: 90
+    env:
+      RUSTC_WRAPPER: /home/small-ci-user/.cargo/bin/sccache
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          clean: "true"
+
+      - name: regular rust tests
+        run: cargo test --locked --release -- --skip opaque_wrap_function --skip bool_list_literal --skip platform_switching_swift --skip swift_ui --skip str_append_scalar && sccache --show-stats
+        # swift tests are skipped because of "Could not find or use auto-linked library 'swiftCompatibilityConcurrency'" on macos-11 x86_64 CI machine
+        # this issue may be caused by using older versions of XCode
+
+      - name: test examples/helloWorld.roc separately because it is ignored by default
+        run: cargo test --locked --release -p roc_cli cli_run::hello_world -- --ignored && sccache --show-stats
+
+      - name: test launching the editor
+        run: cargo test --release --locked editor_launch_test::launch -- --ignored # `--ignored` to run this test that is ignored for "normal" runs

--- a/.github/workflows/macos_x86_64.yml
+++ b/.github/workflows/macos_x86_64.yml
@@ -10,12 +10,12 @@ env:
   RUST_BACKTRACE: 1
 
 jobs:
-  test-zig-rust-wasm:
+  test-rust-macos-x86-64:
     name: test zig, rust, wasm...
     runs-on: [self-hosted, macOS, X64]
     timeout-minutes: 90
     env:
-      RUSTC_WRAPPER: /home/small-ci-user/.cargo/bin/sccache
+      RUSTC_WRAPPER: /Users/username1/.cargo/bin
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/macos_x86_64.yml
+++ b/.github/workflows/macos_x86_64.yml
@@ -1,6 +1,6 @@
 on: [pull_request]
 
-name: CI
+name: Macos x86-64 rust tests
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/macos_x86_64.yml
+++ b/.github/workflows/macos_x86_64.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: [self-hosted, macOS, X64]
     timeout-minutes: 90
     env:
-      RUSTC_WRAPPER: /Users/username1/.cargo/bin
+      RUSTC_WRAPPER: /Users/username1/.cargo/bin/sccache
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/macos_x86_64.yml
+++ b/.github/workflows/macos_x86_64.yml
@@ -11,7 +11,6 @@ env:
 
 jobs:
   test-rust-macos-x86-64:
-    name: test zig, rust, wasm...
     runs-on: [self-hosted, macOS, X64]
     timeout-minutes: 90
     env:

--- a/.github/workflows/macos_x86_64.yml
+++ b/.github/workflows/macos_x86_64.yml
@@ -25,8 +25,9 @@ jobs:
         # swift tests are skipped because of "Could not find or use auto-linked library 'swiftCompatibilityConcurrency'" on macos-11 x86_64 CI machine
         # this issue may be caused by using older versions of XCode
 
-      - name: test examples/helloWorld.roc separately because it is ignored by default
-        run: cargo test --locked --release -p roc_cli cli_run::hello_world -- --ignored && sccache --show-stats
+      # TODO build basic-cli for macos 11
+      #- name: test examples/helloWorld.roc separately because it is ignored by default
+      #  run: cargo test --locked --release -p roc_cli cli_run::hello_world -- --ignored && sccache --show-stats
 
       - name: test launching the editor
         run: cargo test --release --locked editor_launch_test::launch -- --ignored # `--ignored` to run this test that is ignored for "normal" runs


### PR DESCRIPTION
Execute all regular rust tests on the self-hosted x86_64 macos server on every PR. Previously we used to only do cli tests on the github macos x86_64 server.