### PR TITLE
working aarch64 elf tests

### DIFF
--- a/crates/compiler/gen_dev/src/generic64/aarch64.rs
+++ b/crates/compiler/gen_dev/src/generic64/aarch64.rs
@@ -1272,21 +1272,13 @@ impl Assembler<AArch64GeneralReg, AArch64FloatReg> for AArch64Assembler {
     }
 
     #[inline(always)]
-    fn mov_base32_reg64(buf: &mut Vec<'_, u8>, offset: i32, src: AArch64GeneralReg) {
-        Self::mov_mem64_offset32_reg64(buf, AArch64GeneralReg::FP, offset, src)
-    }
-
-    #[inline(always)]
-    fn mov_base32_reg32(_buf: &mut Vec<'_, u8>, _offset: i32, _src: AArch64GeneralReg) {
-        todo!()
-    }
-    #[inline(always)]
-    fn mov_base32_reg16(_buf: &mut Vec<'_, u8>, _offset: i32, _src: AArch64GeneralReg) {
-        todo!()
-    }
-    #[inline(always)]
-    fn mov_base32_reg8(_buf: &mut Vec<'_, u8>, _offset: i32, _src: AArch64GeneralReg) {
-        todo!()
+    fn mov_base32_reg(
+        buf: &mut Vec<'_, u8>,
+        register_width: RegisterWidth,
+        offset: i32,
+        src: AArch64GeneralReg,
+    ) {
+        Self::mov_mem_offset32_reg(buf, register_width, AArch64GeneralReg::FP, offset, src)
     }
 
     fn mov_mem_offset32_reg(

--- a/crates/compiler/gen_dev/src/generic64/aarch64.rs
+++ b/crates/compiler/gen_dev/src/generic64/aarch64.rs
@@ -1187,11 +1187,15 @@ impl Assembler<AArch64GeneralReg, AArch64FloatReg> for AArch64Assembler {
         dst: AArch64GeneralReg,
         src: AArch64GeneralReg,
     ) {
-        match register_width {
-            RegisterWidth::W8 => todo!(),
-            RegisterWidth::W16 => todo!(),
-            RegisterWidth::W32 => todo!(),
-            RegisterWidth::W64 => mov_reg64_reg64(buf, dst, src),
+        if dst != src {
+            // TODO can we be more fine-grained here? there is a 32-bit version of this instruction
+            // but that does not really help for W8 and W16
+            match register_width {
+                RegisterWidth::W8 => mov_reg64_reg64(buf, dst, src),
+                RegisterWidth::W16 => mov_reg64_reg64(buf, dst, src),
+                RegisterWidth::W32 => mov_reg64_reg64(buf, dst, src),
+                RegisterWidth::W64 => mov_reg64_reg64(buf, dst, src),
+            }
         }
     }
 

--- a/crates/compiler/gen_dev/src/generic64/aarch64.rs
+++ b/crates/compiler/gen_dev/src/generic64/aarch64.rs
@@ -880,7 +880,9 @@ impl Assembler<AArch64GeneralReg, AArch64FloatReg> for AArch64Assembler {
         imm32: i32,
     ) {
         if imm32 < 0 {
-            todo!("immediate addition with values less than 0");
+            // add immediates must be signed, so we have to use a register here
+            Self::mov_reg64_imm64(buf, dst, imm32 as i64);
+            add_reg64_reg64_reg64(buf, dst, src, dst);
         } else if imm32 < 0xFFF {
             add_reg64_reg64_imm12(buf, dst, src, imm32 as u16);
         } else {
@@ -2733,10 +2735,10 @@ fn add_reg64_reg64_imm12(
     let inst = ArithmeticImmediate::new(ArithmeticImmediateParams {
         op: false,
         s: false,
+        sh: false,
+        imm12,
         rd: dst,
         rn: src,
-        imm12,
-        sh: false,
     });
 
     buf.extend(inst.bytes());

--- a/crates/compiler/gen_dev/src/generic64/aarch64.rs
+++ b/crates/compiler/gen_dev/src/generic64/aarch64.rs
@@ -263,7 +263,19 @@ impl CallConv<AArch64GeneralReg, AArch64FloatReg, AArch64Assembler> for AArch64C
         AArch64GeneralReg::IP0,
         AArch64GeneralReg::IP1,
     ];
-    const FLOAT_PARAM_REGS: &'static [AArch64FloatReg] = &[];
+
+    // The first eight registers, v0-v7, are used to pass argument values
+    // into a subroutine and to return result values from a function.
+    const FLOAT_PARAM_REGS: &'static [AArch64FloatReg] = &[
+        AArch64FloatReg::V0,
+        AArch64FloatReg::V1,
+        AArch64FloatReg::V2,
+        AArch64FloatReg::V3,
+        AArch64FloatReg::V4,
+        AArch64FloatReg::V5,
+        AArch64FloatReg::V6,
+        AArch64FloatReg::V7,
+    ];
     const FLOAT_RETURN_REGS: &'static [AArch64FloatReg] = Self::FLOAT_PARAM_REGS;
     const FLOAT_DEFAULT_FREE_REGS: &'static [AArch64FloatReg] = &[];
 

--- a/crates/compiler/gen_dev/src/generic64/aarch64.rs
+++ b/crates/compiler/gen_dev/src/generic64/aarch64.rs
@@ -919,7 +919,7 @@ impl Assembler<AArch64GeneralReg, AArch64FloatReg> for AArch64Assembler {
 
     #[inline(always)]
     fn call(buf: &mut Vec<'_, u8>, relocs: &mut Vec<'_, Relocation>, fn_name: String) {
-        let inst = 0b1001_0100_0000_0000_0000_0000_0000u32;
+        let inst = 0b1001_0100_0000_0000_0000_0000_0000_0000u32;
         buf.extend(inst.to_le_bytes());
         relocs.push(Relocation::LinkedFunction {
             offset: buf.len() as u64 - 4,

--- a/crates/compiler/gen_dev/src/generic64/aarch64.rs
+++ b/crates/compiler/gen_dev/src/generic64/aarch64.rs
@@ -1252,12 +1252,12 @@ impl Assembler<AArch64GeneralReg, AArch64FloatReg> for AArch64Assembler {
         todo!()
     }
     #[inline(always)]
-    fn mov_base32_freg64(_buf: &mut Vec<'_, u8>, _offset: i32, _src: AArch64FloatReg) {
-        todo!("saving floating point reg to base offset for AArch64");
+    fn mov_base32_freg64(buf: &mut Vec<'_, u8>, offset: i32, src: AArch64FloatReg) {
+        Self::mov_mem64_offset32_freg64(buf, AArch64GeneralReg::FP, offset, src)
     }
     #[inline(always)]
-    fn mov_base32_freg32(_buf: &mut Vec<'_, u8>, _offset: i32, _src: AArch64FloatReg) {
-        todo!("saving floating point reg to base offset for AArch64");
+    fn mov_base32_freg32(buf: &mut Vec<'_, u8>, offset: i32, src: AArch64FloatReg) {
+        Self::mov_mem64_offset32_freg64(buf, AArch64GeneralReg::FP, offset, src)
     }
     #[inline(always)]
     fn movesd_mem64_offset32_freg64(
@@ -1363,6 +1363,23 @@ impl Assembler<AArch64GeneralReg, AArch64FloatReg> for AArch64Assembler {
     }
 
     #[inline(always)]
+    fn mov_mem64_offset32_freg64(
+        buf: &mut Vec<'_, u8>,
+        dst: AArch64GeneralReg,
+        offset: i32,
+        src: AArch64FloatReg,
+    ) {
+        if offset < 0 {
+            todo!("negative mem offsets for AArch64");
+        } else if offset < (0xFFF << 8) {
+            debug_assert!(offset % 8 == 0);
+            str_freg64_reg64_imm12(buf, src, dst, (offset as u16) >> 3);
+        } else {
+            todo!("mem offsets over 32k for AArch64");
+        }
+    }
+
+    #[inline(always)]
     fn mov_mem32_offset32_reg32(
         _buf: &mut Vec<'_, u8>,
         _dst: AArch64GeneralReg,
@@ -1439,15 +1456,9 @@ impl Assembler<AArch64GeneralReg, AArch64FloatReg> for AArch64Assembler {
     }
     #[inline(always)]
     fn mov_stack32_freg64(buf: &mut Vec<'_, u8>, offset: i32, src: AArch64FloatReg) {
-        if offset < 0 {
-            todo!("negative stack offsets for AArch64");
-        } else if offset < (0xFFF << 8) {
-            debug_assert!(offset % 8 == 0);
-            str_freg64_reg64_imm12(buf, src, AArch64GeneralReg::ZRSP, (offset as u16) >> 3);
-        } else {
-            todo!("stack offsets over 32k for AArch64");
-        }
+        Self::mov_mem64_offset32_freg64(buf, AArch64GeneralReg::ZRSP, offset, src)
     }
+
     #[inline(always)]
     fn mov_stack32_reg(
         buf: &mut Vec<'_, u8>,

--- a/crates/compiler/gen_dev/src/generic64/aarch64.rs
+++ b/crates/compiler/gen_dev/src/generic64/aarch64.rs
@@ -1171,12 +1171,13 @@ impl Assembler<AArch64GeneralReg, AArch64FloatReg> for AArch64Assembler {
 
     #[inline(always)]
     fn movzx_reg_reg(
-        _buf: &mut Vec<'_, u8>,
-        _input_width: RegisterWidth,
-        _dst: AArch64GeneralReg,
-        _src: AArch64GeneralReg,
+        buf: &mut Vec<'_, u8>,
+        input_width: RegisterWidth,
+        dst: AArch64GeneralReg,
+        src: AArch64GeneralReg,
     ) {
-        todo!("move with zero extension");
+        // moving with zero extension is the default in arm
+        Self::mov_reg_reg(buf, input_width, dst, src)
     }
 
     #[inline(always)]

--- a/crates/compiler/gen_dev/src/generic64/aarch64.rs
+++ b/crates/compiler/gen_dev/src/generic64/aarch64.rs
@@ -879,7 +879,7 @@ impl Assembler<AArch64GeneralReg, AArch64FloatReg> for AArch64Assembler {
         _fn_name: String,
         _dst: AArch64GeneralReg,
     ) {
-        todo!("data pointer for AArch64");
+        eprintln!("data_pointer not implemented for this target");
     }
 
     #[inline(always)]

--- a/crates/compiler/gen_dev/src/generic64/aarch64.rs
+++ b/crates/compiler/gen_dev/src/generic64/aarch64.rs
@@ -858,8 +858,13 @@ impl Assembler<AArch64GeneralReg, AArch64FloatReg> for AArch64Assembler {
     }
 
     #[inline(always)]
-    fn call(_buf: &mut Vec<'_, u8>, _relocs: &mut Vec<'_, Relocation>, _fn_name: String) {
-        todo!("calling functions literal for AArch64");
+    fn call(buf: &mut Vec<'_, u8>, relocs: &mut Vec<'_, Relocation>, fn_name: String) {
+        let inst = 0b1001_0100_0000_0000_0000_0000_0000u32;
+        buf.extend(inst.to_le_bytes());
+        relocs.push(Relocation::LinkedFunction {
+            offset: buf.len() as u64 - 4,
+            name: fn_name,
+        });
     }
 
     #[inline(always)]

--- a/crates/compiler/gen_dev/src/generic64/mod.rs
+++ b/crates/compiler/gen_dev/src/generic64/mod.rs
@@ -420,6 +420,12 @@ pub trait Assembler<GeneralReg: RegTrait, FloatReg: RegTrait>: Sized + Copy {
         offset: i32,
     );
 
+    fn mov_mem64_offset32_freg64(
+        buf: &mut Vec<'_, u8>,
+        dst: GeneralReg,
+        offset: i32,
+        src: FloatReg,
+    );
     fn mov_freg64_stack32(buf: &mut Vec<'_, u8>, dst: FloatReg, offset: i32);
     fn mov_reg64_stack32(buf: &mut Vec<'_, u8>, dst: GeneralReg, offset: i32);
     fn mov_stack32_freg64(buf: &mut Vec<'_, u8>, offset: i32, src: FloatReg);

--- a/crates/compiler/gen_dev/src/generic64/mod.rs
+++ b/crates/compiler/gen_dev/src/generic64/mod.rs
@@ -731,6 +731,9 @@ impl<
     fn relocations_mut(&mut self) -> &mut Vec<'a, Relocation> {
         &mut self.relocs
     }
+    fn target_info(&self) -> TargetInfo {
+        self.storage_manager.target_info
+    }
     fn module_interns_helpers_mut(
         &mut self,
     ) -> (

--- a/crates/compiler/gen_dev/src/generic64/mod.rs
+++ b/crates/compiler/gen_dev/src/generic64/mod.rs
@@ -35,10 +35,10 @@ const JUMP_PLACEHOLDER: i32 = 0x0011_1100;
 
 #[derive(Debug, Clone, Copy)]
 pub enum RegisterWidth {
-    W8,
-    W16,
-    W32,
-    W64,
+    W8 = 0b00,
+    W16 = 0b01,
+    W32 = 0b10,
+    W64 = 0b11,
 }
 
 impl RegisterWidth {
@@ -329,10 +329,25 @@ pub trait Assembler<GeneralReg: RegTrait, FloatReg: RegTrait>: Sized + Copy {
     // base32 is similar to stack based instructions but they reference the base/frame pointer.
     fn mov_freg64_base32(buf: &mut Vec<'_, u8>, dst: FloatReg, offset: i32);
 
-    fn mov_reg64_base32(buf: &mut Vec<'_, u8>, dst: GeneralReg, offset: i32);
-    fn mov_reg32_base32(buf: &mut Vec<'_, u8>, dst: GeneralReg, offset: i32);
-    fn mov_reg16_base32(buf: &mut Vec<'_, u8>, dst: GeneralReg, offset: i32);
-    fn mov_reg8_base32(buf: &mut Vec<'_, u8>, dst: GeneralReg, offset: i32);
+    fn mov_reg_base32(
+        buf: &mut Vec<'_, u8>,
+        register_width: RegisterWidth,
+        dst: GeneralReg,
+        offset: i32,
+    );
+
+    fn mov_reg64_base32(buf: &mut Vec<'_, u8>, dst: GeneralReg, offset: i32) {
+        Self::mov_reg_base32(buf, RegisterWidth::W64, dst, offset)
+    }
+    fn mov_reg32_base32(buf: &mut Vec<'_, u8>, dst: GeneralReg, offset: i32) {
+        Self::mov_reg_base32(buf, RegisterWidth::W32, dst, offset)
+    }
+    fn mov_reg16_base32(buf: &mut Vec<'_, u8>, dst: GeneralReg, offset: i32) {
+        Self::mov_reg_base32(buf, RegisterWidth::W16, dst, offset)
+    }
+    fn mov_reg8_base32(buf: &mut Vec<'_, u8>, dst: GeneralReg, offset: i32) {
+        Self::mov_reg_base32(buf, RegisterWidth::W8, dst, offset)
+    }
 
     fn mov_base32_freg64(buf: &mut Vec<'_, u8>, offset: i32, src: FloatReg);
     fn mov_base32_freg32(buf: &mut Vec<'_, u8>, offset: i32, src: FloatReg);
@@ -343,25 +358,46 @@ pub trait Assembler<GeneralReg: RegTrait, FloatReg: RegTrait>: Sized + Copy {
     fn mov_base32_reg8(buf: &mut Vec<'_, u8>, offset: i32, src: GeneralReg);
 
     // move from memory (a pointer) to register
+    fn mov_reg_mem_offset32(
+        buf: &mut Vec<'_, u8>,
+        register_width: RegisterWidth,
+        dst: GeneralReg,
+        src: GeneralReg,
+        offset: i32,
+    );
+
     fn mov_reg64_mem64_offset32(
         buf: &mut Vec<'_, u8>,
         dst: GeneralReg,
         src: GeneralReg,
         offset: i32,
-    );
+    ) {
+        Self::mov_reg_mem_offset32(buf, RegisterWidth::W64, dst, src, offset)
+    }
     fn mov_reg32_mem32_offset32(
         buf: &mut Vec<'_, u8>,
         dst: GeneralReg,
         src: GeneralReg,
         offset: i32,
-    );
+    ) {
+        Self::mov_reg_mem_offset32(buf, RegisterWidth::W32, dst, src, offset)
+    }
     fn mov_reg16_mem16_offset32(
         buf: &mut Vec<'_, u8>,
         dst: GeneralReg,
         src: GeneralReg,
         offset: i32,
-    );
-    fn mov_reg8_mem8_offset32(buf: &mut Vec<'_, u8>, dst: GeneralReg, src: GeneralReg, offset: i32);
+    ) {
+        Self::mov_reg_mem_offset32(buf, RegisterWidth::W16, dst, src, offset)
+    }
+    fn mov_reg8_mem8_offset32(
+        buf: &mut Vec<'_, u8>,
+        dst: GeneralReg,
+        src: GeneralReg,
+        offset: i32,
+    ) {
+        Self::mov_reg_mem_offset32(buf, RegisterWidth::W8, dst, src, offset)
+    }
 
     fn mov_freg64_mem64_offset32(
         buf: &mut Vec<'_, u8>,
@@ -377,25 +413,46 @@ pub trait Assembler<GeneralReg: RegTrait, FloatReg: RegTrait>: Sized + Copy {
     );
 
     // move from register to memory
+    fn mov_mem_offset32_reg(
+        buf: &mut Vec<'_, u8>,
+        register_width: RegisterWidth,
+        dst: GeneralReg,
+        offset: i32,
+        src: GeneralReg,
+    );
+
     fn mov_mem64_offset32_reg64(
         buf: &mut Vec<'_, u8>,
         dst: GeneralReg,
         offset: i32,
         src: GeneralReg,
-    );
+    ) {
+        Self::mov_mem_offset32_reg(buf, RegisterWidth::W64, dst, offset, src)
+    }
     fn mov_mem32_offset32_reg32(
         buf: &mut Vec<'_, u8>,
         dst: GeneralReg,
         offset: i32,
         src: GeneralReg,
-    );
+    ) {
+        Self::mov_mem_offset32_reg(buf, RegisterWidth::W32, dst, offset, src)
+    }
     fn mov_mem16_offset32_reg16(
         buf: &mut Vec<'_, u8>,
         dst: GeneralReg,
         offset: i32,
         src: GeneralReg,
-    );
-    fn mov_mem8_offset32_reg8(buf: &mut Vec<'_, u8>, dst: GeneralReg, offset: i32, src: GeneralReg);
+    ) {
+        Self::mov_mem_offset32_reg(buf, RegisterWidth::W16, dst, offset, src)
+    }
+    fn mov_mem8_offset32_reg8(
+        buf: &mut Vec<'_, u8>,
+        dst: GeneralReg,
+        offset: i32,
+        src: GeneralReg,
+    ) {
+        Self::mov_mem_offset32_reg(buf, RegisterWidth::W8, dst, offset, src)
+    }
 
     fn movesd_mem64_offset32_freg64(
         buf: &mut Vec<'_, u8>,

--- a/crates/compiler/gen_dev/src/generic64/mod.rs
+++ b/crates/compiler/gen_dev/src/generic64/mod.rs
@@ -30,6 +30,9 @@ use storage::{RegStorage, StorageManager};
 
 // TODO: on all number functions double check and deal with over/underflow.
 
+// NOTE: must fit in 27 bits and aligned to 4 for aarch64
+const JUMP_PLACEHOLDER: i32 = 0x0011_1100;
+
 #[derive(Debug, Clone, Copy)]
 pub enum RegisterWidth {
     W8,
@@ -1070,7 +1073,7 @@ impl<
             // Build unconditional jump to the end of this switch.
             // Since we don't know the offset yet, set it to 0 and overwrite later.
             let jmp_location = self.buf.len();
-            let jmp_offset = ASM::jmp_imm32(&mut self.buf, 0x1234_5678);
+            let jmp_offset = ASM::jmp_imm32(&mut self.buf, JUMP_PLACEHOLDER);
             ret_jumps.push((jmp_location, jmp_offset));
 
             // Overwrite the original jne with the correct offset.
@@ -1162,7 +1165,7 @@ impl<
             .setup_jump(self.layout_interner, &mut self.buf, id, args, arg_layouts);
 
         let jmp_location = self.buf.len();
-        let start_offset = ASM::jmp_imm32(&mut self.buf, 0x1234_5678);
+        let start_offset = ASM::jmp_imm32(&mut self.buf, JUMP_PLACEHOLDER);
 
         if let Some(vec) = self.join_map.get_mut(id) {
             vec.push((jmp_location as u64, start_offset as u64))
@@ -4342,7 +4345,7 @@ impl<
             )
         }
         let inst_loc = self.buf.len() as u64;
-        let offset = ASM::jmp_imm32(&mut self.buf, 0x1234_5678) as u64;
+        let offset = ASM::jmp_imm32(&mut self.buf, JUMP_PLACEHOLDER) as u64;
         self.relocs.push(Relocation::JmpToReturn {
             inst_loc,
             inst_size: self.buf.len() as u64 - inst_loc,

--- a/crates/compiler/gen_dev/src/generic64/mod.rs
+++ b/crates/compiler/gen_dev/src/generic64/mod.rs
@@ -352,10 +352,25 @@ pub trait Assembler<GeneralReg: RegTrait, FloatReg: RegTrait>: Sized + Copy {
     fn mov_base32_freg64(buf: &mut Vec<'_, u8>, offset: i32, src: FloatReg);
     fn mov_base32_freg32(buf: &mut Vec<'_, u8>, offset: i32, src: FloatReg);
 
-    fn mov_base32_reg64(buf: &mut Vec<'_, u8>, offset: i32, src: GeneralReg);
-    fn mov_base32_reg32(buf: &mut Vec<'_, u8>, offset: i32, src: GeneralReg);
-    fn mov_base32_reg16(buf: &mut Vec<'_, u8>, offset: i32, src: GeneralReg);
-    fn mov_base32_reg8(buf: &mut Vec<'_, u8>, offset: i32, src: GeneralReg);
+    fn mov_base32_reg(
+        buf: &mut Vec<'_, u8>,
+        register_width: RegisterWidth,
+        offset: i32,
+        src: GeneralReg,
+    );
+
+    fn mov_base32_reg64(buf: &mut Vec<'_, u8>, offset: i32, src: GeneralReg) {
+        Self::mov_base32_reg(buf, RegisterWidth::W64, offset, src)
+    }
+    fn mov_base32_reg32(buf: &mut Vec<'_, u8>, offset: i32, src: GeneralReg) {
+        Self::mov_base32_reg(buf, RegisterWidth::W32, offset, src)
+    }
+    fn mov_base32_reg16(buf: &mut Vec<'_, u8>, offset: i32, src: GeneralReg) {
+        Self::mov_base32_reg(buf, RegisterWidth::W16, offset, src)
+    }
+    fn mov_base32_reg8(buf: &mut Vec<'_, u8>, offset: i32, src: GeneralReg) {
+        Self::mov_base32_reg(buf, RegisterWidth::W8, offset, src)
+    }
 
     // move from memory (a pointer) to register
     fn mov_reg_mem_offset32(

--- a/crates/compiler/gen_dev/src/generic64/x86_64.rs
+++ b/crates/compiler/gen_dev/src/generic64/x86_64.rs
@@ -2294,20 +2294,20 @@ impl Assembler<X86_64GeneralReg, X86_64FloatReg> for X86_64Assembler {
     }
 
     #[inline(always)]
-    fn mov_base32_reg64(buf: &mut Vec<'_, u8>, offset: i32, src: X86_64GeneralReg) {
-        mov_base64_offset32_reg64(buf, X86_64GeneralReg::RBP, offset, src)
-    }
-    #[inline(always)]
-    fn mov_base32_reg32(buf: &mut Vec<'_, u8>, offset: i32, src: X86_64GeneralReg) {
-        mov_base32_offset32_reg32(buf, X86_64GeneralReg::RBP, offset, src)
-    }
-    #[inline(always)]
-    fn mov_base32_reg16(buf: &mut Vec<'_, u8>, offset: i32, src: X86_64GeneralReg) {
-        mov_base16_offset32_reg16(buf, X86_64GeneralReg::RBP, offset, src)
-    }
-    #[inline(always)]
-    fn mov_base32_reg8(buf: &mut Vec<'_, u8>, offset: i32, src: X86_64GeneralReg) {
-        mov_base8_offset32_reg8(buf, X86_64GeneralReg::RBP, offset, src)
+    fn mov_base32_reg(
+        buf: &mut Vec<'_, u8>,
+        register_width: RegisterWidth,
+        offset: i32,
+        src: X86_64GeneralReg,
+    ) {
+        use RegisterWidth::*;
+
+        match register_width {
+            W8 => mov_base8_offset32_reg8(buf, X86_64GeneralReg::RBP, offset, src),
+            W16 => mov_base16_offset32_reg16(buf, X86_64GeneralReg::RBP, offset, src),
+            W32 => mov_base32_offset32_reg32(buf, X86_64GeneralReg::RBP, offset, src),
+            W64 => mov_base64_offset32_reg64(buf, X86_64GeneralReg::RBP, offset, src),
+        }
     }
 
     #[inline(always)]

--- a/crates/compiler/gen_dev/src/generic64/x86_64.rs
+++ b/crates/compiler/gen_dev/src/generic64/x86_64.rs
@@ -675,6 +675,8 @@ impl X64_64SystemVStoreArgs {
         sym: Symbol,
         in_layout: InLayout<'a>,
     ) {
+        type ASM = X86_64Assembler;
+
         // we use the return register as a temporary register; it will be overwritten anyway
         let tmp_reg = Self::GENERAL_RETURN_REGS[0];
 
@@ -689,19 +691,19 @@ impl X64_64SystemVStoreArgs {
                     let reg1 = Self::GENERAL_PARAM_REGS[self.general_i];
                     let reg2 = Self::GENERAL_PARAM_REGS[self.general_i + 1];
 
-                    X86_64Assembler::mov_reg64_base32(buf, reg1, offset);
-                    X86_64Assembler::mov_reg64_base32(buf, reg2, offset + 8);
+                    ASM::mov_reg64_base32(buf, reg1, offset);
+                    ASM::mov_reg64_base32(buf, reg2, offset + 8);
 
                     self.general_i += 2;
                 } else {
                     // Copy to stack using return reg as buffer.
                     let reg = Self::GENERAL_RETURN_REGS[0];
 
-                    X86_64Assembler::mov_reg64_base32(buf, reg, offset);
-                    X86_64Assembler::mov_stack32_reg64(buf, self.tmp_stack_offset, reg);
+                    ASM::mov_reg64_base32(buf, reg, offset);
+                    ASM::mov_stack32_reg64(buf, self.tmp_stack_offset, reg);
 
-                    X86_64Assembler::mov_reg64_base32(buf, reg, offset + 8);
-                    X86_64Assembler::mov_stack32_reg64(buf, self.tmp_stack_offset + 8, reg);
+                    ASM::mov_reg64_base32(buf, reg, offset + 8);
+                    ASM::mov_stack32_reg64(buf, self.tmp_stack_offset + 8, reg);
 
                     self.tmp_stack_offset += 16;
                 }

--- a/crates/compiler/gen_dev/src/generic64/x86_64.rs
+++ b/crates/compiler/gen_dev/src/generic64/x86_64.rs
@@ -2423,6 +2423,16 @@ impl Assembler<X86_64GeneralReg, X86_64FloatReg> for X86_64Assembler {
     }
 
     #[inline(always)]
+    fn mov_mem64_offset32_freg64(
+        buf: &mut Vec<'_, u8>,
+        dst: X86_64GeneralReg,
+        offset: i32,
+        src: X86_64FloatReg,
+    ) {
+        movsd_base64_offset32_freg64(buf, dst, offset, src)
+    }
+
+    #[inline(always)]
     fn mov_freg64_stack32(buf: &mut Vec<'_, u8>, dst: X86_64FloatReg, offset: i32) {
         movsd_freg64_base64_offset32(buf, dst, X86_64GeneralReg::RSP, offset)
     }

--- a/crates/compiler/gen_dev/src/generic64/x86_64.rs
+++ b/crates/compiler/gen_dev/src/generic64/x86_64.rs
@@ -2257,20 +2257,20 @@ impl Assembler<X86_64GeneralReg, X86_64FloatReg> for X86_64Assembler {
     }
 
     #[inline(always)]
-    fn mov_reg64_base32(buf: &mut Vec<'_, u8>, dst: X86_64GeneralReg, offset: i32) {
-        mov_reg64_base64_offset32(buf, dst, X86_64GeneralReg::RBP, offset)
-    }
-    #[inline(always)]
-    fn mov_reg32_base32(buf: &mut Vec<'_, u8>, dst: X86_64GeneralReg, offset: i32) {
-        mov_reg32_base32_offset32(buf, dst, X86_64GeneralReg::RBP, offset)
-    }
-    #[inline(always)]
-    fn mov_reg16_base32(buf: &mut Vec<'_, u8>, dst: X86_64GeneralReg, offset: i32) {
-        mov_reg16_base16_offset32(buf, dst, X86_64GeneralReg::RBP, offset)
-    }
-    #[inline(always)]
-    fn mov_reg8_base32(buf: &mut Vec<'_, u8>, dst: X86_64GeneralReg, offset: i32) {
-        mov_reg8_base8_offset32(buf, dst, X86_64GeneralReg::RBP, offset)
+    fn mov_reg_base32(
+        buf: &mut Vec<'_, u8>,
+        register_width: RegisterWidth,
+        dst: X86_64GeneralReg,
+        offset: i32,
+    ) {
+        use RegisterWidth::*;
+
+        match register_width {
+            W8 => mov_reg8_base8_offset32(buf, dst, X86_64GeneralReg::RBP, offset),
+            W16 => mov_reg16_base16_offset32(buf, dst, X86_64GeneralReg::RBP, offset),
+            W32 => mov_reg32_base32_offset32(buf, dst, X86_64GeneralReg::RBP, offset),
+            W64 => mov_reg64_base64_offset32(buf, dst, X86_64GeneralReg::RBP, offset),
+        }
     }
 
     #[inline(always)]
@@ -2311,78 +2311,35 @@ impl Assembler<X86_64GeneralReg, X86_64FloatReg> for X86_64Assembler {
     }
 
     #[inline(always)]
-    fn mov_reg64_mem64_offset32(
+    fn mov_reg_mem_offset32(
         buf: &mut Vec<'_, u8>,
+        register_width: RegisterWidth,
         dst: X86_64GeneralReg,
         src: X86_64GeneralReg,
         offset: i32,
     ) {
-        mov_reg64_base64_offset32(buf, dst, src, offset)
-    }
-    #[inline(always)]
-    fn mov_reg32_mem32_offset32(
-        buf: &mut Vec<'_, u8>,
-        dst: X86_64GeneralReg,
-        src: X86_64GeneralReg,
-        offset: i32,
-    ) {
-        mov_reg32_base32_offset32(buf, dst, src, offset)
-    }
-    fn mov_reg16_mem16_offset32(
-        buf: &mut Vec<'_, u8>,
-        dst: X86_64GeneralReg,
-        src: X86_64GeneralReg,
-        offset: i32,
-    ) {
-        mov_reg16_base16_offset32(buf, dst, src, offset)
-    }
-    fn mov_reg8_mem8_offset32(
-        buf: &mut Vec<'_, u8>,
-        dst: X86_64GeneralReg,
-        src: X86_64GeneralReg,
-        offset: i32,
-    ) {
-        mov_reg8_base8_offset32(buf, dst, src, offset)
+        match register_width {
+            RegisterWidth::W8 => mov_reg8_base8_offset32(buf, dst, src, offset),
+            RegisterWidth::W16 => mov_reg16_base16_offset32(buf, dst, src, offset),
+            RegisterWidth::W32 => mov_reg32_base32_offset32(buf, dst, src, offset),
+            RegisterWidth::W64 => mov_reg64_base64_offset32(buf, dst, src, offset),
+        }
     }
 
     #[inline(always)]
-    fn mov_mem64_offset32_reg64(
+    fn mov_mem_offset32_reg(
         buf: &mut Vec<'_, u8>,
+        register_width: RegisterWidth,
         dst: X86_64GeneralReg,
         offset: i32,
         src: X86_64GeneralReg,
     ) {
-        mov_base64_offset32_reg64(buf, dst, offset, src)
-    }
-
-    #[inline(always)]
-    fn mov_mem32_offset32_reg32(
-        buf: &mut Vec<'_, u8>,
-        dst: X86_64GeneralReg,
-        offset: i32,
-        src: X86_64GeneralReg,
-    ) {
-        mov_base32_offset32_reg32(buf, dst, offset, src)
-    }
-
-    #[inline(always)]
-    fn mov_mem16_offset32_reg16(
-        buf: &mut Vec<'_, u8>,
-        dst: X86_64GeneralReg,
-        offset: i32,
-        src: X86_64GeneralReg,
-    ) {
-        mov_base16_offset32_reg16(buf, dst, offset, src)
-    }
-
-    #[inline(always)]
-    fn mov_mem8_offset32_reg8(
-        buf: &mut Vec<'_, u8>,
-        dst: X86_64GeneralReg,
-        offset: i32,
-        src: X86_64GeneralReg,
-    ) {
-        mov_base8_offset32_reg8(buf, dst, offset, src)
+        match register_width {
+            RegisterWidth::W8 => mov_base8_offset32_reg8(buf, dst, offset, src),
+            RegisterWidth::W16 => mov_base16_offset32_reg16(buf, dst, offset, src),
+            RegisterWidth::W32 => mov_base32_offset32_reg32(buf, dst, offset, src),
+            RegisterWidth::W64 => mov_base64_offset32_reg64(buf, dst, offset, src),
+        }
     }
 
     #[inline(always)]

--- a/crates/compiler/gen_dev/src/lib.rs
+++ b/crates/compiler/gen_dev/src/lib.rs
@@ -28,6 +28,7 @@ use roc_mono::list_element_layout;
 mod generic64;
 mod object_builder;
 pub use object_builder::build_module;
+use roc_target::TargetInfo;
 mod run_roc;
 
 #[derive(Debug, Clone, Copy)]
@@ -303,6 +304,7 @@ trait Backend<'a> {
     fn interns_mut(&mut self) -> &mut Interns;
     fn interner(&self) -> &STLayoutInterner<'a>;
     fn relocations_mut(&mut self) -> &mut Vec<'a, Relocation>;
+    fn target_info(&self) -> TargetInfo;
 
     fn interner_mut(&mut self) -> &mut STLayoutInterner<'a> {
         self.module_interns_helpers_mut().1

--- a/crates/compiler/gen_dev/src/object_builder.rs
+++ b/crates/compiler/gen_dev/src/object_builder.rs
@@ -275,17 +275,17 @@ fn generate_wrapper<'a, B: Backend<'a>>(
     };
     output.add_symbol(symbol);
     if let Some(sym_id) = output.symbol_id(name) {
-        let encoding = match backend.target_info().architecture {
+        let (encoding, size) = match backend.target_info().architecture {
             roc_target::Architecture::Aarch32 => todo!(),
-            roc_target::Architecture::Aarch64 => RelocationEncoding::AArch64Call,
+            roc_target::Architecture::Aarch64 => (RelocationEncoding::AArch64Call, 26),
             roc_target::Architecture::Wasm32 => todo!(),
             roc_target::Architecture::X86_32 => todo!(),
-            roc_target::Architecture::X86_64 => RelocationEncoding::X86Branch,
+            roc_target::Architecture::X86_64 => (RelocationEncoding::X86Branch, 32),
         };
 
         let reloc = write::Relocation {
             offset: offset + proc_offset,
-            size: 32,
+            size,
             kind: RelocationKind::PltRelative,
             encoding,
             symbol: sym_id,
@@ -891,17 +891,17 @@ fn build_proc<'a, B: Backend<'a>>(
                 }
 
                 if let Some(sym_id) = output.symbol_id(name.as_bytes()) {
-                    let encoding = match target_info.architecture {
+                    let (encoding, size) = match target_info.architecture {
                         roc_target::Architecture::Aarch32 => todo!(),
-                        roc_target::Architecture::Aarch64 => RelocationEncoding::AArch64Call,
+                        roc_target::Architecture::Aarch64 => (RelocationEncoding::AArch64Call, 26),
                         roc_target::Architecture::Wasm32 => todo!(),
                         roc_target::Architecture::X86_32 => todo!(),
-                        roc_target::Architecture::X86_64 => RelocationEncoding::X86Branch,
+                        roc_target::Architecture::X86_64 => (RelocationEncoding::X86Branch, 32),
                     };
 
                     write::Relocation {
                         offset: offset + proc_offset,
-                        size: 32,
+                        size,
                         kind: RelocationKind::PltRelative,
                         encoding,
                         symbol: sym_id,

--- a/crates/compiler/gen_dev/src/object_builder.rs
+++ b/crates/compiler/gen_dev/src/object_builder.rs
@@ -275,11 +275,19 @@ fn generate_wrapper<'a, B: Backend<'a>>(
     };
     output.add_symbol(symbol);
     if let Some(sym_id) = output.symbol_id(name) {
+        let encoding = match backend.target_info().architecture {
+            roc_target::Architecture::Aarch32 => todo!(),
+            roc_target::Architecture::Aarch64 => RelocationEncoding::AArch64Call,
+            roc_target::Architecture::Wasm32 => todo!(),
+            roc_target::Architecture::X86_32 => todo!(),
+            roc_target::Architecture::X86_64 => RelocationEncoding::X86Branch,
+        };
+
         let reloc = write::Relocation {
             offset: offset + proc_offset,
             size: 32,
             kind: RelocationKind::PltRelative,
-            encoding: RelocationEncoding::X86Branch,
+            encoding,
             symbol: sym_id,
             addend: -4,
         };

--- a/crates/compiler/gen_dev/src/object_builder.rs
+++ b/crates/compiler/gen_dev/src/object_builder.rs
@@ -797,6 +797,7 @@ fn build_proc<'a, B: Backend<'a>>(
     proc: Proc<'a>,
 ) {
     let mut local_data_index = 0;
+    let target_info = backend.target_info();
     let (proc_data, relocs, rc_proc_names) = backend.build_proc(proc, layout_ids);
     let proc_offset = output.add_symbol_data(proc_id, section_id, &proc_data, 16);
     for reloc in relocs.iter() {
@@ -882,11 +883,19 @@ fn build_proc<'a, B: Backend<'a>>(
                 }
 
                 if let Some(sym_id) = output.symbol_id(name.as_bytes()) {
+                    let encoding = match target_info.architecture {
+                        roc_target::Architecture::Aarch32 => todo!(),
+                        roc_target::Architecture::Aarch64 => RelocationEncoding::AArch64Call,
+                        roc_target::Architecture::Wasm32 => todo!(),
+                        roc_target::Architecture::X86_32 => todo!(),
+                        roc_target::Architecture::X86_64 => RelocationEncoding::X86Branch,
+                    };
+
                     write::Relocation {
                         offset: offset + proc_offset,
                         size: 32,
                         kind: RelocationKind::PltRelative,
-                        encoding: RelocationEncoding::X86Branch,
+                        encoding,
                         symbol: sym_id,
                         addend: -4,
                     }

--- a/crates/compiler/test_gen/src/helpers/dev.rs
+++ b/crates/compiler/test_gen/src/helpers/dev.rs
@@ -216,7 +216,7 @@ pub fn helper(
         roc_bitcode::host_tempfile().expect("failed to write host builtins object to tempfile");
 
     // TODO make this an environment variable
-    if false {
+    if true {
         let file_path = std::env::temp_dir().join("app.o");
         println!("gen-test object file written to {}", file_path.display());
         std::fs::copy(&app_o_file, file_path).unwrap();

--- a/crates/compiler/test_gen/src/helpers/dev.rs
+++ b/crates/compiler/test_gen/src/helpers/dev.rs
@@ -364,8 +364,9 @@ macro_rules! assert_evals_to {
         let (_main_fn_name, errors, lib) =
             $crate::helpers::dev::helper(&arena, $src, $leak, $lazy_literals);
 
-        // cfg!(target_arch = "aarch64") {
-        let result = if false {
+        let result = if cfg!(target_arch = "aarch64") {
+            let typ = std::any::type_name::<$ty>();
+            println!("calling the `{_main_fn_name}: {typ}` function");
             let result = $crate::helpers::dev::run_function::<$ty>(&_main_fn_name, &lib);
             Ok(result)
         } else {

--- a/crates/compiler/test_gen/src/helpers/dev.rs
+++ b/crates/compiler/test_gen/src/helpers/dev.rs
@@ -216,7 +216,7 @@ pub fn helper(
         roc_bitcode::host_tempfile().expect("failed to write host builtins object to tempfile");
 
     // TODO make this an environment variable
-    if true {
+    if false {
         let file_path = std::env::temp_dir().join("app.o");
         println!("gen-test object file written to {}", file_path.display());
         std::fs::copy(&app_o_file, file_path).unwrap();
@@ -364,6 +364,8 @@ macro_rules! assert_evals_to {
         let (_main_fn_name, errors, lib) =
             $crate::helpers::dev::helper(&arena, $src, $leak, $lazy_literals);
 
+        // NOTE: on aarch64 our infrastructure for roc_panic does not work yet. Therefore we call
+        // just the main roc function which does not do anything to catch/report panics.
         let result = if cfg!(target_arch = "aarch64") {
             let typ = std::any::type_name::<$ty>();
             println!("calling the `{_main_fn_name}: {typ}` function");


### PR DESCRIPTION
aarch64 macho will need some experimentation with what relocation type to use. this makes some 50 tests in `gen_num` pass, and there are some general cleanups for the backend in here too