### PR TITLE
Stop using llvm instrinsics that just call libc

### DIFF
--- a/crates/cli/tests/cli_run.rs
+++ b/crates/cli/tests/cli_run.rs
@@ -725,7 +725,7 @@ mod cli_run {
                 Arg::PlainText("81"),
             ],
             &[],
-            "4\n",
+            "4.000000000000001\n",
             UseValgrind::No,
             TestCliCommands::Run,
         )

--- a/crates/compiler/builtins/bitcode/build.zig
+++ b/crates/compiler/builtins/bitcode/build.zig
@@ -17,7 +17,7 @@ pub fn build(b: *Builder) void {
     // Tests
     var main_tests = b.addTest(main_path);
     main_tests.setBuildMode(mode);
-    main_tests.linkSystemLibrary("c");
+    main_tests.linkLibC();
     const test_step = b.step("test", "Run tests");
     test_step.dependOn(&main_tests.step);
 

--- a/crates/compiler/builtins/bitcode/src/main.zig
+++ b/crates/compiler/builtins/bitcode/src/main.zig
@@ -85,8 +85,12 @@ comptime {
         num.exportPow(T, ROC_BUILTINS ++ "." ++ NUM ++ ".pow_int.");
         num.exportDivCeil(T, ROC_BUILTINS ++ "." ++ NUM ++ ".div_ceil.");
 
-        num.exportRoundF32(T, ROC_BUILTINS ++ "." ++ NUM ++ ".round_f32.");
-        num.exportRoundF64(T, ROC_BUILTINS ++ "." ++ NUM ++ ".round_f64.");
+        num.exportRound(f32, T, ROC_BUILTINS ++ "." ++ NUM ++ ".round_f32.");
+        num.exportRound(f64, T, ROC_BUILTINS ++ "." ++ NUM ++ ".round_f64.");
+        num.exportFloor(f32, T, ROC_BUILTINS ++ "." ++ NUM ++ ".floor_f32.");
+        num.exportFloor(f64, T, ROC_BUILTINS ++ "." ++ NUM ++ ".floor_f64.");
+        num.exportCeiling(f32, T, ROC_BUILTINS ++ "." ++ NUM ++ ".ceiling_f32.");
+        num.exportCeiling(f64, T, ROC_BUILTINS ++ "." ++ NUM ++ ".ceiling_f64.");
 
         num.exportAddWithOverflow(T, ROC_BUILTINS ++ "." ++ NUM ++ ".add_with_overflow.");
         num.exportAddOrPanic(T, ROC_BUILTINS ++ "." ++ NUM ++ ".add_or_panic.");
@@ -126,6 +130,8 @@ comptime {
 
         num.exportPow(T, ROC_BUILTINS ++ "." ++ NUM ++ ".pow.");
         num.exportLog(T, ROC_BUILTINS ++ "." ++ NUM ++ ".log.");
+        num.exportFAbs(T, ROC_BUILTINS ++ "." ++ NUM ++ ".fabs.");
+        num.exportSqrt(T, ROC_BUILTINS ++ "." ++ NUM ++ ".sqrt.");
 
         num.exportAddWithOverflow(T, ROC_BUILTINS ++ "." ++ NUM ++ ".add_with_overflow.");
         num.exportSubWithOverflow(T, ROC_BUILTINS ++ "." ++ NUM ++ ".sub_with_overflow.");

--- a/crates/compiler/builtins/bitcode/src/num.zig
+++ b/crates/compiler/builtins/bitcode/src/num.zig
@@ -152,7 +152,7 @@ pub fn exportAtan(comptime T: type, comptime name: []const u8) void {
 pub fn exportSin(comptime T: type, comptime name: []const u8) void {
     comptime var f = struct {
         fn func(input: T) callconv(.C) T {
-            return @sin(input);
+            return math.sin(input);
         }
     }.func;
     @export(f, .{ .name = name ++ @typeName(T), .linkage = .Strong });
@@ -161,7 +161,7 @@ pub fn exportSin(comptime T: type, comptime name: []const u8) void {
 pub fn exportCos(comptime T: type, comptime name: []const u8) void {
     comptime var f = struct {
         fn func(input: T) callconv(.C) T {
-            return @cos(input);
+            return math.cos(input);
         }
     }.func;
     @export(f, .{ .name = name ++ @typeName(T), .linkage = .Strong });
@@ -170,25 +170,52 @@ pub fn exportCos(comptime T: type, comptime name: []const u8) void {
 pub fn exportLog(comptime T: type, comptime name: []const u8) void {
     comptime var f = struct {
         fn func(input: T) callconv(.C) T {
-            return @log(input);
+            return math.ln(input);
         }
     }.func;
     @export(f, .{ .name = name ++ @typeName(T), .linkage = .Strong });
 }
 
-pub fn exportRoundF32(comptime T: type, comptime name: []const u8) void {
+pub fn exportFAbs(comptime T: type, comptime name: []const u8) void {
     comptime var f = struct {
-        fn func(input: f32) callconv(.C) T {
-            return @floatToInt(T, (@round(input)));
+        fn func(input: T) callconv(.C) T {
+            return math.absFloat(input);
         }
     }.func;
     @export(f, .{ .name = name ++ @typeName(T), .linkage = .Strong });
 }
 
-pub fn exportRoundF64(comptime T: type, comptime name: []const u8) void {
+pub fn exportSqrt(comptime T: type, comptime name: []const u8) void {
     comptime var f = struct {
-        fn func(input: f64) callconv(.C) T {
-            return @floatToInt(T, (@round(input)));
+        fn func(input: T) callconv(.C) T {
+            return math.sqrt(input);
+        }
+    }.func;
+    @export(f, .{ .name = name ++ @typeName(T), .linkage = .Strong });
+}
+
+pub fn exportRound(comptime F: type, comptime T: type, comptime name: []const u8) void {
+    comptime var f = struct {
+        fn func(input: F) callconv(.C) T {
+            return @floatToInt(T, (math.round(input)));
+        }
+    }.func;
+    @export(f, .{ .name = name ++ @typeName(T), .linkage = .Strong });
+}
+
+pub fn exportFloor(comptime F: type, comptime T: type, comptime name: []const u8) void {
+    comptime var f = struct {
+        fn func(input: F) callconv(.C) T {
+            return @floatToInt(T, (math.floor(input)));
+        }
+    }.func;
+    @export(f, .{ .name = name ++ @typeName(T), .linkage = .Strong });
+}
+
+pub fn exportCeiling(comptime F: type, comptime T: type, comptime name: []const u8) void {
+    comptime var f = struct {
+        fn func(input: F) callconv(.C) T {
+            return @floatToInt(T, (math.ceil(input)));
         }
     }.func;
     @export(f, .{ .name = name ++ @typeName(T), .linkage = .Strong });

--- a/crates/compiler/builtins/src/bitcode.rs
+++ b/crates/compiler/builtins/src/bitcode.rs
@@ -267,9 +267,15 @@ pub const NUM_IS_INFINITE: IntrinsicName = float_intrinsic!("roc_builtins.num.is
 pub const NUM_IS_FINITE: IntrinsicName = float_intrinsic!("roc_builtins.num.is_finite");
 pub const NUM_LOG: IntrinsicName = float_intrinsic!("roc_builtins.num.log");
 pub const NUM_POW: IntrinsicName = float_intrinsic!("roc_builtins.num.pow");
+pub const NUM_FABS: IntrinsicName = float_intrinsic!("roc_builtins.num.fabs");
+pub const NUM_SQRT: IntrinsicName = float_intrinsic!("roc_builtins.num.sqrt");
 
 pub const NUM_POW_INT: IntrinsicName = int_intrinsic!("roc_builtins.num.pow_int");
 pub const NUM_DIV_CEIL: IntrinsicName = int_intrinsic!("roc_builtins.num.div_ceil");
+pub const NUM_CEILING_F32: IntrinsicName = int_intrinsic!("roc_builtins.num.ceiling_f32");
+pub const NUM_CEILING_F64: IntrinsicName = int_intrinsic!("roc_builtins.num.ceiling_f64");
+pub const NUM_FLOOR_F32: IntrinsicName = int_intrinsic!("roc_builtins.num.floor_f32");
+pub const NUM_FLOOR_F64: IntrinsicName = int_intrinsic!("roc_builtins.num.floor_f64");
 pub const NUM_ROUND_F32: IntrinsicName = int_intrinsic!("roc_builtins.num.round_f32");
 pub const NUM_ROUND_F64: IntrinsicName = int_intrinsic!("roc_builtins.num.round_f64");
 

--- a/crates/compiler/gen_llvm/src/llvm/intrinsics.rs
+++ b/crates/compiler/gen_llvm/src/llvm/intrinsics.rs
@@ -7,11 +7,12 @@ use inkwell::{
 };
 use roc_builtins::{
     bitcode::{FloatWidth, IntWidth, IntrinsicName},
-    float_intrinsic, llvm_int_intrinsic,
+    llvm_int_intrinsic,
 };
 
 use super::build::{add_func, FunctionSpec};
 
+#[allow(dead_code)]
 fn add_float_intrinsic<'ctx, F>(
     ctx: &'ctx Context,
     module: &Module<'ctx>,
@@ -111,18 +112,6 @@ pub(crate) fn add_intrinsics<'ctx>(ctx: &'ctx Context, module: &Module<'ctx>) {
         i8_ptr_type.fn_type(&[], false),
     );
 
-    add_float_intrinsic(ctx, module, &LLVM_LOG, |t| t.fn_type(&[t.into()], false));
-    add_float_intrinsic(ctx, module, &LLVM_POW, |t| {
-        t.fn_type(&[t.into(), t.into()], false)
-    });
-    add_float_intrinsic(ctx, module, &LLVM_FABS, |t| t.fn_type(&[t.into()], false));
-    add_float_intrinsic(ctx, module, &LLVM_SIN, |t| t.fn_type(&[t.into()], false));
-    add_float_intrinsic(ctx, module, &LLVM_COS, |t| t.fn_type(&[t.into()], false));
-    add_float_intrinsic(ctx, module, &LLVM_CEILING, |t| {
-        t.fn_type(&[t.into()], false)
-    });
-    add_float_intrinsic(ctx, module, &LLVM_FLOOR, |t| t.fn_type(&[t.into()], false));
-
     add_int_intrinsic(ctx, module, &LLVM_ADD_WITH_OVERFLOW, |t| {
         let fields = [t.into(), i1_type.into()];
         ctx.struct_type(&fields, false)
@@ -149,17 +138,6 @@ pub(crate) fn add_intrinsics<'ctx>(ctx: &'ctx Context, module: &Module<'ctx>) {
         t.fn_type(&[t.into(), t.into()], false)
     });
 }
-
-pub const LLVM_POW: IntrinsicName = float_intrinsic!("llvm.pow");
-pub const LLVM_FABS: IntrinsicName = float_intrinsic!("llvm.fabs");
-pub static LLVM_SQRT: IntrinsicName = float_intrinsic!("llvm.sqrt");
-pub static LLVM_LOG: IntrinsicName = float_intrinsic!("llvm.log");
-
-pub static LLVM_SIN: IntrinsicName = float_intrinsic!("llvm.sin");
-pub static LLVM_COS: IntrinsicName = float_intrinsic!("llvm.cos");
-pub static LLVM_CEILING: IntrinsicName = float_intrinsic!("llvm.ceil");
-pub static LLVM_FLOOR: IntrinsicName = float_intrinsic!("llvm.floor");
-pub static LLVM_ROUND: IntrinsicName = float_intrinsic!("llvm.round");
 
 pub static LLVM_MEMSET_I64: &str = "llvm.memset.p0i8.i64";
 pub static LLVM_MEMSET_I32: &str = "llvm.memset.p0i8.i32";


### PR DESCRIPTION
Instead we use the zig standard library functions. The zig standard library functions never call libc. They will only use an llvm instrinsic if it does not generate a call to libc.