### PR TITLE
change debug to call `Inspect.inspect` instead of inlining it

### DIFF
--- a/crates/compiler/test_mono/generated/dbg_in_expect.txt
+++ b/crates/compiler/test_mono/generated/dbg_in_expect.txt
@@ -3,46 +3,46 @@ procedure Bool.2 ():
     ret Bool.23;
 
 procedure Inspect.249 (Inspect.250, Inspect.248):
-    let Inspect.320 : Str = "\"";
-    let Inspect.319 : Str = CallByName Inspect.61 Inspect.250 Inspect.320;
-    let Inspect.315 : Str = CallByName Inspect.61 Inspect.319 Inspect.248;
-    let Inspect.316 : Str = "\"";
-    let Inspect.314 : Str = CallByName Inspect.61 Inspect.315 Inspect.316;
-    ret Inspect.314;
+    let Inspect.323 : Str = "\"";
+    let Inspect.322 : Str = CallByName Inspect.61 Inspect.250 Inspect.323;
+    let Inspect.318 : Str = CallByName Inspect.61 Inspect.322 Inspect.248;
+    let Inspect.319 : Str = "\"";
+    let Inspect.317 : Str = CallByName Inspect.61 Inspect.318 Inspect.319;
+    ret Inspect.317;
 
 procedure Inspect.30 (Inspect.147):
     ret Inspect.147;
-
-procedure Inspect.31 (Inspect.305, Inspect.149):
-    let Inspect.307 : Str = CallByName Inspect.249 Inspect.149 Inspect.305;
-    ret Inspect.307;
 
 procedure Inspect.35 (Inspect.300):
     ret Inspect.300;
 
 procedure Inspect.36 (Inspect.304):
-    let Inspect.309 : Str = "";
-    ret Inspect.309;
+    let Inspect.311 : Str = "";
+    ret Inspect.311;
 
 procedure Inspect.44 (Inspect.248):
-    let Inspect.310 : Str = CallByName Inspect.30 Inspect.248;
-    ret Inspect.310;
+    let Inspect.313 : Str = CallByName Inspect.30 Inspect.248;
+    ret Inspect.313;
+
+procedure Inspect.5 (Inspect.150):
+    let Inspect.312 : Str = CallByName Inspect.44 Inspect.150;
+    let Inspect.309 : {} = Struct {};
+    let Inspect.308 : Str = CallByName Inspect.36 Inspect.309;
+    let Inspect.307 : Str = CallByName Inspect.249 Inspect.308 Inspect.312;
+    ret Inspect.307;
 
 procedure Inspect.61 (Inspect.303, Inspect.298):
-    let Inspect.318 : Str = CallByName Str.3 Inspect.303 Inspect.298;
+    let Inspect.321 : Str = CallByName Str.3 Inspect.303 Inspect.298;
     dec Inspect.298;
-    ret Inspect.318;
+    ret Inspect.321;
 
 procedure Str.3 (#Attr.2, #Attr.3):
     let Str.292 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
     ret Str.292;
 
 procedure Test.1 ():
-    let Test.8 : Str = "";
-    let Test.5 : Str = CallByName Inspect.44 Test.8;
-    let Test.7 : {} = Struct {};
-    let Test.6 : Str = CallByName Inspect.36 Test.7;
-    let Test.4 : Str = CallByName Inspect.31 Test.5 Test.6;
+    let Test.5 : Str = "";
+    let Test.4 : Str = CallByName Inspect.5 Test.5;
     let Test.0 : Str = CallByName Inspect.35 Test.4;
     dbg Test.0;
     dec Test.0;

--- a/crates/compiler/test_mono/generated/dbg_str_followed_by_number.txt
+++ b/crates/compiler/test_mono/generated/dbg_str_followed_by_number.txt
@@ -1,44 +1,44 @@
 procedure Inspect.249 (Inspect.250, Inspect.248):
-    let Inspect.320 : Str = "\"";
-    let Inspect.319 : Str = CallByName Inspect.61 Inspect.250 Inspect.320;
-    let Inspect.315 : Str = CallByName Inspect.61 Inspect.319 Inspect.248;
-    let Inspect.316 : Str = "\"";
-    let Inspect.314 : Str = CallByName Inspect.61 Inspect.315 Inspect.316;
-    ret Inspect.314;
+    let Inspect.323 : Str = "\"";
+    let Inspect.322 : Str = CallByName Inspect.61 Inspect.250 Inspect.323;
+    let Inspect.318 : Str = CallByName Inspect.61 Inspect.322 Inspect.248;
+    let Inspect.319 : Str = "\"";
+    let Inspect.317 : Str = CallByName Inspect.61 Inspect.318 Inspect.319;
+    ret Inspect.317;
 
 procedure Inspect.30 (Inspect.147):
     ret Inspect.147;
-
-procedure Inspect.31 (Inspect.305, Inspect.149):
-    let Inspect.307 : Str = CallByName Inspect.249 Inspect.149 Inspect.305;
-    ret Inspect.307;
 
 procedure Inspect.35 (Inspect.300):
     ret Inspect.300;
 
 procedure Inspect.36 (Inspect.304):
-    let Inspect.309 : Str = "";
-    ret Inspect.309;
+    let Inspect.311 : Str = "";
+    ret Inspect.311;
 
 procedure Inspect.44 (Inspect.248):
-    let Inspect.310 : Str = CallByName Inspect.30 Inspect.248;
-    ret Inspect.310;
+    let Inspect.313 : Str = CallByName Inspect.30 Inspect.248;
+    ret Inspect.313;
+
+procedure Inspect.5 (Inspect.150):
+    let Inspect.312 : Str = CallByName Inspect.44 Inspect.150;
+    let Inspect.309 : {} = Struct {};
+    let Inspect.308 : Str = CallByName Inspect.36 Inspect.309;
+    let Inspect.307 : Str = CallByName Inspect.249 Inspect.308 Inspect.312;
+    ret Inspect.307;
 
 procedure Inspect.61 (Inspect.303, Inspect.298):
-    let Inspect.318 : Str = CallByName Str.3 Inspect.303 Inspect.298;
+    let Inspect.321 : Str = CallByName Str.3 Inspect.303 Inspect.298;
     dec Inspect.298;
-    ret Inspect.318;
+    ret Inspect.321;
 
 procedure Str.3 (#Attr.2, #Attr.3):
     let Str.292 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
     ret Str.292;
 
 procedure Test.0 ():
-    let Test.7 : Str = "";
-    let Test.4 : Str = CallByName Inspect.44 Test.7;
-    let Test.6 : {} = Struct {};
-    let Test.5 : Str = CallByName Inspect.36 Test.6;
-    let Test.3 : Str = CallByName Inspect.31 Test.4 Test.5;
+    let Test.4 : Str = "";
+    let Test.3 : Str = CallByName Inspect.5 Test.4;
     let Test.1 : Str = CallByName Inspect.35 Test.3;
     dbg Test.1;
     dec Test.1;

--- a/crates/compiler/uitest/tests/ability/specialize/inspect/opaque_automatic.txt
+++ b/crates/compiler/uitest/tests/ability/specialize/inspect/opaque_automatic.txt
@@ -9,44 +9,44 @@ main =
 
 # -emit:mono
 procedure Inspect.251 (Inspect.252):
-    let Inspect.314 : Str = "<opaque>";
-    let Inspect.313 : Str = CallByName Inspect.61 Inspect.252 Inspect.314;
-    ret Inspect.313;
+    let Inspect.317 : Str = "<opaque>";
+    let Inspect.316 : Str = CallByName Inspect.61 Inspect.252 Inspect.317;
+    ret Inspect.316;
 
 procedure Inspect.30 (Inspect.147):
     ret Inspect.147;
-
-procedure Inspect.31 (Inspect.305, Inspect.149):
-    let Inspect.307 : Str = CallByName Inspect.251 Inspect.149;
-    ret Inspect.307;
 
 procedure Inspect.35 (Inspect.300):
     ret Inspect.300;
 
 procedure Inspect.36 (Inspect.304):
-    let Inspect.309 : Str = "";
-    ret Inspect.309;
+    let Inspect.311 : Str = "";
+    ret Inspect.311;
 
 procedure Inspect.45 (Inspect.302):
-    let Inspect.311 : {} = Struct {};
-    let Inspect.310 : {} = CallByName Inspect.30 Inspect.311;
-    ret Inspect.310;
+    let Inspect.314 : {} = Struct {};
+    let Inspect.313 : {} = CallByName Inspect.30 Inspect.314;
+    ret Inspect.313;
+
+procedure Inspect.5 (Inspect.150):
+    let Inspect.312 : {} = CallByName Inspect.45 Inspect.150;
+    let Inspect.309 : {} = Struct {};
+    let Inspect.308 : Str = CallByName Inspect.36 Inspect.309;
+    let Inspect.307 : Str = CallByName Inspect.251 Inspect.308;
+    ret Inspect.307;
 
 procedure Inspect.61 (Inspect.303, Inspect.298):
-    let Inspect.316 : Str = CallByName Str.3 Inspect.303 Inspect.298;
+    let Inspect.319 : Str = CallByName Str.3 Inspect.303 Inspect.298;
     dec Inspect.298;
-    ret Inspect.316;
+    ret Inspect.319;
 
 procedure Str.3 (#Attr.2, #Attr.3):
     let Str.292 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
     ret Str.292;
 
 procedure Test.0 ():
-    let Test.8 : {} = Struct {};
-    let Test.5 : {} = CallByName Inspect.45 Test.8;
-    let Test.7 : {} = Struct {};
-    let Test.6 : Str = CallByName Inspect.36 Test.7;
-    let Test.4 : Str = CallByName Inspect.31 Test.5 Test.6;
+    let Test.5 : {} = Struct {};
+    let Test.4 : Str = CallByName Inspect.5 Test.5;
     let Test.2 : Str = CallByName Inspect.35 Test.4;
     dbg Test.2;
     dec Test.2;

--- a/crates/compiler/uitest/tests/ability/specialize/inspect/opaque_automatic_late.txt
+++ b/crates/compiler/uitest/tests/ability/specialize/inspect/opaque_automatic_late.txt
@@ -12,43 +12,43 @@ main =
 
 # -emit:mono
 procedure Inspect.251 (Inspect.252):
-    let Inspect.314 : Str = "<opaque>";
-    let Inspect.313 : Str = CallByName Inspect.61 Inspect.252 Inspect.314;
-    ret Inspect.313;
+    let Inspect.317 : Str = "<opaque>";
+    let Inspect.316 : Str = CallByName Inspect.61 Inspect.252 Inspect.317;
+    ret Inspect.316;
 
 procedure Inspect.30 (Inspect.147):
     ret Inspect.147;
-
-procedure Inspect.31 (Inspect.305, Inspect.149):
-    let Inspect.307 : Str = CallByName Inspect.251 Inspect.149;
-    ret Inspect.307;
 
 procedure Inspect.35 (Inspect.300):
     ret Inspect.300;
 
 procedure Inspect.36 (Inspect.304):
-    let Inspect.309 : Str = "";
-    ret Inspect.309;
+    let Inspect.311 : Str = "";
+    ret Inspect.311;
 
 procedure Inspect.45 (Inspect.302):
-    let Inspect.311 : {} = Struct {};
-    let Inspect.310 : {} = CallByName Inspect.30 Inspect.311;
-    ret Inspect.310;
+    let Inspect.314 : {} = Struct {};
+    let Inspect.313 : {} = CallByName Inspect.30 Inspect.314;
+    ret Inspect.313;
+
+procedure Inspect.5 (Inspect.150):
+    let Inspect.312 : {} = CallByName Inspect.45 Inspect.150;
+    let Inspect.309 : {} = Struct {};
+    let Inspect.308 : Str = CallByName Inspect.36 Inspect.309;
+    let Inspect.307 : Str = CallByName Inspect.251 Inspect.308;
+    ret Inspect.307;
 
 procedure Inspect.61 (Inspect.303, Inspect.298):
-    let Inspect.316 : Str = CallByName Str.3 Inspect.303 Inspect.298;
+    let Inspect.319 : Str = CallByName Str.3 Inspect.303 Inspect.298;
     dec Inspect.298;
-    ret Inspect.316;
+    ret Inspect.319;
 
 procedure Str.3 (#Attr.2, #Attr.3):
     let Str.292 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
     ret Str.292;
 
 procedure Test.2 (Test.3):
-    let Test.9 : {} = CallByName Inspect.45 Test.3;
-    let Test.11 : {} = Struct {};
-    let Test.10 : Str = CallByName Inspect.36 Test.11;
-    let Test.8 : Str = CallByName Inspect.31 Test.9 Test.10;
+    let Test.8 : Str = CallByName Inspect.5 Test.3;
     let Test.4 : Str = CallByName Inspect.35 Test.8;
     dbg Test.4;
     dec Test.4;


### PR DESCRIPTION
This is to workaround #6167 and can be reverted once it is fixed