### PR TITLE
Check lib64 before lib when linking

### DIFF
--- a/crates/compiler/build/src/link.rs
+++ b/crates/compiler/build/src/link.rs
@@ -891,8 +891,8 @@ fn link_linux(
     lib_dirs.extend([
         usr_lib_arch_path,
         lib_arch_path,
-        strs_to_path(&["/usr", "lib"]),
         strs_to_path(&["/usr", "lib64"]),
+        strs_to_path(&["/usr", "lib"]),
     ]);
 
     // Look for the libraries we'll need


### PR DESCRIPTION
Depending on the linux distro, lib will contain 32bit libraries. We want the 64bit version of libraries if they exist, so check lib64 first.