### PR TITLE
Implement mono / code generation for tuples

### DIFF
--- a/crates/ast/src/constrain.rs
+++ b/crates/ast/src/constrain.rs
@@ -9,7 +9,7 @@ use roc_module::{
 use roc_region::all::Region;
 use roc_types::{
     subs::Variable,
-    types::{self, AnnotationSource, PReason, PatternCategory},
+    types::{self, AnnotationSource, IndexOrField, PReason, PatternCategory},
     types::{Category, Reason},
 };
 
@@ -375,7 +375,7 @@ pub fn constrain_expr<'a>(
                 env.pool.add(ext_type),
             );
 
-            let category = Category::RecordAccessor(field.as_str(env.pool).into());
+            let category = Category::Accessor(IndexOrField::Field(field.as_str(env.pool).into()));
 
             let record_expected = Expected::NoExpectation(record_type.shallow_clone());
             let record_con = Eq(

--- a/crates/ast/src/lang/core/expr/expr_to_expr2.rs
+++ b/crates/ast/src/lang/core/expr/expr_to_expr2.rs
@@ -6,6 +6,7 @@ use roc_can::num::{
 use roc_can::operator::desugar_expr;
 use roc_collections::all::MutSet;
 use roc_module::symbol::Symbol;
+use roc_parse::ident::Accessor;
 use roc_parse::{ast::Expr, pattern::PatternType};
 use roc_problem::can::{Problem, RuntimeError};
 use roc_region::all::{Loc, Region};
@@ -295,7 +296,7 @@ pub fn expr_to_expr2<'a>(
             )
         }
 
-        RecordAccessorFunction(field) => (
+        AccessorFunction(Accessor::RecordField(field)) => (
             Expr2::Accessor {
                 function_var: env.var_store.fresh(),
                 record_var: env.var_store.fresh(),

--- a/crates/ast/src/lang/core/types.rs
+++ b/crates/ast/src/lang/core/types.rs
@@ -405,7 +405,7 @@ pub fn to_type2<'a>(
 
             Type2::Variable(var)
         }
-        Tuple { fields: _, ext: _ } => {
+        Tuple { elems: _, ext: _ } => {
             todo!("tuple type");
         }
         Record { fields, ext, .. } => {

--- a/crates/compiler/can/src/debug/pretty_print.rs
+++ b/crates/compiler/can/src/debug/pretty_print.rs
@@ -5,7 +5,7 @@ use crate::expr::Expr::{self, *};
 use crate::expr::{
     ClosureData, DeclarationTag, Declarations, FunctionDef, OpaqueWrapFunctionData, WhenBranch,
 };
-use crate::pattern::{Pattern, RecordDestruct};
+use crate::pattern::{Pattern, RecordDestruct, TupleDestruct};
 
 use roc_module::symbol::{Interns, ModuleId, Symbol};
 
@@ -335,7 +335,6 @@ fn expr<'a>(c: &Ctx, p: EPrec, f: &'a Arena<'a>, e: &'a Expr) -> DocBuilder<'a, 
             f.text(format!("@{}", opaque_name.as_str(c.interns)))
         }
         RecordAccessor(_) => todo!(),
-        TupleAccessor(_) => todo!(),
         RecordUpdate {
             symbol, updates, ..
         } => f
@@ -504,6 +503,19 @@ fn pattern<'a>(
                 ),
             )
             .append(f.text("}"))
+            .group(),
+        TupleDestructure { destructs, .. } => f
+            .text("(")
+            .append(
+                f.intersperse(
+                    destructs
+                        .iter()
+                        .map(|l| &l.value)
+                        .map(|TupleDestruct { typ: (_, p), .. }| pattern(c, Free, f, &p.value)),
+                    f.text(", "),
+                ),
+            )
+            .append(f.text(")"))
             .group(),
         List { .. } => todo!(),
         NumLiteral(_, n, _, _) | IntLiteral(_, _, n, _, _) | FloatLiteral(_, _, n, _, _) => {

--- a/crates/compiler/can/src/module.rs
+++ b/crates/compiler/can/src/module.rs
@@ -918,6 +918,15 @@ fn fix_values_captured_in_closure_pattern(
                 }
             }
         }
+        TupleDestructure { destructs, .. } => {
+            for loc_destruct in destructs.iter_mut() {
+                fix_values_captured_in_closure_pattern(
+                    &mut loc_destruct.value.typ.1.value,
+                    no_capture_symbols,
+                    closure_captures,
+                )
+            }
+        }
         List { patterns, .. } => {
             for loc_pat in patterns.patterns.iter_mut() {
                 fix_values_captured_in_closure_pattern(
@@ -1087,8 +1096,7 @@ fn fix_values_captured_in_closure_expr(
         | TypedHole { .. }
         | RuntimeError(_)
         | ZeroArgumentTag { .. }
-        | RecordAccessor { .. }
-        | TupleAccessor { .. } => {}
+        | RecordAccessor { .. } => {}
 
         List { loc_elems, .. } => {
             for elem in loc_elems.iter_mut() {

--- a/crates/compiler/can/src/operator.rs
+++ b/crates/compiler/can/src/operator.rs
@@ -130,8 +130,7 @@ pub fn desugar_expr<'a>(arena: &'a Bump, loc_expr: &'a Loc<Expr<'a>>) -> &'a Loc
         | NonBase10Int { .. }
         | Str(_)
         | SingleQuote(_)
-        | RecordAccessorFunction(_)
-        | TupleAccessorFunction(_)
+        | AccessorFunction(_)
         | Var { .. }
         | Underscore { .. }
         | MalformedIdent(_, _)

--- a/crates/compiler/constrain/src/pattern.rs
+++ b/crates/compiler/constrain/src/pattern.rs
@@ -3,7 +3,7 @@ use crate::expr::{constrain_expr, Env};
 use roc_can::constraint::{Constraint, Constraints, PExpectedTypeIndex, TypeOrVar};
 use roc_can::expected::{Expected, PExpected};
 use roc_can::pattern::Pattern::{self, *};
-use roc_can::pattern::{DestructType, ListPatterns, RecordDestruct};
+use roc_can::pattern::{DestructType, ListPatterns, RecordDestruct, TupleDestruct};
 use roc_collections::all::{HumanIndex, SendMap};
 use roc_collections::VecMap;
 use roc_module::ident::Lowercase;
@@ -124,6 +124,10 @@ fn headers_from_annotation_help(
             Type::EmptyRec => destructs.is_empty(),
             _ => false,
         },
+
+        TupleDestructure { destructs: _, .. } => {
+            todo!();
+        }
 
         List { patterns, .. } => {
             if let Some((_, Some(rest))) = patterns.opt_rest {
@@ -463,6 +467,96 @@ pub fn constrain_pattern(
                 PatternCategory::Character,
                 region,
             ));
+        }
+
+        TupleDestructure {
+            whole_var,
+            ext_var,
+            destructs,
+        } => {
+            state.vars.push(*whole_var);
+            state.vars.push(*ext_var);
+            let ext_type = Type::Variable(*ext_var);
+
+            let mut elem_types: VecMap<usize, Type> = VecMap::default();
+
+            for Loc {
+                value:
+                    TupleDestruct {
+                        destruct_index: index,
+                        var,
+                        typ,
+                    },
+                ..
+            } in destructs.iter()
+            {
+                let pat_type = Type::Variable(*var);
+                let pat_type_index = constraints.push_variable(*var);
+                let expected =
+                    constraints.push_pat_expected_type(PExpected::NoExpectation(pat_type_index));
+
+                let (guard_var, loc_guard) = typ;
+                let elem_type = {
+                    let guard_type = constraints.push_variable(*guard_var);
+                    let expected_pat = constraints.push_pat_expected_type(PExpected::ForReason(
+                        PReason::PatternGuard,
+                        pat_type_index,
+                        loc_guard.region,
+                    ));
+
+                    state.constraints.push(constraints.pattern_presence(
+                        guard_type,
+                        expected_pat,
+                        PatternCategory::PatternGuard,
+                        region,
+                    ));
+                    state.vars.push(*guard_var);
+
+                    constrain_pattern(
+                        types,
+                        constraints,
+                        env,
+                        &loc_guard.value,
+                        loc_guard.region,
+                        expected,
+                        state,
+                    );
+
+                    pat_type
+                };
+
+                elem_types.insert(*index, elem_type);
+
+                state.vars.push(*var);
+            }
+
+            let tuple_type = {
+                let typ = types.from_old_type(&Type::Tuple(
+                    elem_types,
+                    TypeExtension::from_non_annotation_type(ext_type),
+                ));
+                constraints.push_type(types, typ)
+            };
+
+            let whole_var_index = constraints.push_variable(*whole_var);
+            let expected_record =
+                constraints.push_expected_type(Expected::NoExpectation(tuple_type));
+            let whole_con = constraints.equal_types(
+                whole_var_index,
+                expected_record,
+                Category::Storage(std::file!(), std::line!()),
+                region,
+            );
+
+            let record_con = constraints.pattern_presence(
+                whole_var_index,
+                expected,
+                PatternCategory::Record,
+                region,
+            );
+
+            state.constraints.push(whole_con);
+            state.constraints.push(record_con);
         }
 
         RecordDestructure {

--- a/crates/compiler/exhaustive/src/lib.rs
+++ b/crates/compiler/exhaustive/src/lib.rs
@@ -38,6 +38,7 @@ pub enum RenderAs {
     Tag,
     Opaque,
     Record(Vec<Lowercase>),
+    Tuple,
     Guard,
 }
 

--- a/crates/compiler/fmt/src/annotation.rs
+++ b/crates/compiler/fmt/src/annotation.rs
@@ -177,7 +177,7 @@ impl<'a> Formattable for TypeAnnotation<'a> {
                 annot.is_multiline() || has_clauses.iter().any(|has| has.is_multiline())
             }
 
-            Tuple { fields, ext } => {
+            Tuple { elems: fields, ext } => {
                 match ext {
                     Some(ann) if ann.value.is_multiline() => return true,
                     _ => {}
@@ -343,7 +343,7 @@ impl<'a> Formattable for TypeAnnotation<'a> {
                 }
             }
 
-            Tuple { fields, ext } => {
+            Tuple { elems: fields, ext } => {
                 fmt_collection(buf, indent, Braces::Round, *fields, newlines);
 
                 if let Some(loc_ext_ann) = *ext {

--- a/crates/compiler/fmt/src/expr.rs
+++ b/crates/compiler/fmt/src/expr.rs
@@ -12,6 +12,7 @@ use roc_parse::ast::{
     AssignedField, Base, Collection, CommentOrNewline, Expr, ExtractSpaces, Pattern, WhenBranch,
 };
 use roc_parse::ast::{StrLiteral, StrSegment};
+use roc_parse::ident::Accessor;
 use roc_region::all::Loc;
 
 impl<'a> Formattable for Expr<'a> {
@@ -35,9 +36,8 @@ impl<'a> Formattable for Expr<'a> {
             | NonBase10Int { .. }
             | SingleQuote(_)
             | RecordAccess(_, _)
-            | RecordAccessorFunction(_)
+            | AccessorFunction(_)
             | TupleAccess(_, _)
-            | TupleAccessorFunction(_)
             | Var { .. }
             | Underscore { .. }
             | MalformedIdent(_, _)
@@ -434,18 +434,16 @@ impl<'a> Formattable for Expr<'a> {
 
                 sub_expr.format_with_options(buf, Parens::InApply, newlines, indent);
             }
-            RecordAccessorFunction(key) => {
+            AccessorFunction(key) => {
                 buf.indent(indent);
                 buf.push('.');
-                buf.push_str(key);
+                match key {
+                    Accessor::RecordField(key) => buf.push_str(key),
+                    Accessor::TupleIndex(key) => buf.push_str(key),
+                }
             }
             RecordAccess(expr, key) => {
                 expr.format_with_options(buf, Parens::InApply, Newlines::Yes, indent);
-                buf.push('.');
-                buf.push_str(key);
-            }
-            TupleAccessorFunction(key) => {
-                buf.indent(indent);
                 buf.push('.');
                 buf.push_str(key);
             }

--- a/crates/compiler/fmt/src/spaces.rs
+++ b/crates/compiler/fmt/src/spaces.rs
@@ -656,9 +656,8 @@ impl<'a> RemoveSpaces<'a> for Expr<'a> {
             },
             Expr::Str(a) => Expr::Str(a.remove_spaces(arena)),
             Expr::RecordAccess(a, b) => Expr::RecordAccess(arena.alloc(a.remove_spaces(arena)), b),
-            Expr::RecordAccessorFunction(a) => Expr::RecordAccessorFunction(a),
+            Expr::AccessorFunction(a) => Expr::AccessorFunction(a),
             Expr::TupleAccess(a, b) => Expr::TupleAccess(arena.alloc(a.remove_spaces(arena)), b),
-            Expr::TupleAccessorFunction(a) => Expr::TupleAccessorFunction(a),
             Expr::List(a) => Expr::List(a.remove_spaces(arena)),
             Expr::RecordUpdate { update, fields } => Expr::RecordUpdate {
                 update: arena.alloc(update.remove_spaces(arena)),
@@ -813,8 +812,8 @@ impl<'a> RemoveSpaces<'a> for TypeAnnotation<'a> {
                     vars: vars.remove_spaces(arena),
                 },
             ),
-            TypeAnnotation::Tuple { fields, ext } => TypeAnnotation::Tuple {
-                fields: fields.remove_spaces(arena),
+            TypeAnnotation::Tuple { elems: fields, ext } => TypeAnnotation::Tuple {
+                elems: fields.remove_spaces(arena),
                 ext: ext.remove_spaces(arena),
             },
             TypeAnnotation::Record { fields, ext } => TypeAnnotation::Record {

--- a/crates/compiler/load_internal/src/docs.rs
+++ b/crates/compiler/load_internal/src/docs.rs
@@ -403,7 +403,7 @@ fn contains_unexposed_type(
 
             false
         }
-        Tuple { fields, ext } => {
+        Tuple { elems: fields, ext } => {
             if let Some(loc_ext) = ext {
                 if contains_unexposed_type(&loc_ext.value, exposed_module_ids, module_ids) {
                     return true;

--- a/crates/compiler/parse/src/ast.rs
+++ b/crates/compiler/parse/src/ast.rs
@@ -1,6 +1,7 @@
 use std::fmt::Debug;
 
 use crate::header::{AppHeader, HostedHeader, InterfaceHeader, PackageHeader, PlatformHeader};
+use crate::ident::Accessor;
 use crate::parser::ESingleQuote;
 use bumpalo::collections::{String, Vec};
 use bumpalo::Bump;
@@ -243,13 +244,12 @@ pub enum Expr<'a> {
 
     /// Look up exactly one field on a record, e.g. `x.foo`.
     RecordAccess(&'a Expr<'a>, &'a str),
-    /// e.g. `.foo`
-    RecordAccessorFunction(&'a str),
+
+    /// e.g. `.foo` or `.0`
+    AccessorFunction(Accessor<'a>),
 
     /// Look up exactly one field on a tuple, e.g. `(x, y).1`.
     TupleAccess(&'a Expr<'a>, &'a str),
-    /// e.g. `.1`
-    TupleAccessorFunction(&'a str),
 
     // Collection Literals
     List(Collection<'a, &'a Loc<Expr<'a>>>),
@@ -612,7 +612,7 @@ pub enum TypeAnnotation<'a> {
     },
 
     Tuple {
-        fields: Collection<'a, Loc<TypeAnnotation<'a>>>,
+        elems: Collection<'a, Loc<TypeAnnotation<'a>>>,
         /// The row type variable in an open tuple, e.g. the `r` in `( Str, Str )r`.
         /// This is None if it's a closed tuple annotation like `( Str, Str )`.
         ext: Option<&'a Loc<TypeAnnotation<'a>>>,
@@ -1459,8 +1459,7 @@ impl<'a> Malformed for Expr<'a> {
             Float(_) |
             Num(_) |
             NonBase10Int { .. } |
-            TupleAccessorFunction(_) |
-            RecordAccessorFunction(_) |
+            AccessorFunction(_) |
             Var { .. } |
             Underscore(_) |
             Tag(_) |
@@ -1729,7 +1728,7 @@ impl<'a> Malformed for TypeAnnotation<'a> {
                 fields.iter().any(|field| field.is_malformed())
                     || ext.map(|ext| ext.is_malformed()).unwrap_or_default()
             }
-            TypeAnnotation::Tuple { fields, ext } => {
+            TypeAnnotation::Tuple { elems: fields, ext } => {
                 fields.iter().any(|field| field.is_malformed())
                     || ext.map(|ext| ext.is_malformed()).unwrap_or_default()
             }

--- a/crates/compiler/parse/src/expr.rs
+++ b/crates/compiler/parse/src/expr.rs
@@ -1872,9 +1872,8 @@ fn expr_to_pattern_help<'a>(arena: &'a Bump, expr: &Expr<'a>) -> Result<Pattern<
             is_negative: *is_negative,
         }),
         // These would not have parsed as patterns
-        Expr::RecordAccessorFunction(_)
+        Expr::AccessorFunction(_)
         | Expr::RecordAccess(_, _)
-        | Expr::TupleAccessorFunction(_)
         | Expr::TupleAccess(_, _)
         | Expr::List { .. }
         | Expr::Closure(_, _)
@@ -2459,8 +2458,7 @@ fn ident_to_expr<'a>(arena: &'a Bump, src: Ident<'a>) -> Expr<'a> {
 
             answer
         }
-        Ident::RecordAccessorFunction(string) => Expr::RecordAccessorFunction(string),
-        Ident::TupleAccessorFunction(string) => Expr::TupleAccessorFunction(string),
+        Ident::AccessorFunction(string) => Expr::AccessorFunction(string),
         Ident::Malformed(string, problem) => Expr::MalformedIdent(string, problem),
     }
 }

--- a/crates/compiler/parse/src/parser.rs
+++ b/crates/compiler/parse/src/parser.rs
@@ -536,8 +536,7 @@ pub enum EPattern<'a> {
     IndentEnd(Position),
     AsIndentStart(Position),
 
-    RecordAccessorFunction(Position),
-    TupleAccessorFunction(Position),
+    AccessorFunction(Position),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/compiler/parse/src/pattern.rs
+++ b/crates/compiler/parse/src/pattern.rs
@@ -417,13 +417,9 @@ fn loc_ident_pattern_help<'a>(
                     state,
                 ))
             }
-            Ident::RecordAccessorFunction(_string) => Err((
+            Ident::AccessorFunction(_string) => Err((
                 MadeProgress,
-                EPattern::RecordAccessorFunction(loc_ident.region.start()),
-            )),
-            Ident::TupleAccessorFunction(_string) => Err((
-                MadeProgress,
-                EPattern::TupleAccessorFunction(loc_ident.region.start()),
+                EPattern::AccessorFunction(loc_ident.region.start()),
             )),
             Ident::Malformed(malformed, problem) => {
                 debug_assert!(!malformed.is_empty());

--- a/crates/compiler/parse/src/type_annotation.rs
+++ b/crates/compiler/parse/src/type_annotation.rs
@@ -250,7 +250,7 @@ fn loc_type_in_parens<'a>(
             if fields.len() > 1 || ext.is_some() {
                 Ok((
                     MadeProgress,
-                    Loc::at(region, TypeAnnotation::Tuple { fields, ext }),
+                    Loc::at(region, TypeAnnotation::Tuple { elems: fields, ext }),
                     state,
                 ))
             } else if fields.len() == 1 {

--- a/crates/compiler/solve/tests/solve_expr.rs
+++ b/crates/compiler/solve/tests/solve_expr.rs
@@ -1498,6 +1498,20 @@ mod solve_expr {
     }
 
     #[test]
+    fn tuple_accessor_generalization() {
+        infer_eq(
+            indoc!(
+                r#"
+                    get0 = .0
+
+                    { a: get0 (1, 2), b: get0 ("a", "b", "c") }
+                "#
+            ),
+            "{ a : Num *, b : Str }",
+        );
+    }
+
+    #[test]
     fn record_arg() {
         infer_eq("\\rec -> rec.x", "{ x : a }* -> a");
     }

--- a/crates/compiler/test_gen/src/gen_tuples.rs
+++ b/crates/compiler/test_gen/src/gen_tuples.rs
@@ -1,0 +1,620 @@
+#[cfg(feature = "gen-llvm")]
+use crate::helpers::llvm::assert_evals_to;
+
+#[cfg(feature = "gen-dev")]
+use crate::helpers::dev::assert_evals_to;
+
+#[cfg(feature = "gen-wasm")]
+use crate::helpers::wasm::assert_evals_to;
+
+// use crate::assert_wasm_evals_to as assert_evals_to;
+use indoc::indoc;
+
+#[cfg(all(test, any(feature = "gen-llvm", feature = "gen-wasm")))]
+use roc_std::RocStr;
+
+#[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-dev", feature = "gen-wasm"))]
+fn basic_tuple() {
+    assert_evals_to!(
+        indoc!(
+            r#"
+                    ( 15, 17, 19 ).0
+                "#
+        ),
+        15,
+        i64
+    );
+
+    assert_evals_to!(
+        indoc!(
+            r#"
+                    ( 15, 17, 19 ).1
+                "#
+        ),
+        17,
+        i64
+    );
+
+    assert_evals_to!(
+        indoc!(
+            r#"
+                    ( 15, 17, 19 ).2
+                "#
+        ),
+        19,
+        i64
+    );
+}
+
+#[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-dev", feature = "gen-wasm"))]
+fn f64_tuple() {
+    assert_evals_to!(
+        indoc!(
+            r#"
+                   tup = (17.2, 15.1, 19.3)
+
+                   tup.0
+                "#
+        ),
+        17.2,
+        f64
+    );
+
+    assert_evals_to!(
+        indoc!(
+            r#"
+                   tup = (17.2, 15.1, 19.3)
+
+                   tup.1
+                "#
+        ),
+        15.1,
+        f64
+    );
+
+    assert_evals_to!(
+        indoc!(
+            r#"
+                    tup = (17.2, 15.1, 19.3)
+
+                    tup.2
+                "#
+        ),
+        19.3,
+        f64
+    );
+}
+
+#[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
+fn fn_tuple() {
+    assert_evals_to!(
+        indoc!(
+            r#"
+                    getRec = \x -> ("foo", x, 19)
+
+                    (getRec 15).1
+                "#
+        ),
+        15,
+        i64
+    );
+
+    assert_evals_to!(
+        indoc!(
+            r#"
+                    rec = (15, 17, 19)
+
+                    rec.2 + rec.0
+                "#
+        ),
+        34,
+        i64
+    );
+}
+
+#[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-dev", feature = "gen-wasm"))]
+fn int_tuple() {
+    assert_evals_to!(
+        indoc!(
+            r#"
+                    rec = (15, 17, 19)
+
+                    rec.0
+                "#
+        ),
+        15,
+        i64
+    );
+
+    assert_evals_to!(
+        indoc!(
+            r#"
+                    rec = (15, 17, 19)
+
+                    rec.1
+                "#
+        ),
+        17,
+        i64
+    );
+
+    assert_evals_to!(
+        indoc!(
+            r#"
+                    rec = (15, 17, 19)
+
+                    rec.2
+                "#
+        ),
+        19,
+        i64
+    );
+}
+
+#[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-dev", feature = "gen-wasm"))]
+fn when_on_tuple() {
+    assert_evals_to!(
+        indoc!(
+            r#"
+                when (0x2, 0x3) is
+                    (x, y) -> x + y
+                "#
+        ),
+        5,
+        i64
+    );
+}
+
+#[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-dev", feature = "gen-wasm"))]
+fn when_tuple_with_guard_pattern() {
+    assert_evals_to!(
+        indoc!(
+            r#"
+                when (0x2, 1.23) is
+                    (var, _) -> var + 3
+                "#
+        ),
+        5,
+        i64
+    );
+}
+
+#[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-dev", feature = "gen-wasm"))]
+fn let_with_tuple_pattern() {
+    assert_evals_to!(
+        indoc!(
+            r#"
+                (x, _ ) = (0x2, 1.23)
+
+                x
+                "#
+        ),
+        2,
+        i64
+    );
+
+    assert_evals_to!(
+        indoc!(
+            r#"
+                (_, y) = (0x2, 0x3)
+
+                y
+                "#
+        ),
+        3,
+        i64
+    );
+}
+
+#[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-dev", feature = "gen-wasm"))]
+fn tuple_guard_pattern() {
+    assert_evals_to!(
+        indoc!(
+            r#"
+                when (0x2, 1.23) is
+                    (0x4, _) -> 5
+                    (x, _) -> x + 4
+                "#
+        ),
+        6,
+        i64
+    );
+
+    assert_evals_to!(
+        indoc!(
+            r#"
+                when (0x2, 0x3) is
+                    (_, 0x4) -> 5
+                    (_, x) -> x + 4
+                "#
+        ),
+        7,
+        i64
+    );
+}
+
+#[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-dev", feature = "gen-wasm"))]
+fn twice_tuple_access() {
+    assert_evals_to!(
+        indoc!(
+            r#"
+                x =  (0x2, 0x3)
+
+                x.0 + x.1
+                "#
+        ),
+        5,
+        i64
+    );
+}
+
+#[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm", feature = "gen-dev"))]
+fn i64_tuple2_literal() {
+    assert_evals_to!(
+        indoc!(
+            r#"
+                   (3, 5)
+                "#
+        ),
+        (3, 5),
+        (i64, i64)
+    );
+}
+
+#[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
+fn i64_tuple3_literal() {
+    assert_evals_to!(
+        indoc!(
+            r#"
+               (3, 5, 17)
+            "#
+        ),
+        (3, 5, 17),
+        (i64, i64, i64)
+    );
+}
+
+#[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm", feature = "gen-dev"))]
+fn f64_tuple2_literal() {
+    assert_evals_to!(
+        indoc!(
+            r#"
+                   (3.1, 5.1)
+                "#
+        ),
+        (3.1, 5.1),
+        (f64, f64)
+    );
+}
+
+#[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
+fn bool_tuple4_literal() {
+    assert_evals_to!(
+        indoc!(
+            r#"
+               tuple : (Bool, Bool, Bool, Bool)
+               tuple = (Bool.true, Bool.false, Bool.false, Bool.true)
+
+               tuple
+            "#
+        ),
+        (true, false, false, true),
+        (bool, bool, bool, bool)
+    );
+}
+
+// Not supported by wasm because of the size of the tuple:
+// FromWasm32Memory is only implemented for tuples of up to 4 elements
+#[test]
+#[cfg(any(feature = "gen-llvm"))]
+fn i64_tuple9_literal() {
+    assert_evals_to!(
+        indoc!(
+            r#"
+               ( 3, 5, 17, 1, 9, 12, 13, 14, 15 )
+            "#
+        ),
+        [3, 5, 17, 1, 9, 12, 13, 14, 15],
+        [i64; 9]
+    );
+}
+
+#[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm", feature = "gen-dev"))]
+fn return_tuple() {
+    assert_evals_to!(
+        indoc!(
+            r#"
+                x = 4
+                y = 3
+
+                (x, y)
+                "#
+        ),
+        (4, 3),
+        (i64, i64)
+    );
+}
+
+#[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm", feature = "gen-dev"))]
+fn return_tuple_2() {
+    assert_evals_to!(
+        indoc!(
+            r#"
+                (3, 5)
+                "#
+        ),
+        [3, 5],
+        [i64; 2]
+    );
+}
+
+#[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm", feature = "gen-dev"))]
+fn return_tuple_3() {
+    assert_evals_to!(
+        indoc!(
+            r#"
+                ( 3, 5, 4 )
+                "#
+        ),
+        (3, 5, 4),
+        (i64, i64, i64)
+    );
+}
+
+#[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm", feature = "gen-dev"))]
+fn return_tuple_4() {
+    assert_evals_to!(
+        indoc!(
+            r#"
+                ( 3, 5, 4, 2 )
+                "#
+        ),
+        [3, 5, 4, 2],
+        [i64; 4]
+    );
+}
+
+// Not supported by wasm because of the size of the tuple:
+// FromWasm32Memory is only implemented for tuples of up to 4 elements
+#[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-dev"))]
+fn return_tuple_5() {
+    assert_evals_to!(
+        indoc!(
+            r#"
+                ( 3, 5, 4, 2, 1 )
+                "#
+        ),
+        [3, 5, 4, 2, 1],
+        [i64; 5]
+    );
+}
+
+// Not supported by wasm because of the size of the tuple:
+// FromWasm32Memory is only implemented for tuples of up to 4 elements
+#[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-dev"))]
+fn return_tuple_6() {
+    assert_evals_to!(
+        indoc!(
+            r#"
+                ( 3, 5, 4, 2, 1, 7 )
+                "#
+        ),
+        [3, 5, 4, 2, 1, 7],
+        [i64; 6]
+    );
+}
+
+// Not supported by wasm because of the size of the tuple:
+// FromWasm32Memory is only implemented for tuples of up to 4 elements
+#[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-dev"))]
+fn return_tuple_7() {
+    assert_evals_to!(
+        indoc!(
+            r#"
+                ( 3, 5, 4, 2, 1, 7, 8 )
+                "#
+        ),
+        [3, 5, 4, 2, 1, 7, 8],
+        [i64; 7]
+    );
+}
+
+#[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
+fn return_tuple_float_int() {
+    assert_evals_to!(
+        indoc!(
+            r#"
+                (1.23, 0x1)
+                "#
+        ),
+        (1.23, 0x1),
+        (f64, i64)
+    );
+}
+
+#[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
+fn return_tuple_int_float() {
+    assert_evals_to!(
+        indoc!(
+            r#"
+                ( 0x1, 1.23 )
+                "#
+        ),
+        (0x1, 1.23),
+        (i64, f64)
+    );
+}
+
+#[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
+fn return_tuple_float_float() {
+    assert_evals_to!(
+        indoc!(
+            r#"
+                ( 2.46, 1.23 )
+                "#
+        ),
+        (2.46, 1.23),
+        (f64, f64)
+    );
+}
+
+#[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
+fn return_tuple_float_float_float() {
+    assert_evals_to!(
+        indoc!(
+            r#"
+                ( 2.46, 1.23, 0.1 )
+                "#
+        ),
+        (2.46, 1.23, 0.1),
+        (f64, f64, f64)
+    );
+}
+
+#[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm", feature = "gen-dev"))]
+fn return_nested_tuple() {
+    assert_evals_to!(
+        indoc!(
+            r#"
+                (0x0, (2.46, 1.23, 0.1))
+                "#
+        ),
+        (0x0, (2.46, 1.23, 0.1)),
+        (i64, (f64, f64, f64))
+    );
+}
+
+#[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
+fn nested_tuple_load() {
+    assert_evals_to!(
+        indoc!(
+            r#"
+                x = (0, (0x2, 0x5, 0x6))
+
+                y = x.1
+
+                y.2
+                "#
+        ),
+        6,
+        i64
+    );
+}
+
+#[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
+fn tuple_accessor_twice() {
+    assert_evals_to!(".0 (4, 5)  + .1 ( 2.46, 3 ) ", 7, i64);
+}
+
+#[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
+fn tuple_accessor_multi_element_tuple() {
+    assert_evals_to!(
+        indoc!(
+            r#"
+                .0 (4, "foo")
+                "#
+        ),
+        4,
+        i64
+    );
+}
+
+#[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
+fn booleans_in_tuple() {
+    assert_evals_to!(indoc!("(1 == 1, 1 == 1)"), (true, true), (bool, bool));
+    assert_evals_to!(indoc!("(1 != 1, 1 == 1)"), (false, true), (bool, bool));
+    assert_evals_to!(indoc!("(1 == 1, 1 != 1)"), (true, false), (bool, bool));
+    assert_evals_to!(indoc!("(1 != 1, 1 != 1)"), (false, false), (bool, bool));
+}
+
+// TODO: this test fails for mysterious reasons
+#[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
+fn alignment_in_tuple() {
+    assert_evals_to!(
+        indoc!("(32, 1 == 1, 78u16)"),
+        (32i64, 78u16, true),
+        (i64, u16, bool)
+    );
+}
+
+#[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
+fn tuple_length_polymorphism() {
+    assert_evals_to!(
+        indoc!(
+            r#"
+            a = (42, 43)
+            b = (1, 2, 44)
+
+            f : (I64, I64)a, (I64, I64)b -> I64
+            f = \(x1, x2), (x3, x4) -> x1 + x2 + x3 + x4
+
+            f a b
+            "#
+        ),
+        88,
+        i64
+    );
+}
+
+#[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
+fn generalized_tuple_accessor() {
+    assert_evals_to!(
+        indoc!(
+            r#"
+            return0 = .0
+
+            return0 ("foo", 1)
+            "#
+        ),
+        RocStr::from("foo"),
+        RocStr
+    );
+}
+
+#[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
+fn generalized_explicit_tuple_accessor() {
+    assert_evals_to!(
+        indoc!(
+            r#"
+            return0 = \x -> x.0
+
+            return0 ("foo", 1)
+            "#
+        ),
+        RocStr::from("foo"),
+        RocStr
+    );
+}

--- a/crates/compiler/test_gen/src/tests.rs
+++ b/crates/compiler/test_gen/src/tests.rs
@@ -17,6 +17,7 @@ pub mod gen_result;
 pub mod gen_set;
 pub mod gen_str;
 pub mod gen_tags;
+pub mod gen_tuples;
 mod helpers;
 pub mod wasm_str;
 

--- a/crates/compiler/test_mono/generated/tuple_pattern_match.txt
+++ b/crates/compiler/test_mono/generated/tuple_pattern_match.txt
@@ -1,0 +1,29 @@
+procedure Test.0 ():
+    let Test.15 : I64 = 1i64;
+    let Test.16 : I64 = 2i64;
+    let Test.1 : {I64, I64} = Struct {Test.15, Test.16};
+    joinpoint Test.5:
+        let Test.2 : Str = "A";
+        ret Test.2;
+    in
+    let Test.12 : I64 = StructAtIndex 1 Test.1;
+    let Test.13 : I64 = 2i64;
+    let Test.14 : Int1 = lowlevel Eq Test.13 Test.12;
+    if Test.14 then
+        let Test.6 : I64 = StructAtIndex 0 Test.1;
+        let Test.7 : I64 = 1i64;
+        let Test.8 : Int1 = lowlevel Eq Test.7 Test.6;
+        if Test.8 then
+            jump Test.5;
+        else
+            let Test.3 : Str = "B";
+            ret Test.3;
+    else
+        let Test.9 : I64 = StructAtIndex 0 Test.1;
+        let Test.10 : I64 = 1i64;
+        let Test.11 : Int1 = lowlevel Eq Test.10 Test.9;
+        if Test.11 then
+            jump Test.5;
+        else
+            let Test.4 : Str = "C";
+            ret Test.4;

--- a/crates/compiler/test_mono/src/tests.rs
+++ b/crates/compiler/test_mono/src/tests.rs
@@ -2192,6 +2192,20 @@ fn list_one_vs_one_spread_issue_4685() {
     )
 }
 
+#[mono_test]
+fn tuple_pattern_match() {
+    indoc!(
+        r#"
+        app "test" provides [main] to "./platform"
+
+        main = when (1, 2) is
+            (1, _) -> "A"
+            (_, 2) -> "B"
+            (_, _) -> "C"
+        "#
+    )
+}
+
 #[mono_test(mode = "test")]
 fn issue_4705() {
     indoc!(

--- a/crates/compiler/test_syntax/tests/snapshots/pass/function_with_tuple_ext_type.expr.result-ast
+++ b/crates/compiler/test_syntax/tests/snapshots/pass/function_with_tuple_ext_type.expr.result-ast
@@ -22,7 +22,7 @@ Defs(
                 @4-20 Function(
                     [
                         @4-10 Tuple {
-                            fields: [
+                            elems: [
                                 @5-8 Apply(
                                     "",
                                     "Str",
@@ -37,7 +37,7 @@ Defs(
                         },
                     ],
                     @14-20 Tuple {
-                        fields: [
+                        elems: [
                             @15-18 Apply(
                                 "",
                                 "Str",
@@ -59,7 +59,7 @@ Defs(
                 ann_type: @4-20 Function(
                     [
                         @4-10 Tuple {
-                            fields: [
+                            elems: [
                                 @5-8 Apply(
                                     "",
                                     "Str",
@@ -74,7 +74,7 @@ Defs(
                         },
                     ],
                     @14-20 Tuple {
-                        fields: [
+                        elems: [
                             @15-18 Apply(
                                 "",
                                 "Str",

--- a/crates/compiler/test_syntax/tests/snapshots/pass/function_with_tuple_type.expr.result-ast
+++ b/crates/compiler/test_syntax/tests/snapshots/pass/function_with_tuple_type.expr.result-ast
@@ -28,7 +28,7 @@ Defs(
                         ),
                     ],
                     @11-21 Tuple {
-                        fields: [
+                        elems: [
                             @12-15 Apply(
                                 "",
                                 "I64",
@@ -57,7 +57,7 @@ Defs(
                         ),
                     ],
                     @11-21 Tuple {
-                        fields: [
+                        elems: [
                             @12-15 Apply(
                                 "",
                                 "I64",

--- a/crates/compiler/test_syntax/tests/snapshots/pass/tuple_accessor_function.expr.result-ast
+++ b/crates/compiler/test_syntax/tests/snapshots/pass/tuple_accessor_function.expr.result-ast
@@ -1,6 +1,8 @@
 Apply(
-    @0-2 TupleAccessorFunction(
-        "1",
+    @0-2 AccessorFunction(
+        TupleIndex(
+            "1",
+        ),
     ),
     [
         @3-12 Tuple(

--- a/crates/compiler/test_syntax/tests/snapshots/pass/tuple_type.expr.result-ast
+++ b/crates/compiler/test_syntax/tests/snapshots/pass/tuple_type.expr.result-ast
@@ -22,7 +22,7 @@ Defs(
                 @3-27 Function(
                     [
                         @3-13 Tuple {
-                            fields: [
+                            elems: [
                                 @4-7 Apply(
                                     "",
                                     "Str",
@@ -38,7 +38,7 @@ Defs(
                         },
                     ],
                     @17-27 Tuple {
-                        fields: [
+                        elems: [
                             @18-21 Apply(
                                 "",
                                 "Str",
@@ -61,7 +61,7 @@ Defs(
                 ann_type: @3-27 Function(
                     [
                         @3-13 Tuple {
-                            fields: [
+                            elems: [
                                 @4-7 Apply(
                                     "",
                                     "Str",
@@ -77,7 +77,7 @@ Defs(
                         },
                     ],
                     @17-27 Tuple {
-                        fields: [
+                        elems: [
                             @18-21 Apply(
                                 "",
                                 "Str",

--- a/crates/compiler/test_syntax/tests/snapshots/pass/tuple_type_ext.expr.result-ast
+++ b/crates/compiler/test_syntax/tests/snapshots/pass/tuple_type_ext.expr.result-ast
@@ -22,7 +22,7 @@ Defs(
                 @3-29 Function(
                     [
                         @3-14 Tuple {
-                            fields: [
+                            elems: [
                                 @4-7 Apply(
                                     "",
                                     "Str",
@@ -42,7 +42,7 @@ Defs(
                         },
                     ],
                     @18-29 Tuple {
-                        fields: [
+                        elems: [
                             @19-22 Apply(
                                 "",
                                 "Str",
@@ -69,7 +69,7 @@ Defs(
                 ann_type: @3-29 Function(
                     [
                         @3-14 Tuple {
-                            fields: [
+                            elems: [
                                 @4-7 Apply(
                                     "",
                                     "Str",
@@ -89,7 +89,7 @@ Defs(
                         },
                     ],
                     @18-29 Tuple {
-                        fields: [
+                        elems: [
                             @19-22 Apply(
                                 "",
                                 "Str",

--- a/crates/compiler/types/src/types.rs
+++ b/crates/compiler/types/src/types.rs
@@ -3617,6 +3617,13 @@ fn variables_help_detailed(tipe: &Type, accum: &mut VariableDetail) {
     }
 }
 
+/// Either a field name for a record or an index into a tuple
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum IndexOrField {
+    Field(Lowercase),
+    Index(usize),
+}
+
 #[derive(Debug)]
 pub struct RecordStructure {
     /// Invariant: these should be sorted!
@@ -3777,10 +3784,9 @@ pub enum Category {
 
     // records
     Record,
-    RecordAccessor(Lowercase),
+    Accessor(IndexOrField),
     RecordAccess(Lowercase),
     Tuple,
-    TupleAccessor(usize),
     TupleAccess(usize),
     DefaultValue(Lowercase), // for setting optional fields
 
@@ -3796,6 +3802,7 @@ pub enum Category {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PatternCategory {
     Record,
+    Tuple,
     List,
     EmptyRecord,
     PatternGuard,

--- a/crates/reporting/tests/test_reporting.rs
+++ b/crates/reporting/tests/test_reporting.rs
@@ -958,6 +958,59 @@ mod test_reporting {
     );
 
     test_report!(
+        tuple_exhaustiveness_bad,
+        indoc!(
+            r#"
+            Color : [Red, Blue]
+
+            value : (Color, Color)
+            value = (Red, Red)
+
+            when value is
+                (Blue, Blue) -> "foo"
+                (Red, Blue) -> "foo"
+                (Blue, Red) -> "foo"
+                #(Red, Red) -> "foo"
+            "#
+        ),
+        @r###"
+    ── UNSAFE PATTERN ──────────────────────────────────────── /code/proj/Main.roc ─
+
+    This `when` does not cover all the possibilities:
+
+     9│>      when value is
+    10│>          (Blue, Blue) -> "foo"
+    11│>          (Red, Blue) -> "foo"
+    12│>          (Blue, Red) -> "foo"
+
+    Other possibilities include:
+
+        ( Red, Red )
+
+    I would have to crash if I saw one of those! Add branches for them!
+    "###
+    );
+
+    test_report!(
+        tuple_exhaustiveness_good,
+        indoc!(
+            r#"
+            Color : [Red, Blue]
+
+            value : (Color, Color)
+            value = (Red, Red)
+
+            when value is
+                (Blue, Blue) -> "foo"
+                (Red, Blue) -> "foo"
+                (Blue, Red) -> "foo"
+                (Red, Red) -> "foo"
+            "#
+        ),
+        @"" // No error
+    );
+
+    test_report!(
         elem_in_list,
         indoc!(
             r#"


### PR DESCRIPTION
Note that I combined the code paths for record & tuple accessors using `field: IndexOrField` (tuple or record, respectively). I called the combined type `StructAccessorData`.

I experimented with also doing the same thing with TupleAccess/RecordAccess, but the there wasn't nearly as much code sharing possible in that case.

Thanks to Ayaz for helping investigate/resolve the test failures!