### PR TITLE
Show the right fct name in type error messages

### DIFF
--- a/crates/compiler/constrain/src/expr.rs
+++ b/crates/compiler/constrain/src/expr.rs
@@ -502,6 +502,7 @@ pub fn constrain_expr(
                 let reason = Reason::FnArg {
                     name: opt_symbol,
                     arg_index: HumanIndex::zero_based(index),
+                    called_via: *called_via,
                 };
                 let expected_arg =
                     constraints.push_expected_type(ForReason(reason, arg_type_index, region));

--- a/crates/compiler/load/tests/test_reporting.rs
+++ b/crates/compiler/load/tests/test_reporting.rs
@@ -2447,7 +2447,7 @@ mod test_reporting {
         @r###"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
-    This 2nd argument to `add` has an unexpected type:
+    This 2nd argument to + has an unexpected type:
 
     4│      0x4 + "foo"
                   ^^^^^
@@ -2456,7 +2456,7 @@ mod test_reporting {
 
         Str
 
-    But `add` needs its 2nd argument to be:
+    But + needs its 2nd argument to be:
 
         Int *
     "###
@@ -2472,7 +2472,7 @@ mod test_reporting {
         @r###"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
-    This 2nd argument to `add` has an unexpected type:
+    This 2nd argument to + has an unexpected type:
 
     4│      0x4 + 3.14
                   ^^^^
@@ -2481,7 +2481,7 @@ mod test_reporting {
 
         Frac *
 
-    But `add` needs its 2nd argument to be:
+    But + needs its 2nd argument to be:
 
         Int *
 
@@ -2500,7 +2500,7 @@ mod test_reporting {
         @r###"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
-    This 2nd argument to `add` has an unexpected type:
+    This 2nd argument to + has an unexpected type:
 
     4│      42 + True
                  ^^^^
@@ -2509,7 +2509,7 @@ mod test_reporting {
 
         [True]
 
-    But `add` needs its 2nd argument to be:
+    But + needs its 2nd argument to be:
 
         Num *
     "###
@@ -3556,7 +3556,7 @@ mod test_reporting {
 
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
-    This 2nd argument to `add` has an unexpected type:
+    This 2nd argument to + has an unexpected type:
 
     14│      x + y + h + l + minlit + maxlit
                                       ^^^^^^
@@ -3565,7 +3565,7 @@ mod test_reporting {
 
         U128
 
-    But `add` needs its 2nd argument to be:
+    But + needs its 2nd argument to be:
 
         I128 or Dec
     "###
@@ -3843,7 +3843,7 @@ mod test_reporting {
         @r###"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
-    This 2nd argument to `add` has an unexpected type:
+    This 2nd argument to + has an unexpected type:
 
     4│      \{ x, y ? True } -> x + y
                                     ^
@@ -3852,7 +3852,7 @@ mod test_reporting {
 
         [True]
 
-    But `add` needs its 2nd argument to be:
+    But + needs its 2nd argument to be:
 
         Num a
     "###
@@ -6377,7 +6377,7 @@ In roc, functions are always written as a lambda, like{}
         @r###"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
-    This 2nd argument to `mul` has an unexpected type:
+    This 2nd argument to * has an unexpected type:
 
     5│      mult = \a, b -> a * b
                                 ^
@@ -6386,7 +6386,7 @@ In roc, functions are always written as a lambda, like{}
 
         F64
 
-    But `mul` needs its 2nd argument to be:
+    But * needs its 2nd argument to be:
 
         Num *
 
@@ -6421,7 +6421,7 @@ In roc, functions are always written as a lambda, like{}
         @r###"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
-    This 2nd argument to `mul` has an unexpected type:
+    This 2nd argument to * has an unexpected type:
 
     5│      mult = \a, b -> a * b
                                 ^
@@ -6430,7 +6430,7 @@ In roc, functions are always written as a lambda, like{}
 
         F64
 
-    But `mul` needs its 2nd argument to be:
+    But * needs its 2nd argument to be:
 
         Num a
 
@@ -9234,7 +9234,7 @@ In roc, functions are always written as a lambda, like{}
         @r###"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
-    This 2nd argument to `isEq` has an unexpected type:
+    This 2nd argument to == has an unexpected type:
 
     9│          Job lst -> lst == ""
                                   ^^
@@ -9243,7 +9243,7 @@ In roc, functions are always written as a lambda, like{}
 
         Str
 
-    But `isEq` needs its 2nd argument to be:
+    But == needs its 2nd argument to be:
 
         List [Job ∞] as ∞
     "###
@@ -10013,7 +10013,7 @@ In roc, functions are always written as a lambda, like{}
         @r###"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
-    This 2nd argument to `isEq` has an unexpected type:
+    This 2nd argument to == has an unexpected type:
 
     4│      0x80000000000000000000000000000000 == -0x80000000000000000000000000000000
                                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -10022,7 +10022,7 @@ In roc, functions are always written as a lambda, like{}
 
         I128
 
-    But `isEq` needs its 2nd argument to be:
+    But == needs its 2nd argument to be:
 
         U128
     "###
@@ -10038,7 +10038,7 @@ In roc, functions are always written as a lambda, like{}
         @r###"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
-    This 2nd argument to `isEq` has an unexpected type:
+    This 2nd argument to == has an unexpected type:
 
     4│      170141183460469231731687303715884105728 == -170141183460469231731687303715884105728
                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -10047,7 +10047,7 @@ In roc, functions are always written as a lambda, like{}
 
         I128 or Dec
 
-    But `isEq` needs its 2nd argument to be:
+    But == needs its 2nd argument to be:
 
         U128
     "###

--- a/crates/compiler/module/src/called_via.rs
+++ b/crates/compiler/module/src/called_via.rs
@@ -102,6 +102,15 @@ pub enum UnaryOp {
     Not,
 }
 
+impl std::fmt::Display for UnaryOp {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            UnaryOp::Negate => write!(f, "-"),
+            UnaryOp::Not => write!(f, "!"),
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum BinOp {
     // highest precedence

--- a/crates/compiler/types/src/types.rs
+++ b/crates/compiler/types/src/types.rs
@@ -3370,6 +3370,7 @@ pub enum Reason {
     FnArg {
         name: Option<Symbol>,
         arg_index: HumanIndex,
+        called_via: CalledVia,
     },
     TypedArg {
         name: Option<Symbol>,

--- a/crates/repl_test/src/tests.rs
+++ b/crates/repl_test/src/tests.rs
@@ -658,17 +658,17 @@ fn too_few_args() {
 
 #[cfg(not(feature = "wasm"))] // TODO: mismatch is due to terminal control codes!
 #[test]
-fn type_problem() {
+fn type_problem_function() {
     expect_failure(
-        "1 + \"\"",
+        "Num.add 1 \"not a num\"",
         indoc!(
             r#"
                 ── TYPE MISMATCH ───────────────────────────────────────────────────────────────
 
                 This 2nd argument to add has an unexpected type:
 
-                4│      1 + ""
-                            ^^
+                4│      Num.add 1 "not a num"
+                                  ^^^^^^^^^^^
 
                 The argument is a string of type:
 
@@ -677,6 +677,84 @@ fn type_problem() {
                 But add needs its 2nd argument to be:
 
                     Num *
+                "#
+        ),
+    );
+}
+
+#[cfg(not(feature = "wasm"))] // TODO: mismatch is due to terminal control codes!
+#[test]
+fn type_problem_binary_operator() {
+    expect_failure(
+        "1 + \"\"",
+        indoc!(
+            r#"
+                ── TYPE MISMATCH ───────────────────────────────────────────────────────────────
+
+                This 2nd argument to + has an unexpected type:
+
+                4│      1 + ""
+                            ^^
+
+                The argument is a string of type:
+
+                    Str
+
+                But + needs its 2nd argument to be:
+
+                    Num *
+                "#
+        ),
+    );
+}
+
+#[cfg(not(feature = "wasm"))] // TODO: mismatch is due to terminal control codes!
+#[test]
+fn type_problem_unary_operator() {
+    expect_failure(
+        "!\"not a bool\"",
+        indoc!(
+            r#"
+                ── TYPE MISMATCH ───────────────────────────────────────────────────────────────
+
+                This 1st argument to ! has an unexpected type:
+
+                4│      !"not a bool"
+                         ^^^^^^^^^^^^
+
+                The argument is a string of type:
+
+                    Str
+
+                But ! needs its 1st argument to be:
+
+                    Bool
+                "#
+        ),
+    );
+}
+
+#[cfg(not(feature = "wasm"))] // TODO: mismatch is due to terminal control codes!
+#[test]
+fn type_problem_string_interpolation() {
+    expect_failure(
+        "\"This is not a string -> \\(1)\"",
+        indoc!(
+            r#"
+                ── TYPE MISMATCH ───────────────────────────────────────────────────────────────
+
+                This argument to this string interpolation has an unexpected type:
+
+                4│      "This is not a string -> \(1)"
+                                                   ^
+
+                The argument is a number of type:
+
+                    Num *
+
+                But this string interpolation needs its argument to be:
+
+                    Str
                 "#
         ),
     );

--- a/crates/reporting/src/report.rs
+++ b/crates/reporting/src/report.rs
@@ -490,6 +490,13 @@ impl<'a> RocDocAllocator<'a> {
         self.text(content.to_string()).annotate(Annotation::BinOp)
     }
 
+    pub fn unop(
+        &'a self,
+        content: roc_module::called_via::UnaryOp,
+    ) -> DocBuilder<'a, Self, Annotation> {
+        self.text(content.to_string()).annotate(Annotation::UnaryOp)
+    }
+
     /// Turns off backticks/colors in a block
     pub fn type_block(
         &'a self,
@@ -843,6 +850,7 @@ pub enum Annotation {
     Structure,
     Symbol,
     BinOp,
+    UnaryOp,
     Error,
     GutterBar,
     LineNumber,
@@ -1027,6 +1035,9 @@ where
             BinOp => {
                 self.write_str(self.palette.alias)?;
             }
+            UnaryOp => {
+                self.write_str(self.palette.alias)?;
+            }
             Symbol => {
                 self.write_str(self.palette.variable)?;
             }
@@ -1075,9 +1086,9 @@ where
         match self.style_stack.pop() {
             None => {}
             Some(annotation) => match annotation {
-                Emphasized | Url | TypeVariable | Alias | Symbol | BinOp | Error | GutterBar
-                | Ellipsis | Typo | TypoSuggestion | ParserSuggestion | Structure | CodeBlock
-                | PlainText | LineNumber | Tip | Module | Header | Keyword => {
+                Emphasized | Url | TypeVariable | Alias | Symbol | BinOp | UnaryOp | Error
+                | GutterBar | Ellipsis | Typo | TypoSuggestion | ParserSuggestion | Structure
+                | CodeBlock | PlainText | LineNumber | Tip | Module | Header | Keyword => {
                     self.write_str(self.palette.reset)?;
                 }
 


### PR DESCRIPTION
fix #1668

I went a bit further than the ticket description and, along with binary operators, I also handled unary operators and string interpolation.

See the [tests](https://github.com/roc-lang/roc/blob/c858031f744371396b198002a2f09ad516db0e43/crates/repl_test/src/tests.rs#L659-L761) for examples of error messages.

I suspect we might run into the same kind of issue when desugaring fields access functions for records. However, I don't know Roc well enough yet to be able to see what could be wrong. If someone can think of a case that would raise the same issue with record desugaring, please provide a short example. And I'll fix it as well. 