### PR TITLE
Add optimize.sh script for website

### DIFF
--- a/www/wip_new_website/optimize.sh
+++ b/www/wip_new_website/optimize.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env sh
+
+set -eu
+
+function hash_file {
+    # the file to rename
+    filename="$1"
+
+    # generate SHA256 hash of the file content
+    hash=$(sha256sum "${filename}" | head -c 8)
+
+    # get the filename without the extension and the extension
+    base="${filename%.*}"
+    ext="${filename##*.}"
+
+    # build new filename
+    echo "${base}-${hash}.${ext}"
+}
+
+content=$(cat content/*.md)
+
+pushd dist/fonts
+for ttf_file in *.ttf; do
+	# Subset the font into a new file, then replace the original
+	hb-subset "${ttf_file}" "${content}" --output-file "${ttf_file}.subset"
+	mv "${ttf_file}.subset" "${ttf_file}"
+
+	# Compress into woff2
+	woff2_compress "${ttf_file}"
+
+	# Rename ttf with hash
+	hashed_ttf=$(hash_file "${ttf_file}")
+	mv "${ttf_file}" "${hashed_ttf}"
+
+	# Rename woff2 with hash
+	woff2_file="${ttf_file%.*}.woff2"
+	hashed_woff2=$(hash_file "${woff2_file}")
+	mv "${woff2_file}" "${hashed_woff2}"
+
+	# Replace urls in the CSS
+	sed -i -e "s:/${ttf_file}:/${hashed_ttf}:g" -e "s:/${woff2_file}:/${hashed_woff2}:g" ../wip/site.css
+done
+popd
+
+# Minify the CSS file, and let esbuild add a content hash to the file name
+npm exec --yes esbuild -- --minify dist/wip/site.css --outdir=dist/wip/ --entry-names='[name]-[hash]'
+# Remove unused original file
+rm dist/wip/site.css
+
+# Find the new filename
+css_with_hash=$(basename dist/wip/site-*.css)
+# Replace all occurances in the html
+sed -i "s:/wip/site.css:/wip/${css_with_hash}:g" dist/wip/*.html

--- a/www/wip_new_website/static/site.css
+++ b/www/wip_new_website/static/site.css
@@ -313,120 +313,45 @@ li {
     font-family: "Permanent Marker";
     font-style: normal;
     font-weight: 400;
-    src: url("/fonts/permanent-marker-v16-latin/permanent-marker-v16-latin-regular.woff2")
-            format("woff2"),
-        url("/fonts/permanent-marker-v16-latin/permanent-marker-v16-latin-regular.woff")
-            format("woff");
-    unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
-        U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212,
-        U+2215, U+FEFF, U+FFFD;
+    src:
+        url("/fonts/PermanentMarker.woff2") format("woff2"),
+        url("/fonts/PermanentMarker.ttf") format("truetype");
 }
 
-/* latin-ext */
 @font-face {
     font-family: "Merriweather";
     font-style: normal;
     font-weight: 400;
-    src: url("/fonts/merriweather-v30-latin-ext_latin/merriweather-v30-latin-ext_latin-regular.woff2")
-            format("woff2"),
-        url("/fonts/merriweather-v30-latin-ext_latin/merriweather-v30-latin-ext_latin-regular.woff")
-            format("woff");
-    unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB,
-        U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+    src:
+        url("/fonts/Merriweather.woff2") format("woff2"),
+        url("/fonts/Merriweather.ttf") format("truetype");
 }
 
-/* latin */
-@font-face {
-    font-family: "Merriweather";
-    font-style: normal;
-    font-weight: 400;
-    src: url("/fonts/merriweather-v30-latin/merriweather-v30-latin-regular.woff2")
-            format("woff2"),
-        url("/fonts/merriweather-v30-latin/merriweather-v30-latin-regular.woff")
-            format("woff");
-    unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
-        U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212,
-        U+2215, U+FEFF, U+FFFD;
-}
-
-/* latin-ext */
 @font-face {
     font-family: "Merriweather Sans";
     font-style: normal;
     font-weight: 400;
-    src: url("/fonts/merriweather-sans-v22-latin-ext_latin/merriweather-sans-v22-latin-ext_latin-regular.woff2")
-            format("woff2"),
-        url("/fonts/merriweather-sans-v22-latin-ext_latin/merriweather-sans-v22-latin-ext_latin-regular.woff")
-            format("woff");
-    unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB,
-        U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+    src:
+        url("/fonts/MerriweatherSans.woff2") format("woff2"),
+        url("/fonts/MerriweatherSans.ttf") format("truetype");
 }
 
-/* latin */
-@font-face {
-    font-family: "Merriweather Sans";
-    font-style: normal;
-    font-weight: 400;
-    src: url("/fonts/merriweather-sans-v22-latin/merriweather-sans-v22-latin-regular.woff2")
-            format("woff2"),
-        url("/fonts/merriweather-sans-v22-latin/merriweather-sans-v22-latin-regular.woff")
-            format("woff");
-    unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
-        U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212,
-        U+2215, U+FEFF, U+FFFD;
-}
-
-/* latin-ext */
 @font-face {
     font-family: "Lato";
     font-style: normal;
     font-weight: 400;
-    src: url("/fonts/lato-v23-latin-ext_latin/lato-v23-latin-ext_latin-regular.woff2")
-            format("woff2"),
-        url("/fonts/lato-v23-latin-ext_latin/lato-v23-latin-ext_latin-regular.woff")
-            format("woff");
-    unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB,
-        U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+    src:
+        url("/fonts/Lato.woff2") format("woff2"),
+        url("/fonts/Lato.ttf") format("truetype");
 }
 
-/* latin */
-@font-face {
-    font-family: "Lato";
-    font-style: normal;
-    font-weight: 400;
-    src: url("/fonts/lato-v23-latin/lato-v23-latin-regular.woff2")
-            format("woff2"),
-        url("/fonts/lato-v23-latin/lato-v23-latin-regular.woff") format("woff");
-    unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
-        U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212,
-        U+2215, U+FEFF, U+FFFD;
-}
-
-/* latin-ext */
 @font-face {
     font-family: "Source Code Pro";
     font-style: normal;
     font-weight: 400;
-    src: url("/fonts/source-code-pro-v22-latin-ext_latin/source-code-pro-v22-latin-ext_latin-regular.woff2")
-            format("woff2"),
-        url("/fonts/source-code-pro-v22-latin-ext_latin/source-code-pro-v22-latin-ext_latin-regular.woff")
-            format("woff");
-    unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB,
-        U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
-}
-
-/* latin */
-@font-face {
-    font-family: "Source Code Pro";
-    font-style: normal;
-    font-weight: 400;
-    src: url("/fonts/source-code-pro-v22-latin/source-code-pro-v22-latin-regular.woff2")
-            format("woff2"),
-        url("/fonts/source-code-pro-v22-latin/source-code-pro-v22-latin-regular.woff")
-            format("woff");
-    unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
-        U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212,
-        U+2215, U+FEFF, U+FFFD;
+    src:
+        url("/fonts/SourceCodePro.woff2") format("woff2"),
+        url("/fonts/SourceCodePro.ttf") format("truetype");
 }
 
 @media (prefers-color-scheme: dark) {


### PR DESCRIPTION
As discussed in the Zulip chat, here's a script (or beginnings of a script) for minimizing the static assets used in the website.
This script requires 2 things:
- `hb-subset`, which is a binary in some harfbuzz package or another (@Anton-4 said they would help would this, hopefully that's the right @).
- The full `.ttf` files of the fonts, instead of `.woff`/`.woff2` files. 

On my machine, I just downloaded the `.ttf` files directly and placed them at the root of the `fonts` folder (removing the `-Regular` from the names). I _guess_ the only downside of this is that when developing (not using the script) you'll get 404s for the `.woff2` files, but it'll still load the `.ttf`s. I'm not sure the best way to proceed with this part, since the static files are in a completely different repo.

The CSS file can be cleaned up, since most of the font shenanigans is for splitting up the codepoints between files, but that's not needed since the fonts will be subsetted down to exactly what's needed.

Stats
before: 126.51 kB / 60.57 kB transferred
after: 87.52 kB / 43.73 kB transferred