### PR TITLE
Fix debug info

### DIFF
--- a/BUILDING_FROM_SOURCE.md
+++ b/BUILDING_FROM_SOURCE.md
@@ -76,7 +76,7 @@ To run the test suite (via `cargo test`), you additionally need to install:
 - [`valgrind`](https://www.valgrind.org/) (needs special treatment to [install on macOS](https://stackoverflow.com/a/61359781)
 Alternatively, you can use `cargo test --no-fail-fast` or `cargo test -p specific_tests` to skip over the valgrind failures & tests.
 
-For debugging LLVM IR, we use [DebugIR](https://github.com/vaivaswatha/debugir). This dependency is only required to build with the `--debug` flag, and for normal development you should be fine without it.
+For emitting LLVM IR for debugging purposes, the `--emit-llvm-ir` flag can be used.
 
 ### libxcb libraries
 

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -50,7 +50,8 @@ pub const CMD_GLUE: &str = "glue";
 pub const CMD_GEN_STUB_LIB: &str = "gen-stub-lib";
 pub const CMD_PREPROCESS_HOST: &str = "preprocess-host";
 
-pub const FLAG_DEBUG: &str = "debug";
+pub const FLAG_EMIT_LLVM_IR: &str = "emit-llvm-ir";
+pub const FLAG_PROFILING: &str = "profiling";
 pub const FLAG_BUNDLE: &str = "bundle";
 pub const FLAG_DEV: &str = "dev";
 pub const FLAG_OPTIMIZE: &str = "optimize";
@@ -102,9 +103,15 @@ pub fn build_app() -> Command {
         .action(ArgAction::SetTrue)
         .required(false);
 
-    let flag_debug = Arg::new(FLAG_DEBUG)
-        .long(FLAG_DEBUG)
-        .help("Store LLVM debug information in the generated program")
+    let flag_emit_llvm_ir = Arg::new(FLAG_EMIT_LLVM_IR)
+        .long(FLAG_EMIT_LLVM_IR)
+        .help("Emit a `.ll` file containing the LLVM IR of the program")
+        .action(ArgAction::SetTrue)
+        .required(false);
+
+    let flag_profiling = Arg::new(FLAG_PROFILING)
+        .long(FLAG_PROFILING)
+        .help("Keep debug info in the final generated program even in optmized builds")
         .action(ArgAction::SetTrue)
         .required(false);
 
@@ -163,7 +170,8 @@ pub fn build_app() -> Command {
             .arg(flag_max_threads.clone())
             .arg(flag_opt_size.clone())
             .arg(flag_dev.clone())
-            .arg(flag_debug.clone())
+            .arg(flag_emit_llvm_ir.clone())
+            .arg(flag_profiling.clone())
             .arg(flag_time.clone())
             .arg(flag_linker.clone())
             .arg(flag_prebuilt.clone())
@@ -212,7 +220,8 @@ pub fn build_app() -> Command {
             .arg(flag_max_threads.clone())
             .arg(flag_opt_size.clone())
             .arg(flag_dev.clone())
-            .arg(flag_debug.clone())
+            .arg(flag_emit_llvm_ir.clone())
+            .arg(flag_profiling.clone())
             .arg(flag_time.clone())
             .arg(flag_linker.clone())
             .arg(flag_prebuilt.clone())
@@ -234,7 +243,8 @@ pub fn build_app() -> Command {
             .arg(flag_max_threads.clone())
             .arg(flag_opt_size.clone())
             .arg(flag_dev.clone())
-            .arg(flag_debug.clone())
+            .arg(flag_emit_llvm_ir.clone())
+            .arg(flag_profiling.clone())
             .arg(flag_time.clone())
             .arg(flag_linker.clone())
             .arg(flag_prebuilt.clone())
@@ -247,7 +257,8 @@ pub fn build_app() -> Command {
             .arg(flag_max_threads.clone())
             .arg(flag_opt_size.clone())
             .arg(flag_dev.clone())
-            .arg(flag_debug.clone())
+            .arg(flag_emit_llvm_ir.clone())
+            .arg(flag_profiling.clone())
             .arg(flag_time.clone())
             .arg(flag_linker.clone())
             .arg(flag_prebuilt.clone())
@@ -376,7 +387,8 @@ pub fn build_app() -> Command {
         .arg(flag_max_threads)
         .arg(flag_opt_size)
         .arg(flag_dev)
-        .arg(flag_debug)
+        .arg(flag_emit_llvm_ir)
+        .arg(flag_profiling)
         .arg(flag_time)
         .arg(flag_linker)
         .arg(flag_prebuilt)
@@ -696,7 +708,13 @@ pub fn build(
         CodeGenBackend::Llvm(backend_mode)
     };
 
-    let emit_debug_info = matches.get_flag(FLAG_DEBUG);
+    let emit_llvm_ir = matches.get_flag(FLAG_EMIT_LLVM_IR);
+    if emit_llvm_ir && !matches!(code_gen_backend, CodeGenBackend::Llvm(_)) {
+        user_error!("Cannot emit llvm ir while using a dev backend.");
+    }
+
+    let emit_debug_info = matches.get_flag(FLAG_PROFILING)
+        || matches!(opt_level, OptLevel::Development | OptLevel::Normal);
     let emit_timings = matches.get_flag(FLAG_TIME);
 
     let threading = match matches.get_one::<usize>(FLAG_MAX_THREADS) {
@@ -745,6 +763,7 @@ pub fn build(
         backend: code_gen_backend,
         opt_level,
         emit_debug_info,
+        emit_llvm_ir,
     };
 
     let load_config = standard_load_config(&triple, build_ordering, threading);

--- a/crates/compiler/build/src/program.rs
+++ b/crates/compiler/build/src/program.rs
@@ -138,6 +138,7 @@ pub fn gen_from_mono_module<'a>(
 // TODO how should imported modules factor into this? What if those use builtins too?
 // TODO this should probably use more helper functions
 // TODO make this polymorphic in the llvm functions so it can be reused for another backend.
+#[allow(clippy::too_many_arguments)]
 fn gen_from_mono_module_llvm<'a>(
     arena: &'a bumpalo::Bump,
     loaded: MonomorphizedModule<'a>,

--- a/crates/compiler/build/src/program.rs
+++ b/crates/compiler/build/src/program.rs
@@ -151,9 +151,6 @@ fn gen_from_mono_module_llvm<'a>(
     let context = Context::create();
     let module = arena.alloc(module_from_builtins(target, &context, "app"));
 
-    // strip Zig debug stuff
-    // module.strip_debug_info();
-
     // mark our zig-defined builtins as internal
     let app_ll_file = {
         let mut temp = PathBuf::from(roc_file_path);
@@ -245,8 +242,7 @@ fn gen_from_mono_module_llvm<'a>(
 
     env.dibuilder.finalize();
 
-    // we don't use the debug info, and it causes weird errors.
-    module.strip_debug_info();
+    // TODO: pipeline flag here to conditionally strip debug info.
 
     // Uncomment this to see the module's optimized LLVM instruction output:
     // env.module.print_to_stderr();
@@ -361,8 +357,6 @@ fn gen_from_mono_module_llvm<'a>(
 
         MemoryBuffer::create_from_file(&app_o_file).expect("memory buffer creation works")
     } else if emit_debug_info {
-        module.strip_debug_info();
-
         let mut app_ll_dbg_file = PathBuf::from(roc_file_path);
         app_ll_dbg_file.set_extension("dbg.ll");
 

--- a/crates/compiler/builtins/bitcode/build.zig
+++ b/crates/compiler/builtins/bitcode/build.zig
@@ -57,7 +57,7 @@ fn generateLlvmIrFile(
     object_name: []const u8,
 ) void {
     const obj = b.addObject(.{ .name = object_name, .root_source_file = main_path, .optimize = mode, .target = target, .use_llvm = true });
-    obj.strip = false;
+    obj.strip = true;
     obj.disable_stack_probing = true;
 
     // Generating the bin seems required to get zig to generate the llvm ir.
@@ -87,7 +87,7 @@ fn generateObjectFile(
     object_name: []const u8,
 ) void {
     const obj = b.addObject(.{ .name = object_name, .root_source_file = main_path, .optimize = mode, .target = target, .use_llvm = true });
-    obj.strip = false;
+    obj.strip = true;
     obj.link_function_sections = true;
     obj.force_pic = true;
     obj.disable_stack_probing = true;

--- a/crates/compiler/builtins/bitcode/build.zig
+++ b/crates/compiler/builtins/bitcode/build.zig
@@ -7,7 +7,7 @@ const CrossTarget = std.zig.CrossTarget;
 const Arch = std.Target.Cpu.Arch;
 
 pub fn build(b: *Build) void {
-    // const mode = b.standardOptimizeOption(.{ .preferred_optimize_mode = .ReleaseFast });
+    // const mode = b.standardOptimizeOption(.{ .preferred_optimize_mode = .Debug });
     const mode = b.standardOptimizeOption(.{ .preferred_optimize_mode = .ReleaseFast });
 
     // Options
@@ -57,7 +57,8 @@ fn generateLlvmIrFile(
     object_name: []const u8,
 ) void {
     const obj = b.addObject(.{ .name = object_name, .root_source_file = main_path, .optimize = mode, .target = target, .use_llvm = true });
-    obj.strip = true;
+    obj.strip = false;
+    obj.disable_stack_probing = true;
 
     // Generating the bin seems required to get zig to generate the llvm ir.
     _ = obj.getEmittedBin();
@@ -86,9 +87,10 @@ fn generateObjectFile(
     object_name: []const u8,
 ) void {
     const obj = b.addObject(.{ .name = object_name, .root_source_file = main_path, .optimize = mode, .target = target, .use_llvm = true });
-    obj.strip = true;
+    obj.strip = false;
     obj.link_function_sections = true;
     obj.force_pic = true;
+    obj.disable_stack_probing = true;
 
     const obj_file = obj.getEmittedBin();
 

--- a/crates/compiler/gen_llvm/src/llvm/build.rs
+++ b/crates/compiler/gen_llvm/src/llvm/build.rs
@@ -4717,6 +4717,8 @@ fn expose_function_to_host_help_c_abi_v2<'a, 'ctx>(
     let subprogram = env.new_subprogram(c_function_name);
     c_function.set_subprogram(subprogram);
 
+    debug_info_init!(env, c_function);
+
     // STEP 2: build the exposed function's body
     let builder = env.builder;
     let context = env.context;

--- a/crates/compiler/gen_llvm/src/llvm/build.rs
+++ b/crates/compiler/gen_llvm/src/llvm/build.rs
@@ -1230,6 +1230,8 @@ fn promote_to_wasm_test_wrapper<'a, 'ctx>(
         let subprogram = env.new_subprogram(main_fn_name);
         c_function.set_subprogram(subprogram);
 
+        debug_info_init!(env, c_function);
+
         // STEP 2: build the exposed function's body
         let builder = env.builder;
         let context = env.context;
@@ -4367,6 +4369,8 @@ fn expose_function_to_host_help_c_abi_generic<'a, 'ctx>(
     let subprogram = env.new_subprogram(c_function_name);
     c_function.set_subprogram(subprogram);
 
+    debug_info_init!(env, c_function);
+
     // STEP 2: build the exposed function's body
     let builder = env.builder;
     let context = env.context;
@@ -4374,8 +4378,6 @@ fn expose_function_to_host_help_c_abi_generic<'a, 'ctx>(
     let entry = context.append_basic_block(c_function, "entry");
 
     builder.position_at_end(entry);
-
-    debug_info_init!(env, c_function);
 
     // drop the first argument, which is the pointer we write the result into
     let args_vector = c_function.get_params();
@@ -4422,6 +4424,7 @@ fn expose_function_to_host_help_c_abi_generic<'a, 'ctx>(
     let call_result = if env.mode.returns_roc_result() {
         debug_assert_eq!(args.len(), roc_function.get_params().len());
 
+        let dbg_loc = builder.get_current_debug_location().unwrap();
         let roc_wrapper_function =
             make_exception_catcher(env, layout_interner, roc_function, return_layout);
         debug_assert_eq!(
@@ -4430,6 +4433,7 @@ fn expose_function_to_host_help_c_abi_generic<'a, 'ctx>(
         );
 
         builder.position_at_end(entry);
+        builder.set_current_debug_location(dbg_loc);
 
         let wrapped_layout = roc_call_result_layout(env.arena, return_layout);
         call_direct_roc_function(
@@ -4515,6 +4519,8 @@ fn expose_function_to_host_help_c_abi_gen_test<'a, 'ctx>(
     let subprogram = env.new_subprogram(c_function_name);
     c_function.set_subprogram(subprogram);
 
+    debug_info_init!(env, c_function);
+
     // STEP 2: build the exposed function's body
     let builder = env.builder;
     let context = env.context;
@@ -4522,8 +4528,6 @@ fn expose_function_to_host_help_c_abi_gen_test<'a, 'ctx>(
     let entry = context.append_basic_block(c_function, "entry");
 
     builder.position_at_end(entry);
-
-    debug_info_init!(env, c_function);
 
     // drop the final argument, which is the pointer we write the result into
     let args_vector = c_function.get_params();
@@ -4571,10 +4575,12 @@ fn expose_function_to_host_help_c_abi_gen_test<'a, 'ctx>(
     let (call_result, call_result_layout) = {
         let last_block = builder.get_insert_block().unwrap();
 
+        let dbg_loc = builder.get_current_debug_location().unwrap();
         let roc_wrapper_function =
             make_exception_catcher(env, layout_interner, roc_function, return_layout);
 
         builder.position_at_end(last_block);
+        builder.set_current_debug_location(dbg_loc);
 
         let wrapper_result = roc_call_result_layout(env.arena, return_layout);
 
@@ -4626,11 +4632,11 @@ fn expose_function_to_host_help_c_abi_gen_test<'a, 'ctx>(
     let subprogram = env.new_subprogram(&size_function_name);
     size_function.set_subprogram(subprogram);
 
+    debug_info_init!(env, size_function);
+
     let entry = context.append_basic_block(size_function, "entry");
 
     builder.position_at_end(entry);
-
-    debug_info_init!(env, size_function);
 
     let size: BasicValueEnum = return_type.size_of().unwrap().into();
     builder.new_build_return(Some(&size));
@@ -4947,11 +4953,11 @@ fn expose_function_to_host_help_c_abi<'a, 'ctx>(
     let subprogram = env.new_subprogram(&size_function_name);
     size_function.set_subprogram(subprogram);
 
+    debug_info_init!(env, size_function);
+
     let entry = env.context.append_basic_block(size_function, "entry");
 
     env.builder.position_at_end(entry);
-
-    debug_info_init!(env, size_function);
 
     let return_type = match env.mode {
         LlvmBackendMode::GenTest | LlvmBackendMode::WasmGenTest | LlvmBackendMode::CliTest => {
@@ -5348,6 +5354,8 @@ fn make_exception_catching_wrapper<'a, 'ctx>(
 
     let subprogram = env.new_subprogram(wrapper_function_name);
     wrapper_function.set_subprogram(subprogram);
+
+    debug_info_init!(env, wrapper_function);
 
     // The exposed main function must adhere to the C calling convention, but the wrapper can still be fastcc.
     wrapper_function.set_call_conventions(FAST_CALL_CONV);
@@ -5824,6 +5832,8 @@ fn build_proc_header<'a, 'ctx>(
 
     let subprogram = env.new_subprogram(&fn_name);
     fn_val.set_subprogram(subprogram);
+
+    debug_info_init!(env, fn_val);
 
     if env.exposed_to_host.contains(&symbol) {
         let arguments = Vec::from_iter_in(proc.args.iter().map(|(layout, _)| *layout), env.arena);

--- a/crates/compiler/gen_llvm/src/llvm/expect.rs
+++ b/crates/compiler/gen_llvm/src/llvm/expect.rs
@@ -469,6 +469,8 @@ fn build_clone_tag<'a, 'ctx>(
             let subprogram = env.new_subprogram(&fn_name);
             function_value.set_subprogram(subprogram);
 
+            debug_info_init!(env, function_value);
+
             env.dibuilder.finalize();
 
             build_clone_tag_help(

--- a/crates/compiler/gen_llvm/src/llvm/externs.rs
+++ b/crates/compiler/gen_llvm/src/llvm/externs.rs
@@ -1,3 +1,4 @@
+use crate::debug_info_init;
 use crate::llvm::bitcode::call_void_bitcode_fn;
 use crate::llvm::build::{add_func, get_panic_msg_ptr, get_panic_tag_ptr, BuilderExt, C_CALL_CONV};
 use crate::llvm::build::{CCReturn, Env, FunctionSpec};
@@ -253,6 +254,8 @@ pub fn add_sjlj_roc_panic(env: &Env<'_, '_, '_>) {
 
         let subprogram = env.new_subprogram("roc_panic");
         fn_val.set_subprogram(subprogram);
+
+        debug_info_init!(env, fn_val);
 
         env.dibuilder.finalize();
 

--- a/crates/compiler/gen_llvm/src/llvm/refcounting.rs
+++ b/crates/compiler/gen_llvm/src/llvm/refcounting.rs
@@ -156,6 +156,8 @@ impl<'ctx> PointerToRefcount<'ctx> {
                 let subprogram = env.new_subprogram(fn_name);
                 function_value.set_subprogram(subprogram);
 
+                debug_info_init!(env, function_value);
+
                 Self::build_decrement_function_body(env, function_value, alignment);
 
                 function_value
@@ -1048,6 +1050,8 @@ pub fn build_header_help<'ctx>(
 
     let subprogram = env.new_subprogram(fn_name);
     fn_val.set_subprogram(subprogram);
+
+    debug_info_init!(env, fn_val);
 
     env.dibuilder.finalize();
 

--- a/crates/compiler/test_gen/benches/list_map.rs
+++ b/crates/compiler/test_gen/benches/list_map.rs
@@ -57,7 +57,7 @@ fn roc_function<'a, 'b>(
     let config = helpers::llvm::HelperConfig {
         mode: LlvmBackendMode::GenTest,
         ignore_problems: false,
-        add_debug_info: true,
+        emit_debug_info: true,
         opt_level: OptLevel::Optimize,
     };
 

--- a/crates/compiler/test_gen/benches/quicksort.rs
+++ b/crates/compiler/test_gen/benches/quicksort.rs
@@ -86,7 +86,7 @@ fn roc_function<'a>(
     let config = helpers::llvm::HelperConfig {
         mode: LlvmBackendMode::GenTest,
         ignore_problems: false,
-        add_debug_info: true,
+        emit_debug_info: true,
         opt_level: OptLevel::Optimize,
     };
 

--- a/crates/compiler/test_gen/src/helpers/llvm.rs
+++ b/crates/compiler/test_gen/src/helpers/llvm.rs
@@ -233,9 +233,6 @@ fn create_llvm_module<'a>(
         exposed_to_host: MutSet::default(),
     };
 
-    // strip Zig debug stuff
-    module.strip_debug_info();
-
     // Add roc_alloc, roc_realloc, and roc_dealloc, since the repl has no
     // platform to provide them.
     add_default_roc_externs(&env);
@@ -278,9 +275,6 @@ fn create_llvm_module<'a>(
     };
 
     env.dibuilder.finalize();
-
-    // strip all debug info: we don't use it at the moment and causes weird validation issues
-    module.strip_debug_info();
 
     // Uncomment this to see the module's un-optimized LLVM instruction output:
     // env.module.print_to_stderr();

--- a/crates/compiler/test_gen/src/helpers/llvm.rs
+++ b/crates/compiler/test_gen/src/helpers/llvm.rs
@@ -340,7 +340,7 @@ pub fn helper<'a>(
     if !config.emit_debug_info {
         module.strip_debug_info();
     }
-    let res_lib = llvm_module_to_dylib(&module, &target, config.opt_level);
+    let res_lib = llvm_module_to_dylib(module, &target, config.opt_level);
 
     let lib = res_lib.expect("Error loading compiled dylib for test");
 

--- a/crates/compiler/test_gen/src/helpers/llvm.rs
+++ b/crates/compiler/test_gen/src/helpers/llvm.rs
@@ -487,7 +487,7 @@ where
 
     let config = HelperConfig {
         mode: LlvmBackendMode::WasmGenTest,
-        add_debug_info: false,
+        emit_debug_info: false,
         ignore_problems,
         opt_level: OPT_LEVEL,
     };

--- a/crates/glue/src/load.rs
+++ b/crates/glue/src/load.rs
@@ -55,6 +55,7 @@ pub fn generate(
                 backend,
                 opt_level: OptLevel::Development,
                 emit_debug_info: false,
+                emit_llvm_ir: false,
             };
 
             let load_config = standard_load_config(

--- a/crates/repl_cli/src/cli_gen.rs
+++ b/crates/repl_cli/src/cli_gen.rs
@@ -255,9 +255,6 @@ fn mono_module_to_dylib_llvm<'a>(
 
     env.dibuilder.finalize();
 
-    // we don't use the debug info, and it causes weird errors.
-    module.strip_debug_info();
-
     // Uncomment this to see the module's un-optimized LLVM instruction output:
     // env.module.print_to_stderr();
 

--- a/crates/repl_expect/src/run.rs
+++ b/crates/repl_expect/src/run.rs
@@ -713,9 +713,6 @@ pub fn expect_mono_module_to_dylib<'a>(
 
     env.dibuilder.finalize();
 
-    // we don't use the debug info, and it causes weird errors.
-    module.strip_debug_info();
-
     // Uncomment this to see the module's un-optimized LLVM instruction output:
     // env.module.print_to_stderr();
 

--- a/flake.nix
+++ b/flake.nix
@@ -64,29 +64,6 @@
               curl # for wasm-bindgen-cli libcurl (see ./ci/www-repl.sh)
             ]);
 
-        # For debugging LLVM IR
-        debugir = pkgs.stdenv.mkDerivation {
-          name = "debugir";
-          src = pkgs.fetchFromGitHub {
-            owner = "vaivaswatha";
-            repo = "debugir";
-            rev = "b981e0b74872d9896ba447dd6391dfeb63332b80";
-            sha256 = "Gzey0SF0NZkpiObk5e29nbc41dn4Olv1dx+6YixaZH0=";
-          };
-          buildInputs = with pkgs; [ cmake libxml2 llvmPkgs.llvm.dev ];
-          buildPhase = ''
-            mkdir build
-            cd build
-            cmake -DLLVM_DIR=${llvmPkgs.llvm.dev} -DCMAKE_BUILD_TYPE=Release ../
-            cmake --build ../
-            cp ../debugir .
-          '';
-          installPhase = ''
-            mkdir -p $out/bin
-            cp debugir $out/bin
-          '';
-        };
-
         sharedInputs = (with pkgs; [
           # build libraries
           cmake
@@ -109,8 +86,6 @@
           python3
           libiconv # for examples/gui
           libxkbcommon # for examples/gui
-          # debugir needs to be updated to llvm 15
-          # debugir # used in crates/compiler/build/src/program.rs
           cargo-criterion # for benchmarks
           simple-http-server # to view roc website when trying out edits
           wasm-pack # for repl_wasm


### PR DESCRIPTION
This gets function debug info working. Was just a minor bug.

After that, it changes the `roc` api to enable debug info generation. Firstly, we no longer just strip all debug info. We leave it in for both Development and Normal builds. It is still strip by default in optimized builds unless `--profiling` is passed.

The old `--debug` flag was renamed to `--emit-llvm-ir`. ~~It still does the same thing though of emitting llvm ir and then trying to run it through debugir.~~ It just emits the `.ll` file and doesn't use `debugir` anymore.

~~I am not sure it is worth keeping around `debugir`, but I left it for now. `debugir` is still not updated to the latest version of llvm. So I think it is simply not function rn. On top of that, if we generate our own debug info and that works, I think there is less of a need for this.~~  I decided to rip the bandaid off, `debugir` still isn't updated. So obviously we haven't used it in a while. We can generate proper debug info. We should focus on improve that instead of using `debugir` into the future.