### PR TITLE
remove once_cell dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2532,9 +2532,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.15.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
+checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
 
 [[package]]
 name = "oorandom"
@@ -3391,7 +3391,6 @@ dependencies = [
  "libc",
  "libloading",
  "mimalloc",
- "once_cell",
  "parking_lot 0.12.1",
  "pretty_assertions",
  "roc_build",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -96,7 +96,6 @@ indoc = "1.0.7"
 serial_test = "0.9.0"
 criterion = { git = "https://github.com/Anton-4/criterion.rs"}
 cli_utils = { path = "../cli_utils" }
-once_cell = "1.15.0"
 parking_lot = "0.12"
 
 [[bench]]


### PR DESCRIPTION
it is unused, and its version conflicts with newer versions of inkwell