### PR TITLE
auto delete old nix shells

### DIFF
--- a/.github/workflows/nix_macos_apple_silicon.yml
+++ b/.github/workflows/nix_macos_apple_silicon.yml
@@ -18,6 +18,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      # These started to accumulate quickly since #5990, not sure why
+      - name: Clean up old nix shells
+        run: rm -rf /private/tmp/nix-shell.*
+
       - run: zig version
 
       - name: check formatting with rustfmt


### PR DESCRIPTION
The CI server fills up quickly with these shells, leading to `out of space` errors.