### PR TITLE
ignore dead code wasm interpreter

### DIFF
--- a/crates/wasm_interp/src/instance.rs
+++ b/crates/wasm_interp/src/instance.rs
@@ -70,6 +70,7 @@ pub struct Instance<'a, I: ImportDispatcher> {
 
 impl<'a, I: ImportDispatcher> Instance<'a, I> {
     #[cfg(test)]
+    #[allow(dead_code)]
     pub(crate) fn new<G>(
         arena: &'a Bump,
         memory_pages: u32,


### PR DESCRIPTION
This was a clippy error that slipped through due to issues with our required CI checks configuration.