### PR TITLE
Docs: read static assets from fs for debug builds

### DIFF
--- a/crates/docs/src/lib.rs
+++ b/crates/docs/src/lib.rs
@@ -80,13 +80,22 @@ pub fn generate_docs_html(root_file: PathBuf) {
         }
     })();
 
-    fs::write(build_dir.join("search.js"), assets.search_js).unwrap();
-    fs::write(build_dir.join("styles.css"), assets.styles_css).unwrap();
-    fs::write(build_dir.join("favicon.svg"), assets.favicon_svg).unwrap();
-
-    // Get the html template
-    // For debug builds, read from fs to speed up build
-    // Otherwise, include as string literal
+    // Write CSS, JS, and favicon
+    // (The HTML requires more work!)
+    for (file, contents) in [
+        ("search.js", assets.search_js),
+        ("styles.css", assets.styles_css),
+        ("favicon.svg", assets.favicon_svg),
+    ] {
+        let dir = build_dir.join(file);
+        fs::write(&dir, contents).unwrap_or_else(|error| {
+            panic!(
+                "Attempted to write {} but failed with this error: {}",
+                dir.display(),
+                error
+            )
+        })
+    }
 
     // Insert asset urls & sidebar links
     let template_html = assets

--- a/crates/docs/src/lib.rs
+++ b/crates/docs/src/lib.rs
@@ -36,25 +36,50 @@ pub fn generate_docs_html(root_file: PathBuf) {
     fs::create_dir_all(build_dir).expect("TODO gracefully handle being unable to create build dir");
 
     // Copy over the assets
-    fs::write(
-        build_dir.join("search.js"),
-        include_str!("./static/search.js"),
-    )
-    .expect("TODO gracefully handle failing to make the search javascript");
+    // For debug builds, read assets from fs to speed up build
+    // Otherwise, include as string literal
 
-    fs::write(
-        build_dir.join("styles.css"),
-        include_str!("./static/styles.css"),
-    )
-    .expect("TODO gracefully handle failing to make the stylesheet");
+    // Copy search.js
+    #[cfg(not(debug_assertions))]
+    let search_js = include_str!("./static/search.js");
 
-    fs::write(
-        build_dir.join("favicon.svg"),
-        include_str!("./static/favicon.svg"),
-    )
-    .expect("TODO gracefully handle failing to make the favicon");
+    #[cfg(debug_assertions)]
+    let search_js = fs::read_to_string("./crates/docs/src/static/search.js").unwrap();
 
-    let template_html = include_str!("./static/index.html")
+    fs::write(build_dir.join("search.js"), search_js)
+        .expect("TODO gracefully handle failing to make the search javascript");
+
+    // Copy styles.css
+    #[cfg(not(debug_assertions))]
+    let styles_css = include_str!("./static/styles.css");
+
+    #[cfg(debug_assertions)]
+    let styles_css = fs::read_to_string("./crates/docs/src/static/styles.css").unwrap();
+
+    fs::write(build_dir.join("styles.css"), styles_css)
+        .expect("TODO gracefully handle failing to make the stylesheet");
+
+    // Copy favicon.svg
+    #[cfg(not(debug_assertions))]
+    let favicon_svg = include_str!("./static/favicon.svg");
+
+    #[cfg(debug_assertions)]
+    let favicon_svg = fs::read_to_string("./crates/docs/src/static/favicon.svg").unwrap();
+
+    fs::write(build_dir.join("favicon.svg"), favicon_svg)
+        .expect("TODO gracefully handle failing to make the favicon");
+
+    // Get the html template
+    // For debug builds, read from fs to speed up build
+    // Otherwise, include as string literal
+    #[cfg(not(debug_assertions))]
+    let raw_template_html = include_str!("./static/index.html");
+
+    #[cfg(debug_assertions)]
+    let raw_template_html = fs::read_to_string("./crates/docs/src/static/index.html").unwrap();
+
+    // Insert asset urls & sidebar links
+    let template_html = raw_template_html
         .replace("<!-- search.js -->", "/search.js")
         .replace("<!-- styles.css -->", "/styles.css")
         .replace("<!-- favicon.svg -->", "/favicon.svg")

--- a/crates/docs/src/lib.rs
+++ b/crates/docs/src/lib.rs
@@ -47,7 +47,7 @@ pub fn generate_docs_html(root_file: PathBuf) {
     }
 
     #[cfg(not(debug_assertions))]
-    let assets = (|| {
+    let assets = {
         let search_js = include_str!("./static/search.js");
         let styles_css = include_str!("./static/styles.css");
         let favicon_svg = include_str!("./static/favicon.svg");
@@ -59,14 +59,15 @@ pub fn generate_docs_html(root_file: PathBuf) {
             favicon_svg,
             raw_template_html,
         }
-    })();
+    };
 
     #[cfg(debug_assertions)]
-    let assets = (|| {
+    let assets = {
         // Construct the absolute path to the static assets
         let workspace_dir = std::env!("ROC_WORKSPACE_DIR");
         let static_dir = Path::new(workspace_dir).join("crates/docs/src/static");
 
+        // Read the assets from the filesystem
         let search_js = fs::read_to_string(static_dir.join("search.js")).unwrap();
         let styles_css = fs::read_to_string(static_dir.join("styles.css")).unwrap();
         let favicon_svg = fs::read_to_string(static_dir.join("favicon.svg")).unwrap();
@@ -78,7 +79,7 @@ pub fn generate_docs_html(root_file: PathBuf) {
             favicon_svg,
             raw_template_html,
         }
-    })();
+    };
 
     // Write CSS, JS, and favicon
     // (The HTML requires more work!)


### PR DESCRIPTION
## What this does:

For debug builds only, instead of including the contents of files in `crates/docs/src/static` as string literals using `include_str!`, read the contents from the filesystem.

This means that Cargo no longer has to rebuild when e.g. `index.html` or `styles.css` change, allowing faster iteration on the theme and layout of the generated docs.


Opened per this conversation: https://roc.zulipchat.com/#narrow/stream/304641-ideas/topic/docs.20improvements/near/355812138

## Questions

- Should I do more robust error handling on `fs::read_to_string` calls? Should that perhaps be another PR with better error handling for the `fs::write` calls as well?
- Do the comments sufficiently clarify what I did? 
- Any stylistic changes to make?

## Notes

Many tests failed on my machine, even on `main` (MacOS 13.3.1 ARM). Hope I didn't break anything :/.