### PR TITLE
implement panic on overflow for mul in the dev backend

### DIFF
--- a/crates/compiler/gen_dev/src/generic64/x86_64.rs
+++ b/crates/compiler/gen_dev/src/generic64/x86_64.rs
@@ -523,12 +523,12 @@ impl CallConv<X86_64GeneralReg, X86_64FloatReg, X86_64Assembler> for X86_64Syste
         use X86_64GeneralReg::*;
         type ASM = X86_64Assembler;
 
-        // move the first argument to roc_panic (a *RocStr) into r8
-        ASM::add_reg64_reg64_imm32(buf, R8, RSP, 8);
+        // move the first argument to roc_panic (a *const RocStr) into r8
+        ASM::mov_reg64_reg64(buf, R8, RDI);
 
         // move the crash tag into the second return register. We add 1 to it because the 0 value
         // is already used for "no crash occurred"
-        ASM::add_reg64_reg64_imm32(buf, RDX, RDI, 1);
+        ASM::add_reg64_reg64_imm32(buf, RDX, RSI, 1);
 
         // the setlongjmp_buffer
         ASM::data_pointer(buf, relocs, String::from("setlongjmp_buffer"), RDI);

--- a/crates/compiler/gen_dev/src/object_builder.rs
+++ b/crates/compiler/gen_dev/src/object_builder.rs
@@ -159,6 +159,30 @@ fn define_setlongjmp_buffer(output: &mut Object) -> SymbolId {
     symbol_id
 }
 
+// needed to implement Crash when setjmp/longjmp is used
+fn define_panic_msg(output: &mut Object) -> SymbolId {
+    let bss_section = output.section_id(StandardSection::Data);
+
+    //  3 words for a RocStr
+    const SIZE: usize = 3 * core::mem::size_of::<u64>();
+
+    let symbol = Symbol {
+        name: b"panic_msg".to_vec(),
+        value: 0,
+        size: SIZE as u64,
+        kind: SymbolKind::Data,
+        scope: SymbolScope::Linkage,
+        weak: false,
+        section: SymbolSection::Section(bss_section),
+        flags: SymbolFlags::None,
+    };
+
+    let symbol_id = output.add_symbol(symbol);
+    output.add_symbol_data(symbol_id, bss_section, &[0x00; SIZE], 8);
+
+    symbol_id
+}
+
 fn generate_setjmp<'a, B: Backend<'a>>(backend: &mut B, output: &mut Object) {
     let text_section = output.section_id(StandardSection::Text);
     let proc_symbol = Symbol {
@@ -422,6 +446,7 @@ fn build_object<'a, B: Backend<'a>>(
     */
 
     if backend.env().mode.generate_roc_panic() {
+        define_panic_msg(&mut output);
         define_setlongjmp_buffer(&mut output);
 
         generate_roc_panic(&mut backend, &mut output);

--- a/crates/compiler/test_gen/src/gen_num.rs
+++ b/crates/compiler/test_gen/src/gen_num.rs
@@ -1989,7 +1989,7 @@ fn float_sub_checked() {
 }
 
 #[test]
-#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
+#[cfg(any(feature = "gen-llvm", feature = "gen-dev", feature = "gen-wasm"))]
 #[should_panic(expected = r#"Roc failed with message: "Integer multiplication overflowed!"#)]
 fn int_positive_mul_overflow() {
     assert_evals_to!(


### PR DESCRIPTION
fix #6334 

this is the proper fix. it makes decimals use `mulWithOverflow` and panics on overflow. This surfaced a bug in the dev backend where it used a by-value rocstr instead of a by-pointer one. This is now fixed. That should mean many more tests work for gen_num, if the dev backend uses the panicking variant of the operation (it often does not though, but we can change that now).