### PR TITLE
Increase spacing between docs entries

### DIFF
--- a/crates/docs/src/static/styles.css
+++ b/crates/docs/src/static/styles.css
@@ -175,7 +175,7 @@ section {
   border: 2px solid var(--border-color);
   border-radius: 8px;
   padding: 0px 0px 16px 0px;
-  margin: 32px 16px;
+  margin: 72px 16px;
 }
 
 section > *:last-child {


### PR DESCRIPTION
This makes the "cards" a bit more visually distinct from one another.

## Before

<img width="919" alt="Screen Shot 2023-03-12 at 9 08 19 AM" src="https://user-images.githubusercontent.com/1094080/224546693-9f3220f2-3937-4a14-8b6b-d5762ac618a9.png">

## After
<img width="972" alt="Screen Shot 2023-03-12 at 9 06 23 AM" src="https://user-images.githubusercontent.com/1094080/224546651-e376c6a9-804d-41cc-8878-1420cb020e48.png">
