### PR TITLE
reproduce crash in `expect` with Lists of different length

### DIFF
--- a/crates/repl_eval/src/eval.rs
+++ b/crates/repl_eval/src/eval.rs
@@ -341,7 +341,7 @@ fn jit_to_ast_help<'a, A: ReplApp<'a>>(
     layout: InLayout<'a>,
     var: Variable,
 ) -> Expr<'a> {
-    let (newtype_containers, alias_content, raw_var) = unroll_newtypes_and_aliases(env, var);
+    let (newtype_containers, _alias_content, raw_var) = unroll_newtypes_and_aliases(env, var);
 
     macro_rules! num_helper {
         ($ty:ty) => {
@@ -1054,7 +1054,7 @@ fn struct_to_ast<'a, 'env, M: ReplAppMemory>(
         // We'll advance this as we iterate through the fields
         let mut field_addr = addr;
 
-        // the type checker stores record fiels in alphabetical order
+        // the type checker stores record fields in alphabetical order
         let alphabetical_fields: Vec<_> = record_fields
             .sorted_iterator(subs, Variable::EMPTY_RECORD)
             .map(|(l, field)| {

--- a/crates/repl_expect/src/app.rs
+++ b/crates/repl_expect/src/app.rs
@@ -17,7 +17,15 @@ macro_rules! deref_number {
 }
 
 impl ReplAppMemory for ExpectMemory {
-    deref_number!(deref_bool, bool);
+    fn deref_bool(&self, addr: usize) -> bool {
+        let ptr = unsafe { self.start.add(addr) } as *const u8;
+        let value = unsafe { std::ptr::read_unaligned(ptr) };
+
+        // bool values should only ever be 0 or 1
+        debug_assert!(value == 0 || value == 1);
+
+        value != 0
+    }
 
     deref_number!(deref_u8, u8);
     deref_number!(deref_u16, u16);

--- a/crates/repl_expect/src/lib.rs
+++ b/crates/repl_expect/src/lib.rs
@@ -1072,6 +1072,29 @@ mod test {
                 r#"
                 This expectation failed:
 
+                 8│>  expect
+                 9│>
+                10│>      actual : Request
+                11│>      actual = {
+                12│>          fieldA: Get,
+                13│>          fieldB: "/things?id=2",
+                14│>      }
+                15│>
+                16│>      expected : Request
+                17│>      expected = {
+                18│>          fieldA: Get,
+                19│>          fieldB: "/things?id=1",
+                20│>      }
+                21│>      actual == expected
+
+                When it failed, these variables had these values:
+
+                actual : Request
+                actual = { fieldA: Get, fieldB: "/things?id=2" }
+
+                expected : Request
+                expected = { fieldA: Get, fieldB: "/things?id=1" }
+
                 "#
             ),
         );

--- a/crates/repl_expect/src/lib.rs
+++ b/crates/repl_expect/src/lib.rs
@@ -975,4 +975,68 @@ mod test {
             ),
         );
     }
+
+    #[test]
+    fn foobar() {
+        run_expect_test(
+            indoc!(
+                r#"
+                interface Test exposes [] imports []
+
+                expect
+                    actual : { headers: List U8, body: List U8, x: List U8 }
+                    actual = {
+                        body: [],
+                        headers: [],
+                        x: [],
+                    }
+
+                    expected : { headers: List U8, body: List U8, x: List U8 }
+                    expected = {
+                        body: [ 42, 43, 44 ],
+                        headers: [15, 16, 17],
+                        x: [115, 116, 117],
+                    }
+                    actual == expected
+                "#
+            ),
+            indoc!(
+                r#"
+                This expectation failed:
+
+                 3│>  expect
+                 4│>      actual : { headers: List U8, body: List U8, x: List U8 }
+                 5│>      actual = {
+                 6│>          body: [],
+                 7│>          headers: [],
+                 8│>          x: [],
+                 9│>      }
+                10│>
+                11│>      expected : { headers: List U8, body: List U8, x: List U8 }
+                12│>      expected = {
+                13│>          body: [ 42, 43, 44 ],
+                14│>          headers: [15, 16, 17],
+                15│>          x: [115, 116, 117],
+                16│>      }
+                17│>      actual == expected
+
+                When it failed, these variables had these values:
+
+                actual : {
+                    body : List (Int Unsigned8),
+                    headers : List (Int Unsigned8),
+                    x : List (Int Unsigned8),
+                }
+                actual = { body: [], headers: [], x: [] }
+
+                expected : {
+                    body : List (Int Unsigned8),
+                    headers : List (Int Unsigned8),
+                    x : List (Int Unsigned8),
+                }
+                expected = { body: [42, 43, 44], headers: [15, 16, 17], x: [115, 116, 117] }
+                "#
+            ),
+        );
+    }
 }

--- a/crates/repl_expect/src/lib.rs
+++ b/crates/repl_expect/src/lib.rs
@@ -977,7 +977,7 @@ mod test {
     }
 
     #[test]
-    fn foobar() {
+    fn adjacent_lists() {
         run_expect_test(
             indoc!(
                 r#"
@@ -1035,6 +1035,43 @@ mod test {
                     x : List (Int Unsigned8),
                 }
                 expected = { body: [42, 43, 44], headers: [15, 16, 17], x: [115, 116, 117] }
+                "#
+            ),
+        );
+    }
+
+    #[test]
+    fn record_field_ordering() {
+        run_expect_test(
+            indoc!(
+                r#"
+                interface Test exposes [] imports []
+
+                Request : {
+                    fieldA : [Get, Post],
+                    fieldB : Str,
+                }
+
+                expect
+
+                    actual : Request
+                    actual = {
+                        fieldA: Get,
+                        fieldB: "/things?id=2",
+                    }
+
+                    expected : Request
+                    expected = {
+                        fieldA: Get,
+                        fieldB: "/things?id=1",
+                    }
+                    actual == expected
+                "#
+            ),
+            indoc!(
+                r#"
+                This expectation failed:
+
                 "#
             ),
         );

--- a/examples/parser/Parser/Http.roc
+++ b/examples/parser/Parser/Http.roc
@@ -140,7 +140,7 @@ expect
         httpVersion: "1.1",
         headers: [
             Header "Host" "bar.example",
-            Header "Accept-Encoding" "gzip, deflate",
+            # Header "Accept-Encoding" "gzip, deflate",
         ],
         body: "Hello, world!" |> Str.toUtf8,
     }

--- a/examples/parser/Parser/Http.roc
+++ b/examples/parser/Parser/Http.roc
@@ -134,6 +134,8 @@ expect
         """
     actual =
         parseStr request requestText
+
+    expected : Result Request [ParsingFailure Str, ParsingIncomplete Str]
     expected = Ok {
         method: Get,
         uri: "/things?id=1",

--- a/examples/parser/Parser/Http.roc
+++ b/examples/parser/Parser/Http.roc
@@ -142,7 +142,7 @@ expect
         httpVersion: "1.1",
         headers: [
             Header "Host" "bar.example",
-            # Header "Accept-Encoding" "gzip, deflate",
+            Header "Accept-Encoding" "gzip, deflate",
         ],
         body: "Hello, world!" |> Str.toUtf8,
     }


### PR DESCRIPTION
In the description of https://github.com/roc-lang/roc/pull/4858, I mentioned that `expect` seems to crash comparing lists of different lengths, instead of nicely reporting a test failure. Here's a reproduction of that.
I also remember getting crashes with the `digits` parser but that now seems to have a different crash in mono. See https://github.com/roc-lang/roc/pull/4895

```
RUST_BACKTRACE=1 target/debug/roc test examples/parser/Parser/Http.roc 
thread 'main' panicked at 'capacity overflow', /Users/briancarroll/.cargo/registry/src/github.com-1ecc6299db9ec823/bumpalo-3.11.0/src/collections/raw_vec.rs:691:5
stack backtrace:
   0: rust_begin_unwind
             at /rustc/a55dd71d5fb0ec5a6a3a9e8c27b2127ba491ce52/library/std/src/panicking.rs:584:5
   1: core::panicking::panic_fmt
             at /rustc/a55dd71d5fb0ec5a6a3a9e8c27b2127ba491ce52/library/core/src/panicking.rs:142:14
   2: bumpalo::collections::raw_vec::capacity_overflow
             at /Users/briancarroll/.cargo/registry/src/github.com-1ecc6299db9ec823/bumpalo-3.11.0/src/collections/raw_vec.rs:691:5
   3: bumpalo::collections::raw_vec::RawVec<T>::allocate_in::{{closure}}
             at /Users/briancarroll/.cargo/registry/src/github.com-1ecc6299db9ec823/bumpalo-3.11.0/src/collections/raw_vec.rs:91:36
   4: core::option::Option<T>::unwrap_or_else
             at /rustc/a55dd71d5fb0ec5a6a3a9e8c27b2127ba491ce52/library/core/src/option.rs:825:21
   5: bumpalo::collections::raw_vec::RawVec<T>::allocate_in
             at /Users/briancarroll/.cargo/registry/src/github.com-1ecc6299db9ec823/bumpalo-3.11.0/src/collections/raw_vec.rs:89:30
   6: bumpalo::collections::raw_vec::RawVec<T>::with_capacity_in
             at /Users/briancarroll/.cargo/registry/src/github.com-1ecc6299db9ec823/bumpalo-3.11.0/src/collections/raw_vec.rs:75:9
   7: bumpalo::collections::vec::Vec<T>::with_capacity_in
             at /Users/briancarroll/.cargo/registry/src/github.com-1ecc6299db9ec823/bumpalo-3.11.0/src/collections/vec.rs:586:18
   8: roc_repl_eval::eval::list_to_ast
             at ./crates/repl_eval/src/eval.rs:914:22
   9: roc_repl_eval::eval::addr_to_ast
             at ./crates/repl_eval/src/eval.rs:601:13
  10: roc_repl_eval::eval::struct_to_ast
             at ./crates/repl_eval/src/eval.rs:1068:24
  11: roc_repl_eval::eval::addr_to_ast
             at ./crates/repl_eval/src/eval.rs:610:17
  12: roc_repl_eval::eval::sequence_of_expr
             at ./crates/repl_eval/src/eval.rs:989:20
  13: roc_repl_eval::eval::expr_of_tag
             at ./crates/repl_eval/src/eval.rs:282:18
  14: roc_repl_eval::eval::addr_to_ast
             at ./crates/repl_eval/src/eval.rs:686:13
  15: roc_repl_eval::eval::jit_to_ast_help::{{closure}}
             at ./crates/repl_eval/src/eval.rs:469:21
  16: <roc_repl_expect::app::ExpectReplApp as roc_repl_eval::ReplApp>::call_function_dynamic_size
             at ./crates/repl_expect/src/app.rs:136:9
  17: roc_repl_eval::eval::jit_to_ast_help
             at ./crates/repl_eval/src/eval.rs:465:13
  18: roc_repl_eval::eval::jit_to_ast
             at ./crates/repl_eval/src/eval.rs:68:13
  19: roc_repl_expect::get_values
             at ./crates/repl_expect/src/lib.rs:71:13
  20: roc_repl_expect::run::render_expect_failure
             at ./crates/repl_expect/src/run.rs:574:44
  21: roc_repl_expect::run::run_expect_pure
             at ./crates/repl_expect/src/run.rs:276:27
  22: roc_repl_expect::run::run_expects_with_memory
             at ./crates/repl_expect/src/run.rs:219:22
  23: roc_repl_expect::run::run_toplevel_expects
             at ./crates/repl_expect/src/run.rs:169:5
  24: roc_cli::test
             at ./crates/cli/src/lib.rs:476:28
  25: roc::main
             at ./crates/cli/src/main.rs:67:17
  26: core::ops::function::FnOnce::call_once
             at /rustc/a55dd71d5fb0ec5a6a3a9e8c27b2127ba491ce52/library/core/src/ops/function.rs:248:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```