### PR TITLE
Initial template for Zig glue 

### DIFF
--- a/crates/glue/src/ZigGlue.roc
+++ b/crates/glue/src/ZigGlue.roc
@@ -1,0 +1,27 @@
+app "zig-glue"
+    packages { pf: "../platform/main.roc" }
+    imports [
+        pf.Types.{ Types },
+        pf.File.{ File },
+        "../../compiler/builtins/bitcode/src/list.zig" as rocStdList : Str,
+    ]
+    provides [makeGlue] to pf
+
+makeGlue : List Types -> Result (List File) Str
+makeGlue = \typesByArch ->
+    typesByArch
+    |> List.map convertTypesToFile
+    |> List.concat staticFiles
+    |> Ok
+
+## These are always included, and don't depend on the specifics of the app.
+staticFiles : List File
+staticFiles = [
+    { name: "list.zig", content: rocStdList },
+]
+
+convertTypesToFile : Types -> File
+convertTypesToFile = \_ -> {
+    name: "glue.zig",
+    content: "// Nothing to see yet",
+}


### PR DESCRIPTION
This PR adds the initial template for a Zig glue implementation. Its purpose is to show put the basic parts together as a base to add additional functionality. 

Tested using `roc glue ../roc/crates/glue/src/ZigGlue.roc src/glue/ src/main.roc` with [ostcar/roc-wasi-platform](https://github.com/ostcar/roc-wasi-platform)