### PR TITLE
Stop using "rlib"

### DIFF
--- a/crates/glue/tests/fixture-templates/rust/Cargo.toml
+++ b/crates/glue/tests/fixture-templates/rust/Cargo.toml
@@ -20,7 +20,7 @@ links = "app"
 [lib]
 name = "host"
 path = "src/lib.rs"
-crate-type = ["staticlib", "rlib"]
+crate-type = ["staticlib", "lib"]
 
 [[bin]]
 name = "host"

--- a/examples/cli/false-interpreter/platform/Cargo.toml
+++ b/examples/cli/false-interpreter/platform/Cargo.toml
@@ -10,7 +10,7 @@ links = "app"
 [lib]
 name = "host"
 path = "src/lib.rs"
-crate-type = ["staticlib", "rlib"]
+crate-type = ["staticlib", "lib"]
 
 [[bin]]
 name = "host"

--- a/examples/glue/rust-platform/Cargo.toml
+++ b/examples/glue/rust-platform/Cargo.toml
@@ -9,7 +9,7 @@ links = "app"
 [lib]
 name = "host"
 path = "src/lib.rs"
-crate-type = ["staticlib", "rlib"]
+crate-type = ["staticlib", "lib"]
 
 [[bin]]
 name = "host"

--- a/examples/gui/breakout/platform/Cargo.toml
+++ b/examples/gui/breakout/platform/Cargo.toml
@@ -8,7 +8,7 @@ version = "0.0.1"
 [lib]
 name = "host"
 path = "src/lib.rs"
-crate-type = ["staticlib", "rlib"]
+crate-type = ["staticlib", "lib"]
 
 [[bin]]
 name = "host"

--- a/examples/gui/platform/Cargo.toml
+++ b/examples/gui/platform/Cargo.toml
@@ -9,7 +9,7 @@ version = "0.0.1"
 [lib]
 name = "host"
 path = "src/lib.rs"
-crate-type = ["staticlib", "rlib"]
+crate-type = ["staticlib", "lib"]
 
 [[bin]]
 name = "host"

--- a/examples/platform-switching/rust-platform/Cargo.toml
+++ b/examples/platform-switching/rust-platform/Cargo.toml
@@ -9,7 +9,7 @@ version = "0.0.1"
 [lib]
 name = "host"
 path = "src/lib.rs"
-crate-type = ["staticlib", "rlib"]
+crate-type = ["staticlib", "lib"]
 
 [[bin]]
 name = "host"

--- a/examples/static-site-gen/platform/Cargo.toml
+++ b/examples/static-site-gen/platform/Cargo.toml
@@ -10,7 +10,7 @@ links = "app"
 [lib]
 name = "host"
 path = "src/lib.rs"
-crate-type = ["staticlib", "rlib"]
+crate-type = ["staticlib", "lib"]
 
 [[bin]]
 name = "host"


### PR DESCRIPTION
I don't know if this matters at all, but I don't think we should use "rlib". The [rust docs](https://doc.rust-lang.org/reference/linkage.html) suggest using "lib" by default. "lib" probably just aliases to "rlib", but it lets the compiler pick what it wants. I don't think this will fix anything, but I am half hopeful it will somehow fix #6121.

Other thing to test that probably won't fix #6121, but is worth just double checking is changing the library name such that the binary and library don't have the same name.