### PR TITLE
Revert "Allow rust binaries to remove dead code"

### DIFF
--- a/crates/compiler/build/src/link.rs
+++ b/crates/compiler/build/src/link.rs
@@ -554,7 +554,7 @@ pub fn rebuild_host(
             let rust_flags = if cfg!(windows) {
                 "-Z export-executable-symbols"
             } else {
-                "-C link-args=-rdynamic"
+                "-C link-dead-code"
             };
             cargo_cmd.env("RUSTFLAGS", rust_flags);
             cargo_cmd.args(["--bin", "host"]);


### PR DESCRIPTION
This reverts commit d0e1da40ac3f4dc3a247e451199f81b70bf725a3.

This is causing [segfaults in basic-cli](https://github.com/roc-lang/basic-cli/issues/123) and Folkert would like a new basic-cli release for the simple-c-abi branch.