### PR TITLE
Treat html as text in markdown parsing to disallow html in docs

### DIFF
--- a/crates/docs/src/lib.rs
+++ b/crates/docs/src/lib.rs
@@ -884,6 +884,9 @@ fn markdown_to_html(
                     }
                 }
             }
+            Event::Html(html) => {
+                docs_parser.push(Event::Text(html));
+            }
             e => {
                 docs_parser.push(e);
             }


### PR DESCRIPTION
This PR resolves #4474 .
Thank you for the review!