### PR TITLE
gen_dev: add `List.reserve` and `List.append` using zig builtins

### DIFF
--- a/crates/compiler/gen_dev/src/generic64/mod.rs
+++ b/crates/compiler/gen_dev/src/generic64/mod.rs
@@ -1341,6 +1341,94 @@ impl<
         self.free_symbol(&Symbol::DEV_TMP3);
     }
 
+    fn build_list_reserve(
+        &mut self,
+        dst: &Symbol,
+        args: &'a [Symbol],
+        arg_layouts: &[InLayout<'a>],
+        ret_layout: &InLayout<'a>,
+    ) {
+        let list = args[0];
+        let list_layout = arg_layouts[0];
+        let spare = args[1];
+        let spare_layout = arg_layouts[1];
+
+        // Load list alignment argument (u32).
+        let u32_layout = Layout::U32;
+        let list_alignment = self.layout_interner.alignment_bytes(list_layout);
+        self.load_literal(
+            &Symbol::DEV_TMP,
+            &u32_layout,
+            &Literal::Int((list_alignment as i128).to_ne_bytes()),
+        );
+
+        // Load element_width argument (usize).
+        let u64_layout = Layout::U64;
+        let element_width = self.layout_interner.stack_size(*ret_layout);
+        self.load_literal(
+            &Symbol::DEV_TMP2,
+            &u64_layout,
+            &Literal::Int((element_width as i128).to_ne_bytes()),
+        );
+
+        // Load UpdateMode.InPlace argument (1u8)
+        let u8_layout = Layout::U8;
+        let update_mode = 1u8;
+        self.load_literal(
+            &Symbol::DEV_TMP3,
+            &u64_layout,
+            &Literal::Int((update_mode as i128).to_ne_bytes()),
+        );
+
+        // Setup the return location.
+        let base_offset = self
+            .storage_manager
+            .claim_stack_area(dst, self.layout_interner.stack_size(*ret_layout));
+
+        let lowlevel_args = bumpalo::vec![
+        in self.env.arena;
+            list,
+            // alignment
+            Symbol::DEV_TMP,
+            spare,
+            // element_width
+            Symbol::DEV_TMP2,
+            // update_mode
+            Symbol::DEV_TMP3,
+
+         ];
+        let lowlevel_arg_layouts = bumpalo::vec![
+        in self.env.arena;
+            list_layout,
+            u32_layout,
+            spare_layout,
+            u64_layout,
+            u8_layout
+        ];
+
+        self.build_fn_call(
+            &Symbol::DEV_TMP4,
+            bitcode::LIST_RESERVE.to_string(),
+            &lowlevel_args,
+            &lowlevel_arg_layouts,
+            &ret_layout,
+        );
+        self.free_symbol(&Symbol::DEV_TMP);
+        self.free_symbol(&Symbol::DEV_TMP2);
+        self.free_symbol(&Symbol::DEV_TMP3);
+
+        // Return list value from fn call
+        self.storage_manager.copy_symbol_to_stack_offset(
+            self.layout_interner,
+            &mut self.buf,
+            base_offset,
+            &Symbol::DEV_TMP4,
+            &ret_layout,
+        );
+
+        self.free_symbol(&Symbol::DEV_TMP4);
+    }
+
     fn build_list_get_unsafe(
         &mut self,
         dst: &Symbol,

--- a/crates/compiler/gen_dev/src/generic64/mod.rs
+++ b/crates/compiler/gen_dev/src/generic64/mod.rs
@@ -1371,9 +1371,9 @@ impl<
             &Literal::Int((element_width as i128).to_ne_bytes()),
         );
 
-        // Load UpdateMode.InPlace argument (1u8)
+        // Load UpdateMode.Immutable argument (0u8)
         let u8_layout = Layout::U8;
-        let update_mode = 1u8;
+        let update_mode = 0u8;
         self.load_literal(
             &Symbol::DEV_TMP3,
             &u64_layout,

--- a/crates/compiler/gen_dev/src/generic64/mod.rs
+++ b/crates/compiler/gen_dev/src/generic64/mod.rs
@@ -1411,7 +1411,7 @@ impl<
             bitcode::LIST_RESERVE.to_string(),
             &lowlevel_args,
             &lowlevel_arg_layouts,
-            &ret_layout,
+            ret_layout,
         );
         self.free_symbol(&Symbol::DEV_TMP);
         self.free_symbol(&Symbol::DEV_TMP2);
@@ -1423,7 +1423,7 @@ impl<
             &mut self.buf,
             base_offset,
             &Symbol::DEV_TMP4,
-            &ret_layout,
+            ret_layout,
         );
 
         self.free_symbol(&Symbol::DEV_TMP4);
@@ -1486,7 +1486,7 @@ impl<
             bitcode::LIST_APPEND_UNSAFE.to_string(),
             &lowlevel_args,
             &lowlevel_arg_layouts,
-            &ret_layout,
+            ret_layout,
         );
         self.free_symbol(&Symbol::DEV_TMP);
         self.free_symbol(&Symbol::DEV_TMP2);
@@ -1497,7 +1497,7 @@ impl<
             &mut self.buf,
             base_offset,
             &Symbol::DEV_TMP3,
-            &ret_layout,
+            ret_layout,
         );
 
         self.free_symbol(&Symbol::DEV_TMP3);

--- a/crates/compiler/gen_dev/src/lib.rs
+++ b/crates/compiler/gen_dev/src/lib.rs
@@ -687,6 +687,14 @@ trait Backend<'a> {
                 );
                 self.build_list_with_capacity(sym, args[0], arg_layouts[0], ret_layout)
             }
+            LowLevel::ListReserve => {
+                debug_assert_eq!(
+                    2,
+                    args.len(),
+                    "ListReserve: expected to have exactly two arguments"
+                );
+                self.build_list_reserve(sym, args, arg_layouts, ret_layout)
+            }
             LowLevel::ListGetUnsafe => {
                 debug_assert_eq!(
                     2,
@@ -932,6 +940,15 @@ trait Backend<'a> {
         dst: &Symbol,
         capacity: Symbol,
         capacity_layout: InLayout<'a>,
+        ret_layout: &InLayout<'a>,
+    );
+
+    /// build_list_reserve enlarges a list to at least accommodate the given capacity.
+    fn build_list_reserve(
+        &mut self,
+        dst: &Symbol,
+        args: &'a [Symbol],
+        arg_layouts: &[InLayout<'a>],
         ret_layout: &InLayout<'a>,
     );
 

--- a/crates/compiler/gen_dev/src/lib.rs
+++ b/crates/compiler/gen_dev/src/lib.rs
@@ -695,6 +695,14 @@ trait Backend<'a> {
                 );
                 self.build_list_reserve(sym, args, arg_layouts, ret_layout)
             }
+            LowLevel::ListAppendUnsafe => {
+                debug_assert_eq!(
+                    2,
+                    args.len(),
+                    "ListAppendUnsafe: expected to have exactly two arguments"
+                );
+                self.build_list_append_unsafe(sym, args, arg_layouts, ret_layout)
+            }
             LowLevel::ListGetUnsafe => {
                 debug_assert_eq!(
                     2,
@@ -776,7 +784,7 @@ trait Backend<'a> {
                 self.build_eq(sym, &args[0], &Symbol::DEV_TMP, &arg_layouts[0]);
                 self.free_symbol(&Symbol::DEV_TMP)
             }
-            Symbol::LIST_GET | Symbol::LIST_SET | Symbol::LIST_REPLACE => {
+            Symbol::LIST_GET | Symbol::LIST_SET | Symbol::LIST_REPLACE | Symbol::LIST_APPEND => {
                 // TODO: This is probably simple enough to be worth inlining.
                 let layout_id = LayoutIds::default().get(func_sym, ret_layout);
                 let fn_name = self.symbol_to_string(func_sym, layout_id);
@@ -945,6 +953,15 @@ trait Backend<'a> {
 
     /// build_list_reserve enlarges a list to at least accommodate the given capacity.
     fn build_list_reserve(
+        &mut self,
+        dst: &Symbol,
+        args: &'a [Symbol],
+        arg_layouts: &[InLayout<'a>],
+        ret_layout: &InLayout<'a>,
+    );
+
+    /// build_list_append_unsafe returns a new list with a given element appended.
+    fn build_list_append_unsafe(
         &mut self,
         dst: &Symbol,
         args: &'a [Symbol],

--- a/crates/compiler/test_gen/src/gen_list.rs
+++ b/crates/compiler/test_gen/src/gen_list.rs
@@ -145,7 +145,7 @@ fn variously_sized_list_literals() {
 }
 
 #[test]
-#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm", feature = "gen-dev"))]
 fn list_append_basic() {
     assert_evals_to!(
         "List.append [1] 2",
@@ -702,13 +702,13 @@ fn list_swap() {
 }
 
 #[test]
-#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm", feature = "gen-dev"))]
 fn list_append_to_empty_list() {
     assert_evals_to!("List.append [] 3", RocList::from_slice(&[3]), RocList<i64>);
 }
 
 #[test]
-#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm", feature = "gen-dev"))]
 fn list_append_to_empty_list_of_int() {
     assert_evals_to!(
         indoc!(
@@ -736,7 +736,7 @@ fn list_append_bools() {
 }
 
 #[test]
-#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm", feature = "gen-dev"))]
 fn list_append_longer_list() {
     assert_evals_to!(
         "List.append [11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22] 23",

--- a/crates/compiler/test_gen/src/gen_list.rs
+++ b/crates/compiler/test_gen/src/gen_list.rs
@@ -2617,7 +2617,7 @@ fn list_contains_str() {
 }
 
 #[test]
-#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm", feature = "gen-dev"))]
 fn list_manual_range() {
     assert_evals_to!(
         indoc!(
@@ -3382,7 +3382,7 @@ fn with_capacity() {
 }
 
 #[test]
-#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm", feature = "gen-dev"))]
 fn with_capacity_append() {
     // see https://github.com/roc-lang/roc/issues/1732
     assert_evals_to!(

--- a/crates/compiler/test_gen/src/gen_list.rs
+++ b/crates/compiler/test_gen/src/gen_list.rs
@@ -3431,12 +3431,12 @@ fn reserve_unchanged() {
         // both lists are empty.
         (0, RocList::empty(), 15, RocList::empty()),
         (RocList<u64>, RocList<u64>),
-        |(value_a, value_b): (RocList<u64>, RocList<u64>)| ((
+        |(value_a, value_b): (RocList<u64>, RocList<u64>)| (
             value_a.capacity(),
             value_a,
             value_b.capacity(),
             value_b
-        ))
+        )
     );
 }
 

--- a/crates/compiler/test_gen/src/gen_list.rs
+++ b/crates/compiler/test_gen/src/gen_list.rs
@@ -3402,6 +3402,45 @@ fn with_capacity_append() {
 }
 
 #[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm", feature = "gen-dev"))]
+fn reserve() {
+    assert_evals_to!(
+        indoc!(
+            r#"
+            List.reserve [] 15
+            "#
+        ),
+        (15, RocList::empty()),
+        RocList<u64>,
+        |value: RocList<u64>| (value.capacity(), value)
+    );
+}
+
+#[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm", feature = "gen-dev"))]
+fn reserve_unchanged() {
+    assert_evals_to!(
+        indoc!(
+            r#"
+            a = []
+            b = List.reserve a 15
+            {a, b}
+            "#
+        ),
+        // a's capacity is unchanged when we reserve 15 more capcity
+        // both lists are empty.
+        (0, RocList::empty(), 15, RocList::empty()),
+        (RocList<u64>, RocList<u64>),
+        |(value_a, value_b): (RocList<u64>, RocList<u64>)| ((
+            value_a.capacity(),
+            value_a,
+            value_b.capacity(),
+            value_b
+        ))
+    );
+}
+
+#[test]
 #[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
 fn call_function_in_empty_list() {
     assert_evals_to!(


### PR DESCRIPTION
Hey, PR with a couple more implementations for list operations in the dev backend :)

This PR closes #4960 and closes #4961 

I decided to group these as their implementations are similar and pretty straight-forward.
Haven't re-enabled the `list_bool_append` test as the bools are not supported in the dev backend within lists (yet).