### PR TITLE
use qualified imports for json example

### DIFF
--- a/crates/compiler/builtins/roc/Json.roc
+++ b/crates/compiler/builtins/roc/Json.roc
@@ -21,12 +21,12 @@
 ## result : Result Language _
 ## result =
 ##     jsonStr
-##     |> Decode.fromBytes fromUtf8 # returns `Ok {name : "Röc Lang"}`
+##     |> Decode.fromBytes Json.fromUtf8 # returns `Ok {name : "Röc Lang"}`
 ##
 ## name =
 ##     decodedValue <- Result.map result
 ##
-##     Encode.toBytes decodedValue.name toUtf8
+##     Encode.toBytes decodedValue.name Json.toUtf8
 ##
 ## expect name == Ok (Str.toUtf8 "\"Röc Lang\"")
 ## ```


### PR DESCRIPTION
I ran into this little problem while trying to use the `Json` module for the first time. I used the example as a guide to implement my first JSON decoder.
I got a little confused because I was not sure where the `fromUtf8` and `toUtf8` functions came from. From the `Str` module or maybe from the `Decode` module?
Because the example does not show how the functions were imported, we introduce some (in my eyes) unnecessary ambiguity.
I thought that qualified imports remove the ambiguity!?