### PR TITLE
Add newline for partial record definition

### DIFF
--- a/crates/repl_ui/src/repl_state.rs
+++ b/crates/repl_ui/src/repl_state.rs
@@ -266,6 +266,7 @@ pub fn parse_src<'a>(arena: &'a Bump, line: &'a str) -> ParseOutcome<'a> {
                 // Special case some syntax errors to allow for multi-line inputs
                 Err((_, EExpr::Closure(EClosure::Body(_, _), _)))
                 | Err((_, EExpr::When(EWhen::Pattern(EPattern::Start(_), _), _)))
+                | Err((_, EExpr::Record(_, _)))
                 | Err((_, EExpr::Start(_)))
                 | Err((_, EExpr::IndentStart(_))) => ParseOutcome::Incomplete,
                 Err((_, EExpr::DefMissingFinalExpr(_)))


### PR DESCRIPTION
Resolves [this issue](https://github.com/roc-lang/roc/issues/2666).

The change is simple! I also wrote some tests associated tests.

As a follow-up, would it be useful to auto-indent, not just for record definitions but also when statements, closures and maybe others?

I checked and we currently manage newlining with the `rustyline` library, [where](https://docs.rs/rustyline/latest/src/rustyline/lib.rs.html#526) unfortunately adding tabs after submitting incomplete input (such as with `record = {`) is not configurable. Any suggestions on how to manage that?