### PR TITLE
Fix `roc help`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,7 +82,7 @@ bumpalo = { version = "3.12.0", features = ["collections"] }
 bytemuck = { version = "1.13.1", features = ["derive"] }
 capstone = { version = "0.11.0", default-features = false }
 cgmath = "0.18.0"
-clap = { version = "4.2.7", default-features = false, features = ["std", "color", "suggestions"] }
+clap = { version = "4.2.7", default-features = false, features = ["std", "color", "suggestions", "help", "usage", "error-context"] }
 colored = "2.0.0"
 confy = { git = 'https://github.com/rust-cli/confy', features = ["yaml_conf"], default-features = false }
 console_error_panic_hook = "0.1.7"


### PR DESCRIPTION
Fixes omission in the [clap v4 upgrade](https://github.com/roc-lang/roc/pull/5405)

See [relevant bullet](https://github.com/clap-rs/clap/blob/2d4644a8703369d3a3c50dd58c713d48ab1da2ac/CHANGELOG.md?plain=1#LL590C32-L590C67) in changelog.