### PR TITLE
Use hello as app name for hello.roc example

### DIFF
--- a/crates/cli/tests/cli_run.rs
+++ b/crates/cli/tests/cli_run.rs
@@ -687,6 +687,17 @@ mod cli_run {
     }
 
     #[test]
+    fn breakout_hello_gui() {
+        test_roc_app_slim(
+            "examples/gui/breakout",
+            "hello-gui.roc",
+            "hello-gui",
+            "",
+            UseValgrind::No,
+        )
+    }
+
+    #[test]
     #[cfg_attr(windows, ignore)]
     fn quicksort() {
         test_roc_app_slim(

--- a/examples/gui/breakout/hello-gui.roc
+++ b/examples/gui/breakout/hello-gui.roc
@@ -1,4 +1,4 @@
-app "hello"
+app "hello-gui"
     packages { pf: "platform/main.roc" }
     imports [pf.Game.{ Bounds, Elem, Event }]
     provides [program] { Model } to pf

--- a/examples/gui/breakout/hello.roc
+++ b/examples/gui/breakout/hello.roc
@@ -1,4 +1,4 @@
-app "breakout"
+app "hello"
     packages { pf: "platform/main.roc" }
     imports [pf.Game.{ Bounds, Elem, Event }]
     provides [program] { Model } to pf


### PR DESCRIPTION
This is to prevent a name collision with breakout.roc example located in the same directory.