### PR TITLE
Fix decimal-point number representation

### DIFF
--- a/crates/roc_std/src/lib.rs
+++ b/crates/roc_std/src/lib.rs
@@ -374,7 +374,6 @@ impl RocDec {
 
         let is_negative = self.as_i128() < 0;
         let decimal_location = string.len() - Self::DECIMAL_PLACES;
-        dbg!(decimal_location, is_negative, string.len());
 
         // skip trailing zeros
         let last_nonzero_byte = string.trim_end_matches('0').len();

--- a/crates/roc_std/src/lib.rs
+++ b/crates/roc_std/src/lib.rs
@@ -373,7 +373,8 @@ impl RocDec {
         write!(string, "{:019}", self.as_i128()).unwrap();
 
         let is_negative = self.as_i128() < 0;
-        let decimal_location = string.len() - Self::DECIMAL_PLACES + (is_negative as usize);
+        let decimal_location = string.len() - Self::DECIMAL_PLACES;
+        dbg!(decimal_location, is_negative, string.len());
 
         // skip trailing zeros
         let last_nonzero_byte = string.trim_end_matches('0').len();

--- a/crates/roc_std/src/lib.rs
+++ b/crates/roc_std/src/lib.rs
@@ -372,13 +372,11 @@ impl RocDec {
         // get their leading zeros placed in bytes for us. i.e. `string = b"0012340000000000000"`
         write!(string, "{:019}", self.as_i128()).unwrap();
 
-        let is_negative = self.as_i128() < 0;
         let decimal_location = string.len() - Self::DECIMAL_PLACES;
-
         // skip trailing zeros
         let last_nonzero_byte = string.trim_end_matches('0').len();
 
-        if last_nonzero_byte < decimal_location {
+        if last_nonzero_byte <= decimal_location {
             // This means that we've removed trailing zeros and are left with an integer. Our
             // convention is to print these without a decimal point or trailing zeros, so we're done.
             string.truncate(decimal_location);
@@ -393,19 +391,14 @@ impl RocDec {
         // push a dummy character so we have space for the decimal dot
         string.push('$');
 
-        if decimal_location == last_nonzero_byte {
-            // never have a '.' as the last character
-            string.truncate(last_nonzero_byte)
-        } else {
-            // Safety: at any time, the string only contains ascii characters, so it is always valid utf8
-            let bytes = unsafe { string.as_bytes_mut() };
+        // Safety: at any time, the string only contains ascii characters, so it is always valid utf8
+        let bytes = unsafe { string.as_bytes_mut() };
 
-            // shift the fractional part by one
-            bytes.copy_within(decimal_location..last_nonzero_byte, decimal_location + 1);
+        // shift the fractional part by one
+        bytes.copy_within(decimal_location..last_nonzero_byte, decimal_location + 1);
 
-            // and put in the decimal dot in the right place
-            bytes[decimal_location] = b'.';
-        }
+        // and put in the decimal dot in the right place
+        bytes[decimal_location] = b'.';
 
         string.as_str()
     }

--- a/crates/roc_std/tests/test_roc_std.rs
+++ b/crates/roc_std/tests/test_roc_std.rs
@@ -295,8 +295,11 @@ mod test_roc_std {
         assert_eq!(format!("{example}"), "1000.5678");
 
         let sample_negative = "-1.234";
-        let example = RocDec::from_str(sample_negative).unwrap().to_str();
+        let example = RocDec::from_str(sample_negative).unwrap();
         assert_eq!(format!("{example}"), sample_negative);
+
+        let example = RocDec::from_str("1000.000").unwrap();
+        assert_eq!(format!("{example}"), "1000");
     }
 
     #[test]

--- a/crates/roc_std/tests/test_roc_std.rs
+++ b/crates/roc_std/tests/test_roc_std.rs
@@ -279,7 +279,7 @@ mod test_roc_std {
     fn roc_dec_fmt() {
         assert_eq!(
             format!("{}", RocDec::MIN),
-            "-1701411834604692317316.87303715884105728"
+            "-170141183460469231731.687303715884105728"
         );
 
         let half = RocDec::from_str("0.5").unwrap();

--- a/crates/roc_std/tests/test_roc_std.rs
+++ b/crates/roc_std/tests/test_roc_std.rs
@@ -293,6 +293,10 @@ mod test_roc_std {
 
         let example = RocDec::from_str("1_000.5678").unwrap();
         assert_eq!(format!("{example}"), "1000.5678");
+
+        let sample_negative = "-1.234";
+        let example = RocDec::from_str(sample_negative).unwrap().to_str();
+        assert_eq!(format!("{example}"), sample_negative);
     }
 
     #[test]


### PR DESCRIPTION
Fixes [this issue](https://github.com/roc-lang/roc/issues/5813).

In summary, negative decimal-point numbers (Fracs and Decs) are represented with an offset decimal point because the negative sign was incorrectly accounted for in the offset calculations. One test was also incorrect.

This PR does the following:
- fix the faulty offset calculations
- simplify somewhat the `RocDec::to_str_helper` method
- add a dedicated test