### PR TITLE
Get rid of WhenRecursive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3273,6 +3273,7 @@ dependencies = [
  "morphic_lib",
  "roc_collections",
  "roc_debug_flags",
+ "roc_error_macros",
  "roc_module",
  "roc_mono",
 ]

--- a/crates/compiler/alias_analysis/Cargo.toml
+++ b/crates/compiler/alias_analysis/Cargo.toml
@@ -8,6 +8,7 @@ version = "0.0.1"
 [dependencies]
 morphic_lib = {path = "../../vendor/morphic_lib"}
 roc_collections = {path = "../collections"}
+roc_error_macros = {path = "../../error_macros"}
 roc_module = {path = "../module"}
 roc_mono = {path = "../mono"}
 roc_debug_flags = {path = "../debug_flags"}

--- a/crates/compiler/alias_analysis/src/lib.rs
+++ b/crates/compiler/alias_analysis/src/lib.rs
@@ -9,6 +9,7 @@ use morphic_lib::{
     TypeDefBuilder, TypeId, TypeName, UpdateModeVar, ValueId,
 };
 use roc_collections::all::{MutMap, MutSet};
+use roc_error_macros::internal_error;
 use roc_module::low_level::LowLevel;
 use roc_module::symbol::Symbol;
 
@@ -365,13 +366,7 @@ fn build_entry_point<'a>(
         let block = builder.add_block();
 
         // to the modelling language, the arguments appear out of thin air
-        let argument_type = build_tuple_type(
-            env,
-            &mut builder,
-            interner,
-            layout.arguments,
-            &WhenRecursive::Unreachable,
-        )?;
+        let argument_type = build_tuple_type(env, &mut builder, interner, layout.arguments)?;
 
         // does not make any assumptions about the input
         // let argument = builder.add_unknown_with(block, &[], argument_type)?;
@@ -401,13 +396,7 @@ fn build_entry_point<'a>(
         let block = builder.add_block();
 
         let struct_layout = interner.insert(Layout::struct_no_name_order(layouts));
-        let type_id = layout_spec(
-            env,
-            &mut builder,
-            interner,
-            struct_layout,
-            &WhenRecursive::Unreachable,
-        )?;
+        let type_id = layout_spec(env, &mut builder, interner, struct_layout)?;
 
         let argument = builder.add_unknown_with(block, &[], type_id)?;
 
@@ -466,20 +455,8 @@ fn proc_spec<'a>(
     let args_struct_layout = interner.insert(Layout::struct_no_name_order(
         argument_layouts.into_bump_slice(),
     ));
-    let arg_type_id = layout_spec(
-        &mut env,
-        &mut builder,
-        interner,
-        args_struct_layout,
-        &WhenRecursive::Unreachable,
-    )?;
-    let ret_type_id = layout_spec(
-        &mut env,
-        &mut builder,
-        interner,
-        proc.ret_layout,
-        &WhenRecursive::Unreachable,
-    )?;
+    let arg_type_id = layout_spec(&mut env, &mut builder, interner, args_struct_layout)?;
+    let ret_type_id = layout_spec(&mut env, &mut builder, interner, proc.ret_layout)?;
 
     let spec = builder.build(arg_type_id, ret_type_id, root)?;
 
@@ -617,17 +594,10 @@ fn stmt_spec<'a>(
             let mut type_ids = Vec::new();
 
             for p in parameters.iter() {
-                type_ids.push(layout_spec(
-                    env,
-                    builder,
-                    interner,
-                    p.layout,
-                    &WhenRecursive::Unreachable,
-                )?);
+                type_ids.push(layout_spec(env, builder, interner, p.layout)?);
             }
 
-            let ret_type_id =
-                layout_spec(env, builder, interner, layout, &WhenRecursive::Unreachable)?;
+            let ret_type_id = layout_spec(env, builder, interner, layout)?;
 
             let jp_arg_type_id = builder.add_tuple_type(&type_ids)?;
 
@@ -668,8 +638,7 @@ fn stmt_spec<'a>(
             builder.add_sub_block(block, BlockExpr(cont_block, cont_value_id))
         }
         Jump(id, symbols) => {
-            let ret_type_id =
-                layout_spec(env, builder, interner, layout, &WhenRecursive::Unreachable)?;
+            let ret_type_id = layout_spec(env, builder, interner, layout)?;
             let argument = build_tuple_value(builder, env, block, symbols)?;
 
             let jpid = env.join_points[id];
@@ -678,8 +647,7 @@ fn stmt_spec<'a>(
         Crash(msg, _) => {
             // Model this as a foreign call rather than TERMINATE because
             // we want ownership of the message.
-            let result_type =
-                layout_spec(env, builder, interner, layout, &WhenRecursive::Unreachable)?;
+            let result_type = layout_spec(env, builder, interner, layout)?;
 
             builder.add_unknown_with(block, &[env.symbols[msg]], result_type)
         }
@@ -708,23 +676,16 @@ fn build_tuple_value(
     builder.add_make_tuple(block, &value_ids)
 }
 
-#[derive(Clone, Debug, PartialEq)]
-enum WhenRecursive<'a> {
-    Unreachable,
-    Loop(UnionLayout<'a>),
-}
-
 fn build_recursive_tuple_type<'a>(
     env: &mut Env<'a>,
     builder: &mut impl TypeContext,
     interner: &STLayoutInterner<'a>,
     layouts: &[InLayout<'a>],
-    when_recursive: &WhenRecursive,
 ) -> Result<TypeId> {
     let mut field_types = Vec::new();
 
     for field in layouts.iter() {
-        let type_id = layout_spec_help(env, builder, interner, *field, when_recursive)?;
+        let type_id = layout_spec_help(env, builder, interner, *field)?;
         field_types.push(type_id);
     }
 
@@ -736,12 +697,11 @@ fn build_tuple_type<'a>(
     builder: &mut impl TypeContext,
     interner: &STLayoutInterner<'a>,
     layouts: &[InLayout<'a>],
-    when_recursive: &WhenRecursive,
 ) -> Result<TypeId> {
     let mut field_types = Vec::new();
 
     for field in layouts.iter() {
-        field_types.push(layout_spec(env, builder, interner, *field, when_recursive)?);
+        field_types.push(layout_spec(env, builder, interner, *field)?);
     }
 
     builder.add_tuple_type(&field_types)
@@ -811,13 +771,7 @@ fn call_spec<'a>(
                 .map(|symbol| env.symbols[symbol])
                 .collect();
 
-            let result_type = layout_spec(
-                env,
-                builder,
-                interner,
-                *ret_layout,
-                &WhenRecursive::Unreachable,
-            )?;
+            let result_type = layout_spec(env, builder, interner, *ret_layout)?;
 
             builder.add_unknown_with(block, &arguments, result_type)
         }
@@ -888,23 +842,11 @@ fn call_spec<'a>(
                         list_append(builder, block, update_mode_var, state, new_element)
                     };
 
-                    let output_element_type = layout_spec(
-                        env,
-                        builder,
-                        interner,
-                        *return_layout,
-                        &WhenRecursive::Unreachable,
-                    )?;
+                    let output_element_type = layout_spec(env, builder, interner, *return_layout)?;
 
                     let state_layout =
                         interner.insert(Layout::Builtin(Builtin::List(*return_layout)));
-                    let state_type = layout_spec(
-                        env,
-                        builder,
-                        interner,
-                        state_layout,
-                        &WhenRecursive::Unreachable,
-                    )?;
+                    let state_type = layout_spec(env, builder, interner, state_layout)?;
 
                     let init_state = new_list(builder, block, output_element_type)?;
 
@@ -931,13 +873,7 @@ fn call_spec<'a>(
                     let arg0_layout = argument_layouts[0];
 
                     let state_layout = interner.insert(Layout::Builtin(Builtin::List(arg0_layout)));
-                    let state_type = layout_spec(
-                        env,
-                        builder,
-                        interner,
-                        state_layout,
-                        &WhenRecursive::Unreachable,
-                    )?;
+                    let state_type = layout_spec(env, builder, interner, state_layout)?;
                     let init_state = list;
 
                     add_loop(builder, block, state_type, init_state, loop_body)
@@ -961,23 +897,11 @@ fn call_spec<'a>(
                         list_append(builder, block, update_mode_var, state, new_element)
                     };
 
-                    let output_element_type = layout_spec(
-                        env,
-                        builder,
-                        interner,
-                        *return_layout,
-                        &WhenRecursive::Unreachable,
-                    )?;
+                    let output_element_type = layout_spec(env, builder, interner, *return_layout)?;
 
                     let state_layout =
                         interner.insert(Layout::Builtin(Builtin::List(*return_layout)));
-                    let state_type = layout_spec(
-                        env,
-                        builder,
-                        interner,
-                        state_layout,
-                        &WhenRecursive::Unreachable,
-                    )?;
+                    let state_type = layout_spec(env, builder, interner, state_layout)?;
 
                     let init_state = new_list(builder, block, output_element_type)?;
 
@@ -1007,23 +931,11 @@ fn call_spec<'a>(
                         list_append(builder, block, update_mode_var, state, new_element)
                     };
 
-                    let output_element_type = layout_spec(
-                        env,
-                        builder,
-                        interner,
-                        *return_layout,
-                        &WhenRecursive::Unreachable,
-                    )?;
+                    let output_element_type = layout_spec(env, builder, interner, *return_layout)?;
 
                     let state_layout =
                         interner.insert(Layout::Builtin(Builtin::List(*return_layout)));
-                    let state_type = layout_spec(
-                        env,
-                        builder,
-                        interner,
-                        state_layout,
-                        &WhenRecursive::Unreachable,
-                    )?;
+                    let state_type = layout_spec(env, builder, interner, state_layout)?;
 
                     let init_state = new_list(builder, block, output_element_type)?;
 
@@ -1059,23 +971,11 @@ fn call_spec<'a>(
                         list_append(builder, block, update_mode_var, state, new_element)
                     };
 
-                    let output_element_type = layout_spec(
-                        env,
-                        builder,
-                        interner,
-                        *return_layout,
-                        &WhenRecursive::Unreachable,
-                    )?;
+                    let output_element_type = layout_spec(env, builder, interner, *return_layout)?;
 
                     let state_layout =
                         interner.insert(Layout::Builtin(Builtin::List(*return_layout)));
-                    let state_type = layout_spec(
-                        env,
-                        builder,
-                        interner,
-                        state_layout,
-                        &WhenRecursive::Unreachable,
-                    )?;
+                    let state_type = layout_spec(env, builder, interner, state_layout)?;
 
                     let init_state = new_list(builder, block, output_element_type)?;
 
@@ -1130,7 +1030,7 @@ fn lowlevel_spec<'a>(
 ) -> Result<ValueId> {
     use LowLevel::*;
 
-    let type_id = layout_spec(env, builder, interner, layout, &WhenRecursive::Unreachable)?;
+    let type_id = layout_spec(env, builder, interner, layout)?;
     let mode = update_mode.to_bytes();
     let update_mode_var = UpdateModeVar(&mode);
 
@@ -1238,13 +1138,7 @@ fn lowlevel_spec<'a>(
 
             match interner.get(layout) {
                 Layout::Builtin(Builtin::List(element_layout)) => {
-                    let type_id = layout_spec(
-                        env,
-                        builder,
-                        interner,
-                        element_layout,
-                        &WhenRecursive::Unreachable,
-                    )?;
+                    let type_id = layout_spec(env, builder, interner, element_layout)?;
                     new_list(builder, block, type_id)
                 }
                 _ => unreachable!("empty array does not have a list layout"),
@@ -1287,8 +1181,7 @@ fn lowlevel_spec<'a>(
             // TODO overly pessimstic
             let arguments: Vec<_> = arguments.iter().map(|symbol| env.symbols[symbol]).collect();
 
-            let result_type =
-                layout_spec(env, builder, interner, layout, &WhenRecursive::Unreachable)?;
+            let result_type = layout_spec(env, builder, interner, layout)?;
 
             builder.add_unknown_with(block, &arguments, result_type)
         }
@@ -1302,9 +1195,7 @@ fn recursive_tag_variant<'a>(
     union_layout: &UnionLayout,
     fields: &[InLayout<'a>],
 ) -> Result<TypeId> {
-    let when_recursive = WhenRecursive::Loop(*union_layout);
-
-    build_recursive_tuple_type(env, builder, interner, fields, &when_recursive)
+    build_recursive_tuple_type(env, builder, interner, fields)
 }
 
 fn recursive_variant_types<'a>(
@@ -1432,13 +1323,7 @@ fn expr_spec<'a>(
 
             let value_id = match tag_layout {
                 UnionLayout::NonRecursive(tags) => {
-                    let variant_types = non_recursive_variant_types(
-                        env,
-                        builder,
-                        interner,
-                        tags,
-                        &WhenRecursive::Unreachable,
-                    )?;
+                    let variant_types = non_recursive_variant_types(env, builder, interner, tags)?;
                     let value_id = build_tuple_value(builder, env, block, arguments)?;
                     return builder.add_make_union(block, &variant_types, *tag_id as u32, value_id);
                 }
@@ -1543,13 +1428,7 @@ fn expr_spec<'a>(
             builder.add_get_tuple_field(block, value_id, *index as u32)
         }
         Array { elem_layout, elems } => {
-            let type_id = layout_spec(
-                env,
-                builder,
-                interner,
-                *elem_layout,
-                &WhenRecursive::Unreachable,
-            )?;
+            let type_id = layout_spec(env, builder, interner, *elem_layout)?;
 
             let list = new_list(builder, block, type_id)?;
 
@@ -1576,13 +1455,7 @@ fn expr_spec<'a>(
 
         EmptyArray => match interner.get(layout) {
             Layout::Builtin(Builtin::List(element_layout)) => {
-                let type_id = layout_spec(
-                    env,
-                    builder,
-                    interner,
-                    element_layout,
-                    &WhenRecursive::Unreachable,
-                )?;
+                let type_id = layout_spec(env, builder, interner, element_layout)?;
                 new_list(builder, block, type_id)
             }
             _ => unreachable!("empty array does not have a list layout"),
@@ -1615,7 +1488,7 @@ fn expr_spec<'a>(
             with_new_heap_cell(builder, block, union_data)
         }
         RuntimeErrorFunction(_) => {
-            let type_id = layout_spec(env, builder, interner, layout, &WhenRecursive::Unreachable)?;
+            let type_id = layout_spec(env, builder, interner, layout)?;
 
             builder.add_terminate(block, type_id)
         }
@@ -1647,9 +1520,8 @@ fn layout_spec<'a>(
     builder: &mut impl TypeContext,
     interner: &STLayoutInterner<'a>,
     layout: InLayout<'a>,
-    when_recursive: &WhenRecursive,
 ) -> Result<TypeId> {
-    layout_spec_help(env, builder, interner, layout, when_recursive)
+    layout_spec_help(env, builder, interner, layout)
 }
 
 fn non_recursive_variant_types<'a>(
@@ -1657,19 +1529,11 @@ fn non_recursive_variant_types<'a>(
     builder: &mut impl TypeContext,
     interner: &STLayoutInterner<'a>,
     tags: &[&[InLayout<'a>]],
-    // If there is a recursive pointer latent within this layout, coming from a containing layout.
-    when_recursive: &WhenRecursive,
 ) -> Result<Vec<TypeId>> {
     let mut result = Vec::with_capacity(tags.len());
 
     for tag in tags.iter() {
-        result.push(build_tuple_type(
-            env,
-            builder,
-            interner,
-            tag,
-            when_recursive,
-        )?);
+        result.push(build_tuple_type(env, builder, interner, tag)?);
     }
 
     Ok(result)
@@ -1680,22 +1544,17 @@ fn layout_spec_help<'a>(
     builder: &mut impl TypeContext,
     interner: &STLayoutInterner<'a>,
     layout: InLayout<'a>,
-    when_recursive: &WhenRecursive,
 ) -> Result<TypeId> {
     use Layout::*;
 
     match interner.get(layout) {
-        Builtin(builtin) => builtin_spec(env, builder, interner, &builtin, when_recursive),
+        Builtin(builtin) => builtin_spec(env, builder, interner, &builtin),
         Struct { field_layouts, .. } => {
-            build_recursive_tuple_type(env, builder, interner, field_layouts, when_recursive)
+            build_recursive_tuple_type(env, builder, interner, field_layouts)
         }
-        LambdaSet(lambda_set) => layout_spec_help(
-            env,
-            builder,
-            interner,
-            lambda_set.runtime_representation(),
-            when_recursive,
-        ),
+        LambdaSet(lambda_set) => {
+            layout_spec_help(env, builder, interner, lambda_set.runtime_representation())
+        }
         Union(union_layout) => {
             match union_layout {
                 UnionLayout::NonRecursive(&[]) => {
@@ -1705,8 +1564,7 @@ fn layout_spec_help<'a>(
                     builder.add_tuple_type(&[])
                 }
                 UnionLayout::NonRecursive(tags) => {
-                    let variant_types =
-                        non_recursive_variant_types(env, builder, interner, tags, when_recursive)?;
+                    let variant_types = non_recursive_variant_types(env, builder, interner, tags)?;
                     builder.add_union_type(&variant_types)
                 }
                 UnionLayout::Recursive(_)
@@ -1724,29 +1582,21 @@ fn layout_spec_help<'a>(
         }
 
         Boxed(inner_layout) => {
-            let inner_type =
-                layout_spec_help(env, builder, interner, inner_layout, when_recursive)?;
+            let inner_type = layout_spec_help(env, builder, interner, inner_layout)?;
             let cell_type = builder.add_heap_cell_type();
 
             builder.add_tuple_type(&[cell_type, inner_type])
         }
         // TODO(recursive-layouts): update once we have recursive pointer loops
-        RecursivePointer(_) => match when_recursive {
-            WhenRecursive::Unreachable => {
-                unreachable!()
-            }
-            WhenRecursive::Loop(union_layout) => match union_layout {
-                UnionLayout::NonRecursive(_) => unreachable!(),
-                UnionLayout::Recursive(_)
-                | UnionLayout::NullableUnwrapped { .. }
-                | UnionLayout::NullableWrapped { .. }
-                | UnionLayout::NonNullableUnwrapped(_) => {
-                    let type_name_bytes = recursive_tag_union_name_bytes(union_layout).as_bytes();
-                    let type_name = TypeName(&type_name_bytes);
+        RecursivePointer(union_layout) => match interner.get(union_layout) {
+            Layout::Union(union_layout) => {
+                assert!(!matches!(union_layout, UnionLayout::NonRecursive(..)));
+                let type_name_bytes = recursive_tag_union_name_bytes(&union_layout).as_bytes();
+                let type_name = TypeName(&type_name_bytes);
 
-                    Ok(builder.add_named_type(MOD_APP, type_name))
-                }
-            },
+                Ok(builder.add_named_type(MOD_APP, type_name))
+            }
+            _ => internal_error!("somehow, a non-recursive layout is under a recursive pointer"),
         },
     }
 }
@@ -1756,7 +1606,6 @@ fn builtin_spec<'a>(
     builder: &mut impl TypeContext,
     interner: &STLayoutInterner<'a>,
     builtin: &Builtin<'a>,
-    when_recursive: &WhenRecursive,
 ) -> Result<TypeId> {
     use Builtin::*;
 
@@ -1765,8 +1614,7 @@ fn builtin_spec<'a>(
         Decimal | Float(_) => builder.add_tuple_type(&[]),
         Str => str_type(builder),
         List(element_layout) => {
-            let element_type =
-                layout_spec_help(env, builder, interner, *element_layout, when_recursive)?;
+            let element_type = layout_spec_help(env, builder, interner, *element_layout)?;
 
             let cell = builder.add_heap_cell_type();
             let bag = builder.add_bag_type(element_type)?;

--- a/crates/compiler/alias_analysis/src/lib.rs
+++ b/crates/compiler/alias_analysis/src/lib.rs
@@ -1192,7 +1192,6 @@ fn recursive_tag_variant<'a>(
     env: &mut Env<'a>,
     builder: &mut impl TypeContext,
     interner: &STLayoutInterner<'a>,
-    union_layout: &UnionLayout,
     fields: &[InLayout<'a>],
 ) -> Result<TypeId> {
     build_recursive_tuple_type(env, builder, interner, fields)
@@ -1216,23 +1215,11 @@ fn recursive_variant_types<'a>(
             result = Vec::with_capacity(tags.len());
 
             for tag in tags.iter() {
-                result.push(recursive_tag_variant(
-                    env,
-                    builder,
-                    interner,
-                    union_layout,
-                    tag,
-                )?);
+                result.push(recursive_tag_variant(env, builder, interner, tag)?);
             }
         }
         NonNullableUnwrapped(fields) => {
-            result = vec![recursive_tag_variant(
-                env,
-                builder,
-                interner,
-                union_layout,
-                fields,
-            )?];
+            result = vec![recursive_tag_variant(env, builder, interner, fields)?];
         }
         NullableWrapped {
             nullable_id,
@@ -1243,39 +1230,21 @@ fn recursive_variant_types<'a>(
             let cutoff = *nullable_id as usize;
 
             for tag in tags[..cutoff].iter() {
-                result.push(recursive_tag_variant(
-                    env,
-                    builder,
-                    interner,
-                    union_layout,
-                    tag,
-                )?);
+                result.push(recursive_tag_variant(env, builder, interner, tag)?);
             }
 
-            result.push(recursive_tag_variant(
-                env,
-                builder,
-                interner,
-                union_layout,
-                &[],
-            )?);
+            result.push(recursive_tag_variant(env, builder, interner, &[])?);
 
             for tag in tags[cutoff..].iter() {
-                result.push(recursive_tag_variant(
-                    env,
-                    builder,
-                    interner,
-                    union_layout,
-                    tag,
-                )?);
+                result.push(recursive_tag_variant(env, builder, interner, tag)?);
             }
         }
         NullableUnwrapped {
             nullable_id,
             other_fields: fields,
         } => {
-            let unit = recursive_tag_variant(env, builder, interner, union_layout, &[])?;
-            let other_type = recursive_tag_variant(env, builder, interner, union_layout, fields)?;
+            let unit = recursive_tag_variant(env, builder, interner, &[])?;
+            let other_type = recursive_tag_variant(env, builder, interner, fields)?;
 
             if *nullable_id {
                 // nullable_id == 1

--- a/crates/compiler/gen_llvm/src/llvm/build.rs
+++ b/crates/compiler/gen_llvm/src/llvm/build.rs
@@ -37,7 +37,6 @@ use roc_collections::all::{ImMap, MutMap, MutSet};
 use roc_debug_flags::dbg_do;
 #[cfg(debug_assertions)]
 use roc_debug_flags::ROC_PRINT_LLVM_FN_VERIFICATION;
-use roc_error_macros::internal_error;
 use roc_module::symbol::{Interns, ModuleId, Symbol};
 use roc_mono::ir::{
     BranchInfo, CallType, CrashTag, EntryPoint, JoinPointId, ListLiteralElement, ModifyRc,
@@ -6099,24 +6098,4 @@ pub fn add_func<'ctx>(
     spec.attach_attributes(ctx, fn_val);
 
     fn_val
-}
-
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub(crate) enum WhenRecursive<'a> {
-    Unreachable,
-    Loop(UnionLayout<'a>),
-}
-
-impl<'a> WhenRecursive<'a> {
-    pub fn unwrap_recursive_pointer(&self, layout: Layout<'a>) -> Layout<'a> {
-        match layout {
-            Layout::RecursivePointer(_) => match self {
-                WhenRecursive::Loop(lay) => Layout::Union(*lay),
-                WhenRecursive::Unreachable => {
-                    internal_error!("cannot compare recursive pointers outside of a structure")
-                }
-            },
-            _ => layout,
-        }
-    }
 }

--- a/crates/compiler/gen_llvm/src/llvm/compare.rs
+++ b/crates/compiler/gen_llvm/src/llvm/compare.rs
@@ -1213,7 +1213,7 @@ fn build_tag_eq_help<'a, 'ctx, 'env>(
                 env.builder.position_at_end(block);
 
                 let struct_layout =
-                    layout_interner.insert(Layout::struct_no_name_order(&field_layouts));
+                    layout_interner.insert(Layout::struct_no_name_order(field_layouts));
 
                 let answer = eq_ptr_to_struct(
                     env,
@@ -1253,8 +1253,7 @@ fn build_tag_eq_help<'a, 'ctx, 'env>(
 
             env.builder.position_at_end(compare_fields);
 
-            let struct_layout =
-                layout_interner.insert(Layout::struct_no_name_order(&field_layouts));
+            let struct_layout = layout_interner.insert(Layout::struct_no_name_order(field_layouts));
 
             let answer = eq_ptr_to_struct(
                 env,

--- a/crates/compiler/gen_llvm/src/llvm/compare.rs
+++ b/crates/compiler/gen_llvm/src/llvm/compare.rs
@@ -963,15 +963,8 @@ fn build_tag_eq_help<'a, 'ctx, 'env>(
                 let block = env.context.append_basic_block(parent, "tag_id_modify");
                 env.builder.position_at_end(block);
 
-                let answer = eq_ptr_to_struct(
-                    env,
-                    layout_interner,
-                    layout_ids,
-                    union_layout,
-                    field_layouts,
-                    tag1,
-                    tag2,
-                );
+                let answer =
+                    eq_ptr_to_struct(env, layout_interner, layout_ids, field_layouts, tag1, tag2);
 
                 env.builder.build_return(Some(&answer));
 
@@ -1033,15 +1026,8 @@ fn build_tag_eq_help<'a, 'ctx, 'env>(
                 let block = env.context.append_basic_block(parent, "tag_id_modify");
                 env.builder.position_at_end(block);
 
-                let answer = eq_ptr_to_struct(
-                    env,
-                    layout_interner,
-                    layout_ids,
-                    union_layout,
-                    field_layouts,
-                    tag1,
-                    tag2,
-                );
+                let answer =
+                    eq_ptr_to_struct(env, layout_interner, layout_ids, field_layouts, tag1, tag2);
 
                 env.builder.build_return(Some(&answer));
 
@@ -1097,7 +1083,6 @@ fn build_tag_eq_help<'a, 'ctx, 'env>(
                 env,
                 layout_interner,
                 layout_ids,
-                union_layout,
                 other_fields,
                 tag1.into_pointer_value(),
                 tag2.into_pointer_value(),
@@ -1190,15 +1175,8 @@ fn build_tag_eq_help<'a, 'ctx, 'env>(
                 let block = env.context.append_basic_block(parent, "tag_id_modify");
                 env.builder.position_at_end(block);
 
-                let answer = eq_ptr_to_struct(
-                    env,
-                    layout_interner,
-                    layout_ids,
-                    union_layout,
-                    field_layouts,
-                    tag1,
-                    tag2,
-                );
+                let answer =
+                    eq_ptr_to_struct(env, layout_interner, layout_ids, field_layouts, tag1, tag2);
 
                 env.builder.build_return(Some(&answer));
 
@@ -1232,7 +1210,6 @@ fn build_tag_eq_help<'a, 'ctx, 'env>(
                 env,
                 layout_interner,
                 layout_ids,
-                union_layout,
                 field_layouts,
                 tag1.into_pointer_value(),
                 tag2.into_pointer_value(),
@@ -1247,7 +1224,6 @@ fn eq_ptr_to_struct<'a, 'ctx, 'env>(
     env: &Env<'a, 'ctx, 'env>,
     layout_interner: &mut STLayoutInterner<'a>,
     layout_ids: &mut LayoutIds<'a>,
-    union_layout: &UnionLayout<'a>,
     field_layouts: &'a [InLayout<'a>],
     tag1: PointerValue<'ctx>,
     tag2: PointerValue<'ctx>,

--- a/crates/compiler/gen_llvm/src/llvm/expect.rs
+++ b/crates/compiler/gen_llvm/src/llvm/expect.rs
@@ -9,6 +9,7 @@ use inkwell::types::{BasicMetadataTypeEnum, BasicType, BasicTypeEnum};
 use inkwell::values::{BasicValueEnum, FunctionValue, IntValue, PointerValue};
 use inkwell::AddressSpace;
 use roc_builtins::bitcode;
+use roc_error_macros::internal_error;
 use roc_module::symbol::Symbol;
 use roc_mono::ir::LookupType;
 use roc_mono::layout::{
@@ -19,7 +20,7 @@ use roc_region::all::Region;
 use super::build::BuilderExt;
 use super::build::{
     add_func, load_roc_value, load_symbol_and_layout, use_roc_value, FunctionSpec, LlvmBackendMode,
-    Scope, WhenRecursive,
+    Scope,
 };
 use super::convert::struct_type_from_union_layout;
 
@@ -220,7 +221,6 @@ pub(crate) fn clone_to_shared_memory<'a, 'ctx, 'env>(
             cursors,
             value,
             layout,
-            WhenRecursive::Unreachable,
         );
 
         offset = extra_offset;
@@ -286,7 +286,6 @@ fn build_clone<'a, 'ctx, 'env>(
     cursors: Cursors<'ctx>,
     value: BasicValueEnum<'ctx>,
     layout: InLayout<'a>,
-    when_recursive: WhenRecursive<'a>,
 ) -> IntValue<'ctx> {
     match layout_interner.get(layout) {
         Layout::Builtin(builtin) => build_clone_builtin(
@@ -297,7 +296,6 @@ fn build_clone<'a, 'ctx, 'env>(
             cursors,
             value,
             builtin,
-            when_recursive,
         ),
 
         Layout::Struct { field_layouts, .. } => build_clone_struct(
@@ -308,7 +306,6 @@ fn build_clone<'a, 'ctx, 'env>(
             cursors,
             value,
             field_layouts,
-            when_recursive,
         ),
 
         // Since we will never actually display functions (and hence lambda sets)
@@ -343,7 +340,6 @@ fn build_clone<'a, 'ctx, 'env>(
                     cursors,
                     value,
                     union_layout,
-                    WhenRecursive::Loop(union_layout),
                 )
             }
         }
@@ -376,39 +372,39 @@ fn build_clone<'a, 'ctx, 'env>(
                 cursors,
                 value,
                 inner_layout,
-                when_recursive,
             )
         }
 
-        Layout::RecursivePointer(_) => match when_recursive {
-            WhenRecursive::Unreachable => {
-                unreachable!("recursion pointers should never be compared directly")
-            }
+        Layout::RecursivePointer(rec_layout) => {
+            let layout = rec_layout;
 
-            WhenRecursive::Loop(union_layout) => {
-                let layout = layout_interner.insert(Layout::Union(union_layout));
+            let bt = basic_type_from_layout(env, layout_interner, layout);
 
-                let bt = basic_type_from_layout(env, layout_interner, layout);
+            // cast the i64 pointer to a pointer to block of memory
+            let field1_cast = env.builder.build_pointer_cast(
+                value.into_pointer_value(),
+                bt.into_pointer_type(),
+                "i64_to_opaque",
+            );
 
-                // cast the i64 pointer to a pointer to block of memory
-                let field1_cast = env.builder.build_pointer_cast(
-                    value.into_pointer_value(),
-                    bt.into_pointer_type(),
-                    "i64_to_opaque",
-                );
+            let union_layout = match layout_interner.get(rec_layout) {
+                Layout::Union(union_layout) => {
+                    debug_assert!(!matches!(union_layout, UnionLayout::NonRecursive(..)));
+                    union_layout
+                }
+                _ => internal_error!(),
+            };
 
-                build_clone_tag(
-                    env,
-                    layout_interner,
-                    layout_ids,
-                    ptr,
-                    cursors,
-                    field1_cast.into(),
-                    union_layout,
-                    WhenRecursive::Loop(union_layout),
-                )
-            }
-        },
+            build_clone_tag(
+                env,
+                layout_interner,
+                layout_ids,
+                ptr,
+                cursors,
+                field1_cast.into(),
+                union_layout,
+            )
+        }
     }
 }
 
@@ -420,7 +416,6 @@ fn build_clone_struct<'a, 'ctx, 'env>(
     cursors: Cursors<'ctx>,
     value: BasicValueEnum<'ctx>,
     field_layouts: &[InLayout<'a>],
-    when_recursive: WhenRecursive<'a>,
 ) -> IntValue<'ctx> {
     let layout = Layout::struct_no_name_order(field_layouts);
 
@@ -447,7 +442,6 @@ fn build_clone_struct<'a, 'ctx, 'env>(
                 cursors,
                 field,
                 *field_layout,
-                when_recursive,
             );
 
             let field_width = env
@@ -472,7 +466,6 @@ fn build_clone_tag<'a, 'ctx, 'env>(
     cursors: Cursors<'ctx>,
     value: BasicValueEnum<'ctx>,
     union_layout: UnionLayout<'a>,
-    when_recursive: WhenRecursive<'a>,
 ) -> IntValue<'ctx> {
     let layout = layout_interner.insert(Layout::Union(union_layout));
     let layout_id = layout_ids.get(Symbol::CLONE, &layout);
@@ -512,7 +505,6 @@ fn build_clone_tag<'a, 'ctx, 'env>(
                 layout_interner,
                 layout_ids,
                 union_layout,
-                when_recursive,
                 function_value,
             );
 
@@ -575,7 +567,6 @@ fn build_clone_tag_help<'a, 'ctx, 'env>(
     layout_interner: &mut STLayoutInterner<'a>,
     layout_ids: &mut LayoutIds<'a>,
     union_layout: UnionLayout<'a>,
-    when_recursive: WhenRecursive<'a>,
     fn_val: FunctionValue<'ctx>,
 ) {
     use bumpalo::collections::Vec;
@@ -643,16 +634,8 @@ fn build_clone_tag_help<'a, 'ctx, 'env>(
                     basic_type,
                 );
 
-                let answer = build_clone(
-                    env,
-                    layout_interner,
-                    layout_ids,
-                    ptr,
-                    cursors,
-                    data,
-                    layout,
-                    when_recursive,
-                );
+                let answer =
+                    build_clone(env, layout_interner, layout_ids, ptr, cursors, data, layout);
 
                 env.builder.build_return(Some(&answer));
 
@@ -712,17 +695,8 @@ fn build_clone_tag_help<'a, 'ctx, 'env>(
                     ),
                 };
 
-                let when_recursive = WhenRecursive::Loop(union_layout);
-                let answer = build_clone(
-                    env,
-                    layout_interner,
-                    layout_ids,
-                    ptr,
-                    cursors,
-                    data,
-                    layout,
-                    when_recursive,
-                );
+                let answer =
+                    build_clone(env, layout_interner, layout_ids, ptr, cursors, data, layout);
 
                 env.builder.build_return(Some(&answer));
 
@@ -762,17 +736,7 @@ fn build_clone_tag_help<'a, 'ctx, 'env>(
 
             let data = load_tag_data(env, layout_interner, union_layout, tag_value, basic_type);
 
-            let when_recursive = WhenRecursive::Loop(union_layout);
-            let answer = build_clone(
-                env,
-                layout_interner,
-                layout_ids,
-                ptr,
-                cursors,
-                data,
-                layout,
-                when_recursive,
-            );
+            let answer = build_clone(env, layout_interner, layout_ids, ptr, cursors, data, layout);
 
             env.builder.build_return(Some(&answer));
         }
@@ -831,17 +795,8 @@ fn build_clone_tag_help<'a, 'ctx, 'env>(
                     let data =
                         load_tag_data(env, layout_interner, union_layout, tag_value, basic_type);
 
-                    let when_recursive = WhenRecursive::Loop(union_layout);
-                    let answer = build_clone(
-                        env,
-                        layout_interner,
-                        layout_ids,
-                        ptr,
-                        cursors,
-                        data,
-                        layout,
-                        when_recursive,
-                    );
+                    let answer =
+                        build_clone(env, layout_interner, layout_ids, ptr, cursors, data, layout);
 
                     env.builder.build_return(Some(&answer));
 
@@ -917,17 +872,8 @@ fn build_clone_tag_help<'a, 'ctx, 'env>(
                     basic_type,
                 );
 
-                let when_recursive = WhenRecursive::Loop(union_layout);
-                let answer = build_clone(
-                    env,
-                    layout_interner,
-                    layout_ids,
-                    ptr,
-                    cursors,
-                    data,
-                    layout,
-                    when_recursive,
-                );
+                let answer =
+                    build_clone(env, layout_interner, layout_ids, ptr, cursors, data, layout);
 
                 env.builder.build_return(Some(&answer));
             }
@@ -997,7 +943,6 @@ fn build_clone_builtin<'a, 'ctx, 'env>(
     cursors: Cursors<'ctx>,
     value: BasicValueEnum<'ctx>,
     builtin: Builtin<'a>,
-    when_recursive: WhenRecursive<'a>,
 ) -> IntValue<'ctx> {
     use Builtin::*;
 
@@ -1102,7 +1047,6 @@ fn build_clone_builtin<'a, 'ctx, 'env>(
                         cursors,
                         element,
                         elem,
-                        when_recursive,
                     );
 
                     bd.build_store(rest_offset, new_offset);


### PR DESCRIPTION
We still need WhenRecursive in the repl because that uses entry points in layout that operate over both layouts and variables, where we do not properly intern recursive layouts yet, but everywhere else WhenRecursive can be stripped out.

Also lifts some mutable usages of interners to not be mutable.