### PR TITLE
updated arm64 CI timeout

### DIFF
--- a/.github/workflows/nightly_old_linux_arm64.yml
+++ b/.github/workflows/nightly_old_linux_arm64.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     name: build and package nightly release
     runs-on: [self-hosted, Linux, ARM64]
-    timeout-minutes: 90
+    timeout-minutes: 180
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
When the rust version is upgraded this can take a long time on a raspberry pi.