### PR TITLE
Improving error messages when encountering a 404 while fetching a platform

### DIFF
--- a/crates/packaging/src/https.rs
+++ b/crates/packaging/src/https.rs
@@ -240,6 +240,7 @@ pub enum Problem {
     InvalidUrl(UrlProblem),
     /// The Content-Length header of the response exceeded max_download_bytes
     DownloadTooBig(u64),
+    NotFound,
 }
 
 pub fn download_and_hash(
@@ -254,6 +255,10 @@ pub fn download_and_hash(
         .get(url)
         .send()
         .map_err(Problem::HttpErr)?;
+
+    if resp.status() == reqwest::StatusCode::NOT_FOUND {
+        return Err(Problem::NotFound);
+    }
 
     // Some servers don't return Content-Length - e.g. Netlify seems to only sometimes return it.
     // If they do, and if it says the file is going to be too big, don't bother downloading it!

--- a/crates/reporting/src/report.rs
+++ b/crates/reporting/src/report.rs
@@ -1238,10 +1238,7 @@ pub fn to_https_problem_report<'b>(
                     .annotate(Annotation::Url)
                     .indent(4),
                 alloc.concat([alloc.reflow(r"But the file was not found (404).")]),
-                alloc.concat([
-                    alloc.tip(),
-                    alloc.reflow(r"Is the URL correct?"),
-                ]),
+                alloc.concat([alloc.tip(), alloc.reflow(r"Is the URL correct?")]),
             ]);
             Report {
                 filename: "UNKNOWN.roc".into(),

--- a/crates/reporting/src/report.rs
+++ b/crates/reporting/src/report.rs
@@ -1230,6 +1230,26 @@ pub fn to_https_problem_report<'b>(
                 severity: Severity::Fatal,
             }
         }
+        Problem::NotFound => {
+            let doc = alloc.stack([
+                alloc.reflow(r"I was trying to download this URL:"),
+                alloc
+                    .string((&url).to_string())
+                    .annotate(Annotation::Url)
+                    .indent(4),
+                alloc.concat([alloc.reflow(r"But the file was not found on the server")]),
+                alloc.concat([
+                    alloc.tip(),
+                    alloc.reflow(r"Perhaps you can check that this URL is correct?"),
+                ]),
+            ]);
+            Report {
+                filename: "UNKNOWN.roc".into(),
+                doc,
+                title: "NOTFOUND".to_string(),
+                severity: Severity::Fatal,
+            }
+        }
         // TODO: The reporting text for IoErr and FsExtraErr could probably be unified
         Problem::IoErr(io_error) => {
             let doc = alloc.stack([

--- a/crates/reporting/src/report.rs
+++ b/crates/reporting/src/report.rs
@@ -1130,7 +1130,7 @@ pub fn to_https_problem_report<'b>(
     match https_problem {
         Problem::UnsupportedEncoding(not_supported_encoding) => {
             let doc = alloc.stack([
-                alloc.reflow(r"I was trying to download this URL:"),
+                alloc.reflow(r"I tried to download from this URL:"),
                 alloc.string((&url).to_string()).annotate(Annotation::Url).indent(4),
                 alloc.concat([
                     alloc.reflow(r"But the server replied with a "),
@@ -1162,7 +1162,7 @@ pub fn to_https_problem_report<'b>(
         }
         Problem::MultipleEncodings(multiple_encodings) => {
             let doc = alloc.stack([
-                alloc.reflow(r"I was trying to download this URL:"),
+                alloc.reflow(r"I tried to download from this URL:"),
                 alloc.string((&url).to_string()).annotate(Annotation::Url).indent(4),
                 alloc.concat([
                     alloc.reflow(r"But the server replied with multiple "),
@@ -1232,15 +1232,15 @@ pub fn to_https_problem_report<'b>(
         }
         Problem::NotFound => {
             let doc = alloc.stack([
-                alloc.reflow(r"I was trying to download this URL:"),
+                alloc.reflow(r"I tried to download from this URL:"),
                 alloc
                     .string((&url).to_string())
                     .annotate(Annotation::Url)
                     .indent(4),
-                alloc.concat([alloc.reflow(r"But the file was not found on the server")]),
+                alloc.concat([alloc.reflow(r"But the file was not found (404).")]),
                 alloc.concat([
                     alloc.tip(),
-                    alloc.reflow(r"Perhaps you can check that this URL is correct?"),
+                    alloc.reflow(r"Is the URL correct?"),
                 ]),
             ]);
             Report {
@@ -1253,7 +1253,7 @@ pub fn to_https_problem_report<'b>(
         // TODO: The reporting text for IoErr and FsExtraErr could probably be unified
         Problem::IoErr(io_error) => {
             let doc = alloc.stack([
-                alloc.reflow(r"I was trying to download this URL:"),
+                alloc.reflow(r"I tried to download from this URL:"),
                 alloc
                     .string((&url).to_string())
                     .annotate(Annotation::Url)
@@ -1280,7 +1280,7 @@ pub fn to_https_problem_report<'b>(
         // TODO: The reporting text for IoErr and FsExtraErr could probably be unified
         Problem::FsExtraErr(fs_extra_error) => {
             let doc = alloc.stack([
-                alloc.reflow(r"I was trying to download this URL:"),
+                alloc.reflow(r"I tried to download from this URL:"),
                 alloc
                     .string((&url).to_string())
                     .annotate(Annotation::Url)
@@ -1306,7 +1306,7 @@ pub fn to_https_problem_report<'b>(
         }
         Problem::HttpErr(reqwest_error) => {
             let doc = alloc.stack([
-                alloc.reflow(r"I was trying to download this URL:"),
+                alloc.reflow(r"I tried to download from this URL:"),
                 alloc
                     .string((&url).to_string())
                     .annotate(Annotation::Url)
@@ -1343,7 +1343,7 @@ pub fn to_https_problem_report<'b>(
             };
 
             let doc = alloc.stack([
-                alloc.reflow(r"I was trying to download this URL:"),
+                alloc.reflow(r"I tried to download from this URL:"),
                 alloc
                     .string((&url).to_string())
                     .annotate(Annotation::Url)
@@ -1376,7 +1376,7 @@ pub fn to_https_problem_report<'b>(
         }
         Problem::InvalidUrl(roc_packaging::https::UrlProblem::MissingTarExt) => {
             let doc = alloc.stack([
-                alloc.reflow(r"I was trying to download this URL:"),
+                alloc.reflow(r"I tried to download from this URL:"),
                 alloc
                     .string((&url).to_string())
                     .annotate(Annotation::Url)
@@ -1411,7 +1411,7 @@ pub fn to_https_problem_report<'b>(
             invalid_fragment,
         )) => {
             let doc = alloc.stack([
-                alloc.reflow(r"I was trying to download this URL:"),
+                alloc.reflow(r"I tried to download from this URL:"),
                 alloc
                     .string((&url).to_string())
                     .annotate(Annotation::Url)
@@ -1447,7 +1447,7 @@ pub fn to_https_problem_report<'b>(
         }
         Problem::InvalidUrl(roc_packaging::https::UrlProblem::MissingHash) => {
             let doc = alloc.stack([
-                alloc.reflow(r"I was trying to download this URL:"),
+                alloc.reflow(r"I tried to download from this URL:"),
                 alloc
                     .string((&url).to_string())
                     .annotate(Annotation::Url)
@@ -1485,7 +1485,7 @@ pub fn to_https_problem_report<'b>(
         }
         Problem::InvalidUrl(roc_packaging::https::UrlProblem::MissingHttps) => {
             let doc = alloc.stack([
-                alloc.reflow(r"I was trying to download this URL:"),
+                alloc.reflow(r"I tried to download from this URL:"),
                 alloc
                     .string((&url).to_string())
                     .annotate(Annotation::Url)
@@ -1511,7 +1511,7 @@ pub fn to_https_problem_report<'b>(
         }
         Problem::InvalidUrl(roc_packaging::https::UrlProblem::MisleadingCharacter) => {
             let doc = alloc.stack([
-                alloc.reflow(r"I was trying to download this URL:"),
+                alloc.reflow(r"I tried to download from this URL:"),
                 alloc
                     .string((&url).to_string())
                     .annotate(Annotation::Url)
@@ -1557,7 +1557,7 @@ pub fn to_https_problem_report<'b>(
                 .get_appropriate_unit(false)
                 .format(3);
             let doc = alloc.stack([
-                alloc.reflow(r"I was trying to download this URL:"),
+                alloc.reflow(r"I tried to download from this URL:"),
                 alloc
                     .string((&url).to_string())
                     .annotate(Annotation::Url)


### PR DESCRIPTION
This PR is to fix the improve the error message when the URL provided to download a platform is incorrect and the server returns a 404. 