### PR TITLE
interpolation version mismatch patch

### DIFF
--- a/.github/workflows/basic_cli_test_arm64.yml
+++ b/.github/workflows/basic_cli_test_arm64.yml
@@ -1,5 +1,4 @@
 on:
-  pull_request:
   workflow_dispatch:
 
 # this cancels workflows currently in progress if you start a new one

--- a/.github/workflows/basic_cli_test_arm64.yml
+++ b/.github/workflows/basic_cli_test_arm64.yml
@@ -1,4 +1,5 @@
 on:
+  pull_request:
   workflow_dispatch:
 
 # this cancels workflows currently in progress if you start a new one
@@ -52,6 +53,10 @@ jobs:
           git fetch --tags
           latestTag=$(git describe --tags $(git rev-list --tags --max-count=1))
           git checkout $latestTag
+
+      # temp issue with new string interpolation syntax
+      # TODO undo when 0.7.2 or 0.8.0 is released
+      - run: sed -i 's/\$//g' examples/tcp-client.roc
 
       - name: Run all tests with latest roc nightly and latest basic-cli release
         run: |

--- a/.github/workflows/basic_cli_test_arm64.yml
+++ b/.github/workflows/basic_cli_test_arm64.yml
@@ -56,7 +56,7 @@ jobs:
 
       # temp issue with new string interpolation syntax
       # TODO undo when 0.7.2 or 0.8.0 is released
-      - run: sed -i 's/\$//g' examples/tcp-client.roc
+      - run: sed -i 's/\$//g' basic-cli/examples/tcp-client.roc
 
       - name: Run all tests with latest roc nightly and latest basic-cli release
         run: |


### PR DESCRIPTION
This script tests the latest release of basic-cli but one example used `$(which cat)` in a string, which is causing issues with the new interpolation syntax. I now just delete the `$` for that specific file before testing.