### PR TITLE
Allow expressions inside string interpolation

### DIFF
--- a/crates/compiler/can/src/operator.rs
+++ b/crates/compiler/can/src/operator.rs
@@ -157,7 +157,7 @@ pub fn desugar_expr<'a>(arena: &'a Bump, loc_expr: &'a Loc<Expr<'a>>) -> &'a Loc
                 let region = loc_expr.region;
                 let new_lines = Vec::from_iter_in(
                     lines
-                        .into_iter()
+                        .iter()
                         .map(|segments| desugar_str_segments(arena, segments)),
                     arena,
                 );
@@ -472,7 +472,7 @@ fn desugar_str_segments<'a>(
     segments: &'a [StrSegment<'a>],
 ) -> &'a [StrSegment<'a>] {
     Vec::from_iter_in(
-        segments.into_iter().map(|segment| match segment {
+        segments.iter().map(|segment| match segment {
             StrSegment::Plaintext(_) | StrSegment::Unicode(_) | StrSegment::EscapedChar(_) => {
                 *segment
             }

--- a/crates/repl_test/src/cli.rs
+++ b/crates/repl_test/src/cli.rs
@@ -3,7 +3,6 @@ use std::io::Write;
 use std::path::PathBuf;
 use std::process::{Command, ExitStatus, Stdio};
 
-use roc_repl_cli::repl_state::TIPS;
 use roc_repl_cli::{SHORT_INSTRUCTIONS, WELCOME_MESSAGE};
 use roc_test_utils::assert_multiline_str_eq;
 
@@ -153,22 +152,7 @@ pub fn expect_failure(input: &str, expected: &str) {
     match out.stdout.find(ERROR_MESSAGE_START) {
         Some(index) => {
             assert_multiline_str_eq!("", out.stderr.as_str());
-
-            // For some unknown reason, in the non-wasm tests, if there's a syntax error
-            // (e.g. in the nested string interpolation test), it prints the tips at the end.
-            // This doesn't happen in the actual CLI repl or in the wasm tests.
-            //
-            // Ideally we'd figure out why that's happening and stop it from happening,
-            // but since it only happens in the CLI tests, in the meantime this is an acceptable fix.
-            let tips_index = out
-                .stdout
-                .rfind(std::str::from_utf8(&strip_ansi_escapes::strip(TIPS).unwrap()).unwrap())
-                .unwrap_or(out.stdout.len());
-
-            assert_multiline_str_eq!(
-                expected.trim_end(),
-                out.stdout[index..tips_index].trim_end()
-            );
+            assert_multiline_str_eq!(expected, &out.stdout[index..]);
             assert!(out.status.success());
         }
         None => {

--- a/crates/repl_test/src/cli.rs
+++ b/crates/repl_test/src/cli.rs
@@ -3,6 +3,7 @@ use std::io::Write;
 use std::path::PathBuf;
 use std::process::{Command, ExitStatus, Stdio};
 
+use roc_repl_cli::repl_state::TIPS;
 use roc_repl_cli::{SHORT_INSTRUCTIONS, WELCOME_MESSAGE};
 use roc_test_utils::assert_multiline_str_eq;
 
@@ -152,7 +153,22 @@ pub fn expect_failure(input: &str, expected: &str) {
     match out.stdout.find(ERROR_MESSAGE_START) {
         Some(index) => {
             assert_multiline_str_eq!("", out.stderr.as_str());
-            assert_multiline_str_eq!(expected, &out.stdout[index..]);
+
+            // For some unknown reason, in the non-wasm tests, if there's a syntax error
+            // (e.g. in the nested string interpolation test), it prints the tips at the end.
+            // This doesn't happen in the actual CLI repl or in the wasm tests.
+            //
+            // Ideally we'd figure out why that's happening and stop it from happening,
+            // but since it only happens in the CLI tests, in the meantime this is an acceptable fix.
+            let tips_index = out
+                .stdout
+                .rfind(std::str::from_utf8(&strip_ansi_escapes::strip(TIPS).unwrap()).unwrap())
+                .unwrap_or(out.stdout.len());
+
+            assert_multiline_str_eq!(
+                expected.trim_end(),
+                out.stdout[index..tips_index].trim_end()
+            );
             assert!(out.status.success());
         }
         None => {

--- a/crates/repl_test/src/tests.rs
+++ b/crates/repl_test/src/tests.rs
@@ -1380,22 +1380,7 @@ fn interpolation_with_nested_interpolation() {
 
                 You can learn more about string interpolation at
                 <https://www.roc-lang.org/tutorial#string-interpolation>
-
-
-                Enter an expression to evaluate, or a definition (like x = 1) to use in future expressions.
-
-                Unless there was a compile-time error, expressions get automatically named so you can refer to them later.
-                For example, if you see # val1 after an output, you can now refer to that expression as val1 in future expressions.
-
-                Tips:
-
-                  - ctrl-v + ctrl-j makes a newline
-
-                  - :q to quit
-
-                  - :help"#
+            "#
         ),
-        // TODO figure out why the tests prints the repl help text at the end, but only after syntax errors or something?
-        // In the actual repl this doesn't happen, only in the test.
     );
 }

--- a/crates/repl_test/src/tests.rs
+++ b/crates/repl_test/src/tests.rs
@@ -1359,6 +1359,9 @@ fn interpolation_with_operator_desugaring() {
     );
 }
 
+// This test doesn't work on wasm because wasm expects <span>s, but
+// the point of the test is the string interpolation behavior.
+#[cfg(not(feature = "wasm"))]
 #[test]
 fn interpolation_with_nested_interpolation() {
     expect_failure(

--- a/crates/repl_test/src/tests.rs
+++ b/crates/repl_test/src/tests.rs
@@ -1322,3 +1322,79 @@ fn ordered_tag_union_memory_layout() {
         r#"Height 1 { column: 3, line: 2 } : Node"#,
     );
 }
+
+#[test]
+fn interpolation_with_nested_strings() {
+    expect_success(
+        indoc!(
+            r#"
+            "foo \(Str.joinWith ["a", "b", "c"] ", ") bar"
+            "#
+        ),
+        r#""foo a, b, c bar" : Str"#,
+    );
+}
+
+#[test]
+fn interpolation_with_num_to_str() {
+    expect_success(
+        indoc!(
+            r#"
+            "foo \(Num.toStr Num.maxI8) bar"
+            "#
+        ),
+        r#""foo 127 bar" : Str"#,
+    );
+}
+
+#[test]
+fn interpolation_with_operator_desugaring() {
+    expect_success(
+        indoc!(
+            r#"
+            "foo \(Num.toStr (1 + 2)) bar"
+            "#
+        ),
+        r#""foo 3 bar" : Str"#,
+    );
+}
+
+#[test]
+fn interpolation_with_nested_interpolation() {
+    expect_failure(
+        indoc!(
+            r#"
+            "foo \(Str.joinWith ["a\(Num.toStr 5)", "b"] "c")"
+            "#
+        ),
+        indoc!(
+            r#"
+                ── SYNTAX PROBLEM ──────────────────────────────────────────────────────────────
+
+                This string interpolation is invalid:
+
+                4│      "foo \(Str.joinWith ["a\(Num.toStr 5)", "b"] "c")"
+                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+                String interpolation cannot contain newlines, comments, or nested
+                interpolations.
+
+                You can learn more about string interpolation at
+                <https://www.roc-lang.org/tutorial#string-interpolation>
+
+
+                Enter an expression to evaluate, or a definition (like x = 1) to use in future expressions.
+
+                Unless there was a compile-time error, expressions get automatically named so you can refer to them later.
+                For example, if you see # val1 after an output, you can now refer to that expression as val1 in future expressions.
+
+                Tips:
+
+                  - ctrl-v + ctrl-j makes a newline
+
+                  - :q to quit
+
+                  - :help"#
+        ),
+    );
+}

--- a/crates/repl_test/src/tests.rs
+++ b/crates/repl_test/src/tests.rs
@@ -1380,7 +1380,22 @@ fn interpolation_with_nested_interpolation() {
 
                 You can learn more about string interpolation at
                 <https://www.roc-lang.org/tutorial#string-interpolation>
-            "#
+
+
+                Enter an expression to evaluate, or a definition (like x = 1) to use in future expressions.
+
+                Unless there was a compile-time error, expressions get automatically named so you can refer to them later.
+                For example, if you see # val1 after an output, you can now refer to that expression as val1 in future expressions.
+
+                Tips:
+
+                  - ctrl-v + ctrl-j makes a newline
+
+                  - :q to quit
+
+                  - :help"#
         ),
+        // TODO figure out why the tests prints the repl help text at the end, but only after syntax errors or something?
+        // In the actual repl this doesn't happen, only in the test.
     );
 }

--- a/crates/repl_test/src/tests.rs
+++ b/crates/repl_test/src/tests.rs
@@ -1376,8 +1376,7 @@ fn interpolation_with_nested_interpolation() {
                 4│      "foo \(Str.joinWith ["a\(Num.toStr 5)", "b"] "c")"
                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-                String interpolation cannot contain newlines, comments, or nested
-                interpolations.
+                String interpolations cannot contain newlines or other interpolations.
 
                 You can learn more about string interpolation at
                 <https://www.roc-lang.org/tutorial#string-interpolation>

--- a/crates/repl_test/src/tests.rs
+++ b/crates/repl_test/src/tests.rs
@@ -1395,5 +1395,7 @@ fn interpolation_with_nested_interpolation() {
 
                   - :help"#
         ),
+        // TODO figure out why the tests prints the repl help text at the end, but only after syntax errors or something?
+        // In the actual repl this doesn't happen, only in the test.
     );
 }

--- a/crates/reporting/src/error/canonicalize.rs
+++ b/crates/reporting/src/error/canonicalize.rs
@@ -557,7 +557,7 @@ pub fn can_problem<'b>(
             doc = alloc.stack([
                 alloc.reflow("This string interpolation is invalid:"),
                 alloc.region(lines.convert_region(region)),
-                alloc.reflow(r"String interpolation cannot contain newlines, comments, or nested interpolations."),
+                alloc.reflow(r"String interpolations cannot contain newlines or other interpolations."),
                 alloc.reflow(r"You can learn more about string interpolation at <https://www.roc-lang.org/tutorial#string-interpolation>"),
             ]);
 

--- a/crates/reporting/src/error/canonicalize.rs
+++ b/crates/reporting/src/error/canonicalize.rs
@@ -557,14 +557,8 @@ pub fn can_problem<'b>(
             doc = alloc.stack([
                 alloc.reflow("This string interpolation is invalid:"),
                 alloc.region(lines.convert_region(region)),
-                alloc.concat([
-                    alloc.reflow(r"I was expecting an identifier, like "),
-                    alloc.parser_suggestion("\\u(message)"),
-                    alloc.reflow(" or "),
-                    alloc.parser_suggestion("\\u(LoremIpsum.text)"),
-                    alloc.text("."),
-                ]),
-                alloc.reflow(r"Learn more about string interpolation at TODO"),
+                alloc.reflow(r"String interpolation cannot contain newlines, comments, or nested interpolations."),
+                alloc.reflow(r"You can learn more about string interpolation at <https://www.roc-lang.org/tutorial#string-interpolation>"),
             ]);
 
             title = SYNTAX_PROBLEM.to_string();

--- a/crates/reporting/tests/test_reporting.rs
+++ b/crates/reporting/tests/test_reporting.rs
@@ -5366,24 +5366,6 @@ Tab characters are not allowed."###,
     );
 
     test_report!(
-        interpolate_not_identifier,
-        r#""abc\(32)def""#,
-        @r###"
-    ── SYNTAX PROBLEM ──────────────────────────────────────── /code/proj/Main.roc ─
-
-    This string interpolation is invalid:
-
-    4│      "abc\(32)def"
-                  ^^
-
-    I was expecting an identifier, like \u(message) or
-    \u(LoremIpsum.text).
-
-    Learn more about string interpolation at TODO
-    "###
-    );
-
-    test_report!(
         unicode_too_large,
         r#""abc\u(110000)def""#,
         @r###"
@@ -10339,7 +10321,7 @@ In roc, functions are always written as a lambda, like{}
         optional_field_in_record_builder,
         indoc!(
             r#"
-            { 
+            {
                 a: <- apply "a",
                 b,
                 c ? "optional"
@@ -10355,7 +10337,7 @@ In roc, functions are always written as a lambda, like{}
     1│  app "test" provides [main] to "./platform"
     2│
     3│  main =
-    4│      { 
+    4│      {
     5│          a: <- apply "a",
     6│          b,
     7│          c ? "optional"
@@ -10444,7 +10426,7 @@ In roc, functions are always written as a lambda, like{}
             r#"
             succeed = \_ -> crash ""
 
-            succeed { 
+            succeed {
                 a: <- "a",
             }
             "#
@@ -13889,10 +13871,10 @@ In roc, functions are always written as a lambda, like{}
     ── TOO FEW ARGS ────────────────────────────────────────── /code/proj/Main.roc ─
 
     The `sub` function expects 2 arguments, but it got only 1:
-    
+
     4│      2 |> (Num.sub 3)
                   ^^^^^^^
-    
+
     Roc does not allow functions to be partially applied. Use a closure to
     make partial application explicit.
     "###
@@ -13909,10 +13891,10 @@ In roc, functions are always written as a lambda, like{}
     ── TOO FEW ARGS ────────────────────────────────────────── /code/proj/Main.roc ─
 
     The `sub` function expects 2 arguments, but it got only 1:
-    
+
     4│      2 |> (Num.sub 3) |> Num.sub 3
                   ^^^^^^^
-    
+
     Roc does not allow functions to be partially applied. Use a closure to
     make partial application explicit.
     "###

--- a/www/generate_tutorial/src/input/tutorial.md
+++ b/www/generate_tutorial/src/input/tutorial.md
@@ -41,21 +41,7 @@ You can also assign specific names to expressions. Try entering these lines:
 <pre><samp class="repl-prompt">greeting = <span class="literal">"Hi"</span></samp></pre>
 <pre><samp class="repl-prompt">audience = <span class="literal">"World"</span></samp></pre>
 
-From now until you exit the REPL, you can refer to either `greeting` or `audience` by those names!
-
-### [String Interpolation](#string-interpolation) {#string-interpolation}
-
-You can combine named strings together using _string interpolation_, like so:
-
-<pre><samp class="repl-prompt"><span class="literal">"<span class="str-esc">\(</span><span class="str-interp">greeting</span><span class="str-esc">)</span> there, <span class="str-esc">\(</span><span class="str-interp">audience</span><span class="str-esc">)</span>!"</span></samp></pre>
-
-If you put this into the REPL, you should see this output:
-
-<pre><samp><span class="literal">"Hi there, World!" </span><span class="colon">:</span> Str <span class="comment">               # val2</span></samp></pre>
-
-Notice that the REPL printed `# val2` here. This works just like `# val1` did before, but it chose the name `val2` for this expression because `val1` was already taken. As we continue entering more expressions into the REPL, you'll see more and more of these generated names—but they won't be mentioned again in this tutorial, since they're just a convenience.
-
-By the way, there are many other ways to put strings together! Check out the [documentation](https://www.roc-lang.org/builtins/Str) for the `Str` module for more.
+From now until you exit the REPL, you can refer to either `greeting` or `audience` by those names! We'll use these later on in the tutorial.
 
 ### [Arithmetic](#arithmetic) {#arithmetic}
 
@@ -65,9 +51,11 @@ Now let's try using an _operator_, specifically the `+` operator. Enter this:
 
 You should see this output:
 
-<pre><samp>2 <span class="colon">:</span> Num *</samp></pre>
+<pre><samp>2 <span class="colon">:</span> Num * <span class="comment">               # val2</span></samp></pre>
 
 According to the REPL, one plus one equals two. Sounds right!
+
+> Notice that the REPL printed `# val2` here. This works just like `# val1` did before, but it chose the name `val2` for this expression because `val1` was already taken. As we continue entering more expressions into the REPL, you'll see more and more of these generated names—but they won't be mentioned again in this tutorial, since they're just a convenience.
 
 Roc will respect [order of operations](https://en.wikipedia.org/wiki/Order_of_operations) when using multiple arithmetic operators like `+` and `-`, but you can use parentheses to specify exactly how they should be grouped.
 
@@ -75,7 +63,6 @@ Roc will respect [order of operations](https://en.wikipedia.org/wiki/Order_of_op
 
 -1 <span class="colon">:</span> Num *
 </span></samp></pre>
-
 
 ### [Calling Functions](#calling-functions) {#calling-functions}
 
@@ -117,6 +104,24 @@ That's not what we intended to do. Putting parentheses around the `Num.toStr 42`
 Both the `Str.concat` function and the `Num.toStr` function have a dot in their names. In `Str.concat`, `Str` is the name of a _module_, and `concat` is the name of a function inside that module. Similarly, `Num` is a module, and `toStr` is a function inside that module.
 
 We'll get into more depth about modules later, but for now you can think of a module as a named collection of functions. Eventually we'll discuss how to use them for more than that.
+
+### [String Interpolation](#string-interpolation) {#string-interpolation}
+
+An alternative syntax for `Str.concat` is _string interpolation_, which looks like this:
+
+<pre><samp class="repl-prompt"><span class="literal">"<span class="str-esc">\(</span><span class="str-interp">greeting</span><span class="str-esc">)</span> there, <span class="str-esc">\(</span><span class="str-interp">audience</span><span class="str-esc">)</span>!"</span></samp></pre>
+
+This is syntax sugar for calling `Str.concat` several times, like so:
+
+```roc
+Str.concat greeting (Str.concat " there, " (Str.concat audience "!"))
+```
+
+You can put entire single-line expressions inside the parentheses in string interpolation. For example:
+
+<pre><samp class="repl-prompt"><span class="literal">"Two plus three is: <span class="str-esc">\(</span><span class="str-interp">Num.toStr (2 + 3)</span><span class="str-esc">)</span>"</span></samp></pre>
+
+By the way, there are many other ways to put strings together! Check out the [documentation](https://www.roc-lang.org/builtins/Str) for the `Str` module for more.
 
 ## [Building an Application](#building-an-application) {#building-an-application}
 


### PR DESCRIPTION
String interpolation can now include any expression as long as it doesn't contain newlines, comments, or other string interpolations.