### PR TITLE
Do not replace already-recursive lambda sets in occurs checks

### DIFF
--- a/crates/compiler/solve/src/solve.rs
+++ b/crates/compiler/solve/src/solve.rs
@@ -3609,7 +3609,7 @@ fn check_for_infinite_type(
                 }
                 Content::LambdaSet(subs::LambdaSet {
                     solved,
-                    recursion_var: _,
+                    recursion_var: OptVariable::NONE,
                     unspecialized,
                     ambient_function: ambient_function_var,
                 }) => {

--- a/crates/compiler/uitest/tests/recursive_type/multiple_nested_recursive_lambda_sets.txt
+++ b/crates/compiler/uitest/tests/recursive_type/multiple_nested_recursive_lambda_sets.txt
@@ -1,0 +1,25 @@
+# +opt infer:print_only_under_alias
+
+app "test" provides [main] to "./platform"
+
+Effect : {} -> Str
+
+after = \fx, toNext ->
+    afterInner = \{} ->
+        fxOut = fx {}
+        next = toNext fxOut
+        next {}
+
+    afterInner
+
+await : Effect, (Str -> Effect) -> Effect
+await = \fx, cont -> after fx (\result -> cont result)
+
+line : Str -> Effect
+line = \s -> \{} -> s
+
+main =
+#^^^^{-1} {} -[[afterInner(8) ({} -[[afterInner(8) ({} -a-> Str) (Str -[[13 (Str -[[20 Str]]-> ({} -[[16 Str]]-> Str))]]-> ({} -[[16 Str]]-> Str)), 16 Str] as a]-> Str) (Str -[[13 (Str -[[21]]-> ({} -[[16 Str]]-> Str))]]-> ({} -[[16 Str]]-> Str))] as [[afterInner(8) ({} -[[afterInner(8) ({} -a-> Str) (Str -[[13 (Str -[[20 Str]]-> ({} -[[16 Str]]-> Str))]]-> ({} -[[16 Str]]-> Str)), 16 Str] as a]-> Str) (Str -[[13 (Str -[[21]]-> ({} -[[16 Str]]-> Str))]]-> ({} -[[16 Str]]-> Str))] as b]]-> Str
+    await
+        (List.walk ["a", "b"] (line "printing letters") (\state, elem -> await state (\_ -> line elem)))
+        (\_ -> line "")


### PR DESCRIPTION
If a lambda set appears in an occurs chain but it is itself already recursive, then it is should not be eligibil for modification in the occurs chain.

Closes #4725