### PR TITLE
Begin implementing semantic layouts

### DIFF
--- a/crates/compiler/alias_analysis/src/lib.rs
+++ b/crates/compiler/alias_analysis/src/lib.rs
@@ -852,9 +852,8 @@ fn call_spec<'a>(
 
                     let output_element_type = layout_spec(env, builder, interner, *return_layout)?;
 
-                    let state_layout = interner.insert(Layout {
-                        repr: LayoutRepr::Builtin(Builtin::List(*return_layout)),
-                    });
+                    let state_layout = interner
+                        .insert_no_semantic(LayoutRepr::Builtin(Builtin::List(*return_layout)));
                     let state_type = layout_spec(env, builder, interner, state_layout)?;
 
                     let init_state = new_list(builder, block, output_element_type)?;
@@ -881,9 +880,8 @@ fn call_spec<'a>(
 
                     let arg0_layout = argument_layouts[0];
 
-                    let state_layout = interner.insert(Layout {
-                        repr: LayoutRepr::Builtin(Builtin::List(arg0_layout)),
-                    });
+                    let state_layout = interner
+                        .insert_no_semantic(LayoutRepr::Builtin(Builtin::List(arg0_layout)));
                     let state_type = layout_spec(env, builder, interner, state_layout)?;
                     let init_state = list;
 
@@ -910,9 +908,8 @@ fn call_spec<'a>(
 
                     let output_element_type = layout_spec(env, builder, interner, *return_layout)?;
 
-                    let state_layout = interner.insert(Layout {
-                        repr: LayoutRepr::Builtin(Builtin::List(*return_layout)),
-                    });
+                    let state_layout = interner
+                        .insert_no_semantic(LayoutRepr::Builtin(Builtin::List(*return_layout)));
                     let state_type = layout_spec(env, builder, interner, state_layout)?;
 
                     let init_state = new_list(builder, block, output_element_type)?;
@@ -945,9 +942,8 @@ fn call_spec<'a>(
 
                     let output_element_type = layout_spec(env, builder, interner, *return_layout)?;
 
-                    let state_layout = interner.insert(Layout {
-                        repr: LayoutRepr::Builtin(Builtin::List(*return_layout)),
-                    });
+                    let state_layout = interner
+                        .insert_no_semantic(LayoutRepr::Builtin(Builtin::List(*return_layout)));
                     let state_type = layout_spec(env, builder, interner, state_layout)?;
 
                     let init_state = new_list(builder, block, output_element_type)?;
@@ -986,9 +982,8 @@ fn call_spec<'a>(
 
                     let output_element_type = layout_spec(env, builder, interner, *return_layout)?;
 
-                    let state_layout = interner.insert(Layout {
-                        repr: LayoutRepr::Builtin(Builtin::List(*return_layout)),
-                    });
+                    let state_layout = interner
+                        .insert_no_semantic(LayoutRepr::Builtin(Builtin::List(*return_layout)));
                     let state_type = layout_spec(env, builder, interner, state_layout)?;
 
                     let init_state = new_list(builder, block, output_element_type)?;

--- a/crates/compiler/alias_analysis/src/lib.rs
+++ b/crates/compiler/alias_analysis/src/lib.rs
@@ -403,7 +403,7 @@ fn build_entry_point<'a>(
 
         let block = builder.add_block();
 
-        let struct_layout = interner.insert(Layout::struct_no_name_order(layouts));
+        let struct_layout = interner.insert_no_semantic(LayoutRepr::struct_(layouts));
         let type_id = layout_spec(env, &mut builder, interner, struct_layout)?;
 
         let argument = builder.add_unknown_with(block, &[], type_id)?;
@@ -460,9 +460,8 @@ fn proc_spec<'a>(
     )?;
 
     let root = BlockExpr(block, value_id);
-    let args_struct_layout = interner.insert(Layout::struct_no_name_order(
-        argument_layouts.into_bump_slice(),
-    ));
+    let args_struct_layout =
+        interner.insert_no_semantic(LayoutRepr::struct_(argument_layouts.into_bump_slice()));
     let arg_type_id = layout_spec(&mut env, &mut builder, interner, args_struct_layout)?;
     let ret_type_id = layout_spec(&mut env, &mut builder, interner, proc.ret_layout)?;
 

--- a/crates/compiler/gen_dev/src/generic64/mod.rs
+++ b/crates/compiler/gen_dev/src/generic64/mod.rs
@@ -1817,9 +1817,8 @@ impl<
                 let new_element_layout = higher_order.passed_function.return_layout;
 
                 let input_list_layout = LayoutRepr::Builtin(Builtin::List(old_element_layout));
-                let input_list_in_layout = self.layout_interner.insert(Layout {
-                    repr: input_list_layout,
-                });
+                let input_list_in_layout =
+                    self.layout_interner.insert_no_semantic(input_list_layout);
 
                 let caller = self.debug_symbol("caller");
                 let data = self.debug_symbol("data");
@@ -2572,9 +2571,9 @@ impl<
                 );
             }
             _ => {
-                let union_in_layout = self.layout_interner.insert(Layout {
-                    repr: LayoutRepr::Union(*union_layout),
-                });
+                let union_in_layout = self
+                    .layout_interner
+                    .insert_no_semantic(LayoutRepr::Union(*union_layout));
                 todo!(
                     "loading from union type: {:?}",
                     self.layout_interner.dbg(union_in_layout)

--- a/crates/compiler/gen_dev/src/lib.rs
+++ b/crates/compiler/gen_dev/src/lib.rs
@@ -196,9 +196,9 @@ trait Backend<'a> {
     }
 
     fn increment_fn_pointer(&mut self, layout: InLayout<'a>) -> Symbol {
-        let box_layout = self.interner_mut().insert(Layout {
-            repr: LayoutRepr::Boxed(layout),
-        });
+        let box_layout = self
+            .interner_mut()
+            .insert_no_semantic(LayoutRepr::Boxed(layout));
 
         let element_increment = self.debug_symbol("element_increment");
         let element_increment_symbol = self.build_indirect_inc(layout);
@@ -216,9 +216,9 @@ trait Backend<'a> {
     }
 
     fn decrement_fn_pointer(&mut self, layout: InLayout<'a>) -> Symbol {
-        let box_layout = self.interner_mut().insert(Layout {
-            repr: LayoutRepr::Boxed(layout),
-        });
+        let box_layout = self
+            .interner_mut()
+            .insert_no_semantic(LayoutRepr::Boxed(layout));
 
         let element_decrement = self.debug_symbol("element_decrement");
         let element_decrement_symbol = self.build_indirect_dec(layout);

--- a/crates/compiler/gen_dev/src/object_builder.rs
+++ b/crates/compiler/gen_dev/src/object_builder.rs
@@ -456,9 +456,9 @@ fn build_exposed_generic_proc<'a, B: Backend<'a>>(backend: &mut B, proc: &Proc<'
     let s2 = backend.debug_symbol_in(platform, "s2");
     let s3 = backend.debug_symbol_in(platform, "s3");
 
-    let box_layout = backend.interner_mut().insert(Layout {
-        repr: roc_mono::layout::LayoutRepr::Boxed(proc.ret_layout),
-    });
+    let box_layout = backend
+        .interner_mut()
+        .insert_no_semantic(roc_mono::layout::LayoutRepr::Boxed(proc.ret_layout));
 
     let mut args = bumpalo::collections::Vec::new_in(arena);
     args.extend(proc.args);

--- a/crates/compiler/gen_dev/src/object_builder.rs
+++ b/crates/compiler/gen_dev/src/object_builder.rs
@@ -456,9 +456,9 @@ fn build_exposed_generic_proc<'a, B: Backend<'a>>(backend: &mut B, proc: &Proc<'
     let s2 = backend.debug_symbol_in(platform, "s2");
     let s3 = backend.debug_symbol_in(platform, "s3");
 
-    let box_layout = backend
-        .interner_mut()
-        .insert(roc_mono::layout::Layout::Boxed(proc.ret_layout));
+    let box_layout = backend.interner_mut().insert(Layout {
+        repr: roc_mono::layout::LayoutRepr::Boxed(proc.ret_layout),
+    });
 
     let mut args = bumpalo::collections::Vec::new_in(arena);
     args.extend(proc.args);

--- a/crates/compiler/gen_llvm/src/llvm/bitcode.rs
+++ b/crates/compiler/gen_llvm/src/llvm/bitcode.rs
@@ -18,7 +18,7 @@ use inkwell::AddressSpace;
 use roc_error_macros::internal_error;
 use roc_module::symbol::Symbol;
 use roc_mono::layout::{
-    Builtin, InLayout, LambdaSet, Layout, LayoutIds, LayoutInterner, STLayoutInterner,
+    Builtin, InLayout, LambdaSet, LayoutIds, LayoutInterner, LayoutRepr, STLayoutInterner,
 };
 
 use super::build::{create_entry_block_alloca, BuilderExt};
@@ -610,8 +610,8 @@ pub fn build_compare_wrapper<'a, 'ctx>(
 
             let closure_data_repr = closure_data_layout.runtime_representation();
 
-            let arguments_cast = match layout_interner.get(closure_data_repr) {
-                Layout::Struct {
+            let arguments_cast = match layout_interner.get(closure_data_repr).repr {
+                LayoutRepr::Struct {
                     field_layouts: &[], ..
                 } => {
                     // nothing to add

--- a/crates/compiler/gen_llvm/src/llvm/build.rs
+++ b/crates/compiler/gen_llvm/src/llvm/build.rs
@@ -1348,7 +1348,7 @@ pub fn build_exp_expr<'a, 'ctx>(
                     let field_layouts = tag_layouts[*tag_id as usize];
 
                     let struct_layout =
-                        layout_interner.insert(Layout::struct_no_name_order(field_layouts));
+                        layout_interner.insert_no_semantic(LayoutRepr::struct_(field_layouts));
                     let struct_type = basic_type_from_layout(env, layout_interner, struct_layout);
 
                     let opaque_data_ptr = env
@@ -1405,7 +1405,7 @@ pub fn build_exp_expr<'a, 'ctx>(
                 }
                 UnionLayout::NonNullableUnwrapped(field_layouts) => {
                     let struct_layout =
-                        layout_interner.insert(Layout::struct_no_name_order(field_layouts));
+                        layout_interner.insert_no_semantic(LayoutRepr::struct_(field_layouts));
 
                     let struct_type = basic_type_from_layout(env, layout_interner, struct_layout);
                     let target_loaded_type = basic_type_from_layout(env, layout_interner, layout);
@@ -1456,7 +1456,7 @@ pub fn build_exp_expr<'a, 'ctx>(
 
                     let field_layouts = other_fields;
                     let struct_layout =
-                        layout_interner.insert(Layout::struct_no_name_order(field_layouts));
+                        layout_interner.insert_no_semantic(LayoutRepr::struct_(field_layouts));
 
                     let struct_type = basic_type_from_layout(env, layout_interner, struct_layout);
                     let target_loaded_type = basic_type_from_layout(env, layout_interner, layout);
@@ -2095,7 +2095,7 @@ fn lookup_at_index_ptr2<'a, 'ctx>(
 ) -> BasicValueEnum<'ctx> {
     let builder = env.builder;
 
-    let struct_layout = layout_interner.insert(Layout::struct_no_name_order(field_layouts));
+    let struct_layout = layout_interner.insert_no_semantic(LayoutRepr::struct_(field_layouts));
     let struct_type =
         basic_type_from_layout(env, layout_interner, struct_layout).into_struct_type();
 
@@ -3718,7 +3718,7 @@ fn expose_function_to_host_help_c_abi_generic<'a, 'ctx>(
 
         builder.position_at_end(entry);
 
-        let wrapped_layout = layout_interner.insert(roc_call_result_layout(
+        let wrapped_layout = layout_interner.insert_no_semantic(roc_call_result_layout(
             env.arena,
             return_layout,
             env.target_info,
@@ -3859,7 +3859,7 @@ fn expose_function_to_host_help_c_abi_gen_test<'a, 'ctx>(
 
         builder.position_at_end(last_block);
 
-        let wrapper_result = layout_interner.insert(Layout::struct_no_name_order(
+        let wrapper_result = layout_interner.insert_no_semantic(LayoutRepr::struct_(
             env.arena.alloc([Layout::U64, return_layout]),
         ));
 
@@ -4473,10 +4473,10 @@ fn roc_call_result_layout<'a>(
     arena: &'a Bump,
     return_layout: InLayout<'a>,
     target_info: TargetInfo,
-) -> Layout<'a> {
+) -> LayoutRepr<'a> {
     let elements = [Layout::U64, Layout::usize(target_info), return_layout];
 
-    Layout::struct_no_name_order(arena.alloc(elements))
+    LayoutRepr::struct_(arena.alloc(elements))
 }
 
 fn roc_call_result_type<'ctx>(

--- a/crates/compiler/gen_llvm/src/llvm/build.rs
+++ b/crates/compiler/gen_llvm/src/llvm/build.rs
@@ -43,7 +43,7 @@ use roc_mono::ir::{
     ListLiteralElement, ModifyRc, OptLevel, ProcLayout, SingleEntryPoint,
 };
 use roc_mono::layout::{
-    Builtin, InLayout, LambdaName, LambdaSet, Layout, LayoutIds, LayoutInterner, Niche,
+    Builtin, InLayout, LambdaName, LambdaSet, Layout, LayoutIds, LayoutInterner, LayoutRepr, Niche,
     RawFunctionLayout, STLayoutInterner, TagIdIntType, UnionLayout,
 };
 use roc_std::RocDec;
@@ -783,13 +783,13 @@ pub fn build_exp_literal<'a, 'ctx>(
     use roc_mono::ir::Literal::*;
 
     match literal {
-        Int(bytes) => match layout_interner.get(layout) {
-            Layout::Builtin(Builtin::Bool) => env
+        Int(bytes) => match layout_interner.get(layout).repr {
+            LayoutRepr::Builtin(Builtin::Bool) => env
                 .context
                 .bool_type()
                 .const_int(i128::from_ne_bytes(*bytes) as u64, false)
                 .into(),
-            Layout::Builtin(Builtin::Int(int_width)) => {
+            LayoutRepr::Builtin(Builtin::Int(int_width)) => {
                 int_with_precision(env, i128::from_ne_bytes(*bytes), int_width).into()
             }
             _ => panic!("Invalid layout for int literal = {:?}", layout),
@@ -797,8 +797,8 @@ pub fn build_exp_literal<'a, 'ctx>(
 
         U128(bytes) => const_u128(env, u128::from_ne_bytes(*bytes)).into(),
 
-        Float(float) => match layout_interner.get(layout) {
-            Layout::Builtin(Builtin::Float(float_width)) => {
+        Float(float) => match layout_interner.get(layout).repr {
+            LayoutRepr::Builtin(Builtin::Float(float_width)) => {
                 float_with_precision(env, *float, float_width)
             }
             _ => panic!("Invalid layout for float literal = {:?}", layout),
@@ -1178,8 +1178,8 @@ pub fn build_exp_expr<'a, 'ctx>(
             let tag_ptr = tag_ptr.into_pointer_value();
 
             // reset is only generated for union values
-            let union_layout = match layout_interner.get(layout) {
-                Layout::Union(ul) => ul,
+            let union_layout = match layout_interner.get(layout).repr {
+                LayoutRepr::Union(ul) => ul,
                 _ => unreachable!(),
             };
 
@@ -1285,15 +1285,16 @@ pub fn build_exp_expr<'a, 'ctx>(
         } => {
             let (value, layout) = load_symbol_and_layout(scope, structure);
 
-            let layout = if let Layout::LambdaSet(lambda_set) = layout_interner.get(layout) {
+            let layout = if let LayoutRepr::LambdaSet(lambda_set) = layout_interner.get(layout).repr
+            {
                 lambda_set.runtime_representation()
             } else {
                 layout
             };
 
             // extract field from a record
-            match (value, layout_interner.get(layout)) {
-                (StructValue(argument), Layout::Struct { field_layouts, .. }) => {
+            match (value, layout_interner.get(layout).repr) {
+                (StructValue(argument), LayoutRepr::Struct { field_layouts, .. }) => {
                     debug_assert!(!field_layouts.is_empty());
 
                     let field_value = env
@@ -1586,7 +1587,7 @@ fn build_tag_field_value<'a, 'ctx>(
     value: BasicValueEnum<'ctx>,
     tag_field_layout: InLayout<'a>,
 ) -> BasicValueEnum<'ctx> {
-    if let Layout::RecursivePointer(_) = layout_interner.get(tag_field_layout) {
+    if let LayoutRepr::RecursivePointer(_) = layout_interner.get(tag_field_layout).repr {
         debug_assert!(value.is_pointer_value());
 
         // we store recursive pointers as `i64*`
@@ -1741,7 +1742,9 @@ fn build_tag<'a, 'ctx>(
                 use std::cmp::Ordering::*;
                 match tag_id.cmp(&(*nullable_id as _)) {
                     Equal => {
-                        let layout = layout_interner.insert(Layout::Union(*union_layout));
+                        let layout = layout_interner.insert(Layout {
+                            repr: LayoutRepr::Union(*union_layout),
+                        });
 
                         return basic_type_from_layout(env, layout_interner, layout)
                             .into_pointer_type()
@@ -2505,8 +2508,8 @@ pub fn build_exp_stmt<'a, 'ctx>(
 
             for (symbol, expr, layout) in queue {
                 debug_assert!(!matches!(
-                    layout_interner.get(*layout),
-                    Layout::RecursivePointer(_)
+                    layout_interner.get(*layout).repr,
+                    LayoutRepr::RecursivePointer(_)
                 ));
 
                 let val = build_exp_expr(
@@ -2805,9 +2808,10 @@ pub fn build_exp_stmt<'a, 'ctx>(
                 DecRef(symbol) => {
                     let (value, layout) = load_symbol_and_layout(scope, symbol);
 
-                    match layout_interner.get(layout) {
-                        Layout::Builtin(Builtin::Str) => todo!(),
-                        Layout::Builtin(Builtin::List(element_layout)) => {
+                    let lay = layout_interner.get(layout);
+                    match lay.repr {
+                        LayoutRepr::Builtin(Builtin::Str) => todo!(),
+                        LayoutRepr::Builtin(Builtin::List(element_layout)) => {
                             debug_assert!(value.is_struct_value());
                             let element_layout = layout_interner.get(element_layout);
                             let alignment =
@@ -2816,7 +2820,7 @@ pub fn build_exp_stmt<'a, 'ctx>(
                             build_list::decref(env, value.into_struct_value(), alignment);
                         }
 
-                        lay if lay.is_refcounted() => {
+                        _ if lay.is_refcounted() => {
                             if value.is_pointer_value() {
                                 let value_ptr = value.into_pointer_value();
 
@@ -3388,8 +3392,8 @@ fn build_switch_ir<'a, 'ctx>(
     let cont_block = context.append_basic_block(parent, "cont");
 
     // Build the condition
-    let cond = match layout_interner.get(cond_layout) {
-        Layout::Builtin(Builtin::Float(float_width)) => {
+    let cond = match layout_interner.get(cond_layout).repr {
+        LayoutRepr::Builtin(Builtin::Float(float_width)) => {
             // float matches are done on the bit pattern
             cond_layout = Layout::float_width(float_width);
 
@@ -3402,19 +3406,19 @@ fn build_switch_ir<'a, 'ctx>(
                 .build_bitcast(cond_value, int_type, "")
                 .into_int_value()
         }
-        Layout::Union(variant) => {
+        LayoutRepr::Union(variant) => {
             cond_layout = variant.tag_id_layout();
 
             get_tag_id(env, layout_interner, parent, &variant, cond_value)
         }
-        Layout::Builtin(_) => cond_value.into_int_value(),
+        LayoutRepr::Builtin(_) => cond_value.into_int_value(),
         other => todo!("Build switch value from layout: {:?}", other),
     };
 
     // Build the cases
     let mut incoming = Vec::with_capacity_in(branches.len(), arena);
 
-    if let Layout::Builtin(Builtin::Bool) = layout_interner.get(cond_layout) {
+    if let LayoutRepr::Builtin(Builtin::Bool) = layout_interner.get(cond_layout).repr {
         match (branches, default_branch) {
             ([(0, _, false_branch)], true_branch) | ([(1, _, true_branch)], false_branch) => {
                 let then_block = context.append_basic_block(parent, "then_block");
@@ -3822,8 +3826,8 @@ fn expose_function_to_host_help_c_abi_gen_test<'a, 'ctx>(
             // the C and Fast calling conventions agree
             arguments_for_call.push(*arg);
         } else {
-            match layout_interner.get(*layout) {
-                Layout::Builtin(Builtin::List(_)) => {
+            match layout_interner.get(*layout).repr {
+                LayoutRepr::Builtin(Builtin::List(_)) => {
                     let list_type = arg_type
                         .into_pointer_type()
                         .get_element_type()
@@ -3961,7 +3965,7 @@ fn expose_function_to_host_help_c_abi_v2<'a, 'ctx>(
         };
 
         for (i, layout) in arguments.iter().enumerate() {
-            if let Layout::Builtin(Builtin::Str) = layout_interner.get(*layout) {
+            if let LayoutRepr::Builtin(Builtin::Str) = layout_interner.get(*layout).repr {
                 // Indicate to LLVM that this argument is semantically passed by-value
                 // even though technically (because of its size) it is passed by-reference
                 let byval_attribute_id = Attribute::get_named_enum_kind_id("byval");
@@ -4061,8 +4065,10 @@ fn expose_function_to_host_help_c_abi_v2<'a, 'ctx>(
                         env.target_info.architecture,
                         roc_target::Architecture::X86_32 | roc_target::Architecture::X86_64
                     ) {
-                        let c_abi_type = match layout_interner.get(*layout) {
-                            Layout::Builtin(Builtin::Str | Builtin::List(_)) => c_abi_roc_str_type,
+                        let c_abi_type = match layout_interner.get(*layout).repr {
+                            LayoutRepr::Builtin(Builtin::Str | Builtin::List(_)) => {
+                                c_abi_roc_str_type
+                            }
                             _ => todo!("figure out what the C type is"),
                         };
 
@@ -5628,8 +5634,8 @@ fn to_cc_type<'a, 'ctx>(
     layout_interner: &mut STLayoutInterner<'a>,
     layout: InLayout<'a>,
 ) -> BasicTypeEnum<'ctx> {
-    match layout_interner.runtime_representation(layout) {
-        Layout::Builtin(builtin) => to_cc_type_builtin(env, &builtin),
+    match layout_interner.runtime_representation(layout).repr {
+        LayoutRepr::Builtin(builtin) => to_cc_type_builtin(env, &builtin),
         _ => {
             // TODO this is almost certainly incorrect for bigger structs
             basic_type_from_layout(env, layout_interner, layout)
@@ -5675,8 +5681,8 @@ impl RocReturn {
         target_info: TargetInfo,
         layout: InLayout,
     ) -> bool {
-        match interner.get(layout) {
-            Layout::Builtin(builtin) => {
+        match interner.get(layout).repr {
+            LayoutRepr::Builtin(builtin) => {
                 use Builtin::*;
 
                 match target_info.ptr_width() {
@@ -5688,8 +5694,8 @@ impl RocReturn {
                     }
                 }
             }
-            Layout::Union(UnionLayout::NonRecursive(_)) => true,
-            Layout::LambdaSet(lambda_set) => RocReturn::roc_return_by_pointer(
+            LayoutRepr::Union(UnionLayout::NonRecursive(_)) => true,
+            LayoutRepr::LambdaSet(lambda_set) => RocReturn::roc_return_by_pointer(
                 interner,
                 target_info,
                 lambda_set.runtime_representation(),

--- a/crates/compiler/gen_llvm/src/llvm/build.rs
+++ b/crates/compiler/gen_llvm/src/llvm/build.rs
@@ -1742,9 +1742,8 @@ fn build_tag<'a, 'ctx>(
                 use std::cmp::Ordering::*;
                 match tag_id.cmp(&(*nullable_id as _)) {
                     Equal => {
-                        let layout = layout_interner.insert(Layout {
-                            repr: LayoutRepr::Union(*union_layout),
-                        });
+                        let layout =
+                            layout_interner.insert_no_semantic(LayoutRepr::Union(*union_layout));
 
                         return basic_type_from_layout(env, layout_interner, layout)
                             .into_pointer_type()

--- a/crates/compiler/gen_llvm/src/llvm/compare.rs
+++ b/crates/compiler/gen_llvm/src/llvm/compare.rs
@@ -11,7 +11,7 @@ use roc_builtins::bitcode::{FloatWidth, IntWidth};
 use roc_error_macros::internal_error;
 use roc_module::symbol::Symbol;
 use roc_mono::layout::{
-    Builtin, InLayout, Layout, LayoutIds, LayoutInterner, LayoutRepr, STLayoutInterner, UnionLayout,
+    Builtin, InLayout, LayoutIds, LayoutInterner, LayoutRepr, STLayoutInterner, UnionLayout,
 };
 
 use super::build::{load_roc_value, use_roc_value, BuilderExt};
@@ -973,7 +973,7 @@ fn build_tag_eq_help<'a, 'ctx>(
                 env.builder.position_at_end(block);
 
                 let struct_layout =
-                    layout_interner.insert(Layout::struct_no_name_order(field_layouts));
+                    layout_interner.insert_no_semantic(LayoutRepr::struct_(field_layouts));
 
                 let answer = eq_ptr_to_struct(
                     env,
@@ -1046,7 +1046,7 @@ fn build_tag_eq_help<'a, 'ctx>(
                 env.builder.position_at_end(block);
 
                 let struct_layout =
-                    layout_interner.insert(Layout::struct_no_name_order(field_layouts));
+                    layout_interner.insert_no_semantic(LayoutRepr::struct_(field_layouts));
 
                 let answer = eq_ptr_to_struct(
                     env,
@@ -1108,7 +1108,8 @@ fn build_tag_eq_help<'a, 'ctx>(
 
             env.builder.position_at_end(compare_other);
 
-            let struct_layout = layout_interner.insert(Layout::struct_no_name_order(other_fields));
+            let struct_layout =
+                layout_interner.insert_no_semantic(LayoutRepr::struct_(other_fields));
 
             let answer = eq_ptr_to_struct(
                 env,
@@ -1208,7 +1209,7 @@ fn build_tag_eq_help<'a, 'ctx>(
                 env.builder.position_at_end(block);
 
                 let struct_layout =
-                    layout_interner.insert(Layout::struct_no_name_order(field_layouts));
+                    layout_interner.insert_no_semantic(LayoutRepr::struct_(field_layouts));
 
                 let answer = eq_ptr_to_struct(
                     env,
@@ -1248,7 +1249,8 @@ fn build_tag_eq_help<'a, 'ctx>(
 
             env.builder.position_at_end(compare_fields);
 
-            let struct_layout = layout_interner.insert(Layout::struct_no_name_order(field_layouts));
+            let struct_layout =
+                layout_interner.insert_no_semantic(LayoutRepr::struct_(field_layouts));
 
             let answer = eq_ptr_to_struct(
                 env,

--- a/crates/compiler/gen_llvm/src/llvm/convert.rs
+++ b/crates/compiler/gen_llvm/src/llvm/convert.rs
@@ -6,7 +6,8 @@ use inkwell::values::StructValue;
 use inkwell::AddressSpace;
 use roc_builtins::bitcode::{FloatWidth, IntWidth};
 use roc_mono::layout::{
-    round_up_to_alignment, Builtin, InLayout, Layout, LayoutInterner, STLayoutInterner, UnionLayout,
+    round_up_to_alignment, Builtin, InLayout, Layout, LayoutInterner, LayoutRepr, STLayoutInterner,
+    UnionLayout,
 };
 use roc_target::TargetInfo;
 
@@ -33,9 +34,9 @@ pub fn basic_type_from_layout<'a, 'ctx, 'env>(
     layout_interner: &'env mut STLayoutInterner<'a>,
     layout: InLayout<'_>,
 ) -> BasicTypeEnum<'ctx> {
-    use Layout::*;
+    use LayoutRepr::*;
 
-    match layout_interner.get(layout) {
+    match layout_interner.get(layout).repr {
         Struct {
             field_layouts: sorted_fields,
             ..
@@ -150,9 +151,9 @@ pub fn argument_type_from_layout<'a, 'ctx>(
     layout_interner: &mut STLayoutInterner<'a>,
     layout: InLayout<'a>,
 ) -> BasicTypeEnum<'ctx> {
-    use Layout::*;
+    use LayoutRepr::*;
 
-    match layout_interner.get(layout) {
+    match layout_interner.get(layout).repr {
         LambdaSet(lambda_set) => {
             argument_type_from_layout(env, layout_interner, lambda_set.runtime_representation())
         }

--- a/crates/compiler/gen_llvm/src/llvm/expect.rs
+++ b/crates/compiler/gen_llvm/src/llvm/expect.rs
@@ -476,9 +476,7 @@ fn build_clone_tag<'a, 'ctx>(
     value: BasicValueEnum<'ctx>,
     union_layout: UnionLayout<'a>,
 ) -> IntValue<'ctx> {
-    let layout = layout_interner.insert(Layout {
-        repr: LayoutRepr::Union(union_layout),
-    });
+    let layout = layout_interner.insert_no_semantic(LayoutRepr::Union(union_layout));
     let layout_id = layout_ids.get(Symbol::CLONE, &layout);
     let fn_name = layout_id.to_symbol_string(Symbol::CLONE, &env.interns);
 

--- a/crates/compiler/gen_llvm/src/llvm/refcounting.rs
+++ b/crates/compiler/gen_llvm/src/llvm/refcounting.rs
@@ -19,7 +19,7 @@ use inkwell::{AddressSpace, IntPredicate};
 use roc_module::symbol::Interns;
 use roc_module::symbol::Symbol;
 use roc_mono::layout::{
-    Builtin, InLayout, Layout, LayoutIds, LayoutInterner, LayoutRepr, STLayoutInterner, UnionLayout,
+    Builtin, InLayout, LayoutIds, LayoutInterner, LayoutRepr, STLayoutInterner, UnionLayout,
 };
 
 use super::build::{cast_if_necessary_for_opaque_recursive_pointers, load_roc_value, FunctionSpec};
@@ -267,7 +267,7 @@ fn modify_refcount_struct<'a, 'ctx>(
     let block = env.builder.get_insert_block().expect("to be in a function");
     let di_location = env.builder.get_current_debug_location().unwrap();
 
-    let layout = layout_interner.insert(Layout::struct_no_name_order(layouts));
+    let layout = layout_interner.insert_no_semantic(LayoutRepr::struct_(layouts));
 
     let (_, fn_name) = function_name_from_mode(
         layout_ids,
@@ -1274,7 +1274,7 @@ fn build_rec_union_recursive_decrement<'a, 'ctx>(
 
         env.builder.position_at_end(block);
 
-        let fields_struct = layout_interner.insert(Layout::struct_no_name_order(field_layouts));
+        let fields_struct = layout_interner.insert_no_semantic(LayoutRepr::struct_(field_layouts));
         let wrapper_type = basic_type_from_layout(env, layout_interner, fields_struct);
 
         // cast the opaque pointer to a pointer of the correct shape
@@ -1744,7 +1744,7 @@ fn modify_refcount_nonrecursive_help<'a, 'ctx>(
         let block = env.context.append_basic_block(parent, "tag_id_modify");
         env.builder.position_at_end(block);
 
-        let fields_struct = layout_interner.insert(Layout::struct_no_name_order(field_layouts));
+        let fields_struct = layout_interner.insert_no_semantic(LayoutRepr::struct_(field_layouts));
         let data_struct_type = basic_type_from_layout(env, layout_interner, fields_struct);
 
         debug_assert!(data_struct_type.is_struct_type());

--- a/crates/compiler/gen_llvm/src/llvm/refcounting.rs
+++ b/crates/compiler/gen_llvm/src/llvm/refcounting.rs
@@ -19,7 +19,8 @@ use inkwell::{AddressSpace, IntPredicate};
 use roc_module::symbol::Interns;
 use roc_module::symbol::Symbol;
 use roc_mono::layout::{
-    Builtin, InLayout, Layout, LayoutIds, LayoutInterner, LayoutRepr, STLayoutInterner, UnionLayout,
+    Builtin, InLayout, Layout, LayoutIds, LayoutInterner, LayoutRepr, STLayoutInterner,
+    SemanticRepr, UnionLayout,
 };
 
 use super::build::{cast_if_necessary_for_opaque_recursive_pointers, load_roc_value, FunctionSpec};
@@ -609,9 +610,8 @@ fn modify_refcount_list<'a, 'ctx>(
             element_layout
         };
 
-    let list_layout = layout_interner.insert(Layout {
-        repr: LayoutRepr::Builtin(Builtin::List(element_layout)),
-    });
+    let list_layout =
+        layout_interner.insert_no_semantic(LayoutRepr::Builtin(Builtin::List(element_layout)));
     let (_, fn_name) = function_name_from_mode(
         layout_ids,
         &env.interns,
@@ -805,8 +805,10 @@ fn modify_refcount_str_help<'a, 'ctx>(
     let parent = fn_val;
 
     let str_type = zig_str_type(env);
+    // TODO(deref-layout)
     let str_wrapper = if (Layout {
         repr: LayoutRepr::Builtin(Builtin::Str),
+        semantic: SemanticRepr::None,
     })
     .is_passed_by_reference(layout_interner, env.target_info)
     {
@@ -862,9 +864,7 @@ fn modify_refcount_boxed<'a, 'ctx>(
     let block = env.builder.get_insert_block().expect("to be in a function");
     let di_location = env.builder.get_current_debug_location().unwrap();
 
-    let boxed_layout = layout_interner.insert(Layout {
-        repr: LayoutRepr::Boxed(inner_layout),
-    });
+    let boxed_layout = layout_interner.insert_no_semantic(LayoutRepr::Boxed(inner_layout));
 
     let (_, fn_name) = function_name_from_mode(
         layout_ids,
@@ -926,9 +926,7 @@ fn modify_refcount_box_help<'a, 'ctx>(
     let boxed = arg_val.into_pointer_value();
     let refcount_ptr = PointerToRefcount::from_ptr_to_data(env, boxed);
     let call_mode = mode_to_call_mode(fn_val, mode);
-    let boxed_layout = layout_interner.insert(Layout {
-        repr: LayoutRepr::Boxed(inner_layout),
-    });
+    let boxed_layout = layout_interner.insert_no_semantic(LayoutRepr::Boxed(inner_layout));
 
     match mode {
         Mode::Inc => {
@@ -1072,9 +1070,7 @@ fn build_rec_union<'a, 'ctx>(
     mode: Mode,
     union_layout: UnionLayout<'a>,
 ) -> FunctionValue<'ctx> {
-    let layout = layout_interner.insert(Layout {
-        repr: LayoutRepr::Union(union_layout),
-    });
+    let layout = layout_interner.insert_no_semantic(LayoutRepr::Union(union_layout));
 
     let (_, fn_name) = function_name_from_mode(
         layout_ids,
@@ -1177,9 +1173,7 @@ fn build_rec_union_help<'a, 'ctx>(
     let refcount_ptr = PointerToRefcount::from_ptr_to_data(env, value_ptr);
     let call_mode = mode_to_call_mode(fn_val, mode);
 
-    let layout = layout_interner.insert(Layout {
-        repr: LayoutRepr::Union(union_layout),
-    });
+    let layout = layout_interner.insert_no_semantic(LayoutRepr::Union(union_layout));
 
     match mode {
         Mode::Inc => {
@@ -1322,9 +1316,8 @@ fn build_rec_union_recursive_decrement<'a, 'ctx>(
                 debug_assert!(ptr_as_i64_ptr.is_pointer_value());
 
                 // therefore we must cast it to our desired type
-                let union_layout = layout_interner.insert(Layout {
-                    repr: LayoutRepr::Union(union_layout),
-                });
+                let union_layout =
+                    layout_interner.insert_no_semantic(LayoutRepr::Union(union_layout));
                 let union_type = basic_type_from_layout(env, layout_interner, union_layout);
                 let recursive_field_ptr = cast_basic_basic(env.builder, ptr_as_i64_ptr, union_type);
 
@@ -1362,9 +1355,8 @@ fn build_rec_union_recursive_decrement<'a, 'ctx>(
         match decrement_or_reuse {
             DecOrReuse::Reuse => {}
             DecOrReuse::Dec => {
-                let union_layout = layout_interner.insert(Layout {
-                    repr: LayoutRepr::Union(union_layout),
-                });
+                let union_layout =
+                    layout_interner.insert_no_semantic(LayoutRepr::Union(union_layout));
                 refcount_ptr.modify(call_mode, union_layout, env, layout_interner);
             }
         }
@@ -1422,9 +1414,8 @@ fn build_rec_union_recursive_decrement<'a, 'ctx>(
 
             // increment/decrement the cons-cell itself
             if let DecOrReuse::Dec = decrement_or_reuse {
-                let union_layout = layout_interner.insert(Layout {
-                    repr: LayoutRepr::Union(union_layout),
-                });
+                let union_layout =
+                    layout_interner.insert_no_semantic(LayoutRepr::Union(union_layout));
                 refcount_ptr.modify(call_mode, union_layout, env, layout_interner);
             }
         }
@@ -1484,9 +1475,7 @@ pub fn build_reset<'a, 'ctx>(
 ) -> FunctionValue<'ctx> {
     let mode = Mode::Dec;
 
-    let union_layout_in = layout_interner.insert(Layout {
-        repr: LayoutRepr::Union(union_layout),
-    });
+    let union_layout_in = layout_interner.insert_no_semantic(LayoutRepr::Union(union_layout));
     let layout_id = layout_ids.get(Symbol::DEC, &union_layout_in);
     let fn_name = layout_id.to_symbol_string(Symbol::DEC, &env.interns);
     let fn_name = format!("{}_reset", fn_name);
@@ -1582,9 +1571,7 @@ fn build_reuse_rec_union_help<'a, 'ctx>(
 
     env.builder.position_at_end(should_recurse_block);
 
-    let layout = layout_interner.insert(Layout {
-        repr: LayoutRepr::Union(union_layout),
-    });
+    let layout = layout_interner.insert_no_semantic(LayoutRepr::Union(union_layout));
 
     let do_recurse_block = env.context.append_basic_block(parent, "do_recurse");
     let no_recurse_block = env.context.append_basic_block(parent, "no_recurse");
@@ -1646,9 +1633,7 @@ fn modify_refcount_nonrecursive<'a, 'ctx>(
     fields: &'a [&'a [InLayout<'a>]],
 ) -> FunctionValue<'ctx> {
     let union_layout = UnionLayout::NonRecursive(fields);
-    let layout = layout_interner.insert(Layout {
-        repr: LayoutRepr::Union(union_layout),
-    });
+    let layout = layout_interner.insert_no_semantic(LayoutRepr::Union(union_layout));
 
     let block = env.builder.get_insert_block().expect("to be in a function");
     let di_location = env.builder.get_current_debug_location().unwrap();
@@ -1718,9 +1703,7 @@ fn modify_refcount_nonrecursive_help<'a, 'ctx>(
     let before_block = env.builder.get_insert_block().expect("to be in a function");
 
     let union_layout = UnionLayout::NonRecursive(tags);
-    let layout = layout_interner.insert(Layout {
-        repr: LayoutRepr::Union(union_layout),
-    });
+    let layout = layout_interner.insert_no_semantic(LayoutRepr::Union(union_layout));
     let union_struct_type = basic_type_from_layout(env, layout_interner, layout).into_struct_type();
 
     // read the tag_id

--- a/crates/compiler/gen_llvm/src/llvm/refcounting.rs
+++ b/crates/compiler/gen_llvm/src/llvm/refcounting.rs
@@ -19,8 +19,7 @@ use inkwell::{AddressSpace, IntPredicate};
 use roc_module::symbol::Interns;
 use roc_module::symbol::Symbol;
 use roc_mono::layout::{
-    Builtin, InLayout, Layout, LayoutIds, LayoutInterner, LayoutRepr, STLayoutInterner,
-    SemanticRepr, UnionLayout,
+    Builtin, InLayout, Layout, LayoutIds, LayoutInterner, LayoutRepr, STLayoutInterner, UnionLayout,
 };
 
 use super::build::{cast_if_necessary_for_opaque_recursive_pointers, load_roc_value, FunctionSpec};
@@ -805,12 +804,8 @@ fn modify_refcount_str_help<'a, 'ctx>(
     let parent = fn_val;
 
     let str_type = zig_str_type(env);
-    // TODO(deref-layout)
-    let str_wrapper = if (Layout {
-        repr: LayoutRepr::Builtin(Builtin::Str),
-        semantic: SemanticRepr::None,
-    })
-    .is_passed_by_reference(layout_interner, env.target_info)
+    let str_wrapper = if LayoutRepr::Builtin(Builtin::Str)
+        .is_passed_by_reference(layout_interner, env.target_info)
     {
         env.builder
             .new_build_load(str_type, arg_val.into_pointer_value(), "load_str_to_stack")

--- a/crates/compiler/gen_wasm/src/low_level.rs
+++ b/crates/compiler/gen_wasm/src/low_level.rs
@@ -6,7 +6,9 @@ use roc_module::low_level::LowLevel;
 use roc_module::symbol::Symbol;
 use roc_mono::code_gen_help::HelperOp;
 use roc_mono::ir::{HigherOrderLowLevel, PassedFunction, ProcLayout};
-use roc_mono::layout::{Builtin, FieldOrderHash, InLayout, Layout, LayoutInterner, UnionLayout};
+use roc_mono::layout::{
+    Builtin, FieldOrderHash, InLayout, Layout, LayoutInterner, LayoutRepr, UnionLayout,
+};
 use roc_mono::low_level::HigherOrder;
 
 use crate::backend::{ProcLookupData, ProcSource, WasmBackend};
@@ -237,19 +239,19 @@ impl<'a> LowLevelCall<'a> {
             }
             StrGetCapacity => self.load_args_and_call_zig(backend, bitcode::STR_CAPACITY),
             StrToNum => {
-                let number_layout = match backend.layout_interner.get(self.ret_layout) {
-                    Layout::Struct { field_layouts, .. } => field_layouts[0],
+                let number_layout = match backend.layout_interner.get(self.ret_layout).repr {
+                    LayoutRepr::Struct { field_layouts, .. } => field_layouts[0],
                     _ => {
                         internal_error!("Unexpected mono layout {:?} for StrToNum", self.ret_layout)
                     }
                 };
                 // match on the return layout to figure out which zig builtin we need
-                let intrinsic = match backend.layout_interner.get(number_layout) {
-                    Layout::Builtin(Builtin::Int(int_width)) => &bitcode::STR_TO_INT[int_width],
-                    Layout::Builtin(Builtin::Float(float_width)) => {
+                let intrinsic = match backend.layout_interner.get(number_layout).repr {
+                    LayoutRepr::Builtin(Builtin::Int(int_width)) => &bitcode::STR_TO_INT[int_width],
+                    LayoutRepr::Builtin(Builtin::Float(float_width)) => {
                         &bitcode::STR_TO_FLOAT[float_width]
                     }
-                    Layout::Builtin(Builtin::Decimal) => bitcode::DEC_FROM_STR,
+                    LayoutRepr::Builtin(Builtin::Decimal) => bitcode::DEC_FROM_STR,
                     rest => internal_error!("Unexpected layout {:?} for StrToNum", rest),
                 };
 
@@ -388,32 +390,36 @@ impl<'a> LowLevelCall<'a> {
                 };
 
                 // Byte offsets of each field in the return struct
-                let (ret_list_offset, ret_elem_offset, elem_layout) = match self.ret_layout_raw {
-                    Layout::Struct {
+                let (ret_list_offset, ret_elem_offset, elem_layout) = match self.ret_layout_raw.repr
+                {
+                    LayoutRepr::Struct {
                         field_layouts: &[f1, f2],
                         ..
-                    } => match (
-                        backend.layout_interner.get(f1),
-                        backend.layout_interner.get(f2),
-                    ) {
-                        (Layout::Builtin(Builtin::List(list_elem)), value_layout)
-                            if value_layout == backend.layout_interner.get(list_elem) =>
-                        {
-                            let list_offset = 0;
-                            let elem_offset = Layout::Builtin(Builtin::List(list_elem))
+                    } => {
+                        let l1 = backend.layout_interner.get(f1);
+                        let l2 = backend.layout_interner.get(f2);
+                        match (l1.repr, l2.repr) {
+                            (LayoutRepr::Builtin(Builtin::List(list_elem)), _)
+                                if l2.repr == backend.layout_interner.get(list_elem).repr =>
+                            {
+                                let list_offset = 0;
+                                let elem_offset = Layout {
+                                    repr: LayoutRepr::Builtin(Builtin::List(list_elem)),
+                                }
                                 .stack_size(backend.layout_interner, TARGET_INFO);
-                            (list_offset, elem_offset, f2)
+                                (list_offset, elem_offset, f2)
+                            }
+                            (_, LayoutRepr::Builtin(Builtin::List(list_elem)))
+                                if l1.repr == backend.layout_interner.get(list_elem).repr =>
+                            {
+                                let list_offset =
+                                    l1.stack_size(backend.layout_interner, TARGET_INFO);
+                                let elem_offset = 0;
+                                (list_offset, elem_offset, f1)
+                            }
+                            _ => internal_error!("Invalid return layout for ListReplaceUnsafe"),
                         }
-                        (value_layout, Layout::Builtin(Builtin::List(list_elem)))
-                            if value_layout == backend.layout_interner.get(list_elem) =>
-                        {
-                            let list_offset =
-                                value_layout.stack_size(backend.layout_interner, TARGET_INFO);
-                            let elem_offset = 0;
-                            (list_offset, elem_offset, f1)
-                        }
-                        _ => internal_error!("Invalid return layout for ListReplaceUnsafe"),
-                    },
+                    }
                     _ => internal_error!("Invalid return layout for ListReplaceUnsafe"),
                 };
 
@@ -691,9 +697,11 @@ impl<'a> LowLevelCall<'a> {
 
                 // The refcount function receives a pointer to an element in the list
                 // This is the same as a Struct containing the element
-                let in_memory_layout = backend.layout_interner.insert(Layout::Struct {
-                    field_order_hash: FieldOrderHash::from_ordered_fields(&[]),
-                    field_layouts: backend.env.arena.alloc([elem_layout]),
+                let in_memory_layout = backend.layout_interner.insert(Layout {
+                    repr: LayoutRepr::Struct {
+                        field_order_hash: FieldOrderHash::from_ordered_fields(&[]),
+                        field_layouts: backend.env.arena.alloc([elem_layout]),
+                    },
                 });
                 let dec_fn = backend.get_refcount_fn_index(in_memory_layout, HelperOp::Dec);
                 let dec_fn_ptr = backend.get_fn_ptr(dec_fn);
@@ -737,9 +745,11 @@ impl<'a> LowLevelCall<'a> {
 
                 // The refcount function receives a pointer to an element in the list
                 // This is the same as a Struct containing the element
-                let in_memory_layout = backend.layout_interner.insert(Layout::Struct {
-                    field_order_hash: FieldOrderHash::from_ordered_fields(&[]),
-                    field_layouts: backend.env.arena.alloc([elem_layout]),
+                let in_memory_layout = backend.layout_interner.insert(Layout {
+                    repr: LayoutRepr::Struct {
+                        field_order_hash: FieldOrderHash::from_ordered_fields(&[]),
+                        field_layouts: backend.env.arena.alloc([elem_layout]),
+                    },
                 });
                 let dec_fn = backend.get_refcount_fn_index(in_memory_layout, HelperOp::Dec);
                 let dec_fn_ptr = backend.get_fn_ptr(dec_fn);
@@ -812,11 +822,11 @@ impl<'a> LowLevelCall<'a> {
             }
 
             // Num
-            NumAdd => match self.ret_layout_raw {
-                Layout::Builtin(Builtin::Int(width)) => {
+            NumAdd => match self.ret_layout_raw.repr {
+                LayoutRepr::Builtin(Builtin::Int(width)) => {
                     self.load_args_and_call_zig(backend, &bitcode::NUM_ADD_OR_PANIC_INT[width])
                 }
-                Layout::Builtin(Builtin::Float(width)) => match width {
+                LayoutRepr::Builtin(Builtin::Float(width)) => match width {
                     FloatWidth::F32 => {
                         self.load_args(backend);
                         backend.code_builder.f32_add()
@@ -826,14 +836,14 @@ impl<'a> LowLevelCall<'a> {
                         backend.code_builder.f64_add()
                     }
                 },
-                Layout::Builtin(Builtin::Decimal) => {
+                LayoutRepr::Builtin(Builtin::Decimal) => {
                     self.load_args_and_call_zig(backend, bitcode::DEC_ADD_OR_PANIC)
                 }
                 _ => panic_ret_type(),
             },
 
-            NumAddWrap => match self.ret_layout_raw {
-                Layout::Builtin(Builtin::Int(width)) => match width {
+            NumAddWrap => match self.ret_layout_raw.repr {
+                LayoutRepr::Builtin(Builtin::Int(width)) => match width {
                     IntWidth::I128 | IntWidth::U128 => {
                         // TODO: don't panic
                         self.load_args_and_call_zig(backend, &bitcode::NUM_ADD_OR_PANIC_INT[width])
@@ -852,7 +862,7 @@ impl<'a> LowLevelCall<'a> {
                         self.wrap_small_int(backend, width);
                     }
                 },
-                Layout::Builtin(Builtin::Float(width)) => match width {
+                LayoutRepr::Builtin(Builtin::Float(width)) => match width {
                     FloatWidth::F32 => {
                         self.load_args(backend);
                         backend.code_builder.f32_add()
@@ -862,7 +872,7 @@ impl<'a> LowLevelCall<'a> {
                         backend.code_builder.f64_add()
                     }
                 },
-                Layout::Builtin(Builtin::Decimal) => {
+                LayoutRepr::Builtin(Builtin::Decimal) => {
                     // TODO: don't panic
                     self.load_args_and_call_zig(backend, bitcode::DEC_ADD_OR_PANIC)
                 }
@@ -872,42 +882,42 @@ impl<'a> LowLevelCall<'a> {
             NumToStr => self.num_to_str(backend),
             NumAddChecked => {
                 let arg_layout = backend.storage.symbol_layouts[&self.arguments[0]];
-                match backend.layout_interner.get(arg_layout) {
-                    Layout::Builtin(Builtin::Int(width)) => {
+                match backend.layout_interner.get(arg_layout).repr {
+                    LayoutRepr::Builtin(Builtin::Int(width)) => {
                         self.load_args_and_call_zig(backend, &bitcode::NUM_ADD_CHECKED_INT[width])
                     }
-                    Layout::Builtin(Builtin::Float(width)) => {
+                    LayoutRepr::Builtin(Builtin::Float(width)) => {
                         self.load_args_and_call_zig(backend, &bitcode::NUM_ADD_CHECKED_FLOAT[width])
                     }
-                    Layout::Builtin(Builtin::Decimal) => {
+                    LayoutRepr::Builtin(Builtin::Decimal) => {
                         self.load_args_and_call_zig(backend, bitcode::DEC_ADD_WITH_OVERFLOW)
                     }
                     x => internal_error!("NumAddChecked is not defined for {:?}", x),
                 }
             }
-            NumAddSaturated => match self.ret_layout_raw {
-                Layout::Builtin(Builtin::Int(width)) => {
+            NumAddSaturated => match self.ret_layout_raw.repr {
+                LayoutRepr::Builtin(Builtin::Int(width)) => {
                     self.load_args_and_call_zig(backend, &bitcode::NUM_ADD_SATURATED_INT[width])
                 }
-                Layout::Builtin(Builtin::Float(FloatWidth::F32)) => {
+                LayoutRepr::Builtin(Builtin::Float(FloatWidth::F32)) => {
                     self.load_args(backend);
                     backend.code_builder.f32_add()
                 }
-                Layout::Builtin(Builtin::Float(FloatWidth::F64)) => {
+                LayoutRepr::Builtin(Builtin::Float(FloatWidth::F64)) => {
                     self.load_args(backend);
                     backend.code_builder.f64_add()
                 }
-                Layout::Builtin(Builtin::Decimal) => {
+                LayoutRepr::Builtin(Builtin::Decimal) => {
                     self.load_args_and_call_zig(backend, bitcode::DEC_ADD_SATURATED)
                 }
                 _ => panic_ret_type(),
             },
 
-            NumSub => match self.ret_layout_raw {
-                Layout::Builtin(Builtin::Int(width)) => {
+            NumSub => match self.ret_layout_raw.repr {
+                LayoutRepr::Builtin(Builtin::Int(width)) => {
                     self.load_args_and_call_zig(backend, &bitcode::NUM_SUB_OR_PANIC_INT[width])
                 }
-                Layout::Builtin(Builtin::Float(width)) => match width {
+                LayoutRepr::Builtin(Builtin::Float(width)) => match width {
                     FloatWidth::F32 => {
                         self.load_args(backend);
                         backend.code_builder.f32_sub()
@@ -917,14 +927,14 @@ impl<'a> LowLevelCall<'a> {
                         backend.code_builder.f64_sub()
                     }
                 },
-                Layout::Builtin(Builtin::Decimal) => {
+                LayoutRepr::Builtin(Builtin::Decimal) => {
                     self.load_args_and_call_zig(backend, bitcode::DEC_SUB_OR_PANIC)
                 }
                 _ => panic_ret_type(),
             },
 
-            NumSubWrap => match self.ret_layout_raw {
-                Layout::Builtin(Builtin::Int(width)) => match width {
+            NumSubWrap => match self.ret_layout_raw.repr {
+                LayoutRepr::Builtin(Builtin::Int(width)) => match width {
                     IntWidth::I128 | IntWidth::U128 => {
                         // TODO: don't panic
                         self.load_args_and_call_zig(backend, &bitcode::NUM_SUB_OR_PANIC_INT[width])
@@ -943,7 +953,7 @@ impl<'a> LowLevelCall<'a> {
                         self.wrap_small_int(backend, width);
                     }
                 },
-                Layout::Builtin(Builtin::Float(width)) => match width {
+                LayoutRepr::Builtin(Builtin::Float(width)) => match width {
                     FloatWidth::F32 => {
                         self.load_args(backend);
                         backend.code_builder.f32_sub()
@@ -953,7 +963,7 @@ impl<'a> LowLevelCall<'a> {
                         backend.code_builder.f64_sub()
                     }
                 },
-                Layout::Builtin(Builtin::Decimal) => {
+                LayoutRepr::Builtin(Builtin::Decimal) => {
                     // TODO: don't panic
                     self.load_args_and_call_zig(backend, bitcode::DEC_SUB_OR_PANIC)
                 }
@@ -961,42 +971,42 @@ impl<'a> LowLevelCall<'a> {
             },
             NumSubChecked => {
                 let arg_layout = backend.storage.symbol_layouts[&self.arguments[0]];
-                match backend.layout_interner.get(arg_layout) {
-                    Layout::Builtin(Builtin::Int(width)) => {
+                match backend.layout_interner.get(arg_layout).repr {
+                    LayoutRepr::Builtin(Builtin::Int(width)) => {
                         self.load_args_and_call_zig(backend, &bitcode::NUM_SUB_CHECKED_INT[width])
                     }
-                    Layout::Builtin(Builtin::Float(width)) => {
+                    LayoutRepr::Builtin(Builtin::Float(width)) => {
                         self.load_args_and_call_zig(backend, &bitcode::NUM_SUB_CHECKED_FLOAT[width])
                     }
-                    Layout::Builtin(Builtin::Decimal) => {
+                    LayoutRepr::Builtin(Builtin::Decimal) => {
                         self.load_args_and_call_zig(backend, bitcode::DEC_SUB_WITH_OVERFLOW)
                     }
                     x => internal_error!("NumSubChecked is not defined for {:?}", x),
                 }
             }
-            NumSubSaturated => match self.ret_layout_raw {
-                Layout::Builtin(Builtin::Int(width)) => {
+            NumSubSaturated => match self.ret_layout_raw.repr {
+                LayoutRepr::Builtin(Builtin::Int(width)) => {
                     self.load_args_and_call_zig(backend, &bitcode::NUM_SUB_SATURATED_INT[width])
                 }
-                Layout::Builtin(Builtin::Float(FloatWidth::F32)) => {
+                LayoutRepr::Builtin(Builtin::Float(FloatWidth::F32)) => {
                     self.load_args(backend);
                     backend.code_builder.f32_sub()
                 }
-                Layout::Builtin(Builtin::Float(FloatWidth::F64)) => {
+                LayoutRepr::Builtin(Builtin::Float(FloatWidth::F64)) => {
                     self.load_args(backend);
                     backend.code_builder.f64_sub()
                 }
-                Layout::Builtin(Builtin::Decimal) => {
+                LayoutRepr::Builtin(Builtin::Decimal) => {
                     self.load_args_and_call_zig(backend, bitcode::DEC_SUB_SATURATED)
                 }
                 _ => panic_ret_type(),
             },
 
-            NumMul => match self.ret_layout_raw {
-                Layout::Builtin(Builtin::Int(width)) => {
+            NumMul => match self.ret_layout_raw.repr {
+                LayoutRepr::Builtin(Builtin::Int(width)) => {
                     self.load_args_and_call_zig(backend, &bitcode::NUM_MUL_OR_PANIC_INT[width])
                 }
-                Layout::Builtin(Builtin::Float(width)) => match width {
+                LayoutRepr::Builtin(Builtin::Float(width)) => match width {
                     FloatWidth::F32 => {
                         self.load_args(backend);
                         backend.code_builder.f32_mul()
@@ -1006,13 +1016,13 @@ impl<'a> LowLevelCall<'a> {
                         backend.code_builder.f64_mul()
                     }
                 },
-                Layout::Builtin(Builtin::Decimal) => {
+                LayoutRepr::Builtin(Builtin::Decimal) => {
                     self.load_args_and_call_zig(backend, bitcode::DEC_MUL_OR_PANIC)
                 }
                 _ => panic_ret_type(),
             },
-            NumMulWrap => match self.ret_layout_raw {
-                Layout::Builtin(Builtin::Int(width)) => match width {
+            NumMulWrap => match self.ret_layout_raw.repr {
+                LayoutRepr::Builtin(Builtin::Int(width)) => match width {
                     IntWidth::I128 | IntWidth::U128 => {
                         self.load_args_and_call_zig(backend, &bitcode::NUM_MUL_WRAP_INT[width])
                     }
@@ -1030,7 +1040,7 @@ impl<'a> LowLevelCall<'a> {
                         self.wrap_small_int(backend, width);
                     }
                 },
-                Layout::Builtin(Builtin::Float(width)) => match width {
+                LayoutRepr::Builtin(Builtin::Float(width)) => match width {
                     FloatWidth::F32 => {
                         self.load_args(backend);
                         backend.code_builder.f32_mul()
@@ -1040,25 +1050,25 @@ impl<'a> LowLevelCall<'a> {
                         backend.code_builder.f64_mul()
                     }
                 },
-                Layout::Builtin(Builtin::Decimal) => {
+                LayoutRepr::Builtin(Builtin::Decimal) => {
                     // TODO: don't panic
                     self.load_args_and_call_zig(backend, bitcode::DEC_MUL_OR_PANIC)
                 }
                 _ => panic_ret_type(),
             },
-            NumMulSaturated => match self.ret_layout_raw {
-                Layout::Builtin(Builtin::Int(width)) => {
+            NumMulSaturated => match self.ret_layout_raw.repr {
+                LayoutRepr::Builtin(Builtin::Int(width)) => {
                     self.load_args_and_call_zig(backend, &bitcode::NUM_MUL_SATURATED_INT[width])
                 }
-                Layout::Builtin(Builtin::Float(FloatWidth::F32)) => {
+                LayoutRepr::Builtin(Builtin::Float(FloatWidth::F32)) => {
                     self.load_args(backend);
                     backend.code_builder.f32_mul()
                 }
-                Layout::Builtin(Builtin::Float(FloatWidth::F64)) => {
+                LayoutRepr::Builtin(Builtin::Float(FloatWidth::F64)) => {
                     self.load_args(backend);
                     backend.code_builder.f64_mul()
                 }
-                Layout::Builtin(Builtin::Decimal) => {
+                LayoutRepr::Builtin(Builtin::Decimal) => {
                     self.load_args_and_call_zig(backend, bitcode::DEC_MUL_SATURATED)
                 }
                 _ => panic_ret_type(),
@@ -1066,14 +1076,14 @@ impl<'a> LowLevelCall<'a> {
 
             NumMulChecked => {
                 let arg_layout = backend.storage.symbol_layouts[&self.arguments[0]];
-                match backend.layout_interner.get(arg_layout) {
-                    Layout::Builtin(Builtin::Int(width)) => {
+                match backend.layout_interner.get(arg_layout).repr {
+                    LayoutRepr::Builtin(Builtin::Int(width)) => {
                         self.load_args_and_call_zig(backend, &bitcode::NUM_MUL_CHECKED_INT[width])
                     }
-                    Layout::Builtin(Builtin::Float(width)) => {
+                    LayoutRepr::Builtin(Builtin::Float(width)) => {
                         self.load_args_and_call_zig(backend, &bitcode::NUM_MUL_CHECKED_FLOAT[width])
                     }
-                    Layout::Builtin(Builtin::Decimal) => {
+                    LayoutRepr::Builtin(Builtin::Decimal) => {
                         self.load_args_and_call_zig(backend, bitcode::DEC_MUL_WITH_OVERFLOW)
                     }
                     x => internal_error!("NumMulChecked is not defined for {:?}", x),
@@ -1248,8 +1258,8 @@ impl<'a> LowLevelCall<'a> {
                     x => todo!("{:?} for {:?}", self.lowlevel, x),
                 }
             }
-            NumDivCeilUnchecked => match self.ret_layout_raw {
-                Layout::Builtin(Builtin::Int(width)) => {
+            NumDivCeilUnchecked => match self.ret_layout_raw.repr {
+                LayoutRepr::Builtin(Builtin::Int(width)) => {
                     self.load_args_and_call_zig(backend, &bitcode::NUM_DIV_CEIL[width])
                 }
                 _ => panic_ret_type(),
@@ -1459,32 +1469,32 @@ impl<'a> LowLevelCall<'a> {
                     _ => todo!("{:?} for {:?}", self.lowlevel, self.ret_layout),
                 }
             }
-            NumSin => match self.ret_layout_raw {
-                Layout::Builtin(Builtin::Float(width)) => {
+            NumSin => match self.ret_layout_raw.repr {
+                LayoutRepr::Builtin(Builtin::Float(width)) => {
                     self.load_args_and_call_zig(backend, &bitcode::NUM_SIN[width]);
                 }
                 _ => panic_ret_type(),
             },
-            NumCos => match self.ret_layout_raw {
-                Layout::Builtin(Builtin::Float(width)) => {
+            NumCos => match self.ret_layout_raw.repr {
+                LayoutRepr::Builtin(Builtin::Float(width)) => {
                     self.load_args_and_call_zig(backend, &bitcode::NUM_COS[width]);
                 }
                 _ => panic_ret_type(),
             },
             NumSqrtUnchecked => {
                 self.load_args(backend);
-                match self.ret_layout_raw {
-                    Layout::Builtin(Builtin::Float(FloatWidth::F32)) => {
+                match self.ret_layout_raw.repr {
+                    LayoutRepr::Builtin(Builtin::Float(FloatWidth::F32)) => {
                         backend.code_builder.f32_sqrt()
                     }
-                    Layout::Builtin(Builtin::Float(FloatWidth::F64)) => {
+                    LayoutRepr::Builtin(Builtin::Float(FloatWidth::F64)) => {
                         backend.code_builder.f64_sqrt()
                     }
                     _ => panic_ret_type(),
                 }
             }
-            NumLogUnchecked => match self.ret_layout_raw {
-                Layout::Builtin(Builtin::Float(width)) => {
+            NumLogUnchecked => match self.ret_layout_raw.repr {
+                LayoutRepr::Builtin(Builtin::Float(width)) => {
                     self.load_args_and_call_zig(backend, &bitcode::NUM_LOG[width]);
                 }
                 _ => panic_ret_type(),
@@ -1507,8 +1517,8 @@ impl<'a> LowLevelCall<'a> {
                     _ => todo!("{:?}: {:?} -> {:?}", self.lowlevel, arg_type, ret_type),
                 }
             }
-            NumPow => match self.ret_layout_raw {
-                Layout::Builtin(Builtin::Float(width)) => {
+            NumPow => match self.ret_layout_raw.repr {
+                LayoutRepr::Builtin(Builtin::Float(width)) => {
                     self.load_args_and_call_zig(backend, &bitcode::NUM_POW[width]);
                 }
                 _ => panic_ret_type(),
@@ -1517,8 +1527,9 @@ impl<'a> LowLevelCall<'a> {
             NumCountLeadingZeroBits => match backend
                 .layout_interner
                 .get(backend.storage.symbol_layouts[&self.arguments[0]])
+                .repr
             {
-                Layout::Builtin(Builtin::Int(width)) => {
+                LayoutRepr::Builtin(Builtin::Int(width)) => {
                     self.load_args_and_call_zig(
                         backend,
                         &bitcode::NUM_COUNT_LEADING_ZERO_BITS[width],
@@ -1529,8 +1540,9 @@ impl<'a> LowLevelCall<'a> {
             NumCountTrailingZeroBits => match backend
                 .layout_interner
                 .get(backend.storage.symbol_layouts[&self.arguments[0]])
+                .repr
             {
-                Layout::Builtin(Builtin::Int(width)) => {
+                LayoutRepr::Builtin(Builtin::Int(width)) => {
                     self.load_args_and_call_zig(
                         backend,
                         &bitcode::NUM_COUNT_TRAILING_ZERO_BITS[width],
@@ -1541,8 +1553,9 @@ impl<'a> LowLevelCall<'a> {
             NumCountOneBits => match backend
                 .layout_interner
                 .get(backend.storage.symbol_layouts[&self.arguments[0]])
+                .repr
             {
-                Layout::Builtin(Builtin::Int(width)) => {
+                LayoutRepr::Builtin(Builtin::Int(width)) => {
                     self.load_args_and_call_zig(backend, &bitcode::NUM_COUNT_ONE_BITS[width]);
                 }
                 _ => panic_ret_type(),
@@ -1617,20 +1630,20 @@ impl<'a> LowLevelCall<'a> {
             NumIsInfinite => num_is_infinite(backend, self.arguments[0]),
             NumIsFinite => num_is_finite(backend, self.arguments[0]),
 
-            NumAtan => match self.ret_layout_raw {
-                Layout::Builtin(Builtin::Float(width)) => {
+            NumAtan => match self.ret_layout_raw.repr {
+                LayoutRepr::Builtin(Builtin::Float(width)) => {
                     self.load_args_and_call_zig(backend, &bitcode::NUM_ATAN[width]);
                 }
                 _ => panic_ret_type(),
             },
-            NumAcos => match self.ret_layout_raw {
-                Layout::Builtin(Builtin::Float(width)) => {
+            NumAcos => match self.ret_layout_raw.repr {
+                LayoutRepr::Builtin(Builtin::Float(width)) => {
                     self.load_args_and_call_zig(backend, &bitcode::NUM_ACOS[width]);
                 }
                 _ => panic_ret_type(),
             },
-            NumAsin => match self.ret_layout_raw {
-                Layout::Builtin(Builtin::Float(width)) => {
+            NumAsin => match self.ret_layout_raw.repr {
+                LayoutRepr::Builtin(Builtin::Float(width)) => {
                     self.load_args_and_call_zig(backend, &bitcode::NUM_ASIN[width]);
                 }
                 _ => panic_ret_type(),
@@ -1777,15 +1790,15 @@ impl<'a> LowLevelCall<'a> {
             NumIntCast => {
                 let arg_layout = backend.storage.symbol_layouts[&self.arguments[0]];
                 let arg_type = CodeGenNumType::from(arg_layout);
-                let arg_width = match backend.layout_interner.get(arg_layout) {
-                    Layout::Builtin(Builtin::Int(w)) => w,
-                    Layout::Builtin(Builtin::Bool) => IntWidth::U8,
+                let arg_width = match backend.layout_interner.get(arg_layout).repr {
+                    LayoutRepr::Builtin(Builtin::Int(w)) => w,
+                    LayoutRepr::Builtin(Builtin::Bool) => IntWidth::U8,
                     x => internal_error!("Num.intCast is not defined for {:?}", x),
                 };
 
                 let ret_type = CodeGenNumType::from(self.ret_layout);
-                let ret_width = match self.ret_layout_raw {
-                    Layout::Builtin(Builtin::Int(w)) => w,
+                let ret_width = match self.ret_layout_raw.repr {
+                    LayoutRepr::Builtin(Builtin::Int(w)) => w,
                     x => internal_error!("Num.intCast is not defined for {:?}", x),
                 };
 
@@ -1847,10 +1860,10 @@ impl<'a> LowLevelCall<'a> {
             NumToFloatCast => {
                 self.load_args(backend);
                 let arg_layout = backend.storage.symbol_layouts[&self.arguments[0]];
-                let arg_signed = match backend.layout_interner.get(arg_layout) {
-                    Layout::Builtin(Builtin::Int(w)) => w.is_signed(),
-                    Layout::Builtin(Builtin::Float(_)) => true, // unused
-                    Layout::Builtin(Builtin::Decimal) => true,
+                let arg_signed = match backend.layout_interner.get(arg_layout).repr {
+                    LayoutRepr::Builtin(Builtin::Int(w)) => w.is_signed(),
+                    LayoutRepr::Builtin(Builtin::Float(_)) => true, // unused
+                    LayoutRepr::Builtin(Builtin::Decimal) => true,
                     x => internal_error!("Num.intCast is not defined for {:?}", x),
                 };
                 let ret_type = CodeGenNumType::from(self.ret_layout);
@@ -1894,24 +1907,18 @@ impl<'a> LowLevelCall<'a> {
             NumToIntChecked => {
                 let arg_layout = backend.storage.symbol_layouts[&self.arguments[0]];
 
-                let (arg_width, ret_width) =
-                    match (backend.layout_interner.get(arg_layout), self.ret_layout_raw) {
-                        (
-                            Layout::Builtin(Builtin::Int(arg_width)),
-                            Layout::Struct {
-                                field_layouts: &[ret, ..],
-                                ..
-                            },
-                        ) => match backend.layout_interner.get(ret) {
-                            Layout::Builtin(Builtin::Int(ret_width)) => (arg_width, ret_width),
-                            _ => {
-                                internal_error!(
-                                    "NumToIntChecked is not defined for signature {:?} -> {:?}",
-                                    arg_layout,
-                                    self.ret_layout
-                                );
-                            }
+                let (arg_width, ret_width) = match (
+                    backend.layout_interner.get(arg_layout).repr,
+                    self.ret_layout_raw.repr,
+                ) {
+                    (
+                        LayoutRepr::Builtin(Builtin::Int(arg_width)),
+                        LayoutRepr::Struct {
+                            field_layouts: &[ret, ..],
+                            ..
                         },
+                    ) => match backend.layout_interner.get(ret).repr {
+                        LayoutRepr::Builtin(Builtin::Int(ret_width)) => (arg_width, ret_width),
                         _ => {
                             internal_error!(
                                 "NumToIntChecked is not defined for signature {:?} -> {:?}",
@@ -1919,7 +1926,15 @@ impl<'a> LowLevelCall<'a> {
                                 self.ret_layout
                             );
                         }
-                    };
+                    },
+                    _ => {
+                        internal_error!(
+                            "NumToIntChecked is not defined for signature {:?} -> {:?}",
+                            arg_layout,
+                            self.ret_layout
+                        );
+                    }
+                };
 
                 if arg_width.is_signed() {
                     self.load_args_and_call_zig(
@@ -2005,12 +2020,12 @@ impl<'a> LowLevelCall<'a> {
 
         let invert_result = matches!(self.lowlevel, LowLevel::NotEq);
 
-        match arg_layout_raw {
-            Layout::Builtin(
+        match arg_layout_raw.repr {
+            LayoutRepr::Builtin(
                 Builtin::Int(_) | Builtin::Float(_) | Builtin::Bool | Builtin::Decimal,
             ) => self.eq_or_neq_number(backend),
 
-            Layout::Builtin(Builtin::Str) => {
+            LayoutRepr::Builtin(Builtin::Str) => {
                 self.load_args_and_call_zig(backend, bitcode::STR_EQUAL);
                 if invert_result {
                     backend.code_builder.i32_eqz();
@@ -2019,21 +2034,21 @@ impl<'a> LowLevelCall<'a> {
 
             // Empty record is always equal to empty record.
             // There are no runtime arguments to check, so just emit true or false.
-            Layout::Struct { field_layouts, .. } if field_layouts.is_empty() => {
+            LayoutRepr::Struct { field_layouts, .. } if field_layouts.is_empty() => {
                 backend.code_builder.i32_const(!invert_result as i32);
             }
 
             // Void is always equal to void. This is the type for the contents of the empty list in `[] == []`
             // This instruction will never execute, but we need an i32 for module validation
-            Layout::Union(UnionLayout::NonRecursive(tags)) if tags.is_empty() => {
+            LayoutRepr::Union(UnionLayout::NonRecursive(tags)) if tags.is_empty() => {
                 backend.code_builder.i32_const(!invert_result as i32);
             }
 
-            Layout::Builtin(Builtin::List(_))
-            | Layout::Struct { .. }
-            | Layout::Union(_)
-            | Layout::LambdaSet(_)
-            | Layout::Boxed(_) => {
+            LayoutRepr::Builtin(Builtin::List(_))
+            | LayoutRepr::Struct { .. }
+            | LayoutRepr::Union(_)
+            | LayoutRepr::LambdaSet(_)
+            | LayoutRepr::Boxed(_) => {
                 // Don't want Zig calling convention here, we're calling internal Roc functions
                 backend
                     .storage
@@ -2051,7 +2066,7 @@ impl<'a> LowLevelCall<'a> {
                 }
             }
 
-            Layout::RecursivePointer(_) => {
+            LayoutRepr::RecursivePointer(_) => {
                 internal_error!(
                     "Tried to apply `==` to RecursivePointer values {:?}",
                     self.arguments,
@@ -2147,11 +2162,11 @@ impl<'a> LowLevelCall<'a> {
 
     fn num_to_str(&self, backend: &mut WasmBackend<'a, '_>) {
         let arg_layout = backend.storage.symbol_layouts[&self.arguments[0]];
-        match backend.layout_interner.get(arg_layout) {
-            Layout::Builtin(Builtin::Int(width)) => {
+        match backend.layout_interner.get(arg_layout).repr {
+            LayoutRepr::Builtin(Builtin::Int(width)) => {
                 self.load_args_and_call_zig(backend, &bitcode::STR_FROM_INT[width])
             }
-            Layout::Builtin(Builtin::Float(width)) => match width {
+            LayoutRepr::Builtin(Builtin::Float(width)) => match width {
                 FloatWidth::F32 => {
                     self.load_args(backend);
                     backend.code_builder.f64_promote_f32();
@@ -2161,7 +2176,7 @@ impl<'a> LowLevelCall<'a> {
                     self.load_args_and_call_zig(backend, &bitcode::STR_FROM_FLOAT[width]);
                 }
             },
-            Layout::Builtin(Builtin::Decimal) => {
+            LayoutRepr::Builtin(Builtin::Decimal) => {
                 self.load_args_and_call_zig(backend, bitcode::DEC_TO_STR)
             }
             x => internal_error!("NumToStr is not defined for {:?}", x),
@@ -2356,8 +2371,9 @@ pub fn call_higher_order_lowlevel<'a>(
     let (closure_data_layout, closure_data_exists) = match backend
         .layout_interner
         .get(backend.storage.symbol_layouts[captured_environment])
+        .repr
     {
-        Layout::LambdaSet(lambda_set) => {
+        LayoutRepr::LambdaSet(lambda_set) => {
             if lambda_set.is_represented(backend.layout_interner).is_some() {
                 (lambda_set.runtime_representation(), true)
             } else {
@@ -2367,7 +2383,7 @@ pub fn call_higher_order_lowlevel<'a>(
                 (Layout::UNIT, false)
             }
         }
-        Layout::Struct {
+        LayoutRepr::Struct {
             field_layouts: &[], ..
         } => (Layout::UNIT, false),
         x => internal_error!("Closure data has an invalid layout\n{:?}", x),
@@ -2448,10 +2464,12 @@ pub fn call_higher_order_lowlevel<'a>(
             argument_layouts.len()
         };
 
-        let boxed_closure_arg_layouts = argument_layouts
-            .iter()
-            .take(n_non_closure_args)
-            .map(|lay| backend.layout_interner.insert(Layout::Boxed(*lay)));
+        let boxed_closure_arg_layouts =
+            argument_layouts.iter().take(n_non_closure_args).map(|lay| {
+                backend.layout_interner.insert(Layout {
+                    repr: LayoutRepr::Boxed(*lay),
+                })
+            });
 
         wrapper_arg_layouts.push(wrapped_captures_layout);
         wrapper_arg_layouts.extend(boxed_closure_arg_layouts);
@@ -2459,11 +2477,9 @@ pub fn call_higher_order_lowlevel<'a>(
         match helper_proc_source {
             ProcSource::HigherOrderMapper(_) => {
                 // Our convention for mappers is that they write to the heap via the last argument
-                wrapper_arg_layouts.push(
-                    backend
-                        .layout_interner
-                        .insert(Layout::Boxed(*result_layout)),
-                );
+                wrapper_arg_layouts.push(backend.layout_interner.insert(Layout {
+                    repr: LayoutRepr::Boxed(*result_layout),
+                }));
                 ProcLayout {
                     arguments: wrapper_arg_layouts.into_bump_slice(),
                     result: Layout::UNIT,
@@ -2592,8 +2608,8 @@ pub fn call_higher_order_lowlevel<'a>(
 }
 
 fn unwrap_list_elem_layout(list_layout: Layout) -> InLayout {
-    match list_layout {
-        Layout::Builtin(Builtin::List(x)) => x,
+    match list_layout.repr {
+        LayoutRepr::Builtin(Builtin::List(x)) => x,
         e => internal_error!("expected List layout, got {:?}", e),
     }
 }
@@ -2655,9 +2671,11 @@ fn list_map_n<'a>(
         for el in arg_elem_layouts.iter() {
             // The dec function will be passed a pointer to the element within the list, not the element itself!
             // Here we wrap the layout in a Struct to ensure we get the right code gen
-            let el_ptr = backend.layout_interner.insert(Layout::Struct {
-                field_order_hash: FieldOrderHash::from_ordered_fields(&[]),
-                field_layouts: backend.env.arena.alloc([*el]),
+            let el_ptr = backend.layout_interner.insert(Layout {
+                repr: LayoutRepr::Struct {
+                    field_order_hash: FieldOrderHash::from_ordered_fields(&[]),
+                    field_layouts: backend.env.arena.alloc([*el]),
+                },
             });
             let idx = backend.get_refcount_fn_index(el_ptr, HelperOp::Dec);
             let ptr = backend.get_fn_ptr(idx);
@@ -2695,9 +2713,11 @@ fn ensure_symbol_is_in_memory<'a>(
                 offset,
                 symbol,
             );
-            let in_memory_layout = backend.layout_interner.insert(Layout::Struct {
-                field_order_hash: FieldOrderHash::from_ordered_fields(&[]), // don't care
-                field_layouts: arena.alloc([layout]),
+            let in_memory_layout = backend.layout_interner.insert(Layout {
+                repr: LayoutRepr::Struct {
+                    field_order_hash: FieldOrderHash::from_ordered_fields(&[]), // don't care
+                    field_layouts: arena.alloc([layout]),
+                },
             });
             (frame_ptr, offset, in_memory_layout)
         }

--- a/crates/compiler/gen_wasm/src/low_level.rs
+++ b/crates/compiler/gen_wasm/src/low_level.rs
@@ -2389,9 +2389,12 @@ pub fn call_higher_order_lowlevel<'a>(
         // If there is closure data, make sure we put in a struct it before passing it to the
         // external builtin impl. That way it's always an `i32` pointer.
         let wrapped_closure_data_sym = backend.create_symbol("wrapped_captures");
-        let wrapped_captures_layout = backend.layout_interner.insert(Layout::struct_no_name_order(
-            backend.env.arena.alloc([closure_data_layout]),
-        ));
+        let wrapped_captures_layout =
+            backend
+                .layout_interner
+                .insert_no_semantic(LayoutRepr::struct_(
+                    backend.env.arena.alloc([closure_data_layout]),
+                ));
 
         // make sure that the wrapping struct is available in stack memory, so we can hand out a
         // pointer to it.

--- a/crates/compiler/gen_wasm/src/low_level.rs
+++ b/crates/compiler/gen_wasm/src/low_level.rs
@@ -404,12 +404,8 @@ impl<'a> LowLevelCall<'a> {
                                 if l2.repr == backend.layout_interner.get(list_elem).repr =>
                             {
                                 let list_offset = 0;
-                                // TODO(deref-layout)
-                                let elem_offset = Layout {
-                                    repr: LayoutRepr::Builtin(Builtin::List(list_elem)),
-                                    semantic: SemanticRepr::None,
-                                }
-                                .stack_size(backend.layout_interner, TARGET_INFO);
+                                let elem_offset = LayoutRepr::Builtin(Builtin::List(list_elem))
+                                    .stack_size(backend.layout_interner, TARGET_INFO);
                                 (list_offset, elem_offset, f2)
                             }
                             (_, LayoutRepr::Builtin(Builtin::List(list_elem)))

--- a/crates/compiler/gen_wasm/src/low_level.rs
+++ b/crates/compiler/gen_wasm/src/low_level.rs
@@ -6,10 +6,7 @@ use roc_module::low_level::LowLevel;
 use roc_module::symbol::Symbol;
 use roc_mono::code_gen_help::HelperOp;
 use roc_mono::ir::{HigherOrderLowLevel, PassedFunction, ProcLayout};
-use roc_mono::layout::{
-    Builtin, FieldOrderHash, InLayout, Layout, LayoutInterner, LayoutRepr, SemanticRepr,
-    UnionLayout,
-};
+use roc_mono::layout::{Builtin, InLayout, Layout, LayoutInterner, LayoutRepr, UnionLayout};
 use roc_mono::low_level::HigherOrder;
 
 use crate::backend::{ProcLookupData, ProcSource, WasmBackend};
@@ -700,7 +697,6 @@ impl<'a> LowLevelCall<'a> {
                     backend
                         .layout_interner
                         .insert_no_semantic(LayoutRepr::Struct {
-                            field_order_hash: FieldOrderHash::from_ordered_fields(&[]),
                             field_layouts: backend.env.arena.alloc([elem_layout]),
                         });
                 let dec_fn = backend.get_refcount_fn_index(in_memory_layout, HelperOp::Dec);
@@ -749,7 +745,6 @@ impl<'a> LowLevelCall<'a> {
                     backend
                         .layout_interner
                         .insert_no_semantic(LayoutRepr::Struct {
-                            field_order_hash: FieldOrderHash::from_ordered_fields(&[]),
                             field_layouts: backend.env.arena.alloc([elem_layout]),
                         });
                 let dec_fn = backend.get_refcount_fn_index(in_memory_layout, HelperOp::Dec);
@@ -2677,7 +2672,6 @@ fn list_map_n<'a>(
             let el_ptr = backend
                 .layout_interner
                 .insert_no_semantic(LayoutRepr::Struct {
-                    field_order_hash: FieldOrderHash::from_ordered_fields(&[]),
                     field_layouts: backend.env.arena.alloc([*el]),
                 });
             let idx = backend.get_refcount_fn_index(el_ptr, HelperOp::Dec);
@@ -2719,7 +2713,6 @@ fn ensure_symbol_is_in_memory<'a>(
             let in_memory_layout = backend
                 .layout_interner
                 .insert_no_semantic(LayoutRepr::Struct {
-                    field_order_hash: FieldOrderHash::from_ordered_fields(&[]), // don't care
                     field_layouts: arena.alloc([layout]),
                 });
             (frame_ptr, offset, in_memory_layout)

--- a/crates/compiler/gen_wasm/src/wasm32_result.rs
+++ b/crates/compiler/gen_wasm/src/wasm32_result.rs
@@ -7,7 +7,7 @@ The user needs to analyse the Wasm module's memory to decode the result.
 use bumpalo::{collections::Vec, Bump};
 
 use roc_builtins::bitcode::{FloatWidth, IntWidth};
-use roc_mono::layout::{Builtin, InLayout, Layout, LayoutInterner, UnionLayout};
+use roc_mono::layout::{Builtin, InLayout, LayoutInterner, LayoutRepr, UnionLayout};
 use roc_std::{RocBox, RocDec, RocList, RocOrder, RocResult, RocStr, I128, U128};
 use roc_wasm_module::{
     linking::SymInfo, linking::WasmObjectSymbol, Align, Export, ExportType, LocalId, Signature,
@@ -55,30 +55,30 @@ pub fn insert_wrapper_for_layout<'a>(
         }
     };
 
-    match interner.get(layout) {
-        Layout::Builtin(Builtin::Int(IntWidth::U8 | IntWidth::I8)) => {
+    match interner.get(layout).repr {
+        LayoutRepr::Builtin(Builtin::Int(IntWidth::U8 | IntWidth::I8)) => {
             i8::insert_wrapper(arena, module, wrapper_name, main_fn_index);
         }
-        Layout::Builtin(Builtin::Int(IntWidth::U16 | IntWidth::I16)) => {
+        LayoutRepr::Builtin(Builtin::Int(IntWidth::U16 | IntWidth::I16)) => {
             i16::insert_wrapper(arena, module, wrapper_name, main_fn_index);
         }
-        Layout::Builtin(Builtin::Int(IntWidth::U32 | IntWidth::I32)) => {
+        LayoutRepr::Builtin(Builtin::Int(IntWidth::U32 | IntWidth::I32)) => {
             i32::insert_wrapper(arena, module, wrapper_name, main_fn_index);
         }
-        Layout::Builtin(Builtin::Int(IntWidth::U64 | IntWidth::I64)) => {
+        LayoutRepr::Builtin(Builtin::Int(IntWidth::U64 | IntWidth::I64)) => {
             i64::insert_wrapper(arena, module, wrapper_name, main_fn_index);
         }
-        Layout::Builtin(Builtin::Float(FloatWidth::F32)) => {
+        LayoutRepr::Builtin(Builtin::Float(FloatWidth::F32)) => {
             f32::insert_wrapper(arena, module, wrapper_name, main_fn_index);
         }
-        Layout::Builtin(Builtin::Float(FloatWidth::F64)) => {
+        LayoutRepr::Builtin(Builtin::Float(FloatWidth::F64)) => {
             f64::insert_wrapper(arena, module, wrapper_name, main_fn_index);
         }
-        Layout::Builtin(Builtin::Bool) => {
+        LayoutRepr::Builtin(Builtin::Bool) => {
             bool::insert_wrapper(arena, module, wrapper_name, main_fn_index);
         }
-        Layout::Union(UnionLayout::NonRecursive(_)) => stack_data_structure(),
-        Layout::Union(_) | Layout::Boxed(_) => {
+        LayoutRepr::Union(UnionLayout::NonRecursive(_)) => stack_data_structure(),
+        LayoutRepr::Union(_) | LayoutRepr::Boxed(_) => {
             i32::insert_wrapper(arena, module, wrapper_name, main_fn_index);
         }
         _ => stack_data_structure(),

--- a/crates/compiler/mono/src/code_gen_help/equality.rs
+++ b/crates/compiler/mono/src/code_gen_help/equality.rs
@@ -7,7 +7,7 @@ use crate::ir::{
     BranchInfo, Call, CallType, Expr, JoinPointId, Literal, Param, Stmt, UpdateModeId,
 };
 use crate::layout::{
-    Builtin, InLayout, Layout, LayoutInterner, STLayoutInterner, TagIdIntType, UnionLayout,
+    InLayout, Layout, LayoutInterner, LayoutRepr, STLayoutInterner, TagIdIntType, UnionLayout,
 };
 
 use super::{let_lowlevel, CodeGenHelp, Context, LAYOUT_BOOL};
@@ -22,30 +22,26 @@ pub fn eq_generic<'a>(
     layout_interner: &mut STLayoutInterner<'a>,
     layout: InLayout<'a>,
 ) -> Stmt<'a> {
-    let main_body = match layout_interner.get(layout) {
-        Layout::Builtin(Builtin::Int(_) | Builtin::Float(_) | Builtin::Bool | Builtin::Decimal) => {
+    use crate::layout::Builtin::*;
+    use LayoutRepr::*;
+    let main_body = match layout_interner.get(layout).repr {
+        Builtin(Int(_) | Float(_) | Bool | Decimal) => {
             unreachable!(
                 "No generated proc for `==`. Use direct code gen for {:?}",
                 layout
             )
         }
-        Layout::Builtin(Builtin::Str) => {
+        Builtin(Str) => {
             unreachable!("No generated helper proc for `==` on Str. Use Zig function.")
         }
-        Layout::Builtin(Builtin::List(elem_layout)) => {
-            eq_list(root, ident_ids, ctx, layout_interner, elem_layout)
-        }
-        Layout::Struct { field_layouts, .. } => {
+        Builtin(List(elem_layout)) => eq_list(root, ident_ids, ctx, layout_interner, elem_layout),
+        Struct { field_layouts, .. } => {
             eq_struct(root, ident_ids, ctx, layout_interner, field_layouts)
         }
-        Layout::Union(union_layout) => {
-            eq_tag_union(root, ident_ids, ctx, layout_interner, union_layout)
-        }
-        Layout::Boxed(inner_layout) => {
-            eq_boxed(root, ident_ids, ctx, layout_interner, inner_layout)
-        }
-        Layout::LambdaSet(_) => unreachable!("`==` is not defined on functions"),
-        Layout::RecursivePointer(_) => {
+        Union(union_layout) => eq_tag_union(root, ident_ids, ctx, layout_interner, union_layout),
+        Boxed(inner_layout) => eq_boxed(root, ident_ids, ctx, layout_interner, inner_layout),
+        LambdaSet(_) => unreachable!("`==` is not defined on functions"),
+        RecursivePointer(_) => {
             unreachable!(
                 "Can't perform `==` on RecursivePointer. Should have been replaced by a tag union."
             )
@@ -440,7 +436,9 @@ fn eq_tag_union_help<'a>(
     if is_non_recursive {
         compare_ptr_or_value
     } else {
-        let union_layout = layout_interner.insert(Layout::Union(union_layout));
+        let union_layout = layout_interner.insert(Layout {
+            repr: LayoutRepr::Union(union_layout),
+        });
         let loop_params_iter = operands.iter().map(|arg| Param {
             symbol: *arg,
             ownership: Ownership::Borrowed,
@@ -472,9 +470,12 @@ fn eq_tag_fields<'a>(
 ) -> Stmt<'a> {
     // Find a RecursivePointer to use in the tail recursion loop
     // (If there are more than one, the others will use non-tail recursion)
-    let rec_ptr_index = field_layouts
-        .iter()
-        .position(|field| matches!(layout_interner.get(*field), Layout::RecursivePointer(_)));
+    let rec_ptr_index = field_layouts.iter().position(|field| {
+        matches!(
+            layout_interner.get(*field).repr,
+            LayoutRepr::RecursivePointer(_)
+        )
+    });
 
     let (tailrec_index, innermost_stmt) = match rec_ptr_index {
         None => {
@@ -660,7 +661,9 @@ fn eq_list<'a>(
     let arena = root.arena;
 
     // A "Box" layout (heap pointer to a single list element)
-    let box_layout = layout_interner.insert(Layout::Boxed(elem_layout));
+    let box_layout = layout_interner.insert(Layout {
+        repr: LayoutRepr::Boxed(elem_layout),
+    });
 
     // Compare lengths
 

--- a/crates/compiler/mono/src/code_gen_help/equality.rs
+++ b/crates/compiler/mono/src/code_gen_help/equality.rs
@@ -436,9 +436,7 @@ fn eq_tag_union_help<'a>(
     if is_non_recursive {
         compare_ptr_or_value
     } else {
-        let union_layout = layout_interner.insert(Layout {
-            repr: LayoutRepr::Union(union_layout),
-        });
+        let union_layout = layout_interner.insert_no_semantic(LayoutRepr::Union(union_layout));
         let loop_params_iter = operands.iter().map(|arg| Param {
             symbol: *arg,
             ownership: Ownership::Borrowed,
@@ -661,9 +659,7 @@ fn eq_list<'a>(
     let arena = root.arena;
 
     // A "Box" layout (heap pointer to a single list element)
-    let box_layout = layout_interner.insert(Layout {
-        repr: LayoutRepr::Boxed(elem_layout),
-    });
+    let box_layout = layout_interner.insert_no_semantic(LayoutRepr::Boxed(elem_layout));
 
     // Compare lengths
 

--- a/crates/compiler/mono/src/code_gen_help/mod.rs
+++ b/crates/compiler/mono/src/code_gen_help/mod.rs
@@ -533,7 +533,8 @@ impl<'a> CodeGenHelp<'a> {
         layout_interner: &mut STLayoutInterner<'a>,
         layout: InLayout<'a>,
     ) -> InLayout<'a> {
-        let repr = match layout_interner.get(layout).repr {
+        let lay = layout_interner.get(layout);
+        let repr = match lay.repr {
             LayoutRepr::Builtin(Builtin::List(v)) => {
                 let v = self.replace_rec_ptr(ctx, layout_interner, v);
                 LayoutRepr::Builtin(Builtin::List(v))
@@ -581,7 +582,8 @@ impl<'a> CodeGenHelp<'a> {
             // This line is the whole point of the function
             LayoutRepr::RecursivePointer(_) => LayoutRepr::Union(ctx.recursive_union.unwrap()),
         };
-        layout_interner.insert_no_semantic(repr)
+
+        layout_interner.insert(Layout::new(repr, lay.semantic()))
     }
 
     fn union_tail_recursion_fields(

--- a/crates/compiler/mono/src/code_gen_help/mod.rs
+++ b/crates/compiler/mono/src/code_gen_help/mod.rs
@@ -10,7 +10,8 @@ use crate::ir::{
     Proc, ProcLayout, SelfRecursive, Stmt, UpdateModeId,
 };
 use crate::layout::{
-    Builtin, InLayout, LambdaName, Layout, LayoutInterner, Niche, STLayoutInterner, UnionLayout,
+    Builtin, InLayout, LambdaName, Layout, LayoutInterner, LayoutRepr, Niche, STLayoutInterner,
+    UnionLayout,
 };
 
 mod equality;
@@ -285,11 +286,13 @@ impl<'a> CodeGenHelp<'a> {
         self.debug_recursion_depth += 1;
 
         let layout = if matches!(
-            layout_interner.get(called_layout),
-            Layout::RecursivePointer(_)
+            layout_interner.get(called_layout).repr,
+            LayoutRepr::RecursivePointer(_)
         ) {
             let union_layout = ctx.recursive_union.unwrap();
-            layout_interner.insert(Layout::Union(union_layout))
+            layout_interner.insert(Layout {
+                repr: LayoutRepr::Union(union_layout),
+            })
         } else {
             called_layout
         };
@@ -300,7 +303,9 @@ impl<'a> CodeGenHelp<'a> {
 
             let (ret_layout, arg_layouts): (InLayout<'a>, &'a [InLayout<'a>]) = {
                 let arg = self.replace_rec_ptr(ctx, layout_interner, layout);
-                let box_arg = layout_interner.insert(Layout::Boxed(arg));
+                let box_arg = layout_interner.insert(Layout {
+                    repr: LayoutRepr::Boxed(arg),
+                });
 
                 match ctx.op {
                     Dec | DecRef(_) => (LAYOUT_UNIT, self.arena.alloc([arg])),
@@ -429,12 +434,16 @@ impl<'a> CodeGenHelp<'a> {
                 }
                 Dec | DecRef(_) | Reset | ResetRef => self.arena.alloc([roc_value]),
                 IndirectInc => {
-                    let box_layout = layout_interner.insert(Layout::Boxed(layout));
+                    let box_layout = layout_interner.insert(Layout {
+                        repr: LayoutRepr::Boxed(layout),
+                    });
                     let inc_amount = (self.layout_isize, ARG_2);
                     self.arena.alloc([(box_layout, ARG_1), inc_amount])
                 }
                 IndirectDec => {
-                    let box_layout = layout_interner.insert(Layout::Boxed(layout));
+                    let box_layout = layout_interner.insert(Layout {
+                        repr: LayoutRepr::Boxed(layout),
+                    });
                     self.arena.alloc([(box_layout, ARG_1)])
                 }
                 Eq => self.arena.alloc([roc_value, (layout, ARG_2)]),
@@ -482,7 +491,9 @@ impl<'a> CodeGenHelp<'a> {
                 niche: Niche::NONE,
             },
             HelperOp::IndirectInc => {
-                let box_layout = layout_interner.insert(Layout::Boxed(layout));
+                let box_layout = layout_interner.insert(Layout {
+                    repr: LayoutRepr::Boxed(layout),
+                });
 
                 ProcLayout {
                     arguments: self.arena.alloc([box_layout, self.layout_isize]),
@@ -491,7 +502,9 @@ impl<'a> CodeGenHelp<'a> {
                 }
             }
             HelperOp::IndirectDec => {
-                let box_layout = layout_interner.insert(Layout::Boxed(layout));
+                let box_layout = layout_interner.insert(Layout {
+                    repr: LayoutRepr::Boxed(layout),
+                });
 
                 ProcLayout {
                     arguments: self.arena.alloc([box_layout]),
@@ -532,15 +545,15 @@ impl<'a> CodeGenHelp<'a> {
         layout_interner: &mut STLayoutInterner<'a>,
         layout: InLayout<'a>,
     ) -> InLayout<'a> {
-        let layout = match layout_interner.get(layout) {
-            Layout::Builtin(Builtin::List(v)) => {
+        let repr = match layout_interner.get(layout).repr {
+            LayoutRepr::Builtin(Builtin::List(v)) => {
                 let v = self.replace_rec_ptr(ctx, layout_interner, v);
-                Layout::Builtin(Builtin::List(v))
+                LayoutRepr::Builtin(Builtin::List(v))
             }
 
-            Layout::Builtin(_) => return layout,
+            LayoutRepr::Builtin(_) => return layout,
 
-            Layout::Struct {
+            LayoutRepr::Struct {
                 field_layouts,
                 field_order_hash,
             } => {
@@ -548,13 +561,13 @@ impl<'a> CodeGenHelp<'a> {
                 for f in field_layouts.iter() {
                     new_field_layouts.push(self.replace_rec_ptr(ctx, layout_interner, *f));
                 }
-                Layout::Struct {
+                LayoutRepr::Struct {
                     field_layouts: new_field_layouts.into_bump_slice(),
                     field_order_hash,
                 }
             }
 
-            Layout::Union(UnionLayout::NonRecursive(tags)) => {
+            LayoutRepr::Union(UnionLayout::NonRecursive(tags)) => {
                 let mut new_tags = Vec::with_capacity_in(tags.len(), self.arena);
                 for fields in tags {
                     let mut new_fields = Vec::with_capacity_in(fields.len(), self.arena);
@@ -563,28 +576,28 @@ impl<'a> CodeGenHelp<'a> {
                     }
                     new_tags.push(new_fields.into_bump_slice());
                 }
-                Layout::Union(UnionLayout::NonRecursive(new_tags.into_bump_slice()))
+                LayoutRepr::Union(UnionLayout::NonRecursive(new_tags.into_bump_slice()))
             }
 
-            Layout::Union(_) => {
+            LayoutRepr::Union(_) => {
                 // we always fully unroll recursive types. That means tha when we find a
                 // recursive tag union we can replace it with the layout
                 return layout;
             }
 
-            Layout::Boxed(inner) => {
+            LayoutRepr::Boxed(inner) => {
                 let inner = self.replace_rec_ptr(ctx, layout_interner, inner);
-                Layout::Boxed(inner)
+                LayoutRepr::Boxed(inner)
             }
 
-            Layout::LambdaSet(lambda_set) => {
+            LayoutRepr::LambdaSet(lambda_set) => {
                 return self.replace_rec_ptr(ctx, layout_interner, lambda_set.representation)
             }
 
             // This line is the whole point of the function
-            Layout::RecursivePointer(_) => Layout::Union(ctx.recursive_union.unwrap()),
+            LayoutRepr::RecursivePointer(_) => LayoutRepr::Union(ctx.recursive_union.unwrap()),
         };
-        layout_interner.insert(layout)
+        layout_interner.insert(Layout { repr })
     }
 
     fn union_tail_recursion_fields(
@@ -668,16 +681,22 @@ impl<'a> CallerProc<'a> {
         };
 
         let box_capture_layout = if let Some(capture_layout) = capture_layout {
-            layout_interner.insert(Layout::Boxed(capture_layout))
+            layout_interner.insert(Layout {
+                repr: LayoutRepr::Boxed(capture_layout),
+            })
         } else {
-            layout_interner.insert(Layout::Boxed(Layout::UNIT))
+            layout_interner.insert(Layout {
+                repr: LayoutRepr::Boxed(Layout::UNIT),
+            })
         };
 
-        let box_argument_layout =
-            layout_interner.insert(Layout::Boxed(passed_function.argument_layouts[0]));
+        let box_argument_layout = layout_interner.insert(Layout {
+            repr: LayoutRepr::Boxed(passed_function.argument_layouts[0]),
+        });
 
-        let box_return_layout =
-            layout_interner.insert(Layout::Boxed(passed_function.return_layout));
+        let box_return_layout = layout_interner.insert(Layout {
+            repr: LayoutRepr::Boxed(passed_function.return_layout),
+        });
 
         let proc_layout = ProcLayout {
             arguments: arena.alloc([box_capture_layout, box_argument_layout, box_return_layout]),
@@ -826,22 +845,22 @@ fn layout_needs_helper_proc<'a>(
     layout: InLayout<'a>,
     op: HelperOp,
 ) -> bool {
-    match layout_interner.get(layout) {
-        Layout::Builtin(Builtin::Int(_) | Builtin::Float(_) | Builtin::Bool | Builtin::Decimal) => {
-            false
-        }
-        Layout::Builtin(Builtin::Str) => {
+    match layout_interner.get(layout).repr {
+        LayoutRepr::Builtin(
+            Builtin::Int(_) | Builtin::Float(_) | Builtin::Bool | Builtin::Decimal,
+        ) => false,
+        LayoutRepr::Builtin(Builtin::Str) => {
             // Str type can use either Zig functions or generated IR, since it's not generic.
             // Eq uses a Zig function, refcount uses generated IR.
             // Both are fine, they were just developed at different times.
             matches!(op, HelperOp::Inc | HelperOp::Dec | HelperOp::DecRef(_))
         }
-        Layout::Builtin(Builtin::List(_)) => true,
-        Layout::Struct { .. } => true, // note: we do generate a helper for Unit, with just a Stmt::Ret
-        Layout::Union(UnionLayout::NonRecursive(tags)) => !tags.is_empty(),
-        Layout::Union(_) => true,
-        Layout::LambdaSet(_) => true,
-        Layout::RecursivePointer(_) => false,
-        Layout::Boxed(_) => true,
+        LayoutRepr::Builtin(Builtin::List(_)) => true,
+        LayoutRepr::Struct { .. } => true, // note: we do generate a helper for Unit, with just a Stmt::Ret
+        LayoutRepr::Union(UnionLayout::NonRecursive(tags)) => !tags.is_empty(),
+        LayoutRepr::Union(_) => true,
+        LayoutRepr::LambdaSet(_) => true,
+        LayoutRepr::RecursivePointer(_) => false,
+        LayoutRepr::Boxed(_) => true,
     }
 }

--- a/crates/compiler/mono/src/code_gen_help/mod.rs
+++ b/crates/compiler/mono/src/code_gen_help/mod.rs
@@ -541,17 +541,13 @@ impl<'a> CodeGenHelp<'a> {
 
             LayoutRepr::Builtin(_) => return layout,
 
-            LayoutRepr::Struct {
-                field_layouts,
-                field_order_hash,
-            } => {
+            LayoutRepr::Struct { field_layouts } => {
                 let mut new_field_layouts = Vec::with_capacity_in(field_layouts.len(), self.arena);
                 for f in field_layouts.iter() {
                     new_field_layouts.push(self.replace_rec_ptr(ctx, layout_interner, *f));
                 }
                 LayoutRepr::Struct {
                     field_layouts: new_field_layouts.into_bump_slice(),
-                    field_order_hash,
                 }
             }
 

--- a/crates/compiler/mono/src/code_gen_help/refcount.rs
+++ b/crates/compiler/mono/src/code_gen_help/refcount.rs
@@ -12,7 +12,8 @@ use crate::ir::{
     BranchInfo, Call, CallType, Expr, JoinPointId, Literal, ModifyRc, Param, Stmt, UpdateModeId,
 };
 use crate::layout::{
-    Builtin, InLayout, Layout, LayoutInterner, STLayoutInterner, TagIdIntType, UnionLayout,
+    Builtin, InLayout, Layout, LayoutInterner, LayoutRepr, STLayoutInterner, TagIdIntType,
+    UnionLayout,
 };
 
 use super::{CodeGenHelp, Context, HelperOp};
@@ -74,9 +75,9 @@ pub fn refcount_stmt<'a>(
         }
 
         ModifyRc::DecRef(structure) => {
-            match layout_interner.get(layout) {
+            match layout_interner.get(layout).repr {
                 // Str has no children, so Dec is the same as DecRef.
-                Layout::Builtin(Builtin::Str) => {
+                LayoutRepr::Builtin(Builtin::Str) => {
                     ctx.op = HelperOp::Dec;
                     refcount_stmt(
                         root,
@@ -90,8 +91,8 @@ pub fn refcount_stmt<'a>(
                 }
 
                 // Struct and non-recursive Unions are stack-only, so DecRef is a no-op
-                Layout::Struct { .. } => following,
-                Layout::Union(UnionLayout::NonRecursive(_)) => following,
+                LayoutRepr::Struct { .. } => following,
+                LayoutRepr::Union(UnionLayout::NonRecursive(_)) => following,
 
                 // Inline the refcounting code instead of making a function. Don't iterate fields,
                 // and replace any return statements with jumps to the `following` statement.
@@ -181,14 +182,16 @@ pub fn refcount_generic<'a>(
     layout: InLayout<'a>,
     structure: Symbol,
 ) -> Stmt<'a> {
-    match layout_interner.get(layout) {
-        Layout::Builtin(Builtin::Int(_) | Builtin::Float(_) | Builtin::Bool | Builtin::Decimal) => {
+    match layout_interner.get(layout).repr {
+        LayoutRepr::Builtin(
+            Builtin::Int(_) | Builtin::Float(_) | Builtin::Bool | Builtin::Decimal,
+        ) => {
             // Generate a dummy function that immediately returns Unit
             // Some higher-order Zig builtins *always* call an RC function on List elements.
             rc_return_stmt(root, ident_ids, ctx)
         }
-        Layout::Builtin(Builtin::Str) => refcount_str(root, ident_ids, ctx),
-        Layout::Builtin(Builtin::List(elem_layout)) => refcount_list(
+        LayoutRepr::Builtin(Builtin::Str) => refcount_str(root, ident_ids, ctx),
+        LayoutRepr::Builtin(Builtin::List(elem_layout)) => refcount_list(
             root,
             ident_ids,
             ctx,
@@ -196,7 +199,7 @@ pub fn refcount_generic<'a>(
             elem_layout,
             structure,
         ),
-        Layout::Struct { field_layouts, .. } => refcount_struct(
+        LayoutRepr::Struct { field_layouts, .. } => refcount_struct(
             root,
             ident_ids,
             ctx,
@@ -204,7 +207,7 @@ pub fn refcount_generic<'a>(
             field_layouts,
             structure,
         ),
-        Layout::Union(union_layout) => refcount_union(
+        LayoutRepr::Union(union_layout) => refcount_union(
             root,
             ident_ids,
             ctx,
@@ -213,7 +216,7 @@ pub fn refcount_generic<'a>(
             union_layout,
             structure,
         ),
-        Layout::LambdaSet(lambda_set) => {
+        LayoutRepr::LambdaSet(lambda_set) => {
             let runtime_layout = lambda_set.representation;
             refcount_generic(
                 root,
@@ -224,10 +227,10 @@ pub fn refcount_generic<'a>(
                 structure,
             )
         }
-        Layout::RecursivePointer(_) => unreachable!(
+        LayoutRepr::RecursivePointer(_) => unreachable!(
             "We should never call a refcounting helper on a RecursivePointer layout directly"
         ),
-        Layout::Boxed(inner_layout) => refcount_boxed(
+        LayoutRepr::Boxed(inner_layout) => refcount_boxed(
             root,
             ident_ids,
             ctx,
@@ -298,15 +301,17 @@ pub fn refcount_reset_proc_body<'a>(
     let is_unique = root.create_symbol(ident_ids, "is_unique");
     let addr = root.create_symbol(ident_ids, "addr");
 
-    let union_layout = match layout_interner.get(layout) {
-        Layout::Union(u) => u,
+    let union_layout = match layout_interner.get(layout).repr {
+        LayoutRepr::Union(u) => u,
         _ => unimplemented!("Reset is only implemented for UnionLayout"),
     };
 
     // Whenever we recurse into a child layout we will want to Decrement
     ctx.op = HelperOp::Dec;
     ctx.recursive_union = Some(union_layout);
-    let recursion_ptr = layout_interner.insert(Layout::RecursivePointer(layout));
+    let recursion_ptr = layout_interner.insert(Layout {
+        repr: LayoutRepr::RecursivePointer(layout),
+    });
 
     // Reset structure is unique. Decrement its children and return a pointer to the allocation.
     let then_stmt = {
@@ -480,15 +485,17 @@ pub fn refcount_resetref_proc_body<'a>(
     let is_unique = root.create_symbol(ident_ids, "is_unique");
     let addr = root.create_symbol(ident_ids, "addr");
 
-    let union_layout = match layout_interner.get(layout) {
-        Layout::Union(u) => u,
+    let union_layout = match layout_interner.get(layout).repr {
+        LayoutRepr::Union(u) => u,
         _ => unimplemented!("Reset is only implemented for UnionLayout"),
     };
 
     // Whenever we recurse into a child layout we will want to Decrement
     ctx.op = HelperOp::Dec;
     ctx.recursive_union = Some(union_layout);
-    let recursion_ptr = layout_interner.insert(Layout::RecursivePointer(layout));
+    let recursion_ptr = layout_interner.insert(Layout {
+        repr: LayoutRepr::RecursivePointer(layout),
+    });
 
     // Reset structure is unique. Return a pointer to the allocation.
     let then_stmt = Stmt::Ret(addr);
@@ -859,7 +866,9 @@ fn refcount_list<'a>(
     let arena = root.arena;
 
     // A "Box" layout (heap pointer to a single list element)
-    let box_layout = layout_interner.insert(Layout::Boxed(elem_layout));
+    let box_layout = layout_interner.insert(Layout {
+        repr: LayoutRepr::Boxed(elem_layout),
+    });
 
     //
     // Check if the list is empty
@@ -1480,8 +1489,10 @@ fn refcount_union_rec<'a>(
     };
 
     let rc_structure_stmt = {
-        let alignment = Layout::Union(union_layout)
-            .allocation_alignment_bytes(layout_interner, root.target_info);
+        let alignment = Layout {
+            repr: LayoutRepr::Union(union_layout),
+        }
+        .allocation_alignment_bytes(layout_interner, root.target_info);
         let ret_stmt = rc_return_stmt(root, ident_ids, ctx);
 
         modify_refcount(
@@ -1537,7 +1548,9 @@ fn refcount_union_tailrec<'a>(
     let tailrec_loop = JoinPointId(root.create_symbol(ident_ids, "tailrec_loop"));
     let current = root.create_symbol(ident_ids, "current");
     let next_ptr = root.create_symbol(ident_ids, "next_ptr");
-    let layout = layout_interner.insert(Layout::Union(union_layout));
+    let layout = layout_interner.insert(Layout {
+        repr: LayoutRepr::Union(union_layout),
+    });
 
     let tag_id_layout = union_layout.tag_id_layout();
 
@@ -1682,7 +1695,9 @@ fn refcount_union_tailrec<'a>(
         let jump_with_null_ptr = Stmt::Let(
             null_pointer,
             Expr::NullPointer,
-            layout_interner.insert(Layout::Union(union_layout)),
+            layout_interner.insert(Layout {
+                repr: LayoutRepr::Union(union_layout),
+            }),
             root.arena.alloc(Stmt::Jump(
                 jp_modify_union,
                 root.arena.alloc([null_pointer]),
@@ -1726,7 +1741,9 @@ fn refcount_union_tailrec<'a>(
     ));
 
     let loop_init = Stmt::Jump(tailrec_loop, root.arena.alloc([initial_structure]));
-    let union_layout = layout_interner.insert(Layout::Union(union_layout));
+    let union_layout = layout_interner.insert(Layout {
+        repr: LayoutRepr::Union(union_layout),
+    });
     let loop_param = Param {
         symbol: current,
         ownership: Ownership::Borrowed,

--- a/crates/compiler/mono/src/code_gen_help/refcount.rs
+++ b/crates/compiler/mono/src/code_gen_help/refcount.rs
@@ -12,8 +12,8 @@ use crate::ir::{
     BranchInfo, Call, CallType, Expr, JoinPointId, Literal, ModifyRc, Param, Stmt, UpdateModeId,
 };
 use crate::layout::{
-    Builtin, InLayout, Layout, LayoutInterner, LayoutRepr, STLayoutInterner, SemanticRepr,
-    TagIdIntType, UnionLayout,
+    Builtin, InLayout, Layout, LayoutInterner, LayoutRepr, STLayoutInterner, TagIdIntType,
+    UnionLayout,
 };
 
 use super::{CodeGenHelp, Context, HelperOp};
@@ -1483,12 +1483,8 @@ fn refcount_union_rec<'a>(
     };
 
     let rc_structure_stmt = {
-        // TODO(deref-layout)
-        let alignment = Layout {
-            repr: LayoutRepr::Union(union_layout),
-            semantic: SemanticRepr::None,
-        }
-        .allocation_alignment_bytes(layout_interner, root.target_info);
+        let alignment = LayoutRepr::Union(union_layout)
+            .allocation_alignment_bytes(layout_interner, root.target_info);
         let ret_stmt = rc_return_stmt(root, ident_ids, ctx);
 
         modify_refcount(

--- a/crates/compiler/mono/src/debug/checker.rs
+++ b/crates/compiler/mono/src/debug/checker.rs
@@ -10,7 +10,8 @@ use crate::{
         ModifyRc, Param, Proc, ProcLayout, Stmt,
     },
     layout::{
-        Builtin, InLayout, Layout, LayoutInterner, STLayoutInterner, TagIdIntType, UnionLayout,
+        Builtin, InLayout, Layout, LayoutInterner, LayoutRepr, STLayoutInterner, TagIdIntType,
+        UnionLayout,
     },
 };
 
@@ -198,8 +199,8 @@ impl<'a, 'r> Ctx<'a, 'r> {
         // lazily.
         loop {
             layout = self.interner.chase_recursive_in(layout);
-            match self.interner.get(layout) {
-                Layout::LambdaSet(ls) => layout = ls.representation,
+            match self.interner.get(layout).repr {
+                LayoutRepr::LambdaSet(ls) => layout = ls.representation,
                 _ => return layout,
             }
         }
@@ -291,9 +292,9 @@ impl<'a, 'r> Ctx<'a, 'r> {
             } => {
                 self.check_sym_layout(*cond_symbol, *cond_layout, UseKind::SwitchCond);
                 let layout = self.resolve(*cond_layout);
-                match self.interner.get(layout) {
-                    Layout::Builtin(Builtin::Int(_)) => {}
-                    Layout::Builtin(Builtin::Bool) => {}
+                match self.interner.get(layout).repr {
+                    LayoutRepr::Builtin(Builtin::Int(_)) => {}
+                    LayoutRepr::Builtin(Builtin::Bool) => {}
                     _ => self.problem(ProblemKind::BadSwitchConditionLayout {
                         found_layout: *cond_layout,
                     }),
@@ -397,7 +398,9 @@ impl<'a, 'r> Ctx<'a, 'r> {
                 tag_id,
                 arguments,
             } => {
-                let interned_layout = self.interner.insert(Layout::Union(tag_layout));
+                let interned_layout = self.interner.insert(Layout {
+                    repr: LayoutRepr::Union(tag_layout),
+                });
                 self.check_tag_expr(interned_layout, tag_layout, tag_id, arguments);
                 Some(interned_layout)
             }
@@ -435,10 +438,9 @@ impl<'a, 'r> Ctx<'a, 'r> {
                         }
                     }
                 }
-                Some(
-                    self.interner
-                        .insert(Layout::Builtin(Builtin::List(*elem_layout))),
-                )
+                Some(self.interner.insert(Layout {
+                    repr: LayoutRepr::Builtin(Builtin::List(*elem_layout)),
+                }))
             }
             Expr::EmptyArray => {
                 // TODO don't know what the element layout is
@@ -446,12 +448,14 @@ impl<'a, 'r> Ctx<'a, 'r> {
             }
             &Expr::ExprBox { symbol } => self.with_sym_layout(symbol, |ctx, _def_line, layout| {
                 let inner = layout;
-                Some(ctx.interner.insert(Layout::Boxed(inner)))
+                Some(ctx.interner.insert(Layout {
+                    repr: LayoutRepr::Boxed(inner),
+                }))
             }),
             &Expr::ExprUnbox { symbol } => self.with_sym_layout(symbol, |ctx, def_line, layout| {
                 let layout = ctx.resolve(layout);
-                match ctx.interner.get(layout) {
-                    Layout::Boxed(inner) => Some(inner),
+                match ctx.interner.get(layout).repr {
+                    LayoutRepr::Boxed(inner) => Some(inner),
                     _ => {
                         ctx.problem(ProblemKind::UnboxNotABox { symbol, def_line });
                         None
@@ -466,7 +470,9 @@ impl<'a, 'r> Ctx<'a, 'r> {
                 tag_id: _,
                 arguments: _,
             } => {
-                let union = self.interner.insert(Layout::Union(tag_layout));
+                let union = self.interner.insert(Layout {
+                    repr: LayoutRepr::Union(tag_layout),
+                });
                 self.check_sym_layout(symbol, union, UseKind::TagReuse);
                 // TODO also check update arguments
                 Some(union)
@@ -489,8 +495,8 @@ impl<'a, 'r> Ctx<'a, 'r> {
     fn check_struct_at_index(&mut self, structure: Symbol, index: u64) -> Option<InLayout<'a>> {
         self.with_sym_layout(structure, |ctx, def_line, layout| {
             let layout = ctx.resolve(layout);
-            match ctx.interner.get(layout) {
-                Layout::Struct { field_layouts, .. } => {
+            match ctx.interner.get(layout).repr {
+                LayoutRepr::Struct { field_layouts, .. } => {
                     if index as usize >= field_layouts.len() {
                         ctx.problem(ProblemKind::StructIndexOOB {
                             structure,
@@ -522,7 +528,9 @@ impl<'a, 'r> Ctx<'a, 'r> {
         tag_id: u16,
         index: u64,
     ) -> Option<InLayout<'a>> {
-        let union = self.interner.insert(Layout::Union(union_layout));
+        let union = self.interner.insert(Layout {
+            repr: LayoutRepr::Union(union_layout),
+        });
         self.with_sym_layout(structure, |ctx, def_line, _layout| {
             ctx.check_sym_layout(structure, union, UseKind::TagExpr);
 

--- a/crates/compiler/mono/src/debug/checker.rs
+++ b/crates/compiler/mono/src/debug/checker.rs
@@ -398,9 +398,9 @@ impl<'a, 'r> Ctx<'a, 'r> {
                 tag_id,
                 arguments,
             } => {
-                let interned_layout = self.interner.insert(Layout {
-                    repr: LayoutRepr::Union(tag_layout),
-                });
+                let interned_layout = self
+                    .interner
+                    .insert_no_semantic(LayoutRepr::Union(tag_layout));
                 self.check_tag_expr(interned_layout, tag_layout, tag_id, arguments);
                 Some(interned_layout)
             }
@@ -438,9 +438,10 @@ impl<'a, 'r> Ctx<'a, 'r> {
                         }
                     }
                 }
-                Some(self.interner.insert(Layout {
-                    repr: LayoutRepr::Builtin(Builtin::List(*elem_layout)),
-                }))
+                Some(
+                    self.interner
+                        .insert_no_semantic(LayoutRepr::Builtin(Builtin::List(*elem_layout))),
+                )
             }
             Expr::EmptyArray => {
                 // TODO don't know what the element layout is
@@ -448,9 +449,7 @@ impl<'a, 'r> Ctx<'a, 'r> {
             }
             &Expr::ExprBox { symbol } => self.with_sym_layout(symbol, |ctx, _def_line, layout| {
                 let inner = layout;
-                Some(ctx.interner.insert(Layout {
-                    repr: LayoutRepr::Boxed(inner),
-                }))
+                Some(ctx.interner.insert_no_semantic(LayoutRepr::Boxed(inner)))
             }),
             &Expr::ExprUnbox { symbol } => self.with_sym_layout(symbol, |ctx, def_line, layout| {
                 let layout = ctx.resolve(layout);
@@ -470,9 +469,9 @@ impl<'a, 'r> Ctx<'a, 'r> {
                 tag_id: _,
                 arguments: _,
             } => {
-                let union = self.interner.insert(Layout {
-                    repr: LayoutRepr::Union(tag_layout),
-                });
+                let union = self
+                    .interner
+                    .insert_no_semantic(LayoutRepr::Union(tag_layout));
                 self.check_sym_layout(symbol, union, UseKind::TagReuse);
                 // TODO also check update arguments
                 Some(union)
@@ -528,9 +527,9 @@ impl<'a, 'r> Ctx<'a, 'r> {
         tag_id: u16,
         index: u64,
     ) -> Option<InLayout<'a>> {
-        let union = self.interner.insert(Layout {
-            repr: LayoutRepr::Union(union_layout),
-        });
+        let union = self
+            .interner
+            .insert_no_semantic(LayoutRepr::Union(union_layout));
         self.with_sym_layout(structure, |ctx, def_line, _layout| {
             ctx.check_sym_layout(structure, union, UseKind::TagExpr);
 

--- a/crates/compiler/mono/src/drop_specialization.rs
+++ b/crates/compiler/mono/src/drop_specialization.rs
@@ -21,7 +21,9 @@ use crate::ir::{
     BranchInfo, Call, CallType, Expr, JoinPointId, Literal, ModifyRc, Proc, ProcLayout, Stmt,
     UpdateModeId,
 };
-use crate::layout::{Builtin, InLayout, Layout, LayoutInterner, STLayoutInterner, UnionLayout};
+use crate::layout::{
+    Builtin, InLayout, Layout, LayoutInterner, LayoutRepr, STLayoutInterner, UnionLayout,
+};
 
 use bumpalo::Bump;
 
@@ -338,9 +340,9 @@ fn specialize_drops_stmt<'a, 'i>(
                     let in_layout = environment.get_symbol_layout(symbol);
                     let runtime_layout = layout_interner.runtime_representation(*in_layout);
 
-                    let new_dec = match runtime_layout {
+                    let new_dec = match runtime_layout.repr {
                         // Layout has children, try to inline them.
-                        Layout::Struct { field_layouts, .. } => specialize_struct(
+                        LayoutRepr::Struct { field_layouts, .. } => specialize_struct(
                             arena,
                             layout_interner,
                             ident_ids,
@@ -350,7 +352,7 @@ fn specialize_drops_stmt<'a, 'i>(
                             &mut incremented_children,
                             continuation,
                         ),
-                        Layout::Union(union_layout) => specialize_union(
+                        LayoutRepr::Union(union_layout) => specialize_union(
                             arena,
                             layout_interner,
                             ident_ids,
@@ -360,7 +362,7 @@ fn specialize_drops_stmt<'a, 'i>(
                             &mut incremented_children,
                             continuation,
                         ),
-                        Layout::Boxed(_layout) => specialize_boxed(
+                        LayoutRepr::Boxed(_layout) => specialize_boxed(
                             arena,
                             layout_interner,
                             ident_ids,
@@ -369,7 +371,7 @@ fn specialize_drops_stmt<'a, 'i>(
                             symbol,
                             continuation,
                         ),
-                        Layout::Builtin(Builtin::List(layout)) => specialize_list(
+                        LayoutRepr::Builtin(Builtin::List(layout)) => specialize_list(
                             arena,
                             layout_interner,
                             ident_ids,

--- a/crates/compiler/mono/src/ir.rs
+++ b/crates/compiler/mono/src/ir.rs
@@ -5,7 +5,7 @@ use crate::ir::literal::{make_num_literal, IntOrFloatValue};
 use crate::layout::{
     self, Builtin, ClosureCallOptions, ClosureRepresentation, EnumDispatch, InLayout, LambdaName,
     LambdaSet, Layout, LayoutCache, LayoutInterner, LayoutProblem, LayoutRepr, Niche,
-    RawFunctionLayout, SemanticRepr, TLLayoutInterner, TagIdIntType, UnionLayout, WrappedVariant,
+    RawFunctionLayout, TLLayoutInterner, TagIdIntType, UnionLayout, WrappedVariant,
 };
 use bumpalo::collections::{CollectIn, Vec};
 use bumpalo::Bump;

--- a/crates/compiler/mono/src/ir.rs
+++ b/crates/compiler/mono/src/ir.rs
@@ -5941,8 +5941,10 @@ where
                 Vec::from_iter_in(combined.iter().map(|(_, b)| **b), env.arena).into_bump_slice();
 
             debug_assert_eq!(
-                Layout::struct_no_name_order(field_layouts),
-                layout_cache.get_in(lambda_set.runtime_representation())
+                LayoutRepr::struct_(field_layouts),
+                layout_cache
+                    .get_in(lambda_set.runtime_representation())
+                    .repr
             );
 
             let expr = Expr::Struct(symbols);

--- a/crates/compiler/mono/src/ir.rs
+++ b/crates/compiler/mono/src/ir.rs
@@ -4,8 +4,8 @@ use crate::borrow::Ownership;
 use crate::ir::literal::{make_num_literal, IntOrFloatValue};
 use crate::layout::{
     self, Builtin, ClosureCallOptions, ClosureRepresentation, EnumDispatch, InLayout, LambdaName,
-    LambdaSet, Layout, LayoutCache, LayoutInterner, LayoutProblem, Niche, RawFunctionLayout,
-    TLLayoutInterner, TagIdIntType, UnionLayout, WrappedVariant,
+    LambdaSet, Layout, LayoutCache, LayoutInterner, LayoutProblem, LayoutRepr, Niche,
+    RawFunctionLayout, TLLayoutInterner, TagIdIntType, UnionLayout, WrappedVariant,
 };
 use bumpalo::collections::{CollectIn, Vec};
 use bumpalo::Bump;
@@ -1063,8 +1063,12 @@ impl<'a> Procs<'a> {
 
         // anonymous functions cannot reference themselves, therefore cannot be tail-recursive
         // EXCEPT when the closure conversion makes it tail-recursive.
-        let is_self_recursive = match top_level.arguments.last().map(|l| layout_cache.get_in(*l)) {
-            Some(Layout::LambdaSet(lambda_set)) => lambda_set.contains(name.name()),
+        let is_self_recursive = match top_level
+            .arguments
+            .last()
+            .map(|l| layout_cache.get_in(*l).repr)
+        {
+            Some(LayoutRepr::LambdaSet(lambda_set)) => lambda_set.contains(name.name()),
             _ => false,
         };
 
@@ -4142,8 +4146,8 @@ pub fn with_hole<'a>(
             let interned = layout_cache.from_var(env.arena, var, env.subs).unwrap();
             let layout = layout_cache.get_in(interned);
 
-            match layout {
-                Layout::Builtin(Builtin::List(elem_layout)) if elem_layout == Layout::U8 => {
+            match layout.repr {
+                LayoutRepr::Builtin(Builtin::List(elem_layout)) if elem_layout == Layout::U8 => {
                     let mut elements = Vec::with_capacity_in(bytes.len(), env.arena);
                     for byte in bytes.iter() {
                         elements.push(ListLiteralElement::Literal(Literal::Byte(*byte)));
@@ -4155,7 +4159,7 @@ pub fn with_hole<'a>(
 
                     Stmt::Let(assigned, expr, interned, hole)
                 }
-                Layout::Builtin(Builtin::Str) => Stmt::Let(
+                LayoutRepr::Builtin(Builtin::Str) => Stmt::Let(
                     assigned,
                     Expr::Literal(Literal::Str(
                         // This is safe because we ensure the utf8 bytes are valid earlier in the compiler pipeline.
@@ -4620,14 +4624,16 @@ pub fn with_hole<'a>(
             match opt_elem_layout {
                 Ok(elem_layout) => {
                     let expr = Expr::EmptyArray;
-                    let list_layout =
-                        layout_cache.put_in(Layout::Builtin(Builtin::List(elem_layout)));
+                    let list_layout = layout_cache.put_in(Layout {
+                        repr: LayoutRepr::Builtin(Builtin::List(elem_layout)),
+                    });
                     Stmt::Let(assigned, expr, list_layout, hole)
                 }
                 Err(LayoutProblem::UnresolvedTypeVar(_)) => {
                     let expr = Expr::EmptyArray;
-                    let list_layout =
-                        layout_cache.put_in(Layout::Builtin(Builtin::List(Layout::VOID)));
+                    let list_layout = layout_cache.put_in(Layout {
+                        repr: LayoutRepr::Builtin(Builtin::List(Layout::VOID)),
+                    });
                     Stmt::Let(assigned, expr, list_layout, hole)
                 }
                 Err(LayoutProblem::Erroneous) => panic!("list element is error type"),
@@ -4673,7 +4679,9 @@ pub fn with_hole<'a>(
                 elems: elements.into_bump_slice(),
             };
 
-            let list_layout = layout_cache.put_in(Layout::Builtin(Builtin::List(elem_layout)));
+            let list_layout = layout_cache.put_in(Layout {
+                repr: LayoutRepr::Builtin(Builtin::List(elem_layout)),
+            });
 
             let stmt = Stmt::Let(assigned, expr, list_layout, hole);
 
@@ -4975,8 +4983,8 @@ pub fn with_hole<'a>(
                 .from_var(env.arena, record_var, env.subs)
                 .unwrap_or_else(|err| panic!("TODO turn fn_var into a RuntimeError {:?}", err));
 
-            let field_layouts = match layout_cache.get_in(record_layout) {
-                Layout::Struct { field_layouts, .. } => field_layouts,
+            let field_layouts = match layout_cache.get_in(record_layout).repr {
+                LayoutRepr::Struct { field_layouts, .. } => field_layouts,
                 _ => arena.alloc([record_layout]),
             };
 
@@ -6138,8 +6146,8 @@ fn convert_tag_union<'a>(
                 layout_cache.from_var(env.arena, variant_var, env.subs),
                 "Wrapped"
             );
-            let union_layout = match layout_cache.interner.chase_recursive(variant_layout) {
-                Layout::Union(ul) => ul,
+            let union_layout = match layout_cache.interner.chase_recursive(variant_layout).repr {
+                LayoutRepr::Union(ul) => ul,
                 other => internal_error!(
                     "unexpected layout {:?} for {:?}",
                     other,
@@ -6269,7 +6277,9 @@ fn convert_tag_union<'a>(
                 }
             };
 
-            let union_layout = layout_cache.put_in(Layout::Union(union_layout));
+            let union_layout = layout_cache.put_in(Layout {
+                repr: LayoutRepr::Union(union_layout),
+            });
 
             let stmt = Stmt::Let(assigned, tag, union_layout, hole);
             let iter = field_symbols_temp
@@ -7807,9 +7817,10 @@ fn specialize_symbol<'a>(
                             // data for a lambda set.
                             let layout = match raw {
                                 RawFunctionLayout::ZeroArgumentThunk(layout) => layout,
-                                RawFunctionLayout::Function(_, lambda_set, _) => {
-                                    layout_cache.put_in(Layout::LambdaSet(lambda_set))
-                                }
+                                RawFunctionLayout::Function(_, lambda_set, _) => layout_cache
+                                    .put_in(Layout {
+                                        repr: LayoutRepr::LambdaSet(lambda_set),
+                                    }),
                             };
 
                             let raw = RawFunctionLayout::ZeroArgumentThunk(layout);
@@ -9714,8 +9725,8 @@ where
     }
 
     while let Some(layout) = stack.pop() {
-        match layout {
-            Layout::Builtin(builtin) => match builtin {
+        match layout.repr {
+            LayoutRepr::Builtin(builtin) => match builtin {
                 Builtin::Int(_)
                 | Builtin::Float(_)
                 | Builtin::Bool
@@ -9723,7 +9734,7 @@ where
                 | Builtin::Str => { /* do nothing */ }
                 Builtin::List(element) => stack.push(layout_interner.get(element)),
             },
-            Layout::Struct { field_layouts, .. } => {
+            LayoutRepr::Struct { field_layouts, .. } => {
                 if field_layouts.iter().any(|l| {
                     layout_interner
                         .get(*l)
@@ -9746,10 +9757,10 @@ where
                     stack.push(layout_interner.get(*in_layout));
                 }
             }
-            Layout::Boxed(boxed) => {
+            LayoutRepr::Boxed(boxed) => {
                 stack.push(layout_interner.get(boxed));
             }
-            Layout::Union(union_layout) => match union_layout {
+            LayoutRepr::Union(union_layout) => match union_layout {
                 UnionLayout::NonRecursive(tags) => {
                     for in_layout in tags.iter().flat_map(|e| e.iter()) {
                         stack.push(layout_interner.get(*in_layout));
@@ -9779,7 +9790,7 @@ where
                     }
                 }
             },
-            Layout::LambdaSet(lambda_set) => {
+            LayoutRepr::LambdaSet(lambda_set) => {
                 let raw_function_layout =
                     RawFunctionLayout::Function(lambda_set.args, lambda_set, lambda_set.ret);
 
@@ -9794,7 +9805,7 @@ where
                 // TODO: figure out if we need to look at the other layouts
                 // stack.push(layout_interner.get(lambda_set.ret));
             }
-            Layout::RecursivePointer(_) => {
+            LayoutRepr::RecursivePointer(_) => {
                 /* do nothing, we've already generated for this type through the Union(_) */
             }
         }
@@ -9816,12 +9827,14 @@ where
     I: LayoutInterner<'a>,
 {
     let interned_unboxed_struct_layout = layout_interner.insert(*unboxed_struct_layout);
-    let boxed_struct_layout = Layout::Boxed(interned_unboxed_struct_layout);
+    let boxed_struct_layout = Layout {
+        repr: LayoutRepr::Boxed(interned_unboxed_struct_layout),
+    };
     let boxed_struct_layout = layout_interner.insert(boxed_struct_layout);
     let mut answer = bumpalo::collections::Vec::with_capacity_in(field_layouts.len(), arena);
 
-    let field_layouts = match layout_interner.get(interned_unboxed_struct_layout) {
-        Layout::Struct { field_layouts, .. } => field_layouts,
+    let field_layouts = match layout_interner.get(interned_unboxed_struct_layout).repr {
+        LayoutRepr::Struct { field_layouts, .. } => field_layouts,
         other => {
             unreachable!(
                 "{:?} {:?}",
@@ -9927,7 +9940,9 @@ where
     I: LayoutInterner<'a>,
 {
     let interned = layout_interner.insert(*unboxed_struct_layout);
-    let boxed_struct_layout = Layout::Boxed(interned);
+    let boxed_struct_layout = Layout {
+        repr: LayoutRepr::Boxed(interned),
+    };
     let boxed_struct_layout = layout_interner.insert(boxed_struct_layout);
     let mut answer = bumpalo::collections::Vec::with_capacity_in(field_layouts.len(), arena);
 

--- a/crates/compiler/mono/src/ir.rs
+++ b/crates/compiler/mono/src/ir.rs
@@ -9059,10 +9059,7 @@ fn match_on_lambda_set<'a>(
                 env.arena.alloc(result),
             )
         }
-        ClosureCallOptions::Struct {
-            field_layouts,
-            field_order_hash: _,
-        } => {
+        ClosureCallOptions::Struct { field_layouts } => {
             let function_symbol = match lambda_set.iter_set().next() {
                 Some(function_symbol) => function_symbol,
                 None => {

--- a/crates/compiler/mono/src/ir.rs
+++ b/crates/compiler/mono/src/ir.rs
@@ -9819,10 +9819,8 @@ where
     I: LayoutInterner<'a>,
 {
     let interned_unboxed_struct_layout = layout_interner.insert(*unboxed_struct_layout);
-    let boxed_struct_layout = Layout {
-        repr: LayoutRepr::Boxed(interned_unboxed_struct_layout),
-        semantic: SemanticRepr::NONE,
-    };
+    let boxed_struct_layout =
+        Layout::no_semantic(LayoutRepr::Boxed(interned_unboxed_struct_layout));
     let boxed_struct_layout = layout_interner.insert(boxed_struct_layout);
     let mut answer = bumpalo::collections::Vec::with_capacity_in(field_layouts.len(), arena);
 
@@ -9933,10 +9931,7 @@ where
     I: LayoutInterner<'a>,
 {
     let interned = layout_interner.insert(*unboxed_struct_layout);
-    let boxed_struct_layout = Layout {
-        repr: LayoutRepr::Boxed(interned),
-        semantic: SemanticRepr::NONE,
-    };
+    let boxed_struct_layout = Layout::no_semantic(LayoutRepr::Boxed(interned));
     let boxed_struct_layout = layout_interner.insert(boxed_struct_layout);
     let mut answer = bumpalo::collections::Vec::with_capacity_in(field_layouts.len(), arena);
 

--- a/crates/compiler/mono/src/ir.rs
+++ b/crates/compiler/mono/src/ir.rs
@@ -9821,7 +9821,7 @@ where
     let interned_unboxed_struct_layout = layout_interner.insert(*unboxed_struct_layout);
     let boxed_struct_layout = Layout {
         repr: LayoutRepr::Boxed(interned_unboxed_struct_layout),
-        semantic: SemanticRepr::None,
+        semantic: SemanticRepr::NONE,
     };
     let boxed_struct_layout = layout_interner.insert(boxed_struct_layout);
     let mut answer = bumpalo::collections::Vec::with_capacity_in(field_layouts.len(), arena);
@@ -9935,7 +9935,7 @@ where
     let interned = layout_interner.insert(*unboxed_struct_layout);
     let boxed_struct_layout = Layout {
         repr: LayoutRepr::Boxed(interned),
-        semantic: SemanticRepr::None,
+        semantic: SemanticRepr::NONE,
     };
     let boxed_struct_layout = layout_interner.insert(boxed_struct_layout);
     let mut answer = bumpalo::collections::Vec::with_capacity_in(field_layouts.len(), arena);

--- a/crates/compiler/mono/src/ir/decision_tree.rs
+++ b/crates/compiler/mono/src/ir/decision_tree.rs
@@ -5,8 +5,8 @@ use crate::ir::{
     GuardStmtSpec, JoinPointId, Literal, Param, Procs, Stmt,
 };
 use crate::layout::{
-    Builtin, InLayout, Layout, LayoutCache, LayoutInterner, TLLayoutInterner, TagIdIntType,
-    UnionLayout,
+    Builtin, InLayout, Layout, LayoutCache, LayoutInterner, LayoutRepr, TLLayoutInterner,
+    TagIdIntType, UnionLayout,
 };
 use roc_builtins::bitcode::{FloatWidth, IntWidth};
 use roc_collections::all::{MutMap, MutSet};
@@ -1015,8 +1015,8 @@ fn to_relevant_branch_help<'a>(
                     match layout {
                         UnionLayout::NonRecursive([[arg]])
                             if matches!(
-                                interner.get(*arg),
-                                Layout::Struct {
+                                interner.get(*arg).repr,
+                                LayoutRepr::Struct {
                                     field_layouts: [_],
                                     ..
                                 }
@@ -1579,8 +1579,8 @@ fn path_to_expr_help<'a>(
             PathInstruction::TagIndex { index, tag_id } => {
                 let index = *index;
 
-                match layout_interner.chase_recursive(layout) {
-                    Layout::Union(union_layout) => {
+                match layout_interner.chase_recursive(layout).repr {
+                    LayoutRepr::Union(union_layout) => {
                         let inner_expr = Expr::UnionAtIndex {
                             tag_id: *tag_id,
                             structure: symbol,
@@ -1600,7 +1600,7 @@ fn path_to_expr_help<'a>(
                         layout = inner_layout;
                     }
 
-                    Layout::Struct { field_layouts, .. } => {
+                    LayoutRepr::Struct { field_layouts, .. } => {
                         debug_assert!(field_layouts.len() > 1);
 
                         let inner_expr = Expr::StructAtIndex {
@@ -1632,8 +1632,8 @@ fn path_to_expr_help<'a>(
             PathInstruction::ListIndex { index } => {
                 let list_sym = symbol;
 
-                match layout_interner.get(layout) {
-                    Layout::Builtin(Builtin::List(elem_layout)) => {
+                match layout_interner.get(layout).repr {
+                    LayoutRepr::Builtin(Builtin::List(elem_layout)) => {
                         let (index_sym, new_stores) = build_list_index_probe(env, list_sym, index);
 
                         stores.extend(new_stores);
@@ -1679,8 +1679,8 @@ fn test_to_comparison<'a>(
             // (e.g. record pattern guard matches)
             debug_assert!(union.alternatives.len() > 1);
 
-            match layout_interner.chase_recursive(test_layout) {
-                Layout::Union(union_layout) => {
+            match layout_interner.chase_recursive(test_layout).repr {
+                LayoutRepr::Union(union_layout) => {
                     let lhs = Expr::Literal(Literal::Int((tag_id as i128).to_ne_bytes()));
 
                     let rhs = Expr::GetTagId {
@@ -1769,8 +1769,8 @@ fn test_to_comparison<'a>(
             let list_layout = test_layout;
             let list_sym = rhs_symbol;
 
-            match layout_interner.get(list_layout) {
-                Layout::Builtin(Builtin::List(_elem_layout)) => {
+            match layout_interner.get(list_layout).repr {
+                LayoutRepr::Builtin(Builtin::List(_elem_layout)) => {
                     let real_len_expr = Expr::Call(Call {
                         call_type: CallType::LowLevel {
                             op: LowLevel::ListLen,
@@ -2316,7 +2316,7 @@ fn decide_to_branching<'a>(
             // We have learned more about the exact layout of the cond (based on the path)
             // but tests are still relative to the original cond symbol
             let inner_cond_layout_raw = layout_cache.interner.chase_recursive(inner_cond_layout);
-            let mut switch = if let Layout::Union(union_layout) = inner_cond_layout_raw {
+            let mut switch = if let LayoutRepr::Union(union_layout) = inner_cond_layout_raw.repr {
                 let tag_id_symbol = env.unique_symbol();
 
                 let temp = Stmt::Switch {
@@ -2338,7 +2338,7 @@ fn decide_to_branching<'a>(
                     union_layout.tag_id_layout(),
                     env.arena.alloc(temp),
                 )
-            } else if let Layout::Builtin(Builtin::List(_)) = inner_cond_layout_raw {
+            } else if let LayoutRepr::Builtin(Builtin::List(_)) = inner_cond_layout_raw.repr {
                 let len_symbol = env.unique_symbol();
 
                 let switch = Stmt::Switch {
@@ -2396,8 +2396,8 @@ fn boolean_all<'a>(arena: &'a Bump, tests: Vec<(Expr<'a>, Expr<'a>, InLayout<'a>
         expr = Expr::RunLowLevel(
             LowLevel::And,
             arena.alloc([
-                (test, Layout::Builtin(Builtin::Int1)),
-                (expr, Layout::Builtin(Builtin::Int1)),
+                (test, LayoutRepr::Builtin(Builtin::Int1)),
+                (expr, LayoutRepr::Builtin(Builtin::Int1)),
             ]),
         );
     }

--- a/crates/compiler/mono/src/ir/literal.rs
+++ b/crates/compiler/mono/src/ir/literal.rs
@@ -4,7 +4,7 @@ use roc_error_macros::internal_error;
 use roc_module::symbol::Symbol;
 use roc_std::RocDec;
 
-use crate::layout::{Builtin, InLayout, Layout, LayoutInterner, TLLayoutInterner};
+use crate::layout::{Builtin, InLayout, LayoutInterner, LayoutRepr, TLLayoutInterner};
 
 use super::pattern::Pattern;
 
@@ -83,22 +83,22 @@ pub fn make_num_literal<'a>(
     num_str: &str,
     num_value: IntOrFloatValue,
 ) -> NumLiteral {
-    match interner.get(layout) {
-        Layout::Builtin(Builtin::Int(width)) => match num_value {
+    match interner.get(layout).repr {
+        LayoutRepr::Builtin(Builtin::Int(width)) => match num_value {
             IntOrFloatValue::Int(IntValue::I128(n)) => NumLiteral::Int(n, width),
             IntOrFloatValue::Int(IntValue::U128(n)) => NumLiteral::U128(n),
             IntOrFloatValue::Float(..) => {
                 internal_error!("Float value where int was expected, should have been a type error")
             }
         },
-        Layout::Builtin(Builtin::Float(width)) => match num_value {
+        LayoutRepr::Builtin(Builtin::Float(width)) => match num_value {
             IntOrFloatValue::Float(n) => NumLiteral::Float(n, width),
             IntOrFloatValue::Int(int_value) => match int_value {
                 IntValue::I128(n) => NumLiteral::Float(i128::from_ne_bytes(n) as f64, width),
                 IntValue::U128(n) => NumLiteral::Float(u128::from_ne_bytes(n) as f64, width),
             },
         },
-        Layout::Builtin(Builtin::Decimal) => {
+        LayoutRepr::Builtin(Builtin::Decimal) => {
             let dec = match RocDec::from_str(num_str) {
                 Some(d) => d,
                 None => internal_error!(

--- a/crates/compiler/mono/src/ir/pattern.rs
+++ b/crates/compiler/mono/src/ir/pattern.rs
@@ -1,7 +1,7 @@
 use crate::ir::{substitute_in_exprs, Env, Expr, Procs, Stmt};
 use crate::layout::{
-    self, Builtin, InLayout, Layout, LayoutCache, LayoutInterner, LayoutProblem, TagIdIntType,
-    UnionLayout, WrappedVariant,
+    self, Builtin, InLayout, Layout, LayoutCache, LayoutInterner, LayoutProblem, LayoutRepr,
+    TagIdIntType, UnionLayout, WrappedVariant,
 };
 use bumpalo::collections::Vec;
 use roc_builtins::bitcode::{FloatWidth, IntWidth};
@@ -344,8 +344,8 @@ fn from_can_pattern_help<'a>(
         StrLiteral(v) => Ok(Pattern::StrLiteral(v.clone())),
         SingleQuote(var, _, c, _) => {
             let layout = layout_cache.from_var(env.arena, *var, env.subs);
-            match layout.map(|l| layout_cache.get_in(l)) {
-                Ok(Layout::Builtin(Builtin::Int(width))) => {
+            match layout.map(|l| layout_cache.get_in(l).repr) {
+                Ok(LayoutRepr::Builtin(Builtin::Int(width))) => {
                     Ok(Pattern::IntLiteral((*c as i128).to_ne_bytes(), width))
                 }
                 o => internal_error!("an integer width was expected, but we found {:?}", o),
@@ -583,11 +583,12 @@ fn from_can_pattern_help<'a>(
                     // problems down the line because we hash layouts and an unrolled
                     // version is not the same as the minimal version.
                     let whole_var_layout = layout_cache.from_var(env.arena, *whole_var, env.subs);
-                    let layout =
-                        match whole_var_layout.map(|l| layout_cache.interner.chase_recursive(l)) {
-                            Ok(Layout::Union(ul)) => ul,
-                            _ => internal_error!(),
-                        };
+                    let layout = match whole_var_layout
+                        .map(|l| layout_cache.interner.chase_recursive(l).repr)
+                    {
+                        Ok(LayoutRepr::Union(ul)) => ul,
+                        _ => internal_error!(),
+                    };
 
                     use WrappedVariant::*;
                     match variant {
@@ -1551,9 +1552,11 @@ fn store_tag_pattern<'a>(
     for (index, (argument, arg_layout)) in arguments.iter().enumerate().rev() {
         let mut arg_layout = *arg_layout;
 
-        if let Layout::RecursivePointer(_) = layout_cache.get_in(arg_layout) {
+        if let LayoutRepr::RecursivePointer(_) = layout_cache.get_in(arg_layout).repr {
             // TODO(recursive-layouts): fix after disjoint rec ptrs
-            arg_layout = layout_cache.put_in(Layout::Union(union_layout));
+            arg_layout = layout_cache.put_in(Layout {
+                repr: LayoutRepr::Union(union_layout),
+            });
         }
 
         let load = Expr::UnionAtIndex {
@@ -1629,7 +1632,7 @@ fn store_newtype_pattern<'a>(
     for (index, (argument, arg_layout)) in arguments.iter().enumerate().rev() {
         let mut arg_layout = *arg_layout;
 
-        if let Layout::RecursivePointer(_) = layout_cache.get_in(arg_layout) {
+        if let LayoutRepr::RecursivePointer(_) = layout_cache.get_in(arg_layout).repr {
             arg_layout = layout;
         }
 

--- a/crates/compiler/mono/src/ir/pattern.rs
+++ b/crates/compiler/mono/src/ir/pattern.rs
@@ -1554,9 +1554,7 @@ fn store_tag_pattern<'a>(
 
         if let LayoutRepr::RecursivePointer(_) = layout_cache.get_in(arg_layout).repr {
             // TODO(recursive-layouts): fix after disjoint rec ptrs
-            arg_layout = layout_cache.put_in(Layout {
-                repr: LayoutRepr::Union(union_layout),
-            });
+            arg_layout = layout_cache.put_in_no_semantic(LayoutRepr::Union(union_layout));
         }
 
         let load = Expr::UnionAtIndex {

--- a/crates/compiler/mono/src/ir/pattern.rs
+++ b/crates/compiler/mono/src/ir/pattern.rs
@@ -1208,7 +1208,7 @@ fn store_pattern_help<'a>(
                 fields.extend(arguments.iter().map(|x| x.1));
 
                 let layout =
-                    layout_cache.put_in(Layout::struct_no_name_order(fields.into_bump_slice()));
+                    layout_cache.put_in_no_semantic(LayoutRepr::struct_(fields.into_bump_slice()));
 
                 return store_newtype_pattern(
                     env,

--- a/crates/compiler/mono/src/layout.rs
+++ b/crates/compiler/mono/src/layout.rs
@@ -663,7 +663,7 @@ impl FieldOrderHash {
     const ZERO_FIELD_HASH: Self = Self(0);
     const IRRELEVANT_NON_ZERO_FIELD_HASH: Self = Self(1);
 
-    pub fn from_ordered_fields(fields: &[&Lowercase]) -> Self {
+    pub fn from_ordered_fields(fields: &[&str]) -> Self {
         if fields.is_empty() {
             // HACK: we must make sure this is always equivalent to a `ZERO_FIELD_HASH`.
             return Self::ZERO_FIELD_HASH;
@@ -3262,8 +3262,12 @@ fn layout_from_flat_type<'a>(
                 )
             });
 
-            let ordered_field_names =
-                Vec::from_iter_in(sortables.iter().map(|(label, _)| *label), arena);
+            let ordered_field_names = Vec::from_iter_in(
+                sortables
+                    .iter()
+                    .map(|(label, _)| &*arena.alloc_str(label.as_str())),
+                arena,
+            );
             let field_order_hash =
                 FieldOrderHash::from_ordered_fields(ordered_field_names.as_slice());
 
@@ -3278,7 +3282,7 @@ fn layout_from_flat_type<'a>(
                         field_order_hash,
                         field_layouts: layouts.into_bump_slice(),
                     },
-                    semantic: SemanticRepr::None,
+                    semantic: SemanticRepr::record(ordered_field_names.into_bump_slice()),
                 };
 
                 Ok(env.cache.put_in(struct_layout))

--- a/crates/compiler/mono/src/layout.rs
+++ b/crates/compiler/mono/src/layout.rs
@@ -3127,7 +3127,7 @@ fn layout_from_flat_type<'a>(
                         cached!(Layout::from_var(env, inner_var), criteria, env.subs);
                     let boxed_layout = env.cache.put_in(Layout {
                         repr: LayoutRepr::Boxed(inner_layout),
-                        semantic: SemanticRepr::None,
+                        semantic: SemanticRepr::NONE,
                     });
 
                     Cacheable(Ok(boxed_layout), criteria)
@@ -4112,7 +4112,7 @@ where
                         repr: LayoutRepr::Union(UnionLayout::NonRecursive(
                             tag_layouts.into_bump_slice(),
                         )),
-                        semantic: SemanticRepr::None,
+                        semantic: SemanticRepr::NONE,
                     };
                     env.cache.put_in(layout)
                 }
@@ -4228,14 +4228,14 @@ where
             env.arena,
             Layout {
                 repr: LayoutRepr::Union(union_layout),
-                semantic: SemanticRepr::None,
+                semantic: SemanticRepr::NONE,
             },
         )
     } else {
         // There are no naked recursion pointers, so we can insert the layout as-is.
         env.cache.interner.insert(Layout {
             repr: LayoutRepr::Union(union_layout),
-            semantic: SemanticRepr::None,
+            semantic: SemanticRepr::NONE,
         })
     };
 
@@ -4371,7 +4371,7 @@ pub(crate) fn list_layout_from_elem<'a>(
 
     let list_layout = env.cache.put_in(Layout {
         repr: LayoutRepr::Builtin(Builtin::List(element_layout)),
-        semantic: SemanticRepr::None,
+        semantic: SemanticRepr::NONE,
     });
 
     Cacheable(Ok(list_layout), criteria)
@@ -4549,13 +4549,13 @@ mod test {
         let a = &[Layout::UNIT] as &[_];
         let b = &[interner.insert(Layout {
             repr: LayoutRepr::LambdaSet(lambda_set),
-            semantic: SemanticRepr::None,
+            semantic: SemanticRepr::NONE,
         })] as &[_];
         let tt = [a, b];
 
         let layout = Layout {
             repr: LayoutRepr::Union(UnionLayout::NonRecursive(&tt)),
-            semantic: SemanticRepr::None,
+            semantic: SemanticRepr::NONE,
         };
 
         let target_info = TargetInfo::default_x86_64();
@@ -4569,14 +4569,14 @@ mod test {
 
         let ok_tag = &[interner.insert(Layout {
             repr: LayoutRepr::Builtin(Builtin::Int(IntWidth::U32)),
-            semantic: SemanticRepr::None,
+            semantic: SemanticRepr::NONE,
         })];
         let err_tag = &[Layout::UNIT];
         let tags = [ok_tag as &[_], err_tag as &[_]];
         let union_layout = UnionLayout::NonRecursive(&tags as &[_]);
         let layout = Layout {
             repr: LayoutRepr::Union(union_layout),
-            semantic: SemanticRepr::None,
+            semantic: SemanticRepr::NONE,
         };
 
         let target_info = TargetInfo::default_x86_64();

--- a/crates/compiler/mono/src/layout.rs
+++ b/crates/compiler/mono/src/layout.rs
@@ -657,7 +657,7 @@ impl<'a> RawFunctionLayout<'a> {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct Layout<'a> {
     pub repr: LayoutRepr<'a>,
-    pub semantic: SemanticRepr<'a>,
+    semantic: SemanticRepr<'a>,
 }
 
 /// Types for code gen must be monomorphic. No type variables allowed!
@@ -2328,6 +2328,21 @@ pub fn is_any_float_range(subs: &Subs, var: Variable) -> bool {
 }
 
 impl<'a> Layout<'a> {
+    pub const fn new(repr: LayoutRepr<'a>, semantic: SemanticRepr<'a>) -> Self {
+        Self { repr, semantic }
+    }
+
+    pub const fn no_semantic(repr: LayoutRepr<'a>) -> Self {
+        Self {
+            repr,
+            semantic: SemanticRepr::NONE,
+        }
+    }
+
+    pub const fn semantic(&self) -> SemanticRepr<'a> {
+        self.semantic
+    }
+
     fn new_help<'b>(
         env: &mut Env<'a, 'b>,
         _var: Variable,

--- a/crates/compiler/mono/src/layout.rs
+++ b/crates/compiler/mono/src/layout.rs
@@ -3332,7 +3332,7 @@ fn layout_from_flat_type<'a>(
                         field_order_hash,
                         field_layouts: layouts.into_bump_slice(),
                     },
-                    semantic: SemanticRepr::None,
+                    semantic: SemanticRepr::tuple(layouts.len()),
                 };
 
                 Ok(env.cache.put_in(struct_layout))

--- a/crates/compiler/mono/src/layout/intern.rs
+++ b/crates/compiler/mono/src/layout/intern.rs
@@ -127,7 +127,7 @@ impl<'a> Layout<'a> {
             field_layouts: &[],
             field_order_hash: FieldOrderHash::ZERO_FIELD_HASH,
         },
-        semantic: SemanticRepr::None,
+        semantic: SemanticRepr::EMPTY_RECORD,
     };
 
     pub const fn float_width(w: FloatWidth) -> InLayout<'static> {

--- a/crates/compiler/mono/src/layout/intern.rs
+++ b/crates/compiler/mono/src/layout/intern.rs
@@ -14,10 +14,7 @@ use roc_target::TargetInfo;
 
 use crate::layout::LayoutRepr;
 
-use super::{
-    semantic::SemaRecord, Builtin, FieldOrderHash, LambdaSet, Layout, SeenRecPtrs, SemanticRepr,
-    UnionLayout,
-};
+use super::{Builtin, FieldOrderHash, LambdaSet, Layout, SeenRecPtrs, SemanticRepr, UnionLayout};
 
 macro_rules! cache_interned_layouts {
     ($($i:literal, $name:ident, $vis:vis, $layout:expr)*; $total_constants:literal) => {
@@ -130,7 +127,7 @@ impl<'a> Layout<'a> {
             field_layouts: &[],
             field_order_hash: FieldOrderHash::ZERO_FIELD_HASH,
         },
-        semantic: SemanticRepr::Record(SemaRecord::new(&[])),
+        semantic: SemanticRepr::None,
     };
 
     pub const fn float_width(w: FloatWidth) -> InLayout<'static> {

--- a/crates/compiler/mono/src/layout/intern.rs
+++ b/crates/compiler/mono/src/layout/intern.rs
@@ -155,10 +155,7 @@ pub trait LayoutInterner<'a>: Sized {
     /// Interns a value with no semantic representation, returning its interned representation.
     /// If the value has been interned before, the old interned representation will be re-used.
     fn insert_no_semantic(&mut self, repr: LayoutRepr<'a>) -> InLayout<'a> {
-        self.insert(Layout {
-            repr,
-            semantic: SemanticRepr::NONE,
-        })
+        self.insert(Layout::no_semantic(repr))
     }
 
     /// Creates a [LambdaSet], including caching the [LayoutRepr::LambdaSet] representation of the

--- a/crates/compiler/mono/src/layout/intern.rs
+++ b/crates/compiler/mono/src/layout/intern.rs
@@ -51,7 +51,7 @@ macro_rules! nosema {
     ($r:expr) => {
         Layout {
             repr: $r,
-            semantic: SemanticRepr::None,
+            semantic: SemanticRepr::NONE,
         }
     };
 }
@@ -120,7 +120,7 @@ impl_to_from_int_width! {
 impl<'a> Layout<'a> {
     pub(super) const VOID_NAKED: Self = Layout {
         repr: LayoutRepr::Union(UnionLayout::NonRecursive(&[])),
-        semantic: SemanticRepr::None,
+        semantic: SemanticRepr::NONE,
     };
     pub(super) const UNIT_NAKED: Self = Layout {
         repr: LayoutRepr::Struct { field_layouts: &[] },
@@ -157,7 +157,7 @@ pub trait LayoutInterner<'a>: Sized {
     fn insert_no_semantic(&mut self, repr: LayoutRepr<'a>) -> InLayout<'a> {
         self.insert(Layout {
             repr,
-            semantic: SemanticRepr::None,
+            semantic: SemanticRepr::NONE,
         })
     }
 
@@ -665,7 +665,7 @@ impl<'a> GlobalLayoutInterner<'a> {
         };
         let lambda_set_layout = Layout {
             repr: LayoutRepr::LambdaSet(full_lambda_set),
-            semantic: SemanticRepr::None,
+            semantic: SemanticRepr::NONE,
         };
 
         vec[slot.0] = lambda_set_layout;
@@ -974,7 +974,7 @@ macro_rules! st_impl {
                 };
                 let lay = Layout {
                     repr: LayoutRepr::LambdaSet(lambda_set),
-                    semantic: SemanticRepr::None
+                    semantic: SemanticRepr::NONE
                 };
                 self.vec[slot.0] = lay;
 
@@ -1065,7 +1065,7 @@ mod reify {
         };
         Layout {
             repr,
-            semantic: SemanticRepr::None,
+            semantic: SemanticRepr::NONE,
         }
     }
 
@@ -1544,7 +1544,7 @@ mod insert_lambda_set {
             interner.insert_lambda_set(arena, TEST_ARGS, TEST_RET, TEST_SET, FIXUP, Layout::UNIT);
         let lambda_set_layout_in = interner.insert(Layout {
             repr: LayoutRepr::LambdaSet(lambda_set),
-            semantic: SemanticRepr::None,
+            semantic: SemanticRepr::NONE,
         });
         assert_eq!(lambda_set.full_layout, lambda_set_layout_in);
     }
@@ -1603,7 +1603,7 @@ mod insert_recursive_layout {
     fn make_layout<'a>(arena: &'a Bump, interner: &mut impl LayoutInterner<'a>) -> Layout<'a> {
         let list_rec = Layout {
             repr: LayoutRepr::Builtin(Builtin::List(Layout::NAKED_RECURSIVE_PTR)),
-            semantic: SemanticRepr::None,
+            semantic: SemanticRepr::NONE,
         };
         let repr = LayoutRepr::Union(UnionLayout::Recursive(&*arena.alloc([
             &*arena.alloc([interner.insert(list_rec)]),
@@ -1613,7 +1613,7 @@ mod insert_recursive_layout {
         ])));
         Layout {
             repr,
-            semantic: SemanticRepr::None,
+            semantic: SemanticRepr::NONE,
         }
     }
 

--- a/crates/compiler/mono/src/layout/intern.rs
+++ b/crates/compiler/mono/src/layout/intern.rs
@@ -1031,7 +1031,7 @@ mod reify {
     use bumpalo::{collections::Vec, Bump};
     use roc_module::symbol::Symbol;
 
-    use crate::layout::{Builtin, LambdaSet, Layout, LayoutRepr, SemanticRepr, UnionLayout};
+    use crate::layout::{Builtin, LambdaSet, Layout, LayoutRepr, UnionLayout};
 
     use super::{InLayout, LayoutInterner, NeedsRecursionPointerFixup};
 
@@ -1062,7 +1062,7 @@ mod reify {
         };
         Layout {
             repr,
-            semantic: SemanticRepr::NONE,
+            semantic: normalized_layout.semantic,
         }
     }
 

--- a/crates/compiler/mono/src/layout/intern.rs
+++ b/crates/compiler/mono/src/layout/intern.rs
@@ -1593,7 +1593,7 @@ mod insert_recursive_layout {
         };
         let repr = LayoutRepr::Union(UnionLayout::Recursive(&*arena.alloc([
             &*arena.alloc([interner.insert(list_rec)]),
-            &*arena.alloc_slice_fill_iter([interner.insert(Layout::struct_no_name_order(
+            &*arena.alloc_slice_fill_iter([interner.insert_no_semantic(LayoutRepr::struct_(
                 &*arena.alloc([Layout::NAKED_RECURSIVE_PTR]),
             ))]),
         ])));

--- a/crates/compiler/mono/src/layout/semantic.rs
+++ b/crates/compiler/mono/src/layout/semantic.rs
@@ -21,7 +21,8 @@ enum Inner<'a> {
 }
 
 impl<'a> SemanticRepr<'a> {
-    pub const NONE: Self = Self(Inner::None);
+    pub(super) const NONE: Self = Self(Inner::None);
+    pub(super) const EMPTY_RECORD: Self = Self::record(&[]);
 
     pub(super) const fn record(fields: &'a [&'a str]) -> Self {
         Self(Inner::Record(SemaRecord { fields }))

--- a/crates/compiler/mono/src/layout/semantic.rs
+++ b/crates/compiler/mono/src/layout/semantic.rs
@@ -8,6 +8,7 @@
 pub enum SemanticRepr<'a> {
     None,
     Record(SemaRecord<'a>),
+    Tuple(SemaTuple),
 }
 
 impl<'a> SemanticRepr<'a> {
@@ -16,9 +17,18 @@ impl<'a> SemanticRepr<'a> {
     pub(super) fn record(fields: &'a [&'a str]) -> Self {
         Self::Record(SemaRecord { fields })
     }
+
+    pub(super) fn tuple(size: usize) -> Self {
+        Self::Tuple(SemaTuple { size })
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct SemaRecord<'a> {
     pub fields: &'a [&'a str],
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct SemaTuple {
+    pub size: usize,
 }

--- a/crates/compiler/mono/src/layout/semantic.rs
+++ b/crates/compiler/mono/src/layout/semantic.rs
@@ -4,31 +4,40 @@
 /// Semantic representations describe the shape of a type a [Layout][super::Layout] is generated
 /// for. Semantic representations disambiguate types that have the same runtime memory layout, but
 /// different shapes.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct SemanticRepr<'a>(Inner<'a>);
+
+impl<'a> std::fmt::Debug for SemanticRepr<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub enum SemanticRepr<'a> {
+enum Inner<'a> {
     None,
     Record(SemaRecord<'a>),
     Tuple(SemaTuple),
 }
 
 impl<'a> SemanticRepr<'a> {
-    pub(super) const EMPTY_RECORD: Self = Self::Record(SemaRecord { fields: &[] });
+    pub const NONE: Self = Self(Inner::None);
 
-    pub(super) fn record(fields: &'a [&'a str]) -> Self {
-        Self::Record(SemaRecord { fields })
+    pub(super) const fn record(fields: &'a [&'a str]) -> Self {
+        Self(Inner::Record(SemaRecord { fields }))
     }
 
     pub(super) fn tuple(size: usize) -> Self {
-        Self::Tuple(SemaTuple { size })
+        Self(Inner::Tuple(SemaTuple { size }))
     }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct SemaRecord<'a> {
-    pub fields: &'a [&'a str],
+struct SemaRecord<'a> {
+    fields: &'a [&'a str],
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct SemaTuple {
-    pub size: usize,
+struct SemaTuple {
+    size: usize,
 }

--- a/crates/compiler/mono/src/layout/semantic.rs
+++ b/crates/compiler/mono/src/layout/semantic.rs
@@ -1,0 +1,24 @@
+//! Semantic representations of memory layouts for the purposes of specialization.
+
+/// A semantic representation of a memory layout.
+/// Semantic representations describe the shape of a type a [Layout][super::Layout] is generated
+/// for. Semantic representations disambiguate types that have the same runtime memory layout, but
+/// different shapes.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum SemanticRepr<'a> {
+    None,
+    Record(SemaRecord<'a>),
+}
+
+impl<'a> SemanticRepr<'a> {
+    pub(super) const EMPTY_RECORD: Self = Self::Record(SemaRecord { fields: &[] });
+
+    pub(super) fn record(fields: &'a [&'a str]) -> Self {
+        Self::Record(SemaRecord { fields })
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct SemaRecord<'a> {
+    pub fields: &'a [&'a str],
+}

--- a/crates/compiler/mono/src/reset_reuse.rs
+++ b/crates/compiler/mono/src/reset_reuse.rs
@@ -10,7 +10,7 @@ use crate::ir::{
     BranchInfo, Expr, JoinPointId, ModifyRc, Param, Proc, ProcLayout, Stmt, UpdateModeId,
     UpdateModeIds,
 };
-use crate::layout::{InLayout, Layout, LayoutInterner, STLayoutInterner, UnionLayout};
+use crate::layout::{InLayout, LayoutInterner, LayoutRepr, STLayoutInterner, UnionLayout};
 
 use bumpalo::Bump;
 
@@ -1133,8 +1133,8 @@ fn symbol_layout_reusability<'a>(
     symbol: &Symbol,
     layout: &InLayout<'a>,
 ) -> Reuse {
-    match layout_interner.get(*layout) {
-        Layout::Union(union_layout) => {
+    match layout_interner.get(*layout).repr {
+        LayoutRepr::Union(union_layout) => {
             can_reuse_union_layout_tag(&union_layout, environment.get_symbol_tag(symbol))
         }
         // Strings literals are constants.

--- a/crates/compiler/test_gen/src/gen_tags.rs
+++ b/crates/compiler/test_gen/src/gen_tags.rs
@@ -27,7 +27,7 @@ fn width_and_alignment_u8_u8() {
 
     let layout = Layout {
         repr: LayoutRepr::Union(UnionLayout::NonRecursive(&tt)),
-        semantic: SemanticRepr::None,
+        semantic: SemanticRepr::NONE,
     };
 
     assert_eq!(layout.alignment_bytes(&interner, target_info), 1);

--- a/crates/compiler/test_gen/src/gen_tags.rs
+++ b/crates/compiler/test_gen/src/gen_tags.rs
@@ -10,7 +10,7 @@ use crate::helpers::wasm::assert_evals_to;
 #[cfg(test)]
 use indoc::indoc;
 
-use roc_mono::layout::{LayoutRepr, STLayoutInterner, SemanticRepr};
+use roc_mono::layout::{LayoutRepr, STLayoutInterner};
 #[cfg(test)]
 use roc_std::{RocList, RocStr, U128};
 
@@ -25,10 +25,7 @@ fn width_and_alignment_u8_u8() {
     let t = &[Layout::U8] as &[_];
     let tt = [t, t];
 
-    let layout = Layout {
-        repr: LayoutRepr::Union(UnionLayout::NonRecursive(&tt)),
-        semantic: SemanticRepr::NONE,
-    };
+    let layout = Layout::no_semantic(LayoutRepr::Union(UnionLayout::NonRecursive(&tt)));
 
     assert_eq!(layout.alignment_bytes(&interner, target_info), 1);
     assert_eq!(layout.stack_size(&interner, target_info), 2);

--- a/crates/compiler/test_gen/src/gen_tags.rs
+++ b/crates/compiler/test_gen/src/gen_tags.rs
@@ -10,7 +10,7 @@ use crate::helpers::wasm::assert_evals_to;
 #[cfg(test)]
 use indoc::indoc;
 
-use roc_mono::layout::STLayoutInterner;
+use roc_mono::layout::{LayoutRepr, STLayoutInterner};
 #[cfg(test)]
 use roc_std::{RocList, RocStr, U128};
 
@@ -25,7 +25,9 @@ fn width_and_alignment_u8_u8() {
     let t = &[Layout::U8] as &[_];
     let tt = [t, t];
 
-    let layout = Layout::Union(UnionLayout::NonRecursive(&tt));
+    let layout = Layout {
+        repr: LayoutRepr::Union(UnionLayout::NonRecursive(&tt)),
+    };
 
     assert_eq!(layout.alignment_bytes(&interner, target_info), 1);
     assert_eq!(layout.stack_size(&interner, target_info), 2);

--- a/crates/compiler/test_gen/src/gen_tags.rs
+++ b/crates/compiler/test_gen/src/gen_tags.rs
@@ -10,7 +10,7 @@ use crate::helpers::wasm::assert_evals_to;
 #[cfg(test)]
 use indoc::indoc;
 
-use roc_mono::layout::{LayoutRepr, STLayoutInterner};
+use roc_mono::layout::{LayoutRepr, STLayoutInterner, SemanticRepr};
 #[cfg(test)]
 use roc_std::{RocList, RocStr, U128};
 
@@ -27,6 +27,7 @@ fn width_and_alignment_u8_u8() {
 
     let layout = Layout {
         repr: LayoutRepr::Union(UnionLayout::NonRecursive(&tt)),
+        semantic: SemanticRepr::None,
     };
 
     assert_eq!(layout.alignment_bytes(&interner, target_info), 1);

--- a/crates/compiler/test_mono/generated/recursively_build_effect.txt
+++ b/crates/compiler/test_mono/generated/recursively_build_effect.txt
@@ -8,8 +8,8 @@ procedure Str.3 (#Attr.2, #Attr.3):
 
 procedure Test.11 (Test.29, #Attr.12):
     let Test.10 : {} = UnionAtIndex (Id 0) (Index 0) #Attr.12;
-    let #Derived_gen.0 : Int1 = lowlevel RefCountIsUnique #Attr.12;
-    if #Derived_gen.0 then
+    let #Derived_gen.2 : Int1 = lowlevel RefCountIsUnique #Attr.12;
+    if #Derived_gen.2 then
         decref #Attr.12;
         ret Test.10;
     else
@@ -23,7 +23,7 @@ procedure Test.14 (Test.62, Test.63):
     joinpoint Test.37 Test.36 #Attr.12:
         let Test.12 : {} = UnionAtIndex (Id 1) (Index 1) #Attr.12;
         let Test.13 : I64 = UnionAtIndex (Id 1) (Index 0) #Attr.12;
-        joinpoint #Derived_gen.1:
+        joinpoint #Derived_gen.0:
             let Test.43 : {} = Struct {};
             let Test.42 : {} = CallByName Test.11 Test.43 Test.12;
             let Test.38 : [<r>C {}, C I64 {}] = CallByName Test.9 Test.42 Test.13;
@@ -38,13 +38,13 @@ procedure Test.14 (Test.62, Test.63):
                     jump Test.37 Test.40 Test.38;
             
         in
-        let #Derived_gen.2 : Int1 = lowlevel RefCountIsUnique #Attr.12;
-        if #Derived_gen.2 then
+        let #Derived_gen.1 : Int1 = lowlevel RefCountIsUnique #Attr.12;
+        if #Derived_gen.1 then
             decref #Attr.12;
-            jump #Derived_gen.1;
+            jump #Derived_gen.0;
         else
             decref #Attr.12;
-            jump #Derived_gen.1;
+            jump #Derived_gen.0;
     in
     jump Test.37 Test.62 Test.63;
 

--- a/crates/compiler/test_mono/generated/recursively_build_effect.txt
+++ b/crates/compiler/test_mono/generated/recursively_build_effect.txt
@@ -8,8 +8,8 @@ procedure Str.3 (#Attr.2, #Attr.3):
 
 procedure Test.11 (Test.29, #Attr.12):
     let Test.10 : {} = UnionAtIndex (Id 0) (Index 0) #Attr.12;
-    let #Derived_gen.2 : Int1 = lowlevel RefCountIsUnique #Attr.12;
-    if #Derived_gen.2 then
+    let #Derived_gen.0 : Int1 = lowlevel RefCountIsUnique #Attr.12;
+    if #Derived_gen.0 then
         decref #Attr.12;
         ret Test.10;
     else
@@ -23,7 +23,7 @@ procedure Test.14 (Test.62, Test.63):
     joinpoint Test.37 Test.36 #Attr.12:
         let Test.12 : {} = UnionAtIndex (Id 1) (Index 1) #Attr.12;
         let Test.13 : I64 = UnionAtIndex (Id 1) (Index 0) #Attr.12;
-        joinpoint #Derived_gen.0:
+        joinpoint #Derived_gen.1:
             let Test.43 : {} = Struct {};
             let Test.42 : {} = CallByName Test.11 Test.43 Test.12;
             let Test.38 : [<r>C {}, C I64 {}] = CallByName Test.9 Test.42 Test.13;
@@ -38,13 +38,13 @@ procedure Test.14 (Test.62, Test.63):
                     jump Test.37 Test.40 Test.38;
             
         in
-        let #Derived_gen.1 : Int1 = lowlevel RefCountIsUnique #Attr.12;
-        if #Derived_gen.1 then
+        let #Derived_gen.2 : Int1 = lowlevel RefCountIsUnique #Attr.12;
+        if #Derived_gen.2 then
             decref #Attr.12;
-            jump #Derived_gen.0;
+            jump #Derived_gen.1;
         else
             decref #Attr.12;
-            jump #Derived_gen.0;
+            jump #Derived_gen.1;
     in
     jump Test.37 Test.62 Test.63;
 

--- a/crates/glue/src/types.rs
+++ b/crates/glue/src/types.rs
@@ -16,7 +16,7 @@ use roc_mono::{
     ir::LambdaSetId,
     layout::{
         cmp_fields, ext_var_is_empty_tag_union, round_up_to_alignment, Builtin, Discriminant,
-        InLayout, Layout, LayoutCache, LayoutInterner, TLLayoutInterner, UnionLayout,
+        InLayout, Layout, LayoutCache, LayoutInterner, LayoutRepr, TLLayoutInterner, UnionLayout,
     },
 };
 use roc_target::{Architecture, OperatingSystem, TargetInfo};
@@ -1383,26 +1383,28 @@ fn add_type_help<'a>(
 
             add_tag_union(env, opt_name, tags, var, types, layout, Some(rec_root))
         }
-        Content::Structure(FlatType::Apply(symbol, _)) => match env.layout_cache.get_in(layout) {
-            Layout::Builtin(builtin) => {
-                add_builtin_type(env, builtin, var, opt_name, types, layout)
-            }
-            _ => {
-                if symbol.is_builtin() {
-                    todo!(
-                        "Handle Apply for builtin symbol {:?} and layout {:?}",
-                        symbol,
-                        layout
-                    )
-                } else {
-                    todo!(
-                        "Handle non-builtin Apply for symbol {:?} and layout {:?}",
-                        symbol,
-                        layout
-                    )
+        Content::Structure(FlatType::Apply(symbol, _)) => {
+            match env.layout_cache.get_in(layout).repr {
+                LayoutRepr::Builtin(builtin) => {
+                    add_builtin_type(env, builtin, var, opt_name, types, layout)
+                }
+                _ => {
+                    if symbol.is_builtin() {
+                        todo!(
+                            "Handle Apply for builtin symbol {:?} and layout {:?}",
+                            symbol,
+                            layout
+                        )
+                    } else {
+                        todo!(
+                            "Handle non-builtin Apply for symbol {:?} and layout {:?}",
+                            symbol,
+                            layout
+                        )
+                    }
                 }
             }
-        },
+        }
         Content::Structure(FlatType::Func(args, closure_var, ret_var)) => {
             let is_toplevel = false; // or in any case, we cannot assume that we are
 
@@ -1430,11 +1432,11 @@ fn add_type_help<'a>(
         }
         Content::Alias(name, alias_vars, real_var, _) => {
             if name.is_builtin() {
-                match env.layout_cache.get_in(layout) {
-                    Layout::Builtin(builtin) => {
+                match env.layout_cache.get_in(layout).repr {
+                    LayoutRepr::Builtin(builtin) => {
                         add_builtin_type(env, builtin, var, opt_name, types, layout)
                     }
-                    Layout::Union(union_layout) if *name == Symbol::BOOL_BOOL => {
+                    LayoutRepr::Union(union_layout) if *name == Symbol::BOOL_BOOL => {
                         if cfg!(debug_assertions) {
                             match union_layout {
                                 UnionLayout::NonRecursive(tag_layouts) => {
@@ -1451,7 +1453,7 @@ fn add_type_help<'a>(
 
                         types.add_anonymous(&env.layout_cache.interner, RocType::Bool, layout)
                     }
-                    Layout::Union(union_layout) if *name == Symbol::RESULT_RESULT => {
+                    LayoutRepr::Union(union_layout) if *name == Symbol::RESULT_RESULT => {
                         match union_layout {
                             UnionLayout::NonRecursive(tags) => {
                                 // Result should always have exactly two tags: Ok and Err
@@ -1489,12 +1491,12 @@ fn add_type_help<'a>(
                             }
                         }
                     }
-                    Layout::Struct { .. } if *name == Symbol::RESULT_RESULT => {
+                    LayoutRepr::Struct { .. } if *name == Symbol::RESULT_RESULT => {
                         // can happen if one or both of a and b in `Result.Result a b` are the
                         // empty tag union `[]`
                         add_type_help(env, layout, *real_var, opt_name, types)
                     }
-                    Layout::Struct { .. } if *name == Symbol::DICT_DICT => {
+                    LayoutRepr::Struct { .. } if *name == Symbol::DICT_DICT => {
                         let type_vars = env.subs.get_subs_slice(alias_vars.type_variables());
 
                         let key_var = type_vars[0];
@@ -1520,7 +1522,7 @@ fn add_type_help<'a>(
 
                         type_id
                     }
-                    Layout::Struct { .. } if *name == Symbol::SET_SET => {
+                    LayoutRepr::Struct { .. } if *name == Symbol::SET_SET => {
                         let type_vars = env.subs.get_subs_slice(alias_vars.type_variables());
 
                         let key_var = type_vars[0];
@@ -1685,11 +1687,11 @@ fn add_builtin_type<'a>(
             Alias(Symbol::DICT_DICT, _alias_variables, alias_var, AliasKind::Opaque),
         ) => {
             match (
-                env.layout_cache.get_in(elem_layout),
+                env.layout_cache.get_in(elem_layout).repr,
                 env.subs.get_content_without_compacting(*alias_var),
             ) {
                 (
-                    Layout::Struct { field_layouts, .. },
+                    LayoutRepr::Struct { field_layouts, .. },
                     Content::Structure(FlatType::Apply(Symbol::LIST_LIST, args_subs_slice)),
                 ) => {
                     let (key_var, val_var) = {
@@ -1735,11 +1737,11 @@ fn add_builtin_type<'a>(
             Alias(Symbol::SET_SET, _alias_vars, alias_var, AliasKind::Opaque),
         ) => {
             match (
-                env.layout_cache.get_in(elem_layout),
+                env.layout_cache.get_in(elem_layout).repr,
                 env.subs.get_content_without_compacting(*alias_var),
             ) {
                 (
-                    Layout::Struct { field_layouts, .. },
+                    LayoutRepr::Struct { field_layouts, .. },
                     Alias(Symbol::DICT_DICT, alias_args, _alias_var, AliasKind::Opaque),
                 ) => {
                     let dict_type_vars = env.subs.get_subs_slice(alias_args.type_variables());
@@ -1908,7 +1910,7 @@ fn tag_union_type_from_layout<'a>(
 ) -> RocTagUnion {
     let subs = env.subs;
 
-    match env.layout_cache.get_in(layout) {
+    match env.layout_cache.get_in(layout).repr {
         _ if union_tags.is_newtype_wrapper(subs)
             && matches!(
                 subs.get_content_without_compacting(var),
@@ -1929,7 +1931,7 @@ fn tag_union_type_from_layout<'a>(
                 payload,
             }
         }
-        Layout::Union(union_layout) => {
+        LayoutRepr::Union(union_layout) => {
             use UnionLayout::*;
 
             match union_layout {
@@ -2053,10 +2055,10 @@ fn tag_union_type_from_layout<'a>(
                 }
             }
         }
-        Layout::Builtin(Builtin::Int(int_width)) => {
+        LayoutRepr::Builtin(Builtin::Int(int_width)) => {
             add_int_enumeration(union_tags, subs, &name, int_width)
         }
-        Layout::Struct { field_layouts, .. } => {
+        LayoutRepr::Struct { field_layouts, .. } => {
             let (tag_name, payload) =
                 single_tag_payload_fields(env, union_tags, subs, layout, field_layouts, types);
 
@@ -2066,13 +2068,13 @@ fn tag_union_type_from_layout<'a>(
                 payload,
             }
         }
-        Layout::Builtin(Builtin::Bool) => {
+        LayoutRepr::Builtin(Builtin::Bool) => {
             // This isn't actually a Bool, but rather a 2-tag union with no payloads
             // (so it has the same layout as a Bool, but actually isn't one; if it were
             // a real Bool, it would have been handled elsewhere already!)
             add_int_enumeration(union_tags, subs, &name, IntWidth::U8)
         }
-        Layout::Builtin(builtin) => {
+        LayoutRepr::Builtin(builtin) => {
             let type_id = add_builtin_type(env, builtin, var, opt_name, types, layout);
             let (tag_name, _) = single_tag_payload(union_tags, subs);
 
@@ -2085,7 +2087,7 @@ fn tag_union_type_from_layout<'a>(
                 },
             }
         }
-        Layout::Boxed(elem_layout) => {
+        LayoutRepr::Boxed(elem_layout) => {
             let (tag_name, payload_fields) =
                 single_tag_payload_fields(env, union_tags, subs, layout, &[elem_layout], types);
 
@@ -2095,7 +2097,7 @@ fn tag_union_type_from_layout<'a>(
                 payload: payload_fields,
             }
         }
-        Layout::LambdaSet(lambda_set) => tag_union_type_from_layout(
+        LayoutRepr::LambdaSet(lambda_set) => tag_union_type_from_layout(
             env,
             opt_name,
             name,
@@ -2104,7 +2106,7 @@ fn tag_union_type_from_layout<'a>(
             types,
             lambda_set.runtime_representation(),
         ),
-        Layout::RecursivePointer(_) => {
+        LayoutRepr::RecursivePointer(_) => {
             // A single-tag union which only wraps itself is erroneous and should have
             // been turned into an error earlier in the process.
             unreachable!();

--- a/crates/repl_eval/src/eval.rs
+++ b/crates/repl_eval/src/eval.rs
@@ -419,9 +419,10 @@ fn jit_to_ast_help<'a, A: ReplApp<'a>>(
         ),
         LayoutRepr::Struct { field_layouts, .. } => {
             let fields = [Layout::U64, layout];
+            // TODO: no need to intern here
             let layout = env
                 .layout_cache
-                .put_in(Layout::struct_no_name_order(env.arena.alloc(fields)));
+                .put_in_no_semantic(LayoutRepr::struct_(env.arena.alloc(fields)));
 
             let result_stack_size = env.layout_cache.interner.stack_size(layout);
 
@@ -1033,7 +1034,7 @@ fn struct_to_ast<'a, M: ReplAppMemory>(
 
         let struct_layout = env
             .layout_cache
-            .put_in(Layout::struct_no_name_order(inner_layouts));
+            .put_in_no_semantic(LayoutRepr::struct_(inner_layouts));
         let loc_expr = &*arena.alloc(Loc {
             value: addr_to_ast(
                 env,

--- a/crates/repl_eval/src/eval.rs
+++ b/crates/repl_eval/src/eval.rs
@@ -419,12 +419,9 @@ fn jit_to_ast_help<'a, A: ReplApp<'a>>(
         ),
         LayoutRepr::Struct { field_layouts, .. } => {
             let fields = [Layout::U64, layout];
-            // TODO: no need to intern here
-            let layout = env
-                .layout_cache
-                .put_in_no_semantic(LayoutRepr::struct_(env.arena.alloc(fields)));
 
-            let result_stack_size = env.layout_cache.interner.stack_size(layout);
+            let result_stack_size = LayoutRepr::struct_(env.arena.alloc(fields))
+                .stack_size(&env.layout_cache.interner, env.target_info);
 
             let struct_addr_to_ast = |mem: &'a A::Memory, addr: usize| match env
                 .subs

--- a/crates/repl_eval/src/eval.rs
+++ b/crates/repl_eval/src/eval.rs
@@ -11,7 +11,7 @@ use roc_module::symbol::{Interns, ModuleId, Symbol};
 use roc_mono::ir::ProcLayout;
 use roc_mono::layout::{
     self, cmp_fields, union_sorted_tags_pub, Builtin, InLayout, Layout, LayoutCache,
-    LayoutInterner, TLLayoutInterner, UnionLayout, UnionVariant, WrappedVariant,
+    LayoutInterner, LayoutRepr, TLLayoutInterner, UnionLayout, UnionVariant, WrappedVariant,
 };
 use roc_parse::ast::{AssignedField, Collection, Expr, Pattern, StrLiteral};
 use roc_region::all::{Loc, Region};
@@ -353,13 +353,13 @@ fn jit_to_ast_help<'a, A: ReplApp<'a>>(
         };
     }
 
-    let expr = match env.layout_cache.get_in(layout) {
-        Layout::Builtin(Builtin::Bool) => {
+    let expr = match env.layout_cache.get_in(layout).repr {
+        LayoutRepr::Builtin(Builtin::Bool) => {
             app.call_function(main_fn_name, |_mem: &A::Memory, num: bool| {
                 bool_to_ast(env, num, env.subs.get_content_without_compacting(raw_var))
             })
         }
-        Layout::Builtin(Builtin::Int(int_width)) => {
+        LayoutRepr::Builtin(Builtin::Int(int_width)) => {
             use IntWidth::*;
 
             match int_width {
@@ -386,7 +386,7 @@ fn jit_to_ast_help<'a, A: ReplApp<'a>>(
                 I128 => num_helper!(i128),
             }
         }
-        Layout::Builtin(Builtin::Float(float_width)) => {
+        LayoutRepr::Builtin(Builtin::Float(float_width)) => {
             use FloatWidth::*;
 
             match float_width {
@@ -394,8 +394,8 @@ fn jit_to_ast_help<'a, A: ReplApp<'a>>(
                 F64 => num_helper!(f64),
             }
         }
-        Layout::Builtin(Builtin::Decimal) => num_helper!(RocDec),
-        Layout::Builtin(Builtin::Str) => {
+        LayoutRepr::Builtin(Builtin::Decimal) => num_helper!(RocDec),
+        LayoutRepr::Builtin(Builtin::Str) => {
             let body = |mem: &A::Memory, addr| {
                 let string = mem.deref_str(addr);
                 let arena_str = env.arena.alloc_str(string);
@@ -404,7 +404,7 @@ fn jit_to_ast_help<'a, A: ReplApp<'a>>(
 
             app.call_function_returns_roc_str(env.target_info, main_fn_name, body)
         }
-        Layout::Builtin(Builtin::List(elem_layout)) => app.call_function_returns_roc_list(
+        LayoutRepr::Builtin(Builtin::List(elem_layout)) => app.call_function_returns_roc_list(
             main_fn_name,
             |mem: &A::Memory, (addr, len, _cap)| {
                 list_to_ast(
@@ -417,7 +417,7 @@ fn jit_to_ast_help<'a, A: ReplApp<'a>>(
                 )
             },
         ),
-        Layout::Struct { field_layouts, .. } => {
+        LayoutRepr::Struct { field_layouts, .. } => {
             let fields = [Layout::U64, layout];
             let layout = env
                 .layout_cache
@@ -466,7 +466,7 @@ fn jit_to_ast_help<'a, A: ReplApp<'a>>(
                 struct_addr_to_ast,
             )
         }
-        Layout::Union(UnionLayout::NonRecursive(_)) => {
+        LayoutRepr::Union(UnionLayout::NonRecursive(_)) => {
             let size = env.layout_cache.interner.stack_size(layout);
 
             app.call_function_dynamic_size(
@@ -484,10 +484,10 @@ fn jit_to_ast_help<'a, A: ReplApp<'a>>(
                 },
             )
         }
-        Layout::Union(UnionLayout::Recursive(_))
-        | Layout::Union(UnionLayout::NonNullableUnwrapped(_))
-        | Layout::Union(UnionLayout::NullableUnwrapped { .. })
-        | Layout::Union(UnionLayout::NullableWrapped { .. }) => {
+        LayoutRepr::Union(UnionLayout::Recursive(_))
+        | LayoutRepr::Union(UnionLayout::NonNullableUnwrapped(_))
+        | LayoutRepr::Union(UnionLayout::NullableUnwrapped { .. })
+        | LayoutRepr::Union(UnionLayout::NullableWrapped { .. }) => {
             let size = env.layout_cache.interner.stack_size(layout);
 
             app.call_function_dynamic_size(
@@ -505,11 +505,11 @@ fn jit_to_ast_help<'a, A: ReplApp<'a>>(
                 },
             )
         }
-        Layout::RecursivePointer(_) => {
+        LayoutRepr::RecursivePointer(_) => {
             unreachable!("RecursivePointers can only be inside structures")
         }
-        Layout::LambdaSet(_) => OPAQUE_FUNCTION,
-        Layout::Boxed(_) => {
+        LayoutRepr::LambdaSet(_) => OPAQUE_FUNCTION,
+        LayoutRepr::Boxed(_) => {
             let size = env.layout_cache.interner.stack_size(layout);
 
             app.call_function_dynamic_size(main_fn_name, size as usize, |mem: &A::Memory, addr| {
@@ -559,11 +559,11 @@ fn addr_to_ast<'a, M: ReplAppMemory>(
     let (newtype_containers, _alias_content, raw_var) = unroll_newtypes_and_aliases(env, var);
     let raw_content = env.subs.get_content_without_compacting(raw_var);
 
-    let expr = match (raw_content, env.layout_cache.get_in(layout)) {
-        (Content::Structure(FlatType::Func(_, _, _)), _) | (_, Layout::LambdaSet(_)) => {
+    let expr = match (raw_content, env.layout_cache.get_in(layout).repr) {
+        (Content::Structure(FlatType::Func(_, _, _)), _) | (_, LayoutRepr::LambdaSet(_)) => {
             OPAQUE_FUNCTION
         }
-        (_, Layout::Builtin(Builtin::Bool)) => {
+        (_, LayoutRepr::Builtin(Builtin::Bool)) => {
             // TODO: bits are not as expected here.
             // num is always false at the moment.
             let num: u8 = mem.deref_u8(addr);
@@ -572,7 +572,7 @@ fn addr_to_ast<'a, M: ReplAppMemory>(
 
             bool_to_ast(env, num != 0, raw_content)
         }
-        (_, Layout::Builtin(Builtin::Int(int_width))) => {
+        (_, LayoutRepr::Builtin(Builtin::Int(int_width))) => {
             use IntWidth::*;
 
             match int_width {
@@ -594,7 +594,7 @@ fn addr_to_ast<'a, M: ReplAppMemory>(
                 I128 => helper!(deref_i128, i128),
             }
         }
-        (_, Layout::Builtin(Builtin::Float(float_width))) => {
+        (_, LayoutRepr::Builtin(Builtin::Float(float_width))) => {
             use FloatWidth::*;
 
             match float_width {
@@ -602,22 +602,22 @@ fn addr_to_ast<'a, M: ReplAppMemory>(
                 F64 => helper!(deref_f64, f64),
             }
         }
-        (_, Layout::Builtin(Builtin::Decimal)) => {
+        (_, LayoutRepr::Builtin(Builtin::Decimal)) => {
             helper!(deref_dec, RocDec)
         }
-        (_, Layout::Builtin(Builtin::List(elem_layout))) => {
+        (_, LayoutRepr::Builtin(Builtin::List(elem_layout))) => {
             let elem_addr = mem.deref_usize(addr);
             let len = mem.deref_usize(addr + env.target_info.ptr_width() as usize);
             let _cap = mem.deref_usize(addr + 2 * env.target_info.ptr_width() as usize);
 
             list_to_ast(env, mem, elem_addr, len, elem_layout, raw_content)
         }
-        (_, Layout::Builtin(Builtin::Str)) => {
+        (_, LayoutRepr::Builtin(Builtin::Str)) => {
             let string = mem.deref_str(addr);
             let arena_str = env.arena.alloc_str(string);
             Expr::Str(StrLiteral::PlainLine(arena_str))
         }
-        (_, Layout::Struct { field_layouts, .. }) => match raw_content {
+        (_, LayoutRepr::Struct { field_layouts, .. }) => match raw_content {
             Content::Structure(FlatType::Record(fields, _)) => {
                 struct_to_ast(env, mem, addr, *fields)
             }
@@ -644,7 +644,7 @@ fn addr_to_ast<'a, M: ReplAppMemory>(
                 );
             }
         },
-        (_, Layout::RecursivePointer(_)) => match (raw_content, when_recursive) {
+        (_, LayoutRepr::RecursivePointer(_)) => match (raw_content, when_recursive) {
             (
                 Content::RecursionVar {
                     structure,
@@ -667,13 +667,13 @@ fn addr_to_ast<'a, M: ReplAppMemory>(
                 let union_layout = env.layout_cache
                     .from_var(env.arena, *structure, env.subs)
                     .expect("no layout for structure");
-                debug_assert!(matches!(env.layout_cache.get_in(union_layout), Layout::Union(..)));
+                debug_assert!(matches!(env.layout_cache.get_in(union_layout).repr, LayoutRepr::Union(..)));
                 let when_recursive = WhenRecursive::Loop(union_layout);
                 addr_to_ast(env, mem, addr, union_layout, when_recursive, *structure)
             }
             other => unreachable!("Something had a RecursivePointer layout, but instead of being a RecursionVar and having a known recursive layout, I found {:?}", other),
         },
-        (_, Layout::Union(UnionLayout::NonRecursive(union_layouts))) => {
+        (_, LayoutRepr::Union(UnionLayout::NonRecursive(union_layouts))) => {
             let union_layout = UnionLayout::NonRecursive(union_layouts);
 
             let tags = match raw_content {
@@ -708,7 +708,7 @@ fn addr_to_ast<'a, M: ReplAppMemory>(
                 WhenRecursive::Unreachable,
             )
         }
-        (_, Layout::Union(union_layout @ UnionLayout::Recursive(union_layouts))) => {
+        (_, LayoutRepr::Union(union_layout @ UnionLayout::Recursive(union_layouts))) => {
             let (rec_var, tags) = match raw_content {
                 Content::Structure(FlatType::RecursiveTagUnion(rec_var, tags, _)) => {
                     (rec_var, tags)
@@ -747,7 +747,7 @@ fn addr_to_ast<'a, M: ReplAppMemory>(
                 when_recursive,
             )
         }
-        (_, Layout::Union(UnionLayout::NonNullableUnwrapped(_))) => {
+        (_, LayoutRepr::Union(UnionLayout::NonNullableUnwrapped(_))) => {
             let (rec_var, tags) = match unroll_recursion_var(env, raw_content) {
                 Content::Structure(FlatType::RecursiveTagUnion(rec_var, tags, _)) => {
                     (rec_var, tags)
@@ -778,7 +778,7 @@ fn addr_to_ast<'a, M: ReplAppMemory>(
                 when_recursive,
             )
         }
-        (_, Layout::Union(UnionLayout::NullableUnwrapped { .. })) => {
+        (_, LayoutRepr::Union(UnionLayout::NullableUnwrapped { .. })) => {
             let (rec_var, tags) = match unroll_recursion_var(env, raw_content) {
                 Content::Structure(FlatType::RecursiveTagUnion(rec_var, tags, _)) => {
                     (rec_var, tags)
@@ -818,7 +818,7 @@ fn addr_to_ast<'a, M: ReplAppMemory>(
                 )
             }
         }
-        (_, Layout::Union(union_layout @ UnionLayout::NullableWrapped { .. })) => {
+        (_, LayoutRepr::Union(union_layout @ UnionLayout::NullableWrapped { .. })) => {
             let (rec_var, tags) = match unroll_recursion_var(env, raw_content) {
                 Content::Structure(FlatType::RecursiveTagUnion(rec_var, tags, _)) => {
                     (rec_var, tags)
@@ -863,7 +863,7 @@ fn addr_to_ast<'a, M: ReplAppMemory>(
         }
         (
             Content::Structure(FlatType::Apply(Symbol::BOX_BOX_TYPE, args)),
-            Layout::Boxed(inner_layout),
+            LayoutRepr::Boxed(inner_layout),
         ) => {
             debug_assert_eq!(args.len(), 1);
 
@@ -889,7 +889,7 @@ fn addr_to_ast<'a, M: ReplAppMemory>(
 
             Expr::Apply(box_box, box_box_args, CalledVia::Space)
         }
-        (_, Layout::Boxed(_)) => {
+        (_, LayoutRepr::Boxed(_)) => {
             unreachable!("Box layouts can only be behind a `Box.Box` application")
         }
     };


### PR DESCRIPTION
This patch adds the notion of a "semantic layout" to disambiguate types with the same layout but different semantics during code generation. This first patch validates the utility of the new model by eliminating the `field_order_hash` hack on struct fields.

See https://rwx.notion.site/Semantic-memory-layout-representations-139d12b150414e3480dc6c59fe398458

Part of #5354 