### PR TITLE
Update Tutorial & Website

### DIFF
--- a/www/content/community.md
+++ b/www/content/community.md
@@ -29,7 +29,7 @@ There are three loose stages that a design proposal can go through in Roc: idea,
 
 In the idea stage, people are encouraged to describe their idea and explore the problem, potential solutions, and tradeoffs. It's a good idea to share the idea in [`#ideas` on Zulip](https://roc.zulipchat.com/#narrow/stream/304641-ideas). There's no prerequisite for sharing an idea (it's only an idea, after all!) and likewise there's also no obligation for any contributor to necessarily act on it.
 
-If the idea seems promising and worth developing further (as confirmed by a Roc contributor with expertise in the relevant area—not necessarily the [BDFN](/wip/bdfn)), usually the next step is to get more specific with a written proposal that details all the necessary information about what the change would involve.
+If the idea seems promising and worth developing further (as confirmed by a Roc contributor with expertise in the relevant area—not necessarily the [BDFN](/bdfn)), usually the next step is to get more specific with a written proposal that details all the necessary information about what the change would involve.
 
 A written proposal isn't always necessary (for example, it may be deemed a simple and uncontroversial enough change that we're comfortable proceeding straight to implementation), but since writing proposals can be time-consuming, it's definitely a good idea to get confirmation at the idea stage from an experienced contributor before taking the time to write one up.
 

--- a/www/content/docs.md
+++ b/www/content/docs.md
@@ -1,7 +1,7 @@
 # Documentation
 
 - [builtins](/builtins) - docs for modules built into the language—`Str`, `Num`, etc.
-- basic-webserver - a platform for making Web servers ([source code](https://github.com/roc-lang/basic-webserver))
+- [basic-webserver](https://roc-lang.github.io/basic-webserver/) - a platform for making Web servers ([source code](https://github.com/roc-lang/basic-webserver))
 - [basic-cli](/packages/basic-cli) - a platform for making command-line interfaces ([source code](https://github.com/roc-lang/basic-cli))
 
 In the future, a language reference will be on this page too.

--- a/www/content/fast.md
+++ b/www/content/fast.md
@@ -81,4 +81,4 @@ The next major performance improvement will be caching. Currently, `roc` always 
 
 In addition to being fast, Roc also aims to be a friendly programming language.
 
-[What does _friendly_ mean here?](/wip/friendly)
+[What does _friendly_ mean here?](/friendly)

--- a/www/content/friendly.md
+++ b/www/content/friendly.md
@@ -1,6 +1,6 @@
 # Friendly
 
-Besides having a [friendly community](/wip/community), Roc also prioritizes being a user-friendly language. This impacts the syntax, semantics, and tools Roc ships with.
+Besides having a [friendly community](/community), Roc also prioritizes being a user-friendly language. This impacts the syntax, semantics, and tools Roc ships with.
 
 ## [Syntax and Formatter](#syntax) {#syntax}
 
@@ -95,6 +95,6 @@ In the future, there are plans to add built-in support for [benchmarking](https:
 
 ## Functional
 
-Besides being designed to be [fast](/wip/fast) and friendly, Roc is also a functional programming language.
+Besides being designed to be [fast](/fast) and friendly, Roc is also a functional programming language.
 
-[What does _functional_ mean here?](/wip/functional)
+[What does _functional_ mean here?](/functional)

--- a/www/content/tutorial.md
+++ b/www/content/tutorial.md
@@ -41,7 +41,7 @@ Let's start by getting acquainted with Roc's [_Read-Eval-Print-Loop_](https://en
 
 You can use the online REPL at [roc-lang.org/repl](https://www.roc-lang.org/repl). 
 
-Or you can run this in a terminal: <code class="block">roc repl</code>, and if Roc is [installed](/wip/install.html), you should see this:
+Or you can run this in a terminal: <code class="block">roc repl</code>, and if Roc is [installed](/install), you should see this:
 
 <pre>
 <samp>

--- a/www/content/tutorial.md
+++ b/www/content/tutorial.md
@@ -37,13 +37,20 @@
 
 ## [REPL](#repl) {#repl}
 
-Let's start by getting acquainted with Roc's [_Read-Eval-Print-Loop_](https://en.wikipedia.org/wiki/Read%E2%80%93eval%E2%80%93print_loop), or **REPL** for short. Run this in a terminal:
+Let's start by getting acquainted with Roc's [_Read-Eval-Print-Loop_](https://en.wikipedia.org/wiki/Read%E2%80%93eval%E2%80%93print_loop), or **REPL** for short. 
 
-<code class="block">roc repl</code>
+You can use the online REPL at [roc-lang.org/repl](https://www.roc-lang.org/repl). 
 
-If Roc is [installed](/wip/install.html), you should see this:
+Or you can run this in a terminal: <code class="block">roc repl</code>, and if Roc is [installed](/wip/install.html), you should see this:
 
-<pre><samp>The rockin' roc repl</samp></pre>
+<pre>
+<samp>
+  The rockin’ roc repl
+────────────────────────
+
+Enter an expression, or :help, or :q to quit.
+
+</samp></pre>
 
 So far, so good!
 
@@ -63,16 +70,12 @@ Congratulations! You've just written your first Roc code.
 
 When you entered the _expression_ `"Hello, World!"`, the REPL printed it back out. It also printed `: Str`, because `Str` is that expression's type. We'll talk about types later; for now, let's ignore the `:` and whatever comes after it whenever we see them.
 
-Let's try that out. Put this into the repl and press Enter:
+You can assign specific names to expressions. Try entering these lines:
 
-<pre><samp class="repl-prompt">val1</samp></pre>
-
-You should see the same `"Hello, World!"` line as before.
-
-You can also assign specific names to expressions. Try entering these lines:
-
-<pre><samp class="repl-prompt">greeting = <span class="literal">"Hi"</span></samp></pre>
-<pre><samp class="repl-prompt">audience = <span class="literal">"World"</span></samp></pre>
+```
+greeting = "Hi"
+audience = "World"
+```
 
 From now until you exit the REPL, you can refer to either `greeting` or `audience` by those names! We'll use these later on in the tutorial.
 
@@ -84,7 +87,7 @@ Now let's try using an _operator_, specifically the `+` operator. Enter this:
 
 You should see this output:
 
-<pre><samp>2 <span class="colon">:</span> Num * <span class="comment">               # val2</span></samp></pre>
+<pre><samp>2 <span class="colon">:</span> Num * <span class="comment"></span></samp></pre>
 
 According to the REPL, one plus one equals two. Sounds right!
 

--- a/www/public/site.css
+++ b/www/public/site.css
@@ -907,7 +907,9 @@ code .kw {
 samp .op,
 code .op,
 samp .keyword.operator,
-code .keyword.operator {
+code .keyword.operator,
+samp .colon,
+code .colon {
     color: var(--primary-1);
 }
 


### PR DESCRIPTION
This PR
- Updates the first part of the Tutorial to reflect latest changes to REPL
- Includes a link for users to use [roc-lang.org/repl](https://www.roc-lang.org/repl) as an alternative to using roc cli
- Fixes css for colon's in tutorial
- Adds documentation link to `roc-lang/basic-webserver` in website
- Fixes a number of broken links that pointed to `/wip`

## Updated Tutorial REPL section
<img width="572" alt="Screenshot 2023-11-20 at 20 29 57" src="https://github.com/roc-lang/roc/assets/2679227/012def3d-f030-4bc6-a00d-33763d8d6a75">
