### PR TITLE
Remove `--` requirement for `roc [FILE]` to allow better messaging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3233,6 +3233,7 @@ dependencies = [
  "cli_utils",
  "const_format",
  "criterion",
+ "distance",
  "errno",
  "indoc",
  "inkwell",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -67,6 +67,7 @@ ven_pretty = { path = "../vendor/pretty" }
 bumpalo.workspace = true
 clap.workspace = true
 const_format.workspace = true
+distance.workspace = true
 errno.workspace = true
 indoc.workspace = true
 inkwell.workspace = true

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -578,15 +578,18 @@ pub fn build(
                     ));
                     // Add some additional hints if run as `roc [FILENAME]`.
                     if matches.subcommand().is_none() {
-                        if let Some(possible_typo) = path.to_str() {
-                            if let Some((nearest_command, _)) =
-                                nearest_match(possible_typo, subcommands)
-                            {
-                                error_lines.push(format!(
-                                    "Did you mean to use the {} subcommand?",
-                                    nearest_command
-                                ));
+                        match path.to_str() {
+                            Some(possible_typo) if !possible_typo.ends_with(".roc") => {
+                                if let Some((nearest_command, _)) =
+                                    nearest_match(possible_typo, subcommands)
+                                {
+                                    error_lines.push(format!(
+                                        "Did you mean to use the {} subcommand?",
+                                        nearest_command
+                                    ));
+                                }
                             }
+                            _ => (),
                         }
                     }
                     error_lines.push("You can run `roc help` to see the list of available subcommands and for more information on how to provide a .roc file.".to_string());

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -566,7 +566,7 @@ pub fn build(
                         expected_file_path_string
                     ));
                     // Add some additional hints if run as `roc [FILENAME]`.
-                    if let None = matches.subcommand() {
+                    if matches.subcommand().is_none() {
                         error_lines.push("Did you misspell a subcommand?".to_string());
                     }
                     error_lines.push("You can run `roc help` to see the list of available subcommands and for more information on how to provide a .roc file.".to_string());

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -530,9 +530,9 @@ pub fn test(matches: &ArgMatches, triple: Triple) -> io::Result<i32> {
     }
 }
 
-// Find the element of `options` with the smallest edit distance to
-// `reference`. Returns a tuple containing the element and the distance, or
-// `None` if the `options` `Vec` is empty.
+/// Find the element of `options` with the smallest edit distance to
+/// `reference`. Returns a tuple containing the element and the distance, or
+/// `None` if the `options` `Vec` is empty.
 fn nearest_match<'a>(reference: &str, options: &'a [String]) -> Option<(&'a String, usize)> {
     options
         .iter()

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -140,14 +140,14 @@ pub fn build_app() -> Command {
         .help("Arguments to pass into the app being run\ne.g. `roc run -- arg1 arg2`")
         .value_parser(value_parser!(OsString))
         .num_args(0..)
-        .allow_hyphen_values(true)
-        .last(true);
+        .allow_hyphen_values(true);
 
     let build_target_values_parser =
         PossibleValuesParser::new(Target::iter().map(Into::<&'static str>::into));
     let app = Command::new("roc")
         .version(concatcp!(VERSION, "\n"))
         .about("Run the given .roc file, if there are no compilation errors.\nYou can use one of the SUBCOMMANDS below to do something else!")
+        .args_conflicts_with_subcommands(true)
         .subcommand(Command::new(CMD_BUILD)
             .about("Build a binary from the given .roc file, but don't run it")
             .arg(flag_optimize.clone())
@@ -214,7 +214,7 @@ pub fn build_app() -> Command {
                     .required(false)
                     .default_value(DEFAULT_ROC_FILENAME)
             )
-            .arg(args_for_app.clone())
+            .arg(args_for_app.clone().last(true))
         )
         .subcommand(Command::new(CMD_REPL)
             .about("Launch the interactive Read Eval Print Loop (REPL)")
@@ -230,7 +230,7 @@ pub fn build_app() -> Command {
             .arg(flag_linker.clone())
             .arg(flag_prebuilt.clone())
             .arg(roc_file_to_run.clone())
-            .arg(args_for_app.clone())
+            .arg(args_for_app.clone().last(true))
         )
         .subcommand(Command::new(CMD_DEV)
             .about("`check` a .roc file, and then run it if there were no errors")
@@ -243,7 +243,7 @@ pub fn build_app() -> Command {
             .arg(flag_linker.clone())
             .arg(flag_prebuilt.clone())
             .arg(roc_file_to_run.clone())
-            .arg(args_for_app.clone())
+            .arg(args_for_app.clone().last(true))
         )
         .subcommand(Command::new(CMD_FORMAT)
             .about("Format a .roc file using standard Roc formatting")
@@ -333,8 +333,8 @@ pub fn build_app() -> Command {
         .arg(flag_time)
         .arg(flag_linker)
         .arg(flag_prebuilt)
-        .arg(roc_file_to_run.required(false))
-        .arg(args_for_app);
+        .arg(roc_file_to_run)
+        .arg(args_for_app.trailing_var_arg(true));
 
     if cfg!(feature = "editor") {
         app.subcommand(
@@ -559,7 +559,20 @@ pub fn build(
                         DEFAULT_ROC_FILENAME
                     )
                 }
-                _ => eprintln!("\nThis file was not found: {}\n\nYou can run `roc help` for more information on how to provide a .roc file.\n", expected_file_path_string),
+                _ => {
+                    let mut error_lines = Vec::new();
+                    error_lines.push(format!(
+                        "This file was not found: {}",
+                        expected_file_path_string
+                    ));
+                    // Add some additional hints if run as `roc [FILENAME]`.
+                    if let None = matches.subcommand() {
+                        error_lines.push("Did you misspell a subcommand?".to_string());
+                    }
+                    error_lines.push("You can run `roc help` to see the list of available subcommands and for more information on how to provide a .roc file.".to_string());
+
+                    eprintln!("\n{}\n", error_lines.join("\n\n"));
+                }
             }
 
             process::exit(1);

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -32,13 +32,19 @@ use roc_cli::build;
 fn main() -> io::Result<()> {
     let _tracing_guards = roc_tracing::setup_tracing!();
 
-    let matches = build_app().get_matches();
+    let app = build_app();
+    let subcommands: Vec<String> = app
+        .get_subcommands()
+        .map(|c| c.get_name().to_owned())
+        .collect();
+    let matches = app.get_matches();
 
     let exit_code = match matches.subcommand() {
         None => {
             if matches.contains_id(ROC_FILE) {
                 build(
                     &matches,
+                    &subcommands,
                     BuildConfig::BuildAndRunIfNoErrors,
                     Triple::host(),
                     RocCacheDir::Persistent(cache::roc_cache_dir().as_path()),
@@ -54,6 +60,7 @@ fn main() -> io::Result<()> {
             if matches.contains_id(ROC_FILE) {
                 build(
                     matches,
+                    &subcommands,
                     BuildConfig::BuildAndRun,
                     Triple::host(),
                     RocCacheDir::Persistent(cache::roc_cache_dir().as_path()),
@@ -78,6 +85,7 @@ fn main() -> io::Result<()> {
             if matches.contains_id(ROC_FILE) {
                 build(
                     matches,
+                    &subcommands,
                     BuildConfig::BuildAndRunIfNoErrors,
                     Triple::host(),
                     RocCacheDir::Persistent(cache::roc_cache_dir().as_path()),
@@ -136,6 +144,7 @@ fn main() -> io::Result<()> {
 
             Ok(build(
                 matches,
+                &subcommands,
                 BuildConfig::BuildOnly,
                 target.to_triple(),
                 RocCacheDir::Persistent(cache::roc_cache_dir().as_path()),


### PR DESCRIPTION
https://github.com/roc-lang/roc/issues/5388

`roc [FILE]` no longer requires `--`, to allow for better error messaging (see `foromat` example below). Subcommands are required up front to avoid ambiguity:

```
$ roc help
Run the given .roc file, if there are no compilation errors.
You can use one of the SUBCOMMANDS below to do something else!

Usage: roc [OPTIONS] [ROC_FILE] [ARGS_FOR_APP]...
       roc <COMMAND>
```

`--` is still required for `roc <COMMAND>`:

```
$ roc help test
Run all top-level `expect`s in a main module and any modules it imports

Usage: roc test [OPTIONS] [ROC_FILE] [-- [ARGS_FOR_APP]...]
```

When `roc [FILE]` errors, we provide a hint about a possible misspelled subcommand:

```
$ roc foromat *

This file was not found: /Users/dlsmith/src/roc/foromat

Did you mean to use the format subcommand?

You can run `roc help` to see the list of available subcommands and for more information on how to provide a .roc file.
```