### PR TITLE
Fix a field name in tutorial to match its context

### DIFF
--- a/www/generate_tutorial/src/input/tutorial.md
+++ b/www/generate_tutorial/src/input/tutorial.md
@@ -346,8 +346,8 @@ The `addAndStringify` function will accept any record with at least the fields `
 ```roc
 total = addAndStringify { birds: 5, iguanas: 7 }
 
-# The `name` field is unused by addAndStringify
-totalWithNote = addAndStringify { birds: 4, iguanas: 3, name: "Whee!" }
+# The `note` field is unused by addAndStringify
+totalWithNote = addAndStringify { birds: 4, iguanas: 3, note: "Whee!" }
 
 addAndStringify = \counts ->
     Num.toStr (counts.birds + counts.iguanas)


### PR DESCRIPTION
Hi I just started to learn roc and it is a really nice language!
While going through the tutorial, I found a possible mistake. This PR fixes it.