### PR TITLE
Always load .roc files with an explicit align 16

### DIFF
--- a/crates/compiler/load_internal/src/file.rs
+++ b/crates/compiler/load_internal/src/file.rs
@@ -3238,7 +3238,7 @@ fn load_package_from_disk<'a>(
 ) -> Result<Msg<'a>, LoadingProblem<'a>> {
     let module_start_time = Instant::now();
     let file_io_start = module_start_time;
-    let read_result = fs::read(filename);
+    let read_result = roc_parse::state::State::read_file(filename);
     let file_io_duration = file_io_start.elapsed();
 
     match read_result {
@@ -4038,7 +4038,7 @@ fn load_filename<'a>(
     module_start_time: Instant,
 ) -> Result<HeaderOutput<'a>, LoadingProblem<'a>> {
     let file_io_start = Instant::now();
-    let file = fs::read(&filename);
+    let file = roc_parse::state::State::read_file(&filename);
     let file_io_duration = file_io_start.elapsed();
 
     match file {

--- a/crates/compiler/parse/benches/bench_parse.rs
+++ b/crates/compiler/parse/benches/bench_parse.rs
@@ -10,13 +10,12 @@ pub fn parse_benchmark(c: &mut Criterion) {
         path.push("cli");
         path.push("false-interpreter");
         path.push("False.roc");
-        let src = std::fs::read_to_string(&path).unwrap();
+        let src = State::read_file(&path).unwrap();
 
         b.iter(|| {
             let arena = Bump::new();
 
-            let (_actual, state) =
-                module::parse_header(&arena, State::new(src.as_bytes())).unwrap();
+            let (_actual, state) = module::parse_header(&arena, State::new(&src)).unwrap();
 
             let min_indent = 0;
             let res = module_defs()
@@ -35,13 +34,12 @@ pub fn parse_benchmark(c: &mut Criterion) {
         path.push("builtins");
         path.push("roc");
         path.push("Num.roc");
-        let src = std::fs::read_to_string(&path).unwrap();
+        let src = State::read_file(&path).unwrap();
 
         b.iter(|| {
             let arena = Bump::new();
 
-            let (_actual, state) =
-                module::parse_header(&arena, State::new(src.as_bytes())).unwrap();
+            let (_actual, state) = module::parse_header(&arena, State::new(&src)).unwrap();
 
             let min_indent = 0;
             let res = module_defs()


### PR DESCRIPTION
This is potentially relevant in the future when parsing with SIMD.

Also, this centralizes the file loading logic before we parse, which is nice.