### PR TITLE
Support equivalence for finding lambda sets

### DIFF
--- a/crates/compiler/mono/src/decision_tree.rs
+++ b/crates/compiler/mono/src/decision_tree.rs
@@ -1406,7 +1406,7 @@ fn path_to_expr_help<'a>(
             PathInstruction::TagIndex { index, tag_id } => {
                 let index = *index;
 
-                match layout_interner.get(layout) {
+                match layout_interner.chase_recursive(layout) {
                     Layout::Union(union_layout) => {
                         let inner_expr = Expr::UnionAtIndex {
                             tag_id: *tag_id,
@@ -1506,7 +1506,7 @@ fn test_to_comparison<'a>(
             // (e.g. record pattern guard matches)
             debug_assert!(union.alternatives.len() > 1);
 
-            match layout_interner.get(test_layout) {
+            match layout_interner.chase_recursive(test_layout) {
                 Layout::Union(union_layout) => {
                     let lhs = Expr::Literal(Literal::Int((tag_id as i128).to_ne_bytes()));
 
@@ -2108,7 +2108,7 @@ fn decide_to_branching<'a>(
 
             // We have learned more about the exact layout of the cond (based on the path)
             // but tests are still relative to the original cond symbol
-            let inner_cond_layout_raw = layout_cache.get_in(inner_cond_layout);
+            let inner_cond_layout_raw = layout_cache.interner.chase_recursive(inner_cond_layout);
             let mut switch = if let Layout::Union(union_layout) = inner_cond_layout_raw {
                 let tag_id_symbol = env.unique_symbol();
 

--- a/crates/compiler/mono/src/ir.rs
+++ b/crates/compiler/mono/src/ir.rs
@@ -5927,7 +5927,7 @@ fn convert_tag_union<'a>(
                 layout_cache.from_var(env.arena, variant_var, env.subs),
                 "Wrapped"
             );
-            let union_layout = match layout_cache.get_in(variant_layout) {
+            let union_layout = match layout_cache.interner.chase_recursive(variant_layout) {
                 Layout::Union(ul) => ul,
                 other => internal_error!(
                     "unexpected layout {:?} for {:?}",
@@ -9466,10 +9466,11 @@ fn from_can_pattern_help<'a>(
                     // problems down the line because we hash layouts and an unrolled
                     // version is not the same as the minimal version.
                     let whole_var_layout = layout_cache.from_var(env.arena, *whole_var, env.subs);
-                    let layout = match whole_var_layout.map(|l| layout_cache.get_in(l)) {
-                        Ok(Layout::Union(ul)) => ul,
-                        _ => unreachable!(),
-                    };
+                    let layout =
+                        match whole_var_layout.map(|l| layout_cache.interner.chase_recursive(l)) {
+                            Ok(Layout::Union(ul)) => ul,
+                            _ => internal_error!(),
+                        };
 
                     use WrappedVariant::*;
                     match variant {

--- a/crates/compiler/mono/src/ir.rs
+++ b/crates/compiler/mono/src/ir.rs
@@ -344,11 +344,9 @@ impl<'a> Proc<'a> {
         let args_doc = self.args.iter().map(|(layout, symbol)| {
             let arg_doc = symbol_to_doc(alloc, *symbol, pretty);
             if pretty_print_ir_symbols() {
-                arg_doc.append(alloc.reflow(": ")).append(interner.to_doc(
-                    *layout,
-                    alloc,
-                    Parens::NotNeeded,
-                ))
+                arg_doc
+                    .append(alloc.reflow(": "))
+                    .append(interner.to_doc_top(*layout, alloc))
             } else {
                 arg_doc
             }
@@ -359,7 +357,7 @@ impl<'a> Proc<'a> {
                 .text("procedure : ")
                 .append(symbol_to_doc(alloc, self.name.name(), pretty))
                 .append(" ")
-                .append(interner.to_doc(self.ret_layout, alloc, Parens::NotNeeded))
+                .append(interner.to_doc_top(self.ret_layout, alloc))
                 .append(alloc.hardline())
                 .append(alloc.text("procedure = "))
                 .append(symbol_to_doc(alloc, self.name.name(), pretty))
@@ -2152,7 +2150,7 @@ impl<'a> Stmt<'a> {
                 .text("let ")
                 .append(symbol_to_doc(alloc, *symbol, pretty))
                 .append(" : ")
-                .append(interner.to_doc(*layout, alloc, Parens::NotNeeded))
+                .append(interner.to_doc_top(*layout, alloc))
                 .append(" = ")
                 .append(expr.to_doc(alloc, pretty))
                 .append(";")

--- a/crates/compiler/mono/src/layout.rs
+++ b/crates/compiler/mono/src/layout.rs
@@ -4,6 +4,7 @@ use bumpalo::collections::Vec;
 use bumpalo::Bump;
 use roc_builtins::bitcode::{FloatWidth, IntWidth};
 use roc_collections::all::{default_hasher, FnvMap, MutMap};
+use roc_collections::VecSet;
 use roc_error_macros::{internal_error, todo_abilities};
 use roc_module::ident::{Lowercase, TagName};
 use roc_module::symbol::{Interns, Symbol};
@@ -727,6 +728,7 @@ impl<'a> UnionLayout<'a> {
         self,
         alloc: &'b D,
         interner: &I,
+        seen_rec: &mut SeenRecPtrs<'a>,
         _parens: Parens,
     ) -> DocBuilder<'b, D, A>
     where
@@ -740,14 +742,14 @@ impl<'a> UnionLayout<'a> {
         match self {
             NonRecursive(tags) => {
                 let tags_doc = tags.iter().map(|fields| {
-                    alloc.text("C ").append(alloc.intersperse(
-                        fields.iter().map(|x| {
-                            interner
-                                .get(*x)
-                                .to_doc(alloc, interner, Parens::InTypeParam)
-                        }),
-                        " ",
-                    ))
+                    alloc.text("C ").append(
+                        alloc.intersperse(
+                            fields
+                                .iter()
+                                .map(|x| interner.to_doc(*x, alloc, seen_rec, Parens::InTypeParam)),
+                            " ",
+                        ),
+                    )
                 });
 
                 alloc
@@ -757,14 +759,14 @@ impl<'a> UnionLayout<'a> {
             }
             Recursive(tags) => {
                 let tags_doc = tags.iter().map(|fields| {
-                    alloc.text("C ").append(alloc.intersperse(
-                        fields.iter().map(|x| {
-                            interner
-                                .get(*x)
-                                .to_doc(alloc, interner, Parens::InTypeParam)
-                        }),
-                        " ",
-                    ))
+                    alloc.text("C ").append(
+                        alloc.intersperse(
+                            fields
+                                .iter()
+                                .map(|x| interner.to_doc(*x, alloc, seen_rec, Parens::InTypeParam)),
+                            " ",
+                        ),
+                    )
                 });
                 alloc
                     .text("[<r>")
@@ -772,14 +774,14 @@ impl<'a> UnionLayout<'a> {
                     .append(alloc.text("]"))
             }
             NonNullableUnwrapped(fields) => {
-                let fields_doc = alloc.text("C ").append(alloc.intersperse(
-                    fields.iter().map(|x| {
-                        interner
-                            .get(*x)
-                            .to_doc(alloc, interner, Parens::InTypeParam)
-                    }),
-                    " ",
-                ));
+                let fields_doc = alloc.text("C ").append(
+                    alloc.intersperse(
+                        fields
+                            .iter()
+                            .map(|x| interner.to_doc(*x, alloc, seen_rec, Parens::InTypeParam)),
+                        " ",
+                    ),
+                );
                 alloc
                     .text("[<rnnu>")
                     .append(fields_doc)
@@ -789,14 +791,14 @@ impl<'a> UnionLayout<'a> {
                 nullable_id,
                 other_fields,
             } => {
-                let fields_doc = alloc.text("C ").append(alloc.intersperse(
-                    other_fields.iter().map(|x| {
-                        interner
-                            .get(*x)
-                            .to_doc(alloc, interner, Parens::InTypeParam)
-                    }),
-                    " ",
-                ));
+                let fields_doc = alloc.text("C ").append(
+                    alloc.intersperse(
+                        other_fields
+                            .iter()
+                            .map(|x| interner.to_doc(*x, alloc, seen_rec, Parens::InTypeParam)),
+                        " ",
+                    ),
+                );
                 let tags_doc = if nullable_id {
                     alloc.concat(vec![alloc.text("<null>, "), fields_doc])
                 } else {
@@ -812,21 +814,20 @@ impl<'a> UnionLayout<'a> {
                 other_tags,
             } => {
                 let nullable_id = nullable_id as usize;
-                let tags_docs = (0..(other_tags.len() + 1)).map(|i| {
-                    if i == nullable_id {
-                        alloc.text("<null>")
-                    } else {
-                        let idx = if i > nullable_id { i - 1 } else { i };
-                        alloc.text("C ").append(alloc.intersperse(
-                            other_tags[idx].iter().map(|x| {
-                                interner
-                                    .get(*x)
-                                    .to_doc(alloc, interner, Parens::InTypeParam)
-                            }),
-                            " ",
-                        ))
-                    }
-                });
+                let tags_docs =
+                    (0..(other_tags.len() + 1)).map(|i| {
+                        if i == nullable_id {
+                            alloc.text("<null>")
+                        } else {
+                            let idx = if i > nullable_id { i - 1 } else { i };
+                            alloc.text("C ").append(alloc.intersperse(
+                                other_tags[idx].iter().map(|x| {
+                                    interner.to_doc(*x, alloc, seen_rec, Parens::InTypeParam)
+                                }),
+                                " ",
+                            ))
+                        }
+                    });
                 let tags_docs = alloc.intersperse(tags_docs, alloc.text(", "));
                 alloc
                     .text("[<rnw>")
@@ -1273,7 +1274,12 @@ pub struct Niche<'a>(NichePriv<'a>);
 impl<'a> Niche<'a> {
     pub const NONE: Niche<'a> = Niche(NichePriv::Captures(&[]));
 
-    pub fn to_doc<'b, D, A, I>(self, alloc: &'b D, interner: &I) -> DocBuilder<'b, D, A>
+    pub fn to_doc<'b, D, A, I>(
+        self,
+        alloc: &'b D,
+        interner: &I,
+        seen_rec: &mut SeenRecPtrs<'a>,
+    ) -> DocBuilder<'b, D, A>
     where
         D: DocAllocator<'b, A>,
         D::Doc: Clone,
@@ -1286,7 +1292,7 @@ impl<'a> Niche<'a> {
                 alloc.intersperse(
                     captures
                         .iter()
-                        .map(|c| interner.get(*c).to_doc(alloc, interner, Parens::NotNeeded)),
+                        .map(|c| interner.to_doc(*c, alloc, seen_rec, Parens::NotNeeded)),
                     alloc.reflow(", "),
                 ),
                 alloc.reflow("})"),
@@ -2702,44 +2708,6 @@ impl<'a> Layout<'a> {
         }
     }
 
-    pub fn to_doc<'b, D, A, I>(
-        self,
-        alloc: &'b D,
-        interner: &I,
-        parens: Parens,
-    ) -> DocBuilder<'b, D, A>
-    where
-        D: DocAllocator<'b, A>,
-        D::Doc: Clone,
-        A: Clone,
-        I: LayoutInterner<'a>,
-    {
-        use Layout::*;
-
-        match self {
-            Builtin(builtin) => builtin.to_doc(alloc, interner, parens),
-            Struct { field_layouts, .. } => {
-                let fields_doc = field_layouts
-                    .iter()
-                    .map(|x| interner.get(*x).to_doc(alloc, interner, parens));
-
-                alloc
-                    .text("{")
-                    .append(alloc.intersperse(fields_doc, ", "))
-                    .append(alloc.text("}"))
-            }
-            Union(union_layout) => union_layout.to_doc(alloc, interner, parens),
-            LambdaSet(lambda_set) => interner
-                .get(lambda_set.runtime_representation())
-                .to_doc(alloc, interner, parens),
-            RecursivePointer(_) => alloc.text("*self"),
-            Boxed(inner) => alloc
-                .text("Boxed(")
-                .append(interner.get(inner).to_doc(alloc, interner, parens))
-                .append(")"),
-        }
-    }
-
     /// Used to build a `Layout::Struct` where the field name order is irrelevant.
     pub fn struct_no_name_order(field_layouts: &'a [InLayout]) -> Self {
         if field_layouts.is_empty() {
@@ -2772,6 +2740,8 @@ impl<'a> Layout<'a> {
         }
     }
 }
+
+pub type SeenRecPtrs<'a> = VecSet<InLayout<'a>>;
 
 impl<'a> Layout<'a> {
     pub fn usize(target_info: TargetInfo) -> InLayout<'a> {
@@ -2900,6 +2870,7 @@ impl<'a> Builtin<'a> {
         self,
         alloc: &'b D,
         interner: &I,
+        seen_rec: &mut SeenRecPtrs<'a>,
         _parens: Parens,
     ) -> DocBuilder<'b, D, A>
     where
@@ -2941,12 +2912,12 @@ impl<'a> Builtin<'a> {
             Decimal => alloc.text("Decimal"),
 
             Str => alloc.text("Str"),
-            List(layout) => {
-                let layout = interner.get(layout);
-                alloc
-                    .text("List ")
-                    .append(layout.to_doc(alloc, interner, Parens::InTypeParam))
-            }
+            List(layout) => alloc.text("List ").append(interner.to_doc(
+                layout,
+                alloc,
+                seen_rec,
+                Parens::InTypeParam,
+            )),
         }
     }
 

--- a/crates/compiler/mono/src/layout/intern.rs
+++ b/crates/compiler/mono/src/layout/intern.rs
@@ -236,7 +236,7 @@ pub trait LayoutInterner<'a>: Sized {
             static SCRATCHPAD: RefCell<Option<Vec<(InLayout<'static>, InLayout<'static>)>>> = RefCell::new(Some(Vec::with_capacity(64)));
         }
 
-        let answer = SCRATCHPAD.with(|f| {
+        SCRATCHPAD.with(|f| {
             // SAFETY: the promotion to lifetime 'a only lasts during equivalence-checking; the
             // scratchpad stack is cleared after every use.
             let mut stack: Vec<(InLayout<'a>, InLayout<'a>)> =
@@ -249,9 +249,7 @@ pub trait LayoutInterner<'a>: Sized {
                 unsafe { std::mem::transmute(stack) };
             f.replace(Some(stack));
             answer
-        });
-
-        answer
+        })
     }
 
     fn to_doc<'b, D, A>(
@@ -550,8 +548,7 @@ impl<'a> GlobalLayoutInterner<'a> {
                 vec: &mut vec,
                 target_info: self.0.target_info,
             };
-            let done = reify::reify_lambda_set_captures(arena, &mut interner, slot, normalized.set);
-            done
+            reify::reify_lambda_set_captures(arena, &mut interner, slot, normalized.set)
         } else {
             normalized.set
         };

--- a/crates/compiler/mono/src/layout/intern.rs
+++ b/crates/compiler/mono/src/layout/intern.rs
@@ -755,7 +755,7 @@ impl<'a> LayoutInterner<'a> for TLLayoutInterner<'a> {
         if let Some(full_layout) = new_interned_full_layout {
             self.record(full_layout, interned);
         }
-        self.insert(Layout::RecursivePointer(interned))
+        interned
     }
 
     fn get(&self, key: InLayout<'a>) -> Layout<'a> {
@@ -887,7 +887,7 @@ macro_rules! st_impl {
                 //   - if so, use that one immediately
                 //   - otherwise, allocate a new slot, update the recursive layout, and intern
                 if let Some(in_layout) = self.map.get(&normalized_layout) {
-                    return self.insert(Layout::RecursivePointer(*in_layout));
+                    return *in_layout;
                 }
 
                 // This recursive layout must be new to the interner, reserve a slot and fill it in.
@@ -900,7 +900,7 @@ macro_rules! st_impl {
                 self.map.insert(normalized_layout, slot);
                 self.map.insert(full_layout, slot);
 
-                self.insert(Layout::RecursivePointer(slot))
+                slot
             }
 
             fn get(&self, key: InLayout<'a>) -> Layout<'a> {

--- a/crates/compiler/mono/src/layout/intern.rs
+++ b/crates/compiler/mono/src/layout/intern.rs
@@ -843,7 +843,7 @@ macro_rules! st_impl {
                 //   - if so, use that one immediately
                 //   - otherwise, allocate a new slot, update the recursive layout, and intern
                 if let Some(in_layout) = self.map.get(&normalized_layout) {
-                    return *in_layout;
+                    return self.insert(Layout::RecursivePointer(*in_layout));
                 }
 
                 // This recursive layout must be new to the interner, reserve a slot and fill it in.

--- a/crates/compiler/mono/src/layout/intern.rs
+++ b/crates/compiler/mono/src/layout/intern.rs
@@ -1133,7 +1133,32 @@ mod equiv {
                         _ => return false,
                     }
                 }
-                (LambdaSet(_), LambdaSet(_)) => todo!(),
+                (
+                    LambdaSet(layout::LambdaSet {
+                        args: args1,
+                        ret: ret1,
+                        set: set1,
+                        representation: repr1,
+                        full_layout: _,
+                    }),
+                    LambdaSet(layout::LambdaSet {
+                        args: args2,
+                        ret: ret2,
+                        set: set2,
+                        representation: repr2,
+                        full_layout: _,
+                    }),
+                ) => {
+                    for ((fn1, captures1), (fn2, captures2)) in (**set1).iter().zip(*set2) {
+                        if fn1 != fn2 {
+                            return false;
+                        }
+                        equiv_fields!(captures1, captures2);
+                    }
+                    equiv_fields!(args1, args2);
+                    stack.push((ret1, ret2));
+                    stack.push((repr1, repr2));
+                }
                 _ => return false,
             }
         }

--- a/crates/compiler/mono/src/layout/intern.rs
+++ b/crates/compiler/mono/src/layout/intern.rs
@@ -1248,7 +1248,7 @@ mod insert_recursive_layout {
     }
 
     fn get_rec_ptr_index<'a>(interner: &impl LayoutInterner<'a>, layout: InLayout<'a>) -> usize {
-        match interner.get(layout) {
+        match interner.chase_recursive(layout) {
             Layout::Union(UnionLayout::Recursive(&[&[l1], &[l2]])) => {
                 match (interner.get(l1), interner.get(l2)) {
                     (
@@ -1372,7 +1372,7 @@ mod insert_recursive_layout {
             make_layout(arena, &mut interner)
         };
 
-        let in1 = {
+        let in1: InLayout = {
             let mut interner = global.fork();
             interner.insert_recursive(arena, layout)
         };

--- a/crates/compiler/mono/src/layout/intern.rs
+++ b/crates/compiler/mono/src/layout/intern.rs
@@ -692,7 +692,7 @@ impl<'a> LayoutInterner<'a> for TLLayoutInterner<'a> {
         if let Some(full_layout) = new_interned_full_layout {
             self.record(full_layout, interned);
         }
-        interned
+        self.insert(Layout::RecursivePointer(interned))
     }
 
     fn get(&self, key: InLayout<'a>) -> Layout<'a> {
@@ -824,7 +824,7 @@ macro_rules! st_impl {
                 self.map.insert(normalized_layout, slot);
                 self.map.insert(full_layout, slot);
 
-                slot
+                self.insert(Layout::RecursivePointer(slot))
             }
 
             fn get(&self, key: InLayout<'a>) -> Layout<'a> {

--- a/crates/compiler/mono/src/reset_reuse.rs
+++ b/crates/compiler/mono/src/reset_reuse.rs
@@ -615,7 +615,7 @@ fn function_r_branch_body<'a, 'i>(
             scrutinee,
             layout,
             tag_id,
-        } => match env.interner.get(*layout) {
+        } => match env.interner.chase_recursive(*layout) {
             Layout::Union(UnionLayout::NonRecursive(_)) => temp,
             Layout::Union(union_layout) if !union_layout.tag_is_null(*tag_id) => {
                 let ctor_info = CtorInfo {

--- a/crates/compiler/test_gen/src/gen_primitives.rs
+++ b/crates/compiler/test_gen/src/gen_primitives.rs
@@ -3170,7 +3170,6 @@ fn alias_defined_out_of_order() {
 
 #[test]
 #[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
-#[ignore = "TODO https://github.com/roc-lang/roc/issues/4905"]
 fn recursively_build_effect() {
     assert_evals_to!(
         indoc!(

--- a/crates/compiler/test_mono/generated/recursively_build_effect.txt
+++ b/crates/compiler/test_mono/generated/recursively_build_effect.txt
@@ -1,0 +1,86 @@
+procedure Num.20 (#Attr.2, #Attr.3):
+    let Num.256 : I64 = lowlevel NumSub #Attr.2 #Attr.3;
+    ret Num.256;
+
+procedure Str.3 (#Attr.2, #Attr.3):
+    let Str.267 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
+    ret Str.267;
+
+procedure Test.11 (Test.29, #Attr.12):
+    let Test.10 : {} = UnionAtIndex (Id 0) (Index 0) #Attr.12;
+    dec #Attr.12;
+    ret Test.10;
+
+procedure Test.11 (Test.29, Test.10):
+    ret Test.10;
+
+procedure Test.14 (Test.36, #Attr.12):
+    let Test.12 : {} = UnionAtIndex (Id 1) (Index 1) #Attr.12;
+    let Test.13 : I64 = UnionAtIndex (Id 1) (Index 0) #Attr.12;
+    dec #Attr.12;
+    let Test.46 : {} = Struct {};
+    let Test.45 : {} = CallByName Test.11 Test.46 Test.12;
+    let Test.38 : [<r>C {}, C I64 {}] = CallByName Test.9 Test.45 Test.13;
+    let Test.40 : {} = Struct {};
+    let Test.41 : U8 = GetTagId Test.38;
+    joinpoint Test.42 Test.39:
+        ret Test.39;
+    in
+    switch Test.41:
+        case 0:
+            let Test.43 : {} = CallByName Test.11 Test.40 Test.38;
+            jump Test.42 Test.43;
+    
+        default:
+            let Test.44 : {} = CallByName Test.14 Test.40 Test.38;
+            jump Test.42 Test.44;
+    
+
+procedure Test.2 ():
+    let Test.6 : Str = "Hello";
+    let Test.7 : Str = "World";
+    let Test.21 : Str = ", ";
+    let Test.23 : Str = "!";
+    let Test.22 : Str = CallByName Str.3 Test.7 Test.23;
+    dec Test.23;
+    let Test.20 : Str = CallByName Str.3 Test.21 Test.22;
+    dec Test.22;
+    let Test.19 : Str = CallByName Str.3 Test.6 Test.20;
+    dec Test.20;
+    ret Test.19;
+
+procedure Test.3 (Test.8):
+    let Test.57 : I64 = 0i64;
+    let Test.58 : Int1 = lowlevel Eq Test.57 Test.8;
+    if Test.58 then
+        let Test.27 : {} = Struct {};
+        let Test.26 : [<r>C {}, C I64 {}] = CallByName Test.4 Test.27;
+        ret Test.26;
+    else
+        let Test.52 : {} = Struct {};
+        let Test.33 : {} = CallByName Test.4 Test.52;
+        let Test.32 : [<r>C {}, C I64 {}] = CallByName Test.5 Test.33 Test.8;
+        ret Test.32;
+
+procedure Test.4 (Test.10):
+    let Test.28 : [<r>C {}, C I64 {}] = TagId(0) Test.10;
+    ret Test.28;
+
+procedure Test.4 (Test.10):
+    ret Test.10;
+
+procedure Test.5 (Test.16, Test.13):
+    let Test.35 : [<r>C {}, C I64 {}] = TagId(1) Test.13 Test.16;
+    ret Test.35;
+
+procedure Test.9 (Test.47, Test.8):
+    let Test.51 : I64 = 1i64;
+    let Test.50 : I64 = CallByName Num.20 Test.8 Test.51;
+    let Test.49 : [<r>C {}, C I64 {}] = CallByName Test.3 Test.50;
+    ret Test.49;
+
+procedure Test.0 ():
+    let Test.24 : I64 = 4i64;
+    let Test.17 : [<r>C {}, C I64 {}] = CallByName Test.3 Test.24;
+    let Test.18 : Str = CallByName Test.2;
+    ret Test.18;

--- a/crates/compiler/test_mono/src/tests.rs
+++ b/crates/compiler/test_mono/src/tests.rs
@@ -150,7 +150,7 @@ fn compiles_to_ir(test_name: &str, src: &str, mode: &str, no_check: bool) {
 
     let main_fn_symbol = exposed_to_host.values.keys().copied().next();
 
-    if !no_check {
+    if !no_check && false {
         check_procedures(arena, &interns, &mut layout_interner, &procedures);
     }
 

--- a/crates/compiler/test_mono/src/tests.rs
+++ b/crates/compiler/test_mono/src/tests.rs
@@ -150,7 +150,7 @@ fn compiles_to_ir(test_name: &str, src: &str, mode: &str, no_check: bool) {
 
     let main_fn_symbol = exposed_to_host.values.keys().copied().next();
 
-    if !no_check && false {
+    if !no_check {
         check_procedures(arena, &interns, &mut layout_interner, &procedures);
     }
 

--- a/crates/compiler/test_mono/src/tests.rs
+++ b/crates/compiler/test_mono/src/tests.rs
@@ -592,7 +592,7 @@ fn record_optional_field_function_use_default() {
     "#
 }
 
-#[mono_test(no_check = "https://github.com/roc-lang/roc/issues/4694")]
+#[mono_test]
 fn quicksort_help() {
     // do we still need with_larger_debug_stack?
     r#"


### PR DESCRIPTION
- Adds a procedure for checking equality of layouts up to lambda sets. This is needed for the procedure that looks up a lambda's index in a lambda set, and for the ir-checker. This turns a test back on.
- Adds support for recursive lambda sets, where a capture links back to the lambda set itself. We intern these the same way we do regular recursive layouts.

Closes #4905
Closes #4694

This needs benchmarks; I will provide them soon.