### PR TITLE
Fixes for Windows zig builtin tests

### DIFF
--- a/.github/workflows/windows_tests.yml
+++ b/.github/workflows/windows_tests.yml
@@ -34,8 +34,12 @@ jobs:
           7z x zig-windows-x86_64-0.9.1.zip
           Add-Content $env:GITHUB_PATH "C:\zig-windows-x86_64-0.9.1\"
 
-      - name: zig version
-        run: zig version
+      - run: zig version
+
+      - name: zig tests
+        run: |
+          cd crates\compiler\builtins\bitcode\
+          zig build test
 
       - name: install rust nightly 1.70.0
         run: rustup install nightly-2023-04-15

--- a/crates/compiler/builtins/bitcode/src/compiler_rt.zig
+++ b/crates/compiler/builtins/bitcode/src/compiler_rt.zig
@@ -17,18 +17,9 @@ const v2u64 = @Vector(2, u64);
 
 // Export it as weak incase it is already linked in by something else.
 comptime {
-    @export(__muloti4, .{ .name = "__muloti4", .linkage = .Weak });
-    @export(__lshrti3, .{ .name = "__lshrti3", .linkage = .Weak });
-    if (want_windows_v2u64_abi) {
-        @export(__divti3_windows_x86_64, .{ .name = "__divti3", .linkage = .Weak });
-        @export(__modti3_windows_x86_64, .{ .name = "__modti3", .linkage = .Weak });
-        @export(__umodti3_windows_x86_64, .{ .name = "__umodti3", .linkage = .Weak });
-        @export(__udivti3_windows_x86_64, .{ .name = "__udivti3", .linkage = .Weak });
-        @export(__fixdfti_windows_x86_64, .{ .name = "__fixdfti", .linkage = .Weak });
-        @export(__fixsfti_windows_x86_64, .{ .name = "__fixsfti", .linkage = .Weak });
-        @export(__fixunsdfti_windows_x86_64, .{ .name = "__fixunsdfti", .linkage = .Weak });
-        @export(__fixunssfti_windows_x86_64, .{ .name = "__fixunssfti", .linkage = .Weak });
-    } else {
+    if (!want_windows_v2u64_abi) {
+        @export(__muloti4, .{ .name = "__muloti4", .linkage = .Weak });
+        @export(__lshrti3, .{ .name = "__lshrti3", .linkage = .Weak });
         @export(__divti3, .{ .name = "__divti3", .linkage = .Weak });
         @export(__modti3, .{ .name = "__modti3", .linkage = .Weak });
         @export(__umodti3, .{ .name = "__umodti3", .linkage = .Weak });

--- a/crates/compiler/builtins/bitcode/src/libc.zig
+++ b/crates/compiler/builtins/bitcode/src/libc.zig
@@ -9,7 +9,10 @@ comptime {
     // TODO: remove this workaround.
     // Our wasm llvm pipeline always links in memcpy.
     // As such, our impl will conflict.
-    if (arch != .wasm32) {
+    if (builtin.is_test and builtin.os.tag == .windows) {
+        // We don't need memcpy on Windows for tests because the tests are built with -lc
+        // lld-link: error: duplicate symbol: memcpy
+    } else if (arch != .wasm32) {
         @export(memcpy, .{ .name = "memcpy", .linkage = .Strong });
     }
 }

--- a/crates/compiler/builtins/bitcode/src/utils.zig
+++ b/crates/compiler/builtins/bitcode/src/utils.zig
@@ -52,6 +52,10 @@ comptime {
             @export(testing_roc_mmap, .{ .name = "roc_mmap", .linkage = .Strong });
             @export(testing_roc_shm_open, .{ .name = "roc_shm_open", .linkage = .Strong });
         }
+
+        if (builtin.os.tag == .windows) {
+            @export(roc_getppid_windows_stub, .{ .name = "roc_getppid", .linkage = .Strong });
+        }
     }
 }
 

--- a/crates/compiler/gen_llvm/src/llvm/externs.rs
+++ b/crates/compiler/gen_llvm/src/llvm/externs.rs
@@ -160,9 +160,16 @@ pub fn add_default_roc_externs(env: &Env<'_, '_, '_>) {
             }
         }
 
-        unreachable_function(env, "roc_getppid");
-        unreachable_function(env, "roc_mmap");
-        unreachable_function(env, "roc_shm_open");
+        match env.target_info.operating_system {
+            roc_target::OperatingSystem::Windows => {
+                // We don't need these functions on Windows
+            }
+            _ => {
+                unreachable_function(env, "roc_getppid");
+                unreachable_function(env, "roc_mmap");
+                unreachable_function(env, "roc_shm_open");
+            }
+        }
 
         add_sjlj_roc_panic(env)
     }


### PR DESCRIPTION
With these changes running `zig build test` on Windows in `crates/compiler/builtins/bitcode` results in all 153 tests passing. 

These currently look hacky and I'm not sure I am qualified to fix these. Request a review to understand what should be fixed so this could be merged.