### PR TITLE
Specify target folder in rust example platforms

### DIFF
--- a/examples/cli/cli-platform/.cargo/config.toml
+++ b/examples/cli/cli-platform/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+target-dir = "target"

--- a/examples/cli/false-interpreter/platform/.cargo/config.toml
+++ b/examples/cli/false-interpreter/platform/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+target-dir = "target"

--- a/examples/glue/rust-platform/.cargo/config.toml
+++ b/examples/glue/rust-platform/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+target-dir = "target"

--- a/examples/gui/platform/.cargo/config.toml
+++ b/examples/gui/platform/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+target-dir = "target"

--- a/examples/platform-switching/rust-platform/.cargo/config.toml
+++ b/examples/platform-switching/rust-platform/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+target-dir = "target"

--- a/examples/static-site-gen/platform/.cargo/config.toml
+++ b/examples/static-site-gen/platform/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+target-dir = "target"


### PR DESCRIPTION
The rust platforms in the examples expect a cargo target folder at `target`, leading to roc panicking with the following message if the cargo target folder differs:

```
thread '<unnamed>' panicked at 'I could not find a folder named debug in "cli-platform/target". This may be because the `cargo build` for the platform went wrong.', crates/compiler/build/src/link.rs:828:17
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
thread 'main' panicked at 'Failed to (re)build platform.: Any { .. }', crates/compiler/build/src/program.rs:972:46
```

Solution: Set target folder via `.cargo/config.toml`