### PR TITLE
Fix `List.intersperse` docs example

### DIFF
--- a/crates/compiler/builtins/roc/List.roc
+++ b/crates/compiler/builtins/roc/List.roc
@@ -1016,7 +1016,7 @@ sublistLowlevel : List elem, Nat, Nat -> List elem
 
 ## Intersperses `sep` between the elements of `list`
 ## ```
-## List.intersperse 9 [1, 2, 3]     # [1, 9, 2, 9, 3]
+## List.intersperse [1, 2, 3] 9     # [1, 9, 2, 9, 3]
 ## ```
 intersperse : List elem, elem -> List elem
 intersperse = \list, sep ->


### PR DESCRIPTION
The example in the docs for `List.intersperse` mistakenly pass the separator as the first argument when it should be passing the list.