### PR TITLE
Wrap inline code on mobile devices

### DIFF
--- a/www/public/site.css
+++ b/www/public/site.css
@@ -322,6 +322,10 @@ p, aside, li, footer {
     h1 code, h2 code, h3 code, h4 code, h5 code {
         font-size: inherit;
     }
+    
+    code {
+        white-space: normal;
+    }
 
     #tutorial-toc-toggle-label,
     #close-tutorial-toc {


### PR DESCRIPTION
As [Nick pointed out](https://roc.zulipchat.com/#narrow/stream/231634-beginners/topic/Tutorial/near/329053677) the tutorial doesn't look good on mobile if the inline code snippets are not wrapped on newlines.
I added a css rule to go back to normal line wrapping on mobile devices. This way the inline code snippets can still be on a single line on devices with a wider screen for a better reading experience