### PR TITLE
Catch non-recursive function arity mismatches during typechecking

### DIFF
--- a/crates/compiler/constrain/src/expr.rs
+++ b/crates/compiler/constrain/src/expr.rs
@@ -1956,7 +1956,7 @@ fn constrain_function_def(
             );
 
             let return_type_annotation_expected = constraints.push_expected_type(FromAnnotation(
-                loc_pattern.clone(),
+                loc_pattern,
                 arity,
                 AnnotationSource::TypedBody {
                     region: annotation.region,

--- a/crates/compiler/constrain/src/expr.rs
+++ b/crates/compiler/constrain/src/expr.rs
@@ -3022,6 +3022,29 @@ fn constrain_typed_function_arguments(
             }
         }
     }
+
+    // There may be argument idents left over that don't line up with the function arity.
+    // Add their patterns' symbols in so that they are present in the env, even though this will
+    // wind up a type error.
+    if arguments.len() > arg_types.len() {
+        for (pattern_var, _annotated_mark, loc_pattern) in &arguments[arg_types.len()..] {
+            let pattern_var_index = constraints.push_variable(*pattern_var);
+
+            def_pattern_state.vars.push(*pattern_var);
+
+            let pattern_expected =
+                constraints.push_pat_expected_type(PExpected::NoExpectation(pattern_var_index));
+            constrain_pattern(
+                types,
+                constraints,
+                env,
+                &loc_pattern.value,
+                loc_pattern.region,
+                pattern_expected,
+                argument_pattern_state,
+            );
+        }
+    }
 }
 
 fn constrain_typed_function_arguments_simple(
@@ -3142,6 +3165,29 @@ fn constrain_typed_function_arguments_simple(
                     .constraints
                     .push(exhaustive_constraint)
             }
+        }
+    }
+
+    // There may be argument idents left over that don't line up with the function arity.
+    // Add their patterns' symbols in so that they are present in the env, even though this will
+    // wind up a type error.
+    if arguments.len() > arg_types.len() {
+        for (pattern_var, _annotated_mark, loc_pattern) in &arguments[arg_types.len()..] {
+            let pattern_var_index = constraints.push_variable(*pattern_var);
+
+            def_pattern_state.vars.push(*pattern_var);
+
+            let pattern_expected =
+                constraints.push_pat_expected_type(PExpected::NoExpectation(pattern_var_index));
+            constrain_pattern(
+                types,
+                constraints,
+                env,
+                &loc_pattern.value,
+                loc_pattern.region,
+                pattern_expected,
+                argument_pattern_state,
+            );
         }
     }
 }

--- a/crates/reporting/tests/test_reporting.rs
+++ b/crates/reporting/tests/test_reporting.rs
@@ -2615,6 +2615,27 @@ mod test_reporting {
     I would have to crash if I saw one of those! So rather than pattern
     matching in function arguments, put a `when` in the function body to
     account for all possibilities.
+
+    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+
+    Something is off with the body of the `f` definition:
+
+     9│      f : Either -> {}
+    10│      f = \Left v -> v
+                 ^^^^^^^^^^^^
+
+    The body is an anonymous function of type:
+
+        […] -> {}
+
+    But the type annotation on `f` says it should be:
+
+        [Right Str, …] -> {}
+
+    Tip: Looks like a closed tag union does not have the `Right` tag.
+
+    Tip: Closed tag unions can't grow, because that might change the size
+    in memory. Can you use an open tag union?
     "###
     );
 
@@ -13429,6 +13450,40 @@ I recommend using camelCase. It's the standard style in Roc code!
     3│  f : U8, U8 -> U8
     4│  f = \x -> x
             ^^^^^^^
+
+    The body is an anonymous function of type:
+
+        (U8 -> U8)
+
+    But the type annotation on `f` says it should be:
+
+        (U8, U8 -> U8)
+
+    Tip: It looks like it takes too few arguments. I was expecting 1 more.
+    "###
+    );
+
+    test_report!(
+        function_arity_mismatch_nested,
+        indoc!(
+            r#"
+            app "test" provides [main] to "./platform"
+
+            main =
+                f : U8, U8 -> U8
+                f = \x -> x
+
+                f
+            "#
+        ),
+        @r###"
+    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+
+    Something is off with the body of the `f` definition:
+
+    4│      f : U8, U8 -> U8
+    5│      f = \x -> x
+                ^^^^^^^
 
     The body is an anonymous function of type:
 

--- a/crates/reporting/tests/test_reporting.rs
+++ b/crates/reporting/tests/test_reporting.rs
@@ -13410,4 +13410,35 @@ I recommend using camelCase. It's the standard style in Roc code!
     meant to unwrap it first?
     "###
     );
+
+    test_report!(
+        function_arity_mismatch,
+        indoc!(
+            r#"
+            app "test" provides [f] to "./platform"
+
+            f : U8, U8 -> U8
+            f = \x -> x
+            "#
+        ),
+        @r###"
+    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+
+    Something is off with the body of the `f` definition:
+
+    3│  f : U8, U8 -> U8
+    4│  f = \x -> x
+            ^^^^^^^
+
+    The body is an anonymous function of type:
+
+        (U8 -> U8)
+
+    But the type annotation on `f` says it should be:
+
+        (U8, U8 -> U8)
+
+    Tip: It looks like it takes too few arguments. I was expecting 1 more.
+    "###
+    );
 }

--- a/crates/reporting/tests/test_reporting.rs
+++ b/crates/reporting/tests/test_reporting.rs
@@ -13433,7 +13433,7 @@ I recommend using camelCase. It's the standard style in Roc code!
     );
 
     test_report!(
-        function_arity_mismatch,
+        function_arity_mismatch_too_few,
         indoc!(
             r#"
             app "test" provides [f] to "./platform"
@@ -13464,7 +13464,42 @@ I recommend using camelCase. It's the standard style in Roc code!
     );
 
     test_report!(
-        function_arity_mismatch_nested,
+        function_arity_mismatch_too_many,
+        indoc!(
+            r#"
+            app "test" provides [f] to "./platform"
+
+            f : U8, U8 -> U8
+            f = \x, y, z -> x + y + z
+            "#
+        ),
+        @r###"
+    ── UNRECOGNIZED NAME ───────────────────────────────────── /code/proj/Main.roc ─
+
+    The #UserApp module does not expose anything by the name `z`.
+
+    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+
+    Something is off with the body of the `f` definition:
+
+    3│  f : U8, U8 -> U8
+    4│  f = \x, y, z -> x + y + z
+            ^^^^^^^^^^^^^^^^^^^^^
+
+    The body is an anonymous function of type:
+
+        (U8, U8, * -> U8)
+
+    But the type annotation on `f` says it should be:
+
+        (U8, U8 -> U8)
+
+    Tip: It looks like it takes too many arguments. I'm seeing 1 extra.
+    "###
+    );
+
+    test_report!(
+        function_arity_mismatch_nested_too_few,
         indoc!(
             r#"
             app "test" provides [main] to "./platform"
@@ -13494,6 +13529,44 @@ I recommend using camelCase. It's the standard style in Roc code!
         (U8, U8 -> U8)
 
     Tip: It looks like it takes too few arguments. I was expecting 1 more.
+    "###
+    );
+
+    test_report!(
+        function_arity_mismatch_nested_too_many,
+        indoc!(
+            r#"
+            app "test" provides [main] to "./platform"
+
+            main =
+                f : U8, U8 -> U8
+                f = \x, y, z -> x + y + z
+
+                f
+            "#
+        ),
+        @r###"
+    ── UNRECOGNIZED NAME ───────────────────────────────────── /code/proj/Main.roc ─
+
+    The #UserApp module does not expose anything by the name `z`.
+
+    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+
+    Something is off with the body of the `f` definition:
+
+    4│      f : U8, U8 -> U8
+    5│      f = \x, y, z -> x + y + z
+                ^^^^^^^^^^^^^^^^^^^^^
+
+    The body is an anonymous function of type:
+
+        (U8, U8, * -> U8)
+
+    But the type annotation on `f` says it should be:
+
+        (U8, U8 -> U8)
+
+    Tip: It looks like it takes too many arguments. I'm seeing 1 extra.
     "###
     );
 }

--- a/crates/reporting/tests/test_reporting.rs
+++ b/crates/reporting/tests/test_reporting.rs
@@ -13474,10 +13474,6 @@ I recommend using camelCase. It's the standard style in Roc code!
             "#
         ),
         @r###"
-    ── UNRECOGNIZED NAME ───────────────────────────────────── /code/proj/Main.roc ─
-
-    The #UserApp module does not expose anything by the name `z`.
-
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     Something is off with the body of the `f` definition:
@@ -13488,7 +13484,7 @@ I recommend using camelCase. It's the standard style in Roc code!
 
     The body is an anonymous function of type:
 
-        (U8, U8, * -> U8)
+        (U8, U8, Int Unsigned8 -> U8)
 
     But the type annotation on `f` says it should be:
 
@@ -13546,10 +13542,6 @@ I recommend using camelCase. It's the standard style in Roc code!
             "#
         ),
         @r###"
-    ── UNRECOGNIZED NAME ───────────────────────────────────── /code/proj/Main.roc ─
-
-    The #UserApp module does not expose anything by the name `z`.
-
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     Something is off with the body of the `f` definition:
@@ -13560,7 +13552,7 @@ I recommend using camelCase. It's the standard style in Roc code!
 
     The body is an anonymous function of type:
 
-        (U8, U8, * -> U8)
+        (U8, U8, Int Unsigned8 -> U8)
 
     But the type annotation on `f` says it should be:
 


### PR DESCRIPTION
Turns out we used to freely allow things like

```
f : U8, U8 -> U8
f = \x -> x
```

now we don't!

Closes #5236