### PR TITLE
Fix a few bugs Virtual-DOM cropped up

### DIFF
--- a/crates/compiler/derive_key/src/decoding.rs
+++ b/crates/compiler/derive_key/src/decoding.rs
@@ -100,7 +100,8 @@ impl FlatDecodable {
                 Self::from_var(subs, range.default_compilation_variable())
             }
             //
-            Content::RecursionVar { .. } => Err(Underivable),
+            Content::RecursionVar { structure, .. } => Self::from_var(subs, structure),
+            //
             Content::Error => Err(Underivable),
             Content::FlexVar(_)
             | Content::RigidVar(_)

--- a/crates/compiler/derive_key/src/encoding.rs
+++ b/crates/compiler/derive_key/src/encoding.rs
@@ -135,7 +135,8 @@ impl FlatEncodable {
                 Self::from_var(subs, range.default_compilation_variable())
             }
             //
-            Content::RecursionVar { .. } => Err(Underivable),
+            Content::RecursionVar { structure, .. } => Self::from_var(subs, structure),
+            //
             Content::Error => Err(Underivable),
             Content::FlexVar(_)
             | Content::RigidVar(_)

--- a/crates/compiler/mono/src/ir.rs
+++ b/crates/compiler/mono/src/ir.rs
@@ -5792,12 +5792,17 @@ fn late_resolve_ability_specialization<'a>(
             solved,
             unspecialized,
             recursion_var: _,
-            ambient_function: _,
+            ambient_function,
         } = env.subs.get_lambda_set(*lambda_set);
 
         debug_assert!(unspecialized.is_empty());
         let mut iter_lambda_set = solved.iter_all();
-        debug_assert_eq!(iter_lambda_set.len(), 1);
+        debug_assert_eq!(
+            iter_lambda_set.len(),
+            1,
+            "{:?}",
+            (env.subs.dbg(*lambda_set), env.subs.dbg(ambient_function))
+        );
         let spec_symbol_index = iter_lambda_set.next().unwrap().0;
         env.subs[spec_symbol_index]
     } else {

--- a/crates/compiler/unify/src/unify.rs
+++ b/crates/compiler/unify/src/unify.rs
@@ -1820,15 +1820,6 @@ fn unify_unspecialized_lambdas<M: MetaCollector>(
                             let _dropped = uls_right.next().unwrap();
                             let kept = uls_left.next().unwrap();
                             merged_uls.push(*kept);
-
-                            debug_assert!(uls_right
-                                .peek()
-                                .map(|r| !env.subs.equivalent_without_compacting(var_l, r.0))
-                                .unwrap_or(true));
-                            debug_assert!(uls_left
-                                .peek()
-                                .map(|l| !env.subs.equivalent_without_compacting(l.0, var_r))
-                                .unwrap_or(true));
                         } else {
                             // Even if these two variables unify, since they are not equivalent,
                             // they correspond to different specializations! As such we must not

--- a/crates/compiler/unify/src/unify.rs
+++ b/crates/compiler/unify/src/unify.rs
@@ -1823,11 +1823,11 @@ fn unify_unspecialized_lambdas<M: MetaCollector>(
 
                             debug_assert!(uls_right
                                 .peek()
-                                .map(|r| env.subs.equivalent_without_compacting(var_l, r.0))
+                                .map(|r| !env.subs.equivalent_without_compacting(var_l, r.0))
                                 .unwrap_or(true));
                             debug_assert!(uls_left
                                 .peek()
-                                .map(|l| env.subs.equivalent_without_compacting(l.0, var_r))
+                                .map(|l| !env.subs.equivalent_without_compacting(l.0, var_r))
                                 .unwrap_or(true));
                         } else {
                             // Even if these two variables unify, since they are not equivalent,


### PR DESCRIPTION
- Derivation of abilities for recursive types should trivially pass under the recursion var
- When we adjust rank for an alias's type variable, don't adjust its lambda set variables. The reasoning is given in the diff.

Closes #4806