### PR TITLE
AArch64: Fix passing function pointers

### DIFF
--- a/.github/workflows/nix_macos_apple_silicon.yml
+++ b/.github/workflows/nix_macos_apple_silicon.yml
@@ -40,7 +40,7 @@ jobs:
         run: cd examples/platform-switching/rust-platform && nix develop -c cargo test --release --locked
 
       - name: test aarch64 dev backend
-        run: nix develop -c cargo nextest-gen-dev --locked --release --no-fail-fast -E 'test(gen_num) + test(gen_records) + test(gen_tuples) + test(gen_result)'
+        run: nix develop -c cargo nextest-gen-dev --locked --release --no-fail-fast -E 'test(gen_num) + test(gen_records) + test(gen_tuples) + test(gen_result) + test(gen_tags) + test(gen_compare)'
 
       # we run the llvm wasm tests only on this machine because it is fast and wasm should be cross-target
       - name: execute llvm wasm tests with --release

--- a/crates/compiler/gen_dev/src/object_builder.rs
+++ b/crates/compiler/gen_dev/src/object_builder.rs
@@ -1021,7 +1021,11 @@ fn build_proc<'a, B: Backend<'a>>(
     }
 }
 
-fn add_undefined_rc_proc(output: &mut Object<'_>, name: &String, rc_proc_names: &Vec<'_, (symbol::Symbol, String)>) {
+fn add_undefined_rc_proc(
+    output: &mut Object<'_>,
+    name: &String,
+    rc_proc_names: &Vec<'_, (symbol::Symbol, String)>,
+) {
     // If the symbol is an undefined reference counting procedure, we need to add it here.
     if output.symbol_id(name.as_bytes()).is_none() {
         for (sym, rc_name) in rc_proc_names.iter() {


### PR DESCRIPTION
In the ARM dev backend, we use `LinkedData` for function pointers, but `object_builder` only added undefined RC procs for `LinkedFunction` relocs, leading to a crash later when looking up its symbol.

This fixes 52 tests 🎉 