### PR TITLE
Allow spaces before and after the colon in the `packages` header section

### DIFF
--- a/crates/compiler/test_syntax/tests/snapshots/pass/space_before_colon.full.formatted.roc
+++ b/crates/compiler/test_syntax/tests/snapshots/pass/space_before_colon.full.formatted.roc
@@ -1,0 +1,6 @@
+app "example"
+    packages { pf: "path" }
+    imports [pf.Stdout]
+    provides [main] to pf
+
+main = Stdout.line "Hello"

--- a/crates/compiler/test_syntax/tests/snapshots/pass/space_before_colon.full.result-ast
+++ b/crates/compiler/test_syntax/tests/snapshots/pass/space_before_colon.full.result-ast
@@ -1,0 +1,116 @@
+Full {
+    header: Module {
+        comments: [],
+        header: App(
+            AppHeader {
+                before_name: [],
+                name: @4-13 PlainLine(
+                    "example",
+                ),
+                packages: Some(
+                    KeywordItem {
+                        keyword: Spaces {
+                            before: [
+                                Newline,
+                            ],
+                            item: PackagesKeyword,
+                            after: [],
+                        },
+                        item: [
+                            @29-40 PackageEntry {
+                                shorthand: "pf",
+                                spaces_after_shorthand: [],
+                                package_name: @34-40 PackageName(
+                                    "path",
+                                ),
+                            },
+                        ],
+                    },
+                ),
+                imports: Some(
+                    KeywordItem {
+                        keyword: Spaces {
+                            before: [
+                                Newline,
+                            ],
+                            item: ImportsKeyword,
+                            after: [],
+                        },
+                        item: [
+                            @57-66 Package(
+                                "pf",
+                                ModuleName(
+                                    "Stdout",
+                                ),
+                                [],
+                            ),
+                        ],
+                    },
+                ),
+                provides: ProvidesTo {
+                    provides_keyword: Spaces {
+                        before: [
+                            Newline,
+                        ],
+                        item: ProvidesKeyword,
+                        after: [],
+                    },
+                    entries: [
+                        @84-88 ExposedName(
+                            "main",
+                        ),
+                    ],
+                    types: None,
+                    to_keyword: Spaces {
+                        before: [],
+                        item: ToKeyword,
+                        after: [],
+                    },
+                    to: @94-96 ExistingPackage(
+                        "pf",
+                    ),
+                },
+            },
+        ),
+    },
+    module_defs: Defs {
+        tags: [
+            Index(2147483648),
+        ],
+        regions: [
+            @98-124,
+        ],
+        space_before: [
+            Slice(start = 0, length = 2),
+        ],
+        space_after: [
+            Slice(start = 2, length = 0),
+        ],
+        spaces: [
+            Newline,
+            Newline,
+        ],
+        type_defs: [],
+        value_defs: [
+            Body(
+                @98-102 Identifier(
+                    "main",
+                ),
+                @105-124 Apply(
+                    @105-116 Var {
+                        module_name: "Stdout",
+                        ident: "line",
+                    },
+                    [
+                        @117-124 Str(
+                            PlainLine(
+                                "Hello",
+                            ),
+                        ),
+                    ],
+                    Space,
+                ),
+            ),
+        ],
+    },
+}

--- a/crates/compiler/test_syntax/tests/snapshots/pass/space_before_colon.full.roc
+++ b/crates/compiler/test_syntax/tests/snapshots/pass/space_before_colon.full.roc
@@ -1,0 +1,6 @@
+app "example"
+    packages { pf : "path" }
+    imports [ pf.Stdout ]
+    provides [ main ] to pf
+
+main = Stdout.line "Hello"

--- a/crates/compiler/test_syntax/tests/test_snapshots.rs
+++ b/crates/compiler/test_syntax/tests/test_snapshots.rs
@@ -430,6 +430,7 @@ mod test_snapshots {
         pass/requires_type.header,
         pass/single_arg_closure.expr,
         pass/single_underscore_closure.expr,
+        pass/space_before_colon.full,
         pass/space_only_after_minus.expr,
         pass/spaced_singleton_list.expr,
         pass/spaces_inside_empty_list.expr,


### PR DESCRIPTION
Fixes #4902