### PR TITLE
Statically ingest compiler-rt into builtins

### DIFF
--- a/crates/cli/tests/fixtures/multi-dep-str/platform/host.zig
+++ b/crates/cli/tests/fixtures/multi-dep-str/platform/host.zig
@@ -6,20 +6,6 @@ const testing = std.testing;
 const expectEqual = testing.expectEqual;
 const expect = testing.expect;
 
-comptime {
-    // This is a workaround for https://github.com/ziglang/zig/issues/8218
-    // which is only necessary on macOS.
-    //
-    // Once that issue is fixed, we can undo the changes in
-    // 177cf12e0555147faa4d436e52fc15175c2c4ff0 and go back to passing
-    // -fcompiler-rt in link.rs instead of doing this. Note that this
-    // workaround is present in many host.zig files, so make sure to undo
-    // it everywhere!
-    if (builtin.os.tag == .macos) {
-        _ = @import("compiler_rt");
-    }
-}
-
 const mem = std.mem;
 const Allocator = mem.Allocator;
 

--- a/crates/cli/tests/fixtures/multi-dep-thunk/platform/host.zig
+++ b/crates/cli/tests/fixtures/multi-dep-thunk/platform/host.zig
@@ -6,20 +6,6 @@ const testing = std.testing;
 const expectEqual = testing.expectEqual;
 const expect = testing.expect;
 
-comptime {
-    // This is a workaround for https://github.com/ziglang/zig/issues/8218
-    // which is only necessary on macOS.
-    //
-    // Once that issue is fixed, we can undo the changes in
-    // 177cf12e0555147faa4d436e52fc15175c2c4ff0 and go back to passing
-    // -fcompiler-rt in link.rs instead of doing this. Note that this
-    // workaround is present in many host.zig files, so make sure to undo
-    // it everywhere!
-    if (builtin.os.tag == .macos) {
-        _ = @import("compiler_rt");
-    }
-}
-
 const mem = std.mem;
 const Allocator = mem.Allocator;
 

--- a/crates/cli/tests/fixtures/packages/platform/host.zig
+++ b/crates/cli/tests/fixtures/packages/platform/host.zig
@@ -6,20 +6,6 @@ const testing = std.testing;
 const expectEqual = testing.expectEqual;
 const expect = testing.expect;
 
-comptime {
-    // This is a workaround for https://github.com/ziglang/zig/issues/8218
-    // which is only necessary on macOS.
-    //
-    // Once that issue is fixed, we can undo the changes in
-    // 177cf12e0555147faa4d436e52fc15175c2c4ff0 and go back to passing
-    // -fcompiler-rt in link.rs instead of doing this. Note that this
-    // workaround is present in many host.zig files, so make sure to undo
-    // it everywhere!
-    if (builtin.os.tag == .macos) {
-        _ = @import("compiler_rt");
-    }
-}
-
 const mem = std.mem;
 const Allocator = mem.Allocator;
 

--- a/crates/cli_testing_examples/algorithms/fibonacci-platform/host.zig
+++ b/crates/cli_testing_examples/algorithms/fibonacci-platform/host.zig
@@ -5,20 +5,6 @@ const expectEqual = testing.expectEqual;
 const expect = testing.expect;
 const maxInt = std.math.maxInt;
 
-comptime {
-    // This is a workaround for https://github.com/ziglang/zig/issues/8218
-    // which is only necessary on macOS.
-    //
-    // Once that issue is fixed, we can undo the changes in
-    // 177cf12e0555147faa4d436e52fc15175c2c4ff0 and go back to passing
-    // -fcompiler-rt in link.rs instead of doing this. Note that this
-    // workaround is present in many host.zig files, so make sure to undo
-    // it everywhere!
-    if (builtin.os.tag == .macos) {
-        _ = @import("compiler_rt");
-    }
-}
-
 const mem = std.mem;
 const Allocator = mem.Allocator;
 

--- a/crates/cli_testing_examples/algorithms/quicksort-platform/host.zig
+++ b/crates/cli_testing_examples/algorithms/quicksort-platform/host.zig
@@ -6,20 +6,6 @@ const testing = std.testing;
 const expectEqual = testing.expectEqual;
 const expect = testing.expect;
 
-comptime {
-    // This is a workaround for https://github.com/ziglang/zig/issues/8218
-    // which is only necessary on macOS.
-    //
-    // Once that issue is fixed, we can undo the changes in
-    // 177cf12e0555147faa4d436e52fc15175c2c4ff0 and go back to passing
-    // -fcompiler-rt in link.rs instead of doing this. Note that this
-    // workaround is present in many host.zig files, so make sure to undo
-    // it everywhere!
-    if (builtin.os.tag == .macos) {
-        _ = @import("compiler_rt");
-    }
-}
-
 const mem = std.mem;
 const Allocator = mem.Allocator;
 

--- a/crates/cli_testing_examples/benchmarks/platform/host.zig
+++ b/crates/cli_testing_examples/benchmarks/platform/host.zig
@@ -7,20 +7,6 @@ const expectEqual = testing.expectEqual;
 const expect = testing.expect;
 const maxInt = std.math.maxInt;
 
-comptime {
-    // This is a workaround for https://github.com/ziglang/zig/issues/8218
-    // which is only necessary on macOS.
-    //
-    // Once that issue is fixed, we can undo the changes in
-    // 177cf12e0555147faa4d436e52fc15175c2c4ff0 and go back to passing
-    // -fcompiler-rt in link.rs instead of doing this. Note that this
-    // workaround is present in many host.zig files, so make sure to undo
-    // it everywhere!
-    if (builtin.os.tag == .macos) {
-        _ = @import("compiler_rt");
-    }
-}
-
 const mem = std.mem;
 const Allocator = mem.Allocator;
 

--- a/crates/cli_testing_examples/expects/zig-platform/host.zig
+++ b/crates/cli_testing_examples/expects/zig-platform/host.zig
@@ -6,20 +6,6 @@ const testing = std.testing;
 const expectEqual = testing.expectEqual;
 const expect = testing.expect;
 
-comptime {
-    // This is a workaround for https://github.com/ziglang/zig/issues/8218
-    // which is only necessary on macOS.
-    //
-    // Once that issue is fixed, we can undo the changes in
-    // 177cf12e0555147faa4d436e52fc15175c2c4ff0 and go back to passing
-    // -fcompiler-rt in link.rs instead of doing this. Note that this
-    // workaround is present in many host.zig files, so make sure to undo
-    // it everywhere!
-    if (builtin.os.tag == .macos) {
-        _ = @import("compiler_rt");
-    }
-}
-
 const Align = 2 * @alignOf(usize);
 extern fn malloc(size: usize) callconv(.C) ?*align(Align) anyopaque;
 extern fn realloc(c_ptr: [*]align(Align) u8, size: usize) callconv(.C) ?*anyopaque;

--- a/crates/compiler/build/src/link.rs
+++ b/crates/compiler/build/src/link.rs
@@ -285,11 +285,6 @@ pub fn build_zig_host_native(
         "glue",
         find_zig_glue_path().to_str().unwrap(),
         "--pkg-end",
-        // include the zig runtime
-        "--pkg-begin",
-        "compiler_rt",
-        zig_compiler_rt_path.to_str().unwrap(),
-        "--pkg-end",
         // include libc
         "--library",
         "c",

--- a/crates/compiler/build/src/link.rs
+++ b/crates/compiler/build/src/link.rs
@@ -171,6 +171,10 @@ pub fn build_zig_host_native(
         // cross-compile?
         "-target",
         target,
+        // Some examples need the compiler-rt in the host object file.
+        // Specifically , it pulls in `__zig_probe_stack`.
+        // There may be a better way to pull this in, but this is the simplest way.
+        "-fcompiler-rt",
     ]);
 
     // valgrind does not yet support avx512 instructions, see #1963.
@@ -259,46 +263,6 @@ pub fn build_zig_host_native(
     builtins_host_path: &Path,
     // For compatibility with the non-macOS def above. Keep these in sync.
 ) -> Command {
-    use serde_json::Value;
-
-    // Run `zig env` to find the location of zig's std/ directory
-    let zig_env_output = zig().args(["env"]).output().unwrap();
-
-    let zig_env_json = if zig_env_output.status.success() {
-        std::str::from_utf8(&zig_env_output.stdout).unwrap_or_else(|utf8_err| {
-            internal_error!(
-                "`zig env` failed; its stderr output was invalid utf8 ({:?})",
-                utf8_err
-            );
-        })
-    } else {
-        match std::str::from_utf8(&zig_env_output.stderr) {
-            Ok(stderr) => internal_error!("`zig env` failed - stderr output was: {:?}", stderr),
-            Err(utf8_err) => internal_error!(
-                "`zig env` failed; its stderr output was invalid utf8 ({:?})",
-                utf8_err
-            ),
-        }
-    };
-
-    let mut zig_compiler_rt_path = match serde_json::from_str(zig_env_json) {
-        Ok(Value::Object(map)) => match map.get("std_dir") {
-            Some(Value::String(std_dir)) => PathBuf::from(Path::new(std_dir)),
-            _ => {
-                internal_error!("Expected JSON containing a `std_dir` String field from `zig env`, but got: {:?}", zig_env_json);
-            }
-        },
-        _ => {
-            internal_error!(
-                "Expected JSON containing a `std_dir` field from `zig env`, but got: {:?}",
-                zig_env_json
-            );
-        }
-    };
-
-    zig_compiler_rt_path.push("special");
-    zig_compiler_rt_path.push("compiler_rt.zig");
-
     let mut zig_cmd = zig();
     zig_cmd
         .env_clear()
@@ -441,7 +405,7 @@ pub fn build_c_host_native(
                     "-lm",
                     "-lpthread",
                     "-ldl",
-                    // "-lrt",
+                    "-lrt",
                     "-lutil",
                 ]);
             }
@@ -1107,7 +1071,7 @@ fn link_linux(
             "-lm",
             "-lpthread",
             "-ldl",
-            // "-lrt",
+            "-lrt",
             "-lutil",
             "-lc_nonshared",
             libgcc_path.to_str().unwrap(),

--- a/crates/compiler/build/src/link.rs
+++ b/crates/compiler/build/src/link.rs
@@ -173,17 +173,6 @@ pub fn build_zig_host_native(
         target,
     ]);
 
-    // some examples need the compiler-rt in the app object file.
-    // but including it on windows causes weird crashes, at least
-    // when we use zig 0.9. It looks like zig 0.10 is going to fix
-    // this problem for us, so this is a temporary workaround
-    if !target.contains("windows") {
-        zig_cmd.args([
-            // include the zig runtime
-            "-fcompiler-rt",
-        ]);
-    }
-
     // valgrind does not yet support avx512 instructions, see #1963.
     if env::var("NO_AVX512").is_ok() {
         zig_cmd.args(["-mcpu", "x86_64"]);
@@ -452,7 +441,7 @@ pub fn build_c_host_native(
                     "-lm",
                     "-lpthread",
                     "-ldl",
-                    "-lrt",
+                    // "-lrt",
                     "-lutil",
                 ]);
             }
@@ -1118,7 +1107,7 @@ fn link_linux(
             "-lm",
             "-lpthread",
             "-ldl",
-            "-lrt",
+            // "-lrt",
             "-lutil",
             "-lc_nonshared",
             libgcc_path.to_str().unwrap(),

--- a/crates/compiler/builtins/bitcode/src/main.zig
+++ b/crates/compiler/builtins/bitcode/src/main.zig
@@ -9,12 +9,6 @@ const ROC_BUILTINS = "roc_builtins";
 const NUM = "num";
 const STR = "str";
 
-comptime {
-    if (builtin.cpu.arch != .wasm32) {
-        _ = @import("compiler_rt");
-    }
-}
-
 // Dec Module
 const dec = @import("dec.zig");
 

--- a/crates/compiler/builtins/bitcode/src/main.zig
+++ b/crates/compiler/builtins/bitcode/src/main.zig
@@ -10,7 +10,7 @@ const NUM = "num";
 const STR = "str";
 
 comptime {
-    if (builtin.target.os.tag != .windows and builtin.cpu.arch != .wasm32) {
+    if (builtin.cpu.arch != .wasm32) {
         _ = @import("compiler_rt");
     }
 }

--- a/crates/compiler/gen_llvm/src/llvm/intrinsics.rs
+++ b/crates/compiler/gen_llvm/src/llvm/intrinsics.rs
@@ -79,10 +79,6 @@ pub(crate) fn add_intrinsics<'ctx>(ctx: &'ctx Context, module: &Module<'ctx>) {
     let i32_type = ctx.i32_type();
     let void_type = ctx.void_type();
 
-    if let Some(func) = module.get_function("__muloti4") {
-        func.set_linkage(Linkage::WeakAny);
-    }
-
     add_intrinsic(
         ctx,
         module,

--- a/crates/valgrind/zig-platform/host.zig
+++ b/crates/valgrind/zig-platform/host.zig
@@ -6,20 +6,6 @@ const testing = std.testing;
 const expectEqual = testing.expectEqual;
 const expect = testing.expect;
 
-comptime {
-    // This is a workaround for https://github.com/ziglang/zig/issues/8218
-    // which is only necessary on macOS.
-    //
-    // Once that issue is fixed, we can undo the changes in
-    // 177cf12e0555147faa4d436e52fc15175c2c4ff0 and go back to passing
-    // -fcompiler-rt in link.rs instead of doing this. Note that this
-    // workaround is present in many host.zig files, so make sure to undo
-    // it everywhere!
-    if (builtin.os.tag == .macos) {
-        _ = @import("compiler_rt");
-    }
-}
-
 const Align = 2 * @alignOf(usize);
 extern fn malloc(size: usize) callconv(.C) ?*align(Align) anyopaque;
 extern fn realloc(c_ptr: [*]align(Align) u8, size: usize) callconv(.C) ?*anyopaque;

--- a/examples/cli/effects-platform/host.zig
+++ b/examples/cli/effects-platform/host.zig
@@ -7,20 +7,6 @@ const expectEqual = testing.expectEqual;
 const expect = testing.expect;
 const maxInt = std.math.maxInt;
 
-comptime {
-    // This is a workaround for https://github.com/ziglang/zig/issues/8218
-    // which is only necessary on macOS.
-    //
-    // Once that issue is fixed, we can undo the changes in
-    // 177cf12e0555147faa4d436e52fc15175c2c4ff0 and go back to passing
-    // -fcompiler-rt in link.rs instead of doing this. Note that this
-    // workaround is present in many host.zig files, so make sure to undo
-    // it everywhere!
-    if (builtin.os.tag == .macos) {
-        _ = @import("compiler_rt");
-    }
-}
-
 const mem = std.mem;
 const Allocator = mem.Allocator;
 

--- a/examples/cli/tui-platform/host.zig
+++ b/examples/cli/tui-platform/host.zig
@@ -7,20 +7,6 @@ const expectEqual = testing.expectEqual;
 const expect = testing.expect;
 const maxInt = std.math.maxInt;
 
-comptime {
-    // This is a workaround for https://github.com/ziglang/zig/issues/8218
-    // which is only necessary on macOS.
-    //
-    // Once that issue is fixed, we can undo the changes in
-    // 177cf12e0555147faa4d436e52fc15175c2c4ff0 and go back to passing
-    // -fcompiler-rt in link.rs instead of doing this. Note that this
-    // workaround is present in many host.zig files, so make sure to undo
-    // it everywhere!
-    if (builtin.os.tag == .macos) {
-        _ = @import("compiler_rt");
-    }
-}
-
 const mem = std.mem;
 const Allocator = mem.Allocator;
 

--- a/examples/platform-switching/zig-platform/host.zig
+++ b/examples/platform-switching/zig-platform/host.zig
@@ -6,20 +6,6 @@ const testing = std.testing;
 const expectEqual = testing.expectEqual;
 const expect = testing.expect;
 
-comptime {
-    // This is a workaround for https://github.com/ziglang/zig/issues/8218
-    // which is only necessary on macOS.
-    //
-    // Once that issue is fixed, we can undo the changes in
-    // 177cf12e0555147faa4d436e52fc15175c2c4ff0 and go back to passing
-    // -fcompiler-rt in link.rs instead of doing this. Note that this
-    // workaround is present in many host.zig files, so make sure to undo
-    // it everywhere!
-    if (builtin.os.tag == .macos) {
-        _ = @import("compiler_rt");
-    }
-}
-
 const Align = 2 * @alignOf(usize);
 extern fn malloc(size: usize) callconv(.C) ?*align(Align) anyopaque;
 extern fn realloc(c_ptr: [*]align(Align) u8, size: usize) callconv(.C) ?*anyopaque;


### PR DESCRIPTION
Now the platform doesn't have to link it if the platform doesn't depend on it. It also fixes some dependency issue that the surgical linker was hitting. Also, simplifies a number of workarounds.