### PR TITLE
Fix 2 bugs in windows dev backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4784,7 +4784,6 @@ dependencies = [
  "criterion",
  "indoc",
  "inkwell",
- "lazy_static",
  "libc",
  "libloading",
  "roc_bitcode",

--- a/crates/compiler/gen_dev/src/generic64/mod.rs
+++ b/crates/compiler/gen_dev/src/generic64/mod.rs
@@ -985,7 +985,8 @@ impl<
                 let dst_reg = self.storage_manager.claim_float_reg(&mut self.buf, dst);
                 ASM::mov_freg64_freg64(&mut self.buf, dst_reg, CC::FLOAT_RETURN_REGS[0]);
             }
-            LayoutRepr::I128 | LayoutRepr::U128 => {
+            // Note that on windows there is only 1 general return register so we can't use this optimisation
+            LayoutRepr::I128 | LayoutRepr::U128 if CC::GENERAL_RETURN_REGS.len() > 1 => {
                 let offset = self.storage_manager.claim_stack_area(dst, 16);
 
                 ASM::mov_base32_reg64(&mut self.buf, offset, CC::GENERAL_RETURN_REGS[0]);

--- a/crates/compiler/gen_dev/src/generic64/x86_64.rs
+++ b/crates/compiler/gen_dev/src/generic64/x86_64.rs
@@ -1130,6 +1130,9 @@ impl CallConv<X86_64GeneralReg, X86_64FloatReg, X86_64Assembler> for X86_64Windo
     ];
     const SHADOW_SPACE_SIZE: u8 = 32;
 
+    // Refer https://learn.microsoft.com/en-us/cpp/build/x64-calling-convention?view=msvc-170#callercallee-saved-registers
+    // > The x64 ABI considers registers RBX, RBP, RDI, RSI, RSP, R12, R13, R14, R15, and XMM6-XMM15 nonvolatile.
+    // > They must be saved and restored by a function that uses them.
     #[inline(always)]
     fn general_callee_saved(reg: &X86_64GeneralReg) -> bool {
         matches!(
@@ -1146,16 +1149,23 @@ impl CallConv<X86_64GeneralReg, X86_64FloatReg, X86_64Assembler> for X86_64Windo
         )
     }
 
+    // Refer https://learn.microsoft.com/en-us/cpp/build/x64-calling-convention?view=msvc-170#callercallee-saved-registers
+    // > The x64 ABI considers registers RBX, RBP, RDI, RSI, RSP, R12, R13, R14, R15, and XMM6-XMM15 nonvolatile.
+    // > They must be saved and restored by a function that uses them.
     #[inline(always)]
     fn float_callee_saved(reg: &X86_64FloatReg) -> bool {
         matches!(
             reg,
-            X86_64FloatReg::XMM0
-                | X86_64FloatReg::XMM1
-                | X86_64FloatReg::XMM2
-                | X86_64FloatReg::XMM3
-                | X86_64FloatReg::XMM4
-                | X86_64FloatReg::XMM5
+            X86_64FloatReg::XMM6
+                | X86_64FloatReg::XMM7
+                | X86_64FloatReg::XMM8
+                | X86_64FloatReg::XMM9
+                | X86_64FloatReg::XMM10
+                | X86_64FloatReg::XMM11
+                | X86_64FloatReg::XMM12
+                | X86_64FloatReg::XMM13
+                | X86_64FloatReg::XMM14
+                | X86_64FloatReg::XMM15
         )
     }
 

--- a/crates/compiler/gen_dev/src/generic64/x86_64.rs
+++ b/crates/compiler/gen_dev/src/generic64/x86_64.rs
@@ -1303,7 +1303,7 @@ impl CallConv<X86_64GeneralReg, X86_64FloatReg, X86_64Assembler> for X86_64Windo
                 debug_assert_eq!(base_offset % 8, 0);
                 debug_assert_eq!(size, 16);
 
-                X86_64Assembler::mov_reg64_base32(buf, X86_64GeneralReg::RAX, base_offset + 0x00);
+                X86_64Assembler::mov_reg64_base32(buf, X86_64GeneralReg::RAX, base_offset);
                 X86_64Assembler::mov_reg64_base32(buf, X86_64GeneralReg::RDX, base_offset + 0x08);
             }
             _ if layout_interner.stack_size(*layout) == 0 => {}
@@ -1358,7 +1358,7 @@ impl CallConv<X86_64GeneralReg, X86_64FloatReg, X86_64Assembler> for X86_64Windo
             LayoutRepr::I128 | LayoutRepr::U128 => {
                 let size = layout_interner.stack_size(*layout);
                 let offset = storage_manager.claim_stack_area(sym, size);
-                X86_64Assembler::mov_base32_reg64(buf, offset + 0x00, X86_64GeneralReg::RAX);
+                X86_64Assembler::mov_base32_reg64(buf, offset, X86_64GeneralReg::RAX);
                 X86_64Assembler::mov_base32_reg64(buf, offset + 0x08, X86_64GeneralReg::RDX);
             }
             _ if layout_interner.stack_size(*layout) == 0 => {

--- a/crates/compiler/test_gen/Cargo.toml
+++ b/crates/compiler/test_gen/Cargo.toml
@@ -18,7 +18,13 @@ wasi_libc_sys = { path = "../../wasi-libc-sys" }
 
 tempfile.workspace = true
 
+[dependencies]
+roc_gen_llvm = { path = "../gen_llvm", optional = true }
+inkwell = { workspace = true, optional = true }
+
 [dev-dependencies]
+roc_gen_dev = { path = "../gen_dev" }
+roc_gen_wasm = { path = "../gen_wasm" }
 roc_bitcode = { path = "../builtins/bitcode" }
 roc_build = { path = "../build", features = ["target-aarch64", "target-x86_64", "target-wasm32"] }
 roc_builtins = { path = "../builtins" }
@@ -28,9 +34,6 @@ roc_command_utils = { path = "../../utils/command" }
 roc_constrain = { path = "../constrain" }
 roc_debug_flags = { path = "../debug_flags" }
 roc_error_macros = { path = "../../error_macros" }
-roc_gen_dev = { path = "../gen_dev" }
-roc_gen_llvm = { path = "../gen_llvm" }
-roc_gen_wasm = { path = "../gen_wasm" }
 roc_load = { path = "../load" }
 roc_module = { path = "../module" }
 roc_mono = { path = "../mono" }
@@ -50,8 +53,6 @@ roc_wasm_module = { path = "../../wasm_module" }
 bumpalo.workspace = true
 criterion.workspace = true
 indoc.workspace = true
-inkwell.workspace = true
-lazy_static.workspace = true
 libc.workspace = true
 libloading.workspace = true
 target-lexicon.workspace = true
@@ -61,7 +62,7 @@ tempfile.workspace = true
 [features]
 default = ["gen-llvm"]
 gen-dev = []
-gen-llvm = []
+gen-llvm = ["roc_gen_llvm", "inkwell"]
 gen-llvm-wasm = ["gen-llvm"]
 gen-wasm = []
 


### PR DESCRIPTION
fixes two issues in the windows dev backend. This _almost_ makes `gen_num` pass, but there is still a bug in `num_to_str` that turns out to be hard to debug. So for now this is not tested on CI yet.