### PR TITLE
fix twitter max redirects

### DIFF
--- a/mlc_config.json
+++ b/mlc_config.json
@@ -34,6 +34,9 @@
             "pattern": "https://www.10xeditor.com/"
         },
         {
+            "pattern": "https://www.twitter.com/"
+        },
+        {
             "pattern": "https://www.roc-lang.org/packages/basic-cli/Stdout#line"
         }
     ]


### PR DESCRIPTION
The link checker recently started having problems with twitter links.