### PR TITLE
gen_dev: add `List.concat` and fix element width bug

### DIFF
--- a/crates/compiler/gen_dev/src/generic64/mod.rs
+++ b/crates/compiler/gen_dev/src/generic64/mod.rs
@@ -1269,6 +1269,7 @@ impl<
         dst: &Symbol,
         capacity: Symbol,
         capacity_layout: InLayout<'a>,
+        element_layout: InLayout<'a>,
         ret_layout: &InLayout<'a>,
     ) {
         // List alignment argument (u32).
@@ -1282,7 +1283,7 @@ impl<
 
         // Load element_width argument (usize).
         let u64_layout = Layout::U64;
-        let element_width = self.layout_interner.stack_size(*ret_layout);
+        let element_width = self.layout_interner.stack_size(element_layout);
         self.load_literal(
             &Symbol::DEV_TMP2,
             &u64_layout,

--- a/crates/compiler/gen_dev/src/generic64/mod.rs
+++ b/crates/compiler/gen_dev/src/generic64/mod.rs
@@ -1652,6 +1652,82 @@ impl<
         self.free_symbol(&Symbol::DEV_TMP5);
     }
 
+    fn build_list_concat(
+        &mut self,
+        dst: &Symbol,
+        args: &'a [Symbol],
+        arg_layouts: &[InLayout<'a>],
+        element_layout: InLayout<'a>,
+        ret_layout: &InLayout<'a>,
+    ) {
+        let list_a = args[0];
+        let list_a_layout = arg_layouts[0];
+        let list_b = args[1];
+        let list_b_layout = arg_layouts[1];
+
+        // Load list alignment argument (u32).
+        let u32_layout = Layout::U32;
+        let list_alignment = self.layout_interner.alignment_bytes(*ret_layout);
+        self.load_literal(
+            &Symbol::DEV_TMP,
+            &u32_layout,
+            &Literal::Int((list_alignment as i128).to_ne_bytes()),
+        );
+
+        // Load element_width argument (usize).
+        let u64_layout = Layout::U64;
+        let element_width = self.layout_interner.stack_size(element_layout);
+        self.load_literal(
+            &Symbol::DEV_TMP2,
+            &u64_layout,
+            &Literal::Int((element_width as i128).to_ne_bytes()),
+        );
+
+        // Setup the return location.
+        let base_offset = self
+            .storage_manager
+            .claim_stack_area(dst, self.layout_interner.stack_size(*ret_layout));
+
+        let lowlevel_args = bumpalo::vec![
+        in self.env.arena;
+            list_a,
+            list_b,
+            // alignment
+            Symbol::DEV_TMP,
+            // element_width
+            Symbol::DEV_TMP2,
+         ];
+        let lowlevel_arg_layouts = bumpalo::vec![
+        in self.env.arena;
+            list_a_layout,
+            list_b_layout,
+            u32_layout,
+            u64_layout
+        ];
+
+        self.build_fn_call(
+            &Symbol::DEV_TMP3,
+            bitcode::LIST_CONCAT.to_string(),
+            &lowlevel_args,
+            &lowlevel_arg_layouts,
+            ret_layout,
+        );
+
+        self.free_symbol(&Symbol::DEV_TMP);
+        self.free_symbol(&Symbol::DEV_TMP2);
+
+        // Return list value from fn call
+        self.storage_manager.copy_symbol_to_stack_offset(
+            self.layout_interner,
+            &mut self.buf,
+            base_offset,
+            &Symbol::DEV_TMP3,
+            ret_layout,
+        );
+
+        self.free_symbol(&Symbol::DEV_TMP3);
+    }
+
     fn build_ptr_cast(&mut self, dst: &Symbol, src: &Symbol) {
         let dst_reg = self.storage_manager.claim_general_reg(&mut self.buf, dst);
         self.storage_manager

--- a/crates/compiler/gen_dev/src/lib.rs
+++ b/crates/compiler/gen_dev/src/lib.rs
@@ -21,6 +21,7 @@ use roc_mono::layout::{
     Builtin, InLayout, Layout, LayoutId, LayoutIds, LayoutInterner, STLayoutInterner, TagIdIntType,
     UnionLayout,
 };
+use roc_mono::list_element_layout;
 
 mod generic64;
 mod object_builder;
@@ -685,7 +686,14 @@ trait Backend<'a> {
                     args.len(),
                     "ListWithCapacity: expected to have exactly one argument"
                 );
-                self.build_list_with_capacity(sym, args[0], arg_layouts[0], ret_layout)
+                let element_layout = list_element_layout!(self.interner(), *ret_layout);
+                self.build_list_with_capacity(
+                    sym,
+                    args[0],
+                    arg_layouts[0],
+                    element_layout,
+                    ret_layout,
+                )
             }
             LowLevel::ListReserve => {
                 debug_assert_eq!(
@@ -948,6 +956,7 @@ trait Backend<'a> {
         dst: &Symbol,
         capacity: Symbol,
         capacity_layout: InLayout<'a>,
+        element_layout: InLayout<'a>,
         ret_layout: &InLayout<'a>,
     );
 

--- a/crates/compiler/gen_dev/src/lib.rs
+++ b/crates/compiler/gen_dev/src/lib.rs
@@ -727,6 +727,15 @@ trait Backend<'a> {
                 );
                 self.build_list_replace_unsafe(sym, args, arg_layouts, ret_layout)
             }
+            LowLevel::ListConcat => {
+                debug_assert_eq!(
+                    2,
+                    args.len(),
+                    "ListConcat: expected to have exactly two arguments"
+                );
+                let element_layout = list_element_layout!(self.interner(), *ret_layout);
+                self.build_list_concat(sym, args, arg_layouts, element_layout, ret_layout)
+            }
             LowLevel::StrConcat => self.build_fn_call(
                 sym,
                 bitcode::STR_CONCAT.to_string(),
@@ -993,6 +1002,16 @@ trait Backend<'a> {
         dst: &Symbol,
         args: &'a [Symbol],
         arg_layouts: &[InLayout<'a>],
+        ret_layout: &InLayout<'a>,
+    );
+
+    /// build_list_concat returns a new list containing the two argument lists concatenated.
+    fn build_list_concat(
+        &mut self,
+        dst: &Symbol,
+        args: &'a [Symbol],
+        arg_layouts: &[InLayout<'a>],
+        element_layout: InLayout<'a>,
         ret_layout: &InLayout<'a>,
     );
 

--- a/crates/compiler/gen_llvm/src/llvm/lowlevel.rs
+++ b/crates/compiler/gen_llvm/src/llvm/lowlevel.rs
@@ -13,6 +13,7 @@ use roc_module::{low_level::LowLevel, symbol::Symbol};
 use roc_mono::{
     ir::HigherOrderLowLevel,
     layout::{Builtin, InLayout, LambdaSet, Layout, LayoutIds, LayoutInterner, STLayoutInterner},
+    list_element_layout,
 };
 use roc_target::PtrWidth;
 
@@ -48,15 +49,6 @@ use super::{
     build::{load_symbol, load_symbol_and_layout, Env, Scope},
     convert::zig_dec_type,
 };
-
-macro_rules! list_element_layout {
-    ($interner:expr, $list_layout:expr) => {
-        match $interner.get($list_layout) {
-            Layout::Builtin(Builtin::List(list_layout)) => list_layout,
-            _ => unreachable!("invalid list layout"),
-        }
-    };
-}
 
 pub(crate) fn run_low_level<'a, 'ctx, 'env>(
     env: &Env<'a, 'ctx, 'env>,

--- a/crates/compiler/mono/src/layout.rs
+++ b/crates/compiler/mono/src/layout.rs
@@ -2113,6 +2113,16 @@ pub enum Builtin<'a> {
     List(InLayout<'a>),
 }
 
+#[macro_export]
+macro_rules! list_element_layout {
+    ($interner:expr, $list_layout:expr) => {
+        match $interner.get($list_layout) {
+            Layout::Builtin(Builtin::List(list_layout)) => list_layout,
+            _ => internal_error!("invalid list layout"),
+        }
+    };
+}
+
 pub struct Env<'a, 'b> {
     target_info: TargetInfo,
     arena: &'a Bump,

--- a/crates/compiler/test_gen/src/gen_list.rs
+++ b/crates/compiler/test_gen/src/gen_list.rs
@@ -1601,7 +1601,7 @@ fn list_reverse_empty_list() {
 }
 
 #[test]
-#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm", feature = "gen-dev"))]
 fn list_concat_two_empty_lists() {
     assert_evals_to!(
         "List.concat [] []",
@@ -1611,7 +1611,7 @@ fn list_concat_two_empty_lists() {
 }
 
 #[test]
-#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm", feature = "gen-dev"))]
 fn list_concat_two_empty_lists_of_int() {
     assert_evals_to!(
         indoc!(
@@ -1633,7 +1633,7 @@ fn list_concat_two_empty_lists_of_int() {
 }
 
 #[test]
-#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm", feature = "gen-dev"))]
 fn list_concat_second_list_is_empty() {
     assert_evals_to!(
         "List.concat [12, 13] []",
@@ -1643,7 +1643,7 @@ fn list_concat_second_list_is_empty() {
 }
 
 #[test]
-#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm", feature = "gen-dev"))]
 fn list_concat_first_list_is_empty() {
     assert_evals_to!(
         "List.concat [] [23, 24]",
@@ -1653,7 +1653,7 @@ fn list_concat_first_list_is_empty() {
 }
 
 #[test]
-#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm", feature = "gen-dev"))]
 fn list_concat_two_non_empty_lists() {
     assert_evals_to!(
         "List.concat [1, 2] [3, 4]",
@@ -1679,7 +1679,7 @@ fn list_concat_two_bigger_non_empty_lists() {
 }
 
 #[allow(dead_code)]
-#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm", feature = "gen-dev"))]
 fn assert_concat_worked(num_elems1: i64, num_elems2: i64) {
     let vec1: Vec<i64> = (0..num_elems1)
         .map(|i| 12345 % (i + num_elems1 + num_elems2 + 1))
@@ -1701,7 +1701,7 @@ fn assert_concat_worked(num_elems1: i64, num_elems2: i64) {
 }
 
 #[test]
-#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm", feature = "gen-dev"))]
 fn list_concat_empty_list() {
     assert_concat_worked(0, 0);
     assert_concat_worked(1, 0);
@@ -1725,7 +1725,7 @@ fn list_concat_empty_list() {
 }
 
 #[test]
-#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm", feature = "gen-dev"))]
 fn list_concat_nonempty_lists() {
     assert_concat_worked(1, 1);
     assert_concat_worked(1, 2);
@@ -1741,7 +1741,7 @@ fn list_concat_nonempty_lists() {
 }
 
 #[test]
-#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm", feature = "gen-dev"))]
 fn list_concat_large() {
     with_larger_debug_stack(|| {
         // these values produce mono ASTs so large that

--- a/crates/compiler/test_gen/src/helpers/dev.rs
+++ b/crates/compiler/test_gen/src/helpers/dev.rs
@@ -269,6 +269,7 @@ macro_rules! assert_evals_to {
 
         let transform = |success| {
             let expected = $expected;
+            #[allow(clippy::redundant_closure_call)]
             let given = $transform(success);
             assert_eq!(&given, &expected);
         };


### PR DESCRIPTION
This PR adds `List.concat` and fixes a bug I introduced myself in `List.withCapacity`. It was using the layout of the list itself and not the list element to allocate. I've fixed this and brought in a macro helper from the llvm backend that's used to assert the `element_width` of lists.
`List.concat` is also implemented through the zig builtins.

This closes #4975 :)


I also noticed that the `clippy` CI check we use doesn't check with the `gen-dev` feature, so I fixed some of the lints I was running into in my editor. We may want to do a separate sweep of these lints at some point and perhaps check it in CI.