### PR TITLE
force reqwest version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -527,6 +527,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13418e745008f7349ec7e449155f419a61b92b58a99cc3616942b926825ec76b"
 
 [[package]]
+name = "core-foundation"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1185,10 +1195,11 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.23.2"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1788965e61b367cd03a62950836d5cd41560c3577d90e40e0819373194d1661c"
+checksum = "8d78e1e73ec14cf7375674f74d7dde185c8206fd9dea6fb6295e8a98098aaa97"
 dependencies = [
+ "futures-util",
  "http",
  "hyper",
  "rustls",
@@ -2129,9 +2140,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.17"
+version = "0.11.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13293b639a097af28fc8a90f22add145a9c954e49d77da06263d58cf44d5fb91"
+checksum = "046cd98826c46c2ac8ddecae268eb5c2e58628688a5fc7a2643704a73faba95b"
 dependencies = [
  "base64 0.21.0",
  "bytes",
@@ -2155,6 +2166,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
+ "system-configuration",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -3157,14 +3169,14 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.20.8"
+version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fff78fc74d175294f4e83b28343315ffcfb114b156f0185e9741cb5570f50e2f"
+checksum = "cd8d6c9f025a446bc4d18ad9632e69aec8f287aa84499ee335599fabd20c3fd8"
 dependencies = [
  "log",
  "ring",
+ "rustls-webpki",
  "sct",
- "webpki",
 ]
 
 [[package]]
@@ -3174,6 +3186,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
 dependencies = [
  "base64 0.21.0",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c7d5dece342910d9ba34d259310cae3e0154b873b35408b787b59bce53d34fe"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -3599,6 +3621,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3909,13 +3952,12 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.23.4"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
  "rustls",
  "tokio",
- "webpki",
 ]
 
 [[package]]
@@ -4343,23 +4385,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0e74f82d49d545ad128049b7e88f6576df2da6b02e9ce565c6f533be576957e"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
 name = "webpki-roots"
-version = "0.22.6"
+version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
-dependencies = [
- "webpki",
-]
+checksum = "14247bb57be4f377dfb94c72830b8ce8fc6beac03cf4bf7b9732eadd414123fc"
 
 [[package]]
 name = "winapi"
@@ -4550,11 +4579,12 @@ checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winreg"
-version = "0.10.1"
+version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
- "winapi",
+ "cfg-if",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,7 +137,7 @@ quote = "1.0.23"
 rand = "0.8.5"
 regex = "1.7.1"
 remove_dir_all = "0.8.1"
-reqwest = { version = "0.11.14", default-features = false, features = ["blocking", "rustls-tls"] }                       # default-features=false removes libopenssl as a dependency on Linux, which might not be available!
+reqwest = { version = "0.11.20", default-features = false, features = ["blocking", "rustls-tls"] }                       # default-features=false removes libopenssl as a dependency on Linux, which might not be available!
 rlimit = "0.9.1"
 rustyline = { git = "https://github.com/roc-lang/rustyline", rev = "e74333c" }
 rustyline-derive = { git = "https://github.com/roc-lang/rustyline", rev = "e74333c" }

--- a/examples/cli/cli-platform/Cargo.toml
+++ b/examples/cli/cli-platform/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/main.rs"
 [dependencies]
 backtrace = "0.3"
 libc = "0.2"
-reqwest = { version = "0.11.11", default-features = false, features = ["blocking", "rustls-tls"] }
+reqwest = { version = "=0.11.20", default-features = false, features = ["blocking", "rustls-tls"] }
 roc_std = { path = "../../../crates/roc_std" }
 
 [workspace]


### PR DESCRIPTION
This fixes the the breaking tests before building nightlies on macos, due to a bug in the latest releases of reqwest.
```
 The roc command:

  "/Users/m1ci/actions-runner2/_work/roc/roc/target/release/roc --max-threads=1 /Users/m1ci/actions-runner2/_work/roc/roc/examples/cli/ingested-file.roc --"

had unexpected stderr:

  🔨 Rebuilding platform...
Undefined symbols for architecture arm64:
  "_SCDynamicStoreCopyProxies", referenced from:
      __ZN20system_configuration13dynamic_store14SCDynamicStore11get_proxies17h9364091d51e512b0E in macos-arm64.o
  "_SCDynamicStoreCreateWithOptions", referenced from:
      __ZN20system_configuration13dynamic_store14SCDynamicStore6create17ha461b4b2450916f0E in macos-arm64.o
  "_kSCDynamicStoreUseSessionKeys", referenced from:
      __ZN20system_configuration13dynamic_store30SCDynamicStoreBuilder$LT$T$GT$20create_store_options17h502ae73ba7f0a696E in macos-arm64.o
  "_kSCPropNetProxiesHTTPEnable", referenced from:
      __ZN7reqwest5proxy22get_from_platform_impl17h37558a23f1abce25E in macos-arm64.o
  "_kSCPropNetProxiesHTTPPort", referenced from:
      __ZN7reqwest5proxy22get_from_platform_impl17h37558a23f1abce25E in macos-arm64.o
  "_kSCPropNetProxiesHTTPProxy", referenced from:
      __ZN7reqwest5proxy22get_from_platform_impl17h37558a23f1abce25E in macos-arm64.o
  "_kSCPropNetProxiesHTTPSEnable", referenced from:
      __ZN7reqwest5proxy22get_from_platform_impl17h37558a23f1abce25E in macos-arm64.o
  "_kSCPropNetProxiesHTTPSPort", referenced from:
      __ZN7reqwest5proxy22get_from_platform_impl17h37558a23f1abce25E in macos-arm64.o
  "_kSCPropNetProxiesHTTPSProxy", referenced from:
      __ZN7reqwest5proxy22get_from_platform_impl17h37558a23f1abce25E in macos-arm64.o
ld: symbol(s) not found for architecture arm64
/Users/m1ci/actions-runner2/_work/roc/roc/examples/cli/ingested-file: No such file or directory
thread 'main' panicked at 'not yet implemented: gracefully handle `ld` (or `zig` in the case of wasm with --optimize) returning exit code Some(1)', crates/compiler/build/src/program.rs:1049:17
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
```
The roc command:

  "/Users/username1/actions-runner/_work/roc/roc/target/release/roc --max-threads=1 /Users/username1/actions-runner/_work/roc/roc/examples/helloWorldNoURL.roc --"

had unexpected stderr:

  🔨 Rebuilding platform...
Undefined symbols for architecture x86_64:
  "_SCDynamicStoreCopyProxies", referenced from:
      __ZN20system_configuration13dynamic_store14SCDynamicStore11get_proxies17haf6647afa069c62cE in macos-x64.o
  "_SCDynamicStoreCreateWithOptions", referenced from:
      __ZN20system_configuration13dynamic_store14SCDynamicStore6create17h3410712259de6324E in macos-x64.o
  "_kSCDynamicStoreUseSessionKeys", referenced from:
      __ZN20system_configuration13dynamic_store30SCDynamicStoreBuilder$LT$T$GT$20create_store_options17hb356ed04d634f084E in macos-x64.o
  "_kSCPropNetProxiesHTTPEnable", referenced from:
      __ZN7reqwest5proxy22get_from_platform_impl17hc14c4d9c33c0f4dcE in macos-x64.o
  "_kSCPropNetProxiesHTTPPort", referenced from:
      __ZN7reqwest5proxy22get_from_platform_impl17hc14c4d9c33c0f4dcE in macos-x64.o
  "_kSCPropNetProxiesHTTPProxy", referenced from:
      __ZN7reqwest5proxy22get_from_platform_impl17hc14c4d9c33c0f4dcE in macos-x64.o
  "_kSCPropNetProxiesHTTPSEnable", referenced from:
      __ZN7reqwest5proxy22get_from_platform_impl17hc14c4d9c33c0f4dcE in macos-x64.o
  "_kSCPropNetProxiesHTTPSPort", referenced from:
      __ZN7reqwest5proxy22get_from_platform_impl17hc14c4d9c33c0f4dcE in macos-x64.o
  "_kSCPropNetProxiesHTTPSProxy", referenced from:
      __ZN7reqwest5proxy22get_from_platform_impl17hc14c4d9c33c0f4dcE in macos-x64.o
ld: symbol(s) not found for architecture x86_64
thread 'main' panicked at 'not yet implemented: gracefully handle `ld` (or `zig` in the case of wasm with --optimize) returning exit code Some(1)', crates/compiler/build/src/program.rs:1049:17
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```