### PR TITLE
Ensure that closures inside recursive closures capture correctly

### DIFF
--- a/crates/compiler/solve/tests/solve_expr.rs
+++ b/crates/compiler/solve/tests/solve_expr.rs
@@ -8778,4 +8778,32 @@ mod solve_expr {
         @"main : List w_a"
         );
     }
+
+    #[test]
+    fn recursive_closure_with_transiently_used_capture() {
+        infer_queries!(
+            indoc!(
+                r#"
+                app "test" provides [f] to "./platform"
+
+                thenDo = \x, callback ->
+                    callback x
+
+                f = \{} ->
+                    code = 10u16
+
+                    bf = \{} ->
+                    #^^{-1}
+                        thenDo code \_ -> bf {}
+                        #           ^^^^^^^^^^^
+
+                    bf {}
+                "#
+            ),
+        @r###"
+        bf : {} -[[bf(5) U16]]-> *
+        \_ -> bf {} : U16 -[[6 U16]]-> *
+        "###
+        );
+    }
 }

--- a/crates/compiler/test_mono/generated/recursive_closure_with_transiently_used_capture.txt
+++ b/crates/compiler/test_mono/generated/recursive_closure_with_transiently_used_capture.txt
@@ -1,0 +1,18 @@
+procedure Test.1 (Test.2, Test.3):
+    let Test.14 : [] = CallByName Test.6 Test.2 Test.3;
+    ret Test.14;
+
+procedure Test.5 (Test.8, Test.4):
+    let Test.12 : [] = CallByName Test.1 Test.4 Test.4;
+    ret Test.12;
+
+procedure Test.6 (Test.15, Test.4):
+    let Test.18 : {} = Struct {};
+    let Test.17 : [] = CallByName Test.5 Test.18 Test.4;
+    ret Test.17;
+
+procedure Test.0 (Test.7):
+    let Test.4 : U16 = 10i64;
+    let Test.10 : {} = Struct {};
+    let Test.9 : [] = CallByName Test.5 Test.10 Test.4;
+    ret Test.9;

--- a/crates/compiler/test_mono/src/tests.rs
+++ b/crates/compiler/test_mono/src/tests.rs
@@ -2768,3 +2768,23 @@ fn inline_return_joinpoints_in_union_lambda_set() {
         "#
     )
 }
+
+#[mono_test]
+fn recursive_closure_with_transiently_used_capture() {
+    indoc!(
+        r#"
+        app "test" provides [f] to "./platform"
+
+        thenDo = \x, callback ->
+            callback x
+
+        f = \{} ->
+            code = 10u16
+
+            bf = \{} ->
+                thenDo code \_ -> bf {}
+
+            bf {}
+        "#
+    )
+}


### PR DESCRIPTION
With a code like

```
thenDo = \x, callback ->
    callback x

f = \{} ->
    code = 10u16

    bf = \{} ->
        thenDo code \_ -> bf {}

    bf {}
```

The lambda `\_ -> bf {}` must capture `bf`. Previously, this would not happen correctly, because we assumed that mutually recursive functions (including singleton recursive functions, like `bf` here) cannot capture themselves.

Of course, that premise does not hold in general. Instead, we should have mutually recursive functions capture the closure (haha, get it) of values captured by all functions constituting the mutual recursion. Then, any nested closures can capture outer recursive closures' values appropriately.