### PR TITLE
Support fixpoint-fixing under recursion variables

### DIFF
--- a/crates/compiler/debug_flags/src/lib.rs
+++ b/crates/compiler/debug_flags/src/lib.rs
@@ -92,6 +92,9 @@ flags! {
     /// Prints all type mismatches hit during type unification.
     ROC_PRINT_MISMATCHES
 
+    /// Prints all type variables entered for fixpoint-fixing.
+    ROC_PRINT_FIXPOINT_FIXING
+
     /// Verifies that after let-generalization of a def, any rigid variables in the type annotation
     /// of the def are indeed generalized.
     ///

--- a/crates/compiler/uitest/tests/recursive_type/issue_5476.txt
+++ b/crates/compiler/uitest/tests/recursive_type/issue_5476.txt
@@ -1,0 +1,19 @@
+interface Test exposes [main] imports []
+
+Term : [
+    Bar Term,
+    Foo,
+]
+
+f = \list ->
+    when list is
+    #    ^^^^ List ([Bar [Bar a]*, Foo]* as a)
+        [] -> Foo
+        [b] -> b
+        [b, ..] -> Bar (Bar b)
+
+whatever : Term -> Str
+whatever = \_ -> "done"
+
+main = whatever (f [])
+#                  ^^ List ([Bar a, Foo] as a)


### PR DESCRIPTION
Sometimes, we might need to fixpoint-fix a unification like

[ Bar [ Bar <a>, Foo ], Foo ] as <a>  🛠️  [ Bar <b>, Foo ] as <b>

where we hit a comparison between <a> and <b>. In this case, follow each
recursion point independently and see if we can find the chain to the needle
we were searching for.

Closes #5476
