### PR TITLE
Update inkwell prepare llvm15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2532,9 +2532,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.15.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
+checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
 
 [[package]]
 name = "oorandom"
@@ -3391,7 +3391,6 @@ dependencies = [
  "libc",
  "libloading",
  "mimalloc",
- "once_cell",
  "parking_lot 0.12.1",
  "pretty_assertions",
  "roc_build",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1783,7 +1783,7 @@ checksum = "adab1eaa3408fb7f0c777a73e7465fd5656136fc93b670eb6df3c88c2c1344e3"
 [[package]]
 name = "inkwell"
 version = "0.1.0"
-source = "git+https://github.com/roc-lang/inkwell?branch=master#9b63d543eaf996aa91fdeb20a2bc8b8558775648"
+source = "git+https://github.com/roc-lang/inkwell?branch=inkwell-llvm-15#95a3a13c99289539f5cdd91193a4def38711117d"
 dependencies = [
  "either",
  "inkwell_internals",
@@ -1795,8 +1795,8 @@ dependencies = [
 
 [[package]]
 name = "inkwell_internals"
-version = "0.5.0"
-source = "git+https://github.com/roc-lang/inkwell?branch=master#9b63d543eaf996aa91fdeb20a2bc8b8558775648"
+version = "0.7.0"
+source = "git+https://github.com/roc-lang/inkwell?branch=inkwell-llvm-15#95a3a13c99289539f5cdd91193a4def38711117d"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ resolver = "2"
 # commit of TheDan64/inkwell, push a new tag which points to the latest commit,
 # change the tag value in this Cargo.toml to point to that tag, and `cargo update`.
 # This way, GitHub Actions works and nobody's builds get broken.
-inkwell = { git = "https://github.com/roc-lang/inkwell", branch = "master", features = [ "llvm13-0" ] }
+inkwell = { git = "https://github.com/roc-lang/inkwell", branch = "inkwell-llvm-15", features = [ "llvm13-0" ] }
 
 arrayvec = "0.7.2"
 bincode = "1.3.3"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -96,7 +96,6 @@ indoc = "1.0.7"
 serial_test = "0.9.0"
 criterion = { git = "https://github.com/Anton-4/criterion.rs"}
 cli_utils = { path = "../cli_utils" }
-once_cell = "1.15.0"
 parking_lot = "0.12"
 
 [[bench]]

--- a/crates/compiler/gen_llvm/src/llvm/bitcode.rs
+++ b/crates/compiler/gen_llvm/src/llvm/bitcode.rs
@@ -11,8 +11,8 @@ use crate::llvm::refcounting::{
 use inkwell::attributes::{Attribute, AttributeLoc};
 use inkwell::types::{BasicType, BasicTypeEnum, StructType};
 use inkwell::values::{
-    BasicValue, BasicValueEnum, CallSiteValue, FunctionValue, InstructionValue, IntValue,
-    PointerValue, StructValue,
+    BasicValueEnum, CallSiteValue, FunctionValue, InstructionValue, IntValue, PointerValue,
+    StructValue,
 };
 use inkwell::AddressSpace;
 use roc_error_macros::internal_error;
@@ -206,7 +206,7 @@ fn build_transform_caller_help<'a, 'ctx, 'env>(
     let block = env.builder.get_insert_block().expect("to be in a function");
     let di_location = env.builder.get_current_debug_location().unwrap();
 
-    let arg_type = env.context.i8_type().ptr_type(AddressSpace::Generic);
+    let arg_type = env.context.i8_type().ptr_type(AddressSpace::default());
 
     let function_value = crate::llvm::refcounting::build_header_help(
         env,
@@ -244,7 +244,7 @@ fn build_transform_caller_help<'a, 'ctx, 'env>(
 
     for (argument_ptr, layout) in arguments.iter().zip(argument_layouts) {
         let basic_type =
-            basic_type_from_layout(env, layout_interner, *layout).ptr_type(AddressSpace::Generic);
+            basic_type_from_layout(env, layout_interner, *layout).ptr_type(AddressSpace::default());
 
         let cast_ptr = env.builder.build_pointer_cast(
             argument_ptr.into_pointer_value(),
@@ -274,7 +274,7 @@ fn build_transform_caller_help<'a, 'ctx, 'env>(
         }
         (true, layout) => {
             let closure_type = basic_type_from_layout(env, layout_interner, layout)
-                .ptr_type(AddressSpace::Generic);
+                .ptr_type(AddressSpace::default());
 
             let closure_cast =
                 env.builder
@@ -310,8 +310,7 @@ fn build_transform_caller_help<'a, 'ctx, 'env>(
     env.builder.build_return(None);
 
     env.builder.position_at_end(block);
-    env.builder
-        .set_current_debug_location(env.context, di_location);
+    env.builder.set_current_debug_location(di_location);
 
     function_value
 }
@@ -375,7 +374,7 @@ fn build_rc_wrapper<'a, 'ctx, 'env>(
     let function_value = match env.module.get_function(fn_name.as_str()) {
         Some(function_value) => function_value,
         None => {
-            let arg_type = env.context.i8_type().ptr_type(AddressSpace::Generic);
+            let arg_type = env.context.i8_type().ptr_type(AddressSpace::default());
 
             let function_value = match rc_operation {
                 Mode::Inc | Mode::Dec => crate::llvm::refcounting::build_header_help(
@@ -411,7 +410,7 @@ fn build_rc_wrapper<'a, 'ctx, 'env>(
             generic_value_ptr.set_name(Symbol::ARG_1.as_str(&env.interns));
 
             let value_type = basic_type_from_layout(env, layout_interner, layout);
-            let value_ptr_type = value_type.ptr_type(AddressSpace::Generic);
+            let value_ptr_type = value_type.ptr_type(AddressSpace::default());
             let value_ptr =
                 env.builder
                     .build_pointer_cast(generic_value_ptr, value_ptr_type, "load_opaque");
@@ -449,8 +448,7 @@ fn build_rc_wrapper<'a, 'ctx, 'env>(
     };
 
     env.builder.position_at_end(block);
-    env.builder
-        .set_current_debug_location(env.context, di_location);
+    env.builder.set_current_debug_location(di_location);
 
     function_value
 }
@@ -472,7 +470,7 @@ pub fn build_eq_wrapper<'a, 'ctx, 'env>(
     let function_value = match env.module.get_function(fn_name.as_str()) {
         Some(function_value) => function_value,
         None => {
-            let arg_type = env.context.i8_type().ptr_type(AddressSpace::Generic);
+            let arg_type = env.context.i8_type().ptr_type(AddressSpace::default());
 
             let function_value = crate::llvm::refcounting::build_header_help(
                 env,
@@ -502,7 +500,7 @@ pub fn build_eq_wrapper<'a, 'ctx, 'env>(
             value_ptr2.set_name(Symbol::ARG_2.as_str(&env.interns));
 
             let value_type = basic_type_from_layout(env, layout_interner, layout)
-                .ptr_type(AddressSpace::Generic);
+                .ptr_type(AddressSpace::default());
 
             let value_cast1 = env
                 .builder
@@ -533,8 +531,7 @@ pub fn build_eq_wrapper<'a, 'ctx, 'env>(
     };
 
     env.builder.position_at_end(block);
-    env.builder
-        .set_current_debug_location(env.context, di_location);
+    env.builder.set_current_debug_location(di_location);
 
     function_value
 }
@@ -557,7 +554,7 @@ pub fn build_compare_wrapper<'a, 'ctx, 'env>(
     let function_value = match env.module.get_function(fn_name) {
         Some(function_value) => function_value,
         None => {
-            let arg_type = env.context.i8_type().ptr_type(AddressSpace::Generic);
+            let arg_type = env.context.i8_type().ptr_type(AddressSpace::default());
 
             let function_value = crate::llvm::refcounting::build_header_help(
                 env,
@@ -592,7 +589,7 @@ pub fn build_compare_wrapper<'a, 'ctx, 'env>(
             value_ptr2.set_name(Symbol::ARG_3.as_str(&env.interns));
 
             let value_type = basic_type_from_layout(env, layout_interner, layout);
-            let value_ptr_type = value_type.ptr_type(AddressSpace::Generic);
+            let value_ptr_type = value_type.ptr_type(AddressSpace::default());
 
             let value_cast1 =
                 env.builder
@@ -623,7 +620,7 @@ pub fn build_compare_wrapper<'a, 'ctx, 'env>(
                 _ => {
                     let closure_type =
                         basic_type_from_layout(env, layout_interner, closure_data_repr);
-                    let closure_ptr_type = closure_type.ptr_type(AddressSpace::Generic);
+                    let closure_ptr_type = closure_type.ptr_type(AddressSpace::default());
 
                     let closure_cast = env.builder.build_pointer_cast(
                         closure_ptr,
@@ -659,8 +656,7 @@ pub fn build_compare_wrapper<'a, 'ctx, 'env>(
     };
 
     env.builder.position_at_end(block);
-    env.builder
-        .set_current_debug_location(env.context, di_location);
+    env.builder.set_current_debug_location(di_location);
 
     function_value
 }
@@ -798,7 +794,7 @@ fn ptr_len_cap<'a, 'ctx, 'env>(
 
     let ptr = env.builder.build_int_to_ptr(
         lower_word,
-        env.context.i8_type().ptr_type(AddressSpace::Generic),
+        env.context.i8_type().ptr_type(AddressSpace::default()),
         "list_ptr",
     );
 

--- a/crates/compiler/gen_llvm/src/llvm/build.rs
+++ b/crates/compiler/gen_llvm/src/llvm/build.rs
@@ -24,8 +24,8 @@ use inkwell::types::{
 };
 use inkwell::values::BasicValueEnum::{self, *};
 use inkwell::values::{
-    BasicMetadataValueEnum, BasicValue, CallSiteValue, FunctionValue, InstructionValue, IntValue,
-    PhiValue, PointerValue, StructValue,
+    BasicMetadataValueEnum, CallSiteValue, FunctionValue, InstructionValue, IntValue, PhiValue,
+    PointerValue, StructValue,
 };
 use inkwell::OptimizationLevel;
 use inkwell::{AddressSpace, IntPredicate};
@@ -156,7 +156,7 @@ macro_rules! debug_info_init {
             /* current_scope */ lexical_block.as_debug_info_scope(),
             /* inlined_at */ None,
         );
-        $env.builder.set_current_debug_location(&$env.context, loc);
+        $env.builder.set_current_debug_location(loc);
     }};
 }
 
@@ -685,7 +685,7 @@ fn promote_to_wasm_test_wrapper<'a, 'ctx, 'env>(
 
     let output_type = match roc_main_fn.get_type().get_return_type() {
         Some(return_type) => {
-            let output_type = return_type.ptr_type(AddressSpace::Generic);
+            let output_type = return_type.ptr_type(AddressSpace::default());
             output_type.into()
         }
         None => {
@@ -879,7 +879,7 @@ fn small_str_ptr_width_8<'a, 'ctx, 'env>(
     let len = env.ptr_int().const_int(word2, false);
     let cap = env.ptr_int().const_int(word3, false);
 
-    let address_space = AddressSpace::Generic;
+    let address_space = AddressSpace::default();
     let ptr_type = env.context.i8_type().ptr_type(address_space);
     let ptr = env.builder.build_int_to_ptr(ptr, ptr_type, "to_u8_ptr");
 
@@ -906,7 +906,7 @@ fn small_str_ptr_width_4<'a, 'ctx, 'env>(
     let len = env.ptr_int().const_int(word2 as u64, false);
     let cap = env.ptr_int().const_int(word3 as u64, false);
 
-    let address_space = AddressSpace::Generic;
+    let address_space = AddressSpace::default();
     let ptr_type = env.context.i8_type().ptr_type(address_space);
     let ptr = env.builder.build_int_to_ptr(ptr, ptr_type, "to_u8_ptr");
 
@@ -1048,7 +1048,7 @@ fn struct_pointer_from_fields<'a, 'ctx, 'env, I>(
         .builder
         .build_bitcast(
             input_pointer,
-            struct_type.ptr_type(AddressSpace::Generic),
+            struct_type.ptr_type(AddressSpace::default()),
             "struct_ptr",
         )
         .into_pointer_value();
@@ -1309,7 +1309,7 @@ pub fn build_exp_expr<'a, 'ctx, 'env>(
 
                     let data_ptr = env.builder.build_pointer_cast(
                         opaque_data_ptr,
-                        struct_type.ptr_type(AddressSpace::Generic),
+                        struct_type.ptr_type(AddressSpace::default()),
                         "to_data_pointer",
                     );
 
@@ -1534,7 +1534,7 @@ fn build_tag_field_value<'a, 'ctx, 'env>(
         env.builder
             .build_pointer_cast(
                 value.into_pointer_value(),
-                env.context.i64_type().ptr_type(AddressSpace::Generic),
+                env.context.i64_type().ptr_type(AddressSpace::default()),
                 "cast_recursive_pointer",
             )
             .into()
@@ -1750,7 +1750,7 @@ fn build_tag<'a, 'ctx, 'env>(
             );
 
             if tag_id == *nullable_id as _ {
-                let output_type = roc_union.struct_type().ptr_type(AddressSpace::Generic);
+                let output_type = roc_union.struct_type().ptr_type(AddressSpace::default());
 
                 return output_type.const_null().into();
             }
@@ -2002,7 +2002,7 @@ fn lookup_at_index_ptr<'a, 'ctx, 'env>(
 
     let ptr = env.builder.build_pointer_cast(
         value,
-        struct_type.ptr_type(AddressSpace::Generic),
+        struct_type.ptr_type(AddressSpace::default()),
         "cast_lookup_at_index_ptr",
     );
 
@@ -2057,7 +2057,7 @@ fn lookup_at_index_ptr2<'a, 'ctx, 'env>(
 
     let data_ptr = env.builder.build_pointer_cast(
         value,
-        struct_type.ptr_type(AddressSpace::Generic),
+        struct_type.ptr_type(AddressSpace::default()),
         "cast_lookup_at_index_ptr",
     );
 
@@ -2180,7 +2180,7 @@ pub fn allocate_with_refcount_help<'a, 'ctx, 'env>(
     )
     .into_pointer_value();
 
-    let ptr_type = value_type.ptr_type(AddressSpace::Generic);
+    let ptr_type = value_type.ptr_type(AddressSpace::default());
 
     env.builder
         .build_pointer_cast(ptr, ptr_type, "alloc_cast_to_desired")
@@ -2405,7 +2405,7 @@ pub fn store_roc_value_opaque<'a, 'ctx, 'env>(
     value: BasicValueEnum<'ctx>,
 ) {
     let target_type =
-        basic_type_from_layout(env, layout_interner, layout).ptr_type(AddressSpace::Generic);
+        basic_type_from_layout(env, layout_interner, layout).ptr_type(AddressSpace::default());
     let destination =
         env.builder
             .build_pointer_cast(opaque_destination, target_type, "store_roc_value_opaque");
@@ -2658,7 +2658,7 @@ pub fn build_exp_stmt<'a, 'ctx, 'env>(
                     let basic_type = basic_type_from_layout(env, layout_interner, param.layout);
 
                     let phi_type = if layout_interner.is_passed_by_reference(param.layout) {
-                        basic_type.ptr_type(AddressSpace::Generic).into()
+                        basic_type.ptr_type(AddressSpace::default()).into()
                     } else {
                         basic_type
                     };
@@ -3201,7 +3201,7 @@ fn complex_bitcast_from_bigger_than_to<'ctx>(
     // then read it back as a different type
     let to_type_pointer = builder.build_pointer_cast(
         argument_pointer,
-        to_type.ptr_type(inkwell::AddressSpace::Generic),
+        to_type.ptr_type(inkwell::AddressSpace::default()),
         name,
     );
 
@@ -3224,7 +3224,7 @@ fn complex_bitcast_to_bigger_than_from<'ctx>(
         storage,
         from_value
             .get_type()
-            .ptr_type(inkwell::AddressSpace::Generic),
+            .ptr_type(inkwell::AddressSpace::default()),
         name,
     );
 
@@ -3585,7 +3585,7 @@ fn expose_function_to_host_help_c_abi_generic<'a, 'ctx, 'env>(
             argument_types.insert(0, output_type);
         }
         Some(return_type) => {
-            let output_type = return_type.ptr_type(AddressSpace::Generic);
+            let output_type = return_type.ptr_type(AddressSpace::default());
             argument_types.insert(0, output_type.into());
         }
     }
@@ -3637,7 +3637,7 @@ fn expose_function_to_host_help_c_abi_generic<'a, 'ctx, 'env>(
                 // bitcast the ptr
                 let fastcc_ptr = env.builder.build_pointer_cast(
                     arg.into_pointer_value(),
-                    fastcc_type.ptr_type(AddressSpace::Generic),
+                    fastcc_type.ptr_type(AddressSpace::default()),
                     "bitcast_arg",
                 );
 
@@ -3732,7 +3732,7 @@ fn expose_function_to_host_help_c_abi_gen_test<'a, 'ctx, 'env>(
     let return_type = wrapper_return_type;
 
     let c_function_spec = {
-        let output_type = return_type.ptr_type(AddressSpace::Generic);
+        let output_type = return_type.ptr_type(AddressSpace::default());
         argument_types.push(output_type.into());
         FunctionSpec::cconv(env, CCReturn::Void, None, &argument_types)
     };
@@ -3896,7 +3896,10 @@ fn expose_function_to_host_help_c_abi_v2<'a, 'ctx, 'env>(
 
     let c_abi_roc_str_type = env.context.struct_type(
         &[
-            env.context.i8_type().ptr_type(AddressSpace::Generic).into(),
+            env.context
+                .i8_type()
+                .ptr_type(AddressSpace::default())
+                .into(),
             env.ptr_int().into(),
             env.ptr_int().into(),
         ],
@@ -4015,7 +4018,7 @@ fn expose_function_to_host_help_c_abi_v2<'a, 'ctx, 'env>(
                     // bitcast the ptr
                     let fastcc_ptr = env.builder.build_pointer_cast(
                         arg.into_pointer_value(),
-                        fastcc_type.ptr_type(AddressSpace::Generic),
+                        fastcc_type.ptr_type(AddressSpace::default()),
                         "bitcast_arg",
                     );
 
@@ -4192,7 +4195,7 @@ pub fn get_sjlj_buffer<'a, 'ctx, 'env>(env: &Env<'a, 'ctx, 'env>) -> PointerValu
 
     env.builder.build_pointer_cast(
         global.as_pointer_value(),
-        env.context.i32_type().ptr_type(AddressSpace::Generic),
+        env.context.i32_type().ptr_type(AddressSpace::default()),
         "cast_sjlj_buffer",
     )
 }
@@ -4209,12 +4212,12 @@ pub fn build_setjmp_call<'a, 'ctx, 'env>(env: &Env<'a, 'ctx, 'env>) -> BasicValu
         let buf_type = env
             .context
             .i8_type()
-            .ptr_type(AddressSpace::Generic)
+            .ptr_type(AddressSpace::default())
             .array_type(5);
 
         let jmp_buf_i8p_arr = env.builder.build_pointer_cast(
             jmp_buf,
-            buf_type.ptr_type(AddressSpace::Generic),
+            buf_type.ptr_type(AddressSpace::default()),
             "jmp_buf [5 x i8*]",
         );
 
@@ -4255,7 +4258,7 @@ pub fn build_setjmp_call<'a, 'ctx, 'env>(env: &Env<'a, 'ctx, 'env>) -> BasicValu
             .builder
             .build_pointer_cast(
                 jmp_buf,
-                env.context.i8_type().ptr_type(AddressSpace::Generic),
+                env.context.i8_type().ptr_type(AddressSpace::default()),
                 "jmp_buf i8*",
             )
             .into();
@@ -4412,7 +4415,7 @@ fn roc_call_result_type<'a, 'ctx, 'env>(
     env.context.struct_type(
         &[
             env.context.i64_type().into(),
-            zig_str_type(env).ptr_type(AddressSpace::Generic).into(),
+            zig_str_type(env).ptr_type(AddressSpace::default()).into(),
             return_type,
         ],
         false,
@@ -4488,7 +4491,7 @@ fn make_exception_catching_wrapper<'a, 'ctx, 'env>(
         basic_type_from_layout(env, layout_interner, return_layout),
     );
 
-    // argument_types.push(wrapper_return_type.ptr_type(AddressSpace::Generic).into());
+    // argument_types.push(wrapper_return_type.ptr_type(AddressSpace::default()).into());
 
     // let wrapper_function_type = env.context.void_type().fn_type(&argument_types, false);
     let wrapper_function_spec = FunctionSpec::cconv(
@@ -5015,7 +5018,7 @@ fn build_closure_caller<'a, 'ctx, 'env>(
 
     for layout in arguments {
         let arg_type = basic_type_from_layout(env, layout_interner, *layout);
-        let arg_ptr_type = arg_type.ptr_type(AddressSpace::Generic);
+        let arg_ptr_type = arg_type.ptr_type(AddressSpace::default());
 
         argument_types.push(arg_ptr_type.into());
     }
@@ -5024,7 +5027,7 @@ fn build_closure_caller<'a, 'ctx, 'env>(
         let basic_type =
             basic_type_from_layout(env, layout_interner, lambda_set.runtime_representation());
 
-        basic_type.ptr_type(AddressSpace::Generic)
+        basic_type.ptr_type(AddressSpace::default())
     };
     argument_types.push(closure_argument_type.into());
 
@@ -5033,7 +5036,7 @@ fn build_closure_caller<'a, 'ctx, 'env>(
 
     let result_type = basic_type_from_layout(env, layout_interner, result);
 
-    let output_type = { result_type.ptr_type(AddressSpace::Generic) };
+    let output_type = { result_type.ptr_type(AddressSpace::default()) };
     argument_types.push(output_type.into());
 
     // STEP 1: build function header
@@ -5549,7 +5552,7 @@ fn to_cc_type_builtin<'a, 'ctx, 'env>(
             basic_type_from_builtin(env, builtin)
         }
         Builtin::Str | Builtin::List(_) => {
-            let address_space = AddressSpace::Generic;
+            let address_space = AddressSpace::default();
             let field_types: [BasicTypeEnum; 3] = [
                 env.context.i8_type().ptr_type(address_space).into(),
                 env.ptr_int().into(),
@@ -5664,7 +5667,7 @@ impl<'ctx> FunctionSpec<'ctx> {
         let (typ, opt_sret_parameter) = match cc_return {
             CCReturn::ByPointer => {
                 // turn the output type into a pointer type. Make it the first argument to the function
-                let output_type = return_type.unwrap().ptr_type(AddressSpace::Generic);
+                let output_type = return_type.unwrap().ptr_type(AddressSpace::default());
 
                 let mut arguments: Vec<'_, BasicTypeEnum> =
                     bumpalo::vec![in env.arena; output_type.into()];
@@ -5706,7 +5709,7 @@ impl<'ctx> FunctionSpec<'ctx> {
                 return_type.fn_type(&function_arguments(env, &argument_types), false)
             }
             RocReturn::ByPointer => {
-                argument_types.push(return_type.ptr_type(AddressSpace::Generic).into());
+                argument_types.push(return_type.ptr_type(AddressSpace::default()).into());
                 env.context
                     .void_type()
                     .fn_type(&function_arguments(env, &argument_types), false)
@@ -5954,7 +5957,7 @@ fn define_global_str_literal_ptr<'a, 'ctx, 'env>(
 
     let ptr = env.builder.build_pointer_cast(
         global.as_pointer_value(),
-        env.context.i8_type().ptr_type(AddressSpace::Generic),
+        env.context.i8_type().ptr_type(AddressSpace::default()),
         "to_opaque",
     );
 

--- a/crates/compiler/gen_llvm/src/llvm/build_list.rs
+++ b/crates/compiler/gen_llvm/src/llvm/build_list.rs
@@ -74,7 +74,7 @@ fn pass_element_as_opaque<'a, 'ctx, 'env>(
     env.builder
         .build_pointer_cast(
             element_ptr,
-            env.context.i8_type().ptr_type(AddressSpace::Generic),
+            env.context.i8_type().ptr_type(AddressSpace::default()),
             "pass_element_as_opaque",
         )
         .into()
@@ -97,7 +97,7 @@ pub(crate) fn pass_as_opaque<'a, 'ctx, 'env>(
     env.builder
         .build_pointer_cast(
             ptr,
-            env.context.i8_type().ptr_type(AddressSpace::Generic),
+            env.context.i8_type().ptr_type(AddressSpace::default()),
             "pass_as_opaque",
         )
         .into()
@@ -133,7 +133,7 @@ pub(crate) fn list_get_unsafe<'a, 'ctx, 'env>(
     let builder = env.builder;
 
     let elem_type = basic_type_from_layout(env, layout_interner, element_layout);
-    let ptr_type = elem_type.ptr_type(AddressSpace::Generic);
+    let ptr_type = elem_type.ptr_type(AddressSpace::default());
     // Load the pointer to the array data
     let array_data_ptr = load_list_ptr(builder, wrapper_struct, ptr_type);
 
@@ -804,7 +804,7 @@ pub(crate) fn decref<'a, 'ctx, 'env>(
     let (_, pointer) = load_list(
         env.builder,
         wrapper_struct,
-        env.context.i8_type().ptr_type(AddressSpace::Generic),
+        env.context.i8_type().ptr_type(AddressSpace::default()),
     );
 
     crate::llvm::refcounting::decref_pointer_check_null(env, pointer, alignment);

--- a/crates/compiler/gen_llvm/src/llvm/build_str.rs
+++ b/crates/compiler/gen_llvm/src/llvm/build_str.rs
@@ -32,7 +32,7 @@ pub(crate) fn decode_from_utf8_result<'a, 'ctx, 'env>(
         PtrWidth::Bytes4 | PtrWidth::Bytes8 => {
             let result_ptr_cast = env.builder.build_pointer_cast(
                 pointer,
-                record_type.ptr_type(AddressSpace::Generic),
+                record_type.ptr_type(AddressSpace::default()),
                 "to_unnamed",
             );
 

--- a/crates/compiler/gen_llvm/src/llvm/compare.rs
+++ b/crates/compiler/gen_llvm/src/llvm/compare.rs
@@ -4,9 +4,7 @@ use crate::llvm::build_str::str_equal;
 use crate::llvm::convert::basic_type_from_layout;
 use bumpalo::collections::Vec;
 use inkwell::types::BasicType;
-use inkwell::values::{
-    BasicValue, BasicValueEnum, FunctionValue, IntValue, PointerValue, StructValue,
-};
+use inkwell::values::{BasicValueEnum, FunctionValue, IntValue, PointerValue, StructValue};
 use inkwell::{AddressSpace, FloatPredicate, IntPredicate};
 use roc_builtins::bitcode;
 use roc_builtins::bitcode::{FloatWidth, IntWidth};
@@ -461,8 +459,7 @@ fn build_list_eq<'a, 'ctx, 'env>(
     };
 
     env.builder.position_at_end(block);
-    env.builder
-        .set_current_debug_location(env.context, di_location);
+    env.builder.set_current_debug_location(di_location);
     let call = env
         .builder
         .build_call(function, &[list1.into(), list2.into()], "list_eq");
@@ -500,7 +497,7 @@ fn build_list_eq_help<'a, 'ctx, 'env>(
             /* current_scope */ lexical_block.as_debug_info_scope(),
             /* inlined_at */ None,
         );
-        builder.set_current_debug_location(ctx, loc);
+        builder.set_current_debug_location(loc);
     }
 
     // Add args to scope
@@ -537,7 +534,7 @@ fn build_list_eq_help<'a, 'ctx, 'env>(
 
         let builder = env.builder;
         let element_type = basic_type_from_layout(env, layout_interner, element_layout);
-        let ptr_type = element_type.ptr_type(AddressSpace::Generic);
+        let ptr_type = element_type.ptr_type(AddressSpace::default());
         let ptr1 = load_list_ptr(env.builder, list1, ptr_type);
         let ptr2 = load_list_ptr(env.builder, list2, ptr_type);
 
@@ -672,8 +669,7 @@ fn build_struct_eq<'a, 'ctx, 'env>(
     };
 
     env.builder.position_at_end(block);
-    env.builder
-        .set_current_debug_location(env.context, di_location);
+    env.builder.set_current_debug_location(di_location);
     let call = env
         .builder
         .build_call(function, &[struct1.into(), struct2.into()], "struct_eq");
@@ -711,7 +707,7 @@ fn build_struct_eq_help<'a, 'ctx, 'env>(
             /* current_scope */ lexical_block.as_debug_info_scope(),
             /* inlined_at */ None,
         );
-        builder.set_current_debug_location(ctx, loc);
+        builder.set_current_debug_location(loc);
     }
 
     // Add args to scope
@@ -858,8 +854,7 @@ fn build_tag_eq<'a, 'ctx, 'env>(
     };
 
     env.builder.position_at_end(block);
-    env.builder
-        .set_current_debug_location(env.context, di_location);
+    env.builder.set_current_debug_location(di_location);
     let call = env
         .builder
         .build_call(function, &[tag1.into(), tag2.into()], "tag_eq");
@@ -897,7 +892,7 @@ fn build_tag_eq_help<'a, 'ctx, 'env>(
             /* current_scope */ lexical_block.as_debug_info_scope(),
             /* inlined_at */ None,
         );
-        builder.set_current_debug_location(ctx, loc);
+        builder.set_current_debug_location(loc);
     }
 
     // Add args to scope
@@ -1285,13 +1280,13 @@ fn eq_ptr_to_struct<'a, 'ctx, 'env>(
     // cast the opaque pointer to a pointer of the correct shape
     let struct1_ptr = env.builder.build_pointer_cast(
         tag1,
-        wrapper_type.ptr_type(AddressSpace::Generic),
+        wrapper_type.ptr_type(AddressSpace::default()),
         "opaque_to_correct",
     );
 
     let struct2_ptr = env.builder.build_pointer_cast(
         tag2,
-        wrapper_type.ptr_type(AddressSpace::Generic),
+        wrapper_type.ptr_type(AddressSpace::default()),
         "opaque_to_correct",
     );
 
@@ -1361,8 +1356,7 @@ fn build_box_eq<'a, 'ctx, 'env>(
     };
 
     env.builder.position_at_end(block);
-    env.builder
-        .set_current_debug_location(env.context, di_location);
+    env.builder.set_current_debug_location(di_location);
     let call = env
         .builder
         .build_call(function, &[tag1.into(), tag2.into()], "tag_eq");
@@ -1400,7 +1394,7 @@ fn build_box_eq_help<'a, 'ctx, 'env>(
             /* current_scope */ lexical_block.as_debug_info_scope(),
             /* inlined_at */ None,
         );
-        builder.set_current_debug_location(ctx, loc);
+        builder.set_current_debug_location(loc);
     }
 
     // Add args to scope

--- a/crates/compiler/gen_llvm/src/llvm/convert.rs
+++ b/crates/compiler/gen_llvm/src/llvm/convert.rs
@@ -44,13 +44,13 @@ pub fn basic_type_from_layout<'a, 'ctx, 'env>(
         Boxed(inner_layout) => {
             let inner_type = basic_type_from_layout(env, layout_interner, inner_layout);
 
-            inner_type.ptr_type(AddressSpace::Generic).into()
+            inner_type.ptr_type(AddressSpace::default()).into()
         }
         Union(union_layout) => basic_type_from_union_layout(env, layout_interner, &union_layout),
         RecursivePointer(_) => env
             .context
             .i64_type()
-            .ptr_type(AddressSpace::Generic)
+            .ptr_type(AddressSpace::default())
             .as_basic_type_enum(),
 
         Builtin(builtin) => basic_type_from_builtin(env, &builtin),
@@ -109,7 +109,7 @@ pub fn basic_type_from_union_layout<'a, 'ctx, 'env>(
         Recursive(_)
         | NonNullableUnwrapped(_)
         | NullableWrapped { .. }
-        | NullableUnwrapped { .. } => struct_type.ptr_type(AddressSpace::Generic).into(),
+        | NullableUnwrapped { .. } => struct_type.ptr_type(AddressSpace::default()).into(),
     }
 }
 
@@ -158,7 +158,7 @@ pub fn argument_type_from_layout<'a, 'ctx, 'env>(
             let base = basic_type_from_layout(env, layout_interner, layout);
 
             if layout_interner.is_passed_by_reference(layout) {
-                base.ptr_type(AddressSpace::Generic).into()
+                base.ptr_type(AddressSpace::default()).into()
             } else {
                 base
             }
@@ -176,7 +176,7 @@ pub fn argument_type_from_union_layout<'a, 'ctx, 'env>(
     let heap_type = basic_type_from_union_layout(env, layout_interner, union_layout);
 
     if let UnionLayout::NonRecursive(_) = union_layout {
-        heap_type.ptr_type(AddressSpace::Generic).into()
+        heap_type.ptr_type(AddressSpace::default()).into()
     } else {
         heap_type
     }
@@ -375,7 +375,7 @@ impl<'ctx> RocUnion<'ctx> {
 
         let cast_pointer = env.builder.build_pointer_cast(
             data_buffer,
-            data.get_type().ptr_type(AddressSpace::Generic),
+            data.get_type().ptr_type(AddressSpace::default()),
             "to_data_ptr",
         );
 
@@ -436,7 +436,7 @@ pub fn zig_dec_type<'a, 'ctx, 'env>(env: &Env<'a, 'ctx, 'env>) -> StructType<'ct
 }
 
 pub fn zig_has_tag_id_type<'a, 'ctx, 'env>(env: &Env<'a, 'ctx, 'env>) -> StructType<'ctx> {
-    let u8_ptr_t = env.context.i8_type().ptr_type(AddressSpace::Generic);
+    let u8_ptr_t = env.context.i8_type().ptr_type(AddressSpace::default());
 
     env.context
         .struct_type(&[env.context.bool_type().into(), u8_ptr_t.into()], false)

--- a/crates/compiler/gen_llvm/src/llvm/expect.rs
+++ b/crates/compiler/gen_llvm/src/llvm/expect.rs
@@ -99,7 +99,7 @@ fn read_state<'a, 'ctx, 'env>(
     env: &Env<'a, 'ctx, 'env>,
     ptr: PointerValue<'ctx>,
 ) -> (IntValue<'ctx>, IntValue<'ctx>) {
-    let ptr_type = env.ptr_int().ptr_type(AddressSpace::Generic);
+    let ptr_type = env.ptr_int().ptr_type(AddressSpace::default());
     let ptr = env.builder.build_pointer_cast(ptr, ptr_type, "");
 
     let one = env.ptr_int().const_int(1, false);
@@ -119,7 +119,7 @@ fn write_state<'a, 'ctx, 'env>(
     count: IntValue<'ctx>,
     offset: IntValue<'ctx>,
 ) {
-    let ptr_type = env.ptr_int().ptr_type(AddressSpace::Generic);
+    let ptr_type = env.ptr_int().ptr_type(AddressSpace::default());
     let ptr = env.builder.build_pointer_cast(ptr, ptr_type, "");
 
     let one = env.ptr_int().const_int(1, false);
@@ -252,7 +252,7 @@ pub(crate) fn clone_to_shared_memory<'a, 'ctx, 'env>(
                     )
                 };
 
-                let u32_ptr = env.context.i32_type().ptr_type(AddressSpace::Generic);
+                let u32_ptr = env.context.i32_type().ptr_type(AddressSpace::default());
                 let ptr = env
                     .builder
                     .build_pointer_cast(ptr, u32_ptr, "cast_ptr_type");
@@ -323,7 +323,7 @@ fn build_clone<'a, 'ctx, 'env>(
                     )
                 };
 
-                let ptr_type = value.get_type().ptr_type(AddressSpace::Generic);
+                let ptr_type = value.get_type().ptr_type(AddressSpace::default());
                 let ptr = env
                     .builder
                     .build_pointer_cast(ptr, ptr_type, "cast_ptr_type");
@@ -479,7 +479,10 @@ fn build_clone_tag<'a, 'ctx, 'env>(
 
             let function_type = env.ptr_int().fn_type(
                 &[
-                    env.context.i8_type().ptr_type(AddressSpace::Generic).into(),
+                    env.context
+                        .i8_type()
+                        .ptr_type(AddressSpace::default())
+                        .into(),
                     env.ptr_int().into(),
                     env.ptr_int().into(),
                     BasicMetadataTypeEnum::from(value.get_type()),
@@ -509,8 +512,7 @@ fn build_clone_tag<'a, 'ctx, 'env>(
             );
 
             env.builder.position_at_end(block);
-            env.builder
-                .set_current_debug_location(env.context, di_location);
+            env.builder.set_current_debug_location(di_location);
 
             function_value
         }
@@ -555,7 +557,7 @@ fn load_tag_data<'a, 'ctx, 'env>(
 
     let data_ptr = env.builder.build_pointer_cast(
         raw_data_ptr,
-        tag_type.ptr_type(AddressSpace::Generic),
+        tag_type.ptr_type(AddressSpace::default()),
         "data_ptr",
     );
 
@@ -924,7 +926,7 @@ fn build_copy<'a, 'ctx, 'env>(
         )
     };
 
-    let ptr_type = value.get_type().ptr_type(AddressSpace::Generic);
+    let ptr_type = value.get_type().ptr_type(AddressSpace::default());
     let ptr = env
         .builder
         .build_pointer_cast(ptr, ptr_type, "cast_ptr_type");
@@ -996,7 +998,7 @@ fn build_clone_builtin<'a, 'ctx, 'env>(
                 let dest = pointer_at_offset(bd, env.context.i8_type(), ptr, elements_start_offset);
                 let src = bd.build_pointer_cast(
                     elements,
-                    env.context.i8_type().ptr_type(AddressSpace::Generic),
+                    env.context.i8_type().ptr_type(AddressSpace::default()),
                     "to_bytes_pointer",
                 );
                 bd.build_memcpy(dest, 1, src, 1, elements_width).unwrap();
@@ -1006,7 +1008,7 @@ fn build_clone_builtin<'a, 'ctx, 'env>(
                 let element_type = basic_type_from_layout(env, layout_interner, elem);
                 let elements = bd.build_pointer_cast(
                     elements,
-                    element_type.ptr_type(AddressSpace::Generic),
+                    element_type.ptr_type(AddressSpace::default()),
                     "elements",
                 );
 

--- a/crates/compiler/gen_llvm/src/llvm/externs.rs
+++ b/crates/compiler/gen_llvm/src/llvm/externs.rs
@@ -4,7 +4,6 @@ use crate::llvm::build::{CCReturn, Env, FunctionSpec};
 use crate::llvm::convert::zig_str_type;
 use inkwell::module::Linkage;
 use inkwell::types::BasicType;
-use inkwell::values::BasicValue;
 use inkwell::AddressSpace;
 use roc_builtins::bitcode;
 
@@ -19,7 +18,7 @@ pub fn add_default_roc_externs(env: &Env<'_, '_, '_>) {
     let builder = env.builder;
 
     let usize_type = env.ptr_int();
-    let i8_ptr_type = ctx.i8_type().ptr_type(AddressSpace::Generic);
+    let i8_ptr_type = ctx.i8_type().ptr_type(AddressSpace::default());
 
     match env.mode {
         super::build::LlvmBackendMode::CliTest => {
@@ -271,7 +270,7 @@ pub fn build_longjmp_call(env: &Env) {
         // Call the LLVM-intrinsic longjmp: `void @llvm.eh.sjlj.longjmp(i8* %setjmp_buf)`
         let jmp_buf_i8p = env.builder.build_pointer_cast(
             jmp_buf,
-            env.context.i8_type().ptr_type(AddressSpace::Generic),
+            env.context.i8_type().ptr_type(AddressSpace::default()),
             "jmp_buf i8*",
         );
         let _call = env.build_intrinsic_call(LLVM_LONGJMP, &[jmp_buf_i8p.into()]);

--- a/crates/compiler/gen_llvm/src/llvm/intrinsics.rs
+++ b/crates/compiler/gen_llvm/src/llvm/intrinsics.rs
@@ -75,7 +75,7 @@ pub(crate) fn add_intrinsics<'ctx>(ctx: &'ctx Context, module: &Module<'ctx>) {
     // https://releases.llvm.org/10.0.0/docs/LangRef.html#standard-c-library-intrinsics
     let i1_type = ctx.bool_type();
     let i8_type = ctx.i8_type();
-    let i8_ptr_type = i8_type.ptr_type(AddressSpace::Generic);
+    let i8_ptr_type = i8_type.ptr_type(AddressSpace::default());
     let i32_type = ctx.i32_type();
     let void_type = ctx.void_type();
 

--- a/crates/compiler/gen_llvm/src/llvm/lowlevel.rs
+++ b/crates/compiler/gen_llvm/src/llvm/lowlevel.rs
@@ -248,7 +248,7 @@ pub(crate) fn run_low_level<'a, 'ctx, 'env>(
 
                             let roc_return_type =
                                 basic_type_from_layout(env, layout_interner, layout)
-                                    .ptr_type(AddressSpace::Generic);
+                                    .ptr_type(AddressSpace::default());
 
                             let roc_return_alloca = env.builder.build_pointer_cast(
                                 zig_return_alloca,
@@ -489,7 +489,7 @@ pub(crate) fn run_low_level<'a, 'ctx, 'env>(
                     let return_type = basic_type_from_layout(env, layout_interner, layout);
                     let cast_result = env.builder.build_pointer_cast(
                         result,
-                        return_type.ptr_type(AddressSpace::Generic),
+                        return_type.ptr_type(AddressSpace::default()),
                         "cast",
                     );
 
@@ -1655,7 +1655,7 @@ fn dec_alloca<'a, 'ctx, 'env>(
 
     let ptr = env.builder.build_pointer_cast(
         alloca,
-        value.get_type().ptr_type(AddressSpace::Generic),
+        value.get_type().ptr_type(AddressSpace::default()),
         "cast_to_i128_ptr",
     );
 
@@ -2005,7 +2005,7 @@ fn build_int_unary_op<'a, 'ctx, 'env>(
 
                                 let roc_return_type =
                                     basic_type_from_layout(env, layout_interner, return_layout)
-                                        .ptr_type(AddressSpace::Generic);
+                                        .ptr_type(AddressSpace::default());
 
                                 let roc_return_alloca = env.builder.build_pointer_cast(
                                     zig_return_alloca,

--- a/crates/compiler/gen_llvm/src/llvm/refcounting.rs
+++ b/crates/compiler/gen_llvm/src/llvm/refcounting.rs
@@ -11,9 +11,7 @@ use bumpalo::collections::Vec;
 use inkwell::basic_block::BasicBlock;
 use inkwell::module::Linkage;
 use inkwell::types::{AnyTypeEnum, BasicMetadataTypeEnum, BasicType, BasicTypeEnum};
-use inkwell::values::{
-    BasicValue, BasicValueEnum, FunctionValue, IntValue, PointerValue, StructValue,
-};
+use inkwell::values::{BasicValueEnum, FunctionValue, IntValue, PointerValue, StructValue};
 use inkwell::{AddressSpace, IntPredicate};
 use roc_module::symbol::Interns;
 use roc_module::symbol::Symbol;
@@ -40,7 +38,7 @@ impl<'ctx> PointerToRefcount<'ctx> {
 
         let value = env.builder.build_pointer_cast(
             ptr,
-            refcount_type.ptr_type(AddressSpace::Generic),
+            refcount_type.ptr_type(AddressSpace::default()),
             "to_refcount_ptr",
         );
 
@@ -54,7 +52,7 @@ impl<'ctx> PointerToRefcount<'ctx> {
         let builder = env.builder;
         // pointer to usize
         let refcount_type = env.ptr_int();
-        let refcount_ptr_type = refcount_type.ptr_type(AddressSpace::Generic);
+        let refcount_ptr_type = refcount_type.ptr_type(AddressSpace::default());
 
         let ptr_as_usize_ptr =
             builder.build_pointer_cast(data_ptr, refcount_ptr_type, "as_usize_ptr");
@@ -148,7 +146,7 @@ impl<'ctx> PointerToRefcount<'ctx> {
             None => {
                 // inc and dec return void
                 let fn_type = context.void_type().fn_type(
-                    &[env.ptr_int().ptr_type(AddressSpace::Generic).into()],
+                    &[env.ptr_int().ptr_type(AddressSpace::default()).into()],
                     false,
                 );
 
@@ -172,8 +170,7 @@ impl<'ctx> PointerToRefcount<'ctx> {
         let refcount_ptr = self.value;
 
         env.builder.position_at_end(block);
-        env.builder
-            .set_current_debug_location(env.context, di_location);
+        env.builder.set_current_debug_location(di_location);
 
         let call = env
             .builder
@@ -216,7 +213,7 @@ fn incref_pointer<'a, 'ctx, 'env>(
             env.builder
                 .build_pointer_cast(
                     pointer,
-                    env.ptr_int().ptr_type(AddressSpace::Generic),
+                    env.ptr_int().ptr_type(AddressSpace::default()),
                     "to_isize_ptr",
                 )
                 .into(),
@@ -238,7 +235,7 @@ fn decref_pointer<'a, 'ctx, 'env>(
             env.builder
                 .build_pointer_cast(
                     pointer,
-                    env.ptr_int().ptr_type(AddressSpace::Generic),
+                    env.ptr_int().ptr_type(AddressSpace::default()),
                     "to_isize_ptr",
                 )
                 .into(),
@@ -261,7 +258,7 @@ pub fn decref_pointer_check_null<'a, 'ctx, 'env>(
             env.builder
                 .build_pointer_cast(
                     pointer,
-                    env.context.i8_type().ptr_type(AddressSpace::Generic),
+                    env.context.i8_type().ptr_type(AddressSpace::default()),
                     "to_i8_ptr",
                 )
                 .into(),
@@ -312,8 +309,7 @@ fn modify_refcount_struct<'a, 'ctx, 'env>(
     };
 
     env.builder.position_at_end(block);
-    env.builder
-        .set_current_debug_location(env.context, di_location);
+    env.builder.set_current_debug_location(di_location);
 
     function
 }
@@ -655,8 +651,7 @@ fn modify_refcount_list<'a, 'ctx, 'env>(
     };
 
     env.builder.position_at_end(block);
-    env.builder
-        .set_current_debug_location(env.context, di_location);
+    env.builder.set_current_debug_location(di_location);
 
     function
 }
@@ -715,7 +710,7 @@ fn modify_refcount_list_help<'a, 'ctx, 'env>(
 
     if layout_interner.contains_refcounted(element_layout) {
         let ptr_type = basic_type_from_layout(env, layout_interner, element_layout)
-            .ptr_type(AddressSpace::Generic);
+            .ptr_type(AddressSpace::default());
 
         let (len, ptr) = load_list(env.builder, original_wrapper, ptr_type);
 
@@ -786,8 +781,7 @@ fn modify_refcount_str<'a, 'ctx, 'env>(
     };
 
     env.builder.position_at_end(block);
-    env.builder
-        .set_current_debug_location(env.context, di_location);
+    env.builder.set_current_debug_location(di_location);
 
     function
 }
@@ -896,8 +890,7 @@ fn modify_refcount_boxed<'a, 'ctx, 'env>(
     };
 
     env.builder.position_at_end(block);
-    env.builder
-        .set_current_debug_location(env.context, di_location);
+    env.builder.set_current_debug_location(di_location);
 
     function
 }
@@ -1062,8 +1055,7 @@ fn build_rec_union<'a, 'ctx, 'env>(
             );
 
             env.builder.position_at_end(block);
-            env.builder
-                .set_current_debug_location(env.context, di_location);
+            env.builder.set_current_debug_location(di_location);
 
             function_value
         }
@@ -1248,7 +1240,7 @@ fn build_rec_union_recursive_decrement<'a, 'ctx, 'env>(
         // cast the opaque pointer to a pointer of the correct shape
         let struct_ptr = env.builder.build_pointer_cast(
             value_ptr,
-            wrapper_type.ptr_type(AddressSpace::Generic),
+            wrapper_type.ptr_type(AddressSpace::default()),
             "opaque_to_correct_recursive_decrement",
         );
 
@@ -1271,7 +1263,7 @@ fn build_rec_union_recursive_decrement<'a, 'ctx, 'env>(
                     .unwrap();
 
                 let ptr_as_i64_ptr = env.builder.new_build_load(
-                    env.context.i64_type().ptr_type(AddressSpace::Generic),
+                    env.context.i64_type().ptr_type(AddressSpace::default()),
                     elem_pointer,
                     "load_recursive_pointer",
                 );
@@ -1455,8 +1447,7 @@ pub fn build_reset<'a, 'ctx, 'env>(
             );
 
             env.builder.position_at_end(block);
-            env.builder
-                .set_current_debug_location(env.context, di_location);
+            env.builder.set_current_debug_location(di_location);
 
             function_value
         }
@@ -1622,8 +1613,7 @@ fn modify_refcount_nonrecursive<'a, 'ctx, 'env>(
     };
 
     env.builder.position_at_end(block);
-    env.builder
-        .set_current_debug_location(env.context, di_location);
+    env.builder.set_current_debug_location(di_location);
 
     function
 }
@@ -1722,7 +1712,7 @@ fn modify_refcount_nonrecursive_help<'a, 'ctx, 'env>(
 
         let cast_tag_data_pointer = env.builder.build_pointer_cast(
             opaque_tag_data_ptr,
-            data_struct_type.ptr_type(AddressSpace::Generic),
+            data_struct_type.ptr_type(AddressSpace::default()),
             "cast_to_concrete_tag",
         );
 
@@ -1741,7 +1731,7 @@ fn modify_refcount_nonrecursive_help<'a, 'ctx, 'env>(
 
                 // This is the actual pointer to the recursive data.
                 let field_value = env.builder.new_build_load(
-                    env.context.i64_type().ptr_type(AddressSpace::Generic),
+                    env.context.i64_type().ptr_type(AddressSpace::default()),
                     field_ptr,
                     "load_recursive_pointer",
                 );

--- a/default.nix
+++ b/default.nix
@@ -24,7 +24,7 @@ rustPlatform.buildRustPackage {
     outputHashes = {
       "confy-0.5.0" = "sha256-BVTczVbURL1Id/k/5ArlDQTZxLuI3XxQl7BdIx230U4=";
       "criterion-0.3.5" = "sha256-7REd3phV6PBzqWwKF8hwttw4FTq2tKGxxAAJDpLC50A=";
-      "inkwell-0.1.0" = "sha256-Sl50CW9H5IXV3k7BoAc0l2mv57lbrzhNxD0ub1AlOxM=";
+      "inkwell-0.1.0" = "sha256-1kpvY3naS33B99nuu5ZYhb7mdddAyG+DkbUl/RG1Ptg=";
       "plotters-0.3.1" = "sha256-noy/RSjoEPZZbOJTZw1yxGcX5S+2q/7mxnUrzDyxOFw=";
       "rustyline-9.1.1" = "sha256-aqQqz6nSp+Qn44gm3jXmmQUO6/fYTx7iLph2tbA24Bs=";
     };


### PR DESCRIPTION
upgrades to an inkwell version that supports llvm 15 (but llvm 15 is not yet enabled).

It then updates API usage in preparation of the llvm 15 upgrade