### PR TITLE
allow lowlevel and match

### DIFF
--- a/crates/compiler/mono/src/drop_specialization.rs
+++ b/crates/compiler/mono/src/drop_specialization.rs
@@ -410,7 +410,7 @@ fn specialize_drops_stmt<'a, 'i>(
                     // let a = index b; dec b
                     // As a might get dropped as a result of the decrement of b.
                     let mut incremented_children = {
-                        let mut todo_children = bumpalo::vec![in &arena; *symbol];
+                        let mut todo_children = bumpalo::vec![in arena; *symbol];
                         let mut incremented_children = MutSet::default();
 
                         while let Some(child) = todo_children.pop() {

--- a/crates/compiler/mono/src/drop_specialization.rs
+++ b/crates/compiler/mono/src/drop_specialization.rs
@@ -290,7 +290,7 @@ fn specialize_drops_stmt<'a, 'i>(
                         .min()
                         .unwrap();
 
-                    // TODO verify this works.
+                    // Update the existing env to match the lowest count.
                     *count = *consumed;
                 }
             }
@@ -321,7 +321,7 @@ fn specialize_drops_stmt<'a, 'i>(
             }
 
             let newer_branches = new_branches
-                .into_iter()
+                .iter()
                 .map(|(label, info, branch, branch_env)| {
                     let new_branch = insert_incs!(branch_env, branch);
 

--- a/crates/compiler/mono/src/layout.rs
+++ b/crates/compiler/mono/src/layout.rs
@@ -2736,9 +2736,16 @@ impl<'a> LayoutRepr<'a> {
 
             RecursivePointer(_) => true,
 
-            Builtin(List(_)) | Builtin(Str) => true,
+            Builtin(builtin ) => match builtin {
+                Int(_) | Float(_) | Bool |  Decimal => false,
+                Str | List(_) => true,
+            } 
+          
+            Boxed(_) => true,
 
-            _ => false,
+            Struct(_) => false,
+
+            LambdaSet(_) => false,
         }
     }
 

--- a/crates/compiler/mono/src/layout.rs
+++ b/crates/compiler/mono/src/layout.rs
@@ -2736,16 +2736,9 @@ impl<'a> LayoutRepr<'a> {
 
             RecursivePointer(_) => true,
 
-            Builtin(builtin) => match builtin {
-                Int(_) | Float(_) | Bool | Decimal => false,
-                Str | List(_) => true,
-            },
+            Builtin(List(_)) | Builtin(Str) => true,
 
-            Boxed(_) => true,
-
-            Struct(_) => false,
-
-            LambdaSet(_) => false,
+            _ => false,
         }
     }
 

--- a/crates/compiler/mono/src/layout.rs
+++ b/crates/compiler/mono/src/layout.rs
@@ -2736,11 +2736,11 @@ impl<'a> LayoutRepr<'a> {
 
             RecursivePointer(_) => true,
 
-            Builtin(builtin ) => match builtin {
-                Int(_) | Float(_) | Bool |  Decimal => false,
+            Builtin(builtin) => match builtin {
+                Int(_) | Float(_) | Bool | Decimal => false,
                 Str | List(_) => true,
-            } 
-          
+            },
+
             Boxed(_) => true,
 
             Struct(_) => false,

--- a/crates/compiler/test_mono/generated/issue_4749.txt
+++ b/crates/compiler/test_mono/generated/issue_4749.txt
@@ -41,8 +41,8 @@ procedure Decode.26 (Decode.105, Decode.106):
 procedure Decode.27 (Decode.107, Decode.108):
     let Decode.122 : {List U8, [C {}, C Str]} = CallByName Decode.26 Decode.107 Decode.108;
     let Decode.110 : List U8 = StructAtIndex 0 Decode.122;
-    let Decode.109 : [C {}, C Str] = StructAtIndex 1 Decode.122;
     inc Decode.110;
+    let Decode.109 : [C {}, C Str] = StructAtIndex 1 Decode.122;
     let Decode.125 : Int1 = CallByName List.1 Decode.110;
     if Decode.125 then
         dec Decode.110;
@@ -532,9 +532,9 @@ procedure Json.68 ():
 procedure Json.69 (Json.1467):
     joinpoint Json.1197 Json.1165:
         let Json.599 : List U8 = StructAtIndex 0 Json.1165;
+        inc Json.599;
         let Json.600 : List U8 = StructAtIndex 1 Json.1165;
         let Json.1315 : U64 = 0i64;
-        inc Json.599;
         let Json.601 : [C {}, C U8] = CallByName List.2 Json.599 Json.1315;
         let Json.1314 : U64 = 1i64;
         inc Json.599;

--- a/crates/compiler/test_mono/generated/issue_4770.txt
+++ b/crates/compiler/test_mono/generated/issue_4770.txt
@@ -140,9 +140,9 @@ procedure Test.1 (Test.77):
                 let Test.51 : [<r>C I64, C List *self] = StructAtIndex 1 Test.6;
                 dec Test.52;
                 let Test.14 : List [<r>C I64, C List *self] = UnionAtIndex (Id 1) (Index 0) Test.51;
+                inc Test.14;
                 joinpoint #Derived_gen.2:
                     let Test.35 : {} = Struct {};
-                    inc Test.14;
                     let Test.33 : List {[<r>C I64, C List *self], [<r>C I64, C List *self]} = CallByName List.23 Test.12 Test.14 Test.35;
                     let Test.34 : {} = Struct {};
                     let Test.29 : Int1 = CallByName List.56 Test.33 Test.34;

--- a/crates/compiler/test_mono/generated/issue_4772_weakened_monomorphic_destructure.txt
+++ b/crates/compiler/test_mono/generated/issue_4772_weakened_monomorphic_destructure.txt
@@ -506,9 +506,9 @@ procedure Json.68 ():
 procedure Json.69 (Json.1467):
     joinpoint Json.1197 Json.1165:
         let Json.599 : List U8 = StructAtIndex 0 Json.1165;
+        inc Json.599;
         let Json.600 : List U8 = StructAtIndex 1 Json.1165;
         let Json.1315 : U64 = 0i64;
-        inc Json.599;
         let Json.601 : [C {}, C U8] = CallByName List.2 Json.599 Json.1315;
         let Json.1314 : U64 = 1i64;
         inc Json.599;

--- a/crates/compiler/test_mono/generated/rb_tree_fbip.txt
+++ b/crates/compiler/test_mono/generated/rb_tree_fbip.txt
@@ -203,8 +203,8 @@ procedure Test.3 (Test.9, Test.10, Test.11):
                             let Test.173 : Int1 = true;
                             let Test.177 : Int1 = lowlevel Eq Test.173 Test.172;
                             if Test.177 then
-                                let #Derived_gen.272 : [<rnu>C *self I64 *self I32 Int1, <null>] = Reset { symbol: Test.16, id: UpdateModeId { id: 242 } };
                                 inc Test.19;
+                                let #Derived_gen.272 : [<rnu>C *self I64 *self I32 Int1, <null>] = Reset { symbol: Test.16, id: UpdateModeId { id: 242 } };
                                 let Test.118 : [<rnu>C *self I64 *self I32 Int1, <null>] = CallByName Test.3 Test.19 Test.10 Test.11;
                                 joinpoint Test.137 #Derived_gen.317 #Derived_gen.318:
                                     let Test.136 : [<rnu>C *self I64 *self I32 Int1, <null>] = UnionAtIndex (Id 1) (Index 0) Test.118;

--- a/crates/compiler/test_mono/generated/specialize_after_match.txt
+++ b/crates/compiler/test_mono/generated/specialize_after_match.txt
@@ -1,0 +1,79 @@
+procedure Num.19 (#Attr.2, #Attr.3):
+    let Num.282 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.282;
+
+procedure Num.24 (#Attr.2, #Attr.3):
+    let Num.283 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
+    ret Num.283;
+
+procedure Test.2 (Test.9, Test.10):
+    let Test.38 : U8 = 1i64;
+    let Test.39 : U8 = GetTagId Test.9;
+    let Test.40 : Int1 = lowlevel Eq Test.38 Test.39;
+    if Test.40 then
+        let Test.20 : U64 = CallByName Test.3 Test.10;
+        ret Test.20;
+    else
+        let Test.11 : Str = UnionAtIndex (Id 0) (Index 0) Test.9;
+        let Test.12 : [<rnu><null>, C Str *self] = UnionAtIndex (Id 0) (Index 1) Test.9;
+        let Test.35 : U8 = 1i64;
+        let Test.36 : U8 = GetTagId Test.10;
+        let Test.37 : Int1 = lowlevel Eq Test.35 Test.36;
+        if Test.37 then
+            let Test.29 : U64 = CallByName Test.3 Test.9;
+            ret Test.29;
+        else
+            joinpoint #Derived_gen.3:
+                let Test.13 : Str = UnionAtIndex (Id 0) (Index 0) Test.10;
+                let Test.14 : [<rnu><null>, C Str *self] = UnionAtIndex (Id 0) (Index 1) Test.10;
+                let Test.33 : U64 = CallByName Test.3 Test.12;
+                let Test.34 : U64 = 1i64;
+                let Test.15 : U64 = CallByName Num.19 Test.33 Test.34;
+                let Test.16 : U64 = CallByName Test.3 Test.10;
+                let Test.31 : Int1 = CallByName Num.24 Test.15 Test.16;
+                if Test.31 then
+                    ret Test.15;
+                else
+                    ret Test.16;
+            in
+            let #Derived_gen.4 : Int1 = lowlevel RefCountIsUnique Test.9;
+            if #Derived_gen.4 then
+                dec Test.11;
+                decref Test.9;
+                jump #Derived_gen.3;
+            else
+                inc Test.12;
+                decref Test.9;
+                jump #Derived_gen.3;
+
+procedure Test.3 (Test.17):
+    let Test.26 : U8 = 1i64;
+    let Test.27 : U8 = GetTagId Test.17;
+    let Test.28 : Int1 = lowlevel Eq Test.26 Test.27;
+    if Test.28 then
+        let Test.22 : U64 = 0i64;
+        ret Test.22;
+    else
+        let Test.18 : [<rnu><null>, C Str *self] = UnionAtIndex (Id 0) (Index 1) Test.17;
+        joinpoint #Derived_gen.0:
+            let Test.24 : U64 = 1i64;
+            let Test.25 : U64 = CallByName Test.3 Test.18;
+            let Test.23 : U64 = CallByName Num.19 Test.24 Test.25;
+            ret Test.23;
+        in
+        let #Derived_gen.2 : Int1 = lowlevel RefCountIsUnique Test.17;
+        if #Derived_gen.2 then
+            let #Derived_gen.1 : Str = UnionAtIndex (Id 0) (Index 0) Test.17;
+            dec #Derived_gen.1;
+            decref Test.17;
+            jump #Derived_gen.0;
+        else
+            inc Test.18;
+            decref Test.17;
+            jump #Derived_gen.0;
+
+procedure Test.0 ():
+    let Test.5 : [<rnu><null>, C Str *self] = TagId(1) ;
+    let Test.6 : [<rnu><null>, C Str *self] = TagId(1) ;
+    let Test.19 : U64 = CallByName Test.2 Test.5 Test.6;
+    ret Test.19;

--- a/crates/compiler/test_mono/src/tests.rs
+++ b/crates/compiler/test_mono/src/tests.rs
@@ -3013,3 +3013,40 @@ fn rb_tree_fbip() {
         "#
     )
 }
+
+#[mono_test]
+fn specialize_after_match() {
+    indoc!(
+        r#"
+        app "test" provides [main] to "./platform"
+
+        main = 
+            listA : LinkedList Str
+            listA = Nil
+            
+            listB : LinkedList Str
+            listB = Nil
+
+            longestLinkedList listA listB
+
+        LinkedList a : [Cons a (LinkedList a), Nil]
+
+        longestLinkedList : LinkedList a, LinkedList a -> Nat
+        longestLinkedList = \listA, listB -> when listA is
+            Nil -> linkedListLength listB
+            Cons a aa -> when listB is
+                Nil -> linkedListLength listA
+                Cons b bb -> 
+                    lengthA = (linkedListLength aa) + 1
+                    lengthB = linkedListLength listB
+                    if lengthA > lengthB
+                        then lengthA
+                        else lengthB
+        
+        linkedListLength : LinkedList a -> Nat
+        linkedListLength = \list -> when list is
+            Nil -> 0
+            Cons _ rest -> 1 + linkedListLength rest
+        "#
+    )
+}


### PR DESCRIPTION
this allows drop specialization to remove increments before a pattern match to drop specialize drops in the pattern match branches.