### PR TITLE
Tutorial - Fix broken examples link

### DIFF
--- a/www/content/tutorial.md
+++ b/www/content/tutorial.md
@@ -1712,7 +1712,7 @@ Well done on making it this far!
 
 We've covered all of the basic syntax and features of Roc in this Tutorial. You should now have a good foundation and be ready to start writing your own applications.
 
-You can continue reading through more advanced topics below, or perhaps checkout some of the [Examples](/example) for more a detailed exploration of ways to do various things.
+You can continue reading through more advanced topics below, or perhaps checkout some of the [Examples](/examples) for more a detailed exploration of ways to do various things.
 
 ## [Appendix: Advanced Concepts](#appendix-advanced-concepts) {#appendix-advanced-concepts}
 


### PR DESCRIPTION
Hey !

Reading the tutorial before the advent of code, I end up on a broken link in the "examples" section of the [tutorial](https://www.roc-lang.org/tutorial#abilities) where the current link points https://www.roc-lang.org/example (which does not exist) but should point to https://www.roc-lang.org/examples .

Have a nice day :)