### PR TITLE
[Tutorial] Fix an error where the Str module does not expose `isCapitalized`

### DIFF
--- a/www/content/tutorial.md
+++ b/www/content/tutorial.md
@@ -745,11 +745,11 @@ Ensuring that all elements in a list share a type eliminates entire categories o
 We can use tags with payloads to make a list that contains a mixture of different types. For example:
 
 ```roc
-List.map [StrElem "A", StrElem "b", NumElem 1, StrElem "c", NumElem -3] \elem ->
+List.map [StrElem "A", StrElem "", NumElem 1, StrElem "c", NumElem -3] \elem ->
     when elem is
         NumElem num -> Num.isNegative num
-        StrElem str -> Str.isCapitalized str
-# returns [Bool.true, Bool.false, Bool.false, Bool.false, Bool.true]
+        StrElem str -> Str.isEmpty str
+# returns [Bool.false, Bool.true, Bool.false, Bool.false, Bool.true]
 ```
 
 Compare this with the example from earlier, which caused a compile-time error:
@@ -758,7 +758,7 @@ Compare this with the example from earlier, which caused a compile-time error:
 List.map ["A", "B", "C", 1, 2, 3] Num.isNegative
 ```
 
-The version that uses tags works because we aren't trying to call `Num.isNegative` on each element. Instead, we're using a `when` to tell when we've got a string or a number, and then calling either `Num.isNegative` or `Str.isCapitalized` depending on which type we have.
+The version that uses tags works because we aren't trying to call `Num.isNegative` on each element. Instead, we're using a `when` to tell when we've got a string or a number, and then calling either `Num.isNegative` or `Str.isEmpty` depending on which type we have.
 
 We could take this as far as we like, adding more different tags (e.g. `BoolElem Bool.true`) and then adding more branches to the `when` to handle them appropriately.
 


### PR DESCRIPTION
## Why

I stumbled upon an error when I copy & paste an example in the section [Lists that hold elements of different types](https://www.roc-lang.org/tutorial#lists-that-hold-elements-of-different-types) onto `roc repl` [^1]:

```sh
$ roc repl

  The rockin' roc repl
────────────────────────

Enter an expression, or :help, or :q to quit.

» List.map [StrElem "A", StrElem "b", NumElem 1, StrElem "c", NumElem -3] \elem ->
…     when elem is
…         NumElem num -> Num.isNegative num
…         StrElem str -> Str.isCapitalized str
… # returns [Bool.true, Bool.false, Bool.false, Bool.false, Bool.true]
This Roc code crashed with: "ValueNotExposed { module_name: ModuleName(IdentStr { string: "Str" }), ident: Ide
nt(IdentStr { string: "isCapitalized" }), region: @241-258, exposed_values: ['isEmpty', 'concat', 'joinWith',
'split', 'countGraphemes', 'startsWith', 'endsWith', 'fromUtf8', 'toUtf8', 'startsWithScalar', 'fromUtf8Range'
, 'repeat', 'trim', 'trimStart', 'trimEnd', 'toDec', 'toF64', 'toF32', 'toNat', 'toU128', 'toI128', 'toU64', '
toI64', 'toU32', 'toI32', 'toU16', 'toI16', 'toU8', 'toI8', 'toScalars', 'getUnsafe', 'countUtf8Bytes', 'subst
ringUnsafe', 'splitFirst', 'splitLast', 'walkUtf8WithIndex', 'reserve', 'appendScalarUnsafe', 'appendScalar',
'getScalarUnsafe', 'walkScalars', 'walkScalarsUntil', 'strToNum', 'fromUtf8RangeLowlevel', 'capacity', 'replac
eEach', 'replaceFirst', 'replaceLast', 'withCapacity', 'withPrefix', 'graphemes', 'isValidScalar', 'releaseExc
essCapacity', 'walkUtf8', 'contains'] }"

── NOT EXPOSED ─────────────────────────────────────────────────────────────────


The Str module does not expose `isCapitalized`:

7│              StrElem str -> Str.isCapitalized str
                               ^^^^^^^^^^^^^^^^^

Did you mean one of these?

    Str.isEmpty
    Str.split
    Str.startsWith
    Str.splitFirst
```

## How

- Replace `Str.isCapitalized` by [`Str.isEmpty`](https://www.roc-lang.org/builtins/Str#isEmpty)

[^1]:`roc version`: `roc nightly pre-release, built from commit 668a9d3 on Sa 25 Nov 2023 09:07:07 UTC` 
