### PR TITLE
Fix macos ld warning

### DIFF
--- a/crates/compiler/build/src/link.rs
+++ b/crates/compiler/build/src/link.rs
@@ -1078,6 +1078,12 @@ fn link_macos(
             // "--gc-sections",
             "-arch",
             &arch,
+            // Suppress warnings, because otherwise it prints:
+            //
+            //   ld: warning: -undefined dynamic_lookup may not work with chained fixups
+            //
+            // We can't disable that option without breaking either x64 mac or ARM mac
+            "-w",
             "-macos_version_min",
             &get_macos_version(),
         ])

--- a/crates/linker/src/generate_dylib/macho.rs
+++ b/crates/linker/src/generate_dylib/macho.rs
@@ -71,6 +71,12 @@ pub fn create_dylib_macho(
             dummy_obj_file.path().to_str().unwrap(),
             "-o",
             dummy_lib_file.to_str().unwrap(),
+            // Suppress warnings, because otherwise it prints:
+            //
+            //   ld: warning: -undefined dynamic_lookup may not work with chained fixups
+            //
+            // We can't disable that option without breaking either x64 mac or ARM mac
+            "-w",
         ])
         .output()
         .unwrap();


### PR DESCRIPTION
Apparently the only way to suppress this is by giving `ld` the `-w` flag (suppress all warnings). As we've previously learned, changing the thing it's warning about either breaks macOS on x64 or on ARM, so suppressing the warning seems like the only option to prevent it from printing all the time.

In the future, switching to surgical linking on macOS will be a nicer permanent fix for this!