### PR TITLE
Style Web REPL

### DIFF
--- a/crates/docs/src/lib.rs
+++ b/crates/docs/src/lib.rs
@@ -102,9 +102,6 @@ pub fn generate_docs_html(root_file: PathBuf) {
     // Insert asset urls & sidebar links
     let template_html = assets
         .raw_template_html
-        .replace("<!-- search.js -->", "search.js")
-        .replace("<!-- styles.css -->", "styles.css")
-        .replace("<!-- favicon.svg -->", "/favicon.svg")
         .replace(
             "<!-- Prefetch links -->",
             loaded_module

--- a/crates/docs/src/static/favicon.svg
+++ b/crates/docs/src/static/favicon.svg
@@ -1,4 +1,5 @@
 <svg viewBox="0 0 52 53" xmlns="http://www.w3.org/2000/svg">
-  <style>polygon{fill:#7d59dd}@media (prefers-color-scheme: dark){polygon{fill:#9c7bea}}</style>
-  <polygon points="0,0 23.8834,3.21052 37.2438,19.0101 45.9665,16.6324 50.5,22 45,22 44.0315,26.3689 26.4673,39.3424 27.4527,45.2132 17.655,53 23.6751,22.7086"/>
+  <!-- Make this icon look nicer in dark mode. (Only Firefox supports this; others ignore it.) -->
+  <style>@media (prefers-color-scheme: dark){polygon{fill:#9c7bea}}</style>
+  <polygon fill="#7d59dd" points="0,0 23.8834,3.21052 37.2438,19.0101 45.9665,16.6324 50.5,22 45,22 44.0315,26.3689 26.4673,39.3424 27.4527,45.2132 17.655,53 23.6751,22.7086"/>
 </svg>

--- a/crates/docs/src/static/index.html
+++ b/crates/docs/src/static/index.html
@@ -8,43 +8,46 @@
     <meta name="viewport" content="width=device-width">
     <base href="<!-- base -->">
     <script type="text/javascript" src="<!-- search.js -->" defer></script>
-    <link rel="icon" href="<!-- favicon.svg -->">
     <link rel="stylesheet" href="<!-- styles.css -->">
+    <link rel="icon" href="/favicon.svg">
+    <link rel="mask-icon" href="/favicon.svg" color="#7d59dd">
     <!-- Prefetch links -->
 </head>
 
 <body>
-<nav id="sidebar-nav">
-    <input id="module-search" aria-labelledby="search-link" type="text" placeholder="Search" />
-    <label for="module-search" id="search-link"><span id="search-link-text">Search</span> <span id="search-link-hint">(press <span id="search-shortcut-key">s</span>)</span></label>
-    <div class="module-links">
-        <!-- Module links -->
-    </div>
-</nav>
-<div class="top-header-extension">
-    <!-- if the window gets big, this extends the purple bar on the top header to the left edge of the window -->
-</div>
-<header class="top-header">
-    <div class="pkg-and-logo">
-        <a class="logo" href="/" aria-labelledby="logo-link">
-            <svg viewBox="0 -6 51 58" fill="none" xmlns="http://www.w3.org/2000/svg" aria-labelledby="logo-link" role="img">
-                <title id="logo-link">Return to Roc packages</title>
-                <polygon role="presentation" points="0,0 23.8834,3.21052 37.2438,19.0101 45.9665,16.6324 50.5,22 45,22 44.0315,26.3689 26.4673,39.3424 27.4527,45.2132 17.655,53 23.6751,22.7086" />
-            </svg>
-        </a>
-        <!-- Package Name -->
-    </div>
-    <div class="top-header-triangle">
+    <nav id="sidebar-nav">
+        <input id="module-search" aria-labelledby="search-link" type="text" placeholder="Search" />
+        <label for="module-search" id="search-link"><span id="search-link-text">Search</span> <span
+                id="search-link-hint">(press <span id="search-shortcut-key">s</span>)</span></label>
+        <div class="module-links">
+            <!-- Module links -->
+        </div>
+    </nav>
+    <div class="top-header-extension">
         <!-- if the window gets big, this extends the purple bar on the top header to the left edge of the window -->
     </div>
-</header>
-<main>
-    <!-- Module Docs -->
-</main>
-<footer>
-    <p>Made by people who like to make nice things.</p>
-    <p>© 2023</p>
-</footer>
+    <header class="top-header">
+        <div class="pkg-and-logo">
+            <a class="logo" href="/" aria-labelledby="logo-link">
+                <svg viewBox="0 -6 51 58" fill="none" xmlns="http://www.w3.org/2000/svg" aria-labelledby="logo-link"
+                    role="img">
+                    <title id="logo-link">Return to Roc packages</title>
+                    <polygon role="presentation"
+                        points="0,0 23.8834,3.21052 37.2438,19.0101 45.9665,16.6324 50.5,22 45,22 44.0315,26.3689 26.4673,39.3424 27.4527,45.2132 17.655,53 23.6751,22.7086" />
+                </svg>
+            </a>
+            <!-- Package Name -->
+        </div>
+        <div class="top-header-triangle">
+            <!-- if the window gets big, this extends the purple bar on the top header to the left edge of the window -->
+        </div>
+    </header>
+    <main>
+        <!-- Module Docs -->
+    </main>
+    <footer>
+        <p>Made by people who like to make nice things.</p>
+    </footer>
 </body>
 
 </html>

--- a/crates/docs/src/static/index.html
+++ b/crates/docs/src/static/index.html
@@ -10,6 +10,9 @@
     <script type="text/javascript" src="search.js" defer></script>
     <link rel="stylesheet" href="styles.css">
     <link rel="icon" href="/favicon.svg">
+    <!-- Safari ignores rel="icon" and only respects rel="mask-icon". It will render the SVG with
+    fill="#000" unless this `color` attribute here is hardcoded (not a CSS `var()`) to override it.
+  -->
     <link rel="mask-icon" href="/favicon.svg" color="#7d59dd">
     <!-- Prefetch links -->
 </head>

--- a/crates/docs/src/static/index.html
+++ b/crates/docs/src/static/index.html
@@ -7,8 +7,8 @@
     <!-- <meta name="description" content="TODO populate this based on the module's description"> -->
     <meta name="viewport" content="width=device-width">
     <base href="<!-- base -->">
-    <script type="text/javascript" src="<!-- search.js -->" defer></script>
-    <link rel="stylesheet" href="<!-- styles.css -->">
+    <script type="text/javascript" src="search.js" defer></script>
+    <link rel="stylesheet" href="styles.css">
     <link rel="icon" href="/favicon.svg">
     <link rel="mask-icon" href="/favicon.svg" color="#7d59dd">
     <!-- Prefetch links -->

--- a/crates/repl_cli/src/lib.rs
+++ b/crates/repl_cli/src/lib.rs
@@ -20,6 +20,18 @@ use target_lexicon::Triple;
 
 use crate::cli_gen::eval_llvm;
 
+pub const WELCOME_MESSAGE: &str = concatcp!(
+    "\n  The rockin’ ",
+    BLUE,
+    "roc repl",
+    END_COL,
+    "\n",
+    PINK,
+    "────────────────────────",
+    END_COL,
+    "\n\n"
+);
+
 #[derive(Completer, Helper, Hinter, Default)]
 pub struct ReplHelper {
     validator: InputValidator,

--- a/crates/repl_cli/src/lib.rs
+++ b/crates/repl_cli/src/lib.rs
@@ -1,21 +1,20 @@
 //! Command Line Interface (CLI) functionality for the Read-Evaluate-Print-Loop (REPL).
 mod cli_gen;
 
-use std::borrow::Cow;
-
 use bumpalo::Bump;
+use const_format::concatcp;
 use roc_load::MonomorphizedModule;
 use roc_mono::ir::OptLevel;
 use roc_repl_eval::gen::Problems;
+use roc_repl_ui::colors::{BLUE, END_COL, PINK};
 use roc_repl_ui::repl_state::{ReplAction, ReplState};
-use roc_repl_ui::{
-    format_output, is_incomplete, CONT_PROMPT, PROMPT, SHORT_INSTRUCTIONS, TIPS, WELCOME_MESSAGE,
-};
+use roc_repl_ui::{format_output, is_incomplete, CONT_PROMPT, PROMPT, SHORT_INSTRUCTIONS, TIPS};
 use roc_reporting::report::{ANSI_STYLE_CODES, DEFAULT_PALETTE};
 use roc_target::TargetInfo;
 use rustyline::highlight::{Highlighter, PromptInfo};
 use rustyline::validate::{self, ValidationContext, ValidationResult, Validator};
 use rustyline_derive::{Completer, Helper, Hinter};
+use std::borrow::Cow;
 use target_lexicon::Triple;
 
 use crate::cli_gen::eval_llvm;

--- a/crates/repl_test/src/cli.rs
+++ b/crates/repl_test/src/cli.rs
@@ -1,10 +1,10 @@
+use roc_repl_cli::WELCOME_MESSAGE;
+use roc_repl_ui::SHORT_INSTRUCTIONS;
+use roc_test_utils::assert_multiline_str_eq;
 use std::env;
 use std::io::Write;
 use std::path::PathBuf;
 use std::process::{Command, ExitStatus, Stdio};
-
-use roc_repl_ui::{SHORT_INSTRUCTIONS, WELCOME_MESSAGE};
-use roc_test_utils::assert_multiline_str_eq;
 
 const ERROR_MESSAGE_START: char = '─';
 

--- a/crates/repl_test/src/state.rs
+++ b/crates/repl_test/src/state.rs
@@ -93,12 +93,7 @@ fn partial_record_definition() {
         incomplete(&mut input);
 
         input.push('}');
-        complete(
-            &input,
-            &mut state,
-            "{ field: \"field\" } : { field : Str }",
-            "successfulRecord",
-        );
+        complete(&input, &mut state, "{ field: \"field\" } : { field : Str }");
     }
 
     // Partially define a record incompletely

--- a/crates/repl_test/src/tests.rs
+++ b/crates/repl_test/src/tests.rs
@@ -1405,11 +1405,10 @@ fn interpolation_with_nested_interpolation() {
 
                 Enter an expression to evaluate, or a definition (like x = 1) to use later.
 
-                Tips:
-
                   - ctrl-v + ctrl-j makes a newline
-                  - :q to quit
-                  - :help shows this text again"#
+                  - :q quits
+                  - :help shows this text again
+            "#
         ),
         // TODO figure out why the tests prints the repl help text at the end, but only after syntax errors or something?
         // In the actual repl this doesn't happen, only in the test.

--- a/crates/repl_test/src/tests.rs
+++ b/crates/repl_test/src/tests.rs
@@ -1408,10 +1408,8 @@ fn interpolation_with_nested_interpolation() {
                 Tips:
 
                   - ctrl-v + ctrl-j makes a newline
-
                   - :q to quit
-
-                  - :help"#
+                  - :help shows this text again"#
         ),
         // TODO figure out why the tests prints the repl help text at the end, but only after syntax errors or something?
         // In the actual repl this doesn't happen, only in the test.

--- a/crates/repl_test/src/tests.rs
+++ b/crates/repl_test/src/tests.rs
@@ -1403,7 +1403,7 @@ fn interpolation_with_nested_interpolation() {
                 <https://www.roc-lang.org/tutorial#string-interpolation>
 
 
-                Enter an expression to evaluate, or a definition (like x = 1) to use in future expressions.
+                Enter an expression to evaluate, or a definition (like x = 1) to use later.
 
                 Tips:
 

--- a/crates/repl_ui/src/lib.rs
+++ b/crates/repl_ui/src/lib.rs
@@ -11,13 +11,15 @@ use roc_parse::ast::{Expr, ValueDef};
 use roc_repl_eval::gen::{Problems, ReplOutput};
 use roc_reporting::report::StyleCodes;
 
+use crate::colors::GREEN;
+
 // TODO add link to repl tutorial(does not yet exist).
 pub const TIPS: &str = concatcp!(
     "\nEnter an expression to evaluate, or a definition (like ",
     BLUE,
     "x = 1",
     END_COL,
-    ") to use later.\n\nTips:\n\n",
+    ") to use later.\n\n",
     if cfg!(target_family = "wasm") {
         // In the web REPL, the :quit command doesn't make sense. Just close the browser tab!
         // We use Shift-Enter for newlines because it's nicer than our workaround for Unix terminals (see below)
@@ -51,15 +53,21 @@ pub const TIPS: &str = concatcp!(
             PINK,
             "ctrl-j",
             END_COL,
-            " makes a newline\n\n",
+            " makes a newline\n",
             BLUE,
             "  - ",
             END_COL,
-            ":q to quit\n\n",
+            GREEN,
+            ":q",
+            END_COL,
+            " quits\n",
             BLUE,
             "  - ",
             END_COL,
-            ":help"
+            GREEN,
+            ":help",
+            END_COL,
+            " shows this text again\n",
         )
     }
 );

--- a/crates/repl_ui/src/lib.rs
+++ b/crates/repl_ui/src/lib.rs
@@ -34,7 +34,7 @@ pub const TIPS: &str = concatcp!(
             PINK,
             "Ctrl-Enter",
             END_COL,
-            " makes a newline\n\n",
+            " makes a newline\n",
             BLUE,
             "  - ",
             END_COL,

--- a/crates/repl_ui/src/lib.rs
+++ b/crates/repl_ui/src/lib.rs
@@ -11,25 +11,13 @@ use roc_parse::ast::{Expr, ValueDef};
 use roc_repl_eval::gen::{Problems, ReplOutput};
 use roc_reporting::report::StyleCodes;
 
-pub const WELCOME_MESSAGE: &str = concatcp!(
-    "\n  The rockin’ ",
-    BLUE,
-    "roc repl",
-    END_COL,
-    "\n",
-    PINK,
-    "────────────────────────",
-    END_COL,
-    "\n\n"
-);
-
 // TODO add link to repl tutorial(does not yet exist).
 pub const TIPS: &str = concatcp!(
     "\nEnter an expression to evaluate, or a definition (like ",
     BLUE,
     "x = 1",
     END_COL,
-    ") to use in future expressions.\n\nTips:\n\n",
+    ") to use later.\n\nTips:\n\n",
     if cfg!(target_family = "wasm") {
         // In the web REPL, the :quit command doesn't make sense. Just close the browser tab!
         // We use Shift-Enter for newlines because it's nicer than our workaround for Unix terminals (see below)

--- a/www/public/different-names/index.html
+++ b/www/public/different-names/index.html
@@ -3,141 +3,140 @@
 <html lang="en">
 
 <head>
-  <meta charset="utf-8">
-
-  <title>Different Names in Roc</title>
-  <meta name="description" content="Names of things in Roc that differ from other languages.">
-  <meta name="viewport" content="width=device-width">
-  <link rel="stylesheet" href="/site.css">
-  <link rel="icon" href="/favicon.svg">
+    <meta charset="utf-8">
+    <title>Different Names in Roc</title>
+    <meta name="description" content="Names of things in Roc that differ from other languages.">
+    <meta name="viewport" content="width=device-width">
+    <link rel="stylesheet" href="/site.css">
+    <link rel="icon" href="/favicon.svg">
 </head>
 
 <body>
-  <h1>Different Names</h1>
-  <p>Different programming languages sometimes choose different names for similar operations.
-    If you're new to Roc, you may be searching for a familiar operation and not find it because
-    that operation (or a similar one) goes by a different name in Roc.
-  </p>
+    <h1>Different Names</h1>
+    <p>Different programming languages sometimes choose different names for similar operations.
+        If you're new to Roc, you may be searching for a familiar operation and not find it because
+        that operation (or a similar one) goes by a different name in Roc.
+    </p>
 
-  <p>To help with this, here are some Roc operations along with some names found in other languages
-    for similar operations.
-  </p>
+    <p>To help with this, here are some Roc operations along with some names found in other languages
+        for similar operations.
+    </p>
 
-  <table>
-    <thead>
-        <tr>
-            <th>Roc Name</th>
-            <th>Other Names</th>
-        </tr>
-    </thead>
-    <tbody id="different-names-body">
-        <tr>
-            <td><a href="/builtins/List#walk">List.walk</a></td>
-            <td>
-                <ul>
-                    <li>fold</li>
-                    <li>foldl</li>
-                    <li>foldLeft</li>
-                    <li>fold_left</li>
-                    <li>fold-left</li>
-                    <li>reduce</li>
-                    <li>lreduce</li>
-                    <li>array_reduce</li>
-                    <li>inject</li>
-                    <li>accumulate</li>
-                    <li>Aggregate</li>
-                </ul>
-            </td>
-        </tr>
-        <tr>
-            <td><a href="/builtins/List#walkBackwards">List.walkBackwards</a></td>
-            <td>
-                <ul>
-                    <li>foldr</li>
-                    <li>foldRight</li>
-                    <li>fold_right</li>
-                    <li>fold-right</li>
-                    <li>reduceRight</li>
-                    <li>rreduce</li>
-                </ul>
-            </td>
-        </tr>
-        <tr>
-            <td><a href="/builtins/List#join">List.first</a></td>
-            <td>
-                <ul>
-                    <li>head</li>
-                    <li>get(0)</li>
-                    <li>[0]</li>
-                </ul>
-            </td>
-        </tr>
-        <tr>
-            <td><a href="/builtins/List#keepIf">List.keepIf</a></td>
-            <td>
-                <ul>
-                    <li>filter</li>
-                    <li>select</li>
-                    <li>copy_if</li>
-                    <li>remove-if-not</li>
-                </ul>
-            </td>
-        </tr>
-        <tr>
-            <td><a href="/builtins/List#dropIf">List.dropIf</a></td>
-            <td>
-                <ul>
-                    <li>reject</li>
-                    <li>remove_copy_if</li>
-                    <li>remove-if</li>
-                </ul>
-            </td>
-        </tr>
-        <tr>
-            <td><a href="/builtins/List#join">List.join</a></td>
-            <td>
-                <ul>
-                    <li>flatten</li>
-                    <li>flat</li>
-                    <li>concat</li>
-                    <li>smoosh</li>
-                </ul>
-            </td>
-        </tr>
-        <tr>
-            <td><a href="/builtins/List#joinMap">List.joinMap</a></td>
-            <td>
-                <ul>
-                    <li>filterMap</li>
-                    <li>filter_map</li>
-                </ul>
-            </td>
-        </tr>
-        <tr>
-            <td><a href="/builtins/List#keepOks">List.keepOks</a></td>
-            <td>
-                <ul>
-                    <li>compact</li>
-                    <li>filterMap(identity)</li>
-                </ul>
-            </td>
-        </tr>
-        <tr>
-            <td><a href="/builtins/Result#try">Result.try</a></td>
-            <td>
-                <ul>
-                    <li>bind</li>
-                    <li>flatMap</li>
-                    <li>andThen</li>
-                    <li>(&gt;&gt;=)</li>
-                </ul>
-            </td>
-        </tr>
-    </tbody>
-  </table>
-  <footer>
-    <p>Made by people who like to make nice things.</p>
-    <p>© 2022</p>
-  </footer>
+    <table>
+        <thead>
+            <tr>
+                <th>Roc Name</th>
+                <th>Other Names</th>
+            </tr>
+        </thead>
+        <tbody id="different-names-body">
+            <tr>
+                <td><a href="/builtins/List#walk">List.walk</a></td>
+                <td>
+                    <ul>
+                        <li>fold</li>
+                        <li>foldl</li>
+                        <li>foldLeft</li>
+                        <li>fold_left</li>
+                        <li>fold-left</li>
+                        <li>reduce</li>
+                        <li>lreduce</li>
+                        <li>array_reduce</li>
+                        <li>inject</li>
+                        <li>accumulate</li>
+                        <li>Aggregate</li>
+                    </ul>
+                </td>
+            </tr>
+            <tr>
+                <td><a href="/builtins/List#walkBackwards">List.walkBackwards</a></td>
+                <td>
+                    <ul>
+                        <li>foldr</li>
+                        <li>foldRight</li>
+                        <li>fold_right</li>
+                        <li>fold-right</li>
+                        <li>reduceRight</li>
+                        <li>rreduce</li>
+                    </ul>
+                </td>
+            </tr>
+            <tr>
+                <td><a href="/builtins/List#join">List.first</a></td>
+                <td>
+                    <ul>
+                        <li>head</li>
+                        <li>get(0)</li>
+                        <li>[0]</li>
+                    </ul>
+                </td>
+            </tr>
+            <tr>
+                <td><a href="/builtins/List#keepIf">List.keepIf</a></td>
+                <td>
+                    <ul>
+                        <li>filter</li>
+                        <li>select</li>
+                        <li>copy_if</li>
+                        <li>remove-if-not</li>
+                    </ul>
+                </td>
+            </tr>
+            <tr>
+                <td><a href="/builtins/List#dropIf">List.dropIf</a></td>
+                <td>
+                    <ul>
+                        <li>reject</li>
+                        <li>remove_copy_if</li>
+                        <li>remove-if</li>
+                    </ul>
+                </td>
+            </tr>
+            <tr>
+                <td><a href="/builtins/List#join">List.join</a></td>
+                <td>
+                    <ul>
+                        <li>flatten</li>
+                        <li>flat</li>
+                        <li>concat</li>
+                        <li>smoosh</li>
+                    </ul>
+                </td>
+            </tr>
+            <tr>
+                <td><a href="/builtins/List#joinMap">List.joinMap</a></td>
+                <td>
+                    <ul>
+                        <li>filterMap</li>
+                        <li>filter_map</li>
+                    </ul>
+                </td>
+            </tr>
+            <tr>
+                <td><a href="/builtins/List#keepOks">List.keepOks</a></td>
+                <td>
+                    <ul>
+                        <li>compact</li>
+                        <li>filterMap(identity)</li>
+                    </ul>
+                </td>
+            </tr>
+            <tr>
+                <td><a href="/builtins/Result#try">Result.try</a></td>
+                <td>
+                    <ul>
+                        <li>bind</li>
+                        <li>flatMap</li>
+                        <li>andThen</li>
+                        <li>(&gt;&gt;=)</li>
+                    </ul>
+                </td>
+            </tr>
+        </tbody>
+    </table>
+    <footer>
+        <p>Made by people who like to make nice things.</p>
+    </footer>
 </body>
+
 </html>

--- a/www/public/different-names/index.html
+++ b/www/public/different-names/index.html
@@ -9,6 +9,10 @@
     <meta name="viewport" content="width=device-width">
     <link rel="stylesheet" href="/site.css">
     <link rel="icon" href="/favicon.svg">
+    <!-- Safari ignores rel="icon" and only respects rel="mask-icon". It will render the SVG with
+    fill="#000" unless this `color` attribute here is hardcoded (not a CSS `var()`) to override it.
+  -->
+    <link rel="mask-icon" href="/favicon.svg" color="#7d59dd">
 </head>
 
 <body>

--- a/www/public/index.html
+++ b/www/public/index.html
@@ -21,7 +21,8 @@
 
   <p>Roc compiles to machine code or to <a href="https://webassembly.org">WebAssembly</a>. Eventually
     you'll be able to use Roc to build high-quality servers, command-line applications, graphical
-    native desktop user interfaces, among other classes of applications. Today, only command-line interfaces have support beyond the
+    native desktop user interfaces, among other classes of applications. Today, only command-line interfaces have
+    support beyond the
     proof-of-concept stage; the other use cases will mature over time.</p>
 
   <p>Like <a href="https://www.lua.org/">Lua</a>, Roc's automatic memory management doesn't require
@@ -39,7 +40,8 @@
   <p>With all that context in mind, if you'd like to try it out or to get involved with contributing,
     the <a href="https://github.com/roc-lang/roc">source code repository</a> has
     <a href="https://github.com/roc-lang/roc/releases">nightly builds</a> you can download,
-    and a <a href="https://roc-lang.org/tutorial">tutorial</a>.</p>
+    and a <a href="https://roc-lang.org/tutorial">tutorial</a>.
+  </p>
 
   <p>If you'd like to learn more about Roc, you can continue reading here, or check out one of these videos:</p>
   <ul>
@@ -64,7 +66,7 @@
     that sees mainstream use in industry. The goal is that nobody should find themselves
     thinking "I should rewrite my Roc program in [some mainstream garbage-collected language]
     because that will make it run significantly faster."
-    </p>
+  </p>
 
   <p>When benchmarking Roc code against similarly-optimized programs written in
     <a href="https://go.dev">Go</a>,
@@ -75,7 +77,8 @@
     languages like Rust, Zig, C, D, and C++ is a non-goal, as is outperforming research languages
     that see little or no use in industry. (Realistically, there will always be certain specific
     benchmarks where some popular non-systems-level languages outperform Roc, but the goal is to
-    usually be at the front of that pack.)</p>
+    usually be at the front of that pack.)
+  </p>
 
   <h4>Current progress</h4>
 
@@ -99,202 +102,215 @@
     like C, C++, Zig, and Rust do. The most costly is automatic memory management, which Roc
     implements using automatic reference counting. Static reference count optimizations like
     elision and reuse (thanks to Morphic and
-    <a href="https://www.microsoft.com/en-us/research/publication/perceus-garbage-free-reference-counting-with-reuse/">Perceus</a>)
-    improve things, but significant runtime overhead remains.</p>
+    <a
+      href="https://www.microsoft.com/en-us/research/publication/perceus-garbage-free-reference-counting-with-reuse/">Perceus</a>)
+    improve things, but significant runtime overhead remains.
+  </p>
 
   <p>Eliminating this overhead altogether would require sacrificing other design goals
-  (e.g. it would require introducing memory-unsafe operations, or compile-time lifetime errors),
-  and there isn't much overhead left to remove outside of automatic memory management. For example,
-  smaller sources of overhead include mandatory array bounds checks, disallowing cyclic references
-  (which rules out a certain niche of efficient graph data structures), and automatic opportunistic
-  in-place mutation instead of direct mutation. Even if all of these sources of overhead were
-  completely eliminated, it seems unlikely that typical Roc programs would see a particularly big
-  performance boost.</p>
+    (e.g. it would require introducing memory-unsafe operations, or compile-time lifetime errors),
+    and there isn't much overhead left to remove outside of automatic memory management. For example,
+    smaller sources of overhead include mandatory array bounds checks, disallowing cyclic references
+    (which rules out a certain niche of efficient graph data structures), and automatic opportunistic
+    in-place mutation instead of direct mutation. Even if all of these sources of overhead were
+    completely eliminated, it seems unlikely that typical Roc programs would see a particularly big
+    performance boost.</p>
 
-<p>Overall, we expect Roc's performance in the use cases mentioned above (servers, CLIs, GUIs, etc.)
-   to be about the same as the equivalent C++ code would be, if all that C++ code
-   (including its dependencies) were written in a restricted subset of C++ which always did array
-   bounds checks and used shared pointers for all heap allocations.
-   The Roc code might even run somewhat faster, because its reference counts are non-atomic by default,
-   and can be statically optimized away in some cases—but then again, Roc also has a bit of overhead
-   to perform opportunistic in-place mutation instead of direct mutation.</p>
+  <p>Overall, we expect Roc's performance in the use cases mentioned above (servers, CLIs, GUIs, etc.)
+    to be about the same as the equivalent C++ code would be, if all that C++ code
+    (including its dependencies) were written in a restricted subset of C++ which always did array
+    bounds checks and used shared pointers for all heap allocations.
+    The Roc code might even run somewhat faster, because its reference counts are non-atomic by default,
+    and can be statically optimized away in some cases—but then again, Roc also has a bit of overhead
+    to perform opportunistic in-place mutation instead of direct mutation.</p>
 
-<p>To be clear, we don't expect this because we've benchmarked a bunch of programs written in Roc
-  and in this restricted C++ subset, and found that the numbers were about the same (although if
-  you know C++ well enough and want to do such experiments, we'd happy to help and would be
-  interested to see the results!) but rather because Roc's compiler and
-  <a href="https://clang.llvm.org/">clang</a> should both be generating essentially the same
-  LLVM instructions when the C++ is restricted to that subset.</p>
+  <p>To be clear, we don't expect this because we've benchmarked a bunch of programs written in Roc
+    and in this restricted C++ subset, and found that the numbers were about the same (although if
+    you know C++ well enough and want to do such experiments, we'd happy to help and would be
+    interested to see the results!) but rather because Roc's compiler and
+    <a href="https://clang.llvm.org/">clang</a> should both be generating essentially the same
+    LLVM instructions when the C++ is restricted to that subset.
+  </p>
 
-<p>Of course, <em>unrestricted</em> C++ code can certainly run faster than unrestricted Roc code.
-  The same is true when comparing other such minimal-overhead systems languages to Roc, including
-  Rust, Zig, C, and D. The point of the comparison is to give you a general idea of what Roc
-  compiles to, since it is quite different from the VMs and JITted bytecode interpreters found in
-  today's most popular garbage-collected languages!</p>
+  <p>Of course, <em>unrestricted</em> C++ code can certainly run faster than unrestricted Roc code.
+    The same is true when comparing other such minimal-overhead systems languages to Roc, including
+    Rust, Zig, C, and D. The point of the comparison is to give you a general idea of what Roc
+    compiles to, since it is quite different from the VMs and JITted bytecode interpreters found in
+    today's most popular garbage-collected languages!</p>
 
-<p>The talk <a href="https://youtu.be/vzfy4EKwG_Y">Outperforming Imperative with Pure Functional Languages</a>
-  discusses some early results from Roc's optimizations, and
-  <a href="https://media.handmade-seattle.com/roc-lang">Roc at Handmade Seattle</a> gets into
-  low-level details of how Roc's compiler generates programs similarly to how clang does.</p>
+  <p>The talk <a href="https://youtu.be/vzfy4EKwG_Y">Outperforming Imperative with Pure Functional Languages</a>
+    discusses some early results from Roc's optimizations, and
+    <a href="https://media.handmade-seattle.com/roc-lang">Roc at Handmade Seattle</a> gets into
+    low-level details of how Roc's compiler generates programs similarly to how clang does.
+  </p>
 
-<h2>A <em>Friendly</em> Language</h2>
+  <h2>A <em>Friendly</em> Language</h2>
 
-<h3>Goals</h3>
+  <h3>Goals</h3>
 
-<p>Roc aims to be a user-friendly language with a friendly community of users.</p>
+  <p>Roc aims to be a user-friendly language with a friendly community of users.</p>
 
-<p>A programming language can be much more than a tool for writing software, it can also be a way
-  for people to come together through shared experiences, to teach and to learn from one another,
-  and to make new friends.</p>
+  <p>A programming language can be much more than a tool for writing software, it can also be a way
+    for people to come together through shared experiences, to teach and to learn from one another,
+    and to make new friends.</p>
 
-<p>No community is perfect, but a community where people show kindness to each another by default
-  can be a true joy to participate in. That all starts with friendliness, especially towards
-  beginners, and including towards people who prefer other programming languages.
-  After all, languages are tools people use to create software, and there's no need for us
-  to create artificial divisions between ourselves based on the tools we use!</p>
+  <p>No community is perfect, but a community where people show kindness to each another by default
+    can be a true joy to participate in. That all starts with friendliness, especially towards
+    beginners, and including towards people who prefer other programming languages.
+    After all, languages are tools people use to create software, and there's no need for us
+    to create artificial divisions between ourselves based on the tools we use!</p>
 
-<p>On a technical level, Roc aims to ship a toolset where user-friendliness is a major priority.
-  This includes everything from helpful error messages (aiming to meet the bar set by
-  <a href="https://elm-lang.org">Elm</a>) to quality-of-life improvements inspired by dynamic
-  languages (always being able to run your program even if there are compile errors, automatic
-  serialization and deserialization using schemas determined by type inference, reliable hot
-  code loading that's always enabled and requires no configuration to set up, etc.) to accessibility
-  features in the included editor.</p>
+  <p>On a technical level, Roc aims to ship a toolset where user-friendliness is a major priority.
+    This includes everything from helpful error messages (aiming to meet the bar set by
+    <a href="https://elm-lang.org">Elm</a>) to quality-of-life improvements inspired by dynamic
+    languages (always being able to run your program even if there are compile errors, automatic
+    serialization and deserialization using schemas determined by type inference, reliable hot
+    code loading that's always enabled and requires no configuration to set up, etc.) to accessibility
+    features in the included editor.
+  </p>
 
-<p>Roc also aims to ship a single binary that includes not only a compiler, but also a
-  <a href="https://en.wikipedia.org/wiki/Read%E2%80%93eval%E2%80%93print_loop">REPL</a>,
-  package manager, test runner, debugger, static analyzer, code formatter, and a full-featured
-  editor, all of which are designed to work seamlessly together.</p>
+  <p>Roc also aims to ship a single binary that includes not only a compiler, but also a
+    <a href="https://en.wikipedia.org/wiki/Read%E2%80%93eval%E2%80%93print_loop">REPL</a>,
+    package manager, test runner, debugger, static analyzer, code formatter, and a full-featured
+    editor, all of which are designed to work seamlessly together.
+  </p>
 
-<h3>Current Progress</h3>
+  <h3>Current Progress</h3>
 
-<p>Work has not yet started on the package manager, static analyzer, debugger, or hot code loading
-  system, and although work has started on the editor, it's not yet far enough along to be usable
-  for practical purposes. The standard library is perhaps 80 percent complete in terms of
-  functionality, but a lot of operations do not yet have documentation.</p>
+  <p>Work has not yet started on the package manager, static analyzer, debugger, or hot code loading
+    system, and although work has started on the editor, it's not yet far enough along to be usable
+    for practical purposes. The standard library is perhaps 80 percent complete in terms of
+    functionality, but a lot of operations do not yet have documentation.</p>
 
-<p>The REPL fully supports entering arbitrary expressions, and will evaluate them and print the
-  results. It remembers recent expressions entered in the current session (if you press the up arrow),
-  but it can't yet execute effects. You can try out the REPL in a browser at
-  <a href="https://roc-lang.org/repl">roc-lang.org/repl</a> - it uses a WebAssembly build of Roc's
-  compiler, and compiles the code you write to WebAssembly on the fly, which it then executes in
-  the browser to display the answer.</p>
+  <p>The REPL fully supports entering arbitrary expressions, and will evaluate them and print the
+    results. It remembers recent expressions entered in the current session (if you press the up arrow),
+    but it can't yet execute effects. You can try out the REPL in a browser at
+    <a href="https://roc-lang.org/repl">roc-lang.org/repl</a> - it uses a WebAssembly build of Roc's
+    compiler, and compiles the code you write to WebAssembly on the fly, which it then executes in
+    the browser to display the answer.
+  </p>
 
-<p>The compiler works well enough on a basic level to build things with it, but some error messages
-  could use significant improvement, and it has a lot of known bugs and missing features. You can
-  currently use it on macOS (either Intel or Apple Silicon), Linux (only x86-64 machines at the moment),
-  and Windows (only recently supported; debugging and testing features don't work on it yet, and
-  there are likely bugs we haven't encountered yet due to lack of battle testing). Support for other
-  operating systems has not yet been discussed.</p>
+  <p>The compiler works well enough on a basic level to build things with it, but some error messages
+    could use significant improvement, and it has a lot of known bugs and missing features. You can
+    currently use it on macOS (either Intel or Apple Silicon), Linux (only x86-64 machines at the moment),
+    and Windows (only recently supported; debugging and testing features don't work on it yet, and
+    there are likely bugs we haven't encountered yet due to lack of battle testing). Support for other
+    operating systems has not yet been discussed.</p>
 
-<p>The compiler doesn't yet support incremental compilation or hot code loading, and build times vary
-  based on what machine you're building for.</p>
+  <p>The compiler doesn't yet support incremental compilation or hot code loading, and build times vary
+    based on what machine you're building for.</p>
 
-<p>For example, suppose you run `roc check`, which reports errors it finds (type mismatches, naming
-  errors, and so on) but doesn't actually build an executable, on a code base that's under a thousand
-  lines of code. On an M1 MacBook Pro, this typically takes about 10 milliseconds.</p>
+  <p>For example, suppose you run `roc check`, which reports errors it finds (type mismatches, naming
+    errors, and so on) but doesn't actually build an executable, on a code base that's under a thousand
+    lines of code. On an M1 MacBook Pro, this typically takes about 10 milliseconds.</p>
 
-<p>In contrast, if you do `roc build` (or `roc run`) on that same machine, it will take closer to 500
-  milliseconds instead. Almost all that extra time is spent waiting for LLVM to generate (unoptimized)
-  machine code, and then for the system linker to assemble an executable from it.</p>
+  <p>In contrast, if you do `roc build` (or `roc run`) on that same machine, it will take closer to 500
+    milliseconds instead. Almost all that extra time is spent waiting for LLVM to generate (unoptimized)
+    machine code, and then for the system linker to assemble an executable from it.</p>
 
-<p> Fortunately, we can eliminate almost all of those extra 490 millisconds of build time by using
-Roc's (work in progress) development backend instead of LLVM. This compiles directly from Roc's
-internal representation to machine code, like most compilers did before LLVM. (LLVM can optimize
-code into running very fast, but even when it performs no optimization at all, LLVM itself takes a lot
-longer to run than generating unoptimized machine code directly.)</p>
+  <p> Fortunately, we can eliminate almost all of those extra 490 millisconds of build time by using
+    Roc's (work in progress) development backend instead of LLVM. This compiles directly from Roc's
+    internal representation to machine code, like most compilers did before LLVM. (LLVM can optimize
+    code into running very fast, but even when it performs no optimization at all, LLVM itself takes a lot
+    longer to run than generating unoptimized machine code directly.)</p>
 
-<p>The LLVM backend is currently the most feature-complete, followed closely by the WebAssembly backend
-  (which the online REPL uses exclusively, instead of LLVM). The x86 and ARM backends still have a
-  ways to go, but improving them can be done by anyone with the patience to read some documentation;
-  we have issues split up for them, and are happy to help new contributors get up and running!</p>
+  <p>The LLVM backend is currently the most feature-complete, followed closely by the WebAssembly backend
+    (which the online REPL uses exclusively, instead of LLVM). The x86 and ARM backends still have a
+    ways to go, but improving them can be done by anyone with the patience to read some documentation;
+    we have issues split up for them, and are happy to help new contributors get up and running!</p>
 
-<p>Builds on Linux and Windows also use Roc's surgical linker instead of the system linker, which
-  runs so fast that linking essentially disappears from the performance profile altogether. The
-  surgical linker currently only works on Linux and Windows, and it currently supports building
-  executables but not (yet) dynamic libraries, which is relevant if you're using Roc to create
-  plugins or want to call Roc functions from existing code bases in other languages. Work has started
-  on macOS surgical linking, but it isn't usable yet. If you're interested in working on that,
-  please get in touch on <a href="https://roc.zulipchat.com/">Roc Zulip</a>!</p>
+  <p>Builds on Linux and Windows also use Roc's surgical linker instead of the system linker, which
+    runs so fast that linking essentially disappears from the performance profile altogether. The
+    surgical linker currently only works on Linux and Windows, and it currently supports building
+    executables but not (yet) dynamic libraries, which is relevant if you're using Roc to create
+    plugins or want to call Roc functions from existing code bases in other languages. Work has started
+    on macOS surgical linking, but it isn't usable yet. If you're interested in working on that,
+    please get in touch on <a href="https://roc.zulipchat.com/">Roc Zulip</a>!</p>
 
-<p>The test runner currently has first-class support for running standard non-effectful tests.
-  It does not yet have first-class support for effectful tests, property-based tests, snapshot tests,
-  or "simulation tests" (where effects are replaced by hardcoded values during the test - similar to
-  "mocking" in other languages), although these are all planned for the future.</p>
+  <p>The test runner currently has first-class support for running standard non-effectful tests.
+    It does not yet have first-class support for effectful tests, property-based tests, snapshot tests,
+    or "simulation tests" (where effects are replaced by hardcoded values during the test - similar to
+    "mocking" in other languages), although these are all planned for the future.</p>
 
-<p>The code formatter is nearly feature-complete, although occasionally it will report an error -
-  usually due to a comment being placed somewhere it doesn't yet know how to handle. Unlike most of
-  the rest of the compiler, the formatter is one place where the number of known bugs is so small
-  that fuzzing would be very helpful as a way to surface bugs we don't yet know about. (If you're
-  interested in working on setting up fuzzing for the formatter, please let us know in
-  the <a href="https://roc.zulipchat.com/#narrow/stream/316715-contributing"><code>#contributing</code> channel</a>
-  on Zulip! Separately, we're also very interested in fuzzing the compiler, even though we already
-  have a sizable list of known bugs there.)</p>
+  <p>The code formatter is nearly feature-complete, although occasionally it will report an error -
+    usually due to a comment being placed somewhere it doesn't yet know how to handle. Unlike most of
+    the rest of the compiler, the formatter is one place where the number of known bugs is so small
+    that fuzzing would be very helpful as a way to surface bugs we don't yet know about. (If you're
+    interested in working on setting up fuzzing for the formatter, please let us know in
+    the <a href="https://roc.zulipchat.com/#narrow/stream/316715-contributing"><code>#contributing</code> channel</a>
+    on Zulip! Separately, we're also very interested in fuzzing the compiler, even though we already
+    have a sizable list of known bugs there.)</p>
 
-<p>On the community side, so far the community is a friendly bunch, and we want to keep it that way
-  as it grows! We hope to do that by encouraging a culture of kindness and helping one another out,
-  especially by being welcoming towards beginners.</p>
+  <p>On the community side, so far the community is a friendly bunch, and we want to keep it that way
+    as it grows! We hope to do that by encouraging a culture of kindness and helping one another out,
+    especially by being welcoming towards beginners.</p>
 
-<p>If you'd like to join in, the best place to do that is in our Zulip chat. Feel free to drop by the
-  <a href="https://roc.zulipchat.com/#narrow/stream/231634-beginners/topic/introductions"><code>introductions</code> topic</a>
-  and introduce yourself!</p>
+  <p>If you'd like to join in, the best place to do that is in our Zulip chat. Feel free to drop by the
+    <a href="https://roc.zulipchat.com/#narrow/stream/231634-beginners/topic/introductions"><code>introductions</code>
+      topic</a>
+    and introduce yourself!
+  </p>
 
-<h2>A <em>Functional</em> Language</h2>
+  <h2>A <em>Functional</em> Language</h2>
 
-<h3>Goals</h3>
+  <h3>Goals</h3>
 
-<p>Roc aims to be a purely functional programming language. This means all Roc functions are
-  <a href="https://en.wikipedia.org/wiki/Pure_function">pure functions</a>, and all effects are
-  <a href="https://medium.com/@kaw2k/managed-effects-and-elm-36b7fcd246a9">managed effects</a>
-  instead of side effects.</p>
+  <p>Roc aims to be a purely functional programming language. This means all Roc functions are
+    <a href="https://en.wikipedia.org/wiki/Pure_function">pure functions</a>, and all effects are
+    <a href="https://medium.com/@kaw2k/managed-effects-and-elm-36b7fcd246a9">managed effects</a>
+    instead of side effects.
+  </p>
 
-<p>A major motivating reason for this is to facilitate tooling. For example, in the future the goal
-  is that Roc's test runner won't bother re-running tests whose outcomes could not possibly have
-  changed (because they were pure functions whose inputs did not change). Tests that contain only
-  pure functions can be trivially run in parallel, and they will never <a href="https://www.smashingmagazine.com/2021/04/flaky-tests-living-nightmare/">flake</a>.
-  Additionally, having the guarantee that the application contains only pure functions can also make
-  certain debugging tools more reliable, such as time travel and retroactive tracing.
-</p>
+  <p>A major motivating reason for this is to facilitate tooling. For example, in the future the goal
+    is that Roc's test runner won't bother re-running tests whose outcomes could not possibly have
+    changed (because they were pure functions whose inputs did not change). Tests that contain only
+    pure functions can be trivially run in parallel, and they will never <a
+      href="https://www.smashingmagazine.com/2021/04/flaky-tests-living-nightmare/">flake</a>.
+    Additionally, having the guarantee that the application contains only pure functions can also make
+    certain debugging tools more reliable, such as time travel and retroactive tracing.
+  </p>
 
-<p>Roc also takes a novel approach to managed effects. In most programming languages, the standard
-  library contains both data structures and I/O primitives (e.g. for using the file system or the
-  network), and then you might decide to use a <a href="https://en.wikipedia.org/wiki/Application_framework">framework</a>
-  on top of that standard library.</p>
+  <p>Roc also takes a novel approach to managed effects. In most programming languages, the standard
+    library contains both data structures and I/O primitives (e.g. for using the file system or the
+    network), and then you might decide to use a <a
+      href="https://en.wikipedia.org/wiki/Application_framework">framework</a>
+    on top of that standard library.</p>
 
-<p>In Roc, every application is built on a <em>platform</em>. A platform is like a framework except
-  that it also provides I/O primitives and behind-the-scenes memory management. (Roc's standard
-  library only contains data structures.) In practice, this means that using Roc feels similar to
-  using any other programming language where you've chosen to use a framework, except that the
-  documentation for your I/O primitives comes from the framework instead of the standard library.</p>
+  <p>In Roc, every application is built on a <em>platform</em>. A platform is like a framework except
+    that it also provides I/O primitives and behind-the-scenes memory management. (Roc's standard
+    library only contains data structures.) In practice, this means that using Roc feels similar to
+    using any other programming language where you've chosen to use a framework, except that the
+    documentation for your I/O primitives comes from the framework instead of the standard library.</p>
 
-<p>This might sound like a minor distinction, but it turns out there are a lot of surprising benefits
-  to organizing things this way, which would be impossible to achieve without having platforms as a
-  first-class language concept. <a href="https://youtu.be/cpQwtwVKAfU">The Edges of Cutting-Edge Languages</a>
-  goes into more detail about some of these benefits.
-</p>
+  <p>This might sound like a minor distinction, but it turns out there are a lot of surprising benefits
+    to organizing things this way, which would be impossible to achieve without having platforms as a
+    first-class language concept. <a href="https://youtu.be/cpQwtwVKAfU">The Edges of Cutting-Edge Languages</a>
+    goes into more detail about some of these benefits.
+  </p>
 
-<h3>Current Progress</h3>
+  <h3>Current Progress</h3>
 
-<p>Today, platforms as a concept already exist, and there are a few different ones implemented.
-  You can find them in the <a href="https://github.com/roc-lang/roc/tree/main/examples"><code>examples/</code></a>
-  directory in the source code repository. The platform for building command-line interfaces is the
-  most fully featured; the others are mostly in the proof-of-concept stage.
-</p>
+  <p>Today, platforms as a concept already exist, and there are a few different ones implemented.
+    You can find them in the <a href="https://github.com/roc-lang/roc/tree/main/examples"><code>examples/</code></a>
+    directory in the source code repository. The platform for building command-line interfaces is the
+    most fully featured; the others are mostly in the proof-of-concept stage.
+  </p>
 
-<p>Roc's built-in tooling is not yet far enough along to take advantage of pure functions. For
-  example, there is a built-in test runner, but it does not yet run tests in parallel or skip
-  running tests whose outcomes could not possibly have changed.
-</p>
+  <p>Roc's built-in tooling is not yet far enough along to take advantage of pure functions. For
+    example, there is a built-in test runner, but it does not yet run tests in parallel or skip
+    running tests whose outcomes could not possibly have changed.
+  </p>
 
-<p>Roc is already a purely functional programming language, though, so all of these benefits
-  are ready to be unlocked as the tooling implementations progress!
-</p>
+  <p>Roc is already a purely functional programming language, though, so all of these benefits
+    are ready to be unlocked as the tooling implementations progress!
+  </p>
 
-<h2>The Roc Programming Language Foundation</h2>
+  <h2>The Roc Programming Language Foundation</h2>
 
-<p>We've created a nonprofit to support Roc, you can learn more about it <a href="https://foundation.roc-lang.org/">here</a>.</p>
+  <p>We've created a nonprofit to support Roc, you can learn more about it <a
+      href="https://foundation.roc-lang.org/">here</a>.</p>
 
-<footer>This site is powered by <a href="https://www.netlify.com">Netlify</a>.</footer>
+  <footer>This site is powered by <a href="https://www.netlify.com">Netlify</a>.</footer>
 </body>
 
 </html>

--- a/www/public/repl/index.html
+++ b/www/public/repl/index.html
@@ -14,7 +14,14 @@
 </head>
 
 <body>
-  <div class="body-wrapper">
+  <div id="top-bar">
+    <nav><a class="home-link" href="/" title="The Roc Programming Language">roc</a>
+      <div id="top-bar-links"><a href="/tutorial">tutorial</a><a
+          href="https://github.com/roc-lang/roc/tree/main/getting_started">install</a><a href="/repl">repl</a><a
+          href="/builtins/Bool">docs</a></div>
+    </nav>
+  </div>
+  <main>
     <h1>The rockin’ Roc REPL</h1>
     <code class="history">
       <div id="help-text"></div>
@@ -28,8 +35,8 @@
       <textarea rows="5" autofocus id="source-input"
         placeholder="You can enter Roc code here after the compiler is loaded!" disabled></textarea>
     </section>
-  </div>
-  <script type="module" src="/repl/repl.js"></script>
+    </div>
+    <script type="module" src="/repl/repl.js"></script>
 </body>
 
 </html>

--- a/www/public/repl/index.html
+++ b/www/public/repl/index.html
@@ -3,9 +3,9 @@
 <html>
 
 <head>
-  <title>Roc REPL</title>
+  <title>REPL</title>
+  <link rel="stylesheet" href="/site.css" />
   <link rel="stylesheet" href="/repl/repl.css" />
-  <link rel="stylesheet" href="/styles.css" />
   <link rel="icon" href="/favicon.svg">
   <!-- Safari ignores rel="icon" and only respects rel="mask-icon". It will render the SVG with
     fill="#000" unless this `color` attribute here is hardcoded (not a CSS `var()`) to override it.
@@ -15,23 +15,17 @@
 
 <body>
   <div class="body-wrapper">
-    <section class="text">
-      <h1>The rockin’ Roc REPL</h1>
-    </section>
-
-    <section class="history">
-      <div class="scroll code">
-        <div id="help-text"></div>
-        <div id="history-text">
-          <div id="loading-message">
-            Loading Roc compiler as a WebAssembly module…please wait!
-          </div>
+    <h1>The rockin’ Roc REPL</h1>
+    <code class="history">
+      <div id="help-text"></div>
+      <div id="history-text">
+        <div id="loading-message">
+          Loading Roc compiler as a WebAssembly module…please wait!
         </div>
       </div>
-    </section>
-
-    <section class="source">
-      <textarea rows="5" autofocus id="source-input" class="code"
+    </code>
+    <section id="source-input-wrapper">
+      <textarea rows="5" autofocus id="source-input"
         placeholder="You can enter Roc code here after the compiler is loaded!" disabled></textarea>
     </section>
   </div>

--- a/www/public/repl/index.html
+++ b/www/public/repl/index.html
@@ -27,11 +27,7 @@
     <h1>The rockin’ Roc REPL</h1>
     <code class="history">
       <div id="help-text"></div>
-      <div id="history-text">
-        <div id="loading-message">
-          Loading Roc compiler as a WebAssembly module…please wait!
-        </div>
-      </div>
+      <div id="history-text"><div id="loading-message">Loading Roc compiler as a WebAssembly module…please wait!</div></div>
     </code>
     <section id="source-input-wrapper">
       <textarea rows="5" autofocus id="source-input"

--- a/www/public/repl/index.html
+++ b/www/public/repl/index.html
@@ -3,6 +3,8 @@
 <html>
 
 <head>
+  <meta charset="utf-8">
+
   <title>REPL</title>
   <link rel="stylesheet" href="/site.css" />
   <link rel="stylesheet" href="/repl/repl.css" />

--- a/www/public/repl/index.html
+++ b/www/public/repl/index.html
@@ -1,39 +1,41 @@
 <!DOCTYPE html>
 
 <html>
-  <head>
-    <title>Roc REPL</title>
-    <link rel="stylesheet" href="/repl/repl.css" />
-  </head>
 
-  <body>
-    <div class="body-wrapper">
-      <section class="text">
-        <h1>The rockin' Roc REPL</h1>
-      </section>
+<head>
+  <title>Roc REPL</title>
+  <link rel="stylesheet" href="/repl/repl.css" />
+  <link rel="stylesheet" href="/styles.css" />
+  <link rel="icon" href="/favicon.svg">
+  <!-- Safari ignores rel="icon" and only respects rel="mask-icon". It will render the SVG with
+    fill="#000" unless this `color` attribute here is hardcoded (not a CSS `var()`) to override it.
+  -->
+  <link rel="mask-icon" href="/favicon.svg" color="#7d59dd">
+</head>
 
-      <section class="history">
-        <div class="scroll code">
-          <div id="help-text"></div>
-          <div id="history-text">
-            <div id="loading-message">
-              Loading Roc compiler as a WebAssembly module... please wait!
-            </div>
+<body>
+  <div class="body-wrapper">
+    <section class="text">
+      <h1>The rockin’ Roc REPL</h1>
+    </section>
+
+    <section class="history">
+      <div class="scroll code">
+        <div id="help-text"></div>
+        <div id="history-text">
+          <div id="loading-message">
+            Loading Roc compiler as a WebAssembly module…please wait!
           </div>
         </div>
-      </section>
+      </div>
+    </section>
 
-      <section class="source">
-        <textarea
-          rows="5"
-          autofocus
-          id="source-input"
-          class="code"
-          placeholder="You can enter Roc code here after the compiler is loaded!"
-          disabled
-        ></textarea>
-      </section>
-    </div>
-    <script type="module" src="/repl/repl.js"></script>
-  </body>
+    <section class="source">
+      <textarea rows="5" autofocus id="source-input" class="code"
+        placeholder="You can enter Roc code here after the compiler is loaded!" disabled></textarea>
+    </section>
+  </div>
+  <script type="module" src="/repl/repl.js"></script>
+</body>
+
 </html>

--- a/www/public/repl/repl.css
+++ b/www/public/repl/repl.css
@@ -32,8 +32,10 @@ h1 {
 #source-input-wrapper::before {
   content: "» ";
   position: absolute;
-  left: 1em;
-  top: 14px;
+  left: 15px;
+  top: 18px;
+  line-height: 16px;
+  height: 16px;
   z-index: 2;
   font-family: var(--font-mono);
   color: var(--cyan);
@@ -48,8 +50,8 @@ h1 {
   background-color: var(--code-bg);
   display: inline-block;
   height: 5em;
-  padding: calc(1em - 1px);
-  padding-left: 2.4em;
+  padding: 16px;
+  padding-left: 36px;
   border: 1px solid transparent;
   margin: 0;
   margin-bottom: 2em;

--- a/www/public/repl/repl.css
+++ b/www/public/repl/repl.css
@@ -133,7 +133,15 @@ li {
 }
 
 .color-white {
-  color: white;
+  /* Really this isn't white so much as "default text color." For the repl, this should be black
+  in a light color scheme, and only white in dark mode. The name could be better! */
+  color: black;
+}
+
+@media (prefers-color-scheme: dark) {
+  .color-white {
+    color: white;
+  }
 }
 
 .bold {

--- a/www/public/repl/repl.css
+++ b/www/public/repl/repl.css
@@ -6,7 +6,7 @@ body {
   height: 100%;
 }
 
-.body-wrapper {
+main {
   display: flex;
   flex-direction: column;
   max-width: 900px;
@@ -16,9 +16,9 @@ body {
 
 h1 {
   font-family: "Merriweather";
-  font-size: 24px;
-  line-height: 24px;
-  padding: 18px 0;
+  font-size: 48px;
+  line-height: 48px;
+  padding: 48px 0;
   margin: 0;
   color: var(--header-link-color);
 }
@@ -52,6 +52,7 @@ h1 {
   padding-left: 2.4em;
   border: 1px solid transparent;
   margin: 0;
+  margin-bottom: 2em;
   box-sizing: border-box;
 }
 

--- a/www/public/repl/repl.css
+++ b/www/public/repl/repl.css
@@ -1,103 +1,138 @@
 html {
   height: 100%;
 }
+
 body {
-  height: 92%;
-  background-color: #222;
-  color: #ccc;
-  font-family: sans-serif;
-  font-size: 12px;
+  height: 100%;
 }
+
 .body-wrapper {
   display: flex;
   flex-direction: column;
   max-width: 900px;
   height: 100%;
   margin: 0 auto;
-  padding: 0 24px;
 }
+
 h1 {
-  margin: 32px auto;
-  color: #eee;
-  text-align: center;
+  font-family: "Merriweather";
+  font-size: 24px;
+  line-height: 24px;
+  padding: 18px 0;
+  margin: 0;
+  color: var(--header-link-color);
 }
+
+#source-input-wrapper {
+  position: relative;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+#source-input-wrapper::before {
+  content: "» ";
+  position: absolute;
+  left: 1em;
+  top: 14px;
+  z-index: 2;
+  font-family: var(--font-mono);
+  color: var(--cyan);
+  /* Let clicks pass through to the textarea */
+  pointer-events: none;
+}
+
+#source-input {
+  width: 100%;
+  font-family: var(--font-mono);
+  color: var(--code-color);
+  background-color: var(--code-bg);
+  display: inline-block;
+  height: 5em;
+  padding: calc(1em - 1px);
+  padding-left: 2.4em;
+  border: 1px solid transparent;
+  margin: 0;
+  box-sizing: border-box;
+}
+
+#source-input:focus {
+  border: 1px solid var(--cyan);
+  box-sizing: border-box;
+  outline: none;
+}
+
 li {
   margin: 8px;
 }
-section.history {
-  flex: 1;
-  position: relative;
-  height: 100%;
+
+.history {
+  padding: 1em;
+  padding-bottom: 0;
 }
-.scroll {
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  overflow: auto;
-}
+
 #history-text {
   margin: 16px 0;
   padding: 8px;
+  padding-bottom: 0;
 }
+
 #loading-message {
   margin: 40% 10%;
 }
+
 .history-item {
   margin-bottom: 24px;
 }
+
 .history-item .input {
   margin: 0;
   margin-bottom: 8px;
 }
+
 .history-item .output {
   margin: 0;
 }
+
 .panic {
   color: red;
 }
+
 .input-line-prefix {
-  color: cyan;
-}
-.code {
-  font-family: "Courier New", Courier, monospace;
-  background-color: #111;
-  color: #fff;
-}
-section.source {
-  display: flex;
-  flex-direction: column;
-}
-section.source textarea {
-  padding: 8px;
-  margin-bottom: 16px;
+  color: var(--cyan);
 }
 
 .color-red {
   color: red;
 }
+
 .color-green {
-  color: green;
+  color: var(--green);
 }
+
 .color-yellow {
-  color: yellow;
+  color: var(--orange);
 }
+
 .color-blue {
-  color: blue;
+  color: var(--cyan);
 }
+
 .color-magenta {
-  color: magenta;
+  color: var(--magenta);
 }
+
 .color-cyan {
-  color: cyan;
+  color: var(--cyan);
 }
+
 .color-white {
   color: white;
 }
+
 .bold {
   font-weight: bold;
 }
+
 .underline {
   text-decoration: underline;
 }

--- a/www/public/repl/repl.css
+++ b/www/public/repl/repl.css
@@ -49,7 +49,7 @@ h1 {
   color: var(--code-color);
   background-color: var(--code-bg);
   display: inline-block;
-  height: 5em;
+  height: 76px;
   padding: 16px;
   padding-left: 36px;
   border: 1px solid transparent;

--- a/www/public/repl/repl.css
+++ b/www/public/repl/repl.css
@@ -73,6 +73,12 @@ li {
   padding-bottom: 0;
 }
 
+#help-text,
+#history-text {
+  white-space: pre-wrap;
+
+}
+
 #history-text {
   margin-top: 16px;
 }

--- a/www/public/repl/repl.css
+++ b/www/public/repl/repl.css
@@ -1,17 +1,6 @@
-html {
-  height: 100%;
-}
-
-body {
-  height: 100%;
-}
-
 main {
   display: flex;
   flex-direction: column;
-  max-width: 900px;
-  height: 100%;
-  margin: 0 auto;
 }
 
 h1 {

--- a/www/public/repl/repl.css
+++ b/www/public/repl/repl.css
@@ -72,9 +72,7 @@ li {
 }
 
 #history-text {
-  margin: 16px 0;
-  padding: 8px;
-  padding-bottom: 0;
+  margin-top: 16px;
 }
 
 #loading-message {

--- a/www/public/repl/repl.js
+++ b/www/public/repl/repl.js
@@ -62,11 +62,8 @@ roc_repl_wasm.default("/repl/roc_repl_wasm_bg.wasm").then(async (instance) => {
 // ----------------------------------------------------------------------------
 
 function onInput(event) {
-  const target = event.target;
-
   // Have the textarea grow with the input
-  target.style.height = ""; // Reset height
-  target.style.height = target.scrollHeight + 8 + "px";
+  event.target.style.height = event.target.scrollHeight + 2 + "px"; // +2 for the border
 }
 
 function onEnter(event) {

--- a/www/public/repl/repl.js
+++ b/www/public/repl/repl.js
@@ -37,6 +37,7 @@ const repl = {
 
 // Initialise
 repl.elemSourceInput.addEventListener("input", onInput);
+repl.elemSourceInput.addEventListener("keydown", onInputKeydown);
 repl.elemSourceInput.addEventListener("keyup", onInputKeyup);
 roc_repl_wasm.default("/repl/roc_repl_wasm_bg.wasm").then(async (instance) => {
   repl.elemHistory.querySelector("#loading-message").remove();
@@ -66,22 +67,32 @@ function onInput(event) {
   event.target.style.height = event.target.scrollHeight + 2 + "px"; // +2 for the border
 }
 
-function onEnter(event) {
-  const inputText = event.target.value.trim();
+function onInputKeydown(event) {
+  const ENTER = 13;
 
-  event.target.value = "";
-  event.target.style.height = "";
+  const { keyCode } = event;
 
-  repl.inputQueue.push(inputText);
-  if (repl.inputQueue.length === 1) {
-    processInputQueue();
+  if (keyCode === ENTER) {
+    if (!event.shiftKey && !event.ctrlKey && !event.altKey) {
+      // Don't advance the caret to the next line
+      event.preventDefault();
+
+      const inputText = repl.elemSourceInput.value.trim();
+
+      repl.elemSourceInput.value = "";
+      repl.elemSourceInput.style.height = "";
+
+      repl.inputQueue.push(inputText);
+      if (repl.inputQueue.length === 1) {
+        processInputQueue();
+      }
+    }
   }
 }
 
 function onInputKeyup(event) {
   const UP = 38;
   const DOWN = 40;
-  const ENTER = 13;
 
   const { keyCode } = event;
 
@@ -111,12 +122,6 @@ function onInputKeyup(event) {
       } else {
         repl.inputHistoryIndex++;
         setInput(repl.inputHistory[repl.inputHistoryIndex]);
-      }
-      break;
-
-    case ENTER:
-      if (!event.shiftKey && !event.ctrlKey && !event.altKey) {
-        onEnter({ target: repl.elemSourceInput });
       }
       break;
 

--- a/www/public/repl/repl.js
+++ b/www/public/repl/repl.js
@@ -37,7 +37,6 @@ const repl = {
 
 // Initialise
 repl.elemSourceInput.addEventListener("input", onInput);
-repl.elemSourceInput.addEventListener("change", onInputChange);
 repl.elemSourceInput.addEventListener("keyup", onInputKeyup);
 roc_repl_wasm.default("/repl/roc_repl_wasm_bg.wasm").then(async (instance) => {
   repl.elemHistory.querySelector("#loading-message").remove();
@@ -70,7 +69,7 @@ function onInput(event) {
   target.style.height = target.scrollHeight + 8 + "px";
 }
 
-function onInputChange(event) {
+function onEnter(event) {
   const inputText = event.target.value.trim();
 
   event.target.value = "";
@@ -120,7 +119,7 @@ function onInputKeyup(event) {
 
     case ENTER:
       if (!event.shiftKey && !event.ctrlKey && !event.altKey) {
-        onInputChange({ target: repl.elemSourceInput });
+        onEnter({ target: repl.elemSourceInput });
       }
       break;
 

--- a/www/public/repl/repl.js
+++ b/www/public/repl/repl.js
@@ -51,7 +51,7 @@ roc_repl_wasm.default("/repl/roc_repl_wasm_bg.wasm").then(async (instance) => {
   try {
     const helpText = await roc_repl_wasm.entrypoint_from_js(":help");
     const helpElem = document.getElementById("help-text");
-    helpElem.innerHTML = helpText.trim().replace(/\n/g, '<br>');
+    helpElem.innerHTML = helpText.trim();
   } catch (e) {
     // Print error for Roc devs. Don't use console.error, we overrode that above to display on the page!
     console.warn(e);
@@ -233,7 +233,7 @@ function createHistoryEntry(inputText) {
 
 function updateHistoryEntry(index, ok, outputText) {
   const outputElem = document.createElement("div");
-  outputElem.innerHTML = outputText.replace(/\n/g, "<br>");
+  outputElem.innerHTML = outputText;
   outputElem.classList.add("output", ok ? "output-ok" : "output-error");
 
   const historyItem = repl.elemHistory.children[index];

--- a/www/public/site.css
+++ b/www/public/site.css
@@ -43,6 +43,7 @@ html,
 body {
     margin: 0;
     padding: 0;
+    height: 100%;
 }
 
 footer {
@@ -635,7 +636,7 @@ h4 {
 /* Comments `#` and Documentation comments `##` */
 samp .comment,
 code .comment {
-  color: var(--green);
+    color: var(--green);
 }
 
 /* Number, String, Tag literals */
@@ -651,19 +652,19 @@ samp .constant,
 code .constant,
 samp .literal,
 code .literal {
-  color: var(--cyan);
+    color: var(--cyan);
 }
 
 /* Keywords and punctuation */
-samp .keyword, 
+samp .keyword,
 code .keyword,
-samp .punctuation.section, 
+samp .punctuation.section,
 code .punctuation.section,
-samp .punctuation.separator, 
+samp .punctuation.separator,
 code .punctuation.separator,
-samp .punctuation.terminator, 
+samp .punctuation.terminator,
 code .punctuation.terminator,
-samp .kw, 
+samp .kw,
 code .kw {
     color: var(--magenta);
 }
@@ -673,13 +674,13 @@ samp .op,
 code .op,
 samp .keyword.operator,
 code .keyword.operator {
-  color: var(--orange);
+    color: var(--orange);
 }
 
 /* Delimieters */
 samp .delimeter,
 code .delimeter {
-  color: var(--gray);
+    color: var(--gray);
 }
 
 /* Variables modules and field names */
@@ -691,7 +692,7 @@ samp .meta.block,
 code .meta.block,
 samp .lowerident,
 code .lowerident {
-  color: var(--blue);
+    color: var(--blue);
 }
 
 /* Types, Tags, and Modules */
@@ -701,12 +702,12 @@ samp .meta.path,
 code .meta.path,
 samp .upperident,
 code .upperident {
-  color: var(--green);
+    color: var(--green);
 }
 
 samp .dim,
 code .dim {
-  opacity: 0.55;
+    opacity: 0.55;
 }
 
 .button-container {

--- a/www/public/styles.css
+++ b/www/public/styles.css
@@ -65,14 +65,16 @@ a:hover {
 }
 
 .pkg-and-logo {
-  min-width: 0; /* necessary for text-overflow: ellipsis to work in descendants */
+  min-width: 0;
+  /* necessary for text-overflow: ellipsis to work in descendants */
   display: flex;
   align-items: center;
   height: 100%;
   background-color: var(--top-bar-bg);
 }
 
-.pkg-and-logo a, .pkg-and-logo a:visited {
+.pkg-and-logo a,
+.pkg-and-logo a:visited {
   color: var(--top-bar-fg);
 }
 
@@ -82,14 +84,17 @@ a:hover {
 }
 
 .main-container {
-  min-width: 0; /* necessary for text-overflow: ellipsis to work in descendants */
+  min-width: 0;
+  /* necessary for text-overflow: ellipsis to work in descendants */
 }
 
 .search-button {
-  flex-shrink: 0; /* always shrink the package name before these; they have a relatively constrained length */
+  flex-shrink: 0;
+  /* always shrink the package name before these; they have a relatively constrained length */
   padding: 12px 18px;
   margin-right: 42px;
-  display: none; /* only show this in the mobile view */
+  display: none;
+  /* only show this in the mobile view */
 }
 
 .version {
@@ -159,7 +164,8 @@ main {
   font-family: var(--font-sans);
   font-size: 24px;
   height: 100%;
-  min-width: 0; /* necessary for text-overflow: ellipsis to work in descendants */
+  min-width: 0;
+  /* necessary for text-overflow: ellipsis to work in descendants */
 }
 
 .top-header-triangle {
@@ -174,8 +180,8 @@ main {
 }
 
 p {
-    overflow-wrap: break-word;
-    margin: 24px 0;
+  overflow-wrap: break-word;
+  margin: 24px 0;
 }
 
 footer {
@@ -233,7 +239,8 @@ footer p {
   margin-bottom: 48px;
 }
 
-.module-name a, .module-name a:visited {
+.module-name a,
+.module-name a:visited {
   color: inherit;
 }
 
@@ -251,7 +258,8 @@ footer p {
   text-overflow: ellipsis;
 }
 
-a, a:visited {
+a,
+a:visited {
   color: var(--link-color);
 }
 
@@ -316,19 +324,20 @@ pre {
   height: 0;
 }
 
-#module-search, #module-search:focus {
+#module-search,
+#module-search:focus {
   opacity: 1;
   padding: 12px 16px;
   height: 48px;
 }
 
 /* Show the "Search" label link when the text input has a placeholder */
-#module-search:placeholder-shown + #search-link {
+#module-search:placeholder-shown+#search-link {
   display: flex;
 }
 
 /* Hide the "Search" label link when the text input has focus */
-#module-search:focus + #search-link {
+#module-search:focus+#search-link {
   display: none;
 }
 
@@ -390,7 +399,8 @@ pre {
 
 @media only screen and (max-device-width: 480px) {
   .search-button {
-    display: block; /* This is only visible in mobile. */
+    display: block;
+    /* This is only visible in mobile. */
   }
 
   .top-header {

--- a/www/wip_new_website/main.roc
+++ b/www/wip_new_website/main.roc
@@ -2,7 +2,7 @@ app "roc-website"
     packages { pf: "../../examples/static-site-gen/platform/main.roc" }
     imports [
         pf.Html.{ html, head, body, footer, div, main, text, nav, a, link, meta },
-        pf.Html.Attributes.{ content, name, id, href, rel, lang, class, title, charset },
+        pf.Html.Attributes.{ content, name, id, href, rel, lang, class, title, charset, color },
     ]
     provides [transformFileContent] to pf
 
@@ -43,6 +43,9 @@ view = \page, htmlContent ->
             meta [name "viewport", content "width=device-width"] [],
             link [rel "stylesheet", href "/wip/site.css"] [],
             link [rel "icon", href "/favicon.svg"] [],
+            # Safari ignores rel="icon" and only respects rel="mask-icon". It will render the SVG with
+            # fill="#000" unless this `color` attribute here is hardcoded (not a CSS `var()`) to override it.
+            link [rel "mask-icon", href "/favicon.svg", color "#7d59dd"] [],
         ],
         body [] [
             viewNavbar,


### PR DESCRIPTION
This styles `/repl` to look more like other parts of the site.

<img width="1344" alt="Screenshot 2023-09-18 at 11 51 08 AM" src="https://github.com/roc-lang/roc/assets/1094080/8ad98fc4-1487-421c-a285-1e934a461aad">

Also it makes some tweaks to the scrolling and resizing behavior:
* The textarea gets focus as soon as the web repl finishes loading
* If you add multiple lines, the textarea grows automatically
* Nothing has a vertical scroll bar except the page, and whenever you enter something, the page scrolls to the end. This way, you can always scroll without needing your cursor to be anywhere in particular.