### PR TITLE
Record Builder Syntax

### DIFF
--- a/crates/ast/src/constrain.rs
+++ b/crates/ast/src/constrain.rs
@@ -289,6 +289,7 @@ pub fn constrain_expr<'a>(
             let fn_reason = Reason::FnCall {
                 name: opt_symbol,
                 arity: args.len() as u8,
+                called_via: *called_via,
             };
 
             let fn_con = constrain_expr(arena, env, call_expr, fn_expected, region);

--- a/crates/compiler/can/src/expr.rs
+++ b/crates/compiler/can/src/expr.rs
@@ -1052,6 +1052,9 @@ pub fn canonicalize_expr<'a>(
                 can_defs_with_return(env, var_store, inner_scope, env.arena.alloc(defs), loc_ret)
             })
         }
+        ast::Expr::RecordBuilder(_) => {
+            unreachable!("RecordBuilder should have been desugared by now")
+        }
         ast::Expr::Backpassing(_, _, _) => {
             unreachable!("Backpassing should have been desugared by now")
         }

--- a/crates/compiler/can/src/expr.rs
+++ b/crates/compiler/can/src/expr.rs
@@ -1367,6 +1367,14 @@ pub fn canonicalize_expr<'a>(
 
             (RuntimeError(problem), Output::default())
         }
+        ast::Expr::UnappliedRecordBuilder(sub_expr) => {
+            use roc_problem::can::RuntimeError::*;
+
+            let problem = UnappliedRecordBuilder(sub_expr.region);
+            env.problem(Problem::RuntimeError(problem.clone()));
+
+            (RuntimeError(problem), Output::default())
+        }
         &ast::Expr::NonBase10Int {
             string,
             base,

--- a/crates/compiler/can/src/expr.rs
+++ b/crates/compiler/can/src/expr.rs
@@ -1359,6 +1359,14 @@ pub fn canonicalize_expr<'a>(
 
             (RuntimeError(problem), Output::default())
         }
+        ast::Expr::MultipleRecordBuilders(sub_expr) => {
+            use roc_problem::can::RuntimeError::*;
+
+            let problem = MultipleRecordBuilders(sub_expr.region);
+            env.problem(Problem::RuntimeError(problem.clone()));
+
+            (RuntimeError(problem), Output::default())
+        }
         &ast::Expr::NonBase10Int {
             string,
             base,

--- a/crates/compiler/can/src/operator.rs
+++ b/crates/compiler/can/src/operator.rs
@@ -137,6 +137,7 @@ pub fn desugar_expr<'a>(arena: &'a Bump, loc_expr: &'a Loc<Expr<'a>>) -> &'a Loc
         | MalformedIdent(_, _)
         | MalformedClosure
         | PrecedenceConflict { .. }
+        | MultipleRecordBuilders { .. }
         | Tag(_)
         | OpaqueRef(_)
         | IngestedFile(_, _)
@@ -253,7 +254,7 @@ pub fn desugar_expr<'a>(arena: &'a Bump, loc_expr: &'a Loc<Expr<'a>>) -> &'a Loc
             }
         }
         RecordBuilder(_) => {
-            todo!("Compiler error: Record builders must be applied to functions");
+            todo!("Compiler error: Record builders must be applied to functions")
         }
         BinOps(lefts, right) => desugar_bin_ops(arena, loc_expr.region, lefts, right),
         Defs(defs, loc_ret) => {
@@ -274,7 +275,10 @@ pub fn desugar_expr<'a>(arena: &'a Bump, loc_expr: &'a Loc<Expr<'a>>) -> &'a Loc
                     match current {
                         RecordBuilder(fields) => {
                             if builder_apply_exprs.is_some() {
-                                todo!("Compiler error: A function application can only be passed one record builder")
+                                return arena.alloc(Loc {
+                                    value: MultipleRecordBuilders(loc_expr),
+                                    region: loc_expr.region,
+                                });
                             }
 
                             let builder_arg = record_builder_arg(arena, loc_arg.region, fields);

--- a/crates/compiler/can/src/operator.rs
+++ b/crates/compiler/can/src/operator.rs
@@ -138,6 +138,7 @@ pub fn desugar_expr<'a>(arena: &'a Bump, loc_expr: &'a Loc<Expr<'a>>) -> &'a Loc
         | MalformedClosure
         | PrecedenceConflict { .. }
         | MultipleRecordBuilders { .. }
+        | UnappliedRecordBuilder { .. }
         | Tag(_)
         | OpaqueRef(_)
         | IngestedFile(_, _)
@@ -253,9 +254,10 @@ pub fn desugar_expr<'a>(arena: &'a Bump, loc_expr: &'a Loc<Expr<'a>>) -> &'a Loc
                 }
             }
         }
-        RecordBuilder(_) => {
-            todo!("Compiler error: Record builders must be applied to functions")
-        }
+        RecordBuilder(_) => arena.alloc(Loc {
+            value: UnappliedRecordBuilder(loc_expr),
+            region: loc_expr.region,
+        }),
         BinOps(lefts, right) => desugar_bin_ops(arena, loc_expr.region, lefts, right),
         Defs(defs, loc_ret) => {
             let mut defs = (*defs).clone();

--- a/crates/compiler/can/src/operator.rs
+++ b/crates/compiler/can/src/operator.rs
@@ -315,7 +315,6 @@ pub fn desugar_expr<'a>(arena: &'a Bump, loc_expr: &'a Loc<Expr<'a>>) -> &'a Loc
                         let args = std::slice::from_ref(arena.alloc(apply));
 
                         apply = arena.alloc(Loc {
-                            // Agus TODO: new CalledVia?
                             value: Apply(desugared_expr, args, *called_via),
                             region: loc_expr.region,
                         });

--- a/crates/compiler/can/src/operator.rs
+++ b/crates/compiler/can/src/operator.rs
@@ -315,7 +315,7 @@ pub fn desugar_expr<'a>(arena: &'a Bump, loc_expr: &'a Loc<Expr<'a>>) -> &'a Loc
                         let args = std::slice::from_ref(arena.alloc(apply));
 
                         apply = arena.alloc(Loc {
-                            value: Apply(desugared_expr, args, *called_via),
+                            value: Apply(desugared_expr, args, CalledVia::RecordBuilder),
                             region: loc_expr.region,
                         });
                     }

--- a/crates/compiler/can/src/operator.rs
+++ b/crates/compiler/can/src/operator.rs
@@ -7,7 +7,7 @@ use roc_module::called_via::BinOp::Pizza;
 use roc_module::called_via::{BinOp, CalledVia};
 use roc_module::ident::ModuleName;
 use roc_parse::ast::Expr::{self, *};
-use roc_parse::ast::{AssignedField, ValueDef, WhenBranch};
+use roc_parse::ast::{AssignedField, Collection, RecordBuilderField, ValueDef, WhenBranch};
 use roc_region::all::{Loc, Region};
 
 // BinOp precedence logic adapted from Gluon by Markus Westerlind
@@ -252,6 +252,9 @@ pub fn desugar_expr<'a>(arena: &'a Bump, loc_expr: &'a Loc<Expr<'a>>) -> &'a Loc
                 }
             }
         }
+        RecordBuilder(_) => {
+            todo!("Compiler error: Record builders must be applied to functions");
+        }
         BinOps(lefts, right) => desugar_bin_ops(arena, loc_expr.region, lefts, right),
         Defs(defs, loc_ret) => {
             let mut defs = (*defs).clone();
@@ -263,17 +266,51 @@ pub fn desugar_expr<'a>(arena: &'a Bump, loc_expr: &'a Loc<Expr<'a>>) -> &'a Loc
         }
         Apply(loc_fn, loc_args, called_via) => {
             let mut desugared_args = Vec::with_capacity_in(loc_args.len(), arena);
+            let mut builder_apply_exprs = None;
 
             for loc_arg in loc_args.iter() {
-                desugared_args.push(desugar_expr(arena, loc_arg));
+                let arg = match loc_arg.value {
+                    RecordBuilder(fields) => {
+                        if builder_apply_exprs.is_some() {
+                            todo!("Compiler error: A function application can only be passed one record builder")
+                        }
+
+                        let builder_arg = record_builder_arg(arena, loc_arg.region, fields);
+                        builder_apply_exprs = Some(builder_arg.apply_exprs);
+                        builder_arg.closure
+                    }
+                    _ => loc_arg,
+                };
+
+                desugared_args.push(desugar_expr(arena, arg));
             }
 
             let desugared_args = desugared_args.into_bump_slice();
 
-            arena.alloc(Loc {
+            let mut apply: &Loc<Expr> = arena.alloc(Loc {
                 value: Apply(desugar_expr(arena, loc_fn), desugared_args, *called_via),
                 region: loc_expr.region,
-            })
+            });
+
+            match builder_apply_exprs {
+                None => {}
+
+                Some(apply_exprs) => {
+                    for expr in apply_exprs {
+                        let desugared_expr = desugar_expr(arena, expr);
+
+                        let args = std::slice::from_ref(arena.alloc(apply));
+
+                        apply = arena.alloc(Loc {
+                            // Agus TODO: new CalledVia?
+                            value: Apply(desugared_expr, args, *called_via),
+                            region: loc_expr.region,
+                        });
+                    }
+                }
+            }
+
+            apply
         }
         When(loc_cond_expr, branches) => {
             let loc_desugared_cond = &*arena.alloc(desugar_expr(arena, loc_cond_expr));
@@ -427,6 +464,88 @@ fn desugar_field<'a>(
         SpaceAfter(field, _spaces) => desugar_field(arena, field),
 
         Malformed(string) => Malformed(string),
+    }
+}
+
+struct RecordBuilderArg<'a> {
+    closure: &'a Loc<Expr<'a>>,
+    apply_exprs: Vec<'a, &'a Loc<Expr<'a>>>,
+}
+
+fn record_builder_arg<'a>(
+    arena: &'a Bump,
+    region: Region,
+    fields: Collection<'a, Loc<RecordBuilderField<'a>>>,
+) -> RecordBuilderArg<'a> {
+    let mut record_fields = Vec::with_capacity_in(fields.len(), arena);
+    let mut apply_exprs = Vec::with_capacity_in(fields.len(), arena);
+    let mut apply_field_names = Vec::with_capacity_in(fields.len(), arena);
+
+    // Build the record that the closure will return and gather apply expressions
+
+    for field in fields.iter() {
+        let mut current = field.value;
+
+        let new_field = loop {
+            match current {
+                RecordBuilderField::Value(label, spaces, expr) => {
+                    break AssignedField::RequiredValue(label, spaces, expr)
+                }
+                RecordBuilderField::ApplyValue(label, _spaces, expr) => {
+                    apply_field_names.push(label);
+                    apply_exprs.push(expr);
+
+                    break AssignedField::LabelOnly(label);
+                }
+                RecordBuilderField::LabelOnly(label) => break AssignedField::LabelOnly(label),
+                RecordBuilderField::SpaceBefore(sub_field, _) => {
+                    current = *sub_field;
+                }
+                RecordBuilderField::SpaceAfter(sub_field, _) => {
+                    current = *sub_field;
+                }
+                RecordBuilderField::Malformed(malformed) => {
+                    break AssignedField::Malformed(malformed)
+                }
+            }
+        };
+
+        record_fields.push(Loc {
+            value: new_field,
+            region: field.region,
+        });
+    }
+
+    let record_fields = fields.replace_items(record_fields.into_bump_slice());
+
+    let mut body = arena.alloc(Loc {
+        value: Record(record_fields),
+        region,
+    });
+
+    // Construct the builder's closure
+    //
+    // { x, y, z: 3 }
+    // \y -> { x, y, z: 3 }
+    // \x -> \y -> { x, y, z: 3 }
+
+    for name in apply_field_names.iter().rev() {
+        let ident = roc_parse::ast::Pattern::Identifier(name.value);
+
+        let arg_pattern = arena.alloc(Loc {
+            value: ident,
+            region: name.region,
+        });
+
+        body = arena.alloc(Loc {
+            value: Closure(std::slice::from_ref(arg_pattern), body),
+            region,
+        });
+    }
+
+    RecordBuilderArg {
+        closure: body,
+        apply_exprs,
     }
 }
 

--- a/crates/compiler/can/tests/test_can.rs
+++ b/crates/compiler/can/tests/test_can.rs
@@ -773,6 +773,32 @@ mod test_can {
         }
     }
 
+    #[test]
+    fn multiple_record_builders_error() {
+        let src = indoc!(
+            r#"
+                succeed 
+                    { a <- apply "a" }
+                    { b <- apply "b" }
+            "#
+        );
+        let arena = Bump::new();
+        let CanExprOut {
+            problems, loc_expr, ..
+        } = can_expr_with(&arena, test_home(), src);
+
+        assert_eq!(problems.len(), 1);
+        assert!(problems.iter().all(|problem| matches!(
+            problem,
+            Problem::RuntimeError(roc_problem::can::RuntimeError::MultipleRecordBuilders { .. })
+        )));
+
+        assert!(matches!(
+            loc_expr.value,
+            Expr::RuntimeError(roc_problem::can::RuntimeError::MultipleRecordBuilders { .. })
+        ));
+    }
+
     // TAIL CALLS
     fn get_closure(expr: &Expr, i: usize) -> roc_can::expr::Recursive {
         match expr {

--- a/crates/compiler/can/tests/test_can.rs
+++ b/crates/compiler/can/tests/test_can.rs
@@ -799,6 +799,30 @@ mod test_can {
         ));
     }
 
+    #[test]
+    fn hanging_record_builder() {
+        let src = indoc!(
+            r#"
+                { a <- apply "a" }
+            "#
+        );
+        let arena = Bump::new();
+        let CanExprOut {
+            problems, loc_expr, ..
+        } = can_expr_with(&arena, test_home(), src);
+
+        assert_eq!(problems.len(), 1);
+        assert!(problems.iter().all(|problem| matches!(
+            problem,
+            Problem::RuntimeError(roc_problem::can::RuntimeError::UnappliedRecordBuilder { .. })
+        )));
+
+        assert!(matches!(
+            loc_expr.value,
+            Expr::RuntimeError(roc_problem::can::RuntimeError::UnappliedRecordBuilder { .. })
+        ));
+    }
+
     // TAIL CALLS
     fn get_closure(expr: &Expr, i: usize) -> roc_can::expr::Recursive {
         match expr {

--- a/crates/compiler/can/tests/test_can.rs
+++ b/crates/compiler/can/tests/test_can.rs
@@ -735,7 +735,7 @@ mod test_can {
     fn assert_apply_call(expr: &Expr, expected: &str, interns: &roc_module::symbol::Interns) {
         match simplify_curried_call(expr) {
             (Var(sym, _), Str(val)) => {
-                assert_eq!(sym.as_str(&interns), "apply");
+                assert_eq!(sym.as_str(interns), "apply");
                 assert_eq!(val.to_string(), expected);
             }
             call => panic!("Not a valid (get {}) call: {:?}", expected, call),

--- a/crates/compiler/can/tests/test_can.rs
+++ b/crates/compiler/can/tests/test_can.rs
@@ -14,8 +14,10 @@ mod helpers;
 mod test_can {
     use crate::helpers::{can_expr_with, test_home, CanExprOut};
     use bumpalo::Bump;
+    use core::panic;
     use roc_can::expr::Expr::{self, *};
     use roc_can::expr::{ClosureData, IntValue, Recursive};
+    use roc_module::symbol::Symbol;
     use roc_problem::can::{CycleEntry, FloatErrorKind, IntErrorKind, Problem, RuntimeError};
     use roc_region::all::{Position, Region};
     use std::{f64, i64};
@@ -653,6 +655,122 @@ mod test_can {
             loc_expr.value,
             Expr::RuntimeError(roc_problem::can::RuntimeError::InvalidOptionalValue { .. })
         ));
+    }
+
+    // RECORD BUILDERS
+    #[test]
+    fn record_builder_desugar() {
+        let src = indoc!(
+            r#"
+                succeed = \_ -> crash "succeed"
+                apply = \_ -> crash "get"
+
+                d = 3
+
+                succeed {
+                    a: 1,
+                    b <- apply "b",
+                    c <- apply "c",
+                    d
+                }
+            "#
+        );
+        let arena = Bump::new();
+        let out = can_expr_with(&arena, test_home(), src);
+
+        assert_eq!(out.problems.len(), 0);
+
+        // Assert that we desugar to:
+        //
+        // (apply "c") ((apply "b") (succeed \b -> \c -> { a: 1, b, c, d }))
+
+        // (apply "c") ..
+        let (apply_c, c_to_b) = simplify_curried_call(&out.loc_expr.value);
+        assert_apply_call(apply_c, "c", &out.interns);
+
+        // (apply "b") ..
+        let (apply_b, b_to_succeed) = simplify_curried_call(c_to_b);
+        assert_apply_call(apply_b, "b", &out.interns);
+
+        // (succeed ..)
+        let (succeed, b_closure) = simplify_curried_call(b_to_succeed);
+
+        match succeed {
+            Var(sym, _) => assert_eq!(sym.as_str(&out.interns), "succeed"),
+            _ => panic!("Not calling succeed: {:?}", succeed),
+        }
+
+        // \b -> ..
+        let (b_sym, c_closure) = simplify_builder_closure(b_closure);
+
+        // \c -> ..
+        let (c_sym, c_body) = simplify_builder_closure(c_closure);
+
+        // { a: 1, b, c, d }
+        match c_body {
+            Record { fields, .. } => {
+                match get_field_expr(fields, "a") {
+                    Num(_, num_str, _, _) => {
+                        assert_eq!(num_str.to_string(), "1");
+                    }
+                    expr => panic!("a is not a Num: {:?}", expr),
+                }
+
+                assert_eq!(get_field_var_sym(fields, "b"), b_sym);
+                assert_eq!(get_field_var_sym(fields, "c"), c_sym);
+                assert_eq!(get_field_var_sym(fields, "d").as_str(&out.interns), "d");
+            }
+            _ => panic!("Closure body wasn't a Record: {:?}", c_body),
+        }
+    }
+
+    fn simplify_curried_call(expr: &Expr) -> (&Expr, &Expr) {
+        match expr {
+            LetNonRec(_, loc_expr) => simplify_curried_call(&loc_expr.value),
+            Call(fun, args, _) => (&fun.1.value, &args[0].1.value),
+            _ => panic!("Final Expr is not a Call: {:?}", expr),
+        }
+    }
+
+    fn assert_apply_call(expr: &Expr, expected: &str, interns: &roc_module::symbol::Interns) {
+        match simplify_curried_call(expr) {
+            (Var(sym, _), Str(val)) => {
+                assert_eq!(sym.as_str(&interns), "apply");
+                assert_eq!(val.to_string(), expected);
+            }
+            call => panic!("Not a valid (get {}) call: {:?}", expected, call),
+        };
+    }
+
+    fn simplify_builder_closure(expr: &Expr) -> (Symbol, &Expr) {
+        use roc_can::pattern::Pattern::*;
+
+        match expr {
+            Closure(closure) => match &closure.arguments[0].2.value {
+                Identifier(sym) => (*sym, &closure.loc_body.value),
+                pattern => panic!("Not an identifier pattern: {:?}", pattern),
+            },
+            _ => panic!("Not a closure: {:?}", expr),
+        }
+    }
+
+    fn get_field_expr<'a>(
+        fields: &'a roc_collections::SendMap<roc_module::ident::Lowercase, roc_can::expr::Field>,
+        name: &'a str,
+    ) -> &'a Expr {
+        let ident = roc_module::ident::Lowercase::from(name);
+
+        &fields.get(&ident).unwrap().loc_expr.value
+    }
+
+    fn get_field_var_sym(
+        fields: &roc_collections::SendMap<roc_module::ident::Lowercase, roc_can::expr::Field>,
+        name: &str,
+    ) -> roc_module::symbol::Symbol {
+        match get_field_expr(fields, name) {
+            Var(sym, _) => *sym,
+            expr => panic!("Not a var: {:?}", expr),
+        }
     }
 
     // TAIL CALLS

--- a/crates/compiler/constrain/src/expr.rs
+++ b/crates/compiler/constrain/src/expr.rs
@@ -466,6 +466,7 @@ pub fn constrain_expr(
             let fn_reason = Reason::FnCall {
                 name: opt_symbol,
                 arity: loc_args.len() as u8,
+                called_via: *called_via,
             };
 
             let fn_con = constrain_expr(

--- a/crates/compiler/fmt/src/expr.rs
+++ b/crates/compiler/fmt/src/expr.rs
@@ -78,7 +78,8 @@ impl<'a> Formattable for Expr<'a> {
             UnaryOp(loc_subexpr, _)
             | PrecedenceConflict(roc_parse::ast::PrecedenceConflict {
                 expr: loc_subexpr, ..
-            }) => loc_subexpr.is_multiline(),
+            })
+            | MultipleRecordBuilders(loc_subexpr) => loc_subexpr.is_multiline(),
 
             ParensAround(subexpr) => subexpr.is_multiline(),
 
@@ -498,6 +499,9 @@ impl<'a> Formattable for Expr<'a> {
             }
             MalformedClosure => {}
             PrecedenceConflict { .. } => {}
+            MultipleRecordBuilders(sub_expr) => {
+                sub_expr.format_with_options(buf, parens, newlines, indent)
+            }
             IngestedFile(_, _) => {}
         }
     }

--- a/crates/compiler/fmt/src/expr.rs
+++ b/crates/compiler/fmt/src/expr.rs
@@ -79,7 +79,8 @@ impl<'a> Formattable for Expr<'a> {
             | PrecedenceConflict(roc_parse::ast::PrecedenceConflict {
                 expr: loc_subexpr, ..
             })
-            | MultipleRecordBuilders(loc_subexpr) => loc_subexpr.is_multiline(),
+            | MultipleRecordBuilders(loc_subexpr)
+            | UnappliedRecordBuilder(loc_subexpr) => loc_subexpr.is_multiline(),
 
             ParensAround(subexpr) => subexpr.is_multiline(),
 
@@ -499,9 +500,8 @@ impl<'a> Formattable for Expr<'a> {
             }
             MalformedClosure => {}
             PrecedenceConflict { .. } => {}
-            MultipleRecordBuilders(sub_expr) => {
-                sub_expr.format_with_options(buf, parens, newlines, indent)
-            }
+            MultipleRecordBuilders { .. } => {}
+            UnappliedRecordBuilder { .. } => {}
             IngestedFile(_, _) => {}
         }
     }

--- a/crates/compiler/fmt/src/spaces.rs
+++ b/crates/compiler/fmt/src/spaces.rs
@@ -747,9 +747,8 @@ impl<'a> RemoveSpaces<'a> for Expr<'a> {
             Expr::MalformedIdent(a, b) => Expr::MalformedIdent(a, remove_spaces_bad_ident(b)),
             Expr::MalformedClosure => Expr::MalformedClosure,
             Expr::PrecedenceConflict(a) => Expr::PrecedenceConflict(a),
-            Expr::MultipleRecordBuilders(a) => {
-                Expr::MultipleRecordBuilders(arena.alloc(a.remove_spaces(arena)))
-            }
+            Expr::MultipleRecordBuilders(a) => Expr::MultipleRecordBuilders(a),
+            Expr::UnappliedRecordBuilder(a) => Expr::UnappliedRecordBuilder(a),
             Expr::SpaceBefore(a, _) => a.remove_spaces(arena),
             Expr::SpaceAfter(a, _) => a.remove_spaces(arena),
             Expr::SingleQuote(a) => Expr::Num(a),

--- a/crates/compiler/fmt/src/spaces.rs
+++ b/crates/compiler/fmt/src/spaces.rs
@@ -4,8 +4,9 @@ use roc_module::called_via::{BinOp, UnaryOp};
 use roc_parse::{
     ast::{
         AbilityMember, AssignedField, Collection, CommentOrNewline, Defs, Expr, Has, HasAbilities,
-        HasAbility, HasClause, HasImpls, Header, Module, Pattern, Spaced, Spaces, StrLiteral,
-        StrSegment, Tag, TypeAnnotation, TypeDef, TypeHeader, ValueDef, WhenBranch,
+        HasAbility, HasClause, HasImpls, Header, Module, Pattern, RecordBuilderField, Spaced,
+        Spaces, StrLiteral, StrSegment, Tag, TypeAnnotation, TypeDef, TypeHeader, ValueDef,
+        WhenBranch,
     },
     header::{
         AppHeader, ExposedName, HostedHeader, ImportsEntry, InterfaceHeader, KeywordItem,
@@ -614,6 +615,29 @@ impl<'a, T: RemoveSpaces<'a> + Copy + std::fmt::Debug> RemoveSpaces<'a> for Assi
     }
 }
 
+impl<'a> RemoveSpaces<'a> for RecordBuilderField<'a> {
+    fn remove_spaces(&self, arena: &'a Bump) -> Self {
+        match *self {
+            RecordBuilderField::Value(a, _, c) => RecordBuilderField::Value(
+                a.remove_spaces(arena),
+                arena.alloc([]),
+                arena.alloc(c.remove_spaces(arena)),
+            ),
+            RecordBuilderField::ApplyValue(a, _, c) => RecordBuilderField::ApplyValue(
+                a.remove_spaces(arena),
+                arena.alloc([]),
+                arena.alloc(c.remove_spaces(arena)),
+            ),
+            RecordBuilderField::LabelOnly(a) => {
+                RecordBuilderField::LabelOnly(a.remove_spaces(arena))
+            }
+            RecordBuilderField::Malformed(a) => RecordBuilderField::Malformed(a),
+            RecordBuilderField::SpaceBefore(a, _) => a.remove_spaces(arena),
+            RecordBuilderField::SpaceAfter(a, _) => a.remove_spaces(arena),
+        }
+    }
+}
+
 impl<'a> RemoveSpaces<'a> for StrLiteral<'a> {
     fn remove_spaces(&self, arena: &'a Bump) -> Self {
         match *self {
@@ -660,6 +684,7 @@ impl<'a> RemoveSpaces<'a> for Expr<'a> {
                 fields: fields.remove_spaces(arena),
             },
             Expr::Record(a) => Expr::Record(a.remove_spaces(arena)),
+            Expr::RecordBuilder(a) => Expr::RecordBuilder(a.remove_spaces(arena)),
             Expr::Tuple(a) => Expr::Tuple(a.remove_spaces(arena)),
             Expr::Var { module_name, ident } => Expr::Var { module_name, ident },
             Expr::Underscore(a) => Expr::Underscore(a),

--- a/crates/compiler/fmt/src/spaces.rs
+++ b/crates/compiler/fmt/src/spaces.rs
@@ -747,6 +747,9 @@ impl<'a> RemoveSpaces<'a> for Expr<'a> {
             Expr::MalformedIdent(a, b) => Expr::MalformedIdent(a, remove_spaces_bad_ident(b)),
             Expr::MalformedClosure => Expr::MalformedClosure,
             Expr::PrecedenceConflict(a) => Expr::PrecedenceConflict(a),
+            Expr::MultipleRecordBuilders(a) => {
+                Expr::MultipleRecordBuilders(arena.alloc(a.remove_spaces(arena)))
+            }
             Expr::SpaceBefore(a, _) => a.remove_spaces(arena),
             Expr::SpaceAfter(a, _) => a.remove_spaces(arena),
             Expr::SingleQuote(a) => Expr::Num(a),

--- a/crates/compiler/module/src/called_via.rs
+++ b/crates/compiler/module/src/called_via.rs
@@ -88,6 +88,10 @@ pub enum CalledVia {
     /// This call is the result of desugaring string interpolation,
     /// e.g. "\(first) \(last)" is transformed into Str.concat (Str.concat first " ") last.
     StringInterpolation,
+
+    /// This call is the result of desugaring a Record Builder field.
+    /// e.g. succeed { a <- get "a" } is transformed into (get "a") (succeed \a -> { a })
+    RecordBuilder,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/crates/compiler/parse/src/ast.rs
+++ b/crates/compiler/parse/src/ast.rs
@@ -328,6 +328,7 @@ pub enum Expr<'a> {
     // We should tell the author to disambiguate by grouping them with parens.
     PrecedenceConflict(&'a PrecedenceConflict<'a>),
     MultipleRecordBuilders(&'a Loc<Expr<'a>>),
+    UnappliedRecordBuilder(&'a Loc<Expr<'a>>),
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1535,7 +1536,8 @@ impl<'a> Malformed for Expr<'a> {
             MalformedIdent(_, _) |
             MalformedClosure |
             PrecedenceConflict(_) |
-            MultipleRecordBuilders(_) => true,
+            MultipleRecordBuilders(_) |
+            UnappliedRecordBuilder(_) => true,
         }
     }
 }

--- a/crates/compiler/parse/src/ast.rs
+++ b/crates/compiler/parse/src/ast.rs
@@ -327,6 +327,7 @@ pub enum Expr<'a> {
     // Both operators were non-associative, e.g. (True == False == False).
     // We should tell the author to disambiguate by grouping them with parens.
     PrecedenceConflict(&'a PrecedenceConflict<'a>),
+    MultipleRecordBuilders(&'a Loc<Expr<'a>>),
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1533,7 +1534,8 @@ impl<'a> Malformed for Expr<'a> {
 
             MalformedIdent(_, _) |
             MalformedClosure |
-            PrecedenceConflict(_) => true,
+            PrecedenceConflict(_) |
+            MultipleRecordBuilders(_) => true,
         }
     }
 }

--- a/crates/compiler/parse/src/expr.rs
+++ b/crates/compiler/parse/src/expr.rs
@@ -1928,6 +1928,7 @@ fn expr_to_pattern_help<'a>(arena: &'a Bump, expr: &Expr<'a>) -> Result<Pattern<
         | Expr::Dbg(_, _)
         | Expr::MalformedClosure
         | Expr::PrecedenceConflict { .. }
+        | Expr::MultipleRecordBuilders { .. }
         | Expr::RecordUpdate { .. }
         | Expr::UnaryOp(_, _)
         | Expr::Crash => return Err(()),

--- a/crates/compiler/parse/src/expr.rs
+++ b/crates/compiler/parse/src/expr.rs
@@ -1929,6 +1929,7 @@ fn expr_to_pattern_help<'a>(arena: &'a Bump, expr: &Expr<'a>) -> Result<Pattern<
         | Expr::MalformedClosure
         | Expr::PrecedenceConflict { .. }
         | Expr::MultipleRecordBuilders { .. }
+        | Expr::UnappliedRecordBuilder { .. }
         | Expr::RecordUpdate { .. }
         | Expr::UnaryOp(_, _)
         | Expr::Crash => return Err(()),

--- a/crates/compiler/parse/src/expr.rs
+++ b/crates/compiler/parse/src/expr.rs
@@ -2564,21 +2564,21 @@ impl<'a> RecordField<'a> {
     }
 
     pub fn to_assigned_field(
-        &self,
+        self,
         arena: &'a Bump,
     ) -> Result<AssignedField<'a, Expr<'a>>, FoundApplyValue> {
         use AssignedField::*;
 
         match self {
             RecordField::RequiredValue(loc_label, spaces, loc_expr) => {
-                Ok(RequiredValue(*loc_label, spaces, loc_expr))
+                Ok(RequiredValue(loc_label, spaces, loc_expr))
             }
 
             RecordField::OptionalValue(loc_label, spaces, loc_expr) => {
-                Ok(OptionalValue(*loc_label, spaces, loc_expr))
+                Ok(OptionalValue(loc_label, spaces, loc_expr))
             }
 
-            RecordField::LabelOnly(loc_label) => Ok(LabelOnly(*loc_label)),
+            RecordField::LabelOnly(loc_label) => Ok(LabelOnly(loc_label)),
 
             RecordField::ApplyValue(_, _, _) => Err(FoundApplyValue),
 
@@ -2597,22 +2597,22 @@ impl<'a> RecordField<'a> {
     }
 
     fn to_builder_field(
-        &self,
+        self,
         arena: &'a Bump,
     ) -> Result<RecordBuilderField<'a>, FoundOptionalValue> {
         use RecordBuilderField::*;
 
         match self {
             RecordField::RequiredValue(loc_label, spaces, loc_expr) => {
-                Ok(Value(*loc_label, spaces, loc_expr))
+                Ok(Value(loc_label, spaces, loc_expr))
             }
 
             RecordField::OptionalValue(_, _, _) => Err(FoundOptionalValue),
 
-            RecordField::LabelOnly(loc_label) => Ok(LabelOnly(*loc_label)),
+            RecordField::LabelOnly(loc_label) => Ok(LabelOnly(loc_label)),
 
             RecordField::ApplyValue(loc_label, spaces, loc_expr) => {
-                Ok(ApplyValue(*loc_label, spaces, loc_expr))
+                Ok(ApplyValue(loc_label, spaces, loc_expr))
             }
 
             RecordField::SpaceBefore(field, spaces) => {

--- a/crates/compiler/parse/src/parser.rs
+++ b/crates/compiler/parse/src/parser.rs
@@ -97,7 +97,6 @@ impl_space_problem! {
     EPattern<'a>,
     EProvides<'a>,
     ERecord<'a>,
-    ERecordBuilder<'a>,
     ERequires<'a>,
     EString<'a>,
     EType<'a>,
@@ -359,7 +358,8 @@ pub enum EExpr<'a> {
 
     InParens(EInParens<'a>, Position),
     Record(ERecord<'a>, Position),
-    RecordBuilder(ERecordBuilder<'a>, Position),
+    OptionalValueInRecordBuilder(Region),
+    RecordUpdateBuilder(Region),
 
     // SingleQuote errors are folded into the EString
     Str(EString<'a>, Position),
@@ -412,23 +412,10 @@ pub enum ERecord<'a> {
     Field(Position),
     Colon(Position),
     QuestionMark(Position),
+    Arrow(Position),
     Ampersand(Position),
 
     // TODO remove
-    Expr(&'a EExpr<'a>, Position),
-
-    Space(BadInputError, Position),
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum ERecordBuilder<'a> {
-    End(Position),
-    Open(Position),
-
-    Field(Position),
-    Colon(Position),
-    Arrow(Position),
-
     Expr(&'a EExpr<'a>, Position),
 
     Space(BadInputError, Position),
@@ -691,6 +678,7 @@ pub enum ETypeAbilityImpl<'a> {
 
     Field(Position),
     Colon(Position),
+    Arrow(Position),
     Optional(Position),
     Type(&'a EType<'a>, Position),
 
@@ -711,6 +699,7 @@ impl<'a> From<ERecord<'a>> for ETypeAbilityImpl<'a> {
             ERecord::Open(p) => ETypeAbilityImpl::Open(p),
             ERecord::Field(p) => ETypeAbilityImpl::Field(p),
             ERecord::Colon(p) => ETypeAbilityImpl::Colon(p),
+            ERecord::Arrow(p) => ETypeAbilityImpl::Arrow(p),
             ERecord::Space(s, p) => ETypeAbilityImpl::Space(s, p),
             ERecord::Updateable(p) => ETypeAbilityImpl::Updateable(p),
             ERecord::QuestionMark(p) => ETypeAbilityImpl::QuestionMark(p),

--- a/crates/compiler/parse/src/parser.rs
+++ b/crates/compiler/parse/src/parser.rs
@@ -97,6 +97,7 @@ impl_space_problem! {
     EPattern<'a>,
     EProvides<'a>,
     ERecord<'a>,
+    ERecordBuilder<'a>,
     ERequires<'a>,
     EString<'a>,
     EType<'a>,
@@ -358,6 +359,7 @@ pub enum EExpr<'a> {
 
     InParens(EInParens<'a>, Position),
     Record(ERecord<'a>, Position),
+    RecordBuilder(ERecordBuilder<'a>, Position),
 
     // SingleQuote errors are folded into the EString
     Str(EString<'a>, Position),
@@ -413,6 +415,20 @@ pub enum ERecord<'a> {
     Ampersand(Position),
 
     // TODO remove
+    Expr(&'a EExpr<'a>, Position),
+
+    Space(BadInputError, Position),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ERecordBuilder<'a> {
+    End(Position),
+    Open(Position),
+
+    Field(Position),
+    Colon(Position),
+    Arrow(Position),
+
     Expr(&'a EExpr<'a>, Position),
 
     Space(BadInputError, Position),

--- a/crates/compiler/parse/src/type_annotation.rs
+++ b/crates/compiler/parse/src/type_annotation.rs
@@ -5,7 +5,7 @@ use crate::ast::{
 use crate::blankspace::{
     space0_around_ee, space0_before_e, space0_before_optional_after, space0_e,
 };
-use crate::expr::record_field;
+use crate::expr::{record_field, FoundApplyValue};
 use crate::ident::{lowercase_ident, lowercase_ident_keyword_e};
 use crate::keyword;
 use crate::parser::{
@@ -554,7 +554,7 @@ fn ability_impl_field<'a>() -> impl Parser<'a, AssignedField<'a, Expr<'a>>, ERec
     then(record_field(), move |arena, state, _, field| {
         match field.to_assigned_field(arena) {
             Ok(assigned_field) => Ok((MadeProgress, assigned_field, state)),
-            Err(()) => Err((MadeProgress, ERecord::Field(state.pos()))),
+            Err(FoundApplyValue) => Err((MadeProgress, ERecord::Field(state.pos()))),
         }
     })
 }

--- a/crates/compiler/parse/src/type_annotation.rs
+++ b/crates/compiler/parse/src/type_annotation.rs
@@ -1,11 +1,11 @@
 use crate::ast::{
-    AssignedField, CommentOrNewline, HasAbilities, HasAbility, HasClause, HasImpls, Pattern,
+    AssignedField, CommentOrNewline, Expr, HasAbilities, HasAbility, HasClause, HasImpls, Pattern,
     Spaceable, Spaced, Tag, TypeAnnotation, TypeHeader,
 };
 use crate::blankspace::{
     space0_around_ee, space0_before_e, space0_before_optional_after, space0_e,
 };
-use crate::expr::record_value_field;
+use crate::expr::record_field;
 use crate::ident::{lowercase_ident, lowercase_ident_keyword_e};
 use crate::keyword;
 use crate::parser::{
@@ -537,7 +537,7 @@ fn parse_has_ability<'a>() -> impl Parser<'a, HasAbility<'a>, EType<'a>> {
                     EType::TAbilityImpl,
                     collection_trailing_sep_e!(
                         word1(b'{', ETypeAbilityImpl::Open),
-                        specialize(|e: ERecord<'_>, _| e.into(), loc!(record_value_field())),
+                        specialize(|e: ERecord<'_>, _| e.into(), loc!(ability_impl_field())),
                         word1(b',', ETypeAbilityImpl::End),
                         word1(b'}', ETypeAbilityImpl::End),
                         AssignedField::SpaceBefore
@@ -548,6 +548,15 @@ fn parse_has_ability<'a>() -> impl Parser<'a, HasAbility<'a>, EType<'a>> {
             EType::TIndentEnd
         )))
     }))
+}
+
+fn ability_impl_field<'a>() -> impl Parser<'a, AssignedField<'a, Expr<'a>>, ERecord<'a>> {
+    then(record_field(), move |arena, state, _, field| {
+        match field.to_assigned_field(arena) {
+            Ok(assigned_field) => Ok((MadeProgress, assigned_field, state)),
+            Err(()) => Err((MadeProgress, ERecord::Field(state.pos()))),
+        }
+    })
 }
 
 fn expression<'a>(

--- a/crates/compiler/problem/src/can.rs
+++ b/crates/compiler/problem/src/can.rs
@@ -362,6 +362,7 @@ impl Problem {
             | Problem::RuntimeError(RuntimeError::MultipleCharsInSingleQuote(region))
             | Problem::RuntimeError(RuntimeError::DegenerateBranch(region))
             | Problem::RuntimeError(RuntimeError::MultipleRecordBuilders(region))
+            | Problem::RuntimeError(RuntimeError::UnappliedRecordBuilder(region))
             | Problem::InvalidAliasRigid { region, .. }
             | Problem::InvalidInterpolation(region)
             | Problem::InvalidHexadecimal(region)
@@ -591,6 +592,7 @@ pub enum RuntimeError {
     DegenerateBranch(Region),
 
     MultipleRecordBuilders(Region),
+    UnappliedRecordBuilder(Region),
 }
 
 impl RuntimeError {

--- a/crates/compiler/problem/src/can.rs
+++ b/crates/compiler/problem/src/can.rs
@@ -361,6 +361,7 @@ impl Problem {
             | Problem::RuntimeError(RuntimeError::EmptySingleQuote(region))
             | Problem::RuntimeError(RuntimeError::MultipleCharsInSingleQuote(region))
             | Problem::RuntimeError(RuntimeError::DegenerateBranch(region))
+            | Problem::RuntimeError(RuntimeError::MultipleRecordBuilders(region))
             | Problem::InvalidAliasRigid { region, .. }
             | Problem::InvalidInterpolation(region)
             | Problem::InvalidHexadecimal(region)
@@ -588,6 +589,8 @@ pub enum RuntimeError {
     MultipleCharsInSingleQuote(Region),
 
     DegenerateBranch(Region),
+
+    MultipleRecordBuilders(Region),
 }
 
 impl RuntimeError {

--- a/crates/compiler/test_syntax/tests/test_fmt.rs
+++ b/crates/compiler/test_syntax/tests/test_fmt.rs
@@ -1979,6 +1979,27 @@ mod test_fmt {
     }
 
     #[test]
+    fn multiline_record_builder_func_arg() {
+        expr_formats_to(
+            indoc!(
+                r#"
+                succeed {  a: get "a" |> batch,
+                    b: get "b" |> batch, 
+                }
+                "#
+            ),
+            indoc!(
+                r#"
+                succeed {
+                    a: get "a" |> batch,
+                    b: get "b" |> batch,
+                }
+                "#
+            ),
+        );
+    }
+
+    #[test]
     fn final_comments_in_records() {
         expr_formats_same(indoc!(
             r#"

--- a/crates/compiler/test_syntax/tests/test_fmt.rs
+++ b/crates/compiler/test_syntax/tests/test_fmt.rs
@@ -2000,6 +2000,25 @@ mod test_fmt {
     }
 
     #[test]
+    fn can_format_multiple_record_builders() {
+        expr_formats_to(
+            indoc!(
+                r#"
+                succeed { a <- get "a" } 
+                    { b <- get "b" }
+                "#
+            ),
+            indoc!(
+                r#"
+                succeed
+                    { a <- get "a" }
+                    { b <- get "b" }
+                "#
+            ),
+        );
+    }
+
+    #[test]
     fn final_comments_in_records() {
         expr_formats_same(indoc!(
             r#"

--- a/crates/compiler/test_syntax/tests/test_fmt.rs
+++ b/crates/compiler/test_syntax/tests/test_fmt.rs
@@ -1927,6 +1927,58 @@ mod test_fmt {
     }
 
     #[test]
+    fn record_builder() {
+        expr_formats_same(indoc!(
+            r#"
+            { a: 1, b <- get "b" |> batch, c <- get "c" |> batch, d }
+            "#
+        ));
+
+        expr_formats_to(
+            indoc!(
+                r#"
+                {   a: 1, b <-  get "b" |> batch,   c <- get "c" |> batch }
+                "#
+            ),
+            indoc!(
+                r#"
+                { a: 1, b <- get "b" |> batch, c <- get "c" |> batch }
+                "#
+            ),
+        );
+
+        expr_formats_same(indoc!(
+            r#"
+            {
+                a: 1,
+                b <- get "b" |> batch,
+                c <- get "c" |> batch,
+                d,
+            }
+            "#
+        ));
+
+        expr_formats_to(
+            indoc!(
+                r#"
+                {   a: 1, b <-  get "b" |> batch,
+                c <- get "c" |> batch, d }
+                "#
+            ),
+            indoc!(
+                r#"
+                {
+                    a: 1,
+                    b <- get "b" |> batch,
+                    c <- get "c" |> batch,
+                    d,
+                }
+                "#
+            ),
+        );
+    }
+
+    #[test]
     fn final_comments_in_records() {
         expr_formats_same(indoc!(
             r#"

--- a/crates/compiler/types/src/types.rs
+++ b/crates/compiler/types/src/types.rs
@@ -3566,6 +3566,7 @@ pub enum Reason {
     FnCall {
         name: Option<Symbol>,
         arity: u8,
+        called_via: CalledVia,
     },
     LowLevelOpArg {
         op: LowLevel,

--- a/crates/reporting/src/error/canonicalize.rs
+++ b/crates/reporting/src/error/canonicalize.rs
@@ -2147,6 +2147,18 @@ fn pretty_runtime_error<'b>(
 
             title = "MULTIPLE RECORD BUILDERS";
         }
+        RuntimeError::UnappliedRecordBuilder(region) => {
+            doc = alloc.stack([
+                alloc.reflow("This record builder was not applied to a function:"),
+                alloc.region(lines.convert_region(region)),
+                alloc.reflow("However, we need a function to construct the record."),
+                alloc.note(
+                    "Functions must be applied directly. The pipe operator (|>) cannot be used.",
+                ),
+            ]);
+
+            title = "UNAPPLIED RECORD BUILDER";
+        }
     }
 
     (doc, title)

--- a/crates/reporting/src/error/canonicalize.rs
+++ b/crates/reporting/src/error/canonicalize.rs
@@ -2133,6 +2133,20 @@ fn pretty_runtime_error<'b>(
 
             title = "DEGENERATE BRANCH";
         }
+        RuntimeError::MultipleRecordBuilders(region) => {
+            let tip = alloc
+                .tip()
+                .append(alloc.reflow("You can combine them or apply them separately."));
+
+            doc = alloc.stack([
+                alloc.reflow("This function is applied to multiple record builders:"),
+                alloc.region(lines.convert_region(region)),
+                alloc.note("Functions can only take at most one record builder!"),
+                tip,
+            ]);
+
+            title = "MULTIPLE RECORD BUILDERS";
+        }
     }
 
     (doc, title)

--- a/crates/reporting/src/error/parse.rs
+++ b/crates/reporting/src/error/parse.rs
@@ -549,6 +549,46 @@ fn to_expr_report<'a>(
             }
         }
 
+        EExpr::OptionalValueInRecordBuilder(region) => {
+            let surroundings = Region::new(start, region.end());
+            let region = lines.convert_region(*region);
+
+            let doc = alloc.stack([
+                alloc.reflow(
+                    r"I am partway through parsing a record builder, and I found an optional field:",
+                ),
+                alloc.region_with_subregion(lines.convert_region(surroundings), region),
+                alloc.reflow("Optional fields can only appear when you destructure a record."),
+            ]);
+
+            Report {
+                filename,
+                doc,
+                title: "BAD RECORD BUILDER".to_string(),
+                severity: Severity::RuntimeError,
+            }
+        }
+
+        EExpr::RecordUpdateBuilder(region) => {
+            let surroundings = Region::new(start, region.end());
+            let region = lines.convert_region(*region);
+
+            let doc = alloc.stack([
+                alloc.reflow(
+                    r"I am partway through parsing a record update, and I found a record builder field:",
+                ),
+                alloc.region_with_subregion(lines.convert_region(surroundings), region),
+                alloc.reflow("Record builders cannot be updated like records."),
+            ]);
+
+            Report {
+                filename,
+                doc,
+                title: "BAD RECORD UPDATE".to_string(),
+                severity: Severity::RuntimeError,
+            }
+        }
+
         EExpr::Space(error, pos) => to_space_report(alloc, lines, filename, error, *pos),
 
         &EExpr::Number(ENumber::End, pos) => {

--- a/crates/reporting/src/error/type.rs
+++ b/crates/reporting/src/error/type.rs
@@ -1138,7 +1138,11 @@ fn to_expr_report<'b>(
                     ),
                 }
             }
-            Reason::FnCall { name, arity } => match describe_wanted_function(&found) {
+            Reason::FnCall {
+                name,
+                arity,
+                called_via,
+            } => match describe_wanted_function(&found) {
                 DescribedFunction::NotAFunction(tag) => {
                     let this_value = match name {
                         None => alloc.text("This value"),
@@ -1174,7 +1178,21 @@ fn to_expr_report<'b>(
                                 )),
                             ]),
                             alloc.region(lines.convert_region(expr_region)),
-                            alloc.reflow("Are there any missing commas? Or missing parentheses?"),
+                            match called_via {
+                                CalledVia::RecordBuilder => {
+                                    alloc.concat([
+                                        alloc.tip(),
+                                        alloc.reflow("Replace "),
+                                        alloc.keyword("<-"),
+                                        alloc.reflow(" with "),
+                                        alloc.keyword(":"),
+                                        alloc.reflow(" to assign the field directly.")
+                                    ])
+                                }
+                                _ => {
+                                    alloc.reflow("Are there any missing commas? Or missing parentheses?")
+                                }
+                            }
                         ]),
                     };
 

--- a/crates/reporting/src/error/type.rs
+++ b/crates/reporting/src/error/type.rs
@@ -1163,7 +1163,14 @@ fn to_expr_report<'b>(
                                 ),
                             ]),
                             alloc.region(lines.convert_region(expr_region)),
-                            alloc.reflow("I can't call an opaque type because I don't know what it is! Maybe you meant to unwrap it first?"),
+                            match called_via {
+                                CalledVia::RecordBuilder => {
+                                    alloc.hint("Did you mean to apply it to a function first?")
+                                },
+                                _ => {
+                                    alloc.reflow("I can't call an opaque type because I don't know what it is! Maybe you meant to unwrap it first?")
+                                }
+                            }
                         ]),
                         Other => alloc.stack([
                             alloc.concat([

--- a/crates/reporting/tests/test_reporting.rs
+++ b/crates/reporting/tests/test_reporting.rs
@@ -10205,6 +10205,27 @@ I recommend using camelCase. It's the standard style in Roc code!
     );
 
     test_report!(
+        unapplied_record_builder,
+        indoc!(
+            r#"
+            { a <- apply "a" }
+            "#
+        ),
+        @r###"
+    ── UNAPPLIED RECORD BUILDER ────────────────────────────── /code/proj/Main.roc ─
+
+    This record builder was not applied to a function:
+
+    4│      { a <- apply "a" }
+            ^^^^^^^^^^^^^^^^^^
+
+    However, we need a function to construct the record.
+
+    Note: Functions must be applied directly. The pipe operator (|>) cannot be used.
+    "###
+    );
+
+    test_report!(
         destructure_assignment_introduces_no_variables_nested,
         indoc!(
             r#"

--- a/crates/reporting/tests/test_reporting.rs
+++ b/crates/reporting/tests/test_reporting.rs
@@ -10180,6 +10180,63 @@ I recommend using camelCase. It's the standard style in Roc code!
     // Record Builders
 
     test_report!(
+        optional_field_in_record_builder,
+        indoc!(
+            r#"
+            { 
+                a <- apply "a",
+                b,
+                c ? "optional"
+            }
+            "#
+        ),
+        @r###"
+    ── BAD RECORD BUILDER ────────── tmp/optional_field_in_record_builder/Test.roc ─
+
+    I am partway through parsing a record builder, and I found an optional
+    field:
+
+    1│  app "test" provides [main] to "./platform"
+    2│
+    3│  main =
+    4│      { 
+    5│          a <- apply "a",
+    6│          b,
+    7│          c ? "optional"
+                ^^^^^^^^^^^^^^
+
+    Optional fields can only appear when you destructure a record.
+    "###
+    );
+
+    test_report!(
+        record_update_builder,
+        indoc!(
+            r#"
+            { rec &
+                a <- apply "a",
+                b: 3
+            }
+            "#
+        ),
+        @r###"
+    ── BAD RECORD UPDATE ────────────────────── tmp/record_update_builder/Test.roc ─
+
+    I am partway through parsing a record update, and I found a record
+    builder field:
+
+    1│  app "test" provides [main] to "./platform"
+    2│
+    3│  main =
+    4│      { rec &
+    5│          a <- apply "a",
+                ^^^^^^^^^^^^^^
+
+    Record builders cannot be updated like records.
+    "###
+    );
+
+    test_report!(
         multiple_record_builders,
         indoc!(
             r#"

--- a/crates/reporting/tests/test_reporting.rs
+++ b/crates/reporting/tests/test_reporting.rs
@@ -10177,6 +10177,33 @@ I recommend using camelCase. It's the standard style in Roc code!
         )
     );
 
+    // Record Builders
+
+    test_report!(
+        multiple_record_builders,
+        indoc!(
+            r#"
+            succeed
+                { a <- apply "a" }
+                { b <- apply "b" }
+            "#
+        ),
+        @r###"
+    ── MULTIPLE RECORD BUILDERS ────────────────────────────── /code/proj/Main.roc ─
+
+    This function is applied to multiple record builders:
+
+    4│>      succeed
+    5│>          { a <- apply "a" }
+    6│>          { b <- apply "b" }
+
+    Note: Functions can only take at most one record builder!
+
+    Tip: You can combine them or apply them separately.
+
+    "###
+    );
+
     test_report!(
         destructure_assignment_introduces_no_variables_nested,
         indoc!(

--- a/crates/reporting/tests/test_reporting.rs
+++ b/crates/reporting/tests/test_reporting.rs
@@ -10226,6 +10226,29 @@ I recommend using camelCase. It's the standard style in Roc code!
     );
 
     test_report!(
+        record_builder_apply_non_function,
+        indoc!(
+            r#"
+            succeed = \_ -> crash ""
+
+            succeed { 
+                a <- "a",
+            }
+            "#
+        ),
+        @r###"
+    ── TOO MANY ARGS ───────────────────────────────────────── /code/proj/Main.roc ─
+
+    This value is not a function, but it was given 1 argument:
+
+    7│          a <- "a",
+                     ^^^
+
+    Tip: Replace `<-` with `:` to assign the field directly.
+    "###
+    );
+
+    test_report!(
         destructure_assignment_introduces_no_variables_nested,
         indoc!(
             r#"

--- a/crates/reporting/tests/test_reporting.rs
+++ b/crates/reporting/tests/test_reporting.rs
@@ -10248,6 +10248,38 @@ I recommend using camelCase. It's the standard style in Roc code!
     "###
     );
 
+    // Skipping test because opaque types defined in the same module
+    // do not fail with the special opaque type error
+    //
+    // test_report!(
+    //     record_builder_apply_opaque,
+    //     indoc!(
+    //         r#"
+    //         succeed = \_ -> crash ""
+
+    //         Decode := {}
+
+    //         get : Str -> Decode
+    //         get = \_ -> @Decode {}
+
+    //         succeed {
+    //             a <- get "a",
+    //             # missing |> apply ^
+    //         }
+    //         "#
+    //     ),
+    //     @r###"
+    // ── TOO MANY ARGS ───────────────────────────────────────── /code/proj/Main.roc ─
+
+    // This value is an opaque type, so it cannot be called with an argument:
+
+    // 12│          a <- get "a",
+    //                   ^^^^^^^
+
+    // Hint: Did you mean to apply it to a function first?
+    //     "###
+    // );
+
     test_report!(
         destructure_assignment_introduces_no_variables_nested,
         indoc!(


### PR DESCRIPTION
## Syntax

Implements the syntax described in the [Record Builder proposal](https://docs.google.com/document/d/1Jo9nZCekkoF6SaDcRqPqoPcgPaAAvlNZC7v3kgVQ3Tc/edit) with [some changes](https://roc.zulipchat.com/#narrow/stream/316715-contributing/topic/Record.20Builder.20Syntax/near/355286566):

```elm
usersAndPosts : Task { users: List User, posts: List Post } _
usersAndPosts = Task.succeed {
    users <- Http.get "/users" |> Task.batch,
    posts <- Http.get "/posts" |> Task.batch,
}
```

⭐  This is not specific to `Task`, it's just syntax sugar for applicative pipelines. As seen in [elm-json-decode-pipeline](https://package.elm-lang.org/packages/NoRedInk/elm-json-decode-pipeline/latest/) or [dillonkearns/elm-graphql](https://package.elm-lang.org/packages/dillonkearns/elm-graphql/latest/Graphql-SelectionSet#pipelines).

### Static fields

This implementation also lets you write:

```elm
me <- Http.get "/me" |> Task.await

Task.succeed {
    me,
    posts <- Http.get "/users/\(me.id)/posts" |> Task.batch,
    friends <- Http.get "/users/\(me.id)/friends" |> Task.batch,
    movies: [],
}
```
This would first send a request to get `me` and then 2 parallel requests to get `posts` and `friends`.

## Errors

If there's a type mismatch, the errors are the same you would get for any record:

![CleanShot 2023-05-13 at 20 43 11@2x](https://github.com/roc-lang/roc/assets/1724813/b2f6e540-98c9-4141-8804-c5fa81009a15)

⭐  No cryptic applicative function annotations!

### Hints

Existing errors were specialized to provide hints when they occur in Record Builders. See [`TOO MANY ARGS`](https://github.com/roc-lang/roc/blob/f94004d1372044e61f0f960e896a2853462080c5/crates/reporting/tests/test_reporting.rs#L10297-L10305) and it's [opaque type variant](https://github.com/roc-lang/roc/blob/f94004d1372044e61f0f960e896a2853462080c5/crates/reporting/tests/test_reporting.rs#L10329-L10336) which is useful when you forget to `|> apply`.

### Feedback

Please provide any feedback or ways you think we can improve errors.

## Restrictions

Record Builders must be directly applied to functions:

```elm
succeed {
    a <- get "a" |> apply
}
```

<details>
<summary>
They cannot be assigned to defs pre-application or piped:
</summary>

```elm
builder = {
    a <- get "a" |> apply
}
succeed builder

{
    a <- get "a" |> apply
}
|> succeed
```
☝️  that is a [compiler error](https://github.com/roc-lang/roc/blob/f94004d1372044e61f0f960e896a2853462080c5/crates/reporting/tests/test_reporting.rs#L10272-L10281).

> I originally wanted to support `|>`, but the way we desugar it makes this hard. Happy to discuss further.

</details>

<details>
<summary>
The function can also be a tag or opaque type wrapper:
</summary>

```elm
Succeed {
    a <- get "a" |> apply
}

@Parser {
    a <- get "a" |> apply
}
```
</details>

<details>
<summary>
The function can take other arguments:
</summary>

```elm
succeed 
    123
    { a <- get "a" |> apply }
    "hi" 
```
</details>

<details>
<summary>
but at most one record builder:
</summary>

```elm
succeed 
    { a <- get "a" |> apply } 
    { b <- get "b" |> apply } 
````

☝️  that is a [compiler error](https://github.com/roc-lang/roc/blob/f94004d1372044e61f0f960e896a2853462080c5/crates/reporting/tests/test_reporting.rs#L10249-L10259).

</details>

<details>
<summary>
You cannot mix record updates and builders:
</summary>

```elm
succeed 
    { rec &
        a <- get "a" |> apply
    }
```
☝️  that is a [compiler error](https://github.com/roc-lang/roc/blob/f94004d1372044e61f0f960e896a2853462080c5/crates/reporting/tests/test_reporting.rs#L10223-L10235).
</details>
