### PR TITLE
Create seamless slices when getting a substring

### DIFF
--- a/crates/compiler/builtins/bitcode/src/str.zig
+++ b/crates/compiler/builtins/bitcode/src/str.zig
@@ -1498,8 +1498,33 @@ pub fn getCapacity(string: RocStr) callconv(.C) usize {
 }
 
 pub fn substringUnsafe(string: RocStr, start: usize, length: usize) callconv(.C) RocStr {
-    const slice = string.asSlice()[start .. start + length];
-    return RocStr.fromSlice(slice);
+    if (string.isSmallStr()) {
+        if (start == 0) {
+            var output = string;
+            output.setLen(length);
+            return output;
+        }
+        const slice = string.asSlice()[start .. start + length];
+        return RocStr.fromSlice(slice);
+    }
+    if (string.str_bytes) |source_ptr| {
+        if (start == 0 and string.isUnique()) {
+            var output = string;
+            output.setLen(length);
+            return output;
+        } else {
+            const str_ref_ptr = (@intFromPtr(source_ptr) >> 1);
+            const slice_ref_ptr = string.str_capacity;
+            const slice_mask = string.seamlessSliceMask();
+            const ref_ptr = (str_ref_ptr & ~slice_mask) | (slice_ref_ptr & slice_mask);
+            return RocStr{
+                .str_bytes = source_ptr + start,
+                .str_len = length | SEAMLESS_SLICE_BIT,
+                .str_capacity = ref_ptr,
+            };
+        }
+    }
+    return RocStr.empty();
 }
 
 pub fn getUnsafe(string: RocStr, index: usize) callconv(.C) u8 {

--- a/crates/compiler/mono/src/drop_specialization.rs
+++ b/crates/compiler/mono/src/drop_specialization.rs
@@ -1540,7 +1540,7 @@ fn low_level_no_rc(lowlevel: &LowLevel) -> RC {
         StrGetUnsafe | ListGetUnsafe => RC::NoRc,
         ListConcat => RC::Rc,
         StrConcat => RC::Rc,
-        StrSubstringUnsafe => RC::NoRc,
+        StrSubstringUnsafe => RC::Rc,
         StrReserve => RC::Rc,
         StrAppendScalar => RC::Rc,
         StrGetScalarUnsafe => RC::NoRc,

--- a/crates/compiler/mono/src/inc_dec.rs
+++ b/crates/compiler/mono/src/inc_dec.rs
@@ -1292,7 +1292,7 @@ fn lowlevel_borrow_signature(arena: &Bump, op: LowLevel) -> &[Ownership] {
         StrGetUnsafe | ListGetUnsafe => arena.alloc_slice_copy(&[borrowed, irrelevant]),
         ListConcat => arena.alloc_slice_copy(&[owned, owned]),
         StrConcat => arena.alloc_slice_copy(&[owned, borrowed]),
-        StrSubstringUnsafe => arena.alloc_slice_copy(&[borrowed, irrelevant, irrelevant]),
+        StrSubstringUnsafe => arena.alloc_slice_copy(&[owned, irrelevant, irrelevant]),
         StrReserve => arena.alloc_slice_copy(&[owned, irrelevant]),
         StrAppendScalar => arena.alloc_slice_copy(&[owned, irrelevant]),
         StrGetScalarUnsafe => arena.alloc_slice_copy(&[borrowed, irrelevant]),


### PR DESCRIPTION
This is a huge perf gain. I had an app that took 5 seconds and spent almost 100% of the time in copying. Now it takes about 150ms.