### PR TITLE
Support `roc format` to stdout/from stdin

### DIFF
--- a/crates/cli/src/format.rs
+++ b/crates/cli/src/format.rs
@@ -1,7 +1,7 @@
 use std::ffi::OsStr;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 
-use crate::FormatMode;
 use bumpalo::Bump;
 use roc_error_macros::{internal_error, user_error};
 use roc_fmt::def::fmt_defs;
@@ -13,6 +13,13 @@ use roc_parse::{
     parser::{Parser, SyntaxError},
     state::State,
 };
+
+#[derive(Copy, Clone, Debug)]
+pub enum FormatMode {
+    WriteToFile,
+    WriteToStdout,
+    CheckOnly,
+}
 
 fn flatten_directories(files: std::vec::Vec<PathBuf>) -> std::vec::Vec<PathBuf> {
     let mut to_flatten = files;
@@ -58,99 +65,163 @@ fn is_roc_file(path: &Path) -> bool {
     matches!(path.extension().and_then(OsStr::to_str), Some("roc"))
 }
 
-pub fn format(files: std::vec::Vec<PathBuf>, mode: FormatMode) -> Result<(), String> {
-    let files = flatten_directories(files);
+pub fn format_files(files: std::vec::Vec<PathBuf>, mode: FormatMode) -> Result<(), String> {
+    let arena = Bump::new();
 
-    for file in files {
-        let arena = Bump::new();
-
+    for file in flatten_directories(files) {
         let src = std::fs::read_to_string(&file).unwrap();
 
-        let ast = arena.alloc(parse_all(&arena, &src).unwrap_or_else(|e| {
-            user_error!("Unexpected parse failure when parsing this formatting:\n\n{:?}\n\nParse error was:\n\n{:?}\n\n", src, e)
-        }));
-        let mut buf = Buf::new_in(&arena);
-        fmt_all(&mut buf, ast);
-
-        let reparsed_ast = arena.alloc(parse_all(&arena, buf.as_str()).unwrap_or_else(|e| {
-            let mut fail_file = file.clone();
-            fail_file.set_extension("roc-format-failed");
-            std::fs::write(&fail_file, buf.as_str()).unwrap();
-            internal_error!(
-                "Formatting bug; formatted code isn't valid\n\n\
-                I wrote the incorrect result to this file for debugging purposes:\n{}\n\n\
-                Parse error was: {:?}\n\n",
-                fail_file.display(),
-                e
-            );
-        }));
-
-        let ast_normalized = ast.remove_spaces(&arena);
-        let reparsed_ast_normalized = reparsed_ast.remove_spaces(&arena);
-
-        // HACK!
-        // We compare the debug format strings of the ASTs, because I'm finding in practice that _somewhere_ deep inside the ast,
-        // the PartialEq implementation is returning `false` even when the Debug-formatted impl is exactly the same.
-        // I don't have the patience to debug this right now, so let's leave it for another day...
-        // TODO: fix PartialEq impl on ast types
-        if format!("{ast_normalized:?}") != format!("{reparsed_ast_normalized:?}") {
-            let mut fail_file = file.clone();
-            fail_file.set_extension("roc-format-failed");
-            std::fs::write(&fail_file, buf.as_str()).unwrap();
-
-            let mut before_file = file.clone();
-            before_file.set_extension("roc-format-failed-ast-before");
-            std::fs::write(&before_file, format!("{ast_normalized:#?}\n")).unwrap();
-
-            let mut after_file = file.clone();
-            after_file.set_extension("roc-format-failed-ast-after");
-            std::fs::write(&after_file, format!("{reparsed_ast_normalized:#?}\n")).unwrap();
-
-            internal_error!(
-                "Formatting bug; formatting didn't reparse as the same tree\n\n\
-                I wrote the incorrect result to this file for debugging purposes:\n{}\n\n\
-                I wrote the tree before and after formatting to these files for debugging purposes:\n{}\n{}\n\n",
-                fail_file.display(),
-                before_file.display(),
-                after_file.display());
-        }
-
-        // Now verify that the resultant formatting is _stable_ - i.e. that it doesn't change again if re-formatted
-        let mut reformatted_buf = Buf::new_in(&arena);
-        fmt_all(&mut reformatted_buf, reparsed_ast);
-        if buf.as_str() != reformatted_buf.as_str() {
-            let mut unstable_1_file = file.clone();
-            unstable_1_file.set_extension("roc-format-unstable-1");
-            std::fs::write(&unstable_1_file, buf.as_str()).unwrap();
-
-            let mut unstable_2_file = file.clone();
-            unstable_2_file.set_extension("roc-format-unstable-2");
-            std::fs::write(&unstable_2_file, reformatted_buf.as_str()).unwrap();
-
-            internal_error!(
-                "Formatting bug; formatting is not stable. Reformatting the formatted file changed it again.\n\n\
-                I wrote the result of formatting to this file for debugging purposes:\n{}\n\n\
-                I wrote the result of double-formatting here:\n{}\n\n",
-                unstable_1_file.display(),
-                unstable_2_file.display());
-        }
-
-        match mode {
-            FormatMode::CheckOnly => {
-                // If we notice that this file needs to be formatted, return early
-                if buf.as_str() != src {
-                    return Err("One or more files need to be reformatted.".to_string());
+        match format_src(&arena, &src) {
+            Ok(buf) => {
+                match mode {
+                    FormatMode::CheckOnly => {
+                        // If we notice that this file needs to be formatted, return early
+                        if buf.as_str() != src {
+                            return Err("One or more files need to be reformatted.".to_string());
+                        }
+                    }
+                    FormatMode::WriteToFile => {
+                        // If all the checks above passed, actually write out the new file.
+                        std::fs::write(&file, buf.as_str()).unwrap();
+                    }
+                    FormatMode::WriteToStdout => {
+                        std::io::stdout().lock().write_all(buf.as_bytes()).unwrap()
+                    }
                 }
             }
+            Err(err) => match err {
+                FormatProblem::ParsingFailed {
+                    formatted_src,
+                    parse_err,
+                } => {
+                    let fail_file = file.with_extension("roc-format-failed");
 
-            FormatMode::Format => {
-                // If all the checks above passed, actually write out the new file.
-                std::fs::write(&file, buf.as_str()).unwrap();
-            }
+                    std::fs::write(&fail_file, formatted_src.as_str()).unwrap();
+
+                    internal_error!(
+                        "Formatting bug; formatted code isn't valid\n\n\
+                        I wrote the incorrect result to this file for debugging purposes:\n{}\n\n\
+                        Parse error was: {:?}\n\n",
+                        fail_file.display(),
+                        parse_err
+                    );
+                }
+                FormatProblem::ReformattingChangedAst {
+                    formatted_src,
+                    ast_before,
+                    ast_after,
+                } => {
+                    let mut fail_file = file.clone();
+                    fail_file.set_extension("roc-format-failed");
+                    std::fs::write(&fail_file, formatted_src.as_str()).unwrap();
+
+                    let mut before_file = file.clone();
+                    before_file.set_extension("roc-format-failed-ast-before");
+                    std::fs::write(&before_file, ast_before).unwrap();
+
+                    let mut after_file = file.clone();
+                    after_file.set_extension("roc-format-failed-ast-after");
+                    std::fs::write(&after_file, ast_after).unwrap();
+
+                    internal_error!(
+                        "Formatting bug; formatting didn't reparse as the same tree\n\n\
+                        I wrote the incorrect result to this file for debugging purposes:\n{}\n\n\
+                        I wrote the tree before and after formatting to these files for debugging purposes:\n{}\n{}\n\n",
+                        fail_file.display(),
+                        before_file.display(),
+                        after_file.display()
+                    );
+                }
+                FormatProblem::ReformattingUnstable {
+                    formatted_src,
+                    reformatted_src,
+                } => {
+                    let mut unstable_1_file = file.clone();
+                    unstable_1_file.set_extension("roc-format-unstable-1");
+                    std::fs::write(&unstable_1_file, formatted_src).unwrap();
+
+                    let mut unstable_2_file = file.clone();
+                    unstable_2_file.set_extension("roc-format-unstable-2");
+                    std::fs::write(&unstable_2_file, reformatted_src).unwrap();
+
+                    internal_error!(
+                        "Formatting bug; formatting is not stable. Reformatting the formatted file changed it again.\n\n\
+                        I wrote the result of formatting to this file for debugging purposes:\n{}\n\n\
+                        I wrote the result of double-formatting here:\n{}\n\n",
+                        unstable_1_file.display(),
+                        unstable_2_file.display()
+                    );
+                }
+            },
         }
     }
 
     Ok(())
+}
+
+#[derive(Debug)]
+pub enum FormatProblem {
+    ParsingFailed {
+        formatted_src: String,
+        parse_err: String,
+    },
+    ReformattingChangedAst {
+        formatted_src: String,
+        ast_before: String,
+        ast_after: String,
+    },
+    ReformattingUnstable {
+        formatted_src: String,
+        reformatted_src: String,
+    },
+}
+
+pub fn format_src(arena: &Bump, src: &str) -> Result<String, FormatProblem> {
+    let ast = arena.alloc(parse_all(&arena, &src).unwrap_or_else(|e| {
+        user_error!("Unexpected parse failure when parsing this formatting:\n\n{:?}\n\nParse error was:\n\n{:?}\n\n", src, e)
+    }));
+    let mut buf = Buf::new_in(&arena);
+    fmt_all(&mut buf, ast);
+
+    let reparsed_ast = match arena.alloc(parse_all(&arena, buf.as_str())) {
+        Ok(ast) => ast,
+        Err(e) => {
+            return Err(FormatProblem::ParsingFailed {
+                formatted_src: buf.as_str().to_string(),
+                parse_err: format!("{:?}", e),
+            });
+        }
+    };
+
+    let ast_normalized = ast.remove_spaces(&arena);
+    let reparsed_ast_normalized = reparsed_ast.remove_spaces(&arena);
+
+    // HACK!
+    // We compare the debug format strings of the ASTs, because I'm finding in practice that _somewhere_ deep inside the ast,
+    // the PartialEq implementation is returning `false` even when the Debug-formatted impl is exactly the same.
+    // I don't have the patience to debug this right now, so let's leave it for another day...
+    // TODO: fix PartialEq impl on ast types
+    if format!("{ast_normalized:?}") != format!("{reparsed_ast_normalized:?}") {
+        return Err(FormatProblem::ReformattingChangedAst {
+            formatted_src: buf.as_str().to_string(),
+            ast_before: format!("{ast_normalized:#?}\n"),
+            ast_after: format!("{reparsed_ast_normalized:#?}\n"),
+        });
+    }
+
+    // Now verify that the resultant formatting is _stable_ - i.e. that it doesn't change again if re-formatted
+    let mut reformatted_buf = Buf::new_in(&arena);
+
+    fmt_all(&mut reformatted_buf, reparsed_ast);
+
+    if buf.as_str() != reformatted_buf.as_str() {
+        return Err(FormatProblem::ReformattingUnstable {
+            formatted_src: buf.as_str().to_string(),
+            reformatted_src: reformatted_buf.as_str().to_string(),
+        });
+    }
+
+    Ok(buf.as_str().to_string())
 }
 
 fn parse_all<'a>(arena: &'a Bump, src: &'a str) -> Result<Ast<'a>, SyntaxError<'a>> {

--- a/crates/cli/src/format.rs
+++ b/crates/cli/src/format.rs
@@ -177,13 +177,13 @@ pub enum FormatProblem {
 }
 
 pub fn format_src(arena: &Bump, src: &str) -> Result<String, FormatProblem> {
-    let ast = arena.alloc(parse_all(&arena, &src).unwrap_or_else(|e| {
+    let ast = arena.alloc(parse_all(arena, src).unwrap_or_else(|e| {
         user_error!("Unexpected parse failure when parsing this formatting:\n\n{:?}\n\nParse error was:\n\n{:?}\n\n", src, e)
     }));
-    let mut buf = Buf::new_in(&arena);
+    let mut buf = Buf::new_in(arena);
     fmt_all(&mut buf, ast);
 
-    let reparsed_ast = match arena.alloc(parse_all(&arena, buf.as_str())) {
+    let reparsed_ast = match arena.alloc(parse_all(arena, buf.as_str())) {
         Ok(ast) => ast,
         Err(e) => {
             return Err(FormatProblem::ParsingFailed {
@@ -193,8 +193,8 @@ pub fn format_src(arena: &Bump, src: &str) -> Result<String, FormatProblem> {
         }
     };
 
-    let ast_normalized = ast.remove_spaces(&arena);
-    let reparsed_ast_normalized = reparsed_ast.remove_spaces(&arena);
+    let ast_normalized = ast.remove_spaces(arena);
+    let reparsed_ast_normalized = reparsed_ast.remove_spaces(arena);
 
     // HACK!
     // We compare the debug format strings of the ASTs, because I'm finding in practice that _somewhere_ deep inside the ast,
@@ -210,7 +210,7 @@ pub fn format_src(arena: &Bump, src: &str) -> Result<String, FormatProblem> {
     }
 
     // Now verify that the resultant formatting is _stable_ - i.e. that it doesn't change again if re-formatted
-    let mut reformatted_buf = Buf::new_in(&arena);
+    let mut reformatted_buf = Buf::new_in(arena);
 
     fmt_all(&mut reformatted_buf, reparsed_ast);
 

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -35,7 +35,7 @@ use target_lexicon::{Architecture, Triple};
 use tempfile::TempDir;
 
 mod format;
-pub use format::format;
+pub use format::{format_files, format_src, FormatMode};
 
 pub const CMD_BUILD: &str = "build";
 pub const CMD_RUN: &str = "run";
@@ -62,6 +62,8 @@ pub const FLAG_TIME: &str = "time";
 pub const FLAG_LINKER: &str = "linker";
 pub const FLAG_PREBUILT: &str = "prebuilt-platform";
 pub const FLAG_CHECK: &str = "check";
+pub const FLAG_STDIN: &str = "stdin";
+pub const FLAG_STDOUT: &str = "stdout";
 pub const FLAG_WASM_STACK_SIZE_KB: &str = "wasm-stack-size-kb";
 pub const ROC_FILE: &str = "ROC_FILE";
 pub const ROC_DIR: &str = "ROC_DIR";
@@ -258,6 +260,20 @@ pub fn build_app() -> Command {
                     .action(ArgAction::SetTrue)
                     .required(false),
             )
+            .arg(
+                Arg::new(FLAG_STDIN)
+                    .long(FLAG_STDIN)
+                    .help("Read file to format from stdin")
+                    .action(ArgAction::SetTrue)
+                    .required(false),
+            )
+            .arg(
+                Arg::new(FLAG_STDOUT)
+                    .long(FLAG_STDOUT)
+                    .help("Print formatted file to stdout")
+                    .action(ArgAction::SetTrue)
+                    .required(false),
+            )
         )
         .subcommand(Command::new(CMD_VERSION)
             .about(concatcp!("Print the Roc compiler’s version, which is currently ", VERSION)))
@@ -340,11 +356,6 @@ pub enum BuildConfig {
     BuildOnly,
     BuildAndRun,
     BuildAndRunIfNoErrors,
-}
-
-pub enum FormatMode {
-    Format,
-    CheckOnly,
 }
 
 fn opt_level_from_flags(matches: &ArgMatches) -> OptLevel {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -243,7 +243,9 @@ fn main() -> io::Result<()> {
 
                 match matches.get_many::<OsString>(DIRECTORY_OR_FILES) {
                     Some(os_values) => {
-                        values.extend(os_string_values.into_iter().cloned());
+                        for os_string in os_values {
+                            values.push(os_string.to_owned());
+                        }
                     }
                     None => {
                         let mut os_string_values: Vec<OsString> = Vec::new();
@@ -253,7 +255,9 @@ fn main() -> io::Result<()> {
                             &mut os_string_values,
                         )?;
 
-                        values.extend(os_string_values.into_iter().cloned());
+                        for os_string in os_string_values {
+                            values.push(os_string);
+                        }
                     }
                 }
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -243,9 +243,7 @@ fn main() -> io::Result<()> {
 
                 match matches.get_many::<OsString>(DIRECTORY_OR_FILES) {
                     Some(os_values) => {
-                        for os_string in os_values {
-                            values.push(os_string.to_owned());
-                        }
+                        values.extend(os_string_values.into_iter().cloned());
                     }
                     None => {
                         let mut os_string_values: Vec<OsString> = Vec::new();
@@ -255,9 +253,7 @@ fn main() -> io::Result<()> {
                             &mut os_string_values,
                         )?;
 
-                        for os_string in os_string_values {
-                            values.push(os_string);
-                        }
+                        values.extend(os_string_values.into_iter().cloned());
                     }
                 }
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,11 +1,12 @@
 //! The `roc` binary that brings together all functionality in the Roc toolset.
+use bumpalo::Bump;
 use roc_build::link::LinkType;
 use roc_build::program::{check_file, CodeGenBackend};
 use roc_cli::{
-    build_app, format, test, BuildConfig, FormatMode, CMD_BUILD, CMD_CHECK, CMD_DEV, CMD_DOCS,
-    CMD_FORMAT, CMD_GEN_STUB_LIB, CMD_GLUE, CMD_REPL, CMD_RUN, CMD_TEST, CMD_VERSION,
-    DIRECTORY_OR_FILES, FLAG_CHECK, FLAG_DEV, FLAG_LIB, FLAG_NO_LINK, FLAG_TARGET, FLAG_TIME,
-    GLUE_DIR, GLUE_SPEC, ROC_FILE,
+    build_app, format_files, format_src, test, BuildConfig, FormatMode, CMD_BUILD, CMD_CHECK,
+    CMD_DEV, CMD_DOCS, CMD_FORMAT, CMD_GEN_STUB_LIB, CMD_GLUE, CMD_REPL, CMD_RUN, CMD_TEST,
+    CMD_VERSION, DIRECTORY_OR_FILES, FLAG_CHECK, FLAG_DEV, FLAG_LIB, FLAG_NO_LINK, FLAG_STDIN,
+    FLAG_STDOUT, FLAG_TARGET, FLAG_TIME, GLUE_DIR, GLUE_SPEC, ROC_FILE,
 };
 use roc_docs::generate_docs_html;
 use roc_error_macros::user_error;
@@ -15,7 +16,7 @@ use roc_load::{FunctionKind, LoadingProblem, Threading};
 use roc_packaging::cache::{self, RocCacheDir};
 use roc_target::Target;
 use std::fs::{self, FileType};
-use std::io;
+use std::io::{self, Read, Write};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use target_lexicon::Triple;
@@ -151,7 +152,7 @@ fn main() -> io::Result<()> {
             )?)
         }
         Some((CMD_CHECK, matches)) => {
-            let arena = bumpalo::Bump::new();
+            let arena = Bump::new();
 
             let emit_timings = matches.get_flag(FLAG_TIME);
             let roc_file_path = matches.get_one::<PathBuf>(ROC_FILE).unwrap();
@@ -219,46 +220,102 @@ fn main() -> io::Result<()> {
             Ok(0)
         }
         Some((CMD_FORMAT, matches)) => {
-            let maybe_values = matches.get_many::<OsString>(DIRECTORY_OR_FILES);
-
-            let mut values: Vec<OsString> = Vec::new();
-
-            match maybe_values {
-                None => {
-                    let mut os_string_values: Vec<OsString> = Vec::new();
-                    read_all_roc_files(
-                        &std::env::current_dir()?.as_os_str().to_os_string(),
-                        &mut os_string_values,
-                    )?;
-                    for os_string in os_string_values {
-                        values.push(os_string);
-                    }
+            let from_stdin = matches.get_flag(FLAG_STDIN);
+            let to_stdout = matches.get_flag(FLAG_STDOUT);
+            let format_mode = if to_stdout {
+                FormatMode::WriteToStdout
+            } else {
+                match matches.get_flag(FLAG_CHECK) {
+                    true => FormatMode::CheckOnly,
+                    false => FormatMode::WriteToFile,
                 }
-                Some(os_values) => {
-                    for os_string in os_values {
-                        values.push(os_string.to_owned());
-                    }
-                }
-            }
-
-            let mut roc_files = Vec::new();
-
-            // Populate roc_files
-            for os_str in values {
-                let metadata = fs::metadata(os_str.clone())?;
-                roc_files_recursive(os_str.as_os_str(), metadata.file_type(), &mut roc_files)?;
-            }
-
-            let format_mode = match matches.get_flag(FLAG_CHECK) {
-                true => FormatMode::CheckOnly,
-                false => FormatMode::Format,
             };
 
-            let format_exit_code = match format(roc_files, format_mode) {
-                Ok(_) => 0,
-                Err(message) => {
-                    eprintln!("{message}");
-                    1
+            if from_stdin && matches!(format_mode, FormatMode::WriteToFile) {
+                eprintln!("When using the --stdin flag, either the --check or the --stdout flag must also be specified. (Otherwise, it's unclear what filename to write to!)");
+                std::process::exit(1);
+            }
+
+            let roc_files = {
+                let mut roc_files = Vec::new();
+
+                let mut values: Vec<OsString> = Vec::new();
+
+                match matches.get_many::<OsString>(DIRECTORY_OR_FILES) {
+                    Some(os_values) => {
+                        for os_string in os_values {
+                            values.push(os_string.to_owned());
+                        }
+                    }
+                    None => {
+                        let mut os_string_values: Vec<OsString> = Vec::new();
+
+                        read_all_roc_files(
+                            &std::env::current_dir()?.as_os_str().to_os_string(),
+                            &mut os_string_values,
+                        )?;
+
+                        for os_string in os_string_values {
+                            values.push(os_string);
+                        }
+                    }
+                }
+
+                // Populate roc_files
+                for os_str in values {
+                    let metadata = fs::metadata(os_str.clone())?;
+                    roc_files_recursive(os_str.as_os_str(), metadata.file_type(), &mut roc_files)?;
+                }
+
+                roc_files
+            };
+
+            let format_exit_code = if from_stdin {
+                let mut buf = Vec::new();
+                let arena = Bump::new();
+
+                io::stdin().read_to_end(&mut buf)?;
+
+                let src = std::str::from_utf8(&buf).unwrap_or_else(|err| {
+                    eprintln!("Stdin contained invalid UTF-8 bytes: {err:?}");
+                    std::process::exit(1);
+                });
+
+                match format_src(&arena, src) {
+                    Ok(formatted_src) => {
+                        match format_mode {
+                            FormatMode::CheckOnly => {
+                                if src == formatted_src {
+                                    eprintln!("One or more files need to be reformatted.");
+                                    1
+                                } else {
+                                    0
+                                }
+                            }
+                            FormatMode::WriteToStdout => {
+                                std::io::stdout().lock().write_all(src.as_bytes()).unwrap();
+
+                                0
+                            }
+                            FormatMode::WriteToFile => {
+                                // We would have errored out already if you specified --stdin
+                                // without either --stdout or --check specified as well.
+                                unreachable!()
+                            }
+                        }
+                    }
+                    Err(problem) => {
+                        eprintln!("`roc format` failed: {problem:?}");
+                        1
+                    }
+                }
+            } else {
+                match format_files(roc_files, format_mode) {
+                    Ok(()) => 0,
+                    Err(message) => {
+                        eprintln!("{message}");
+                        1
+                    }
                 }
             };
 


### PR DESCRIPTION
New `roc format` flags: `--stdin` and `--stdout` (they can be used separately or together):

<img width="787" alt="Screenshot 2023-10-18 at 11 05 56 PM" src="https://github.com/roc-lang/roc/assets/1094080/c106be90-550f-4c89-ba1c-d153785e337e">


Editor plugins for code formatting apparently like to use stdio for this!