### PR TITLE
Make web REPL warning more accurate

### DIFF
--- a/www/public/repl/index.html
+++ b/www/public/repl/index.html
@@ -33,7 +33,7 @@
         ></textarea>
       </section>
     </div>
-    <p style="margin-top: 20px;">⚠️ This web REPL misses some features that are available in the CLI (roc repl) like defining variables without a final expression, which will result in the "Missing Final Expression" error.</p>
+    <p class="features-warning">⚠️ Unlike the CLI <code>roc repl</code>, the web REPL does not allow defining variables without a final expression. That will result in the "Missing Final Expression" error.</p>
     <script type="module" src="/repl/repl.js"></script>
   </body>
 </html>

--- a/www/public/repl/repl.css
+++ b/www/public/repl/repl.css
@@ -103,3 +103,9 @@ section.source textarea {
 .underline {
   text-decoration: underline;
 }
+.features-warning {
+  margin-top: 20px;
+  text-align: center;
+  font-size: small;
+  color: #999;
+}


### PR DESCRIPTION
The existing warning says there are "some features" missing, and that "Missing Final Expression" is only an _example_. But that makes it sound like it's generally unreliable and could be missing _any_ features, and nobody really knows!
The truth is that "Missing Final Expression" is the one and only feature that's missing. There is no uncertainty about it.

### Before

> ⚠️ This web REPL misses some features that are available in the CLI (roc repl) like defining variables without a final expression, which will result in the "Missing Final Expression" error.

<img width="1728" alt="Screenshot 2023-09-07 at 09 37 24" src="https://github.com/roc-lang/roc/assets/4647158/2238d103-ebb0-448a-916c-1776e5016d60">



### After

> ⚠️ Unlike the CLI <code>roc repl</code>, the web REPL does not allow defining variables without a final expression. That will result in the "Missing Final Expression" error.

<img width="1728" alt="Screenshot 2023-09-07 at 09 30 31" src="https://github.com/roc-lang/roc/assets/4647158/cf05ab9a-b7cb-4cab-979e-fd63e7b6defc">
