### PR TITLE
aarch64 linux error fix

### DIFF
--- a/crates/compiler/build/src/target.rs
+++ b/crates/compiler/build/src/target.rs
@@ -149,13 +149,20 @@ pub fn target_machine(
 
     init_arch(target);
 
+    // workaround for issue:
+    #[cfg(all(target_arch = "aarch64", target_os = "macos"))]
+    let code_model = CodeModel::Large;
+
+    #[cfg(not(all(target_arch = "aarch64", target_os = "macos")))]
+    let code_model = CodeModel::Default;
+
     Target::from_name(arch).unwrap().create_target_machine(
         &TargetTriple::create(target_triple_str(target)),
         "generic",
         "",
         opt,
         reloc,
-        CodeModel::Default,
+        code_model,
     )
 }
 

--- a/crates/compiler/build/src/target.rs
+++ b/crates/compiler/build/src/target.rs
@@ -149,23 +149,14 @@ pub fn target_machine(
 
     init_arch(target);
 
-    let code_model = match target.architecture {
-        // LLVM 12 will not compile our programs without a large code model.
-        // The reason is not totally clear to me, but my guess is a few special-cases in
-        //   llvm/lib/Target/AArch64/AArch64ISelLowering.cpp (instructions)
-        //   llvm/lib/Target/AArch64/AArch64Subtarget.cpp (GoT tables)
-        // Revisit when upgrading to LLVM 13.
-        Architecture::Aarch64(..) => CodeModel::Large,
-        _ => CodeModel::Default,
-    };
 
     Target::from_name(arch).unwrap().create_target_machine(
         &TargetTriple::create(target_triple_str(target)),
         "generic",
-        "", // TODO: this probably should be TargetMachine::get_host_cpu_features() to enable all features.
+        "",
         opt,
         reloc,
-        code_model,
+        CodeModel::Default,
     )
 }
 

--- a/crates/compiler/build/src/target.rs
+++ b/crates/compiler/build/src/target.rs
@@ -149,7 +149,6 @@ pub fn target_machine(
 
     init_arch(target);
 
-
     Target::from_name(arch).unwrap().create_target_machine(
         &TargetTriple::create(target_triple_str(target)),
         "generic",


### PR DESCRIPTION
This fixes the error `relocation R_AARCH64_MOVW_UABS_G0_NC cannot be used against local symbol`.
This fix is already in #5577 but that PR is stuck on a difficult segfault.