### PR TITLE
Tweak tutorial intro wording

### DIFF
--- a/www/generate_tutorial/src/tutorial.roc
+++ b/www/generate_tutorial/src/tutorial.roc
@@ -95,7 +95,7 @@ tutorialIntro =
                 label [id "tutorial-toc-toggle-label", for "tutorial-toc-toggle"] [text "contents"],
             ],
             p [] [text "Welcome to Roc!"],
-            p [] [text "This tutorial will teach you how to build Roc applications. Along the way, you'll learn how to write tests, use the REPL, and much more!"],
+            p [] [text "This tutorial will teach you how to build Roc applications. Along the way, you'll learn how to write tests, use the REPL, and more!"],
         ],
         section [] [
             h2 [ id "installation" ] [


### PR DESCRIPTION
Changing "much more" to "more" avoids a one-word wrapping:

## Before

<img width="570" alt="Screen Shot 2023-03-12 at 8 59 52 AM" src="https://user-images.githubusercontent.com/1094080/224546245-55e75c87-0d18-44e2-b0f0-c14f8bc26713.png">

## After

<img width="555" alt="Screen Shot 2023-03-12 at 9 00 24 AM" src="https://user-images.githubusercontent.com/1094080/224546280-c565f209-718b-4545-a539-f519f284cc9f.png">
