### PR TITLE
Fix a confusing initial value in the web REPL JS

### DIFF
--- a/www/public/repl/repl.js
+++ b/www/public/repl/repl.js
@@ -30,8 +30,9 @@ const repl = {
   compiler: null,
   app: null,
 
-  // Temporary storage for values passing back and forth between JS and Wasm
-  result_addr: { addr: 0, buffer: new ArrayBuffer() },
+  // Temporary storage for the address of the result of running the user's code.
+  // Used while control flow returns to Rust to allocate space to copy the app's memory buffer.
+  result_addr: 0,
 };
 
 // Initialise


### PR DESCRIPTION
In #5863 I make `result_addr` a number, whereas it used to be an object.
I forgot to change the initial value though! It's still an object!
The initial value is always overwritten, so it has no effect on functionality. But the whole point of that PR was code clarity, so let's fix it!

The default git diff isn't really enough to see that this is correct. You might want to "view file" and see the other 2 usages of the field, which treat it as a number.

This fix is not urgent because everything works. But people might look at the source code after I do a talk on it tomorrow and get confused.
