### PR TITLE
Completion of Modules and imports 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2699,6 +2699,7 @@ dependencies = [
  "bumpalo",
  "env_logger 0.10.2",
  "expect-test",
+ "futures",
  "indoc",
  "log",
  "parking_lot",

--- a/crates/compiler/fmt/src/pattern.rs
+++ b/crates/compiler/fmt/src/pattern.rs
@@ -42,7 +42,8 @@ impl<'a> Formattable for Pattern<'a> {
         // Theory: a pattern should only be multiline when it contains a comment
         match self {
             Pattern::SpaceBefore(_, spaces) | Pattern::SpaceAfter(_, spaces) => {
-                debug_assert!(!spaces.is_empty());
+                //TODO: This isn't always true, should it be?
+                // debug_assert!(!spaces.is_empty());
 
                 spaces.iter().any(|s| s.is_comment())
             }

--- a/crates/compiler/fmt/src/pattern.rs
+++ b/crates/compiler/fmt/src/pattern.rs
@@ -41,8 +41,12 @@ impl<'a> Formattable for Pattern<'a> {
     fn is_multiline(&self) -> bool {
         // Theory: a pattern should only be multiline when it contains a comment
         match self {
-            Pattern::SpaceBefore(a, spaces) | Pattern::SpaceAfter(a, spaces) => {
-                debug_assert!(!spaces.is_empty(), "spaces is empty in pattern {:#?}", a);
+            Pattern::SpaceBefore(pattern, spaces) | Pattern::SpaceAfter(pattern, spaces) => {
+                debug_assert!(
+                    !spaces.is_empty(),
+                    "spaces is empty in pattern {:#?}",
+                    pattern
+                );
 
                 spaces.iter().any(|s| s.is_comment())
             }

--- a/crates/compiler/fmt/src/pattern.rs
+++ b/crates/compiler/fmt/src/pattern.rs
@@ -41,9 +41,8 @@ impl<'a> Formattable for Pattern<'a> {
     fn is_multiline(&self) -> bool {
         // Theory: a pattern should only be multiline when it contains a comment
         match self {
-            Pattern::SpaceBefore(_, spaces) | Pattern::SpaceAfter(_, spaces) => {
-                //TODO: This isn't always true, should it be?
-                // debug_assert!(!spaces.is_empty());
+            Pattern::SpaceBefore(a, spaces) | Pattern::SpaceAfter(a, spaces) => {
+                debug_assert!(!spaces.is_empty(), "spaces is empty in pattern {:#?}", a);
 
                 spaces.iter().any(|s| s.is_comment())
             }

--- a/crates/compiler/load_internal/src/file.rs
+++ b/crates/compiler/load_internal/src/file.rs
@@ -2537,6 +2537,14 @@ fn update<'a>(
             }
 
             report_unused_imported_modules(&mut state, module_id, &constrained_module);
+            state
+                .module_cache
+                .imported_modules
+                .insert(module_id, constrained_module.imported_modules.clone());
+            state
+                .module_cache
+                .exposed_imports
+                .insert(module_id, constrained_module.module.exposed_imports.clone());
 
             state
                 .module_cache
@@ -2583,6 +2591,10 @@ fn update<'a>(
                 .module_cache
                 .type_problems
                 .insert(module_id, solved_module.problems);
+            state
+                .module_cache
+                .exposes
+                .insert(module_id, solved_module.exposed_vars_by_symbol.clone());
 
             let should_include_expects = (!loc_expects.is_empty() || !loc_dbgs.is_empty()) && {
                 let modules = state.arc_modules.lock();
@@ -2737,6 +2749,7 @@ fn update<'a>(
                     state.module_cache.checked.insert(
                         module_id,
                         CheckedModule {
+                            aliases: solved_module.aliases,
                             solved_subs,
                             decls,
                             abilities_store,
@@ -3400,6 +3413,10 @@ fn finish(
         timings: state.timings,
         docs_by_module,
         abilities_store,
+        imported_modules: state.module_cache.imported_modules,
+        exposed_imports: state.module_cache.exposed_imports,
+        imports: state.module_cache.imports,
+        exposes: state.module_cache.exposes,
     }
 }
 

--- a/crates/compiler/load_internal/src/file.rs
+++ b/crates/compiler/load_internal/src/file.rs
@@ -2539,10 +2539,6 @@ fn update<'a>(
             report_unused_imported_modules(&mut state, module_id, &constrained_module);
             state
                 .module_cache
-                .imported_modules
-                .insert(module_id, constrained_module.imported_modules.clone());
-            state
-                .module_cache
                 .exposed_imports
                 .insert(module_id, constrained_module.module.exposed_imports.clone());
 
@@ -3413,7 +3409,6 @@ fn finish(
         timings: state.timings,
         docs_by_module,
         abilities_store,
-        imported_modules: state.module_cache.imported_modules,
         exposed_imports: state.module_cache.exposed_imports,
         imports: state.module_cache.imports,
         exposes: state.module_cache.exposes,

--- a/crates/compiler/load_internal/src/file.rs
+++ b/crates/compiler/load_internal/src/file.rs
@@ -2745,7 +2745,6 @@ fn update<'a>(
                     state.module_cache.checked.insert(
                         module_id,
                         CheckedModule {
-                            aliases: solved_module.aliases,
                             solved_subs,
                             decls,
                             abilities_store,

--- a/crates/compiler/load_internal/src/module.rs
+++ b/crates/compiler/load_internal/src/module.rs
@@ -136,10 +136,6 @@ pub struct TypeCheckedModule<'a> {
 
 #[derive(Debug)]
 pub struct CheckedModule {
-    /// all aliases and their definitions. this has to include non-exposed aliases
-    /// because exposed aliases can depend on non-exposed ones)
-    pub aliases: MutMap<Symbol, (bool, Alias)>,
-
     pub solved_subs: Solved<Subs>,
     pub decls: Declarations,
     pub abilities_store: AbilitiesStore,

--- a/crates/compiler/load_internal/src/module.rs
+++ b/crates/compiler/load_internal/src/module.rs
@@ -48,7 +48,6 @@ pub struct LoadedModule {
     pub typechecked: MutMap<ModuleId, CheckedModule>,
 
     pub imports: MutMap<ModuleId, MutSet<ModuleId>>,
-    pub imported_modules: MutMap<ModuleId, MutMap<ModuleId, Region>>,
     pub exposed_imports: MutMap<ModuleId, MutMap<Symbol, Region>>,
     pub exposes: MutMap<ModuleId, Vec<(Symbol, Variable)>>,
 }

--- a/crates/compiler/load_internal/src/module.rs
+++ b/crates/compiler/load_internal/src/module.rs
@@ -46,6 +46,11 @@ pub struct LoadedModule {
     pub docs_by_module: Vec<(ModuleId, ModuleDocumentation)>,
     pub abilities_store: AbilitiesStore,
     pub typechecked: MutMap<ModuleId, CheckedModule>,
+
+    pub imports: MutMap<ModuleId, MutSet<ModuleId>>,
+    pub imported_modules: MutMap<ModuleId, MutMap<ModuleId, Region>>,
+    pub exposed_imports: MutMap<ModuleId, MutMap<Symbol, Region>>,
+    pub exposes: MutMap<ModuleId, Vec<(Symbol, Variable)>>,
 }
 
 impl LoadedModule {
@@ -132,6 +137,10 @@ pub struct TypeCheckedModule<'a> {
 
 #[derive(Debug)]
 pub struct CheckedModule {
+    /// all aliases and their definitions. this has to include non-exposed aliases
+    /// because exposed aliases can depend on non-exposed ones)
+    pub aliases: MutMap<Symbol, (bool, Alias)>,
+
     pub solved_subs: Solved<Subs>,
     pub decls: Declarations,
     pub abilities_store: AbilitiesStore,

--- a/crates/compiler/load_internal/src/module_cache.rs
+++ b/crates/compiler/load_internal/src/module_cache.rs
@@ -36,7 +36,6 @@ pub(crate) struct ModuleCache<'a> {
     /// Various information
     pub(crate) imports: MutMap<ModuleId, MutSet<ModuleId>>,
     pub(crate) exposes: MutMap<ModuleId, Vec<(Symbol, Variable)>>,
-    pub(crate) imported_modules: MutMap<ModuleId, MutMap<ModuleId, Region>>,
     pub(crate) exposed_imports: MutMap<ModuleId, MutMap<Symbol, Region>>,
     pub(crate) top_level_thunks: MutMap<ModuleId, MutSet<Symbol>>,
     pub(crate) documentation: VecMap<ModuleId, ModuleDocumentation>,
@@ -108,7 +107,6 @@ impl Default for ModuleCache<'_> {
             late_specializations: Default::default(),
             external_specializations_requested: Default::default(),
             imports: Default::default(),
-            imported_modules: Default::default(),
             exposed_imports: Default::default(),
             exposes: Default::default(),
             top_level_thunks: Default::default(),

--- a/crates/compiler/load_internal/src/module_cache.rs
+++ b/crates/compiler/load_internal/src/module_cache.rs
@@ -9,7 +9,9 @@ use roc_module::ident::ModuleName;
 use roc_module::symbol::{ModuleId, PQModuleName, Symbol};
 use roc_mono::ir::ExternalSpecializations;
 use roc_problem::Severity;
+use roc_region::all::Region;
 use roc_solve_problem::TypeError;
+use roc_types::subs::Variable;
 use roc_types::types::Alias;
 use std::path::PathBuf;
 
@@ -33,6 +35,9 @@ pub(crate) struct ModuleCache<'a> {
 
     /// Various information
     pub(crate) imports: MutMap<ModuleId, MutSet<ModuleId>>,
+    pub(crate) exposes: MutMap<ModuleId, Vec<(Symbol, Variable)>>,
+    pub(crate) imported_modules: MutMap<ModuleId, MutMap<ModuleId, Region>>,
+    pub(crate) exposed_imports: MutMap<ModuleId, MutMap<Symbol, Region>>,
     pub(crate) top_level_thunks: MutMap<ModuleId, MutSet<Symbol>>,
     pub(crate) documentation: VecMap<ModuleId, ModuleDocumentation>,
     pub(crate) can_problems: MutMap<ModuleId, Vec<roc_problem::can::Problem>>,
@@ -103,6 +108,9 @@ impl Default for ModuleCache<'_> {
             late_specializations: Default::default(),
             external_specializations_requested: Default::default(),
             imports: Default::default(),
+            imported_modules: Default::default(),
+            exposed_imports: Default::default(),
+            exposes: Default::default(),
             top_level_thunks: Default::default(),
             documentation: Default::default(),
             can_problems: Default::default(),

--- a/crates/lang_srv/Cargo.toml
+++ b/crates/lang_srv/Cargo.toml
@@ -34,3 +34,4 @@ tokio = { version = "1.20.1", features = [ "rt", "rt-multi-thread", "macros", "i
 log.workspace = true
 indoc.workspace=true
 env_logger = "0.10.1"
+futures.workspace = true

--- a/crates/lang_srv/src/analysis.rs
+++ b/crates/lang_srv/src/analysis.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use bumpalo::Bump;
-use log::debug;
+use log::{debug, trace};
 use parking_lot::Mutex;
 use roc_can::{abilities::AbilitiesStore, expr::Declarations};
 use roc_collections::{MutMap, MutSet};
@@ -160,12 +160,12 @@ pub(crate) fn global_analysis(doc_info: DocInfo) -> Vec<AnalyzedDocument> {
         all_subs,
         exposed,
     };
-    debug!("docs: {:#?}", docs_by_module);
+    trace!("docs: {:#?}", docs_by_module);
 
     for (module_id, (path, source)) in sources {
         let doc = builder.build_document(path, source, module_id, doc_info.version);
-        debug!("================");
-        debug!("module:{:?}", module_id);
+        trace!("================");
+        trace!("module:{:?}", module_id);
 
         // let exposed_imp = exposed_imports.get(&module_id)?;
         if let Some(modu) = &doc.analysis_result.module {
@@ -175,10 +175,10 @@ pub(crate) fn global_analysis(doc_info: DocInfo) -> Vec<AnalyzedDocument> {
 
             // debug!("exposed_imports:{:#?}", exposed_imp);
             // debug!("exposed:{:#?}", );
-            debug!("imports:{:#?}", imports);
+            trace!("imports:{:#?}", imports);
 
             // debug!("docs:{:#?}", docs.1.entries);
-            debug!("alais:{:#?}", aliases);
+            trace!("alais:{:#?}", aliases);
             // debug!("decls:{:#?}", module.declarations)
         }
         documents.push(doc);

--- a/crates/lang_srv/src/analysis.rs
+++ b/crates/lang_srv/src/analysis.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{HashMap},
     path::{Path, PathBuf},
     sync::Arc,
 };
@@ -12,7 +12,7 @@ use roc_collections::{MutMap, MutSet};
 use roc_load::{CheckedModule, LoadedModule};
 use roc_module::symbol::{Interns, ModuleId, Symbol};
 use roc_packaging::cache::{self, RocCacheDir};
-use roc_region::all::{LineInfo, Region};
+use roc_region::all::{LineInfo};
 use roc_reporting::report::RocDocAllocator;
 use roc_solve_problem::TypeError;
 use roc_types::{
@@ -106,11 +106,11 @@ pub(crate) fn global_analysis(doc_info: DocInfo) -> Vec<AnalyzedDocument> {
         solved,
         abilities_store,
         docs_by_module,
-        imported_modules,
+        
         exposed_imports,
         mut imports,
-        exposed_types_storage,
-        mut exposes,
+        
+        exposes,
         ..
     } = module;
 

--- a/crates/lang_srv/src/analysis.rs
+++ b/crates/lang_srv/src/analysis.rs
@@ -105,7 +105,7 @@ pub(crate) fn global_analysis(doc_info: DocInfo) -> Vec<AnalyzedDocument> {
         abilities_store,
         docs_by_module,
         imported_modules,
-        mut exposed_imports,
+        exposed_imports,
         mut imports,
         exposed_types_storage,
         mut exposes,
@@ -116,6 +116,7 @@ pub(crate) fn global_analysis(doc_info: DocInfo) -> Vec<AnalyzedDocument> {
         subs: solved.into_inner(),
         abilities_store,
     });
+    debug!("exposed_imports: {:#?}", &exposed_imports);
     let exposed_imports: HashMap<_, _> = exposed_imports
         .into_iter()
         .map(|(id, symbols)| {
@@ -124,7 +125,10 @@ pub(crate) fn global_analysis(doc_info: DocInfo) -> Vec<AnalyzedDocument> {
                 symbols
                     .into_iter()
                     .filter_map(|(symbol, _)| {
-                        exposes.get(&id)?.iter().find(|(symb, _)| symb == &symbol)
+                        exposes.get(&id)?.iter().find(|(symb, _)| {
+                            //TODO this seems to not be comparing proprely so we aren't getting any exposed imports
+                            symb == &symbol
+                        })
                     })
                     .cloned()
                     .collect::<Vec<_>>(),

--- a/crates/lang_srv/src/analysis.rs
+++ b/crates/lang_srv/src/analysis.rs
@@ -33,7 +33,7 @@ use self::{analysed_doc::ModuleIdToUrl, tokens::Token};
 
 pub const HIGHLIGHT_TOKENS_LEGEND: &[SemanticTokenType] = Token::LEGEND;
 
-///Contains maps of info about all modules that were analyved
+///Contains maps of info about all modules that were analyzed
 #[derive(Debug)]
 pub(super) struct ModulesInfo {
     subs: Mutex<HashMap<ModuleId, Subs>>,

--- a/crates/lang_srv/src/analysis.rs
+++ b/crates/lang_srv/src/analysis.rs
@@ -15,10 +15,7 @@ use roc_packaging::cache::{self, RocCacheDir};
 use roc_region::all::LineInfo;
 use roc_reporting::report::RocDocAllocator;
 use roc_solve_problem::TypeError;
-use roc_types::{
-    subs::{Subs, Variable},
-    types::Alias,
-};
+use roc_types::subs::{Subs, Variable};
 
 use tower_lsp::lsp_types::{Diagnostic, SemanticTokenType, Url};
 
@@ -48,7 +45,6 @@ pub(super) struct AnalyzedModule {
     exposed_imports: Vec<(Symbol, Variable)>,
     ///This modules imports grouped by which module they come from
     imports: HashMap<ModuleId, Arc<Vec<(Symbol, Variable)>>>,
-    _aliases: MutMap<Symbol, (bool, Alias)>,
     module_id: ModuleId,
     interns: Interns,
     subs: Subs,
@@ -261,7 +257,6 @@ impl<'a> AnalyzedDocumentBuilder<'a> {
         let subs;
         let abilities;
         let declarations;
-        let aliases;
 
         //lookup the type info for each import from the module where it was exposed
         let imports = self
@@ -286,19 +281,16 @@ impl<'a> AnalyzedDocumentBuilder<'a> {
             subs = m.solved_subs.into_inner();
             abilities = m.abilities_store;
             declarations = m.decls;
-            aliases = m.aliases;
         } else {
             let rm = self.root_module.take().unwrap();
             subs = rm.subs;
             abilities = rm.abilities_store;
             declarations = self.declarations_by_id.remove(&module_id).unwrap();
-            aliases = HashMap::default();
         }
 
         let analyzed_module = AnalyzedModule {
             exposed_imports,
             imports,
-            _aliases: aliases,
             subs,
             abilities,
             declarations,

--- a/crates/lang_srv/src/analysis.rs
+++ b/crates/lang_srv/src/analysis.rs
@@ -270,22 +270,8 @@ impl<'a> AnalyzedDocumentBuilder<'a> {
         let declarations;
 
         //lookup the type info for each import from the module where it was exposed
-        let imports = self
-            .imports
-            .remove(&module_id)
-            .unwrap_or_default()
-            .into_iter()
-            .map(|id| {
-                (
-                    id,
-                    self.modules_info
-                        .exposed
-                        .get(&id)
-                        .unwrap_or(&Arc::new(vec![]))
-                        .clone(),
-                )
-            })
-            .collect::<HashMap<_, _>>();
+        let this_imports = self.imports.remove(&module_id).unwrap_or_default();
+        let imports = self.get_symbols_for_imports(this_imports);
 
         let exposed_imports = self.exposed_imports.remove(&module_id).unwrap_or_default();
 
@@ -327,6 +313,27 @@ impl<'a> AnalyzedDocumentBuilder<'a> {
                 diagnostics,
             },
         }
+    }
+
+    ///Gets the exposed symbols, and type info for each imported module
+    fn get_symbols_for_imports(
+        &mut self,
+        imports: MutSet<ModuleId>,
+    ) -> HashMap<ModuleId, Arc<Vec<(Symbol, Variable)>>> {
+        let imports = imports
+            .into_iter()
+            .map(|id| {
+                (
+                    id,
+                    self.modules_info
+                        .exposed
+                        .get(&id)
+                        .unwrap_or(&Arc::new(vec![]))
+                        .clone(),
+                )
+            })
+            .collect::<HashMap<_, _>>();
+        imports
     }
 
     fn build_diagnostics(

--- a/crates/lang_srv/src/analysis.rs
+++ b/crates/lang_srv/src/analysis.rs
@@ -163,7 +163,7 @@ fn resolve_exposed_imports(
                     .into_iter()
                     .filter_map(|(symbol, _)| {
                         exposes.get(&module_id)?.iter().find(|(symb, _)| {
-                            //TODO this seems to not be comparing proprely so we aren't getting any exposed imports
+                            //TODO this seems to not be comparing properly so we aren't getting any exposed imports
                             symb == &symbol
                         })
                     })
@@ -179,7 +179,7 @@ fn make_modules_info(
     typechecked: &MutMap<ModuleId, CheckedModule>,
 ) -> ModulesInfo {
     //We wrap this in arc because later we will go through each module's imports and store the full list of symbols that each imported module exposes.
-    //eg: A imports B. B exposes [add, mutiply, divide] and A will store a reference to that list.
+    //eg: A imports B. B exposes [add, multiply, divide] and A will store a reference to that list.
     let exposed = exposes
         .into_iter()
         .map(|(id, symbols)| (id, Arc::new(symbols)))

--- a/crates/lang_srv/src/analysis.rs
+++ b/crates/lang_srv/src/analysis.rs
@@ -320,7 +320,7 @@ impl<'a> AnalyzedDocumentBuilder<'a> {
         &mut self,
         imports: MutSet<ModuleId>,
     ) -> HashMap<ModuleId, Arc<Vec<(Symbol, Variable)>>> {
-        let imports = imports
+        imports
             .into_iter()
             .map(|id| {
                 (
@@ -332,8 +332,7 @@ impl<'a> AnalyzedDocumentBuilder<'a> {
                         .clone(),
                 )
             })
-            .collect::<HashMap<_, _>>();
-        imports
+            .collect::<HashMap<_, _>>()
     }
 
     fn build_diagnostics(

--- a/crates/lang_srv/src/analysis/analysed_doc.rs
+++ b/crates/lang_srv/src/analysis/analysed_doc.rs
@@ -242,7 +242,6 @@ impl AnalyzedDocument {
                 .unwrap_or(false);
             if is_module_completion {
                 info!("Getting module dot completion");
-                //TODO: this doesn't work with builtins for some reason
                 Some(get_upper_case_completion_items(
                     symbol_prefix,
                     interns,

--- a/crates/lang_srv/src/analysis/analysed_doc.rs
+++ b/crates/lang_srv/src/analysis/analysed_doc.rs
@@ -226,10 +226,8 @@ impl AnalyzedDocument {
             subs,
             declarations,
             exposed_imports,
-
             imports,
-            other_modules_subs,
-            modules_exposed,
+            modules_info,
             ..
         } = self.module()?;
 
@@ -249,8 +247,7 @@ impl AnalyzedDocument {
                     symbol_prefix,
                     interns,
                     imports,
-                    other_modules_subs,
-                    modules_exposed,
+                    modules_info,
                     true,
                 ))
             } else {
@@ -275,8 +272,7 @@ impl AnalyzedDocument {
                     symbol_prefix,
                     interns,
                     imports,
-                    other_modules_subs,
-                    modules_exposed,
+                    modules_info,
                     true,
                 );
                 Some(completions)

--- a/crates/lang_srv/src/analysis/analysed_doc.rs
+++ b/crates/lang_srv/src/analysis/analysed_doc.rs
@@ -1,4 +1,4 @@
-use log::debug;
+use log::{debug, info};
 use std::collections::HashMap;
 
 use bumpalo::Bump;
@@ -228,6 +228,7 @@ impl AnalyzedDocument {
             exposed_imports,
             aliases,
             imports,
+            other_subs,
             ..
         } = self.module()?;
 
@@ -241,6 +242,7 @@ impl AnalyzedDocument {
                 .map(|a| a.chars().nth(0).unwrap().is_uppercase())
                 .unwrap_or(false);
             if is_module_completion {
+                info!("Getting module dot completion");
                 //TODO: this doesn't work with builtins for some reason
                 Some(get_upper_case_completion_items(
                     position,
@@ -250,9 +252,11 @@ impl AnalyzedDocument {
                     &mut subs.clone(),
                     imports,
                     aliases,
+                    other_subs,
                     true,
                 ))
             } else {
+                info!("Getting record dot completion");
                 field_completion(
                     position,
                     symbol_prefix,
@@ -265,6 +269,7 @@ impl AnalyzedDocument {
         } else {
             let is_module_or_type_completion = symbol_prefix.chars().nth(0).unwrap().is_uppercase();
             if is_module_or_type_completion {
+                info!("Getting module completion");
                 let completions = get_upper_case_completion_items(
                     position,
                     symbol_prefix,
@@ -273,10 +278,12 @@ impl AnalyzedDocument {
                     &mut subs.clone(),
                     imports,
                     aliases,
+                    other_subs,
                     false,
                 );
                 Some(completions)
             } else {
+                info!("Getting variable completion");
                 let completions = get_completion_items(
                     position,
                     symbol_prefix,

--- a/crates/lang_srv/src/analysis/analysed_doc.rs
+++ b/crates/lang_srv/src/analysis/analysed_doc.rs
@@ -235,11 +235,11 @@ impl AnalyzedDocument {
         let is_field_or_module_completion = symbol_prefix.contains('.');
 
         if is_field_or_module_completion {
-            //if the second last second is capitalised we know we are completing a module of an import of a module
+            //if the second last section is capitalised we know we are completing a module of an import of a module eg: My.Module.function
             let is_module_completion = symbol_prefix
                 .split('.')
                 .nth_back(1)
-                .map(|a| a.chars().nth(0).unwrap().is_uppercase())
+                .and_then(|a| a.chars().nth(0).map(|c| c.is_uppercase()))
                 .unwrap_or(false);
             if is_module_completion {
                 info!("Getting module dot completion");
@@ -267,7 +267,10 @@ impl AnalyzedDocument {
                 )
             }
         } else {
-            let is_module_or_type_completion = symbol_prefix.chars().nth(0).unwrap().is_uppercase();
+            let is_module_or_type_completion = symbol_prefix
+                .chars()
+                .nth(0)
+                .map_or(false, |c| c.is_uppercase());
             if is_module_or_type_completion {
                 info!("Getting module completion");
                 let completions = get_upper_case_completion_items(

--- a/crates/lang_srv/src/analysis/analysed_doc.rs
+++ b/crates/lang_srv/src/analysis/analysed_doc.rs
@@ -247,7 +247,6 @@ impl AnalyzedDocument {
                 //TODO: this doesn't work with builtins for some reason
                 Some(get_upper_case_completion_items(
                     symbol_prefix,
-                    module_id,
                     interns,
                     imports,
                     other_modules_subs,
@@ -274,7 +273,6 @@ impl AnalyzedDocument {
                 info!("Getting module completion");
                 let completions = get_upper_case_completion_items(
                     symbol_prefix,
-                    module_id,
                     interns,
                     imports,
                     other_modules_subs,

--- a/crates/lang_srv/src/analysis/analysed_doc.rs
+++ b/crates/lang_srv/src/analysis/analysed_doc.rs
@@ -13,9 +13,7 @@ use tower_lsp::lsp_types::{
 };
 
 use crate::{
-    analysis::completion::{
-        field_completion, get_completion_items, get_upper_case_completion_items,
-    },
+    analysis::completion::{field_completion, get_completion_items, get_module_completion_items},
     convert::{ToRange, ToRocPosition},
 };
 
@@ -242,7 +240,7 @@ impl AnalyzedDocument {
                 .unwrap_or(false);
             if is_module_completion {
                 info!("Getting module dot completion");
-                Some(get_upper_case_completion_items(
+                Some(get_module_completion_items(
                     symbol_prefix,
                     interns,
                     imports,
@@ -267,7 +265,7 @@ impl AnalyzedDocument {
                 .map_or(false, |c| c.is_uppercase());
             if is_module_or_type_completion {
                 info!("Getting module completion");
-                let completions = get_upper_case_completion_items(
+                let completions = get_module_completion_items(
                     symbol_prefix,
                     interns,
                     imports,

--- a/crates/lang_srv/src/analysis/analysed_doc.rs
+++ b/crates/lang_srv/src/analysis/analysed_doc.rs
@@ -232,14 +232,16 @@ impl AnalyzedDocument {
         let is_field_or_module_completion = symbol_prefix.contains('.');
 
         if is_field_or_module_completion {
-            //if the second last section is capitalised we know we are completing a module of an import of a module eg: My.Module.function
+            // If the second to last section is capitalised we know we are completing a
+            // module inside an import of a module, e.g.: My.Module.function
             let is_module_completion = symbol_prefix
                 .split('.')
-                .nth_back(1)
-                .and_then(|a| a.chars().nth(0).map(|c| c.is_uppercase()))
+                .nth_back(1) // second to last
+                .and_then(|str| str.chars().nth(0).map(|c| c.is_uppercase()))
                 .unwrap_or(false);
+
             if is_module_completion {
-                info!("Getting module dot completion");
+                info!("Getting module dot completion...");
                 Some(get_module_completion_items(
                     symbol_prefix,
                     interns,
@@ -248,7 +250,7 @@ impl AnalyzedDocument {
                     true,
                 ))
             } else {
-                info!("Getting record dot completion");
+                info!("Getting record dot completion...");
                 field_completion(
                     position,
                     symbol_prefix,
@@ -263,8 +265,9 @@ impl AnalyzedDocument {
                 .chars()
                 .nth(0)
                 .map_or(false, |c| c.is_uppercase());
+
             if is_module_or_type_completion {
-                info!("Getting module completion");
+                info!("Getting module completion...");
                 let completions = get_module_completion_items(
                     symbol_prefix,
                     interns,
@@ -274,7 +277,7 @@ impl AnalyzedDocument {
                 );
                 Some(completions)
             } else {
-                info!("Getting variable completion");
+                info!("Getting variable completion...");
                 let completions = get_completion_items(
                     position,
                     symbol_prefix,

--- a/crates/lang_srv/src/analysis/analysed_doc.rs
+++ b/crates/lang_srv/src/analysis/analysed_doc.rs
@@ -241,6 +241,7 @@ impl AnalyzedDocument {
                 .map(|a| a.chars().nth(0).unwrap().is_uppercase())
                 .unwrap_or(false);
             if is_module_completion {
+                //TODO: this doesn't work with builtins for some reason
                 Some(get_upper_case_completion_items(
                     position,
                     symbol_prefix,
@@ -283,6 +284,7 @@ impl AnalyzedDocument {
                     &mut subs.clone(),
                     module_id,
                     interns,
+                    exposed_imports,
                 );
                 Some(completions)
             }

--- a/crates/lang_srv/src/analysis/analysed_doc.rs
+++ b/crates/lang_srv/src/analysis/analysed_doc.rs
@@ -226,9 +226,10 @@ impl AnalyzedDocument {
             subs,
             declarations,
             exposed_imports,
-            aliases,
+
             imports,
             other_modules_subs,
+            modules_exposed,
             ..
         } = self.module()?;
 
@@ -250,6 +251,7 @@ impl AnalyzedDocument {
                     interns,
                     imports,
                     other_modules_subs,
+                    modules_exposed,
                     true,
                 ))
             } else {
@@ -276,6 +278,7 @@ impl AnalyzedDocument {
                     interns,
                     imports,
                     other_modules_subs,
+                    modules_exposed,
                     true,
                 );
                 Some(completions)

--- a/crates/lang_srv/src/analysis/analysed_doc.rs
+++ b/crates/lang_srv/src/analysis/analysed_doc.rs
@@ -282,7 +282,7 @@ impl AnalyzedDocument {
                     imports,
                     aliases,
                     other_subs,
-                    false,
+                    true,
                 );
                 Some(completions)
             } else {

--- a/crates/lang_srv/src/analysis/analysed_doc.rs
+++ b/crates/lang_srv/src/analysis/analysed_doc.rs
@@ -228,7 +228,7 @@ impl AnalyzedDocument {
             exposed_imports,
             aliases,
             imports,
-            other_subs,
+            other_modules_subs,
             ..
         } = self.module()?;
 
@@ -245,14 +245,11 @@ impl AnalyzedDocument {
                 info!("Getting module dot completion");
                 //TODO: this doesn't work with builtins for some reason
                 Some(get_upper_case_completion_items(
-                    position,
                     symbol_prefix,
                     module_id,
                     interns,
-                    &mut subs.clone(),
                     imports,
-                    aliases,
-                    other_subs,
+                    other_modules_subs,
                     true,
                 ))
             } else {
@@ -260,10 +257,10 @@ impl AnalyzedDocument {
                 field_completion(
                     position,
                     symbol_prefix,
-                    &declarations,
-                    &interns,
+                    declarations,
+                    interns,
                     &mut subs.clone(),
-                    &module_id,
+                    module_id,
                 )
             }
         } else {
@@ -274,14 +271,11 @@ impl AnalyzedDocument {
             if is_module_or_type_completion {
                 info!("Getting module completion");
                 let completions = get_upper_case_completion_items(
-                    position,
                     symbol_prefix,
                     module_id,
                     interns,
-                    &mut subs.clone(),
                     imports,
-                    aliases,
-                    other_subs,
+                    other_modules_subs,
                     true,
                 );
                 Some(completions)

--- a/crates/lang_srv/src/analysis/completion.rs
+++ b/crates/lang_srv/src/analysis/completion.rs
@@ -308,8 +308,11 @@ pub fn get_completion_items(
     subs: &mut Subs,
     module_id: &ModuleId,
     interns: &Interns,
+    exposed_imports: &Vec<(Symbol, Variable)>,
 ) -> Vec<CompletionItem> {
-    let completions = get_completions(position, decls, prefix, interns);
+    let mut completions = get_completions(position, decls, prefix, interns);
+    completions.extend(exposed_imports);
+    debug!("extended with:{:#?}", exposed_imports);
     make_completion_items(
         subs,
         module_id,
@@ -340,15 +343,16 @@ pub fn get_upper_case_completion_items(
                 format!("`{0}` module", mod_name),
             )]
         } else if prefix.starts_with(&mod_name) {
-            make_completion_items(
-                subs,
-                module_id,
-                interns,
-                vars.clone()
-                    .iter()
-                    .map(|(sym, vars)| (sym.as_str(interns).to_string(), vars.clone()))
-                    .collect::<Vec<_>>(),
-            )
+            vars.clone()
+                .iter()
+                .map(|(sym, vars)| {
+                    CompletionItem::new_simple(
+                        sym.as_str(interns).to_string(),
+                        //TODO! I need to get subs from the module we are completing from
+                        "builtin".to_string(),
+                    )
+                })
+                .collect::<Vec<_>>()
         } else {
             vec![]
         }

--- a/crates/lang_srv/src/analysis/completion.rs
+++ b/crates/lang_srv/src/analysis/completion.rs
@@ -298,7 +298,10 @@ fn make_completion_item(
         ..Default::default()
     }
 }
-/// Walks through declarations that would be accessible from the provided position adding them to a list of completion items until all accessible declarations have been fully explored
+
+/// Walks through declarations that would be accessible from the provided
+/// position, adding them to a list of completion items until all accessible
+/// declarations have been fully explored.
 pub fn get_completion_items(
     position: Position,
     prefix: String,
@@ -310,7 +313,9 @@ pub fn get_completion_items(
 ) -> Vec<CompletionItem> {
     let mut completions = get_completions(position, decls, prefix, interns);
     completions.extend(exposed_imports);
+
     debug!("extended with:{:#?}", exposed_imports);
+
     make_completion_items(
         subs,
         module_id,
@@ -321,6 +326,7 @@ pub fn get_completion_items(
             .collect(),
     )
 }
+
 pub(super) fn get_module_completion_items(
     prefix: String,
     interns: &Interns,
@@ -347,16 +353,19 @@ pub(super) fn get_module_completion_items(
                     ..Default::default()
                 };
                 vec![item]
-            //Complete dot completions
+
+            // Complete dot completions
             } else if prefix.starts_with(&(mod_name + ".")) {
                 get_module_exposed_completion(exposed_symbols, modules_info, mod_id, interns)
             } else {
                 vec![]
             }
         });
+
     if just_modules {
         return module_completions.collect();
     }
+
     module_completions.collect()
 }
 
@@ -369,7 +378,8 @@ fn get_module_exposed_completion(
     exposed_symbols
         .iter()
         .map(|(sym, var)| {
-            //We need to fetch the subs for the module that is exposing what we are trying to complete because that will have the type info we need
+            // We need to fetch the subs for the module that is exposing what we
+            // are trying to complete, because that will have the type info we need.
             modules_info
                 .with_subs(mod_id, |subs| {
                     make_completion_item(
@@ -385,8 +395,8 @@ fn get_module_exposed_completion(
         .collect::<Vec<_>>()
 }
 
-///Provides a list of completions for Type aliases within the scope.
-///TODO: Use this when we know we are within a type definition
+/// Provides a list of completions for Type aliases within the scope.
+/// TODO: Use this when we know we are within a type definition.
 fn _alias_completions(
     aliases: &MutMap<Symbol, (bool, Alias)>,
     module_id: &ModuleId,
@@ -397,9 +407,10 @@ fn _alias_completions(
         .filter(|(symbol, (_exposed, _alias))| &symbol.module_id() == module_id)
         .map(|(symbol, (_exposed, _alias))| {
             let name = symbol.as_str(interns).to_string();
+
             CompletionItem {
                 label: name.clone(),
-                detail: Some(name + "we don't know how to print types "),
+                detail: Some(name + " we don't know how to print types."),
                 kind: Some(CompletionItemKind::CLASS),
                 ..Default::default()
             }

--- a/crates/lang_srv/src/analysis/completion.rs
+++ b/crates/lang_srv/src/analysis/completion.rs
@@ -1,7 +1,4 @@
-use std::{
-    collections::{HashMap},
-    sync::Arc,
-};
+use std::{collections::HashMap, sync::Arc};
 
 use log::{debug, trace, warn};
 use parking_lot::Mutex;
@@ -11,7 +8,7 @@ use roc_can::{
     pattern::{ListPatterns, Pattern, RecordDestruct, TupleDestruct},
     traverse::{walk_decl, walk_def, walk_expr, DeclarationInfo, Visitor},
 };
-use roc_collections::{MutMap};
+use roc_collections::MutMap;
 use roc_module::symbol::{Interns, ModuleId, Symbol};
 use roc_region::all::{Loc, Position, Region};
 use roc_types::{
@@ -19,8 +16,6 @@ use roc_types::{
     types::Alias,
 };
 use tower_lsp::lsp_types::{CompletionItem, CompletionItemKind};
-
-
 
 use super::utils::format_var_type;
 
@@ -333,7 +328,7 @@ pub fn get_upper_case_completion_items(
     interns: &Interns,
     _subs: &mut Subs,
     imported_modules: &HashMap<ModuleId, Arc<Vec<(Symbol, Variable)>>>,
-    aliases: &MutMap<Symbol, (bool, Alias)>,
+    _aliases: &MutMap<Symbol, (bool, Alias)>,
     all_subs: &Mutex<HashMap<ModuleId, Subs>>,
     just_modules: bool,
 ) -> Vec<CompletionItem> {
@@ -368,17 +363,28 @@ pub fn get_upper_case_completion_items(
     if just_modules {
         return module_completions.collect();
     }
-    //TODO! use a proper completion type instead of simple
-    let aliases_completions = aliases
+
+    module_completions.collect()
+}
+
+//Provides a list of complteions for Type aliases within the scope.
+//TODO: Use this when we know we are within a type definition
+/*
+ fn alias_completions(
+    aliases: &MutMap<Symbol, (bool, Alias)>,
+    module_id: &ModuleId,
+    interns: &Interns,
+) -> Vec<CompletionItem> {
+    aliases
         .iter()
         .filter(|(symbol, (_exposed, _alias))| &symbol.module_id() == module_id)
         .map(|(symbol, (_exposed, _alias))| {
             let name = symbol.as_str(interns).to_string();
             CompletionItem::new_simple(name.clone(), name + "we don't know how to print types ")
-        });
-
-    module_completions.chain(aliases_completions).collect()
+        })
+        .collect()
 }
+*/
 fn make_completion_items(
     subs: &mut Subs,
     module_id: &ModuleId,

--- a/crates/lang_srv/src/analysis/completion.rs
+++ b/crates/lang_srv/src/analysis/completion.rs
@@ -349,7 +349,7 @@ pub(super) fn get_upper_case_completion_items(
             vars.clone()
                 .iter()
                 .map(|(sym, var)| {
-                    //TODO! I need to get subs from the module we are completing from
+                    //We need to fetch the subs for the module that is exposing what we are trying to complete because that will have the type info we need
                     modules_info
                         .subs
                         .lock()
@@ -377,8 +377,8 @@ pub(super) fn get_upper_case_completion_items(
     module_completions.collect()
 }
 
-//Provides a list of complteions for Type aliases within the scope.
-//TODO: Use this when we know we are within a type definition
+///Provides a list of completions for Type aliases within the scope.
+///TODO: Use this when we know we are within a type definition
 fn _alias_completions(
     aliases: &MutMap<Symbol, (bool, Alias)>,
     module_id: &ModuleId,

--- a/crates/lang_srv/src/analysis/completion.rs
+++ b/crates/lang_srv/src/analysis/completion.rs
@@ -306,7 +306,7 @@ pub fn get_completion_items(
     subs: &mut Subs,
     module_id: &ModuleId,
     interns: &Interns,
-    exposed_imports: &Vec<(Symbol, Variable)>,
+    exposed_imports: &[(Symbol, Variable)],
 ) -> Vec<CompletionItem> {
     let mut completions = get_completions(position, decls, prefix, interns);
     completions.extend(exposed_imports);
@@ -361,7 +361,7 @@ pub(super) fn get_module_completion_items(
 }
 
 fn get_module_exposed_completion(
-    exposed_symbols: &Vec<(Symbol, Variable)>,
+    exposed_symbols: &[(Symbol, Variable)],
     modules_info: &ModulesInfo,
     mod_id: &ModuleId,
     interns: &Interns,

--- a/crates/lang_srv/src/analysis/completion.rs
+++ b/crates/lang_srv/src/analysis/completion.rs
@@ -336,7 +336,7 @@ pub(super) fn get_upper_case_completion_items(
                 label: mod_name.clone(),
                 kind: Some(CompletionItemKind::MODULE),
                 documentation: Some(formatting::module_documentation(
-                    formatting::DescripitonType::Exposes,
+                    formatting::DescriptionsType::Exposes,
                     mod_id,
                     interns,
                     modules_info,

--- a/crates/lang_srv/src/analysis/completion.rs
+++ b/crates/lang_srv/src/analysis/completion.rs
@@ -326,7 +326,6 @@ pub fn get_completion_items(
 }
 pub fn get_upper_case_completion_items(
     prefix: String,
-    module_id: &ModuleId,
     interns: &Interns,
     imported_modules: &HashMap<ModuleId, Arc<Vec<(Symbol, Variable)>>>,
     all_subs: &Mutex<HashMap<ModuleId, Subs>>,

--- a/crates/lang_srv/src/analysis/completion.rs
+++ b/crates/lang_srv/src/analysis/completion.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{HashMap},
     sync::Arc,
 };
 
@@ -11,8 +11,8 @@ use roc_can::{
     pattern::{ListPatterns, Pattern, RecordDestruct, TupleDestruct},
     traverse::{walk_decl, walk_def, walk_expr, DeclarationInfo, Visitor},
 };
-use roc_collections::{MutMap, MutSet};
-use roc_module::symbol::{self, Interns, ModuleId, Symbol};
+use roc_collections::{MutMap};
+use roc_module::symbol::{Interns, ModuleId, Symbol};
 use roc_region::all::{Loc, Position, Region};
 use roc_types::{
     subs::{Subs, Variable},
@@ -20,7 +20,7 @@ use roc_types::{
 };
 use tower_lsp::lsp_types::{CompletionItem, CompletionItemKind};
 
-use crate::registry::Registry;
+
 
 use super::utils::format_var_type;
 
@@ -327,11 +327,11 @@ pub fn get_completion_items(
     )
 }
 pub fn get_upper_case_completion_items(
-    position: Position,
+    _position: Position,
     prefix: String,
     module_id: &ModuleId,
     interns: &Interns,
-    subs: &mut Subs,
+    _subs: &mut Subs,
     imported_modules: &HashMap<ModuleId, Arc<Vec<(Symbol, Variable)>>>,
     aliases: &MutMap<Symbol, (bool, Alias)>,
     all_subs: &Mutex<HashMap<ModuleId, Subs>>,
@@ -365,14 +365,14 @@ pub fn get_upper_case_completion_items(
             vec![]
         }
     });
-    if (just_modules) {
+    if just_modules {
         return module_completions.collect();
     }
     //TODO! use a proper completion type instead of simple
     let aliases_completions = aliases
         .iter()
-        .filter(|(symbol, (exposed, alias))| &symbol.module_id() == module_id)
-        .map(|(symbol, (exposed, alias))| {
+        .filter(|(symbol, (_exposed, _alias))| &symbol.module_id() == module_id)
+        .map(|(symbol, (_exposed, _alias))| {
             let name = symbol.as_str(interns).to_string();
             CompletionItem::new_simple(name.clone(), name + "we don't know how to print types ")
         });

--- a/crates/lang_srv/src/analysis/completion/formatting.rs
+++ b/crates/lang_srv/src/analysis/completion/formatting.rs
@@ -61,7 +61,7 @@ pub fn module_documentation(
     };
 
     match description_type {
-        DescripitonType::Name => md_doc(format!("{0} module", mod_name)),
+        DescripitonType::Name => md_doc(format!("`{0}` module", mod_name)),
         DescripitonType::Exposes => md_doc(format!("```roc\n{0}\n```", exposed())),
         DescripitonType::NameAndExposes => md_doc(format!(
             "`{0}` module\n```roc\n{1}\n```",

--- a/crates/lang_srv/src/analysis/completion/formatting.rs
+++ b/crates/lang_srv/src/analysis/completion/formatting.rs
@@ -5,7 +5,7 @@ use tower_lsp::lsp_types::{Documentation, MarkupContent, MarkupKind};
 
 use crate::analysis::{utils::format_var_type, ModulesInfo};
 
-fn module_exposed_list(
+fn get_module_exposed_list(
     module_id: &ModuleId,
     interns: &Interns,
     modules_info: &ModulesInfo,
@@ -14,9 +14,9 @@ fn module_exposed_list(
     modules_info.with_subs(module_id, |subs| {
         let items = exposed
             .iter()
-            .map(|(symb, var)| {
+            .map(|(symbol, var)| {
                 let var_str = format_var_type(*var, subs, module_id, interns);
-                format!("{0}: {1}", symb.as_str(interns), var_str)
+                format!("{0}: {1}", symbol.as_str(interns), var_str)
             })
             .collect::<Vec<_>>();
 
@@ -26,14 +26,15 @@ fn module_exposed_list(
 pub(super) enum DescriptionsType {
     Exposes,
 }
+
 fn md_doc(val: String) -> Documentation {
     Documentation::MarkupContent(MarkupContent {
         kind: MarkupKind::Markdown,
         value: val,
     })
 }
-///Generates a nicely formatted block of text for the completionitem documentation field
 
+/// Generates a nicely formatted block of text for the completionitem documentation field.
 pub(super) fn module_documentation(
     description_type: DescriptionsType,
     module_id: &ModuleId,
@@ -42,7 +43,7 @@ pub(super) fn module_documentation(
     modules_info: &ModulesInfo,
 ) -> Documentation {
     let exposed_string =
-        module_exposed_list(module_id, interns, modules_info, exposed).unwrap_or_default();
+        get_module_exposed_list(module_id, interns, modules_info, exposed).unwrap_or_default();
 
     match description_type {
         DescriptionsType::Exposes => md_doc(format!("```roc\n{0}\n```", exposed_string)),

--- a/crates/lang_srv/src/analysis/completion/formatting.rs
+++ b/crates/lang_srv/src/analysis/completion/formatting.rs
@@ -32,6 +32,7 @@ fn md_doc(val: String) -> Documentation {
         value: val,
     })
 }
+///Generates a nicely formatted block of text for the completionitem documentation field
 
 pub(super) fn module_documentation(
     description_type: DescripitonType,

--- a/crates/lang_srv/src/analysis/completion/formatting.rs
+++ b/crates/lang_srv/src/analysis/completion/formatting.rs
@@ -1,0 +1,70 @@
+use std::{collections::HashMap, sync::Arc};
+
+use parking_lot::Mutex;
+use roc_module::symbol::{Interns, ModuleId, Symbol};
+use roc_types::subs::{Subs, Variable};
+use tower_lsp::lsp_types::{Documentation, MarkupContent, MarkupKind};
+
+use crate::analysis::utils::format_var_type;
+
+fn module_exposed_list(
+    module_id: &ModuleId,
+    interns: &Interns,
+    imported_modules: &HashMap<ModuleId, Arc<Vec<(Symbol, Variable)>>>,
+    all_subs: &Mutex<HashMap<ModuleId, Subs>>,
+    modules_exposed: &Mutex<HashMap<ModuleId, Arc<Vec<(Symbol, Variable)>>>>,
+) -> Option<std::string::String> {
+    modules_exposed.lock().get(module_id).and_then(|exposed| {
+        all_subs.lock().get_mut(module_id).map(|subs| {
+            let items = exposed
+                .iter()
+                .map(|(symb, var)| {
+                    let var_str = format_var_type(*var, subs, module_id, interns);
+                    format!("    {0}: {1}", symb.as_str(interns), var_str)
+                })
+                .collect::<Vec<_>>();
+
+            format!("{{\n{0}\n}}", items.join(",\n"))
+        })
+    })
+}
+pub enum DescripitonType {
+    Name,
+    Exposes,
+    NameAndExposes,
+}
+fn md_doc(val: String) -> Documentation {
+    Documentation::MarkupContent(MarkupContent {
+        kind: MarkupKind::Markdown,
+        value: val,
+    })
+}
+
+pub fn module_documentation(
+    description_type: DescripitonType,
+    module_id: &ModuleId,
+    mod_name: &String,
+    interns: &Interns,
+    imported_modules: &HashMap<ModuleId, Arc<Vec<(Symbol, Variable)>>>,
+    all_subs: &Mutex<HashMap<ModuleId, Subs>>,
+    modules_exposed: &Mutex<HashMap<ModuleId, Arc<Vec<(Symbol, Variable)>>>>,
+) -> Documentation {
+    let exposed = || {
+        module_exposed_list(
+            module_id,
+            interns,
+            imported_modules,
+            all_subs,
+            modules_exposed,
+        )
+        .unwrap_or_default()
+    };
+
+    match description_type {
+        DescripitonType::Name => md_doc(format!("{0} module", mod_name)),
+        DescripitonType::Exposes => md_doc(format!("```roc\n{0}\n```", exposed())),
+        DescripitonType::NameAndExposes => {
+            md_doc(format!("{0}\n```roc\n{1}\n```", mod_name, exposed()))
+        }
+    }
+}

--- a/crates/lang_srv/src/analysis/completion/formatting.rs
+++ b/crates/lang_srv/src/analysis/completion/formatting.rs
@@ -23,7 +23,7 @@ fn module_exposed_list(
         })
     })
 }
-pub(super) enum DescripitonType {
+pub(super) enum DescriptionsType {
     Exposes,
 }
 fn md_doc(val: String) -> Documentation {
@@ -35,7 +35,7 @@ fn md_doc(val: String) -> Documentation {
 ///Generates a nicely formatted block of text for the completionitem documentation field
 
 pub(super) fn module_documentation(
-    description_type: DescripitonType,
+    description_type: DescriptionsType,
     module_id: &ModuleId,
     interns: &Interns,
     modules_info: &ModulesInfo,
@@ -43,6 +43,6 @@ pub(super) fn module_documentation(
     let exposed = || module_exposed_list(module_id, interns, modules_info).unwrap_or_default();
 
     match description_type {
-        DescripitonType::Exposes => md_doc(format!("```roc\n{0}\n```", exposed())),
+        DescriptionsType::Exposes => md_doc(format!("```roc\n{0}\n```", exposed())),
     }
 }

--- a/crates/lang_srv/src/analysis/completion/formatting.rs
+++ b/crates/lang_srv/src/analysis/completion/formatting.rs
@@ -20,11 +20,11 @@ fn module_exposed_list(
                 .iter()
                 .map(|(symb, var)| {
                     let var_str = format_var_type(*var, subs, module_id, interns);
-                    format!("    {0}: {1}", symb.as_str(interns), var_str)
+                    format!("{0}: {1}", symb.as_str(interns), var_str)
                 })
                 .collect::<Vec<_>>();
 
-            format!("{{\n{0}\n}}", items.join(",\n"))
+            format!("{0}", items.join("\n"))
         })
     })
 }
@@ -63,8 +63,10 @@ pub fn module_documentation(
     match description_type {
         DescripitonType::Name => md_doc(format!("{0} module", mod_name)),
         DescripitonType::Exposes => md_doc(format!("```roc\n{0}\n```", exposed())),
-        DescripitonType::NameAndExposes => {
-            md_doc(format!("{0}\n```roc\n{1}\n```", mod_name, exposed()))
-        }
+        DescripitonType::NameAndExposes => md_doc(format!(
+            "`{0}` module\n```roc\n{1}\n```",
+            mod_name,
+            exposed()
+        )),
     }
 }

--- a/crates/lang_srv/src/analysis/completion/formatting.rs
+++ b/crates/lang_srv/src/analysis/completion/formatting.rs
@@ -9,7 +9,7 @@ fn module_exposed_list(
     module_id: &ModuleId,
     interns: &Interns,
     modules_info: &ModulesInfo,
-    exposed: &Vec<(Symbol, Variable)>,
+    exposed: &[(Symbol, Variable)],
 ) -> Option<std::string::String> {
     modules_info.with_subs(module_id, |subs| {
         let items = exposed
@@ -38,7 +38,7 @@ pub(super) fn module_documentation(
     description_type: DescriptionsType,
     module_id: &ModuleId,
     interns: &Interns,
-    exposed: &Vec<(Symbol, Variable)>,
+    exposed: &[(Symbol, Variable)],
     modules_info: &ModulesInfo,
 ) -> Documentation {
     let exposed_string =

--- a/crates/lang_srv/src/analysis/completion/formatting.rs
+++ b/crates/lang_srv/src/analysis/completion/formatting.rs
@@ -1,5 +1,6 @@
-use roc_module::symbol::{Interns, ModuleId};
+use roc_module::symbol::{Interns, ModuleId, Symbol};
 
+use roc_types::subs::Variable;
 use tower_lsp::lsp_types::{Documentation, MarkupContent, MarkupKind};
 
 use crate::analysis::{utils::format_var_type, ModulesInfo};
@@ -7,20 +8,19 @@ use crate::analysis::{utils::format_var_type, ModulesInfo};
 fn module_exposed_list(
     module_id: &ModuleId,
     interns: &Interns,
-    ModulesInfo { subs, exposed }: &ModulesInfo,
+    modules_info: &ModulesInfo,
+    exposed: &Vec<(Symbol, Variable)>,
 ) -> Option<std::string::String> {
-    exposed.get(module_id).and_then(|exposed| {
-        subs.lock().get_mut(module_id).map(|subs| {
-            let items = exposed
-                .iter()
-                .map(|(symb, var)| {
-                    let var_str = format_var_type(*var, subs, module_id, interns);
-                    format!("{0}: {1}", symb.as_str(interns), var_str)
-                })
-                .collect::<Vec<_>>();
+    modules_info.with_subs(module_id, |subs| {
+        let items = exposed
+            .iter()
+            .map(|(symb, var)| {
+                let var_str = format_var_type(*var, subs, module_id, interns);
+                format!("{0}: {1}", symb.as_str(interns), var_str)
+            })
+            .collect::<Vec<_>>();
 
-            items.join("\n").to_string()
-        })
+        items.join("\n").to_string()
     })
 }
 pub(super) enum DescriptionsType {
@@ -38,11 +38,13 @@ pub(super) fn module_documentation(
     description_type: DescriptionsType,
     module_id: &ModuleId,
     interns: &Interns,
+    exposed: &Vec<(Symbol, Variable)>,
     modules_info: &ModulesInfo,
 ) -> Documentation {
-    let exposed = || module_exposed_list(module_id, interns, modules_info).unwrap_or_default();
+    let exposed_string =
+        module_exposed_list(module_id, interns, modules_info, exposed).unwrap_or_default();
 
     match description_type {
-        DescriptionsType::Exposes => md_doc(format!("```roc\n{0}\n```", exposed())),
+        DescriptionsType::Exposes => md_doc(format!("```roc\n{0}\n```", exposed_string)),
     }
 }

--- a/crates/lang_srv/src/server.rs
+++ b/crates/lang_srv/src/server.rs
@@ -400,8 +400,8 @@ mod tests {
         info!("doc is:\n{0}", change);
 
         inner.change(&url, change, 1).await.unwrap();
-        let comp1 = get_completion_labels(reg, &url, position).await;
-        comp1
+        
+        get_completion_labels(reg, &url, position).await
     }
 
     ///Test that completion works properly when we apply an "as" pattern to an identifier
@@ -491,9 +491,8 @@ mod tests {
     #[tokio::test]
     async fn test_completion_fun_params() {
         let actual = completion_test(
-            indoc! {r#"
-            main =\param1,param2->
-              "#},
+            indoc! {r"main =\param1,param2->
+  "},
             "par",
             Position::new(4, 3),
         )
@@ -512,9 +511,8 @@ mod tests {
     #[tokio::test]
     async fn test_completion_closure() {
         let actual = completion_test(
-            indoc! {r#"
-            main =[]|>List.map\param1,param2->
-              "#},
+            indoc! {r"main =[]|>List.map\param1,param2->
+  "},
             "par",
             Position::new(4, 3),
         )

--- a/crates/lang_srv/src/server.rs
+++ b/crates/lang_srv/src/server.rs
@@ -388,11 +388,11 @@ mod tests {
     }
     ///Runs a basic completion and returns the response
     async fn completion_test(
-        inital: &str,
+        initial: &str,
         addition: &str,
         position: Position,
     ) -> Option<std::vec::Vec<std::string::String>> {
-        let doc = DOC_LIT.to_string() + inital;
+        let doc = DOC_LIT.to_string() + initial;
         let (inner, url) = test_setup(doc.clone()).await;
         let reg = &inner.registry;
 

--- a/crates/lang_srv/src/server.rs
+++ b/crates/lang_srv/src/server.rs
@@ -491,9 +491,9 @@ mod tests {
     #[tokio::test]
     async fn test_completion_fun_params() {
         let actual = completion_test(
-            indoc! {r#"
+            indoc! {r"
             main = \param1, param2 ->
-              "#},
+              "},
             "par",
             Position::new(4, 3),
         )
@@ -512,9 +512,9 @@ mod tests {
     #[tokio::test]
     async fn test_completion_closure() {
         let actual = completion_test(
-            indoc! {r#"
+            indoc! {r"
             main = [] |> List.map \ param1 , param2-> 
-              "#},
+              "},
             "par",
             Position::new(4, 3),
         )

--- a/crates/lang_srv/src/server.rs
+++ b/crates/lang_srv/src/server.rs
@@ -400,7 +400,7 @@ mod tests {
         info!("doc is:\n{0}", change);
 
         inner.change(&url, change, 1).await.unwrap();
-        
+
         get_completion_labels(reg, &url, position).await
     }
 
@@ -491,8 +491,9 @@ mod tests {
     #[tokio::test]
     async fn test_completion_fun_params() {
         let actual = completion_test(
-            indoc! {r"main =\param1,param2->
-  "},
+            indoc! {r#"
+            main = \param1, param2 ->
+              "#},
             "par",
             Position::new(4, 3),
         )
@@ -511,8 +512,9 @@ mod tests {
     #[tokio::test]
     async fn test_completion_closure() {
         let actual = completion_test(
-            indoc! {r"main =[]|>List.map\param1,param2->
-  "},
+            indoc! {r#"
+            main = [] |> List.map \ param1 , param2-> 
+              "#},
             "par",
             Position::new(4, 3),
         )


### PR DESCRIPTION
# Module Completion
![test](https://github.com/roc-lang/roc/assets/26968035/4fcbbcad-dbb1-4e42-8e64-cff5a7379f0d)
This builds upon my other pr #6134 adding completion for modules and their contents.
It also fixes issues with the panic wrapper not correctly catching panics from async calls.

It lays some the groundwork for completion of type aliases, getting some of the data we need in the right place, and creating a method for completing them,  but doesn't fully implement that feature. 
Alias completion is complex because we need a way to know we are within a type definition.