### PR TITLE
Move old num_mul to num_mul_wrap and use that from num_mul

### DIFF
--- a/crates/compiler/gen_dev/src/generic64/mod.rs
+++ b/crates/compiler/gen_dev/src/generic64/mod.rs
@@ -1263,6 +1263,12 @@ impl<
     }
 
     fn build_num_mul(&mut self, dst: &Symbol, src1: &Symbol, src2: &Symbol, layout: &InLayout<'a>) {
+        // for the time being, `num_mul` is implemented as wrapping multiplication. In roc, the normal
+        // `mul` should panic on overflow, but we just don't do that yet
+        self.build_num_mul_wrap(dst, src1, src2, layout)
+    }
+
+    fn build_num_mul_wrap(&mut self, dst: &Symbol, src1: &Symbol, src2: &Symbol, layout: &InLayout<'a>) {
         use Builtin::Int;
 
         match self.layout_interner.get_repr(*layout) {
@@ -1324,7 +1330,7 @@ impl<
                 let src2_reg = self.storage_manager.load_to_float_reg(&mut self.buf, src2);
                 ASM::mul_freg32_freg32_freg32(&mut self.buf, dst_reg, src1_reg, src2_reg);
             }
-            x => todo!("NumMul: layout, {:?}", x),
+            x => todo!("NumMulWrap: layout, {:?}", x),
         }
     }
 

--- a/crates/compiler/gen_dev/src/generic64/mod.rs
+++ b/crates/compiler/gen_dev/src/generic64/mod.rs
@@ -1268,7 +1268,13 @@ impl<
         self.build_num_mul_wrap(dst, src1, src2, layout)
     }
 
-    fn build_num_mul_wrap(&mut self, dst: &Symbol, src1: &Symbol, src2: &Symbol, layout: &InLayout<'a>) {
+    fn build_num_mul_wrap(
+        &mut self,
+        dst: &Symbol,
+        src1: &Symbol,
+        src2: &Symbol,
+        layout: &InLayout<'a>,
+    ) {
         use Builtin::Int;
 
         match self.layout_interner.get_repr(*layout) {

--- a/crates/compiler/gen_dev/src/lib.rs
+++ b/crates/compiler/gen_dev/src/lib.rs
@@ -960,7 +960,7 @@ trait Backend<'a> {
                 ret_layout,
             ),
             LowLevel::NumMul => self.build_num_mul(sym, &args[0], &args[1], ret_layout),
-            LowLevel::NumMulWrap => self.build_num_mul(sym, &args[0], &args[1], ret_layout),
+            LowLevel::NumMulWrap => self.build_num_mul_wrap(sym, &args[0], &args[1], ret_layout),
             LowLevel::NumDivTruncUnchecked | LowLevel::NumDivFrac => {
                 debug_assert_eq!(
                     2,
@@ -1963,6 +1963,9 @@ trait Backend<'a> {
 
     /// build_num_mul stores `src1 * src2` into dst.
     fn build_num_mul(&mut self, dst: &Symbol, src1: &Symbol, src2: &Symbol, layout: &InLayout<'a>);
+
+    /// build_num_mul_wrap stores `src1 * src2` into dst.
+    fn build_num_mul_wrap(&mut self, dst: &Symbol, src1: &Symbol, src2: &Symbol, layout: &InLayout<'a>);
 
     /// build_num_mul stores `src1 / src2` into dst.
     fn build_num_div(&mut self, dst: &Symbol, src1: &Symbol, src2: &Symbol, layout: &InLayout<'a>);

--- a/crates/compiler/gen_dev/src/lib.rs
+++ b/crates/compiler/gen_dev/src/lib.rs
@@ -1965,7 +1965,13 @@ trait Backend<'a> {
     fn build_num_mul(&mut self, dst: &Symbol, src1: &Symbol, src2: &Symbol, layout: &InLayout<'a>);
 
     /// build_num_mul_wrap stores `src1 * src2` into dst.
-    fn build_num_mul_wrap(&mut self, dst: &Symbol, src1: &Symbol, src2: &Symbol, layout: &InLayout<'a>);
+    fn build_num_mul_wrap(
+        &mut self,
+        dst: &Symbol,
+        src1: &Symbol,
+        src2: &Symbol,
+        layout: &InLayout<'a>,
+    );
 
     /// build_num_mul stores `src1 / src2` into dst.
     fn build_num_div(&mut self, dst: &Symbol, src1: &Symbol, src2: &Symbol, layout: &InLayout<'a>);


### PR DESCRIPTION
### X86 dev backend: NumMulWrap #3797

Current **num_mul** does what **num_mul_wrap** should do. So move code to wrapped and call it from **num_mul**. Also add comment for num_mul that we should panic on overflow.