### PR TITLE
Parse numbers in Http parser

### DIFF
--- a/examples/parser/Parser/Http.roc
+++ b/examples/parser/Parser/Http.roc
@@ -80,6 +80,11 @@ httpVersion =
     |> skip (codeunit '.')
     |> keep digits
 
+expect
+    actual = parseStr httpVersion "HTTP/1.1"
+    expected = Ok { major: 1, minor: 1 }
+    actual == expected
+
 Header : [Header Str Str]
 
 stringWithoutColon : Parser RawStr Str

--- a/examples/parser/Parser/Http.roc
+++ b/examples/parser/Parser/Http.roc
@@ -16,7 +16,6 @@ interface Parser.Http
             codeunitSatisfies,
             strFromRaw,
             anyRawString,
-            digit,
             digits,
         },
     ]

--- a/examples/parser/Parser/Http.roc
+++ b/examples/parser/Parser/Http.roc
@@ -23,7 +23,7 @@ interface Parser.Http
 # https://www.ietf.org/rfc/rfc2616.txt
 Method : [Options, Get, Post, Put, Delete, Head, Trace, Connect, Patch]
 
-HttpVersion : { major: U8, minor: U8}
+HttpVersion : { major : U8, minor : U8 }
 
 Request : {
     method : Method,

--- a/examples/parser/Parser/Str.roc
+++ b/examples/parser/Parser/Str.roc
@@ -178,10 +178,10 @@ digit : Parser RawStr U8
 digit =
     digitParsers =
         List.range { start: At '0', end: At '9' }
-        |> List.map \digitNum ->
-            digitNum
+        |> List.map \digitCodeUnit ->
+            digitCodeUnit
             |> codeunit
-            |> map \_ -> digitNum
+            |> map \_ -> digitCodeUnit - '0'
 
     oneOf digitParsers
 


### PR DESCRIPTION
In this [PR](https://github.com/roc-lang/roc/pull/4858) I found I was getting crashes in `Parser.digits`. I worked around them by just leaving the relevant numbers as strings. Here's what happens when I try to parse the digits.
Tagging @folkertdev and @ayazhafiz since you have both done lots of work in mono.

```
thread 'main' panicked at 'internal error: entered unreachable code: symbol/layout `Parser.Core.combined` ProcLayout {
    arguments: [
        InLayout(
            25,
        ),
        InLayout(
            139,
        ),
    ],
    result: InLayout(
        213,
    ),
    niche: Niche(
        Captures(
            [
                InLayout(
                    126,
                ),
                InLayout(
                    137,
                ),
            ],
        ),
    ),
} combo must be in DeclarationToIndex
However 53 similar layouts were found:
...
```