### PR TITLE
patch instruction reference link

### DIFF
--- a/crates/compiler/gen_dev/README.md
+++ b/crates/compiler/gen_dev/README.md
@@ -105,7 +105,7 @@ This is the general procedure I follow with some helpful links:
   Also, sometimes it doesn't seem to generate things quite as you expect.
 - [Alternative Online Assembler](http://shell-storm.org/online/Online-Assembler-and-Disassembler/) -
   Like previous but with more architecture options.
-- [x86 and amd64 instruction reference](https://www.felixcloutier.com/x86/) -
+- [x86 and amd64 instruction reference](https://web.archive.org/web/20230221053750/https://www.felixcloutier.com/x86/) -
   Great for looking up x86_64 instructions and there bytes.
   Definitely missing information if you aren't used to reading it.
 - [Intel 64 ISA Reference](https://software.intel.com/content/dam/develop/public/us/en/documents/325383-sdm-vol-2abcd.pdf) -


### PR DESCRIPTION
This link was broken so I replaced it with a waybackmachine link