### PR TITLE
Remove Nat uses from Str

### DIFF
--- a/crates/cli/tests/cli_run.rs
+++ b/crates/cli/tests/cli_run.rs
@@ -872,10 +872,10 @@ mod cli_run {
             &[],
             indoc!(
                 r#"
-                This roc file can print it's own source code. The source is:
+                This roc file can print its own source code. The source is:
 
                 app "ingested-file"
-                    packages { pf: "https://github.com/roc-lang/basic-cli/releases/download/0.7.1/Icc3xJoIixF3hCcfXrDwLCu4wQHtNdPyoJkEbkgIElA.tar.br" }
+                    packages { pf: "https://github.com/roc-lang/basic-cli/releases/download/0.8.1/x8URkvfyi9I0QhmVG98roKBUs_AZRkLFwFJVJ3942YA.tar.br" }
                     imports [
                         pf.Stdout,
                         "ingested-file.roc" as ownCode : Str,
@@ -883,7 +883,7 @@ mod cli_run {
                     provides [main] to pf
 
                 main =
-                    Stdout.line "\nThis roc file can print it's own source code. The source is:\n\n\(ownCode)"
+                    Stdout.line "\nThis roc file can print its own source code. The source is:\n\n$(ownCode)"
 
                 "#
             ),

--- a/crates/compiler/builtins/bitcode/src/str.zig
+++ b/crates/compiler/builtins/bitcode/src/str.zig
@@ -1134,8 +1134,8 @@ test "countSegments: overlapping delimiter 2" {
     try expectEqual(segments_count, 3);
 }
 
-pub fn countUtf8Bytes(string: RocStr) callconv(.C) usize {
-    return string.len();
+pub fn countUtf8Bytes(string: RocStr) callconv(.C) u64 {
+    return @intCast(string.len());
 }
 
 pub fn isEmpty(string: RocStr) callconv(.C) bool {
@@ -1146,7 +1146,10 @@ pub fn getCapacity(string: RocStr) callconv(.C) usize {
     return string.getCapacity();
 }
 
-pub fn substringUnsafe(string: RocStr, start: usize, length: usize) callconv(.C) RocStr {
+pub fn substringUnsafe(string: RocStr, start_u64: u64, length_u64: u64) callconv(.C) RocStr {
+    const start: usize = @intCast(start_u64);
+    const length: usize = @intCast(length_u64);
+
     if (string.isSmallStr()) {
         if (start == 0) {
             var output = string;
@@ -1178,8 +1181,8 @@ pub fn substringUnsafe(string: RocStr, start: usize, length: usize) callconv(.C)
     return RocStr.empty();
 }
 
-pub fn getUnsafe(string: RocStr, index: usize) callconv(.C) u8 {
-    return string.getUnchecked(index);
+pub fn getUnsafe(string: RocStr, index: u64) callconv(.C) u8 {
+    return string.getUnchecked(@intCast(index));
 }
 
 test "substringUnsafe: start" {
@@ -1242,7 +1245,8 @@ pub fn startsWith(string: RocStr, prefix: RocStr) callconv(.C) bool {
 }
 
 // Str.repeat
-pub fn repeat(string: RocStr, count: usize) callconv(.C) RocStr {
+pub fn repeat(string: RocStr, count_u64: u64) callconv(.C) RocStr {
+    const count: usize = @intCast(count_u64);
     const bytes_len = string.len();
     const bytes_ptr = string.asU8ptr();
 
@@ -1497,7 +1501,7 @@ inline fn strToBytes(arg: RocStr) RocList {
 }
 
 const FromUtf8Result = extern struct {
-    byte_index: usize,
+    byte_index: u64,
     string: RocStr,
     is_ok: bool,
     problem_code: Utf8ByteProblem,
@@ -1510,14 +1514,17 @@ const CountAndStart = extern struct {
 
 pub fn fromUtf8RangeC(
     list: RocList,
-    start: usize,
-    count: usize,
+    start: u64,
+    count: u64,
     update_mode: UpdateMode,
 ) callconv(.C) FromUtf8Result {
     return fromUtf8Range(list, start, count, update_mode);
 }
 
-pub fn fromUtf8Range(arg: RocList, start: usize, count: usize, update_mode: UpdateMode) FromUtf8Result {
+pub fn fromUtf8Range(arg: RocList, start_u64: u64, count_u64: u64, update_mode: UpdateMode) FromUtf8Result {
+    const start: usize = @intCast(start_u64);
+    const count: usize = @intCast(count_u64);
+
     if (arg.len() == 0 or count == 0) {
         arg.decref(RocStr.alignment);
         return FromUtf8Result{
@@ -1547,7 +1554,7 @@ pub fn fromUtf8Range(arg: RocList, start: usize, count: usize, update_mode: Upda
         return FromUtf8Result{
             .is_ok = false,
             .string = RocStr.empty(),
-            .byte_index = temp.index,
+            .byte_index = @intCast(temp.index),
             .problem_code = temp.problem,
         };
     }
@@ -1674,7 +1681,7 @@ fn sliceHelp(bytes: [*]const u8, length: usize) RocList {
 }
 
 fn toErrUtf8ByteResponse(index: usize, problem: Utf8ByteProblem) FromUtf8Result {
-    return FromUtf8Result{ .is_ok = false, .string = RocStr.empty(), .byte_index = index, .problem_code = problem };
+    return FromUtf8Result{ .is_ok = false, .string = RocStr.empty(), .byte_index = @as(index, @intCast(u64)), .problem_code = problem };
 }
 
 // NOTE on memory: the validate function consumes a RC token of the input. Since
@@ -2367,8 +2374,10 @@ test "capacity: big string" {
     try expect(data.getCapacity() >= data_bytes.len);
 }
 
-pub fn reserve(string: RocStr, spare: usize) callconv(.C) RocStr {
+pub fn reserve(string: RocStr, spare_u64: u64) callconv(.C) RocStr {
     const old_length = string.len();
+    const spare: usize = @intCast(spare_u64);
+
     if (string.getCapacity() >= old_length + spare) {
         return string;
     } else {
@@ -2378,8 +2387,8 @@ pub fn reserve(string: RocStr, spare: usize) callconv(.C) RocStr {
     }
 }
 
-pub fn withCapacity(capacity: usize) callconv(.C) RocStr {
-    var str = RocStr.allocate(capacity);
+pub fn withCapacity(capacity: u64) callconv(.C) RocStr {
+    var str = RocStr.allocate(@intCast(capacity));
     str.setLen(0);
     return str;
 }

--- a/crates/compiler/builtins/bitcode/src/str.zig
+++ b/crates/compiler/builtins/bitcode/src/str.zig
@@ -1681,7 +1681,7 @@ fn sliceHelp(bytes: [*]const u8, length: usize) RocList {
 }
 
 fn toErrUtf8ByteResponse(index: usize, problem: Utf8ByteProblem) FromUtf8Result {
-    return FromUtf8Result{ .is_ok = false, .string = RocStr.empty(), .byte_index = @as(index, @intCast(u64)), .problem_code = problem };
+    return FromUtf8Result{ .is_ok = false, .string = RocStr.empty(), .byte_index = @as(u64, @intCast(index)), .problem_code = problem };
 }
 
 // NOTE on memory: the validate function consumes a RC token of the input. Since

--- a/crates/compiler/builtins/roc/Result.roc
+++ b/crates/compiler/builtins/roc/Result.roc
@@ -84,8 +84,8 @@ try = \result, transform ->
 ## function on the value the `Err` holds. Then returns that new result. If the
 ## result is `Ok`, this has no effect. Use `try` to transform an `Ok`.
 ## ```
-## Result.onErr (Ok 10) \errorNum -> Str.toNat errorNum
-## Result.onErr (Err "42") \errorNum -> Str.toNat errorNum
+## Result.onErr (Ok 10) \errorNum -> Str.toU64 errorNum
+## Result.onErr (Err "42") \errorNum -> Str.toU64 errorNum
 ## ```
 onErr : Result a err, (err -> Result a otherErr) -> Result a otherErr
 onErr = \result, transform ->

--- a/crates/compiler/builtins/roc/Str.roc
+++ b/crates/compiler/builtins/roc/Str.roc
@@ -347,7 +347,6 @@ interface Str
         toDec,
         toF64,
         toF32,
-        toNat,
         toU128,
         toI128,
         toU64,
@@ -375,7 +374,7 @@ interface Str
         Bool.{ Bool, Eq },
         Result.{ Result },
         List,
-        Num.{ Nat, Num, U8, U16, U32, U64, U128, I8, I16, I32, I64, I128, F32, F64, Dec },
+        Num.{ Num, U8, U16, U32, U64, U128, I8, I16, I32, I64, I128, F32, F64, Dec },
     ]
 
 Utf8ByteProblem : [
@@ -387,7 +386,7 @@ Utf8ByteProblem : [
     EncodesSurrogateHalf,
 ]
 
-Utf8Problem : { byteIndex : Nat, problem : Utf8ByteProblem }
+Utf8Problem : { byteIndex : U64, problem : Utf8ByteProblem }
 
 ## Returns [Bool.true] if the string is empty, and [Bool.false] otherwise.
 ## ```
@@ -428,7 +427,7 @@ concat : Str, Str -> Str
 ## the cost of using more memory than is necessary.
 ##
 ## For more details on how the performance optimization works, see [Str.reserve].
-withCapacity : Nat -> Str
+withCapacity : U64 -> Str
 
 ## Increase a string's capacity by at least the given number of additional bytes.
 ##
@@ -486,7 +485,7 @@ withCapacity : Nat -> Str
 ## reallocations but will also waste a lot of memory!
 ##
 ## If you plan to use [Str.reserve] on an empty string, it's generally better to use [Str.withCapacity] instead.
-reserve : Str, Nat -> Str
+reserve : Str, U64 -> Str
 
 ## Combines a [List] of strings into a single string, with a separator
 ## string in between each.
@@ -516,7 +515,7 @@ split : Str, Str -> List Str
 ## expect Str.repeat "" 10 == ""
 ## expect Str.repeat "anything" 0 == ""
 ## ```
-repeat : Str, Nat -> Str
+repeat : Str, U64 -> Str
 
 ## Returns a [List] of the string's [U8] UTF-8 [code units](https://unicode.org/glossary/#code_unit).
 ## (To split the string into a [List] of smaller [Str] values instead of [U8] values,
@@ -540,9 +539,9 @@ toUtf8 : Str -> List U8
 ## expect Str.fromUtf8 [] == Ok ""
 ## expect Str.fromUtf8 [255] |> Result.isErr
 ## ```
-fromUtf8 : List U8 -> Result Str [BadUtf8 Utf8ByteProblem Nat]
+fromUtf8 : List U8 -> Result Str [BadUtf8 Utf8ByteProblem U64]
 fromUtf8 = \bytes ->
-    result = fromUtf8RangeLowlevel bytes 0 (List.len bytes)
+    result = fromUtf8RangeLowlevel bytes 0 (List.len bytes |> Num.toU64)
 
     if result.cIsOk then
         Ok result.bString
@@ -560,9 +559,9 @@ expect (Str.fromUtf8 [255]) |> Result.isErr
 ## ```
 ## expect Str.fromUtf8Range [72, 105, 80, 103] { start : 0, count : 2 } == Ok "Hi"
 ## ```
-fromUtf8Range : List U8, { start : Nat, count : Nat } -> Result Str [BadUtf8 Utf8ByteProblem Nat, OutOfBounds]
+fromUtf8Range : List U8, { start : U64, count : U64 } -> Result Str [BadUtf8 Utf8ByteProblem U64, OutOfBounds]
 fromUtf8Range = \bytes, config ->
-    if Num.addSaturated config.start config.count <= List.len bytes then
+    if Num.addSaturated config.start config.count <= (List.len bytes |> Num.toU64) then
         result = fromUtf8RangeLowlevel bytes config.start config.count
 
         if result.cIsOk then
@@ -579,13 +578,13 @@ expect (Str.fromUtf8Range [] { start: 0, count: 0 }) == Ok ""
 expect (Str.fromUtf8Range [72, 105, 80, 103] { start: 2, count: 3 }) |> Result.isErr
 
 FromUtf8Result : {
-    aByteIndex : Nat,
+    aByteIndex : U64,
     bString : Str,
     cIsOk : Bool,
     dProblemCode : Utf8ByteProblem,
 }
 
-fromUtf8RangeLowlevel : List U8, Nat, Nat -> FromUtf8Result
+fromUtf8RangeLowlevel : List U8, U64, U64 -> FromUtf8Result
 
 ## Check if the given [Str] starts with a value.
 ## ```
@@ -649,25 +648,6 @@ toF64 = \string -> strToNumHelp string
 ## ```
 toF32 : Str -> Result F32 [InvalidNumStr]
 toF32 = \string -> strToNumHelp string
-
-## Convert a [Str] to a [Nat]. If the given number doesn't fit in [Nat], it will be [truncated](https://www.ualberta.ca/computing-science/media-library/teaching-resources/java/truncation-rounding.html).
-## [Nat] has a different maximum number depending on the system you're building
-## for, so this may give a different answer on different systems.
-##
-## For example, on a 32-bit system, `Num.maxNat` will return the same answer as
-## `Num.maxU32`. This means that calling `Str.toNat "9_000_000_000"` on a 32-bit
-## system will return `Num.maxU32` instead of 9 billion, because 9 billion is
-## larger than `Num.maxU32` and will not fit in a [Nat] on a 32-bit system.
-##
-## Calling `Str.toNat "9_000_000_000"` on a 64-bit system will return
-## the [Nat] value of 9_000_000_000. This is because on a 64-bit system, [Nat] can
-## hold up to `Num.maxU64`, and 9_000_000_000 is smaller than `Num.maxU64`.
-## ```
-## expect Str.toNat "9_000_000_000" == Ok 9000000000
-## expect Str.toNat "not a number" == Err InvalidNumStr
-## ```
-toNat : Str -> Result Nat [InvalidNumStr]
-toNat = \string -> strToNumHelp string
 
 ## Encode a [Str] to an unsigned [U128] integer. A [U128] value can hold numbers
 ## from `0` to `340_282_366_920_938_463_463_374_607_431_768_211_455` (over
@@ -788,16 +768,16 @@ toI8 : Str -> Result I8 [InvalidNumStr]
 toI8 = \string -> strToNumHelp string
 
 ## Get the byte at the given index, without performing a bounds check.
-getUnsafe : Str, Nat -> U8
+getUnsafe : Str, U64 -> U8
 
 ## Gives the number of bytes in a [Str] value.
 ## ```
 ## expect Str.countUtf8Bytes "Hello World" == 11
 ## ```
-countUtf8Bytes : Str -> Nat
+countUtf8Bytes : Str -> U64
 
 ## string slice that does not do bounds checking or utf-8 verification
-substringUnsafe : Str, Nat, Nat -> Str
+substringUnsafe : Str, U64, U64 -> Str
 
 ## Returns the given [Str] with each occurrence of a substring replaced.
 ## If the substring is not found, returns the original string.
@@ -905,7 +885,7 @@ expect splitFirst "hullabaloo" "ab" == Ok { before: "hull", after: "aloo" }
 # splitFirst when needle is haystack
 expect splitFirst "foo" "foo" == Ok { before: "", after: "" }
 
-firstMatch : Str, Str -> [Some Nat, None]
+firstMatch : Str, Str -> [Some U64, None]
 firstMatch = \haystack, needle ->
     haystackLength = Str.countUtf8Bytes haystack
     needleLength = Str.countUtf8Bytes needle
@@ -913,7 +893,7 @@ firstMatch = \haystack, needle ->
 
     firstMatchHelp haystack needle 0 lastPossible
 
-firstMatchHelp : Str, Str, Nat, Nat -> [Some Nat, None]
+firstMatchHelp : Str, Str, U64, U64 -> [Some U64, None]
 firstMatchHelp = \haystack, needle, index, lastPossible ->
     if index <= lastPossible then
         if matchesAt haystack index needle then
@@ -956,7 +936,7 @@ expect Str.splitLast "hullabaloo" "ab" == Ok { before: "hull", after: "aloo" }
 # splitLast when needle is haystack
 expect Str.splitLast "foo" "foo" == Ok { before: "", after: "" }
 
-lastMatch : Str, Str -> [Some Nat, None]
+lastMatch : Str, Str -> [Some U64, None]
 lastMatch = \haystack, needle ->
     haystackLength = Str.countUtf8Bytes haystack
     needleLength = Str.countUtf8Bytes needle
@@ -964,7 +944,7 @@ lastMatch = \haystack, needle ->
 
     lastMatchHelp haystack needle lastPossibleIndex
 
-lastMatchHelp : Str, Str, Nat -> [Some Nat, None]
+lastMatchHelp : Str, Str, U64 -> [Some U64, None]
 lastMatchHelp = \haystack, needle, index ->
     if matchesAt haystack index needle then
         Some index
@@ -978,7 +958,7 @@ lastMatchHelp = \haystack, needle, index ->
 
 min = \x, y -> if x < y then x else y
 
-matchesAt : Str, Nat, Str -> Bool
+matchesAt : Str, U64, Str -> Bool
 matchesAt = \haystack, haystackIndex, needle ->
     haystackLength = Str.countUtf8Bytes haystack
     needleLength = Str.countUtf8Bytes needle
@@ -1019,15 +999,15 @@ matchesAtHelp = \state ->
 ## state for each byte. The index for that byte in the string is provided
 ## to the update function.
 ## ```
-## f : List U8, U8, Nat -> List U8
+## f : List U8, U8, U64 -> List U8
 ## f = \state, byte, _ -> List.append state byte
 ## expect Str.walkUtf8WithIndex "ABC" [] f == [65, 66, 67]
 ## ```
-walkUtf8WithIndex : Str, state, (state, U8, Nat -> state) -> state
+walkUtf8WithIndex : Str, state, (state, U8, U64 -> state) -> state
 walkUtf8WithIndex = \string, state, step ->
     walkUtf8WithIndexHelp string state step 0 (Str.countUtf8Bytes string)
 
-walkUtf8WithIndexHelp : Str, state, (state, U8, Nat -> state), Nat, Nat -> state
+walkUtf8WithIndexHelp : Str, state, (state, U8, U64 -> state), U64, U64 -> state
 walkUtf8WithIndexHelp = \string, state, step, index, length ->
     if index < length then
         byte = Str.getUnsafe string index
@@ -1051,7 +1031,7 @@ walkUtf8 : Str, state, (state, U8 -> state) -> state
 walkUtf8 = \str, initial, step ->
     walkUtf8Help str initial step 0 (Str.countUtf8Bytes str)
 
-walkUtf8Help : Str, state, (state, U8 -> state), Nat, Nat -> state
+walkUtf8Help : Str, state, (state, U8 -> state), U64, U64 -> state
 walkUtf8Help = \str, state, step, index, length ->
     if index < length then
         byte = Str.getUnsafe str index

--- a/crates/compiler/load_internal/src/file.rs
+++ b/crates/compiler/load_internal/src/file.rs
@@ -4864,7 +4864,7 @@ fn import_variable_for_symbol(
                             // Today we define builtins in each module that uses them
                             // so even though they have a different module name from
                             // the surrounding module, they are not technically imported
-                            debug_assert!(symbol.is_builtin());
+                            debug_assert!(symbol.is_builtin(), "The symbol {:?} was not found and was assumed to be a builtin, but it wasn't a builtin.", symbol);
                             return;
                         }
                         AbilityMemberMustBeAvailable => {

--- a/crates/compiler/test_gen/src/gen_str.rs
+++ b/crates/compiler/test_gen/src/gen_str.rs
@@ -1371,11 +1371,11 @@ fn str_to_nat() {
     assert_evals_to!(
         indoc!(
             r#"
-            Str.toNat "1"
+            Str.toU64 "1"
             "#
         ),
         RocResult::ok(1),
-        RocResult<usize, ()>
+        RocResult<u64, ()>
     );
 }
 

--- a/crates/compiler/test_gen/src/wasm_str.rs
+++ b/crates/compiler/test_gen/src/wasm_str.rs
@@ -1029,21 +1029,6 @@ fn str_trim_end_small_to_small_shared() {
 }
 
 #[test]
-fn str_to_nat() {
-    assert_evals_to!(
-        indoc!(
-            r#"
-             when Str.toNat "1" is
-                 Ok n -> n
-                 Err _ -> 0
-                "#
-        ),
-        1,
-        usize
-    );
-}
-
-#[test]
 fn str_to_i128() {
     assert_evals_to!(
         indoc!(

--- a/crates/compiler/test_mono/generated/compose_recursive_lambda_set_productive_nullable_wrapped.txt
+++ b/crates/compiler/test_mono/generated/compose_recursive_lambda_set_productive_nullable_wrapped.txt
@@ -40,8 +40,8 @@ procedure Num.51 (#Attr.2, #Attr.3):
     ret Num.297;
 
 procedure Str.3 (#Attr.2, #Attr.3):
-    let Str.253 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
-    ret Str.253;
+    let Str.252 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
+    ret Str.252;
 
 procedure Test.1 (Test.5):
     ret Test.5;

--- a/crates/compiler/test_mono/generated/dbg_in_expect.txt
+++ b/crates/compiler/test_mono/generated/dbg_in_expect.txt
@@ -42,8 +42,8 @@ procedure Inspect.62 (Inspect.306):
     ret Inspect.306;
 
 procedure Str.3 (#Attr.2, #Attr.3):
-    let Str.251 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
-    ret Str.251;
+    let Str.250 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
+    ret Str.250;
 
 procedure Test.1 ():
     let Test.4 : Str = "";

--- a/crates/compiler/test_mono/generated/dbg_str_followed_by_number.txt
+++ b/crates/compiler/test_mono/generated/dbg_str_followed_by_number.txt
@@ -38,8 +38,8 @@ procedure Inspect.62 (Inspect.306):
     ret Inspect.306;
 
 procedure Str.3 (#Attr.2, #Attr.3):
-    let Str.251 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
-    ret Str.251;
+    let Str.250 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
+    ret Str.250;
 
 procedure Test.0 ():
     let Test.3 : Str = "";

--- a/crates/compiler/test_mono/generated/encode_derived_nested_record_string.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_nested_record_string.txt
@@ -176,7 +176,7 @@ procedure List.8 (#Attr.2, #Attr.3):
     let List.658 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
     ret List.658;
 
-procedure List.80 (#Derived_gen.50, #Derived_gen.51, #Derived_gen.52, #Derived_gen.53, #Derived_gen.54):
+procedure List.80 (#Derived_gen.23, #Derived_gen.24, #Derived_gen.25, #Derived_gen.26, #Derived_gen.27):
     joinpoint List.685 List.489 List.490 List.491 List.492 List.493:
         let List.687 : Int1 = CallByName Num.22 List.492 List.493;
         if List.687 then
@@ -200,40 +200,9 @@ procedure List.80 (#Derived_gen.50, #Derived_gen.51, #Derived_gen.52, #Derived_g
             let List.686 : [C {U64, Int1}, C {U64, Int1}] = TagId(1) List.490;
             ret List.686;
     in
-    jump List.685 #Derived_gen.50 #Derived_gen.51 #Derived_gen.52 #Derived_gen.53 #Derived_gen.54;
+    jump List.685 #Derived_gen.23 #Derived_gen.24 #Derived_gen.25 #Derived_gen.26 #Derived_gen.27;
 
-procedure List.90 (#Derived_gen.26, #Derived_gen.27, #Derived_gen.28, #Derived_gen.29, #Derived_gen.30):
-    joinpoint List.641 List.161 List.162 List.163 List.164 List.165:
-        let List.643 : Int1 = CallByName Num.22 List.164 List.165;
-        if List.643 then
-            let List.647 : U8 = CallByName List.66 List.161 List.164;
-            let List.166 : List U8 = CallByName TotallyNotJson.183 List.162 List.647;
-            let List.646 : U64 = 1i64;
-            let List.645 : U64 = CallByName Num.51 List.164 List.646;
-            jump List.641 List.161 List.166 List.163 List.645 List.165;
-        else
-            dec List.161;
-            ret List.162;
-    in
-    jump List.641 #Derived_gen.26 #Derived_gen.27 #Derived_gen.28 #Derived_gen.29 #Derived_gen.30;
-
-procedure List.90 (#Derived_gen.40, #Derived_gen.41, #Derived_gen.42, #Derived_gen.43, #Derived_gen.44):
-    joinpoint List.595 List.161 List.162 List.163 List.164 List.165:
-        let List.597 : Int1 = CallByName Num.22 List.164 List.165;
-        if List.597 then
-            let List.601 : {Str, Str} = CallByName List.66 List.161 List.164;
-            inc List.601;
-            let List.166 : {List U8, U64} = CallByName TotallyNotJson.203 List.162 List.601;
-            let List.600 : U64 = 1i64;
-            let List.599 : U64 = CallByName Num.51 List.164 List.600;
-            jump List.595 List.161 List.166 List.163 List.599 List.165;
-        else
-            dec List.161;
-            ret List.162;
-    in
-    jump List.595 #Derived_gen.40 #Derived_gen.41 #Derived_gen.42 #Derived_gen.43 #Derived_gen.44;
-
-procedure List.90 (#Derived_gen.45, #Derived_gen.46, #Derived_gen.47, #Derived_gen.48, #Derived_gen.49):
+procedure List.90 (#Derived_gen.34, #Derived_gen.35, #Derived_gen.36, #Derived_gen.37, #Derived_gen.38):
     joinpoint List.629 List.161 List.162 List.163 List.164 List.165:
         let List.631 : Int1 = CallByName Num.22 List.164 List.165;
         if List.631 then
@@ -247,69 +216,105 @@ procedure List.90 (#Derived_gen.45, #Derived_gen.46, #Derived_gen.47, #Derived_g
             dec List.161;
             ret List.162;
     in
-    jump List.629 #Derived_gen.45 #Derived_gen.46 #Derived_gen.47 #Derived_gen.48 #Derived_gen.49;
+    jump List.629 #Derived_gen.34 #Derived_gen.35 #Derived_gen.36 #Derived_gen.37 #Derived_gen.38;
+
+procedure List.90 (#Derived_gen.39, #Derived_gen.40, #Derived_gen.41, #Derived_gen.42, #Derived_gen.43):
+    joinpoint List.641 List.161 List.162 List.163 List.164 List.165:
+        let List.643 : Int1 = CallByName Num.22 List.164 List.165;
+        if List.643 then
+            let List.647 : U8 = CallByName List.66 List.161 List.164;
+            let List.166 : List U8 = CallByName TotallyNotJson.183 List.162 List.647;
+            let List.646 : U64 = 1i64;
+            let List.645 : U64 = CallByName Num.51 List.164 List.646;
+            jump List.641 List.161 List.166 List.163 List.645 List.165;
+        else
+            dec List.161;
+            ret List.162;
+    in
+    jump List.641 #Derived_gen.39 #Derived_gen.40 #Derived_gen.41 #Derived_gen.42 #Derived_gen.43;
+
+procedure List.90 (#Derived_gen.47, #Derived_gen.48, #Derived_gen.49, #Derived_gen.50, #Derived_gen.51):
+    joinpoint List.595 List.161 List.162 List.163 List.164 List.165:
+        let List.597 : Int1 = CallByName Num.22 List.164 List.165;
+        if List.597 then
+            let List.601 : {Str, Str} = CallByName List.66 List.161 List.164;
+            inc List.601;
+            let List.166 : {List U8, U64} = CallByName TotallyNotJson.203 List.162 List.601;
+            let List.600 : U64 = 1i64;
+            let List.599 : U64 = CallByName Num.51 List.164 List.600;
+            jump List.595 List.161 List.166 List.163 List.599 List.165;
+        else
+            dec List.161;
+            ret List.162;
+    in
+    jump List.595 #Derived_gen.47 #Derived_gen.48 #Derived_gen.49 #Derived_gen.50 #Derived_gen.51;
 
 procedure Num.127 (#Attr.2):
-    let Num.312 : U8 = lowlevel NumIntCast #Attr.2;
-    ret Num.312;
-
-procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.316 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.316;
-
-procedure Num.20 (#Attr.2, #Attr.3):
-    let Num.313 : U64 = lowlevel NumSub #Attr.2 #Attr.3;
+    let Num.313 : U8 = lowlevel NumIntCast #Attr.2;
     ret Num.313;
 
+procedure Num.133 (#Attr.2):
+    let Num.297 : U64 = lowlevel NumIntCast #Attr.2;
+    ret Num.297;
+
+procedure Num.19 (#Attr.2, #Attr.3):
+    let Num.317 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.317;
+
+procedure Num.20 (#Attr.2, #Attr.3):
+    let Num.314 : U64 = lowlevel NumSub #Attr.2 #Attr.3;
+    ret Num.314;
+
 procedure Num.21 (#Attr.2, #Attr.3):
-    let Num.318 : U64 = lowlevel NumMul #Attr.2 #Attr.3;
-    ret Num.318;
+    let Num.319 : U64 = lowlevel NumMul #Attr.2 #Attr.3;
+    ret Num.319;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.324 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.324;
-
-procedure Num.24 (#Attr.2, #Attr.3):
-    let Num.326 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
-    ret Num.326;
-
-procedure Num.51 (#Attr.2, #Attr.3):
-    let Num.321 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
-    ret Num.321;
-
-procedure Num.75 (#Attr.2, #Attr.3):
-    let Num.325 : U64 = lowlevel NumSubWrap #Attr.2 #Attr.3;
+    let Num.325 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
     ret Num.325;
 
+procedure Num.24 (#Attr.2, #Attr.3):
+    let Num.327 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
+    ret Num.327;
+
+procedure Num.51 (#Attr.2, #Attr.3):
+    let Num.322 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
+    ret Num.322;
+
+procedure Num.75 (#Attr.2, #Attr.3):
+    let Num.326 : U64 = lowlevel NumSubWrap #Attr.2 #Attr.3;
+    ret Num.326;
+
 procedure Num.94 (#Attr.2, #Attr.3):
-    let Num.317 : U64 = lowlevel NumDivCeilUnchecked #Attr.2 #Attr.3;
-    ret Num.317;
+    let Num.318 : U64 = lowlevel NumDivCeilUnchecked #Attr.2 #Attr.3;
+    ret Num.318;
 
 procedure Str.12 (#Attr.2):
     let Str.263 : List U8 = lowlevel StrToUtf8 #Attr.2;
     ret Str.263;
 
 procedure Str.43 (#Attr.2, #Attr.3, #Attr.4):
-    let Str.260 : {U64, Str, Int1, U8} = lowlevel StrFromUtf8Range #Attr.2 #Attr.3 #Attr.4;
-    ret Str.260;
+    let Str.259 : {U64, Str, Int1, U8} = lowlevel StrFromUtf8Range #Attr.2 #Attr.3 #Attr.4;
+    ret Str.259;
 
 procedure Str.9 (Str.68):
-    let Str.258 : U64 = 0i64;
-    let Str.259 : U64 = CallByName List.6 Str.68;
-    let Str.69 : {U64, Str, Int1, U8} = CallByName Str.43 Str.68 Str.258 Str.259;
-    let Str.255 : Int1 = StructAtIndex 2 Str.69;
-    if Str.255 then
-        let Str.257 : Str = StructAtIndex 1 Str.69;
-        let Str.256 : [C {U64, U8}, C Str] = TagId(1) Str.257;
-        ret Str.256;
+    let Str.257 : U64 = 0i64;
+    let Str.260 : U64 = CallByName List.6 Str.68;
+    let Str.258 : U64 = CallByName Num.133 Str.260;
+    let Str.69 : {U64, Str, Int1, U8} = CallByName Str.43 Str.68 Str.257 Str.258;
+    let Str.254 : Int1 = StructAtIndex 2 Str.69;
+    if Str.254 then
+        let Str.256 : Str = StructAtIndex 1 Str.69;
+        let Str.255 : [C {U64, U8}, C Str] = TagId(1) Str.256;
+        ret Str.255;
     else
-        let Str.253 : U8 = StructAtIndex 3 Str.69;
-        let Str.254 : U64 = StructAtIndex 0 Str.69;
+        let Str.252 : U8 = StructAtIndex 3 Str.69;
+        let Str.253 : U64 = StructAtIndex 0 Str.69;
         let #Derived_gen.55 : Str = StructAtIndex 1 Str.69;
         dec #Derived_gen.55;
-        let Str.252 : {U64, U8} = Struct {Str.254, Str.253};
-        let Str.251 : [C {U64, U8}, C Str] = TagId(0) Str.252;
-        ret Str.251;
+        let Str.251 : {U64, U8} = Struct {Str.253, Str.252};
+        let Str.250 : [C {U64, U8}, C Str] = TagId(0) Str.251;
+        ret Str.250;
 
 procedure TotallyNotJson.150 (TotallyNotJson.151, TotallyNotJson.1043, TotallyNotJson.149):
     let TotallyNotJson.1046 : List U8 = CallByName TotallyNotJson.26 TotallyNotJson.149;

--- a/crates/compiler/test_mono/generated/encode_derived_record_one_field_string.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_record_one_field_string.txt
@@ -135,7 +135,7 @@ procedure List.8 (#Attr.2, #Attr.3):
     let List.624 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
     ret List.624;
 
-procedure List.80 (#Derived_gen.18, #Derived_gen.19, #Derived_gen.20, #Derived_gen.21, #Derived_gen.22):
+procedure List.80 (#Derived_gen.21, #Derived_gen.22, #Derived_gen.23, #Derived_gen.24, #Derived_gen.25):
     joinpoint List.651 List.489 List.490 List.491 List.492 List.493:
         let List.653 : Int1 = CallByName Num.22 List.492 List.493;
         if List.653 then
@@ -159,7 +159,7 @@ procedure List.80 (#Derived_gen.18, #Derived_gen.19, #Derived_gen.20, #Derived_g
             let List.652 : [C {U64, Int1}, C {U64, Int1}] = TagId(1) List.490;
             ret List.652;
     in
-    jump List.651 #Derived_gen.18 #Derived_gen.19 #Derived_gen.20 #Derived_gen.21 #Derived_gen.22;
+    jump List.651 #Derived_gen.21 #Derived_gen.22 #Derived_gen.23 #Derived_gen.24 #Derived_gen.25;
 
 procedure List.90 (#Derived_gen.10, #Derived_gen.11, #Derived_gen.12, #Derived_gen.13, #Derived_gen.14):
     joinpoint List.607 List.161 List.162 List.163 List.164 List.165:
@@ -176,7 +176,7 @@ procedure List.90 (#Derived_gen.10, #Derived_gen.11, #Derived_gen.12, #Derived_g
     in
     jump List.607 #Derived_gen.10 #Derived_gen.11 #Derived_gen.12 #Derived_gen.13 #Derived_gen.14;
 
-procedure List.90 (#Derived_gen.26, #Derived_gen.27, #Derived_gen.28, #Derived_gen.29, #Derived_gen.30):
+procedure List.90 (#Derived_gen.29, #Derived_gen.30, #Derived_gen.31, #Derived_gen.32, #Derived_gen.33):
     joinpoint List.595 List.161 List.162 List.163 List.164 List.165:
         let List.597 : Int1 = CallByName Num.22 List.164 List.165;
         if List.597 then
@@ -190,69 +190,74 @@ procedure List.90 (#Derived_gen.26, #Derived_gen.27, #Derived_gen.28, #Derived_g
             dec List.161;
             ret List.162;
     in
-    jump List.595 #Derived_gen.26 #Derived_gen.27 #Derived_gen.28 #Derived_gen.29 #Derived_gen.30;
+    jump List.595 #Derived_gen.29 #Derived_gen.30 #Derived_gen.31 #Derived_gen.32 #Derived_gen.33;
 
 procedure Num.127 (#Attr.2):
-    let Num.302 : U8 = lowlevel NumIntCast #Attr.2;
-    ret Num.302;
-
-procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.306 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.306;
-
-procedure Num.20 (#Attr.2, #Attr.3):
-    let Num.303 : U64 = lowlevel NumSub #Attr.2 #Attr.3;
+    let Num.303 : U8 = lowlevel NumIntCast #Attr.2;
     ret Num.303;
 
+procedure Num.133 (#Attr.2):
+    let Num.297 : U64 = lowlevel NumIntCast #Attr.2;
+    ret Num.297;
+
+procedure Num.19 (#Attr.2, #Attr.3):
+    let Num.307 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.307;
+
+procedure Num.20 (#Attr.2, #Attr.3):
+    let Num.304 : U64 = lowlevel NumSub #Attr.2 #Attr.3;
+    ret Num.304;
+
 procedure Num.21 (#Attr.2, #Attr.3):
-    let Num.308 : U64 = lowlevel NumMul #Attr.2 #Attr.3;
-    ret Num.308;
+    let Num.309 : U64 = lowlevel NumMul #Attr.2 #Attr.3;
+    ret Num.309;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.314 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.314;
-
-procedure Num.24 (#Attr.2, #Attr.3):
-    let Num.316 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
-    ret Num.316;
-
-procedure Num.51 (#Attr.2, #Attr.3):
-    let Num.311 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
-    ret Num.311;
-
-procedure Num.75 (#Attr.2, #Attr.3):
-    let Num.315 : U64 = lowlevel NumSubWrap #Attr.2 #Attr.3;
+    let Num.315 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
     ret Num.315;
 
+procedure Num.24 (#Attr.2, #Attr.3):
+    let Num.317 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
+    ret Num.317;
+
+procedure Num.51 (#Attr.2, #Attr.3):
+    let Num.312 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
+    ret Num.312;
+
+procedure Num.75 (#Attr.2, #Attr.3):
+    let Num.316 : U64 = lowlevel NumSubWrap #Attr.2 #Attr.3;
+    ret Num.316;
+
 procedure Num.94 (#Attr.2, #Attr.3):
-    let Num.307 : U64 = lowlevel NumDivCeilUnchecked #Attr.2 #Attr.3;
-    ret Num.307;
+    let Num.308 : U64 = lowlevel NumDivCeilUnchecked #Attr.2 #Attr.3;
+    ret Num.308;
 
 procedure Str.12 (#Attr.2):
     let Str.262 : List U8 = lowlevel StrToUtf8 #Attr.2;
     ret Str.262;
 
 procedure Str.43 (#Attr.2, #Attr.3, #Attr.4):
-    let Str.260 : {U64, Str, Int1, U8} = lowlevel StrFromUtf8Range #Attr.2 #Attr.3 #Attr.4;
-    ret Str.260;
+    let Str.259 : {U64, Str, Int1, U8} = lowlevel StrFromUtf8Range #Attr.2 #Attr.3 #Attr.4;
+    ret Str.259;
 
 procedure Str.9 (Str.68):
-    let Str.258 : U64 = 0i64;
-    let Str.259 : U64 = CallByName List.6 Str.68;
-    let Str.69 : {U64, Str, Int1, U8} = CallByName Str.43 Str.68 Str.258 Str.259;
-    let Str.255 : Int1 = StructAtIndex 2 Str.69;
-    if Str.255 then
-        let Str.257 : Str = StructAtIndex 1 Str.69;
-        let Str.256 : [C {U64, U8}, C Str] = TagId(1) Str.257;
-        ret Str.256;
+    let Str.257 : U64 = 0i64;
+    let Str.260 : U64 = CallByName List.6 Str.68;
+    let Str.258 : U64 = CallByName Num.133 Str.260;
+    let Str.69 : {U64, Str, Int1, U8} = CallByName Str.43 Str.68 Str.257 Str.258;
+    let Str.254 : Int1 = StructAtIndex 2 Str.69;
+    if Str.254 then
+        let Str.256 : Str = StructAtIndex 1 Str.69;
+        let Str.255 : [C {U64, U8}, C Str] = TagId(1) Str.256;
+        ret Str.255;
     else
-        let Str.253 : U8 = StructAtIndex 3 Str.69;
-        let Str.254 : U64 = StructAtIndex 0 Str.69;
+        let Str.252 : U8 = StructAtIndex 3 Str.69;
+        let Str.253 : U64 = StructAtIndex 0 Str.69;
         let #Derived_gen.34 : Str = StructAtIndex 1 Str.69;
         dec #Derived_gen.34;
-        let Str.252 : {U64, U8} = Struct {Str.254, Str.253};
-        let Str.251 : [C {U64, U8}, C Str] = TagId(0) Str.252;
-        ret Str.251;
+        let Str.251 : {U64, U8} = Struct {Str.253, Str.252};
+        let Str.250 : [C {U64, U8}, C Str] = TagId(0) Str.251;
+        ret Str.250;
 
 procedure TotallyNotJson.150 (TotallyNotJson.151, TotallyNotJson.1009, TotallyNotJson.149):
     let TotallyNotJson.1012 : List U8 = CallByName TotallyNotJson.26 TotallyNotJson.149;

--- a/crates/compiler/test_mono/generated/encode_derived_record_two_field_strings.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_record_two_field_strings.txt
@@ -142,7 +142,7 @@ procedure List.8 (#Attr.2, #Attr.3):
     let List.624 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
     ret List.624;
 
-procedure List.80 (#Derived_gen.22, #Derived_gen.23, #Derived_gen.24, #Derived_gen.25, #Derived_gen.26):
+procedure List.80 (#Derived_gen.25, #Derived_gen.26, #Derived_gen.27, #Derived_gen.28, #Derived_gen.29):
     joinpoint List.651 List.489 List.490 List.491 List.492 List.493:
         let List.653 : Int1 = CallByName Num.22 List.492 List.493;
         if List.653 then
@@ -166,7 +166,7 @@ procedure List.80 (#Derived_gen.22, #Derived_gen.23, #Derived_gen.24, #Derived_g
             let List.652 : [C {U64, Int1}, C {U64, Int1}] = TagId(1) List.490;
             ret List.652;
     in
-    jump List.651 #Derived_gen.22 #Derived_gen.23 #Derived_gen.24 #Derived_gen.25 #Derived_gen.26;
+    jump List.651 #Derived_gen.25 #Derived_gen.26 #Derived_gen.27 #Derived_gen.28 #Derived_gen.29;
 
 procedure List.90 (#Derived_gen.14, #Derived_gen.15, #Derived_gen.16, #Derived_gen.17, #Derived_gen.18):
     joinpoint List.607 List.161 List.162 List.163 List.164 List.165:
@@ -183,7 +183,7 @@ procedure List.90 (#Derived_gen.14, #Derived_gen.15, #Derived_gen.16, #Derived_g
     in
     jump List.607 #Derived_gen.14 #Derived_gen.15 #Derived_gen.16 #Derived_gen.17 #Derived_gen.18;
 
-procedure List.90 (#Derived_gen.30, #Derived_gen.31, #Derived_gen.32, #Derived_gen.33, #Derived_gen.34):
+procedure List.90 (#Derived_gen.33, #Derived_gen.34, #Derived_gen.35, #Derived_gen.36, #Derived_gen.37):
     joinpoint List.595 List.161 List.162 List.163 List.164 List.165:
         let List.597 : Int1 = CallByName Num.22 List.164 List.165;
         if List.597 then
@@ -197,69 +197,74 @@ procedure List.90 (#Derived_gen.30, #Derived_gen.31, #Derived_gen.32, #Derived_g
             dec List.161;
             ret List.162;
     in
-    jump List.595 #Derived_gen.30 #Derived_gen.31 #Derived_gen.32 #Derived_gen.33 #Derived_gen.34;
+    jump List.595 #Derived_gen.33 #Derived_gen.34 #Derived_gen.35 #Derived_gen.36 #Derived_gen.37;
 
 procedure Num.127 (#Attr.2):
-    let Num.302 : U8 = lowlevel NumIntCast #Attr.2;
-    ret Num.302;
-
-procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.306 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.306;
-
-procedure Num.20 (#Attr.2, #Attr.3):
-    let Num.303 : U64 = lowlevel NumSub #Attr.2 #Attr.3;
+    let Num.303 : U8 = lowlevel NumIntCast #Attr.2;
     ret Num.303;
 
+procedure Num.133 (#Attr.2):
+    let Num.297 : U64 = lowlevel NumIntCast #Attr.2;
+    ret Num.297;
+
+procedure Num.19 (#Attr.2, #Attr.3):
+    let Num.307 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.307;
+
+procedure Num.20 (#Attr.2, #Attr.3):
+    let Num.304 : U64 = lowlevel NumSub #Attr.2 #Attr.3;
+    ret Num.304;
+
 procedure Num.21 (#Attr.2, #Attr.3):
-    let Num.308 : U64 = lowlevel NumMul #Attr.2 #Attr.3;
-    ret Num.308;
+    let Num.309 : U64 = lowlevel NumMul #Attr.2 #Attr.3;
+    ret Num.309;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.314 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.314;
-
-procedure Num.24 (#Attr.2, #Attr.3):
-    let Num.316 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
-    ret Num.316;
-
-procedure Num.51 (#Attr.2, #Attr.3):
-    let Num.311 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
-    ret Num.311;
-
-procedure Num.75 (#Attr.2, #Attr.3):
-    let Num.315 : U64 = lowlevel NumSubWrap #Attr.2 #Attr.3;
+    let Num.315 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
     ret Num.315;
 
+procedure Num.24 (#Attr.2, #Attr.3):
+    let Num.317 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
+    ret Num.317;
+
+procedure Num.51 (#Attr.2, #Attr.3):
+    let Num.312 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
+    ret Num.312;
+
+procedure Num.75 (#Attr.2, #Attr.3):
+    let Num.316 : U64 = lowlevel NumSubWrap #Attr.2 #Attr.3;
+    ret Num.316;
+
 procedure Num.94 (#Attr.2, #Attr.3):
-    let Num.307 : U64 = lowlevel NumDivCeilUnchecked #Attr.2 #Attr.3;
-    ret Num.307;
+    let Num.308 : U64 = lowlevel NumDivCeilUnchecked #Attr.2 #Attr.3;
+    ret Num.308;
 
 procedure Str.12 (#Attr.2):
     let Str.262 : List U8 = lowlevel StrToUtf8 #Attr.2;
     ret Str.262;
 
 procedure Str.43 (#Attr.2, #Attr.3, #Attr.4):
-    let Str.260 : {U64, Str, Int1, U8} = lowlevel StrFromUtf8Range #Attr.2 #Attr.3 #Attr.4;
-    ret Str.260;
+    let Str.259 : {U64, Str, Int1, U8} = lowlevel StrFromUtf8Range #Attr.2 #Attr.3 #Attr.4;
+    ret Str.259;
 
 procedure Str.9 (Str.68):
-    let Str.258 : U64 = 0i64;
-    let Str.259 : U64 = CallByName List.6 Str.68;
-    let Str.69 : {U64, Str, Int1, U8} = CallByName Str.43 Str.68 Str.258 Str.259;
-    let Str.255 : Int1 = StructAtIndex 2 Str.69;
-    if Str.255 then
-        let Str.257 : Str = StructAtIndex 1 Str.69;
-        let Str.256 : [C {U64, U8}, C Str] = TagId(1) Str.257;
-        ret Str.256;
+    let Str.257 : U64 = 0i64;
+    let Str.260 : U64 = CallByName List.6 Str.68;
+    let Str.258 : U64 = CallByName Num.133 Str.260;
+    let Str.69 : {U64, Str, Int1, U8} = CallByName Str.43 Str.68 Str.257 Str.258;
+    let Str.254 : Int1 = StructAtIndex 2 Str.69;
+    if Str.254 then
+        let Str.256 : Str = StructAtIndex 1 Str.69;
+        let Str.255 : [C {U64, U8}, C Str] = TagId(1) Str.256;
+        ret Str.255;
     else
-        let Str.253 : U8 = StructAtIndex 3 Str.69;
-        let Str.254 : U64 = StructAtIndex 0 Str.69;
+        let Str.252 : U8 = StructAtIndex 3 Str.69;
+        let Str.253 : U64 = StructAtIndex 0 Str.69;
         let #Derived_gen.38 : Str = StructAtIndex 1 Str.69;
         dec #Derived_gen.38;
-        let Str.252 : {U64, U8} = Struct {Str.254, Str.253};
-        let Str.251 : [C {U64, U8}, C Str] = TagId(0) Str.252;
-        ret Str.251;
+        let Str.251 : {U64, U8} = Struct {Str.253, Str.252};
+        let Str.250 : [C {U64, U8}, C Str] = TagId(0) Str.251;
+        ret Str.250;
 
 procedure TotallyNotJson.150 (TotallyNotJson.151, TotallyNotJson.1009, TotallyNotJson.149):
     let TotallyNotJson.1012 : List U8 = CallByName TotallyNotJson.26 TotallyNotJson.149;

--- a/crates/compiler/test_mono/generated/encode_derived_string.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_string.txt
@@ -80,7 +80,7 @@ procedure List.8 (#Attr.2, #Attr.3):
     let List.579 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
     ret List.579;
 
-procedure List.80 (#Derived_gen.0, #Derived_gen.1, #Derived_gen.2, #Derived_gen.3, #Derived_gen.4):
+procedure List.80 (#Derived_gen.8, #Derived_gen.9, #Derived_gen.10, #Derived_gen.11, #Derived_gen.12):
     joinpoint List.616 List.489 List.490 List.491 List.492 List.493:
         let List.618 : Int1 = CallByName Num.22 List.492 List.493;
         if List.618 then
@@ -104,9 +104,9 @@ procedure List.80 (#Derived_gen.0, #Derived_gen.1, #Derived_gen.2, #Derived_gen.
             let List.617 : [C {U64, Int1}, C {U64, Int1}] = TagId(1) List.490;
             ret List.617;
     in
-    jump List.616 #Derived_gen.0 #Derived_gen.1 #Derived_gen.2 #Derived_gen.3 #Derived_gen.4;
+    jump List.616 #Derived_gen.8 #Derived_gen.9 #Derived_gen.10 #Derived_gen.11 #Derived_gen.12;
 
-procedure List.90 (#Derived_gen.8, #Derived_gen.9, #Derived_gen.10, #Derived_gen.11, #Derived_gen.12):
+procedure List.90 (#Derived_gen.0, #Derived_gen.1, #Derived_gen.2, #Derived_gen.3, #Derived_gen.4):
     joinpoint List.587 List.161 List.162 List.163 List.164 List.165:
         let List.589 : Int1 = CallByName Num.22 List.164 List.165;
         if List.589 then
@@ -119,61 +119,66 @@ procedure List.90 (#Derived_gen.8, #Derived_gen.9, #Derived_gen.10, #Derived_gen
             dec List.161;
             ret List.162;
     in
-    jump List.587 #Derived_gen.8 #Derived_gen.9 #Derived_gen.10 #Derived_gen.11 #Derived_gen.12;
+    jump List.587 #Derived_gen.0 #Derived_gen.1 #Derived_gen.2 #Derived_gen.3 #Derived_gen.4;
+
+procedure Num.133 (#Attr.2):
+    let Num.297 : U64 = lowlevel NumIntCast #Attr.2;
+    ret Num.297;
 
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.298 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.298;
+    let Num.299 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.299;
 
 procedure Num.21 (#Attr.2, #Attr.3):
-    let Num.300 : U64 = lowlevel NumMul #Attr.2 #Attr.3;
-    ret Num.300;
+    let Num.301 : U64 = lowlevel NumMul #Attr.2 #Attr.3;
+    ret Num.301;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.304 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.304;
-
-procedure Num.24 (#Attr.2, #Attr.3):
-    let Num.306 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
-    ret Num.306;
-
-procedure Num.51 (#Attr.2, #Attr.3):
-    let Num.302 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
-    ret Num.302;
-
-procedure Num.75 (#Attr.2, #Attr.3):
-    let Num.305 : U64 = lowlevel NumSubWrap #Attr.2 #Attr.3;
+    let Num.305 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
     ret Num.305;
 
+procedure Num.24 (#Attr.2, #Attr.3):
+    let Num.307 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
+    ret Num.307;
+
+procedure Num.51 (#Attr.2, #Attr.3):
+    let Num.303 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
+    ret Num.303;
+
+procedure Num.75 (#Attr.2, #Attr.3):
+    let Num.306 : U64 = lowlevel NumSubWrap #Attr.2 #Attr.3;
+    ret Num.306;
+
 procedure Num.94 (#Attr.2, #Attr.3):
-    let Num.299 : U64 = lowlevel NumDivCeilUnchecked #Attr.2 #Attr.3;
-    ret Num.299;
+    let Num.300 : U64 = lowlevel NumDivCeilUnchecked #Attr.2 #Attr.3;
+    ret Num.300;
 
 procedure Str.12 (#Attr.2):
     let Str.261 : List U8 = lowlevel StrToUtf8 #Attr.2;
     ret Str.261;
 
 procedure Str.43 (#Attr.2, #Attr.3, #Attr.4):
-    let Str.260 : {U64, Str, Int1, U8} = lowlevel StrFromUtf8Range #Attr.2 #Attr.3 #Attr.4;
-    ret Str.260;
+    let Str.259 : {U64, Str, Int1, U8} = lowlevel StrFromUtf8Range #Attr.2 #Attr.3 #Attr.4;
+    ret Str.259;
 
 procedure Str.9 (Str.68):
-    let Str.258 : U64 = 0i64;
-    let Str.259 : U64 = CallByName List.6 Str.68;
-    let Str.69 : {U64, Str, Int1, U8} = CallByName Str.43 Str.68 Str.258 Str.259;
-    let Str.255 : Int1 = StructAtIndex 2 Str.69;
-    if Str.255 then
-        let Str.257 : Str = StructAtIndex 1 Str.69;
-        let Str.256 : [C {U64, U8}, C Str] = TagId(1) Str.257;
-        ret Str.256;
+    let Str.257 : U64 = 0i64;
+    let Str.260 : U64 = CallByName List.6 Str.68;
+    let Str.258 : U64 = CallByName Num.133 Str.260;
+    let Str.69 : {U64, Str, Int1, U8} = CallByName Str.43 Str.68 Str.257 Str.258;
+    let Str.254 : Int1 = StructAtIndex 2 Str.69;
+    if Str.254 then
+        let Str.256 : Str = StructAtIndex 1 Str.69;
+        let Str.255 : [C {U64, U8}, C Str] = TagId(1) Str.256;
+        ret Str.255;
     else
-        let Str.253 : U8 = StructAtIndex 3 Str.69;
-        let Str.254 : U64 = StructAtIndex 0 Str.69;
+        let Str.252 : U8 = StructAtIndex 3 Str.69;
+        let Str.253 : U64 = StructAtIndex 0 Str.69;
         let #Derived_gen.13 : Str = StructAtIndex 1 Str.69;
         dec #Derived_gen.13;
-        let Str.252 : {U64, U8} = Struct {Str.254, Str.253};
-        let Str.251 : [C {U64, U8}, C Str] = TagId(0) Str.252;
-        ret Str.251;
+        let Str.251 : {U64, U8} = Struct {Str.253, Str.252};
+        let Str.250 : [C {U64, U8}, C Str] = TagId(0) Str.251;
+        ret Str.250;
 
 procedure TotallyNotJson.150 (TotallyNotJson.151, TotallyNotJson.973, TotallyNotJson.149):
     let TotallyNotJson.976 : List U8 = CallByName TotallyNotJson.26 TotallyNotJson.149;

--- a/crates/compiler/test_mono/generated/encode_derived_tag_one_field_string.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_tag_one_field_string.txt
@@ -137,7 +137,7 @@ procedure List.8 (#Attr.2, #Attr.3):
     let List.633 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
     ret List.633;
 
-procedure List.80 (#Derived_gen.26, #Derived_gen.27, #Derived_gen.28, #Derived_gen.29, #Derived_gen.30):
+procedure List.80 (#Derived_gen.18, #Derived_gen.19, #Derived_gen.20, #Derived_gen.21, #Derived_gen.22):
     joinpoint List.657 List.489 List.490 List.491 List.492 List.493:
         let List.659 : Int1 = CallByName Num.22 List.492 List.493;
         if List.659 then
@@ -161,9 +161,9 @@ procedure List.80 (#Derived_gen.26, #Derived_gen.27, #Derived_gen.28, #Derived_g
             let List.658 : [C {U64, Int1}, C {U64, Int1}] = TagId(1) List.490;
             ret List.658;
     in
-    jump List.657 #Derived_gen.26 #Derived_gen.27 #Derived_gen.28 #Derived_gen.29 #Derived_gen.30;
+    jump List.657 #Derived_gen.18 #Derived_gen.19 #Derived_gen.20 #Derived_gen.21 #Derived_gen.22;
 
-procedure List.90 (#Derived_gen.13, #Derived_gen.14, #Derived_gen.15, #Derived_gen.16, #Derived_gen.17):
+procedure List.90 (#Derived_gen.10, #Derived_gen.11, #Derived_gen.12, #Derived_gen.13, #Derived_gen.14):
     joinpoint List.613 List.161 List.162 List.163 List.164 List.165:
         let List.615 : Int1 = CallByName Num.22 List.164 List.165;
         if List.615 then
@@ -176,9 +176,9 @@ procedure List.90 (#Derived_gen.13, #Derived_gen.14, #Derived_gen.15, #Derived_g
             dec List.161;
             ret List.162;
     in
-    jump List.613 #Derived_gen.13 #Derived_gen.14 #Derived_gen.15 #Derived_gen.16 #Derived_gen.17;
+    jump List.613 #Derived_gen.10 #Derived_gen.11 #Derived_gen.12 #Derived_gen.13 #Derived_gen.14;
 
-procedure List.90 (#Derived_gen.18, #Derived_gen.19, #Derived_gen.20, #Derived_gen.21, #Derived_gen.22):
+procedure List.90 (#Derived_gen.23, #Derived_gen.24, #Derived_gen.25, #Derived_gen.26, #Derived_gen.27):
     joinpoint List.601 List.161 List.162 List.163 List.164 List.165:
         let List.603 : Int1 = CallByName Num.22 List.164 List.165;
         if List.603 then
@@ -192,69 +192,74 @@ procedure List.90 (#Derived_gen.18, #Derived_gen.19, #Derived_gen.20, #Derived_g
             dec List.161;
             ret List.162;
     in
-    jump List.601 #Derived_gen.18 #Derived_gen.19 #Derived_gen.20 #Derived_gen.21 #Derived_gen.22;
+    jump List.601 #Derived_gen.23 #Derived_gen.24 #Derived_gen.25 #Derived_gen.26 #Derived_gen.27;
 
 procedure Num.127 (#Attr.2):
-    let Num.304 : U8 = lowlevel NumIntCast #Attr.2;
-    ret Num.304;
-
-procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.308 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.308;
-
-procedure Num.20 (#Attr.2, #Attr.3):
-    let Num.305 : U64 = lowlevel NumSub #Attr.2 #Attr.3;
+    let Num.305 : U8 = lowlevel NumIntCast #Attr.2;
     ret Num.305;
 
+procedure Num.133 (#Attr.2):
+    let Num.297 : U64 = lowlevel NumIntCast #Attr.2;
+    ret Num.297;
+
+procedure Num.19 (#Attr.2, #Attr.3):
+    let Num.309 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.309;
+
+procedure Num.20 (#Attr.2, #Attr.3):
+    let Num.306 : U64 = lowlevel NumSub #Attr.2 #Attr.3;
+    ret Num.306;
+
 procedure Num.21 (#Attr.2, #Attr.3):
-    let Num.310 : U64 = lowlevel NumMul #Attr.2 #Attr.3;
-    ret Num.310;
+    let Num.311 : U64 = lowlevel NumMul #Attr.2 #Attr.3;
+    ret Num.311;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.316 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.316;
-
-procedure Num.24 (#Attr.2, #Attr.3):
-    let Num.318 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
-    ret Num.318;
-
-procedure Num.51 (#Attr.2, #Attr.3):
-    let Num.313 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
-    ret Num.313;
-
-procedure Num.75 (#Attr.2, #Attr.3):
-    let Num.317 : U64 = lowlevel NumSubWrap #Attr.2 #Attr.3;
+    let Num.317 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
     ret Num.317;
 
+procedure Num.24 (#Attr.2, #Attr.3):
+    let Num.319 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
+    ret Num.319;
+
+procedure Num.51 (#Attr.2, #Attr.3):
+    let Num.314 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
+    ret Num.314;
+
+procedure Num.75 (#Attr.2, #Attr.3):
+    let Num.318 : U64 = lowlevel NumSubWrap #Attr.2 #Attr.3;
+    ret Num.318;
+
 procedure Num.94 (#Attr.2, #Attr.3):
-    let Num.309 : U64 = lowlevel NumDivCeilUnchecked #Attr.2 #Attr.3;
-    ret Num.309;
+    let Num.310 : U64 = lowlevel NumDivCeilUnchecked #Attr.2 #Attr.3;
+    ret Num.310;
 
 procedure Str.12 (#Attr.2):
     let Str.262 : List U8 = lowlevel StrToUtf8 #Attr.2;
     ret Str.262;
 
 procedure Str.43 (#Attr.2, #Attr.3, #Attr.4):
-    let Str.260 : {U64, Str, Int1, U8} = lowlevel StrFromUtf8Range #Attr.2 #Attr.3 #Attr.4;
-    ret Str.260;
+    let Str.259 : {U64, Str, Int1, U8} = lowlevel StrFromUtf8Range #Attr.2 #Attr.3 #Attr.4;
+    ret Str.259;
 
 procedure Str.9 (Str.68):
-    let Str.258 : U64 = 0i64;
-    let Str.259 : U64 = CallByName List.6 Str.68;
-    let Str.69 : {U64, Str, Int1, U8} = CallByName Str.43 Str.68 Str.258 Str.259;
-    let Str.255 : Int1 = StructAtIndex 2 Str.69;
-    if Str.255 then
-        let Str.257 : Str = StructAtIndex 1 Str.69;
-        let Str.256 : [C {U64, U8}, C Str] = TagId(1) Str.257;
-        ret Str.256;
+    let Str.257 : U64 = 0i64;
+    let Str.260 : U64 = CallByName List.6 Str.68;
+    let Str.258 : U64 = CallByName Num.133 Str.260;
+    let Str.69 : {U64, Str, Int1, U8} = CallByName Str.43 Str.68 Str.257 Str.258;
+    let Str.254 : Int1 = StructAtIndex 2 Str.69;
+    if Str.254 then
+        let Str.256 : Str = StructAtIndex 1 Str.69;
+        let Str.255 : [C {U64, U8}, C Str] = TagId(1) Str.256;
+        ret Str.255;
     else
-        let Str.253 : U8 = StructAtIndex 3 Str.69;
-        let Str.254 : U64 = StructAtIndex 0 Str.69;
+        let Str.252 : U8 = StructAtIndex 3 Str.69;
+        let Str.253 : U64 = StructAtIndex 0 Str.69;
         let #Derived_gen.34 : Str = StructAtIndex 1 Str.69;
         dec #Derived_gen.34;
-        let Str.252 : {U64, U8} = Struct {Str.254, Str.253};
-        let Str.251 : [C {U64, U8}, C Str] = TagId(0) Str.252;
-        ret Str.251;
+        let Str.251 : {U64, U8} = Struct {Str.253, Str.252};
+        let Str.250 : [C {U64, U8}, C Str] = TagId(0) Str.251;
+        ret Str.250;
 
 procedure TotallyNotJson.150 (TotallyNotJson.151, TotallyNotJson.1014, TotallyNotJson.149):
     let TotallyNotJson.1017 : List U8 = CallByName TotallyNotJson.26 TotallyNotJson.149;

--- a/crates/compiler/test_mono/generated/encode_derived_tag_two_payloads_string.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_tag_two_payloads_string.txt
@@ -140,7 +140,7 @@ procedure List.8 (#Attr.2, #Attr.3):
     let List.633 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
     ret List.633;
 
-procedure List.80 (#Derived_gen.19, #Derived_gen.20, #Derived_gen.21, #Derived_gen.22, #Derived_gen.23):
+procedure List.80 (#Derived_gen.11, #Derived_gen.12, #Derived_gen.13, #Derived_gen.14, #Derived_gen.15):
     joinpoint List.657 List.489 List.490 List.491 List.492 List.493:
         let List.659 : Int1 = CallByName Num.22 List.492 List.493;
         if List.659 then
@@ -164,9 +164,24 @@ procedure List.80 (#Derived_gen.19, #Derived_gen.20, #Derived_gen.21, #Derived_g
             let List.658 : [C {U64, Int1}, C {U64, Int1}] = TagId(1) List.490;
             ret List.658;
     in
-    jump List.657 #Derived_gen.19 #Derived_gen.20 #Derived_gen.21 #Derived_gen.22 #Derived_gen.23;
+    jump List.657 #Derived_gen.11 #Derived_gen.12 #Derived_gen.13 #Derived_gen.14 #Derived_gen.15;
 
-procedure List.90 (#Derived_gen.14, #Derived_gen.15, #Derived_gen.16, #Derived_gen.17, #Derived_gen.18):
+procedure List.90 (#Derived_gen.19, #Derived_gen.20, #Derived_gen.21, #Derived_gen.22, #Derived_gen.23):
+    joinpoint List.613 List.161 List.162 List.163 List.164 List.165:
+        let List.615 : Int1 = CallByName Num.22 List.164 List.165;
+        if List.615 then
+            let List.619 : U8 = CallByName List.66 List.161 List.164;
+            let List.166 : List U8 = CallByName TotallyNotJson.183 List.162 List.619;
+            let List.618 : U64 = 1i64;
+            let List.617 : U64 = CallByName Num.51 List.164 List.618;
+            jump List.613 List.161 List.166 List.163 List.617 List.165;
+        else
+            dec List.161;
+            ret List.162;
+    in
+    jump List.613 #Derived_gen.19 #Derived_gen.20 #Derived_gen.21 #Derived_gen.22 #Derived_gen.23;
+
+procedure List.90 (#Derived_gen.30, #Derived_gen.31, #Derived_gen.32, #Derived_gen.33, #Derived_gen.34):
     joinpoint List.601 List.161 List.162 List.163 List.164 List.165:
         let List.603 : Int1 = CallByName Num.22 List.164 List.165;
         if List.603 then
@@ -180,84 +195,74 @@ procedure List.90 (#Derived_gen.14, #Derived_gen.15, #Derived_gen.16, #Derived_g
             dec List.161;
             ret List.162;
     in
-    jump List.601 #Derived_gen.14 #Derived_gen.15 #Derived_gen.16 #Derived_gen.17 #Derived_gen.18;
-
-procedure List.90 (#Derived_gen.24, #Derived_gen.25, #Derived_gen.26, #Derived_gen.27, #Derived_gen.28):
-    joinpoint List.613 List.161 List.162 List.163 List.164 List.165:
-        let List.615 : Int1 = CallByName Num.22 List.164 List.165;
-        if List.615 then
-            let List.619 : U8 = CallByName List.66 List.161 List.164;
-            let List.166 : List U8 = CallByName TotallyNotJson.183 List.162 List.619;
-            let List.618 : U64 = 1i64;
-            let List.617 : U64 = CallByName Num.51 List.164 List.618;
-            jump List.613 List.161 List.166 List.163 List.617 List.165;
-        else
-            dec List.161;
-            ret List.162;
-    in
-    jump List.613 #Derived_gen.24 #Derived_gen.25 #Derived_gen.26 #Derived_gen.27 #Derived_gen.28;
+    jump List.601 #Derived_gen.30 #Derived_gen.31 #Derived_gen.32 #Derived_gen.33 #Derived_gen.34;
 
 procedure Num.127 (#Attr.2):
-    let Num.304 : U8 = lowlevel NumIntCast #Attr.2;
-    ret Num.304;
-
-procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.308 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.308;
-
-procedure Num.20 (#Attr.2, #Attr.3):
-    let Num.305 : U64 = lowlevel NumSub #Attr.2 #Attr.3;
+    let Num.305 : U8 = lowlevel NumIntCast #Attr.2;
     ret Num.305;
 
+procedure Num.133 (#Attr.2):
+    let Num.297 : U64 = lowlevel NumIntCast #Attr.2;
+    ret Num.297;
+
+procedure Num.19 (#Attr.2, #Attr.3):
+    let Num.309 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.309;
+
+procedure Num.20 (#Attr.2, #Attr.3):
+    let Num.306 : U64 = lowlevel NumSub #Attr.2 #Attr.3;
+    ret Num.306;
+
 procedure Num.21 (#Attr.2, #Attr.3):
-    let Num.310 : U64 = lowlevel NumMul #Attr.2 #Attr.3;
-    ret Num.310;
+    let Num.311 : U64 = lowlevel NumMul #Attr.2 #Attr.3;
+    ret Num.311;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.316 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.316;
-
-procedure Num.24 (#Attr.2, #Attr.3):
-    let Num.318 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
-    ret Num.318;
-
-procedure Num.51 (#Attr.2, #Attr.3):
-    let Num.313 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
-    ret Num.313;
-
-procedure Num.75 (#Attr.2, #Attr.3):
-    let Num.317 : U64 = lowlevel NumSubWrap #Attr.2 #Attr.3;
+    let Num.317 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
     ret Num.317;
 
+procedure Num.24 (#Attr.2, #Attr.3):
+    let Num.319 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
+    ret Num.319;
+
+procedure Num.51 (#Attr.2, #Attr.3):
+    let Num.314 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
+    ret Num.314;
+
+procedure Num.75 (#Attr.2, #Attr.3):
+    let Num.318 : U64 = lowlevel NumSubWrap #Attr.2 #Attr.3;
+    ret Num.318;
+
 procedure Num.94 (#Attr.2, #Attr.3):
-    let Num.309 : U64 = lowlevel NumDivCeilUnchecked #Attr.2 #Attr.3;
-    ret Num.309;
+    let Num.310 : U64 = lowlevel NumDivCeilUnchecked #Attr.2 #Attr.3;
+    ret Num.310;
 
 procedure Str.12 (#Attr.2):
     let Str.262 : List U8 = lowlevel StrToUtf8 #Attr.2;
     ret Str.262;
 
 procedure Str.43 (#Attr.2, #Attr.3, #Attr.4):
-    let Str.260 : {U64, Str, Int1, U8} = lowlevel StrFromUtf8Range #Attr.2 #Attr.3 #Attr.4;
-    ret Str.260;
+    let Str.259 : {U64, Str, Int1, U8} = lowlevel StrFromUtf8Range #Attr.2 #Attr.3 #Attr.4;
+    ret Str.259;
 
 procedure Str.9 (Str.68):
-    let Str.258 : U64 = 0i64;
-    let Str.259 : U64 = CallByName List.6 Str.68;
-    let Str.69 : {U64, Str, Int1, U8} = CallByName Str.43 Str.68 Str.258 Str.259;
-    let Str.255 : Int1 = StructAtIndex 2 Str.69;
-    if Str.255 then
-        let Str.257 : Str = StructAtIndex 1 Str.69;
-        let Str.256 : [C {U64, U8}, C Str] = TagId(1) Str.257;
-        ret Str.256;
+    let Str.257 : U64 = 0i64;
+    let Str.260 : U64 = CallByName List.6 Str.68;
+    let Str.258 : U64 = CallByName Num.133 Str.260;
+    let Str.69 : {U64, Str, Int1, U8} = CallByName Str.43 Str.68 Str.257 Str.258;
+    let Str.254 : Int1 = StructAtIndex 2 Str.69;
+    if Str.254 then
+        let Str.256 : Str = StructAtIndex 1 Str.69;
+        let Str.255 : [C {U64, U8}, C Str] = TagId(1) Str.256;
+        ret Str.255;
     else
-        let Str.253 : U8 = StructAtIndex 3 Str.69;
-        let Str.254 : U64 = StructAtIndex 0 Str.69;
+        let Str.252 : U8 = StructAtIndex 3 Str.69;
+        let Str.253 : U64 = StructAtIndex 0 Str.69;
         let #Derived_gen.35 : Str = StructAtIndex 1 Str.69;
         dec #Derived_gen.35;
-        let Str.252 : {U64, U8} = Struct {Str.254, Str.253};
-        let Str.251 : [C {U64, U8}, C Str] = TagId(0) Str.252;
-        ret Str.251;
+        let Str.251 : {U64, U8} = Struct {Str.253, Str.252};
+        let Str.250 : [C {U64, U8}, C Str] = TagId(0) Str.251;
+        ret Str.250;
 
 procedure TotallyNotJson.150 (TotallyNotJson.151, TotallyNotJson.1014, TotallyNotJson.149):
     let TotallyNotJson.1017 : List U8 = CallByName TotallyNotJson.26 TotallyNotJson.149;

--- a/crates/compiler/test_mono/generated/inspect_derived_dict.txt
+++ b/crates/compiler/test_mono/generated/inspect_derived_dict.txt
@@ -1193,12 +1193,12 @@ procedure Num.96 (#Attr.2):
     ret Num.464;
 
 procedure Str.12 (#Attr.2):
-    let Str.253 : List U8 = lowlevel StrToUtf8 #Attr.2;
-    ret Str.253;
+    let Str.252 : List U8 = lowlevel StrToUtf8 #Attr.2;
+    ret Str.252;
 
 procedure Str.3 (#Attr.2, #Attr.3):
-    let Str.254 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
-    ret Str.254;
+    let Str.253 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
+    ret Str.253;
 
 procedure Test.0 ():
     let Test.8 : Str = "a";

--- a/crates/compiler/test_mono/generated/inspect_derived_list.txt
+++ b/crates/compiler/test_mono/generated/inspect_derived_list.txt
@@ -167,8 +167,8 @@ procedure Num.96 (#Attr.2):
     ret Num.297;
 
 procedure Str.3 (#Attr.2, #Attr.3):
-    let Str.251 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
-    ret Str.251;
+    let Str.250 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
+    ret Str.250;
 
 procedure Test.0 ():
     let Test.2 : List I64 = Array [1i64, 2i64, 3i64];

--- a/crates/compiler/test_mono/generated/inspect_derived_nested_record_string.txt
+++ b/crates/compiler/test_mono/generated/inspect_derived_nested_record_string.txt
@@ -269,8 +269,8 @@ procedure Num.51 (#Attr.2, #Attr.3):
     ret Num.299;
 
 procedure Str.3 (#Attr.2, #Attr.3):
-    let Str.252 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
-    ret Str.252;
+    let Str.251 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
+    ret Str.251;
 
 procedure Test.0 ():
     let Test.4 : Str = "bar";

--- a/crates/compiler/test_mono/generated/inspect_derived_record.txt
+++ b/crates/compiler/test_mono/generated/inspect_derived_record.txt
@@ -197,8 +197,8 @@ procedure Num.96 (#Attr.2):
     ret Num.298;
 
 procedure Str.3 (#Attr.2, #Attr.3):
-    let Str.251 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
-    ret Str.251;
+    let Str.250 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
+    ret Str.250;
 
 procedure Test.0 ():
     let Test.3 : Decimal = 3dec;

--- a/crates/compiler/test_mono/generated/inspect_derived_record_one_field_string.txt
+++ b/crates/compiler/test_mono/generated/inspect_derived_record_one_field_string.txt
@@ -166,8 +166,8 @@ procedure Num.51 (#Attr.2, #Attr.3):
     ret Num.297;
 
 procedure Str.3 (#Attr.2, #Attr.3):
-    let Str.251 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
-    ret Str.251;
+    let Str.250 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
+    ret Str.250;
 
 procedure Test.0 ():
     let Test.3 : Str = "foo";

--- a/crates/compiler/test_mono/generated/inspect_derived_record_two_field_strings.txt
+++ b/crates/compiler/test_mono/generated/inspect_derived_record_two_field_strings.txt
@@ -173,8 +173,8 @@ procedure Num.51 (#Attr.2, #Attr.3):
     ret Num.297;
 
 procedure Str.3 (#Attr.2, #Attr.3):
-    let Str.251 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
-    ret Str.251;
+    let Str.250 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
+    ret Str.250;
 
 procedure Test.0 ():
     let Test.3 : Str = "foo";

--- a/crates/compiler/test_mono/generated/inspect_derived_string.txt
+++ b/crates/compiler/test_mono/generated/inspect_derived_string.txt
@@ -38,8 +38,8 @@ procedure Inspect.62 (Inspect.306):
     ret Inspect.306;
 
 procedure Str.3 (#Attr.2, #Attr.3):
-    let Str.251 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
-    ret Str.251;
+    let Str.250 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
+    ret Str.250;
 
 procedure Test.0 ():
     let Test.2 : Str = "abc";

--- a/crates/compiler/test_mono/generated/inspect_derived_tag_one_field_string.txt
+++ b/crates/compiler/test_mono/generated/inspect_derived_tag_one_field_string.txt
@@ -168,8 +168,8 @@ procedure Num.51 (#Attr.2, #Attr.3):
     ret Num.297;
 
 procedure Str.3 (#Attr.2, #Attr.3):
-    let Str.251 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
-    ret Str.251;
+    let Str.250 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
+    ret Str.250;
 
 procedure Test.0 ():
     let Test.4 : Str = "foo";

--- a/crates/compiler/test_mono/generated/inspect_derived_tag_two_payloads_string.txt
+++ b/crates/compiler/test_mono/generated/inspect_derived_tag_two_payloads_string.txt
@@ -171,8 +171,8 @@ procedure Num.51 (#Attr.2, #Attr.3):
     ret Num.297;
 
 procedure Str.3 (#Attr.2, #Attr.3):
-    let Str.251 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
-    ret Str.251;
+    let Str.250 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
+    ret Str.250;
 
 procedure Test.0 ():
     let Test.5 : Str = "foo";

--- a/crates/compiler/test_mono/generated/issue_2583_specialize_errors_behind_unified_branches.txt
+++ b/crates/compiler/test_mono/generated/issue_2583_specialize_errors_behind_unified_branches.txt
@@ -47,28 +47,28 @@ procedure Num.22 (#Attr.2, #Attr.3):
     let Num.297 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
     ret Num.297;
 
-procedure Str.27 (Str.88):
-    let Str.251 : [C Int1, C I64] = CallByName Str.61 Str.88;
-    ret Str.251;
+procedure Str.27 (Str.87):
+    let Str.250 : [C Int1, C I64] = CallByName Str.61 Str.87;
+    ret Str.250;
 
 procedure Str.42 (#Attr.2):
-    let Str.259 : {I64, U8} = lowlevel StrToNum #Attr.2;
-    ret Str.259;
+    let Str.258 : {I64, U8} = lowlevel StrToNum #Attr.2;
+    ret Str.258;
 
-procedure Str.61 (Str.195):
-    let Str.196 : {I64, U8} = CallByName Str.42 Str.195;
-    dec Str.195;
-    let Str.257 : U8 = StructAtIndex 1 Str.196;
-    let Str.258 : U8 = 0i64;
-    let Str.254 : Int1 = CallByName Bool.11 Str.257 Str.258;
-    if Str.254 then
-        let Str.256 : I64 = StructAtIndex 0 Str.196;
-        let Str.255 : [C Int1, C I64] = TagId(1) Str.256;
-        ret Str.255;
+procedure Str.61 (Str.194):
+    let Str.195 : {I64, U8} = CallByName Str.42 Str.194;
+    dec Str.194;
+    let Str.256 : U8 = StructAtIndex 1 Str.195;
+    let Str.257 : U8 = 0i64;
+    let Str.253 : Int1 = CallByName Bool.11 Str.256 Str.257;
+    if Str.253 then
+        let Str.255 : I64 = StructAtIndex 0 Str.195;
+        let Str.254 : [C Int1, C I64] = TagId(1) Str.255;
+        ret Str.254;
     else
-        let Str.253 : Int1 = false;
-        let Str.252 : [C Int1, C I64] = TagId(0) Str.253;
-        ret Str.252;
+        let Str.252 : Int1 = false;
+        let Str.251 : [C Int1, C I64] = TagId(0) Str.252;
+        ret Str.251;
 
 procedure Test.0 ():
     let Test.3 : Int1 = CallByName Bool.2;

--- a/crates/compiler/test_mono/generated/issue_4749.txt
+++ b/crates/compiler/test_mono/generated/issue_4749.txt
@@ -178,6 +178,10 @@ procedure List.80 (#Derived_gen.1, #Derived_gen.2, #Derived_gen.3, #Derived_gen.
     in
     jump List.636 #Derived_gen.1 #Derived_gen.2 #Derived_gen.3 #Derived_gen.4 #Derived_gen.5;
 
+procedure Num.133 (#Attr.2):
+    let Num.336 : U64 = lowlevel NumIntCast #Attr.2;
+    ret Num.336;
+
 procedure Num.19 (#Attr.2, #Attr.3):
     let Num.300 : U8 = lowlevel NumAdd #Attr.2 #Attr.3;
     ret Num.300;
@@ -219,26 +223,27 @@ procedure Num.77 (#Attr.2, #Attr.3):
     ret Num.331;
 
 procedure Str.43 (#Attr.2, #Attr.3, #Attr.4):
-    let Str.260 : {U64, Str, Int1, U8} = lowlevel StrFromUtf8Range #Attr.2 #Attr.3 #Attr.4;
-    ret Str.260;
+    let Str.259 : {U64, Str, Int1, U8} = lowlevel StrFromUtf8Range #Attr.2 #Attr.3 #Attr.4;
+    ret Str.259;
 
 procedure Str.9 (Str.68):
-    let Str.258 : U64 = 0i64;
-    let Str.259 : U64 = CallByName List.6 Str.68;
-    let Str.69 : {U64, Str, Int1, U8} = CallByName Str.43 Str.68 Str.258 Str.259;
-    let Str.255 : Int1 = StructAtIndex 2 Str.69;
-    if Str.255 then
-        let Str.257 : Str = StructAtIndex 1 Str.69;
-        let Str.256 : [C {U64, U8}, C Str] = TagId(1) Str.257;
-        ret Str.256;
+    let Str.257 : U64 = 0i64;
+    let Str.260 : U64 = CallByName List.6 Str.68;
+    let Str.258 : U64 = CallByName Num.133 Str.260;
+    let Str.69 : {U64, Str, Int1, U8} = CallByName Str.43 Str.68 Str.257 Str.258;
+    let Str.254 : Int1 = StructAtIndex 2 Str.69;
+    if Str.254 then
+        let Str.256 : Str = StructAtIndex 1 Str.69;
+        let Str.255 : [C {U64, U8}, C Str] = TagId(1) Str.256;
+        ret Str.255;
     else
-        let Str.253 : U8 = StructAtIndex 3 Str.69;
-        let Str.254 : U64 = StructAtIndex 0 Str.69;
+        let Str.252 : U8 = StructAtIndex 3 Str.69;
+        let Str.253 : U64 = StructAtIndex 0 Str.69;
         let #Derived_gen.6 : Str = StructAtIndex 1 Str.69;
         dec #Derived_gen.6;
-        let Str.252 : {U64, U8} = Struct {Str.254, Str.253};
-        let Str.251 : [C {U64, U8}, C Str] = TagId(0) Str.252;
-        ret Str.251;
+        let Str.251 : {U64, U8} = Struct {Str.253, Str.252};
+        let Str.250 : [C {U64, U8}, C Str] = TagId(0) Str.251;
+        ret Str.250;
 
 procedure Test.3 ():
     let Test.0 : List U8 = Array [82i64, 111i64, 99i64];

--- a/crates/compiler/test_mono/generated/issue_4772_weakened_monomorphic_destructure.txt
+++ b/crates/compiler/test_mono/generated/issue_4772_weakened_monomorphic_destructure.txt
@@ -152,6 +152,10 @@ procedure List.80 (#Derived_gen.1, #Derived_gen.2, #Derived_gen.3, #Derived_gen.
     in
     jump List.632 #Derived_gen.1 #Derived_gen.2 #Derived_gen.3 #Derived_gen.4 #Derived_gen.5;
 
+procedure Num.133 (#Attr.2):
+    let Num.336 : U64 = lowlevel NumIntCast #Attr.2;
+    ret Num.336;
+
 procedure Num.19 (#Attr.2, #Attr.3):
     let Num.300 : U8 = lowlevel NumAdd #Attr.2 #Attr.3;
     ret Num.300;
@@ -193,53 +197,54 @@ procedure Num.77 (#Attr.2, #Attr.3):
     ret Num.331;
 
 procedure Str.12 (#Attr.2):
-    let Str.260 : List U8 = lowlevel StrToUtf8 #Attr.2;
-    ret Str.260;
-
-procedure Str.27 (Str.88):
-    let Str.251 : [C {}, C I64] = CallByName Str.61 Str.88;
-    ret Str.251;
-
-procedure Str.42 (#Attr.2):
-    let Str.259 : {I64, U8} = lowlevel StrToNum #Attr.2;
+    let Str.259 : List U8 = lowlevel StrToUtf8 #Attr.2;
     ret Str.259;
 
-procedure Str.43 (#Attr.2, #Attr.3, #Attr.4):
-    let Str.270 : {U64, Str, Int1, U8} = lowlevel StrFromUtf8Range #Attr.2 #Attr.3 #Attr.4;
-    ret Str.270;
+procedure Str.27 (Str.87):
+    let Str.250 : [C {}, C I64] = CallByName Str.61 Str.87;
+    ret Str.250;
 
-procedure Str.61 (Str.195):
-    let Str.196 : {I64, U8} = CallByName Str.42 Str.195;
-    dec Str.195;
-    let Str.257 : U8 = StructAtIndex 1 Str.196;
-    let Str.258 : U8 = 0i64;
-    let Str.254 : Int1 = CallByName Bool.11 Str.257 Str.258;
-    if Str.254 then
-        let Str.256 : I64 = StructAtIndex 0 Str.196;
-        let Str.255 : [C {}, C I64] = TagId(1) Str.256;
-        ret Str.255;
+procedure Str.42 (#Attr.2):
+    let Str.258 : {I64, U8} = lowlevel StrToNum #Attr.2;
+    ret Str.258;
+
+procedure Str.43 (#Attr.2, #Attr.3, #Attr.4):
+    let Str.269 : {U64, Str, Int1, U8} = lowlevel StrFromUtf8Range #Attr.2 #Attr.3 #Attr.4;
+    ret Str.269;
+
+procedure Str.61 (Str.194):
+    let Str.195 : {I64, U8} = CallByName Str.42 Str.194;
+    dec Str.194;
+    let Str.256 : U8 = StructAtIndex 1 Str.195;
+    let Str.257 : U8 = 0i64;
+    let Str.253 : Int1 = CallByName Bool.11 Str.256 Str.257;
+    if Str.253 then
+        let Str.255 : I64 = StructAtIndex 0 Str.195;
+        let Str.254 : [C {}, C I64] = TagId(1) Str.255;
+        ret Str.254;
     else
-        let Str.253 : {} = Struct {};
-        let Str.252 : [C {}, C I64] = TagId(0) Str.253;
-        ret Str.252;
+        let Str.252 : {} = Struct {};
+        let Str.251 : [C {}, C I64] = TagId(0) Str.252;
+        ret Str.251;
 
 procedure Str.9 (Str.68):
-    let Str.268 : U64 = 0i64;
-    let Str.269 : U64 = CallByName List.6 Str.68;
-    let Str.69 : {U64, Str, Int1, U8} = CallByName Str.43 Str.68 Str.268 Str.269;
-    let Str.265 : Int1 = StructAtIndex 2 Str.69;
-    if Str.265 then
-        let Str.267 : Str = StructAtIndex 1 Str.69;
-        let Str.266 : [C {U64, U8}, C Str] = TagId(1) Str.267;
-        ret Str.266;
+    let Str.267 : U64 = 0i64;
+    let Str.270 : U64 = CallByName List.6 Str.68;
+    let Str.268 : U64 = CallByName Num.133 Str.270;
+    let Str.69 : {U64, Str, Int1, U8} = CallByName Str.43 Str.68 Str.267 Str.268;
+    let Str.264 : Int1 = StructAtIndex 2 Str.69;
+    if Str.264 then
+        let Str.266 : Str = StructAtIndex 1 Str.69;
+        let Str.265 : [C {U64, U8}, C Str] = TagId(1) Str.266;
+        ret Str.265;
     else
-        let Str.263 : U8 = StructAtIndex 3 Str.69;
-        let Str.264 : U64 = StructAtIndex 0 Str.69;
+        let Str.262 : U8 = StructAtIndex 3 Str.69;
+        let Str.263 : U64 = StructAtIndex 0 Str.69;
         let #Derived_gen.7 : Str = StructAtIndex 1 Str.69;
         dec #Derived_gen.7;
-        let Str.262 : {U64, U8} = Struct {Str.264, Str.263};
-        let Str.261 : [C {U64, U8}, C Str] = TagId(0) Str.262;
-        ret Str.261;
+        let Str.261 : {U64, U8} = Struct {Str.263, Str.262};
+        let Str.260 : [C {U64, U8}, C Str] = TagId(0) Str.261;
+        ret Str.260;
 
 procedure Test.0 ():
     let Test.37 : Str = "-1234";

--- a/crates/compiler/test_mono/generated/list_map_closure_borrows.txt
+++ b/crates/compiler/test_mono/generated/list_map_closure_borrows.txt
@@ -31,12 +31,12 @@ procedure Num.22 (#Attr.2, #Attr.3):
     ret Num.297;
 
 procedure Str.16 (#Attr.2, #Attr.3):
-    let Str.251 : Str = lowlevel StrRepeat #Attr.2 #Attr.3;
-    ret Str.251;
+    let Str.250 : Str = lowlevel StrRepeat #Attr.2 #Attr.3;
+    ret Str.250;
 
 procedure Str.3 (#Attr.2, #Attr.3):
-    let Str.252 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
-    ret Str.252;
+    let Str.251 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
+    ret Str.251;
 
 procedure Test.1 ():
     let Test.21 : Str = "lllllllllllllllllllllooooooooooong";

--- a/crates/compiler/test_mono/generated/list_map_closure_owns.txt
+++ b/crates/compiler/test_mono/generated/list_map_closure_owns.txt
@@ -31,8 +31,8 @@ procedure Num.22 (#Attr.2, #Attr.3):
     ret Num.297;
 
 procedure Str.3 (#Attr.2, #Attr.3):
-    let Str.252 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
-    ret Str.252;
+    let Str.251 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
+    ret Str.251;
 
 procedure Test.1 ():
     let Test.21 : Str = "lllllllllllllllllllllooooooooooong";

--- a/crates/compiler/test_mono/generated/polymorphic_expression_unification.txt
+++ b/crates/compiler/test_mono/generated/polymorphic_expression_unification.txt
@@ -3,8 +3,8 @@ procedure Bool.11 (#Attr.2, #Attr.3):
     ret Bool.23;
 
 procedure Str.3 (#Attr.2, #Attr.3):
-    let Str.252 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
-    ret Str.252;
+    let Str.251 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
+    ret Str.251;
 
 procedure Test.2 (Test.7):
     let Test.24 : Str = ".trace(\"";

--- a/crates/compiler/test_mono/generated/recursively_build_effect.txt
+++ b/crates/compiler/test_mono/generated/recursively_build_effect.txt
@@ -3,8 +3,8 @@ procedure Num.20 (#Attr.2, #Attr.3):
     ret Num.297;
 
 procedure Str.3 (#Attr.2, #Attr.3):
-    let Str.253 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
-    ret Str.253;
+    let Str.252 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
+    ret Str.252;
 
 procedure Test.11 (Test.29, #Attr.12):
     let Test.32 : {} = UnionAtIndex (Id 0) (Index 0) #Attr.12;

--- a/crates/compiler/test_mono/generated/unspecialized_lambda_set_unification_does_not_duplicate_identical_concrete_types.txt
+++ b/crates/compiler/test_mono/generated/unspecialized_lambda_set_unification_does_not_duplicate_identical_concrete_types.txt
@@ -220,8 +220,8 @@ procedure Num.94 (#Attr.2, #Attr.3):
     ret Num.309;
 
 procedure Str.12 (#Attr.2):
-    let Str.252 : List U8 = lowlevel StrToUtf8 #Attr.2;
-    ret Str.252;
+    let Str.251 : List U8 = lowlevel StrToUtf8 #Attr.2;
+    ret Str.251;
 
 procedure Test.2 (Test.10):
     let Test.15 : {Str, Str} = CallByName Encode.23 Test.10;

--- a/crates/compiler/test_mono/generated/unspecialized_lambda_set_unification_keeps_all_concrete_types_without_unification_of_unifiable.txt
+++ b/crates/compiler/test_mono/generated/unspecialized_lambda_set_unification_keeps_all_concrete_types_without_unification_of_unifiable.txt
@@ -178,8 +178,8 @@ procedure Num.51 (#Attr.2, #Attr.3):
     ret Num.319;
 
 procedure Str.12 (#Attr.2):
-    let Str.252 : List U8 = lowlevel StrToUtf8 #Attr.2;
-    ret Str.252;
+    let Str.251 : List U8 = lowlevel StrToUtf8 #Attr.2;
+    ret Str.251;
 
 procedure Test.2 (Test.11):
     let Test.18 : {{}, {}} = CallByName Encode.23 Test.11;

--- a/crates/compiler/test_syntax/tests/snapshots/pass/newline_in_packages.full.formatted.roc
+++ b/crates/compiler/test_syntax/tests/snapshots/pass/newline_in_packages.full.formatted.roc
@@ -1,7 +1,7 @@
 app "hello"
     packages {
         pf:
-        "https://github.com/roc-lang/basic-cli/releases/download/0.7.1/Icc3xJoIixF3hCcfXrDwLCu4wQHtNdPyoJkEbkgIElA.tar.br",
+        "https://github.com/roc-lang/basic-cli/releases/download/0.8.1/x8URkvfyi9I0QhmVG98roKBUs_AZRkLFwFJVJ3942YA.tar.br",
     }
     imports [pf.Stdout]
     provides [main] to pf

--- a/crates/compiler/test_syntax/tests/snapshots/pass/newline_in_packages.full.result-ast
+++ b/crates/compiler/test_syntax/tests/snapshots/pass/newline_in_packages.full.result-ast
@@ -24,7 +24,7 @@ Full {
                                         Newline,
                                     ],
                                     package_name: @31-145 PackageName(
-                                        "https://github.com/roc-lang/basic-cli/releases/download/0.7.1/Icc3xJoIixF3hCcfXrDwLCu4wQHtNdPyoJkEbkgIElA.tar.br",
+                                        "https://github.com/roc-lang/basic-cli/releases/download/0.8.1/x8URkvfyi9I0QhmVG98roKBUs_AZRkLFwFJVJ3942YA.tar.br",
                                     ),
                                 },
                                 [

--- a/crates/compiler/test_syntax/tests/snapshots/pass/newline_in_packages.full.roc
+++ b/crates/compiler/test_syntax/tests/snapshots/pass/newline_in_packages.full.roc
@@ -1,6 +1,6 @@
 app "hello"
     packages { pf:
-"https://github.com/roc-lang/basic-cli/releases/download/0.7.1/Icc3xJoIixF3hCcfXrDwLCu4wQHtNdPyoJkEbkgIElA.tar.br"
+"https://github.com/roc-lang/basic-cli/releases/download/0.8.1/x8URkvfyi9I0QhmVG98roKBUs_AZRkLFwFJVJ3942YA.tar.br"
 }
     imports [pf.Stdout]
     provides [main] to pf

--- a/crates/compiler/uitest/tests/ability/specialize/inspect/opaque_automatic.txt
+++ b/crates/compiler/uitest/tests/ability/specialize/inspect/opaque_automatic.txt
@@ -46,8 +46,8 @@ procedure Inspect.62 (Inspect.306):
     ret Inspect.306;
 
 procedure Str.3 (#Attr.2, #Attr.3):
-    let Str.251 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
-    ret Str.251;
+    let Str.250 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
+    ret Str.250;
 
 procedure Test.0 ():
     let Test.4 : {} = Struct {};

--- a/crates/compiler/uitest/tests/ability/specialize/inspect/opaque_automatic_late.txt
+++ b/crates/compiler/uitest/tests/ability/specialize/inspect/opaque_automatic_late.txt
@@ -49,8 +49,8 @@ procedure Inspect.62 (Inspect.306):
     ret Inspect.306;
 
 procedure Str.3 (#Attr.2, #Attr.3):
-    let Str.251 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
-    ret Str.251;
+    let Str.250 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
+    ret Str.250;
 
 procedure Test.2 (Test.3):
     let Test.4 : Str = CallByName Inspect.34 Test.3;

--- a/examples/cli/argsBROKEN.roc
+++ b/examples/cli/argsBROKEN.roc
@@ -1,5 +1,5 @@
 app "args"
-    packages { pf: "https://github.com/roc-lang/basic-cli/releases/download/0.7.1/Icc3xJoIixF3hCcfXrDwLCu4wQHtNdPyoJkEbkgIElA.tar.br" }
+    packages { pf: "https://github.com/roc-lang/basic-cli/releases/download/0.8.1/x8URkvfyi9I0QhmVG98roKBUs_AZRkLFwFJVJ3942YA.tar.br" }
     imports [pf.Stdout, pf.Arg, pf.Task.{ Task }]
     provides [main] to pf
 

--- a/examples/cli/countdown.roc
+++ b/examples/cli/countdown.roc
@@ -1,5 +1,5 @@
 app "countdown"
-    packages { pf: "https://github.com/roc-lang/basic-cli/releases/download/0.7.1/Icc3xJoIixF3hCcfXrDwLCu4wQHtNdPyoJkEbkgIElA.tar.br" }
+    packages { pf: "https://github.com/roc-lang/basic-cli/releases/download/0.8.1/x8URkvfyi9I0QhmVG98roKBUs_AZRkLFwFJVJ3942YA.tar.br" }
     imports [pf.Stdin, pf.Stdout, pf.Task.{ await, loop }]
     provides [main] to pf
 

--- a/examples/cli/echo.roc
+++ b/examples/cli/echo.roc
@@ -1,5 +1,5 @@
 app "echo"
-    packages { pf: "https://github.com/roc-lang/basic-cli/releases/download/0.7.1/Icc3xJoIixF3hCcfXrDwLCu4wQHtNdPyoJkEbkgIElA.tar.br" }
+    packages { pf: "https://github.com/roc-lang/basic-cli/releases/download/0.8.1/x8URkvfyi9I0QhmVG98roKBUs_AZRkLFwFJVJ3942YA.tar.br" }
     imports [pf.Stdin, pf.Stdout, pf.Task.{ Task }]
     provides [main] to pf
 

--- a/examples/cli/env.roc
+++ b/examples/cli/env.roc
@@ -1,5 +1,5 @@
 app "env"
-    packages { pf: "https://github.com/roc-lang/basic-cli/releases/download/0.7.1/Icc3xJoIixF3hCcfXrDwLCu4wQHtNdPyoJkEbkgIElA.tar.br" }
+    packages { pf: "https://github.com/roc-lang/basic-cli/releases/download/0.8.1/x8URkvfyi9I0QhmVG98roKBUs_AZRkLFwFJVJ3942YA.tar.br" }
     imports [pf.Stdout, pf.Stderr, pf.Env, pf.Task.{ Task }]
     provides [main] to pf
 

--- a/examples/cli/fileBROKEN.roc
+++ b/examples/cli/fileBROKEN.roc
@@ -1,5 +1,5 @@
 app "file-io"
-    packages { pf: "https://github.com/roc-lang/basic-cli/releases/download/0.7.1/Icc3xJoIixF3hCcfXrDwLCu4wQHtNdPyoJkEbkgIElA.tar.br" }
+    packages { pf: "https://github.com/roc-lang/basic-cli/releases/download/0.8.1/x8URkvfyi9I0QhmVG98roKBUs_AZRkLFwFJVJ3942YA.tar.br" }
     imports [
         pf.Stdout,
         pf.Stderr,

--- a/examples/cli/form.roc
+++ b/examples/cli/form.roc
@@ -1,5 +1,5 @@
 app "form"
-    packages { pf: "https://github.com/roc-lang/basic-cli/releases/download/0.7.1/Icc3xJoIixF3hCcfXrDwLCu4wQHtNdPyoJkEbkgIElA.tar.br" }
+    packages { pf: "https://github.com/roc-lang/basic-cli/releases/download/0.8.1/x8URkvfyi9I0QhmVG98roKBUs_AZRkLFwFJVJ3942YA.tar.br" }
     imports [pf.Stdin, pf.Stdout, pf.Task.{ await, Task }]
     provides [main] to pf
 

--- a/examples/cli/http-get.roc
+++ b/examples/cli/http-get.roc
@@ -1,5 +1,5 @@
 app "http-get"
-    packages { pf: "https://github.com/roc-lang/basic-cli/releases/download/0.7.1/Icc3xJoIixF3hCcfXrDwLCu4wQHtNdPyoJkEbkgIElA.tar.br" }
+    packages { pf: "https://github.com/roc-lang/basic-cli/releases/download/0.8.1/x8URkvfyi9I0QhmVG98roKBUs_AZRkLFwFJVJ3942YA.tar.br" }
     imports [pf.Http, pf.Task.{ Task }, pf.Stdin, pf.Stdout]
     provides [main] to pf
 

--- a/examples/cli/ingested-file-bytes.roc
+++ b/examples/cli/ingested-file-bytes.roc
@@ -1,5 +1,5 @@
 app "ingested-file-bytes"
-    packages { pf: "https://github.com/roc-lang/basic-cli/releases/download/0.7.1/Icc3xJoIixF3hCcfXrDwLCu4wQHtNdPyoJkEbkgIElA.tar.br" }
+    packages { pf: "https://github.com/roc-lang/basic-cli/releases/download/0.8.1/x8URkvfyi9I0QhmVG98roKBUs_AZRkLFwFJVJ3942YA.tar.br" }
     imports [
         pf.Stdout,
         "../../LICENSE" as license : _, # A type hole can also be used here.

--- a/examples/cli/ingested-file.roc
+++ b/examples/cli/ingested-file.roc
@@ -1,5 +1,5 @@
 app "ingested-file"
-    packages { pf: "https://github.com/roc-lang/basic-cli/releases/download/0.7.1/Icc3xJoIixF3hCcfXrDwLCu4wQHtNdPyoJkEbkgIElA.tar.br" }
+    packages { pf: "https://github.com/roc-lang/basic-cli/releases/download/0.8.1/x8URkvfyi9I0QhmVG98roKBUs_AZRkLFwFJVJ3942YA.tar.br" }
     imports [
         pf.Stdout,
         "ingested-file.roc" as ownCode : Str,
@@ -7,4 +7,4 @@ app "ingested-file"
     provides [main] to pf
 
 main =
-    Stdout.line "\nThis roc file can print it's own source code. The source is:\n\n\(ownCode)"
+    Stdout.line "\nThis roc file can print its own source code. The source is:\n\n$(ownCode)"

--- a/examples/helloWorld.roc
+++ b/examples/helloWorld.roc
@@ -1,5 +1,5 @@
 app "helloWorld"
-    packages { pf: "https://github.com/roc-lang/basic-cli/releases/download/0.7.1/Icc3xJoIixF3hCcfXrDwLCu4wQHtNdPyoJkEbkgIElA.tar.br" }
+    packages { pf: "https://github.com/roc-lang/basic-cli/releases/download/0.8.1/x8URkvfyi9I0QhmVG98roKBUs_AZRkLFwFJVJ3942YA.tar.br" }
     imports [pf.Stdout]
     provides [main] to pf
 

--- a/examples/inspect-logging.roc
+++ b/examples/inspect-logging.roc
@@ -2,7 +2,7 @@
 # Shows how Roc values can be logged
 #
 app "inspect-logging"
-    packages { pf: "https://github.com/roc-lang/basic-cli/releases/download/0.7.1/Icc3xJoIixF3hCcfXrDwLCu4wQHtNdPyoJkEbkgIElA.tar.br" }
+    packages { pf: "https://github.com/roc-lang/basic-cli/releases/download/0.8.1/x8URkvfyi9I0QhmVG98roKBUs_AZRkLFwFJVJ3942YA.tar.br" }
     imports [
         pf.Stdout,
         Community,

--- a/examples/parser/letter-counts.roc
+++ b/examples/parser/letter-counts.roc
@@ -1,6 +1,6 @@
 app "example"
     packages {
-        cli: "https://github.com/roc-lang/basic-cli/releases/download/0.7.1/Icc3xJoIixF3hCcfXrDwLCu4wQHtNdPyoJkEbkgIElA.tar.br",
+        cli: "https://github.com/roc-lang/basic-cli/releases/download/0.8.1/x8URkvfyi9I0QhmVG98roKBUs_AZRkLFwFJVJ3942YA.tar.br",
         parser: "https://github.com/lukewilliamboswell/roc-parser/releases/download/0.5/KB-TITJ4DfunB88sFBWjCtCGV7LRRDdTH5JUXp4gIb8.tar.br",
     }
     imports [

--- a/examples/parser/letter-counts.roc
+++ b/examples/parser/letter-counts.roc
@@ -1,7 +1,7 @@
 app "example"
     packages {
         cli: "https://github.com/roc-lang/basic-cli/releases/download/0.8.1/x8URkvfyi9I0QhmVG98roKBUs_AZRkLFwFJVJ3942YA.tar.br",
-        parser: "https://github.com/lukewilliamboswell/roc-parser/releases/download/0.5/KB-TITJ4DfunB88sFBWjCtCGV7LRRDdTH5JUXp4gIb8.tar.br",
+        parser: "https://github.com/lukewilliamboswell/roc-parser/releases/download/0.5.2/9VrPjwfQQ1QeSL3CfmWr2Pr9DESdDIXy97pwpuq84Ck.tar.br",
     }
     imports [
         cli.Stdout,

--- a/examples/parser/parse-movies-csv.roc
+++ b/examples/parser/parse-movies-csv.roc
@@ -1,6 +1,6 @@
 app "example"
     packages {
-        pf: "https://github.com/roc-lang/basic-cli/releases/download/0.7.1/Icc3xJoIixF3hCcfXrDwLCu4wQHtNdPyoJkEbkgIElA.tar.br",
+        pf: "https://github.com/roc-lang/basic-cli/releases/download/0.8.1/x8URkvfyi9I0QhmVG98roKBUs_AZRkLFwFJVJ3942YA.tar.br",
         parser: "https://github.com/lukewilliamboswell/roc-parser/releases/download/0.5/KB-TITJ4DfunB88sFBWjCtCGV7LRRDdTH5JUXp4gIb8.tar.br",
     }
     imports [

--- a/examples/parser/parse-movies-csv.roc
+++ b/examples/parser/parse-movies-csv.roc
@@ -1,7 +1,7 @@
 app "example"
     packages {
         pf: "https://github.com/roc-lang/basic-cli/releases/download/0.8.1/x8URkvfyi9I0QhmVG98roKBUs_AZRkLFwFJVJ3942YA.tar.br",
-        parser: "https://github.com/lukewilliamboswell/roc-parser/releases/download/0.5/KB-TITJ4DfunB88sFBWjCtCGV7LRRDdTH5JUXp4gIb8.tar.br",
+        parser: "https://github.com/lukewilliamboswell/roc-parser/releases/download/0.5.2/9VrPjwfQQ1QeSL3CfmWr2Pr9DESdDIXy97pwpuq84Ck.tar.br",
     }
     imports [
         pf.Stdout,

--- a/examples/static-site-gen/platform/Html.roc
+++ b/examples/static-site-gen/platform/Html.roc
@@ -126,8 +126,8 @@ interface Html
 
 Node : [
     Text Str,
-    Element Str Nat (List Attribute) (List Node),
-    UnclosedElem Str Nat (List Attribute),
+    Element Str U64 (List Attribute) (List Node),
+    UnclosedElem Str U64 (List Attribute),
 ]
 
 Attribute : Html.Attributes.Attribute
@@ -172,7 +172,7 @@ unclosedElem = \tagName ->
         UnclosedElem tagName totalSize attrs
 
 # internal helper
-nodeSize : Node -> Nat
+nodeSize : Node -> U64
 nodeSize = \node ->
     when node is
         Text content ->

--- a/www/content/platforms.md
+++ b/www/content/platforms.md
@@ -1,6 +1,6 @@
 # Platforms
 
-Something that sets Roc apart from other programming languages is its <span class="nowrap">*platforms and applications*</span> architecture.
+Something that sets Roc apart from other programming languages is its <span class="nowrap">_platforms and applications_</span> architecture.
 
 ## [Applications](#applications) {#applications}
 
@@ -8,7 +8,7 @@ Here is a Roc application that prints `"Hello, World!"` to the command line:
 
 ```roc
 app "hello"
-    packages { pf: "https://github.com/roc-lang/basic-cli/releases/download/0.7.1/Icc3xJoIixF3hCcfXrDwLCu4wQHtNdPyoJkEbkgIElA.tar.br" }
+    packages { pf: "https://github.com/roc-lang/basic-cli/releases/download/0.8.1/x8URkvfyi9I0QhmVG98roKBUs_AZRkLFwFJVJ3942YA.tar.br" }
     imports [pf.Stdout]
     provides [main] to pf
 
@@ -26,19 +26,20 @@ Also like many game engines and Web frameworks, Roc platforms have a high-level 
 
 Here are some example Roc platforms, and functionality they might provide:
 
-* A Roc game engine platform might provide functionality for rendering and sound.
-* A Roc Web server platform (like [basic-webserver](https://github.com/roc-lang/basic-webserver)) probably would not provide functionality for rendering and sound, but it might provide functionality for responding to incoming HTTP requests—which a game engine platform likely would not.
-* A Roc native [GUI](https://en.wikipedia.org/wiki/Graphical_user_interface) platform might provide functionality for defining native operating system UI elements, whereas a game engine platform might focus more on rendering with [shaders](https://en.wikipedia.org/wiki/Shader), and a Web server platform would not have GUI functionality at all.
+-   A Roc game engine platform might provide functionality for rendering and sound.
+-   A Roc Web server platform (like [basic-webserver](https://github.com/roc-lang/basic-webserver)) probably would not provide functionality for rendering and sound, but it might provide functionality for responding to incoming HTTP requests—which a game engine platform likely would not.
+-   A Roc native [GUI](https://en.wikipedia.org/wiki/Graphical_user_interface) platform might provide functionality for defining native operating system UI elements, whereas a game engine platform might focus more on rendering with [shaders](https://en.wikipedia.org/wiki/Shader), and a Web server platform would not have GUI functionality at all.
 
-These are broad domains, but platforms can be much more specific than this. For example, anyone could make a platform for writing [Vim](https://en.wikipedia.org/wiki/Vim_(text_editor)) plugins, or [Postgres](https://en.wikipedia.org/wiki/PostgreSQL) extensions, or robots ([which has already happened](https://roc.zulipchat.com/#narrow/stream/304902-show-and-tell/topic/Roc.20on.20a.20microcontroller/near/286678630)), or even [implementing servo logic for a clock that physically turns panels to simulate an LCD](https://roc.zulipchat.com/#narrow/stream/304641-ideas/topic/Roc.20Clock/near/327939600). You really can get as specific as you like!
+These are broad domains, but platforms can be much more specific than this. For example, anyone could make a platform for writing [Vim](<https://en.wikipedia.org/wiki/Vim_(text_editor)>) plugins, or [Postgres](https://en.wikipedia.org/wiki/PostgreSQL) extensions, or robots ([which has already happened](https://roc.zulipchat.com/#narrow/stream/304902-show-and-tell/topic/Roc.20on.20a.20microcontroller/near/286678630)), or even [implementing servo logic for a clock that physically turns panels to simulate an LCD](https://roc.zulipchat.com/#narrow/stream/304641-ideas/topic/Roc.20Clock/near/327939600). You really can get as specific as you like!
 
 Platforms can also be designed to have a single, specific application run on them. For example, you can make a platform that is essentially "your entire existing code base in another language," and then use Roc as an embedded language within that code base. For example, [Vendr](https://www.vendr.com/careers) is using this strategy to call Roc functions from their [Node.js](https://nodejs.org/en) backend using [roc-esbuild](https://github.com/vendrinc/roc-esbuild), as a way to incrementally transition code from Node to Roc.
 
 ## [Platform scope](#scope) {#scope}
 
 Roc platforms have a broader scope of responsibility than game engines or Web frameworks. In addition to providing a nice domain-specific interface, platforms are also responsible for:
-* Tailoring memory management to that domain (more on this later)
-* Providing all I/O primitives
+
+-   Tailoring memory management to that domain (more on this later)
+-   Providing all I/O primitives
 
 In most languages, I/O primitives come with the standard library. In Roc, the [standard library](https://www.roc-lang.org/builtins/) contains only data structures; an application gets all of its I/O primitives from its platform. For example, in the "Hello, World" application above, the `Stdout.line` function comes from the `basic-cli` platform itself, not from Roc's standard library.
 
@@ -48,7 +49,7 @@ This design has a few benefits.
 
 Some I/O operations make sense in some use cases but not others.
 
-For example, suppose I'm building an application on a platform for command-line interfaces, and I use a third-party package which sometimes blocks the program while it waits for [standard input](https://en.wikipedia.org/wiki/Standard_streams#Standard_input_(stdin)). This might be fine for my command-line application, but it would probably be a very bad fit if I'm using a webserver. Similarly, a package which does some occasional file I/O for caching might work fine on either of those platforms, but might break in surprising ways when used in a platform that's designed to run in a browser on WebAssembly—since browsers don't offer arbitrary file I/O access!
+For example, suppose I'm building an application on a platform for command-line interfaces, and I use a third-party package which sometimes blocks the program while it waits for [standard input](<https://en.wikipedia.org/wiki/Standard_streams#Standard_input_(stdin)>). This might be fine for my command-line application, but it would probably be a very bad fit if I'm using a webserver. Similarly, a package which does some occasional file I/O for caching might work fine on either of those platforms, but might break in surprising ways when used in a platform that's designed to run in a browser on WebAssembly—since browsers don't offer arbitrary file I/O access!
 
 Because Roc's I/O primitives come from platforms, these mismatches can be prevented at build time. The browser-based platform would not expose file I/O primitives, the webserver wouldn't expose a way to block on reading from standard input, and so on. (Note that there's a design in the works for allowing packages which perform I/O to work across multiple platforms—but only platforms which support the I/O primitives it requires—but this design has not yet been implemented.)
 
@@ -58,7 +59,7 @@ Since platforms have exclusive control over all I/O primitives, one of the thing
 
 [This talk](https://www.youtube.com/watch?v=cpQwtwVKAfU&t=75s) shows an example of taking this idea a step further with a "safe scripting" platform for writing command-line scripts. The idea is that you could download a script from the Internet and run it on this platform without worrying that the script would do bad things to your computer, because the platform would (much like a Web browser) show you specific prompts before allowing the script to do potentially harmful I/O, such as filesystem operations.
 
-These security guarantees can be relied on because platforms have *exclusive* control over all I/O primitives, including how they are implemented. There are no escape hatches that a malicious program could use to get around these, either; for example, Roc programs that want to call functions in other languages must do so using primitives provided by the platform, which the platform can disallow (or sandbox with end-user prompts) in the same way.
+These security guarantees can be relied on because platforms have _exclusive_ control over all I/O primitives, including how they are implemented. There are no escape hatches that a malicious program could use to get around these, either; for example, Roc programs that want to call functions in other languages must do so using primitives provided by the platform, which the platform can disallow (or sandbox with end-user prompts) in the same way.
 
 ### [Performance benefits](#performance) {#performance}
 
@@ -75,8 +76,9 @@ To understand how platforms can tailor automatic memory management to their part
 ### [The Host and the Roc API](#host-and-roc-api) {#host-and-roc-api}
 
 Each platform consists of two parts:
-* **The Roc API** is the part that application authors see. For example, `Stdout.line` is part of basic-cli's Roc API.
-* **The Host** is the under-the-hood implementation written in a language other than Roc. For example, basic-cli's host is written in Rust. It has a Rust function which implements the behavior of the `Stdout.line` operation, and all the other I/O operations it supports.
+
+-   **The Roc API** is the part that application authors see. For example, `Stdout.line` is part of basic-cli's Roc API.
+-   **The Host** is the under-the-hood implementation written in a language other than Roc. For example, basic-cli's host is written in Rust. It has a Rust function which implements the behavior of the `Stdout.line` operation, and all the other I/O operations it supports.
 
 This design means that application authors don't necessarily need to know (or care) about the non-Roc language being used to implement the platform's host. That can be a behind-the-scenes implementation detail that only the platform's author(s) are concerned with. Application authors only interact with the public-facing Roc API.
 
@@ -97,6 +99,7 @@ When a compiled Roc program runs, it's actually the host—not the Roc applicati
 Knowing this, a useful mental model for how Roc platforms and applications interact at the implementation level is: the Roc application compiles down to a C library which the platform can choose to call (or not).
 
 This is essentially what's happening behind the scenes when you run `roc build`. Specifically:
+
 1. The Roc compiler builds the Roc application into a binary [object file](https://en.wikipedia.org/wiki/Object_file)
 2. Since that application specified its platform, the compiler then looks up the platform's host implementation (which the platform will have provided as an already-compiled binary)
 3. Now that it has a binary for the Roc application and a binary for the host, it links them together into one combined binary in which the host portion calls the application portion as many times as it likes.
@@ -109,6 +112,6 @@ Every Roc application has exactly one platform. That platform provides all the I
 
 This I/O design has [security benefits](#security), [ecosystem benefits](#ecosystem), and [performance benefits](#performance). The [domain-specific memory management](#memory) platforms can implement can offer additional benefits as well.
 
-Applications only interact with the *Roc API* portion of a platform, but there is also a *host* portion (written in a different language) that works behind the scenes. The host determines how the program starts, how memory is allocated and deallocated, and how I/O primitives are implemented.
+Applications only interact with the _Roc API_ portion of a platform, but there is also a _host_ portion (written in a different language) that works behind the scenes. The host determines how the program starts, how memory is allocated and deallocated, and how I/O primitives are implemented.
 
 Anyone can implement their own platform. There isn't yet an official guide about how to do this, so the best way to get help if you'd like to create a platform is to [say hi in the `#beginners` channel](https://roc.zulipchat.com/#narrow/stream/231634-beginners) on [Roc Zulip!](https://roc.zulipchat.com)

--- a/www/content/tutorial.md
+++ b/www/content/tutorial.md
@@ -36,9 +36,9 @@
 
 ## [REPL](#repl) {#repl}
 
-Let's start by getting acquainted with Roc's [_Read-Eval-Print-Loop_](https://en.wikipedia.org/wiki/Read%E2%80%93eval%E2%80%93print_loop), or **REPL** for short. 
+Let's start by getting acquainted with Roc's [_Read-Eval-Print-Loop_](https://en.wikipedia.org/wiki/Read%E2%80%93eval%E2%80%93print_loop), or **REPL** for short.
 
-You can use the online REPL at [roc-lang.org/repl](https://www.roc-lang.org/repl). 
+You can use the online REPL at [roc-lang.org/repl](https://www.roc-lang.org/repl).
 
 Or you can run this in a terminal: <code class="block">roc repl</code>, and if Roc is [installed](/install), you should see this:
 
@@ -164,7 +164,7 @@ Make a file named `main.roc` and put this in it:
 
 ```roc
 app "hello"
-    packages { pf: "https://github.com/roc-lang/basic-cli/releases/download/0.7.1/Icc3xJoIixF3hCcfXrDwLCu4wQHtNdPyoJkEbkgIElA.tar.br" }
+    packages { pf: "https://github.com/roc-lang/basic-cli/releases/download/0.8.1/x8URkvfyi9I0QhmVG98roKBUs_AZRkLFwFJVJ3942YA.tar.br" }
     imports [pf.Stdout]
     provides [main] to pf
 
@@ -207,9 +207,9 @@ You should see this:
 
 A definition names an expression.
 
-- The first two defs assign the names `birds` and `iguanas` to the expressions `3` and `2`.
-- The next def assigns the name `total` to the expression `Num.toStr (birds + iguanas)`.
-- The last def assigns the name `main` to an expression which returns a `Task`. We'll [discuss tasks later](#tasks).
+-   The first two defs assign the names `birds` and `iguanas` to the expressions `3` and `2`.
+-   The next def assigns the name `total` to the expression `Num.toStr (birds + iguanas)`.
+-   The last def assigns the name `main` to an expression which returns a `Task`. We'll [discuss tasks later](#tasks).
 
 Once we have a def, we can use its name in other expressions. For example, the `total` expression refers to `birds` and `iguanas`, and `Stdout.line "There are $(total) animals."` refers to `total`.
 
@@ -260,8 +260,8 @@ addAndStringify = \num1, num2 ->
 
 We did two things here:
 
-- We introduced a _local def_ named `sum`, and set it equal to `num1 + num2`. Because we defined `sum` inside `addAndStringify`, it's _local_ to that scope and can't be accessed outside that function.
-- We added an `if`\-`then`\-`else` conditional to return either `""` or `Num.toStr sum` depending on whether `sum == 0`.
+-   We introduced a _local def_ named `sum`, and set it equal to `num1 + num2`. Because we defined `sum` inside `addAndStringify`, it's _local_ to that scope and can't be accessed outside that function.
+-   We added an `if`\-`then`\-`else` conditional to return either `""` or `Num.toStr sum` depending on whether `sum == 0`.
 
 Every `if` must be accompanied by both `then` and also `else`. Having an `if` without an `else` is an error, because `if` is an expression, and all expressions must evaluate to a value. If there were ever an `if` without an `else`, that would be an expression that might not evaluate to a value!
 
@@ -367,7 +367,7 @@ addAndStringify = \counts ->
     Num.toStr (counts.birds + counts.iguanas)
 ```
 
-The function now takes a _record_, which is a group of named values. Records are not [objects](https://en.wikipedia.org/wiki/Object_(computer_science)); they don't have methods or inheritance, they just store information.
+The function now takes a _record_, which is a group of named values. Records are not [objects](<https://en.wikipedia.org/wiki/Object_(computer_science)>); they don't have methods or inheritance, they just store information.
 
 The expression `{ birds: 5, iguanas: 7 }` defines a record with two _fields_ (the `birds` field and the `iguanas` field) and then assigns the number `5` to the `birds` field and the number `7` to the `iguanas` field. Order doesn't matter with record fields; we could have also specified `iguanas` first and `birds` second, and Roc would consider it the exact same record.
 
@@ -411,10 +411,10 @@ returnFoo { foo: "hi!", bar: "blah" }
 Sometimes we assign a def to a field that happens to have the same name—for example, `{ x: x }`.
 In these cases, we shorten it to writing the name of the def alone—for example, `{ x }`. We can do this with as many fields as we like; here are several different ways to define the same record:
 
-- `{ x: x, y: y }`
-- `{ x, y }`
-- `{ x: x, y }`
-- `{ x, y: y }`
+-   `{ x: x, y: y }`
+-   `{ x, y }`
+-   `{ x: x, y }`
+-   `{ x, y: y }`
 
 ### [Record destructuring](#record-destructuring) {#record-destructuring}
 
@@ -452,8 +452,8 @@ fromOriginal = { original & birds: 4, iguanas: 3 }
 
 The `fromScratch` and `fromOriginal` records are equal, although they're defined in different ways.
 
-- `fromScratch` was built using the same record syntax we've been using up to this point.
-- `fromOriginal` created a new record using the contents of `original` as defaults for fields that it didn't specify after the `&`.
+-   `fromScratch` was built using the same record syntax we've been using up to this point.
+-   `fromOriginal` created a new record using the contents of `original` as defaults for fields that it didn't specify after the `&`.
 
 Note that `&` can't introduce new fields to a record, or change the types of existing fields.
 (Trying to do either of these will result in an error at build time!)
@@ -474,7 +474,7 @@ table = \{
     ->
 ```
 
-This is using *optional field destructuring* to destructure a record while
+This is using _optional field destructuring_ to destructure a record while
 also providing default values for any fields that might be missing.
 
 Here's the type of `table`:
@@ -490,8 +490,8 @@ table :
     -> Table
 ```
 
-This says that `table` takes a record with two *required* fields, `height` and
-`width`, and two *optional* fields, `title` and `description`. It also says that
+This says that `table` takes a record with two _required_ fields, `height` and
+`width`, and two _optional_ fields, `title` and `description`. It also says that
 the `height` and `width` fields have the type `Pixels`, a type alias for some
 numeric type, and the `title` and `description` fields have the type `Str`.
 This means you can choose to omit the `title`, `description`, or both fields, when calling the function... but if you provide them, they must have the type `Str`.
@@ -504,7 +504,7 @@ These default values can reference other expressions in the record destructure; 
 Destructuring is the only way to implement a record with optional fields. For example, if you write the expression `config.title` and `title` is an
 optional field, you'll get a compile error.
 
-This means it's never possible to end up with an *optional value* that exists
+This means it's never possible to end up with an _optional value_ that exists
 outside a record field. Optionality is a concept that exists only in record
 fields, and it's intended for the use case of config records like this. The
 ergonomics of destructuring mean this wouldn't be a good fit for data modeling, consider using a `Result` type instead.
@@ -861,6 +861,7 @@ These functions demonstrate a common pattern in Roc: operations that can fail re
 Result.withDefault (List.get ["a", "b", "c"] 100) ""
 # returns "" because that's the default we said to use if List.get returned an Err
 ```
+
 ```roc
 Result.isOk (List.get ["a", "b", "c"] 1)
 # returns `Bool.true` because `List.get` returned an `Ok` tag. (The payload gets ignored.)
@@ -875,9 +876,9 @@ that quite does what you want, and you might find yourself calling `List.get` re
 retrieve every element in the list and use it to build up the new value you want. That approach
 can work, but it has a few downsides:
 
-* Each `List.get` call returns a `Result` that must be dealt with, even though you plan to use every element in the list anyway
-* There's a runtime performance overhead associated with each of these `Result`s, which you won't find in other "look at every element in the list" operations like `List.keepIf`.
-* It's more verbose than the alternative we're about to discuss
+-   Each `List.get` call returns a `Result` that must be dealt with, even though you plan to use every element in the list anyway
+-   There's a runtime performance overhead associated with each of these `Result`s, which you won't find in other "look at every element in the list" operations like `List.keepIf`.
+-   It's more verbose than the alternative we're about to discuss
 
 The `List.walk` function gives you a way to walk over the elements in a list and build up whatever
 return value you like. It's a great alternative to calling `List.get` on every element in the list
@@ -905,13 +906,13 @@ In this example, we walk over the list `[1, 2, 3, 4, 5]` and add each element to
 
 It then proceeds to walk over each element in the list and call that function. Each time, the state that function returns becomes the argument to the next function call. Here are the arguments the function will receive, and what it will return, as `List.walk` walks over the list `[1, 2, 3, 4, 5]`:
 
-|               State               | Element |             Return Value             |
+| State                             | Element | Return Value                         |
 | --------------------------------- | ------- | ------------------------------------ |
-|     `{ evens: [], odds: [] }`     |   `1`   |      `{ evens: [], odds: [1] }`      |
-|     `{ evens: [], odds: [1] }`    |   `2`   |      `{ evens: [2], odds: [1] }`     |
-|    `{ evens: [2], odds: [1] }`    |   `3`   |    `{ evens: [2], odds: [1, 3] }`    |
-|   `{ evens: [2], odds: [1, 3] }`  |   `4`   |   `{ evens: [2, 4], odds: [1, 3] }`  |
-| `{ evens: [2, 4], odds: [1, 3] }` |   `5`   | `{ evens: [2, 4], odds: [1, 3, 5] }` |
+| `{ evens: [], odds: [] }`         | `1`     | `{ evens: [], odds: [1] }`           |
+| `{ evens: [], odds: [1] }`        | `2`     | `{ evens: [2], odds: [1] }`          |
+| `{ evens: [2], odds: [1] }`       | `3`     | `{ evens: [2], odds: [1, 3] }`       |
+| `{ evens: [2], odds: [1, 3] }`    | `4`     | `{ evens: [2, 4], odds: [1, 3] }`    |
+| `{ evens: [2, 4], odds: [1, 3] }` | `5`     | `{ evens: [2, 4], odds: [1, 3, 5] }` |
 
 Note that the initial `state` argument is `{ evens: [], odds: [] }` because that's the argument
 we passed `List.walk` for its initial state. From then on, each `state` argument is whatever the
@@ -932,6 +933,7 @@ When you have nested function calls, sometimes it can be clearer to write them i
 ```roc
 Result.withDefault (List.get ["a", "b", "c"] 1) ""
 ```
+
 ```roc
 List.get ["a", "b", "c"] 1
 |> Result.withDefault ""
@@ -954,6 +956,7 @@ One reason the `|>` operator injects the value as the first argument is to make 
 ```roc
 List.append ["a", "b", "c"] "d"
 ```
+
 ```roc
 ["a", "b", "c"]
 |> List.append "d"
@@ -964,9 +967,11 @@ Another example is `Num.div`. All three of the following do the same thing, beca
 ```roc
 first / second
 ```
+
 ```roc
 Num.div first second
 ```
+
 ```roc
 first |> Num.div second
 ```
@@ -1154,9 +1159,10 @@ Here, Roc's compiler will infer that `color`'s type is `[Red, Yellow, Green]`, b
 ### [Opaque Types](#opaque-types) {#opaque-types}
 
 A type can be defined to be opaque to hide its internal structure. This is a lot more amazing than it may seem. It can make your code more modular, robust, and easier to read:
-- If a type is opaque you can modify its internal structure and be certain that no dependencies need to be updated.
-- You can prevent that data needs to be checked multiple times. For example, you can create an opaque `NonEmptyList` from a `List` after you've checked it. Now all functions that you pass this `NonEmptyList` to do not need to handle the empty list case.
-- Having the type `Username` in a type signature gives you more context compared to `Str`. Even if the `Username` is an opaque type for `Str`.
+
+-   If a type is opaque you can modify its internal structure and be certain that no dependencies need to be updated.
+-   You can prevent that data needs to be checked multiple times. For example, you can create an opaque `NonEmptyList` from a `List` after you've checked it. Now all functions that you pass this `NonEmptyList` to do not need to handle the empty list case.
+-   Having the type `Username` in a type signature gives you more context compared to `Str`. Even if the `Username` is an opaque type for `Str`.
 
 You can create an opaque type with the `:=` operator. Let's make one called `Username`:
 
@@ -1198,24 +1204,24 @@ Following this pattern, the 16 in `I16` means that it's a signed 16-bit integer.
 
 Choosing a size depends on your performance needs and the range of numbers you want to represent. Consider:
 
-- Larger integer sizes can represent a wider range of numbers. If you absolutely need to represent numbers in a certain range, make sure to pick an integer size that can hold them!
-- Smaller integer sizes take up less memory. These savings rarely matter in variables and function arguments, but the sizes of integers that you use in data structures can add up. This can also affect whether those data structures fit in [cache lines](https://en.wikipedia.org/wiki/CPU_cache#Cache_performance), which can easily be a performance bottleneck.
-- Certain processors work faster on some numeric sizes than others. There isn't even a general rule like "larger numeric sizes run slower" (or the reverse, for that matter) that applies to all processors. In fact, if the CPU is taking too long to run numeric calculations, you may find a performance improvement by experimenting with numeric sizes that are larger than otherwise necessary. However, in practice, doing this typically degrades overall performance, so be careful to measure properly!
+-   Larger integer sizes can represent a wider range of numbers. If you absolutely need to represent numbers in a certain range, make sure to pick an integer size that can hold them!
+-   Smaller integer sizes take up less memory. These savings rarely matter in variables and function arguments, but the sizes of integers that you use in data structures can add up. This can also affect whether those data structures fit in [cache lines](https://en.wikipedia.org/wiki/CPU_cache#Cache_performance), which can easily be a performance bottleneck.
+-   Certain processors work faster on some numeric sizes than others. There isn't even a general rule like "larger numeric sizes run slower" (or the reverse, for that matter) that applies to all processors. In fact, if the CPU is taking too long to run numeric calculations, you may find a performance improvement by experimenting with numeric sizes that are larger than otherwise necessary. However, in practice, doing this typically degrades overall performance, so be careful to measure properly!
 
 Here are the different fixed-size integer types that Roc supports:
 
 | Range                                                                                                             | Type   |
-|-------------------------------------------------------------------------------------------------------------------|--------|
-| `-128`  <br> `127`                                                                                                | `I8`   |
-| `0`     <br> `255`                                                                                                | `U8`   |
-| `-32_768`  <br> `32_767`                                                                                          | `I16`  |
-| `0`     <br>  `65_535`                                                                                            | `U16`  |
+| ----------------------------------------------------------------------------------------------------------------- | ------ |
+| `-128` <br> `127`                                                                                                 | `I8`   |
+| `0` <br> `255`                                                                                                    | `U8`   |
+| `-32_768` <br> `32_767`                                                                                           | `I16`  |
+| `0` <br> `65_535`                                                                                                 | `U16`  |
 | `-2_147_483_648` <br> `2_147_483_647`                                                                             | `I32`  |
-| `0`     <br> (over 4 billion) `4_294_967_295`                                                                     | `U32`  |
+| `0` <br> (over 4 billion) `4_294_967_295`                                                                         | `U32`  |
 | `-9_223_372_036_854_775_808` <br> `9_223_372_036_854_775_807`                                                     | `I64`  |
-| `0`     <br> _(over 18 quintillion)_`18_446_744_073_709_551_615`                                                  | `U64`  |
+| `0` <br> _(over 18 quintillion)_`18_446_744_073_709_551_615`                                                      | `U64`  |
 | `-170_141_183_460_469_231_731_687_303_715_884_105_728` <br> `170_141_183_460_469_231_731_687_303_715_884_105_727` | `I128` |
-| `0`     <br>  _(over 340 undecillion)_`340_282_366_920_938_463_463_374_607_431_768_211_455`                       | `U128` |
+| `0` <br> _(over 340 undecillion)_`340_282_366_920_938_463_463_374_607_431_768_211_455`                            | `U128` |
 
 Roc also has one variable-size integer type: `Nat` (short for "natural number"). The size of `Nat` is equal to the size of a memory address, which varies by system. For example, when compiling for a 64-bit system, `Nat` works the same way as `U64`. When compiling for a 32-bit system, it works the same way as `U32`. Most popular computing devices today are 64-bit, so `Nat` is usually the same as `U64`, but Web Assembly is typically 32-bit - so when running a Roc program built for Web Assembly, `Nat` will work like a `U32` in that program.
 
@@ -1229,9 +1235,9 @@ As such, it's very important to design your integer operations not to exceed the
 
 Roc has three fractional types:
 
-- `F32`, a 32-bit [floating-point number](https://en.wikipedia.org/wiki/IEEE_754)
-- `F64`, a 64-bit [floating-point number](https://en.wikipedia.org/wiki/IEEE_754)
-- `Dec`, a 128-bit decimal [fixed-point number](https://en.wikipedia.org/wiki/Fixed-point_arithmetic)
+-   `F32`, a 32-bit [floating-point number](https://en.wikipedia.org/wiki/IEEE_754)
+-   `F64`, a 64-bit [floating-point number](https://en.wikipedia.org/wiki/IEEE_754)
+-   `Dec`, a 128-bit decimal [fixed-point number](https://en.wikipedia.org/wiki/Fixed-point_arithmetic)
 
 These are different from integers, they can represent numbers with fractional components, such as 1.5 and -0.123.
 
@@ -1260,9 +1266,11 @@ There's also an `Int` type which is only compatible with integers, and a `Frac` 
 ```roc
 Num.xor : Int a, Int a -> Int a
 ```
+
 ```roc
 Num.cos : Frac a -> Frac a
 ```
+
 When you write a number literal in Roc, it has the type `Num *`. So you could call `Num.xor 1 1` and also `Num.cos 1` and have them all work as expected; the number literal `1` has the type `Num *`, which is compatible with the more constrained types `Int` and `Frac`. For the same reason, you can pass number literals to functions expecting even more constrained types, like `I32` or `F64`.
 
 ### [Number Literals](#number-literals) {#number-literals}
@@ -1378,12 +1386,12 @@ So you'll want to use `roc dev` or `roc test` to get the output for `expect`.
 
 Each `.roc` file is a separate module and contains Roc code for different purposes. Here are all of the different types of modules that Roc supports;
 
-- **Builtins** provide functions that are automatically imported into every module.
-- **Applications** are combined with a platform and compiled into an executable.
-- **Interfaces** provide functions which can be imported into other modules.
-- **Packages** organise modules to share functionality across applications and platforms.
-- **Platforms** provide effects such as IO to interface with the outside world.
-- **Hosted** *note this module type is likely to be deprecated soon*.
+-   **Builtins** provide functions that are automatically imported into every module.
+-   **Applications** are combined with a platform and compiled into an executable.
+-   **Interfaces** provide functions which can be imported into other modules.
+-   **Packages** organise modules to share functionality across applications and platforms.
+-   **Platforms** provide effects such as IO to interface with the outside world.
+-   **Hosted** _note this module type is likely to be deprecated soon_.
 
 ### [Builtin Modules](#builtin-modules) {#builtin-modules}
 
@@ -1403,8 +1411,8 @@ These modules are not ordinary `.roc` files that live on your filesystem. Rather
 
 Besides being built into the compiler, the builtin modules are different from other modules in that:
 
-- They are always imported. You never need to add them to `imports`.
-- All their types are imported unqualified automatically. So you never need to write `Num.Nat`, because it's as if the `Num` module was imported using `imports [Num.{ Nat }]` (the same is true for all the other types in the `Num` module).
+-   They are always imported. You never need to add them to `imports`.
+-   All their types are imported unqualified automatically. So you never need to write `Num.Nat`, because it's as if the `Num` module was imported using `imports [Num.{ Nat }]` (the same is true for all the other types in the `Num` module).
 
 ### [App Module Header](#app-module-header) {#app-module-header}
 
@@ -1412,7 +1420,7 @@ Let's take a closer look at the part of `main.roc` above the `main` def:
 
 ```roc
 app "hello"
-    packages { pf: "https://github.com/roc-lang/basic-cli/releases/download/0.7.1/Icc3xJoIixF3hCcfXrDwLCu4wQHtNdPyoJkEbkgIElA.tar.br" }
+    packages { pf: "https://github.com/roc-lang/basic-cli/releases/download/0.8.1/x8URkvfyi9I0QhmVG98roKBUs_AZRkLFwFJVJ3942YA.tar.br" }
     imports [pf.Stdout]
     provides [main] to pf
 ```
@@ -1424,16 +1432,16 @@ The line `app "hello"` shows that this module is a Roc application. The "hello" 
 The remaining lines all involve the [platform](https://github.com/roc-lang/roc/wiki/Roc-concepts-explained#platform) this application is built on:
 
 ```roc
-packages { pf: "https://github.com/roc-lang/basic-cli/releases/download/0.7.1/Icc3xJoIixF3hCcfXrDwLCu4wQHtNdPyoJkEbkgIElA.tar.br" }
+packages { pf: "https://github.com/roc-lang/basic-cli/releases/download/0.8.1/x8URkvfyi9I0QhmVG98roKBUs_AZRkLFwFJVJ3942YA.tar.br" }
 imports [pf.Stdout]
 provides [main] to pf
 ```
 
 The `packages { pf: "https://...tar.br" }` part says three things:
 
-- We're going to be using a _package_ (a collection of modules) that can be downloaded from the URL `"https://...tar.br"`
-- That package's [base64](https://en.wikipedia.org/wiki/Base64#URL_applications)\-encoded [BLAKE3](<https://en.wikipedia.org/wiki/BLAKE_(hash_function)#BLAKE3>) cryptographic hash is the long string at the end (before the `.tar.br` file extension). Once the file has been downloaded, its contents will be verified against this hash, and it will only be installed if they match. This way, you can be confident the download was neither corrupted nor changed since it was originally published.
-- We're going to name that package `pf` so we can refer to it more concisely in the future.
+-   We're going to be using a _package_ (a collection of modules) that can be downloaded from the URL `"https://...tar.br"`
+-   That package's [base64](https://en.wikipedia.org/wiki/Base64#URL_applications)\-encoded [BLAKE3](<https://en.wikipedia.org/wiki/BLAKE_(hash_function)#BLAKE3>) cryptographic hash is the long string at the end (before the `.tar.br` file extension). Once the file has been downloaded, its contents will be verified against this hash, and it will only be installed if they match. This way, you can be confident the download was neither corrupted nor changed since it was originally published.
+-   We're going to name that package `pf` so we can refer to it more concisely in the future.
 
 The `imports [pf.Stdout]` line says that we want to import the `Stdout` module from the `pf` package, and make it available in the current module.
 
@@ -1512,10 +1520,10 @@ Tasks are technically not part of the Roc language, but they're very common in p
 
 In the `basic-cli` platform, we have four operations we can do:
 
-- Write a string to the terminal
-- Read a string from user input
-- Write a string to a file
-- Read a string from a file
+-   Write a string to the terminal
+-   Read a string from user input
+-   Write a string to a file
+-   Read a string from a file
 
 We'll use these four operations to learn about tasks.
 
@@ -1523,7 +1531,7 @@ Let's start with a basic "Hello World" program.
 
 ```roc
 app "cli-tutorial"
-    packages { pf: "https://github.com/roc-lang/basic-cli/releases/download/0.7.1/Icc3xJoIixF3hCcfXrDwLCu4wQHtNdPyoJkEbkgIElA.tar.br" }
+    packages { pf: "https://github.com/roc-lang/basic-cli/releases/download/0.8.1/x8URkvfyi9I0QhmVG98roKBUs_AZRkLFwFJVJ3942YA.tar.br" }
     imports [pf.Stdout]
     provides [main] to pf
 
@@ -1557,7 +1565,7 @@ Let's change `main` to read a line from `stdin`, and then print what we got:
 
 ```roc
 app "cli-tutorial"
-    packages { pf: "https://github.com/roc-lang/basic-cli/releases/download/0.7.1/Icc3xJoIixF3hCcfXrDwLCu4wQHtNdPyoJkEbkgIElA.tar.br" }
+    packages { pf: "https://github.com/roc-lang/basic-cli/releases/download/0.8.1/x8URkvfyi9I0QhmVG98roKBUs_AZRkLFwFJVJ3942YA.tar.br" }
     imports [pf.Stdout, pf.Stdin, pf.Task]
     provides [main] to pf
 
@@ -1602,7 +1610,7 @@ This works, but we can make it a little nicer to read. Let's change it to the fo
 
 ```roc
 app "cli-tutorial"
-    packages { pf: "https://github.com/roc-lang/basic-cli/releases/download/0.7.1/Icc3xJoIixF3hCcfXrDwLCu4wQHtNdPyoJkEbkgIElA.tar.br" }
+    packages { pf: "https://github.com/roc-lang/basic-cli/releases/download/0.8.1/x8URkvfyi9I0QhmVG98roKBUs_AZRkLFwFJVJ3942YA.tar.br" }
     imports [pf.Stdout, pf.Stdin, pf.Task.{ await }]
     provides [main] to pf
 
@@ -1704,15 +1712,15 @@ This way, it reads like a series of instructions:
 
 Some important things to note about backpassing and `await`:
 
-- `await` is not a language keyword in Roc! It's referring to the `Task.await` function, which we imported unqualified by writing `Task.{ await }` in our module imports. (That said, it is playing a similar role here to the `await` keyword in languages that have `async`/`await` keywords, even though in this case it's a function instead of a special keyword.)
-- Backpassing syntax does not need to be used with `await` in particular. It can be used with any function.
-- Roc's compiler treats functions defined with backpassing exactly the same way as functions defined the other way. The only difference between `\input ->` and `input <-` is how they look, so feel free to use whichever looks nicer to you!
+-   `await` is not a language keyword in Roc! It's referring to the `Task.await` function, which we imported unqualified by writing `Task.{ await }` in our module imports. (That said, it is playing a similar role here to the `await` keyword in languages that have `async`/`await` keywords, even though in this case it's a function instead of a special keyword.)
+-   Backpassing syntax does not need to be used with `await` in particular. It can be used with any function.
+-   Roc's compiler treats functions defined with backpassing exactly the same way as functions defined the other way. The only difference between `\input ->` and `input <-` is how they look, so feel free to use whichever looks nicer to you!
 
 See the [Task & Error Handling example](https://www.roc-lang.org/examples/Tasks/README.html) for a more detailed explanation of how to use tasks to help with error handling in a larger program.
 
 ## [Examples](#examples) {#examples}
 
-Well done on making it this far! 
+Well done on making it this far!
 
 We've covered all of the basic syntax and features of Roc in this Tutorial. You should now have a good foundation and be ready to start writing your own applications.
 
@@ -1733,9 +1741,9 @@ fullName = \user ->
 
 I can pass this function a record that has more fields than just `firstName` and `lastName`, as long as it has _at least_ both of those fields (and both of them are strings). So any of these calls would work:
 
-- `fullName { firstName: "Sam", lastName: "Sample" }`
-- `fullName { firstName: "Sam", lastName: "Sample", email: "blah@example.com" }`
-- `fullName { age: 5, firstName: "Sam", things: 3, lastName: "Sample", role: Admin }`
+-   `fullName { firstName: "Sam", lastName: "Sample" }`
+-   `fullName { firstName: "Sam", lastName: "Sample", email: "blah@example.com" }`
+-   `fullName { age: 5, firstName: "Sam", things: 3, lastName: "Sample", role: Admin }`
 
 This `user` argument is an _open record_ - that is, a description of a minimum set of fields on a record, and their types. When a function takes an open record as an argument, it's okay if you pass it a record with more fields than just the ones specified.
 
@@ -1775,9 +1783,9 @@ addHttps = \record ->
 
 This function uses _constrained records_ in its type. The annotation is saying:
 
-- This function takes a record which has at least a `url` field, and possibly others
-- That `url` field has the type `Str`
-- It returns a record of exactly the same type as the one it was given
+-   This function takes a record which has at least a `url` field, and possibly others
+-   That `url` field has the type `Str`
+-   It returns a record of exactly the same type as the one it was given
 
 So if we give this function a record with five fields, it will return a record with those same five fields. The only requirement is that one of those fields must be `url: Str`.
 
@@ -1785,9 +1793,9 @@ In practice, constrained records appear in type annotations much less often than
 
 Here's when you can typically expect to encounter these three flavors of type variables in records:
 
-- _Open records_ are what the compiler infers when you use a record as an argument, or when destructuring it (for example, `{ x, y } =`).
-- _Closed records_ are what the compiler infers when you create a new record (for example, `{ x: 5, y: 6 }`)
-- _Constrained records_ are what the compiler infers when you do a record update (for example, `{ user & email: newEmail }`)
+-   _Open records_ are what the compiler infers when you use a record as an argument, or when destructuring it (for example, `{ x, y } =`).
+-   _Closed records_ are what the compiler infers when you create a new record (for example, `{ x: 5, y: 6 }`)
+-   _Constrained records_ are what the compiler infers when you do a record update (for example, `{ user & email: newEmail }`)
 
 Of note, you can pass a closed record to a function that accepts a smaller open record, but not the reverse. So a function `{ a : Str, b : Bool }* -> Str` can accept an `{ a : Str, b : Bool, c : Bool }` record, but a function `{ a : Str, b : Bool, c : Bool } -> Str` would not accept an `{ a : Str, b : Bool }*` record.
 
@@ -1946,16 +1954,16 @@ Earlier we saw how a function which accepts an open union must account for more 
 
 So if I have an `[Ok Str]*` value, I can pass it to functions with any of these types (among others):
 
-|              Function Type              | Can it receive `[Ok Str]*`? |
+| Function Type                           | Can it receive `[Ok Str]*`? |
 | --------------------------------------- | --------------------------- |
-|           `[Ok Str]* -> Bool`           |             Yes             |
-|           `[Ok Str] -> Bool`            |             Yes             |
-|      `[Ok Str, Err Bool]* -> Bool`      |             Yes             |
-|      `[Ok Str, Err Bool] -> Bool`       |             Yes             |
-| `[Ok Str, Err Bool, Whatever]* -> Bool` |             Yes             |
-| `[Ok Str, Err Bool, Whatever] -> Bool`  |             Yes             |
-|        `Result Str Bool -> Bool`        |             Yes             |
-|     `[Err Bool, Whatever]* -> Bool`     |             Yes             |
+| `[Ok Str]* -> Bool`                     | Yes                         |
+| `[Ok Str] -> Bool`                      | Yes                         |
+| `[Ok Str, Err Bool]* -> Bool`           | Yes                         |
+| `[Ok Str, Err Bool] -> Bool`            | Yes                         |
+| `[Ok Str, Err Bool, Whatever]* -> Bool` | Yes                         |
+| `[Ok Str, Err Bool, Whatever] -> Bool`  | Yes                         |
+| `Result Str Bool -> Bool`               | Yes                         |
+| `[Err Bool, Whatever]* -> Bool`         | Yes                         |
 
 That last one works because a function accepting an open union can accept any unrecognized tag (including `Ok Str`) even though it is not mentioned as one of the tags in `[Err Bool, Whatever]*`! Remember, when a function accepts an open tag union, any `when` branches on that union must include a catch-all `_ ->` branch, which is the branch that will end up handling the `Ok Str` value we pass in.
 
@@ -1967,10 +1975,10 @@ However, I could not pass an `[Ok Str]*` to a function with a _closed_ tag union
 
 In summary, here's a way to think about the difference between open unions in a value you have, compared to a value you're accepting:
 
-- If you _have_ a closed union, that means it has all the tags it ever will, and can't accumulate more.
-- If you _have_ an open union, that means it can accumulate more tags through conditional branches.
-- If you _accept_ a closed union, that means you only have to handle the possibilities listed in the union.
-- If you _accept_ an open union, that means you have to handle the possibility that it has a tag you can't know about.
+-   If you _have_ a closed union, that means it has all the tags it ever will, and can't accumulate more.
+-   If you _have_ an open union, that means it can accumulate more tags through conditional branches.
+-   If you _accept_ a closed union, that means you only have to handle the possibilities listed in the union.
+-   If you _accept_ an open union, that means you have to handle the possibility that it has a tag you can't know about.
 
 ### [Type Variables in Tag Unions](#type-variables-in-tag-unions) {#type-variables-in-tag-unions}
 
@@ -2010,8 +2018,8 @@ So if we give this function a `[Foo Str, Bar Bool, Baz (List Str)]` argument, th
 
 If we removed the type annotation from `example` above, Roc's compiler would infer the same type anyway. This may be surprising if you look closely at the body of the function, because:
 
-- The return type includes `Foo Str`, but no branch explicitly returns `Foo`. Couldn't the return type be `[Bar Bool]a` instead?
-- The argument type includes `Bar Bool` even though we never look at `Bar`'s payload. Couldn't the argument type be inferred to be `Bar *` instead of `Bar Bool`, since we never look at it?
+-   The return type includes `Foo Str`, but no branch explicitly returns `Foo`. Couldn't the return type be `[Bar Bool]a` instead?
+-   The argument type includes `Bar Bool` even though we never look at `Bar`'s payload. Couldn't the argument type be inferred to be `Bar *` instead of `Bar Bool`, since we never look at it?
 
 The reason it has this type is the `other -> other` branch. Take a look at that branch, and ask this question: "What is the type of `other`?" There has to be exactly one answer! It can't be the case that `other` has one type before the `->` and another type after it; whenever you see a named value in Roc, it is guaranteed to have the same type everywhere it appears in that scope.
 
@@ -2025,12 +2033,12 @@ For this reason, any time you see a function that only runs a `when` on its only
 
 The record builder syntax sugar is a useful feature which leverages the functional programming concept of [applicative functors](https://lucamug.medium.com/functors-applicatives-and-monads-in-pictures-784c2b5786f7), to provide a flexible method for constructing complex types.
 
-The record builder syntax sugar helps to build up a record by applying a series of functions to it. 
+The record builder syntax sugar helps to build up a record by applying a series of functions to it.
 
 For example, let's say we write a record-builder as follows:
 
 ```roc
-{ aliceID, bobID, trudyID } = 
+{ aliceID, bobID, trudyID } =
     initIDCount {
         aliceID: <- incID,
         bobID: <- incID,
@@ -2061,24 +2069,23 @@ These are all the reserved keywords in Roc. You can't choose any of these as nam
 
 Here are various Roc expressions involving operators, and what they desugar to.
 
-| Expression                    |    Desugars To     |
-| ----------------------------- | ------------------ |
-| `a + b`                       |   `Num.add a b`    |
-| `a - b`                       |   `Num.sub a b`    |
-| `a * b`                       |   `Num.mul a b`    |
-| `a / b`                       |   `Num.div a b`    |
-| `a // b`                      | `Num.divTrunc a b` |
-| `a ^ b`                       |   `Num.pow a b`    |
-| `a % b`                       |   `Num.rem a b`    |
-| `-a`                          |    `Num.neg a`     |
-| `a == b`                      |  `Bool.isEq a b`   |
-| `a != b`                      | `Bool.isNotEq a b` |
-| `a && b`                      |   `Bool.and a b`   |
-| <code>a \|\| b</code>         | `Bool.or a b`      |
-| `!a`                          |    `Bool.not a`    |
-| <code>a \|> f</code>          |       `f a`        |
-| <code>f a b \|> g x y</code>  | `g (f a b) x y`    |
-
+| Expression                   | Desugars To        |
+| ---------------------------- | ------------------ |
+| `a + b`                      | `Num.add a b`      |
+| `a - b`                      | `Num.sub a b`      |
+| `a * b`                      | `Num.mul a b`      |
+| `a / b`                      | `Num.div a b`      |
+| `a // b`                     | `Num.divTrunc a b` |
+| `a ^ b`                      | `Num.pow a b`      |
+| `a % b`                      | `Num.rem a b`      |
+| `-a`                         | `Num.neg a`        |
+| `a == b`                     | `Bool.isEq a b`    |
+| `a != b`                     | `Bool.isNotEq a b` |
+| `a && b`                     | `Bool.and a b`     |
+| <code>a \|\| b</code>        | `Bool.or a b`      |
+| `!a`                         | `Bool.not a`       |
+| <code>a \|> f</code>         | `f a`              |
+| <code>f a b \|> g x y</code> | `g (f a b) x y`    |
 
 </section>
 <script type="text/javascript" src="/builtins/search.js" defer></script>


### PR DESCRIPTION
## NOTE: blocked on the upcoming `basic-cli` 0.8.0 release, which will be compatible with these changes!

This is an incremental step toward removing `Nat` from Roc.

Starting with `Str` because `Str` depends on `List`, which depends on `Num`, so it's easier to start with `Str` than those.