### PR TITLE
Freshly instantiate nested recursion variables under aliases and opaques

### DIFF
--- a/crates/compiler/can/src/annotation.rs
+++ b/crates/compiler/can/src/annotation.rs
@@ -1258,56 +1258,6 @@ fn shallow_dealias_with_scope<'a>(scope: &'a mut Scope, typ: &'a Type) -> &'a Ty
     result
 }
 
-struct FreshenedAlias {
-    new_lambda_set_variables: Vec<LambdaSet>,
-    actual_type: Type,
-}
-
-fn instantiate_and_freshen_alias_type(
-    var_store: &mut VarStore,
-    introduced_variables: &mut IntroducedVariables,
-    type_variables: &[Loc<AliasVar>],
-    type_arguments: Vec<Type>,
-    recursion_variables: impl IntoIterator<Item = Variable>,
-    lambda_set_variables: &[LambdaSet],
-    mut actual_type: Type,
-) -> FreshenedAlias {
-    let mut substitutions = ImMap::default();
-
-    for (loc_var, arg_ann) in type_variables.iter().zip(type_arguments.into_iter()) {
-        let var = loc_var.value.var;
-
-        substitutions.insert(var, arg_ann.clone());
-    }
-
-    // make sure all nested recursion variables is freshly instantiated
-    for rec_var in recursion_variables {
-        let new = var_store.fresh();
-        substitutions.insert(rec_var, Type::Variable(new));
-    }
-
-    // make sure all nested lambda set variables are freshly instantiated
-    let mut new_lambda_set_variables = Vec::with_capacity(lambda_set_variables.len());
-    for typ in lambda_set_variables.iter() {
-        if let Type::Variable(var) = typ.0 {
-            let fresh = var_store.fresh();
-            substitutions.insert(var, Type::Variable(fresh));
-            introduced_variables.insert_lambda_set(fresh);
-            new_lambda_set_variables.push(LambdaSet(Type::Variable(fresh)));
-        } else {
-            unreachable!("at this point there should be only vars in there");
-        }
-    }
-
-    // instantiate variables
-    actual_type.substitute(&substitutions);
-
-    FreshenedAlias {
-        new_lambda_set_variables,
-        actual_type,
-    }
-}
-
 pub fn freshen_opaque_def(
     var_store: &mut VarStore,
     opaque: &Alias,
@@ -1323,27 +1273,44 @@ pub fn freshen_opaque_def(
         })
         .collect();
 
-    let fresh_type_arguments = fresh_variables
-        .iter()
-        .map(|av| Type::Variable(av.var))
-        .collect();
-
     // NB: We don't introduce the fresh variables here, we introduce them during constraint gen.
     // NB: If there are bugs, check whether this is a problem!
     let mut introduced_variables = IntroducedVariables::default();
 
-    let FreshenedAlias {
-        new_lambda_set_variables,
-        actual_type,
-    } = instantiate_and_freshen_alias_type(
-        var_store,
-        &mut introduced_variables,
-        &opaque.type_variables,
-        fresh_type_arguments,
-        opaque.recursion_variables.iter().copied(),
-        &opaque.lambda_set_variables,
-        opaque.typ.clone(),
-    );
+    let mut substitutions = ImMap::default();
+
+    // Freshen all type variables used in the opaque.
+    for (loc_var, fresh_var) in opaque.type_variables.iter().zip(fresh_variables.iter()) {
+        let old_var = loc_var.value.var;
+        substitutions.insert(old_var, Type::Variable(fresh_var.var));
+        // NB: fresh var not introduced in this pass; see above.
+    }
+
+    // Freshen all nested recursion variables.
+    for &rec_var in opaque.recursion_variables.iter() {
+        let new = var_store.fresh();
+        substitutions.insert(rec_var, Type::Variable(new));
+    }
+
+    // Freshen all nested lambda sets.
+    let mut new_lambda_set_variables = Vec::with_capacity(opaque.lambda_set_variables.len());
+    for typ in opaque.lambda_set_variables.iter() {
+        if let Type::Variable(var) = typ.0 {
+            let fresh = var_store.fresh();
+            substitutions.insert(var, Type::Variable(fresh));
+            introduced_variables.insert_lambda_set(fresh);
+            new_lambda_set_variables.push(LambdaSet(Type::Variable(fresh)));
+        } else {
+            unreachable!("at this point there should be only vars in there");
+        }
+    }
+
+    // Fresh the real type with our new variables.
+    let actual_type = {
+        let mut typ = opaque.typ.clone();
+        typ.substitute(&substitutions);
+        typ
+    };
 
     (fresh_variables, new_lambda_set_variables, actual_type)
 }

--- a/crates/compiler/can/src/def.rs
+++ b/crates/compiler/can/src/def.rs
@@ -2925,12 +2925,14 @@ fn correct_mutual_recursive_type_alias<'a>(
             };
 
             let mut new_lambda_sets = ImSet::default();
+            let mut new_recursion_variables = ImSet::default();
             let mut new_infer_ext_vars = ImSet::default();
             alias_type.instantiate_aliases(
                 alias_region,
                 &can_instantiate_symbol,
                 var_store,
                 &mut new_lambda_sets,
+                &mut new_recursion_variables,
                 &mut new_infer_ext_vars,
             );
 
@@ -2952,6 +2954,9 @@ fn correct_mutual_recursive_type_alias<'a>(
                     .iter()
                     .map(|var| LambdaSet(Type::Variable(*var))),
             );
+
+            // add any new recursion variables
+            alias.recursion_variables.extend(new_recursion_variables);
 
             // add any new infer-in-output extension variables that the instantiation created to the current alias
             alias

--- a/crates/compiler/can/src/scope.rs
+++ b/crates/compiler/can/src/scope.rs
@@ -463,6 +463,7 @@ pub fn create_alias(
         let mut hidden = type_variables;
 
         for var in (vars.iter().map(|lv| lv.value.var))
+            .chain(recursion_variables.iter().copied())
             .chain(infer_ext_in_output_variables.iter().copied())
         {
             hidden.remove(&var);

--- a/crates/compiler/test_solve_helpers/src/lib.rs
+++ b/crates/compiler/test_solve_helpers/src/lib.rs
@@ -254,6 +254,7 @@ fn parse_queries(src: &str, line_info: &LineInfo) -> Vec<TypeQuery> {
 
 #[derive(Default, Clone, Copy)]
 pub struct InferOptions {
+    pub allow_errors: bool,
     pub print_can_decls: bool,
     pub print_only_under_alias: bool,
     pub no_promote: bool,
@@ -376,7 +377,7 @@ pub fn infer_queries<'a>(
         if !can_problems.is_empty() && !allow_can_errors {
             return Err(format!("Canonicalization problems: {can_problems}",).into());
         }
-        if !type_problems.is_empty() {
+        if !type_problems.is_empty() && !options.allow_errors {
             return Err(format!("Type problems: {type_problems}",).into());
         }
     }

--- a/crates/compiler/test_solve_helpers/src/lib.rs
+++ b/crates/compiler/test_solve_helpers/src/lib.rs
@@ -256,7 +256,6 @@ fn parse_queries(src: &str, line_info: &LineInfo) -> Vec<TypeQuery> {
 pub struct InferOptions {
     pub print_can_decls: bool,
     pub print_only_under_alias: bool,
-    pub allow_errors: bool,
     pub no_promote: bool,
 }
 
@@ -348,6 +347,7 @@ pub fn infer_queries<'a>(
     src: &str,
     dependencies: impl IntoIterator<Item = (&'a str, &'a str)>,
     options: InferOptions,
+    allow_can_errors: bool,
 ) -> Result<InferredProgram, Box<dyn Error>> {
     let (
         LoadedModule {
@@ -369,11 +369,11 @@ pub fn infer_queries<'a>(
     let can_problems = can_problems.remove(&home).unwrap_or_default();
     let type_problems = type_problems.remove(&home).unwrap_or_default();
 
-    if !options.allow_errors {
+    {
         let (can_problems, type_problems) =
             format_problems(&src, home, &interns, can_problems, type_problems);
 
-        if !can_problems.is_empty() {
+        if !can_problems.is_empty() && !allow_can_errors {
             return Err(format!("Canonicalization problems: {can_problems}",).into());
         }
         if !type_problems.is_empty() {

--- a/crates/compiler/types/src/types.rs
+++ b/crates/compiler/types/src/types.rs
@@ -3104,22 +3104,6 @@ fn instantiate_aliases<'a, F>(
 
                 actual.substitute(&substitution);
 
-                // instantiate recursion variable!
-                //if let Type::RecursiveTagUnion(rec_var, mut tags, mut ext) = actual {
-                //    let new_rec_var = ctx.var_store.fresh();
-                //    substitution.clear();
-                //    substitution.insert(rec_var, Type::Variable(new_rec_var));
-
-                //    for typ in tags.iter_mut().flat_map(|v| v.1.iter_mut()) {
-                //        typ.substitute(&substitution);
-                //    }
-
-                //    if let TypeExtension::Open(ext, _) = &mut ext {
-                //        ext.substitute(&substitution);
-                //    }
-
-                //    actual = Type::RecursiveTagUnion(new_rec_var, tags, ext);
-                //}
                 let alias = Type::Alias {
                     symbol: *symbol,
                     type_arguments: named_args,

--- a/crates/compiler/types/src/types.rs
+++ b/crates/compiler/types/src/types.rs
@@ -2316,7 +2316,7 @@ impl Type {
                 RecursiveTagUnion(rec, tags, ext) => {
                     if let Some(replacement) = substitutions.get(rec) {
                         let new_rec_var = match replacement {
-                            Type::Variable(v) => v.clone(),
+                            Type::Variable(v) => *v,
                             _ => panic!("Recursion var substitution must be a variable"),
                         };
 

--- a/crates/compiler/types/src/types.rs
+++ b/crates/compiler/types/src/types.rs
@@ -171,23 +171,15 @@ impl RecordField<Type> {
         }
     }
 
-    pub fn instantiate_aliases<'a, F>(
+    fn instantiate_aliases<'a, F>(
         &mut self,
         region: Region,
-        aliases: &'a F,
-        var_store: &mut VarStore,
-        new_lambda_sets: &mut ImSet<Variable>,
-        new_infer_ext_vars: &mut ImSet<Variable>,
+        aliases: &F,
+        ctx: &mut InstantiateAliasesCtx<'_>,
     ) where
         F: Fn(Symbol) -> Option<&'a Alias>,
     {
-        self.as_inner_mut().instantiate_aliases(
-            region,
-            aliases,
-            var_store,
-            new_lambda_sets,
-            new_infer_ext_vars,
-        )
+        instantiate_aliases(self.as_inner_mut(), region, aliases, ctx)
     }
 
     pub fn contains_symbol(&self, rep_symbol: Symbol) -> bool {
@@ -229,20 +221,12 @@ impl LambdaSet {
     fn instantiate_aliases<'a, F>(
         &mut self,
         region: Region,
-        aliases: &'a F,
-        var_store: &mut VarStore,
-        new_lambda_sets: &mut ImSet<Variable>,
-        new_infer_ext_vars: &mut ImSet<Variable>,
+        aliases: &F,
+        ctx: &mut InstantiateAliasesCtx<'_>,
     ) where
         F: Fn(Symbol) -> Option<&'a Alias>,
     {
-        self.0.instantiate_aliases(
-            region,
-            aliases,
-            var_store,
-            new_lambda_sets,
-            new_infer_ext_vars,
-        )
+        instantiate_aliases(&mut self.0, region, aliases, ctx)
     }
 }
 
@@ -2329,7 +2313,16 @@ impl Type {
                         stack.push(ext);
                     }
                 }
-                RecursiveTagUnion(_, tags, ext) => {
+                RecursiveTagUnion(rec, tags, ext) => {
+                    if let Some(replacement) = substitutions.get(rec) {
+                        let new_rec_var = match replacement {
+                            Type::Variable(v) => v.clone(),
+                            _ => panic!("Recursion var substitution must be a variable"),
+                        };
+
+                        *rec = new_rec_var;
+                    }
+
                     for (_, args) in tags {
                         stack.extend(args.iter_mut());
                     }
@@ -2842,324 +2835,21 @@ impl Type {
     pub fn instantiate_aliases<'a, F>(
         &mut self,
         region: Region,
-        aliases: &'a F,
+        aliases: &F,
         var_store: &mut VarStore,
         new_lambda_set_variables: &mut ImSet<Variable>,
+        new_recursion_variables: &mut ImSet<Variable>,
         new_infer_ext_vars: &mut ImSet<Variable>,
     ) where
         F: Fn(Symbol) -> Option<&'a Alias>,
     {
-        use Type::*;
-
-        match self {
-            Function(args, closure, ret) => {
-                for arg in args {
-                    arg.instantiate_aliases(
-                        region,
-                        aliases,
-                        var_store,
-                        new_lambda_set_variables,
-                        new_infer_ext_vars,
-                    );
-                }
-                closure.instantiate_aliases(
-                    region,
-                    aliases,
-                    var_store,
-                    new_lambda_set_variables,
-                    new_infer_ext_vars,
-                );
-                ret.instantiate_aliases(
-                    region,
-                    aliases,
-                    var_store,
-                    new_lambda_set_variables,
-                    new_infer_ext_vars,
-                );
-            }
-            FunctionOrTagUnion(_, _, ext) => {
-                if let TypeExtension::Open(ext, _) = ext {
-                    ext.instantiate_aliases(
-                        region,
-                        aliases,
-                        var_store,
-                        new_lambda_set_variables,
-                        new_infer_ext_vars,
-                    );
-                }
-            }
-            RecursiveTagUnion(_, tags, ext) | TagUnion(tags, ext) => {
-                for (_, args) in tags {
-                    for x in args {
-                        x.instantiate_aliases(
-                            region,
-                            aliases,
-                            var_store,
-                            new_lambda_set_variables,
-                            new_infer_ext_vars,
-                        );
-                    }
-                }
-
-                if let TypeExtension::Open(ext, _) = ext {
-                    ext.instantiate_aliases(
-                        region,
-                        aliases,
-                        var_store,
-                        new_lambda_set_variables,
-                        new_infer_ext_vars,
-                    );
-                }
-            }
-            Record(fields, ext) => {
-                for (_, x) in fields.iter_mut() {
-                    x.instantiate_aliases(
-                        region,
-                        aliases,
-                        var_store,
-                        new_lambda_set_variables,
-                        new_infer_ext_vars,
-                    );
-                }
-
-                if let TypeExtension::Open(ext, _) = ext {
-                    ext.instantiate_aliases(
-                        region,
-                        aliases,
-                        var_store,
-                        new_lambda_set_variables,
-                        new_infer_ext_vars,
-                    );
-                }
-            }
-            Tuple(elems, ext) => {
-                for (_, x) in elems.iter_mut() {
-                    x.instantiate_aliases(
-                        region,
-                        aliases,
-                        var_store,
-                        new_lambda_set_variables,
-                        new_infer_ext_vars,
-                    );
-                }
-
-                if let TypeExtension::Open(ext, _) = ext {
-                    ext.instantiate_aliases(
-                        region,
-                        aliases,
-                        var_store,
-                        new_lambda_set_variables,
-                        new_infer_ext_vars,
-                    );
-                }
-            }
-            DelayedAlias(AliasCommon {
-                type_arguments,
-                lambda_set_variables,
-                infer_ext_in_output_types,
-                symbol: _,
-            }) => {
-                debug_assert!(lambda_set_variables
-                    .iter()
-                    .all(|lambda_set| matches!(lambda_set.0, Type::Variable(..))));
-                debug_assert!(infer_ext_in_output_types
-                    .iter()
-                    .all(|t| matches!(t, Type::Variable(..) | Type::EmptyTagUnion)));
-                type_arguments.iter_mut().for_each(|t| {
-                    t.value.typ.instantiate_aliases(
-                        region,
-                        aliases,
-                        var_store,
-                        new_lambda_set_variables,
-                        new_infer_ext_vars,
-                    )
-                });
-            }
-            HostExposedAlias {
-                type_arguments: type_args,
-                lambda_set_variables,
-                actual: actual_type,
-                ..
-            } => {
-                for arg in type_args {
-                    arg.instantiate_aliases(
-                        region,
-                        aliases,
-                        var_store,
-                        new_lambda_set_variables,
-                        new_infer_ext_vars,
-                    );
-                }
-
-                for arg in lambda_set_variables {
-                    arg.instantiate_aliases(
-                        region,
-                        aliases,
-                        var_store,
-                        new_lambda_set_variables,
-                        new_infer_ext_vars,
-                    );
-                }
-
-                actual_type.instantiate_aliases(
-                    region,
-                    aliases,
-                    var_store,
-                    new_lambda_set_variables,
-                    new_infer_ext_vars,
-                );
-            }
-            Alias {
-                type_arguments: type_args,
-                lambda_set_variables,
-                actual: actual_type,
-                ..
-            } => {
-                for arg in type_args {
-                    arg.typ.instantiate_aliases(
-                        region,
-                        aliases,
-                        var_store,
-                        new_lambda_set_variables,
-                        new_infer_ext_vars,
-                    );
-                }
-
-                for arg in lambda_set_variables {
-                    arg.instantiate_aliases(
-                        region,
-                        aliases,
-                        var_store,
-                        new_lambda_set_variables,
-                        new_infer_ext_vars,
-                    );
-                }
-
-                actual_type.instantiate_aliases(
-                    region,
-                    aliases,
-                    var_store,
-                    new_lambda_set_variables,
-                    new_infer_ext_vars,
-                );
-            }
-            Apply(symbol, args, _) => {
-                if let Some(alias) = aliases(*symbol) {
-                    if args.len() != alias.type_variables.len() {
-                        // We will have already reported an error during canonicalization.
-                        *self = Type::Error;
-                        return;
-                    }
-
-                    let mut actual = alias.typ.clone();
-
-                    let mut named_args = Vec::with_capacity(args.len());
-                    let mut substitution = ImMap::default();
-
-                    // TODO substitute further in args
-                    for (
-                        Loc {
-                            value:
-                                AliasVar {
-                                    var: placeholder,
-                                    opt_bound_abilities,
-                                    ..
-                                },
-                            ..
-                        },
-                        filler,
-                    ) in alias.type_variables.iter().zip(args.iter())
-                    {
-                        let mut filler = filler.clone();
-                        filler.value.instantiate_aliases(
-                            region,
-                            aliases,
-                            var_store,
-                            new_lambda_set_variables,
-                            new_infer_ext_vars,
-                        );
-                        named_args.push(OptAbleType {
-                            typ: filler.value.clone(),
-                            opt_abilities: opt_bound_abilities.clone(),
-                        });
-                        substitution.insert(*placeholder, filler.value);
-                    }
-
-                    // make sure hidden variables are freshly instantiated
-                    let mut lambda_set_variables =
-                        Vec::with_capacity(alias.lambda_set_variables.len());
-                    for typ in alias.lambda_set_variables.iter() {
-                        if let Type::Variable(var) = typ.0 {
-                            let fresh = var_store.fresh();
-                            new_lambda_set_variables.insert(fresh);
-                            substitution.insert(var, Type::Variable(fresh));
-                            lambda_set_variables.push(LambdaSet(Type::Variable(fresh)));
-                        } else {
-                            unreachable!("at this point there should be only vars in there");
-                        }
-                    }
-                    let mut infer_ext_in_output_types =
-                        Vec::with_capacity(alias.infer_ext_in_output_variables.len());
-                    for var in alias.infer_ext_in_output_variables.iter() {
-                        let fresh = var_store.fresh();
-                        new_infer_ext_vars.insert(fresh);
-                        substitution.insert(*var, Type::Variable(fresh));
-                        infer_ext_in_output_types.push(Type::Variable(fresh));
-                    }
-
-                    actual.instantiate_aliases(
-                        region,
-                        aliases,
-                        var_store,
-                        new_lambda_set_variables,
-                        new_infer_ext_vars,
-                    );
-
-                    actual.substitute(&substitution);
-
-                    // instantiate recursion variable!
-                    if let Type::RecursiveTagUnion(rec_var, mut tags, mut ext) = actual {
-                        let new_rec_var = var_store.fresh();
-                        substitution.clear();
-                        substitution.insert(rec_var, Type::Variable(new_rec_var));
-
-                        for typ in tags.iter_mut().flat_map(|v| v.1.iter_mut()) {
-                            typ.substitute(&substitution);
-                        }
-
-                        if let TypeExtension::Open(ext, _) = &mut ext {
-                            ext.substitute(&substitution);
-                        }
-
-                        actual = Type::RecursiveTagUnion(new_rec_var, tags, ext);
-                    }
-                    let alias = Type::Alias {
-                        symbol: *symbol,
-                        type_arguments: named_args,
-                        lambda_set_variables,
-                        infer_ext_in_output_types,
-                        actual: Box::new(actual),
-                        kind: alias.kind,
-                    };
-
-                    *self = alias;
-                } else {
-                    // one of the special-cased Apply types.
-                    for x in args {
-                        x.value.instantiate_aliases(
-                            region,
-                            aliases,
-                            var_store,
-                            new_lambda_set_variables,
-                            new_infer_ext_vars,
-                        );
-                    }
-                }
-            }
-            RangedNumber(_) => {}
-            UnspecializedLambdaSet { .. } => {}
-            EmptyRec | EmptyTagUnion | ClosureTag { .. } | Error | Variable(_) => {}
-        }
+        let mut ctx = InstantiateAliasesCtx {
+            var_store,
+            new_lambda_set_variables,
+            new_recursion_variables,
+            new_infer_ext_vars,
+        };
+        instantiate_aliases(self, region, aliases, &mut ctx)
     }
 
     pub fn instantiate_lambda_sets_as_unspecialized(
@@ -3232,6 +2922,224 @@ impl Type {
             Type::Variable(v) => *v,
             _ => internal_error!("{}", reason),
         }
+    }
+}
+
+struct InstantiateAliasesCtx<'a> {
+    var_store: &'a mut VarStore,
+    new_lambda_set_variables: &'a mut ImSet<Variable>,
+    new_recursion_variables: &'a mut ImSet<Variable>,
+    new_infer_ext_vars: &'a mut ImSet<Variable>,
+}
+
+fn instantiate_aliases<'a, F>(
+    typ: &mut Type,
+    region: Region,
+    aliases: &F,
+    ctx: &mut InstantiateAliasesCtx<'_>,
+) where
+    F: Fn(Symbol) -> Option<&'a Alias>,
+{
+    use Type::*;
+
+    match typ {
+        Function(args, closure, ret) => {
+            for arg in args {
+                instantiate_aliases(arg, region, aliases, ctx);
+            }
+            instantiate_aliases(closure, region, aliases, ctx);
+            instantiate_aliases(ret, region, aliases, ctx);
+        }
+        FunctionOrTagUnion(_, _, ext) => {
+            if let TypeExtension::Open(ext, _) = ext {
+                instantiate_aliases(ext, region, aliases, ctx);
+            }
+        }
+        RecursiveTagUnion(_, tags, ext) | TagUnion(tags, ext) => {
+            for (_, args) in tags {
+                for x in args {
+                    instantiate_aliases(x, region, aliases, ctx);
+                }
+            }
+
+            if let TypeExtension::Open(ext, _) = ext {
+                instantiate_aliases(ext, region, aliases, ctx);
+            }
+        }
+        Record(fields, ext) => {
+            for (_, x) in fields.iter_mut() {
+                x.instantiate_aliases(region, aliases, ctx);
+            }
+
+            if let TypeExtension::Open(ext, _) = ext {
+                instantiate_aliases(ext, region, aliases, ctx);
+            }
+        }
+        Tuple(elems, ext) => {
+            for (_, x) in elems.iter_mut() {
+                instantiate_aliases(x, region, aliases, ctx);
+            }
+
+            if let TypeExtension::Open(ext, _) = ext {
+                instantiate_aliases(ext, region, aliases, ctx);
+            }
+        }
+        DelayedAlias(AliasCommon {
+            type_arguments,
+            lambda_set_variables,
+            infer_ext_in_output_types,
+            symbol: _,
+        }) => {
+            debug_assert!(lambda_set_variables
+                .iter()
+                .all(|lambda_set| matches!(lambda_set.0, Type::Variable(..))));
+            debug_assert!(infer_ext_in_output_types
+                .iter()
+                .all(|t| matches!(t, Type::Variable(..) | Type::EmptyTagUnion)));
+            type_arguments
+                .iter_mut()
+                .for_each(|t| instantiate_aliases(&mut t.value.typ, region, aliases, ctx));
+        }
+        HostExposedAlias {
+            type_arguments: type_args,
+            lambda_set_variables,
+            actual: actual_type,
+            ..
+        } => {
+            for arg in type_args {
+                instantiate_aliases(arg, region, aliases, ctx);
+            }
+
+            for arg in lambda_set_variables {
+                arg.instantiate_aliases(region, aliases, ctx);
+            }
+
+            instantiate_aliases(&mut *actual_type, region, aliases, ctx);
+        }
+        Alias {
+            type_arguments: type_args,
+            lambda_set_variables,
+            actual: actual_type,
+            ..
+        } => {
+            for arg in type_args {
+                instantiate_aliases(&mut arg.typ, region, aliases, ctx);
+            }
+
+            for arg in lambda_set_variables {
+                arg.instantiate_aliases(region, aliases, ctx);
+            }
+
+            instantiate_aliases(actual_type, region, aliases, ctx);
+        }
+        Apply(symbol, args, _) => {
+            if let Some(alias) = aliases(*symbol) {
+                if args.len() != alias.type_variables.len() {
+                    // We will have already reported an error during canonicalization.
+                    *typ = Type::Error;
+                    return;
+                }
+
+                let mut actual = alias.typ.clone();
+
+                let mut named_args = Vec::with_capacity(args.len());
+                let mut substitution = ImMap::default();
+
+                // TODO substitute further in args
+                for (
+                    Loc {
+                        value:
+                            AliasVar {
+                                var: placeholder,
+                                opt_bound_abilities,
+                                ..
+                            },
+                        ..
+                    },
+                    filler,
+                ) in alias.type_variables.iter().zip(args.iter())
+                {
+                    let mut filler = filler.clone();
+                    instantiate_aliases(&mut filler.value, region, aliases, ctx);
+                    named_args.push(OptAbleType {
+                        typ: filler.value.clone(),
+                        opt_abilities: opt_bound_abilities.clone(),
+                    });
+                    substitution.insert(*placeholder, filler.value);
+                }
+
+                // make sure nested lambda set variables are freshly instantiated
+                let mut lambda_set_variables = Vec::with_capacity(alias.lambda_set_variables.len());
+                for typ in alias.lambda_set_variables.iter() {
+                    if let Type::Variable(var) = typ.0 {
+                        let fresh = ctx.var_store.fresh();
+                        ctx.new_lambda_set_variables.insert(fresh);
+                        substitution.insert(var, Type::Variable(fresh));
+                        lambda_set_variables.push(LambdaSet(Type::Variable(fresh)));
+                    } else {
+                        unreachable!("at this point there should be only vars in there");
+                    }
+                }
+
+                // make sure all nested recursion variables are freshly instantiated
+                let mut recursion_variables = Vec::with_capacity(alias.recursion_variables.len());
+                for var in alias.recursion_variables.iter() {
+                    let fresh = ctx.var_store.fresh();
+                    ctx.new_recursion_variables.insert(fresh);
+                    substitution.insert(*var, Type::Variable(fresh));
+                    recursion_variables.push(Type::Variable(fresh));
+                }
+
+                // make sure all nested infer-open-in-output position ext vars are freshly instantiated
+                let mut infer_ext_in_output_types =
+                    Vec::with_capacity(alias.infer_ext_in_output_variables.len());
+                for var in alias.infer_ext_in_output_variables.iter() {
+                    let fresh = ctx.var_store.fresh();
+                    ctx.new_infer_ext_vars.insert(fresh);
+                    substitution.insert(*var, Type::Variable(fresh));
+                    infer_ext_in_output_types.push(Type::Variable(fresh));
+                }
+
+                instantiate_aliases(&mut actual, region, aliases, ctx);
+
+                actual.substitute(&substitution);
+
+                // instantiate recursion variable!
+                //if let Type::RecursiveTagUnion(rec_var, mut tags, mut ext) = actual {
+                //    let new_rec_var = ctx.var_store.fresh();
+                //    substitution.clear();
+                //    substitution.insert(rec_var, Type::Variable(new_rec_var));
+
+                //    for typ in tags.iter_mut().flat_map(|v| v.1.iter_mut()) {
+                //        typ.substitute(&substitution);
+                //    }
+
+                //    if let TypeExtension::Open(ext, _) = &mut ext {
+                //        ext.substitute(&substitution);
+                //    }
+
+                //    actual = Type::RecursiveTagUnion(new_rec_var, tags, ext);
+                //}
+                let alias = Type::Alias {
+                    symbol: *symbol,
+                    type_arguments: named_args,
+                    lambda_set_variables,
+                    infer_ext_in_output_types,
+                    actual: Box::new(actual),
+                    kind: alias.kind,
+                };
+
+                *typ = alias;
+            } else {
+                // one of the special-cased Apply types.
+                for x in args {
+                    instantiate_aliases(&mut x.value, region, aliases, ctx);
+                }
+            }
+        }
+        RangedNumber(_) => {}
+        UnspecializedLambdaSet { .. } => {}
+        EmptyRec | EmptyTagUnion | ClosureTag { .. } | Error | Variable(_) => {}
     }
 }
 

--- a/crates/compiler/uitest/src/uitest.rs
+++ b/crates/compiler/uitest/src/uitest.rs
@@ -254,6 +254,7 @@ impl<'a> TestCase<'a> {
         for infer_opt in found_infer_opts {
             let opt = infer_opt.name("opt").unwrap().as_str();
             match opt.trim() {
+                "allow_errors" => infer_opts.allow_errors = true,
                 "print_only_under_alias" => infer_opts.print_only_under_alias = true,
                 other => return Err(format!("unknown infer option: {other:?}").into()),
             }

--- a/crates/compiler/uitest/tests/recursive_type/freshly_instantiated_recursion_var_under_alias.txt
+++ b/crates/compiler/uitest/tests/recursive_type/freshly_instantiated_recursion_var_under_alias.txt
@@ -1,6 +1,5 @@
 # +opt can:allow_errors
 # +opt infer:print_only_under_alias
-# +emit:mono
 app "test" provides [single] to "./platform"
 
 LL a : [Nil, Cons a (LL a)]
@@ -9,7 +8,7 @@ LinkedList a : LL a
 
 single : a -> LinkedList a
 single = \item -> (Cons item Nil)
-#^^^^^^{-1} a -[[single(0)]]-> [Cons a ([Cons elem b, Nil] as b), Nil]* as [Cons elem b, Nil] as b
+#^^^^^^{-1} a -[[single(0)]]-> [Cons a b, Nil]* as b
 
 walk : LinkedList elem, state, (state, elem -> state) -> state
 walk = \list, state, fn ->
@@ -17,9 +16,3 @@ walk = \list, state, fn ->
     when list is
         Nil -> state
         Cons first rest -> walk (rest) (fn state first) fn
-
-# -emit:mono
-procedure Test.0 (Test.6):
-    let Test.15 : [<rnu><null>, C *self []] = TagId(1) ;
-    let Test.14 : [<rnu><null>, C *self []] = TagId(0) Test.15 Test.6;
-    ret Test.14;

--- a/crates/compiler/uitest/tests/recursive_type/freshly_instantiated_recursion_var_under_alias.txt
+++ b/crates/compiler/uitest/tests/recursive_type/freshly_instantiated_recursion_var_under_alias.txt
@@ -1,0 +1,25 @@
+# +opt can:allow_errors
+# +opt infer:print_only_under_alias
+# +emit:mono
+app "test" provides [single] to "./platform"
+
+LL a : [Nil, Cons a (LL a)]
+
+LinkedList a : LL a
+
+single : a -> LinkedList a
+single = \item -> (Cons item Nil)
+#^^^^^^{-1} a -[[single(0)]]-> [Cons a ([Cons elem b, Nil] as b), Nil]* as [Cons elem b, Nil] as b
+
+walk : LinkedList elem, state, (state, elem -> state) -> state
+walk = \list, state, fn ->
+#^^^^{-1} [Cons elem a, Nil] as a, state, (state, elem -[[]]-> state) -[[walk(3)]]-> state
+    when list is
+        Nil -> state
+        Cons first rest -> walk (rest) (fn state first) fn
+
+# -emit:mono
+procedure Test.0 (Test.6):
+    let Test.15 : [<rnu><null>, C *self []] = TagId(1) ;
+    let Test.14 : [<rnu><null>, C *self []] = TagId(0) Test.15 Test.6;
+    ret Test.14;

--- a/crates/compiler/uitest/tests/recursive_type/freshly_instantiated_recursion_var_under_opaque.txt
+++ b/crates/compiler/uitest/tests/recursive_type/freshly_instantiated_recursion_var_under_opaque.txt
@@ -1,0 +1,16 @@
+# +opt can:allow_errors
+# +opt infer:print_only_under_alias
+app "test" provides [single] to "./platform"
+
+LL a : [Nil, Cons a (LL a)]
+
+LinkedList a := LL a
+
+single = \item -> @LinkedList (Cons item Nil)
+#^^^^^^{-1} a -[[single(0)]]-> [Cons a ([Cons * b, Nil] as b), Nil] as [Cons * b, Nil] as b
+
+walk = \@LinkedList list, state, fn ->
+#^^^^{-1} [Cons a b, Nil] as b, c, (c, a -[[]]-> c) -[[walk(3)]]-> c
+    when list is
+        Nil -> state
+        Cons first rest -> walk (@LinkedList rest) (fn state first) fn

--- a/crates/compiler/uitest/tests/recursive_type/freshly_instantiated_recursion_var_under_opaque.txt
+++ b/crates/compiler/uitest/tests/recursive_type/freshly_instantiated_recursion_var_under_opaque.txt
@@ -7,7 +7,7 @@ LL a : [Nil, Cons a (LL a)]
 LinkedList a := LL a
 
 single = \item -> @LinkedList (Cons item Nil)
-#^^^^^^{-1} a -[[single(0)]]-> [Cons a ([Cons * b, Nil] as b), Nil] as [Cons * b, Nil] as b
+#^^^^^^{-1} a -[[single(0)]]-> [Cons a b, Nil] as b
 
 walk = \@LinkedList list, state, fn ->
 #^^^^{-1} [Cons a b, Nil] as b, c, (c, a -[[]]-> c) -[[walk(3)]]-> c


### PR DESCRIPTION
Like we instantiate nested lambda set variables and nested OIOP
variables for aliases, we need to do the same for recursion variables.

Closes #5264 