### PR TITLE
Remove inaccurate debug assertion in IR gen

### DIFF
--- a/crates/compiler/mono/src/ir.rs
+++ b/crates/compiler/mono/src/ir.rs
@@ -4963,9 +4963,6 @@ pub fn with_hole<'a>(
                 _ => arena.alloc([record_layout]),
             };
 
-            debug_assert_eq!(field_layouts.len(), symbols.len());
-            debug_assert_eq!(fields.len(), symbols.len());
-
             if symbols.len() == 1 {
                 // TODO we can probably special-case this more, skippiing the generation of
                 // UpdateExisting

--- a/crates/compiler/test_mono/generated/issue_4759.txt
+++ b/crates/compiler/test_mono/generated/issue_4759.txt
@@ -1,0 +1,13 @@
+procedure Test.1 (Test.2):
+    dec Test.2;
+    let Test.7 : Str = "ux";
+    let Test.8 : Str = "uy";
+    let Test.6 : {Str, Str} = Struct {Test.7, Test.8};
+    ret Test.6;
+
+procedure Test.0 ():
+    let Test.10 : Str = "x";
+    let Test.11 : Str = "y";
+    let Test.9 : {Str, Str} = Struct {Test.10, Test.11};
+    let Test.3 : {Str, Str} = CallByName Test.1 Test.9;
+    ret Test.3;

--- a/crates/compiler/test_mono/src/tests.rs
+++ b/crates/compiler/test_mono/src/tests.rs
@@ -2845,3 +2845,17 @@ fn compose_recursive_lambda_set_productive_nullable_wrapped() {
          "#
     )
 }
+
+#[mono_test]
+fn issue_4759() {
+    indoc!(
+        r#"
+        app "test" provides [main] to "./platform"
+
+        main =
+            update { a : { x : "x", y: "y" } }
+
+        update = \state -> { state & a : { x : "ux", y: "uy" } }
+        "#
+    )
+}


### PR DESCRIPTION
There might be more symbols than field layouts when restructuring a
record if the record is a newtype.

Closes #4759
