### PR TITLE
Fix glue for closures

### DIFF
--- a/crates/glue/src/RustGlue.roc
+++ b/crates/glue/src/RustGlue.roc
@@ -151,7 +151,7 @@ generateEntryPoint = \buf, types, name, id ->
                 ret = typeName types id
                 "() -> \(ret)"
 
-    (externSignature, returnsFn) =
+    (externSignature, returnTypeName, returnsFn) =
         when Types.shape types id is
             Function rocFn ->
                 arguments =
@@ -163,16 +163,16 @@ generateEntryPoint = \buf, types, name, id ->
                         else
                             "_: &mut core::mem::ManuallyDrop<\(type)>"
 
-                (ret, retFn) =
-                    when Types.shape types rocFn.ret is
-                        Function _ -> ("u8", Bool.true)
-                        _ -> (typeName types rocFn.ret, Bool.false)
-
-                ("(_: *mut \(ret), \(arguments))", retFn)
+                ret = typeName types rocFn.ret
+                when Types.shape types rocFn.ret is
+                    Function _ ->
+                        ("(_: *mut u8, \(arguments))", ret, Bool.true)
+                    _ -> 
+                        ("(_: *mut \(ret), \(arguments))", ret, Bool.false)
 
             _ ->
                 ret = typeName types id
-                ("(_: *mut \(ret))", Bool.false)
+                ("(_: *mut \(ret))", ret, Bool.false)
 
     externArguments =
         when Types.shape types id is
@@ -201,7 +201,7 @@ generateEntryPoint = \buf, types, name, id ->
             unsafe {
                 let capacity = roc__\(name)_1_size() as usize;
 
-                let mut ret = RocFunction_88 {
+                let mut ret = \(returnTypeName) {
                     closure_data: Vec::with_capacity(capacity),
                 };
                 ret.closure_data.resize(capacity, 0);

--- a/crates/glue/src/RustGlue.roc
+++ b/crates/glue/src/RustGlue.roc
@@ -20,7 +20,7 @@ app "rust-glue"
 makeGlue : List Types -> Result (List File) Str
 makeGlue = \typesByArch ->
     modFileContent =
-        List.walk typesByArch "" \content, types ->
+        List.walk typesByArch fileHeader \content, types ->
             arch = (Types.target types).architecture
             archStr = archName arch
 

--- a/crates/glue/src/RustGlue.roc
+++ b/crates/glue/src/RustGlue.roc
@@ -195,11 +195,11 @@ generateEntryPoint = \buf, types, name, id ->
         pub fn \(name)\(publicSignature) {
             extern "C" {
                 fn roc__\(name)_1_exposed_generic\(externSignature);
-                fn roc__\(name)_1_size() -> i64;
+                fn roc__\(name)_1_exposed_size() -> i64;
             }
 
             unsafe {
-                let capacity = roc__\(name)_1_size() as usize;
+                let capacity = roc__\(name)_1_exposed_size() as usize;
 
                 let mut ret = \(returnTypeName) {
                     closure_data: Vec::with_capacity(capacity),
@@ -278,7 +278,7 @@ generateFunction = \buf, types, rocFn ->
     \(buf)
 
     #[repr(C)]
-    #[derive(Debug, Clone)]
+    #[derive(Debug)]
     pub struct \(name) {
         closure_data: Vec<u8>,
     }

--- a/crates/glue/tests/fixtures/closures/app.roc
+++ b/crates/glue/tests/fixtures/closures/app.roc
@@ -1,0 +1,10 @@
+app "app"
+    packages { pf: "platform.roc" }
+    imports []
+    provides [main] to pf
+
+main : I64 -> ({} -> I64)
+main = \x ->
+    capture1 = 2
+    capture2 = 8
+    \{} -> capture1 * capture2 * x

--- a/crates/glue/tests/fixtures/closures/platform.roc
+++ b/crates/glue/tests/fixtures/closures/platform.roc
@@ -1,0 +1,9 @@
+platform "test-platform"
+    requires {} { main : I64 -> ({} -> I64) }
+    exposes []
+    packages {}
+    imports []
+    provides [mainForHost]
+
+mainForHost : I64 -> ({} -> I64)
+mainForHost = \x -> main x

--- a/crates/glue/tests/fixtures/closures/src/lib.rs
+++ b/crates/glue/tests/fixtures/closures/src/lib.rs
@@ -1,0 +1,55 @@
+use roc_app;
+
+#[no_mangle]
+pub extern "C" fn rust_main() -> i32 {
+    let closure = roc_app::mainForHost(42i64);
+
+    println!("Answer was: {:?}", closure.force_thunk()); // Debug
+
+    // Exit code
+    0
+}
+
+// Externs required by roc_std and by the Roc app
+
+use core::ffi::c_void;
+use std::ffi::CStr;
+use std::os::raw::c_char;
+
+#[no_mangle]
+pub unsafe extern "C" fn roc_alloc(size: usize, _alignment: u32) -> *mut c_void {
+    return libc::malloc(size);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn roc_realloc(
+    c_ptr: *mut c_void,
+    new_size: usize,
+    _old_size: usize,
+    _alignment: u32,
+) -> *mut c_void {
+    return libc::realloc(c_ptr, new_size);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn roc_dealloc(c_ptr: *mut c_void, _alignment: u32) {
+    return libc::free(c_ptr);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn roc_panic(c_ptr: *mut c_void, tag_id: u32) {
+    match tag_id {
+        0 => {
+            let slice = CStr::from_ptr(c_ptr as *const c_char);
+            let string = slice.to_str().unwrap();
+            eprintln!("Roc hit a panic: {}", string);
+            std::process::exit(1);
+        }
+        _ => todo!(),
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn roc_memset(dst: *mut c_void, c: i32, n: usize) -> *mut c_void {
+    libc::memset(dst, c, n)
+}

--- a/crates/glue/tests/test_glue_cli.rs
+++ b/crates/glue/tests/test_glue_cli.rs
@@ -131,6 +131,9 @@ mod glue_cli_run {
         arguments:"arguments" => indoc!(r#"
             Answer was: 84
         "#),
+        closures:"closures" => indoc!(r#"
+            Answer was: 672
+        "#),
         rocresult:"rocresult" => indoc!(r#"
             Answer was: RocOk(ManuallyDrop { value: "Hello World!" })
             Answer was: RocErr(ManuallyDrop { value: 42 })


### PR DESCRIPTION
Closure captures should just be a list of bytes. They also need to call the size function to figure out how many bytes to load. Roc does not return a RocFunction type directly otherwise.