### PR TITLE
Fix hang from bad imports

### DIFF
--- a/crates/compiler/load_internal/src/file.rs
+++ b/crates/compiler/load_internal/src/file.rs
@@ -2191,15 +2191,14 @@ fn check_for_missing_package_shorthand_in_cache<'a>(
                         match header.header_type {
                             HeaderType::Hosted { ..} |
                             HeaderType::Builtin {..} |
-                            HeaderType::Interface {..} => 
+                            HeaderType::Interface {..} =>
                             {
                                 let mod_type= header.header_type.to_string();
                                 format!("The package shorthand '{shorthand}' that you are using in the 'imports' section of the header of module '{module_path}' doesn't exist.\nCheck that package shorthand is correct or reference the package in an 'app' or 'package' header.\nThis module is an {mod_type}, because of a bug in the compiler we are unable to directly typecheck {mod_type} modules with package imports so this error may not be correct. Please start checking at an app, package or platform file that imports this file.")
                             },
                             _=>
                                 format!("The package shorthand '{shorthand}' that you are using in the 'imports' section of the header of module '{module_path}' doesn't exist.\nCheck that package shorthand is correct or reference the package in an 'app' or 'package' header.")
-                        
-            }))
+                        }))
                     } else {
                         None
                     }

--- a/crates/compiler/load_internal/src/file.rs
+++ b/crates/compiler/load_internal/src/file.rs
@@ -2367,6 +2367,20 @@ fn update<'a>(
                         }
                     }
                     Builtin { .. } | Interface { .. } => {
+                        let qualified_modules = header
+                            .package_qualified_imported_modules
+                            .iter()
+                            .filter(|pqim| match pqim {
+                                PackageQualified::Unqualified(_) => false,
+                                PackageQualified::Qualified(shorthand, _) => shorthand != &"",
+                            })
+                            .collect::<Vec<_>>();
+                        assert!(
+                            qualified_modules.is_empty(),
+                            "package qualified modules not allowed in interfaces. Remove: {:#?} ",
+                            qualified_modules
+                        );
+
                         if header.is_root_module {
                             debug_assert!(matches!(
                                 state.platform_path,

--- a/crates/compiler/load_internal/src/file.rs
+++ b/crates/compiler/load_internal/src/file.rs
@@ -2185,7 +2185,7 @@ fn check_for_missing_package_shorthand<'a>(
             let package_missing=packages
                 .iter()
                 .find(|p| p.value.shorthand == shorthand)
-                .is_some();
+                .is_none();
             if package_missing{
                 Some(
                     LoadingProblem::FormattedReport(

--- a/crates/compiler/load_internal/src/file/reporting.rs
+++ b/crates/compiler/load_internal/src/file/reporting.rs
@@ -1,0 +1,22 @@
+fn report_missing_package_shorthand2<'a>(
+    packages: &[Loc<PackageEntry>],
+    imports: &[Loc<ImportsEntry>],
+) -> Option<LoadingProblem<'a>> {
+    imports.iter().find_map(|i| match i.value {
+        ImportsEntry::Module(_, _) | ImportsEntry::IngestedFile(_, _) => None,
+        ImportsEntry::Package(shorthand, name, _) => {
+            let name=name.as_str();
+            if packages
+                .iter()
+                .find(|p| p.value.shorthand == shorthand)
+                .is_none()
+            {
+                Some(
+                    LoadingProblem::FormattedReport(
+                        format!("The package shorthand '{shorthand}' that you are importing the module '{name}' from in '{shorthand}.{name}', doesn't exist in this module.\nImport it in the \"packages\" section of the header.")))
+            } else {
+                None
+            }
+        }
+    })
+}

--- a/crates/compiler/load_internal/tests/test_load.rs
+++ b/crates/compiler/load_internal/tests/test_load.rs
@@ -1163,8 +1163,8 @@ fn module_interface_with_qualified_import() {
         err,
         indoc!(
             r#"
-            You seem to be trying to import from the package 'b' in the import 'b.T'.
-            Modules of type "interface" don't support package imports."#
+            The package shorthand 'b' that you are using in the 'imports' section of the header doesn't exist in this module.
+            Check that package shorthand is correct or reference the package in an 'app' or 'package' header."#
         ),
         "\n{}",
         err

--- a/crates/compiler/load_internal/tests/test_load.rs
+++ b/crates/compiler/load_internal/tests/test_load.rs
@@ -1162,8 +1162,7 @@ fn module_interface_with_qualified_import() {
     assert_eq!(
         err,
         indoc!(
-            r"
-            "
+            r#"You seem to be trying to import the module b.T from a package "b" inside a module of type "interface" that doesn't support that."#
         ),
         "\n{}",
         err

--- a/crates/compiler/load_internal/tests/test_load.rs
+++ b/crates/compiler/load_internal/tests/test_load.rs
@@ -1163,8 +1163,9 @@ fn module_interface_with_qualified_import() {
         err,
         indoc!(
             r#"
-            The package shorthand 'b' that you are using in the 'imports' section of the header doesn't exist in this module.
-            Check that package shorthand is correct or reference the package in an 'app' or 'package' header."#
+            The package shorthand 'b' that you are using in the 'imports' section of the header of module 'tmp/module_interface_with_qualified_import/A' doesn't exist.
+            Check that package shorthand is correct or reference the package in an 'app' or 'package' header.
+            This module is an interface, because of a bug in the compiler we are unable to directly typecheck interface modules with package imports so this error may not be correct. Please start checking at an app, package or platform file that imports this file."#
         ),
         "\n{}",
         err
@@ -1191,8 +1192,8 @@ fn app_missing_package_import() {
         err,
         indoc!(
             r#"
-            The package shorthand 'notpack' that you are importing the module 'Mod' from in 'notpack.Mod', doesn't exist in this module.
-            Import it in the "packages" section of the header."#
+            The package shorthand 'notpack' that you are using in the 'imports' section of the header of module 'tmp/app_missing_package_import/Main' doesn't exist.
+            Check that package shorthand is correct or reference the package in an 'app' or 'package' header."#
         ),
         "\n{}",
         err

--- a/crates/compiler/load_internal/tests/test_load.rs
+++ b/crates/compiler/load_internal/tests/test_load.rs
@@ -1170,3 +1170,31 @@ fn module_interface_with_qualified_import() {
         err
     );
 }
+#[test]
+fn app_missing_package_import() {
+    let modules = vec![(
+        "Main",
+        indoc!(
+            r#"
+                app "example"
+                    packages { pack: "./package/main.roc" }
+                    imports [notpack.Mod]
+                    provides [] to pack
+
+                main = ""
+                "#
+        ),
+    )];
+
+    let err = multiple_modules("app_missing_package_import", modules).unwrap_err();
+    assert_eq!(
+        err,
+        indoc!(
+            r#"
+            The package shorthand 'notpack' that you are importing the module 'Mod' from in 'notpack.Mod', doesn't exist in this module.
+            Import it in the "packages" section of the header."#
+        ),
+        "\n{}",
+        err
+    );
+}

--- a/crates/compiler/load_internal/tests/test_load.rs
+++ b/crates/compiler/load_internal/tests/test_load.rs
@@ -1058,7 +1058,6 @@ fn module_cyclic_import_itself() {
         err
     );
 }
-
 #[test]
 fn module_cyclic_import_transitive() {
     let modules = vec![
@@ -1143,6 +1142,28 @@ fn nested_module_has_incorrect_name() {
             Based on the nesting and use of this module, I expect it to have name
 
                 Dep.Foo"
+        ),
+        "\n{}",
+        err
+    );
+}
+#[test]
+fn module_interface_with_qualified_import() {
+    let modules = vec![(
+        "A",
+        indoc!(
+            r"
+            interface A exposes [] imports [b.T]
+            "
+        ),
+    )];
+
+    let err = multiple_modules("module_interface_with_qualified_import", modules).unwrap_err();
+    assert_eq!(
+        err,
+        indoc!(
+            r"
+            "
         ),
         "\n{}",
         err

--- a/crates/compiler/load_internal/tests/test_load.rs
+++ b/crates/compiler/load_internal/tests/test_load.rs
@@ -1162,7 +1162,9 @@ fn module_interface_with_qualified_import() {
     assert_eq!(
         err,
         indoc!(
-            r#"You seem to be trying to import the module b.T from a package "b" inside a module of type "interface" that doesn't support that."#
+            r#"
+            You seem to be trying to import from the package 'b' in the import 'b.T'.
+            Modules of type "interface" don't support package imports."#
         ),
         "\n{}",
         err

--- a/crates/compiler/parse/src/header.rs
+++ b/crates/compiler/parse/src/header.rs
@@ -23,6 +23,16 @@ impl<'a> HeaderType<'a> {
             HeaderType::Platform { .. } | HeaderType::Package { .. } => &[],
         }
     }
+    pub fn to_string(&'a self) -> &str {
+        match self {
+            HeaderType::App { .. } => "app",
+            HeaderType::Hosted { .. } => "hosted",
+            HeaderType::Builtin { .. } => "builtin",
+            HeaderType::Package { .. } => "package",
+            HeaderType::Platform { .. } => "platform",
+            HeaderType::Interface { .. } => "interface",
+        }
+    }
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
We have a few issues with the language server hanging 
#6336 
#6269 
#6185 
#6200

I believe these are all caused by the same problem.
When an interface header has a qualified import which is invalid syntax or a app header tries to import from a package shorthand that doesn't exist. eg:`interface A import [pf.Task]` The messages
between the state_thread and the worker_task thread die out and they are then both left sitting waiting for messages that never come.

I have fixed this by just checking if there are any package imports that are invalid and failing to load if so

I know the implementation is a little rough but given the module-params syntax changes will render package shorthands obsolete this seemed like a reasonable short term fix.