### PR TITLE
gen_dev: add `List.prepend`

### DIFF
--- a/crates/compiler/gen_dev/src/generic64/mod.rs
+++ b/crates/compiler/gen_dev/src/generic64/mod.rs
@@ -1333,12 +1333,7 @@ impl<
             // element_width
             Symbol::DEV_TMP2,
          ];
-        let lowlevel_arg_layouts = bumpalo::vec![
-        in self.env.arena;
-            capacity_layout,
-            u32_layout,
-            u64_layout,
-        ];
+        let lowlevel_arg_layouts = [capacity_layout, u32_layout, u64_layout];
 
         self.build_fn_call(
             &Symbol::DEV_TMP3,
@@ -1418,14 +1413,7 @@ impl<
             Symbol::DEV_TMP3,
 
          ];
-        let lowlevel_arg_layouts = bumpalo::vec![
-        in self.env.arena;
-            list_layout,
-            u32_layout,
-            spare_layout,
-            u64_layout,
-            u8_layout
-        ];
+        let lowlevel_arg_layouts = [list_layout, u32_layout, spare_layout, u64_layout, u8_layout];
 
         self.build_fn_call(
             &Symbol::DEV_TMP4,
@@ -1495,12 +1483,7 @@ impl<
             // element_width
             Symbol::DEV_TMP2
          ];
-        let lowlevel_arg_layouts = bumpalo::vec![
-        in self.env.arena;
-            list_layout,
-            u64_layout,
-            u64_layout,
-        ];
+        let lowlevel_arg_layouts = [list_layout, u64_layout, u64_layout];
 
         self.build_fn_call(
             &Symbol::DEV_TMP3,
@@ -1648,14 +1631,13 @@ impl<
             Symbol::DEV_TMP3,
             Symbol::DEV_TMP4,
          ];
-        let lowlevel_arg_layouts = bumpalo::vec![
-        in self.env.arena;
-                list_layout,
-                u32_layout,
-                index_layout,
-                u64_layout,
-                u64_layout,
-                u64_layout,
+        let lowlevel_arg_layouts = [
+            list_layout,
+            u32_layout,
+            index_layout,
+            u64_layout,
+            u64_layout,
+            u64_layout,
         ];
 
         self.build_fn_call(
@@ -1727,13 +1709,7 @@ impl<
             // element_width
             Symbol::DEV_TMP2,
          ];
-        let lowlevel_arg_layouts = bumpalo::vec![
-        in self.env.arena;
-            list_a_layout,
-            list_b_layout,
-            u32_layout,
-            u64_layout
-        ];
+        let lowlevel_arg_layouts = [list_a_layout, list_b_layout, u32_layout, u64_layout];
 
         self.build_fn_call(
             &Symbol::DEV_TMP3,
@@ -1814,13 +1790,7 @@ impl<
             // element_width
             Symbol::DEV_TMP3,
          ];
-        let lowlevel_arg_layouts = bumpalo::vec![
-        in self.env.arena;
-            list_layout,
-            u32_layout,
-            u64_layout,
-            u64_layout,
-        ];
+        let lowlevel_arg_layouts = [list_layout, u32_layout, u64_layout, u64_layout];
 
         self.build_fn_call(
             &Symbol::DEV_TMP4,

--- a/crates/compiler/gen_dev/src/generic64/mod.rs
+++ b/crates/compiler/gen_dev/src/generic64/mod.rs
@@ -1758,6 +1758,93 @@ impl<
         self.free_symbol(&Symbol::DEV_TMP3);
     }
 
+    fn build_list_prepend(
+        &mut self,
+        dst: &Symbol,
+        args: &'a [Symbol],
+        arg_layouts: &[InLayout<'a>],
+        ret_layout: &InLayout<'a>,
+    ) {
+        let list = args[0];
+        let list_layout = arg_layouts[0];
+        let elem = args[1];
+        let elem_layout = arg_layouts[1];
+
+        // List alignment argument (u32).
+        let u32_layout = Layout::U32;
+        let list_alignment = self.layout_interner.alignment_bytes(*ret_layout);
+        self.load_literal(
+            &Symbol::DEV_TMP,
+            &u32_layout,
+            &Literal::Int((list_alignment as i128).to_ne_bytes()),
+        );
+
+        // Have to pass the input element by pointer, so put it on the stack and load it's address.
+        self.storage_manager
+            .ensure_symbol_on_stack(&mut self.buf, &elem);
+        let (new_elem_offset, _) = self.storage_manager.stack_offset_and_size(&elem);
+
+        // Load address of input element into register.
+        let reg = self
+            .storage_manager
+            .claim_general_reg(&mut self.buf, &Symbol::DEV_TMP2);
+        ASM::add_reg64_reg64_imm32(&mut self.buf, reg, CC::BASE_PTR_REG, new_elem_offset);
+
+        // Load element_witdh argument (usize).
+        let u64_layout = Layout::U64;
+        let elem_stack_size = self.layout_interner.stack_size(elem_layout);
+        self.load_literal(
+            &Symbol::DEV_TMP3,
+            &u64_layout,
+            &Literal::Int((elem_stack_size as i128).to_ne_bytes()),
+        );
+
+        // Setup the return location.
+        let base_offset = self
+            .storage_manager
+            .claim_stack_area(dst, self.layout_interner.stack_size(*ret_layout));
+
+        let lowlevel_args = bumpalo::vec![
+        in self.env.arena;
+            list,
+            // alignment
+            Symbol::DEV_TMP,
+            // element
+            Symbol::DEV_TMP2,
+            // element_width
+            Symbol::DEV_TMP3,
+         ];
+        let lowlevel_arg_layouts = bumpalo::vec![
+        in self.env.arena;
+            list_layout,
+            u32_layout,
+            u64_layout,
+            u64_layout,
+        ];
+
+        self.build_fn_call(
+            &Symbol::DEV_TMP4,
+            bitcode::LIST_PREPEND.to_string(),
+            &lowlevel_args,
+            &lowlevel_arg_layouts,
+            ret_layout,
+        );
+        self.free_symbol(&Symbol::DEV_TMP);
+        self.free_symbol(&Symbol::DEV_TMP2);
+        self.free_symbol(&Symbol::DEV_TMP3);
+
+        // Return list value from fn call
+        self.storage_manager.copy_symbol_to_stack_offset(
+            self.layout_interner,
+            &mut self.buf,
+            base_offset,
+            &Symbol::DEV_TMP4,
+            ret_layout,
+        );
+
+        self.free_symbol(&Symbol::DEV_TMP4);
+    }
+
     fn build_ptr_cast(&mut self, dst: &Symbol, src: &Symbol) {
         let dst_reg = self.storage_manager.claim_general_reg(&mut self.buf, dst);
         self.storage_manager

--- a/crates/compiler/gen_dev/src/generic64/mod.rs
+++ b/crates/compiler/gen_dev/src/generic64/mod.rs
@@ -1312,13 +1312,7 @@ impl<
         );
 
         // Load element_width argument (usize).
-        let u64_layout = Layout::U64;
-        let element_width = self.layout_interner.stack_size(element_layout);
-        self.load_literal(
-            &Symbol::DEV_TMP2,
-            &u64_layout,
-            &Literal::Int((element_width as i128).to_ne_bytes()),
-        );
+        self.load_layout_stack_size(element_layout, Symbol::DEV_TMP2);
 
         // Setup the return location.
         let base_offset = self
@@ -1333,7 +1327,7 @@ impl<
             // element_width
             Symbol::DEV_TMP2,
          ];
-        let lowlevel_arg_layouts = [capacity_layout, u32_layout, u64_layout];
+        let lowlevel_arg_layouts = [capacity_layout, u32_layout, Layout::U64];
 
         self.build_fn_call(
             &Symbol::DEV_TMP3,
@@ -1379,20 +1373,14 @@ impl<
         );
 
         // Load element_width argument (usize).
-        let u64_layout = Layout::U64;
-        let element_width = self.layout_interner.stack_size(*ret_layout);
-        self.load_literal(
-            &Symbol::DEV_TMP2,
-            &u64_layout,
-            &Literal::Int((element_width as i128).to_ne_bytes()),
-        );
+        self.load_layout_stack_size(*ret_layout, Symbol::DEV_TMP2);
 
         // Load UpdateMode.Immutable argument (0u8)
         let u8_layout = Layout::U8;
         let update_mode = 0u8;
         self.load_literal(
             &Symbol::DEV_TMP3,
-            &u64_layout,
+            &u8_layout,
             &Literal::Int((update_mode as i128).to_ne_bytes()),
         );
 
@@ -1413,7 +1401,13 @@ impl<
             Symbol::DEV_TMP3,
 
          ];
-        let lowlevel_arg_layouts = [list_layout, u32_layout, spare_layout, u64_layout, u8_layout];
+        let lowlevel_arg_layouts = [
+            list_layout,
+            u32_layout,
+            spare_layout,
+            Layout::U64,
+            u8_layout,
+        ];
 
         self.build_fn_call(
             &Symbol::DEV_TMP4,
@@ -1462,13 +1456,7 @@ impl<
         ASM::add_reg64_reg64_imm32(&mut self.buf, reg, CC::BASE_PTR_REG, new_elem_offset);
 
         // Load element_witdh argument (usize).
-        let u64_layout = Layout::U64;
-        let elem_stack_size = self.layout_interner.stack_size(elem_layout);
-        self.load_literal(
-            &Symbol::DEV_TMP2,
-            &u64_layout,
-            &Literal::Int((elem_stack_size as i128).to_ne_bytes()),
-        );
+        self.load_layout_stack_size(elem_layout, Symbol::DEV_TMP2);
 
         // Setup the return location.
         let base_offset = self
@@ -1483,7 +1471,7 @@ impl<
             // element_width
             Symbol::DEV_TMP2
          ];
-        let lowlevel_arg_layouts = [list_layout, u64_layout, u64_layout];
+        let lowlevel_arg_layouts = [list_layout, Layout::U64, Layout::U64];
 
         self.build_fn_call(
             &Symbol::DEV_TMP3,
@@ -1579,12 +1567,7 @@ impl<
         ASM::add_reg64_reg64_imm32(&mut self.buf, reg, CC::BASE_PTR_REG, new_elem_offset);
 
         // Load the elements size.
-        let elem_stack_size = self.layout_interner.stack_size(elem_layout);
-        self.load_literal(
-            &Symbol::DEV_TMP3,
-            &u64_layout,
-            &Literal::Int((elem_stack_size as i128).to_ne_bytes()),
-        );
+        self.load_layout_stack_size(elem_layout, Symbol::DEV_TMP3);
 
         // Setup the return location.
         let base_offset = self
@@ -1669,7 +1652,7 @@ impl<
         dst: &Symbol,
         args: &'a [Symbol],
         arg_layouts: &[InLayout<'a>],
-        element_layout: InLayout<'a>,
+        elem_layout: InLayout<'a>,
         ret_layout: &InLayout<'a>,
     ) {
         let list_a = args[0];
@@ -1687,13 +1670,7 @@ impl<
         );
 
         // Load element_width argument (usize).
-        let u64_layout = Layout::U64;
-        let element_width = self.layout_interner.stack_size(element_layout);
-        self.load_literal(
-            &Symbol::DEV_TMP2,
-            &u64_layout,
-            &Literal::Int((element_width as i128).to_ne_bytes()),
-        );
+        self.load_layout_stack_size(elem_layout, Symbol::DEV_TMP2);
 
         // Setup the return location.
         let base_offset = self
@@ -1709,7 +1686,7 @@ impl<
             // element_width
             Symbol::DEV_TMP2,
          ];
-        let lowlevel_arg_layouts = [list_a_layout, list_b_layout, u32_layout, u64_layout];
+        let lowlevel_arg_layouts = [list_a_layout, list_b_layout, u32_layout, Layout::U64];
 
         self.build_fn_call(
             &Symbol::DEV_TMP3,
@@ -1767,13 +1744,7 @@ impl<
         ASM::add_reg64_reg64_imm32(&mut self.buf, reg, CC::BASE_PTR_REG, new_elem_offset);
 
         // Load element_witdh argument (usize).
-        let u64_layout = Layout::U64;
-        let elem_stack_size = self.layout_interner.stack_size(elem_layout);
-        self.load_literal(
-            &Symbol::DEV_TMP3,
-            &u64_layout,
-            &Literal::Int((elem_stack_size as i128).to_ne_bytes()),
-        );
+        self.load_layout_stack_size(elem_layout, Symbol::DEV_TMP3);
 
         // Setup the return location.
         let base_offset = self
@@ -1790,7 +1761,7 @@ impl<
             // element_width
             Symbol::DEV_TMP3,
          ];
-        let lowlevel_arg_layouts = [list_layout, u32_layout, u64_layout, u64_layout];
+        let lowlevel_arg_layouts = [list_layout, u32_layout, Layout::U64, Layout::U64];
 
         self.build_fn_call(
             &Symbol::DEV_TMP4,
@@ -2344,6 +2315,14 @@ impl<
         for (i, byte) in tmp.iter().enumerate() {
             self.buf[jmp_location as usize + i] = *byte;
         }
+    }
+
+    fn load_layout_stack_size(&mut self, layout: InLayout<'a>, symbol: Symbol) {
+        let u64_layout = Layout::U64;
+        let width = self.layout_interner.stack_size(layout);
+        let width_literal = Literal::Int((width as i128).to_ne_bytes());
+
+        self.load_literal(&symbol, &u64_layout, &width_literal);
     }
 }
 

--- a/crates/compiler/gen_dev/src/generic64/mod.rs
+++ b/crates/compiler/gen_dev/src/generic64/mod.rs
@@ -1299,7 +1299,7 @@ impl<
         dst: &Symbol,
         capacity: Symbol,
         capacity_layout: InLayout<'a>,
-        element_layout: InLayout<'a>,
+        elem_layout: InLayout<'a>,
         ret_layout: &InLayout<'a>,
     ) {
         // List alignment argument (u32).
@@ -1312,7 +1312,7 @@ impl<
         );
 
         // Load element_width argument (usize).
-        self.load_layout_stack_size(element_layout, Symbol::DEV_TMP2);
+        self.load_layout_stack_size(elem_layout, Symbol::DEV_TMP2);
 
         // Setup the return location.
         let base_offset = self

--- a/crates/compiler/gen_dev/src/lib.rs
+++ b/crates/compiler/gen_dev/src/lib.rs
@@ -707,14 +707,8 @@ trait Backend<'a> {
                     args.len(),
                     "ListWithCapacity: expected to have exactly one argument"
                 );
-                let element_layout = list_element_layout!(self.interner(), *ret_layout);
-                self.build_list_with_capacity(
-                    sym,
-                    args[0],
-                    arg_layouts[0],
-                    element_layout,
-                    ret_layout,
-                )
+                let elem_layout = list_element_layout!(self.interner(), *ret_layout);
+                self.build_list_with_capacity(sym, args[0], arg_layouts[0], elem_layout, ret_layout)
             }
             LowLevel::ListReserve => {
                 debug_assert_eq!(
@@ -754,8 +748,8 @@ trait Backend<'a> {
                     args.len(),
                     "ListConcat: expected to have exactly two arguments"
                 );
-                let element_layout = list_element_layout!(self.interner(), *ret_layout);
-                self.build_list_concat(sym, args, arg_layouts, element_layout, ret_layout)
+                let elem_layout = list_element_layout!(self.interner(), *ret_layout);
+                self.build_list_concat(sym, args, arg_layouts, elem_layout, ret_layout)
             }
             LowLevel::ListPrepend => {
                 debug_assert_eq!(
@@ -1021,7 +1015,7 @@ trait Backend<'a> {
         dst: &Symbol,
         capacity: Symbol,
         capacity_layout: InLayout<'a>,
-        element_layout: InLayout<'a>,
+        elem_layout: InLayout<'a>,
         ret_layout: &InLayout<'a>,
     );
 
@@ -1067,7 +1061,7 @@ trait Backend<'a> {
         dst: &Symbol,
         args: &'a [Symbol],
         arg_layouts: &[InLayout<'a>],
-        element_layout: InLayout<'a>,
+        elem_layout: InLayout<'a>,
         ret_layout: &InLayout<'a>,
     );
 

--- a/crates/compiler/gen_dev/src/lib.rs
+++ b/crates/compiler/gen_dev/src/lib.rs
@@ -757,6 +757,14 @@ trait Backend<'a> {
                 let element_layout = list_element_layout!(self.interner(), *ret_layout);
                 self.build_list_concat(sym, args, arg_layouts, element_layout, ret_layout)
             }
+            LowLevel::ListPrepend => {
+                debug_assert_eq!(
+                    2,
+                    args.len(),
+                    "ListPrepend: expected to have exactly two arguments"
+                );
+                self.build_list_prepend(sym, args, arg_layouts, ret_layout)
+            }
             LowLevel::StrConcat => self.build_fn_call(
                 sym,
                 bitcode::STR_CONCAT.to_string(),
@@ -1060,6 +1068,15 @@ trait Backend<'a> {
         args: &'a [Symbol],
         arg_layouts: &[InLayout<'a>],
         element_layout: InLayout<'a>,
+        ret_layout: &InLayout<'a>,
+    );
+
+    /// build_list_prepend returns a new list with a given element prepended.
+    fn build_list_prepend(
+        &mut self,
+        dst: &Symbol,
+        args: &'a [Symbol],
+        arg_layouts: &[InLayout<'a>],
         ret_layout: &InLayout<'a>,
     );
 

--- a/crates/compiler/test_gen/src/gen_list.rs
+++ b/crates/compiler/test_gen/src/gen_list.rs
@@ -746,7 +746,7 @@ fn list_append_longer_list() {
 }
 
 #[test]
-#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm", feature = "gen-dev"))]
 fn list_prepend() {
     assert_evals_to!("List.prepend [] 1", RocList::from_slice(&[1]), RocList<i64>);
     assert_evals_to!(
@@ -768,7 +768,11 @@ fn list_prepend() {
         RocList::from_slice(&[6, 4]),
         RocList<i64>
     );
+}
 
+#[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
+fn list_prepend_str() {
     assert_evals_to!(
         indoc!(
             r#"
@@ -795,7 +799,7 @@ fn list_prepend_bools() {
 }
 
 #[test]
-#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm", feature = "gen-dev"))]
 fn list_prepend_big_list() {
     assert_evals_to!(
         "List.prepend [10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 100, 100, 100, 100] 9",


### PR DESCRIPTION
Heyo, another PR for the dev backend :)
This time it's `List.prepend` which is similar to the existing `List.append` implementation.

I had to split up a test because some string usage caused invalid memory errors.

Closes #4981