### PR TITLE
Switch callee register

### DIFF
--- a/crates/compiler/gen_dev/src/generic64/aarch64.rs
+++ b/crates/compiler/gen_dev/src/generic64/aarch64.rs
@@ -365,6 +365,7 @@ impl CallConv<AArch64GeneralReg, AArch64FloatReg, AArch64Assembler> for AArch64C
     ///  213568:       f90033fd        str     x29, [sp, #96]
     const SHADOW_SPACE_SIZE: u8 = 16;
 
+    // These are registers that a called function must save and restore if it wants to use them.
     #[inline(always)]
     fn general_callee_saved(reg: &AArch64GeneralReg) -> bool {
         matches!(

--- a/crates/compiler/gen_dev/src/generic64/x86_64.rs
+++ b/crates/compiler/gen_dev/src/generic64/x86_64.rs
@@ -199,6 +199,7 @@ impl CallConv<X86_64GeneralReg, X86_64FloatReg, X86_64Assembler> for X86_64Syste
     ];
     const SHADOW_SPACE_SIZE: u8 = 0;
 
+    // These are registers that a called function must save and restore if it wants to use them.
     #[inline(always)]
     fn general_callee_saved(reg: &X86_64GeneralReg) -> bool {
         matches!(
@@ -1409,6 +1410,8 @@ impl CallConv<X86_64GeneralReg, X86_64FloatReg, X86_64Assembler> for X86_64Windo
     ];
     const SHADOW_SPACE_SIZE: u8 = 32;
 
+    // These are registers that a called function must save and restore if it wants to use them.
+    //
     // Refer https://learn.microsoft.com/en-us/cpp/build/x64-calling-convention?view=msvc-170#callercallee-saved-registers
     // > The x64 ABI considers registers RBX, RBP, RDI, RSI, RSP, R12, R13, R14, R15, and XMM6-XMM15 nonvolatile.
     // > They must be saved and restored by a function that uses them.


### PR DESCRIPTION
ensure that when a switch case uses a callee-saved register, that register gets stored/restored properly. 

Fixes the `nested_switch` test case not working on linux in debug mode. For future reference this is the error you get in a debugger

```
* thread #3, name = 'gen_primitives:', stop reason = signal SIGABRT
  * frame #0: 0x00007ffff7a4b00b libc.so.6`__GI_raise(sig=2) at raise.c:51:1
    frame #1: 0x00007ffff7a2a859 libc.so.6`__GI_abort at abort.c:79:7
    frame #2: 0x00007ffff7a9526e libc.so.6`__libc_message(action=<unavailable>, fmt="\xa8#\x80��) at libc_fatal.c:155:5
    frame #3: 0x00007ffff7a9d2fc libc.so.6`malloc_printerr(str=<unavailable>) at malloc.c:5347:3
    frame #4: 0x00007ffff7a9eb2c libc.so.6`_int_free(av=<unavailable>, p=<unavailable>, have_lock=0) at malloc.c:4173:5
    frame #5: 0x0000555557c245cd test_gen-22b682fa147ad9b6`std::sys::unix::thread::Thread::new::thread_start::ha211bb47f6f5cedc [inlined] alloc::alloc::dealloc::h4361f28e835fbe0c at alloc.rs:121:14
    frame #6: 0x0000555557c245c4 test_gen-22b682fa147ad9b6`std::sys::unix::thread::Thread::new::thread_start::ha211bb47f6f5cedc [inlined] _$LT$alloc..alloc..Global$u20$as$u20$core..alloc..Allocator$GT$::deallocate::ha112d84f942362e8 at alloc.rs:258
    frame #7: 0x0000555557c245c4 test_gen-22b682fa147ad9b6`std::sys::unix::thread::Thread::new::thread_start::ha211bb47f6f5cedc [inlined] alloc::alloc::box_free::hb53b7baa5b31cc66 at alloc.rs:352
    frame #8: 0x0000555557c245c4 test_gen-22b682fa147ad9b6`std::sys::unix::thread::Thread::new::thread_start::ha211bb47f6f5cedc [inlined] _$LT$alloc..boxed..Box$LT$F$C$A$GT$$u20$as$u20$core..ops..function..FnOnce$LT$Args$GT$$GT$::call_once::h9adfc2ae43657457 at boxed.rs:1985
    frame #9: 0x0000555557c245ad test_gen-22b682fa147ad9b6`std::sys::unix::thread::Thread::new::thread_start::ha211bb47f6f5cedc [inlined] _$LT$alloc..boxed..Box$LT$F$C$A$GT$$u20$as$u20$core..ops..function..FnOnce$LT$Args$GT$$GT$::call_once::h14fefbfa7b574396 at boxed.rs:1985
    frame #10: 0x0000555557c245a6 test_gen-22b682fa147ad9b6`std::sys::unix::thread::Thread::new::thread_start::ha211bb47f6f5cedc at thread.rs:108
    frame #11: 0x00007ffff7f80609 libpthread.so.0`start_thread(arg=<unavailable>) at pthread_create.c:477:8
    frame #12: 0x00007ffff7b27133 libc.so.6`__clone at clone.S:95
```

I knew it had to be some corruption of the registers, so I diff'd the register state before and after the call to roc's main function. Sure enough, the callee-saved `r15` register had been modified. Then it's just a matter of tracking down why and where to fix that.

