### PR TITLE
Support subfolders in target folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,8 +22,8 @@ zig-cache
 vgcore.*
 
 # roc cache files
-*.rh1
-*.rm1
+*.rh*
+*.rm*
 preprocessedhost
 metadata
 roc-cheaty-lib.so


### PR DESCRIPTION
Usually the target folder directly contains `debug` or `release` but for different targets these can also be located in e.g. x86_64-unknown-linux-musl. My changes support that situation.