### PR TITLE
Seamless slices for Lists

### DIFF
--- a/crates/cli/tests/fixtures/multi-dep-str/platform/host.zig
+++ b/crates/cli/tests/fixtures/multi-dep-str/platform/host.zig
@@ -115,7 +115,7 @@ pub export fn main() i32 {
     // stdout the result
     stdout.print("{s}\n", .{callresult.asSlice()}) catch unreachable;
 
-    callresult.deinit();
+    callresult.decref();
 
     stderr.print("runtime: {d:.3}ms\n", .{seconds * 1000}) catch unreachable;
 

--- a/crates/cli/tests/fixtures/multi-dep-thunk/platform/host.zig
+++ b/crates/cli/tests/fixtures/multi-dep-thunk/platform/host.zig
@@ -114,7 +114,7 @@ pub export fn main() i32 {
     // stdout the result
     stdout.print("{s}\n", .{callresult.asSlice()}) catch unreachable;
 
-    callresult.deinit();
+    callresult.decref();
 
     stderr.print("runtime: {d:.3}ms\n", .{seconds * 1000}) catch unreachable;
 

--- a/crates/cli/tests/fixtures/packages/platform/host.zig
+++ b/crates/cli/tests/fixtures/packages/platform/host.zig
@@ -115,7 +115,7 @@ pub export fn main() i32 {
     // stdout the result
     stdout.print("{s}\n", .{callresult.asSlice()}) catch unreachable;
 
-    callresult.deinit();
+    callresult.decref();
 
     stderr.print("runtime: {d:.3}ms\n", .{seconds * 1000}) catch unreachable;
 

--- a/crates/cli_testing_examples/expects/zig-platform/host.zig
+++ b/crates/cli_testing_examples/expects/zig-platform/host.zig
@@ -134,7 +134,7 @@ pub fn main() u8 {
     // stdout the result
     stdout.print("{s}", .{callresult.asSlice()}) catch unreachable;
 
-    callresult.deinit();
+    callresult.decref();
 
     stderr.print("runtime: {d:.3}ms\n", .{seconds * 1000}) catch unreachable;
 

--- a/crates/compiler/builtins/bitcode/src/dec.zig
+++ b/crates/compiler/builtins/bitcode/src/dec.zig
@@ -921,8 +921,8 @@ test "toStr: 123.1111111" {
 test "toStr: 123.1111111111111 (big str)" {
     var dec: RocDec = .{ .num = 123111111111111000000 };
     var res_roc_str = dec.toStr();
-    errdefer res_roc_str.deinit();
-    defer res_roc_str.deinit();
+    errdefer res_roc_str.decref();
+    defer res_roc_str.decref();
 
     const res_slice: []const u8 = "123.111111111111"[0..];
     try expectEqualSlices(u8, res_slice, res_roc_str.asSlice());
@@ -931,8 +931,8 @@ test "toStr: 123.1111111111111 (big str)" {
 test "toStr: 123.111111111111444444 (max number of decimal places)" {
     var dec: RocDec = .{ .num = 123111111111111444444 };
     var res_roc_str = dec.toStr();
-    errdefer res_roc_str.deinit();
-    defer res_roc_str.deinit();
+    errdefer res_roc_str.decref();
+    defer res_roc_str.decref();
 
     const res_slice: []const u8 = "123.111111111111444444"[0..];
     try expectEqualSlices(u8, res_slice, res_roc_str.asSlice());
@@ -941,8 +941,8 @@ test "toStr: 123.111111111111444444 (max number of decimal places)" {
 test "toStr: 12345678912345678912.111111111111111111 (max number of digits)" {
     var dec: RocDec = .{ .num = 12345678912345678912111111111111111111 };
     var res_roc_str = dec.toStr();
-    errdefer res_roc_str.deinit();
-    defer res_roc_str.deinit();
+    errdefer res_roc_str.decref();
+    defer res_roc_str.decref();
 
     const res_slice: []const u8 = "12345678912345678912.111111111111111111"[0..];
     try expectEqualSlices(u8, res_slice, res_roc_str.asSlice());
@@ -951,8 +951,8 @@ test "toStr: 12345678912345678912.111111111111111111 (max number of digits)" {
 test "toStr: std.math.maxInt" {
     var dec: RocDec = .{ .num = std.math.maxInt(i128) };
     var res_roc_str = dec.toStr();
-    errdefer res_roc_str.deinit();
-    defer res_roc_str.deinit();
+    errdefer res_roc_str.decref();
+    defer res_roc_str.decref();
 
     const res_slice: []const u8 = "170141183460469231731.687303715884105727"[0..];
     try expectEqualSlices(u8, res_slice, res_roc_str.asSlice());
@@ -961,8 +961,8 @@ test "toStr: std.math.maxInt" {
 test "toStr: std.math.minInt" {
     var dec: RocDec = .{ .num = std.math.minInt(i128) };
     var res_roc_str = dec.toStr();
-    errdefer res_roc_str.deinit();
-    defer res_roc_str.deinit();
+    errdefer res_roc_str.decref();
+    defer res_roc_str.decref();
 
     const res_slice: []const u8 = "-170141183460469231731.687303715884105728"[0..];
     try expectEqualSlices(u8, res_slice, res_roc_str.asSlice());
@@ -1047,8 +1047,8 @@ test "div: 10 / 3" {
     var denom: RocDec = RocDec.fromU64(3);
 
     var roc_str = RocStr.init("3.333333333333333333", 20);
-    errdefer roc_str.deinit();
-    defer roc_str.deinit();
+    errdefer roc_str.decref();
+    defer roc_str.decref();
 
     var res: RocDec = RocDec.fromStr(roc_str).?;
 

--- a/crates/compiler/builtins/bitcode/src/list.zig
+++ b/crates/compiler/builtins/bitcode/src/list.zig
@@ -87,6 +87,9 @@ pub const RocList = extern struct {
     }
 
     pub fn decref(self: RocList, alignment: u32) void {
+        // TODO: I am pretty sure there is a way to do this without a branch.
+        // Bit manipulation should be able to conditionally select the correct pointer.
+        // If this is updated, we should also update decref in build_list.rs and modify_refcount_list from refcounting.rs
         if (self.isSeamlessSlice()) {
             const ref_ptr = @intToPtr([*]isize, self.capacity_or_ref_ptr << 1);
             utils.decref_ptr_to_refcount(ref_ptr, alignment);

--- a/crates/compiler/builtins/bitcode/src/list.zig
+++ b/crates/compiler/builtins/bitcode/src/list.zig
@@ -18,7 +18,7 @@ const HasTagId = fn (u16, ?[*]u8) callconv(.C) extern struct { matched: bool, da
 pub const RocList = extern struct {
     bytes: ?[*]u8,
     length: usize,
-    capacityOrRefPtr: usize,
+    capacity_or_ref_ptr: usize,
 
     pub inline fn len(self: RocList) usize {
         return self.length;
@@ -26,13 +26,13 @@ pub const RocList = extern struct {
 
     pub fn getCapacity(self: RocList) usize {
         if (!self.isSeamlessSlice()) {
-            return self.capacityOrRefPtr;
+            return self.capacity_or_ref_ptr;
         }
         return self.length;
     }
 
     pub fn isSeamlessSlice(self: RocList) bool {
-        return @bitCast(isize, self.capacityOrRefPtr) < 0;
+        return @bitCast(isize, self.capacity_or_ref_ptr) < 0;
     }
 
     pub fn isEmpty(self: RocList) bool {
@@ -40,7 +40,7 @@ pub const RocList = extern struct {
     }
 
     pub fn empty() RocList {
-        return RocList{ .bytes = null, .length = 0, .capacityOrRefPtr = 0 };
+        return RocList{ .bytes = null, .length = 0, .capacity_or_ref_ptr = 0 };
     }
 
     pub fn eql(self: RocList, other: RocList) bool {
@@ -88,7 +88,7 @@ pub const RocList = extern struct {
 
     pub fn decref(self: RocList, alignment: u32) void {
         if (self.isSeamlessSlice()) {
-            const ref_ptr = @intToPtr([*]isize, self.capacityOrRefPtr << 1);
+            const ref_ptr = @intToPtr([*]isize, self.capacity_or_ref_ptr << 1);
             utils.decref_ptr_to_refcount(ref_ptr, alignment);
         } else {
             utils.decref(self.bytes, self.getCapacity(), alignment);
@@ -163,7 +163,7 @@ pub const RocList = extern struct {
         return RocList{
             .bytes = utils.allocateWithRefcount(data_bytes, alignment),
             .length = length,
-            .capacityOrRefPtr = capacity,
+            .capacity_or_ref_ptr = capacity,
         };
     }
 
@@ -177,11 +177,11 @@ pub const RocList = extern struct {
             if (self.isUnique() and !self.isSeamlessSlice()) {
                 const capacity = self.getCapacity();
                 if (capacity >= new_length) {
-                    return RocList{ .bytes = self.bytes, .length = new_length, .capacityOrRefPtr = capacity };
+                    return RocList{ .bytes = self.bytes, .length = new_length, .capacity_or_ref_ptr = capacity };
                 } else {
                     const new_capacity = utils.calculateCapacity(capacity, new_length, element_width);
                     const new_source = utils.unsafeReallocate(source_ptr, alignment, capacity, new_capacity, element_width);
-                    return RocList{ .bytes = new_source, .length = new_length, .capacityOrRefPtr = new_capacity };
+                    return RocList{ .bytes = new_source, .length = new_length, .capacity_or_ref_ptr = new_capacity };
                 }
             }
             return self.reallocateFresh(alignment, new_length, element_width);
@@ -585,7 +585,7 @@ pub fn listSublist(
                 return RocList{
                     .bytes = source_ptr + start * element_width,
                     .length = keep_len,
-                    .capacityOrRefPtr = list.capacityOrRefPtr,
+                    .capacity_or_ref_ptr = list.capacity_or_ref_ptr,
                 };
             }
 
@@ -596,7 +596,7 @@ pub fn listSublist(
             return RocList{
                 .bytes = source_ptr + start * element_width,
                 .length = keep_len,
-                .capacityOrRefPtr = (@ptrToInt(ref_ptr) >> 1) | seamless_slice_bit,
+                .capacity_or_ref_ptr = (@ptrToInt(ref_ptr) >> 1) | seamless_slice_bit,
             };
         }
     }

--- a/crates/compiler/builtins/bitcode/src/list.zig
+++ b/crates/compiler/builtins/bitcode/src/list.zig
@@ -538,11 +538,6 @@ pub fn listSublist(
     len: usize,
     dec: Dec,
 ) callconv(.C) RocList {
-    // Alignment is no longer used.
-    // This will never free the original list.
-    // It will either return a seamless slice or an empty list with capacity.
-    _ = alignment;
-
     const size = list.len();
     if (len == 0 or start >= size) {
         if (list.isUnique()) {
@@ -558,6 +553,7 @@ pub fn listSublist(
                 return output;
             }
         }
+        list.decref(alignment);
         return RocList.empty();
     }
 
@@ -620,9 +616,9 @@ pub fn listDropAt(
     // For simplicity, do this by calling listSublist.
     // In the future, we can test if it is faster to manually inline the important parts here.
     if (drop_index == 0) {
-        return listSublist(list, alignment, element_width, 1, size - 1, dec);
-    } else if (drop_index == size - 1) {
-        return listSublist(list, alignment, element_width, 0, size - 1, dec);
+        return listSublist(list, alignment, element_width, 1, size -| 1, dec);
+    } else if (drop_index == size -| 1) {
+        return listSublist(list, alignment, element_width, 0, size -| 1, dec);
     }
 
     if (list.bytes) |source_ptr| {

--- a/crates/compiler/builtins/bitcode/src/list.zig
+++ b/crates/compiler/builtins/bitcode/src/list.zig
@@ -112,7 +112,8 @@ pub const RocList = extern struct {
     }
 
     pub fn decref(self: RocList, alignment: u32) void {
-        utils.decref(self.getRefcountPtr(), self.getCapacity(), alignment);
+        // We use the raw capacity to ensure we always decrement the refcount of seamless slices.
+        utils.decref(self.getRefcountPtr(), self.capacity_or_ref_ptr, alignment);
     }
 
     pub fn elements(self: RocList, comptime T: type) ?[*]T {

--- a/crates/compiler/builtins/bitcode/src/list.zig
+++ b/crates/compiler/builtins/bitcode/src/list.zig
@@ -615,9 +615,17 @@ pub fn listDropAt(
     drop_index: usize,
     dec: Dec,
 ) callconv(.C) RocList {
-    if (list.bytes) |source_ptr| {
-        const size = list.len();
+    const size = list.len();
+    // If droping the first or last element, return a seamless slice.
+    // For simplicity, do this by calling listSublist.
+    // In the future, we can test if it is faster to manually inline the important parts here.
+    if (drop_index == 0) {
+        return listSublist(list, alignment, element_width, 1, size - 1, dec);
+    } else if (drop_index == size - 1) {
+        return listSublist(list, alignment, element_width, 0, size - 1, dec);
+    }
 
+    if (list.bytes) |source_ptr| {
         if (drop_index >= size) {
             return list;
         }

--- a/crates/compiler/builtins/bitcode/src/main.zig
+++ b/crates/compiler/builtins/bitcode/src/main.zig
@@ -144,7 +144,6 @@ comptime {
     exportStrFn(str.getScalarUnsafe, "get_scalar_unsafe");
     exportStrFn(str.appendScalar, "append_scalar");
     exportStrFn(str.strToUtf8C, "to_utf8");
-    exportStrFn(str.fromUtf8C, "from_utf8");
     exportStrFn(str.fromUtf8RangeC, "from_utf8_range");
     exportStrFn(str.repeat, "repeat");
     exportStrFn(str.strTrim, "trim");

--- a/crates/compiler/builtins/bitcode/src/main.zig
+++ b/crates/compiler/builtins/bitcode/src/main.zig
@@ -54,6 +54,8 @@ comptime {
     exportListFn(list.listReplaceInPlace, "replace_in_place");
     exportListFn(list.listSwap, "swap");
     exportListFn(list.listIsUnique, "is_unique");
+    exportListFn(list.listCapacity, "capacity");
+    exportListFn(list.listRefcountPtr, "refcount_ptr");
 }
 
 // Num Module

--- a/crates/compiler/builtins/bitcode/src/str.zig
+++ b/crates/compiler/builtins/bitcode/src/str.zig
@@ -58,6 +58,7 @@ pub const RocStr = extern struct {
     }
 
     pub fn fromByteList(list: RocList) RocStr {
+        // TODO: upon adding string seamless slices, I believe this branch can be changed to bit manipulation.
         if (list.isSeamlessSlice()) {
             // Str doesn't have seamless slices yet.
             // Need to copy.

--- a/crates/compiler/builtins/bitcode/src/str.zig
+++ b/crates/compiler/builtins/bitcode/src/str.zig
@@ -623,7 +623,7 @@ test "strToScalars: empty string" {
 
     const expected = RocList.empty();
     const actual = strToScalars(str);
-    defer RocList.deinit(actual, u32);
+    defer actual.deinit(@sizeOf(u32));
 
     try expect(RocList.eql(actual, expected));
 }
@@ -634,10 +634,10 @@ test "strToScalars: One ASCII char" {
 
     const expected_array = [_]u32{82};
     const expected = RocList.fromSlice(u32, expected_array[0..expected_array.len]);
-    defer RocList.deinit(expected, u32);
+    defer expected.deinit(@sizeOf(u32));
 
     const actual = strToScalars(str);
-    defer RocList.deinit(actual, u32);
+    defer actual.deinit(@sizeOf(u32));
 
     try expect(RocList.eql(actual, expected));
 }
@@ -648,10 +648,10 @@ test "strToScalars: Multiple ASCII chars" {
 
     const expected_array = [_]u32{ 82, 111, 99, 33 };
     const expected = RocList.fromSlice(u32, expected_array[0..expected_array.len]);
-    defer RocList.deinit(expected, u32);
+    defer expected.deinit(@sizeOf(u32));
 
     const actual = strToScalars(str);
-    defer RocList.deinit(actual, u32);
+    defer actual.deinit(@sizeOf(u32));
 
     try expect(RocList.eql(actual, expected));
 }
@@ -662,10 +662,10 @@ test "strToScalars: One 2-byte UTF-8 character" {
 
     const expected_array = [_]u32{233};
     const expected = RocList.fromSlice(u32, expected_array[0..expected_array.len]);
-    defer RocList.deinit(expected, u32);
+    defer expected.deinit(@sizeOf(u32));
 
     const actual = strToScalars(str);
-    defer RocList.deinit(actual, u32);
+    defer actual.deinit(@sizeOf(u32));
 
     try expect(RocList.eql(actual, expected));
 }
@@ -676,10 +676,10 @@ test "strToScalars: Multiple 2-byte UTF-8 characters" {
 
     const expected_array = [_]u32{ 67, 228, 102, 233, 115 };
     const expected = RocList.fromSlice(u32, expected_array[0..expected_array.len]);
-    defer RocList.deinit(expected, u32);
+    defer expected.deinit(@sizeOf(u32));
 
     const actual = strToScalars(str);
-    defer RocList.deinit(actual, u32);
+    defer actual.deinit(@sizeOf(u32));
 
     try expect(RocList.eql(actual, expected));
 }
@@ -690,10 +690,10 @@ test "strToScalars: One 3-byte UTF-8 character" {
 
     const expected_array = [_]u32{40527};
     const expected = RocList.fromSlice(u32, expected_array[0..expected_array.len]);
-    defer RocList.deinit(expected, u32);
+    defer expected.deinit(@sizeOf(u32));
 
     const actual = strToScalars(str);
-    defer RocList.deinit(actual, u32);
+    defer actual.deinit(@sizeOf(u32));
 
     try expect(RocList.eql(actual, expected));
 }
@@ -704,10 +704,10 @@ test "strToScalars: Multiple 3-byte UTF-8 characters" {
 
     const expected_array = [_]u32{ 40527, 24456, 26377, 36259 };
     const expected = RocList.fromSlice(u32, expected_array[0..expected_array.len]);
-    defer RocList.deinit(expected, u32);
+    defer expected.deinit(@sizeOf(u32));
 
     const actual = strToScalars(str);
-    defer RocList.deinit(actual, u32);
+    defer actual.deinit(@sizeOf(u32));
 
     try expect(RocList.eql(actual, expected));
 }
@@ -719,10 +719,10 @@ test "strToScalars: One 4-byte UTF-8 character" {
 
     const expected_array = [_]u32{73728};
     const expected = RocList.fromSlice(u32, expected_array[0..expected_array.len]);
-    defer RocList.deinit(expected, u32);
+    defer expected.deinit(@sizeOf(u32));
 
     const actual = strToScalars(str);
-    defer RocList.deinit(actual, u32);
+    defer actual.deinit(@sizeOf(u32));
 
     try expect(RocList.eql(actual, expected));
 }
@@ -734,10 +734,10 @@ test "strToScalars: Multiple 4-byte UTF-8 characters" {
 
     const expected_array = [_]u32{ 73728, 73729 };
     const expected = RocList.fromSlice(u32, expected_array[0..expected_array.len]);
-    defer RocList.deinit(expected, u32);
+    defer expected.deinit(@sizeOf(u32));
 
     const actual = strToScalars(str);
-    defer RocList.deinit(actual, u32);
+    defer actual.deinit(@sizeOf(u32));
 
     try expect(RocList.eql(actual, expected));
 }
@@ -1377,7 +1377,7 @@ fn graphemesTest(input: []const u8, expected: []const []const u8) !void {
     try expectEqual(expected.len, count);
 
     const graphemes = strGraphemes(rocstr);
-    defer graphemes.deinit(u8);
+    defer graphemes.deinit(@sizeOf(u8));
     if (input.len == 0) return; // empty string
     const elems = graphemes.elements(RocStr) orelse unreachable;
     for (expected) |g, i| {
@@ -1802,8 +1802,7 @@ inline fn fromUtf8(arg: RocList, update_mode: UpdateMode) FromUtf8Result {
             const string = RocStr.init(@ptrCast([*]u8, arg.bytes), arg.len());
 
             // then decrement the input list
-            const data_bytes = arg.len();
-            utils.decref(arg.bytes, data_bytes, RocStr.alignment);
+            arg.deinit(RocStr.alignment);
 
             return FromUtf8Result{
                 .is_ok = true,
@@ -1831,8 +1830,7 @@ inline fn fromUtf8(arg: RocList, update_mode: UpdateMode) FromUtf8Result {
         const temp = errorToProblem(@ptrCast([*]u8, arg.bytes), arg.length);
 
         // consume the input list
-        const data_bytes = arg.len();
-        utils.decref(arg.bytes, data_bytes, RocStr.alignment);
+        arg.deinit(RocStr.alignment);
 
         return FromUtf8Result{
             .is_ok = false,
@@ -1879,7 +1877,7 @@ pub fn fromUtf8Range(arg: RocList, start: usize, count: usize, update_mode: Upda
             const string = RocStr.init(@ptrCast([*]const u8, bytes), count);
 
             // decref the list
-            utils.decref(arg.bytes, arg.len(), 1);
+            arg.deinit(RocStr.alignment);
 
             return FromUtf8Result{
                 .is_ok = true,
@@ -1892,7 +1890,7 @@ pub fn fromUtf8Range(arg: RocList, start: usize, count: usize, update_mode: Upda
         const temp = errorToProblem(@ptrCast([*]u8, arg.bytes), arg.length);
 
         // decref the list
-        utils.decref(arg.bytes, arg.len(), 1);
+        arg.deinit(RocStr.alignment);
 
         return FromUtf8Result{
             .is_ok = false,

--- a/crates/compiler/builtins/bitcode/src/str.zig
+++ b/crates/compiler/builtins/bitcode/src/str.zig
@@ -66,7 +66,7 @@ pub const RocStr = extern struct {
         return RocStr{
             .str_bytes = list.bytes,
             .str_len = list.length,
-            .str_capacity = list.capacity_or_ref_ptr, // This is guaranteed to be a proper capcity.
+            .str_capacity = list.capacity_or_ref_ptr, // This is guaranteed to be a proper capacity.
         };
     }
 

--- a/crates/compiler/builtins/bitcode/src/str.zig
+++ b/crates/compiler/builtins/bitcode/src/str.zig
@@ -89,11 +89,7 @@ pub const RocStr = extern struct {
         }
     }
 
-    pub fn deinit(self: RocStr) void {
-        self.decref();
-    }
-
-    fn decref(self: RocStr) void {
+    pub fn decref(self: RocStr) void {
         if (!self.isSmallStr()) {
             utils.decref(self.str_bytes, self.str_capacity, RocStr.alignment);
         }
@@ -388,8 +384,8 @@ pub const RocStr = extern struct {
 
         try expect(roc_str1.eq(roc_str2));
 
-        roc_str1.deinit();
-        roc_str2.deinit();
+        roc_str1.decref();
+        roc_str2.decref();
     }
 
     test "RocStr.eq: small, not equal, different length" {
@@ -404,8 +400,8 @@ pub const RocStr = extern struct {
         var roc_str2 = RocStr.init(str2_ptr, str2_len);
 
         defer {
-            roc_str1.deinit();
-            roc_str2.deinit();
+            roc_str1.decref();
+            roc_str2.decref();
         }
 
         try expect(!roc_str1.eq(roc_str2));
@@ -423,8 +419,8 @@ pub const RocStr = extern struct {
         var roc_str2 = RocStr.init(str2_ptr, str2_len);
 
         defer {
-            roc_str1.deinit();
-            roc_str2.deinit();
+            roc_str1.decref();
+            roc_str2.decref();
         }
 
         try expect(!roc_str1.eq(roc_str2));
@@ -436,8 +432,8 @@ pub const RocStr = extern struct {
         const roc_str2 = RocStr.init(content, content.len);
 
         defer {
-            roc_str1.deinit();
-            roc_str2.deinit();
+            roc_str1.decref();
+            roc_str2.decref();
         }
 
         try expect(roc_str1.eq(roc_str2));
@@ -450,8 +446,8 @@ pub const RocStr = extern struct {
         const roc_str2 = RocStr.init(content2, content2.len);
 
         defer {
-            roc_str1.deinit();
-            roc_str2.deinit();
+            roc_str1.decref();
+            roc_str2.decref();
         }
 
         try expect(!roc_str1.eq(roc_str2));
@@ -464,8 +460,8 @@ pub const RocStr = extern struct {
         const roc_str2 = RocStr.init(content2, content2.len);
 
         defer {
-            roc_str1.deinit();
-            roc_str2.deinit();
+            roc_str1.decref();
+            roc_str2.decref();
         }
 
         try expect(!roc_str1.eq(roc_str2));
@@ -484,8 +480,8 @@ pub const RocStr = extern struct {
         roc_str2.str_bytes.?[31] = '-';
 
         defer {
-            roc_str1.deinit();
-            roc_str2.deinit();
+            roc_str1.decref();
+            roc_str2.decref();
         }
 
         try expect(roc_str1.eq(roc_str2));
@@ -619,95 +615,95 @@ inline fn writeNextScalar(non_empty_string: RocStr, src_index: usize, dest: [*]u
 
 test "strToScalars: empty string" {
     const str = RocStr.fromSlice("");
-    defer RocStr.deinit(str);
+    defer RocStr.decref(str);
 
     const expected = RocList.empty();
     const actual = strToScalars(str);
-    defer actual.deinit(@sizeOf(u32));
+    defer actual.decref(@sizeOf(u32));
 
     try expect(RocList.eql(actual, expected));
 }
 
 test "strToScalars: One ASCII char" {
     const str = RocStr.fromSlice("R");
-    defer RocStr.deinit(str);
+    defer RocStr.decref(str);
 
     const expected_array = [_]u32{82};
     const expected = RocList.fromSlice(u32, expected_array[0..expected_array.len]);
-    defer expected.deinit(@sizeOf(u32));
+    defer expected.decref(@sizeOf(u32));
 
     const actual = strToScalars(str);
-    defer actual.deinit(@sizeOf(u32));
+    defer actual.decref(@sizeOf(u32));
 
     try expect(RocList.eql(actual, expected));
 }
 
 test "strToScalars: Multiple ASCII chars" {
     const str = RocStr.fromSlice("Roc!");
-    defer RocStr.deinit(str);
+    defer RocStr.decref(str);
 
     const expected_array = [_]u32{ 82, 111, 99, 33 };
     const expected = RocList.fromSlice(u32, expected_array[0..expected_array.len]);
-    defer expected.deinit(@sizeOf(u32));
+    defer expected.decref(@sizeOf(u32));
 
     const actual = strToScalars(str);
-    defer actual.deinit(@sizeOf(u32));
+    defer actual.decref(@sizeOf(u32));
 
     try expect(RocList.eql(actual, expected));
 }
 
 test "strToScalars: One 2-byte UTF-8 character" {
     const str = RocStr.fromSlice("é");
-    defer RocStr.deinit(str);
+    defer RocStr.decref(str);
 
     const expected_array = [_]u32{233};
     const expected = RocList.fromSlice(u32, expected_array[0..expected_array.len]);
-    defer expected.deinit(@sizeOf(u32));
+    defer expected.decref(@sizeOf(u32));
 
     const actual = strToScalars(str);
-    defer actual.deinit(@sizeOf(u32));
+    defer actual.decref(@sizeOf(u32));
 
     try expect(RocList.eql(actual, expected));
 }
 
 test "strToScalars: Multiple 2-byte UTF-8 characters" {
     const str = RocStr.fromSlice("Cäfés");
-    defer RocStr.deinit(str);
+    defer RocStr.decref(str);
 
     const expected_array = [_]u32{ 67, 228, 102, 233, 115 };
     const expected = RocList.fromSlice(u32, expected_array[0..expected_array.len]);
-    defer expected.deinit(@sizeOf(u32));
+    defer expected.decref(@sizeOf(u32));
 
     const actual = strToScalars(str);
-    defer actual.deinit(@sizeOf(u32));
+    defer actual.decref(@sizeOf(u32));
 
     try expect(RocList.eql(actual, expected));
 }
 
 test "strToScalars: One 3-byte UTF-8 character" {
     const str = RocStr.fromSlice("鹏");
-    defer RocStr.deinit(str);
+    defer RocStr.decref(str);
 
     const expected_array = [_]u32{40527};
     const expected = RocList.fromSlice(u32, expected_array[0..expected_array.len]);
-    defer expected.deinit(@sizeOf(u32));
+    defer expected.decref(@sizeOf(u32));
 
     const actual = strToScalars(str);
-    defer actual.deinit(@sizeOf(u32));
+    defer actual.decref(@sizeOf(u32));
 
     try expect(RocList.eql(actual, expected));
 }
 
 test "strToScalars: Multiple 3-byte UTF-8 characters" {
     const str = RocStr.fromSlice("鹏很有趣");
-    defer RocStr.deinit(str);
+    defer RocStr.decref(str);
 
     const expected_array = [_]u32{ 40527, 24456, 26377, 36259 };
     const expected = RocList.fromSlice(u32, expected_array[0..expected_array.len]);
-    defer expected.deinit(@sizeOf(u32));
+    defer expected.decref(@sizeOf(u32));
 
     const actual = strToScalars(str);
-    defer actual.deinit(@sizeOf(u32));
+    defer actual.decref(@sizeOf(u32));
 
     try expect(RocList.eql(actual, expected));
 }
@@ -715,14 +711,14 @@ test "strToScalars: Multiple 3-byte UTF-8 characters" {
 test "strToScalars: One 4-byte UTF-8 character" {
     // from https://design215.com/toolbox/utf8-4byte-characters.php
     const str = RocStr.fromSlice("𒀀");
-    defer RocStr.deinit(str);
+    defer RocStr.decref(str);
 
     const expected_array = [_]u32{73728};
     const expected = RocList.fromSlice(u32, expected_array[0..expected_array.len]);
-    defer expected.deinit(@sizeOf(u32));
+    defer expected.decref(@sizeOf(u32));
 
     const actual = strToScalars(str);
-    defer actual.deinit(@sizeOf(u32));
+    defer actual.decref(@sizeOf(u32));
 
     try expect(RocList.eql(actual, expected));
 }
@@ -730,14 +726,14 @@ test "strToScalars: One 4-byte UTF-8 character" {
 test "strToScalars: Multiple 4-byte UTF-8 characters" {
     // from https://design215.com/toolbox/utf8-4byte-characters.php
     const str = RocStr.fromSlice("𒀀𒀁");
-    defer RocStr.deinit(str);
+    defer RocStr.decref(str);
 
     const expected_array = [_]u32{ 73728, 73729 };
     const expected = RocList.fromSlice(u32, expected_array[0..expected_array.len]);
-    defer expected.deinit(@sizeOf(u32));
+    defer expected.decref(@sizeOf(u32));
 
     const actual = strToScalars(str);
-    defer actual.deinit(@sizeOf(u32));
+    defer actual.decref(@sizeOf(u32));
 
     try expect(RocList.eql(actual, expected));
 }
@@ -871,15 +867,15 @@ test "strSplitHelp: empty delimiter" {
 
     defer {
         for (array) |roc_str| {
-            roc_str.deinit();
+            roc_str.decref();
         }
 
         for (expected) |roc_str| {
-            roc_str.deinit();
+            roc_str.decref();
         }
 
-        str.deinit();
-        delimiter.deinit();
+        str.decref();
+        delimiter.decref();
     }
 
     try expectEqual(array.len, expected.len);
@@ -905,15 +901,15 @@ test "strSplitHelp: no delimiter" {
 
     defer {
         for (array) |roc_str| {
-            roc_str.deinit();
+            roc_str.decref();
         }
 
         for (expected) |roc_str| {
-            roc_str.deinit();
+            roc_str.decref();
         }
 
-        str.deinit();
-        delimiter.deinit();
+        str.decref();
+        delimiter.decref();
     }
 
     try expectEqual(array.len, expected.len);
@@ -944,15 +940,15 @@ test "strSplitHelp: empty start" {
 
     defer {
         for (array) |rocStr| {
-            rocStr.deinit();
+            rocStr.decref();
         }
 
         for (expected) |rocStr| {
-            rocStr.deinit();
+            rocStr.decref();
         }
 
-        str.deinit();
-        delimiter.deinit();
+        str.decref();
+        delimiter.decref();
     }
 
     try expectEqual(array.len, expected.len);
@@ -986,15 +982,15 @@ test "strSplitHelp: empty end" {
 
     defer {
         for (array) |rocStr| {
-            rocStr.deinit();
+            rocStr.decref();
         }
 
         for (expected) |rocStr| {
-            rocStr.deinit();
+            rocStr.decref();
         }
 
-        str.deinit();
-        delimiter.deinit();
+        str.decref();
+        delimiter.decref();
     }
 
     try expectEqual(array.len, expected.len);
@@ -1020,14 +1016,14 @@ test "strSplitHelp: string equals delimiter" {
 
     defer {
         for (array) |rocStr| {
-            rocStr.deinit();
+            rocStr.decref();
         }
 
         for (expected) |rocStr| {
-            rocStr.deinit();
+            rocStr.decref();
         }
 
-        str_delimiter.deinit();
+        str_delimiter.decref();
     }
 
     try expectEqual(array.len, expected.len);
@@ -1060,15 +1056,15 @@ test "strSplitHelp: delimiter on sides" {
 
     defer {
         for (array) |rocStr| {
-            rocStr.deinit();
+            rocStr.decref();
         }
 
         for (expected) |rocStr| {
-            rocStr.deinit();
+            rocStr.decref();
         }
 
-        str.deinit();
-        delimiter.deinit();
+        str.decref();
+        delimiter.decref();
     }
 
     try expectEqual(array.len, expected.len);
@@ -1101,15 +1097,15 @@ test "strSplitHelp: three pieces" {
 
     defer {
         for (array) |roc_str| {
-            roc_str.deinit();
+            roc_str.decref();
         }
 
         for (expected_array) |roc_str| {
-            roc_str.deinit();
+            roc_str.decref();
         }
 
-        str.deinit();
-        delimiter.deinit();
+        str.decref();
+        delimiter.decref();
     }
 
     try expectEqual(expected_array.len, array.len);
@@ -1226,8 +1222,8 @@ test "countSegments: long delimiter" {
     const delimiter = RocStr.init(delimiter_arr, delimiter_arr.len);
 
     defer {
-        str.deinit();
-        delimiter.deinit();
+        str.decref();
+        delimiter.decref();
     }
 
     const segments_count = countSegments(str, delimiter);
@@ -1244,8 +1240,8 @@ test "countSegments: delimiter at start" {
     const delimiter = RocStr.init(delimiter_arr, delimiter_arr.len);
 
     defer {
-        str.deinit();
-        delimiter.deinit();
+        str.decref();
+        delimiter.decref();
     }
 
     const segments_count = countSegments(str, delimiter);
@@ -1263,8 +1259,8 @@ test "countSegments: delimiter interspered" {
     const delimiter = RocStr.init(delimiter_arr, delimiter_arr.len);
 
     defer {
-        str.deinit();
-        delimiter.deinit();
+        str.decref();
+        delimiter.decref();
     }
 
     const segments_count = countSegments(str, delimiter);
@@ -1279,7 +1275,7 @@ test "countSegments: string equals delimiter" {
     const str_delimiter = RocStr.init(str_delimiter_arr, str_delimiter_arr.len);
 
     defer {
-        str_delimiter.deinit();
+        str_delimiter.decref();
     }
 
     const segments_count = countSegments(str_delimiter, str_delimiter);
@@ -1372,12 +1368,12 @@ pub fn strGraphemes(roc_str: RocStr) callconv(.C) RocList {
 // these test both countGraphemeClusters() and strGraphemes()
 fn graphemesTest(input: []const u8, expected: []const []const u8) !void {
     const rocstr = RocStr.fromSlice(input);
-    defer rocstr.deinit();
+    defer rocstr.decref();
     const count = countGraphemeClusters(rocstr);
     try expectEqual(expected.len, count);
 
     const graphemes = strGraphemes(rocstr);
-    defer graphemes.deinit(@sizeOf(u8));
+    defer graphemes.decref(@sizeOf(u8));
     if (input.len == 0) return; // empty string
     const elems = graphemes.elements(RocStr) orelse unreachable;
     for (expected) |g, i| {
@@ -1428,10 +1424,10 @@ pub fn getUnsafe(string: RocStr, index: usize) callconv(.C) u8 {
 
 test "substringUnsafe: start" {
     const str = RocStr.fromSlice("abcdef");
-    defer str.deinit();
+    defer str.decref();
 
     const expected = RocStr.fromSlice("abc");
-    defer expected.deinit();
+    defer expected.decref();
 
     const actual = substringUnsafe(str, 0, 3);
 
@@ -1440,10 +1436,10 @@ test "substringUnsafe: start" {
 
 test "substringUnsafe: middle" {
     const str = RocStr.fromSlice("abcdef");
-    defer str.deinit();
+    defer str.decref();
 
     const expected = RocStr.fromSlice("bcd");
-    defer expected.deinit();
+    defer expected.decref();
 
     const actual = substringUnsafe(str, 1, 3);
 
@@ -1452,10 +1448,10 @@ test "substringUnsafe: middle" {
 
 test "substringUnsafe: end" {
     const str = RocStr.fromSlice("a string so long it is heap-allocated");
-    defer str.deinit();
+    defer str.decref();
 
     const expected = RocStr.fromSlice("heap-allocated");
-    defer expected.deinit();
+    defer expected.decref();
 
     const actual = substringUnsafe(str, 23, 37 - 23);
 
@@ -1547,15 +1543,15 @@ test "startsWith: foo starts with fo" {
 
 test "startsWith: 123456789123456789 starts with 123456789123456789" {
     const str = RocStr.fromSlice("123456789123456789");
-    defer str.deinit();
+    defer str.decref();
     try expect(startsWith(str, str));
 }
 
 test "startsWith: 12345678912345678910 starts with 123456789123456789" {
     const str = RocStr.fromSlice("12345678912345678910");
-    defer str.deinit();
+    defer str.decref();
     const prefix = RocStr.fromSlice("123456789123456789");
-    defer prefix.deinit();
+    defer prefix.decref();
 
     try expect(startsWith(str, prefix));
 }
@@ -1586,23 +1582,23 @@ pub fn endsWith(string: RocStr, suffix: RocStr) callconv(.C) bool {
 test "endsWith: foo ends with oo" {
     const foo = RocStr.init("foo", 3);
     const oo = RocStr.init("oo", 2);
-    defer foo.deinit();
-    defer oo.deinit();
+    defer foo.decref();
+    defer oo.decref();
 
     try expect(endsWith(foo, oo));
 }
 
 test "endsWith: 123456789123456789 ends with 123456789123456789" {
     const str = RocStr.init("123456789123456789", 18);
-    defer str.deinit();
+    defer str.decref();
     try expect(endsWith(str, str));
 }
 
 test "endsWith: 12345678912345678910 ends with 345678912345678910" {
     const str = RocStr.init("12345678912345678910", 20);
     const suffix = RocStr.init("345678912345678910", 18);
-    defer str.deinit();
-    defer suffix.deinit();
+    defer str.decref();
+    defer suffix.decref();
 
     try expect(endsWith(str, suffix));
 }
@@ -1610,8 +1606,8 @@ test "endsWith: 12345678912345678910 ends with 345678912345678910" {
 test "endsWith: hello world ends with world" {
     const str = RocStr.init("hello world", 11);
     const suffix = RocStr.init("world", 5);
-    defer str.deinit();
-    defer suffix.deinit();
+    defer str.decref();
+    defer suffix.decref();
 
     try expect(endsWith(str, suffix));
 }
@@ -1654,14 +1650,14 @@ test "RocStr.concat: small concat small" {
     var roc_str3 = RocStr.init(str3_ptr, str3_len);
 
     defer {
-        roc_str1.deinit();
-        roc_str2.deinit();
-        roc_str3.deinit();
+        roc_str1.decref();
+        roc_str2.decref();
+        roc_str3.decref();
     }
 
     const result = strConcat(roc_str1, roc_str2);
 
-    defer result.deinit();
+    defer result.decref();
 
     try expect(roc_str3.eq(result));
 }
@@ -1744,14 +1740,14 @@ test "RocStr.joinWith: result is big" {
     };
 
     defer {
-        roc_sep.deinit();
-        roc_elem.deinit();
-        roc_result.deinit();
+        roc_sep.decref();
+        roc_elem.decref();
+        roc_result.decref();
     }
 
     const result = strJoinWith(list, roc_sep);
 
-    defer result.deinit();
+    defer result.decref();
 
     try expect(roc_result.eq(result));
 }
@@ -1802,7 +1798,7 @@ inline fn fromUtf8(arg: RocList, update_mode: UpdateMode) FromUtf8Result {
             const string = RocStr.init(@ptrCast([*]u8, arg.bytes), arg.len());
 
             // then decrement the input list
-            arg.deinit(RocStr.alignment);
+            arg.decref(RocStr.alignment);
 
             return FromUtf8Result{
                 .is_ok = true,
@@ -1830,7 +1826,7 @@ inline fn fromUtf8(arg: RocList, update_mode: UpdateMode) FromUtf8Result {
         const temp = errorToProblem(@ptrCast([*]u8, arg.bytes), arg.length);
 
         // consume the input list
-        arg.deinit(RocStr.alignment);
+        arg.decref(RocStr.alignment);
 
         return FromUtf8Result{
             .is_ok = false,
@@ -1877,7 +1873,7 @@ pub fn fromUtf8Range(arg: RocList, start: usize, count: usize, update_mode: Upda
             const string = RocStr.init(@ptrCast([*]const u8, bytes), count);
 
             // decref the list
-            arg.deinit(RocStr.alignment);
+            arg.decref(RocStr.alignment);
 
             return FromUtf8Result{
                 .is_ok = true,
@@ -1890,7 +1886,7 @@ pub fn fromUtf8Range(arg: RocList, start: usize, count: usize, update_mode: Upda
         const temp = errorToProblem(@ptrCast([*]u8, arg.bytes), arg.length);
 
         // decref the list
-        arg.deinit(RocStr.alignment);
+        arg.decref(RocStr.alignment);
 
         return FromUtf8Result{
             .is_ok = false,
@@ -2158,7 +2154,7 @@ pub fn strTrim(input_string: RocStr) callconv(.C) RocStr {
     var string = input_string;
 
     if (string.isEmpty()) {
-        string.deinit();
+        string.decref();
         return RocStr.empty();
     }
 
@@ -2168,7 +2164,7 @@ pub fn strTrim(input_string: RocStr) callconv(.C) RocStr {
     const original_len = string.len();
 
     if (original_len == leading_bytes) {
-        string.deinit();
+        string.decref();
         return RocStr.empty();
     }
 
@@ -2209,7 +2205,7 @@ pub fn strTrimLeft(input_string: RocStr) callconv(.C) RocStr {
     var string = input_string;
 
     if (string.isEmpty()) {
-        string.deinit();
+        string.decref();
         return RocStr.empty();
     }
 
@@ -2219,7 +2215,7 @@ pub fn strTrimLeft(input_string: RocStr) callconv(.C) RocStr {
     const original_len = string.len();
 
     if (original_len == leading_bytes) {
-        string.deinit();
+        string.decref();
         return RocStr.empty();
     }
 
@@ -2259,7 +2255,7 @@ pub fn strTrimRight(input_string: RocStr) callconv(.C) RocStr {
     var string = input_string;
 
     if (string.isEmpty()) {
-        string.deinit();
+        string.decref();
         return RocStr.empty();
     }
 
@@ -2269,7 +2265,7 @@ pub fn strTrimRight(input_string: RocStr) callconv(.C) RocStr {
     const original_len = string.len();
 
     if (original_len == trailing_bytes) {
-        string.deinit();
+        string.decref();
         return RocStr.empty();
     }
 
@@ -2405,13 +2401,13 @@ test "strTrim: null byte" {
     try expectEqual(@as(usize, SMALL_STR_MAX_LENGTH), original.getCapacity());
 
     const original_with_capacity = reserve(original, 40);
-    defer original_with_capacity.deinit();
+    defer original_with_capacity.decref();
 
     try expectEqual(@as(usize, 1), original_with_capacity.len());
     try expectEqual(@as(usize, 64), original_with_capacity.getCapacity());
 
     const trimmed = strTrim(original.clone());
-    defer trimmed.deinit();
+    defer trimmed.decref();
 
     try expect(original.eq(trimmed));
 }
@@ -2419,7 +2415,7 @@ test "strTrim: null byte" {
 test "strTrim: blank" {
     const original_bytes = "   ";
     const original = RocStr.init(original_bytes, original_bytes.len);
-    defer original.deinit();
+    defer original.decref();
 
     const trimmed = strTrim(original);
 
@@ -2429,13 +2425,13 @@ test "strTrim: blank" {
 test "strTrim: large to large" {
     const original_bytes = " hello even more giant world ";
     const original = RocStr.init(original_bytes, original_bytes.len);
-    defer original.deinit();
+    defer original.decref();
 
     try expect(!original.isSmallStr());
 
     const expected_bytes = "hello even more giant world";
     const expected = RocStr.init(expected_bytes, expected_bytes.len);
-    defer expected.deinit();
+    defer expected.decref();
 
     try expect(!expected.isSmallStr());
 
@@ -2447,13 +2443,13 @@ test "strTrim: large to large" {
 test "strTrim: large to small" {
     const original_bytes = "             hello         ";
     const original = RocStr.init(original_bytes, original_bytes.len);
-    defer original.deinit();
+    defer original.decref();
 
     try expect(!original.isSmallStr());
 
     const expected_bytes = "hello";
     const expected = RocStr.init(expected_bytes, expected_bytes.len);
-    defer expected.deinit();
+    defer expected.decref();
 
     try expect(expected.isSmallStr());
 
@@ -2469,13 +2465,13 @@ test "strTrim: large to small" {
 test "strTrim: small to small" {
     const original_bytes = " hello ";
     const original = RocStr.init(original_bytes, original_bytes.len);
-    defer original.deinit();
+    defer original.decref();
 
     try expect(original.isSmallStr());
 
     const expected_bytes = "hello";
     const expected = RocStr.init(expected_bytes, expected_bytes.len);
-    defer expected.deinit();
+    defer expected.decref();
 
     try expect(expected.isSmallStr());
 
@@ -2493,7 +2489,7 @@ test "strTrimLeft: empty" {
 test "strTrimLeft: blank" {
     const original_bytes = "   ";
     const original = RocStr.init(original_bytes, original_bytes.len);
-    defer original.deinit();
+    defer original.decref();
 
     const trimmed = strTrimLeft(original);
 
@@ -2503,13 +2499,13 @@ test "strTrimLeft: blank" {
 test "strTrimLeft: large to large" {
     const original_bytes = " hello even more giant world ";
     const original = RocStr.init(original_bytes, original_bytes.len);
-    defer original.deinit();
+    defer original.decref();
 
     try expect(!original.isSmallStr());
 
     const expected_bytes = "hello even more giant world ";
     const expected = RocStr.init(expected_bytes, expected_bytes.len);
-    defer expected.deinit();
+    defer expected.decref();
 
     try expect(!expected.isSmallStr());
 
@@ -2527,12 +2523,12 @@ test "strTrimLeft: large to small" {
 
     const expected_bytes = "hello ";
     const expected = RocStr.init(expected_bytes, expected_bytes.len);
-    defer expected.deinit();
+    defer expected.decref();
 
     try expect(expected.isSmallStr());
 
     const trimmed = strTrimLeft(original);
-    defer trimmed.deinit();
+    defer trimmed.decref();
 
     try expect(trimmed.eq(expected));
     try expect(!trimmed.isSmallStr());
@@ -2541,13 +2537,13 @@ test "strTrimLeft: large to small" {
 test "strTrimLeft: small to small" {
     const original_bytes = " hello ";
     const original = RocStr.init(original_bytes, original_bytes.len);
-    defer original.deinit();
+    defer original.decref();
 
     try expect(original.isSmallStr());
 
     const expected_bytes = "hello ";
     const expected = RocStr.init(expected_bytes, expected_bytes.len);
-    defer expected.deinit();
+    defer expected.decref();
 
     try expect(expected.isSmallStr());
 
@@ -2565,7 +2561,7 @@ test "strTrimRight: empty" {
 test "strTrimRight: blank" {
     const original_bytes = "   ";
     const original = RocStr.init(original_bytes, original_bytes.len);
-    defer original.deinit();
+    defer original.decref();
 
     const trimmed = strTrimRight(original);
 
@@ -2575,13 +2571,13 @@ test "strTrimRight: blank" {
 test "strTrimRight: large to large" {
     const original_bytes = " hello even more giant world ";
     const original = RocStr.init(original_bytes, original_bytes.len);
-    defer original.deinit();
+    defer original.decref();
 
     try expect(!original.isSmallStr());
 
     const expected_bytes = " hello even more giant world";
     const expected = RocStr.init(expected_bytes, expected_bytes.len);
-    defer expected.deinit();
+    defer expected.decref();
 
     try expect(!expected.isSmallStr());
 
@@ -2599,12 +2595,12 @@ test "strTrimRight: large to small" {
 
     const expected_bytes = " hello";
     const expected = RocStr.init(expected_bytes, expected_bytes.len);
-    defer expected.deinit();
+    defer expected.decref();
 
     try expect(expected.isSmallStr());
 
     const trimmed = strTrimRight(original);
-    defer trimmed.deinit();
+    defer trimmed.decref();
 
     try expect(trimmed.eq(expected));
     try expect(!trimmed.isSmallStr());
@@ -2613,13 +2609,13 @@ test "strTrimRight: large to small" {
 test "strTrimRight: small to small" {
     const original_bytes = " hello ";
     const original = RocStr.init(original_bytes, original_bytes.len);
-    defer original.deinit();
+    defer original.decref();
 
     try expect(original.isSmallStr());
 
     const expected_bytes = " hello";
     const expected = RocStr.init(expected_bytes, expected_bytes.len);
-    defer expected.deinit();
+    defer expected.decref();
 
     try expect(expected.isSmallStr());
 
@@ -2653,7 +2649,7 @@ test "ReverseUtf8View: empty" {
 test "capacity: small string" {
     const data_bytes = "foobar";
     var data = RocStr.init(data_bytes, data_bytes.len);
-    defer data.deinit();
+    defer data.decref();
 
     try expectEqual(data.getCapacity(), SMALL_STR_MAX_LENGTH);
 }
@@ -2661,7 +2657,7 @@ test "capacity: small string" {
 test "capacity: big string" {
     const data_bytes = "a string so large that it must be heap-allocated";
     var data = RocStr.init(data_bytes, data_bytes.len);
-    defer data.deinit();
+    defer data.decref();
 
     try expect(data.getCapacity() >= data_bytes.len);
 }
@@ -2685,11 +2681,11 @@ test "appendScalar: small A" {
     var data = RocStr.init(data_bytes, data_bytes.len);
 
     const actual = appendScalar(data, A[0]);
-    defer actual.deinit();
+    defer actual.decref();
 
     const expected_bytes = "helloA";
     const expected = RocStr.init(expected_bytes, expected_bytes.len);
-    defer expected.deinit();
+    defer expected.decref();
 
     try expect(actual.eq(expected));
 }
@@ -2699,11 +2695,11 @@ test "appendScalar: small 😀" {
     var data = RocStr.init(data_bytes, data_bytes.len);
 
     const actual = appendScalar(data, 0x1F600);
-    defer actual.deinit();
+    defer actual.decref();
 
     const expected_bytes = "hello😀";
     const expected = RocStr.init(expected_bytes, expected_bytes.len);
-    defer expected.deinit();
+    defer expected.decref();
 
     try expect(actual.eq(expected));
 }
@@ -2715,11 +2711,11 @@ test "appendScalar: big A" {
     var data = RocStr.init(data_bytes, data_bytes.len);
 
     const actual = appendScalar(data, A[0]);
-    defer actual.deinit();
+    defer actual.decref();
 
     const expected_bytes = "a string so large that it must be heap-allocatedA";
     const expected = RocStr.init(expected_bytes, expected_bytes.len);
-    defer expected.deinit();
+    defer expected.decref();
 
     try expect(actual.eq(expected));
 }
@@ -2729,11 +2725,11 @@ test "appendScalar: big 😀" {
     var data = RocStr.init(data_bytes, data_bytes.len);
 
     const actual = appendScalar(data, 0x1F600);
-    defer actual.deinit();
+    defer actual.decref();
 
     const expected_bytes = "a string so large that it must be heap-allocated😀";
     const expected = RocStr.init(expected_bytes, expected_bytes.len);
-    defer expected.deinit();
+    defer expected.decref();
 
     try expect(actual.eq(expected));
 }

--- a/crates/compiler/builtins/bitcode/src/str.zig
+++ b/crates/compiler/builtins/bitcode/src/str.zig
@@ -66,7 +66,7 @@ pub const RocStr = extern struct {
         return RocStr{
             .str_bytes = list.bytes,
             .str_len = list.length,
-            .str_capacity = list.capacityOrRefPtr, // This is guaranteed to be a proper capcity.
+            .str_capacity = list.capacity_or_ref_ptr, // This is guaranteed to be a proper capcity.
         };
     }
 
@@ -1678,7 +1678,7 @@ test "RocStr.concat: small concat small" {
 pub const RocListStr = extern struct {
     list_elements: ?[*]RocStr,
     list_length: usize,
-    list_capacityOrRefPtr: usize,
+    list_capacity_or_ref_ptr: usize,
 };
 
 // Str.joinWith
@@ -1686,7 +1686,7 @@ pub fn strJoinWithC(list: RocList, separator: RocStr) callconv(.C) RocStr {
     const roc_list_str = RocListStr{
         .list_elements = @ptrCast(?[*]RocStr, @alignCast(@alignOf(usize), list.bytes)),
         .list_length = list.length,
-        .list_capacityOrRefPtr = list.capacityOrRefPtr,
+        .list_capacity_or_ref_ptr = list.capacity_or_ref_ptr,
     };
 
     return @call(.{ .modifier = always_inline }, strJoinWith, .{ roc_list_str, separator });
@@ -1748,7 +1748,7 @@ test "RocStr.joinWith: result is big" {
     var elements: [3]RocStr = .{ roc_elem, roc_elem, roc_elem };
     const list = RocListStr{
         .list_length = 3,
-        .list_capacityOrRefPtr = 3,
+        .list_capacity_or_ref_ptr = 3,
         .list_elements = @ptrCast([*]RocStr, &elements),
     };
 
@@ -1779,9 +1779,9 @@ inline fn strToBytes(arg: RocStr) RocList {
 
         @memcpy(ptr, arg.asU8ptr(), length);
 
-        return RocList{ .length = length, .bytes = ptr, .capacityOrRefPtr = length };
+        return RocList{ .length = length, .bytes = ptr, .capacity_or_ref_ptr = length };
     } else {
-        return RocList{ .length = length, .bytes = arg.str_bytes, .capacityOrRefPtr = arg.str_capacity };
+        return RocList{ .length = length, .bytes = arg.str_bytes, .capacity_or_ref_ptr = arg.str_capacity };
     }
 }
 
@@ -1915,7 +1915,7 @@ pub const Utf8ByteProblem = enum(u8) {
 };
 
 fn validateUtf8Bytes(bytes: [*]u8, length: usize) FromUtf8Result {
-    return fromUtf8Range(RocList{ .bytes = bytes, .length = length, .capacityOrRefPtr = length }, 0, length, .Immutable);
+    return fromUtf8Range(RocList{ .bytes = bytes, .length = length, .capacity_or_ref_ptr = length }, 0, length, .Immutable);
 }
 
 fn validateUtf8BytesX(str: RocList) FromUtf8Result {

--- a/crates/compiler/builtins/bitcode/src/utils.zig
+++ b/crates/compiler/builtins/bitcode/src/utils.zig
@@ -204,7 +204,7 @@ pub fn decref(
     decref_ptr_to_refcount(isizes - 1, alignment);
 }
 
-pub inline fn decref_ptr_to_refcount(
+inline fn decref_ptr_to_refcount(
     refcount_ptr: [*]isize,
     alignment: u32,
 ) void {

--- a/crates/compiler/builtins/bitcode/src/utils.zig
+++ b/crates/compiler/builtins/bitcode/src/utils.zig
@@ -204,7 +204,7 @@ pub fn decref(
     decref_ptr_to_refcount(isizes - 1, alignment);
 }
 
-inline fn decref_ptr_to_refcount(
+pub inline fn decref_ptr_to_refcount(
     refcount_ptr: [*]isize,
     alignment: u32,
 ) void {

--- a/crates/compiler/builtins/roc/List.roc
+++ b/crates/compiler/builtins/roc/List.roc
@@ -846,15 +846,6 @@ dropLast = \list ->
 ##
 ## To split the list into two lists, use `List.split`.
 ##
-## ## Performance Details
-##
-## When given a Unique list, this runs extremely fast. It sets the list's length
-## to the given length value, and frees the leftover elements. This runs very
-## slightly faster than `List.takeLast`.
-##
-## In fact, `List.takeFirst list 1` runs faster than `List.first list` when given
-## a Unique list, because [List.first] returns the first element as well -
-## which introduces a conditional bounds check as well as a memory load.
 takeFirst : List elem, Nat -> List elem
 takeFirst = \list, outputLength ->
     List.sublist list { start: 0, len: outputLength }
@@ -875,16 +866,6 @@ takeFirst = \list, outputLength ->
 ##
 ## To split the list into two lists, use `List.split`.
 ##
-## ## Performance Details
-##
-## When given a Unique list, this runs extremely fast. It moves the list's
-## pointer to the index at the given length value, updates its length,
-## and frees the leftover elements. This runs very nearly as fast as
-## `List.takeFirst` on a Unique list.
-##
-## In fact, `List.takeLast list 1` runs faster than `List.first list` when given
-## a Unique list, because [List.first] returns the first element as well -
-## which introduces a conditional bounds check as well as a memory load.
 takeLast : List elem, Nat -> List elem
 takeLast = \list, outputLength ->
     List.sublist list { start: Num.subSaturated (List.len list) outputLength, len: outputLength }

--- a/crates/compiler/builtins/src/bitcode.rs
+++ b/crates/compiler/builtins/src/bitcode.rs
@@ -350,6 +350,8 @@ pub const LIST_IS_UNIQUE: &str = "roc_builtins.list.is_unique";
 pub const LIST_PREPEND: &str = "roc_builtins.list.prepend";
 pub const LIST_APPEND_UNSAFE: &str = "roc_builtins.list.append_unsafe";
 pub const LIST_RESERVE: &str = "roc_builtins.list.reserve";
+pub const LIST_CAPACITY: &str = "roc_builtins.list.capacity";
+pub const LIST_REFCOUNT_PTR: &str = "roc_builtins.list.refcount_ptr";
 
 pub const DEC_FROM_STR: &str = "roc_builtins.dec.from_str";
 pub const DEC_TO_STR: &str = "roc_builtins.dec.to_str";

--- a/crates/compiler/gen_llvm/src/llvm/build.rs
+++ b/crates/compiler/gen_llvm/src/llvm/build.rs
@@ -2789,7 +2789,7 @@ pub fn build_exp_stmt<'a, 'ctx, 'env>(
                             let alignment =
                                 element_layout.alignment_bytes(layout_interner, env.target_info);
 
-                            build_list::decref(env, value.into_struct_value(), alignment, parent);
+                            build_list::decref(env, value.into_struct_value(), alignment);
                         }
 
                         lay if lay.is_refcounted() => {

--- a/crates/compiler/gen_llvm/src/llvm/build.rs
+++ b/crates/compiler/gen_llvm/src/llvm/build.rs
@@ -2784,12 +2784,13 @@ pub fn build_exp_stmt<'a, 'ctx, 'env>(
                     match layout_interner.get(layout) {
                         Layout::Builtin(Builtin::Str) => todo!(),
                         Layout::Builtin(Builtin::List(element_layout)) => {
-                            debug_assert!(value.is_struct_value());
-                            let element_layout = layout_interner.get(element_layout);
-                            let alignment =
-                                element_layout.alignment_bytes(layout_interner, env.target_info);
+                            // debug_assert!(value.is_struct_value());
+                            // let element_layout = layout_interner.get(element_layout);
+                            // let alignment =
+                            //     element_layout.alignment_bytes(layout_interner, env.target_info);
 
-                            build_list::decref(env, value.into_struct_value(), alignment);
+                            // build_list::decref(env, value.into_struct_value(), alignment);
+                            todo!()
                         }
 
                         lay if lay.is_refcounted() => {

--- a/crates/compiler/gen_llvm/src/llvm/build.rs
+++ b/crates/compiler/gen_llvm/src/llvm/build.rs
@@ -2784,13 +2784,12 @@ pub fn build_exp_stmt<'a, 'ctx, 'env>(
                     match layout_interner.get(layout) {
                         Layout::Builtin(Builtin::Str) => todo!(),
                         Layout::Builtin(Builtin::List(element_layout)) => {
-                            // debug_assert!(value.is_struct_value());
-                            // let element_layout = layout_interner.get(element_layout);
-                            // let alignment =
-                            //     element_layout.alignment_bytes(layout_interner, env.target_info);
+                            debug_assert!(value.is_struct_value());
+                            let element_layout = layout_interner.get(element_layout);
+                            let alignment =
+                                element_layout.alignment_bytes(layout_interner, env.target_info);
 
-                            // build_list::decref(env, value.into_struct_value(), alignment);
-                            todo!()
+                            build_list::decref(env, value.into_struct_value(), alignment, parent);
                         }
 
                         lay if lay.is_refcounted() => {

--- a/crates/compiler/gen_llvm/src/llvm/build_list.rs
+++ b/crates/compiler/gen_llvm/src/llvm/build_list.rs
@@ -398,6 +398,7 @@ pub(crate) fn list_capacity<'ctx>(
     builder: &Builder<'ctx>,
     wrapper_struct: StructValue<'ctx>,
 ) -> IntValue<'ctx> {
+    // TODO: This won't work on seemless slices. Needs to return the len if the capacity is negative.
     builder
         .build_extract_value(wrapper_struct, Builtin::WRAPPER_CAPACITY, "list_capacity")
         .unwrap()
@@ -801,6 +802,7 @@ pub(crate) fn decref<'a, 'ctx, 'env>(
     wrapper_struct: StructValue<'ctx>,
     alignment: u32,
 ) {
+    // TODO: This definitely needs to handle seamless slices
     let (_, pointer) = load_list(
         env.builder,
         wrapper_struct,

--- a/crates/compiler/gen_llvm/src/llvm/build_list.rs
+++ b/crates/compiler/gen_llvm/src/llvm/build_list.rs
@@ -393,19 +393,18 @@ pub(crate) fn list_len<'ctx>(
         .into_int_value()
 }
 
-/// List.capacity : List * -> Nat
-pub(crate) fn list_capacity<'a, 'ctx, 'env>(
-    env: &Env<'a, 'ctx, 'env>,
+pub(crate) fn list_capacity_or_ref_ptr<'ctx>(
+    builder: &Builder<'ctx>,
     wrapper_struct: StructValue<'ctx>,
 ) -> IntValue<'ctx> {
-    call_list_bitcode_fn(
-        env,
-        &[wrapper_struct],
-        &[],
-        BitcodeReturns::Basic,
-        bitcode::LIST_CAPACITY,
-    )
-    .into_int_value()
+    builder
+        .build_extract_value(
+            wrapper_struct,
+            Builtin::WRAPPER_CAPACITY,
+            "list_capacity_or_ref_ptr",
+        )
+        .unwrap()
+        .into_int_value()
 }
 
 // Gets a pointer to just after the refcount for a list or seamless slice.

--- a/crates/compiler/gen_llvm/src/llvm/build_list.rs
+++ b/crates/compiler/gen_llvm/src/llvm/build_list.rs
@@ -801,13 +801,56 @@ pub(crate) fn decref<'a, 'ctx, 'env>(
     env: &Env<'a, 'ctx, 'env>,
     wrapper_struct: StructValue<'ctx>,
     alignment: u32,
+    parent: FunctionValue<'ctx>,
 ) {
-    // TODO: This definitely needs to handle seamless slices
-    let (_, pointer) = load_list(
-        env.builder,
-        wrapper_struct,
-        env.context.i8_type().ptr_type(AddressSpace::default()),
+    let builder = env.builder;
+    let ctx = env.context;
+
+    let capacity = list_capacity(builder, wrapper_struct);
+    let is_regular_list = builder.build_int_compare(
+        IntPredicate::SGE,
+        capacity,
+        env.ptr_int().const_zero(),
+        "cap >= 0",
     );
 
-    crate::llvm::refcounting::decref_pointer_check_null(env, pointer, alignment);
+    let get_list_ptr_block = ctx.append_basic_block(parent, "get_list_ptr");
+    let get_slice_ptr_block = ctx.append_basic_block(parent, "get_slice_ptr");
+    let decref_block = ctx.append_basic_block(parent, "decref");
+    builder.build_conditional_branch(is_regular_list, get_list_ptr_block, get_slice_ptr_block);
+
+    builder.position_at_end(get_list_ptr_block);
+    let ptr_type = env.context.i8_type().ptr_type(AddressSpace::default());
+    let (_, list_ptr) = load_list(builder, wrapper_struct, ptr_type);
+    builder.build_unconditional_branch(decref_block);
+
+    builder.position_at_end(get_slice_ptr_block);
+    let refcount_ptr_int = builder.build_left_shift(
+        capacity,
+        env.ptr_int().const_int(1, false),
+        "extract_refcount_from_capacity",
+    );
+    // TODO: adding one here feels silly.
+    // We should probably expose a zig builtin to directly deal with the refcount pointer.
+    // Instead we add one and then zig subtracts one.
+    let slice_ptr_int = builder.build_int_add(
+        refcount_ptr_int,
+        env.ptr_int().const_int(1, false),
+        "inc_refcount_ptr",
+    );
+    let slice_ptr = builder.build_int_to_ptr(slice_ptr_int, ptr_type, "to_slice_ptr");
+    builder.build_unconditional_branch(decref_block);
+
+    builder.position_at_end(decref_block);
+    let result = builder.build_phi(ptr_type, "branch");
+    result.add_incoming(&[
+        (&list_ptr, get_list_ptr_block),
+        (&slice_ptr, get_slice_ptr_block),
+    ]);
+
+    crate::llvm::refcounting::decref_pointer_check_null(
+        env,
+        result.as_basic_value().into_pointer_value(),
+        alignment,
+    );
 }

--- a/crates/compiler/gen_llvm/src/llvm/lowlevel.rs
+++ b/crates/compiler/gen_llvm/src/llvm/lowlevel.rs
@@ -28,8 +28,8 @@ use crate::llvm::{
         load_roc_value, roc_function_call, BuilderExt, RocReturn,
     },
     build_list::{
-        list_append_unsafe, list_capacity, list_concat, list_drop_at, list_get_unsafe, list_len,
-        list_map, list_map2, list_map3, list_map4, list_prepend, list_replace_unsafe, list_reserve,
+        list_append_unsafe, list_concat, list_drop_at, list_get_unsafe, list_len, list_map,
+        list_map2, list_map3, list_map4, list_prepend, list_replace_unsafe, list_reserve,
         list_sort_with, list_sublist, list_swap, list_symbol_to_c_abi, list_with_capacity,
         pass_update_mode,
     },
@@ -632,10 +632,16 @@ pub(crate) fn run_low_level<'a, 'ctx, 'env>(
             list_len(env.builder, list.into_struct_value()).into()
         }
         ListGetCapacity => {
-            // List.capacity : List * -> Nat
+            // List.capacity: List a -> Nat
             arguments!(list);
 
-            list_capacity(env.builder, list.into_struct_value()).into()
+            call_list_bitcode_fn(
+                env,
+                &[list.into_struct_value()],
+                &[],
+                BitcodeReturns::Basic,
+                bitcode::LIST_CAPACITY,
+            )
         }
         ListWithCapacity => {
             // List.withCapacity : Nat -> List a

--- a/crates/compiler/gen_llvm/src/llvm/refcounting.rs
+++ b/crates/compiler/gen_llvm/src/llvm/refcounting.rs
@@ -5,7 +5,9 @@ use crate::llvm::build::{
     add_func, cast_basic_basic, get_tag_id, tag_pointer_clear_tag_id, use_roc_value, Env,
     FAST_CALL_CONV,
 };
-use crate::llvm::build_list::{incrementing_elem_loop, list_capacity, load_list};
+use crate::llvm::build_list::{
+    incrementing_elem_loop, list_capacity, list_refcount_ptr, load_list,
+};
 use crate::llvm::convert::{basic_type_from_layout, zig_str_type, RocUnion};
 use bumpalo::collections::Vec;
 use inkwell::basic_block::BasicBlock;
@@ -41,21 +43,6 @@ impl<'ctx> PointerToRefcount<'ctx> {
             refcount_type.ptr_type(AddressSpace::default()),
             "to_refcount_ptr",
         );
-
-        Self { value }
-    }
-
-    /// # Safety
-    ///
-    /// the invariant is that the given pointer really points to the refcount,
-    /// not the data, and only is the start of the allocated buffer if the
-    /// alignment works out that way.
-    pub unsafe fn from_ptr_int<'a, 'env>(env: &Env<'a, 'ctx, 'env>, int: IntValue<'ctx>) -> Self {
-        let refcount_type = env.ptr_int();
-        let refcount_ptr_type = refcount_type.ptr_type(AddressSpace::default());
-        let value = env
-            .builder
-            .build_int_to_ptr(int, refcount_ptr_type, "to_refcount_ptr");
 
         Self { value }
     }
@@ -706,10 +693,10 @@ fn modify_refcount_list_help<'a, 'ctx, 'env>(
     let parent = fn_val;
     let original_wrapper = arg_val.into_struct_value();
 
-    let capacity = list_capacity(builder, original_wrapper);
+    let capacity = list_capacity(env, original_wrapper);
 
     let is_non_empty = builder.build_int_compare(
-        IntPredicate::SGT,
+        IntPredicate::UGT,
         capacity,
         env.ptr_int().const_zero(),
         "cap > 0",
@@ -717,11 +704,9 @@ fn modify_refcount_list_help<'a, 'ctx, 'env>(
 
     // build blocks
     let modification_list_block = ctx.append_basic_block(parent, "modification_list_block");
-    let check_slice_block = ctx.append_basic_block(parent, "check_slice_block");
-    let modification_slice_block = ctx.append_basic_block(parent, "modification_slice_block");
     let cont_block = ctx.append_basic_block(parent, "modify_rc_list_cont");
 
-    builder.build_conditional_branch(is_non_empty, modification_list_block, check_slice_block);
+    builder.build_conditional_branch(is_non_empty, modification_list_block, cont_block);
 
     builder.position_at_end(modification_list_block);
 
@@ -754,60 +739,8 @@ fn modify_refcount_list_help<'a, 'ctx, 'env>(
         );
     }
 
-    let refcount_ptr = PointerToRefcount::from_list_wrapper(env, original_wrapper);
-    let call_mode = mode_to_call_mode(fn_val, mode);
-    refcount_ptr.modify(call_mode, layout, env, layout_interner);
-
-    builder.build_unconditional_branch(cont_block);
-
-    builder.position_at_end(check_slice_block);
-
-    let is_seamless_slice = builder.build_int_compare(
-        IntPredicate::SLT,
-        capacity,
-        env.ptr_int().const_zero(),
-        "cap < 0",
-    );
-    builder.build_conditional_branch(is_seamless_slice, modification_slice_block, cont_block);
-
-    builder.position_at_end(modification_slice_block);
-
-    if layout_interner.contains_refcounted(element_layout) {
-        let ptr_type = basic_type_from_layout(env, layout_interner, element_layout)
-            .ptr_type(AddressSpace::default());
-
-        let (len, ptr) = load_list(env.builder, original_wrapper, ptr_type);
-
-        let loop_fn = |layout_interner, _index, element| {
-            modify_refcount_layout_help(
-                env,
-                layout_interner,
-                layout_ids,
-                mode.to_call_mode(fn_val),
-                element,
-                element_layout,
-            );
-        };
-
-        incrementing_elem_loop(
-            env,
-            layout_interner,
-            parent,
-            element_layout,
-            ptr,
-            len,
-            "modify_rc_index",
-            loop_fn,
-        );
-    }
-
-    // a slices refcount is `capacity << 1`
-    let refcount_ptr_int = builder.build_left_shift(
-        capacity,
-        env.ptr_int().const_int(1, false),
-        "extract_refcount_from_capacity",
-    );
-    let refcount_ptr = unsafe { PointerToRefcount::from_ptr_int(env, refcount_ptr_int) };
+    let refcount_ptr =
+        PointerToRefcount::from_ptr_to_data(env, list_refcount_ptr(env, original_wrapper));
     let call_mode = mode_to_call_mode(fn_val, mode);
     refcount_ptr.modify(call_mode, layout, env, layout_interner);
 

--- a/crates/compiler/gen_wasm/src/low_level.rs
+++ b/crates/compiler/gen_wasm/src/low_level.rs
@@ -318,44 +318,7 @@ impl<'a> LowLevelCall<'a> {
                 _ => internal_error!("invalid storage for List"),
             },
 
-            ListGetCapacity => match backend.storage.get(&self.arguments[0]) {
-                StoredValue::StackMemory { location, .. } => {
-                    let (local_id, offset) =
-                        location.local_and_offset(backend.storage.stack_frame_pointer);
-                    backend.code_builder.get_local(local_id);
-                    // List is stored as (pointer, length, capacity),
-                    // with each of those fields being 4 bytes on wasm.
-                    // So the capacity is 8 bytes after the start of the struct.
-                    //
-                    // WRAPPER_CAPACITY represents the index of the capacity field
-                    // (which is 2 as of the writing of this comment). If the field order
-                    // ever changes, WRAPPER_CAPACITY should be updated and this logic should
-                    // continue to work even though this comment may become inaccurate.
-
-                    // On top of this, if the capacity is less than zero, the list is a seamless slice.
-                    // We need to return the length in that case.
-                    let code_builder = &mut backend.code_builder;
-                    let tmp = backend.storage.create_anonymous_local(ValueType::I32);
-                    code_builder.i32_load(Align::Bytes4, offset + (4 * Builtin::WRAPPER_CAPACITY));
-                    code_builder.i64_const(0);
-                    code_builder.i32_lt_s(); // capacity < 0
-
-                    code_builder.if_();
-                    {
-                        code_builder.i32_load(Align::Bytes4, offset + (4 * Builtin::WRAPPER_LEN));
-                        code_builder.set_local(tmp);
-                    }
-                    code_builder.else_();
-                    {
-                        code_builder
-                            .i32_load(Align::Bytes4, offset + (4 * Builtin::WRAPPER_CAPACITY));
-                        code_builder.set_local(tmp);
-                    }
-                    code_builder.end();
-                    code_builder.get_local(tmp);
-                }
-                _ => internal_error!("invalid storage for List"),
-            },
+            ListGetCapacity => self.load_args_and_call_zig(backend, bitcode::LIST_CAPACITY),
 
             ListIsUnique => self.load_args_and_call_zig(backend, bitcode::LIST_IS_UNIQUE),
 

--- a/crates/valgrind/zig-platform/host.zig
+++ b/crates/valgrind/zig-platform/host.zig
@@ -130,7 +130,7 @@ pub fn main() u8 {
     // stdout the result
     stdout.print("{s}", .{callresult.asSlice()}) catch unreachable;
 
-    callresult.deinit();
+    callresult.decref();
 
     stderr.print("runtime: {d:.3}ms\n", .{seconds * 1000}) catch unreachable;
 

--- a/examples/cli/false-interpreter/platform/src/lib.rs
+++ b/examples/cli/false-interpreter/platform/src/lib.rs
@@ -134,18 +134,26 @@ pub extern "C" fn rust_main() -> i32 {
 
 unsafe fn call_the_closure(closure_data_ptr: *const u8) -> i64 {
     let size = size_Fx_result() as usize;
-    let layout = Layout::array::<u8>(size).unwrap();
-    let buffer = std::alloc::alloc(layout) as *mut u8;
+    if size == 0 {
+        call_Fx(
+            // This flags pointer will never get dereferenced
+            MaybeUninit::uninit().as_ptr(),
+            closure_data_ptr as *const u8,
+            std::ptr::null_mut(),
+        );
+    } else {
+        let layout = Layout::array::<u8>(size).unwrap();
+        let buffer = std::alloc::alloc(layout) as *mut u8;
 
-    call_Fx(
-        // This flags pointer will never get dereferenced
-        MaybeUninit::uninit().as_ptr(),
-        closure_data_ptr as *const u8,
-        buffer as *mut u8,
-    );
+        call_Fx(
+            // This flags pointer will never get dereferenced
+            MaybeUninit::uninit().as_ptr(),
+            closure_data_ptr as *const u8,
+            buffer as *mut u8,
+        );
 
-    std::alloc::dealloc(buffer, layout);
-
+        std::alloc::dealloc(buffer, layout);
+    }
     0
 }
 

--- a/examples/platform-switching/web-assembly-platform/host.zig
+++ b/examples/platform-switching/web-assembly-platform/host.zig
@@ -51,7 +51,7 @@ pub fn main() u8 {
     // display the result using JavaScript
     js_display_roc_string(callresult.asU8ptr(), callresult.len());
 
-    callresult.deinit();
+    callresult.decref();
 
     return 0;
 }

--- a/examples/platform-switching/zig-platform/host.zig
+++ b/examples/platform-switching/zig-platform/host.zig
@@ -130,7 +130,7 @@ pub fn main() u8 {
     // stdout the result
     stdout.print("{s}", .{callresult.asSlice()}) catch unreachable;
 
-    callresult.deinit();
+    callresult.decref();
 
     stderr.print("runtime: {d:.3}ms\n", .{seconds * 1000}) catch unreachable;
 

--- a/examples/virtual-dom-wip/platform/src/server-side/host.zig
+++ b/examples/virtual-dom-wip/platform/src/server-side/host.zig
@@ -51,13 +51,13 @@ const hostJavaScriptBytes = @embedFile("../client-side/host.js");
 
 pub fn main() u8 {
     const json = RocStr.fromSlice("42");
-    defer json.deinit();
+    defer json.decref();
 
     const hostJavaScript = RocStr.fromSlice(hostJavaScriptBytes);
-    defer hostJavaScript.deinit();
+    defer hostJavaScript.decref();
 
     const result = roc__main_1_exposed(json, hostJavaScript);
-    defer result.payload.deinit();
+    defer result.payload.decref();
 
     const writer = if (result.isOk)
         std.io.getStdOut().writer()


### PR DESCRIPTION
This PR adds seamless slices for Lists in Roc. It does not add them to strings.

Now functions like `List.drop` and `List.subList` will return slices. This should greatly help with the parser use case if a parser is operating over a list of bytes.