### PR TITLE
gen_dev x86: misc low-level bool comparison functions 

### DIFF
--- a/crates/compiler/gen_dev/src/generic64/mod.rs
+++ b/crates/compiler/gen_dev/src/generic64/mod.rs
@@ -1132,6 +1132,22 @@ impl<
         }
     }
 
+    fn build_and(&mut self, dst: &Symbol, src1: &Symbol, src2: &Symbol, arg_layout: &InLayout<'a>) {
+        match *arg_layout {
+            Layout::BOOL => {
+                let dst_reg = self.storage_manager.claim_general_reg(&mut self.buf, dst);
+                let src1_reg = self
+                    .storage_manager
+                    .load_to_general_reg(&mut self.buf, src1);
+                let src2_reg = self
+                    .storage_manager
+                    .load_to_general_reg(&mut self.buf, src2);
+                ASM::and_reg64_reg64_reg64(&mut self.buf, dst_reg, src1_reg, src2_reg);
+            }
+            x => todo!("And: layout, {:?}", x),
+        }
+    }
+
     fn build_num_lt(
         &mut self,
         dst: &Symbol,

--- a/crates/compiler/gen_dev/src/generic64/mod.rs
+++ b/crates/compiler/gen_dev/src/generic64/mod.rs
@@ -1102,7 +1102,7 @@ impl<
 
     fn build_eq(&mut self, dst: &Symbol, src1: &Symbol, src2: &Symbol, arg_layout: &InLayout<'a>) {
         match *arg_layout {
-            single_register_int_builtins!() => {
+            single_register_int_builtins!() | Layout::BOOL => {
                 let dst_reg = self.storage_manager.claim_general_reg(&mut self.buf, dst);
                 let src1_reg = self
                     .storage_manager
@@ -1117,8 +1117,8 @@ impl<
     }
 
     fn build_neq(&mut self, dst: &Symbol, src1: &Symbol, src2: &Symbol, arg_layout: &InLayout<'a>) {
-        match self.layout_interner.get(*arg_layout) {
-            Layout::Builtin(Builtin::Int(IntWidth::I64 | IntWidth::U64)) => {
+        match *arg_layout {
+            single_register_int_builtins!() | Layout::BOOL => {
                 let dst_reg = self.storage_manager.claim_general_reg(&mut self.buf, dst);
                 let src1_reg = self
                     .storage_manager

--- a/crates/compiler/gen_dev/src/generic64/mod.rs
+++ b/crates/compiler/gen_dev/src/generic64/mod.rs
@@ -1148,6 +1148,22 @@ impl<
         }
     }
 
+    fn build_or(&mut self, dst: &Symbol, src1: &Symbol, src2: &Symbol, arg_layout: &InLayout<'a>) {
+        match *arg_layout {
+            Layout::BOOL => {
+                let dst_reg = self.storage_manager.claim_general_reg(&mut self.buf, dst);
+                let src1_reg = self
+                    .storage_manager
+                    .load_to_general_reg(&mut self.buf, src1);
+                let src2_reg = self
+                    .storage_manager
+                    .load_to_general_reg(&mut self.buf, src2);
+                ASM::or_reg64_reg64_reg64(&mut self.buf, dst_reg, src1_reg, src2_reg);
+            }
+            x => todo!("Or: layout, {:?}", x),
+        }
+    }
+
     fn build_num_lt(
         &mut self,
         dst: &Symbol,

--- a/crates/compiler/gen_dev/src/lib.rs
+++ b/crates/compiler/gen_dev/src/lib.rs
@@ -649,6 +649,15 @@ trait Backend<'a> {
                 );
                 self.build_or(sym, &args[0], &args[1], &arg_layouts[0])
             }
+            LowLevel::Not => {
+                debug_assert_eq!(1, args.len(), "Not: expected to have exactly one argument");
+                debug_assert_eq!(
+                    Layout::BOOL,
+                    *ret_layout,
+                    "Not: expected to have return layout of type Bool"
+                );
+                self.build_not(sym, &args[0], &arg_layouts[0])
+            }
             LowLevel::NumLt => {
                 debug_assert_eq!(
                     2,
@@ -1047,6 +1056,9 @@ trait Backend<'a> {
 
     /// build_or stores the result of `src1 || src2` into dst.
     fn build_or(&mut self, dst: &Symbol, src1: &Symbol, src2: &Symbol, arg_layout: &InLayout<'a>);
+
+    /// build_not stores the result of `!src` into dst.
+    fn build_not(&mut self, dst: &Symbol, src: &Symbol, arg_layout: &InLayout<'a>);
 
     /// build_num_lt stores the result of `src1 < src2` into dst.
     fn build_num_lt(

--- a/crates/compiler/gen_dev/src/lib.rs
+++ b/crates/compiler/gen_dev/src/lib.rs
@@ -623,6 +623,19 @@ trait Backend<'a> {
                 );
                 self.build_neq(sym, &args[0], &args[1], &arg_layouts[0])
             }
+            LowLevel::And => {
+                debug_assert_eq!(2, args.len(), "And: expected to have exactly two argument");
+                debug_assert_eq!(
+                    arg_layouts[0], arg_layouts[1],
+                    "And: expected all arguments of to have the same layout"
+                );
+                debug_assert_eq!(
+                    Layout::BOOL,
+                    *ret_layout,
+                    "And: expected to have return layout of type Bool"
+                );
+                self.build_and(sym, &args[0], &args[1], &arg_layouts[0])
+            }
             LowLevel::NumLt => {
                 debug_assert_eq!(
                     2,
@@ -1015,6 +1028,9 @@ trait Backend<'a> {
 
     /// build_neq stores the result of `src1 != src2` into dst.
     fn build_neq(&mut self, dst: &Symbol, src1: &Symbol, src2: &Symbol, arg_layout: &InLayout<'a>);
+
+    /// build_and stores the result of `src1 && src2` into dst.
+    fn build_and(&mut self, dst: &Symbol, src1: &Symbol, src2: &Symbol, arg_layout: &InLayout<'a>);
 
     /// build_num_lt stores the result of `src1 < src2` into dst.
     fn build_num_lt(

--- a/crates/compiler/gen_dev/src/lib.rs
+++ b/crates/compiler/gen_dev/src/lib.rs
@@ -636,6 +636,19 @@ trait Backend<'a> {
                 );
                 self.build_and(sym, &args[0], &args[1], &arg_layouts[0])
             }
+            LowLevel::Or => {
+                debug_assert_eq!(2, args.len(), "Or: expected to have exactly two argument");
+                debug_assert_eq!(
+                    arg_layouts[0], arg_layouts[1],
+                    "Or: expected all arguments of to have the same layout"
+                );
+                debug_assert_eq!(
+                    Layout::BOOL,
+                    *ret_layout,
+                    "Or: expected to have return layout of type Bool"
+                );
+                self.build_or(sym, &args[0], &args[1], &arg_layouts[0])
+            }
             LowLevel::NumLt => {
                 debug_assert_eq!(
                     2,
@@ -1031,6 +1044,9 @@ trait Backend<'a> {
 
     /// build_and stores the result of `src1 && src2` into dst.
     fn build_and(&mut self, dst: &Symbol, src1: &Symbol, src2: &Symbol, arg_layout: &InLayout<'a>);
+
+    /// build_or stores the result of `src1 || src2` into dst.
+    fn build_or(&mut self, dst: &Symbol, src1: &Symbol, src2: &Symbol, arg_layout: &InLayout<'a>);
 
     /// build_num_lt stores the result of `src1 < src2` into dst.
     fn build_num_lt(

--- a/crates/compiler/test_gen/src/gen_compare.rs
+++ b/crates/compiler/test_gen/src/gen_compare.rs
@@ -27,7 +27,7 @@ fn eq_i64() {
 }
 
 #[test]
-#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm", feature = "gen-dev"))]
 fn neq_i64() {
     assert_evals_to!(
         indoc!(
@@ -61,7 +61,7 @@ fn eq_u64() {
 }
 
 #[test]
-#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm", feature = "gen-dev"))]
 fn neq_u64() {
     assert_evals_to!(
         indoc!(
@@ -78,7 +78,7 @@ fn neq_u64() {
 }
 
 #[test]
-#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm", feature = "gen-dev"))]
 fn eq_bool_tag() {
     assert_evals_to!(
         indoc!(
@@ -95,7 +95,7 @@ fn eq_bool_tag() {
 }
 
 #[test]
-#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm", feature = "gen-dev"))]
 fn neq_bool_tag() {
     assert_evals_to!(
         indoc!(
@@ -152,7 +152,7 @@ fn unit() {
 }
 
 #[test]
-#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm", feature = "gen-dev"))]
 fn newtype() {
     assert_evals_to!("Identity 42 == Identity 42", true, bool);
     assert_evals_to!("Identity 42 != Identity 42", false, bool);

--- a/crates/compiler/test_gen/src/gen_compare.rs
+++ b/crates/compiler/test_gen/src/gen_compare.rs
@@ -130,6 +130,16 @@ fn or_bool() {
 }
 
 #[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm", feature = "gen-dev"))]
+fn not_bool() {
+    assert_evals_to!("!Bool.true", false, bool);
+    assert_evals_to!("!Bool.false", true, bool);
+
+    assert_evals_to!("!(!Bool.true)", true, bool);
+    assert_evals_to!("!(!Bool.false)", false, bool);
+}
+
+#[test]
 #[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
 fn empty_record() {
     assert_evals_to!("{} == {}", true, bool);

--- a/crates/compiler/test_gen/src/gen_compare.rs
+++ b/crates/compiler/test_gen/src/gen_compare.rs
@@ -113,6 +113,24 @@ fn neq_bool_tag() {
 
 #[test]
 #[cfg(any(feature = "gen-llvm", feature = "gen-wasm", feature = "gen-dev"))]
+fn bool_logic() {
+    assert_evals_to!(
+        indoc!(
+            r#"
+                bool1 = Bool.true
+                bool2 = Bool.false
+                bool3 = !bool1
+
+                (bool1 && bool2) || bool2 && bool3
+                "#
+        ),
+        false,
+        bool
+    );
+}
+
+#[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm", feature = "gen-dev"))]
 fn and_bool() {
     assert_evals_to!("Bool.true && Bool.true", true, bool);
     assert_evals_to!("Bool.true && Bool.false", false, bool);

--- a/crates/compiler/test_gen/src/gen_compare.rs
+++ b/crates/compiler/test_gen/src/gen_compare.rs
@@ -112,6 +112,15 @@ fn neq_bool_tag() {
 }
 
 #[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm", feature = "gen-dev"))]
+fn and_bool() {
+    assert_evals_to!("Bool.true && Bool.true", true, bool);
+    assert_evals_to!("Bool.true && Bool.false", false, bool);
+    assert_evals_to!("Bool.false && Bool.true", false, bool);
+    assert_evals_to!("Bool.false && Bool.false", false, bool);
+}
+
+#[test]
 #[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
 fn empty_record() {
     assert_evals_to!("{} == {}", true, bool);

--- a/crates/compiler/test_gen/src/gen_compare.rs
+++ b/crates/compiler/test_gen/src/gen_compare.rs
@@ -121,6 +121,15 @@ fn and_bool() {
 }
 
 #[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm", feature = "gen-dev"))]
+fn or_bool() {
+    assert_evals_to!("Bool.true || Bool.true", true, bool);
+    assert_evals_to!("Bool.true || Bool.false", true, bool);
+    assert_evals_to!("Bool.false || Bool.true", true, bool);
+    assert_evals_to!("Bool.false || Bool.false", false, bool);
+}
+
+#[test]
 #[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
 fn empty_record() {
     assert_evals_to!("{} == {}", true, bool);


### PR DESCRIPTION
This PR adds some missing low-level functions, adjusting some of the existing ones. 

Does't quite close, but addresses some of the points in #3516

I noticed the `arguments!` macro in the LLVM backend, I think we could benefit from something like that in the dev backend, may look into that next.

One thing in this PR is how `not` is implemented as the bool representation is somewhat non-standard as outlined in https://github.com/roc-lang/roc/pull/3070/files#r906731092
I'm unsure what the conclusions were to that, but I've worked around this in the PR :)