### PR TITLE
gen_dev: x86 Add `List.withCapacity` implementation

### DIFF
--- a/crates/compiler/gen_dev/src/generic64/mod.rs
+++ b/crates/compiler/gen_dev/src/generic64/mod.rs
@@ -1274,6 +1274,73 @@ impl<
         self.storage_manager.list_len(&mut self.buf, dst, list);
     }
 
+    fn build_list_with_capacity(
+        &mut self,
+        dst: &Symbol,
+        capacity: Symbol,
+        capacity_layout: InLayout<'a>,
+        ret_layout: &InLayout<'a>,
+    ) {
+        // List alignment argument (u32).
+        let u32_layout = Layout::U32;
+        let list_alignment = self.layout_interner.alignment_bytes(*ret_layout);
+        self.load_literal(
+            &Symbol::DEV_TMP,
+            &u32_layout,
+            &Literal::Int((list_alignment as i128).to_ne_bytes()),
+        );
+
+        // Load element_width argument (usize).
+        let u64_layout = Layout::U64;
+        let element_width = self.layout_interner.stack_size(*ret_layout);
+        self.load_literal(
+            &Symbol::DEV_TMP2,
+            &u64_layout,
+            &Literal::Int((element_width as i128).to_ne_bytes()),
+        );
+
+        // Setup the return location.
+        let base_offset = self
+            .storage_manager
+            .claim_stack_area(dst, self.layout_interner.stack_size(*ret_layout));
+
+        let lowlevel_args = bumpalo::vec![
+        in self.env.arena;
+            capacity,
+            // alignment
+            Symbol::DEV_TMP,
+            // element_width
+            Symbol::DEV_TMP2,
+         ];
+        let lowlevel_arg_layouts = bumpalo::vec![
+        in self.env.arena;
+            capacity_layout,
+            u32_layout,
+            u64_layout,
+        ];
+
+        self.build_fn_call(
+            &Symbol::DEV_TMP3,
+            bitcode::LIST_WITH_CAPACITY.to_string(),
+            &lowlevel_args,
+            &lowlevel_arg_layouts,
+            &ret_layout,
+        );
+        self.free_symbol(&Symbol::DEV_TMP);
+        self.free_symbol(&Symbol::DEV_TMP2);
+
+        // Copy from list to the output record.
+        self.storage_manager.copy_symbol_to_stack_offset(
+            self.layout_interner,
+            &mut self.buf,
+            base_offset,
+            &Symbol::DEV_TMP3,
+            &ret_layout,
+        );
+
+        self.free_symbol(&Symbol::DEV_TMP3);
+    }
+
     fn build_list_get_unsafe(
         &mut self,
         dst: &Symbol,

--- a/crates/compiler/gen_dev/src/generic64/mod.rs
+++ b/crates/compiler/gen_dev/src/generic64/mod.rs
@@ -1324,7 +1324,7 @@ impl<
             bitcode::LIST_WITH_CAPACITY.to_string(),
             &lowlevel_args,
             &lowlevel_arg_layouts,
-            &ret_layout,
+            ret_layout,
         );
         self.free_symbol(&Symbol::DEV_TMP);
         self.free_symbol(&Symbol::DEV_TMP2);
@@ -1335,7 +1335,7 @@ impl<
             &mut self.buf,
             base_offset,
             &Symbol::DEV_TMP3,
-            &ret_layout,
+            ret_layout,
         );
 
         self.free_symbol(&Symbol::DEV_TMP3);

--- a/crates/compiler/gen_dev/src/lib.rs
+++ b/crates/compiler/gen_dev/src/lib.rs
@@ -679,6 +679,14 @@ trait Backend<'a> {
                 );
                 self.build_list_len(sym, &args[0])
             }
+            LowLevel::ListWithCapacity => {
+                debug_assert_eq!(
+                    1,
+                    args.len(),
+                    "ListWithCapacity: expected to have exactly one argument"
+                );
+                self.build_list_with_capacity(sym, args[0], arg_layouts[0], ret_layout)
+            }
             LowLevel::ListGetUnsafe => {
                 debug_assert_eq!(
                     2,
@@ -917,6 +925,15 @@ trait Backend<'a> {
 
     /// build_list_len returns the length of a list.
     fn build_list_len(&mut self, dst: &Symbol, list: &Symbol);
+
+    /// build_list_with_capacity creates and returns a list with the given capacity.
+    fn build_list_with_capacity(
+        &mut self,
+        dst: &Symbol,
+        capacity: Symbol,
+        capacity_layout: InLayout<'a>,
+        ret_layout: &InLayout<'a>,
+    );
 
     /// build_list_get_unsafe loads the element from the list at the index.
     fn build_list_get_unsafe(

--- a/crates/compiler/gen_wasm/src/low_level.rs
+++ b/crates/compiler/gen_wasm/src/low_level.rs
@@ -541,12 +541,6 @@ impl<'a> LowLevelCall<'a> {
                 let elem_layout = backend.layout_interner.get(elem_layout);
                 let (elem_width, elem_align) =
                     elem_layout.stack_size_and_alignment(backend.layout_interner, TARGET_INFO);
-                let (spare_local, spare_offset, _) = ensure_symbol_is_in_memory(
-                    backend,
-                    spare,
-                    Layout::usize(TARGET_INFO),
-                    backend.env.arena,
-                );
 
                 // Zig arguments              Wasm types
                 //  (return pointer)           i32
@@ -568,11 +562,9 @@ impl<'a> LowLevelCall<'a> {
 
                 backend.code_builder.i32_const(elem_align as i32);
 
-                backend.code_builder.get_local(spare_local);
-                if spare_offset > 0 {
-                    backend.code_builder.i32_const(spare_offset as i32);
-                    backend.code_builder.i32_add();
-                }
+                backend
+                    .storage
+                    .load_symbols(&mut backend.code_builder, &[spare]);
 
                 backend.code_builder.i32_const(elem_width as i32);
 

--- a/crates/compiler/test_gen/src/gen_list.rs
+++ b/crates/compiler/test_gen/src/gen_list.rs
@@ -3363,8 +3363,27 @@ fn monomorphized_lists() {
 }
 
 #[test]
-#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm", feature = "gen-dev"))]
 fn with_capacity() {
+    assert_evals_to!(
+        indoc!(
+            r#"
+            l : List U64
+            l = List.withCapacity 10
+            
+            l
+            "#
+        ),
+        // Equality check for RocList does not account for capacity
+        (10, RocList::with_capacity(10)),
+        RocList<u64>,
+        |value: RocList<u64>| (value.capacity(), value)
+    );
+}
+
+#[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
+fn with_capacity_append() {
     // see https://github.com/roc-lang/roc/issues/1732
     assert_evals_to!(
         indoc!(
@@ -3376,8 +3395,9 @@ fn with_capacity() {
                 |> List.append 3u64
             "#
         ),
-        RocList::from_slice(&[0, 1, 2, 3]),
-        RocList<u64>
+        (10, RocList::from_slice(&[0, 1, 2, 3])),
+        RocList<u64>,
+        |value: RocList<u64>| (value.capacity(), value)
     );
 }
 

--- a/crates/roc_std/src/roc_list.rs
+++ b/crates/roc_std/src/roc_list.rs
@@ -241,6 +241,7 @@ where
                 }
 
                 // Allocate new memory.
+                self.capacity = slice.len();
                 let new_elements = Self::elems_with_capacity(slice.len());
 
                 // Copy the old elements to the new allocation.
@@ -251,6 +252,7 @@ where
                 new_elements
             }
         } else {
+            self.capacity = slice.len();
             Self::elems_with_capacity(slice.len())
         };
 
@@ -274,8 +276,6 @@ where
             // a incrementing the reference count panics.
             self.length += 1;
         }
-
-        self.capacity = self.length
     }
 }
 


### PR DESCRIPTION
This PR adds and implementation for `List.withCapacity` using the zig builtin `listWithCapacity`.
I've changed the existing `with_capacity` test so we can validate the capacity by itself.

Closes #4930 :)

I would like to add that I have not tried implementing a builtin like this yet, so am unsure about the `load_literal` calls I'm making (are they using the right values?)
The new test is passing, but I'd like to implement `append` to make sure the layout works as intended :)