### PR TITLE
gen_dev: Fix subtle issue with function call building and add bool to array creation in generic64

### DIFF
--- a/crates/compiler/gen_dev/src/generic64/mod.rs
+++ b/crates/compiler/gen_dev/src/generic64/mod.rs
@@ -1850,7 +1850,7 @@ impl<
             };
             // TODO: Expand to all types.
             match self.layout_interner.get(*elem_layout) {
-                Layout::Builtin(Builtin::Int(IntWidth::I64 | IntWidth::U64)) => {
+                Layout::Builtin(Builtin::Int(IntWidth::I64 | IntWidth::U64) | Builtin::Bool) => {
                     let sym_reg = self
                         .storage_manager
                         .load_to_general_reg(&mut self.buf, elem_sym);

--- a/crates/compiler/test_gen/src/gen_list.rs
+++ b/crates/compiler/test_gen/src/gen_list.rs
@@ -52,7 +52,7 @@ fn int_list_literal() {
 }
 
 #[test]
-#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm", feature = "gen-dev"))]
 fn bool_list_literal() {
     assert_evals_to!(
         indoc!(
@@ -84,7 +84,45 @@ fn bool_list_literal() {
         RocList::from_slice(&[false; 1]),
         RocList<bool>
     );
+}
 
+#[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm", feature = "gen-dev"))]
+fn bool_list_concat() {
+    assert_evals_to!(
+        indoc!(
+            r#"
+               List.concat [Bool.true, Bool.false] [Bool.false, Bool.true]
+               "#
+        ),
+        RocList::from_slice(&[true, false, false, true]),
+        RocList<bool>
+    );
+
+    assert_evals_to!(
+        indoc!(
+            r#"
+               List.concat [] [Bool.false, Bool.true]
+               "#
+        ),
+        RocList::from_slice(&[false, true]),
+        RocList<bool>
+    );
+
+    assert_evals_to!(
+        indoc!(
+            r#"
+               List.concat [Bool.true, Bool.false] []
+               "#
+        ),
+        RocList::from_slice(&[true, false]),
+        RocList<bool>
+    );
+}
+
+#[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
+fn bool_list_literal_repeat() {
     assert_evals_to!(
         indoc!(
             r#"
@@ -726,7 +764,7 @@ fn list_append_to_empty_list_of_int() {
 }
 
 #[test]
-#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm", feature = "gen-dev"))]
 fn list_append_bools() {
     assert_evals_to!(
         "List.append [Bool.true, Bool.false] Bool.true",
@@ -789,7 +827,7 @@ fn list_prepend_str() {
 }
 
 #[test]
-#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm", feature = "gen-dev"))]
 fn list_prepend_bools() {
     assert_evals_to!(
         "List.prepend [Bool.true, Bool.false] Bool.true",


### PR DESCRIPTION
This PR fixes an issue where the function call building logic would consume the `HigherOrder` calltype.

Also drive-by added bools to list creation such that we can enable more tests. 