### PR TITLE
Windows build fixes + CI

### DIFF
--- a/.github/workflows/windows_release_build.yml
+++ b/.github/workflows/windows_release_build.yml
@@ -41,4 +41,4 @@ jobs:
           7z x LLVM-13.0.1-win64.7z -oC:\LLVM-13.0.1-win64
 
       - name: cargo build release. Twice for zig lld-link error.
-        run: cargo build --locked --release || cargo build --locked --release --no-run
+        run: cargo build --locked --release || cargo build --locked --release

--- a/.github/workflows/windows_release_build.yml
+++ b/.github/workflows/windows_release_build.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: set up llvm 13
         run: |
-          curl.exe -L -O https://github.com/roc-lang/llvm-package-windows/releases/download/v13.0.1/LLVM-13.0.1-win64.7z
+          curl.exe -L -O -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" https://github.com/roc-lang/llvm-package-windows/releases/download/v13.0.1/LLVM-13.0.1-win64.7z
           7z x LLVM-13.0.1-win64.7z -oC:\LLVM-13.0.1-win64
 
       - name: cargo build release. Twice for zig lld-link error.

--- a/.github/workflows/windows_release_build.yml
+++ b/.github/workflows/windows_release_build.yml
@@ -1,0 +1,44 @@
+on: [pull_request]
+
+name: windows - release build
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  RUST_BACKTRACE: 1
+
+jobs:
+  windows-release-build:
+    name: windows-release-build
+    runs-on: windows-2022
+    env:
+      LLVM_SYS_130_PREFIX: C:\LLVM-13.0.1-win64
+
+    timeout-minutes: 150
+    steps:
+      - uses: actions/checkout@v2
+
+      - run: Add-Content -Path "$env:GITHUB_ENV" -Value "GITHUB_RUNNER_CPU=$((Get-CimInstance Win32_Processor).Name)"
+
+      - name: download and install zig
+        run: |
+          curl.exe --output "C:\zig-windows-x86_64-0.9.1.zip" --url https://ziglang.org/download/0.9.1/zig-windows-x86_64-0.9.1.zip
+          cd C:\
+          7z x zig-windows-x86_64-0.9.1.zip
+          Add-Content $env:GITHUB_PATH "C:\zig-windows-x86_64-0.9.1\"
+
+      - name: zig version
+        run: zig version
+
+      - name: install rust nightly 1.65
+        run: rustup install nightly-2022-09-17
+
+      - name: set up llvm 13
+        run: |
+          curl.exe -L -O https://github.com/roc-lang/llvm-package-windows/releases/download/v13.0.1/LLVM-13.0.1-win64.7z
+          7z x LLVM-13.0.1-win64.7z -oC:\LLVM-13.0.1-win64
+
+      - name: cargo build release. Twice for zig lld-link error.
+        run: cargo build --locked --release || cargo build --locked --release --no-run

--- a/.github/workflows/windows_tests.yml
+++ b/.github/workflows/windows_tests.yml
@@ -1,6 +1,6 @@
 on: [pull_request]
 
-name: Test windows build
+name: windows - subset of tests
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -10,8 +10,8 @@ env:
   RUST_BACKTRACE: 1
 
 jobs:
-  windows-cargo-build:
-    name: windows-cargo-build
+  windows-test-subset
+    name: windows-test-subset
     runs-on: windows-2022
     env:
       LLVM_SYS_130_PREFIX: C:\LLVM-13.0.1-win64

--- a/.github/workflows/windows_tests.yml
+++ b/.github/workflows/windows_tests.yml
@@ -10,7 +10,7 @@ env:
   RUST_BACKTRACE: 1
 
 jobs:
-  windows-test-subset
+  windows-test-subset:
     name: windows-test-subset
     runs-on: windows-2022
     env:
@@ -41,7 +41,7 @@ jobs:
 
       - name: set up llvm 13
         run: |
-          curl.exe -L -O https://github.com/roc-lang/llvm-package-windows/releases/download/v13.0.1/LLVM-13.0.1-win64.7z
+          curl.exe -L -O -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" https://github.com/roc-lang/llvm-package-windows/releases/download/v13.0.1/LLVM-13.0.1-win64.7z
           7z x LLVM-13.0.1-win64.7z -oC:\LLVM-13.0.1-win64
 
       - name: Build tests --release without running. Twice for zig lld-link error.

--- a/crates/compiler/load/build.rs
+++ b/crates/compiler/load/build.rs
@@ -3,7 +3,6 @@ use std::path::{Path, PathBuf};
 #[cfg(not(windows))]
 use bumpalo::Bump;
 use roc_module::symbol::ModuleId;
-use roc_packaging::cache::RocCacheDir;
 
 const SKIP_SUBS_CACHE: bool = {
     match option_env!("ROC_SKIP_SUBS_CACHE") {
@@ -70,6 +69,7 @@ fn write_types_for_module_dummy(output_path: &Path) {
 fn write_types_for_module_real(module_id: ModuleId, filename: &str, output_path: &Path) {
     use roc_can::module::TypeState;
     use roc_load_internal::file::{LoadingProblem, Threading};
+    use roc_packaging::cache::RocCacheDir;
     use roc_reporting::cli::report_problems;
 
     let arena = Bump::new();

--- a/crates/repl_wasm/build.rs
+++ b/crates/repl_wasm/build.rs
@@ -7,6 +7,12 @@ use wasi_libc_sys::{WASI_COMPILER_RT_PATH, WASI_LIBC_PATH};
 
 const PLATFORM_FILENAME: &str = "repl_platform";
 
+#[cfg(not(windows))]
+const OBJECT_EXTENSION: &str = "o";
+
+#[cfg(windows)]
+const OBJECT_EXTENSION: &str = "obj";
+
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
     let source_path = format!("src/{}.c", PLATFORM_FILENAME);
@@ -21,7 +27,7 @@ fn main() {
 
     let mut pre_linked_binary_path = PathBuf::from(std::env::var("OUT_DIR").unwrap());
     pre_linked_binary_path.extend(["pre_linked_binary"]);
-    pre_linked_binary_path.set_extension("o");
+    pre_linked_binary_path.set_extension(OBJECT_EXTENSION);
 
     let builtins_host_tempfile =
         bitcode::host_wasm_tempfile().expect("failed to write host builtins object to tempfile");
@@ -60,7 +66,7 @@ fn zig_executable() -> String {
 
 fn build_wasm_platform(out_dir: &str, source_path: &str) -> PathBuf {
     let mut platform_obj = PathBuf::from(out_dir).join(PLATFORM_FILENAME);
-    platform_obj.set_extension("o");
+    platform_obj.set_extension(OBJECT_EXTENSION);
 
     Command::new(&zig_executable())
         .args([

--- a/crates/repl_wasm/src/repl.rs
+++ b/crates/repl_wasm/src/repl.rs
@@ -164,8 +164,13 @@ impl<'a> ReplApp<'a> for WasmReplApp<'a> {
     }
 }
 
+#[cfg(not(windows))]
 const PRE_LINKED_BINARY: &[u8] =
     include_bytes!(concat!(env!("OUT_DIR"), "/pre_linked_binary.o")) as &[_];
+
+#[cfg(windows)]
+const PRE_LINKED_BINARY: &[u8] =
+    include_bytes!(concat!(env!("OUT_DIR"), "/pre_linked_binary.obj")) as &[_];
 
 pub async fn entrypoint_from_js(src: String) -> Result<String, String> {
     #[cfg(feature = "console_error_panic_hook")]


### PR DESCRIPTION
- `cargo build` was failing on windows due to the assumption that .o files were used, I've used `cfg` to use `.obj` on windows.
- I've added a CI workflow for `cargo build`, previously only the tests were built.