### PR TITLE
Drop zero-sized types from rust glue

### DIFF
--- a/crates/glue/templates/header.rs
+++ b/crates/glue/templates/header.rs
@@ -16,6 +16,7 @@
 #![allow(clippy::redundant_static_lifetimes)]
 #![allow(clippy::needless_borrow)]
 #![allow(clippy::clone_on_copy)]
+#![allow(clippy::unreachable_pattern)]
 
 type Op_StderrWrite = roc_std::RocStr;
 type Op_StdoutWrite = roc_std::RocStr;


### PR DESCRIPTION
Zero-sized types are not part of the C standard, and only some C compilers support them at all. We should avoid using them in `repr(C)` things (by dropping them instead of representing them as `()`), and in the future will should drop them in C glue as well.