### PR TITLE
glue: limit derives

### DIFF
--- a/examples/glue/glue.roc
+++ b/examples/glue/glue.roc
@@ -4,6 +4,7 @@ app "rocLovesRust"
     provides [main] to pf
 
 main =
+    msg = "Roc <3 Rust, also on stderr!\n" 
     StdoutWrite "Roc <3 Rust!\n" \{} ->
-        StdoutWrite "Roc <3 Rust!\n" \{} ->
+        StderrWrite msg \{} ->
             Done

--- a/examples/glue/glue.roc
+++ b/examples/glue/glue.roc
@@ -4,7 +4,7 @@ app "rocLovesRust"
     provides [main] to pf
 
 main =
-    msg = "Roc <3 Rust, also on stderr!\n" 
+    msg = "Roc <3 Rust, also on stderr!\n"
     StdoutWrite "Roc <3 Rust!\n" \{} ->
         StderrWrite msg \{} ->
             Done

--- a/examples/glue/rust-platform/src/lib.rs
+++ b/examples/glue/rust-platform/src/lib.rs
@@ -89,7 +89,7 @@ pub extern "C" fn rust_main() -> i32 {
     loop {
         match dbg!(op.discriminant()) {
             StdoutWrite => {
-                let stdout_write = unsafe { op.get_StdoutWrite() };
+                let stdout_write = op.get_StdoutWrite();
                 let output: RocStr = stdout_write.f0;
                 op = unsafe { stdout_write.f1.force_thunk(()) };
 
@@ -98,7 +98,7 @@ pub extern "C" fn rust_main() -> i32 {
                 }
             }
             StderrWrite => {
-                let stderr_write = unsafe { op.get_StderrWrite() };
+                let stderr_write = op.get_StderrWrite();
                 let output: RocStr = stderr_write.f0;
                 op = unsafe { stderr_write.f1.force_thunk(()) };
 


### PR DESCRIPTION
uses `canDerivePartialEq` as a proxy for Hash and Ord. I think this is correct right now, we may need to give them custom `canDerive*` functions in the future.