### PR TITLE
AArch64: Use scratch register instead of XR while loading args

### DIFF
--- a/crates/compiler/gen_dev/src/generic64/aarch64.rs
+++ b/crates/compiler/gen_dev/src/generic64/aarch64.rs
@@ -766,7 +766,8 @@ impl AArch64CallLoadArgs {
                             in_layout,
                         );
 
-                        let tmp_reg = AArch64GeneralReg::XR;
+                        let tmp_sym = Symbol::DEV_TMP;
+                        let tmp_reg =  storage_manager.claim_general_reg(buf, &tmp_sym);
 
                         super::x86_64::copy_to_base_offset::<_, _, AArch64Assembler>(
                             buf,
@@ -776,6 +777,8 @@ impl AArch64CallLoadArgs {
                             tmp_reg,
                             0,
                         );
+
+                        storage_manager.free_symbol(&tmp_sym);
 
                         self.general_i += 1;
                     }

--- a/crates/compiler/gen_dev/src/generic64/aarch64.rs
+++ b/crates/compiler/gen_dev/src/generic64/aarch64.rs
@@ -766,8 +766,7 @@ impl AArch64CallLoadArgs {
                             in_layout,
                         );
 
-                        let tmp_sym = Symbol::DEV_TMP;
-                        let tmp_reg =  storage_manager.claim_general_reg(buf, &tmp_sym);
+                        let tmp_reg = AArch64GeneralReg::X15;
 
                         super::x86_64::copy_to_base_offset::<_, _, AArch64Assembler>(
                             buf,
@@ -777,8 +776,6 @@ impl AArch64CallLoadArgs {
                             tmp_reg,
                             0,
                         );
-
-                        storage_manager.free_symbol(&tmp_sym);
 
                         self.general_i += 1;
                     }


### PR DESCRIPTION
When a function returns via arg pointer, the caller sets XR (x8) to the address where the return value goes. We were sometimes using XR as a temporary register while loading args, which lead to a segfault when returning.

It will now use `X15` instead which is reserved for scratch in our assembly.