### PR TITLE
fix clippy (1.72.1) unnecessary hashes

### DIFF
--- a/crates/compiler/can/tests/test_can.rs
+++ b/crates/compiler/can/tests/test_can.rs
@@ -280,12 +280,12 @@ mod test_can {
     #[test]
     fn correct_annotated_body() {
         let src = indoc!(
-            r#"
+            r"
                 f : Num.Int * -> Num.Int *
                 f = \ a -> a
 
                 f
-            "#
+            "
         );
         let arena = Bump::new();
         let CanExprOut { problems, .. } = can_expr_with(&arena, test_home(), src);
@@ -296,12 +296,12 @@ mod test_can {
     #[test]
     fn correct_annotated_body_with_comments() {
         let src = indoc!(
-            r#"
+            r"
                 f : Num.Int * -> Num.Int * # comment
                 f = \ a -> a
 
                 f
-            "#
+            "
         );
         let arena = Bump::new();
         let CanExprOut { problems, .. } = can_expr_with(&arena, test_home(), src);
@@ -312,12 +312,12 @@ mod test_can {
     #[test]
     fn name_mismatch_annotated_body() {
         let src = indoc!(
-            r#"
+            r"
                 f : Num.Int * -> Num.Int *
                 g = \ a -> a
 
                 g
-            "#
+            "
         );
         let arena = Bump::new();
         let CanExprOut { problems, .. } = can_expr_with(&arena, test_home(), src);
@@ -340,12 +340,12 @@ mod test_can {
     #[test]
     fn name_mismatch_annotated_body_with_comment() {
         let src = indoc!(
-            r#"
+            r"
                 f : Num.Int * -> Num.Int * # comment
                 g = \ a -> a
 
                 g
-            "#
+            "
         );
         let arena = Bump::new();
         let CanExprOut { problems, .. } = can_expr_with(&arena, test_home(), src);
@@ -368,13 +368,13 @@ mod test_can {
     #[test]
     fn separated_annotated_body() {
         let src = indoc!(
-            r#"
+            r"
                 f : Num.Int * -> Num.Int *
 
                 f = \ a -> a
 
                 f 42
-            "#
+            "
         );
         let arena = Bump::new();
         let CanExprOut { problems, .. } = can_expr_with(&arena, test_home(), src);
@@ -389,13 +389,13 @@ mod test_can {
     #[test]
     fn separated_annotated_body_with_comment() {
         let src = indoc!(
-            r#"
+            r"
                 f : Num.Int * -> Num.Int *
                 # comment
                 f = \ a -> a
 
                 f 42
-            "#
+            "
         );
         let arena = Bump::new();
         let CanExprOut { problems, .. } = can_expr_with(&arena, test_home(), src);
@@ -410,13 +410,13 @@ mod test_can {
     #[test]
     fn shadowed_annotation() {
         let src = indoc!(
-            r#"
+            r"
                 f : Num.Int * -> Num.Int *
 
                 f : Num.Int * -> Num.Int *
 
                 f
-            "#
+            "
         );
         let arena = Bump::new();
         let CanExprOut { problems, .. } = can_expr_with(&arena, test_home(), src);
@@ -432,7 +432,7 @@ mod test_can {
     #[test]
     fn correct_nested_unannotated_body() {
         let src = indoc!(
-            r#"
+            r"
                 f : Num.Int *
                 f =
                     g = 42
@@ -440,7 +440,7 @@ mod test_can {
                     g + 1
 
                 f
-            "#
+            "
         );
         let arena = Bump::new();
         let CanExprOut { problems, .. } = can_expr_with(&arena, test_home(), src);
@@ -451,7 +451,7 @@ mod test_can {
     #[test]
     fn correct_nested_annotated_body() {
         let src = indoc!(
-            r#"
+            r"
                 f : Num.Int *
                 f =
                     g : Num.Int *
@@ -460,7 +460,7 @@ mod test_can {
                     g + 1
 
                 f
-            "#
+            "
         );
         let arena = Bump::new();
         let CanExprOut { problems, .. } = can_expr_with(&arena, test_home(), src);
@@ -471,7 +471,7 @@ mod test_can {
     #[test]
     fn correct_nested_body_annotated_multiple_lines() {
         let src = indoc!(
-            r#"
+            r"
                 f : Num.Int *
                 f =
                     g : Num.Int *
@@ -482,7 +482,7 @@ mod test_can {
                     g + h + z
 
                 f
-            "#
+            "
         );
         let arena = Bump::new();
         let CanExprOut { problems, .. } = can_expr_with(&arena, test_home(), src);
@@ -493,7 +493,7 @@ mod test_can {
     #[test]
     fn correct_nested_body_unannotated_multiple_lines() {
         let src = indoc!(
-            r#"
+            r"
                 f : Num.Int *
                 f =
                     g = 42
@@ -503,7 +503,7 @@ mod test_can {
                     g + h + z
 
                 f
-            "#
+            "
         );
         let arena = Bump::new();
         let CanExprOut { problems, .. } = can_expr_with(&arena, test_home(), src);
@@ -513,7 +513,7 @@ mod test_can {
     #[test]
     fn correct_double_nested_body() {
         let src = indoc!(
-            r#"
+            r"
                 f : Num.Int *
                 f =
                     g =
@@ -523,7 +523,7 @@ mod test_can {
 
 
                 f
-            "#
+            "
         );
         let arena = Bump::new();
         let CanExprOut { problems, .. } = can_expr_with(&arena, test_home(), src);
@@ -534,13 +534,13 @@ mod test_can {
     #[test]
     fn annotation_followed_with_unrelated_affectation() {
         let src = indoc!(
-            r#"
+            r"
                 F : Str
 
                 x = 1
 
                 x
-            "#
+            "
         );
         let arena = Bump::new();
         let CanExprOut { problems, .. } = can_expr_with(&arena, test_home(), src);
@@ -554,7 +554,7 @@ mod test_can {
     #[test]
     fn two_annotations_followed_with_unrelated_affectation() {
         let src = indoc!(
-            r#"
+            r"
                 G : Str
 
                 F : {}
@@ -562,7 +562,7 @@ mod test_can {
                 x = 1
 
                 x
-            "#
+            "
         );
         let arena = Bump::new();
         let CanExprOut { problems, .. } = can_expr_with(&arena, test_home(), src);
@@ -581,11 +581,11 @@ mod test_can {
     //     // it only exists in the closure's arguments.
     //     let arena = Bump::new();
     //     let src = indoc!(
-    //         r#"
+    //         r"
     //         func = \arg -> arg
 
     //         func 2
-    //     "#
+    //     "
     //     );
     //     let (_actual, output, problems, _var_store, _vars, _constraint) =
     //         can_expr_with(&arena, test_home(), src);
@@ -608,13 +608,13 @@ mod test_can {
     // fn call_by_pointer_for_fn_args() {
     //     // This function will get passed in as a pointer.
     //     let src = indoc!(
-    //         r#"
+    //         r"
     //         apply = \f, x -> f x
 
     //         identity = \a -> a
 
     //         apply identity 5
-    //     "#
+    //     "
     //     );
     //     let arena = Bump::new();
     //     let (_actual, output, problems, _var_store, _vars, _constraint) =
@@ -637,9 +637,9 @@ mod test_can {
     #[test]
     fn incorrect_optional_value() {
         let src = indoc!(
-            r#"
+            r"
                 { x ? 42 }
-            "#
+            "
         );
         let arena = Bump::new();
         let CanExprOut {
@@ -911,7 +911,7 @@ mod test_can {
     #[test]
     fn recognize_tail_calls() {
         let src = indoc!(
-            r#"
+            r"
                 g = \x ->
                     when x is
                         0 -> 0
@@ -936,7 +936,7 @@ mod test_can {
                         { x: p, y: h }
                     )
                 )
-            "#
+            "
         );
         let arena = Bump::new();
         let CanExprOut {
@@ -963,7 +963,7 @@ mod test_can {
     // #[test]
     // fn reproduce_incorrect_unused_defs() {
     //     let src = indoc!(
-    //         r#"
+    //         r"
     //             g = \x ->
     //                 when x is
     //                     0 -> 0
@@ -983,7 +983,7 @@ mod test_can {
     //             # variables must be (indirectly) referenced in the body for analysis to work
     //             # { x: p, y: h }
     //             g
-    //         "#
+    //         "
     //     );
     //     let arena = Bump::new();
     //     let CanExprOut {
@@ -1012,14 +1012,14 @@ mod test_can {
     #[test]
     fn when_tail_call() {
         let src = indoc!(
-            r#"
+            r"
                 g = \x ->
                     when x is
                         0 -> 0
                         _ -> g (x + 1)
 
                 g 0
-            "#
+            "
         );
         let arena = Bump::new();
         let CanExprOut {
@@ -1034,11 +1034,11 @@ mod test_can {
     #[test]
     fn immediate_tail_call() {
         let src = indoc!(
-            r#"
+            r"
                 f = \x -> f x
 
                 f 0
-            "#
+            "
         );
         let arena = Bump::new();
         let CanExprOut {
@@ -1055,13 +1055,13 @@ mod test_can {
     #[test]
     fn when_condition_is_no_tail_call() {
         let src = indoc!(
-            r#"
+            r"
             q = \x ->
                     when q x is
                         _ -> 0
 
             q 0
-        "#
+        "
         );
         let arena = Bump::new();
         let CanExprOut {
@@ -1076,7 +1076,7 @@ mod test_can {
     #[test]
     fn good_mutual_recursion() {
         let src = indoc!(
-            r#"
+            r"
                 q = \x ->
                         when x is
                             0 -> 0
@@ -1088,7 +1088,7 @@ mod test_can {
                             _ -> q (x - 1)
 
                 q p
-            "#
+            "
         );
         let arena = Bump::new();
         let CanExprOut {
@@ -1107,11 +1107,11 @@ mod test_can {
     #[test]
     fn valid_self_recursion() {
         let src = indoc!(
-            r#"
+            r"
                 boom = \_ -> boom {}
 
                 boom
-            "#
+            "
         );
         let arena = Bump::new();
         let CanExprOut {
@@ -1128,13 +1128,13 @@ mod test_can {
     #[test]
     fn invalid_mutual_recursion() {
         let src = indoc!(
-            r#"
+            r"
                 x = y
                 y = z
                 z = x
 
                 x
-            "#
+            "
         );
         let home = test_home();
         let arena = Bump::new();
@@ -1176,11 +1176,11 @@ mod test_can {
     #[test]
     fn dict() {
         let src = indoc!(
-            r#"
+            r"
                 x = Dict.empty {}
 
                 Dict.len x
-            "#
+            "
         );
         let arena = Bump::new();
         let CanExprOut { problems, .. } = can_expr_with(&arena, test_home(), src);
@@ -1191,7 +1191,7 @@ mod test_can {
     #[test]
     fn unused_def_regression() {
         let src = indoc!(
-            r#"
+            r"
                 Booly : [Yes, No, Maybe]
 
                 y : Booly
@@ -1205,7 +1205,7 @@ mod test_can {
                 x = [y]
 
                 x
-            "#
+            "
         );
         let arena = Bump::new();
         let CanExprOut { problems, .. } = can_expr_with(&arena, test_home(), src);
@@ -1216,14 +1216,14 @@ mod test_can {
     #[test]
     fn optional_field_not_unused() {
         let src = indoc!(
-            r#"
+            r"
                 fallbackZ = 3
 
                 fn = \{ x, y, z ? fallbackZ } ->
                     { x, y, z }
 
                 fn { x: 0, y: 1 }
-            "#
+            "
         );
         let arena = Bump::new();
         let CanExprOut { problems, .. } = can_expr_with(&arena, test_home(), src);
@@ -1234,12 +1234,12 @@ mod test_can {
     #[test]
     fn issue_2534() {
         let src = indoc!(
-            r#"
+            r"
             x = { a: 1 }
             {
                 x & a: 2
             }
-            "#
+            "
         );
         let arena = Bump::new();
         let CanExprOut { problems, .. } = can_expr_with(&arena, test_home(), src);
@@ -1252,13 +1252,13 @@ mod test_can {
     //    // "local" should be used, because the closure used it.
     //    // However, "unused" should be unused.
     //    let (_, output, problems, _) = can_expr(indoc!(
-    //        r#"
+    //        r"
     //        local = 5
     //        unused = 6
     //        func = \arg -> arg + local
 
     //        3 + func 2
-    //    "#
+    //    "
     //    ));
 
     //    assert_eq!(
@@ -1283,13 +1283,13 @@ mod test_can {
     //fn unused_closure() {
     //    // "unused" should be unused because it's in func, which is unused.
     //    let (_, output, problems, _) = can_expr(indoc!(
-    //        r#"
+    //        r"
     //        local = 5
     //        unused = 6
     //        func = \arg -> arg + unused
 
     //        local
-    //    "#
+    //    "
     //    ));
 
     //    assert_eq!(
@@ -1316,9 +1316,9 @@ mod test_can {
     //     #[test]
     //     fn basic_unrecognized_constant() {
     //         let (expr, output, problems, _) = can_expr(indoc!(
-    //             r#"
+    //             r"
     //             x
-    //         "#
+    //         "
     //         ));
 
     //         assert_eq!(
@@ -1342,12 +1342,12 @@ mod test_can {
     //#[test]
     //fn complex_unrecognized_constant() {
     //    let (_, output, problems, _) = can_expr(indoc!(
-    //        r#"
+    //        r"
     //        a = 5
     //        b = 6
 
     //        a + b * z
-    //    "#
+    //    "
     //    ));
 
     //    assert_eq!(
@@ -1375,13 +1375,13 @@ mod test_can {
     //    // This should report that both a and b are unused, since the return expr never references them.
     //    // It should not report them as circular, since we haven't solved the halting problem here.
     //    let (_, output, problems, _) = can_expr(indoc!(
-    //        r#"
+    //        r"
     //        a = \arg -> if arg > 0 then b 7 else 0
     //        b = \arg -> if arg > 0 then a (arg - 1) else 0
     //        c = 5
 
     //        c
-    //    "#
+    //    "
     //    ));
 
     //    assert_eq!(problems, vec![unused("a"), unused("b")]);
@@ -1400,7 +1400,7 @@ mod test_can {
     //#[test]
     //fn can_fibonacci() {
     //    let (_, output, problems, _) = can_expr(indoc!(
-    //        r#"
+    //        r"
     //        fibonacci = \num ->
     //            if num < 2 then
     //                num
@@ -1408,7 +1408,7 @@ mod test_can {
     //                fibonacci (num - 1) + fibonacci (num - 2)
 
     //        fibonacci 9
-    //    "#
+    //    "
     //    ));
 
     //    assert_eq!(problems, vec![]);
@@ -1430,7 +1430,7 @@ mod test_can {
     //    // is considered a tail call, even though it only
     //    // calls itself from one branch!
     //    let (_, output, problems, _) = can_expr(indoc!(
-    //        r#"
+    //        r"
     //        factorial = \num ->
     //            factorialHelp num 0
 
@@ -1441,7 +1441,7 @@ mod test_can {
     //                factorialHelp (num - 1) (total * num)
 
     //        factorial 9
-    //    "#
+    //    "
     //    ));
 
     //    assert_eq!(problems, vec![]);
@@ -1462,12 +1462,12 @@ mod test_can {
     //    // This should report that neither a nor b are unused,
     //    // since if you never call a function but do return it, that's okay!
     //    let (_, output, problems, _) = can_expr(indoc!(
-    //        r#"
+    //        r"
     //        a = \_ -> 42
     //        b = a
 
     //        b
-    //    "#
+    //    "
     //    ));
 
     //    assert_eq!(problems, Vec::new());
@@ -1488,14 +1488,14 @@ mod test_can {
     //#[test]
     //fn reorder_assignments() {
     //    let (expr, output, problems, _) = can_expr(indoc!(
-    //        r#"
+    //        r"
     //        increment = \arg -> arg + 1
     //        z = (increment 2) + y
     //        y = x + 1
     //        x = 9
 
     //        z * 3
-    //    "#
+    //    "
     //    ));
 
     //    assert_eq!(problems, vec![]);
@@ -1526,7 +1526,7 @@ mod test_can {
     //#[test]
     //fn reorder_closed_over_assignments() {
     //    let (expr, output, problems, _) = can_expr(indoc!(
-    //        r#"
+    //        r"
     //        z = func1 x
     //        x = 9
     //        y = func2 3
@@ -1534,7 +1534,7 @@ mod test_can {
     //        func2 = \arg -> arg + x
 
     //        z
-    //    "#
+    //    "
     //    ));
 
     //    assert_eq!(problems, vec![]);
@@ -1628,14 +1628,14 @@ mod test_can {
     //#[test]
     //fn circular_assignment() {
     //    let (_, _, problems, _) = can_expr(indoc!(
-    //        r#"
+    //        r"
     //        c = d + 3
     //        b = 2 + c
     //        d = a + 7
     //        a = b + 1
 
     //        2 + d
-    //    "#
+    //    "
     //    ));
 
     //    assert_eq!(
@@ -1655,9 +1655,9 @@ mod test_can {
     //    // There was a bug where this reported UnusedArgument("val")
     //    // since it was used only in the returned function only.
     //    let (_, _, problems, _) = can_expr(indoc!(
-    //        r#"
+    //        r"
     //        \val -> \_ -> val
-    //    "#
+    //    "
     //    ));
 
     //    assert_eq!(problems, vec![]);
@@ -1831,7 +1831,7 @@ mod test_can {
     //                      "abcd\\(efg)hij"
     //                      "#
     //             ),
-    //             Str(r#"abcd\(efg)hij"#.into()),
+    //             Str(r"abcd\(efg)hij".into()),
     //         );
     //     }
 
@@ -1848,7 +1848,7 @@ mod test_can {
 
     //     #[test]
     //     fn string_with_special_escapes() {
-    //         expect_parsed_str(r#"x\x"#, r#""x\\x""#);
+    //         expect_parsed_str(r"x\x", r#""x\\x""#);
     //         expect_parsed_str(r#"x"x"#, r#""x\"x""#);
     //         expect_parsed_str("x\tx", r#""x\tx""#);
     //         expect_parsed_str("x\rx", r#""x\rx""#);

--- a/crates/compiler/load/tests/test_reporting.rs
+++ b/crates/compiler/load/tests/test_reporting.rs
@@ -475,11 +475,11 @@ mod test_reporting {
     test_report!(
         value_not_exposed,
         indoc!(
-            r#"
+            r"
             List.isempty 1 2
-        "#
+        "
         ),
-        @r###"
+        @r"
     ── NOT EXPOSED ─────────────────────────────────────────── /code/proj/Main.roc ─
 
     The List module does not expose `isempty`:
@@ -493,20 +493,20 @@ mod test_reporting {
         List.set
         List.get
         List.keepIf
-    "###
+    "
     );
 
     test_report!(
         report_unused_def,
         indoc!(
-            r#"
+            r"
             x = 1
             y = 2
 
             x
-        "#
+        "
         ),
-        @r###"
+        @r"
     ── UNUSED DEFINITION ───────────────────────────────────── /code/proj/Main.roc ─
 
     `y` is not used anywhere in your code.
@@ -516,22 +516,22 @@ mod test_reporting {
 
     If you didn't intend on using `y` then remove it so future readers of
     your code don't wonder why it is there.
-    "###
+    "
     );
 
     test_report!(
         report_shadowing,
         indoc!(
-            r#"
+            r"
            i = 1
 
            s = \i ->
                i + 1
 
            s i
-       "#
+       "
         ),
-        @r###"
+        @r"
     ── DUPLICATE NAME ──────────────────────────────────────── /code/proj/Main.roc ─
 
     The `i` name is first defined here:
@@ -546,13 +546,13 @@ mod test_reporting {
 
     Since these variables have the same name, it's easy to use the wrong
     one by accident. Give one of them a new name.
-    "###
+    "
     );
 
     test_report!(
         report_shadowing_in_annotation,
         indoc!(
-            r#"
+            r"
             Booly : [Yes, No]
 
             Booly : [Yes, No, Maybe]
@@ -561,9 +561,9 @@ mod test_reporting {
             x = []
 
             x
-       "#
+       "
         ),
-        @r###"
+        @r"
     ── DUPLICATE NAME ──────────────────────────────────────── /code/proj/Main.roc ─
 
     The `Booly` name is first defined here:
@@ -578,13 +578,13 @@ mod test_reporting {
 
     Since these aliases have the same name, it's easy to use the wrong one
     by accident. Give one of them a new name.
-    "###
+    "
     );
 
     test_report!(
         report_precedence_problem_single_line,
         indoc!(
-            r#"x = 1
+            r"x = 1
             y =
                 if selectedId != thisId == adminsId then
                     4
@@ -593,9 +593,9 @@ mod test_reporting {
                     5
 
             { x, y }
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── SYNTAX PROBLEM ──────────────────────────────────────── /code/proj/Main.roc ─
 
     Using != and == together requires parentheses, to clarify how they
@@ -603,7 +603,7 @@ mod test_reporting {
 
     6│          if selectedId != thisId == adminsId then
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    "###
+    "
     );
 
     test_report!(
@@ -644,11 +644,11 @@ mod test_reporting {
     test_report!(
         lowercase_primitive_tag_bool,
         indoc!(
-            r#"
+            r"
             if true then 1 else 2
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── UNRECOGNIZED NAME ───────────────────────────────────── /code/proj/Main.roc ─
 
     Nothing is named `true` in this scope.
@@ -662,13 +662,13 @@ mod test_reporting {
         Num
         Str
         Err
-    "###
+    "
     );
 
     test_report!(
         report_precedence_problem_multiline,
         indoc!(
-            r#"
+            r"
             if
                 1
                     == 2
@@ -678,9 +678,9 @@ mod test_reporting {
 
             else
                 3
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── SYNTAX PROBLEM ──────────────────────────────────────── /code/proj/Main.roc ─
 
     Using more than one == like this requires parentheses, to clarify how
@@ -689,7 +689,7 @@ mod test_reporting {
     5│>          1
     6│>              == 2
     7│>              == 3
-    "###
+    "
     );
 
     test_report!(
@@ -706,7 +706,7 @@ mod test_reporting {
              box "wizard" []
          "#
         ),
-        @r###"
+        @r#"
     ── UNUSED ARGUMENT ─────────────────────────────────────── /code/proj/Main.roc ─
 
     `box` doesn't use `htmlChildren`.
@@ -729,17 +729,17 @@ mod test_reporting {
 
     If you didn't intend on using `y` then remove it so future readers of
     your code don't wonder why it is there.
-    "###
+    "#
     );
 
     #[test]
     fn report_value_color() {
         let src: &str = indoc!(
-            r#"
+            r"
                 activityIndicatorLarge = div
 
                 view activityIndicatorLarge
-            "#
+            "
         );
 
         let arena = Bump::new();
@@ -765,12 +765,12 @@ mod test_reporting {
     #[test]
     fn report_module_color() {
         let src: &str = indoc!(
-            r#"
+            r"
                 x = 1
                 y = 2
 
                 x
-            "#
+            "
         );
 
         let arena = Bump::new();
@@ -795,15 +795,15 @@ mod test_reporting {
     fn report_region_in_color() {
         color_report_problem_as(
             indoc!(
-                r#"
+                r"
                     isDisabled = \user -> user.isAdmin
 
                     theAdmin
                         |> isDisabled
-                "#
+                "
             ),
             indoc!(
-                r#"
+                r"
                 <cyan>── UNRECOGNIZED NAME ───────────────────────────────────── /code/proj/Main.roc ─<reset>
 
                 Nothing is named `theAdmin` in this scope.
@@ -817,7 +817,7 @@ mod test_reporting {
                     List
                     Err
                     Box
-                "#
+                "
             ),
         );
     }
@@ -829,7 +829,7 @@ mod test_reporting {
             if "foo" then 2 else 3
             "#
         ),
-        @r###"
+        @r#"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     This `if` condition needs to be a Bool:
@@ -843,19 +843,19 @@ mod test_reporting {
 
     But I need every `if` condition to evaluate to a Bool—either `Bool.true`
     or `Bool.false`.
-    "###
+    "#
     );
 
     test_report!(
         when_if_guard,
         indoc!(
-            r#"
+            r"
             when 1 is
                 2 if 1 -> 0x0
                 _ -> 0x1
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     This `if` guard condition needs to be a Bool:
@@ -870,7 +870,7 @@ mod test_reporting {
 
     But I need every `if` guard condition to evaluate to a Bool—either
     `Bool.true` or `Bool.false`.
-    "###
+    "
     );
 
     test_report!(
@@ -880,7 +880,7 @@ mod test_reporting {
             if Bool.true then 2 else "foo"
             "#
         ),
-        @r###"
+        @r#"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     This `if` has an `else` branch with a different type from its `then` branch:
@@ -897,7 +897,7 @@ mod test_reporting {
         Num *
 
     All branches in an `if` must have the same type!
-    "###
+    "#
     );
 
     test_report!(
@@ -907,7 +907,7 @@ mod test_reporting {
              if Bool.true then 2 else if Bool.false then 2 else "foo"
              "#
         ),
-        @r###"
+        @r#"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     The 3rd branch of this `if` does not match all the previous branches:
@@ -924,7 +924,7 @@ mod test_reporting {
         Num *
 
     All branches in an `if` must have the same type!
-    "###
+    "#
     );
 
     test_report!(
@@ -937,7 +937,7 @@ mod test_reporting {
                 _ -> ""
             "#
         ),
-        @r###"
+        @r#"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     The 2nd branch of this `when` does not match all the previous branches:
@@ -956,7 +956,7 @@ mod test_reporting {
         Str
 
     All branches of a `when` must have the same type!
-    "###
+    "#
     );
 
     test_report!(
@@ -975,7 +975,7 @@ mod test_reporting {
                 #(Red, Red) -> "foo"
             "#
         ),
-        @r###"
+        @r#"
     ── UNSAFE PATTERN ──────────────────────────────────────── /code/proj/Main.roc ─
 
     This `when` does not cover all the possibilities:
@@ -990,7 +990,7 @@ mod test_reporting {
         ( Red, Red )
 
     I would have to crash if I saw one of those! Add branches for them!
-    "###
+    "#
     );
 
     test_report!(
@@ -1019,7 +1019,7 @@ mod test_reporting {
             [1, 3, "foo"]
             "#
         ),
-        @r###"
+        @r#"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     This list contains elements with different types:
@@ -1036,17 +1036,17 @@ mod test_reporting {
         Num *
 
     Every element in a list must have the same type!
-    "###
+    "#
     );
 
     test_report!(
         unwrap_num_elem_in_list,
         indoc!(
-            r#"
+            r"
             [1, 2.2, 0x3]
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     This list contains elements with different types:
@@ -1066,7 +1066,7 @@ mod test_reporting {
 
     Tip: You can convert between integers and fractions using functions
     like `Num.toFrac` and `Num.round`.
-    "###
+    "
     );
 
     test_report!(
@@ -1079,7 +1079,7 @@ mod test_reporting {
             { x & foo: "bar" }
             "#
         ),
-        @r###"
+        @r#"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     I cannot update the `.foo` field like this:
@@ -1097,19 +1097,19 @@ mod test_reporting {
 
     Record update syntax does not allow you to change the type of fields.
     You can achieve that with record literal syntax.
-    "###
+    "#
     );
 
     test_report!(
         circular_type,
         indoc!(
-            r#"
+            r"
             f = \g -> g g
 
             f
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── CIRCULAR TYPE ───────────────────────────────────────── /code/proj/Main.roc ─
 
     I'm inferring a weird self-referential type for `f`:
@@ -1122,19 +1122,19 @@ mod test_reporting {
     infinitely.
 
         (∞ -> a) -> a
-    "###
+    "
     );
 
     test_report!(
         polymorphic_recursion,
         indoc!(
-            r#"
+            r"
             f = \x -> f [x]
 
             f
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── CIRCULAR TYPE ───────────────────────────────────────── /code/proj/Main.roc ─
 
     I'm inferring a weird self-referential type for `f`:
@@ -1147,20 +1147,20 @@ mod test_reporting {
     infinitely.
 
         List ∞ -> *
-    "###
+    "
     );
 
     test_report!(
         polymorphic_mutual_recursion,
         indoc!(
-            r#"
+            r"
             f = \x -> g x
             g = \x -> f [x]
 
             f
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── CIRCULAR TYPE ───────────────────────────────────────── /code/proj/Main.roc ─
 
     I'm inferring a weird self-referential type for `f`:
@@ -1186,21 +1186,21 @@ mod test_reporting {
     infinitely.
 
         List ∞ -> *
-    "###
+    "
     );
 
     test_report!(
         polymorphic_mutual_recursion_annotated,
         indoc!(
-            r#"
+            r"
             f : a -> List a
             f = \x -> g x
             g = \x -> f [x]
 
             f
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     This expression is used in an unexpected way:
@@ -1221,22 +1221,22 @@ mod test_reporting {
     it will only produce a `List` value of a single specific type. Maybe
     change the type annotation to be more specific? Maybe change the code
     to be more general?
-    "###
+    "
     );
 
     test_report!(
         polymorphic_mutual_recursion_dually_annotated_lie,
         indoc!(
-            r#"
+            r"
             f : a -> List a
             f = \x -> g x
             g : b -> List b
             g = \x -> f [x]
 
             f
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     This expression is used in an unexpected way:
@@ -1257,20 +1257,20 @@ mod test_reporting {
     it will only produce a `List` value of a single specific type. Maybe
     change the type annotation to be more specific? Maybe change the code
     to be more general?
-    "###
+    "
     );
 
     test_report!(
         polymorphic_recursion_inference_var,
         indoc!(
-            r#"
+            r"
             f : _
             f = \x -> f [x]
 
             f
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── CIRCULAR TYPE ───────────────────────────────────────── /code/proj/Main.roc ─
 
     I'm inferring a weird self-referential type for `f`:
@@ -1283,20 +1283,20 @@ mod test_reporting {
     infinitely.
 
         List ∞ -> *
-    "###
+    "
     );
 
     test_report!(
         polymorphic_recursion_with_deep_inference_var,
         indoc!(
-            r#"
+            r"
             f : _ -> List _
             f = \x -> f [x]
 
             f
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── CIRCULAR TYPE ───────────────────────────────────────── /code/proj/Main.roc ─
 
     I'm inferring a weird self-referential type for `f`:
@@ -1309,19 +1309,19 @@ mod test_reporting {
     infinitely.
 
         List ∞ -> List *
-    "###
+    "
     );
 
     test_report!(
         mutual_polymorphic_recursion_with_inference_var,
         indoc!(
-            r#"
+            r"
             f : _ -> List _
             f = \x -> g x
             g = \x -> f [x]
 
             f
-            "#
+            "
         ),
         // TODO: the second error is duplicated because when solving `f : _ -> List _`, we
         // introduce the variable for `f` twice: once to solve `f` without generalization,
@@ -1334,7 +1334,7 @@ mod test_reporting {
         // variables they can put themselves in, and to run the constraint algorithm
         // against that extra variable, rather than possibly having to translate a `Type`
         // again.
-        @r###"
+        @r"
     ── CIRCULAR TYPE ───────────────────────────────────────── /code/proj/Main.roc ─
 
     I'm inferring a weird self-referential type for `f`:
@@ -1360,21 +1360,21 @@ mod test_reporting {
     infinitely.
 
         List ∞ -> List *
-    "###
+    "
     );
 
     test_report!(
         mutual_polymorphic_recursion_with_inference_var_second,
         indoc!(
-            r#"
+            r"
             f = \x -> g x
             g : _ -> List _
             g = \x -> f [x]
 
             f
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── CIRCULAR TYPE ───────────────────────────────────────── /code/proj/Main.roc ─
 
     I'm inferring a weird self-referential type for `f`:
@@ -1400,22 +1400,22 @@ mod test_reporting {
     infinitely.
 
         List ∞ -> List *
-    "###
+    "
     );
 
     test_report!(
         record_field_mismatch,
         indoc!(
-            r#"
+            r"
             bar = { bar : 0x3 }
 
             f : { foo : Num.Int * } -> [Yes, No]
             f = \_ -> Yes
 
             f bar
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     This 1st argument to `f` has an unexpected type:
@@ -1436,20 +1436,20 @@ mod test_reporting {
     Tip: Can more type annotations be added? Type annotations always help
     me give more specific messages, and I think they could help a lot in
     this case
-    "###
+    "
     );
 
     test_report!(
         tag_mismatch,
         indoc!(
-            r#"
+            r"
             f : [Red, Green] -> [Yes, No]
             f = \_ -> Yes
 
             f Blue
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     This 1st argument to `f` has an unexpected type:
@@ -1473,7 +1473,7 @@ mod test_reporting {
     Tip: Can more type annotations be added? Type annotations always help
     me give more specific messages, and I think they could help a lot in
     this case
-    "###
+    "
     );
 
     test_report!(
@@ -1486,7 +1486,7 @@ mod test_reporting {
             f (Blue 3.14)
             "#
         ),
-        @r###"
+        @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     This 1st argument to `f` has an unexpected type:
@@ -1510,20 +1510,20 @@ mod test_reporting {
     Tip: Can more type annotations be added? Type annotations always help
     me give more specific messages, and I think they could help a lot in
     this case
-    "###
+    "
     );
 
     test_report!(
         from_annotation_if,
         indoc!(
-            r#"
+            r"
             x : Num.Int *
             x = if Bool.true then 3.14 else 4
 
             x
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     Something is off with the `then` branch of this `if` expression:
@@ -1542,22 +1542,22 @@ mod test_reporting {
 
     Tip: You can convert between integers and fractions using functions
     like `Num.toFrac` and `Num.round`.
-    "###
+    "
     );
 
     test_report!(
         from_annotation_when,
         indoc!(
-            r#"
+            r"
             x : Num.Int *
             x =
                 when True is
                     _ -> 3.14
 
             x
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     Something is off with the body of the `x` definition:
@@ -1577,20 +1577,20 @@ mod test_reporting {
 
     Tip: You can convert between integers and fractions using functions
     like `Num.toFrac` and `Num.round`.
-    "###
+    "
     );
 
     test_report!(
         from_annotation_function,
         indoc!(
-            r#"
+            r"
             x : Num.Int * -> Num.Int *
             x = \_ -> 3.14
 
             x
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     Something is off with the body of the `x` definition:
@@ -1609,20 +1609,20 @@ mod test_reporting {
 
     Tip: You can convert between integers and fractions using functions
     like `Num.toFrac` and `Num.round`.
-    "###
+    "
     );
 
     test_report!(
         fncall_value,
         indoc!(
-            r#"
+            r"
             x : Num.I64
             x = 42
 
             x 3
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── TOO MANY ARGS ───────────────────────────────────────── /code/proj/Main.roc ─
 
     The `x` value is not a function, but it was given 1 argument:
@@ -1631,20 +1631,20 @@ mod test_reporting {
             ^
 
     Are there any missing commas? Or missing parentheses?
-    "###
+    "
     );
 
     test_report!(
         fncall_overapplied,
         indoc!(
-            r#"
+            r"
             f : Num.I64 -> Num.I64
             f = \_ -> 42
 
             f 1 2
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── TOO MANY ARGS ───────────────────────────────────────── /code/proj/Main.roc ─
 
     The `f` function expects 1 argument, but it got 2 instead:
@@ -1653,20 +1653,20 @@ mod test_reporting {
             ^
 
     Are there any missing commas? Or missing parentheses?
-    "###
+    "
     );
 
     test_report!(
         fncall_underapplied,
         indoc!(
-            r#"
+            r"
             f : Num.I64, Num.I64 -> Num.I64
             f = \_, _ -> 42
 
             f 1
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── TOO FEW ARGS ────────────────────────────────────────── /code/proj/Main.roc ─
 
     The `f` function expects 2 arguments, but it got only 1:
@@ -1676,18 +1676,18 @@ mod test_reporting {
 
     Roc does not allow functions to be partially applied. Use a closure to
     make partial application explicit.
-    "###
+    "
     );
 
     test_report!(
         pattern_when_condition,
         indoc!(
-            r#"
+            r"
             when 1 is
                 {} -> 42
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     The branches of this `when` expression don't match the condition:
@@ -1704,19 +1704,19 @@ mod test_reporting {
         {}a
 
     The branches must be cases of the `when` condition's type!
-    "###
+    "
     );
 
     test_report!(
         pattern_when_pattern,
         indoc!(
-            r#"
+            r"
             when 1 is
                 2 -> 3
                 {} -> 42
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     The 2nd pattern in this `when` does not match the previous ones:
@@ -1731,18 +1731,18 @@ mod test_reporting {
     But all the previous branches match:
 
         Num *
-    "###
+    "
     );
 
     test_report!(
         pattern_guard_mismatch_alias,
         indoc!(
-            r#"
+            r"
              when { foo: 1 } is
                  { foo: True } -> 42
-             "#
+             "
         ),
-        @r###"
+        @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     The branches of this `when` expression don't match the condition:
@@ -1759,7 +1759,7 @@ mod test_reporting {
         { foo : [True] }
 
     The branches must be cases of the `when` condition's type!
-    "###
+    "
     );
 
     test_report!(
@@ -1770,7 +1770,7 @@ mod test_reporting {
                  { foo: True } -> 42
              "#
         ),
-        @r###"
+        @r#"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     The branches of this `when` expression don't match the condition:
@@ -1787,19 +1787,19 @@ mod test_reporting {
         { foo : [True] }
 
     The branches must be cases of the `when` condition's type!
-    "###
+    "#
     );
 
     // needs some improvement, but the principle works
     test_report!(
         pattern_guard_does_not_bind_label,
         indoc!(
-            r#"
+            r"
              when { foo: 1 } is
                  { foo: _ } -> foo
-             "#
+             "
         ),
-        @r###"
+        @r"
     ── UNRECOGNIZED NAME ───────────────────────────────────── /code/proj/Main.roc ─
 
     Nothing is named `foo` in this scope.
@@ -1813,19 +1813,19 @@ mod test_reporting {
         Bool
         U8
         F64
-    "###
+    "
     );
 
     test_report! {
         pattern_guard_can_be_shadowed_above,
         indoc!(
-            r#"
+            r"
             foo = 3
 
             when { foo: 1 } is
                 { foo: 2 } -> foo
                 _ -> foo
-             "#
+             "
         ),
         @"" // should give no error
     }
@@ -1833,14 +1833,14 @@ mod test_reporting {
     test_report! {
         pattern_guard_can_be_shadowed_below,
         indoc!(
-            r#"
+            r"
             when { foo: 1 } is
                 { foo: 2 } ->
                     foo = 3
 
                     foo
                 _ -> 3
-             "#
+             "
         ),
         // should give no error
         @""
@@ -1849,13 +1849,13 @@ mod test_reporting {
     test_report!(
         pattern_or_pattern_mismatch,
         indoc!(
-            r#"
+            r"
             when { foo: 1 } is
                 {} | 1 -> 3
-            "#
+            "
         ),
         // Just putting this here. We should probably handle or-patterns better
-        @r###"
+        @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     The 2nd pattern in this branch does not match the previous ones:
@@ -1870,20 +1870,20 @@ mod test_reporting {
     But all the previous branches match:
 
         {}a
-    "###
+    "
     );
 
     test_report!(
         pattern_let_mismatch,
         indoc!(
-            r#"
+            r"
             (Foo x) = 42
 
             x
-            "#
+            "
         ),
         // Maybe this should specifically say the pattern doesn't work?
-        @r###"
+        @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     This expression is used in an unexpected way:
@@ -1898,20 +1898,20 @@ mod test_reporting {
     But you are trying to use it as:
 
         [Foo *]
-    "###
+    "
     );
 
     test_report!(
         from_annotation_complex_pattern,
         indoc!(
-            r#"
+            r"
             { x } : { x : Num.Int * }
             { x } = { x: 4.0 }
 
             x
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     Something is off with the body of this definition:
@@ -1930,19 +1930,19 @@ mod test_reporting {
 
     Tip: You can convert between integers and fractions using functions
     like `Num.toFrac` and `Num.round`.
-    "###
+    "
     );
 
     test_report!(
         malformed_int_pattern,
         indoc!(
-            r#"
+            r"
             when 1 is
                 100A -> 3
                 _ -> 4
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── SYNTAX PROBLEM ──────────────────────────────────────── /code/proj/Main.roc ─
 
     This integer pattern is malformed:
@@ -1951,19 +1951,19 @@ mod test_reporting {
                 ^^^^
 
     Tip: Learn more about number literals at TODO
-    "###
+    "
     );
 
     test_report!(
         malformed_float_pattern,
         indoc!(
-            r#"
+            r"
             when 1 is
                 2.X -> 3
                 _ -> 4
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── SYNTAX PROBLEM ──────────────────────────────────────── /code/proj/Main.roc ─
 
     This float pattern is malformed:
@@ -1972,19 +1972,19 @@ mod test_reporting {
                 ^^^
 
     Tip: Learn more about number literals at TODO
-    "###
+    "
     );
 
     test_report!(
         malformed_hex_pattern,
         indoc!(
-            r#"
+            r"
             when 1 is
                 0xZ -> 3
                 _ -> 4
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── SYNTAX PROBLEM ──────────────────────────────────────── /code/proj/Main.roc ─
 
     This hex integer pattern is malformed:
@@ -1993,19 +1993,19 @@ mod test_reporting {
                 ^^^
 
     Tip: Learn more about number literals at TODO
-    "###
+    "
     );
 
     test_report!(
         malformed_oct_pattern,
         indoc!(
-            r#"
+            r"
             when 1 is
                 0o9 -> 3
                 _ -> 4
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── SYNTAX PROBLEM ──────────────────────────────────────── /code/proj/Main.roc ─
 
     This octal integer pattern is malformed:
@@ -2014,19 +2014,19 @@ mod test_reporting {
                 ^^^
 
     Tip: Learn more about number literals at TODO
-    "###
+    "
     );
 
     test_report!(
         malformed_bin_pattern,
         indoc!(
-            r#"
+            r"
             when 1 is
                 0b4 -> 3
                 _ -> 4
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── SYNTAX PROBLEM ──────────────────────────────────────── /code/proj/Main.roc ─
 
     This binary integer pattern is malformed:
@@ -2035,20 +2035,20 @@ mod test_reporting {
                 ^^^
 
     Tip: Learn more about number literals at TODO
-    "###
+    "
     );
 
     test_report!(
         missing_fields,
         indoc!(
-            r#"
+            r"
             x : { a : Num.Int *, b : Num.Frac *, c : Str }
             x = { b: 4.0 }
 
             x
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     Something is off with the body of the `x` definition:
@@ -2070,7 +2070,7 @@ mod test_reporting {
         }
 
     Tip: Looks like the c and a fields are missing.
-    "###
+    "
     );
 
     // this previously reported the message below, not sure which is better
@@ -2091,14 +2091,14 @@ mod test_reporting {
     test_report!(
         bad_double_rigid,
         indoc!(
-            r#"
+            r"
             f : a, b -> a
             f = \x, y -> if Bool.true then x else y
 
             f
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     Something is off with the `else` branch of this `if` expression:
@@ -2119,20 +2119,20 @@ mod test_reporting {
     Your code seems to be saying they are the same though. Maybe they
     should be the same in your type annotation? Maybe your code uses them
     in a weird way?
-    "###
+    "
     );
 
     test_report!(
         bad_rigid_function,
         indoc!(
-            r#"
+            r"
             f : Str -> msg
             f = \_ -> Foo
 
             f
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     Something is off with the body of the `f` definition:
@@ -2154,20 +2154,20 @@ mod test_reporting {
     it will only produce a tag value of a single specific type. Maybe
     change the type annotation to be more specific? Maybe change the code
     to be more general?
-    "###
+    "
     );
 
     test_report!(
         bad_rigid_value,
         indoc!(
-            r#"
+            r"
             f : msg
             f = 0x3
 
             f
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     Something is off with the body of the `f` definition:
@@ -2189,21 +2189,21 @@ mod test_reporting {
     it will only produce a `Int` value of a single specific type. Maybe
     change the type annotation to be more specific? Maybe change the code
     to be more general?
-    "###
+    "
     );
 
     // TODO improve tag suggestions
     test_report!(
         typo_lowercase_ok,
         indoc!(
-            r#"
+            r"
             f : Str -> [Ok Num.I64, InvalidFoo]
             f = \_ -> ok 4
 
             f
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── UNRECOGNIZED NAME ───────────────────────────────────── /code/proj/Main.roc ─
 
     Nothing is named `ok` in this scope.
@@ -2217,14 +2217,14 @@ mod test_reporting {
         U8
         Box
         Eq
-    "###
+    "
     );
 
     // these error messages seem pretty helpful
     test_report!(
         typo_uppercase_ok,
         indoc!(
-            r#"
+            r"
             f : Str -> Num.I64
             f = \_ ->
                 ok = 3
@@ -2232,9 +2232,9 @@ mod test_reporting {
                 Ok
 
             f
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── UNUSED DEFINITION ───────────────────────────────────── /code/proj/Main.roc ─
 
     `ok` is not used anywhere in your code.
@@ -2263,20 +2263,20 @@ mod test_reporting {
     But the type annotation on `f` says it should be:
 
         I64
-    "###
+    "
     );
 
     // invalid recursion
     test_report!(
         circular_definition_self,
         indoc!(
-            r#"
+            r"
             f = f
 
             f
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── CIRCULAR DEFINITION ─────────────────────────────────── /code/proj/Main.roc ─
 
     `f` is defined directly in terms of itself:
@@ -2288,22 +2288,22 @@ mod test_reporting {
     infinite loop!
 
     Hint: Did you mean to define `f` as a function?
-    "###
+    "
     );
 
     // invalid mutual recursion
     test_report!(
         circular_definition,
         indoc!(
-            r#"
+            r"
             foo = bar
 
             bar = foo
 
             foo
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── CIRCULAR DEFINITION ─────────────────────────────────── /code/proj/Main.roc ─
 
     The `foo` definition is causing a very tricky infinite loop:
@@ -2319,19 +2319,19 @@ mod test_reporting {
         │     ↓
         │     bar
         └─────┘
-    "###
+    "
     );
 
     test_report!(
         update_empty_record,
         indoc!(
-            r#"
+            r"
             x = {}
 
             { x & foo: 3 }
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     This `x` record doesn’t have a `foo` field:
@@ -2340,20 +2340,20 @@ mod test_reporting {
                   ^^^^^^
 
     In fact, `x` is a record with no fields at all!
-    "###
+    "
     );
 
     test_report!(
         update_record,
         indoc!(
-            r#"
+            r"
             x = { fo: 3, bar: 4 }
 
             { x & foo: 3 }
-            "#
+            "
         ),
         // TODO also suggest fields with the correct type
-        @r###"
+        @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     This `x` record doesn’t have a `foo` field:
@@ -2369,13 +2369,13 @@ mod test_reporting {
         }
 
     Maybe `foo:` should be `fo:` instead?
-    "###
+    "
     );
 
     test_report!(
         update_record_ext,
         indoc!(
-            r#"
+            r"
             f : { fo: Num.I64 }ext -> Num.I64
             f = \r ->
                 r2 = { r & foo: r.fo }
@@ -2383,10 +2383,10 @@ mod test_reporting {
                 r2.fo
 
             f
-            "#
+            "
         ),
         // TODO also suggest fields with the correct type
-        @r###"
+        @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     This `r` record doesn’t have a `foo` field:
@@ -2401,20 +2401,20 @@ mod test_reporting {
         }ext
 
     Maybe `foo:` should be `fo:` instead?
-    "###
+    "
     );
 
     test_report!(
         update_record_snippet,
         indoc!(
-            r#"
+            r"
             x = { fo: 3, bar: 4, baz: 3, spam: 42, foobar: 3 }
 
             { x & foo: 3 }
-            "#
+            "
         ),
         // TODO also suggest fields with the correct type
-        @r###"
+        @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     This `x` record doesn’t have a `foo` field:
@@ -2433,7 +2433,7 @@ mod test_reporting {
         }
 
     Maybe `foo:` should be `fo:` instead?
-    "###
+    "
     );
 
     test_report!(
@@ -2444,7 +2444,7 @@ mod test_reporting {
             "#
         ),
         // TODO also suggest fields with the correct type
-        @r###"
+        @r#"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     This 2nd argument to + has an unexpected type:
@@ -2459,17 +2459,17 @@ mod test_reporting {
     But + needs its 2nd argument to be:
 
         Int *
-    "###
+    "#
     );
 
     test_report!(
         int_frac,
         indoc!(
-            r#"
+            r"
             0x4 + 3.14
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     This 2nd argument to + has an unexpected type:
@@ -2487,17 +2487,17 @@ mod test_reporting {
 
     Tip: You can convert between integers and fractions using functions
     like `Num.toFrac` and `Num.round`.
-    "###
+    "
     );
 
     test_report!(
         boolean_tag,
         indoc!(
-            r#"
+            r"
             42 + True
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     This 2nd argument to + has an unexpected type:
@@ -2512,20 +2512,20 @@ mod test_reporting {
     But + needs its 2nd argument to be:
 
         Num *
-    "###
+    "
     );
 
     test_report!(
         tag_missing,
         indoc!(
-            r#"
+            r"
             f : [A] -> [A, B]
             f = \a -> a
 
             f
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     Something is off with the body of the `f` definition:
@@ -2546,20 +2546,20 @@ mod test_reporting {
 
     Tip: Closed tag unions can't grow, because that might change the size
     in memory. Can you use an open tag union?
-    "###
+    "
     );
 
     test_report!(
         tags_missing,
         indoc!(
-            r#"
+            r"
             f : [A] -> [A, B, C]
             f = \a -> a
 
             f
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     Something is off with the body of the `f` definition:
@@ -2584,13 +2584,13 @@ mod test_reporting {
 
     Tip: Closed tag unions can't grow, because that might change the size
     in memory. Can you use an open tag union?
-    "###
+    "
     );
 
     test_report!(
         patterns_fn_not_exhaustive,
         indoc!(
-            r#"
+            r"
             Either : [Left {}, Right Str]
 
             x : Either
@@ -2600,9 +2600,9 @@ mod test_reporting {
             f = \Left v -> v
 
             f x
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── UNSAFE PATTERN ──────────────────────────────────────── /code/proj/Main.roc ─
 
     This pattern does not cover all the possibilities:
@@ -2638,13 +2638,13 @@ mod test_reporting {
 
     Tip: Closed tag unions can't grow, because that might change the size
     in memory. Can you use an open tag union?
-    "###
+    "
     );
 
     test_report!(
         patterns_let_not_exhaustive,
         indoc!(
-            r#"
+            r"
             x : [Left {}, Right Str]
             x = Left {}
 
@@ -2652,9 +2652,9 @@ mod test_reporting {
             (Left y) = x
 
             y
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     This expression is used in an unexpected way:
@@ -2674,18 +2674,18 @@ mod test_reporting {
 
     Tip: Closed tag unions can't grow, because that might change the size
     in memory. Can you use an open tag union?
-    "###
+    "
     );
 
     test_report!(
         patterns_when_not_exhaustive,
         indoc!(
-            r#"
+            r"
             when 0x1 is
                 2 -> 0x3
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── UNSAFE PATTERN ──────────────────────────────────────── /code/proj/Main.roc ─
 
     This `when` does not cover all the possibilities:
@@ -2698,21 +2698,21 @@ mod test_reporting {
         _
 
     I would have to crash if I saw one of those! Add branches for them!
-    "###
+    "
     );
 
     test_report!(
         patterns_bool_not_exhaustive,
         indoc!(
-            r#"
+            r"
             x : [Red, Green]
             x = Green
 
             when x is
                 Red -> 3
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── UNSAFE PATTERN ──────────────────────────────────────── /code/proj/Main.roc ─
 
     This `when` does not cover all the possibilities:
@@ -2725,22 +2725,22 @@ mod test_reporting {
         Green
 
     I would have to crash if I saw one of those! Add branches for them!
-    "###
+    "
     );
 
     test_report!(
         patterns_enum_not_exhaustive,
         indoc!(
-            r#"
+            r"
             x : [Red, Green, Blue]
             x = Red
 
             when x is
                 Red -> 0
                 Green -> 1
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── UNSAFE PATTERN ──────────────────────────────────────── /code/proj/Main.roc ─
 
     This `when` does not cover all the possibilities:
@@ -2754,22 +2754,22 @@ mod test_reporting {
         Blue
 
     I would have to crash if I saw one of those! Add branches for them!
-    "###
+    "
     );
 
     test_report!(
         patterns_remote_data_not_exhaustive,
         indoc!(
-            r#"
+            r"
             RemoteData e a :  [NotAsked, Loading, Failure e, Success a]
 
             x : RemoteData Num.I64 Str
 
             when x is
                 NotAsked -> 3
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── UNSAFE PATTERN ──────────────────────────────────────── /code/proj/Main.roc ─
 
     This `when` does not cover all the possibilities:
@@ -2784,21 +2784,21 @@ mod test_reporting {
         Success _
 
     I would have to crash if I saw one of those! Add branches for them!
-    "###
+    "
     );
 
     test_report!(
         patterns_record_not_exhaustive,
         indoc!(
-            r#"
+            r"
             x = { a: 3 }
 
             when x is
                 { a: 4 } -> 4
-            "#
+            "
         ),
         // Tip: Looks like a record field guard is not exhaustive. Learn more about record pattern matches at TODO.
-        @r###"
+        @r"
     ── UNSAFE PATTERN ──────────────────────────────────────── /code/proj/Main.roc ─
 
     This `when` does not cover all the possibilities:
@@ -2811,13 +2811,13 @@ mod test_reporting {
         { a }
 
     I would have to crash if I saw one of those! Add branches for them!
-    "###
+    "
     );
 
     test_report!(
         patterns_record_guard_not_exhaustive,
         indoc!(
-            r#"
+            r"
             y : [Nothing, Just Num.I64]
             y = Just 4
             x = { a: y, b: 42}
@@ -2825,9 +2825,9 @@ mod test_reporting {
             when x is
                 { a: Nothing } -> 4
                 { a: Just 3 } -> 4
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── UNSAFE PATTERN ──────────────────────────────────────── /code/proj/Main.roc ─
 
     This `when` does not cover all the possibilities:
@@ -2841,19 +2841,19 @@ mod test_reporting {
         { a: Just _ }
 
     I would have to crash if I saw one of those! Add branches for them!
-    "###
+    "
     );
 
     test_report!(
         patterns_nested_tag_not_exhaustive,
         indoc!(
-            r#"
+            r"
             when Record Nothing 1 is
                 Record (Nothing) b -> b
                 Record (Just 3) b -> b
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── UNSAFE PATTERN ──────────────────────────────────────── /code/proj/Main.roc ─
 
     This `when` does not cover all the possibilities:
@@ -2867,20 +2867,20 @@ mod test_reporting {
         Record (Just _) _
 
     I would have to crash if I saw one of those! Add branches for them!
-    "###
+    "
     );
 
     test_report!(
         patterns_int_redundant,
         indoc!(
-            r#"
+            r"
             when 0x1 is
                 2 -> 3
                 2 -> 4
                 _ -> 5
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── REDUNDANT PATTERN ───────────────────────────────────── /code/proj/Main.roc ─
 
     The 2nd pattern is redundant:
@@ -2892,23 +2892,23 @@ mod test_reporting {
 
     Any value of this shape will be handled by a previous pattern, so this
     one should be removed.
-    "###
+    "
     );
 
     test_report!(
         unify_alias_other,
         indoc!(
-            r#"
+            r"
             Foo a : { x : Num.Int a }
 
             f : Foo a -> Num.Int a
             f = \r -> r.x
 
             f { y: 3.14 }
-            "#
+            "
         ),
         // de-aliases the alias to give a better error message
-        @r###"
+        @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     This 1st argument to `f` has an unexpected type:
@@ -2929,24 +2929,24 @@ mod test_reporting {
     Tip: Can more type annotations be added? Type annotations always help
     me give more specific messages, and I think they could help a lot in
     this case
-    "###
+    "
     );
 
     test_report!(
         #[ignore]
         cyclic_alias,
         indoc!(
-            r#"
+            r"
             Foo : { x : Bar }
             Bar : { y : Foo }
 
             f : Foo
 
             f
-            "#
+            "
         ),
         // should not report Bar as unused!
-        @r###"
+        @r"
     ── CYCLIC ALIAS ────────────────────────────────────────── /code/proj/Main.roc ─
 
     The `Foo` alias is self-recursive in an invalid way:
@@ -2956,23 +2956,23 @@ mod test_reporting {
 
     Recursion in aliases is only allowed if recursion happens behind a
     tagged union, at least one variant of which is not recursive.
-    "###
+    "
     );
 
     test_report!(
         self_recursive_alias,
         indoc!(
-            r#"
+            r"
             Foo : { x : Foo }
 
             f : Foo
             f = 3
 
             f
-            "#
+            "
         ),
         // should not report Bar as unused!
-        @r###"
+        @r"
     ── CYCLIC ALIAS ────────────────────────────────────────── /code/proj/Main.roc ─
 
     The `Foo` alias is self-recursive in an invalid way:
@@ -2982,17 +2982,17 @@ mod test_reporting {
 
     Recursion in aliases is only allowed if recursion happens behind a
     tagged union, at least one variant of which is not recursive.
-    "###
+    "
     );
 
     test_report!(
         record_duplicate_field_same_type,
         indoc!(
-            r#"
+            r"
             { x: 4, y: 3, x: 4 }
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── DUPLICATE FIELD NAME ────────────────────────────────── /code/proj/Main.roc ─
 
     This record defines the `.x` field twice!
@@ -3006,7 +3006,7 @@ mod test_reporting {
                           ^^^^
 
     For clarity, remove the previous `.x` definitions from this record.
-    "###
+    "
     );
 
     test_report!(
@@ -3016,7 +3016,7 @@ mod test_reporting {
             { x: 4, y: 3, x: "foo" }
             "#
         ),
-        @r###"
+        @r#"
     ── DUPLICATE FIELD NAME ────────────────────────────────── /code/proj/Main.roc ─
 
     This record defines the `.x` field twice!
@@ -3030,7 +3030,7 @@ mod test_reporting {
                           ^^^^^^^^
 
     For clarity, remove the previous `.x` definitions from this record.
-    "###
+    "#
     );
 
     test_report!(
@@ -3044,7 +3044,7 @@ mod test_reporting {
             }
             "#
         ),
-        @r###"
+        @r#"
     ── DUPLICATE FIELD NAME ────────────────────────────────── /code/proj/Main.roc ─
 
     This record defines the `.x` field twice!
@@ -3064,7 +3064,7 @@ mod test_reporting {
     8│       }
 
     For clarity, remove the previous `.x` definitions from this record.
-    "###
+    "#
     );
 
     test_report!(
@@ -3079,7 +3079,7 @@ mod test_reporting {
                 }
             "#
         ),
-        @r###"
+        @r#"
     ── DUPLICATE FIELD NAME ────────────────────────────────── /code/proj/Main.roc ─
 
     This record defines the `.x` field twice!
@@ -3099,7 +3099,7 @@ mod test_reporting {
     9│           }
 
     For clarity, remove the previous `.x` definitions from this record.
-    "###
+    "#
     );
 
     test_report!(
@@ -3112,7 +3112,7 @@ mod test_reporting {
             a
             "#
         ),
-        @r###"
+        @r"
     ── DUPLICATE FIELD NAME ────────────────────────────────── /code/proj/Main.roc ─
 
     This record type defines the `.foo` field twice!
@@ -3127,7 +3127,7 @@ mod test_reporting {
 
     For clarity, remove the previous `.foo` definitions from this record
     type.
-    "###
+    "
     );
 
     test_report!(
@@ -3140,7 +3140,7 @@ mod test_reporting {
             a
             "#
         ),
-        @r###"
+        @r"
     ── DUPLICATE TAG NAME ──────────────────────────────────── /code/proj/Main.roc ─
 
     This tag union type defines the `Foo` tag twice!
@@ -3155,21 +3155,21 @@ mod test_reporting {
 
     For clarity, remove the previous `Foo` definitions from this tag union
     type.
-    "###
+    "
     );
 
     test_report!(
         annotation_definition_mismatch,
         indoc!(
-            r#"
+            r"
             bar : Num.I64
             foo = \x -> x
 
             # NOTE: neither bar or foo are defined at this point
             4
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── NAMING PROBLEM ──────────────────────────────────────── /code/proj/Main.roc ─
 
     This annotation does not match the definition immediately following
@@ -3179,19 +3179,19 @@ mod test_reporting {
     5│>      foo = \x -> x
 
     Is it a typo? If not, put either a newline or comment between them.
-    "###
+    "
     );
 
     test_report!(
         annotation_newline_body_is_fine,
         indoc!(
-            r#"
+            r"
             bar : Num.I64
 
             foo = \x -> x
 
             foo bar
-            "#
+            "
         ),
         @""
     );
@@ -3199,13 +3199,13 @@ mod test_reporting {
     test_report!(
         invalid_alias_rigid_var_pattern,
         indoc!(
-            r#"
+            r"
             MyAlias 1 : Num.I64
 
             4
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── SYNTAX PROBLEM ──────────────────────────────────────── /code/proj/Main.roc ─
 
     This definition of `MyAlias` has an unexpected pattern:
@@ -3224,20 +3224,20 @@ mod test_reporting {
 
     If you didn't intend on using `MyAlias` then remove it so future readers
     of your code don't wonder why it is there.
-    "###
+    "
     );
 
     test_report!(
         invalid_opaque_rigid_var_pattern,
         indoc!(
-            r#"
+            r"
             Age 1 := Num.I64
 
             a : Age
             a
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── SYNTAX PROBLEM ──────────────────────────────────────── /code/proj/Main.roc ─
 
     This definition of `Age` has an unexpected pattern:
@@ -3246,20 +3246,20 @@ mod test_reporting {
                 ^
 
     Only type variables like `a` or `value` can occur in this position.
-    "###
+    "
     );
 
     test_report!(
         invalid_num,
         indoc!(
-            r#"
+            r"
             a : Num.Num Num.I64 Num.F64
             a = 3
 
             a
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── TOO MANY TYPE ARGUMENTS ─────────────────────────────── /code/proj/Main.roc ─
 
     The `Num` opaque expects 1 type argument, but it got 2 instead:
@@ -3268,20 +3268,20 @@ mod test_reporting {
                 ^^^^^^^^^^^^^^^^^^^^^^^
 
     Are there missing parentheses?
-    "###
+    "
     );
 
     test_report!(
         invalid_num_fn,
         indoc!(
-            r#"
+            r"
             f : Str -> Num.Num Num.I64 Num.F64
             f = \_ -> 3
 
             f
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── TOO MANY TYPE ARGUMENTS ─────────────────────────────── /code/proj/Main.roc ─
 
     The `Num` opaque expects 1 type argument, but it got 2 instead:
@@ -3290,22 +3290,22 @@ mod test_reporting {
                        ^^^^^^^^^^^^^^^^^^^^^^^
 
     Are there missing parentheses?
-    "###
+    "
     );
 
     test_report!(
         too_few_type_arguments,
         indoc!(
-            r#"
+            r"
             Pair a b : [Pair a b]
 
             x : Pair Num.I64
             x = Pair 2 3
 
             x
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── TOO FEW TYPE ARGUMENTS ──────────────────────────────── /code/proj/Main.roc ─
 
     The `Pair` alias expects 2 type arguments, but it got 1 instead:
@@ -3314,22 +3314,22 @@ mod test_reporting {
                 ^^^^^^^^^^^^
 
     Are there missing parentheses?
-    "###
+    "
     );
 
     test_report!(
         too_many_type_arguments,
         indoc!(
-            r#"
+            r"
             Pair a b : [Pair a b]
 
             x : Pair Num.I64 Num.I64 Num.I64
             x = 3
 
             x
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── TOO MANY TYPE ARGUMENTS ─────────────────────────────── /code/proj/Main.roc ─
 
     The `Pair` alias expects 2 type arguments, but it got 3 instead:
@@ -3338,21 +3338,21 @@ mod test_reporting {
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
     Are there missing parentheses?
-    "###
+    "
     );
 
     test_report!(
         phantom_type_variable,
         indoc!(
-            r#"
+            r"
             Foo a : [Foo]
 
             f : Foo Num.I64
 
             f
-            "#
+            "
         ),
-        @r###"
+        @r#"
     ── UNUSED TYPE ALIAS PARAMETER ─────────────────────────── /code/proj/Main.roc ─
 
     The `a` type parameter is not used in the `Foo` alias definition:
@@ -3364,17 +3364,17 @@ mod test_reporting {
 
     Tip: If you want an unused type parameter (a so-called "phantom
     type"), read the guide section on phantom values.
-    "###
+    "#
     );
 
     test_report!(
         elm_function_syntax,
         indoc!(
-            r#"
+            r"
             f x y = x
-            "#
+            "
         ),
-        @r###"
+        @r#"
     ── ARGUMENTS BEFORE EQUALS ────────────────── tmp/elm_function_syntax/Test.roc ─
 
     I am partway through parsing a definition, but I got stuck here:
@@ -3387,7 +3387,7 @@ mod test_reporting {
 
     Looks like you are trying to define a function. In roc, functions are
     always written as a lambda, like increment = \n -> n + 1.
-    "###
+    "#
     );
 
     test_report!(
@@ -3402,7 +3402,7 @@ mod test_reporting {
             x
             "#
         ),
-        @r###"
+        @r#"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     Something is off with the body of the `x` definition:
@@ -3430,7 +3430,7 @@ mod test_reporting {
             Cons {} a,
             Nil,
         ] as a
-    "###
+    "#
     );
 
     test_report!(
@@ -3451,7 +3451,7 @@ mod test_reporting {
         ),
         // TODO render tag unions across multiple lines
         // TODO do not show recursion var if the recursion var does not render on the surface of a type
-        @r###"
+        @r#"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     Something is off with the body of the `x` definition:
@@ -3485,13 +3485,13 @@ mod test_reporting {
             ACons I64 (BList I64 I64),
             ANil,
         ] as a
-    "###
+    "#
     );
 
     test_report!(
         integer_out_of_range,
         indoc!(
-            r#"
+            r"
             x = 170_141_183_460_469_231_731_687_303_715_884_105_728_000
 
             y = -170_141_183_460_469_231_731_687_303_715_884_105_728_000
@@ -3503,9 +3503,9 @@ mod test_reporting {
             maxlit =  340_282_366_920_938_463_463_374_607_431_768_211_455
 
             x + y + h + l + minlit + maxlit
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── SYNTAX PROBLEM ──────────────────────────────────────── /code/proj/Main.roc ─
 
     This integer literal is too big:
@@ -3568,21 +3568,21 @@ mod test_reporting {
     But + needs its 2nd argument to be:
 
         I128 or Dec
-    "###
+    "
     );
 
     // have to deal with some whitespace issues because of the format! macro
     test_report!(
         float_out_of_range,
         indoc!(
-            r#"
+            r"
             overflow = 11.7976931348623157e308
             underflow = -11.7976931348623157e308
 
             overflow + underflow
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── SYNTAX PROBLEM ──────────────────────────────────────── /code/proj/Main.roc ─
 
     This float literal is too big:
@@ -3606,7 +3606,7 @@ mod test_reporting {
     -1.7976931348623157e308 and 1.7976931348623157e308
 
     Tip: Learn more about number literals at TODO
-    "###
+    "
     );
 
     // the generated messages here are incorrect. Waiting for a rust nightly feature to land,
@@ -3615,7 +3615,7 @@ mod test_reporting {
     test_report!(
         integer_malformed,
         indoc!(
-            r#"
+            r"
             dec = 100A
 
             hex = 0xZZZ
@@ -3625,9 +3625,9 @@ mod test_reporting {
             bin = 0b2
 
             dec + hex + oct + bin
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── SYNTAX PROBLEM ──────────────────────────────────────── /code/proj/Main.roc ─
 
     This integer literal contains an invalid digit:
@@ -3675,13 +3675,13 @@ mod test_reporting {
     0 and 1, or have an integer suffix.
 
     Tip: Learn more about number literals at TODO
-    "###
+    "
     );
 
     test_report!(
         integer_empty,
         indoc!(
-            r#"
+            r"
             dec = 20
 
             hex = 0x
@@ -3691,9 +3691,9 @@ mod test_reporting {
             bin = 0b
 
             dec + hex + oct + bin
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── SYNTAX PROBLEM ──────────────────────────────────────── /code/proj/Main.roc ─
 
     This hex integer literal contains no digits:
@@ -3729,19 +3729,19 @@ mod test_reporting {
     digits 0 and 1, or have an integer suffix.
 
     Tip: Learn more about number literals at TODO
-    "###
+    "
     );
 
     test_report!(
         float_malformed,
         indoc!(
-            r#"
+            r"
             x = 3.0A
 
             x
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── SYNTAX PROBLEM ──────────────────────────────────────── /code/proj/Main.roc ─
 
     This float literal contains an invalid digit:
@@ -3753,13 +3753,13 @@ mod test_reporting {
     scientific notation 10e4, or have a float suffix.
 
     Tip: Learn more about number literals at TODO
-    "###
+    "
     );
 
     test_report!(
         invalid_record_update,
         indoc!(
-            r#"
+            r"
             foo = { bar: 3 }
             updateNestedRecord = { foo.bar & x: 4 }
 
@@ -3770,9 +3770,9 @@ mod test_reporting {
             x = { example & age: 4 }
 
             { updateNestedRecord, foo, x, y }
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── SYNTAX PROBLEM ──────────────────────────────────────── /code/proj/Main.roc ─
 
     This expression cannot be updated:
@@ -3805,17 +3805,17 @@ mod test_reporting {
                    ^^^^^^^^^^^^
 
     Only variables can be updated with record update syntax.
-    "###
+    "
     );
 
     test_report!(
         module_not_imported,
         indoc!(
-            r#"
+            r"
             Foo.test
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── MODULE NOT IMPORTED ─────────────────────────────────── /code/proj/Main.roc ─
 
     The `Foo` module is not imported:
@@ -3830,17 +3830,17 @@ mod test_reporting {
         Bool
         Num
         Set
-    "###
+    "
     );
 
     test_report!(
         optional_record_default_type_error,
         indoc!(
-            r#"
+            r"
             \{ x, y ? True } -> x + y
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     This 2nd argument to + has an unexpected type:
@@ -3855,7 +3855,7 @@ mod test_reporting {
     But + needs its 2nd argument to be:
 
         Num a
-    "###
+    "
     );
 
     test_report!(
@@ -3868,7 +3868,7 @@ mod test_reporting {
             f
             "#
         ),
-        @r###"
+        @r#"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     The 1st argument to `f` is weird:
@@ -3883,21 +3883,21 @@ mod test_reporting {
     But the annotation on `f` says the 1st argument should be:
 
         { y ? I64, … }
-    "###
+    "#
     );
 
     test_report!(
         optional_record_invalid_let_binding,
         indoc!(
-            r#"
+            r"
             \rec ->
                 { x, y } : { x : Num.I64, y ? Str }
                 { x, y } = rec
 
                 { x, y }
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     Something is off with the body of this definition:
@@ -3915,20 +3915,20 @@ mod test_reporting {
 
     Tip: To extract the `.y` field it must be non-optional, but the type
     says this field is optional. Learn more about optional fields at TODO.
-    "###
+    "
     );
 
     test_report!(
         optional_record_invalid_function,
         indoc!(
-            r#"
+            r"
             f : { x : Num.I64, y ? Num.I64 } -> Num.I64
             f = \{ x, y } -> x + y
 
             f
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     The 1st argument to `f` is weird:
@@ -3946,22 +3946,22 @@ mod test_reporting {
 
     Tip: To extract the `.y` field it must be non-optional, but the type
     says this field is optional. Learn more about optional fields at TODO.
-    "###
+    "
     );
 
     test_report!(
         optional_record_invalid_when,
         indoc!(
-            r#"
+            r"
             f : { x : Num.I64, y ? Num.I64 } -> Num.I64
             f = \r ->
                     when r is
                         { x, y } -> x + y
 
             f
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     The branches of this `when` expression don't match the condition:
@@ -3981,20 +3981,20 @@ mod test_reporting {
 
     Tip: To extract the `.y` field it must be non-optional, but the type
     says this field is optional. Learn more about optional fields at TODO.
-    "###
+    "
     );
 
     test_report!(
         optional_record_invalid_access,
         indoc!(
-            r#"
+            r"
             f : { x : Num.I64, y ? Num.I64 } -> Num.I64
             f = \r -> r.y
 
             f
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     This expression is used in an unexpected way:
@@ -4012,20 +4012,20 @@ mod test_reporting {
 
     Tip: To extract the `.y` field it must be non-optional, but the type
     says this field is optional. Learn more about optional fields at TODO.
-    "###
+    "
     );
 
     test_report!(
         optional_record_invalid_accessor,
         indoc!(
-            r#"
+            r"
                 f : { x : Num.I64, y ? Num.I64 } -> Num.I64
                 f = \r -> .y r
 
                 f
-                "#
+                "
         ),
-        @r###"
+        @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     This 1st argument to this function has an unexpected type:
@@ -4043,7 +4043,7 @@ mod test_reporting {
 
     Tip: To extract the `.y` field it must be non-optional, but the type
     says this field is optional. Learn more about optional fields at TODO.
-    "###
+    "
     );
 
     test_report!(
@@ -4059,7 +4059,7 @@ mod test_reporting {
             f
             "#
         ),
-        @r###"
+        @r#"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     The branches of this `when` expression don't match the condition:
@@ -4077,7 +4077,7 @@ mod test_reporting {
         { y : Str, … }
 
     The branches must be cases of the `when` condition's type!
-    "###
+    "#
     );
 
     test_report!(
@@ -4093,7 +4093,7 @@ mod test_reporting {
             f
             "#
         ),
-        @r###"
+        @r#"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     The branches of this `when` expression don't match the condition:
@@ -4111,17 +4111,17 @@ mod test_reporting {
         { y ? Str, … }
 
     The branches must be cases of the `when` condition's type!
-    "###
+    "#
     );
 
     test_report!(
         incorrect_optional_field,
         indoc!(
-            r#"
+            r"
             { x: 5, y ? 42 }
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── BAD OPTIONAL VALUE ──────────────────────────────────── /code/proj/Main.roc ─
 
     This record uses an optional value for the `.y` field in an incorrect
@@ -4133,17 +4133,17 @@ mod test_reporting {
     You can only use optional values in record destructuring, like:
 
         { answer ? 42, otherField } = myRecord
-    "###
+    "
     );
 
     test_report!(
         first_wildcard_is_required,
         indoc!(
-            r#"
+            r"
             when Foo 1 2 3 is
                 Foo _ 1 _ -> 1
                 _ -> 2
-            "#
+            "
         ),
         @""
     );
@@ -4151,14 +4151,14 @@ mod test_reporting {
     test_report!(
         second_wildcard_is_redundant,
         indoc!(
-            r#"
+            r"
             when Foo 1 2 3 is
                 Foo _ 1 _ -> 1
                 _ -> 2
                 _ -> 3
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── REDUNDANT PATTERN ───────────────────────────────────── /code/proj/Main.roc ─
 
     The 3rd pattern is redundant:
@@ -4171,13 +4171,13 @@ mod test_reporting {
 
     Any value of this shape will be handled by a previous pattern, so this
     one should be removed.
-    "###
+    "
     );
 
     test_report!(
         alias_using_alias,
         indoc!(
-            r#"
+            r"
             # The color of a node. Leaves are considered Black.
             NodeColor : [Red, Black]
 
@@ -4189,7 +4189,7 @@ mod test_reporting {
                 Empty
 
             empty
-            "#
+            "
         ),
         @""
     );
@@ -4197,13 +4197,13 @@ mod test_reporting {
     test_report!(
         unused_argument,
         indoc!(
-            r#"
+            r"
             f = \foo -> 1
 
             f
-            "#
+            "
         ),
-        @r###"
+        @r#"
     ── UNUSED ARGUMENT ─────────────────────────────────────── /code/proj/Main.roc ─
 
     `f` doesn't use `foo`.
@@ -4215,17 +4215,17 @@ mod test_reporting {
     really do need `foo` as an argument of `f`, prefix it with an underscore,
     like this: "_`foo`". Adding an underscore at the start of a variable
     name is a way of saying that the variable is not used.
-    "###
+    "#
     );
 
     test_report!(
         qualified_tag,
         indoc!(
-            r#"
+            r"
             Foo.Bar
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── SYNTAX PROBLEM ──────────────────────────────────────── /code/proj/Main.roc ─
 
     I am trying to parse a qualified name here:
@@ -4236,17 +4236,17 @@ mod test_reporting {
     This looks like a qualified tag name to me, but tags cannot be
     qualified! Maybe you wanted a qualified name, something like
     Json.Decode.string?
-    "###
+    "
     );
 
     test_report!(
         module_ident_ends_with_dot,
         indoc!(
-            r#"
+            r"
             Foo.Bar.
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── SYNTAX PROBLEM ──────────────────────────────────────── /code/proj/Main.roc ─
 
     I am trying to parse a qualified name here:
@@ -4256,17 +4256,17 @@ mod test_reporting {
 
     I was expecting to see an identifier next, like height. A complete
     qualified name looks something like Json.Decode.string.
-    "###
+    "
     );
 
     test_report!(
         record_access_ends_with_dot,
         indoc!(
-            r#"
+            r"
             foo.bar.
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── SYNTAX PROBLEM ──────────────────────────────────────── /code/proj/Main.roc ─
 
     I am trying to parse a record field access here:
@@ -4275,20 +4275,20 @@ mod test_reporting {
                     ^
 
     So I expect to see a lowercase letter next, like .name or .height.
-    "###
+    "
     );
 
     test_report!(
         type_annotation_double_colon,
         indoc!(
-            r#"
+            r"
             f :: I64
             f = 42
 
             f
-            "#
+            "
         ),
-        @r###"
+        @r#"
     ── UNKNOWN OPERATOR ──────────────── tmp/type_annotation_double_colon/Test.roc ─
 
     This looks like an operator, but it's not one I recognize!
@@ -4301,7 +4301,7 @@ mod test_reporting {
 
     I have no specific suggestion for this operator, see TODO for the full
     list of operators in Roc.
-    "###
+    "#
     );
 
     // NOTE: VERY BAD ERROR MESSAGE
@@ -4311,16 +4311,16 @@ mod test_reporting {
     test_report!(
         double_equals_in_def,
         indoc!(
-            r#"
+            r"
             x = 3
             y =
                 x == 5
                 Num.add 1 2
 
             { x,  y }
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── TOO MANY ARGS ───────────────────────────────────────── /code/proj/Main.roc ─
 
     This value is not a function, but it was given 3 arguments:
@@ -4329,17 +4329,17 @@ mod test_reporting {
                      ^
 
     Are there any missing commas? Or missing parentheses?
-    "###
+    "
     );
 
     test_report!(
         tag_union_open,
         indoc!(
-            r#"
+            r"
             f : [
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── UNFINISHED TAG UNION TYPE ───────────────────── tmp/tag_union_open/Test.roc ─
 
     I am partway through parsing a tag union type, but I got stuck here:
@@ -4351,17 +4351,17 @@ mod test_reporting {
 
     I was expecting to see a closing square bracket before this, so try
     adding a ] and see if that helps?
-    "###
+    "
     );
 
     test_report!(
         tag_union_end,
         indoc!(
-            r#"
+            r"
             f : [Yes,
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── UNFINISHED TAG UNION TYPE ────────────────────── tmp/tag_union_end/Test.roc ─
 
     I am partway through parsing a tag union type, but I got stuck here:
@@ -4373,17 +4373,17 @@ mod test_reporting {
 
     I was expecting to see a closing square bracket before this, so try
     adding a ] and see if that helps?
-    "###
+    "
     );
 
     test_report!(
         tag_union_lowercase_tag_name,
         indoc!(
-            r#"
+            r"
             f : [lowercase]
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── WEIRD TAG NAME ────────────────── tmp/tag_union_lowercase_tag_name/Test.roc ─
 
     I am partway through parsing a tag union type, but I got stuck here:
@@ -4394,17 +4394,17 @@ mod test_reporting {
     I was expecting to see a tag name.
 
     Hint: Tag names start with an uppercase letter, like Err or Green.
-    "###
+    "
     );
 
     test_report!(
         tag_union_second_lowercase_tag_name,
         indoc!(
-            r#"
+            r"
             f : [Good, bad]
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── WEIRD TAG NAME ─────────── tmp/tag_union_second_lowercase_tag_name/Test.roc ─
 
     I am partway through parsing a tag union type, but I got stuck here:
@@ -4415,17 +4415,17 @@ mod test_reporting {
     I was expecting to see a tag name.
 
     Hint: Tag names start with an uppercase letter, like Err or Green.
-    "###
+    "
     );
 
     test_report!(
         record_type_open,
         indoc!(
-            r#"
+            r"
             f : {
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── UNFINISHED RECORD TYPE ────────────────────── tmp/record_type_open/Test.roc ─
 
     I am partway through parsing a record type, but I got stuck here:
@@ -4437,18 +4437,18 @@ mod test_reporting {
 
     I was expecting to see a closing curly brace before this, so try
     adding a } and see if that helps?
-    "###
+    "
     );
 
     test_report!(
         record_type_open_indent,
         indoc!(
-            r#"
+            r"
             f : {
             foo : I64,
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── UNFINISHED RECORD TYPE ─────────────── tmp/record_type_open_indent/Test.roc ─
 
     I am partway through parsing a record type, but I got stuck here:
@@ -4461,17 +4461,17 @@ mod test_reporting {
 
     I was expecting to see a closing curly brace before this, so try
     adding a } and see if that helps?
-    "###
+    "
     );
 
     test_report!(
         record_type_end,
         indoc!(
-            r#"
+            r"
             f : { a: Int,
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── UNFINISHED RECORD TYPE ─────────────────────── tmp/record_type_end/Test.roc ─
 
     I am partway through parsing a record type, but I got stuck here:
@@ -4483,17 +4483,17 @@ mod test_reporting {
 
     I was expecting to see a closing curly brace before this, so try
     adding a } and see if that helps?
-    "###
+    "
     );
 
     test_report!(
         record_type_keyword_field_name,
         indoc!(
-            r#"
+            r"
             f : { if : I64 }
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── UNFINISHED RECORD TYPE ──────── tmp/record_type_keyword_field_name/Test.roc ─
 
     I just started parsing a record type, but I got stuck on this field
@@ -4504,18 +4504,18 @@ mod test_reporting {
 
     Looks like you are trying to use `if` as a field name, but that is a
     reserved word. Try using a different name!
-    "###
+    "
     );
 
     // a case where the message cannot be as good as elm's
     test_report!(
         record_type_missing_comma,
         indoc!(
-            r#"
+            r"
             f : { foo  bar }
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── UNFINISHED RECORD TYPE ───────────── tmp/record_type_missing_comma/Test.roc ─
 
     I am partway through parsing a record type, but I got stuck here:
@@ -4525,14 +4525,14 @@ mod test_reporting {
 
     I was expecting to see a colon, question mark, comma or closing curly
     brace.
-    "###
+    "
     );
 
     // a case where the message cannot be as good as elm's
     test_report!(
         record_type_tab,
         "f : { foo \t }",
-        @r###"
+        @r"
     ── TAB CHARACTER ──────────────────────────────── tmp/record_type_tab/Test.roc ─
 
     I encountered a tab character:
@@ -4541,13 +4541,13 @@ mod test_reporting {
                       ^
 
     Tab characters are not allowed, use spaces instead.
-    "###
+    "
     );
 
     test_report!(
         comment_with_tab,
         "# comment with a \t\n4",
-        @r###"
+        @r"
     ── TAB CHARACTER ─────────────────────────────── tmp/comment_with_tab/Test.roc ─
 
     I encountered a tab character:
@@ -4556,13 +4556,13 @@ mod test_reporting {
                              ^
 
     Tab characters are not allowed, use spaces instead.
-    "###
+    "
     );
 
     test_report!(
         comment_with_control_character,
         "# comment with a \x07\n",
-        @r###"
+        @r"
     ── ASCII CONTROL CHARACTER ─────── tmp/comment_with_control_character/Test.roc ─
 
     I encountered an ASCII control character:
@@ -4571,13 +4571,13 @@ mod test_reporting {
                              ^
 
     ASCII control characters are not allowed.
-    "###
+    "
     );
 
     test_report!(
         record_type_carriage_return,
         "f : { \r foo }",
-        @r###"
+        @r"
     ── MISPLACED CARRIAGE RETURN ──────── tmp/record_type_carriage_return/Test.roc ─
 
     I encountered a stray carriage return (\r):
@@ -4586,18 +4586,18 @@ mod test_reporting {
                   ^
 
     A carriage return (\r) has to be followed by a newline (\n).
-    "###
+    "
     );
 
     // TODO bad error message
     test_report!(
         type_in_parens_start,
         indoc!(
-            r#"
+            r"
             f : (
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── UNFINISHED PARENTHESES ────────────────── tmp/type_in_parens_start/Test.roc ─
 
     I am partway through parsing a type in parentheses, but I got stuck
@@ -4610,17 +4610,17 @@ mod test_reporting {
 
     I was expecting to see a closing parenthesis before this, so try
     adding a ) and see if that helps?
-    "###
+    "
     );
 
     test_report!(
         type_in_parens_end,
         indoc!(
-            r#"
+            r"
             f : ( I64
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── UNFINISHED PARENTHESES ──────────────────── tmp/type_in_parens_end/Test.roc ─
 
     I am partway through parsing a type in parentheses, but I got stuck
@@ -4633,19 +4633,19 @@ mod test_reporting {
 
     I was expecting to see a closing parenthesis before this, so try
     adding a ) and see if that helps?
-    "###
+    "
     );
 
     test_report!(
         type_apply_double_dot,
         indoc!(
-            r#"
+            r"
             f : Foo..Bar
 
             f
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── SYNTAX PROBLEM ──────────────────────────────────────── /code/proj/Main.roc ─
 
     I am confused by this type name:
@@ -4655,7 +4655,7 @@ mod test_reporting {
 
     Type names start with an uppercase letter, and can optionally be
     qualified by a module name, like Bool or Http.Request.Request.
-    "###
+    "
     );
     //                ── DOUBLE DOT ──────────────────────────────────────────────────────────────────
     //
@@ -4669,13 +4669,13 @@ mod test_reporting {
     test_report!(
         type_apply_trailing_dot,
         indoc!(
-            r#"
+            r"
             f : Foo.Bar.
 
             f
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── SYNTAX PROBLEM ──────────────────────────────────────── /code/proj/Main.roc ─
 
     I am confused by this type name:
@@ -4685,7 +4685,7 @@ mod test_reporting {
 
     Type names start with an uppercase letter, and can optionally be
     qualified by a module name, like Bool or Http.Request.Request.
-    "###
+    "
     );
     //                ── TRAILING DOT ────────────────────────────────────────────────────────────────
     //
@@ -4700,11 +4700,11 @@ mod test_reporting {
     test_report!(
         type_apply_stray_dot,
         indoc!(
-            r#"
+            r"
             f : .
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── UNFINISHED TYPE ───────────────────────── tmp/type_apply_stray_dot/Test.roc ─
 
     I just started parsing a type, but I got stuck here:
@@ -4713,19 +4713,19 @@ mod test_reporting {
                 ^
 
     I am expecting a type next, like Bool or List a.
-    "###
+    "
     );
 
     test_report!(
         type_apply_start_with_number,
         indoc!(
-            r#"
+            r"
             f : Foo.1
 
             f
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── SYNTAX PROBLEM ──────────────────────────────────────── /code/proj/Main.roc ─
 
     I am confused by this type name:
@@ -4735,7 +4735,7 @@ mod test_reporting {
 
     Type names start with an uppercase letter, and can optionally be
     qualified by a module name, like Bool or Http.Request.Request.
-    "###
+    "
     );
     //                ── WEIRD QUALIFIED NAME ────────────────────────────────────────────────────────
     //
@@ -4750,13 +4750,13 @@ mod test_reporting {
     test_report!(
         type_apply_start_with_lowercase,
         indoc!(
-            r#"
+            r"
             f : Foo.foo
 
             f
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── SYNTAX PROBLEM ──────────────────────────────────────── /code/proj/Main.roc ─
 
     I am confused by this type name:
@@ -4766,17 +4766,17 @@ mod test_reporting {
 
     Type names start with an uppercase letter, and can optionally be
     qualified by a module name, like Bool or Http.Request.Request.
-    "###
+    "
     );
 
     test_report!(
         def_missing_final_expression,
         indoc!(
-            r#"
+            r"
             f : Foo.foo
-            "#
+            "
         ),
-        @r###"
+        @r#"
     ── MISSING FINAL EXPRESSION ──────── tmp/def_missing_final_expression/Test.roc ─
 
     I am partway through parsing a definition, but I got stuck here:
@@ -4794,17 +4794,17 @@ mod test_reporting {
         y = 2
 
         x + y
-    "###
+    "#
     );
 
     test_report!(
         expression_indentation_end,
         indoc!(
-            r#"
+            r"
             f <- Foo.foo
-            "#
+            "
         ),
-        @r###"
+        @r#"
     ── INDENT ENDS AFTER EXPRESSION ────── tmp/expression_indentation_end/Test.roc ─
 
     I am partway through parsing an expression, but I got stuck here:
@@ -4817,20 +4817,20 @@ mod test_reporting {
 
     Looks like the indentation ends prematurely here. Did you mean to have
     another expression after this line?
-    "###
+    "#
     );
 
     test_report!(
         type_inline_alias,
         indoc!(
-            r#"
+            r"
             f : I64 as
             f = 0
 
             f
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── UNFINISHED INLINE ALIAS ──────────────────── tmp/type_inline_alias/Test.roc ─
 
     I just started parsing an inline type alias, but I got stuck here:
@@ -4839,20 +4839,20 @@ mod test_reporting {
                       ^
 
     Note: I may be confused by indentation
-    "###
+    "
     );
 
     test_report!(
         type_double_comma,
         indoc!(
-            r#"
+            r"
             f : I64,,I64 -> I64
             f = 0
 
             f
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── DOUBLE COMMA ─────────────────────────────── tmp/type_double_comma/Test.roc ─
 
     I just started parsing a function argument type, but I encountered two
@@ -4862,20 +4862,20 @@ mod test_reporting {
                     ^
 
     Try removing one of them.
-    "###
+    "
     );
 
     test_report!(
         type_argument_no_arrow,
         indoc!(
-            r#"
+            r"
             f : I64, I64
             f = 0
 
             f
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── UNFINISHED TYPE ─────────────────────── tmp/type_argument_no_arrow/Test.roc ─
 
     I am partway through parsing a type, but I got stuck here:
@@ -4884,21 +4884,21 @@ mod test_reporting {
                         ^
 
     Note: I may be confused by indentation
-    "###
+    "
     );
 
     // TODO could do better by pointing out we're parsing a function type
     test_report!(
         type_argument_arrow_then_nothing,
         indoc!(
-            r#"
+            r"
             f : I64, I64 ->
             f = 0
 
             f
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── UNFINISHED TYPE ───────────── tmp/type_argument_arrow_then_nothing/Test.roc ─
 
     I just started parsing a type, but I got stuck here:
@@ -4907,7 +4907,7 @@ mod test_reporting {
                            ^
 
     Note: I may be confused by indentation
-    "###
+    "
     );
 
     // TODO could do better by pointing out we're parsing a function type
@@ -4923,7 +4923,7 @@ mod test_reporting {
             main = myDict
             "#
         ),
-        @r###"
+        @r#"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     Something is off with the body of the `myDict` definition:
@@ -4939,7 +4939,7 @@ mod test_reporting {
     But the type annotation on `myDict` says it should be:
 
         Dict I64 Str
-    "###
+    "#
     );
 
     test_report!(
@@ -4958,7 +4958,7 @@ mod test_reporting {
             main = myDict
             "#
         ),
-        @r###"
+        @r#"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     Something is off with the body of the `myDict` definition:
@@ -4974,23 +4974,23 @@ mod test_reporting {
     But the type annotation on `myDict` says it should be:
 
         HSet Str
-    "###
+    "#
     );
 
     // this should get better with time
     test_report!(
         if_guard_without_condition,
         indoc!(
-            r#"
+            r"
             when Just 4 is
                 Just if ->
                     4
 
                 _ ->
                     2
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── IF GUARD NO CONDITION ───────────── tmp/if_guard_without_condition/Test.roc ─
 
     I just started parsing an if guard, but there is no guard condition:
@@ -5000,22 +5000,22 @@ mod test_reporting {
                         ^
 
     Try adding an expression before the arrow!
-    "###
+    "
     );
 
     test_report!(
         empty_or_pattern,
         indoc!(
-            r#"
+            r"
             when Just 4 is
                 Just 4 | ->
                     4
 
                 _ ->
                     2
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── UNFINISHED PATTERN ────────────────────────── tmp/empty_or_pattern/Test.roc ─
 
     I just started parsing a pattern, but I got stuck here:
@@ -5024,23 +5024,23 @@ mod test_reporting {
                          ^
 
     Note: I may be confused by indentation
-    "###
+    "
     );
 
     // TODO check if "what_is_next" is a keyword
     test_report!(
         pattern_binds_keyword,
         indoc!(
-            r#"
+            r"
             when Just 4 is
                 Just when ->
                     4
 
                 _ ->
                     2
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── MISSING ARROW ────────────────────────── tmp/pattern_binds_keyword/Test.roc ─
 
     I am partway through parsing a `when` expression, but got stuck here:
@@ -5063,20 +5063,20 @@ mod test_reporting {
 
     Notice the indentation. All patterns are aligned, and each branch is
     indented a bit more than the corresponding pattern. That is important!
-    "###
+    "
     );
 
     // this should get better with time
     test_report!(
         when_missing_arrow,
         indoc!(
-            r#"
+            r"
             when 5 is
                 1 -> 2
                 _
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── UNFINISHED WHEN ─────────────────────────── tmp/when_missing_arrow/Test.roc ─
 
     I was partway through parsing a `when` expression, but I got stuck here:
@@ -5099,17 +5099,17 @@ mod test_reporting {
 
     Notice the indentation. All patterns are aligned, and each branch is
     indented a bit more than the corresponding pattern. That is important!
-    "###
+    "
     );
 
     test_report!(
         lambda_double_comma,
         indoc!(
-            r#"
+            r"
             \a,,b -> 1
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── UNFINISHED ARGUMENT LIST ───────────────── tmp/lambda_double_comma/Test.roc ─
 
     I am partway through parsing a function argument list, but I got stuck
@@ -5120,17 +5120,17 @@ mod test_reporting {
 
     I was expecting an argument pattern before this, so try adding an
     argument before the comma and see if that helps?
-    "###
+    "
     );
 
     test_report!(
         lambda_leading_comma,
         indoc!(
-            r#"
+            r"
             \,b -> 1
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── UNFINISHED ARGUMENT LIST ──────────────── tmp/lambda_leading_comma/Test.roc ─
 
     I am partway through parsing a function argument list, but I got stuck
@@ -5141,7 +5141,7 @@ mod test_reporting {
 
     I was expecting an argument pattern before this, so try adding an
     argument before the comma and see if that helps?
-    "###
+    "
     );
 
     // this should get better with time
@@ -5171,32 +5171,32 @@ mod test_reporting {
     test_report!(
         when_outdented_branch,
         indoc!(
-            r#"
+            r"
             when 4 is
                 5 -> 2
              2 -> 2
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── NOT END OF FILE ──────────────────────── tmp/when_outdented_branch/Test.roc ─
 
     I expected to reach the end of the file, but got stuck here:
 
     6│       2 -> 2
              ^
-    "###
+    "
     );
 
     test_report!(
         when_over_indented_underscore,
         indoc!(
-            r#"
+            r"
             when 4 is
                 5 -> 2
                  _ -> 2
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── UNEXPECTED ARROW ─────────────── tmp/when_over_indented_underscore/Test.roc ─
 
     I am parsing a `when` expression right now, but this arrow is confusing
@@ -5221,19 +5221,19 @@ mod test_reporting {
 
     Notice the indentation. All patterns are aligned, and each branch is
     indented a bit more than the corresponding pattern. That is important!
-    "###
+    "
     );
 
     test_report!(
         when_over_indented_int,
         indoc!(
-            r#"
+            r"
             when 4 is
                 5 -> Num.neg
                  2 -> 2
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── UNEXPECTED ARROW ────────────────────── tmp/when_over_indented_int/Test.roc ─
 
     I am parsing a `when` expression right now, but this arrow is confusing
@@ -5258,22 +5258,22 @@ mod test_reporting {
 
     Notice the indentation. All patterns are aligned, and each branch is
     indented a bit more than the corresponding pattern. That is important!
-    "###
+    "
     );
 
     // TODO I think we can do better here
     test_report!(
         if_outdented_then,
         indoc!(
-            r#"
+            r"
             x =
                 if 5 == 5
             then 2 else 3
 
             x
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── UNFINISHED IF ────────────────────────────── tmp/if_outdented_then/Test.roc ─
 
     I was partway through parsing an `if` expression, but I got stuck here:
@@ -5282,18 +5282,18 @@ mod test_reporting {
                          ^
 
     I was expecting to see the `then` keyword next.
-    "###
+    "
     );
 
     // this should get better with time
     test_report!(
         if_missing_else,
         indoc!(
-            r#"
+            r"
             if 5 == 5 then 2
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── UNFINISHED IF ──────────────────────────────── tmp/if_missing_else/Test.roc ─
 
     I was partway through parsing an `if` expression, but I got stuck here:
@@ -5302,17 +5302,17 @@ mod test_reporting {
                             ^
 
     I was expecting to see the `else` keyword next.
-    "###
+    "
     );
 
     test_report!(
         list_double_comma,
         indoc!(
-            r#"
+            r"
             [1, 2, , 3]
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── UNFINISHED LIST ──────────────────────────── tmp/list_double_comma/Test.roc ─
 
     I am partway through started parsing a list, but I got stuck here:
@@ -5322,17 +5322,17 @@ mod test_reporting {
 
     I was expecting to see a list entry before this comma, so try adding a
     list entry and see if that helps?
-    "###
+    "
     );
 
     test_report!(
         list_without_end,
         indoc!(
-            r#"
+            r"
             [1, 2,
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── UNFINISHED LIST ───────────────────────────── tmp/list_without_end/Test.roc ─
 
     I am partway through started parsing a list, but I got stuck here:
@@ -5348,17 +5348,17 @@ mod test_reporting {
     Note: When I get stuck like this, it usually means that there is a
     missing parenthesis or bracket somewhere earlier. It could also be a
     stray keyword or operator.
-    "###
+    "
     );
 
     test_report!(
         number_double_dot,
         indoc!(
-            r#"
+            r"
             1.1.1
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── SYNTAX PROBLEM ──────────────────────────────────────── /code/proj/Main.roc ─
 
     This float literal contains an invalid digit:
@@ -5370,13 +5370,13 @@ mod test_reporting {
     scientific notation 10e4, or have a float suffix.
 
     Tip: Learn more about number literals at TODO
-    "###
+    "
     );
 
     test_report!(
         unicode_not_hex,
         r#""abc\u(zzzz)def""#,
-        @r###"
+        @r#"
     ── WEIRD CODE POINT ───────────────────────────── tmp/unicode_not_hex/Test.roc ─
 
     I am partway through parsing a unicode code point, but I got stuck
@@ -5388,13 +5388,13 @@ mod test_reporting {
     I was expecting a hexadecimal number, like \u(1100) or \u(00FF).
 
     Learn more about working with unicode in roc at TODO
-    "###
+    "#
     );
 
     test_report!(
         unicode_too_large,
         r#""abc\u(110000)def""#,
-        @r###"
+        @r#"
     ── INVALID UNICODE ─────────────────────────────────────── /code/proj/Main.roc ─
 
     This unicode code point is invalid:
@@ -5403,13 +5403,13 @@ mod test_reporting {
                    ^^^^^^
 
     Learn more about working with unicode in roc at TODO
-    "###
+    "#
     );
 
     test_report!(
         weird_escape,
         r#""abc\qdef""#,
-        @r###"
+        @r#"
     ── WEIRD ESCAPE ──────────────────────────────────── tmp/weird_escape/Test.roc ─
 
     I was partway through parsing a  string literal, but I got stuck here:
@@ -5427,13 +5427,13 @@ mod test_reporting {
         - An escaped backslash: \\
         - A unicode code point: \u(00FF)
         - An interpolated string: \(myVariable)
-    "###
+    "#
     );
 
     test_report!(
         single_quote_too_long,
-        r#"'abcdef'"#,
-        @r###"
+        r"'abcdef'",
+        @r#"
     ── INVALID SCALAR ───────────────────────── tmp/single_quote_too_long/Test.roc ─
 
     I am part way through parsing this scalar literal (character literal),
@@ -5444,13 +5444,13 @@ mod test_reporting {
 
     You could change it to something like 'a' or '\n'. Note, roc strings
     use double quotes, like "hello".
-    "###
+    "#
     );
 
     test_report!(
         single_no_end,
         r#""there is no end"#,
-        @r###"
+        @r#"
     ── ENDLESS STRING ───────────────────────────────── tmp/single_no_end/Test.roc ─
 
     I cannot find the end of this string:
@@ -5460,13 +5460,13 @@ mod test_reporting {
 
     You could change it to something like "to be or not to be" or even
     just "".
-    "###
+    "#
     );
 
     test_report!(
         multi_no_end,
         r#""""there is no end"#,
-        @r###"
+        @r#"
     ── ENDLESS STRING ────────────────────────────────── tmp/multi_no_end/Test.roc ─
 
     I cannot find the end of this block string:
@@ -5476,13 +5476,13 @@ mod test_reporting {
 
     You could change it to something like """to be or not to be""" or even
     just """""".
-    "###
+    "#
     );
 
     test_report!(
         multi_insufficient_indent,
         "    \"\"\"\n  testing\n    \"\"\"", // 4 space indent on the start, 2 space on the `testing` line
-        @r###"
+        @r#"
     ── INSUFFICIENT INDENT IN MULTI-LINE STRING ─ ..._insufficient_indent/Test.roc ─
 
     This multiline string is not sufficiently indented:
@@ -5494,17 +5494,17 @@ mod test_reporting {
     Lines in a multi-line string must be indented at least as much as the
     beginning """. This extra indentation is automatically removed from
     the string during compilation.
-    "###
+    "#
     );
 
     test_report!(
         dbg_without_final_expression,
         indoc!(
-            r#"
+            r"
             dbg 42
-            "#
+            "
         ),
-        @r###"
+        @r#"
     ── INDENT ENDS AFTER EXPRESSION ──── tmp/dbg_without_final_expression/Test.roc ─
 
     I am partway through parsing a dbg statement, but I got stuck here:
@@ -5516,17 +5516,17 @@ mod test_reporting {
 
         dbg 42
         "done"
-    "###
+    "#
     );
 
     test_report!(
         expect_without_final_expression,
         indoc!(
-            r#"
+            r"
             expect 1 + 1 == 2
-            "#
+            "
         ),
-        @r###"
+        @r#"
     ── INDENT ENDS AFTER EXPRESSION ─ tmp/expect_without_final_expression/Test.roc ─
 
     I am partway through parsing an expect statement, but I got stuck
@@ -5539,7 +5539,7 @@ mod test_reporting {
 
         expect 1 + 1 == 2
         "done"
-    "###
+    "#
     );
 
     // https://github.com/roc-lang/roc/issues/1714
@@ -5552,7 +5552,7 @@ mod test_reporting {
             if Bool.true then 1 else "\(greeting), World!"
             "#,
             ),
-            @r###"
+            @r#"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     This `if` has an `else` branch with a different type from its `then` branch:
@@ -5569,7 +5569,7 @@ mod test_reporting {
         Num *
 
     All branches in an `if` must have the same type!
-    "###
+    "#
         );
 
     macro_rules! comparison_binop_transparency_tests {
@@ -5615,13 +5615,13 @@ All branches in an `if` must have the same type!
     test_report!(
         keyword_record_field_access,
         indoc!(
-            r#"
+            r"
             foo = {}
 
             foo.if
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     This `foo` record doesn’t have a `if` field:
@@ -5630,17 +5630,17 @@ All branches in an `if` must have the same type!
             ^^^^^^
 
     In fact, `foo` is a record with no fields at all!
-    "###
+    "
     );
 
     test_report!(
         keyword_qualified_import,
         indoc!(
-            r#"
+            r"
             Num.if
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── NOT EXPOSED ─────────────────────────────────────────── /code/proj/Main.roc ─
 
     The Num module does not expose `if`:
@@ -5654,17 +5654,17 @@ All branches in an `if` must have the same type!
         Num.div
         Num.min
         Num.e
-    "###
+    "
     );
 
     test_report!(
         stray_dot_expr,
         indoc!(
-            r#"
+            r"
             Num.add . 23
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── SYNTAX PROBLEM ──────────────────────────────────────── /code/proj/Main.roc ─
 
     I am trying to parse a record field access here:
@@ -5673,17 +5673,17 @@ All branches in an `if` must have the same type!
                      ^
 
     So I expect to see a lowercase letter next, like .name or .height.
-    "###
+    "
     );
 
     test_report!(
         opaque_ref_field_access,
         indoc!(
-            r#"
+            r"
             @UUID.bar
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── SYNTAX PROBLEM ──────────────────────────────────────── /code/proj/Main.roc ─
 
     I am very confused by this field access:
@@ -5692,17 +5692,17 @@ All branches in an `if` must have the same type!
                  ^^^^
 
     It looks like a record field access on an opaque reference.
-    "###
+    "
     );
 
     test_report!(
         weird_accessor,
         indoc!(
-            r#"
+            r"
             .foo.bar
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── SYNTAX PROBLEM ──────────────────────────────────────── /code/proj/Main.roc ─
 
     I am very confused by this field access
@@ -5713,17 +5713,17 @@ All branches in an `if` must have the same type!
     It looks like a field access on an accessor. I parse.client.name as
     (.client).name. Maybe use an anonymous function like
     (\r -> r.client.name) instead?
-    "###
+    "
     );
 
     test_report!(
         closure_underscore_ident,
         indoc!(
-            r#"
+            r"
             \the_answer -> 100
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── NAMING PROBLEM ──────────────────────────────────────── /code/proj/Main.roc ─
 
     I am trying to parse an identifier here:
@@ -5732,32 +5732,32 @@ All branches in an `if` must have the same type!
                 ^
 
     Underscores are not allowed in identifiers. Use camelCase instead!
-    "###
+    "
     );
 
     test_report!(
         #[ignore]
         double_binop,
         indoc!(
-            r#"
+            r"
             key >= 97 && <= 122
-            "#
+            "
         ),
-        @r#"
-        "#
+        @r"
+        "
     );
 
     test_report!(
         #[ignore]
         case_of,
         indoc!(
-            r#"
+            r"
             case 1 of
                 1 -> True
                 _ -> False
-            "#
+            "
         ),
-        @r###"
+        @r#"
     ── UNKNOWN OPERATOR ───────────────────────────────────── tmp/case_of/Test.roc ─
 
     This looks like an operator, but it's not one I recognize!
@@ -5780,7 +5780,7 @@ All branches in an `if` must have the same type!
         increment : I64 -> I64
         increment = \n -> n + 1
 
-    "###
+    "#
     );
 
     test_report!(
@@ -5790,7 +5790,7 @@ All branches in an `if` must have the same type!
             ["foo", bar("")]
             "#
         ),
-        @r###"
+        @r#"
     ── UNRECOGNIZED NAME ───────────────────────────────────── /code/proj/Main.roc ─
 
     Nothing is named `bar` in this scope.
@@ -5804,18 +5804,18 @@ All branches in an `if` must have the same type!
         Str
         Err
         U8
-    "###
+    "#
     );
 
     test_report!(
         invalid_operator,
         indoc!(
-            r#"
+            r"
             main =
                 5 ** 3
-            "#
+            "
         ),
-        @r###"
+        @r#"
     ── UNKNOWN OPERATOR ──────────────────────────── tmp/invalid_operator/Test.roc ─
 
     This looks like an operator, but it's not one I recognize!
@@ -5829,18 +5829,18 @@ All branches in an `if` must have the same type!
 
     I have no specific suggestion for this operator, see TODO for the full
     list of operators in Roc.
-    "###
+    "#
     );
 
     test_report!(
         double_plus,
         indoc!(
-            r#"
+            r"
             main =
                 [] ++ []
-            "#
+            "
         ),
-        @r###"
+        @r#"
     ── UNKNOWN OPERATOR ───────────────────────────────── tmp/double_plus/Test.roc ─
 
     This looks like an operator, but it's not one I recognize!
@@ -5854,20 +5854,20 @@ All branches in an `if` must have the same type!
 
     To concatenate two lists or strings, try using List.concat or
     Str.concat instead.
-    "###
+    "#
     );
 
     test_report!(
         inline_hastype,
         indoc!(
-            r#"
+            r"
             main =
                 (\x -> x) : I64
 
                 3
-            "#
+            "
         ),
-        @r###"
+        @r#"
     ── UNKNOWN OPERATOR ────────────────────────────── tmp/inline_hastype/Test.roc ─
 
     This looks like an operator, but it's not one I recognize!
@@ -5884,7 +5884,7 @@ All branches in an `if` must have the same type!
 
         increment : I64 -> I64
         increment = \x -> x + 1
-    "###
+    "#
     );
 
     // this is still bad, but changing the order and progress of other parsers should improve it
@@ -5892,14 +5892,14 @@ All branches in an `if` must have the same type!
     test_report!(
         wild_case_arrow,
         indoc!(
-            r#"
+            r"
             main = 5 -> 3
-            "#
+            "
         ),
         |golden| pretty_assertions::assert_eq!(
             golden,
             &format!(
-                r###"── UNKNOWN OPERATOR ───────────────────────────── tmp/wild_case_arrow/Test.roc ─
+                r#"── UNKNOWN OPERATOR ───────────────────────────── tmp/wild_case_arrow/Test.roc ─
 
 This looks like an operator, but it's not one I recognize!
 
@@ -5913,7 +5913,7 @@ Looks like you are trying to define a function.{}
 
 In roc, functions are always written as a lambda, like{}
 
-    increment = \n -> n + 1"###,
+    increment = \n -> n + 1"#,
                 ' ', ' '
             )
         )
@@ -5931,7 +5931,7 @@ In roc, functions are always written as a lambda, like{}
                 "#
             ),
             indoc!(
-                r#"
+                r"
                 ── WEIRD PROVIDES ──────────────────────────────────────── /code/proj/Main.roc ─
 
                 I am partway through parsing a provides list, but I got stuck here:
@@ -5943,7 +5943,7 @@ In roc, functions are always written as a lambda, like{}
                 I was expecting a type name, value name or function name next, like
 
                     provides [Animal, default, tame]
-            "#
+            "
             ),
         )
     }
@@ -5966,7 +5966,7 @@ In roc, functions are always written as a lambda, like{}
                 "#
             ),
             indoc!(
-                r#"
+                r"
                 ── WEIRD PROVIDES ──────────────────────────────────────── /code/proj/Main.roc ─
 
                 I am partway through parsing a header, but I got stuck here:
@@ -5977,7 +5977,7 @@ In roc, functions are always written as a lambda, like{}
                 I am expecting the `provides` keyword next, like
 
                     provides [Animal, default, tame]
-            "#
+            "
             ),
         )
     }
@@ -6078,13 +6078,13 @@ In roc, functions are always written as a lambda, like{}
     fn missing_imports() {
         report_header_problem_as(
             indoc!(
-                r#"
+                r"
                 interface Foobar
                     exposes [main, Foo]
-                "#
+                "
             ),
             indoc!(
-                r#"
+                r"
                 ── WEIRD IMPORTS ───────────────────────────────────────── /code/proj/Main.roc ─
 
                 I am partway through parsing a header, but I got stuck here:
@@ -6095,7 +6095,7 @@ In roc, functions are always written as a lambda, like{}
                 I am expecting the `imports` keyword next, like
 
                     imports [Animal, default, tame]
-                "#
+                "
             ),
         )
     }
@@ -6104,14 +6104,14 @@ In roc, functions are always written as a lambda, like{}
     fn exposes_identifier() {
         report_header_problem_as(
             indoc!(
-                r#"
+                r"
                 interface Foobar
                     exposes [main, @Foo]
                     imports [pf.Task, Base64]
-                "#
+                "
             ),
             indoc!(
-                r#"
+                r"
                 ── WEIRD EXPOSES ───────────────────────────────────────── /code/proj/Main.roc ─
 
                 I am partway through parsing an `exposes` list, but I got stuck here:
@@ -6123,7 +6123,7 @@ In roc, functions are always written as a lambda, like{}
                 I was expecting a type name, value name or function name next, like
 
                     exposes [Animal, default, tame]
-            "#
+            "
             ),
         )
     }
@@ -6132,14 +6132,14 @@ In roc, functions are always written as a lambda, like{}
     fn invalid_module_name() {
         report_header_problem_as(
             indoc!(
-                r#"
+                r"
                 interface foobar
                     exposes [main, @Foo]
                     imports [pf.Task, Base64]
-                "#
+                "
             ),
             indoc!(
-                r#"
+                r"
                 ── WEIRD MODULE NAME ───────────────────────────────────── /code/proj/Main.roc ─
 
                 I am partway through parsing a header, but got stuck here:
@@ -6149,7 +6149,7 @@ In roc, functions are always written as a lambda, like{}
 
                 I am expecting a module name next, like BigNum or Main. Module names
                 must start with an uppercase letter.
-            "#
+            "
             ),
         )
     }
@@ -6158,11 +6158,11 @@ In roc, functions are always written as a lambda, like{}
     fn invalid_app_name() {
         report_header_problem_as(
             indoc!(
-                r#"
+                r"
                 app foobar
                     exposes [main, @Foo]
                     imports [pf.Task, Base64]
-                "#
+                "
             ),
             indoc!(
                 r#"
@@ -6183,13 +6183,13 @@ In roc, functions are always written as a lambda, like{}
     test_report!(
         apply_unary_negative,
         indoc!(
-            r#"
+            r"
             foo = 3
 
             -foo 1 2
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── TOO MANY ARGS ───────────────────────────────────────── /code/proj/Main.roc ─
 
     This value is not a function, but it was given 2 arguments:
@@ -6198,19 +6198,19 @@ In roc, functions are always written as a lambda, like{}
             ^^^^
 
     Are there any missing commas? Or missing parentheses?
-    "###
+    "
     );
 
     test_report!(
         apply_unary_not,
         indoc!(
-            r#"
+            r"
             foo = Bool.true
 
             !foo 1 2
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── TOO MANY ARGS ───────────────────────────────────────── /code/proj/Main.roc ─
 
     This value is not a function, but it was given 2 arguments:
@@ -6219,20 +6219,20 @@ In roc, functions are always written as a lambda, like{}
             ^^^^
 
     Are there any missing commas? Or missing parentheses?
-    "###
+    "
     );
 
     test_report!(
         applied_tag_function,
         indoc!(
-            r#"
+            r"
             x : List [Foo Str]
             x = List.map [1, 2] Foo
 
             x
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     Something is off with the body of the `x` definition:
@@ -6248,17 +6248,17 @@ In roc, functions are always written as a lambda, like{}
     But the type annotation on `x` says it should be:
 
         List [Foo Str]
-    "###
+    "
     );
 
     test_report!(
         pattern_in_parens_open,
         indoc!(
-            r#"
+            r"
             \( a
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── UNFINISHED PARENTHESES ──────────────── tmp/pattern_in_parens_open/Test.roc ─
 
     I am partway through parsing a pattern in parentheses, but I got stuck
@@ -6271,17 +6271,17 @@ In roc, functions are always written as a lambda, like{}
 
     I was expecting to see a closing parenthesis before this, so try
     adding a ) and see if that helps?
-    "###
+    "
     );
 
     test_report!(
         pattern_in_parens_end_comma,
         indoc!(
-            r#"
+            r"
             \( a,
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── UNFINISHED PARENTHESES ─────────── tmp/pattern_in_parens_end_comma/Test.roc ─
 
     I am partway through parsing a pattern in parentheses, but I got stuck
@@ -6294,17 +6294,17 @@ In roc, functions are always written as a lambda, like{}
 
     I was expecting to see a closing parenthesis before this, so try
     adding a ) and see if that helps?
-    "###
+    "
     );
 
     test_report!(
         pattern_in_parens_end,
         indoc!(
-            r#"
+            r"
             \( a
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── UNFINISHED PARENTHESES ───────────────── tmp/pattern_in_parens_end/Test.roc ─
 
     I am partway through parsing a pattern in parentheses, but I got stuck
@@ -6317,18 +6317,18 @@ In roc, functions are always written as a lambda, like{}
 
     I was expecting to see a closing parenthesis before this, so try
     adding a ) and see if that helps?
-    "###
+    "
     );
 
     test_report!(
         unfinished_closure_pattern_in_parens,
         indoc!(
-            r#"
+            r"
             x = \( a
             )
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── UNFINISHED FUNCTION ───── tmp/unfinished_closure_pattern_in_parens/Test.roc ─
 
     I was partway through parsing a  function, but I got stuck here:
@@ -6338,17 +6338,17 @@ In roc, functions are always written as a lambda, like{}
              ^
 
     I just saw a pattern, so I was expecting to see a -> next.
-    "###
+    "
     );
 
     test_report!(
         pattern_in_parens_indent_open,
         indoc!(
-            r#"
+            r"
             \(
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── UNFINISHED PARENTHESES ───────── tmp/pattern_in_parens_indent_open/Test.roc ─
 
     I am partway through parsing a pattern in parentheses, but I got stuck
@@ -6361,7 +6361,7 @@ In roc, functions are always written as a lambda, like{}
 
     I was expecting to see a closing parenthesis before this, so try
     adding a ) and see if that helps?
-    "###
+    "
     );
 
     test_report!(
@@ -6373,7 +6373,7 @@ In roc, functions are always written as a lambda, like{}
             x + 1
             "#
         ),
-        @r###"
+        @r#"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     This 2nd argument to `map` has an unexpected type:
@@ -6389,7 +6389,7 @@ In roc, functions are always written as a lambda, like{}
     But `map` needs its 2nd argument to be:
 
         Str -> Num *
-    "###
+    "#
     );
 
     test_report!(
@@ -6401,7 +6401,7 @@ In roc, functions are always written as a lambda, like{}
             4
             "#
         ),
-        @r###"
+        @r#"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     This `expect` condition needs to be a Bool:
@@ -6415,20 +6415,20 @@ In roc, functions are always written as a lambda, like{}
 
     But I need every `expect` condition to evaluate to a Bool—either
     `Bool.true` or `Bool.false`.
-    "###
+    "#
     );
 
     test_report!(
         num_too_general_wildcard,
         indoc!(
-            r#"
+            r"
             mult : Num.Num *, Num.F64 -> Num.F64
             mult = \a, b -> a * b
 
             mult 0 0
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     This 2nd argument to * has an unexpected type:
@@ -6459,20 +6459,20 @@ In roc, functions are always written as a lambda, like{}
     But the type annotation on `mult` says it should be:
 
         F64
-    "###
+    "
     );
 
     test_report!(
         num_too_general_named,
         indoc!(
-            r#"
+            r"
             mult : Num.Num a, Num.F64 -> Num.F64
             mult = \a, b -> a * b
 
             mult 0 0
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     This 2nd argument to * has an unexpected type:
@@ -6503,7 +6503,7 @@ In roc, functions are always written as a lambda, like{}
     But the type annotation on `mult` says it should be:
 
         F64
-    "###
+    "
     );
 
     test_report!(
@@ -6522,7 +6522,7 @@ In roc, functions are always written as a lambda, like{}
             canIGo
             "#
         ),
-        @r###"
+        @r"
     ── DUPLICATE NAME ──────────────────────────────────────── /code/proj/Main.roc ─
 
     This alias has the same name as a builtin:
@@ -6541,7 +6541,7 @@ In roc, functions are always written as a lambda, like{}
                           ^^^^^^^^
 
     Are there missing parentheses?
-    "###
+    "
     );
 
     test_report!(
@@ -6560,7 +6560,7 @@ In roc, functions are always written as a lambda, like{}
             canIGo
             "#
         ),
-        @r###"
+        @r"
     ── DUPLICATE NAME ──────────────────────────────────────── /code/proj/Main.roc ─
 
     This alias has the same name as a builtin:
@@ -6579,20 +6579,20 @@ In roc, functions are always written as a lambda, like{}
                           ^^^^^^^^^^^^
 
     Are there missing parentheses?
-    "###
+    "
     );
 
     test_report!(
         inference_var_conflict_in_rigid_links,
         indoc!(
-            r#"
+            r"
             f : a -> (_ -> b) where a implements Eq
             f = \x -> \y -> if x == y then x else y
             f
-            "#
+            "
         ),
         // TODO: We should tell the user that we inferred `_` as `a`
-        @r###"
+        @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     Something is off with the body of the `f` definition:
@@ -6613,20 +6613,20 @@ In roc, functions are always written as a lambda, like{}
     Your code seems to be saying they are the same though. Maybe they
     should be the same in your type annotation? Maybe your code uses them
     in a weird way?
-    "###
+    "
     );
 
     test_report!(
         error_wildcards_are_related,
         indoc!(
-            r#"
+            r"
             f : * -> *
             f = \x -> x
 
             f
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     Something is off with the body of the `f` definition:
@@ -6645,20 +6645,20 @@ In roc, functions are always written as a lambda, like{}
     Tip: Any connection between types must use a named type variable, not
     a `*`! Maybe the annotation  on `f` should have a named type variable in
     place of the `*`?
-    "###
+    "
     );
 
     test_report!(
         error_nested_wildcards_are_related,
         indoc!(
-            r#"
+            r"
             f : a, b, * -> {x: a, y: b, z: *}
             f = \x, y, z -> {x, y, z}
 
             f
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     Something is off with the body of the `f` definition:
@@ -6682,13 +6682,13 @@ In roc, functions are always written as a lambda, like{}
     Tip: Any connection between types must use a named type variable, not
     a `*`! Maybe the annotation  on `f` should have a named type variable in
     place of the `*`?
-    "###
+    "
     );
 
     test_report!(
         error_wildcards_are_related_in_nested_defs,
         indoc!(
-            r#"
+            r"
             f : a, b, * -> *
             f = \_, _, x2 ->
                 inner : * -> *
@@ -6696,9 +6696,9 @@ In roc, functions are always written as a lambda, like{}
                 inner x2
 
             f
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     Something is off with the body of the `inner` definition:
@@ -6717,17 +6717,17 @@ In roc, functions are always written as a lambda, like{}
     Tip: Any connection between types must use a named type variable, not
     a `*`! Maybe the annotation  on `inner` should have a named type variable
     in place of the `*`?
-    "###
+    "
     );
 
     test_report!(
         error_inline_alias_not_an_alias,
         indoc!(
-            r#"
+            r"
             f : List elem -> [Nil, Cons elem a] as a
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── NOT AN INLINE ALIAS ────────── tmp/error_inline_alias_not_an_alias/Test.roc ─
 
     The inline type after this `as` is not a type alias:
@@ -6737,17 +6737,17 @@ In roc, functions are always written as a lambda, like{}
 
     Inline alias types must start with an uppercase identifier and be
     followed by zero or more type arguments, like Point or List a.
-    "###
+    "
     );
 
     test_report!(
         error_inline_alias_qualified,
         indoc!(
-            r#"
+            r"
             f : List elem -> [Nil, Cons elem a] as Module.LinkedList a
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── QUALIFIED ALIAS NAME ──────────── tmp/error_inline_alias_qualified/Test.roc ─
 
     This type alias has a qualified name:
@@ -6757,17 +6757,17 @@ In roc, functions are always written as a lambda, like{}
 
     An alias introduces a new name to the current scope, so it must be
     unqualified.
-    "###
+    "
     );
 
     test_report!(
         error_inline_alias_argument_uppercase,
         indoc!(
-            r#"
+            r"
             f : List elem -> [Nil, Cons elem a] as LinkedList U
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── TYPE ARGUMENT NOT LOWERCASE ─ ...r_inline_alias_argument_uppercase/Test.roc ─
 
     This alias type argument is not lowercase:
@@ -6776,7 +6776,7 @@ In roc, functions are always written as a lambda, like{}
                                                               ^
 
     All type arguments must be lowercase.
-    "###
+    "
     );
 
     test_report!(
@@ -6791,7 +6791,7 @@ In roc, functions are always written as a lambda, like{}
             isEmpty (Name "boo")
             "#
         ),
-        @r###"
+        @r#"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     This 1st argument to `isEmpty` has an unexpected type:
@@ -6812,22 +6812,22 @@ In roc, functions are always written as a lambda, like{}
     Tip: Can more type annotations be added? Type annotations always help
     me give more specific messages, and I think they could help a lot in
     this case
-    "###
+    "#
     );
 
     test_report!(
         issue_2326,
         indoc!(
-            r#"
+            r"
             C a b : a -> D a b
             D a b : { a, b }
 
             f : C a Num.Nat -> D a Num.Nat
             f = \c -> c 6
             f
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     This 1st argument to `c` has an unexpected type:
@@ -6848,19 +6848,19 @@ In roc, functions are always written as a lambda, like{}
     it will only produce a `Num` value of a single specific type. Maybe
     change the type annotation to be more specific? Maybe change the code
     to be more general?
-    "###
+    "
     );
 
     test_report!(
         issue_2380_annotations_only,
         indoc!(
-            r#"
+            r"
             F : F
             a : F
             a
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── CYCLIC ALIAS ────────────────────────────────────────── /code/proj/Main.roc ─
 
     The `F` alias is self-recursive in an invalid way:
@@ -6870,20 +6870,20 @@ In roc, functions are always written as a lambda, like{}
 
     Recursion in aliases is only allowed if recursion happens behind a
     tagged union, at least one variant of which is not recursive.
-    "###
+    "
     );
 
     test_report!(
         issue_2380_typed_body,
         indoc!(
-            r#"
+            r"
             F : F
             a : F
             a = 1
             a
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── CYCLIC ALIAS ────────────────────────────────────────── /code/proj/Main.roc ─
 
     The `F` alias is self-recursive in an invalid way:
@@ -6893,19 +6893,19 @@ In roc, functions are always written as a lambda, like{}
 
     Recursion in aliases is only allowed if recursion happens behind a
     tagged union, at least one variant of which is not recursive.
-    "###
+    "
     );
 
     test_report!(
         issue_2380_alias_with_vars,
         indoc!(
-            r#"
+            r"
             F a b : F a b
             a : F Str Str
             a
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── CYCLIC ALIAS ────────────────────────────────────────── /code/proj/Main.roc ─
 
     The `F` alias is self-recursive in an invalid way:
@@ -6915,7 +6915,7 @@ In roc, functions are always written as a lambda, like{}
 
     Recursion in aliases is only allowed if recursion happens behind a
     tagged union, at least one variant of which is not recursive.
-    "###
+    "
     );
 
     test_report!(
@@ -6930,7 +6930,7 @@ In roc, functions are always written as a lambda, like{}
             job { inputs: ["build", "test"] }
             "#
         ),
-        @r###"
+        @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     The 1st argument to `job` is weird:
@@ -6949,7 +6949,7 @@ In roc, functions are always written as a lambda, like{}
     Tip: To extract the `.inputs` field it must be non-optional, but the
     type says this field is optional. Learn more about optional fields at
     TODO.
-    "###
+    "
     );
 
     test_report!(
@@ -6965,7 +6965,7 @@ In roc, functions are always written as a lambda, like{}
             job { inputs: ["build", "test"] }
             "#
         ),
-        @r###"
+        @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     Something is off with the body of the `job` definition:
@@ -6982,21 +6982,21 @@ In roc, functions are always written as a lambda, like{}
     But the type annotation on `job` says it should be:
 
         [Job { inputs : List a }]a as a
-    "###
+    "
     );
 
     test_report!(
         nested_datatype,
         indoc!(
-            r#"
+            r"
             Nested a : [Chain a (Nested (List a)), Term]
 
             s : Nested Str
 
             s
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── NESTED DATATYPE ─────────────────────────────────────── /code/proj/Main.roc ─
 
     `Nested` is a nested datatype. Here is one recursive usage of it:
@@ -7012,19 +7012,19 @@ In roc, functions are always written as a lambda, like{}
     Nested datatypes are not supported in Roc.
 
     Hint: Consider rewriting the definition of `Nested` to use the recursive type with the same arguments.
-    "###
+    "
     );
 
     test_report!(
         nested_datatype_inline,
         indoc!(
-            r#"
+            r"
             f : {} -> [Chain a (Nested (List a)), Term] as Nested a
 
             f
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── NESTED DATATYPE ─────────────────────────────────────── /code/proj/Main.roc ─
 
     `Nested` is a nested datatype. Here is one recursive usage of it:
@@ -7040,7 +7040,7 @@ In roc, functions are always written as a lambda, like{}
     Nested datatypes are not supported in Roc.
 
     Hint: Consider rewriting the definition of `Nested` to use the recursive type with the same arguments.
-    "###
+    "
     );
 
     macro_rules! mismatched_suffix_tests {
@@ -7054,10 +7054,10 @@ In roc, functions are always written as a lambda, like{}
                     let bad_type = if $suffix == "u8" { "I8" } else { "U8" };
 
                     format!(indoc!(
-                        r#"
+                        r"
                         use : Num.{} -> Num.U8
                         use {}{}
-                        "#
+                        "
                     ), bad_type, number, $suffix)
                 },
                 |golden| {
@@ -7072,7 +7072,7 @@ In roc, functions are always written as a lambda, like{}
                     };
 
                     let real = format!(indoc!(
-                        r#"
+                        r"
                         ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
                         This 1st argument to `use` has an unexpected type:
@@ -7087,7 +7087,7 @@ In roc, functions are always written as a lambda, like{}
                         But `use` needs its 1st argument to be:
 
                             {}
-                        "#
+                        "
                     ), number, $suffix, carets, kind, typ, bad_type);
 
                     assert_eq!(golden, real);
@@ -7124,11 +7124,11 @@ In roc, functions are always written as a lambda, like{}
                     let bad_suffix = if $suffix == "u8" { "i8" } else { "u8" };
 
                     format!(indoc!(
-                        r#"
+                        r"
                         when {}{} is
                             {}{} -> 1
                             _ -> 1
-                        "#
+                        "
                     ), number, bad_suffix, number, $suffix)
                 },
                 |golden| {
@@ -7139,7 +7139,7 @@ In roc, functions are always written as a lambda, like{}
                     let bad_type = if $suffix == "u8" { "I8" } else { "U8" };
 
                     let real = format!(indoc!(
-                        r#"
+                        r"
                         ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
                         The branches of this `when` expression don't match the condition:
@@ -7157,7 +7157,7 @@ In roc, functions are always written as a lambda, like{}
                             {}
 
                         The branches must be cases of the `when` condition's type!
-                        "#
+                        "
                     ), number, bad_suffix, number, $suffix, bad_type, typ);
 
                     assert_eq!(golden, real);
@@ -7186,12 +7186,12 @@ In roc, functions are always written as a lambda, like{}
     test_report!(
         bad_numeric_literal_suffix,
         indoc!(
-            r#"
+            r"
             1u256
-            "#
+            "
         ),
         // TODO: link to number suffixes
-        @r###"
+        @r"
     ── SYNTAX PROBLEM ──────────────────────────────────────── /code/proj/Main.roc ─
 
     This integer literal contains an invalid digit:
@@ -7203,18 +7203,18 @@ In roc, functions are always written as a lambda, like{}
     0-9, or have an integer suffix.
 
     Tip: Learn more about number literals at TODO
-    "###
+    "
     );
 
     test_report!(
         numer_literal_multi_suffix,
         indoc!(
-            r#"
+            r"
             1u8u8
-            "#
+            "
         ),
         // TODO: link to number suffixes
-        @r###"
+        @r"
     ── SYNTAX PROBLEM ──────────────────────────────────────── /code/proj/Main.roc ─
 
     This integer literal contains an invalid digit:
@@ -7226,47 +7226,47 @@ In roc, functions are always written as a lambda, like{}
     0-9, or have an integer suffix.
 
     Tip: Learn more about number literals at TODO
-    "###
+    "
     );
 
     test_report!(
         int_literal_has_float_suffix,
         indoc!(
-            r#"
+            r"
             0b1f32
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── CONFLICTING NUMBER SUFFIX ───────────────────────────── /code/proj/Main.roc ─
 
     This number literal is an integer, but it has a float suffix:
 
     4│      0b1f32
             ^^^^^^
-    "###
+    "
     );
 
     test_report!(
         float_literal_has_int_suffix,
         indoc!(
-            r#"
+            r"
             1.0u8
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── CONFLICTING NUMBER SUFFIX ───────────────────────────── /code/proj/Main.roc ─
 
     This number literal is a float, but it has an integer suffix:
 
     4│      1.0u8
             ^^^^^
-    "###
+    "
     );
 
     test_report!(
         u8_overflow,
         "256u8",
-        @r###"
+        @r"
     ── NUMBER OVERFLOWS SUFFIX ─────────────────────────────── /code/proj/Main.roc ─
 
     This integer literal overflows the type indicated by its suffix:
@@ -7276,13 +7276,13 @@ In roc, functions are always written as a lambda, like{}
 
     Tip: The suffix indicates this integer is a U8, whose maximum value is
     255.
-    "###
+    "
     );
 
     test_report!(
         negative_u8,
         "-1u8",
-        @r###"
+        @r"
     ── NUMBER UNDERFLOWS SUFFIX ────────────────────────────── /code/proj/Main.roc ─
 
     This integer literal underflows the type indicated by its suffix:
@@ -7292,13 +7292,13 @@ In roc, functions are always written as a lambda, like{}
 
     Tip: The suffix indicates this integer is a U8, whose minimum value is
     0.
-    "###
+    "
     );
 
     test_report!(
         u16_overflow,
         "65536u16",
-        @r###"
+        @r"
     ── NUMBER OVERFLOWS SUFFIX ─────────────────────────────── /code/proj/Main.roc ─
 
     This integer literal overflows the type indicated by its suffix:
@@ -7308,13 +7308,13 @@ In roc, functions are always written as a lambda, like{}
 
     Tip: The suffix indicates this integer is a U16, whose maximum value
     is 65535.
-    "###
+    "
     );
 
     test_report!(
         negative_u16,
         "-1u16",
-        @r###"
+        @r"
     ── NUMBER UNDERFLOWS SUFFIX ────────────────────────────── /code/proj/Main.roc ─
 
     This integer literal underflows the type indicated by its suffix:
@@ -7324,13 +7324,13 @@ In roc, functions are always written as a lambda, like{}
 
     Tip: The suffix indicates this integer is a U16, whose minimum value
     is 0.
-    "###
+    "
     );
 
     test_report!(
         u32_overflow,
         "4_294_967_296u32",
-        @r###"
+        @r"
     ── NUMBER OVERFLOWS SUFFIX ─────────────────────────────── /code/proj/Main.roc ─
 
     This integer literal overflows the type indicated by its suffix:
@@ -7340,13 +7340,13 @@ In roc, functions are always written as a lambda, like{}
 
     Tip: The suffix indicates this integer is a U32, whose maximum value
     is 4_294_967_295.
-    "###
+    "
     );
 
     test_report!(
         negative_u32,
         "-1u32",
-        @r###"
+        @r"
     ── NUMBER UNDERFLOWS SUFFIX ────────────────────────────── /code/proj/Main.roc ─
 
     This integer literal underflows the type indicated by its suffix:
@@ -7356,13 +7356,13 @@ In roc, functions are always written as a lambda, like{}
 
     Tip: The suffix indicates this integer is a U32, whose minimum value
     is 0.
-    "###
+    "
     );
 
     test_report!(
         u64_overflow,
         "18_446_744_073_709_551_616u64",
-        @r###"
+        @r"
     ── NUMBER OVERFLOWS SUFFIX ─────────────────────────────── /code/proj/Main.roc ─
 
     This integer literal overflows the type indicated by its suffix:
@@ -7372,13 +7372,13 @@ In roc, functions are always written as a lambda, like{}
 
     Tip: The suffix indicates this integer is a U64, whose maximum value
     is 18_446_744_073_709_551_615.
-    "###
+    "
     );
 
     test_report!(
         negative_u64,
         "-1u64",
-        @r###"
+        @r"
     ── NUMBER UNDERFLOWS SUFFIX ────────────────────────────── /code/proj/Main.roc ─
 
     This integer literal underflows the type indicated by its suffix:
@@ -7388,13 +7388,13 @@ In roc, functions are always written as a lambda, like{}
 
     Tip: The suffix indicates this integer is a U64, whose minimum value
     is 0.
-    "###
+    "
     );
 
     test_report!(
         negative_u128,
         "-1u128",
-        @r###"
+        @r"
     ── NUMBER UNDERFLOWS SUFFIX ────────────────────────────── /code/proj/Main.roc ─
 
     This integer literal underflows the type indicated by its suffix:
@@ -7404,13 +7404,13 @@ In roc, functions are always written as a lambda, like{}
 
     Tip: The suffix indicates this integer is a U128, whose minimum value
     is 0.
-    "###
+    "
     );
 
     test_report!(
         i8_overflow,
         "128i8",
-        @r###"
+        @r"
     ── NUMBER OVERFLOWS SUFFIX ─────────────────────────────── /code/proj/Main.roc ─
 
     This integer literal overflows the type indicated by its suffix:
@@ -7420,13 +7420,13 @@ In roc, functions are always written as a lambda, like{}
 
     Tip: The suffix indicates this integer is a I8, whose maximum value is
     127.
-    "###
+    "
     );
 
     test_report!(
         i8_underflow,
         "-129i8",
-        @r###"
+        @r"
     ── NUMBER UNDERFLOWS SUFFIX ────────────────────────────── /code/proj/Main.roc ─
 
     This integer literal underflows the type indicated by its suffix:
@@ -7436,13 +7436,13 @@ In roc, functions are always written as a lambda, like{}
 
     Tip: The suffix indicates this integer is a I8, whose minimum value is
     -128.
-    "###
+    "
     );
 
     test_report!(
         i16_overflow,
         "32768i16",
-        @r###"
+        @r"
     ── NUMBER OVERFLOWS SUFFIX ─────────────────────────────── /code/proj/Main.roc ─
 
     This integer literal overflows the type indicated by its suffix:
@@ -7452,13 +7452,13 @@ In roc, functions are always written as a lambda, like{}
 
     Tip: The suffix indicates this integer is a I16, whose maximum value
     is 32767.
-    "###
+    "
     );
 
     test_report!(
         i16_underflow,
         "-32769i16",
-        @r###"
+        @r"
     ── NUMBER UNDERFLOWS SUFFIX ────────────────────────────── /code/proj/Main.roc ─
 
     This integer literal underflows the type indicated by its suffix:
@@ -7468,13 +7468,13 @@ In roc, functions are always written as a lambda, like{}
 
     Tip: The suffix indicates this integer is a I16, whose minimum value
     is -32768.
-    "###
+    "
     );
 
     test_report!(
         i32_overflow,
         "2_147_483_648i32",
-        @r###"
+        @r"
     ── NUMBER OVERFLOWS SUFFIX ─────────────────────────────── /code/proj/Main.roc ─
 
     This integer literal overflows the type indicated by its suffix:
@@ -7484,13 +7484,13 @@ In roc, functions are always written as a lambda, like{}
 
     Tip: The suffix indicates this integer is a I32, whose maximum value
     is 2_147_483_647.
-    "###
+    "
     );
 
     test_report!(
         i32_underflow,
         "-2_147_483_649i32",
-        @r###"
+        @r"
     ── NUMBER UNDERFLOWS SUFFIX ────────────────────────────── /code/proj/Main.roc ─
 
     This integer literal underflows the type indicated by its suffix:
@@ -7500,13 +7500,13 @@ In roc, functions are always written as a lambda, like{}
 
     Tip: The suffix indicates this integer is a I32, whose minimum value
     is -2_147_483_648.
-    "###
+    "
     );
 
     test_report!(
         i64_overflow,
         "9_223_372_036_854_775_808i64",
-        @r###"
+        @r"
     ── NUMBER OVERFLOWS SUFFIX ─────────────────────────────── /code/proj/Main.roc ─
 
     This integer literal overflows the type indicated by its suffix:
@@ -7516,13 +7516,13 @@ In roc, functions are always written as a lambda, like{}
 
     Tip: The suffix indicates this integer is a I64, whose maximum value
     is 9_223_372_036_854_775_807.
-    "###
+    "
     );
 
     test_report!(
         i64_underflow,
         "-9_223_372_036_854_775_809i64",
-        @r###"
+        @r"
     ── NUMBER UNDERFLOWS SUFFIX ────────────────────────────── /code/proj/Main.roc ─
 
     This integer literal underflows the type indicated by its suffix:
@@ -7532,13 +7532,13 @@ In roc, functions are always written as a lambda, like{}
 
     Tip: The suffix indicates this integer is a I64, whose minimum value
     is -9_223_372_036_854_775_808.
-    "###
+    "
     );
 
     test_report!(
         i128_overflow,
         "170_141_183_460_469_231_731_687_303_715_884_105_728i128",
-        @r###"
+        @r"
     ── NUMBER OVERFLOWS SUFFIX ─────────────────────────────── /code/proj/Main.roc ─
 
     This integer literal overflows the type indicated by its suffix:
@@ -7548,19 +7548,19 @@ In roc, functions are always written as a lambda, like{}
 
     Tip: The suffix indicates this integer is a I128, whose maximum value
     is 170_141_183_460_469_231_731_687_303_715_884_105_727.
-    "###
+    "
     );
 
     test_report!(
         list_get_negative_number,
         indoc!(
-            r#"
+            r"
              List.get [1,2,3] -1
-             "#
+             "
         ),
         // TODO: this error message could be improved, e.g. something like "This argument can
         // be used as ... because of its literal value"
-        @r###"
+        @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     This 2nd argument to `get` has an unexpected type:
@@ -7575,18 +7575,18 @@ In roc, functions are always written as a lambda, like{}
     But `get` needs its 2nd argument to be:
 
         Nat
-    "###
+    "
     );
 
     test_report!(
         list_get_negative_number_indirect,
         indoc!(
-            r#"
+            r"
              a = -9_223_372_036_854
              List.get [1,2,3] a
-             "#
+             "
         ),
-        @r###"
+        @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     This 2nd argument to `get` has an unexpected type:
@@ -7601,19 +7601,19 @@ In roc, functions are always written as a lambda, like{}
     But `get` needs its 2nd argument to be:
 
         Nat
-    "###
+    "
     );
 
     test_report!(
         list_get_negative_number_double_indirect,
         indoc!(
-            r#"
+            r"
              a = -9_223_372_036_854
              b = a
              List.get [1,2,3] b
-             "#
+             "
         ),
-        @r###"
+        @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     This 2nd argument to `get` has an unexpected type:
@@ -7628,19 +7628,19 @@ In roc, functions are always written as a lambda, like{}
     But `get` needs its 2nd argument to be:
 
         Nat
-    "###
+    "
     );
 
     test_report!(
         compare_unsigned_to_signed,
         indoc!(
-            r#"
+            r"
             when -1 is
                1u8 -> 1
                _ -> 1
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     The branches of this `when` expression don't match the condition:
@@ -7658,20 +7658,20 @@ In roc, functions are always written as a lambda, like{}
         U8
 
     The branches must be cases of the `when` condition's type!
-    "###
+    "
     );
 
     test_report!(
         recursive_type_alias_is_newtype,
         indoc!(
-            r#"
+            r"
             R a : [Only (R a)]
 
             v : R Str
             v
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── CYCLIC ALIAS ────────────────────────────────────────── /code/proj/Main.roc ─
 
     The `R` alias is self-recursive in an invalid way:
@@ -7681,20 +7681,20 @@ In roc, functions are always written as a lambda, like{}
 
     Recursion in aliases is only allowed if recursion happens behind a
     tagged union, at least one variant of which is not recursive.
-    "###
+    "
     );
 
     test_report!(
         recursive_type_alias_is_newtype_deep,
         indoc!(
-            r#"
+            r"
             R a : [Only { very: [Deep (R a)] }]
 
             v : R Str
             v
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── CYCLIC ALIAS ────────────────────────────────────────── /code/proj/Main.roc ─
 
     The `R` alias is self-recursive in an invalid way:
@@ -7704,21 +7704,21 @@ In roc, functions are always written as a lambda, like{}
 
     Recursion in aliases is only allowed if recursion happens behind a
     tagged union, at least one variant of which is not recursive.
-    "###
+    "
     );
 
     test_report!(
         recursive_type_alias_is_newtype_mutual,
         indoc!(
-            r#"
+            r"
             Foo a : [Thing (Bar a)]
             Bar a : [Stuff (Foo a)]
 
             v : Bar Str
             v
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── CYCLIC ALIAS ────────────────────────────────────────── /code/proj/Main.roc ─
 
     The `Foo` alias is recursive in an invalid way:
@@ -7737,13 +7737,13 @@ In roc, functions are always written as a lambda, like{}
 
     Recursion in aliases is only allowed if recursion happens behind a
     tagged union, at least one variant of which is not recursive.
-    "###
+    "
     );
 
     test_report!(
         issue_2458,
         indoc!(
-            r#"
+            r"
             Result a b : [Ok a, Err b]
 
             Foo a : [Blah (Result (Bar a) [])]
@@ -7751,9 +7751,9 @@ In roc, functions are always written as a lambda, like{}
 
             v : Bar Str
             v
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── DUPLICATE NAME ──────────────────────────────────────── /code/proj/Main.roc ─
 
     This alias has the same name as a builtin:
@@ -7763,17 +7763,17 @@ In roc, functions are always written as a lambda, like{}
 
     All builtin aliases are in scope by default, so I need this alias to
     have a different name!
-    "###
+    "
     );
 
     test_report!(
         opaque_type_not_in_scope,
         indoc!(
-            r#"
+            r"
             @Age 21
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── OPAQUE TYPE NOT DEFINED ─────────────────────────────── /code/proj/Main.roc ─
 
     The opaque type Age referenced here is not defined:
@@ -7782,19 +7782,19 @@ In roc, functions are always written as a lambda, like{}
             ^^^^
 
     Note: It looks like there are no opaque types declared in this scope yet!
-    "###
+    "
     );
 
     test_report!(
         opaque_reference_not_opaque_type,
         indoc!(
-            r#"
+            r"
             Age : Num.U8
 
             @Age 21
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── OPAQUE TYPE NOT DEFINED ─────────────────────────────── /code/proj/Main.roc ─
 
     The opaque type Age referenced here is not defined:
@@ -7818,20 +7818,20 @@ In roc, functions are always written as a lambda, like{}
 
     If you didn't intend on using `Age` then remove it so future readers of
     your code don't wonder why it is there.
-    "###
+    "
     );
 
     test_report!(
         qualified_opaque_reference,
         indoc!(
-            r#"
+            r"
             OtherModule.@Age 21
-            "#
+            "
         ),
         // TODO: get rid of the first error. Consider parsing OtherModule.@Age to completion
         // and checking it during can. The reason the error appears is because it is parsed as
         // Apply(Error(OtherModule), [@Age, 21])
-        @r###"
+        @r"
     ── OPAQUE TYPE NOT DEFINED ─────────────────────────────── /code/proj/Main.roc ─
 
     The opaque type Age referenced here is not defined:
@@ -7850,24 +7850,24 @@ In roc, functions are always written as a lambda, like{}
 
     I was expecting to see an identifier next, like height. A complete
     qualified name looks something like Json.Decode.string.
-    "###
+    "
     );
 
     test_report!(
         opaque_used_outside_declaration_scope,
         indoc!(
-            r#"
+            r"
             age =
                 Age := Num.U8
                 21u8
 
             @Age age
-            "#
+            "
         ),
         // TODO(opaques): there is a potential for a better error message here, if the usage of
         // `@Age` can be linked to the declaration of `Age` inside `age`, and a suggestion to
         // raise that declaration to the outer scope.
-        @r###"
+        @r"
     ── UNUSED DEFINITION ───────────────────────────────────── /code/proj/Main.roc ─
 
     `Age` is not used anywhere in your code.
@@ -7886,7 +7886,7 @@ In roc, functions are always written as a lambda, like{}
             ^^^^
 
     Note: It looks like there are no opaque types declared in this scope yet!
-    "###
+    "
     );
 
     test_report!(
@@ -7898,7 +7898,7 @@ In roc, functions are always written as a lambda, like{}
             alt
             "#
         ),
-        @r###"
+        @r"
     ── MODULE NOT IMPORTED ─────────────────────────────────── /code/proj/Main.roc ─
 
     The `Task` module is not imported:
@@ -7913,7 +7913,7 @@ In roc, functions are always written as a lambda, like{}
         List
         Num
         Box
-    "###
+    "
     );
 
     test_report!(
@@ -7930,7 +7930,7 @@ In roc, functions are always written as a lambda, like{}
         ),
         // TODO(opaques): error could be improved by saying that the opaque definition demands
         // that the argument be a U8, and linking to the definitin!
-        @r###"
+        @r#"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     This expression is used in an unexpected way:
@@ -7945,7 +7945,7 @@ In roc, functions are always written as a lambda, like{}
     But you are trying to use it as:
 
         U8
-    "###
+    "#
     );
 
     test_report!(
@@ -7959,7 +7959,7 @@ In roc, functions are always written as a lambda, like{}
             else @F {}
             "#
         ),
-        @r###"
+        @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     This expression is used in an unexpected way:
@@ -7974,7 +7974,7 @@ In roc, functions are always written as a lambda, like{}
     But you are trying to use it as:
 
         Str
-    "###
+    "
     );
 
     test_report!(
@@ -7989,7 +7989,7 @@ In roc, functions are always written as a lambda, like{}
             v
             "#
         ),
-        @r###"
+        @r#"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     Something is off with the body of the `v` definition:
@@ -8010,24 +8010,24 @@ In roc, functions are always written as a lambda, like{}
     both types are the same opaque type. Did you mean to create an opaque
     type by wrapping it? If I have an opaque type Age := U32 I can create
     an instance of this opaque type by doing @Age 23.
-    "###
+    "#
     );
 
     test_report!(
         opaque_mismatch_pattern_check,
         indoc!(
-            r#"
+            r"
             Age := Num.U8
 
             f : Age -> Num.U8
             f = \Age n -> n
 
             f
-            "#
+            "
         ),
         // TODO(opaques): error could be improved by saying that the user-provided pattern
         // probably wants to change "Age" to "@Age"!
-        @r###"
+        @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     The 1st argument to `f` is weird:
@@ -8047,7 +8047,7 @@ In roc, functions are always written as a lambda, like{}
     both types are the same opaque type. Did you mean to create an opaque
     type by wrapping it? If I have an opaque type Age := U32 I can create
     an instance of this opaque type by doing @Age 23.
-    "###
+    "
     );
 
     test_report!(
@@ -8062,7 +8062,7 @@ In roc, functions are always written as a lambda, like{}
                     @F {} -> ""
             "#
         ),
-        @r###"
+        @r#"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     The 2nd pattern in this `when` does not match the previous ones:
@@ -8077,7 +8077,7 @@ In roc, functions are always written as a lambda, like{}
     But all the previous branches match:
 
         F [A]
-    "###
+    "#
     );
 
     test_report!(
@@ -8093,7 +8093,7 @@ In roc, functions are always written as a lambda, like{}
                 @F B -> ""
             "#
         ),
-        @r###"
+        @r#"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     The branches of this `when` expression don't match the condition:
@@ -8115,7 +8115,7 @@ In roc, functions are always written as a lambda, like{}
     Tip: Looks like the branches are missing coverage of the `C` tag.
 
     Tip: Maybe you need to add a catch-all branch, like `_`?
-    "###
+    "#
     );
 
     test_report!(
@@ -8131,7 +8131,7 @@ In roc, functions are always written as a lambda, like{}
                 @F 2 -> ""
             "#
         ),
-        @r###"
+        @r#"
     ── UNSAFE PATTERN ──────────────────────────────────────── /code/proj/Main.roc ─
 
     This `when` does not cover all the possibilities:
@@ -8145,13 +8145,13 @@ In roc, functions are always written as a lambda, like{}
         @F _
 
     I would have to crash if I saw one of those! Add branches for them!
-    "###
+    "#
     );
 
     test_report!(
         let_polymorphism_with_scoped_type_variables,
         indoc!(
-            r#"
+            r"
             f : a -> a
             f = \x ->
                 y : a -> a
@@ -8162,9 +8162,9 @@ In roc, functions are always written as a lambda, like{}
                 (\_ -> x1) n
 
             f
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     This 1st argument to `y` has an unexpected type:
@@ -8185,7 +8185,7 @@ In roc, functions are always written as a lambda, like{}
     it will only produce a `U8` value of a single specific type. Maybe
     change the type annotation to be more specific? Maybe change the code
     to be more general?
-    "###
+    "
     );
 
     test_report!(
@@ -8197,7 +8197,7 @@ In roc, functions are always written as a lambda, like{}
                 A if Bool.true -> ""
             "#
         ),
-        @r###"
+        @r#"
     ── UNSAFE PATTERN ──────────────────────────────────────── /code/proj/Main.roc ─
 
     This `when` does not cover all the possibilities:
@@ -8210,18 +8210,18 @@ In roc, functions are always written as a lambda, like{}
         A    (note the lack of an if clause)
 
     I would have to crash if I saw one of those! Add branches for them!
-    "###
+    "#
     );
 
     test_report!(
         invalid_record_extension_type,
         indoc!(
-            r#"
+            r"
             f : { x : Num.Nat }[]
             f
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── INVALID_EXTENSION_TYPE ──────────────────────────────── /code/proj/Main.roc ─
 
     This record extension type is invalid:
@@ -8231,18 +8231,18 @@ In roc, functions are always written as a lambda, like{}
 
     Note: A record extension variable can only contain a type variable or
     another record.
-    "###
+    "
     );
 
     test_report!(
         invalid_tag_extension_type,
         indoc!(
-            r#"
+            r"
             f : [A]Str
             f
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── INVALID_EXTENSION_TYPE ──────────────────────────────── /code/proj/Main.roc ─
 
     This tag union extension type is invalid:
@@ -8252,13 +8252,13 @@ In roc, functions are always written as a lambda, like{}
 
     Note: A tag union extension variable can only contain a type variable
     or another tag union.
-    "###
+    "
     );
 
     test_report!(
         unknown_type,
         indoc!(
-            r#"
+            r"
             Type : [Constructor UnknownType]
 
             insertHelper : UnknownType, Type -> Type
@@ -8267,9 +8267,9 @@ In roc, functions are always written as a lambda, like{}
                     Constructor _ -> Constructor h
 
             insertHelper
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── UNRECOGNIZED NAME ───────────────────────────────────── /code/proj/Main.roc ─
 
     Nothing is named `UnknownType` in this scope.
@@ -8297,20 +8297,20 @@ In roc, functions are always written as a lambda, like{}
         Unsigned8
         Unsigned16
         Unsigned64
-    "###
+    "
     );
 
     test_report!(
         ability_first_demand_not_indented_enough,
         indoc!(
-            r#"
+            r"
             MEq implements
             eq : a, a -> U64 where a implements MEq
 
             1
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── UNFINISHED ABILITY ── tmp/ability_first_demand_not_indented_enough/Test.roc ─
 
     I was partway through parsing an ability definition, but I got stuck
@@ -8321,21 +8321,21 @@ In roc, functions are always written as a lambda, like{}
             ^
 
     I suspect this line is not indented enough (by 1 spaces)
-    "###
+    "
     );
 
     test_report!(
         ability_demands_not_indented_with_first,
         indoc!(
-            r#"
+            r"
             MEq implements
                 eq : a, a -> U64 where a implements MEq
                     neq : a, a -> U64 where a implements MEq
 
             1
-            "#
+            "
         ),
-        @r#"
+        @r"
         ── UNFINISHED ABILITY ─── tmp/ability_demands_not_indented_with_first/Test.roc ─
 
         I was partway through parsing an ability definition, but I got stuck
@@ -8345,20 +8345,20 @@ In roc, functions are always written as a lambda, like{}
         6│              neq : a, a -> U64 where a implements MEq
                         ^
 
-        I suspect this line is indented too much (by 4 spaces)"#
+        I suspect this line is indented too much (by 4 spaces)"
     );
 
     test_report!(
         ability_demand_value_has_args,
         indoc!(
-            r#"
+            r"
                 MEq implements
                     eq b c : a, a -> U64 where a implements MEq
 
                 1
-                "#
+                "
         ),
-        @r#"
+        @r"
         ── UNFINISHED ABILITY ───────────── tmp/ability_demand_value_has_args/Test.roc ─
 
         I was partway through parsing an ability definition, but I got stuck
@@ -8369,20 +8369,20 @@ In roc, functions are always written as a lambda, like{}
                        ^
 
         I was expecting to see a : annotating the signature of this value
-        next."#
+        next."
     );
 
     test_report!(
         ability_non_signature_expression,
         indoc!(
-            r#"
+            r"
             MEq implements
                 123
 
             1
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── UNFINISHED ABILITY ────────── tmp/ability_non_signature_expression/Test.roc ─
 
     I was partway through parsing an ability definition, but I got stuck
@@ -8393,19 +8393,19 @@ In roc, functions are always written as a lambda, like{}
                 ^
 
     I was expecting to see a value signature next.
-    "###
+    "
     );
 
     test_report!(
         wildcard_in_alias,
         indoc!(
-            r#"
+            r"
             I : Num.Int *
             a : I
             a
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── UNBOUND TYPE VARIABLE ───────────────────────────────── /code/proj/Main.roc ─
 
     The definition of `I` has an unbound type variable:
@@ -8415,19 +8415,19 @@ In roc, functions are always written as a lambda, like{}
 
     Tip: Type variables must be bound before the `:`. Perhaps you intended
     to add a type parameter to this type?
-    "###
+    "
     );
 
     test_report!(
         wildcard_in_opaque,
         indoc!(
-            r#"
+            r"
             I := Num.Int *
             a : I
             a
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── UNBOUND TYPE VARIABLE ───────────────────────────────── /code/proj/Main.roc ─
 
     The definition of `I` has an unbound type variable:
@@ -8437,19 +8437,19 @@ In roc, functions are always written as a lambda, like{}
 
     Tip: Type variables must be bound before the `:=`. Perhaps you intended
     to add a type parameter to this type?
-    "###
+    "
     );
 
     test_report!(
         multiple_wildcards_in_alias,
         indoc!(
-            r#"
+            r"
             I : [A (Num.Int *), B (Num.Int *)]
             a : I
             a
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── UNBOUND TYPE VARIABLE ───────────────────────────────── /code/proj/Main.roc ─
 
     The definition of `I` has 2 unbound type variables.
@@ -8461,19 +8461,19 @@ In roc, functions are always written as a lambda, like{}
 
     Tip: Type variables must be bound before the `:`. Perhaps you intended
     to add a type parameter to this type?
-    "###
+    "
     );
 
     test_report!(
         inference_var_in_alias,
         indoc!(
-            r#"
+            r"
             I : Num.Int _
             a : I
             a
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── UNBOUND TYPE VARIABLE ───────────────────────────────── /code/proj/Main.roc ─
 
     The definition of `I` has an unbound type variable:
@@ -8483,19 +8483,19 @@ In roc, functions are always written as a lambda, like{}
 
     Tip: Type variables must be bound before the `:`. Perhaps you intended
     to add a type parameter to this type?
-    "###
+    "
     );
 
     test_report!(
         unbound_var_in_alias,
         indoc!(
-            r#"
+            r"
             I : Num.Int a
             a : I
             a
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── UNBOUND TYPE VARIABLE ───────────────────────────────── /code/proj/Main.roc ─
 
     The definition of `I` has an unbound type variable:
@@ -8505,7 +8505,7 @@ In roc, functions are always written as a lambda, like{}
 
     Tip: Type variables must be bound before the `:`. Perhaps you intended
     to add a type parameter to this type?
-    "###
+    "
     );
 
     test_report!(
@@ -8518,7 +8518,7 @@ In roc, functions are always written as a lambda, like{}
               hash : a -> U64 where a implements MHash
             "#
         ),
-        @r###"
+        @r"
     ── ABILITY HAS TYPE VARIABLES ──────────────────────────── /code/proj/Main.roc ─
 
     The definition of the `MHash` ability includes type variables:
@@ -8538,7 +8538,7 @@ In roc, functions are always written as a lambda, like{}
 
     If you didn't intend on using `MHash` then remove it so future readers
     of your code don't wonder why it is there.
-    "###
+    "
     );
 
     test_report!(
@@ -8550,14 +8550,14 @@ In roc, functions are always written as a lambda, like{}
             MHash implements hash : a, b -> Num.U64 where a implements MHash, b implements Bool.Bool
             "#
         ),
-        @r###"
+        @r#"
     ── IMPLEMENTS CLAUSE IS NOT AN ABILITY ─────────────────── /code/proj/Main.roc ─
 
     The type referenced in this "implements" clause is not an ability:
 
     3│  MHash implements hash : a, b -> Num.U64 where a implements MHash, b implements Bool.Bool
                                                                                        ^^^^^^^^^
-    "###
+    "#
     );
 
     test_report!(
@@ -8569,7 +8569,7 @@ In roc, functions are always written as a lambda, like{}
             Ab1 implements ab1 : a -> {} where a implements Ab1, a implements Ab1
             "#
         ),
-        @r#"
+        @r"
         ── DUPLICATE NAME ──────────────────────────────────────── /code/proj/Main.roc ─
 
         The `a` name is first defined here:
@@ -8584,7 +8584,7 @@ In roc, functions are always written as a lambda, like{}
 
         Since these variables have the same name, it's easy to use the wrong
         one by accident. Give one of them a new name.
-        "#
+        "
     );
 
     test_report!(
@@ -8598,7 +8598,7 @@ In roc, functions are always written as a lambda, like{}
             Ability implements ab1 : a -> U64 where a implements Ability
             "#
         ),
-        @r#"
+        @r"
         ── DUPLICATE NAME ──────────────────────────────────────── /code/proj/Main.roc ─
 
         The `Ability` name is first defined here:
@@ -8613,7 +8613,7 @@ In roc, functions are always written as a lambda, like{}
 
         Since these abilities have the same name, it's easy to use the wrong
         one by accident. Give one of them a new name.
-        "#
+        "
     );
 
     test_report!(
@@ -8625,7 +8625,7 @@ In roc, functions are always written as a lambda, like{}
             Ability implements ab : {} -> {}
             "#
         ),
-        @r#"
+        @r"
         ── ABILITY MEMBER MISSING IMPLEMENTS CLAUSE ────────────── /code/proj/Main.roc ─
 
         The definition of the ability member `ab` does not include an `implements`
@@ -8650,7 +8650,7 @@ In roc, functions are always written as a lambda, like{}
 
         If you didn't intend on using `Ability` then remove it so future readers
         of your code don't wonder why it is there.
-        "#
+        "
     );
 
     test_report!(
@@ -8662,7 +8662,7 @@ In roc, functions are always written as a lambda, like{}
             MEq implements eq : a, b -> Bool.Bool where a implements MEq, b implements MEq
             "#
         ),
-        @r#"
+        @r"
         ── ABILITY MEMBER BINDS MULTIPLE VARIABLES ─────────────── /code/proj/Main.roc ─
 
         The definition of the ability member `eq` includes multiple variables
@@ -8676,7 +8676,7 @@ In roc, functions are always written as a lambda, like{}
         looking at specializations!
 
         Hint: Did you mean to only bind `a` to `MEq`?
-        "#
+        "
     );
 
     test_report!(
@@ -8690,7 +8690,7 @@ In roc, functions are always written as a lambda, like{}
             f : a -> Num.U64 where a implements MHash
             "#
         ),
-        @r###"
+        @r"
     ── ILLEGAL IMPLEMENTS CLAUSE ───────────────────────────── /code/proj/Main.roc ─
 
     An `implements` clause is not allowed here:
@@ -8715,7 +8715,7 @@ In roc, functions are always written as a lambda, like{}
         a implements MHash
 
     Otherwise, the function does not need to be part of the ability!
-    "###
+    "
     );
 
     test_report!(
@@ -8731,7 +8731,7 @@ In roc, functions are always written as a lambda, like{}
             hash = \@Id n -> n
             "#
         ),
-        @r#"
+        @r"
         ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
         Something is off with this specialization of `hash`:
@@ -8746,7 +8746,7 @@ In roc, functions are always written as a lambda, like{}
         But the type annotation on `hash` says it must match:
 
             Id -> U64
-        "#
+        "
     );
 
     test_report!(
@@ -8764,7 +8764,7 @@ In roc, functions are always written as a lambda, like{}
             eq = \@Id m, @Id n -> m == n
             "#
         ),
-        @r###"
+        @r"
     ── INCOMPLETE ABILITY IMPLEMENTATION ───────────────────── /code/proj/Main.roc ─
 
     This type does not fully implement the `MEq` ability:
@@ -8775,7 +8775,7 @@ In roc, functions are always written as a lambda, like{}
     The following necessary members are missing implementations:
 
         le
-    "###
+    "
     );
 
     test_report!(
@@ -8790,7 +8790,7 @@ In roc, functions are always written as a lambda, like{}
             hash = \_ -> 0u64
             "#
         ),
-        @r###"
+        @r"
     ── UNUSED DEFINITION ───────────────────────────────────── /code/proj/Main.roc ─
 
     `hash` is not used anywhere in your code.
@@ -8800,7 +8800,7 @@ In roc, functions are always written as a lambda, like{}
 
     If you didn't intend on using `hash` then remove it so future readers of
     your code don't wonder why it is there.
-    "###
+    "
     );
 
     test_report!(
@@ -8819,7 +8819,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
         // TODO: the error message here could be seriously improved!
-        @r###"
+        @r"
     ── OVERLOADED SPECIALIZATION ───────────────────────────── /code/proj/Main.roc ─
 
     This ability member specialization is already claimed to specialize
@@ -8854,7 +8854,7 @@ In roc, functions are always written as a lambda, like{}
     Specializations can only be made for concrete types. If you have a
     generic implementation for this value, perhaps you don't need an
     ability?
-    "###
+    "
     );
 
     test_report!(
@@ -8872,7 +8872,7 @@ In roc, functions are always written as a lambda, like{}
             hash = \@One _ -> 0u64
             "#
         ),
-        @r###"
+        @r"
     ── OVERLOADED SPECIALIZATION ───────────────────────────── /code/proj/Main.roc ─
 
     This ability member specialization is already claimed to specialize
@@ -8885,7 +8885,7 @@ In roc, functions are always written as a lambda, like{}
 
     Ability specializations can only provide implementations for one
     opaque type, since all opaque types are different!
-    "###
+    "
     );
 
     test_report!(
@@ -8903,7 +8903,7 @@ In roc, functions are always written as a lambda, like{}
             eq = \@You {}, @AndI {} -> False
             "#
         ),
-        @r###"
+        @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     Something is off with this specialization of `eq`:
@@ -8920,7 +8920,7 @@ In roc, functions are always written as a lambda, like{}
         You, You -> Bool
 
     Tip: Did you mean to use `Bool.false` rather than `False`?
-    "###
+    "
     );
 
     test_report!(
@@ -8938,7 +8938,7 @@ In roc, functions are always written as a lambda, like{}
             hash = \@Id n -> n
             "#
         ),
-        @r###"
+        @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     Something is off with the body of the `hash` definition:
@@ -8954,7 +8954,7 @@ In roc, functions are always written as a lambda, like{}
     But the type annotation on `hash` says it should be:
 
         U32
-    "###
+    "
     );
 
     test_report!(
@@ -8979,7 +8979,7 @@ In roc, functions are always written as a lambda, like{}
                 }
             "#
         ),
-        @r###"
+        @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     This expression has a type that does not implement the abilities it's expected to:
@@ -9001,7 +9001,7 @@ In roc, functions are always written as a lambda, like{}
                              ^^^^^^^^
 
     The type `User` does not fully implement the ability `MHash`.
-    "###
+    "
     );
 
     test_report!(
@@ -9017,7 +9017,7 @@ In roc, functions are always written as a lambda, like{}
                 123
             "#
         ),
-        @r#"
+        @r"
         ── ABILITY NOT ON TOP-LEVEL ────────────────────────────── /code/proj/Main.roc ─
 
         This ability definition is not on the top-level of a module:
@@ -9026,7 +9026,7 @@ In roc, functions are always written as a lambda, like{}
         5│>          hash : a -> U64 where a implements MHash
 
         Abilities can only be defined on the top-level of a Roc module.
-        "#
+        "
     );
 
     test_report!(
@@ -9045,7 +9045,7 @@ In roc, functions are always written as a lambda, like{}
             hashable = @Id 15
             "#
         ),
-        @r###"
+        @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     Something is off with the body of the `hashable` definition:
@@ -9067,7 +9067,7 @@ In roc, functions are always written as a lambda, like{}
 
     But, I see that the type is only ever used as a a `Id` value. Can you
     replace `a` with a more specific type?
-    "###
+    "
     );
 
     test_report!(
@@ -9091,7 +9091,7 @@ In roc, functions are always written as a lambda, like{}
             result = mulMHashes (@Id 100) (@Three {})
             "#
         ),
-        @r###"
+        @r"
     ── ABILITY USED AS TYPE ────────────────────────────────── /code/proj/Main.roc ─
 
     You are attempting to use the ability `MHash` as a type directly:
@@ -9119,7 +9119,7 @@ In roc, functions are always written as a lambda, like{}
     Hint: Perhaps you meant to include an `implements` annotation, like
 
         b implements MHash
-    "###
+    "
     );
 
     test_report!(
@@ -9135,7 +9135,7 @@ In roc, functions are always written as a lambda, like{}
             foo
             "#
         ),
-        @r###"
+        @r#"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     The branches of this `when` expression don't match the condition:
@@ -9158,7 +9158,7 @@ In roc, functions are always written as a lambda, like{}
         ]
 
     The branches must be cases of the `when` condition's type!
-    "###
+    "#
     );
 
     // from https://github.com/roc-lang/roc/commit/1372737f5e53ee5bb96d7e1b9593985e5537023a
@@ -9169,11 +9169,11 @@ In roc, functions are always written as a lambda, like{}
     test_report!(
         always_function,
         indoc!(
-            r#"
+            r"
             always = \val -> \_ -> val
 
             always
-            "#
+            "
         ),
         @""
     );
@@ -9260,7 +9260,7 @@ In roc, functions are always written as a lambda, like{}
                 default {}
             "#
         ),
-        @r#"
+        @r"
         ── SPECIALIZATION NOT ON TOP-LEVEL ─────────────────────── /code/proj/Main.roc ─
 
         This specialization of the `default` ability member is in a nested
@@ -9270,7 +9270,7 @@ In roc, functions are always written as a lambda, like{}
                 ^^^^^^^
 
         Specializations can only be defined on the top-level of a module.
-        "#
+        "
     );
 
     test_report!(
@@ -9285,7 +9285,7 @@ In roc, functions are always written as a lambda, like{}
                 Job lst -> lst == ""
             "#
         ),
-        @r###"
+        @r#"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     This 2nd argument to == has an unexpected type:
@@ -9300,7 +9300,7 @@ In roc, functions are always written as a lambda, like{}
     But == needs its 2nd argument to be:
 
         List [Job ∞] as ∞
-    "###
+    "#
     );
 
     test_report!(
@@ -9321,7 +9321,7 @@ In roc, functions are always written as a lambda, like{}
                         go goal new
             "#
         ),
-        @r###"
+        @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     This 1st argument to `remove` has an unexpected type:
@@ -9368,13 +9368,13 @@ In roc, functions are always written as a lambda, like{}
     infinitely.
 
         Set ∞
-    "###
+    "
     );
 
     test_report!(
         cycle_through_non_function,
         indoc!(
-            r#"
+            r"
             force : ({} -> I64) -> I64
             force = \eval -> eval {}
 
@@ -9383,9 +9383,9 @@ In roc, functions are always written as a lambda, like{}
             t2 = t1 {}
 
             t2
-            "#
+            "
         ),
-        @r#"
+        @r"
         ── CIRCULAR DEFINITION ─────────────────────────────────── /code/proj/Main.roc ─
 
         The `t1` definition is causing a very tricky infinite loop:
@@ -9401,7 +9401,7 @@ In roc, functions are always written as a lambda, like{}
             │     ↓
             │     t2
             └─────┘
-        "#
+        "
     );
 
     test_report!(
@@ -9413,7 +9413,7 @@ In roc, functions are always written as a lambda, like{}
             main = Encode.toEncoder \x -> x
             "#
         ),
-        @r###"
+        @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     This expression has a type that does not implement the abilities it's expected to:
@@ -9426,7 +9426,7 @@ In roc, functions are always written as a lambda, like{}
         a -> a
 
     Note: `Encoding` cannot be generated for functions.
-    "###
+    "
     );
 
     test_report!(
@@ -9441,7 +9441,7 @@ In roc, functions are always written as a lambda, like{}
         ),
         // TODO: this error message is quite unfortunate. We should remove the duplication, and
         // also support regions that point to things in other modules. See also https://github.com/roc-lang/roc/issues/3056.
-        @r###"
+        @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     This expression has a type that does not implement the abilities it's expected to:
@@ -9461,7 +9461,7 @@ In roc, functions are always written as a lambda, like{}
 
     Tip: `A` does not implement `Encoding`. Consider adding a custom
     implementation or `implements Encode.Encoding` to the definition of `A`.
-    "###
+    "
     );
 
     test_report!(
@@ -9478,7 +9478,7 @@ In roc, functions are always written as a lambda, like{}
                 t2 = t1 {}
                 "#
         ),
-        @r#"
+        @r"
             ── CIRCULAR DEFINITION ─────────────────────────────────── /code/proj/Main.roc ─
 
             The `t1` definition is causing a very tricky infinite loop:
@@ -9494,7 +9494,7 @@ In roc, functions are always written as a lambda, like{}
                 │     ↓
                 │     t2
                 └─────┘
-            "#
+            "
     );
 
     test_report!(
@@ -9508,7 +9508,7 @@ In roc, functions are always written as a lambda, like{}
             A := U8 implements [MEq {eq}]
             "#
         ),
-        @r###"
+        @r"
     ── IMPLEMENTATION NOT FOUND ────────────────────────────── /code/proj/Main.roc ─
 
     An implementation of `eq` could not be found in this scope:
@@ -9530,7 +9530,7 @@ In roc, functions are always written as a lambda, like{}
     The following necessary members are missing implementations:
 
         eq
-    "###
+    "
     );
 
     test_report!(
@@ -9546,7 +9546,7 @@ In roc, functions are always written as a lambda, like{}
             myMEq = \m, n -> m == n
             "#
         ),
-        @r###"
+        @r"
     ── UNRECOGNIZED NAME ───────────────────────────────────── /code/proj/Main.roc ─
 
     Nothing is named `aMEq` in this scope.
@@ -9571,7 +9571,7 @@ In roc, functions are always written as a lambda, like{}
     The following necessary members are missing implementations:
 
         eq
-    "###
+    "
     );
 
     test_report!(
@@ -9587,7 +9587,7 @@ In roc, functions are always written as a lambda, like{}
             myMEq = \m, n -> m == n
             "#
         ),
-        @r###"
+        @r"
     ── OPTIONAL ABILITY IMPLEMENTATION ─────────────────────── /code/proj/Main.roc ─
 
     Ability implementations cannot be optional:
@@ -9609,7 +9609,7 @@ In roc, functions are always written as a lambda, like{}
     The following necessary members are missing implementations:
 
         eq
-    "###
+    "
     );
 
     test_report!(
@@ -9625,7 +9625,7 @@ In roc, functions are always written as a lambda, like{}
             myEncoder = 1
             "#
         ),
-        @r###"
+        @r"
     ── OPTIONAL ABILITY IMPLEMENTATION ─────────────────────── /code/proj/Main.roc ─
 
     Ability implementations cannot be optional:
@@ -9649,7 +9649,7 @@ In roc, functions are always written as a lambda, like{}
     The following necessary members are missing implementations:
 
         toEncoder
-    "###
+    "
     );
 
     test_report!(
@@ -9663,7 +9663,7 @@ In roc, functions are always written as a lambda, like{}
             A := U8 implements [ MEq {eq : Bool.eq} ]
             "#
         ),
-        @r###"
+        @r"
     ── QUALIFIED ABILITY IMPLEMENTATION ────────────────────── /code/proj/Main.roc ─
 
     This ability implementation is qualified:
@@ -9684,7 +9684,7 @@ In roc, functions are always written as a lambda, like{}
     The following necessary members are missing implementations:
 
         eq
-    "###
+    "
     );
 
     test_report!(
@@ -9698,7 +9698,7 @@ In roc, functions are always written as a lambda, like{}
             A := U8 implements [ MEq {eq : \m, n -> m == n} ]
             "#
         ),
-        @r###"
+        @r"
     ── ABILITY IMPLEMENTATION NOT IDENTIFIER ───────────────── /code/proj/Main.roc ─
 
     This ability implementation is not an identifier:
@@ -9721,7 +9721,7 @@ In roc, functions are always written as a lambda, like{}
     The following necessary members are missing implementations:
 
         eq
-    "###
+    "
     );
 
     test_report!(
@@ -9737,7 +9737,7 @@ In roc, functions are always written as a lambda, like{}
             eqA = \@A m, @A n -> m == n
             "#
         ),
-        @r###"
+        @r"
     ── DUPLICATE IMPLEMENTATION ────────────────────────────── /code/proj/Main.roc ─
 
     This ability member implementation is duplicate:
@@ -9751,7 +9751,7 @@ In roc, functions are always written as a lambda, like{}
                                   ^^^^^^^
 
     Only one custom implementation can be defined for an ability member.
-    "###
+    "
     );
 
     test_report!(
@@ -9765,7 +9765,7 @@ In roc, functions are always written as a lambda, like{}
             A := U8 implements [ Foo {} ]
             "#
         ),
-        @r###"
+        @r"
     ── NOT AN ABILITY ──────────────────────────────────────── /code/proj/Main.roc ─
 
     This identifier is not an ability in scope:
@@ -9774,7 +9774,7 @@ In roc, functions are always written as a lambda, like{}
                              ^^^
 
     Only abilities can be implemented.
-    "###
+    "
     );
 
     test_report!(
@@ -9788,7 +9788,7 @@ In roc, functions are always written as a lambda, like{}
             A := {} implements [Ab]
             "#
         ),
-        @r###"
+        @r"
     ── ILLEGAL DERIVE ──────────────────────────────────────── /code/proj/Main.roc ─
 
     This ability cannot be derived:
@@ -9799,7 +9799,7 @@ In roc, functions are always written as a lambda, like{}
     Only builtin abilities can be derived.
 
     Note: The builtin abilities are `Encoding`, `Decoding`, `Hash`, `Eq`, `Inspect`
-    "###
+    "
     );
 
     test_report!(
@@ -9811,7 +9811,7 @@ In roc, functions are always written as a lambda, like{}
             A a := a -> a implements [Encode.Encoding]
             "#
         ),
-        @r###"
+        @r"
     ── INCOMPLETE ABILITY IMPLEMENTATION ───────────────────── /code/proj/Main.roc ─
 
     I can't derive an implementation of the `Encoding` ability for `A`:
@@ -9822,7 +9822,7 @@ In roc, functions are always written as a lambda, like{}
     Note: `Encoding` cannot be generated for functions.
 
     Tip: You can define a custom implementation of `Encoding` for `A`.
-    "###
+    "
     );
 
     test_report!(
@@ -9836,7 +9836,7 @@ In roc, functions are always written as a lambda, like{}
             B := {}
             "#
         ),
-        @r###"
+        @r"
     ── INCOMPLETE ABILITY IMPLEMENTATION ───────────────────── /code/proj/Main.roc ─
 
     I can't derive an implementation of the `Encoding` ability for `A`:
@@ -9848,7 +9848,7 @@ In roc, functions are always written as a lambda, like{}
     implementation or `implements Encode.Encoding` to the definition of `B`.
 
     Tip: You can define a custom implementation of `Encoding` for `A`.
-    "###
+    "
     );
 
     test_report!(
@@ -9888,7 +9888,7 @@ In roc, functions are always written as a lambda, like{}
             main = \n -> n + 2
             "#
         ),
-        @r###"
+        @r"
     ── DUPLICATE NAME ──────────────────────────────────────── /code/proj/Main.roc ─
 
     The `main` name is first defined here:
@@ -9915,13 +9915,13 @@ In roc, functions are always written as a lambda, like{}
     assignment, consider removing the assignment. Since Roc is purely
     functional, assignments that don't introduce variables cannot affect a
     program's behavior!
-    "###
+    "
     );
 
     test_report!(
         issue_1755,
         indoc!(
-            r#"
+            r"
             Handle := {}
 
             await : Result a err, (a -> Result b err) -> Result b err
@@ -9935,9 +9935,9 @@ In roc, functions are always written as a lambda, like{}
                 close handle
 
             withOpen
-            "#
+            "
         ),
-        @r#"
+        @r"
         ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
         Something is off with the body of the `withOpen` definition:
@@ -9959,20 +9959,20 @@ In roc, functions are always written as a lambda, like{}
         Tip: Any connection between types must use a named type variable, not
         a `*`! Maybe the annotation  on `withOpen` should have a named type
         variable in place of the `*`?
-        "#
+        "
     );
 
     test_report!(
         recursive_body_and_annotation_with_inference_disagree,
         indoc!(
-            r#"
+            r"
             f : _ -> (_ -> Str)
             f = \_ -> if Bool.true then {} else f {}
 
             f
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     This expression is used in an unexpected way:
@@ -9987,13 +9987,13 @@ In roc, functions are always written as a lambda, like{}
     But you are trying to use it as:
 
         * -> Str
-    "###
+    "
     );
 
     test_report!(
         same_phantom_types_unify,
         indoc!(
-            r#"
+            r"
             F a b := b
 
             foo : F Str Str -> {}
@@ -10001,7 +10001,7 @@ In roc, functions are always written as a lambda, like{}
             x : F Str Str
 
             foo x
-            "#
+            "
         ),
         @r"" // okay
     );
@@ -10009,7 +10009,7 @@ In roc, functions are always written as a lambda, like{}
     test_report!(
         different_phantom_types,
         indoc!(
-            r#"
+            r"
             F a b := b
 
             foo : F Str Str -> {}
@@ -10017,9 +10017,9 @@ In roc, functions are always written as a lambda, like{}
             x : F U8 Str
 
             foo x
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     This 1st argument to `foo` has an unexpected type:
@@ -10034,7 +10034,7 @@ In roc, functions are always written as a lambda, like{}
     But `foo` needs its 1st argument to be:
 
         F Str Str
-    "###
+    "
     );
 
     test_report!(
@@ -10053,18 +10053,18 @@ In roc, functions are always written as a lambda, like{}
             x : F MHash {}
             "#
         ),
-        @r###"
-        "###
+        @r"
+        "
     );
 
     test_report!(
         int_literals_cannot_fit_in_same_type,
         indoc!(
-            r#"
+            r"
             0x80000000000000000000000000000000 == -0x80000000000000000000000000000000
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     This 2nd argument to == has an unexpected type:
@@ -10079,17 +10079,17 @@ In roc, functions are always written as a lambda, like{}
     But == needs its 2nd argument to be:
 
         U128
-    "###
+    "
     );
 
     test_report!(
         num_literals_cannot_fit_in_same_type,
         indoc!(
-            r#"
+            r"
             170141183460469231731687303715884105728 == -170141183460469231731687303715884105728
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     This 2nd argument to == has an unexpected type:
@@ -10104,13 +10104,13 @@ In roc, functions are always written as a lambda, like{}
     But == needs its 2nd argument to be:
 
         U128
-    "###
+    "
     );
 
     test_report!(
         recursive_alias_cannot_leak_into_recursive_opaque,
         indoc!(
-            r#"
+            r"
             OList := [Nil, Cons {} OList]
 
             AList : [Nil, Cons {} AList]
@@ -10124,9 +10124,9 @@ In roc, functions are always written as a lambda, like{}
                     Cons _ lst -> lst
 
             olist
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     Something is off with the 2nd branch of this `when` expression:
@@ -10152,18 +10152,18 @@ In roc, functions are always written as a lambda, like{}
     both types are the same opaque type. Did you mean to create an opaque
     type by wrapping it? If I have an opaque type Age := U32 I can create
     an instance of this opaque type by doing @Age 23.
-    "###
+    "
     );
 
     test_report!(
         opaque_wrap_function_mismatch,
         indoc!(
-            r#"
+            r"
             A := U8
             List.map [1u16, 2u16, 3u16] @A
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     This 2nd argument to `map` has an unexpected type:
@@ -10178,7 +10178,7 @@ In roc, functions are always written as a lambda, like{}
     But `map` needs its 2nd argument to be:
 
         U16 -> A
-    "###
+    "
     );
 
     test_report!(
@@ -10189,7 +10189,7 @@ In roc, functions are always written as a lambda, like{}
                 A x | B y -> x
             "#
         ),
-        @r###"
+        @r#"
         ── NAME NOT BOUND IN ALL PATTERNS ──────────────────────── /code/proj/Main.roc ─
 
         `x` is not bound in all patterns of this `when` branch
@@ -10221,7 +10221,7 @@ In roc, functions are always written as a lambda, like{}
 
         If you don't need to use `y`, prefix it with an underscore, like "_y",
         or replace it with just an "_".
-        "###
+        "#
     );
 
     test_report!(
@@ -10233,7 +10233,7 @@ In roc, functions are always written as a lambda, like{}
                     A _ C -> ""
             "#
         ),
-        @r###"
+        @r#"
     ── UNSAFE PATTERN ──────────────────────────────────────── /code/proj/Main.roc ─
 
     This `when` does not cover all the possibilities:
@@ -10247,20 +10247,20 @@ In roc, functions are always written as a lambda, like{}
         A _ _
 
     I would have to crash if I saw one of those! Add branches for them!
-    "###
+    "#
     );
 
     test_report!(
         forgot_to_remove_underscore,
         indoc!(
-            r#"
+            r"
             \_foo -> foo
-            "#
+            "
         ),
         |golden| pretty_assertions::assert_eq!(
             golden,
             indoc!(
-                r###"── UNRECOGNIZED NAME ───────────────────────────────────── /code/proj/Main.roc ─
+                r"── UNRECOGNIZED NAME ───────────────────────────────────── /code/proj/Main.roc ─
 
                 Nothing is named `foo` in this scope.
 
@@ -10280,7 +10280,7 @@ In roc, functions are always written as a lambda, like{}
                     Bool
                     U8
                     F64
-                "###
+                "
             ),
         )
     );
@@ -10288,16 +10288,16 @@ In roc, functions are always written as a lambda, like{}
     test_report!(
         call_with_underscore_identifier,
         indoc!(
-            r#"
+            r"
             f = \x, y, z -> x + y + z
 
             f 1 _ 1
-            "#
+            "
         ),
         |golden| pretty_assertions::assert_eq!(
             golden,
             indoc!(
-                r###"── SYNTAX PROBLEM ──────────────────────────────────────── /code/proj/Main.roc ─
+                r"── SYNTAX PROBLEM ──────────────────────────────────────── /code/proj/Main.roc ─
 
                 An underscore is being used as a variable here:
 
@@ -10306,7 +10306,7 @@ In roc, functions are always written as a lambda, like{}
 
                 An underscore can be used to ignore a value when pattern matching, but
                 it cannot be used as a variable.
-                "###
+                "
             ),
         )
     );
@@ -10314,16 +10314,16 @@ In roc, functions are always written as a lambda, like{}
     test_report!(
         call_with_declared_identifier_starting_with_underscore,
         indoc!(
-            r#"
+            r"
             f = \x, y, z -> x + y + z
 
             \a, _b -> f a _b 1
-            "#
+            "
         ),
         |golden| pretty_assertions::assert_eq!(
             golden,
             indoc!(
-                r###"── SYNTAX PROBLEM ──────────────────────────────────────── /code/proj/Main.roc ─
+                r"── SYNTAX PROBLEM ──────────────────────────────────────── /code/proj/Main.roc ─
 
                 This variable's name starts with an underscore:
 
@@ -10338,7 +10338,7 @@ In roc, functions are always written as a lambda, like{}
                 A variable's name can only start with an underscore if the variable is
                 unused. Since you are using this variable, you could remove the
                 underscore from its name in both places.
-                "###
+                "
             ),
         )
     );
@@ -10346,16 +10346,16 @@ In roc, functions are always written as a lambda, like{}
     test_report!(
         call_with_undeclared_identifier_starting_with_underscore,
         indoc!(
-            r#"
+            r"
             f = \x, y, z -> x + y + z
 
             \a, _b -> f a _r 1
-            "#
+            "
         ),
         |golden| pretty_assertions::assert_eq!(
             golden,
             indoc!(
-                r###"
+                r"
                 ── SYNTAX PROBLEM ──────────────────────────────────────── /code/proj/Main.roc ─
 
                 This variable's name starts with an underscore:
@@ -10365,7 +10365,7 @@ In roc, functions are always written as a lambda, like{}
 
                 A variable's name can only start with an underscore if the variable is
                 unused. But it looks like the variable is being used here!
-                "###
+                "
             ),
         )
     );
@@ -10373,16 +10373,16 @@ In roc, functions are always written as a lambda, like{}
     test_report!(
         underscore_in_middle_of_identifier,
         indoc!(
-            r#"
+            r"
             f = \x, y, z -> x + y + z
 
             \a, _b -> f a var_name 1
-            "#
+            "
         ),
         |golden| pretty_assertions::assert_eq!(
             golden,
             indoc!(
-                r###"
+                r"
                 ── SYNTAX PROBLEM ──────────────────────────────────────── /code/proj/Main.roc ─
 
                 Underscores are not allowed in identifier names:
@@ -10391,7 +10391,7 @@ In roc, functions are always written as a lambda, like{}
                                       ^^^^^^^^
 
                 I recommend using camelCase. It's the standard style in Roc code!
-                "###
+                "
             ),
         )
     );
@@ -10409,7 +10409,7 @@ In roc, functions are always written as a lambda, like{}
             }
             "#
         ),
-        @r###"
+        @r#"
     ── BAD RECORD BUILDER ────────── tmp/optional_field_in_record_builder/Test.roc ─
 
     I am partway through parsing a record builder, and I found an optional
@@ -10425,7 +10425,7 @@ In roc, functions are always written as a lambda, like{}
                 ^^^^^^^^^^^^^^
 
     Optional fields can only appear when you destructure a record.
-    "###
+    "#
     );
 
     test_report!(
@@ -10438,7 +10438,7 @@ In roc, functions are always written as a lambda, like{}
             }
             "#
         ),
-        @r###"
+        @r#"
     ── BAD RECORD UPDATE ────────────────────── tmp/record_update_builder/Test.roc ─
 
     I am partway through parsing a record update, and I found a record
@@ -10452,7 +10452,7 @@ In roc, functions are always written as a lambda, like{}
                 ^^^^^^^^^^^^^^^
 
     Record builders cannot be updated like records.
-    "###
+    "#
     );
 
     test_report!(
@@ -10464,7 +10464,7 @@ In roc, functions are always written as a lambda, like{}
                 { b: <- apply "b" }
             "#
         ),
-        @r###"
+        @r#"
     ── MULTIPLE RECORD BUILDERS ────────────────────────────── /code/proj/Main.roc ─
 
     This function is applied to multiple record builders:
@@ -10477,7 +10477,7 @@ In roc, functions are always written as a lambda, like{}
 
     Tip: You can combine them or apply them separately.
 
-    "###
+    "#
     );
 
     test_report!(
@@ -10487,7 +10487,7 @@ In roc, functions are always written as a lambda, like{}
             { a: <- apply "a" }
             "#
         ),
-        @r###"
+        @r#"
     ── UNAPPLIED RECORD BUILDER ────────────────────────────── /code/proj/Main.roc ─
 
     This record builder was not applied to a function:
@@ -10498,7 +10498,7 @@ In roc, functions are always written as a lambda, like{}
     However, we need a function to construct the record.
 
     Note: Functions must be applied directly. The pipe operator (|>) cannot be used.
-    "###
+    "#
     );
 
     test_report!(
@@ -10512,7 +10512,7 @@ In roc, functions are always written as a lambda, like{}
             }
             "#
         ),
-        @r###"
+        @r#"
     ── TOO MANY ARGS ───────────────────────────────────────── /code/proj/Main.roc ─
 
     This value is not a function, but it was given 1 argument:
@@ -10521,7 +10521,7 @@ In roc, functions are always written as a lambda, like{}
                       ^^^
 
     Tip: Remove `<-` to assign the field directly.
-    "###
+    "#
     );
 
     // Skipping test because opaque types defined in the same module
@@ -10544,7 +10544,7 @@ In roc, functions are always written as a lambda, like{}
     //         }
     //         "#
     //     ),
-    //     @r###"
+    //     @r#"
     // ── TOO MANY ARGS ───────────────────────────────────────── /code/proj/Main.roc ─
 
     // This value is an opaque type, so it cannot be called with an argument:
@@ -10553,13 +10553,13 @@ In roc, functions are always written as a lambda, like{}
     //                    ^^^^^^^
 
     // Hint: Did you mean to apply it to a function first?
-    //     "###
+    //     "#
     // );
 
     test_report!(
         destructure_assignment_introduces_no_variables_nested,
         indoc!(
-            r#"
+            r"
             Pair _ _ = Pair 0 1
 
             _ = Pair 0 1
@@ -10569,9 +10569,9 @@ In roc, functions are always written as a lambda, like{}
             Foo = Foo
 
             0
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── UNNECESSARY DEFINITION ──────────────────────────────── /code/proj/Main.roc ─
 
     This destructure assignment doesn't introduce any new variables:
@@ -10619,7 +10619,7 @@ In roc, functions are always written as a lambda, like{}
     assignment, consider removing the assignment. Since Roc is purely
     functional, assignments that don't introduce variables cannot affect a
     program's behavior!
-    "###
+    "
     );
 
     test_report!(
@@ -10637,7 +10637,7 @@ In roc, functions are always written as a lambda, like{}
             Foo = Foo
             "#
         ),
-        @r###"
+        @r"
     ── UNNECESSARY DEFINITION ──────────────────────────────── /code/proj/Main.roc ─
 
     This destructure assignment doesn't introduce any new variables:
@@ -10685,7 +10685,7 @@ In roc, functions are always written as a lambda, like{}
     assignment, consider removing the assignment. Since Roc is purely
     functional, assignments that don't introduce variables cannot affect a
     program's behavior!
-    "###
+    "
     );
 
     test_report!(
@@ -10701,7 +10701,7 @@ In roc, functions are always written as a lambda, like{}
             hash = \@Id _ -> 0
             "#
         ),
-        @r###"
+        @r"
     ── UNUSED DEFINITION ───────────────────────────────────── /code/proj/Main.roc ─
 
     `hash` is not used anywhere in your code.
@@ -10711,7 +10711,7 @@ In roc, functions are always written as a lambda, like{}
 
     If you didn't intend on using `hash` then remove it so future readers of
     your code don't wonder why it is there.
-    "###
+    "
     );
 
     test_report!(
@@ -10728,7 +10728,7 @@ In roc, functions are always written as a lambda, like{}
             hash = \@Id2 _ -> 0
             "#
         ),
-        @r###"
+        @r"
     ── WRONG SPECIALIZATION TYPE ───────────────────────────── /code/proj/Main.roc ─
 
     This specialization of `hash` is not for the expected type:
@@ -10738,20 +10738,20 @@ In roc, functions are always written as a lambda, like{}
 
     It was previously claimed to be a specialization for `Id`, but was
     determined to actually specialize `Id2`!
-    "###
+    "
     );
 
     test_report!(
         mismatched_record_annotation,
         indoc!(
-            r#"
+            r"
                 x : { y : Str }
                 x = {}
 
                 x
-                "#
+                "
         ),
-        @r###"
+        @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     Something is off with the body of the `x` definition:
@@ -10769,19 +10769,19 @@ In roc, functions are always written as a lambda, like{}
         { y : Str }
 
     Tip: Looks like the y field is missing.
-    "###
+    "
     );
 
     test_report!(
         cyclic_opaque,
         indoc!(
-            r#"
+            r"
             Recursive := [Infinitely Recursive]
 
             0
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── CYCLIC ALIAS ────────────────────────────────────────── /code/proj/Main.roc ─
 
     The `Recursive` opaque is self-recursive in an invalid way:
@@ -10791,7 +10791,7 @@ In roc, functions are always written as a lambda, like{}
 
     Recursion in opaquees is only allowed if recursion happens behind a
     tagged union, at least one variant of which is not recursive.
-    "###
+    "
     );
 
     test_report!(
@@ -10803,7 +10803,7 @@ In roc, functions are always written as a lambda, like{}
             A a := a -> a implements [Decode.Decoding]
             "#
         ),
-        @r###"
+        @r"
     ── INCOMPLETE ABILITY IMPLEMENTATION ───────────────────── /code/proj/Main.roc ─
 
     I can't derive an implementation of the `Decoding` ability for `A`:
@@ -10814,7 +10814,7 @@ In roc, functions are always written as a lambda, like{}
     Note: `Decoding` cannot be generated for functions.
 
     Tip: You can define a custom implementation of `Decoding` for `A`.
-    "###
+    "
     );
 
     test_report!(
@@ -10828,7 +10828,7 @@ In roc, functions are always written as a lambda, like{}
             B := {}
             "#
         ),
-        @r###"
+        @r"
     ── INCOMPLETE ABILITY IMPLEMENTATION ───────────────────── /code/proj/Main.roc ─
 
     I can't derive an implementation of the `Decoding` ability for `A`:
@@ -10841,7 +10841,7 @@ In roc, functions are always written as a lambda, like{}
 
     Tip: You can define a custom implementation of `Decoding` for `A`.
 
-    "###
+    "
     );
 
     test_report!(
@@ -10883,7 +10883,7 @@ In roc, functions are always written as a lambda, like{}
                 myDecoder
             "#
         ),
-        @r###"
+        @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     This expression has a type that does not implement the abilities it's expected to:
@@ -10896,7 +10896,7 @@ In roc, functions are always written as a lambda, like{}
         a -> a
 
     Note: `Decoding` cannot be generated for functions.
-    "###
+    "
     );
 
     test_report!(
@@ -10914,7 +10914,7 @@ In roc, functions are always written as a lambda, like{}
                 myDecoder
             "#
         ),
-        @r###"
+        @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     This expression has a type that does not implement the abilities it's expected to:
@@ -10934,17 +10934,17 @@ In roc, functions are always written as a lambda, like{}
 
     Tip: `A` does not implement `Decoding`. Consider adding a custom
     implementation or `implements Decode.Decoding` to the definition of `A`.
-    "###
+    "
     );
 
     test_report!(
         anonymous_function_does_not_use_param,
         indoc!(
-            r#"
+            r"
             (\x -> 5) 1
-            "#
+            "
         ),
-    @r###"
+    @r#"
     ── UNUSED ARGUMENT ─────────────────────────────────────── /code/proj/Main.roc ─
 
     This function doesn't use `x`.
@@ -10956,7 +10956,7 @@ In roc, functions are always written as a lambda, like{}
     really do need `x` as an argument of this function, prefix it with an
     underscore, like this: "_`x`". Adding an underscore at the start of a
     variable name is a way of saying that the variable is not used.
-    "###
+    "#
     );
 
     test_report!(
@@ -10976,7 +10976,7 @@ In roc, functions are always written as a lambda, like{}
                         Ok "foo"
             "#
         ),
-        @r###"
+        @r#"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     The branches of this `when` expression don't match the condition:
@@ -10997,7 +10997,7 @@ In roc, functions are always written as a lambda, like{}
         [Good … *, …]
 
     The branches must be cases of the `when` condition's type!
-    "###
+    "#
     );
 
     test_report!(
@@ -11009,7 +11009,7 @@ In roc, functions are always written as a lambda, like{}
             f
             "#
         ),
-        @r###"
+        @r#"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     Something is off with the body of the `f` definition:
@@ -11034,7 +11034,7 @@ In roc, functions are always written as a lambda, like{}
 
     Tip: To extract the `.b` field it must be non-optional, but the type
     says this field is optional. Learn more about optional fields at TODO.
-    "###
+    "#
     );
 
     test_report!(
@@ -11046,7 +11046,7 @@ In roc, functions are always written as a lambda, like{}
             f
             "#
         ),
-        @r###"
+        @r#"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     Something is off with the `then` branch of this `if` expression:
@@ -11067,7 +11067,7 @@ In roc, functions are always written as a lambda, like{}
         }
 
     Tip: Looks like the b field is missing.
-    "###
+    "#
     );
 
     test_report!(
@@ -11078,7 +11078,7 @@ In roc, functions are always written as a lambda, like{}
                 A foo -> ""
             "#
         ),
-    @r###"
+    @r#"
     ── UNUSED DEFINITION ───────────────────────────────────── /code/proj/Main.roc ─
 
     `foo` is not used in this `when` branch.
@@ -11088,7 +11088,7 @@ In roc, functions are always written as a lambda, like{}
 
     If you don't need to use `foo`, prefix it with an underscore, like
     "_foo", or replace it with just an "_".
-    "###
+    "#
     );
 
     test_report!(
@@ -11104,7 +11104,7 @@ In roc, functions are always written as a lambda, like{}
                     _ -> "something went wrong"
             "#
         ),
-    @r###"
+    @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     This expression has a type that does not implement the abilities it's expected to:
@@ -11117,7 +11117,7 @@ In roc, functions are always written as a lambda, like{}
         * -> *
 
     Note: `Decoding` cannot be generated for functions.
-    "###
+    "
     );
 
     test_report!(
@@ -11133,7 +11133,7 @@ In roc, functions are always written as a lambda, like{}
                  myDecoder
              "#
         ),
-        @r###"
+        @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     This expression has a type that does not implement the abilities it's expected to:
@@ -11153,7 +11153,7 @@ In roc, functions are always written as a lambda, like{}
     records that may or may not contain them at compile time, but are not
     a concept that extends to runtime!
     Maybe you wanted to use a `Result`?
-    "###
+    "
     );
 
     test_report!(
@@ -11167,8 +11167,8 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
     // no problem!
-    @r###"
-    "###
+    @r"
+    "
     );
 
     test_report!(
@@ -11183,8 +11183,8 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
     // no problem!
-    @r###"
-    "###
+    @r"
+    "
     );
 
     test_report!(
@@ -11199,7 +11199,7 @@ In roc, functions are always written as a lambda, like{}
                 Err _ -> ""
             "#
         ),
-    @r###"
+    @r#"
     ── UNSAFE PATTERN ──────────────────────────────────────── /code/proj/Main.roc ─
 
     This `when` does not cover all the possibilities:
@@ -11214,7 +11214,7 @@ In roc, functions are always written as a lambda, like{}
         Ok (Ok B)
 
     I would have to crash if I saw one of those! Add branches for them!
-    "###
+    "#
     );
 
     test_report!(
@@ -11227,7 +11227,7 @@ In roc, functions are always written as a lambda, like{}
                 Ok (Ok A) -> ""
             "#
         ),
-    @r###"
+    @r#"
     ── UNSAFE PATTERN ──────────────────────────────────────── /code/proj/Main.roc ─
 
     This `when` does not cover all the possibilities:
@@ -11240,7 +11240,7 @@ In roc, functions are always written as a lambda, like{}
         Ok (Ok B)
 
     I would have to crash if I saw one of those! Add branches for them!
-    "###
+    "#
     );
 
     test_report!(
@@ -11254,7 +11254,7 @@ In roc, functions are always written as a lambda, like{}
                 Err _ -> ""
             "#
         ),
-    @r###"
+    @r#"
     ── UNMATCHABLE PATTERN ─────────────────────────────────── /code/proj/Main.roc ─
 
     The 2nd pattern will never be matched:
@@ -11266,7 +11266,7 @@ In roc, functions are always written as a lambda, like{}
 
     It's impossible to create a value of this shape, so this pattern can
     be safely removed!
-    "###
+    "#
     );
 
     test_report!(
@@ -11281,7 +11281,7 @@ In roc, functions are always written as a lambda, like{}
                 Err _ -> ""
             "#
         ),
-    @r###"
+    @r#"
     ── UNMATCHABLE PATTERN ─────────────────────────────────── /code/proj/Main.roc ─
 
     The 2nd pattern will never be matched:
@@ -11306,7 +11306,7 @@ In roc, functions are always written as a lambda, like{}
 
     It's impossible to create a value of this shape, so this pattern can
     be safely removed!
-    "###
+    "#
     );
 
     test_report!(
@@ -11318,7 +11318,7 @@ In roc, functions are always written as a lambda, like{}
             ""
             "#
         ),
-    @r###"
+    @r"
     ── DUPLICATE NAME ──────────────────────────────────────── /code/proj/Main.roc ─
 
     This opaque type has the same name as a builtin:
@@ -11328,7 +11328,7 @@ In roc, functions are always written as a lambda, like{}
 
     All builtin opaque types are in scope by default, so I need this
     opaque type to have a different name!
-    "###
+    "
     );
 
     test_report!(
@@ -11340,7 +11340,7 @@ In roc, functions are always written as a lambda, like{}
             main = ""
             "#
         ),
-    @r###"
+    @r#"
     ── UNUSED IMPORT ───────────────────────────────────────── /code/proj/Main.roc ─
 
     `List.concat` is not used in this module.
@@ -11349,7 +11349,7 @@ In roc, functions are always written as a lambda, like{}
                                    ^^^^^^
 
     Since `List.concat` isn't used, you don't need to import it.
-    "###
+    "#
     );
 
     test_report!(
@@ -11362,8 +11362,8 @@ In roc, functions are always written as a lambda, like{}
             main = Str.concat "" ""
             "#
         ),
-    @r###"
-    "###
+    @r"
+    "
     );
 
     test_report!(
@@ -11378,8 +11378,8 @@ In roc, functions are always written as a lambda, like{}
             main = ""
             "#
         ),
-    @r###"
-    "###
+    @r"
+    "
     );
 
     test_report!(
@@ -11392,7 +11392,7 @@ In roc, functions are always written as a lambda, like{}
                 if Bool.true then {} else main
             "#
         ),
-    @r###"
+    @r"
     ── CIRCULAR DEFINITION ─────────────────────────────────── /code/proj/Main.roc ─
 
     `main` is defined directly in terms of itself:
@@ -11404,7 +11404,7 @@ In roc, functions are always written as a lambda, like{}
     infinite loop!
 
     Hint: Did you mean to define `main` as a function?
-    "###
+    "
     );
 
     test_report!(
@@ -11414,7 +11414,7 @@ In roc, functions are always written as a lambda, like{}
             if True then "" else ""
             "#
         ),
-    @r###"
+    @r#"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     This `if` condition needs to be a Bool:
@@ -11430,7 +11430,7 @@ In roc, functions are always written as a lambda, like{}
     or `Bool.false`.
 
     Tip: Did you mean to use `Bool.true` rather than `True`?
-    "###
+    "#
     );
 
     test_report!(
@@ -11440,7 +11440,7 @@ In roc, functions are always written as a lambda, like{}
             if False then "" else ""
             "#
         ),
-    @r###"
+    @r#"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     This `if` condition needs to be a Bool:
@@ -11456,7 +11456,7 @@ In roc, functions are always written as a lambda, like{}
     or `Bool.false`.
 
     Tip: Did you mean to use `Bool.false` rather than `False`?
-    "###
+    "#
     );
 
     test_report!(
@@ -11468,7 +11468,7 @@ In roc, functions are always written as a lambda, like{}
              A a := a -> a implements [Hash]
              "#
         ),
-        @r###"
+        @r"
     ── INCOMPLETE ABILITY IMPLEMENTATION ───────────────────── /code/proj/Main.roc ─
 
     I can't derive an implementation of the `Hash` ability for `A`:
@@ -11479,7 +11479,7 @@ In roc, functions are always written as a lambda, like{}
     Note: `Hash` cannot be generated for functions.
 
     Tip: You can define a custom implementation of `Hash` for `A`.
-    "###
+    "
     );
 
     test_report!(
@@ -11493,7 +11493,7 @@ In roc, functions are always written as a lambda, like{}
              B := {}
              "#
         ),
-        @r###"
+        @r"
     ── INCOMPLETE ABILITY IMPLEMENTATION ───────────────────── /code/proj/Main.roc ─
 
     I can't derive an implementation of the `Hash` ability for `A`:
@@ -11506,7 +11506,7 @@ In roc, functions are always written as a lambda, like{}
 
     Tip: You can define a custom implementation of `Hash` for `A`.
 
-    "###
+    "
     );
 
     test_report!(
@@ -11576,7 +11576,7 @@ In roc, functions are always written as a lambda, like{}
              main = foo (\x -> x)
              "#
         ),
-        @r###"
+        @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     This expression has a type that does not implement the abilities it's expected to:
@@ -11589,7 +11589,7 @@ In roc, functions are always written as a lambda, like{}
         a -> a
 
     Note: `Hash` cannot be generated for functions.
-    "###
+    "
     );
 
     test_report!(
@@ -11603,7 +11603,7 @@ In roc, functions are always written as a lambda, like{}
              main = foo (A (\x -> x) B)
              "#
         ),
-        @r###"
+        @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     This expression has a type that does not implement the abilities it's expected to:
@@ -11622,7 +11622,7 @@ In roc, functions are always written as a lambda, like{}
     cannot be generated.
 
     Note: `Hash` cannot be generated for functions.
-    "###
+    "
     );
 
     test_no_problem!(
@@ -11649,7 +11649,7 @@ In roc, functions are always written as a lambda, like{}
              main = foo ("", \{} -> {})
              "#
         ),
-        @r###"
+        @r#"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     This expression has a type that does not implement the abilities it's expected to:
@@ -11671,21 +11671,21 @@ In roc, functions are always written as a lambda, like{}
     cannot be generated.
 
     Note: `Hash` cannot be generated for functions.
-    "###
+    "#
     );
 
     test_report!(
         shift_by_negative,
         indoc!(
-            r#"
+            r"
             {
                 a: Num.shiftLeftBy 1 -1,
                 b: Num.shiftRightBy 1 -1,
                 c: Num.shiftRightZfBy 1 -1,
             }
-            "#
+            "
         ),
-    @r###"
+    @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     This 2nd argument to `shiftRightZfBy` has an unexpected type:
@@ -11730,20 +11730,20 @@ In roc, functions are always written as a lambda, like{}
     But `shiftLeftBy` needs its 2nd argument to be:
 
         U8
-    "###
+    "
     );
 
     test_report!(
         big_char_does_not_fit_in_u8,
         indoc!(
-            r#"
+            r"
             digits : List U8
             digits = List.range { start: At '0', end: At '9' }
 
             List.contains digits '☃'
-            "#
+            "
         ),
-    @r###"
+    @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     This 2nd argument to `contains` has an unexpected type:
@@ -11758,7 +11758,7 @@ In roc, functions are always written as a lambda, like{}
     But `contains` needs its 2nd argument to be:
 
         Int Unsigned8
-    "###
+    "
     );
 
     test_report!(
@@ -11770,7 +11770,7 @@ In roc, functions are always written as a lambda, like{}
              A a := a -> a implements [Eq]
              "#
         ),
-        @r###"
+        @r"
     ── INCOMPLETE ABILITY IMPLEMENTATION ───────────────────── /code/proj/Main.roc ─
 
     I can't derive an implementation of the `Eq` ability for `A`:
@@ -11781,7 +11781,7 @@ In roc, functions are always written as a lambda, like{}
     Note: `Eq` cannot be generated for functions.
 
     Tip: You can define a custom implementation of `Eq` for `A`.
-    "###
+    "
     );
 
     test_report!(
@@ -11795,7 +11795,7 @@ In roc, functions are always written as a lambda, like{}
                 _ -> ""
             "#
         ),
-    @r###"
+    @r#"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     The branches of this `when` expression don't match the condition:
@@ -11813,7 +11813,7 @@ In roc, functions are always written as a lambda, like{}
         U16, I32, U32, I64, Nat, U64, I128, or U128
 
     The branches must be cases of the `when` condition's type!
-    "###
+    "#
     );
 
     test_report!(
@@ -11825,7 +11825,7 @@ In roc, functions are always written as a lambda, like{}
              A := F32 implements [Eq]
              "#
         ),
-        @r###"
+        @r"
     ── INCOMPLETE ABILITY IMPLEMENTATION ───────────────────── /code/proj/Main.roc ─
 
     I can't derive an implementation of the `Eq` ability for `A`:
@@ -11839,7 +11839,7 @@ In roc, functions are always written as a lambda, like{}
     doesn't support total equality, it cannot support the `Eq` ability!
 
     Tip: You can define a custom implementation of `Eq` for `A`.
-    "###
+    "
     );
 
     test_report!(
@@ -11851,7 +11851,7 @@ In roc, functions are always written as a lambda, like{}
              A := F64 implements [Eq]
              "#
         ),
-        @r###"
+        @r"
     ── INCOMPLETE ABILITY IMPLEMENTATION ───────────────────── /code/proj/Main.roc ─
 
     I can't derive an implementation of the `Eq` ability for `A`:
@@ -11865,7 +11865,7 @@ In roc, functions are always written as a lambda, like{}
     doesn't support total equality, it cannot support the `Eq` ability!
 
     Tip: You can define a custom implementation of `Eq` for `A`.
-    "###
+    "
     );
 
     test_report!(
@@ -11879,7 +11879,7 @@ In roc, functions are always written as a lambda, like{}
              B := {}
              "#
         ),
-        @r###"
+        @r"
     ── INCOMPLETE ABILITY IMPLEMENTATION ───────────────────── /code/proj/Main.roc ─
 
     I can't derive an implementation of the `Eq` ability for `A`:
@@ -11892,7 +11892,7 @@ In roc, functions are always written as a lambda, like{}
 
     Tip: You can define a custom implementation of `Eq` for `A`.
 
-    "###
+    "
     );
 
     test_report!(
@@ -11962,7 +11962,7 @@ In roc, functions are always written as a lambda, like{}
              main = foo (\x -> x)
              "#
         ),
-        @r###"
+        @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     This expression has a type that does not implement the abilities it's expected to:
@@ -11975,7 +11975,7 @@ In roc, functions are always written as a lambda, like{}
         a -> a
 
     Note: `Eq` cannot be generated for functions.
-    "###
+    "
     );
 
     test_report!(
@@ -11989,7 +11989,7 @@ In roc, functions are always written as a lambda, like{}
              main = foo (A (\x -> x) B)
              "#
         ),
-        @r###"
+        @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     This expression has a type that does not implement the abilities it's expected to:
@@ -12008,17 +12008,17 @@ In roc, functions are always written as a lambda, like{}
     cannot be generated.
 
     Note: `Eq` cannot be generated for functions.
-    "###
+    "
     );
 
     test_report!(
         cannot_eq_functions,
         indoc!(
-            r#"
+            r"
             (\x -> x) == (\x -> x)
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     This expression has a type that does not implement the abilities it's expected to:
@@ -12031,17 +12031,17 @@ In roc, functions are always written as a lambda, like{}
         a -> a
 
     Note: `Eq` cannot be generated for functions.
-    "###
+    "
     );
 
     test_report!(
         cannot_not_eq_functions,
         indoc!(
-            r#"
+            r"
             (\x -> x) == (\x -> x)
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     This expression has a type that does not implement the abilities it's expected to:
@@ -12054,7 +12054,7 @@ In roc, functions are always written as a lambda, like{}
         a -> a
 
     Note: `Eq` cannot be generated for functions.
-    "###
+    "
     );
 
     test_no_problem!(
@@ -12081,7 +12081,7 @@ In roc, functions are always written as a lambda, like{}
              main = foo ("", 1.0f64)
              "#
         ),
-        @r###"
+        @r#"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     This expression has a type that does not implement the abilities it's expected to:
@@ -12106,20 +12106,20 @@ In roc, functions are always written as a lambda, like{}
     because Roc's floating-point numbers cannot be compared for total
     equality - in Roc, `NaN` is never comparable to `NaN`. If a type
     doesn't support total equality, it cannot support the `Eq` ability!
-    "###
+    "#
     );
 
     test_report!(
         cannot_import_structural_eq_not_eq,
         indoc!(
-            r#"
+            r"
             {
                 a: Bool.structuralEq,
                 b: Bool.structuralNotEq,
             }
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── NOT EXPOSED ─────────────────────────────────────────── /code/proj/Main.roc ─
 
     The Bool module does not expose `structuralEq`:
@@ -12147,7 +12147,7 @@ In roc, functions are always written as a lambda, like{}
         Bool.true
         Bool.boolIsEq
         Bool.false
-    "###
+    "
     );
 
     test_report!(
@@ -12161,7 +12161,7 @@ In roc, functions are always written as a lambda, like{}
             f : F ({} -> {})
             "#
         ),
-    @r###"
+    @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     This expression has a type that does not implement the abilities it's expected to:
@@ -12174,7 +12174,7 @@ In roc, functions are always written as a lambda, like{}
         {} -> {}
 
     Note: `Hash` cannot be generated for functions.
-    "###
+    "
     );
 
     test_report!(
@@ -12186,7 +12186,7 @@ In roc, functions are always written as a lambda, like{}
             foo
             "#
         ),
-    @r###"
+    @r#"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     The 1st argument to `foo` is weird:
@@ -12201,7 +12201,7 @@ In roc, functions are always written as a lambda, like{}
     But the annotation on `foo` says the 1st argument should be:
 
         { a : Str }
-    "###
+    "#
     );
 
     test_report!(
@@ -12215,7 +12215,7 @@ In roc, functions are always written as a lambda, like{}
             main = ""
             "#
         ),
-    @r###"
+    @r"
     ── INCOMPLETE ABILITY IMPLEMENTATION ───────────────────── /code/proj/Main.roc ─
 
     I can't derive an implementation of the `Hash` ability for `F`:
@@ -12248,19 +12248,19 @@ In roc, functions are always written as a lambda, like{}
     Note: `Encoding` cannot be generated for functions.
 
     Tip: You can define a custom implementation of `Encoding` for `F`.
-    "###
+    "
     );
 
     test_report!(
         duplicate_ability_in_has_clause,
         indoc!(
-            r#"
+            r"
             f : a -> {} where a implements Hash & Hash
 
             f
-            "#
+            "
         ),
-    @r###"
+    @r"
     ── DUPLICATE BOUND ABILITY ─────────────────────────────── /code/proj/Main.roc ─
 
     I already saw that this type variable is bound to the `Hash` ability
@@ -12271,7 +12271,7 @@ In roc, functions are always written as a lambda, like{}
 
     Abilities only need to bound to a type variable once in an `implements`
     clause!
-    "###
+    "
     );
 
     test_report!(
@@ -12286,7 +12286,7 @@ In roc, functions are always written as a lambda, like{}
             main = \x -> g x
             "#
         ),
-    @r###"
+    @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     This 1st argument to `g` has an unexpected type:
@@ -12308,7 +12308,7 @@ In roc, functions are always written as a lambda, like{}
     But, I see that it's also used as if it implements the ability
     `Decoding`. Can you use `x` without that ability? If not, consider adding
     it to the `implements` clause of `x`.
-    "###
+    "
     );
 
     test_report!(
@@ -12323,7 +12323,7 @@ In roc, functions are always written as a lambda, like{}
             main = \x -> g x
             "#
         ),
-    @r###"
+    @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     This 1st argument to `g` has an unexpected type:
@@ -12345,7 +12345,7 @@ In roc, functions are always written as a lambda, like{}
     But, I see that it's also used as if it implements the abilities `Hash`
     and `Decoding`. Can you use `x` without those abilities? If not, consider
     adding them to the `implements` clause of `x`.
-    "###
+    "
     );
 
     test_report!(
@@ -12361,7 +12361,7 @@ In roc, functions are always written as a lambda, like{}
             main = \x -> g (f x)
             "#
         ),
-    @r###"
+    @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     This 1st argument to `g` has an unexpected type:
@@ -12383,7 +12383,7 @@ In roc, functions are always written as a lambda, like{}
     But, I see that it's also used as if it implements the ability
     `Decoding`. Can you use `x` without that ability? If not, consider adding
     it to the `implements` clause of `x`.
-    "###
+    "
     );
 
     test_report!(
@@ -12394,7 +12394,7 @@ In roc, functions are always written as a lambda, like{}
                 [1, 2, -> ""
             "#
         ),
-    @r###"
+    @r#"
     ── UNFINISHED LIST PATTERN ────────── tmp/list_pattern_not_terminated/Test.roc ─
 
     I am partway through parsing a list pattern, but I got stuck here:
@@ -12404,7 +12404,7 @@ In roc, functions are always written as a lambda, like{}
 
     I was expecting to see a closing square brace before this, so try
     adding a ] and see if that helps?
-    "###
+    "#
     );
 
     test_report!(
@@ -12415,7 +12415,7 @@ In roc, functions are always written as a lambda, like{}
                 [...] -> ""
             "#
         ),
-    @r###"
+    @r#"
     ── INCORRECT REST PATTERN ─────── tmp/list_pattern_weird_rest_pattern/Test.roc ─
 
     It looks like you may trying to write a list rest pattern, but it's
@@ -12426,18 +12426,18 @@ In roc, functions are always written as a lambda, like{}
 
     List rest patterns, which match zero or more elements in a list, are
     denoted with .. - is that what you meant?
-    "###
+    "#
     );
 
     test_report!(
         unnecessary_extension_variable,
         indoc!(
-            r#"
+            r"
             f : {} -> [A, B]*
             f
-            "#
+            "
         ),
-    @r###"
+    @r"
     ── UNNECESSARY WILDCARD ────────────────────────────────── /code/proj/Main.roc ─
 
     This type annotation has a wildcard type variable (`*`) that isn't
@@ -12453,7 +12453,7 @@ In roc, functions are always written as a lambda, like{}
 
     You can safely remove this to make the code more concise without
     changing what it means.
-    "###
+    "
     );
 
     test_report!(
@@ -12464,7 +12464,7 @@ In roc, functions are always written as a lambda, like{}
                 [.., A, ..] -> ""
             "#
         ),
-    @r###"
+    @r#"
     ── MULTIPLE LIST REST PATTERNS ─────────────────────────── /code/proj/Main.roc ─
 
     This list pattern match has multiple rest patterns:
@@ -12487,7 +12487,7 @@ In roc, functions are always written as a lambda, like{}
         _
 
     I would have to crash if I saw one of those! Add branches for them!
-    "###
+    "#
     );
 
     test_report!(
@@ -12498,7 +12498,7 @@ In roc, functions are always written as a lambda, like{}
                 [A, .., .., B] -> ""
             "#
         ),
-    @r###"
+    @r#"
     ── MULTIPLE LIST REST PATTERNS ─────────────────────────── /code/proj/Main.roc ─
 
     This list pattern match has multiple rest patterns:
@@ -12521,7 +12521,7 @@ In roc, functions are always written as a lambda, like{}
         _
 
     I would have to crash if I saw one of those! Add branches for them!
-    "###
+    "#
     );
 
     test_report!(
@@ -12532,7 +12532,7 @@ In roc, functions are always written as a lambda, like{}
                 [A, 1u8] -> ""
             "#
         ),
-    @r###"
+    @r#"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     This list element doesn't match the types of other elements in the
@@ -12548,7 +12548,7 @@ In roc, functions are always written as a lambda, like{}
     But the other elements in this list pattern match
 
         [A]
-    "###
+    "#
     );
 
     test_report!(
@@ -12559,7 +12559,7 @@ In roc, functions are always written as a lambda, like{}
                 ["foo", "bar"] -> ""
             "#
         ),
-    @r###"
+    @r#"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     The branches of this `when` expression don't match the condition:
@@ -12579,7 +12579,7 @@ In roc, functions are always written as a lambda, like{}
         List Str
 
     The branches must be cases of the `when` condition's type!
-    "###
+    "#
     );
 
     test_report!(
@@ -12592,7 +12592,7 @@ In roc, functions are always written as a lambda, like{}
                 [] -> ""
             "#
         ),
-    @r###"
+    @r#"
     ── UNSAFE PATTERN ──────────────────────────────────────── /code/proj/Main.roc ─
 
     This `when` does not cover all the possibilities:
@@ -12605,7 +12605,7 @@ In roc, functions are always written as a lambda, like{}
         [_, ..]
 
     I would have to crash if I saw one of those! Add branches for them!
-    "###
+    "#
     );
 
     test_no_problem!(
@@ -12632,7 +12632,7 @@ In roc, functions are always written as a lambda, like{}
                 [A, A] -> ""
             "#
         ),
-    @r###"
+    @r#"
     ── UNSAFE PATTERN ──────────────────────────────────────── /code/proj/Main.roc ─
 
     This `when` does not cover all the possibilities:
@@ -12647,7 +12647,7 @@ In roc, functions are always written as a lambda, like{}
         [_, _, _, ..]
 
     I would have to crash if I saw one of those! Add branches for them!
-    "###
+    "#
     );
 
     test_no_problem!(
@@ -12676,7 +12676,7 @@ In roc, functions are always written as a lambda, like{}
                 [..] -> ""
             "#
         ),
-    @r###"
+    @r#"
     ── REDUNDANT PATTERN ───────────────────────────────────── /code/proj/Main.roc ─
     
     The 2nd pattern is redundant:
@@ -12688,19 +12688,19 @@ In roc, functions are always written as a lambda, like{}
     
     Any value of this shape will be handled by a previous pattern, so this
     one should be removed.
-    "###
+    "#
     );
 
     test_no_problem!(
         list_match_spread_as,
         indoc!(
-            r#"
+            r"
             l : List [A, B]
 
             when l is
                 [A, .. as rest] | [.. as rest, A] -> rest
                 [.. as rest] -> rest
-            "#
+            "
         )
     );
 
@@ -12742,7 +12742,7 @@ In roc, functions are always written as a lambda, like{}
                 [A, ..] -> ""
             "#
         ),
-    @r###"
+    @r#"
     ── UNSAFE PATTERN ──────────────────────────────────────── /code/proj/Main.roc ─
 
     This `when` does not cover all the possibilities:
@@ -12756,7 +12756,7 @@ In roc, functions are always written as a lambda, like{}
         [B, ..]
 
     I would have to crash if I saw one of those! Add branches for them!
-    "###
+    "#
     );
 
     test_report!(
@@ -12769,7 +12769,7 @@ In roc, functions are always written as a lambda, like{}
                 [A, B, ..] -> ""
             "#
         ),
-    @r###"
+    @r#"
     ── UNSAFE PATTERN ──────────────────────────────────────── /code/proj/Main.roc ─
 
     This `when` does not cover all the possibilities:
@@ -12784,7 +12784,7 @@ In roc, functions are always written as a lambda, like{}
         [_, A, ..]
 
     I would have to crash if I saw one of those! Add branches for them!
-    "###
+    "#
     );
 
     test_no_problem!(
@@ -12812,7 +12812,7 @@ In roc, functions are always written as a lambda, like{}
                 [.., A] -> ""
             "#
         ),
-    @r###"
+    @r#"
     ── UNSAFE PATTERN ──────────────────────────────────────── /code/proj/Main.roc ─
 
     This `when` does not cover all the possibilities:
@@ -12826,7 +12826,7 @@ In roc, functions are always written as a lambda, like{}
         [.., B]
 
     I would have to crash if I saw one of those! Add branches for them!
-    "###
+    "#
     );
 
     test_report!(
@@ -12839,7 +12839,7 @@ In roc, functions are always written as a lambda, like{}
                 [.., B, A] -> ""
             "#
         ),
-    @r###"
+    @r#"
     ── UNSAFE PATTERN ──────────────────────────────────────── /code/proj/Main.roc ─
 
     This `when` does not cover all the possibilities:
@@ -12854,7 +12854,7 @@ In roc, functions are always written as a lambda, like{}
         [.., _, B]
 
     I would have to crash if I saw one of those! Add branches for them!
-    "###
+    "#
     );
 
     test_no_problem!(
@@ -12888,7 +12888,7 @@ In roc, functions are always written as a lambda, like{}
                 [B, .., A] -> ""
             "#
         ),
-    @r###"
+    @r#"
     ── UNSAFE PATTERN ──────────────────────────────────────── /code/proj/Main.roc ─
 
     This `when` does not cover all the possibilities:
@@ -12904,7 +12904,7 @@ In roc, functions are always written as a lambda, like{}
         [_, .., _]
 
     I would have to crash if I saw one of those! Add branches for them!
-    "###
+    "#
     );
 
     test_report!(
@@ -12919,7 +12919,7 @@ In roc, functions are always written as a lambda, like{}
                 [B, .., B] -> ""
             "#
         ),
-    @r###"
+    @r#"
     ── UNSAFE PATTERN ──────────────────────────────────────── /code/proj/Main.roc ─
 
     This `when` does not cover all the possibilities:
@@ -12936,7 +12936,7 @@ In roc, functions are always written as a lambda, like{}
         [A, .., A]
 
     I would have to crash if I saw one of those! Add branches for them!
-    "###
+    "#
     );
 
     test_report!(
@@ -12951,7 +12951,7 @@ In roc, functions are always written as a lambda, like{}
                 [A, A, .., A, A] -> ""
             "#
         ),
-    @r###"
+    @r#"
     ── UNSAFE PATTERN ──────────────────────────────────────── /code/proj/Main.roc ─
 
     This `when` does not cover all the possibilities:
@@ -12969,7 +12969,7 @@ In roc, functions are always written as a lambda, like{}
         [_, _, _]
 
     I would have to crash if I saw one of those! Add branches for them!
-    "###
+    "#
     );
 
     test_no_problem!(
@@ -13000,7 +13000,7 @@ In roc, functions are always written as a lambda, like{}
                 [[..], .., [.., B]] -> ""
             "#
         ),
-    @r###"
+    @r#"
     ── UNSAFE PATTERN ──────────────────────────────────────── /code/proj/Main.roc ─
 
     This `when` does not cover all the possibilities:
@@ -13018,7 +13018,7 @@ In roc, functions are always written as a lambda, like{}
         [_, .., [.., A]]
 
     I would have to crash if I saw one of those! Add branches for them!
-    "###
+    "#
     );
 
     test_report!(
@@ -13034,7 +13034,7 @@ In roc, functions are always written as a lambda, like{}
                 [..] -> ""
             "#
         ),
-    @r###"
+    @r#"
     ── REDUNDANT PATTERN ───────────────────────────────────── /code/proj/Main.roc ─
 
     The 3rd pattern is redundant:
@@ -13047,7 +13047,7 @@ In roc, functions are always written as a lambda, like{}
 
     Any value of this shape will be handled by a previous pattern, so this
     one should be removed.
-    "###
+    "#
     );
 
     test_report!(
@@ -13062,7 +13062,7 @@ In roc, functions are always written as a lambda, like{}
                 [..] -> ""
             "#
         ),
-    @r###"
+    @r#"
     ── REDUNDANT PATTERN ───────────────────────────────────── /code/proj/Main.roc ─
 
     The 3rd pattern is redundant:
@@ -13075,7 +13075,7 @@ In roc, functions are always written as a lambda, like{}
 
     Any value of this shape will be handled by a previous pattern, so this
     one should be removed.
-    "###
+    "#
     );
 
     test_report!(
@@ -13090,7 +13090,7 @@ In roc, functions are always written as a lambda, like{}
                 [.., _] -> ""
             "#
         ),
-    @r###"
+    @r#"
     ── REDUNDANT PATTERN ───────────────────────────────────── /code/proj/Main.roc ─
 
     The 3rd pattern is redundant:
@@ -13103,7 +13103,7 @@ In roc, functions are always written as a lambda, like{}
 
     Any value of this shape will be handled by a previous pattern, so this
     one should be removed.
-    "###
+    "#
     );
 
     test_report!(
@@ -13118,7 +13118,7 @@ In roc, functions are always written as a lambda, like{}
                 [..] -> ""
             "#
         ),
-    @r###"
+    @r#"
     ── REDUNDANT PATTERN ───────────────────────────────────── /code/proj/Main.roc ─
 
     The 2nd pattern is redundant:
@@ -13130,7 +13130,7 @@ In roc, functions are always written as a lambda, like{}
 
     Any value of this shape will be handled by a previous pattern, so this
     one should be removed.
-    "###
+    "#
     );
 
     test_no_problem!(
@@ -13157,7 +13157,7 @@ In roc, functions are always written as a lambda, like{}
             f = \l -> if l == l then l else l
             "#
         ),
-    @r###"
+    @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     This expression has a type that does not implement the abilities it's expected to:
@@ -13178,17 +13178,17 @@ In roc, functions are always written as a lambda, like{}
     Tip: This type variable is not bound to `Eq`. Consider adding an
     `implements` clause to bind the type variable, like
     `where e implements Bool.Eq`
-    "###
+    "
     );
 
     test_report!(
         crash_given_non_string,
         indoc!(
-            r#"
+            r"
             crash {}
-            "#
+            "
         ),
-    @r###"
+    @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     This value passed to `crash` is not a string:
@@ -13203,17 +13203,17 @@ In roc, functions are always written as a lambda, like{}
     But I can only `crash` with messages of type
 
         Str
-    "###
+    "
     );
 
     test_report!(
         crash_unapplied,
         indoc!(
-            r#"
+            r"
             crash
-            "#
+            "
         ),
-    @r###"
+    @r"
     ── UNAPPLIED CRASH ─────────────────────────────────────── /code/proj/Main.roc ─
 
     This `crash` doesn't have a message given to it:
@@ -13224,7 +13224,7 @@ In roc, functions are always written as a lambda, like{}
     `crash` must be passed a message to crash with at the exact place it's
     used. `crash` can't be used as a value that's passed around, like
     functions can be - it must be applied immediately!
-    "###
+    "
     );
 
     test_report!(
@@ -13234,7 +13234,7 @@ In roc, functions are always written as a lambda, like{}
             crash "" ""
             "#
         ),
-    @r###"
+    @r#"
     ── OVERAPPLIED CRASH ───────────────────────────────────── /code/proj/Main.roc ─
 
     This `crash` has too many values given to it:
@@ -13243,7 +13243,7 @@ In roc, functions are always written as a lambda, like{}
                   ^^^^^
 
     `crash` must be given exacly one message to crash with.
-    "###
+    "#
     );
 
     test_no_problem!(
@@ -13270,7 +13270,7 @@ In roc, functions are always written as a lambda, like{}
             main = n == 1f64
             "#
         ),
-    @r###"
+    @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     This expression has a type that does not implement the abilities it's expected to:
@@ -13286,7 +13286,7 @@ In roc, functions are always written as a lambda, like{}
     because Roc's floating-point numbers cannot be compared for total
     equality - in Roc, `NaN` is never comparable to `NaN`. If a type
     doesn't support total equality, it cannot support the `Eq` ability!
-    "###
+    "
     );
 
     test_no_problem!(
@@ -13312,7 +13312,7 @@ In roc, functions are always written as a lambda, like{}
             g = \{} -> if Bool.true then "" else g {}
             "#
         ),
-    @r###"
+    @r#"
     ── DEFINITION ONLY USED IN RECURSION ───────────────────── /code/proj/Main.roc ─
 
     This definition is only used in recursion with itself:
@@ -13322,7 +13322,7 @@ In roc, functions are always written as a lambda, like{}
 
     If you don't intend to use or export this definition, it should be
     removed!
-    "###
+    "#
     );
 
     test_no_problem!(
@@ -13345,7 +13345,7 @@ In roc, functions are always written as a lambda, like{}
             g = \{} -> if Bool.true then "" else f {}
             "#
         ),
-    @r###"
+    @r#"
     ── DEFINITIONs ONLY USED IN RECURSION ──────────────────── /code/proj/Main.roc ─
 
     These 2 definitions are only used in mutual recursion with themselves:
@@ -13355,7 +13355,7 @@ In roc, functions are always written as a lambda, like{}
 
     If you don't intend to use or export any of them, they should all be
     removed!
-    "###
+    "#
     );
 
     test_report!(
@@ -13367,8 +13367,8 @@ In roc, functions are always written as a lambda, like{}
             g = \{} -> if Bool.true then "" else f {}
             "#
         ),
-    @r###"
-    "###
+    @r"
+    "
     );
 
     test_report!(
@@ -13381,7 +13381,7 @@ In roc, functions are always written as a lambda, like{}
                 ""
             "#
         ),
-    @r###"
+    @r#"
     ── DEFINITION ONLY USED IN RECURSION ───────────────────── /code/proj/Main.roc ─
 
     This definition is only used in recursion with itself:
@@ -13391,7 +13391,7 @@ In roc, functions are always written as a lambda, like{}
 
     If you don't intend to use or export this definition, it should be
     removed!
-    "###
+    "#
     );
 
     test_no_problem!(
@@ -13417,7 +13417,7 @@ In roc, functions are always written as a lambda, like{}
                 ""
             "#
         ),
-    @r###"
+    @r#"
     ── DEFINITIONs ONLY USED IN RECURSION ──────────────────── /code/proj/Main.roc ─
 
     These 2 definitions are only used in mutual recursion with themselves:
@@ -13427,7 +13427,7 @@ In roc, functions are always written as a lambda, like{}
 
     If you don't intend to use or export any of them, they should all be
     removed!
-    "###
+    "#
     );
 
     test_report!(
@@ -13441,8 +13441,8 @@ In roc, functions are always written as a lambda, like{}
                 f
             "#
         ),
-    @r###"
-    "###
+    @r"
+    "
     );
 
     // TODO(weakening-reports)
@@ -13456,7 +13456,7 @@ In roc, functions are always written as a lambda, like{}
 
             {one, str}
         "#),
-    @r###"
+    @r#"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     This 2nd argument to `concat` has an unexpected type:
@@ -13471,7 +13471,7 @@ In roc, functions are always written as a lambda, like{}
     But `concat` needs its 2nd argument to be:
 
         List Str
-    "###
+    "#
     );
 
     test_report!(
@@ -13487,7 +13487,7 @@ In roc, functions are always written as a lambda, like{}
                 else Two
             "#
         ),
-    @r###"
+    @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     Something is off with the `else` branch of this `if` expression:
@@ -13506,7 +13506,7 @@ In roc, functions are always written as a lambda, like{}
     But the type annotation on `main` says it should be:
 
         [One]
-    "###
+    "
     );
 
     test_report!(
@@ -13524,7 +13524,7 @@ In roc, functions are always written as a lambda, like{}
                 else Two
             "#
         ),
-    @r###"
+    @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     Something is off with the `else` branch of this `if` expression:
@@ -13543,7 +13543,7 @@ In roc, functions are always written as a lambda, like{}
     But the type annotation on `main` says it should be:
 
         [One]
-    "###
+    "
     );
 
     test_report!(
@@ -13560,7 +13560,7 @@ In roc, functions are always written as a lambda, like{}
                         Two -> Two
             "#
         ),
-    @r###"
+    @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     Something is off with the body of the `main` definition:
@@ -13579,7 +13579,7 @@ In roc, functions are always written as a lambda, like{}
     But the type annotation on `main` says it should be:
 
         List […]
-    "###
+    "
     );
 
     test_report!(
@@ -13598,7 +13598,7 @@ In roc, functions are always written as a lambda, like{}
                         Two -> Two
             "#
         ),
-    @r###"
+    @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     Something is off with the body of the `main` definition:
@@ -13617,7 +13617,7 @@ In roc, functions are always written as a lambda, like{}
     But the type annotation on `main` says it should be:
 
         List […]
-    "###
+    "
     );
 
     test_no_problem!(
@@ -13649,7 +13649,7 @@ In roc, functions are always written as a lambda, like{}
                 myDecoder
             "#
         ),
-        @r###"
+        @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     This expression has a type that does not implement the abilities it's expected to:
@@ -13664,7 +13664,7 @@ In roc, functions are always written as a lambda, like{}
     Note: Decoding to a Nat is not supported. Consider decoding to a
     fixed-sized unsigned integer, like U64, then converting to a Nat if
     needed.
-    "###
+    "
     );
 
     test_report!(
@@ -13678,7 +13678,7 @@ In roc, functions are always written as a lambda, like{}
             main = Encode.toEncoder x
             "#
         ),
-        @r###"
+        @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     This expression has a type that does not implement the abilities it's expected to:
@@ -13697,7 +13697,7 @@ In roc, functions are always written as a lambda, like{}
     cannot be generated.
 
     Tip: `Natural` does not implement `Encoding`.
-    "###
+    "
     );
 
     test_no_problem!(
@@ -13728,7 +13728,7 @@ In roc, functions are always written as a lambda, like{}
                 myDecoder
             "#
         ),
-        @r###"
+        @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     This expression has a type that does not implement the abilities it's expected to:
@@ -13741,7 +13741,7 @@ In roc, functions are always written as a lambda, like{}
         U32, {} -> {}
 
     Note: `Decoding` cannot be generated for functions.
-    "###
+    "
     );
 
     test_no_problem!(
@@ -13768,7 +13768,7 @@ In roc, functions are always written as a lambda, like{}
             main = Encode.toEncoder x
             "#
         ),
-        @r###"
+        @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     This expression has a type that does not implement the abilities it's expected to:
@@ -13781,7 +13781,7 @@ In roc, functions are always written as a lambda, like{}
         U32, {} -> {}
 
     Note: `Encoding` cannot be generated for functions.
-    "###
+    "
     );
 
     test_report!(
@@ -13808,7 +13808,7 @@ In roc, functions are always written as a lambda, like{}
                     Zulip -> "zulip"
             "#
         ),
-        @r###"
+        @r#"
     ── UNSAFE PATTERN ──────────────────────────────────────── /code/proj/Main.roc ─
 
     This `when` does not cover all the possibilities:
@@ -13825,19 +13825,19 @@ In roc, functions are always written as a lambda, like{}
         _
 
     I would have to crash if I saw one of those! Add branches for them!
-    "###
+    "#
     );
 
     test_no_problem!(
         openness_constraint_opens_under_tuple,
         indoc!(
-            r#"
+            r"
               x : [A, B, C]
               when (x, 1u8) is
                 (A, _) -> Bool.true
                 (B, _) -> Bool.true
                 _ -> Bool.true
-            "#
+            "
         )
     );
 
@@ -13856,7 +13856,7 @@ In roc, functions are always written as a lambda, like{}
             main = parser "hi"
             "#
         ),
-        @r###"
+        @r#"
     ── TOO MANY ARGS ───────────────────────────────────────── /code/proj/Main.roc ─
 
     The `parser` value is an opaque type, so it cannot be called with an
@@ -13867,7 +13867,7 @@ In roc, functions are always written as a lambda, like{}
 
     I can't call an opaque type because I don't know what it is! Maybe you
     meant to unwrap it first?
-    "###
+    "#
     );
 
     test_report!(
@@ -13880,7 +13880,7 @@ In roc, functions are always written as a lambda, like{}
             f = \x -> x
             "#
         ),
-        @r###"
+        @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     Something is off with the body of the `f` definition:
@@ -13898,7 +13898,7 @@ In roc, functions are always written as a lambda, like{}
         (U8, U8 -> U8)
 
     Tip: It looks like it takes too few arguments. I was expecting 1 more.
-    "###
+    "
     );
 
     test_report!(
@@ -13911,7 +13911,7 @@ In roc, functions are always written as a lambda, like{}
             f = \x, y, z -> x + y + z
             "#
         ),
-        @r###"
+        @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     Something is off with the body of the `f` definition:
@@ -13929,7 +13929,7 @@ In roc, functions are always written as a lambda, like{}
         (U8, U8 -> U8)
 
     Tip: It looks like it takes too many arguments. I'm seeing 1 extra.
-    "###
+    "
     );
 
     test_report!(
@@ -13945,7 +13945,7 @@ In roc, functions are always written as a lambda, like{}
                 f
             "#
         ),
-        @r###"
+        @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     Something is off with the body of the `f` definition:
@@ -13963,7 +13963,7 @@ In roc, functions are always written as a lambda, like{}
         (U8, U8 -> U8)
 
     Tip: It looks like it takes too few arguments. I was expecting 1 more.
-    "###
+    "
     );
 
     test_report!(
@@ -13979,7 +13979,7 @@ In roc, functions are always written as a lambda, like{}
                 f
             "#
         ),
-        @r###"
+        @r"
     ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
 
     Something is off with the body of the `f` definition:
@@ -13997,17 +13997,17 @@ In roc, functions are always written as a lambda, like{}
         (U8, U8 -> U8)
 
     Tip: It looks like it takes too many arguments. I'm seeing 1 extra.
-    "###
+    "
     );
 
     test_report!(
         pizza_parens_right,
         indoc!(
-            r#"
+            r"
             2 |> (Num.sub 3)
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── TOO FEW ARGS ────────────────────────────────────────── /code/proj/Main.roc ─
 
     The `sub` function expects 2 arguments, but it got only 1:
@@ -14017,17 +14017,17 @@ In roc, functions are always written as a lambda, like{}
 
     Roc does not allow functions to be partially applied. Use a closure to
     make partial application explicit.
-    "###
+    "
     );
 
     test_report!(
         pizza_parens_middle,
         indoc!(
-            r#"
+            r"
             2 |> (Num.sub 3) |> Num.sub 3
-            "#
+            "
         ),
-        @r###"
+        @r"
     ── TOO FEW ARGS ────────────────────────────────────────── /code/proj/Main.roc ─
 
     The `sub` function expects 2 arguments, but it got only 1:
@@ -14037,6 +14037,6 @@ In roc, functions are always written as a lambda, like{}
 
     Roc does not allow functions to be partially applied. Use a closure to
     make partial application explicit.
-    "###
+    "
     );
 }

--- a/crates/compiler/load_internal/tests/test_load.rs
+++ b/crates/compiler/load_internal/tests/test_load.rs
@@ -325,7 +325,7 @@ fn import_transitive_alias() {
         (
             "RBTree",
             indoc!(
-                r#"
+                r"
                         interface RBTree exposes [RedBlackTree, empty] imports []
 
                         # The color of a node. Leaves are considered Black.
@@ -337,18 +337,18 @@ fn import_transitive_alias() {
                         empty : RedBlackTree k v
                         empty =
                             Empty
-                    "#
+                    "
             ),
         ),
         (
             "Other",
             indoc!(
-                r#"
+                r"
                         interface Other exposes [empty] imports [RBTree]
 
                         empty : RBTree.RedBlackTree I64 I64
                         empty = RBTree.empty
-                    "#
+                    "
             ),
         ),
     ];
@@ -628,11 +628,11 @@ fn parse_problem() {
     let modules = vec![(
         "Main",
         indoc!(
-            r#"
+            r"
                 interface Main exposes [main] imports []
 
                 main = [
-                "#
+                "
         ),
     )];
 
@@ -820,23 +820,23 @@ fn opaque_wrapped_unwrapped_outside_defining_module() {
         (
             "Age",
             indoc!(
-                r#"
+                r"
                     interface Age exposes [Age] imports []
 
                     Age := U32
-                    "#
+                    "
             ),
         ),
         (
             "Main",
             indoc!(
-                r#"
+                r"
                     interface Main exposes [twenty, readAge] imports [Age.{ Age }]
 
                     twenty = @Age 20
 
                     readAge = \@Age n -> n
-                    "#
+                    "
             ),
         ),
     ];
@@ -846,7 +846,7 @@ fn opaque_wrapped_unwrapped_outside_defining_module() {
     assert_eq!(
         err,
         indoc!(
-            r#"
+            r"
                 ── OPAQUE TYPE DECLARED OUTSIDE SCOPE ─ ...rapped_outside_defining_module/Main ─
 
                 The unwrapped opaque type Age referenced here:
@@ -883,7 +883,7 @@ fn opaque_wrapped_unwrapped_outside_defining_module() {
                                                                       ^^^^^^^^^^^
 
                 Since Age isn't used, you don't need to import it.
-                "#
+                "
         ),
         "\n{}",
         err
@@ -993,11 +993,11 @@ fn module_doesnt_match_file_path() {
     let modules = vec![(
         "Age",
         indoc!(
-            r#"
+            r"
                 interface NotAge exposes [Age] imports []
 
                 Age := U32
-                "#
+                "
         ),
     )];
 
@@ -1005,7 +1005,7 @@ fn module_doesnt_match_file_path() {
     assert_eq!(
         err,
         indoc!(
-            r#"
+            r"
             ── WEIRD MODULE NAME ─────────────────── tmp/module_doesnt_match_file_path/Age ─
 
             This module name does not correspond with the file path it is defined
@@ -1016,7 +1016,7 @@ fn module_doesnt_match_file_path() {
 
             Module names must correspond with the file paths they are defined in.
             For example, I expect to see BigNum defined in BigNum.roc, or Math.Sin
-            defined in Math/Sin.roc."#
+            defined in Math/Sin.roc."
         ),
         "\n{}",
         err
@@ -1028,9 +1028,9 @@ fn module_cyclic_import_itself() {
     let modules = vec![(
         "Age",
         indoc!(
-            r#"
+            r"
             interface Age exposes [] imports [Age]
-            "#
+            "
         ),
     )];
 
@@ -1038,7 +1038,7 @@ fn module_cyclic_import_itself() {
     assert_eq!(
         err,
         indoc!(
-            r#"
+            r"
             ── IMPORT CYCLE ────────────────────────── tmp/module_cyclic_import_itself/Age ─
 
             I can't compile Age because it depends on itself through the following
@@ -1052,7 +1052,7 @@ fn module_cyclic_import_itself() {
 
             Cyclic dependencies are not allowed in Roc! Can you restructure a
             module in this import chain so that it doesn't have to depend on
-            itself?"#
+            itself?"
         ),
         "\n{}",
         err
@@ -1065,17 +1065,17 @@ fn module_cyclic_import_transitive() {
         (
             "Age",
             indoc!(
-                r#"
+                r"
                 interface Age exposes [] imports [Person]
-                "#
+                "
             ),
         ),
         (
             "Person",
             indoc!(
-                r#"
+                r"
                 interface Person exposes [] imports [Age]
-                "#
+                "
             ),
         ),
     ];
@@ -1084,7 +1084,7 @@ fn module_cyclic_import_transitive() {
     assert_eq!(
         err,
         indoc!(
-            r#"
+            r"
             ── IMPORT CYCLE ────────────────── tmp/module_cyclic_import_transitive/Age.roc ─
 
             I can't compile Age because it depends on itself through the following
@@ -1100,7 +1100,7 @@ fn module_cyclic_import_transitive() {
 
             Cyclic dependencies are not allowed in Roc! Can you restructure a
             module in this import chain so that it doesn't have to depend on
-            itself?"#
+            itself?"
         ),
         "\n{}",
         err
@@ -1113,17 +1113,17 @@ fn nested_module_has_incorrect_name() {
         (
             "Dep/Foo.roc",
             indoc!(
-                r#"
+                r"
                 interface Foo exposes [] imports []
-                "#
+                "
             ),
         ),
         (
             "I.roc",
             indoc!(
-                r#"
+                r"
                 interface I exposes [] imports [Dep.Foo]
-                "#
+                "
             ),
         ),
     ];
@@ -1132,7 +1132,7 @@ fn nested_module_has_incorrect_name() {
     assert_eq!(
         err,
         indoc!(
-            r#"
+            r"
             ── INCORRECT MODULE NAME ──── tmp/nested_module_has_incorrect_name/Dep/Foo.roc ─
 
             This module has a different name than I expected:
@@ -1142,7 +1142,7 @@ fn nested_module_has_incorrect_name() {
 
             Based on the nesting and use of this module, I expect it to have name
 
-                Dep.Foo"#
+                Dep.Foo"
         ),
         "\n{}",
         err

--- a/crates/compiler/parse/tests/test_parse.rs
+++ b/crates/compiler/parse/tests/test_parse.rs
@@ -272,11 +272,11 @@ mod test_parse {
 
         let arena = Bump::new();
         let src = indoc!(
-            r#"
+            r"
                 foo = \list ->
                     isTest = \_ -> 5
                     List.map list isTest
-            "#
+            "
         );
         let actual = module_defs()
             .parse(&arena, State::new(src.as_bytes()), 0)
@@ -295,12 +295,12 @@ mod test_parse {
 
         // highlights a problem with the else branch demanding a newline after its expression
         let src = indoc!(
-            r#"
+            r"
             main =
                 v = \y -> if x then y else z
 
                 1
-            "#
+            "
         );
 
         let state = State::new(src.as_bytes());

--- a/crates/compiler/solve/tests/solve_expr.rs
+++ b/crates/compiler/solve/tests/solve_expr.rs
@@ -98,12 +98,12 @@ mod solve_expr {
     fn dec_literal() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                     val : Dec
                     val = 1.2
 
                     val
-                "#
+                "
             ),
             "Dec",
         );
@@ -137,9 +137,9 @@ mod solve_expr {
     fn string_starts_with() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                 Str.startsWith
-                "#
+                "
             ),
             "Str, Str -> Bool",
         );
@@ -149,9 +149,9 @@ mod solve_expr {
     fn string_from_int() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                 Num.toStr
-                "#
+                "
             ),
             "Num * -> Str",
         );
@@ -161,9 +161,9 @@ mod solve_expr {
     fn string_from_utf8() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                 Str.fromUtf8
-                "#
+                "
             ),
             "List U8 -> Result Str [BadUtf8 Utf8ByteProblem Nat]",
         );
@@ -175,9 +175,9 @@ mod solve_expr {
     fn empty_list() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                     []
-                "#
+                "
             ),
             "List *",
         );
@@ -187,9 +187,9 @@ mod solve_expr {
     fn list_of_lists() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                     [[]]
-                "#
+                "
             ),
             "List (List *)",
         );
@@ -199,9 +199,9 @@ mod solve_expr {
     fn triple_nested_list() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                     [[[]]]
-                "#
+                "
             ),
             "List (List (List *))",
         );
@@ -211,9 +211,9 @@ mod solve_expr {
     fn nested_empty_list() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                     [[], [[]]]
-                "#
+                "
             ),
             "List (List (List *))",
         );
@@ -223,9 +223,9 @@ mod solve_expr {
     fn list_of_one_int() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                     [42]
-                "#
+                "
             ),
             "List (Num *)",
         );
@@ -235,9 +235,9 @@ mod solve_expr {
     fn triple_nested_int_list() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                     [[[5]]]
-                "#
+                "
             ),
             "List (List (List (Num *)))",
         );
@@ -247,9 +247,9 @@ mod solve_expr {
     fn list_of_ints() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                     [1, 2, 3]
-                "#
+                "
             ),
             "List (Num *)",
         );
@@ -259,9 +259,9 @@ mod solve_expr {
     fn nested_list_of_ints() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                     [[1], [2, 3]]
-                "#
+                "
             ),
             "List (List (Num *))",
         );
@@ -381,9 +381,9 @@ mod solve_expr {
     fn mismatch_heterogeneous_nested_empty_list() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                 [[1], [[]]]
-            "#
+            "
             ),
             "List <type mismatch>",
         );
@@ -395,9 +395,9 @@ mod solve_expr {
     fn always_return_empty_record() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                     \_ -> {}
-                "#
+                "
             ),
             "* -> {}",
         );
@@ -407,9 +407,9 @@ mod solve_expr {
     fn two_arg_return_int() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                     \_, _ -> 42
-                "#
+                "
             ),
             "*, * -> Num *",
         );
@@ -433,11 +433,11 @@ mod solve_expr {
     fn def_empty_record() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                     foo = {}
 
                     foo
-                "#
+                "
             ),
             "{}",
         );
@@ -461,11 +461,11 @@ mod solve_expr {
     fn def_1_arg_closure() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                     fn = \_ -> {}
 
                     fn
-                "#
+                "
             ),
             "* -> {}",
         );
@@ -516,9 +516,9 @@ mod solve_expr {
     fn applied_tag_function_list() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                 [\x -> Bar x, Foo]
-                "#
+                "
             ),
             "List (a -> [Bar a, Foo a])",
         )
@@ -529,9 +529,9 @@ mod solve_expr {
     fn applied_tag_function_list_other_way() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                 [Foo, \x -> Bar x]
-                "#
+                "
             ),
             "List (a -> [Bar a, Foo a])",
         )
@@ -542,7 +542,7 @@ mod solve_expr {
     fn applied_tag_function_record() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                 foo0 = Foo
                 foo1 = Foo
                 foo2 = Foo
@@ -552,7 +552,7 @@ mod solve_expr {
                     y: [foo1, \x -> Foo x],
                     z: [foo2, \x,y  -> Foo x y]
                 }
-                "#
+                "
             ),
             "{ x : List [Foo], y : List (a -> [Foo a]), z : List (b, c -> [Foo b c]) }",
         )
@@ -563,12 +563,12 @@ mod solve_expr {
     fn applied_tag_function_with_annotation() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                 x : List [Foo I64]
                 x = List.map [1, 2] Foo
 
                 x
-                "#
+                "
             ),
             "List [Foo I64]",
         )
@@ -578,11 +578,11 @@ mod solve_expr {
     fn def_2_arg_closure() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                     func = \_, _ -> 42
 
                     func
-                "#
+                "
             ),
             "*, * -> Num *",
         );
@@ -638,7 +638,7 @@ mod solve_expr {
     fn def_multiple_ints() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                     c = b
 
                     b = a
@@ -646,7 +646,7 @@ mod solve_expr {
                     a = 42
 
                     c
-                "#
+                "
             ),
             "Num *",
         );
@@ -656,7 +656,7 @@ mod solve_expr {
     fn def_returning_closure() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                     f = \z -> z
                     g = \z -> z
 
@@ -665,7 +665,7 @@ mod solve_expr {
                         b = g x
                         x
                     )
-                "#
+                "
             ),
             "a -> a",
         );
@@ -705,13 +705,13 @@ mod solve_expr {
     fn identity_infers_principal_type() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                     identity = \x -> x
 
                     y = identity 5
 
                     identity
-                "#
+                "
             ),
             "a -> a",
         );
@@ -738,11 +738,11 @@ mod solve_expr {
     fn call_returns_list() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                     enlist = \val -> [val]
 
                     enlist 5
-                "#
+                "
             ),
             "List (Num *)",
         );
@@ -767,9 +767,9 @@ mod solve_expr {
     fn pizza_desugar() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                     1 |> (\a -> a)
-                "#
+                "
             ),
             "Num *",
         );
@@ -793,9 +793,9 @@ mod solve_expr {
     fn anonymous_identity() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                     (\a -> a) 3.14
-                "#
+                "
             ),
             "Frac *",
         );
@@ -805,9 +805,9 @@ mod solve_expr {
     fn identity_of_identity() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                     (\val -> val) (\val -> val)
-                "#
+                "
             ),
             "a -> a",
         );
@@ -817,11 +817,11 @@ mod solve_expr {
     fn recursive_identity() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                     identity = \val -> val
 
                     identity identity
-                "#
+                "
             ),
             "a -> a",
         );
@@ -831,9 +831,9 @@ mod solve_expr {
     fn identity_function() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                     \val -> val
-                "#
+                "
             ),
             "a -> a",
         );
@@ -843,12 +843,12 @@ mod solve_expr {
     fn use_apply() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                 identity = \a -> a
                 apply = \f, x -> f x
 
                 apply identity 5
-                "#
+                "
             ),
             "Num *",
         );
@@ -858,9 +858,9 @@ mod solve_expr {
     fn apply_function() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                     \f, x -> f x
-                "#
+                "
             ),
             "(a -> b), a -> b",
         );
@@ -871,13 +871,13 @@ mod solve_expr {
     // fn use_flip() {
     //     infer_eq(
     //         indoc!(
-    //             r#"
+    //             r"
     //                 flip = \f -> (\a b -> f b a)
     //                 neverendingInt = \f int -> f int
     //                 x = neverendingInt (\a -> a) 5
 
     //                 flip neverendingInt
-    //             "#
+    //             "
     //         ),
     //         "(Num *, (a -> a)) -> Num *",
     //     );
@@ -887,9 +887,9 @@ mod solve_expr {
     fn flip_function() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                     \f -> (\a, b -> f b a)
-                "#
+                "
             ),
             "(a, b -> c) -> (b, a -> c)",
         );
@@ -899,9 +899,9 @@ mod solve_expr {
     fn always_function() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                     \val -> \_ -> val
-                "#
+                "
             ),
             "a -> (* -> a)",
         );
@@ -911,9 +911,9 @@ mod solve_expr {
     fn pass_a_function() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                     \f -> f {}
-                "#
+                "
             ),
             "({} -> a) -> a",
         );
@@ -925,9 +925,9 @@ mod solve_expr {
     // fn div_operator() {
     //     infer_eq(
     //         indoc!(
-    //             r#"
+    //             r"
     //             \l r -> l / r
-    //         "#
+    //         "
     //         ),
     //         "F64, F64 -> F64",
     //     );
@@ -937,9 +937,9 @@ mod solve_expr {
     //     fn basic_float_division() {
     //         infer_eq(
     //             indoc!(
-    //                 r#"
+    //                 r"
     //                 1 / 2
-    //             "#
+    //             "
     //             ),
     //             "F64",
     //         );
@@ -949,9 +949,9 @@ mod solve_expr {
     //     fn basic_int_division() {
     //         infer_eq(
     //             indoc!(
-    //                 r#"
+    //                 r"
     //                 1 // 2
-    //             "#
+    //             "
     //             ),
     //             "Num *",
     //         );
@@ -961,9 +961,9 @@ mod solve_expr {
     //     fn basic_addition() {
     //         infer_eq(
     //             indoc!(
-    //                 r#"
+    //                 r"
     //                 1 + 2
-    //             "#
+    //             "
     //             ),
     //             "Num *",
     //         );
@@ -973,9 +973,9 @@ mod solve_expr {
     // fn basic_circular_type() {
     //     infer_eq(
     //         indoc!(
-    //             r#"
+    //             r"
     //             \x -> x x
-    //         "#
+    //         "
     //         ),
     //         "<Type Mismatch: Circular Type>",
     //     );
@@ -984,9 +984,9 @@ mod solve_expr {
     // #[test]
     // fn y_combinator_has_circular_type() {
     //     assert_eq!(
-    //         infer(indoc!(r#"
+    //         infer(indoc!(r"
     //             \f -> (\x -> f x x) (\x -> f x x)
-    //         "#)),
+    //         ")),
     //         Erroneous(Problem::CircularType)
     //     );
     // }
@@ -1022,12 +1022,12 @@ mod solve_expr {
     fn if_with_int_literals() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                     if Bool.true then
                         42
                     else
                         24
-                "#
+                "
             ),
             "Num *",
         );
@@ -1037,11 +1037,11 @@ mod solve_expr {
     fn when_with_int_literals() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                     when 1 is
                     1 -> 2
                     3 -> 4
-                "#
+                "
             ),
             "Num *",
         );
@@ -1120,14 +1120,14 @@ mod solve_expr {
     fn record_with_bound_var() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                     fn = \rec ->
                         x = rec.x
 
                         rec
 
                     fn
-                "#
+                "
             ),
             "{ x : a }b -> { x : a }b",
         );
@@ -1137,12 +1137,12 @@ mod solve_expr {
     fn using_type_signature() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                     bar : custom -> custom
                     bar = \x -> x
 
                     bar
-                "#
+                "
             ),
             "custom -> custom",
         );
@@ -1166,11 +1166,11 @@ mod solve_expr {
     fn type_signature_without_body_rigid() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                     foo : Num * -> custom
 
                     foo 2
-                "#
+                "
             ),
             "custom",
         );
@@ -1185,11 +1185,11 @@ mod solve_expr {
     fn type_signature_without_body_record() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                     { x, y } : { x : ({} -> custom), y : {} }
 
                     x
-                "#
+                "
             ),
             "{} -> custom",
         );
@@ -1199,7 +1199,7 @@ mod solve_expr {
     fn empty_record_pattern() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                 # technically, an empty record can be destructured
                 thunk = \{} -> 42
 
@@ -1207,7 +1207,7 @@ mod solve_expr {
 
                 when xEmpty is
                     { x: {} } -> {}
-                "#
+                "
             ),
             "{}",
         );
@@ -1218,12 +1218,12 @@ mod solve_expr {
         // check that a closed record remains closed
         infer_eq(
             indoc!(
-                r#"
+                r"
                 foo : { x : custom } -> custom
                 foo = \{ x } -> x
 
                 foo
-            "#
+            "
             ),
             "{ x : custom } -> custom",
         );
@@ -1247,9 +1247,9 @@ mod solve_expr {
     fn bare_tag() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                     Foo
-                "#
+                "
             ),
             "[Foo]",
         );
@@ -1259,9 +1259,9 @@ mod solve_expr {
     fn single_tag_pattern() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                     \Foo -> 42
-                "#
+                "
             ),
             "[Foo] -> Num *",
         );
@@ -1271,12 +1271,12 @@ mod solve_expr {
     fn two_tag_pattern() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                     \x ->
                         when x is
                             True -> 1
                             False -> 0
-                "#
+                "
             ),
             "[False, True] -> Num *",
         );
@@ -1298,13 +1298,13 @@ mod solve_expr {
     fn record_extraction() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                     f = \x ->
                         when x is
                             { a, b: _ } -> a
 
                     f
-                "#
+                "
             ),
             "{ a : a, b : * }* -> a",
         );
@@ -1314,10 +1314,10 @@ mod solve_expr {
     fn record_field_pattern_match_with_guard() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                     when { x: 5 } is
                         { x: 4 } -> 4
-                "#
+                "
             ),
             "Num *",
         );
@@ -1327,9 +1327,9 @@ mod solve_expr {
     fn tag_union_pattern_match() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                     \Foo x -> Foo x
-                "#
+                "
             ),
             "[Foo a] -> [Foo a]",
         );
@@ -1364,11 +1364,11 @@ mod solve_expr {
     fn qualified_annotation_num_integer() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                    int : Num.Num (Num.Integer Num.Signed64)
 
                    int
-                "#
+                "
             ),
             "I64",
         );
@@ -1377,12 +1377,12 @@ mod solve_expr {
     fn qualified_annotated_num_integer() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                    int : Num.Num (Num.Integer Num.Signed64)
                    int = 5
 
                    int
-                "#
+                "
             ),
             "I64",
         );
@@ -1391,11 +1391,11 @@ mod solve_expr {
     fn annotation_num_integer() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                    int : Num (Integer Signed64)
 
                    int
-                "#
+                "
             ),
             "I64",
         );
@@ -1404,12 +1404,12 @@ mod solve_expr {
     fn annotated_num_integer() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                    int : Num (Integer Signed64)
                    int = 5
 
                    int
-                "#
+                "
             ),
             "I64",
         );
@@ -1419,11 +1419,11 @@ mod solve_expr {
     fn qualified_annotation_using_i128() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                     int : Num.I128
 
                     int
-                "#
+                "
             ),
             "I128",
         );
@@ -1432,12 +1432,12 @@ mod solve_expr {
     fn qualified_annotated_using_i128() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                     int : Num.I128
                     int = 5
 
                     int
-                "#
+                "
             ),
             "I128",
         );
@@ -1446,11 +1446,11 @@ mod solve_expr {
     fn annotation_using_i128() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                     int : I128
 
                     int
-                "#
+                "
             ),
             "I128",
         );
@@ -1459,12 +1459,12 @@ mod solve_expr {
     fn annotated_using_i128() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                     int : I128
                     int = 5
 
                     int
-                "#
+                "
             ),
             "I128",
         );
@@ -1474,11 +1474,11 @@ mod solve_expr {
     fn qualified_annotation_using_u128() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                     int : Num.U128
 
                     int
-                "#
+                "
             ),
             "U128",
         );
@@ -1487,12 +1487,12 @@ mod solve_expr {
     fn qualified_annotated_using_u128() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                     int : Num.U128
                     int = 5
 
                     int
-                "#
+                "
             ),
             "U128",
         );
@@ -1501,11 +1501,11 @@ mod solve_expr {
     fn annotation_using_u128() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                     int : U128
 
                     int
-                "#
+                "
             ),
             "U128",
         );
@@ -1514,12 +1514,12 @@ mod solve_expr {
     fn annotated_using_u128() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                     int : U128
                     int = 5
 
                     int
-                "#
+                "
             ),
             "U128",
         );
@@ -1529,11 +1529,11 @@ mod solve_expr {
     fn qualified_annotation_using_i64() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                     int : Num.I64
 
                     int
-                "#
+                "
             ),
             "I64",
         );
@@ -1542,12 +1542,12 @@ mod solve_expr {
     fn qualified_annotated_using_i64() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                     int : Num.I64
                     int = 5
 
                     int
-                "#
+                "
             ),
             "I64",
         );
@@ -1556,11 +1556,11 @@ mod solve_expr {
     fn annotation_using_i64() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                     int : I64
 
                     int
-                "#
+                "
             ),
             "I64",
         );
@@ -1569,12 +1569,12 @@ mod solve_expr {
     fn annotated_using_i64() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                     int : I64
                     int = 5
 
                     int
-                "#
+                "
             ),
             "I64",
         );
@@ -1584,11 +1584,11 @@ mod solve_expr {
     fn qualified_annotation_using_u64() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                     int : Num.U64
 
                     int
-                "#
+                "
             ),
             "U64",
         );
@@ -1597,12 +1597,12 @@ mod solve_expr {
     fn qualified_annotated_using_u64() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                     int : Num.U64
                     int = 5
 
                     int
-                "#
+                "
             ),
             "U64",
         );
@@ -1611,11 +1611,11 @@ mod solve_expr {
     fn annotation_using_u64() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                     int : U64
 
                     int
-                "#
+                "
             ),
             "U64",
         );
@@ -1624,12 +1624,12 @@ mod solve_expr {
     fn annotated_using_u64() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                     int : U64
                     int = 5
 
                     int
-                "#
+                "
             ),
             "U64",
         );
@@ -1639,11 +1639,11 @@ mod solve_expr {
     fn qualified_annotation_using_i32() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                     int : Num.I32
 
                     int
-                "#
+                "
             ),
             "I32",
         );
@@ -1652,12 +1652,12 @@ mod solve_expr {
     fn qualified_annotated_using_i32() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                     int : Num.I32
                     int = 5
 
                     int
-                "#
+                "
             ),
             "I32",
         );
@@ -1666,11 +1666,11 @@ mod solve_expr {
     fn annotation_using_i32() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                     int : I32
 
                     int
-                "#
+                "
             ),
             "I32",
         );
@@ -1679,12 +1679,12 @@ mod solve_expr {
     fn annotated_using_i32() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                     int : I32
                     int = 5
 
                     int
-                "#
+                "
             ),
             "I32",
         );
@@ -1694,11 +1694,11 @@ mod solve_expr {
     fn qualified_annotation_using_u32() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                     int : Num.U32
 
                     int
-                "#
+                "
             ),
             "U32",
         );
@@ -1707,12 +1707,12 @@ mod solve_expr {
     fn qualified_annotated_using_u32() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                     int : Num.U32
                     int = 5
 
                     int
-                "#
+                "
             ),
             "U32",
         );
@@ -1721,11 +1721,11 @@ mod solve_expr {
     fn annotation_using_u32() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                     int : U32
 
                     int
-                "#
+                "
             ),
             "U32",
         );
@@ -1734,12 +1734,12 @@ mod solve_expr {
     fn annotated_using_u32() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                     int : U32
                     int = 5
 
                     int
-                "#
+                "
             ),
             "U32",
         );
@@ -1749,11 +1749,11 @@ mod solve_expr {
     fn qualified_annotation_using_i16() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                     int : Num.I16
 
                     int
-                "#
+                "
             ),
             "I16",
         );
@@ -1762,12 +1762,12 @@ mod solve_expr {
     fn qualified_annotated_using_i16() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                     int : Num.I16
                     int = 5
 
                     int
-                "#
+                "
             ),
             "I16",
         );
@@ -1776,11 +1776,11 @@ mod solve_expr {
     fn annotation_using_i16() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                     int : I16
 
                     int
-                "#
+                "
             ),
             "I16",
         );
@@ -1789,12 +1789,12 @@ mod solve_expr {
     fn annotated_using_i16() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                     int : I16
                     int = 5
 
                     int
-                "#
+                "
             ),
             "I16",
         );
@@ -1804,11 +1804,11 @@ mod solve_expr {
     fn qualified_annotation_using_u16() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                     int : Num.U16
 
                     int
-                "#
+                "
             ),
             "U16",
         );
@@ -1817,12 +1817,12 @@ mod solve_expr {
     fn qualified_annotated_using_u16() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                     int : Num.U16
                     int = 5
 
                     int
-                "#
+                "
             ),
             "U16",
         );
@@ -1831,11 +1831,11 @@ mod solve_expr {
     fn annotation_using_u16() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                     int : U16
 
                     int
-                "#
+                "
             ),
             "U16",
         );
@@ -1844,12 +1844,12 @@ mod solve_expr {
     fn annotated_using_u16() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                     int : U16
                     int = 5
 
                     int
-                "#
+                "
             ),
             "U16",
         );
@@ -1859,11 +1859,11 @@ mod solve_expr {
     fn qualified_annotation_using_i8() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                     int : Num.I8
 
                     int
-                "#
+                "
             ),
             "I8",
         );
@@ -1872,12 +1872,12 @@ mod solve_expr {
     fn qualified_annotated_using_i8() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                     int : Num.I8
                     int = 5
 
                     int
-                "#
+                "
             ),
             "I8",
         );
@@ -1886,11 +1886,11 @@ mod solve_expr {
     fn annotation_using_i8() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                     int : I8
 
                     int
-                "#
+                "
             ),
             "I8",
         );
@@ -1899,12 +1899,12 @@ mod solve_expr {
     fn annotated_using_i8() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                     int : I8
                     int = 5
 
                     int
-                "#
+                "
             ),
             "I8",
         );
@@ -1914,11 +1914,11 @@ mod solve_expr {
     fn qualified_annotation_using_u8() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                     int : Num.U8
 
                     int
-                "#
+                "
             ),
             "U8",
         );
@@ -1927,12 +1927,12 @@ mod solve_expr {
     fn qualified_annotated_using_u8() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                     int : Num.U8
                     int = 5
 
                     int
-                "#
+                "
             ),
             "U8",
         );
@@ -1941,11 +1941,11 @@ mod solve_expr {
     fn annotation_using_u8() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                     int : U8
 
                     int
-                "#
+                "
             ),
             "U8",
         );
@@ -1954,12 +1954,12 @@ mod solve_expr {
     fn annotated_using_u8() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                     int : U8
                     int = 5
 
                     int
-                "#
+                "
             ),
             "U8",
         );
@@ -1969,11 +1969,11 @@ mod solve_expr {
     fn qualified_annotation_num_floatingpoint() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                    float : Num.Num (Num.FloatingPoint Num.Binary64)
 
                    float
-                "#
+                "
             ),
             "F64",
         );
@@ -1982,12 +1982,12 @@ mod solve_expr {
     fn qualified_annotated_num_floatingpoint() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                    float : Num.Num (Num.FloatingPoint Num.Binary64)
                    float = 5.5
 
                    float
-                "#
+                "
             ),
             "F64",
         );
@@ -1996,11 +1996,11 @@ mod solve_expr {
     fn annotation_num_floatingpoint() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                    float : Num (FloatingPoint Binary64)
 
                    float
-                "#
+                "
             ),
             "F64",
         );
@@ -2009,12 +2009,12 @@ mod solve_expr {
     fn annotated_num_floatingpoint() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                    float : Num (FloatingPoint Binary64)
                    float = 5.5
 
                    float
-                "#
+                "
             ),
             "F64",
         );
@@ -2024,11 +2024,11 @@ mod solve_expr {
     fn qualified_annotation_f64() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                    float : Num.F64
 
                    float
-                "#
+                "
             ),
             "F64",
         );
@@ -2037,12 +2037,12 @@ mod solve_expr {
     fn qualified_annotated_f64() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                    float : Num.F64
                    float = 5.5
 
                    float
-                "#
+                "
             ),
             "F64",
         );
@@ -2051,11 +2051,11 @@ mod solve_expr {
     fn annotation_f64() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                    float : F64
 
                    float
-                "#
+                "
             ),
             "F64",
         );
@@ -2064,12 +2064,12 @@ mod solve_expr {
     fn annotated_f64() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                    float : F64
                    float = 5.5
 
                    float
-                "#
+                "
             ),
             "F64",
         );
@@ -2079,11 +2079,11 @@ mod solve_expr {
     fn qualified_annotation_f32() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                    float : Num.F32
 
                    float
-                "#
+                "
             ),
             "F32",
         );
@@ -2092,12 +2092,12 @@ mod solve_expr {
     fn qualified_annotated_f32() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                    float : Num.F32
                    float = 5.5
 
                    float
-                "#
+                "
             ),
             "F32",
         );
@@ -2106,11 +2106,11 @@ mod solve_expr {
     fn annotation_f32() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                    float : F32
 
                    float
-                "#
+                "
             ),
             "F32",
         );
@@ -2119,12 +2119,12 @@ mod solve_expr {
     fn annotated_f32() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                    float : F32
                    float = 5.5
 
                    float
-                "#
+                "
             ),
             "F32",
         );
@@ -2134,14 +2134,14 @@ mod solve_expr {
     fn fake_result_ok() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                     Res a e : [Okay a, Error e]
 
                     ok : Res I64 *
                     ok = Okay 5
 
                     ok
-                "#
+                "
             ),
             "Res I64 *",
         );
@@ -2168,12 +2168,12 @@ mod solve_expr {
     fn basic_result_ok() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                     ok : Result I64 *
                     ok = Ok 5
 
                     ok
-                "#
+                "
             ),
             "Result I64 *",
         );
@@ -2221,13 +2221,13 @@ mod solve_expr {
     //     // wasn't added to the vars_by_symbol.
     //     infer_eq_without_problem(
     //         indoc!(
-    //             r#"
+    //             r"
     //                int : I64
 
     //                p = (\x -> x) int
 
     //                p
-    //                "#
+    //                "
     //         ),
     //         "I64",
     //     );
@@ -2237,14 +2237,14 @@ mod solve_expr {
     fn num_identity() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                     numIdentity : Num.Num a -> Num.Num a
                     numIdentity = \x -> x
 
                     y = numIdentity 3.14
 
                     { numIdentity, x : numIdentity 42, y }
-                "#
+                "
             ),
             "{ numIdentity : Num a -> Num a, x : Num *, y : Frac * }",
         );
@@ -2254,7 +2254,7 @@ mod solve_expr {
     fn when_with_annotation() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                     x : Num.Num (Num.Integer Num.Signed64)
                     x =
                         when 2 is
@@ -2262,7 +2262,7 @@ mod solve_expr {
                             _ -> 5
 
                     x
-                "#
+                "
             ),
             "I64",
         );
@@ -2273,14 +2273,14 @@ mod solve_expr {
     fn integer_sum() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                     f = \n ->
                         when n is
                             0 -> 0
                             _ -> f n
 
                     f
-                "#
+                "
             ),
             "Num * -> Num *",
         );
@@ -2290,13 +2290,13 @@ mod solve_expr {
     fn identity_map() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                     map : (a -> b), [Identity a] -> [Identity b]
                     map = \f, identity ->
                         when identity is
                             Identity v -> Identity (f v)
                     map
-                "#
+                "
             ),
             "(a -> b), [Identity a] -> [Identity b]",
         );
@@ -2306,14 +2306,14 @@ mod solve_expr {
     fn to_bit() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                    toBit = \bool ->
                        when bool is
                            True -> 1
                            False -> 0
 
                    toBit
-                "#
+                "
             ),
             "[False, True] -> Num *",
         );
@@ -2342,14 +2342,14 @@ mod solve_expr {
     fn from_bit() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                    fromBit = \int ->
                        when int is
                            0 -> False
                            _ -> True
 
                    fromBit
-                "#
+                "
             ),
             "Num * -> [False, True]",
         );
@@ -2359,7 +2359,7 @@ mod solve_expr {
     fn result_map_explicit() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                     map : (a -> b), [Err e, Ok a] -> [Err e, Ok b]
                     map = \f, result ->
                         when result is
@@ -2367,7 +2367,7 @@ mod solve_expr {
                             Err e -> Err e
 
                     map
-                "#
+                "
             ),
             "(a -> b), [Err e, Ok a] -> [Err e, Ok b]",
         );
@@ -2377,7 +2377,7 @@ mod solve_expr {
     fn result_map_alias() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                     Res e a : [Ok a, Err e]
 
                     map : (a -> b), Res e a -> Res e b
@@ -2387,7 +2387,7 @@ mod solve_expr {
                             Err e -> Err e
 
                     map
-                       "#
+                       "
             ),
             "(a -> b), Res e a -> Res e b",
         );
@@ -2397,11 +2397,11 @@ mod solve_expr {
     fn record_from_load() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                     foo = \{ x } -> x
 
                     foo { x: 5 }
-                "#
+                "
             ),
             "Num *",
         );
@@ -2411,7 +2411,7 @@ mod solve_expr {
     fn defs_from_load() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                     alwaysThreePointZero = \_ -> 3.0
 
                     answer = 42
@@ -2421,7 +2421,7 @@ mod solve_expr {
                     threePointZero = identity (alwaysThreePointZero {})
 
                     threePointZero
-                "#
+                "
             ),
             "Frac *",
         );
@@ -2463,14 +2463,14 @@ mod solve_expr {
     fn use_alias_with_argument_in_let() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                 Foo a : { foo : a }
 
                 v : Foo (Num.Num (Num.Integer Num.Signed64))
                 v = { foo: 42 }
 
                 v
-                "#
+                "
             ),
             "Foo I64",
         );
@@ -2480,14 +2480,14 @@ mod solve_expr {
     fn identity_alias() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                 Foo a : { foo : a }
 
                 id : Foo a -> Foo a
                 id = \x -> x
 
                 id
-                "#
+                "
             ),
             "Foo a -> Foo a",
         );
@@ -2497,12 +2497,12 @@ mod solve_expr {
     fn linked_list_empty() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                     empty : [Cons a (ConsList a), Nil] as ConsList a
                     empty = Nil
 
                     empty
-                       "#
+                       "
             ),
             "ConsList a",
         );
@@ -2512,12 +2512,12 @@ mod solve_expr {
     fn linked_list_singleton() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                     singleton : a -> [Cons a (ConsList a), Nil] as ConsList a
                     singleton = \x -> Cons x Nil
 
                     singleton
-                       "#
+                       "
             ),
             "a -> ConsList a",
         );
@@ -2527,7 +2527,7 @@ mod solve_expr {
     fn peano_length() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                     Peano : [S Peano, Z]
 
                     length : Peano -> Num.Num (Num.Integer Num.Signed64)
@@ -2537,7 +2537,7 @@ mod solve_expr {
                             S v -> length v
 
                     length
-                       "#
+                       "
             ),
             "Peano -> I64",
         );
@@ -2547,7 +2547,7 @@ mod solve_expr {
     fn peano_map() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                     map : [S Peano, Z] as Peano -> Peano
                     map = \peano ->
                         when peano is
@@ -2555,7 +2555,7 @@ mod solve_expr {
                             S v -> S (map v)
 
                     map
-                       "#
+                       "
             ),
             "Peano -> Peano",
         );
@@ -2565,7 +2565,7 @@ mod solve_expr {
     fn infer_linked_list_map() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                     map = \f, list ->
                         when list is
                             Nil -> Nil
@@ -2576,7 +2576,7 @@ mod solve_expr {
                                 Cons a b
 
                     map
-                       "#
+                       "
             ),
             "(a -> b), [Cons a c, Nil] as c -> [Cons b d, Nil] as d",
         );
@@ -2586,7 +2586,7 @@ mod solve_expr {
     fn typecheck_linked_list_map() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                     ConsList a : [Cons a (ConsList a), Nil]
 
                     map : (a -> b), ConsList a -> ConsList b
@@ -2597,7 +2597,7 @@ mod solve_expr {
                                 Cons (f x) (map f xs)
 
                     map
-                       "#
+                       "
             ),
             "(a -> b), ConsList a -> ConsList b",
         );
@@ -2629,7 +2629,7 @@ mod solve_expr {
     fn mismatch_in_apply_gets_reported() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                 r : { x : (Num.Num (Num.Integer Signed64)) }
                 r = { x : 1 }
 
@@ -2639,7 +2639,7 @@ mod solve_expr {
                 when 0 is
                     1 -> s.left
                     0 -> r
-                   "#
+                   "
             ),
             "<type mismatch>",
         );
@@ -2649,7 +2649,7 @@ mod solve_expr {
     fn mismatch_in_tag_gets_reported() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                 r : [Ok Str.Str]
                 r = Ok 1
 
@@ -2659,7 +2659,7 @@ mod solve_expr {
                 when 0 is
                     1 -> s.left
                     0 -> r
-                   "#
+                   "
             ),
             "<type mismatch>",
         );
@@ -2671,12 +2671,12 @@ mod solve_expr {
     // fn nums() {
     //     infer_eq_without_problem(
     //         indoc!(
-    //             r#"
+    //             r"
     //                 s : Num *
     //                 s = 3.1
 
     //                 s
-    //                 "#
+    //                 "
     //         ),
     //         "<Type Mismatch: _____________>",
     //     );
@@ -2709,14 +2709,14 @@ mod solve_expr {
     fn unit_alias() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                     Unit : [Unit]
 
                     unit : Unit
                     unit = Unit
 
                     unit
-                "#
+                "
             ),
             "Unit",
         );
@@ -2726,7 +2726,7 @@ mod solve_expr {
     fn rigid_in_letnonrec() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                     ConsList a : [Cons a (ConsList a), Nil]
 
                     toEmpty : ConsList a -> ConsList a
@@ -2737,7 +2737,7 @@ mod solve_expr {
                         result
 
                     toEmpty
-                "#
+                "
             ),
             "ConsList a -> ConsList a",
         );
@@ -2747,7 +2747,7 @@ mod solve_expr {
     fn rigid_in_letrec_ignored() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                     ConsList a : [Cons a (ConsList a), Nil]
 
                     toEmpty : ConsList a -> ConsList a
@@ -2758,7 +2758,7 @@ mod solve_expr {
                         toEmpty result
 
                     toEmpty
-                "#
+                "
             ),
             "ConsList a -> ConsList a",
         );
@@ -2846,7 +2846,7 @@ mod solve_expr {
     fn peano_map_infer_nested() {
         infer_eq(
             indoc!(
-                r#"
+                r"
                     map = \peano ->
                             when peano is
                                 Z -> Z
@@ -2855,7 +2855,7 @@ mod solve_expr {
 
 
                     map
-                "#
+                "
             ),
             "[S a, Z] as a -> [S b, Z] as b",
         );
@@ -2882,12 +2882,12 @@ mod solve_expr {
     fn let_tag_pattern_with_annotation() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                      UserId x : [UserId I64]
                      UserId x = UserId 42
 
                      x
-                 "#
+                 "
             ),
             "I64",
         );
@@ -2897,7 +2897,7 @@ mod solve_expr {
     fn typecheck_record_linked_list_map() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                     ConsList q : [Cons { x: q, xs: ConsList q }, Nil]
 
                     map : (a -> b), ConsList a -> ConsList b
@@ -2908,7 +2908,7 @@ mod solve_expr {
                                 Cons { x: f x, xs : map f xs }
 
                     map
-                "#
+                "
             ),
             "(a -> b), ConsList a -> ConsList b",
         );
@@ -2918,7 +2918,7 @@ mod solve_expr {
     fn infer_record_linked_list_map() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                     map = \f, list ->
                         when list is
                             Nil -> Nil
@@ -2926,7 +2926,7 @@ mod solve_expr {
                                 Cons { x: f x, xs : map f xs }
 
                     map
-                "#
+                "
             ),
             "(a -> b), [Cons { x : a, xs : c }*, Nil] as c -> [Cons { x : b, xs : d }, Nil] as d",
         );
@@ -2936,7 +2936,7 @@ mod solve_expr {
     fn typecheck_mutually_recursive_tag_union_2() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                     ListA a b : [Cons a (ListB b a), Nil]
                     ListB a b : [Cons a (ListA b a), Nil]
 
@@ -2953,7 +2953,7 @@ mod solve_expr {
                                         Cons a (Cons (f b) (toAs f newLista))
 
                     toAs
-                "#
+                "
             ),
             "(b -> a), ListA a b -> ConsList a",
         );
@@ -2963,7 +2963,7 @@ mod solve_expr {
     fn typecheck_mutually_recursive_tag_union_listabc() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                     ListA a : [Cons a (ListB a)]
                     ListB a : [Cons a (ListC a)]
                     ListC a : [Cons a (ListA a), Nil]
@@ -2972,7 +2972,7 @@ mod solve_expr {
                     val = Cons 1 (Cons 2 (Cons 3 Nil))
 
                     val
-                "#
+                "
             ),
             "ListC I64",
         );
@@ -2982,7 +2982,7 @@ mod solve_expr {
     fn infer_mutually_recursive_tag_union() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                    toAs = \f, lista ->
                         when lista is
                             Nil -> Nil
@@ -2993,7 +2993,7 @@ mod solve_expr {
                                         Cons a (Cons (f b) (toAs f newLista))
 
                    toAs
-                "#
+                "
             ),
             "(a -> b), [Cons c [Cons a d, Nil], Nil] as d -> [Cons c [Cons b e], Nil] as e",
         );
@@ -3015,7 +3015,7 @@ mod solve_expr {
     fn type_more_general_than_signature() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                 partition : Nat, Nat, List (Int a) -> [Pair Nat (List (Int a))]
                 partition = \low, high, initialList ->
                     when List.get initialList high is
@@ -3026,7 +3026,7 @@ mod solve_expr {
                             Pair (low - 1) initialList
 
                 partition
-                            "#
+                            "
             ),
             "Nat, Nat, List (Int a) -> [Pair Nat (List (Int a))]",
         );
@@ -3036,7 +3036,7 @@ mod solve_expr {
     fn quicksort_partition() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
             swap : Nat, Nat, List a -> List a
             swap = \i, j, list ->
                 when Pair (List.get list i) (List.get list j) is
@@ -3074,7 +3074,7 @@ mod solve_expr {
                         Pair (low - 1) initialList
 
             partition
-        "#
+        "
             ),
             "Nat, Nat, List (Int a) -> [Pair Nat (List (Int a))]",
         );
@@ -3084,7 +3084,7 @@ mod solve_expr {
     fn identity_list() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                 idList : List a -> List a
                 idList = \list -> list
 
@@ -3093,7 +3093,7 @@ mod solve_expr {
 
 
                 foo
-            "#
+            "
             ),
             "List I64 -> List I64",
         );
@@ -3103,18 +3103,18 @@ mod solve_expr {
     fn list_get() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                     List.get [10, 9, 8, 7] 1
-                "#
+                "
             ),
             "Result (Num *) [OutOfBounds]",
         );
 
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                     List.get
-                "#
+                "
             ),
             "List a, Nat -> Result a [OutOfBounds]",
         );
@@ -3124,7 +3124,7 @@ mod solve_expr {
     fn use_rigid_twice() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                 id1 : q -> q
                 id1 = \x -> x
 
@@ -3132,7 +3132,7 @@ mod solve_expr {
                 id2 = \x -> x
 
                 { id1, id2 }
-                "#
+                "
             ),
             "{ id1 : q -> q, id2 : q1 -> q1 }",
         );
@@ -3142,9 +3142,9 @@ mod solve_expr {
     fn map_insert() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                 Dict.insert
-                "#
+                "
             ),
             "Dict k v, k, v -> Dict k v where k implements Hash & Eq",
         );
@@ -3154,9 +3154,9 @@ mod solve_expr {
     fn num_to_frac() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                 Num.toFrac
-                "#
+                "
             ),
             "Num * -> Frac a",
         );
@@ -3166,9 +3166,9 @@ mod solve_expr {
     fn pow() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                 Num.pow
-                "#
+                "
             ),
             "Frac a, Frac a -> Frac a",
         );
@@ -3178,9 +3178,9 @@ mod solve_expr {
     fn ceiling() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                 Num.ceiling
-                "#
+                "
             ),
             "Frac * -> Int a",
         );
@@ -3190,9 +3190,9 @@ mod solve_expr {
     fn floor() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                 Num.floor
-                "#
+                "
             ),
             "Frac * -> Int a",
         );
@@ -3202,9 +3202,9 @@ mod solve_expr {
     fn div() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                 Num.div
-                "#
+                "
             ),
             "Frac a, Frac a -> Frac a",
         )
@@ -3214,9 +3214,9 @@ mod solve_expr {
     fn div_checked() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                 Num.divChecked
-                "#
+                "
             ),
             "Frac a, Frac a -> Result (Frac a) [DivByZero]",
         )
@@ -3226,9 +3226,9 @@ mod solve_expr {
     fn div_ceil() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                 Num.divCeil
-                "#
+                "
             ),
             "Int a, Int a -> Int a",
         );
@@ -3238,9 +3238,9 @@ mod solve_expr {
     fn div_ceil_checked() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                 Num.divCeilChecked
-                "#
+                "
             ),
             "Int a, Int a -> Result (Int a) [DivByZero]",
         );
@@ -3250,9 +3250,9 @@ mod solve_expr {
     fn div_trunc() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                 Num.divTrunc
-                "#
+                "
             ),
             "Int a, Int a -> Int a",
         );
@@ -3262,9 +3262,9 @@ mod solve_expr {
     fn div_trunc_checked() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                 Num.divTruncChecked
-                "#
+                "
             ),
             "Int a, Int a -> Result (Int a) [DivByZero]",
         );
@@ -3274,9 +3274,9 @@ mod solve_expr {
     fn atan() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                 Num.atan
-                "#
+                "
             ),
             "Frac a -> Frac a",
         );
@@ -3286,9 +3286,9 @@ mod solve_expr {
     fn min_i128() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                 Num.minI128
-                "#
+                "
             ),
             "I128",
         );
@@ -3298,9 +3298,9 @@ mod solve_expr {
     fn max_i128() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                 Num.maxI128
-                "#
+                "
             ),
             "I128",
         );
@@ -3310,9 +3310,9 @@ mod solve_expr {
     fn min_i64() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                 Num.minI64
-                "#
+                "
             ),
             "I64",
         );
@@ -3322,9 +3322,9 @@ mod solve_expr {
     fn max_i64() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                 Num.maxI64
-                "#
+                "
             ),
             "I64",
         );
@@ -3334,9 +3334,9 @@ mod solve_expr {
     fn min_u64() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                 Num.minU64
-                "#
+                "
             ),
             "U64",
         );
@@ -3346,9 +3346,9 @@ mod solve_expr {
     fn max_u64() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                 Num.maxU64
-                "#
+                "
             ),
             "U64",
         );
@@ -3358,9 +3358,9 @@ mod solve_expr {
     fn min_i32() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                 Num.minI32
-                "#
+                "
             ),
             "I32",
         );
@@ -3370,9 +3370,9 @@ mod solve_expr {
     fn max_i32() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                 Num.maxI32
-                "#
+                "
             ),
             "I32",
         );
@@ -3382,9 +3382,9 @@ mod solve_expr {
     fn min_u32() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                 Num.minU32
-                "#
+                "
             ),
             "U32",
         );
@@ -3394,9 +3394,9 @@ mod solve_expr {
     fn max_u32() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                 Num.maxU32
-                "#
+                "
             ),
             "U32",
         );
@@ -3406,7 +3406,7 @@ mod solve_expr {
     fn reconstruct_path() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                 reconstructPath : Dict position position, position -> List position where position implements Hash & Eq
                 reconstructPath = \cameFrom, goal ->
                     when Dict.get cameFrom goal is
@@ -3417,7 +3417,7 @@ mod solve_expr {
                             List.append (reconstructPath cameFrom next) goal
 
                 reconstructPath
-                "#
+                "
             ),
             "Dict position position, position -> List position where position implements Hash & Eq",
         );
@@ -3428,7 +3428,7 @@ mod solve_expr {
         // Related to a bug solved in 81fbab0b3fe4765bc6948727e603fc2d49590b1c
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                 f = \r ->
                     g = r.q
                     h = r.p
@@ -3436,7 +3436,7 @@ mod solve_expr {
                     42
 
                 f
-                "#
+                "
             ),
             "{ p : *, q : * }* -> Num *",
         );
@@ -3484,14 +3484,14 @@ mod solve_expr {
     fn when_with_or_pattern_and_guard() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                 \x ->
                     when x is
                         2 | 3 -> 0
                         a if a < 20 ->  1
                         3 | 4 if Bool.false -> 2
                         _ -> 3
-                "#
+                "
             ),
             "Num * -> Num *",
         );
@@ -3503,7 +3503,7 @@ mod solve_expr {
         // Roc seems to do this correctly, tracking to make sure it stays that way
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                 sort : ConsList cm -> ConsList cm
                 sort =
                     \xs ->
@@ -3538,7 +3538,7 @@ mod solve_expr {
                 ConsList a : [Nil, Cons a (ConsList a)]
 
                 { x: sortWith, y: sort, z: sortBy }
-                "#
+                "
             ),
             "{ x : (foobar, foobar -> Order), ConsList foobar -> ConsList foobar, y : ConsList cm -> ConsList cm, z : (x -> cmpl), ConsList x -> ConsList x }"
         );
@@ -3556,7 +3556,7 @@ mod solve_expr {
     //        // Roc seems to do this correctly, tracking to make sure it stays that way
     //        infer_eq_without_problem(
     //            indoc!(
-    //                r#"
+    //                r"
     //                Type a : [TypeCtor (Type (Wrapper a))]
     //
     //                Wrapper a : [Wrapper a]
@@ -3570,7 +3570,7 @@ mod solve_expr {
     //                            encodeType1 v0
     //
     //                encodeType1
-    //                "#
+    //                "
     //            ),
     //            "Type a -> Opaque",
     //        );
@@ -3580,7 +3580,7 @@ mod solve_expr {
     fn rigids() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                 f : List a -> List a
                 f = \input ->
                     # let-polymorphism at work
@@ -3591,7 +3591,7 @@ mod solve_expr {
                         Ok val -> List.append (x {}) val
                         Err _ -> input
                 f
-                "#
+                "
             ),
             "List a -> List a",
         );
@@ -3609,12 +3609,12 @@ mod solve_expr {
         // should hit a debug_assert! in debug mode, and produce a type error in release mode
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                 test : ({ foo : I64 }ext -> Bool), { foo : I64 } -> Bool
                 test = \fn, a -> fn a
 
                 test
-                "#
+                "
             ),
             "should fail",
         );
@@ -3626,11 +3626,11 @@ mod solve_expr {
     fn optional_field_unifies_with_missing() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                     negatePoint : { x : I64, y : I64, z ? Num c } -> { x : I64, y : I64, z : Num c }
 
                     negatePoint { x: 1, y: 2 }
-                "#
+                "
             ),
             "{ x : I64, y : I64, z : Num c }",
         );
@@ -3657,11 +3657,11 @@ mod solve_expr {
     fn optional_field_unifies_with_present() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                     negatePoint : { x : Num a, y : Num b, z ? c } -> { x : Num a, y : Num b, z : c }
 
                     negatePoint { x: 1, y: 2.1, z: 0x3 }
-                "#
+                "
             ),
             "{ x : Num *, y : Frac *, z : Int * }",
         );
@@ -3688,9 +3688,9 @@ mod solve_expr {
     fn optional_field_function() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                 \{ x, y ? 0 } -> x + y
-                "#
+                "
             ),
             "{ x : Num a, y ? Num a }* -> Num a",
         );
@@ -3700,11 +3700,11 @@ mod solve_expr {
     fn optional_field_let() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                 { x, y ? 0 } = { x: 32 }
 
                 x + y
-                "#
+                "
             ),
             "Num *",
         );
@@ -3714,11 +3714,11 @@ mod solve_expr {
     fn optional_field_when() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                 \r ->
                     when r is
                         { x, y ? 0 } -> x + y
-                "#
+                "
             ),
             "{ x : Num a, y ? Num a }* -> Num a",
         );
@@ -3728,13 +3728,13 @@ mod solve_expr {
     fn optional_field_let_with_signature() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                 \rec ->
                     { x, y } : { x : I64, y ? Bool }*
                     { x, y ? Bool.false } = rec
 
                     { x, y }
-                "#
+                "
             ),
             "{ x : I64, y ? Bool }* -> { x : I64, y : Bool }",
         );
@@ -3744,9 +3744,9 @@ mod solve_expr {
     fn list_walk_backwards() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                 List.walkBackwards
-                "#
+                "
             ),
             "List elem, state, (state, elem -> state) -> state",
         );
@@ -3756,13 +3756,13 @@ mod solve_expr {
     fn list_walk_backwards_example() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                 empty : List I64
                 empty =
                     []
 
                 List.walkBackwards empty 0 (\a, b -> a + b)
-                "#
+                "
             ),
             "I64",
         );
@@ -3771,7 +3771,7 @@ mod solve_expr {
     #[test]
     fn list_walk_with_index_until() {
         infer_eq_without_problem(
-            indoc!(r#"List.walkWithIndexUntil"#),
+            indoc!(r"List.walkWithIndexUntil"),
             "List elem, state, (state, elem, Nat -> [Break state, Continue state]) -> state",
         );
     }
@@ -3780,9 +3780,9 @@ mod solve_expr {
     fn list_drop_at() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                 List.dropAt
-                "#
+                "
             ),
             "List elem, Nat -> List elem",
         );
@@ -3792,9 +3792,9 @@ mod solve_expr {
     fn str_trim() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                 Str.trim
-                "#
+                "
             ),
             "Str -> Str",
         );
@@ -3804,9 +3804,9 @@ mod solve_expr {
     fn str_trim_start() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                 Str.trimStart
-                "#
+                "
             ),
             "Str -> Str",
         );
@@ -3816,9 +3816,9 @@ mod solve_expr {
     fn list_take_first() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                 List.takeFirst
-                "#
+                "
             ),
             "List elem, Nat -> List elem",
         );
@@ -3828,9 +3828,9 @@ mod solve_expr {
     fn list_take_last() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                 List.takeLast
-                "#
+                "
             ),
             "List elem, Nat -> List elem",
         );
@@ -3840,9 +3840,9 @@ mod solve_expr {
     fn list_sublist() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                 List.sublist
-                "#
+                "
             ),
             "List elem, { len : Nat, start : Nat } -> List elem",
         );
@@ -3860,9 +3860,9 @@ mod solve_expr {
     fn list_drop_last() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                 List.dropLast
-                "#
+                "
             ),
             "List elem, Nat -> List elem",
         );
@@ -3872,9 +3872,9 @@ mod solve_expr {
     fn list_intersperse() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                 List.intersperse
-                "#
+                "
             ),
             "List elem, elem -> List elem",
         );
@@ -3885,13 +3885,13 @@ mod solve_expr {
         // such functions will be lifted to the top-level, and are thus globally available!
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                 f = \x -> x + 1
 
                 g = \y -> f y
 
                 g
-                "#
+                "
             ),
             "Num a -> Num a",
         );
@@ -4638,11 +4638,11 @@ mod solve_expr {
     fn inference_var_inside_arrow() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                 id : _ -> _
                 id = \x -> x
                 id
-                "#
+                "
             ),
             "a -> a",
         )
@@ -4671,11 +4671,11 @@ mod solve_expr {
     fn inference_var_inside_ctor_linked() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                 swapRcd: {x: _, y: _} -> {x: _, y: _}
                 swapRcd = \{x, y} -> {x: y, y: x}
                 swapRcd
-                "#
+                "
             ),
             "{ x : a, y : b } -> { x : b, y : a }",
         )
@@ -4685,11 +4685,11 @@ mod solve_expr {
     fn inference_var_link_with_rigid() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                 swapRcd: {x: tx, y: ty} -> {x: _, y: _}
                 swapRcd = \{x, y} -> {x: y, y: x}
                 swapRcd
-                "#
+                "
             ),
             "{ x : tx, y : ty } -> { x : ty, y : tx }",
         )
@@ -4718,7 +4718,7 @@ mod solve_expr {
         // See https://github.com/roc-lang/roc/issues/2053
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                 pastelize: _ -> [Lavender, Peach]_
                 pastelize = \color ->
                     when color is
@@ -4726,7 +4726,7 @@ mod solve_expr {
                         Orange -> Peach
                         col -> col
                 pastelize
-                "#
+                "
             ),
             "[Blue, Lavender, Orange, Peach]a -> [Blue, Lavender, Orange, Peach]a",
         )
@@ -4751,14 +4751,14 @@ mod solve_expr {
     fn issue_2217() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                 LinkedList elem : [Empty, Prepend (LinkedList elem) elem]
 
                 fromList : List elem -> LinkedList elem
                 fromList = \elems -> List.walk elems Empty Prepend
 
                 fromList
-                "#
+                "
             ),
             "List elem -> LinkedList elem",
         )
@@ -4768,12 +4768,12 @@ mod solve_expr {
     fn issue_2217_inlined() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                 fromList : List elem -> [Empty, Prepend (LinkedList elem) elem] as LinkedList elem
                 fromList = \elems -> List.walk elems Empty Prepend
 
                 fromList
-                "#
+                "
             ),
             "List elem -> LinkedList elem",
         )
@@ -4783,12 +4783,12 @@ mod solve_expr {
     fn infer_union_input_position1() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                  \tag ->
                      when tag is
                        A -> X
                        B -> Y
-                 "#
+                 "
             ),
             "[A, B] -> [X, Y]",
         )
@@ -4798,13 +4798,13 @@ mod solve_expr {
     fn infer_union_input_position2() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                  \tag ->
                      when tag is
                        A -> X
                        B -> Y
                        _ -> Z
-                 "#
+                 "
             ),
             "[A, B]* -> [X, Y, Z]",
         )
@@ -4814,12 +4814,12 @@ mod solve_expr {
     fn infer_union_input_position3() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                  \tag ->
                      when tag is
                        A M -> X
                        A N -> Y
-                 "#
+                 "
             ),
             "[A [M, N]] -> [X, Y]",
         )
@@ -4829,13 +4829,13 @@ mod solve_expr {
     fn infer_union_input_position4() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                  \tag ->
                      when tag is
                        A M -> X
                        A N -> Y
                        A _ -> Z
-                 "#
+                 "
             ),
             "[A [M, N]*] -> [X, Y, Z]",
         )
@@ -4845,12 +4845,12 @@ mod solve_expr {
     fn infer_union_input_position5() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                  \tag ->
                      when tag is
                        A (M J) -> X
                        A (N K) -> X
-                 "#
+                 "
             ),
             "[A [M [J], N [K]]] -> [X]",
         )
@@ -4860,13 +4860,13 @@ mod solve_expr {
     fn infer_union_input_position6() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                  \tag ->
                      when tag is
                        A M -> X
                        B   -> X
                        A N -> X
-                 "#
+                 "
             ),
             "[A [M, N], B] -> [X]",
         )
@@ -4876,12 +4876,12 @@ mod solve_expr {
     fn infer_union_input_position7() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                  \tag ->
                      when tag is
                          A -> X
                          t -> t
-                 "#
+                 "
             ),
             "[A, X]a -> [A, X]a",
         )
@@ -4891,13 +4891,13 @@ mod solve_expr {
     fn infer_union_input_position8() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                  \opt ->
                      when opt is
                          Some ({tag: A}) -> 1
                          Some ({tag: B}) -> 1
                          None -> 0
-                 "#
+                 "
             ),
             "[None, Some { tag : [A, B] }*] -> Num *",
         )
@@ -4925,12 +4925,12 @@ mod solve_expr {
     fn infer_union_input_position10() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                  \r ->
                      when r is
                          { x: Blue, y ? 3 } -> y
                          { x: Red, y ? 5 } -> y
-                 "#
+                 "
             ),
             "{ x : [Blue, Red], y ? Num a }* -> Num a",
         )
@@ -4941,9 +4941,9 @@ mod solve_expr {
     fn infer_union_argument_position() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                  \UserId id -> id + 1
-                 "#
+                 "
             ),
             "[UserId (Num a)] -> Num a",
         )
@@ -4953,11 +4953,11 @@ mod solve_expr {
     fn infer_union_def_position() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                  \email ->
                     Email str = email
                     Str.isEmpty str
-                 "#
+                 "
             ),
             "[Email Str] -> Bool",
         )
@@ -4967,7 +4967,7 @@ mod solve_expr {
     fn numeric_literal_suffixes() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                 {
                     u8:   123u8,
                     u16:  123u16,
@@ -5005,9 +5005,9 @@ mod solve_expr {
                     ff32: 123f32,
                     ff64: 123f64,
                 }
-                "#
+                "
             ),
-            r#"{ bi128 : I128, bi16 : I16, bi32 : I32, bi64 : I64, bi8 : I8, bnat : Nat, bu128 : U128, bu16 : U16, bu32 : U32, bu64 : U64, bu8 : U8, dec : Dec, f32 : F32, f64 : F64, fdec : Dec, ff32 : F32, ff64 : F64, i128 : I128, i16 : I16, i32 : I32, i64 : I64, i8 : I8, nat : Nat, u128 : U128, u16 : U16, u32 : U32, u64 : U64, u8 : U8 }"#,
+            r"{ bi128 : I128, bi16 : I16, bi32 : I32, bi64 : I64, bi8 : I8, bnat : Nat, bu128 : U128, bu16 : U16, bu32 : U32, bu64 : U64, bu8 : U8, dec : Dec, f32 : F32, f64 : F64, fdec : Dec, ff32 : F32, ff64 : F64, i128 : I128, i16 : I16, i32 : I32, i64 : I64, i8 : I8, nat : Nat, u128 : U128, u16 : U16, u32 : U32, u64 : U64, u8 : U8 }",
         )
     }
 
@@ -5015,7 +5015,7 @@ mod solve_expr {
     fn numeric_literal_suffixes_in_pattern() {
         infer_eq_without_problem(
             indoc!(
-                r#"
+                r"
                 {
                     u8:   (\n ->
                             when n is
@@ -5137,9 +5137,9 @@ mod solve_expr {
                               123f64 -> n
                               _ -> n),
                 }
-                "#
+                "
             ),
-            r#"{ bi128 : I128 -> I128, bi16 : I16 -> I16, bi32 : I32 -> I32, bi64 : I64 -> I64, bi8 : I8 -> I8, bnat : Nat -> Nat, bu128 : U128 -> U128, bu16 : U16 -> U16, bu32 : U32 -> U32, bu64 : U64 -> U64, bu8 : U8 -> U8, dec : Dec -> Dec, f32 : F32 -> F32, f64 : F64 -> F64, fdec : Dec -> Dec, ff32 : F32 -> F32, ff64 : F64 -> F64, i128 : I128 -> I128, i16 : I16 -> I16, i32 : I32 -> I32, i64 : I64 -> I64, i8 : I8 -> I8, nat : Nat -> Nat, u128 : U128 -> U128, u16 : U16 -> U16, u32 : U32 -> U32, u64 : U64 -> U64, u8 : U8 -> U8 }"#,
+            r"{ bi128 : I128 -> I128, bi16 : I16 -> I16, bi32 : I32 -> I32, bi64 : I64 -> I64, bi8 : I8 -> I8, bnat : Nat -> Nat, bu128 : U128 -> U128, bu16 : U16 -> U16, bu32 : U32 -> U32, bu64 : U64 -> U64, bu8 : U8 -> U8, dec : Dec -> Dec, f32 : F32 -> F32, f64 : F64 -> F64, fdec : Dec -> Dec, ff32 : F32 -> F32, ff64 : F64 -> F64, i128 : I128 -> I128, i16 : I16 -> I16, i32 : I32 -> I32, i64 : I64 -> I64, i8 : I8 -> I8, nat : Nat -> Nat, u128 : U128 -> U128, u16 : U16 -> U16, u32 : U32 -> U32, u64 : U64 -> U64, u8 : U8 -> U8 }",
         )
     }
 }

--- a/crates/compiler/test_gen/src/gen_abilities.rs
+++ b/crates/compiler/test_gen/src/gen_abilities.rs
@@ -542,7 +542,7 @@ mod encode_immediate {
                                 _ -> "<bad>"
                         "#
                     ), $num, stringify!($typ)),
-                    RocStr::from(format!(r#"{}"#, $num).as_str()),
+                    RocStr::from(format!(r"{}", $num).as_str()),
                     RocStr
                 )
             }
@@ -1011,7 +1011,7 @@ fn decode_derive_decoder_for_opaque() {
                     _ -> "FAIL"
             "#
         ),
-        RocStr::from(r#"Hello, World!"#),
+        RocStr::from(r"Hello, World!"),
         RocStr
     )
 }
@@ -1458,7 +1458,7 @@ mod hash {
     use indoc::indoc;
 
     const TEST_HASHER: &str = indoc!(
-        r#"
+        r"
         THasher := List U8 implements [Hasher {
             addBytes: tAddBytes,
             addU8: tAddU8,
@@ -1507,7 +1507,7 @@ mod hash {
         tComplete = \@THasher _ -> Num.maxU64
 
         tRead = \@THasher bytes -> bytes
-        "#
+        "
     );
 
     fn build_test(input: &str) -> String {
@@ -1668,7 +1668,7 @@ mod hash {
         #[test]
         fn list_u8() {
             assert_evals_to!(
-                &build_test(r#"[15u8, 23u8, 37u8]"#),
+                &build_test(r"[15u8, 23u8, 37u8]"),
                 RocList::from_slice(&[15, 23, 37]),
                 RocList<u8>
             )
@@ -1700,7 +1700,7 @@ mod hash {
         #[test]
         fn empty_record() {
             assert_evals_to!(
-                &build_test(r#"{}"#),
+                &build_test(r"{}"),
                 RocList::from_slice(&[] as &[u8]),
                 RocList<u8>
             )
@@ -1728,7 +1728,7 @@ mod hash {
         fn record_of_list_of_records() {
             assert_evals_to!(
                 &build_test(
-                    r#"{ a: [ { b: 15u8 }, { b: 23u8 } ], b: [ { c: 45u8 }, { c: 73u8 } ] }"#
+                    r"{ a: [ { b: 15u8 }, { b: 23u8 } ], b: [ { c: 45u8 }, { c: 73u8 } ] }"
                 ),
                 RocList::from_slice(&[15, 23, 45, 73]),
                 RocList<u8>
@@ -1757,7 +1757,7 @@ mod hash {
         fn tuple_of_list_of_tuples() {
             assert_evals_to!(
                 &build_test(
-                    r#"( [ ( 15u8, 32u8 ), ( 23u8, 41u8 ) ], [ (45u8, 63u8), (58u8, 73u8) ] )"#
+                    r"( [ ( 15u8, 32u8 ), ( 23u8, 41u8 ) ], [ (45u8, 63u8), (58u8, 73u8) ] )"
                 ),
                 RocList::from_slice(&[15, 32, 23, 41, 45, 63, 58, 73]),
                 RocList<u8>
@@ -2152,7 +2152,7 @@ fn issue_4772_weakened_monomorphic_destructure() {
     with_larger_debug_stack(|| {
         assert_evals_to!(
             indoc!(
-                r###"
+                r#"
                 app "test"
                         imports [TotallyNotJson]
                         provides [main] to "./platform"
@@ -2173,7 +2173,7 @@ fn issue_4772_weakened_monomorphic_destructure() {
 
                 main =
                     getNumber |> Result.map .val |> Result.withDefault 0
-                "###
+                "#
             ),
             1234i64,
             i64
@@ -2302,7 +2302,7 @@ mod inspect {
             main = Inspect.toStr (@Op {})
             "#
             ),
-            RocStr::from(r#"<opaque>"#),
+            RocStr::from(r"<opaque>"),
             RocStr
         );
     }
@@ -2322,7 +2322,7 @@ mod inspect {
             main = late (@Op {})
             "#
             ),
-            RocStr::from(r#"<opaque>"#),
+            RocStr::from(r"<opaque>"),
             RocStr
         );
     }

--- a/crates/compiler/test_gen/src/gen_definitions.rs
+++ b/crates/compiler/test_gen/src/gen_definitions.rs
@@ -19,11 +19,11 @@ use roc_std::{RocList, RocResult, RocStr};
 fn def_closure_in_parens() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             id = (\x -> x)
 
             id 42u32
-            "#
+            "
         ),
         42,
         u32
@@ -35,11 +35,11 @@ fn def_closure_in_parens() {
 fn def_closure_in_multiple_parens() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             id = (((\x -> x)))
 
             id 42u32
-            "#
+            "
         ),
         42,
         u32

--- a/crates/compiler/test_gen/src/gen_dict.rs
+++ b/crates/compiler/test_gen/src/gen_dict.rs
@@ -20,9 +20,9 @@ use roc_std::{RocList, RocStr};
 fn dict_empty_len() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             Dict.len (Dict.empty {})
-            "#
+            "
         ),
         0,
         usize
@@ -34,11 +34,11 @@ fn dict_empty_len() {
 fn dict_insert_empty() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             Dict.empty {}
                 |> Dict.insert 42 32
                 |> Dict.len
-            "#
+            "
         ),
         1,
         usize
@@ -50,12 +50,12 @@ fn dict_insert_empty() {
 fn dict_empty_contains() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             empty : Dict.Dict I64 F64
             empty = Dict.empty {}
 
             Dict.contains empty 42
-            "#
+            "
         ),
         false,
         bool
@@ -67,12 +67,12 @@ fn dict_empty_contains() {
 fn dict_nonempty_contains() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             empty : Dict.Dict I64 F64
             empty = Dict.insert (Dict.empty {}) 42 1.23
 
             Dict.contains empty 42
-            "#
+            "
         ),
         true,
         bool
@@ -85,14 +85,14 @@ fn dict_nonempty_contains() {
 fn dict_empty_remove() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             empty : Dict.Dict I64 F64
             empty = Dict.empty {}
 
             empty
                 |> Dict.remove 42
                 |> Dict.len
-            "#
+            "
         ),
         0,
         i64
@@ -104,7 +104,7 @@ fn dict_empty_remove() {
 fn dict_nonempty_remove() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             empty : Dict.Dict I64 F64
             empty = Dict.insert (Dict.empty {}) 42 1.23
 
@@ -112,7 +112,7 @@ fn dict_nonempty_remove() {
                 |> Dict.remove 42
                 |> Dict.len
                 |> Num.toI64
-            "#
+            "
         ),
         0,
         i64
@@ -124,7 +124,7 @@ fn dict_nonempty_remove() {
 fn dict_nonempty_get() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             empty : Dict.Dict I64 F64
             empty = Dict.insert (Dict.empty {}) 42 1.23
 
@@ -137,7 +137,7 @@ fn dict_nonempty_get() {
                 |> Dict.insert 42 1.23f64
                 |> Dict.get 42
                 |> withDefault 0
-            "#
+            "
         ),
         1.23,
         f64
@@ -145,7 +145,7 @@ fn dict_nonempty_get() {
 
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             withDefault = \x, def ->
                 when  x is
                     Ok v -> v
@@ -155,7 +155,7 @@ fn dict_nonempty_get() {
                 |> Dict.insert 42 1.23f64
                 |> Dict.get 43
                 |> withDefault 0
-            "#
+            "
         ),
         0.0,
         f64
@@ -167,7 +167,7 @@ fn dict_nonempty_get() {
 fn keys() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             myDict : Dict.Dict I64 I64
             myDict =
                 Dict.empty {}
@@ -177,7 +177,7 @@ fn keys() {
 
 
             Dict.keys myDict
-            "#
+            "
         ),
         RocList::from_slice(&[0, 1, 2]),
         RocList<i64>
@@ -189,7 +189,7 @@ fn keys() {
 fn values() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             myDict : Dict.Dict I64 I64
             myDict =
                 Dict.empty {}
@@ -199,7 +199,7 @@ fn values() {
 
 
             Dict.values myDict
-            "#
+            "
         ),
         RocList::from_slice(&[100, 200, 300]),
         RocList<i64>
@@ -211,14 +211,14 @@ fn values() {
 fn from_list_with_fold_simple() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             myDict : Dict.Dict I64 I64
             myDict =
                 [1,2,3]
                     |> List.walk (Dict.empty {}) (\accum, value -> Dict.insert accum value value)
 
             Dict.values myDict
-            "#
+            "
         ),
         RocList::from_slice(&[1, 2, 3]),
         RocList<i64>
@@ -230,7 +230,7 @@ fn from_list_with_fold_simple() {
 fn from_list_with_fold_reallocates() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             range : I64, I64, List I64-> List I64
             range = \low, high, accum ->
                 if low < high then
@@ -245,7 +245,7 @@ fn from_list_with_fold_reallocates() {
                     |> List.walk (Dict.empty {}) (\accum, value -> Dict.insert accum value value)
 
             Dict.values myDict
-            "#
+            "
         ),
         RocList::from_slice(&[
             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
@@ -329,7 +329,7 @@ fn big_str_values() {
 fn unit_values() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             myDict : Dict.Dict I64 {}
             myDict =
                 Dict.empty {}
@@ -339,7 +339,7 @@ fn unit_values() {
                     |> Dict.insert 3 {}
 
             Num.toI64 (Dict.len myDict)
-            "#
+            "
         ),
         4,
         i64
@@ -351,13 +351,13 @@ fn unit_values() {
 fn single() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             myDict : Dict.Dict I64 {}
             myDict =
                 Dict.single 12345 {}
 
             Num.toI64 (Dict.len myDict)
-            "#
+            "
         ),
         1,
         i64
@@ -369,14 +369,14 @@ fn single() {
 fn insert_all() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             myDict : Dict I64 {}
             myDict =
                 Dict.insertAll (Dict.single 0 {}) (Dict.single 1 {})
 
             Dict.len myDict
                 |> Num.toI64
-            "#
+            "
         ),
         2,
         i64
@@ -388,14 +388,14 @@ fn insert_all() {
 fn insert_all_prefer_second() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             myDict : Dict.Dict I64 I64
             myDict =
                 (Dict.single 0 100)
                     |> Dict.insertAll (Dict.single 0 200)
 
             Dict.values myDict
-            "#
+            "
         ),
         RocList::from_slice(&[200]),
         RocList<i64>
@@ -407,7 +407,7 @@ fn insert_all_prefer_second() {
 fn keep_shared() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             dict1 : Dict.Dict I64 {}
             dict1 =
                 Dict.empty {}
@@ -427,7 +427,7 @@ fn keep_shared() {
             Dict.keepShared dict1 dict2
                 |> Dict.len
                 |> Num.toI64
-            "#
+            "
         ),
         2,
         i64
@@ -439,7 +439,7 @@ fn keep_shared() {
 fn keep_shared_value_must_match() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             dict1 : Dict.Dict I64 I64
             dict1 =
                 Dict.empty {}
@@ -458,7 +458,7 @@ fn keep_shared_value_must_match() {
 
             Dict.keepShared dict1 dict2
                 |> Dict.values
-            "#
+            "
         ),
         RocList::from_slice(&[2]),
         RocList<i64>
@@ -470,7 +470,7 @@ fn keep_shared_value_must_match() {
 fn remove_all() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             dict1 : Dict.Dict I64 {}
             dict1 =
                 Dict.empty {}
@@ -490,7 +490,7 @@ fn remove_all() {
             Dict.removeAll dict1 dict2
                 |> Dict.len
                 |> Num.toI64
-            "#
+            "
         ),
         3,
         i64
@@ -502,7 +502,7 @@ fn remove_all() {
 fn remove_all_prefer_first() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             dict1 : Dict.Dict I64 I64
             dict1 =
                 Dict.empty {}
@@ -521,7 +521,7 @@ fn remove_all_prefer_first() {
 
             Dict.removeAll dict1 dict2
                 |> Dict.values
-            "#
+            "
         ),
         RocList::from_slice(&[1, 5, 3]),
         RocList<i64>
@@ -533,7 +533,7 @@ fn remove_all_prefer_first() {
 fn walk_sum_keys() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             dict1 : Dict.Dict I64 I64
             dict1 =
                 Dict.empty {}
@@ -544,7 +544,7 @@ fn walk_sum_keys() {
                     |> Dict.insert 5 5
 
             Dict.walk dict1 0 \k, _, a -> k + a
-            "#
+            "
         ),
         15,
         i64

--- a/crates/compiler/test_gen/src/gen_list.rs
+++ b/crates/compiler/test_gen/src/gen_list.rs
@@ -983,11 +983,7 @@ fn list_walk_subtraction() {
 #[test]
 #[cfg(any(feature = "gen-llvm", feature = "gen-wasm", feature = "gen-dev"))]
 fn list_walk_until_sum() {
-    assert_evals_to!(
-        r"List.walkUntil [1, 2] 0 \a,b -> Continue (a + b)",
-        3,
-        i64
-    );
+    assert_evals_to!(r"List.walkUntil [1, 2] 0 \a,b -> Continue (a + b)", 3, i64);
 }
 
 #[test]

--- a/crates/compiler/test_gen/src/gen_list.rs
+++ b/crates/compiler/test_gen/src/gen_list.rs
@@ -55,11 +55,11 @@ fn int_list_literal() {
 fn bool_list_literal() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                false = Bool.false
 
                [false]
-               "#
+               "
         ),
         RocList::from_slice(&[false; 1]),
         RocList<bool>
@@ -73,12 +73,12 @@ fn bool_list_literal() {
 
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                false : Bool
                false = Bool.false
 
                [false]
-               "#
+               "
         ),
         RocList::from_slice(&[false; 1]),
         RocList<bool>
@@ -116,9 +116,9 @@ fn dec_list_join() {
 fn bool_list_concat() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                List.concat [Bool.true, Bool.false] [Bool.false, Bool.true]
-               "#
+               "
         ),
         RocList::from_slice(&[true, false, false, true]),
         RocList<bool>
@@ -126,9 +126,9 @@ fn bool_list_concat() {
 
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                List.concat [] [Bool.false, Bool.true]
-               "#
+               "
         ),
         RocList::from_slice(&[false, true]),
         RocList<bool>
@@ -136,9 +136,9 @@ fn bool_list_concat() {
 
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                List.concat [Bool.true, Bool.false] []
-               "#
+               "
         ),
         RocList::from_slice(&[true, false]),
         RocList<bool>
@@ -150,12 +150,12 @@ fn bool_list_concat() {
 fn bool_list_literal_repeat() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                true : Bool
                true = Bool.true
 
                List.repeat true 23
-               "#
+               "
         ),
         RocList::from_slice(&[true; 23]),
         RocList<bool>
@@ -163,12 +163,12 @@ fn bool_list_literal_repeat() {
 
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                true : Bool
                true = Bool.true
 
                List.repeat { x: true, y: true } 23
-               "#
+               "
         ),
         RocList::from_slice(&[[true, true]; 23]),
         RocList<[bool; 2]>
@@ -176,12 +176,12 @@ fn bool_list_literal_repeat() {
 
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                true : Bool
                true = Bool.true
 
                List.repeat { x: true, y: true, a: true, b: true, c: true, d : true, e: true, f: true } 23
-               "#
+               "
         ),
         RocList::from_slice(&[[true, true, true, true, true, true, true, true]; 23]),
         RocList<[bool; 8]>
@@ -317,9 +317,9 @@ fn list_sublist() {
 fn list_map_try_ok() {
     assert_evals_to!(
         // No transformation
-        r#"
+        r"
             List.mapTry [1, 2, 3] \elem -> Ok elem
-        "#,
+        ",
         // Result I64 [] is unwrapped to just I64
         RocList::<i64>::from_slice(&[1, 2, 3]),
         RocList<i64>
@@ -348,22 +348,22 @@ fn list_map_try_err() {
     use core::convert::Infallible;
 
     assert_evals_to!(
-        r#"
+        r"
             List.mapTry [1, 2, 3] \_ -> Err -1
-        "#,
+        ",
         RocResult::err(-1),
         RocResult<RocList<Infallible>, i64>
     );
 
     assert_evals_to!(
         // If any element returns Err, the whole thing returns Err
-        r#"
+        r"
             List.mapTry [1, 2, 3] \num ->
                 if num > 2 then
                     Err -1
                 else
                     Ok num
-        "#,
+        ",
         RocResult::err(-1),
         RocResult<RocList<i64>, i64>
     );
@@ -373,25 +373,25 @@ fn list_map_try_err() {
 #[cfg(any(feature = "gen-llvm", feature = "gen-wasm", feature = "gen-dev"))]
 fn list_split() {
     assert_evals_to!(
-        r#"
+        r"
         list = List.split [1, 2, 3] 0
         list.before
-        "#,
+        ",
         RocList::<i64>::from_slice(&[]),
         RocList<i64>
     );
     assert_evals_to!(
-        r#"
+        r"
         list = List.split [1, 2, 3] 0
         list.others
-        "#,
+        ",
         RocList::from_slice(&[1, 2, 3]),
         RocList<i64>
     );
     assert_evals_to!(
-        r#"
+        r"
         List.split [1, 2, 3] 1
-        "#,
+        ",
         (RocList::from_slice(&[1]), RocList::from_slice(&[2, 3])),
         (RocList<i64>, RocList<i64>,)
     );
@@ -425,18 +425,18 @@ fn list_split() {
 #[cfg(any(feature = "gen-llvm", feature = "gen-wasm", feature = "gen-dev"))]
 fn list_split_first() {
     assert_evals_to!(
-        r#"
+        r"
                List.splitFirst [2, 3, 0, 4, 0, 6, 0, 8, 9] 0
                |> Result.map .before
-        "#,
+        ",
         RocResult::ok(RocList::<i64>::from_slice(&[2, 3])),
         RocResult<RocList<i64>, ()>
     );
     assert_evals_to!(
-        r#"
+        r"
                List.splitFirst [2, 3, 0, 4, 0, 6, 0, 8, 9] 0
                |> Result.map .after
-        "#,
+        ",
         RocResult::ok(RocList::<i64>::from_slice(&[4, 0, 6, 0, 8, 9])),
         RocResult<RocList<i64>, ()>
     );
@@ -458,18 +458,18 @@ fn list_split_first() {
 #[cfg(any(feature = "gen-llvm", feature = "gen-wasm", feature = "gen-dev"))]
 fn list_split_last() {
     assert_evals_to!(
-        r#"
+        r"
                List.splitLast [2, 3, 0, 4, 0, 6, 0, 8, 9] 0
                |> Result.map .before
-        "#,
+        ",
         RocResult::ok(RocList::<i64>::from_slice(&[2, 3, 0, 4, 0, 6])),
         RocResult<RocList<i64>, ()>
     );
     assert_evals_to!(
-        r#"
+        r"
                List.splitLast [2, 3, 0, 4, 0, 6, 0, 8, 9] 0
                |> Result.map .after
-        "#,
+        ",
         RocResult::ok(RocList::<i64>::from_slice(&[8, 9])),
         RocResult<RocList<i64>, ()>
     );
@@ -569,18 +569,18 @@ fn list_drop_at() {
 fn list_intersperse() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                     List.intersperse [0, 0, 0] 1
-                "#
+                "
         ),
         RocList::from_slice(&[0, 1, 0, 1, 0]),
         RocList<i64>
     );
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                     List.intersperse [] 1
-                "#
+                "
         ),
         RocList::<i64>::from_slice(&[]),
         RocList<i64>
@@ -592,12 +592,12 @@ fn list_intersperse() {
 fn list_drop_at_shared() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                list : List I64
                list = [if Bool.true then 4 else 4, 5, 6]
 
                { newList: List.dropAt list 0, original: list }
-               "#
+               "
         ),
         (
             // new_list
@@ -614,12 +614,12 @@ fn list_drop_at_shared() {
 fn list_drop_if_empty_list_of_int() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             empty : List I64
             empty = []
 
             List.dropIf empty \_ -> Bool.true
-            "#
+            "
         ),
         RocList::<i64>::from_slice(&[]),
         RocList<i64>
@@ -631,12 +631,12 @@ fn list_drop_if_empty_list_of_int() {
 fn list_drop_if_empty_list() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             alwaysTrue : I64 -> Bool
             alwaysTrue = \_ -> Bool.true
 
             List.dropIf [] alwaysTrue
-            "#
+            "
         ),
         RocList::<i64>::from_slice(&[]),
         RocList<i64>
@@ -648,9 +648,9 @@ fn list_drop_if_empty_list() {
 fn list_drop_if_always_false_for_non_empty_list() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             List.dropIf [1,2,3,4,5,6,7,8] (\_ -> Bool.false)
-            "#
+            "
         ),
         RocList::from_slice(&[1, 2, 3, 4, 5, 6, 7, 8]),
         RocList<i64>
@@ -662,9 +662,9 @@ fn list_drop_if_always_false_for_non_empty_list() {
 fn list_drop_if_always_true_for_non_empty_list() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             List.dropIf [1,2,3,4,5,6,7,8] (\_ -> Bool.true)
-            "#
+            "
         ),
         RocList::<i64>::from_slice(&[]),
         RocList<i64>
@@ -676,9 +676,9 @@ fn list_drop_if_always_true_for_non_empty_list() {
 fn list_drop_if_geq3() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             List.dropIf [1,2,3,4,5,6,7,8] (\n -> n >= 3)
-            "#
+            "
         ),
         RocList::from_slice(&[1, 2]),
         RocList<i64>
@@ -724,12 +724,12 @@ fn list_drop_last() {
 fn list_drop_last_mutable() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                list : List I64
                list = [if Bool.true then 4 else 4, 5, 6]
 
                { newList: List.dropLast list 1, original: list }
-               "#
+               "
         ),
         (
             // new_list
@@ -788,13 +788,13 @@ fn list_append_to_empty_list() {
 fn list_append_to_empty_list_of_int() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 initThrees : List I64
                 initThrees =
                     []
 
                 List.append (List.append initThrees 3) 3
-            "#
+            "
         ),
         RocList::from_slice(&[3, 3]),
         RocList<i64>
@@ -833,13 +833,13 @@ fn list_prepend() {
 
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 init : List I64
                 init =
                     []
 
                 List.prepend (List.prepend init 4) 6
-            "#
+            "
         ),
         RocList::from_slice(&[6, 4]),
         RocList<i64>
@@ -891,9 +891,9 @@ fn list_prepend_big_list() {
 fn list_walk_backwards_empty_all_inline() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             List.walkBackwards [0x1] 0 \state, elem -> state + elem
-            "#
+            "
         ),
         1,
         i64
@@ -901,13 +901,13 @@ fn list_walk_backwards_empty_all_inline() {
 
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             empty : List I64
             empty =
                 []
 
             List.walkBackwards empty 0 \state, elem -> state + elem
-            "#
+            "
         ),
         0,
         i64
@@ -935,7 +935,7 @@ fn list_walk_backwards_with_str() {
 fn list_walk_backwards_with_record() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             Bit : [Zero, One]
 
             byte : List Bit
@@ -951,7 +951,7 @@ fn list_walk_backwards_with_record() {
             finalCounts = List.walkBackwards byte initialCounts acc
 
             finalCounts.ones * 10 + finalCounts.zeroes
-            "#
+            "
         ),
         35,
         i64
@@ -977,14 +977,14 @@ fn list_walk_with_str() {
 #[test]
 #[cfg(any(feature = "gen-llvm", feature = "gen-wasm", feature = "gen-dev"))]
 fn list_walk_subtraction() {
-    assert_evals_to!(r#"List.walk [1, 2] 1 Num.sub"#, (1 - 1) - 2, i64);
+    assert_evals_to!(r"List.walk [1, 2] 1 Num.sub", (1 - 1) - 2, i64);
 }
 
 #[test]
 #[cfg(any(feature = "gen-llvm", feature = "gen-wasm", feature = "gen-dev"))]
 fn list_walk_until_sum() {
     assert_evals_to!(
-        r#"List.walkUntil [1, 2] 0 \a,b -> Continue (a + b)"#,
+        r"List.walkUntil [1, 2] 0 \a,b -> Continue (a + b)",
         3,
         i64
     );
@@ -994,7 +994,7 @@ fn list_walk_until_sum() {
 #[cfg(any(feature = "gen-llvm", feature = "gen-wasm", feature = "gen-dev"))]
 fn list_walk_with_index_until_sum() {
     assert_evals_to!(
-        r#"
+        r"
         List.walkWithIndexUntil [5, 7, 2, 3] 0 (\state, elem, index ->
             if elem % 2 == 0 then
                 Break state
@@ -1005,7 +1005,7 @@ fn list_walk_with_index_until_sum() {
                 c = Num.toI64 state
                 Continue (a + b + c)
         )
-        "#,
+        ",
         13,
         i64
     );
@@ -1015,7 +1015,7 @@ fn list_walk_with_index_until_sum() {
 #[cfg(any(feature = "gen-llvm", feature = "gen-wasm", feature = "gen-dev"))]
 fn list_walk_implements_position() {
     assert_evals_to!(
-        r#"
+        r"
         Option a : [Some a, None]
 
         find : List a, a -> Option Nat where a implements Eq
@@ -1033,7 +1033,7 @@ fn list_walk_implements_position() {
         when find [1, 2, 3] 3 is
             None -> 0
             Some v -> v
-        "#,
+        ",
         2,
         usize
     );
@@ -1043,7 +1043,7 @@ fn list_walk_implements_position() {
 #[cfg(any(feature = "gen-llvm", feature = "gen-wasm", feature = "gen-dev"))]
 fn list_walk_until_even_prefix_sum() {
     assert_evals_to!(
-        r#"
+        r"
         helper = \a, b ->
             if Num.isEven b then
                 Continue (a + b)
@@ -1051,7 +1051,7 @@ fn list_walk_until_even_prefix_sum() {
             else
                 Break a
 
-        List.walkUntil [2, 4, 8, 9] 0 helper"#,
+        List.walkUntil [2, 4, 8, 9] 0 helper",
         2 + 4 + 8,
         i64
     );
@@ -1060,7 +1060,7 @@ fn list_walk_until_even_prefix_sum() {
 #[test]
 #[cfg(any(feature = "gen-llvm", feature = "gen-wasm", feature = "gen-dev"))]
 fn list_walk_from_sum() {
-    assert_evals_to!(r#"List.walkFrom [1, 2, 3] 1 0 Num.add"#, 5, i64);
+    assert_evals_to!(r"List.walkFrom [1, 2, 3] 1 0 Num.add", 5, i64);
 }
 
 #[test]
@@ -1068,13 +1068,13 @@ fn list_walk_from_sum() {
 fn list_keep_if_empty_list_of_int() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             empty : List I64
             empty =
                 []
 
             List.keepIf empty \_ -> Bool.true
-            "#
+            "
         ),
         RocList::<i64>::from_slice(&[]),
         RocList<i64>
@@ -1086,14 +1086,14 @@ fn list_keep_if_empty_list_of_int() {
 fn list_keep_if_empty_list() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             alwaysTrue : I64 -> Bool
             alwaysTrue = \_ ->
                 Bool.true
 
 
             List.keepIf [] alwaysTrue
-            "#
+            "
         ),
         RocList::<i64>::from_slice(&[]),
         RocList<i64>
@@ -1105,7 +1105,7 @@ fn list_keep_if_empty_list() {
 fn list_keep_if_always_true_for_non_empty_list() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             alwaysTrue : I64 -> Bool
             alwaysTrue = \_ ->
                 Bool.true
@@ -1115,7 +1115,7 @@ fn list_keep_if_always_true_for_non_empty_list() {
                 [1,2,3,4,5,6,7,8]
 
             List.keepIf oneThroughEight alwaysTrue
-            "#
+            "
         ),
         RocList::from_slice(&[1, 2, 3, 4, 5, 6, 7, 8]),
         RocList<i64>
@@ -1127,13 +1127,13 @@ fn list_keep_if_always_true_for_non_empty_list() {
 fn list_keep_if_always_false_for_non_empty_list() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             alwaysFalse : I64 -> Bool
             alwaysFalse = \_ ->
                 Bool.false
 
             List.keepIf [1,2,3,4,5,6,7,8] alwaysFalse
-            "#
+            "
         ),
         RocList::<i64>::from_slice(&[]),
         RocList<i64>
@@ -1145,13 +1145,13 @@ fn list_keep_if_always_false_for_non_empty_list() {
 fn list_keep_if_one() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             intIsLessThanThree : I64 -> Bool
             intIsLessThanThree = \i ->
                 i < 3
 
             List.keepIf [1,2,3,4,5,6,7,8] intIsLessThanThree
-            "#
+            "
         ),
         RocList::from_slice(&[1, 2]),
         RocList<i64>
@@ -1177,9 +1177,9 @@ fn list_keep_if_str_is_hello() {
 fn list_count_if_empty_list() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             List.countIf [] \_ -> Bool.true
-            "#
+            "
         ),
         0,
         usize
@@ -1191,7 +1191,7 @@ fn list_count_if_empty_list() {
 fn list_count_if_always_true_for_non_empty_list() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             alwaysTrue : I64 -> Bool
             alwaysTrue = \_ ->
                 Bool.true
@@ -1201,7 +1201,7 @@ fn list_count_if_always_true_for_non_empty_list() {
                 [1,2,3,4,5,6,7,8]
 
             List.countIf oneThroughEight alwaysTrue
-            "#
+            "
         ),
         8,
         usize
@@ -1213,13 +1213,13 @@ fn list_count_if_always_true_for_non_empty_list() {
 fn list_count_if_always_false_for_non_empty_list() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             alwaysFalse : I64 -> Bool
             alwaysFalse = \_ ->
                 Bool.false
 
             List.countIf [1,2,3,4,5,6,7,8] alwaysFalse
-            "#
+            "
         ),
         0,
         usize
@@ -1231,13 +1231,13 @@ fn list_count_if_always_false_for_non_empty_list() {
 fn list_count_if_condition() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             intIsLessThanThree : I64 -> Bool
             intIsLessThanThree = \i ->
                 i < 3
 
             List.countIf [1,2,3,4,5,6,7,8] intIsLessThanThree
-            "#
+            "
         ),
         2,
         usize
@@ -1263,13 +1263,13 @@ fn list_count_if_str() {
 fn list_map_on_empty_list_with_int_layout() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             empty : List I64
             empty =
                 []
 
             List.map empty (\x -> x)
-            "#
+            "
         ),
         RocList::<i64>::from_slice(&[]),
         RocList<i64>
@@ -1281,13 +1281,13 @@ fn list_map_on_empty_list_with_int_layout() {
 fn list_map_on_non_empty_list() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             nonEmpty : List I64
             nonEmpty =
                 [1]
 
             List.map nonEmpty (\x -> x)
-            "#
+            "
         ),
         RocList::from_slice(&[1]),
         RocList<i64>
@@ -1299,13 +1299,13 @@ fn list_map_on_non_empty_list() {
 fn list_map_changes_input() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             nonEmpty : List I64
             nonEmpty =
                 [1]
 
             List.map nonEmpty (\x -> x + 1)
-            "#
+            "
         ),
         RocList::from_slice(&[2]),
         RocList<i64>
@@ -1317,13 +1317,13 @@ fn list_map_changes_input() {
 fn list_map_on_big_list() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             nonEmpty : List I64
             nonEmpty =
                 [1, 2, 3, 4, 5, 1, 2, 3, 4, 5, 1, 2, 3, 4, 5, 1, 2, 3, 4, 5, 1, 2, 3, 4, 5]
 
             List.map nonEmpty (\x -> x * 2)
-            "#
+            "
         ),
         RocList::from_slice(&[
             2, 4, 6, 8, 10, 2, 4, 6, 8, 10, 2, 4, 6, 8, 10, 2, 4, 6, 8, 10, 2, 4, 6, 8, 10
@@ -1337,14 +1337,14 @@ fn list_map_on_big_list() {
 fn list_map_with_type_change() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             nonEmpty : List I64
             nonEmpty =
                 [1, 1, -4, 1, 2]
 
 
             List.map nonEmpty (\x -> x > 0)
-            "#
+            "
         ),
         RocList::from_slice(&[true, true, false, true, true]),
         RocList<bool>
@@ -1356,7 +1356,7 @@ fn list_map_with_type_change() {
 fn list_map_using_defined_function() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
              nonEmpty : List I64
              nonEmpty =
                  [2, 2, -4, 2, 3]
@@ -1366,7 +1366,7 @@ fn list_map_using_defined_function() {
                  i > 1
 
              List.map nonEmpty greaterThanOne
-             "#
+             "
         ),
         RocList::from_slice(&[true, true, false, true, true]),
         RocList<bool>
@@ -1378,9 +1378,9 @@ fn list_map_using_defined_function() {
 fn list_map_all_inline() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             List.map [] (\x -> x > 0)
-            "#
+            "
         ),
         RocList::<bool>::from_slice(&[]),
         RocList<bool>
@@ -1392,7 +1392,7 @@ fn list_map_all_inline() {
 fn list_map_closure_int() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             int : I64
             int = 123
 
@@ -1401,7 +1401,7 @@ fn list_map_closure_int() {
                 [0]
 
             List.map single (\x -> x + int)
-            "#
+            "
         ),
         RocList::from_slice(&[123]),
         RocList<i64>
@@ -1413,7 +1413,7 @@ fn list_map_closure_int() {
 fn list_map_closure_float() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             float : F64
             float = 1.23
 
@@ -1422,7 +1422,7 @@ fn list_map_closure_float() {
                 [0]
 
             List.map single (\x -> x + float)
-            "#
+            "
         ),
         RocList::from_slice(&[1.23]),
         RocList<f64>
@@ -1451,9 +1451,9 @@ fn list_map_closure_string() {
 fn list_map4_group() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             List.map4 [1,2,3] [3,2,1] [2,1,3] [3,1,2] (\a, b, c, d -> Group a b c d)
-            "#
+            "
         ),
         RocList::from_slice(&[[1, 3, 2, 3], [2, 2, 1, 1], [3, 1, 3, 2]]),
         RocList<[i64; 4]>
@@ -1484,9 +1484,9 @@ fn list_map4_different_length() {
 fn list_map3_group() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             List.map3 [1,2,3] [3,2,1] [2,1,3] (\a, b, c -> Group a b c)
-            "#
+            "
         ),
         RocList::from_slice(&[(1, 3, 2), (2, 2, 1), (3, 1, 3)]),
         RocList<(i64, i64, i64)>
@@ -1516,10 +1516,10 @@ fn list_map3_different_length() {
 fn list_map2_pair() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             f = (\a,b -> Pair a b)
             List.map2 [1,2,3] [3,2,1] f
-            "#
+            "
         ),
         RocList::from_slice(&[(1, 3), (2, 2), (3, 1)]),
         RocList<(i64, i64)>
@@ -1588,7 +1588,7 @@ fn list_join_two_non_empty_lists_of_float() {
 fn list_join_to_big_list() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 List.join
                     [
                         [1.2f64, 1.1],
@@ -1599,7 +1599,7 @@ fn list_join_to_big_list() {
                         [3.0, 4.0, 5.0, 6.1, 9.0],
                         [3.0, 4.0, 5.0, 6.1, 9.0]
                    ]
-            "#
+            "
         ),
         RocList::from_slice(&[
             1.2, 1.1, 2.1, 2.2, 3.0, 4.0, 5.0, 6.1, 9.0, 3.0, 4.0, 5.0, 6.1, 9.0, 3.0, 4.0, 5.0,
@@ -1614,13 +1614,13 @@ fn list_join_to_big_list() {
 fn list_join_defined_empty_list() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 empty : List F64
                 empty =
                     []
 
                 List.join [[0.2, 11.11], empty]
-            "#
+            "
         ),
         RocList::from_slice(&[0.2, 11.11]),
         RocList<f64>
@@ -1685,13 +1685,13 @@ fn list_repeat() {
 
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 noStrs : List Str
                 noStrs =
                     []
 
                 List.repeat noStrs 2
-            "#
+            "
         ),
         RocList::from_slice(&[RocList::<i64>::default(), RocList::default()]),
         RocList<RocList<i64>>
@@ -1725,13 +1725,13 @@ fn list_reverse() {
 fn list_reverse_empty_list_of_int() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 emptyList : List I64
                 emptyList =
                     []
 
                 List.reverse emptyList
-            "#
+            "
         ),
         RocList::<i64>::from_slice(&[]),
         RocList<i64>
@@ -1763,7 +1763,7 @@ fn list_concat_two_empty_lists() {
 fn list_concat_two_empty_lists_of_int() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 firstList : List I64
                 firstList =
                     []
@@ -1773,7 +1773,7 @@ fn list_concat_two_empty_lists_of_int() {
                     []
 
                 List.concat firstList secondList
-            "#
+            "
         ),
         RocList::<i64>::from_slice(&[]),
         RocList<i64>
@@ -1918,11 +1918,11 @@ fn basic_int_list_len() {
 fn loaded_int_list_len() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 nums = [2, 4, 6]
 
                 List.len nums
-            "#
+            "
         ),
         3,
         usize
@@ -1934,13 +1934,13 @@ fn loaded_int_list_len() {
 fn fn_int_list_len() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 getLen = \list -> List.len list
 
                 nums = [2, 4, 6, 8]
 
                 getLen nums
-            "#
+            "
         ),
         4,
         usize
@@ -1964,9 +1964,9 @@ fn empty_list_is_empty() {
 fn first_int_list() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             List.first [12, 9, 6, 3]
-            "#
+            "
         ),
         RocResult::ok(12),
         RocResult<i64, ()>
@@ -1992,9 +1992,9 @@ fn first_str_list() {
 fn first_wildcard_empty_list() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             List.last [] |> Result.map (\_ -> 0i64)
-            "#
+            "
         ),
         RocResult::err(()),
         RocResult<i64, ()>
@@ -2006,12 +2006,12 @@ fn first_wildcard_empty_list() {
 fn first_empty_list() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             list : List I64
             list = []
 
             List.first list
-            "#
+            "
         ),
         RocResult::err(()),
         RocResult<i64, ()>
@@ -2023,9 +2023,9 @@ fn first_empty_list() {
 fn last_int_list() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             List.last [12, 9, 6, 3]
-            "#
+            "
         ),
         RocResult::ok(3),
         RocResult<i64, ()>
@@ -2037,9 +2037,9 @@ fn last_int_list() {
 fn last_wildcard_empty_list() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             List.last [] |> Result.map (\_ -> 0i64)
-            "#
+            "
         ),
         RocResult::err(()),
         RocResult<i64, ()>
@@ -2051,12 +2051,12 @@ fn last_wildcard_empty_list() {
 fn last_empty_list() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             list : List I64
             list = []
 
             List.last list
-            "#
+            "
         ),
         RocResult::err(()),
         RocResult<i64, ()>
@@ -2068,12 +2068,12 @@ fn last_empty_list() {
 fn get_empty_list() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             list : List I64
             list = []
 
             List.get list 0
-            "#
+            "
         ),
         RocResult::err(()),
         RocResult<i64, ()>
@@ -2088,10 +2088,10 @@ fn get_wildcard_empty_list() {
     // would make the test pointless. Therefore, we must explicitly change the type on the roc side
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             List.get [] 0
             |> Result.map (\_ -> {})
-            "#
+            "
         ),
         RocResult::err(()),
         RocResult<(), ()>
@@ -2117,9 +2117,9 @@ fn get_str_list_ok() {
 fn get_int_list_ok() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             List.get [12, 9, 6] 1
-            "#
+            "
         ),
         RocResult::ok(9),
         RocResult<i64, ()>
@@ -2131,9 +2131,9 @@ fn get_int_list_ok() {
 fn get_int_list_oob() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             List.get [12, 9, 6] 1000
-            "#
+            "
         ),
         RocResult::err(()),
         RocResult<i64, ()>
@@ -2145,10 +2145,10 @@ fn get_int_list_oob() {
 fn replace_unique_int_list() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 record = List.replace [12, 9, 7, 1, 5] 2 33
                 record.list
-            "#
+            "
         ),
         RocList::from_slice(&[12, 9, 33, 1, 5]),
         RocList<i64>
@@ -2160,10 +2160,10 @@ fn replace_unique_int_list() {
 fn replace_unique_int_list_out_of_bounds() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 record = List.replace [12, 9, 7, 1, 5] 5 33
                 record.value
-            "#
+            "
         ),
         33,
         i64
@@ -2175,10 +2175,10 @@ fn replace_unique_int_list_out_of_bounds() {
 fn replace_unique_int_list_get_old_value() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 record = List.replace [12, 9, 7, 1, 5] 2 33
                 record.value
-            "#
+            "
         ),
         7,
         i64
@@ -2190,12 +2190,12 @@ fn replace_unique_int_list_get_old_value() {
 fn replace_unique_get_large_value() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 list : List { a : U64, b: U64, c: U64, d: U64 }
                 list = [{ a: 1, b: 2, c: 3, d: 4 }, { a: 5, b: 6, c: 7, d: 8 }, { a: 9, b: 10, c: 11, d: 12 }]
                 record = List.replace list 1 { a: 13, b: 14, c: 15, d: 16 }
                 record.value
-            "#
+            "
         ),
         [5, 6, 7, 8],
         [u64; 4]
@@ -2207,7 +2207,7 @@ fn replace_unique_get_large_value() {
 fn replace_shared_int_list() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             wrapper = \shared ->
                 # This should not mutate the original
                 replaced = (List.replace shared 1 7.7).list
@@ -2224,7 +2224,7 @@ fn replace_shared_int_list() {
                 { x, y }
 
             wrapper [2.1f64, 4.3]
-            "#
+            "
         ),
         (7.7, 4.3),
         (f64, f64)
@@ -2236,9 +2236,9 @@ fn replace_shared_int_list() {
 fn get_set_unique_int_list_i64() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             List.get (List.set [12, 9, 7, 3] 1 42) 1
-            "#
+            "
         ),
         RocResult::ok(42),
         RocResult<i64, ()>
@@ -2250,9 +2250,9 @@ fn get_set_unique_int_list_i64() {
 fn get_set_unique_int_list_i8() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             List.get (List.set [12, 9, 7, 3] 1 42i8) 1
-            "#
+            "
         ),
         RocResult::ok(42),
         RocResult<i8, ()>
@@ -2284,7 +2284,7 @@ fn set_unique_list_oob() {
 fn set_shared_int_list() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             wrapper = \shared ->
                 # This should not mutate the original
                 x =
@@ -2300,7 +2300,7 @@ fn set_shared_int_list() {
                 { x, y }
 
             wrapper [2.1f64, 4.3]
-            "#
+            "
         ),
         (7.7, 4.3),
         (f64, f64)
@@ -2312,7 +2312,7 @@ fn set_shared_int_list() {
 fn set_shared_list_oob() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             shared = [2, 4]
 
             # This List.set is out of bounds, and should have no effect
@@ -2327,7 +2327,7 @@ fn set_shared_list_oob() {
                     Err _ -> 0
 
             { x, y }
-            "#
+            "
         ),
         (4, 4),
         (i64, i64)
@@ -2339,11 +2339,11 @@ fn set_shared_list_oob() {
 fn get_unique_int_list() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 unique = [2, 4]
 
                 List.get unique 1
-            "#
+            "
         ),
         RocResult::ok(4),
         RocResult<i64, ()>
@@ -2355,12 +2355,12 @@ fn get_unique_int_list() {
 fn gen_wrap_len() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 wrapLen = \list ->
                     [List.len list]
 
                 wrapLen [1, 7, 9]
-            "#
+            "
         ),
         RocList::from_slice(&[3]),
         RocList<usize>
@@ -2372,12 +2372,12 @@ fn gen_wrap_len() {
 fn gen_wrap_first() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 wrapFirst = \list ->
                     [List.first list]
 
                 wrapFirst [1, 2]
-            "#
+            "
         ),
         RocList::from_slice(&[1]),
         RocList<i64>
@@ -2389,7 +2389,7 @@ fn gen_wrap_first() {
 fn gen_duplicate() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 # Duplicate the first element into the second index
                 dupe = \list ->
                     when List.first list is
@@ -2400,7 +2400,7 @@ fn gen_duplicate() {
                             []
 
                 dupe [1, 2]
-            "#
+            "
         ),
         RocList::from_slice(&[1, 1]),
         RocList<i64>
@@ -2668,12 +2668,12 @@ fn quicksort_singleton() {
 fn empty_list_increment_decrement() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             x : List I64
             x = []
 
             List.len x + List.len x
-            "#
+            "
         ),
         0,
         usize
@@ -2685,12 +2685,12 @@ fn empty_list_increment_decrement() {
 fn list_literal_increment_decrement() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             x : List I64
             x = [1,2,3]
 
             List.len x + List.len x
-            "#
+            "
         ),
         6,
         usize
@@ -2702,7 +2702,7 @@ fn list_literal_increment_decrement() {
 fn list_pass_to_function() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             x : List I64
             x = [1,2,3]
 
@@ -2710,7 +2710,7 @@ fn list_pass_to_function() {
             id = \y -> y
 
             id x
-            "#
+            "
         ),
         RocList::from_slice(&[1, 2, 3]),
         RocList<i64>
@@ -2722,7 +2722,7 @@ fn list_pass_to_function() {
 fn list_pass_to_set() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             x : List I64
             x = [1,2,3]
 
@@ -2730,7 +2730,7 @@ fn list_pass_to_set() {
             id = \y -> List.set y 0 0
 
             id x
-            "#
+            "
         ),
         RocList::from_slice(&[0, 2, 3]),
         RocList<i64>
@@ -2742,13 +2742,13 @@ fn list_pass_to_set() {
 fn list_wrap_in_tag() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             id : List I64 -> [Pair (List I64) I64]
             id = \y -> Pair y 4
 
             when id [1,2,3] is
                 Pair v _ -> v
-            "#
+            "
         ),
         RocList::from_slice(&[1, 2, 3]),
         RocList<i64>
@@ -2784,7 +2784,7 @@ fn list_contains_str() {
 fn list_manual_range() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             range : I64, I64, List I64-> List I64
             range = \low, high, accum ->
                 if low < high then
@@ -2793,7 +2793,7 @@ fn list_manual_range() {
                     accum
 
             range 0 5 [42]
-            "#
+            "
         ),
         RocList::from_slice(&[42, 0, 1, 2, 3, 4]),
         RocList<i64>
@@ -2805,10 +2805,10 @@ fn list_manual_range() {
 fn list_min() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             List.min []
             |> Result.map (\_ -> {})
-            "#
+            "
         ),
         RocResult::err(()),
         RocResult<(), ()>
@@ -2816,9 +2816,9 @@ fn list_min() {
 
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             List.min [3, 1, 2]
-            "#
+            "
         ),
         RocResult::ok(1),
         RocResult<i64, ()>
@@ -2830,10 +2830,10 @@ fn list_min() {
 fn list_max() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             List.max []
             |> Result.map (\_ -> {})
-            "#
+            "
         ),
         RocResult::err(()),
         RocResult<(), ()>
@@ -2841,9 +2841,9 @@ fn list_max() {
 
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             List.max [3, 1, 2]
-            "#
+            "
         ),
         RocResult::ok(3),
         RocResult<i64, ()>
@@ -2928,9 +2928,9 @@ fn list_keep_errs() {
     );
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             List.keepErrs [0,1,2] (\x -> Num.remChecked x 0 |> Result.mapErr (\_ -> 32))
-            "#
+            "
         ),
         RocList::from_slice(&[32, 32, 32]),
         RocList<i64>
@@ -2959,14 +2959,14 @@ fn list_map_with_index() {
 fn cleanup_because_exception() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             x = [1,2]
 
             five : I64
             five = 5
 
             five + Num.maxI64 + 3 + (Num.intCast (List.len x))
-               "#
+               "
         ),
         9,
         i64
@@ -3084,9 +3084,9 @@ fn map_with_index_multi_record() {
     // see https://github.com/roc-lang/roc/issues/1700
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             List.mapWithIndex [{ x: {}, y: {} }] \_, _ -> {}
-            "#
+            "
         ),
         RocList::from_slice(&[((), ())]),
         RocList<((), ())>
@@ -3245,9 +3245,9 @@ fn list_find_empty_typed_list() {
 fn list_find_empty_layout() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             List.findFirst [] \_ -> Bool.true
-            "#
+            "
         ),
         // [Ok [], Err [NotFound]] gets unwrapped all the way to just [NotFound],
         // which is the unit!
@@ -3257,9 +3257,9 @@ fn list_find_empty_layout() {
 
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             List.findLast [] \_ -> Bool.true
-            "#
+            "
         ),
         // [Ok [], Err [NotFound]] gets unwrapped all the way to just [NotFound],
         // which is the unit!
@@ -3329,11 +3329,11 @@ fn list_find_index_not_found() {
 fn list_find_index_empty_typed_list() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             when List.findFirstIndex [] (\s -> Str.countGraphemes s > 5) is
                 Ok v -> v
                 Err _ -> 999
-            "#
+            "
         ),
         999,
         usize
@@ -3341,11 +3341,11 @@ fn list_find_index_empty_typed_list() {
 
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             when List.findLastIndex [] (\s -> Str.countGraphemes s > 5) is
                 Ok v -> v
                 Err _ -> 999
-            "#
+            "
         ),
         999,
         usize
@@ -3357,9 +3357,9 @@ fn list_find_index_empty_typed_list() {
 fn list_ends_with_empty() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             List.endsWith [] []
-            "#
+            "
         ),
         true,
         bool
@@ -3435,9 +3435,9 @@ fn list_ends_with_nonempty() {
 fn list_starts_with_empty() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             List.startsWith [] []
-            "#
+            "
         ),
         true,
         bool
@@ -3513,14 +3513,14 @@ fn list_starts_with_nonempty() {
 fn monomorphized_lists() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             l = \{} -> [1, 2, 3]
 
             f : List U8, List U16 -> Nat
             f = \_, _ -> 18
 
             f (l {}) (l {})
-            "#
+            "
         ),
         18,
         usize
@@ -3532,12 +3532,12 @@ fn monomorphized_lists() {
 fn with_capacity() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             l : List U64
             l = List.withCapacity 10
 
             l
-            "#
+            "
         ),
         // Equality check for RocList does not account for capacity
         (10, RocList::with_capacity(10)),
@@ -3552,13 +3552,13 @@ fn with_capacity_append() {
     // see https://github.com/roc-lang/roc/issues/1732
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             List.withCapacity 10
                 |> List.append 0u64
                 |> List.append 1u64
                 |> List.append 2u64
                 |> List.append 3u64
-            "#
+            "
         ),
         (10, RocList::from_slice(&[0, 1, 2, 3])),
         RocList<u64>,
@@ -3571,9 +3571,9 @@ fn with_capacity_append() {
 fn reserve() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             List.reserve [] 15
-            "#
+            "
         ),
         (15, RocList::empty()),
         RocList<u64>,
@@ -3586,11 +3586,11 @@ fn reserve() {
 fn reserve_unchanged() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             a = []
             b = List.reserve a 15
             {a, b}
-            "#
+            "
         ),
         // a's capacity is unchanged when we reserve 15 more capcity
         // both lists are empty.
@@ -3610,10 +3610,10 @@ fn reserve_unchanged() {
 fn release_excess_capacity() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             List.reserve [] 15
             |> List.releaseExcessCapacity
-            "#
+            "
         ),
         (0, RocList::empty()),
         RocList<u64>,
@@ -3626,10 +3626,10 @@ fn release_excess_capacity() {
 fn release_excess_capacity_with_len() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             List.reserve [1] 50
             |> List.releaseExcessCapacity
-            "#
+            "
         ),
         (1, RocList::from_slice(&[1])),
         RocList<u64>,
@@ -3642,9 +3642,9 @@ fn release_excess_capacity_with_len() {
 fn release_excess_capacity_empty() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             List.releaseExcessCapacity []
-            "#
+            "
         ),
         (0, RocList::empty()),
         RocList<u64>,
@@ -3657,11 +3657,11 @@ fn release_excess_capacity_empty() {
 fn call_function_in_empty_list() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             lst : List ({} -> {})
             lst = []
             List.map lst \f -> f {}
-            "#
+            "
         ),
         RocList::from_slice(&[]),
         RocList<()>
@@ -3673,10 +3673,10 @@ fn call_function_in_empty_list() {
 fn call_function_in_empty_list_unbound() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             lst = []
             List.map lst \f -> f {}
-            "#
+            "
         ),
         RocList::from_slice(&[]),
         RocList<()>
@@ -3720,9 +3720,9 @@ fn issue_3571_lowlevel_call_function_with_bool_lambda_set() {
 fn issue_3530_uninitialized_capacity_in_list_literal() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             [11,22,33]
-            "#
+            "
         ),
         3,
         (usize, usize, usize),
@@ -3754,7 +3754,7 @@ fn list_infer_usage() {
 #[cfg(any(feature = "gen-llvm", feature = "gen-wasm", feature = "gen-dev"))]
 fn list_walk_backwards_implements_position() {
     assert_evals_to!(
-        r#"
+        r"
         Option a : [Some a, None]
 
         find : List a, a -> Option Nat where a implements Eq
@@ -3772,7 +3772,7 @@ fn list_walk_backwards_implements_position() {
         when find [1, 2, 3] 3 is
             None -> 0
             Some v -> v
-        "#,
+        ",
         0,
         usize
     );
@@ -3782,7 +3782,7 @@ fn list_walk_backwards_implements_position() {
 #[cfg(any(feature = "gen-llvm", feature = "gen-wasm", feature = "gen-dev"))]
 fn list_walk_backwards_until_sum() {
     assert_evals_to!(
-        r#"List.walkBackwardsUntil [1, 2] 0 \a,b -> Continue (a + b)"#,
+        r"List.walkBackwardsUntil [1, 2] 0 \a,b -> Continue (a + b)",
         3,
         i64
     );
@@ -3792,7 +3792,7 @@ fn list_walk_backwards_until_sum() {
 #[cfg(any(feature = "gen-llvm", feature = "gen-wasm", feature = "gen-dev"))]
 fn list_walk_backwards_until_even_prefix_sum() {
     assert_evals_to!(
-        r#"
+        r"
         helper = \a, b ->
             if Num.isEven b then
                 Continue (a + b)
@@ -3800,7 +3800,7 @@ fn list_walk_backwards_until_even_prefix_sum() {
             else
                 Break a
 
-        List.walkBackwardsUntil [9, 8, 4, 2] 0 helper"#,
+        List.walkBackwardsUntil [9, 8, 4, 2] 0 helper",
         2 + 4 + 8,
         i64
     );
@@ -3810,7 +3810,7 @@ fn list_walk_backwards_until_even_prefix_sum() {
 #[cfg(any(feature = "gen-llvm", feature = "gen-wasm", feature = "gen-dev"))]
 fn list_walk_from_until_sum() {
     assert_evals_to!(
-        r#"List.walkFromUntil [1, 2, 3, 4] 2 0 \a,b -> Continue (a + b)"#,
+        r"List.walkFromUntil [1, 2, 3, 4] 2 0 \a,b -> Continue (a + b)",
         7,
         i64
     );
@@ -3820,7 +3820,7 @@ fn list_walk_from_until_sum() {
 #[cfg(any(feature = "gen-llvm", feature = "gen-wasm", feature = "gen-dev"))]
 fn concat_unique_to_nonunique_overlapping_issue_4697() {
     assert_evals_to!(
-        r#"
+        r"
         # originalList is shared, but others is unique.
         # When we concat originalList with others, others should be re-used.
 
@@ -3828,7 +3828,7 @@ fn concat_unique_to_nonunique_overlapping_issue_4697() {
         others = [2u8, 3u8, 4u8]
         new = List.concat originalList others
         {a: originalList, b: new}
-        "#,
+        ",
         (
             RocList::from_slice(&[1u8]),
             RocList::from_slice(&[1u8, 2, 3, 4]),
@@ -3841,7 +3841,7 @@ fn concat_unique_to_nonunique_overlapping_issue_4697() {
 #[cfg(any(feature = "gen-llvm", feature = "gen-wasm", feature = "gen-dev"))]
 fn list_walk_from_even_prefix_sum() {
     assert_evals_to!(
-        r#"
+        r"
         helper = \a, b ->
             if Num.isEven b then
                 Continue (a + b)
@@ -3849,7 +3849,7 @@ fn list_walk_from_even_prefix_sum() {
             else
                 Break a
 
-        List.walkFromUntil [2, 4, 8, 9] 1 0 helper"#,
+        List.walkFromUntil [2, 4, 8, 9] 1 0 helper",
         4 + 8,
         i64
     );
@@ -3864,9 +3864,9 @@ fn list_walk_from_even_prefix_sum() {
 fn list_range_length_overflow() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             List.range {start: At 255u8, end: Length 2}
-               "#
+               "
         ),
         RocList::<u8>::default(),
         RocList::<u8>
@@ -3892,13 +3892,13 @@ mod pattern_match {
     #[test]
     fn unary_exact_size_match() {
         assert_evals_to!(
-            r#"
+            r"
             helper = \l -> when l is
                 [] -> 1u8
                 _ -> 2u8
 
             [ helper [], helper [{}] ]
-            "#,
+            ",
             RocList::from_slice(&[1, 2]),
             RocList<u8>
         )
@@ -3907,7 +3907,7 @@ mod pattern_match {
     #[test]
     fn many_exact_size_match() {
         assert_evals_to!(
-            r#"
+            r"
             helper = \l -> when l is
                 [] -> 1u8
                 [_] -> 2u8
@@ -3916,7 +3916,7 @@ mod pattern_match {
                 _ -> 5u8
 
             [ helper [], helper [{}], helper [{}, {}], helper [{}, {}, {}], helper [{}, {}, {}, {}] ]
-            "#,
+            ",
             RocList::from_slice(&[1, 2, 3, 4, 5]),
             RocList<u8>
         )
@@ -3926,7 +3926,7 @@ mod pattern_match {
     fn ranged_matches_head() {
         with_larger_debug_stack(|| {
             assert_evals_to!(
-                r#"
+                r"
                 helper = \l -> when l is
                     [] -> 1u8
                     [A] -> 2u8
@@ -3941,7 +3941,7 @@ mod pattern_match {
                     helper [A, B], helper [A, B, A], helper [A, B, B], helper [A, B, A, B],
                     helper [B], helper [B, A], helper [B, B], helper [B, A, B, B],
                 ]
-                "#,
+                ",
                 RocList::from_slice(&[
                     1, //
                     2, //
@@ -3958,7 +3958,7 @@ mod pattern_match {
     fn ranged_matches_tail() {
         with_larger_debug_stack(|| {
             assert_evals_to!(
-                r#"
+                r"
                 helper = \l -> when l is
                     [] -> 1u8
                     [A] -> 2u8
@@ -3973,7 +3973,7 @@ mod pattern_match {
                     helper [B, A], helper [A, B, A], helper [B, B, A], helper [B, A, B, A],
                     helper [B], helper [A, B], helper [B, B], helper [B, A, B, B],
                 ]
-                "#,
+                ",
                 RocList::from_slice(&[
                     1, //
                     2, //
@@ -3989,7 +3989,7 @@ mod pattern_match {
     #[test]
     fn bind_variables() {
         assert_evals_to!(
-            r#"
+            r"
             helper : List U16 -> U16
             helper = \l -> when l is
                 [] -> 1
@@ -4003,7 +4003,7 @@ mod pattern_match {
                 helper [3, 5], helper [3, 5, 7],
                 helper [2, 3, 5, 7], helper [11, 2, 3, 5, 7], helper [13, 11, 2, 3, 5, 7],
             ]
-            "#,
+            ",
             RocList::from_slice(&[
                 1, //
                 5, //
@@ -4017,7 +4017,7 @@ mod pattern_match {
     #[test]
     fn order_list_size_tests_issue_4732() {
         assert_evals_to!(
-            r#"
+            r"
             helper : List U8 -> U8
             helper = \l -> when l is
                 [1, ..]          -> 1
@@ -4046,7 +4046,7 @@ mod pattern_match {
 
                 helper [], helper [7],
             ]
-            "#,
+            ",
             RocList::from_slice(&[
                 1, 1, //
                 2, 2, //
@@ -4064,7 +4064,7 @@ mod pattern_match {
     #[test]
     fn rest_as() {
         assert_evals_to!(
-            r#"
+            r"
             helper : List U8 -> U8
             helper = \l -> when l is
                 [1, .. as rest, 1] -> helper rest
@@ -4078,7 +4078,7 @@ mod pattern_match {
                 helper [1, 1, 2, 4, 1],
                 helper [1, 1, 8, 7, 3, 1, 1, 1],
             ]
-            "#,
+            ",
             RocList::from_slice(&[0, 4, 6, 11]),
             RocList<u8>
         )

--- a/crates/compiler/test_gen/src/gen_num.rs
+++ b/crates/compiler/test_gen/src/gen_num.rs
@@ -18,12 +18,12 @@ use roc_std::{RocDec, RocOrder, RocResult};
 fn nat_alias() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             i : Num.Nat
             i = 1
 
             i
-            "#
+            "
         ),
         1,
         usize
@@ -35,12 +35,12 @@ fn nat_alias() {
 fn i128_signed_int_alias() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             i : I128
             i = 128
 
             i
-            "#
+            "
         ),
         128,
         i128
@@ -70,12 +70,12 @@ fn i64_signed_int_alias() {
 fn i32_signed_int_alias() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             i : I32
             i = 32
 
             i
-            "#
+            "
         ),
         32,
         i32
@@ -86,12 +86,12 @@ fn i32_signed_int_alias() {
 fn i16_signed_int_alias() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                     i : I16
                     i = 16
 
                     i
-                "#
+                "
         ),
         16,
         i16
@@ -102,12 +102,12 @@ fn i16_signed_int_alias() {
 fn i8_signed_int_alias() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                     i : I8
                     i = 8
 
                     i
-                "#
+                "
         ),
         8,
         i8
@@ -119,12 +119,12 @@ fn i8_signed_int_alias() {
 fn i128_hex_int_alias() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                     f : I128
                     f = 0x123
 
                     f
-                "#
+                "
         ),
         0x123,
         i128
@@ -135,12 +135,12 @@ fn i128_hex_int_alias() {
 fn i64_hex_int_alias() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                     f : I64
                     f = 0x123
 
                     f
-                "#
+                "
         ),
         0x123,
         i64
@@ -151,12 +151,12 @@ fn i64_hex_int_alias() {
 fn i32_hex_int_alias() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                     f : I32
                     f = 0x123
 
                     f
-                "#
+                "
         ),
         0x123,
         i32
@@ -167,12 +167,12 @@ fn i32_hex_int_alias() {
 fn i16_hex_int_alias() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                     f : I16
                     f = 0x123
 
                     f
-                "#
+                "
         ),
         0x123,
         i16
@@ -183,12 +183,12 @@ fn i16_hex_int_alias() {
 fn i8_hex_int_alias() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                     f : I8
                     f = 0xA
 
                     f
-                "#
+                "
         ),
         0xA,
         i8
@@ -200,12 +200,12 @@ fn i8_hex_int_alias() {
 fn u128_signed_int_alias() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                     i : U128
                     i = 128
 
                     i
-                "#
+                "
         ),
         128,
         u128
@@ -216,12 +216,12 @@ fn u128_signed_int_alias() {
 fn u64_signed_int_alias() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                     i : U64
                     i = 64
 
                     i
-                "#
+                "
         ),
         64,
         u64
@@ -232,12 +232,12 @@ fn u64_signed_int_alias() {
 fn u32_signed_int_alias() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                     i : U32
                     i = 32
 
                     i
-                "#
+                "
         ),
         32,
         u32
@@ -248,12 +248,12 @@ fn u32_signed_int_alias() {
 fn u16_signed_int_alias() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                     i : U16
                     i = 16
 
                     i
-                "#
+                "
         ),
         16,
         u16
@@ -264,12 +264,12 @@ fn u16_signed_int_alias() {
 fn u8_signed_int_alias() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                     i : U8
                     i = 8
 
                     i
-                "#
+                "
         ),
         8,
         u8
@@ -281,12 +281,12 @@ fn u8_signed_int_alias() {
 fn u128_hex_int_alias() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                     f : U128
                     f = 0x123
 
                     f
-                "#
+                "
         ),
         0x123,
         i128
@@ -297,12 +297,12 @@ fn u128_hex_int_alias() {
 fn u64_hex_int_alias() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                     f : U64
                     f = 0x123
 
                     f
-                "#
+                "
         ),
         0x123,
         u64
@@ -313,12 +313,12 @@ fn u64_hex_int_alias() {
 fn u32_hex_int_alias() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                     f : U32
                     f = 0x123
 
                     f
-                "#
+                "
         ),
         0x123,
         u32
@@ -329,12 +329,12 @@ fn u32_hex_int_alias() {
 fn u16_hex_int_alias() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                     f : U16
                     f = 0x123
 
                     f
-                "#
+                "
         ),
         0x123,
         u16
@@ -345,12 +345,12 @@ fn u16_hex_int_alias() {
 fn u8_hex_int_alias() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                     f : U8
                     f = 0xA
 
                     f
-                "#
+                "
         ),
         0xA,
         u8
@@ -361,11 +361,11 @@ fn u8_hex_int_alias() {
 fn character_literal() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                     x = 'A'
 
                     x
-                "#
+                "
         ),
         65,
         i64
@@ -376,11 +376,11 @@ fn character_literal() {
 fn character_literal_back_slash() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                     x = '\\'
 
                     x
-                "#
+                "
         ),
         92,
         i64
@@ -391,11 +391,11 @@ fn character_literal_back_slash() {
 fn character_literal_single_quote() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                     x = '\''
 
                     x
-                "#
+                "
         ),
         39,
         i64
@@ -406,11 +406,11 @@ fn character_literal_single_quote() {
 fn character_literal_new_line() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                     x = '\n'
 
                     x
-                "#
+                "
         ),
         10,
         i64
@@ -422,12 +422,12 @@ fn character_literal_new_line() {
 fn dec_float_alias() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                     x : Dec
                     x = 2.1
 
                     x
-                "#
+                "
         ),
         RocDec::from_str_to_i128_unsafe("2.1"),
         i128
@@ -439,12 +439,12 @@ fn dec_float_alias() {
 fn f64_float_alias() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                     f : F64
                     f = 3.6
 
                     f
-                "#
+                "
         ),
         3.6,
         f64
@@ -455,12 +455,12 @@ fn f64_float_alias() {
 fn f32_float_alias() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                     f : F32
                     f = 3.6
 
                     f
-                "#
+                "
         ),
         3.6,
         f32
@@ -580,9 +580,9 @@ fn various_sized_abs() {
 fn abs_min_int_overflow() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 Num.abs Num.minI64
-                "#
+                "
         ),
         0,
         i64
@@ -594,7 +594,7 @@ fn abs_min_int_overflow() {
 fn gen_if_fn() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                     limitedNegate = \num ->
                         x =
                             if num == 1 then
@@ -606,7 +606,7 @@ fn gen_if_fn() {
                         x
 
                     limitedNegate 1
-                "#
+                "
         ),
         -1,
         i64
@@ -618,9 +618,9 @@ fn gen_if_fn() {
 fn gen_float_eq() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                     1.0 == 1.0
-                "#
+                "
         ),
         true,
         bool
@@ -632,7 +632,7 @@ fn gen_float_eq() {
 fn gen_add_dec() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                     x : Dec
                     x = 2.1
 
@@ -643,7 +643,7 @@ fn gen_add_dec() {
                     z = x + y
 
                     z
-                "#
+                "
         ),
         RocDec::from_str_to_i128_unsafe("5.2"),
         i128
@@ -654,9 +654,9 @@ fn gen_add_dec() {
 fn gen_add_f32() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                     1.1f32 + 2.4f32 + 3
-                "#
+                "
         ),
         6.5,
         f32
@@ -667,9 +667,9 @@ fn gen_add_f32() {
 fn gen_add_f64() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                     1.1f64 + 2.4 + 3
-                "#
+                "
         ),
         6.5,
         f64
@@ -681,11 +681,11 @@ fn gen_add_f64() {
 fn gen_wrap_add_nums() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                     add2 = \num1, num2 -> num1 + num2
 
                     add2 4 5
-                "#
+                "
         ),
         9,
         i64
@@ -709,11 +709,11 @@ fn gen_div_f32() {
 fn gen_div_checked_f64() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                     when Num.divChecked 48 2f64 is
                         Ok val -> val
                         Err _ -> -1
-                "#
+                "
         ),
         24.0,
         f64
@@ -725,11 +725,11 @@ fn gen_div_checked_f64() {
 fn gen_div_checked_by_zero_f64() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                     when Num.divChecked 47 0f64 is
                         Ok val -> val
                         Err _ -> -1
-                "#
+                "
         ),
         -1.0,
         f64
@@ -741,7 +741,7 @@ fn gen_div_checked_by_zero_f64() {
 fn gen_div_dec() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                     x : Dec
                     x = 10
 
@@ -749,7 +749,7 @@ fn gen_div_dec() {
                     y = 3
 
                     x / y
-                "#
+                "
         ),
         RocDec::from_str_to_i128_unsafe("3.333333333333333333"),
         i128
@@ -761,7 +761,7 @@ fn gen_div_dec() {
 fn gen_div_checked_dec() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                     x : Dec
                     x = 10
 
@@ -771,7 +771,7 @@ fn gen_div_checked_dec() {
                     when Num.divChecked x y is
                         Ok val -> val
                         Err _ -> -1
-                "#
+                "
         ),
         RocDec::from_str_to_i128_unsafe("3.333333333333333333"),
         i128
@@ -782,7 +782,7 @@ fn gen_div_checked_dec() {
 fn gen_div_checked_by_zero_dec() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                     x : Dec
                     x = 10
 
@@ -792,7 +792,7 @@ fn gen_div_checked_by_zero_dec() {
                     when Num.divChecked x y is
                         Ok val -> val
                         Err _ -> -1
-                "#
+                "
         ),
         RocDec::from_str_to_i128_unsafe("-1"),
         i128
@@ -811,9 +811,9 @@ fn gen_div_dec_by_zero() {
 #[should_panic(expected = r#"Roc failed with message: "Integer division by 0!"#)]
 fn gen_div_ceil_by_zero() {
     assert_evals_to!(
-        r#"
+        r"
             Num.divCeil 5 0 == 0
-        "#,
+        ",
         false,
         bool
     );
@@ -824,9 +824,9 @@ fn gen_div_ceil_by_zero() {
 fn gen_int_eq() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                     4 == 4
-                "#
+                "
         ),
         true,
         bool
@@ -838,9 +838,9 @@ fn gen_int_eq() {
 fn gen_int_neq() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                     4 != 5
-                "#
+                "
         ),
         true,
         bool
@@ -870,7 +870,7 @@ fn float_greater_than() {
 fn gen_dec_eq() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                     x : Dec
                     x = 4
 
@@ -878,7 +878,7 @@ fn gen_dec_eq() {
                     y = 4
 
                     x == y
-                "#
+                "
         ),
         true,
         bool
@@ -890,7 +890,7 @@ fn gen_dec_eq() {
 fn gen_dec_neq() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                     x : Dec
                     x = 4
 
@@ -898,7 +898,7 @@ fn gen_dec_neq() {
                     y = 5
 
                     x != y
-                "#
+                "
         ),
         true,
         bool
@@ -910,13 +910,13 @@ fn gen_dec_neq() {
 fn gen_wrap_int_neq() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                     wrappedNotEq : a, a -> Bool where a implements Eq
                     wrappedNotEq = \num1, num2 ->
                         num1 != num2
 
                     wrappedNotEq 2 3
-                "#
+                "
         ),
         true,
         bool
@@ -928,9 +928,9 @@ fn gen_wrap_int_neq() {
 fn gen_add_i8() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                     1i8 + 2i8 + 3i8
-                "#
+                "
         ),
         6,
         i8
@@ -942,9 +942,9 @@ fn gen_add_i8() {
 fn gen_add_u8() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                     1u8 + 2u8 + 3u8
-                "#
+                "
         ),
         6,
         u8
@@ -956,9 +956,9 @@ fn gen_add_u8() {
 fn gen_add_i16() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                     1i16 + 2i16 + 3i16
-                "#
+                "
         ),
         6,
         i16
@@ -970,9 +970,9 @@ fn gen_add_i16() {
 fn gen_add_u16() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                     1u16 + 2u16 + 3u16
-                "#
+                "
         ),
         6,
         u16
@@ -984,9 +984,9 @@ fn gen_add_u16() {
 fn gen_add_i32() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                     1i32 + 2i32 + 3i32
-                "#
+                "
         ),
         6,
         i32
@@ -998,9 +998,9 @@ fn gen_add_i32() {
 fn gen_add_u32() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                     1u32 + 2u32 + 3u32
-                "#
+                "
         ),
         6,
         u32
@@ -1012,9 +1012,9 @@ fn gen_add_u32() {
 fn gen_add_i64() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                     1 + 2 + 3
-                "#
+                "
         ),
         6,
         i64
@@ -1026,7 +1026,7 @@ fn gen_add_i64() {
 fn gen_sub_dec() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                     x : Dec
                     x = 1.5
 
@@ -1037,7 +1037,7 @@ fn gen_sub_dec() {
                     z = 3
 
                     (x - y) - z
-                "#
+                "
         ),
         RocDec::from_str_to_i128_unsafe("-3.9"),
         i128
@@ -1049,7 +1049,7 @@ fn gen_sub_dec() {
 fn gen_mul_dec() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                     x : Dec
                     x = 2
 
@@ -1060,7 +1060,7 @@ fn gen_mul_dec() {
                     z = 6
 
                     x * y * z
-                "#
+                "
         ),
         RocDec::from_str_to_i128_unsafe("48.0"),
         i128
@@ -1168,11 +1168,11 @@ fn gen_div_u64() {
 fn gen_div_checked_i64() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                     when Num.divTruncChecked 1000 10 is
                         Ok val -> val
                         Err _ -> -1
-                "#
+                "
         ),
         100,
         i64
@@ -1184,11 +1184,11 @@ fn gen_div_checked_i64() {
 fn gen_div_checked_by_zero_i64() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                     when Num.divTruncChecked 1000 0 is
                         Err DivByZero -> 99
                         _ -> -24
-                "#
+                "
         ),
         99,
         i64
@@ -1206,11 +1206,11 @@ fn gen_rem_i64() {
 fn gen_rem_checked_div_by_zero_i64() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             when Num.remChecked 8 0 is
                 Err DivByZero -> 4
                 Ok _ -> -23
-            "#
+            "
         ),
         4,
         i64
@@ -1499,9 +1499,9 @@ fn gte_f64() {
 fn gen_order_of_arithmetic_ops() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                     1 + 3 * 7 - 2
-                "#
+                "
         ),
         20,
         i64
@@ -1513,9 +1513,9 @@ fn gen_order_of_arithmetic_ops() {
 fn gen_order_of_arithmetic_ops_complex_float() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                     3 - 48 * 2.0f64
-                "#
+                "
         ),
         -93.0,
         f64
@@ -1527,14 +1527,14 @@ fn gen_order_of_arithmetic_ops_complex_float() {
 fn if_guard_bind_variable_false() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 wrapper = \{} ->
                     when 10 is
                         x if x == 5 -> 0
                         _ -> 42
 
                 wrapper {}
-                "#
+                "
         ),
         42,
         i64
@@ -1546,14 +1546,14 @@ fn if_guard_bind_variable_false() {
 fn if_guard_bind_variable_true() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 wrapper = \{} ->
                     when 10 is
                         x if x == 10 -> 42
                         _ -> 0
 
                 wrapper {}
-                "#
+                "
         ),
         42,
         i64
@@ -1565,14 +1565,14 @@ fn if_guard_bind_variable_true() {
 fn tail_call_elimination() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                     sum = \n, accum ->
                         when n is
                             0 -> accum
                             _ -> sum (n - 1) (n + accum)
 
                     sum 1_000_000 0
-                "#
+                "
         ),
         500000500000,
         i64
@@ -1606,9 +1606,9 @@ fn int_negate() {
 fn neg_min_int_overflow() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 Num.neg Num.minI64
-                "#
+                "
         ),
         0,
         i64
@@ -1620,11 +1620,11 @@ fn neg_min_int_overflow() {
 fn gen_wrap_int_neg() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                     wrappedNeg = \num -> -num
 
                     wrappedNeg 3
-                "#
+                "
         ),
         -3,
         i64
@@ -1636,12 +1636,12 @@ fn gen_wrap_int_neg() {
 fn gen_basic_fn() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                     always42 : Num.Num (Num.Integer Num.Signed64) -> Num.Num (Num.Integer Num.Signed64)
                     always42 = \_ -> 42
 
                     always42 5
-                "#
+                "
         ),
         42,
         i64
@@ -1665,14 +1665,14 @@ fn num_to_frac() {
 fn num_to_frac_f64_to_f32() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                     f64 : F64
                     f64 = 9.0
 
                     f32 : F32
                     f32 = Num.toFrac f64
                     f32
-                "#
+                "
         ),
         9.0,
         f32
@@ -1684,7 +1684,7 @@ fn num_to_frac_f64_to_f32() {
 fn num_to_frac_f32_to_f32() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
 
                     arg : F32
                     arg = 9.0
@@ -1692,7 +1692,7 @@ fn num_to_frac_f32_to_f32() {
                     ret : F32
                     ret = Num.toFrac arg
                     ret
-                "#
+                "
         ),
         9.0,
         f32
@@ -1704,7 +1704,7 @@ fn num_to_frac_f32_to_f32() {
 fn num_to_frac_f64_to_f64() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
 
                     arg : F64
                     arg = 9.0
@@ -1712,7 +1712,7 @@ fn num_to_frac_f64_to_f64() {
                     ret : F64
                     ret = Num.toFrac arg
                     ret
-                "#
+                "
         ),
         9.0,
         f64
@@ -1724,7 +1724,7 @@ fn num_to_frac_f64_to_f64() {
 fn num_to_frac_f32_to_f64() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
 
                     f32 : F32
                     f32 = 9.0
@@ -1732,7 +1732,7 @@ fn num_to_frac_f32_to_f64() {
                     f64 : F64
                     f64 = Num.toFrac f32
                     f64
-                "#
+                "
         ),
         9.0,
         f64
@@ -1744,12 +1744,12 @@ fn num_to_frac_f32_to_f64() {
 fn float_to_float() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             x : F64
             x = Num.toFrac 0.5f64
 
             x
-            "#
+            "
         ),
         0.5,
         f64
@@ -1834,9 +1834,9 @@ fn atan() {
 fn int_add_overflow() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 9_223_372_036_854_775_807 + 1
-                "#
+                "
         ),
         0,
         i64
@@ -1937,11 +1937,11 @@ fn float_sub_overflow() {
 fn int_sub_checked() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 when Num.subChecked 5 2 is
                     Ok v -> v
                     _ -> -1
-                "#
+                "
         ),
         3,
         i64
@@ -1949,11 +1949,11 @@ fn int_sub_checked() {
 
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 when Num.subChecked Num.minI64 1 is
                     Err Overflow -> -1
                     Ok v -> v
-                "#
+                "
         ),
         -1,
         i64
@@ -1965,11 +1965,11 @@ fn int_sub_checked() {
 fn float_sub_checked() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 when Num.subChecked 1.0 0.0f64 is
                     Ok v -> v
                     Err Overflow -> -1.0
-                "#
+                "
         ),
         1.0,
         f64
@@ -1977,11 +1977,11 @@ fn float_sub_checked() {
 
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 when Num.subChecked -1.7976931348623157e308f64 1.7976931348623157e308 is
                     Err Overflow -> -1
                     Ok v -> v
-                "#
+                "
         ),
         -1.0,
         f64
@@ -1994,9 +1994,9 @@ fn float_sub_checked() {
 fn int_positive_mul_overflow() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 9_223_372_036_854_775_807 * 2
-                "#
+                "
         ),
         0,
         i64
@@ -2009,9 +2009,9 @@ fn int_positive_mul_overflow() {
 fn int_negative_mul_overflow() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 (-9_223_372_036_854_775_808) * 2
-                "#
+                "
         ),
         0,
         i64
@@ -2023,9 +2023,9 @@ fn int_negative_mul_overflow() {
 fn float_positive_mul_overflow() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                     1.7976931348623157e308f64 * 2
-                "#
+                "
         ),
         f64::INFINITY,
         f64
@@ -2037,9 +2037,9 @@ fn float_positive_mul_overflow() {
 fn float_negative_mul_overflow() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                     -1.7976931348623157e308f64 * 2
-                "#
+                "
         ),
         -f64::INFINITY,
         f64
@@ -2063,11 +2063,11 @@ fn int_mul_wrap_i128() {
 fn int_mul_checked() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 when Num.mulChecked 20 2 is
                     Ok v -> v
                     _ -> -1
-                "#
+                "
         ),
         40,
         i64
@@ -2075,11 +2075,11 @@ fn int_mul_checked() {
 
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 when Num.mulChecked Num.maxI64 2 is
                     Err Overflow -> -1
                     Ok v -> v
-                "#
+                "
         ),
         -1,
         i64
@@ -2091,11 +2091,11 @@ fn int_mul_checked() {
 fn float_mul_checked() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 when Num.mulChecked 20.0 2.0f64 is
                     Ok v -> v
                     Err Overflow -> -1.0
-                "#
+                "
         ),
         40.0,
         f64
@@ -2103,11 +2103,11 @@ fn float_mul_checked() {
 
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 when Num.mulChecked 1.7976931348623157e308f64 2 is
                     Err Overflow -> -1
                     Ok v -> v
-                "#
+                "
         ),
         -1.0,
         f64
@@ -2776,11 +2776,11 @@ fn bytes_to_u128_subtly_out_of_bounds() {
 fn bytes_to_u16_max_u8s() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 when Num.bytesToU16 [255, 255] 0 is
                     Ok v -> v
                     Err OutOfBounds -> 1
-                "#
+                "
         ),
         65535,
         u16
@@ -2792,11 +2792,11 @@ fn bytes_to_u16_max_u8s() {
 fn bytes_to_u16_min_u8s() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 when Num.bytesToU16 [0, 0] 0 is
                     Ok v -> v
                     Err OutOfBounds -> 1
-                "#
+                "
         ),
         0,
         u16
@@ -2808,11 +2808,11 @@ fn bytes_to_u16_min_u8s() {
 fn bytes_to_u16_random_u8s() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 when Num.bytesToU16 [164, 215] 0 is
                     Ok v -> v
                     Err OutOfBounds -> 1
-                "#
+                "
         ),
         55_204,
         u16
@@ -2824,11 +2824,11 @@ fn bytes_to_u16_random_u8s() {
 fn bytes_to_u32_min_u8s() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 when Num.bytesToU32 [0, 0, 0, 0] 0 is
                     Ok v -> v
                     Err OutOfBounds -> 1
-                "#
+                "
         ),
         0,
         u32
@@ -2840,11 +2840,11 @@ fn bytes_to_u32_min_u8s() {
 fn bytes_to_u32_max_u8s() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 when Num.bytesToU32 [255, 255, 255, 255] 0 is
                     Ok v -> v
                     Err OutOfBounds -> 1
-                "#
+                "
         ),
         4_294_967_295,
         u32
@@ -2856,11 +2856,11 @@ fn bytes_to_u32_max_u8s() {
 fn bytes_to_u32_random_u8s() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 when Num.bytesToU32 [252, 124, 128, 121] 0 is
                     Ok v -> v
                     Err OutOfBounds -> 1
-                "#
+                "
         ),
         2_038_463_740,
         u32
@@ -2872,11 +2872,11 @@ fn bytes_to_u32_random_u8s() {
 fn bytes_to_u64_min_u8s() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 when Num.bytesToU64 [0, 0, 0, 0, 0, 0, 0, 0] 0 is
                     Ok v -> v
                     Err OutOfBounds -> 1
-                "#
+                "
         ),
         0,
         u64
@@ -2888,11 +2888,11 @@ fn bytes_to_u64_min_u8s() {
 fn bytes_to_u64_max_u8s() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 when Num.bytesToU64 [255, 255, 255, 255, 255, 255, 255, 255] 0 is
                     Ok v -> v
                     Err OutOfBounds -> 1
-                "#
+                "
         ),
         18_446_744_073_709_551_615,
         u64
@@ -2904,11 +2904,11 @@ fn bytes_to_u64_max_u8s() {
 fn bytes_to_u64_random_u8s() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 when Num.bytesToU64 [252, 124, 128, 121, 1, 32, 177, 211] 0 is
                     Ok v -> v
                     Err OutOfBounds -> 1
-                "#
+                "
         ),
         15_254_008_603_586_100_476,
         u64
@@ -2920,11 +2920,11 @@ fn bytes_to_u64_random_u8s() {
 fn bytes_to_u128_min_u8s() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 when Num.bytesToU128 [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] 0 is
                     Ok v -> v
                     Err OutOfBounds -> 1
-                "#
+                "
         ),
         0,
         u128
@@ -2936,11 +2936,11 @@ fn bytes_to_u128_min_u8s() {
 fn bytes_to_u128_max_u8s() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 when Num.bytesToU128 [255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255] 0 is
                     Ok v -> v
                     Err OutOfBounds -> 1
-                "#
+                "
         ),
         340_282_366_920_938_463_463_374_607_431_768_211_455,
         u128
@@ -2952,11 +2952,11 @@ fn bytes_to_u128_max_u8s() {
 fn bytes_to_u128_random_u8s() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 when Num.bytesToU128 [252, 124, 128, 121, 1, 32, 177, 211, 3, 57, 203, 122, 95, 164, 23, 145] 0 is
                     Ok v -> v
                     Err OutOfBounds -> 1
-                "#
+                "
         ),
         192_860_816_096_412_392_720_639_456_393_488_792_828,
         u128
@@ -3014,20 +3014,20 @@ fn when_on_i16() {
 fn num_to_str() {
     use roc_std::RocStr;
 
-    assert_evals_to!(r#"Num.toStr 1234"#, RocStr::from("1234"), RocStr);
-    assert_evals_to!(r#"Num.toStr 0"#, RocStr::from("0"), RocStr);
-    assert_evals_to!(r#"Num.toStr -1"#, RocStr::from("-1"), RocStr);
+    assert_evals_to!(r"Num.toStr 1234", RocStr::from("1234"), RocStr);
+    assert_evals_to!(r"Num.toStr 0", RocStr::from("0"), RocStr);
+    assert_evals_to!(r"Num.toStr -1", RocStr::from("-1"), RocStr);
 
     let max = format!("{}", i64::MAX);
     assert_evals_to!(
-        r#"Num.toStr Num.maxI64"#,
+        r"Num.toStr Num.maxI64",
         RocStr::from(max.as_str()),
         RocStr
     );
 
     let min = format!("{}", i64::MIN);
     assert_evals_to!(
-        r#"Num.toStr Num.minI64"#,
+        r"Num.toStr Num.minI64",
         RocStr::from(min.as_str()),
         RocStr
     );
@@ -3038,12 +3038,12 @@ fn num_to_str() {
 fn num_to_str_u8() {
     use roc_std::RocStr;
 
-    assert_evals_to!(r#"Num.toStr 0u8"#, RocStr::from("0"), RocStr);
-    assert_evals_to!(r#"Num.toStr 1u8"#, RocStr::from("1"), RocStr);
-    assert_evals_to!(r#"Num.toStr 10u8"#, RocStr::from("10"), RocStr);
+    assert_evals_to!(r"Num.toStr 0u8", RocStr::from("0"), RocStr);
+    assert_evals_to!(r"Num.toStr 1u8", RocStr::from("1"), RocStr);
+    assert_evals_to!(r"Num.toStr 10u8", RocStr::from("10"), RocStr);
 
     let max = format!("{}", u8::MAX);
-    assert_evals_to!(r#"Num.toStr Num.maxU8"#, RocStr::from(max.as_str()), RocStr);
+    assert_evals_to!(r"Num.toStr Num.maxU8", RocStr::from(max.as_str()), RocStr);
 }
 
 #[test]
@@ -3051,13 +3051,13 @@ fn num_to_str_u8() {
 fn num_to_str_u16() {
     use roc_std::RocStr;
 
-    assert_evals_to!(r#"Num.toStr 0u16"#, RocStr::from("0"), RocStr);
-    assert_evals_to!(r#"Num.toStr 1u16"#, RocStr::from("1"), RocStr);
-    assert_evals_to!(r#"Num.toStr 10u16"#, RocStr::from("10"), RocStr);
+    assert_evals_to!(r"Num.toStr 0u16", RocStr::from("0"), RocStr);
+    assert_evals_to!(r"Num.toStr 1u16", RocStr::from("1"), RocStr);
+    assert_evals_to!(r"Num.toStr 10u16", RocStr::from("10"), RocStr);
 
     let max = format!("{}", u16::MAX);
     assert_evals_to!(
-        r#"Num.toStr Num.maxU16"#,
+        r"Num.toStr Num.maxU16",
         RocStr::from(max.as_str()),
         RocStr
     );
@@ -3068,13 +3068,13 @@ fn num_to_str_u16() {
 fn num_to_str_u32() {
     use roc_std::RocStr;
 
-    assert_evals_to!(r#"Num.toStr 0u32"#, RocStr::from("0"), RocStr);
-    assert_evals_to!(r#"Num.toStr 1u32"#, RocStr::from("1"), RocStr);
-    assert_evals_to!(r#"Num.toStr 10u32"#, RocStr::from("10"), RocStr);
+    assert_evals_to!(r"Num.toStr 0u32", RocStr::from("0"), RocStr);
+    assert_evals_to!(r"Num.toStr 1u32", RocStr::from("1"), RocStr);
+    assert_evals_to!(r"Num.toStr 10u32", RocStr::from("10"), RocStr);
 
     let max = format!("{}", u32::MAX);
     assert_evals_to!(
-        r#"Num.toStr Num.maxU32"#,
+        r"Num.toStr Num.maxU32",
         RocStr::from(max.as_str()),
         RocStr
     );
@@ -3085,13 +3085,13 @@ fn num_to_str_u32() {
 fn num_to_str_u64() {
     use roc_std::RocStr;
 
-    assert_evals_to!(r#"Num.toStr 0u64"#, RocStr::from("0"), RocStr);
-    assert_evals_to!(r#"Num.toStr 1u64"#, RocStr::from("1"), RocStr);
-    assert_evals_to!(r#"Num.toStr 10u64"#, RocStr::from("10"), RocStr);
+    assert_evals_to!(r"Num.toStr 0u64", RocStr::from("0"), RocStr);
+    assert_evals_to!(r"Num.toStr 1u64", RocStr::from("1"), RocStr);
+    assert_evals_to!(r"Num.toStr 10u64", RocStr::from("10"), RocStr);
 
     let max = format!("{}", u64::MAX);
     assert_evals_to!(
-        r#"Num.toStr Num.maxU64"#,
+        r"Num.toStr Num.maxU64",
         RocStr::from(max.as_str()),
         RocStr
     );
@@ -3102,17 +3102,17 @@ fn num_to_str_u64() {
 fn num_to_str_i8() {
     use roc_std::RocStr;
 
-    assert_evals_to!(r#"Num.toStr -10i8"#, RocStr::from("-10"), RocStr);
-    assert_evals_to!(r#"Num.toStr -1i8"#, RocStr::from("-1"), RocStr);
-    assert_evals_to!(r#"Num.toStr 0i8"#, RocStr::from("0"), RocStr);
-    assert_evals_to!(r#"Num.toStr 1i8"#, RocStr::from("1"), RocStr);
-    assert_evals_to!(r#"Num.toStr 10i8"#, RocStr::from("10"), RocStr);
+    assert_evals_to!(r"Num.toStr -10i8", RocStr::from("-10"), RocStr);
+    assert_evals_to!(r"Num.toStr -1i8", RocStr::from("-1"), RocStr);
+    assert_evals_to!(r"Num.toStr 0i8", RocStr::from("0"), RocStr);
+    assert_evals_to!(r"Num.toStr 1i8", RocStr::from("1"), RocStr);
+    assert_evals_to!(r"Num.toStr 10i8", RocStr::from("10"), RocStr);
 
     let max = format!("{}", i8::MAX);
-    assert_evals_to!(r#"Num.toStr Num.maxI8"#, RocStr::from(max.as_str()), RocStr);
+    assert_evals_to!(r"Num.toStr Num.maxI8", RocStr::from(max.as_str()), RocStr);
 
     let max = format!("{}", i8::MIN);
-    assert_evals_to!(r#"Num.toStr Num.minI8"#, RocStr::from(max.as_str()), RocStr);
+    assert_evals_to!(r"Num.toStr Num.minI8", RocStr::from(max.as_str()), RocStr);
 }
 
 #[test]
@@ -3120,22 +3120,22 @@ fn num_to_str_i8() {
 fn num_to_str_i16() {
     use roc_std::RocStr;
 
-    assert_evals_to!(r#"Num.toStr -10i16"#, RocStr::from("-10"), RocStr);
-    assert_evals_to!(r#"Num.toStr -1i16"#, RocStr::from("-1"), RocStr);
-    assert_evals_to!(r#"Num.toStr 0i16"#, RocStr::from("0"), RocStr);
-    assert_evals_to!(r#"Num.toStr 1i16"#, RocStr::from("1"), RocStr);
-    assert_evals_to!(r#"Num.toStr 10i16"#, RocStr::from("10"), RocStr);
+    assert_evals_to!(r"Num.toStr -10i16", RocStr::from("-10"), RocStr);
+    assert_evals_to!(r"Num.toStr -1i16", RocStr::from("-1"), RocStr);
+    assert_evals_to!(r"Num.toStr 0i16", RocStr::from("0"), RocStr);
+    assert_evals_to!(r"Num.toStr 1i16", RocStr::from("1"), RocStr);
+    assert_evals_to!(r"Num.toStr 10i16", RocStr::from("10"), RocStr);
 
     let max = format!("{}", i16::MAX);
     assert_evals_to!(
-        r#"Num.toStr Num.maxI16"#,
+        r"Num.toStr Num.maxI16",
         RocStr::from(max.as_str()),
         RocStr
     );
 
     let max = format!("{}", i16::MIN);
     assert_evals_to!(
-        r#"Num.toStr Num.minI16"#,
+        r"Num.toStr Num.minI16",
         RocStr::from(max.as_str()),
         RocStr
     );
@@ -3146,22 +3146,22 @@ fn num_to_str_i16() {
 fn num_to_str_i32() {
     use roc_std::RocStr;
 
-    assert_evals_to!(r#"Num.toStr -10i32"#, RocStr::from("-10"), RocStr);
-    assert_evals_to!(r#"Num.toStr -1i32"#, RocStr::from("-1"), RocStr);
-    assert_evals_to!(r#"Num.toStr 0i32"#, RocStr::from("0"), RocStr);
-    assert_evals_to!(r#"Num.toStr 1i32"#, RocStr::from("1"), RocStr);
-    assert_evals_to!(r#"Num.toStr 10i32"#, RocStr::from("10"), RocStr);
+    assert_evals_to!(r"Num.toStr -10i32", RocStr::from("-10"), RocStr);
+    assert_evals_to!(r"Num.toStr -1i32", RocStr::from("-1"), RocStr);
+    assert_evals_to!(r"Num.toStr 0i32", RocStr::from("0"), RocStr);
+    assert_evals_to!(r"Num.toStr 1i32", RocStr::from("1"), RocStr);
+    assert_evals_to!(r"Num.toStr 10i32", RocStr::from("10"), RocStr);
 
     let max = format!("{}", i32::MAX);
     assert_evals_to!(
-        r#"Num.toStr Num.maxI32"#,
+        r"Num.toStr Num.maxI32",
         RocStr::from(max.as_str()),
         RocStr
     );
 
     let max = format!("{}", i32::MIN);
     assert_evals_to!(
-        r#"Num.toStr Num.minI32"#,
+        r"Num.toStr Num.minI32",
         RocStr::from(max.as_str()),
         RocStr
     );
@@ -3172,22 +3172,22 @@ fn num_to_str_i32() {
 fn num_to_str_i64() {
     use roc_std::RocStr;
 
-    assert_evals_to!(r#"Num.toStr -10i64"#, RocStr::from("-10"), RocStr);
-    assert_evals_to!(r#"Num.toStr -1i64"#, RocStr::from("-1"), RocStr);
-    assert_evals_to!(r#"Num.toStr 0i64"#, RocStr::from("0"), RocStr);
-    assert_evals_to!(r#"Num.toStr 1i64"#, RocStr::from("1"), RocStr);
-    assert_evals_to!(r#"Num.toStr 10i64"#, RocStr::from("10"), RocStr);
+    assert_evals_to!(r"Num.toStr -10i64", RocStr::from("-10"), RocStr);
+    assert_evals_to!(r"Num.toStr -1i64", RocStr::from("-1"), RocStr);
+    assert_evals_to!(r"Num.toStr 0i64", RocStr::from("0"), RocStr);
+    assert_evals_to!(r"Num.toStr 1i64", RocStr::from("1"), RocStr);
+    assert_evals_to!(r"Num.toStr 10i64", RocStr::from("10"), RocStr);
 
     let max = format!("{}", i64::MAX);
     assert_evals_to!(
-        r#"Num.toStr Num.maxI64"#,
+        r"Num.toStr Num.maxI64",
         RocStr::from(max.as_str()),
         RocStr
     );
 
     let max = format!("{}", i64::MIN);
     assert_evals_to!(
-        r#"Num.toStr Num.minI64"#,
+        r"Num.toStr Num.minI64",
         RocStr::from(max.as_str()),
         RocStr
     );
@@ -3198,20 +3198,20 @@ fn num_to_str_i64() {
 fn num_to_str_f32() {
     use roc_std::RocStr;
 
-    assert_evals_to!(r#"Num.toStr -10.75f32"#, RocStr::from("-10.75"), RocStr);
-    assert_evals_to!(r#"Num.toStr -1.75f32"#, RocStr::from("-1.75"), RocStr);
-    assert_evals_to!(r#"Num.toStr 0f32"#, RocStr::from("0"), RocStr);
-    assert_evals_to!(r#"Num.toStr 1.75f32"#, RocStr::from("1.75"), RocStr);
-    assert_evals_to!(r#"Num.toStr 10.75f32"#, RocStr::from("10.75"), RocStr);
+    assert_evals_to!(r"Num.toStr -10.75f32", RocStr::from("-10.75"), RocStr);
+    assert_evals_to!(r"Num.toStr -1.75f32", RocStr::from("-1.75"), RocStr);
+    assert_evals_to!(r"Num.toStr 0f32", RocStr::from("0"), RocStr);
+    assert_evals_to!(r"Num.toStr 1.75f32", RocStr::from("1.75"), RocStr);
+    assert_evals_to!(r"Num.toStr 10.75f32", RocStr::from("10.75"), RocStr);
 
     assert_evals_to!(
-        r#"Num.toStr Num.maxF32"#,
+        r"Num.toStr Num.maxF32",
         RocStr::from("340282346638528860000000000000000000000"),
         RocStr
     );
 
     assert_evals_to!(
-        r#"Num.toStr Num.minF32"#,
+        r"Num.toStr Num.minF32",
         RocStr::from("-340282346638528860000000000000000000000"),
         RocStr
     );
@@ -3222,20 +3222,20 @@ fn num_to_str_f32() {
 fn num_to_str_f64() {
     use roc_std::RocStr;
 
-    assert_evals_to!(r#"Num.toStr -10.75f64"#, RocStr::from("-10.75"), RocStr);
-    assert_evals_to!(r#"Num.toStr -1.75f64"#, RocStr::from("-1.75"), RocStr);
-    assert_evals_to!(r#"Num.toStr 0f64"#, RocStr::from("0"), RocStr);
-    assert_evals_to!(r#"Num.toStr 1.75f64"#, RocStr::from("1.75"), RocStr);
-    assert_evals_to!(r#"Num.toStr 10.75f64"#, RocStr::from("10.75"), RocStr);
+    assert_evals_to!(r"Num.toStr -10.75f64", RocStr::from("-10.75"), RocStr);
+    assert_evals_to!(r"Num.toStr -1.75f64", RocStr::from("-1.75"), RocStr);
+    assert_evals_to!(r"Num.toStr 0f64", RocStr::from("0"), RocStr);
+    assert_evals_to!(r"Num.toStr 1.75f64", RocStr::from("1.75"), RocStr);
+    assert_evals_to!(r"Num.toStr 10.75f64", RocStr::from("10.75"), RocStr);
 
     assert_evals_to!(
-        r#"Num.toStr Num.maxF64"#,
+        r"Num.toStr Num.maxF64",
         RocStr::from(f64::MAX.to_string().as_str()),
         RocStr
     );
 
     assert_evals_to!(
-        r#"Num.toStr Num.minF64"#,
+        r"Num.toStr Num.minF64",
         RocStr::from(f64::MIN.to_string().as_str()),
         RocStr
     );
@@ -3246,20 +3246,20 @@ fn num_to_str_f64() {
 fn num_to_str_dec() {
     use roc_std::RocStr;
 
-    assert_evals_to!(r#"Num.toStr -10.75dec"#, RocStr::from("-10.75"), RocStr);
-    assert_evals_to!(r#"Num.toStr -1.75dec"#, RocStr::from("-1.75"), RocStr);
-    assert_evals_to!(r#"Num.toStr 0dec"#, RocStr::from("0.0"), RocStr);
-    assert_evals_to!(r#"Num.toStr 1.75dec"#, RocStr::from("1.75"), RocStr);
-    assert_evals_to!(r#"Num.toStr 10.75dec"#, RocStr::from("10.75"), RocStr);
+    assert_evals_to!(r"Num.toStr -10.75dec", RocStr::from("-10.75"), RocStr);
+    assert_evals_to!(r"Num.toStr -1.75dec", RocStr::from("-1.75"), RocStr);
+    assert_evals_to!(r"Num.toStr 0dec", RocStr::from("0.0"), RocStr);
+    assert_evals_to!(r"Num.toStr 1.75dec", RocStr::from("1.75"), RocStr);
+    assert_evals_to!(r"Num.toStr 10.75dec", RocStr::from("10.75"), RocStr);
 
     assert_evals_to!(
-        r#"Num.toStr 170141183460469.105727dec"#,
+        r"Num.toStr 170141183460469.105727dec",
         RocStr::from("170141183460469.105727"),
         RocStr
     );
 
     assert_evals_to!(
-        r#"Num.toStr -170141183460469.105727dec"#,
+        r"Num.toStr -170141183460469.105727dec",
         RocStr::from("-170141183460469.105727"),
         RocStr
     );
@@ -3270,13 +3270,13 @@ fn num_to_str_dec() {
 fn u8_addition_greater_than_i8() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             x : U8
             x = 100
             y : U8
             y = 100
             x + y
-            "#
+            "
         ),
         200,
         u8
@@ -3288,13 +3288,13 @@ fn u8_addition_greater_than_i8() {
 fn u8_sub_greater_than_i8() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             x : U8
             x = 255
             y : U8
             y = 55
             x - y
-            "#
+            "
         ),
         200,
         u8
@@ -3306,13 +3306,13 @@ fn u8_sub_greater_than_i8() {
 fn u8_mul_greater_than_i8() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             x : U8
             x = 40
             y : U8
             y = 5
             x * y
-            "#
+            "
         ),
         200,
         u8
@@ -3324,13 +3324,13 @@ fn u8_mul_greater_than_i8() {
 fn add_saturated() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             x : U8
             x = 200
             y : U8
             y = 200
             Num.addSaturated x y
-            "#
+            "
         ),
         255,
         u8
@@ -3338,13 +3338,13 @@ fn add_saturated() {
 
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             x : I8
             x = 100
             y : I8
             y = 100
             Num.addSaturated x y
-            "#
+            "
         ),
         127,
         i8
@@ -3352,13 +3352,13 @@ fn add_saturated() {
 
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             x : I8
             x = -100
             y : I8
             y = -100
             Num.addSaturated x y
-            "#
+            "
         ),
         -128,
         i8
@@ -3370,39 +3370,39 @@ fn add_saturated() {
 fn sub_saturated() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             x : U8
             x = 10
             y : U8
             y = 20
             Num.subSaturated x y
-            "#
+            "
         ),
         0,
         u8
     );
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             x : I8
             x = -100
             y : I8
             y = 100
             Num.subSaturated x y
-            "#
+            "
         ),
         -128,
         i8
     );
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             x : I8
             x = 100
             y : I8
             y = -100
             Num.subSaturated x y
-            "#
+            "
         ),
         127,
         i8
@@ -3414,65 +3414,65 @@ fn sub_saturated() {
 fn mul_saturated() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             x : U8
             x = 20
             y : U8
             y = 20
             Num.mulSaturated x y
-            "#
+            "
         ),
         255,
         u8
     );
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             x : I8
             x = -20
             y : I8
             y = -20
             Num.mulSaturated x y
-            "#
+            "
         ),
         127,
         i8
     );
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             x : I8
             x = 20
             y : I8
             y = -20
             Num.mulSaturated x y
-            "#
+            "
         ),
         -128,
         i8
     );
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             x : I8
             x = -20
             y : I8
             y = 20
             Num.mulSaturated x y
-            "#
+            "
         ),
         -128,
         i8
     );
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             x : I8
             x = 20
             y : I8
             y = 20
             Num.mulSaturated x y
-            "#
+            "
         ),
         127,
         i8
@@ -3484,14 +3484,14 @@ fn mul_saturated() {
 fn monomorphized_ints() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             x = 100
 
             f : U8, U32 -> Nat
             f = \_, _ -> 18
 
             f x x
-            "#
+            "
         ),
         18,
         usize
@@ -3503,14 +3503,14 @@ fn monomorphized_ints() {
 fn monomorphized_floats() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             x = 100.0
 
             f : F32, F64 -> Nat
             f = \_, _ -> 18
 
             f x x
-            "#
+            "
         ),
         18,
         usize
@@ -3522,7 +3522,7 @@ fn monomorphized_floats() {
 fn monomorphized_ints_names_dont_conflict() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             f : U8 -> Nat
             f = \_ -> 9
             x =
@@ -3534,7 +3534,7 @@ fn monomorphized_ints_names_dont_conflict() {
                 f n
 
             x + y
-            "#
+            "
         ),
         18,
         usize
@@ -3573,14 +3573,14 @@ fn monomorphized_ints_aliased() {
 fn to_float_f32() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             n : U8
             n = 100
 
             f : F32
             f = Num.toFrac n
             f
-            "#
+            "
         ),
         100.,
         f32
@@ -3592,14 +3592,14 @@ fn to_float_f32() {
 fn to_float_f64() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             n : U8
             n = 100
 
             f : F64
             f = Num.toFrac n
             f
-            "#
+            "
         ),
         100.,
         f64
@@ -3612,9 +3612,9 @@ fn to_float_f64() {
 fn upcast_of_int_is_zext() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             Num.toU16 0b1000_0000u8
-            "#
+            "
         ),
         128,
         u16
@@ -3627,11 +3627,11 @@ fn upcast_of_int_is_zext() {
 fn upcast_of_int_checked_is_zext() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             when Num.toU16Checked 0b1000_0000u8 is
                 Ok 128u16 -> 1u8
                 _ -> 0u8
-            "#
+            "
         ),
         1,
         u8
@@ -3643,9 +3643,9 @@ fn upcast_of_int_checked_is_zext() {
 fn modulo_of_unsigned() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             0b1111_1111u8 % 64
-            "#
+            "
         ),
         63,
         u8
@@ -3657,9 +3657,9 @@ fn modulo_of_unsigned() {
 fn div_of_unsigned() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             0b1111_1111u8 // 2
-            "#
+            "
         ),
         127,
         u8
@@ -3671,9 +3671,9 @@ fn div_of_unsigned() {
 fn dec_float_suffix() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             123.0dec
-            "#
+            "
         ),
         RocDec::from_str_to_i128_unsafe("123.0"),
         i128
@@ -3685,9 +3685,9 @@ fn dec_float_suffix() {
 fn dec_no_decimal() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             3dec
-            "#
+            "
         ),
         RocDec::from_str_to_i128_unsafe("3.0"),
         i128
@@ -3699,11 +3699,11 @@ fn dec_no_decimal() {
 fn ceiling_to_u32() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             n : U32
             n = Num.ceiling 124.5f64
             n
-            "#
+            "
         ),
         125,
         u32
@@ -3715,11 +3715,11 @@ fn ceiling_to_u32() {
 fn floor_to_u32() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             n : U32
             n = Num.floor 124.5f64
             n
-            "#
+            "
         ),
         124,
         u32
@@ -3731,11 +3731,11 @@ fn floor_to_u32() {
 fn round_to_u32() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             n : U32
             n = Num.round 124.49f64
             n
-            "#
+            "
         ),
         124,
         u32
@@ -3747,9 +3747,9 @@ fn round_to_u32() {
 fn promote_u64_number_layout() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             9999999999999999999 + 1
-            "#
+            "
         ),
         10000000000000000000,
         u64
@@ -3761,12 +3761,12 @@ fn promote_u64_number_layout() {
 fn promote_i128_number_layout() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             {
                 a: 18446744073709551616 + 1,
                 b: -9223372036854775809 + 1,
             }
-            "#
+            "
         ),
         (18446744073709551617, -9223372036854775808),
         (i128, i128)
@@ -3778,9 +3778,9 @@ fn promote_i128_number_layout() {
 fn promote_u128_number_layout() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             170141183460469231731687303715884105728 + 1
-            "#
+            "
         ),
         170141183460469231731687303715884105729,
         u128
@@ -3792,13 +3792,13 @@ fn promote_u128_number_layout() {
 fn when_on_decimals() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             when 42.42dec is
                 42.42 -> 42
                 0.05 -> 1
                 3.14 -> 2
                 _ -> 4
-            "#
+            "
         ),
         42,
         i64
@@ -3806,12 +3806,12 @@ fn when_on_decimals() {
 
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             when 42.42dec is
                 0.05 -> 1
                 3.14 -> 2
                 _ -> 4
-            "#
+            "
         ),
         4,
         i64
@@ -3823,13 +3823,13 @@ fn when_on_decimals() {
 fn when_on_i128() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             when 1701411834604692317316873037158841057i128 is
                 1701411834604692317316873037158841057 -> 42
                 32 -> 1
                 64 -> 2
                 _ -> 4
-            "#
+            "
         ),
         42,
         i64
@@ -3841,13 +3841,13 @@ fn when_on_i128() {
 fn when_on_u128() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             when 170141183460469231731687303715884105728u128 is
                 170141183460469231731687303715884105728u128 -> 42
                 32 -> 1
                 64 -> 2
                 _ -> 4
-            "#
+            "
         ),
         42,
         i64
@@ -3859,10 +3859,10 @@ fn when_on_u128() {
 fn condition_polymorphic_num_becomes_float() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             x = if Bool.true then 2 else 3
             x * 5f32
-            "#
+            "
         ),
         10.,
         f32
@@ -3872,79 +3872,79 @@ fn condition_polymorphic_num_becomes_float() {
 #[test]
 #[cfg(any(feature = "gen-llvm", feature = "gen-wasm", feature = "gen-dev"))]
 fn num_count_leading_zero_bits() {
-    assert_evals_to!(r#"Num.countLeadingZeroBits 0b0010_1000u8"#, 2, u8);
-    assert_evals_to!(r#"Num.countLeadingZeroBits 0b0010_1000u16"#, 10, u8);
-    assert_evals_to!(r#"Num.countLeadingZeroBits 0b0010_1000u32"#, 26, u8);
-    assert_evals_to!(r#"Num.countLeadingZeroBits 0b0010_1000u64"#, 58, u8);
+    assert_evals_to!(r"Num.countLeadingZeroBits 0b0010_1000u8", 2, u8);
+    assert_evals_to!(r"Num.countLeadingZeroBits 0b0010_1000u16", 10, u8);
+    assert_evals_to!(r"Num.countLeadingZeroBits 0b0010_1000u32", 26, u8);
+    assert_evals_to!(r"Num.countLeadingZeroBits 0b0010_1000u64", 58, u8);
 }
 
 #[test]
 #[cfg(any(feature = "gen-llvm", feature = "gen-wasm", feature = "gen-dev"))]
 fn num_count_trailing_zero_bits() {
-    assert_evals_to!(r#"Num.countTrailingZeroBits 0b0010_1000u8"#, 3, u8);
-    assert_evals_to!(r#"Num.countTrailingZeroBits 0b0010_0000u16"#, 5, u8);
-    assert_evals_to!(r#"Num.countTrailingZeroBits 0u32"#, 32, u8);
-    assert_evals_to!(r#"Num.countTrailingZeroBits 0b0010_1111u64"#, 0, u8);
+    assert_evals_to!(r"Num.countTrailingZeroBits 0b0010_1000u8", 3, u8);
+    assert_evals_to!(r"Num.countTrailingZeroBits 0b0010_0000u16", 5, u8);
+    assert_evals_to!(r"Num.countTrailingZeroBits 0u32", 32, u8);
+    assert_evals_to!(r"Num.countTrailingZeroBits 0b0010_1111u64", 0, u8);
 }
 
 #[test]
 #[cfg(any(feature = "gen-llvm", feature = "gen-wasm", feature = "gen-dev"))]
 fn num_count_one_bits() {
-    assert_evals_to!(r#"Num.countOneBits 0b0010_1000u8"#, 2, u8);
-    assert_evals_to!(r#"Num.countOneBits 0b0010_0000u16"#, 1, u8);
-    assert_evals_to!(r#"Num.countOneBits 0u32"#, 0, u8);
-    assert_evals_to!(r#"Num.countOneBits 0b0010_1111u64"#, 5, u8);
+    assert_evals_to!(r"Num.countOneBits 0b0010_1000u8", 2, u8);
+    assert_evals_to!(r"Num.countOneBits 0b0010_0000u16", 1, u8);
+    assert_evals_to!(r"Num.countOneBits 0u32", 0, u8);
+    assert_evals_to!(r"Num.countOneBits 0b0010_1111u64", 5, u8);
 }
 
 #[test]
 #[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
 fn num_abs_diff_int() {
-    assert_evals_to!(r#"Num.absDiff 0u8 0u8"#, 0, u8);
-    assert_evals_to!(r#"Num.absDiff 1u8 2u8"#, 1, u8);
-    assert_evals_to!(r#"Num.absDiff 2u8 1u8"#, 1, u8);
-    assert_evals_to!(r#"Num.absDiff -1 1"#, 2, i64);
-    assert_evals_to!(r#"Num.absDiff 1 -1"#, 2, i64);
-    assert_evals_to!(r#"Num.absDiff Num.minI64 -1"#, i64::MAX, i64);
+    assert_evals_to!(r"Num.absDiff 0u8 0u8", 0, u8);
+    assert_evals_to!(r"Num.absDiff 1u8 2u8", 1, u8);
+    assert_evals_to!(r"Num.absDiff 2u8 1u8", 1, u8);
+    assert_evals_to!(r"Num.absDiff -1 1", 2, i64);
+    assert_evals_to!(r"Num.absDiff 1 -1", 2, i64);
+    assert_evals_to!(r"Num.absDiff Num.minI64 -1", i64::MAX, i64);
 }
 
 #[test]
 #[cfg(feature = "gen-llvm")]
 fn num_abs_diff_large_bits() {
-    assert_evals_to!(r#"Num.absDiff 0u128 0u128"#, 0, u128);
-    assert_evals_to!(r#"Num.absDiff 1u128 2u128"#, 1, u128);
-    assert_evals_to!(r#"Num.absDiff -1i128 1i128"#, 2, i128);
-    assert_evals_to!(r#"Num.absDiff Num.minI128 -1i128"#, i128::MAX, i128);
+    assert_evals_to!(r"Num.absDiff 0u128 0u128", 0, u128);
+    assert_evals_to!(r"Num.absDiff 1u128 2u128", 1, u128);
+    assert_evals_to!(r"Num.absDiff -1i128 1i128", 2, i128);
+    assert_evals_to!(r"Num.absDiff Num.minI128 -1i128", i128::MAX, i128);
 }
 
 #[test]
 #[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
 fn num_abs_diff_float() {
-    assert_evals_to!(r#"Num.absDiff 0.0f64 0.0"#, 0.0, f64);
-    assert_evals_to!(r#"Num.absDiff 1.0f64 2.0"#, 1.0, f64);
-    assert_evals_to!(r#"Num.absDiff 2.0f64 1.0"#, 1.0, f64);
-    assert_evals_to!(r#"Num.absDiff -1.0f64 1.0"#, 2.0, f64);
-    assert_evals_to!(r#"Num.absDiff 1.0f64 -1.0"#, 2.0, f64);
+    assert_evals_to!(r"Num.absDiff 0.0f64 0.0", 0.0, f64);
+    assert_evals_to!(r"Num.absDiff 1.0f64 2.0", 1.0, f64);
+    assert_evals_to!(r"Num.absDiff 2.0f64 1.0", 1.0, f64);
+    assert_evals_to!(r"Num.absDiff -1.0f64 1.0", 2.0, f64);
+    assert_evals_to!(r"Num.absDiff 1.0f64 -1.0", 2.0, f64);
 }
 
 #[test]
 #[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
 #[should_panic(expected = r#"Roc failed with message: "Integer subtraction overflowed!"#)]
 fn num_abs_max_overflow() {
-    assert_evals_to!(r#"Num.absDiff Num.maxI64 -1"#, 0, i64);
+    assert_evals_to!(r"Num.absDiff Num.maxI64 -1", 0, i64);
 }
 
 #[test]
 #[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
 #[should_panic(expected = r#"Roc failed with message: "Integer subtraction overflowed!"#)]
 fn num_abs_int_min_overflow() {
-    assert_evals_to!(r#"Num.absDiff Num.minI64 0"#, 0, i64);
+    assert_evals_to!(r"Num.absDiff Num.minI64 0", 0, i64);
 }
 
 #[test]
 #[cfg(feature = "gen-llvm")]
 #[should_panic(expected = r#"Roc failed with message: "Integer subtraction overflowed!"#)]
 fn num_abs_large_bits_min_overflow() {
-    assert_evals_to!(r#"Num.absDiff Num.minI128 0"#, 0, i128);
+    assert_evals_to!(r"Num.absDiff Num.minI128 0", 0, i128);
 }
 
 #[test]
@@ -3982,9 +3982,9 @@ fn bool_in_switch() {
 fn add_checked_dec() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             Num.addChecked 2.0dec 4.0dec
-            "#
+            "
         ),
         RocResult::ok(RocDec::from(6)),
         RocResult<RocDec, ()>
@@ -3996,9 +3996,9 @@ fn add_checked_dec() {
 fn sub_checked_dec() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             Num.subChecked 5.0dec 2.0dec
-            "#
+            "
         ),
         RocResult::ok(RocDec::from(3)),
         RocResult<RocDec, ()>
@@ -4010,9 +4010,9 @@ fn sub_checked_dec() {
 fn mul_checked_dec() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             Num.mulChecked 5.0dec 2.0dec
-            "#
+            "
         ),
         RocResult::ok(RocDec::from_str("10.0").unwrap()),
         RocResult<RocDec, ()>
@@ -4024,12 +4024,12 @@ fn mul_checked_dec() {
 fn mul_checked_u128() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             x : Result U128 [ Overflow ]
             x = Num.mulChecked 5u128 2u128
 
             x
-            "#
+            "
         ),
         RocResult::ok(5u128 * 2u128),
         RocResult<u128, ()>
@@ -4041,12 +4041,12 @@ fn mul_checked_u128() {
 fn sub_checked_u128() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             x : Result U128 [ Overflow ]
             x = Num.subChecked 5u128 2u128
 
             x
-            "#
+            "
         ),
         RocResult::ok(5u128 - 2u128),
         RocResult<u128, ()>
@@ -4058,12 +4058,12 @@ fn sub_checked_u128() {
 fn add_checked_u128() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             x : Result U128 [ Overflow ]
             x = Num.addChecked 5u128 2u128
 
             x
-            "#
+            "
         ),
         RocResult::ok(5u128 + 2u128),
         RocResult<u128, ()>
@@ -4073,23 +4073,23 @@ fn add_checked_u128() {
 #[test]
 #[cfg(any(feature = "gen-llvm", feature = "gen-dev", feature = "gen-wasm"))]
 fn num_min() {
-    assert_evals_to!(r#"Num.min 0 0"#, 0, i64);
-    assert_evals_to!(r#"Num.min 1 2"#, 1, i64);
-    assert_evals_to!(r#"Num.min 2 1"#, 1, i64);
-    assert_evals_to!(r#"Num.min 2 -2"#, -2, i64);
-    assert_evals_to!(r#"Num.min -2 2"#, -2, i64);
-    assert_evals_to!(r#"Num.min Num.minI64 Num.maxI64"#, i64::MIN, i64);
-    assert_evals_to!(r#"Num.min Num.maxI64 Num.minI64"#, i64::MIN, i64);
+    assert_evals_to!(r"Num.min 0 0", 0, i64);
+    assert_evals_to!(r"Num.min 1 2", 1, i64);
+    assert_evals_to!(r"Num.min 2 1", 1, i64);
+    assert_evals_to!(r"Num.min 2 -2", -2, i64);
+    assert_evals_to!(r"Num.min -2 2", -2, i64);
+    assert_evals_to!(r"Num.min Num.minI64 Num.maxI64", i64::MIN, i64);
+    assert_evals_to!(r"Num.min Num.maxI64 Num.minI64", i64::MIN, i64);
 }
 
 #[test]
 #[cfg(any(feature = "gen-llvm", feature = "gen-dev", feature = "gen-wasm"))]
 fn num_max() {
-    assert_evals_to!(r#"Num.max 0 0"#, 0, i64);
-    assert_evals_to!(r#"Num.max 1 2"#, 2, i64);
-    assert_evals_to!(r#"Num.max 2 1"#, 2, i64);
-    assert_evals_to!(r#"Num.max 2 -2"#, 2, i64);
-    assert_evals_to!(r#"Num.max -2 2"#, 2, i64);
-    assert_evals_to!(r#"Num.max Num.minI64 Num.maxI64"#, i64::MAX, i64);
-    assert_evals_to!(r#"Num.max Num.maxI64 Num.minI64"#, i64::MAX, i64);
+    assert_evals_to!(r"Num.max 0 0", 0, i64);
+    assert_evals_to!(r"Num.max 1 2", 2, i64);
+    assert_evals_to!(r"Num.max 2 1", 2, i64);
+    assert_evals_to!(r"Num.max 2 -2", 2, i64);
+    assert_evals_to!(r"Num.max -2 2", 2, i64);
+    assert_evals_to!(r"Num.max Num.minI64 Num.maxI64", i64::MAX, i64);
+    assert_evals_to!(r"Num.max Num.maxI64 Num.minI64", i64::MAX, i64);
 }

--- a/crates/compiler/test_gen/src/gen_num.rs
+++ b/crates/compiler/test_gen/src/gen_num.rs
@@ -3019,18 +3019,10 @@ fn num_to_str() {
     assert_evals_to!(r"Num.toStr -1", RocStr::from("-1"), RocStr);
 
     let max = format!("{}", i64::MAX);
-    assert_evals_to!(
-        r"Num.toStr Num.maxI64",
-        RocStr::from(max.as_str()),
-        RocStr
-    );
+    assert_evals_to!(r"Num.toStr Num.maxI64", RocStr::from(max.as_str()), RocStr);
 
     let min = format!("{}", i64::MIN);
-    assert_evals_to!(
-        r"Num.toStr Num.minI64",
-        RocStr::from(min.as_str()),
-        RocStr
-    );
+    assert_evals_to!(r"Num.toStr Num.minI64", RocStr::from(min.as_str()), RocStr);
 }
 
 #[test]
@@ -3056,11 +3048,7 @@ fn num_to_str_u16() {
     assert_evals_to!(r"Num.toStr 10u16", RocStr::from("10"), RocStr);
 
     let max = format!("{}", u16::MAX);
-    assert_evals_to!(
-        r"Num.toStr Num.maxU16",
-        RocStr::from(max.as_str()),
-        RocStr
-    );
+    assert_evals_to!(r"Num.toStr Num.maxU16", RocStr::from(max.as_str()), RocStr);
 }
 
 #[test]
@@ -3073,11 +3061,7 @@ fn num_to_str_u32() {
     assert_evals_to!(r"Num.toStr 10u32", RocStr::from("10"), RocStr);
 
     let max = format!("{}", u32::MAX);
-    assert_evals_to!(
-        r"Num.toStr Num.maxU32",
-        RocStr::from(max.as_str()),
-        RocStr
-    );
+    assert_evals_to!(r"Num.toStr Num.maxU32", RocStr::from(max.as_str()), RocStr);
 }
 
 #[test]
@@ -3090,11 +3074,7 @@ fn num_to_str_u64() {
     assert_evals_to!(r"Num.toStr 10u64", RocStr::from("10"), RocStr);
 
     let max = format!("{}", u64::MAX);
-    assert_evals_to!(
-        r"Num.toStr Num.maxU64",
-        RocStr::from(max.as_str()),
-        RocStr
-    );
+    assert_evals_to!(r"Num.toStr Num.maxU64", RocStr::from(max.as_str()), RocStr);
 }
 
 #[test]
@@ -3127,18 +3107,10 @@ fn num_to_str_i16() {
     assert_evals_to!(r"Num.toStr 10i16", RocStr::from("10"), RocStr);
 
     let max = format!("{}", i16::MAX);
-    assert_evals_to!(
-        r"Num.toStr Num.maxI16",
-        RocStr::from(max.as_str()),
-        RocStr
-    );
+    assert_evals_to!(r"Num.toStr Num.maxI16", RocStr::from(max.as_str()), RocStr);
 
     let max = format!("{}", i16::MIN);
-    assert_evals_to!(
-        r"Num.toStr Num.minI16",
-        RocStr::from(max.as_str()),
-        RocStr
-    );
+    assert_evals_to!(r"Num.toStr Num.minI16", RocStr::from(max.as_str()), RocStr);
 }
 
 #[test]
@@ -3153,18 +3125,10 @@ fn num_to_str_i32() {
     assert_evals_to!(r"Num.toStr 10i32", RocStr::from("10"), RocStr);
 
     let max = format!("{}", i32::MAX);
-    assert_evals_to!(
-        r"Num.toStr Num.maxI32",
-        RocStr::from(max.as_str()),
-        RocStr
-    );
+    assert_evals_to!(r"Num.toStr Num.maxI32", RocStr::from(max.as_str()), RocStr);
 
     let max = format!("{}", i32::MIN);
-    assert_evals_to!(
-        r"Num.toStr Num.minI32",
-        RocStr::from(max.as_str()),
-        RocStr
-    );
+    assert_evals_to!(r"Num.toStr Num.minI32", RocStr::from(max.as_str()), RocStr);
 }
 
 #[test]
@@ -3179,18 +3143,10 @@ fn num_to_str_i64() {
     assert_evals_to!(r"Num.toStr 10i64", RocStr::from("10"), RocStr);
 
     let max = format!("{}", i64::MAX);
-    assert_evals_to!(
-        r"Num.toStr Num.maxI64",
-        RocStr::from(max.as_str()),
-        RocStr
-    );
+    assert_evals_to!(r"Num.toStr Num.maxI64", RocStr::from(max.as_str()), RocStr);
 
     let max = format!("{}", i64::MIN);
-    assert_evals_to!(
-        r"Num.toStr Num.minI64",
-        RocStr::from(max.as_str()),
-        RocStr
-    );
+    assert_evals_to!(r"Num.toStr Num.minI64", RocStr::from(max.as_str()), RocStr);
 }
 
 #[test]

--- a/crates/compiler/test_gen/src/gen_primitives.rs
+++ b/crates/compiler/test_gen/src/gen_primitives.rs
@@ -28,11 +28,11 @@ fn basic_float() {
 fn branch_first_float() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 when 1.23f64 is
                     1.23 -> 12
                     _ -> 34
-            "#
+            "
         ),
         12,
         i64
@@ -44,11 +44,11 @@ fn branch_first_float() {
 fn branch_second_float() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 when 2.34 is
                     1.23 -> 63
                     _ -> 48
-            "#
+            "
         ),
         48,
         i64
@@ -60,12 +60,12 @@ fn branch_second_float() {
 fn branch_third_float() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                when 10.0 is
                    1.0 -> 63
                    2.0 -> 48
                    _ -> 112
-            "#
+            "
         ),
         112,
         i64
@@ -77,11 +77,11 @@ fn branch_third_float() {
 fn branch_first_int() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 when 1 is
                     1 -> 12
                     _ -> 34
-            "#
+            "
         ),
         12,
         i64
@@ -93,11 +93,11 @@ fn branch_first_int() {
 fn branch_second_int() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 when 2 is
                     1 -> 63
                     _ -> 48
-            "#
+            "
         ),
         48,
         i64
@@ -109,12 +109,12 @@ fn branch_second_int() {
 fn branch_third_int() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 when 10 is
                     1 -> 63
                     2 -> 48
                     _ -> 112
-            "#
+            "
         ),
         112,
         i64
@@ -126,11 +126,11 @@ fn branch_third_int() {
 fn branch_store_variable() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 when 0 is
                     1 -> 12
                     a -> a
-            "#
+            "
         ),
         0,
         i64
@@ -142,13 +142,13 @@ fn branch_store_variable() {
 fn when_one_element_tag() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             x : [Pair (Int a) (Int a)]
             x = Pair 0x2 0x3
 
             when x is
                 Pair l r -> l + r
-            "#
+            "
         ),
         5,
         i64
@@ -160,14 +160,14 @@ fn when_one_element_tag() {
 fn when_two_element_tag_first() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             x : [A (Int a), B (Int a)]
             x = A 0x2
 
             when x is
                 A v -> v
                 B v -> v
-            "#
+            "
         ),
         2,
         i64
@@ -179,14 +179,14 @@ fn when_two_element_tag_first() {
 fn when_two_element_tag_second() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             x : [A (Int a), B (Int a)]
             x = B 0x3
 
             when x is
                 A v -> v
                 B v -> v
-            "#
+            "
         ),
         3,
         i64
@@ -198,10 +198,10 @@ fn when_two_element_tag_second() {
 fn gen_when_one_branch() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 when 1.23 is
                     _ -> 23
-            "#
+            "
         ),
         23,
         i64
@@ -213,7 +213,7 @@ fn gen_when_one_branch() {
 fn gen_large_when_int() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 foo = \num ->
                     when num is
                         0 -> 200
@@ -224,7 +224,7 @@ fn gen_large_when_int() {
                         _ -> 1000
 
                 foo -3
-            "#
+            "
         ),
         111,
         i64
@@ -236,7 +236,7 @@ fn gen_large_when_int() {
 fn gen_large_when_float() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 foo = \num ->
                     when num is
                         0.5f64 -> 200.1
@@ -247,7 +247,7 @@ fn gen_large_when_float() {
                         _ -> 1000.6f64
 
                 foo -3.6
-            "#
+            "
         ),
         111.2,
         f64
@@ -259,11 +259,11 @@ fn gen_large_when_float() {
 fn or_pattern() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             when 2 is
                 1 | 2 -> 42
                 _ -> 1
-            "#
+            "
         ),
         42,
         i64
@@ -275,11 +275,11 @@ fn or_pattern() {
 fn apply_identity() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 identity = \a -> a
 
                 identity 5
-            "#
+            "
         ),
         5,
         i64
@@ -291,12 +291,12 @@ fn apply_identity() {
 fn apply_unnamed_identity() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             wrapper = \{} ->
                 (\a -> a) 5
 
             wrapper {}
-            "#
+            "
         ),
         5,
         i64
@@ -308,7 +308,7 @@ fn apply_unnamed_identity() {
 fn return_unnamed_fn() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             wrapper = \{} ->
                 alwaysFloatIdentity : Int * -> (Frac a -> Frac a)
                 alwaysFloatIdentity = \_ ->
@@ -317,7 +317,7 @@ fn return_unnamed_fn() {
                 (alwaysFloatIdentity 2) 1.23f64
 
             wrapper {}
-            "#
+            "
         ),
         1.23,
         f64
@@ -329,7 +329,7 @@ fn return_unnamed_fn() {
 fn gen_when_fn() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 limitedNegate = \num ->
                     when num is
                         1 -> -1
@@ -337,7 +337,7 @@ fn gen_when_fn() {
                         _ -> num
 
                 limitedNegate 1
-            "#
+            "
         ),
         -1,
         i64
@@ -349,11 +349,11 @@ fn gen_when_fn() {
 fn gen_basic_def() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 answer = 42
 
                 answer
-            "#
+            "
         ),
         42,
         i64
@@ -361,11 +361,11 @@ fn gen_basic_def() {
 
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 float = 1.23f64
 
                 float
-            "#
+            "
         ),
         1.23,
         f64
@@ -377,13 +377,13 @@ fn gen_basic_def() {
 fn gen_multiple_defs() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 answer = 42
 
                 float = 1.23f64
 
                 if float > 3 then answer else answer
-            "#
+            "
         ),
         42,
         i64
@@ -391,13 +391,13 @@ fn gen_multiple_defs() {
 
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 answer = 42
 
                 float = 1.23f64
 
                 if answer > 3 then float else float
-            "#
+            "
         ),
         1.23,
         f64
@@ -411,7 +411,7 @@ fn gen_multiple_defs() {
 //    fn gen_chained_defs() {
 //        assert_evals_to!(
 //            indoc!(
-//                r#"
+//                r"
 //                    x = i1
 //                    i3 = i2
 //                    i1 = 1337
@@ -419,7 +419,7 @@ fn gen_multiple_defs() {
 //                    y = 12.4
 //
 //                    i3
-//                "#
+//                "
 //            ),
 //            1337,
 //            i64
@@ -431,7 +431,7 @@ fn gen_multiple_defs() {
 //    fn gen_nested_defs_old() {
 //        assert_evals_to!(
 //            indoc!(
-//                r#"
+//                r"
 //                    x = 5
 //
 //                    answer =
@@ -461,7 +461,7 @@ fn gen_multiple_defs() {
 //                    y = 12.4
 //
 //                    answer
-//                "#
+//                "
 //            ),
 //            1337,
 //            i64
@@ -473,7 +473,7 @@ fn gen_multiple_defs() {
 //    fn let_x_in_x() {
 //        assert_evals_to!(
 //            indoc!(
-//                r#"
+//                r"
 //                    x = 5
 //
 //                    answer =
@@ -484,7 +484,7 @@ fn gen_multiple_defs() {
 //                        nested
 //
 //                    answer
-//                "#
+//                "
 //            ),
 //            1337,
 //            i64
@@ -496,7 +496,7 @@ fn gen_multiple_defs() {
 fn factorial() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             factorial = \n, accum ->
                 when n is
                     0 ->
@@ -506,7 +506,7 @@ fn factorial() {
                         factorial (n - 1) (n * accum)
 
             factorial 10 1
-            "#
+            "
         ),
         3628800,
         i64
@@ -518,7 +518,7 @@ fn factorial() {
 fn peano1() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 Peano : [S Peano, Z]
 
                 three : Peano
@@ -527,7 +527,7 @@ fn peano1() {
                 when three is
                     Z -> 2
                     S _ -> 1
-                "#
+                "
         ),
         1,
         i64
@@ -539,7 +539,7 @@ fn peano1() {
 fn peano2() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 Peano : [S Peano, Z]
 
                 three : Peano
@@ -549,7 +549,7 @@ fn peano2() {
                     S (S _) -> 1
                     S (_) -> 0
                     Z -> 0
-                "#
+                "
         ),
         1,
         i64
@@ -833,7 +833,7 @@ fn linked_list_map() {
 fn when_nested_maybe() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             Maybe a : [Nothing, Just a]
 
             x : Maybe (Maybe (Int a))
@@ -842,7 +842,7 @@ fn when_nested_maybe() {
             when x is
                 Just (Just v) -> v + 0x1
                 _ -> 0x1
-                "#
+                "
         ),
         42,
         i64
@@ -850,7 +850,7 @@ fn when_nested_maybe() {
 
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             Maybe a : [Nothing, Just a]
 
             x : Maybe (Maybe (Int *))
@@ -860,7 +860,7 @@ fn when_nested_maybe() {
                 Just (Just v) -> v + 0x1
                 Just Nothing -> 0x2
                 Nothing -> 0x1
-                "#
+                "
         ),
         2,
         i64
@@ -868,7 +868,7 @@ fn when_nested_maybe() {
 
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             Maybe a : [Nothing, Just a]
 
             x : Maybe (Maybe (Int *))
@@ -878,7 +878,7 @@ fn when_nested_maybe() {
                 Just (Just v) -> v + 0x1
                 Just Nothing -> 0x2
                 Nothing -> 0x1
-                "#
+                "
         ),
         1,
         i64
@@ -890,7 +890,7 @@ fn when_nested_maybe() {
 fn when_peano() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 Peano : [S Peano, Z]
 
                 three : Peano
@@ -900,7 +900,7 @@ fn when_peano() {
                     S (S _) -> 1
                     S (_) -> 2
                     Z -> 3
-                "#
+                "
         ),
         1,
         i64
@@ -908,7 +908,7 @@ fn when_peano() {
 
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 Peano : [S Peano, Z]
 
                 three : Peano
@@ -918,7 +918,7 @@ fn when_peano() {
                     S (S _) -> 1
                     S (_) -> 2
                     Z -> 3
-                "#
+                "
         ),
         2,
         i64
@@ -926,7 +926,7 @@ fn when_peano() {
 
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 Peano : [S Peano, Z]
 
                 three : Peano
@@ -936,7 +936,7 @@ fn when_peano() {
                     S (S _) -> 1
                     S (_) -> 2
                     Z -> 3
-                "#
+                "
         ),
         3,
         i64
@@ -955,7 +955,7 @@ fn when_peano() {
 fn overflow_frees_list() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             myList = [1,2,3]
 
             # integer overflow; must use the list so it is defined before the overflow
@@ -967,7 +967,7 @@ fn overflow_frees_list() {
             index = Num.intCast n
 
             List.get myList index
-                 "#
+                 "
         ),
         (3, 0),
         (i64, i8)
@@ -980,12 +980,12 @@ fn overflow_frees_list() {
 fn undefined_variable() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                  if Bool.true then
                      x + z
                  else
                      y + z
-                 "#
+                 "
         ),
         3,
         i64
@@ -1016,12 +1016,12 @@ fn a_crash() {
 fn annotation_without_body() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             foo : Int *
 
 
             foo
-            "#
+            "
         ),
         3,
         i64
@@ -2022,11 +2022,11 @@ fn hof_conditional() {
     // exposed issue with the if condition being just a symbol
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 passTrue = \f -> f Bool.true
 
                 passTrue (\trueVal -> if trueVal then Bool.false else Bool.true)
-            "#
+            "
         ),
         0,
         u8
@@ -2041,12 +2041,12 @@ fn hof_conditional() {
 fn pattern_shadowing() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             x = 4
 
             when 4 is
                 x -> x
-            "#
+            "
         ),
         0,
         i64
@@ -2060,11 +2060,11 @@ fn pattern_shadowing() {
 fn unsupported_pattern_str_interp() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             { x: 4 } = { x : 4 }
 
             x
-            "#
+            "
         ),
         0,
         i64
@@ -2120,14 +2120,14 @@ fn case_or_pattern() {
     // it is currently duplicated
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             x : [Red, Green, Blue]
             x = Red
 
             when x is
                 Red | Green -> 0
                 Blue -> 1
-            "#
+            "
         ),
         0,
         i64
@@ -2517,11 +2517,11 @@ fn backpassing_result() {
 fn function_malformed_pattern() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 x = 3
 
                 (\x -> x) 42
-            "#
+            "
         ),
         3,
         i64
@@ -2534,12 +2534,12 @@ fn function_malformed_pattern() {
 fn call_invalid_layout() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 f : I64 -> I64
                 f = \x -> x
 
                 f {}
-            "#
+            "
         ),
         3,
         i64,
@@ -3261,12 +3261,12 @@ fn polymophic_expression_captured_inside_closure() {
 fn issue_2322() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             double = \x -> x * 2
             doubleBind = \x -> (\_ -> double x)
             doubleThree = doubleBind 3
             doubleThree {}
-            "#
+            "
         ),
         6,
         i64
@@ -3312,14 +3312,14 @@ fn box_and_unbox_big_string() {
 fn box_and_unbox_nonrecursive_tag() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             result : Result U64 U64
             result = Ok 42
 
             result
             |> Box.box
             |> Box.unbox
-            "#
+            "
         ),
         roc_std::RocResult::ok(42),
         roc_std::RocResult<u64, u64>
@@ -3409,9 +3409,9 @@ fn box_and_unbox_f32() {
 fn box_and_unbox_record_2_u64() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             Box.unbox (Box.box { a: 15u64, b: 27u64 })
-            "#
+            "
         ),
         (15, 27),
         (u64, u64)
@@ -3423,9 +3423,9 @@ fn box_and_unbox_record_2_u64() {
 fn box_and_unbox_record_3_u64() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             Box.unbox (Box.box { a: 15u64, b: 27u64, c: 34u64 })
-            "#
+            "
         ),
         (15, 27, 34),
         (u64, u64, u64)
@@ -3437,9 +3437,9 @@ fn box_and_unbox_record_3_u64() {
 fn box_and_unbox_record_2_u8() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             Box.unbox (Box.box { a: 15u8, b: 27u8 })
-            "#
+            "
         ),
         (15, 27),
         (u8, u8)
@@ -3451,9 +3451,9 @@ fn box_and_unbox_record_2_u8() {
 fn box_and_unbox_record_3_u8() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             Box.unbox (Box.box { a: 15u8, b: 27u8, c: 34u8 })
-            "#
+            "
         ),
         (15, 27, 34),
         (u8, u8, u8)
@@ -3465,12 +3465,12 @@ fn box_and_unbox_record_3_u8() {
 fn box_and_unbox_tag_union() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             v : [A U8, B U8] # usually stack allocated
             v = B 27u8
 
             Box.unbox (Box.box v)
-            "#
+            "
         ),
         (27, 1),
         (u8, u8)
@@ -3534,7 +3534,7 @@ fn issue_2894() {
 fn polymorphic_def_used_in_closure() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             a : I64 -> _
             a = \g ->
                 f = { r: g, h: 32 }
@@ -3543,7 +3543,7 @@ fn polymorphic_def_used_in_closure() {
                 h1 = (\{} -> f.h) {}
                 h1
             a 1
-            "#
+            "
         ),
         32,
         u64
@@ -3555,13 +3555,13 @@ fn polymorphic_def_used_in_closure() {
 fn polymorphic_lambda_set_usage() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             id1 = \x -> x
             id2 = \y -> y
             id = if Bool.true then id1 else id2
 
             id 9u8
-            "#
+            "
         ),
         9,
         u8
@@ -3573,7 +3573,7 @@ fn polymorphic_lambda_set_usage() {
 fn polymorphic_lambda_set_multiple_specializations() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             id1 = \x -> x
             id2 = \y -> y
             id = \z ->
@@ -3581,7 +3581,7 @@ fn polymorphic_lambda_set_multiple_specializations() {
                 f z
 
             (id 9u8) + Num.toU8 (id 16u16)
-            "#
+            "
         ),
         25,
         u8
@@ -3642,14 +3642,14 @@ fn mutual_recursion_top_level_defs() {
 fn polymorphic_lambda_captures_polymorphic_value() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             x = 2
 
             f1 = \_ -> x
 
             f = if Bool.true then f1 else f1
             f {}
-            "#
+            "
         ),
         2,
         u64
@@ -3661,7 +3661,7 @@ fn polymorphic_lambda_captures_polymorphic_value() {
 fn lambda_capture_niche_u64_vs_u8_capture() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             capture : _ -> ({} -> Str)
             capture = \val ->
                 \{} ->
@@ -3677,7 +3677,7 @@ fn lambda_capture_niche_u64_vs_u8_capture() {
                     capture 18u8
 
             fun {}
-            "#
+            "
         ),
         RocStr::from("123"),
         RocStr
@@ -3789,14 +3789,14 @@ fn lambda_capture_niches_have_captured_function_in_closure() {
 fn recursive_call_capturing_function() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             a = \b ->
                 c = \d ->
                     if d == 7 then d else c (d + b)
                 c 1
 
             a 6
-            "#
+            "
         ),
         7,
         i64
@@ -3808,13 +3808,13 @@ fn recursive_call_capturing_function() {
 fn shared_pattern_variable_in_when_branches() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             f = \t ->
                 when t is
                     A x | B x -> x
 
             {a: f (A 15u8), b: (B 31u8)}
-            "#
+            "
         ),
         (15u8, 31u8),
         (u8, u8)
@@ -3826,12 +3826,12 @@ fn shared_pattern_variable_in_when_branches() {
 fn symbol_not_bound_in_all_patterns_runs_when_no_bound_symbol_used() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             f = \t -> when t is
                         A x | B y -> 31u8
 
             {a: f (A 15u8), b: f (B 15u8)}
-            "#
+            "
         ),
         (31u8, 31u8),
         (u8, u8),
@@ -3845,10 +3845,10 @@ fn symbol_not_bound_in_all_patterns_runs_when_no_bound_symbol_used() {
 fn symbol_not_bound_in_all_patterns_runs_when_bound_pattern_reached() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             when A 15u8 is
                 A x | B y -> x
-            "#
+            "
         ),
         15u8,
         u8,
@@ -3865,10 +3865,10 @@ fn symbol_not_bound_in_all_patterns_runs_when_bound_pattern_reached() {
 fn runtime_error_when_degenerate_pattern_reached() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             when B 15u8 is
                 A x | B y -> x + 5u8
-            "#
+            "
         ),
         15u8,
         u8,
@@ -4399,7 +4399,7 @@ fn pattern_as_of_symbol() {
 fn function_specialization_information_in_lambda_set_thunk() {
     assert_evals_to!(
         indoc!(
-            r###"
+            r#"
             app "test" provides [main] to "./platform"
 
             andThen = \{} ->
@@ -4409,7 +4409,7 @@ fn function_specialization_information_in_lambda_set_thunk() {
             between = andThen {}
 
             main = between \{} -> between \{} -> 10u8
-            "###
+            "#
         ),
         30,
         u8
@@ -4421,7 +4421,7 @@ fn function_specialization_information_in_lambda_set_thunk() {
 fn function_specialization_information_in_lambda_set_thunk_independent_defs() {
     assert_evals_to!(
         indoc!(
-            r###"
+            r#"
             app "test" provides [main] to "./platform"
 
             andThen = \{} ->
@@ -4433,7 +4433,7 @@ fn function_specialization_information_in_lambda_set_thunk_independent_defs() {
             between2 = andThen {}
 
             main = between1 \{} -> between2 \{} -> 10u8
-            "###
+            "#
         ),
         30,
         u8
@@ -4526,7 +4526,7 @@ fn layout_cache_structure_with_multiple_recursive_structures() {
 fn reset_recursive_type_wraps_in_named_type() {
     assert_evals_to!(
         indoc!(
-            r###"
+            r#"
             app "test" provides [main] to "./platform"
 
             main : Str
@@ -4553,7 +4553,7 @@ fn reset_recursive_type_wraps_in_named_type() {
                   strX = f x
                   strXs = printLinkedList xs f
                   "Cons \(strX) (\(strXs))"
-            "###
+            "#
         ),
         RocStr::from("Cons 2 (Cons 3 (Cons 4 (Nil)))"),
         RocStr
@@ -4619,12 +4619,12 @@ fn many_arguments() {
     // exhausts all argument registers on x86 and aarch
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             fun = \a,b,c,d, e,f,g,h, i ->
                 (a + b + c + d) + (e + f + g + h) + i
 
             fun 0i64 1 2 3 4 5 6 7 8
-            "#
+            "
         ),
         1 + 2 + 3 + 4 + 5 + 6 + 7 + 8,
         i64
@@ -4636,9 +4636,9 @@ fn many_arguments() {
 fn multiple_uses_of_bool_true_record() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             (Bool.true, Bool.true).0
-            "#
+            "
         ),
         true,
         bool
@@ -4650,14 +4650,14 @@ fn multiple_uses_of_bool_true_record() {
 fn multiple_uses_of_bool_true_tag_union() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             x : [ One Bool Bool, Empty ]
             x = One Bool.true Bool.true
 
             when x is
                 One a _ -> a
                 Empty -> Bool.false
-            "#
+            "
         ),
         true,
         bool

--- a/crates/compiler/test_gen/src/gen_records.rs
+++ b/crates/compiler/test_gen/src/gen_records.rs
@@ -18,9 +18,9 @@ use roc_std::{RocList, RocStr};
 fn basic_record() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                     { y: 17, x: 15, z: 19 }.x
-                "#
+                "
         ),
         15,
         i64
@@ -28,9 +28,9 @@ fn basic_record() {
 
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                     { x: 15, y: 17, z: 19 }.y
-                "#
+                "
         ),
         17,
         i64
@@ -38,9 +38,9 @@ fn basic_record() {
 
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                     { x: 15, y: 17, z: 19 }.z
-                "#
+                "
         ),
         19,
         i64
@@ -52,11 +52,11 @@ fn basic_record() {
 fn f64_record() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                    rec = { y: 17.2f64, x: 15.1f64, z: 19.3f64 }
 
                    rec.x
-                "#
+                "
         ),
         15.1,
         f64
@@ -64,11 +64,11 @@ fn f64_record() {
 
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                    rec = { y: 17.2f64, x: 15.1f64, z: 19.3f64 }
 
                    rec.y
-                "#
+                "
         ),
         17.2,
         f64
@@ -76,11 +76,11 @@ fn f64_record() {
 
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                     rec = { y: 17.2f64, x: 15.1f64, z: 19.3f64 }
 
                     rec.z
-                "#
+                "
         ),
         19.3,
         f64
@@ -93,14 +93,14 @@ fn pass_bool_record() {
     // found a bug there the register to use was not incremented correctly
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                true : Bool
                true = Bool.true
 
                f = \_, x -> x
 
                f { x: true, y: true } 23
-               "#
+               "
         ),
         23,
         i64
@@ -124,11 +124,11 @@ fn fn_record() {
 
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                     rec = { x: 15, y: 17, z: 19 }
 
                     rec.z + rec.x
-                "#
+                "
         ),
         34,
         i64
@@ -140,11 +140,11 @@ fn fn_record() {
 fn def_record() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                     rec = { y: 17, x: 15, z: 19 }
 
                     rec.x
-                "#
+                "
         ),
         15,
         i64
@@ -152,11 +152,11 @@ fn def_record() {
 
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                     rec = { x: 15, y: 17, z: 19 }
 
                     rec.y
-                "#
+                "
         ),
         17,
         i64
@@ -164,11 +164,11 @@ fn def_record() {
 
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                     rec = { x: 15, y: 17, z: 19 }
 
                     rec.z
-                "#
+                "
         ),
         19,
         i64
@@ -180,10 +180,10 @@ fn def_record() {
 fn when_on_record() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 when { x: 0x2 } is
                     { x } -> x + 3
-                "#
+                "
         ),
         5,
         i64
@@ -195,10 +195,10 @@ fn when_on_record() {
 fn when_record_with_guard_pattern() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 when { x: 0x2, y: 1.23 } is
                     { x: var } -> var + 3
-                "#
+                "
         ),
         5,
         i64
@@ -210,11 +210,11 @@ fn when_record_with_guard_pattern() {
 fn let_with_record_pattern() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 { x } = { x: 0x2, y: 1.23 }
 
                 x
-                "#
+                "
         ),
         2,
         i64
@@ -226,11 +226,11 @@ fn let_with_record_pattern() {
 fn record_guard_pattern() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 when { x: 0x2, y: 1.23 } is
                     { x: 0x4 } -> 5
                     { x } -> x + 3
-                "#
+                "
         ),
         5,
         i64
@@ -242,11 +242,11 @@ fn record_guard_pattern() {
 fn twice_record_access() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 x =  {a: 0x2, b: 0x3 }
 
                 x.a + x.b
-                "#
+                "
         ),
         5,
         i64
@@ -257,11 +257,11 @@ fn twice_record_access() {
 fn empty_record() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 v = {}
 
                 v
-                "#
+                "
         ),
         (),
         ()
@@ -272,9 +272,9 @@ fn empty_record() {
 fn i64_record2_literal() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                    { x: 3, y: 5 }
-                "#
+                "
         ),
         (3, 5),
         (i64, i64)
@@ -286,9 +286,9 @@ fn i64_record2_literal() {
 // fn i64_record3_literal() {
 //     assert_evals_to!(
 //         indoc!(
-//             r#"
+//             r"
 //                { x: 3, y: 5, z: 17 }
-//             "#
+//             "
 //         ),
 //         (3, 5, 17),
 //         (i64, i64, i64)
@@ -299,9 +299,9 @@ fn i64_record2_literal() {
 fn f64_record2_literal() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                    { x: 3.1f64, y: 5.1f64 }
-                "#
+                "
         ),
         (3.1, 5.1),
         (f64, f64)
@@ -313,9 +313,9 @@ fn f64_record2_literal() {
 // fn f64_record3_literal() {
 //     assert_evals_to!(
 //         indoc!(
-//             r#"
+//             r"
 //                { x: 3.1, y: 5.1, z: 17.1 }
-//             "#
+//             "
 //         ),
 //         (3.1, 5.1, 17.1),
 //         (f64, f64, f64)
@@ -327,12 +327,12 @@ fn f64_record2_literal() {
 // fn bool_record4_literal() {
 //     assert_evals_to!(
 //         indoc!(
-//             r#"
+//             r"
 //                record : { a : Bool, b : Bool, c : Bool, d : Bool }
 //                record = { a: Bool.true, b: Bool.true, c : Bool.true, d : Bool }
 
 //                record
-//             "#
+//             "
 //         ),
 //         (true, false, false, true),
 //         (bool, bool, bool, bool)
@@ -343,9 +343,9 @@ fn f64_record2_literal() {
 fn i64_record1_literal() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                    { a: 3 }
-                "#
+                "
         ),
         3,
         i64
@@ -357,9 +357,9 @@ fn i64_record1_literal() {
 // fn i64_record9_literal() {
 //     assert_evals_to!(
 //         indoc!(
-//             r#"
+//             r"
 //                { a: 3, b: 5, c: 17, d: 1, e: 9, f: 12, g: 13, h: 14, i: 15 }
-//             "#
+//             "
 //         ),
 //         (3, 5, 17, 1, 9, 12, 13, 14, 15),
 //         (i64, i64, i64, i64, i64, i64, i64, i64, i64)
@@ -371,9 +371,9 @@ fn i64_record1_literal() {
 // fn f64_record3_literal() {
 //     assert_evals_to!(
 //         indoc!(
-//             r#"
+//             r"
 //                { x: 3.1, y: 5.1, z: 17.1 }
-//             "#
+//             "
 //         ),
 //         (3.1, 5.1, 17.1),
 //         (f64, f64, f64)
@@ -384,12 +384,12 @@ fn i64_record1_literal() {
 fn bool_literal() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 x : Bool
                 x = Bool.true
 
                 x
-                "#
+                "
         ),
         true,
         bool
@@ -401,12 +401,12 @@ fn bool_literal() {
 fn return_record() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 x = 4
                 y = 3
 
                 { x, y }
-                "#
+                "
         ),
         (4, 3),
         (i64, i64)
@@ -446,7 +446,7 @@ fn optional_field_when_use_default() {
 fn optional_field_when_use_default_nested() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 f = \r ->
                     when r is
                         { x: Blue, y ? 3 } -> y
@@ -458,7 +458,7 @@ fn optional_field_when_use_default_nested() {
                 d = f { x: Red }
 
                 a * b * c * d
-                "#
+                "
         ),
         3 * 5 * 7 * 11,
         i64
@@ -491,13 +491,13 @@ fn optional_field_destructure_module() {
 fn optional_field_destructure_expr() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 fn = \r ->
                     { x ? 10, y } = r
                     x + y
 
                 fn { x: 4, y: 9 }
-                "#
+                "
         ),
         13,
         i64
@@ -551,13 +551,13 @@ fn optional_field_let_no_use_default() {
 fn optional_field_let_no_use_default_nested() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 f = \r ->
                     { x ? 10, y } = r
                     x + y
 
                 f { y: 9, x: 4 }
-                "#
+                "
         ),
         13,
         i64
@@ -569,12 +569,12 @@ fn optional_field_let_no_use_default_nested() {
 fn optional_field_function_use_default() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 f = \{ x ? 10, y } -> x + y
 
 
                 f { y: 9 }
-                "#
+                "
         ),
         19,
         i64
@@ -605,12 +605,12 @@ fn optional_field_function_no_use_default() {
 fn optional_field_function_no_use_default_nested() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 f = \{ x ? 10, y } -> x + y
 
 
                 f { x: 4, y: 9 }
-                "#
+                "
         ),
         13,
         i64
@@ -622,10 +622,10 @@ fn optional_field_function_no_use_default_nested() {
 fn optional_field_singleton_record() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 when { x : 4 } is
                     { x ? 3 } -> x
-                "#
+                "
         ),
         4,
         i64
@@ -637,10 +637,10 @@ fn optional_field_singleton_record() {
 fn optional_field_empty_record() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 when { } is
                     { x ? 3 } -> x
-                "#
+                "
         ),
         3,
         i64
@@ -652,9 +652,9 @@ fn optional_field_empty_record() {
 fn return_record_2() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 { x: 3, y: 5 }
-                "#
+                "
         ),
         [3, 5],
         [i64; 2]
@@ -666,9 +666,9 @@ fn return_record_2() {
 fn return_record_3() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 { x: 3, y: 5, z: 4 }
-                "#
+                "
         ),
         (3, 5, 4),
         (i64, i64, i64)
@@ -680,9 +680,9 @@ fn return_record_3() {
 fn return_record_4() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 { a: 3, b: 5, c: 4, d: 2 }
-                "#
+                "
         ),
         [3, 5, 4, 2],
         [i64; 4]
@@ -694,9 +694,9 @@ fn return_record_4() {
 fn return_record_5() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 { a: 3, b: 5, c: 4, d: 2, e: 1 }
-                "#
+                "
         ),
         [3, 5, 4, 2, 1],
         [i64; 5]
@@ -708,9 +708,9 @@ fn return_record_5() {
 fn return_record_6() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 { a: 3, b: 5, c: 4, d: 2, e: 1, f: 7 }
-                "#
+                "
         ),
         [3, 5, 4, 2, 1, 7],
         [i64; 6]
@@ -722,9 +722,9 @@ fn return_record_6() {
 fn return_record_7() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 { a: 3, b: 5, c: 4, d: 2, e: 1, f: 7, g: 8 }
-                "#
+                "
         ),
         [3, 5, 4, 2, 1, 7, 8],
         [i64; 7]
@@ -736,9 +736,9 @@ fn return_record_7() {
 fn return_record_float_int() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 { a: 1.23f64, b: 0x1 }
-                "#
+                "
         ),
         (1.23, 0x1),
         (f64, i64)
@@ -750,9 +750,9 @@ fn return_record_float_int() {
 fn return_record_int_float() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 { a: 0x1, b: 1.23f64 }
-                "#
+                "
         ),
         (0x1, 1.23),
         (i64, f64)
@@ -764,9 +764,9 @@ fn return_record_int_float() {
 fn return_record_float_float() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 { a: 2.46f64, b: 1.23f64 }
-                "#
+                "
         ),
         (2.46, 1.23),
         (f64, f64)
@@ -778,9 +778,9 @@ fn return_record_float_float() {
 fn return_record_float_float_float() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 { a: 2.46f64, b: 1.23f64, c: 0.1f64 }
-                "#
+                "
         ),
         (2.46, 1.23, 0.1),
         (f64, f64, f64)
@@ -792,9 +792,9 @@ fn return_record_float_float_float() {
 fn return_nested_record() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 { flag: 0x0, payload: { a: 2.46f64, b: 1.23f64, c: 0.1f64 } }
-                "#
+                "
         ),
         (0x0, (2.46, 1.23, 0.1)),
         (i64, (f64, f64, f64))
@@ -806,13 +806,13 @@ fn return_nested_record() {
 fn nested_record_load() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 x = { a : { b : 0x5 } }
 
                 y = x.a
 
                 y.b
-                "#
+                "
         ),
         5,
         i64
@@ -844,9 +844,9 @@ fn accessor_multi_element_record() {
 fn accessor_single_element_record() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 .foo { foo: 4 }
-                "#
+                "
         ),
         4,
         i64
@@ -858,11 +858,11 @@ fn accessor_single_element_record() {
 fn update_record() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 rec = { foo: 42, bar: 2.46f64 }
 
                 { rec & foo: rec.foo + 1 }
-                "#
+                "
         ),
         (2.46, 43),
         (f64, i64)
@@ -874,11 +874,11 @@ fn update_record() {
 fn update_single_element_record() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 rec = { foo: 42}
 
                 { rec & foo: rec.foo + 1 }
-                "#
+                "
         ),
         43,
         i64
@@ -927,14 +927,14 @@ fn alignment_in_record() {
 fn blue_and_present() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 f = \r ->
                     when r is
                         { x: Blue, y ? 3 } -> y
                         { x: Red, y ? 5 } -> y
 
                 f { x: Blue, y: 7 }
-                "#
+                "
         ),
         7,
         i64
@@ -946,14 +946,14 @@ fn blue_and_present() {
 fn blue_and_absent() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 f = \r ->
                     when r is
                         { x: Blue, y ? 3 } -> y
                         { x: Red, y ? 5 } -> y
 
                 f { x: Blue }
-                "#
+                "
         ),
         3,
         i64
@@ -965,7 +965,7 @@ fn blue_and_absent() {
 fn update_the_only_field() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             Model : { foo : I64 }
 
             model : Model
@@ -977,7 +977,7 @@ fn update_the_only_field() {
             newModel = { model & foo }
 
             newModel.foo
-                "#
+                "
         ),
         4,
         i64
@@ -990,7 +990,7 @@ fn update_the_only_field() {
 fn both_have_unique_fields() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             a = { x: 42, y: 43 }
             b = { x: 42, z: 44 }
 
@@ -998,7 +998,7 @@ fn both_have_unique_fields() {
             f = \{ x: x1}, { x: x2 } -> x1 + x2
 
             f a b
-            "#
+            "
         ),
         84,
         i64

--- a/crates/compiler/test_gen/src/gen_result.rs
+++ b/crates/compiler/test_gen/src/gen_result.rs
@@ -17,12 +17,12 @@ use roc_std::{RocResult, RocStr};
 fn with_default_ok() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             result : Result I64 {}
             result = Ok 12345
 
             Result.withDefault result 0
-            "#
+            "
         ),
         12345,
         i64
@@ -34,12 +34,12 @@ fn with_default_ok() {
 fn with_default_err() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             result : Result I64 {}
             result = Err {}
 
             Result.withDefault result 0
-            "#
+            "
         ),
         0,
         i64
@@ -51,14 +51,14 @@ fn with_default_err() {
 fn result_map() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             result : Result I64 {}
             result = Ok 2
 
             result
                 |> Result.map (\x -> x + 1)
                 |> Result.withDefault 0
-            "#
+            "
         ),
         3,
         i64
@@ -66,14 +66,14 @@ fn result_map() {
 
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             result : Result I64 {}
             result = Err {}
 
             result
                 |> Result.map (\x -> x + 1)
                 |> Result.withDefault 0
-            "#
+            "
         ),
         0,
         i64
@@ -85,14 +85,14 @@ fn result_map() {
 fn result_map_err() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             result : Result {} I64
             result = Err 2
 
             when Result.mapErr result (\x -> x + 1) is
                 Err n -> n
                 Ok _ -> 0
-            "#
+            "
         ),
         3,
         i64
@@ -100,14 +100,14 @@ fn result_map_err() {
 
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             result : Result {} I64
             result = Ok {}
 
             when Result.mapErr result (\x -> x + 1) is
                 Err n -> n
                 Ok _ -> 0
-            "#
+            "
         ),
         0,
         i64
@@ -119,10 +119,10 @@ fn result_map_err() {
 fn err_type_var() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             Result.map (Ok 3) (\x -> x + 1)
                 |> Result.withDefault -1
-            "#
+            "
         ),
         4,
         i64
@@ -134,13 +134,13 @@ fn err_type_var() {
 fn err_type_var_annotation() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             ok : Result I64 *
             ok = Ok 3
 
             Result.map ok (\x -> x + 1)
                 |> Result.withDefault -1
-            "#
+            "
         ),
         4,
         i64
@@ -152,13 +152,13 @@ fn err_type_var_annotation() {
 fn err_empty_tag_union() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             ok : Result I64 []
             ok = Ok 3
 
             Result.map ok (\x -> x + 1)
                 |> Result.withDefault -1
-            "#
+            "
         ),
         4,
         i64
@@ -170,12 +170,12 @@ fn err_empty_tag_union() {
 fn is_ok() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             result : Result I64 {}
             result = Ok 2
 
             Result.isOk result
-            "#
+            "
         ),
         true,
         bool
@@ -183,12 +183,12 @@ fn is_ok() {
 
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             result : Result I64 {}
             result = Err {}
 
             Result.isOk result
-            "#
+            "
         ),
         false,
         bool
@@ -200,12 +200,12 @@ fn is_ok() {
 fn is_err() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             result : Result I64 {}
             result = Ok 2
 
             Result.isErr result
-            "#
+            "
         ),
         false,
         bool
@@ -213,12 +213,12 @@ fn is_err() {
 
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             result : Result I64 {}
             result = Err {}
 
             Result.isErr result
-            "#
+            "
         ),
         true,
         bool
@@ -230,12 +230,12 @@ fn is_err() {
 fn roc_result_ok_i64() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             result : Result I64 {}
             result = Ok 42
 
             result
-            "#
+            "
         ),
         RocResult::ok(42),
         RocResult<i64, ()>
@@ -250,12 +250,12 @@ fn roc_result_ok_f64() {
 
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             result : Result F64 {}
             result = Ok 42.0
 
             result
-            "#
+            "
         ),
         RocResult::ok(42.0),
         RocResult<f64, ()>

--- a/crates/compiler/test_gen/src/gen_set.rs
+++ b/crates/compiler/test_gen/src/gen_set.rs
@@ -20,9 +20,9 @@ use roc_std::RocList;
 fn empty_len() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             Set.len (Set.empty {})
-            "#
+            "
         ),
         0,
         usize
@@ -34,9 +34,9 @@ fn empty_len() {
 fn single_len() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             Set.len (Set.single 42)
-            "#
+            "
         ),
         1,
         usize
@@ -48,9 +48,9 @@ fn single_len() {
 fn single_to_list() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             Set.toList (Set.single 42)
-            "#
+            "
         ),
         RocList::from_slice(&[42]),
         RocList<i64>
@@ -58,9 +58,9 @@ fn single_to_list() {
 
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             Set.toList (Set.single 1)
-            "#
+            "
         ),
         RocList::from_slice(&[1]),
         RocList<i64>
@@ -72,13 +72,13 @@ fn single_to_list() {
 fn insert() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             Set.empty {}
                 |> Set.insert 0
                 |> Set.insert 1
                 |> Set.insert 2
                 |> Set.toList
-            "#
+            "
         ),
         RocList::from_slice(&[0, 1, 2]),
         RocList<i64>
@@ -90,14 +90,14 @@ fn insert() {
 fn remove() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             Set.empty {}
                 |> Set.insert 0
                 |> Set.insert 1
                 |> Set.remove 1
                 |> Set.remove 2
                 |> Set.toList
-            "#
+            "
         ),
         RocList::from_slice(&[0]),
         RocList<i64>
@@ -109,7 +109,7 @@ fn remove() {
 fn union() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             set1 : Set.Set I64
             set1 = Set.fromList [1,2]
 
@@ -118,7 +118,7 @@ fn union() {
 
             Set.union set1 set2
                 |> Set.toList
-            "#
+            "
         ),
         RocList::from_slice(&[1, 3, 4, 2]),
         RocList<i64>
@@ -130,7 +130,7 @@ fn union() {
 fn difference() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             set1 : Set.Set I64
             set1 = Set.fromList [1,2]
 
@@ -139,7 +139,7 @@ fn difference() {
 
             Set.difference set1 set2
                 |> Set.toList
-            "#
+            "
         ),
         RocList::from_slice(&[2]),
         RocList<i64>
@@ -151,7 +151,7 @@ fn difference() {
 fn intersection() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             set1 : Set.Set I64
             set1 = Set.fromList [1,2]
 
@@ -160,7 +160,7 @@ fn intersection() {
 
             Set.intersection set1 set2
                 |> Set.toList
-            "#
+            "
         ),
         RocList::from_slice(&[1]),
         RocList<i64>
@@ -172,9 +172,9 @@ fn intersection() {
 fn walk_sum() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             Set.walk (Set.fromList [1,2,3]) 0 (\x, y -> x + y)
-            "#
+            "
         ),
         6,
         i64
@@ -186,9 +186,9 @@ fn walk_sum() {
 fn contains() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             Set.contains (Set.fromList [1,3,4]) 4
-            "#
+            "
         ),
         true,
         bool
@@ -196,9 +196,9 @@ fn contains() {
 
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             Set.contains (Set.fromList [1,3,4]) 2
-            "#
+            "
         ),
         false,
         bool
@@ -210,11 +210,11 @@ fn contains() {
 fn from_list() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             [1,2,2,3,1,4]
                 |> Set.fromList
                 |> Set.toList
-            "#
+            "
         ),
         RocList::from_slice(&[1, 2, 3, 4]),
         RocList<i64>
@@ -222,14 +222,14 @@ fn from_list() {
 
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             empty : List I64
             empty = []
 
             empty
                 |> Set.fromList
                 |> Set.toList
-            "#
+            "
         ),
         RocList::<i64>::default(),
         RocList<i64>
@@ -242,11 +242,11 @@ fn from_list() {
 fn from_list_void() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             []
                 |> Set.fromList
                 |> Set.toList
-            "#
+            "
         ),
         RocList::<i64>::default(),
         RocList<i64>
@@ -258,9 +258,9 @@ fn from_list_void() {
 fn to_list_empty() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             Set.toList (Set.empty {})
-            "#
+            "
         ),
         RocList::<std::convert::Infallible>::default(),
         RocList<std::convert::Infallible>

--- a/crates/compiler/test_gen/src/gen_tags.rs
+++ b/crates/compiler/test_gen/src/gen_tags.rs
@@ -39,14 +39,14 @@ fn width_and_alignment_u8_u8() {
 fn applied_tag_nothing() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 Maybe a : [Just a, Nothing]
 
                 x : Maybe I64
                 x = Nothing
 
                 x
-                "#
+                "
         ),
         1,
         (i64, u8),
@@ -59,14 +59,14 @@ fn applied_tag_nothing() {
 fn applied_tag_just() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 Maybe a : [Just a, Nothing]
 
                 y : Maybe I64
                 y = Just 0x4
 
                 y
-                "#
+                "
         ),
         (0x4, 0),
         (i64, u8)
@@ -78,7 +78,7 @@ fn applied_tag_just() {
 fn applied_tag_just_enum() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 Fruit : [Orange, Apple, Banana]
                 Maybe a : [Just a, Nothing]
 
@@ -89,7 +89,7 @@ fn applied_tag_just_enum() {
                 y = Just orange
 
                 y
-                "#
+                "
         ),
         (2, 0),
         (u8, u8)
@@ -101,12 +101,12 @@ fn applied_tag_just_enum() {
 fn true_is_true() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                    bool : Bool
                    bool = Bool.true
 
                    bool
-                "#
+                "
         ),
         true,
         bool
@@ -118,12 +118,12 @@ fn true_is_true() {
 fn false_is_false() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                    bool : Bool
                    bool = Bool.false
 
                    bool
-                "#
+                "
         ),
         false,
         bool
@@ -135,7 +135,7 @@ fn false_is_false() {
 fn basic_enum() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 Fruit : [Apple, Orange, Banana]
 
                 apple : Fruit
@@ -145,7 +145,7 @@ fn basic_enum() {
                 orange = Orange
 
                 apple == orange
-                "#
+                "
         ),
         false,
         bool
@@ -157,7 +157,7 @@ fn basic_enum() {
 fn even_odd() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 even = \n ->
                     when n is
                         0 -> Bool.true
@@ -171,7 +171,7 @@ fn even_odd() {
                         _ -> even (n - 1)
 
                 odd 5 && even 42
-                "#
+                "
         ),
         true,
         bool
@@ -183,9 +183,9 @@ fn even_odd() {
 fn gen_literal_true() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 if Bool.true then -1 else 1
-                "#
+                "
         ),
         -1,
         i64
@@ -197,9 +197,9 @@ fn gen_literal_true() {
 fn gen_if_float() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 if Bool.true then -1.0 else 1.0f64
-                "#
+                "
         ),
         -1.0,
         f64
@@ -210,14 +210,14 @@ fn gen_if_float() {
 fn when_on_nothing() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 x : [Nothing, Just I64]
                 x = Nothing
 
                 when x is
                     Nothing -> 0x2
                     Just _ -> 0x1
-                "#
+                "
         ),
         2,
         i64
@@ -229,14 +229,14 @@ fn when_on_nothing() {
 fn when_on_just() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 x : [Nothing, Just I64]
                 x = Just 41
 
                 when x is
                     Just v -> v + 0x1
                     Nothing -> 0x1
-                "#
+                "
         ),
         42,
         i64
@@ -248,14 +248,14 @@ fn when_on_just() {
 fn when_on_result() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 x : Result I64 I64
                 x = Err 41
 
                 when x is
                     Err v ->  v + 1
                     Ok _ -> 1
-                "#
+                "
         ),
         42,
         i64
@@ -267,7 +267,7 @@ fn when_on_result() {
 fn when_on_these() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 These a b : [This a, That b, These a b]
 
                 x : These I64 I64
@@ -277,7 +277,7 @@ fn when_on_these() {
                     These a b -> a + b
                     That v -> v
                     This v -> v
-                "#
+                "
         ),
         5,
         i64
@@ -290,11 +290,11 @@ fn match_on_two_values() {
     // this will produce a Chain internally
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 when Pair 2 3 is
                     Pair 4 3 -> 9
                     Pair a b -> a + b
-                "#
+                "
         ),
         5,
         i64
@@ -306,12 +306,12 @@ fn match_on_two_values() {
 fn pair_with_underscore() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 when Pair 2 3 is
                     Pair 4 _ -> 1
                     Pair 3 _ -> 2
                     Pair a b -> a + b
-                "#
+                "
         ),
         5,
         i64
@@ -324,7 +324,7 @@ fn result_with_underscore() {
     // This test revealed an issue with hashing Test values
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             x : Result I64 I64
             x = Ok 2
 
@@ -332,7 +332,7 @@ fn result_with_underscore() {
                 Ok 3 -> 1
                 Ok _ -> 2
                 Err _ -> 3
-            "#
+            "
         ),
         2,
         i64
@@ -369,7 +369,7 @@ fn maybe_is_just_not_nested() {
 fn maybe_is_just_nested() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 Maybe a : [Just a, Nothing]
 
                 isJust : Maybe a -> Bool
@@ -379,7 +379,7 @@ fn maybe_is_just_nested() {
                         Just _ -> Bool.true
 
                 isJust (Just 42)
-                "#
+                "
         ),
         true,
         bool
@@ -391,7 +391,7 @@ fn maybe_is_just_nested() {
 fn nested_pattern_match() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 Maybe a : [Nothing, Just a]
 
                 x : Maybe (Maybe I64)
@@ -400,7 +400,7 @@ fn nested_pattern_match() {
                 when x is
                     Just (Just v) -> v + 0x1
                     _ -> 0x1
-                "#
+                "
         ),
         42,
         i64
@@ -428,11 +428,11 @@ fn if_guard_vanilla() {
 fn when_on_single_value_tag() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             when Identity 0 is
                 Identity 0 -> 6
                 Identity s -> s
-            "#
+            "
         ),
         6,
         i64
@@ -444,7 +444,7 @@ fn when_on_single_value_tag() {
 fn if_guard_multiple() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             f = \n ->
                 when Identity n 0 is
                         Identity x _ if x == 0 -> x + 0
@@ -453,7 +453,7 @@ fn if_guard_multiple() {
                         Identity x _ -> x - x
 
             { a: f 0, b: f 1, c: f 2, d: f 4 }
-                "#
+                "
         ),
         [0, 1, 2, 0],
         [i64; 4]
@@ -465,13 +465,13 @@ fn if_guard_multiple() {
 fn if_guard_constructor_switch() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             when Identity 32 0 is
                     Identity 41 _ -> 0
                     Identity s 0 if s == 32 -> 3
                     # Identity s 0 -> s
                     Identity z _ -> z
-                "#
+                "
         ),
         3,
         i64
@@ -509,12 +509,12 @@ fn if_guard_constructor_switch() {
 fn if_guard_constructor_chain() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             when Identity 43 0 is
                     Identity 42 _ if 3 == 3 -> 43
                     # Identity 42 _ -> 1
                     Identity z _ -> z
-                "#
+                "
         ),
         43,
         i64
@@ -526,14 +526,14 @@ fn if_guard_constructor_chain() {
 fn if_guard_pattern_false() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 wrapper = \{} ->
                     when 2 is
                         2 if Bool.false -> 0
                         _ -> 42
 
                 wrapper {}
-                "#
+                "
         ),
         42,
         i64
@@ -545,14 +545,14 @@ fn if_guard_pattern_false() {
 fn if_guard_switch() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 wrapper = \{} ->
                     when 2 is
                         2 | 3 if Bool.false -> 0
                         _ -> 42
 
                 wrapper {}
-                "#
+                "
         ),
         42,
         i64
@@ -564,14 +564,14 @@ fn if_guard_switch() {
 fn if_guard_pattern_true() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 wrapper = \{} ->
                     when 2 is
                         2 if Bool.true -> 42
                         _ -> 0
 
                 wrapper {}
-                "#
+                "
         ),
         42,
         i64
@@ -583,14 +583,14 @@ fn if_guard_pattern_true() {
 fn if_guard_exhaustiveness() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 wrapper = \{} ->
                     when 2 is
                         _ if Bool.false -> 0
                         _ -> 42
 
                 wrapper {}
-                "#
+                "
         ),
         42,
         i64
@@ -602,7 +602,7 @@ fn if_guard_exhaustiveness() {
 fn when_on_enum() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 Fruit : [Apple, Orange, Banana]
 
                 apple : Fruit
@@ -612,7 +612,7 @@ fn when_on_enum() {
                     Apple -> 1
                     Banana -> 2
                     Orange -> 3
-                "#
+                "
         ),
         1,
         i64
@@ -624,14 +624,14 @@ fn when_on_enum() {
 fn pattern_matching_unit() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 Unit : [Unit]
 
                 f : Unit -> I64
                 f = \Unit -> 42
 
                 f Unit
-                "#
+                "
         ),
         42,
         i64
@@ -639,7 +639,7 @@ fn pattern_matching_unit() {
 
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 Unit : [Unit]
 
                 x : Unit
@@ -647,7 +647,7 @@ fn pattern_matching_unit() {
 
                 when x is
                     Unit -> 42
-                "#
+                "
         ),
         42,
         i64
@@ -655,12 +655,12 @@ fn pattern_matching_unit() {
 
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 f : {} -> I64
                 f = \{} -> 42
 
                 f {}
-                "#
+                "
         ),
         42,
         i64
@@ -668,10 +668,10 @@ fn pattern_matching_unit() {
 
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 when {} is
                     {} -> 42
-                "#
+                "
         ),
         42,
         i64
@@ -683,12 +683,12 @@ fn pattern_matching_unit() {
 fn one_element_tag() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 x : [Pair I64]
                 x = Pair 2
 
                 x
-                "#
+                "
         ),
         2,
         i64
@@ -721,14 +721,14 @@ fn nested_tag_union() {
 fn unit_type() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 Unit : [Unit]
 
                 v : Unit
                 v = Unit
 
                 v
-                "#
+                "
         ),
         (),
         ()
@@ -740,12 +740,12 @@ fn unit_type() {
 fn join_point_if() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 x =
                     if Bool.true then 1 else 2
 
                 x
-                "#
+                "
         ),
         1,
         i64
@@ -757,7 +757,7 @@ fn join_point_if() {
 fn join_point_when() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             wrapper = \{} ->
                 x : [Red, White, Blue]
                 x = Blue
@@ -771,7 +771,7 @@ fn join_point_when() {
                 y
 
             wrapper {}
-            "#
+            "
         ),
         3.1,
         f64
@@ -783,7 +783,7 @@ fn join_point_when() {
 fn join_point_with_cond_expr() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 wrapper = \{} ->
                     y =
                         when 1 + 2 is
@@ -794,7 +794,7 @@ fn join_point_with_cond_expr() {
                     y
 
                 wrapper {}
-            "#
+            "
         ),
         3,
         i64
@@ -802,7 +802,7 @@ fn join_point_with_cond_expr() {
 
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             y =
                 if 1 + 2 > 0 then
                     3
@@ -810,7 +810,7 @@ fn join_point_with_cond_expr() {
                     0
 
             y
-            "#
+            "
         ),
         3,
         i64
@@ -1135,12 +1135,12 @@ fn applied_tag_function_pair() {
 fn tag_must_be_its_own_type() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             z : [A, B, C]
             z = Z
 
             z
-            "#
+            "
         ),
         1,
         i64
@@ -1171,12 +1171,12 @@ fn recursive_tag_union_into_flat_tag_union() {
 fn monomorphized_tag() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             b = \{} -> Bar
             f : [Foo, Bar], [Bar, Baz] -> U8
             f = \_, _ -> 18
             f (b {}) (b {})
-            "#
+            "
         ),
         18,
         u8
@@ -1391,7 +1391,7 @@ fn issue_2445() {
 fn issue_2458() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             Foo a : [Blah (Bar a), Nothing {}]
             Bar a : Foo a
 
@@ -1401,7 +1401,7 @@ fn issue_2458() {
             when v is
                 Blah (Blah (Nothing {})) -> 15
                 _ -> 25
-            "#
+            "
         ),
         15,
         u8
@@ -1471,11 +1471,11 @@ fn issue_1162() {
 fn polymorphic_tag() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             x : [Y U8]
             x = Y 3
             x
-            "#
+            "
         ),
         3, // Y is a newtype, it gets unwrapped
         u8
@@ -1487,11 +1487,11 @@ fn polymorphic_tag() {
 fn issue_2725_alias_polymorphic_lambda() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             wrap = \value -> Tag value
             wrapIt = wrap
             wrapIt 42
-            "#
+            "
         ),
         42, // Tag is a newtype, it gets unwrapped
         i64
@@ -1717,7 +1717,7 @@ fn instantiate_annotated_as_recursive_alias_multiple_polymorphic_expr() {
 fn issue_3560_nested_tag_constructor_is_newtype() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             f : _ -> u8
             f = \t ->
                 when t is
@@ -1725,7 +1725,7 @@ fn issue_3560_nested_tag_constructor_is_newtype() {
                     Wrapper (AlternatePayload it) -> it
 
             {a: f (Wrapper (Payload 15u8)), b: f(Wrapper (AlternatePayload 31u8))}
-            "#
+            "
         ),
         (15, 31),
         (u8, u8)
@@ -1737,7 +1737,7 @@ fn issue_3560_nested_tag_constructor_is_newtype() {
 fn issue_3560_nested_tag_constructor_is_record_newtype() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             f : _ -> u8
             f = \t ->
                 when t is
@@ -1745,7 +1745,7 @@ fn issue_3560_nested_tag_constructor_is_record_newtype() {
                     {wrapper: (AlternatePayload it)} -> it
 
             {a: f {wrapper: (Payload 15u8)}, b: f {wrapper: (AlternatePayload 31u8)}}
-            "#
+            "
         ),
         (15, 31),
         (u8, u8)
@@ -1791,7 +1791,7 @@ fn alignment_i128() {
 fn error_type_in_tag_union_payload() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             f : ([] -> Bool) -> Bool
             f = \fun ->
               if Bool.true then
@@ -1800,7 +1800,7 @@ fn error_type_in_tag_union_payload() {
                 Bool.false
 
             f (\x -> x)
-            "#
+            "
         ),
         0,
         u8,
@@ -1864,7 +1864,7 @@ fn issue_3653_recursion_pointer_in_naked_opaque_localized() {
 fn issue_2165_recursive_tag_destructure() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             SomeTag : [ Ctor { rec : List SomeTag } ]
 
             x : SomeTag
@@ -1872,7 +1872,7 @@ fn issue_2165_recursive_tag_destructure() {
 
             when x is
               Ctor { rec } -> Num.toStr (List.len rec)
-            "#
+            "
         ),
         RocStr::from("0"),
         RocStr
@@ -2183,7 +2183,7 @@ fn issue_5162_recast_nested_nullable_unwrapped_layout() {
     with_larger_debug_stack(|| {
         assert_evals_to!(
             indoc!(
-                r###"
+                r#"
                 app "test" provides [main] to "./platform"
 
                 Concept : [
@@ -2197,7 +2197,7 @@ fn issue_5162_recast_nested_nullable_unwrapped_layout() {
                 main =
                     when Dict.single bottom 0 is
                         _ -> Bool.true
-                "###
+                "#
             ),
             true,
             bool
@@ -2210,7 +2210,7 @@ fn issue_5162_recast_nested_nullable_unwrapped_layout() {
 fn nullable_wrapped_eq_issue_5434() {
     assert_evals_to!(
         indoc!(
-            r###"
+            r#"
             app "test" provides [main] to "./platform"
 
             Value : [
@@ -2229,7 +2229,7 @@ fn nullable_wrapped_eq_issue_5434() {
                     Bool.true
                 else
                     Bool.false
-            "###
+            "#
         ),
         false,
         bool
@@ -2241,7 +2241,7 @@ fn nullable_wrapped_eq_issue_5434() {
 fn recursive_tag_id_in_allocation_basic() {
     assert_evals_to!(
         indoc!(
-            r###"
+            r#"
             app "test" provides [main] to "./platform"
 
             Value : [
@@ -2270,7 +2270,7 @@ fn recursive_tag_id_in_allocation_basic() {
                     G _ -> "G"
                     H _ -> "H"
                     I _ -> "I"
-            "###
+            "#
         ),
         RocStr::from("H"),
         RocStr
@@ -2282,7 +2282,7 @@ fn recursive_tag_id_in_allocation_basic() {
 fn recursive_tag_id_in_allocation_eq() {
     assert_evals_to!(
         indoc!(
-            r###"
+            r#"
             app "test" provides [main] to "./platform"
 
             Value : [
@@ -2304,7 +2304,7 @@ fn recursive_tag_id_in_allocation_eq() {
             y = H 42
 
             main = (x == x) && (x != y) && (y == y)
-            "###
+            "#
         ),
         true,
         bool

--- a/crates/compiler/test_gen/src/gen_tuples.rs
+++ b/crates/compiler/test_gen/src/gen_tuples.rs
@@ -18,9 +18,9 @@ use roc_std::RocStr;
 fn basic_tuple() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                     ( 15, 17, 19 ).0
-                "#
+                "
         ),
         15,
         i64
@@ -28,9 +28,9 @@ fn basic_tuple() {
 
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                     ( 15, 17, 19 ).1
-                "#
+                "
         ),
         17,
         i64
@@ -38,9 +38,9 @@ fn basic_tuple() {
 
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                     ( 15, 17, 19 ).2
-                "#
+                "
         ),
         19,
         i64
@@ -52,11 +52,11 @@ fn basic_tuple() {
 fn f64_tuple() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                    tup = (17.2f64, 15.1f64, 19.3f64)
 
                    tup.0
-                "#
+                "
         ),
         17.2,
         f64
@@ -64,11 +64,11 @@ fn f64_tuple() {
 
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                    tup = (17.2f64, 15.1f64, 19.3f64)
 
                    tup.1
-                "#
+                "
         ),
         15.1,
         f64
@@ -76,11 +76,11 @@ fn f64_tuple() {
 
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                     tup = (17.2f64, 15.1f64, 19.3f64)
 
                     tup.2
-                "#
+                "
         ),
         19.3,
         f64
@@ -104,11 +104,11 @@ fn fn_tuple() {
 
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                     rec = (15, 17, 19)
 
                     rec.2 + rec.0
-                "#
+                "
         ),
         34,
         i64
@@ -120,11 +120,11 @@ fn fn_tuple() {
 fn int_tuple() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                     rec = (15, 17, 19)
 
                     rec.0
-                "#
+                "
         ),
         15,
         i64
@@ -132,11 +132,11 @@ fn int_tuple() {
 
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                     rec = (15, 17, 19)
 
                     rec.1
-                "#
+                "
         ),
         17,
         i64
@@ -144,11 +144,11 @@ fn int_tuple() {
 
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                     rec = (15, 17, 19)
 
                     rec.2
-                "#
+                "
         ),
         19,
         i64
@@ -160,10 +160,10 @@ fn int_tuple() {
 fn when_on_tuple() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 when (0x2, 0x3) is
                     (x, y) -> x + y
-                "#
+                "
         ),
         5,
         i64
@@ -175,10 +175,10 @@ fn when_on_tuple() {
 fn when_tuple_with_guard_pattern() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 when (0x2, 1.23) is
                     (var, _) -> var + 3
-                "#
+                "
         ),
         5,
         i64
@@ -190,11 +190,11 @@ fn when_tuple_with_guard_pattern() {
 fn let_with_tuple_pattern() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 (x, _ ) = (0x2, 1.23)
 
                 x
-                "#
+                "
         ),
         2,
         i64
@@ -202,11 +202,11 @@ fn let_with_tuple_pattern() {
 
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 (_, y) = (0x2, 0x3)
 
                 y
-                "#
+                "
         ),
         3,
         i64
@@ -218,11 +218,11 @@ fn let_with_tuple_pattern() {
 fn tuple_guard_pattern() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 when (0x2, 1.23) is
                     (0x4, _) -> 5
                     (x, _) -> x + 4
-                "#
+                "
         ),
         6,
         i64
@@ -230,11 +230,11 @@ fn tuple_guard_pattern() {
 
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 when (0x2, 0x3) is
                     (_, 0x4) -> 5
                     (_, x) -> x + 4
-                "#
+                "
         ),
         7,
         i64
@@ -246,11 +246,11 @@ fn tuple_guard_pattern() {
 fn twice_tuple_access() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 x =  (0x2, 0x3)
 
                 x.0 + x.1
-                "#
+                "
         ),
         5,
         i64
@@ -262,9 +262,9 @@ fn twice_tuple_access() {
 fn i64_tuple2_literal() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                    (3, 5)
-                "#
+                "
         ),
         (3, 5),
         (i64, i64)
@@ -276,9 +276,9 @@ fn i64_tuple2_literal() {
 fn i64_tuple3_literal() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                (3, 5, 17)
-            "#
+            "
         ),
         (3, 5, 17),
         (i64, i64, i64)
@@ -290,9 +290,9 @@ fn i64_tuple3_literal() {
 fn f64_tuple2_literal() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                    (3.1f64, 5.1f64)
-                "#
+                "
         ),
         (3.1, 5.1),
         (f64, f64)
@@ -304,12 +304,12 @@ fn f64_tuple2_literal() {
 fn bool_tuple4_literal() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                tuple : (Bool, Bool, Bool, Bool)
                tuple = (Bool.true, Bool.false, Bool.false, Bool.true)
 
                tuple
-            "#
+            "
         ),
         (true, false, false, true),
         (bool, bool, bool, bool)
@@ -323,9 +323,9 @@ fn bool_tuple4_literal() {
 fn i64_tuple9_literal() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                ( 3, 5, 17, 1, 9, 12, 13, 14, 15 )
-            "#
+            "
         ),
         [3, 5, 17, 1, 9, 12, 13, 14, 15],
         [i64; 9]
@@ -337,12 +337,12 @@ fn i64_tuple9_literal() {
 fn return_tuple() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 x = 4
                 y = 3
 
                 (x, y)
-                "#
+                "
         ),
         (4, 3),
         (i64, i64)
@@ -354,9 +354,9 @@ fn return_tuple() {
 fn return_tuple_2() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 (3, 5)
-                "#
+                "
         ),
         [3, 5],
         [i64; 2]
@@ -368,9 +368,9 @@ fn return_tuple_2() {
 fn return_tuple_3() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 ( 3, 5, 4 )
-                "#
+                "
         ),
         (3, 5, 4),
         (i64, i64, i64)
@@ -382,9 +382,9 @@ fn return_tuple_3() {
 fn return_tuple_4() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 ( 3, 5, 4, 2 )
-                "#
+                "
         ),
         [3, 5, 4, 2],
         [i64; 4]
@@ -398,9 +398,9 @@ fn return_tuple_4() {
 fn return_tuple_5() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 ( 3, 5, 4, 2, 1 )
-                "#
+                "
         ),
         [3, 5, 4, 2, 1],
         [i64; 5]
@@ -414,9 +414,9 @@ fn return_tuple_5() {
 fn return_tuple_6() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 ( 3, 5, 4, 2, 1, 7 )
-                "#
+                "
         ),
         [3, 5, 4, 2, 1, 7],
         [i64; 6]
@@ -430,9 +430,9 @@ fn return_tuple_6() {
 fn return_tuple_7() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 ( 3, 5, 4, 2, 1, 7, 8 )
-                "#
+                "
         ),
         [3, 5, 4, 2, 1, 7, 8],
         [i64; 7]
@@ -444,9 +444,9 @@ fn return_tuple_7() {
 fn return_tuple_float_int() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 (1.23f64, 0x1)
-                "#
+                "
         ),
         (1.23, 0x1),
         (f64, i64)
@@ -458,9 +458,9 @@ fn return_tuple_float_int() {
 fn return_tuple_int_float() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 ( 0x1, 1.23f64 )
-                "#
+                "
         ),
         (0x1, 1.23),
         (i64, f64)
@@ -472,9 +472,9 @@ fn return_tuple_int_float() {
 fn return_tuple_float_float() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 ( 2.46f64, 1.23f64 )
-                "#
+                "
         ),
         (2.46, 1.23),
         (f64, f64)
@@ -486,9 +486,9 @@ fn return_tuple_float_float() {
 fn return_tuple_float_float_float() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 ( 2.46f64, 1.23f64, 0.1f64 )
-                "#
+                "
         ),
         (2.46, 1.23, 0.1),
         (f64, f64, f64)
@@ -500,9 +500,9 @@ fn return_tuple_float_float_float() {
 fn return_nested_tuple() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 (0x0, (2.46f64, 1.23f64, 0.1f64))
-                "#
+                "
         ),
         (0x0, (2.46, 1.23, 0.1)),
         (i64, (f64, f64, f64))
@@ -514,13 +514,13 @@ fn return_nested_tuple() {
 fn nested_tuple_load() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
                 x = (0, (0x2, 0x5, 0x6))
 
                 y = x.1
 
                 y.2
-                "#
+                "
         ),
         6,
         i64
@@ -572,7 +572,7 @@ fn alignment_in_tuple() {
 fn tuple_length_polymorphism() {
     assert_evals_to!(
         indoc!(
-            r#"
+            r"
             a = (42, 43)
             b = (1, 2, 44)
 
@@ -580,7 +580,7 @@ fn tuple_length_polymorphism() {
             f = \(x1, x2), (x3, x4) -> x1 + x2 + x3 + x4
 
             f a b
-            "#
+            "
         ),
         88,
         i64

--- a/crates/compiler/test_mono/src/tests.rs
+++ b/crates/compiler/test_mono/src/tests.rs
@@ -252,133 +252,133 @@ fn verify_procedures<'a>(
 
 #[mono_test]
 fn ir_int_literal() {
-    r#"
+    r"
     5
-    "#
+    "
 }
 
 #[mono_test]
 fn ir_int_add() {
-    r#"
+    r"
     x = [1,2]
     5 + 4 + 3 + List.len x
-    "#
+    "
 }
 
 #[mono_test]
 fn ir_assignment() {
-    r#"
+    r"
     x = 5
 
     x
-    "#
+    "
 }
 
 #[mono_test]
 fn ir_when_maybe() {
-    r#"
+    r"
     when Just 3 is
         Just n -> n
         Nothing -> 0
-    "#
+    "
 }
 
 #[mono_test]
 fn ir_when_these() {
-    r#"
+    r"
     when These 1 2 is
         This x -> x
         That y -> y
         These x _ -> x
-    "#
+    "
 }
 
 #[mono_test]
 fn ir_when_record() {
-    r#"
+    r"
     when { x: 1, y: 3.14 } is
         { x } -> x
-    "#
+    "
 }
 
 #[mono_test]
 fn ir_plus() {
-    r#"
+    r"
     1 + 2
-    "#
+    "
 }
 
 #[mono_test]
 fn ir_round() {
-    r#"
+    r"
     Num.round 3.6
-    "#
+    "
 }
 
 #[mono_test]
 fn ir_when_idiv() {
-    r#"
+    r"
     when Num.divTruncChecked 1000 10 is
         Ok val -> val
         Err _ -> -1
-    "#
+    "
 }
 
 #[mono_test]
 fn ir_two_defs() {
-    r#"
+    r"
     x = 3
     y = 4
 
     x + y
-    "#
+    "
 }
 
 #[mono_test]
 fn ir_when_just() {
-    r#"
+    r"
     x : [Nothing, Just I64]
     x = Just 41
 
     when x is
         Just v -> v + 0x1
         Nothing -> 0x1
-    "#
+    "
 }
 
 #[mono_test]
 fn one_element_tag() {
-    r#"
+    r"
     x : [Pair I64]
     x = Pair 2
 
     x
-    "#
+    "
 }
 
 #[mono_test]
 fn guard_pattern_true() {
-    r#"
+    r"
     wrapper = \{} ->
         when 2 is
             2 if Bool.false -> 42
             _ -> 0
 
     wrapper {}
-    "#
+    "
 }
 
 #[mono_test]
 fn when_on_record() {
-    r#"
+    r"
     when { x: 0x2 } is
         { x } -> x + 3
-    "#
+    "
 }
 
 #[mono_test]
 fn when_nested_maybe() {
-    r#"
+    r"
     Maybe a : [Nothing, Just a]
 
     x : Maybe (Maybe I64)
@@ -387,56 +387,56 @@ fn when_nested_maybe() {
     when x is
         Just (Just v) -> v + 0x1
         _ -> 0x1
-    "#
+    "
 }
 
 #[mono_test]
 fn when_on_two_values() {
-    r#"
+    r"
     when Pair 2 3 is
         Pair 4 3 -> 9
         Pair a b -> a + b
-    "#
+    "
 }
 
 #[mono_test]
 fn dict() {
-    r#"
+    r"
     Dict.len (Dict.empty {})
-    "#
+    "
 }
 
 #[mono_test]
 fn list_append_closure() {
-    r#"
+    r"
     myFunction = \l -> List.append l 42
 
     myFunction [1, 2]
-    "#
+    "
 }
 
 #[mono_test]
 fn list_append() {
     // TODO this leaks at the moment
     // ListAppend needs to decrement its arguments
-    r#"
+    r"
     List.append [1] 2
-    "#
+    "
 }
 
 #[mono_test]
 fn list_len() {
-    r#"
+    r"
     x = [1,2,3]
     y = [1.0]
 
     List.len x + List.len y
-    "#
+    "
 }
 
 #[mono_test]
 fn when_joinpoint() {
-    r#"
+    r"
     wrapper = \{} ->
         x : [Red, White, Blue]
         x = Blue
@@ -450,34 +450,34 @@ fn when_joinpoint() {
         y
 
     wrapper {}
-    "#
+    "
 }
 
 #[mono_test]
 fn simple_if() {
-    r#"
+    r"
     if Bool.true then
         1
     else
         2
-    "#
+    "
 }
 
 #[mono_test]
 fn if_multi_branch() {
-    r#"
+    r"
     if Bool.true then
         1
     else if Bool.false then
         2
     else
         3
-    "#
+    "
 }
 
 #[mono_test]
 fn when_on_result() {
-    r#"
+    r"
     wrapper = \{} ->
         x : Result I64 I64
         x = Ok 2
@@ -490,71 +490,71 @@ fn when_on_result() {
         y
 
     wrapper {}
-    "#
+    "
 }
 
 #[mono_test]
 fn let_with_record_pattern() {
-    r#"
+    r"
     { x } = { x: 0x2, y: 3.14 }
 
     x
-    "#
+    "
 }
 
 #[mono_test]
 fn let_with_record_pattern_list() {
-    r#"
+    r"
     { x } = { x: [1, 3, 4], y: 3.14 }
 
     x
-    "#
+    "
 }
 
 #[mono_test]
 fn if_guard_bind_variable_false() {
-    r#"
+    r"
     wrapper = \{} ->
         when 10 is
             x if x == 5 -> 0
             _ -> 42
 
     wrapper {}
-    "#
+    "
 }
 
 #[mono_test]
 fn alias_variable() {
-    r#"
+    r"
     x = 5
     y = x
 
     3
-    "#
+    "
 }
 
 #[mono_test]
 fn alias_variable_and_return_it() {
-    r#"
+    r"
     x = 5
     y = x
 
     y
-    "#
+    "
 }
 
 #[mono_test]
 fn branch_store_variable() {
-    r#"
+    r"
     when 0 is
         1 -> 12
         a -> a
-    "#
+    "
 }
 
 #[mono_test]
 fn list_pass_to_function() {
-    r#"
+    r"
     x : List I64
     x = [1,2,3]
 
@@ -562,57 +562,57 @@ fn list_pass_to_function() {
     id = \y -> List.set y 0 0
 
     id x
-    "#
+    "
 }
 
 #[mono_test]
 fn record_optional_field_let_no_use_default() {
-    r#"
+    r"
     f = \r ->
         { x ? 10, y } = r
         x + y
 
 
     f { x: 4, y: 9 }
-    "#
+    "
 }
 
 #[mono_test]
 fn record_optional_field_let_use_default() {
-    r#"
+    r"
     f = \r ->
         { x ? 10, y } = r
         x + y
 
 
     f { y: 9 }
-    "#
+    "
 }
 
 #[mono_test]
 fn record_optional_field_function_no_use_default() {
-    r#"
+    r"
     f = \{ x ? 10, y } -> x + y
 
 
     f { x: 4, y: 9 }
-    "#
+    "
 }
 
 #[mono_test]
 fn record_optional_field_function_use_default() {
-    r#"
+    r"
     f = \{ x ? 10, y } -> x + y
 
 
     f { y: 9 }
-    "#
+    "
 }
 
 #[mono_test]
 fn quicksort_help() {
     // do we still need with_larger_debug_stack?
-    r#"
+    r"
     quicksortHelp : List (Num a), I64, I64 -> List (Num a)
     quicksortHelp = \list, low, high ->
         if low < high then
@@ -625,7 +625,7 @@ fn quicksort_help() {
             list
 
     quicksortHelp [] 0 0
-    "#
+    "
 }
 
 #[mono_test]
@@ -745,7 +745,7 @@ fn quicksort_swap() {
 
 #[mono_test]
 fn factorial() {
-    r#"
+    r"
     factorial = \n, accum ->
         when n is
             0 ->
@@ -755,12 +755,12 @@ fn factorial() {
                 factorial (n - 1) (n * accum)
 
     factorial 10 1
-    "#
+    "
 }
 
 #[mono_test]
 fn is_nil() {
-    r#"
+    r"
     ConsList a : [Cons a (ConsList a), Nil]
 
     isNil : ConsList a -> Bool
@@ -770,13 +770,13 @@ fn is_nil() {
             Cons _ _ -> Bool.false
 
     isNil (Cons 0x2 Nil)
-    "#
+    "
 }
 
 #[mono_test]
 #[ignore]
 fn has_none() {
-    r#"
+    r"
     Maybe a : [Just a, Nothing]
     ConsList a : [Cons a (ConsList a), Nil]
 
@@ -788,7 +788,7 @@ fn has_none() {
             Cons (Just _) xs -> hasNone xs
 
     hasNone (Cons (Just 3) Nil)
-    "#
+    "
 }
 
 #[mono_test]
@@ -839,29 +839,29 @@ fn list_cannot_update_inplace() {
 
 #[mono_test]
 fn list_get() {
-    r#"
+    r"
     wrapper = \{} ->
         List.get [1,2,3] 0
 
     wrapper {}
-    "#
+    "
 }
 
 #[mono_test]
 fn peano() {
-    r#"
+    r"
     Peano : [S Peano, Z]
 
     three : Peano
     three = S (S (S Z))
 
     three
-    "#
+    "
 }
 
 #[mono_test]
 fn peano1() {
-    r#"
+    r"
     Peano : [S Peano, Z]
 
     three : Peano
@@ -870,12 +870,12 @@ fn peano1() {
     when three is
         Z -> 0
         S _ -> 1
-    "#
+    "
 }
 
 #[mono_test]
 fn peano2() {
-    r#"
+    r"
     Peano : [S Peano, Z]
 
     three : Peano
@@ -885,12 +885,12 @@ fn peano2() {
         S (S _) -> 1
         S (_) -> 0
         Z -> 0
-    "#
+    "
 }
 
 #[mono_test]
 fn optional_when() {
-    r#"
+    r"
     f = \r ->
         when r is
             { x: Blue, y ? 3 } -> y
@@ -902,15 +902,15 @@ fn optional_when() {
     d = f { x: Red }
 
     a * b * c * d
-    "#
+    "
 }
 
 #[mono_test]
 fn optional_field_with_binary_op() {
-    r#"
+    r"
         { bar ? 1 + 1 } = {}
         bar
-    "#
+    "
 }
 
 #[mono_test]
@@ -924,7 +924,7 @@ fn nested_optional_field_with_binary_op() {
 
 #[mono_test]
 fn multiline_record_pattern() {
-    r#"
+    r"
         x = { a: 1, b: 2, c: 3 }
         {
             a,
@@ -933,12 +933,12 @@ fn multiline_record_pattern() {
         } = x
 
         a + b + c
-    "#
+    "
 }
 
 #[mono_test]
 fn nested_pattern_match() {
-    r#"
+    r"
     Maybe a : [Nothing, Just a]
 
     x : Maybe (Maybe I64)
@@ -947,13 +947,13 @@ fn nested_pattern_match() {
     when x is
         Just (Just v) -> v + 0x1
         _ -> 0x1
-    "#
+    "
 }
 
 #[mono_test]
 #[ignore]
 fn linked_list_length_twice() {
-    r#"
+    r"
     LinkedList a : [Nil, Cons a (LinkedList a)]
 
     nil : LinkedList I64
@@ -966,7 +966,7 @@ fn linked_list_length_twice() {
             Cons _ rest -> 1 + length rest
 
     length nil + length nil
-    "#
+    "
 }
 
 #[mono_test]
@@ -996,7 +996,7 @@ fn rigids() {
 
 #[mono_test]
 fn let_x_in_x() {
-    r#"
+    r"
     x = 5
 
     answer =
@@ -1007,12 +1007,12 @@ fn let_x_in_x() {
         nested
 
     answer
-    "#
+    "
 }
 
 #[mono_test]
 fn let_x_in_x_indirect() {
-    r#"
+    r"
     x = 5
 
     answer =
@@ -1026,7 +1026,7 @@ fn let_x_in_x_indirect() {
         nested
 
     { answer, unused }.answer
-    "#
+    "
 }
 
 #[mono_test]
@@ -1310,13 +1310,13 @@ fn monomorphized_applied_tag() {
 #[ignore = "Cannot compile polymorphic closures yet"]
 fn aliased_polymorphic_closure() {
     indoc!(
-        r#"
+        r"
         n : U8
         n = 1
         f = \{} -> (\a -> n)
         g = f {}
         g {}
-        "#
+        "
     )
 }
 
@@ -1341,11 +1341,11 @@ fn issue_2535_let_weakened_fields_referenced_in_list() {
 #[mono_test]
 fn issue_2725_alias_polymorphic_lambda() {
     indoc!(
-        r#"
+        r"
         wrap = \value -> Tag value
         wrapIt = wrap
         wrapIt 42
-        "#
+        "
     )
 }
 
@@ -1361,7 +1361,7 @@ fn issue_2583_specialize_errors_behind_unified_branches() {
 #[mono_test]
 fn issue_2810() {
     indoc!(
-        r#"
+        r"
         Command : [Command Tool]
 
         Job : [Job Command]
@@ -1371,7 +1371,7 @@ fn issue_2810() {
         a : Job
         a = Job (Command (FromJob (Job (Command SystemTool))))
         a
-        "#
+        "
     )
 }
 
@@ -1608,14 +1608,14 @@ fn choose_correct_recursion_var_under_record() {
 #[mono_test]
 fn tail_call_elimination() {
     indoc!(
-        r#"
+        r"
         sum = \n, accum ->
             when n is
                 0 -> accum
                 _ -> sum (n - 1) (n + accum)
 
         sum 1_000_000 0
-        "#
+        "
     )
 }
 
@@ -1650,7 +1650,7 @@ fn tail_call_with_different_layout() {
 #[mono_test]
 fn lambda_capture_niche_u8_vs_u64() {
     indoc!(
-        r#"
+        r"
         capture : _ -> ({} -> Str)
         capture = \val ->
             \{} ->
@@ -1665,7 +1665,7 @@ fn lambda_capture_niche_u8_vs_u64() {
                 False -> capture 18u8
 
         fun {}
-        "#
+        "
     )
 }
 
@@ -1777,37 +1777,37 @@ fn lambda_set_niche_same_layout_different_constructor() {
 #[mono_test]
 fn choose_u64_layout() {
     indoc!(
-        r#"
+        r"
         9999999999999999999 + 1
-        "#
+        "
     )
 }
 
 #[mono_test]
 fn choose_i128_layout() {
     indoc!(
-        r#"
+        r"
         {
             a: 18446744073709551616 + 1,
             b: -9223372036854775809 + 1,
         }
-        "#
+        "
     )
 }
 
 #[mono_test]
 fn choose_u128_layout() {
     indoc!(
-        r#"
+        r"
         170141183460469231731687303715884105728 + 1
-        "#
+        "
     )
 }
 
 #[mono_test]
 fn recursive_call_capturing_function() {
     indoc!(
-        r#"
+        r"
         a = \b ->
             c : U32 -> U32
             c = \d ->
@@ -1815,28 +1815,28 @@ fn recursive_call_capturing_function() {
             c 0
 
         a 6
-        "#
+        "
     )
 }
 
 #[mono_test]
 fn call_function_in_empty_list() {
     indoc!(
-        r#"
+        r"
         lst : List ({} -> {})
         lst = []
         List.map lst \f -> f {}
-        "#
+        "
     )
 }
 
 #[mono_test]
 fn call_function_in_empty_list_unbound() {
     indoc!(
-        r#"
+        r"
         lst = []
         List.map lst \f -> f {}
-        "#
+        "
     )
 }
 
@@ -2048,9 +2048,9 @@ fn issue_3669() {
 #[mono_test]
 fn num_width_gt_u8_layout_as_float() {
     indoc!(
-        r#"
+        r"
         1 / 200
-        "#
+        "
     )
 }
 
@@ -2254,7 +2254,7 @@ fn tuple_pattern_match() {
 #[mono_test(mode = "test")]
 fn issue_4705() {
     indoc!(
-        r###"
+        r"
         interface Test exposes [] imports []
 
         go : {} -> Bool
@@ -2264,28 +2264,28 @@ fn issue_4705() {
             input = {}
             x = go input
             x
-        "###
+        "
     )
 }
 
 #[mono_test(mode = "test", large_stack = "true")]
 fn issue_4749() {
     indoc!(
-        r###"
+        r#"
         interface Test exposes [] imports [TotallyNotJson]
 
         expect
             input = [82, 111, 99]
             got = Decode.fromBytes input TotallyNotJson.json
             got == Ok "Roc"
-        "###
+        "#
     )
 }
 
 #[mono_test(mode = "test")]
 fn lambda_set_with_imported_toplevels_issue_4733() {
     indoc!(
-        r###"
+        r"
         interface Test exposes [] imports []
 
         fn = \{} ->
@@ -2297,28 +2297,28 @@ fn lambda_set_with_imported_toplevels_issue_4733() {
             \a -> op a a
 
         expect ((fn {}) 3) == 9
-        "###
+        "
     )
 }
 
 #[mono_test]
 fn order_list_size_tests_issue_4732() {
     indoc!(
-        r###"
+        r#"
         when [] is
             [1, ..]          -> "B1"
             [2, 1, ..]       -> "B2"
             [3, 2, 1, ..]    -> "B3"
             [4, 3, 2, 1, ..] -> "B4"
             _                -> "Catchall"
-        "###
+        "#
     )
 }
 
 #[mono_test]
 fn anonymous_closure_in_polymorphic_expression_issue_4717() {
     indoc!(
-        r###"
+        r#"
         app "test" provides [main] to "platform"
 
         chompWhile : (List U8) -> (List U8)
@@ -2331,14 +2331,14 @@ fn anonymous_closure_in_polymorphic_expression_issue_4717() {
                     List.dropFirst input index
 
         main = chompWhile [1u8, 2u8, 3u8]
-        "###
+        "#
     )
 }
 
 #[mono_test]
 fn list_map_take_capturing_or_noncapturing() {
     indoc!(
-        r###"
+        r#"
         app "test" provides [main] to "platform"
 
         main =
@@ -2355,28 +2355,28 @@ fn list_map_take_capturing_or_noncapturing() {
                     k = \n -> n + n
                     k
             List.map [1u8, 2u8, 3u8] f
-        "###
+        "#
     )
 }
 
 #[mono_test]
 fn issue_4557() {
     indoc!(
-        r###"
+        r#"
         app "test" provides [main] to "./platform"
 
         isEqQ = \q1, q2 -> when T q1 q2 is
             T (U f1) (U f2) -> Bool.or (isEqQ (U f2) (U f1)) (f1 {} == f2 {})
 
         main = isEqQ (U \{} -> "a") (U \{} -> "a")
-        "###
+        "#
     )
 }
 
 #[mono_test]
 fn nullable_wrapped_with_nullable_not_last_index() {
     indoc!(
-        r###"
+        r#"
         app "test" provides [main] to "./platform"
 
         Parser : [
@@ -2393,14 +2393,14 @@ fn nullable_wrapped_with_nullable_not_last_index() {
                 CharLiteral -> "c"
 
         main = toIdParser CharLiteral == "c"
-        "###
+        "#
     )
 }
 
 #[mono_test]
 fn pattern_as_toplevel() {
     indoc!(
-        r###"
+        r#"
         app "test" provides [main] to "./platform"
 
         record = { a: 42i64, b: "foo" }
@@ -2409,14 +2409,14 @@ fn pattern_as_toplevel() {
             when record is
                 { a: 42i64 } as r -> record == r
                 _ -> Bool.false
-        "###
+        "#
     )
 }
 
 #[mono_test]
 fn pattern_as_nested() {
     indoc!(
-        r###"
+        r#"
         app "test" provides [main] to "./platform"
 
         record = { a: 42i64, b: "foo" }
@@ -2425,20 +2425,20 @@ fn pattern_as_nested() {
             when Pair {} record is
                 Pair {} ({ a: 42i64 } as r) -> record == r
                 _ -> Bool.false
-        "###
+        "#
     )
 }
 
 #[mono_test]
 fn pattern_as_of_symbol() {
     indoc!(
-        r###"
+        r#"
         app "test" provides [main] to "./platform"
 
         main =
             when "foo" is
                 a as b -> a == b
-        "###
+        "#
     )
 }
 
@@ -2447,7 +2447,7 @@ fn function_specialization_information_in_lambda_set_thunk() {
     // https://github.com/roc-lang/roc/issues/4734
     // https://rwx.notion.site/Let-generalization-Let-s-not-742a3ab23ff742619129dcc848a271cf#6b08b0a203fb443db2d7238a0eb154eb
     indoc!(
-        r###"
+        r#"
         app "test" provides [main] to "./platform"
 
         andThen = \{} ->
@@ -2457,7 +2457,7 @@ fn function_specialization_information_in_lambda_set_thunk() {
         between = andThen {}
 
         main = between \{} -> between \{} -> 10
-        "###
+        "#
     )
 }
 
@@ -2466,7 +2466,7 @@ fn function_specialization_information_in_lambda_set_thunk_independent_defs() {
     // https://github.com/roc-lang/roc/issues/4734
     // https://rwx.notion.site/Let-generalization-Let-s-not-742a3ab23ff742619129dcc848a271cf#6b08b0a203fb443db2d7238a0eb154eb
     indoc!(
-        r###"
+        r#"
         app "test" provides [main] to "./platform"
 
         andThen = \{} ->
@@ -2478,14 +2478,14 @@ fn function_specialization_information_in_lambda_set_thunk_independent_defs() {
         between2 = andThen {}
 
         main = between1 \{} -> between2 \{} -> 10u8
-        "###
+        "#
     )
 }
 
 #[mono_test(mode = "test", large_stack = "true")]
 fn issue_4772_weakened_monomorphic_destructure() {
     indoc!(
-        r###"
+        r#"
         interface Test exposes [] imports [TotallyNotJson]
 
         getNumber =
@@ -2505,7 +2505,7 @@ fn issue_4772_weakened_monomorphic_destructure() {
         expect
             result = getNumber
             result == Ok {val : -1234i64, input : []}
-        "###
+        "#
     )
 }
 
@@ -2515,7 +2515,7 @@ fn weakening_avoids_overspecialization() {
     // `index` - to `Nat` and the default integer type, `I64`. The test is to ensure only one
     // specialization, that of `Nat`, exists.
     indoc!(
-        r###"
+        r#"
         app "test" provides [main] to "./platform"
 
         main : (List U8) -> (List U8)
@@ -2526,7 +2526,7 @@ fn weakening_avoids_overspecialization() {
                 input
             else
                 List.dropFirst input index
-        "###
+        "#
     )
 }
 
@@ -3124,13 +3124,13 @@ fn drop_specialize_after_jump() {
 #[mono_test(mode = "test")]
 fn dbg_in_expect() {
     indoc!(
-        r###"
+        r#"
         interface Test exposes [] imports []
 
         expect
             dbg ""
             Bool.true
-        "###
+        "#
     )
 }
 

--- a/crates/compiler/test_syntax/tests/test_fmt.rs
+++ b/crates/compiler/test_syntax/tests/test_fmt.rs
@@ -152,22 +152,22 @@ mod test_fmt {
         expr_formats_to(
             &format!(
                 indoc!(
-                    r#"
+                    r"
             # first comment{space}
             x = 0 # second comment{space}
 
             x
-            "#
+            "
                 ),
                 space = " ",
             ),
             indoc!(
-                r#"
+                r"
             # first comment
             x = 0 # second comment
 
             x
-            "#
+            "
             ),
         );
     }
@@ -175,59 +175,59 @@ mod test_fmt {
     #[test]
     fn def_with_inline_comment() {
         expr_formats_same(indoc!(
-            r#"
+            r"
             x = 0 # comment
 
             x
-            "#
+            "
         ));
 
         expr_formats_to(
             indoc!(
-                r#"
+                r"
                 x = 0# comment
 
                 x
-                "#
+                "
             ),
             indoc!(
-                r#"
+                r"
                 x = 0 # comment
 
                 x
-                "#
+                "
             ),
         );
 
         expr_formats_to(
             indoc!(
-                r#"
+                r"
                 x = 0# comment
                 x
-                "#
+                "
             ),
             indoc!(
-                r#"
+                r"
                 x = 0 # comment
                 x
-                "#
+                "
             ),
         );
 
         expr_formats_to(
             indoc!(
-                r#"
+                r"
                 x = 0  # comment
 
                 x
-                "#
+                "
             ),
             indoc!(
-                r#"
+                r"
                 x = 0 # comment
 
                 x
-                "#
+                "
             ),
         );
     }
@@ -261,7 +261,7 @@ mod test_fmt {
     #[test]
     fn type_annotation_allow_blank_line_before_and_after_comment() {
         expr_formats_same(indoc!(
-            r#"
+            r"
                 person : {
                     firstName : Str,
                     # comment
@@ -269,11 +269,11 @@ mod test_fmt {
                 }
 
                 person
-                "#
+                "
         ));
 
         expr_formats_same(indoc!(
-            r#"
+            r"
                 person : {
                     firstName : Str,
 
@@ -282,11 +282,11 @@ mod test_fmt {
                 }
 
                 person
-                "#
+                "
         ));
 
         expr_formats_same(indoc!(
-            r#"
+            r"
                 person : {
                     firstName : Str,
                     # comment
@@ -295,11 +295,11 @@ mod test_fmt {
                 }
 
                 person
-                "#
+                "
         ));
 
         expr_formats_same(indoc!(
-            r#"
+            r"
                 person : {
                     firstName : Str,
 
@@ -309,11 +309,11 @@ mod test_fmt {
                 }
 
                 person
-                "#
+                "
         ));
 
         expr_formats_same(indoc!(
-            r#"
+            r"
                 person : {
                     firstName : Str,
 
@@ -326,11 +326,11 @@ mod test_fmt {
                 }
 
                 person
-                "#
+                "
         ));
 
         expr_formats_same(indoc!(
-            r#"
+            r"
                 person : {
                     firstName : Str,
 
@@ -342,12 +342,12 @@ mod test_fmt {
                 }
 
                 person
-                "#
+                "
         ));
 
         expr_formats_to(
             indoc!(
-                r#"
+                r"
                 person : {
 
                     # comment
@@ -357,10 +357,10 @@ mod test_fmt {
                 }
 
                 person
-                "#
+                "
             ),
             indoc!(
-                r#"
+                r"
                 person : {
                     # comment
 
@@ -369,112 +369,112 @@ mod test_fmt {
                 }
 
                 person
-                "#
-            ),
-        );
-
-        expr_formats_to(
-            indoc!(
-                r#"
-                person : {
-                    firstName : Str,
-                    lastName : Str,
-
-                    # comment
-
-                }
-
-                person
-                "#
-            ),
-            indoc!(
-                r#"
-                person : {
-                    firstName : Str,
-                    lastName : Str,
-
-                    # comment
-                }
-
-                person
-                "#
+                "
             ),
         );
 
         expr_formats_to(
             indoc!(
-                r#"
+                r"
                 person : {
                     firstName : Str,
-
+                    lastName : Str,
 
                     # comment
-                    lastName : Str,
+
                 }
 
                 person
-                "#
+                "
             ),
             indoc!(
-                r#"
+                r"
                 person : {
                     firstName : Str,
+                    lastName : Str,
 
                     # comment
-                    lastName : Str,
                 }
 
                 person
-                "#
-            ),
-        );
-
-        expr_formats_to(
-            indoc!(
-                r#"
-                person : {
-                    firstName : Str,
-                    # comment
-
-
-                    lastName : Str,
-                }
-
-                person
-                "#
-            ),
-            indoc!(
-                r#"
-                person : {
-                    firstName : Str,
-                    # comment
-
-                    lastName : Str,
-                }
-
-                person
-                "#
+                "
             ),
         );
 
         expr_formats_to(
             indoc!(
-                r#"
+                r"
                 person : {
                     firstName : Str,
 
 
                     # comment
-
-
                     lastName : Str,
                 }
 
                 person
-                "#
+                "
             ),
             indoc!(
-                r#"
+                r"
+                person : {
+                    firstName : Str,
+
+                    # comment
+                    lastName : Str,
+                }
+
+                person
+                "
+            ),
+        );
+
+        expr_formats_to(
+            indoc!(
+                r"
+                person : {
+                    firstName : Str,
+                    # comment
+
+
+                    lastName : Str,
+                }
+
+                person
+                "
+            ),
+            indoc!(
+                r"
+                person : {
+                    firstName : Str,
+                    # comment
+
+                    lastName : Str,
+                }
+
+                person
+                "
+            ),
+        );
+
+        expr_formats_to(
+            indoc!(
+                r"
+                person : {
+                    firstName : Str,
+
+
+                    # comment
+
+
+                    lastName : Str,
+                }
+
+                person
+                "
+            ),
+            indoc!(
+                r"
                 person : {
                     firstName : Str,
 
@@ -484,7 +484,7 @@ mod test_fmt {
                 }
 
                 person
-                "#
+                "
             ),
         );
     }
@@ -723,7 +723,7 @@ mod test_fmt {
     #[test]
     fn list_allow_blank_line_before_and_after_comment() {
         expr_formats_same(indoc!(
-            r#"
+            r"
                 list = [
                     0,
                     # comment
@@ -731,11 +731,11 @@ mod test_fmt {
                 ]
 
                 list
-                "#
+                "
         ));
 
         expr_formats_same(indoc!(
-            r#"
+            r"
                 list = [
                     0,
 
@@ -744,11 +744,11 @@ mod test_fmt {
                 ]
 
                 list
-                "#
+                "
         ));
 
         expr_formats_same(indoc!(
-            r#"
+            r"
                 list = [
                     0,
                     # comment
@@ -757,11 +757,11 @@ mod test_fmt {
                 ]
 
                 list
-                "#
+                "
         ));
 
         expr_formats_same(indoc!(
-            r#"
+            r"
                 list = [
                     0,
 
@@ -771,11 +771,11 @@ mod test_fmt {
                 ]
 
                 list
-                "#
+                "
         ));
 
         expr_formats_same(indoc!(
-            r#"
+            r"
                 list = [
                     0,
 
@@ -788,11 +788,11 @@ mod test_fmt {
                 ]
 
                 list
-                "#
+                "
         ));
 
         expr_formats_same(indoc!(
-            r#"
+            r"
                 list = [
                     0,
 
@@ -804,11 +804,11 @@ mod test_fmt {
                 ]
 
                 list
-                "#
+                "
         ));
         expr_formats_to(
             indoc!(
-                r#"
+                r"
                 list = [
 
                     # comment
@@ -818,10 +818,10 @@ mod test_fmt {
                 ]
 
                 list
-                "#
+                "
             ),
             indoc!(
-                r#"
+                r"
                 list = [
                     # comment
 
@@ -830,112 +830,112 @@ mod test_fmt {
                 ]
 
                 list
-                "#
-            ),
-        );
-
-        expr_formats_to(
-            indoc!(
-                r#"
-                list = [
-                    0,
-                    1,
-
-                    # comment
-
-                ]
-
-                list
-                "#
-            ),
-            indoc!(
-                r#"
-                list = [
-                    0,
-                    1,
-
-                    # comment
-                ]
-
-                list
-                "#
+                "
             ),
         );
 
         expr_formats_to(
             indoc!(
-                r#"
+                r"
                 list = [
                     0,
-
+                    1,
 
                     # comment
-                    1,
+
                 ]
 
                 list
-                "#
+                "
             ),
             indoc!(
-                r#"
+                r"
                 list = [
                     0,
+                    1,
 
                     # comment
-                    1,
                 ]
 
                 list
-                "#
-            ),
-        );
-
-        expr_formats_to(
-            indoc!(
-                r#"
-                list = [
-                    0,
-                    # comment
-
-
-                    1,
-                ]
-
-                list
-                "#
-            ),
-            indoc!(
-                r#"
-                list = [
-                    0,
-                    # comment
-
-                    1,
-                ]
-
-                list
-                "#
+                "
             ),
         );
 
         expr_formats_to(
             indoc!(
-                r#"
+                r"
                 list = [
                     0,
 
 
                     # comment
-
-
                     1,
                 ]
 
                 list
-                "#
+                "
             ),
             indoc!(
-                r#"
+                r"
+                list = [
+                    0,
+
+                    # comment
+                    1,
+                ]
+
+                list
+                "
+            ),
+        );
+
+        expr_formats_to(
+            indoc!(
+                r"
+                list = [
+                    0,
+                    # comment
+
+
+                    1,
+                ]
+
+                list
+                "
+            ),
+            indoc!(
+                r"
+                list = [
+                    0,
+                    # comment
+
+                    1,
+                ]
+
+                list
+                "
+            ),
+        );
+
+        expr_formats_to(
+            indoc!(
+                r"
+                list = [
+                    0,
+
+
+                    # comment
+
+
+                    1,
+                ]
+
+                list
+                "
+            ),
+            indoc!(
+                r"
                 list = [
                     0,
 
@@ -945,7 +945,7 @@ mod test_fmt {
                 ]
 
                 list
-                "#
+                "
             ),
         );
     }
@@ -954,16 +954,16 @@ mod test_fmt {
     fn force_space_at_beginning_of_comment() {
         expr_formats_to(
             indoc!(
-                r#"
+                r"
                 #comment
                 f
-                "#
+                "
             ),
             indoc!(
-                r#"
+                r"
                 # comment
                 f
-                "#
+                "
             ),
         );
     }
@@ -971,12 +971,12 @@ mod test_fmt {
     #[test]
     fn func_def() {
         expr_formats_same(indoc!(
-            r#"
+            r"
                 f = \x, y ->
                     x
 
                 f 4
-            "#
+            "
         ));
     }
 
@@ -1155,63 +1155,63 @@ mod test_fmt {
     #[test]
     fn zero() {
         expr_formats_same(indoc!(
-            r#"
+            r"
             0
-            "#
+            "
         ));
     }
 
     #[test]
     fn zero_point_zero() {
         expr_formats_same(indoc!(
-            r#"
+            r"
             0.0
-            "#
+            "
         ));
     }
 
     #[test]
     fn int_with_underscores() {
         expr_formats_same(indoc!(
-            r#"
+            r"
             1_23_456
-            "#
+            "
         ));
     }
 
     #[test]
     fn float_with_underscores() {
         expr_formats_same(indoc!(
-            r#"
+            r"
             1_23_456.7_89_10
-            "#
+            "
         ));
     }
 
     #[test]
     fn multi_arg_closure() {
         expr_formats_same(indoc!(
-            r#"
+            r"
             \a, b, c -> a b c
-            "#
+            "
         ));
     }
 
     #[test]
     fn destructure_tag_closure() {
         expr_formats_same(indoc!(
-            r#"
+            r"
             \Foo a -> Foo a
-            "#
+            "
         ));
     }
 
     #[test]
     fn destructure_nested_tag_closure() {
         expr_formats_same(indoc!(
-            r#"
+            r"
             \Foo (Bar a) -> Foo (Bar a)
-            "#
+            "
         ));
     }
 
@@ -1220,44 +1220,44 @@ mod test_fmt {
     #[test]
     fn single_def() {
         expr_formats_same(indoc!(
-            r#"
+            r"
             x = 5
 
             42
-            "#
+            "
         ));
     }
 
     #[test]
     fn two_defs() {
         expr_formats_same(indoc!(
-            r#"
+            r"
             x = 5
             y = 10
 
             42
-            "#
+            "
         ));
 
         expr_formats_to(
             indoc!(
-                r#"
+                r"
                 x = 5
 
 
                 y = 10
 
                 42
-                "#
+                "
             ),
             indoc!(
-                r#"
+                r"
                 x = 5
 
                 y = 10
 
                 42
-                "#
+                "
             ),
         );
     }
@@ -1266,23 +1266,23 @@ mod test_fmt {
     fn excess_parens() {
         expr_formats_to(
             indoc!(
-                r#"
+                r"
                 x = (5)
 
 
                 y = ((10))
 
                 42
-                "#
+                "
             ),
             indoc!(
-                r#"
+                r"
                 x = 5
 
                 y = 10
 
                 42
-                "#
+                "
             ),
         );
     }
@@ -1290,42 +1290,42 @@ mod test_fmt {
     #[test]
     fn defs_with_defs() {
         expr_formats_same(indoc!(
-            r#"
+            r"
                 x =
                     y = 4
                     z = 8
                     w
 
                 x
-                "#
+                "
         ));
     }
 
     #[test]
     fn comment_between_two_defs() {
         expr_formats_same(indoc!(
-            r#"
+            r"
             x = 5
             # Hello
             y = 10
 
             42
-            "#
+            "
         ));
 
         expr_formats_same(indoc!(
-            r#"
+            r"
             x = 5
             # Hello
             # two comments
             y = 10
 
             42
-            "#
+            "
         ));
 
         expr_formats_same(indoc!(
-            r#"
+            r"
             x = 5
             # Hello
             # two comments
@@ -1333,7 +1333,7 @@ mod test_fmt {
 
             # v-- This is the return value
             42
-            "#
+            "
         ));
     }
 
@@ -1341,7 +1341,7 @@ mod test_fmt {
     fn space_between_comments() {
         expr_formats_to(
             indoc!(
-                r#"
+                r"
                 # 9
 
                 # A
@@ -1349,16 +1349,16 @@ mod test_fmt {
 
                 # C
                 9
-                "#
+                "
             ),
             indoc!(
-                r#"
+                r"
                 # 9
                 # A
                 # B
                 # C
                 9
-                "#
+                "
             ),
         );
     }
@@ -1367,7 +1367,7 @@ mod test_fmt {
     fn reduce_space_between_comments() {
         expr_formats_to(
             indoc!(
-                r#"
+                r"
                 # First
 
 
@@ -1375,20 +1375,20 @@ mod test_fmt {
 
                 # Second
                 x
-                "#
+                "
             ),
             indoc!(
-                r#"
+                r"
                 # First
                 # Second
                 x
-                "#
+                "
             ),
         );
 
         expr_formats_to(
             indoc!(
-                r#"
+                r"
                 f = \x ->
                     # 1st
 
@@ -1399,10 +1399,10 @@ mod test_fmt {
                     x
 
                 f 4
-                "#
+                "
             ),
             indoc!(
-                r#"
+                r"
                 f = \x ->
                     # 1st
 
@@ -1410,7 +1410,7 @@ mod test_fmt {
                     x
 
                 f 4
-                "#
+                "
             ),
         );
     }
@@ -1418,64 +1418,64 @@ mod test_fmt {
     #[test]
     fn doesnt_detect_comment_in_comment() {
         expr_formats_same(indoc!(
-            r#"
+            r"
             # One Comment # Still one Comment
             9
-            "#
+            "
         ));
     }
 
     #[test]
     fn parenthetical_def() {
         expr_formats_same(indoc!(
-            r#"
+            r"
             (UserId userId) = 5
             y = 10
 
             42
-            "#
+            "
         ));
 
         expr_formats_same(indoc!(
-            r#"
+            r"
             # A
             (UserId userId) = 5
             # B
             y = 10
 
             42
-            "#
+            "
         ));
     }
 
     #[test]
     fn record_destructuring() {
         expr_formats_same(indoc!(
-            r#"
+            r"
             { x, y } = 5
 
             { x: 5 } = { x: 5 }
 
             42
-            "#
+            "
         ));
     }
 
     #[test]
     fn record_field_destructuring() {
         expr_formats_same(indoc!(
-            r#"
+            r"
                 when foo is
                     { x: 5 } ->
                         42
-            "#
+            "
         ));
     }
 
     #[test]
     fn lambda_returns_record() {
         expr_formats_same(indoc!(
-            r#"
+            r"
                 toRecord = \_ -> {
                     x: 1,
                     y: 2,
@@ -1483,20 +1483,20 @@ mod test_fmt {
                 }
 
                 toRecord
-            "#
+            "
         ));
 
         expr_formats_same(indoc!(
-            r#"
+            r"
                     func = \_ ->
                         { x: 1, y: 2, z: 3 }
 
                     func
-                "#
+                "
         ));
 
         expr_formats_same(indoc!(
-            r#"
+            r"
                 toRecord = \_ ->
                     val = 0
 
@@ -1507,12 +1507,12 @@ mod test_fmt {
                     }
 
                 toRecord
-            "#
+            "
         ));
 
         expr_formats_to(
             indoc!(
-                r#"
+                r"
                     toRecord = \_ ->
                         {
                             x: 1,
@@ -1521,10 +1521,10 @@ mod test_fmt {
                         }
 
                     toRecord
-                "#
+                "
             ),
             indoc!(
-                r#"
+                r"
                     toRecord = \_ -> {
                         x: 1,
                         y: 2,
@@ -1532,7 +1532,7 @@ mod test_fmt {
                     }
 
                     toRecord
-                "#
+                "
             ),
         );
     }
@@ -1540,7 +1540,7 @@ mod test_fmt {
     #[test]
     fn lambda_returns_list() {
         expr_formats_same(indoc!(
-            r#"
+            r"
                 toList = \_ -> [
                     1,
                     2,
@@ -1548,20 +1548,20 @@ mod test_fmt {
                 ]
 
                 toList
-            "#
+            "
         ));
 
         expr_formats_same(indoc!(
-            r#"
+            r"
                     func = \_ ->
                         [1, 2, 3]
 
                     func
-                "#
+                "
         ));
 
         expr_formats_same(indoc!(
-            r#"
+            r"
                 toList = \_ ->
                     val = 0
 
@@ -1572,12 +1572,12 @@ mod test_fmt {
                     ]
 
                 toList
-            "#
+            "
         ));
 
         expr_formats_to(
             indoc!(
-                r#"
+                r"
                     toList = \_ ->
                         [
                             1,
@@ -1586,10 +1586,10 @@ mod test_fmt {
                         ]
 
                     toList
-                "#
+                "
             ),
             indoc!(
-                r#"
+                r"
                     toList = \_ -> [
                         1,
                         2,
@@ -1597,7 +1597,7 @@ mod test_fmt {
                     ]
 
                     toList
-                "#
+                "
             ),
         );
     }
@@ -1605,7 +1605,7 @@ mod test_fmt {
     #[test]
     fn multiline_list_func_arg() {
         expr_formats_same(indoc!(
-            r#"
+            r"
                     result = func arg [
                         1,
                         2,
@@ -1613,32 +1613,32 @@ mod test_fmt {
                     ]
 
                     result
-                "#
+                "
         ));
 
         expr_formats_to(
             indoc!(
-                r#"
+                r"
                     result = func arg
                         [ 1, 2, 3 ]
 
                     result
-                "#
+                "
             ),
             indoc!(
-                r#"
+                r"
                     result = func
                         arg
                         [1, 2, 3]
 
                     result
-                "#
+                "
             ),
         );
 
         expr_formats_to(
             indoc!(
-                r#"
+                r"
                     result = func arg [
                             1,
                             2,
@@ -1646,10 +1646,10 @@ mod test_fmt {
                         ]
 
                     result
-                "#
+                "
             ),
             indoc!(
-                r#"
+                r"
                     result = func arg [
                         1,
                         2,
@@ -1657,13 +1657,13 @@ mod test_fmt {
                     ]
 
                     result
-                "#
+                "
             ),
         );
 
         expr_formats_to(
             indoc!(
-                r#"
+                r"
                     result = func [
                             1,
                             2,
@@ -1672,10 +1672,10 @@ mod test_fmt {
                         arg
 
                     result
-                "#
+                "
             ),
             indoc!(
-                r#"
+                r"
                     result = func
                         [
                             1,
@@ -1685,14 +1685,14 @@ mod test_fmt {
                         arg
 
                     result
-                "#
+                "
             ),
         );
 
         // TODO: do we want to override the user's intent like this?
         expr_formats_to(
             indoc!(
-                r#"
+                r"
                     result = func arg
                         [
                             1,
@@ -1701,10 +1701,10 @@ mod test_fmt {
                         ]
 
                     result
-                "#
+                "
             ),
             indoc!(
-                r#"
+                r"
                     result = func arg [
                         1,
                         2,
@@ -1712,12 +1712,12 @@ mod test_fmt {
                     ]
 
                     result
-                "#
+                "
             ),
         );
 
         expr_formats_same(indoc!(
-            r#"
+            r"
                     result = func
                         arg
                         [
@@ -1727,14 +1727,14 @@ mod test_fmt {
                         ]
 
                     result
-                "#
+                "
         ));
     }
 
     #[test]
     fn multiline_record_func_arg() {
         expr_formats_same(indoc!(
-            r#"
+            r"
                 result = func arg {
                     x: 1,
                     y: 2,
@@ -1742,32 +1742,32 @@ mod test_fmt {
                 }
 
                 result
-            "#
+            "
         ));
 
         expr_formats_to(
             indoc!(
-                r#"
+                r"
                     result = func arg
                         { x: 1, y: 2, z: 3 }
 
                     result
-                "#
+                "
             ),
             indoc!(
-                r#"
+                r"
                     result = func
                         arg
                         { x: 1, y: 2, z: 3 }
 
                     result
-                "#
+                "
             ),
         );
 
         expr_formats_to(
             indoc!(
-                r#"
+                r"
                     result = func arg {
                             x: 1,
                             y: 2,
@@ -1775,10 +1775,10 @@ mod test_fmt {
                         }
 
                     result
-                "#
+                "
             ),
             indoc!(
-                r#"
+                r"
                     result = func arg {
                         x: 1,
                         y: 2,
@@ -1786,13 +1786,13 @@ mod test_fmt {
                     }
 
                     result
-                "#
+                "
             ),
         );
 
         expr_formats_to(
             indoc!(
-                r#"
+                r"
                     result = func {
                             x: 1,
                             y: 2,
@@ -1801,10 +1801,10 @@ mod test_fmt {
                         arg
 
                     result
-                "#
+                "
             ),
             indoc!(
-                r#"
+                r"
                     result = func
                         {
                             x: 1,
@@ -1814,14 +1814,14 @@ mod test_fmt {
                         arg
 
                     result
-                "#
+                "
             ),
         );
 
         // TODO: do we want to override the user's intent like this?
         expr_formats_to(
             indoc!(
-                r#"
+                r"
                     result = func arg
                         {
                             x: 1,
@@ -1830,10 +1830,10 @@ mod test_fmt {
                         }
 
                     result
-                "#
+                "
             ),
             indoc!(
-                r#"
+                r"
                     result = func arg {
                         x: 1,
                         y: 2,
@@ -1841,12 +1841,12 @@ mod test_fmt {
                     }
 
                     result
-                "#
+                "
             ),
         );
 
         expr_formats_same(indoc!(
-            r#"
+            r"
                     result = func
                         arg
                         {
@@ -1856,68 +1856,68 @@ mod test_fmt {
                         }
 
                     result
-                "#
+                "
         ));
     }
 
     #[test]
     fn record_updating() {
         expr_formats_same(indoc!(
-            r#"
+            r"
             { shoes & leftShoe: nothing }
-            "#
+            "
         ));
 
         expr_formats_to(
             indoc!(
-                r#"
+                r"
                 {   shoes  &  rightShoe : nothing }
-                "#
+                "
             ),
             indoc!(
-                r#"
+                r"
                 { shoes & rightShoe: nothing }
-                "#
+                "
             ),
         );
 
         expr_formats_to(
             indoc!(
-                r#"
+                r"
                 {   shoes  &  rightShoe : nothing }
-                "#
+                "
             ),
             indoc!(
-                r#"
+                r"
                 { shoes & rightShoe: nothing }
-                "#
+                "
             ),
         );
 
         expr_formats_same(indoc!(
-            r#"
+            r"
             { shoes &
                 rightShoe: newRightShoe,
                 leftShoe: newLeftShoe,
             }
-            "#
+            "
         ));
 
         expr_formats_to(
             indoc!(
-                r#"
+                r"
                 { shoes
                     & rightShoe: bareFoot
                     , leftShoe: bareFoot }
-                "#
+                "
             ),
             indoc!(
-                r#"
+                r"
                 { shoes &
                     rightShoe: bareFoot,
                     leftShoe: bareFoot,
                 }
-                "#
+                "
             ),
         );
     }
@@ -2089,20 +2089,20 @@ mod test_fmt {
     #[test]
     fn final_comments_in_records() {
         expr_formats_same(indoc!(
-            r#"
+            r"
             {
                 x: 42,
                 # comment
-            }"#
+            }"
         ));
 
         expr_formats_same(indoc!(
-            r#"
+            r"
             {
                 x: 42,
                 # comment
                 # other comment
-            }"#
+            }"
         ));
     }
 
@@ -2110,21 +2110,21 @@ mod test_fmt {
     fn final_comments_without_comma_in_records() {
         expr_formats_to(
             indoc!(
-                r#"
+                r"
             {
                 y: 41,
                 # comment 1
                 x: 42 # comment 2
-            }"#
+            }"
             ),
             indoc!(
-                r#"
+                r"
             {
                 y: 41,
                 # comment 1
                 x: 42,
                 # comment 2
-            }"#
+            }"
             ),
         );
     }
@@ -2133,21 +2133,21 @@ mod test_fmt {
     fn multiple_final_comments_without_comma_in_records() {
         expr_formats_to(
             indoc!(
-                r#"
+                r"
             {
                 y: 41,
                 x: 42 # comment 1
                 # comment 2
-            }"#
+            }"
             ),
             indoc!(
-                r#"
+                r"
             {
                 y: 41,
                 x: 42,
                 # comment 1
                 # comment 2
-            }"#
+            }"
             ),
         );
     }
@@ -2156,7 +2156,7 @@ mod test_fmt {
     fn comments_with_newlines_in_records() {
         expr_formats_to(
             indoc!(
-                r#"
+                r"
             {
                 z: 44 #comment 0
                 ,
@@ -2168,10 +2168,10 @@ mod test_fmt {
                 # comment 3
 
                 # comment 4
-            }"#
+            }"
             ),
             indoc!(
-                r#"
+                r"
             {
                 z: 44,
                 # comment 0
@@ -2181,7 +2181,7 @@ mod test_fmt {
                 x: 42,
                 # comment 3
                 # comment 4
-            }"#
+            }"
             ),
         );
     }
@@ -2190,21 +2190,21 @@ mod test_fmt {
     fn multiple_final_comments_with_comma_in_records() {
         expr_formats_to(
             indoc!(
-                r#"
+                r"
             {
                 y: 41,
                 x: 42, # comment 1
                 # comment 2
-            }"#
+            }"
             ),
             indoc!(
-                r#"
+                r"
             {
                 y: 41,
                 x: 42,
                 # comment 1
                 # comment 2
-            }"#
+            }"
             ),
         );
     }
@@ -2213,21 +2213,21 @@ mod test_fmt {
     fn trailing_comma_in_record_annotation() {
         expr_formats_to(
             indoc!(
-                r#"
+                r"
                 f: {                    y : Int *,
                                          x : Int * ,
                    }
 
-                f"#
+                f"
             ),
             indoc!(
-                r#"
+                r"
                 f : {
                     y : Int *,
                     x : Int *,
                 }
 
-                f"#
+                f"
             ),
         );
     }
@@ -2235,19 +2235,19 @@ mod test_fmt {
     #[test]
     fn trailing_comma_in_record_annotation_same() {
         expr_formats_same(indoc!(
-            r#"
+            r"
                 f : {
                     y : Int *,
                     x : Int *,
                 }
 
                 f
-            "#
+            "
         ));
 
         expr_formats_to(
             indoc!(
-                r#"
+                r"
                     f :
                         {
                             y : Int *,
@@ -2255,17 +2255,17 @@ mod test_fmt {
                         }
 
                     f
-                "#
+                "
             ),
             indoc!(
-                r#"
+                r"
                     f : {
                         y : Int *,
                         x : Int *,
                     }
 
                     f
-                "#
+                "
             ),
         );
     }
@@ -2273,33 +2273,33 @@ mod test_fmt {
     #[test]
     fn multiline_type_definition() {
         expr_formats_same(indoc!(
-            r#"
+            r"
                 f :
                     Int *
 
-                f"#
+                f"
         ));
     }
 
     #[test]
     fn multiline_empty_record_type_definition() {
         expr_formats_same(indoc!(
-            r#"
+            r"
                 f :
                     {}
 
                 f
-            "#
+            "
         ));
 
         expr_formats_same(indoc!(
-            r#"
+            r"
                 f :
                     {
                     }
 
                 f
-            "#
+            "
         ));
     }
 
@@ -2307,19 +2307,19 @@ mod test_fmt {
     fn type_definition_comment_after_colon() {
         expr_formats_to(
             indoc!(
-                r#"
+                r"
                 f : # comment
                     {}
 
-                f"#
+                f"
             ),
             indoc!(
-                r#"
+                r"
                 f :
                     # comment
                     {}
 
-                f"#
+                f"
             ),
         );
     }
@@ -2328,35 +2328,35 @@ mod test_fmt {
     fn type_definition_add_space_around_optional_record() {
         expr_formats_to(
             indoc!(
-                r#"
+                r"
                 f : { a ?Str }
 
-                f"#
+                f"
             ),
             indoc!(
-                r#"
+                r"
                 f : { a ? Str }
 
-                f"#
+                f"
             ),
         );
 
         expr_formats_to(
             indoc!(
-                r#"
+                r"
                 f : {
                     a ?Str,
                 }
 
-                f"#
+                f"
             ),
             indoc!(
-                r#"
+                r"
                 f : {
                     a ? Str,
                 }
 
-                f"#
+                f"
             ),
         );
     }
@@ -2366,20 +2366,20 @@ mod test_fmt {
     fn final_comment_in_empty_record_type_definition() {
         expr_formats_to(
             indoc!(
-                r#"
+                r"
                 f :
                     { # comment
                     }
 
-                f"#
+                f"
             ),
             indoc!(
-                r#"
+                r"
                 f : {
                     # comment
                 }
 
-                f"#
+                f"
             ),
         );
     }
@@ -2387,94 +2387,94 @@ mod test_fmt {
     #[test]
     fn multiline_curly_brace_type() {
         expr_formats_same(indoc!(
-            r#"
+            r"
                 x : {
                     a : Int,
                 }
 
                 x
-            "#
+            "
         ));
 
         expr_formats_same(indoc!(
-            r#"
+            r"
                 x :
                     { a : Int }
 
                 x
-            "#
+            "
         ));
     }
 
     #[test]
     fn multiline_brace_type() {
         expr_formats_same(indoc!(
-            r#"
+            r"
                 x : [
                     Int,
                 ]
 
                 x
-            "#
+            "
         ));
 
         expr_formats_same(indoc!(
-            r#"
+            r"
                 x :
                     [Int]
 
                 x
-            "#
+            "
         ));
     }
 
     #[test]
     fn multiline_fn_signature() {
         expr_formats_same(indoc!(
-            r#"
+            r"
                 foo :
                     Str,
                     Nat
                     -> Bool
 
                 foo
-            "#
+            "
         ));
 
         expr_formats_same(indoc!(
-            r#"
+            r"
                     foo :
                         Str, Int, Nat -> Bool
 
                     foo
-                "#
+                "
         ));
 
         expr_formats_to(
             indoc!(
-                r#"
+                r"
                     foo :
                         Str,
                         Nat -> Bool
 
                     foo
-                "#
+                "
             ),
             indoc!(
-                r#"
+                r"
                     foo :
                         Str,
                         Nat
                         -> Bool
 
                     foo
-                "#
+                "
             ),
         );
 
         expr_formats_to(
             indoc!(
-                r#"
+                r"
                     foo :
 
                         Str,
@@ -2483,37 +2483,37 @@ mod test_fmt {
                         -> Bool
 
                     foo
-                "#
+                "
             ),
             indoc!(
-                r#"
+                r"
                     foo :
                         Str,
                         Nat
                         -> Bool
 
                     foo
-                "#
+                "
             ),
         );
 
         expr_formats_to(
             indoc!(
-                r#"
+                r"
                     foo :
 
                         Str, Nat -> Bool
 
                     foo
-                "#
+                "
             ),
             indoc!(
-                r#"
+                r"
                     foo :
                         Str, Nat -> Bool
 
                     foo
-                "#
+                "
             ),
         );
     }
@@ -2522,7 +2522,7 @@ mod test_fmt {
     fn final_comment_record_annotation() {
         expr_formats_to(
             indoc!(
-                r#"
+                r"
                 f :
                     {
                         x: Int * # comment 1
@@ -2530,16 +2530,16 @@ mod test_fmt {
                         # comment 2
                     }
 
-                f"#
+                f"
             ),
             indoc!(
-                r#"
+                r"
                 f : {
                     x : Int *, # comment 1
                     # comment 2
                 }
 
-                f"#
+                f"
             ),
         );
     }
@@ -2547,79 +2547,79 @@ mod test_fmt {
     #[test]
     fn def_closure() {
         expr_formats_same(indoc!(
-            r#"
+            r"
             identity = \a -> a
 
             identity 42
-            "#
+            "
         ));
 
         expr_formats_same(indoc!(
-            r#"
+            r"
             identity = \a ->
                 a
 
             identity 44
-            "#
+            "
         ));
 
         expr_formats_same(indoc!(
-            r#"
+            r"
             identity = \a -> a
 
             # Hello
             identity 40
-            "#
+            "
         ));
 
         expr_formats_to(
             indoc!(
-                r#"
+                r"
                     identity = \a
                         -> a
 
                     identity 41
-                "#
+                "
             ),
             indoc!(
-                r#"
+                r"
                     identity = \a -> a
 
                     identity 41
-                "#
+                "
             ),
         );
 
         expr_formats_to(
             indoc!(
-                r#"
+                r"
                     identity = \a
                         ->
                             a + b
 
                     identity 4010
-                "#
+                "
             ),
             indoc!(
-                r#"
+                r"
                     identity = \a ->
                         a + b
 
                     identity 4010
-                "#
+                "
             ),
         );
 
         expr_formats_same(indoc!(
-            r#"
+            r"
             identity = \a, b -> a
 
             identity 43
-            "#
+            "
         ));
 
         // expr_formats_same(indoc!(
-        //     r#"
+        //     r"
         //    identity =
         //        \{
         //            x,
@@ -2628,11 +2628,11 @@ mod test_fmt {
         //        -> a
         //
         //    identity 43
-        //    "#
+        //    "
         // ));
 
         expr_formats_same(indoc!(
-            r#"
+            r"
             identity = \a,
                 b,
                 # it's c!!
@@ -2640,14 +2640,14 @@ mod test_fmt {
                 -> a
 
             identity 43
-            "#
+            "
         ));
     }
 
     #[test]
     fn closure_multiline_pattern() {
         expr_formats_same(indoc!(
-            r#"
+            r"
             identity = \a,
                 b,
                 # it's c!!
@@ -2655,7 +2655,7 @@ mod test_fmt {
                 -> a
 
             identity 43
-            "#
+            "
         ));
     }
 
@@ -2681,38 +2681,38 @@ mod test_fmt {
     #[test]
     fn multi_line_list() {
         expr_formats_same(indoc!(
-            r#"
+            r"
             [
                 7,
                 8,
                 9,
             ]
-            "#
+            "
         ));
 
         expr_formats_to(
             indoc!(
-                r#"
+                r"
                 [ 17
                 , 18
                 , 19
                 ]
-                "#
+                "
             ),
             indoc!(
-                r#"
+                r"
                 [
                     17,
                     18,
                     19,
                 ]
-                "#
+                "
             ),
         );
 
         expr_formats_to(
             indoc!(
-                r#"
+                r"
                 [ 27
 
                 , 28
@@ -2720,85 +2720,85 @@ mod test_fmt {
 
                 , 29
                 ]
-                "#
+                "
             ),
             indoc!(
-                r#"
+                r"
                 [
                     27,
                     28,
                     29,
                 ]
-                "#
+                "
             ),
         );
 
         expr_formats_to(
             indoc!(
-                r#"
+                r"
                 [
                     157, 158,
                     159
                 ]
-                "#
+                "
             ),
             indoc!(
-                r#"
+                r"
                 [
                     157,
                     158,
                     159,
                 ]
-                "#
+                "
             ),
         );
 
         expr_formats_to(
             indoc!(
-                r#"
+                r"
                 [
                     557, 648,
                     759, 837
                 ]
-                "#
+                "
             ),
             indoc!(
-                r#"
+                r"
                 [
                     557,
                     648,
                     759,
                     837,
                 ]
-                "#
+                "
             ),
         );
 
         expr_formats_to(
             indoc!(
-                r#"
+                r"
                 [
                     257, 358,
                     # Hey!
                     459
                 ]
-                "#
+                "
             ),
             indoc!(
-                r#"
+                r"
                 [
                     257,
                     358,
                     # Hey!
                     459,
                 ]
-                "#
+                "
             ),
         );
 
         expr_formats_to(
             indoc!(
-                r#"
+                r"
                 [
                 # Thirty Seven
 
@@ -2809,10 +2809,10 @@ mod test_fmt {
 
                 , 39
                 ]
-                "#
+                "
             ),
             indoc!(
-                r#"
+                r"
                 [
                     # Thirty Seven
 
@@ -2821,13 +2821,13 @@ mod test_fmt {
                     38,
                     39,
                 ]
-                "#
+                "
             ),
         );
 
         expr_formats_to(
             indoc!(
-                r#"
+                r"
                 [ # 47!
                 # Top 47
                   47
@@ -2840,10 +2840,10 @@ mod test_fmt {
                 # Bottom 49
                 # 49!
                 ]
-                "#
+                "
             ),
             indoc!(
-                r#"
+                r"
                 [
                     # 47!
                     # Top 47
@@ -2857,7 +2857,7 @@ mod test_fmt {
                     # Bottom 49
                     # 49!
                 ]
-                "#
+                "
             ),
         );
     }
@@ -2865,52 +2865,52 @@ mod test_fmt {
     fn ending_comments_in_list() {
         expr_formats_to(
             indoc!(
-                r#"
+                r"
                 [ # Top 49
                  49
                 # Bottom 49
                 ,
                 # 49!
                 ]
-                "#
+                "
             ),
             indoc!(
-                r#"
+                r"
                 [
                     # Top 49
                     49,
                     # Bottom 49
                     # 49!
                 ]
-                "#
+                "
             ),
         );
     }
     #[test]
     fn multi_line_list_def() {
         expr_formats_same(indoc!(
-            r#"
+            r"
                 l = [
                     1,
                     2,
                 ]
 
                 l
-            "#
+            "
         ));
 
         expr_formats_same(indoc!(
-            r#"
+            r"
                 l =
                     [1, 2]
 
                 l
-            "#
+            "
         ));
 
         expr_formats_to(
             indoc!(
-                r#"
+                r"
                 l =
                     [
                         1,
@@ -2918,46 +2918,46 @@ mod test_fmt {
                     ]
 
                 l
-                "#
+                "
             ),
             indoc!(
-                r#"
+                r"
                 l = [
                     1,
                     2,
                 ]
 
                 l
-                "#
+                "
             ),
         );
 
         expr_formats_to(
             indoc!(
-                r#"
+                r"
                 results = [
                     Ok 4,
                     Ok 5
                     ]
 
                 allOks results
-                "#
+                "
             ),
             indoc!(
-                r#"
+                r"
                 results = [
                     Ok 4,
                     Ok 5,
                 ]
 
                 allOks results
-                "#
+                "
             ),
         );
 
         expr_formats_to(
             indoc!(
-                r#"
+                r"
                     results =
                         # Let's count past 6
                         [
@@ -2966,10 +2966,10 @@ mod test_fmt {
                         ]
 
                     allOks results
-                "#
+                "
             ),
             indoc!(
-                r#"
+                r"
                     results =
                         # Let's count past 6
                         [
@@ -2978,7 +2978,7 @@ mod test_fmt {
                         ]
 
                     allOks results
-                "#
+                "
             ),
         );
     }
@@ -3012,35 +3012,35 @@ mod test_fmt {
 
         expr_formats_to(
             indoc!(
-                r#"
+                r"
                     f = \a, b -> {  }
 
                     f
-                "#
+                "
             ),
             indoc!(
-                r#"
+                r"
                     f = \a, b -> {}
 
                     f
-                "#
+                "
             ),
         );
 
         expr_formats_to(
             indoc!(
-                r#"
+                r"
                     { } <- f a b
 
                     {}
-                "#
+                "
             ),
             indoc!(
-                r#"
+                r"
                     {} <- f a b
 
                     {}
-                "#
+                "
             ),
         );
     }
@@ -3049,10 +3049,10 @@ mod test_fmt {
     #[ignore]
     fn empty_record_with_comment() {
         expr_formats_same(indoc!(
-            r#"
+            r"
             {
                 # comment
-            }"#
+            }"
         ));
     }
 
@@ -3061,9 +3061,9 @@ mod test_fmt {
     fn empty_record_with_newline() {
         expr_formats_to(
             indoc!(
-                r#"
+                r"
             {
-            }"#
+            }"
             ),
             "{}",
         );
@@ -3081,19 +3081,19 @@ mod test_fmt {
     #[test]
     fn two_fields_newline() {
         expr_formats_same(indoc!(
-            r#"
+            r"
             {
                 x: 4,
                 y: 42,
             }
-            "#
+            "
         ));
     }
 
     #[test]
     fn multi_line_record_def() {
         expr_formats_same(indoc!(
-            r#"
+            r"
                 pos = {
                     x: 4,
                     y: 11,
@@ -3101,20 +3101,20 @@ mod test_fmt {
                 }
 
                 pos
-            "#
+            "
         ));
 
         expr_formats_same(indoc!(
-            r#"
+            r"
                 pos =
                     { x: 4, y: 11, z: 16 }
 
                 pos
-            "#
+            "
         ));
 
         expr_formats_same(indoc!(
-            r#"
+            r"
                 myDef =
                     list = [
                         a,
@@ -3127,12 +3127,12 @@ mod test_fmt {
                     }
 
                 myDef
-            "#
+            "
         ));
 
         expr_formats_to(
             indoc!(
-                r#"
+                r"
                     pos =
                         {
                             x: 4,
@@ -3141,10 +3141,10 @@ mod test_fmt {
                         }
 
                     pos
-                "#
+                "
             ),
             indoc!(
-                r#"
+                r"
                     pos = {
                         x: 4,
                         y: 11,
@@ -3152,30 +3152,30 @@ mod test_fmt {
                     }
 
                     pos
-                "#
+                "
             ),
         );
 
         expr_formats_to(
             indoc!(
-                r#"
+                r"
                 pos = {
                         x: 5,
                         y: 10,
                     }
 
                 pos
-                "#
+                "
             ),
             indoc!(
-                r#"
+                r"
                 pos = {
                     x: 5,
                     y: 10,
                 }
 
                 pos
-                "#
+                "
             ),
         );
     }
@@ -3184,19 +3184,19 @@ mod test_fmt {
     fn two_fields_center_newline() {
         expr_formats_to(
             indoc!(
-                r#"
+                r"
                 { x: 4,
                     y: 42
                 }
-                "#
+                "
             ),
             indoc!(
-                r#"
+                r"
                 {
                     x: 4,
                     y: 42,
                 }
-                "#
+                "
             ),
         );
     }
@@ -3204,11 +3204,11 @@ mod test_fmt {
     #[test]
     fn one_unnamed_field() {
         expr_formats_same(indoc!(
-            r#"
+            r"
             foo = 4
 
             { foo }
-        "#
+        "
         ));
     }
 
@@ -3217,29 +3217,29 @@ mod test_fmt {
     #[test]
     fn single_line_if() {
         expr_formats_same(indoc!(
-            r#"
+            r"
             if foo bar then a b c else d e f
-            "#
+            "
         ));
 
         expr_formats_same(indoc!(
-            r#"
+            r"
             if foo (a b c) then a b c else d e f
-            "#
+            "
         ));
     }
 
     #[test]
     fn multi_line_if_condition() {
         expr_formats_same(indoc!(
-            r#"
+            r"
             if
                 waterWillBoil pressure temperature
             then
                 turnOnAc
             else
                 identity
-            "#
+            "
         ));
     }
 
@@ -3247,7 +3247,7 @@ mod test_fmt {
     fn multi_line_if_condition_with_spaces() {
         expr_formats_to(
             indoc!(
-                r#"
+                r"
                 if
 
 
@@ -3259,17 +3259,17 @@ mod test_fmt {
 
                 else
                     identity
-                "#
+                "
             ),
             indoc!(
-                r#"
+                r"
                 if
                     willBoil home water
                 then
                     \_ -> leave
                 else
                     identity
-                "#
+                "
             ),
         );
     }
@@ -3277,7 +3277,7 @@ mod test_fmt {
     #[test]
     fn multi_line_if_condition_with_multi_line_expr_1() {
         expr_formats_same(indoc!(
-            r#"
+            r"
             if
                 snowWillFall
                     pressure
@@ -3286,7 +3286,7 @@ mod test_fmt {
                 bundleUp
             else
                 identity
-            "#
+            "
         ));
     }
 
@@ -3309,7 +3309,7 @@ mod test_fmt {
     fn if_removes_newlines_from_else() {
         expr_formats_to(
             indoc!(
-                r#"
+                r"
                 if
                     isPrime 8
                 then
@@ -3322,10 +3322,10 @@ mod test_fmt {
                     # F
 
                     just (div 1 8)
-                "#
+                "
             ),
             indoc!(
-                r#"
+                r"
                 if
                     isPrime 8
                 then
@@ -3336,7 +3336,7 @@ mod test_fmt {
                     # E
                     # F
                     just (div 1 8)
-                "#
+                "
             ),
         );
     }
@@ -3345,7 +3345,7 @@ mod test_fmt {
     fn if_removes_newlines_from_then() {
         expr_formats_to(
             indoc!(
-                r#"
+                r"
                 if
                     isPrime 9
                 then
@@ -3358,10 +3358,10 @@ mod test_fmt {
 
                 else
                     just (div 1 9)
-                "#
+                "
             ),
             indoc!(
-                r#"
+                r"
                 if
                     isPrime 9
                 then
@@ -3371,7 +3371,7 @@ mod test_fmt {
                     # GG
                 else
                     just (div 1 9)
-                "#
+                "
             ),
         );
     }
@@ -3380,7 +3380,7 @@ mod test_fmt {
     fn if_removes_newlines_from_condition() {
         expr_formats_to(
             indoc!(
-                r#"
+                r"
                 if
 
                     # Is
@@ -3395,10 +3395,10 @@ mod test_fmt {
                     nothing
                 else
                     just (div 1 10)
-                "#
+                "
             ),
             indoc!(
-                r#"
+                r"
                 if
                     # Is
                     # It
@@ -3408,7 +3408,7 @@ mod test_fmt {
                     nothing
                 else
                     just (div 1 10)
-                "#
+                "
             ),
         );
     }
@@ -3417,28 +3417,28 @@ mod test_fmt {
     fn multi_line_if() {
         expr_formats_to(
             indoc!(
-                r#"
+                r"
                 if lessThan four five then
                     four
 
 
                 else
                     five
-                "#
+                "
             ),
             indoc!(
-                r#"
+                r"
                 if lessThan four five then
                     four
                 else
                     five
-                "#
+                "
             ),
         );
 
         expr_formats_to(
             indoc!(
-                r#"
+                r"
                 if lessThan three four then
 
 
@@ -3451,36 +3451,36 @@ mod test_fmt {
 
 
                     four
-                "#
+                "
             ),
             indoc!(
-                r#"
+                r"
                 if lessThan three four then
                     three
                 else
                     four
-                "#
+                "
             ),
         );
 
         expr_formats_same(indoc!(
-            r#"
+            r"
             if foo bar then
                 a b c
             else
                 d e f
-            "#
+            "
         ));
     }
 
     #[test]
     fn multi_line_application() {
         expr_formats_same(indoc!(
-            r#"
+            r"
             combine
                 peanutButter
                 chocolate
-            "#
+            "
         ));
     }
 
@@ -3488,34 +3488,34 @@ mod test_fmt {
     fn partial_multi_line_application() {
         expr_formats_to(
             indoc!(
-                r#"
+                r"
                 mix vodka
                     tonic
-                "#
+                "
             ),
             indoc!(
-                r#"
+                r"
                 mix
                     vodka
                     tonic
-                "#
+                "
             ),
         );
 
         expr_formats_to(
             indoc!(
-                r#"
+                r"
                 f
                     a b c
-                "#
+                "
             ),
             indoc!(
-                r#"
+                r"
                 f
                     a
                     b
                     c
-                "#
+                "
             ),
         );
     }
@@ -3525,14 +3525,14 @@ mod test_fmt {
     #[test]
     fn integer_when() {
         expr_formats_same(indoc!(
-            r#"
+            r"
             when b is
                 1 ->
                     1
 
                 _ ->
                     2
-            "#
+            "
         ));
     }
 
@@ -3540,7 +3540,7 @@ mod test_fmt {
     fn integer_when_with_space() {
         expr_formats_to(
             indoc!(
-                r#"
+                r"
                 when year is
                     1999 ->
 
@@ -3552,17 +3552,17 @@ mod test_fmt {
                     _ ->
 
                         0
-                "#
+                "
             ),
             indoc!(
-                r#"
+                r"
                 when year is
                     1999 ->
                         1
 
                     _ ->
                         0
-                "#
+                "
             ),
         );
     }
@@ -3570,7 +3570,7 @@ mod test_fmt {
     #[test]
     fn when_with_comments() {
         expr_formats_same(indoc!(
-            r#"
+            r"
             when b is
                 # look at cases
                 1 -> # when 1
@@ -3583,7 +3583,7 @@ mod test_fmt {
                     # more comment
                     2
 
-            "#
+            "
         ));
     }
 
@@ -3603,20 +3603,20 @@ mod test_fmt {
     #[test]
     fn nested_when() {
         expr_formats_same(indoc!(
-            r#"
+            r"
             when b is
                 _ ->
                     when c is
                         _ ->
                             1
-            "#
+            "
         ));
     }
 
     #[test]
     fn def_when() {
         expr_formats_same(indoc!(
-            r#"
+            r"
             myLongFunctionName = \x ->
                 when b is
                     1 | 2 ->
@@ -3628,7 +3628,7 @@ mod test_fmt {
                         5
 
             123
-        "#
+        "
         ));
     }
 
@@ -3641,7 +3641,7 @@ mod test_fmt {
             // we want to make sure the `when` is at the beginning of the line, inserting
             // a newline if necessary.
             indoc!(
-                r#"
+                r"
                 myLongFunctionName = \x -> when b is
                     1 | 2 ->
                         when c is
@@ -3652,10 +3652,10 @@ mod test_fmt {
                         5
 
                 123
-            "#
+            "
             ),
             indoc!(
-                r#"
+                r"
                 myLongFunctionName = \x ->
                     when b is
                         1 | 2 ->
@@ -3667,7 +3667,7 @@ mod test_fmt {
                             5
 
                 123
-            "#
+            "
             ),
         );
     }
@@ -3675,7 +3675,7 @@ mod test_fmt {
     #[test]
     fn when_with_alternatives_1() {
         expr_formats_same(indoc!(
-            r#"
+            r"
             when b is
                 1 | 2 ->
                     when c is
@@ -3684,20 +3684,20 @@ mod test_fmt {
 
                 3 | 4 ->
                     5
-        "#
+        "
         ));
     }
 
     #[test]
     fn when_with_alternatives_2() {
         expr_formats_same(indoc!(
-            r#"
+            r"
             when b is
                 # a comment here
                 1 | 2 ->
                     # a comment there
                     1
-        "#
+        "
         ));
     }
 
@@ -3705,19 +3705,19 @@ mod test_fmt {
     fn when_with_alternatives_3() {
         expr_formats_to(
             indoc!(
-                r#"
+                r"
             when b is
             1   |   2 |3 ->
 
                     1
-            "#
+            "
             ),
             indoc!(
-                r#"
+                r"
             when b is
                 1 | 2 | 3 ->
                     1
-                "#
+                "
             ),
         );
     }
@@ -3726,7 +3726,7 @@ mod test_fmt {
     fn when_with_alternatives_4() {
         expr_formats_to(
             indoc!(
-                r#"
+                r"
             when b is
                 1   |   2 |
                     3
@@ -3746,10 +3746,10 @@ mod test_fmt {
                      |  18 -> 19
                 20 -> 21
 
-            "#
+            "
             ),
             indoc!(
-                r#"
+                r"
             when b is
                 1
                 | 2
@@ -3769,7 +3769,7 @@ mod test_fmt {
                         | 18 -> 19
 
                 20 -> 21
-                "#
+                "
             ),
         );
     }
@@ -3778,19 +3778,19 @@ mod test_fmt {
     fn with_multiline_pattern_indentation() {
         expr_formats_to(
             indoc!(
-                r#"
+                r"
             when b is   3->4
                         9
                          |8->9
-            "#
+            "
             ),
             indoc!(
-                r#"
+                r"
             when b is
                 3 -> 4
                 9
                 | 8 -> 9
-            "#
+            "
             ),
         );
     }
@@ -3798,7 +3798,7 @@ mod test_fmt {
     #[test]
     fn multi_line_when_condition_1() {
         expr_formats_same(indoc!(
-            r#"
+            r"
             when
                 complexFunction a b c
             is
@@ -3807,14 +3807,14 @@ mod test_fmt {
 
                 _ ->
                     Just True
-            "#
+            "
         ));
     }
 
     #[test]
     fn multi_line_when_condition_2() {
         expr_formats_same(indoc!(
-            r#"
+            r"
             when
                 # this is quite complicated
                 complexFunction a b c
@@ -3825,7 +3825,7 @@ mod test_fmt {
 
                 Simple z ->
                     z
-            "#
+            "
         ));
     }
 
@@ -3833,7 +3833,7 @@ mod test_fmt {
     fn multi_line_when_condition_3() {
         expr_formats_to(
             indoc!(
-                r#"
+                r"
             x = 2
             y = 3
 
@@ -3844,10 +3844,10 @@ mod test_fmt {
 
                 _ ->
                     y
-            "#
+            "
             ),
             indoc!(
-                r#"
+                r"
             x = 2
             y = 3
 
@@ -3860,7 +3860,7 @@ mod test_fmt {
 
                 _ ->
                     y
-            "#
+            "
             ),
         );
     }
@@ -3869,7 +3869,7 @@ mod test_fmt {
     fn multi_line_when_condition_4() {
         expr_formats_to(
             indoc!(
-                r#"
+                r"
             x = 2
             y = 3
 
@@ -3881,10 +3881,10 @@ mod test_fmt {
 
                 _ ->
                     y
-            "#
+            "
             ),
             indoc!(
-                r#"
+                r"
             x = 2
             y = 3
 
@@ -3897,7 +3897,7 @@ mod test_fmt {
 
                 _ ->
                     y
-            "#
+            "
             ),
         );
     }
@@ -3930,57 +3930,57 @@ mod test_fmt {
     #[test]
     fn single_line_when_patterns() {
         expr_formats_same(indoc!(
-            r#"
+            r"
             when x is
                 Foo -> 1
                 Bar -> 2
-            "#
+            "
         ));
 
         expr_formats_same(indoc!(
-            r#"
+            r"
             when x is
                 Foo -> 1
                 Bar ->
                     2
-            "#
+            "
         ));
 
         expr_formats_to(
             indoc!(
-                r#"
+                r"
                 when x is
                     Foo -> 1
 
                     Bar ->
                         2
-                "#
+                "
             ),
             indoc!(
-                r#"
+                r"
                 when x is
                     Foo -> 1
                     Bar ->
                         2
-                "#
+                "
             ),
         );
 
         expr_formats_to(
             indoc!(
-                r#"
+                r"
                 when x is
                     Foo -> 1
 
                     Bar -> 2
-                "#
+                "
             ),
             indoc!(
-                r#"
+                r"
                 when x is
                     Foo -> 1
                     Bar -> 2
-                "#
+                "
             ),
         );
     }
@@ -3988,11 +3988,11 @@ mod test_fmt {
     #[test]
     fn when_with_single_quote_char() {
         expr_formats_same(indoc!(
-            r#"
+            r"
                 when x is
                     '0' -> 0
                     '1' -> 1
-                "#
+                "
         ));
     }
 
@@ -4002,7 +4002,7 @@ mod test_fmt {
     fn multiple_blank_lines_collapse_to_one() {
         expr_formats_to(
             indoc!(
-                r#"
+                r"
                 x = 5
 
 
@@ -4012,16 +4012,16 @@ mod test_fmt {
 
 
                 42
-                "#
+                "
             ),
             indoc!(
-                r#"
+                r"
                 x = 5
 
                 y = 10
 
                 42
-                "#
+                "
             ),
         );
     }
@@ -4029,7 +4029,7 @@ mod test_fmt {
     #[test]
     fn def_returning_closure() {
         expr_formats_same(indoc!(
-            r#"
+            r"
             f = \x -> x
             g = \x -> x
 
@@ -4038,7 +4038,7 @@ mod test_fmt {
                 b = f x
 
                 x
-            "#
+            "
         ));
     }
 
@@ -4048,7 +4048,7 @@ mod test_fmt {
         // which of course is not the same tree (and nor does it parse)
         expr_formats_to(
             indoc!(
-                r#"
+                r"
                 \x ->
                     m = 2
 
@@ -4056,17 +4056,17 @@ mod test_fmt {
                     m1 = insert m n powerOf10
 
                     42
-                "#
+                "
             ),
             indoc!(
-                r#"
+                r"
                 \x ->
                     m = 2
 
                     m1 = insert m n powerOf10
 
                     42
-                "#
+                "
             ),
         );
     }
@@ -4074,21 +4074,21 @@ mod test_fmt {
     #[test]
     fn when_guard() {
         expr_formats_same(indoc!(
-            r#"
+            r"
             when maybeScore is
                 Just score if score > 21 ->
                     win
 
                 _ ->
                     nextRound
-            "#
+            "
         ));
     }
 
     #[test]
     fn when_guard_using_function() {
         expr_formats_same(indoc!(
-            r#"
+            r"
             when authenticationResponse is
                 Ok user if hasPermission user ->
                     loadPage route user
@@ -4098,7 +4098,7 @@ mod test_fmt {
 
                 Err _ ->
                     ErrorPage
-            "#
+            "
         ));
     }
 
@@ -4107,21 +4107,21 @@ mod test_fmt {
     #[test]
     fn accessor() {
         expr_formats_same(indoc!(
-            r#"
+            r"
             .id
-            "#
+            "
         ));
 
         expr_formats_same(indoc!(
-            r#"
+            r"
             user.name
-            "#
+            "
         ));
 
         expr_formats_same(indoc!(
-            r#"
+            r"
             (getUser userId users).name
-            "#
+            "
         ));
     }
 
@@ -4130,12 +4130,12 @@ mod test_fmt {
     #[test]
     fn precedence_conflict() {
         expr_formats_same(indoc!(
-            r#"
+            r"
             if True == False == True then
                 False
             else
                 True
-            "#
+            "
         ));
     }
 
@@ -4143,17 +4143,17 @@ mod test_fmt {
     fn multi_line_precedence_conflict_1() {
         expr_formats_to(
             indoc!(
-                r#"
+                r"
             if True
                 == False == True
             then
                 False
             else
                 True
-            "#
+            "
             ),
             indoc!(
-                r#"
+                r"
             if
                 True
                 == False
@@ -4162,7 +4162,7 @@ mod test_fmt {
                 False
             else
                 True
-            "#
+            "
             ),
         );
     }
@@ -4197,14 +4197,14 @@ mod test_fmt {
     #[test]
     fn precedence_conflict_functions() {
         expr_formats_same(indoc!(
-            r#"
+            r"
             when f x == g y == h z is
                 True ->
                     Ok 1
 
                 False ->
                     Err 2
-            "#
+            "
         ));
     }
 
@@ -4257,17 +4257,17 @@ mod test_fmt {
     fn multiline_binop_with_comments() {
         expr_formats_to(
             indoc!(
-                r#"
+                r"
             x = 1
                 + 1 # comment 1
                 - 1 # comment 2
                 * 1 # comment 3
 
             x
-            "#
+            "
             ),
             indoc!(
-                r#"
+                r"
             x =
                 1
                 + 1 # comment 1
@@ -4275,87 +4275,87 @@ mod test_fmt {
                 * 1 # comment 3
 
             x
-            "#
+            "
             ),
         );
 
         expr_formats_to(
             indoc!(
-                r#"
+                r"
             x = 1
                 + 1 # comment 1
                 * 1 # comment 2
 
             x
-            "#
+            "
             ),
             indoc!(
-                r#"
+                r"
             x =
                 1
                 + 1 # comment 1
                 * 1 # comment 2
 
             x
-            "#
+            "
             ),
         );
 
         expr_formats_to(
             indoc!(
-                r#"
+                r"
             x = 1
                 + 1 # comment
 
             x
-            "#
+            "
             ),
             indoc!(
-                r#"
+                r"
             x =
                 1
                 + 1 # comment
 
             x
-            "#
+            "
             ),
         );
 
         expr_formats_to(
             indoc!(
-                r#"
+                r"
             x = 1
                 * 1
                 + 1 # comment
 
             x
-            "#
+            "
             ),
             indoc!(
-                r#"
+                r"
             x =
                 1
                 * 1
                 + 1 # comment
 
             x
-            "#
+            "
             ),
         );
 
         expr_formats_to(
             indoc!(
-                r#"
+                r"
             x = 1
                 - 1
                 * 1
                 + 1
 
             x
-            "#
+            "
             ),
             indoc!(
-                r#"
+                r"
             x =
                 1
                 - 1
@@ -4363,7 +4363,7 @@ mod test_fmt {
                 + 1
 
             x
-            "#
+            "
             ),
         );
     }
@@ -4371,7 +4371,7 @@ mod test_fmt {
     #[test]
     fn multiline_binop_if_with_comments() {
         expr_formats_same(indoc!(
-            r#"
+            r"
             if
                 x
                 + 1 # comment 1
@@ -4382,7 +4382,7 @@ mod test_fmt {
                 < 1 # comment 4
             else
                 42
-            "#
+            "
         ));
     }
 
@@ -4453,27 +4453,27 @@ mod test_fmt {
     #[test]
     fn precedence_conflict_greater_than() {
         expr_formats_same(indoc!(
-            r#"
+            r"
             3 > 4 > 10
-            "#
+            "
         ));
     }
 
     #[test]
     fn precedence_conflict_greater_than_and_less_than() {
         expr_formats_same(indoc!(
-            r#"
+            r"
             1 < 4 > 1
-            "#
+            "
         ));
     }
 
     #[test]
     fn binop_if() {
         expr_formats_same(indoc!(
-            r#"
+            r"
             5 * (if x > 0 then 1 else 2)
-            "#
+            "
         ));
     }
 
@@ -4482,20 +4482,20 @@ mod test_fmt {
     #[test]
     fn unary_op() {
         expr_formats_same(indoc!(
-            r#"
+            r"
                 y = -4
 
                 !x
-            "#
+            "
         ));
     }
 
     #[test]
     fn unary_call_parens() {
         expr_formats_same(indoc!(
-            r#"
+            r"
                 !(f 1)
-            "#
+            "
         ));
     }
 
@@ -4503,9 +4503,9 @@ mod test_fmt {
     fn unary_call_no_parens() {
         // TIL: Negating a function "does what you might expect"... which is cool!
         expr_formats_same(indoc!(
-            r#"
+            r"
                 !f 1
-            "#
+            "
         ));
     }
 
@@ -4514,9 +4514,9 @@ mod test_fmt {
     #[test]
     fn binary_op() {
         expr_formats_same(indoc!(
-            r#"
+            r"
             1 == 1
-            "#
+            "
         ));
     }
 
@@ -4524,14 +4524,14 @@ mod test_fmt {
     fn binary_op_with_spaces() {
         expr_formats_to(
             indoc!(
-                r#"
+                r"
                 2   !=   3
-                "#
+                "
             ),
             indoc!(
-                r#"
+                r"
                 2 != 3
-                "#
+                "
             ),
         );
     }
@@ -4539,11 +4539,11 @@ mod test_fmt {
     #[test]
     fn multi_line_binary_op_1() {
         expr_formats_same(indoc!(
-            r#"
+            r"
             isLast
             && isEmpty
             && isLoaded
-            "#
+            "
         ));
     }
 
@@ -4551,21 +4551,21 @@ mod test_fmt {
     fn multi_line_binary_op_2() {
         expr_formats_to(
             indoc!(
-                r#"
+                r"
             x = 1
                 < 2
 
             f x
-            "#
+            "
             ),
             indoc!(
-                r#"
+                r"
             x =
                 1
                 < 2
 
             f x
-            "#
+            "
             ),
         );
     }
@@ -4574,20 +4574,20 @@ mod test_fmt {
     fn multi_line_binary_op_with_comments() {
         expr_formats_to(
             indoc!(
-                r#"
+                r"
                 1
                 * 2
                 / 3
                 // 4
-                "#
+                "
             ),
             indoc!(
-                r#"
+                r"
                 1
                 * 2
                 / 3
                 // 4
-                "#
+                "
             ),
         );
     }
@@ -4596,19 +4596,19 @@ mod test_fmt {
     fn partial_multi_line_binary_op_1() {
         expr_formats_to(
             indoc!(
-                r#"
+                r"
                 2 % 3
                     // 5
                     + 7
-                "#
+                "
             ),
             indoc!(
-                r#"
+                r"
                 2
                 % 3
                 // 5
                 + 7
-                "#
+                "
             ),
         );
     }
@@ -4617,17 +4617,17 @@ mod test_fmt {
     fn partial_multi_line_binary_op_2() {
         expr_formats_to(
             indoc!(
-                r#"
+                r"
                 isGreenLight
                     && isRedLight && isYellowLight
-                "#
+                "
             ),
             indoc!(
-                r#"
+                r"
                 isGreenLight
                 && isRedLight
                 && isYellowLight
-                "#
+                "
             ),
         );
     }
@@ -4635,55 +4635,55 @@ mod test_fmt {
     #[test]
     fn pipline_op_with_apply() {
         expr_formats_same(indoc!(
-            r#"
+            r"
             output
             |> List.set (offset + 0) b
             |> List.set (offset + 1) a
-            "#
+            "
         ));
     }
 
     #[test]
     fn apply_lambda() {
         expr_formats_same(indoc!(
-            r#"
+            r"
             List.map
                 xs
                 (\i ->
                     i + length)
-            "#
+            "
         ));
     }
 
     #[test]
     fn pipline_apply_lambda_1() {
         expr_formats_same(indoc!(
-            r#"
+            r"
             shout
             |> List.map
                 xs
                 (\i -> i)
-            "#
+            "
         ));
     }
 
     #[test]
     fn pipline_apply_lambda_2() {
         expr_formats_same(indoc!(
-            r#"
+            r"
             shout
             |> List.map
                 xs
                 (\i -> i)
             |> List.join
-            "#
+            "
         ));
     }
 
     #[test]
     fn comment_between_multiline_ann_args() {
         expr_formats_same(indoc!(
-            r#"
+            r"
                 blah :
                     Str,
                     # comment
@@ -4691,14 +4691,14 @@ mod test_fmt {
                     -> Str
 
                 42
-            "#
+            "
         ))
     }
 
     #[test]
     fn pipeline_apply_lambda_multiline() {
         expr_formats_same(indoc!(
-            r#"
+            r"
                 example = \model ->
                     model
                     |> withModel
@@ -4712,12 +4712,12 @@ mod test_fmt {
                         )
 
                 example
-            "#
+            "
         ));
 
         expr_formats_to(
             indoc!(
-                r#"
+                r"
                     example = \model ->
                         model
                             |> withModel
@@ -4731,10 +4731,10 @@ mod test_fmt {
                                 )
 
                     example
-                "#
+                "
             ),
             indoc!(
-                r#"
+                r"
                     example = \model ->
                         model
                         |> withModel
@@ -4748,7 +4748,7 @@ mod test_fmt {
                             )
 
                     example
-                "#
+                "
             ),
         );
     }
@@ -4756,12 +4756,12 @@ mod test_fmt {
     #[test]
     fn func_call_trailing_multiline_lambda() {
         expr_formats_same(indoc!(
-            r#"
+            r"
                 list = List.map [1, 2, 3] \x ->
                     x + 1
 
                 list
-            "#
+            "
         ));
     }
 
@@ -4770,8 +4770,8 @@ mod test_fmt {
     #[test]
     fn single_line_interface() {
         module_formats_same(indoc!(
-            r#"
-                interface Foo exposes [] imports []"#
+            r"
+                interface Foo exposes [] imports []"
         ));
     }
 
@@ -4780,15 +4780,15 @@ mod test_fmt {
         // TODO: make the formatter add a space between '42' and # below:
         module_formats_to(
             indoc!(
-                r#"
+                r"
             interface Foo exposes [] imports []
-            a = 42 # Yay greetings"#
+            a = 42 # Yay greetings"
             ),
             indoc!(
-                r#"
+                r"
             interface Foo exposes [] imports []
             a = 42 # Yay greetings
-            "#
+            "
             ),
         );
     }
@@ -4796,37 +4796,37 @@ mod test_fmt {
     #[test]
     fn multiline_interface() {
         module_formats_same(indoc!(
-            r#"
+            r"
                 interface Foo
                     exposes []
-                    imports []"#
+                    imports []"
         ));
     }
 
     #[test]
     fn interface_exposing() {
         module_formats_same(indoc!(
-            r#"
+            r"
                 interface Foo
                     exposes [Bar, Baz, a, b]
-                    imports []"#
+                    imports []"
         ));
     }
 
     #[test]
     fn interface_importing() {
         module_formats_same(indoc!(
-            r#"
+            r"
                 interface Foo
                     exposes [Bar, Baz, a, b]
-                    imports [Blah, Thing.{ foo, bar }, Stuff]"#
+                    imports [Blah, Thing.{ foo, bar }, Stuff]"
         ));
     }
 
     #[test]
     fn multi_line_interface() {
         module_formats_same(indoc!(
-            r#"
+            r"
                 interface Foo
                     exposes [
                         Stuff,
@@ -4836,7 +4836,7 @@ mod test_fmt {
                     imports [
                         Blah,
                         Baz.{ stuff, things },
-                    ]"#
+                    ]"
         ));
     }
 
@@ -4927,15 +4927,15 @@ mod test_fmt {
     #[test]
     fn single_line_hosted() {
         module_formats_same(indoc!(
-            r#"
-                hosted Foo exposes [] imports [] generates Bar with []"#
+            r"
+                hosted Foo exposes [] imports [] generates Bar with []"
         ));
     }
 
     #[test]
     fn multi_line_hosted() {
         module_formats_same(indoc!(
-            r#"
+            r"
                 hosted Foo
                     exposes [
                         Stuff,
@@ -4950,7 +4950,7 @@ mod test_fmt {
                         map,
                         after,
                         loop,
-                    ]"#
+                    ]"
         ));
     }
 
@@ -4959,38 +4959,38 @@ mod test_fmt {
     #[test]
     fn list_alias() {
         expr_formats_same(indoc!(
-            r#"
+            r"
             ConsList a : [Cons a (ConsList a), Nil]
 
             f : ConsList a -> ConsList a
             f = \_ -> Nil
 
             f
-            "#
+            "
         ));
     }
 
     #[test]
     fn wildcard() {
         expr_formats_same(indoc!(
-            r#"
+            r"
             f : List *
             f = []
 
             a
-            "#
+            "
         ));
     }
 
     #[test]
     fn identity() {
         expr_formats_same(indoc!(
-            r#"
+            r"
             f : a -> a
             f = []
 
             a
-            "#
+            "
         ));
     }
 
@@ -5016,28 +5016,28 @@ mod test_fmt {
     #[test]
     fn multiline_tag_union_annotation_no_comments() {
         expr_formats_same(indoc!(
-            r#"
+            r"
             b : [
                 True,
                 False,
             ]
 
             b
-            "#
+            "
         ));
 
         expr_formats_same(indoc!(
-            r#"
+            r"
             b :
                 [True, False]
 
             b
-            "#
+            "
         ));
 
         expr_formats_to(
             indoc!(
-                r#"
+                r"
                 b :
                     [
                         True,
@@ -5045,40 +5045,40 @@ mod test_fmt {
                     ]
 
                 b
-                "#
+                "
             ),
             indoc!(
-                r#"
+                r"
                 b : [
                     True,
                     False,
                 ]
 
                 b
-                "#
+                "
             ),
         );
 
         expr_formats_to(
             indoc!(
-                r#"
+                r"
                 b : [
                         True,
                         False,
                     ]
 
                 b
-                "#
+                "
             ),
             indoc!(
-                r#"
+                r"
                 b : [
                     True,
                     False,
                 ]
 
                 b
-                "#
+                "
             ),
         );
     }
@@ -5086,7 +5086,7 @@ mod test_fmt {
     #[test]
     fn multiline_tag_union_annotation_beginning_on_same_line() {
         expr_formats_same(indoc!(
-            r#"
+            r"
             Expr : [
                 Add Expr Expr,
                 Mul Expr Expr,
@@ -5094,7 +5094,7 @@ mod test_fmt {
                 Var I64,
             ]
 
-            Expr"#
+            Expr"
         ));
     }
 
@@ -5102,7 +5102,7 @@ mod test_fmt {
     fn multiline_tag_union_annotation_with_final_comment() {
         expr_formats_to(
             indoc!(
-                r#"
+                r"
             b :
                 [
                     True,
@@ -5113,10 +5113,10 @@ mod test_fmt {
                 ]
 
             b
-            "#
+            "
             ),
             indoc!(
-                r#"
+                r"
                 b : [
                     True,
                     # comment 1
@@ -5125,7 +5125,7 @@ mod test_fmt {
                 ]
 
                 b
-                "#
+                "
             ),
         );
     }
@@ -5133,12 +5133,12 @@ mod test_fmt {
     #[test]
     fn tag_union() {
         expr_formats_same(indoc!(
-            r#"
+            r"
             f : [True, False] -> [True, False]
             f = \x -> x
 
             a
-            "#
+            "
         ));
     }
 
@@ -5147,7 +5147,7 @@ mod test_fmt {
     // #[test]
     // fn multiline_tag_union_function_annotation() {
     //     expr_formats_same(indoc!(
-    //         r#"
+    //         r"
     //         f :
     //             [
     //                 True,
@@ -5160,14 +5160,14 @@ mod test_fmt {
     //         f = \x -> x
 
     //         a
-    //         "#
+    //         "
     //     ));
     // }
 
     #[test]
     fn recursive_tag_union() {
         expr_formats_same(indoc!(
-            r#"
+            r"
             f : [Cons a (ConsList a), Nil] as ConsList a -> [Just a, Nothing]
             f = \list ->
                 when list is
@@ -5178,100 +5178,100 @@ mod test_fmt {
                         Just first
 
             f
-            "#
+            "
         ));
     }
 
     #[test]
     fn function_application_package_type() {
         expr_formats_same(indoc!(
-            r#"
+            r"
             main : Task.Task {} []
             main = 42
 
             main
-            "#
+            "
         ));
     }
 
     #[test]
     fn record_type() {
         expr_formats_same(indoc!(
-            r#"
+            r"
             f : { foo : Int * }
             f = { foo: 1000 }
 
             a
-            "#
+            "
         ));
     }
 
     #[test]
     fn record_pattern_with_apply_guard() {
         expr_formats_same(indoc!(
-            r#"
+            r"
             when { x: 1 } is
                 { x: Just 4 } ->
                     4
-            "#
+            "
         ));
     }
 
     #[test]
     fn record_pattern_with_record_guard() {
         expr_formats_same(indoc!(
-            r#"
+            r"
             when { x: 1 } is
                 { x: { x: True } } ->
                     4
-            "#
+            "
         ));
     }
 
     #[test]
     fn body_starts_with_spaces_multiline() {
         expr_formats_same(indoc!(
-            r#"
+            r"
             y =
                 Foo
                     1
                     2
 
             y
-            "#
+            "
         ));
     }
 
     #[test]
     fn backpassing_simple() {
         expr_formats_same(indoc!(
-            r#"
+            r"
                 getChar = \ctx ->
                     x <- Task.await (getCharScope scope)
                     42
 
                 42
-            "#
+            "
         ));
     }
 
     #[test]
     fn backpassing_apply_tag() {
         expr_formats_same(indoc!(
-            r#"
+            r"
                 getChar = \ctx ->
                     (T val newScope) <- Task.await (getCharScope scope)
                     42
 
                 42
-            "#
+            "
         ));
     }
 
     #[test]
     fn backpassing_parens_body() {
         expr_formats_same(indoc!(
-            r#"
+            r"
             Task.fromResult
                 (
                     b <- binaryOp ctx
@@ -5280,12 +5280,12 @@ mod test_fmt {
                     else
                         0
                 )
-            "#
+            "
         ));
 
         expr_formats_to(
             indoc!(
-                r#"
+                r"
                     Task.fromResult
                         (b <- binaryOp ctx
                             if a == b then
@@ -5293,10 +5293,10 @@ mod test_fmt {
                             else
                                 0
                             )
-                "#
+                "
             ),
             indoc!(
-                r#"
+                r"
                     Task.fromResult
                         (
                             b <- binaryOp ctx
@@ -5305,23 +5305,23 @@ mod test_fmt {
                             else
                                 0
                         )
-                "#
+                "
             ),
         );
 
         expr_formats_to(
             indoc!(
-                r#"
+                r"
                     Task.fromResult
                         (b <- binaryOp ctx
                             if a == b then
                                 -1
                             else
                                 0)
-                "#
+                "
             ),
             indoc!(
-                r#"
+                r"
                     Task.fromResult
                         (
                             b <- binaryOp ctx
@@ -5330,7 +5330,7 @@ mod test_fmt {
                             else
                                 0
                         )
-                "#
+                "
             ),
         );
     }
@@ -5338,31 +5338,31 @@ mod test_fmt {
     #[test]
     fn backpassing_body_on_newline() {
         expr_formats_same(indoc!(
-            r#"
+            r"
                 getChar = \ctx ->
                     x <-
                         Task.await (getCharScope scope)
                     42
 
                 42
-            "#
+            "
         ));
     }
 
     #[test]
     fn multiline_higher_order_function() {
         expr_formats_same(indoc!(
-            r#"
+            r"
             foo :
                 (Str -> Bool)
                 -> Bool
 
             42
-            "#
+            "
         ));
 
         expr_formats_same(indoc!(
-            r#"
+            r"
             foo :
                 (Str -> Bool),
                 Str
@@ -5371,117 +5371,117 @@ mod test_fmt {
                 42
 
             42
-            "#
+            "
         ));
 
         expr_formats_same(indoc!(
-            r#"
+            r"
                 foo :
                     (Str -> Bool) -> Bool
 
                 42
-                "#
+                "
         ));
 
         expr_formats_same(indoc!(
-            r#"
+            r"
                 foo :
                     (Str -> Bool), Str -> Bool
                 foo = \bar, baz ->
                     42
 
                 42
-                "#
+                "
         ));
 
         expr_formats_same(indoc!(
-            r#"
+            r"
                 foo :
                     (Str -> Bool), Str -> Bool # comment
                 foo = \bar, baz ->
                     42
 
                 42
-                "#
+                "
         ));
     }
 
     #[test]
     fn multiline_opaque_tag_union() {
         expr_formats_same(indoc!(
-            r#"
+            r"
             A := [
                 B,
                 C,
             ]
 
             0
-            "#
+            "
         ));
     }
 
     #[test]
     fn opaque_implements_clause() {
         expr_formats_same(indoc!(
-            r#"
+            r"
             A := U8 implements [Eq, Hash]
 
             0
-            "#
+            "
         ));
 
         expr_formats_to(
             indoc!(
-                r#"
+                r"
                 A :=
                     U8
                     implements [Eq, Hash]
 
                 0
-                "#
+                "
             ),
             indoc!(
-                r#"
+                r"
                 A := U8
                     implements [Eq, Hash]
 
                 0
-                "#
+                "
             ),
         );
 
         expr_formats_to(
             indoc!(
-                r#"
+                r"
                 A := a where a implements Hash implements [ Eq, Hash ]
 
                 0
-                "#
+                "
             ),
             indoc!(
-                r#"
+                r"
                 A := a where a implements Hash
                     implements [Eq, Hash]
 
                 0
-                "#
+                "
             ),
         );
 
         expr_formats_to(
             indoc!(
-                r#"
+                r"
                 A := U8 implements []
 
                 0
-                "#
+                "
             ),
             indoc!(
-                r#"
+                r"
                 A := U8 implements []
 
                 0
-                "#
+                "
             ),
         );
     }
@@ -5490,7 +5490,7 @@ mod test_fmt {
     fn comma_prefixed_indented_record() {
         expr_formats_to(
             indoc!(
-                r#"
+                r"
             Model position :
                 { evaluated : Set position
                 , openSet : Set position
@@ -5500,10 +5500,10 @@ mod test_fmt {
 
 
             a
-            "#,
+            ",
             ),
             indoc!(
-                r#"
+                r"
             Model position : {
                 evaluated : Set position,
                 openSet : Set position,
@@ -5512,7 +5512,7 @@ mod test_fmt {
             }
 
             a
-            "#,
+            ",
             ),
         );
     }
@@ -5520,24 +5520,24 @@ mod test_fmt {
     #[test]
     fn opaque_implements_with_impls() {
         expr_formats_same(indoc!(
-            r#"
+            r"
             A := U8 implements [Eq { eq }, Hash { hash }]
 
             0
-            "#
+            "
         ));
 
         expr_formats_same(indoc!(
-            r#"
+            r"
             A := U8 implements [Eq { eq, eq1 }]
 
             0
-            "#
+            "
         ));
 
         expr_formats_to(
             indoc!(
-                r#"
+                r"
                 A := U8 implements [Eq {   eq,     eq1   }]
                 A := U8 implements [Eq {
                                     eq,
@@ -5545,10 +5545,10 @@ mod test_fmt {
                                 }]
 
                 0
-                "#
+                "
             ),
             indoc!(
-                r#"
+                r"
                 A := U8 implements [Eq { eq, eq1 }]
                 A := U8 implements [
                         Eq {
@@ -5558,25 +5558,25 @@ mod test_fmt {
                     ]
 
                 0
-                "#
+                "
             ),
         );
 
         expr_formats_same(indoc!(
-            r#"
+            r"
             A := a where a implements Other
                 implements [Eq { eq }, Hash { hash }]
 
             0
-            "#
+            "
         ));
 
         expr_formats_same(indoc!(
-            r#"
+            r"
             A := U8 implements [Eq {}]
 
             0
-            "#
+            "
         ));
     }
 
@@ -5584,7 +5584,7 @@ mod test_fmt {
     fn comments_in_multiline_tag_union_annotation() {
         expr_formats_to(
             indoc!(
-                r#"
+                r"
                     UnionAnn : [
                         Foo, # comment 1
                         Bar, # comment 2
@@ -5594,10 +5594,10 @@ mod test_fmt {
                     ]
 
                     0
-                "#
+                "
             ),
             indoc!(
-                r#"
+                r"
                     UnionAnn : [
                         Foo, # comment 1
                         Bar, # comment 2
@@ -5607,7 +5607,7 @@ mod test_fmt {
                     ]
 
                     0
-                "#
+                "
             ),
         );
     }
@@ -5615,7 +5615,7 @@ mod test_fmt {
     #[test]
     fn test_where_after() {
         expr_formats_same(indoc!(
-            r#"
+            r"
                 Dict k v := {
                     metadata : List I8,
                     dataIndices : List Nat,
@@ -5624,7 +5624,7 @@ mod test_fmt {
                 } where k implements Hash & Eq
 
                 a
-                "#
+                "
         ));
     }
 
@@ -5687,7 +5687,7 @@ mod test_fmt {
     #[test]
     fn expect_single_line() {
         expr_formats_same(indoc!(
-            r#"
+            r"
             x = 5
 
             expect x == y
@@ -5695,11 +5695,11 @@ mod test_fmt {
             expect y == z
 
             42
-            "#
+            "
         ));
 
         module_formats_same(indoc!(
-            r#"
+            r"
                 interface Foo exposes [] imports []
 
                 expect x == y
@@ -5707,14 +5707,14 @@ mod test_fmt {
                 expect y == z
 
                 foo = bar
-            "#
+            "
         ));
     }
 
     #[test]
     fn expect_multiline() {
         expr_formats_same(indoc!(
-            r#"
+            r"
             x = 5
 
             expect
@@ -5722,11 +5722,11 @@ mod test_fmt {
                 |> baz
 
             42
-            "#
+            "
         ));
 
         module_formats_same(indoc!(
-            r#"
+            r"
                 interface Foo exposes [] imports []
 
                 expect
@@ -5738,7 +5738,7 @@ mod test_fmt {
                         etc
 
                 foo = bar
-            "#
+            "
         ));
     }
 
@@ -5788,49 +5788,49 @@ mod test_fmt {
     #[test]
     fn format_chars() {
         expr_formats_same(indoc!(
-            r#"
+            r"
             ' '
-            "#
+            "
         ));
 
         expr_formats_same(indoc!(
-            r#"
+            r"
             '\n'
-            "#
+            "
         ));
     }
 
     #[test]
     fn format_char_pattern() {
         expr_formats_same(indoc!(
-            r#"
+            r"
             when x is
                 ' ' -> x
                 '\n' -> x
                 '\t' -> x
-            "#
+            "
         ));
     }
 
     #[test]
     fn format_nested_pipeline() {
         expr_formats_same(indoc!(
-            r#"
+            r"
             (a |> b) |> c
-            "#
+            "
         ));
 
         expr_formats_same(indoc!(
-            r#"
+            r"
             a |> b |> c
-            "#
+            "
         ));
     }
 
     #[test]
     fn ability_member_doc_comments() {
         module_formats_same(indoc!(
-            r#"
+            r"
             interface Foo exposes [] imports []
 
             A implements
@@ -5841,19 +5841,19 @@ mod test_fmt {
                 de : a -> a where a implements A
 
             f = g
-            "#
+            "
         ));
     }
 
     #[test]
     fn leading_comments_preserved() {
         module_formats_same(indoc!(
-            r#"
+            r"
             # hello world
             interface Foo
                 exposes []
                 imports []
-            "#
+            "
         ));
 
         module_formats_same(indoc!(
@@ -5879,32 +5879,32 @@ mod test_fmt {
     #[test]
     fn clauses_with_multiple_abilities() {
         expr_formats_same(indoc!(
-            r#"
+            r"
             f : {} -> a where a implements Eq & Hash & Decode
 
             f
-            "#
+            "
         ));
 
         expr_formats_to(
             indoc!(
-                r#"
+                r"
                 f : {} -> a where a implements Eq & Hash & Decode,
                               b implements Eq & Hash
 
                 f
-                "#
+                "
             ),
             indoc!(
                 // TODO: ideally, this would look a bit nicer - consider
                 // f : {} -> a
                 //   where a implements Eq & Hash & Decode,
                 //     b implements Eq & Hash
-                r#"
+                r"
                 f : {} -> a where a implements Eq & Hash & Decode, b implements Eq & Hash
 
                 f
-                "#
+                "
             ),
         );
     }
@@ -5912,58 +5912,58 @@ mod test_fmt {
     #[test]
     fn format_list_patterns() {
         expr_formats_same(indoc!(
-            r#"
+            r"
             when [] is
                 [] -> []
-            "#
+            "
         ));
 
         expr_formats_to(
             indoc!(
-                r#"
+                r"
                 when [] is
                     [  ] -> []
-                "#
+                "
             ),
             indoc!(
-                r#"
+                r"
                 when [] is
                     [] -> []
-                "#
+                "
             ),
         );
 
         expr_formats_to(
             indoc!(
-                r#"
+                r"
                 when [] is
                     [ x,  ..  ,    A  5   6,  .. ] -> []
-                "#
+                "
             ),
             indoc!(
-                r#"
+                r"
                 when [] is
                     [x, .., A 5 6, ..] -> []
-                "#
+                "
             ),
         );
 
         expr_formats_to(
             indoc!(
-                r#"
+                r"
                 when [] is
                     [ x, 4, 5 ] -> []
                     [ ..,   5 ] -> []
                     [ x,   .. ] -> []
-                "#
+                "
             ),
             indoc!(
-                r#"
+                r"
                 when [] is
                     [x, 4, 5] -> []
                     [.., 5] -> []
                     [x, ..] -> []
-                "#
+                "
             ),
         );
     }
@@ -6007,7 +6007,7 @@ mod test_fmt {
     fn issue_6197() {
         expr_formats_to(
             indoc!(
-                r#"
+                r"
                 when l1 is
                     [
                     .. 
@@ -6018,14 +6018,14 @@ mod test_fmt {
                     l2
                     ->
                         f rest
-                "#
+                "
             ),
             indoc!(
-                r#"
+                r"
                 when l1 is
                     [.. as rest] as l2 ->
                         f rest
-                "#
+                "
             ),
         );
     }
@@ -6034,7 +6034,7 @@ mod test_fmt {
     //    #[test]
     //    fn multiline_apply() {
     //        expr_formats_same(indoc!(
-    //            r#"
+    //            r"
     //            f :
     //                Result a
     //                    { x : Int *
@@ -6044,7 +6044,7 @@ mod test_fmt {
     //                -> Int *
     //            f =
     //                \_ -> 4
-    //            "#
+    //            "
     //        ));
     //    }
 }

--- a/crates/repl_expect/src/lib.rs
+++ b/crates/repl_expect/src/lib.rs
@@ -238,12 +238,12 @@ mod test {
                 "#
             ),
             indoc!(
-                r#"
+                r"
                 This expectation failed:
 
                 5│  expect 1 == 2
                     ^^^^^^^^^^^^^
-                "#
+                "
             ),
         );
     }
@@ -265,7 +265,7 @@ mod test {
                 "#
             ),
             indoc!(
-                r#"
+                r"
                 This expectation failed:
 
                 5│>  expect
@@ -281,7 +281,7 @@ mod test {
 
                 b : Num *
                 b = 2
-                "#
+                "
             ),
         );
     }
@@ -380,7 +380,7 @@ mod test {
                 "#
             ),
             indoc!(
-                r#"
+                r"
                 This expectation failed:
 
                  5│>  expect
@@ -397,7 +397,7 @@ mod test {
 
                 expected : Result I64 [OutOfBounds]
                 expected = Ok 42
-                "#
+                "
             ),
         );
     }
@@ -463,7 +463,7 @@ mod test {
                 "#
             ),
             indoc!(
-                r#"
+                r"
                 This expectation failed:
 
                 5│>  expect
@@ -485,7 +485,7 @@ mod test {
                     y : U8,
                 }
                 vec2 = { x: 4, y: 8 }
-                "#
+                "
             ),
         );
     }
@@ -965,22 +965,22 @@ mod test {
     fn issue_i4389() {
         run_expect_test(
             indoc!(
-                r#"
+                r"
                 interface Test exposes [] imports []
 
                 expect
                     totalCount = \{} -> 1u8
                     totalCount {} == 96u8
-                "#
+                "
             ),
             indoc!(
-                r#"
+                r"
                 This expectation failed:
 
                 3│>  expect
                 4│>      totalCount = \{} -> 1u8
                 5│>      totalCount {} == 96u8
-                "#
+                "
             ),
         );
     }
@@ -989,7 +989,7 @@ mod test {
     fn adjacent_lists() {
         run_expect_test(
             indoc!(
-                r#"
+                r"
                 interface Test exposes [] imports []
 
                 expect
@@ -1007,10 +1007,10 @@ mod test {
                         x: [115, 116, 117],
                     }
                     actual == expected
-                "#
+                "
             ),
             indoc!(
-                r#"
+                r"
                 This expectation failed:
 
                  3│>  expect
@@ -1044,7 +1044,7 @@ mod test {
                     x : List (Int Unsigned8),
                 }
                 expected = { body: [42, 43, 44], headers: [15, 16, 17], x: [115, 116, 117] }
-                "#
+                "
             ),
         );
     }
@@ -1113,7 +1113,7 @@ mod test {
     fn tag_payloads_of_different_size() {
         run_expect_test(
             indoc!(
-                r#"
+                r"
                 interface Test exposes [] imports []
 
                 actual : [Leftover (List U8), TooShort]
@@ -1124,10 +1124,10 @@ mod test {
                     expected = TooShort
 
                     actual == expected
-                "#
+                "
             ),
             indoc!(
-                r#"
+                r"
                 This expectation failed:
 
                  6│>  expect
@@ -1143,7 +1143,7 @@ mod test {
                     TooShort,
                 ]
                 expected = TooShort
-                "#
+                "
             ),
         );
     }
@@ -1220,7 +1220,7 @@ mod test {
     fn match_on_opaque_number_type() {
         run_expect_test(
             indoc!(
-                r#"
+                r"
                 interface Test exposes [] imports []
 
                 hexToByte : U8, U8 -> U8
@@ -1231,10 +1231,10 @@ mod test {
                     actual = hexToByte 7 4
                     expected = 't'
                     actual == expected
-                "#
+                "
             ),
             indoc!(
-                r#"
+                r"
                 This expectation failed:
 
                  7│>  expect
@@ -1249,7 +1249,7 @@ mod test {
 
                 expected : Int Unsigned8
                 expected = 116
-                "#
+                "
             ),
         );
     }

--- a/crates/repl_test/src/tests.rs
+++ b/crates/repl_test/src/tests.rs
@@ -124,11 +124,11 @@ fn bool_basic_equality() {
 fn bool_true() {
     expect_success(
         indoc!(
-            r#"
+            r"
             Bool.true
-            "#
+            "
         ),
-        r#"Bool.true : Bool"#,
+        r"Bool.true : Bool",
     );
 }
 
@@ -136,11 +136,11 @@ fn bool_true() {
 fn bool_false() {
     expect_success(
         indoc!(
-            r#"
+            r"
             Bool.false
-            "#
+            "
         ),
-        r#"Bool.false : Bool"#,
+        r"Bool.false : Bool",
     );
 }
 
@@ -315,24 +315,24 @@ fn nested_string_list() {
 #[test]
 fn nested_num_list() {
     expect_success(
-        r#"[[[4, 3, 2], [1, 0]], [[]], []]"#,
-        r#"[[[4, 3, 2], [1, 0]], [[]], []] : List (List (List (Num *)))"#,
+        r"[[[4, 3, 2], [1, 0]], [[]], []]",
+        r"[[[4, 3, 2], [1, 0]], [[]], []] : List (List (List (Num *)))",
     );
 }
 
 #[test]
 fn nested_int_list() {
     expect_success(
-        r#"[[[4, 3, 2], [1, 0x0]], [[]], []]"#,
-        r#"[[[4, 3, 2], [1, 0]], [[]], []] : List (List (List (Int *)))"#,
+        r"[[[4, 3, 2], [1, 0x0]], [[]], []]",
+        r"[[[4, 3, 2], [1, 0]], [[]], []] : List (List (List (Int *)))",
     );
 }
 
 #[test]
 fn nested_float_list() {
     expect_success(
-        r#"[[[4, 3, 2], [1, 0.0]], [[]], []]"#,
-        r#"[[[4, 3, 2], [1, 0]], [[]], []] : List (List (List (Frac *)))"#,
+        r"[[[4, 3, 2], [1, 0.0]], [[]], []]",
+        r"[[[4, 3, 2], [1, 0]], [[]], []] : List (List (List (Frac *)))",
     );
 }
 
@@ -641,7 +641,7 @@ fn too_few_args() {
     expect_failure(
         "Num.add 2",
         indoc!(
-            r#"
+            r"
                 ── TOO FEW ARGS ────────────────────────────────────────────────────────────────
 
                 The add function expects 2 arguments, but it got only 1:
@@ -651,7 +651,7 @@ fn too_few_args() {
 
                 Roc does not allow functions to be partially applied. Use a closure to
                 make partial application explicit.
-                "#
+                "
         ),
     );
 }
@@ -970,7 +970,7 @@ fn large_nullable_wrapped_tag_union() {
 fn issue_2300() {
     expect_success(
         r#"\Email str -> str == """#,
-        r#"<function> : [Email Str] -> Bool"#,
+        r"<function> : [Email Str] -> Bool",
     )
 }
 
@@ -978,8 +978,8 @@ fn issue_2300() {
 #[test]
 fn function_in_list() {
     expect_success(
-        r#"[\x -> x + 1, \s -> s * 2]"#,
-        r#"[<function>, <function>] : List (Num a -> Num a)"#,
+        r"[\x -> x + 1, \s -> s * 2]",
+        r"[<function>, <function>] : List (Num a -> Num a)",
     )
 }
 
@@ -987,8 +987,8 @@ fn function_in_list() {
 #[test]
 fn function_in_record() {
     expect_success(
-        r#"{ n: 1, adder: \x -> x + 1 }"#,
-        r#"{ adder: <function>, n: 1 } : { adder : Num a -> Num a, n : Num * }"#,
+        r"{ n: 1, adder: \x -> x + 1 }",
+        r"{ adder: <function>, n: 1 } : { adder : Num a -> Num a, n : Num * }",
     )
 }
 
@@ -996,8 +996,8 @@ fn function_in_record() {
 #[test]
 fn function_in_unwrapped_record() {
     expect_success(
-        r#"{ adder: \x -> x + 1 }"#,
-        r#"{ adder: <function> } : { adder : Num a -> Num a }"#,
+        r"{ adder: \x -> x + 1 }",
+        r"{ adder: <function> } : { adder : Num a -> Num a }",
     )
 }
 
@@ -1005,16 +1005,16 @@ fn function_in_unwrapped_record() {
 #[test]
 fn function_in_tag() {
     expect_success(
-        r#"Adder (\x -> x + 1)"#,
-        r#"Adder <function> : [Adder (Num a -> Num a)]"#,
+        r"Adder (\x -> x + 1)",
+        r"Adder <function> : [Adder (Num a -> Num a)]",
     )
 }
 
 #[test]
 fn newtype_of_record_of_tag_of_record_of_tag() {
     expect_success(
-        r#"A {b: C {d: 1}}"#,
-        r#"A { b: C { d: 1 } } : [A { b : [C { d : Num * }] }]"#,
+        r"A {b: C {d: 1}}",
+        r"A { b: C { d: 1 } } : [A { b : [C { d : Num * }] }]",
     )
 }
 
@@ -1022,11 +1022,11 @@ fn newtype_of_record_of_tag_of_record_of_tag() {
 fn print_u8s() {
     expect_success(
         indoc!(
-            r#"
+            r"
                 x : U8
                 x = 129
                 x
-                "#
+                "
         ),
         "129 : U8",
     )
@@ -1062,17 +1062,17 @@ fn parse_problem() {
 fn issue_2343_complete_mono_with_shadowed_vars() {
     expect_failure(
         indoc!(
-            r#"
+            r"
                 b = False
                 f = \b ->
                     when b is
                         True -> 5
                         False -> 15
                 f b
-                "#
+                "
         ),
         indoc!(
-            r#"
+            r"
                 ── DUPLICATE NAME ──────────────────────────────────────────────────────────────
 
                 The b name is first defined here:
@@ -1087,7 +1087,7 @@ fn issue_2343_complete_mono_with_shadowed_vars() {
 
                 Since these variables have the same name, it's easy to use the wrong
                 one by accident. Give one of them a new name.
-                "#
+                "
         ),
     );
 }
@@ -1126,12 +1126,12 @@ fn tag_with_type_behind_alias() {
 fn issue_2588_record_with_function_and_nonfunction() {
     expect_success(
         indoc!(
-            r#"
+            r"
             x = 1
             f = \n -> n * 2
-            { y: f x, f }"#
+            { y: f x, f }"
         ),
-        r#"{ f: <function>, y: 2 } : { f : Num a -> Num a, y : Num * }"#,
+        r"{ f: <function>, y: 2 } : { f : Num a -> Num a, y : Num * }",
     )
 }
 
@@ -1139,10 +1139,10 @@ fn issue_2588_record_with_function_and_nonfunction() {
 fn opaque_apply() {
     expect_success(
         indoc!(
-            r#"
+            r"
             Age := U32
 
-            @Age 23"#
+            @Age 23"
         ),
         "@Age 23 : Age",
     )
@@ -1165,14 +1165,14 @@ fn opaque_apply_polymorphic() {
 fn opaque_pattern_and_call() {
     expect_success(
         indoc!(
-            r#"
+            r"
             F t u := [Package t u]
 
             f = \@F (Package A {}) -> @F (Package {} A)
 
-            f (@F (Package A {}))"#
+            f (@F (Package A {}))"
         ),
-        r#"@F (Package {} A) : F {} [A]"#,
+        r"@F (Package {} A) : F {} [A]",
     )
 }
 
@@ -1180,10 +1180,10 @@ fn opaque_pattern_and_call() {
 fn dec_in_repl() {
     expect_success(
         indoc!(
-            r#"
+            r"
             x: Dec
             x=1.23
-            x"#
+            x"
         ),
         "1.23 : Dec",
     )
@@ -1193,12 +1193,12 @@ fn dec_in_repl() {
 fn print_i8_issue_2710() {
     expect_success(
         indoc!(
-            r#"
+            r"
             a : I8
             a = -1
-            a"#
+            a"
         ),
-        r#"-1 : I8"#,
+        r"-1 : I8",
     )
 }
 
@@ -1243,11 +1243,11 @@ fn issue_2582_specialize_result_value() {
 fn issue_2818() {
     expect_success(
         indoc!(
-            r#"
+            r"
             f : {} -> List Str
             f = \_ ->
               x = []
-              x"#
+              x"
         ),
         r"<function> : {} -> List Str",
     )
@@ -1257,7 +1257,7 @@ fn issue_2818() {
 fn issue_2810_recursive_layout_inside_nonrecursive() {
     expect_success(
         indoc!(
-            r#"
+            r"
             Command : [Command Tool]
 
             Job : [Job Command]
@@ -1266,7 +1266,7 @@ fn issue_2810_recursive_layout_inside_nonrecursive() {
 
             a : Job
             a = Job (Command (FromJob (Job (Command SystemTool))))
-            a"#
+            a"
         ),
         "Job (Command (FromJob (Job (Command SystemTool)))) : Job",
     )
@@ -1276,12 +1276,12 @@ fn issue_2810_recursive_layout_inside_nonrecursive() {
 fn render_nullable_unwrapped_passing_through_alias() {
     expect_success(
         indoc!(
-            r#"
+            r"
             Deep : [L DeepList]
             DeepList : [Nil, Cons Deep]
             v : DeepList
             v = (Cons (L (Cons (L (Cons (L Nil))))))
-            v"#
+            v"
         ),
         "Cons (L (Cons (L (Cons (L Nil))))) : DeepList",
     )
@@ -1291,9 +1291,9 @@ fn render_nullable_unwrapped_passing_through_alias() {
 fn opaque_wrap_function() {
     expect_success(
         indoc!(
-            r#"
+            r"
             A a := a
-            List.map [1u8, 2u8, 3u8] @A"#
+            List.map [1u8, 2u8, 3u8] @A"
         ),
         "[@A 1, @A 2, @A 3] : List (A U8)",
     );
@@ -1305,10 +1305,10 @@ fn opaque_wrap_function() {
 fn dict_get_single() {
     expect_success(
         indoc!(
-            r#"
-            Dict.single 0 {a: 1, c: 2} |> Dict.get 0"#
+            r"
+            Dict.single 0 {a: 1, c: 2} |> Dict.get 0"
         ),
-        r#"Ok { a: 1, c: 2 } : Result { a : Num *, c : Num * } [KeyNotFound]"#,
+        r"Ok { a: 1, c: 2 } : Result { a : Num *, c : Num * } [KeyNotFound]",
     )
 }
 
@@ -1319,7 +1319,7 @@ fn record_of_poly_function() {
             r#"
             { a: \_ -> "a" }"#
         ),
-        r#"{ a: <function> } : { a : * -> Str }"#,
+        r"{ a: <function> } : { a : * -> Str }",
     );
 }
 
@@ -1338,18 +1338,18 @@ fn record_of_poly_function_and_string() {
 fn newtype_by_void_is_wrapped() {
     expect_success(
         indoc!(
-            r#"
-            Result.try (Err 42) (\x -> Err (x+1))"#
+            r"
+            Result.try (Err 42) (\x -> Err (x+1))"
         ),
-        r#"Err 42 : Result b (Num *)"#,
+        r"Err 42 : Result b (Num *)",
     );
 
     expect_success(
         indoc!(
-            r#"
-            Result.try (Ok 42) (\x -> Ok (x+1))"#
+            r"
+            Result.try (Ok 42) (\x -> Ok (x+1))"
         ),
-        r#"Ok 43 : Result (Num *) err"#,
+        r"Ok 43 : Result (Num *) err",
     );
 }
 
@@ -1357,11 +1357,11 @@ fn newtype_by_void_is_wrapped() {
 fn enum_tag_union_in_list() {
     expect_success(
         indoc!(
-            r#"
+            r"
             [E, F, G, H]
-            "#
+            "
         ),
-        r#"[E, F, G, H] : List [E, F, G, H]"#,
+        r"[E, F, G, H] : List [E, F, G, H]",
     );
 }
 
@@ -1373,7 +1373,7 @@ fn str_to_dec() {
             Str.toDec "1234.1234"
             "#
         ),
-        r#"Ok 1234.1234 : Result Dec [InvalidNumStr]"#,
+        r"Ok 1234.1234 : Result Dec [InvalidNumStr]",
     );
 }
 
@@ -1405,7 +1405,7 @@ fn nested_tuple() {
 fn ordered_tag_union_memory_layout() {
     expect_success(
         indoc!(
-            r#"
+            r"
             Loc : { line: U32, column: U32 }
 
             Node : [ A Loc, Height U8 Loc ]
@@ -1413,9 +1413,9 @@ fn ordered_tag_union_memory_layout() {
             x : Node
             x = Height 1 { line: 2, column: 3 }
             x
-            "#
+            "
         ),
-        r#"Height 1 { column: 3, line: 2 } : Node"#,
+        r"Height 1 { column: 3, line: 2 } : Node",
     );
 }
 

--- a/crates/valgrind/src/lib.rs
+++ b/crates/valgrind/src/lib.rs
@@ -149,7 +149,7 @@ fn run_with_valgrind(binary_path: &std::path::Path) {
         let memory_errors = extract_valgrind_errors(&raw_xml).unwrap_or_else(|err| {
             panic!(
                 indoc!(
-                    r#"
+                    r"
                     failed to parse the `valgrind` xml output:
 
                         Error was:
@@ -167,7 +167,7 @@ fn run_with_valgrind(binary_path: &std::path::Path) {
                         valgrind stderr was:
 
                             {}
-                    "#
+                    "
                 ),
                 err, raw_xml, valgrind_out.stdout, valgrind_out.stderr
             );
@@ -214,7 +214,7 @@ fn list_concat_consumes_first_argument() {
 #[test]
 fn list_concat_consumes_second_argument() {
     valgrind_test(indoc!(
-        r#"
+        r"
         (
             a : List U8
             a = []
@@ -223,7 +223,7 @@ fn list_concat_consumes_second_argument() {
             |> List.len
             |> Num.toStr
         )
-        "#
+        "
     ));
 }
 
@@ -273,7 +273,7 @@ fn str_concat_first_argument_not_unique() {
 #[test]
 fn list_concat_empty_list_zero_sized_type() {
     valgrind_test(indoc!(
-        r#"
+        r"
         (
             a = List.reserve [] 11
             b = []
@@ -281,7 +281,7 @@ fn list_concat_empty_list_zero_sized_type() {
             |> List.len
             |> Num.toStr
         )
-        "#
+        "
     ));
 }
 
@@ -316,7 +316,7 @@ fn str_trim_start_capacity() {
 #[test]
 fn str_concat_later_referencing_empty_list_with_capacity() {
     valgrind_test(indoc!(
-        r#"
+        r"
         (
             a : List U8
             a = List.withCapacity 1
@@ -326,7 +326,7 @@ fn str_concat_later_referencing_empty_list_with_capacity() {
             |> Num.addWrap (List.len a)
             |> Num.toStr
         )
-        "#
+        "
     ));
 }
 
@@ -504,7 +504,7 @@ fn tree_rebalance() {
 #[test]
 fn lowlevel_list_calls() {
     valgrind_test(indoc!(
-        r#"
+        r"
         (
             a = List.map [1,1,1,1,1] (\x -> x + 0)
             b = List.map2 a [1,1,1,1,1] (\x, y -> x + y)
@@ -514,7 +514,7 @@ fn lowlevel_list_calls() {
 
             Num.toStr (List.len e)
         )
-        "#
+        "
     ));
 }
 


### PR DESCRIPTION
I put the fix to this new clippy rule in a separate PR because it's massive and now the reviewer does not need to look for the other clippy changes between these ones.

All changes are one of the following:
- r#"..."# to r"..."
- r###"..."### to r#"..."#
- r###"..."### to r"..."