### PR TITLE
Fixed mistake in backpassing example in the tutorial

### DIFF
--- a/www/generate_tutorial/src/input/tutorial.md
+++ b/www/generate_tutorial/src/input/tutorial.md
@@ -1574,7 +1574,7 @@ This `<-` syntax is called _backpassing_. The `<-` is a way to define an anonymo
 Here, we're using backpassing to define two anonymous functions. Here's one of them:
 
 ```roc
-text <-
+text <- await Stdin.line
 
 Stdout.line "You just entered: \(text)"
 ```


### PR DESCRIPTION
I was reading the tutorial and it looks like this single line was missing from the example.

Also, generally, it's an excellent tutorial and I eagerly await the uncompleted chapters :)