### PR TITLE
Fix Web REPL ordering bug

### DIFF
--- a/crates/repl_wasm/README.md
+++ b/crates/repl_wasm/README.md
@@ -2,41 +2,27 @@
 
 ## Running locally
 
-### 1. Build the Roc website
-
-For a minimal build (when just working on the web REPL)
-
-```bash
-cp -r www/public www/build
-```
-
-Or, for a full build (with std lib documentation, downloadable source code, etc.)
-
-```bash
-www/build.sh
-```
-
-### 2. Build the web REPL
+### 1. Build the web REPL
 
 This builds the compiler as a `.wasm` file, and generates JS glue code.
 It will `cargo install` the `wasm-pack` command line tool if you don't already have it.
-You should run it from the project root directory.
 
 ```bash
 crates/repl_wasm/build-www.sh
 ```
 
-### 3. Make symlinks to the generated Wasm and JS
+### 2. Make symlinks to the generated Wasm and JS
+
 ```bash
 cd www/public
 ln -s ../../../crates/repl_wasm/build/roc_repl_wasm_bg.wasm
 ln -s ../../../crates/repl_wasm/build/roc_repl_wasm.js
 ```
 These symlinks are ignored by Git.
-This is slightly different from how we do the production build but it makes development easy.
-You can directly edit files like repl.js and just reload your browser to see changes.
 
-### 4. Run a local HTTP server
+> This is a bit different from the production build, where we copy all the files to `www/build/`. But for development, it's convenient to have just one copy of files like `www/public/repl.js`. You can make changes, reload your browser to see them, and commit them to Git, without getting mixed up between different copies of the same file.
+
+### 3. Run a local HTTP server
 
 Browsers won't load .wasm files over the `file://` protocol, so you need to serve the files in `./www/build/` from a local web server.
 Any server will do, but this example should work on any system that has Python 3 installed:
@@ -46,7 +32,7 @@ cd www/public
 python3 -m http.server
 ```
 
-### 5. Open your browser
+### 4. Open your browser
 
 You should be able to find the Roc REPL at <http://127.0.0.1:8000/repl> (or whatever port your web server mentioned when it started up.)
 

--- a/www/public/repl/index.html
+++ b/www/public/repl/index.html
@@ -13,8 +13,9 @@
       </section>
 
       <section class="history">
-        <div class="scroll-wrap">
-          <div id="history-text" class="scroll code">
+        <div class="scroll code">
+          <pre id="help-text"></pre>
+          <div id="history-text">
             <div id="loading-message">
               Loading Roc compiler as a WebAssembly module... please wait!
             </div>

--- a/www/public/repl/repl.css
+++ b/www/public/repl/repl.css
@@ -26,8 +26,6 @@ li {
 }
 section.history {
   flex: 1;
-}
-.scroll-wrap {
   position: relative;
   height: 100%;
 }

--- a/www/public/repl/repl.js
+++ b/www/public/repl/repl.js
@@ -38,21 +38,22 @@ const repl = {
 // Initialise
 repl.elemSourceInput.addEventListener("change", onInputChange);
 repl.elemSourceInput.addEventListener("keyup", onInputKeyup);
-roc_repl_wasm.default("/repl/roc_repl_wasm_bg.wasm").then((instance) => {
+roc_repl_wasm.default("/repl/roc_repl_wasm_bg.wasm").then(async (instance) => {
   repl.elemHistory.querySelector("#loading-message").remove();
   repl.elemSourceInput.disabled = false;
   repl.elemSourceInput.placeholder =
     "Type some Roc code and press Enter. (Use Shift-Enter or Ctrl-Enter for multi-line input)";
   repl.compiler = instance;
 
-  // Show the help text by providing fake input
-  repl.inputQueue.push(":help");
-  processInputQueue();
-
-  // Remove the fake input
-  repl.inputHistory.shift();
-  repl.inputHistoryIndex = 0;
-  document.querySelector(".input").remove();
+  // Get help text from the compiler, and display it at top of the history panel
+  try {
+    const helpText = await roc_repl_wasm.entrypoint_from_js(":help");
+    const helpElem = document.getElementById("help-text");
+    helpElem.innerHTML = helpText;
+  } catch (e) {
+    // Print error for Roc devs. Don't use console.error, we overrode that above to display on the page!
+    console.warn(e);
+  }
 });
 
 // ----------------------------------------------------------------------------

--- a/www/public/repl/repl.js
+++ b/www/public/repl/repl.js
@@ -1,16 +1,13 @@
 // The only way we can provide values to wasm_bindgen's generated code is to set globals
-function setGlobalsForWasmBindgen() {
-  window.js_create_app = js_create_app;
-  window.js_run_app = js_run_app;
-  window.js_get_result_and_memory = js_get_result_and_memory;
+window.js_create_app = js_create_app;
+window.js_run_app = js_run_app;
+window.js_get_result_and_memory = js_get_result_and_memory;
 
-  // The only place we use console.error is in wasm_bindgen, where it gets a single string argument.
-  console.error = function displayErrorInHistoryPanel(string) {
-    const html = `<div class="panic">${string}</div>`;
-    updateHistoryEntry(repl.inputHistoryIndex, false, html);
-  };
-}
-setGlobalsForWasmBindgen();
+// The only place we use console.error is in wasm_bindgen, where it gets a single string argument.
+console.error = function displayErrorInHistoryPanel(string) {
+  const html = `<div class="panic">${string}</div>`;
+  updateHistoryEntry(repl.inputHistoryIndex, false, html);
+};
 
 import * as roc_repl_wasm from "./roc_repl_wasm.js";
 import { getMockWasiImports } from "./wasi.js";


### PR DESCRIPTION
In #5790, I added `:help` text to the top of the history panel, as a little last-minute touch.

It worked by adding a fake input and output to the history and then removing just the input from the DOM.
It also removed the entry from the `inputHistory` array, to prevent it appearing in the panel when you hit the UP arrow enough times.
However this introduces a mismatch between the number of items in `inputHistory` array and the number of `.history-item` divs in the DOM, which caused each REPL output to appear *above* the user input that caused it! 🙃

The fix is to just make all of this separate from history!
We just make a separate call into Rust to get the initial `:help`, instead of trying to reuse code for two things that turn out not to be as similar as I thought.

### Testing locally

If you want to test locally, see instructions in the [repl_wasm README](https://github.com/roc-lang/roc/blob/11a3eec49cac7ced40af59881add50824d4830dc/crates/repl_wasm/README.md)


### Live version, reverse order


<img width="776" alt="Screenshot 2023-09-13 at 08 20 39" src="https://github.com/roc-lang/roc/assets/4647158/549f935d-3796-45f5-ad71-974d5726d3b6">


### This branch, correct order



<img width="772" alt="Screenshot 2023-09-13 at 08 20 04" src="https://github.com/roc-lang/roc/assets/4647158/a000c80e-ff48-4135-b474-bee51171664f">






