### PR TITLE
Last seen join points

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,6 +3,12 @@ test-gen-llvm = "test -p test_gen"
 test-gen-dev = "test -p roc_gen_dev -p test_gen --no-default-features --features gen-dev"
 test-gen-wasm = "test -p roc_gen_wasm -p test_gen --no-default-features --features gen-wasm"
 test-gen-llvm-wasm = "test -p roc_gen_wasm -p test_gen --no-default-features --features gen-llvm-wasm"
+
+nextest-gen-llvm = "nextest run -p test_gen"
+nextest-gen-dev = "nextest run -p roc_gen_dev -p test_gen --no-default-features --features gen-dev"
+nextest-gen-wasm = "nextest run -p roc_gen_wasm -p test_gen --no-default-features --features gen-wasm"
+nextest-gen-llvm-wasm = "nextest run -p roc_gen_wasm -p test_gen --no-default-features --features gen-llvm-wasm"
+
 uitest = "test -p uitest"
 
 [target.wasm32-unknown-unknown]


### PR DESCRIPTION
for symbols captured by a join point, they would be last seen within the join point, and therefore considered dead after the first iteration of the joinpoint. Now such variables are alive for the whole duration of the join point.