### PR TITLE
Only mark roc_std no_std if std feature is not present

### DIFF
--- a/crates/roc_std/src/lib.rs
+++ b/crates/roc_std/src/lib.rs
@@ -1,5 +1,5 @@
 //! Provides Rust representations of Roc data structures.
-#![no_std]
+#![cfg_attr(not(feature = "std"), no_std)]
 #![crate_type = "lib"]
 
 use arrayvec::ArrayString;

--- a/crates/roc_std/src/roc_str.rs
+++ b/crates/roc_std/src/roc_str.rs
@@ -18,7 +18,7 @@ use core::{
 };
 
 #[cfg(feature = "std")]
-use core::ffi::{CStr, CString};
+use std::ffi::{CStr, CString};
 
 use crate::RocList;
 


### PR DESCRIPTION
Otherwise, you will get compile errors with the std feature.