### PR TITLE
Fix List.range crashing

### DIFF
--- a/crates/compiler/builtins/roc/List.roc
+++ b/crates/compiler/builtins/roc/List.roc
@@ -726,6 +726,7 @@ rangeHelp = \accum, i, calcNext, isValid ->
                 rangeHelp (List.append accum val) (calcNext val) calcNext isValid
             else
                 accum
+
         Err _ ->
             # We went past the end of the numeric range and there is no next.
             # return the generated list.
@@ -738,6 +739,7 @@ rangeLengthHelp = \accum, i, remaining, calcNext ->
         when i is
             Ok val ->
                 rangeLengthHelp (List.appendUnsafe accum val) (calcNext val) (remaining - 1) calcNext
+
             Err _ ->
                 # We went past the end of the numeric range and there is no next.
                 # The list is not the correct length yet, so we must crash.
@@ -774,10 +776,10 @@ expect
     List.range { start: After 250u8, end: At 255 } == [251, 252, 253, 254, 255]
 
 expect
-    List.range { start: After 250u8, end: At 255 , step: 10} == []
+    List.range { start: After 250u8, end: At 255, step: 10 } == []
 
 expect
-    List.range { start: After 250u8, end: At 245 , step: 10} == []
+    List.range { start: After 250u8, end: At 245, step: 10 } == []
 
 expect
     List.range { start: At 4, end: At 0 } == [4, 3, 2, 1, 0]

--- a/crates/compiler/test_gen/src/gen_list.rs
+++ b/crates/compiler/test_gen/src/gen_list.rs
@@ -3696,6 +3696,24 @@ fn list_walk_from_even_prefix_sum() {
     );
 }
 
+#[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
+// TODO: update how roc decides whether or not to print `User crashed` or `Roc failed` such that this prints `Roc failed ...``
+#[should_panic(
+    expected = r#"User crash with message: "List.range: failed to generate enough elements to fill the range before overflowing the numeric type"#
+)]
+fn list_range_length_overflow() {
+    assert_evals_to!(
+        indoc!(
+            r#"
+            List.range {start: At 255u8, end: Length 2}
+               "#
+        ),
+        RocList::default(),
+        RocList::<u8>
+    );
+}
+
 #[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
 mod pattern_match {
     #[cfg(feature = "gen-llvm")]

--- a/crates/compiler/test_gen/src/gen_list.rs
+++ b/crates/compiler/test_gen/src/gen_list.rs
@@ -3709,7 +3709,7 @@ fn list_range_length_overflow() {
             List.range {start: At 255u8, end: Length 2}
                "#
         ),
-        RocList::default(),
+        RocList::<u8>::default(),
         RocList::<u8>
     );
 }

--- a/crates/compiler/test_mono/generated/anonymous_closure_in_polymorphic_expression_issue_4717.txt
+++ b/crates/compiler/test_mono/generated/anonymous_closure_in_polymorphic_expression_issue_4717.txt
@@ -3,85 +3,85 @@ procedure Bool.11 (#Attr.2, #Attr.3):
     ret Bool.24;
 
 procedure List.26 (List.152, List.153, List.154):
-    let List.493 : [C U64, C U64] = CallByName List.91 List.152 List.153 List.154;
-    let List.496 : U8 = 1i64;
-    let List.497 : U8 = GetTagId List.493;
-    let List.498 : Int1 = lowlevel Eq List.496 List.497;
-    if List.498 then
-        let List.155 : U64 = UnionAtIndex (Id 1) (Index 0) List.493;
+    let List.508 : [C U64, C U64] = CallByName List.91 List.152 List.153 List.154;
+    let List.511 : U8 = 1i64;
+    let List.512 : U8 = GetTagId List.508;
+    let List.513 : Int1 = lowlevel Eq List.511 List.512;
+    if List.513 then
+        let List.155 : U64 = UnionAtIndex (Id 1) (Index 0) List.508;
         ret List.155;
     else
-        let List.156 : U64 = UnionAtIndex (Id 0) (Index 0) List.493;
+        let List.156 : U64 = UnionAtIndex (Id 0) (Index 0) List.508;
         ret List.156;
 
-procedure List.29 (List.294, List.295):
-    let List.492 : U64 = CallByName List.6 List.294;
-    let List.296 : U64 = CallByName Num.77 List.492 List.295;
-    let List.478 : List U8 = CallByName List.43 List.294 List.296;
-    ret List.478;
+procedure List.29 (List.297, List.298):
+    let List.507 : U64 = CallByName List.6 List.297;
+    let List.299 : U64 = CallByName Num.77 List.507 List.298;
+    let List.493 : List U8 = CallByName List.43 List.297 List.299;
+    ret List.493;
 
-procedure List.43 (List.292, List.293):
-    let List.490 : U64 = CallByName List.6 List.292;
-    let List.489 : U64 = CallByName Num.77 List.490 List.293;
-    let List.480 : {U64, U64} = Struct {List.293, List.489};
-    let List.479 : List U8 = CallByName List.49 List.292 List.480;
-    ret List.479;
+procedure List.43 (List.295, List.296):
+    let List.505 : U64 = CallByName List.6 List.295;
+    let List.504 : U64 = CallByName Num.77 List.505 List.296;
+    let List.495 : {U64, U64} = Struct {List.296, List.504};
+    let List.494 : List U8 = CallByName List.49 List.295 List.495;
+    ret List.494;
 
-procedure List.49 (List.366, List.367):
-    let List.487 : U64 = StructAtIndex 0 List.367;
-    let List.488 : U64 = 0i64;
-    let List.485 : Int1 = CallByName Bool.11 List.487 List.488;
-    if List.485 then
-        dec List.366;
-        let List.486 : List U8 = Array [];
-        ret List.486;
+procedure List.49 (List.369, List.370):
+    let List.502 : U64 = StructAtIndex 0 List.370;
+    let List.503 : U64 = 0i64;
+    let List.500 : Int1 = CallByName Bool.11 List.502 List.503;
+    if List.500 then
+        dec List.369;
+        let List.501 : List U8 = Array [];
+        ret List.501;
     else
-        let List.482 : U64 = StructAtIndex 1 List.367;
-        let List.483 : U64 = StructAtIndex 0 List.367;
-        let List.481 : List U8 = CallByName List.72 List.366 List.482 List.483;
-        ret List.481;
+        let List.497 : U64 = StructAtIndex 1 List.370;
+        let List.498 : U64 = StructAtIndex 0 List.370;
+        let List.496 : List U8 = CallByName List.72 List.369 List.497 List.498;
+        ret List.496;
 
 procedure List.6 (#Attr.2):
-    let List.491 : U64 = lowlevel ListLen #Attr.2;
-    ret List.491;
+    let List.506 : U64 = lowlevel ListLen #Attr.2;
+    ret List.506;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.514 : U8 = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.514;
+    let List.529 : U8 = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.529;
 
 procedure List.72 (#Attr.2, #Attr.3, #Attr.4):
-    let List.484 : List U8 = lowlevel ListSublist #Attr.2 #Attr.3 #Attr.4;
-    ret List.484;
-
-procedure List.80 (List.528, List.529, List.530, List.531, List.532):
-    joinpoint List.502 List.429 List.430 List.431 List.432 List.433:
-        let List.504 : Int1 = CallByName Num.22 List.432 List.433;
-        if List.504 then
-            let List.513 : U8 = CallByName List.66 List.429 List.432;
-            let List.505 : [C U64, C U64] = CallByName Test.4 List.430 List.513;
-            let List.510 : U8 = 1i64;
-            let List.511 : U8 = GetTagId List.505;
-            let List.512 : Int1 = lowlevel Eq List.510 List.511;
-            if List.512 then
-                let List.434 : U64 = UnionAtIndex (Id 1) (Index 0) List.505;
-                let List.508 : U64 = 1i64;
-                let List.507 : U64 = CallByName Num.19 List.432 List.508;
-                jump List.502 List.429 List.434 List.431 List.507 List.433;
-            else
-                let List.435 : U64 = UnionAtIndex (Id 0) (Index 0) List.505;
-                let List.509 : [C U64, C U64] = TagId(0) List.435;
-                ret List.509;
-        else
-            let List.503 : [C U64, C U64] = TagId(1) List.430;
-            ret List.503;
-    in
-    jump List.502 List.528 List.529 List.530 List.531 List.532;
-
-procedure List.91 (List.426, List.427, List.428):
-    let List.500 : U64 = 0i64;
-    let List.501 : U64 = CallByName List.6 List.426;
-    let List.499 : [C U64, C U64] = CallByName List.80 List.426 List.427 List.428 List.500 List.501;
+    let List.499 : List U8 = lowlevel ListSublist #Attr.2 #Attr.3 #Attr.4;
     ret List.499;
+
+procedure List.80 (List.543, List.544, List.545, List.546, List.547):
+    joinpoint List.517 List.432 List.433 List.434 List.435 List.436:
+        let List.519 : Int1 = CallByName Num.22 List.435 List.436;
+        if List.519 then
+            let List.528 : U8 = CallByName List.66 List.432 List.435;
+            let List.520 : [C U64, C U64] = CallByName Test.4 List.433 List.528;
+            let List.525 : U8 = 1i64;
+            let List.526 : U8 = GetTagId List.520;
+            let List.527 : Int1 = lowlevel Eq List.525 List.526;
+            if List.527 then
+                let List.437 : U64 = UnionAtIndex (Id 1) (Index 0) List.520;
+                let List.523 : U64 = 1i64;
+                let List.522 : U64 = CallByName Num.19 List.435 List.523;
+                jump List.517 List.432 List.437 List.434 List.522 List.436;
+            else
+                let List.438 : U64 = UnionAtIndex (Id 0) (Index 0) List.520;
+                let List.524 : [C U64, C U64] = TagId(0) List.438;
+                ret List.524;
+        else
+            let List.518 : [C U64, C U64] = TagId(1) List.433;
+            ret List.518;
+    in
+    jump List.517 List.543 List.544 List.545 List.546 List.547;
+
+procedure List.91 (List.429, List.430, List.431):
+    let List.515 : U64 = 0i64;
+    let List.516 : U64 = CallByName List.6 List.429;
+    let List.514 : [C U64, C U64] = CallByName List.80 List.429 List.430 List.431 List.515 List.516;
+    ret List.514;
 
 procedure Num.19 (#Attr.2, #Attr.3):
     let Num.258 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/call_function_in_empty_list.txt
+++ b/crates/compiler/test_mono/generated/call_function_in_empty_list.txt
@@ -1,7 +1,7 @@
 procedure List.5 (#Attr.2, #Attr.3):
-    let List.478 : List {} = lowlevel ListMap { xs: `#Attr.#arg1` } #Attr.2 Test.2 #Attr.3;
+    let List.493 : List {} = lowlevel ListMap { xs: `#Attr.#arg1` } #Attr.2 Test.2 #Attr.3;
     decref #Attr.2;
-    ret List.478;
+    ret List.493;
 
 procedure Test.2 (Test.3):
     let Test.7 : {} = Struct {};

--- a/crates/compiler/test_mono/generated/call_function_in_empty_list_unbound.txt
+++ b/crates/compiler/test_mono/generated/call_function_in_empty_list_unbound.txt
@@ -1,7 +1,7 @@
 procedure List.5 (#Attr.2, #Attr.3):
-    let List.478 : List [] = lowlevel ListMap { xs: `#Attr.#arg1` } #Attr.2 Test.2 #Attr.3;
+    let List.493 : List [] = lowlevel ListMap { xs: `#Attr.#arg1` } #Attr.2 Test.2 #Attr.3;
     decref #Attr.2;
-    ret List.478;
+    ret List.493;
 
 procedure Test.2 (Test.3):
     let Test.7 : {} = Struct {};

--- a/crates/compiler/test_mono/generated/choose_correct_recursion_var_under_record.txt
+++ b/crates/compiler/test_mono/generated/choose_correct_recursion_var_under_record.txt
@@ -3,46 +3,46 @@ procedure Bool.1 ():
     ret Bool.24;
 
 procedure List.2 (List.95, List.96):
-    let List.492 : U64 = CallByName List.6 List.95;
-    let List.488 : Int1 = CallByName Num.22 List.96 List.492;
-    if List.488 then
-        let List.490 : Str = CallByName List.66 List.95 List.96;
-        let List.489 : [C {}, C Str] = TagId(1) List.490;
-        ret List.489;
+    let List.507 : U64 = CallByName List.6 List.95;
+    let List.503 : Int1 = CallByName Num.22 List.96 List.507;
+    if List.503 then
+        let List.505 : Str = CallByName List.66 List.95 List.96;
+        let List.504 : [C {}, C Str] = TagId(1) List.505;
+        ret List.504;
     else
-        let List.487 : {} = Struct {};
-        let List.486 : [C {}, C Str] = TagId(0) List.487;
-        ret List.486;
+        let List.502 : {} = Struct {};
+        let List.501 : [C {}, C Str] = TagId(0) List.502;
+        ret List.501;
 
 procedure List.5 (#Attr.2, #Attr.3):
-    let List.494 : List Str = lowlevel ListMap { xs: `#Attr.#arg1` } #Attr.2 Test.10 #Attr.3;
-    ret List.494;
+    let List.509 : List Str = lowlevel ListMap { xs: `#Attr.#arg1` } #Attr.2 Test.10 #Attr.3;
+    ret List.509;
 
 procedure List.6 (#Attr.2):
-    let List.493 : U64 = lowlevel ListLen #Attr.2;
-    ret List.493;
+    let List.508 : U64 = lowlevel ListLen #Attr.2;
+    ret List.508;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.491 : Str = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.491;
+    let List.506 : Str = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.506;
 
-procedure List.9 (List.283):
-    let List.485 : U64 = 0i64;
-    let List.478 : [C {}, C Str] = CallByName List.2 List.283 List.485;
-    let List.482 : U8 = 1i64;
-    let List.483 : U8 = GetTagId List.478;
-    let List.484 : Int1 = lowlevel Eq List.482 List.483;
-    if List.484 then
-        let List.284 : Str = UnionAtIndex (Id 1) (Index 0) List.478;
-        inc List.284;
-        dec List.478;
-        let List.479 : [C {}, C Str] = TagId(1) List.284;
-        ret List.479;
+procedure List.9 (List.286):
+    let List.500 : U64 = 0i64;
+    let List.493 : [C {}, C Str] = CallByName List.2 List.286 List.500;
+    let List.497 : U8 = 1i64;
+    let List.498 : U8 = GetTagId List.493;
+    let List.499 : Int1 = lowlevel Eq List.497 List.498;
+    if List.499 then
+        let List.287 : Str = UnionAtIndex (Id 1) (Index 0) List.493;
+        inc List.287;
+        dec List.493;
+        let List.494 : [C {}, C Str] = TagId(1) List.287;
+        ret List.494;
     else
-        dec List.478;
-        let List.481 : {} = Struct {};
-        let List.480 : [C {}, C Str] = TagId(0) List.481;
-        ret List.480;
+        dec List.493;
+        let List.496 : {} = Struct {};
+        let List.495 : [C {}, C Str] = TagId(0) List.496;
+        ret List.495;
 
 procedure Num.22 (#Attr.2, #Attr.3):
     let Num.256 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/closure_in_list.txt
+++ b/crates/compiler/test_mono/generated/closure_in_list.txt
@@ -1,6 +1,6 @@
 procedure List.6 (#Attr.2):
-    let List.478 : U64 = lowlevel ListLen #Attr.2;
-    ret List.478;
+    let List.493 : U64 = lowlevel ListLen #Attr.2;
+    ret List.493;
 
 procedure Test.1 (Test.5):
     let Test.2 : I64 = 41i64;

--- a/crates/compiler/test_mono/generated/dict.txt
+++ b/crates/compiler/test_mono/generated/dict.txt
@@ -20,58 +20,58 @@ procedure Dict.4 (Dict.497):
     ret Dict.85;
 
 procedure List.11 (List.114, List.115):
-    let List.479 : List I8 = CallByName List.68 List.115;
-    let List.478 : List I8 = CallByName List.81 List.114 List.115 List.479;
-    ret List.478;
+    let List.494 : List I8 = CallByName List.68 List.115;
+    let List.493 : List I8 = CallByName List.81 List.114 List.115 List.494;
+    ret List.493;
 
 procedure List.11 (List.114, List.115):
-    let List.491 : List U64 = CallByName List.68 List.115;
-    let List.490 : List U64 = CallByName List.81 List.114 List.115 List.491;
-    ret List.490;
+    let List.506 : List U64 = CallByName List.68 List.115;
+    let List.505 : List U64 = CallByName List.81 List.114 List.115 List.506;
+    ret List.505;
 
 procedure List.68 (#Attr.2):
-    let List.489 : List I8 = lowlevel ListWithCapacity #Attr.2;
-    ret List.489;
+    let List.504 : List I8 = lowlevel ListWithCapacity #Attr.2;
+    ret List.504;
 
 procedure List.68 (#Attr.2):
-    let List.501 : List U64 = lowlevel ListWithCapacity #Attr.2;
+    let List.516 : List U64 = lowlevel ListWithCapacity #Attr.2;
+    ret List.516;
+
+procedure List.71 (#Attr.2, #Attr.3):
+    let List.501 : List I8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
     ret List.501;
 
 procedure List.71 (#Attr.2, #Attr.3):
-    let List.486 : List I8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
-    ret List.486;
+    let List.513 : List U64 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
+    ret List.513;
 
-procedure List.71 (#Attr.2, #Attr.3):
-    let List.498 : List U64 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
-    ret List.498;
-
-procedure List.81 (List.502, List.503, List.504):
-    joinpoint List.480 List.116 List.117 List.118:
-        let List.488 : U64 = 0i64;
-        let List.482 : Int1 = CallByName Num.24 List.117 List.488;
-        if List.482 then
-            let List.487 : U64 = 1i64;
-            let List.484 : U64 = CallByName Num.20 List.117 List.487;
-            let List.485 : List I8 = CallByName List.71 List.118 List.116;
-            jump List.480 List.116 List.484 List.485;
+procedure List.81 (List.517, List.518, List.519):
+    joinpoint List.495 List.116 List.117 List.118:
+        let List.503 : U64 = 0i64;
+        let List.497 : Int1 = CallByName Num.24 List.117 List.503;
+        if List.497 then
+            let List.502 : U64 = 1i64;
+            let List.499 : U64 = CallByName Num.20 List.117 List.502;
+            let List.500 : List I8 = CallByName List.71 List.118 List.116;
+            jump List.495 List.116 List.499 List.500;
         else
             ret List.118;
     in
-    jump List.480 List.502 List.503 List.504;
+    jump List.495 List.517 List.518 List.519;
 
-procedure List.81 (List.510, List.511, List.512):
-    joinpoint List.492 List.116 List.117 List.118:
-        let List.500 : U64 = 0i64;
-        let List.494 : Int1 = CallByName Num.24 List.117 List.500;
-        if List.494 then
-            let List.499 : U64 = 1i64;
-            let List.496 : U64 = CallByName Num.20 List.117 List.499;
-            let List.497 : List U64 = CallByName List.71 List.118 List.116;
-            jump List.492 List.116 List.496 List.497;
+procedure List.81 (List.525, List.526, List.527):
+    joinpoint List.507 List.116 List.117 List.118:
+        let List.515 : U64 = 0i64;
+        let List.509 : Int1 = CallByName Num.24 List.117 List.515;
+        if List.509 then
+            let List.514 : U64 = 1i64;
+            let List.511 : U64 = CallByName Num.20 List.117 List.514;
+            let List.512 : List U64 = CallByName List.71 List.118 List.116;
+            jump List.507 List.116 List.511 List.512;
         else
             ret List.118;
     in
-    jump List.492 List.510 List.511 List.512;
+    jump List.507 List.525 List.526 List.527;
 
 procedure Num.20 (#Attr.2, #Attr.3):
     let Num.257 : U64 = lowlevel NumSub #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/empty_list_of_function_type.txt
+++ b/crates/compiler/test_mono/generated/empty_list_of_function_type.txt
@@ -3,24 +3,24 @@ procedure Bool.1 ():
     ret Bool.23;
 
 procedure List.2 (List.95, List.96):
-    let List.484 : U64 = CallByName List.6 List.95;
-    let List.480 : Int1 = CallByName Num.22 List.96 List.484;
-    if List.480 then
-        let List.482 : {} = CallByName List.66 List.95 List.96;
-        let List.481 : [C {}, C {}] = TagId(1) List.482;
-        ret List.481;
+    let List.499 : U64 = CallByName List.6 List.95;
+    let List.495 : Int1 = CallByName Num.22 List.96 List.499;
+    if List.495 then
+        let List.497 : {} = CallByName List.66 List.95 List.96;
+        let List.496 : [C {}, C {}] = TagId(1) List.497;
+        ret List.496;
     else
-        let List.479 : {} = Struct {};
-        let List.478 : [C {}, C {}] = TagId(0) List.479;
-        ret List.478;
+        let List.494 : {} = Struct {};
+        let List.493 : [C {}, C {}] = TagId(0) List.494;
+        ret List.493;
 
 procedure List.6 (#Attr.2):
-    let List.485 : U64 = lowlevel ListLen #Attr.2;
-    ret List.485;
+    let List.500 : U64 = lowlevel ListLen #Attr.2;
+    ret List.500;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.483 : {} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.483;
+    let List.498 : {} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.498;
 
 procedure Num.22 (#Attr.2, #Attr.3):
     let Num.256 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/encode.txt
+++ b/crates/compiler/test_mono/generated/encode.txt
@@ -1,16 +1,16 @@
 procedure List.4 (List.106, List.107):
-    let List.481 : U64 = 1i64;
-    let List.479 : List U8 = CallByName List.70 List.106 List.481;
-    let List.478 : List U8 = CallByName List.71 List.479 List.107;
-    ret List.478;
+    let List.496 : U64 = 1i64;
+    let List.494 : List U8 = CallByName List.70 List.106 List.496;
+    let List.493 : List U8 = CallByName List.71 List.494 List.107;
+    ret List.493;
 
 procedure List.70 (#Attr.2, #Attr.3):
-    let List.482 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
-    ret List.482;
+    let List.497 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
+    ret List.497;
 
 procedure List.71 (#Attr.2, #Attr.3):
-    let List.480 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
-    ret List.480;
+    let List.495 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
+    ret List.495;
 
 procedure Test.23 (Test.24, Test.35, Test.22):
     let Test.37 : List U8 = CallByName List.4 Test.24 Test.22;

--- a/crates/compiler/test_mono/generated/encode_derived_nested_record_string.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_nested_record_string.txt
@@ -205,98 +205,98 @@ procedure Json.96 (Json.97, Json.475, Json.95):
     ret Json.477;
 
 procedure List.138 (List.139, List.140, List.137):
-    let List.519 : {List U8, U64} = CallByName Json.114 List.139 List.140;
-    ret List.519;
+    let List.534 : {List U8, U64} = CallByName Json.114 List.139 List.140;
+    ret List.534;
 
 procedure List.138 (List.139, List.140, List.137):
-    let List.592 : {List U8, U64} = CallByName Json.114 List.139 List.140;
-    ret List.592;
+    let List.607 : {List U8, U64} = CallByName Json.114 List.139 List.140;
+    ret List.607;
 
 procedure List.18 (List.135, List.136, List.137):
-    let List.500 : {List U8, U64} = CallByName List.91 List.135 List.136 List.137;
-    ret List.500;
+    let List.515 : {List U8, U64} = CallByName List.91 List.135 List.136 List.137;
+    ret List.515;
 
 procedure List.18 (List.135, List.136, List.137):
-    let List.573 : {List U8, U64} = CallByName List.91 List.135 List.136 List.137;
-    ret List.573;
+    let List.588 : {List U8, U64} = CallByName List.91 List.135 List.136 List.137;
+    ret List.588;
 
 procedure List.4 (List.106, List.107):
-    let List.572 : U64 = 1i64;
-    let List.571 : List U8 = CallByName List.70 List.106 List.572;
-    let List.570 : List U8 = CallByName List.71 List.571 List.107;
-    ret List.570;
+    let List.587 : U64 = 1i64;
+    let List.586 : List U8 = CallByName List.70 List.106 List.587;
+    let List.585 : List U8 = CallByName List.71 List.586 List.107;
+    ret List.585;
 
 procedure List.6 (#Attr.2):
-    let List.478 : U64 = lowlevel ListLen #Attr.2;
-    ret List.478;
+    let List.493 : U64 = lowlevel ListLen #Attr.2;
+    ret List.493;
 
 procedure List.6 (#Attr.2):
-    let List.521 : U64 = lowlevel ListLen #Attr.2;
-    ret List.521;
+    let List.536 : U64 = lowlevel ListLen #Attr.2;
+    ret List.536;
 
 procedure List.6 (#Attr.2):
-    let List.595 : U64 = lowlevel ListLen #Attr.2;
-    ret List.595;
+    let List.610 : U64 = lowlevel ListLen #Attr.2;
+    ret List.610;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.516 : {Str, Str} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.516;
+    let List.531 : {Str, Str} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.531;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.589 : {Str, Str} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.589;
+    let List.604 : {Str, Str} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.604;
 
 procedure List.70 (#Attr.2, #Attr.3):
-    let List.551 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
-    ret List.551;
+    let List.566 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
+    ret List.566;
 
 procedure List.71 (#Attr.2, #Attr.3):
-    let List.549 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
-    ret List.549;
+    let List.564 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
+    ret List.564;
 
 procedure List.8 (#Attr.2, #Attr.3):
-    let List.594 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
-    ret List.594;
+    let List.609 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
+    ret List.609;
 
-procedure List.80 (List.531, List.532, List.533, List.534, List.535):
-    joinpoint List.506 List.429 List.430 List.431 List.432 List.433:
-        let List.508 : Int1 = CallByName Num.22 List.432 List.433;
-        if List.508 then
-            let List.515 : {Str, Str} = CallByName List.66 List.429 List.432;
-            let List.509 : {List U8, U64} = CallByName List.138 List.430 List.515 List.431;
-            let List.512 : U64 = 1i64;
-            let List.511 : U64 = CallByName Num.19 List.432 List.512;
-            jump List.506 List.429 List.509 List.431 List.511 List.433;
+procedure List.80 (List.546, List.547, List.548, List.549, List.550):
+    joinpoint List.521 List.432 List.433 List.434 List.435 List.436:
+        let List.523 : Int1 = CallByName Num.22 List.435 List.436;
+        if List.523 then
+            let List.530 : {Str, Str} = CallByName List.66 List.432 List.435;
+            let List.524 : {List U8, U64} = CallByName List.138 List.433 List.530 List.434;
+            let List.527 : U64 = 1i64;
+            let List.526 : U64 = CallByName Num.19 List.435 List.527;
+            jump List.521 List.432 List.524 List.434 List.526 List.436;
         else
-            ret List.430;
+            ret List.433;
     in
-    jump List.506 List.531 List.532 List.533 List.534 List.535;
+    jump List.521 List.546 List.547 List.548 List.549 List.550;
 
-procedure List.80 (List.605, List.606, List.607, List.608, List.609):
-    joinpoint List.579 List.429 List.430 List.431 List.432 List.433:
-        let List.581 : Int1 = CallByName Num.22 List.432 List.433;
-        if List.581 then
-            let List.588 : {Str, Str} = CallByName List.66 List.429 List.432;
-            let List.582 : {List U8, U64} = CallByName List.138 List.430 List.588 List.431;
-            let List.585 : U64 = 1i64;
-            let List.584 : U64 = CallByName Num.19 List.432 List.585;
-            jump List.579 List.429 List.582 List.431 List.584 List.433;
+procedure List.80 (List.620, List.621, List.622, List.623, List.624):
+    joinpoint List.594 List.432 List.433 List.434 List.435 List.436:
+        let List.596 : Int1 = CallByName Num.22 List.435 List.436;
+        if List.596 then
+            let List.603 : {Str, Str} = CallByName List.66 List.432 List.435;
+            let List.597 : {List U8, U64} = CallByName List.138 List.433 List.603 List.434;
+            let List.600 : U64 = 1i64;
+            let List.599 : U64 = CallByName Num.19 List.435 List.600;
+            jump List.594 List.432 List.597 List.434 List.599 List.436;
         else
-            ret List.430;
+            ret List.433;
     in
-    jump List.579 List.605 List.606 List.607 List.608 List.609;
+    jump List.594 List.620 List.621 List.622 List.623 List.624;
 
-procedure List.91 (List.426, List.427, List.428):
-    let List.504 : U64 = 0i64;
-    let List.505 : U64 = CallByName List.6 List.426;
-    let List.503 : {List U8, U64} = CallByName List.80 List.426 List.427 List.428 List.504 List.505;
-    ret List.503;
+procedure List.91 (List.429, List.430, List.431):
+    let List.519 : U64 = 0i64;
+    let List.520 : U64 = CallByName List.6 List.429;
+    let List.518 : {List U8, U64} = CallByName List.80 List.429 List.430 List.431 List.519 List.520;
+    ret List.518;
 
-procedure List.91 (List.426, List.427, List.428):
-    let List.577 : U64 = 0i64;
-    let List.578 : U64 = CallByName List.6 List.426;
-    let List.576 : {List U8, U64} = CallByName List.80 List.426 List.427 List.428 List.577 List.578;
-    ret List.576;
+procedure List.91 (List.429, List.430, List.431):
+    let List.592 : U64 = 0i64;
+    let List.593 : U64 = CallByName List.6 List.429;
+    let List.591 : {List U8, U64} = CallByName List.80 List.429 List.430 List.431 List.592 List.593;
+    ret List.591;
 
 procedure Num.125 (#Attr.2):
     let Num.282 : U8 = lowlevel NumIntCast #Attr.2;

--- a/crates/compiler/test_mono/generated/encode_derived_record_one_field_string.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_record_one_field_string.txt
@@ -118,62 +118,62 @@ procedure Json.96 (Json.97, Json.435, Json.95):
     ret Json.437;
 
 procedure List.138 (List.139, List.140, List.137):
-    let List.525 : {List U8, U64} = CallByName Json.114 List.139 List.140;
-    ret List.525;
+    let List.540 : {List U8, U64} = CallByName Json.114 List.139 List.140;
+    ret List.540;
 
 procedure List.18 (List.135, List.136, List.137):
-    let List.506 : {List U8, U64} = CallByName List.91 List.135 List.136 List.137;
-    ret List.506;
+    let List.521 : {List U8, U64} = CallByName List.91 List.135 List.136 List.137;
+    ret List.521;
 
 procedure List.4 (List.106, List.107):
-    let List.505 : U64 = 1i64;
-    let List.504 : List U8 = CallByName List.70 List.106 List.505;
-    let List.503 : List U8 = CallByName List.71 List.504 List.107;
-    ret List.503;
+    let List.520 : U64 = 1i64;
+    let List.519 : List U8 = CallByName List.70 List.106 List.520;
+    let List.518 : List U8 = CallByName List.71 List.519 List.107;
+    ret List.518;
 
 procedure List.6 (#Attr.2):
-    let List.478 : U64 = lowlevel ListLen #Attr.2;
-    ret List.478;
+    let List.493 : U64 = lowlevel ListLen #Attr.2;
+    ret List.493;
 
 procedure List.6 (#Attr.2):
-    let List.528 : U64 = lowlevel ListLen #Attr.2;
-    ret List.528;
+    let List.543 : U64 = lowlevel ListLen #Attr.2;
+    ret List.543;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.522 : {Str, Str} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.522;
+    let List.537 : {Str, Str} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.537;
 
 procedure List.70 (#Attr.2, #Attr.3):
-    let List.484 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
-    ret List.484;
+    let List.499 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
+    ret List.499;
 
 procedure List.71 (#Attr.2, #Attr.3):
-    let List.482 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
-    ret List.482;
+    let List.497 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
+    ret List.497;
 
 procedure List.8 (#Attr.2, #Attr.3):
-    let List.527 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
-    ret List.527;
+    let List.542 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
+    ret List.542;
 
-procedure List.80 (List.538, List.539, List.540, List.541, List.542):
-    joinpoint List.512 List.429 List.430 List.431 List.432 List.433:
-        let List.514 : Int1 = CallByName Num.22 List.432 List.433;
-        if List.514 then
-            let List.521 : {Str, Str} = CallByName List.66 List.429 List.432;
-            let List.515 : {List U8, U64} = CallByName List.138 List.430 List.521 List.431;
-            let List.518 : U64 = 1i64;
-            let List.517 : U64 = CallByName Num.19 List.432 List.518;
-            jump List.512 List.429 List.515 List.431 List.517 List.433;
+procedure List.80 (List.553, List.554, List.555, List.556, List.557):
+    joinpoint List.527 List.432 List.433 List.434 List.435 List.436:
+        let List.529 : Int1 = CallByName Num.22 List.435 List.436;
+        if List.529 then
+            let List.536 : {Str, Str} = CallByName List.66 List.432 List.435;
+            let List.530 : {List U8, U64} = CallByName List.138 List.433 List.536 List.434;
+            let List.533 : U64 = 1i64;
+            let List.532 : U64 = CallByName Num.19 List.435 List.533;
+            jump List.527 List.432 List.530 List.434 List.532 List.436;
         else
-            ret List.430;
+            ret List.433;
     in
-    jump List.512 List.538 List.539 List.540 List.541 List.542;
+    jump List.527 List.553 List.554 List.555 List.556 List.557;
 
-procedure List.91 (List.426, List.427, List.428):
-    let List.510 : U64 = 0i64;
-    let List.511 : U64 = CallByName List.6 List.426;
-    let List.509 : {List U8, U64} = CallByName List.80 List.426 List.427 List.428 List.510 List.511;
-    ret List.509;
+procedure List.91 (List.429, List.430, List.431):
+    let List.525 : U64 = 0i64;
+    let List.526 : U64 = CallByName List.6 List.429;
+    let List.524 : {List U8, U64} = CallByName List.80 List.429 List.430 List.431 List.525 List.526;
+    ret List.524;
 
 procedure Num.125 (#Attr.2):
     let Num.263 : U8 = lowlevel NumIntCast #Attr.2;

--- a/crates/compiler/test_mono/generated/encode_derived_record_two_field_strings.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_record_two_field_strings.txt
@@ -126,62 +126,62 @@ procedure Json.96 (Json.97, Json.435, Json.95):
     ret Json.437;
 
 procedure List.138 (List.139, List.140, List.137):
-    let List.525 : {List U8, U64} = CallByName Json.114 List.139 List.140;
-    ret List.525;
+    let List.540 : {List U8, U64} = CallByName Json.114 List.139 List.140;
+    ret List.540;
 
 procedure List.18 (List.135, List.136, List.137):
-    let List.506 : {List U8, U64} = CallByName List.91 List.135 List.136 List.137;
-    ret List.506;
+    let List.521 : {List U8, U64} = CallByName List.91 List.135 List.136 List.137;
+    ret List.521;
 
 procedure List.4 (List.106, List.107):
-    let List.505 : U64 = 1i64;
-    let List.504 : List U8 = CallByName List.70 List.106 List.505;
-    let List.503 : List U8 = CallByName List.71 List.504 List.107;
-    ret List.503;
+    let List.520 : U64 = 1i64;
+    let List.519 : List U8 = CallByName List.70 List.106 List.520;
+    let List.518 : List U8 = CallByName List.71 List.519 List.107;
+    ret List.518;
 
 procedure List.6 (#Attr.2):
-    let List.478 : U64 = lowlevel ListLen #Attr.2;
-    ret List.478;
+    let List.493 : U64 = lowlevel ListLen #Attr.2;
+    ret List.493;
 
 procedure List.6 (#Attr.2):
-    let List.528 : U64 = lowlevel ListLen #Attr.2;
-    ret List.528;
+    let List.543 : U64 = lowlevel ListLen #Attr.2;
+    ret List.543;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.522 : {Str, Str} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.522;
+    let List.537 : {Str, Str} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.537;
 
 procedure List.70 (#Attr.2, #Attr.3):
-    let List.484 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
-    ret List.484;
+    let List.499 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
+    ret List.499;
 
 procedure List.71 (#Attr.2, #Attr.3):
-    let List.482 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
-    ret List.482;
+    let List.497 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
+    ret List.497;
 
 procedure List.8 (#Attr.2, #Attr.3):
-    let List.527 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
-    ret List.527;
+    let List.542 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
+    ret List.542;
 
-procedure List.80 (List.538, List.539, List.540, List.541, List.542):
-    joinpoint List.512 List.429 List.430 List.431 List.432 List.433:
-        let List.514 : Int1 = CallByName Num.22 List.432 List.433;
-        if List.514 then
-            let List.521 : {Str, Str} = CallByName List.66 List.429 List.432;
-            let List.515 : {List U8, U64} = CallByName List.138 List.430 List.521 List.431;
-            let List.518 : U64 = 1i64;
-            let List.517 : U64 = CallByName Num.19 List.432 List.518;
-            jump List.512 List.429 List.515 List.431 List.517 List.433;
+procedure List.80 (List.553, List.554, List.555, List.556, List.557):
+    joinpoint List.527 List.432 List.433 List.434 List.435 List.436:
+        let List.529 : Int1 = CallByName Num.22 List.435 List.436;
+        if List.529 then
+            let List.536 : {Str, Str} = CallByName List.66 List.432 List.435;
+            let List.530 : {List U8, U64} = CallByName List.138 List.433 List.536 List.434;
+            let List.533 : U64 = 1i64;
+            let List.532 : U64 = CallByName Num.19 List.435 List.533;
+            jump List.527 List.432 List.530 List.434 List.532 List.436;
         else
-            ret List.430;
+            ret List.433;
     in
-    jump List.512 List.538 List.539 List.540 List.541 List.542;
+    jump List.527 List.553 List.554 List.555 List.556 List.557;
 
-procedure List.91 (List.426, List.427, List.428):
-    let List.510 : U64 = 0i64;
-    let List.511 : U64 = CallByName List.6 List.426;
-    let List.509 : {List U8, U64} = CallByName List.80 List.426 List.427 List.428 List.510 List.511;
-    ret List.509;
+procedure List.91 (List.429, List.430, List.431):
+    let List.525 : U64 = 0i64;
+    let List.526 : U64 = CallByName List.6 List.429;
+    let List.524 : {List U8, U64} = CallByName List.80 List.429 List.430 List.431 List.525 List.526;
+    ret List.524;
 
 procedure Num.125 (#Attr.2):
     let Num.263 : U8 = lowlevel NumIntCast #Attr.2;

--- a/crates/compiler/test_mono/generated/encode_derived_string.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_string.txt
@@ -31,26 +31,26 @@ procedure Json.96 (Json.97, Json.399, Json.95):
     ret Json.401;
 
 procedure List.4 (List.106, List.107):
-    let List.487 : U64 = 1i64;
-    let List.486 : List U8 = CallByName List.70 List.106 List.487;
-    let List.485 : List U8 = CallByName List.71 List.486 List.107;
-    ret List.485;
+    let List.502 : U64 = 1i64;
+    let List.501 : List U8 = CallByName List.70 List.106 List.502;
+    let List.500 : List U8 = CallByName List.71 List.501 List.107;
+    ret List.500;
 
 procedure List.6 (#Attr.2):
-    let List.478 : U64 = lowlevel ListLen #Attr.2;
-    ret List.478;
+    let List.493 : U64 = lowlevel ListLen #Attr.2;
+    ret List.493;
 
 procedure List.70 (#Attr.2, #Attr.3):
-    let List.484 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
-    ret List.484;
+    let List.499 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
+    ret List.499;
 
 procedure List.71 (#Attr.2, #Attr.3):
-    let List.482 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
-    ret List.482;
+    let List.497 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
+    ret List.497;
 
 procedure List.8 (#Attr.2, #Attr.3):
-    let List.488 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
-    ret List.488;
+    let List.503 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
+    ret List.503;
 
 procedure Num.125 (#Attr.2):
     let Num.257 : U8 = lowlevel NumIntCast #Attr.2;

--- a/crates/compiler/test_mono/generated/encode_derived_tag_one_field_string.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_tag_one_field_string.txt
@@ -127,62 +127,62 @@ procedure Json.96 (Json.97, Json.440, Json.95):
     ret Json.442;
 
 procedure List.138 (List.139, List.140, List.137):
-    let List.531 : {List U8, U64} = CallByName Json.128 List.139 List.140;
-    ret List.531;
+    let List.546 : {List U8, U64} = CallByName Json.128 List.139 List.140;
+    ret List.546;
 
 procedure List.18 (List.135, List.136, List.137):
-    let List.512 : {List U8, U64} = CallByName List.91 List.135 List.136 List.137;
-    ret List.512;
+    let List.527 : {List U8, U64} = CallByName List.91 List.135 List.136 List.137;
+    ret List.527;
 
 procedure List.4 (List.106, List.107):
-    let List.511 : U64 = 1i64;
-    let List.510 : List U8 = CallByName List.70 List.106 List.511;
-    let List.509 : List U8 = CallByName List.71 List.510 List.107;
-    ret List.509;
+    let List.526 : U64 = 1i64;
+    let List.525 : List U8 = CallByName List.70 List.106 List.526;
+    let List.524 : List U8 = CallByName List.71 List.525 List.107;
+    ret List.524;
 
 procedure List.6 (#Attr.2):
-    let List.478 : U64 = lowlevel ListLen #Attr.2;
-    ret List.478;
+    let List.493 : U64 = lowlevel ListLen #Attr.2;
+    ret List.493;
 
 procedure List.6 (#Attr.2):
-    let List.532 : U64 = lowlevel ListLen #Attr.2;
-    ret List.532;
+    let List.547 : U64 = lowlevel ListLen #Attr.2;
+    ret List.547;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.528 : Str = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.528;
+    let List.543 : Str = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.543;
 
 procedure List.70 (#Attr.2, #Attr.3):
-    let List.484 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
-    ret List.484;
+    let List.499 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
+    ret List.499;
 
 procedure List.71 (#Attr.2, #Attr.3):
-    let List.482 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
-    ret List.482;
+    let List.497 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
+    ret List.497;
 
 procedure List.8 (#Attr.2, #Attr.3):
-    let List.534 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
-    ret List.534;
+    let List.549 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
+    ret List.549;
 
-procedure List.80 (List.544, List.545, List.546, List.547, List.548):
-    joinpoint List.518 List.429 List.430 List.431 List.432 List.433:
-        let List.520 : Int1 = CallByName Num.22 List.432 List.433;
-        if List.520 then
-            let List.527 : Str = CallByName List.66 List.429 List.432;
-            let List.521 : {List U8, U64} = CallByName List.138 List.430 List.527 List.431;
-            let List.524 : U64 = 1i64;
-            let List.523 : U64 = CallByName Num.19 List.432 List.524;
-            jump List.518 List.429 List.521 List.431 List.523 List.433;
+procedure List.80 (List.559, List.560, List.561, List.562, List.563):
+    joinpoint List.533 List.432 List.433 List.434 List.435 List.436:
+        let List.535 : Int1 = CallByName Num.22 List.435 List.436;
+        if List.535 then
+            let List.542 : Str = CallByName List.66 List.432 List.435;
+            let List.536 : {List U8, U64} = CallByName List.138 List.433 List.542 List.434;
+            let List.539 : U64 = 1i64;
+            let List.538 : U64 = CallByName Num.19 List.435 List.539;
+            jump List.533 List.432 List.536 List.434 List.538 List.436;
         else
-            ret List.430;
+            ret List.433;
     in
-    jump List.518 List.544 List.545 List.546 List.547 List.548;
+    jump List.533 List.559 List.560 List.561 List.562 List.563;
 
-procedure List.91 (List.426, List.427, List.428):
-    let List.516 : U64 = 0i64;
-    let List.517 : U64 = CallByName List.6 List.426;
-    let List.515 : {List U8, U64} = CallByName List.80 List.426 List.427 List.428 List.516 List.517;
-    ret List.515;
+procedure List.91 (List.429, List.430, List.431):
+    let List.531 : U64 = 0i64;
+    let List.532 : U64 = CallByName List.6 List.429;
+    let List.530 : {List U8, U64} = CallByName List.80 List.429 List.430 List.431 List.531 List.532;
+    ret List.530;
 
 procedure Num.125 (#Attr.2):
     let Num.265 : U8 = lowlevel NumIntCast #Attr.2;

--- a/crates/compiler/test_mono/generated/encode_derived_tag_two_payloads_string.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_tag_two_payloads_string.txt
@@ -133,62 +133,62 @@ procedure Json.96 (Json.97, Json.440, Json.95):
     ret Json.442;
 
 procedure List.138 (List.139, List.140, List.137):
-    let List.531 : {List U8, U64} = CallByName Json.128 List.139 List.140;
-    ret List.531;
+    let List.546 : {List U8, U64} = CallByName Json.128 List.139 List.140;
+    ret List.546;
 
 procedure List.18 (List.135, List.136, List.137):
-    let List.512 : {List U8, U64} = CallByName List.91 List.135 List.136 List.137;
-    ret List.512;
+    let List.527 : {List U8, U64} = CallByName List.91 List.135 List.136 List.137;
+    ret List.527;
 
 procedure List.4 (List.106, List.107):
-    let List.511 : U64 = 1i64;
-    let List.510 : List U8 = CallByName List.70 List.106 List.511;
-    let List.509 : List U8 = CallByName List.71 List.510 List.107;
-    ret List.509;
+    let List.526 : U64 = 1i64;
+    let List.525 : List U8 = CallByName List.70 List.106 List.526;
+    let List.524 : List U8 = CallByName List.71 List.525 List.107;
+    ret List.524;
 
 procedure List.6 (#Attr.2):
-    let List.478 : U64 = lowlevel ListLen #Attr.2;
-    ret List.478;
+    let List.493 : U64 = lowlevel ListLen #Attr.2;
+    ret List.493;
 
 procedure List.6 (#Attr.2):
-    let List.532 : U64 = lowlevel ListLen #Attr.2;
-    ret List.532;
+    let List.547 : U64 = lowlevel ListLen #Attr.2;
+    ret List.547;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.528 : Str = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.528;
+    let List.543 : Str = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.543;
 
 procedure List.70 (#Attr.2, #Attr.3):
-    let List.484 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
-    ret List.484;
+    let List.499 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
+    ret List.499;
 
 procedure List.71 (#Attr.2, #Attr.3):
-    let List.482 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
-    ret List.482;
+    let List.497 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
+    ret List.497;
 
 procedure List.8 (#Attr.2, #Attr.3):
-    let List.534 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
-    ret List.534;
+    let List.549 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
+    ret List.549;
 
-procedure List.80 (List.544, List.545, List.546, List.547, List.548):
-    joinpoint List.518 List.429 List.430 List.431 List.432 List.433:
-        let List.520 : Int1 = CallByName Num.22 List.432 List.433;
-        if List.520 then
-            let List.527 : Str = CallByName List.66 List.429 List.432;
-            let List.521 : {List U8, U64} = CallByName List.138 List.430 List.527 List.431;
-            let List.524 : U64 = 1i64;
-            let List.523 : U64 = CallByName Num.19 List.432 List.524;
-            jump List.518 List.429 List.521 List.431 List.523 List.433;
+procedure List.80 (List.559, List.560, List.561, List.562, List.563):
+    joinpoint List.533 List.432 List.433 List.434 List.435 List.436:
+        let List.535 : Int1 = CallByName Num.22 List.435 List.436;
+        if List.535 then
+            let List.542 : Str = CallByName List.66 List.432 List.435;
+            let List.536 : {List U8, U64} = CallByName List.138 List.433 List.542 List.434;
+            let List.539 : U64 = 1i64;
+            let List.538 : U64 = CallByName Num.19 List.435 List.539;
+            jump List.533 List.432 List.536 List.434 List.538 List.436;
         else
-            ret List.430;
+            ret List.433;
     in
-    jump List.518 List.544 List.545 List.546 List.547 List.548;
+    jump List.533 List.559 List.560 List.561 List.562 List.563;
 
-procedure List.91 (List.426, List.427, List.428):
-    let List.516 : U64 = 0i64;
-    let List.517 : U64 = CallByName List.6 List.426;
-    let List.515 : {List U8, U64} = CallByName List.80 List.426 List.427 List.428 List.516 List.517;
-    ret List.515;
+procedure List.91 (List.429, List.430, List.431):
+    let List.531 : U64 = 0i64;
+    let List.532 : U64 = CallByName List.6 List.429;
+    let List.530 : {List U8, U64} = CallByName List.80 List.429 List.430 List.431 List.531 List.532;
+    ret List.530;
 
 procedure Num.125 (#Attr.2):
     let Num.265 : U8 = lowlevel NumIntCast #Attr.2;

--- a/crates/compiler/test_mono/generated/ir_int_add.txt
+++ b/crates/compiler/test_mono/generated/ir_int_add.txt
@@ -1,6 +1,6 @@
 procedure List.6 (#Attr.2):
-    let List.478 : U64 = lowlevel ListLen #Attr.2;
-    ret List.478;
+    let List.493 : U64 = lowlevel ListLen #Attr.2;
+    ret List.493;
 
 procedure Num.19 (#Attr.2, #Attr.3):
     let Num.258 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/issue_2583_specialize_errors_behind_unified_branches.txt
+++ b/crates/compiler/test_mono/generated/issue_2583_specialize_errors_behind_unified_branches.txt
@@ -7,39 +7,39 @@ procedure Bool.2 ():
     ret Bool.23;
 
 procedure List.2 (List.95, List.96):
-    let List.492 : U64 = CallByName List.6 List.95;
-    let List.488 : Int1 = CallByName Num.22 List.96 List.492;
-    if List.488 then
-        let List.490 : I64 = CallByName List.66 List.95 List.96;
-        let List.489 : [C {}, C I64] = TagId(1) List.490;
-        ret List.489;
+    let List.507 : U64 = CallByName List.6 List.95;
+    let List.503 : Int1 = CallByName Num.22 List.96 List.507;
+    if List.503 then
+        let List.505 : I64 = CallByName List.66 List.95 List.96;
+        let List.504 : [C {}, C I64] = TagId(1) List.505;
+        ret List.504;
     else
-        let List.487 : {} = Struct {};
-        let List.486 : [C {}, C I64] = TagId(0) List.487;
-        ret List.486;
+        let List.502 : {} = Struct {};
+        let List.501 : [C {}, C I64] = TagId(0) List.502;
+        ret List.501;
 
 procedure List.6 (#Attr.2):
-    let List.493 : U64 = lowlevel ListLen #Attr.2;
-    ret List.493;
+    let List.508 : U64 = lowlevel ListLen #Attr.2;
+    ret List.508;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.491 : I64 = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.491;
+    let List.506 : I64 = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.506;
 
-procedure List.9 (List.283):
-    let List.485 : U64 = 0i64;
-    let List.478 : [C {}, C I64] = CallByName List.2 List.283 List.485;
-    let List.482 : U8 = 1i64;
-    let List.483 : U8 = GetTagId List.478;
-    let List.484 : Int1 = lowlevel Eq List.482 List.483;
-    if List.484 then
-        let List.284 : I64 = UnionAtIndex (Id 1) (Index 0) List.478;
-        let List.479 : [C Int1, C I64] = TagId(1) List.284;
-        ret List.479;
+procedure List.9 (List.286):
+    let List.500 : U64 = 0i64;
+    let List.493 : [C {}, C I64] = CallByName List.2 List.286 List.500;
+    let List.497 : U8 = 1i64;
+    let List.498 : U8 = GetTagId List.493;
+    let List.499 : Int1 = lowlevel Eq List.497 List.498;
+    if List.499 then
+        let List.287 : I64 = UnionAtIndex (Id 1) (Index 0) List.493;
+        let List.494 : [C Int1, C I64] = TagId(1) List.287;
+        ret List.494;
     else
-        let List.481 : Int1 = true;
-        let List.480 : [C Int1, C I64] = TagId(0) List.481;
-        ret List.480;
+        let List.496 : Int1 = true;
+        let List.495 : [C Int1, C I64] = TagId(0) List.496;
+        ret List.495;
 
 procedure Num.22 (#Attr.2, #Attr.3):
     let Num.256 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/issue_4749.txt
+++ b/crates/compiler/test_mono/generated/issue_4749.txt
@@ -176,96 +176,96 @@ procedure Json.41 ():
     ret Json.397;
 
 procedure List.1 (List.94):
-    let List.479 : U64 = CallByName List.6 List.94;
-    let List.480 : U64 = 0i64;
-    let List.478 : Int1 = CallByName Bool.11 List.479 List.480;
-    ret List.478;
+    let List.494 : U64 = CallByName List.6 List.94;
+    let List.495 : U64 = 0i64;
+    let List.493 : Int1 = CallByName Bool.11 List.494 List.495;
+    ret List.493;
 
 procedure List.2 (List.95, List.96):
-    let List.536 : U64 = CallByName List.6 List.95;
-    let List.532 : Int1 = CallByName Num.22 List.96 List.536;
-    if List.532 then
-        let List.534 : U8 = CallByName List.66 List.95 List.96;
-        let List.533 : [C {}, C U8] = TagId(1) List.534;
-        ret List.533;
+    let List.551 : U64 = CallByName List.6 List.95;
+    let List.547 : Int1 = CallByName Num.22 List.96 List.551;
+    if List.547 then
+        let List.549 : U8 = CallByName List.66 List.95 List.96;
+        let List.548 : [C {}, C U8] = TagId(1) List.549;
+        ret List.548;
     else
-        let List.531 : {} = Struct {};
-        let List.530 : [C {}, C U8] = TagId(0) List.531;
-        ret List.530;
+        let List.546 : {} = Struct {};
+        let List.545 : [C {}, C U8] = TagId(0) List.546;
+        ret List.545;
 
 procedure List.4 (List.106, List.107):
-    let List.520 : U64 = 1i64;
-    let List.518 : List U8 = CallByName List.70 List.106 List.520;
-    let List.517 : List U8 = CallByName List.71 List.518 List.107;
-    ret List.517;
+    let List.535 : U64 = 1i64;
+    let List.533 : List U8 = CallByName List.70 List.106 List.535;
+    let List.532 : List U8 = CallByName List.71 List.533 List.107;
+    ret List.532;
 
-procedure List.49 (List.366, List.367):
-    let List.492 : U64 = StructAtIndex 0 List.367;
-    let List.493 : U64 = 0i64;
-    let List.490 : Int1 = CallByName Bool.11 List.492 List.493;
-    if List.490 then
-        dec List.366;
-        let List.491 : List U8 = Array [];
-        ret List.491;
+procedure List.49 (List.369, List.370):
+    let List.507 : U64 = StructAtIndex 0 List.370;
+    let List.508 : U64 = 0i64;
+    let List.505 : Int1 = CallByName Bool.11 List.507 List.508;
+    if List.505 then
+        dec List.369;
+        let List.506 : List U8 = Array [];
+        ret List.506;
     else
-        let List.487 : U64 = StructAtIndex 1 List.367;
-        let List.488 : U64 = StructAtIndex 0 List.367;
-        let List.486 : List U8 = CallByName List.72 List.366 List.487 List.488;
-        ret List.486;
+        let List.502 : U64 = StructAtIndex 1 List.370;
+        let List.503 : U64 = StructAtIndex 0 List.370;
+        let List.501 : List U8 = CallByName List.72 List.369 List.502 List.503;
+        ret List.501;
 
-procedure List.52 (List.381, List.382):
-    let List.383 : U64 = CallByName List.6 List.381;
-    joinpoint List.515 List.384:
-        let List.513 : U64 = 0i64;
-        let List.512 : {U64, U64} = Struct {List.384, List.513};
-        inc List.381;
-        let List.385 : List U8 = CallByName List.49 List.381 List.512;
-        let List.511 : U64 = CallByName Num.20 List.383 List.384;
-        let List.510 : {U64, U64} = Struct {List.511, List.384};
-        let List.386 : List U8 = CallByName List.49 List.381 List.510;
-        let List.509 : {List U8, List U8} = Struct {List.385, List.386};
-        ret List.509;
+procedure List.52 (List.384, List.385):
+    let List.386 : U64 = CallByName List.6 List.384;
+    joinpoint List.530 List.387:
+        let List.528 : U64 = 0i64;
+        let List.527 : {U64, U64} = Struct {List.387, List.528};
+        inc List.384;
+        let List.388 : List U8 = CallByName List.49 List.384 List.527;
+        let List.526 : U64 = CallByName Num.20 List.386 List.387;
+        let List.525 : {U64, U64} = Struct {List.526, List.387};
+        let List.389 : List U8 = CallByName List.49 List.384 List.525;
+        let List.524 : {List U8, List U8} = Struct {List.388, List.389};
+        ret List.524;
     in
-    let List.516 : Int1 = CallByName Num.24 List.383 List.382;
-    if List.516 then
-        jump List.515 List.382;
+    let List.531 : Int1 = CallByName Num.24 List.386 List.385;
+    if List.531 then
+        jump List.530 List.385;
     else
-        jump List.515 List.383;
+        jump List.530 List.386;
 
 procedure List.6 (#Attr.2):
-    let List.556 : U64 = lowlevel ListLen #Attr.2;
-    ret List.556;
+    let List.571 : U64 = lowlevel ListLen #Attr.2;
+    ret List.571;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.535 : U8 = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.535;
+    let List.550 : U8 = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.550;
 
 procedure List.70 (#Attr.2, #Attr.3):
-    let List.521 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
-    ret List.521;
+    let List.536 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
+    ret List.536;
 
 procedure List.71 (#Attr.2, #Attr.3):
-    let List.519 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
-    ret List.519;
+    let List.534 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
+    ret List.534;
 
 procedure List.72 (#Attr.2, #Attr.3, #Attr.4):
-    let List.489 : List U8 = lowlevel ListSublist #Attr.2 #Attr.3 #Attr.4;
-    ret List.489;
+    let List.504 : List U8 = lowlevel ListSublist #Attr.2 #Attr.3 #Attr.4;
+    ret List.504;
 
-procedure List.9 (List.283):
-    let List.529 : U64 = 0i64;
-    let List.522 : [C {}, C U8] = CallByName List.2 List.283 List.529;
-    let List.526 : U8 = 1i64;
-    let List.527 : U8 = GetTagId List.522;
-    let List.528 : Int1 = lowlevel Eq List.526 List.527;
-    if List.528 then
-        let List.284 : U8 = UnionAtIndex (Id 1) (Index 0) List.522;
-        let List.523 : [C {}, C U8] = TagId(1) List.284;
-        ret List.523;
+procedure List.9 (List.286):
+    let List.544 : U64 = 0i64;
+    let List.537 : [C {}, C U8] = CallByName List.2 List.286 List.544;
+    let List.541 : U8 = 1i64;
+    let List.542 : U8 = GetTagId List.537;
+    let List.543 : Int1 = lowlevel Eq List.541 List.542;
+    if List.543 then
+        let List.287 : U8 = UnionAtIndex (Id 1) (Index 0) List.537;
+        let List.538 : [C {}, C U8] = TagId(1) List.287;
+        ret List.538;
     else
-        let List.525 : {} = Struct {};
-        let List.524 : [C {}, C U8] = TagId(0) List.525;
-        ret List.524;
+        let List.540 : {} = Struct {};
+        let List.539 : [C {}, C U8] = TagId(0) List.540;
+        ret List.539;
 
 procedure Num.20 (#Attr.2, #Attr.3):
     let Num.258 : U64 = lowlevel NumSub #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/issue_4772_weakened_monomorphic_destructure.txt
+++ b/crates/compiler/test_mono/generated/issue_4772_weakened_monomorphic_destructure.txt
@@ -150,90 +150,90 @@ procedure Json.41 ():
     ret Json.397;
 
 procedure List.2 (List.95, List.96):
-    let List.530 : U64 = CallByName List.6 List.95;
-    let List.526 : Int1 = CallByName Num.22 List.96 List.530;
-    if List.526 then
-        let List.528 : U8 = CallByName List.66 List.95 List.96;
-        let List.527 : [C {}, C U8] = TagId(1) List.528;
-        ret List.527;
+    let List.545 : U64 = CallByName List.6 List.95;
+    let List.541 : Int1 = CallByName Num.22 List.96 List.545;
+    if List.541 then
+        let List.543 : U8 = CallByName List.66 List.95 List.96;
+        let List.542 : [C {}, C U8] = TagId(1) List.543;
+        ret List.542;
     else
-        let List.525 : {} = Struct {};
-        let List.524 : [C {}, C U8] = TagId(0) List.525;
-        ret List.524;
+        let List.540 : {} = Struct {};
+        let List.539 : [C {}, C U8] = TagId(0) List.540;
+        ret List.539;
 
 procedure List.4 (List.106, List.107):
-    let List.514 : U64 = 1i64;
-    let List.512 : List U8 = CallByName List.70 List.106 List.514;
-    let List.511 : List U8 = CallByName List.71 List.512 List.107;
-    ret List.511;
+    let List.529 : U64 = 1i64;
+    let List.527 : List U8 = CallByName List.70 List.106 List.529;
+    let List.526 : List U8 = CallByName List.71 List.527 List.107;
+    ret List.526;
 
-procedure List.49 (List.366, List.367):
-    let List.486 : U64 = StructAtIndex 0 List.367;
-    let List.487 : U64 = 0i64;
-    let List.484 : Int1 = CallByName Bool.11 List.486 List.487;
-    if List.484 then
-        dec List.366;
-        let List.485 : List U8 = Array [];
-        ret List.485;
+procedure List.49 (List.369, List.370):
+    let List.501 : U64 = StructAtIndex 0 List.370;
+    let List.502 : U64 = 0i64;
+    let List.499 : Int1 = CallByName Bool.11 List.501 List.502;
+    if List.499 then
+        dec List.369;
+        let List.500 : List U8 = Array [];
+        ret List.500;
     else
-        let List.481 : U64 = StructAtIndex 1 List.367;
-        let List.482 : U64 = StructAtIndex 0 List.367;
-        let List.480 : List U8 = CallByName List.72 List.366 List.481 List.482;
-        ret List.480;
+        let List.496 : U64 = StructAtIndex 1 List.370;
+        let List.497 : U64 = StructAtIndex 0 List.370;
+        let List.495 : List U8 = CallByName List.72 List.369 List.496 List.497;
+        ret List.495;
 
-procedure List.52 (List.381, List.382):
-    let List.383 : U64 = CallByName List.6 List.381;
-    joinpoint List.509 List.384:
-        let List.507 : U64 = 0i64;
-        let List.506 : {U64, U64} = Struct {List.384, List.507};
-        inc List.381;
-        let List.385 : List U8 = CallByName List.49 List.381 List.506;
-        let List.505 : U64 = CallByName Num.20 List.383 List.384;
-        let List.504 : {U64, U64} = Struct {List.505, List.384};
-        let List.386 : List U8 = CallByName List.49 List.381 List.504;
-        let List.503 : {List U8, List U8} = Struct {List.385, List.386};
-        ret List.503;
+procedure List.52 (List.384, List.385):
+    let List.386 : U64 = CallByName List.6 List.384;
+    joinpoint List.524 List.387:
+        let List.522 : U64 = 0i64;
+        let List.521 : {U64, U64} = Struct {List.387, List.522};
+        inc List.384;
+        let List.388 : List U8 = CallByName List.49 List.384 List.521;
+        let List.520 : U64 = CallByName Num.20 List.386 List.387;
+        let List.519 : {U64, U64} = Struct {List.520, List.387};
+        let List.389 : List U8 = CallByName List.49 List.384 List.519;
+        let List.518 : {List U8, List U8} = Struct {List.388, List.389};
+        ret List.518;
     in
-    let List.510 : Int1 = CallByName Num.24 List.383 List.382;
-    if List.510 then
-        jump List.509 List.382;
+    let List.525 : Int1 = CallByName Num.24 List.386 List.385;
+    if List.525 then
+        jump List.524 List.385;
     else
-        jump List.509 List.383;
+        jump List.524 List.386;
 
 procedure List.6 (#Attr.2):
-    let List.550 : U64 = lowlevel ListLen #Attr.2;
-    ret List.550;
+    let List.565 : U64 = lowlevel ListLen #Attr.2;
+    ret List.565;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.529 : U8 = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.529;
+    let List.544 : U8 = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.544;
 
 procedure List.70 (#Attr.2, #Attr.3):
-    let List.515 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
-    ret List.515;
+    let List.530 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
+    ret List.530;
 
 procedure List.71 (#Attr.2, #Attr.3):
-    let List.513 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
-    ret List.513;
+    let List.528 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
+    ret List.528;
 
 procedure List.72 (#Attr.2, #Attr.3, #Attr.4):
-    let List.483 : List U8 = lowlevel ListSublist #Attr.2 #Attr.3 #Attr.4;
-    ret List.483;
+    let List.498 : List U8 = lowlevel ListSublist #Attr.2 #Attr.3 #Attr.4;
+    ret List.498;
 
-procedure List.9 (List.283):
-    let List.523 : U64 = 0i64;
-    let List.516 : [C {}, C U8] = CallByName List.2 List.283 List.523;
-    let List.520 : U8 = 1i64;
-    let List.521 : U8 = GetTagId List.516;
-    let List.522 : Int1 = lowlevel Eq List.520 List.521;
-    if List.522 then
-        let List.284 : U8 = UnionAtIndex (Id 1) (Index 0) List.516;
-        let List.517 : [C {}, C U8] = TagId(1) List.284;
-        ret List.517;
+procedure List.9 (List.286):
+    let List.538 : U64 = 0i64;
+    let List.531 : [C {}, C U8] = CallByName List.2 List.286 List.538;
+    let List.535 : U8 = 1i64;
+    let List.536 : U8 = GetTagId List.531;
+    let List.537 : Int1 = lowlevel Eq List.535 List.536;
+    if List.537 then
+        let List.287 : U8 = UnionAtIndex (Id 1) (Index 0) List.531;
+        let List.532 : [C {}, C U8] = TagId(1) List.287;
+        ret List.532;
     else
-        let List.519 : {} = Struct {};
-        let List.518 : [C {}, C U8] = TagId(0) List.519;
-        ret List.518;
+        let List.534 : {} = Struct {};
+        let List.533 : [C {}, C U8] = TagId(0) List.534;
+        ret List.533;
 
 procedure Num.20 (#Attr.2, #Attr.3):
     let Num.258 : U64 = lowlevel NumSub #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/list_append.txt
+++ b/crates/compiler/test_mono/generated/list_append.txt
@@ -1,16 +1,16 @@
 procedure List.4 (List.106, List.107):
-    let List.481 : U64 = 1i64;
-    let List.479 : List I64 = CallByName List.70 List.106 List.481;
-    let List.478 : List I64 = CallByName List.71 List.479 List.107;
-    ret List.478;
+    let List.496 : U64 = 1i64;
+    let List.494 : List I64 = CallByName List.70 List.106 List.496;
+    let List.493 : List I64 = CallByName List.71 List.494 List.107;
+    ret List.493;
 
 procedure List.70 (#Attr.2, #Attr.3):
-    let List.482 : List I64 = lowlevel ListReserve #Attr.2 #Attr.3;
-    ret List.482;
+    let List.497 : List I64 = lowlevel ListReserve #Attr.2 #Attr.3;
+    ret List.497;
 
 procedure List.71 (#Attr.2, #Attr.3):
-    let List.480 : List I64 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
-    ret List.480;
+    let List.495 : List I64 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
+    ret List.495;
 
 procedure Test.0 ():
     let Test.2 : List I64 = Array [1i64];

--- a/crates/compiler/test_mono/generated/list_append_closure.txt
+++ b/crates/compiler/test_mono/generated/list_append_closure.txt
@@ -1,16 +1,16 @@
 procedure List.4 (List.106, List.107):
-    let List.481 : U64 = 1i64;
-    let List.479 : List I64 = CallByName List.70 List.106 List.481;
-    let List.478 : List I64 = CallByName List.71 List.479 List.107;
-    ret List.478;
+    let List.496 : U64 = 1i64;
+    let List.494 : List I64 = CallByName List.70 List.106 List.496;
+    let List.493 : List I64 = CallByName List.71 List.494 List.107;
+    ret List.493;
 
 procedure List.70 (#Attr.2, #Attr.3):
-    let List.482 : List I64 = lowlevel ListReserve #Attr.2 #Attr.3;
-    ret List.482;
+    let List.497 : List I64 = lowlevel ListReserve #Attr.2 #Attr.3;
+    ret List.497;
 
 procedure List.71 (#Attr.2, #Attr.3):
-    let List.480 : List I64 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
-    ret List.480;
+    let List.495 : List I64 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
+    ret List.495;
 
 procedure Test.1 (Test.2):
     let Test.6 : I64 = 42i64;

--- a/crates/compiler/test_mono/generated/list_cannot_update_inplace.txt
+++ b/crates/compiler/test_mono/generated/list_cannot_update_inplace.txt
@@ -1,27 +1,27 @@
 procedure List.3 (List.103, List.104, List.105):
-    let List.481 : {List I64, I64} = CallByName List.64 List.103 List.104 List.105;
-    let List.480 : List I64 = StructAtIndex 0 List.481;
-    inc List.480;
-    dec List.481;
-    ret List.480;
+    let List.496 : {List I64, I64} = CallByName List.64 List.103 List.104 List.105;
+    let List.495 : List I64 = StructAtIndex 0 List.496;
+    inc List.495;
+    dec List.496;
+    ret List.495;
 
 procedure List.6 (#Attr.2):
-    let List.479 : U64 = lowlevel ListLen #Attr.2;
-    ret List.479;
+    let List.494 : U64 = lowlevel ListLen #Attr.2;
+    ret List.494;
 
 procedure List.64 (List.100, List.101, List.102):
-    let List.486 : U64 = CallByName List.6 List.100;
-    let List.483 : Int1 = CallByName Num.22 List.101 List.486;
-    if List.483 then
-        let List.484 : {List I64, I64} = CallByName List.67 List.100 List.101 List.102;
-        ret List.484;
+    let List.501 : U64 = CallByName List.6 List.100;
+    let List.498 : Int1 = CallByName Num.22 List.101 List.501;
+    if List.498 then
+        let List.499 : {List I64, I64} = CallByName List.67 List.100 List.101 List.102;
+        ret List.499;
     else
-        let List.482 : {List I64, I64} = Struct {List.100, List.102};
-        ret List.482;
+        let List.497 : {List I64, I64} = Struct {List.100, List.102};
+        ret List.497;
 
 procedure List.67 (#Attr.2, #Attr.3, #Attr.4):
-    let List.485 : {List I64, I64} = lowlevel ListReplaceUnsafe #Attr.2 #Attr.3 #Attr.4;
-    ret List.485;
+    let List.500 : {List I64, I64} = lowlevel ListReplaceUnsafe #Attr.2 #Attr.3 #Attr.4;
+    ret List.500;
 
 procedure Num.19 (#Attr.2, #Attr.3):
     let Num.256 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/list_get.txt
+++ b/crates/compiler/test_mono/generated/list_get.txt
@@ -1,22 +1,22 @@
 procedure List.2 (List.95, List.96):
-    let List.484 : U64 = CallByName List.6 List.95;
-    let List.480 : Int1 = CallByName Num.22 List.96 List.484;
-    if List.480 then
-        let List.482 : I64 = CallByName List.66 List.95 List.96;
-        let List.481 : [C {}, C I64] = TagId(1) List.482;
-        ret List.481;
+    let List.499 : U64 = CallByName List.6 List.95;
+    let List.495 : Int1 = CallByName Num.22 List.96 List.499;
+    if List.495 then
+        let List.497 : I64 = CallByName List.66 List.95 List.96;
+        let List.496 : [C {}, C I64] = TagId(1) List.497;
+        ret List.496;
     else
-        let List.479 : {} = Struct {};
-        let List.478 : [C {}, C I64] = TagId(0) List.479;
-        ret List.478;
+        let List.494 : {} = Struct {};
+        let List.493 : [C {}, C I64] = TagId(0) List.494;
+        ret List.493;
 
 procedure List.6 (#Attr.2):
-    let List.485 : U64 = lowlevel ListLen #Attr.2;
-    ret List.485;
+    let List.500 : U64 = lowlevel ListLen #Attr.2;
+    ret List.500;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.483 : I64 = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.483;
+    let List.498 : I64 = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.498;
 
 procedure Num.22 (#Attr.2, #Attr.3):
     let Num.256 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/list_len.txt
+++ b/crates/compiler/test_mono/generated/list_len.txt
@@ -1,10 +1,10 @@
 procedure List.6 (#Attr.2):
-    let List.478 : U64 = lowlevel ListLen #Attr.2;
-    ret List.478;
+    let List.493 : U64 = lowlevel ListLen #Attr.2;
+    ret List.493;
 
 procedure List.6 (#Attr.2):
-    let List.479 : U64 = lowlevel ListLen #Attr.2;
-    ret List.479;
+    let List.494 : U64 = lowlevel ListLen #Attr.2;
+    ret List.494;
 
 procedure Num.19 (#Attr.2, #Attr.3):
     let Num.256 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/list_map_closure_borrows.txt
+++ b/crates/compiler/test_mono/generated/list_map_closure_borrows.txt
@@ -1,26 +1,26 @@
 procedure List.2 (List.95, List.96):
-    let List.484 : U64 = CallByName List.6 List.95;
-    let List.480 : Int1 = CallByName Num.22 List.96 List.484;
-    if List.480 then
-        let List.482 : Str = CallByName List.66 List.95 List.96;
-        let List.481 : [C {}, C Str] = TagId(1) List.482;
-        ret List.481;
+    let List.499 : U64 = CallByName List.6 List.95;
+    let List.495 : Int1 = CallByName Num.22 List.96 List.499;
+    if List.495 then
+        let List.497 : Str = CallByName List.66 List.95 List.96;
+        let List.496 : [C {}, C Str] = TagId(1) List.497;
+        ret List.496;
     else
-        let List.479 : {} = Struct {};
-        let List.478 : [C {}, C Str] = TagId(0) List.479;
-        ret List.478;
+        let List.494 : {} = Struct {};
+        let List.493 : [C {}, C Str] = TagId(0) List.494;
+        ret List.493;
 
 procedure List.5 (#Attr.2, #Attr.3):
-    let List.486 : List Str = lowlevel ListMap { xs: `#Attr.#arg1` } #Attr.2 Test.3 #Attr.3;
-    ret List.486;
+    let List.501 : List Str = lowlevel ListMap { xs: `#Attr.#arg1` } #Attr.2 Test.3 #Attr.3;
+    ret List.501;
 
 procedure List.6 (#Attr.2):
-    let List.485 : U64 = lowlevel ListLen #Attr.2;
-    ret List.485;
+    let List.500 : U64 = lowlevel ListLen #Attr.2;
+    ret List.500;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.483 : Str = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.483;
+    let List.498 : Str = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.498;
 
 procedure Num.22 (#Attr.2, #Attr.3):
     let Num.256 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/list_map_closure_owns.txt
+++ b/crates/compiler/test_mono/generated/list_map_closure_owns.txt
@@ -1,27 +1,27 @@
 procedure List.2 (List.95, List.96):
-    let List.484 : U64 = CallByName List.6 List.95;
-    let List.480 : Int1 = CallByName Num.22 List.96 List.484;
-    if List.480 then
-        let List.482 : Str = CallByName List.66 List.95 List.96;
-        let List.481 : [C {}, C Str] = TagId(1) List.482;
-        ret List.481;
+    let List.499 : U64 = CallByName List.6 List.95;
+    let List.495 : Int1 = CallByName Num.22 List.96 List.499;
+    if List.495 then
+        let List.497 : Str = CallByName List.66 List.95 List.96;
+        let List.496 : [C {}, C Str] = TagId(1) List.497;
+        ret List.496;
     else
-        let List.479 : {} = Struct {};
-        let List.478 : [C {}, C Str] = TagId(0) List.479;
-        ret List.478;
+        let List.494 : {} = Struct {};
+        let List.493 : [C {}, C Str] = TagId(0) List.494;
+        ret List.493;
 
 procedure List.5 (#Attr.2, #Attr.3):
-    let List.486 : List Str = lowlevel ListMap { xs: `#Attr.#arg1` } #Attr.2 Test.3 #Attr.3;
+    let List.501 : List Str = lowlevel ListMap { xs: `#Attr.#arg1` } #Attr.2 Test.3 #Attr.3;
     decref #Attr.2;
-    ret List.486;
+    ret List.501;
 
 procedure List.6 (#Attr.2):
-    let List.485 : U64 = lowlevel ListLen #Attr.2;
-    ret List.485;
+    let List.500 : U64 = lowlevel ListLen #Attr.2;
+    ret List.500;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.483 : Str = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.483;
+    let List.498 : Str = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.498;
 
 procedure Num.22 (#Attr.2, #Attr.3):
     let Num.256 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/list_map_take_capturing_or_noncapturing.txt
+++ b/crates/compiler/test_mono/generated/list_map_take_capturing_or_noncapturing.txt
@@ -1,24 +1,24 @@
 procedure List.5 (#Attr.2, #Attr.3):
-    let List.479 : U8 = GetTagId #Attr.3;
-    joinpoint List.480 List.478:
-        inc List.478;
-        ret List.478;
+    let List.494 : U8 = GetTagId #Attr.3;
+    joinpoint List.495 List.493:
+        inc List.493;
+        ret List.493;
     in
-    switch List.479:
+    switch List.494:
         case 0:
-            let List.481 : List U8 = lowlevel ListMap { xs: `#Attr.#arg1` } #Attr.2 Test.4 #Attr.3;
+            let List.496 : List U8 = lowlevel ListMap { xs: `#Attr.#arg1` } #Attr.2 Test.4 #Attr.3;
             decref #Attr.2;
-            jump List.480 List.481;
+            jump List.495 List.496;
     
         case 1:
-            let List.482 : List U8 = lowlevel ListMap { xs: `#Attr.#arg1` } #Attr.2 Test.6 #Attr.3;
+            let List.497 : List U8 = lowlevel ListMap { xs: `#Attr.#arg1` } #Attr.2 Test.6 #Attr.3;
             decref #Attr.2;
-            jump List.480 List.482;
+            jump List.495 List.497;
     
         default:
-            let List.483 : List U8 = lowlevel ListMap { xs: `#Attr.#arg1` } #Attr.2 Test.8 #Attr.3;
+            let List.498 : List U8 = lowlevel ListMap { xs: `#Attr.#arg1` } #Attr.2 Test.8 #Attr.3;
             decref #Attr.2;
-            jump List.480 List.483;
+            jump List.495 List.498;
     
 
 procedure Num.19 (#Attr.2, #Attr.3):

--- a/crates/compiler/test_mono/generated/list_pass_to_function.txt
+++ b/crates/compiler/test_mono/generated/list_pass_to_function.txt
@@ -1,27 +1,27 @@
 procedure List.3 (List.103, List.104, List.105):
-    let List.479 : {List I64, I64} = CallByName List.64 List.103 List.104 List.105;
-    let List.478 : List I64 = StructAtIndex 0 List.479;
-    inc List.478;
-    dec List.479;
-    ret List.478;
+    let List.494 : {List I64, I64} = CallByName List.64 List.103 List.104 List.105;
+    let List.493 : List I64 = StructAtIndex 0 List.494;
+    inc List.493;
+    dec List.494;
+    ret List.493;
 
 procedure List.6 (#Attr.2):
-    let List.485 : U64 = lowlevel ListLen #Attr.2;
-    ret List.485;
+    let List.500 : U64 = lowlevel ListLen #Attr.2;
+    ret List.500;
 
 procedure List.64 (List.100, List.101, List.102):
-    let List.484 : U64 = CallByName List.6 List.100;
-    let List.481 : Int1 = CallByName Num.22 List.101 List.484;
-    if List.481 then
-        let List.482 : {List I64, I64} = CallByName List.67 List.100 List.101 List.102;
-        ret List.482;
+    let List.499 : U64 = CallByName List.6 List.100;
+    let List.496 : Int1 = CallByName Num.22 List.101 List.499;
+    if List.496 then
+        let List.497 : {List I64, I64} = CallByName List.67 List.100 List.101 List.102;
+        ret List.497;
     else
-        let List.480 : {List I64, I64} = Struct {List.100, List.102};
-        ret List.480;
+        let List.495 : {List I64, I64} = Struct {List.100, List.102};
+        ret List.495;
 
 procedure List.67 (#Attr.2, #Attr.3, #Attr.4):
-    let List.483 : {List I64, I64} = lowlevel ListReplaceUnsafe #Attr.2 #Attr.3 #Attr.4;
-    ret List.483;
+    let List.498 : {List I64, I64} = lowlevel ListReplaceUnsafe #Attr.2 #Attr.3 #Attr.4;
+    ret List.498;
 
 procedure Num.22 (#Attr.2, #Attr.3):
     let Num.256 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/list_sort_asc.txt
+++ b/crates/compiler/test_mono/generated/list_sort_asc.txt
@@ -1,16 +1,16 @@
 procedure List.28 (#Attr.2, #Attr.3):
-    let List.480 : List I64 = lowlevel ListSortWith { xs: `#Attr.#arg1` } #Attr.2 Num.46 #Attr.3;
+    let List.495 : List I64 = lowlevel ListSortWith { xs: `#Attr.#arg1` } #Attr.2 Num.46 #Attr.3;
     let #Derived_gen.0 : Int1 = lowlevel ListIsUnique #Attr.2;
     if #Derived_gen.0 then
-        ret List.480;
+        ret List.495;
     else
         decref #Attr.2;
-        ret List.480;
+        ret List.495;
 
-procedure List.59 (List.278):
-    let List.479 : {} = Struct {};
-    let List.478 : List I64 = CallByName List.28 List.278 List.479;
-    ret List.478;
+procedure List.59 (List.281):
+    let List.494 : {} = Struct {};
+    let List.493 : List I64 = CallByName List.28 List.281 List.494;
+    ret List.493;
 
 procedure Num.46 (#Attr.2, #Attr.3):
     let Num.256 : U8 = lowlevel NumCompare #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/quicksort_swap.txt
+++ b/crates/compiler/test_mono/generated/quicksort_swap.txt
@@ -1,43 +1,43 @@
 procedure List.2 (List.95, List.96):
-    let List.500 : U64 = CallByName List.6 List.95;
-    let List.497 : Int1 = CallByName Num.22 List.96 List.500;
-    if List.497 then
-        let List.499 : I64 = CallByName List.66 List.95 List.96;
-        let List.498 : [C {}, C I64] = TagId(1) List.499;
-        ret List.498;
+    let List.515 : U64 = CallByName List.6 List.95;
+    let List.512 : Int1 = CallByName Num.22 List.96 List.515;
+    if List.512 then
+        let List.514 : I64 = CallByName List.66 List.95 List.96;
+        let List.513 : [C {}, C I64] = TagId(1) List.514;
+        ret List.513;
     else
-        let List.496 : {} = Struct {};
-        let List.495 : [C {}, C I64] = TagId(0) List.496;
-        ret List.495;
+        let List.511 : {} = Struct {};
+        let List.510 : [C {}, C I64] = TagId(0) List.511;
+        ret List.510;
 
 procedure List.3 (List.103, List.104, List.105):
-    let List.487 : {List I64, I64} = CallByName List.64 List.103 List.104 List.105;
-    let List.486 : List I64 = StructAtIndex 0 List.487;
-    inc List.486;
-    dec List.487;
-    ret List.486;
+    let List.502 : {List I64, I64} = CallByName List.64 List.103 List.104 List.105;
+    let List.501 : List I64 = StructAtIndex 0 List.502;
+    inc List.501;
+    dec List.502;
+    ret List.501;
 
 procedure List.6 (#Attr.2):
-    let List.485 : U64 = lowlevel ListLen #Attr.2;
-    ret List.485;
+    let List.500 : U64 = lowlevel ListLen #Attr.2;
+    ret List.500;
 
 procedure List.64 (List.100, List.101, List.102):
-    let List.484 : U64 = CallByName List.6 List.100;
-    let List.481 : Int1 = CallByName Num.22 List.101 List.484;
-    if List.481 then
-        let List.482 : {List I64, I64} = CallByName List.67 List.100 List.101 List.102;
-        ret List.482;
+    let List.499 : U64 = CallByName List.6 List.100;
+    let List.496 : Int1 = CallByName Num.22 List.101 List.499;
+    if List.496 then
+        let List.497 : {List I64, I64} = CallByName List.67 List.100 List.101 List.102;
+        ret List.497;
     else
-        let List.480 : {List I64, I64} = Struct {List.100, List.102};
-        ret List.480;
+        let List.495 : {List I64, I64} = Struct {List.100, List.102};
+        ret List.495;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.493 : I64 = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.493;
+    let List.508 : I64 = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.508;
 
 procedure List.67 (#Attr.2, #Attr.3, #Attr.4):
-    let List.483 : {List I64, I64} = lowlevel ListReplaceUnsafe #Attr.2 #Attr.3 #Attr.4;
-    ret List.483;
+    let List.498 : {List I64, I64} = lowlevel ListReplaceUnsafe #Attr.2 #Attr.3 #Attr.4;
+    ret List.498;
 
 procedure Num.22 (#Attr.2, #Attr.3):
     let Num.258 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/rigids.txt
+++ b/crates/compiler/test_mono/generated/rigids.txt
@@ -1,43 +1,43 @@
 procedure List.2 (List.95, List.96):
-    let List.500 : U64 = CallByName List.6 List.95;
-    let List.497 : Int1 = CallByName Num.22 List.96 List.500;
-    if List.497 then
-        let List.499 : I64 = CallByName List.66 List.95 List.96;
-        let List.498 : [C {}, C I64] = TagId(1) List.499;
-        ret List.498;
+    let List.515 : U64 = CallByName List.6 List.95;
+    let List.512 : Int1 = CallByName Num.22 List.96 List.515;
+    if List.512 then
+        let List.514 : I64 = CallByName List.66 List.95 List.96;
+        let List.513 : [C {}, C I64] = TagId(1) List.514;
+        ret List.513;
     else
-        let List.496 : {} = Struct {};
-        let List.495 : [C {}, C I64] = TagId(0) List.496;
-        ret List.495;
+        let List.511 : {} = Struct {};
+        let List.510 : [C {}, C I64] = TagId(0) List.511;
+        ret List.510;
 
 procedure List.3 (List.103, List.104, List.105):
-    let List.487 : {List I64, I64} = CallByName List.64 List.103 List.104 List.105;
-    let List.486 : List I64 = StructAtIndex 0 List.487;
-    inc List.486;
-    dec List.487;
-    ret List.486;
+    let List.502 : {List I64, I64} = CallByName List.64 List.103 List.104 List.105;
+    let List.501 : List I64 = StructAtIndex 0 List.502;
+    inc List.501;
+    dec List.502;
+    ret List.501;
 
 procedure List.6 (#Attr.2):
-    let List.485 : U64 = lowlevel ListLen #Attr.2;
-    ret List.485;
+    let List.500 : U64 = lowlevel ListLen #Attr.2;
+    ret List.500;
 
 procedure List.64 (List.100, List.101, List.102):
-    let List.484 : U64 = CallByName List.6 List.100;
-    let List.481 : Int1 = CallByName Num.22 List.101 List.484;
-    if List.481 then
-        let List.482 : {List I64, I64} = CallByName List.67 List.100 List.101 List.102;
-        ret List.482;
+    let List.499 : U64 = CallByName List.6 List.100;
+    let List.496 : Int1 = CallByName Num.22 List.101 List.499;
+    if List.496 then
+        let List.497 : {List I64, I64} = CallByName List.67 List.100 List.101 List.102;
+        ret List.497;
     else
-        let List.480 : {List I64, I64} = Struct {List.100, List.102};
-        ret List.480;
+        let List.495 : {List I64, I64} = Struct {List.100, List.102};
+        ret List.495;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.493 : I64 = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.493;
+    let List.508 : I64 = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.508;
 
 procedure List.67 (#Attr.2, #Attr.3, #Attr.4):
-    let List.483 : {List I64, I64} = lowlevel ListReplaceUnsafe #Attr.2 #Attr.3 #Attr.4;
-    ret List.483;
+    let List.498 : {List I64, I64} = lowlevel ListReplaceUnsafe #Attr.2 #Attr.3 #Attr.4;
+    ret List.498;
 
 procedure Num.22 (#Attr.2, #Attr.3):
     let Num.258 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/unspecialized_lambda_set_unification_does_not_duplicate_identical_concrete_types.txt
+++ b/crates/compiler/test_mono/generated/unspecialized_lambda_set_unification_does_not_duplicate_identical_concrete_types.txt
@@ -116,58 +116,58 @@ procedure Json.96 (Json.97, Json.443, Json.95):
     ret Json.445;
 
 procedure List.138 (List.139, List.140, List.137):
-    let List.529 : {List U8, U64} = CallByName Json.128 List.139 List.140;
-    ret List.529;
+    let List.544 : {List U8, U64} = CallByName Json.128 List.139 List.140;
+    ret List.544;
 
 procedure List.18 (List.135, List.136, List.137):
-    let List.510 : {List U8, U64} = CallByName List.91 List.135 List.136 List.137;
-    ret List.510;
+    let List.525 : {List U8, U64} = CallByName List.91 List.135 List.136 List.137;
+    ret List.525;
 
 procedure List.4 (List.106, List.107):
-    let List.509 : U64 = 1i64;
-    let List.508 : List U8 = CallByName List.70 List.106 List.509;
-    let List.507 : List U8 = CallByName List.71 List.508 List.107;
-    ret List.507;
+    let List.524 : U64 = 1i64;
+    let List.523 : List U8 = CallByName List.70 List.106 List.524;
+    let List.522 : List U8 = CallByName List.71 List.523 List.107;
+    ret List.522;
 
 procedure List.6 (#Attr.2):
-    let List.530 : U64 = lowlevel ListLen #Attr.2;
-    ret List.530;
+    let List.545 : U64 = lowlevel ListLen #Attr.2;
+    ret List.545;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.526 : Str = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.526;
+    let List.541 : Str = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.541;
 
 procedure List.70 (#Attr.2, #Attr.3):
-    let List.482 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
-    ret List.482;
+    let List.497 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
+    ret List.497;
 
 procedure List.71 (#Attr.2, #Attr.3):
-    let List.480 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
-    ret List.480;
+    let List.495 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
+    ret List.495;
 
 procedure List.8 (#Attr.2, #Attr.3):
-    let List.532 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
-    ret List.532;
+    let List.547 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
+    ret List.547;
 
-procedure List.80 (List.542, List.543, List.544, List.545, List.546):
-    joinpoint List.516 List.429 List.430 List.431 List.432 List.433:
-        let List.518 : Int1 = CallByName Num.22 List.432 List.433;
-        if List.518 then
-            let List.525 : Str = CallByName List.66 List.429 List.432;
-            let List.519 : {List U8, U64} = CallByName List.138 List.430 List.525 List.431;
-            let List.522 : U64 = 1i64;
-            let List.521 : U64 = CallByName Num.19 List.432 List.522;
-            jump List.516 List.429 List.519 List.431 List.521 List.433;
+procedure List.80 (List.557, List.558, List.559, List.560, List.561):
+    joinpoint List.531 List.432 List.433 List.434 List.435 List.436:
+        let List.533 : Int1 = CallByName Num.22 List.435 List.436;
+        if List.533 then
+            let List.540 : Str = CallByName List.66 List.432 List.435;
+            let List.534 : {List U8, U64} = CallByName List.138 List.433 List.540 List.434;
+            let List.537 : U64 = 1i64;
+            let List.536 : U64 = CallByName Num.19 List.435 List.537;
+            jump List.531 List.432 List.534 List.434 List.536 List.436;
         else
-            ret List.430;
+            ret List.433;
     in
-    jump List.516 List.542 List.543 List.544 List.545 List.546;
+    jump List.531 List.557 List.558 List.559 List.560 List.561;
 
-procedure List.91 (List.426, List.427, List.428):
-    let List.514 : U64 = 0i64;
-    let List.515 : U64 = CallByName List.6 List.426;
-    let List.513 : {List U8, U64} = CallByName List.80 List.426 List.427 List.428 List.514 List.515;
-    ret List.513;
+procedure List.91 (List.429, List.430, List.431):
+    let List.529 : U64 = 0i64;
+    let List.530 : U64 = CallByName List.6 List.429;
+    let List.528 : {List U8, U64} = CallByName List.80 List.429 List.430 List.431 List.529 List.530;
+    ret List.528;
 
 procedure Num.125 (#Attr.2):
     let Num.265 : U8 = lowlevel NumIntCast #Attr.2;

--- a/crates/compiler/test_mono/generated/unspecialized_lambda_set_unification_keeps_all_concrete_types_without_unification_of_unifiable.txt
+++ b/crates/compiler/test_mono/generated/unspecialized_lambda_set_unification_keeps_all_concrete_types_without_unification_of_unifiable.txt
@@ -223,94 +223,94 @@ procedure Json.21 (Json.124, Json.125):
     ret Json.488;
 
 procedure List.138 (List.139, List.140, List.137):
-    let List.523 : {List U8, U64} = CallByName Json.128 List.139 List.140;
-    ret List.523;
+    let List.538 : {List U8, U64} = CallByName Json.128 List.139 List.140;
+    ret List.538;
 
 procedure List.138 (List.139, List.140, List.137):
-    let List.596 : {List U8, U64} = CallByName Json.128 List.139 List.140;
-    ret List.596;
+    let List.611 : {List U8, U64} = CallByName Json.128 List.139 List.140;
+    ret List.611;
 
 procedure List.18 (List.135, List.136, List.137):
-    let List.504 : {List U8, U64} = CallByName List.91 List.135 List.136 List.137;
-    ret List.504;
+    let List.519 : {List U8, U64} = CallByName List.91 List.135 List.136 List.137;
+    ret List.519;
 
 procedure List.18 (List.135, List.136, List.137):
-    let List.577 : {List U8, U64} = CallByName List.91 List.135 List.136 List.137;
-    ret List.577;
+    let List.592 : {List U8, U64} = CallByName List.91 List.135 List.136 List.137;
+    ret List.592;
 
 procedure List.4 (List.106, List.107):
-    let List.576 : U64 = 1i64;
-    let List.575 : List U8 = CallByName List.70 List.106 List.576;
-    let List.574 : List U8 = CallByName List.71 List.575 List.107;
-    ret List.574;
+    let List.591 : U64 = 1i64;
+    let List.590 : List U8 = CallByName List.70 List.106 List.591;
+    let List.589 : List U8 = CallByName List.71 List.590 List.107;
+    ret List.589;
 
 procedure List.6 (#Attr.2):
-    let List.524 : U64 = lowlevel ListLen #Attr.2;
-    ret List.524;
+    let List.539 : U64 = lowlevel ListLen #Attr.2;
+    ret List.539;
 
 procedure List.6 (#Attr.2):
-    let List.597 : U64 = lowlevel ListLen #Attr.2;
-    ret List.597;
+    let List.612 : U64 = lowlevel ListLen #Attr.2;
+    ret List.612;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.520 : [C {}, C {}] = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.520;
+    let List.535 : [C {}, C {}] = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.535;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.593 : [] = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.593;
+    let List.608 : [] = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.608;
 
 procedure List.70 (#Attr.2, #Attr.3):
-    let List.555 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
-    ret List.555;
+    let List.570 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
+    ret List.570;
 
 procedure List.71 (#Attr.2, #Attr.3):
-    let List.553 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
-    ret List.553;
+    let List.568 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
+    ret List.568;
 
 procedure List.8 (#Attr.2, #Attr.3):
-    let List.598 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
-    ret List.598;
+    let List.613 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
+    ret List.613;
 
-procedure List.80 (List.535, List.536, List.537, List.538, List.539):
-    joinpoint List.510 List.429 List.430 List.431 List.432 List.433:
-        let List.512 : Int1 = CallByName Num.22 List.432 List.433;
-        if List.512 then
-            let List.519 : [C {}, C {}] = CallByName List.66 List.429 List.432;
-            let List.513 : {List U8, U64} = CallByName List.138 List.430 List.519 List.431;
-            let List.516 : U64 = 1i64;
-            let List.515 : U64 = CallByName Num.19 List.432 List.516;
-            jump List.510 List.429 List.513 List.431 List.515 List.433;
+procedure List.80 (List.550, List.551, List.552, List.553, List.554):
+    joinpoint List.525 List.432 List.433 List.434 List.435 List.436:
+        let List.527 : Int1 = CallByName Num.22 List.435 List.436;
+        if List.527 then
+            let List.534 : [C {}, C {}] = CallByName List.66 List.432 List.435;
+            let List.528 : {List U8, U64} = CallByName List.138 List.433 List.534 List.434;
+            let List.531 : U64 = 1i64;
+            let List.530 : U64 = CallByName Num.19 List.435 List.531;
+            jump List.525 List.432 List.528 List.434 List.530 List.436;
         else
-            ret List.430;
+            ret List.433;
     in
-    jump List.510 List.535 List.536 List.537 List.538 List.539;
+    jump List.525 List.550 List.551 List.552 List.553 List.554;
 
-procedure List.80 (List.608, List.609, List.610, List.611, List.612):
-    joinpoint List.583 List.429 List.430 List.431 List.432 List.433:
-        let List.585 : Int1 = CallByName Num.22 List.432 List.433;
-        if List.585 then
-            let List.592 : [] = CallByName List.66 List.429 List.432;
-            let List.586 : {List U8, U64} = CallByName List.138 List.430 List.592 List.431;
-            let List.589 : U64 = 1i64;
-            let List.588 : U64 = CallByName Num.19 List.432 List.589;
-            jump List.583 List.429 List.586 List.431 List.588 List.433;
+procedure List.80 (List.623, List.624, List.625, List.626, List.627):
+    joinpoint List.598 List.432 List.433 List.434 List.435 List.436:
+        let List.600 : Int1 = CallByName Num.22 List.435 List.436;
+        if List.600 then
+            let List.607 : [] = CallByName List.66 List.432 List.435;
+            let List.601 : {List U8, U64} = CallByName List.138 List.433 List.607 List.434;
+            let List.604 : U64 = 1i64;
+            let List.603 : U64 = CallByName Num.19 List.435 List.604;
+            jump List.598 List.432 List.601 List.434 List.603 List.436;
         else
-            ret List.430;
+            ret List.433;
     in
-    jump List.583 List.608 List.609 List.610 List.611 List.612;
+    jump List.598 List.623 List.624 List.625 List.626 List.627;
 
-procedure List.91 (List.426, List.427, List.428):
-    let List.508 : U64 = 0i64;
-    let List.509 : U64 = CallByName List.6 List.426;
-    let List.507 : {List U8, U64} = CallByName List.80 List.426 List.427 List.428 List.508 List.509;
-    ret List.507;
+procedure List.91 (List.429, List.430, List.431):
+    let List.523 : U64 = 0i64;
+    let List.524 : U64 = CallByName List.6 List.429;
+    let List.522 : {List U8, U64} = CallByName List.80 List.429 List.430 List.431 List.523 List.524;
+    ret List.522;
 
-procedure List.91 (List.426, List.427, List.428):
-    let List.581 : U64 = 0i64;
-    let List.582 : U64 = CallByName List.6 List.426;
-    let List.580 : {List U8, U64} = CallByName List.80 List.426 List.427 List.428 List.581 List.582;
-    ret List.580;
+procedure List.91 (List.429, List.430, List.431):
+    let List.596 : U64 = 0i64;
+    let List.597 : U64 = CallByName List.6 List.429;
+    let List.595 : {List U8, U64} = CallByName List.80 List.429 List.430 List.431 List.596 List.597;
+    ret List.595;
 
 procedure Num.125 (#Attr.2):
     let Num.284 : U8 = lowlevel NumIntCast #Attr.2;

--- a/crates/compiler/test_mono/generated/weakening_avoids_overspecialization.txt
+++ b/crates/compiler/test_mono/generated/weakening_avoids_overspecialization.txt
@@ -3,85 +3,85 @@ procedure Bool.11 (#Attr.2, #Attr.3):
     ret Bool.24;
 
 procedure List.26 (List.152, List.153, List.154):
-    let List.493 : [C U64, C U64] = CallByName List.91 List.152 List.153 List.154;
-    let List.496 : U8 = 1i64;
-    let List.497 : U8 = GetTagId List.493;
-    let List.498 : Int1 = lowlevel Eq List.496 List.497;
-    if List.498 then
-        let List.155 : U64 = UnionAtIndex (Id 1) (Index 0) List.493;
+    let List.508 : [C U64, C U64] = CallByName List.91 List.152 List.153 List.154;
+    let List.511 : U8 = 1i64;
+    let List.512 : U8 = GetTagId List.508;
+    let List.513 : Int1 = lowlevel Eq List.511 List.512;
+    if List.513 then
+        let List.155 : U64 = UnionAtIndex (Id 1) (Index 0) List.508;
         ret List.155;
     else
-        let List.156 : U64 = UnionAtIndex (Id 0) (Index 0) List.493;
+        let List.156 : U64 = UnionAtIndex (Id 0) (Index 0) List.508;
         ret List.156;
 
-procedure List.29 (List.294, List.295):
-    let List.492 : U64 = CallByName List.6 List.294;
-    let List.296 : U64 = CallByName Num.77 List.492 List.295;
-    let List.478 : List U8 = CallByName List.43 List.294 List.296;
-    ret List.478;
+procedure List.29 (List.297, List.298):
+    let List.507 : U64 = CallByName List.6 List.297;
+    let List.299 : U64 = CallByName Num.77 List.507 List.298;
+    let List.493 : List U8 = CallByName List.43 List.297 List.299;
+    ret List.493;
 
-procedure List.43 (List.292, List.293):
-    let List.490 : U64 = CallByName List.6 List.292;
-    let List.489 : U64 = CallByName Num.77 List.490 List.293;
-    let List.480 : {U64, U64} = Struct {List.293, List.489};
-    let List.479 : List U8 = CallByName List.49 List.292 List.480;
-    ret List.479;
+procedure List.43 (List.295, List.296):
+    let List.505 : U64 = CallByName List.6 List.295;
+    let List.504 : U64 = CallByName Num.77 List.505 List.296;
+    let List.495 : {U64, U64} = Struct {List.296, List.504};
+    let List.494 : List U8 = CallByName List.49 List.295 List.495;
+    ret List.494;
 
-procedure List.49 (List.366, List.367):
-    let List.487 : U64 = StructAtIndex 0 List.367;
-    let List.488 : U64 = 0i64;
-    let List.485 : Int1 = CallByName Bool.11 List.487 List.488;
-    if List.485 then
-        dec List.366;
-        let List.486 : List U8 = Array [];
-        ret List.486;
+procedure List.49 (List.369, List.370):
+    let List.502 : U64 = StructAtIndex 0 List.370;
+    let List.503 : U64 = 0i64;
+    let List.500 : Int1 = CallByName Bool.11 List.502 List.503;
+    if List.500 then
+        dec List.369;
+        let List.501 : List U8 = Array [];
+        ret List.501;
     else
-        let List.482 : U64 = StructAtIndex 1 List.367;
-        let List.483 : U64 = StructAtIndex 0 List.367;
-        let List.481 : List U8 = CallByName List.72 List.366 List.482 List.483;
-        ret List.481;
+        let List.497 : U64 = StructAtIndex 1 List.370;
+        let List.498 : U64 = StructAtIndex 0 List.370;
+        let List.496 : List U8 = CallByName List.72 List.369 List.497 List.498;
+        ret List.496;
 
 procedure List.6 (#Attr.2):
-    let List.491 : U64 = lowlevel ListLen #Attr.2;
-    ret List.491;
+    let List.506 : U64 = lowlevel ListLen #Attr.2;
+    ret List.506;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.514 : U8 = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.514;
+    let List.529 : U8 = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.529;
 
 procedure List.72 (#Attr.2, #Attr.3, #Attr.4):
-    let List.484 : List U8 = lowlevel ListSublist #Attr.2 #Attr.3 #Attr.4;
-    ret List.484;
-
-procedure List.80 (List.528, List.529, List.530, List.531, List.532):
-    joinpoint List.502 List.429 List.430 List.431 List.432 List.433:
-        let List.504 : Int1 = CallByName Num.22 List.432 List.433;
-        if List.504 then
-            let List.513 : U8 = CallByName List.66 List.429 List.432;
-            let List.505 : [C U64, C U64] = CallByName Test.3 List.430 List.513;
-            let List.510 : U8 = 1i64;
-            let List.511 : U8 = GetTagId List.505;
-            let List.512 : Int1 = lowlevel Eq List.510 List.511;
-            if List.512 then
-                let List.434 : U64 = UnionAtIndex (Id 1) (Index 0) List.505;
-                let List.508 : U64 = 1i64;
-                let List.507 : U64 = CallByName Num.19 List.432 List.508;
-                jump List.502 List.429 List.434 List.431 List.507 List.433;
-            else
-                let List.435 : U64 = UnionAtIndex (Id 0) (Index 0) List.505;
-                let List.509 : [C U64, C U64] = TagId(0) List.435;
-                ret List.509;
-        else
-            let List.503 : [C U64, C U64] = TagId(1) List.430;
-            ret List.503;
-    in
-    jump List.502 List.528 List.529 List.530 List.531 List.532;
-
-procedure List.91 (List.426, List.427, List.428):
-    let List.500 : U64 = 0i64;
-    let List.501 : U64 = CallByName List.6 List.426;
-    let List.499 : [C U64, C U64] = CallByName List.80 List.426 List.427 List.428 List.500 List.501;
+    let List.499 : List U8 = lowlevel ListSublist #Attr.2 #Attr.3 #Attr.4;
     ret List.499;
+
+procedure List.80 (List.543, List.544, List.545, List.546, List.547):
+    joinpoint List.517 List.432 List.433 List.434 List.435 List.436:
+        let List.519 : Int1 = CallByName Num.22 List.435 List.436;
+        if List.519 then
+            let List.528 : U8 = CallByName List.66 List.432 List.435;
+            let List.520 : [C U64, C U64] = CallByName Test.3 List.433 List.528;
+            let List.525 : U8 = 1i64;
+            let List.526 : U8 = GetTagId List.520;
+            let List.527 : Int1 = lowlevel Eq List.525 List.526;
+            if List.527 then
+                let List.437 : U64 = UnionAtIndex (Id 1) (Index 0) List.520;
+                let List.523 : U64 = 1i64;
+                let List.522 : U64 = CallByName Num.19 List.435 List.523;
+                jump List.517 List.432 List.437 List.434 List.522 List.436;
+            else
+                let List.438 : U64 = UnionAtIndex (Id 0) (Index 0) List.520;
+                let List.524 : [C U64, C U64] = TagId(0) List.438;
+                ret List.524;
+        else
+            let List.518 : [C U64, C U64] = TagId(1) List.433;
+            ret List.518;
+    in
+    jump List.517 List.543 List.544 List.545 List.546 List.547;
+
+procedure List.91 (List.429, List.430, List.431):
+    let List.515 : U64 = 0i64;
+    let List.516 : U64 = CallByName List.6 List.429;
+    let List.514 : [C U64, C U64] = CallByName List.80 List.429 List.430 List.431 List.515 List.516;
+    ret List.514;
 
 procedure Num.19 (#Attr.2, #Attr.3):
     let Num.258 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;


### PR DESCRIPTION
Now it will only crash when using Length in an invalid way. `At`, `After` and `Before` when used without `Length` will never crash.