### PR TITLE
Lambda set compaction must preserve unique specializations of concrete types

### DIFF
--- a/crates/compiler/can/src/debug/pretty_print.rs
+++ b/crates/compiler/can/src/debug/pretty_print.rs
@@ -385,7 +385,15 @@ fn expr<'a>(c: &Ctx, p: EPrec, f: &'a Arena<'a>, e: &'a Expr) -> DocBuilder<'a, 
         ),
         Crash { .. } => todo!(),
         ZeroArgumentTag { .. } => todo!(),
-        OpaqueRef { .. } => todo!(),
+        OpaqueRef { name, argument, .. } => maybe_paren!(
+            Free,
+            p,
+            || true,
+            pp_sym(c, f, *name)
+                .append(f.space())
+                .append(expr(c, AppArg, f, &argument.1.value))
+                .group()
+        ),
         Dbg { .. } => todo!(),
         Expect { .. } => todo!(),
         ExpectFx { .. } => todo!(),

--- a/crates/compiler/mono/src/borrow.rs
+++ b/crates/compiler/mono/src/borrow.rs
@@ -100,8 +100,14 @@ pub fn infer_borrow<'a>(
                 // host-exposed functions must always own their arguments.
                 let is_host_exposed = host_exposed_procs.contains(&key.0);
 
-                let param_offset = param_map.get_param_offset(key.0, key.1);
-                env.collect_proc(&mut param_map, proc, param_offset, is_host_exposed);
+                let param_offset = param_map.get_param_offset(interner, key.0, key.1);
+                env.collect_proc(
+                    interner,
+                    &mut param_map,
+                    proc,
+                    param_offset,
+                    is_host_exposed,
+                );
             }
 
             if !env.modified {
@@ -167,6 +173,7 @@ impl<'a> DeclarationToIndex<'a> {
 
     fn get_param_offset(
         &self,
+        interner: &STLayoutInterner<'a>,
         needle_symbol: Symbol,
         needle_layout: ProcLayout<'a>,
     ) -> ParamOffset {
@@ -181,12 +188,14 @@ impl<'a> DeclarationToIndex<'a> {
             .elements
             .iter()
             .filter_map(|(Declaration { symbol, layout }, _)| {
-                (*symbol == needle_symbol).then_some(layout)
+                (*symbol == needle_symbol)
+                    .then_some(layout)
+                    .map(|l| l.dbg_deep(interner))
             })
             .collect::<std::vec::Vec<_>>();
         unreachable!(
             "symbol/layout {:?} {:#?} combo must be in DeclarationToIndex\nHowever {} similar layouts were found:\n{:#?}",
-            needle_symbol, needle_layout, similar.len(), similar
+            needle_symbol, needle_layout.dbg_deep(interner), similar.len(), similar,
         )
     }
 }
@@ -206,13 +215,24 @@ pub struct ParamMap<'a> {
 }
 
 impl<'a> ParamMap<'a> {
-    pub fn get_param_offset(&self, symbol: Symbol, layout: ProcLayout<'a>) -> ParamOffset {
-        self.declaration_to_index.get_param_offset(symbol, layout)
+    pub fn get_param_offset(
+        &self,
+        interner: &STLayoutInterner<'a>,
+        symbol: Symbol,
+        layout: ProcLayout<'a>,
+    ) -> ParamOffset {
+        self.declaration_to_index
+            .get_param_offset(interner, symbol, layout)
     }
 
-    pub fn get_symbol(&self, symbol: Symbol, layout: ProcLayout<'a>) -> Option<&[Param<'a>]> {
+    pub fn get_symbol(
+        &self,
+        interner: &STLayoutInterner<'a>,
+        symbol: Symbol,
+        layout: ProcLayout<'a>,
+    ) -> Option<&[Param<'a>]> {
         // let index: usize = self.declaration_to_index[&(symbol, layout)].into();
-        let index: usize = self.get_param_offset(symbol, layout).into();
+        let index: usize = self.get_param_offset(interner, symbol, layout).into();
 
         self.declarations.get(index..index + layout.arguments.len())
     }
@@ -292,7 +312,7 @@ impl<'a> ParamMap<'a> {
             return;
         }
 
-        let index: usize = self.get_param_offset(key.0, key.1).into();
+        let index: usize = self.get_param_offset(interner, key.0, key.1).into();
 
         for (i, param) in Self::init_borrow_args(arena, interner, proc.args)
             .iter()
@@ -312,7 +332,7 @@ impl<'a> ParamMap<'a> {
         proc: &Proc<'a>,
         key: (Symbol, ProcLayout<'a>),
     ) {
-        let index: usize = self.get_param_offset(key.0, key.1).into();
+        let index: usize = self.get_param_offset(interner, key.0, key.1).into();
 
         for (i, param) in Self::init_borrow_args_always_owned(arena, proc.args)
             .iter()
@@ -534,7 +554,13 @@ impl<'a> BorrowInfState<'a> {
     ///
     /// and determines whether z and which of the symbols used in e
     /// must be taken as owned parameters
-    fn collect_call(&mut self, param_map: &mut ParamMap<'a>, z: Symbol, e: &crate::ir::Call<'a>) {
+    fn collect_call(
+        &mut self,
+        interner: &STLayoutInterner<'a>,
+        param_map: &mut ParamMap<'a>,
+        z: Symbol,
+        e: &crate::ir::Call<'a>,
+    ) {
         use crate::ir::CallType::*;
 
         let crate::ir::Call {
@@ -553,7 +579,7 @@ impl<'a> BorrowInfState<'a> {
 
                 // get the borrow signature of the applied function
                 let ps = param_map
-                    .get_symbol(name.name(), top_level)
+                    .get_symbol(interner, name.name(), top_level)
                     .expect("function is defined");
 
                 // the return value will be owned
@@ -595,11 +621,14 @@ impl<'a> BorrowInfState<'a> {
                     niche: passed_function.name.niche(),
                 };
 
-                let function_ps =
-                    match param_map.get_symbol(passed_function.name.name(), closure_layout) {
-                        Some(function_ps) => function_ps,
-                        None => unreachable!(),
-                    };
+                let function_ps = match param_map.get_symbol(
+                    interner,
+                    passed_function.name.name(),
+                    closure_layout,
+                ) {
+                    Some(function_ps) => function_ps,
+                    None => unreachable!(),
+                };
 
                 match op {
                     ListMap { xs } => {
@@ -671,7 +700,13 @@ impl<'a> BorrowInfState<'a> {
         }
     }
 
-    fn collect_expr(&mut self, param_map: &mut ParamMap<'a>, z: Symbol, e: &Expr<'a>) {
+    fn collect_expr(
+        &mut self,
+        interner: &STLayoutInterner<'a>,
+        param_map: &mut ParamMap<'a>,
+        z: Symbol,
+        e: &Expr<'a>,
+    ) {
         use Expr::*;
 
         match e {
@@ -724,7 +759,7 @@ impl<'a> BorrowInfState<'a> {
                 self.own_var(z);
             }
 
-            Call(call) => self.collect_call(param_map, z, call),
+            Call(call) => self.collect_call(interner, param_map, z, call),
 
             Literal(_) | RuntimeErrorFunction(_) => {}
 
@@ -757,6 +792,7 @@ impl<'a> BorrowInfState<'a> {
     #[allow(clippy::many_single_char_names)]
     fn preserve_tail_call(
         &mut self,
+        interner: &STLayoutInterner<'a>,
         param_map: &mut ParamMap<'a>,
         x: Symbol,
         v: &Expr<'a>,
@@ -782,7 +818,7 @@ impl<'a> BorrowInfState<'a> {
             if self.current_proc == g.name() && x == *z {
                 // anonymous functions (for which the ps may not be known)
                 // can never be tail-recursive, so this is fine
-                if let Some(ps) = param_map.get_symbol(g.name(), top_level) {
+                if let Some(ps) = param_map.get_symbol(interner, g.name(), top_level) {
                     self.own_params_using_args(ys, ps)
                 }
             }
@@ -801,7 +837,12 @@ impl<'a> BorrowInfState<'a> {
         }
     }
 
-    fn collect_stmt(&mut self, param_map: &mut ParamMap<'a>, stmt: &Stmt<'a>) {
+    fn collect_stmt(
+        &mut self,
+        interner: &STLayoutInterner<'a>,
+        param_map: &mut ParamMap<'a>,
+        stmt: &Stmt<'a>,
+    ) {
         use Stmt::*;
 
         match stmt {
@@ -813,11 +854,11 @@ impl<'a> BorrowInfState<'a> {
             } => {
                 let old = self.param_set.clone();
                 self.update_param_set(ys);
-                self.collect_stmt(param_map, v);
+                self.collect_stmt(interner, param_map, v);
                 self.param_set = old;
                 self.update_param_map_join_point(param_map, *j);
 
-                self.collect_stmt(param_map, b);
+                self.collect_stmt(interner, param_map, b);
             }
 
             Let(x, v, _, mut b) => {
@@ -830,17 +871,17 @@ impl<'a> BorrowInfState<'a> {
                     stack.push((*symbol, expr));
                 }
 
-                self.collect_stmt(param_map, b);
+                self.collect_stmt(interner, param_map, b);
 
                 let mut it = stack.into_iter().rev();
 
                 // collect the final expr, and see if we need to preserve a tail call
                 let (x, v) = it.next().unwrap();
-                self.collect_expr(param_map, x, v);
-                self.preserve_tail_call(param_map, x, v, b);
+                self.collect_expr(interner, param_map, x, v);
+                self.preserve_tail_call(interner, param_map, x, v, b);
 
                 for (x, v) in it {
-                    self.collect_expr(param_map, x, v);
+                    self.collect_expr(interner, param_map, x, v);
                 }
             }
 
@@ -859,21 +900,21 @@ impl<'a> BorrowInfState<'a> {
                 ..
             } => {
                 for (_, _, b) in branches.iter() {
-                    self.collect_stmt(param_map, b);
+                    self.collect_stmt(interner, param_map, b);
                 }
-                self.collect_stmt(param_map, default_branch.1);
+                self.collect_stmt(interner, param_map, default_branch.1);
             }
 
             Dbg { remainder, .. } => {
-                self.collect_stmt(param_map, remainder);
+                self.collect_stmt(interner, param_map, remainder);
             }
 
             Expect { remainder, .. } => {
-                self.collect_stmt(param_map, remainder);
+                self.collect_stmt(interner, param_map, remainder);
             }
 
             ExpectFx { remainder, .. } => {
-                self.collect_stmt(param_map, remainder);
+                self.collect_stmt(interner, param_map, remainder);
             }
 
             Refcounting(_, _) => unreachable!("these have not been introduced yet"),
@@ -891,6 +932,7 @@ impl<'a> BorrowInfState<'a> {
 
     fn collect_proc(
         &mut self,
+        interner: &STLayoutInterner<'a>,
         param_map: &mut ParamMap<'a>,
         proc: &Proc<'a>,
         param_offset: ParamOffset,
@@ -912,7 +954,7 @@ impl<'a> BorrowInfState<'a> {
             owned_entry.extend(params.iter().map(|p| p.symbol));
         }
 
-        self.collect_stmt(param_map, &proc.body);
+        self.collect_stmt(interner, param_map, &proc.body);
         self.update_param_map_declaration(param_map, param_offset, proc.args.len());
 
         self.param_set = old;

--- a/crates/compiler/mono/src/inc_dec.rs
+++ b/crates/compiler/mono/src/inc_dec.rs
@@ -605,7 +605,7 @@ impl<'a, 'i> Context<'a, 'i> {
                 // get the borrow signature
                 let ps = self
                     .param_map
-                    .get_symbol(name.name(), top_level)
+                    .get_symbol(self.layout_interner, name.name(), top_level)
                     .expect("function is defined");
 
                 let v = Expr::Call(crate::ir::Call {
@@ -653,10 +653,11 @@ impl<'a, 'i> Context<'a, 'i> {
             niche: passed_function.name.niche(),
         };
 
-        let function_ps = match self
-            .param_map
-            .get_symbol(passed_function.name.name(), function_layout)
-        {
+        let function_ps = match self.param_map.get_symbol(
+            self.layout_interner,
+            passed_function.name.name(),
+            function_layout,
+        ) {
             Some(function_ps) => function_ps,
             None => unreachable!(),
         };
@@ -1510,19 +1511,28 @@ pub fn visit_procs<'a, 'i>(
     };
 
     for (key, proc) in procs.iter_mut() {
-        visit_proc(arena, &mut codegen, param_map, &ctx, proc, key.1);
+        visit_proc(
+            arena,
+            layout_interner,
+            &mut codegen,
+            param_map,
+            &ctx,
+            proc,
+            key.1,
+        );
     }
 }
 
 fn visit_proc<'a, 'i>(
     arena: &'a Bump,
+    interner: &STLayoutInterner<'a>,
     codegen: &mut CodegenTools<'i>,
     param_map: &'a ParamMap<'a>,
     ctx: &Context<'a, 'i>,
     proc: &mut Proc<'a>,
     layout: ProcLayout<'a>,
 ) {
-    let params = match param_map.get_symbol(proc.name.name(), layout) {
+    let params = match param_map.get_symbol(interner, proc.name.name(), layout) {
         Some(slice) => slice,
         None => Vec::from_iter_in(
             proc.args.iter().cloned().map(|(layout, symbol)| Param {

--- a/crates/compiler/mono/src/ir.rs
+++ b/crates/compiler/mono/src/ir.rs
@@ -3933,6 +3933,33 @@ impl<'a> ProcLayout<'a> {
             }
         }
     }
+
+    pub fn dbg_deep<'r, I: LayoutInterner<'a>>(&self, interner: &'r I) -> DbgProcLayout<'a, 'r, I> {
+        DbgProcLayout {
+            layout: *self,
+            interner,
+        }
+    }
+}
+
+pub struct DbgProcLayout<'a, 'r, I: LayoutInterner<'a>> {
+    layout: ProcLayout<'a>,
+    interner: &'r I,
+}
+
+impl<'a, 'r, I: LayoutInterner<'a>> std::fmt::Debug for DbgProcLayout<'a, 'r, I> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let ProcLayout {
+            arguments,
+            result,
+            niche,
+        } = self.layout;
+        f.debug_struct("ProcLayout")
+            .field("arguments", &self.interner.dbg_deep_iter(arguments))
+            .field("result", &self.interner.dbg_deep(result))
+            .field("niche", &niche.dbg_deep(self.interner))
+            .finish()
+    }
 }
 
 fn specialize_naked_symbol<'a>(

--- a/crates/compiler/mono/src/layout.rs
+++ b/crates/compiler/mono/src/layout.rs
@@ -1313,6 +1313,14 @@ impl<'a> Niche<'a> {
             ]),
         }
     }
+
+    pub fn dbg_deep<'r, I: LayoutInterner<'a>>(
+        &'r self,
+        interner: &'r I,
+    ) -> crate::layout::intern::dbg::DbgFields<'a, 'r, I> {
+        let NichePriv::Captures(caps) = &self.0;
+        interner.dbg_deep_iter(caps)
+    }
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]

--- a/crates/compiler/mono/src/layout/intern.rs
+++ b/crates/compiler/mono/src/layout/intern.rs
@@ -365,6 +365,10 @@ pub trait LayoutInterner<'a>: Sized {
     fn dbg_deep<'r>(&'r self, layout: InLayout<'a>) -> dbg::Dbg<'a, 'r, Self> {
         dbg::Dbg(self, layout)
     }
+
+    fn dbg_deep_iter<'r>(&'r self, layouts: &'a [InLayout<'a>]) -> dbg::DbgFields<'a, 'r, Self> {
+        dbg::DbgFields(self, layouts)
+    }
 }
 
 /// An interned layout.
@@ -1274,7 +1278,7 @@ mod equiv {
     }
 }
 
-mod dbg {
+pub mod dbg {
     use roc_module::symbol::Symbol;
 
     use crate::layout::{Builtin, LambdaSet, Layout, UnionLayout};
@@ -1311,7 +1315,7 @@ mod dbg {
         }
     }
 
-    struct DbgFields<'a, 'r, I: LayoutInterner<'a>>(&'r I, &'a [InLayout<'a>]);
+    pub struct DbgFields<'a, 'r, I: LayoutInterner<'a>>(pub &'r I, pub &'a [InLayout<'a>]);
 
     impl<'a, 'r, I: LayoutInterner<'a>> std::fmt::Debug for DbgFields<'a, 'r, I> {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/crates/compiler/test_gen/src/gen_abilities.rs
+++ b/crates/compiler/test_gen/src/gen_abilities.rs
@@ -788,6 +788,59 @@ fn encode_derived_record_with_many_types() {
 }
 
 #[test]
+#[cfg(all(any(feature = "gen-llvm", feature = "gen-wasm")))]
+fn encode_derived_generic_record_with_different_field_types() {
+    assert_evals_to!(
+        indoc!(
+            r#"
+            app "test"
+                imports [Encode, Json]
+                provides [main] to "./platform"
+
+            Q a b := {a: a, b: b} has [Encoding]
+
+            q = @Q {a: 10u32, b: "fieldb"}
+
+            main =
+                result = Str.fromUtf8 (Encode.toBytes q Json.toUtf8)
+                when result is
+                    Ok s -> s
+                    _ -> "<bad>"
+            "#
+        ),
+        RocStr::from(r#"{"a":10,"b":"fieldb"}"#),
+        RocStr
+    )
+}
+
+#[test]
+#[cfg(all(any(feature = "gen-llvm", feature = "gen-wasm")))]
+fn encode_derived_generic_tag_with_different_field_types() {
+    assert_evals_to!(
+        indoc!(
+            r#"
+            app "test"
+                imports [Encode, Json]
+                provides [main] to "./platform"
+
+            Q a b := [A a, B b] has [Encoding]
+
+            q : Q Str U32
+            q = @Q (B 67)
+
+            main =
+                result = Str.fromUtf8 (Encode.toBytes q Json.toUtf8)
+                when result is
+                    Ok s -> s
+                    _ -> "<bad>"
+            "#
+        ),
+        RocStr::from(r#"{"B":[67]}"#),
+        RocStr
+    )
+}
+
+#[test]
 #[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
 fn decode_use_stdlib() {
     assert_evals_to!(

--- a/crates/compiler/test_mono/generated/unspecialized_lambda_set_unification_does_not_duplicate_identical_concrete_types.txt
+++ b/crates/compiler/test_mono/generated/unspecialized_lambda_set_unification_does_not_duplicate_identical_concrete_types.txt
@@ -1,0 +1,235 @@
+procedure Bool.2 ():
+    let Bool.23 : Int1 = true;
+    ret Bool.23;
+
+procedure Encode.22 (Encode.93):
+    ret Encode.93;
+
+procedure Encode.22 (Encode.93):
+    ret Encode.93;
+
+procedure Encode.22 (Encode.93):
+    ret Encode.93;
+
+procedure Encode.23 (Encode.94, Encode.102, Encode.96):
+    let Encode.106 : List U8 = CallByName Test.5 Encode.94 Encode.96 Encode.102;
+    ret Encode.106;
+
+procedure Encode.23 (Encode.94, Encode.102, Encode.96):
+    let Encode.113 : List U8 = CallByName Json.126 Encode.94 Encode.96 Encode.102;
+    ret Encode.113;
+
+procedure Encode.23 (Encode.94, Encode.102, Encode.96):
+    let Encode.118 : List U8 = CallByName Json.96 Encode.94 Encode.96 Encode.102;
+    ret Encode.118;
+
+procedure Encode.25 (Encode.100, Encode.101):
+    let Encode.104 : List U8 = Array [];
+    let Encode.105 : {Str, Str} = CallByName Test.2 Encode.100;
+    let Encode.103 : List U8 = CallByName Encode.23 Encode.104 Encode.105 Encode.101;
+    ret Encode.103;
+
+procedure Json.1 ():
+    let Json.396 : {} = Struct {};
+    ret Json.396;
+
+procedure Json.126 (Json.127, Json.399, #Attr.12):
+    let Json.125 : List Str = StructAtIndex 1 #Attr.12;
+    inc Json.125;
+    let Json.124 : Str = StructAtIndex 0 #Attr.12;
+    inc Json.124;
+    dec #Attr.12;
+    let Json.437 : I64 = 123i64;
+    let Json.436 : U8 = CallByName Num.125 Json.437;
+    let Json.433 : List U8 = CallByName List.4 Json.127 Json.436;
+    let Json.435 : I64 = 34i64;
+    let Json.434 : U8 = CallByName Num.125 Json.435;
+    let Json.431 : List U8 = CallByName List.4 Json.433 Json.434;
+    let Json.432 : List U8 = CallByName Str.12 Json.124;
+    let Json.428 : List U8 = CallByName List.8 Json.431 Json.432;
+    let Json.430 : I64 = 34i64;
+    let Json.429 : U8 = CallByName Num.125 Json.430;
+    let Json.425 : List U8 = CallByName List.4 Json.428 Json.429;
+    let Json.427 : I64 = 58i64;
+    let Json.426 : U8 = CallByName Num.125 Json.427;
+    let Json.422 : List U8 = CallByName List.4 Json.425 Json.426;
+    let Json.424 : I64 = 91i64;
+    let Json.423 : U8 = CallByName Num.125 Json.424;
+    let Json.129 : List U8 = CallByName List.4 Json.422 Json.423;
+    let Json.421 : U64 = CallByName List.6 Json.125;
+    let Json.409 : {List U8, U64} = Struct {Json.129, Json.421};
+    let Json.410 : {} = Struct {};
+    let Json.408 : {List U8, U64} = CallByName List.18 Json.125 Json.409 Json.410;
+    dec Json.125;
+    let Json.131 : List U8 = StructAtIndex 0 Json.408;
+    inc Json.131;
+    dec Json.408;
+    let Json.407 : I64 = 93i64;
+    let Json.406 : U8 = CallByName Num.125 Json.407;
+    let Json.403 : List U8 = CallByName List.4 Json.131 Json.406;
+    let Json.405 : I64 = 125i64;
+    let Json.404 : U8 = CallByName Num.125 Json.405;
+    let Json.402 : List U8 = CallByName List.4 Json.403 Json.404;
+    ret Json.402;
+
+procedure Json.128 (Json.401, Json.134):
+    let Json.132 : List U8 = StructAtIndex 0 Json.401;
+    inc Json.132;
+    let Json.133 : U64 = StructAtIndex 1 Json.401;
+    dec Json.401;
+    let Json.420 : {} = Struct {};
+    let Json.135 : List U8 = CallByName Encode.23 Json.132 Json.134 Json.420;
+    joinpoint Json.415 Json.136:
+        let Json.413 : U64 = 1i64;
+        let Json.412 : U64 = CallByName Num.20 Json.133 Json.413;
+        let Json.411 : {List U8, U64} = Struct {Json.136, Json.412};
+        ret Json.411;
+    in
+    let Json.419 : U64 = 1i64;
+    let Json.416 : Int1 = CallByName Num.24 Json.133 Json.419;
+    if Json.416 then
+        let Json.418 : I64 = 44i64;
+        let Json.417 : U8 = CallByName Num.125 Json.418;
+        let Json.414 : List U8 = CallByName List.4 Json.135 Json.417;
+        jump Json.415 Json.414;
+    else
+        jump Json.415 Json.135;
+
+procedure Json.18 (Json.95):
+    let Json.453 : Str = CallByName Encode.22 Json.95;
+    ret Json.453;
+
+procedure Json.21 (Json.124, Json.125):
+    let Json.439 : {Str, List Str} = Struct {Json.124, Json.125};
+    let Json.438 : {Str, List Str} = CallByName Encode.22 Json.439;
+    ret Json.438;
+
+procedure Json.96 (Json.97, Json.443, Json.95):
+    let Json.452 : I64 = 34i64;
+    let Json.451 : U8 = CallByName Num.125 Json.452;
+    let Json.449 : List U8 = CallByName List.4 Json.97 Json.451;
+    let Json.450 : List U8 = CallByName Str.12 Json.95;
+    let Json.446 : List U8 = CallByName List.8 Json.449 Json.450;
+    let Json.448 : I64 = 34i64;
+    let Json.447 : U8 = CallByName Num.125 Json.448;
+    let Json.445 : List U8 = CallByName List.4 Json.446 Json.447;
+    ret Json.445;
+
+procedure List.138 (List.139, List.140, List.137):
+    let List.529 : {List U8, U64} = CallByName Json.128 List.139 List.140;
+    ret List.529;
+
+procedure List.18 (List.135, List.136, List.137):
+    let List.510 : {List U8, U64} = CallByName List.90 List.135 List.136 List.137;
+    ret List.510;
+
+procedure List.4 (List.106, List.107):
+    let List.509 : U64 = 1i64;
+    let List.508 : List U8 = CallByName List.70 List.106 List.509;
+    let List.507 : List U8 = CallByName List.71 List.508 List.107;
+    ret List.507;
+
+procedure List.6 (#Attr.2):
+    let List.530 : U64 = lowlevel ListLen #Attr.2;
+    ret List.530;
+
+procedure List.66 (#Attr.2, #Attr.3):
+    let List.526 : Str = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.526;
+
+procedure List.70 (#Attr.2, #Attr.3):
+    let List.482 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
+    ret List.482;
+
+procedure List.71 (#Attr.2, #Attr.3):
+    let List.480 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
+    ret List.480;
+
+procedure List.8 (#Attr.2, #Attr.3):
+    let List.532 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
+    ret List.532;
+
+procedure List.90 (List.426, List.427, List.428):
+    let List.514 : U64 = 0i64;
+    let List.515 : U64 = CallByName List.6 List.426;
+    let List.513 : {List U8, U64} = CallByName List.91 List.426 List.427 List.428 List.514 List.515;
+    ret List.513;
+
+procedure List.91 (List.542, List.543, List.544, List.545, List.546):
+    joinpoint List.516 List.429 List.430 List.431 List.432 List.433:
+        let List.518 : Int1 = CallByName Num.22 List.432 List.433;
+        if List.518 then
+            let List.525 : Str = CallByName List.66 List.429 List.432;
+            let List.519 : {List U8, U64} = CallByName List.138 List.430 List.525 List.431;
+            let List.522 : U64 = 1i64;
+            let List.521 : U64 = CallByName Num.19 List.432 List.522;
+            jump List.516 List.429 List.519 List.431 List.521 List.433;
+        else
+            ret List.430;
+    in
+    jump List.516 List.542 List.543 List.544 List.545 List.546;
+
+procedure Num.125 (#Attr.2):
+    let Num.265 : U8 = lowlevel NumIntCast #Attr.2;
+    ret Num.265;
+
+procedure Num.19 (#Attr.2, #Attr.3):
+    let Num.268 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.268;
+
+procedure Num.20 (#Attr.2, #Attr.3):
+    let Num.266 : U64 = lowlevel NumSub #Attr.2 #Attr.3;
+    ret Num.266;
+
+procedure Num.22 (#Attr.2, #Attr.3):
+    let Num.269 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.269;
+
+procedure Num.24 (#Attr.2, #Attr.3):
+    let Num.267 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
+    ret Num.267;
+
+procedure Str.12 (#Attr.2):
+    let Str.266 : List U8 = lowlevel StrToUtf8 #Attr.2;
+    ret Str.266;
+
+procedure Test.2 (Test.10):
+    let Test.15 : {Str, Str} = CallByName Encode.22 Test.10;
+    ret Test.15;
+
+procedure Test.3 ():
+    let Test.9 : Str = "";
+    inc Test.9;
+    let Test.14 : {Str, Str} = Struct {Test.9, Test.9};
+    ret Test.14;
+
+procedure Test.5 (Test.6, Test.7, Test.4):
+    joinpoint Test.20 Test.8:
+        let Test.18 : List U8 = CallByName Encode.23 Test.6 Test.8 Test.7;
+        ret Test.18;
+    in
+    let Test.25 : Int1 = CallByName Bool.2;
+    if Test.25 then
+        let Test.26 : Str = "A";
+        let Test.29 : Str = StructAtIndex 0 Test.4;
+        inc Test.29;
+        dec Test.4;
+        let Test.28 : Str = CallByName Json.18 Test.29;
+        let Test.27 : List Str = Array [Test.28];
+        let Test.19 : {Str, List Str} = CallByName Json.21 Test.26 Test.27;
+        jump Test.20 Test.19;
+    else
+        let Test.21 : Str = "B";
+        let Test.24 : Str = StructAtIndex 1 Test.4;
+        inc Test.24;
+        dec Test.4;
+        let Test.23 : Str = CallByName Json.18 Test.24;
+        let Test.22 : List Str = Array [Test.23];
+        let Test.19 : {Str, List Str} = CallByName Json.21 Test.21 Test.22;
+        jump Test.20 Test.19;
+
+procedure Test.0 ():
+    let Test.12 : {Str, Str} = CallByName Test.3;
+    let Test.13 : {} = CallByName Json.1;
+    let Test.11 : List U8 = CallByName Encode.25 Test.12 Test.13;
+    ret Test.11;

--- a/crates/compiler/test_mono/generated/unspecialized_lambda_set_unification_keeps_all_concrete_types_without_unification.txt
+++ b/crates/compiler/test_mono/generated/unspecialized_lambda_set_unification_keeps_all_concrete_types_without_unification.txt
@@ -1,0 +1,82 @@
+procedure Bool.2 ():
+    let Bool.23 : Int1 = true;
+    ret Bool.23;
+
+procedure Test.12 (Test.52):
+    let Test.75 : Int1 = false;
+    ret Test.75;
+
+procedure Test.13 (Test.51):
+    let Test.83 : Int1 = true;
+    ret Test.83;
+
+procedure Test.14 (Test.50):
+    ret Test.50;
+
+procedure Test.15 (Test.49):
+    let Test.74 : {} = Struct {};
+    let Test.73 : Int1 = CallByName Test.12 Test.74;
+    ret Test.73;
+
+procedure Test.16 (Test.48):
+    let Test.82 : {} = Struct {};
+    let Test.81 : Int1 = CallByName Test.13 Test.82;
+    ret Test.81;
+
+procedure Test.17 (Test.47):
+    ret Test.47;
+
+procedure Test.35 (Test.36, Test.76):
+    inc Test.36;
+    ret Test.36;
+
+procedure Test.37 (Test.38, Test.84):
+    inc Test.38;
+    ret Test.38;
+
+procedure Test.40 (Test.41, Test.65, Test.39):
+    let Test.68 : {} = Struct {};
+    joinpoint Test.69 Test.67:
+        ret Test.67;
+    in
+    switch Test.39:
+        case 0:
+            let Test.70 : List U8 = CallByName Test.35 Test.41 Test.68;
+            jump Test.69 Test.70;
+    
+        default:
+            let Test.71 : List U8 = CallByName Test.37 Test.41 Test.68;
+            jump Test.69 Test.71;
+    
+
+procedure Test.43 (Test.44, Test.42):
+    joinpoint Test.62 Test.60:
+        let Test.59 : List U8 = Array [];
+        let Test.58 : List U8 = CallByName Test.40 Test.59 Test.44 Test.60;
+        dec Test.59;
+        ret Test.58;
+    in
+    let Test.78 : Int1 = CallByName Bool.2;
+    if Test.78 then
+        let Test.80 : Str = StructAtIndex 0 Test.42;
+        inc Test.80;
+        dec Test.42;
+        let Test.79 : Int1 = CallByName Test.16 Test.80;
+        dec Test.80;
+        let Test.61 : Int1 = CallByName Test.14 Test.79;
+        jump Test.62 Test.61;
+    else
+        let Test.72 : U8 = StructAtIndex 1 Test.42;
+        dec Test.42;
+        let Test.63 : Int1 = CallByName Test.15 Test.72;
+        let Test.61 : Int1 = CallByName Test.14 Test.63;
+        jump Test.62 Test.61;
+
+procedure Test.0 ():
+    let Test.86 : Str = "";
+    let Test.87 : U8 = 7i64;
+    let Test.55 : {Str, U8} = Struct {Test.86, Test.87};
+    let Test.46 : {Str, U8} = CallByName Test.17 Test.55;
+    let Test.54 : {} = Struct {};
+    let Test.53 : List U8 = CallByName Test.43 Test.54 Test.46;
+    ret Test.53;

--- a/crates/compiler/test_mono/generated/unspecialized_lambda_set_unification_keeps_all_concrete_types_without_unification_of_unifiable.txt
+++ b/crates/compiler/test_mono/generated/unspecialized_lambda_set_unification_keeps_all_concrete_types_without_unification_of_unifiable.txt
@@ -1,0 +1,374 @@
+procedure #Derived.0 (#Derived.1):
+    let #Derived_gen.10 : [C {}, C {}] = TagId(0) #Derived.1;
+    let #Derived_gen.9 : [C {}, C {}] = CallByName Encode.22 #Derived_gen.10;
+    ret #Derived_gen.9;
+
+procedure #Derived.2 (#Derived.3, #Derived.4, #Attr.12):
+    let #Derived.1 : {} = UnionAtIndex (Id 0) (Index 0) #Attr.12;
+    joinpoint #Derived_gen.14 #Derived_gen.13:
+        let #Derived_gen.12 : List U8 = CallByName Encode.23 #Derived.3 #Derived_gen.13 #Derived.4;
+        ret #Derived_gen.12;
+    in
+    let #Derived_gen.16 : Str = "A";
+    let #Derived_gen.17 : List [] = Array [];
+    let #Derived_gen.15 : {Str, List []} = CallByName Json.21 #Derived_gen.16 #Derived_gen.17;
+    jump #Derived_gen.14 #Derived_gen.15;
+
+procedure #Derived.5 (#Derived.6):
+    let #Derived_gen.1 : [C {}, C {}] = TagId(1) #Derived.6;
+    let #Derived_gen.0 : [C {}, C {}] = CallByName Encode.22 #Derived_gen.1;
+    ret #Derived_gen.0;
+
+procedure #Derived.7 (#Derived.8, #Derived.9, #Attr.12):
+    let #Derived.6 : {} = UnionAtIndex (Id 1) (Index 0) #Attr.12;
+    joinpoint #Derived_gen.5 #Derived_gen.4:
+        let #Derived_gen.3 : List U8 = CallByName Encode.23 #Derived.8 #Derived_gen.4 #Derived.9;
+        ret #Derived_gen.3;
+    in
+    let #Derived_gen.7 : Str = "B";
+    let #Derived_gen.8 : List [] = Array [];
+    let #Derived_gen.6 : {Str, List []} = CallByName Json.21 #Derived_gen.7 #Derived_gen.8;
+    jump #Derived_gen.5 #Derived_gen.6;
+
+procedure Bool.2 ():
+    let Bool.23 : Int1 = true;
+    ret Bool.23;
+
+procedure Encode.22 (Encode.93):
+    ret Encode.93;
+
+procedure Encode.22 (Encode.93):
+    ret Encode.93;
+
+procedure Encode.22 (Encode.93):
+    ret Encode.93;
+
+procedure Encode.22 (Encode.93):
+    ret Encode.93;
+
+procedure Encode.23 (Encode.94, Encode.102, Encode.96):
+    let Encode.106 : List U8 = CallByName Test.5 Encode.94 Encode.96 Encode.102;
+    ret Encode.106;
+
+procedure Encode.23 (Encode.94, Encode.102, Encode.96):
+    let Encode.113 : List U8 = CallByName Json.126 Encode.94 Encode.96 Encode.102;
+    ret Encode.113;
+
+procedure Encode.23 (Encode.94, Encode.102, Encode.96):
+    let Encode.117 : U8 = GetTagId Encode.102;
+    joinpoint Encode.118 Encode.116:
+        ret Encode.116;
+    in
+    switch Encode.117:
+        case 0:
+            let Encode.119 : List U8 = CallByName #Derived.2 Encode.94 Encode.96 Encode.102;
+            jump Encode.118 Encode.119;
+    
+        default:
+            let Encode.120 : List U8 = CallByName #Derived.7 Encode.94 Encode.96 Encode.102;
+            jump Encode.118 Encode.120;
+    
+
+procedure Encode.23 (Encode.94, Encode.102, Encode.96):
+    let Encode.132 : List U8 = CallByName Json.126 Encode.94 Encode.96 Encode.102;
+    ret Encode.132;
+
+procedure Encode.23 (Encode.94, Encode.102, Encode.96):
+    let Encode.136 : Str = "a Lambda Set is empty. Most likely there is a type error in your program.";
+    Crash Encode.136
+
+procedure Encode.25 (Encode.100, Encode.101):
+    let Encode.104 : List U8 = Array [];
+    let Encode.105 : {{}, {}} = CallByName Test.2 Encode.100;
+    let Encode.103 : List U8 = CallByName Encode.23 Encode.104 Encode.105 Encode.101;
+    ret Encode.103;
+
+procedure Json.1 ():
+    let Json.396 : {} = Struct {};
+    ret Json.396;
+
+procedure Json.126 (Json.127, Json.399, #Attr.12):
+    let Json.125 : List [C {}, C {}] = StructAtIndex 1 #Attr.12;
+    inc Json.125;
+    let Json.124 : Str = StructAtIndex 0 #Attr.12;
+    inc Json.124;
+    dec #Attr.12;
+    let Json.437 : I64 = 123i64;
+    let Json.436 : U8 = CallByName Num.125 Json.437;
+    let Json.433 : List U8 = CallByName List.4 Json.127 Json.436;
+    let Json.435 : I64 = 34i64;
+    let Json.434 : U8 = CallByName Num.125 Json.435;
+    let Json.431 : List U8 = CallByName List.4 Json.433 Json.434;
+    let Json.432 : List U8 = CallByName Str.12 Json.124;
+    let Json.428 : List U8 = CallByName List.8 Json.431 Json.432;
+    let Json.430 : I64 = 34i64;
+    let Json.429 : U8 = CallByName Num.125 Json.430;
+    let Json.425 : List U8 = CallByName List.4 Json.428 Json.429;
+    let Json.427 : I64 = 58i64;
+    let Json.426 : U8 = CallByName Num.125 Json.427;
+    let Json.422 : List U8 = CallByName List.4 Json.425 Json.426;
+    let Json.424 : I64 = 91i64;
+    let Json.423 : U8 = CallByName Num.125 Json.424;
+    let Json.129 : List U8 = CallByName List.4 Json.422 Json.423;
+    let Json.421 : U64 = CallByName List.6 Json.125;
+    let Json.409 : {List U8, U64} = Struct {Json.129, Json.421};
+    let Json.410 : {} = Struct {};
+    let Json.408 : {List U8, U64} = CallByName List.18 Json.125 Json.409 Json.410;
+    dec Json.125;
+    let Json.131 : List U8 = StructAtIndex 0 Json.408;
+    inc Json.131;
+    dec Json.408;
+    let Json.407 : I64 = 93i64;
+    let Json.406 : U8 = CallByName Num.125 Json.407;
+    let Json.403 : List U8 = CallByName List.4 Json.131 Json.406;
+    let Json.405 : I64 = 125i64;
+    let Json.404 : U8 = CallByName Num.125 Json.405;
+    let Json.402 : List U8 = CallByName List.4 Json.403 Json.404;
+    ret Json.402;
+
+procedure Json.126 (Json.127, Json.399, #Attr.12):
+    let Json.125 : List [] = StructAtIndex 1 #Attr.12;
+    inc Json.125;
+    let Json.124 : Str = StructAtIndex 0 #Attr.12;
+    inc Json.124;
+    dec #Attr.12;
+    let Json.487 : I64 = 123i64;
+    let Json.486 : U8 = CallByName Num.125 Json.487;
+    let Json.483 : List U8 = CallByName List.4 Json.127 Json.486;
+    let Json.485 : I64 = 34i64;
+    let Json.484 : U8 = CallByName Num.125 Json.485;
+    let Json.481 : List U8 = CallByName List.4 Json.483 Json.484;
+    let Json.482 : List U8 = CallByName Str.12 Json.124;
+    let Json.478 : List U8 = CallByName List.8 Json.481 Json.482;
+    let Json.480 : I64 = 34i64;
+    let Json.479 : U8 = CallByName Num.125 Json.480;
+    let Json.475 : List U8 = CallByName List.4 Json.478 Json.479;
+    let Json.477 : I64 = 58i64;
+    let Json.476 : U8 = CallByName Num.125 Json.477;
+    let Json.472 : List U8 = CallByName List.4 Json.475 Json.476;
+    let Json.474 : I64 = 91i64;
+    let Json.473 : U8 = CallByName Num.125 Json.474;
+    let Json.129 : List U8 = CallByName List.4 Json.472 Json.473;
+    let Json.471 : U64 = CallByName List.6 Json.125;
+    let Json.459 : {List U8, U64} = Struct {Json.129, Json.471};
+    let Json.460 : {} = Struct {};
+    let Json.458 : {List U8, U64} = CallByName List.18 Json.125 Json.459 Json.460;
+    dec Json.125;
+    let Json.131 : List U8 = StructAtIndex 0 Json.458;
+    inc Json.131;
+    dec Json.458;
+    let Json.457 : I64 = 93i64;
+    let Json.456 : U8 = CallByName Num.125 Json.457;
+    let Json.453 : List U8 = CallByName List.4 Json.131 Json.456;
+    let Json.455 : I64 = 125i64;
+    let Json.454 : U8 = CallByName Num.125 Json.455;
+    let Json.452 : List U8 = CallByName List.4 Json.453 Json.454;
+    ret Json.452;
+
+procedure Json.128 (Json.401, Json.134):
+    let Json.132 : List U8 = StructAtIndex 0 Json.401;
+    inc Json.132;
+    let Json.133 : U64 = StructAtIndex 1 Json.401;
+    dec Json.401;
+    let Json.420 : {} = Struct {};
+    let Json.135 : List U8 = CallByName Encode.23 Json.132 Json.134 Json.420;
+    joinpoint Json.415 Json.136:
+        let Json.413 : U64 = 1i64;
+        let Json.412 : U64 = CallByName Num.20 Json.133 Json.413;
+        let Json.411 : {List U8, U64} = Struct {Json.136, Json.412};
+        ret Json.411;
+    in
+    let Json.419 : U64 = 1i64;
+    let Json.416 : Int1 = CallByName Num.24 Json.133 Json.419;
+    if Json.416 then
+        let Json.418 : I64 = 44i64;
+        let Json.417 : U8 = CallByName Num.125 Json.418;
+        let Json.414 : List U8 = CallByName List.4 Json.135 Json.417;
+        jump Json.415 Json.414;
+    else
+        jump Json.415 Json.135;
+
+procedure Json.128 (Json.401, Json.134):
+    let Json.132 : List U8 = StructAtIndex 0 Json.401;
+    inc Json.132;
+    let Json.133 : U64 = StructAtIndex 1 Json.401;
+    dec Json.401;
+    let Json.470 : {} = Struct {};
+    let Json.135 : List U8 = CallByName Encode.23 Json.132 Json.134 Json.470;
+    dec Json.132;
+    joinpoint Json.465 Json.136:
+        let Json.463 : U64 = 1i64;
+        let Json.462 : U64 = CallByName Num.20 Json.133 Json.463;
+        let Json.461 : {List U8, U64} = Struct {Json.136, Json.462};
+        ret Json.461;
+    in
+    let Json.469 : U64 = 1i64;
+    let Json.466 : Int1 = CallByName Num.24 Json.133 Json.469;
+    if Json.466 then
+        let Json.468 : I64 = 44i64;
+        let Json.467 : U8 = CallByName Num.125 Json.468;
+        let Json.464 : List U8 = CallByName List.4 Json.135 Json.467;
+        jump Json.465 Json.464;
+    else
+        jump Json.465 Json.135;
+
+procedure Json.21 (Json.124, Json.125):
+    let Json.439 : {Str, List [C {}, C {}]} = Struct {Json.124, Json.125};
+    let Json.438 : {Str, List [C {}, C {}]} = CallByName Encode.22 Json.439;
+    ret Json.438;
+
+procedure Json.21 (Json.124, Json.125):
+    let Json.489 : {Str, List []} = Struct {Json.124, Json.125};
+    let Json.488 : {Str, List []} = CallByName Encode.22 Json.489;
+    ret Json.488;
+
+procedure List.138 (List.139, List.140, List.137):
+    let List.523 : {List U8, U64} = CallByName Json.128 List.139 List.140;
+    ret List.523;
+
+procedure List.138 (List.139, List.140, List.137):
+    let List.596 : {List U8, U64} = CallByName Json.128 List.139 List.140;
+    ret List.596;
+
+procedure List.18 (List.135, List.136, List.137):
+    let List.504 : {List U8, U64} = CallByName List.90 List.135 List.136 List.137;
+    ret List.504;
+
+procedure List.18 (List.135, List.136, List.137):
+    let List.577 : {List U8, U64} = CallByName List.90 List.135 List.136 List.137;
+    ret List.577;
+
+procedure List.4 (List.106, List.107):
+    let List.576 : U64 = 1i64;
+    let List.575 : List U8 = CallByName List.70 List.106 List.576;
+    let List.574 : List U8 = CallByName List.71 List.575 List.107;
+    ret List.574;
+
+procedure List.6 (#Attr.2):
+    let List.524 : U64 = lowlevel ListLen #Attr.2;
+    ret List.524;
+
+procedure List.6 (#Attr.2):
+    let List.597 : U64 = lowlevel ListLen #Attr.2;
+    ret List.597;
+
+procedure List.66 (#Attr.2, #Attr.3):
+    let List.520 : [C {}, C {}] = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.520;
+
+procedure List.66 (#Attr.2, #Attr.3):
+    let List.593 : [] = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.593;
+
+procedure List.70 (#Attr.2, #Attr.3):
+    let List.555 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
+    ret List.555;
+
+procedure List.71 (#Attr.2, #Attr.3):
+    let List.553 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
+    ret List.553;
+
+procedure List.8 (#Attr.2, #Attr.3):
+    let List.598 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
+    ret List.598;
+
+procedure List.90 (List.426, List.427, List.428):
+    let List.508 : U64 = 0i64;
+    let List.509 : U64 = CallByName List.6 List.426;
+    let List.507 : {List U8, U64} = CallByName List.91 List.426 List.427 List.428 List.508 List.509;
+    ret List.507;
+
+procedure List.90 (List.426, List.427, List.428):
+    let List.581 : U64 = 0i64;
+    let List.582 : U64 = CallByName List.6 List.426;
+    let List.580 : {List U8, U64} = CallByName List.91 List.426 List.427 List.428 List.581 List.582;
+    ret List.580;
+
+procedure List.91 (List.535, List.536, List.537, List.538, List.539):
+    joinpoint List.510 List.429 List.430 List.431 List.432 List.433:
+        let List.512 : Int1 = CallByName Num.22 List.432 List.433;
+        if List.512 then
+            let List.519 : [C {}, C {}] = CallByName List.66 List.429 List.432;
+            let List.513 : {List U8, U64} = CallByName List.138 List.430 List.519 List.431;
+            let List.516 : U64 = 1i64;
+            let List.515 : U64 = CallByName Num.19 List.432 List.516;
+            jump List.510 List.429 List.513 List.431 List.515 List.433;
+        else
+            ret List.430;
+    in
+    jump List.510 List.535 List.536 List.537 List.538 List.539;
+
+procedure List.91 (List.608, List.609, List.610, List.611, List.612):
+    joinpoint List.583 List.429 List.430 List.431 List.432 List.433:
+        let List.585 : Int1 = CallByName Num.22 List.432 List.433;
+        if List.585 then
+            let List.592 : [] = CallByName List.66 List.429 List.432;
+            let List.586 : {List U8, U64} = CallByName List.138 List.430 List.592 List.431;
+            let List.589 : U64 = 1i64;
+            let List.588 : U64 = CallByName Num.19 List.432 List.589;
+            jump List.583 List.429 List.586 List.431 List.588 List.433;
+        else
+            ret List.430;
+    in
+    jump List.583 List.608 List.609 List.610 List.611 List.612;
+
+procedure Num.125 (#Attr.2):
+    let Num.284 : U8 = lowlevel NumIntCast #Attr.2;
+    ret Num.284;
+
+procedure Num.19 (#Attr.2, #Attr.3):
+    let Num.287 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.287;
+
+procedure Num.20 (#Attr.2, #Attr.3):
+    let Num.285 : U64 = lowlevel NumSub #Attr.2 #Attr.3;
+    ret Num.285;
+
+procedure Num.22 (#Attr.2, #Attr.3):
+    let Num.288 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.288;
+
+procedure Num.24 (#Attr.2, #Attr.3):
+    let Num.286 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
+    ret Num.286;
+
+procedure Str.12 (#Attr.2):
+    let Str.267 : List U8 = lowlevel StrToUtf8 #Attr.2;
+    ret Str.267;
+
+procedure Test.2 (Test.11):
+    let Test.18 : {{}, {}} = CallByName Encode.22 Test.11;
+    ret Test.18;
+
+procedure Test.3 ():
+    let Test.16 : {} = Struct {};
+    let Test.17 : {} = Struct {};
+    let Test.15 : {{}, {}} = Struct {Test.16, Test.17};
+    ret Test.15;
+
+procedure Test.5 (Test.6, Test.7, Test.4):
+    joinpoint Test.23 Test.8:
+        let Test.21 : List U8 = CallByName Encode.23 Test.6 Test.8 Test.7;
+        ret Test.21;
+    in
+    let Test.28 : Int1 = CallByName Bool.2;
+    if Test.28 then
+        let Test.29 : Str = "A";
+        let Test.32 : {} = StructAtIndex 0 Test.4;
+        let Test.31 : [C {}, C {}] = CallByName #Derived.0 Test.32;
+        let Test.30 : List [C {}, C {}] = Array [Test.31];
+        let Test.22 : {Str, List [C {}, C {}]} = CallByName Json.21 Test.29 Test.30;
+        jump Test.23 Test.22;
+    else
+        let Test.24 : Str = "B";
+        let Test.27 : {} = StructAtIndex 1 Test.4;
+        let Test.26 : [C {}, C {}] = CallByName #Derived.5 Test.27;
+        let Test.25 : List [C {}, C {}] = Array [Test.26];
+        let Test.22 : {Str, List [C {}, C {}]} = CallByName Json.21 Test.24 Test.25;
+        jump Test.23 Test.22;
+
+procedure Test.0 ():
+    let Test.13 : {{}, {}} = CallByName Test.3;
+    let Test.14 : {} = CallByName Json.1;
+    let Test.12 : List U8 = CallByName Encode.25 Test.13 Test.14;
+    ret Test.12;

--- a/crates/compiler/test_mono/src/tests.rs
+++ b/crates/compiler/test_mono/src/tests.rs
@@ -2571,3 +2571,155 @@ fn recursive_lambda_set_has_nested_non_recursive_lambda_sets_issue_5026() {
         "#
     )
 }
+
+#[mono_test]
+fn unspecialized_lambda_set_unification_keeps_all_concrete_types_without_unification() {
+    // This is a regression test for the ambient lambda set specialization algorithm.
+    //
+    // In the program below, monomorphization of `toEncoderQ` with the `Q` in `main` induces the
+    // resolution of `t.a` and `t.b`, and the unification of their pending unspecialization lambda
+    // sets, when `t.a` and `t.b` have been resolved to concrete types, but before the
+    // specialization procedure steps in to resolve the lambda sets concretely. That's because
+    // monomorphization unifies the general type of `toEncoderQ` with the concrete type, forcing
+    // concretization of `t`, but the specialization procedure runs only after the unification is
+    // complete.
+    //
+    // In this case, it's imperative that the unspecialized lambda sets of `toEncoder t.a` and
+    // `toEncoder t.b` wind up in the same lambda set, that is in
+    //
+    // tag : @MEncoder (Bytes, Linear -[[] + @MU8:toEncoder:1 + @MStr:toEncoder+1] -> Bytes)
+    //       -[lTag]->
+    //       @MEncoder (Bytes, Linear -[[Linear:lTag:3 { @MEncoder (Bytes, Linear -[[] + @MU8:toEncoder:1 + @MStr:toEncoder:1] -> Bytes) }]] -> Bytes)
+    //
+    // rather than forcing the lambda set inside to `tag` to become disjoint, as e.g.
+    //
+    // tag : @MEncoder (Bytes, Linear -[[] + @MU8:toEncoder:1 + @MStr:toEncoder+1] -> Bytes)
+    //       -[lTag]->
+    //       @MEncoder (Bytes, Linear -[[
+    //                      Linear:lTag:3 { @MEncoder (Bytes, Linear -[[] + @MU8:toEncoder:1] -> Bytes) },
+    //                      Linear:lTag:3 { @MEncoder (Bytes, Linear -[[] + @MStr:toEncoder:1] -> Bytes) },
+    //                  ]] -> Bytes)
+    indoc!(
+        r#"
+        app "test" provides [main] to "./platform"
+
+        MEncoder fmt := List U8, fmt -> List U8 | fmt has Format
+
+        MEncoding has
+          toEncoder : val -> MEncoder fmt | val has MEncoding, fmt has Format
+
+        Format has
+          u8 : {} -> MEncoder fmt | fmt has Format
+          str : {} -> MEncoder fmt | fmt has Format
+          tag : MEncoder fmt -> MEncoder fmt | fmt has Format
+
+        Linear := {} has [Format {u8: lU8, str: lStr, tag: lTag}]
+
+        MU8 := U8 has [MEncoding {toEncoder: toEncoderU8}]
+        MStr := Str has [MEncoding {toEncoder: toEncoderStr}]
+
+        Q a b := { a: a, b: b }
+
+        lU8 = \{} -> @MEncoder (\lst, @Linear {} -> lst)
+        lStr = \{} -> @MEncoder (\lst, @Linear {} -> lst)
+
+        lTag = \@MEncoder doFormat -> @MEncoder (\lst, @Linear {} ->
+            doFormat lst (@Linear {})
+        )
+
+        toEncoderU8 = \@MU8 _ -> u8 {}
+
+        toEncoderStr = \@MStr _ -> str {}
+
+        toEncoderQ =
+            \@Q t -> \fmt ->
+                @MEncoder doit = if Bool.true
+                    then tag (toEncoder t.a)
+                    else tag (toEncoder t.b)
+
+                doit [] fmt
+
+        main =
+            fmt = toEncoderQ (@Q {a : @MStr "", b: @MU8 7})
+            fmt (@Linear {})
+        "#
+    )
+}
+
+#[mono_test]
+fn unspecialized_lambda_set_unification_keeps_all_concrete_types_without_unification_of_unifiable()
+{
+    // This is a regression test for the ambient lambda set specialization algorithm.
+    //
+    // The principle of the test is equivalent to that of `unspecialized_lambda_set_unification_keeps_all_concrete_types_without_unification`.
+    //
+    // However, this test requires a larger reproduction because it is negative behavior is only
+    // visible in the presence of builtin ability usage (in this case, `Encoding` and
+    // `EncoderFormatting`).
+    //
+    // In this test, the payload types `[A]*` and `[B]*` of the encoded type `Q` are unifiable in
+    // their unspecialized lambda set representations under `toEncoderQ`; however, they must not
+    // be, because they in fact represent to different specializations of needed encoders. In
+    // particular, the lambda set `[[] + [A]:toEncoder:1 + [B]:toEncoder:1]` must be preserved,
+    // rather than collapsing to `[[] + [A, B]:toEncoder:1]`.
+    indoc!(
+        r#"
+        app "test" imports [Json] provides [main] to "./platform"
+
+        Q a b := { a: a, b: b } has [Encoding {toEncoder: toEncoderQ}]
+
+        toEncoderQ =
+            \@Q t -> Encode.custom \bytes, fmt ->
+                f = if Bool.true
+                    then Encode.tag "A" [Encode.toEncoder t.a]
+                    else Encode.tag "B" [Encode.toEncoder t.b]
+
+                Encode.appendWith bytes f fmt
+
+        accessor = @Q {a : A, b: B}
+
+        main =
+            Encode.toBytes accessor Json.toUtf8
+        "#
+    )
+}
+
+#[mono_test]
+fn unspecialized_lambda_set_unification_does_not_duplicate_identical_concrete_types() {
+    // This is a regression test for the ambient lambda set specialization algorithm.
+    //
+    // The principle of the test is equivalent to that of `unspecialized_lambda_set_unification_keeps_all_concrete_types_without_unification`.
+    //
+    // However, this test requires a larger reproduction because it is negative behavior is only
+    // visible in the presence of builtin ability usage (in this case, `Encoding` and
+    // `EncoderFormatting`).
+    //
+    // In this test, the payload types `Str` and `Str` of the encoded type `Q` are unifiable in
+    // their unspecialized lambda set representations under `toEncoderQ`, and moreoever they are
+    // equivalent specializations, since they both come from the same root variable `x`. In as
+    // such, the lambda set `[[] + Str:toEncoder:1]` should be produced during compaction, rather
+    // than staying as the expanded `[[] + Str:toEncoder:1 + Str:toEncoder:1]` after the types of
+    // `t.a` and `t.b` are filled in.
+    indoc!(
+        r#"
+        app "test" imports [Json] provides [main] to "./platform"
+
+        Q a b := { a: a, b: b } has [Encoding {toEncoder: toEncoderQ}]
+
+        toEncoderQ =
+            \@Q t -> Encode.custom \bytes, fmt ->
+                f = if Bool.true
+                    then Encode.tag "A" [Encode.toEncoder t.a]
+                    else Encode.tag "B" [Encode.toEncoder t.b]
+
+                Encode.appendWith bytes f fmt
+
+        accessor =
+            x = ""
+            @Q {a : x, b: x}
+
+        main =
+            Encode.toBytes accessor Json.toUtf8
+        "#
+    )
+}


### PR DESCRIPTION
There are times that multiple concrete types may appear in
unspecialized lambda sets that are being unified. The primary case is
during monomorphization, when unspecialized lambda sets join at the same
time that concrete types get instantiated. Since lambda set
specialization and compaction happens only after unifications are
complete, unifications that monomorphize can induce the above-described
situation.

In these cases,

- unspecialized lambda sets that are due to equivalent type variables
  can be compacted, since they are in fact the same specialization.
- unspecialized lambda sets that are due to different type variables
  cannot be compacted, even if their types unify, since they may point
  to different specializations. For example, consider the unspecialized
  lambda set `[[] + [A]:toEncoder:1 + [B]:toEncoder:1]` - this set wants
  two encoders, one for `[A]` and one for `[B]`, which is materially
  different from the set `[[] + [A, B]:toEncoder:1]`.
