### PR TITLE
Enable wasm dict tests

### DIFF
--- a/crates/compiler/mono/src/code_gen_help/mod.rs
+++ b/crates/compiler/mono/src/code_gen_help/mod.rs
@@ -125,16 +125,6 @@ impl<'a> CodeGenHelp<'a> {
         modify: &ModifyRc,
         following: &'a Stmt<'a>,
     ) -> (&'a Stmt<'a>, Vec<'a, (Symbol, ProcLayout<'a>)>) {
-        if !refcount::is_rc_implemented_yet(layout_interner, layout) {
-            // Just a warning, so we can decouple backend development from refcounting development.
-            // When we are closer to completion, we can change it to a panic.
-            println!(
-                "WARNING! MEMORY LEAK! Refcounting not yet implemented for Layout {:?}",
-                layout
-            );
-            return (following, Vec::new_in(self.arena));
-        }
-
         let op = match modify {
             ModifyRc::Inc(..) => HelperOp::Inc,
             ModifyRc::Dec(_) => HelperOp::Dec,

--- a/crates/compiler/mono/src/code_gen_help/refcount.rs
+++ b/crates/compiler/mono/src/code_gen_help/refcount.rs
@@ -74,7 +74,7 @@ pub fn refcount_stmt<'a>(
 
         ModifyRc::DecRef(structure) => {
             match layout_interner.get(layout) {
-                // Str has no children, so we might as well do what we normally do and call the helper.
+                // Str has no children, so Dec is the same as DecRef.
                 Layout::Builtin(Builtin::Str) => {
                     ctx.op = HelperOp::Dec;
                     refcount_stmt(
@@ -139,7 +139,6 @@ pub fn refcount_generic<'a>(
             ident_ids,
             ctx,
             layout_interner,
-            layout,
             elem_layout,
             structure,
         ),
@@ -725,7 +724,6 @@ fn refcount_list<'a>(
     ident_ids: &mut IdentIds,
     ctx: &mut Context<'a>,
     layout_interner: &mut STLayoutInterner<'a>,
-    layout: InLayout,
     elem_layout: InLayout<'a>,
     structure: Symbol,
 ) -> Stmt<'a> {
@@ -774,7 +772,7 @@ fn refcount_list<'a>(
     //
 
     let rc_ptr = root.create_symbol(ident_ids, "rc_ptr");
-    let alignment = layout_interner.alignment_bytes(layout);
+    let elem_alignment = layout_interner.alignment_bytes(elem_layout);
 
     let ret_stmt = rc_return_stmt(root, ident_ids, ctx);
     let modify_list = modify_refcount(
@@ -782,7 +780,7 @@ fn refcount_list<'a>(
         ident_ids,
         ctx,
         rc_ptr,
-        alignment,
+        elem_alignment,
         arena.alloc(ret_stmt),
     );
 

--- a/crates/compiler/mono/src/code_gen_help/refcount.rs
+++ b/crates/compiler/mono/src/code_gen_help/refcount.rs
@@ -127,8 +127,6 @@ pub fn refcount_generic<'a>(
     layout: InLayout<'a>,
     structure: Symbol,
 ) -> Stmt<'a> {
-    debug_assert!(is_rc_implemented_yet(layout_interner, layout));
-
     match layout_interner.get(layout) {
         Layout::Builtin(Builtin::Int(_) | Builtin::Float(_) | Builtin::Bool | Builtin::Decimal) => {
             // Generate a dummy function that immediately returns Unit
@@ -414,44 +412,6 @@ pub fn refcount_reset_proc_body<'a>(
     };
 
     rc_ptr_stmt
-}
-
-// Check if refcounting is implemented yet. In the long term, this will be deleted.
-// In the short term, it helps us to skip refcounting and let it leak, so we can make
-// progress incrementally. Kept in sync with generate_procs using assertions.
-pub fn is_rc_implemented_yet<'a, I>(interner: &I, layout: InLayout<'a>) -> bool
-where
-    I: LayoutInterner<'a>,
-{
-    use UnionLayout::*;
-
-    match interner.get(layout) {
-        Layout::Builtin(Builtin::List(elem_layout)) => is_rc_implemented_yet(interner, elem_layout),
-        Layout::Builtin(_) => true,
-        Layout::Struct { field_layouts, .. } => field_layouts
-            .iter()
-            .all(|l| is_rc_implemented_yet(interner, *l)),
-        Layout::Union(union_layout) => match union_layout {
-            NonRecursive(tags) => tags
-                .iter()
-                .all(|fields| fields.iter().all(|l| is_rc_implemented_yet(interner, *l))),
-            Recursive(tags) => tags
-                .iter()
-                .all(|fields| fields.iter().all(|l| is_rc_implemented_yet(interner, *l))),
-            NonNullableUnwrapped(fields) => {
-                fields.iter().all(|l| is_rc_implemented_yet(interner, *l))
-            }
-            NullableWrapped { other_tags, .. } => other_tags
-                .iter()
-                .all(|fields| fields.iter().all(|l| is_rc_implemented_yet(interner, *l))),
-            NullableUnwrapped { other_fields, .. } => other_fields
-                .iter()
-                .all(|l| is_rc_implemented_yet(interner, *l)),
-        },
-        Layout::LambdaSet(lambda_set) => is_rc_implemented_yet(interner, lambda_set.representation),
-        Layout::RecursivePointer(_) => true,
-        Layout::Boxed(_) => true,
-    }
 }
 
 fn rc_return_stmt<'a>(

--- a/crates/compiler/test_gen/src/gen_dict.rs
+++ b/crates/compiler/test_gen/src/gen_dict.rs
@@ -16,7 +16,7 @@ use indoc::indoc;
 use roc_std::{RocList, RocStr};
 
 #[test]
-#[cfg(any(feature = "gen-llvm"))]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
 fn dict_empty_len() {
     assert_evals_to!(
         indoc!(
@@ -30,7 +30,7 @@ fn dict_empty_len() {
 }
 
 #[test]
-#[cfg(any(feature = "gen-llvm"))]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
 fn dict_insert_empty() {
     assert_evals_to!(
         indoc!(
@@ -46,7 +46,7 @@ fn dict_insert_empty() {
 }
 
 #[test]
-#[cfg(any(feature = "gen-llvm"))]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
 fn dict_empty_contains() {
     assert_evals_to!(
         indoc!(
@@ -63,7 +63,7 @@ fn dict_empty_contains() {
 }
 
 #[test]
-#[cfg(any(feature = "gen-llvm"))]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
 fn dict_nonempty_contains() {
     assert_evals_to!(
         indoc!(
@@ -81,7 +81,7 @@ fn dict_nonempty_contains() {
 
 #[test]
 #[ignore = "TODO figure out why this is broken with llvm wasm tests"]
-#[cfg(any(feature = "gen-llvm"))]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
 fn dict_empty_remove() {
     assert_evals_to!(
         indoc!(
@@ -100,7 +100,7 @@ fn dict_empty_remove() {
 }
 
 #[test]
-#[cfg(any(feature = "gen-llvm"))]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
 fn dict_nonempty_remove() {
     assert_evals_to!(
         indoc!(
@@ -120,7 +120,7 @@ fn dict_nonempty_remove() {
 }
 
 #[test]
-#[cfg(any(feature = "gen-llvm"))]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
 fn dict_nonempty_get() {
     assert_evals_to!(
         indoc!(
@@ -256,11 +256,7 @@ fn from_list_with_fold_reallocates() {
 }
 
 #[test]
-#[cfg(any(feature = "gen-llvm"))]
-// TODO: Re-enable this test for wasm.
-// Currently it causes "[trap] out of bounds memory access" due to the small strings.
-// I was unable to find the root cause and with llvm and valgrind it passes with no issues.
-// #[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
 fn small_str_keys() {
     assert_evals_to!(
         indoc!(
@@ -269,14 +265,11 @@ fn small_str_keys() {
             myDict =
                 Dict.empty {}
                     |> Dict.insert "a" 100
-                    |> Dict.insert "b" 100
-                    |> Dict.insert "c" 100
-
 
             Dict.keys myDict
             "#
         ),
-        RocList::from_slice(&["a".into(), "b".into(), "c".into(),],),
+        RocList::from_slice(&["a".into()]),
         RocList<RocStr>
     );
 }
@@ -332,7 +325,7 @@ fn big_str_values() {
 }
 
 #[test]
-#[cfg(any(feature = "gen-llvm"))]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
 fn unit_values() {
     assert_evals_to!(
         indoc!(
@@ -354,7 +347,7 @@ fn unit_values() {
 }
 
 #[test]
-#[cfg(any(feature = "gen-llvm"))]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
 fn single() {
     assert_evals_to!(
         indoc!(
@@ -372,7 +365,7 @@ fn single() {
 }
 
 #[test]
-#[cfg(any(feature = "gen-llvm"))]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
 fn insert_all() {
     assert_evals_to!(
         indoc!(
@@ -410,7 +403,7 @@ fn insert_all_prefer_second() {
 }
 
 #[test]
-#[cfg(any(feature = "gen-llvm"))]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
 fn keep_shared() {
     assert_evals_to!(
         indoc!(
@@ -473,7 +466,7 @@ fn keep_shared_prefer_first() {
 }
 
 #[test]
-#[cfg(any(feature = "gen-llvm"))]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
 fn remove_all() {
     assert_evals_to!(
         indoc!(
@@ -505,7 +498,7 @@ fn remove_all() {
 }
 
 #[test]
-#[cfg(any(feature = "gen-llvm"))]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
 fn remove_all_prefer_first() {
     assert_evals_to!(
         indoc!(
@@ -536,7 +529,7 @@ fn remove_all_prefer_first() {
 }
 
 #[test]
-#[cfg(any(feature = "gen-llvm"))]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
 fn walk_sum_keys() {
     assert_evals_to!(
         indoc!(


### PR DESCRIPTION
Closes #4679

#4683 fixed some wasm code gen issues for Dict, and now we can re-enable some tests.

One of the tests uncovered a bug in `mono::code_gen_help` (which generates refcounting code as IR for the dev backends). The `List` refcounting code does some pointer math with the data pointer and an alignment value. But it accidentally used the alignment of the `List` itself rather than the elements inside it.
