### PR TITLE
Improve handling of multi pattern unbound variables

### DIFF
--- a/crates/compiler/can/src/expr.rs
+++ b/crates/compiler/can/src/expr.rs
@@ -1597,7 +1597,8 @@ fn canonicalize_closure_body<'a>(
 enum MultiPatternVariables {
     OnePattern,
     MultiPattern {
-        bound_occurrences: VecMap<Symbol, (Region, u8)>,
+        num_patterns: usize,
+        bound_occurrences: VecMap<Symbol, (Region, usize)>,
     },
 }
 
@@ -1606,7 +1607,8 @@ impl MultiPatternVariables {
     fn new(num_patterns: usize) -> Self {
         if num_patterns > 1 {
             Self::MultiPattern {
-                bound_occurrences: VecMap::with_capacity(2),
+                num_patterns,
+                bound_occurrences: VecMap::with_capacity(num_patterns),
             }
         } else {
             Self::OnePattern
@@ -1617,7 +1619,9 @@ impl MultiPatternVariables {
     fn add_pattern(&mut self, pattern: &Loc<Pattern>) {
         match self {
             MultiPatternVariables::OnePattern => {}
-            MultiPatternVariables::MultiPattern { bound_occurrences } => {
+            MultiPatternVariables::MultiPattern {
+                bound_occurrences, ..
+            } => {
                 for (sym, region) in BindingsFromPattern::new(pattern) {
                     if !bound_occurrences.contains_key(&sym) {
                         bound_occurrences.insert(sym, (region, 0));
@@ -1630,15 +1634,18 @@ impl MultiPatternVariables {
 
     #[inline(always)]
     fn get_unbound(self) -> impl Iterator<Item = (Symbol, Region)> {
-        let bound_occurrences = match self {
-            MultiPatternVariables::OnePattern => Default::default(),
-            MultiPatternVariables::MultiPattern { bound_occurrences } => bound_occurrences,
+        let (bound_occurrences, num_patterns) = match self {
+            MultiPatternVariables::OnePattern => (Default::default(), 1),
+            MultiPatternVariables::MultiPattern {
+                bound_occurrences,
+                num_patterns,
+            } => (bound_occurrences, num_patterns),
         };
 
         bound_occurrences
             .into_iter()
-            .filter_map(|(sym, (region, occurs))| {
-                if occurs == 1 {
+            .filter_map(move |(sym, (region, occurs))| {
+                if occurs != num_patterns {
                     Some((sym, region))
                 } else {
                     None

--- a/crates/compiler/load/tests/test_reporting.rs
+++ b/crates/compiler/load/tests/test_reporting.rs
@@ -10221,6 +10221,28 @@ In roc, functions are always written as a lambda, like{}
     );
 
     test_report!(
+        issue_6279,
+        indoc!(
+            r#"
+            when A "" is
+                A x | B x | C -> x
+            "#
+        ),
+        @r###"
+        ── NAME NOT BOUND IN ALL PATTERNS in /code/proj/Main.roc ───────────────────────
+
+        `x` is not bound in all patterns of this `when` branch
+
+        5│          A x | B x | C -> x
+                      ^
+
+        Identifiers introduced in a `when` branch must be bound in all patterns
+        of the branch. Otherwise, the program would crash when it tries to use
+        an identifier that wasn't bound!
+        "###
+    );
+
+    test_report!(
         flip_flop_catch_all_branches_not_exhaustive,
         indoc!(
             r#"


### PR DESCRIPTION
Without this change, errors are only being caught when a variable is bound in exactly one of the patterns.

Closes https://github.com/roc-lang/roc/issues/6279