### PR TITLE
Preserve function argument/return layouts in lambda set layouts

### DIFF
--- a/crates/compiler/mono/src/debug/checker.rs
+++ b/crates/compiler/mono/src/debug/checker.rs
@@ -706,6 +706,8 @@ fn resolve_recursive_layout<'a>(
             | Builtin::Str => return layout,
         },
         Layout::LambdaSet(LambdaSet {
+            args,
+            ret,
             set,
             representation,
             full_layout,
@@ -717,6 +719,8 @@ fn resolve_recursive_layout<'a>(
             });
             let set = arena.alloc_slice_fill_iter(set);
             Layout::LambdaSet(LambdaSet {
+                args,
+                ret,
                 set: arena.alloc(&*set),
                 representation,
                 full_layout,

--- a/crates/compiler/mono/src/ir.rs
+++ b/crates/compiler/mono/src/ir.rs
@@ -6357,13 +6357,15 @@ fn register_capturing_closure<'a>(
         let is_self_recursive = !matches!(recursive, roc_can::expr::Recursive::NotRecursive);
 
         let captured_symbols = match *env.subs.get_content_without_compacting(function_type) {
-            Content::Structure(FlatType::Func(_, closure_var, _)) => {
+            Content::Structure(FlatType::Func(args, closure_var, ret)) => {
                 let lambda_set_layout = {
                     LambdaSet::from_var_pub(
                         layout_cache,
                         env.arena,
                         env.subs,
+                        args,
                         closure_var,
+                        ret,
                         env.target_info,
                     )
                 };

--- a/crates/compiler/mono/src/layout.rs
+++ b/crates/compiler/mono/src/layout.rs
@@ -1832,6 +1832,10 @@ impl<'a> LambdaSet<'a> {
                     set_with_variables.push((function_symbol, variables.as_slice()));
 
                     last_function_symbol = Some(function_symbol);
+
+                    if let Some(rec_var) = opt_recursion_var.into_variable() {
+                        env.remove_seen(rec_var);
+                    }
                 }
 
                 let (set, set_with_variables) = if has_duplicate_lambda_names {

--- a/crates/compiler/mono/src/layout.rs
+++ b/crates/compiler/mono/src/layout.rs
@@ -37,7 +37,7 @@ roc_error_macros::assert_sizeof_aarch64!(LambdaSet, 5 * 8);
 roc_error_macros::assert_sizeof_wasm!(Builtin, 2 * 4);
 roc_error_macros::assert_sizeof_wasm!(Layout, 6 * 4);
 roc_error_macros::assert_sizeof_wasm!(UnionLayout, 3 * 4);
-roc_error_macros::assert_sizeof_wasm!(LambdaSet, 3 * 4);
+roc_error_macros::assert_sizeof_wasm!(LambdaSet, 5 * 4);
 
 roc_error_macros::assert_sizeof_default!(Builtin, 2 * 8);
 roc_error_macros::assert_sizeof_default!(Layout, 6 * 8);

--- a/crates/compiler/mono/src/layout/intern.rs
+++ b/crates/compiler/mono/src/layout/intern.rs
@@ -18,7 +18,7 @@ macro_rules! cache_interned_layouts {
         impl<'a> Layout<'a> {
             $(
             #[allow(unused)] // for now
-            pub const $name: InLayout<'static> = unsafe { InLayout::from_reserved_index($i) };
+            pub const $name: InLayout<'static> = unsafe { InLayout::from_index($i) };
             )*
         }
 
@@ -244,7 +244,7 @@ impl<'a> InLayout<'a> {
     /// let inserted = interner.insert("something");
     /// assert_eq!(reserved_interned, inserted);
     /// ```
-    const unsafe fn from_reserved_index(index: usize) -> Self {
+    pub(crate) const unsafe fn from_index(index: usize) -> Self {
         Self(index, PhantomData)
     }
 }
@@ -400,7 +400,10 @@ impl<'a> GlobalLayoutInterner<'a> {
                 let mut map = self.0.map.lock();
                 let mut vec = self.0.vec.write();
 
-                let slot = unsafe { InLayout::from_reserved_index(vec.len()) };
+                let slot = unsafe { InLayout::from_index(vec.len()) };
+
+                // dbg!((normalized, normalized_hash, slot));
+
                 let lambda_set = LambdaSet {
                     full_layout: slot,
                     ..normalized
@@ -595,7 +598,7 @@ impl<'a> LayoutInterner<'a> for STLayoutInterner<'a> {
         }
 
         // This lambda set must be new to the interner, reserve a slot and fill it in.
-        let slot = unsafe { InLayout::from_reserved_index(self.vec.len()) };
+        let slot = unsafe { InLayout::from_index(self.vec.len()) };
         let lambda_set = LambdaSet {
             args,
             ret,

--- a/crates/compiler/test_gen/src/gen_primitives.rs
+++ b/crates/compiler/test_gen/src/gen_primitives.rs
@@ -4208,3 +4208,49 @@ fn pattern_as_of_symbol() {
         bool
     );
 }
+
+#[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
+fn function_specialization_information_in_lambda_set_thunk() {
+    assert_evals_to!(
+        indoc!(
+            r###"
+            app "test" provides [main] to "./platform"
+
+            andThen = \{} ->
+                x = 10u8
+                \newFn -> Num.add (newFn {}) x
+
+            between = andThen {}
+
+            main = between \{} -> between \{} -> 10u8
+            "###
+        ),
+        30,
+        u8
+    );
+}
+
+#[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
+fn function_specialization_information_in_lambda_set_thunk_independent_defs() {
+    assert_evals_to!(
+        indoc!(
+            r###"
+            app "test" provides [main] to "./platform"
+
+            andThen = \{} ->
+                x = 10u8
+                \newFn -> Num.add (newFn {}) x
+
+            between1 = andThen {}
+
+            between2 = andThen {}
+
+            main = between1 \{} -> between2 \{} -> 10u8
+            "###
+        ),
+        30,
+        u8
+    );
+}

--- a/crates/compiler/test_gen/src/gen_primitives.rs
+++ b/crates/compiler/test_gen/src/gen_primitives.rs
@@ -3170,6 +3170,7 @@ fn alias_defined_out_of_order() {
 
 #[test]
 #[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
+#[ignore = "TODO https://github.com/roc-lang/roc/issues/4905"]
 fn recursively_build_effect() {
     assert_evals_to!(
         indoc!(

--- a/crates/compiler/test_mono/generated/function_specialization_information_in_lambda_set_thunk.txt
+++ b/crates/compiler/test_mono/generated/function_specialization_information_in_lambda_set_thunk.txt
@@ -1,10 +1,6 @@
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.257 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.257;
-
-procedure Test.1 (Test.8):
-    let Test.3 : I64 = 10i64;
-    ret Test.3;
+    let Num.256 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.256;
 
 procedure Test.1 (Test.8):
     let Test.3 : I64 = 10i64;
@@ -15,35 +11,34 @@ procedure Test.2 ():
     let Test.12 : I64 = CallByName Test.1 Test.13;
     ret Test.12;
 
-procedure Test.2 ():
-    let Test.24 : {} = Struct {};
-    let Test.23 : I64 = CallByName Test.1 Test.24;
-    ret Test.23;
-
 procedure Test.4 (Test.5, Test.3):
     let Test.18 : {} = Struct {};
-    let Test.17 : I64 = CallByName Test.6 Test.18;
-    let Test.16 : I64 = CallByName Num.19 Test.17 Test.3;
-    ret Test.16;
+    joinpoint Test.19 Test.17:
+        let Test.16 : I64 = CallByName Num.19 Test.17 Test.3;
+        ret Test.16;
+    in
+    switch Test.5:
+        case 0:
+            let Test.20 : I64 = CallByName Test.6 Test.18;
+            jump Test.19 Test.20;
+    
+        default:
+            let Test.21 : I64 = CallByName Test.7 Test.18;
+            jump Test.19 Test.21;
+    
 
-procedure Test.4 (Test.5, Test.3):
-    let Test.29 : {} = Struct {};
-    let Test.28 : I64 = CallByName Test.7 Test.29;
-    let Test.27 : I64 = CallByName Num.19 Test.28 Test.3;
+procedure Test.6 (Test.22):
+    let Test.25 : Int1 = true;
+    let Test.24 : I64 = CallByName Test.2;
+    let Test.23 : I64 = CallByName Test.4 Test.25 Test.24;
+    ret Test.23;
+
+procedure Test.7 (Test.26):
+    let Test.27 : I64 = 10i64;
     ret Test.27;
 
-procedure Test.6 (Test.19):
-    let Test.22 : {} = Struct {};
-    let Test.21 : I64 = CallByName Test.2;
-    let Test.20 : I64 = CallByName Test.4 Test.22 Test.21;
-    ret Test.20;
-
-procedure Test.7 (Test.30):
-    let Test.31 : I64 = 10i64;
-    ret Test.31;
-
 procedure Test.0 ():
-    let Test.11 : {} = Struct {};
+    let Test.11 : Int1 = false;
     let Test.10 : I64 = CallByName Test.2;
     let Test.9 : I64 = CallByName Test.4 Test.11 Test.10;
     ret Test.9;

--- a/crates/compiler/test_mono/generated/function_specialization_information_in_lambda_set_thunk.txt
+++ b/crates/compiler/test_mono/generated/function_specialization_information_in_lambda_set_thunk.txt
@@ -1,0 +1,49 @@
+procedure Num.19 (#Attr.2, #Attr.3):
+    let Num.257 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.257;
+
+procedure Test.1 (Test.8):
+    let Test.3 : I64 = 10i64;
+    ret Test.3;
+
+procedure Test.1 (Test.8):
+    let Test.3 : I64 = 10i64;
+    ret Test.3;
+
+procedure Test.2 ():
+    let Test.13 : {} = Struct {};
+    let Test.12 : I64 = CallByName Test.1 Test.13;
+    ret Test.12;
+
+procedure Test.2 ():
+    let Test.24 : {} = Struct {};
+    let Test.23 : I64 = CallByName Test.1 Test.24;
+    ret Test.23;
+
+procedure Test.4 (Test.5, Test.3):
+    let Test.18 : {} = Struct {};
+    let Test.17 : I64 = CallByName Test.6 Test.18;
+    let Test.16 : I64 = CallByName Num.19 Test.17 Test.3;
+    ret Test.16;
+
+procedure Test.4 (Test.5, Test.3):
+    let Test.29 : {} = Struct {};
+    let Test.28 : I64 = CallByName Test.7 Test.29;
+    let Test.27 : I64 = CallByName Num.19 Test.28 Test.3;
+    ret Test.27;
+
+procedure Test.6 (Test.19):
+    let Test.22 : {} = Struct {};
+    let Test.21 : I64 = CallByName Test.2;
+    let Test.20 : I64 = CallByName Test.4 Test.22 Test.21;
+    ret Test.20;
+
+procedure Test.7 (Test.30):
+    let Test.31 : I64 = 10i64;
+    ret Test.31;
+
+procedure Test.0 ():
+    let Test.11 : {} = Struct {};
+    let Test.10 : I64 = CallByName Test.2;
+    let Test.9 : I64 = CallByName Test.4 Test.11 Test.10;
+    ret Test.9;

--- a/crates/compiler/test_mono/generated/function_specialization_information_in_lambda_set_thunk_independent_defs.txt
+++ b/crates/compiler/test_mono/generated/function_specialization_information_in_lambda_set_thunk_independent_defs.txt
@@ -1,0 +1,49 @@
+procedure Num.19 (#Attr.2, #Attr.3):
+    let Num.257 : U8 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.257;
+
+procedure Test.1 (Test.9):
+    let Test.4 : U8 = 10i64;
+    ret Test.4;
+
+procedure Test.1 (Test.9):
+    let Test.4 : U8 = 10i64;
+    ret Test.4;
+
+procedure Test.2 ():
+    let Test.14 : {} = Struct {};
+    let Test.13 : U8 = CallByName Test.1 Test.14;
+    ret Test.13;
+
+procedure Test.3 ():
+    let Test.25 : {} = Struct {};
+    let Test.24 : U8 = CallByName Test.1 Test.25;
+    ret Test.24;
+
+procedure Test.5 (Test.6, Test.4):
+    let Test.19 : {} = Struct {};
+    let Test.18 : U8 = CallByName Test.7 Test.19;
+    let Test.17 : U8 = CallByName Num.19 Test.18 Test.4;
+    ret Test.17;
+
+procedure Test.5 (Test.6, Test.4):
+    let Test.30 : {} = Struct {};
+    let Test.29 : U8 = CallByName Test.8 Test.30;
+    let Test.28 : U8 = CallByName Num.19 Test.29 Test.4;
+    ret Test.28;
+
+procedure Test.7 (Test.20):
+    let Test.23 : {} = Struct {};
+    let Test.22 : U8 = CallByName Test.3;
+    let Test.21 : U8 = CallByName Test.5 Test.23 Test.22;
+    ret Test.21;
+
+procedure Test.8 (Test.31):
+    let Test.32 : U8 = 10i64;
+    ret Test.32;
+
+procedure Test.0 ():
+    let Test.12 : {} = Struct {};
+    let Test.11 : U8 = CallByName Test.2;
+    let Test.10 : U8 = CallByName Test.5 Test.12 Test.11;
+    ret Test.10;

--- a/crates/compiler/test_mono/src/tests.rs
+++ b/crates/compiler/test_mono/src/tests.rs
@@ -2408,3 +2408,43 @@ fn pattern_as_of_symbol() {
         "###
     )
 }
+
+#[mono_test]
+fn function_specialization_information_in_lambda_set_thunk() {
+    // https://github.com/roc-lang/roc/issues/4734
+    // https://rwx.notion.site/Let-generalization-Let-s-not-742a3ab23ff742619129dcc848a271cf#6b08b0a203fb443db2d7238a0eb154eb
+    indoc!(
+        r###"
+        app "test" provides [main] to "./platform"
+
+        andThen = \{} ->
+            x = 10
+            \newFn -> Num.add (newFn {}) x
+
+        between = andThen {}
+
+        main = between \{} -> between \{} -> 10
+        "###
+    )
+}
+
+#[mono_test]
+fn function_specialization_information_in_lambda_set_thunk_independent_defs() {
+    // https://github.com/roc-lang/roc/issues/4734
+    // https://rwx.notion.site/Let-generalization-Let-s-not-742a3ab23ff742619129dcc848a271cf#6b08b0a203fb443db2d7238a0eb154eb
+    indoc!(
+        r###"
+        app "test" provides [main] to "./platform"
+
+        andThen = \{} ->
+            x = 10u8
+            \newFn -> Num.add (newFn {}) x
+
+        between1 = andThen {}
+
+        between2 = andThen {}
+
+        main = between1 \{} -> between2 \{} -> 10u8
+        "###
+    )
+}


### PR DESCRIPTION
This fixes #4734 and unblocks some work for glue of closures since that presumably needs argument/return layouts on the lambda set layout.

There are some follow ups I'd like to do after this, including

- https://github.com/roc-lang/roc/issues/4905 (we have one regression due to this problem)
- we can clean up `RawLayout::Function` since all the information needed there is now embedded in lambda sets.

I'll dump benchmarks here soon but I suspect with interning the delta will be very low.