### PR TITLE
add NullPointer to mono::ir::Expr

### DIFF
--- a/crates/compiler/alias_analysis/src/lib.rs
+++ b/crates/compiler/alias_analysis/src/lib.rs
@@ -1289,6 +1289,11 @@ fn expr_spec<'a>(
 
     match expr {
         Literal(literal) => literal_spec(builder, block, literal),
+        NullPointer => {
+            let pointer_type = layout_spec(env, builder, interner, layout)?;
+
+            builder.add_unknown_with(block, &[], pointer_type)
+        }
         Call(call) => call_spec(builder, interner, env, block, layout, call),
         Reuse {
             tag_layout,

--- a/crates/compiler/gen_dev/src/lib.rs
+++ b/crates/compiler/gen_dev/src/lib.rs
@@ -1501,6 +1501,7 @@ trait Backend<'a> {
                 self.set_last_seen(*sym, stmt);
                 match expr {
                     Expr::Literal(_) => {}
+                    Expr::NullPointer => {}
 
                     Expr::Call(call) => self.scan_ast_call(call, stmt),
 

--- a/crates/compiler/gen_llvm/src/llvm/build.rs
+++ b/crates/compiler/gen_llvm/src/llvm/build.rs
@@ -1082,6 +1082,12 @@ pub fn build_exp_expr<'a, 'ctx, 'env>(
 
     match expr {
         Literal(literal) => build_exp_literal(env, layout_interner, parent, layout, literal),
+        NullPointer => {
+            let basic_type = basic_type_from_layout(env, layout_interner, layout);
+
+            debug_assert!(basic_type.is_pointer_type());
+            basic_type.into_pointer_type().const_zero().into()
+        }
 
         Call(call) => build_exp_call(
             env,

--- a/crates/compiler/gen_wasm/src/backend.rs
+++ b/crates/compiler/gen_wasm/src/backend.rs
@@ -1041,6 +1041,8 @@ impl<'a, 'r> WasmBackend<'a, 'r> {
         match expr {
             Expr::Literal(lit) => self.expr_literal(lit, storage),
 
+            Expr::NullPointer => self.expr_null_pointer(),
+
             Expr::Call(roc_mono::ir::Call {
                 call_type,
                 arguments,
@@ -1230,6 +1232,10 @@ impl<'a, 'r> WasmBackend<'a, 'r> {
         self.module.data.append_segment(segment);
 
         elements_addr
+    }
+
+    fn expr_null_pointer(&mut self) {
+        self.code_builder.i32_const(0);
     }
 
     /*******************************************************************

--- a/crates/compiler/mono/src/borrow.rs
+++ b/crates/compiler/mono/src/borrow.rs
@@ -761,7 +761,7 @@ impl<'a> BorrowInfState<'a> {
 
             Call(call) => self.collect_call(interner, param_map, z, call),
 
-            Literal(_) | RuntimeErrorFunction(_) => {}
+            Literal(_) | NullPointer | RuntimeErrorFunction(_) => {}
 
             StructAtIndex { structure: x, .. } => {
                 // if the structure (record/tag/array) is owned, the extracted value is

--- a/crates/compiler/mono/src/debug/checker.rs
+++ b/crates/compiler/mono/src/debug/checker.rs
@@ -390,6 +390,7 @@ impl<'a, 'r> Ctx<'a, 'r> {
     fn check_expr(&mut self, e: &Expr<'a>) -> Option<InLayout<'a>> {
         match e {
             Expr::Literal(_) => None,
+            Expr::NullPointer => None,
             Expr::Call(call) => self.check_call(call),
             &Expr::Tag {
                 tag_layout,

--- a/crates/compiler/mono/src/inc_dec.rs
+++ b/crates/compiler/mono/src/inc_dec.rs
@@ -213,7 +213,7 @@ pub fn occurring_variables_expr(expr: &Expr<'_>, result: &mut MutSet<Symbol>) {
             result.insert(*symbol);
         }
 
-        EmptyArray | RuntimeErrorFunction(_) | Literal(_) => {}
+        EmptyArray | RuntimeErrorFunction(_) | Literal(_) | NullPointer => {}
 
         GetTagId {
             structure: symbol, ..
@@ -946,7 +946,7 @@ impl<'a, 'i> Context<'a, 'i> {
                 self.arena.alloc(Stmt::Let(z, v, l, b))
             }
 
-            EmptyArray | Literal(_) | Reset { .. } | RuntimeErrorFunction(_) => {
+            EmptyArray | Literal(_) | Reset { .. } | NullPointer | RuntimeErrorFunction(_) => {
                 // EmptyArray is always stack-allocated function pointers are persistent
                 self.arena.alloc(Stmt::Let(z, v, l, b))
             }

--- a/crates/compiler/mono/src/ir.rs
+++ b/crates/compiler/mono/src/ir.rs
@@ -1878,6 +1878,7 @@ pub enum Expr<'a> {
         arguments: &'a [Symbol],
     },
     Struct(&'a [Symbol]),
+    NullPointer,
 
     StructAtIndex {
         index: u64,
@@ -2016,6 +2017,7 @@ impl<'a> Expr<'a> {
                     .append(alloc.space())
                     .append(alloc.intersperse(it, " "))
             }
+            NullPointer => alloc.text("NullPointer"),
             Reuse {
                 symbol,
                 tag_id,
@@ -7461,6 +7463,8 @@ fn substitute_in_expr<'a>(
                 None
             }
         }
+
+        NullPointer => None,
 
         Reuse { .. } | Reset { .. } => unreachable!("reset/reuse have not been introduced yet"),
 

--- a/crates/compiler/mono/src/reset_reuse.rs
+++ b/crates/compiler/mono/src/reset_reuse.rs
@@ -319,6 +319,7 @@ fn insert_reset<'a>(
             }
 
             Literal(_)
+            | NullPointer
             | Call(_)
             | Tag { .. }
             | Struct(_)
@@ -839,6 +840,7 @@ fn has_live_var<'a>(jp_live_vars: &JPLiveVarMap, stmt: &'a Stmt<'a>, needle: Sym
 fn has_live_var_expr<'a>(expr: &'a Expr<'a>, needle: Symbol) -> bool {
     match expr {
         Expr::Literal(_) => false,
+        Expr::NullPointer => false,
         Expr::Call(call) => has_live_var_call(call, needle),
         Expr::Array { elems: fields, .. } => {
             for element in fields.iter() {


### PR DESCRIPTION
adds a null pointer Expr, which is useful as a placeholder for a missing reuse token (part of implementing perceus)