### PR TITLE
remove ref to string interpolation in start of tutorial

### DIFF
--- a/www/content/tutorial.md
+++ b/www/content/tutorial.md
@@ -100,7 +100,7 @@ Roc will respect [order of operations](https://en.wikipedia.org/wiki/Order_of_op
 
 ### [Calling Functions](#calling-functions) {#calling-functions}
 
-Remember back in the [string interpolation](#string-interpolation) section when we mentioned other ways to combine strings? Here's one of them:
+Let's try calling a function:
 
 <pre><samp><span class="repl-prompt">Str.concat "Hi " "there!"</span>
 


### PR DESCRIPTION
This line is confusing because the string interpolation appears later in the tutorial now. 

I tried to replace it with something in that fits the style of the rest of the tutorial :)