### PR TITLE
switch to rust 1.67

### DIFF
--- a/.github/workflows/windows_release_build.yml
+++ b/.github/workflows/windows_release_build.yml
@@ -32,8 +32,8 @@ jobs:
       - name: zig version
         run: zig version
 
-      - name: install rust nightly 1.66
-        run: rustup install nightly-2022-10-30
+      - name: install rust nightly 1.67
+        run: rustup install nightly-2022-12-09
 
       - name: set up llvm 13
         run: |

--- a/.github/workflows/windows_tests.yml
+++ b/.github/workflows/windows_tests.yml
@@ -36,8 +36,8 @@ jobs:
       - name: zig version
         run: zig version
 
-      - name: install rust nightly 1.66
-        run: rustup install nightly-2022-10-30
+      - name: install rust nightly 1.67
+        run: rustup install nightly-2022-12-09
 
       - name: set up llvm 13
         run: |

--- a/crates/ast/src/ast_error.rs
+++ b/crates/ast/src/ast_error.rs
@@ -59,7 +59,7 @@ impl From<ModuleError> for ASTError {
 impl From<(Region, Loc<Ident>)> for ASTError {
     fn from(ident_exists_err: (Region, Loc<Ident>)) -> Self {
         Self::IdentExistsError {
-            msg: format!("{:?}", ident_exists_err),
+            msg: format!("{ident_exists_err:?}"),
         }
     }
 }
@@ -67,7 +67,7 @@ impl From<(Region, Loc<Ident>)> for ASTError {
 impl<'a> From<SyntaxError<'a>> for ASTError {
     fn from(syntax_err: SyntaxError) -> Self {
         Self::SyntaxErrorNoBacktrace {
-            msg: format!("{:?}", syntax_err),
+            msg: format!("{syntax_err:?}"),
         }
     }
 }

--- a/crates/ast/src/builtin_aliases.rs
+++ b/crates/ast/src/builtin_aliases.rs
@@ -94,8 +94,7 @@ pub fn aliases() -> MutMap<Symbol, BuiltinAlias> {
     let mut add_alias = |symbol, alias| {
         debug_assert!(
             !aliases.contains_key(&symbol),
-            "Duplicate alias definition for {:?}",
-            symbol
+            "Duplicate alias definition for {symbol:?}"
         );
 
         // TODO instead of using Region::zero for all of these,

--- a/crates/ast/src/constrain.rs
+++ b/crates/ast/src/constrain.rs
@@ -2065,7 +2065,7 @@ pub mod test_constrain {
 
                 assert_eq!(actual_str, expected_str);
             }
-            Err(e) => panic!("syntax error {:?}", e),
+            Err(e) => panic!("syntax error {e:?}"),
         }
     }
 

--- a/crates/ast/src/lang/core/expr/expr2_to_string.rs
+++ b/crates/ast/src/lang/core/expr/expr2_to_string.rs
@@ -130,7 +130,7 @@ fn expr2_to_string_helper(
             );
         }
         Expr2::Call { .. } => {
-            let _ = write!(out_string, "Call({:?})", expr2);
+            let _ = write!(out_string, "Call({expr2:?})");
         }
         Expr2::Closure { args, .. } => {
             out_string.push_str("Closure:\n");
@@ -148,7 +148,7 @@ fn expr2_to_string_helper(
             }
         }
         &Expr2::Var { .. } => {
-            let _ = write!(out_string, "{:?}", expr2);
+            let _ = write!(out_string, "{expr2:?}");
         }
         Expr2::RuntimeError { .. } => {
             out_string.push_str("RuntimeError\n");

--- a/crates/ast/src/lang/core/expr/expr_to_expr2.rs
+++ b/crates/ast/src/lang/core/expr/expr_to_expr2.rs
@@ -671,27 +671,19 @@ pub fn expr_to_expr2<'a>(
         // operator desugaring should have removed them!
         bad_expr @ SpaceBefore(_, _) => {
             panic!(
-                "A SpaceBefore did not get removed during operator desugaring somehow: {:#?}",
-                bad_expr
+                "A SpaceBefore did not get removed during operator desugaring somehow: {bad_expr:#?}"
             );
         }
         bad_expr @ SpaceAfter(_, _) => {
             panic!(
-                "A SpaceAfter did not get removed during operator desugaring somehow: {:#?}",
-                bad_expr
+                "A SpaceAfter did not get removed during operator desugaring somehow: {bad_expr:#?}"
             );
         }
         bad_expr @ BinOps { .. } => {
-            panic!(
-                "A binary operator chain did not get desugared somehow: {:#?}",
-                bad_expr
-            );
+            panic!("A binary operator chain did not get desugared somehow: {bad_expr:#?}");
         }
         bad_expr @ UnaryOp(_, _) => {
-            panic!(
-                "A unary operator did not get desugared somehow: {:#?}",
-                bad_expr
-            );
+            panic!("A unary operator did not get desugared somehow: {bad_expr:#?}");
         }
 
         rest => todo!("not yet implemented {:?}", rest),

--- a/crates/ast/src/lang/core/str.rs
+++ b/crates/ast/src/lang/core/str.rs
@@ -227,7 +227,7 @@ pub fn update_str_expr(
         Expr2::Str(old_pool_str) => Either::OldPoolStr(*old_pool_str),
         other => UnexpectedASTNodeSnafu {
             required_node_type: "SmallStr or Str",
-            encountered_node_type: format!("{:?}", other),
+            encountered_node_type: format!("{other:?}"),
         }
         .fail()?,
     };

--- a/crates/ast/src/lang/env.rs
+++ b/crates/ast/src/lang/env.rs
@@ -102,8 +102,7 @@ impl<'a> Env<'a> {
     ) -> Result<Symbol, RuntimeError> {
         debug_assert!(
             !module_name.is_empty(),
-            "Called env.qualified_lookup with an unqualified ident: {:?}",
-            ident
+            "Called env.qualified_lookup with an unqualified ident: {ident:?}"
         );
 
         let module_name: ModuleName = module_name.into();

--- a/crates/ast/src/module.rs
+++ b/crates/ast/src/module.rs
@@ -25,14 +25,8 @@ pub fn load_module(
     match loaded {
         Ok(x) => x,
         Err(roc_load::LoadingProblem::FormattedReport(report)) => {
-            panic!(
-                "Failed to load module from src_file: {:?}. Report: {}",
-                src_file, report
-            );
+            panic!("Failed to load module from src_file: {src_file:?}. Report: {report}");
         }
-        Err(e) => panic!(
-            "Failed to load module from src_file {:?}: {:?}",
-            src_file, e
-        ),
+        Err(e) => panic!("Failed to load module from src_file {src_file:?}: {e:?}"),
     }
 }

--- a/crates/cli/src/format.rs
+++ b/crates/cli/src/format.rs
@@ -93,18 +93,18 @@ pub fn format(files: std::vec::Vec<PathBuf>, mode: FormatMode) -> Result<(), Str
         // the PartialEq implementation is returning `false` even when the Debug-formatted impl is exactly the same.
         // I don't have the patience to debug this right now, so let's leave it for another day...
         // TODO: fix PartialEq impl on ast types
-        if format!("{:?}", ast_normalized) != format!("{:?}", reparsed_ast_normalized) {
+        if format!("{ast_normalized:?}") != format!("{reparsed_ast_normalized:?}") {
             let mut fail_file = file.clone();
             fail_file.set_extension("roc-format-failed");
             std::fs::write(&fail_file, buf.as_str()).unwrap();
 
             let mut before_file = file.clone();
             before_file.set_extension("roc-format-failed-ast-before");
-            std::fs::write(&before_file, format!("{:#?}\n", ast_normalized)).unwrap();
+            std::fs::write(&before_file, format!("{ast_normalized:#?}\n")).unwrap();
 
             let mut after_file = file.clone();
             after_file.set_extension("roc-format-failed-ast-after");
-            std::fs::write(&after_file, format!("{:#?}\n", reparsed_ast_normalized)).unwrap();
+            std::fs::write(&after_file, format!("{reparsed_ast_normalized:#?}\n")).unwrap();
 
             internal_error!(
                 "Formatting bug; formatting didn't reparse as the same tree\n\n\

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -416,12 +416,10 @@ pub fn test(matches: &ArgMatches, triple: Triple) -> io::Result<i32> {
         match matches.value_source(ROC_FILE) {
             Some(ValueSource::DefaultValue) => {
                 eprintln!(
-                    "\nThe current directory ({}) does not contain a {} file to use as a default.\n\nYou can run `roc help` for more information on how to provide a .roc file.\n",
-                    current_dir_string,
-                    DEFAULT_ROC_FILENAME
+                    "\nThe current directory ({current_dir_string}) does not contain a {DEFAULT_ROC_FILENAME} file to use as a default.\n\nYou can run `roc help` for more information on how to provide a .roc file.\n"
                 )
             }
-            _ => eprintln!("\nThis file was not found: {}\n\nYou can run `roc help` for more information on how to provide a .roc file.\n", expected_file_path_string),
+            _ => eprintln!("\nThis file was not found: {expected_file_path_string}\n\nYou can run `roc help` for more information on how to provide a .roc file.\n"),
         }
 
         process::exit(1);
@@ -565,16 +563,13 @@ pub fn build(
             match matches.value_source(ROC_FILE) {
                 Some(ValueSource::DefaultValue) => {
                     eprintln!(
-                        "\nThe current directory ({}) does not contain a {} file to use as a default.\n\nYou can run `roc help` for more information on how to provide a .roc file.\n",
-                        current_dir_string,
-                        DEFAULT_ROC_FILENAME
+                        "\nThe current directory ({current_dir_string}) does not contain a {DEFAULT_ROC_FILENAME} file to use as a default.\n\nYou can run `roc help` for more information on how to provide a .roc file.\n"
                     )
                 }
                 _ => {
                     let mut error_lines = Vec::new();
                     error_lines.push(format!(
-                        "This file was not found: {}",
-                        expected_file_path_string
+                        "This file was not found: {expected_file_path_string}"
                     ));
                     // Add some additional hints if run as `roc [FILENAME]`.
                     if matches.subcommand().is_none() {
@@ -584,8 +579,7 @@ pub fn build(
                                     nearest_match(possible_typo, subcommands)
                                 {
                                     error_lines.push(format!(
-                                        "Did you mean to use the {} subcommand?",
-                                        nearest_command
+                                        "Did you mean to use the {nearest_command} subcommand?"
                                     ));
                                 }
                             }
@@ -1144,7 +1138,7 @@ fn roc_run_executable_file_path(binary_bytes: &[u8]) -> std::io::Result<Executab
         );
     }
 
-    let path = PathBuf::from(format!("/proc/self/fd/{}", fd));
+    let path = PathBuf::from(format!("/proc/self/fd/{fd}"));
 
     std::fs::write(&path, binary_bytes)?;
 
@@ -1351,7 +1345,7 @@ impl std::str::FromStr for Target {
             "linux64" => Ok(Target::Linux64),
             "windows64" => Ok(Target::Windows64),
             "wasm32" => Ok(Target::Wasm32),
-            _ => Err(format!("Roc does not know how to compile to {}", string)),
+            _ => Err(format!("Roc does not know how to compile to {string}")),
         }
     }
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -200,12 +200,12 @@ fn main() -> io::Result<()> {
                 }
 
                 Err(LoadingProblem::FormattedReport(report)) => {
-                    print!("{}", report);
+                    print!("{report}");
 
                     Ok(1)
                 }
                 Err(other) => {
-                    panic!("build_file failed with error:\n{:?}", other);
+                    panic!("build_file failed with error:\n{other:?}");
                 }
             }
         }
@@ -272,7 +272,7 @@ fn main() -> io::Result<()> {
             let format_exit_code = match format(roc_files, format_mode) {
                 Ok(_) => 0,
                 Err(message) => {
-                    eprintln!("{}", message);
+                    eprintln!("{message}");
                     1
                 }
             };

--- a/crates/cli/tests/cli_run.rs
+++ b/crates/cli/tests/cli_run.rs
@@ -90,7 +90,7 @@ mod cli_run {
 
         // e.g. "1 error and 0 warnings found in 123 ms."
         let (before_first_digit, _) = err.split_at(err.rfind("found in ").unwrap());
-        let err = format!("{}found in <ignored for test> ms.", before_first_digit);
+        let err = format!("{before_first_digit}found in <ignored for test> ms.");
 
         // make paths consistent
         let err = err.replace('\\', "/");
@@ -230,7 +230,7 @@ mod cli_run {
                                         what: _,
                                         xwhat,
                                     } = error;
-                                    println!("Valgrind Error: {}\n", kind);
+                                    println!("Valgrind Error: {kind}\n");
 
                                     if let Some(ValgrindErrorXWhat {
                                         text,
@@ -238,14 +238,14 @@ mod cli_run {
                                         leakedblocks: _,
                                     }) = xwhat
                                     {
-                                        println!("    {}", text);
+                                        println!("    {text}");
                                     }
                                 }
                                 panic!("Valgrind reported memory errors");
                             }
                         } else {
                             let exit_code = match valgrind_out.status.code() {
-                                Some(code) => format!("exit code {}", code),
+                                Some(code) => format!("exit code {code}"),
                                 None => "no exit code".to_string(),
                             };
 
@@ -301,7 +301,7 @@ mod cli_run {
             // e.g. "1 failed and 0 passed in 123 ms."
             if let Some(split) = actual.rfind("passed in ") {
                 let (before_first_digit, _) = actual.split_at(split);
-                actual = format!("{}passed in <ignored for test> ms.", before_first_digit);
+                actual = format!("{before_first_digit}passed in <ignored for test> ms.");
             }
 
             let self_path = file.display().to_string();
@@ -397,8 +397,7 @@ mod cli_run {
             "swiftui" | "rocLovesSwift" => {
                 if cfg!(not(target_os = "macos")) {
                     eprintln!(
-                        "WARNING: skipping testing example {} because it only works on MacOS.",
-                        roc_filename
+                        "WARNING: skipping testing example {roc_filename} because it only works on MacOS."
                     );
                     return;
                 } else {
@@ -409,8 +408,7 @@ mod cli_run {
             "rocLovesWebAssembly" => {
                 // this is a web assembly example, but we don't test with JS at the moment
                 eprintln!(
-                    "WARNING: skipping testing example {} because it only works in a browser!",
-                    roc_filename
+                    "WARNING: skipping testing example {roc_filename} because it only works in a browser!"
                 );
                 return;
             }
@@ -965,16 +963,14 @@ mod cli_run {
             match roc_filename {
                 "QuicksortApp.roc" => {
                     eprintln!(
-                    "WARNING: skipping testing benchmark {} because the test is broken right now!",
-                    roc_filename
+                    "WARNING: skipping testing benchmark {roc_filename} because the test is broken right now!"
                 );
                     return;
                 }
                 "TestAStar.roc" => {
                     if cfg!(feature = "wasm32-cli-run") {
                         eprintln!(
-                        "WARNING: skipping testing benchmark {} because it currently does not work on wasm32 due to dictionaries.",
-                        roc_filename
+                        "WARNING: skipping testing benchmark {roc_filename} because it currently does not work on wasm32 due to dictionaries."
                     );
                         return;
                     }

--- a/crates/cli/tests/editor.rs
+++ b/crates/cli/tests/editor.rs
@@ -30,7 +30,7 @@ mod editor_launch_test {
 
         // The editor expects to be run from the root of the repo, so it can find the cli-platform to init a new project folder.
         env::set_current_dir(&root_dir)
-            .unwrap_or_else(|_| panic!("Failed to set current dir to {:?}", root_dir));
+            .unwrap_or_else(|_| panic!("Failed to set current dir to {root_dir:?}"));
 
         let roc_binary_path = build_roc_bin(&["--features", "editor"]);
 

--- a/crates/cli_utils/src/bench_utils.rs
+++ b/crates/cli_utils/src/bench_utils.rs
@@ -25,8 +25,7 @@ fn exec_bench_w_input<T: Measurement>(
 
     assert!(
         compile_out.status.success(),
-        "build ended with bad status {:?}",
-        compile_out
+        "build ended with bad status {compile_out:?}"
     );
 
     check_cmd_output(file, stdin_str, executable_filename, expected_ending);
@@ -58,10 +57,7 @@ fn check_cmd_output(
     };
 
     if !&out.stdout.ends_with(expected_ending) {
-        panic!(
-            "expected output to end with {:?} but instead got {:#?}",
-            expected_ending, out
-        );
+        panic!("expected output to end with {expected_ending:?} but instead got {out:#?}");
     }
     assert!(out.status.success());
 }
@@ -96,7 +92,7 @@ fn bench_cmd<T: Measurement>(
     }
 
     if let Some(bench_group) = bench_group_opt {
-        bench_group.bench_function(&format!("Benchmarking {:?}", executable_filename), |b| {
+        bench_group.bench_function(&format!("Benchmarking {executable_filename:?}"), |b| {
             b.iter(|| run_cmd(black_box(&cmd_str), black_box([stdin_str]), &[], []))
         });
     } else {

--- a/crates/cli_utils/src/helpers.rs
+++ b/crates/cli_utils/src/helpers.rs
@@ -216,7 +216,7 @@ pub fn build_roc_bin(extra_args: &[&str]) -> PathBuf {
 
     cargo_cmd.current_dir(root_project_dir).args(&args);
 
-    let cargo_cmd_str = format!("{:?}", cargo_cmd);
+    let cargo_cmd_str = format!("{cargo_cmd:?}");
 
     let cargo_output = cargo_cmd.output().unwrap();
 
@@ -255,7 +255,7 @@ pub fn run_cmd<'a, I: IntoIterator<Item = &'a str>, E: IntoIterator<Item = (&'a 
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()
-        .unwrap_or_else(|_| panic!("failed to execute cmd `{}` in CLI test", cmd_name));
+        .unwrap_or_else(|_| panic!("failed to execute cmd `{cmd_name}` in CLI test"));
 
     {
         let stdin = child.stdin.as_mut().expect("Failed to open stdin");
@@ -269,7 +269,7 @@ pub fn run_cmd<'a, I: IntoIterator<Item = &'a str>, E: IntoIterator<Item = (&'a 
 
     let output = child
         .wait_with_output()
-        .unwrap_or_else(|_| panic!("failed to execute cmd `{}` in CLI test", cmd_name));
+        .unwrap_or_else(|_| panic!("failed to execute cmd `{cmd_name}` in CLI test"));
 
     Out {
         cmd_str,

--- a/crates/code_markup/src/markup/nodes.rs
+++ b/crates/code_markup/src/markup/nodes.rs
@@ -376,7 +376,7 @@ pub fn tree_as_string(root_node_id: MarkNodeId, mark_node_pool: &SlowPool) -> St
 
     let node = mark_node_pool.get(root_node_id);
 
-    writeln!(full_string, "{} mn_id {}\n", node, root_node_id).unwrap();
+    writeln!(full_string, "{node} mn_id {root_node_id}\n").unwrap();
 
     tree_as_string_helper(node, 1, &mut full_string, mark_node_pool);
 
@@ -399,7 +399,7 @@ fn tree_as_string_helper(
             .join("")
             .to_owned();
 
-        writeln!(full_str, "{} mn_id {}", child_str, child_id).unwrap();
+        writeln!(full_str, "{child_str} mn_id {child_id}").unwrap();
 
         tree_string.push_str(&full_str);
 

--- a/crates/code_markup/src/markup_error.rs
+++ b/crates/code_markup/src/markup_error.rs
@@ -56,7 +56,7 @@ pub type MarkResult<T, E = MarkError> = std::result::Result<T, E>;
 
 impl From<UtilError> for MarkError {
     fn from(util_err: UtilError) -> Self {
-        let msg = format!("{}", util_err);
+        let msg = format!("{util_err}");
 
         // hack to handle MarkError derive
         let dummy_res: Result<(), NoneError> = Err(NoneError {});

--- a/crates/code_markup/src/slow_pool.rs
+++ b/crates/code_markup/src/slow_pool.rs
@@ -39,8 +39,8 @@ impl SlowPool {
 
         for (mark_node_id, node) in self.nodes.iter().enumerate() {
             let ast_node_id_str = match mark_id_ast_id_map.get(mark_node_id) {
-                Ok(ast_id) => format!("{:?}", ast_id),
-                Err(err) => format!("{:?}", err),
+                Ok(ast_id) => format!("{ast_id:?}"),
+                Err(err) => format!("{err:?}"),
             };
             let ast_node_id: String = ast_node_id_str
                 .chars()
@@ -52,7 +52,7 @@ impl SlowPool {
             let node_children = node.get_children_ids();
 
             if !node_children.is_empty() {
-                child_str = format!("children: {:?}", node_children);
+                child_str = format!("children: {node_children:?}");
             }
 
             write!(

--- a/crates/compiler/alias_analysis/src/lib.rs
+++ b/crates/compiler/alias_analysis/src/lib.rs
@@ -117,7 +117,7 @@ where
     }
 
     if debug() {
-        for (i, c) in (format!("{:?}", symbol)).chars().take(25).enumerate() {
+        for (i, c) in (format!("{symbol:?}")).chars().take(25).enumerate() {
             name_bytes[25 + i] = c as u8;
         }
     }
@@ -131,7 +131,7 @@ fn bytes_as_ascii(bytes: &[u8]) -> String {
     let mut buf = String::new();
 
     for byte in bytes {
-        write!(buf, "{:02X}", byte).unwrap();
+        write!(buf, "{byte:02X}").unwrap();
     }
 
     buf

--- a/crates/compiler/build/src/link.rs
+++ b/crates/compiler/build/src/link.rs
@@ -530,7 +530,7 @@ pub fn rebuild_host(
             // on windows, we need the nightly toolchain so we can use `-Z export-executable-symbols`
             // using `+nightly` only works when running cargo through rustup
             let mut cmd = rustup();
-            cmd.args(["run", "nightly-2022-10-30", "cargo"]);
+            cmd.args(["run", "nightly-2022-12-09", "cargo"]);
 
             cmd
         } else {

--- a/crates/compiler/build/src/link.rs
+++ b/crates/compiler/build/src/link.rs
@@ -161,7 +161,7 @@ pub fn build_zig_host_native(
 
     zig_cmd.args([
         zig_host_src,
-        &format!("-femit-bin={}", emit_bin),
+        &format!("-femit-bin={emit_bin}"),
         "--pkg-begin",
         "glue",
         find_zig_glue_path().to_str().unwrap(),
@@ -399,7 +399,7 @@ pub fn build_swift_host_native(
 
     match arch {
         Architecture::Aarch64(_) => command.arg("-arm64"),
-        _ => command.arg(format!("-{}", arch)),
+        _ => command.arg(format!("-{arch}")),
     };
 
     command
@@ -928,7 +928,7 @@ fn link_linux(
                     .map(|segments| segments.join("/"))
                     .collect::<Vec<String>>()
                     .join("\n");
-                eprintln!("We looked in the following directories:\n{}", dirs);
+                eprintln!("We looked in the following directories:\n{dirs}");
                 process::exit(1);
             }
         };
@@ -1085,8 +1085,8 @@ fn link_macos(
 
     let sdk_path = "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib";
     if Path::new(sdk_path).exists() {
-        ld_command.arg(format!("-L{}", sdk_path));
-        ld_command.arg(format!("-L{}/swift", sdk_path));
+        ld_command.arg(format!("-L{sdk_path}"));
+        ld_command.arg(format!("-L{sdk_path}/swift"));
     };
 
     let roc_link_flags = match env::var("ROC_LINK_FLAGS") {
@@ -1288,9 +1288,7 @@ pub fn llvm_module_to_dylib(
 
     assert!(
         exit_status.success(),
-        "\n___________\nLinking command failed with status {:?}:\n\n  {:?}\n___________\n",
-        exit_status,
-        child
+        "\n___________\nLinking command failed with status {exit_status:?}:\n\n  {child:?}\n___________\n"
     );
 
     // Load the dylib

--- a/crates/compiler/build/src/program.rs
+++ b/crates/compiler/build/src/program.rs
@@ -320,10 +320,10 @@ fn gen_from_mono_module_llvm<'a>(
         if !unrecognized.is_empty() {
             let out = unrecognized
                 .iter()
-                .map(|x| format!("{:?}", x))
+                .map(|x| format!("{x:?}"))
                 .collect::<Vec<String>>()
                 .join(", ");
-            eprintln!("Unrecognized sanitizer: {}\nSupported options are \"address\", \"memory\", \"thread\", \"cargo-fuzz\", and \"afl.rs\".", out);
+            eprintln!("Unrecognized sanitizer: {out}\nSupported options are \"address\", \"memory\", \"thread\", \"cargo-fuzz\", and \"afl.rs\".");
             eprintln!("Note: \"cargo-fuzz\" and \"afl.rs\" both enable sanitizer coverage for fuzzing. They just use different parameters to match the respective libraries.")
         }
 
@@ -340,7 +340,7 @@ fn gen_from_mono_module_llvm<'a>(
         }
         let opt = opt.output().unwrap();
 
-        assert!(opt.stderr.is_empty(), "{:#?}", opt);
+        assert!(opt.stderr.is_empty(), "{opt:#?}");
 
         // write the .o file. Note that this builds the .o for the local machine,
         // and ignores the `target_machine` entirely.
@@ -358,7 +358,7 @@ fn gen_from_mono_module_llvm<'a>(
             .output()
             .unwrap();
 
-        assert!(bc_to_object.status.success(), "{:#?}", bc_to_object);
+        assert!(bc_to_object.status.success(), "{bc_to_object:#?}");
 
         MemoryBuffer::create_from_file(&app_o_file).expect("memory buffer creation works")
     } else if emit_debug_info {
@@ -414,7 +414,7 @@ fn gen_from_mono_module_llvm<'a>(
                     .output()
                     .unwrap();
 
-                assert!(ll_to_object.stderr.is_empty(), "{:#?}", ll_to_object);
+                assert!(ll_to_object.stderr.is_empty(), "{ll_to_object:#?}");
             }
             _ => unreachable!(),
         }
@@ -716,13 +716,13 @@ pub fn handle_error_module(
 pub fn handle_loading_problem(problem: LoadingProblem) -> std::io::Result<i32> {
     match problem {
         LoadingProblem::FormattedReport(report) => {
-            print!("{}", report);
+            print!("{report}");
             Ok(1)
         }
         _ => {
             // TODO: tighten up the types here, we should always end up with a
             // formatted report from load.
-            print!("Failed with error: {:?}", problem);
+            print!("Failed with error: {problem:?}");
             Ok(1)
         }
     }
@@ -889,7 +889,7 @@ fn build_loaded_file<'a>(
         buf.push('\n');
 
         use std::fmt::Write;
-        write!(buf, "{}", module_timing).unwrap();
+        write!(buf, "{module_timing}").unwrap();
 
         if it.peek().is_some() {
             buf.push('\n');
@@ -914,10 +914,7 @@ fn build_loaded_file<'a>(
                 .expect("Failed to (re)build platform.");
 
             if emit_timings && !is_platform_prebuilt {
-                println!(
-                    "Finished rebuilding the platform in {} ms\n",
-                    rebuild_duration
-                );
+                println!("Finished rebuilding the platform in {rebuild_duration} ms\n");
             }
 
             Some(HostRebuildTiming::BeforeApp(rebuild_duration))
@@ -957,8 +954,7 @@ fn build_loaded_file<'a>(
 
     if emit_timings {
         println!(
-            "\n\nCompilation finished!\n\nHere's how long each module took to compile:\n\n{}",
-            buf
+            "\n\nCompilation finished!\n\nHere's how long each module took to compile:\n\n{buf}"
         );
 
         println!(
@@ -972,10 +968,7 @@ fn build_loaded_file<'a>(
         let rebuild_duration = thread.join().expect("Failed to (re)build platform.");
 
         if emit_timings && !is_platform_prebuilt {
-            println!(
-                "Finished rebuilding the platform in {} ms\n",
-                rebuild_duration
-            );
+            println!("Finished rebuilding the platform in {rebuild_duration} ms\n");
         }
     }
 
@@ -1007,7 +1000,7 @@ fn build_loaded_file<'a>(
             };
             let app_o_file = tempfile::Builder::new()
                 .prefix("roc_app")
-                .suffix(&format!(".{}", extension))
+                .suffix(&format!(".{extension}"))
                 .tempfile()
                 .map_err(|err| todo!("TODO Gracefully handle tempfile creation error {:?}", err))?;
             let app_o_file = app_o_file.path();
@@ -1257,8 +1250,7 @@ pub fn check_file<'a>(
 
     if emit_timings {
         println!(
-            "\n\nCompilation finished!\n\nHere's how long each module took to compile:\n\n{}",
-            buf
+            "\n\nCompilation finished!\n\nHere's how long each module took to compile:\n\n{buf}"
         );
 
         println!("Finished checking in {} ms\n", compilation_end.as_millis(),);

--- a/crates/compiler/builtins/bitcode/bc/build.rs
+++ b/crates/compiler/builtins/bitcode/bc/build.rs
@@ -61,12 +61,12 @@ fn generate_bc_file(bitcode_path: &Path, zig_object: &str, file_name: &str) {
     ll_path.set_extension("ll");
     let dest_ir_host = ll_path.to_str().expect("Invalid dest ir path");
 
-    println!("Compiling host ir to: {}", dest_ir_host);
+    println!("Compiling host ir to: {dest_ir_host}");
 
     let mut bc_path = bitcode_path.join(file_name);
     bc_path.set_extension("bc");
     let dest_bc_64bit = bc_path.to_str().expect("Invalid dest bc path");
-    println!("Compiling 64-bit bitcode to: {}", dest_bc_64bit);
+    println!("Compiling 64-bit bitcode to: {dest_bc_64bit}");
 
     // workaround for github.com/ziglang/zig/issues/9711
     #[cfg(target_os = "macos")]
@@ -104,7 +104,7 @@ fn run_command(mut command: Command, flaky_fail_counter: usize) {
             false => {
                 let error_str = match str::from_utf8(&output.stderr) {
                     Ok(stderr) => stderr.to_string(),
-                    Err(_) => format!("Failed to run \"{}\"", command_str),
+                    Err(_) => format!("Failed to run \"{command_str}\""),
                 };
 
                 // Flaky test errors that only occur sometimes on MacOS ci server.

--- a/crates/compiler/builtins/bitcode/build.rs
+++ b/crates/compiler/builtins/bitcode/build.rs
@@ -66,7 +66,7 @@ fn generate_object_file(bitcode_path: &Path, zig_object: &str, object_file_name:
     let src_obj_path = bitcode_path.join(object_file_name);
     let src_obj = src_obj_path.to_str().expect("Invalid src object path");
 
-    println!("Compiling zig object `{}` to: {}", zig_object, src_obj);
+    println!("Compiling zig object `{zig_object}` to: {src_obj}");
 
     if !DEBUG {
         let mut zig_cmd = zig();
@@ -77,7 +77,7 @@ fn generate_object_file(bitcode_path: &Path, zig_object: &str, object_file_name:
 
         run_command(zig_cmd, 0);
 
-        println!("Moving zig object `{}` to: {}", zig_object, dest_obj);
+        println!("Moving zig object `{zig_object}` to: {dest_obj}");
 
         // we store this .o file in rust's `target` folder (for wasm we need to leave a copy here too)
         fs::copy(src_obj, dest_obj).unwrap_or_else(|err| {
@@ -167,7 +167,7 @@ fn run_command(mut command: Command, flaky_fail_counter: usize) {
             false => {
                 let error_str = match str::from_utf8(&output.stderr) {
                     Ok(stderr) => stderr.to_string(),
-                    Err(_) => format!("Failed to run \"{}\"", command_str),
+                    Err(_) => format!("Failed to run \"{command_str}\""),
                 };
 
                 // Flaky test errors that only occur sometimes on MacOS ci server.

--- a/crates/compiler/can/src/abilities.rs
+++ b/crates/compiler/can/src/abilities.rs
@@ -469,8 +469,7 @@ impl IAbilitiesStore<Resolved> {
 
         debug_assert!(
             old_specialization.is_none(),
-            "Existing resolution: {:?}",
-            old_specialization
+            "Existing resolution: {old_specialization:?}"
         );
     }
 

--- a/crates/compiler/can/src/constraint.rs
+++ b/crates/compiler/can/src/constraint.rs
@@ -196,7 +196,7 @@ impl Constraints {
 
         let mut buf = String::new();
 
-        writeln!(buf, "Constraints statistics for module {:?}:", module_id)?;
+        writeln!(buf, "Constraints statistics for module {module_id:?}:")?;
 
         writeln!(buf, "   constraints length: {}:", self.constraints.len())?;
         writeln!(
@@ -853,16 +853,16 @@ impl std::fmt::Debug for Constraint {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Eq(Eq(arg0, arg1, arg2, arg3)) => {
-                write!(f, "Eq({:?}, {:?}, {:?}, {:?})", arg0, arg1, arg2, arg3)
+                write!(f, "Eq({arg0:?}, {arg1:?}, {arg2:?}, {arg3:?})")
             }
             Self::Store(arg0, arg1, arg2, arg3) => {
-                write!(f, "Store({:?}, {:?}, {:?}, {:?})", arg0, arg1, arg2, arg3)
+                write!(f, "Store({arg0:?}, {arg1:?}, {arg2:?}, {arg3:?})")
             }
             Self::Lookup(arg0, arg1, arg2) => {
-                write!(f, "Lookup({:?}, {:?}, {:?})", arg0, arg1, arg2)
+                write!(f, "Lookup({arg0:?}, {arg1:?}, {arg2:?})")
             }
             Self::Pattern(arg0, arg1, arg2, arg3) => {
-                write!(f, "Pattern({:?}, {:?}, {:?}, {:?})", arg0, arg1, arg2, arg3)
+                write!(f, "Pattern({arg0:?}, {arg1:?}, {arg2:?}, {arg3:?})")
             }
             Self::True => write!(f, "True"),
             Self::SaveTheEnvironment => write!(f, "SaveTheEnvironment"),
@@ -871,27 +871,19 @@ impl std::fmt::Debug for Constraint {
             Self::IsOpenType(arg0) => f.debug_tuple("IsOpenType").field(arg0).finish(),
             Self::IncludesTag(arg0) => f.debug_tuple("IncludesTag").field(arg0).finish(),
             Self::PatternPresence(arg0, arg1, arg2, arg3) => {
-                write!(
-                    f,
-                    "PatternPresence({:?}, {:?}, {:?}, {:?})",
-                    arg0, arg1, arg2, arg3
-                )
+                write!(f, "PatternPresence({arg0:?}, {arg1:?}, {arg2:?}, {arg3:?})")
             }
             Self::Exhaustive(arg0, arg1, arg2, arg3) => {
-                write!(
-                    f,
-                    "Exhaustive({:?}, {:?}, {:?}, {:?})",
-                    arg0, arg1, arg2, arg3
-                )
+                write!(f, "Exhaustive({arg0:?}, {arg1:?}, {arg2:?}, {arg3:?})")
             }
             Self::Resolve(arg0) => {
-                write!(f, "Resolve({:?})", arg0)
+                write!(f, "Resolve({arg0:?})")
             }
             Self::CheckCycle(arg0, arg1) => {
-                write!(f, "CheckCycle({:?}, {:?})", arg0, arg1)
+                write!(f, "CheckCycle({arg0:?}, {arg1:?})")
             }
             Self::IngestedFile(arg0, arg1, arg2) => {
-                write!(f, "IngestedFile({:?}, {:?}, {:?})", arg0, arg1, arg2)
+                write!(f, "IngestedFile({arg0:?}, {arg1:?}, {arg2:?})")
             }
         }
     }

--- a/crates/compiler/can/src/copy.rs
+++ b/crates/compiler/can/src/copy.rs
@@ -24,7 +24,7 @@ trait CopyEnv {
             if descriptor.copy.into_variable().is_some() {
                 descriptor.copy = OptVariable::NONE;
             } else {
-                debug_assert!(false, "{:?} marked as copied but it wasn't", var);
+                debug_assert!(false, "{var:?} marked as copied but it wasn't");
             }
         })
     }
@@ -1320,7 +1320,7 @@ mod test {
                     FlexVar(Some(name)) => {
                         assert_eq!(subs[*name].as_str(), "a");
                     }
-                    it => panic!("{:?}", it),
+                    it => panic!("{it:?}"),
                 }
                 assert_eq!(var, variant_var);
                 assert!(matches!(
@@ -1337,7 +1337,7 @@ mod test {
                     FlexVar(Some(name)) => {
                         assert_eq!(subs[*name].as_str(), "b");
                     }
-                    it => panic!("{:?}", it),
+                    it => panic!("{it:?}"),
                 }
 
                 match arg.value {
@@ -1355,10 +1355,10 @@ mod test {
                         assert_eq!(name.0.as_str(), "G");
                         assert_eq!(arguments.len(), 0);
                     }
-                    e => panic!("{:?}", e),
+                    e => panic!("{e:?}"),
                 }
             }
-            e => panic!("{:?}", e),
+            e => panic!("{e:?}"),
         }
     }
 
@@ -1403,7 +1403,7 @@ mod test {
                     FlexVar(Some(name)) => {
                         assert_eq!(target[*name].as_str(), "a");
                     }
-                    it => panic!("{:?}", it),
+                    it => panic!("{it:?}"),
                 }
                 assert_eq!(var, variant_var);
                 assert!(matches!(
@@ -1418,7 +1418,7 @@ mod test {
                     FlexVar(Some(name)) => {
                         assert_eq!(target[*name].as_str(), "b");
                     }
-                    it => panic!("{:?}", it),
+                    it => panic!("{it:?}"),
                 }
 
                 match arg.value {
@@ -1436,10 +1436,10 @@ mod test {
                         assert_eq!(name.0.as_str(), "G");
                         assert_eq!(arguments.len(), 0);
                     }
-                    e => panic!("{:?}", e),
+                    e => panic!("{e:?}"),
                 }
             }
-            e => panic!("{:?}", e),
+            e => panic!("{e:?}"),
         }
     }
 

--- a/crates/compiler/can/src/def.rs
+++ b/crates/compiler/can/src/def.rs
@@ -1069,8 +1069,7 @@ fn canonicalize_value_defs<'a>(
             debug_assert_eq!(env.home, s.module_id());
             debug_assert!(
                 !symbol_to_index.iter().any(|(id, _)| *id == s.ident_id()),
-                "{:?}",
-                s
+                "{s:?}"
             );
 
             symbol_to_index.push((s.ident_id(), def_index as u32));
@@ -1838,7 +1837,7 @@ pub(crate) fn sort_can_defs(
             );
 
             let declaration = if def_ordering.references.get_row_col(index, index) {
-                debug_assert!(!is_specialization, "Self-recursive specializations can only be determined during solving - but it was determined for {:?} now, that's a bug!", def);
+                debug_assert!(!is_specialization, "Self-recursive specializations can only be determined during solving - but it was determined for {def:?} now, that's a bug!");
 
                 if is_initial
                     && !def

--- a/crates/compiler/can/src/derive.rs
+++ b/crates/compiler/can/src/derive.rs
@@ -222,16 +222,16 @@ pub(crate) fn synthesize_member_impl<'a>(
     ability_member: Symbol,
 ) -> (Symbol, Loc<Pattern>, &'a Loc<ast::Expr<'a>>) {
     // @Opaq
-    let at_opaque = env.arena.alloc_str(&format!("@{}", opaque_name));
+    let at_opaque = env.arena.alloc_str(&format!("@{opaque_name}"));
 
     let (impl_name, def_body): (String, ast::Expr<'a>) = match ability_member {
         Symbol::ENCODE_TO_ENCODER => (
-            format!("#{}_toEncoder", opaque_name),
+            format!("#{opaque_name}_toEncoder"),
             to_encoder(env, at_opaque),
         ),
-        Symbol::DECODE_DECODER => (format!("#{}_decoder", opaque_name), decoder(env, at_opaque)),
-        Symbol::HASH_HASH => (format!("#{}_hash", opaque_name), hash(env, at_opaque)),
-        Symbol::BOOL_IS_EQ => (format!("#{}_isEq", opaque_name), is_eq(env, at_opaque)),
+        Symbol::DECODE_DECODER => (format!("#{opaque_name}_decoder"), decoder(env, at_opaque)),
+        Symbol::HASH_HASH => (format!("#{opaque_name}_hash"), hash(env, at_opaque)),
+        Symbol::BOOL_IS_EQ => (format!("#{opaque_name}_isEq"), is_eq(env, at_opaque)),
         other => internal_error!("{:?} is not a derivable ability member!", other),
     };
 

--- a/crates/compiler/can/src/effect_module.rs
+++ b/crates/compiler/can/src/effect_module.rs
@@ -1362,7 +1362,7 @@ pub fn build_host_exposed_def(
         match typ.shallow_structural_dealias() {
             Type::Function(args, _, _) => {
                 for i in 0..args.len() {
-                    let name = format!("closure_arg_{}_{}", ident, i);
+                    let name = format!("closure_arg_{ident}_{i}");
 
                     let arg_symbol = {
                         let ident = name.clone().into();
@@ -1381,7 +1381,7 @@ pub fn build_host_exposed_def(
                     linked_symbol_arguments.push((arg_var, Expr::Var(arg_symbol, arg_var)));
                 }
 
-                let foreign_symbol_name = format!("roc_fx_{}", ident);
+                let foreign_symbol_name = format!("roc_fx_{ident}");
                 let low_level_call = Expr::ForeignCall {
                     foreign_symbol: foreign_symbol_name.into(),
                     args: linked_symbol_arguments,
@@ -1389,7 +1389,7 @@ pub fn build_host_exposed_def(
                 };
 
                 let effect_closure_symbol = {
-                    let name = format!("effect_closure_{}", ident);
+                    let name = format!("effect_closure_{ident}");
 
                     let ident = name.into();
                     scope.introduce(ident, Region::zero()).unwrap()
@@ -1435,7 +1435,7 @@ pub fn build_host_exposed_def(
             _ => {
                 // not a function
 
-                let foreign_symbol_name = format!("roc_fx_{}", ident);
+                let foreign_symbol_name = format!("roc_fx_{ident}");
                 let low_level_call = Expr::ForeignCall {
                     foreign_symbol: foreign_symbol_name.into(),
                     args: linked_symbol_arguments,
@@ -1443,7 +1443,7 @@ pub fn build_host_exposed_def(
                 };
 
                 let effect_closure_symbol = {
-                    let name = format!("effect_closure_{}", ident);
+                    let name = format!("effect_closure_{ident}");
 
                     let ident = name.into();
                     scope.introduce(ident, Region::zero()).unwrap()

--- a/crates/compiler/can/src/env.rs
+++ b/crates/compiler/can/src/env.rs
@@ -67,8 +67,7 @@ impl<'a> Env<'a> {
     ) -> Result<Symbol, RuntimeError> {
         debug_assert!(
             !module_name_str.is_empty(),
-            "Called env.qualified_lookup with an unqualified ident: {:?}",
-            ident
+            "Called env.qualified_lookup with an unqualified ident: {ident:?}"
         );
 
         let module_name = ModuleName::from(module_name_str);

--- a/crates/compiler/can/src/module.rs
+++ b/crates/compiler/can/src/module.rs
@@ -347,9 +347,7 @@ pub fn canonicalize_module_defs<'a>(
             // the symbol should already be added to the scope when this module is canonicalized
             debug_assert!(
                 scope.contains_alias(symbol) || scope.abilities_store.is_ability(symbol),
-                "The {:?} is not a type alias or ability known in {:?}",
-                symbol,
-                home
+                "The {symbol:?} is not a type alias or ability known in {home:?}"
             );
 
             // but now we know this symbol by a different identifier, so we still need to add it to

--- a/crates/compiler/can/src/num.rs
+++ b/crates/compiler/can/src/num.rs
@@ -220,8 +220,7 @@ fn from_str_radix(src: &str, radix: u32) -> Result<ParsedNumResult, IntErrorKind
 
     assert!(
         (2..=36).contains(&radix),
-        "from_str_radix_int: must lie in the range `[2, 36]` - found {}",
-        radix
+        "from_str_radix_int: must lie in the range `[2, 36]` - found {radix}"
     );
 
     let (opt_exact_bound, src) = parse_literal_suffix(src);

--- a/crates/compiler/can/src/pattern.rs
+++ b/crates/compiler/can/src/pattern.rs
@@ -531,7 +531,7 @@ pub fn canonicalize_pattern<'a>(
                     use std::ops::Neg;
 
                     let sign_str = if is_negative { "-" } else { "" };
-                    let int_str = format!("{}{}", sign_str, int).into_boxed_str();
+                    let int_str = format!("{sign_str}{int}").into_boxed_str();
                     let i = match int {
                         // Safety: this is fine because I128::MAX = |I128::MIN| - 1
                         IntValue::I128(n) if is_negative => {

--- a/crates/compiler/can/tests/helpers/mod.rs
+++ b/crates/compiler/can/tests/helpers/mod.rs
@@ -37,8 +37,7 @@ pub struct CanExprOut {
 pub fn can_expr_with(arena: &Bump, home: ModuleId, expr_str: &str) -> CanExprOut {
     let loc_expr = roc_parse::test_helpers::parse_loc_with(arena, expr_str).unwrap_or_else(|e| {
         panic!(
-            "can_expr_with() got a parse error when attempting to canonicalize:\n\n{:?} {:?}",
-            expr_str, e
+            "can_expr_with() got a parse error when attempting to canonicalize:\n\n{expr_str:?} {e:?}"
         )
     });
 

--- a/crates/compiler/can/tests/test_can.rs
+++ b/crates/compiler/can/tests/test_can.rs
@@ -422,7 +422,7 @@ mod test_can {
         let CanExprOut { problems, .. } = can_expr_with(&arena, test_home(), src);
 
         assert_eq!(problems.len(), 2);
-        println!("{:#?}", problems);
+        println!("{problems:#?}");
         assert!(problems.iter().any(|problem| matches!(
             problem,
             Problem::RuntimeError(RuntimeError::Shadowing { .. })

--- a/crates/compiler/collections/src/all.rs
+++ b/crates/compiler/collections/src/all.rs
@@ -202,7 +202,7 @@ fn int_to_ordinal(number: usize) -> std::string::String {
         },
     };
 
-    format!("{}{}", number, ending)
+    format!("{number}{ending}")
 }
 
 #[macro_export]

--- a/crates/compiler/collections/src/small_string_interner.rs
+++ b/crates/compiler/collections/src/small_string_interner.rs
@@ -48,9 +48,9 @@ enum Kind {
 impl Debug for Kind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Generated(arg0) => write!(f, "Generated({})", arg0),
+            Self::Generated(arg0) => write!(f, "Generated({arg0})"),
             Self::Empty => write!(f, "Empty"),
-            Self::Interned(arg0) => write!(f, "Interned({})", arg0),
+            Self::Interned(arg0) => write!(f, "Interned({arg0})"),
         }
     }
 }
@@ -155,7 +155,7 @@ impl SmallStringInterner {
         let index = self.lengths.len();
 
         let offset = self.buffer.len();
-        write!(self.buffer, "{}", index).unwrap();
+        write!(self.buffer, "{index}").unwrap();
 
         // this is a generated name, so store it as a negative length
         let length = Length(-((self.buffer.len() - offset) as i16));

--- a/crates/compiler/constrain/src/expr.rs
+++ b/crates/compiler/constrain/src/expr.rs
@@ -1044,8 +1044,7 @@ pub fn constrain_expr(
 
                     debug_assert!(
                         intersection.is_empty(),
-                        "Two patterns introduce the same symbols - that's a bug!\n{:?}",
-                        intersection
+                        "Two patterns introduce the same symbols - that's a bug!\n{intersection:?}"
                     );
                 }
 

--- a/crates/compiler/derive/src/hash.rs
+++ b/crates/compiler/derive/src/hash.rs
@@ -298,7 +298,7 @@ fn hash_tag_union(
                     Expr::Int(
                         discr_num_var,
                         discr_precision_var,
-                        format!("{}", discr_n).into_boxed_str(),
+                        format!("{discr_n}").into_boxed_str(),
                         IntValue::I128((discr_n as i128).to_ne_bytes()),
                         IntBound::Exact(discr_width),
                     ),

--- a/crates/compiler/derive/src/util.rs
+++ b/crates/compiler/derive/src/util.rs
@@ -31,7 +31,7 @@ impl Env<'_> {
                 let name = if i == 1 {
                     hint.clone()
                 } else {
-                    format!("{}{}", hint, i)
+                    format!("{hint}{i}")
                 };
                 if self.derived_ident_ids.get_id(&name).is_none() {
                     break name;
@@ -151,7 +151,7 @@ impl Env<'_> {
                                         == self.subs.get_root_key_without_compacting(lambda_set)
                                 });
                             debug_assert!(belongs_to_specialized_lambda_sets,
-                                "Did not expect derivers to need to specialize unspecialized lambda sets, but we got one: {:?} for {:?}", lambda_set, spec_var)
+                                "Did not expect derivers to need to specialize unspecialized lambda sets, but we got one: {lambda_set:?} for {spec_var:?}")
                         }
                     }
                 }

--- a/crates/compiler/gen_dev/src/generic64/aarch64.rs
+++ b/crates/compiler/gen_dev/src/generic64/aarch64.rs
@@ -3164,7 +3164,7 @@ mod tests {
                     UsesZR => "xzr".to_owned(),
                     UsesSP => "sp".to_owned(),
                 },
-                _ => format!("{}", self),
+                _ => format!("{self}"),
             }
         }
     }

--- a/crates/compiler/gen_dev/src/generic64/x86_64.rs
+++ b/crates/compiler/gen_dev/src/generic64/x86_64.rs
@@ -3612,7 +3612,7 @@ mod tests {
     fn test_add_reg64_imm32() {
         disassembler_test!(
             add_reg64_imm32,
-            |reg, imm| format!("add {}, 0x{:x}", reg, imm),
+            |reg, imm| format!("add {reg}, 0x{imm:x}"),
             ALL_GENERAL_REGS,
             [TEST_I32]
         );
@@ -3622,7 +3622,7 @@ mod tests {
     fn test_add_reg64_reg64() {
         disassembler_test!(
             add_reg64_reg64,
-            |reg1, reg2| format!("add {}, {}", reg1, reg2),
+            |reg1, reg2| format!("add {reg1}, {reg2}"),
             ALL_GENERAL_REGS,
             ALL_GENERAL_REGS
         );
@@ -3632,7 +3632,7 @@ mod tests {
     fn test_sub_reg64_reg64() {
         disassembler_test!(
             sub_reg64_reg64,
-            |reg1, reg2| format!("sub {}, {}", reg1, reg2),
+            |reg1, reg2| format!("sub {reg1}, {reg2}"),
             ALL_GENERAL_REGS,
             ALL_GENERAL_REGS
         );
@@ -3642,7 +3642,7 @@ mod tests {
     fn test_addsd_freg64_freg64() {
         disassembler_test!(
             addsd_freg64_freg64,
-            |reg1, reg2| format!("addsd {}, {}", reg1, reg2),
+            |reg1, reg2| format!("addsd {reg1}, {reg2}"),
             ALL_FLOAT_REGS,
             ALL_FLOAT_REGS
         );
@@ -3652,7 +3652,7 @@ mod tests {
     fn test_addss_freg32_freg32() {
         disassembler_test!(
             addss_freg32_freg32,
-            |reg1, reg2| format!("addss {}, {}", reg1, reg2),
+            |reg1, reg2| format!("addss {reg1}, {reg2}"),
             ALL_FLOAT_REGS,
             ALL_FLOAT_REGS
         );
@@ -3662,7 +3662,7 @@ mod tests {
     fn test_andpd_freg64_freg64() {
         disassembler_test!(
             andpd_freg64_freg64,
-            |reg1, reg2| format!("andpd {}, {}", reg1, reg2),
+            |reg1, reg2| format!("andpd {reg1}, {reg2}"),
             ALL_FLOAT_REGS,
             ALL_FLOAT_REGS
         );
@@ -3729,7 +3729,7 @@ mod tests {
     fn test_cmovl_reg64_reg64() {
         disassembler_test!(
             cmovl_reg64_reg64,
-            |reg1, reg2| format!("cmovl {}, {}", reg1, reg2),
+            |reg1, reg2| format!("cmovl {reg1}, {reg2}"),
             ALL_GENERAL_REGS,
             ALL_GENERAL_REGS
         );
@@ -3739,7 +3739,7 @@ mod tests {
     fn test_cmp_reg64_imm32() {
         disassembler_test!(
             cmp_reg64_imm32,
-            |reg, imm| format!("cmp {}, 0x{:x}", reg, imm),
+            |reg, imm| format!("cmp {reg}, 0x{imm:x}"),
             ALL_GENERAL_REGS,
             [TEST_I32]
         );
@@ -3749,7 +3749,7 @@ mod tests {
     fn test_imul_reg64_reg64() {
         disassembler_test!(
             imul_reg64_reg64,
-            |reg1, reg2| format!("imul {}, {}", reg1, reg2),
+            |reg1, reg2| format!("imul {reg1}, {reg2}"),
             ALL_GENERAL_REGS,
             ALL_GENERAL_REGS
         );
@@ -3759,7 +3759,7 @@ mod tests {
     fn test_mul_reg64_reg64() {
         disassembler_test!(
             mul_reg64_reg64,
-            |reg| format!("mul {}", reg),
+            |reg| format!("mul {reg}"),
             ALL_GENERAL_REGS
         );
     }
@@ -3768,7 +3768,7 @@ mod tests {
     fn test_mulsd_freg64_freg64() {
         disassembler_test!(
             mulsd_freg64_freg64,
-            |reg1, reg2| format!("mulsd {}, {}", reg1, reg2),
+            |reg1, reg2| format!("mulsd {reg1}, {reg2}"),
             ALL_FLOAT_REGS,
             ALL_FLOAT_REGS
         );
@@ -3778,7 +3778,7 @@ mod tests {
     fn test_mulss_freg32_freg32() {
         disassembler_test!(
             mulss_freg32_freg32,
-            |reg1, reg2| format!("mulss {}, {}", reg1, reg2),
+            |reg1, reg2| format!("mulss {reg1}, {reg2}"),
             ALL_FLOAT_REGS,
             ALL_FLOAT_REGS
         );
@@ -3788,7 +3788,7 @@ mod tests {
     fn test_idiv_reg64_reg64() {
         disassembler_test!(
             idiv_reg64_reg64,
-            |reg| format!("cqo\nidiv {}", reg),
+            |reg| format!("cqo\nidiv {reg}"),
             ALL_GENERAL_REGS
         );
     }
@@ -3797,7 +3797,7 @@ mod tests {
     fn test_div_reg64_reg64() {
         disassembler_test!(
             udiv_reg64_reg64,
-            |reg| format!("cqo\ndiv {}", reg),
+            |reg| format!("cqo\ndiv {reg}"),
             ALL_GENERAL_REGS
         );
     }
@@ -3806,7 +3806,7 @@ mod tests {
     fn test_divsd_freg64_freg64() {
         disassembler_test!(
             divsd_freg64_freg64,
-            |reg1, reg2| format!("divsd {}, {}", reg1, reg2),
+            |reg1, reg2| format!("divsd {reg1}, {reg2}"),
             ALL_FLOAT_REGS,
             ALL_FLOAT_REGS
         );
@@ -3816,7 +3816,7 @@ mod tests {
     fn test_divss_freg32_freg32() {
         disassembler_test!(
             divss_freg32_freg32,
-            |reg1, reg2| format!("divss {}, {}", reg1, reg2),
+            |reg1, reg2| format!("divss {reg1}, {reg2}"),
             ALL_FLOAT_REGS,
             ALL_FLOAT_REGS
         );
@@ -3846,7 +3846,7 @@ mod tests {
     fn test_mov_reg64_imm32() {
         disassembler_test!(
             mov_reg64_imm32,
-            |reg, imm| format!("mov {}, 0x{:x}", reg, imm),
+            |reg, imm| format!("mov {reg}, 0x{imm:x}"),
             ALL_GENERAL_REGS,
             [TEST_I32]
         );
@@ -3856,13 +3856,13 @@ mod tests {
     fn test_mov_reg64_imm64() {
         disassembler_test!(
             mov_reg64_imm64,
-            |reg, imm| format!("movabs {}, 0x{:x}", reg, imm),
+            |reg, imm| format!("movabs {reg}, 0x{imm:x}"),
             ALL_GENERAL_REGS,
             [TEST_I64]
         );
         disassembler_test!(
             mov_reg64_imm64,
-            |reg, imm| format!("mov {}, 0x{:x}", reg, imm),
+            |reg, imm| format!("mov {reg}, 0x{imm:x}"),
             ALL_GENERAL_REGS,
             [TEST_I32 as i64]
         );
@@ -3872,7 +3872,7 @@ mod tests {
     fn test_lea_reg64() {
         disassembler_test!(
             lea_reg64,
-            |reg| format!("lea {}, [rip]", reg),
+            |reg| format!("lea {reg}, [rip]"),
             ALL_GENERAL_REGS
         );
     }
@@ -3898,7 +3898,7 @@ mod tests {
                         X86_64GeneralReg::low_32bits_string(&reg1),
                         X86_64GeneralReg::low_32bits_string(&reg2)
                     ),
-                    RegisterWidth::W64 => format!("mov {}, {}", reg1, reg2),
+                    RegisterWidth::W64 => format!("mov {reg1}, {reg2}"),
                 }
             },
             ALL_REGISTER_WIDTHS,
@@ -3967,7 +3967,7 @@ mod tests {
     fn test_movsd_freg64_base64_offset32() {
         disassembler_test!(
             movsd_freg64_base64_offset32,
-            |reg1, reg2, imm| format!("movsd {}, qword ptr [{} + 0x{:x}]", reg1, reg2, imm),
+            |reg1, reg2, imm| format!("movsd {reg1}, qword ptr [{reg2} + 0x{imm:x}]"),
             ALL_FLOAT_REGS,
             ALL_GENERAL_REGS,
             [TEST_I32]
@@ -3978,7 +3978,7 @@ mod tests {
     fn test_movss_freg32_base32_offset32() {
         disassembler_test!(
             movss_freg32_base32_offset32,
-            |reg1, reg2, imm| format!("movss {}, dword ptr [{} + 0x{:x}]", reg1, reg2, imm),
+            |reg1, reg2, imm| format!("movss {reg1}, dword ptr [{reg2} + 0x{imm:x}]"),
             ALL_FLOAT_REGS,
             ALL_GENERAL_REGS,
             [TEST_I32]
@@ -3989,7 +3989,7 @@ mod tests {
     fn test_movsd_base64_offset32_freg64() {
         disassembler_test!(
             movsd_base64_offset32_freg64,
-            |reg1, imm, reg2| format!("movsd qword ptr [{} + 0x{:x}], {}", reg1, imm, reg2),
+            |reg1, imm, reg2| format!("movsd qword ptr [{reg1} + 0x{imm:x}], {reg2}"),
             ALL_GENERAL_REGS,
             [TEST_I32],
             ALL_FLOAT_REGS
@@ -4011,7 +4011,7 @@ mod tests {
     fn test_mov_reg64_base64_offset32() {
         disassembler_test!(
             mov_reg64_base64_offset32,
-            |reg1, reg2, imm| format!("mov {}, qword ptr [{} + 0x{:x}]", reg1, reg2, imm),
+            |reg1, reg2, imm| format!("mov {reg1}, qword ptr [{reg2} + 0x{imm:x}]"),
             ALL_GENERAL_REGS,
             ALL_GENERAL_REGS,
             [TEST_I32]
@@ -4070,7 +4070,7 @@ mod tests {
     fn test_mov_base64_offset32_reg64() {
         disassembler_test!(
             mov_base64_offset32_reg64,
-            |reg1, imm, reg2| format!("mov qword ptr [{} + 0x{:x}], {}", reg1, imm, reg2),
+            |reg1, imm, reg2| format!("mov qword ptr [{reg1} + 0x{imm:x}], {reg2}"),
             ALL_GENERAL_REGS,
             [TEST_I32],
             ALL_GENERAL_REGS
@@ -4129,7 +4129,7 @@ mod tests {
     fn test_movsx_reg64_base32_offset32() {
         disassembler_test!(
             movsx_reg64_base32_offset32,
-            |reg1, reg2, imm| format!("movsxd {}, dword ptr [{} + 0x{:x}]", reg1, reg2, imm),
+            |reg1, reg2, imm| format!("movsxd {reg1}, dword ptr [{reg2} + 0x{imm:x}]"),
             ALL_GENERAL_REGS,
             ALL_GENERAL_REGS,
             [TEST_I32]
@@ -4140,7 +4140,7 @@ mod tests {
     fn test_movsx_reg64_base16_offset32() {
         disassembler_test!(
             movsx_reg64_base16_offset32,
-            |reg1, reg2, imm| format!("movsx {}, word ptr [{} + 0x{:x}]", reg1, reg2, imm),
+            |reg1, reg2, imm| format!("movsx {reg1}, word ptr [{reg2} + 0x{imm:x}]"),
             ALL_GENERAL_REGS,
             ALL_GENERAL_REGS,
             [TEST_I32]
@@ -4151,7 +4151,7 @@ mod tests {
     fn test_movsx_reg64_base8_offset32() {
         disassembler_test!(
             movsx_reg64_base8_offset32,
-            |reg1, reg2, imm| format!("movsx {}, byte ptr [{} + 0x{:x}]", reg1, reg2, imm),
+            |reg1, reg2, imm| format!("movsx {reg1}, byte ptr [{reg2} + 0x{imm:x}]"),
             ALL_GENERAL_REGS,
             ALL_GENERAL_REGS,
             [TEST_I32]
@@ -4162,7 +4162,7 @@ mod tests {
     fn test_movzx_reg64_base16_offset32() {
         disassembler_test!(
             movzx_reg64_base16_offset32,
-            |reg1, reg2, imm| format!("movzx {}, word ptr [{} + 0x{:x}]", reg1, reg2, imm),
+            |reg1, reg2, imm| format!("movzx {reg1}, word ptr [{reg2} + 0x{imm:x}]"),
             ALL_GENERAL_REGS,
             ALL_GENERAL_REGS,
             [TEST_I32]
@@ -4173,7 +4173,7 @@ mod tests {
     fn test_movzx_reg64_base8_offset32() {
         disassembler_test!(
             movzx_reg64_base8_offset32,
-            |reg1, reg2, imm| format!("movzx {}, byte ptr [{} + 0x{:x}]", reg1, reg2, imm),
+            |reg1, reg2, imm| format!("movzx {reg1}, byte ptr [{reg2} + 0x{imm:x}]"),
             ALL_GENERAL_REGS,
             ALL_GENERAL_REGS,
             [TEST_I32]
@@ -4194,7 +4194,7 @@ mod tests {
     fn test_movq_reg64_freg64() {
         disassembler_test!(
             movq_reg64_freg64,
-            |dst, src| format!("movq {}, {}", dst, src),
+            |dst, src| format!("movq {dst}, {src}"),
             ALL_GENERAL_REGS,
             ALL_FLOAT_REGS
         );
@@ -4204,7 +4204,7 @@ mod tests {
     fn test_movsd_freg64_freg64() {
         disassembler_test!(
             raw_movsd_freg64_freg64,
-            |reg1, reg2| format!("movsd {}, {}", reg1, reg2),
+            |reg1, reg2| format!("movsd {reg1}, {reg2}"),
             ALL_FLOAT_REGS,
             ALL_FLOAT_REGS
         );
@@ -4214,7 +4214,7 @@ mod tests {
     fn test_movss_freg32_freg32() {
         disassembler_test!(
             raw_movss_freg32_freg32,
-            |reg1, reg2| format!("movss {}, {}", reg1, reg2),
+            |reg1, reg2| format!("movss {reg1}, {reg2}"),
             ALL_FLOAT_REGS,
             ALL_FLOAT_REGS
         );
@@ -4224,7 +4224,7 @@ mod tests {
     fn test_movss_freg32_rip_offset32() {
         disassembler_test!(
             movss_freg32_rip_offset32,
-            |reg, imm| format!("movss {}, dword ptr [rip + 0x{:x}]", reg, imm),
+            |reg, imm| format!("movss {reg}, dword ptr [rip + 0x{imm:x}]"),
             ALL_FLOAT_REGS,
             [TEST_I32 as u32]
         );
@@ -4234,7 +4234,7 @@ mod tests {
     fn test_movsd_freg64_rip_offset32() {
         disassembler_test!(
             movsd_freg64_rip_offset32,
-            |reg, imm| format!("movsd {}, qword ptr [rip + 0x{:x}]", reg, imm),
+            |reg, imm| format!("movsd {reg}, qword ptr [rip + 0x{imm:x}]"),
             ALL_FLOAT_REGS,
             [TEST_I32 as u32]
         );
@@ -4242,7 +4242,7 @@ mod tests {
 
     #[test]
     fn test_neg_reg64() {
-        disassembler_test!(neg_reg64, |reg| format!("neg {}", reg), ALL_GENERAL_REGS);
+        disassembler_test!(neg_reg64, |reg| format!("neg {reg}"), ALL_GENERAL_REGS);
     }
 
     #[test]
@@ -4251,13 +4251,13 @@ mod tests {
         const CVTTSS2SI_CODE: u8 = 0x2C;
         disassembler_test!(
             |buf, r1, r2| cvtsi2_help(buf, 0xF3, CVTSI2SS_CODE, r1, r2),
-            |reg1, reg2| format!("cvtsi2ss {}, {}", reg1, reg2),
+            |reg1, reg2| format!("cvtsi2ss {reg1}, {reg2}"),
             ALL_FLOAT_REGS,
             ALL_GENERAL_REGS
         );
         disassembler_test!(
             |buf, r1, r2| cvtsi2_help(buf, 0xF3, CVTTSS2SI_CODE, r1, r2),
-            |reg1, reg2| format!("cvttss2si {}, {}", reg1, reg2),
+            |reg1, reg2| format!("cvttss2si {reg1}, {reg2}"),
             ALL_GENERAL_REGS,
             ALL_FLOAT_REGS
         );
@@ -4268,7 +4268,7 @@ mod tests {
         const CVTSS2SD_CODE: u8 = 0x5A;
         disassembler_test!(
             |buf, r1, r2| cvtsi2_help(buf, 0xF3, CVTSS2SD_CODE, r1, r2),
-            |reg1, reg2| format!("cvtss2sd {}, {}", reg1, reg2),
+            |reg1, reg2| format!("cvtss2sd {reg1}, {reg2}"),
             ALL_FLOAT_REGS,
             ALL_FLOAT_REGS
         );
@@ -4292,7 +4292,7 @@ mod tests {
     fn test_sub_reg64_imm32() {
         disassembler_test!(
             sub_reg64_imm32,
-            |reg, imm| format!("sub {}, 0x{:x}", reg, imm),
+            |reg, imm| format!("sub {reg}, 0x{imm:x}"),
             ALL_GENERAL_REGS,
             [TEST_I32]
         );
@@ -4300,12 +4300,12 @@ mod tests {
 
     #[test]
     fn test_pop_reg64() {
-        disassembler_test!(pop_reg64, |reg| format!("pop {}", reg), ALL_GENERAL_REGS);
+        disassembler_test!(pop_reg64, |reg| format!("pop {reg}"), ALL_GENERAL_REGS);
     }
 
     #[test]
     fn test_push_reg64() {
-        disassembler_test!(push_reg64, |reg| format!("push {}", reg), ALL_GENERAL_REGS);
+        disassembler_test!(push_reg64, |reg| format!("push {reg}"), ALL_GENERAL_REGS);
     }
 
     #[test]

--- a/crates/compiler/gen_dev/src/lib.rs
+++ b/crates/compiler/gen_dev/src/lib.rs
@@ -351,7 +351,7 @@ trait Backend<'a> {
         // the functions from the generates #help module (refcounting, equality) is always suffixed
         // with 1. That is fine, they are always unique anyway.
         if ident_string.contains("#help") {
-            format!("{}_{}_1", module_string, ident_string)
+            format!("{module_string}_{ident_string}_1")
         } else {
             format!("{}_{}_{}", module_string, ident_string, state.finish())
         }

--- a/crates/compiler/gen_dev/src/object_builder.rs
+++ b/crates/compiler/gen_dev/src/object_builder.rs
@@ -605,7 +605,7 @@ fn build_proc<'a, B: Backend<'a>>(
         let elfreloc = match reloc {
             Relocation::LocalData { offset, data } => {
                 let data_symbol = write::Symbol {
-                    name: format!("{}.data{}", fn_name, local_data_index)
+                    name: format!("{fn_name}.data{local_data_index}")
                         .as_bytes()
                         .to_vec(),
                     value: 0,

--- a/crates/compiler/gen_llvm/src/llvm/bitcode.rs
+++ b/crates/compiler/gen_llvm/src/llvm/bitcode.rs
@@ -34,10 +34,7 @@ pub fn call_bitcode_fn<'ctx>(
         .try_as_basic_value()
         .left()
         .unwrap_or_else(|| {
-            panic!(
-                "LLVM error: Did not get return value from bitcode function {:?}",
-                fn_name
-            )
+            panic!("LLVM error: Did not get return value from bitcode function {fn_name:?}")
         })
 }
 
@@ -49,7 +46,7 @@ pub fn call_void_bitcode_fn<'ctx>(
     call_bitcode_fn_help(env, args, fn_name)
         .try_as_basic_value()
         .right()
-        .unwrap_or_else(|| panic!("LLVM error: Tried to call void bitcode function, but got return value from bitcode function, {:?}", fn_name))
+        .unwrap_or_else(|| panic!("LLVM error: Tried to call void bitcode function, but got return value from bitcode function, {fn_name:?}"))
 }
 
 fn call_bitcode_fn_help<'ctx>(
@@ -63,7 +60,7 @@ fn call_bitcode_fn_help<'ctx>(
     let fn_val = env
         .module
         .get_function(fn_name)
-        .unwrap_or_else(|| panic!("Unrecognized builtin function: {:?} - if you're working on the Roc compiler, do you need to rebuild the bitcode? See compiler/builtins/bitcode/README.md", fn_name));
+        .unwrap_or_else(|| panic!("Unrecognized builtin function: {fn_name:?} - if you're working on the Roc compiler, do you need to rebuild the bitcode? See compiler/builtins/bitcode/README.md"));
 
     let call = env.builder.build_call(fn_val, &arguments, "call_builtin");
 
@@ -378,9 +375,9 @@ fn build_rc_wrapper<'a, 'ctx>(
         .to_symbol_string(symbol, &env.interns);
 
     let fn_name = match rc_operation {
-        Mode::IncN => format!("{}_inc_n", fn_name),
-        Mode::Inc => format!("{}_inc", fn_name),
-        Mode::Dec => format!("{}_dec", fn_name),
+        Mode::IncN => format!("{fn_name}_inc_n"),
+        Mode::Inc => format!("{fn_name}_inc"),
+        Mode::Dec => format!("{fn_name}_dec"),
     };
 
     let function_value = match env.module.get_function(fn_name.as_str()) {

--- a/crates/compiler/gen_llvm/src/llvm/build.rs
+++ b/crates/compiler/gen_llvm/src/llvm/build.rs
@@ -263,7 +263,7 @@ impl<'a, 'ctx, 'env> Env<'a, 'ctx, 'env> {
         let fn_val = self
             .module
             .get_function(intrinsic_name)
-            .unwrap_or_else(|| panic!("Unrecognized intrinsic function: {}", intrinsic_name));
+            .unwrap_or_else(|| panic!("Unrecognized intrinsic function: {intrinsic_name}"));
 
         let mut arg_vals: Vec<BasicMetadataValueEnum> =
             Vec::with_capacity_in(args.len(), self.arena);
@@ -289,10 +289,7 @@ impl<'a, 'ctx, 'env> Env<'a, 'ctx, 'env> {
         let call = self.build_intrinsic_call(intrinsic_name, args);
 
         call.try_as_basic_value().left().unwrap_or_else(|| {
-            panic!(
-                "LLVM error: Invalid call by name for intrinsic {}",
-                intrinsic_name
-            )
+            panic!("LLVM error: Invalid call by name for intrinsic {intrinsic_name}")
         })
     }
 
@@ -498,17 +495,14 @@ pub fn module_from_builtins<'ctx>(
             } => {
                 include_bytes!("../../../builtins/bitcode/builtins-windows-x86_64.bc")
             }
-            _ => panic!(
-                "The zig builtins are not currently built for this target: {:?}",
-                target
-            ),
+            _ => panic!("The zig builtins are not currently built for this target: {target:?}"),
         }
     };
 
     let memory_buffer = MemoryBuffer::create_from_memory_range(bitcode_bytes, module_name);
 
     let module = Module::parse_bitcode_from_buffer(&memory_buffer, ctx)
-        .unwrap_or_else(|err| panic!("Unable to import builtins bitcode. LLVM error: {:?}", err));
+        .unwrap_or_else(|err| panic!("Unable to import builtins bitcode. LLVM error: {err:?}"));
 
     // Add LLVM intrinsics.
     add_intrinsics(ctx, &module);
@@ -766,7 +760,7 @@ pub fn build_exp_literal<'a, 'ctx>(
             LayoutRepr::Builtin(Builtin::Int(int_width)) => {
                 int_with_precision(env, i128::from_ne_bytes(*bytes), int_width).into()
             }
-            _ => panic!("Invalid layout for int literal = {:?}", layout),
+            _ => panic!("Invalid layout for int literal = {layout:?}"),
         },
 
         U128(bytes) => const_u128(env, u128::from_ne_bytes(*bytes)).into(),
@@ -775,7 +769,7 @@ pub fn build_exp_literal<'a, 'ctx>(
             LayoutRepr::Builtin(Builtin::Float(float_width)) => {
                 float_with_precision(env, *float, float_width)
             }
-            _ => panic!("Invalid layout for float literal = {:?}", layout),
+            _ => panic!("Invalid layout for float literal = {layout:?}"),
         },
 
         Decimal(bytes) => {
@@ -2056,7 +2050,7 @@ pub fn get_tag_id<'a, 'ctx>(
 
     match union_layout {
         UnionLayout::NonRecursive(_) => {
-            debug_assert!(argument.is_pointer_value(), "{:?}", argument);
+            debug_assert!(argument.is_pointer_value(), "{argument:?}");
 
             let argument_ptr = argument.into_pointer_value();
             get_tag_id_wrapped(env, layout_interner, *union_layout, argument_ptr)
@@ -3514,10 +3508,7 @@ fn build_switch_ir<'a, 'ctx>(
             layout_interner,
             layout_interner.get_repr(stored_layout)
         ),
-        "This switch matches on {:?}, but the matched-on symbol {:?} has layout {:?}",
-        cond_layout,
-        cond_symbol,
-        stored_layout
+        "This switch matches on {cond_layout:?}, but the matched-on symbol {cond_symbol:?} has layout {stored_layout:?}"
     );
 
     let cont_block = context.append_basic_block(parent, "cont");
@@ -3623,7 +3614,7 @@ fn build_switch_ir<'a, 'ctx>(
                 condition_int_type.const_int(*int, false)
             };
 
-            let block = context.append_basic_block(parent, format!("branch{}", int).as_str());
+            let block = context.append_basic_block(parent, format!("branch{int}").as_str());
 
             cases.push((int_val, block));
         }
@@ -4032,7 +4023,7 @@ fn expose_function_to_host_help_c_abi_gen_test<'a, 'ctx>(
         &[],
     );
 
-    let size_function_name: String = format!("roc__{}_size", ident_string);
+    let size_function_name: String = format!("roc__{ident_string}_size");
 
     let size_function = add_func(
         env.context,
@@ -4332,7 +4323,7 @@ fn expose_function_to_host_help_c_abi<'a, 'ctx>(
         roc_function,
         arguments,
         return_layout,
-        &format!("{}_generic", c_function_name),
+        &format!("{c_function_name}_generic"),
     );
 
     let c_function = expose_function_to_host_help_c_abi_v2(
@@ -4351,7 +4342,7 @@ fn expose_function_to_host_help_c_abi<'a, 'ctx>(
         Some(env.context.i64_type().as_basic_type_enum()),
         &[],
     );
-    let size_function_name: String = format!("{}_size", c_function_name);
+    let size_function_name: String = format!("{c_function_name}_size");
 
     let size_function = add_func(
         env.context,
@@ -4998,7 +4989,7 @@ pub fn build_procedures_expose_expects<'a>(
         let mut it = func_solutions.specs();
         let func_spec = match it.next() {
             Some(spec) => spec,
-            None => panic!("no specialization for expect {}", symbol),
+            None => panic!("no specialization for expect {symbol}"),
         };
 
         debug_assert!(
@@ -5012,7 +5003,7 @@ pub fn build_procedures_expose_expects<'a>(
 
         let name = roc_main_fn.get_name().to_str().unwrap();
 
-        let expect_name = &format!("Expect_{}", name);
+        let expect_name = &format!("Expect_{name}");
         let expect_name = env.arena.alloc_str(expect_name);
         expect_names.push(&*expect_name);
 
@@ -5024,7 +5015,7 @@ pub fn build_procedures_expose_expects<'a>(
             roc_main_fn,
             top_level.arguments,
             top_level.result,
-            &format!("Expect_{}", name),
+            &format!("Expect_{name}"),
         );
     }
 
@@ -5051,7 +5042,7 @@ fn build_procedures_help<'a>(
         entry_point,
         it,
     ) {
-        Err(e) => panic!("Error in alias analysis: {}", e),
+        Err(e) => panic!("Error in alias analysis: {e}"),
         Ok(solutions) => solutions,
     };
 
@@ -5147,10 +5138,10 @@ fn func_spec_name<'a>(
 
     let ident_string = symbol.as_str(interns);
     let module_string = interns.module_ids.get_name(symbol.module_id()).unwrap();
-    write!(buf, "{}_{}_", module_string, ident_string).unwrap();
+    write!(buf, "{module_string}_{ident_string}_").unwrap();
 
     for byte in func_spec.0.iter() {
-        write!(buf, "{:x?}", byte).unwrap();
+        write!(buf, "{byte:x?}").unwrap();
     }
 
     buf
@@ -5355,7 +5346,7 @@ fn build_closure_caller<'a, 'ctx>(
     // STEP 1: build function header
 
     // e.g. `roc__mainForHost_0_caller` (def_name is `mainForHost_0`)
-    let function_name = format!("roc__{}_caller", def_name);
+    let function_name = format!("roc__{def_name}_caller");
 
     let function_spec = FunctionSpec::cconv(env, CCReturn::Void, None, &argument_types);
 
@@ -5467,9 +5458,9 @@ fn build_host_exposed_alias_size_help<'a, 'ctx>(
     let i64 = env.context.i64_type().as_basic_type_enum();
     let size_function_spec = FunctionSpec::cconv(env, CCReturn::Return, Some(i64), &[]);
     let size_function_name: String = if let Some(label) = opt_label {
-        format!("roc__{}_{}_size", def_name, label)
+        format!("roc__{def_name}_{label}_size")
     } else {
-        format!("roc__{}_size", def_name,)
+        format!("roc__{def_name}_size",)
     };
 
     let size_function = add_func(
@@ -5604,10 +5595,7 @@ fn function_value_by_name_help<'a, 'ctx>(
             );
             eprintln!("Is the function defined? If so, maybe there is a problem with the layout");
 
-            panic!(
-                "Unrecognized builtin function: {:?} (symbol: {:?})",
-                fn_name, symbol,
-            )
+            panic!("Unrecognized builtin function: {fn_name:?} (symbol: {symbol:?})",)
         } else {
             // Unrecognized non-builtin function:
             eprintln!(
@@ -5618,10 +5606,7 @@ fn function_value_by_name_help<'a, 'ctx>(
             );
             eprintln!("Is the function defined? If so, maybe there is a problem with the layout");
 
-            panic!(
-                "Unrecognized non-builtin function: {:?} (symbol: {:?})",
-                fn_name, symbol,
-            )
+            panic!("Unrecognized non-builtin function: {fn_name:?} (symbol: {symbol:?})",)
         }
     })
 }
@@ -6282,7 +6267,7 @@ fn define_global_str_literal<'ctx>(
         message.hash(&mut hasher);
         let hash = hasher.finish();
 
-        format!("_str_literal_{}", hash)
+        format!("_str_literal_{hash}")
     };
 
     match module.get_global(&name) {
@@ -6383,7 +6368,7 @@ pub fn add_func<'ctx>(
 ) -> FunctionValue<'ctx> {
     if cfg!(debug_assertions) {
         if let Some(func) = module.get_function(name) {
-            panic!("Attempting to redefine LLVM function {}, which was already defined in this module as:\n\n{:#?}", name, func);
+            panic!("Attempting to redefine LLVM function {name}, which was already defined in this module as:\n\n{func:#?}");
         }
     }
 

--- a/crates/compiler/gen_llvm/src/llvm/compare.rs
+++ b/crates/compiler/gen_llvm/src/llvm/compare.rs
@@ -329,8 +329,7 @@ fn build_neq<'a, 'ctx>(
 ) -> BasicValueEnum<'ctx> {
     if lhs_layout != rhs_layout {
         panic!(
-            "Inequality of different layouts; did you have a type mismatch?\n{:?} != {:?}",
-            lhs_layout, rhs_layout
+            "Inequality of different layouts; did you have a type mismatch?\n{lhs_layout:?} != {rhs_layout:?}"
         );
     }
 
@@ -789,7 +788,7 @@ fn build_struct_eq_help<'a, 'ctx>(
             .into_int_value()
         };
 
-        current = ctx.append_basic_block(parent, &format!("eq_step_{}", index));
+        current = ctx.append_basic_block(parent, &format!("eq_step_{index}"));
 
         env.builder
             .build_conditional_branch(are_equal, current, return_false);

--- a/crates/compiler/gen_llvm/src/llvm/convert.rs
+++ b/crates/compiler/gen_llvm/src/llvm/convert.rs
@@ -14,8 +14,8 @@ use roc_target::TargetInfo;
 
 use super::struct_::RocStruct;
 
-pub fn basic_type_from_layout<'a, 'ctx, 'env>(
-    env: &Env<'a, 'ctx, 'env>,
+pub fn basic_type_from_layout<'a, 'ctx>(
+    env: &Env<'a, 'ctx, '_>,
     layout_interner: &STLayoutInterner<'a>,
     layout: LayoutRepr<'_>,
 ) -> BasicTypeEnum<'ctx> {

--- a/crates/compiler/gen_llvm/src/llvm/lowlevel.rs
+++ b/crates/compiler/gen_llvm/src/llvm/lowlevel.rs
@@ -1832,7 +1832,7 @@ fn throw_on_overflow<'ctx>(
         .unwrap()
 }
 
-fn throw_because_overflow<'ctx>(env: &Env<'_, 'ctx, '_>, message: &str) {
+fn throw_because_overflow(env: &Env<'_, '_, '_>, message: &str) {
     let block = env.builder.get_insert_block().expect("to be in a function");
     let di_location = env.builder.get_current_debug_location().unwrap();
 

--- a/crates/compiler/gen_llvm/src/llvm/lowlevel.rs
+++ b/crates/compiler/gen_llvm/src/llvm/lowlevel.rs
@@ -2892,6 +2892,6 @@ fn load_symbol_and_lambda_set<'a, 'ctx>(
     let (ptr, layout) = scope.load_symbol_and_layout(symbol);
     match layout_interner.get_repr(layout) {
         LayoutRepr::LambdaSet(lambda_set) => (ptr, lambda_set),
-        other => panic!("Not a lambda set: {:?}, {:?}", other, ptr),
+        other => panic!("Not a lambda set: {other:?}, {ptr:?}"),
     }
 }

--- a/crates/compiler/gen_llvm/src/llvm/refcounting.rs
+++ b/crates/compiler/gen_llvm/src/llvm/refcounting.rs
@@ -132,7 +132,7 @@ impl<'ctx> PointerToRefcount<'ctx> {
         let block = env.builder.get_insert_block().expect("to be in a function");
         let di_location = env.builder.get_current_debug_location().unwrap();
 
-        let fn_name = &format!("decrement_refcounted_ptr_{}", alignment);
+        let fn_name = &format!("decrement_refcounted_ptr_{alignment}");
 
         let function = match env.module.get_function(fn_name) {
             Some(function_value) => function_value,
@@ -1398,7 +1398,7 @@ pub fn build_reset<'a, 'ctx>(
     let union_layout_repr = LayoutRepr::Union(union_layout);
     let layout_id = layout_ids.get(Symbol::DEC, &union_layout_repr);
     let fn_name = layout_id.to_symbol_string(Symbol::DEC, &env.interns);
-    let fn_name = format!("{}_reset", fn_name);
+    let fn_name = format!("{fn_name}_reset");
 
     let dec_function = build_rec_union(env, layout_interner, layout_ids, Mode::Dec, union_layout);
 

--- a/crates/compiler/gen_llvm/src/llvm/scope.rs
+++ b/crates/compiler/gen_llvm/src/llvm/scope.rs
@@ -28,17 +28,14 @@ impl<'a, 'ctx> Scope<'a, 'ctx> {
         match self.symbols.get(symbol) {
             Some((_, ptr)) => *ptr,
 
-            None => panic!(
-                "There was no entry for {:?} {} in scope {:?}",
-                symbol, symbol, self
-            ),
+            None => panic!("There was no entry for {symbol:?} {symbol} in scope {self:?}"),
         }
     }
 
     pub fn load_symbol_and_layout(&self, symbol: &Symbol) -> (BasicValueEnum<'ctx>, InLayout<'a>) {
         match self.symbols.get(symbol) {
             Some((layout, ptr)) => (*ptr, *layout),
-            None => panic!("There was no entry for {:?} in scope {:?}", symbol, self),
+            None => panic!("There was no entry for {symbol:?} in scope {self:?}"),
         }
     }
 

--- a/crates/compiler/gen_llvm/src/llvm/struct_.rs
+++ b/crates/compiler/gen_llvm/src/llvm/struct_.rs
@@ -153,7 +153,7 @@ fn index_struct_ptr<'a, 'ctx>(
     let field_layout = field_layouts[index as usize];
     let field_repr = layout_interner.get_repr(field_layout);
 
-    let name = format!("struct_field_access_record_{}", index);
+    let name = format!("struct_field_access_record_{index}");
     let field_value = env
         .builder
         .new_build_struct_gep(struct_type, ptr, index as u32, &name)

--- a/crates/compiler/gen_llvm/src/llvm/struct_.rs
+++ b/crates/compiler/gen_llvm/src/llvm/struct_.rs
@@ -126,7 +126,7 @@ fn index_struct_value<'a, 'ctx>(
         argument,
         index as _,
         env.arena
-            .alloc(format!("struct_field_access_record_{}", index)),
+            .alloc(format!("struct_field_access_record_{index}")),
     );
 
     let field_layout = field_layouts[index as usize];

--- a/crates/compiler/gen_wasm/src/backend.rs
+++ b/crates/compiler/gen_wasm/src/backend.rs
@@ -313,7 +313,7 @@ impl<'a, 'r> WasmBackend<'a, 'r> {
         if let Ok(sym_index) = self.module.linking.find_internal_symbol(START) {
             let fn_index = match self.module.linking.symbol_table[sym_index] {
                 SymInfo::Function(WasmObjectSymbol::ExplicitlyNamed { index, .. }) => index,
-                _ => panic!("linker symbol `{}` is not a function", START),
+                _ => panic!("linker symbol `{START}` is not a function"),
             };
             self.module.export.append(Export {
                 name: START,
@@ -463,7 +463,7 @@ impl<'a, 'r> WasmBackend<'a, 'r> {
         if DEBUG_SETTINGS.storage_map {
             println!("\nStorage:");
             for (sym, storage) in self.storage.symbol_storage_map.iter() {
-                println!("{:?} => {:?}", sym, storage);
+                println!("{sym:?} => {storage:?}");
             }
         }
     }
@@ -1424,7 +1424,7 @@ impl<'a, 'r> WasmBackend<'a, 'r> {
             .host_lookup
             .iter()
             .find(|(fn_name, _)| *fn_name == name)
-            .unwrap_or_else(|| panic!("The Roc app tries to call `{}` but I can't find it!", name));
+            .unwrap_or_else(|| panic!("The Roc app tries to call `{name}` but I can't find it!"));
 
         self.called_fns.set(*fn_index as usize, true);
 
@@ -1614,7 +1614,7 @@ impl<'a, 'r> WasmBackend<'a, 'r> {
                     ListLiteralElement::Literal(lit) => {
                         // This has no Symbol but our storage methods expect one.
                         // Let's just pretend it was defined in a `Let`.
-                        let debug_name = format!("{:?}_{}", sym, i);
+                        let debug_name = format!("{sym:?}_{i}");
                         let elem_sym = self.create_symbol(&debug_name);
                         let expr = Expr::Literal(*lit);
 

--- a/crates/compiler/gen_wasm/src/code_builder.rs
+++ b/crates/compiler/gen_wasm/src/code_builder.rs
@@ -322,10 +322,7 @@ impl<'a> CodeBuilder<'a> {
             self.add_insertion(pushed_at, SETLOCAL, local_id.0);
         } else {
             if DEBUG_SETTINGS.instructions {
-                println!(
-                    "{:?} has been popped implicitly. Leaving it on the stack.",
-                    symbol
-                );
+                println!("{symbol:?} has been popped implicitly. Leaving it on the stack.");
             }
             self.add_insertion(pushed_at, TEELOCAL, local_id.0);
         }
@@ -501,9 +498,7 @@ impl<'a> CodeBuilder<'a> {
 
         debug_assert!(
             stack_size >= pops,
-            "Wasm value stack underflow. Tried to pop {} but only {} available",
-            pops,
-            stack_size
+            "Wasm value stack underflow. Tried to pop {pops} but only {stack_size} available"
         );
 
         let new_len = stack_size - pops;
@@ -517,11 +512,7 @@ impl<'a> CodeBuilder<'a> {
     /// Plain instruction without any immediates
     fn inst(&mut self, opcode: OpCode, pops: usize, push: bool) {
         self.inst_base(opcode, pops, push);
-        log_instruction!(
-            "{:10}\t\t{:?}",
-            format!("{:?}", opcode),
-            self.vm_block_stack
-        );
+        log_instruction!("{:10}\t\t{:?}", format!("{opcode:?}"), self.vm_block_stack);
     }
 
     /// Block instruction
@@ -538,7 +529,7 @@ impl<'a> CodeBuilder<'a> {
             value_stack: Vec::with_capacity_in(8, self.arena),
         });
 
-        log_instruction!("{:10}\t{:?}", format!("{:?}", opcode), &self.vm_block_stack);
+        log_instruction!("{:10}\t{:?}", format!("{opcode:?}"), &self.vm_block_stack);
     }
 
     fn inst_imm32(&mut self, opcode: OpCode, pops: usize, push: bool, immediate: u32) {
@@ -546,7 +537,7 @@ impl<'a> CodeBuilder<'a> {
         self.code.encode_u32(immediate);
         log_instruction!(
             "{:10}\t{}\t{:?}",
-            format!("{:?}", opcode),
+            format!("{opcode:?}"),
             immediate,
             self.vm_block_stack
         );
@@ -558,7 +549,7 @@ impl<'a> CodeBuilder<'a> {
         self.code.encode_u32(offset);
         log_instruction!(
             "{:10} {:?} {}\t{:?}",
-            format!("{:?}", opcode),
+            format!("{opcode:?}"),
             align,
             offset,
             self.vm_block_stack
@@ -654,7 +645,7 @@ impl<'a> CodeBuilder<'a> {
 
         log_instruction!(
             "{:10}\t{}\t{:?}",
-            format!("{:?}", CALL),
+            format!("{CALL:?}"),
             function_index,
             self.vm_block_stack
         );
@@ -725,7 +716,7 @@ impl<'a> CodeBuilder<'a> {
     {
         log_instruction!(
             "{:10}\t{}\t{:?}",
-            format!("{:?}", opcode),
+            format!("{opcode:?}"),
             x,
             self.vm_block_stack
         );

--- a/crates/compiler/gen_wasm/src/low_level.rs
+++ b/crates/compiler/gen_wasm/src/low_level.rs
@@ -2063,8 +2063,7 @@ impl<'a> LowLevelCall<'a> {
             .runtime_representation(backend.storage.symbol_layouts[&self.arguments[1]]);
         debug_assert_eq!(
             arg_layout_raw, other_arg_layout,
-            "Cannot do `==` comparison on different types: {:?} vs {:?}",
-            arg_layout, other_arg_layout
+            "Cannot do `==` comparison on different types: {arg_layout:?} vs {other_arg_layout:?}"
         );
 
         let invert_result = matches!(self.lowlevel, LowLevel::NotEq);
@@ -2502,7 +2501,7 @@ pub fn call_higher_order_lowlevel<'a>(
             }
         }
     };
-    let wrapper_sym = backend.create_symbol(&format!("#wrap#{:?}", fn_name));
+    let wrapper_sym = backend.create_symbol(&format!("#wrap#{fn_name:?}"));
     let wrapper_layout = {
         let mut wrapper_arg_layouts: Vec<InLayout<'a>> =
             Vec::with_capacity_in(argument_layouts.len() + 1, backend.env.arena);

--- a/crates/compiler/late_solve/src/lib.rs
+++ b/crates/compiler/late_solve/src/lib.rs
@@ -52,7 +52,7 @@ impl WorldAbilities {
             .unwrap()
             .insert(module, (store, exposed_types));
 
-        debug_assert!(old_store.is_none(), "{:?} abilities not new", module);
+        debug_assert!(old_store.is_none(), "{module:?} abilities not new");
     }
 
     #[inline(always)]

--- a/crates/compiler/load_internal/src/file.rs
+++ b/crates/compiler/load_internal/src/file.rs
@@ -175,7 +175,7 @@ fn start_phase<'a>(
 
                 match opt_dep_name {
                     None => {
-                        panic!("Module {:?} is not in module_cache.module_names", module_id)
+                        panic!("Module {module_id:?} is not in module_cache.module_names")
                     }
                     Some(dep_name) => {
                         let module_name = dep_name.clone();
@@ -820,11 +820,11 @@ impl std::fmt::Display for ModuleTiming {
         let multiple_make_specializations_passes = module_timing.make_specializations.len() > 1;
         for (i, pass_time) in module_timing.make_specializations.iter().enumerate() {
             let suffix = if multiple_make_specializations_passes {
-                format!(" (Pass {})", i)
+                format!(" (Pass {i})")
             } else {
                 String::new()
             };
-            report_timing(f, &format!("Make Specializations{}", suffix), *pass_time)?;
+            report_timing(f, &format!("Make Specializations{suffix}"), *pass_time)?;
         }
         report_timing(f, "Other", module_timing.other())?;
         f.write_str("\n")?;
@@ -1866,7 +1866,7 @@ fn worker_task<'a>(
                         ">>> {}",
                         match &task {
                             BuildTask::LoadModule { module_name, .. } => {
-                                format!("BuildTask::LoadModule({:?})", module_name)
+                                format!("BuildTask::LoadModule({module_name:?})")
                             }
                             BuildTask::Parse { header } => {
                                 format!("BuildTask::Parse({})", header.module_path.display())
@@ -1879,10 +1879,10 @@ fn worker_task<'a>(
                                 format!("BuildTask::Solve({:?})", module.module_id)
                             }
                             BuildTask::BuildPendingSpecializations { module_id, .. } => {
-                                format!("BuildTask::BuildPendingSpecializations({:?})", module_id)
+                                format!("BuildTask::BuildPendingSpecializations({module_id:?})")
                             }
                             BuildTask::MakeSpecializations { module_id, .. } => {
-                                format!("BuildTask::MakeSpecializations({:?})", module_id)
+                                format!("BuildTask::MakeSpecializations({module_id:?})")
                             }
                         }
                     );
@@ -3248,8 +3248,7 @@ fn load_package_from_disk<'a>(
                     },
                     _parse_state,
                 )) => Err(LoadingProblem::UnexpectedHeader(format!(
-                    "expected platform/package module, got Interface with header\n{:?}",
-                    header
+                    "expected platform/package module, got Interface with header\n{header:?}"
                 ))),
                 Ok((
                     ast::Module {
@@ -3258,8 +3257,7 @@ fn load_package_from_disk<'a>(
                     },
                     _parse_state,
                 )) => Err(LoadingProblem::UnexpectedHeader(format!(
-                    "expected platform/package module, got Hosted module with header\n{:?}",
-                    header
+                    "expected platform/package module, got Hosted module with header\n{header:?}"
                 ))),
                 Ok((
                     ast::Module {
@@ -3268,8 +3266,7 @@ fn load_package_from_disk<'a>(
                     },
                     _parse_state,
                 )) => Err(LoadingProblem::UnexpectedHeader(format!(
-                    "expected platform/package module, got App with header\n{:?}",
-                    header
+                    "expected platform/package module, got App with header\n{header:?}"
                 ))),
                 Ok((
                     ast::Module {
@@ -3402,10 +3399,7 @@ fn load_builtin_module_help<'a>(
             (info, parse_state)
         }
         Ok(_) => panic!("invalid header format for builtin module"),
-        Err(e) => panic!(
-            "Hit a parse error in the header of {:?}:\n{:?}",
-            filename, e
-        ),
+        Err(e) => panic!("Hit a parse error in the header of {filename:?}:\n{e:?}"),
     }
 }
 
@@ -5583,8 +5577,7 @@ fn build_pending_specializations<'a>(
                             }
                             LayoutProblem::UnresolvedTypeVar(v) => {
                                 let message = format!(
-                                    "top level function has unresolved type variable {:?}",
-                                    v
+                                    "top level function has unresolved type variable {v:?}"
                                 );
                                 procs_base
                                     .runtime_errors
@@ -5664,8 +5657,7 @@ fn build_pending_specializations<'a>(
                             }
                             LayoutProblem::UnresolvedTypeVar(v) => {
                                 let message = format!(
-                                    "top level function has unresolved type variable {:?}",
-                                    v
+                                    "top level function has unresolved type variable {v:?}"
                                 );
                                 procs_base
                                     .runtime_errors
@@ -5702,14 +5694,13 @@ fn build_pending_specializations<'a>(
                 use roc_can::pattern::Pattern;
                 let symbol = match &loc_pattern.value {
                     Pattern::Identifier(_) => {
-                        debug_assert!(false, "identifier ended up in Destructure {:?}", symbol);
+                        debug_assert!(false, "identifier ended up in Destructure {symbol:?}");
                         symbol
                     }
                     Pattern::AbilityMemberSpecialization { ident, specializes } => {
                         debug_assert!(
                             false,
-                            "ability member ended up in Destructure {:?} specializes {:?}",
-                            ident, specializes
+                            "ability member ended up in Destructure {ident:?} specializes {specializes:?}"
                         );
                         symbol
                     }
@@ -5741,8 +5732,7 @@ fn build_pending_specializations<'a>(
                             }
                             LayoutProblem::UnresolvedTypeVar(v) => {
                                 let message = format!(
-                                    "top level function has unresolved type variable {:?}",
-                                    v
+                                    "top level function has unresolved type variable {v:?}"
                                 );
                                 procs_base
                                     .runtime_errors
@@ -5808,8 +5798,7 @@ fn build_pending_specializations<'a>(
                             }
                             LayoutProblem::UnresolvedTypeVar(v) => {
                                 let message = format!(
-                                    "top level function has unresolved type variable {:?}",
-                                    v
+                                    "top level function has unresolved type variable {v:?}"
                                 );
                                 procs_base
                                     .runtime_errors
@@ -5881,8 +5870,7 @@ fn build_pending_specializations<'a>(
                             }
                             LayoutProblem::UnresolvedTypeVar(v) => {
                                 let message = format!(
-                                    "top level function has unresolved type variable {:?}",
-                                    v
+                                    "top level function has unresolved type variable {v:?}"
                                 );
                                 procs_base
                                     .runtime_errors

--- a/crates/compiler/load_internal/src/work.rs
+++ b/crates/compiler/load_internal/src/work.rs
@@ -67,8 +67,7 @@ impl MakeSpecializationsDependents {
         let entry = self.entry(module_id);
         debug_assert!(
             entry.succ.is_empty(),
-            "already added successors for module '{:?}'",
-            module_id
+            "already added successors for module '{module_id:?}'"
         );
 
         entry.succ.extend(succ.into_iter());
@@ -516,8 +515,7 @@ impl<'a> Dependencies<'a> {
         debug_assert_eq!(
             make_specializations_dependents.0.len(),
             default_make_specializations_dependents_len,
-            "more modules were added to the graph: {:?}",
-            make_specializations_dependents
+            "more modules were added to the graph: {make_specializations_dependents:?}"
         );
 
         output
@@ -567,8 +565,7 @@ impl<'a> Dependencies<'a> {
         debug_assert_eq!(
             make_specializations_dependents.0.len(),
             default_make_specializations_dependents_len,
-            "more modules were added to the graph: {:?}",
-            make_specializations_dependents
+            "more modules were added to the graph: {make_specializations_dependents:?}"
         );
 
         output

--- a/crates/compiler/load_internal/tests/test_load.rs
+++ b/crates/compiler/load_internal/tests/test_load.rs
@@ -106,9 +106,9 @@ fn multiple_modules(subdir: &str, files: Vec<(&str, &str)>) -> Result<LoadedModu
     let arena = &arena;
 
     match multiple_modules_help(subdir, arena, files) {
-        Err(io_error) => panic!("IO trouble: {:?}", io_error),
+        Err(io_error) => panic!("IO trouble: {io_error:?}"),
         Ok(Err(LoadingProblem::FormattedReport(buf))) => Err(buf),
-        Ok(Err(loading_problem)) => Err(format!("{:?}", loading_problem)),
+        Ok(Err(loading_problem)) => Err(format!("{loading_problem:?}")),
         Ok(Ok(mut loaded_module)) => {
             let home = loaded_module.module_id;
             let (filepath, src) = loaded_module.sources.get(&home).unwrap();
@@ -148,7 +148,7 @@ fn multiple_modules_help<'a>(
     // Use a deterministic temporary directory.
     // We can't have all tests use "tmp" because tests run in parallel,
     // so append the test name to the tmp path.
-    let tmp = format!("tmp/{}", subdir);
+    let tmp = format!("tmp/{subdir}");
     let dir = roc_test_utils::TmpDir::new(&tmp);
 
     let app_module = files.pop().unwrap();
@@ -162,7 +162,7 @@ fn multiple_modules_help<'a>(
         fs::create_dir_all(file_path.parent().unwrap())?;
 
         let mut file = File::create(file_path)?;
-        writeln!(file, "{}", source)?;
+        writeln!(file, "{source}")?;
         file_handles.push(file);
     }
 
@@ -173,7 +173,7 @@ fn multiple_modules_help<'a>(
         let file_path = dir.path().join(filename);
         let full_file_path = file_path.clone();
         let mut file = File::create(file_path)?;
-        writeln!(file, "{}", source)?;
+        writeln!(file, "{source}")?;
         file_handles.push(file);
 
         load_and_typecheck(arena, full_file_path, Default::default(), TARGET_INFO)
@@ -188,16 +188,16 @@ fn load_fixture(
     subs_by_module: ExposedByModule,
 ) -> LoadedModule {
     let src_dir = fixtures_dir().join(dir_name);
-    let filename = src_dir.join(format!("{}.roc", module_name));
+    let filename = src_dir.join(format!("{module_name}.roc"));
     let arena = Bump::new();
     let loaded = load_and_typecheck(&arena, filename, subs_by_module, TARGET_INFO);
     let mut loaded_module = match loaded {
         Ok(x) => x,
         Err(roc_load_internal::file::LoadingProblem::FormattedReport(report)) => {
-            println!("{}", report);
+            println!("{report}");
             panic!("{}", report);
         }
-        Err(e) => panic!("{:?}", e),
+        Err(e) => panic!("{e:?}"),
     };
 
     let home = loaded_module.module_id;
@@ -258,7 +258,7 @@ fn expect_types(mut loaded_module: LoadedModule, mut expected_types: HashMap<&st
                 let expected_type = expected_types
                     .remove(fully_qualified.as_str())
                     .unwrap_or_else(|| {
-                        panic!("Defs included an unexpected symbol: {:?}", fully_qualified)
+                        panic!("Defs included an unexpected symbol: {fully_qualified:?}")
                     });
 
                 assert_eq!((&symbol, expected_type), (&symbol, actual_str.as_str()));
@@ -273,7 +273,7 @@ fn expect_types(mut loaded_module: LoadedModule, mut expected_types: HashMap<&st
                     let expected_type = expected_types
                         .remove(fully_qualified.as_str())
                         .unwrap_or_else(|| {
-                            panic!("Defs included an unexpected symbol: {:?}", fully_qualified)
+                            panic!("Defs included an unexpected symbol: {fully_qualified:?}")
                         });
 
                     assert_eq!((&symbol, expected_type), (&symbol, actual_str.as_str()));
@@ -705,8 +705,7 @@ fn platform_does_not_exist() {
             // assert!(report.contains("FILE NOT FOUND"), "report=({})", report);
             assert!(
                 report.contains("zzz-does-not-exist/main.roc"),
-                "report=({})",
-                report
+                "report=({report})"
             );
         }
         Ok(_) => unreachable!("we expect failure here"),

--- a/crates/compiler/module/src/symbol.rs
+++ b/crates/compiler/module/src/symbol.rs
@@ -172,7 +172,7 @@ impl Symbol {
 
     #[cfg(debug_assertions)]
     pub fn contains(self, needle: &str) -> bool {
-        format!("{:?}", self).contains(needle)
+        format!("{self:?}").contains(needle)
     }
 }
 
@@ -194,7 +194,7 @@ impl fmt::Debug for Symbol {
             match DEBUG_IDENT_IDS_BY_MODULE_ID.lock() {
                 Ok(names) => match &names.get(&(module_id.to_zero_indexed() as u32)) {
                     Some(ident_ids) => match ident_ids.get_name(ident_id) {
-                        Some(ident_str) => write!(f, "`{:?}.{}`", module_id, ident_str),
+                        Some(ident_str) => write!(f, "`{module_id:?}.{ident_str}`"),
                         None => fallback_debug_fmt(*self, f),
                     },
                     None => fallback_debug_fmt(*self, f),
@@ -207,7 +207,7 @@ impl fmt::Debug for Symbol {
                     use std::io::Write;
 
                     let mut stderr = std::io::stderr();
-                    writeln!(stderr, "DEBUG INFO: Failed to acquire lock for Debug reading from DEBUG_IDENT_IDS_BY_MODULE_ID, presumably because a thread panicked: {:?}", err).unwrap();
+                    writeln!(stderr, "DEBUG INFO: Failed to acquire lock for Debug reading from DEBUG_IDENT_IDS_BY_MODULE_ID, presumably because a thread panicked: {err:?}").unwrap();
 
                     fallback_debug_fmt(*self, f)
                 }
@@ -229,7 +229,7 @@ impl fmt::Display for Symbol {
         let ident_id = self.ident_id();
 
         match ident_id {
-            IdentId(value) => write!(f, "{:?}.{:?}", module_id, value),
+            IdentId(value) => write!(f, "{module_id:?}.{value:?}"),
         }
     }
 }
@@ -244,7 +244,7 @@ fn fallback_debug_fmt(symbol: Symbol, f: &mut fmt::Formatter) -> fmt::Result {
     let module_id = symbol.module_id();
     let ident_id = symbol.ident_id();
 
-    write!(f, "`{:?}.{:?}`", module_id, ident_id)
+    write!(f, "`{module_id:?}.{ident_id:?}`")
 }
 
 /// This is used in Debug builds only, to let us have a Debug instance
@@ -312,8 +312,8 @@ pub fn get_module_ident_ids<'a>(
     all_ident_ids
         .get(module_id)
         .with_context(|| ModuleIdNotFoundSnafu {
-            module_id: format!("{:?}", module_id),
-            all_ident_ids: format!("{:?}", all_ident_ids),
+            module_id: format!("{module_id:?}"),
+            all_ident_ids: format!("{all_ident_ids:?}"),
         })
 }
 
@@ -324,7 +324,7 @@ pub fn get_module_ident_ids_mut<'a>(
     all_ident_ids
         .get_mut(module_id)
         .with_context(|| ModuleIdNotFoundSnafu {
-            module_id: format!("{:?}", module_id),
+            module_id: format!("{module_id:?}"),
             all_ident_ids: "I could not return all_ident_ids here because of borrowing issues.",
         })
 }
@@ -400,7 +400,7 @@ impl fmt::Debug for ModuleId {
 
         if PRETTY_PRINT_DEBUG_SYMBOLS {
             match names.try_get(self.to_zero_indexed()) {
-                Some(str_ref) => write!(f, "{}", str_ref),
+                Some(str_ref) => write!(f, "{str_ref}"),
                 None => {
                     internal_error!(
                         "Could not find a Debug name for module ID {} in {:?}",
@@ -645,7 +645,7 @@ impl IdentIds {
     pub fn update_key(&mut self, old_name: &str, new_name: &str) -> Result<IdentId, String> {
         match self.interner.find_and_update(old_name, new_name) {
             Some(index) => Ok(IdentId(index as u32)),
-            None => Err(format!("The identifier {:?} is not in IdentIds", old_name)),
+            None => Err(format!("The identifier {old_name:?} is not in IdentIds")),
         }
     }
 
@@ -682,7 +682,7 @@ impl IdentIds {
         self.get_name(ident_id)
             .with_context(|| IdentIdNotFoundSnafu {
                 ident_id,
-                ident_ids_str: format!("{:?}", self),
+                ident_ids_str: format!("{self:?}"),
             })
     }
 

--- a/crates/compiler/mono/src/code_gen_help/equality.rs
+++ b/crates/compiler/mono/src/code_gen_help/equality.rs
@@ -138,7 +138,7 @@ fn eq_struct<'a>(
 ) -> Stmt<'a> {
     let mut else_stmt = Stmt::Ret(Symbol::BOOL_TRUE);
     for (i, layout) in field_layouts.iter().enumerate().rev() {
-        let field1_sym = root.create_symbol(ident_ids, &format!("field_1_{}", i));
+        let field1_sym = root.create_symbol(ident_ids, &format!("field_1_{i}"));
         let field1_expr = Expr::StructAtIndex {
             index: i as u64,
             field_layouts,
@@ -146,7 +146,7 @@ fn eq_struct<'a>(
         };
         let field1_stmt = |next| Stmt::Let(field1_sym, field1_expr, *layout, next);
 
-        let field2_sym = root.create_symbol(ident_ids, &format!("field_2_{}", i));
+        let field2_sym = root.create_symbol(ident_ids, &format!("field_2_{i}"));
         let field2_expr = Expr::StructAtIndex {
             index: i as u64,
             field_layouts,
@@ -164,7 +164,7 @@ fn eq_struct<'a>(
             )
             .unwrap();
 
-        let eq_call_name = format!("eq_call_{}", i);
+        let eq_call_name = format!("eq_call_{i}");
         let eq_call_sym = root.create_symbol(ident_ids, &eq_call_name);
         let eq_call_stmt = |next| Stmt::Let(eq_call_sym, eq_call_expr, LAYOUT_BOOL, next);
 
@@ -488,8 +488,8 @@ fn eq_tag_fields<'a>(
         Some(i) => {
             // Implement tail recursion on this RecursivePointer,
             // in the innermost `else` clause after all other fields have been checked
-            let field1_sym = root.create_symbol(ident_ids, &format!("field_1_{}_{}", tag_id, i));
-            let field2_sym = root.create_symbol(ident_ids, &format!("field_2_{}_{}", tag_id, i));
+            let field1_sym = root.create_symbol(ident_ids, &format!("field_1_{tag_id}_{i}"));
+            let field2_sym = root.create_symbol(ident_ids, &format!("field_2_{tag_id}_{i}"));
 
             let field1_expr = Expr::UnionAtIndex {
                 union_layout,
@@ -533,8 +533,8 @@ fn eq_tag_fields<'a>(
             continue; // the tail-recursive field is handled elsewhere
         }
 
-        let field1_sym = root.create_symbol(ident_ids, &format!("field_1_{}_{}", tag_id, i));
-        let field2_sym = root.create_symbol(ident_ids, &format!("field_2_{}_{}", tag_id, i));
+        let field1_sym = root.create_symbol(ident_ids, &format!("field_1_{tag_id}_{i}"));
+        let field2_sym = root.create_symbol(ident_ids, &format!("field_2_{tag_id}_{i}"));
 
         let field1_expr = Expr::UnionAtIndex {
             union_layout,
@@ -560,7 +560,7 @@ fn eq_tag_fields<'a>(
             )
             .unwrap();
 
-        let eq_call_name = format!("eq_call_{}", i);
+        let eq_call_name = format!("eq_call_{i}");
         let eq_call_sym = root.create_symbol(ident_ids, &eq_call_name);
 
         stmt = Stmt::Let(

--- a/crates/compiler/mono/src/code_gen_help/mod.rs
+++ b/crates/compiler/mono/src/code_gen_help/mod.rs
@@ -783,7 +783,7 @@ impl<'a> CallerProc<'a> {
                 .pretty(80)
                 .to_string();
 
-            println!("{}", doc);
+            println!("{doc}");
         }
 
         Self {

--- a/crates/compiler/mono/src/code_gen_help/refcount.rs
+++ b/crates/compiler/mono/src/code_gen_help/refcount.rs
@@ -1276,7 +1276,7 @@ fn refcount_struct<'a>(
 
     for (i, field_layout) in field_layouts.iter().enumerate().rev() {
         if layout_interner.contains_refcounted(*field_layout) {
-            let field_val = root.create_symbol(ident_ids, &format!("field_val_{}", i));
+            let field_val = root.create_symbol(ident_ids, &format!("field_val_{i}"));
             let field_val_expr = Expr::StructAtIndex {
                 index: i as u64,
                 field_layouts,
@@ -1284,7 +1284,7 @@ fn refcount_struct<'a>(
             };
             let field_val_stmt = |next| Stmt::Let(field_val, field_val_expr, *field_layout, next);
 
-            let mod_unit = root.create_symbol(ident_ids, &format!("mod_field_{}", i));
+            let mod_unit = root.create_symbol(ident_ids, &format!("mod_field_{i}"));
             let mod_args = refcount_args(root, ctx, field_val);
             let mod_expr = root
                 .call_specialized_op(ident_ids, ctx, layout_interner, *field_layout, mod_args)
@@ -1758,7 +1758,7 @@ fn refcount_union_tailrec<'a>(
                             filtered.push((i, *field));
                         } else {
                             let field_val =
-                                root.create_symbol(ident_ids, &format!("field_{}_{}", tag_id, i));
+                                root.create_symbol(ident_ids, &format!("field_{tag_id}_{i}"));
                             let field_val_expr = Expr::UnionAtIndex {
                                 union_layout,
                                 tag_id,
@@ -1896,7 +1896,7 @@ fn refcount_tag_fields<'a>(
 
     for (i, field_layout) in field_layouts.iter().rev() {
         if layout_interner.contains_refcounted(*field_layout) {
-            let field_val = root.create_symbol(ident_ids, &format!("field_{}_{}", tag_id, i));
+            let field_val = root.create_symbol(ident_ids, &format!("field_{tag_id}_{i}"));
             let field_val_expr = Expr::UnionAtIndex {
                 union_layout,
                 tag_id,
@@ -1905,7 +1905,7 @@ fn refcount_tag_fields<'a>(
             };
             let field_val_stmt = |next| Stmt::Let(field_val, field_val_expr, *field_layout, next);
 
-            let mod_unit = root.create_symbol(ident_ids, &format!("mod_field_{}_{}", tag_id, i));
+            let mod_unit = root.create_symbol(ident_ids, &format!("mod_field_{tag_id}_{i}"));
             let mod_args = refcount_args(root, ctx, field_val);
             let mod_expr = root
                 .call_specialized_op(ident_ids, ctx, layout_interner, *field_layout, mod_args)

--- a/crates/compiler/mono/src/debug/report.rs
+++ b/crates/compiler/mono/src/debug/report.rs
@@ -62,7 +62,7 @@ where
         .pretty(80)
         .to_string();
 
-    eprintln!("Full source: {}", src);
+    eprintln!("Full source: {src}");
 
     let interpolated_docs = stack(
         f,

--- a/crates/compiler/mono/src/drop_specialization.rs
+++ b/crates/compiler/mono/src/drop_specialization.rs
@@ -806,7 +806,7 @@ fn specialize_struct<'a, 'i>(
                         // This value has not been index before, create a new symbol.
                         None => {
                             let field_symbol =
-                                environment.create_symbol(ident_ids, &format!("field_val_{}", i));
+                                environment.create_symbol(ident_ids, &format!("field_val_{i}"));
 
                             let field_val_expr = Expr::StructAtIndex {
                                 index: i as u64,
@@ -945,7 +945,7 @@ fn specialize_union<'a, 'i>(
                                         Some(rc) => {
                                             let field_symbol = environment.create_symbol(
                                                 ident_ids,
-                                                &format!("field_val_{}", i),
+                                                &format!("field_val_{i}"),
                                             );
 
                                             let field_val_expr = Expr::UnionAtIndex {
@@ -1134,11 +1134,11 @@ fn specialize_list<'a, 'i>(
                             // If the symbol is unknown, we have to get the value from the list.
                             // Should only happen when list elements are discarded.
                             None => {
-                                let field_symbol = environment
-                                    .create_symbol(ident_ids, &format!("field_val_{}", i));
+                                let field_symbol =
+                                    environment.create_symbol(ident_ids, &format!("field_val_{i}"));
 
-                                let index_symbol = environment
-                                    .create_symbol(ident_ids, &format!("index_val_{}", i));
+                                let index_symbol =
+                                    environment.create_symbol(ident_ids, &format!("index_val_{i}"));
 
                                 let dec = arena.alloc(Stmt::Refcounting(
                                     ModifyRc::Dec(field_symbol),

--- a/crates/compiler/mono/src/drop_specialization.rs
+++ b/crates/compiler/mono/src/drop_specialization.rs
@@ -1427,7 +1427,7 @@ impl<'a> DropSpecializationEnvironment<'a> {
         }
     }
 
-    fn create_symbol<'i>(&self, ident_ids: &'i mut IdentIds, debug_name: &str) -> Symbol {
+    fn create_symbol(&self, ident_ids: &mut IdentIds, debug_name: &str) -> Symbol {
         let ident_id = ident_ids.add_str(debug_name);
         Symbol::new(self.home, ident_id)
     }

--- a/crates/compiler/mono/src/ir.rs
+++ b/crates/compiler/mono/src/ir.rs
@@ -181,8 +181,7 @@ impl<'a> PartialProcs<'a> {
     pub fn insert(&mut self, symbol: Symbol, partial_proc: PartialProc<'a>) -> PartialProcId {
         debug_assert!(
             !self.contains_key(symbol),
-            "The {:?} is inserted as a partial proc twice: that's a bug!",
-            symbol,
+            "The {symbol:?} is inserted as a partial proc twice: that's a bug!",
         );
 
         let id = PartialProcId(self.symbols.len());
@@ -675,7 +674,7 @@ impl<'a> Specialized<'a> {
                 } else {
                     match in_progress {
                         InProgressProc::InProgress => {
-                            panic!("Function {:?} ({:?}) is not done specializing", s, l)
+                            panic!("Function {s:?} ({l:?}) is not done specializing")
                         }
                         InProgressProc::Done(proc) => Some((s, l, proc)),
                     }
@@ -838,11 +837,7 @@ impl<'a> SymbolSpecializations<'a> {
     /// Only those bound to number literals can be compiled polymorphically.
     fn mark_eligible(&mut self, symbol: Symbol) {
         let _old = self.0.insert(symbol, VecMap::with_capacity(1));
-        debug_assert!(
-            _old.is_none(),
-            "overwriting specializations for {:?}",
-            symbol
-        );
+        debug_assert!(_old.is_none(), "overwriting specializations for {symbol:?}");
     }
 
     /// Removes all specializations for a symbol, returning the type and symbol of each specialization.
@@ -945,8 +940,7 @@ impl<'a> Procs<'a> {
             .expect("specialization stack is empty");
         debug_assert_eq!(
             popped, specialization,
-            "incorrect popped specialization: passed {:?}, but was {:?}",
-            specialization, popped
+            "incorrect popped specialization: passed {specialization:?}, but was {popped:?}"
         );
     }
 
@@ -1026,7 +1020,7 @@ impl<'a> Procs<'a> {
     ) -> Result<ProcLayout<'a>, RuntimeError> {
         let raw_layout = layout_cache
             .raw_from_var(env.arena, annotation, env.subs)
-            .unwrap_or_else(|err| panic!("TODO turn fn_var into a RuntimeError {:?}", err));
+            .unwrap_or_else(|err| panic!("TODO turn fn_var into a RuntimeError {err:?}"));
 
         let top_level = ProcLayout::from_raw_named(env.arena, name, raw_layout);
 
@@ -1054,7 +1048,7 @@ impl<'a> Procs<'a> {
                 // if we've already specialized this one, no further work is needed.
                 if !already_specialized {
                     if self.is_module_thunk(name.name()) {
-                        debug_assert!(layout.arguments.is_empty(), "{:?}", name);
+                        debug_assert!(layout.arguments.is_empty(), "{name:?}");
                     }
 
                     let needs_suspended_specialization =
@@ -1145,7 +1139,7 @@ impl<'a> Procs<'a> {
                                     );
                                 }
                                 Err(error) => {
-                                    panic!("TODO generate a RuntimeError message for {:?}", error);
+                                    panic!("TODO generate a RuntimeError message for {error:?}");
                                 }
                             }
                         }
@@ -1234,7 +1228,7 @@ impl<'a> Procs<'a> {
                             .insert_specialized(proc_name.name(), proc_layout, proc);
                     }
                     Err(error) => {
-                        panic!("TODO generate a RuntimeError message for {:?}", error);
+                        panic!("TODO generate a RuntimeError message for {error:?}");
                     }
                 }
             }
@@ -1918,13 +1912,13 @@ pub(crate) fn symbol_to_doc_string(symbol: Symbol, force_pretty: bool) -> String
     use roc_module::ident::ModuleName;
 
     if pretty_print_ir_symbols() || force_pretty {
-        format!("{:?}", symbol)
+        format!("{symbol:?}")
     } else {
-        let text = format!("{}", symbol);
+        let text = format!("{symbol}");
 
         if text.starts_with(ModuleName::APP) {
             let name: String = text.trim_start_matches(ModuleName::APP).into();
-            format!("Test{}", name)
+            format!("Test{name}")
         } else {
             text
         }
@@ -2016,7 +2010,7 @@ impl<'a> Expr<'a> {
                 .text("Reset { symbol: ")
                 .append(symbol_to_doc(alloc, *symbol, pretty))
                 .append(", id: ")
-                .append(format!("{:?}", update_mode))
+                .append(format!("{update_mode:?}"))
                 .append(" }"),
             ResetRef {
                 symbol,
@@ -2025,7 +2019,7 @@ impl<'a> Expr<'a> {
                 .text("ResetRef { symbol: ")
                 .append(symbol_to_doc(alloc, *symbol, pretty))
                 .append(", id: ")
-                .append(format!("{:?}", update_mode))
+                .append(format!("{update_mode:?}"))
                 .append(" }"),
             Struct(args) => {
                 let it = args.iter().map(|s| symbol_to_doc(alloc, *s, pretty));
@@ -3036,7 +3030,7 @@ fn specialize_external_help<'a>(
     let partial_proc_id = match procs.partial_procs.symbol_to_id(name.name()) {
         Some(v) => v,
         None => {
-            panic!("Cannot find a partial proc for {:?}", name);
+            panic!("Cannot find a partial proc for {name:?}");
         }
     };
 
@@ -3765,8 +3759,7 @@ fn build_specialized_proc<'a>(
             debug_assert_eq!(
                 pattern_layouts_len + 1,
                 pattern_symbols.len(),
-                "Tried to zip two vecs with different lengths in {:?}!",
-                proc_name,
+                "Tried to zip two vecs with different lengths in {proc_name:?}!",
             );
 
             let proc_args = proc_args.into_bump_slice();
@@ -3806,14 +3799,12 @@ fn build_specialized_proc<'a>(
                         // so far, the problem when hitting this branch was always somewhere else
                         // I think this branch should not be reachable in a bugfree compiler
                         panic!(
-                            "more arguments (according to the layout) than argument symbols for {:?}",
-                            proc_name
+                            "more arguments (according to the layout) than argument symbols for {proc_name:?}"
                         )
                     }
                 }
                 Ordering::Less => panic!(
-                    "more argument symbols than arguments (according to the layout) for {:?}",
-                    proc_name
+                    "more argument symbols than arguments (according to the layout) for {proc_name:?}"
                 ),
             }
         }
@@ -3845,14 +3836,12 @@ fn build_specialized_proc<'a>(
                         // so far, the problem when hitting this branch was always somewhere else
                         // I think this branch should not be reachable in a bugfree compiler
                         panic!(
-                            "more arguments (according to the layout) than argument symbols for {:?}",
-                            proc_name
+                            "more arguments (according to the layout) than argument symbols for {proc_name:?}"
                         )
                     }
                 }
                 Ordering::Less => panic!(
-                    "more argument symbols than arguments (according to the layout) for {:?}",
-                    proc_name
+                    "more argument symbols than arguments (according to the layout) for {proc_name:?}"
                 ),
             }
         }
@@ -3881,7 +3870,7 @@ fn specialize_variable<'a>(
     // TODO: can we get rid of raw entirely?
     let raw = layout_cache
         .raw_from_var(env.arena, fn_var, env.subs)
-        .unwrap_or_else(|err| panic!("TODO handle invalid function {:?}", err));
+        .unwrap_or_else(|err| panic!("TODO handle invalid function {err:?}"));
 
     let raw = if procs.is_module_thunk(proc_name.name()) {
         match raw {
@@ -4043,7 +4032,7 @@ fn specialize_naked_symbol<'a>(
         return result;
     } else if env.is_imported_symbol(symbol) {
         match layout_cache.from_var(env.arena, variable, env.subs) {
-            Err(e) => panic!("invalid layout {:?}", e),
+            Err(e) => panic!("invalid layout {e:?}"),
             Ok(_) => {
                 // this is a 0-arity thunk
                 let result = call_by_name(
@@ -4573,7 +4562,7 @@ pub fn with_hole<'a>(
                         let layout = layout_cache
                             .from_var(env.arena, branch_var, env.subs)
                             .unwrap_or_else(|err| {
-                                panic!("TODO turn fn_var into a RuntimeError {:?}", err)
+                                panic!("TODO turn fn_var into a RuntimeError {err:?}")
                             });
 
                         let param = Param {
@@ -4639,7 +4628,7 @@ pub fn with_hole<'a>(
 
             let layout = layout_cache
                 .from_var(env.arena, expr_var, env.subs)
-                .unwrap_or_else(|err| panic!("TODO turn fn_var into a RuntimeError {:?}", err));
+                .unwrap_or_else(|err| panic!("TODO turn fn_var into a RuntimeError {err:?}"));
 
             let param = Param {
                 symbol: assigned,
@@ -4692,7 +4681,7 @@ pub fn with_hole<'a>(
 
             let elem_layout = layout_cache
                 .from_var(env.arena, elem_var, env.subs)
-                .unwrap_or_else(|err| panic!("TODO turn fn_var into a RuntimeError {:?}", err));
+                .unwrap_or_else(|err| panic!("TODO turn fn_var into a RuntimeError {err:?}"));
 
             for arg_expr in loc_elems.into_iter() {
                 if let Some(literal) =
@@ -5033,7 +5022,7 @@ pub fn with_hole<'a>(
 
             let record_layout = layout_cache
                 .from_var(env.arena, record_var, env.subs)
-                .unwrap_or_else(|err| panic!("TODO turn fn_var into a RuntimeError {:?}", err));
+                .unwrap_or_else(|err| panic!("TODO turn fn_var into a RuntimeError {err:?}"));
 
             let field_layouts = match layout_cache.get_repr(record_layout) {
                 LayoutRepr::Struct(field_layouts) => field_layouts,
@@ -5181,7 +5170,7 @@ pub fn with_hole<'a>(
                     if let Err(e) = inserted {
                         return runtime_error(
                             env,
-                            env.arena.alloc(format!("RuntimeError: {:?}", e,)),
+                            env.arena.alloc(format!("RuntimeError: {e:?}",)),
                         );
                     } else {
                         drop(inserted);
@@ -5754,7 +5743,7 @@ fn compile_struct_like_access<'a>(
 
             let layout = layout_cache
                 .from_var(env.arena, elem_var, env.subs)
-                .unwrap_or_else(|err| panic!("TODO turn fn_var into a RuntimeError {:?}", err));
+                .unwrap_or_else(|err| panic!("TODO turn fn_var into a RuntimeError {err:?}"));
 
             Stmt::Let(assigned, expr, layout, hole)
         }
@@ -6197,7 +6186,7 @@ fn convert_tag_union<'a>(
             // Layout will unpack this unwrapped tack if it only has one (non-zero-sized) field
             let layout = layout_cache
                 .from_var(env.arena, variant_var, env.subs)
-                .unwrap_or_else(|err| panic!("TODO turn fn_var into a RuntimeError {:?}", err));
+                .unwrap_or_else(|err| panic!("TODO turn fn_var into a RuntimeError {err:?}"));
 
             // even though this was originally a Tag, we treat it as a Struct from now on
             let stmt = if let [only_field] = field_symbols {
@@ -6231,7 +6220,7 @@ fn convert_tag_union<'a>(
                 // Layout will unpack this unwrapped tack if it only has one (non-zero-sized) field
                 let layout = layout_cache
                     .from_var(env.arena, variant_var, env.subs)
-                    .unwrap_or_else(|err| panic!("TODO turn fn_var into a RuntimeError {:?}", err));
+                    .unwrap_or_else(|err| panic!("TODO turn fn_var into a RuntimeError {err:?}"));
 
                 // even though this was originally a Tag, we treat it as a Struct from now on
                 let stmt = if let [only_field] = field_symbols {
@@ -6496,8 +6485,7 @@ fn tag_union_to_function<'a>(
         Err(e) => runtime_error(
             env,
             env.arena.alloc(format!(
-                "Could not produce tag function due to a runtime error: {:?}",
-                e,
+                "Could not produce tag function due to a runtime error: {e:?}",
             )),
         ),
     }
@@ -8284,17 +8272,13 @@ fn call_by_name<'a>(
     match layout_cache.raw_from_var(env.arena, fn_var, env.subs) {
         Err(LayoutProblem::UnresolvedTypeVar(var)) => {
             let msg = format!(
-                "Hit an unresolved type variable {:?} when creating a layout for {:?} (var {:?})",
-                var, proc_name, fn_var
+                "Hit an unresolved type variable {var:?} when creating a layout for {proc_name:?} (var {fn_var:?})"
             );
 
             evaluate_arguments_then_runtime_error(env, procs, layout_cache, msg, loc_args)
         }
         Err(LayoutProblem::Erroneous) => {
-            let msg = format!(
-                "Hit an erroneous type when creating a layout for {:?}",
-                proc_name
-            );
+            let msg = format!("Hit an erroneous type when creating a layout for {proc_name:?}");
 
             evaluate_arguments_then_runtime_error(env, procs, layout_cache, msg, loc_args)
         }
@@ -8446,9 +8430,7 @@ fn call_by_name_help<'a>(
         Some(name) => {
             debug_assert!(
                 iter_lambda_names.next().is_none(),
-                "Somehow, call by name for {:?} has multiple capture niches: {:?}",
-                proc_name,
-                lambda_set
+                "Somehow, call by name for {proc_name:?} has multiple capture niches: {lambda_set:?}"
             );
             name
         }
@@ -8487,8 +8469,7 @@ fn call_by_name_help<'a>(
         debug_assert_eq!(
             argument_layouts.len(),
             field_symbols.len(),
-            "see call_by_name for background (scroll down a bit), function is {:?}",
-            proc_name,
+            "see call_by_name for background (scroll down a bit), function is {proc_name:?}",
         );
         call_specialized_proc(
             env,
@@ -8539,8 +8520,7 @@ fn call_by_name_help<'a>(
             debug_assert_eq!(
                 argument_layouts.len(),
                 field_symbols.len(),
-                "see call_by_name for background (scroll down a bit), function is {:?}",
-                proc_name,
+                "see call_by_name for background (scroll down a bit), function is {proc_name:?}",
             );
 
             let field_symbols = field_symbols.into_bump_slice();
@@ -8592,8 +8572,7 @@ fn call_by_name_help<'a>(
                 debug_assert_eq!(
                     argument_layouts.len(),
                     field_symbols.len(),
-                    "see call_by_name for background (scroll down a bit), function is {:?}",
-                    proc_name,
+                    "see call_by_name for background (scroll down a bit), function is {proc_name:?}",
                 );
 
                 let field_symbols = field_symbols.into_bump_slice();
@@ -8784,8 +8763,7 @@ fn call_by_name_module_thunk<'a>(
                             Ok((proc, raw_layout)) => {
                                 debug_assert!(
                                     raw_layout.is_zero_argument_thunk(),
-                                    "but actually {:?}",
-                                    raw_layout
+                                    "but actually {raw_layout:?}"
                                 );
 
                                 let was_present = procs
@@ -9044,10 +9022,9 @@ where
             }
             None => {
                 eprintln!(
-                    "a function passed to `{:?}` LowLevel call has an empty lambda set!
+                    "a function passed to `{op:?}` LowLevel call has an empty lambda set!
                      The most likely reason is that some symbol you use is not in scope.
-                    ",
-                    op
+                    "
                 );
 
                 hole.clone()
@@ -10073,7 +10050,7 @@ fn unique_glue_symbol(
     use std::fmt::Write;
     let mut string = bumpalo::collections::String::with_capacity_in(32, arena);
 
-    let _result = write!(&mut string, "roc__getter_{}_{}", module_name, unique_id);
+    let _result = write!(&mut string, "roc__getter_{module_name}_{unique_id}");
     debug_assert_eq!(_result, Ok(())); // This should never fail, but doesn't hurt to debug-check!
 
     let bump_string = string.into_bump_str();

--- a/crates/compiler/mono/src/ir.rs
+++ b/crates/compiler/mono/src/ir.rs
@@ -74,8 +74,8 @@ roc_error_macros::assert_sizeof_wasm!(Call, 44);
 roc_error_macros::assert_sizeof_wasm!(CallType, 36);
 
 roc_error_macros::assert_sizeof_non_wasm!(Literal, 3 * 8);
-roc_error_macros::assert_sizeof_non_wasm!(Expr, 9 * 8);
-roc_error_macros::assert_sizeof_non_wasm!(Stmt, 12 * 8);
+roc_error_macros::assert_sizeof_non_wasm!(Expr, 10 * 8);
+roc_error_macros::assert_sizeof_non_wasm!(Stmt, 13 * 8);
 roc_error_macros::assert_sizeof_non_wasm!(ProcLayout, 5 * 8);
 roc_error_macros::assert_sizeof_non_wasm!(Call, 9 * 8);
 roc_error_macros::assert_sizeof_non_wasm!(CallType, 7 * 8);

--- a/crates/compiler/mono/src/ir/decision_tree.rs
+++ b/crates/compiler/mono/src/ir/decision_tree.rs
@@ -775,8 +775,7 @@ fn to_relevant_branch<'a>(
                 // if there is no test, the pattern should not require any
                 debug_assert!(
                     matches!(pattern, Pattern::Identifier(_) | Pattern::Underscore,),
-                    "{:?}",
-                    pattern,
+                    "{pattern:?}",
                 );
 
                 Some(branch.clone())

--- a/crates/compiler/mono/src/layout.rs
+++ b/crates/compiler/mono/src/layout.rs
@@ -165,8 +165,7 @@ impl<'a> LayoutCache<'a> {
         let Cacheable(value, criteria) = Layout::from_var(&mut env, var);
         debug_assert!(
             criteria.is_cacheable(),
-            "{:?} not cacheable as top-level",
-            value
+            "{value:?} not cacheable as top-level"
         );
         value
     }
@@ -192,8 +191,7 @@ impl<'a> LayoutCache<'a> {
         let Cacheable(value, criteria) = RawFunctionLayout::from_var(&mut env, var);
         debug_assert!(
             criteria.is_cacheable(),
-            "{:?} not cacheable as top-level",
-            value
+            "{value:?} not cacheable as top-level"
         );
         value
     }
@@ -1485,9 +1483,7 @@ impl<'a> LambdaSet<'a> {
     {
         debug_assert!(
             self.contains(function_symbol),
-            "function symbol {:?} not in set {:?}",
-            function_symbol,
-            self
+            "function symbol {function_symbol:?} not in set {self:?}"
         );
 
         let comparator = |other_name: Symbol, other_captures_layouts: &[InLayout<'a>]| {
@@ -3210,10 +3206,7 @@ fn layout_from_flat_type<'a>(
                     Cacheable(Ok(boxed_layout), criteria)
                 }
                 _ => {
-                    panic!(
-                        "TODO layout_from_flat_type for Apply({:?}, {:?})",
-                        symbol, args
-                    );
+                    panic!("TODO layout_from_flat_type for Apply({symbol:?}, {args:?})");
                 }
             }
         }
@@ -3664,7 +3657,7 @@ pub fn union_sorted_tags<'a>(
 
                 Error => return Err(LayoutProblem::Erroneous),
 
-                other => panic!("invalid content in tag union variable: {:?}", other),
+                other => panic!("invalid content in tag union variable: {other:?}"),
             }
         }
     };
@@ -4387,7 +4380,7 @@ pub fn ext_var_is_empty_tag_union(subs: &Subs, tag_ext: TagExt) -> bool {
                 }
                 // So that we can continue compiling in the presence of errors
                 Error => ext_fields.is_empty(),
-                _ => panic!("invalid content in ext_var: {:?}", content),
+                _ => panic!("invalid content in ext_var: {content:?}"),
             }
         }
     }
@@ -4442,17 +4435,14 @@ fn layout_from_num_content<'a>(
             Symbol::NUM_DEC => Ok(Layout::DEC),
 
             _ => {
-                panic!(
-                    "Invalid Num.Num type application: Apply({:?}, {:?})",
-                    symbol, args
-                );
+                panic!("Invalid Num.Num type application: Apply({symbol:?}, {args:?})");
             }
         },
         Alias(_, _, _, _) => {
             todo!("TODO recursively resolve type aliases in num_from_content");
         }
         Structure(_) | RangedNumber(..) | LambdaSet(_) => {
-            panic!("Invalid Num.Num type application: {:?}", content);
+            panic!("Invalid Num.Num type application: {content:?}");
         }
         Error => Err(LayoutProblem::Erroneous),
     };

--- a/crates/compiler/mono/src/reset_reuse.rs
+++ b/crates/compiler/mono/src/reset_reuse.rs
@@ -1404,8 +1404,8 @@ fn drop_unused_reuse_tokens<'a>(
     })
 }
 
-fn get_reuse_layout_info<'a, 'i>(
-    layout_interner: &'i STLayoutInterner<'a>,
+fn get_reuse_layout_info<'a>(
+    layout_interner: &STLayoutInterner<'a>,
     union_layout: UnionLayout<'a>,
 ) -> TokenLayout {
     let (size, alignment) = union_layout.data_size_and_alignment(layout_interner);

--- a/crates/compiler/mono/src/tail_recursion.rs
+++ b/crates/compiler/mono/src/tail_recursion.rs
@@ -501,9 +501,9 @@ where
     candidate_set
 }
 
-fn trmc_candidates_help<'a>(
+fn trmc_candidates_help(
     function_name: LambdaName,
-    stmt: &'_ Stmt<'a>,
+    stmt: &'_ Stmt<'_>,
     candidates: &mut TrmcCandidateSet,
 ) {
     // if this stmt is the literal tail tag application and return, then this is a TRMC opportunity

--- a/crates/compiler/parse/src/ast.rs
+++ b/crates/compiler/parse/src/ast.rs
@@ -743,8 +743,8 @@ impl<'a> CommentOrNewline<'a> {
         use CommentOrNewline::*;
         match self {
             Newline => "\n".to_owned(),
-            LineComment(comment_str) => format!("#{}", comment_str),
-            DocComment(comment_str) => format!("##{}", comment_str),
+            LineComment(comment_str) => format!("#{comment_str}"),
+            DocComment(comment_str) => format!("##{comment_str}"),
         }
     }
 

--- a/crates/compiler/parse/src/state.rs
+++ b/crates/compiler/parse/src/state.rs
@@ -136,7 +136,7 @@ impl<'a> fmt::Debug for State<'a> {
         write!(f, "State {{")?;
 
         match std::str::from_utf8(self.bytes()) {
-            Ok(string) => write!(f, "\n\tbytes: [utf8] {:?}", string)?,
+            Ok(string) => write!(f, "\n\tbytes: [utf8] {string:?}")?,
             Err(_) => write!(f, "\n\tbytes: [invalid utf8] {:?}", self.bytes())?,
         }
 
@@ -151,5 +151,5 @@ fn state_size() {
     // cache line.
     let state_size = std::mem::size_of::<State>();
     let maximum = std::mem::size_of::<usize>() * 8;
-    assert!(state_size <= maximum, "{:?} <= {:?}", state_size, maximum);
+    assert!(state_size <= maximum, "{state_size:?} <= {maximum:?}");
 }

--- a/crates/compiler/parse/tests/test_parse.rs
+++ b/crates/compiler/parse/tests/test_parse.rs
@@ -81,7 +81,7 @@ mod test_parse {
     #[test]
     fn string_with_escaped_char_at_end() {
         parses_with_escaped_char(
-            |esc| format!(r#""abcd{}""#, esc),
+            |esc| format!(r#""abcd{esc}""#),
             |esc, arena| bumpalo::vec![in arena;  Plaintext("abcd"), EscapedChar(esc)],
         );
     }
@@ -89,7 +89,7 @@ mod test_parse {
     #[test]
     fn string_with_escaped_char_in_front() {
         parses_with_escaped_char(
-            |esc| format!(r#""{}abcd""#, esc),
+            |esc| format!(r#""{esc}abcd""#),
             |esc, arena| bumpalo::vec![in arena; EscapedChar(esc), Plaintext("abcd")],
         );
     }
@@ -97,7 +97,7 @@ mod test_parse {
     #[test]
     fn string_with_escaped_char_in_middle() {
         parses_with_escaped_char(
-            |esc| format!(r#""ab{}cd""#, esc),
+            |esc| format!(r#""ab{esc}cd""#),
             |esc, arena| bumpalo::vec![in arena; Plaintext("ab"), EscapedChar(esc), Plaintext("cd")],
         );
     }
@@ -105,7 +105,7 @@ mod test_parse {
     #[test]
     fn string_with_multiple_escaped_chars() {
         parses_with_escaped_char(
-            |esc| format!(r#""{}abc{}de{}fghi{}""#, esc, esc, esc, esc),
+            |esc| format!(r#""{esc}abc{esc}de{esc}fghi{esc}""#),
             |esc, arena| bumpalo::vec![in arena; EscapedChar(esc), Plaintext("abc"), EscapedChar(esc), Plaintext("de"), EscapedChar(esc), Plaintext("fghi"), EscapedChar(esc)],
         );
     }
@@ -247,7 +247,7 @@ mod test_parse {
         // These can potentially be whole numbers. `Display` omits the decimal point for those,
         // causing them to no longer be parsed as fractional numbers by Roc.
         // Using `Debug` instead of `Display` ensures they always have a decimal point.
-        let float_string = format!("{:?}", num);
+        let float_string = format!("{num:?}");
 
         assert_parses_to(float_string.as_str(), Float(float_string.as_str()));
     }
@@ -284,7 +284,7 @@ mod test_parse {
 
         // It should occur twice in the debug output - once for the pattern,
         // and then again for the lookup.
-        let occurrences = format!("{:?}", actual).split("isTest").count() - 1;
+        let occurrences = format!("{actual:?}").split("isTest").count() - 1;
 
         assert_eq!(occurrences, 2);
     }

--- a/crates/compiler/problem/src/can.rs
+++ b/crates/compiler/problem/src/can.rs
@@ -613,11 +613,10 @@ impl RuntimeError {
         match self {
             DegenerateBranch(region) => {
                 format!(
-                    "Hit a branch pattern that does not bind all symbols its body needs, at {:?}",
-                    region
+                    "Hit a branch pattern that does not bind all symbols its body needs, at {region:?}"
                 )
             }
-            err => format!("{:?}", err),
+            err => format!("{err:?}"),
         }
     }
 }

--- a/crates/compiler/region/src/all.rs
+++ b/crates/compiler/region/src/all.rs
@@ -434,10 +434,7 @@ fn test_line_info() {
             } else {
                 "\n" // HACK! pretend there's an extra newline on the end, strictly so we can do the comparison
             };
-            println!(
-                "checking {:?} {:?}, expecting {:?}",
-                input, offset, expected
-            );
+            println!("checking {input:?} {offset:?}, expecting {expected:?}");
             let line_column = info.convert_offset(offset as u32);
             assert!(
                 Some(line_column) > last,

--- a/crates/compiler/solve/src/ability.rs
+++ b/crates/compiler/solve/src/ability.rs
@@ -1322,8 +1322,7 @@ pub fn type_implementing_specialization(
                 .filter(|mia| mia.ability == ability)
                 .count()
         } < 2,
-        "Multiple variables bound to an ability - this is ambiguous and should have been caught in canonicalization: {:?}",
-        specialization_must_implement_constraints
+        "Multiple variables bound to an ability - this is ambiguous and should have been caught in canonicalization: {specialization_must_implement_constraints:?}"
     );
 
     specialization_must_implement_constraints

--- a/crates/compiler/solve/src/pools.rs
+++ b/crates/compiler/solve/src/pools.rs
@@ -27,14 +27,14 @@ impl Pools {
     pub fn get_mut(&mut self, rank: Rank) -> &mut Vec<Variable> {
         match self.0.get_mut(rank.into_usize()) {
             Some(reference) => reference,
-            None => panic!("Compiler bug: could not find pool at rank {}", rank),
+            None => panic!("Compiler bug: could not find pool at rank {rank}"),
         }
     }
 
     pub fn get(&self, rank: Rank) -> &Vec<Variable> {
         match self.0.get(rank.into_usize()) {
             Some(reference) => reference,
-            None => panic!("Compiler bug: could not find pool at rank {}", rank),
+            None => panic!("Compiler bug: could not find pool at rank {rank}"),
         }
     }
 

--- a/crates/compiler/solve/src/solve.rs
+++ b/crates/compiler/solve/src/solve.rs
@@ -404,7 +404,7 @@ fn solve(
                     if it.peek().is_some() {
                         let failing: Vec<_> = it.collect();
                         println!("Rigids {:?}", &rigid_vars);
-                        println!("Failing {:?}", failing);
+                        println!("Failing {failing:?}");
                         debug_assert!(false);
                     }
                 });
@@ -1739,8 +1739,7 @@ fn check_ability_specialization(
         );
         debug_assert!(
             !awaiting_specializations.waiting_for(impl_key),
-            "still have lambda sets waiting for {:?}, but it was just resolved",
-            impl_key
+            "still have lambda sets waiting for {impl_key:?}, but it was just resolved"
         );
     }
 }

--- a/crates/compiler/solve/src/specialize.rs
+++ b/crates/compiler/solve/src/specialize.rs
@@ -187,9 +187,9 @@ fn trace_compaction_step_1(subs: &Subs, c_a: Variable, uls_a: &[Variable]) {
         .collect::<Vec<_>>()
         .join(",");
     eprintln!("===lambda set compaction===");
-    eprintln!("  concrete type: {:?}", c_a);
+    eprintln!("  concrete type: {c_a:?}");
     eprintln!("  step 1:");
-    eprintln!("    uls_a = {{ {} }}", uls_a);
+    eprintln!("    uls_a = {{ {uls_a} }}");
 }
 
 #[cfg(debug_assertions)]
@@ -205,7 +205,7 @@ fn trace_compaction_step_2(subs: &Subs, uls_a: &[Variable]) {
         .collect::<Vec<_>>()
         .join(",");
     eprintln!("  step 2:");
-    eprintln!("    uls_a' = {{ {} }}", uls_a);
+    eprintln!("    uls_a' = {{ {uls_a} }}");
 }
 
 #[cfg(debug_assertions)]
@@ -226,9 +226,9 @@ fn trace_compaction_step_3iter_start(
     );
     let t_f1 = roc_types::subs::SubsFmtContent(subs.get_content_without_compacting(t_f1), subs);
     let t_f2 = roc_types::subs::SubsFmtContent(subs.get_content_without_compacting(t_f2), subs);
-    eprintln!("    - iteration: {:?}", iteration_lambda_set);
-    eprintln!("         {:?}", t_f1);
-    eprintln!("      ~  {:?}", t_f2);
+    eprintln!("    - iteration: {iteration_lambda_set:?}");
+    eprintln!("         {t_f1:?}");
+    eprintln!("      ~  {t_f2:?}");
 }
 
 #[cfg(debug_assertions)]
@@ -239,7 +239,7 @@ fn trace_compaction_step_3iter_end(subs: &Subs, t_f_result: Variable, skipped: b
     if skipped {
     eprintln!("      SKIP");
     }
-    eprintln!("      =  {:?}\n", t_f_result);
+    eprintln!("      =  {t_f_result:?}\n");
 }
 
 macro_rules! trace_compact {
@@ -536,7 +536,7 @@ fn compact_lambda_set<P: Phase>(
         Err(()) => {
             // Do nothing other than to remove the concrete lambda to drop from the lambda set,
             // which we already did in 1b above.
-            trace_compact!(3iter_end_skipped. env.subs, t_f1);
+            trace_compact!(3iter_end_skipped.env.subs, t_f1);
             return OneCompactionResult::Compacted {
                 new_obligations: Default::default(),
                 new_lambda_sets_to_specialize: Default::default(),
@@ -559,7 +559,7 @@ fn compact_lambda_set<P: Phase>(
         Err(()) => {
             // Do nothing other than to remove the concrete lambda to drop from the lambda set,
             // which we already did in 1b above.
-            trace_compact!(3iter_end_skipped. env.subs, t_f1);
+            trace_compact!(3iter_end_skipped.env.subs, t_f1);
             return OneCompactionResult::Compacted {
                 new_obligations: Default::default(),
                 new_lambda_sets_to_specialize: Default::default(),
@@ -572,7 +572,7 @@ fn compact_lambda_set<P: Phase>(
     let t_f2 = deep_copy_var_in(env, target_rank, t_f2, env.arena);
 
     // 3. Unify `t_f1 ~ t_f2`.
-    trace_compact!(3iter_start. env.subs, this_lambda_set, t_f1, t_f2);
+    trace_compact!(3iter_start.env.subs, this_lambda_set, t_f1, t_f2);
     let (vars, new_obligations, new_lambda_sets_to_specialize, _meta) = unify(
         &mut env.uenv(),
         t_f1,
@@ -581,7 +581,7 @@ fn compact_lambda_set<P: Phase>(
         Polarity::Pos,
     )
     .expect_success("ambient functions don't unify");
-    trace_compact!(3iter_end. env.subs, t_f1);
+    trace_compact!(3iter_end.env.subs, t_f1);
 
     env.introduce(target_rank, &vars);
 

--- a/crates/compiler/solve/tests/solve_expr.rs
+++ b/crates/compiler/solve/tests/solve_expr.rs
@@ -49,7 +49,7 @@ mod solve_expr {
 
         exposed_to_host.retain(|s, _| !abilities_store.is_specialization_name(*s));
 
-        debug_assert!(exposed_to_host.len() == 1, "{:?}", exposed_to_host);
+        debug_assert!(exposed_to_host.len() == 1, "{exposed_to_host:?}");
         let (_symbol, variable) = exposed_to_host.into_iter().next().unwrap();
         let actual_str = name_and_print_var(variable, subs, home, &interns, DebugPrint::NOTHING);
 
@@ -61,8 +61,7 @@ mod solve_expr {
 
         assert!(
             can_problems.is_empty(),
-            "Canonicalization problems: {}",
-            can_problems
+            "Canonicalization problems: {can_problems}"
         );
 
         assert_eq!(actual, expected.to_string());
@@ -73,17 +72,13 @@ mod solve_expr {
 
         assert!(
             can_problems.is_empty(),
-            "Canonicalization problems: {}",
-            can_problems
+            "Canonicalization problems: {can_problems}"
         );
 
         if !type_problems.is_empty() {
             // fail with an assert, but print the problems normally so rust doesn't try to diff
             // an empty vec with the problems.
-            panic!(
-                "expected:\n{:?}\ninferred:\n{:?}\nproblems:\n{}",
-                expected, actual, type_problems,
-            );
+            panic!("expected:\n{expected:?}\ninferred:\n{actual:?}\nproblems:\n{type_problems}",);
         }
         assert_eq!(actual, expected.to_string());
     }

--- a/crates/compiler/test_derive/src/util.rs
+++ b/crates/compiler/test_derive/src/util.rs
@@ -335,7 +335,7 @@ fn assemble_derived_golden(
     specialization_lsets.sort_by_key(|(region, _)| *region);
     for (region, var) in specialization_lsets {
         let pretty_lset = print_var(var, false);
-        let _ = writeln!(pretty_buf, "#   @<{}>: {}", region, pretty_lset);
+        let _ = writeln!(pretty_buf, "#   @<{region}>: {pretty_lset}");
     }
 
     pretty_buf.push_str(derived_source);
@@ -476,10 +476,7 @@ fn check_derived_typechecks_and_golden(
             .render_raw(80, &mut roc_reporting::report::CiWrite::new(&mut buf))
             .unwrap();
 
-        panic!(
-            "Derived does not typecheck:\n{}\nDerived def:\n{}",
-            buf, derived_program
-        );
+        panic!("Derived does not typecheck:\n{buf}\nDerived def:\n{derived_program}");
     }
 
     let golden = assemble_derived_golden(

--- a/crates/compiler/test_gen/benches/list_map.rs
+++ b/crates/compiler/test_gen/benches/list_map.rs
@@ -65,7 +65,7 @@ fn roc_function<'a, 'b>(
     let (main_fn_name, errors, lib) =
         helpers::llvm::helper(arena, config, source, arena.alloc(context));
 
-    assert!(errors.is_empty(), "Encountered errors:\n{}", errors);
+    assert!(errors.is_empty(), "Encountered errors:\n{errors}");
 
     run_roc_dylib!(arena.alloc(lib), main_fn_name, &Input, Output)
 }

--- a/crates/compiler/test_gen/benches/quicksort.rs
+++ b/crates/compiler/test_gen/benches/quicksort.rs
@@ -94,7 +94,7 @@ fn roc_function<'a>(
     let (main_fn_name, errors, lib) =
         helpers::llvm::helper(arena, config, source, arena.alloc(context));
 
-    assert!(errors.is_empty(), "Encountered errors:\n{}", errors);
+    assert!(errors.is_empty(), "Encountered errors:\n{errors}");
 
     run_roc_dylib!(arena.alloc(lib), main_fn_name, *mut Input, Output)
 }

--- a/crates/compiler/test_gen/build.rs
+++ b/crates/compiler/test_gen/build.rs
@@ -41,8 +41,8 @@ fn build_wasm_linking_test_host() {
     let host_wasm: &str = host_wasm_path.to_str().unwrap();
     let host_native: &str = host_native_path.to_str().unwrap();
 
-    println!("cargo:rerun-if-changed={}", host_source);
-    println!("cargo:rerun-if-changed={}", import_source);
+    println!("cargo:rerun-if-changed={host_source}");
+    println!("cargo:rerun-if-changed={import_source}");
 
     if !Path::new("build").exists() {
         fs::create_dir("build").unwrap();
@@ -57,7 +57,7 @@ fn build_wasm_linking_test_host() {
         "-target",
         "wasm32-freestanding-musl",
         host_source,
-        &format!("-femit-bin={}", host_wasm),
+        &format!("-femit-bin={host_wasm}"),
     ]);
 
     let mut import_obj_path = PathBuf::from("build").join("wasm_linking_host_imports");
@@ -73,7 +73,7 @@ fn build_wasm_linking_test_host() {
         "build-exe",
         host_source,
         import_obj,
-        &format!("-femit-bin={}", host_native),
+        &format!("-femit-bin={host_native}"),
         #[cfg(windows)]
         "--subsystem",
         #[cfg(windows)]
@@ -148,7 +148,7 @@ fn run_zig(args: &[&str]) {
     let mut zig_cmd = zig();
 
     let full_zig_cmd = zig_cmd.args(args);
-    println!("{:?}", full_zig_cmd);
+    println!("{full_zig_cmd:?}");
 
     let zig_cmd_output = full_zig_cmd.output().unwrap();
 
@@ -164,6 +164,6 @@ fn run_zig(args: &[&str]) {
         panic!("zig call failed with status {:?}", zig_cmd_output.status);
     }
 
-    assert!(zig_cmd_output.stdout.is_empty(), "{:#?}", zig_cmd_output);
-    assert!(zig_cmd_output.stderr.is_empty(), "{:#?}", zig_cmd_output);
+    assert!(zig_cmd_output.stdout.is_empty(), "{zig_cmd_output:#?}");
+    assert!(zig_cmd_output.stderr.is_empty(), "{zig_cmd_output:#?}");
 }

--- a/crates/compiler/test_gen/src/gen_list.rs
+++ b/crates/compiler/test_gen/src/gen_list.rs
@@ -1776,14 +1776,14 @@ fn assert_concat_worked(num_elems1: i64, num_elems2: i64) {
     let vec2: Vec<i64> = (0..num_elems2)
         .map(|i| 54321 % (i + num_elems1 + num_elems2 + 1))
         .collect();
-    let slice_str1 = format!("{:?}", vec1);
-    let slice_str2 = format!("{:?}", vec2);
+    let slice_str1 = format!("{vec1:?}");
+    let slice_str2 = format!("{vec2:?}");
     let mut expected = vec1;
 
     expected.extend(vec2);
 
     assert_evals_to!(
-        &format!("List.concat {} {}", slice_str1, slice_str2),
+        &format!("List.concat {slice_str1} {slice_str2}"),
         RocList::from_slice(&expected),
         RocList<i64>
     );

--- a/crates/compiler/test_gen/src/helpers/llvm.rs
+++ b/crates/compiler/test_gen/src/helpers/llvm.rs
@@ -89,10 +89,10 @@ fn create_llvm_module<'a>(
         Err(LoadMonomorphizedError::LoadingProblem(roc_load::LoadingProblem::FormattedReport(
             report,
         ))) => {
-            println!("{}", report);
+            println!("{report}");
             panic!();
         }
-        Err(e) => panic!("{:?}", e),
+        Err(e) => panic!("{e:?}"),
     };
 
     use roc_load::MonomorphizedModule;
@@ -283,8 +283,7 @@ fn create_llvm_module<'a>(
         let path = std::env::temp_dir().join("test.ll");
         env.module.print_to_file(&path).unwrap();
         panic!(
-            "Errors defining module:\n\n{}\n\nI have written the full module to `{:?}`",
-            errors, path
+            "Errors defining module:\n\n{errors}\n\nI have written the full module to `{path:?}`"
         );
     };
 
@@ -374,7 +373,7 @@ fn annotate_with_debug_info<'ctx>(
                 ErrorKind::NotFound => panic!(
                     r"I could not find the `debugir` tool on the PATH, install it from https://github.com/vaivaswatha/debugir"
                 ),
-                _ => panic!("{:?}", error),
+                _ => panic!("{error:?}"),
             }
         }
     }
@@ -495,17 +494,14 @@ fn llvm_module_to_wasm_file(
         let msg = String::from_utf8_lossy(&output.stderr);
 
         if msg.contains("wasm-ld: error: unknown file type") {
-            panic!(
-                "{}\nThis can happen if multiple tests have the same input string",
-                msg
-            );
+            panic!("{msg}\nThis can happen if multiple tests have the same input string");
         } else {
             panic!("{}", msg);
         }
     }
 
-    assert!(output.status.success(), "{:#?}", output);
-    assert!(output.stdout.is_empty(), "{:#?}", output);
+    assert!(output.status.success(), "{output:#?}");
+    assert!(output.stdout.is_empty(), "{output:#?}");
 
     test_wasm_path
 }
@@ -570,7 +566,7 @@ pub fn try_run_lib_function<T>(
         let main: libloading::Symbol<unsafe extern "C" fn(*mut RocCallResult<T>)> = lib
             .get(main_fn_name.as_bytes())
             .ok()
-            .ok_or(format!("Unable to JIT compile `{}`", main_fn_name))
+            .ok_or(format!("Unable to JIT compile `{main_fn_name}`"))
             .expect("errored");
 
         let mut main_result = MaybeUninit::uninit();
@@ -607,7 +603,7 @@ where
     match result {
         Ok(raw) => {
             // only if there are no exceptions thrown, check for errors
-            assert!(errors.is_empty(), "Encountered errors:\n{}", errors);
+            assert!(errors.is_empty(), "Encountered errors:\n{errors}");
 
             #[allow(clippy::redundant_closure_call)]
             let given = transform(raw);
@@ -618,8 +614,8 @@ where
             std::mem::forget(given);
         }
         Err((msg, tag)) => match tag {
-            CrashTag::Roc => panic!(r#"Roc failed with message: "{}""#, msg),
-            CrashTag::User => panic!(r#"User crash with message: "{}""#, msg),
+            CrashTag::Roc => panic!(r#"Roc failed with message: "{msg}""#),
+            CrashTag::User => panic!(r#"User crash with message: "{msg}""#),
         },
     }
 }

--- a/crates/compiler/test_gen/src/helpers/mod.rs
+++ b/crates/compiler/test_gen/src/helpers/mod.rs
@@ -24,7 +24,7 @@ pub(crate) fn src_hash(src: &str) -> u64 {
 pub(crate) fn save_wasm_file(app_module_bytes: &[u8], build_dir_hash: u64) {
     use std::path::Path;
 
-    let debug_dir_str = format!("/tmp/roc/gen_wasm/{:016x}", build_dir_hash);
+    let debug_dir_str = format!("/tmp/roc/gen_wasm/{build_dir_hash:016x}");
     let debug_dir_path = Path::new(&debug_dir_str);
     let final_wasm_file = debug_dir_path.join("final.wasm");
 

--- a/crates/compiler/test_mono/src/tests.rs
+++ b/crates/compiler/test_mono/src/tests.rs
@@ -123,10 +123,10 @@ fn compiles_to_ir(test_name: &str, src: &str, mode: &str, allow_type_errors: boo
         Err(LoadMonomorphizedError::LoadingProblem(roc_load::LoadingProblem::FormattedReport(
             report,
         ))) => {
-            println!("{}", report);
+            println!("{report}");
             panic!();
         }
-        Err(e) => panic!("{:?}", e),
+        Err(e) => panic!("{e:?}"),
     };
 
     use roc_load::MonomorphizedModule;
@@ -201,7 +201,7 @@ fn verify_procedures<'a>(
 
     let result = procs_string.join("\n");
 
-    let path = format!("generated/{}.txt", test_name);
+    let path = format!("generated/{test_name}.txt");
     std::fs::create_dir_all("generated").unwrap();
     std::fs::write(&path, result).unwrap();
 

--- a/crates/compiler/test_syntax/src/test_helpers.rs
+++ b/crates/compiler/test_syntax/src/test_helpers.rs
@@ -96,10 +96,10 @@ impl<'a> Output<'a> {
 
     pub fn debug_format_inner(&self) -> String {
         match self {
-            Output::Header(header) => format!("{:#?}\n", header),
-            Output::ModuleDefs(defs) => format!("{:#?}\n", defs),
-            Output::Expr(expr) => format!("{:#?}\n", expr),
-            Output::Full { .. } => format!("{:#?}\n", self),
+            Output::Header(header) => format!("{header:#?}\n"),
+            Output::ModuleDefs(defs) => format!("{defs:#?}\n"),
+            Output::Expr(expr) => format!("{expr:#?}\n"),
+            Output::Full { .. } => format!("{self:#?}\n"),
         }
     }
 }
@@ -224,7 +224,7 @@ impl<'a> Input<'a> {
         // the PartialEq implementation is returning `false` even when the Debug-formatted impl is exactly the same.
         // I don't have the patience to debug this right now, so let's leave it for another day...
         // TODO: fix PartialEq impl on ast types
-        if format!("{:?}", ast_normalized) != format!("{:?}", reparsed_ast_normalized) {
+        if format!("{ast_normalized:?}") != format!("{reparsed_ast_normalized:?}") {
             panic!(
                 "Formatting bug; formatting didn't reparse to the same AST (after removing spaces)\n\n\
                 * * * Source code before formatting:\n{}\n\n\

--- a/crates/compiler/test_syntax/tests/test_fmt.rs
+++ b/crates/compiler/test_syntax/tests/test_fmt.rs
@@ -43,8 +43,7 @@ mod test_fmt {
                 fmt_defs(buf, &loc_defs, 0);
             }
             Err(error) => panic!(
-                r"Unexpected parse failure when parsing this for defs formatting:\n\n{:?}\n\nParse error was:\n\n{:?}\n\n",
-                src, error
+                r"Unexpected parse failure when parsing this for defs formatting:\n\n{src:?}\n\nParse error was:\n\n{error:?}\n\n"
             ),
         }
     }
@@ -67,8 +66,7 @@ mod test_fmt {
 
                 let (reparsed_ast, state) = module::parse_header(&arena, State::new(output.as_bytes())).unwrap_or_else(|err| {
                     panic!(
-                        "After formatting, the source code no longer parsed!\n\nParse error was: {:?}\n\nThe code that failed to parse:\n\n{}\n\n",
-                        err, output
+                        "After formatting, the source code no longer parsed!\n\nParse error was: {err:?}\n\nThe code that failed to parse:\n\n{output}\n\n"
                     );
                 });
 
@@ -80,13 +78,11 @@ mod test_fmt {
                 // the PartialEq implementation is returning `false` even when the Debug-formatted impl is exactly the same.
                 // I don't have the patience to debug this right now, so let's leave it for another day...
                 // TODO: fix PartialEq impl on ast types
-                if format!("{:?}", ast_normalized) != format!("{:?}", reparsed_ast_normalized) {
+                if format!("{ast_normalized:?}") != format!("{reparsed_ast_normalized:?}") {
                     panic!(
                         "Formatting bug; formatting didn't reparse to the same AST (after removing spaces)\n\n\
-                        * * * Source code before formatting:\n{}\n\n\
-                        * * * Source code after formatting:\n{}\n\n",
-                        src,
-                        output
+                        * * * Source code before formatting:\n{src}\n\n\
+                        * * * Source code after formatting:\n{output}\n\n"
                     );
                 }
 
@@ -111,7 +107,7 @@ mod test_fmt {
                 // those more than we want to know that the expectation failed!
                 assert_multiline_str_eq!(expected, output);
             }
-            Err(error) => panic!("Unexpected parse failure when parsing this for module header formatting:\n\n{:?}\n\nParse error was:\n\n{:?}\n\n", src, error)
+            Err(error) => panic!("Unexpected parse failure when parsing this for module header formatting:\n\n{src:?}\n\nParse error was:\n\n{error:?}\n\n")
         };
     }
 

--- a/crates/compiler/test_syntax/tests/test_snapshots.rs
+++ b/crates/compiler/test_syntax/tests/test_snapshots.rs
@@ -526,14 +526,13 @@ mod test_snapshots {
             // Expect file to be missing
             assert!(
                 !result_path.exists(),
-                "Expected {:?} to be missing. \
+                "Expected {result_path:?} to be missing. \
                 This is how we represent a 'default' result (i.e. a test that \
                 formats to the same thing as the input). \
                 Consider running the tests with:\n\
                 `env ROC_SNAPSHOT_TEST_OVERWRITE=1 cargo test ...`\n\
                 (which will delete the file for you),\n\
-                and commiting the delete.",
-                result_path
+                and commiting the delete."
             );
         }
     }
@@ -545,15 +544,12 @@ mod test_snapshots {
         let mut parent = std::path::PathBuf::from("tests");
         parent.push("snapshots");
         parent.push(expect.to_dir_name());
-        let input_path = parent.join(format!("{}.{}.roc", name, ty));
-        let result_path = parent.join(format!("{}.{}.result-ast", name, ty));
-        let formatted_path = parent.join(format!("{}.{}.formatted.roc", name, ty));
+        let input_path = parent.join(format!("{name}.{ty}.roc"));
+        let result_path = parent.join(format!("{name}.{ty}.result-ast"));
+        let formatted_path = parent.join(format!("{name}.{ty}.formatted.roc"));
 
         let source = std::fs::read_to_string(&input_path).unwrap_or_else(|err| {
-            panic!(
-                "Could not find a snapshot test result at {:?} - {:?}",
-                input_path, err
-            )
+            panic!("Could not find a snapshot test result at {input_path:?} - {err:?}")
         });
 
         let input = func(&source);
@@ -566,14 +562,14 @@ mod test_snapshots {
                 }
                 Ok(ast.debug_format_inner())
             }
-            Err(err) => Err(format!("{:?}", err)),
+            Err(err) => Err(format!("{err:?}")),
         };
 
         if expect == TestExpectation::Pass {
             let tokens = roc_parse::highlight::highlight(&source);
             for token in tokens {
                 if token.value == roc_parse::highlight::Token::Error {
-                    panic!("Found an error highlight token in the input: {:?}", token);
+                    panic!("Found an error highlight token in the input: {token:?}");
                 }
             }
         }
@@ -653,7 +649,7 @@ mod test_snapshots {
     #[test]
     fn string_with_escaped_char_at_end() {
         parses_with_escaped_char(
-            |esc| format!(r#""abcd{}""#, esc),
+            |esc| format!(r#""abcd{esc}""#),
             |esc, arena| bumpalo::vec![in arena;  Plaintext("abcd"), EscapedChar(esc)],
         );
     }
@@ -661,7 +657,7 @@ mod test_snapshots {
     #[test]
     fn string_with_escaped_char_in_front() {
         parses_with_escaped_char(
-            |esc| format!(r#""{}abcd""#, esc),
+            |esc| format!(r#""{esc}abcd""#),
             |esc, arena| bumpalo::vec![in arena; EscapedChar(esc), Plaintext("abcd")],
         );
     }
@@ -669,7 +665,7 @@ mod test_snapshots {
     #[test]
     fn string_with_escaped_char_in_middle() {
         parses_with_escaped_char(
-            |esc| format!(r#""ab{}cd""#, esc),
+            |esc| format!(r#""ab{esc}cd""#),
             |esc, arena| bumpalo::vec![in arena; Plaintext("ab"), EscapedChar(esc), Plaintext("cd")],
         );
     }
@@ -677,7 +673,7 @@ mod test_snapshots {
     #[test]
     fn string_with_multiple_escaped_chars() {
         parses_with_escaped_char(
-            |esc| format!(r#""{}abc{}de{}fghi{}""#, esc, esc, esc, esc),
+            |esc| format!(r#""{esc}abc{esc}de{esc}fghi{esc}""#),
             |esc, arena| bumpalo::vec![in arena; EscapedChar(esc), Plaintext("abc"), EscapedChar(esc), Plaintext("de"), EscapedChar(esc), Plaintext("fghi"), EscapedChar(esc)],
         );
     }

--- a/crates/compiler/types/src/pretty_print.rs
+++ b/crates/compiler/types/src/pretty_print.rs
@@ -820,7 +820,7 @@ fn write_content<'a>(
                     "".to_string()
                 };
                 if env.home == symbol.module_id() {
-                    format!("{}{}", ident_str, disambiguation,)
+                    format!("{ident_str}{disambiguation}",)
                 } else {
                     format!(
                         "{}.{}{}",

--- a/crates/compiler/types/src/subs.rs
+++ b/crates/compiler/types/src/subs.rs
@@ -774,11 +774,11 @@ impl fmt::Debug for Subs {
             let root = self.get_root_key_without_compacting(var);
 
             if var == root {
-                write!(f, "{} => ", i)?;
+                write!(f, "{i} => ")?;
 
                 subs_fmt_desc(&desc, self, f)?;
             } else {
-                write!(f, "{} => <{:?}>", i, root)?;
+                write!(f, "{i} => <{root:?}>")?;
             }
 
             writeln!(f)?;
@@ -811,7 +811,7 @@ fn subs_fmt_content(this: &Content, subs: &Subs, f: &mut fmt::Formatter) -> fmt:
                 Some(index) => subs[*index].as_str(),
                 None => "_",
             };
-            write!(f, "Flex({})", name)
+            write!(f, "Flex({name})")
         }
         Content::FlexAbleVar(name, symbols) => {
             let name = match name {
@@ -827,7 +827,7 @@ fn subs_fmt_content(this: &Content, subs: &Subs, f: &mut fmt::Formatter) -> fmt:
         Content::RecursionVar {
             structure,
             opt_name,
-        } => write!(f, "Recursion({:?}, {:?})", structure, opt_name),
+        } => write!(f, "Recursion({structure:?}, {opt_name:?})"),
         Content::Structure(flat_type) => subs_fmt_flat_type(flat_type, subs, f),
         Content::Alias(name, arguments, actual, kind) => {
             let slice = subs.get_subs_slice(arguments.all_variables());
@@ -855,7 +855,7 @@ fn subs_fmt_content(this: &Content, subs: &Subs, f: &mut fmt::Formatter) -> fmt:
             write!(f, "LambdaSet([")?;
 
             for (name, slice) in solved.iter_from_subs(subs) {
-                write!(f, "{:?} ", name)?;
+                write!(f, "{name:?} ")?;
                 for var in slice {
                     write!(
                         f,
@@ -869,7 +869,7 @@ fn subs_fmt_content(this: &Content, subs: &Subs, f: &mut fmt::Formatter) -> fmt:
 
             write!(f, "]")?;
             if let Some(rec_var) = recursion_var.into_variable() {
-                write!(f, " as <{:?}>", rec_var)?;
+                write!(f, " as <{rec_var:?}>")?;
             }
             for Uls(var, member, region) in subs.get_subs_slice(*unspecialized) {
                 write!(
@@ -881,10 +881,10 @@ fn subs_fmt_content(this: &Content, subs: &Subs, f: &mut fmt::Formatter) -> fmt:
                     region
                 )?;
             }
-            write!(f, ", ^<{:?}>)", ambient_function_var)
+            write!(f, ", ^<{ambient_function_var:?}>)")
         }
         Content::RangedNumber(range) => {
-            write!(f, "RangedNumber( {:?})", range)
+            write!(f, "RangedNumber( {range:?})")
         }
         Content::Error => write!(f, "Error"),
     }
@@ -903,7 +903,7 @@ fn subs_fmt_flat_type(this: &FlatType, subs: &Subs, f: &mut fmt::Formatter) -> f
         FlatType::Apply(name, arguments) => {
             let slice = subs.get_subs_slice(*arguments);
 
-            write!(f, "Apply({:?}, {:?})", name, slice)
+            write!(f, "Apply({name:?}, {slice:?})")
         }
         FlatType::Func(arguments, lambda_set, result) => {
             let slice = subs.get_subs_slice(*arguments);
@@ -948,7 +948,7 @@ fn subs_fmt_flat_type(this: &FlatType, subs: &Subs, f: &mut fmt::Formatter) -> f
                 )?;
             }
 
-            write!(f, "}}<{:?}>", new_ext)
+            write!(f, "}}<{new_ext:?}>")
         }
         FlatType::Tuple(elems, ext) => {
             write!(f, "( ")?;
@@ -962,14 +962,14 @@ fn subs_fmt_flat_type(this: &FlatType, subs: &Subs, f: &mut fmt::Formatter) -> f
                 )?;
             }
 
-            write!(f, ")<{:?}>", new_ext)
+            write!(f, ")<{new_ext:?}>")
         }
         FlatType::TagUnion(tags, ext) => {
             write!(f, "[")?;
 
             let (it, new_ext) = tags.sorted_iterator_and_ext(subs, *ext);
             for (name, slice) in it {
-                write!(f, "{:?} ", name)?;
+                write!(f, "{name:?} ")?;
                 for var in slice {
                     write!(
                         f,
@@ -981,26 +981,22 @@ fn subs_fmt_flat_type(this: &FlatType, subs: &Subs, f: &mut fmt::Formatter) -> f
                 write!(f, ", ")?;
             }
 
-            write!(f, "]<{:?}>", new_ext)
+            write!(f, "]<{new_ext:?}>")
         }
         FlatType::FunctionOrTagUnion(tagnames, symbol, ext) => {
             let tagnames: &[TagName] = subs.get_subs_slice(*tagnames);
 
-            write!(
-                f,
-                "FunctionOrTagUnion({:?}, {:?}, {:?})",
-                tagnames, symbol, ext
-            )
+            write!(f, "FunctionOrTagUnion({tagnames:?}, {symbol:?}, {ext:?})")
         }
         FlatType::RecursiveTagUnion(rec, tags, ext) => {
             write!(f, "[")?;
 
             let (it, new_ext) = tags.sorted_iterator_and_ext(subs, *ext);
             for (name, slice) in it {
-                write!(f, "{:?} {:?}, ", name, slice)?;
+                write!(f, "{name:?} {slice:?}, ")?;
             }
 
-            write!(f, "]<{:?}> as <{:?}>", new_ext, rec)
+            write!(f, "]<{new_ext:?}> as <{rec:?}>")
         }
         FlatType::EmptyRecord => write!(f, "EmptyRecord"),
         FlatType::EmptyTuple => write!(f, "EmptyTuple"),
@@ -1016,7 +1012,7 @@ impl std::fmt::Debug for DebugUtable<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str("UnificationTable {\n")?;
         for v in 0..self.0.utable.len() {
-            f.write_fmt(format_args!("  {} => ", v))?;
+            f.write_fmt(format_args!("  {v} => "))?;
             let var = unsafe { Variable::from_index(v as u32) };
             let root = self.0.utable.root_key_without_compacting(var);
             if root == var {
@@ -2820,9 +2816,7 @@ where
         debug_assert_eq!(
             labels.len(),
             variables.len(),
-            "tag name len != variables len: {:?} {:?}",
-            labels,
-            variables,
+            "tag name len != variables len: {labels:?} {variables:?}",
         );
 
         Self {
@@ -4025,7 +4019,7 @@ where
     } else {
         // TODO is this the proper use of index here, or should we be
         // doing something else like turning it into an ASCII letter?
-        Lowercase::from(format!("{}{}", given_name, index))
+        Lowercase::from(format!("{given_name}{index}"))
     };
 
     match taken_names.get(&indexed_name) {
@@ -4335,7 +4329,7 @@ fn flat_type_to_err_type(
                 ErrorType::Error => ErrorType::Record(err_fields, TypeExt::Closed),
 
                 other =>
-                    panic!("Tried to convert a record extension to an error, but the record extension had the ErrorType of {:?}", other)
+                    panic!("Tried to convert a record extension to an error, but the record extension had the ErrorType of {other:?}")
             }
         }
 
@@ -4367,7 +4361,7 @@ fn flat_type_to_err_type(
                 ErrorType::Error => ErrorType::Tuple(err_elems, TypeExt::Closed),
 
                 other =>
-                    panic!("Tried to convert a record extension to an error, but the record extension had the ErrorType of {:?}", other)
+                    panic!("Tried to convert a record extension to an error, but the record extension had the ErrorType of {other:?}")
             }
         }
 
@@ -4393,7 +4387,7 @@ fn flat_type_to_err_type(
                 ErrorType::Error => ErrorType::TagUnion(err_tags, TypeExt::Closed, pol),
 
                 other =>
-                    panic!("Tried to convert a tag union extension to an error, but the tag union extension had the ErrorType of {:?}", other)
+                    panic!("Tried to convert a tag union extension to an error, but the tag union extension had the ErrorType of {other:?}")
             }
         }
 
@@ -4423,7 +4417,7 @@ fn flat_type_to_err_type(
                 ErrorType::Error => ErrorType::TagUnion(err_tags, TypeExt::Closed, pol),
 
                 other =>
-                    panic!("Tried to convert a tag union extension to an error, but the tag union extension had the ErrorType of {:?}", other)
+                    panic!("Tried to convert a tag union extension to an error, but the tag union extension had the ErrorType of {other:?}")
             }
         }
 
@@ -4455,7 +4449,7 @@ fn flat_type_to_err_type(
                 ErrorType::Error => ErrorType::RecursiveTagUnion(rec_error_type, err_tags, TypeExt::Closed, pol),
 
                 other =>
-                    panic!("Tried to convert a recursive tag union extension to an error, but the tag union extension had the ErrorType of {:?}", other)
+                    panic!("Tried to convert a recursive tag union extension to an error, but the tag union extension had the ErrorType of {other:?}")
             }
         }
     }

--- a/crates/compiler/types/src/types.rs
+++ b/crates/compiler/types/src/types.rs
@@ -55,11 +55,11 @@ impl<T: fmt::Debug> fmt::Debug for RecordField<T> {
         use RecordField::*;
 
         match self {
-            Optional(typ) => write!(f, "Optional({:?})", typ),
-            Required(typ) => write!(f, "Required({:?})", typ),
-            Demanded(typ) => write!(f, "Demanded({:?})", typ),
-            RigidRequired(typ) => write!(f, "RigidRequired({:?})", typ),
-            RigidOptional(typ) => write!(f, "RigidOptional({:?})", typ),
+            Optional(typ) => write!(f, "Optional({typ:?})"),
+            Required(typ) => write!(f, "Required({typ:?})"),
+            Demanded(typ) => write!(f, "Demanded({typ:?})"),
+            RigidRequired(typ) => write!(f, "RigidRequired({typ:?})"),
+            RigidOptional(typ) => write!(f, "RigidOptional({typ:?})"),
         }
     }
 }
@@ -1949,10 +1949,10 @@ fn write_tags<'a>(
 
     let mut it = tags.peekable();
     while let Some((label, arguments)) = it.next() {
-        write!(f, "{:?}", label)?;
+        write!(f, "{label:?}")?;
 
         for argument in arguments {
-            write!(f, " {:?}", argument)?;
+            write!(f, " {argument:?}")?;
         }
 
         if it.peek().is_some() {
@@ -1976,23 +1976,23 @@ impl fmt::Debug for Type {
                         write!(f, ", ")?;
                     }
 
-                    write!(f, "{:?}", arg)?;
+                    write!(f, "{arg:?}")?;
                 }
 
-                write!(f, " |{:?}|", closure)?;
+                write!(f, " |{closure:?}|")?;
                 write!(f, " -> ")?;
 
                 ret.fmt(f)?;
 
                 write!(f, ")")
             }
-            Type::Variable(var) => write!(f, "<{:?}>", var),
+            Type::Variable(var) => write!(f, "<{var:?}>"),
 
             Type::Apply(symbol, args, _) => {
-                write!(f, "({:?}", symbol)?;
+                write!(f, "({symbol:?}")?;
 
                 for arg in args {
-                    write!(f, " {:?}", arg)?;
+                    write!(f, " {arg:?}")?;
                 }
 
                 write!(f, ")")
@@ -2004,10 +2004,10 @@ impl fmt::Debug for Type {
                 lambda_set_variables,
                 infer_ext_in_output_types,
             }) => {
-                write!(f, "(DelayedAlias {:?}", symbol)?;
+                write!(f, "(DelayedAlias {symbol:?}")?;
 
                 for arg in type_arguments {
-                    write!(f, " {:?}", arg)?;
+                    write!(f, " {arg:?}")?;
                 }
 
                 for (lambda_set, greek_letter) in
@@ -2017,7 +2017,7 @@ impl fmt::Debug for Type {
                 }
 
                 for (i, infer_ext) in infer_ext_in_output_types.iter().enumerate() {
-                    write!(f, " `{}@{:?}", i, infer_ext)?;
+                    write!(f, " `{i}@{infer_ext:?}")?;
                 }
 
                 write!(f, ")")?;
@@ -2032,12 +2032,12 @@ impl fmt::Debug for Type {
                 actual: _actual,
                 ..
             } => {
-                write!(f, "(Alias {:?}", symbol)?;
+                write!(f, "(Alias {symbol:?}")?;
 
                 for arg in type_arguments {
                     write!(f, " {:?}", &arg.typ)?;
                     if let Some(abs) = &arg.opt_abilities {
-                        write!(f, ":{:?}", abs)?;
+                        write!(f, ":{abs:?}")?;
                     }
                 }
 
@@ -2048,7 +2048,7 @@ impl fmt::Debug for Type {
                 }
 
                 // Sometimes it's useful to see the expansion of the alias
-                write!(f, "[ but actually {:?} ]", _actual)?;
+                write!(f, "[ but actually {_actual:?} ]")?;
 
                 write!(f, ")")?;
 
@@ -2059,10 +2059,10 @@ impl fmt::Debug for Type {
                 type_arguments: arguments,
                 ..
             } => {
-                write!(f, "HostExposedAlias {:?}", name)?;
+                write!(f, "HostExposedAlias {name:?}")?;
 
                 for arg in arguments {
-                    write!(f, " {:?}", arg)?;
+                    write!(f, " {arg:?}")?;
                 }
 
                 // Sometimes it's useful to see the expansion of the alias
@@ -2082,13 +2082,11 @@ impl fmt::Debug for Type {
                 for (label, field_type) in fields {
                     match field_type {
                         RecordField::Optional(_) | RecordField::RigidOptional(_) => {
-                            write!(f, "{:?} ? {:?}", label, field_type)?
+                            write!(f, "{label:?} ? {field_type:?}")?
                         }
                         RecordField::Required(_)
                         | RecordField::Demanded(_)
-                        | RecordField::RigidRequired(_) => {
-                            write!(f, "{:?} : {:?}", label, field_type)?
-                        }
+                        | RecordField::RigidRequired(_) => write!(f, "{label:?} : {field_type:?}")?,
                     }
 
                     if any_written_yet {
@@ -2129,7 +2127,7 @@ impl fmt::Debug for Type {
                 let mut any_written_yet = false;
 
                 for (_, field_type) in elems.iter() {
-                    write!(f, "{:?}", field_type)?;
+                    write!(f, "{field_type:?}")?;
 
                     if any_written_yet {
                         write!(f, ", ")?;
@@ -2179,7 +2177,7 @@ impl fmt::Debug for Type {
             }
             Type::FunctionOrTagUnion(tag_name, _, ext) => {
                 write!(f, "[")?;
-                write!(f, "{:?}", tag_name)?;
+                write!(f, "{tag_name:?}")?;
                 write!(f, "]")?;
 
                 match ext {
@@ -2204,9 +2202,9 @@ impl fmt::Debug for Type {
             } => {
                 write!(f, "ClosureTag(")?;
 
-                write!(f, "{:?}, ", name)?;
+                write!(f, "{name:?}, ")?;
                 for capture in captures {
-                    write!(f, "{:?}, ", capture)?;
+                    write!(f, "{capture:?}, ")?;
                 }
 
                 write!(f, ")")
@@ -2229,13 +2227,13 @@ impl fmt::Debug for Type {
                     }
                 }?;
 
-                write!(f, " as <{:?}>", rec)
+                write!(f, " as <{rec:?}>")
             }
             Type::RangedNumber(range_vars) => {
-                write!(f, "Ranged({:?})", range_vars)
+                write!(f, "Ranged({range_vars:?})")
             }
             Type::UnspecializedLambdaSet { unspecialized } => {
-                write!(f, "{:?}", unspecialized)
+                write!(f, "{unspecialized:?}")
             }
         }
     }
@@ -4005,7 +4003,7 @@ fn write_debug_error_type_help(error_type: ErrorType, buf: &mut String, parens: 
                 buf.push('(');
             }
             buf.push_str(name.as_str());
-            write!(buf, "has {:?}", symbol).unwrap();
+            write!(buf, "has {symbol:?}").unwrap();
             if write_parens {
                 buf.push(')');
             }
@@ -4016,7 +4014,7 @@ fn write_debug_error_type_help(error_type: ErrorType, buf: &mut String, parens: 
             if write_parens {
                 buf.push('(');
             }
-            write!(buf, "{:?}", symbol).unwrap();
+            write!(buf, "{symbol:?}").unwrap();
 
             for arg in arguments {
                 buf.push(' ');
@@ -4061,7 +4059,7 @@ fn write_debug_error_type_help(error_type: ErrorType, buf: &mut String, parens: 
             if write_parens {
                 buf.push('(');
             }
-            write!(buf, "{:?}", symbol).unwrap();
+            write!(buf, "{symbol:?}").unwrap();
 
             for arg in arguments {
                 buf.push(' ');
@@ -4146,7 +4144,7 @@ fn write_debug_error_type_help(error_type: ErrorType, buf: &mut String, parens: 
             let mut it = tags.into_iter().peekable();
 
             while let Some((tag, args)) = it.next() {
-                write!(buf, "{:?}", tag).unwrap();
+                write!(buf, "{tag:?}").unwrap();
                 for arg in args {
                     buf.push(' ');
                     write_debug_error_type_help(arg, buf, Parens::InTypeParam);
@@ -4165,7 +4163,7 @@ fn write_debug_error_type_help(error_type: ErrorType, buf: &mut String, parens: 
 
             let mut it = tags.into_iter().peekable();
             while let Some((tag, args)) = it.next() {
-                write!(buf, "{:?}", tag).unwrap();
+                write!(buf, "{tag:?}").unwrap();
                 for arg in args {
                     buf.push(' ');
                     write_debug_error_type_help(arg, buf, Parens::Unnecessary);

--- a/crates/compiler/uitest/src/mono.rs
+++ b/crates/compiler/uitest/src/mono.rs
@@ -60,10 +60,10 @@ pub fn write_compiled_ir<'a>(
         Err(LoadMonomorphizedError::LoadingProblem(roc_load::LoadingProblem::FormattedReport(
             report,
         ))) => {
-            println!("{}", report);
+            println!("{report}");
             panic!();
         }
-        Err(e) => panic!("{:?}", e),
+        Err(e) => panic!("{e:?}"),
     };
 
     use roc_load::MonomorphizedModule;
@@ -146,9 +146,9 @@ fn write_procedures<'a>(
     let mut procs = procs_strings.iter().peekable();
     while let Some(proc) = procs.next() {
         if procs.peek().is_some() {
-            writeln!(writer, "{}", proc)?;
+            writeln!(writer, "{proc}")?;
         } else {
-            write!(writer, "{}", proc)?;
+            write!(writer, "{proc}")?;
         }
     }
 

--- a/crates/compiler/uitest/src/uitest.rs
+++ b/crates/compiler/uitest/src/uitest.rs
@@ -337,7 +337,7 @@ fn assemble_query_output(
 
     for (module, source) in other_modules.iter() {
         writeln!(writer, "## module {module}")?;
-        writeln!(writer, "{}\n", source)?;
+        writeln!(writer, "{source}\n")?;
     }
 
     if !other_modules.is_empty() {

--- a/crates/compiler/unify/src/unify.rs
+++ b/crates/compiler/unify/src/unify.rs
@@ -1853,8 +1853,7 @@ fn unify_unspecialized_lambdas<M: MetaCollector>(
 
     debug_assert!(
         is_sorted_unspecialized_lamba_set_list(env.subs, &merged_uls),
-        "merging of unspecialized lambda sets does not preserve sort! {:?}",
-        merged_uls
+        "merging of unspecialized lambda sets does not preserve sort! {merged_uls:?}"
     );
 
     Ok((

--- a/crates/docs/src/lib.rs
+++ b/crates/docs/src/lib.rs
@@ -151,10 +151,7 @@ pub fn generate_docs_html(root_file: PathBuf) {
             );
 
         fs::write(build_dir.join("index.html"), rendered_package).unwrap_or_else(|error| {
-            panic!(
-                "Attempted to write index.html but failed with this error: {}",
-                error
-            )
+            panic!("Attempted to write index.html but failed with this error: {error}")
         });
     }
 
@@ -470,10 +467,10 @@ pub fn load_module_for_docs(filename: PathBuf) -> LoadedModule {
     ) {
         Ok(loaded) => loaded,
         Err(LoadingProblem::FormattedReport(report)) => {
-            eprintln!("{}", report);
+            eprintln!("{report}");
             std::process::exit(1);
         }
-        Err(e) => panic!("{:?}", e),
+        Err(e) => panic!("{e:?}"),
     }
 }
 
@@ -796,8 +793,7 @@ fn doc_url<'a>(
             Err(_) => {
                 // TODO return Err here
                 panic!(
-                    "Tried to generate an automatic link in docs for symbol `{}`, but that symbol was not in scope in this module.",
-                    ident
+                    "Tried to generate an automatic link in docs for symbol `{ident}`, but that symbol was not in scope in this module."
                 );
             }
         }
@@ -819,8 +815,7 @@ fn doc_url<'a>(
                 else if !all_exposed_symbols.contains(&symbol) {
                     // TODO return Err here
                     panic!(
-                            "Tried to generate an automatic link in docs for `{}.{}`, but `{}` does not expose `{}`.",
-                            module_name, ident, module_name, ident);
+                            "Tried to generate an automatic link in docs for `{module_name}.{ident}`, but `{module_name}` does not expose `{ident}`.");
                 }
 
                 // This is a valid symbol for this dependency,
@@ -831,7 +826,7 @@ fn doc_url<'a>(
             }
             None => {
                 // TODO return Err here
-                panic!("Tried to generate a doc link for `{}.{}` but the `{}` module was not imported!", module_name, ident, module_name);
+                panic!("Tried to generate a doc link for `{module_name}.{ident}` but the `{module_name}` module was not imported!");
             }
         }
     }
@@ -847,7 +842,7 @@ fn doc_url<'a>(
 
     DocUrl {
         url,
-        title: format!("Docs for {}.{}", module_name, ident),
+        title: format!("Docs for {module_name}.{ident}"),
     }
 }
 
@@ -935,8 +930,7 @@ fn markdown_to_html(
     for event in parser {
         match event {
             Event::Code(code_str) => {
-                let inline_code =
-                    pulldown_cmark::CowStr::from(format!("<code>{}</code>", code_str));
+                let inline_code = pulldown_cmark::CowStr::from(format!("<code>{code_str}</code>"));
                 docs_parser.push(pulldown_cmark::Event::Html(inline_code));
             }
             Event::End(Link(LinkType::ShortcutUnknown, ref _url, ref _title)) => {

--- a/crates/editor/src/editor/code_lines.rs
+++ b/crates/editor/src/editor/code_lines.rs
@@ -66,13 +66,13 @@ impl fmt::Display for CodeLines {
         for row in &self.lines {
             let row_str = row
                 .chars()
-                .map(|code_char| format!("{}", code_char))
+                .map(|code_char| format!("{code_char}"))
                 .collect::<Vec<String>>()
                 .join(" ");
 
             let escaped_row_str = row_str.replace('\n', "\\n");
 
-            write!(f, "\n{}", escaped_row_str)?;
+            write!(f, "\n{escaped_row_str}")?;
         }
 
         writeln!(f, "      (code_lines, {:?} lines)", self.lines.len())?;

--- a/crates/editor/src/editor/ed_error.rs
+++ b/crates/editor/src/editor/ed_error.rs
@@ -278,7 +278,7 @@ pub enum EdError {
 pub type EdResult<T, E = EdError> = std::result::Result<T, E>;
 
 pub fn print_err(err: &EdError) {
-    eprintln!("{}", format!("{}", err).truecolor(255, 0, 0));
+    eprintln!("{}", format!("{err}").truecolor(255, 0, 0));
 
     if let Some(backtrace) = ErrorCompat::backtrace(err) {
         eprintln!("{}", color_backtrace(backtrace));
@@ -286,7 +286,7 @@ pub fn print_err(err: &EdError) {
 }
 
 fn color_backtrace(backtrace: &snafu::Backtrace) -> String {
-    let backtrace_str = format!("{}", backtrace);
+    let backtrace_str = format!("{backtrace}");
     let backtrace_split = backtrace_str.split('\n');
     let irrelevant_src = vec![".cargo", "registry", ".rustup", "rustc"];
 
@@ -301,10 +301,10 @@ fn color_backtrace(backtrace: &snafu::Backtrace) -> String {
                 }
                 format!("{}\n", line.truecolor(255, 100, 100))
             } else {
-                format!("{}\n", line)
+                format!("{line}\n")
             }
         } else {
-            format!("{}\n", line)
+            format!("{line}\n")
         };
 
         if let Some(prev_line) = prev_line_opt {
@@ -328,7 +328,7 @@ fn contains_one_of(main_str: &str, contain_slice: &[&str]) -> bool {
 
 impl From<EdError> for String {
     fn from(ed_error: EdError) -> Self {
-        format!("{}", ed_error)
+        format!("{ed_error}")
     }
 }
 

--- a/crates/editor/src/editor/grid_node_map.rs
+++ b/crates/editor/src/editor/grid_node_map.rs
@@ -429,11 +429,11 @@ impl fmt::Display for GridNodeMap {
         for row in &self.lines {
             let row_str = row
                 .iter()
-                .map(|mark_node_id| format!(" {} ", mark_node_id))
+                .map(|mark_node_id| format!(" {mark_node_id} "))
                 .collect::<Vec<String>>()
                 .join(", ");
 
-            writeln!(f, "{}", row_str)?;
+            writeln!(f, "{row_str}")?;
         }
 
         writeln!(f, "(grid_node_map, {:?} lines)", self.lines.len())?;

--- a/crates/editor/src/editor/main.rs
+++ b/crates/editor/src/editor/main.rs
@@ -92,7 +92,7 @@ fn run_event_loop(project_path_opt: Option<&Path>) -> Result<(), Box<dyn Error>>
             )
         })
         .unwrap_or_else(|err| {
-            panic!("Failed to request device: `{}`", err);
+            panic!("Failed to request device: `{err}`");
         })
         .await
     });
@@ -125,7 +125,7 @@ fn run_event_loop(project_path_opt: Option<&Path>) -> Result<(), Box<dyn Error>>
     let code_arena = Bump::new();
 
     let (file_path_buf, code_str) = read_main_roc_file(project_path_opt);
-    println!("Loading file {:?}...", file_path_buf);
+    println!("Loading file {file_path_buf:?}...");
 
     let file_path = Path::new(&file_path_buf);
     let loaded_module = load_module(
@@ -237,7 +237,7 @@ fn run_event_loop(project_path_opt: Option<&Path>) -> Result<(), Box<dyn Error>>
                 if let Err(e) = input_outcome_res {
                     print_err(&e)
                 } else if let Ok(InputOutcome::Ignored) = input_outcome_res {
-                    println!("\nInput '{}' ignored!", ch);
+                    println!("\nInput '{ch}' ignored!");
                 } else {
                     window.request_redraw()
                 }
@@ -507,10 +507,7 @@ fn read_main_roc_file(project_path_opt: Option<&Path>) -> (PathBuf, String) {
 
         let dir_items = ls(project_path, &ls_config)
             .unwrap_or_else(|err| {
-                panic!(
-                    "Failed to list items in project directory; error: {:?}",
-                    err
-                )
+                panic!("Failed to list items in project directory; error: {err:?}")
             })
             .items;
 
@@ -574,15 +571,13 @@ fn init_new_roc_project(project_dir_path: &Path) -> (PathBuf, String) {
 fn create_roc_file_if_not_exists(project_dir_path: &Path, roc_file_path: &Path) -> String {
     if !roc_file_path.exists() {
         let mut roc_file = File::create(roc_file_path).unwrap_or_else(|err| {
-            panic!("No roc file path was passed to the editor, so I wanted to create a new roc project with the file {:?}, but it failed: {}", roc_file_path, err)
+            panic!("No roc file path was passed to the editor, so I wanted to create a new roc project with the file {roc_file_path:?}, but it failed: {err}")
         });
 
-        write!(roc_file, "{}", HELLO_WORLD).unwrap_or_else(|err| {
+        write!(roc_file, "{HELLO_WORLD}").unwrap_or_else(|err| {
             panic!(
-                r#"No roc file path was passed to the editor, so I created a new roc project with the file {:?}
-                I wanted to write roc hello world to that file, but it failed: {:?}"#,
-                roc_file_path,
-                err
+                r#"No roc file path was passed to the editor, so I created a new roc project with the file {roc_file_path:?}
+                I wanted to write roc hello world to that file, but it failed: {err:?}"#
             )
         });
 
@@ -590,8 +585,7 @@ fn create_roc_file_if_not_exists(project_dir_path: &Path, roc_file_path: &Path) 
     } else {
         std::fs::read_to_string(roc_file_path).unwrap_or_else(|err| {
             panic!(
-                "I detected an existing {:?} inside {:?}, but I failed to read from it: {}",
-                roc_file_path, project_dir_path, err
+                "I detected an existing {roc_file_path:?} inside {project_dir_path:?}, but I failed to read from it: {err}"
             )
         })
     }
@@ -613,10 +607,7 @@ fn copy_roc_platform_if_not_exists(
     } else if !project_platform_path.exists() {
         copy(orig_platform_path, project_dir_path, &CopyOptions::new()).unwrap_or_else(|err|{
             panic!(r#"No roc file path was passed to the editor, so I wanted to create a new roc project and roc projects require a platform,
-            I tried to copy the platform at {:?} to {:?} but it failed: {}"#,
-            orig_platform_path,
-            project_platform_path,
-            err
+            I tried to copy the platform at {orig_platform_path:?} to {project_platform_path:?} but it failed: {err}"#
         )
         });
     }

--- a/crates/editor/src/editor/mvc/ed_model.rs
+++ b/crates/editor/src/editor/mvc/ed_model.rs
@@ -206,7 +206,7 @@ impl<'a> EdModule<'a> {
             match parse_res {
                 Ok(ast) => Ok(EdModule { env, ast }),
                 Err(err) => SrcParseSnafu {
-                    syntax_err: format!("{:?}", err),
+                    syntax_err: format!("{err:?}"),
                 }
                 .fail(),
             }
@@ -315,20 +315,17 @@ pub mod test_ed_model {
         let platform_module_path = platform_dir.join("main.roc");
         let mut platform_module_file =
             File::create(platform_module_path).expect("Failed to create main.roc");
-        writeln!(platform_module_file, "{}", PLATFORM_STR).expect("Failed to write to main.roc");
+        writeln!(platform_module_file, "{PLATFORM_STR}").expect("Failed to write to main.roc");
 
         let temp_file_path_buf =
             PathBuf::from([Uuid::new_v4().to_string(), ".roc".to_string()].join(""));
         let temp_file_full_path = temp_dir.path().join(temp_file_path_buf);
 
         let mut file = File::create(temp_file_full_path.clone()).unwrap_or_else(|_| {
-            panic!(
-                "Failed to create temporary file for path {:?}",
-                temp_file_full_path
-            )
+            panic!("Failed to create temporary file for path {temp_file_full_path:?}")
         });
-        writeln!(file, "{}", clean_code_str)
-            .unwrap_or_else(|_| panic!("Failed to write {:?} to file: {:?}", clean_code_str, file));
+        writeln!(file, "{clean_code_str}")
+            .unwrap_or_else(|_| panic!("Failed to write {clean_code_str:?} to file: {file:?}"));
 
         let loaded_module = load_module(
             &temp_file_full_path,

--- a/crates/editor/src/editor/mvc/int_update.rs
+++ b/crates/editor/src/editor/mvc/int_update.rs
@@ -126,7 +126,7 @@ fn check_parse_res<T, E: std::fmt::Debug>(parse_res: Result<T, E>) -> EdResult<T
     match parse_res {
         Ok(some_type) => Ok(some_type),
         Err(parse_err) => StringParseSnafu {
-            msg: format!("{:?}", parse_err),
+            msg: format!("{parse_err:?}"),
         }
         .fail(),
     }

--- a/crates/editor/src/editor/util.rs
+++ b/crates/editor/src/editor/util.rs
@@ -9,7 +9,7 @@ pub fn map_get<'a, K: ::std::fmt::Debug + std::hash::Hash + std::cmp::Eq, V>(
     key: &K,
 ) -> EdResult<&'a V> {
     let value = hash_map.get(key).context(KeyNotFoundSnafu {
-        key_str: format!("{:?}", key),
+        key_str: format!("{key:?}"),
     })?;
 
     Ok(value)
@@ -20,8 +20,8 @@ pub fn index_of<T: ::std::fmt::Debug + std::cmp::Eq>(elt: T, slice: &[T]) -> EdR
         .iter()
         .position(|slice_elt| *slice_elt == elt)
         .with_context(|| {
-            let elt_str = format!("{:?}", elt);
-            let collection_str = format!("{:?}", slice);
+            let elt_str = format!("{elt:?}");
+            let collection_str = format!("{slice:?}");
 
             IndexOfFailedSnafu {
                 elt_str,
@@ -56,8 +56,8 @@ pub fn first_last_index_of<T: ::std::fmt::Debug + std::cmp::Eq>(
     if let (Some(first_index), Some(last_index)) = (first_index_opt, last_index_opt) {
         Ok((first_index, last_index))
     } else {
-        let elt_str = format!("{:?}", elt);
-        let collection_str = format!("{:?}", slice);
+        let elt_str = format!("{elt:?}");
+        let collection_str = format!("{slice:?}");
 
         IndexOfFailedSnafu {
             elt_str,

--- a/crates/editor/src/ui/text/big_text_area.rs
+++ b/crates/editor/src/ui/text/big_text_area.rs
@@ -596,7 +596,7 @@ pub mod test_big_sel_text {
                 assert_eq!(expected_post_lines, post_lines);
                 Ok(())
             }
-            Err(e) => Err(format!("{:?}", e)),
+            Err(e) => Err(format!("{e:?}")),
         }
     }
 

--- a/crates/editor/src/ui/text/text_buffer.rs
+++ b/crates/editor/src/ui/text/text_buffer.rs
@@ -91,7 +91,7 @@ impl TextBuffer {
             txt_pos.column <= line_len,
             OutOfBoundsSnafu {
                 index: txt_pos.column,
-                collection_name: format!("Line in TextBuffer: {}", line_ref),
+                collection_name: format!("Line in TextBuffer: {line_ref}"),
                 len: line_len,
             }
         );

--- a/crates/editor/src/ui/ui_error.rs
+++ b/crates/editor/src/ui/ui_error.rs
@@ -64,6 +64,6 @@ pub type UIResult<T, E = UIError> = std::result::Result<T, E>;
 
 impl From<UIError> for String {
     fn from(ui_error: UIError) -> Self {
-        format!("{}", ui_error)
+        format!("{ui_error}")
     }
 }

--- a/crates/glue/src/load.rs
+++ b/crates/glue/src/load.rs
@@ -138,7 +138,7 @@ pub fn generate(
                     let files: Result<roc_std::RocList<roc_type::File>, roc_std::RocStr> =
                         files.into();
                     let files = files.unwrap_or_else(|err| {
-                        eprintln!("Glue generation failed: {}", err);
+                        eprintln!("Glue generation failed: {err}");
 
                         process::exit(1);
                     });
@@ -358,7 +358,7 @@ pub fn load_types(
     )
     .unwrap_or_else(|problem| match problem {
         LoadingProblem::FormattedReport(report) => {
-            eprintln!("{}", report);
+            eprintln!("{report}");
 
             process::exit(1);
         }

--- a/crates/glue/src/rust_glue.rs
+++ b/crates/glue/src/rust_glue.rs
@@ -999,7 +999,7 @@ pub struct {name} {{
                     | RocType::RocResult(_, _)
                     | RocType::RecursivePointer { .. } => {
                         owned_ret_type = type_name(*payload_id, types);
-                        borrowed_ret_type = format!("&{}", owned_ret_type);
+                        borrowed_ret_type = format!("&{owned_ret_type}");
                         owned_ret = "payload".to_string();
                         borrowed_ret = format!("&{owned_ret}");
                         payload_args = format!("arg: {owned_ret_type}");
@@ -1119,7 +1119,7 @@ pub struct {name} {{
 
                         // TODO revise these - they're all copy/pasted from somewhere else
                         owned_ret_type = type_name(*payload_id, types);
-                        borrowed_ret_type = format!("&{}", owned_ret_type);
+                        borrowed_ret_type = format!("&{owned_ret_type}");
                         owned_ret = "payload".to_string();
                         borrowed_ret = format!("&{owned_ret}");
                         payload_args = format!("arg: {owned_ret_type}");
@@ -1658,7 +1658,7 @@ pub struct {name} {{
                 }},"#
                         )
                     } else {
-                        format!("{},", hash_tag)
+                        format!("{hash_tag},")
                     }
                 },
             );
@@ -2255,7 +2255,7 @@ pub struct {name} {{
             | RocType::TagUnion(_)
             | RocType::RecursivePointer { .. } => {
                 owned_ret_type = type_name(non_null_payload, types);
-                borrowed_ret_type = format!("&{}", owned_ret_type);
+                borrowed_ret_type = format!("&{owned_ret_type}");
                 payload_args = format!("arg: {owned_ret_type}");
                 args_to_payload = "arg".to_string();
                 owned_ret = "payload".to_string();
@@ -2631,7 +2631,7 @@ fn tag_union_struct_help(
         let label = if is_tag_union_payload {
             // Tag union payload fields need "f" prefix
             // because they're numbers
-            format!("f{}", label)
+            format!("f{label}")
         } else {
             escape_kw(label.to_string())
         };
@@ -2671,12 +2671,9 @@ fn tag_union_struct_help(
 
         if cannot_derive_copy(types.get_type(payload_id), types) {
             format!(
-        "core::mem::ManuallyDrop::new({payload_type_name} {{\n{}\n{INDENT}{INDENT}{INDENT}{INDENT}}})",prefixed_fields)
+        "core::mem::ManuallyDrop::new({payload_type_name} {{\n{prefixed_fields}\n{INDENT}{INDENT}{INDENT}{INDENT}}})")
         } else {
-            format!(
-                "{payload_type_name} {{\n{}\n{INDENT}{INDENT}{INDENT}{INDENT}}}",
-                prefixed_fields
-            )
+            format!("{payload_type_name} {{\n{prefixed_fields}\n{INDENT}{INDENT}{INDENT}{INDENT}}}")
         }
     } else {
         "core::mem::ManuallyDrop::new(arg0)".to_string()

--- a/crates/glue/src/types.rs
+++ b/crates/glue/src/types.rs
@@ -521,8 +521,7 @@ impl Types {
             } else {
                 // TODO report this gracefully!
                 panic!(
-                    "Duplicate name detected - {:?} could refer to either {:?} or {:?}",
-                    name, existing_type, typ
+                    "Duplicate name detected - {name:?} could refer to either {existing_type:?} or {typ:?}"
                 );
             }
         } else {
@@ -1213,8 +1212,7 @@ impl<'a> Env<'a> {
 
             debug_assert!(
                 matches!(types.get_type(type_id), RocType::RecursivePointer(TypeId::PENDING)),
-                "The TypeId {:?} was registered as a pending recursive pointer, but was not stored in Types as one.",
-                type_id
+                "The TypeId {type_id:?} was registered as a pending recursive pointer, but was not stored in Types as one."
             );
 
             // size and alignment shouldn't change; this is still
@@ -1267,7 +1265,7 @@ fn add_function_type<'a>(
     let args = env.subs.get_subs_slice(*args);
     let mut arg_type_ids = Vec::with_capacity(args.len());
 
-    let name = format!("RocFunction_{:?}", closure_var);
+    let name = format!("RocFunction_{closure_var:?}");
 
     let id = env.lambda_set_ids.get(&closure_var).unwrap();
     let extern_name = format!("roc__mainForHost_{}_caller", id.0);
@@ -1851,7 +1849,7 @@ where
                         getter: getter.clone(),
                     };
 
-                    (format!("{}", label), type_id, accessors)
+                    (format!("{label}"), type_id, accessors)
                 })
                 .collect();
 
@@ -1865,7 +1863,7 @@ where
                 .map(|(label, field_var, field_layout)| {
                     let type_id = add_type_help(env, field_layout, field_var, None, types);
 
-                    (format!("{}", label), type_id)
+                    (format!("{label}"), type_id)
                 })
                 .collect();
 

--- a/crates/glue/tests/test_glue_cli.rs
+++ b/crates/glue/tests/test_glue_cli.rs
@@ -220,7 +220,7 @@ mod glue_cli_run {
             );
         }
 
-        assert!(glue_out.status.success(), "bad status {:?}", glue_out);
+        assert!(glue_out.status.success(), "bad status {glue_out:?}");
 
         glue_out
     }
@@ -243,7 +243,7 @@ mod glue_cli_run {
             );
         }
 
-        assert!(compile_out.status.success(), "bad status {:?}", compile_out);
+        assert!(compile_out.status.success(), "bad status {compile_out:?}");
 
         compile_out
     }

--- a/crates/highlight/src/lib.rs
+++ b/crates/highlight/src/lib.rs
@@ -102,7 +102,7 @@ fn push_html_span(mut buf: Vec<String>, curr: &str, class: &str) -> Vec<String> 
     // html escape strings from source code
     let escaped = html_escape::encode_text(curr);
 
-    buf.push(format!("<span class=\"{}\">{}</span>", class, escaped));
+    buf.push(format!("<span class=\"{class}\">{escaped}</span>"));
 
     buf
 }
@@ -111,7 +111,7 @@ fn push_html(mut buf: Vec<String>, curr: &str) -> Vec<String> {
     // html escape strings from source code
     let escaped = html_escape::encode_text(curr);
 
-    buf.push(format!("{}", escaped));
+    buf.push(format!("{escaped}"));
 
     buf
 }

--- a/crates/linker/src/elf.rs
+++ b/crates/linker/src/elf.rs
@@ -202,7 +202,7 @@ impl<'a> Surgeries<'a> {
             println!();
             println!("Text Sections");
             for sec in text_sections.iter() {
-                println!("{:+x?}", sec);
+                println!("{sec:+x?}");
             }
         }
 
@@ -285,8 +285,7 @@ impl<'a> Surgeries<'a> {
                         let offset = inst.next_ip() - op_size as u64 - sec.address() + file_offset;
                         if verbose {
                             println!(
-                                "\tNeed to surgically replace {} bytes at file offset {:+x}",
-                                op_size, offset,
+                                "\tNeed to surgically replace {op_size} bytes at file offset {offset:+x}",
                             );
                             println!(
                                 "\tIts current value is {:+x?}",
@@ -373,13 +372,13 @@ pub(crate) fn preprocess_elf(
         other.sort_by_key(|t| t.1);
 
         for (name, vaddr) in other.iter() {
-            println!("\t{:#08x}: {}", vaddr, name);
+            println!("\t{vaddr:#08x}: {name}");
         }
 
         println!("Of which {} are builtins", builtins.len(),);
 
         for (name, vaddr) in builtins.iter() {
-            println!("\t{:#08x}: {}", vaddr, name);
+            println!("\t{vaddr:#08x}: {name}");
         }
     }
 
@@ -410,8 +409,8 @@ pub(crate) fn preprocess_elf(
         }
     };
     if verbose {
-        println!("PLT Address: {:+x}", plt_address);
-        println!("PLT File Offset: {:+x}", plt_offset);
+        println!("PLT Address: {plt_address:+x}");
+        println!("PLT File Offset: {plt_offset:+x}");
     }
 
     let app_syms: Vec<_> = exec_obj
@@ -467,7 +466,7 @@ pub(crate) fn preprocess_elf(
         }
 
         println!();
-        println!("App Function Address Map: {:+x?}", app_func_addresses);
+        println!("App Function Address Map: {app_func_addresses:+x?}");
     }
     let symbol_and_plt_processing_duration = symbol_and_plt_processing_start.elapsed();
 
@@ -526,7 +525,7 @@ pub(crate) fn preprocess_elf(
 
     if verbose {
         println!();
-        println!("{:+x?}", md);
+        println!("{md:+x?}");
     }
 
     let saving_metadata_start = Instant::now();
@@ -593,12 +592,12 @@ fn gen_elf_le(
 
     if verbose {
         println!();
-        println!("PH Offset: {:+x}", ph_offset);
-        println!("PH Entry Size: {}", ph_ent_size);
-        println!("PH Entry Count: {}", ph_num);
-        println!("SH Offset: {:+x}", sh_offset);
-        println!("SH Entry Size: {}", sh_ent_size);
-        println!("SH Entry Count: {}", sh_num);
+        println!("PH Offset: {ph_offset:+x}");
+        println!("PH Entry Size: {ph_ent_size}");
+        println!("PH Entry Count: {ph_num}");
+        println!("SH Offset: {sh_offset:+x}");
+        println!("SH Entry Size: {sh_ent_size}");
+        println!("SH Entry Count: {sh_num}");
     }
 
     // Copy header and shift everything to enable more program sections.
@@ -633,10 +632,7 @@ fn gen_elf_le(
         user_error!("Executable does not load any data at 0x00000000\nProbably input the wrong file as the executable");
     }
     if verbose {
-        println!(
-            "Shifting all data after: {:+x}({:+x})",
-            physical_shift_start, virtual_shift_start
-        );
+        println!("Shifting all data after: {physical_shift_start:+x}({virtual_shift_start:+x})");
     }
 
     // Shift all of the program headers.
@@ -998,7 +994,7 @@ fn scan_elf_dynamic_deps(
     let dynstr_data = match dynstr_sec.uncompressed_data() {
         Ok(data) => data,
         Err(err) => {
-            panic!("Failed to load dynstr section: {}", err);
+            panic!("Failed to load dynstr section: {err}");
         }
     };
 
@@ -1028,10 +1024,7 @@ fn scan_elf_dynamic_deps(
             if Path::new(c_str).file_name() == shared_lib_filename {
                 shared_lib_index = Some(dyn_lib_index);
                 if verbose {
-                    println!(
-                        "Found shared lib in dynamic table at index: {}",
-                        dyn_lib_index
-                    );
+                    println!("Found shared lib in dynamic table at index: {dyn_lib_index}");
                 }
             }
         }
@@ -1260,14 +1253,14 @@ fn surgery_elf_help(
 
     if verbose {
         println!();
-        println!("Is Elf64: {}", elf64);
-        println!("Is Little Endian: {}", litte_endian);
-        println!("PH Offset: {:+x}", ph_offset);
-        println!("PH Entry Size: {}", ph_ent_size);
-        println!("PH Entry Count: {}", ph_num);
-        println!("SH Offset: {:+x}", sh_offset);
-        println!("SH Entry Size: {}", sh_ent_size);
-        println!("SH Entry Count: {}", sh_num);
+        println!("Is Elf64: {elf64}");
+        println!("Is Little Endian: {litte_endian}");
+        println!("PH Offset: {ph_offset:+x}");
+        println!("PH Entry Size: {ph_ent_size}");
+        println!("PH Entry Count: {ph_num}");
+        println!("SH Offset: {sh_offset:+x}");
+        println!("SH Entry Size: {sh_ent_size}");
+        println!("SH Entry Count: {sh_num}");
     }
 
     // Backup section header table.
@@ -1360,8 +1353,8 @@ fn surgery_elf_help(
         }
     }
     if verbose {
-        println!("Data Relocation Offsets: {:+x?}", symbol_vaddr_map);
-        println!("Found App Function Symbols: {:+x?}", app_func_vaddr_map);
+        println!("Data Relocation Offsets: {symbol_vaddr_map:+x?}");
+        println!("Found App Function Symbols: {app_func_vaddr_map:+x?}");
     }
 
     let (new_text_section_offset, new_text_section_vaddr) = text_sections
@@ -1427,22 +1420,18 @@ fn surgery_elf_help(
         if verbose {
             println!();
             println!(
-                "Processing Relocations for Section: 0x{:+x?} @ {:+x} (virt: {:+x})",
-                sec, section_offset, section_virtual_offset
+                "Processing Relocations for Section: 0x{sec:+x?} @ {section_offset:+x} (virt: {section_virtual_offset:+x})"
             );
         }
         for rel in sec.relocations() {
             if verbose {
-                println!("\tFound Relocation: {:+x?}", rel);
+                println!("\tFound Relocation: {rel:+x?}");
             }
             match rel.1.target() {
                 RelocationTarget::Symbol(index) => {
                     let target_offset = if let Some(target_offset) = symbol_vaddr_map.get(&index) {
                         if verbose {
-                            println!(
-                                "\t\tRelocation targets symbol in app at: {:+x}",
-                                target_offset
-                            );
+                            println!("\t\tRelocation targets symbol in app at: {target_offset:+x}");
                         }
                         Some(*target_offset as i64)
                     } else {
@@ -1455,8 +1444,7 @@ fn surgery_elf_help(
                                     let vaddr = (*address + md.added_byte_count) as i64;
                                     if verbose {
                                         println!(
-                                            "\t\tRelocation targets symbol in host: {} @ {:+x}",
-                                            name, vaddr
+                                            "\t\tRelocation targets symbol in host: {name} @ {vaddr:+x}"
                                         );
                                     }
                                     vaddr
@@ -1660,7 +1648,7 @@ fn surgery_elf_help(
 
         for s in md.surgeries.get(func_name).unwrap_or(&vec![]) {
             if verbose {
-                println!("\tPerforming surgery: {:+x?}", s);
+                println!("\tPerforming surgery: {s:+x?}");
             }
             let surgery_virt_offset = match s.virtual_offset {
                 VirtualOffset::Relative(vs) => (vs + md.added_byte_count) as i64,
@@ -1670,7 +1658,7 @@ fn surgery_elf_help(
                 4 => {
                     let target = (func_virt_offset as i64 - surgery_virt_offset) as i32;
                     if verbose {
-                        println!("\tTarget Jump: {:+x}", target);
+                        println!("\tTarget Jump: {target:+x}");
                     }
                     let data = target.to_le_bytes();
                     exec_mmap[(s.file_offset + md.added_byte_count) as usize..][..4]
@@ -1679,7 +1667,7 @@ fn surgery_elf_help(
                 8 => {
                     let target = func_virt_offset as i64 - surgery_virt_offset;
                     if verbose {
-                        println!("\tTarget Jump: {:+x}", target);
+                        println!("\tTarget Jump: {target:+x}");
                     }
                     let data = target.to_le_bytes();
                     exec_mmap[(s.file_offset + md.added_byte_count) as usize..][..8]
@@ -1700,8 +1688,8 @@ fn surgery_elf_help(
             let target =
                 (func_virt_offset as i64 - (plt_vaddr as i64 + jmp_inst_len as i64)) as i32;
             if verbose {
-                println!("\tPLT: {:+x}, {:+x}", plt_off, plt_vaddr);
-                println!("\tTarget Jump: {:+x}", target);
+                println!("\tPLT: {plt_off:+x}, {plt_vaddr:+x}");
+                println!("\tTarget Jump: {target:+x}");
             }
             let data = target.to_le_bytes();
             exec_mmap[plt_off] = 0xE9;

--- a/crates/linker/src/generate_dylib/macho.rs
+++ b/crates/linker/src/generate_dylib/macho.rs
@@ -82,12 +82,10 @@ pub fn create_dylib_macho(
     if !output.status.success() {
         match std::str::from_utf8(&output.stderr) {
             Ok(stderr) => panic!(
-                "Failed to link dummy shared library - stderr of the `ld` command was:\n{}",
-                stderr
+                "Failed to link dummy shared library - stderr of the `ld` command was:\n{stderr}"
             ),
             Err(utf8_err) => panic!(
-                "Failed to link dummy shared library  - stderr of the `ld` command was invalid utf8 ({:?})",
-                utf8_err
+                "Failed to link dummy shared library  - stderr of the `ld` command was invalid utf8 ({utf8_err:?})"
             ),
         }
     }

--- a/crates/linker/src/lib.rs
+++ b/crates/linker/src/lib.rs
@@ -64,7 +64,7 @@ pub fn supported(link_type: LinkType, target: &Triple) -> bool {
 pub const PRECOMPILED_HOST_EXT: &str = "rh"; // Short for "roc host"
 
 pub fn preprocessed_host_filename(target: &Triple) -> Option<String> {
-    roc_target::get_target_triple_str(target).map(|x| format!("{}.{}", x, PRECOMPILED_HOST_EXT))
+    roc_target::get_target_triple_str(target).map(|x| format!("{x}.{PRECOMPILED_HOST_EXT}"))
 }
 
 fn metadata_file_name(target: &Triple) -> String {
@@ -181,9 +181,9 @@ impl ExposedSymbols {
             let sym = x.as_str(interns);
 
             custom_names.extend([
-                format!("roc__{}_1_exposed", sym),
-                format!("roc__{}_1_exposed_generic", sym),
-                format!("roc__{}_1_exposed_size", sym),
+                format!("roc__{sym}_1_exposed"),
+                format!("roc__{sym}_1_exposed_generic"),
+                format!("roc__{sym}_1_exposed_size"),
             ]);
 
             let exported_closure_types = exposed_to_host
@@ -193,9 +193,9 @@ impl ExposedSymbols {
 
             for (i, _) in exported_closure_types.enumerate() {
                 custom_names.extend([
-                    format!("roc__{}_{i}_caller", sym),
-                    format!("roc__{}_{i}_size", sym),
-                    format!("roc__{}_{i}_result_size", sym),
+                    format!("roc__{sym}_{i}_caller"),
+                    format!("roc__{sym}_{i}_size"),
+                    format!("roc__{sym}_{i}_result_size"),
                 ]);
             }
         }
@@ -227,16 +227,16 @@ impl ExposedSymbols {
 
         for sym in &self.top_level_values {
             custom_names.extend([
-                format!("roc__{}_1_exposed", sym),
-                format!("roc__{}_1_exposed_generic", sym),
-                format!("roc__{}_size", sym),
+                format!("roc__{sym}_1_exposed"),
+                format!("roc__{sym}_1_exposed_generic"),
+                format!("roc__{sym}_size"),
             ]);
 
             for closure_type in &self.exported_closure_types {
                 custom_names.extend([
-                    format!("roc__{}_1_{}_caller", sym, closure_type),
-                    format!("roc__{}_1_{}_size", sym, closure_type),
-                    format!("roc__{}_1_{}_result_size", sym, closure_type),
+                    format!("roc__{sym}_1_{closure_type}_caller"),
+                    format!("roc__{sym}_1_{closure_type}_size"),
+                    format!("roc__{sym}_1_{closure_type}_result_size"),
                 ]);
             }
         }
@@ -421,7 +421,7 @@ fn preprocess(
     time: bool,
 ) {
     if verbose {
-        println!("Targeting: {}", target);
+        println!("Targeting: {target}");
     }
 
     let endianness = target

--- a/crates/linker/src/macho.rs
+++ b/crates/linker/src/macho.rs
@@ -192,7 +192,7 @@ impl<'a> Surgeries<'a> {
             println!();
             println!("Text Sections");
             for sec in text_sections.iter() {
-                println!("{:+x?}", sec);
+                println!("{sec:+x?}");
             }
         }
 
@@ -275,8 +275,7 @@ impl<'a> Surgeries<'a> {
                         let offset = inst.next_ip() - op_size as u64 - sec.address() + file_offset;
                         if verbose {
                             println!(
-                                "\tNeed to surgically replace {} bytes at file offset {:+x}",
-                                op_size, offset,
+                                "\tNeed to surgically replace {op_size} bytes at file offset {offset:+x}",
                             );
                             println!(
                                 "\tIts current value is {:+x?}",
@@ -382,8 +381,8 @@ pub(crate) fn preprocess_macho(
         }
     };
     if verbose {
-        println!("PLT Address: {:+x}", plt_address);
-        println!("PLT File Offset: {:+x}", plt_offset);
+        println!("PLT Address: {plt_address:+x}");
+        println!("PLT File Offset: {plt_offset:+x}");
     }
 
     let app_syms: Vec<_> = exec_obj.symbols().filter(is_roc_undefined).collect();
@@ -532,7 +531,7 @@ pub(crate) fn preprocess_macho(
         }
 
         println!();
-        println!("App Function Address Map: {:+x?}", app_func_addresses);
+        println!("App Function Address Map: {app_func_addresses:+x?}");
     }
     let symbol_and_plt_processing_duration = symbol_and_plt_processing_start.elapsed();
 
@@ -603,7 +602,7 @@ pub(crate) fn preprocess_macho(
 
     if verbose {
         println!();
-        println!("{:+x?}", md);
+        println!("{md:+x?}");
     }
 
     let saving_metadata_start = Instant::now();
@@ -1101,8 +1100,7 @@ fn gen_macho_le(
             }
             cmd => {
                 eprintln!(
-                    "- - - Unrecognized Mach-O command during linker preprocessing: 0x{:x?}",
-                    cmd
+                    "- - - Unrecognized Mach-O command during linker preprocessing: 0x{cmd:x?}"
                 );
                 // panic!(
                 //     "Unrecognized Mach-O command during linker preprocessing: 0x{:x?}",
@@ -1237,10 +1235,7 @@ fn surgery_macho_help(
     let new_rodata_section_vaddr = virt_offset;
     if verbose {
         println!();
-        println!(
-            "New Virtual Rodata Section Address: {:+x?}",
-            new_rodata_section_vaddr
-        );
+        println!("New Virtual Rodata Section Address: {new_rodata_section_vaddr:+x?}");
     }
 
     // First decide on sections locations and then recode every exact symbol locations.
@@ -1320,8 +1315,8 @@ fn surgery_macho_help(
         }
     }
     if verbose {
-        println!("Data Relocation Offsets: {:+x?}", symbol_vaddr_map);
-        println!("Found App Function Symbols: {:+x?}", app_func_vaddr_map);
+        println!("Data Relocation Offsets: {symbol_vaddr_map:+x?}");
+        println!("Found App Function Symbols: {app_func_vaddr_map:+x?}");
     }
 
     // let (new_text_section_offset, new_text_section_vaddr) = text_sections
@@ -1356,22 +1351,18 @@ fn surgery_macho_help(
         if verbose {
             println!();
             println!(
-                "Processing Relocations for Section: 0x{:+x?} @ {:+x} (virt: {:+x})",
-                sec, section_offset, section_virtual_offset
+                "Processing Relocations for Section: 0x{sec:+x?} @ {section_offset:+x} (virt: {section_virtual_offset:+x})"
             );
         }
         for rel in sec.relocations() {
             if verbose {
-                println!("\tFound Relocation: {:+x?}", rel);
+                println!("\tFound Relocation: {rel:+x?}");
             }
             match rel.1.target() {
                 RelocationTarget::Symbol(index) => {
                     let target_offset = if let Some(target_offset) = symbol_vaddr_map.get(&index) {
                         if verbose {
-                            println!(
-                                "\t\tRelocation targets symbol in app at: {:+x}",
-                                target_offset
-                            );
+                            println!("\t\tRelocation targets symbol in app at: {target_offset:+x}");
                         }
                         Some(*target_offset as i64)
                     } else {
@@ -1384,8 +1375,7 @@ fn surgery_macho_help(
                                     let vaddr = (*address + md.added_byte_count) as i64;
                                     if verbose {
                                         println!(
-                                            "\t\tRelocation targets symbol in host: {} @ {:+x}",
-                                            name, vaddr
+                                            "\t\tRelocation targets symbol in host: {name} @ {vaddr:+x}"
                                         );
                                     }
                                     vaddr
@@ -1406,10 +1396,9 @@ fn surgery_macho_help(
                         };
                         if verbose {
                             println!(
-                                "\t\tRelocation base location: {:+x} (virt: {:+x})",
-                                base, virt_base
+                                "\t\tRelocation base location: {base:+x} (virt: {virt_base:+x})"
                             );
-                            println!("\t\tFinal relocation target offset: {:+x}", target);
+                            println!("\t\tFinal relocation target offset: {target:+x}");
                         }
                         match rel.1.size() {
                             32 => {
@@ -1560,7 +1549,7 @@ fn surgery_macho_help(
 
         for s in md.surgeries.get(func_name).unwrap_or(&vec![]) {
             if verbose {
-                println!("\tPerforming surgery: {:+x?}", s);
+                println!("\tPerforming surgery: {s:+x?}");
             }
             let surgery_virt_offset = match s.virtual_offset {
                 VirtualOffset::Relative(vs) => (vs + md.added_byte_count) as i64,
@@ -1570,7 +1559,7 @@ fn surgery_macho_help(
                 4 => {
                     let target = (func_virt_offset as i64 - surgery_virt_offset) as i32;
                     if verbose {
-                        println!("\tTarget Jump: {:+x}", target);
+                        println!("\tTarget Jump: {target:+x}");
                     }
                     let data = target.to_le_bytes();
                     exec_mmap[(s.file_offset + md.added_byte_count) as usize
@@ -1580,7 +1569,7 @@ fn surgery_macho_help(
                 8 => {
                     let target = func_virt_offset as i64 - surgery_virt_offset;
                     if verbose {
-                        println!("\tTarget Jump: {:+x}", target);
+                        println!("\tTarget Jump: {target:+x}");
                     }
                     let data = target.to_le_bytes();
                     exec_mmap[(s.file_offset + md.added_byte_count) as usize
@@ -1602,8 +1591,8 @@ fn surgery_macho_help(
             let target =
                 (func_virt_offset as i64 - (plt_vaddr as i64 + jmp_inst_len as i64)) as i32;
             if verbose {
-                println!("\tPLT: {:+x}, {:+x}", plt_off, plt_vaddr);
-                println!("\tTarget Jump: {:+x}", target);
+                println!("\tPLT: {plt_off:+x}, {plt_vaddr:+x}");
+                println!("\tTarget Jump: {target:+x}");
             }
             let data = target.to_le_bytes();
             exec_mmap[plt_off] = 0xE9;

--- a/crates/linker/src/pe.rs
+++ b/crates/linker/src/pe.rs
@@ -450,8 +450,7 @@ pub(crate) fn surgery_pe(executable_path: &Path, metadata_path: &Path, roc_app_b
                     .contains(&name.as_str());
                     if *address == 0 && !name.starts_with("roc") && !is_ingested_compiler_rt {
                         eprintln!(
-                            "I don't know the address of the {} function! this may cause segfaults",
-                            name
+                            "I don't know the address of the {name} function! this may cause segfaults"
                         );
                     }
 
@@ -1718,7 +1717,7 @@ mod test {
             std::io::stdout().write_all(&output.stdout).unwrap();
             std::io::stderr().write_all(&output.stderr).unwrap();
 
-            panic!("zig build-exe failed: {}", command_str);
+            panic!("zig build-exe failed: {command_str}");
         }
 
         let preprocessed_host_filename =
@@ -1939,7 +1938,7 @@ mod test {
             std::io::stdout().write_all(&output.stdout).unwrap();
             std::io::stderr().write_all(&output.stderr).unwrap();
 
-            panic!("zig build-exe failed: {}", command_str);
+            panic!("zig build-exe failed: {command_str}");
         }
 
         let host_bytes = std::fs::read(dir.join("host.exe")).unwrap();

--- a/crates/repl_cli/src/cli_gen.rs
+++ b/crates/repl_cli/src/cli_gen.rs
@@ -264,7 +264,7 @@ fn mono_module_to_dylib<'a>(
     if main_fn.verify(true) {
         function_pass.run_on(&main_fn);
     } else {
-        internal_error!("Main function {} failed LLVM verification in build. Uncomment things nearby to see more details.", main_fn_name);
+        internal_error!("Main function {main_fn_name} failed LLVM verification in build. Uncomment things nearby to see more details.", );
     }
 
     module_pass.run_on(env.module);

--- a/crates/repl_cli/src/lib.rs
+++ b/crates/repl_cli/src/lib.rs
@@ -32,7 +32,7 @@ pub fn main() -> i32 {
     // To debug rustyline:
     // <UNCOMMENT> env_logger::init();
     // <RUN WITH:> RUST_LOG=rustyline=debug cargo run repl 2> debug.log
-    print!("{}{}", WELCOME_MESSAGE, SHORT_INSTRUCTIONS);
+    print!("{WELCOME_MESSAGE}{SHORT_INSTRUCTIONS}");
 
     let mut editor = Editor::<ReplState>::new();
     let repl_helper = ReplState::new();
@@ -51,7 +51,7 @@ pub fn main() -> i32 {
                         // If there was no output, don't print a blank line!
                         // (This happens for something like a type annotation.)
                         if !output.is_empty() {
-                            println!("{}", output);
+                            println!("{output}");
                         }
                     }
                     Err(exit_code) => return exit_code,
@@ -70,7 +70,7 @@ pub fn main() -> i32 {
                 return 1;
             }
             Err(err) => {
-                eprintln!("REPL error: {:?}", err);
+                eprintln!("REPL error: {err:?}");
                 return 1;
             }
         }

--- a/crates/repl_eval/src/eval.rs
+++ b/crates/repl_eval/src/eval.rs
@@ -1457,6 +1457,6 @@ fn number_literal_to_ast<T: std::fmt::Display>(arena: &Bump, num: T) -> Expr<'_>
     use std::fmt::Write;
 
     let mut string = bumpalo::collections::String::with_capacity_in(64, arena);
-    write!(string, "{}", num).unwrap();
+    write!(string, "{num}").unwrap();
     Expr::Num(string.into_bump_str())
 }

--- a/crates/repl_expect/src/lib.rs
+++ b/crates/repl_expect/src/lib.rs
@@ -200,7 +200,7 @@ mod test {
             let expected = expected.trim_end();
 
             if x != expected {
-                println!("{}", x);
+                println!("{x}");
             }
 
             assert_eq!(expected, x);

--- a/crates/repl_expect/src/run.rs
+++ b/crates/repl_expect/src/run.rs
@@ -327,7 +327,7 @@ fn run_expect_fx<'a, W: std::io::Write>(
                 try_run_jit_function!(lib, expect.name, (), |v: ()| v);
 
             if let Err((msg, _)) = result {
-                internal_error!("roc panic {}", msg);
+                internal_error!("roc panic {msg}");
             }
 
             if sequence.count_failures() > 0 {
@@ -386,7 +386,7 @@ fn run_expect_fx<'a, W: std::io::Write>(
                             ExpectSequence::START_OFFSET,
                         )?;
                     }
-                    _ => println!("received signal {}", sig),
+                    _ => println!("received signal {sig}"),
                 }
             }
 
@@ -638,7 +638,7 @@ impl ExpectSequence {
                 0 => std::hint::spin_loop(),
                 1 => break ChildProcessMsg::Expect,
                 2 => break ChildProcessMsg::Dbg,
-                n => internal_error!("invalid atomic value set by the child: {:#x}", n),
+                n => internal_error!("invalid atomic value set by the child: {n:#x}"),
             }
         }
     }

--- a/crates/repl_test/src/cli.rs
+++ b/crates/repl_test/src/cli.rs
@@ -75,13 +75,12 @@ pub fn repl_eval(input: &str) -> Out {
 
     // Remove the initial instructions from the output.
 
-    let expected_instructions = format!("{}{}", WELCOME_MESSAGE, SHORT_INSTRUCTIONS);
+    let expected_instructions = format!("{WELCOME_MESSAGE}{SHORT_INSTRUCTIONS}");
     let stdout = String::from_utf8(output.stdout).unwrap();
 
     assert!(
         stdout.starts_with(&expected_instructions),
-        "Unexpected repl output: {}",
-        stdout
+        "Unexpected repl output: {stdout}"
     );
 
     let (_, answer) = stdout.split_at(expected_instructions.len());
@@ -101,8 +100,7 @@ pub fn repl_eval(input: &str) -> Out {
 
         assert!(
             answer.ends_with(&expected_after_answer),
-            "Unexpected repl output after answer: {}",
-            answer
+            "Unexpected repl output after answer: {answer}"
         );
 
         // Use [1..] to trim the leading '\n'

--- a/crates/repl_wasm/build.rs
+++ b/crates/repl_wasm/build.rs
@@ -14,8 +14,8 @@ const OBJECT_EXTENSION: &str = "obj";
 
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
-    let source_path = format!("src/{}.c", PLATFORM_FILENAME);
-    println!("cargo:rerun-if-changed={}", source_path);
+    let source_path = format!("src/{PLATFORM_FILENAME}.c");
+    println!("cargo:rerun-if-changed={source_path}");
 
     // Zig can produce *either* an object containing relocations OR an object containing libc code
     // But we want both, so we have to compile twice with different flags, then link them
@@ -51,9 +51,9 @@ fn main() {
     // (and thus deleted) before the Zig process is done using it!
     let _ = builtins_host_tempfile;
 
-    assert!(output.status.success(), "{:#?}", output);
-    assert!(output.stdout.is_empty(), "{:#?}", output);
-    assert!(output.stderr.is_empty(), "{:#?}", output);
+    assert!(output.status.success(), "{output:#?}");
+    assert!(output.stdout.is_empty(), "{output:#?}");
+    assert!(output.stderr.is_empty(), "{output:#?}");
 }
 
 fn zig_executable() -> String {

--- a/crates/repl_wasm/src/repl.rs
+++ b/crates/repl_wasm/src/repl.rs
@@ -233,7 +233,7 @@ pub async fn entrypoint_from_js(src: String) -> Result<String, String> {
 
     let (_, main_fn_layout) = match procedures.keys().find(|(s, _)| *s == main_fn_symbol) {
         Some(layout) => *layout,
-        None => return Ok(format!("<function> : {}", expr_type_str)),
+        None => return Ok(format!("<function> : {expr_type_str}")),
     };
 
     let app_module_bytes = {
@@ -280,7 +280,7 @@ pub async fn entrypoint_from_js(src: String) -> Result<String, String> {
     // Send the compiled binary out to JS and create an executable instance from it
     js_create_app(&app_module_bytes)
         .await
-        .map_err(|js| format!("{:?}", js))?;
+        .map_err(|js| format!("{js:?}"))?;
 
     let mut app = WasmReplApp { arena };
 

--- a/crates/reporting/src/cli.rs
+++ b/crates/reporting/src/cli.rs
@@ -133,13 +133,13 @@ pub fn report_problems(
         problems_reported = warnings.len();
 
         for warning in warnings.iter() {
-            println!("\n{}\n", warning);
+            println!("\n{warning}\n");
         }
     } else {
         problems_reported = errors.len();
 
         for error in errors.iter() {
-            println!("\n{}\n", error);
+            println!("\n{error}\n");
         }
     }
 

--- a/crates/reporting/src/error/canonicalize.rs
+++ b/crates/reporting/src/error/canonicalize.rs
@@ -843,7 +843,7 @@ pub fn can_problem<'b>(
                     alloc.reflow("An implementation of "), alloc.symbol_unqualified(member), alloc.reflow(" could not be found in this scope:"),
                 ]),
                 alloc.region(lines.convert_region(region)),
-                alloc.tip().append(alloc.concat([alloc.reflow("consider adding a value of name "), alloc.symbol_unqualified(member), alloc.reflow(" in this scope, or using another variable that implements this ability member, like "), alloc.type_str(&format!("{{ {}: my{} }}", member_str, member_str))]))
+                alloc.tip().append(alloc.concat([alloc.reflow("consider adding a value of name "), alloc.symbol_unqualified(member), alloc.reflow(" in this scope, or using another variable that implements this ability member, like "), alloc.type_str(&format!("{{ {member_str}: my{member_str} }}"))]))
             ]);
             title = IMPLEMENTATION_NOT_FOUND.to_string();
         }

--- a/crates/reporting/src/error/expect.rs
+++ b/crates/reporting/src/error/expect.rs
@@ -167,7 +167,7 @@ impl<'a> Renderer<'a> {
             &crate::report::DEFAULT_PALETTE,
         );
 
-        write!(writer, "{}", buf)
+        write!(writer, "{buf}")
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -238,6 +238,6 @@ impl<'a> Renderer<'a> {
             &crate::report::DEFAULT_PALETTE,
         );
 
-        write!(writer, "{}", buf)
+        write!(writer, "{buf}")
     }
 }

--- a/crates/reporting/src/error/type.rs
+++ b/crates/reporting/src/error/type.rs
@@ -1047,7 +1047,7 @@ fn to_expr_report<'b>(
                     region,
                     Some(expr_region),
                     alloc.reflow("This list contains elements with different types:"),
-                    alloc.string(format!("Its {} element is", ith)),
+                    alloc.string(format!("Its {ith} element is")),
                     alloc.reflow(prev_elems_msg),
                     Some(alloc.reflow("Every element in a list must have the same type!")),
                 )
@@ -1180,7 +1180,7 @@ fn to_expr_report<'b>(
                                     if arity == 1 {
                                         "1 argument".into()
                                     } else {
-                                        format!("{} arguments", arity)
+                                        format!("{arity} arguments")
                                     }
                                 )),
                             ]),
@@ -1227,7 +1227,7 @@ fn to_expr_report<'b>(
                                     if n == 1 {
                                         "1 argument".into()
                                     } else {
-                                        format!("{} arguments", n)
+                                        format!("{n} arguments")
                                     },
                                     arity
                                 )),
@@ -1251,7 +1251,7 @@ fn to_expr_report<'b>(
                                     if n == 1 {
                                         "1 argument".into()
                                     } else {
-                                        format!("{} arguments", n)
+                                        format!("{n} arguments")
                                     },
                                     arity
                                 )),
@@ -1865,10 +1865,7 @@ fn format_category<'b>(
         ),
         CallResult(None, _) => (this_is, alloc.text(":")),
         LowLevelOpResult(op) => {
-            panic!(
-                "Compiler bug: invalid return type from low-level op {:?}",
-                op
-            );
+            panic!("Compiler bug: invalid return type from low-level op {op:?}");
         }
         ForeignCall => {
             panic!("Compiler bug: invalid return type from foreign call",);
@@ -4372,8 +4369,8 @@ fn type_problem_to_pretty<'b>(
             match suggestions.get(0) {
                 None => alloc.nil(),
                 Some(nearest) => {
-                    let typo_str = format!("{}", typo);
-                    let nearest_str = format!("{}", nearest);
+                    let typo_str = format!("{typo}");
+                    let nearest_str = format!("{nearest}");
 
                     let found = alloc.text(typo_str).annotate(Annotation::Typo);
                     let suggestion = alloc.text(nearest_str).annotate(Annotation::TypoSuggestion);
@@ -4424,7 +4421,7 @@ fn type_problem_to_pretty<'b>(
             match suggestions.get(0) {
                 None => alloc.nil(),
                 Some(nearest) => {
-                    let nearest_str = format!("{}", nearest);
+                    let nearest_str = format!("{nearest}");
 
                     let found = alloc.text(typo_str).annotate(Annotation::Typo);
                     let suggestion = alloc.text(nearest_str).annotate(Annotation::TypoSuggestion);

--- a/crates/reporting/src/report.rs
+++ b/crates/reporting/src/report.rs
@@ -438,7 +438,7 @@ impl<'a> RocDocAllocator<'a> {
     }
 
     pub fn wrapped_opaque_name(&'a self, opaque: Symbol) -> DocBuilder<'a, Self, Annotation> {
-        debug_assert_eq!(opaque.module_id(), self.home, "Opaque wrappings can only be defined in the same module they're defined in, but this one is defined elsewhere: {:?}", opaque);
+        debug_assert_eq!(opaque.module_id(), self.home, "Opaque wrappings can only be defined in the same module they're defined in, but this one is defined elsewhere: {opaque:?}");
 
         text!(self, "@{}", opaque.as_str(self.interns)).annotate(Annotation::Opaque)
     }
@@ -1612,7 +1612,7 @@ pub fn to_file_problem_report<'b>(
         }
         _ => {
             let error = std::io::Error::from(error);
-            let formatted = format!("{}", error);
+            let formatted = format!("{error}");
             let doc = alloc.stack([
                 alloc.reflow(r"I tried to read this file:"),
                 alloc.string(filename).annotate(Annotation::Error).indent(4),

--- a/crates/reporting/tests/test_reporting.rs
+++ b/crates/reporting/tests/test_reporting.rs
@@ -86,7 +86,7 @@ mod test_reporting {
         path.push("snapshots");
         path.push("fail");
         let kind = if is_expr { "expr" } else { "header" };
-        path.push(format!("{}.{}.roc", test_name, kind));
+        path.push(format!("{test_name}.{kind}.roc"));
 
         std::fs::write(path, src).unwrap();
     }
@@ -113,14 +113,14 @@ mod test_reporting {
             // Use a deterministic temporary directory.
             // We can't have all tests use "tmp" because tests run in parallel,
             // so append the test name to the tmp path.
-            let tmp = format!("tmp/{}", subdir);
+            let tmp = format!("tmp/{subdir}");
             let dir = roc_test_utils::TmpDir::new(&tmp);
 
             let filename = PathBuf::from("Test.roc");
             let file_path = dir.path().join(filename);
             let full_file_path = file_path.clone();
             let mut file = File::create(file_path).unwrap();
-            writeln!(file, "{}", module_src).unwrap();
+            writeln!(file, "{module_src}").unwrap();
             let load_config = LoadConfig {
                 target_info: roc_target::TargetInfo::default_x86_64(),
                 render: RenderTarget::Generic,
@@ -218,7 +218,7 @@ mod test_reporting {
                 buf
             }
             Err(other) => {
-                panic!("failed to load: {:?}", other);
+                panic!("failed to load: {other:?}");
             }
         }
     }
@@ -389,7 +389,7 @@ mod test_reporting {
         // convenient to copy-paste the generated message
         if buf != expected_rendering {
             for line in buf.split('\n') {
-                println!("                {}", line);
+                println!("                {line}");
             }
         }
 

--- a/crates/roc_std/tests/test_roc_std.rs
+++ b/crates/roc_std/tests/test_roc_std.rs
@@ -39,7 +39,7 @@ pub unsafe extern "C" fn roc_panic(c_ptr: *mut c_void, tag_id: u32) {
         0 => {
             let c_str = CStr::from_ptr(c_ptr as *const c_char);
             let string = c_str.to_str().unwrap();
-            panic!("roc_panic during test: {}", string);
+            panic!("roc_panic during test: {string}");
         }
         _ => todo!(),
     }
@@ -282,16 +282,16 @@ mod test_roc_std {
         );
 
         let half = RocDec::from_str("0.5").unwrap();
-        assert_eq!(format!("{}", half), "0.5");
+        assert_eq!(format!("{half}"), "0.5");
 
         let ten = RocDec::from_str("10").unwrap();
-        assert_eq!(format!("{}", ten), "10");
+        assert_eq!(format!("{ten}"), "10");
 
         let example = RocDec::from_str("1234.5678").unwrap();
-        assert_eq!(format!("{}", example), "1234.5678");
+        assert_eq!(format!("{example}"), "1234.5678");
 
         let example = RocDec::from_str("1_000.5678").unwrap();
-        assert_eq!(format!("{}", example), "1000.5678");
+        assert_eq!(format!("{example}"), "1000.5678");
     }
 
     #[test]

--- a/crates/utils/command/src/lib.rs
+++ b/crates/utils/command/src/lib.rs
@@ -112,12 +112,11 @@ fn check_command_available(command_name: &str) -> bool {
 
         cmd.args([command_name]);
 
-        let cmd_str = format!("{:?}", cmd);
+        let cmd_str = format!("{cmd:?}");
 
         let cmd_out = cmd.output().unwrap_or_else(|err| {
             panic!(
-                "Failed to execute `{}` to check if {} is available:\n    {}",
-                cmd_str, command_name, err
+                "Failed to execute `{cmd_str}` to check if {command_name} is available:\n    {err}"
             )
         });
 

--- a/crates/utils/error/src/lib.rs
+++ b/crates/utils/error/src/lib.rs
@@ -42,7 +42,7 @@ pub fn map_get<'a, K: ::std::fmt::Debug + std::hash::Hash + std::cmp::Eq, V>(
     key: &K,
 ) -> UtilResult<&'a V> {
     let value = hash_map.get(key).context(KeyNotFoundSnafu {
-        key_str: format!("{:?}", key),
+        key_str: format!("{key:?}"),
     })?;
 
     Ok(value)
@@ -53,8 +53,8 @@ pub fn index_of<T: ::std::fmt::Debug + std::cmp::Eq>(elt: T, slice: &[T]) -> Uti
         .iter()
         .position(|slice_elt| *slice_elt == elt)
         .with_context(|| {
-            let elt_str = format!("{:?}", elt);
-            let collection_str = format!("{:?}", slice);
+            let elt_str = format!("{elt:?}");
+            let collection_str = format!("{slice:?}");
 
             IndexOfFailedSnafu {
                 elt_str,
@@ -115,8 +115,8 @@ pub fn first_last_index_of<T: ::std::fmt::Debug + std::cmp::Eq>(
     if let (Some(first_index), Some(last_index)) = (first_index_opt, last_index_opt) {
         Ok((first_index, last_index))
     } else {
-        let elt_str = format!("{:?}", elt);
-        let collection_str = format!("{:?}", slice);
+        let elt_str = format!("{elt:?}");
+        let collection_str = format!("{slice:?}");
 
         IndexOfFailedSnafu {
             elt_str,

--- a/crates/valgrind/src/lib.rs
+++ b/crates/valgrind/src/lib.rs
@@ -122,10 +122,10 @@ fn valgrind_test_linux(source: &str) {
         Err(roc_build::program::BuildFileError::LoadingProblem(
             roc_load::LoadingProblem::FormattedReport(report),
         )) => {
-            eprintln!("{}", report);
+            eprintln!("{report}");
             panic!("");
         }
-        Err(e) => panic!("{:?}", e),
+        Err(e) => panic!("{e:?}"),
     }
 
     drop(temp_dir)
@@ -180,7 +180,7 @@ fn run_with_valgrind(binary_path: &std::path::Path) {
                     what: _,
                     xwhat,
                 } = error;
-                println!("Valgrind Error: {}\n", kind);
+                println!("Valgrind Error: {kind}\n");
 
                 if let Some(ValgrindErrorXWhat {
                     text,
@@ -188,14 +188,14 @@ fn run_with_valgrind(binary_path: &std::path::Path) {
                     leakedblocks: _,
                 }) = xwhat
                 {
-                    println!("    {}", text);
+                    println!("    {text}");
                 }
             }
             panic!("Valgrind found memory errors");
         }
     } else {
         let exit_code = match valgrind_out.status.code() {
-            Some(code) => format!("exit code {}", code),
+            Some(code) => format!("exit code {code}"),
             None => "no exit code".to_string(),
         };
 

--- a/crates/vendor/morphic_lib/src/preprocess.rs
+++ b/crates/vendor/morphic_lib/src/preprocess.rs
@@ -160,23 +160,23 @@ impl std::fmt::Display for Error {
 
         if let Some(mod_) = &self.mod_ {
             loc_prefix(f)?;
-            write!(f, "module {:?}", mod_)?;
+            write!(f, "module {mod_:?}")?;
         }
 
         if let Some(def) = &self.def {
             loc_prefix(f)?;
             match def {
                 DefName::Type(name) => {
-                    write!(f, "named type definition {:?}", name)?;
+                    write!(f, "named type definition {name:?}")?;
                 }
                 DefName::Func(name) => {
-                    write!(f, "function definition {:?}", name)?;
+                    write!(f, "function definition {name:?}")?;
                 }
                 DefName::Const(name) => {
-                    write!(f, "constant definition {:?}", name)?;
+                    write!(f, "constant definition {name:?}")?;
                 }
                 DefName::EntryPoint(name) => {
-                    write!(f, "entry point definition {:?}", name)?;
+                    write!(f, "entry point definition {name:?}")?;
                 }
             }
         }
@@ -185,13 +185,13 @@ impl std::fmt::Display for Error {
             loc_prefix(f)?;
             match binding {
                 BindingLocation::Type(id) => {
-                    write!(f, "definition of type binding {:?}", id)?;
+                    write!(f, "definition of type binding {id:?}")?;
                 }
                 BindingLocation::Value(id) => {
-                    write!(f, "definition of value binding {:?}", id)?;
+                    write!(f, "definition of value binding {id:?}")?;
                 }
                 BindingLocation::Continuation(id) => {
-                    write!(f, "definition of continuation binding {:?}", id)?;
+                    write!(f, "definition of continuation binding {id:?}")?;
                 }
             }
         }

--- a/crates/vendor/morphic_lib/src/render_api_ir.rs
+++ b/crates/vendor/morphic_lib/src/render_api_ir.rs
@@ -39,7 +39,7 @@ impl RenderContext {
                 .extend((0..self.indent_level * self.spaces_per_level).map(|_| ' '));
             self.pending_indent = false;
         }
-        write!(&mut self.content, "{}", to_write).expect("writing to string failed");
+        write!(&mut self.content, "{to_write}").expect("writing to string failed");
     }
 
     fn writeln(&mut self, to_write: impl std::fmt::Display) {
@@ -146,8 +146,7 @@ fn render_op(builder: &ExprBuilder, ctx: &mut RenderContext, op: &Op) {
     match op {
         Op::Arg | Op::ContinuationArg | Op::DeclareContinuation { .. } => {
             ctx.write(format_args!(
-                "/* internal error: {:?} should not be rendered as a value */",
-                op
+                "/* internal error: {op:?} should not be rendered as a value */"
             ));
         }
 
@@ -252,7 +251,7 @@ fn render_op(builder: &ExprBuilder, ctx: &mut RenderContext, op: &Op) {
         }
 
         Op::GetTupleField { field_idx } => {
-            ctx.write(format_args!("get_tuple_field {}", field_idx));
+            ctx.write(format_args!("get_tuple_field {field_idx}"));
         }
 
         Op::MakeUnion {
@@ -270,11 +269,11 @@ fn render_op(builder: &ExprBuilder, ctx: &mut RenderContext, op: &Op) {
                     ctx.write(type_ident(*variant_type));
                 },
             );
-            ctx.write(format_args!("> {}", variant_idx));
+            ctx.write(format_args!("> {variant_idx}"));
         }
 
         Op::UnwrapUnion { variant_idx } => {
-            ctx.write(format_args!("unwrap_union {}", variant_idx));
+            ctx.write(format_args!("unwrap_union {variant_idx}"));
         }
 
         Op::MakeNamed { named_mod, named } => {

--- a/crates/wasi-libc-sys/build.rs
+++ b/crates/wasi-libc-sys/build.rs
@@ -24,7 +24,7 @@ fn main() {
             "--global-cache-dir",
             zig_cache_dir.to_str().unwrap(),
             "src/dummy.c",
-            &format!("-femit-bin={}/dummy.wasm", out_dir),
+            &format!("-femit-bin={out_dir}/dummy.wasm"),
         ])
         .output()
         .unwrap();

--- a/crates/wasm_interp/src/instance.rs
+++ b/crates/wasm_interp/src/instance.rs
@@ -105,7 +105,7 @@ impl<'a, I: ImportDispatcher> Instance<'a, I> {
         is_debug_mode: bool,
     ) -> Result<Self, std::string::String> {
         let module =
-            WasmModule::preload(arena, module_bytes, false).map_err(|e| format!("{:?}", e))?;
+            WasmModule::preload(arena, module_bytes, false).map_err(|e| format!("{e:?}"))?;
         Self::for_module(arena, arena.alloc(module), import_dispatcher, is_debug_mode)
     }
 
@@ -178,8 +178,7 @@ impl<'a, I: ImportDispatcher> Instance<'a, I> {
             let actual_type = ValueType::from(value);
             if actual_type != expected_type {
                 return Err(format!(
-                    "Type mismatch on argument {} of {}. Expected {:?} but got {:?}",
-                    i, fn_name, expected_type, value
+                    "Type mismatch on argument {i} of {fn_name}. Expected {expected_type:?} but got {value:?}"
                 ));
             }
             self.value_store.push(value);
@@ -261,10 +260,7 @@ impl<'a, I: ImportDispatcher> Instance<'a, I> {
                     )
                 })
                 .ok_or_else(|| {
-                    format!(
-                        "I couldn't find a function '{}' in this WebAssembly module",
-                        fn_name
-                    )
+                    format!("I couldn't find a function '{fn_name}' in this WebAssembly module")
                 })? as usize
         };
 
@@ -348,7 +344,7 @@ impl<'a, I: ImportDispatcher> Instance<'a, I> {
     fn fetch_immediate_u32(&mut self, module: &WasmModule<'a>) -> u32 {
         let x = u32::parse((), &module.code.bytes, &mut self.program_counter).unwrap();
         if let Some(debug_string) = self.debug_string.as_mut() {
-            write!(debug_string, "{} ", x).unwrap();
+            write!(debug_string, "{x} ").unwrap();
         }
         x
     }
@@ -426,7 +422,7 @@ impl<'a, I: ImportDispatcher> Instance<'a, I> {
 
     fn write_debug<T: fmt::Debug>(&mut self, value: T) {
         if let Some(debug_string) = self.debug_string.as_mut() {
-            std::write!(debug_string, "{:?} ", value).unwrap();
+            std::write!(debug_string, "{value:?} ").unwrap();
         }
     }
 
@@ -512,8 +508,7 @@ impl<'a, I: ImportDispatcher> Instance<'a, I> {
         if let Some(expected) = expected_signature {
             assert_eq!(
                 expected, signature_index,
-                "Indirect function call failed. Expected signature {} but found {}",
-                expected, signature_index,
+                "Indirect function call failed. Expected signature {expected} but found {signature_index}",
             );
         }
 
@@ -599,9 +594,9 @@ impl<'a, I: ImportDispatcher> Instance<'a, I> {
                 } else {
                     write!(debug_string, ", ").unwrap();
                 }
-                write!(debug_string, "{:x?}", arg).unwrap();
+                write!(debug_string, "{arg:x?}").unwrap();
             }
-            writeln!(debug_string, "] return_type={:?}", return_type).unwrap();
+            writeln!(debug_string, "] return_type={return_type:?}").unwrap();
         }
     }
 
@@ -747,15 +742,13 @@ impl<'a, I: ImportDispatcher> Instance<'a, I> {
                 // So far, all compilers seem to be emitting MVP-compatible code. (Rust, Zig, Roc...)
                 assert_eq!(
                     table_index, 0,
-                    "Table index {} not supported at file offset {:#x}. This interpreter only supports Wasm MVP.",
-                    table_index, file_offset
+                    "Table index {table_index} not supported at file offset {file_offset:#x}. This interpreter only supports Wasm MVP."
                 );
 
                 // Dereference the function pointer (look up the element index in the function table)
                 let fn_index = module.element.lookup(element_index).unwrap_or_else(|| {
                     panic!(
-                        "Indirect function call failed. There is no function with element index {}",
-                        element_index
+                        "Indirect function call failed. There is no function with element index {element_index}"
                     )
                 });
 
@@ -1613,28 +1606,28 @@ impl<'a, I: ImportDispatcher> Instance<'a, I> {
             I32TRUNCSF32 => {
                 let arg = self.value_store.pop_f32()?;
                 if arg < i32::MIN as f32 || arg > i32::MAX as f32 {
-                    panic!("Cannot truncate {} from F32 to I32", arg);
+                    panic!("Cannot truncate {arg} from F32 to I32");
                 }
                 self.value_store.push(Value::I32(arg as i32));
             }
             I32TRUNCUF32 => {
                 let arg = self.value_store.pop_f32()?;
                 if arg < u32::MIN as f32 || arg > u32::MAX as f32 {
-                    panic!("Cannot truncate {} from F32 to unsigned I32", arg);
+                    panic!("Cannot truncate {arg} from F32 to unsigned I32");
                 }
                 self.value_store.push(Value::from(arg as u32));
             }
             I32TRUNCSF64 => {
                 let arg = self.value_store.pop_f64()?;
                 if arg < i32::MIN as f64 || arg > i32::MAX as f64 {
-                    panic!("Cannot truncate {} from F64 to I32", arg);
+                    panic!("Cannot truncate {arg} from F64 to I32");
                 }
                 self.value_store.push(Value::I32(arg as i32));
             }
             I32TRUNCUF64 => {
                 let arg = self.value_store.pop_f64()?;
                 if arg < u32::MIN as f64 || arg > u32::MAX as f64 {
-                    panic!("Cannot truncate {} from F64 to unsigned I32", arg);
+                    panic!("Cannot truncate {arg} from F64 to unsigned I32");
                 }
                 self.value_store.push(Value::from(arg as u32));
             }
@@ -1649,28 +1642,28 @@ impl<'a, I: ImportDispatcher> Instance<'a, I> {
             I64TRUNCSF32 => {
                 let arg = self.value_store.pop_f32()?;
                 if arg < i64::MIN as f32 || arg > i64::MAX as f32 {
-                    panic!("Cannot truncate {} from F32 to I64", arg);
+                    panic!("Cannot truncate {arg} from F32 to I64");
                 }
                 self.value_store.push(Value::I64(arg as i64));
             }
             I64TRUNCUF32 => {
                 let arg = self.value_store.pop_f32()?;
                 if arg < u64::MIN as f32 || arg > u64::MAX as f32 {
-                    panic!("Cannot truncate {} from F32 to unsigned I64", arg);
+                    panic!("Cannot truncate {arg} from F32 to unsigned I64");
                 }
                 self.value_store.push(Value::from(arg as u64));
             }
             I64TRUNCSF64 => {
                 let arg = self.value_store.pop_f64()?;
                 if arg < i64::MIN as f64 || arg > i64::MAX as f64 {
-                    panic!("Cannot truncate {} from F64 to I64", arg);
+                    panic!("Cannot truncate {arg} from F64 to I64");
                 }
                 self.value_store.push(Value::I64(arg as i64));
             }
             I64TRUNCUF64 => {
                 let arg = self.value_store.pop_f64()?;
                 if arg < u64::MIN as f64 || arg > u64::MAX as f64 {
-                    panic!("Cannot truncate {} from F64 to unsigned I64", arg);
+                    panic!("Cannot truncate {arg} from F64 to unsigned I64");
                 }
                 self.value_store.push(Value::from(arg as u64));
             }
@@ -1739,12 +1732,12 @@ impl<'a, I: ImportDispatcher> Instance<'a, I> {
 
         if let Some(debug_string) = &self.debug_string {
             if matches!(op_code, CALL | CALLINDIRECT) {
-                eprintln!("\n{:06x} {}", file_offset, debug_string);
+                eprintln!("\n{file_offset:06x} {debug_string}");
             } else {
                 // For calls, we print special debug stuff in do_call
                 let base = self.current_frame.locals_start + self.current_frame.locals_count;
                 let slice = self.value_store.get_slice(base);
-                eprintln!("{:06x} {:17} {:x?}", file_offset, debug_string, slice);
+                eprintln!("{file_offset:06x} {debug_string:17} {slice:x?}");
             }
             let is_return = op_code == RETURN || (op_code == END && implicit_return);
             let is_program_end = self.program_counter == 0;
@@ -1762,7 +1755,7 @@ impl<'a, I: ImportDispatcher> Instance<'a, I> {
 
     #[allow(dead_code)]
     fn debug_values_and_blocks(&self, label: &str) {
-        eprintln!("\n========== {} ==========", label);
+        eprintln!("\n========== {label} ==========");
 
         let mut block_str = String::new();
         let mut block_iter = self.blocks.iter().enumerate();
@@ -1774,17 +1767,17 @@ impl<'a, I: ImportDispatcher> Instance<'a, I> {
                 if *vstack > i {
                     break;
                 }
-                write!(block_str, "{}:{:?} ", b, ty).unwrap();
+                write!(block_str, "{b}:{ty:?} ").unwrap();
                 block = block_iter.next();
             }
             if !block_str.is_empty() {
-                eprintln!("--------------- {}", block_str);
+                eprintln!("--------------- {block_str}");
             }
         };
 
         for (i, v) in self.value_store.iter().enumerate() {
             print_blocks(i);
-            eprintln!("{:3} {:x?}", i, v);
+            eprintln!("{i:3} {v:x?}");
         }
         print_blocks(self.value_store.depth());
 
@@ -1801,7 +1794,7 @@ impl<'a, I: ImportDispatcher> Instance<'a, I> {
     /// --------------
     fn debug_stack_trace(&self, buffer: &mut String) -> fmt::Result {
         let divider = "-------------------";
-        writeln!(buffer, "{}", divider)?;
+        writeln!(buffer, "{divider}")?;
 
         let frames = self.previous_frames.iter().chain(once(&self.current_frame));
         let next_frames = frames.clone().skip(1);
@@ -1850,7 +1843,7 @@ impl<'a, I: ImportDispatcher> Instance<'a, I> {
                 .unwrap_or("");
 
             // Function and address match wasm-objdump formatting, for easy copy & find
-            writeln!(buffer, "func[{}]  {}", fn_index, fn_name)?;
+            writeln!(buffer, "func[{fn_index}]  {fn_name}")?;
             writeln!(buffer, "  address  {:06x}", execution_addrs.next().unwrap())?;
 
             write!(buffer, "  args     ")?;
@@ -1861,7 +1854,7 @@ impl<'a, I: ImportDispatcher> Instance<'a, I> {
                 } else if local_index != 0 {
                     write!(buffer, ", ")?;
                 }
-                write!(buffer, "{}: {:?}", local_index, value)?;
+                write!(buffer, "{local_index}: {value:?}")?;
             }
 
             write!(buffer, "\n  stack    [")?;
@@ -1874,10 +1867,10 @@ impl<'a, I: ImportDispatcher> Instance<'a, I> {
                 if i != stack_start {
                     write!(buffer, ", ")?;
                 }
-                write!(buffer, "{:?}", value)?;
+                write!(buffer, "{value:?}")?;
             }
             writeln!(buffer, "]")?;
-            writeln!(buffer, "{}", divider)?;
+            writeln!(buffer, "{divider}")?;
         }
 
         Ok(())

--- a/crates/wasm_interp/src/lib.rs
+++ b/crates/wasm_interp/src/lib.rs
@@ -53,10 +53,7 @@ impl<'a> ImportDispatcher for DefaultImportDispatcher<'a> {
         if module_name == wasi::MODULE_NAME {
             self.wasi.dispatch(function_name, arguments, memory)
         } else {
-            panic!(
-                "DefaultImportDispatcher does not implement {}.{}",
-                module_name, function_name
-            );
+            panic!("DefaultImportDispatcher does not implement {module_name}.{function_name}");
         }
     }
 }
@@ -76,14 +73,12 @@ impl Error {
         match self {
             Error::Type(expected, actual) => {
                 format!(
-                    "ERROR: I found a type mismatch at file offset {:#x}. Expected {:?}, but found {:?}.\n", 
-                    file_offset, expected, actual
+                    "ERROR: I found a type mismatch at file offset {file_offset:#x}. Expected {expected:?}, but found {actual:?}.\n"
                 )
             }
             Error::StackEmpty => {
                 format!(
-                    "ERROR: I tried to pop a value from the stack at file offset {:#x}, but it was empty.\n",
-                    file_offset
+                    "ERROR: I tried to pop a value from the stack at file offset {file_offset:#x}, but it was empty.\n"
                 )
             }
             Error::MemoryAccessOutOfBounds(addr, memory_size) => {
@@ -93,10 +88,7 @@ impl Error {
                 )
             }
             Error::UnreachableOp => {
-                format!(
-                    "WebAssembly `unreachable` instruction at file offset {:#x}.\n",
-                    file_offset
-                )
+                format!("WebAssembly `unreachable` instruction at file offset {file_offset:#x}.\n")
             }
         }
     }

--- a/crates/wasm_interp/src/main.rs
+++ b/crates/wasm_interp/src/main.rs
@@ -90,7 +90,7 @@ fn main() -> io::Result<()> {
     let dispatcher = DefaultImportDispatcher::new(&wasi_argv);
     let mut inst =
         Instance::for_module(&arena, &module, dispatcher, is_debug_mode).unwrap_or_else(|e| {
-            eprintln!("{}", e);
+            eprintln!("{e}");
             process::exit(2);
         });
 
@@ -103,14 +103,14 @@ fn main() -> io::Result<()> {
     match result {
         Ok(Some(val)) => {
             if is_hex_format {
-                println!("{:#x?}", val)
+                println!("{val:#x?}")
             } else {
-                println!("{:?}", val)
+                println!("{val:?}")
             }
         }
         Ok(None) => {}
         Err(e) => {
-            eprintln!("{}", e);
+            eprintln!("{e}");
             process::exit(3);
         }
     }

--- a/crates/wasm_interp/src/tests/mod.rs
+++ b/crates/wasm_interp/src/tests/mod.rs
@@ -85,7 +85,7 @@ where
 
     // Dump the generated module to a file (this is mainly for debugging the test itself)
     if std::env::var("DEBUG_WASM_INTERP_TEST").is_ok() {
-        let filename = format!("/tmp/{:?}.wasm", op);
+        let filename = format!("/tmp/{op:?}.wasm");
         println!("\nDumping test module to {}\n", &filename);
         let mut outfile_buf = Vec::new_in(&arena);
         module.serialize(&mut outfile_buf);

--- a/crates/wasm_interp/src/tests/test_basics.rs
+++ b/crates/wasm_interp/src/tests/test_basics.rs
@@ -563,7 +563,7 @@ fn test_call_import() {
         module.serialize(&mut buf);
         let filename = "/tmp/roc/call-return.wasm";
         std::fs::write(filename, buf).unwrap();
-        println!("Wrote to {}", filename);
+        println!("Wrote to {filename}");
     }
 
     let mut inst = Instance::for_module(&arena, &module, import_dispatcher, true).unwrap();
@@ -631,7 +631,7 @@ fn test_call_return_no_args() {
         module.serialize(&mut buf);
         let filename = "/tmp/roc/call-return.wasm";
         std::fs::write(filename, buf).unwrap();
-        println!("Wrote to {}", filename);
+        println!("Wrote to {filename}");
     }
 
     let mut inst =
@@ -771,9 +771,9 @@ fn test_call_indirect_help(table_index: u32, elem_index: u32) -> Value {
     if false {
         let mut outfile_buf = Vec::new_in(&arena);
         module.serialize(&mut outfile_buf);
-        let filename = format!("/tmp/roc/call_indirect_{}_{}.wasm", table_index, elem_index);
+        let filename = format!("/tmp/roc/call_indirect_{table_index}_{elem_index}.wasm");
         std::fs::write(&filename, outfile_buf).unwrap();
-        println!("\nWrote to {}\n", filename);
+        println!("\nWrote to {filename}\n");
     }
 
     let mut inst = Instance::for_module(

--- a/crates/wasm_interp/src/value_store.rs
+++ b/crates/wasm_interp/src/value_store.rs
@@ -158,6 +158,6 @@ mod tests {
             stack.push(val);
         }
 
-        assert_eq!(format!("{:?}", VALUES), format!("{:?}", stack));
+        assert_eq!(format!("{VALUES:?}"), format!("{stack:?}"));
     }
 }

--- a/crates/wasm_interp/src/wasi.rs
+++ b/crates/wasm_interp/src/wasi.rs
@@ -161,7 +161,7 @@ impl<'a> WasiDispatcher<'a> {
                 if fd < self.files.len() {
                     success_code
                 } else {
-                    println!("WASI warning: file descriptor {} does not exist", fd);
+                    println!("WASI warning: file descriptor {fd} does not exist");
                     Some(Value::I32(Errno::Badf as i32))
                 }
             }
@@ -291,8 +291,7 @@ impl<'a> WasiDispatcher<'a> {
                 if negative_length_count > 0 {
                     // Let's see if we ever get this message. If not, we can remove this negative-length stuff.
                     eprintln!(
-                        "WASI DEV INFO: found {} negative-length iovecs.",
-                        negative_length_count
+                        "WASI DEV INFO: found {negative_length_count} negative-length iovecs."
                     );
                 }
 
@@ -331,7 +330,7 @@ impl<'a> WasiDispatcher<'a> {
             "sock_recv" => todo!("WASI {}({:?})", function_name, arguments),
             "sock_send" => todo!("WASI {}({:?})", function_name, arguments),
             "sock_shutdown" => todo!("WASI {}({:?})", function_name, arguments),
-            _ => panic!("Unknown WASI function {}({:?})", function_name, arguments),
+            _ => panic!("Unknown WASI function {function_name}({arguments:?})"),
         }
     }
 }

--- a/crates/wasm_module/src/lib.rs
+++ b/crates/wasm_module/src/lib.rs
@@ -183,10 +183,7 @@ impl<'a> WasmModule<'a> {
                     module_errors,
                 )
             } else {
-                format!(
-                    "I wasn't able to understand this WebAssembly file.\n{}",
-                    module_errors,
-                )
+                format!("I wasn't able to understand this WebAssembly file.\n{module_errors}",)
             };
             return Err(ParseError { offset: 0, message });
         }

--- a/crates/wasm_module/src/linking.rs
+++ b/crates/wasm_module/src/linking.rs
@@ -144,7 +144,7 @@ impl Parse<()> for RelocationEntry {
 
         Err(ParseError {
             offset: *cursor,
-            message: format!("Unknown relocation type 0x{:2x}", type_id_byte),
+            message: format!("Unknown relocation type 0x{type_id_byte:2x}"),
         })
     }
 }
@@ -491,7 +491,7 @@ impl Parse<()> for SymType {
             5 => Ok(Self::Table),
             x => Err(ParseError {
                 offset,
-                message: format!("Invalid symbol info type in linking section: {}", x),
+                message: format!("Invalid symbol info type in linking section: {x}"),
             }),
         }
     }
@@ -536,7 +536,7 @@ impl Parse<()> for SubSectionId {
             8 => Ok(Self::SymbolTable),
             x => Err(ParseError {
                 offset,
-                message: format!("Invalid linking subsection ID {}", x),
+                message: format!("Invalid linking subsection ID {x}"),
             }),
         }
     }
@@ -578,10 +578,7 @@ impl<'a> LinkingSection<'a> {
             .iter()
             .position(|sym| sym.name() == Some(target_name))
             .ok_or_else(|| {
-                format!(
-                    "Linking failed! Can't find `{}` in host symbol table",
-                    target_name
-                )
+                format!("Linking failed! Can't find `{target_name}` in host symbol table")
             })
     }
 
@@ -596,7 +593,7 @@ impl<'a> LinkingSection<'a> {
                 _ => false,
             })
             .map(|sym_index| sym_index as u32)
-            .ok_or_else(|| format!("Can't find fn #{} in host symbol table", fn_index))
+            .ok_or_else(|| format!("Can't find fn #{fn_index} in host symbol table"))
     }
 
     pub fn find_and_reindex_imported_fn(
@@ -619,10 +616,7 @@ impl<'a> LinkingSection<'a> {
             })
             .map(|sym_index| sym_index as u32)
             .ok_or_else(|| {
-                format!(
-                    "Linking failed! Can't find fn #{} in host symbol table",
-                    old_fn_index
-                )
+                format!("Linking failed! Can't find fn #{old_fn_index} in host symbol table")
             })
     }
 }
@@ -650,8 +644,7 @@ impl<'a> Parse<&'a Bump> for LinkingSection<'a> {
             return Err(ParseError {
                 offset: *cursor,
                 message: format!(
-                    "This file uses version {} of Wasm linking data, but only version {} is supported.",
-                    linking_version, LINKING_VERSION
+                    "This file uses version {linking_version} of Wasm linking data, but only version {LINKING_VERSION} is supported."
                 ),
             });
         }

--- a/crates/wasm_module/src/sections.rs
+++ b/crates/wasm_module/src/sections.rs
@@ -628,7 +628,7 @@ impl Parse<()> for RefType {
             0x6f => Ok(Self::Extern),
             _ => Err(ParseError {
                 offset: *cursor - 1,
-                message: format!("Invalid RefType 0x{:2x}", byte),
+                message: format!("Invalid RefType 0x{byte:2x}"),
             }),
         }
     }
@@ -973,7 +973,7 @@ impl Parse<()> for ConstExpr {
             }
             _ => Err(ParseError {
                 offset: *cursor,
-                message: format!("Unsupported opcode {:?} in constant expression.", opcode),
+                message: format!("Unsupported opcode {opcode:?} in constant expression."),
             }),
         };
 
@@ -1522,7 +1522,7 @@ impl Parse<()> for DataMode {
         } else {
             Err(ParseError {
                 offset: *cursor - 1,
-                message: format!("Data section: invalid DataMode variant 0x{:x}", variant_id),
+                message: format!("Data section: invalid DataMode variant 0x{variant_id:x}"),
             })
         }
     }
@@ -1574,7 +1574,7 @@ impl<'a> DataSection<'a> {
         let mut cursor = 0;
         for _ in 0..self.count {
             let mode =
-                DataMode::parse((), &self.bytes, &mut cursor).map_err(|e| format!("{:?}", e))?;
+                DataMode::parse((), &self.bytes, &mut cursor).map_err(|e| format!("{e:?}"))?;
             let start = match mode {
                 DataMode::Active {
                     offset: ConstExpr::I32(addr),
@@ -1583,12 +1583,12 @@ impl<'a> DataSection<'a> {
                     continue;
                 }
             };
-            let len32 = u32::parse((), &self.bytes, &mut cursor).map_err(|e| format!("{:?}", e))?;
+            let len32 = u32::parse((), &self.bytes, &mut cursor).map_err(|e| format!("{e:?}"))?;
             let len = len32 as usize;
             let mut target_slice = &mut memory[start..][..len];
             target_slice
                 .write(&self.bytes[cursor..][..len])
-                .map_err(|e| format!("{:?}", e))?;
+                .map_err(|e| format!("{e:?}"))?;
             cursor += len;
         }
         Ok(())
@@ -1859,7 +1859,7 @@ impl<'a> Debug for NameSection<'a> {
         writeln!(f, "NameSection")?;
 
         for (index, name) in self.function_names.iter() {
-            writeln!(f, "  {:4}: {}", index, name)?;
+            writeln!(f, "  {index:4}: {name}")?;
         }
 
         Ok(())

--- a/devtools/flake.lock
+++ b/devtools/flake.lock
@@ -115,8 +115,8 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1682761608,
-        "narHash": "sha256-+6tHbEK8GYDSCLasgawufSLegyJ0cqHV2nfmJICwzrk=",
+        "lastModified": 1682784625,
+        "narHash": "sha256-QUncKiwgpmHajo601NNHOjeUG2/vrGp1oMgxnPhq900=",
         "path": "/home/username/gitrepos/roc9/roc",
         "type": "path"
       },

--- a/examples/platform-switching/rust-platform/rust-toolchain.toml
+++ b/examples/platform-switching/rust-platform/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.66.1"
+channel = "1.67.1"
 
 profile = "default"
 

--- a/flake.lock
+++ b/flake.lock
@@ -74,17 +74,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1674860021,
-        "narHash": "sha256-ES4XUf/AlPp8RetKR6WlWgYEZ7bLWI7k6reHp2q9rqY=",
+        "lastModified": 1679868513,
+        "narHash": "sha256-uRGLALUmieyMVqVt3mXEv0a+g9ouFOCmsv7V/01efEc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9f4346eac544cc0db5eb7d889e71eac0f9c8b9eb",
+        "rev": "d7887373fe0731719365831cd254c1e5948307d3",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9f4346eac544cc0db5eb7d889e71eac0f9c8b9eb",
+        "rev": "d7887373fe0731719365831cd254c1e5948307d3",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "Roc flake";
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs?rev=9f4346eac544cc0db5eb7d889e71eac0f9c8b9eb";
+    nixpkgs.url = "github:nixos/nixpkgs?rev=d7887373fe0731719365831cd254c1e5948307d3";
 
     # rust from nixpkgs has some libc problems, this is patched in the rust-overlay
     rust-overlay = {
@@ -90,7 +90,7 @@
           llvmPkgs.clang
           libxkbcommon
           pkg-config
-          zig # roc builtins are implemented in zig, see compiler/builtins/bitcode/
+          zig_0_9 # roc builtins are implemented in zig, see compiler/builtins/bitcode/
 
           # lib deps
           libffi

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -9,9 +9,9 @@
 #     - update nightly-OLD_DATE in .github/workflows/windows_release_build.yml
 #     - update nightly-OLD_DATE in crates/compiler/build/src/link.rs
 
-channel = "1.66.1" # check ^^^ when changing this
+channel = "1.67.1" # check ^^^ when changing this
 # 
-# channel = "nightly-2022-10-30" # 1.66.0 nightly to be able to use unstable features
+# channel = "nightly-2022-12-09" # 1.67.0 nightly to be able to use unstable features
 profile = "default"
 components = [
     # for usages of rust-analyzer or similar tools inside `nix develop`


### PR DESCRIPTION
This upgrade is causing a segmentation fault when running ./crates/repl_test/test_wasm.sh.
When upgrading to 1.67 the size of `Stmt` and `Expr` also changed from:
```
roc_error_macros::assert_sizeof_non_wasm!(Expr, 9 * 8);
roc_error_macros::assert_sizeof_non_wasm!(Stmt, 12 * 8);
```
to:
```
roc_error_macros::assert_sizeof_non_wasm!(Expr, 10 * 8);
roc_error_macros::assert_sizeof_non_wasm!(Stmt, 13 * 8);
```
So that could be related to this issue.

Lots of tests out of the `repl_test` suite are segfaulting:
```
arbitrary_tag_unions 
basic_1_field_f64_record 
basic_1_field_i64_record 
basic_2_field_f64_record 
basic_2_field_i64_record 
basic_2_field_mixed_record 
basic_3_field_record 
bool_basic_equality 
bool_false 
bool_in_record 
bool_true 
byte_tag_union 
dec_in_repl 
empty_record 
enum_tag_union_in_list 
float_addition 
four_element_record 
identity_lambda 
int_addition 
issue_2149 
issue_2810_recursive_layout_inside_nonrecursive 
large_nullable_wrapped_tag_union 
large_recursive_tag_union_flat_variant 
large_recursive_tag_union_recursive_variant 
list_of_1_field_records 
list_of_2_field_records 
list_of_3_field_records 
literal_0 
literal_42
...
```
I assume `literal_0` is the simplest failure:
[valgrind output for literal_0 test](https://pastebin.com/emunqkMp)