### PR TITLE
Set debug info version

### DIFF
--- a/crates/compiler/gen_llvm/src/llvm/build.rs
+++ b/crates/compiler/gen_llvm/src/llvm/build.rs
@@ -949,6 +949,12 @@ impl<'a, 'ctx, 'env> Env<'a, 'ctx, 'env> {
     }
 
     pub fn new_debug_info(module: &Module<'ctx>) -> (DebugInfoBuilder<'ctx>, DICompileUnit<'ctx>) {
+        let debug_metadata_version = module.get_context().i32_type().const_int(3, false);
+        module.add_basic_value_flag(
+            "Debug Info Version",
+            inkwell::module::FlagBehavior::Warning,
+            debug_metadata_version,
+        );
         module.create_debug_info_builder(
             true,
             /* language */ inkwell::debug_info::DWARFSourceLanguage::C,


### PR DESCRIPTION
We just missed setting it. Set it as specified in the docs: https://thedan64.github.io/inkwell/inkwell/debug_info/index.html#setting-up-the-module-for-holding-debug-info
Not sure why it is 3, but that is the value in the llvm tutorial as well: https://llvm.org/docs/SourceLevelDebugging.html

Fixes #6367