### PR TITLE
do test-gen-dev on nix too

### DIFF
--- a/.github/workflows/nix_linux_x86_64.yml
+++ b/.github/workflows/nix_linux_x86_64.yml
@@ -27,3 +27,6 @@ jobs:
 
       - name: test wasm32 cli_run
         run: nix develop -c cargo test --locked --release --features="wasm32-cli-run"
+
+      - name: test the dev backend # these tests require an explicit feature flag
+        run: cargo test --locked --release --package test_gen --no-default-features --features gen-dev

--- a/.github/workflows/nix_linux_x86_64.yml
+++ b/.github/workflows/nix_linux_x86_64.yml
@@ -29,4 +29,4 @@ jobs:
         run: nix develop -c cargo test --locked --release --features="wasm32-cli-run"
 
       - name: test the dev backend # these tests require an explicit feature flag
-        run: cargo test --locked --release --package test_gen --no-default-features --features gen-dev
+        run: nix develop -c cargo test --locked --release --package test_gen --no-default-features --features gen-dev


### PR DESCRIPTION
There used to be an uncaught failure of the gen-dev tests that only occurred on nix, this test should prevent that from happening in the future.