### PR TITLE
add __udivti3 to must_keep

### DIFF
--- a/crates/compiler/gen_llvm/src/llvm/build.rs
+++ b/crates/compiler/gen_llvm/src/llvm/build.rs
@@ -1075,6 +1075,8 @@ pub fn module_from_builtins<'ctx>(
         // I have no idea why this function is special.
         // Without it, some tests hang on M1 mac outside of nix.
         "__muloti4",
+        // fixes `Undefined Symbol in relocation`
+        "__udivti3",
         // Roc special functions
         "__roc_force_longjmp",
         "__roc_force_setjmp",


### PR DESCRIPTION
Fixes:
```
thread 'main' panicked at 'Undefined Symbol in relocation, (+925, Relocation { kind: PltRelative, encoding: Generic, size: +20, target: Symbol(SymbolIndex(+5e)), addend: +fffffffffffffffc, implicit_addend: false }): Ok(Symbol { name: "__udivti3", address: +0, size: +0, kind: Label, section: Undefined, scope: Unknown, weak: false, flags: Elf { st_info: +10, st_other: +0 } })', crates/linker/src/elf.rs:1486:25
```