### PR TITLE
Update nix_macos_x86_64.yml

### DIFF
--- a/.github/workflows/nix_macos_x86_64.yml
+++ b/.github/workflows/nix_macos_x86_64.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           clean: "true"
 
-      - uses: cachix/install-nix-action@v20
+      - uses: cachix/install-nix-action@v22
 
       - name: execute cli_run tests only, the full tests take too long but are run nightly
         run: nix develop -c cargo test --locked --release -p roc_cli


### PR DESCRIPTION
fixes: `Could not set environment: 150: Operation not permitted while System Integrity Protection is engaged`
see also: https://github.com/cachix/install-nix-action/issues/183