### PR TITLE
fix: repl panic on empty line

### DIFF
--- a/crates/repl_cli/src/repl_state.rs
+++ b/crates/repl_cli/src/repl_state.rs
@@ -96,25 +96,7 @@ impl ReplState {
         let arena = Bump::new();
 
         match parse_src(&arena, line) {
-            ParseOutcome::Empty => {
-                if line.is_empty() {
-                    Ok(TIPS.to_string())
-                } else if line.ends_with('\n') {
-                    // After two blank lines in a row, give up and try parsing it
-                    // even though it's going to fail. This way you don't get stuck
-                    // in a perpetual Incomplete state due to a syntax error.
-                    Ok(self.eval_and_format(line, dimensions))
-                } else {
-                    // The previous line wasn't blank, but the line isn't empty either.
-                    // This could mean that, for example, you're writing a multiline `when`
-                    // and want to add a blank line. No problem! Print a blank line and
-                    // continue waiting for input.
-                    //
-                    // If the user presses enter again, next time prev_line_blank() will be true
-                    //  and we'll try parsing the source as-is.
-                    Ok("\n".to_string())
-                }
-            }
+            ParseOutcome::Empty => Ok(TIPS.to_string()),
             ParseOutcome::Expr(_)
             | ParseOutcome::ValueDef(_)
             | ParseOutcome::TypeDef(_)


### PR DESCRIPTION
Fixes #5337.

I think this part of the code is just old and wans't updated correctly as things changed around it. The comments mentioned removed functions and I couldn't reproduce the issues they used as justifications for calling `ReplState::eval_and_format` after `parse_src` returned `ParseOutcome::Empty`. When the input is incomplete, the `Validator` will prevent a new input beeing emitted and thus if the user is in the middle of a `when` and wants a blank line, it won't get to `ReplState::step` since the validator will say the input is incomplete. If the user wants a blank line without adding identation, just use ctrl-j + ctrl-v.

Please let me know if there are any unhandled scenarios for this that I might have ignored.