### PR TITLE
aarch64 linux c_char fix

### DIFF
--- a/crates/linker/src/elf.rs
+++ b/crates/linker/src/elf.rs
@@ -1023,7 +1023,7 @@ fn scan_elf_dynamic_deps(
                 )
                 .unwrap(),
             ) as usize;
-            let c_buf: *const c_char = dynstr_data[dynstr_off..].as_ptr() as *const i8;
+            let c_buf = dynstr_data[dynstr_off..].as_ptr() as *const c_char;
             let c_str = unsafe { CStr::from_ptr(c_buf) }.to_str().unwrap();
             if Path::new(c_str).file_name() == shared_lib_filename {
                 shared_lib_index = Some(dyn_lib_index);

--- a/crates/linker/src/macho.rs
+++ b/crates/linker/src/macho.rs
@@ -11,7 +11,7 @@ use roc_collections::all::MutMap;
 use roc_error_macros::internal_error;
 use serde::{Deserialize, Serialize};
 use std::{
-    ffi::{CStr, c_char},
+    ffi::{c_char, CStr},
     io::{BufReader, BufWriter},
     mem,
     path::Path,

--- a/crates/linker/src/macho.rs
+++ b/crates/linker/src/macho.rs
@@ -11,7 +11,7 @@ use roc_collections::all::MutMap;
 use roc_error_macros::internal_error;
 use serde::{Deserialize, Serialize};
 use std::{
-    ffi::CStr,
+    ffi::{CStr, c_char},
     io::{BufReader, BufWriter},
     mem,
     path::Path,
@@ -499,7 +499,7 @@ pub(crate) fn preprocess_macho(
                         // std::ffi::CStr is actually not a char* under
                         // the hood (!) but rather an array, so to strip
                         // the trailing null bytes we have to use from_ptr.
-                        let c_str = unsafe { CStr::from_ptr(str_bytes.as_ptr() as *const i8) };
+                        let c_str = unsafe { CStr::from_ptr(str_bytes.as_ptr() as *const c_char) };
 
                         Path::new(c_str.to_str().unwrap())
                     } else {


### PR DESCRIPTION
The `i8` is a `u8` on raspberry pi 4 aarch64 linux, `c_char` takes care of this automatically.