### PR TITLE
ignore inspect_logging on windows

### DIFF
--- a/crates/cli/tests/cli_run.rs
+++ b/crates/cli/tests/cli_run.rs
@@ -939,6 +939,7 @@ mod cli_run {
     }
 
     #[test]
+    #[cfg_attr(windows, ignore)]
     fn inspect_logging() {
         test_roc_app_slim(
             "examples",


### PR DESCRIPTION
the basic-cli build process does not yet include the necessary files for windows