### PR TITLE
upgrade some examples to basic-cli 0.6

### DIFF
--- a/examples/helloWorld.roc
+++ b/examples/helloWorld.roc
@@ -1,5 +1,5 @@
 app "helloWorld"
-    packages { pf: "https://github.com/roc-lang/basic-cli/releases/download/0.5.0/Cufzl36_SnJ4QbOoEmiJ5dIpUxBvdB3NEySvuH82Wio.tar.br" }
+    packages { pf: "https://github.com/roc-lang/basic-cli/releases/download/0.6.0/QOQW08n38nHHrVVkJNiPIjzjvbR3iMjXeFY5w1aT46w.tar.br" }
     imports [pf.Stdout]
     provides [main] to pf
 

--- a/examples/inspect-logging.roc
+++ b/examples/inspect-logging.roc
@@ -2,7 +2,7 @@
 # Shows how Roc values can be logged
 #
 app "inspect-logging"
-    packages { pf: "https://github.com/roc-lang/basic-cli/releases/download/0.5.0/Cufzl36_SnJ4QbOoEmiJ5dIpUxBvdB3NEySvuH82Wio.tar.br" }
+    packages { pf: "https://github.com/roc-lang/basic-cli/releases/download/0.6.0/QOQW08n38nHHrVVkJNiPIjzjvbR3iMjXeFY5w1aT46w.tar.br" }
     imports [
         pf.Stdout,
         LogFormatter,

--- a/examples/parser/examples/letter-counts.roc
+++ b/examples/parser/examples/letter-counts.roc
@@ -1,6 +1,6 @@
 app "example"
     packages {
-        cli: "https://github.com/roc-lang/basic-cli/releases/download/0.5.0/Cufzl36_SnJ4QbOoEmiJ5dIpUxBvdB3NEySvuH82Wio.tar.br",
+        cli: "https://github.com/roc-lang/basic-cli/releases/download/0.6.0/QOQW08n38nHHrVVkJNiPIjzjvbR3iMjXeFY5w1aT46w.tar.br",
         parser: "../package/main.roc",
     }
     imports [


### PR DESCRIPTION
There are more uses of basic-cli 0.5.0 left but I mainly want to check 0.6 with all CI workflows.