### PR TITLE
Various updates for docs generation 

### DIFF
--- a/crates/docs/src/lib.rs
+++ b/crates/docs/src/lib.rs
@@ -934,10 +934,10 @@ fn markdown_to_html(
 
     for event in parser {
         match event {
-            Event::Code(cow_str) => {
-                let highlighted_html =
-                    roc_highlight::highlight_roc_code_inline(cow_str.to_string().as_str());
-                docs_parser.push(Event::Html(CowStr::from(highlighted_html)));
+            Event::Code(code_str) => {
+                let inline_code =
+                    pulldown_cmark::CowStr::from(format!("<code>{}</code>", code_str));
+                docs_parser.push(pulldown_cmark::Event::Html(inline_code));
             }
             Event::End(Link(LinkType::ShortcutUnknown, ref _url, ref _title)) => {
                 // Replace the preceding Text node with a Code node, so it
@@ -954,17 +954,17 @@ fn markdown_to_html(
 
                 docs_parser.push(event);
             }
-            Event::Start(CodeBlock(CodeBlockKind::Fenced(cow_str))) => {
-                in_code_block = Some(cow_str);
+            Event::Start(CodeBlock(CodeBlockKind::Fenced(code_str))) => {
+                in_code_block = Some(code_str);
             }
             Event::End(CodeBlock(_)) => {
                 match in_code_block {
-                    Some(cow_str) => {
-                        if cow_str.contains("unchecked") {
+                    Some(code_str) => {
+                        if code_str.contains("unchecked") {
                             // TODO HANDLE UNCHECKED
                         }
 
-                        if cow_str.contains("repl") {
+                        if code_str.contains("repl") {
                             // TODO HANDLE REPL
                         }
 

--- a/crates/docs/src/static/styles.css
+++ b/crates/docs/src/static/styles.css
@@ -189,6 +189,24 @@ section {
   margin: 72px 0px;
 }
 
+section blockquote {
+  font-style: italic;
+  position: relative;
+  margin-left: 0;
+  margin-right: 0;
+}
+
+section blockquote:before {
+  content: "";
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 2px;
+  height: 100%;
+  background-color: var(--gray);
+}
+
+
 section > *:last-child {
   margin-bottom: 0;
 }


### PR DESCRIPTION
This PR removes docs syntax highlighting for inline code snippets to improve consistency and align with the Tutorial behaviour. Does not affect fenced code blocks which are assumed to be Roc lang and highlighted.

Also a minor change to a variable name `cow_str` to `code_str` to clarify its usage. 

## Before
<img width="902" alt="Screen Shot 2023-06-10 at 14 55 30" src="https://github.com/roc-lang/roc/assets/2679227/b86274e9-fcc2-495c-88fc-fcc4d7252a19">

## After 
<img width="909" alt="Screen Shot 2023-06-10 at 14 57 17" src="https://github.com/roc-lang/roc/assets/2679227/d6fa5775-e74c-4984-a64b-324797b88dfa">

