### PR TITLE
Record all nested recursive structures an entry in the layout cache contains

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3193,6 +3193,7 @@ dependencies = [
  "hashbrown 0.13.2",
  "im",
  "im-rc",
+ "smallvec",
  "wyhash",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,6 +146,7 @@ serde-xml-rs = "0.6.0"
 serde_json = "1.0.94" # update roc_std/Cargo.toml on change
 serial_test = "1.0.0"
 signal-hook = "0.3.15"
+smallvec = { version = "1.10.0", features = ["const_generics", "const_new"] }
 snafu = { version = "0.7.4", features = ["backtraces"] }
 static_assertions = "1.1.0" # update roc_std/Cargo.toml on change
 strip-ansi-escapes = "0.1.1"

--- a/crates/compiler/collections/Cargo.toml
+++ b/crates/compiler/collections/Cargo.toml
@@ -15,3 +15,4 @@ hashbrown.workspace = true
 im-rc.workspace = true
 im.workspace = true
 wyhash.workspace = true
+smallvec.workspace = true

--- a/crates/compiler/collections/src/lib.rs
+++ b/crates/compiler/collections/src/lib.rs
@@ -6,6 +6,7 @@
 pub mod all;
 mod reference_matrix;
 mod small_string_interner;
+mod small_vec;
 pub mod soa;
 mod vec_map;
 mod vec_set;
@@ -13,5 +14,6 @@ mod vec_set;
 pub use all::{default_hasher, BumpMap, ImEntry, ImMap, ImSet, MutMap, MutSet, SendMap};
 pub use reference_matrix::{ReferenceMatrix, Sccs, TopologicalSort};
 pub use small_string_interner::SmallStringInterner;
+pub use small_vec::SmallVec;
 pub use vec_map::VecMap;
 pub use vec_set::VecSet;

--- a/crates/compiler/collections/src/small_vec.rs
+++ b/crates/compiler/collections/src/small_vec.rs
@@ -1,0 +1,61 @@
+use std::fmt::Debug;
+
+use smallvec::SmallVec as Vec;
+
+#[derive(Default)]
+pub struct SmallVec<T, const N: usize>(Vec<[T; N]>);
+
+impl<T, const N: usize> SmallVec<T, N> {
+    pub const fn new() -> Self {
+        Self(Vec::new_const())
+    }
+
+    pub fn push(&mut self, value: T) {
+        self.0.push(value)
+    }
+
+    pub fn pop(&mut self) -> Option<T> {
+        self.0.pop()
+    }
+}
+
+impl<T, const N: usize> std::ops::Deref for SmallVec<T, N> {
+    type Target = [T];
+
+    fn deref(&self) -> &Self::Target {
+        self.0.deref()
+    }
+}
+
+impl<T, const N: usize> Debug for SmallVec<T, N>
+where
+    T: Debug,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl<T, const N: usize> Clone for SmallVec<T, N>
+where
+    T: Clone,
+{
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+impl<T, const N: usize> IntoIterator for SmallVec<T, N> {
+    type Item = T;
+    type IntoIter = <Vec<[T; N]> as IntoIterator>::IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+impl<T, const N: usize> FromIterator<T> for SmallVec<T, N> {
+    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
+        Self(Vec::from_iter(iter))
+    }
+}

--- a/crates/compiler/mono/src/layout.rs
+++ b/crates/compiler/mono/src/layout.rs
@@ -5,7 +5,7 @@ use bumpalo::collections::Vec;
 use bumpalo::Bump;
 use roc_builtins::bitcode::{FloatWidth, IntWidth};
 use roc_collections::all::{default_hasher, FnvMap, MutMap};
-use roc_collections::VecSet;
+use roc_collections::{SmallVec, VecSet};
 use roc_error_macros::{internal_error, todo_abilities};
 use roc_module::ident::{Lowercase, TagName};
 use roc_module::symbol::{Interns, Symbol};
@@ -52,22 +52,22 @@ roc_error_macros::assert_sizeof_default!(LambdaSet, 5 * 8);
 type LayoutResult<'a> = Result<InLayout<'a>, LayoutProblem>;
 type RawFunctionLayoutResult<'a> = Result<RawFunctionLayout<'a>, LayoutProblem>;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 struct CacheMeta {
     /// Does this cache entry include a recursive structure? If so, what's the recursion variable
     /// of that structure?
-    has_recursive_structure: OptVariable,
+    recursive_structures: SmallVec<Variable, 2>,
 }
 
 impl CacheMeta {
     #[inline(always)]
     fn to_criteria(self) -> CacheCriteria {
         let CacheMeta {
-            has_recursive_structure,
+            recursive_structures,
         } = self;
         CacheCriteria {
             has_naked_recursion_pointer: false,
-            has_recursive_structure,
+            recursive_structures,
         }
     }
 }
@@ -208,7 +208,7 @@ impl<'a> LayoutCache<'a> {
             // TODO: it's possible that after unification, roots in earlier cache layers changed...
             // how often does that happen?
             if let Some(result) = layer.0.get(&root) {
-                return Some(*result);
+                return Some(result.clone());
             }
         }
         None
@@ -342,24 +342,24 @@ pub struct CacheSnapshot {
     layer: usize,
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 struct CacheCriteria {
     /// Whether there is a naked recursion pointer in this layout, that doesn't pass through a
     /// recursive structure.
     has_naked_recursion_pointer: bool,
-    /// Whether this layout contains a recursive structure. If `Some`, contains the variable of the
-    /// recursion variable of that structure.
-    has_recursive_structure: OptVariable,
+    /// Recursive structures this layout contains, if any.
+    // Typically at most 1 recursive structure is contained, but there may be more.
+    recursive_structures: SmallVec<Variable, 2>,
 }
 
 const CACHEABLE: CacheCriteria = CacheCriteria {
     has_naked_recursion_pointer: false,
-    has_recursive_structure: OptVariable::NONE,
+    recursive_structures: SmallVec::new(),
 };
 
 const NAKED_RECURSION_PTR: CacheCriteria = CacheCriteria {
     has_naked_recursion_pointer: true,
-    has_recursive_structure: OptVariable::NONE,
+    recursive_structures: SmallVec::new(),
 };
 
 impl CacheCriteria {
@@ -371,25 +371,32 @@ impl CacheCriteria {
 
     /// Makes `self` cacheable iff self and other are cacheable.
     #[inline(always)]
-    fn and(&mut self, other: Self) {
+    fn and(&mut self, other: Self, subs: &Subs) {
         self.has_naked_recursion_pointer =
             self.has_naked_recursion_pointer || other.has_naked_recursion_pointer;
-        // TODO: can these ever conflict?
-        self.has_recursive_structure = self
-            .has_recursive_structure
-            .or(other.has_recursive_structure);
+
+        for &other_rec in other.recursive_structures.iter() {
+            if self
+                .recursive_structures
+                .iter()
+                .any(|rec| subs.equivalent_without_compacting(*rec, other_rec))
+            {
+                continue;
+            }
+            self.recursive_structures.push(other_rec);
+        }
     }
 
     #[inline(always)]
     fn pass_through_recursive_union(&mut self, recursion_var: Variable) {
         self.has_naked_recursion_pointer = false;
-        self.has_recursive_structure = OptVariable::some(recursion_var);
+        self.recursive_structures.push(recursion_var);
     }
 
     #[inline(always)]
     fn cache_metadata(&self) -> CacheMeta {
         CacheMeta {
-            has_recursive_structure: self.has_recursive_structure,
+            recursive_structures: self.recursive_structures.clone(),
         }
     }
 }
@@ -404,9 +411,9 @@ impl<T> Cacheable<T> {
     }
 
     #[inline(always)]
-    fn decompose(self, and_with: &mut CacheCriteria) -> T {
+    fn decompose(self, and_with: &mut CacheCriteria, subs: &Subs) -> T {
         let Self(value, criteria) = self;
-        and_with.and(criteria);
+        and_with.and(criteria, subs);
         value
     }
 
@@ -438,10 +445,10 @@ fn cacheable<T>(v: T) -> Cacheable<T> {
 /// If the layout is not an error, the cache policy is `and`ed with `total_criteria`, and the layout
 /// is passed back.
 macro_rules! cached {
-    ($expr:expr, $total_criteria:expr) => {
+    ($expr:expr, $total_criteria:expr, $subs:expr) => {
         match $expr {
             Cacheable(Ok(v), criteria) => {
-                $total_criteria.and(criteria);
+                $total_criteria.and(criteria, $subs);
                 v
             }
             Cacheable(Err(v), criteria) => return Cacheable(Err(v), criteria),
@@ -583,17 +590,18 @@ impl<'a> RawFunctionLayout<'a> {
 
                 for index in args.into_iter() {
                     let arg_var = env.subs[index];
-                    let layout = cached!(Layout::from_var(env, arg_var), cache_criteria);
+                    let layout = cached!(Layout::from_var(env, arg_var), cache_criteria, env.subs);
                     fn_args.push(layout);
                 }
 
-                let ret = cached!(Layout::from_var(env, ret_var), cache_criteria);
+                let ret = cached!(Layout::from_var(env, ret_var), cache_criteria, env.subs);
 
                 let fn_args = fn_args.into_bump_slice();
 
                 let lambda_set = cached!(
                     LambdaSet::from_var(env, args, closure_var, ret_var),
-                    cache_criteria
+                    cache_criteria,
+                    env.subs
                 );
 
                 Cacheable(Ok(Self::Function(fn_args, lambda_set, ret)), cache_criteria)
@@ -617,7 +625,7 @@ impl<'a> RawFunctionLayout<'a> {
             }
             _ => {
                 let mut criteria = CACHEABLE;
-                let layout = cached!(layout_from_flat_type(env, flat_type), criteria);
+                let layout = cached!(layout_from_flat_type(env, flat_type), criteria, env.subs);
                 Cacheable(Ok(Self::ZeroArgumentThunk(layout)), criteria)
             }
         }
@@ -1803,11 +1811,11 @@ impl<'a> LambdaSet<'a> {
 
         for index in args.into_iter() {
             let arg_var = env.subs[index];
-            let layout = cached!(Layout::from_var(env, arg_var), cache_criteria);
+            let layout = cached!(Layout::from_var(env, arg_var), cache_criteria, env.subs);
             fn_args.push(layout);
         }
 
-        let ret = cached!(Layout::from_var(env, ret_var), cache_criteria);
+        let ret = cached!(Layout::from_var(env, ret_var), cache_criteria, env.subs);
 
         let fn_args = env.arena.alloc(fn_args.into_bump_slice());
 
@@ -1837,7 +1845,7 @@ impl<'a> LambdaSet<'a> {
                         // We determine cacheability of the lambda set based on the runtime
                         // representation, so here the criteria doesn't matter.
                         let mut criteria = CACHEABLE;
-                        let arg = cached!(Layout::from_var(env, *var), criteria);
+                        let arg = cached!(Layout::from_var(env, *var), criteria, env.subs);
                         arguments.push(arg);
                         set_captures_have_naked_rec_ptr =
                             set_captures_have_naked_rec_ptr || criteria.has_naked_recursion_pointer;
@@ -1899,7 +1907,7 @@ impl<'a> LambdaSet<'a> {
                     set_with_variables,
                     opt_recursion_var.into_variable(),
                 );
-                cache_criteria.and(criteria);
+                cache_criteria.and(criteria, env.subs);
 
                 let needs_recursive_fixup = NeedsRecursionPointerFixup(
                     opt_recursion_var.is_some() && set_captures_have_naked_rec_ptr,
@@ -2213,11 +2221,11 @@ impl<'a, 'b> Env<'a, 'b> {
     }
 
     #[inline(always)]
-    fn can_reuse_cached(&self, var: Variable, cache_metadata: CacheMeta) -> bool {
+    fn can_reuse_cached(&self, var: Variable, cache_metadata: &CacheMeta) -> bool {
         let CacheMeta {
-            has_recursive_structure,
+            recursive_structures,
         } = cache_metadata;
-        if let Some(recursive_structure) = has_recursive_structure.into_variable() {
+        for &recursive_structure in recursive_structures.iter() {
             if self.is_seen(recursive_structure) {
                 // If the cached entry references a recursive structure that we're in the process
                 // of visiting currently, we can't use the cached entry, and instead must
@@ -2255,7 +2263,7 @@ macro_rules! cached_or_impl {
             // cache HIT
             inc_stat!($self.cache.$stats, hits);
 
-            if $self.can_reuse_cached($var, metadata) {
+            if $self.can_reuse_cached($var, &metadata) {
                 // Happy path - the cached layout can be reused, return it immediately.
                 return Cacheable(result, metadata.to_criteria());
             } else {
@@ -3139,7 +3147,8 @@ fn layout_from_flat_type<'a>(
                     let mut criteria = CACHEABLE;
 
                     let inner_var = args[0];
-                    let inner_layout = cached!(Layout::from_var(env, inner_var), criteria);
+                    let inner_layout =
+                        cached!(Layout::from_var(env, inner_var), criteria, env.subs);
                     let boxed_layout = env.cache.put_in(Layout::Boxed(inner_layout));
 
                     Cacheable(Ok(boxed_layout), criteria)
@@ -3163,7 +3172,8 @@ fn layout_from_flat_type<'a>(
 
                 let lambda_set = cached!(
                     LambdaSet::from_var(env, args, closure_var, ret_var),
-                    criteria
+                    criteria,
+                    env.subs
                 );
                 let lambda_set = lambda_set.full_layout;
 
@@ -3187,7 +3197,8 @@ fn layout_from_flat_type<'a>(
                     RecordField::Required(field_var)
                     | RecordField::Demanded(field_var)
                     | RecordField::RigidRequired(field_var) => {
-                        let field_layout = cached!(Layout::from_var(env, field_var), criteria);
+                        let field_layout =
+                            cached!(Layout::from_var(env, field_var), criteria, env.subs);
                         sortables.push((label, field_layout));
                     }
                     RecordField::Optional(_) | RecordField::RigidOptional(_) => {
@@ -3239,7 +3250,7 @@ fn layout_from_flat_type<'a>(
             };
 
             for (index, elem) in it {
-                let elem_layout = cached!(Layout::from_var(env, elem), criteria);
+                let elem_layout = cached!(Layout::from_var(env, elem), criteria, env.subs);
                 sortables.push((index, elem_layout));
             }
 
@@ -3652,7 +3663,7 @@ where
 
             for &var in arguments {
                 let Cacheable(result, criteria) = Layout::from_var(env, var);
-                cache_criteria.and(criteria);
+                cache_criteria.and(criteria, env.subs);
                 match result {
                     Ok(layout) => {
                         layouts.push(layout);
@@ -3708,7 +3719,7 @@ where
 
                 for &var in arguments {
                     let Cacheable(result, criteria) = Layout::from_var(env, var);
-                    cache_criteria.and(criteria);
+                    cache_criteria.and(criteria, env.subs);
                     match result {
                         Ok(layout) => {
                             has_any_arguments = true;
@@ -3830,7 +3841,7 @@ where
 
             for var in arguments {
                 let Cacheable(result, criteria) = Layout::from_var(env, var);
-                cache_criteria.and(criteria);
+                cache_criteria.and(criteria, env.subs);
                 match result {
                     Ok(layout) => {
                         layouts.push(layout);
@@ -3904,7 +3915,7 @@ where
 
                 for var in arguments {
                     let Cacheable(result, criteria) = Layout::from_var(env, var);
-                    cache_criteria.and(criteria);
+                    cache_criteria.and(criteria, env.subs);
                     match result {
                         Ok(in_layout) => {
                             has_any_arguments = true;
@@ -4077,7 +4088,8 @@ where
 
     let mut criteria = CACHEABLE;
 
-    let variant = union_sorted_non_recursive_tags_help(env, tags_vec).decompose(&mut criteria);
+    let variant =
+        union_sorted_non_recursive_tags_help(env, tags_vec).decompose(&mut criteria, env.subs);
 
     let result = match variant {
         Never => Layout::VOID,
@@ -4188,11 +4200,11 @@ where
                 // The naked pointer will get fixed-up to loopback to the union below when we
                 // intern the union.
                 tag_layout.push(Layout::NAKED_RECURSIVE_PTR);
-                criteria.and(NAKED_RECURSION_PTR);
+                criteria.and(NAKED_RECURSION_PTR, env.subs);
                 continue;
             }
 
-            let payload = cached!(Layout::from_var(env, var), criteria);
+            let payload = cached!(Layout::from_var(env, var), criteria, env.subs);
             tag_layout.push(payload);
         }
 
@@ -4366,7 +4378,7 @@ pub(crate) fn list_layout_from_elem<'a>(
     } else {
         // NOTE: cannot re-use Content, because it may be recursive
         // then some state is not correctly kept, we have to go through from_var
-        cached!(Layout::from_var(env, element_var), criteria)
+        cached!(Layout::from_var(env, element_var), criteria, env.subs)
     };
 
     let list_layout = env

--- a/crates/compiler/test_gen/src/gen_primitives.rs
+++ b/crates/compiler/test_gen/src/gen_primitives.rs
@@ -4386,3 +4386,38 @@ fn recursive_lambda_set_resolved_only_upon_specialization() {
         u64
     );
 }
+
+#[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
+fn layout_cache_structure_with_multiple_recursive_structures() {
+    assert_evals_to!(
+        indoc!(
+            r#"
+            app "test" provides [main] to "./platform"
+
+            Chain : [
+                End,
+                Link Chain,
+            ]
+
+            LinkedList : [Nil, Cons { first : Chain, rest : LinkedList }]
+
+            main =
+                base : LinkedList 
+                base = Nil
+
+                walker : LinkedList, Chain -> LinkedList
+                walker = \rest, first -> Cons { first, rest } 
+
+                list : List Chain
+                list = []
+
+                r = List.walk list base walker
+                
+                if r == base then 11u8 else 22u8
+            "#
+        ),
+        11,
+        u8
+    );
+}

--- a/crates/compiler/test_mono/generated/layout_cache_structure_with_multiple_recursive_structures.txt
+++ b/crates/compiler/test_mono/generated/layout_cache_structure_with_multiple_recursive_structures.txt
@@ -1,0 +1,56 @@
+procedure List.139 (List.140, List.141, List.138):
+    let List.513 : [<rnu><null>, C {[<rnu>C *self, <null>], *self}] = CallByName Test.7 List.140 List.141;
+    ret List.513;
+
+procedure List.18 (List.136, List.137, List.138):
+    let List.494 : [<rnu><null>, C {[<rnu>C *self, <null>], *self}] = CallByName List.92 List.136 List.137 List.138;
+    ret List.494;
+
+procedure List.6 (#Attr.2):
+    let List.511 : U64 = lowlevel ListLen #Attr.2;
+    ret List.511;
+
+procedure List.66 (#Attr.2, #Attr.3):
+    let List.510 : [<rnu>C *self, <null>] = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.510;
+
+procedure List.80 (List.517, List.518, List.519, List.520, List.521):
+    joinpoint List.500 List.433 List.434 List.435 List.436 List.437:
+        let List.502 : Int1 = CallByName Num.22 List.436 List.437;
+        if List.502 then
+            let List.509 : [<rnu>C *self, <null>] = CallByName List.66 List.433 List.436;
+            let List.503 : [<rnu><null>, C {[<rnu>C *self, <null>], *self}] = CallByName List.139 List.434 List.509 List.435;
+            let List.506 : U64 = 1i64;
+            let List.505 : U64 = CallByName Num.19 List.436 List.506;
+            jump List.500 List.433 List.503 List.435 List.505 List.437;
+        else
+            ret List.434;
+    in
+    jump List.500 List.517 List.518 List.519 List.520 List.521;
+
+procedure List.92 (List.430, List.431, List.432):
+    let List.498 : U64 = 0i64;
+    let List.499 : U64 = CallByName List.6 List.430;
+    let List.497 : [<rnu><null>, C {[<rnu>C *self, <null>], *self}] = CallByName List.80 List.430 List.431 List.432 List.498 List.499;
+    ret List.497;
+
+procedure Num.19 (#Attr.2, #Attr.3):
+    let Num.275 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.275;
+
+procedure Num.22 (#Attr.2, #Attr.3):
+    let Num.276 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.276;
+
+procedure Test.7 (Test.11, Test.12):
+    let Test.17 : {[<rnu>C *self, <null>], [<rnu><null>, C {[<rnu>C *self, <null>], *self}]} = Struct {Test.12, Test.11};
+    let Test.16 : [<rnu><null>, C {[<rnu>C *self, <null>], *self}] = TagId(0) Test.17;
+    ret Test.16;
+
+procedure Test.0 ():
+    let Test.6 : [<rnu><null>, C {[<rnu>C *self, <null>], *self}] = TagId(1) ;
+    let Test.8 : List [<rnu>C *self, <null>] = Array [];
+    let Test.15 : {} = Struct {};
+    let Test.9 : [<rnu><null>, C {[<rnu>C *self, <null>], *self}] = CallByName List.18 Test.8 Test.6 Test.15;
+    dec Test.8;
+    ret Test.9;

--- a/crates/compiler/test_mono/src/tests.rs
+++ b/crates/compiler/test_mono/src/tests.rs
@@ -2859,3 +2859,33 @@ fn issue_4759() {
         "#
     )
 }
+
+#[mono_test]
+fn layout_cache_structure_with_multiple_recursive_structures() {
+    indoc!(
+        r#"
+        app "test" provides [main] to "./platform"
+
+        Chain : [
+            End,
+            Link Chain,
+        ]
+
+        LinkedList : [Nil, Cons { first : Chain, rest : LinkedList }]
+
+        main =
+            base : LinkedList 
+            base = Nil
+
+            walker : LinkedList, Chain -> LinkedList
+            walker = \rest, first -> Cons { first, rest } 
+
+            list : List Chain
+            list = []
+
+            r = List.walk list base walker
+
+            r
+        "#
+    )
+}


### PR DESCRIPTION
If an entry in the layout cache contains recursive structures, the entry
is not reusable if the recursive structure is currently in the "seen"
set. The example elucidated in the source code is as follows:

Suppose we are constructing the layout of

```
[A, B (List r)] as r
```

and we have already constructed and cached the layout of `List r`, which would
be

```
List (Recursive [Unit, List RecursivePointer])
```

If we use the cached entry of `List r`, we would end up with the layout

```
Recursive [Unit, (List (Recursive [Unit, List RecursivePointer]))]
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cached layout for `List r`
```

but this is not correct; the canonical layout of `[A, B (List r)] as r` is

```
Recursive [Unit, (List RecursivePointer)]
```

However, the current implementation only preserves this behavior for
structures that contain one recursive structure under them. In practice,
there can be structures that contain multiple recursive structures under
them, and we must be sure to record all those structures in the
layout-cache.
