### PR TITLE
Give |> the highest precedence, plus some perf opt

### DIFF
--- a/crates/compiler/module/src/called_via.rs
+++ b/crates/compiler/module/src/called_via.rs
@@ -256,7 +256,7 @@ mod tests {
 
     fn index_is_binop_u8(iter: impl Iterator<Item = BinOp>, table_name: &'static str) {
         for (index, op) in iter.enumerate() {
-            assert_eq!(op as usize, index);
+            assert_eq!(op as usize, index,  "{op} was found at index {index} in {table_name}, but it should have been at index {} instead.", op as usize);
         }
     }
 

--- a/crates/compiler/module/src/called_via.rs
+++ b/crates/compiler/module/src/called_via.rs
@@ -260,21 +260,6 @@ mod tests {
         }
     }
 
-    fn no_duplicates(iter: impl Iterator<Item = BinOp> + Clone, table_name: &'static str) {
-        for op_to_count in iter.clone() {
-            let mut instances = 0;
-
-            for current_op in iter.clone() {
-                if current_op == op_to_count {
-                    instances += 1
-                }
-            }
-
-            // Each op should appear exactly once in the table
-            assert_eq!(instances, 1, "{op_to_count} appeared {instances} times in {table_name}, but we expected it to appear once at most.");
-        }
-    }
-
     #[test]
     fn indices_are_correct_in_precedences() {
         index_is_binop_u8(PRECEDENCES.iter().map(|(op, _)| *op), "PRECEDENCES")
@@ -288,20 +273,5 @@ mod tests {
     #[test]
     fn indices_are_correct_in_display_string() {
         index_is_binop_u8(DISPLAY_STRINGS.iter().map(|(op, _)| *op), "DISPLAY_STRINGS")
-    }
-
-    #[test]
-    fn no_duplicates_in_precedences() {
-        no_duplicates(PRECEDENCES.iter().map(|(op, _)| *op), "PRECEDENCES")
-    }
-
-    #[test]
-    fn no_duplicates_in_associativities() {
-        no_duplicates(ASSOCIATIVITIES.iter().map(|(op, _)| *op), "ASSOCIATIVITIES")
-    }
-
-    #[test]
-    fn no_duplicates_in_display_strings() {
-        no_duplicates(DISPLAY_STRINGS.iter().map(|(op, _)| *op), "DISPLAY_STRINGS")
     }
 }

--- a/crates/compiler/module/src/called_via.rs
+++ b/crates/compiler/module/src/called_via.rs
@@ -254,6 +254,12 @@ const fn generate_display_table() -> [&'static str; 20] {
 mod tests {
     use super::{BinOp, ASSOCIATIVITIES, DISPLAY_STRINGS, PRECEDENCES};
 
+    fn index_is_binop_u8(iter: impl Iterator<Item = BinOp>, table_name: &'static str) {
+        for (index, op) in iter.enumerate() {
+            assert_eq!(op as usize, index);
+        }
+    }
+
     fn no_duplicates(iter: impl Iterator<Item = BinOp> + Clone, table_name: &'static str) {
         for op_to_count in iter.clone() {
             let mut instances = 0;
@@ -267,6 +273,21 @@ mod tests {
             // Each op should appear exactly once in the table
             assert_eq!(instances, 1, "{op_to_count} appeared {instances} times in {table_name}, but we expected it to appear once at most.");
         }
+    }
+
+    #[test]
+    fn indices_are_correct_in_precedences() {
+        index_is_binop_u8(PRECEDENCES.iter().map(|(op, _)| *op), "PRECEDENCES")
+    }
+
+    #[test]
+    fn indices_are_correct_in_associativities() {
+        index_is_binop_u8(ASSOCIATIVITIES.iter().map(|(op, _)| *op), "ASSOCIATIVITIES")
+    }
+
+    #[test]
+    fn indices_are_correct_in_display_string() {
+        index_is_binop_u8(DISPLAY_STRINGS.iter().map(|(op, _)| *op), "DISPLAY_STRINGS")
     }
 
     #[test]

--- a/crates/compiler/module/src/called_via.rs
+++ b/crates/compiler/module/src/called_via.rs
@@ -4,14 +4,14 @@ use std::cmp::Ordering;
 use std::fmt;
 
 const PRECEDENCES: [(BinOp, u8); 20] = [
-    (Pizza, 6),
-    (Caret, 5),
-    (Star, 4),
-    (Slash, 4),
-    (DoubleSlash, 4),
-    (Percent, 4),
-    (Plus, 3),
-    (Minus, 3),
+    (Caret, 7),
+    (Star, 6),
+    (Slash, 6),
+    (DoubleSlash, 5),
+    (Percent, 5),
+    (Plus, 4),
+    (Minus, 4),
+    (Pizza, 3),
     (Equals, 2),
     (NotEquals, 2),
     (LessThan, 1),
@@ -28,7 +28,6 @@ const PRECEDENCES: [(BinOp, u8); 20] = [
 ];
 
 const ASSOCIATIVITIES: [(BinOp, Associativity); 20] = [
-    (Pizza, LeftAssociative),
     (Caret, RightAssociative),
     (Star, LeftAssociative),
     (Slash, LeftAssociative),
@@ -36,6 +35,7 @@ const ASSOCIATIVITIES: [(BinOp, Associativity); 20] = [
     (Percent, LeftAssociative),
     (Plus, LeftAssociative),
     (Minus, LeftAssociative),
+    (Pizza, LeftAssociative),
     (Equals, NonAssociative),
     (NotEquals, NonAssociative),
     (LessThan, NonAssociative),
@@ -52,7 +52,6 @@ const ASSOCIATIVITIES: [(BinOp, Associativity); 20] = [
 ];
 
 const DISPLAY_STRINGS: [(BinOp, &str); 20] = [
-    (Pizza, "|>"),
     (Caret, "^"),
     (Star, "*"),
     (Slash, "/"),
@@ -60,6 +59,7 @@ const DISPLAY_STRINGS: [(BinOp, &str); 20] = [
     (Percent, "%"),
     (Plus, "+"),
     (Minus, "-"),
+    (Pizza, "|>"),
     (Equals, "=="),
     (NotEquals, "!="),
     (LessThan, "<"),
@@ -101,7 +101,6 @@ pub enum UnaryOp {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum BinOp {
     // highest precedence
-    Pizza,
     Caret,
     Star,
     Slash,
@@ -109,6 +108,7 @@ pub enum BinOp {
     Percent,
     Plus,
     Minus,
+    Pizza,
     Equals,
     NotEquals,
     LessThan,

--- a/crates/compiler/module/src/called_via.rs
+++ b/crates/compiler/module/src/called_via.rs
@@ -1,6 +1,78 @@
+use self::Associativity::*;
 use self::BinOp::*;
 use std::cmp::Ordering;
 use std::fmt;
+
+const PRECEDENCES: [(BinOp, u8); 20] = [
+    (Pizza, 6),
+    (Caret, 5),
+    (Star, 4),
+    (Slash, 4),
+    (DoubleSlash, 4),
+    (Percent, 4),
+    (Plus, 3),
+    (Minus, 3),
+    (Equals, 2),
+    (NotEquals, 2),
+    (LessThan, 1),
+    (GreaterThan, 1),
+    (LessThanOrEq, 1),
+    (GreaterThanOrEq, 1),
+    (And, 0),
+    (Or, 0),
+    // These should never come up
+    (Assignment, 255),
+    (IsAliasType, 255),
+    (IsOpaqueType, 255),
+    (Backpassing, 255),
+];
+
+const ASSOCIATIVITIES: [(BinOp, Associativity); 20] = [
+    (Pizza, LeftAssociative),
+    (Caret, RightAssociative),
+    (Star, LeftAssociative),
+    (Slash, LeftAssociative),
+    (DoubleSlash, LeftAssociative),
+    (Percent, LeftAssociative),
+    (Plus, LeftAssociative),
+    (Minus, LeftAssociative),
+    (Equals, NonAssociative),
+    (NotEquals, NonAssociative),
+    (LessThan, NonAssociative),
+    (GreaterThan, NonAssociative),
+    (LessThanOrEq, NonAssociative),
+    (GreaterThanOrEq, NonAssociative),
+    (And, RightAssociative),
+    (Or, RightAssociative),
+    // These should never come up
+    (Assignment, LeftAssociative),
+    (IsAliasType, LeftAssociative),
+    (IsOpaqueType, LeftAssociative),
+    (Backpassing, LeftAssociative),
+];
+
+const DISPLAY_STRINGS: [(BinOp, &str); 20] = [
+    (Pizza, "|>"),
+    (Caret, "^"),
+    (Star, "*"),
+    (Slash, "/"),
+    (DoubleSlash, "//"),
+    (Percent, "%"),
+    (Plus, "+"),
+    (Minus, "-"),
+    (Equals, "=="),
+    (NotEquals, "!="),
+    (LessThan, "<"),
+    (GreaterThan, ">"),
+    (LessThanOrEq, "<="),
+    (GreaterThanOrEq, ">="),
+    (And, "&&"),
+    (Or, "||"),
+    (Assignment, "="),
+    (IsAliasType, ":"),
+    (IsOpaqueType, ":="),
+    (Backpassing, "<-"),
+];
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CalledVia {
@@ -29,6 +101,7 @@ pub enum UnaryOp {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum BinOp {
     // highest precedence
+    Pizza,
     Caret,
     Star,
     Slash,
@@ -44,7 +117,6 @@ pub enum BinOp {
     GreaterThanOrEq,
     And,
     Or,
-    Pizza,
     Assignment,
     IsAliasType,
     IsOpaqueType,
@@ -93,29 +165,27 @@ pub enum Associativity {
 
 impl BinOp {
     pub fn associativity(self) -> Associativity {
-        use self::Associativity::*;
+        // The compiler should never pass any of these to this function!
+        debug_assert_ne!(self, Assignment);
+        debug_assert_ne!(self, IsAliasType);
+        debug_assert_ne!(self, IsOpaqueType);
+        debug_assert_ne!(self, Backpassing);
 
-        match self {
-            Pizza | Star | Slash | DoubleSlash | Percent | Plus | Minus => LeftAssociative,
-            And | Or | Caret => RightAssociative,
-            Equals | NotEquals | LessThan | GreaterThan | LessThanOrEq | GreaterThanOrEq => {
-                NonAssociative
-            }
-            Assignment | IsAliasType | IsOpaqueType | Backpassing => unreachable!(),
-        }
+        const ASSOCIATIVITY_TABLE: [Associativity; 20] = generate_associativity_table();
+
+        ASSOCIATIVITY_TABLE[self as usize]
     }
 
     fn precedence(self) -> u8 {
-        match self {
-            Caret => 7,
-            Star | Slash | DoubleSlash | Percent => 6,
-            Plus | Minus => 5,
-            Equals | NotEquals | LessThan | GreaterThan | LessThanOrEq | GreaterThanOrEq => 4,
-            And => 3,
-            Or => 2,
-            Pizza => 1,
-            Assignment | IsAliasType | IsOpaqueType | Backpassing => unreachable!(),
-        }
+        // The compiler should never pass any of these to this function!
+        debug_assert_ne!(self, Assignment);
+        debug_assert_ne!(self, IsAliasType);
+        debug_assert_ne!(self, IsOpaqueType);
+        debug_assert_ne!(self, Backpassing);
+
+        const PRECEDENCE_TABLE: [u8; 20] = generate_precedence_table();
+
+        PRECEDENCE_TABLE[self as usize]
     }
 }
 
@@ -133,29 +203,84 @@ impl Ord for BinOp {
 
 impl std::fmt::Display for BinOp {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let as_str = match self {
-            Caret => "^",
-            Star => "*",
-            Slash => "/",
-            DoubleSlash => "//",
-            Percent => "%",
-            Plus => "+",
-            Minus => "-",
-            Equals => "==",
-            NotEquals => "!=",
-            LessThan => "<",
-            GreaterThan => ">",
-            LessThanOrEq => "<=",
-            GreaterThanOrEq => ">=",
-            And => "&&",
-            Or => "||",
-            Pizza => "|>",
-            Assignment => "=",
-            IsAliasType => ":",
-            IsOpaqueType => ":=",
-            Backpassing => "<-",
-        };
+        debug_assert_ne!(*self, Assignment);
+        debug_assert_ne!(*self, IsAliasType);
+        debug_assert_ne!(*self, IsOpaqueType);
+        debug_assert_ne!(*self, Backpassing);
 
-        write!(f, "{}", as_str)
+        const DISPLAY_TABLE: [&str; 20] = generate_display_table();
+
+        write!(f, "{}", DISPLAY_TABLE[*self as usize])
+    }
+}
+
+const fn generate_precedence_table() -> [u8; 20] {
+    let mut table = [0u8; 20];
+    let mut i = 0;
+
+    while i < PRECEDENCES.len() {
+        table[(PRECEDENCES[i].0) as usize] = PRECEDENCES[i].1;
+        i += 1;
+    }
+
+    table
+}
+
+const fn generate_associativity_table() -> [Associativity; 20] {
+    let mut table = [NonAssociative; 20];
+    let mut i = 0;
+
+    while i < ASSOCIATIVITIES.len() {
+        table[(ASSOCIATIVITIES[i].0) as usize] = ASSOCIATIVITIES[i].1;
+        i += 1;
+    }
+
+    table
+}
+
+const fn generate_display_table() -> [&'static str; 20] {
+    let mut table = [""; 20];
+    let mut i = 0;
+
+    while i < DISPLAY_STRINGS.len() {
+        table[(DISPLAY_STRINGS[i].0) as usize] = DISPLAY_STRINGS[i].1;
+        i += 1;
+    }
+
+    table
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{BinOp, ASSOCIATIVITIES, DISPLAY_STRINGS, PRECEDENCES};
+
+    fn no_duplicates(iter: impl Iterator<Item = BinOp> + Clone, table_name: &'static str) {
+        for op_to_count in iter.clone() {
+            let mut instances = 0;
+
+            for current_op in iter.clone() {
+                if current_op == op_to_count {
+                    instances += 1
+                }
+            }
+
+            // Each op should appear exactly once in the table
+            assert_eq!(instances, 1, "{op_to_count} appeared {instances} times in {table_name}, but we expected it to appear once at most.");
+        }
+    }
+
+    #[test]
+    fn no_duplicates_in_precedences() {
+        no_duplicates(PRECEDENCES.iter().map(|(op, _)| *op), "PRECEDENCES")
+    }
+
+    #[test]
+    fn no_duplicates_in_associativities() {
+        no_duplicates(ASSOCIATIVITIES.iter().map(|(op, _)| *op), "ASSOCIATIVITIES")
+    }
+
+    #[test]
+    fn no_duplicates_in_display_strings() {
+        no_duplicates(DISPLAY_STRINGS.iter().map(|(op, _)| *op), "DISPLAY_STRINGS")
     }
 }


### PR DESCRIPTION
**Update:** found a downside! `x * y |> Num.toStr` no longer works if we give it the *highest* precedence. So instead I tried moving its precedence to higher than everything except arithmetic operators. (So, just higher than comparisons.)

---

In [a Zulip thread](https://roc.zulipchat.com/#narrow/stream/304641-ideas/topic/pizza.20precedence) we discussed making the `|>` operator have the highest precedence. There seemed to be only upsides and no downsides, so this PR does that!

Also, it implements some performance optimizations: namely, making precedence, associativity, and `Display` all use `const` lookup tables instead of conditionals.