### PR TITLE
Dont swallow bad input while parsing spaces

### DIFF
--- a/crates/compiler/load/tests/test_reporting.rs
+++ b/crates/compiler/load/tests/test_reporting.rs
@@ -4563,7 +4563,7 @@ mod test_reporting {
         comment_with_control_character,
         "# comment with a \x07\n",
         @r###"
-    ── ASII CONTROL CHARACTER ──────── tmp/comment_with_control_character/Test.roc ─
+    ── ASCII CONTROL CHARACTER ─────── tmp/comment_with_control_character/Test.roc ─
 
     I encountered an ASCII control character:
 

--- a/crates/compiler/parse/src/expr.rs
+++ b/crates/compiler/parse/src/expr.rs
@@ -549,6 +549,9 @@ pub fn parse_single_def<'a>(
     let spaces_before_current_start = state.pos();
 
     let state = match space0_e(EExpr::IndentStart).parse(arena, state, min_indent) {
+        Err((MadeProgress, bad_input @ EExpr::Space(_, _))) => {
+            return Err((MadeProgress, bad_input));
+        }
         Err((MadeProgress, _)) => {
             return Err((MadeProgress, EExpr::DefMissingFinalExpr(initial.pos())));
         }

--- a/crates/reporting/src/error/parse.rs
+++ b/crates/reporting/src/error/parse.rs
@@ -3893,7 +3893,7 @@ fn to_space_report<'a>(
             Report {
                 filename,
                 doc,
-                title: "ASII CONTROL CHARACTER".to_string(),
+                title: "ASCII CONTROL CHARACTER".to_string(),
                 severity: Severity::RuntimeError,
             }
         }


### PR DESCRIPTION
Fix #5939

The problem in this input is not the presence of Unicode characters. It is the presence of a tab character (the larger space in the comment). Remove only that character and roc is happy to run the test without any trouble.

Anyway, the tab error is rightly identified by the parser but was swallowed and converted to `EExpr::DefMissingFinalExpr`, leading to that confusing error. Keeping it makes roc print the right error.