### PR TITLE
Add x86_64 wrapping subtraction support for gen_dev

### DIFF
--- a/crates/compiler/gen_dev/src/generic64/mod.rs
+++ b/crates/compiler/gen_dev/src/generic64/mod.rs
@@ -1029,6 +1029,28 @@ impl<
         }
     }
 
+    fn build_num_sub_wrap(
+        &mut self,
+        dst: &Symbol,
+        src1: &Symbol,
+        src2: &Symbol,
+        layout: &InLayout<'a>,
+    ) {
+        match self.layout_interner.get(*layout) {
+            Layout::Builtin(Builtin::Int(IntWidth::I64 | IntWidth::U64)) => {
+                let dst_reg = self.storage_manager.claim_general_reg(&mut self.buf, dst);
+                let src1_reg = self
+                    .storage_manager
+                    .load_to_general_reg(&mut self.buf, src1);
+                let src2_reg = self
+                    .storage_manager
+                    .load_to_general_reg(&mut self.buf, src2);
+                ASM::sub_reg64_reg64_reg64(&mut self.buf, dst_reg, src1_reg, src2_reg);
+            }
+            x => todo!("NumSubWrap: layout, {:?}", x),
+        }
+    }
+
     fn build_eq(&mut self, dst: &Symbol, src1: &Symbol, src2: &Symbol, arg_layout: &InLayout<'a>) {
         match *arg_layout {
             single_register_int_builtins!() => {

--- a/crates/compiler/gen_dev/src/lib.rs
+++ b/crates/compiler/gen_dev/src/lib.rs
@@ -516,6 +516,22 @@ trait Backend<'a> {
                 );
                 self.build_num_sub(sym, &args[0], &args[1], ret_layout)
             }
+            LowLevel::NumSubWrap => {
+                debug_assert_eq!(
+                    2,
+                    args.len(),
+                    "NumSubWrap: expected to have exactly two argument"
+                );
+                debug_assert_eq!(
+                    arg_layouts[0], arg_layouts[1],
+                    "NumSubWrap: expected all arguments of to have the same layout"
+                );
+                debug_assert_eq!(
+                    arg_layouts[0], *ret_layout,
+                    "NumSubWrap: expected to have the same argument and return layout"
+                );
+                self.build_num_sub_wrap(sym, &args[0], &args[1], ret_layout)
+            }
             LowLevel::NumBitwiseAnd => {
                 if let Layout::Builtin(Builtin::Int(int_width)) = self.interner().get(*ret_layout) {
                     self.build_int_bitwise_and(sym, &args[0], &args[1], int_width)
@@ -794,6 +810,15 @@ trait Backend<'a> {
 
     /// build_num_sub stores the `src1 - src2` difference into dst.
     fn build_num_sub(&mut self, dst: &Symbol, src1: &Symbol, src2: &Symbol, layout: &InLayout<'a>);
+
+    /// build_num_sub_wrap stores the `src1 - src2` difference into dst.
+    fn build_num_sub_wrap(
+        &mut self,
+        dst: &Symbol,
+        src1: &Symbol,
+        src2: &Symbol,
+        layout: &InLayout<'a>,
+    );
 
     /// stores the `src1 & src2` into dst.
     fn build_int_bitwise_and(

--- a/crates/compiler/test_gen/src/gen_num.rs
+++ b/crates/compiler/test_gen/src/gen_num.rs
@@ -1881,7 +1881,7 @@ fn int_sub_overflow() {
 }
 
 #[test]
-#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
+#[cfg(any(feature = "gen-llvm", feature = "gen-dev", feature = "gen-wasm"))]
 fn int_sub_wrap() {
     assert_evals_to!(
         indoc!(


### PR DESCRIPTION
This PR adds `Num.subWrap` support for the `gen_dev` target :)
Closes #3796

As specified in the issue, `Num.sub` currently works without dealing with panicking, so the implementation for `subWrap` can be a copy of `sub` for now.

I've enabled the `int_sub_wrap` test for the `gen-dev` feature