### PR TITLE
surgical linker: remove jump slot relocations and update static symbols

### DIFF
--- a/.github/workflows/basic_cli_build_release.yml
+++ b/.github/workflows/basic_cli_build_release.yml
@@ -24,13 +24,13 @@ jobs:
       # does a build with the surgical linker and also with the legacy linker
       - run: ./ci/build_basic_cli.sh linux_x86_64 "--linker legacy"
 
-      - name: Save .rh1, .rm1 and .o file 
+      - name: Save .rh1, .rm2 and .o file 
         uses: actions/upload-artifact@v3
         with:
           name: linux-x86_64-files
           path: |
+            basic-cli/src/metadata_linux-x86_64.rm2
             basic-cli/src/linux-x86_64.rh1
-            basic-cli/src/metadata_linux-x86_64.rm1
             basic-cli/src/linux-x86_64.o
 
   build-macos-x86_64-files:

--- a/crates/linker/src/lib.rs
+++ b/crates/linker/src/lib.rs
@@ -96,7 +96,7 @@ pub fn build_and_preprocess_host(
 fn metadata_file_name(target: &Triple) -> String {
     let target_triple_str = get_target_triple_str(target);
 
-    format!("metadata_{}.rm1", target_triple_str.unwrap_or("unknown"))
+    format!("metadata_{}.rm2", target_triple_str.unwrap_or("unknown"))
 }
 
 pub fn link_preprocessed_host(

--- a/crates/linker/src/metadata.rs
+++ b/crates/linker/src/metadata.rs
@@ -32,6 +32,7 @@ pub struct Metadata {
     pub plt_addresses: MutMap<String, (u64, u64)>,
     pub surgeries: MutMap<String, Vec<SurgeryEntry>>,
     pub dynamic_symbol_indices: MutMap<String, u64>,
+    pub static_symbol_indices: MutMap<String, u64>,
     pub roc_symbol_vaddresses: MutMap<String, u64>,
     pub exec_len: u64,
     pub load_align_constraint: u64,

--- a/crates/packaging/src/tarball.rs
+++ b/crates/packaging/src/tarball.rs
@@ -153,7 +153,7 @@ fn write_archive<W: Write>(path: &Path, writer: W) -> io::Result<()> {
                     // surgical linker format
                     Some("rh1"),
                     // metadata file
-                    Some("rm1"),
+                    Some("rm2"),
                     // legacy linker formats
                     Some("o"),
                     Some("obj"),

--- a/examples/helloWorld.roc
+++ b/examples/helloWorld.roc
@@ -1,5 +1,5 @@
 app "helloWorld"
-    packages { pf: "https://github.com/roc-lang/basic-cli/releases/download/0.1.3/5SXwdW7rH8QAOnD71IkHcFxCmBEPtFSLAIkclPEgjHQ.tar.br" }
+    packages { pf: "https://github.com/roc-lang/basic-cli/releases/download/0.2.0/8tCohJeXMBUnjo_zdMq0jSaqdYoCWJkWazBd4wa8cQU.tar.br" }
     imports [pf.Stdout]
     provides [main] to pf
 

--- a/examples/parser/examples/letter-counts.roc
+++ b/examples/parser/examples/letter-counts.roc
@@ -1,6 +1,6 @@
 app "example"
     packages {
-        cli: "https://github.com/roc-lang/basic-cli/releases/download/0.1.4/ZucbkSga8hGGXBkR3ipMdF-qp-kurRHeV8fF2vrWaKw.tar.br",
+        cli: "https://github.com/roc-lang/basic-cli/releases/download/0.2.0/8tCohJeXMBUnjo_zdMq0jSaqdYoCWJkWazBd4wa8cQU.tar.br",
         parser: "../package/main.roc",
     }
     imports [


### PR DESCRIPTION
As discussed, pulled this commit from the llvm-15 branch and am submitting it by itself.

This enables the surgical linker to work with BIND_NOW. It does this by disabling the relocations that we deal with manually and defining all symbols.