### PR TITLE
add macos x64 required dependencies

### DIFF
--- a/getting_started/macos_x86_64.md
+++ b/getting_started/macos_x86_64.md
@@ -18,6 +18,12 @@ which includes the Roc compiler and some helpful utilities.
     cd roc_night<TAB TO AUTOCOMPLETE>
     ```
 
+1. Install required dependencies:
+
+   ```sh
+   brew install z3 zstd
+   ```
+
 1. To be able to run the `roc` command anywhere on your system; add the line below to your shell startup script (.profile, .zshrc, ...):
 
     ```sh


### PR DESCRIPTION
llvm16 requires z3
I believe zstd is also required by llvm

Related to #6053

I think these deps should not be necessary once we setup llvm with musl.