### PR TITLE
add docs/tests to Dict builtin

### DIFF
--- a/crates/compiler/builtins/roc/Dict.roc
+++ b/crates/compiler/builtins/roc/Dict.roc
@@ -100,6 +100,9 @@ Dict k v := {
 } | k has Hash & Eq
 
 ## Return an empty dictionary.
+## ```
+## emptyDict = Dict.empty {}
+## ```
 empty : {} -> Dict k v | k has Hash & Eq
 empty = \{} ->
     @Dict {
@@ -110,6 +113,12 @@ empty = \{} ->
     }
 
 ## Returns the max number of elements the dictionary can hold before requiring a rehash.
+## ```
+## foodDict =
+##           Dict.empty {}
+##           |> Dict.insert "apple" "fruit"
+## capacityOfDict = Dict.capacity foodDict
+## ```
 capacity : Dict k v -> Nat | k has Hash & Eq
 capacity = \@Dict { dataIndices } ->
     cap = List.len dataIndices
@@ -163,6 +172,16 @@ len = \@Dict { size } ->
     size
 
 ## Clears all elements from a dictionary keeping around the allocation if it isn't huge.
+## ```
+## songs =
+##        Dict.empty {}
+##        |> Dict.insert "One" "A Song"
+##        |> Dict.insert "Two" "Candy Canes"
+##        |> Dict.insert "Three" "Boughs of Holly"
+##
+## clearSongs = Dict.clear songs
+## expect Dict.len clearSongs |> Bool.isEq 0
+## ```
 clear : Dict k v -> Dict k v | k has Hash & Eq
 clear = \@Dict { metadata, dataIndices, data } ->
     cap = List.len dataIndices
@@ -206,6 +225,22 @@ walk = \@Dict { data }, initialState, transform ->
 ##
 ## As such, it is typically better for performance to use this over [Dict.walk]
 ## if returning `Break` earlier than the last element is expected to be common.
+## Below is a real world example
+## ```
+## transform = \count, k, v ->
+##     if k == "Orange" then
+##         Break count
+##     else
+##         Continue (count + v)
+##
+## foodDict = Dict.empty {}
+##     |> Dict.insert "Apples" 12
+##     |> Dict.insert "Orange" 24
+##     |> Dict.insert "Banana" 36
+##
+## walkUntil = Dict.walkUntil foodDict 0 transform
+## expect walkUntil == Bool.isEq 12
+## ```
 walkUntil : Dict k v, state, (state, k, v -> [Continue state, Break state]) -> state | k has Hash & Eq
 walkUntil = \@Dict { data }, initialState, transform ->
     List.walkUntil data initialState (\state, T k v -> transform state k v)
@@ -1235,3 +1270,25 @@ expect
         |> complete
 
     hash1 != hash2
+
+expect
+    empty {}
+    |> len
+    |> Bool.isEq 0
+
+expect
+    empty {}
+    |> insert "One" "A Song"
+    |> insert "Two" "Candy Canes"
+    |> insert "Three" "Boughs of Holly"
+    |> clear
+    |> len
+    |> Bool.isEq 0
+
+expect
+    Dict.empty {}
+    |> Dict.insert "Apples" 12
+    |> Dict.insert "Orange" 24
+    |> Dict.insert "Banana" 36
+    |> Dict.walkUntil 0 (\count, k, qty -> if k == "Orange" then Break count else Continue (count + qty))
+    |> Bool.isEq 12

--- a/crates/compiler/builtins/roc/Dict.roc
+++ b/crates/compiler/builtins/roc/Dict.roc
@@ -234,15 +234,15 @@ walk = \@Dict { data }, initialState, transform ->
 ##     |> Dict.insert "Bob" 18
 ##     |> Dict.insert "Charlie" 19
 ##
-## over18 = \_, _, age ->
+## isAdult = \_, _, age ->
 ##         if age >= 18 then
 ##             Break Bool.true
 ##         else
 ##             Continue Bool.false
 ##
-## someoneIsOver18 = Dict.walkUntil people Bool.false over18
+## someoneIsAnAdult = Dict.walkUntil people Bool.false isAdult
 ##
-## expect someoneIsOver18 == Bool.true
+## expect someoneIsAnAdult == Bool.true
 ## ```
 walkUntil : Dict k v, state, (state, k, v -> [Continue state, Break state]) -> state | k has Hash & Eq
 walkUntil = \@Dict { data }, initialState, transform ->

--- a/crates/compiler/builtins/roc/Dict.roc
+++ b/crates/compiler/builtins/roc/Dict.roc
@@ -117,6 +117,7 @@ empty = \{} ->
 ## foodDict =
 ##           Dict.empty {}
 ##           |> Dict.insert "apple" "fruit"
+##
 ## capacityOfDict = Dict.capacity foodDict
 ## ```
 capacity : Dict k v -> Nat | k has Hash & Eq
@@ -180,7 +181,8 @@ len = \@Dict { size } ->
 ##        |> Dict.insert "Three" "Boughs of Holly"
 ##
 ## clearSongs = Dict.clear songs
-## expect Dict.len clearSongs |> Bool.isEq 0
+##
+## expect Dict.len clearSongs == 0
 ## ```
 clear : Dict k v -> Dict k v | k has Hash & Eq
 clear = \@Dict { metadata, dataIndices, data } ->
@@ -225,21 +227,22 @@ walk = \@Dict { data }, initialState, transform ->
 ##
 ## As such, it is typically better for performance to use this over [Dict.walk]
 ## if returning `Break` earlier than the last element is expected to be common.
-## Below is a real world example
 ## ```
-## transform = \count, k, v ->
-##     if k == "Orange" then
-##         Break count
-##     else
-##         Continue (count + v)
+## people =
+##     Dict.empty {}
+##     |> Dict.insert "Alice" 17
+##     |> Dict.insert "Bob" 18
+##     |> Dict.insert "Charlie" 19
 ##
-## foodDict = Dict.empty {}
-##     |> Dict.insert "Apples" 12
-##     |> Dict.insert "Orange" 24
-##     |> Dict.insert "Banana" 36
+## over18 = \_, _, age ->
+##         if age >= 18 then
+##             Break Bool.true
+##         else
+##             Continue Bool.false
 ##
-## walkUntil = Dict.walkUntil foodDict 0 transform
-## expect walkUntil == Bool.isEq 12
+## someoneIsOver18 = Dict.walkUntil people Bool.false over18
+##
+## expect someoneIsOver18 == Bool.true
 ## ```
 walkUntil : Dict k v, state, (state, k, v -> [Continue state, Break state]) -> state | k has Hash & Eq
 walkUntil = \@Dict { data }, initialState, transform ->
@@ -1287,8 +1290,8 @@ expect
 
 expect
     Dict.empty {}
-    |> Dict.insert "Apples" 12
-    |> Dict.insert "Orange" 24
-    |> Dict.insert "Banana" 36
-    |> Dict.walkUntil 0 (\count, k, qty -> if k == "Orange" then Break count else Continue (count + qty))
-    |> Bool.isEq 12
+    |> Dict.insert "Alice" 17
+    |> Dict.insert "Bob" 18
+    |> Dict.insert "Charlie" 19
+    |> Dict.walkUntil Bool.false (\_, _, age -> if age >= 18 then Break Bool.true else Continue Bool.false)
+    |> Bool.isEq Bool.true

--- a/crates/compiler/test_mono/generated/dict.txt
+++ b/crates/compiler/test_mono/generated/dict.txt
@@ -1,22 +1,22 @@
-procedure Dict.1 (Dict.508):
-    let Dict.511 : List {[], []} = Array [];
-    let Dict.518 : U64 = 0i64;
-    let Dict.519 : U64 = 8i64;
-    let Dict.512 : List U64 = CallByName List.11 Dict.518 Dict.519;
-    let Dict.515 : I8 = CallByName Dict.34;
-    let Dict.516 : U64 = 8i64;
-    let Dict.513 : List I8 = CallByName List.11 Dict.515 Dict.516;
-    let Dict.514 : U64 = 0i64;
-    let Dict.510 : {List {[], []}, List U64, List I8, U64} = Struct {Dict.511, Dict.512, Dict.513, Dict.514};
-    ret Dict.510;
-
-procedure Dict.34 ():
-    let Dict.517 : I8 = -128i64;
+procedure Dict.1 (Dict.515):
+    let Dict.518 : List {[], []} = Array [];
+    let Dict.525 : U64 = 0i64;
+    let Dict.526 : U64 = 8i64;
+    let Dict.519 : List U64 = CallByName List.11 Dict.525 Dict.526;
+    let Dict.522 : I8 = CallByName Dict.34;
+    let Dict.523 : U64 = 8i64;
+    let Dict.520 : List I8 = CallByName List.11 Dict.522 Dict.523;
+    let Dict.521 : U64 = 0i64;
+    let Dict.517 : {List {[], []}, List U64, List I8, U64} = Struct {Dict.518, Dict.519, Dict.520, Dict.521};
     ret Dict.517;
 
-procedure Dict.4 (Dict.497):
-    let Dict.85 : U64 = StructAtIndex 3 Dict.497;
-    dec Dict.497;
+procedure Dict.34 ():
+    let Dict.524 : I8 = -128i64;
+    ret Dict.524;
+
+procedure Dict.4 (Dict.504):
+    let Dict.85 : U64 = StructAtIndex 3 Dict.504;
+    dec Dict.504;
     ret Dict.85;
 
 procedure List.11 (List.115, List.116):


### PR DESCRIPTION
Noticed that some methods were missing documentation when trying to look into the Dict builtin. I updated some documentation and added some additional tests.