### PR TITLE
Update flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -44,6 +44,7 @@
             xorg.libXrandr
             xorg.libXi
             xorg.libxcb
+            glibc libxkbcommon # To run example/gui/hello.roc in Wayland
           ];
 
         darwinInputs = with pkgs;


### PR DESCRIPTION
To run example/gui/hello.roc in Wayland (NixOS)

Error message:
https://github.com/rust-windowing/winit/issues/1760

I ran it as usual with `nix-shell`, and then executed it using `nixVulkanIntel ../roc ../hello.rc`. After adding two dependencies, it runs well.