### PR TITLE
Initial support for linking recursive pointer layouts back to their source layouts

### DIFF
--- a/crates/compiler/alias_analysis/src/lib.rs
+++ b/crates/compiler/alias_analysis/src/lib.rs
@@ -1727,7 +1727,8 @@ fn layout_spec_help<'a>(
 
             builder.add_tuple_type(&[cell_type, inner_type])
         }
-        RecursivePointer => match when_recursive {
+        // TODO(recursive-layouts): update once we have recursive pointer loops
+        RecursivePointer(_) => match when_recursive {
             WhenRecursive::Unreachable => {
                 unreachable!()
             }

--- a/crates/compiler/gen_dev/src/generic64/mod.rs
+++ b/crates/compiler/gen_dev/src/generic64/mod.rs
@@ -1874,7 +1874,7 @@ macro_rules! single_register_int_builtins {
 #[macro_export]
 macro_rules! single_register_integers {
     () => {
-        Layout::BOOL | single_register_int_builtins!() | Layout::RECURSIVE_PTR
+        Layout::BOOL | single_register_int_builtins!()
     };
 }
 

--- a/crates/compiler/gen_dev/src/generic64/mod.rs
+++ b/crates/compiler/gen_dev/src/generic64/mod.rs
@@ -1874,7 +1874,7 @@ macro_rules! single_register_int_builtins {
 #[macro_export]
 macro_rules! single_register_integers {
     () => {
-        Layout::BOOL | single_register_int_builtins!()
+        Layout::BOOL | single_register_int_builtins!() | Layout::OPAQUE_PTR
     };
 }
 

--- a/crates/compiler/gen_llvm/src/llvm/build.rs
+++ b/crates/compiler/gen_llvm/src/llvm/build.rs
@@ -1528,7 +1528,7 @@ fn build_tag_field_value<'a, 'ctx, 'env>(
     value: BasicValueEnum<'ctx>,
     tag_field_layout: InLayout<'a>,
 ) -> BasicValueEnum<'ctx> {
-    if let Layout::RecursivePointer = layout_interner.get(tag_field_layout) {
+    if let Layout::RecursivePointer(_) = layout_interner.get(tag_field_layout) {
         debug_assert!(value.is_pointer_value());
 
         // we store recursive pointers as `i64*`
@@ -2020,7 +2020,7 @@ fn lookup_at_index_ptr<'a, 'ctx, 'env>(
         "load_at_index_ptr_old",
     );
 
-    if let Some(Layout::RecursivePointer) = field_layouts
+    if let Some(Layout::RecursivePointer(_)) = field_layouts
         .get(index as usize)
         .map(|l| layout_interner.get(*l))
     {
@@ -2080,7 +2080,7 @@ fn lookup_at_index_ptr2<'a, 'ctx, 'env>(
         "load_at_index_ptr",
     );
 
-    if let Some(Layout::RecursivePointer) = field_layouts
+    if let Some(Layout::RecursivePointer(_)) = field_layouts
         .get(index as usize)
         .map(|l| layout_interner.get(*l))
     {
@@ -2481,7 +2481,10 @@ pub fn build_exp_stmt<'a, 'ctx, 'env>(
             let mut stack = Vec::with_capacity_in(queue.len(), env.arena);
 
             for (symbol, expr, layout) in queue {
-                debug_assert!(layout_interner.get(*layout) != Layout::RecursivePointer);
+                debug_assert!(!matches!(
+                    layout_interner.get(*layout),
+                    Layout::RecursivePointer(_)
+                ));
 
                 let val = build_exp_expr(
                     env,
@@ -6107,7 +6110,7 @@ pub(crate) enum WhenRecursive<'a> {
 impl<'a> WhenRecursive<'a> {
     pub fn unwrap_recursive_pointer(&self, layout: Layout<'a>) -> Layout<'a> {
         match layout {
-            Layout::RecursivePointer => match self {
+            Layout::RecursivePointer(_) => match self {
                 WhenRecursive::Loop(lay) => Layout::Union(*lay),
                 WhenRecursive::Unreachable => {
                     internal_error!("cannot compare recursive pointers outside of a structure")

--- a/crates/compiler/gen_llvm/src/llvm/compare.rs
+++ b/crates/compiler/gen_llvm/src/llvm/compare.rs
@@ -208,7 +208,7 @@ fn build_eq<'a, 'ctx, 'env>(
             rhs_val,
         ),
 
-        Layout::RecursivePointer => match when_recursive {
+        Layout::RecursivePointer(_) => match when_recursive {
             WhenRecursive::Unreachable => {
                 unreachable!("recursion pointers should never be compared directly")
             }
@@ -417,7 +417,7 @@ fn build_neq<'a, 'ctx, 'env>(
             result.into()
         }
 
-        Layout::RecursivePointer => {
+        Layout::RecursivePointer(_) => {
             unreachable!("recursion pointers should never be compared directly")
         }
         Layout::LambdaSet(_) => unreachable!("cannot compare closure"),
@@ -761,7 +761,7 @@ fn build_struct_eq_help<'a, 'ctx, 'env>(
             .build_extract_value(struct2, index as u32, "eq_field")
             .unwrap();
 
-        let are_equal = if let Layout::RecursivePointer = layout_interner.get(*field_layout) {
+        let are_equal = if let Layout::RecursivePointer(_) = layout_interner.get(*field_layout) {
             match &when_recursive {
                 WhenRecursive::Unreachable => {
                     unreachable!("The current layout should not be recursive, but is")

--- a/crates/compiler/gen_llvm/src/llvm/convert.rs
+++ b/crates/compiler/gen_llvm/src/llvm/convert.rs
@@ -47,7 +47,7 @@ pub fn basic_type_from_layout<'a, 'ctx, 'env>(
             inner_type.ptr_type(AddressSpace::Generic).into()
         }
         Union(union_layout) => basic_type_from_union_layout(env, layout_interner, &union_layout),
-        RecursivePointer => env
+        RecursivePointer(_) => env
             .context
             .i64_type()
             .ptr_type(AddressSpace::Generic)

--- a/crates/compiler/gen_llvm/src/llvm/expect.rs
+++ b/crates/compiler/gen_llvm/src/llvm/expect.rs
@@ -380,7 +380,7 @@ fn build_clone<'a, 'ctx, 'env>(
             )
         }
 
-        Layout::RecursivePointer => match when_recursive {
+        Layout::RecursivePointer(_) => match when_recursive {
             WhenRecursive::Unreachable => {
                 unreachable!("recursion pointers should never be compared directly")
             }

--- a/crates/compiler/gen_llvm/src/llvm/refcounting.rs
+++ b/crates/compiler/gen_llvm/src/llvm/refcounting.rs
@@ -1851,7 +1851,7 @@ fn modify_refcount_nonrecursive_help<'a, 'ctx, 'env>(
                     mode.to_call_mode(fn_val),
                     when_recursive,
                     recursive_ptr_field_value,
-                    Layout::RECURSIVE_PTR,
+                    *field_layout,
                 )
             } else if layout_interner.contains_refcounted(*field_layout) {
                 let field_ptr = env

--- a/crates/compiler/gen_llvm/src/llvm/refcounting.rs
+++ b/crates/compiler/gen_llvm/src/llvm/refcounting.rs
@@ -511,7 +511,7 @@ fn modify_refcount_layout_help<'a, 'ctx, 'env>(
     };
 
     match layout_interner.get(layout) {
-        Layout::RecursivePointer => match when_recursive {
+        Layout::RecursivePointer(_) => match when_recursive {
             WhenRecursive::Unreachable => {
                 unreachable!("recursion pointers should never be hashed directly")
             }
@@ -640,7 +640,7 @@ fn modify_refcount_layout_build_function<'a, 'ctx, 'env>(
             Some(function)
         }
 
-        Layout::RecursivePointer => match when_recursive {
+        Layout::RecursivePointer(_) => match when_recursive {
             WhenRecursive::Unreachable => {
                 unreachable!("recursion pointers cannot be in/decremented directly")
             }
@@ -1326,7 +1326,7 @@ fn build_rec_union_recursive_decrement<'a, 'ctx, 'env>(
         let mut deferred_nonrec = Vec::new_in(env.arena);
 
         for (i, field_layout) in field_layouts.iter().enumerate() {
-            if let Layout::RecursivePointer = layout_interner.get(*field_layout) {
+            if let Layout::RecursivePointer(_) = layout_interner.get(*field_layout) {
                 // this field has type `*i64`, but is really a pointer to the data we want
                 let elem_pointer = env
                     .builder
@@ -1810,7 +1810,7 @@ fn modify_refcount_nonrecursive_help<'a, 'ctx, 'env>(
         );
 
         for (i, field_layout) in field_layouts.iter().enumerate() {
-            if let Layout::RecursivePointer = layout_interner.get(*field_layout) {
+            if let Layout::RecursivePointer(_) = layout_interner.get(*field_layout) {
                 let recursive_union_layout = match when_recursive {
                     WhenRecursive::Unreachable => {
                         panic!("non-recursive tag unions cannot contain naked recursion pointers!");

--- a/crates/compiler/gen_wasm/src/layout.rs
+++ b/crates/compiler/gen_wasm/src/layout.rs
@@ -98,7 +98,7 @@ impl WasmLayout {
                 | NullableUnwrapped { .. },
             )
             | Layout::Boxed(_)
-            | Layout::RecursivePointer => Self::Primitive(PTR_TYPE, PTR_SIZE),
+            | Layout::RecursivePointer(_) => Self::Primitive(PTR_TYPE, PTR_SIZE),
         }
     }
 

--- a/crates/compiler/gen_wasm/src/low_level.rs
+++ b/crates/compiler/gen_wasm/src/low_level.rs
@@ -1952,7 +1952,7 @@ impl<'a> LowLevelCall<'a> {
                 }
             }
 
-            Layout::RecursivePointer => {
+            Layout::RecursivePointer(_) => {
                 internal_error!(
                     "Tried to apply `==` to RecursivePointer values {:?}",
                     self.arguments,

--- a/crates/compiler/mono/src/code_gen_help/equality.rs
+++ b/crates/compiler/mono/src/code_gen_help/equality.rs
@@ -45,7 +45,7 @@ pub fn eq_generic<'a>(
             eq_boxed(root, ident_ids, ctx, layout_interner, inner_layout)
         }
         Layout::LambdaSet(_) => unreachable!("`==` is not defined on functions"),
-        Layout::RecursivePointer => {
+        Layout::RecursivePointer(_) => {
             unreachable!(
                 "Can't perform `==` on RecursivePointer. Should have been replaced by a tag union."
             )
@@ -451,7 +451,7 @@ fn eq_tag_fields<'a>(
     // (If there are more than one, the others will use non-tail recursion)
     let rec_ptr_index = field_layouts
         .iter()
-        .position(|field| matches!(layout_interner.get(*field), Layout::RecursivePointer));
+        .position(|field| matches!(layout_interner.get(*field), Layout::RecursivePointer(_)));
 
     let (tailrec_index, innermost_stmt) = match rec_ptr_index {
         None => {

--- a/crates/compiler/mono/src/code_gen_help/mod.rs
+++ b/crates/compiler/mono/src/code_gen_help/mod.rs
@@ -255,7 +255,10 @@ impl<'a> CodeGenHelp<'a> {
         // debug_assert!(self.debug_recursion_depth < 100);
         self.debug_recursion_depth += 1;
 
-        let layout = if matches!(layout_interner.get(called_layout), Layout::RecursivePointer) {
+        let layout = if matches!(
+            layout_interner.get(called_layout),
+            Layout::RecursivePointer(_)
+        ) {
             let union_layout = ctx.recursive_union.unwrap();
             layout_interner.insert(Layout::Union(union_layout))
         } else {
@@ -494,7 +497,7 @@ impl<'a> CodeGenHelp<'a> {
             }
 
             // This line is the whole point of the function
-            Layout::RecursivePointer => Layout::Union(ctx.recursive_union.unwrap()),
+            Layout::RecursivePointer(_) => Layout::Union(ctx.recursive_union.unwrap()),
         };
         layout_interner.insert(layout)
     }
@@ -535,7 +538,7 @@ impl<'a> CodeGenHelp<'a> {
         for fields in tags.iter() {
             let found_index = fields
                 .iter()
-                .position(|f| matches!(layout_interner.get(*f), Layout::RecursivePointer));
+                .position(|f| matches!(layout_interner.get(*f), Layout::RecursivePointer(_)));
             tailrec_indices.push(found_index);
             can_use_tailrec |= found_index.is_some();
         }
@@ -586,7 +589,7 @@ fn layout_needs_helper_proc<'a>(
         Layout::Union(UnionLayout::NonRecursive(tags)) => !tags.is_empty(),
         Layout::Union(_) => true,
         Layout::LambdaSet(_) => true,
-        Layout::RecursivePointer => false,
+        Layout::RecursivePointer(_) => false,
         Layout::Boxed(_) => true,
     }
 }

--- a/crates/compiler/mono/src/code_gen_help/refcount.rs
+++ b/crates/compiler/mono/src/code_gen_help/refcount.rs
@@ -176,7 +176,7 @@ pub fn refcount_generic<'a>(
                 structure,
             )
         }
-        Layout::RecursivePointer => unreachable!(
+        Layout::RecursivePointer(_) => unreachable!(
             "We should never call a refcounting helper on a RecursivePointer layout directly"
         ),
         Layout::Boxed(inner_layout) => refcount_boxed(
@@ -450,7 +450,7 @@ where
                 .all(|l| is_rc_implemented_yet(interner, *l)),
         },
         Layout::LambdaSet(lambda_set) => is_rc_implemented_yet(interner, lambda_set.representation),
-        Layout::RecursivePointer => true,
+        Layout::RecursivePointer(_) => true,
         Layout::Boxed(_) => true,
     }
 }

--- a/crates/compiler/mono/src/debug/checker.rs
+++ b/crates/compiler/mono/src/debug/checker.rs
@@ -657,7 +657,7 @@ fn resolve_recursive_layout<'a>(
 
     // TODO check if recursive pointer not in recursive union
     let layout = match interner.get(layout) {
-        Layout::RecursivePointer => Layout::Union(when_recursive),
+        Layout::RecursivePointer(_) => Layout::Union(when_recursive),
         Layout::Union(union_layout) => match union_layout {
             UnionLayout::NonRecursive(payloads) => {
                 let payloads = payloads.iter().map(|args| {

--- a/crates/compiler/mono/src/ir.rs
+++ b/crates/compiler/mono/src/ir.rs
@@ -7784,7 +7784,7 @@ fn store_tag_pattern<'a>(
     for (index, (argument, arg_layout)) in arguments.iter().enumerate().rev() {
         let mut arg_layout = *arg_layout;
 
-        if let Layout::RecursivePointer = layout_cache.get_in(arg_layout) {
+        if let Layout::RecursivePointer(_) = layout_cache.get_in(arg_layout) {
             // TODO(recursive-layouts): fix after disjoint rec ptrs
             arg_layout = layout_cache.put_in(Layout::Union(union_layout));
         }
@@ -7868,7 +7868,7 @@ fn store_newtype_pattern<'a>(
     for (index, (argument, arg_layout)) in arguments.iter().enumerate().rev() {
         let mut arg_layout = *arg_layout;
 
-        if let Layout::RecursivePointer = layout_cache.get_in(arg_layout) {
+        if let Layout::RecursivePointer(_) = layout_cache.get_in(arg_layout) {
             arg_layout = layout;
         }
 

--- a/crates/compiler/mono/src/layout.rs
+++ b/crates/compiler/mono/src/layout.rs
@@ -4102,7 +4102,10 @@ where
     };
     criteria.pass_through_recursive_union(rec_var);
 
-    let union_layout = env.cache.put_in(Layout::Union(union_layout));
+    let union_layout = env
+        .cache
+        .interner
+        .insert_recursive(env.arena, Layout::Union(union_layout));
 
     Cacheable(Ok(union_layout), criteria)
 }

--- a/crates/compiler/mono/src/layout/intern.rs
+++ b/crates/compiler/mono/src/layout/intern.rs
@@ -62,7 +62,7 @@ cache_interned_layouts! {
     14, F64,  Layout::Builtin(Builtin::Float(FloatWidth::F64))
     15, DEC,  Layout::Builtin(Builtin::Decimal)
     16, STR,  Layout::Builtin(Builtin::Str)
-    17, RECURSIVE_PTR,  Layout::RecursivePointer
+    17, RECURSIVE_PTR,  Layout::RecursivePointer(Layout::VOID)
 
     ; 18
 }

--- a/crates/compiler/mono/src/layout/intern.rs
+++ b/crates/compiler/mono/src/layout/intern.rs
@@ -1057,12 +1057,12 @@ mod insert_recursive_layout {
 
         let in1 = {
             let mut interner = global.fork();
-            interner.insert_recursive(arena, layout);
+            interner.insert_recursive(arena, layout)
         };
 
         let in2 = {
             let mut interner = global.fork();
-            interner.insert_recursive(arena, layout);
+            interner.insert_recursive(arena, layout)
         };
 
         assert_eq!(in1, in2);
@@ -1103,7 +1103,7 @@ mod insert_recursive_layout {
     #[test]
     fn many_threads_read_write() {
         for _ in 0..100 {
-            let mut arenas: Vec<_> = std::iter::repeat_with(|| Bump::new()).take(10).collect();
+            let mut arenas: Vec<_> = std::iter::repeat_with(Bump::new).take(10).collect();
             let global = GlobalLayoutInterner::with_capacity(2, TARGET_INFO);
             std::thread::scope(|s| {
                 let mut handles = Vec::with_capacity(10);
@@ -1148,12 +1148,12 @@ mod insert_recursive_layout {
 
         let in1 = {
             let mut interner = global.fork();
-            interner.insert_recursive(arena, layout);
+            interner.insert_recursive(arena, layout)
         };
 
         let in2 = {
             let mut st_interner = global.unwrap().unwrap();
-            st_interner.insert_recursive(arena, layout);
+            st_interner.insert_recursive(arena, layout)
         };
 
         assert_eq!(in1, in2);

--- a/crates/compiler/mono/src/layout/intern.rs
+++ b/crates/compiler/mono/src/layout/intern.rs
@@ -5,6 +5,7 @@ use std::{
     sync::Arc,
 };
 
+use bumpalo::Bump;
 use parking_lot::{Mutex, RwLock};
 use roc_builtins::bitcode::{FloatWidth, IntWidth};
 use roc_collections::{default_hasher, BumpMap};
@@ -138,6 +139,11 @@ pub trait LayoutInterner<'a>: Sized {
         set: &'a &'a [(Symbol, &'a [InLayout<'a>])],
         representation: InLayout<'a>,
     ) -> LambdaSet<'a>;
+
+    /// Inserts a recursive layout into the interner.
+    /// Takes a normalized recursive layout with the recursion pointer set to [Layout::VOID].
+    /// Will update the RecursivePointer as appropriate during insertion.
+    fn insert_recursive(&mut self, arena: &'a Bump, normalized_layout: Layout<'a>) -> InLayout<'a>;
 
     /// Retrieves a value from the interner.
     fn get(&self, key: InLayout<'a>) -> Layout<'a>;
@@ -301,6 +307,14 @@ pub struct STLayoutInterner<'a> {
     target_info: TargetInfo,
 }
 
+/// Interner constructed with an exclusive lock over [GlobalLayoutInterner]
+struct LockedGlobalInterner<'a, 'r> {
+    map: &'r mut BumpMap<Layout<'a>, InLayout<'a>>,
+    normalized_lambda_set_map: &'r mut BumpMap<LambdaSet<'a>, LambdaSet<'a>>,
+    vec: &'r mut Vec<Layout<'a>>,
+    target_info: TargetInfo,
+}
+
 /// Generic hasher for a value, to be used by all interners.
 ///
 /// This uses the [default_hasher], so interner maps should also rely on [default_hasher].
@@ -426,6 +440,52 @@ impl<'a> GlobalLayoutInterner<'a> {
         }
     }
 
+    fn get_or_insert_hashed_normalized_recursive(
+        &self,
+        arena: &'a Bump,
+        normalized: Layout<'a>,
+        normalized_hash: u64,
+    ) -> WrittenGlobalRecursive<'a> {
+        let mut map = self.0.map.lock();
+        if let Some((_, &interned)) = map
+            .raw_entry()
+            .from_key_hashed_nocheck(normalized_hash, &normalized)
+        {
+            let full_layout = self.0.vec.read()[interned.0];
+            return WrittenGlobalRecursive {
+                interned_layout: interned,
+                full_layout,
+            };
+        }
+
+        let mut vec = self.0.vec.write();
+        let mut normalized_lambda_set_map = self.0.normalized_lambda_set_map.lock();
+
+        let slot = unsafe { InLayout::from_index(vec.len()) };
+        vec.push(Layout::VOID_NAKED);
+
+        let mut interner = LockedGlobalInterner {
+            map: &mut map,
+            normalized_lambda_set_map: &mut normalized_lambda_set_map,
+            vec: &mut vec,
+            target_info: self.0.target_info,
+        };
+        let full_layout = reify::reify_recursive_layout(arena, &mut interner, slot, normalized);
+
+        vec[slot.0] = full_layout;
+
+        let _old = map.insert(normalized, slot);
+        debug_assert!(_old.is_none());
+
+        let _old_full_layout = map.insert(full_layout, slot);
+        debug_assert!(_old_full_layout.is_none());
+
+        WrittenGlobalRecursive {
+            interned_layout: slot,
+            full_layout,
+        }
+    }
+
     fn get(&self, interned: InLayout<'a>) -> Layout<'a> {
         let InLayout(index, _) = interned;
         self.0.vec.read()[index]
@@ -438,6 +498,11 @@ impl<'a> GlobalLayoutInterner<'a> {
 
 struct WrittenGlobalLambdaSet<'a> {
     full_lambda_set: LambdaSet<'a>,
+    full_layout: Layout<'a>,
+}
+
+struct WrittenGlobalRecursive<'a> {
+    interned_layout: InLayout<'a>,
     full_layout: Layout<'a>,
 }
 
@@ -514,6 +579,42 @@ impl<'a> LayoutInterner<'a> for TLLayoutInterner<'a> {
         full_lambda_set
     }
 
+    fn insert_recursive(&mut self, arena: &'a Bump, normalized_layout: Layout<'a>) -> InLayout<'a> {
+        // - Check if the normalized layout already has an interned slot. If it does we're done, since no
+        //   recursive layout would ever have have VOID as the recursion pointer.
+        // - If not, allocate a slot and compute the recursive layout with the recursion pointer
+        //   resolving to the new slot.
+        // - Point the resolved and normalized layout to the new slot.
+        let global = &self.parent;
+        let normalized_hash = hash(normalized_layout);
+        let mut new_interned_full_layout = None;
+        let (&mut normalized_layout, &mut interned) = self
+            .map
+            .raw_entry_mut()
+            .from_key_hashed_nocheck(normalized_hash, &normalized_layout)
+            .or_insert_with(|| {
+                let WrittenGlobalRecursive {
+                    interned_layout,
+                    full_layout,
+                } = global.get_or_insert_hashed_normalized_recursive(
+                    arena,
+                    normalized_layout,
+                    normalized_hash,
+                );
+
+                // The new filled-in layout isn't present in our thread; make sure it is for future
+                // reference.
+                new_interned_full_layout = Some(full_layout);
+
+                (normalized_layout, interned_layout)
+            });
+        self.record(normalized_layout, interned);
+        if let Some(full_layout) = new_interned_full_layout {
+            self.record(full_layout, interned);
+        }
+        interned
+    }
+
     fn get(&self, key: InLayout<'a>) -> Layout<'a> {
         if let Some(Some(value)) = self.vec.borrow().get(key.0) {
             return *value;
@@ -565,63 +666,252 @@ impl<'a> STLayoutInterner<'a> {
     }
 }
 
-impl<'a> LayoutInterner<'a> for STLayoutInterner<'a> {
-    fn insert(&mut self, value: Layout<'a>) -> InLayout<'a> {
-        let hash = hash(value);
-        let (_, interned) = self
-            .map
-            .raw_entry_mut()
-            .from_key_hashed_nocheck(hash, &value)
-            .or_insert_with(|| {
-                let interned = InLayout(self.vec.len(), Default::default());
-                self.vec.push(value);
-                (value, interned)
-            });
-        *interned
+macro_rules! st_impl {
+    ($($lt:lifetime)? $interner:ident) => {
+        impl<'a$(, $lt)?> LayoutInterner<'a> for $interner<'a$(, $lt)?> {
+            fn insert(&mut self, value: Layout<'a>) -> InLayout<'a> {
+                let hash = hash(value);
+                let (_, interned) = self
+                    .map
+                    .raw_entry_mut()
+                    .from_key_hashed_nocheck(hash, &value)
+                    .or_insert_with(|| {
+                        let interned = InLayout(self.vec.len(), Default::default());
+                        self.vec.push(value);
+                        (value, interned)
+                    });
+                *interned
+            }
+
+            fn insert_lambda_set(
+                &mut self,
+                args: &'a &'a [InLayout<'a>],
+                ret: InLayout<'a>,
+                set: &'a &'a [(Symbol, &'a [InLayout<'a>])],
+                representation: InLayout<'a>,
+            ) -> LambdaSet<'a> {
+                // IDEA:
+                //   - check if the "normalized" lambda set (with a void full_layout slot) maps to an
+                //     inserted lambda set
+                //   - if so, use that one immediately
+                //   - otherwise, allocate a new slot, intern the lambda set, and then fill the slot in
+                let normalized_lambda_set =
+                    make_normalized_lamdba_set(args, ret, set, representation);
+                if let Some(lambda_set) = self.normalized_lambda_set_map.get(&normalized_lambda_set)
+                {
+                    return *lambda_set;
+                }
+
+                // This lambda set must be new to the interner, reserve a slot and fill it in.
+                let slot = unsafe { InLayout::from_index(self.vec.len()) };
+                let lambda_set = LambdaSet {
+                    args,
+                    ret,
+                    set,
+                    representation,
+                    full_layout: slot,
+                };
+                let filled_slot = self.insert(Layout::LambdaSet(lambda_set));
+                assert_eq!(slot, filled_slot);
+
+                self.normalized_lambda_set_map
+                    .insert(normalized_lambda_set, lambda_set);
+
+                lambda_set
+            }
+
+            fn insert_recursive(
+                &mut self,
+                arena: &'a Bump,
+                normalized_layout: Layout<'a>,
+            ) -> InLayout<'a> {
+                // IDEA:
+                //   - check if the normalized layout (with a void recursion pointer) maps to an
+                //     inserted lambda set
+                //   - if so, use that one immediately
+                //   - otherwise, allocate a new slot, update the recursive layout, and intern
+                if let Some(in_layout) = self.map.get(&normalized_layout) {
+                    return *in_layout;
+                }
+
+                // This recursive layout must be new to the interner, reserve a slot and fill it in.
+                let slot = unsafe { InLayout::from_index(self.vec.len()) };
+                self.vec.push(Layout::VOID_NAKED);
+                let full_layout =
+                    reify::reify_recursive_layout(arena, self, slot, normalized_layout);
+                self.vec[slot.0] = full_layout;
+
+                self.map.insert(normalized_layout, slot);
+                self.map.insert(full_layout, slot);
+
+                slot
+            }
+
+            fn get(&self, key: InLayout<'a>) -> Layout<'a> {
+                let InLayout(index, _) = key;
+                self.vec[index]
+            }
+
+            fn target_info(&self) -> TargetInfo {
+                self.target_info
+            }
+        }
+    };
+}
+
+st_impl!(STLayoutInterner);
+st_impl!('r LockedGlobalInterner);
+
+mod reify {
+    use bumpalo::{collections::Vec, Bump};
+
+    use crate::layout::{Builtin, LambdaSet, Layout, UnionLayout};
+
+    use super::{InLayout, LayoutInterner};
+
+    // TODO: if recursion becomes a problem we could make this iterative
+    pub fn reify_recursive_layout<'a>(
+        arena: &'a Bump,
+        interner: &mut impl LayoutInterner<'a>,
+        slot: InLayout<'a>,
+        normalized_layout: Layout<'a>,
+    ) -> Layout<'a> {
+        match normalized_layout {
+            Layout::Builtin(builtin) => {
+                Layout::Builtin(reify_builtin(arena, interner, slot, builtin))
+            }
+            Layout::Struct {
+                field_order_hash,
+                field_layouts,
+            } => Layout::Struct {
+                field_order_hash,
+                field_layouts: reify_layout_slice(arena, interner, slot, field_layouts),
+            },
+            Layout::Boxed(lay) => Layout::Boxed(reify_layout(arena, interner, slot, lay)),
+            Layout::Union(un) => Layout::Union(reify_union(arena, interner, slot, un)),
+            Layout::LambdaSet(ls) => Layout::LambdaSet(reify_lambda_set(arena, interner, slot, ls)),
+            Layout::RecursivePointer(l) => {
+                debug_assert_eq!(
+                    l,
+                    Layout::VOID,
+                    "normalized layouts must always have VOID as the recursive pointer!"
+                );
+                Layout::RecursivePointer(slot)
+            }
+        }
     }
 
-    fn insert_lambda_set(
-        &mut self,
-        args: &'a &'a [InLayout<'a>],
-        ret: InLayout<'a>,
-        set: &'a &'a [(Symbol, &'a [InLayout<'a>])],
-        representation: InLayout<'a>,
-    ) -> LambdaSet<'a> {
-        // IDEA:
-        //   - check if the "normalized" lambda set (with a void full_layout slot) maps to an
-        //     inserted lambda set
-        //   - if so, use that one immediately
-        //   - otherwise, allocate a new slot, intern the lambda set, and then fill the slot in
-        let normalized_lambda_set = make_normalized_lamdba_set(args, ret, set, representation);
-        if let Some(lambda_set) = self.normalized_lambda_set_map.get(&normalized_lambda_set) {
-            return *lambda_set;
-        }
+    fn reify_layout<'a>(
+        arena: &'a Bump,
+        interner: &mut impl LayoutInterner<'a>,
+        slot: InLayout<'a>,
+        layout: InLayout<'a>,
+    ) -> InLayout<'a> {
+        let layout = reify_recursive_layout(arena, interner, slot, interner.get(layout));
+        interner.insert(layout)
+    }
 
-        // This lambda set must be new to the interner, reserve a slot and fill it in.
-        let slot = unsafe { InLayout::from_index(self.vec.len()) };
-        let lambda_set = LambdaSet {
+    fn reify_layout_slice<'a>(
+        arena: &'a Bump,
+        interner: &mut impl LayoutInterner<'a>,
+        slot: InLayout<'a>,
+        layouts: &[InLayout<'a>],
+    ) -> &'a [InLayout<'a>] {
+        let mut slice = Vec::with_capacity_in(layouts.len(), arena);
+        for &layout in layouts {
+            slice.push(reify_layout(arena, interner, slot, layout));
+        }
+        slice.into_bump_slice()
+    }
+
+    fn reify_layout_slice_slice<'a>(
+        arena: &'a Bump,
+        interner: &mut impl LayoutInterner<'a>,
+        slot: InLayout<'a>,
+        layouts: &[&[InLayout<'a>]],
+    ) -> &'a [&'a [InLayout<'a>]] {
+        let mut slice = Vec::with_capacity_in(layouts.len(), arena);
+        for &layouts in layouts {
+            slice.push(reify_layout_slice(arena, interner, slot, layouts));
+        }
+        slice.into_bump_slice()
+    }
+
+    fn reify_builtin<'a>(
+        arena: &'a Bump,
+        interner: &mut impl LayoutInterner<'a>,
+        slot: InLayout<'a>,
+        builtin: Builtin<'a>,
+    ) -> Builtin<'a> {
+        match builtin {
+            Builtin::Int(_)
+            | Builtin::Float(_)
+            | Builtin::Bool
+            | Builtin::Decimal
+            | Builtin::Str => builtin,
+            Builtin::List(elem) => Builtin::List(reify_layout(arena, interner, slot, elem)),
+        }
+    }
+
+    fn reify_union<'a>(
+        arena: &'a Bump,
+        interner: &mut impl LayoutInterner<'a>,
+        slot: InLayout<'a>,
+        union: UnionLayout<'a>,
+    ) -> UnionLayout<'a> {
+        match union {
+            UnionLayout::NonRecursive(tags) => {
+                UnionLayout::NonRecursive(reify_layout_slice_slice(arena, interner, slot, tags))
+            }
+            UnionLayout::Recursive(tags) => {
+                UnionLayout::Recursive(reify_layout_slice_slice(arena, interner, slot, tags))
+            }
+            UnionLayout::NonNullableUnwrapped(fields) => {
+                UnionLayout::NonNullableUnwrapped(reify_layout_slice(arena, interner, slot, fields))
+            }
+            UnionLayout::NullableWrapped {
+                nullable_id,
+                other_tags,
+            } => UnionLayout::NullableWrapped {
+                nullable_id,
+                other_tags: reify_layout_slice_slice(arena, interner, slot, other_tags),
+            },
+            UnionLayout::NullableUnwrapped {
+                nullable_id,
+                other_fields,
+            } => UnionLayout::NullableUnwrapped {
+                nullable_id,
+                other_fields: reify_layout_slice(arena, interner, slot, other_fields),
+            },
+        }
+    }
+
+    fn reify_lambda_set<'a>(
+        arena: &'a Bump,
+        interner: &mut impl LayoutInterner<'a>,
+        slot: InLayout<'a>,
+        lambda_set: LambdaSet<'a>,
+    ) -> LambdaSet<'a> {
+        let LambdaSet {
             args,
             ret,
             set,
             representation,
-            full_layout: slot,
+            full_layout: _,
+        } = lambda_set;
+
+        let args = reify_layout_slice(arena, interner, slot, args);
+        let ret = reify_layout(arena, interner, slot, ret);
+        let set = {
+            let mut new_set = Vec::with_capacity_in(set.len(), arena);
+            for (lambda, captures) in set.iter() {
+                new_set.push((*lambda, reify_layout_slice(arena, interner, slot, captures)));
+            }
+            new_set.into_bump_slice()
         };
-        let filled_slot = self.insert(Layout::LambdaSet(lambda_set));
-        assert_eq!(slot, filled_slot);
+        let representation = reify_layout(arena, interner, slot, representation);
 
-        self.normalized_lambda_set_map
-            .insert(normalized_lambda_set, lambda_set);
-
-        lambda_set
-    }
-
-    fn get(&self, key: InLayout<'a>) -> Layout<'a> {
-        let InLayout(index, _) = key;
-        self.vec[index]
-    }
-
-    fn target_info(&self) -> TargetInfo {
-        self.target_info
+        interner.insert_lambda_set(arena.alloc(args), ret, arena.alloc(set), representation)
     }
 }
 
@@ -630,7 +920,7 @@ mod insert_lambda_set {
     use roc_module::symbol::Symbol;
     use roc_target::TargetInfo;
 
-    use crate::layout::Layout;
+    use crate::layout::{LambdaSet, Layout};
 
     use super::{GlobalLayoutInterner, InLayout, LayoutInterner};
 
@@ -652,9 +942,9 @@ mod insert_lambda_set {
                 let mut interner = global.fork();
                 handles.push(std::thread::spawn(move || {
                     interner.insert_lambda_set(TEST_ARGS, TEST_RET, set, repr)
-                }));
+                }))
             }
-            let ins: Vec<_> = handles.into_iter().map(|t| t.join().unwrap()).collect();
+            let ins: Vec<LambdaSet> = handles.into_iter().map(|t| t.join().unwrap()).collect();
             let interned = ins[0];
             assert!(ins.iter().all(|in2| interned == *in2));
         }
@@ -703,6 +993,151 @@ mod insert_lambda_set {
         let mut interner = global.fork();
 
         let in2 = interner.insert_lambda_set(TEST_ARGS, TEST_RET, set, repr);
+
+        assert_eq!(in1, in2);
+    }
+}
+
+#[cfg(test)]
+mod insert_recursive_layout {
+    use bumpalo::Bump;
+    use roc_target::TargetInfo;
+
+    use crate::layout::{Builtin, InLayout, Layout, UnionLayout};
+
+    use super::{GlobalLayoutInterner, LayoutInterner, TLLayoutInterner};
+
+    const TARGET_INFO: TargetInfo = TargetInfo::default_x86_64();
+
+    fn make_layout<'a>(arena: &'a Bump, interner: &mut impl LayoutInterner<'a>) -> Layout<'a> {
+        Layout::Union(UnionLayout::Recursive(&*arena.alloc([
+            &*arena.alloc([interner.insert(Layout::Builtin(Builtin::List(Layout::RECURSIVE_PTR)))]),
+            &*arena.alloc_slice_fill_iter([interner.insert(Layout::struct_no_name_order(
+                &*arena.alloc([Layout::RECURSIVE_PTR]),
+            ))]),
+        ])))
+    }
+
+    fn get_rec_ptr_index<'a>(interner: &TLLayoutInterner<'a>, layout: InLayout<'a>) -> usize {
+        match interner.get(layout) {
+            Layout::Union(UnionLayout::Recursive(&[&[l1], &[l2]])) => {
+                match (interner.get(l1), interner.get(l2)) {
+                    (
+                        Layout::Builtin(Builtin::List(l1)),
+                        Layout::Struct {
+                            field_order_hash: _,
+                            field_layouts: &[l2],
+                        },
+                    ) => match (interner.get(l1), interner.get(l2)) {
+                        (Layout::RecursivePointer(i1), Layout::RecursivePointer(i2)) => {
+                            assert_eq!(i1, i2);
+                            assert_ne!(i1, Layout::VOID);
+                            i1.0
+                        }
+                        _ => unreachable!(),
+                    },
+                    _ => unreachable!(),
+                }
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    #[test]
+    fn write_two_threads() {
+        let arena = &Bump::new();
+        let global = GlobalLayoutInterner::with_capacity(2, TARGET_INFO);
+        let layout = {
+            let mut interner = global.fork();
+            make_layout(arena, &mut interner)
+        };
+
+        let in1 = {
+            let mut interner = global.fork();
+            interner.insert_recursive(arena, layout);
+        };
+
+        let in2 = {
+            let mut interner = global.fork();
+            interner.insert_recursive(arena, layout);
+        };
+
+        assert_eq!(in1, in2);
+    }
+
+    #[test]
+    fn many_threads_read_write() {
+        for _ in 0..100 {
+            let mut arenas: Vec<_> = std::iter::repeat_with(|| Bump::new()).take(10).collect();
+            let global = GlobalLayoutInterner::with_capacity(2, TARGET_INFO);
+            std::thread::scope(|s| {
+                let mut handles = Vec::with_capacity(10);
+                for arena in arenas.iter_mut() {
+                    let mut interner = global.fork();
+                    let handle = s.spawn(move || {
+                        let layout = make_layout(arena, &mut interner);
+                        let in_layout = interner.insert_recursive(arena, layout);
+                        (in_layout, get_rec_ptr_index(&interner, in_layout))
+                    });
+                    handles.push(handle);
+                }
+                let ins: Vec<(InLayout, usize)> =
+                    handles.into_iter().map(|t| t.join().unwrap()).collect();
+                let interned = ins[0];
+                assert!(ins.iter().all(|in2| interned == *in2));
+            });
+        }
+    }
+
+    #[test]
+    fn insert_then_reintern() {
+        let arena = &Bump::new();
+        let global = GlobalLayoutInterner::with_capacity(2, TARGET_INFO);
+        let mut interner = global.fork();
+
+        let layout = make_layout(arena, &mut interner);
+        let interned_layout = interner.insert_recursive(arena, layout);
+        let full_layout = interner.get(interned_layout);
+        assert_ne!(layout, full_layout);
+        assert_eq!(interner.insert(full_layout), interned_layout);
+    }
+
+    #[test]
+    fn write_global_then_single_threaded() {
+        let arena = &Bump::new();
+        let global = GlobalLayoutInterner::with_capacity(2, TARGET_INFO);
+        let layout = {
+            let mut interner = global.fork();
+            make_layout(arena, &mut interner)
+        };
+
+        let in1 = {
+            let mut interner = global.fork();
+            interner.insert_recursive(arena, layout);
+        };
+
+        let in2 = {
+            let mut st_interner = global.unwrap().unwrap();
+            st_interner.insert_recursive(arena, layout);
+        };
+
+        assert_eq!(in1, in2);
+    }
+
+    #[test]
+    fn write_single_threaded_then_global() {
+        let arena = &Bump::new();
+        let global = GlobalLayoutInterner::with_capacity(2, TARGET_INFO);
+        let mut st_interner = global.unwrap().unwrap();
+
+        let layout = make_layout(arena, &mut st_interner);
+
+        let in1 = st_interner.insert_recursive(arena, layout);
+
+        let global = st_interner.into_global();
+        let mut interner = global.fork();
+
+        let in2 = interner.insert_recursive(arena, layout);
 
         assert_eq!(in1, in2);
     }

--- a/crates/compiler/mono/src/layout/intern.rs
+++ b/crates/compiler/mono/src/layout/intern.rs
@@ -588,7 +588,7 @@ impl<'a> LayoutInterner<'a> for TLLayoutInterner<'a> {
         let global = &self.parent;
         let normalized_hash = hash(normalized_layout);
         let mut new_interned_full_layout = None;
-        let (&mut normalized_layout, &mut interned) = self
+        let (&mut _, &mut interned) = self
             .map
             .raw_entry_mut()
             .from_key_hashed_nocheck(normalized_hash, &normalized_layout)

--- a/crates/glue/src/types.rs
+++ b/crates/glue/src/types.rs
@@ -1464,7 +1464,7 @@ fn add_tag_union<'a>(
         Layout::LambdaSet(_) => {
             todo!();
         }
-        Layout::RecursivePointer => {
+        Layout::RecursivePointer(_) => {
             // A single-tag union which only wraps itself is erroneous and should have
             // been turned into an error earlier in the process.
             unreachable!();

--- a/crates/repl_eval/src/eval.rs
+++ b/crates/repl_eval/src/eval.rs
@@ -499,7 +499,7 @@ fn jit_to_ast_help<'a, A: ReplApp<'a>>(
                 },
             )
         }
-        Layout::RecursivePointer => {
+        Layout::RecursivePointer(_) => {
             unreachable!("RecursivePointers can only be inside structures")
         }
         Layout::LambdaSet(_) => OPAQUE_FUNCTION,
@@ -632,7 +632,7 @@ fn addr_to_ast<'a, M: ReplAppMemory>(
                 );
             }
         },
-        (_, Layout::RecursivePointer) => match (raw_content, when_recursive) {
+        (_, Layout::RecursivePointer(_)) => match (raw_content, when_recursive) {
             (
                 Content::RecursionVar {
                     structure,


### PR DESCRIPTION
This patch adds initial support for linking `RecursionPtr`s back to the union layouts they represent.

This is necessary for certain things like intersection recursive layouts, and gives us a path forward for addressing e.g. https://github.com/roc-lang/roc/issues/4905. It should also remove the need for utilities like `WhenRecursive` that the backends use.

Currently the compiler does not read the linked-back recursive pointers, but it does construct them correctly, and use them in layout comparisons. The bulk of the interesting changes are in `layout/intern.rs` , where a new `insert_recursive` method for interning recursive layouts has been introduced. The idea is that while building up a recursive layout, we will in its uses of `RecursivePtr` as `RecursivePtr(VOID)`, a recursive layout that will obviously never exist. This is the "normalized layout". When we go to intern the layout, if the normalized layout already has an entry, we use that. Otherwise, the recursive layout must be fresh, and we allocate it a slot `I`. We then replace all instances of `RecursivePtr(VOID)` in the layout with `RecursivePtr(I)`, and then map both the normalized and corrected layout to the interned slot `I`.