### PR TITLE
Preserve `\(...)` and `$(...)` in `roc format` for now

### DIFF
--- a/crates/compiler/can/src/expr.rs
+++ b/crates/compiler/can/src/expr.rs
@@ -2423,7 +2423,9 @@ pub fn is_valid_interpolation(expr: &ast::Expr<'_>) -> bool {
                 | ast::StrSegment::Plaintext(_) => true,
                 // Disallow nested interpolation. Alternatively, we could allow it but require
                 // a comment above it apologizing to the next person who has to read the code.
-                ast::StrSegment::Interpolated(_) => false,
+                ast::StrSegment::Interpolated(_) | ast::StrSegment::DeprecatedInterpolated(_) => {
+                    false
+                }
             })
         }
         ast::Expr::Record(fields) => fields.iter().all(|loc_field| match loc_field.value {
@@ -2550,7 +2552,7 @@ fn flatten_str_lines<'a>(
                         );
                     }
                 },
-                Interpolated(loc_expr) => {
+                Interpolated(loc_expr) | DeprecatedInterpolated(loc_expr) => {
                     if is_valid_interpolation(loc_expr.value) {
                         // Interpolations desugar to Str.concat calls
                         output.references.insert_call(Symbol::STR_CONCAT);

--- a/crates/compiler/can/src/operator.rs
+++ b/crates/compiler/can/src/operator.rs
@@ -634,6 +634,22 @@ fn desugar_str_segments<'a>(
             StrSegment::Plaintext(_) | StrSegment::Unicode(_) | StrSegment::EscapedChar(_) => {
                 *segment
             }
+            StrSegment::DeprecatedInterpolated(loc_expr) => {
+                let loc_desugared = desugar_expr(
+                    arena,
+                    arena.alloc(Loc {
+                        region: loc_expr.region,
+                        value: *loc_expr.value,
+                    }),
+                    src,
+                    line_info,
+                    module_path,
+                );
+                StrSegment::DeprecatedInterpolated(Loc {
+                    region: loc_desugared.region,
+                    value: arena.alloc(loc_desugared.value),
+                })
+            }
             StrSegment::Interpolated(loc_expr) => {
                 let loc_desugared = desugar_expr(
                     arena,

--- a/crates/compiler/can/src/pattern.rs
+++ b/crates/compiler/can/src/pattern.rs
@@ -1071,7 +1071,7 @@ fn flatten_str_lines(lines: &[&[StrSegment<'_>]]) -> Pattern {
                 Unicode(loc_digits) => {
                     todo!("parse unicode digits {:?}", loc_digits);
                 }
-                Interpolated(loc_expr) => {
+                Interpolated(loc_expr) | DeprecatedInterpolated(loc_expr) => {
                     return Pattern::UnsupportedPattern(loc_expr.region);
                 }
                 EscapedChar(escaped) => buf.push(escaped.unescape()),

--- a/crates/compiler/fmt/src/expr.rs
+++ b/crates/compiler/fmt/src/expr.rs
@@ -612,9 +612,20 @@ fn format_str_segment(seg: &StrSegment, buf: &mut Buf, indent: u16) {
             buf.push('\\');
             buf.push(escaped.to_parsed_char());
         }
-        Interpolated(loc_expr) => {
+        DeprecatedInterpolated(loc_expr) => {
             buf.push_str("\\(");
-            // e.g. (name) in "Hi, \(name)!"
+            // e.g. (name) in "Hi, $(name)!"
+            loc_expr.value.format_with_options(
+                buf,
+                Parens::NotNeeded, // We already printed parens!
+                Newlines::No,      // Interpolations can never have newlines
+                indent,
+            );
+            buf.push(')');
+        }
+        Interpolated(loc_expr) => {
+            buf.push_str("$(");
+            // e.g. (name) in "Hi, $(name)!"
             loc_expr.value.format_with_options(
                 buf,
                 Parens::NotNeeded, // We already printed parens!

--- a/crates/compiler/fmt/src/spaces.rs
+++ b/crates/compiler/fmt/src/spaces.rs
@@ -656,6 +656,9 @@ impl<'a> RemoveSpaces<'a> for StrSegment<'a> {
             StrSegment::Unicode(t) => StrSegment::Unicode(t.remove_spaces(arena)),
             StrSegment::EscapedChar(c) => StrSegment::EscapedChar(c),
             StrSegment::Interpolated(t) => StrSegment::Interpolated(t.remove_spaces(arena)),
+            StrSegment::DeprecatedInterpolated(t) => {
+                StrSegment::DeprecatedInterpolated(t.remove_spaces(arena))
+            }
         }
     }
 }

--- a/crates/compiler/parse/src/ast.rs
+++ b/crates/compiler/parse/src/ast.rs
@@ -119,10 +119,11 @@ pub struct WhenPattern<'a> {
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum StrSegment<'a> {
-    Plaintext(&'a str),              // e.g. "foo"
-    Unicode(Loc<&'a str>),           // e.g. "00A0" in "\u(00A0)"
-    EscapedChar(EscapedChar),        // e.g. '\n' in "Hello!\n"
-    Interpolated(Loc<&'a Expr<'a>>), // e.g. (name) in "Hi, \(name)!"
+    Plaintext(&'a str),       // e.g. "foo"
+    Unicode(Loc<&'a str>),    // e.g. "00A0" in "\u(00A0)"
+    EscapedChar(EscapedChar), // e.g. '\n' in "Hello!\n"
+    Interpolated(Loc<&'a Expr<'a>>),
+    DeprecatedInterpolated(Loc<&'a Expr<'a>>), // The old "$(...)" syntax - will be removed someday
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -216,6 +217,7 @@ impl<'a> TryFrom<StrSegment<'a>> for SingleQuoteSegment<'a> {
             StrSegment::Unicode(s) => Ok(SingleQuoteSegment::Unicode(s)),
             StrSegment::EscapedChar(s) => Ok(SingleQuoteSegment::EscapedChar(s)),
             StrSegment::Interpolated(_) => Err(ESingleQuote::InterpolationNotAllowed),
+            StrSegment::DeprecatedInterpolated(_) => Err(ESingleQuote::InterpolationNotAllowed),
         }
     }
 }
@@ -1590,7 +1592,9 @@ impl<'a> Malformed for StrSegment<'a> {
     fn is_malformed(&self) -> bool {
         match self {
             StrSegment::Plaintext(_) | StrSegment::Unicode(_) | StrSegment::EscapedChar(_) => false,
-            StrSegment::Interpolated(expr) => expr.is_malformed(),
+            StrSegment::Interpolated(expr) | StrSegment::DeprecatedInterpolated(expr) => {
+                expr.is_malformed()
+            }
         }
     }
 }

--- a/crates/compiler/parse/src/string_literal.rs
+++ b/crates/compiler/parse/src/string_literal.rs
@@ -448,7 +448,7 @@ pub fn parse_str_like_literal<'a>() -> impl Parser<'a, StrLikeLiteral<'a>, EStri
                                 bytes.next();
                             }
 
-                            segments.push(StrSegment::Interpolated(loc_expr));
+                            segments.push(StrSegment::DeprecatedInterpolated(loc_expr));
 
                             // Reset the segment
                             segment_parsed_bytes = 0;

--- a/crates/compiler/test_syntax/tests/test_snapshots.rs
+++ b/crates/compiler/test_syntax/tests/test_snapshots.rs
@@ -731,7 +731,7 @@ mod test_snapshots {
 
     #[test]
     fn string_with_interpolation_in_middle() {
-        assert_segments(r#""Hi, \(name)!""#, |arena| {
+        assert_segments(r#""Hi, $(name)!""#, |arena| {
             let expr = arena.alloc(Var {
                 module_name: "",
                 ident: "name",
@@ -747,7 +747,7 @@ mod test_snapshots {
 
     #[test]
     fn string_with_interpolation_in_front() {
-        assert_segments(r#""\(name), hi!""#, |arena| {
+        assert_segments(r#""$(name), hi!""#, |arena| {
             let expr = arena.alloc(Var {
                 module_name: "",
                 ident: "name",
@@ -762,7 +762,7 @@ mod test_snapshots {
 
     #[test]
     fn string_with_interpolation_in_back() {
-        assert_segments(r#""Hello \(name)""#, |arena| {
+        assert_segments(r#""Hello $(name)""#, |arena| {
             let expr = arena.alloc(Var {
                 module_name: "",
                 ident: "name",


### PR DESCRIPTION
In a future change we can have it rewrite either to `$(...)` to make upgrading easier.