### PR TITLE
Fix formatting of backpassing in a nested def with no newline

### DIFF
--- a/crates/compiler/fmt/src/def.rs
+++ b/crates/compiler/fmt/src/def.rs
@@ -420,7 +420,7 @@ pub fn fmt_body<'a, 'buf>(
                     );
                 }
             }
-            Expr::Defs(..) | Expr::BinOps(_, _) => {
+            Expr::Defs(..) | Expr::BinOps(_, _) | Expr::Backpassing(..) => {
                 // Binop chains always get a newline. Otherwise you can have things like:
                 //
                 //     something = foo

--- a/crates/compiler/test_syntax/tests/snapshots/pass/nested_backpassing_no_newline_before.expr.formatted.roc
+++ b/crates/compiler/test_syntax/tests/snapshots/pass/nested_backpassing_no_newline_before.expr.formatted.roc
@@ -1,0 +1,7 @@
+main =
+    task =
+        file <-
+            foo
+        bar
+    task
+42

--- a/crates/compiler/test_syntax/tests/snapshots/pass/nested_backpassing_no_newline_before.expr.result-ast
+++ b/crates/compiler/test_syntax/tests/snapshots/pass/nested_backpassing_no_newline_before.expr.result-ast
@@ -1,0 +1,97 @@
+Defs(
+    Defs {
+        tags: [
+            Index(2147483648),
+        ],
+        regions: [
+            @0-71,
+        ],
+        space_before: [
+            Slice(start = 0, length = 0),
+        ],
+        space_after: [
+            Slice(start = 0, length = 0),
+        ],
+        spaces: [],
+        type_defs: [],
+        value_defs: [
+            Body(
+                @0-4 Identifier(
+                    "main",
+                ),
+                @11-71 SpaceBefore(
+                    Defs(
+                        Defs {
+                            tags: [
+                                Index(2147483648),
+                            ],
+                            regions: [
+                                @11-62,
+                            ],
+                            space_before: [
+                                Slice(start = 0, length = 0),
+                            ],
+                            space_after: [
+                                Slice(start = 0, length = 0),
+                            ],
+                            spaces: [],
+                            type_defs: [],
+                            value_defs: [
+                                Body(
+                                    @11-15 Identifier(
+                                        "task",
+                                    ),
+                                    @18-62 Backpassing(
+                                        [
+                                            @18-22 Identifier(
+                                                "file",
+                                            ),
+                                        ],
+                                        @43-46 SpaceBefore(
+                                            Var {
+                                                module_name: "",
+                                                ident: "foo",
+                                            },
+                                            [
+                                                Newline,
+                                            ],
+                                        ),
+                                        @59-62 SpaceBefore(
+                                            Var {
+                                                module_name: "",
+                                                ident: "bar",
+                                            },
+                                            [
+                                                Newline,
+                                            ],
+                                        ),
+                                    ),
+                                ),
+                            ],
+                        },
+                        @67-71 SpaceBefore(
+                            Var {
+                                module_name: "",
+                                ident: "task",
+                            },
+                            [
+                                Newline,
+                            ],
+                        ),
+                    ),
+                    [
+                        Newline,
+                    ],
+                ),
+            ),
+        ],
+    },
+    @72-74 SpaceBefore(
+        Num(
+            "42",
+        ),
+        [
+            Newline,
+        ],
+    ),
+)

--- a/crates/compiler/test_syntax/tests/snapshots/pass/nested_backpassing_no_newline_before.expr.roc
+++ b/crates/compiler/test_syntax/tests/snapshots/pass/nested_backpassing_no_newline_before.expr.roc
@@ -1,0 +1,6 @@
+main =
+    task = file <- 
+                foo
+            bar
+    task
+42

--- a/crates/compiler/test_syntax/tests/test_snapshots.rs
+++ b/crates/compiler/test_syntax/tests/test_snapshots.rs
@@ -325,6 +325,7 @@ mod test_snapshots {
         pass/negative_in_apply_def.expr,
         pass/negative_int.expr,
         pass/nested_def_annotation.moduledefs,
+        pass/nested_backpassing_no_newline_before.expr,
         pass/nested_def_without_newline.expr,
         pass/nested_if.expr,
         pass/nested_module.header,


### PR DESCRIPTION
Fixes #4338