### PR TITLE
Revert "remove undefined -dynamic_lookup"

### DIFF
--- a/crates/cli/tests/cli_run.rs
+++ b/crates/cli/tests/cli_run.rs
@@ -151,7 +151,11 @@ mod cli_run {
         let stderr = stderr.replacen(ignorable, "", 1);
 
         let is_reporting_runtime = stderr.starts_with("runtime: ") && stderr.ends_with("ms\n");
-        if !(stderr.is_empty() || is_reporting_runtime) {
+        if !(stderr.is_empty() || is_reporting_runtime
+            // macOS ld reports this warning, but if we remove -undefined dynamic_lookup,
+            // linking stops working properly.
+            || stderr.trim() == "ld: warning: -undefined dynamic_lookup may not work with chained fixups")
+        {
             panic!("\n___________\nThe roc command:\n\n  {:?}\n\nhad unexpected stderr:\n\n  {}\n___________\n", compile_out.cmd_str, stderr);
         }
 

--- a/crates/compiler/build/src/link.rs
+++ b/crates/compiler/build/src/link.rs
@@ -1145,7 +1145,7 @@ fn link_macos(
 
             output_path.set_extension("dylib");
 
-            (vec!["-dylib"], output_path)
+            (vec!["-dylib", "-undefined", "dynamic_lookup"], output_path)
         }
         LinkType::None => internal_error!("link_macos should not be called with link type of none"),
     };


### PR DESCRIPTION
It turns out we did need this on mac M1 after all.

Need to find another solution to https://roc.zulipchat.com/#narrow/stream/231635-compiler-development/topic/macos.20linking.20error which doesn't cause a regression on M1s