### PR TITLE
Consistent handling of ld chained fixup warning in cli/glue tests

### DIFF
--- a/crates/cli/tests/cli_run.rs
+++ b/crates/cli/tests/cli_run.rs
@@ -144,14 +144,8 @@ mod cli_run {
             env,
         );
 
-        let ignorable = "🔨 Rebuilding platform...\n";
-        let stderr = compile_out.stderr.replacen(ignorable, "", 1);
-
-        // for some reason, llvm prints out this warning when targeting windows
-        let ignorable = "warning: ignoring debug info with an invalid version (0) in app\r\n";
-        let stderr = stderr.replacen(ignorable, "", 1);
-        if has_error(&stderr) {
-            panic!("\n___________\nThe roc command:\n\n  {:?}\n\nhad unexpected stderr:\n\n  {}\n___________\n", compile_out.cmd_str, stderr);
+        if has_error(&compile_out.stderr) {
+            panic!("\n___________\nThe roc command:\n\n  {:?}\n\nhad unexpected stderr:\n\n  {}\n___________\n", compile_out.cmd_str, compile_out.stderr);
         }
 
         compile_out

--- a/crates/cli/tests/cli_run.rs
+++ b/crates/cli/tests/cli_run.rs
@@ -10,8 +10,9 @@ extern crate roc_module;
 #[cfg(test)]
 mod cli_run {
     use cli_utils::helpers::{
-        extract_valgrind_errors, file_path_from_root, fixture_file, fixtures_dir, known_bad_file,
-        run_cmd, run_roc, run_with_valgrind, strip_colors, Out, ValgrindError, ValgrindErrorXWhat,
+        extract_valgrind_errors, file_path_from_root, fixture_file, fixtures_dir, has_error,
+        known_bad_file, run_cmd, run_roc, run_with_valgrind, strip_colors, Out, ValgrindError,
+        ValgrindErrorXWhat,
     };
     use const_format::concatcp;
     use indoc::indoc;
@@ -149,13 +150,7 @@ mod cli_run {
         // for some reason, llvm prints out this warning when targeting windows
         let ignorable = "warning: ignoring debug info with an invalid version (0) in app\r\n";
         let stderr = stderr.replacen(ignorable, "", 1);
-
-        let is_reporting_runtime = stderr.starts_with("runtime: ") && stderr.ends_with("ms\n");
-        if !(stderr.is_empty() || is_reporting_runtime
-            // macOS ld reports this warning, but if we remove -undefined dynamic_lookup,
-            // linking stops working properly.
-            || stderr.trim() == "ld: warning: -undefined dynamic_lookup may not work with chained fixups")
-        {
+        if has_error(&stderr) {
             panic!("\n___________\nThe roc command:\n\n  {:?}\n\nhad unexpected stderr:\n\n  {}\n___________\n", compile_out.cmd_str, stderr);
         }
 

--- a/crates/cli_utils/src/helpers.rs
+++ b/crates/cli_utils/src/helpers.rs
@@ -105,13 +105,23 @@ where
 }
 
 pub fn has_error(stderr: &str) -> bool {
-    let is_reporting_runtime = stderr.starts_with("runtime: ") && stderr.ends_with("ms\n");
+    let stderr_stripped = stderr
+        .replacen("🔨 Rebuilding platform...\n", "", 1)
+        // for some reason, llvm prints out this warning when targeting windows
+        .replacen(
+            "warning: ignoring debug info with an invalid version (0) in app\r\n",
+            "",
+            1,
+        );
 
-    let is_clean = stderr.is_empty() ||
+    let is_reporting_runtime =
+        stderr_stripped.starts_with("runtime: ") && stderr_stripped.ends_with("ms\n");
+
+    let is_clean = stderr_stripped.is_empty() ||
         is_reporting_runtime ||
         // macOS ld reports this warning, but if we remove -undefined dynamic_lookup,
         // linking stops working properly.
-        stderr.trim() == "ld: warning: -undefined dynamic_lookup may not work with chained fixups";
+        stderr_stripped.trim() == "ld: warning: -undefined dynamic_lookup may not work with chained fixups";
 
     !is_clean
 }

--- a/crates/cli_utils/src/helpers.rs
+++ b/crates/cli_utils/src/helpers.rs
@@ -104,6 +104,18 @@ where
     run_roc_with_stdin(&path_to_roc_binary(), args, &[])
 }
 
+pub fn has_error(stderr: &str) -> bool {
+    let is_reporting_runtime = stderr.starts_with("runtime: ") && stderr.ends_with("ms\n");
+
+    let is_clean = stderr.is_empty() ||
+        is_reporting_runtime ||
+        // macOS ld reports this warning, but if we remove -undefined dynamic_lookup,
+        // linking stops working properly.
+        stderr.trim() == "ld: warning: -undefined dynamic_lookup may not work with chained fixups";
+
+    !is_clean
+}
+
 pub fn path_to_roc_binary() -> PathBuf {
     path_to_binary(if cfg!(windows) { "roc.exe" } else { "roc" })
 }

--- a/crates/glue/tests/test_glue_cli.rs
+++ b/crates/glue/tests/test_glue_cli.rs
@@ -12,7 +12,7 @@ mod helpers;
 #[cfg(test)]
 mod glue_cli_run {
     use crate::helpers::fixtures_dir;
-    use cli_utils::helpers::{run_glue, run_roc, Out};
+    use cli_utils::helpers::{has_error, run_glue, run_roc, Out};
     use std::fs;
     use std::path::Path;
 
@@ -215,8 +215,7 @@ mod glue_cli_run {
 
         let ignorable = "🔨 Rebuilding platform...\n";
         let stderr = glue_out.stderr.replacen(ignorable, "", 1);
-        let is_reporting_runtime = stderr.starts_with("runtime: ") && stderr.ends_with("ms\n");
-        if !(stderr.is_empty() || is_reporting_runtime) {
+        if has_error(&stderr) {
             panic!("`roc glue` command had unexpected stderr: {}", stderr);
         }
 
@@ -238,8 +237,7 @@ mod glue_cli_run {
 
         let ignorable = "🔨 Rebuilding platform...\n";
         let stderr = compile_out.stderr.replacen(ignorable, "", 1);
-        let is_reporting_runtime = stderr.starts_with("runtime: ") && stderr.ends_with("ms\n");
-        if !(stderr.is_empty() || is_reporting_runtime) {
+        if has_error(&stderr) {
             panic!("`roc` command had unexpected stderr: {}", stderr);
         }
 

--- a/crates/glue/tests/test_glue_cli.rs
+++ b/crates/glue/tests/test_glue_cli.rs
@@ -213,10 +213,11 @@ mod glue_cli_run {
             ),
         );
 
-        let ignorable = "🔨 Rebuilding platform...\n";
-        let stderr = glue_out.stderr.replacen(ignorable, "", 1);
-        if has_error(&stderr) {
-            panic!("`roc glue` command had unexpected stderr: {}", stderr);
+        if has_error(&glue_out.stderr) {
+            panic!(
+                "`roc glue` command had unexpected stderr: {}",
+                glue_out.stderr
+            );
         }
 
         assert!(glue_out.status.success(), "bad status {:?}", glue_out);
@@ -235,10 +236,11 @@ mod glue_cli_run {
             &[],
         );
 
-        let ignorable = "🔨 Rebuilding platform...\n";
-        let stderr = compile_out.stderr.replacen(ignorable, "", 1);
-        if has_error(&stderr) {
-            panic!("`roc` command had unexpected stderr: {}", stderr);
+        if has_error(&compile_out.stderr) {
+            panic!(
+                "`roc` command had unexpected stderr: {}",
+                compile_out.stderr
+            );
         }
 
         assert!(compile_out.status.success(), "bad status {:?}", compile_out);


### PR DESCRIPTION
Context: https://roc.zulipchat.com/#narrow/stream/231634-beginners/topic/Linker.20error.20running.20.60roc.20glue.60.20tests