### PR TITLE
fix docs root link

### DIFF
--- a/crates/docs/src/lib.rs
+++ b/crates/docs/src/lib.rs
@@ -26,7 +26,6 @@ pub fn generate_docs_html(root_file: PathBuf) {
 
     // TODO get these from the platform's source file rather than hardcoding them!
     let package_name = "Documentation".to_string();
-    let version = String::new();
 
     // Clear out the generated-docs dir (we'll create a fresh one at the end)
     if build_dir.exists() {
@@ -143,8 +142,8 @@ pub fn generate_docs_html(root_file: PathBuf) {
                 page_title(package_name.as_str(), "").as_str(),
             )
             .replace(
-                "<!-- Package Name and Version -->",
-                render_name_and_version(package_name.as_str(), version.as_str()).as_str(),
+                "<!-- Package Name -->",
+                render_name_link(package_name.as_str()).as_str(),
             )
             .replace(
                 "<!-- Module Docs -->",
@@ -170,8 +169,8 @@ pub fn generate_docs_html(root_file: PathBuf) {
                 page_title(package_name.as_str(), module_name).as_str(),
             )
             .replace(
-                "<!-- Package Name and Version -->",
-                render_name_and_version(package_name.as_str(), version.as_str()).as_str(),
+                "<!-- Package Name -->",
+                render_name_link(package_name.as_str()).as_str(),
             )
             .replace(
                 "<!-- Module Docs -->",
@@ -354,33 +353,22 @@ fn base_url() -> String {
     }
 }
 
-fn render_name_and_version(name: &str, version: &str) -> String {
+fn render_name_link(name: &str) -> String {
     let mut buf = String::new();
-    let mut url_str = base_url();
-
-    url_str.push_str(name);
 
     push_html(&mut buf, "h1", vec![("class", "pkg-full-name")], {
         let mut link_buf = String::new();
 
-        push_html(&mut link_buf, "a", vec![("href", url_str.as_str())], name);
+        // link to root (= docs overview page)
+        push_html(
+            &mut link_buf,
+            "a",
+            vec![("href", base_url().as_str())],
+            name,
+        );
 
         link_buf
     });
-
-    let mut versions_url_str = base_url();
-
-    versions_url_str.push('/');
-    versions_url_str.push_str(name);
-    versions_url_str.push('/');
-    versions_url_str.push_str(version);
-
-    push_html(
-        &mut buf,
-        "a",
-        vec![("class", "version"), ("href", versions_url_str.as_str())],
-        version,
-    );
 
     buf
 }

--- a/crates/docs/src/lib.rs
+++ b/crates/docs/src/lib.rs
@@ -25,6 +25,7 @@ pub fn generate_docs_html(root_file: PathBuf) {
     let loaded_module = load_module_for_docs(root_file);
 
     // TODO get these from the platform's source file rather than hardcoding them!
+    // github.com/roc-lang/roc/issues/5712
     let package_name = "Documentation".to_string();
 
     // Clear out the generated-docs dir (we'll create a fresh one at the end)
@@ -353,6 +354,7 @@ fn base_url() -> String {
     }
 }
 
+// TODO render version as well
 fn render_name_link(name: &str) -> String {
     let mut buf = String::new();
 

--- a/crates/docs/src/static/index.html
+++ b/crates/docs/src/static/index.html
@@ -32,7 +32,7 @@
                 <polygon role="presentation" points="0,0 23.8834,3.21052 37.2438,19.0101 45.9665,16.6324 50.5,22 45,22 44.0315,26.3689 26.4673,39.3424 27.4527,45.2132 17.655,53 23.6751,22.7086" />
             </svg>
         </a>
-        <!-- Package Name and Version -->
+        <!-- Package Name -->
     </div>
     <div class="top-header-triangle">
         <!-- if the window gets big, this extends the purple bar on the top header to the left edge of the window -->

--- a/flake.nix
+++ b/flake.nix
@@ -112,6 +112,7 @@
         aliases = ''
           alias clippy='cargo clippy --workspace --tests --release -- --deny warnings'
           alias fmt='cargo fmt --all'
+          alias fmtc='cargo fmt --all -- --check'
         '';
 
       in {


### PR DESCRIPTION
The docs currently try to use a `/Documentation` link that does not work, this PR fixes that.