### PR TITLE
Cleanup list and str builtin naming from refcount to allocation

### DIFF
--- a/crates/compiler/builtins/bitcode/src/list.zig
+++ b/crates/compiler/builtins/bitcode/src/list.zig
@@ -21,16 +21,18 @@ const SEAMLESS_SLICE_BIT: usize =
 pub const RocList = extern struct {
     bytes: ?[*]u8,
     length: usize,
-    // This technically points to directly after the refcount.
-    // This is an optimization that enables use one code path for regular lists and slices for geting the refcount ptr.
-    capacity_or_ref_ptr: usize,
+    // For normal lists, contains the capacity.
+    // For seamless slices contains the pointer to the original allocation.
+    // This pointer is to the first element of the original list.
+    // Note we storing an allocation pointer, the pointer must be right shifted by one.
+    capacity_or_alloc_ptr: usize,
 
     pub inline fn len(self: RocList) usize {
         return self.length;
     }
 
     pub fn getCapacity(self: RocList) usize {
-        const list_capacity = self.capacity_or_ref_ptr;
+        const list_capacity = self.capacity_or_alloc_ptr;
         const slice_capacity = self.length;
         const slice_mask = self.seamlessSliceMask();
         const capacity = (list_capacity & ~slice_mask) | (slice_capacity & slice_mask);
@@ -38,14 +40,14 @@ pub const RocList = extern struct {
     }
 
     pub fn isSeamlessSlice(self: RocList) bool {
-        return @as(isize, @bitCast(self.capacity_or_ref_ptr)) < 0;
+        return @as(isize, @bitCast(self.capacity_or_alloc_ptr)) < 0;
     }
 
     // This returns all ones if the list is a seamless slice.
     // Otherwise, it returns all zeros.
     // This is done without branching for optimization purposes.
     pub fn seamlessSliceMask(self: RocList) usize {
-        return @as(usize, @bitCast(@as(isize, @bitCast(self.capacity_or_ref_ptr)) >> (@bitSizeOf(isize) - 1)));
+        return @as(usize, @bitCast(@as(isize, @bitCast(self.capacity_or_alloc_ptr)) >> (@bitSizeOf(isize) - 1)));
     }
 
     pub fn isEmpty(self: RocList) bool {
@@ -53,7 +55,7 @@ pub const RocList = extern struct {
     }
 
     pub fn empty() RocList {
-        return RocList{ .bytes = null, .length = 0, .capacity_or_ref_ptr = 0 };
+        return RocList{ .bytes = null, .length = 0, .capacity_or_alloc_ptr = 0 };
     }
 
     pub fn eql(self: RocList, other: RocList) bool {
@@ -99,21 +101,22 @@ pub const RocList = extern struct {
         return list;
     }
 
-    // returns a pointer to just after the refcount.
-    // It is just after the refcount as an optimization for other shared code paths.
-    // For regular list, it just returns their bytes pointer.
-    // For seamless slices, it returns the pointer stored in capacity_or_ref_ptr.
-    pub fn getRefcountPtr(self: RocList) ?[*]u8 {
-        const list_ref_ptr = @intFromPtr(self.bytes);
-        const slice_ref_ptr = self.capacity_or_ref_ptr << 1;
+    // returns a pointer to the original allocation.
+    // This pointer points to the first element of the allocation.
+    // The pointer is to just after the refcount.
+    // For big lists, it just returns their bytes pointer.
+    // For seamless slices, it returns the pointer stored in capacity_or_alloc_ptr.
+    pub fn getAllocationPtr(self: RocList) ?[*]u8 {
+        const list_alloc_ptr = @intFromPtr(self.bytes);
+        const slice_alloc_ptr = self.capacity_or_alloc_ptr << 1;
         const slice_mask = self.seamlessSliceMask();
-        const ref_ptr = (list_ref_ptr & ~slice_mask) | (slice_ref_ptr & slice_mask);
-        return @as(?[*]u8, @ptrFromInt(ref_ptr));
+        const alloc_ptr = (list_alloc_ptr & ~slice_mask) | (slice_alloc_ptr & slice_mask);
+        return @as(?[*]u8, @ptrFromInt(alloc_ptr));
     }
 
     pub fn decref(self: RocList, alignment: u32) void {
         // We use the raw capacity to ensure we always decrement the refcount of seamless slices.
-        utils.decref(self.getRefcountPtr(), self.capacity_or_ref_ptr, alignment);
+        utils.decref(self.getAllocationPtr(), self.capacity_or_alloc_ptr, alignment);
     }
 
     pub fn elements(self: RocList, comptime T: type) ?[*]T {
@@ -187,7 +190,7 @@ pub const RocList = extern struct {
         return RocList{
             .bytes = utils.allocateWithRefcount(data_bytes, alignment),
             .length = length,
-            .capacity_or_ref_ptr = capacity,
+            .capacity_or_alloc_ptr = capacity,
         };
     }
 
@@ -204,7 +207,7 @@ pub const RocList = extern struct {
         return RocList{
             .bytes = utils.allocateWithRefcount(data_bytes, alignment),
             .length = length,
-            .capacity_or_ref_ptr = length,
+            .capacity_or_alloc_ptr = length,
         };
     }
 
@@ -216,13 +219,13 @@ pub const RocList = extern struct {
     ) RocList {
         if (self.bytes) |source_ptr| {
             if (self.isUnique() and !self.isSeamlessSlice()) {
-                const capacity = self.capacity_or_ref_ptr;
+                const capacity = self.capacity_or_alloc_ptr;
                 if (capacity >= new_length) {
-                    return RocList{ .bytes = self.bytes, .length = new_length, .capacity_or_ref_ptr = capacity };
+                    return RocList{ .bytes = self.bytes, .length = new_length, .capacity_or_alloc_ptr = capacity };
                 } else {
                     const new_capacity = utils.calculateCapacity(capacity, new_length, element_width);
                     const new_source = utils.unsafeReallocate(source_ptr, alignment, capacity, new_capacity, element_width);
-                    return RocList{ .bytes = new_source, .length = new_length, .capacity_or_ref_ptr = new_capacity };
+                    return RocList{ .bytes = new_source, .length = new_length, .capacity_or_alloc_ptr = new_capacity };
                 }
             }
             return self.reallocateFresh(alignment, new_length, element_width);
@@ -500,8 +503,8 @@ pub fn listReleaseExcessCapacity(
     update_mode: UpdateMode,
 ) callconv(.C) RocList {
     const old_length = list.len();
-    // We use the direct list.capacity_or_ref_ptr to make sure both that there is no extra capacity and that it isn't a seamless slice.
-    if ((update_mode == .InPlace or list.isUnique()) and list.capacity_or_ref_ptr == old_length) {
+    // We use the direct list.capacity_or_alloc_ptr to make sure both that there is no extra capacity and that it isn't a seamless slice.
+    if ((update_mode == .InPlace or list.isUnique()) and list.capacity_or_alloc_ptr == old_length) {
         return list;
     } else if (old_length == 0) {
         list.decref(alignment);
@@ -649,14 +652,14 @@ pub fn listSublist(
             output.length = keep_len;
             return output;
         } else {
-            const list_ref_ptr = (@intFromPtr(source_ptr) >> 1) | SEAMLESS_SLICE_BIT;
-            const slice_ref_ptr = list.capacity_or_ref_ptr;
+            const list_alloc_ptr = (@intFromPtr(source_ptr) >> 1) | SEAMLESS_SLICE_BIT;
+            const slice_alloc_ptr = list.capacity_or_alloc_ptr;
             const slice_mask = list.seamlessSliceMask();
-            const ref_ptr = (list_ref_ptr & ~slice_mask) | (slice_ref_ptr & slice_mask);
+            const alloc_ptr = (list_alloc_ptr & ~slice_mask) | (slice_alloc_ptr & slice_mask);
             return RocList{
                 .bytes = source_ptr + start * element_width,
                 .length = keep_len,
-                .capacity_or_ref_ptr = ref_ptr,
+                .capacity_or_alloc_ptr = alloc_ptr,
             };
         }
     }
@@ -965,10 +968,10 @@ pub fn listCapacity(
     return list.getCapacity();
 }
 
-pub fn listRefcountPtr(
+pub fn listAllocationPtr(
     list: RocList,
 ) callconv(.C) ?[*]u8 {
-    return list.getRefcountPtr();
+    return list.getAllocationPtr();
 }
 
 test "listConcat: non-unique with unique overlapping" {

--- a/crates/compiler/builtins/bitcode/src/main.zig
+++ b/crates/compiler/builtins/bitcode/src/main.zig
@@ -76,7 +76,7 @@ comptime {
     exportListFn(list.listSwap, "swap");
     exportListFn(list.listIsUnique, "is_unique");
     exportListFn(list.listCapacity, "capacity");
-    exportListFn(list.listRefcountPtr, "refcount_ptr");
+    exportListFn(list.listAllocationPtr, "allocation_ptr");
     exportListFn(list.listReleaseExcessCapacity, "release_excess_capacity");
 }
 
@@ -218,7 +218,7 @@ comptime {
     exportStrFn(str.strCloneTo, "clone_to");
     exportStrFn(str.withCapacity, "with_capacity");
     exportStrFn(str.strGraphemes, "graphemes");
-    exportStrFn(str.strRefcountPtr, "refcount_ptr");
+    exportStrFn(str.strAllocationPtr, "allocation_ptr");
     exportStrFn(str.strReleaseExcessCapacity, "release_excess_capacity");
 
     inline for (INTEGERS) |T| {

--- a/crates/compiler/builtins/src/bitcode.rs
+++ b/crates/compiler/builtins/src/bitcode.rs
@@ -370,7 +370,7 @@ pub const STR_GET_SCALAR_UNSAFE: &str = "roc_builtins.str.get_scalar_unsafe";
 pub const STR_CLONE_TO: &str = "roc_builtins.str.clone_to";
 pub const STR_WITH_CAPACITY: &str = "roc_builtins.str.with_capacity";
 pub const STR_GRAPHEMES: &str = "roc_builtins.str.graphemes";
-pub const STR_REFCOUNT_PTR: &str = "roc_builtins.str.refcount_ptr";
+pub const STR_ALLOCATION_PTR: &str = "roc_builtins.str.allocation_ptr";
 pub const STR_RELEASE_EXCESS_CAPACITY: &str = "roc_builtins.str.release_excess_capacity";
 
 pub const LIST_MAP: &str = "roc_builtins.list.map";
@@ -390,7 +390,7 @@ pub const LIST_PREPEND: &str = "roc_builtins.list.prepend";
 pub const LIST_APPEND_UNSAFE: &str = "roc_builtins.list.append_unsafe";
 pub const LIST_RESERVE: &str = "roc_builtins.list.reserve";
 pub const LIST_CAPACITY: &str = "roc_builtins.list.capacity";
-pub const LIST_REFCOUNT_PTR: &str = "roc_builtins.list.refcount_ptr";
+pub const LIST_ALLOCATION_PTR: &str = "roc_builtins.list.allocation_ptr";
 pub const LIST_RELEASE_EXCESS_CAPACITY: &str = "roc_builtins.list.release_excess_capacity";
 
 pub const DEC_ABS: &str = "roc_builtins.dec.abs";

--- a/crates/compiler/gen_llvm/src/llvm/build_list.rs
+++ b/crates/compiler/gen_llvm/src/llvm/build_list.rs
@@ -450,7 +450,7 @@ pub(crate) fn list_capacity_or_ref_ptr<'ctx>(
 
 // Gets a pointer to just after the refcount for a list or seamless slice.
 // The value is just after the refcount so that normal lists and seamless slices can share code paths easily.
-pub(crate) fn list_refcount_ptr<'ctx>(
+pub(crate) fn list_allocation_ptr<'ctx>(
     env: &Env<'_, 'ctx, '_>,
     wrapper_struct: StructValue<'ctx>,
 ) -> PointerValue<'ctx> {
@@ -459,7 +459,7 @@ pub(crate) fn list_refcount_ptr<'ctx>(
         &[wrapper_struct],
         &[],
         BitcodeReturns::Basic,
-        bitcode::LIST_REFCOUNT_PTR,
+        bitcode::LIST_ALLOCATION_PTR,
     )
     .into_pointer_value()
 }
@@ -864,7 +864,7 @@ pub(crate) fn decref<'ctx>(
     wrapper_struct: StructValue<'ctx>,
     alignment: u32,
 ) {
-    let refcount_ptr = list_refcount_ptr(env, wrapper_struct);
+    let refcount_ptr = list_allocation_ptr(env, wrapper_struct);
 
     crate::llvm::refcounting::decref_pointer_check_null(env, refcount_ptr, alignment);
 }

--- a/crates/compiler/gen_llvm/src/llvm/build_str.rs
+++ b/crates/compiler/gen_llvm/src/llvm/build_str.rs
@@ -48,7 +48,7 @@ pub(crate) fn str_equal<'ctx>(
 
 // Gets a pointer to just after the refcount for a list or seamless slice.
 // The value is just after the refcount so that normal lists and seamless slices can share code paths easily.
-pub(crate) fn str_refcount_ptr<'ctx>(
+pub(crate) fn str_allocation_ptr<'ctx>(
     env: &Env<'_, 'ctx, '_>,
     value: BasicValueEnum<'ctx>,
 ) -> PointerValue<'ctx> {
@@ -57,7 +57,7 @@ pub(crate) fn str_refcount_ptr<'ctx>(
         &[value],
         &[],
         BitcodeReturns::Basic,
-        bitcode::STR_REFCOUNT_PTR,
+        bitcode::STR_ALLOCATION_PTR,
     )
     .into_pointer_value()
 }

--- a/crates/compiler/gen_llvm/src/llvm/refcounting.rs
+++ b/crates/compiler/gen_llvm/src/llvm/refcounting.rs
@@ -5,9 +5,9 @@ use crate::llvm::build::{
     add_func, cast_basic_basic, get_tag_id, tag_pointer_clear_tag_id, Env, FAST_CALL_CONV,
 };
 use crate::llvm::build_list::{
-    incrementing_elem_loop, list_capacity_or_ref_ptr, list_refcount_ptr, load_list,
+    incrementing_elem_loop, list_allocation_ptr, list_capacity_or_ref_ptr, load_list,
 };
-use crate::llvm::build_str::str_refcount_ptr;
+use crate::llvm::build_str::str_allocation_ptr;
 use crate::llvm::convert::{basic_type_from_layout, zig_str_type, RocUnion};
 use crate::llvm::struct_::RocStruct;
 use bumpalo::collections::Vec;
@@ -866,7 +866,7 @@ fn modify_refcount_list_help<'a, 'ctx>(
     }
 
     let refcount_ptr =
-        PointerToRefcount::from_ptr_to_data(env, list_refcount_ptr(env, original_wrapper));
+        PointerToRefcount::from_ptr_to_data(env, list_allocation_ptr(env, original_wrapper));
     let call_mode = mode_to_call_mode(fn_val, mode);
     refcount_ptr.modify(call_mode, layout, env, layout_interner);
 
@@ -973,7 +973,7 @@ fn modify_refcount_str_help<'a, 'ctx>(
     builder.new_build_conditional_branch(is_big_and_non_empty, modification_block, cont_block);
     builder.position_at_end(modification_block);
 
-    let refcount_ptr = PointerToRefcount::from_ptr_to_data(env, str_refcount_ptr(env, arg_val));
+    let refcount_ptr = PointerToRefcount::from_ptr_to_data(env, str_allocation_ptr(env, arg_val));
     let call_mode = mode_to_call_mode(fn_val, mode);
     refcount_ptr.modify(
         call_mode,


### PR DESCRIPTION
Trying to make naming more consistent and clearer here. Especially with some future planned changes, I think calling it the allocation pointer instead of the refcount pointer will help with some clarity. Also, remove all of the redundant `str_` prefixes.