### PR TITLE
Misc seamless slice bugs

### DIFF
--- a/crates/cli/tests/cli_run.rs
+++ b/crates/cli/tests/cli_run.rs
@@ -807,7 +807,7 @@ mod cli_run {
             &[],
             &[Arg::ExamplePath("examples/sqrt.false")],
             &[],
-            &("1414".to_string()),
+            "1414",
             UseValgrind::Yes,
             TestCliCommands::Many,
         )

--- a/crates/cli/tests/cli_run.rs
+++ b/crates/cli/tests/cli_run.rs
@@ -805,10 +805,10 @@ mod cli_run {
             "False.roc",
             "false",
             &[],
-            &[Arg::ExamplePath("examples/hello.false")],
+            &[Arg::ExamplePath("examples/sqrt.false")],
             &[],
-            &("Hello, World!".to_string() + LINE_ENDING),
-            UseValgrind::No,
+            &("1414".to_string()),
+            UseValgrind::Yes,
             TestCliCommands::Many,
         )
     }

--- a/crates/compiler/builtins/bitcode/src/list.zig
+++ b/crates/compiler/builtins/bitcode/src/list.zig
@@ -511,6 +511,7 @@ pub fn listReleaseExcessCapacity(
 
             @memcpy(dest_ptr, source_ptr, old_length * element_width);
         }
+        list.decref(alignment);
         return output;
     }
 }

--- a/crates/compiler/builtins/bitcode/src/list.zig
+++ b/crates/compiler/builtins/bitcode/src/list.zig
@@ -606,18 +606,18 @@ pub fn listSublist(
 ) callconv(.C) RocList {
     const size = list.len();
     if (len == 0 or start >= size) {
-        if (list.isUnique()) {
-            // Decrement the reference counts of all elements.
-            if (list.bytes) |source_ptr| {
-                var i: usize = 0;
-                while (i < size) : (i += 1) {
-                    const element = source_ptr + i * element_width;
-                    dec(element);
-                }
-                var output = list;
-                output.length = 0;
-                return output;
+        // Decrement the reference counts of all elements.
+        if (list.bytes) |source_ptr| {
+            var i: usize = 0;
+            while (i < size) : (i += 1) {
+                const element = source_ptr + i * element_width;
+                dec(element);
             }
+        }
+        if (list.isUnique()) {
+            var output = list;
+            output.length = 0;
+            return output;
         }
         list.decref(alignment);
         return RocList.empty();

--- a/crates/compiler/builtins/bitcode/src/str.zig
+++ b/crates/compiler/builtins/bitcode/src/str.zig
@@ -1989,6 +1989,7 @@ pub fn isValidUnicode(buf: []const u8) bool {
 
         while (buf[i] >= 0b1000_0000) {
             // This forces prefetching, otherwise the loop can run at about half speed.
+            if (i + 4 >= buf.len) break;
             var small_buf: [4]u8 = undefined;
             @memcpy(&small_buf, @ptrCast([*]const u8, buf) + i, 4);
             // TODO: Should we always inline these function calls below?
@@ -1997,7 +1998,6 @@ pub fn isValidUnicode(buf: []const u8) bool {
                     return false;
                 }
                 i += cp_len;
-                if (i + 4 >= buf.len) break;
             } else |_| {
                 return false;
             }
@@ -2927,6 +2927,7 @@ pub fn strReleaseExcessCapacity(
         const dest_ptr = output.asU8ptrMut();
 
         @memcpy(dest_ptr, source_ptr, old_length);
+        string.decref();
 
         return output;
     }


### PR DESCRIPTION
Found some bugs with fuzzing and valgrind. Mostly minor edges cases around empty seamless slices.

Fixed a bug in my new utf8 code where we accessed passed the end of the array. The fix did not effect performance in any meaningful way.

Also, seamless slices caused us to hit an older bug in sublist where we would not decrement the refcount of elements in lists if the list was not unique and the sublist was going to be empty.