### PR TITLE
add missing symbols to dev object files on unix

### DIFF
--- a/crates/compiler/gen_dev/src/object_builder.rs
+++ b/crates/compiler/gen_dev/src/object_builder.rs
@@ -214,6 +214,22 @@ fn build_object<'a, B: Backend<'a>>(
             "roc_panic".into(),
             "roc_builtins.utils.test_panic".into(),
         );
+        // Extra symbols only required on unix systems.
+        if matches!(output.format(), BinaryFormat::Elf | BinaryFormat::MachO) {
+            generate_wrapper(
+                &mut backend,
+                &mut output,
+                "roc_getppid".into(),
+                "getppid".into(),
+            );
+            generate_wrapper(&mut backend, &mut output, "roc_mmap".into(), "mmap".into());
+            generate_wrapper(
+                &mut backend,
+                &mut output,
+                "roc_shm_open".into(),
+                "shm_open".into(),
+            );
+        }
     }
 
     // Setup layout_ids for procedure calls.


### PR DESCRIPTION
Just adding wrappers to make `ld` happy.