### PR TITLE
Determine host-exposed lambda sets once based on proc variable

### DIFF
--- a/crates/compiler/load_internal/src/file.rs
+++ b/crates/compiler/load_internal/src/file.rs
@@ -3437,7 +3437,7 @@ fn finish_specialization<'a>(
                 );
 
                 let lambda_set_names = all_glue_procs
-                    .extern_names
+                    .legacy_layout_based_extern_names
                     .iter()
                     .map(|(lambda_set_id, _)| (*_name, *lambda_set_id));
                 exposed_to_host.lambda_sets.extend(lambda_set_names);


### PR DESCRIPTION
Rather than calculating the HELS for each host-exposed layout (of which there may be multiple), we only need to calculate the HELS based on the top-level type of the host-exposed function.

Also renamed `GlueProcs.extern_names` to
`GlueProcs.legacy_layout_based_extern_names` since they are still currently generated based on the layout, but I think we want to generate all HELS via type variable.

Fixes false-interpreter builds in debug.