### PR TITLE
Revert "glue: find platform main file"

### DIFF
--- a/crates/glue/src/load.rs
+++ b/crates/glue/src/load.rs
@@ -340,6 +340,7 @@ pub fn load_types(
     let function_kind = FunctionKind::LambdaSet;
     let arena = &Bump::new();
     let LoadedModule {
+        module_id: home,
         mut can_problems,
         mut type_problems,
         mut declarations_by_id,
@@ -370,13 +371,6 @@ pub fn load_types(
             todo!("{:?}", problem);
         }
     });
-
-    // find the platform's main module
-    let home = declarations_by_id
-        .keys()
-        .find(|id| format!("{id:?}").trim_start_matches("pf.").is_empty())
-        .copied()
-        .unwrap();
 
     let decls = declarations_by_id.remove(&home).unwrap();
     let subs = solved.inner_mut();


### PR DESCRIPTION
This reverts commit 7be590fae9ab0a5ef65abd23190a499f5c9e99ca.

Unfortunately it breaks the `glue` command we're using at work, so I need to revert it so we can upgrade to the latest nightly `roc`! cc @folkertdev 

(We can diagnose later, but for now I just need to unblock the upgrade.)