### PR TITLE
Allow rust binaries to remove dead code

### DIFF
--- a/crates/compiler/build/src/link.rs
+++ b/crates/compiler/build/src/link.rs
@@ -548,7 +548,7 @@ pub fn rebuild_host(
             let rust_flags = if cfg!(windows) {
                 "-Z export-executable-symbols"
             } else {
-                "-C link-dead-code"
+                "-C link-args=-rdynamic"
             };
             cargo_cmd.env("RUSTFLAGS", rust_flags);
             cargo_cmd.args(["--bin", "host"]);


### PR DESCRIPTION
This simple solution seems to just work, I am a bit surprised, I swear that I tried it before and hit linker issues. Anyway, if we update the basic-cli platform it drops from about 100MB to about 15MB.


Note: we may need to add a special init function to stop linker based dead code elimination. That or special linker commands to keep `roc_*` functions. Currently this is working on my x86 machine without it though.

Guide here if needed on the init function:
https://stackoverflow.com/questions/43712979/how-to-export-a-symbol-from-a-rust-executable