### PR TITLE
Fix RC for unions with non-refcounted fields

### DIFF
--- a/crates/compiler/gen_llvm/src/llvm/refcounting.rs
+++ b/crates/compiler/gen_llvm/src/llvm/refcounting.rs
@@ -1295,6 +1295,9 @@ fn build_rec_union_recursive_decrement<'a, 'ctx>(
             _ => tag_id,
         };
 
+        let block = env.context.append_basic_block(parent, "tag_id_decrement");
+        env.builder.position_at_end(block);
+
         // if none of the fields are or contain anything refcounted, just move on
         if fields_need_no_refcounting(layout_interner, field_layouts) {
             // Still make sure to decrement the refcount of the union as a whole.
@@ -1302,12 +1305,12 @@ fn build_rec_union_recursive_decrement<'a, 'ctx>(
                 let union_layout = LayoutRepr::Union(union_layout);
                 refcount_ptr.modify(call_mode, union_layout, env, layout_interner);
             }
+
+            // this function returns void
+            builder.new_build_return(None);
+
             continue;
         }
-
-        let block = env.context.append_basic_block(parent, "tag_id_decrement");
-
-        env.builder.position_at_end(block);
 
         let fields_struct = LayoutRepr::struct_(field_layouts);
         let wrapper_type = basic_type_from_layout(env, layout_interner, fields_struct);

--- a/crates/compiler/gen_llvm/src/llvm/refcounting.rs
+++ b/crates/compiler/gen_llvm/src/llvm/refcounting.rs
@@ -1309,6 +1309,8 @@ fn build_rec_union_recursive_decrement<'a, 'ctx>(
             // this function returns void
             builder.new_build_return(None);
 
+            cases.push((tag_id_int_type.const_int(tag_id as u64, false), block));
+
             continue;
         }
 

--- a/crates/valgrind/src/lib.rs
+++ b/crates/valgrind/src/lib.rs
@@ -550,3 +550,29 @@ fn joinpoint_nullpointer() {
         "#
     ));
 }
+
+#[test]
+fn freeing_boxes() {
+    valgrind_test(indoc!(
+        r#"
+        (
+            # Without refcounted field
+            a : I32
+            a = 7
+                |> Box.box
+                |> Box.unbox
+
+            # With refcounted field
+            b : Str
+            b =
+                "Testing123. This will definitely be a large string that is on the heap."
+                |> Box.box
+                |> Box.unbox
+
+            a
+            |> Num.toStr
+            |> Str.concat b
+        )
+        "#
+    ));
+}


### PR DESCRIPTION
ensure unions get freed even if they have no RC fields (hit when using box)