### PR TITLE
Add install docs for nix + fix `nix run` for using the roc cli 

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,4 @@
-{ ... }: (import
+(import
   (
     let lock = builtins.fromJSON (builtins.readFile ./flake.lock);
     in fetchTarball {

--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,4 @@
-(import
+{ ... }: (import
   (
     let lock = builtins.fromJSON (builtins.readFile ./flake.lock);
     in fetchTarball {

--- a/flake.nix
+++ b/flake.nix
@@ -148,5 +148,12 @@
           cli = rocBuild.roc-cli;
           lang-server = rocBuild.roc-lang-server;
         };
+
+        apps = {
+          default = {
+            type = "app";
+            program = "${rocBuild.roc-cli}/bin/roc";
+          };
+        };
       });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -27,11 +27,16 @@
   };
 
   outputs = { self, nixpkgs, rust-overlay, flake-utils, nixgl, ... }@inputs:
-    let supportedSystems = [ "x86_64-linux" "x86_64-darwin" "aarch64-darwin" "aarch64-linux" ];
-    in flake-utils.lib.eachSystem supportedSystems (system:
+    let
+      supportedSystems = [ "x86_64-linux" "x86_64-darwin" "aarch64-darwin" "aarch64-linux" ];
+
+      templates = import ./nix/templates { };
+    in
+    { inherit templates; } //
+    flake-utils.lib.eachSystem supportedSystems (system:
       let
         overlays = [ (import rust-overlay) ]
-          ++ (if system == "x86_64-linux" then [ nixgl.overlay ] else [ ]);
+        ++ (if system == "x86_64-linux" then [ nixgl.overlay ] else [ ]);
         pkgs = import nixpkgs { inherit system overlays; };
 
         rocBuild = import ./nix { inherit pkgs; };
@@ -105,7 +110,7 @@
 
         devShell = pkgs.mkShell {
           buildInputs = sharedInputs ++ sharedDevInputs ++ darwinInputs ++ darwinDevInputs ++ linuxDevInputs
-            ++ (if system == "x86_64-linux" then
+          ++ (if system == "x86_64-linux" then
             [ pkgs.nixgl.nixVulkanIntel ]
           else
             [ ]);
@@ -121,7 +126,7 @@
           LD_LIBRARY_PATH = with pkgs;
             lib.makeLibraryPath
               ([ pkg-config stdenv.cc.cc.lib libffi ncurses zlib ]
-                ++ linuxDevInputs);
+              ++ linuxDevInputs);
           NIXPKGS_ALLOW_UNFREE =
             1; # to run the GUI examples with NVIDIA's closed source drivers
 

--- a/getting_started/README.md
+++ b/getting_started/README.md
@@ -11,6 +11,7 @@ If you have a specific question, the [FAQ](../FAQ.md) might have an answer, alth
 ## Installation
 
 - [🐧 Linux x86_64](linux_x86_64.md)
+- [❄️ Nix Linux/MacOS](nix.md)
 - [🍏 MacOS Apple Silicon](macos_apple_silicon.md)
 - [🍏 MacOS x86_64](macos_x86_64.md)
 - [🟦 Windows](windows.md)

--- a/getting_started/nix.md
+++ b/getting_started/nix.md
@@ -1,11 +1,10 @@
 # Roc installation guide for Nix
 
-If you want to quickly get started you can do
+To quickly try out roc, use `nix run`
 ```shell
 nix run roc-lang/roc -- <roc args>
 # example nix run roc-lang/roc -- repl
 ```
-to try out roc!
 
 <details>
 <summary>
@@ -25,14 +24,15 @@ nix flake init --template github:roc-lang/roc#simple --refresh
 ```nix
 {
     inputs = {
+        nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+        flake-utils.url = "github:numtide/flake-utils";
         roc.url = "github:roc-lang/roc";
     };
 
-    outputs = {roc,flake-utils, ...}:
+    outputs = {nixpkgs, roc, flake-utils, ...}:
         flake-utils.lib.eachDefaultSystem (system:
             let
             pkgs = import nixpkgs { inherit system; };
-
             rocPkgs = roc.packages.${system};
             in
             {
@@ -48,6 +48,5 @@ nix flake init --template github:roc-lang/roc#simple --refresh
         );
 }
 ```
-
 
 </details>

--- a/getting_started/nix.md
+++ b/getting_started/nix.md
@@ -1,7 +1,11 @@
 # Roc installation guide for Nix
 
-
-## NixOS quick start
+If you want to quickly get started you can do
+```shell
+nix run roc-lang/roc -- <roc args>
+# example nix run roc-lang/roc -- repl
+```
+to try out roc!
 
 <details>
 <summary>

--- a/getting_started/nix.md
+++ b/getting_started/nix.md
@@ -1,15 +1,17 @@
-# Roc installation guide for Nix
+## Try out
 
-To quickly try out roc, use `nix run`
+To quickly try out roc without installing, use `nix run`:
 ```shell
 nix run roc-lang/roc -- <roc args>
-# example nix run roc-lang/roc -- repl
+# examples:
+# - nix run roc-lang/roc -- repl
+# - nix run roc-lang/roc -- dev main.roc
 ```
 
-## Install via Flakes
+## Use with Flakes
 
 
-### Bootstrap a project with a template
+### Start your project with our template
 
 ```shell
 # use the template in the current directory
@@ -28,8 +30,8 @@ nix flake init --template github:roc-lang/roc#simple --refresh
     outputs = {nixpkgs, roc, flake-utils, ...}:
         flake-utils.lib.eachDefaultSystem (system:
             let
-            pkgs = import nixpkgs { inherit system; };
-            rocPkgs = roc.packages.${system};
+                pkgs = import nixpkgs { inherit system; };
+                rocPkgs = roc.packages.${system};
             in
             {
                 devShells = {
@@ -44,5 +46,3 @@ nix flake init --template github:roc-lang/roc#simple --refresh
         );
 }
 ```
-
-</details>

--- a/getting_started/nix.md
+++ b/getting_started/nix.md
@@ -6,12 +6,8 @@ nix run roc-lang/roc -- <roc args>
 # example nix run roc-lang/roc -- repl
 ```
 
-<details>
-<summary>
-
 ## Install via Flakes
 
-</summary>
 
 ### Bootstrap a project with a template
 

--- a/getting_started/nix.md
+++ b/getting_started/nix.md
@@ -1,0 +1,49 @@
+# Roc installation guide for Nix
+
+
+## NixOS quick start
+
+<details>
+<summary>
+
+## Install via Flakes
+
+</summary>
+
+### Bootstrap a project with a template
+
+```shell
+# use the template in the current directory
+nix flake init --template github:roc-lang/roc#simple --refresh
+```
+
+### Add roc to existing flake
+```nix
+{
+    inputs = {
+        roc.url = "github:roc-lang/roc";
+    };
+
+    outputs = {roc,flake-utils, ...}:
+        flake-utils.lib.eachDefaultSystem (system:
+            let
+            pkgs = import nixpkgs { inherit system; };
+
+            rocPkgs = roc.packages.${system};
+            in
+            {
+                devShells = {
+                    default = pkgs.mkShell {
+                        buildInputs = with pkgs;
+                        [
+                            rocPkgs.cli
+                        ];
+                    };
+                };
+            }
+        );
+}
+```
+
+
+</details>

--- a/nix/builder.nix
+++ b/nix/builder.nix
@@ -3,6 +3,8 @@ let
   inherit (compile-deps) zigPkg llvmPkgs llvmVersion llvmMajorMinorStr glibcPath libGccSPath;
 
   subPackagePath = if subPackage != null then "crates/${subPackage}" else null;
+
+  mainBin = if subPackage == "lang_srv" then "roc_ls" else "roc";
 in
 rustPlatform.buildRustPackage {
   pname = "roc" + lib.optionalString (subPackage != null) "_${subPackage}";
@@ -84,4 +86,11 @@ rustPlatform.buildRustPackage {
         ${wrapRoc}
       fi
     '';
+
+  # https://ryantm.github.io/nixpkgs/stdenv/meta/
+  meta = {
+    homepage = "https://www.roc-lang.org/";
+    license = lib.licenses.upl;
+    mainProgram = mainBin;
+  };
 }

--- a/nix/templates/default.nix
+++ b/nix/templates/default.nix
@@ -1,4 +1,5 @@
-{ ... }: {
+{ ... }: rec {
+  default = simple;
   simple = {
     description = "Basic flake with roc cli + lsp";
     path = ./simple;

--- a/nix/templates/default.nix
+++ b/nix/templates/default.nix
@@ -1,6 +1,6 @@
 { ... }: {
   simple = {
     description = "Basic flake with roc cli + lsp";
-    path = ./simple.nix;
+    path = ./simple;
   };
 }

--- a/nix/templates/default.nix
+++ b/nix/templates/default.nix
@@ -1,0 +1,6 @@
+{ ... }: {
+  simple = {
+    description = "Basic flake with roc cli + lsp";
+    path = ./simple.nix;
+  };
+}

--- a/nix/templates/simple/flake.nix
+++ b/nix/templates/simple/flake.nix
@@ -1,4 +1,6 @@
 {
+  description = "Roc flake template";
+
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
@@ -10,6 +12,7 @@
       let
         pkgs = import nixpkgs { inherit system; };
 
+        # see "packages =" in https://github.com/roc-lang/roc/blob/main/flake.nix
         rocPkgs = roc.packages.${system};
 
         rocFull = rocPkgs.full;
@@ -22,10 +25,10 @@
           default = pkgs.mkShell {
             buildInputs = with pkgs;
               [
-                rocFull # cli included in here
+                rocFull # includes CLI
               ];
 
-            # ROC_LSP_PATH will be read by https://github.com/ivan-demchenko/roc-vscode-unofficial
+            # For vscode plugin https://github.com/ivan-demchenko/roc-vscode-unofficial
             shellHook = ''
               export ROC_LSP_PATH=${rocFull}/bin/roc_ls
             '';

--- a/nix/templates/simple/flake.nix
+++ b/nix/templates/simple/flake.nix
@@ -1,0 +1,34 @@
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    roc.url = "github:roc-lang/roc";
+  };
+
+  outputs = { self, nixpkgs, flake-utils, roc, roc2nix, ... }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+
+        rocPkgs = roc.packages.${system};
+
+        rocFull = rocPkgs.full;
+
+      in
+      {
+        formatter = pkgs.nixpkgs-fmt;
+
+        devShells = {
+          default = pkgs.mkShell {
+            buildInputs = with pkgs;
+              [
+                rocFull # cli included in here
+              ];
+
+            shellHook = ''
+              export ROC_LSP_PATH=${rocFull}/bin/roc_ls
+            '';
+          };
+        };
+      });
+}

--- a/nix/templates/simple/flake.nix
+++ b/nix/templates/simple/flake.nix
@@ -25,6 +25,7 @@
                 rocFull # cli included in here
               ];
 
+            # ROC_LSP_PATH will be read by https://github.com/ivan-demchenko/roc-vscode-unofficial
             shellHook = ''
               export ROC_LSP_PATH=${rocFull}/bin/roc_ls
             '';

--- a/nix/templates/simple/flake.nix
+++ b/nix/templates/simple/flake.nix
@@ -5,7 +5,7 @@
     roc.url = "github:roc-lang/roc";
   };
 
-  outputs = { self, nixpkgs, flake-utils, roc, roc2nix, ... }:
+  outputs = { self, nixpkgs, flake-utils, roc, ... }:
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = import nixpkgs { inherit system; };

--- a/www/content/install.md
+++ b/www/content/install.md
@@ -5,7 +5,7 @@ Roc is a very young language with many incomplete features and known bugs. It do
 There are currently a few known OS-specific issues:
 * **macOS:** There are no known compatibility issues, but the compiler doesn't run as fast as it does on Linux or Windows, because we don't (yet) do our own linking like we do on those targets. (Linking works similarly on Linux and Windows, but the way macOS does it is both different and significantly more complicated.)
 * **Windows:** There are some known Windows-specific compiler bugs, and probably some other unknown ones because more people have tried out Roc on Mac and Linux than on Windows.
-* **Linux:** The nightlies are built with glibc, so they aren't usable on distros that don't use (dynamically linked) glibc, like Alpine or NixOS. In the future we plan to build Linux releases with [musl libc](https://wiki.musl-libc.org/) to address this, but this requires [building LLVM from source with musl](https://wiki.musl-libc.org/building-llvm.html).
+* **Linux:** The nightlies are built with glibc, so they aren't usable on distros that don't use (dynamically linked) glibc, like Alpine. In the future we plan to build Linux releases with [musl libc](https://wiki.musl-libc.org/) to address this, but this requires [building LLVM from source with musl](https://wiki.musl-libc.org/building-llvm.html).
 * **Other operating systems:** Roc has not been built on any other operating systems. [Building from source](https://github.com/roc-lang/roc/blob/main/BUILDING_FROM_SOURCE.md) on another OS might work, but you might very well be the first person ever to try it!
 
 ### [Getting Started](#getting-started) {#getting-started}
@@ -14,6 +14,7 @@ Here are some Getting Started guides for different operating systems:
 <!-- TODO detect current OS with browser and only show link for that, provide other button for others  -->
 
 - [Linux x86-64](https://github.com/roc-lang/roc/blob/main/getting_started/linux_x86_64.md)
+- [Nix Linux/MacOS](https://github.com/roc-lang/roc/blob/main/getting_started/nix.md)
 - [MacOS Apple Silicon](https://github.com/roc-lang/roc/blob/main/getting_started/macos_apple_silicon.md)
 - [MacOS x86-64](https://github.com/roc-lang/roc/blob/main/getting_started/macos_x86_64.md)
 - [Windows](https://github.com/roc-lang/roc/blob/main/getting_started/windows.md)

--- a/www/content/install.md
+++ b/www/content/install.md
@@ -5,7 +5,7 @@ Roc is a very young language with many incomplete features and known bugs. It do
 There are currently a few known OS-specific issues:
 * **macOS:** There are no known compatibility issues, but the compiler doesn't run as fast as it does on Linux or Windows, because we don't (yet) do our own linking like we do on those targets. (Linking works similarly on Linux and Windows, but the way macOS does it is both different and significantly more complicated.)
 * **Windows:** There are some known Windows-specific compiler bugs, and probably some other unknown ones because more people have tried out Roc on Mac and Linux than on Windows.
-* **Linux:** The nightlies are built with glibc, so they aren't usable on distros that don't use (dynamically linked) glibc, like Alpine. In the future we plan to build Linux releases with [musl libc](https://wiki.musl-libc.org/) to address this, but this requires [building LLVM from source with musl](https://wiki.musl-libc.org/building-llvm.html).
+* **Linux:** The nightlies are built with glibc, so they aren't usable on distros that don't use glibc, like Alpine. In the future we plan to build Linux releases with [musl libc](https://wiki.musl-libc.org/) to address this, but this requires [building LLVM from source with musl](https://wiki.musl-libc.org/building-llvm.html).
 * **Other operating systems:** Roc has not been built on any other operating systems. [Building from source](https://github.com/roc-lang/roc/blob/main/BUILDING_FROM_SOURCE.md) on another OS might work, but you might very well be the first person ever to try it!
 
 ### [Getting Started](#getting-started) {#getting-started}


### PR DESCRIPTION
I updated the install docs to call out nix specially. To make onboarding easier I added a flake template which people can use to boilerplate out a new roc project with nix.

I also fixed https://github.com/roc-lang/roc/issues/6148 so people can do `nix run github:roc-lang/roc -- <roc_cli_args>` to play with roc easily.

There is still the issue of the nightly binary not working on nixos but using `steam-run` works for some people. I had mixed results, on my laptop it worked but on my desktop it did not. 

I think if we add a ci job to push the cli build to a public cachix and then have users run `cachix use <roc-cache>` they won't need to build from source as often