### PR TITLE
Fix various missing docs implementations

### DIFF
--- a/crates/compiler/builtins/roc/Hash.roc
+++ b/crates/compiler/builtins/roc/Hash.roc
@@ -28,7 +28,7 @@ interface Hash
         Num.{ U8, U16, U32, U64, U128, I8, I16, I32, I64, I128, Nat, Dec },
     ]
 
-## A value that can hashed.
+## A value that can be hashed.
 Hash implements
     ## Hashes a value into a [Hasher].
     ## Note that [hash] does not produce a hash value itself; the hasher must be

--- a/crates/compiler/load_internal/src/docs.rs
+++ b/crates/compiler/load_internal/src/docs.rs
@@ -54,11 +54,30 @@ pub enum TypeAnnotation {
         fields: Vec<RecordField>,
         extension: Box<TypeAnnotation>,
     },
+    Tuple {
+        elems: Vec<TypeAnnotation>,
+        extension: Box<TypeAnnotation>,
+    },
     Ability {
         members: Vec<AbilityMember>,
     },
     Wildcard,
     NoTypeAnn,
+    Where {
+        ann: Box<TypeAnnotation>,
+        implements: Vec<ImplementsClause>,
+    },
+    As {
+        ann: Box<TypeAnnotation>,
+        name: String,
+        vars: Vec<String>,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub struct ImplementsClause {
+    pub name: String,
+    pub abilities: Vec<TypeAnnotation>,
 }
 
 #[derive(Debug, Clone)]
@@ -540,7 +559,57 @@ fn type_to_docs(in_func_type_ann: bool, type_annotation: ast::TypeAnnotation) ->
             }
         }
         ast::TypeAnnotation::Wildcard => TypeAnnotation::Wildcard,
-        _ => NoTypeAnn,
+        ast::TypeAnnotation::As(loc_ann, _comments, type_header) => TypeAnnotation::As {
+            ann: Box::new(type_to_docs(in_func_type_ann, loc_ann.value)),
+            name: type_header.name.value.to_string(),
+            vars: type_header
+                .vars
+                .iter()
+                .filter_map(|loc_pattern| match loc_pattern.value {
+                    ast::Pattern::Identifier(ident) => Some(ident.to_string()),
+                    _ => None,
+                })
+                .collect(),
+        },
+        ast::TypeAnnotation::Tuple { elems, ext } => {
+            let mut doc_elems = Vec::new();
+
+            for loc_ann in elems.items {
+                doc_elems.push(type_to_docs(in_func_type_ann, loc_ann.value));
+            }
+
+            let extension = match ext {
+                None => NoTypeAnn,
+                Some(ext_type_ann) => type_to_docs(in_func_type_ann, ext_type_ann.value),
+            };
+
+            TypeAnnotation::Tuple {
+                elems: doc_elems,
+                extension: Box::new(extension),
+            }
+        }
+        ast::TypeAnnotation::Where(loc_ann, implements) => TypeAnnotation::Where {
+            ann: Box::new(type_to_docs(in_func_type_ann, loc_ann.value)),
+            implements: implements
+                .iter()
+                .map(|clause| {
+                    let abilities = clause
+                        .value
+                        .abilities
+                        .iter()
+                        .map(|ability| type_to_docs(in_func_type_ann, ability.value))
+                        .collect();
+
+                    ImplementsClause {
+                        name: clause.value.var.value.item().to_string(),
+                        abilities,
+                    }
+                })
+                .collect(),
+        },
+        ast::TypeAnnotation::Malformed(_) | ast::TypeAnnotation::Inferred => {
+            TypeAnnotation::NoTypeAnn
+        }
     }
 }
 

--- a/crates/compiler/parse/src/ast.rs
+++ b/crates/compiler/parse/src/ast.rs
@@ -38,6 +38,13 @@ impl<'a, T> Spaced<'a, T> {
             }
         }
     }
+
+    pub fn item(&self) -> &T {
+        match self {
+            Spaced::Item(answer) => answer,
+            Spaced::SpaceBefore(next, _spaces) | Spaced::SpaceAfter(next, _spaces) => next.item(),
+        }
+    }
 }
 
 impl<'a, T: Debug> Debug for Spaced<'a, T> {

--- a/crates/docs/src/lib.rs
+++ b/crates/docs/src/lib.rs
@@ -651,9 +651,11 @@ fn type_annotation_to_html(
             if is_multiline {
                 new_line(buf);
                 indent(buf, indent_level + 1);
+            } else {
+                buf.push(' ');
             }
 
-            buf.push_str(" -> ");
+            buf.push_str("-> ");
 
             let mut next_indent_level = indent_level;
 


### PR DESCRIPTION
We now generate docs for:
* Ability declarations (e.g. `Hash.Hash`)
* Ability constraints in type annotations
* Tuples
* `as` in type annotations

Also this improves a minor off-by-one space error in `->` docs generation for function annotations.