### PR TITLE
Add CSS border to module functions in docs nav

### DIFF
--- a/crates/docs/src/static/styles.css
+++ b/crates/docs/src/static/styles.css
@@ -324,7 +324,9 @@ footer p {
   width: 100%;
   overflow: hidden;
   text-overflow: ellipsis;
-  padding-left: 36px;
+  margin-left: 14px;
+  padding-left: 26px;
+  border-left: 2px solid var(--violet);
 }
 
 .module-name {


### PR DESCRIPTION
Make side nav in docs more readable

![nav docs left border](https://github.com/roc-lang/roc/assets/29469/857e445e-a29b-4b45-953c-9da46fad3b0a)
