### PR TITLE
Introduce annotation in first step of recursive solving independently

### DIFF
--- a/crates/compiler/can/src/pattern.rs
+++ b/crates/compiler/can/src/pattern.rs
@@ -140,7 +140,7 @@ impl Pattern {
             RecordDestructure { destructs, .. } => {
                 // If all destructs are surely exhaustive, then this is surely exhaustive.
                 destructs.iter().all(|d| match &d.value.typ {
-                    DestructType::Required | DestructType::Optional(_, _) => false,
+                    DestructType::Required | DestructType::Optional(_, _) => true,
                     DestructType::Guard(_, pat) => pat.value.surely_exhaustive(),
                 })
             }

--- a/crates/compiler/collections/src/soa.rs
+++ b/crates/compiler/collections/src/soa.rs
@@ -137,6 +137,10 @@ impl<T> Slice<T> {
     pub fn into_iter(&self) -> impl Iterator<Item = Index<T>> {
         self.indices().map(|i| Index::new(i as _))
     }
+
+    pub const fn at(&self, i: usize) -> Index<T> {
+        Index::new(self.start + i as u32)
+    }
 }
 
 #[derive(PartialEq, Eq)]

--- a/crates/compiler/constrain/src/expr.rs
+++ b/crates/compiler/constrain/src/expr.rs
@@ -3379,9 +3379,8 @@ fn instantiate_rigids(
         if !rigid_substitution.is_empty() {
             annotation.substitute_variables(&rigid_substitution);
         }
-        let annotation_index = types.from_old_type(&annotation);
 
-        annotation_index
+        types.from_old_type(&annotation)
     };
 
     let signature = generate_fresh_ann(types);

--- a/crates/compiler/constrain/src/expr.rs
+++ b/crates/compiler/constrain/src/expr.rs
@@ -2097,6 +2097,7 @@ fn constrain_destructure_def(
                 loc_pattern,
                 &mut ftv,
                 &mut def_pattern_state.headers,
+                IsRecursiveDef::No,
             );
 
             let env = &mut Env {
@@ -2674,6 +2675,7 @@ fn constrain_typed_def(
         &def.loc_pattern,
         &mut ftv,
         &mut def_pattern_state.headers,
+        IsRecursiveDef::No,
     );
 
     let env = &mut Env {
@@ -3323,6 +3325,12 @@ pub struct InstantiateRigids {
     pub new_infer_variables: Vec<Variable>,
 }
 
+#[derive(PartialEq, Eq)]
+enum IsRecursiveDef {
+    Yes,
+    No,
+}
+
 fn instantiate_rigids(
     types: &mut Types,
     constraints: &mut Constraints,
@@ -3331,65 +3339,83 @@ fn instantiate_rigids(
     loc_pattern: &Loc<Pattern>,
     ftv: &mut MutMap<Lowercase, Variable>, // rigids defined before the current annotation
     headers: &mut VecMap<Symbol, Loc<TypeOrVar>>,
+    is_recursive_def: IsRecursiveDef,
 ) -> InstantiateRigids {
-    let mut annotation = annotation.clone();
-    let mut new_rigid_variables: Vec<Variable> = Vec::new();
+    let mut new_rigid_variables = vec![];
+    let mut new_infer_variables = vec![];
 
-    let mut rigid_substitution: MutMap<Variable, Variable> = MutMap::default();
-    for named in introduced_vars.iter_named() {
-        use std::collections::hash_map::Entry::*;
+    let mut generate_fresh_ann = |types: &mut Types| {
+        let mut annotation = annotation.clone();
 
-        match ftv.entry(named.name().clone()) {
-            Occupied(occupied) => {
-                let existing_rigid = occupied.get();
-                rigid_substitution.insert(named.variable(), *existing_rigid);
+        let mut rigid_substitution: MutMap<Variable, Variable> = MutMap::default();
+        for named in introduced_vars.iter_named() {
+            use std::collections::hash_map::Entry::*;
+
+            match ftv.entry(named.name().clone()) {
+                Occupied(occupied) => {
+                    let existing_rigid = occupied.get();
+                    rigid_substitution.insert(named.variable(), *existing_rigid);
+                }
+                Vacant(vacant) => {
+                    // It's possible to use this rigid in nested defs
+                    vacant.insert(named.variable());
+                    new_rigid_variables.push(named.variable());
+                }
             }
-            Vacant(vacant) => {
-                // It's possible to use this rigid in nested defs
-                vacant.insert(named.variable());
-                new_rigid_variables.push(named.variable());
-            }
+        }
+
+        // wildcards are always freshly introduced in this annotation
+        new_rigid_variables.extend(introduced_vars.wildcards.iter().map(|v| v.value));
+
+        // lambda set vars are always freshly introduced in this annotation
+        new_rigid_variables.extend(introduced_vars.lambda_sets.iter().copied());
+
+        // ext-infer vars are always freshly introduced in this annotation
+        new_rigid_variables.extend(introduced_vars.infer_ext_in_output.iter().copied());
+
+        new_infer_variables.extend(introduced_vars.inferred.iter().map(|v| v.value));
+
+        // Instantiate rigid variables
+        if !rigid_substitution.is_empty() {
+            annotation.substitute_variables(&rigid_substitution);
+        }
+        let annotation_index = types.from_old_type(&annotation);
+
+        annotation_index
+    };
+
+    let signature = generate_fresh_ann(types);
+    {
+        // If this is a recursive def, we must also generate a fresh annotation to be used as the
+        // type annotation that will be used in the first def headers introduced during the solving
+        // of the recursive definition.
+        //
+        // That is, this annotation serves as step (1) of XREF(rec-def-strategy). We don't want to
+        // link to the final annotation, since it may be incomplete (or incorrect, see step (1)).
+        // So, we generate a fresh annotation here, and return a separate fresh annotation below;
+        // the latter annotation is the one used to construct the finalized type.
+        let annotation_index = if is_recursive_def == IsRecursiveDef::Yes {
+            generate_fresh_ann(types)
+        } else {
+            signature
+        };
+
+        let loc_annotation_ref = Loc::at(loc_pattern.region, annotation_index);
+        if let Pattern::Identifier(symbol) = loc_pattern.value {
+            let annotation_index = constraints.push_type(types, annotation_index);
+            headers.insert(symbol, Loc::at(loc_pattern.region, annotation_index));
+        } else if let Some(new_headers) = crate::pattern::headers_from_annotation(
+            types,
+            constraints,
+            &loc_pattern.value,
+            &loc_annotation_ref,
+        ) {
+            headers.extend(new_headers)
         }
     }
 
-    // wildcards are always freshly introduced in this annotation
-    new_rigid_variables.extend(introduced_vars.wildcards.iter().map(|v| v.value));
-
-    // lambda set vars are always freshly introduced in this annotation
-    new_rigid_variables.extend(introduced_vars.lambda_sets.iter().copied());
-
-    // ext-infer vars are always freshly introduced in this annotation
-    new_rigid_variables.extend(introduced_vars.infer_ext_in_output.iter().copied());
-
-    let new_infer_variables: Vec<Variable> =
-        introduced_vars.inferred.iter().map(|v| v.value).collect();
-
-    // Instantiate rigid variables
-    if !rigid_substitution.is_empty() {
-        annotation.substitute_variables(&rigid_substitution);
-    }
-    let annotation_index = types.from_old_type(&annotation);
-
-    // TODO investigate when we can skip this. It seems to only be required for correctness
-    // for recursive functions. For non-recursive functions the final type is correct, but
-    // alias information is sometimes lost
-    //
-    // Skipping all of this cloning here would be neat!
-    let loc_annotation_ref = Loc::at(loc_pattern.region, &annotation);
-    if let Pattern::Identifier(symbol) = loc_pattern.value {
-        let annotation_index = constraints.push_type(types, annotation_index);
-        headers.insert(symbol, Loc::at(loc_pattern.region, annotation_index));
-    } else if let Some(new_headers) = crate::pattern::headers_from_annotation(
-        types,
-        constraints,
-        &loc_pattern.value,
-        &loc_annotation_ref,
-    ) {
-        headers.extend(new_headers)
-    }
-
     InstantiateRigids {
-        signature: annotation_index,
+        signature,
         new_rigid_variables,
         new_infer_variables,
     }
@@ -3867,7 +3893,7 @@ pub fn rec_defs_help_simple(
         }
     }
 
-    // Strategy for recursive defs:
+    // NB(rec-def-strategy) Strategy for recursive defs:
     //
     // 1. Let-generalize all rigid annotations. These are the source of truth we'll solve
     //    everything else with. If there are circular type errors here, they will be caught
@@ -4068,6 +4094,7 @@ fn rec_defs_help(
                     &def.loc_pattern,
                     &mut ftv,
                     &mut def_pattern_state.headers,
+                    IsRecursiveDef::Yes,
                 );
 
                 let is_hybrid = !new_infer_variables.is_empty();
@@ -4289,7 +4316,7 @@ fn rec_defs_help(
         }
     }
 
-    // Strategy for recursive defs:
+    // NB(rec-def-strategy) Strategy for recursive defs:
     //
     // 1. Let-generalize all rigid annotations. These are the source of truth we'll solve
     //    everything else with. If there are circular type errors here, they will be caught

--- a/crates/compiler/test_solve_helpers/src/lib.rs
+++ b/crates/compiler/test_solve_helpers/src/lib.rs
@@ -20,7 +20,7 @@ use roc_reporting::report::{can_problem, type_problem, RocDocAllocator};
 use roc_solve_problem::TypeError;
 use roc_types::{
     pretty_print::{name_and_print_var, DebugPrint},
-    subs::{Subs, Variable},
+    subs::{instantiate_rigids, Subs, Variable},
 };
 
 fn promote_expr_to_module(src: &str) -> String {
@@ -533,6 +533,7 @@ impl<'a> QueryCtx<'a> {
         let def_region = Region::new(start_pos, end_pos);
         let def_source = &self.source[start_pos.offset as usize..end_pos.offset as usize];
 
+        instantiate_rigids(self.subs, def.var());
         roc_late_solve::unify(
             self.home,
             self.arena,

--- a/crates/compiler/types/src/types.rs
+++ b/crates/compiler/types/src/types.rs
@@ -1338,13 +1338,10 @@ impl Types {
 
     pub fn shallow_dealias(&self, value: Index<TypeTag>) -> Index<TypeTag> {
         let mut result = value;
-        loop {
-            match self[result] {
-                TypeTag::StructuralAlias { actual, .. } | TypeTag::OpaqueAlias { actual, .. } => {
-                    result = actual
-                }
-                _ => break,
-            }
+        while let TypeTag::StructuralAlias { actual, .. } | TypeTag::OpaqueAlias { actual, .. } =
+            self[result]
+        {
+            result = actual;
         }
         result
     }

--- a/crates/compiler/types/src/types.rs
+++ b/crates/compiler/types/src/types.rs
@@ -1335,6 +1335,19 @@ impl Types {
 
         cloned
     }
+
+    pub fn shallow_dealias(&self, value: Index<TypeTag>) -> Index<TypeTag> {
+        let mut result = value;
+        loop {
+            match self[result] {
+                TypeTag::StructuralAlias { actual, .. } | TypeTag::OpaqueAlias { actual, .. } => {
+                    result = actual
+                }
+                _ => break,
+            }
+        }
+        result
+    }
 }
 
 #[cfg(debug_assertions)]
@@ -1699,6 +1712,8 @@ impl_types_index! {
 
 impl_types_index_slice! {
     tag_names, TagName
+    field_names, Lowercase
+    tags, TypeTag
 }
 
 impl std::ops::Index<Index<AsideTypeSlice>> for Types {
@@ -2806,7 +2821,7 @@ impl Type {
     }
 
     /// a shallow dealias, continue until the first constructor is not an alias.
-    pub fn shallow_dealias(&self) -> &Self {
+    fn shallow_dealias(&self) -> &Self {
         let mut result = self;
         while let Type::Alias { actual, .. } = result {
             result = actual;

--- a/crates/compiler/uitest/tests/recursion/calls_result_in_unique_specializations.txt
+++ b/crates/compiler/uitest/tests/recursion/calls_result_in_unique_specializations.txt
@@ -1,0 +1,17 @@
+app "test" provides [main] to "./platform"
+
+main =
+    foo : a, Bool -> Str
+    foo = \in, b -> if b then "done" else bar in
+#                                         ^^^ a -[[bar(2)]]-> Str
+#   ^^^ a, Bool -[[foo(1)]]-> Str
+
+    bar = \_ -> foo {} Bool.true
+#               ^^^ {}, Bool -[[]]-> Str
+
+    foo "" Bool.false
+#   ^^^{inst} Str, Bool -[[foo(1)]]-> Str
+#   │     foo : a, Bool -> Str
+#   │     foo = \in, b -> if b then "done" else bar in
+#   │                                           ^^^ Str -[[bar(2)]]-> Str
+#   │     ^^^ Str, Bool -[[foo(1)]]-> Str

--- a/crates/compiler/uitest/tests/recursion/constrain_recursive_annotation_independently_issue_5256.txt
+++ b/crates/compiler/uitest/tests/recursion/constrain_recursive_annotation_independently_issue_5256.txt
@@ -1,0 +1,17 @@
+app "test" provides [main] to "./platform"
+
+main =
+    f = \x -> x + 1
+
+    map : { f1: (I64 -> I64) } -> List I64
+    map = \{ f1 } -> List.concat [f1 1] (map { f1 })
+#                                        ^^^ { f1 : I64 -[[]]-> I64 } -[[map(2)]]-> List I64
+#   ^^^ { f1 : I64 -[[]]-> I64 } -[[map(2)]]-> List I64
+
+
+    map { f1: f }
+#   ^^^{inst} { f1 : I64 -[[f(1)]]-> I64 } -[[map(2)]]-> List I64
+#   │     map : { f1: (I64 -> I64) } -> List I64
+#   │     map = \{ f1 } -> List.concat [f1 1] (map { f1 })
+#   │                                          ^^^ { f1 : I64 -[[f(1)]]-> I64 } -[[map(2)]]-> List I64
+#   │     ^^^ { f1 : I64 -[[f(1)]]-> I64 } -[[map(2)]]-> List I64

--- a/crates/reporting/tests/test_reporting.rs
+++ b/crates/reporting/tests/test_reporting.rs
@@ -1237,20 +1237,20 @@ mod test_reporting {
         @r###"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
-    This 1st argument to `f` has an unexpected type:
+    This expression is used in an unexpected way:
 
     7│      g = \x -> f [x]
-                        ^^^
+                      ^^^^^
 
-    The argument is a list of type:
+    This `f` call produces:
+
+        List List b
+
+    But you are trying to use it as:
 
         List b
 
-    But `f` needs its 1st argument to be:
-
-        a
-
-    Tip: The type annotation uses the type variable `a` to say that this
+    Tip: The type annotation uses the type variable `b` to say that this
     definition can produce any type of value. But in the body I see that
     it will only produce a `List` value of a single specific type. Maybe
     change the type annotation to be more specific? Maybe change the code
@@ -12687,42 +12687,6 @@ I recommend using camelCase. It's the standard style in Roc code!
                 _ -> ""
             "#
         )
-    );
-
-    test_report!(
-        polymorphic_recursion_forces_ungeneralized_type,
-        indoc!(
-            r#"
-            foo : a, Bool -> Str
-            foo = \in, b -> if b then "done" else bar in
-
-            bar = \_ -> foo {} Bool.true
-
-            foo "" Bool.false
-            "#
-        ),
-    @r###"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
-
-    This 1st argument to `foo` has an unexpected type:
-
-    9│      foo "" Bool.false
-                ^^
-
-    The argument is a string of type:
-
-        Str
-
-    But `foo` needs its 1st argument to be:
-
-        a
-
-    Tip: The type annotation uses the type variable `a` to say that this
-    definition can produce any type of value. But in the body I see that
-    it will only produce a `Str` value of a single specific type. Maybe
-    change the type annotation to be more specific? Maybe change the code
-    to be more general?
-    "###
     );
 
     test_report!(


### PR DESCRIPTION
The algorithm for solving recursive definitions proceeds in several
steps. There are three main phases: introduction of what's known,
solving what's not known, and then checking our work of what was
inferred against what the programmer claimed. Concretely:

1. All explicitly-annotated signatures in the mutually recursive set are
   introduced and let-generalized.
2. Then, inference type variables (`_`) and unannotated def signatures are
   introduced to the cycle, without generalization. The bodies of these
   defs, that are either unannotated or have inference variables, are
   solved.
3. The defs from step (2) are now let-generalized, since we now know
   that their types are consistent. At this point, all the defs in the
   cycle have their types introduced and let-generalized, but we still
   haven't checked the bodies of the defs froom step (1).
4. Check the bodies of explicitly-annotated defs in recursive set. This
   might materially affect the actual types in the signature, for
   example do to fixpoint-fixing or alias expansion.
5. As a result of (4) possibly changing the structure of the annotated
   type, and because the previous annotated types in (1) were introduced
   at a lower rank, we now re-introduce and re-generalize the solved def
   types, in the same we did in step (3).
5. The rest of the program is solved.

Now, a very important thing here is that the annotation signature
introduced for (1) consists of different type variables than the
annotation signature introduced in (5). The reason is that they live at
different ranks. Prior to this patch we were not explicilty doing so;
this commit ensures that we do.

Closes #5256