### PR TITLE
Fix zig_host_app on NixOS

### DIFF
--- a/crates/linker/src/elf.rs
+++ b/crates/linker/src/elf.rs
@@ -1832,14 +1832,7 @@ mod tests {
         // we need to compile the app first
         let output = std::process::Command::new(&zig)
             .current_dir(dir)
-            .args([
-                "build-obj",
-                "app.zig",
-                "-fPIC",
-                "-target",
-                "x86_64-linux-gnu",
-                "-OReleaseFast",
-            ])
+            .args(["build-obj", "app.zig", "-fPIC", "-OReleaseFast"])
             .output()
             .unwrap();
 
@@ -1878,8 +1871,6 @@ mod tests {
                 "host.zig",
                 "-fPIE",
                 "-lc",
-                "-target",
-                "x86_64-linux-gnu",
                 "-OReleaseFast",
             ])
             .output()


### PR DESCRIPTION
That's a problem with the dynamic loader:
https://discourse.nixos.org/t/no-such-file-of-directory-when-trying-to-execute-binary-file/6150

When linking `libapp.so` with `host.zig`, zig puts in the binary the standard path for the dynamic loader on linux:
`/lib64/ld-linux-x86-64.so.2`

However in NixOS, that file is somewhere else in the nix store (see: https://nixos.wiki/wiki/Packaging/Binaries#The_Dynamic_Loader). Removing the `-target` switch makes zig uses the host target for linking and puts the right path to the dynamic loader in the resulting binary. As we want to execute that binary file in this test, it makes sense to use the default target anyway.

Note that this is relevant for the creation of the binary only. For the creation of the object file, it doesn't really matter. But I removed the `-target` switch as well there for consistency.

Fix #4180