### PR TITLE
Directly import files as `Str` or `List U8`

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -737,7 +737,7 @@ pub fn build(
                             "─".repeat(80)
                         );
 
-                        // Return a nonzero exit code due to falta problem
+                        // Return a nonzero exit code due to fatal problem
                         return Ok(problems.exit_code());
                     }
                     if problems.errors > 0 || problems.warnings > 0 {
@@ -764,7 +764,7 @@ pub fn build(
                             "─".repeat(80)
                         );
 
-                        // Return a nonzero exit code due to falta problem
+                        // Return a nonzero exit code due to fatal problem
                         return Ok(problems.exit_code());
                     }
                     debug_assert_eq!(

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -730,6 +730,16 @@ pub fn build(
                     Ok(problems.exit_code())
                 }
                 BuildAndRun => {
+                    if problems.fatally_errored {
+                        problems.print_to_stdout(total_time);
+                        println!(
+                            ".\n\nCannot run program due to fatal error…\n\n\x1B[36m{}\x1B[39m",
+                            "─".repeat(80)
+                        );
+
+                        // Return a nonzero exit code due to falta problem
+                        return Ok(problems.exit_code());
+                    }
                     if problems.errors > 0 || problems.warnings > 0 {
                         problems.print_to_stdout(total_time);
                         println!(

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -757,10 +757,21 @@ pub fn build(
                     roc_run(&arena, opt_level, triple, args, bytes, expect_metadata)
                 }
                 BuildAndRunIfNoErrors => {
+                    if problems.fatally_errored {
+                        problems.print_to_stdout(total_time);
+                        println!(
+                            ".\n\nCannot run program due to fatal error…\n\n\x1B[36m{}\x1B[39m",
+                            "─".repeat(80)
+                        );
+
+                        // Return a nonzero exit code due to falta problem
+                        return Ok(problems.exit_code());
+                    }
                     debug_assert_eq!(
                         problems.errors, 0,
-                        "if there are errors, they should have been returned as an error variant"
+                        "if there are non-fatal errors, they should have been returned as an error variant"
                     );
+
                     if problems.warnings > 0 {
                         problems.print_to_stdout(total_time);
                         println!(

--- a/crates/cli/tests/cli_run.rs
+++ b/crates/cli/tests/cli_run.rs
@@ -875,21 +875,23 @@ mod cli_run {
             &[],
             &[],
             &[],
-            r#"
-This roc file can print it's own source code. The source is:
+            indoc!(
+                r#"
+                This roc file can print it's own source code. The source is:
 
-app "ingested-file"
-    packages { pf: "cli-platform/main.roc" }
-    imports [
-        pf.Stdout,
-        "ingested-file.roc" as ownCode : Str,
-    ]
-    provides [main] to pf
+                app "ingested-file"
+                    packages { pf: "cli-platform/main.roc" }
+                    imports [
+                        pf.Stdout,
+                        "ingested-file.roc" as ownCode : Str,
+                    ]
+                    provides [main] to pf
 
-main =
-    Stdout.line "\nThis roc file can print it's own source code. The source is:\n\n\(ownCode)"
+                main =
+                    Stdout.line "\nThis roc file can print it's own source code. The source is:\n\n\(ownCode)"
 
-"#,
+                "#
+            ),
             UseValgrind::No,
             TestCliCommands::Run,
         )

--- a/crates/cli/tests/cli_run.rs
+++ b/crates/cli/tests/cli_run.rs
@@ -882,7 +882,7 @@ app "ingested-file"
     packages { pf: "cli-platform/main.roc" }
     imports [
         pf.Stdout,
-        "ingested-file.roc" as ownCode: Str
+        "ingested-file.roc" as ownCode : Str,
     ]
     provides [main] to pf
 

--- a/crates/cli/tests/cli_run.rs
+++ b/crates/cli/tests/cli_run.rs
@@ -865,6 +865,37 @@ mod cli_run {
     }
 
     #[test]
+    #[serial(cli_platform)]
+    #[cfg_attr(windows, ignore)]
+    fn ingested_file() {
+        test_roc_app(
+            "examples/cli",
+            "ingested-file.roc",
+            "ingested-file",
+            &[],
+            &[],
+            &[],
+            r#"
+This roc file can print it's own source code. The source is:
+
+app "ingested-file"
+    packages { pf: "cli-platform/main.roc" }
+    imports [
+        pf.Stdout,
+        "ingested-file.roc" as ownCode: Str
+    ]
+    provides [main] to pf
+
+main =
+    Stdout.line "\nThis roc file can print it's own source code. The source is:\n\n\(ownCode)"
+
+"#,
+            UseValgrind::No,
+            TestCliCommands::Run,
+        )
+    }
+
+    #[test]
     #[serial(parser_package)]
     #[serial(zig_platform)]
     #[cfg_attr(windows, ignore)]

--- a/crates/cli/tests/cli_run.rs
+++ b/crates/cli/tests/cli_run.rs
@@ -896,6 +896,23 @@ main =
     }
 
     #[test]
+    #[serial(cli_platform)]
+    #[cfg_attr(windows, ignore)]
+    fn ingested_file_bytes() {
+        test_roc_app(
+            "examples/cli",
+            "ingested-file-bytes.roc",
+            "ingested-file-bytes",
+            &[],
+            &[],
+            &[],
+            "22424\n",
+            UseValgrind::No,
+            TestCliCommands::Run,
+        )
+    }
+
+    #[test]
     #[serial(parser_package)]
     #[serial(zig_platform)]
     #[cfg_attr(windows, ignore)]

--- a/crates/compiler/can/src/constraint.rs
+++ b/crates/compiler/can/src/constraint.rs
@@ -1,5 +1,6 @@
 use std::cell::Cell;
 use std::path::Path;
+use std::sync::Arc;
 
 use crate::abilities::SpecializationId;
 use crate::exhaustive::{ExhaustiveContext, SketchedRows};
@@ -680,14 +681,14 @@ impl Constraints {
         &mut self,
         type_index: TypeOrVar,
         file_path: Box<Path>,
-        bytes: Vec<u8>,
+        bytes: Arc<Vec<u8>>,
     ) -> Constraint {
         Constraint::IngestedFile(type_index, file_path, bytes)
     }
 }
 
-roc_error_macros::assert_sizeof_default!(Constraint, 6 * 8);
-roc_error_macros::assert_sizeof_aarch64!(Constraint, 6 * 8);
+roc_error_macros::assert_sizeof_default!(Constraint, 4 * 8);
+roc_error_macros::assert_sizeof_aarch64!(Constraint, 4 * 8);
 
 impl std::ops::Index<ExpectedTypeIndex> for Constraints {
     type Output = Expected<TypeOrVar>;
@@ -785,9 +786,7 @@ pub enum Constraint {
     Resolve(OpportunisticResolve),
     CheckCycle(Index<Cycle>, IllegalCycleMark),
 
-    // This is terrible and could be a huge cost to copy.
-    // Not sure a better way to get the bytes here so we can check if they are valid utf8 or decode properly.
-    IngestedFile(TypeOrVar, Box<Path>, Vec<u8>),
+    IngestedFile(TypeOrVar, Box<Path>, Arc<Vec<u8>>),
 }
 
 #[derive(Debug, Clone, Copy, Default)]

--- a/crates/compiler/can/src/constraint.rs
+++ b/crates/compiler/can/src/constraint.rs
@@ -1,5 +1,5 @@
 use std::cell::Cell;
-use std::path::Path;
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use crate::abilities::SpecializationId;
@@ -680,15 +680,15 @@ impl Constraints {
     pub fn ingested_file(
         &mut self,
         type_index: TypeOrVar,
-        file_path: Box<Path>,
+        file_path: Box<PathBuf>,
         bytes: Arc<Vec<u8>>,
     ) -> Constraint {
         Constraint::IngestedFile(type_index, file_path, bytes)
     }
 }
 
-roc_error_macros::assert_sizeof_default!(Constraint, 4 * 8);
-roc_error_macros::assert_sizeof_aarch64!(Constraint, 4 * 8);
+roc_error_macros::assert_sizeof_default!(Constraint, 3 * 8);
+roc_error_macros::assert_sizeof_aarch64!(Constraint, 3 * 8);
 
 impl std::ops::Index<ExpectedTypeIndex> for Constraints {
     type Output = Expected<TypeOrVar>;
@@ -786,7 +786,7 @@ pub enum Constraint {
     Resolve(OpportunisticResolve),
     CheckCycle(Index<Cycle>, IllegalCycleMark),
 
-    IngestedFile(TypeOrVar, Box<Path>, Arc<Vec<u8>>),
+    IngestedFile(TypeOrVar, Box<PathBuf>, Arc<Vec<u8>>),
 }
 
 #[derive(Debug, Clone, Copy, Default)]

--- a/crates/compiler/can/src/copy.rs
+++ b/crates/compiler/can/src/copy.rs
@@ -277,7 +277,9 @@ fn deep_copy_expr_help<C: CopyEnv>(env: &mut C, copied: &mut Vec<Variable>, expr
         Float(v1, v2, str, val, bound) => Float(sub!(*v1), sub!(*v2), str.clone(), *val, *bound),
         Str(str) => Str(str.clone()),
         SingleQuote(v1, v2, char, bound) => SingleQuote(sub!(*v1), sub!(*v2), *char, *bound),
-        IngestedFile(bytes, anno) => IngestedFile(bytes.clone(), anno.clone()),
+        IngestedFile(file_path, bytes, anno) => {
+            IngestedFile(file_path.clone(), bytes.clone(), anno.clone())
+        }
         List {
             elem_var,
             loc_elems,

--- a/crates/compiler/can/src/copy.rs
+++ b/crates/compiler/can/src/copy.rs
@@ -277,6 +277,7 @@ fn deep_copy_expr_help<C: CopyEnv>(env: &mut C, copied: &mut Vec<Variable>, expr
         Float(v1, v2, str, val, bound) => Float(sub!(*v1), sub!(*v2), str.clone(), *val, *bound),
         Str(str) => Str(str.clone()),
         SingleQuote(v1, v2, char, bound) => SingleQuote(sub!(*v1), sub!(*v2), *char, *bound),
+        IngestedFile(bytes, anno) => IngestedFile(bytes.clone(), anno.clone()),
         List {
             elem_var,
             loc_elems,

--- a/crates/compiler/can/src/copy.rs
+++ b/crates/compiler/can/src/copy.rs
@@ -277,8 +277,8 @@ fn deep_copy_expr_help<C: CopyEnv>(env: &mut C, copied: &mut Vec<Variable>, expr
         Float(v1, v2, str, val, bound) => Float(sub!(*v1), sub!(*v2), str.clone(), *val, *bound),
         Str(str) => Str(str.clone()),
         SingleQuote(v1, v2, char, bound) => SingleQuote(sub!(*v1), sub!(*v2), *char, *bound),
-        IngestedFile(file_path, bytes, anno) => {
-            IngestedFile(file_path.clone(), bytes.clone(), anno.clone())
+        IngestedFile(file_path, bytes, var) => {
+            IngestedFile(file_path.clone(), bytes.clone(), sub!(*var))
         }
         List {
             elem_var,

--- a/crates/compiler/can/src/debug/pretty_print.rs
+++ b/crates/compiler/can/src/debug/pretty_print.rs
@@ -165,6 +165,7 @@ fn expr<'a>(c: &Ctx, p: EPrec, f: &'a Arena<'a>, e: &'a Expr) -> DocBuilder<'a, 
         Num(_, n, _, _) | Int(_, _, n, _, _) | Float(_, _, n, _, _) => f.text(&**n),
         Str(s) => f.text(format!(r#""{}""#, s)),
         SingleQuote(_, _, c, _) => f.text(format!("'{}'", c)),
+        IngestedFile(_,_) => todo!("I am not really sure how we want this to be printed. file name? all bytes? as correct type?"),
         List {
             elem_var: _,
             loc_elems,

--- a/crates/compiler/can/src/debug/pretty_print.rs
+++ b/crates/compiler/can/src/debug/pretty_print.rs
@@ -165,7 +165,9 @@ fn expr<'a>(c: &Ctx, p: EPrec, f: &'a Arena<'a>, e: &'a Expr) -> DocBuilder<'a, 
         Num(_, n, _, _) | Int(_, _, n, _, _) | Float(_, _, n, _, _) => f.text(&**n),
         Str(s) => f.text(format!(r#""{}""#, s)),
         SingleQuote(_, _, c, _) => f.text(format!("'{}'", c)),
-        IngestedFile(_,_) => todo!("I am not really sure how we want this to be printed. file name? all bytes? as correct type?"),
+        IngestedFile(file_path, bytes, _) => {
+            f.text(format!("<ingested {:?}, {} bytes>", file_path, bytes.len()))
+        }
         List {
             elem_var: _,
             loc_elems,

--- a/crates/compiler/can/src/expr.rs
+++ b/crates/compiler/can/src/expr.rs
@@ -730,7 +730,10 @@ pub fn canonicalize_expr<'a>(
         ast::Expr::Str(literal) => flatten_str_literal(env, var_store, scope, literal),
 
         // TODO: is this where we should finally load the file?
-        ast::Expr::IngestedFile(literal) => flatten_str_literal(env, var_store, scope, literal),
+        ast::Expr::IngestedFile(file_path, _) => (
+            Expr::Str(file_path.to_str().unwrap().into()),
+            Output::default(),
+        ),
 
         ast::Expr::SingleQuote(string) => {
             let mut it = string.chars().peekable();

--- a/crates/compiler/can/src/expr.rs
+++ b/crates/compiler/can/src/expr.rs
@@ -29,7 +29,7 @@ use roc_types::types::{Alias, Category, IndexOrField, LambdaSet, OptAbleVar, Typ
 use std::fmt::{Debug, Display};
 use std::fs::File;
 use std::io::Read;
-use std::path::Path;
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::{char, u32};
 
@@ -105,7 +105,7 @@ pub enum Expr {
     },
 
     // An ingested files, it's bytes, and the type variable.
-    IngestedFile(Box<Path>, Arc<Vec<u8>>, Variable),
+    IngestedFile(Box<PathBuf>, Arc<Vec<u8>>, Variable),
 
     // Lookups
     Var(Symbol, Variable),
@@ -742,7 +742,11 @@ pub fn canonicalize_expr<'a>(
                 let mut bytes = vec![];
                 match file.read_to_end(&mut bytes) {
                     Ok(_) => (
-                        Expr::IngestedFile((*file_path).into(), Arc::new(bytes), var_store.fresh()),
+                        Expr::IngestedFile(
+                            file_path.to_path_buf().into(),
+                            Arc::new(bytes),
+                            var_store.fresh(),
+                        ),
                         Output::default(),
                     ),
                     Err(e) => {

--- a/crates/compiler/can/src/expr.rs
+++ b/crates/compiler/can/src/expr.rs
@@ -729,6 +729,9 @@ pub fn canonicalize_expr<'a>(
 
         ast::Expr::Str(literal) => flatten_str_literal(env, var_store, scope, literal),
 
+        // TODO: is this where we should finally load the file?
+        ast::Expr::IngestedFile(literal) => flatten_str_literal(env, var_store, scope, literal),
+
         ast::Expr::SingleQuote(string) => {
             let mut it = string.chars().peekable();
             if let Some(char) = it.next() {

--- a/crates/compiler/can/src/expr.rs
+++ b/crates/compiler/can/src/expr.rs
@@ -302,19 +302,7 @@ impl Expr {
             Self::Int(..) => Category::Int,
             Self::Float(..) => Category::Frac,
             Self::Str(..) => Category::Str,
-            Self::IngestedFile(_, anno) => {
-                dbg!(&anno);
-                todo!()
-                // if let Type::Apply(0, 1, 2) = anno.typ {
-                //     Category::Str
-                // } else if let Type::Apply(_, _, _) = anno.typ {
-                //     Category::List
-                // } else {
-                //     todo!(
-                //         "Not sure how we should handle other types here that are probably invalid"
-                //     )
-                // }
-            }
+            Self::IngestedFile(..) => Category::IngestedFile,
             Self::SingleQuote(..) => Category::Character,
             Self::List { .. } => Category::List,
             &Self::Var(sym, _) => Category::Lookup(sym),

--- a/crates/compiler/can/src/expr.rs
+++ b/crates/compiler/can/src/expr.rs
@@ -30,6 +30,7 @@ use std::fmt::{Debug, Display};
 use std::fs::File;
 use std::io::Read;
 use std::path::Path;
+use std::sync::Arc;
 use std::{char, u32};
 
 /// Derives that an opaque type has claimed, to checked and recorded after solving.
@@ -103,8 +104,8 @@ pub enum Expr {
         loc_elems: Vec<Loc<Expr>>,
     },
 
-    // The bytes of a file and the expected type annotation.
-    IngestedFile(Box<Path>, Vec<u8>, Variable),
+    // An ingested files, it's bytes, and the type variable.
+    IngestedFile(Box<Path>, Arc<Vec<u8>>, Variable),
 
     // Lookups
     Var(Symbol, Variable),
@@ -741,7 +742,7 @@ pub fn canonicalize_expr<'a>(
                 let mut bytes = vec![];
                 match file.read_to_end(&mut bytes) {
                     Ok(_) => (
-                        Expr::IngestedFile((*file_path).into(), bytes, var_store.fresh()),
+                        Expr::IngestedFile((*file_path).into(), Arc::new(bytes), var_store.fresh()),
                         Output::default(),
                     ),
                     Err(e) => {

--- a/crates/compiler/can/src/module.rs
+++ b/crates/compiler/can/src/module.rs
@@ -1093,6 +1093,7 @@ fn fix_values_captured_in_closure_expr(
         | Float(..)
         | Str(_)
         | SingleQuote(..)
+        | IngestedFile(..)
         | Var(..)
         | AbilityMember(..)
         | EmptyRecord

--- a/crates/compiler/can/src/operator.rs
+++ b/crates/compiler/can/src/operator.rs
@@ -138,6 +138,7 @@ pub fn desugar_expr<'a>(arena: &'a Bump, loc_expr: &'a Loc<Expr<'a>>) -> &'a Loc
         | PrecedenceConflict { .. }
         | Tag(_)
         | OpaqueRef(_)
+        | IngestedFile(_)
         | Crash => loc_expr,
 
         TupleAccess(sub_expr, paths) => {

--- a/crates/compiler/can/src/operator.rs
+++ b/crates/compiler/can/src/operator.rs
@@ -138,7 +138,7 @@ pub fn desugar_expr<'a>(arena: &'a Bump, loc_expr: &'a Loc<Expr<'a>>) -> &'a Loc
         | PrecedenceConflict { .. }
         | Tag(_)
         | OpaqueRef(_)
-        | IngestedFile(_)
+        | IngestedFile(_, _)
         | Crash => loc_expr,
 
         TupleAccess(sub_expr, paths) => {

--- a/crates/compiler/can/src/traverse.rs
+++ b/crates/compiler/can/src/traverse.rs
@@ -257,6 +257,7 @@ pub fn walk_expr<V: Visitor>(visitor: &mut V, expr: &Expr, var: Variable) {
         Expr::Int(..) => { /* terminal */ }
         Expr::Float(..) => { /* terminal */ }
         Expr::Str(..) => { /* terminal */ }
+        Expr::IngestedFile(..) => { /* terminal */ }
         Expr::SingleQuote(..) => { /* terminal */ }
         Expr::List {
             elem_var,

--- a/crates/compiler/constrain/src/expr.rs
+++ b/crates/compiler/constrain/src/expr.rs
@@ -377,7 +377,7 @@ pub fn constrain_expr(
         }
         IngestedFile(bytes, anno) => match &anno.typ {
             Type::Apply(Symbol::STR_STR, _, _) => {
-                if let Err(_) = std::str::from_utf8(bytes) {
+                if std::str::from_utf8(bytes).is_err() {
                     todo!("cause an error for the type being wrong due to not being a utf8 string");
                 }
 

--- a/crates/compiler/constrain/src/expr.rs
+++ b/crates/compiler/constrain/src/expr.rs
@@ -375,6 +375,12 @@ pub fn constrain_expr(
             let expected_index = expected;
             constraints.equal_types(str_index, expected_index, Category::Str, region)
         }
+        IngestedFile(_, _) => {
+            // This is probably where real type checking happens?
+            let str_index = constraints.push_type(types, Types::STR);
+            let expected_index = expected;
+            constraints.equal_types(str_index, expected_index, Category::Str, region)
+        }
         SingleQuote(num_var, precision_var, _, bound) => single_quote_literal(
             types,
             constraints,
@@ -3943,6 +3949,7 @@ fn is_generalizable_expr(mut expr: &Expr) -> bool {
             }
             OpaqueRef { argument, .. } => expr = &argument.1.value,
             Str(_)
+            | IngestedFile(_, _)
             | List { .. }
             | SingleQuote(_, _, _, _)
             | When { .. }

--- a/crates/compiler/constrain/src/expr.rs
+++ b/crates/compiler/constrain/src/expr.rs
@@ -375,14 +375,15 @@ pub fn constrain_expr(
             let expected_index = expected;
             constraints.equal_types(str_index, expected_index, Category::Str, region)
         }
-        IngestedFile(_, anno) => match &anno.typ {
+        IngestedFile(bytes, anno) => match &anno.typ {
             Type::Apply(Symbol::STR_STR, _, _) => {
+                if let Err(_) = std::str::from_utf8(bytes) {
+                    todo!("cause an error for the type being wrong due to not being a utf8 string");
+                }
+
                 let str_index = constraints.push_type(types, Types::STR);
                 let expected_index = expected;
                 constraints.equal_types(str_index, expected_index, Category::Str, region)
-
-                // TODO: I believe we also should check to make sure they bytes are valid utf8 and bubble up an error.
-                // I am just not sure how the error would get bubbled up.
             }
             Type::Apply(Symbol::LIST_LIST, elem_type, _)
                 if matches!(

--- a/crates/compiler/fmt/src/expr.rs
+++ b/crates/compiler/fmt/src/expr.rs
@@ -44,7 +44,7 @@ impl<'a> Formattable for Expr<'a> {
             | MalformedClosure
             | Tag(_)
             | OpaqueRef(_)
-            | IngestedFile(_)
+            | IngestedFile(_, _)
             | Crash => false,
 
             // These expressions always have newlines
@@ -478,7 +478,7 @@ impl<'a> Formattable for Expr<'a> {
             }
             MalformedClosure => {}
             PrecedenceConflict { .. } => {}
-            IngestedFile(_) => {}
+            IngestedFile(_, _) => {}
         }
     }
 }

--- a/crates/compiler/fmt/src/expr.rs
+++ b/crates/compiler/fmt/src/expr.rs
@@ -44,6 +44,7 @@ impl<'a> Formattable for Expr<'a> {
             | MalformedClosure
             | Tag(_)
             | OpaqueRef(_)
+            | IngestedFile(_)
             | Crash => false,
 
             // These expressions always have newlines
@@ -477,6 +478,7 @@ impl<'a> Formattable for Expr<'a> {
             }
             MalformedClosure => {}
             PrecedenceConflict { .. } => {}
+            IngestedFile(_) => {}
         }
     }
 }

--- a/crates/compiler/fmt/src/module.rs
+++ b/crates/compiler/fmt/src/module.rs
@@ -510,7 +510,7 @@ fn fmt_imports_entry<'a, 'buf>(buf: &mut Buf<'buf>, entry: &ImportsEntry<'a>, in
 
         IngestedFile(file_name, typed_ident) => {
             fmt_str_literal(buf, *file_name, indent);
-            buf.push_str(" as ");
+            buf.push_str_allow_spaces(" as ");
             typed_ident.format(buf, 0);
         }
     }

--- a/crates/compiler/fmt/src/module.rs
+++ b/crates/compiler/fmt/src/module.rs
@@ -507,5 +507,11 @@ fn fmt_imports_entry<'a, 'buf>(buf: &mut Buf<'buf>, entry: &ImportsEntry<'a>, in
                 fmt_collection(buf, indent, Braces::Curly, *entries, Newlines::No)
             }
         }
+
+        IngestedFile(file_name, typed_ident) => {
+            fmt_str_literal(buf, *file_name, indent);
+            buf.push_str(" as ");
+            typed_ident.format(buf, 0);
+        }
     }
 }

--- a/crates/compiler/fmt/src/spaces.rs
+++ b/crates/compiler/fmt/src/spaces.rs
@@ -658,7 +658,7 @@ impl<'a> RemoveSpaces<'a> for Expr<'a> {
                 is_negative,
             },
             Expr::Str(a) => Expr::Str(a.remove_spaces(arena)),
-            Expr::IngestedFile(a) => Expr::Str(a.remove_spaces(arena)),
+            Expr::IngestedFile(a, b) => Expr::IngestedFile(a, b),
             Expr::RecordAccess(a, b) => Expr::RecordAccess(arena.alloc(a.remove_spaces(arena)), b),
             Expr::AccessorFunction(a) => Expr::AccessorFunction(a),
             Expr::TupleAccess(a, b) => Expr::TupleAccess(arena.alloc(a.remove_spaces(arena)), b),

--- a/crates/compiler/fmt/src/spaces.rs
+++ b/crates/compiler/fmt/src/spaces.rs
@@ -658,6 +658,7 @@ impl<'a> RemoveSpaces<'a> for Expr<'a> {
                 is_negative,
             },
             Expr::Str(a) => Expr::Str(a.remove_spaces(arena)),
+            Expr::IngestedFile(a) => Expr::Str(a.remove_spaces(arena)),
             Expr::RecordAccess(a, b) => Expr::RecordAccess(arena.alloc(a.remove_spaces(arena)), b),
             Expr::AccessorFunction(a) => Expr::AccessorFunction(a),
             Expr::TupleAccess(a, b) => Expr::TupleAccess(arena.alloc(a.remove_spaces(arena)), b),

--- a/crates/compiler/fmt/src/spaces.rs
+++ b/crates/compiler/fmt/src/spaces.rs
@@ -420,6 +420,9 @@ impl<'a> RemoveSpaces<'a> for ImportsEntry<'a> {
         match *self {
             ImportsEntry::Module(a, b) => ImportsEntry::Module(a, b.remove_spaces(arena)),
             ImportsEntry::Package(a, b, c) => ImportsEntry::Package(a, b, c.remove_spaces(arena)),
+            ImportsEntry::IngestedFile(a, b) => {
+                ImportsEntry::IngestedFile(a, b.remove_spaces(arena))
+            }
         }
     }
 }

--- a/crates/compiler/load_internal/tests/fixtures/build/interface_with_deps/IngestedFile.roc
+++ b/crates/compiler/load_internal/tests/fixtures/build/interface_with_deps/IngestedFile.roc
@@ -1,0 +1,5 @@
+interface IngestedFile
+    exposes [str]
+    imports ["IngestedFile.roc" as foo : Str]
+
+str = foo

--- a/crates/compiler/load_internal/tests/fixtures/build/interface_with_deps/IngestedFileBytes.roc
+++ b/crates/compiler/load_internal/tests/fixtures/build/interface_with_deps/IngestedFileBytes.roc
@@ -1,0 +1,5 @@
+interface IngestedFileBytes
+    exposes [str]
+    imports ["IngestedFileBytes.roc" as foo : List U8]
+
+str = Str.fromUtf8 foo |> Result.withDefault ""

--- a/crates/compiler/load_internal/tests/fixtures/build/no_deps/MissingIngestedFile.roc
+++ b/crates/compiler/load_internal/tests/fixtures/build/no_deps/MissingIngestedFile.roc
@@ -1,0 +1,8 @@
+interface MissingIngestedFile
+    exposes [unit]
+    imports ["ThisFileIsMissing" as data: List U8]
+
+Unit : [Unit]
+
+unit : Unit
+unit = Unit

--- a/crates/compiler/load_internal/tests/test_load.rs
+++ b/crates/compiler/load_internal/tests/test_load.rs
@@ -573,6 +573,34 @@ fn imported_dep_regression() {
 }
 
 #[test]
+fn ingested_file() {
+    let subs_by_module = Default::default();
+    let loaded_module = load_fixture("interface_with_deps", "IngestedFile", subs_by_module);
+
+    expect_types(
+        loaded_module,
+        hashmap! {
+            "foo" => "Str",
+            "str" => "Str",
+        },
+    );
+}
+
+#[test]
+fn ingested_file_bytes() {
+    let subs_by_module = Default::default();
+    let loaded_module = load_fixture("interface_with_deps", "IngestedFileBytes", subs_by_module);
+
+    expect_types(
+        loaded_module,
+        hashmap! {
+            "foo" => "List U8",
+            "str" => "Str",
+        },
+    );
+}
+
+#[test]
 fn parse_problem() {
     let modules = vec![(
         "Main",
@@ -630,6 +658,20 @@ fn file_not_found() {
 fn imported_file_not_found() {
     let subs_by_module = Default::default();
     let loaded_module = load_fixture("no_deps", "MissingDep", subs_by_module);
+
+    expect_types(
+        loaded_module,
+        hashmap! {
+            "str" => "Str",
+        },
+    );
+}
+
+#[test]
+#[should_panic(expected = "FILE NOT FOUND")]
+fn ingested_file_not_found() {
+    let subs_by_module = Default::default();
+    let loaded_module = load_fixture("no_deps", "MissingIngestedFile", subs_by_module);
 
     expect_types(
         loaded_module,

--- a/crates/compiler/mono/src/ir.rs
+++ b/crates/compiler/mono/src/ir.rs
@@ -31,13 +31,9 @@ use roc_problem::can::{RuntimeError, ShadowKind};
 use roc_region::all::{Loc, Region};
 use roc_std::RocDec;
 use roc_target::TargetInfo;
-use roc_types::types::AliasCommon;
-use roc_types::{
-    subs::{
-        instantiate_rigids, storage_copy_var_to, Content, ExhaustiveMark, FlatType, RedundantMark,
-        StorageSubs, Subs, Variable, VariableSubsSlice,
-    },
-    types::Type,
+use roc_types::subs::{
+    instantiate_rigids, storage_copy_var_to, Content, ExhaustiveMark, FlatType, RedundantMark,
+    StorageSubs, Subs, Variable, VariableSubsSlice,
 };
 use std::collections::HashMap;
 use ven_pretty::{BoxAllocator, DocAllocator, DocBuilder};

--- a/crates/compiler/mono/src/ir.rs
+++ b/crates/compiler/mono/src/ir.rs
@@ -4186,9 +4186,11 @@ pub fn with_hole<'a>(
                     Layout::STR,
                     hole,
                 ),
-                _ => unreachable!(
-                    "All of these cases should be dealt during solve, generating proper errors"
-                ),
+                _ => {
+                    // This will not manifest as a real runtime error and is just returned to have a value here.
+                    // The actual type error during solve will be fatal.
+                    runtime_error(env, "Invalid type for ingested file")
+                }
             }
         }
         SingleQuote(_, _, character, _) => {

--- a/crates/compiler/mono/src/ir.rs
+++ b/crates/compiler/mono/src/ir.rs
@@ -4165,8 +4165,8 @@ pub fn with_hole<'a>(
             match layout {
                 Layout::Builtin(Builtin::List(elem_layout)) if elem_layout == Layout::U8 => {
                     let mut elements = Vec::with_capacity_in(bytes.len(), env.arena);
-                    for byte in bytes {
-                        elements.push(ListLiteralElement::Literal(Literal::Byte(byte)));
+                    for byte in bytes.iter() {
+                        elements.push(ListLiteralElement::Literal(Literal::Byte(*byte)));
                     }
                     let expr = Expr::Array {
                         elem_layout,
@@ -4179,7 +4179,9 @@ pub fn with_hole<'a>(
                     assigned,
                     Expr::Literal(Literal::Str(
                         // This is safe because we ensure the utf8 bytes are valid earlier in the compiler pipeline.
-                        arena.alloc(unsafe { std::str::from_utf8_unchecked(&bytes) }.to_owned()),
+                        arena.alloc(
+                            unsafe { std::str::from_utf8_unchecked(bytes.as_ref()) }.to_owned(),
+                        ),
                     )),
                     Layout::STR,
                     hole,

--- a/crates/compiler/mono/src/ir.rs
+++ b/crates/compiler/mono/src/ir.rs
@@ -4158,6 +4158,17 @@ pub fn with_hole<'a>(
             hole,
         ),
 
+        // TODO: Actually generate for multiple types here.
+        // Should this be able to fail with utf8 or should that have been checked already?
+        IngestedFile(bytes, _) => Stmt::Let(
+            assigned,
+            Expr::Literal(Literal::Str(
+                arena.alloc(std::str::from_utf8(&bytes).unwrap().to_owned()),
+            )),
+            Layout::STR,
+            hole,
+        ),
+
         SingleQuote(_, _, character, _) => {
             let layout = layout_cache
                 .from_var(env.arena, variable, env.subs)

--- a/crates/compiler/mono/src/ir.rs
+++ b/crates/compiler/mono/src/ir.rs
@@ -4195,10 +4195,7 @@ pub fn with_hole<'a>(
 
                 Stmt::Let(assigned, expr, list_layout, hole)
             }
-            x => todo!(
-                "Unsupported requested type for ingested file, give proper error: {:?}",
-                x
-            ),
+            _ => unreachable!("All of these cases should be dealt with earlier in the compiler, generating proper errors"),
         },
 
         SingleQuote(_, _, character, _) => {

--- a/crates/compiler/parse/src/ast.rs
+++ b/crates/compiler/parse/src/ast.rs
@@ -1474,7 +1474,6 @@ impl<'a> Malformed for Expr<'a> {
 
             Str(inner) => inner.is_malformed(),
 
-            // TODO: what is the scope of Malformed? Would this not being a real file make it malformed?
             RecordAccess(inner, _) |
             TupleAccess(inner, _) => inner.is_malformed(),
 

--- a/crates/compiler/parse/src/ast.rs
+++ b/crates/compiler/parse/src/ast.rs
@@ -263,6 +263,9 @@ pub enum Expr<'a> {
 
     Tuple(Collection<'a, &'a Loc<Expr<'a>>>),
 
+    // The name of a file to be ingested directly into a variable.
+    IngestedFile(StrLiteral<'a>),
+
     // Lookups
     Var {
         module_name: &'a str, // module_name will only be filled if the original Roc code stated something like `5 + SomeModule.myVar`, module_name will be blank if it was `5 + myVar`
@@ -1468,6 +1471,9 @@ impl<'a> Malformed for Expr<'a> {
             Crash => false,
 
             Str(inner) => inner.is_malformed(),
+
+            // TODO: what is the scope of Malformed? Would this not being a real file make it malformed?
+            IngestedFile(inner) => inner.is_malformed(),
 
             RecordAccess(inner, _) |
             TupleAccess(inner, _) => inner.is_malformed(),

--- a/crates/compiler/parse/src/ast.rs
+++ b/crates/compiler/parse/src/ast.rs
@@ -1,4 +1,5 @@
 use std::fmt::Debug;
+use std::path::Path;
 
 use crate::header::{AppHeader, HostedHeader, InterfaceHeader, PackageHeader, PlatformHeader};
 use crate::ident::Accessor;
@@ -264,7 +265,7 @@ pub enum Expr<'a> {
     Tuple(Collection<'a, &'a Loc<Expr<'a>>>),
 
     // The name of a file to be ingested directly into a variable.
-    IngestedFile(StrLiteral<'a>),
+    IngestedFile(&'a Path, &'a Loc<TypeAnnotation<'a>>),
 
     // Lookups
     Var {
@@ -1468,13 +1469,12 @@ impl<'a> Malformed for Expr<'a> {
             Tag(_) |
             OpaqueRef(_) |
             SingleQuote(_) | // This is just a &str - not a bunch of segments
+            IngestedFile(_, _) |
             Crash => false,
 
             Str(inner) => inner.is_malformed(),
 
             // TODO: what is the scope of Malformed? Would this not being a real file make it malformed?
-            IngestedFile(inner) => inner.is_malformed(),
-
             RecordAccess(inner, _) |
             TupleAccess(inner, _) => inner.is_malformed(),
 

--- a/crates/compiler/parse/src/expr.rs
+++ b/crates/compiler/parse/src/expr.rs
@@ -1906,7 +1906,8 @@ fn expr_to_pattern_help<'a>(arena: &'a Bump, expr: &Expr<'a>) -> Result<Pattern<
             is_negative,
         },
         // These would not have parsed as patterns
-        Expr::AccessorFunction(_)
+        Expr::IngestedFile(_)
+        | Expr::AccessorFunction(_)
         | Expr::RecordAccess(_, _)
         | Expr::TupleAccess(_, _)
         | Expr::List { .. }

--- a/crates/compiler/parse/src/expr.rs
+++ b/crates/compiler/parse/src/expr.rs
@@ -1906,7 +1906,7 @@ fn expr_to_pattern_help<'a>(arena: &'a Bump, expr: &Expr<'a>) -> Result<Pattern<
             is_negative,
         },
         // These would not have parsed as patterns
-        Expr::IngestedFile(_)
+        Expr::IngestedFile(_, _)
         | Expr::AccessorFunction(_)
         | Expr::RecordAccess(_, _)
         | Expr::TupleAccess(_, _)

--- a/crates/compiler/parse/src/header.rs
+++ b/crates/compiler/parse/src/header.rs
@@ -277,6 +277,9 @@ pub enum ImportsEntry<'a> {
         ModuleName<'a>,
         Collection<'a, Loc<Spaced<'a, ExposedName<'a>>>>,
     ),
+
+    /// e.g "path/to/my/file.txt" as myFile : Str
+    IngestedFile(StrLiteral<'a>, Spaced<'a, TypedIdent<'a>>),
 }
 
 /// e.g.

--- a/crates/compiler/parse/src/module.rs
+++ b/crates/compiler/parse/src/module.rs
@@ -664,6 +664,7 @@ fn imports_entry<'a>() -> impl Parser<'a, Spaced<'a, ImportsEntry<'a>>, EImports
                 specialize(|_, pos| EImports::TypedIdent(pos), typed_ident())
             ),
             |((file_name, _), typed_ident)| {
+                // TODO: look at blacking block strings during parsing.
                 Spaced::Item(ImportsEntry::IngestedFile(file_name, typed_ident))
             }
         )

--- a/crates/compiler/parse/src/module.rs
+++ b/crates/compiler/parse/src/module.rs
@@ -643,7 +643,8 @@ fn imports_entry<'a>() -> impl Parser<'a, Spaced<'a, ImportsEntry<'a>>, EImports
 
                 Spaced::Item(entry)
             }
-        ),
+        )
+        .trace("normal_import"),
         map!(
             and!(
                 and!(
@@ -651,7 +652,13 @@ fn imports_entry<'a>() -> impl Parser<'a, Spaced<'a, ImportsEntry<'a>>, EImports
                     // TODO: str literal allows for multiline strings. We probably don't want that for file names.
                     specialize(|_, pos| EImports::StrLiteral(pos), parse_str_literal()),
                     // e.g. as
-                    word2(b'a', b's', EImports::AsKeyword)
+                    and!(
+                        and!(
+                            space0_e(EImports::AsKeyword),
+                            word2(b'a', b's', EImports::AsKeyword)
+                        ),
+                        space0_e(EImports::AsKeyword)
+                    )
                 ),
                 // e.g. file : Str
                 specialize(|_, pos| EImports::TypedIdent(pos), typed_ident())
@@ -660,6 +667,7 @@ fn imports_entry<'a>() -> impl Parser<'a, Spaced<'a, ImportsEntry<'a>>, EImports
                 Spaced::Item(ImportsEntry::IngestedFile(file_name, typed_ident))
             }
         )
+        .trace("ingest_file_import")
     )
     .trace("imports_entry")
 }

--- a/crates/compiler/parse/src/parser.rs
+++ b/crates/compiler/parse/src/parser.rs
@@ -232,6 +232,9 @@ pub enum EImports {
     IndentSetStart(Position),
     SetStart(Position),
     SetEnd(Position),
+    TypedIdent(Position),
+    AsKeyword(Position),
+    StrLiteral(Position),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/compiler/problem/src/can.rs
+++ b/crates/compiler/problem/src/can.rs
@@ -1,3 +1,6 @@
+use std::io;
+use std::path::PathBuf;
+
 use roc_collections::all::MutSet;
 use roc_module::called_via::BinOp;
 use roc_module::ident::{Ident, Lowercase, ModuleName, TagName};
@@ -204,11 +207,15 @@ pub enum Problem {
     OverAppliedCrash {
         region: Region,
     },
+    FileProblem {
+        filename: PathBuf,
+        error: io::ErrorKind,
+    },
 }
 
 impl Problem {
     pub fn severity(&self) -> Severity {
-        use Severity::{RuntimeError, Warning};
+        use Severity::{Fatal, RuntimeError, Warning};
 
         match self {
             Problem::UnusedDef(_, _) => Warning,
@@ -269,6 +276,7 @@ impl Problem {
             Problem::UnappliedCrash { .. } => RuntimeError,
             Problem::OverAppliedCrash { .. } => RuntimeError,
             Problem::DefsOnlyUsedInRecursion(_, _) => Warning,
+            Problem::FileProblem { .. } => Fatal,
         }
     }
 
@@ -414,6 +422,7 @@ impl Problem {
             | Problem::RuntimeError(RuntimeError::VoidValue)
             | Problem::RuntimeError(RuntimeError::ExposedButNotDefined(_))
             | Problem::RuntimeError(RuntimeError::NoImplementationNamed { .. })
+            | Problem::FileProblem { .. }
             | Problem::ExposedButNotDefined(_) => None,
         }
     }

--- a/crates/compiler/problem/src/lib.rs
+++ b/crates/compiler/problem/src/lib.rs
@@ -6,6 +6,10 @@ pub mod can;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum Severity {
+    /// This should stop compilation in all cases.
+    /// Due to delayed loading of ingested files, this is wanted behaviour over a runtime error.
+    Fatal,
+
     /// This will cause a runtime error if some code get srun
     /// (e.g. type mismatch, naming error)
     RuntimeError,

--- a/crates/compiler/solve/src/solve.rs
+++ b/crates/compiler/solve/src/solve.rs
@@ -1771,6 +1771,55 @@ fn solve(
 
                 state
             }
+            IngestedFile(type_index, _, bytes) => {
+                let actual = either_type_index_to_var(
+                    subs,
+                    rank,
+                    pools,
+                    problems,
+                    abilities_store,
+                    obligation_cache,
+                    &mut can_types,
+                    aliases,
+                    *type_index,
+                );
+
+                if let Success { .. } = unify(
+                    &mut UEnv::new(subs),
+                    actual,
+                    Variable::LIST_U8,
+                    Mode::EQ,
+                    Polarity::OF_VALUE,
+                ) {
+                    // List U8 always valid.
+                    state
+                } else if let Success { .. } = unify(
+                    &mut UEnv::new(subs),
+                    actual,
+                    Variable::STR,
+                    Mode::EQ,
+                    Polarity::OF_VALUE,
+                ) {
+                    // Str only valid if valid utf8.
+                    if std::str::from_utf8(bytes).is_err() {
+                        todo!("add type error due to not being a utf8 string");
+                    }
+
+                    state
+                } else {
+                    // Unexpected type.
+                    todo!("Add type error for unsupported ingested file type");
+                    // let problem = TypeError::BadExpr(
+                    //     *region,
+                    //     Category::Lookup(*symbol),
+                    //     actual_type,
+                    //     expectation.replace_ref(expected_type),
+                    // );
+
+                    // problems.push(problem);
+                    // state
+                }
+            }
         };
     }
 

--- a/crates/compiler/solve/src/solve.rs
+++ b/crates/compiler/solve/src/solve.rs
@@ -1785,7 +1785,9 @@ fn solve(
                 );
 
                 if let Success { .. } = unify(
-                    &mut UEnv::new(subs),
+                    // TODO: if we don't clone and a later branch matches, we will get a failure in alias analysis.
+                    // That said, I assume cloning is expensive and should be avoided.
+                    &mut UEnv::new(&mut subs.clone()),
                     actual,
                     Variable::LIST_U8,
                     Mode::EQ,
@@ -1794,7 +1796,7 @@ fn solve(
                     // List U8 always valid.
                     state
                 } else if let Success { .. } = unify(
-                    &mut UEnv::new(subs),
+                    &mut UEnv::new(&mut subs.clone()),
                     actual,
                     Variable::STR,
                     Mode::EQ,

--- a/crates/compiler/solve/src/solve.rs
+++ b/crates/compiler/solve/src/solve.rs
@@ -1784,19 +1784,19 @@ fn solve(
                     *type_index,
                 );
 
+                let snapshot = subs.snapshot();
                 if let Success { .. } = unify(
-                    // TODO: if we don't clone and a later branch matches, we will get a failure in alias analysis.
-                    // That said, I assume cloning is expensive and should be avoided.
-                    &mut UEnv::new(&mut subs.clone()),
+                    &mut UEnv::new(subs),
                     actual,
                     Variable::LIST_U8,
                     Mode::EQ,
                     Polarity::OF_VALUE,
                 ) {
                     // List U8 always valid.
+                    subs.rollback_to(snapshot);
                     state
                 } else if let Success { .. } = unify(
-                    &mut UEnv::new(&mut subs.clone()),
+                    &mut UEnv::new(subs),
                     actual,
                     Variable::STR,
                     Mode::EQ,
@@ -1807,6 +1807,7 @@ fn solve(
                         todo!("add type error due to not being a utf8 string");
                     }
 
+                    subs.rollback_to(snapshot);
                     state
                 } else {
                     // Unexpected type.
@@ -1819,6 +1820,7 @@ fn solve(
                     // );
 
                     // problems.push(problem);
+                    // subs.rollback_to(snapshot);
                     // state
                 }
             }

--- a/crates/compiler/solve_problem/src/lib.rs
+++ b/crates/compiler/solve_problem/src/lib.rs
@@ -1,4 +1,6 @@
 //! Provides types to describe problems that can occur during solving.
+use std::{path::Path, str::Utf8Error};
+
 use roc_can::expected::{Expected, PExpected};
 use roc_module::{ident::Lowercase, symbol::Symbol};
 use roc_problem::{can::CycleEntry, Severity};
@@ -29,6 +31,8 @@ pub enum TypeError {
         expected_opaque: Symbol,
         found_opaque: Symbol,
     },
+    IngestedFileBadUtf8(Box<Path>, Utf8Error),
+    IngestedFileUnsupportedType(Box<Path>, ErrorType),
 }
 
 impl TypeError {
@@ -48,6 +52,8 @@ impl TypeError {
             TypeError::Exhaustive(exhtv) => exhtv.severity(),
             TypeError::StructuralSpecialization { .. } => RuntimeError,
             TypeError::WrongSpecialization { .. } => RuntimeError,
+            TypeError::IngestedFileBadUtf8(..) => Fatal,
+            TypeError::IngestedFileUnsupportedType(..) => Fatal,
         }
     }
 }

--- a/crates/compiler/solve_problem/src/lib.rs
+++ b/crates/compiler/solve_problem/src/lib.rs
@@ -1,5 +1,5 @@
 //! Provides types to describe problems that can occur during solving.
-use std::{path::Path, str::Utf8Error};
+use std::{path::PathBuf, str::Utf8Error};
 
 use roc_can::expected::{Expected, PExpected};
 use roc_module::{ident::Lowercase, symbol::Symbol};
@@ -31,8 +31,8 @@ pub enum TypeError {
         expected_opaque: Symbol,
         found_opaque: Symbol,
     },
-    IngestedFileBadUtf8(Box<Path>, Utf8Error),
-    IngestedFileUnsupportedType(Box<Path>, ErrorType),
+    IngestedFileBadUtf8(Box<PathBuf>, Utf8Error),
+    IngestedFileUnsupportedType(Box<PathBuf>, ErrorType),
 }
 
 impl TypeError {

--- a/crates/compiler/types/src/types.rs
+++ b/crates/compiler/types/src/types.rs
@@ -15,7 +15,7 @@ use roc_module::symbol::{Interns, Symbol};
 use roc_region::all::{Loc, Region};
 use std::fmt;
 use std::fmt::Write;
-use std::path::Path;
+use std::path::PathBuf;
 
 pub const TYPE_NUM: &str = "Num";
 pub const TYPE_INTEGER: &str = "Integer";
@@ -3782,7 +3782,7 @@ pub enum Category {
     List,
     Str,
     Character,
-    IngestedFile(Box<Path>),
+    IngestedFile(Box<PathBuf>),
 
     // records
     Record,

--- a/crates/compiler/types/src/types.rs
+++ b/crates/compiler/types/src/types.rs
@@ -15,6 +15,7 @@ use roc_module::symbol::{Interns, Symbol};
 use roc_region::all::{Loc, Region};
 use std::fmt;
 use std::fmt::Write;
+use std::path::Path;
 
 pub const TYPE_NUM: &str = "Num";
 pub const TYPE_INTEGER: &str = "Integer";
@@ -3781,7 +3782,7 @@ pub enum Category {
     List,
     Str,
     Character,
-    IngestedFile,
+    IngestedFile(Box<Path>),
 
     // records
     Record,

--- a/crates/compiler/types/src/types.rs
+++ b/crates/compiler/types/src/types.rs
@@ -3781,6 +3781,7 @@ pub enum Category {
     List,
     Str,
     Character,
+    IngestedFile,
 
     // records
     Record,

--- a/crates/repl_eval/src/gen.rs
+++ b/crates/repl_eval/src/gen.rs
@@ -136,7 +136,7 @@ pub fn compile_to_mono<'a, 'i, I: Iterator<Item = &'i str>>(
                     Severity::Warning => {
                         warnings.push(buf);
                     }
-                    Severity::RuntimeError => {
+                    Severity::Fatal | Severity::RuntimeError => {
                         errors.push(buf);
                     }
                 }
@@ -154,7 +154,7 @@ pub fn compile_to_mono<'a, 'i, I: Iterator<Item = &'i str>>(
                     Severity::Warning => {
                         warnings.push(buf);
                     }
-                    Severity::RuntimeError => {
+                    Severity::Fatal | Severity::RuntimeError => {
                         errors.push(buf);
                     }
                 }

--- a/crates/reporting/src/cli.rs
+++ b/crates/reporting/src/cli.rs
@@ -7,6 +7,7 @@ use roc_solve_problem::TypeError;
 
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
 pub struct Problems {
+    pub fatally_errored: bool,
     pub errors: usize,
     pub warnings: usize,
 }
@@ -65,6 +66,7 @@ pub fn report_problems(
     // never need to re-allocate either the warnings or the errors vec!
     let mut warnings = Vec::with_capacity(total_problems);
     let mut errors = Vec::with_capacity(total_problems);
+    let mut fatally_errored = false;
 
     for (home, (module_path, src)) in sources.iter() {
         let mut src_lines: Vec<&str> = Vec::new();
@@ -92,6 +94,10 @@ pub fn report_problems(
                 RuntimeError => {
                     errors.push(buf);
                 }
+                Fatal => {
+                    fatally_errored = true;
+                    errors.push(buf);
+                }
             }
         }
 
@@ -109,6 +115,10 @@ pub fn report_problems(
                         warnings.push(buf);
                     }
                     RuntimeError => {
+                        errors.push(buf);
+                    }
+                    Fatal => {
+                        fatally_errored = true;
                         errors.push(buf);
                     }
                 }
@@ -144,6 +154,7 @@ pub fn report_problems(
     }
 
     Problems {
+        fatally_errored,
         errors: errors.len(),
         warnings: warnings.len(),
     }

--- a/crates/reporting/src/error/canonicalize.rs
+++ b/crates/reporting/src/error/canonicalize.rs
@@ -1094,7 +1094,7 @@ pub fn can_problem<'b>(
             title = "OVERAPPLIED CRASH".to_string();
         }
         Problem::FileProblem { filename, error } => {
-            let report = to_file_problem_report(&alloc, &filename, error);
+            let report = to_file_problem_report(alloc, &filename, error);
             doc = report.doc;
             title = report.title;
         }

--- a/crates/reporting/src/error/canonicalize.rs
+++ b/crates/reporting/src/error/canonicalize.rs
@@ -12,7 +12,7 @@ use roc_types::types::AliasKind;
 use std::path::PathBuf;
 
 use crate::error::r#type::suggest;
-use crate::report::{Annotation, Report, RocDocAllocator, RocDocBuilder};
+use crate::report::{to_file_problem_report, Annotation, Report, RocDocAllocator, RocDocBuilder};
 use ven_pretty::DocAllocator;
 
 const SYNTAX_PROBLEM: &str = "SYNTAX PROBLEM";
@@ -1092,6 +1092,11 @@ pub fn can_problem<'b>(
                 ]),
             ]);
             title = "OVERAPPLIED CRASH".to_string();
+        }
+        Problem::FileProblem { filename, error } => {
+            let report = to_file_problem_report(&alloc, &filename, error);
+            doc = report.doc;
+            title = report.title;
         }
     };
 

--- a/crates/reporting/src/error/type.rs
+++ b/crates/reporting/src/error/type.rs
@@ -209,6 +209,45 @@ pub fn type_problem<'b>(
                 severity,
             })
         }
+        IngestedFileBadUtf8(file_path, utf8_err) => {
+            let stack = [
+                alloc.concat([
+                    alloc.reflow("Failed to load "),
+                    alloc.text(format!("{:?}", file_path)),
+                    alloc.reflow(" as Str:"),
+                ]),
+                alloc.text(format!("{}", utf8_err)),
+            ];
+            Some(Report {
+                title: "INVALID UTF-8".to_string(),
+                filename,
+                doc: alloc.stack(stack),
+                severity,
+            })
+        }
+        IngestedFileUnsupportedType(file_path, typ) => {
+            let stack = [
+                alloc.concat([
+                    alloc.text(format!("{:?}", file_path)),
+                    alloc.reflow(" is annotated to be a "),
+                    alloc.inline_type_block(error_type_to_doc(alloc, typ)),
+                    alloc.reflow("."),
+                ]),
+                alloc.concat([
+                    alloc.reflow("Ingested files can only be of type "),
+                    alloc.type_str("List U8"),
+                    alloc.reflow(" or "),
+                    alloc.type_str("Str"),
+                    alloc.reflow("."),
+                ]),
+            ];
+            Some(Report {
+                title: "INVALID TYPE FOR INGESTED FILE".to_string(),
+                filename,
+                doc: alloc.stack(stack),
+                severity,
+            })
+        }
     }
 }
 

--- a/crates/reporting/src/error/type.rs
+++ b/crates/reporting/src/error/type.rs
@@ -1655,6 +1655,12 @@ fn format_category<'b>(
             alloc.concat([this_is, alloc.text(" a Unicode scalar value")]),
             alloc.text(" of type:"),
         ),
+        IngestedFile => (
+            // TODO: is this what we actually want for the error message here.
+            // Should we somehow get the file name piped to here or type annotation?
+            alloc.concat([this_is, alloc.text(" an ingested file")]),
+            alloc.text(" of type:"),
+        ),
         Lambda => (
             alloc.concat([this_is, alloc.text(" an anonymous function")]),
             alloc.text(" of type:"),

--- a/crates/reporting/src/error/type.rs
+++ b/crates/reporting/src/error/type.rs
@@ -1655,10 +1655,11 @@ fn format_category<'b>(
             alloc.concat([this_is, alloc.text(" a Unicode scalar value")]),
             alloc.text(" of type:"),
         ),
-        IngestedFile => (
-            // TODO: is this what we actually want for the error message here.
-            // Should we somehow get the file name piped to here or type annotation?
-            alloc.concat([this_is, alloc.text(" an ingested file")]),
+        IngestedFile(file_path) => (
+            alloc.concat([
+                this_is,
+                alloc.text(format!(" an ingested file ({:?})", file_path)),
+            ]),
             alloc.text(" of type:"),
         ),
         Lambda => (

--- a/examples/cli/.gitignore
+++ b/examples/cli/.gitignore
@@ -8,4 +8,5 @@ http-get
 file-io
 env
 ingested-file
+ingested-file-bytes
 out.txt

--- a/examples/cli/.gitignore
+++ b/examples/cli/.gitignore
@@ -7,4 +7,5 @@ tui
 http-get
 file-io
 env
+ingested-file
 out.txt

--- a/examples/cli/ingested-file-bytes.roc
+++ b/examples/cli/ingested-file-bytes.roc
@@ -1,0 +1,15 @@
+app "ingested-file-bytes"
+    packages { pf: "cli-platform/main.roc" }
+    imports [
+        pf.Stdout,
+        "ingested-file.roc" as ownCode : _, # A type hole can also be used here.
+    ]
+    provides [main] to pf
+
+main =
+    # Due to how ownCode is used, it will be a List U8.
+    ownCode
+    |> List.map Num.toNat
+    |> List.sum
+    |> Num.toStr
+    |> Stdout.line

--- a/examples/cli/ingested-file.roc
+++ b/examples/cli/ingested-file.roc
@@ -2,7 +2,7 @@ app "ingested-file"
     packages { pf: "cli-platform/main.roc" }
     imports [
         pf.Stdout,
-        "ingested-file.roc" as ownCode: Str
+        "ingested-file.roc" as ownCode : Str,
     ]
     provides [main] to pf
 

--- a/examples/cli/ingested-file.roc
+++ b/examples/cli/ingested-file.roc
@@ -1,0 +1,10 @@
+app "ingested-file"
+    packages { pf: "cli-platform/main.roc" }
+    imports [
+        pf.Stdout,
+        "ingested-file.roc" as ownCode: Str
+    ]
+    provides [main] to pf
+
+main =
+    Stdout.line "\nThis roc file can print it's own source code. The source is:\n\n\(ownCode)"

--- a/examples/helloWorld.roc
+++ b/examples/helloWorld.roc
@@ -4,4 +4,4 @@ app "helloWorld"
     provides [main] to pf
 
 main =
-    Stdout.line "Hello, World!"
+    Stdout.line file

--- a/examples/helloWorld.roc
+++ b/examples/helloWorld.roc
@@ -4,4 +4,4 @@ app "helloWorld"
     provides [main] to pf
 
 main =
-    Stdout.line file
+    Stdout.line "Hello, World!"


### PR DESCRIPTION
So I am sure that I am doing things in wrong locations or in ways that won't be wanted in the long term. I am hoping to get an initial review to point me in the right direction of where is the correct place to handle different error cases. This currently is the minimal pipelining for ingesting a file as a `Str`. I also tried to enable ingesting a file as a `List U8`, but that currently is broken.

Review especially high level organization/structural review with pointers to better ways/locations to deal with loading files would be quite appreciated.