### PR TITLE
Use a global bump allocator in the CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3270,6 +3270,7 @@ dependencies = [
  "target-lexicon",
  "tempfile",
  "ven_pretty",
+ "winapi",
 ]
 
 [[package]]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -81,6 +81,8 @@ tempfile.workspace = true
 [target.'cfg(not(windows))'.dependencies]
 roc_repl_expect = { path = "../repl_expect" }
 
+[target.'cfg(windows)'.dependencies]
+winapi = "0.3"
 
 [dev-dependencies]
 cli_utils = { path = "../cli_utils" }

--- a/crates/cli/src/global_allocator.rs
+++ b/crates/cli/src/global_allocator.rs
@@ -54,9 +54,7 @@ impl RocGlobalAlloc {
     /// This function is not thread-safe! Only call it when you are sure nothing else is potentially changing bump mode
     /// or performing allocations when the bump allocator is active.
     pub unsafe fn disable_bump_mode() {
-        unsafe {
-            USE_BUMP_ALLOCATOR = false;
-        }
+        USE_BUMP_ALLOCATOR = false;
     }
 }
 

--- a/crates/cli/src/global_allocator.rs
+++ b/crates/cli/src/global_allocator.rs
@@ -1,0 +1,113 @@
+use mimalloc::MiMalloc;
+use std::{
+    alloc::{GlobalAlloc, Layout},
+    sync::atomic::{AtomicUsize, Ordering},
+};
+
+/// Use bump allocation instead of MiMalloc
+static mut USE_BUMP_ALLOCATOR: bool = false;
+
+/// How many bytes in the arena have already been handed out.
+static mut ARENA_LEN: AtomicUsize = AtomicUsize::new(0);
+
+/// Arena size for the bump allocator (in bytes). This is virtual memory that will be mmap'd in.
+/// Because of demand paging, the OS will only translate this into physical memory when we run out
+/// of space in previously mapped pages. So the only downside to a big allocation here is using up virtual addresses.
+const ARENA_CAPACITY: usize = 1_000_000_000_000; // a terabyte of virtual memory should be enough for anybody
+
+/// The backing memory for the arena
+static mut ARENA_PTR: *mut u8 = std::ptr::null_mut();
+
+pub struct RocGlobalAlloc;
+
+impl RocGlobalAlloc {
+    /// # Safety
+    /// This function is not thread-safe! Only call it when you are sure nothing else is potentially changing bump mode
+    /// or performing allocations when the bump allocator is active.
+    pub unsafe fn enable_bump_mode() {
+        // The arena has never been initialized, so mmap it.
+        if ARENA_PTR.is_null() {
+            // mmap requires that the requested size be a multiple of page size.
+            let page_size = libc::sysconf(libc::_SC_PAGESIZE) as usize;
+            let bytes_to_mmap = ARENA_CAPACITY + (ARENA_CAPACITY % page_size);
+
+            ARENA_PTR = libc::mmap(
+                std::ptr::null_mut(),
+                bytes_to_mmap,
+                libc::PROT_READ | libc::PROT_WRITE,
+                libc::MAP_PRIVATE | libc::MAP_ANONYMOUS,
+                -1,
+                0,
+            ) as *mut u8;
+
+            if ARENA_PTR.cast() == libc::MAP_FAILED {
+                panic!("`mmap` failed when trying to initialize the global bump arena");
+            }
+        }
+
+        // This should be set after initialization is complete; otherwise, using things like dbg! prior
+        // to here will fail.
+        USE_BUMP_ALLOCATOR = true;
+    }
+
+    /// # Safety
+    /// This function is not thread-safe! Only call it when you are sure nothing else is potentially changing bump mode
+    /// or performing allocations when the bump allocator is active.
+    pub unsafe fn disable_bump_mode() {
+        unsafe {
+            USE_BUMP_ALLOCATOR = false;
+        }
+    }
+}
+
+fn is_inside_arena(ptr: *mut u8) -> bool {
+    let end_of_arena = unsafe { ARENA_PTR.add(ARENA_CAPACITY) };
+
+    unsafe { ptr >= ARENA_PTR && ptr < end_of_arena }
+}
+
+unsafe impl GlobalAlloc for RocGlobalAlloc {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        if USE_BUMP_ALLOCATOR {
+            let align = layout.align();
+            let bytes = layout.size();
+
+            loop {
+                let old_len = ARENA_LEN.load(Ordering::SeqCst);
+
+                // Calculate padding necessary to end up with an address that satisfies our alignment requirements
+                let padding = (align - old_len % align) % align;
+
+                let new_len = old_len + padding + bytes;
+
+                // Try to update ARENA_LEN, making sure it hasn't changed since we used it in our padding calculation.
+                if ARENA_LEN
+                    .compare_exchange(old_len, new_len, Ordering::SeqCst, Ordering::SeqCst)
+                    .is_ok()
+                {
+                    // It hasn't changed; we're good! (Otherwise we'll automatically loop back and try again.)
+
+                    // Store the new allocation immediately after the end of the previous allocation.
+                    let alloc_ptr = ARENA_PTR.add(old_len + (align - old_len % align) % align);
+
+                    // Make sure we didn't allocate past the end of the arena;
+                    // otherwise if anyone tries to write into this pointer, we could get
+                    // data corruption or a segfault. So return null instead of doing that.
+                    return if new_len <= ARENA_CAPACITY {
+                        alloc_ptr
+                    } else {
+                        std::ptr::null_mut()
+                    };
+                }
+            }
+        } else {
+            MiMalloc.alloc(layout)
+        }
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        if !is_inside_arena(ptr) {
+            MiMalloc.dealloc(ptr, layout)
+        }
+    }
+}

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -33,6 +33,7 @@ use target_lexicon::{
 use tempfile::TempDir;
 
 mod format;
+pub mod global_allocator;
 pub use format::format;
 
 pub const CMD_BUILD: &str = "build";

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -20,8 +20,14 @@ use target_lexicon::Triple;
 #[macro_use]
 extern crate const_format;
 
+#[cfg(not(wasm))]
 #[global_allocator]
 static GLOBAL: RocGlobalAlloc = RocGlobalAlloc;
+
+// bump mode requires calling mmap, which fails in wasm; just use MiMalloc instead for wasm.
+#[cfg(wasm)]
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 use std::ffi::{OsStr, OsString};
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -20,14 +20,8 @@ use target_lexicon::Triple;
 #[macro_use]
 extern crate const_format;
 
-#[cfg(not(wasm))]
 #[global_allocator]
 static GLOBAL: RocGlobalAlloc = RocGlobalAlloc;
-
-// bump mode requires calling mmap, which fails in wasm; just use MiMalloc instead for wasm.
-#[cfg(wasm)]
-#[global_allocator]
-static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 use std::ffi::{OsStr, OsString};
 


### PR DESCRIPTION
I'm not sure if this is worth doing, because in my local benchmarks it doesn't actually seem noticeably faster...possibly because we're already doing so much bump allocation in various stages!