### PR TITLE
handle zero-sized types in list decrement

### DIFF
--- a/crates/compiler/builtins/bitcode/src/list.zig
+++ b/crates/compiler/builtins/bitcode/src/list.zig
@@ -20,7 +20,7 @@ pub const RocList = extern struct {
     length: usize,
     capacity: usize,
 
-    pub fn len(self: RocList) usize {
+    pub inline fn len(self: RocList) usize {
         return self.length;
     }
 
@@ -410,9 +410,7 @@ pub fn listWithCapacity(
     alignment: u32,
     element_width: usize,
 ) callconv(.C) RocList {
-    var output = RocList.allocate(alignment, capacity, element_width);
-    output.length = 0;
-    return output;
+    return listReserve(RocList.empty(), alignment, capacity, element_width, .InPlace);
 }
 
 pub fn listReserve(

--- a/crates/compiler/gen_llvm/src/llvm/refcounting.rs
+++ b/crates/compiler/gen_llvm/src/llvm/refcounting.rs
@@ -5,7 +5,7 @@ use crate::llvm::build::{
     add_func, cast_basic_basic, get_tag_id, tag_pointer_clear_tag_id, use_roc_value, Env,
     WhenRecursive, FAST_CALL_CONV,
 };
-use crate::llvm::build_list::{incrementing_elem_loop, list_len, load_list};
+use crate::llvm::build_list::{incrementing_elem_loop, list_capacity, load_list};
 use crate::llvm::convert::{basic_type_from_layout, zig_str_type, RocUnion};
 use bumpalo::collections::Vec;
 use inkwell::basic_block::BasicBlock;
@@ -758,7 +758,7 @@ fn modify_refcount_list_help<'a, 'ctx, 'env>(
     let parent = fn_val;
     let original_wrapper = arg_val.into_struct_value();
 
-    let len = list_len(builder, original_wrapper);
+    let len = list_capacity(builder, original_wrapper);
 
     let is_non_empty = builder.build_int_compare(
         IntPredicate::UGT,

--- a/crates/valgrind/src/lib.rs
+++ b/crates/valgrind/src/lib.rs
@@ -235,3 +235,18 @@ fn str_concat_first_argument_not_unique() {
         "#
     ));
 }
+
+#[test]
+fn list_concat_empty_list_zero_sized_type() {
+    valgrind_test(indoc!(
+        r#"
+        (
+            a = List.reserve [] 11
+            b = []
+            List.concat a b
+            |> List.len
+            |> Num.toStr
+        )
+        "#
+    ));
+}


### PR DESCRIPTION
fix #4870

but ZSTs and lists almost certainly have other bad interactions that lead to leaks or double frees or juts bad things