### PR TITLE
Record changed variables if any nested variable has changed

### DIFF
--- a/crates/cli/tests/cli_run.rs
+++ b/crates/cli/tests/cli_run.rs
@@ -665,7 +665,6 @@ mod cli_run {
     }
 
     #[test]
-    #[ignore = "https://github.com/roc-lang/roc/issues/4919"]
     fn hello_gui() {
         test_roc_app_slim(
             "examples/gui",


### PR DESCRIPTION
When we unify variables in mono, we must invalidate the sections of the layout cache reached by those variables. Previously we did this by recording changed variables as those that were `merge`d. However this is not enough; we must also record all the parent types they came from. The reason is we may have something like

```
Alias (Foo, a) ~ Alias (Bar, U8)
```

where we will merge `a = U8` but we do not merge the aliases.

Closes #4919