### PR TITLE
Wrap text in web REPL history panel

### DIFF
--- a/www/public/repl/index.html
+++ b/www/public/repl/index.html
@@ -14,7 +14,7 @@
 
       <section class="history">
         <div class="scroll code">
-          <pre id="help-text"></pre>
+          <div id="help-text"></div>
           <div id="history-text">
             <div id="loading-message">
               Loading Roc compiler as a WebAssembly module... please wait!

--- a/www/public/repl/repl.js
+++ b/www/public/repl/repl.js
@@ -49,7 +49,7 @@ roc_repl_wasm.default("/repl/roc_repl_wasm_bg.wasm").then(async (instance) => {
   try {
     const helpText = await roc_repl_wasm.entrypoint_from_js(":help");
     const helpElem = document.getElementById("help-text");
-    helpElem.innerHTML = helpText;
+    helpElem.innerHTML = helpText.replace(/\n/g, '<br>');
   } catch (e) {
     // Print error for Roc devs. Don't use console.error, we overrode that above to display on the page!
     console.warn(e);
@@ -199,14 +199,14 @@ function createHistoryEntry(inputText) {
   repl.inputHistory.push(inputText);
 
   const firstLinePrefix = '<span class="input-line-prefix">» </span>';
-  const otherLinePrefix = '\n<span class="input-line-prefix">… </span>';
+  const otherLinePrefix = '<br><span class="input-line-prefix">… </span>';
   const inputLines = inputText.split("\n");
   if (inputLines[inputLines.length - 1] === "") {
     inputLines.pop();
   }
   const inputWithPrefixes = firstLinePrefix + inputLines.join(otherLinePrefix);
 
-  const inputElem = document.createElement("pre");
+  const inputElem = document.createElement("div");
   inputElem.innerHTML = inputWithPrefixes;
   inputElem.classList.add("input");
 
@@ -221,10 +221,9 @@ function createHistoryEntry(inputText) {
 }
 
 function updateHistoryEntry(index, ok, outputText) {
-  const outputElem = document.createElement("pre");
-  outputElem.innerHTML = outputText;
-  outputElem.classList.add("output");
-  outputElem.classList.add(ok ? "output-ok" : "output-error");
+  const outputElem = document.createElement("div");
+  outputElem.innerHTML = outputText.replace(/\n/g, "<br>");
+  outputElem.classList.add("output", ok ? "output-ok" : "output-error");
 
   const historyItem = repl.elemHistory.children[index];
   historyItem.appendChild(outputElem);


### PR DESCRIPTION
For narrower screens, or high zoom, the text overflows in the web REPL and you need to scroll horizontally to see it.
That's not great, and doesn't match what we see in the terminal.

We were using `pre` to get a "source code" font and also make the browser respect newlines instead of ignoring them.

The problem is that `pre` makes it so we _must_ specify everywhere we want a line break! So at the edge of the panel, it overflows instead of wrapping. (`pre` has the CSS property `whitespace: no-wrap` by default.)

To fix this, I changed the `pre` to a `div`. To get the "source code" style back, I used an existing CSS class called `code`. And to make the browser respect newlines, I added some JS to replace `\n` with `<br>` in the compiler output.
So now the browser will respect newlines where the compiler wants them, but also wrap at the end of the line instead of overflowing.

It also puts the `# val1` text in the right place for long output values.

### Before



<img width="631" alt="Screenshot 2023-09-13 at 12 17 52" src="https://github.com/roc-lang/roc/assets/4647158/d16aaf0f-cc1c-46ca-a63c-b2bd59b3811e">


### After

Note: in one of these examples, the _input_ doesn't wrap but the output does. That's because I didn't enter any spaces after the commas, so the browser has nowhere to put a line break. But the compiler formats its output with spaces.
I think that's OK.

<img width="627" alt="Screenshot 2023-09-13 at 12 18 39" src="https://github.com/roc-lang/roc/assets/4647158/11cdb9e2-e71e-4299-be22-3c9826757f9c">
