### PR TITLE
Make it so inline code tags are not split across newlines

### DIFF
--- a/www/public/site.css
+++ b/www/public/site.css
@@ -109,6 +109,7 @@ code {
     background: var(--code-bg);
     padding: 0.1rem 0.5rem;
     border-radius: 4px;
+    white-space: nowrap;
 }
 
 code, samp {


### PR DESCRIPTION
When inline code tags are split across newlines it becomes harder to read.

*Before*
<img width="952" alt="Screenshot 2023-02-18 at 13 24 40" src="https://user-images.githubusercontent.com/62895/219874092-dffca5ce-8e86-447b-970e-c74aa42e1a42.png">

*After*
<img width="944" alt="Screenshot 2023-02-18 at 15 27 49" src="https://user-images.githubusercontent.com/62895/219874159-917a845e-0ec9-452e-95d6-dfe04aa13f4a.png">
