### PR TITLE
Fix typo in gen-dev for float_add_overflow test

### DIFF
--- a/crates/compiler/test_gen/src/gen_num.rs
+++ b/crates/compiler/test_gen/src/gen_num.rs
@@ -1842,7 +1842,7 @@ fn float_add_checked_fail() {
 }
 
 #[test]
-#[cfg(any(feature = "gen-llvm", feature = "gen-wasm", feature = "gen_dev"))]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm", feature = "gen-dev"))]
 fn float_add_overflow() {
     assert_evals_to!(
         "1.7976931348623157e308 + 1.7976931348623157e308",


### PR DESCRIPTION
Found this simple typo while trying to understand the gen-dev part. Seems like now the test will be run and is ok.