### PR TITLE
fixed docs index.html overwrite

### DIFF
--- a/crates/docs/src/lib.rs
+++ b/crates/docs/src/lib.rs
@@ -135,7 +135,7 @@ pub fn generate_docs_html(root_file: PathBuf) {
 
     // TODO fix: as is, this overrides an existing index.html
     // Write index.html for package (/index.html)
-    /*{
+    {
         let rendered_package = template_html
             .replace(
                 "<!-- Page title -->",
@@ -156,7 +156,7 @@ pub fn generate_docs_html(root_file: PathBuf) {
                 error
             )
         });
-    }*/
+    }
 
     // Write each package module's index.html file
     for module_docs in loaded_module.docs_by_module.values() {
@@ -196,8 +196,7 @@ fn page_title(package_name: &str, module_name: &str) -> String {
     format!("<title>{module_name} - {package_name}</title>")
 }
 
-// TODO re-enable with let rendered_package = template_html...
-/*fn render_package_index(root_module: &LoadedModule) -> String {
+fn render_package_index(root_module: &LoadedModule) -> String {
     // The list items containing module links
     let mut module_list_buf = String::new();
 
@@ -228,7 +227,7 @@ fn page_title(package_name: &str, module_name: &str) -> String {
     );
 
     index_buf
-}*/
+}
 
 fn render_module_documentation(
     module: &ModuleDocumentation,

--- a/crates/docs/src/static/index.html
+++ b/crates/docs/src/static/index.html
@@ -42,7 +42,7 @@
 </main>
 <footer>
     <p>Made by people who like to make nice things.</p>
-    <p>© 2021</p>
+    <p>© 2023</p>
 </footer>
 </body>
 

--- a/www/build.sh
+++ b/www/build.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# run from root of repo with `./www/build.sh`
+# check www/README.md to run a test server
+
 # https://vaneyckt.io/posts/safer_bash_scripts_with_set_euxo_pipefail/
 set -euxo pipefail
 
@@ -48,8 +51,11 @@ cargo --version
 export ROC_DOCS_URL_ROOT=/builtins
 
 cargo run --release --bin roc-docs crates/compiler/builtins/roc/main.roc
-mv generated-docs/*.* www/build # move all the .js, .css, etc. files to build/
-mv generated-docs/ www/build/builtins # move all the folders to build/builtins/
+mv generated-docs/*.js www/build # move all .js files to build/
+mv generated-docs/*.css www/build
+mv generated-docs/*.svg www/build
+
+mv generated-docs/ www/build/builtins # move all the rest to build/builtins/
 
 # Manually add this tip to all the builtin docs.
 find www/build/builtins -type f -name 'index.html' -exec sed -i 's!</nav>!<div class="builtins-tip"><b>Tip:</b> <a href="/different-names">Some names</a> differ from other languages.</div></nav>!' {} \;
@@ -58,7 +64,7 @@ find www/build/builtins -type f -name 'index.html' -exec sed -i 's!</nav>!<div c
 # cleanup files that could have stayed behind if the script failed
 rm -rf roc_nightly roc_releases.json
 
-# to prevent GitHub from rate limiting netlify servers
+# we use `! [ -v GITHUB_TOKEN_READ_ONLY ];` to check if we're on a netlify server
 if ! [ -v GITHUB_TOKEN_READ_ONLY ]; then
   echo 'Building tutorial.html from tutorial.md...'
   mkdir www/build/tutorial


### PR DESCRIPTION
An index.html was recently added that provided links to all the docs modules, it did not end up in the builtins folder but in the root folder, thereby replacing the home page for roc-lang.org. This PR fixes that.