### PR TITLE
[Simple PR] Remove native from rust flags

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -10,10 +10,6 @@ test-gen-llvm-wasm = "test -p roc_gen_wasm -p test_gen --no-default-features --f
 # lto=fat       Spend extra effort on link-time optimization across crates
 rustflags = ["-Copt-level=s", "-Clto=fat"]
 
-[target.'cfg(not(target = "wasm32-unknown-unknown"))']
-# Sets the avx, avx2, sse2 and sse4.2 target-features correctly based on your CPU.
-rustflags = ["-Ctarget-cpu=native"]
-
 [env]
 # Gives us the path of the workspace root for use in cargo tests without having
 # to compute it per-package.


### PR DESCRIPTION
It isn't currently faster and it blocks user rustflags in their home/.cargo/config.toml