### PR TITLE
Implement error messages for (parts of) BadInputError

### DIFF
--- a/crates/compiler/parse/src/parser.rs
+++ b/crates/compiler/parse/src/parser.rs
@@ -49,7 +49,6 @@ impl Progress {
 pub enum SyntaxError<'a> {
     Unexpected(Region),
     OutdentedTooFar,
-    TooManyLines,
     Eof(Region),
     InvalidPattern,
     BadUtf8,
@@ -266,10 +265,6 @@ pub enum BadInputError {
     HasTab,
     HasMisplacedCarriageReturn,
     HasAsciiControl,
-    ///
-    TooManyLines,
-    ///
-    ///
     BadUtf8,
 }
 

--- a/crates/reporting/src/error/parse.rs
+++ b/crates/reporting/src/error/parse.rs
@@ -3858,9 +3858,9 @@ fn to_space_report<'a>(
             let region = LineColumnRegion::from_pos(lines.convert_pos(pos));
 
             let doc = alloc.stack([
-                alloc.reflow("I encountered a tab character"),
+                alloc.reflow("I encountered a tab character:"),
                 alloc.region(region),
-                alloc.reflow("Tab characters are not allowed."),
+                alloc.reflow("Tab characters are not allowed, use spaces instead."),
             ]);
 
             Report {
@@ -3875,7 +3875,7 @@ fn to_space_report<'a>(
             let region = LineColumnRegion::from_pos(lines.convert_pos(pos));
 
             let doc = alloc.stack([
-                alloc.reflow("I encountered an ASCII control character"),
+                alloc.reflow("I encountered an ASCII control character:"),
                 alloc.region(region),
                 alloc.reflow("ASCII control characters are not allowed."),
             ]);
@@ -3892,7 +3892,7 @@ fn to_space_report<'a>(
             let region = LineColumnRegion::from_pos(lines.convert_pos(pos));
 
             let doc = alloc.stack([
-                alloc.reflow(r"I encountered a carriage return (\r)"),
+                alloc.reflow(r"I encountered a stray carriage return (\r):"),
                 alloc.region(region),
                 alloc.reflow(r"A carriage return (\r) has to be followed by a newline (\n)."),
             ]);

--- a/crates/reporting/src/error/parse.rs
+++ b/crates/reporting/src/error/parse.rs
@@ -3888,6 +3888,23 @@ fn to_space_report<'a>(
             }
         }
 
+        BadInputError::HasMisplacedCarriageReturn => {
+            let region = LineColumnRegion::from_pos(lines.convert_pos(pos));
+
+            let doc = alloc.stack([
+                alloc.reflow(r"I encountered a carriage return (\r)"),
+                alloc.region(region),
+                alloc.reflow(r"A carriage return (\r) has to be followed by a newline (\n)."),
+            ]);
+
+            Report {
+                filename,
+                doc,
+                title: "MISPLACED CARRIAGE RETURN".to_string(),
+                severity: Severity::RuntimeError,
+            }
+        }
+
         _ => todo!("unhandled type parse error: {:?}", &parse_problem),
     }
 }

--- a/crates/reporting/src/error/parse.rs
+++ b/crates/reporting/src/error/parse.rs
@@ -3858,15 +3858,32 @@ fn to_space_report<'a>(
             let region = LineColumnRegion::from_pos(lines.convert_pos(pos));
 
             let doc = alloc.stack([
-                alloc.reflow(r"I encountered a tab character"),
+                alloc.reflow("I encountered a tab character"),
                 alloc.region(region),
-                alloc.concat([alloc.reflow("Tab characters are not allowed.")]),
+                alloc.reflow("Tab characters are not allowed."),
             ]);
 
             Report {
                 filename,
                 doc,
                 title: "TAB CHARACTER".to_string(),
+                severity: Severity::RuntimeError,
+            }
+        }
+
+        BadInputError::HasAsciiControl => {
+            let region = LineColumnRegion::from_pos(lines.convert_pos(pos));
+
+            let doc = alloc.stack([
+                alloc.reflow("I encountered an ASCII control character"),
+                alloc.region(region),
+                alloc.reflow("ASCII control characters are not allowed."),
+            ]);
+
+            Report {
+                filename,
+                doc,
+                title: "ASII CONTROL CHARACTER".to_string(),
                 severity: Severity::RuntimeError,
             }
         }

--- a/crates/reporting/src/report.rs
+++ b/crates/reporting/src/report.rs
@@ -674,7 +674,15 @@ impl<'a> RocDocAllocator<'a> {
             let line_number = line_number_string;
             let this_line_number_length = line_number.len();
 
-            let line: &str = self.src_lines.get(i as usize).unwrap_or(&"");
+            // filter out any escape characters for the current line that could mess up the output.
+            let line: String = self
+                .src_lines
+                .get(i as usize)
+                .unwrap_or(&"")
+                .chars()
+                .filter(|&c| !c.is_ascii_control() || c == '\t')
+                .collect::<String>();
+
             let is_line_empty = line.trim().is_empty();
             let rest_of_line = if !is_line_empty {
                 self.text(line)

--- a/crates/reporting/tests/test_reporting.rs
+++ b/crates/reporting/tests/test_reporting.rs
@@ -4535,12 +4535,12 @@ mod test_reporting {
         @r###"
     ── TAB CHARACTER ──────────────────────────────── tmp/record_type_tab/Test.roc ─
 
-    I encountered a tab character
+    I encountered a tab character:
 
     4│      f : { foo 	 }
                       ^
 
-    Tab characters are not allowed.
+    Tab characters are not allowed, use spaces instead.
     "###
     );
 
@@ -4550,12 +4550,12 @@ mod test_reporting {
         @r###"
     ── TAB CHARACTER ─────────────────────────────── tmp/comment_with_tab/Test.roc ─
 
-    I encountered a tab character
+    I encountered a tab character:
 
     4│      # comment with a 	
                              ^
 
-    Tab characters are not allowed.
+    Tab characters are not allowed, use spaces instead.
     "###
     );
 
@@ -4565,7 +4565,7 @@ mod test_reporting {
         @r###"
     ── ASII CONTROL CHARACTER ──────── tmp/comment_with_control_character/Test.roc ─
 
-    I encountered an ASCII control character
+    I encountered an ASCII control character:
 
     4│      # comment with a 
                              ^
@@ -4580,7 +4580,7 @@ mod test_reporting {
         @r###"
     ── MISPLACED CARRIAGE RETURN ──────── tmp/record_type_carriage_return/Test.roc ─
 
-    I encountered a carriage return (\r)
+    I encountered a stray carriage return (\r):
 
     4│      f : {  foo }
                   ^

--- a/crates/reporting/tests/test_reporting.rs
+++ b/crates/reporting/tests/test_reporting.rs
@@ -4547,21 +4547,38 @@ mod test_reporting {
     test_report!(
         comment_with_tab,
         "# comment with a \t\n4",
+        @r###"
+    ── TAB CHARACTER ─────────────────────────────── tmp/comment_with_tab/Test.roc ─
+
+    I encountered a tab character
+
+    4│      # comment with a 	
+                             ^
+
+    Tab characters are not allowed.
+    "###
+    );
+
+    
+    test_report!(
+        comment_with_control_character,
+        "# comment with a \x07\n",
         |golden| pretty_assertions::assert_eq!(
             golden,
             &format!(
-                r###"── TAB CHARACTER ─────────────────────────────── tmp/comment_with_tab/Test.roc ─
+                r###"── ASII CONTROL CHARACTER ──────── tmp/comment_with_control_character/Test.roc ─
 
-I encountered a tab character
+I encountered an ASCII control character
 
 4│      # comment with a {}
                          ^
 
-Tab characters are not allowed."###,
-                "\t"
+ASCII control characters are not allowed."###,
+                "\x07"
             )
         )
     );
+
 
     // TODO bad error message
     test_report!(

--- a/crates/reporting/tests/test_reporting.rs
+++ b/crates/reporting/tests/test_reporting.rs
@@ -4559,26 +4559,35 @@ mod test_reporting {
     "###
     );
 
-    
     test_report!(
         comment_with_control_character,
         "# comment with a \x07\n",
-        |golden| pretty_assertions::assert_eq!(
-            golden,
-            &format!(
-                r###"── ASII CONTROL CHARACTER ──────── tmp/comment_with_control_character/Test.roc ─
+        @r###"
+    ── ASII CONTROL CHARACTER ──────── tmp/comment_with_control_character/Test.roc ─
 
-I encountered an ASCII control character
+    I encountered an ASCII control character
 
-4│      # comment with a {}
-                         ^
+    4│      # comment with a 
+                             ^
 
-ASCII control characters are not allowed."###,
-                "\x07"
-            )
-        )
+    ASCII control characters are not allowed.
+    "###
     );
 
+    test_report!(
+        record_type_carriage_return,
+        "f : { \r foo }",
+        @r###"
+    ── MISPLACED CARRIAGE RETURN ──────── tmp/record_type_carriage_return/Test.roc ─
+
+    I encountered a carriage return (\r)
+
+    4│      f : {  foo }
+                  ^
+
+    A carriage return (\r) has to be followed by a newline (\n).
+    "###
+    );
 
     // TODO bad error message
     test_report!(


### PR DESCRIPTION
Tries to fix #5793

I did not implement all of `BadInputError`, because I don't quite understand when `TooManyLines` and `BadUtf8` happen. They are checked at a different place.

To make the output work, I had to filter out the control characters, because the terminal will respect a misplaced CR and therefore mess up the output. So it made sense to me to filter it out, but I'm not sure if I did it correctly and if I did it in the right place.

