### PR TITLE
Llvm 15 preparations

### DIFF
--- a/crates/compiler/build/src/program.rs
+++ b/crates/compiler/build/src/program.rs
@@ -166,7 +166,7 @@ fn gen_from_mono_module_llvm<'a>(
 
     let kind_id = Attribute::get_named_enum_kind_id("alwaysinline");
     debug_assert!(kind_id > 0);
-    let enum_attr = context.create_enum_attribute(kind_id, 1);
+    let enum_attr = context.create_enum_attribute(kind_id, 0);
 
     for function in module.get_functions() {
         let name = function.get_name().to_str().unwrap();

--- a/crates/compiler/gen_llvm/src/llvm/bitcode.rs
+++ b/crates/compiler/gen_llvm/src/llvm/bitcode.rs
@@ -225,7 +225,7 @@ fn build_transform_caller_help<'a, 'ctx>(
 
     let kind_id = Attribute::get_named_enum_kind_id("alwaysinline");
     debug_assert!(kind_id > 0);
-    let attr = env.context.create_enum_attribute(kind_id, 1);
+    let attr = env.context.create_enum_attribute(kind_id, 0);
     function_value.add_attribute(AttributeLoc::Function, attr);
 
     let entry = env.context.append_basic_block(function_value, "entry");
@@ -408,7 +408,7 @@ fn build_rc_wrapper<'a, 'ctx>(
 
             let kind_id = Attribute::get_named_enum_kind_id("alwaysinline");
             debug_assert!(kind_id > 0);
-            let attr = env.context.create_enum_attribute(kind_id, 1);
+            let attr = env.context.create_enum_attribute(kind_id, 0);
             function_value.add_attribute(AttributeLoc::Function, attr);
 
             let entry = env.context.append_basic_block(function_value, "entry");
@@ -497,7 +497,7 @@ pub fn build_eq_wrapper<'a, 'ctx>(
 
             let kind_id = Attribute::get_named_enum_kind_id("alwaysinline");
             debug_assert!(kind_id > 0);
-            let attr = env.context.create_enum_attribute(kind_id, 1);
+            let attr = env.context.create_enum_attribute(kind_id, 0);
             function_value.add_attribute(AttributeLoc::Function, attr);
 
             let entry = env.context.append_basic_block(function_value, "entry");
@@ -598,7 +598,7 @@ pub fn build_compare_wrapper<'a, 'ctx>(
 
             let kind_id = Attribute::get_named_enum_kind_id("alwaysinline");
             debug_assert!(kind_id > 0);
-            let attr = env.context.create_enum_attribute(kind_id, 1);
+            let attr = env.context.create_enum_attribute(kind_id, 0);
             function_value.add_attribute(AttributeLoc::Function, attr);
 
             let entry = env.context.append_basic_block(function_value, "entry");

--- a/crates/compiler/gen_llvm/src/llvm/build.rs
+++ b/crates/compiler/gen_llvm/src/llvm/build.rs
@@ -1941,8 +1941,12 @@ fn tag_pointer_set_tag_id<'ctx>(
 
     // NOTE: assumes the lower bits of `cast_pointer` are all 0
     let indexed_pointer = unsafe {
-        env.builder
-            .build_in_bounds_gep(cast_pointer, &[tag_id_intval], "indexed_pointer")
+        env.builder.new_build_in_bounds_gep(
+            env.context.i8_type(),
+            cast_pointer,
+            &[tag_id_intval],
+            "indexed_pointer",
+        )
     };
 
     env.builder
@@ -1994,7 +1998,14 @@ pub fn tag_pointer_clear_tag_id<'ctx>(
         "cast_to_i8_ptr",
     );
 
-    let indexed_pointer = unsafe { env.builder.build_gep(cast_pointer, &[index], "new_ptr") };
+    let indexed_pointer = unsafe {
+        env.builder.new_build_in_bounds_gep(
+            env.context.i8_type(),
+            cast_pointer,
+            &[index],
+            "new_ptr",
+        )
+    };
 
     env.builder
         .build_pointer_cast(indexed_pointer, pointer.get_type(), "cast_from_i8_ptr")
@@ -3954,11 +3965,9 @@ fn expose_function_to_host_help_c_abi_gen_test<'a, 'ctx>(
             arguments_for_call.push(*arg);
         } else {
             match layout_interner.get_repr(*layout) {
-                LayoutRepr::Builtin(Builtin::List(_)) => {
-                    let list_type = arg_type
-                        .into_pointer_type()
-                        .get_element_type()
-                        .into_struct_type();
+                repr @ LayoutRepr::Builtin(Builtin::List(_)) => {
+                    let list_type = basic_type_from_layout(env, layout_interner, repr);
+
                     let loaded = env.builder.new_build_load(
                         list_type,
                         arg.into_pointer_value(),

--- a/crates/compiler/gen_llvm/src/llvm/build.rs
+++ b/crates/compiler/gen_llvm/src/llvm/build.rs
@@ -1931,7 +1931,7 @@ fn tag_pointer_set_tag_id<'ctx>(
     // we only have 3 bits, so can encode only 0..7 (or on 32-bit targets, 2 bits to encode 0..3)
     debug_assert!((tag_id as u32) < env.target_info.ptr_width() as u32);
 
-    let tag_id_intval = env.ptr_int().const_int(tag_id as u64, false);
+    let tag_id_intval = env.context.i32_type().const_int(tag_id as u64, false);
 
     let cast_pointer = env.builder.build_pointer_cast(
         pointer,
@@ -1991,6 +1991,9 @@ pub fn tag_pointer_clear_tag_id<'ctx>(
     let current_tag_id = env.builder.build_and(as_int, mask, "masked");
 
     let index = env.builder.build_int_neg(current_tag_id, "index");
+    let index = env
+        .builder
+        .build_int_cast(index, env.context.i32_type(), "to_i32");
 
     let cast_pointer = env.builder.build_pointer_cast(
         pointer,
@@ -2444,8 +2447,9 @@ fn list_literal<'a, 'ctx>(
             // all elements are constants, so we can use the memory in the constants section directly
             // here we make a pointer to the first actual element (skipping the 0 bytes that
             // represent the refcount)
-            let zero = env.ptr_int().const_zero();
-            let offset = env.ptr_int().const_int(zero_elements as _, false);
+            let i32_type = env.context.i32_type();
+            let zero = i32_type.const_zero();
+            let offset = i32_type.const_int(zero_elements as _, false);
 
             let ptr = unsafe {
                 env.builder.new_build_in_bounds_gep(
@@ -2474,7 +2478,7 @@ fn list_literal<'a, 'ctx>(
 
             // then replace the `undef`s with the values that we evaluate at runtime
             for (index, val) in runtime_evaluated_elements {
-                let index_val = ctx.i64_type().const_int(index as u64, false);
+                let index_val = ctx.i32_type().const_int(index as u64, false);
                 let elem_ptr = unsafe {
                     builder.new_build_in_bounds_gep(element_type, ptr, &[index_val], "index")
                 };
@@ -2495,7 +2499,7 @@ fn list_literal<'a, 'ctx>(
                 }
                 ListLiteralElement::Symbol(symbol) => scope.load_symbol(symbol),
             };
-            let index_val = ctx.i64_type().const_int(index as u64, false);
+            let index_val = ctx.i32_type().const_int(index as u64, false);
             let elem_ptr = unsafe {
                 builder.new_build_in_bounds_gep(element_type, ptr, &[index_val], "index")
             };
@@ -6259,7 +6263,8 @@ fn define_global_str_literal_ptr<'ctx>(
             env.context.i8_type(),
             ptr,
             &[env
-                .ptr_int()
+                .context
+                .i32_type()
                 .const_int(env.target_info.ptr_width() as u64, false)],
             "get_rc_ptr",
         )

--- a/crates/compiler/gen_llvm/src/llvm/build.rs
+++ b/crates/compiler/gen_llvm/src/llvm/build.rs
@@ -5207,14 +5207,14 @@ fn build_proc_header<'a, 'ctx>(
     if false {
         let kind_id = Attribute::get_named_enum_kind_id("alwaysinline");
         debug_assert!(kind_id > 0);
-        let enum_attr = env.context.create_enum_attribute(kind_id, 1);
+        let enum_attr = env.context.create_enum_attribute(kind_id, 0);
         fn_val.add_attribute(AttributeLoc::Function, enum_attr);
     }
 
     if false {
         let kind_id = Attribute::get_named_enum_kind_id("noinline");
         debug_assert!(kind_id > 0);
-        let enum_attr = env.context.create_enum_attribute(kind_id, 1);
+        let enum_attr = env.context.create_enum_attribute(kind_id, 0);
         fn_val.add_attribute(AttributeLoc::Function, enum_attr);
     }
 

--- a/crates/compiler/gen_llvm/src/llvm/lowlevel.rs
+++ b/crates/compiler/gen_llvm/src/llvm/lowlevel.rs
@@ -1844,19 +1844,19 @@ fn throw_because_overflow<'ctx>(env: &Env<'_, 'ctx, '_>, message: &str) {
             // prevent inlining of this function
             let kind_id = Attribute::get_named_enum_kind_id("noinline");
             debug_assert!(kind_id > 0);
-            let enum_attr = env.context.create_enum_attribute(kind_id, 1);
+            let enum_attr = env.context.create_enum_attribute(kind_id, 0);
             function_value.add_attribute(AttributeLoc::Function, enum_attr);
 
             // calling this function is unlikely
             let kind_id = Attribute::get_named_enum_kind_id("cold");
             debug_assert!(kind_id > 0);
-            let enum_attr = env.context.create_enum_attribute(kind_id, 1);
+            let enum_attr = env.context.create_enum_attribute(kind_id, 0);
             function_value.add_attribute(AttributeLoc::Function, enum_attr);
 
             // this function never returns
             let kind_id = Attribute::get_named_enum_kind_id("noreturn");
             debug_assert!(kind_id > 0);
-            let enum_attr = env.context.create_enum_attribute(kind_id, 1);
+            let enum_attr = env.context.create_enum_attribute(kind_id, 0);
             function_value.add_attribute(AttributeLoc::Function, enum_attr);
 
             // Add a basic block for the entry point

--- a/crates/compiler/gen_llvm/src/llvm/refcounting.rs
+++ b/crates/compiler/gen_llvm/src/llvm/refcounting.rs
@@ -61,7 +61,7 @@ impl<'ctx> PointerToRefcount<'ctx> {
             builder.build_pointer_cast(data_ptr, refcount_ptr_type, "as_usize_ptr");
 
         // get a pointer to index -1
-        let index_intvalue = refcount_type.const_int(-1_i64 as u64, false);
+        let index_intvalue = env.context.i32_type().const_int(-1_i64 as u64, false);
         let refcount_ptr = unsafe {
             builder.new_build_in_bounds_gep(
                 env.ptr_int(),

--- a/crates/compiler/gen_llvm/src/llvm/refcounting.rs
+++ b/crates/compiler/gen_llvm/src/llvm/refcounting.rs
@@ -61,7 +61,7 @@ impl<'ctx> PointerToRefcount<'ctx> {
             builder.build_pointer_cast(data_ptr, refcount_ptr_type, "as_usize_ptr");
 
         // get a pointer to index -1
-        let index_intvalue = env.context.i32_type().const_int(-1_i64 as u64, false);
+        let index_intvalue = refcount_type.const_int(-1_i64 as u64, false);
         let refcount_ptr = unsafe {
             builder.new_build_in_bounds_gep(
                 env.ptr_int(),

--- a/crates/compiler/test_gen/src/helpers/llvm.rs
+++ b/crates/compiler/test_gen/src/helpers/llvm.rs
@@ -192,7 +192,7 @@ fn create_llvm_module<'a>(
 
     let kind_id = Attribute::get_named_enum_kind_id("alwaysinline");
     debug_assert!(kind_id > 0);
-    let attr = context.create_enum_attribute(kind_id, 1);
+    let attr = context.create_enum_attribute(kind_id, 0);
 
     for function in module.get_functions() {
         let name = function.get_name().to_str().unwrap();


### PR DESCRIPTION
some changes to make the llvm 15 upgrade easier

- in the next release, more llvm operations need a type argument
- enum values that are not 0 cause issues
- we should generally prefer 32-bit indices for GEP