### PR TITLE
fix file not found in website build script

### DIFF
--- a/www/build.sh
+++ b/www/build.sh
@@ -111,7 +111,7 @@ rm -rf ./downloaded-basic-cli
 
 git clone --depth 1 https://github.com/roc-lang/basic-cli.git downloaded-basic-cli
 
-cargo run --bin roc-docs downloaded-basic-cli/src/main.roc
+cargo run --bin roc-docs downloaded-basic-cli/platform/main.roc
 
 rm -rf ./downloaded-basic-cli
 


### PR DESCRIPTION
This was caused by https://github.com/roc-lang/basic-cli/pull/144

Old error:
```
 + cargo run --bin roc-docs downloaded-basic-cli/src/main.roc
   Compiling roc_docs_cli v0.0.1 (/Users/m1ci/actions-runner2/_work/roc/roc/crates/docs_cli)
    Finished dev [unoptimized + debuginfo] target(s) in 2.67s
     Running `target/debug/roc-docs downloaded-basic-cli/src/main.roc`
── FILE NOT FOUND ──────────────────────────────────────────────── UNKNOWN.roc ─

I am looking for this file, but it's not there:

    downloaded-basic-cli/src/main.roc

Is the file supposed to be there? Maybe there is a typo in the file
name?
```