### PR TITLE
Use nix file set API to reduce how often we will need to rebuild 

### DIFF
--- a/crates/wasm_interp/src/lib.rs
+++ b/crates/wasm_interp/src/lib.rs
@@ -1,6 +1,5 @@
 mod frame;
 mod instance;
-mod tests;
 mod value_store;
 pub mod wasi;
 

--- a/flake.lock
+++ b/flake.lock
@@ -59,17 +59,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1693140250,
-        "narHash": "sha256-URyIDETtu1bbxcSl83xp7irEV04dPEgj7O3LjHcD1Sk=",
+        "lastModified": 1701068326,
+        "narHash": "sha256-vmMceA+q6hG1yrjb+MP8T0YFDQIrW3bl45e7z24IEts=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "676fe5e01b9a41fa14aaa48d87685677664104b1",
+        "rev": "8cfef6986adfb599ba379ae53c9f5631ecd2fd9c",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
-        "rev": "676fe5e01b9a41fa14aaa48d87685677664104b1",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -2,8 +2,7 @@
   description = "Roc flake";
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs?rev=676fe5e01b9a41fa14aaa48d87685677664104b1";
-
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
     # rust from nixpkgs has some libc problems, this is patched in the rust-overlay
     rust-overlay = {
       url = "github:oxalica/rust-overlay";
@@ -160,7 +159,7 @@
         # You can build this package (the roc CLI) with the `nix build` command.
         packages = {
           default = rocBuild.roc-cli;
-          
+
           # all rust crates in workspace.members of Cargo.toml
           full = rocBuild.roc-full;
           # only the CLI crate = executable provided in nightly releases

--- a/nix/builder.nix
+++ b/nix/builder.nix
@@ -3,6 +3,8 @@ let
   inherit (compile-deps) zigPkg llvmPkgs llvmVersion llvmMajorMinorStr glibcPath libGccSPath;
 
   subPackagePath = if subPackage != null then "crates/${subPackage}" else null;
+
+  filteredSource = pkgs.callPackage ./fileFilter.nix { };
 in
 rustPlatform.buildRustPackage {
   pname = "roc" + lib.optionalString (subPackage != null) "_${subPackage}";
@@ -10,7 +12,7 @@ rustPlatform.buildRustPackage {
 
   buildAndTestSubdir = subPackagePath;
 
-  src = pkgs.nix-gitignore.gitignoreSource [ ] ../.;
+  src = filteredSource;
 
   cargoLock = {
     lockFile = ../Cargo.lock;

--- a/nix/fileFilter.nix
+++ b/nix/fileFilter.nix
@@ -38,13 +38,12 @@ let
   # only look at files in the crates folder
   onlyCratesFolder = fs.intersection ../crates fsBase; # TODO: probably need to union back in the root cargo files
 
-  # the above filter only has the subfolder, put the cargo.toml and lock back
+  # the above filter only has the subfolder, put some needed files from the root back in
   includeCargoRootFiles = fs.unions [
     ../Cargo.toml
     ../Cargo.lock
     ../version.txt
     onlyCratesFolder
-
   ];
 
   # Remove any "simple" files like markdown/pictures since they probably wont be used in the actual code

--- a/nix/fileFilter.nix
+++ b/nix/fileFilter.nix
@@ -1,0 +1,60 @@
+{ lib, nix-gitignore }:
+let
+  # See https://nix.dev/tutorials/file-sets for an guide on how the file set api works
+
+  fs = lib.fileset;
+
+  fileDoesNotHaveExt = fileExts: file: (!lib.lists.any (ext: file.hasExt ext) fileExts);
+
+  repoRoot = ../.;
+
+
+  # "old" way of filtering files that fileset does not support yet
+  # remove anything ignored by git
+  # baseSrc = nix-gitignore.gitignoreSource [ ] repoRoot;
+
+  fsBase = fs.fromSource repoRoot;
+
+
+  # only look at files in the crates folder
+  onlyCratesFolder = fs.intersection ../crates fsBase; # TODO: probably need to union back in the root cargo files
+
+  # the above filter only has the subfolder, put the cargo.toml and lock back
+  includeCargoRootFiles = fs.unions [
+    ../Cargo.toml
+    ../Cargo.lock
+    ../version.txt
+    onlyCratesFolder
+
+  ];
+
+  # Remove any "simple" files like markdown/pictures since they probably wont be used in the actual code
+  removedSimpleFiles =
+    let
+      extensionsToRemove = [ "md" "svg" "png" ];
+    in
+    fs.intersection
+      includeCargoRootFiles
+      (fs.fileFilter (fileDoesNotHaveExt extensionsToRemove) repoRoot);
+
+  # the above filter can make the doc crate sad since it deals with pictures
+  docsAddedBack = fs.unions [
+    ../crates/docs
+    removedSimpleFiles
+  ];
+
+
+  #
+  # If you are trying to see what is ok to exclude from the "main" builds (cli/lang_server)
+  # use `cargo tree` https://doc.rust-lang.org/cargo/commands/cargo-tree.html
+  # 
+  # Ex: `cargo tree -i roc_build` will show all deps of the `roc_build` crate
+  # if only the package passed with `-i` is shown, nothing depends on it
+
+in
+fs.toSource {
+  root = repoRoot;
+  # to debug you can switch to
+  # fileset = fs.traceVal <file set>
+  fileset = docsAddedBack;
+}

--- a/nix/fileFilter.nix
+++ b/nix/fileFilter.nix
@@ -33,8 +33,6 @@ let
 
   # fsBase = fs.fromSource repoRoot;
 
-
-
   # only look at files in the crates folder
   onlyCratesFolder = fs.intersection ../crates fsBase; # TODO: probably need to union back in the root cargo files
 
@@ -69,12 +67,17 @@ let
   # if only the package passed with `-i` is shown, nothing depends on it
   # ===============================
 
+  # remove www folder from checkmate crate since its not built with nix
+  removedWWW = fs.difference docsAddedBack ../crates/compiler/checkmate/www;
+
+  # potential packages/folders that could be removed 
+  # repl_* -> I don't think nix will build those
 
   filteredSrc = fs.toSource {
     root = repoRoot;
     # to debug you can switch to
     # fileset = fs.traceVal <file set>
-    fileset = docsAddedBack;
+    fileset = removedWWW;
   };
 
 in


### PR DESCRIPTION
some context https://roc.zulipchat.com/#narrow/stream/316715-contributing/topic/refactor.20nix.20files.2Fdefault.20build/near/404518156

## What this is

This uses the new file set API (links at the bottom) for nix to reduce how many files we pass as the source to the nix builder for roc.

The bulk of the logic is is `nix/fileFilter.nix`, I added comments above each filter to call out what it does but please let me know if I should explain more.

TLDR of whats filtered
- all folders named `tests` - we don't currently run tests in the nix build so they were not needed
- only files in `crates` folder + a few files in the repo root like Cargo.{toml, lock}
- removes all `.md`, `.svg`, and `.png`
- removes www folder from checkmate

We can probably do more aggressive filtering especially if we refactor where we put the test only crates but I think this is a decent balance for now so if new crates/files are added people don't get weird errors they would not expect.


## Misc changes

I had to update nixpkgs in the flake to get the new apis. I didnt notice any issues locally but might need someone to sanity check me

### some links 

- https://www.tweag.io/blog/2023-11-28-file-sets/
- https://nix.dev/tutorials/file-sets
- https://nixos.org/manual/nixpkgs/unstable/#sec-functions-library-fileset