### PR TITLE
Fix roc_error_macros::assert_sizeof_non_wasm! calls

### DIFF
--- a/crates/compiler/mono/src/ir.rs
+++ b/crates/compiler/mono/src/ir.rs
@@ -65,8 +65,8 @@ roc_error_macros::assert_sizeof_wasm!(Call, 44);
 roc_error_macros::assert_sizeof_wasm!(CallType, 36);
 
 roc_error_macros::assert_sizeof_non_wasm!(Literal, 3 * 8);
-roc_error_macros::assert_sizeof_non_wasm!(Expr, 9 * 8);
-roc_error_macros::assert_sizeof_non_wasm!(Stmt, 12 * 8);
+roc_error_macros::assert_sizeof_non_wasm!(Expr, 10 * 8);
+roc_error_macros::assert_sizeof_non_wasm!(Stmt, 14 * 8);
 roc_error_macros::assert_sizeof_non_wasm!(ProcLayout, 5 * 8);
 roc_error_macros::assert_sizeof_non_wasm!(Call, 9 * 8);
 roc_error_macros::assert_sizeof_non_wasm!(CallType, 7 * 8);


### PR DESCRIPTION
It complained about the transmute failing due to different type sizes (`error[E0512]`). Tweaking the size calculations in this way fixed the build on my machine.

This failed on my M1 Macbook Pro running macOS 12.6.2

I am not sure if this is the right fix, but since it fixed the build on my machine I decided to create this PR.