### PR TITLE
Various bug fixes to generalization and solving of recursion

### DIFF
--- a/crates/compiler/test_gen/src/gen_tags.rs
+++ b/crates/compiler/test_gen/src/gen_tags.rs
@@ -1512,6 +1512,7 @@ fn opaque_assign_to_symbol() {
 
 #[test]
 #[cfg(any(feature = "gen-llvm", feature = "gen-wasm", feature = "gen-dev"))]
+#[ignore = "Blocked on https://github.com/roc-lang/roc/issues/5354"]
 fn issue_2777_default_branch_codegen() {
     assert_evals_to!(
         indoc!(

--- a/crates/compiler/test_mono/generated/issue_4770.txt
+++ b/crates/compiler/test_mono/generated/issue_4770.txt
@@ -1,0 +1,199 @@
+procedure Bool.1 ():
+    let Bool.25 : Int1 = false;
+    ret Bool.25;
+
+procedure Bool.2 ():
+    let Bool.24 : Int1 = true;
+    ret Bool.24;
+
+procedure List.188 (List.496, List.189, List.187):
+    let List.526 : Int1 = CallByName Test.1 List.189;
+    if List.526 then
+        let List.528 : {} = Struct {};
+        let List.527 : [C {}, C {}] = TagId(1) List.528;
+        ret List.527;
+    else
+        let List.525 : {} = Struct {};
+        let List.524 : [C {}, C {}] = TagId(0) List.525;
+        ret List.524;
+
+procedure List.23 (#Attr.2, #Attr.3, #Attr.4):
+    let List.529 : List {[<r>C I64, C List *self], [<r>C I64, C List *self]} = lowlevel ListMap2 { xs: `#Attr.#arg1`, ys: `#Attr.#arg2` } #Attr.2 #Attr.3 Test.15 #Attr.4;
+    decref #Attr.3;
+    decref #Attr.2;
+    ret List.529;
+
+procedure List.56 (List.186, List.187):
+    let List.505 : {} = Struct {};
+    let List.497 : [C {}, C {}] = CallByName List.92 List.186 List.505 List.187;
+    let List.502 : U8 = 1i64;
+    let List.503 : U8 = GetTagId List.497;
+    let List.504 : Int1 = lowlevel Eq List.502 List.503;
+    if List.504 then
+        let List.498 : Int1 = CallByName Bool.2;
+        ret List.498;
+    else
+        let List.499 : Int1 = CallByName Bool.1;
+        ret List.499;
+
+procedure List.6 (#Attr.2):
+    let List.495 : U64 = lowlevel ListLen #Attr.2;
+    ret List.495;
+
+procedure List.6 (#Attr.2):
+    let List.523 : U64 = lowlevel ListLen #Attr.2;
+    ret List.523;
+
+procedure List.66 (#Attr.2, #Attr.3):
+    let List.522 : {[<r>C I64, C List *self], [<r>C I64, C List *self]} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.522;
+
+procedure List.80 (List.534, List.535, List.536, List.537, List.538):
+    joinpoint List.510 List.433 List.434 List.435 List.436 List.437:
+        let List.512 : Int1 = CallByName Num.22 List.436 List.437;
+        if List.512 then
+            let List.521 : {[<r>C I64, C List *self], [<r>C I64, C List *self]} = CallByName List.66 List.433 List.436;
+            let List.513 : [C {}, C {}] = CallByName List.188 List.434 List.521 List.435;
+            let List.518 : U8 = 1i64;
+            let List.519 : U8 = GetTagId List.513;
+            let List.520 : Int1 = lowlevel Eq List.518 List.519;
+            if List.520 then
+                let List.438 : {} = UnionAtIndex (Id 1) (Index 0) List.513;
+                let List.516 : U64 = 1i64;
+                let List.515 : U64 = CallByName Num.19 List.436 List.516;
+                jump List.510 List.433 List.438 List.435 List.515 List.437;
+            else
+                dec List.433;
+                let List.439 : {} = UnionAtIndex (Id 0) (Index 0) List.513;
+                let List.517 : [C {}, C {}] = TagId(0) List.439;
+                ret List.517;
+        else
+            dec List.433;
+            let List.511 : [C {}, C {}] = TagId(1) List.434;
+            ret List.511;
+    in
+    jump List.510 List.534 List.535 List.536 List.537 List.538;
+
+procedure List.92 (List.430, List.431, List.432):
+    let List.508 : U64 = 0i64;
+    let List.509 : U64 = CallByName List.6 List.430;
+    let List.507 : [C {}, C {}] = CallByName List.80 List.430 List.431 List.432 List.508 List.509;
+    ret List.507;
+
+procedure Num.19 (#Attr.2, #Attr.3):
+    let Num.280 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.280;
+
+procedure Num.22 (#Attr.2, #Attr.3):
+    let Num.278 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.278;
+
+procedure Num.22 (#Attr.2, #Attr.3):
+    let Num.281 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.281;
+
+procedure Test.1 (Test.77):
+    joinpoint Test.26 Test.6:
+        let Test.65 : [<r>C I64, C List *self] = StructAtIndex 1 Test.6;
+        inc Test.65;
+        let Test.66 : U8 = 0i64;
+        let Test.67 : U8 = GetTagId Test.65;
+        dec Test.65;
+        let Test.68 : Int1 = lowlevel Eq Test.66 Test.67;
+        if Test.68 then
+            let Test.57 : [<r>C I64, C List *self] = StructAtIndex 0 Test.6;
+            inc Test.57;
+            let Test.58 : U8 = 0i64;
+            let Test.59 : U8 = GetTagId Test.57;
+            let #Derived_gen.1 : [<r>C I64, C List *self] = Reset { symbol: Test.57, id: UpdateModeId { id: 1 } };
+            let Test.60 : Int1 = lowlevel Eq Test.58 Test.59;
+            if Test.60 then
+                decref #Derived_gen.1;
+                let Test.50 : [<r>C I64, C List *self] = StructAtIndex 0 Test.6;
+                inc Test.50;
+                let Test.8 : I64 = UnionAtIndex (Id 0) (Index 0) Test.50;
+                dec Test.50;
+                let Test.49 : [<r>C I64, C List *self] = StructAtIndex 1 Test.6;
+                inc Test.49;
+                dec Test.6;
+                let Test.10 : I64 = UnionAtIndex (Id 0) (Index 0) Test.49;
+                dec Test.49;
+                let Test.27 : Int1 = CallByName Num.22 Test.8 Test.10;
+                ret Test.27;
+            else
+                let Test.39 : [<r>C I64, C List *self] = StructAtIndex 0 Test.6;
+                inc Test.39;
+                let Test.42 : [<r>C I64, C List *self] = StructAtIndex 1 Test.6;
+                inc Test.42;
+                dec Test.6;
+                let Test.41 : List [<r>C I64, C List *self] = Array [Test.42];
+                let Test.40 : [<r>C I64, C List *self] = Reuse #Derived_gen.1 UpdateModeId { id: 1 } TagId(1) Test.41;
+                let Test.38 : {[<r>C I64, C List *self], [<r>C I64, C List *self]} = Struct {Test.39, Test.40};
+                jump Test.26 Test.38;
+        else
+            let Test.61 : [<r>C I64, C List *self] = StructAtIndex 0 Test.6;
+            inc Test.61;
+            let Test.62 : U8 = 1i64;
+            let Test.63 : U8 = GetTagId Test.61;
+            let #Derived_gen.4 : [<r>C I64, C List *self] = Reset { symbol: Test.61, id: UpdateModeId { id: 4 } };
+            let Test.64 : Int1 = lowlevel Eq Test.62 Test.63;
+            if Test.64 then
+                decref #Derived_gen.4;
+                let Test.52 : [<r>C I64, C List *self] = StructAtIndex 0 Test.6;
+                inc Test.52;
+                let Test.12 : List [<r>C I64, C List *self] = UnionAtIndex (Id 1) (Index 0) Test.52;
+                inc Test.12;
+                dec Test.52;
+                let Test.51 : [<r>C I64, C List *self] = StructAtIndex 1 Test.6;
+                inc Test.51;
+                dec Test.6;
+                let Test.14 : List [<r>C I64, C List *self] = UnionAtIndex (Id 1) (Index 0) Test.51;
+                inc Test.14;
+                dec Test.51;
+                let Test.35 : {} = Struct {};
+                inc Test.12;
+                inc Test.14;
+                let Test.33 : List {[<r>C I64, C List *self], [<r>C I64, C List *self]} = CallByName List.23 Test.12 Test.14 Test.35;
+                let Test.34 : {} = Struct {};
+                let Test.29 : Int1 = CallByName List.56 Test.33 Test.34;
+                if Test.29 then
+                    let Test.31 : U64 = CallByName List.6 Test.12;
+                    dec Test.12;
+                    let Test.32 : U64 = CallByName List.6 Test.14;
+                    dec Test.14;
+                    let Test.30 : Int1 = CallByName Num.22 Test.31 Test.32;
+                    ret Test.30;
+                else
+                    dec Test.12;
+                    dec Test.14;
+                    let Test.28 : Int1 = CallByName Bool.1;
+                    ret Test.28;
+            else
+                let Test.48 : [<r>C I64, C List *self] = StructAtIndex 0 Test.6;
+                inc Test.48;
+                let Test.47 : List [<r>C I64, C List *self] = Array [Test.48];
+                let Test.45 : [<r>C I64, C List *self] = Reuse #Derived_gen.4 UpdateModeId { id: 4 } TagId(1) Test.47;
+                let Test.46 : [<r>C I64, C List *self] = StructAtIndex 1 Test.6;
+                inc Test.46;
+                dec Test.6;
+                let Test.44 : {[<r>C I64, C List *self], [<r>C I64, C List *self]} = Struct {Test.45, Test.46};
+                jump Test.26 Test.44;
+    in
+    jump Test.26 Test.77;
+
+procedure Test.15 (Test.16, Test.17):
+    let Test.36 : {[<r>C I64, C List *self], [<r>C I64, C List *self]} = Struct {Test.16, Test.17};
+    ret Test.36;
+
+procedure Test.0 ():
+    let Test.76 : I64 = 10i64;
+    let Test.75 : [<r>C I64, C List *self] = TagId(0) Test.76;
+    let Test.74 : List [<r>C I64, C List *self] = Array [Test.75];
+    let Test.69 : [<r>C I64, C List *self] = TagId(1) Test.74;
+    let Test.73 : I64 = 20i64;
+    let Test.72 : [<r>C I64, C List *self] = TagId(0) Test.73;
+    let Test.71 : List [<r>C I64, C List *self] = Array [Test.72];
+    let Test.70 : [<r>C I64, C List *self] = TagId(1) Test.71;
+    let Test.25 : {[<r>C I64, C List *self], [<r>C I64, C List *self]} = Struct {Test.69, Test.70};
+    let Test.24 : Int1 = CallByName Test.1 Test.25;
+    ret Test.24;

--- a/crates/compiler/test_mono/generated/issue_4770.txt
+++ b/crates/compiler/test_mono/generated/issue_4770.txt
@@ -53,6 +53,7 @@ procedure List.80 (List.534, List.535, List.536, List.537, List.538):
         let List.512 : Int1 = CallByName Num.22 List.436 List.437;
         if List.512 then
             let List.521 : {[<r>C I64, C List *self], [<r>C I64, C List *self]} = CallByName List.66 List.433 List.436;
+            inc List.521;
             let List.513 : [C {}, C {}] = CallByName List.188 List.434 List.521 List.435;
             let List.518 : U8 = 1i64;
             let List.519 : U8 = GetTagId List.513;
@@ -95,10 +96,8 @@ procedure Num.22 (#Attr.2, #Attr.3):
 procedure Test.1 (Test.77):
     joinpoint Test.26 Test.6:
         let Test.65 : [<r>C I64, C List *self] = StructAtIndex 1 Test.6;
-        inc Test.65;
         let Test.66 : U8 = 0i64;
         let Test.67 : U8 = GetTagId Test.65;
-        dec Test.65;
         let Test.68 : Int1 = lowlevel Eq Test.66 Test.67;
         if Test.68 then
             let Test.57 : [<r>C I64, C List *self] = StructAtIndex 0 Test.6;
@@ -110,22 +109,24 @@ procedure Test.1 (Test.77):
             if Test.60 then
                 decref #Derived_gen.1;
                 let Test.50 : [<r>C I64, C List *self] = StructAtIndex 0 Test.6;
-                inc Test.50;
                 let Test.8 : I64 = UnionAtIndex (Id 0) (Index 0) Test.50;
-                dec Test.50;
                 let Test.49 : [<r>C I64, C List *self] = StructAtIndex 1 Test.6;
-                inc Test.49;
-                dec Test.6;
+                dec Test.50;
                 let Test.10 : I64 = UnionAtIndex (Id 0) (Index 0) Test.49;
-                dec Test.49;
-                let Test.27 : Int1 = CallByName Num.22 Test.8 Test.10;
-                ret Test.27;
+                joinpoint #Derived_gen.7:
+                    let Test.27 : Int1 = CallByName Num.22 Test.8 Test.10;
+                    ret Test.27;
+                in
+                let #Derived_gen.8 : Int1 = lowlevel RefCountIsUnique Test.49;
+                if #Derived_gen.8 then
+                    decref Test.49;
+                    jump #Derived_gen.7;
+                else
+                    decref Test.49;
+                    jump #Derived_gen.7;
             else
                 let Test.39 : [<r>C I64, C List *self] = StructAtIndex 0 Test.6;
-                inc Test.39;
                 let Test.42 : [<r>C I64, C List *self] = StructAtIndex 1 Test.6;
-                inc Test.42;
-                dec Test.6;
                 let Test.41 : List [<r>C I64, C List *self] = Array [Test.42];
                 let Test.40 : [<r>C I64, C List *self] = Reuse #Derived_gen.1 UpdateModeId { id: 1 } TagId(1) Test.41;
                 let Test.38 : {[<r>C I64, C List *self], [<r>C I64, C List *self]} = Struct {Test.39, Test.40};
@@ -140,42 +141,44 @@ procedure Test.1 (Test.77):
             if Test.64 then
                 decref #Derived_gen.4;
                 let Test.52 : [<r>C I64, C List *self] = StructAtIndex 0 Test.6;
-                inc Test.52;
                 let Test.12 : List [<r>C I64, C List *self] = UnionAtIndex (Id 1) (Index 0) Test.52;
                 inc Test.12;
-                dec Test.52;
                 let Test.51 : [<r>C I64, C List *self] = StructAtIndex 1 Test.6;
-                inc Test.51;
-                dec Test.6;
+                dec Test.52;
                 let Test.14 : List [<r>C I64, C List *self] = UnionAtIndex (Id 1) (Index 0) Test.51;
-                inc Test.14;
-                dec Test.51;
-                let Test.35 : {} = Struct {};
-                inc Test.12;
-                inc Test.14;
-                let Test.33 : List {[<r>C I64, C List *self], [<r>C I64, C List *self]} = CallByName List.23 Test.12 Test.14 Test.35;
-                let Test.34 : {} = Struct {};
-                let Test.29 : Int1 = CallByName List.56 Test.33 Test.34;
-                if Test.29 then
-                    let Test.31 : U64 = CallByName List.6 Test.12;
-                    dec Test.12;
-                    let Test.32 : U64 = CallByName List.6 Test.14;
-                    dec Test.14;
-                    let Test.30 : Int1 = CallByName Num.22 Test.31 Test.32;
-                    ret Test.30;
+                joinpoint #Derived_gen.9:
+                    let Test.35 : {} = Struct {};
+                    inc Test.12;
+                    inc Test.14;
+                    let Test.33 : List {[<r>C I64, C List *self], [<r>C I64, C List *self]} = CallByName List.23 Test.12 Test.14 Test.35;
+                    let Test.34 : {} = Struct {};
+                    let Test.29 : Int1 = CallByName List.56 Test.33 Test.34;
+                    if Test.29 then
+                        let Test.31 : U64 = CallByName List.6 Test.12;
+                        dec Test.12;
+                        let Test.32 : U64 = CallByName List.6 Test.14;
+                        dec Test.14;
+                        let Test.30 : Int1 = CallByName Num.22 Test.31 Test.32;
+                        ret Test.30;
+                    else
+                        dec Test.12;
+                        dec Test.14;
+                        let Test.28 : Int1 = CallByName Bool.1;
+                        ret Test.28;
+                in
+                let #Derived_gen.10 : Int1 = lowlevel RefCountIsUnique Test.51;
+                if #Derived_gen.10 then
+                    decref Test.51;
+                    jump #Derived_gen.9;
                 else
-                    dec Test.12;
-                    dec Test.14;
-                    let Test.28 : Int1 = CallByName Bool.1;
-                    ret Test.28;
+                    inc Test.14;
+                    decref Test.51;
+                    jump #Derived_gen.9;
             else
                 let Test.48 : [<r>C I64, C List *self] = StructAtIndex 0 Test.6;
-                inc Test.48;
                 let Test.47 : List [<r>C I64, C List *self] = Array [Test.48];
                 let Test.45 : [<r>C I64, C List *self] = Reuse #Derived_gen.4 UpdateModeId { id: 4 } TagId(1) Test.47;
                 let Test.46 : [<r>C I64, C List *self] = StructAtIndex 1 Test.6;
-                inc Test.46;
-                dec Test.6;
                 let Test.44 : {[<r>C I64, C List *self], [<r>C I64, C List *self]} = Struct {Test.45, Test.46};
                 jump Test.26 Test.44;
     in

--- a/crates/compiler/test_mono/src/tests.rs
+++ b/crates/compiler/test_mono/src/tests.rs
@@ -2888,3 +2888,27 @@ fn layout_cache_structure_with_multiple_recursive_structures() {
         "#
     )
 }
+
+#[mono_test]
+fn issue_4770() {
+    indoc!(
+        r#"
+        app "test" provides [main] to "./platform"
+
+        main =
+            isCorrectOrder { left: IsList [IsInteger 10], right: IsList [IsInteger 20] }
+
+        isCorrectOrder = \pair ->
+            when pair is
+                { left: IsInteger left, right: IsInteger right } -> left < right
+                { left: IsList l, right: IsList r } ->
+                    if List.map2 l r (\left, right -> { left, right }) |> List.all isCorrectOrder then
+                        List.len l < List.len r
+                    else
+                        Bool.false
+
+                { left: IsList _, right: IsInteger _ } -> isCorrectOrder { left: pair.left, right: IsList [pair.right] }
+                { left: IsInteger _, right: IsList _ } -> isCorrectOrder { left: IsList [pair.left], right: pair.right }
+        "#
+    )
+}

--- a/crates/compiler/test_solve_helpers/src/lib.rs
+++ b/crates/compiler/test_solve_helpers/src/lib.rs
@@ -257,6 +257,7 @@ pub struct InferOptions {
     pub allow_errors: bool,
     pub print_can_decls: bool,
     pub print_only_under_alias: bool,
+    pub print_ranks: bool,
     pub no_promote: bool,
 }
 
@@ -465,6 +466,7 @@ impl<'a> QueryCtx<'a> {
             DebugPrint {
                 print_lambda_sets: true,
                 print_only_under_alias: self.options.print_only_under_alias,
+                print_ranks: self.options.print_ranks,
                 ignore_polarity: true,
                 print_weakened_vars: true,
             },

--- a/crates/compiler/types/src/pretty_print.rs
+++ b/crates/compiler/types/src/pretty_print.rs
@@ -59,6 +59,7 @@ macro_rules! write_parens {
 pub struct DebugPrint {
     pub print_lambda_sets: bool,
     pub print_only_under_alias: bool,
+    pub print_ranks: bool,
     pub ignore_polarity: bool,
     pub print_weakened_vars: bool,
 }
@@ -67,6 +68,7 @@ impl DebugPrint {
     pub const NOTHING: DebugPrint = DebugPrint {
         print_lambda_sets: false,
         print_only_under_alias: false,
+        print_ranks: false,
         ignore_polarity: false,
         print_weakened_vars: false,
     };
@@ -652,6 +654,10 @@ fn write_content<'a>(
     pol: Polarity,
 ) {
     use crate::subs::Content::*;
+
+    if env.debug.print_ranks {
+        buf.push_str(&format!("⟨@{:?}⟩", subs.get_rank(var).into_usize()));
+    }
 
     match subs.get_content_without_compacting(var) {
         FlexVar(Some(name_index)) => {

--- a/crates/compiler/types/src/subs.rs
+++ b/crates/compiler/types/src/subs.rs
@@ -2010,22 +2010,35 @@ impl Subs {
         result
     }
 
-    pub fn mark_tag_union_recursive(&mut self, recursive: Variable, tags: UnionTags, ext: TagExt) {
+    /// Returns the new recursion variable, which should be introduced to the environment as
+    /// appropriate.
+    #[must_use]
+    pub fn mark_tag_union_recursive(
+        &mut self,
+        recursive: Variable,
+        tags: UnionTags,
+        ext: TagExt,
+    ) -> Variable {
         let (rec_var, new_tags) = self.mark_union_recursive_help(recursive, tags);
 
         let new_ext = ext.map(|v| self.explicit_substitute(recursive, rec_var, v));
         let flat_type = FlatType::RecursiveTagUnion(rec_var, new_tags, new_ext);
 
         self.set_content(recursive, Content::Structure(flat_type));
+
+        rec_var
     }
 
+    /// Returns the new recursion variable, which should be introduced to the environment as
+    /// appropriate.
+    #[must_use]
     pub fn mark_lambda_set_recursive(
         &mut self,
         recursive: Variable,
         solved_lambdas: UnionLambdas,
         unspecialized_lambdas: SubsSlice<Uls>,
         ambient_function_var: Variable,
-    ) {
+    ) -> Variable {
         let (rec_var, new_tags) = self.mark_union_recursive_help(recursive, solved_lambdas);
 
         let new_lambda_set = Content::LambdaSet(LambdaSet {
@@ -2036,6 +2049,8 @@ impl Subs {
         });
 
         self.set_content(recursive, new_lambda_set);
+
+        rec_var
     }
 
     fn mark_union_recursive_help<L: Label>(

--- a/crates/compiler/uitest/src/uitest.rs
+++ b/crates/compiler/uitest/src/uitest.rs
@@ -256,6 +256,7 @@ impl<'a> TestCase<'a> {
             match opt.trim() {
                 "allow_errors" => infer_opts.allow_errors = true,
                 "print_only_under_alias" => infer_opts.print_only_under_alias = true,
+                "print_ranks" => infer_opts.print_ranks = true,
                 other => return Err(format!("unknown infer option: {other:?}").into()),
             }
         }

--- a/crates/compiler/uitest/tests/exhaustive/catchall_branch_for_pattern_not_last.txt
+++ b/crates/compiler/uitest/tests/exhaustive/catchall_branch_for_pattern_not_last.txt
@@ -3,6 +3,6 @@ app "test" provides [main] to "./platform"
 
 main =
     \x -> when x is
-    #^ [A [B]w_a [C]w_b]
+    #^ [A [B]* [C]*]
         A B _ -> ""
         A _ C -> ""

--- a/crates/compiler/uitest/tests/exhaustive/catchall_branch_walk_into_nested_types.txt
+++ b/crates/compiler/uitest/tests/exhaustive/catchall_branch_walk_into_nested_types.txt
@@ -2,6 +2,6 @@ app "test" provides [main] to "./platform"
 
 main =
     \x -> when x is
-    #^ { a : [A { b : [B]w_a }*]w_b }*
+    #^ { a : [A { b : [B]* }*]* }*
         { a: A { b: B } } -> ""
         _ -> ""

--- a/crates/compiler/uitest/tests/pattern/generalize_openness_in_recursive_context_issue_4770.txt
+++ b/crates/compiler/uitest/tests/pattern/generalize_openness_in_recursive_context_issue_4770.txt
@@ -1,0 +1,12 @@
+app "test" provides [main] to "./platform"
+
+main =
+    isCorrectOrder (IsList [IsStr ""])
+#   ^^^^^^^^^^^^^^ [IsList (List a), IsStr Str]w_b as a -[[isCorrectOrder(1)]]-> Bool
+
+isCorrectOrder = \pair ->
+#^^^^^^^^^^^^^^{-1} [IsList (List a)]* as a -[[isCorrectOrder(1)]]-> Bool
+    when pair is
+        IsList l -> List.all l isCorrectOrder
+
+        _ -> Bool.false

--- a/crates/compiler/uitest/tests/recursive_type/generalize_introduced_recursion_variable_issue_4770.txt
+++ b/crates/compiler/uitest/tests/recursive_type/generalize_introduced_recursion_variable_issue_4770.txt
@@ -1,0 +1,10 @@
+app "test" provides [main] to "./platform"
+
+main = isCorrectOrder (IsList [IsStr ""])
+#      ^^^^^^^^^^^^^^ [IsList (List [IsList (List a), IsStr Str]), IsStr Str] -[[isCorrectOrder(1)]]-> Bool
+
+isCorrectOrder = \pair ->
+#^^^^^^^^^^^^^^{-1} [IsList (List [IsList (List a), IsStr *]), IsStr *] -[[isCorrectOrder(1)]]-> Bool
+    when pair is
+        IsList l -> List.all l isCorrectOrder
+        IsStr _ -> isCorrectOrder (IsList [pair])

--- a/crates/compiler/uitest/tests/recursive_type/generalize_introduced_recursion_variable_issue_4770.txt
+++ b/crates/compiler/uitest/tests/recursive_type/generalize_introduced_recursion_variable_issue_4770.txt
@@ -1,10 +1,10 @@
 app "test" provides [main] to "./platform"
 
 main = isCorrectOrder (IsList [IsStr ""])
-#      ^^^^^^^^^^^^^^ [IsList (List [IsList (List a), IsStr Str]), IsStr Str] -[[isCorrectOrder(1)]]-> Bool
+#      ^^^^^^^^^^^^^^ [IsList (List a), IsStr Str] as a -[[isCorrectOrder(1)]]-> Bool
 
 isCorrectOrder = \pair ->
-#^^^^^^^^^^^^^^{-1} [IsList (List [IsList (List a), IsStr *]), IsStr *] -[[isCorrectOrder(1)]]-> Bool
+#^^^^^^^^^^^^^^{-1} [IsList (List a), IsStr *] as a -[[isCorrectOrder(1)]]-> Bool
     when pair is
         IsList l -> List.all l isCorrectOrder
         IsStr _ -> isCorrectOrder (IsList [pair])

--- a/crates/compiler/uitest/tests/solve/infer_contextual_crash.txt
+++ b/crates/compiler/uitest/tests/solve/infer_contextual_crash.txt
@@ -1,6 +1,6 @@
 app "test" provides [getInfallible] to "./platform"
 
 getInfallible = \result -> when result is
-#^^^^^^^^^^^^^{-1} [Ok a]w_b -[[getInfallible(0)]]-> a
+#^^^^^^^^^^^^^{-1} [Ok a]* -[[getInfallible(0)]]-> a
     Ok x -> x
     _ -> crash "turns out this was fallible"


### PR DESCRIPTION
- [Correctly introduce new openness variables at the union rank](https://github.com/roc-lang/roc/commit/7ac24e8afe66c07101bc51d5a1f002a9f027d15c)

- [Correctly introduce new recursion variables at the correct rank](https://github.com/roc-lang/roc/commit/e38b7949554549a9b293f93b002ebc4868ba79bd)

[Defer resolution of a recursion variable during union unification until merging](https://github.com/roc-lang/roc/commit/dd6cb957461c1ce3ab619ae51caa998de65adf8f)

Closes #4770