### PR TITLE
Nix file sets, attempt 2....

### DIFF
--- a/crates/wasm_interp/src/lib.rs
+++ b/crates/wasm_interp/src/lib.rs
@@ -1,6 +1,5 @@
 mod frame;
 mod instance;
-mod tests;
 mod value_store;
 pub mod wasi;
 

--- a/crates/wasm_interp/src/lib.rs
+++ b/crates/wasm_interp/src/lib.rs
@@ -1,5 +1,8 @@
 mod frame;
 mod instance;
+#[cfg(test)]
+mod tests;
+
 mod value_store;
 pub mod wasi;
 

--- a/flake.lock
+++ b/flake.lock
@@ -68,6 +68,7 @@
       },
       "original": {
         "owner": "nixos",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "rev": "886c9aee6ca9324e127f9c2c4e6f68c2641c8256",
         "type": "github"

--- a/flake.lock
+++ b/flake.lock
@@ -68,7 +68,6 @@
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "rev": "886c9aee6ca9324e127f9c2c4e6f68c2641c8256",
         "type": "github"

--- a/nix/builder.nix
+++ b/nix/builder.nix
@@ -3,8 +3,8 @@ let
   inherit (compile-deps) zigPkg llvmPkgs llvmVersion llvmMajorMinorStr glibcPath libGccSPath;
 
   subPackagePath = if subPackage != null then "crates/${subPackage}" else null;
-
   mainBin = if subPackage == "lang_srv" then "roc_ls" else "roc";
+  filteredSource = pkgs.callPackage ./fileFilter.nix { };
 in
 rustPlatform.buildRustPackage {
   pname = "roc" + lib.optionalString (subPackage != null) "_${subPackage}";
@@ -12,7 +12,7 @@ rustPlatform.buildRustPackage {
 
   buildAndTestSubdir = subPackagePath;
 
-  src = pkgs.nix-gitignore.gitignoreSource [ ] ../.;
+  src = filteredSource;
 
   cargoLock = {
     lockFile = ../Cargo.lock;

--- a/nix/fileFilter.nix
+++ b/nix/fileFilter.nix
@@ -1,0 +1,80 @@
+{ lib, nix-gitignore }:
+let
+  # See https://nix.dev/tutorials/file-sets for a guide on how the file set api works
+
+  fs = lib.fileset;
+
+  fileDoesNotHaveExt = fileExts: file: (!lib.lists.any (ext: file.hasExt ext) fileExts);
+
+  repoRoot = ../.;
+
+  # The file set api does not currently have a way to easily remove folders dynamically.
+  # The nix build does not run tests, so we try to remove any folders with only tests.
+  removedTests =
+    let
+      dirFilter = pathStr: (
+        let dirName = baseNameOf pathStr; in !(
+          # remove any folder whos name is `tests` or starts with `test_`
+          dirName == "tests"
+        )
+      );
+      removeTestFilter =
+        path: type:
+        # only do a "real" check on directory, allow everything else through
+        (type == "directory" && dirFilter path)
+        || type != "directory";
+    in
+    lib.sources.cleanSourceWith { src = repoRoot; filter = removeTestFilter; };
+  fsBase = fs.fromSource removedTests;
+
+  # fsBase = fs.fromSource repoRoot;
+
+  # only look at files in the crates folder
+  onlyCratesFolder = fs.intersection ../crates fsBase;
+
+  # the above filter only has the subfolder, put some needed files from the root back in
+  includeCargoRootFiles = fs.unions [
+    ../Cargo.toml
+    ../Cargo.lock
+    ../version.txt
+    onlyCratesFolder
+  ];
+
+  # Remove any "simple" files like markdown/pictures since they probably wont be used in the actual code
+  removedSimpleFiles =
+    let
+      extensionsToRemove = [ "md" "svg" "png" ];
+    in
+    fs.intersection
+      includeCargoRootFiles
+      (fs.fileFilter (fileDoesNotHaveExt extensionsToRemove) repoRoot);
+
+  # the above filter can make the doc crate sad since it has pictures
+  docsAddedBack = fs.unions [
+    ../crates/docs
+    removedSimpleFiles
+  ];
+
+  # ===============================
+  # If you are trying to see what is ok to exclude from the "main" builds (cli/lang_server)
+  # use `cargo tree` https://doc.rust-lang.org/cargo/commands/cargo-tree.html
+  # 
+  # Ex: `cargo tree -i roc_build` will show all deps of the `roc_build` crate
+  # if only the package passed with `-i` is shown, nothing depends on it
+  # ===============================
+
+  # remove www folder from checkmate crate since it's not built with nix
+  removedWWW = fs.difference docsAddedBack ../crates/compiler/checkmate/www;
+
+  # potential packages/folders that could be removed 
+  # repl_* -> I don't think nix will build those
+
+  filteredSrc = fs.toSource {
+    root = repoRoot;
+    # to debug you can switch to
+    # fileset = fs.traceVal <file set>
+    fileset = removedWWW;
+  };
+
+in
+filteredSrc


### PR DESCRIPTION
Some ci errors slipped in from https://github.com/roc-lang/roc/pull/6113 so it was reverted



My guess is the flake update I did. I attempted flake update but this time also updated the rust overlay. My hope is the rust overlay update might better be tracking nix unstable so its ld is also updated.

Shot in the dark since i dont have an m1 :( 


If CI fails again, it would be possible to add a "new" nixpkgs input to the flake and use that just for the lib api and not for its pkgs