### PR TITLE
Fix format for the 'as' keyword

### DIFF
--- a/crates/compiler/fmt/src/spaces.rs
+++ b/crates/compiler/fmt/src/spaces.rs
@@ -5,8 +5,8 @@ use roc_parse::{
     ast::{
         AbilityImpls, AbilityMember, AssignedField, Collection, CommentOrNewline, Defs, Expr,
         Header, Implements, ImplementsAbilities, ImplementsAbility, ImplementsClause, Module,
-        Pattern, RecordBuilderField, Spaced, Spaces, StrLiteral, StrSegment, Tag, TypeAnnotation,
-        TypeDef, TypeHeader, ValueDef, WhenBranch,
+        Pattern, PatternAs, RecordBuilderField, Spaced, Spaces, StrLiteral, StrSegment, Tag,
+        TypeAnnotation, TypeDef, TypeHeader, ValueDef, WhenBranch,
     },
     header::{
         AppHeader, ExposedName, HostedHeader, ImportsEntry, InterfaceHeader, KeywordItem,
@@ -800,9 +800,10 @@ impl<'a> RemoveSpaces<'a> for Pattern<'a> {
             Pattern::OptionalField(a, b) => {
                 Pattern::OptionalField(a, arena.alloc(b.remove_spaces(arena)))
             }
-            Pattern::As(pattern, pattern_as) => {
-                Pattern::As(arena.alloc(pattern.remove_spaces(arena)), pattern_as)
-            }
+            Pattern::As(pattern, pattern_as) => Pattern::As(
+                arena.alloc(pattern.remove_spaces(arena)),
+                pattern_as.remove_spaces(arena),
+            ),
             Pattern::NumLiteral(a) => Pattern::NumLiteral(a),
             Pattern::NonBase10Literal {
                 string,
@@ -826,7 +827,10 @@ impl<'a> RemoveSpaces<'a> for Pattern<'a> {
             Pattern::SingleQuote(a) => Pattern::SingleQuote(a),
             Pattern::List(pats) => Pattern::List(pats.remove_spaces(arena)),
             Pattern::Tuple(pats) => Pattern::Tuple(pats.remove_spaces(arena)),
-            Pattern::ListRest(opt_pattern_as) => Pattern::ListRest(opt_pattern_as),
+            Pattern::ListRest(opt_pattern_as) => Pattern::ListRest(
+                opt_pattern_as
+                    .map(|(_, pattern_as)| ([].as_ref(), pattern_as.remove_spaces(arena))),
+            ),
         }
     }
 }
@@ -933,6 +937,15 @@ impl<'a> RemoveSpaces<'a> for ImplementsAbilities<'a> {
             }
             ImplementsAbilities::SpaceBefore(derived, _)
             | ImplementsAbilities::SpaceAfter(derived, _) => derived.remove_spaces(arena),
+        }
+    }
+}
+
+impl<'a> RemoveSpaces<'a> for PatternAs<'a> {
+    fn remove_spaces(&self, arena: &'a Bump) -> Self {
+        PatternAs {
+            spaces_before: &[],
+            identifier: self.identifier.remove_spaces(arena),
         }
     }
 }

--- a/crates/compiler/test_syntax/tests/test_fmt.rs
+++ b/crates/compiler/test_syntax/tests/test_fmt.rs
@@ -6003,6 +6003,33 @@ mod test_fmt {
         );
     }
 
+    #[test]
+    fn issue_6197() {
+        expr_formats_to(
+            indoc!(
+                r#"
+                when l1 is
+                    [
+                    .. 
+                    as
+                    rest
+                    ]
+                    as 
+                    l2
+                    ->
+                        f rest
+                "#
+            ),
+            indoc!(
+                r#"
+                when l1 is
+                    [.. as rest] as l2 ->
+                        f rest
+                "#
+            ),
+        );
+    }
+
     // this is a parse error atm
     //    #[test]
     //    fn multiline_apply() {


### PR DESCRIPTION
The `format` command was not handling `PatternAs`, so formatting was failing like in the issue below.

Closes https://github.com/roc-lang/roc/issues/6197