### PR TITLE
Differentiate generating final IR and dumping it to an object in cgen

### DIFF
--- a/crates/compiler/build/src/program.rs
+++ b/crates/compiler/build/src/program.rs
@@ -34,7 +34,9 @@ pub const DEFAULT_ROC_FILENAME: &str = "main.roc";
 
 #[derive(Debug, Clone, Copy, Default)]
 pub struct CodeGenTiming {
-    pub code_gen: Duration,
+    pub generate_final_ir: Duration,
+    pub code_gen_object: Duration,
+    pub total: Duration,
 }
 
 pub fn report_problems_monomorphized(loaded: &mut MonomorphizedModule) -> Problems {
@@ -144,7 +146,7 @@ fn gen_from_mono_module_llvm<'a>(
     use inkwell::module::Linkage;
     use inkwell::targets::{FileType, RelocMode};
 
-    let code_gen_start = Instant::now();
+    let all_code_gen_start = Instant::now();
 
     // Generate the binary
     let target_info = roc_target::TargetInfo::from(target);
@@ -228,6 +230,7 @@ fn gen_from_mono_module_llvm<'a>(
         EntryPoint::Test => roc_mono::ir::EntryPoint::Expects { symbols: &[] },
     };
 
+    let build_procedures_start = Instant::now();
     roc_gen_llvm::llvm::build::build_procedures(
         &env,
         &mut loaded.layout_interner,
@@ -237,6 +240,10 @@ fn gen_from_mono_module_llvm<'a>(
         Some(&app_ll_file),
         &loaded.glue_layouts,
     );
+
+    // We are now finished building the LLVM IR.
+    let generate_final_ir = all_code_gen_start.elapsed();
+    let code_gen_object_start = Instant::now();
 
     env.dibuilder.finalize();
 
@@ -439,11 +446,16 @@ fn gen_from_mono_module_llvm<'a>(
         }
     };
 
-    let code_gen = code_gen_start.elapsed();
+    let code_gen_object = code_gen_object_start.elapsed();
+    let total = all_code_gen_start.elapsed();
 
     (
         CodeObject::MemoryBuffer(memory_buffer),
-        CodeGenTiming { code_gen },
+        CodeGenTiming {
+            generate_final_ir,
+            code_gen_object,
+            total,
+        },
         ExpectMetadata {
             interns: env.interns,
             layout_interner: loaded.layout_interner,
@@ -503,7 +515,7 @@ fn gen_from_mono_module_dev_wasm32<'a>(
     preprocessed_host_path: &Path,
     wasm_dev_stack_bytes: Option<u32>,
 ) -> GenFromMono<'a> {
-    let code_gen_start = Instant::now();
+    let all_code_gen_start = Instant::now();
     let MonomorphizedModule {
         module_id,
         procedures,
@@ -550,11 +562,18 @@ fn gen_from_mono_module_dev_wasm32<'a>(
         procedures,
     );
 
-    let code_gen = code_gen_start.elapsed();
+    let generate_final_ir = all_code_gen_start.elapsed();
+    let code_gen_object_start = Instant::now();
+    let code_gen_object = code_gen_object_start.elapsed();
+    let total = all_code_gen_start.elapsed();
 
     (
         CodeObject::Vector(final_binary_bytes),
-        CodeGenTiming { code_gen },
+        CodeGenTiming {
+            generate_final_ir,
+            code_gen_object,
+            total,
+        },
         ExpectMetadata {
             interns,
             layout_interner,
@@ -569,7 +588,7 @@ fn gen_from_mono_module_dev_assembly<'a>(
     target: &target_lexicon::Triple,
     backend_mode: AssemblyBackendMode,
 ) -> GenFromMono<'a> {
-    let code_gen_start = Instant::now();
+    let all_code_gen_start = Instant::now();
 
     let lazy_literals = true;
 
@@ -593,15 +612,23 @@ fn gen_from_mono_module_dev_assembly<'a>(
     let module_object =
         roc_gen_dev::build_module(&env, &mut interns, &mut layout_interner, target, procedures);
 
-    let code_gen = code_gen_start.elapsed();
+    let generate_final_ir = all_code_gen_start.elapsed();
+    let code_gen_object_start = Instant::now();
 
     let module_out = module_object
         .write()
         .expect("failed to build output object");
 
+    let code_gen_object = code_gen_object_start.elapsed();
+    let total = all_code_gen_start.elapsed();
+
     (
         CodeObject::Vector(module_out),
-        CodeGenTiming { code_gen },
+        CodeGenTiming {
+            generate_final_ir,
+            code_gen_object,
+            total,
+        },
         ExpectMetadata {
             interns,
             layout_interner,
@@ -919,9 +946,12 @@ fn build_loaded_file<'a>(
 
     report_timing(
         buf,
-        "Generate Assembly from Mono IR",
-        code_gen_timing.code_gen,
+        "Generate final IR from Mono IR",
+        code_gen_timing.generate_final_ir,
     );
+    report_timing(buf, "Generate object", code_gen_timing.code_gen_object);
+    buf.push('\n');
+    report_timing(buf, "Total", code_gen_timing.total);
 
     let compilation_end = compilation_start.elapsed();
     let size = roc_app_bytes.len();

--- a/crates/compiler/build/src/program.rs
+++ b/crates/compiler/build/src/program.rs
@@ -230,7 +230,6 @@ fn gen_from_mono_module_llvm<'a>(
         EntryPoint::Test => roc_mono::ir::EntryPoint::Expects { symbols: &[] },
     };
 
-    let build_procedures_start = Instant::now();
     roc_gen_llvm::llvm::build::build_procedures(
         &env,
         &mut loaded.layout_interner,


### PR DESCRIPTION
So that we can see how much time it takes to build LLVM IR vs run it through LLVM. For the dev backends this is immaterial