### PR TITLE
Update to wyhash final 4

### DIFF
--- a/crates/compiler/test_mono/generated/dict.txt
+++ b/crates/compiler/test_mono/generated/dict.txt
@@ -1,28 +1,28 @@
-procedure Dict.1 (Dict.556):
-    let Dict.565 : List {[], []} = Array [];
-    let Dict.572 : U64 = 0i64;
-    let Dict.573 : U64 = 8i64;
-    let Dict.566 : List U64 = CallByName List.11 Dict.572 Dict.573;
-    let Dict.569 : I8 = CallByName Dict.39;
-    let Dict.570 : U64 = 8i64;
-    let Dict.567 : List I8 = CallByName List.11 Dict.569 Dict.570;
-    let Dict.568 : U64 = 0i64;
-    let Dict.564 : {List {[], []}, List U64, List I8, U64} = Struct {Dict.565, Dict.566, Dict.567, Dict.568};
-    ret Dict.564;
+procedure Dict.1 (Dict.554):
+    let Dict.563 : List {[], []} = Array [];
+    let Dict.570 : U64 = 0i64;
+    let Dict.571 : U64 = 8i64;
+    let Dict.564 : List U64 = CallByName List.11 Dict.570 Dict.571;
+    let Dict.567 : I8 = CallByName Dict.39;
+    let Dict.568 : U64 = 8i64;
+    let Dict.565 : List I8 = CallByName List.11 Dict.567 Dict.568;
+    let Dict.566 : U64 = 0i64;
+    let Dict.562 : {List {[], []}, List U64, List I8, U64} = Struct {Dict.563, Dict.564, Dict.565, Dict.566};
+    ret Dict.562;
 
 procedure Dict.39 ():
-    let Dict.571 : I8 = -128i64;
-    ret Dict.571;
+    let Dict.569 : I8 = -128i64;
+    ret Dict.569;
 
-procedure Dict.4 (Dict.562):
-    let Dict.100 : U64 = StructAtIndex 3 Dict.562;
-    let #Derived_gen.8 : List {[], []} = StructAtIndex 0 Dict.562;
+procedure Dict.4 (Dict.560):
+    let Dict.101 : U64 = StructAtIndex 3 Dict.560;
+    let #Derived_gen.8 : List {[], []} = StructAtIndex 0 Dict.560;
     dec #Derived_gen.8;
-    let #Derived_gen.7 : List U64 = StructAtIndex 1 Dict.562;
+    let #Derived_gen.7 : List U64 = StructAtIndex 1 Dict.560;
     dec #Derived_gen.7;
-    let #Derived_gen.6 : List I8 = StructAtIndex 2 Dict.562;
+    let #Derived_gen.6 : List I8 = StructAtIndex 2 Dict.560;
     dec #Derived_gen.6;
-    ret Dict.100;
+    ret Dict.101;
 
 procedure List.11 (List.124, List.125):
     let List.536 : List I8 = CallByName List.68 List.125;


### PR DESCRIPTION
This update makes wyhash bad seed resist.
In old version of wyhash certain seeds would ruin the randomness. Changes applied are based off of this diff: https://github.com/wangyi-fudan/wyhash/compare/a5995b9..77e50f2#diff-f2d41a4fb60c2bf10ac6c27f698993daf9aab9e9e2afc809d4966c6fa5d1c709

All test values were generated with the wyhash c++ library to verify the new implementation is correct. C++ Script here:
https://github.com/bhansconnect/roc-dict/blob/main/cc-hash-bench/src/wyhash-tests.cc