### PR TITLE
fix  memcpy on windows

### DIFF
--- a/.github/workflows/windows_tests.yml
+++ b/.github/workflows/windows_tests.yml
@@ -59,6 +59,11 @@ jobs:
       - name: Test setjmp/longjmp logic
         run: cargo test-gen-dev --locked --release nat_alias && cargo test-gen-dev --locked --release a_crash
 
+      - name: Run gen tests
+        run: cargo test-gen-llvm --locked --release gen_str 
+        
       - name: Actually run the tests.
         run: cargo test --locked --release -p roc_ident -p roc_region -p roc_collections -p roc_can -p roc_types -p roc_solve -p roc_mono -p roc_gen_dev -p roc_gen_wasm -p roc_serialize -p roc_editor -p roc_linker -p roc_cli
+
+      
 

--- a/crates/compiler/builtins/bitcode/src/libc.zig
+++ b/crates/compiler/builtins/bitcode/src/libc.zig
@@ -28,15 +28,7 @@ pub fn memcpy(noalias dest: [*]u8, noalias src: [*]const u8, len: usize) callcon
     switch (arch) {
         // x86_64 has a special optimized memcpy that can use avx2.
         .x86_64 => {
-            // On windows the folly memcpy segfaults for unclear reasons
-            // TODO investigate why it segfaults
-            if (builtin.os.tag == .windows) {
-                std.mem.copy(u8, dest[0..len], src[0..len]);
-
-                return dest;
-            } else {
-                return memcpy_target(dest, src, len);
-            }
+            return memcpy_target(dest, src, len);
         },
         else => {
             return musl.memcpy(dest, src, len);

--- a/crates/compiler/builtins/bitcode/src/libc.zig
+++ b/crates/compiler/builtins/bitcode/src/libc.zig
@@ -28,7 +28,15 @@ pub fn memcpy(noalias dest: [*]u8, noalias src: [*]const u8, len: usize) callcon
     switch (arch) {
         // x86_64 has a special optimized memcpy that can use avx2.
         .x86_64 => {
-            return memcpy_target(dest, src, len);
+            // On windows the folly memcpy segfaults for unclear reasons
+            // TODO investigate why it segfaults
+            if (builtin.os.tag == .windows) {
+                std.mem.copy(u8, dest[0..len], src[0..len]);
+
+                return dest;
+            } else {
+                return memcpy_target(dest, src, len);
+            }
         },
         else => {
             return musl.memcpy(dest, src, len);

--- a/crates/compiler/builtins/bitcode/src/libc/folly/memcpy.zig
+++ b/crates/compiler/builtins/bitcode/src/libc/folly/memcpy.zig
@@ -14,5 +14,5 @@ comptime {
     }
 }
 
-pub extern fn __folly_memcpy_prefetchw(noalias dest: [*]u8, noalias src: [*]const u8, len: usize) callconv(.C) [*]u8;
-pub extern fn __folly_memcpy_prefetcht0(noalias dest: [*]u8, noalias src: [*]const u8, len: usize) callconv(.C) [*]u8;
+pub extern fn __folly_memcpy_prefetchw(noalias dest: [*]u8, noalias src: [*]const u8, len: usize) callconv(.SysV) [*]u8;
+pub extern fn __folly_memcpy_prefetcht0(noalias dest: [*]u8, noalias src: [*]const u8, len: usize) callconv(.SysV) [*]u8;

--- a/crates/compiler/builtins/src/bitcode.rs
+++ b/crates/compiler/builtins/src/bitcode.rs
@@ -61,6 +61,13 @@ impl FloatWidth {
             _ => None,
         }
     }
+
+    pub const fn type_name(&self) -> &'static str {
+        match self {
+            Self::F32 => "f32",
+            Self::F64 => "f64",
+        }
+    }
 }
 
 #[repr(u8)]

--- a/crates/compiler/gen_llvm/src/llvm/lowlevel.rs
+++ b/crates/compiler/gen_llvm/src/llvm/lowlevel.rs
@@ -20,7 +20,7 @@ use roc_mono::{
     },
     list_element_layout,
 };
-use roc_target::{OperatingSystem, PtrWidth};
+use roc_target::PtrWidth;
 
 use crate::llvm::{
     bitcode::{


### PR DESCRIPTION
the wrong calling convention was used. the assembly we use assumes systemv, but on windows, .C would be the win64 calling convention. This has now been fixed