### PR TITLE
Fix misc wasm compilation issues

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -359,6 +359,20 @@ pub enum FormatMode {
     CheckOnly,
 }
 
+fn opt_level_from_flags(matches: &ArgMatches) -> OptLevel {
+    match (
+        matches.is_present(FLAG_OPTIMIZE),
+        matches.is_present(FLAG_OPT_SIZE),
+        matches.is_present(FLAG_DEV),
+    ) {
+        (true, false, false) => OptLevel::Optimize,
+        (false, true, false) => OptLevel::Size,
+        (false, false, true) => OptLevel::Development,
+        (false, false, false) => OptLevel::Normal,
+        _ => user_error!("build can be only one of `--dev`, `--optimize`, or `--opt-size`"),
+    }
+}
+
 #[cfg(windows)]
 pub fn test(_matches: &ArgMatches, _triple: Triple) -> io::Result<i32> {
     todo!("running tests does not work on windows right now")
@@ -374,17 +388,7 @@ pub fn test(matches: &ArgMatches, triple: Triple) -> io::Result<i32> {
     let start_time = Instant::now();
     let arena = Bump::new();
     let filename = matches.value_of_os(ROC_FILE).unwrap();
-    let opt_level = match (
-        matches.is_present(FLAG_OPTIMIZE),
-        matches.is_present(FLAG_OPT_SIZE),
-        matches.is_present(FLAG_DEV),
-    ) {
-        (true, false, false) => OptLevel::Optimize,
-        (false, true, false) => OptLevel::Size,
-        (false, false, true) => OptLevel::Development,
-        (false, false, false) => OptLevel::Normal,
-        _ => user_error!("build can be only one of `--dev`, `--optimize`, or `--opt-size`"),
-    };
+    let opt_level = opt_level_from_flags(matches);
 
     let threading = match matches
         .value_of(FLAG_MAX_THREADS)
@@ -603,17 +607,7 @@ pub fn build(
     let opt_level = if let BuildConfig::BuildAndRunIfNoErrors = config {
         OptLevel::Development
     } else {
-        match (
-            matches.is_present(FLAG_OPTIMIZE),
-            matches.is_present(FLAG_OPT_SIZE),
-        ) {
-            (true, false) => OptLevel::Optimize,
-            (false, true) => OptLevel::Size,
-            (false, false) => OptLevel::Normal,
-            (true, true) => {
-                user_error!("build can be only one of `--optimize` and `--opt-size`")
-            }
-        }
+        opt_level_from_flags(matches)
     };
 
     let code_gen_backend = if matches!(triple.architecture, Architecture::Wasm32) {

--- a/crates/compiler/build/src/link.rs
+++ b/crates/compiler/build/src/link.rs
@@ -362,21 +362,8 @@ pub fn build_zig_host_wasm32(
         unimplemented!("Linking a shared library to wasm not yet implemented");
     }
 
-    let zig_target = if matches!(opt_level, OptLevel::Development) {
-        "wasm32-wasi"
-    } else {
-        // For LLVM backend wasm we are emitting a .bc file anyway so this target is OK
-        "i386-linux-musl"
-    };
-
     // NOTE currently just to get compiler warnings if the host code is invalid.
     // the produced artifact is not used
-    //
-    // NOTE we're emitting LLVM IR here (again, it is not actually used)
-    //
-    // we'd like to compile with `-target wasm32-wasi` but that is blocked on
-    //
-    // https://github.com/ziglang/zig/issues/9414
     let mut zig_cmd = zig();
 
     zig_cmd
@@ -397,7 +384,7 @@ pub fn build_zig_host_wasm32(
             "--library",
             "c",
             "-target",
-            zig_target,
+            "wasm32-wasi",
             // "-femit-llvm-ir=/home/folkertdev/roc/roc/crates/cli_testing_examples/benchmarks/platform/host.ll",
             "-fPIC",
             "--strip",

--- a/crates/compiler/build/src/link.rs
+++ b/crates/compiler/build/src/link.rs
@@ -1267,8 +1267,6 @@ fn link_wasm32(
     input_paths: &[&str],
     _link_type: LinkType,
 ) -> io::Result<(Child, PathBuf)> {
-    let wasi_libc_path = find_wasi_libc_path();
-
     let child = zig()
         // .env_clear()
         // .env("PATH", &env_path)
@@ -1276,8 +1274,9 @@ fn link_wasm32(
         .args(input_paths)
         .args([
             // include wasi libc
+            // TOOD: This now compiles fine with `-lc`. That said, the output file doesn't work.
             // using `-lc` is broken in zig 8 (and early 9) in combination with ReleaseSmall
-            wasi_libc_path.to_str().unwrap(),
+            find_wasi_libc_path().to_str().unwrap(),
             &format!("-femit-bin={}", output_path.to_str().unwrap()),
             "-target",
             "wasm32-wasi-musl",

--- a/crates/compiler/build/src/program.rs
+++ b/crates/compiler/build/src/program.rs
@@ -103,7 +103,7 @@ pub fn gen_from_mono_module<'a>(
     let opt = code_gen_options.opt_level;
 
     match code_gen_options.backend {
-        CodeGenBackend::Assembly => gen_from_mono_module_dev(
+        CodeGenBackend::Assembly | CodeGenBackend::Wasm => gen_from_mono_module_dev(
             arena,
             loaded,
             target,
@@ -111,16 +111,6 @@ pub fn gen_from_mono_module<'a>(
             wasm_dev_stack_bytes,
         ),
         CodeGenBackend::Llvm(backend_mode) => {
-            gen_from_mono_module_llvm(arena, loaded, path, target, opt, backend_mode, debug)
-        }
-        CodeGenBackend::Wasm => {
-            // emit wasm via the llvm backend
-
-            let backend_mode = match code_gen_options.opt_level {
-                OptLevel::Development => LlvmBackendMode::BinaryDev,
-                OptLevel::Normal | OptLevel::Size | OptLevel::Optimize => LlvmBackendMode::Binary,
-            };
-
             gen_from_mono_module_llvm(arena, loaded, path, target, opt, backend_mode, debug)
         }
     }

--- a/crates/compiler/roc_target/src/lib.rs
+++ b/crates/compiler/roc_target/src/lib.rs
@@ -29,7 +29,7 @@ impl OperatingSystem {
         match self {
             OperatingSystem::Windows => "obj",
             OperatingSystem::Unix => "o",
-            OperatingSystem::Wasi => "o",
+            OperatingSystem::Wasi => "wasm",
         }
     }
 

--- a/examples/platform-switching/web-assembly-platform/host.zig
+++ b/examples/platform-switching/web-assembly-platform/host.zig
@@ -49,7 +49,7 @@ pub fn main() u8 {
     roc__mainForHost_1_exposed(&callresult);
 
     // display the result using JavaScript
-    js_display_roc_string(callresult.asU8ptr(), callresult.len());
+    js_display_roc_string(callresult.asU8ptrMut(), callresult.len());
 
     callresult.decref();
 


### PR DESCRIPTION
- Set opt_level correctly for all subcommands
- Properly run dev when requested
- use `wasm32-wasi` for llvm host and wasm backend
- fix wasm-ld warnings