### PR TITLE
Support highlighting other languages using static-site platform

### DIFF
--- a/crates/docs/src/static/styles.css
+++ b/crates/docs/src/static/styles.css
@@ -626,19 +626,42 @@ samp .comment,
 code .comment {
   color: var(--green);
 }
-/* Number, String, Tag, Type literals */
+
+/* Number, String, Tag literals */
+samp .storage.type,
+code .storage.type,
+samp .string,
+code .string,
+samp .string.begin,
+code .string.begin,
+samp .string.end,
+code .string.end,
+samp .constant,
+code .constant,
 samp .literal,
 code .literal {
   color: var(--cyan);
 }
+
 /* Keywords and punctuation */
-samp .kw,
+samp .keyword, 
+code .keyword,
+samp .punctuation.section, 
+code .punctuation.section,
+samp .punctuation.separator, 
+code .punctuation.separator,
+samp .punctuation.terminator, 
+code .punctuation.terminator,
+samp .kw, 
 code .kw {
-  color: var(--magenta);
+    color: var(--magenta);
 }
+
 /* Operators */
 samp .op,
-code .op {
+code .op,
+samp .keyword.operator,
+code .keyword.operator {
   color: var(--orange);
 }
 
@@ -649,12 +672,22 @@ code .delimeter {
 }
 
 /* Variables modules and field names */
+samp .function,
+code .function,
+samp .meta.group,
+code .meta.group,
+samp .meta.block,
+code .meta.block,
 samp .lowerident,
 code .lowerident {
   color: var(--blue);
 }
 
 /* Types, Tags, and Modules */
+samp .type,
+code .type,
+samp .meta.path,
+code .meta.path,
 samp .upperident,
 code .upperident {
   color: var(--green);

--- a/examples/static-site-gen/platform/Cargo.toml
+++ b/examples/static-site-gen/platform/Cargo.toml
@@ -18,6 +18,7 @@ path = "src/main.rs"
 
 [dependencies]
 libc = "0.2"
+syntect = "5.0"
 roc_highlight = { path = "../../../crates/highlight" }
 roc_std = { path = "../../../crates/roc_std" }
 

--- a/www/public/site.css
+++ b/www/public/site.css
@@ -635,48 +635,78 @@ h4 {
 /* Comments `#` and Documentation comments `##` */
 samp .comment,
 code .comment {
-    color: var(--green);
+  color: var(--green);
 }
 
-/* Number, String, Tag, Type literals */
+/* Number, String, Tag literals */
+samp .storage.type,
+code .storage.type,
+samp .string,
+code .string,
+samp .string.begin,
+code .string.begin,
+samp .string.end,
+code .string.end,
+samp .constant,
+code .constant,
 samp .literal,
 code .literal {
-    color: var(--cyan);
+  color: var(--cyan);
 }
 
 /* Keywords and punctuation */
-samp .kw,
+samp .keyword, 
+code .keyword,
+samp .punctuation.section, 
+code .punctuation.section,
+samp .punctuation.separator, 
+code .punctuation.separator,
+samp .punctuation.terminator, 
+code .punctuation.terminator,
+samp .kw, 
 code .kw {
     color: var(--magenta);
 }
 
 /* Operators */
 samp .op,
-code .op {
-    color: var(--orange);
+code .op,
+samp .keyword.operator,
+code .keyword.operator {
+  color: var(--orange);
 }
 
 /* Delimieters */
 samp .delimeter,
 code .delimeter {
-    color: var(--gray);
+  color: var(--gray);
 }
 
 /* Variables modules and field names */
+samp .function,
+code .function,
+samp .meta.group,
+code .meta.group,
+samp .meta.block,
+code .meta.block,
 samp .lowerident,
 code .lowerident {
-    color: var(--blue);
+  color: var(--blue);
 }
 
 /* Types, Tags, and Modules */
+samp .type,
+code .type,
+samp .meta.path,
+code .meta.path,
 samp .upperident,
 code .upperident {
-    color: var(--green);
+  color: var(--green);
 }
 
 samp .dim,
 code .dim {
-    opacity: 0.55;
+  opacity: 0.55;
 }
 
 .button-container {


### PR DESCRIPTION
- Adds `syntect` dependency to static-site platform for syntax highlighting code
- Updates static-site inline code to use `roc!` prefix for highlighting Roc code (discussed below)
- Updates static-site fenced code blocks to support other languages
- Updates `.css` files for good coverage of syntect classes, tested with `haskell` and `rust` languages (note syntect doesn't support Elm however Haskell is a good substitute)

## `roc!` prefix

The platform currently highlights inline code blocks by default and assumes they are Roc. This worked well for the tutorial however, does not make sense when used in other places. The main motivation here is development of the Examples site, and a possible Articles site, which often include inline snippets which are not roc code. For example these could be shell commands, or repl outputs etc. I now think defaulting all inline snippets to Roc code was probably the wrong choice for a static-site platform.

I found using a prefix `roc!` is the most practical way to keep highlighting functionality without interfering with the other use-cases. This could also be extended in future to support a `rust!` or `haskell!` prefix in the same way. However this seems to me unlikely to be needed.

The main downside of this change is that the Tutorial will lose its current highlighting on all the inline snippets. I am happy to add another commit to this PR which updates all of the inline snippets in the `.md` tutorial with this prefix if that is desired.

## CSS

I included additional classes into the `.css` files to support the default output of `syntect`. This works well, however it may also be worthwhile updating our classes to more align with these defaults. This would reduce duplication in the `.css` file, and also provide finer grained control over styling for anyone using static-site for roc code. However, I the trade-off here is acceptable, and we can update in future as we use highlighting for other languages.


