### PR TITLE
Improve what happens when mono panics

### DIFF
--- a/crates/compiler/build/src/program.rs
+++ b/crates/compiler/build/src/program.rs
@@ -41,7 +41,6 @@ pub struct CodeGenTiming {
 
 pub fn report_problems_monomorphized(loaded: &mut MonomorphizedModule) -> Problems {
     report_problems(
-        loaded.total_problems(),
         &loaded.sources,
         &loaded.interns,
         &mut loaded.can_problems,
@@ -51,7 +50,6 @@ pub fn report_problems_monomorphized(loaded: &mut MonomorphizedModule) -> Proble
 
 pub fn report_problems_typechecked(loaded: &mut LoadedModule) -> Problems {
     report_problems(
-        loaded.total_problems(),
         &loaded.sources,
         &loaded.interns,
         &mut loaded.can_problems,

--- a/crates/compiler/load/build.rs
+++ b/crates/compiler/load/build.rs
@@ -105,7 +105,6 @@ fn write_types_for_module_real(module_id: ModuleId, filename: &str, output_path:
     };
 
     let problems = report_problems(
-        module.total_problems(),
         &module.sources,
         &module.interns,
         &mut module.can_problems,

--- a/crates/compiler/load_internal/src/file.rs
+++ b/crates/compiler/load_internal/src/file.rs
@@ -1882,13 +1882,15 @@ fn load_multi_threaded<'a>(
             // that there was a compiler crash.
             //
             // Unfortunately, this often has no information to report if there's a panic in mono.
-            report_problems(
-                &sources_recorded,
-                &mut interns_recorded,
-                &mut can_problems_recorded,
-                &mut type_problems_recorded,
-            )
-            .print_to_stdout(Duration::default()); // TODO determine total elapsed time and use it here
+            // Consequently, the following ends up being more misleading than helpful.
+            //
+            // roc_reporting::cli::report_problems(
+            //     &sources_recorded,
+            //     &mut interns_recorded,
+            //     &mut can_problems_recorded,
+            //     &mut type_problems_recorded,
+            // )
+            // .print_to_stdout(Duration::default()); // TODO determine total elapsed time and use it here
 
             Err(LoadingProblem::FormattedReport(
                 "\n\nThere was an unrecoverable error in the Roc compiler. Try using the `roc check` command; that may give a more helpful error report.\n\n".to_string(),

--- a/crates/compiler/load_internal/src/file.rs
+++ b/crates/compiler/load_internal/src/file.rs
@@ -1949,7 +1949,7 @@ fn worker_task_step<'a>(
                         match result {
                             Ok(()) => {}
                             Err(LoadingProblem::ChannelProblem(problem)) => {
-                                panic!("Channel problem: {:?}", problem);
+                                panic!("Channel problem: {problem:?}");
                             }
                             Err(LoadingProblem::ParsingFailed(problem)) => {
                                 msg_tx.send(Msg::FailedToParse(problem)).unwrap();
@@ -2048,7 +2048,7 @@ fn worker_task<'a>(
                     match result {
                         Ok(()) => {}
                         Err(LoadingProblem::ChannelProblem(problem)) => {
-                            panic!("Channel problem: {:?}", problem);
+                            panic!("Channel problem: {problem:?}");
                         }
                         Err(LoadingProblem::ParsingFailed(problem)) => {
                             msg_tx.send(Msg::FailedToParse(problem)).unwrap();

--- a/crates/compiler/load_internal/src/file.rs
+++ b/crates/compiler/load_internal/src/file.rs
@@ -1899,7 +1899,11 @@ fn load_multi_threaded<'a>(
             // .print_to_stdout(Duration::default()); // TODO determine total elapsed time and use it here
 
             Err(LoadingProblem::FormattedReport(
-                "\n\nThere was an unrecoverable error in the Roc compiler. Try using the `roc check` command; that may give a more helpful error report.\n\n".to_string(),
+                concat!(
+                    "\n\nThere was an unrecoverable error in the Roc compiler. The `roc check` ",
+                    "command can sometimes give a more helpful error report than other commands.\n\n"
+                )
+                .to_string(),
             ))
         })
     }

--- a/crates/compiler/load_internal/src/file.rs
+++ b/crates/compiler/load_internal/src/file.rs
@@ -1042,7 +1042,7 @@ pub fn load_and_typecheck_str<'a>(
         roc_cache_dir,
         load_config,
     )? {
-        Monomorphized(_) => unreachable!(""),
+        Monomorphized(_) => unreachable!(),
         TypeChecked(module) => Ok(module),
     }
 }
@@ -1719,8 +1719,8 @@ fn load_multi_threaded<'a>(
     // Get a reference to the completed stealers, so we can send that
     // reference to each worker. (Slices are Sync, but bumpalo Vecs are not.)
     let stealers = stealers.into_bump_slice();
-
     let it = worker_arenas.iter_mut();
+
     {
         thread::scope(|thread_scope| {
             let mut worker_listeners =

--- a/crates/compiler/load_internal/src/module.rs
+++ b/crates/compiler/load_internal/src/module.rs
@@ -223,22 +223,6 @@ pub struct ExposedToHost {
     pub getters: Vec<Symbol>,
 }
 
-impl<'a> MonomorphizedModule<'a> {
-    pub fn total_problems(&self) -> usize {
-        let mut total = 0;
-
-        for problems in self.can_problems.values() {
-            total += problems.len();
-        }
-
-        for problems in self.type_problems.values() {
-            total += problems.len();
-        }
-
-        total
-    }
-}
-
 #[derive(Debug)]
 pub struct ModuleTiming {
     pub read_roc_file: Duration,

--- a/crates/reporting/src/cli.rs
+++ b/crates/reporting/src/cli.rs
@@ -46,13 +46,12 @@ impl Problems {
                 1 => "warning",
                 _ => "warnings",
             },
-            total_time.as_millis(),
+            total_time.as_millis()
         );
     }
 }
 
 pub fn report_problems(
-    total_problems: usize,
     sources: &MutMap<ModuleId, (PathBuf, Box<str>)>,
     interns: &Interns,
     can_problems: &mut MutMap<ModuleId, Vec<roc_problem::can::Problem>>,
@@ -60,7 +59,17 @@ pub fn report_problems(
 ) -> Problems {
     use crate::report::{can_problem, type_problem, Report, RocDocAllocator, DEFAULT_PALETTE};
     use roc_problem::Severity::*;
+
     let palette = DEFAULT_PALETTE;
+    let mut total_problems = 0;
+
+    for problems in can_problems.values() {
+        total_problems += problems.len();
+    }
+
+    for problems in type_problems.values() {
+        total_problems += problems.len();
+    }
 
     // This will often over-allocate total memory, but it means we definitely
     // never need to re-allocate either the warnings or the errors vec!

--- a/crates/reporting/src/cli.rs
+++ b/crates/reporting/src/cli.rs
@@ -135,6 +135,9 @@ pub fn report_problems(
         }
     }
 
+    debug_assert!(can_problems.is_empty() && type_problems.is_empty(), "After reporting problems, there were {:?} can_problems and {:?} type_problems that could not be reported because they did not have corresponding entries in `sources`.", can_problems.len(), type_problems.len());
+    debug_assert_eq!(errors.len() + warnings.len(), total_problems);
+
     let problems_reported;
 
     // Only print warnings if there are no errors


### PR DESCRIPTION
Now instead of hanging the compiler, it exits with an error and prints a suggestion to try `roc check`.

I tried to get it to print the errors that had accumulated so far, but it consistently reported that there were 0 errors to report. There might be some way to get it to do that, so I didn't delete the (nontrivial, but zero runtime cost if there's no error) infrastructure work that it took to set that up, but I'm gonna check this in as-is because it already improves things.