### PR TITLE
link docs to overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Roc is not ready for a 0.1 release yet, but we do have:
 
 - [**installation** guide](https://github.com/roc-lang/roc/tree/main/getting_started)
 - [**tutorial**](https://roc-lang.org/tutorial)
-- [**docs** for the standard library](https://www.roc-lang.org/builtins/Str)
+- [**docs** for the standard library](https://www.roc-lang.org/builtins)
 - [**examples**](https://github.com/roc-lang/examples/tree/main/examples)
 - [frequently asked questions](https://github.com/roc-lang/roc/blob/main/FAQ.md)
 - [Group chat](https://roc.zulipchat.com) for help, questions and discussions


### PR DESCRIPTION
It used to be necessary to link to a specific module page but a module overview page was recently added.