### PR TITLE
Improve filename visibility in error messages

### DIFF
--- a/crates/cli/tests/cli_run.rs
+++ b/crates/cli/tests/cli_run.rs
@@ -1333,7 +1333,7 @@ mod cli_run {
             &[],
             indoc!(
                 r#"
-                ── TYPE MISMATCH ─────────────────────────────── tests/known_bad/TypeError.roc ─
+                ── TYPE MISMATCH in tests/known_bad/TypeError.roc ──────────────────────────────
 
                 Something is off with the body of the main definition:
 
@@ -1369,7 +1369,7 @@ mod cli_run {
             &[],
             indoc!(
                 r#"
-                ── MISSING DEFINITION ────────────────── tests/known_bad/ExposedNotDefined.roc ─
+                ── MISSING DEFINITION in tests/known_bad/ExposedNotDefined.roc ─────────────────
 
                 bar is listed as exposed, but it isn't defined in this module.
 
@@ -1390,7 +1390,7 @@ mod cli_run {
             &[],
             indoc!(
                 r#"
-                ── UNUSED IMPORT ──────────────────────────── tests/known_bad/UnusedImport.roc ─
+                ── UNUSED IMPORT in tests/known_bad/UnusedImport.roc ───────────────────────────
 
                 Nothing from Symbol is used in this module.
 
@@ -1413,7 +1413,7 @@ mod cli_run {
             &[],
             indoc!(
                 r#"
-                ── UNKNOWN GENERATES FUNCTION ─────── tests/known_bad/UnknownGeneratesWith.roc ─
+                ── UNKNOWN GENERATES FUNCTION in tests/known_bad/UnknownGeneratesWith.roc ──────
 
                 I don't know how to generate the foobar function.
 

--- a/crates/cli/tests/cli_run.rs
+++ b/crates/cli/tests/cli_run.rs
@@ -1363,6 +1363,29 @@ mod cli_run {
     }
 
     #[test]
+    fn known_type_error_with_long_path() {
+        check_compile_error(
+            &known_bad_file("UnusedImportButWithALongFileNameForTesting.roc"),
+            &[],
+            indoc!(
+                r#"
+                ── UNUSED IMPORT in ...nown_bad/UnusedImportButWithALongFileNameForTesting.roc ─
+
+                Nothing from Symbol is used in this module.
+
+                3│      imports [Symbol.{ Ident }]
+                                 ^^^^^^^^^^^^^^^^
+
+                Since Symbol isn't used, you don't need to import it.
+
+                ────────────────────────────────────────────────────────────────────────────────
+
+                0 errors and 1 warning found in <ignored for test> ms."#
+            ),
+        );
+    }
+
+    #[test]
     fn exposed_not_defined() {
         check_compile_error(
             &known_bad_file("ExposedNotDefined.roc"),

--- a/crates/cli/tests/known_bad/UnusedImportButWithALongFileNameForTesting.roc
+++ b/crates/cli/tests/known_bad/UnusedImportButWithALongFileNameForTesting.roc
@@ -1,0 +1,7 @@
+interface UnusedImportButWithALongFileNameForTesting
+    exposes [plainText, emText]
+    imports [Symbol.{ Ident }]
+
+plainText = \str -> PlainText str
+
+emText = \str -> EmText str

--- a/crates/compiler/load/tests/test_reporting.rs
+++ b/crates/compiler/load/tests/test_reporting.rs
@@ -480,7 +480,7 @@ mod test_reporting {
         "
         ),
         @r"
-    ── NOT EXPOSED ─────────────────────────────────────────── /code/proj/Main.roc ─
+    ── NOT EXPOSED in /code/proj/Main.roc ──────────────────────────────────────────
 
     The List module does not expose `isempty`:
 
@@ -507,7 +507,7 @@ mod test_reporting {
         "
         ),
         @r"
-    ── UNUSED DEFINITION ───────────────────────────────────── /code/proj/Main.roc ─
+    ── UNUSED DEFINITION in /code/proj/Main.roc ────────────────────────────────────
 
     `y` is not used anywhere in your code.
 
@@ -532,7 +532,7 @@ mod test_reporting {
        "
         ),
         @r"
-    ── DUPLICATE NAME ──────────────────────────────────────── /code/proj/Main.roc ─
+    ── DUPLICATE NAME in /code/proj/Main.roc ───────────────────────────────────────
 
     The `i` name is first defined here:
 
@@ -564,7 +564,7 @@ mod test_reporting {
        "
         ),
         @r"
-    ── DUPLICATE NAME ──────────────────────────────────────── /code/proj/Main.roc ─
+    ── DUPLICATE NAME in /code/proj/Main.roc ───────────────────────────────────────
 
     The `Booly` name is first defined here:
 
@@ -596,7 +596,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── SYNTAX PROBLEM ──────────────────────────────────────── /code/proj/Main.roc ─
+    ── SYNTAX PROBLEM in /code/proj/Main.roc ───────────────────────────────────────
 
     Using != and == together requires parentheses, to clarify how they
     should be grouped.
@@ -625,7 +625,7 @@ mod test_reporting {
             "#
         ),
         @r#"
-        ── UNRECOGNIZED NAME ───────────────────────────────────── /code/proj/Main.roc ─
+        ── UNRECOGNIZED NAME in /code/proj/Main.roc ────────────────────────────────────
 
         Nothing is named `bar` in this scope.
 
@@ -649,7 +649,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── UNRECOGNIZED NAME ───────────────────────────────────── /code/proj/Main.roc ─
+    ── UNRECOGNIZED NAME in /code/proj/Main.roc ────────────────────────────────────
 
     Nothing is named `true` in this scope.
 
@@ -681,7 +681,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── SYNTAX PROBLEM ──────────────────────────────────────── /code/proj/Main.roc ─
+    ── SYNTAX PROBLEM in /code/proj/Main.roc ───────────────────────────────────────
 
     Using more than one == like this requires parentheses, to clarify how
     things should be grouped.
@@ -707,7 +707,7 @@ mod test_reporting {
          "#
         ),
         @r#"
-    ── UNUSED ARGUMENT ─────────────────────────────────────── /code/proj/Main.roc ─
+    ── UNUSED ARGUMENT in /code/proj/Main.roc ──────────────────────────────────────
 
     `box` doesn't use `htmlChildren`.
 
@@ -720,7 +720,7 @@ mod test_reporting {
     at the start of a variable name is a way of saying that the variable
     is not used.
 
-    ── UNUSED DEFINITION ───────────────────────────────────── /code/proj/Main.roc ─
+    ── UNUSED DEFINITION in /code/proj/Main.roc ────────────────────────────────────
 
     `y` is not used anywhere in your code.
 
@@ -804,7 +804,7 @@ mod test_reporting {
             ),
             indoc!(
                 r"
-                <cyan>── UNRECOGNIZED NAME ───────────────────────────────────── /code/proj/Main.roc ─<reset>
+                <cyan>── UNRECOGNIZED NAME in /code/proj/Main.roc ────────────────────────────────────<reset>
 
                 Nothing is named `theAdmin` in this scope.
 
@@ -830,7 +830,7 @@ mod test_reporting {
             "#
         ),
         @r#"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     This `if` condition needs to be a Bool:
 
@@ -856,7 +856,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     This `if` guard condition needs to be a Bool:
 
@@ -881,7 +881,7 @@ mod test_reporting {
             "#
         ),
         @r#"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     This `if` has an `else` branch with a different type from its `then` branch:
 
@@ -908,7 +908,7 @@ mod test_reporting {
              "#
         ),
         @r#"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     The 3rd branch of this `if` does not match all the previous branches:
 
@@ -938,7 +938,7 @@ mod test_reporting {
             "#
         ),
         @r#"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     The 2nd branch of this `when` does not match all the previous branches:
 
@@ -976,7 +976,7 @@ mod test_reporting {
             "#
         ),
         @r#"
-    ── UNSAFE PATTERN ──────────────────────────────────────── /code/proj/Main.roc ─
+    ── UNSAFE PATTERN in /code/proj/Main.roc ───────────────────────────────────────
 
     This `when` does not cover all the possibilities:
 
@@ -1020,7 +1020,7 @@ mod test_reporting {
             "#
         ),
         @r#"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     This list contains elements with different types:
 
@@ -1047,7 +1047,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     This list contains elements with different types:
 
@@ -1080,7 +1080,7 @@ mod test_reporting {
             "#
         ),
         @r#"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     I cannot update the `.foo` field like this:
 
@@ -1110,7 +1110,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── CIRCULAR TYPE ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── CIRCULAR TYPE in /code/proj/Main.roc ────────────────────────────────────────
 
     I'm inferring a weird self-referential type for `f`:
 
@@ -1135,7 +1135,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── CIRCULAR TYPE ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── CIRCULAR TYPE in /code/proj/Main.roc ────────────────────────────────────────
 
     I'm inferring a weird self-referential type for `f`:
 
@@ -1161,7 +1161,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── CIRCULAR TYPE ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── CIRCULAR TYPE in /code/proj/Main.roc ────────────────────────────────────────
 
     I'm inferring a weird self-referential type for `f`:
 
@@ -1174,7 +1174,7 @@ mod test_reporting {
 
         List ∞ -> *
 
-    ── CIRCULAR TYPE ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── CIRCULAR TYPE in /code/proj/Main.roc ────────────────────────────────────────
 
     I'm inferring a weird self-referential type for `g`:
 
@@ -1201,7 +1201,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     This expression is used in an unexpected way:
 
@@ -1237,7 +1237,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     This expression is used in an unexpected way:
 
@@ -1271,7 +1271,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── CIRCULAR TYPE ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── CIRCULAR TYPE in /code/proj/Main.roc ────────────────────────────────────────
 
     I'm inferring a weird self-referential type for `f`:
 
@@ -1297,7 +1297,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── CIRCULAR TYPE ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── CIRCULAR TYPE in /code/proj/Main.roc ────────────────────────────────────────
 
     I'm inferring a weird self-referential type for `f`:
 
@@ -1335,7 +1335,7 @@ mod test_reporting {
         // against that extra variable, rather than possibly having to translate a `Type`
         // again.
         @r"
-    ── CIRCULAR TYPE ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── CIRCULAR TYPE in /code/proj/Main.roc ────────────────────────────────────────
 
     I'm inferring a weird self-referential type for `f`:
 
@@ -1348,7 +1348,7 @@ mod test_reporting {
 
         List ∞ -> List *
 
-    ── CIRCULAR TYPE ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── CIRCULAR TYPE in /code/proj/Main.roc ────────────────────────────────────────
 
     I'm inferring a weird self-referential type for `g`:
 
@@ -1375,7 +1375,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── CIRCULAR TYPE ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── CIRCULAR TYPE in /code/proj/Main.roc ────────────────────────────────────────
 
     I'm inferring a weird self-referential type for `f`:
 
@@ -1388,7 +1388,7 @@ mod test_reporting {
 
         List ∞ -> List *
 
-    ── CIRCULAR TYPE ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── CIRCULAR TYPE in /code/proj/Main.roc ────────────────────────────────────────
 
     I'm inferring a weird self-referential type for `g`:
 
@@ -1416,7 +1416,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     This 1st argument to `f` has an unexpected type:
 
@@ -1450,7 +1450,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     This 1st argument to `f` has an unexpected type:
 
@@ -1487,7 +1487,7 @@ mod test_reporting {
             "#
         ),
         @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     This 1st argument to `f` has an unexpected type:
 
@@ -1524,7 +1524,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     Something is off with the `then` branch of this `if` expression:
 
@@ -1558,7 +1558,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     Something is off with the body of the `x` definition:
 
@@ -1591,7 +1591,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     Something is off with the body of the `x` definition:
 
@@ -1623,7 +1623,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── TOO MANY ARGS ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TOO MANY ARGS in /code/proj/Main.roc ────────────────────────────────────────
 
     The `x` value is not a function, but it was given 1 argument:
 
@@ -1645,7 +1645,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── TOO MANY ARGS ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TOO MANY ARGS in /code/proj/Main.roc ────────────────────────────────────────
 
     The `f` function expects 1 argument, but it got 2 instead:
 
@@ -1667,7 +1667,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── TOO FEW ARGS ────────────────────────────────────────── /code/proj/Main.roc ─
+    ── TOO FEW ARGS in /code/proj/Main.roc ─────────────────────────────────────────
 
     The `f` function expects 2 arguments, but it got only 1:
 
@@ -1688,7 +1688,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     The branches of this `when` expression don't match the condition:
 
@@ -1717,7 +1717,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     The 2nd pattern in this `when` does not match the previous ones:
 
@@ -1743,7 +1743,7 @@ mod test_reporting {
              "
         ),
         @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     The branches of this `when` expression don't match the condition:
 
@@ -1771,7 +1771,7 @@ mod test_reporting {
              "#
         ),
         @r#"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     The branches of this `when` expression don't match the condition:
 
@@ -1800,7 +1800,7 @@ mod test_reporting {
              "
         ),
         @r"
-    ── UNRECOGNIZED NAME ───────────────────────────────────── /code/proj/Main.roc ─
+    ── UNRECOGNIZED NAME in /code/proj/Main.roc ────────────────────────────────────
 
     Nothing is named `foo` in this scope.
 
@@ -1856,7 +1856,7 @@ mod test_reporting {
         ),
         // Just putting this here. We should probably handle or-patterns better
         @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     The 2nd pattern in this branch does not match the previous ones:
 
@@ -1884,7 +1884,7 @@ mod test_reporting {
         ),
         // Maybe this should specifically say the pattern doesn't work?
         @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     This expression is used in an unexpected way:
 
@@ -1912,7 +1912,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     Something is off with the body of this definition:
 
@@ -1943,7 +1943,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── SYNTAX PROBLEM ──────────────────────────────────────── /code/proj/Main.roc ─
+    ── SYNTAX PROBLEM in /code/proj/Main.roc ───────────────────────────────────────
 
     This integer pattern is malformed:
 
@@ -1964,7 +1964,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── SYNTAX PROBLEM ──────────────────────────────────────── /code/proj/Main.roc ─
+    ── SYNTAX PROBLEM in /code/proj/Main.roc ───────────────────────────────────────
 
     This float pattern is malformed:
 
@@ -1985,7 +1985,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── SYNTAX PROBLEM ──────────────────────────────────────── /code/proj/Main.roc ─
+    ── SYNTAX PROBLEM in /code/proj/Main.roc ───────────────────────────────────────
 
     This hex integer pattern is malformed:
 
@@ -2006,7 +2006,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── SYNTAX PROBLEM ──────────────────────────────────────── /code/proj/Main.roc ─
+    ── SYNTAX PROBLEM in /code/proj/Main.roc ───────────────────────────────────────
 
     This octal integer pattern is malformed:
 
@@ -2027,7 +2027,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── SYNTAX PROBLEM ──────────────────────────────────────── /code/proj/Main.roc ─
+    ── SYNTAX PROBLEM in /code/proj/Main.roc ───────────────────────────────────────
 
     This binary integer pattern is malformed:
 
@@ -2049,7 +2049,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     Something is off with the body of the `x` definition:
 
@@ -2099,7 +2099,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     Something is off with the `else` branch of this `if` expression:
 
@@ -2133,7 +2133,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     Something is off with the body of the `f` definition:
 
@@ -2168,7 +2168,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     Something is off with the body of the `f` definition:
 
@@ -2204,7 +2204,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── UNRECOGNIZED NAME ───────────────────────────────────── /code/proj/Main.roc ─
+    ── UNRECOGNIZED NAME in /code/proj/Main.roc ────────────────────────────────────
 
     Nothing is named `ok` in this scope.
 
@@ -2235,7 +2235,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── UNUSED DEFINITION ───────────────────────────────────── /code/proj/Main.roc ─
+    ── UNUSED DEFINITION in /code/proj/Main.roc ────────────────────────────────────
 
     `ok` is not used anywhere in your code.
 
@@ -2245,7 +2245,7 @@ mod test_reporting {
     If you didn't intend on using `ok` then remove it so future readers of
     your code don't wonder why it is there.
 
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     Something is off with the body of the `f` definition:
 
@@ -2277,7 +2277,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── CIRCULAR DEFINITION ─────────────────────────────────── /code/proj/Main.roc ─
+    ── CIRCULAR DEFINITION in /code/proj/Main.roc ──────────────────────────────────
 
     `f` is defined directly in terms of itself:
 
@@ -2304,7 +2304,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── CIRCULAR DEFINITION ─────────────────────────────────── /code/proj/Main.roc ─
+    ── CIRCULAR DEFINITION in /code/proj/Main.roc ──────────────────────────────────
 
     The `foo` definition is causing a very tricky infinite loop:
 
@@ -2332,7 +2332,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     This `x` record doesn’t have a `foo` field:
 
@@ -2354,7 +2354,7 @@ mod test_reporting {
         ),
         // TODO also suggest fields with the correct type
         @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     This `x` record doesn’t have a `foo` field:
 
@@ -2387,7 +2387,7 @@ mod test_reporting {
         ),
         // TODO also suggest fields with the correct type
         @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     This `r` record doesn’t have a `foo` field:
 
@@ -2415,7 +2415,7 @@ mod test_reporting {
         ),
         // TODO also suggest fields with the correct type
         @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     This `x` record doesn’t have a `foo` field:
 
@@ -2445,7 +2445,7 @@ mod test_reporting {
         ),
         // TODO also suggest fields with the correct type
         @r#"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     This 2nd argument to + has an unexpected type:
 
@@ -2470,7 +2470,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     This 2nd argument to + has an unexpected type:
 
@@ -2498,7 +2498,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     This 2nd argument to + has an unexpected type:
 
@@ -2526,7 +2526,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     Something is off with the body of the `f` definition:
 
@@ -2560,7 +2560,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     Something is off with the body of the `f` definition:
 
@@ -2603,7 +2603,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── UNSAFE PATTERN ──────────────────────────────────────── /code/proj/Main.roc ─
+    ── UNSAFE PATTERN in /code/proj/Main.roc ───────────────────────────────────────
 
     This pattern does not cover all the possibilities:
 
@@ -2618,7 +2618,7 @@ mod test_reporting {
     matching in function arguments, put a `when` in the function body to
     account for all possibilities.
 
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     Something is off with the body of the `f` definition:
 
@@ -2655,7 +2655,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     This expression is used in an unexpected way:
 
@@ -2686,7 +2686,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── UNSAFE PATTERN ──────────────────────────────────────── /code/proj/Main.roc ─
+    ── UNSAFE PATTERN in /code/proj/Main.roc ───────────────────────────────────────
 
     This `when` does not cover all the possibilities:
 
@@ -2713,7 +2713,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── UNSAFE PATTERN ──────────────────────────────────────── /code/proj/Main.roc ─
+    ── UNSAFE PATTERN in /code/proj/Main.roc ───────────────────────────────────────
 
     This `when` does not cover all the possibilities:
 
@@ -2741,7 +2741,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── UNSAFE PATTERN ──────────────────────────────────────── /code/proj/Main.roc ─
+    ── UNSAFE PATTERN in /code/proj/Main.roc ───────────────────────────────────────
 
     This `when` does not cover all the possibilities:
 
@@ -2770,7 +2770,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── UNSAFE PATTERN ──────────────────────────────────────── /code/proj/Main.roc ─
+    ── UNSAFE PATTERN in /code/proj/Main.roc ───────────────────────────────────────
 
     This `when` does not cover all the possibilities:
 
@@ -2799,7 +2799,7 @@ mod test_reporting {
         ),
         // Tip: Looks like a record field guard is not exhaustive. Learn more about record pattern matches at TODO.
         @r"
-    ── UNSAFE PATTERN ──────────────────────────────────────── /code/proj/Main.roc ─
+    ── UNSAFE PATTERN in /code/proj/Main.roc ───────────────────────────────────────
 
     This `when` does not cover all the possibilities:
 
@@ -2828,7 +2828,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── UNSAFE PATTERN ──────────────────────────────────────── /code/proj/Main.roc ─
+    ── UNSAFE PATTERN in /code/proj/Main.roc ───────────────────────────────────────
 
     This `when` does not cover all the possibilities:
 
@@ -2854,7 +2854,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── UNSAFE PATTERN ──────────────────────────────────────── /code/proj/Main.roc ─
+    ── UNSAFE PATTERN in /code/proj/Main.roc ───────────────────────────────────────
 
     This `when` does not cover all the possibilities:
 
@@ -2881,7 +2881,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── REDUNDANT PATTERN ───────────────────────────────────── /code/proj/Main.roc ─
+    ── REDUNDANT PATTERN in /code/proj/Main.roc ────────────────────────────────────
 
     The 2nd pattern is redundant:
 
@@ -2909,7 +2909,7 @@ mod test_reporting {
         ),
         // de-aliases the alias to give a better error message
         @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     This 1st argument to `f` has an unexpected type:
 
@@ -2947,7 +2947,7 @@ mod test_reporting {
         ),
         // should not report Bar as unused!
         @r"
-    ── CYCLIC ALIAS ────────────────────────────────────────── /code/proj/Main.roc ─
+    ── CYCLIC ALIAS in /code/proj/Main.roc ─────────────────────────────────────────
 
     The `Foo` alias is self-recursive in an invalid way:
 
@@ -2973,7 +2973,7 @@ mod test_reporting {
         ),
         // should not report Bar as unused!
         @r"
-    ── CYCLIC ALIAS ────────────────────────────────────────── /code/proj/Main.roc ─
+    ── CYCLIC ALIAS in /code/proj/Main.roc ─────────────────────────────────────────
 
     The `Foo` alias is self-recursive in an invalid way:
 
@@ -2993,7 +2993,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── DUPLICATE FIELD NAME ────────────────────────────────── /code/proj/Main.roc ─
+    ── DUPLICATE FIELD NAME in /code/proj/Main.roc ─────────────────────────────────
 
     This record defines the `.x` field twice!
 
@@ -3017,7 +3017,7 @@ mod test_reporting {
             "#
         ),
         @r#"
-    ── DUPLICATE FIELD NAME ────────────────────────────────── /code/proj/Main.roc ─
+    ── DUPLICATE FIELD NAME in /code/proj/Main.roc ─────────────────────────────────
 
     This record defines the `.x` field twice!
 
@@ -3045,7 +3045,7 @@ mod test_reporting {
             "#
         ),
         @r#"
-    ── DUPLICATE FIELD NAME ────────────────────────────────── /code/proj/Main.roc ─
+    ── DUPLICATE FIELD NAME in /code/proj/Main.roc ─────────────────────────────────
 
     This record defines the `.x` field twice!
 
@@ -3080,7 +3080,7 @@ mod test_reporting {
             "#
         ),
         @r#"
-    ── DUPLICATE FIELD NAME ────────────────────────────────── /code/proj/Main.roc ─
+    ── DUPLICATE FIELD NAME in /code/proj/Main.roc ─────────────────────────────────
 
     This record defines the `.x` field twice!
 
@@ -3113,7 +3113,7 @@ mod test_reporting {
             "#
         ),
         @r"
-    ── DUPLICATE FIELD NAME ────────────────────────────────── /code/proj/Main.roc ─
+    ── DUPLICATE FIELD NAME in /code/proj/Main.roc ─────────────────────────────────
 
     This record type defines the `.foo` field twice!
 
@@ -3141,7 +3141,7 @@ mod test_reporting {
             "#
         ),
         @r"
-    ── DUPLICATE TAG NAME ──────────────────────────────────── /code/proj/Main.roc ─
+    ── DUPLICATE TAG NAME in /code/proj/Main.roc ───────────────────────────────────
 
     This tag union type defines the `Foo` tag twice!
 
@@ -3170,7 +3170,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── NAMING PROBLEM ──────────────────────────────────────── /code/proj/Main.roc ─
+    ── NAMING PROBLEM in /code/proj/Main.roc ───────────────────────────────────────
 
     This annotation does not match the definition immediately following
     it:
@@ -3206,7 +3206,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── SYNTAX PROBLEM ──────────────────────────────────────── /code/proj/Main.roc ─
+    ── SYNTAX PROBLEM in /code/proj/Main.roc ───────────────────────────────────────
 
     This definition of `MyAlias` has an unexpected pattern:
 
@@ -3215,7 +3215,7 @@ mod test_reporting {
 
     Only type variables like `a` or `value` can occur in this position.
 
-    ── UNUSED DEFINITION ───────────────────────────────────── /code/proj/Main.roc ─
+    ── UNUSED DEFINITION in /code/proj/Main.roc ────────────────────────────────────
 
     `MyAlias` is not used anywhere in your code.
 
@@ -3238,7 +3238,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── SYNTAX PROBLEM ──────────────────────────────────────── /code/proj/Main.roc ─
+    ── SYNTAX PROBLEM in /code/proj/Main.roc ───────────────────────────────────────
 
     This definition of `Age` has an unexpected pattern:
 
@@ -3260,7 +3260,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── TOO MANY TYPE ARGUMENTS ─────────────────────────────── /code/proj/Main.roc ─
+    ── TOO MANY TYPE ARGUMENTS in /code/proj/Main.roc ──────────────────────────────
 
     The `Num` opaque expects 1 type argument, but it got 2 instead:
 
@@ -3282,7 +3282,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── TOO MANY TYPE ARGUMENTS ─────────────────────────────── /code/proj/Main.roc ─
+    ── TOO MANY TYPE ARGUMENTS in /code/proj/Main.roc ──────────────────────────────
 
     The `Num` opaque expects 1 type argument, but it got 2 instead:
 
@@ -3306,7 +3306,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── TOO FEW TYPE ARGUMENTS ──────────────────────────────── /code/proj/Main.roc ─
+    ── TOO FEW TYPE ARGUMENTS in /code/proj/Main.roc ───────────────────────────────
 
     The `Pair` alias expects 2 type arguments, but it got 1 instead:
 
@@ -3330,7 +3330,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── TOO MANY TYPE ARGUMENTS ─────────────────────────────── /code/proj/Main.roc ─
+    ── TOO MANY TYPE ARGUMENTS in /code/proj/Main.roc ──────────────────────────────
 
     The `Pair` alias expects 2 type arguments, but it got 3 instead:
 
@@ -3353,7 +3353,7 @@ mod test_reporting {
             "
         ),
         @r#"
-    ── UNUSED TYPE ALIAS PARAMETER ─────────────────────────── /code/proj/Main.roc ─
+    ── UNUSED TYPE ALIAS PARAMETER in /code/proj/Main.roc ──────────────────────────
 
     The `a` type parameter is not used in the `Foo` alias definition:
 
@@ -3375,7 +3375,7 @@ mod test_reporting {
             "
         ),
         @r#"
-    ── ARGUMENTS BEFORE EQUALS ────────────────── tmp/elm_function_syntax/Test.roc ─
+    ── ARGUMENTS BEFORE EQUALS in tmp/elm_function_syntax/Test.roc ─────────────────
 
     I am partway through parsing a definition, but I got stuck here:
 
@@ -3403,7 +3403,7 @@ mod test_reporting {
             "#
         ),
         @r#"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     Something is off with the body of the `x` definition:
 
@@ -3452,7 +3452,7 @@ mod test_reporting {
         // TODO render tag unions across multiple lines
         // TODO do not show recursion var if the recursion var does not render on the surface of a type
         @r#"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     Something is off with the body of the `x` definition:
 
@@ -3506,7 +3506,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── SYNTAX PROBLEM ──────────────────────────────────────── /code/proj/Main.roc ─
+    ── SYNTAX PROBLEM in /code/proj/Main.roc ───────────────────────────────────────
 
     This integer literal is too big:
 
@@ -3518,7 +3518,7 @@ mod test_reporting {
 
     Tip: Learn more about number literals at TODO
 
-    ── SYNTAX PROBLEM ──────────────────────────────────────── /code/proj/Main.roc ─
+    ── SYNTAX PROBLEM in /code/proj/Main.roc ───────────────────────────────────────
 
     This integer literal is too small:
 
@@ -3530,7 +3530,7 @@ mod test_reporting {
 
     Tip: Learn more about number literals at TODO
 
-    ── SYNTAX PROBLEM ──────────────────────────────────────── /code/proj/Main.roc ─
+    ── SYNTAX PROBLEM in /code/proj/Main.roc ───────────────────────────────────────
 
     This integer literal is too big:
 
@@ -3542,7 +3542,7 @@ mod test_reporting {
 
     Tip: Learn more about number literals at TODO
 
-    ── SYNTAX PROBLEM ──────────────────────────────────────── /code/proj/Main.roc ─
+    ── SYNTAX PROBLEM in /code/proj/Main.roc ───────────────────────────────────────
 
     This integer literal is too small:
 
@@ -3554,7 +3554,7 @@ mod test_reporting {
 
     Tip: Learn more about number literals at TODO
 
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     This 2nd argument to + has an unexpected type:
 
@@ -3583,7 +3583,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── SYNTAX PROBLEM ──────────────────────────────────────── /code/proj/Main.roc ─
+    ── SYNTAX PROBLEM in /code/proj/Main.roc ───────────────────────────────────────
 
     This float literal is too big:
 
@@ -3595,7 +3595,7 @@ mod test_reporting {
 
     Tip: Learn more about number literals at TODO
 
-    ── SYNTAX PROBLEM ──────────────────────────────────────── /code/proj/Main.roc ─
+    ── SYNTAX PROBLEM in /code/proj/Main.roc ───────────────────────────────────────
 
     This float literal is too small:
 
@@ -3628,7 +3628,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── SYNTAX PROBLEM ──────────────────────────────────────── /code/proj/Main.roc ─
+    ── SYNTAX PROBLEM in /code/proj/Main.roc ───────────────────────────────────────
 
     This integer literal contains an invalid digit:
 
@@ -3640,7 +3640,7 @@ mod test_reporting {
 
     Tip: Learn more about number literals at TODO
 
-    ── SYNTAX PROBLEM ──────────────────────────────────────── /code/proj/Main.roc ─
+    ── SYNTAX PROBLEM in /code/proj/Main.roc ───────────────────────────────────────
 
     This hex integer literal contains an invalid digit:
 
@@ -3652,7 +3652,7 @@ mod test_reporting {
 
     Tip: Learn more about number literals at TODO
 
-    ── SYNTAX PROBLEM ──────────────────────────────────────── /code/proj/Main.roc ─
+    ── SYNTAX PROBLEM in /code/proj/Main.roc ───────────────────────────────────────
 
     This octal integer literal contains an invalid digit:
 
@@ -3664,7 +3664,7 @@ mod test_reporting {
 
     Tip: Learn more about number literals at TODO
 
-    ── SYNTAX PROBLEM ──────────────────────────────────────── /code/proj/Main.roc ─
+    ── SYNTAX PROBLEM in /code/proj/Main.roc ───────────────────────────────────────
 
     This binary integer literal contains an invalid digit:
 
@@ -3694,7 +3694,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── SYNTAX PROBLEM ──────────────────────────────────────── /code/proj/Main.roc ─
+    ── SYNTAX PROBLEM in /code/proj/Main.roc ───────────────────────────────────────
 
     This hex integer literal contains no digits:
 
@@ -3706,7 +3706,7 @@ mod test_reporting {
 
     Tip: Learn more about number literals at TODO
 
-    ── SYNTAX PROBLEM ──────────────────────────────────────── /code/proj/Main.roc ─
+    ── SYNTAX PROBLEM in /code/proj/Main.roc ───────────────────────────────────────
 
     This octal integer literal contains no digits:
 
@@ -3718,7 +3718,7 @@ mod test_reporting {
 
     Tip: Learn more about number literals at TODO
 
-    ── SYNTAX PROBLEM ──────────────────────────────────────── /code/proj/Main.roc ─
+    ── SYNTAX PROBLEM in /code/proj/Main.roc ───────────────────────────────────────
 
     This binary integer literal contains no digits:
 
@@ -3742,7 +3742,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── SYNTAX PROBLEM ──────────────────────────────────────── /code/proj/Main.roc ─
+    ── SYNTAX PROBLEM in /code/proj/Main.roc ───────────────────────────────────────
 
     This float literal contains an invalid digit:
 
@@ -3773,7 +3773,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── SYNTAX PROBLEM ──────────────────────────────────────── /code/proj/Main.roc ─
+    ── SYNTAX PROBLEM in /code/proj/Main.roc ───────────────────────────────────────
 
     This expression cannot be updated:
 
@@ -3782,7 +3782,7 @@ mod test_reporting {
 
     Only variables can be updated with record update syntax.
 
-    ── MODULE NOT IMPORTED ─────────────────────────────────── /code/proj/Main.roc ─
+    ── MODULE NOT IMPORTED in /code/proj/Main.roc ──────────────────────────────────
 
     The `Test` module is not imported:
 
@@ -3797,7 +3797,7 @@ mod test_reporting {
         Dict
         Hash
 
-    ── SYNTAX PROBLEM ──────────────────────────────────────── /code/proj/Main.roc ─
+    ── SYNTAX PROBLEM in /code/proj/Main.roc ───────────────────────────────────────
 
     This expression cannot be updated:
 
@@ -3816,7 +3816,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── MODULE NOT IMPORTED ─────────────────────────────────── /code/proj/Main.roc ─
+    ── MODULE NOT IMPORTED in /code/proj/Main.roc ──────────────────────────────────
 
     The `Foo` module is not imported:
 
@@ -3841,7 +3841,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     This 2nd argument to + has an unexpected type:
 
@@ -3869,7 +3869,7 @@ mod test_reporting {
             "#
         ),
         @r#"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     The 1st argument to `f` is weird:
 
@@ -3898,7 +3898,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     Something is off with the body of this definition:
 
@@ -3929,7 +3929,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     The 1st argument to `f` is weird:
 
@@ -3962,7 +3962,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     The branches of this `when` expression don't match the condition:
 
@@ -3995,7 +3995,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     This expression is used in an unexpected way:
 
@@ -4026,7 +4026,7 @@ mod test_reporting {
                 "
         ),
         @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     This 1st argument to this function has an unexpected type:
 
@@ -4060,7 +4060,7 @@ mod test_reporting {
             "#
         ),
         @r#"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     The branches of this `when` expression don't match the condition:
 
@@ -4094,7 +4094,7 @@ mod test_reporting {
             "#
         ),
         @r#"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     The branches of this `when` expression don't match the condition:
 
@@ -4122,7 +4122,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── BAD OPTIONAL VALUE ──────────────────────────────────── /code/proj/Main.roc ─
+    ── BAD OPTIONAL VALUE in /code/proj/Main.roc ───────────────────────────────────
 
     This record uses an optional value for the `.y` field in an incorrect
     context!
@@ -4159,7 +4159,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── REDUNDANT PATTERN ───────────────────────────────────── /code/proj/Main.roc ─
+    ── REDUNDANT PATTERN in /code/proj/Main.roc ────────────────────────────────────
 
     The 3rd pattern is redundant:
 
@@ -4204,7 +4204,7 @@ mod test_reporting {
             "
         ),
         @r#"
-    ── UNUSED ARGUMENT ─────────────────────────────────────── /code/proj/Main.roc ─
+    ── UNUSED ARGUMENT in /code/proj/Main.roc ──────────────────────────────────────
 
     `f` doesn't use `foo`.
 
@@ -4226,7 +4226,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── SYNTAX PROBLEM ──────────────────────────────────────── /code/proj/Main.roc ─
+    ── SYNTAX PROBLEM in /code/proj/Main.roc ───────────────────────────────────────
 
     I am trying to parse a qualified name here:
 
@@ -4247,7 +4247,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── SYNTAX PROBLEM ──────────────────────────────────────── /code/proj/Main.roc ─
+    ── SYNTAX PROBLEM in /code/proj/Main.roc ───────────────────────────────────────
 
     I am trying to parse a qualified name here:
 
@@ -4267,7 +4267,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── SYNTAX PROBLEM ──────────────────────────────────────── /code/proj/Main.roc ─
+    ── SYNTAX PROBLEM in /code/proj/Main.roc ───────────────────────────────────────
 
     I am trying to parse a record field access here:
 
@@ -4289,7 +4289,7 @@ mod test_reporting {
             "
         ),
         @r#"
-    ── UNKNOWN OPERATOR ──────────────── tmp/type_annotation_double_colon/Test.roc ─
+    ── UNKNOWN OPERATOR in tmp/type_annotation_double_colon/Test.roc ───────────────
 
     This looks like an operator, but it's not one I recognize!
 
@@ -4321,7 +4321,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── TOO MANY ARGS ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TOO MANY ARGS in /code/proj/Main.roc ────────────────────────────────────────
 
     This value is not a function, but it was given 3 arguments:
 
@@ -4340,7 +4340,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── UNFINISHED TAG UNION TYPE ───────────────────── tmp/tag_union_open/Test.roc ─
+    ── UNFINISHED TAG UNION TYPE in tmp/tag_union_open/Test.roc ────────────────────
 
     I am partway through parsing a tag union type, but I got stuck here:
 
@@ -4362,7 +4362,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── UNFINISHED TAG UNION TYPE ────────────────────── tmp/tag_union_end/Test.roc ─
+    ── UNFINISHED TAG UNION TYPE in tmp/tag_union_end/Test.roc ─────────────────────
 
     I am partway through parsing a tag union type, but I got stuck here:
 
@@ -4384,7 +4384,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── WEIRD TAG NAME ────────────────── tmp/tag_union_lowercase_tag_name/Test.roc ─
+    ── WEIRD TAG NAME in tmp/tag_union_lowercase_tag_name/Test.roc ─────────────────
 
     I am partway through parsing a tag union type, but I got stuck here:
 
@@ -4405,7 +4405,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── WEIRD TAG NAME ─────────── tmp/tag_union_second_lowercase_tag_name/Test.roc ─
+    ── WEIRD TAG NAME in tmp/tag_union_second_lowercase_tag_name/Test.roc ──────────
 
     I am partway through parsing a tag union type, but I got stuck here:
 
@@ -4426,7 +4426,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── UNFINISHED RECORD TYPE ────────────────────── tmp/record_type_open/Test.roc ─
+    ── UNFINISHED RECORD TYPE in tmp/record_type_open/Test.roc ─────────────────────
 
     I am partway through parsing a record type, but I got stuck here:
 
@@ -4449,7 +4449,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── UNFINISHED RECORD TYPE ─────────────── tmp/record_type_open_indent/Test.roc ─
+    ── UNFINISHED RECORD TYPE in tmp/record_type_open_indent/Test.roc ──────────────
 
     I am partway through parsing a record type, but I got stuck here:
 
@@ -4472,7 +4472,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── UNFINISHED RECORD TYPE ─────────────────────── tmp/record_type_end/Test.roc ─
+    ── UNFINISHED RECORD TYPE in tmp/record_type_end/Test.roc ──────────────────────
 
     I am partway through parsing a record type, but I got stuck here:
 
@@ -4494,7 +4494,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── UNFINISHED RECORD TYPE ──────── tmp/record_type_keyword_field_name/Test.roc ─
+    ── UNFINISHED RECORD TYPE in tmp/record_type_keyword_field_name/Test.roc ───────
 
     I just started parsing a record type, but I got stuck on this field
     name:
@@ -4516,7 +4516,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── UNFINISHED RECORD TYPE ───────────── tmp/record_type_missing_comma/Test.roc ─
+    ── UNFINISHED RECORD TYPE in tmp/record_type_missing_comma/Test.roc ────────────
 
     I am partway through parsing a record type, but I got stuck here:
 
@@ -4533,7 +4533,7 @@ mod test_reporting {
         record_type_tab,
         "f : { foo \t }",
         @r"
-    ── TAB CHARACTER ──────────────────────────────── tmp/record_type_tab/Test.roc ─
+    ── TAB CHARACTER in tmp/record_type_tab/Test.roc ───────────────────────────────
 
     I encountered a tab character:
 
@@ -4548,7 +4548,7 @@ mod test_reporting {
         comment_with_tab,
         "# comment with a \t\n4",
         @r"
-    ── TAB CHARACTER ─────────────────────────────── tmp/comment_with_tab/Test.roc ─
+    ── TAB CHARACTER in tmp/comment_with_tab/Test.roc ──────────────────────────────
 
     I encountered a tab character:
 
@@ -4563,7 +4563,7 @@ mod test_reporting {
         comment_with_control_character,
         "# comment with a \x07\n",
         @r"
-    ── ASCII CONTROL CHARACTER ─────── tmp/comment_with_control_character/Test.roc ─
+    ── ASCII CONTROL CHARACTER in tmp/comment_with_control_character/Test.roc ──────
 
     I encountered an ASCII control character:
 
@@ -4578,7 +4578,7 @@ mod test_reporting {
         record_type_carriage_return,
         "f : { \r foo }",
         @r"
-    ── MISPLACED CARRIAGE RETURN ──────── tmp/record_type_carriage_return/Test.roc ─
+    ── MISPLACED CARRIAGE RETURN in tmp/record_type_carriage_return/Test.roc ───────
 
     I encountered a stray carriage return (\r):
 
@@ -4598,7 +4598,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── UNFINISHED PARENTHESES ────────────────── tmp/type_in_parens_start/Test.roc ─
+    ── UNFINISHED PARENTHESES in tmp/type_in_parens_start/Test.roc ─────────────────
 
     I am partway through parsing a type in parentheses, but I got stuck
     here:
@@ -4621,7 +4621,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── UNFINISHED PARENTHESES ──────────────────── tmp/type_in_parens_end/Test.roc ─
+    ── UNFINISHED PARENTHESES in tmp/type_in_parens_end/Test.roc ───────────────────
 
     I am partway through parsing a type in parentheses, but I got stuck
     here:
@@ -4646,7 +4646,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── SYNTAX PROBLEM ──────────────────────────────────────── /code/proj/Main.roc ─
+    ── SYNTAX PROBLEM in /code/proj/Main.roc ───────────────────────────────────────
 
     I am confused by this type name:
 
@@ -4676,7 +4676,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── SYNTAX PROBLEM ──────────────────────────────────────── /code/proj/Main.roc ─
+    ── SYNTAX PROBLEM in /code/proj/Main.roc ───────────────────────────────────────
 
     I am confused by this type name:
 
@@ -4705,7 +4705,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── UNFINISHED TYPE ───────────────────────── tmp/type_apply_stray_dot/Test.roc ─
+    ── UNFINISHED TYPE in tmp/type_apply_stray_dot/Test.roc ────────────────────────
 
     I just started parsing a type, but I got stuck here:
 
@@ -4726,7 +4726,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── SYNTAX PROBLEM ──────────────────────────────────────── /code/proj/Main.roc ─
+    ── SYNTAX PROBLEM in /code/proj/Main.roc ───────────────────────────────────────
 
     I am confused by this type name:
 
@@ -4757,7 +4757,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── SYNTAX PROBLEM ──────────────────────────────────────── /code/proj/Main.roc ─
+    ── SYNTAX PROBLEM in /code/proj/Main.roc ───────────────────────────────────────
 
     I am confused by this type name:
 
@@ -4777,7 +4777,7 @@ mod test_reporting {
             "
         ),
         @r#"
-    ── MISSING FINAL EXPRESSION ──────── tmp/def_missing_final_expression/Test.roc ─
+    ── MISSING FINAL EXPRESSION in tmp/def_missing_final_expression/Test.roc ───────
 
     I am partway through parsing a definition, but I got stuck here:
 
@@ -4805,7 +4805,7 @@ mod test_reporting {
             "
         ),
         @r#"
-    ── INDENT ENDS AFTER EXPRESSION ────── tmp/expression_indentation_end/Test.roc ─
+    ── INDENT ENDS AFTER EXPRESSION in tmp/expression_indentation_end/Test.roc ─────
 
     I am partway through parsing an expression, but I got stuck here:
 
@@ -4831,7 +4831,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── UNFINISHED INLINE ALIAS ──────────────────── tmp/type_inline_alias/Test.roc ─
+    ── UNFINISHED INLINE ALIAS in tmp/type_inline_alias/Test.roc ───────────────────
 
     I just started parsing an inline type alias, but I got stuck here:
 
@@ -4853,7 +4853,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── DOUBLE COMMA ─────────────────────────────── tmp/type_double_comma/Test.roc ─
+    ── DOUBLE COMMA in tmp/type_double_comma/Test.roc ──────────────────────────────
 
     I just started parsing a function argument type, but I encountered two
     commas in a row:
@@ -4876,7 +4876,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── UNFINISHED TYPE ─────────────────────── tmp/type_argument_no_arrow/Test.roc ─
+    ── UNFINISHED TYPE in tmp/type_argument_no_arrow/Test.roc ──────────────────────
 
     I am partway through parsing a type, but I got stuck here:
 
@@ -4899,7 +4899,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── UNFINISHED TYPE ───────────── tmp/type_argument_arrow_then_nothing/Test.roc ─
+    ── UNFINISHED TYPE in tmp/type_argument_arrow_then_nothing/Test.roc ────────────
 
     I just started parsing a type, but I got stuck here:
 
@@ -4924,7 +4924,7 @@ mod test_reporting {
             "#
         ),
         @r#"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     Something is off with the body of the `myDict` definition:
 
@@ -4959,7 +4959,7 @@ mod test_reporting {
             "#
         ),
         @r#"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     Something is off with the body of the `myDict` definition:
 
@@ -4991,7 +4991,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── IF GUARD NO CONDITION ───────────── tmp/if_guard_without_condition/Test.roc ─
+    ── IF GUARD NO CONDITION in tmp/if_guard_without_condition/Test.roc ────────────
 
     I just started parsing an if guard, but there is no guard condition:
 
@@ -5016,7 +5016,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── UNFINISHED PATTERN ────────────────────────── tmp/empty_or_pattern/Test.roc ─
+    ── UNFINISHED PATTERN in tmp/empty_or_pattern/Test.roc ─────────────────────────
 
     I just started parsing a pattern, but I got stuck here:
 
@@ -5041,7 +5041,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── MISSING ARROW ────────────────────────── tmp/pattern_binds_keyword/Test.roc ─
+    ── MISSING ARROW in tmp/pattern_binds_keyword/Test.roc ─────────────────────────
 
     I am partway through parsing a `when` expression, but got stuck here:
 
@@ -5077,7 +5077,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── UNFINISHED WHEN ─────────────────────────── tmp/when_missing_arrow/Test.roc ─
+    ── UNFINISHED WHEN in tmp/when_missing_arrow/Test.roc ──────────────────────────
 
     I was partway through parsing a `when` expression, but I got stuck here:
 
@@ -5110,7 +5110,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── UNFINISHED ARGUMENT LIST ───────────────── tmp/lambda_double_comma/Test.roc ─
+    ── UNFINISHED ARGUMENT LIST in tmp/lambda_double_comma/Test.roc ────────────────
 
     I am partway through parsing a function argument list, but I got stuck
     at this comma:
@@ -5131,7 +5131,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── UNFINISHED ARGUMENT LIST ──────────────── tmp/lambda_leading_comma/Test.roc ─
+    ── UNFINISHED ARGUMENT LIST in tmp/lambda_leading_comma/Test.roc ───────────────
 
     I am partway through parsing a function argument list, but I got stuck
     at this comma:
@@ -5178,7 +5178,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── NOT END OF FILE ──────────────────────── tmp/when_outdented_branch/Test.roc ─
+    ── NOT END OF FILE in tmp/when_outdented_branch/Test.roc ───────────────────────
 
     I expected to reach the end of the file, but got stuck here:
 
@@ -5197,7 +5197,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── UNEXPECTED ARROW ─────────────── tmp/when_over_indented_underscore/Test.roc ─
+    ── UNEXPECTED ARROW in tmp/when_over_indented_underscore/Test.roc ──────────────
 
     I am parsing a `when` expression right now, but this arrow is confusing
     me:
@@ -5234,7 +5234,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── UNEXPECTED ARROW ────────────────────── tmp/when_over_indented_int/Test.roc ─
+    ── UNEXPECTED ARROW in tmp/when_over_indented_int/Test.roc ─────────────────────
 
     I am parsing a `when` expression right now, but this arrow is confusing
     me:
@@ -5274,7 +5274,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── UNFINISHED IF ────────────────────────────── tmp/if_outdented_then/Test.roc ─
+    ── UNFINISHED IF in tmp/if_outdented_then/Test.roc ─────────────────────────────
 
     I was partway through parsing an `if` expression, but I got stuck here:
 
@@ -5294,7 +5294,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── UNFINISHED IF ──────────────────────────────── tmp/if_missing_else/Test.roc ─
+    ── UNFINISHED IF in tmp/if_missing_else/Test.roc ───────────────────────────────
 
     I was partway through parsing an `if` expression, but I got stuck here:
 
@@ -5313,7 +5313,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── UNFINISHED LIST ──────────────────────────── tmp/list_double_comma/Test.roc ─
+    ── UNFINISHED LIST in tmp/list_double_comma/Test.roc ───────────────────────────
 
     I am partway through started parsing a list, but I got stuck here:
 
@@ -5333,7 +5333,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── UNFINISHED LIST ───────────────────────────── tmp/list_without_end/Test.roc ─
+    ── UNFINISHED LIST in tmp/list_without_end/Test.roc ────────────────────────────
 
     I am partway through started parsing a list, but I got stuck here:
 
@@ -5359,7 +5359,7 @@ mod test_reporting {
             "
         ),
         @r"
-    ── SYNTAX PROBLEM ──────────────────────────────────────── /code/proj/Main.roc ─
+    ── SYNTAX PROBLEM in /code/proj/Main.roc ───────────────────────────────────────
 
     This float literal contains an invalid digit:
 
@@ -5377,7 +5377,7 @@ mod test_reporting {
         unicode_not_hex,
         r#""abc\u(zzzz)def""#,
         @r#"
-    ── WEIRD CODE POINT ───────────────────────────── tmp/unicode_not_hex/Test.roc ─
+    ── WEIRD CODE POINT in tmp/unicode_not_hex/Test.roc ────────────────────────────
 
     I am partway through parsing a unicode code point, but I got stuck
     here:
@@ -5395,7 +5395,7 @@ mod test_reporting {
         unicode_too_large,
         r#""abc\u(110000)def""#,
         @r#"
-    ── INVALID UNICODE ─────────────────────────────────────── /code/proj/Main.roc ─
+    ── INVALID UNICODE in /code/proj/Main.roc ──────────────────────────────────────
 
     This unicode code point is invalid:
 
@@ -5410,7 +5410,7 @@ mod test_reporting {
         weird_escape,
         r#""abc\qdef""#,
         @r#"
-    ── WEIRD ESCAPE ──────────────────────────────────── tmp/weird_escape/Test.roc ─
+    ── WEIRD ESCAPE in tmp/weird_escape/Test.roc ───────────────────────────────────
 
     I was partway through parsing a  string literal, but I got stuck here:
 
@@ -5434,7 +5434,7 @@ mod test_reporting {
         single_quote_too_long,
         r"'abcdef'",
         @r#"
-    ── INVALID SCALAR ───────────────────────── tmp/single_quote_too_long/Test.roc ─
+    ── INVALID SCALAR in tmp/single_quote_too_long/Test.roc ────────────────────────
 
     I am part way through parsing this scalar literal (character literal),
     but it's too long to fit in a U32 so it's not a valid scalar.
@@ -5451,7 +5451,7 @@ mod test_reporting {
         single_no_end,
         r#""there is no end"#,
         @r#"
-    ── ENDLESS STRING ───────────────────────────────── tmp/single_no_end/Test.roc ─
+    ── ENDLESS STRING in tmp/single_no_end/Test.roc ────────────────────────────────
 
     I cannot find the end of this string:
 
@@ -5467,7 +5467,7 @@ mod test_reporting {
         multi_no_end,
         r#""""there is no end"#,
         @r#"
-    ── ENDLESS STRING ────────────────────────────────── tmp/multi_no_end/Test.roc ─
+    ── ENDLESS STRING in tmp/multi_no_end/Test.roc ─────────────────────────────────
 
     I cannot find the end of this block string:
 
@@ -5483,7 +5483,7 @@ mod test_reporting {
         multi_insufficient_indent,
         "    \"\"\"\n  testing\n    \"\"\"", // 4 space indent on the start, 2 space on the `testing` line
         @r#"
-    ── INSUFFICIENT INDENT IN MULTI-LINE STRING ─ ..._insufficient_indent/Test.roc ─
+    ── INSUFFICIENT INDENT IN MULTI-LINE STRING in ...insufficient_indent/Test.roc ─
 
     This multiline string is not sufficiently indented:
 
@@ -5505,7 +5505,7 @@ mod test_reporting {
             "
         ),
         @r#"
-    ── INDENT ENDS AFTER EXPRESSION ──── tmp/dbg_without_final_expression/Test.roc ─
+    ── INDENT ENDS AFTER EXPRESSION in tmp/dbg_without_final_expression/Test.roc ───
 
     I am partway through parsing a dbg statement, but I got stuck here:
 
@@ -5527,7 +5527,7 @@ mod test_reporting {
             "
         ),
         @r#"
-    ── INDENT ENDS AFTER EXPRESSION ─ tmp/expect_without_final_expression/Test.roc ─
+    ── INDENT ENDS AFTER EXPRESSION in ...expect_without_final_expression/Test.roc ─
 
     I am partway through parsing an expect statement, but I got stuck
     here:
@@ -5553,7 +5553,7 @@ mod test_reporting {
             "#,
             ),
             @r#"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     This `if` has an `else` branch with a different type from its `then` branch:
 
@@ -5579,7 +5579,7 @@ mod test_reporting {
                 $name,
                 &format!(r#"if Bool.true then "abc" else 1 {} 2"#, $op),
                 |golden| assert_eq!(golden, format!(
-r#"── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+r#"── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
 This `if` has an `else` branch with a different type from its `then` branch:
 
@@ -5622,7 +5622,7 @@ All branches in an `if` must have the same type!
             "
         ),
         @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     This `foo` record doesn’t have a `if` field:
 
@@ -5641,7 +5641,7 @@ All branches in an `if` must have the same type!
             "
         ),
         @r"
-    ── NOT EXPOSED ─────────────────────────────────────────── /code/proj/Main.roc ─
+    ── NOT EXPOSED in /code/proj/Main.roc ──────────────────────────────────────────
 
     The Num module does not expose `if`:
 
@@ -5665,7 +5665,7 @@ All branches in an `if` must have the same type!
             "
         ),
         @r"
-    ── SYNTAX PROBLEM ──────────────────────────────────────── /code/proj/Main.roc ─
+    ── SYNTAX PROBLEM in /code/proj/Main.roc ───────────────────────────────────────
 
     I am trying to parse a record field access here:
 
@@ -5684,7 +5684,7 @@ All branches in an `if` must have the same type!
             "
         ),
         @r"
-    ── SYNTAX PROBLEM ──────────────────────────────────────── /code/proj/Main.roc ─
+    ── SYNTAX PROBLEM in /code/proj/Main.roc ───────────────────────────────────────
 
     I am very confused by this field access:
 
@@ -5703,7 +5703,7 @@ All branches in an `if` must have the same type!
             "
         ),
         @r"
-    ── SYNTAX PROBLEM ──────────────────────────────────────── /code/proj/Main.roc ─
+    ── SYNTAX PROBLEM in /code/proj/Main.roc ───────────────────────────────────────
 
     I am very confused by this field access
 
@@ -5724,7 +5724,7 @@ All branches in an `if` must have the same type!
             "
         ),
         @r"
-    ── NAMING PROBLEM ──────────────────────────────────────── /code/proj/Main.roc ─
+    ── NAMING PROBLEM in /code/proj/Main.roc ───────────────────────────────────────
 
     I am trying to parse an identifier here:
 
@@ -5758,7 +5758,7 @@ All branches in an `if` must have the same type!
             "
         ),
         @r#"
-    ── UNKNOWN OPERATOR ───────────────────────────────────── tmp/case_of/Test.roc ─
+    ── UNKNOWN OPERATOR in tmp/case_of/Test.roc ────────────────────────────────────
 
     This looks like an operator, but it's not one I recognize!
 
@@ -5791,7 +5791,7 @@ All branches in an `if` must have the same type!
             "#
         ),
         @r#"
-    ── UNRECOGNIZED NAME ───────────────────────────────────── /code/proj/Main.roc ─
+    ── UNRECOGNIZED NAME in /code/proj/Main.roc ────────────────────────────────────
 
     Nothing is named `bar` in this scope.
 
@@ -5816,7 +5816,7 @@ All branches in an `if` must have the same type!
             "
         ),
         @r#"
-    ── UNKNOWN OPERATOR ──────────────────────────── tmp/invalid_operator/Test.roc ─
+    ── UNKNOWN OPERATOR in tmp/invalid_operator/Test.roc ───────────────────────────
 
     This looks like an operator, but it's not one I recognize!
 
@@ -5841,7 +5841,7 @@ All branches in an `if` must have the same type!
             "
         ),
         @r#"
-    ── UNKNOWN OPERATOR ───────────────────────────────── tmp/double_plus/Test.roc ─
+    ── UNKNOWN OPERATOR in tmp/double_plus/Test.roc ────────────────────────────────
 
     This looks like an operator, but it's not one I recognize!
 
@@ -5868,7 +5868,7 @@ All branches in an `if` must have the same type!
             "
         ),
         @r#"
-    ── UNKNOWN OPERATOR ────────────────────────────── tmp/inline_hastype/Test.roc ─
+    ── UNKNOWN OPERATOR in tmp/inline_hastype/Test.roc ─────────────────────────────
 
     This looks like an operator, but it's not one I recognize!
 
@@ -5899,7 +5899,7 @@ All branches in an `if` must have the same type!
         |golden| pretty_assertions::assert_eq!(
             golden,
             &format!(
-                r#"── UNKNOWN OPERATOR ───────────────────────────── tmp/wild_case_arrow/Test.roc ─
+                r#"── UNKNOWN OPERATOR in tmp/wild_case_arrow/Test.roc ────────────────────────────
 
 This looks like an operator, but it's not one I recognize!
 
@@ -5932,7 +5932,7 @@ In roc, functions are always written as a lambda, like{}
             ),
             indoc!(
                 r"
-                ── WEIRD PROVIDES ──────────────────────────────────────── /code/proj/Main.roc ─
+                ── WEIRD PROVIDES in /code/proj/Main.roc ───────────────────────────────────────
 
                 I am partway through parsing a provides list, but I got stuck here:
 
@@ -5967,7 +5967,7 @@ In roc, functions are always written as a lambda, like{}
             ),
             indoc!(
                 r"
-                ── WEIRD PROVIDES ──────────────────────────────────────── /code/proj/Main.roc ─
+                ── WEIRD PROVIDES in /code/proj/Main.roc ───────────────────────────────────────
 
                 I am partway through parsing a header, but I got stuck here:
 
@@ -5993,7 +5993,7 @@ In roc, functions are always written as a lambda, like{}
             ),
             indoc!(
                 r#"
-                ── WEIRD PROVIDES ──────────────────────────────────────── /code/proj/Main.roc ─
+                ── WEIRD PROVIDES in /code/proj/Main.roc ───────────────────────────────────────
 
                 I am partway through parsing a header, but I got stuck here:
 
@@ -6020,7 +6020,7 @@ In roc, functions are always written as a lambda, like{}
             ),
             indoc!(
                 r#"
-                ── WEIRD PROVIDES ──────────────────────────────────────── /code/proj/Main.roc ─
+                ── WEIRD PROVIDES in /code/proj/Main.roc ───────────────────────────────────────
 
                 I am partway through parsing a header, but I got stuck here:
 
@@ -6057,7 +6057,7 @@ In roc, functions are always written as a lambda, like{}
             ),
             indoc!(
                 r#"
-                ── BAD REQUIRES ────────────────────────────────────────── /code/proj/Main.roc ─
+                ── BAD REQUIRES in /code/proj/Main.roc ─────────────────────────────────────────
 
                 I am partway through parsing a header, but I got stuck here:
 
@@ -6085,7 +6085,7 @@ In roc, functions are always written as a lambda, like{}
             ),
             indoc!(
                 r"
-                ── WEIRD IMPORTS ───────────────────────────────────────── /code/proj/Main.roc ─
+                ── WEIRD IMPORTS in /code/proj/Main.roc ────────────────────────────────────────
 
                 I am partway through parsing a header, but I got stuck here:
 
@@ -6112,7 +6112,7 @@ In roc, functions are always written as a lambda, like{}
             ),
             indoc!(
                 r"
-                ── WEIRD EXPOSES ───────────────────────────────────────── /code/proj/Main.roc ─
+                ── WEIRD EXPOSES in /code/proj/Main.roc ────────────────────────────────────────
 
                 I am partway through parsing an `exposes` list, but I got stuck here:
 
@@ -6140,7 +6140,7 @@ In roc, functions are always written as a lambda, like{}
             ),
             indoc!(
                 r"
-                ── WEIRD MODULE NAME ───────────────────────────────────── /code/proj/Main.roc ─
+                ── WEIRD MODULE NAME in /code/proj/Main.roc ────────────────────────────────────
 
                 I am partway through parsing a header, but got stuck here:
 
@@ -6166,7 +6166,7 @@ In roc, functions are always written as a lambda, like{}
             ),
             indoc!(
                 r#"
-                ── WEIRD APP NAME ──────────────────────────────────────── /code/proj/Main.roc ─
+                ── WEIRD APP NAME in /code/proj/Main.roc ───────────────────────────────────────
 
                 I am partway through parsing a header, but got stuck here:
 
@@ -6190,7 +6190,7 @@ In roc, functions are always written as a lambda, like{}
             "
         ),
         @r"
-    ── TOO MANY ARGS ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TOO MANY ARGS in /code/proj/Main.roc ────────────────────────────────────────
 
     This value is not a function, but it was given 2 arguments:
 
@@ -6211,7 +6211,7 @@ In roc, functions are always written as a lambda, like{}
             "
         ),
         @r"
-    ── TOO MANY ARGS ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TOO MANY ARGS in /code/proj/Main.roc ────────────────────────────────────────
 
     This value is not a function, but it was given 2 arguments:
 
@@ -6233,7 +6233,7 @@ In roc, functions are always written as a lambda, like{}
             "
         ),
         @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     Something is off with the body of the `x` definition:
 
@@ -6259,7 +6259,7 @@ In roc, functions are always written as a lambda, like{}
             "
         ),
         @r"
-    ── UNFINISHED PARENTHESES ──────────────── tmp/pattern_in_parens_open/Test.roc ─
+    ── UNFINISHED PARENTHESES in tmp/pattern_in_parens_open/Test.roc ───────────────
 
     I am partway through parsing a pattern in parentheses, but I got stuck
     here:
@@ -6282,7 +6282,7 @@ In roc, functions are always written as a lambda, like{}
             "
         ),
         @r"
-    ── UNFINISHED PARENTHESES ─────────── tmp/pattern_in_parens_end_comma/Test.roc ─
+    ── UNFINISHED PARENTHESES in tmp/pattern_in_parens_end_comma/Test.roc ──────────
 
     I am partway through parsing a pattern in parentheses, but I got stuck
     here:
@@ -6305,7 +6305,7 @@ In roc, functions are always written as a lambda, like{}
             "
         ),
         @r"
-    ── UNFINISHED PARENTHESES ───────────────── tmp/pattern_in_parens_end/Test.roc ─
+    ── UNFINISHED PARENTHESES in tmp/pattern_in_parens_end/Test.roc ────────────────
 
     I am partway through parsing a pattern in parentheses, but I got stuck
     here:
@@ -6329,7 +6329,7 @@ In roc, functions are always written as a lambda, like{}
             "
         ),
         @r"
-    ── UNFINISHED FUNCTION ───── tmp/unfinished_closure_pattern_in_parens/Test.roc ─
+    ── UNFINISHED FUNCTION in tmp/unfinished_closure_pattern_in_parens/Test.roc ────
 
     I was partway through parsing a  function, but I got stuck here:
 
@@ -6349,7 +6349,7 @@ In roc, functions are always written as a lambda, like{}
             "
         ),
         @r"
-    ── UNFINISHED PARENTHESES ───────── tmp/pattern_in_parens_indent_open/Test.roc ─
+    ── UNFINISHED PARENTHESES in tmp/pattern_in_parens_indent_open/Test.roc ────────
 
     I am partway through parsing a pattern in parentheses, but I got stuck
     here:
@@ -6374,7 +6374,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
         @r#"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     This 2nd argument to `map` has an unexpected type:
 
@@ -6402,7 +6402,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
         @r#"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     This `expect` condition needs to be a Bool:
 
@@ -6429,7 +6429,7 @@ In roc, functions are always written as a lambda, like{}
             "
         ),
         @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     This 2nd argument to * has an unexpected type:
 
@@ -6444,7 +6444,7 @@ In roc, functions are always written as a lambda, like{}
 
         Num *
 
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     Something is off with the body of the `mult` definition:
 
@@ -6473,7 +6473,7 @@ In roc, functions are always written as a lambda, like{}
             "
         ),
         @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     This 2nd argument to * has an unexpected type:
 
@@ -6488,7 +6488,7 @@ In roc, functions are always written as a lambda, like{}
 
         Num a
 
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     Something is off with the body of the `mult` definition:
 
@@ -6523,7 +6523,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
         @r"
-    ── DUPLICATE NAME ──────────────────────────────────────── /code/proj/Main.roc ─
+    ── DUPLICATE NAME in /code/proj/Main.roc ───────────────────────────────────────
 
     This alias has the same name as a builtin:
 
@@ -6533,7 +6533,7 @@ In roc, functions are always written as a lambda, like{}
     All builtin aliases are in scope by default, so I need this alias to
     have a different name!
 
-    ── TOO FEW TYPE ARGUMENTS ──────────────────────────────── /code/proj/Main.roc ─
+    ── TOO FEW TYPE ARGUMENTS in /code/proj/Main.roc ───────────────────────────────
 
     The `Result` alias expects 2 type arguments, but it got 1 instead:
 
@@ -6561,7 +6561,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
         @r"
-    ── DUPLICATE NAME ──────────────────────────────────────── /code/proj/Main.roc ─
+    ── DUPLICATE NAME in /code/proj/Main.roc ───────────────────────────────────────
 
     This alias has the same name as a builtin:
 
@@ -6571,7 +6571,7 @@ In roc, functions are always written as a lambda, like{}
     All builtin aliases are in scope by default, so I need this alias to
     have a different name!
 
-    ── TOO MANY TYPE ARGUMENTS ─────────────────────────────── /code/proj/Main.roc ─
+    ── TOO MANY TYPE ARGUMENTS in /code/proj/Main.roc ──────────────────────────────
 
     The `Result` alias expects 2 type arguments, but it got 3 instead:
 
@@ -6593,7 +6593,7 @@ In roc, functions are always written as a lambda, like{}
         ),
         // TODO: We should tell the user that we inferred `_` as `a`
         @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     Something is off with the body of the `f` definition:
 
@@ -6627,7 +6627,7 @@ In roc, functions are always written as a lambda, like{}
             "
         ),
         @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     Something is off with the body of the `f` definition:
 
@@ -6659,7 +6659,7 @@ In roc, functions are always written as a lambda, like{}
             "
         ),
         @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     Something is off with the body of the `f` definition:
 
@@ -6699,7 +6699,7 @@ In roc, functions are always written as a lambda, like{}
             "
         ),
         @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     Something is off with the body of the `inner` definition:
 
@@ -6728,7 +6728,7 @@ In roc, functions are always written as a lambda, like{}
             "
         ),
         @r"
-    ── NOT AN INLINE ALIAS ────────── tmp/error_inline_alias_not_an_alias/Test.roc ─
+    ── NOT AN INLINE ALIAS in tmp/error_inline_alias_not_an_alias/Test.roc ─────────
 
     The inline type after this `as` is not a type alias:
 
@@ -6748,7 +6748,7 @@ In roc, functions are always written as a lambda, like{}
             "
         ),
         @r"
-    ── QUALIFIED ALIAS NAME ──────────── tmp/error_inline_alias_qualified/Test.roc ─
+    ── QUALIFIED ALIAS NAME in tmp/error_inline_alias_qualified/Test.roc ───────────
 
     This type alias has a qualified name:
 
@@ -6768,7 +6768,7 @@ In roc, functions are always written as a lambda, like{}
             "
         ),
         @r"
-    ── TYPE ARGUMENT NOT LOWERCASE ─ ...r_inline_alias_argument_uppercase/Test.roc ─
+    ── TYPE ARGUMENT NOT LOWERCASE in ..._inline_alias_argument_uppercase/Test.roc ─
 
     This alias type argument is not lowercase:
 
@@ -6792,7 +6792,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
         @r#"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     This 1st argument to `isEmpty` has an unexpected type:
 
@@ -6828,7 +6828,7 @@ In roc, functions are always written as a lambda, like{}
             "
         ),
         @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     This 1st argument to `c` has an unexpected type:
 
@@ -6861,7 +6861,7 @@ In roc, functions are always written as a lambda, like{}
             "
         ),
         @r"
-    ── CYCLIC ALIAS ────────────────────────────────────────── /code/proj/Main.roc ─
+    ── CYCLIC ALIAS in /code/proj/Main.roc ─────────────────────────────────────────
 
     The `F` alias is self-recursive in an invalid way:
 
@@ -6884,7 +6884,7 @@ In roc, functions are always written as a lambda, like{}
             "
         ),
         @r"
-    ── CYCLIC ALIAS ────────────────────────────────────────── /code/proj/Main.roc ─
+    ── CYCLIC ALIAS in /code/proj/Main.roc ─────────────────────────────────────────
 
     The `F` alias is self-recursive in an invalid way:
 
@@ -6906,7 +6906,7 @@ In roc, functions are always written as a lambda, like{}
             "
         ),
         @r"
-    ── CYCLIC ALIAS ────────────────────────────────────────── /code/proj/Main.roc ─
+    ── CYCLIC ALIAS in /code/proj/Main.roc ─────────────────────────────────────────
 
     The `F` alias is self-recursive in an invalid way:
 
@@ -6931,7 +6931,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
         @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     The 1st argument to `job` is weird:
 
@@ -6966,7 +6966,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
         @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     Something is off with the body of the `job` definition:
 
@@ -6997,7 +6997,7 @@ In roc, functions are always written as a lambda, like{}
             "
         ),
         @r"
-    ── NESTED DATATYPE ─────────────────────────────────────── /code/proj/Main.roc ─
+    ── NESTED DATATYPE in /code/proj/Main.roc ──────────────────────────────────────
 
     `Nested` is a nested datatype. Here is one recursive usage of it:
 
@@ -7025,7 +7025,7 @@ In roc, functions are always written as a lambda, like{}
             "
         ),
         @r"
-    ── NESTED DATATYPE ─────────────────────────────────────── /code/proj/Main.roc ─
+    ── NESTED DATATYPE in /code/proj/Main.roc ──────────────────────────────────────
 
     `Nested` is a nested datatype. Here is one recursive usage of it:
 
@@ -7073,7 +7073,7 @@ In roc, functions are always written as a lambda, like{}
 
                     let real = format!(indoc!(
                         r"
-                        ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+                        ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
                         This 1st argument to `use` has an unexpected type:
 
@@ -7140,7 +7140,7 @@ In roc, functions are always written as a lambda, like{}
 
                     let real = format!(indoc!(
                         r"
-                        ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+                        ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
                         The branches of this `when` expression don't match the condition:
 
@@ -7192,7 +7192,7 @@ In roc, functions are always written as a lambda, like{}
         ),
         // TODO: link to number suffixes
         @r"
-    ── SYNTAX PROBLEM ──────────────────────────────────────── /code/proj/Main.roc ─
+    ── SYNTAX PROBLEM in /code/proj/Main.roc ───────────────────────────────────────
 
     This integer literal contains an invalid digit:
 
@@ -7215,7 +7215,7 @@ In roc, functions are always written as a lambda, like{}
         ),
         // TODO: link to number suffixes
         @r"
-    ── SYNTAX PROBLEM ──────────────────────────────────────── /code/proj/Main.roc ─
+    ── SYNTAX PROBLEM in /code/proj/Main.roc ───────────────────────────────────────
 
     This integer literal contains an invalid digit:
 
@@ -7237,7 +7237,7 @@ In roc, functions are always written as a lambda, like{}
             "
         ),
         @r"
-    ── CONFLICTING NUMBER SUFFIX ───────────────────────────── /code/proj/Main.roc ─
+    ── CONFLICTING NUMBER SUFFIX in /code/proj/Main.roc ────────────────────────────
 
     This number literal is an integer, but it has a float suffix:
 
@@ -7254,7 +7254,7 @@ In roc, functions are always written as a lambda, like{}
             "
         ),
         @r"
-    ── CONFLICTING NUMBER SUFFIX ───────────────────────────── /code/proj/Main.roc ─
+    ── CONFLICTING NUMBER SUFFIX in /code/proj/Main.roc ────────────────────────────
 
     This number literal is a float, but it has an integer suffix:
 
@@ -7267,7 +7267,7 @@ In roc, functions are always written as a lambda, like{}
         u8_overflow,
         "256u8",
         @r"
-    ── NUMBER OVERFLOWS SUFFIX ─────────────────────────────── /code/proj/Main.roc ─
+    ── NUMBER OVERFLOWS SUFFIX in /code/proj/Main.roc ──────────────────────────────
 
     This integer literal overflows the type indicated by its suffix:
 
@@ -7283,7 +7283,7 @@ In roc, functions are always written as a lambda, like{}
         negative_u8,
         "-1u8",
         @r"
-    ── NUMBER UNDERFLOWS SUFFIX ────────────────────────────── /code/proj/Main.roc ─
+    ── NUMBER UNDERFLOWS SUFFIX in /code/proj/Main.roc ─────────────────────────────
 
     This integer literal underflows the type indicated by its suffix:
 
@@ -7299,7 +7299,7 @@ In roc, functions are always written as a lambda, like{}
         u16_overflow,
         "65536u16",
         @r"
-    ── NUMBER OVERFLOWS SUFFIX ─────────────────────────────── /code/proj/Main.roc ─
+    ── NUMBER OVERFLOWS SUFFIX in /code/proj/Main.roc ──────────────────────────────
 
     This integer literal overflows the type indicated by its suffix:
 
@@ -7315,7 +7315,7 @@ In roc, functions are always written as a lambda, like{}
         negative_u16,
         "-1u16",
         @r"
-    ── NUMBER UNDERFLOWS SUFFIX ────────────────────────────── /code/proj/Main.roc ─
+    ── NUMBER UNDERFLOWS SUFFIX in /code/proj/Main.roc ─────────────────────────────
 
     This integer literal underflows the type indicated by its suffix:
 
@@ -7331,7 +7331,7 @@ In roc, functions are always written as a lambda, like{}
         u32_overflow,
         "4_294_967_296u32",
         @r"
-    ── NUMBER OVERFLOWS SUFFIX ─────────────────────────────── /code/proj/Main.roc ─
+    ── NUMBER OVERFLOWS SUFFIX in /code/proj/Main.roc ──────────────────────────────
 
     This integer literal overflows the type indicated by its suffix:
 
@@ -7347,7 +7347,7 @@ In roc, functions are always written as a lambda, like{}
         negative_u32,
         "-1u32",
         @r"
-    ── NUMBER UNDERFLOWS SUFFIX ────────────────────────────── /code/proj/Main.roc ─
+    ── NUMBER UNDERFLOWS SUFFIX in /code/proj/Main.roc ─────────────────────────────
 
     This integer literal underflows the type indicated by its suffix:
 
@@ -7363,7 +7363,7 @@ In roc, functions are always written as a lambda, like{}
         u64_overflow,
         "18_446_744_073_709_551_616u64",
         @r"
-    ── NUMBER OVERFLOWS SUFFIX ─────────────────────────────── /code/proj/Main.roc ─
+    ── NUMBER OVERFLOWS SUFFIX in /code/proj/Main.roc ──────────────────────────────
 
     This integer literal overflows the type indicated by its suffix:
 
@@ -7379,7 +7379,7 @@ In roc, functions are always written as a lambda, like{}
         negative_u64,
         "-1u64",
         @r"
-    ── NUMBER UNDERFLOWS SUFFIX ────────────────────────────── /code/proj/Main.roc ─
+    ── NUMBER UNDERFLOWS SUFFIX in /code/proj/Main.roc ─────────────────────────────
 
     This integer literal underflows the type indicated by its suffix:
 
@@ -7395,7 +7395,7 @@ In roc, functions are always written as a lambda, like{}
         negative_u128,
         "-1u128",
         @r"
-    ── NUMBER UNDERFLOWS SUFFIX ────────────────────────────── /code/proj/Main.roc ─
+    ── NUMBER UNDERFLOWS SUFFIX in /code/proj/Main.roc ─────────────────────────────
 
     This integer literal underflows the type indicated by its suffix:
 
@@ -7411,7 +7411,7 @@ In roc, functions are always written as a lambda, like{}
         i8_overflow,
         "128i8",
         @r"
-    ── NUMBER OVERFLOWS SUFFIX ─────────────────────────────── /code/proj/Main.roc ─
+    ── NUMBER OVERFLOWS SUFFIX in /code/proj/Main.roc ──────────────────────────────
 
     This integer literal overflows the type indicated by its suffix:
 
@@ -7427,7 +7427,7 @@ In roc, functions are always written as a lambda, like{}
         i8_underflow,
         "-129i8",
         @r"
-    ── NUMBER UNDERFLOWS SUFFIX ────────────────────────────── /code/proj/Main.roc ─
+    ── NUMBER UNDERFLOWS SUFFIX in /code/proj/Main.roc ─────────────────────────────
 
     This integer literal underflows the type indicated by its suffix:
 
@@ -7443,7 +7443,7 @@ In roc, functions are always written as a lambda, like{}
         i16_overflow,
         "32768i16",
         @r"
-    ── NUMBER OVERFLOWS SUFFIX ─────────────────────────────── /code/proj/Main.roc ─
+    ── NUMBER OVERFLOWS SUFFIX in /code/proj/Main.roc ──────────────────────────────
 
     This integer literal overflows the type indicated by its suffix:
 
@@ -7459,7 +7459,7 @@ In roc, functions are always written as a lambda, like{}
         i16_underflow,
         "-32769i16",
         @r"
-    ── NUMBER UNDERFLOWS SUFFIX ────────────────────────────── /code/proj/Main.roc ─
+    ── NUMBER UNDERFLOWS SUFFIX in /code/proj/Main.roc ─────────────────────────────
 
     This integer literal underflows the type indicated by its suffix:
 
@@ -7475,7 +7475,7 @@ In roc, functions are always written as a lambda, like{}
         i32_overflow,
         "2_147_483_648i32",
         @r"
-    ── NUMBER OVERFLOWS SUFFIX ─────────────────────────────── /code/proj/Main.roc ─
+    ── NUMBER OVERFLOWS SUFFIX in /code/proj/Main.roc ──────────────────────────────
 
     This integer literal overflows the type indicated by its suffix:
 
@@ -7491,7 +7491,7 @@ In roc, functions are always written as a lambda, like{}
         i32_underflow,
         "-2_147_483_649i32",
         @r"
-    ── NUMBER UNDERFLOWS SUFFIX ────────────────────────────── /code/proj/Main.roc ─
+    ── NUMBER UNDERFLOWS SUFFIX in /code/proj/Main.roc ─────────────────────────────
 
     This integer literal underflows the type indicated by its suffix:
 
@@ -7507,7 +7507,7 @@ In roc, functions are always written as a lambda, like{}
         i64_overflow,
         "9_223_372_036_854_775_808i64",
         @r"
-    ── NUMBER OVERFLOWS SUFFIX ─────────────────────────────── /code/proj/Main.roc ─
+    ── NUMBER OVERFLOWS SUFFIX in /code/proj/Main.roc ──────────────────────────────
 
     This integer literal overflows the type indicated by its suffix:
 
@@ -7523,7 +7523,7 @@ In roc, functions are always written as a lambda, like{}
         i64_underflow,
         "-9_223_372_036_854_775_809i64",
         @r"
-    ── NUMBER UNDERFLOWS SUFFIX ────────────────────────────── /code/proj/Main.roc ─
+    ── NUMBER UNDERFLOWS SUFFIX in /code/proj/Main.roc ─────────────────────────────
 
     This integer literal underflows the type indicated by its suffix:
 
@@ -7539,7 +7539,7 @@ In roc, functions are always written as a lambda, like{}
         i128_overflow,
         "170_141_183_460_469_231_731_687_303_715_884_105_728i128",
         @r"
-    ── NUMBER OVERFLOWS SUFFIX ─────────────────────────────── /code/proj/Main.roc ─
+    ── NUMBER OVERFLOWS SUFFIX in /code/proj/Main.roc ──────────────────────────────
 
     This integer literal overflows the type indicated by its suffix:
 
@@ -7561,7 +7561,7 @@ In roc, functions are always written as a lambda, like{}
         // TODO: this error message could be improved, e.g. something like "This argument can
         // be used as ... because of its literal value"
         @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     This 2nd argument to `get` has an unexpected type:
 
@@ -7587,7 +7587,7 @@ In roc, functions are always written as a lambda, like{}
              "
         ),
         @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     This 2nd argument to `get` has an unexpected type:
 
@@ -7614,7 +7614,7 @@ In roc, functions are always written as a lambda, like{}
              "
         ),
         @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     This 2nd argument to `get` has an unexpected type:
 
@@ -7641,7 +7641,7 @@ In roc, functions are always written as a lambda, like{}
             "
         ),
         @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     The branches of this `when` expression don't match the condition:
 
@@ -7672,7 +7672,7 @@ In roc, functions are always written as a lambda, like{}
             "
         ),
         @r"
-    ── CYCLIC ALIAS ────────────────────────────────────────── /code/proj/Main.roc ─
+    ── CYCLIC ALIAS in /code/proj/Main.roc ─────────────────────────────────────────
 
     The `R` alias is self-recursive in an invalid way:
 
@@ -7695,7 +7695,7 @@ In roc, functions are always written as a lambda, like{}
             "
         ),
         @r"
-    ── CYCLIC ALIAS ────────────────────────────────────────── /code/proj/Main.roc ─
+    ── CYCLIC ALIAS in /code/proj/Main.roc ─────────────────────────────────────────
 
     The `R` alias is self-recursive in an invalid way:
 
@@ -7719,7 +7719,7 @@ In roc, functions are always written as a lambda, like{}
             "
         ),
         @r"
-    ── CYCLIC ALIAS ────────────────────────────────────────── /code/proj/Main.roc ─
+    ── CYCLIC ALIAS in /code/proj/Main.roc ─────────────────────────────────────────
 
     The `Foo` alias is recursive in an invalid way:
 
@@ -7754,7 +7754,7 @@ In roc, functions are always written as a lambda, like{}
             "
         ),
         @r"
-    ── DUPLICATE NAME ──────────────────────────────────────── /code/proj/Main.roc ─
+    ── DUPLICATE NAME in /code/proj/Main.roc ───────────────────────────────────────
 
     This alias has the same name as a builtin:
 
@@ -7774,7 +7774,7 @@ In roc, functions are always written as a lambda, like{}
             "
         ),
         @r"
-    ── OPAQUE TYPE NOT DEFINED ─────────────────────────────── /code/proj/Main.roc ─
+    ── OPAQUE TYPE NOT DEFINED in /code/proj/Main.roc ──────────────────────────────
 
     The opaque type Age referenced here is not defined:
 
@@ -7795,7 +7795,7 @@ In roc, functions are always written as a lambda, like{}
             "
         ),
         @r"
-    ── OPAQUE TYPE NOT DEFINED ─────────────────────────────── /code/proj/Main.roc ─
+    ── OPAQUE TYPE NOT DEFINED in /code/proj/Main.roc ──────────────────────────────
 
     The opaque type Age referenced here is not defined:
 
@@ -7809,7 +7809,7 @@ In roc, functions are always written as a lambda, like{}
 
     Note: It looks like there are no opaque types declared in this scope yet!
 
-    ── UNUSED DEFINITION ───────────────────────────────────── /code/proj/Main.roc ─
+    ── UNUSED DEFINITION in /code/proj/Main.roc ────────────────────────────────────
 
     `Age` is not used anywhere in your code.
 
@@ -7832,7 +7832,7 @@ In roc, functions are always written as a lambda, like{}
         // and checking it during can. The reason the error appears is because it is parsed as
         // Apply(Error(OtherModule), [@Age, 21])
         @r"
-    ── OPAQUE TYPE NOT DEFINED ─────────────────────────────── /code/proj/Main.roc ─
+    ── OPAQUE TYPE NOT DEFINED in /code/proj/Main.roc ──────────────────────────────
 
     The opaque type Age referenced here is not defined:
 
@@ -7841,7 +7841,7 @@ In roc, functions are always written as a lambda, like{}
 
     Note: It looks like there are no opaque types declared in this scope yet!
 
-    ── SYNTAX PROBLEM ──────────────────────────────────────── /code/proj/Main.roc ─
+    ── SYNTAX PROBLEM in /code/proj/Main.roc ───────────────────────────────────────
 
     I am trying to parse a qualified name here:
 
@@ -7868,7 +7868,7 @@ In roc, functions are always written as a lambda, like{}
         // `@Age` can be linked to the declaration of `Age` inside `age`, and a suggestion to
         // raise that declaration to the outer scope.
         @r"
-    ── UNUSED DEFINITION ───────────────────────────────────── /code/proj/Main.roc ─
+    ── UNUSED DEFINITION in /code/proj/Main.roc ────────────────────────────────────
 
     `Age` is not used anywhere in your code.
 
@@ -7878,7 +7878,7 @@ In roc, functions are always written as a lambda, like{}
     If you didn't intend on using `Age` then remove it so future readers of
     your code don't wonder why it is there.
 
-    ── OPAQUE TYPE NOT DEFINED ─────────────────────────────── /code/proj/Main.roc ─
+    ── OPAQUE TYPE NOT DEFINED in /code/proj/Main.roc ──────────────────────────────
 
     The opaque type Age referenced here is not defined:
 
@@ -7899,7 +7899,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
         @r"
-    ── MODULE NOT IMPORTED ─────────────────────────────────── /code/proj/Main.roc ─
+    ── MODULE NOT IMPORTED in /code/proj/Main.roc ──────────────────────────────────
 
     The `Task` module is not imported:
 
@@ -7931,7 +7931,7 @@ In roc, functions are always written as a lambda, like{}
         // TODO(opaques): error could be improved by saying that the opaque definition demands
         // that the argument be a U8, and linking to the definitin!
         @r#"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     This expression is used in an unexpected way:
 
@@ -7960,7 +7960,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
         @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     This expression is used in an unexpected way:
 
@@ -7990,7 +7990,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
         @r#"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     Something is off with the body of the `v` definition:
 
@@ -8028,7 +8028,7 @@ In roc, functions are always written as a lambda, like{}
         // TODO(opaques): error could be improved by saying that the user-provided pattern
         // probably wants to change "Age" to "@Age"!
         @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     The 1st argument to `f` is weird:
 
@@ -8063,7 +8063,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
         @r#"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     The 2nd pattern in this `when` does not match the previous ones:
 
@@ -8094,7 +8094,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
         @r#"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     The branches of this `when` expression don't match the condition:
 
@@ -8132,7 +8132,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
         @r#"
-    ── UNSAFE PATTERN ──────────────────────────────────────── /code/proj/Main.roc ─
+    ── UNSAFE PATTERN in /code/proj/Main.roc ───────────────────────────────────────
 
     This `when` does not cover all the possibilities:
 
@@ -8165,7 +8165,7 @@ In roc, functions are always written as a lambda, like{}
             "
         ),
         @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     This 1st argument to `y` has an unexpected type:
 
@@ -8198,7 +8198,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
         @r#"
-    ── UNSAFE PATTERN ──────────────────────────────────────── /code/proj/Main.roc ─
+    ── UNSAFE PATTERN in /code/proj/Main.roc ───────────────────────────────────────
 
     This `when` does not cover all the possibilities:
 
@@ -8222,7 +8222,7 @@ In roc, functions are always written as a lambda, like{}
             "
         ),
         @r"
-    ── INVALID_EXTENSION_TYPE ──────────────────────────────── /code/proj/Main.roc ─
+    ── INVALID_EXTENSION_TYPE in /code/proj/Main.roc ───────────────────────────────
 
     This record extension type is invalid:
 
@@ -8243,7 +8243,7 @@ In roc, functions are always written as a lambda, like{}
             "
         ),
         @r"
-    ── INVALID_EXTENSION_TYPE ──────────────────────────────── /code/proj/Main.roc ─
+    ── INVALID_EXTENSION_TYPE in /code/proj/Main.roc ───────────────────────────────
 
     This tag union extension type is invalid:
 
@@ -8270,7 +8270,7 @@ In roc, functions are always written as a lambda, like{}
             "
         ),
         @r"
-    ── UNRECOGNIZED NAME ───────────────────────────────────── /code/proj/Main.roc ─
+    ── UNRECOGNIZED NAME in /code/proj/Main.roc ────────────────────────────────────
 
     Nothing is named `UnknownType` in this scope.
 
@@ -8284,7 +8284,7 @@ In roc, functions are always written as a lambda, like{}
         Unsigned16
         Unsigned64
 
-    ── UNRECOGNIZED NAME ───────────────────────────────────── /code/proj/Main.roc ─
+    ── UNRECOGNIZED NAME in /code/proj/Main.roc ────────────────────────────────────
 
     Nothing is named `UnknownType` in this scope.
 
@@ -8311,7 +8311,7 @@ In roc, functions are always written as a lambda, like{}
             "
         ),
         @r"
-    ── UNFINISHED ABILITY ── tmp/ability_first_demand_not_indented_enough/Test.roc ─
+    ── UNFINISHED ABILITY in tmp/ability_first_demand_not_indented_enough/Test.roc ─
 
     I was partway through parsing an ability definition, but I got stuck
     here:
@@ -8336,7 +8336,7 @@ In roc, functions are always written as a lambda, like{}
             "
         ),
         @r"
-        ── UNFINISHED ABILITY ─── tmp/ability_demands_not_indented_with_first/Test.roc ─
+        ── UNFINISHED ABILITY in tmp/ability_demands_not_indented_with_first/Test.roc ──
 
         I was partway through parsing an ability definition, but I got stuck
         here:
@@ -8359,7 +8359,7 @@ In roc, functions are always written as a lambda, like{}
                 "
         ),
         @r"
-        ── UNFINISHED ABILITY ───────────── tmp/ability_demand_value_has_args/Test.roc ─
+        ── UNFINISHED ABILITY in tmp/ability_demand_value_has_args/Test.roc ────────────
 
         I was partway through parsing an ability definition, but I got stuck
         here:
@@ -8383,7 +8383,7 @@ In roc, functions are always written as a lambda, like{}
             "
         ),
         @r"
-    ── UNFINISHED ABILITY ────────── tmp/ability_non_signature_expression/Test.roc ─
+    ── UNFINISHED ABILITY in tmp/ability_non_signature_expression/Test.roc ─────────
 
     I was partway through parsing an ability definition, but I got stuck
     here:
@@ -8406,7 +8406,7 @@ In roc, functions are always written as a lambda, like{}
             "
         ),
         @r"
-    ── UNBOUND TYPE VARIABLE ───────────────────────────────── /code/proj/Main.roc ─
+    ── UNBOUND TYPE VARIABLE in /code/proj/Main.roc ────────────────────────────────
 
     The definition of `I` has an unbound type variable:
 
@@ -8428,7 +8428,7 @@ In roc, functions are always written as a lambda, like{}
             "
         ),
         @r"
-    ── UNBOUND TYPE VARIABLE ───────────────────────────────── /code/proj/Main.roc ─
+    ── UNBOUND TYPE VARIABLE in /code/proj/Main.roc ────────────────────────────────
 
     The definition of `I` has an unbound type variable:
 
@@ -8450,7 +8450,7 @@ In roc, functions are always written as a lambda, like{}
             "
         ),
         @r"
-    ── UNBOUND TYPE VARIABLE ───────────────────────────────── /code/proj/Main.roc ─
+    ── UNBOUND TYPE VARIABLE in /code/proj/Main.roc ────────────────────────────────
 
     The definition of `I` has 2 unbound type variables.
 
@@ -8474,7 +8474,7 @@ In roc, functions are always written as a lambda, like{}
             "
         ),
         @r"
-    ── UNBOUND TYPE VARIABLE ───────────────────────────────── /code/proj/Main.roc ─
+    ── UNBOUND TYPE VARIABLE in /code/proj/Main.roc ────────────────────────────────
 
     The definition of `I` has an unbound type variable:
 
@@ -8496,7 +8496,7 @@ In roc, functions are always written as a lambda, like{}
             "
         ),
         @r"
-    ── UNBOUND TYPE VARIABLE ───────────────────────────────── /code/proj/Main.roc ─
+    ── UNBOUND TYPE VARIABLE in /code/proj/Main.roc ────────────────────────────────
 
     The definition of `I` has an unbound type variable:
 
@@ -8519,7 +8519,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
         @r"
-    ── ABILITY HAS TYPE VARIABLES ──────────────────────────── /code/proj/Main.roc ─
+    ── ABILITY HAS TYPE VARIABLES in /code/proj/Main.roc ───────────────────────────
 
     The definition of the `MHash` ability includes type variables:
 
@@ -8529,7 +8529,7 @@ In roc, functions are always written as a lambda, like{}
     Abilities cannot depend on type variables, but their member values
     can!
 
-    ── UNUSED DEFINITION ───────────────────────────────────── /code/proj/Main.roc ─
+    ── UNUSED DEFINITION in /code/proj/Main.roc ────────────────────────────────────
 
     `MHash` is not used anywhere in your code.
 
@@ -8551,7 +8551,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
         @r#"
-    ── IMPLEMENTS CLAUSE IS NOT AN ABILITY ─────────────────── /code/proj/Main.roc ─
+    ── IMPLEMENTS CLAUSE IS NOT AN ABILITY in /code/proj/Main.roc ──────────────────
 
     The type referenced in this "implements" clause is not an ability:
 
@@ -8570,7 +8570,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
         @r"
-        ── DUPLICATE NAME ──────────────────────────────────────── /code/proj/Main.roc ─
+        ── DUPLICATE NAME in /code/proj/Main.roc ───────────────────────────────────────
 
         The `a` name is first defined here:
 
@@ -8599,7 +8599,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
         @r"
-        ── DUPLICATE NAME ──────────────────────────────────────── /code/proj/Main.roc ─
+        ── DUPLICATE NAME in /code/proj/Main.roc ───────────────────────────────────────
 
         The `Ability` name is first defined here:
 
@@ -8626,7 +8626,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
         @r"
-        ── ABILITY MEMBER MISSING IMPLEMENTS CLAUSE ────────────── /code/proj/Main.roc ─
+        ── ABILITY MEMBER MISSING IMPLEMENTS CLAUSE in /code/proj/Main.roc ─────────────
 
         The definition of the ability member `ab` does not include an `implements`
         clause binding a type variable to the ability `Ability`:
@@ -8641,7 +8641,7 @@ In roc, functions are always written as a lambda, like{}
 
         Otherwise, the function does not need to be part of the ability!
 
-        ── UNUSED DEFINITION ───────────────────────────────────── /code/proj/Main.roc ─
+        ── UNUSED DEFINITION in /code/proj/Main.roc ────────────────────────────────────
 
         `Ability` is not used anywhere in your code.
 
@@ -8663,7 +8663,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
         @r"
-        ── ABILITY MEMBER BINDS MULTIPLE VARIABLES ─────────────── /code/proj/Main.roc ─
+        ── ABILITY MEMBER BINDS MULTIPLE VARIABLES in /code/proj/Main.roc ──────────────
 
         The definition of the ability member `eq` includes multiple variables
         bound to the `MEq`` ability:`
@@ -8691,7 +8691,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
         @r"
-    ── ILLEGAL IMPLEMENTS CLAUSE ───────────────────────────── /code/proj/Main.roc ─
+    ── ILLEGAL IMPLEMENTS CLAUSE in /code/proj/Main.roc ────────────────────────────
 
     An `implements` clause is not allowed here:
 
@@ -8701,7 +8701,7 @@ In roc, functions are always written as a lambda, like{}
     `implements` clauses can only be specified on the top-level type
     annotations.
 
-    ── ABILITY MEMBER MISSING IMPLEMENTS CLAUSE ────────────── /code/proj/Main.roc ─
+    ── ABILITY MEMBER MISSING IMPLEMENTS CLAUSE in /code/proj/Main.roc ─────────────
 
     The definition of the ability member `hash` does not include an
     `implements` clause binding a type variable to the ability `MHash`:
@@ -8732,7 +8732,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
         @r"
-        ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+        ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
         Something is off with this specialization of `hash`:
 
@@ -8765,7 +8765,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
         @r"
-    ── INCOMPLETE ABILITY IMPLEMENTATION ───────────────────── /code/proj/Main.roc ─
+    ── INCOMPLETE ABILITY IMPLEMENTATION in /code/proj/Main.roc ────────────────────
 
     This type does not fully implement the `MEq` ability:
 
@@ -8791,7 +8791,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
         @r"
-    ── UNUSED DEFINITION ───────────────────────────────────── /code/proj/Main.roc ─
+    ── UNUSED DEFINITION in /code/proj/Main.roc ────────────────────────────────────
 
     `hash` is not used anywhere in your code.
 
@@ -8820,7 +8820,7 @@ In roc, functions are always written as a lambda, like{}
         ),
         // TODO: the error message here could be seriously improved!
         @r"
-    ── OVERLOADED SPECIALIZATION ───────────────────────────── /code/proj/Main.roc ─
+    ── OVERLOADED SPECIALIZATION in /code/proj/Main.roc ────────────────────────────
 
     This ability member specialization is already claimed to specialize
     another opaque type:
@@ -8833,7 +8833,7 @@ In roc, functions are always written as a lambda, like{}
     Ability specializations can only provide implementations for one
     opaque type, since all opaque types are different!
 
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     This specialization of `hash` is overly general:
 
@@ -8873,7 +8873,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
         @r"
-    ── OVERLOADED SPECIALIZATION ───────────────────────────── /code/proj/Main.roc ─
+    ── OVERLOADED SPECIALIZATION in /code/proj/Main.roc ────────────────────────────
 
     This ability member specialization is already claimed to specialize
     another opaque type:
@@ -8904,7 +8904,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
         @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     Something is off with this specialization of `eq`:
 
@@ -8939,7 +8939,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
         @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     Something is off with the body of the `hash` definition:
 
@@ -8980,7 +8980,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
         @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     This expression has a type that does not implement the abilities it's expected to:
 
@@ -8993,7 +8993,7 @@ In roc, functions are always written as a lambda, like{}
 
     Only builtin abilities can have generated implementations!
 
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     This expression has a type that does not implement the abilities it's expected to:
 
@@ -9018,7 +9018,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
         @r"
-        ── ABILITY NOT ON TOP-LEVEL ────────────────────────────── /code/proj/Main.roc ─
+        ── ABILITY NOT ON TOP-LEVEL in /code/proj/Main.roc ─────────────────────────────
 
         This ability definition is not on the top-level of a module:
 
@@ -9046,7 +9046,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
         @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     Something is off with the body of the `hashable` definition:
 
@@ -9092,7 +9092,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
         @r"
-    ── ABILITY USED AS TYPE ────────────────────────────────── /code/proj/Main.roc ─
+    ── ABILITY USED AS TYPE in /code/proj/Main.roc ─────────────────────────────────
 
     You are attempting to use the ability `MHash` as a type directly:
 
@@ -9106,7 +9106,7 @@ In roc, functions are always written as a lambda, like{}
 
         a implements MHash
 
-    ── ABILITY USED AS TYPE ────────────────────────────────── /code/proj/Main.roc ─
+    ── ABILITY USED AS TYPE in /code/proj/Main.roc ─────────────────────────────────
 
     You are attempting to use the ability `MHash` as a type directly:
 
@@ -9136,7 +9136,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
         @r#"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     The branches of this `when` expression don't match the condition:
 
@@ -9189,7 +9189,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
         @r#"
-        ── WEIRD IMPORTS ────────────────────────── tmp/imports_missing_comma/Test.roc ─
+        ── WEIRD IMPORTS in tmp/imports_missing_comma/Test.roc ─────────────────────────
 
         I am partway through parsing a imports list, but I got stuck here:
 
@@ -9214,7 +9214,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
         @r#"
-        ── UNSAFE PATTERN ──────────────────────────────────────── /code/proj/Main.roc ─
+        ── UNSAFE PATTERN in /code/proj/Main.roc ───────────────────────────────────────
 
         This `when` does not cover all the possibilities:
 
@@ -9261,7 +9261,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
         @r"
-        ── SPECIALIZATION NOT ON TOP-LEVEL ─────────────────────── /code/proj/Main.roc ─
+        ── SPECIALIZATION NOT ON TOP-LEVEL in /code/proj/Main.roc ──────────────────────
 
         This specialization of the `default` ability member is in a nested
         scope:
@@ -9286,7 +9286,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
         @r#"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     This 2nd argument to == has an unexpected type:
 
@@ -9322,7 +9322,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
         @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     This 1st argument to `remove` has an unexpected type:
 
@@ -9343,7 +9343,7 @@ In roc, functions are always written as a lambda, like{}
     change the type annotation to be more specific? Maybe change the code
     to be more general?
 
-    ── CIRCULAR TYPE ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── CIRCULAR TYPE in /code/proj/Main.roc ────────────────────────────────────────
 
     I'm inferring a weird self-referential type for `new`:
 
@@ -9356,7 +9356,7 @@ In roc, functions are always written as a lambda, like{}
 
         { set : Set ∞ }
 
-    ── CIRCULAR TYPE ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── CIRCULAR TYPE in /code/proj/Main.roc ────────────────────────────────────────
 
     I'm inferring a weird self-referential type for `goal`:
 
@@ -9386,7 +9386,7 @@ In roc, functions are always written as a lambda, like{}
             "
         ),
         @r"
-        ── CIRCULAR DEFINITION ─────────────────────────────────── /code/proj/Main.roc ─
+        ── CIRCULAR DEFINITION in /code/proj/Main.roc ──────────────────────────────────
 
         The `t1` definition is causing a very tricky infinite loop:
 
@@ -9414,7 +9414,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
         @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     This expression has a type that does not implement the abilities it's expected to:
 
@@ -9442,7 +9442,7 @@ In roc, functions are always written as a lambda, like{}
         // TODO: this error message is quite unfortunate. We should remove the duplication, and
         // also support regions that point to things in other modules. See also https://github.com/roc-lang/roc/issues/3056.
         @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     This expression has a type that does not implement the abilities it's expected to:
 
@@ -9479,7 +9479,7 @@ In roc, functions are always written as a lambda, like{}
                 "#
         ),
         @r"
-            ── CIRCULAR DEFINITION ─────────────────────────────────── /code/proj/Main.roc ─
+            ── CIRCULAR DEFINITION in /code/proj/Main.roc ──────────────────────────────────
 
             The `t1` definition is causing a very tricky infinite loop:
 
@@ -9509,7 +9509,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
         @r"
-    ── IMPLEMENTATION NOT FOUND ────────────────────────────── /code/proj/Main.roc ─
+    ── IMPLEMENTATION NOT FOUND in /code/proj/Main.roc ─────────────────────────────
 
     An implementation of `eq` could not be found in this scope:
 
@@ -9520,7 +9520,7 @@ In roc, functions are always written as a lambda, like{}
     another variable that implements this ability member, like
     { eq: myeq }
 
-    ── INCOMPLETE ABILITY IMPLEMENTATION ───────────────────── /code/proj/Main.roc ─
+    ── INCOMPLETE ABILITY IMPLEMENTATION in /code/proj/Main.roc ────────────────────
 
     This type does not fully implement the `MEq` ability:
 
@@ -9547,7 +9547,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
         @r"
-    ── UNRECOGNIZED NAME ───────────────────────────────────── /code/proj/Main.roc ─
+    ── UNRECOGNIZED NAME in /code/proj/Main.roc ────────────────────────────────────
 
     Nothing is named `aMEq` in this scope.
 
@@ -9561,7 +9561,7 @@ In roc, functions are always written as a lambda, like{}
         myMEq
         eq
 
-    ── INCOMPLETE ABILITY IMPLEMENTATION ───────────────────── /code/proj/Main.roc ─
+    ── INCOMPLETE ABILITY IMPLEMENTATION in /code/proj/Main.roc ────────────────────
 
     This type does not fully implement the `MEq` ability:
 
@@ -9588,7 +9588,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
         @r"
-    ── OPTIONAL ABILITY IMPLEMENTATION ─────────────────────── /code/proj/Main.roc ─
+    ── OPTIONAL ABILITY IMPLEMENTATION in /code/proj/Main.roc ──────────────────────
 
     Ability implementations cannot be optional:
 
@@ -9599,7 +9599,7 @@ In roc, functions are always written as a lambda, like{}
 
 
 
-    ── INCOMPLETE ABILITY IMPLEMENTATION ───────────────────── /code/proj/Main.roc ─
+    ── INCOMPLETE ABILITY IMPLEMENTATION in /code/proj/Main.roc ────────────────────
 
     This type does not fully implement the `MEq` ability:
 
@@ -9626,7 +9626,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
         @r"
-    ── OPTIONAL ABILITY IMPLEMENTATION ─────────────────────── /code/proj/Main.roc ─
+    ── OPTIONAL ABILITY IMPLEMENTATION in /code/proj/Main.roc ──────────────────────
 
     Ability implementations cannot be optional:
 
@@ -9639,7 +9639,7 @@ In roc, functions are always written as a lambda, like{}
     record of implementations. For example,    implements [Encoding] will
     attempt to derive `Encoding`
 
-    ── INCOMPLETE ABILITY IMPLEMENTATION ───────────────────── /code/proj/Main.roc ─
+    ── INCOMPLETE ABILITY IMPLEMENTATION in /code/proj/Main.roc ────────────────────
 
     This type does not fully implement the `Encoding` ability:
 
@@ -9664,7 +9664,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
         @r"
-    ── QUALIFIED ABILITY IMPLEMENTATION ────────────────────── /code/proj/Main.roc ─
+    ── QUALIFIED ABILITY IMPLEMENTATION in /code/proj/Main.roc ─────────────────────
 
     This ability implementation is qualified:
 
@@ -9674,7 +9674,7 @@ In roc, functions are always written as a lambda, like{}
     Custom implementations must be defined in the local scope, and
     unqualified.
 
-    ── INCOMPLETE ABILITY IMPLEMENTATION ───────────────────── /code/proj/Main.roc ─
+    ── INCOMPLETE ABILITY IMPLEMENTATION in /code/proj/Main.roc ────────────────────
 
     This type does not fully implement the `MEq` ability:
 
@@ -9699,7 +9699,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
         @r"
-    ── ABILITY IMPLEMENTATION NOT IDENTIFIER ───────────────── /code/proj/Main.roc ─
+    ── ABILITY IMPLEMENTATION NOT IDENTIFIER in /code/proj/Main.roc ────────────────
 
     This ability implementation is not an identifier:
 
@@ -9711,7 +9711,7 @@ In roc, functions are always written as a lambda, like{}
 
     Tip: consider defining this expression as a variable.
 
-    ── INCOMPLETE ABILITY IMPLEMENTATION ───────────────────── /code/proj/Main.roc ─
+    ── INCOMPLETE ABILITY IMPLEMENTATION in /code/proj/Main.roc ────────────────────
 
     This type does not fully implement the `MEq` ability:
 
@@ -9738,7 +9738,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
         @r"
-    ── DUPLICATE IMPLEMENTATION ────────────────────────────── /code/proj/Main.roc ─
+    ── DUPLICATE IMPLEMENTATION in /code/proj/Main.roc ─────────────────────────────
 
     This ability member implementation is duplicate:
 
@@ -9766,7 +9766,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
         @r"
-    ── NOT AN ABILITY ──────────────────────────────────────── /code/proj/Main.roc ─
+    ── NOT AN ABILITY in /code/proj/Main.roc ───────────────────────────────────────
 
     This identifier is not an ability in scope:
 
@@ -9789,7 +9789,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
         @r"
-    ── ILLEGAL DERIVE ──────────────────────────────────────── /code/proj/Main.roc ─
+    ── ILLEGAL DERIVE in /code/proj/Main.roc ───────────────────────────────────────
 
     This ability cannot be derived:
 
@@ -9812,7 +9812,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
         @r"
-    ── INCOMPLETE ABILITY IMPLEMENTATION ───────────────────── /code/proj/Main.roc ─
+    ── INCOMPLETE ABILITY IMPLEMENTATION in /code/proj/Main.roc ────────────────────
 
     I can't derive an implementation of the `Encoding` ability for `A`:
 
@@ -9837,7 +9837,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
         @r"
-    ── INCOMPLETE ABILITY IMPLEMENTATION ───────────────────── /code/proj/Main.roc ─
+    ── INCOMPLETE ABILITY IMPLEMENTATION in /code/proj/Main.roc ────────────────────
 
     I can't derive an implementation of the `Encoding` ability for `A`:
 
@@ -9889,7 +9889,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
         @r"
-    ── DUPLICATE NAME ──────────────────────────────────────── /code/proj/Main.roc ─
+    ── DUPLICATE NAME in /code/proj/Main.roc ───────────────────────────────────────
 
     The `main` name is first defined here:
 
@@ -9904,7 +9904,7 @@ In roc, functions are always written as a lambda, like{}
     Since these variables have the same name, it's easy to use the wrong
     one by accident. Give one of them a new name.
 
-    ── UNNECESSARY DEFINITION ──────────────────────────────── /code/proj/Main.roc ─
+    ── UNNECESSARY DEFINITION in /code/proj/Main.roc ───────────────────────────────
 
     This destructure assignment doesn't introduce any new variables:
 
@@ -9938,7 +9938,7 @@ In roc, functions are always written as a lambda, like{}
             "
         ),
         @r"
-        ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+        ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
         Something is off with the body of the `withOpen` definition:
 
@@ -9973,7 +9973,7 @@ In roc, functions are always written as a lambda, like{}
             "
         ),
         @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     This expression is used in an unexpected way:
 
@@ -10020,7 +10020,7 @@ In roc, functions are always written as a lambda, like{}
             "
         ),
         @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     This 1st argument to `foo` has an unexpected type:
 
@@ -10065,7 +10065,7 @@ In roc, functions are always written as a lambda, like{}
             "
         ),
         @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     This 2nd argument to == has an unexpected type:
 
@@ -10090,7 +10090,7 @@ In roc, functions are always written as a lambda, like{}
             "
         ),
         @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     This 2nd argument to == has an unexpected type:
 
@@ -10127,7 +10127,7 @@ In roc, functions are always written as a lambda, like{}
             "
         ),
         @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     Something is off with the 2nd branch of this `when` expression:
 
@@ -10164,7 +10164,7 @@ In roc, functions are always written as a lambda, like{}
             "
         ),
         @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     This 2nd argument to `map` has an unexpected type:
 
@@ -10190,7 +10190,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
         @r#"
-        ── NAME NOT BOUND IN ALL PATTERNS ──────────────────────── /code/proj/Main.roc ─
+        ── NAME NOT BOUND IN ALL PATTERNS in /code/proj/Main.roc ───────────────────────
 
         `x` is not bound in all patterns of this `when` branch
 
@@ -10201,7 +10201,7 @@ In roc, functions are always written as a lambda, like{}
         of the branch. Otherwise, the program would crash when it tries to use
         an identifier that wasn't bound!
 
-        ── NAME NOT BOUND IN ALL PATTERNS ──────────────────────── /code/proj/Main.roc ─
+        ── NAME NOT BOUND IN ALL PATTERNS in /code/proj/Main.roc ───────────────────────
 
         `y` is not bound in all patterns of this `when` branch
 
@@ -10212,7 +10212,7 @@ In roc, functions are always written as a lambda, like{}
         of the branch. Otherwise, the program would crash when it tries to use
         an identifier that wasn't bound!
 
-        ── UNUSED DEFINITION ───────────────────────────────────── /code/proj/Main.roc ─
+        ── UNUSED DEFINITION in /code/proj/Main.roc ────────────────────────────────────
 
         `y` is not used in this `when` branch.
 
@@ -10234,7 +10234,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
         @r#"
-    ── UNSAFE PATTERN ──────────────────────────────────────── /code/proj/Main.roc ─
+    ── UNSAFE PATTERN in /code/proj/Main.roc ───────────────────────────────────────
 
     This `when` does not cover all the possibilities:
 
@@ -10260,7 +10260,7 @@ In roc, functions are always written as a lambda, like{}
         |golden| pretty_assertions::assert_eq!(
             golden,
             indoc!(
-                r"── UNRECOGNIZED NAME ───────────────────────────────────── /code/proj/Main.roc ─
+                r"── UNRECOGNIZED NAME in /code/proj/Main.roc ────────────────────────────────────
 
                 Nothing is named `foo` in this scope.
 
@@ -10297,7 +10297,7 @@ In roc, functions are always written as a lambda, like{}
         |golden| pretty_assertions::assert_eq!(
             golden,
             indoc!(
-                r"── SYNTAX PROBLEM ──────────────────────────────────────── /code/proj/Main.roc ─
+                r"── SYNTAX PROBLEM in /code/proj/Main.roc ───────────────────────────────────────
 
                 An underscore is being used as a variable here:
 
@@ -10323,7 +10323,7 @@ In roc, functions are always written as a lambda, like{}
         |golden| pretty_assertions::assert_eq!(
             golden,
             indoc!(
-                r"── SYNTAX PROBLEM ──────────────────────────────────────── /code/proj/Main.roc ─
+                r"── SYNTAX PROBLEM in /code/proj/Main.roc ───────────────────────────────────────
 
                 This variable's name starts with an underscore:
 
@@ -10356,7 +10356,7 @@ In roc, functions are always written as a lambda, like{}
             golden,
             indoc!(
                 r"
-                ── SYNTAX PROBLEM ──────────────────────────────────────── /code/proj/Main.roc ─
+                ── SYNTAX PROBLEM in /code/proj/Main.roc ───────────────────────────────────────
 
                 This variable's name starts with an underscore:
 
@@ -10383,7 +10383,7 @@ In roc, functions are always written as a lambda, like{}
             golden,
             indoc!(
                 r"
-                ── SYNTAX PROBLEM ──────────────────────────────────────── /code/proj/Main.roc ─
+                ── SYNTAX PROBLEM in /code/proj/Main.roc ───────────────────────────────────────
 
                 Underscores are not allowed in identifier names:
 
@@ -10410,7 +10410,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
         @r#"
-    ── BAD RECORD BUILDER ────────── tmp/optional_field_in_record_builder/Test.roc ─
+    ── BAD RECORD BUILDER in tmp/optional_field_in_record_builder/Test.roc ─────────
 
     I am partway through parsing a record builder, and I found an optional
     field:
@@ -10439,7 +10439,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
         @r#"
-    ── BAD RECORD UPDATE ────────────────────── tmp/record_update_builder/Test.roc ─
+    ── BAD RECORD UPDATE in tmp/record_update_builder/Test.roc ─────────────────────
 
     I am partway through parsing a record update, and I found a record
     builder field:
@@ -10465,7 +10465,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
         @r#"
-    ── MULTIPLE RECORD BUILDERS ────────────────────────────── /code/proj/Main.roc ─
+    ── MULTIPLE RECORD BUILDERS in /code/proj/Main.roc ─────────────────────────────
 
     This function is applied to multiple record builders:
 
@@ -10488,7 +10488,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
         @r#"
-    ── UNAPPLIED RECORD BUILDER ────────────────────────────── /code/proj/Main.roc ─
+    ── UNAPPLIED RECORD BUILDER in /code/proj/Main.roc ─────────────────────────────
 
     This record builder was not applied to a function:
 
@@ -10513,7 +10513,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
         @r#"
-    ── TOO MANY ARGS ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TOO MANY ARGS in /code/proj/Main.roc ────────────────────────────────────────
 
     This value is not a function, but it was given 1 argument:
 
@@ -10545,7 +10545,7 @@ In roc, functions are always written as a lambda, like{}
     //         "#
     //     ),
     //     @r#"
-    // ── TOO MANY ARGS ───────────────────────────────────────── /code/proj/Main.roc ─
+    // ── TOO MANY ARGS in /code/proj/Main.roc ────────────────────────────────────────
 
     // This value is an opaque type, so it cannot be called with an argument:
 
@@ -10572,7 +10572,7 @@ In roc, functions are always written as a lambda, like{}
             "
         ),
         @r"
-    ── UNNECESSARY DEFINITION ──────────────────────────────── /code/proj/Main.roc ─
+    ── UNNECESSARY DEFINITION in /code/proj/Main.roc ───────────────────────────────
 
     This destructure assignment doesn't introduce any new variables:
 
@@ -10584,7 +10584,7 @@ In roc, functions are always written as a lambda, like{}
     functional, assignments that don't introduce variables cannot affect a
     program's behavior!
 
-    ── UNNECESSARY DEFINITION ──────────────────────────────── /code/proj/Main.roc ─
+    ── UNNECESSARY DEFINITION in /code/proj/Main.roc ───────────────────────────────
 
     This destructure assignment doesn't introduce any new variables:
 
@@ -10596,7 +10596,7 @@ In roc, functions are always written as a lambda, like{}
     functional, assignments that don't introduce variables cannot affect a
     program's behavior!
 
-    ── UNNECESSARY DEFINITION ──────────────────────────────── /code/proj/Main.roc ─
+    ── UNNECESSARY DEFINITION in /code/proj/Main.roc ───────────────────────────────
 
     This destructure assignment doesn't introduce any new variables:
 
@@ -10608,7 +10608,7 @@ In roc, functions are always written as a lambda, like{}
     functional, assignments that don't introduce variables cannot affect a
     program's behavior!
 
-    ── UNNECESSARY DEFINITION ──────────────────────────────── /code/proj/Main.roc ─
+    ── UNNECESSARY DEFINITION in /code/proj/Main.roc ───────────────────────────────
 
     This destructure assignment doesn't introduce any new variables:
 
@@ -10638,7 +10638,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
         @r"
-    ── UNNECESSARY DEFINITION ──────────────────────────────── /code/proj/Main.roc ─
+    ── UNNECESSARY DEFINITION in /code/proj/Main.roc ───────────────────────────────
 
     This destructure assignment doesn't introduce any new variables:
 
@@ -10650,7 +10650,7 @@ In roc, functions are always written as a lambda, like{}
     functional, assignments that don't introduce variables cannot affect a
     program's behavior!
 
-    ── UNNECESSARY DEFINITION ──────────────────────────────── /code/proj/Main.roc ─
+    ── UNNECESSARY DEFINITION in /code/proj/Main.roc ───────────────────────────────
 
     This destructure assignment doesn't introduce any new variables:
 
@@ -10662,7 +10662,7 @@ In roc, functions are always written as a lambda, like{}
     functional, assignments that don't introduce variables cannot affect a
     program's behavior!
 
-    ── UNNECESSARY DEFINITION ──────────────────────────────── /code/proj/Main.roc ─
+    ── UNNECESSARY DEFINITION in /code/proj/Main.roc ───────────────────────────────
 
     This destructure assignment doesn't introduce any new variables:
 
@@ -10674,7 +10674,7 @@ In roc, functions are always written as a lambda, like{}
     functional, assignments that don't introduce variables cannot affect a
     program's behavior!
 
-    ── UNNECESSARY DEFINITION ──────────────────────────────── /code/proj/Main.roc ─
+    ── UNNECESSARY DEFINITION in /code/proj/Main.roc ───────────────────────────────
 
     This destructure assignment doesn't introduce any new variables:
 
@@ -10702,7 +10702,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
         @r"
-    ── UNUSED DEFINITION ───────────────────────────────────── /code/proj/Main.roc ─
+    ── UNUSED DEFINITION in /code/proj/Main.roc ────────────────────────────────────
 
     `hash` is not used anywhere in your code.
 
@@ -10729,7 +10729,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
         @r"
-    ── WRONG SPECIALIZATION TYPE ───────────────────────────── /code/proj/Main.roc ─
+    ── WRONG SPECIALIZATION TYPE in /code/proj/Main.roc ────────────────────────────
 
     This specialization of `hash` is not for the expected type:
 
@@ -10752,7 +10752,7 @@ In roc, functions are always written as a lambda, like{}
                 "
         ),
         @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     Something is off with the body of the `x` definition:
 
@@ -10782,7 +10782,7 @@ In roc, functions are always written as a lambda, like{}
             "
         ),
         @r"
-    ── CYCLIC ALIAS ────────────────────────────────────────── /code/proj/Main.roc ─
+    ── CYCLIC ALIAS in /code/proj/Main.roc ─────────────────────────────────────────
 
     The `Recursive` opaque is self-recursive in an invalid way:
 
@@ -10804,7 +10804,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
         @r"
-    ── INCOMPLETE ABILITY IMPLEMENTATION ───────────────────── /code/proj/Main.roc ─
+    ── INCOMPLETE ABILITY IMPLEMENTATION in /code/proj/Main.roc ────────────────────
 
     I can't derive an implementation of the `Decoding` ability for `A`:
 
@@ -10829,7 +10829,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
         @r"
-    ── INCOMPLETE ABILITY IMPLEMENTATION ───────────────────── /code/proj/Main.roc ─
+    ── INCOMPLETE ABILITY IMPLEMENTATION in /code/proj/Main.roc ────────────────────
 
     I can't derive an implementation of the `Decoding` ability for `A`:
 
@@ -10884,7 +10884,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
         @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     This expression has a type that does not implement the abilities it's expected to:
 
@@ -10915,7 +10915,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
         @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     This expression has a type that does not implement the abilities it's expected to:
 
@@ -10945,7 +10945,7 @@ In roc, functions are always written as a lambda, like{}
             "
         ),
     @r#"
-    ── UNUSED ARGUMENT ─────────────────────────────────────── /code/proj/Main.roc ─
+    ── UNUSED ARGUMENT in /code/proj/Main.roc ──────────────────────────────────────
 
     This function doesn't use `x`.
 
@@ -10977,7 +10977,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
         @r#"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     The branches of this `when` expression don't match the condition:
 
@@ -11010,7 +11010,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
         @r#"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     Something is off with the body of the `f` definition:
 
@@ -11047,7 +11047,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
         @r#"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     Something is off with the `then` branch of this `if` expression:
 
@@ -11079,7 +11079,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
     @r#"
-    ── UNUSED DEFINITION ───────────────────────────────────── /code/proj/Main.roc ─
+    ── UNUSED DEFINITION in /code/proj/Main.roc ────────────────────────────────────
 
     `foo` is not used in this `when` branch.
 
@@ -11105,7 +11105,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
     @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     This expression has a type that does not implement the abilities it's expected to:
 
@@ -11134,7 +11134,7 @@ In roc, functions are always written as a lambda, like{}
              "#
         ),
         @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     This expression has a type that does not implement the abilities it's expected to:
 
@@ -11200,7 +11200,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
     @r#"
-    ── UNSAFE PATTERN ──────────────────────────────────────── /code/proj/Main.roc ─
+    ── UNSAFE PATTERN in /code/proj/Main.roc ───────────────────────────────────────
 
     This `when` does not cover all the possibilities:
 
@@ -11228,7 +11228,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
     @r#"
-    ── UNSAFE PATTERN ──────────────────────────────────────── /code/proj/Main.roc ─
+    ── UNSAFE PATTERN in /code/proj/Main.roc ───────────────────────────────────────
 
     This `when` does not cover all the possibilities:
 
@@ -11255,7 +11255,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
     @r#"
-    ── UNMATCHABLE PATTERN ─────────────────────────────────── /code/proj/Main.roc ─
+    ── UNMATCHABLE PATTERN in /code/proj/Main.roc ──────────────────────────────────
 
     The 2nd pattern will never be matched:
 
@@ -11282,7 +11282,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
     @r#"
-    ── UNMATCHABLE PATTERN ─────────────────────────────────── /code/proj/Main.roc ─
+    ── UNMATCHABLE PATTERN in /code/proj/Main.roc ──────────────────────────────────
 
     The 2nd pattern will never be matched:
 
@@ -11294,7 +11294,7 @@ In roc, functions are always written as a lambda, like{}
     It's impossible to create a value of this shape, so this pattern can
     be safely removed!
 
-    ── UNMATCHABLE PATTERN ─────────────────────────────────── /code/proj/Main.roc ─
+    ── UNMATCHABLE PATTERN in /code/proj/Main.roc ──────────────────────────────────
 
     The 3rd pattern will never be matched:
 
@@ -11319,7 +11319,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
     @r"
-    ── DUPLICATE NAME ──────────────────────────────────────── /code/proj/Main.roc ─
+    ── DUPLICATE NAME in /code/proj/Main.roc ───────────────────────────────────────
 
     This opaque type has the same name as a builtin:
 
@@ -11341,7 +11341,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
     @r#"
-    ── UNUSED IMPORT ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── UNUSED IMPORT in /code/proj/Main.roc ────────────────────────────────────────
 
     `List.concat` is not used in this module.
 
@@ -11393,7 +11393,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
     @r"
-    ── CIRCULAR DEFINITION ─────────────────────────────────── /code/proj/Main.roc ─
+    ── CIRCULAR DEFINITION in /code/proj/Main.roc ──────────────────────────────────
 
     `main` is defined directly in terms of itself:
 
@@ -11415,7 +11415,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
     @r#"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     This `if` condition needs to be a Bool:
 
@@ -11441,7 +11441,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
     @r#"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     This `if` condition needs to be a Bool:
 
@@ -11469,7 +11469,7 @@ In roc, functions are always written as a lambda, like{}
              "#
         ),
         @r"
-    ── INCOMPLETE ABILITY IMPLEMENTATION ───────────────────── /code/proj/Main.roc ─
+    ── INCOMPLETE ABILITY IMPLEMENTATION in /code/proj/Main.roc ────────────────────
 
     I can't derive an implementation of the `Hash` ability for `A`:
 
@@ -11494,7 +11494,7 @@ In roc, functions are always written as a lambda, like{}
              "#
         ),
         @r"
-    ── INCOMPLETE ABILITY IMPLEMENTATION ───────────────────── /code/proj/Main.roc ─
+    ── INCOMPLETE ABILITY IMPLEMENTATION in /code/proj/Main.roc ────────────────────
 
     I can't derive an implementation of the `Hash` ability for `A`:
 
@@ -11577,7 +11577,7 @@ In roc, functions are always written as a lambda, like{}
              "#
         ),
         @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     This expression has a type that does not implement the abilities it's expected to:
 
@@ -11604,7 +11604,7 @@ In roc, functions are always written as a lambda, like{}
              "#
         ),
         @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     This expression has a type that does not implement the abilities it's expected to:
 
@@ -11650,7 +11650,7 @@ In roc, functions are always written as a lambda, like{}
              "#
         ),
         @r#"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     This expression has a type that does not implement the abilities it's expected to:
 
@@ -11686,7 +11686,7 @@ In roc, functions are always written as a lambda, like{}
             "
         ),
     @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     This 2nd argument to `shiftRightZfBy` has an unexpected type:
 
@@ -11701,7 +11701,7 @@ In roc, functions are always written as a lambda, like{}
 
         U8
 
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     This 2nd argument to `shiftRightBy` has an unexpected type:
 
@@ -11716,7 +11716,7 @@ In roc, functions are always written as a lambda, like{}
 
         U8
 
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     This 2nd argument to `shiftLeftBy` has an unexpected type:
 
@@ -11744,7 +11744,7 @@ In roc, functions are always written as a lambda, like{}
             "
         ),
     @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     This 2nd argument to `contains` has an unexpected type:
 
@@ -11771,7 +11771,7 @@ In roc, functions are always written as a lambda, like{}
              "#
         ),
         @r"
-    ── INCOMPLETE ABILITY IMPLEMENTATION ───────────────────── /code/proj/Main.roc ─
+    ── INCOMPLETE ABILITY IMPLEMENTATION in /code/proj/Main.roc ────────────────────
 
     I can't derive an implementation of the `Eq` ability for `A`:
 
@@ -11796,7 +11796,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
     @r#"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     The branches of this `when` expression don't match the condition:
 
@@ -11826,7 +11826,7 @@ In roc, functions are always written as a lambda, like{}
              "#
         ),
         @r"
-    ── INCOMPLETE ABILITY IMPLEMENTATION ───────────────────── /code/proj/Main.roc ─
+    ── INCOMPLETE ABILITY IMPLEMENTATION in /code/proj/Main.roc ────────────────────
 
     I can't derive an implementation of the `Eq` ability for `A`:
 
@@ -11852,7 +11852,7 @@ In roc, functions are always written as a lambda, like{}
              "#
         ),
         @r"
-    ── INCOMPLETE ABILITY IMPLEMENTATION ───────────────────── /code/proj/Main.roc ─
+    ── INCOMPLETE ABILITY IMPLEMENTATION in /code/proj/Main.roc ────────────────────
 
     I can't derive an implementation of the `Eq` ability for `A`:
 
@@ -11880,7 +11880,7 @@ In roc, functions are always written as a lambda, like{}
              "#
         ),
         @r"
-    ── INCOMPLETE ABILITY IMPLEMENTATION ───────────────────── /code/proj/Main.roc ─
+    ── INCOMPLETE ABILITY IMPLEMENTATION in /code/proj/Main.roc ────────────────────
 
     I can't derive an implementation of the `Eq` ability for `A`:
 
@@ -11963,7 +11963,7 @@ In roc, functions are always written as a lambda, like{}
              "#
         ),
         @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     This expression has a type that does not implement the abilities it's expected to:
 
@@ -11990,7 +11990,7 @@ In roc, functions are always written as a lambda, like{}
              "#
         ),
         @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     This expression has a type that does not implement the abilities it's expected to:
 
@@ -12019,7 +12019,7 @@ In roc, functions are always written as a lambda, like{}
             "
         ),
         @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     This expression has a type that does not implement the abilities it's expected to:
 
@@ -12042,7 +12042,7 @@ In roc, functions are always written as a lambda, like{}
             "
         ),
         @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     This expression has a type that does not implement the abilities it's expected to:
 
@@ -12082,7 +12082,7 @@ In roc, functions are always written as a lambda, like{}
              "#
         ),
         @r#"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     This expression has a type that does not implement the abilities it's expected to:
 
@@ -12120,7 +12120,7 @@ In roc, functions are always written as a lambda, like{}
             "
         ),
         @r"
-    ── NOT EXPOSED ─────────────────────────────────────────── /code/proj/Main.roc ─
+    ── NOT EXPOSED in /code/proj/Main.roc ──────────────────────────────────────────
 
     The Bool module does not expose `structuralEq`:
 
@@ -12134,7 +12134,7 @@ In roc, functions are always written as a lambda, like{}
         Bool.false
         Bool.isEq
 
-    ── NOT EXPOSED ─────────────────────────────────────────── /code/proj/Main.roc ─
+    ── NOT EXPOSED in /code/proj/Main.roc ──────────────────────────────────────────
 
     The Bool module does not expose `structuralNotEq`:
 
@@ -12162,7 +12162,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
     @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     This expression has a type that does not implement the abilities it's expected to:
 
@@ -12187,7 +12187,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
     @r#"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     The 1st argument to `foo` is weird:
 
@@ -12216,7 +12216,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
     @r"
-    ── INCOMPLETE ABILITY IMPLEMENTATION ───────────────────── /code/proj/Main.roc ─
+    ── INCOMPLETE ABILITY IMPLEMENTATION in /code/proj/Main.roc ────────────────────
 
     I can't derive an implementation of the `Hash` ability for `F`:
 
@@ -12227,7 +12227,7 @@ In roc, functions are always written as a lambda, like{}
 
     Tip: You can define a custom implementation of `Hash` for `F`.
 
-    ── INCOMPLETE ABILITY IMPLEMENTATION ───────────────────── /code/proj/Main.roc ─
+    ── INCOMPLETE ABILITY IMPLEMENTATION in /code/proj/Main.roc ────────────────────
 
     I can't derive an implementation of the `Eq` ability for `F`:
 
@@ -12238,7 +12238,7 @@ In roc, functions are always written as a lambda, like{}
 
     Tip: You can define a custom implementation of `Eq` for `F`.
 
-    ── INCOMPLETE ABILITY IMPLEMENTATION ───────────────────── /code/proj/Main.roc ─
+    ── INCOMPLETE ABILITY IMPLEMENTATION in /code/proj/Main.roc ────────────────────
 
     I can't derive an implementation of the `Encoding` ability for `F`:
 
@@ -12261,7 +12261,7 @@ In roc, functions are always written as a lambda, like{}
             "
         ),
     @r"
-    ── DUPLICATE BOUND ABILITY ─────────────────────────────── /code/proj/Main.roc ─
+    ── DUPLICATE BOUND ABILITY in /code/proj/Main.roc ──────────────────────────────
 
     I already saw that this type variable is bound to the `Hash` ability
     once before:
@@ -12287,7 +12287,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
     @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     This 1st argument to `g` has an unexpected type:
 
@@ -12324,7 +12324,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
     @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     This 1st argument to `g` has an unexpected type:
 
@@ -12362,7 +12362,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
     @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     This 1st argument to `g` has an unexpected type:
 
@@ -12395,7 +12395,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
     @r#"
-    ── UNFINISHED LIST PATTERN ────────── tmp/list_pattern_not_terminated/Test.roc ─
+    ── UNFINISHED LIST PATTERN in tmp/list_pattern_not_terminated/Test.roc ─────────
 
     I am partway through parsing a list pattern, but I got stuck here:
 
@@ -12416,7 +12416,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
     @r#"
-    ── INCORRECT REST PATTERN ─────── tmp/list_pattern_weird_rest_pattern/Test.roc ─
+    ── INCORRECT REST PATTERN in tmp/list_pattern_weird_rest_pattern/Test.roc ──────
 
     It looks like you may trying to write a list rest pattern, but it's
     not the form I expect:
@@ -12438,7 +12438,7 @@ In roc, functions are always written as a lambda, like{}
             "
         ),
     @r"
-    ── UNNECESSARY WILDCARD ────────────────────────────────── /code/proj/Main.roc ─
+    ── UNNECESSARY WILDCARD in /code/proj/Main.roc ─────────────────────────────────
 
     This type annotation has a wildcard type variable (`*`) that isn't
     needed.
@@ -12465,7 +12465,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
     @r#"
-    ── MULTIPLE LIST REST PATTERNS ─────────────────────────── /code/proj/Main.roc ─
+    ── MULTIPLE LIST REST PATTERNS in /code/proj/Main.roc ──────────────────────────
 
     This list pattern match has multiple rest patterns:
 
@@ -12475,7 +12475,7 @@ In roc, functions are always written as a lambda, like{}
     I only support compiling list patterns with one .. pattern! Can you
     remove this additional one?
 
-    ── UNSAFE PATTERN ──────────────────────────────────────── /code/proj/Main.roc ─
+    ── UNSAFE PATTERN in /code/proj/Main.roc ───────────────────────────────────────
 
     This `when` does not cover all the possibilities:
 
@@ -12499,7 +12499,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
     @r#"
-    ── MULTIPLE LIST REST PATTERNS ─────────────────────────── /code/proj/Main.roc ─
+    ── MULTIPLE LIST REST PATTERNS in /code/proj/Main.roc ──────────────────────────
 
     This list pattern match has multiple rest patterns:
 
@@ -12509,7 +12509,7 @@ In roc, functions are always written as a lambda, like{}
     I only support compiling list patterns with one .. pattern! Can you
     remove this additional one?
 
-    ── UNSAFE PATTERN ──────────────────────────────────────── /code/proj/Main.roc ─
+    ── UNSAFE PATTERN in /code/proj/Main.roc ───────────────────────────────────────
 
     This `when` does not cover all the possibilities:
 
@@ -12533,7 +12533,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
     @r#"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     This list element doesn't match the types of other elements in the
     pattern:
@@ -12560,7 +12560,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
     @r#"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     The branches of this `when` expression don't match the condition:
 
@@ -12593,7 +12593,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
     @r#"
-    ── UNSAFE PATTERN ──────────────────────────────────────── /code/proj/Main.roc ─
+    ── UNSAFE PATTERN in /code/proj/Main.roc ───────────────────────────────────────
 
     This `when` does not cover all the possibilities:
 
@@ -12633,7 +12633,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
     @r#"
-    ── UNSAFE PATTERN ──────────────────────────────────────── /code/proj/Main.roc ─
+    ── UNSAFE PATTERN in /code/proj/Main.roc ───────────────────────────────────────
 
     This `when` does not cover all the possibilities:
 
@@ -12677,7 +12677,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
     @r#"
-    ── REDUNDANT PATTERN ───────────────────────────────────── /code/proj/Main.roc ─
+    ── REDUNDANT PATTERN in /code/proj/Main.roc ────────────────────────────────────
     
     The 2nd pattern is redundant:
     
@@ -12743,7 +12743,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
     @r#"
-    ── UNSAFE PATTERN ──────────────────────────────────────── /code/proj/Main.roc ─
+    ── UNSAFE PATTERN in /code/proj/Main.roc ───────────────────────────────────────
 
     This `when` does not cover all the possibilities:
 
@@ -12770,7 +12770,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
     @r#"
-    ── UNSAFE PATTERN ──────────────────────────────────────── /code/proj/Main.roc ─
+    ── UNSAFE PATTERN in /code/proj/Main.roc ───────────────────────────────────────
 
     This `when` does not cover all the possibilities:
 
@@ -12813,7 +12813,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
     @r#"
-    ── UNSAFE PATTERN ──────────────────────────────────────── /code/proj/Main.roc ─
+    ── UNSAFE PATTERN in /code/proj/Main.roc ───────────────────────────────────────
 
     This `when` does not cover all the possibilities:
 
@@ -12840,7 +12840,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
     @r#"
-    ── UNSAFE PATTERN ──────────────────────────────────────── /code/proj/Main.roc ─
+    ── UNSAFE PATTERN in /code/proj/Main.roc ───────────────────────────────────────
 
     This `when` does not cover all the possibilities:
 
@@ -12889,7 +12889,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
     @r#"
-    ── UNSAFE PATTERN ──────────────────────────────────────── /code/proj/Main.roc ─
+    ── UNSAFE PATTERN in /code/proj/Main.roc ───────────────────────────────────────
 
     This `when` does not cover all the possibilities:
 
@@ -12920,7 +12920,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
     @r#"
-    ── UNSAFE PATTERN ──────────────────────────────────────── /code/proj/Main.roc ─
+    ── UNSAFE PATTERN in /code/proj/Main.roc ───────────────────────────────────────
 
     This `when` does not cover all the possibilities:
 
@@ -12952,7 +12952,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
     @r#"
-    ── UNSAFE PATTERN ──────────────────────────────────────── /code/proj/Main.roc ─
+    ── UNSAFE PATTERN in /code/proj/Main.roc ───────────────────────────────────────
 
     This `when` does not cover all the possibilities:
 
@@ -13001,7 +13001,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
     @r#"
-    ── UNSAFE PATTERN ──────────────────────────────────────── /code/proj/Main.roc ─
+    ── UNSAFE PATTERN in /code/proj/Main.roc ───────────────────────────────────────
 
     This `when` does not cover all the possibilities:
 
@@ -13035,7 +13035,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
     @r#"
-    ── REDUNDANT PATTERN ───────────────────────────────────── /code/proj/Main.roc ─
+    ── REDUNDANT PATTERN in /code/proj/Main.roc ────────────────────────────────────
 
     The 3rd pattern is redundant:
 
@@ -13063,7 +13063,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
     @r#"
-    ── REDUNDANT PATTERN ───────────────────────────────────── /code/proj/Main.roc ─
+    ── REDUNDANT PATTERN in /code/proj/Main.roc ────────────────────────────────────
 
     The 3rd pattern is redundant:
 
@@ -13091,7 +13091,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
     @r#"
-    ── REDUNDANT PATTERN ───────────────────────────────────── /code/proj/Main.roc ─
+    ── REDUNDANT PATTERN in /code/proj/Main.roc ────────────────────────────────────
 
     The 3rd pattern is redundant:
 
@@ -13119,7 +13119,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
     @r#"
-    ── REDUNDANT PATTERN ───────────────────────────────────── /code/proj/Main.roc ─
+    ── REDUNDANT PATTERN in /code/proj/Main.roc ────────────────────────────────────
 
     The 2nd pattern is redundant:
 
@@ -13158,7 +13158,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
     @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     This expression has a type that does not implement the abilities it's expected to:
 
@@ -13189,7 +13189,7 @@ In roc, functions are always written as a lambda, like{}
             "
         ),
     @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     This value passed to `crash` is not a string:
 
@@ -13214,7 +13214,7 @@ In roc, functions are always written as a lambda, like{}
             "
         ),
     @r"
-    ── UNAPPLIED CRASH ─────────────────────────────────────── /code/proj/Main.roc ─
+    ── UNAPPLIED CRASH in /code/proj/Main.roc ──────────────────────────────────────
 
     This `crash` doesn't have a message given to it:
 
@@ -13235,7 +13235,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
     @r#"
-    ── OVERAPPLIED CRASH ───────────────────────────────────── /code/proj/Main.roc ─
+    ── OVERAPPLIED CRASH in /code/proj/Main.roc ────────────────────────────────────
 
     This `crash` has too many values given to it:
 
@@ -13271,7 +13271,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
     @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     This expression has a type that does not implement the abilities it's expected to:
 
@@ -13313,7 +13313,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
     @r#"
-    ── DEFINITION ONLY USED IN RECURSION ───────────────────── /code/proj/Main.roc ─
+    ── DEFINITION ONLY USED IN RECURSION in /code/proj/Main.roc ────────────────────
 
     This definition is only used in recursion with itself:
 
@@ -13346,7 +13346,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
     @r#"
-    ── DEFINITIONs ONLY USED IN RECURSION ──────────────────── /code/proj/Main.roc ─
+    ── DEFINITIONs ONLY USED IN RECURSION in /code/proj/Main.roc ───────────────────
 
     These 2 definitions are only used in mutual recursion with themselves:
 
@@ -13382,7 +13382,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
     @r#"
-    ── DEFINITION ONLY USED IN RECURSION ───────────────────── /code/proj/Main.roc ─
+    ── DEFINITION ONLY USED IN RECURSION in /code/proj/Main.roc ────────────────────
 
     This definition is only used in recursion with itself:
 
@@ -13418,7 +13418,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
     @r#"
-    ── DEFINITIONs ONLY USED IN RECURSION ──────────────────── /code/proj/Main.roc ─
+    ── DEFINITIONs ONLY USED IN RECURSION in /code/proj/Main.roc ───────────────────
 
     These 2 definitions are only used in mutual recursion with themselves:
 
@@ -13457,7 +13457,7 @@ In roc, functions are always written as a lambda, like{}
             {one, str}
         "#),
     @r#"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     This 2nd argument to `concat` has an unexpected type:
 
@@ -13488,7 +13488,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
     @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     Something is off with the `else` branch of this `if` expression:
 
@@ -13525,7 +13525,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
     @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     Something is off with the `else` branch of this `if` expression:
 
@@ -13561,7 +13561,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
     @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     Something is off with the body of the `main` definition:
 
@@ -13599,7 +13599,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
     @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     Something is off with the body of the `main` definition:
 
@@ -13650,7 +13650,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
         @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     This expression has a type that does not implement the abilities it's expected to:
 
@@ -13679,7 +13679,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
         @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     This expression has a type that does not implement the abilities it's expected to:
 
@@ -13729,7 +13729,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
         @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     This expression has a type that does not implement the abilities it's expected to:
 
@@ -13769,7 +13769,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
         @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     This expression has a type that does not implement the abilities it's expected to:
 
@@ -13809,7 +13809,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
         @r#"
-    ── UNSAFE PATTERN ──────────────────────────────────────── /code/proj/Main.roc ─
+    ── UNSAFE PATTERN in /code/proj/Main.roc ───────────────────────────────────────
 
     This `when` does not cover all the possibilities:
 
@@ -13857,7 +13857,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
         @r#"
-    ── TOO MANY ARGS ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TOO MANY ARGS in /code/proj/Main.roc ────────────────────────────────────────
 
     The `parser` value is an opaque type, so it cannot be called with an
     argument:
@@ -13881,7 +13881,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
         @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     Something is off with the body of the `f` definition:
 
@@ -13912,7 +13912,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
         @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     Something is off with the body of the `f` definition:
 
@@ -13946,7 +13946,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
         @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     Something is off with the body of the `f` definition:
 
@@ -13980,7 +13980,7 @@ In roc, functions are always written as a lambda, like{}
             "#
         ),
         @r"
-    ── TYPE MISMATCH ───────────────────────────────────────── /code/proj/Main.roc ─
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     Something is off with the body of the `f` definition:
 
@@ -14008,7 +14008,7 @@ In roc, functions are always written as a lambda, like{}
             "
         ),
         @r"
-    ── TOO FEW ARGS ────────────────────────────────────────── /code/proj/Main.roc ─
+    ── TOO FEW ARGS in /code/proj/Main.roc ─────────────────────────────────────────
 
     The `sub` function expects 2 arguments, but it got only 1:
 
@@ -14028,7 +14028,7 @@ In roc, functions are always written as a lambda, like{}
             "
         ),
         @r"
-    ── TOO FEW ARGS ────────────────────────────────────────── /code/proj/Main.roc ─
+    ── TOO FEW ARGS in /code/proj/Main.roc ─────────────────────────────────────────
 
     The `sub` function expects 2 arguments, but it got only 1:
 

--- a/crates/compiler/load_internal/tests/test_load.rs
+++ b/crates/compiler/load_internal/tests/test_load.rs
@@ -641,7 +641,7 @@ fn parse_problem() {
             report,
             indoc!(
                 "
-                    ── UNFINISHED LIST ──────────────────────────────────── tmp/parse_problem/Main ─
+                    ── UNFINISHED LIST in tmp/parse_problem/Main ───────────────────────────────────
 
                     I am partway through started parsing a list, but I got stuck here:
 
@@ -847,7 +847,7 @@ fn opaque_wrapped_unwrapped_outside_defining_module() {
         err,
         indoc!(
             r"
-                ── OPAQUE TYPE DECLARED OUTSIDE SCOPE ─ ...rapped_outside_defining_module/Main ─
+                ── OPAQUE TYPE DECLARED OUTSIDE SCOPE in ...apped_outside_defining_module/Main ─
 
                 The unwrapped opaque type Age referenced here:
 
@@ -861,7 +861,7 @@ fn opaque_wrapped_unwrapped_outside_defining_module() {
 
                 Note: Opaque types can only be wrapped and unwrapped in the module they are defined in!
 
-                ── OPAQUE TYPE DECLARED OUTSIDE SCOPE ─ ...rapped_outside_defining_module/Main ─
+                ── OPAQUE TYPE DECLARED OUTSIDE SCOPE in ...apped_outside_defining_module/Main ─
 
                 The unwrapped opaque type Age referenced here:
 
@@ -875,7 +875,7 @@ fn opaque_wrapped_unwrapped_outside_defining_module() {
 
                 Note: Opaque types can only be wrapped and unwrapped in the module they are defined in!
 
-                ── UNUSED IMPORT ─── tmp/opaque_wrapped_unwrapped_outside_defining_module/Main ─
+                ── UNUSED IMPORT in tmp/opaque_wrapped_unwrapped_outside_defining_module/Main ──
 
                 Nothing from Age is used in this module.
 
@@ -930,7 +930,7 @@ fn issue_2863_module_type_does_not_exist() {
                 report,
                 indoc!(
                     "
-                        ── UNRECOGNIZED NAME ────────── tmp/issue_2863_module_type_does_not_exist/Main ─
+                        ── UNRECOGNIZED NAME in tmp/issue_2863_module_type_does_not_exist/Main ─────────
 
                         Nothing is named `DoesNotExist` in this scope.
 
@@ -1006,7 +1006,7 @@ fn module_doesnt_match_file_path() {
         err,
         indoc!(
             r"
-            ── WEIRD MODULE NAME ─────────────────── tmp/module_doesnt_match_file_path/Age ─
+            ── WEIRD MODULE NAME in tmp/module_doesnt_match_file_path/Age ──────────────────
 
             This module name does not correspond with the file path it is defined
             in:
@@ -1039,7 +1039,7 @@ fn module_cyclic_import_itself() {
         err,
         indoc!(
             r"
-            ── IMPORT CYCLE ────────────────────────── tmp/module_cyclic_import_itself/Age ─
+            ── IMPORT CYCLE in tmp/module_cyclic_import_itself/Age ─────────────────────────
 
             I can't compile Age because it depends on itself through the following
             chain of module imports:
@@ -1085,7 +1085,7 @@ fn module_cyclic_import_transitive() {
         err,
         indoc!(
             r"
-            ── IMPORT CYCLE ────────────────── tmp/module_cyclic_import_transitive/Age.roc ─
+            ── IMPORT CYCLE in tmp/module_cyclic_import_transitive/Age.roc ─────────────────
 
             I can't compile Age because it depends on itself through the following
             chain of module imports:
@@ -1133,7 +1133,7 @@ fn nested_module_has_incorrect_name() {
         err,
         indoc!(
             r"
-            ── INCORRECT MODULE NAME ──── tmp/nested_module_has_incorrect_name/Dep/Foo.roc ─
+            ── INCORRECT MODULE NAME in tmp/nested_module_has_incorrect_name/Dep/Foo.roc ───
 
             This module has a different name than I expected:
 

--- a/crates/reporting/src/report.rs
+++ b/crates/reporting/src/report.rs
@@ -82,9 +82,11 @@ pub fn pretty_header_with_path(title: &str, path: &Path) -> String {
     .to_str()
     .unwrap();
 
+    let additional_path_display = "in";
+    let additional_path_display_width = additional_path_display.len() + 1;
     let title_width = title.len() + 4;
-    let relative_path_width = relative_path.len() + 3;
-    let available_path_width = HEADER_WIDTH - title_width - 1;
+    let relative_path_width = relative_path.len() + 1;
+    let available_path_width = HEADER_WIDTH - title_width - additional_path_display_width - 1;
 
     // If path is too long to fit in 80 characters with everything else then truncate it
     let path_width = relative_path_width.min(available_path_width);
@@ -96,10 +98,11 @@ pub fn pretty_header_with_path(title: &str, path: &Path) -> String {
     };
 
     let header = format!(
-        "── {} {} {} ─",
+        "── {} {} {} {}",
         title,
-        "─".repeat(HEADER_WIDTH - (title_width + path_width)),
-        path
+        additional_path_display,
+        path,
+        "─".repeat(HEADER_WIDTH - (title_width + path_width + additional_path_display_width))
     );
 
     header


### PR DESCRIPTION
Closes #6378

- Changes the header formatting to comply with what's described in the issue.
- Makes all broken tests conform.
- Adds an additional test for the case where the file path gets truncated.