### PR TITLE
Rename Float to Frac in more places

### DIFF
--- a/crates/ast/src/constrain.rs
+++ b/crates/ast/src/constrain.rs
@@ -2140,7 +2140,7 @@ pub mod test_constrain {
                 3.14
                 "#
             ),
-            "Float *",
+            "Frac *",
         )
     }
 
@@ -2315,7 +2315,7 @@ pub mod test_constrain {
                     (\a -> a) 3.14
                 "#
             ),
-            "Float *",
+            "Frac *",
         );
     }
 

--- a/crates/compiler/builtins/README.md
+++ b/crates/compiler/builtins/README.md
@@ -99,7 +99,7 @@ fn atan() {
             Num.atan
             "#
         ),
-        "Float -> Float",
+        "Frac a -> Frac a",
     );
 }
 ```

--- a/crates/compiler/gen_llvm/src/llvm/lowlevel.rs
+++ b/crates/compiler/gen_llvm/src/llvm/lowlevel.rs
@@ -349,7 +349,7 @@ pub(crate) fn run_low_level<'a, 'ctx>(
             )
         }
         StrFromFloat => {
-            // Str.fromFloat : Float * -> Str
+            // Str.fromFloat : Frac * -> Str
             debug_assert_eq!(args.len(), 1);
 
             let (float, float_layout) = scope.load_symbol_and_layout(&args[0]);

--- a/crates/compiler/load_internal/tests/test_load.rs
+++ b/crates/compiler/load_internal/tests/test_load.rs
@@ -445,14 +445,14 @@ fn test_load_and_typecheck() {
         loaded_module,
         hashmap! {
             "floatTest" => "F64",
-            "divisionFn" => "Float a, Float a -> Float a",
-            "x" => "Float *",
+            "divisionFn" => "Frac a, Frac a -> Frac a",
+            "x" => "Frac *",
             "divisionTest" => "F64",
             "intTest" => "I64",
             "constantNum" => "Num *",
             "divisionTest" => "F64",
-            "divDep1ByDep2" => "Float a",
-            "fromDep2" => "Float a",
+            "divDep1ByDep2" => "Frac a",
+            "fromDep2" => "Frac a",
         },
     );
 }
@@ -546,12 +546,12 @@ fn iface_dep_types() {
     expect_types(
         loaded_module,
         hashmap! {
-            "blah2" => "Float *",
+            "blah2" => "Frac *",
             "blah3" => "Str",
             "str" => "Str",
-            "alwaysThree" => "* -> Float *",
+            "alwaysThree" => "* -> Frac *",
             "identity" => "a -> a",
-            "z" => "Float *",
+            "z" => "Frac *",
             "w" => "Dep1.Identity {}",
             "succeed" => "a -> Dep1.Identity a",
             "yay" => "Res.Res {} err",
@@ -568,12 +568,12 @@ fn app_dep_types() {
     expect_types(
         loaded_module,
         hashmap! {
-            "blah2" => "Float *",
+            "blah2" => "Frac *",
             "blah3" => "Str",
             "str" => "Str",
-            "alwaysThree" => "* -> Float *",
+            "alwaysThree" => "* -> Frac *",
             "identity" => "a -> a",
-            "z" => "Float *",
+            "z" => "Frac *",
             "w" => "Dep1.Identity {}",
             "succeed" => "a -> Dep1.Identity a",
             "yay" => "Res.Res {} err",

--- a/crates/compiler/mono/src/ir/literal.rs
+++ b/crates/compiler/mono/src/ir/literal.rs
@@ -88,7 +88,7 @@ pub fn make_num_literal<'a>(
             IntOrFloatValue::Int(IntValue::I128(n)) => NumLiteral::Int(n, width),
             IntOrFloatValue::Int(IntValue::U128(n)) => NumLiteral::U128(n),
             IntOrFloatValue::Float(..) => {
-                internal_error!("Float value where int was expected, should have been a type error")
+                internal_error!("Frac value where int was expected, should have been a type error")
             }
         },
         LayoutRepr::Builtin(Builtin::Float(width)) => match num_value {

--- a/crates/compiler/mono/src/layout/intern.rs
+++ b/crates/compiler/mono/src/layout/intern.rs
@@ -1485,7 +1485,7 @@ pub mod dbg_deep {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             match self.1 {
                 Builtin::Int(w) => f.debug_tuple("Int").field(&w).finish(),
-                Builtin::Float(w) => f.debug_tuple("Float").field(&w).finish(),
+                Builtin::Float(w) => f.debug_tuple("Frac").field(&w).finish(),
                 Builtin::Bool => f.debug_tuple("Bool").finish(),
                 Builtin::Decimal => f.debug_tuple("Decimal").finish(),
                 Builtin::Str => f.debug_tuple("Str").finish(),
@@ -1664,7 +1664,7 @@ pub mod dbg_stable {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             match self.1 {
                 Builtin::Int(w) => f.debug_tuple("Int").field(&w).finish(),
-                Builtin::Float(w) => f.debug_tuple("Float").field(&w).finish(),
+                Builtin::Float(w) => f.debug_tuple("Frac").field(&w).finish(),
                 Builtin::Bool => f.debug_tuple("Bool").finish(),
                 Builtin::Decimal => f.debug_tuple("Decimal").finish(),
                 Builtin::Str => f.debug_tuple("Str").finish(),

--- a/crates/compiler/solve/tests/solve_expr.rs
+++ b/crates/compiler/solve/tests/solve_expr.rs
@@ -91,7 +91,7 @@ mod solve_expr {
 
     #[test]
     fn float_literal() {
-        infer_eq("0.5", "Float *");
+        infer_eq("0.5", "Frac *");
     }
 
     #[test]
@@ -797,7 +797,7 @@ mod solve_expr {
                     (\a -> a) 3.14
                 "#
             ),
-            "Float *",
+            "Frac *",
         );
     }
 
@@ -1061,7 +1061,7 @@ mod solve_expr {
 
     #[test]
     fn two_field_record() {
-        infer_eq("{ x: 5, y : 3.14 }", "{ x : Num *, y : Float * }");
+        infer_eq("{ x: 5, y : 3.14 }", "{ x : Num *, y : Frac * }");
     }
 
     #[test]
@@ -1086,7 +1086,7 @@ mod solve_expr {
 
     #[test]
     fn tuple_literal_ty() {
-        infer_eq("(5, 3.14 )", "( Num *, Float * )*");
+        infer_eq("(5, 3.14 )", "( Num *, Frac * )*");
     }
 
     #[test]
@@ -2246,7 +2246,7 @@ mod solve_expr {
                     { numIdentity, x : numIdentity 42, y }
                 "#
             ),
-            "{ numIdentity : Num a -> Num a, x : Num *, y : Float * }",
+            "{ numIdentity : Num a -> Num a, x : Num *, y : Frac * }",
         );
     }
 
@@ -2423,7 +2423,7 @@ mod solve_expr {
                     threePointZero
                 "#
             ),
-            "Float *",
+            "Frac *",
         );
     }
 
@@ -3158,7 +3158,7 @@ mod solve_expr {
                 Num.toFrac
                 "#
             ),
-            "Num * -> Float a",
+            "Num * -> Frac a",
         );
     }
 
@@ -3170,7 +3170,7 @@ mod solve_expr {
                 Num.pow
                 "#
             ),
-            "Float a, Float a -> Float a",
+            "Frac a, Frac a -> Frac a",
         );
     }
 
@@ -3182,7 +3182,7 @@ mod solve_expr {
                 Num.ceiling
                 "#
             ),
-            "Float * -> Int a",
+            "Frac * -> Int a",
         );
     }
 
@@ -3194,7 +3194,7 @@ mod solve_expr {
                 Num.floor
                 "#
             ),
-            "Float * -> Int a",
+            "Frac * -> Int a",
         );
     }
 
@@ -3206,7 +3206,7 @@ mod solve_expr {
                 Num.div
                 "#
             ),
-            "Float a, Float a -> Float a",
+            "Frac a, Frac a -> Frac a",
         )
     }
 
@@ -3218,7 +3218,7 @@ mod solve_expr {
                 Num.divChecked
                 "#
             ),
-            "Float a, Float a -> Result (Float a) [DivByZero]",
+            "Frac a, Frac a -> Result (Frac a) [DivByZero]",
         )
     }
 
@@ -3278,7 +3278,7 @@ mod solve_expr {
                 Num.atan
                 "#
             ),
-            "Float a -> Float a",
+            "Frac a -> Frac a",
         );
     }
 
@@ -3663,7 +3663,7 @@ mod solve_expr {
                     negatePoint { x: 1, y: 2.1, z: 0x3 }
                 "#
             ),
-            "{ x : Num *, y : Float *, z : Int * }",
+            "{ x : Num *, y : Frac *, z : Int * }",
         );
     }
 
@@ -3680,7 +3680,7 @@ mod solve_expr {
                     { a, b }
                 "#
             ),
-            "{ a : { x : Num *, y : Float *, z : c }, b : { blah : Str, x : Num *, y : Float *, z : c1 } }",
+            "{ a : { x : Num *, y : Frac *, z : c }, b : { blah : Str, x : Num *, y : Frac *, z : c1 } }",
         );
     }
 

--- a/crates/compiler/types/src/pretty_print.rs
+++ b/crates/compiler/types/src/pretty_print.rs
@@ -906,7 +906,7 @@ fn write_float<'a>(
         Alias(Symbol::NUM_BINARY64, _, _, _) => buf.push_str("F64"),
         Alias(Symbol::NUM_DECIMAL, _, _, _) => buf.push_str("Dec"),
         _ => write_parens!(write_parens, buf, {
-            buf.push_str("Float ");
+            buf.push_str("Frac ");
             write_content(env, ctx, var, subs, buf, parens, pol);
         }),
     }

--- a/crates/repl_test/src/tests.rs
+++ b/crates/repl_test/src/tests.rs
@@ -32,12 +32,12 @@ fn literal_0x42() {
 
 #[test]
 fn literal_0point0() {
-    expect_success("0.0", "0 : Float *");
+    expect_success("0.0", "0 : Frac *");
 }
 
 #[test]
 fn literal_4point2() {
-    expect_success("4.2", "4.2 : Float *");
+    expect_success("4.2", "4.2 : Frac *");
 }
 
 #[test]
@@ -52,7 +52,7 @@ fn int_addition() {
 
 #[test]
 fn float_addition() {
-    expect_success("1.1 + 2", "3.1 : Float *");
+    expect_success("1.1 + 2", "3.1 : Frac *");
 }
 
 #[cfg(not(feature = "wasm"))]
@@ -185,7 +185,7 @@ fn tag_in_record() {
 #[test]
 fn single_element_tag_union() {
     expect_success("True 1", "True 1 : [True (Num *)]");
-    expect_success("Foo 1 3.14", "Foo 1 3.14 : [Foo (Num *) (Float *)]");
+    expect_success("Foo 1 3.14", "Foo 1 3.14 : [Foo (Num *) (Frac *)]");
 }
 
 #[test]
@@ -241,7 +241,7 @@ fn tag_with_arguments() {
 
     expect_success(
         "if 1 == 1 then True 3 else False 3.14",
-        "True 3 : [False (Float *), True (Num *)]",
+        "True 3 : [False (Frac *), True (Num *)]",
     )
 }
 
@@ -296,7 +296,7 @@ fn literal_int_list() {
 
 #[test]
 fn literal_float_list() {
-    expect_success("[1.1, 2.2, 3.3]", "[1.1, 2.2, 3.3] : List (Float *)");
+    expect_success("[1.1, 2.2, 3.3]", "[1.1, 2.2, 3.3] : List (Frac *)");
 }
 
 #[test]
@@ -332,7 +332,7 @@ fn nested_int_list() {
 fn nested_float_list() {
     expect_success(
         r#"[[[4, 3, 2], [1, 0.0]], [[]], []]"#,
-        r#"[[[4, 3, 2], [1, 0]], [[]], []] : List (List (List (Float *)))"#,
+        r#"[[[4, 3, 2], [1, 0]], [[]], []] : List (List (List (Frac *)))"#,
     );
 }
 
@@ -411,7 +411,7 @@ fn num_mul_checked() {
 fn list_concat() {
     expect_success(
         "List.concat [1.1, 2.2] [3.3, 4.4, 5.5]",
-        "[1.1, 2.2, 3.3, 4.4, 5.5] : List (Float *)",
+        "[1.1, 2.2, 3.3, 4.4, 5.5] : List (Frac *)",
     );
 }
 
@@ -428,7 +428,7 @@ fn list_contains() {
 fn list_sum() {
     expect_success("List.sum []", "0 : Num a");
     expect_success("List.sum [1, 2, 3]", "6 : Num *");
-    expect_success("List.sum [1.1, 2.2, 3.3]", "6.6 : Float *");
+    expect_success("List.sum [1.1, 2.2, 3.3]", "6.6 : Frac *");
 }
 
 #[cfg(not(feature = "wasm"))]
@@ -471,7 +471,7 @@ fn basic_1_field_i64_record() {
 fn basic_1_field_f64_record() {
     // Even though this gets unwrapped at runtime, the repl should still
     // report it as a record
-    expect_success("{ foo: 4.2 }", "{ foo: 4.2 } : { foo : Float * }");
+    expect_success("{ foo: 4.2 }", "{ foo: 4.2 } : { foo : Frac * }");
 }
 
 #[test]
@@ -490,7 +490,7 @@ fn nested_1_field_f64_record() {
     // report it as a record
     expect_success(
         "{ foo: { bar: { baz: 4.2 } } }",
-        "{ foo: { bar: { baz: 4.2 } } } : { foo : { bar : { baz : Float * } } }",
+        "{ foo: { bar: { baz: 4.2 } } } : { foo : { bar : { baz : Frac * } } }",
     );
 }
 
@@ -506,7 +506,7 @@ fn basic_2_field_i64_record() {
 fn basic_2_field_f64_record() {
     expect_success(
         "{ foo: 4.1, bar: 2.3 }",
-        "{ bar: 2.3, foo: 4.1 } : { bar : Float *, foo : Float * }",
+        "{ bar: 2.3, foo: 4.1 } : { bar : Frac *, foo : Frac * }",
     );
 }
 
@@ -514,7 +514,7 @@ fn basic_2_field_f64_record() {
 fn basic_2_field_mixed_record() {
     expect_success(
         "{ foo: 4.1, bar: 2 }",
-        "{ bar: 2, foo: 4.1 } : { bar : Num *, foo : Float * }",
+        "{ bar: 2, foo: 4.1 } : { bar : Num *, foo : Frac * }",
     );
 }
 
@@ -522,7 +522,7 @@ fn basic_2_field_mixed_record() {
 fn basic_3_field_record() {
     expect_success(
         "{ foo: 4.1, bar: 2, baz: 0x5 }",
-        "{ bar: 2, baz: 5, foo: 4.1 } : { bar : Num *, baz : Int *, foo : Float * }",
+        "{ bar: 2, baz: 5, foo: 4.1 } : { bar : Num *, baz : Int *, foo : Frac * }",
     );
 }
 
@@ -537,7 +537,7 @@ fn list_of_1_field_records() {
 fn list_of_2_field_records() {
     expect_success(
         "[{ foo: 4.1, bar: 2 }]",
-        "[{ bar: 2, foo: 4.1 }] : List { bar : Num *, foo : Float * }",
+        "[{ bar: 2, foo: 4.1 }] : List { bar : Num *, foo : Frac * }",
     );
 }
 
@@ -608,7 +608,7 @@ fn multiline_string_wasm() {
 fn list_of_3_field_records() {
     expect_success(
         "[{ foo: 4.1, bar: 2, baz: 0x3 }]",
-        "[{ bar: 2, baz: 3, foo: 4.1 }] : List { bar : Num *, baz : Int *, foo : Float * }",
+        "[{ bar: 2, baz: 3, foo: 4.1 }] : List { bar : Num *, baz : Int *, foo : Frac * }",
     );
 }
 


### PR DESCRIPTION
Now when we put in the repl `0.1 + 0.2` and the result is a `Dec` (see https://github.com/roc-lang/roc/pull/5792) it doesn't print `0.3 : Float *` - which is not the answer we would have gotten from a floating-point calculation!