### PR TITLE
Add support for $(...) string interpolation syntax

### DIFF
--- a/crates/compiler/can/tests/test_can.rs
+++ b/crates/compiler/can/tests/test_can.rs
@@ -782,7 +782,7 @@ mod test_can {
 
             number = "42"
 
-            succeed { 
+            succeed {
                 number: <- parse number,
                 raw: number,
             }
@@ -817,7 +817,7 @@ mod test_can {
     fn multiple_record_builders_error() {
         let src = indoc!(
             r#"
-                succeed 
+                succeed
                     { a: <- apply "a" }
                     { b: <- apply "b" }
             "#
@@ -1822,18 +1822,18 @@ mod test_can {
     //         );
     //     }
 
-    //     #[test]
-    //     fn string_with_escaped_interpolation() {
-    //         assert_parses_to(
-    //             // This should NOT be string interpolation, because of the \\
-    //             indoc!(
-    //                 r#"
-    //                      "abcd\\(efg)hij"
+    // #[test]
+    // fn string_with_escaped_interpolation() {
+    //     assert_parses_to(
+    //         // This should NOT be string interpolation, because of the \\
+    //         indoc!(
+    //             r#"
+    //                      "abcd\$(efg)hij"
     //                      "#
-    //             ),
-    //             Str(r"abcd\(efg)hij".into()),
-    //         );
-    //     }
+    //         ),
+    //         Str(r"abcd\(efg)hij".into()),
+    //     );
+    // }
 
     //     #[test]
     //     fn string_without_escape() {

--- a/crates/compiler/parse/src/ast.rs
+++ b/crates/compiler/parse/src/ast.rs
@@ -141,6 +141,7 @@ pub enum EscapedChar {
     SingleQuote,    // \'
     Backslash,      // \\
     CarriageReturn, // \r
+    Dollar,         // \$
 }
 
 impl EscapedChar {
@@ -155,6 +156,7 @@ impl EscapedChar {
             CarriageReturn => 'r',
             Tab => 't',
             Newline => 'n',
+            Dollar => '$',
         }
     }
 
@@ -168,6 +170,7 @@ impl EscapedChar {
             CarriageReturn => '\r',
             Tab => '\t',
             Newline => '\n',
+            Dollar => '$',
         }
     }
 }

--- a/crates/compiler/parse/src/string_literal.rs
+++ b/crates/compiler/parse/src/string_literal.rs
@@ -349,6 +349,68 @@ pub fn parse_str_like_literal<'a>() -> impl Parser<'a, StrLikeLiteral<'a>, EStri
                         return Err((MadeProgress, EString::EndlessSingleLine(start_state.pos())));
                     }
                 }
+                b'$' => {
+                    // This is for the byte we're about to parse.
+                    segment_parsed_bytes += 1;
+
+                    // iff the '$' is followed by '(', this is string interpolation.
+                    if let Some(b'(') = bytes.next() {
+                        // We're about to begin string interpolation!
+                        //
+                        // End the previous segment so we can begin a new one.
+                        // Retroactively end it right before the `$` char we parsed.
+                        // (We can't use end_segment! here because it ends it right after
+                        // the just-parsed character, which here would be '(' rather than '$')
+                        // Don't push anything if the string would be empty.
+                        if segment_parsed_bytes > 2 {
+                            // exclude the 2 chars we just parsed, namely '$' and '('
+                            let string_bytes = &state.bytes()[0..(segment_parsed_bytes - 2)];
+
+                            match std::str::from_utf8(string_bytes) {
+                                Ok(string) => {
+                                    state.advance_mut(string.len());
+
+                                    segments.push(StrSegment::Plaintext(string));
+                                }
+                                Err(_) => {
+                                    return Err((
+                                        MadeProgress,
+                                        EString::Space(BadInputError::BadUtf8, state.pos()),
+                                    ));
+                                }
+                            }
+                        }
+
+                        // Advance past the `$(`
+                        state.advance_mut(2);
+
+                        let original_byte_count = state.bytes().len();
+
+                        // Parse an arbitrary expression, followed by ')'
+                        let (_progress, loc_expr, new_state) = skip_second!(
+                            specialize_ref(
+                                EString::Format,
+                                loc(allocated(reset_min_indent(expr::expr_help())))
+                            ),
+                            word1(b')', EString::FormatEnd)
+                        )
+                        .parse(arena, state, min_indent)?;
+
+                        // Advance the iterator past the expr we just parsed.
+                        for _ in 0..(original_byte_count - new_state.bytes().len()) {
+                            bytes.next();
+                        }
+
+                        segments.push(StrSegment::Interpolated(loc_expr));
+
+                        // Reset the segment
+                        segment_parsed_bytes = 0;
+                        state = new_state;
+                    }
+
+                    // If the '$' wasn't followed by '(', then this wasn't interpolation,
+                    // and we don't need to do anything special.
+                }
                 b'\\' => {
                     // We're about to begin an escaped segment of some sort!
                     //
@@ -436,6 +498,9 @@ pub fn parse_str_like_literal<'a>() -> impl Parser<'a, StrLikeLiteral<'a>, EStri
                         }
                         Some(b'n') => {
                             escaped_char!(EscapedChar::Newline);
+                        }
+                        Some(b'$') => {
+                            escaped_char!(EscapedChar::Dollar);
                         }
                         _ => {
                             // Invalid escape! A backslash must be followed

--- a/crates/compiler/test_syntax/tests/test_snapshots.rs
+++ b/crates/compiler/test_syntax/tests/test_snapshots.rs
@@ -777,7 +777,7 @@ mod test_snapshots {
 
     #[test]
     fn string_with_multiple_interpolations() {
-        assert_segments(r#""Hi, \(name)! How is \(project) going?""#, |arena| {
+        assert_segments(r#""Hi, $(name)! How is $(project) going?""#, |arena| {
             let expr1 = arena.alloc(Var {
                 module_name: "",
                 ident: "name",


### PR DESCRIPTION
This adds support for string interpolation using `$(...)` syntax. It keeps the existing `\(...)` for now, to ease the transition. The plan is:

1. Land this PR
2. In separate PRs, update `basic-cli` and examples to use the new syntax
3. In another PR, update `roc format`, tutorial, documentation, etc. to use the new syntax
4. In a separate PR after that, introduce a deprecation warning for using `\(...)` so we can find the remaining instances easily.
5. Eventually, remove the old syntax. (There's no rush on this; maybe we end up accomplishing this by not including `\(` in the upcoming parser rewrite.)