### PR TITLE
lighten bg color for site

### DIFF
--- a/www/wip_new_website/static/site.css
+++ b/www/wip_new_website/static/site.css
@@ -758,7 +758,7 @@ li {
         --primary-1: #9c7cea;
         --primary-2: #1bd6bd;
         --text-color: #ccc;
-        --body-bg-color: #0e0e0f;
+        --body-bg-color: #151517;
         --border-color: var(--gray);
         --code-color: #eeeeee;
         --logo-solid: #8f8f8f;


### PR DESCRIPTION
Changed the lightness of the color (V in HSV) from 6% to 9%, to prevent eye-strain for myself (and maybe others!).

The contrast between text/bg slightly reduces (although still passes WCAG), but we can change text color to be slightly brighter versions of what they are now if someone mentions the text being too dark (although even comparing side by side it's barely noticeable).
