### PR TITLE
Allow `where` to be used as an identifier (except in type vars)

### DIFF
--- a/crates/compiler/parse/src/keyword.rs
+++ b/crates/compiler/parse/src/keyword.rs
@@ -14,6 +14,4 @@ pub const CRASH: &str = "crash";
 pub const IMPLEMENTS: &str = "implements";
 pub const WHERE: &str = "where";
 
-pub const KEYWORDS: [&str; 10] = [
-    IF, THEN, ELSE, WHEN, AS, IS, DBG, EXPECT, EXPECT_FX, CRASH,
-];
+pub const KEYWORDS: [&str; 10] = [IF, THEN, ELSE, WHEN, AS, IS, DBG, EXPECT, EXPECT_FX, CRASH];

--- a/crates/compiler/parse/src/keyword.rs
+++ b/crates/compiler/parse/src/keyword.rs
@@ -14,6 +14,6 @@ pub const CRASH: &str = "crash";
 pub const IMPLEMENTS: &str = "implements";
 pub const WHERE: &str = "where";
 
-pub const KEYWORDS: [&str; 11] = [
-    IF, THEN, ELSE, WHEN, AS, IS, DBG, EXPECT, EXPECT_FX, CRASH, WHERE,
+pub const KEYWORDS: [&str; 10] = [
+    IF, THEN, ELSE, WHEN, AS, IS, DBG, EXPECT, EXPECT_FX, CRASH,
 ];

--- a/crates/compiler/parse/src/type_annotation.rs
+++ b/crates/compiler/parse/src/type_annotation.rs
@@ -729,7 +729,9 @@ fn parse_type_variable<'a>(
         min_indent,
     ) {
         Ok((_, name, state)) => {
-            if name == crate::keyword::WHERE || (name == crate::keyword::IMPLEMENTS && stop_at_surface_has) {
+            if name == crate::keyword::WHERE
+                || (name == crate::keyword::IMPLEMENTS && stop_at_surface_has)
+            {
                 Err((NoProgress, EType::TEnd(state.pos())))
             } else {
                 let answer = TypeAnnotation::BoundVariable(name);

--- a/crates/compiler/parse/src/type_annotation.rs
+++ b/crates/compiler/parse/src/type_annotation.rs
@@ -729,7 +729,7 @@ fn parse_type_variable<'a>(
         min_indent,
     ) {
         Ok((_, name, state)) => {
-            if name == crate::keyword::IMPLEMENTS && stop_at_surface_has {
+            if name == crate::keyword::WHERE || (name == crate::keyword::IMPLEMENTS && stop_at_surface_has) {
                 Err((NoProgress, EType::TEnd(state.pos())))
             } else {
                 let answer = TypeAnnotation::BoundVariable(name);

--- a/crates/compiler/test_syntax/tests/snapshots/fail/where_type_variable.expr.result-ast
+++ b/crates/compiler/test_syntax/tests/snapshots/fail/where_type_variable.expr.result-ast
@@ -1,0 +1,1 @@
+Expr(DefMissingFinalExpr2(ElmStyleFunction(@18-22, @23), @11), @0)

--- a/crates/compiler/test_syntax/tests/snapshots/fail/where_type_variable.expr.roc
+++ b/crates/compiler/test_syntax/tests/snapshots/fail/where_type_variable.expr.roc
@@ -1,0 +1,4 @@
+role : Role where
+role = Admin
+
+role

--- a/crates/compiler/test_syntax/tests/snapshots/pass/where_ident.expr.formatted.roc
+++ b/crates/compiler/test_syntax/tests/snapshots/pass/where_ident.expr.formatted.roc
@@ -1,0 +1,2 @@
+where = { where: 1 }
+where.where

--- a/crates/compiler/test_syntax/tests/snapshots/pass/where_ident.expr.formatted.roc
+++ b/crates/compiler/test_syntax/tests/snapshots/pass/where_ident.expr.formatted.roc
@@ -1,2 +1,4 @@
+where : { where : I32 }
 where = { where: 1 }
+
 where.where

--- a/crates/compiler/test_syntax/tests/snapshots/pass/where_ident.expr.result-ast
+++ b/crates/compiler/test_syntax/tests/snapshots/pass/where_ident.expr.result-ast
@@ -1,10 +1,10 @@
 Defs(
     Defs {
         tags: [
-            Index(2147483648),
+            Index(2147483649),
         ],
         regions: [
-            @0-18,
+            @0-39,
         ],
         space_before: [
             Slice(start = 0, length = 0),
@@ -15,25 +15,62 @@ Defs(
         spaces: [],
         type_defs: [],
         value_defs: [
-            Body(
+            Annotation(
                 @0-5 Identifier(
                     "where",
                 ),
-                @8-18 Record(
-                    [
-                        @9-17 RequiredValue(
+                @8-20 Record {
+                    fields: [
+                        @9-19 RequiredValue(
                             @9-14 "where",
                             [],
-                            @16-17 Num(
+                            @16-19 Apply(
+                                "",
+                                "I32",
+                                [],
+                            ),
+                        ),
+                    ],
+                    ext: None,
+                },
+            ),
+            AnnotatedBody {
+                ann_pattern: @0-5 Identifier(
+                    "where",
+                ),
+                ann_type: @8-20 Record {
+                    fields: [
+                        @9-19 RequiredValue(
+                            @9-14 "where",
+                            [],
+                            @16-19 Apply(
+                                "",
+                                "I32",
+                                [],
+                            ),
+                        ),
+                    ],
+                    ext: None,
+                },
+                comment: None,
+                body_pattern: @21-26 Identifier(
+                    "where",
+                ),
+                body_expr: @29-39 Record(
+                    [
+                        @30-38 RequiredValue(
+                            @30-35 "where",
+                            [],
+                            @37-38 Num(
                                 "1",
                             ),
                         ),
                     ],
                 ),
-            ),
+            },
         ],
     },
-    @19-30 SpaceBefore(
+    @41-52 SpaceBefore(
         RecordAccess(
             Var {
                 module_name: "",
@@ -42,6 +79,7 @@ Defs(
             "where",
         ),
         [
+            Newline,
             Newline,
         ],
     ),

--- a/crates/compiler/test_syntax/tests/snapshots/pass/where_ident.expr.result-ast
+++ b/crates/compiler/test_syntax/tests/snapshots/pass/where_ident.expr.result-ast
@@ -1,0 +1,48 @@
+Defs(
+    Defs {
+        tags: [
+            Index(2147483648),
+        ],
+        regions: [
+            @0-18,
+        ],
+        space_before: [
+            Slice(start = 0, length = 0),
+        ],
+        space_after: [
+            Slice(start = 0, length = 0),
+        ],
+        spaces: [],
+        type_defs: [],
+        value_defs: [
+            Body(
+                @0-5 Identifier(
+                    "where",
+                ),
+                @8-18 Record(
+                    [
+                        @9-17 RequiredValue(
+                            @9-14 "where",
+                            [],
+                            @16-17 Num(
+                                "1",
+                            ),
+                        ),
+                    ],
+                ),
+            ),
+        ],
+    },
+    @19-30 SpaceBefore(
+        RecordAccess(
+            Var {
+                module_name: "",
+                ident: "where",
+            },
+            "where",
+        ),
+        [
+            Newline,
+        ],
+    ),
+)

--- a/crates/compiler/test_syntax/tests/snapshots/pass/where_ident.expr.roc
+++ b/crates/compiler/test_syntax/tests/snapshots/pass/where_ident.expr.roc
@@ -1,2 +1,4 @@
+where : {where: I32}
 where = {where: 1}
+
 where.where

--- a/crates/compiler/test_syntax/tests/snapshots/pass/where_ident.expr.roc
+++ b/crates/compiler/test_syntax/tests/snapshots/pass/where_ident.expr.roc
@@ -1,0 +1,2 @@
+where = {where: 1}
+where.where

--- a/crates/compiler/test_syntax/tests/test_snapshots.rs
+++ b/crates/compiler/test_syntax/tests/test_snapshots.rs
@@ -247,6 +247,7 @@ mod test_snapshots {
         fail/when_over_indented_int.expr,
         fail/when_over_indented_underscore.expr,
         fail/wild_case_arrow.expr,
+        fail/where_type_variable.expr,
         malformed/bad_opaque_ref.expr,
         malformed/malformed_ident_due_to_underscore.expr,
         malformed/malformed_pattern_field_access.expr, // See https://github.com/roc-lang/roc/issues/399
@@ -490,6 +491,7 @@ mod test_snapshots {
         pass/where_clause_on_newline.expr,
         pass/zero_float.expr,
         pass/zero_int.expr,
+        pass/where_ident.expr,
         // END SNAPSHOTS (for automatic test detection via `env ROC_SNAPSHOT_TEST_OVERWRITE=1 cargo test`)
     }
 


### PR DESCRIPTION
Allows `where` to be used as an identifier in defs and record fields:

```elm
where : Str
where = "Home"

meeting : { where: Str }
meeting = { where: "Home" }
```

It's still not a valid type variable because that'd conflict with `where ... implements ...`.

Closes #5823 