### PR TITLE
Add bitwiseNot to Num module

### DIFF
--- a/crates/compiler/builtins/roc/Num.roc
+++ b/crates/compiler/builtins/roc/Num.roc
@@ -976,10 +976,21 @@ remChecked = \a, b ->
 
 isMultipleOf : Int a, Int a -> Bool
 
+## Does a "bitwise and". Each bit of the output is 1 if the corresponding bit
+## of x AND of y is 1, otherwise it's 0.
 bitwiseAnd : Int a, Int a -> Int a
+
+## Does a "bitwise or". Each bit of the output is 0 if the corresponding bit
+## of x AND of y is 0, otherwise it's 1.
 bitwiseXor : Int a, Int a -> Int a
+
+## Does a "bitwise exclusive or". Each bit of the output is the same as the
+## corresponding bit in x if that bit in y is 0, and it's the complement of
+## the bit in x if that bit in y is 1.
 bitwiseOr : Int a, Int a -> Int a
 
+## Returns the complement of x - the number you get by switching each 1 for a
+## 0 and each 0 for a 1. This is the same as -x - 1.
 bitwiseNot : Int a -> Int a
 bitwiseNot = \n ->
     bitwiseXor n (subWrap 0 1)

--- a/crates/compiler/builtins/roc/Num.roc
+++ b/crates/compiler/builtins/roc/Num.roc
@@ -980,13 +980,13 @@ isMultipleOf : Int a, Int a -> Bool
 ## of x AND of y is 1, otherwise it's 0.
 bitwiseAnd : Int a, Int a -> Int a
 
-## Does a "bitwise or". Each bit of the output is 0 if the corresponding bit
-## of x AND of y is 0, otherwise it's 1.
-bitwiseXor : Int a, Int a -> Int a
-
 ## Does a "bitwise exclusive or". Each bit of the output is the same as the
 ## corresponding bit in x if that bit in y is 0, and it's the complement of
 ## the bit in x if that bit in y is 1.
+bitwiseXor : Int a, Int a -> Int a
+
+## Does a "bitwise or". Each bit of the output is 0 if the corresponding bit
+## of x OR of y is 0, otherwise it's 1.
 bitwiseOr : Int a, Int a -> Int a
 
 ## Returns the complement of x - the number you get by switching each 1 for a

--- a/crates/compiler/builtins/roc/Num.roc
+++ b/crates/compiler/builtins/roc/Num.roc
@@ -86,6 +86,7 @@ interface Num
         bitwiseAnd,
         bitwiseXor,
         bitwiseOr,
+        bitwiseNot,
         shiftLeftBy,
         shiftRightBy,
         shiftRightZfBy,
@@ -978,6 +979,10 @@ isMultipleOf : Int a, Int a -> Bool
 bitwiseAnd : Int a, Int a -> Int a
 bitwiseXor : Int a, Int a -> Int a
 bitwiseOr : Int a, Int a -> Int a
+
+bitwiseNot : Int a -> Int a
+bitwiseNot = \n ->
+    bitwiseXor n (subWrap 0 1)
 
 ## Bitwise left shift of a number by another
 ##

--- a/crates/compiler/module/src/symbol.rs
+++ b/crates/compiler/module/src/symbol.rs
@@ -1267,6 +1267,7 @@ define_builtins! {
         161 NUM_E: "e"
         162 NUM_PI: "pi"
         163 NUM_TAU: "tau"
+        164 NUM_BITWISE_NOT: "bitwiseNot"
     }
     4 BOOL: "Bool" => {
         0 BOOL_BOOL: "Bool" exposed_type=true // the Bool.Bool type alias

--- a/crates/compiler/test_mono/generated/anonymous_closure_in_polymorphic_expression_issue_4717.txt
+++ b/crates/compiler/test_mono/generated/anonymous_closure_in_polymorphic_expression_issue_4717.txt
@@ -86,16 +86,16 @@ procedure List.93 (List.436, List.437, List.438):
     ret List.542;
 
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.292 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.292;
+    let Num.294 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.294;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.293 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.293;
+    let Num.295 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.295;
 
 procedure Num.77 (#Attr.2, #Attr.3):
-    let Num.291 : U64 = lowlevel NumSubSaturated #Attr.2 #Attr.3;
-    ret Num.291;
+    let Num.293 : U64 = lowlevel NumSubSaturated #Attr.2 #Attr.3;
+    ret Num.293;
 
 procedure Test.1 (Test.2):
     let Test.13 : U64 = 0i64;

--- a/crates/compiler/test_mono/generated/binary_tree_fbip.txt
+++ b/crates/compiler/test_mono/generated/binary_tree_fbip.txt
@@ -1,6 +1,6 @@
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.290 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.290;
+    let Num.292 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.292;
 
 procedure Test.4 (Test.27):
     let Test.39 : [<rnu>C [<rnu><null>, C *self *self] *self, <null>] = TagId(0) ;

--- a/crates/compiler/test_mono/generated/choose_correct_recursion_var_under_record.txt
+++ b/crates/compiler/test_mono/generated/choose_correct_recursion_var_under_record.txt
@@ -47,8 +47,8 @@ procedure List.9 (List.293):
         ret List.523;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.290 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.290;
+    let Num.292 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.292;
 
 procedure Result.5 (Result.12, Result.13):
     let Result.39 : U8 = 1i64;

--- a/crates/compiler/test_mono/generated/choose_i128_layout.txt
+++ b/crates/compiler/test_mono/generated/choose_i128_layout.txt
@@ -1,6 +1,6 @@
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.291 : I128 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.291;
+    let Num.293 : I128 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.293;
 
 procedure Test.0 ():
     let Test.6 : I128 = 18446744073709551616i64;

--- a/crates/compiler/test_mono/generated/choose_u128_layout.txt
+++ b/crates/compiler/test_mono/generated/choose_u128_layout.txt
@@ -1,6 +1,6 @@
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.290 : U128 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.290;
+    let Num.292 : U128 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.292;
 
 procedure Test.0 ():
     let Test.2 : U128 = 170141183460469231731687303715884105728u128;

--- a/crates/compiler/test_mono/generated/choose_u64_layout.txt
+++ b/crates/compiler/test_mono/generated/choose_u64_layout.txt
@@ -1,6 +1,6 @@
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.290 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.290;
+    let Num.292 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.292;
 
 procedure Test.0 ():
     let Test.2 : U64 = 9999999999999999999i64;

--- a/crates/compiler/test_mono/generated/compose_recursive_lambda_set_productive_nullable_wrapped.txt
+++ b/crates/compiler/test_mono/generated/compose_recursive_lambda_set_productive_nullable_wrapped.txt
@@ -40,12 +40,12 @@ procedure List.93 (List.436, List.437, List.438):
     ret List.524;
 
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.290 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.290;
+    let Num.292 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.292;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.291 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.291;
+    let Num.293 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.293;
 
 procedure Str.3 (#Attr.2, #Attr.3):
     let Str.300 : Str = lowlevel StrConcat #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/dict.txt
+++ b/crates/compiler/test_mono/generated/dict.txt
@@ -79,12 +79,12 @@ procedure List.83 (List.553, List.554, List.555):
     jump List.535 List.553 List.554 List.555;
 
 procedure Num.20 (#Attr.2, #Attr.3):
-    let Num.291 : U64 = lowlevel NumSub #Attr.2 #Attr.3;
-    ret Num.291;
+    let Num.293 : U64 = lowlevel NumSub #Attr.2 #Attr.3;
+    ret Num.293;
 
 procedure Num.24 (#Attr.2, #Attr.3):
-    let Num.293 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
-    ret Num.293;
+    let Num.295 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
+    ret Num.295;
 
 procedure Test.0 ():
     let Test.3 : {} = Struct {};

--- a/crates/compiler/test_mono/generated/empty_list_of_function_type.txt
+++ b/crates/compiler/test_mono/generated/empty_list_of_function_type.txt
@@ -25,8 +25,8 @@ procedure List.66 (#Attr.2, #Attr.3):
     ret List.526;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.290 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.290;
+    let Num.292 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.292;
 
 procedure Test.2 (Test.5):
     dec Test.5;

--- a/crates/compiler/test_mono/generated/encode_derived_nested_record_string.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_nested_record_string.txt
@@ -333,32 +333,32 @@ procedure List.93 (List.436, List.437, List.438):
     ret List.753;
 
 procedure Num.127 (#Attr.2):
-    let Num.314 : U8 = lowlevel NumIntCast #Attr.2;
-    ret Num.314;
+    let Num.316 : U8 = lowlevel NumIntCast #Attr.2;
+    ret Num.316;
 
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.323 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.323;
+    let Num.325 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.325;
 
 procedure Num.20 (#Attr.2, #Attr.3):
-    let Num.327 : U64 = lowlevel NumSub #Attr.2 #Attr.3;
-    ret Num.327;
+    let Num.329 : U64 = lowlevel NumSub #Attr.2 #Attr.3;
+    ret Num.329;
 
 procedure Num.21 (#Attr.2, #Attr.3):
-    let Num.320 : U64 = lowlevel NumMul #Attr.2 #Attr.3;
-    ret Num.320;
+    let Num.322 : U64 = lowlevel NumMul #Attr.2 #Attr.3;
+    ret Num.322;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.326 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.326;
-
-procedure Num.24 (#Attr.2, #Attr.3):
-    let Num.328 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
+    let Num.328 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
     ret Num.328;
 
+procedure Num.24 (#Attr.2, #Attr.3):
+    let Num.330 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
+    ret Num.330;
+
 procedure Num.94 (#Attr.2, #Attr.3):
-    let Num.319 : U64 = lowlevel NumDivCeilUnchecked #Attr.2 #Attr.3;
-    ret Num.319;
+    let Num.321 : U64 = lowlevel NumDivCeilUnchecked #Attr.2 #Attr.3;
+    ret Num.321;
 
 procedure Str.12 (#Attr.2):
     let Str.324 : List U8 = lowlevel StrToUtf8 #Attr.2;

--- a/crates/compiler/test_mono/generated/encode_derived_record_one_field_string.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_record_one_field_string.txt
@@ -268,32 +268,32 @@ procedure List.93 (List.436, List.437, List.438):
     ret List.645;
 
 procedure Num.127 (#Attr.2):
-    let Num.295 : U8 = lowlevel NumIntCast #Attr.2;
-    ret Num.295;
+    let Num.297 : U8 = lowlevel NumIntCast #Attr.2;
+    ret Num.297;
 
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.304 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.304;
+    let Num.306 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.306;
 
 procedure Num.20 (#Attr.2, #Attr.3):
-    let Num.308 : U64 = lowlevel NumSub #Attr.2 #Attr.3;
-    ret Num.308;
+    let Num.310 : U64 = lowlevel NumSub #Attr.2 #Attr.3;
+    ret Num.310;
 
 procedure Num.21 (#Attr.2, #Attr.3):
-    let Num.301 : U64 = lowlevel NumMul #Attr.2 #Attr.3;
-    ret Num.301;
+    let Num.303 : U64 = lowlevel NumMul #Attr.2 #Attr.3;
+    ret Num.303;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.307 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.307;
-
-procedure Num.24 (#Attr.2, #Attr.3):
-    let Num.309 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
+    let Num.309 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
     ret Num.309;
 
+procedure Num.24 (#Attr.2, #Attr.3):
+    let Num.311 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
+    ret Num.311;
+
 procedure Num.94 (#Attr.2, #Attr.3):
-    let Num.300 : U64 = lowlevel NumDivCeilUnchecked #Attr.2 #Attr.3;
-    ret Num.300;
+    let Num.302 : U64 = lowlevel NumDivCeilUnchecked #Attr.2 #Attr.3;
+    ret Num.302;
 
 procedure Str.12 (#Attr.2):
     let Str.313 : List U8 = lowlevel StrToUtf8 #Attr.2;

--- a/crates/compiler/test_mono/generated/encode_derived_record_two_field_strings.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_record_two_field_strings.txt
@@ -275,32 +275,32 @@ procedure List.93 (List.436, List.437, List.438):
     ret List.645;
 
 procedure Num.127 (#Attr.2):
-    let Num.295 : U8 = lowlevel NumIntCast #Attr.2;
-    ret Num.295;
+    let Num.297 : U8 = lowlevel NumIntCast #Attr.2;
+    ret Num.297;
 
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.304 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.304;
+    let Num.306 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.306;
 
 procedure Num.20 (#Attr.2, #Attr.3):
-    let Num.308 : U64 = lowlevel NumSub #Attr.2 #Attr.3;
-    ret Num.308;
+    let Num.310 : U64 = lowlevel NumSub #Attr.2 #Attr.3;
+    ret Num.310;
 
 procedure Num.21 (#Attr.2, #Attr.3):
-    let Num.301 : U64 = lowlevel NumMul #Attr.2 #Attr.3;
-    ret Num.301;
+    let Num.303 : U64 = lowlevel NumMul #Attr.2 #Attr.3;
+    ret Num.303;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.307 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.307;
-
-procedure Num.24 (#Attr.2, #Attr.3):
-    let Num.309 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
+    let Num.309 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
     ret Num.309;
 
+procedure Num.24 (#Attr.2, #Attr.3):
+    let Num.311 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
+    ret Num.311;
+
 procedure Num.94 (#Attr.2, #Attr.3):
-    let Num.300 : U64 = lowlevel NumDivCeilUnchecked #Attr.2 #Attr.3;
-    ret Num.300;
+    let Num.302 : U64 = lowlevel NumDivCeilUnchecked #Attr.2 #Attr.3;
+    ret Num.302;
 
 procedure Str.12 (#Attr.2):
     let Str.313 : List U8 = lowlevel StrToUtf8 #Attr.2;

--- a/crates/compiler/test_mono/generated/encode_derived_string.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_string.txt
@@ -142,28 +142,28 @@ procedure List.93 (List.436, List.437, List.438):
     ret List.576;
 
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.295 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.295;
-
-procedure Num.20 (#Attr.2, #Attr.3):
-    let Num.298 : U64 = lowlevel NumSub #Attr.2 #Attr.3;
-    ret Num.298;
-
-procedure Num.21 (#Attr.2, #Attr.3):
-    let Num.293 : U64 = lowlevel NumMul #Attr.2 #Attr.3;
-    ret Num.293;
-
-procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.297 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    let Num.297 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
     ret Num.297;
 
-procedure Num.24 (#Attr.2, #Attr.3):
-    let Num.299 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
+procedure Num.20 (#Attr.2, #Attr.3):
+    let Num.300 : U64 = lowlevel NumSub #Attr.2 #Attr.3;
+    ret Num.300;
+
+procedure Num.21 (#Attr.2, #Attr.3):
+    let Num.295 : U64 = lowlevel NumMul #Attr.2 #Attr.3;
+    ret Num.295;
+
+procedure Num.22 (#Attr.2, #Attr.3):
+    let Num.299 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
     ret Num.299;
 
+procedure Num.24 (#Attr.2, #Attr.3):
+    let Num.301 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
+    ret Num.301;
+
 procedure Num.94 (#Attr.2, #Attr.3):
-    let Num.292 : U64 = lowlevel NumDivCeilUnchecked #Attr.2 #Attr.3;
-    ret Num.292;
+    let Num.294 : U64 = lowlevel NumDivCeilUnchecked #Attr.2 #Attr.3;
+    ret Num.294;
 
 procedure Str.12 (#Attr.2):
     let Str.312 : List U8 = lowlevel StrToUtf8 #Attr.2;

--- a/crates/compiler/test_mono/generated/encode_derived_tag_one_field_string.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_tag_one_field_string.txt
@@ -223,32 +223,32 @@ procedure List.93 (List.436, List.437, List.438):
     ret List.625;
 
 procedure Num.127 (#Attr.2):
-    let Num.297 : U8 = lowlevel NumIntCast #Attr.2;
-    ret Num.297;
+    let Num.299 : U8 = lowlevel NumIntCast #Attr.2;
+    ret Num.299;
 
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.306 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.306;
+    let Num.308 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.308;
 
 procedure Num.20 (#Attr.2, #Attr.3):
-    let Num.310 : U64 = lowlevel NumSub #Attr.2 #Attr.3;
-    ret Num.310;
+    let Num.312 : U64 = lowlevel NumSub #Attr.2 #Attr.3;
+    ret Num.312;
 
 procedure Num.21 (#Attr.2, #Attr.3):
-    let Num.303 : U64 = lowlevel NumMul #Attr.2 #Attr.3;
-    ret Num.303;
+    let Num.305 : U64 = lowlevel NumMul #Attr.2 #Attr.3;
+    ret Num.305;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.309 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.309;
-
-procedure Num.24 (#Attr.2, #Attr.3):
-    let Num.311 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
+    let Num.311 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
     ret Num.311;
 
+procedure Num.24 (#Attr.2, #Attr.3):
+    let Num.313 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
+    ret Num.313;
+
 procedure Num.94 (#Attr.2, #Attr.3):
-    let Num.302 : U64 = lowlevel NumDivCeilUnchecked #Attr.2 #Attr.3;
-    ret Num.302;
+    let Num.304 : U64 = lowlevel NumDivCeilUnchecked #Attr.2 #Attr.3;
+    ret Num.304;
 
 procedure Str.12 (#Attr.2):
     let Str.313 : List U8 = lowlevel StrToUtf8 #Attr.2;

--- a/crates/compiler/test_mono/generated/encode_derived_tag_two_payloads_string.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_tag_two_payloads_string.txt
@@ -226,32 +226,32 @@ procedure List.93 (List.436, List.437, List.438):
     ret List.625;
 
 procedure Num.127 (#Attr.2):
-    let Num.297 : U8 = lowlevel NumIntCast #Attr.2;
-    ret Num.297;
+    let Num.299 : U8 = lowlevel NumIntCast #Attr.2;
+    ret Num.299;
 
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.306 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.306;
+    let Num.308 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.308;
 
 procedure Num.20 (#Attr.2, #Attr.3):
-    let Num.310 : U64 = lowlevel NumSub #Attr.2 #Attr.3;
-    ret Num.310;
+    let Num.312 : U64 = lowlevel NumSub #Attr.2 #Attr.3;
+    ret Num.312;
 
 procedure Num.21 (#Attr.2, #Attr.3):
-    let Num.303 : U64 = lowlevel NumMul #Attr.2 #Attr.3;
-    ret Num.303;
+    let Num.305 : U64 = lowlevel NumMul #Attr.2 #Attr.3;
+    ret Num.305;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.309 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.309;
-
-procedure Num.24 (#Attr.2, #Attr.3):
-    let Num.311 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
+    let Num.311 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
     ret Num.311;
 
+procedure Num.24 (#Attr.2, #Attr.3):
+    let Num.313 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
+    ret Num.313;
+
 procedure Num.94 (#Attr.2, #Attr.3):
-    let Num.302 : U64 = lowlevel NumDivCeilUnchecked #Attr.2 #Attr.3;
-    ret Num.302;
+    let Num.304 : U64 = lowlevel NumDivCeilUnchecked #Attr.2 #Attr.3;
+    ret Num.304;
 
 procedure Str.12 (#Attr.2):
     let Str.313 : List U8 = lowlevel StrToUtf8 #Attr.2;

--- a/crates/compiler/test_mono/generated/factorial.txt
+++ b/crates/compiler/test_mono/generated/factorial.txt
@@ -1,10 +1,10 @@
 procedure Num.20 (#Attr.2, #Attr.3):
-    let Num.291 : I64 = lowlevel NumSub #Attr.2 #Attr.3;
-    ret Num.291;
+    let Num.293 : I64 = lowlevel NumSub #Attr.2 #Attr.3;
+    ret Num.293;
 
 procedure Num.21 (#Attr.2, #Attr.3):
-    let Num.290 : I64 = lowlevel NumMul #Attr.2 #Attr.3;
-    ret Num.290;
+    let Num.292 : I64 = lowlevel NumMul #Attr.2 #Attr.3;
+    ret Num.292;
 
 procedure Test.1 (Test.15, Test.16):
     joinpoint Test.7 Test.2 Test.3:

--- a/crates/compiler/test_mono/generated/function_specialization_information_in_lambda_set_thunk.txt
+++ b/crates/compiler/test_mono/generated/function_specialization_information_in_lambda_set_thunk.txt
@@ -1,6 +1,6 @@
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.290 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.290;
+    let Num.292 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.292;
 
 procedure Test.1 (Test.8):
     let Test.3 : I64 = 10i64;

--- a/crates/compiler/test_mono/generated/function_specialization_information_in_lambda_set_thunk_independent_defs.txt
+++ b/crates/compiler/test_mono/generated/function_specialization_information_in_lambda_set_thunk_independent_defs.txt
@@ -1,6 +1,6 @@
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.291 : U8 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.291;
+    let Num.293 : U8 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.293;
 
 procedure Test.1 (Test.9):
     let Test.4 : U8 = 10i64;

--- a/crates/compiler/test_mono/generated/inline_return_joinpoints_in_bool_lambda_set.txt
+++ b/crates/compiler/test_mono/generated/inline_return_joinpoints_in_bool_lambda_set.txt
@@ -3,8 +3,8 @@ procedure Bool.1 ():
     ret Bool.23;
 
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.290 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.290;
+    let Num.292 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.292;
 
 procedure Test.3 (Test.4):
     ret Test.4;

--- a/crates/compiler/test_mono/generated/inline_return_joinpoints_in_enum_lambda_set.txt
+++ b/crates/compiler/test_mono/generated/inline_return_joinpoints_in_enum_lambda_set.txt
@@ -1,6 +1,6 @@
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.292 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.292;
+    let Num.294 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.294;
 
 procedure Test.2 (Test.3):
     switch Test.3:

--- a/crates/compiler/test_mono/generated/inline_return_joinpoints_in_union_lambda_set.txt
+++ b/crates/compiler/test_mono/generated/inline_return_joinpoints_in_union_lambda_set.txt
@@ -1,6 +1,6 @@
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.291 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.291;
+    let Num.293 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.293;
 
 procedure Test.2 (Test.3, Test.1):
     let Test.17 : Int1 = false;

--- a/crates/compiler/test_mono/generated/ir_int_add.txt
+++ b/crates/compiler/test_mono/generated/ir_int_add.txt
@@ -3,8 +3,8 @@ procedure List.6 (#Attr.2):
     ret List.521;
 
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.292 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.292;
+    let Num.294 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.294;
 
 procedure Test.0 ():
     let Test.1 : List I64 = Array [1i64, 2i64];

--- a/crates/compiler/test_mono/generated/ir_plus.txt
+++ b/crates/compiler/test_mono/generated/ir_plus.txt
@@ -1,6 +1,6 @@
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.290 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.290;
+    let Num.292 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.292;
 
 procedure Test.0 ():
     let Test.2 : I64 = 1i64;

--- a/crates/compiler/test_mono/generated/ir_round.txt
+++ b/crates/compiler/test_mono/generated/ir_round.txt
@@ -1,6 +1,6 @@
 procedure Num.45 (#Attr.2):
-    let Num.290 : I64 = lowlevel NumRound #Attr.2;
-    ret Num.290;
+    let Num.292 : I64 = lowlevel NumRound #Attr.2;
+    ret Num.292;
 
 procedure Test.0 ():
     let Test.2 : Float64 = 3.6f64;

--- a/crates/compiler/test_mono/generated/ir_two_defs.txt
+++ b/crates/compiler/test_mono/generated/ir_two_defs.txt
@@ -1,6 +1,6 @@
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.290 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.290;
+    let Num.292 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.292;
 
 procedure Test.0 ():
     let Test.1 : I64 = 3i64;

--- a/crates/compiler/test_mono/generated/ir_when_idiv.txt
+++ b/crates/compiler/test_mono/generated/ir_when_idiv.txt
@@ -1,22 +1,22 @@
 procedure Num.30 (#Attr.2):
-    let Num.297 : I64 = 0i64;
-    let Num.296 : Int1 = lowlevel Eq #Attr.2 Num.297;
-    ret Num.296;
+    let Num.299 : I64 = 0i64;
+    let Num.298 : Int1 = lowlevel Eq #Attr.2 Num.299;
+    ret Num.298;
 
 procedure Num.39 (#Attr.2, #Attr.3):
-    let Num.292 : I64 = lowlevel NumDivTruncUnchecked #Attr.2 #Attr.3;
-    ret Num.292;
+    let Num.294 : I64 = lowlevel NumDivTruncUnchecked #Attr.2 #Attr.3;
+    ret Num.294;
 
-procedure Num.40 (Num.262, Num.263):
-    let Num.293 : Int1 = CallByName Num.30 Num.263;
-    if Num.293 then
-        let Num.295 : {} = Struct {};
-        let Num.294 : [C {}, C I64] = TagId(0) Num.295;
-        ret Num.294;
+procedure Num.40 (Num.263, Num.264):
+    let Num.295 : Int1 = CallByName Num.30 Num.264;
+    if Num.295 then
+        let Num.297 : {} = Struct {};
+        let Num.296 : [C {}, C I64] = TagId(0) Num.297;
+        ret Num.296;
     else
-        let Num.291 : I64 = CallByName Num.39 Num.262 Num.263;
-        let Num.290 : [C {}, C I64] = TagId(1) Num.291;
-        ret Num.290;
+        let Num.293 : I64 = CallByName Num.39 Num.263 Num.264;
+        let Num.292 : [C {}, C I64] = TagId(1) Num.293;
+        ret Num.292;
 
 procedure Test.0 ():
     let Test.8 : I64 = 1000i64;

--- a/crates/compiler/test_mono/generated/ir_when_just.txt
+++ b/crates/compiler/test_mono/generated/ir_when_just.txt
@@ -1,6 +1,6 @@
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.290 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.290;
+    let Num.292 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.292;
 
 procedure Test.0 ():
     let Test.10 : I64 = 41i64;

--- a/crates/compiler/test_mono/generated/issue_2583_specialize_errors_behind_unified_branches.txt
+++ b/crates/compiler/test_mono/generated/issue_2583_specialize_errors_behind_unified_branches.txt
@@ -44,8 +44,8 @@ procedure List.9 (List.293):
         ret List.523;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.290 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.290;
+    let Num.292 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.292;
 
 procedure Str.27 (Str.99):
     let Str.298 : [C Int1, C I64] = CallByName Str.72 Str.99;

--- a/crates/compiler/test_mono/generated/issue_4749.txt
+++ b/crates/compiler/test_mono/generated/issue_4749.txt
@@ -196,40 +196,40 @@ procedure List.93 (List.436, List.437, List.438):
     ret List.598;
 
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.293 : U8 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.293;
+    let Num.295 : U8 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.295;
 
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.343 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.343;
+    let Num.345 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.345;
 
 procedure Num.20 (#Attr.2, #Attr.3):
-    let Num.305 : U8 = lowlevel NumSub #Attr.2 #Attr.3;
-    ret Num.305;
+    let Num.307 : U8 = lowlevel NumSub #Attr.2 #Attr.3;
+    ret Num.307;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.342 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.342;
+    let Num.344 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.344;
 
 procedure Num.23 (#Attr.2, #Attr.3):
-    let Num.311 : Int1 = lowlevel NumLte #Attr.2 #Attr.3;
-    ret Num.311;
+    let Num.313 : Int1 = lowlevel NumLte #Attr.2 #Attr.3;
+    ret Num.313;
 
 procedure Num.25 (#Attr.2, #Attr.3):
-    let Num.317 : Int1 = lowlevel NumGte #Attr.2 #Attr.3;
-    ret Num.317;
+    let Num.319 : Int1 = lowlevel NumGte #Attr.2 #Attr.3;
+    ret Num.319;
 
 procedure Num.71 (#Attr.2, #Attr.3):
-    let Num.290 : U8 = lowlevel NumBitwiseOr #Attr.2 #Attr.3;
-    ret Num.290;
+    let Num.292 : U8 = lowlevel NumBitwiseOr #Attr.2 #Attr.3;
+    ret Num.292;
 
 procedure Num.72 (#Attr.2, #Attr.3):
-    let Num.291 : U8 = lowlevel NumShiftLeftBy #Attr.2 #Attr.3;
-    ret Num.291;
+    let Num.293 : U8 = lowlevel NumShiftLeftBy #Attr.2 #Attr.3;
+    ret Num.293;
 
 procedure Num.77 (#Attr.2, #Attr.3):
-    let Num.339 : U64 = lowlevel NumSubSaturated #Attr.2 #Attr.3;
-    ret Num.339;
+    let Num.341 : U64 = lowlevel NumSubSaturated #Attr.2 #Attr.3;
+    ret Num.341;
 
 procedure Str.48 (#Attr.2, #Attr.3, #Attr.4):
     let Str.307 : {U64, Str, Int1, U8} = lowlevel StrFromUtf8Range #Attr.2 #Attr.3 #Attr.4;

--- a/crates/compiler/test_mono/generated/issue_4770.txt
+++ b/crates/compiler/test_mono/generated/issue_4770.txt
@@ -82,16 +82,16 @@ procedure List.93 (List.436, List.437, List.438):
     ret List.534;
 
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.292 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    let Num.294 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.294;
+
+procedure Num.22 (#Attr.2, #Attr.3):
+    let Num.292 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
     ret Num.292;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.290 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.290;
-
-procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.293 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.293;
+    let Num.295 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.295;
 
 procedure Test.1 (Test.77):
     joinpoint Test.26 Test.6:

--- a/crates/compiler/test_mono/generated/issue_4772_weakened_monomorphic_destructure.txt
+++ b/crates/compiler/test_mono/generated/issue_4772_weakened_monomorphic_destructure.txt
@@ -170,40 +170,40 @@ procedure List.93 (List.436, List.437, List.438):
     ret List.592;
 
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.293 : U8 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.293;
+    let Num.295 : U8 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.295;
 
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.343 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.343;
+    let Num.345 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.345;
 
 procedure Num.20 (#Attr.2, #Attr.3):
-    let Num.305 : U8 = lowlevel NumSub #Attr.2 #Attr.3;
-    ret Num.305;
+    let Num.307 : U8 = lowlevel NumSub #Attr.2 #Attr.3;
+    ret Num.307;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.342 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.342;
+    let Num.344 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.344;
 
 procedure Num.23 (#Attr.2, #Attr.3):
-    let Num.311 : Int1 = lowlevel NumLte #Attr.2 #Attr.3;
-    ret Num.311;
+    let Num.313 : Int1 = lowlevel NumLte #Attr.2 #Attr.3;
+    ret Num.313;
 
 procedure Num.25 (#Attr.2, #Attr.3):
-    let Num.317 : Int1 = lowlevel NumGte #Attr.2 #Attr.3;
-    ret Num.317;
+    let Num.319 : Int1 = lowlevel NumGte #Attr.2 #Attr.3;
+    ret Num.319;
 
 procedure Num.71 (#Attr.2, #Attr.3):
-    let Num.290 : U8 = lowlevel NumBitwiseOr #Attr.2 #Attr.3;
-    ret Num.290;
+    let Num.292 : U8 = lowlevel NumBitwiseOr #Attr.2 #Attr.3;
+    ret Num.292;
 
 procedure Num.72 (#Attr.2, #Attr.3):
-    let Num.291 : U8 = lowlevel NumShiftLeftBy #Attr.2 #Attr.3;
-    ret Num.291;
+    let Num.293 : U8 = lowlevel NumShiftLeftBy #Attr.2 #Attr.3;
+    ret Num.293;
 
 procedure Num.77 (#Attr.2, #Attr.3):
-    let Num.339 : U64 = lowlevel NumSubSaturated #Attr.2 #Attr.3;
-    ret Num.339;
+    let Num.341 : U64 = lowlevel NumSubSaturated #Attr.2 #Attr.3;
+    ret Num.341;
 
 procedure Str.12 (#Attr.2):
     let Str.307 : List U8 = lowlevel StrToUtf8 #Attr.2;

--- a/crates/compiler/test_mono/generated/lambda_capture_niche_u8_vs_u64.txt
+++ b/crates/compiler/test_mono/generated/lambda_capture_niche_u8_vs_u64.txt
@@ -1,10 +1,10 @@
 procedure Num.96 (#Attr.2):
-    let Num.290 : Str = lowlevel NumToStr #Attr.2;
-    ret Num.290;
+    let Num.292 : Str = lowlevel NumToStr #Attr.2;
+    ret Num.292;
 
 procedure Num.96 (#Attr.2):
-    let Num.291 : Str = lowlevel NumToStr #Attr.2;
-    ret Num.291;
+    let Num.293 : Str = lowlevel NumToStr #Attr.2;
+    ret Num.293;
 
 procedure Test.1 (Test.4):
     let Test.13 : [C U8, C U64] = TagId(1) Test.4;

--- a/crates/compiler/test_mono/generated/lambda_set_with_imported_toplevels_issue_4733.txt
+++ b/crates/compiler/test_mono/generated/lambda_set_with_imported_toplevels_issue_4733.txt
@@ -7,12 +7,12 @@ procedure Bool.2 ():
     ret Bool.24;
 
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.290 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.290;
+    let Num.292 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.292;
 
 procedure Num.21 (#Attr.2, #Attr.3):
-    let Num.291 : U64 = lowlevel NumMul #Attr.2 #Attr.3;
-    ret Num.291;
+    let Num.293 : U64 = lowlevel NumMul #Attr.2 #Attr.3;
+    ret Num.293;
 
 procedure Test.0 (Test.8):
     let Test.20 : Int1 = CallByName Bool.2;

--- a/crates/compiler/test_mono/generated/layout_cache_structure_with_multiple_recursive_structures.txt
+++ b/crates/compiler/test_mono/generated/layout_cache_structure_with_multiple_recursive_structures.txt
@@ -37,12 +37,12 @@ procedure List.93 (List.436, List.437, List.438):
     ret List.524;
 
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.290 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.290;
+    let Num.292 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.292;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.291 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.291;
+    let Num.293 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.293;
 
 procedure Test.7 (Test.11, Test.12):
     let Test.17 : {[<rnu>C *self, <null>], [<rnu><null>, C {[<rnu>C *self, <null>], *self}]} = Struct {Test.12, Test.11};

--- a/crates/compiler/test_mono/generated/list_cannot_update_inplace.txt
+++ b/crates/compiler/test_mono/generated/list_cannot_update_inplace.txt
@@ -22,12 +22,12 @@ procedure List.67 (#Attr.2, #Attr.3, #Attr.4):
     ret List.528;
 
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.290 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.290;
+    let Num.292 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.292;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.291 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.291;
+    let Num.293 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.293;
 
 procedure Test.1 ():
     let Test.8 : List I64 = Array [1i64, 2i64, 3i64];

--- a/crates/compiler/test_mono/generated/list_get.txt
+++ b/crates/compiler/test_mono/generated/list_get.txt
@@ -21,8 +21,8 @@ procedure List.66 (#Attr.2, #Attr.3):
     ret List.526;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.290 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.290;
+    let Num.292 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.292;
 
 procedure Test.1 (Test.2):
     let Test.6 : List I64 = Array [1i64, 2i64, 3i64];

--- a/crates/compiler/test_mono/generated/list_len.txt
+++ b/crates/compiler/test_mono/generated/list_len.txt
@@ -7,8 +7,8 @@ procedure List.6 (#Attr.2):
     ret List.522;
 
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.290 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.290;
+    let Num.292 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.292;
 
 procedure Test.0 ():
     let Test.1 : List I64 = Array [1i64, 2i64, 3i64];

--- a/crates/compiler/test_mono/generated/list_map_closure_borrows.txt
+++ b/crates/compiler/test_mono/generated/list_map_closure_borrows.txt
@@ -27,8 +27,8 @@ procedure List.66 (#Attr.2, #Attr.3):
     ret List.526;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.290 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.290;
+    let Num.292 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.292;
 
 procedure Str.16 (#Attr.2, #Attr.3):
     let Str.298 : Str = lowlevel StrRepeat #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/list_map_closure_owns.txt
+++ b/crates/compiler/test_mono/generated/list_map_closure_owns.txt
@@ -27,8 +27,8 @@ procedure List.66 (#Attr.2, #Attr.3):
     ret List.526;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.290 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.290;
+    let Num.292 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.292;
 
 procedure Str.3 (#Attr.2, #Attr.3):
     let Str.299 : Str = lowlevel StrConcat #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/list_map_take_capturing_or_noncapturing.txt
+++ b/crates/compiler/test_mono/generated/list_map_take_capturing_or_noncapturing.txt
@@ -21,8 +21,8 @@ procedure List.5 (#Attr.2, #Attr.3):
     
 
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.292 : U8 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.292;
+    let Num.294 : U8 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.294;
 
 procedure Test.4 (Test.5, #Attr.12):
     let Test.1 : U8 = UnionAtIndex (Id 0) (Index 0) #Attr.12;

--- a/crates/compiler/test_mono/generated/list_pass_to_function.txt
+++ b/crates/compiler/test_mono/generated/list_pass_to_function.txt
@@ -22,8 +22,8 @@ procedure List.67 (#Attr.2, #Attr.3, #Attr.4):
     ret List.526;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.290 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.290;
+    let Num.292 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.292;
 
 procedure Test.2 (Test.3):
     let Test.6 : U64 = 0i64;

--- a/crates/compiler/test_mono/generated/list_sort_asc.txt
+++ b/crates/compiler/test_mono/generated/list_sort_asc.txt
@@ -8,8 +8,8 @@ procedure List.59 (List.288):
     ret List.521;
 
 procedure Num.46 (#Attr.2, #Attr.3):
-    let Num.290 : U8 = lowlevel NumCompare #Attr.2 #Attr.3;
-    ret Num.290;
+    let Num.292 : U8 = lowlevel NumCompare #Attr.2 #Attr.3;
+    ret Num.292;
 
 procedure Test.0 ():
     let Test.2 : List I64 = Array [4i64, 3i64, 2i64, 1i64];

--- a/crates/compiler/test_mono/generated/nested_pattern_match.txt
+++ b/crates/compiler/test_mono/generated/nested_pattern_match.txt
@@ -1,6 +1,6 @@
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.290 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.290;
+    let Num.292 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.292;
 
 procedure Test.0 ():
     let Test.19 : I64 = 41i64;

--- a/crates/compiler/test_mono/generated/num_width_gt_u8_layout_as_float.txt
+++ b/crates/compiler/test_mono/generated/num_width_gt_u8_layout_as_float.txt
@@ -1,6 +1,6 @@
 procedure Num.37 (#Attr.2, #Attr.3):
-    let Num.290 : Float64 = lowlevel NumDivFrac #Attr.2 #Attr.3;
-    ret Num.290;
+    let Num.292 : Float64 = lowlevel NumDivFrac #Attr.2 #Attr.3;
+    ret Num.292;
 
 procedure Test.0 ():
     let Test.2 : Float64 = 1f64;

--- a/crates/compiler/test_mono/generated/optional_when.txt
+++ b/crates/compiler/test_mono/generated/optional_when.txt
@@ -1,6 +1,6 @@
 procedure Num.21 (#Attr.2, #Attr.3):
-    let Num.292 : I64 = lowlevel NumMul #Attr.2 #Attr.3;
-    ret Num.292;
+    let Num.294 : I64 = lowlevel NumMul #Attr.2 #Attr.3;
+    ret Num.294;
 
 procedure Test.1 (Test.6):
     let Test.21 : Int1 = false;

--- a/crates/compiler/test_mono/generated/quicksort_help.txt
+++ b/crates/compiler/test_mono/generated/quicksort_help.txt
@@ -1,14 +1,14 @@
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.290 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.290;
+    let Num.292 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.292;
 
 procedure Num.20 (#Attr.2, #Attr.3):
-    let Num.291 : I64 = lowlevel NumSub #Attr.2 #Attr.3;
-    ret Num.291;
+    let Num.293 : I64 = lowlevel NumSub #Attr.2 #Attr.3;
+    ret Num.293;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.292 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.292;
+    let Num.294 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.294;
 
 procedure Test.1 (Test.24, Test.25, Test.26):
     joinpoint Test.12 Test.2 Test.3 Test.4:

--- a/crates/compiler/test_mono/generated/quicksort_swap.txt
+++ b/crates/compiler/test_mono/generated/quicksort_swap.txt
@@ -40,8 +40,8 @@ procedure List.67 (#Attr.2, #Attr.3, #Attr.4):
     ret List.526;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.292 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.292;
+    let Num.294 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.294;
 
 procedure Test.1 (Test.2):
     let Test.28 : U64 = 0i64;

--- a/crates/compiler/test_mono/generated/rb_tree_fbip.txt
+++ b/crates/compiler/test_mono/generated/rb_tree_fbip.txt
@@ -1,10 +1,10 @@
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.293 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.293;
+    let Num.295 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.295;
 
 procedure Num.24 (#Attr.2, #Attr.3):
-    let Num.291 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
-    ret Num.291;
+    let Num.293 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
+    ret Num.293;
 
 procedure Test.3 (Test.9, Test.10, Test.11):
     let Test.254 : U8 = 0i64;

--- a/crates/compiler/test_mono/generated/record_optional_field_function_no_use_default.txt
+++ b/crates/compiler/test_mono/generated/record_optional_field_function_no_use_default.txt
@@ -1,6 +1,6 @@
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.290 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.290;
+    let Num.292 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.292;
 
 procedure Test.1 (Test.4):
     let Test.2 : I64 = StructAtIndex 0 Test.4;

--- a/crates/compiler/test_mono/generated/record_optional_field_function_use_default.txt
+++ b/crates/compiler/test_mono/generated/record_optional_field_function_use_default.txt
@@ -1,6 +1,6 @@
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.290 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.290;
+    let Num.292 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.292;
 
 procedure Test.1 (Test.4):
     let Test.2 : I64 = 10i64;

--- a/crates/compiler/test_mono/generated/record_optional_field_let_no_use_default.txt
+++ b/crates/compiler/test_mono/generated/record_optional_field_let_no_use_default.txt
@@ -1,6 +1,6 @@
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.290 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.290;
+    let Num.292 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.292;
 
 procedure Test.1 (Test.2):
     let Test.3 : I64 = StructAtIndex 0 Test.2;

--- a/crates/compiler/test_mono/generated/record_optional_field_let_use_default.txt
+++ b/crates/compiler/test_mono/generated/record_optional_field_let_use_default.txt
@@ -1,6 +1,6 @@
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.290 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.290;
+    let Num.292 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.292;
 
 procedure Test.1 (Test.2):
     let Test.3 : I64 = 10i64;

--- a/crates/compiler/test_mono/generated/record_update.txt
+++ b/crates/compiler/test_mono/generated/record_update.txt
@@ -22,8 +22,8 @@ procedure List.67 (#Attr.2, #Attr.3, #Attr.4):
     ret List.526;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.290 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.290;
+    let Num.292 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.292;
 
 procedure Test.1 (Test.2):
     let Test.6 : List U64 = StructAtIndex 0 Test.2;

--- a/crates/compiler/test_mono/generated/recursive_call_capturing_function.txt
+++ b/crates/compiler/test_mono/generated/recursive_call_capturing_function.txt
@@ -3,8 +3,8 @@ procedure Bool.2 ():
     ret Bool.23;
 
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.290 : U32 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.290;
+    let Num.292 : U32 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.292;
 
 procedure Test.1 (Test.2):
     let Test.8 : U32 = 0i64;

--- a/crates/compiler/test_mono/generated/recursive_lambda_set_resolved_only_upon_specialization.txt
+++ b/crates/compiler/test_mono/generated/recursive_lambda_set_resolved_only_upon_specialization.txt
@@ -3,12 +3,12 @@ procedure Bool.11 (#Attr.2, #Attr.3):
     ret Bool.23;
 
 procedure Num.20 (#Attr.2, #Attr.3):
-    let Num.291 : U8 = lowlevel NumSub #Attr.2 #Attr.3;
-    ret Num.291;
+    let Num.293 : U8 = lowlevel NumSub #Attr.2 #Attr.3;
+    ret Num.293;
 
 procedure Num.21 (#Attr.2, #Attr.3):
-    let Num.290 : U8 = lowlevel NumMul #Attr.2 #Attr.3;
-    ret Num.290;
+    let Num.292 : U8 = lowlevel NumMul #Attr.2 #Attr.3;
+    ret Num.292;
 
 procedure Test.1 (Test.26, Test.27):
     joinpoint Test.11 Test.2 Test.3:

--- a/crates/compiler/test_mono/generated/recursively_build_effect.txt
+++ b/crates/compiler/test_mono/generated/recursively_build_effect.txt
@@ -1,6 +1,6 @@
 procedure Num.20 (#Attr.2, #Attr.3):
-    let Num.290 : I64 = lowlevel NumSub #Attr.2 #Attr.3;
-    ret Num.290;
+    let Num.292 : I64 = lowlevel NumSub #Attr.2 #Attr.3;
+    ret Num.292;
 
 procedure Str.3 (#Attr.2, #Attr.3):
     let Str.300 : Str = lowlevel StrConcat #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/rigids.txt
+++ b/crates/compiler/test_mono/generated/rigids.txt
@@ -40,8 +40,8 @@ procedure List.67 (#Attr.2, #Attr.3, #Attr.4):
     ret List.526;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.292 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.292;
+    let Num.294 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.294;
 
 procedure Test.1 (Test.2, Test.3, Test.4):
     inc 2 Test.4;

--- a/crates/compiler/test_mono/generated/specialize_after_match.txt
+++ b/crates/compiler/test_mono/generated/specialize_after_match.txt
@@ -1,10 +1,10 @@
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.291 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.291;
+    let Num.293 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.293;
 
 procedure Num.24 (#Attr.2, #Attr.3):
-    let Num.292 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
-    ret Num.292;
+    let Num.294 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
+    ret Num.294;
 
 procedure Test.2 (Test.9, Test.10):
     let Test.38 : U8 = 1i64;

--- a/crates/compiler/test_mono/generated/specialize_closures.txt
+++ b/crates/compiler/test_mono/generated/specialize_closures.txt
@@ -3,12 +3,12 @@ procedure Bool.2 ():
     ret Bool.24;
 
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.291 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.291;
+    let Num.293 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.293;
 
 procedure Num.21 (#Attr.2, #Attr.3):
-    let Num.290 : I64 = lowlevel NumMul #Attr.2 #Attr.3;
-    ret Num.290;
+    let Num.292 : I64 = lowlevel NumMul #Attr.2 #Attr.3;
+    ret Num.292;
 
 procedure Test.1 (Test.2, Test.3):
     let Test.15 : U8 = GetTagId Test.2;

--- a/crates/compiler/test_mono/generated/specialize_lowlevel.txt
+++ b/crates/compiler/test_mono/generated/specialize_lowlevel.txt
@@ -3,12 +3,12 @@ procedure Bool.2 ():
     ret Bool.23;
 
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.291 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.291;
+    let Num.293 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.293;
 
 procedure Num.21 (#Attr.2, #Attr.3):
-    let Num.290 : I64 = lowlevel NumMul #Attr.2 #Attr.3;
-    ret Num.290;
+    let Num.292 : I64 = lowlevel NumMul #Attr.2 #Attr.3;
+    ret Num.292;
 
 procedure Test.6 (Test.8, #Attr.12):
     let Test.4 : I64 = UnionAtIndex (Id 0) (Index 0) #Attr.12;

--- a/crates/compiler/test_mono/generated/tail_call_elimination.txt
+++ b/crates/compiler/test_mono/generated/tail_call_elimination.txt
@@ -1,10 +1,10 @@
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.290 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.290;
+    let Num.292 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.292;
 
 procedure Num.20 (#Attr.2, #Attr.3):
-    let Num.291 : I64 = lowlevel NumSub #Attr.2 #Attr.3;
-    ret Num.291;
+    let Num.293 : I64 = lowlevel NumSub #Attr.2 #Attr.3;
+    ret Num.293;
 
 procedure Test.1 (Test.15, Test.16):
     joinpoint Test.7 Test.2 Test.3:

--- a/crates/compiler/test_mono/generated/unspecialized_lambda_set_unification_does_not_duplicate_identical_concrete_types.txt
+++ b/crates/compiler/test_mono/generated/unspecialized_lambda_set_unification_does_not_duplicate_identical_concrete_types.txt
@@ -212,32 +212,32 @@ procedure List.93 (List.436, List.437, List.438):
     ret List.623;
 
 procedure Num.127 (#Attr.2):
-    let Num.297 : U8 = lowlevel NumIntCast #Attr.2;
-    ret Num.297;
+    let Num.299 : U8 = lowlevel NumIntCast #Attr.2;
+    ret Num.299;
 
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.306 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.306;
+    let Num.308 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.308;
 
 procedure Num.20 (#Attr.2, #Attr.3):
-    let Num.310 : U64 = lowlevel NumSub #Attr.2 #Attr.3;
-    ret Num.310;
+    let Num.312 : U64 = lowlevel NumSub #Attr.2 #Attr.3;
+    ret Num.312;
 
 procedure Num.21 (#Attr.2, #Attr.3):
-    let Num.303 : U64 = lowlevel NumMul #Attr.2 #Attr.3;
-    ret Num.303;
+    let Num.305 : U64 = lowlevel NumMul #Attr.2 #Attr.3;
+    ret Num.305;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.309 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.309;
-
-procedure Num.24 (#Attr.2, #Attr.3):
-    let Num.311 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
+    let Num.311 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
     ret Num.311;
 
+procedure Num.24 (#Attr.2, #Attr.3):
+    let Num.313 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
+    ret Num.313;
+
 procedure Num.94 (#Attr.2, #Attr.3):
-    let Num.302 : U64 = lowlevel NumDivCeilUnchecked #Attr.2 #Attr.3;
-    ret Num.302;
+    let Num.304 : U64 = lowlevel NumDivCeilUnchecked #Attr.2 #Attr.3;
+    ret Num.304;
 
 procedure Str.12 (#Attr.2):
     let Str.299 : List U8 = lowlevel StrToUtf8 #Attr.2;

--- a/crates/compiler/test_mono/generated/unspecialized_lambda_set_unification_keeps_all_concrete_types_without_unification_of_unifiable.txt
+++ b/crates/compiler/test_mono/generated/unspecialized_lambda_set_unification_keeps_all_concrete_types_without_unification_of_unifiable.txt
@@ -174,24 +174,24 @@ procedure List.93 (List.436, List.437, List.438):
     ret List.623;
 
 procedure Num.127 (#Attr.2):
-    let Num.318 : U8 = lowlevel NumIntCast #Attr.2;
-    ret Num.318;
+    let Num.320 : U8 = lowlevel NumIntCast #Attr.2;
+    ret Num.320;
 
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.321 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.321;
+    let Num.323 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.323;
 
 procedure Num.20 (#Attr.2, #Attr.3):
-    let Num.319 : U64 = lowlevel NumSub #Attr.2 #Attr.3;
-    ret Num.319;
+    let Num.321 : U64 = lowlevel NumSub #Attr.2 #Attr.3;
+    ret Num.321;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.322 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.322;
+    let Num.324 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.324;
 
 procedure Num.24 (#Attr.2, #Attr.3):
-    let Num.320 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
-    ret Num.320;
+    let Num.322 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
+    ret Num.322;
 
 procedure Str.12 (#Attr.2):
     let Str.300 : List U8 = lowlevel StrToUtf8 #Attr.2;

--- a/crates/compiler/test_mono/generated/weakening_avoids_overspecialization.txt
+++ b/crates/compiler/test_mono/generated/weakening_avoids_overspecialization.txt
@@ -86,16 +86,16 @@ procedure List.93 (List.436, List.437, List.438):
     ret List.542;
 
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.292 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.292;
+    let Num.294 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.294;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.293 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.293;
+    let Num.295 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.295;
 
 procedure Num.77 (#Attr.2, #Attr.3):
-    let Num.291 : U64 = lowlevel NumSubSaturated #Attr.2 #Attr.3;
-    ret Num.291;
+    let Num.293 : U64 = lowlevel NumSubSaturated #Attr.2 #Attr.3;
+    ret Num.293;
 
 procedure Test.3 (Test.4, Test.12):
     let Test.13 : [C U64, C U64] = TagId(0) Test.4;

--- a/crates/compiler/test_mono/generated/when_guard_appears_multiple_times_in_compiled_decision_tree_issue_5176.txt
+++ b/crates/compiler/test_mono/generated/when_guard_appears_multiple_times_in_compiled_decision_tree_issue_5176.txt
@@ -3,8 +3,8 @@ procedure Bool.2 ():
     ret Bool.25;
 
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.290 : U8 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.290;
+    let Num.292 : U8 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.292;
 
 procedure Test.1 (Test.2):
     joinpoint Test.12:

--- a/crates/compiler/test_mono/generated/when_nested_maybe.txt
+++ b/crates/compiler/test_mono/generated/when_nested_maybe.txt
@@ -1,6 +1,6 @@
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.290 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.290;
+    let Num.292 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.292;
 
 procedure Test.0 ():
     let Test.19 : I64 = 41i64;

--- a/crates/compiler/test_mono/generated/when_on_record.txt
+++ b/crates/compiler/test_mono/generated/when_on_record.txt
@@ -1,6 +1,6 @@
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.290 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.290;
+    let Num.292 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.292;
 
 procedure Test.0 ():
     let Test.5 : I64 = 2i64;

--- a/crates/compiler/test_mono/generated/when_on_two_values.txt
+++ b/crates/compiler/test_mono/generated/when_on_two_values.txt
@@ -1,6 +1,6 @@
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.290 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.290;
+    let Num.292 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.292;
 
 procedure Test.0 ():
     let Test.15 : I64 = 3i64;


### PR DESCRIPTION
This pr adds a bitwise not (complement) function to the Num module. See [this zulip thread](https://roc.zulipchat.com/#narrow/stream/304641-ideas/topic/Num.2EbitwiseComplement) for the discussion.