### PR TITLE
Implement Malformed for AST types via a derive proc macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3728,6 +3728,7 @@ dependencies = [
  "roc_error_macros",
  "roc_module",
  "roc_region",
+ "roc_syntax_derive",
 ]
 
 [[package]]
@@ -3959,6 +3960,15 @@ dependencies = [
  "serde",
  "serde_json",
  "static_assertions",
+]
+
+[[package]]
+name = "roc_syntax_derive"
+version = "0.0.1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/crates/compiler/parse/Cargo.toml
+++ b/crates/compiler/parse/Cargo.toml
@@ -15,6 +15,7 @@ roc_collections = { path = "../collections" }
 roc_module = { path = "../module" }
 roc_region = { path = "../region" }
 roc_error_macros = { path = "../../error_macros" }
+roc_syntax_derive = { path = "../syntax_derive" }
 
 bumpalo.workspace = true
 encode_unicode.workspace = true

--- a/crates/compiler/parse/src/ident.rs
+++ b/crates/compiler/parse/src/ident.rs
@@ -1,9 +1,11 @@
+use crate::ast::Malformed;
 use crate::parser::Progress::{self, *};
 use crate::parser::{BadInputError, EExpr, ParseResult, Parser};
 use crate::state::State;
 use bumpalo::collections::vec::Vec;
 use bumpalo::Bump;
 use roc_region::all::{Position, Region};
+use roc_syntax_derive::Syntax;
 
 /// A tag, for example. Must start with an uppercase letter
 /// and then contain only letters and numbers afterwards - no dots allowed!
@@ -344,7 +346,7 @@ where
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Syntax, Debug, Copy, Clone, PartialEq, Eq)]
 pub enum Accessor<'a> {
     RecordField(&'a str),
     TupleIndex(&'a str),

--- a/crates/compiler/solve/src/specialize.rs
+++ b/crates/compiler/solve/src/specialize.rs
@@ -536,7 +536,7 @@ fn compact_lambda_set<P: Phase>(
         Err(()) => {
             // Do nothing other than to remove the concrete lambda to drop from the lambda set,
             // which we already did in 1b above.
-            trace_compact!(3iter_end_skipped. env.subs, t_f1);
+            trace_compact!(3iter_end_skipped.env.subs, t_f1);
             return OneCompactionResult::Compacted {
                 new_obligations: Default::default(),
                 new_lambda_sets_to_specialize: Default::default(),
@@ -559,7 +559,7 @@ fn compact_lambda_set<P: Phase>(
         Err(()) => {
             // Do nothing other than to remove the concrete lambda to drop from the lambda set,
             // which we already did in 1b above.
-            trace_compact!(3iter_end_skipped. env.subs, t_f1);
+            trace_compact!(3iter_end_skipped.env.subs, t_f1);
             return OneCompactionResult::Compacted {
                 new_obligations: Default::default(),
                 new_lambda_sets_to_specialize: Default::default(),
@@ -572,7 +572,7 @@ fn compact_lambda_set<P: Phase>(
     let t_f2 = deep_copy_var_in(env, target_rank, t_f2, env.arena);
 
     // 3. Unify `t_f1 ~ t_f2`.
-    trace_compact!(3iter_start. env.subs, this_lambda_set, t_f1, t_f2);
+    trace_compact!(3iter_start.env.subs, this_lambda_set, t_f1, t_f2);
     let (vars, new_obligations, new_lambda_sets_to_specialize, _meta) = unify(
         &mut env.uenv(),
         t_f1,
@@ -581,7 +581,7 @@ fn compact_lambda_set<P: Phase>(
         Polarity::Pos,
     )
     .expect_success("ambient functions don't unify");
-    trace_compact!(3iter_end. env.subs, t_f1);
+    trace_compact!(3iter_end.env.subs, t_f1);
 
     env.introduce(target_rank, &vars);
 

--- a/crates/compiler/syntax_derive/Cargo.toml
+++ b/crates/compiler/syntax_derive/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "roc_syntax_derive"
+description = "#[derive(Syntax)] implementation, for generating impls on the roc syntax tree"
+
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+version.workspace = true
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2.workspace = true
+quote.workspace = true
+syn.workspace = true

--- a/crates/compiler/syntax_derive/src/lib.rs
+++ b/crates/compiler/syntax_derive/src/lib.rs
@@ -1,0 +1,176 @@
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+use proc_macro2::Span;
+use quote::quote;
+use syn::{parse_macro_input, parse_quote, DataEnum, DataStruct, DeriveInput, Generics, Ident};
+
+#[proc_macro_derive(Syntax, attributes(malformed))]
+pub fn syntax_derive(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+
+    let malformed_impl = impl_malformed(&input);
+
+    // Build the impl
+    let expanded = quote! {
+        #malformed_impl
+    };
+
+    // Hand the output tokens back to the compiler
+    TokenStream::from(expanded)
+}
+
+/// Generate the `Malformed` impl for the given type.
+/// ```
+/// pub trait Malformed {
+///     /// Returns whether this node is malformed, or contains a malformed node (recursively).
+///     fn is_malformed(&self) -> bool;
+/// }
+/// ```
+///
+/// This impl defers to the Malformed impl of all fields, except in the case of an enum variant
+/// that's marked as `#[malformed]`, in which case it returns `true` immediately.
+fn impl_malformed(input: &DeriveInput) -> proc_macro2::TokenStream {
+    match &input.data {
+        syn::Data::Struct(s) => impl_malformed_struct(&input.ident, &input.generics, s),
+        syn::Data::Enum(e) => impl_malformed_enum(&input.ident, &input.generics, e),
+        syn::Data::Union(_) => panic!("Malformed cannot be derived for unions"),
+    }
+}
+
+fn impl_malformed_struct(
+    ident: &Ident,
+    generics: &Generics,
+    s: &DataStruct,
+) -> proc_macro2::TokenStream {
+    let fields = s.fields.iter().map(|field| {
+        let field_name = field.ident.as_ref().unwrap();
+
+        quote! {
+            if self.#field_name.is_malformed() {
+                return true;
+            }
+        }
+    });
+
+    // Add `: Malformed` bound to each type parameter in the generics.
+    let mut generics = generics.clone();
+    for param in &mut generics.params {
+        if let syn::GenericParam::Type(ref mut type_param) = *param {
+            type_param.bounds.push(parse_quote!(Malformed));
+        }
+    }
+
+    // Prepare the (impl_generics, ty_generics, where_clause) for the impl.
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
+    quote! {
+        impl #impl_generics Malformed for #ident #ty_generics #where_clause {
+            fn is_malformed(&self) -> bool {
+                #(#fields)*
+                false
+            }
+        }
+    }
+}
+
+fn impl_malformed_enum(
+    ident: &Ident,
+    generics: &Generics,
+    e: &DataEnum,
+) -> proc_macro2::TokenStream {
+    let variants = e
+        .variants
+        .iter()
+        .map(|variant| {
+            let variant_ident = &variant.ident;
+            let is_malformed = variant
+                .attrs
+                .iter()
+                .any(|attr| attr.path.is_ident("malformed"));
+            if is_malformed {
+                return match &variant.fields {
+                    syn::Fields::Named(_) => {
+                        quote! {
+                            #ident::#variant_ident { .. } => true
+                        }
+                    }
+                    syn::Fields::Unnamed(_) => {
+                        quote! {
+                            #ident::#variant_ident(..) => true
+                        }
+                    }
+                    syn::Fields::Unit => {
+                        quote! {
+                            #ident::#variant_ident => true
+                        }
+                    }
+                };
+            }
+
+            match &variant.fields {
+                syn::Fields::Named(named) => {
+                    let field_names: Vec<_> = named
+                        .named
+                        .iter()
+                        .map(|field| field.ident.as_ref().unwrap())
+                        .collect();
+                    let field_checks: Vec<_> = field_names
+                        .iter()
+                        .map(|name| quote! { if #name.is_malformed() { return true; } })
+                        .collect();
+                    quote! {
+                        #ident::#variant_ident { #(#field_names),* } => {
+                            #(#field_checks)*
+                            false
+                        }
+                    }
+                }
+                syn::Fields::Unnamed(unnamed) => {
+                    let field_names: Vec<_> = unnamed
+                        .unnamed
+                        .iter()
+                        .enumerate()
+                        .map(|(i, _)| Ident::new(&format!("field_{}", i), Span::call_site()))
+                        .collect();
+                    let field_checks: Vec<_> = field_names
+                        .iter()
+                        .map(|name| quote! { if #name.is_malformed() { return true; } })
+                        .collect();
+                    quote! {
+                        #ident::#variant_ident(#(#field_names),*) => {
+                            #(#field_checks)*
+                            false
+                        }
+                    }
+                }
+                syn::Fields::Unit => {
+                    quote! {
+                        #ident::#variant_ident => false
+                    }
+                }
+            }
+        })
+        .collect::<Vec<_>>();
+
+    // Add `: Malformed` bound to each type parameter in the generics.
+    let mut generics = generics.clone();
+    for param in &mut generics.params {
+        if let syn::GenericParam::Type(ref mut type_param) = *param {
+            type_param.bounds.push(parse_quote!(Malformed));
+        }
+    }
+
+    // Prepare the (impl_generics, ty_generics, where_clause) for the impl.
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
+    quote! {
+        impl #impl_generics Malformed for #ident #ty_generics #where_clause {
+            fn is_malformed(&self) -> bool {
+                match self {
+                    #(#variants),*
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
I'm using the name `Syntax` for the derive macro (distinct from `Malformed`), since the goal is to also do this for several other traits - notably, RemoveSpaces and (eventually) a BumpArbitrary implementation (Arbitrary, but allowing allocating into an bump arena).