### PR TITLE
Change `@` token an UpperIdent

### DIFF
--- a/crates/highlight/src/lib.rs
+++ b/crates/highlight/src/lib.rs
@@ -78,8 +78,7 @@ pub fn highlight(code: &str) -> Vec<String> {
                 buf = push_html_span(buf, current_text, "delimeter");
             }
             // Types, Tags, and Modules
-            Token::UpperIdent
-            | Token::AtSign => {
+            Token::UpperIdent | Token::AtSign => {
                 buf = push_html_span(buf, current_text, "upperident");
             }
             // Variables modules and field names

--- a/crates/highlight/src/lib.rs
+++ b/crates/highlight/src/lib.rs
@@ -45,7 +45,6 @@ pub fn highlight(code: &str) -> Vec<String> {
             | Token::ColonEquals
             | Token::Colon
             | Token::And
-            | Token::AtSign
             | Token::QuestionMark => {
                 buf = push_html_span(buf, current_text, "kw");
             }
@@ -79,7 +78,8 @@ pub fn highlight(code: &str) -> Vec<String> {
                 buf = push_html_span(buf, current_text, "delimeter");
             }
             // Types, Tags, and Modules
-            Token::UpperIdent => {
+            Token::UpperIdent
+            | Token::AtSign => {
                 buf = push_html_span(buf, current_text, "upperident");
             }
             // Variables modules and field names


### PR DESCRIPTION
This PR 
- Updates the `@` token from a Keyword/Punctuation to an UpperIdent token for correct styling syntax highlighting.

## Previous
<img width="712" alt="Screenshot 2023-11-24 at 08 16 10" src="https://github.com/roc-lang/roc/assets/2679227/91d9d052-7d65-42df-894e-5d7c749b9ab5">

## Updated
<img width="711" alt="Screenshot 2023-11-24 at 08 12 07" src="https://github.com/roc-lang/roc/assets/2679227/3ca8c1f2-5dca-4697-8e5e-dfd98e209628">
