### PR TITLE
Add a fast path for validating ASCII charcters

### DIFF
--- a/crates/compiler/builtins/bitcode/src/str.zig
+++ b/crates/compiler/builtins/bitcode/src/str.zig
@@ -1811,7 +1811,7 @@ pub fn fromUtf8RangeC(
 pub fn fromUtf8Range(arg: RocList, start: usize, count: usize, update_mode: UpdateMode) FromUtf8Result {
     const bytes = @ptrCast([*]const u8, arg.bytes)[start..count];
 
-    if (isValidUnicode(@ptrCast([*]const u8, bytes), bytes.len)) {
+    if (isValidUnicode(bytes)) {
         // the output will be correct. Now we need to clone the input
 
         // TODO: rework this to properly take advantage fo seamless slices.
@@ -1877,9 +1877,7 @@ fn errorToProblem(bytes: [*]u8, length: usize) struct { index: usize, problem: U
     unreachable;
 }
 
-pub fn isValidUnicode(ptr: [*]const u8, len: usize) callconv(.C) bool {
-    const buf: []const u8 = ptr[0..len];
-
+pub fn isValidUnicode(buf: []const u8) bool {
     const size = @sizeOf(u64);
     // TODO: we should test changing the step on other platforms.
     // The general tradeoff is making extremely large strings potentially much faster
@@ -1887,7 +1885,7 @@ pub fn isValidUnicode(ptr: [*]const u8, len: usize) callconv(.C) bool {
     const step = size;
     var i: usize = 0;
     while (i + step < buf.len) {
-        var bytes: u64 = 0;
+        var bytes: u64 = undefined;
         @memcpy(@ptrCast([*]u8, &bytes), @ptrCast([*]const u8, buf) + i, size);
         const unicode_bytes = bytes & 0x8080_8080_8080_8080;
         if (unicode_bytes == 0) {
@@ -1899,21 +1897,22 @@ pub fn isValidUnicode(ptr: [*]const u8, len: usize) callconv(.C) bool {
 
         while (buf[i] >= 0b1000_0000) {
             // This forces prefetching, otherwise the loop can run at about half speed.
-            var small_buf = [4]u8{ 0, 0, 0, 0 };
-            @memcpy(&small_buf, @ptrCast([*]const u8, buf) + i, size);
+            var small_buf: [4]u8 = undefined;
+            @memcpy(&small_buf, @ptrCast([*]const u8, buf) + i, 4);
             // TODO: Should we always inline these function calls below?
             if (std.unicode.utf8ByteSequenceLength(small_buf[0])) |cp_len| {
                 if (std.meta.isError(std.unicode.utf8Decode(small_buf[0..cp_len]))) {
                     return false;
                 }
                 i += cp_len;
-                if (i == buf.len) return true;
+                if (i + 4 >= buf.len) break;
             } else |_| {
                 return false;
             }
         }
     }
 
+    if (i == buf.len) return true;
     while (buf[i] < 0b1000_0000) {
         i += 1;
         if (i == buf.len) return true;

--- a/crates/compiler/builtins/bitcode/src/str.zig
+++ b/crates/compiler/builtins/bitcode/src/str.zig
@@ -1887,7 +1887,7 @@ pub fn isValidUnicode(ptr: [*]const u8, len: usize) callconv(.C) bool {
     const step = size;
     var i: usize = 0;
     while (i + step < buf.len) {
-        var bytes: usize = 0;
+        var bytes: u64 = 0;
         @memcpy(@ptrCast([*]u8, &bytes), @ptrCast([*]const u8, buf) + i, size);
         const unicode_bytes = bytes & 0x8080_8080_8080_8080;
         if (unicode_bytes == 0) {

--- a/crates/compiler/builtins/bitcode/src/str.zig
+++ b/crates/compiler/builtins/bitcode/src/str.zig
@@ -1811,7 +1811,7 @@ pub fn fromUtf8RangeC(
 pub fn fromUtf8Range(arg: RocList, start: usize, count: usize, update_mode: UpdateMode) FromUtf8Result {
     const bytes = @ptrCast([*]const u8, arg.bytes)[start..count];
 
-    if (unicode.utf8ValidateSlice(bytes)) {
+    if (isValidUnicode(@ptrCast([*]const u8, bytes), bytes.len)) {
         // the output will be correct. Now we need to clone the input
 
         // TODO: rework this to properly take advantage fo seamless slices.
@@ -1877,8 +1877,8 @@ fn errorToProblem(bytes: [*]u8, length: usize) struct { index: usize, problem: U
     unreachable;
 }
 
-pub fn isValidUnicode(ptr: [*]u8, len: usize) callconv(.C) bool {
-    const buf: []u8 = ptr[0..len];
+pub fn isValidUnicode(ptr: [*]const u8, len: usize) callconv(.C) bool {
+    const buf: []const u8 = ptr[0..len];
 
     const size = @sizeOf(u64);
     // TODO: we should test changing the step on other platforms.
@@ -1914,7 +1914,8 @@ pub fn isValidUnicode(ptr: [*]u8, len: usize) callconv(.C) bool {
         }
     }
 
-    while (buf[i] < 0b1000_0000) : (i += 1) {
+    while (buf[i] < 0b1000_0000) {
+        i += 1;
         if (i == buf.len) return true;
     }
 


### PR DESCRIPTION
From my quick testing using the code for testing this function in zig standard lib:

```
small ascii:     2.2x
small unicode:   0.9x
medium ascii:    15x
medium unicode:  1.01x
medium mix:      3.25x
large ascii:     32.8x
large unicode:   1.03x
large mixed:     3.35x
```

small being less than 8 bytes.
large being roughly greater than 512 bytes.

Not sure the exact turn over point, but only small unicode only strings are slower.