### PR TITLE
Fixes two typos in index.html

### DIFF
--- a/www/public/index.html
+++ b/www/public/index.html
@@ -149,7 +149,7 @@
   for people to come together through shared experiences, to teach and to learn from one another,
   and to make new friends.</p>
 
-<p>No communtiy is perfect, but a community where people show kindness to each another by default
+<p>No community is perfect, but a community where people show kindness to each another by default
   can be a true joy to participate in. That all starts with friendliness, especially towards
   beginners, and including towards people who prefer other programming languages.
   After all, languages are tools people use to create software, and there's no need for us
@@ -233,7 +233,7 @@ longer to run than generating unoptimized machine code directly.)</p>
   on Zulip! Separately, we're also very interested in fuzzing the compiler, even though we already
   have a sizable list of known bugs there.)</p>
 
-<p>On the communtiy side, so far the community is a friendly bunch, and we want to keep it that way
+<p>On the community side, so far the community is a friendly bunch, and we want to keep it that way
   as it grows! We hope to do that by encouraging a culture of kindness and helping one another out,
   especially by being welcoming towards beginners.</p>
 


### PR DESCRIPTION
Corrects two minor typos on the home page.

"communtiy" -> "community"

Signed-off-by: Jack Kellenberger <107156696+jmkellenberger@users.noreply.github.com>