### PR TITLE
Add nix wasm32-unknown-unknown target and wasm-pack input

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -106,6 +106,7 @@
           rust
           cargo-criterion # for benchmarks
           simple-http-server # to view roc website when trying out edits
+          wasm-pack # for repl_wasm
         ]);
       in {
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -19,4 +19,5 @@ components = [
 
 targets = [
     "wasm32-wasi", # for test_wasm.sh
+    "wasm32-unknown-unknown", # for repl_wasm
 ]


### PR DESCRIPTION
`repl_wasm` requires Rust's `wasm32-unknown-uknown` toolchain and `wasm-pack` to be installed. 