### PR TITLE
Compiler crash on unqualified import for unexposed value

### DIFF
--- a/crates/cli_testing_examples/algorithms/quicksort.roc
+++ b/crates/cli_testing_examples/algorithms/quicksort.roc
@@ -8,7 +8,7 @@ quicksort = \originalList ->
 
     quicksortHelp originalList 0 (n - 1)
 
-quicksortHelp : List (Num a), Nat, Nat -> List (Num a)
+quicksortHelp : List (Num a), U64, U64 -> List (Num a)
 quicksortHelp = \list, low, high ->
     if low < high then
         when partition low high list is
@@ -19,7 +19,7 @@ quicksortHelp = \list, low, high ->
     else
         list
 
-partition : Nat, Nat, List (Num a) -> [Pair Nat (List (Num a))]
+partition : U64, U64, List (Num a) -> [Pair U64 (List (Num a))]
 partition = \low, high, initialList ->
     when List.get initialList high is
         Ok pivot ->
@@ -30,7 +30,7 @@ partition = \low, high, initialList ->
         Err _ ->
             Pair low initialList
 
-partitionHelp : Nat, Nat, List (Num c), Nat, Num c -> [Pair Nat (List (Num c))]
+partitionHelp : U64, U64, List (Num c), U64, Num c -> [Pair U64 (List (Num c))]
 partitionHelp = \i, j, list, high, pivot ->
     if j < high then
         when List.get list j is
@@ -45,7 +45,7 @@ partitionHelp = \i, j, list, high, pivot ->
     else
         Pair i list
 
-swap : Nat, Nat, List a -> List a
+swap : U64, U64, List a -> List a
 swap = \i, j, list ->
     when Pair (List.get list i) (List.get list j) is
         Pair (Ok atI) (Ok atJ) ->

--- a/crates/cli_testing_examples/benchmarks/Base64/Decode.roc
+++ b/crates/cli_testing_examples/benchmarks/Base64/Decode.roc
@@ -4,10 +4,10 @@ fromBytes : List U8 -> Result Str DecodeProblem
 fromBytes = \bytes ->
     Bytes.Decode.decode bytes (decodeBase64 (List.len bytes))
 
-decodeBase64 : Nat -> ByteDecoder Str
+decodeBase64 : U64 -> ByteDecoder Str
 decodeBase64 = \width -> Bytes.Decode.loop loopHelp { remaining: width, string: "" }
 
-loopHelp : { remaining : Nat, string : Str } -> ByteDecoder (Bytes.Decode.Step { remaining : Nat, string : Str } Str)
+loopHelp : { remaining : U64, string : Str } -> ByteDecoder (Bytes.Decode.Step { remaining : U64, string : Str } Str)
 loopHelp = \{ remaining, string } ->
     if remaining >= 3 then
         x, y, z <- Bytes.Decode.map3 Bytes.Decode.u8 Bytes.Decode.u8 Bytes.Decode.u8

--- a/crates/cli_testing_examples/benchmarks/Base64/Encode.roc
+++ b/crates/cli_testing_examples/benchmarks/Base64/Encode.roc
@@ -18,7 +18,7 @@ encodeChunks = \bytes ->
     List.walk bytes { output: [], accum: None } folder
     |> encodeResidual
 
-coerce : Nat, a -> a
+coerce : U64, a -> a
 coerce = \_, x -> x
 
 # folder : { output : List ByteEncoder, accum : State }, U8 -> { output : List ByteEncoder, accum : State }

--- a/crates/cli_testing_examples/benchmarks/Bytes/Decode.roc
+++ b/crates/cli_testing_examples/benchmarks/Bytes/Decode.roc
@@ -1,6 +1,6 @@
 interface Bytes.Decode exposes [ByteDecoder, decode, map, map2, u8, loop, Step, succeed, DecodeProblem, after, map3] imports []
 
-State : { bytes : List U8, cursor : Nat }
+State : { bytes : List U8, cursor : U64 }
 
 DecodeProblem : [OutOfBytes]
 

--- a/crates/cli_testing_examples/benchmarks/Bytes/Encode.roc
+++ b/crates/cli_testing_examples/benchmarks/Bytes/Encode.roc
@@ -2,7 +2,7 @@ interface Bytes.Encode exposes [ByteEncoder, sequence, u8, u16, bytes, empty, en
 
 Endianness : [BE, LE]
 
-ByteEncoder : [Signed8 I8, Unsigned8 U8, Signed16 Endianness I16, Unsigned16 Endianness U16, Sequence Nat (List ByteEncoder), Bytes (List U8)]
+ByteEncoder : [Signed8 I8, Unsigned8 U8, Signed16 Endianness I16, Unsigned16 Endianness U16, Sequence U64 (List ByteEncoder), Bytes (List U8)]
 
 u8 : U8 -> ByteEncoder
 u8 = \value -> Unsigned8 value
@@ -24,7 +24,7 @@ sequence : List ByteEncoder -> ByteEncoder
 sequence = \encoders ->
     Sequence (getWidths encoders 0) encoders
 
-getWidth : ByteEncoder -> Nat
+getWidth : ByteEncoder -> U64
 getWidth = \encoder ->
     when encoder is
         Signed8 _ -> 1
@@ -40,7 +40,7 @@ getWidth = \encoder ->
         Sequence w _ -> w
         Bytes bs -> List.len bs
 
-getWidths : List ByteEncoder, Nat -> Nat
+getWidths : List ByteEncoder, U64 -> U64
 getWidths = \encoders, initial ->
     List.walk encoders initial \accum, encoder -> accum + getWidth encoder
 
@@ -51,7 +51,7 @@ encode = \encoder ->
     encodeHelp encoder 0 output
     |> .output
 
-encodeHelp : ByteEncoder, Nat, List U8 -> { output : List U8, offset : Nat }
+encodeHelp : ByteEncoder, U64, List U8 -> { output : List U8, offset : U64 }
 encodeHelp = \encoder, offset, output ->
     when encoder is
         Unsigned8 value ->

--- a/crates/cli_testing_examples/benchmarks/Quicksort.roc
+++ b/crates/cli_testing_examples/benchmarks/Quicksort.roc
@@ -24,7 +24,7 @@ sortWith = \list, order ->
 
     quicksortHelp list order 0 (n - 1)
 
-quicksortHelp : List a, Order a, Nat, Nat -> List a
+quicksortHelp : List a, Order a, U64, U64 -> List a
 quicksortHelp = \list, order, low, high ->
     if low < high then
         when partition low high list order is
@@ -35,7 +35,7 @@ quicksortHelp = \list, order, low, high ->
     else
         list
 
-partition : Nat, Nat, List a, Order a -> [Pair Nat (List a)]
+partition : U64, U64, List a, Order a -> [Pair U64 (List a)]
 partition = \low, high, initialList, order ->
     when List.get initialList high is
         Ok pivot ->
@@ -46,7 +46,7 @@ partition = \low, high, initialList, order ->
         Err _ ->
             Pair low initialList
 
-partitionHelp : Nat, Nat, List c, Order c, Nat, c -> [Pair Nat (List c)]
+partitionHelp : U64, U64, List c, Order c, U64, c -> [Pair U64 (List c)]
 partitionHelp = \i, j, list, order, high, pivot ->
     if j < high then
         when List.get list j is
@@ -63,7 +63,7 @@ partitionHelp = \i, j, list, order, high, pivot ->
     else
         Pair i list
 
-swap : Nat, Nat, List a -> List a
+swap : U64, U64, List a -> List a
 swap = \i, j, list ->
     when Pair (List.get list i) (List.get list j) is
         Pair (Ok atI) (Ok atJ) ->

--- a/crates/compiler/builtins/README.md
+++ b/crates/compiler/builtins/README.md
@@ -6,7 +6,7 @@ Builtins are the functions and modules that are implicitly imported into every m
 
 Edit the appropriate `roc/*.roc` file with your new implementation. All normal rules for writing Roc code apply. Be sure to add a declaration, definition, some documentation and add it to the exposes list it in the module head.
 
-Next, look towards the bottom of the  `compiler/module/src/symbol.rs` file. Inside the `define_builtins!` macro, there is a list for each of the builtin modules and the function or value names it contains. Add a new entry to the appropriate list for your new function.
+Next, look towards the bottom of the `compiler/module/src/symbol.rs` file. Inside the `define_builtins!` macro, there is a list for each of the builtin modules and the function or value names it contains. Add a new entry to the appropriate list for your new function.
 
 For each of the builtin modules, there is a file in `compiler/test_gen/src/` like `gen_num.rs`, `gen_str.rs` etc. Add new tests for the module you are changing to the appropriate file here. You can look at the existing test cases for examples and inspiration.
 
@@ -22,14 +22,14 @@ Some of these have `#` inside their name (`first#list`, `#lt` ..). This is a tri
 
 But we can use these values and some of these are necessary for implementing builtins. For example, `List.get` returns tags, and it is not easy for us to create tags when composing LLVM. What is easier however, is:
 
-- ..writing `List.#getUnsafe` that has the dangerous signature of `List elem, Nat -> elem` in LLVM
-- ..writing `List elem, Nat -> Result elem [OutOfBounds]*` in a type safe way that uses `getUnsafe` internally, only after it checks if the `elem` at `Nat` index exists.
+-   ..writing `List.#getUnsafe` that has the dangerous signature of `List elem, U64 -> elem` in LLVM
+-   ..writing `List elem, U64 -> Result elem [OutOfBounds]*` in a type safe way that uses `getUnsafe` internally, only after it checks if the `elem` at `U64` index exists.
 
 ### can/src/builtins.rs
 
-Right at the top of this module is a function called `builtin_defs`. All this is doing is mapping the `Symbol` defined in `module/src/symbol.rs` to its implementation. Some of the builtins are quite complex, such as `list_get`. What makes `list_get` is that it returns tags, and in order to return tags it first has to  defer to lower-level functions via an if statement.
+Right at the top of this module is a function called `builtin_defs`. All this is doing is mapping the `Symbol` defined in `module/src/symbol.rs` to its implementation. Some of the builtins are quite complex, such as `list_get`. What makes `list_get` is that it returns tags, and in order to return tags it first has to defer to lower-level functions via an if statement.
 
-Lets look at `List.repeat : elem, Nat -> List elem`, which is more straight-forward, and points directly to its lower level implementation:
+Lets look at `List.repeat : elem, U64 -> List elem`, which is more straightforward, and points directly to its lower level implementation:
 
 ```rust
 fn list_repeat(symbol: Symbol, var_store: &mut VarStore) -> Def {
@@ -106,7 +106,7 @@ fn atan() {
 
 But replace `Num.atan` and the type signature with the new builtin.
 
-### test_gen/test/*.rs
+### test_gen/test/\*.rs
 
 In this directory, there are a couple files like `gen_num.rs`, `gen_str.rs`, etc. For the `Str` module builtins, put the test in `gen_str.rs`, etc. Find the one for the new builtin, and add a test like:
 
@@ -123,5 +123,5 @@ But replace `Num.atan`, the return value, and the return type with your new buil
 
 When implementing a new builtin, it is often easy to copy and paste the implementation for an existing builtin. This can take you quite far since many builtins are very similar, but it also risks forgetting to change one small part of what you copy and pasted and losing a lot of time later on when you cant figure out why things don't work. So, speaking from experience, even if you are copying an existing builtin, try and implement it manually without copying and pasting. Two recent instances of this (as of September 7th, 2020):
 
-- `List.keepIf` did not work for a long time because in builtins its `LowLevel` was `ListMap`. This was because I copy and pasted the `List.map` implementation in `builtins.rs
-- `List.walkBackwards` had mysterious memory bugs for a little while because in `unique.rs` its return type was `list_type(flex(b))` instead of `flex(b)` since it was copy and pasted from `List.keepIf`.
+-   `List.keepIf` did not work for a long time because in builtins its `LowLevel` was `ListMap`. This was because I copy and pasted the `List.map` implementation in `builtins.rs
+-   `List.walkBackwards` had mysterious memory bugs for a little while because in `unique.rs` its return type was `list_type(flex(b))` instead of `flex(b)` since it was copy and pasted from `List.keepIf`.

--- a/crates/compiler/builtins/bitcode/src/str.zig
+++ b/crates/compiler/builtins/bitcode/src/str.zig
@@ -1134,8 +1134,8 @@ test "countSegments: overlapping delimiter 2" {
     try expectEqual(segments_count, 3);
 }
 
-pub fn countUtf8Bytes(string: RocStr) callconv(.C) usize {
-    return string.len();
+pub fn countUtf8Bytes(string: RocStr) callconv(.C) u64 {
+    return @intCast(string.len());
 }
 
 pub fn isEmpty(string: RocStr) callconv(.C) bool {
@@ -1146,7 +1146,10 @@ pub fn getCapacity(string: RocStr) callconv(.C) usize {
     return string.getCapacity();
 }
 
-pub fn substringUnsafe(string: RocStr, start: usize, length: usize) callconv(.C) RocStr {
+pub fn substringUnsafe(string: RocStr, start_u64: u64, length_u64: u64) callconv(.C) RocStr {
+    const start: usize = @intCast(start_u64);
+    const length: usize = @intCast(length_u64);
+
     if (string.isSmallStr()) {
         if (start == 0) {
             var output = string;
@@ -1178,8 +1181,8 @@ pub fn substringUnsafe(string: RocStr, start: usize, length: usize) callconv(.C)
     return RocStr.empty();
 }
 
-pub fn getUnsafe(string: RocStr, index: usize) callconv(.C) u8 {
-    return string.getUnchecked(index);
+pub fn getUnsafe(string: RocStr, index: u64) callconv(.C) u8 {
+    return string.getUnchecked(@intCast(index));
 }
 
 test "substringUnsafe: start" {
@@ -1242,7 +1245,8 @@ pub fn startsWith(string: RocStr, prefix: RocStr) callconv(.C) bool {
 }
 
 // Str.repeat
-pub fn repeat(string: RocStr, count: usize) callconv(.C) RocStr {
+pub fn repeat(string: RocStr, count_u64: u64) callconv(.C) RocStr {
+    const count: usize = @intCast(count_u64);
     const bytes_len = string.len();
     const bytes_ptr = string.asU8ptr();
 
@@ -1497,7 +1501,7 @@ inline fn strToBytes(arg: RocStr) RocList {
 }
 
 const FromUtf8Result = extern struct {
-    byte_index: usize,
+    byte_index: u64,
     string: RocStr,
     is_ok: bool,
     problem_code: Utf8ByteProblem,
@@ -1510,14 +1514,17 @@ const CountAndStart = extern struct {
 
 pub fn fromUtf8RangeC(
     list: RocList,
-    start: usize,
-    count: usize,
+    start: u64,
+    count: u64,
     update_mode: UpdateMode,
 ) callconv(.C) FromUtf8Result {
     return fromUtf8Range(list, start, count, update_mode);
 }
 
-pub fn fromUtf8Range(arg: RocList, start: usize, count: usize, update_mode: UpdateMode) FromUtf8Result {
+pub fn fromUtf8Range(arg: RocList, start_u64: u64, count_u64: u64, update_mode: UpdateMode) FromUtf8Result {
+    const start: usize = @intCast(start_u64);
+    const count: usize = @intCast(count_u64);
+
     if (arg.len() == 0 or count == 0) {
         arg.decref(RocStr.alignment);
         return FromUtf8Result{
@@ -1547,7 +1554,7 @@ pub fn fromUtf8Range(arg: RocList, start: usize, count: usize, update_mode: Upda
         return FromUtf8Result{
             .is_ok = false,
             .string = RocStr.empty(),
-            .byte_index = temp.index,
+            .byte_index = @intCast(temp.index),
             .problem_code = temp.problem,
         };
     }
@@ -1674,7 +1681,7 @@ fn sliceHelp(bytes: [*]const u8, length: usize) RocList {
 }
 
 fn toErrUtf8ByteResponse(index: usize, problem: Utf8ByteProblem) FromUtf8Result {
-    return FromUtf8Result{ .is_ok = false, .string = RocStr.empty(), .byte_index = index, .problem_code = problem };
+    return FromUtf8Result{ .is_ok = false, .string = RocStr.empty(), .byte_index = @as(index, @intCast(u64)), .problem_code = problem };
 }
 
 // NOTE on memory: the validate function consumes a RC token of the input. Since
@@ -2367,8 +2374,10 @@ test "capacity: big string" {
     try expect(data.getCapacity() >= data_bytes.len);
 }
 
-pub fn reserve(string: RocStr, spare: usize) callconv(.C) RocStr {
+pub fn reserve(string: RocStr, spare_u64: u64) callconv(.C) RocStr {
     const old_length = string.len();
+    const spare: usize = @intCast(spare_u64);
+
     if (string.getCapacity() >= old_length + spare) {
         return string;
     } else {
@@ -2378,8 +2387,8 @@ pub fn reserve(string: RocStr, spare: usize) callconv(.C) RocStr {
     }
 }
 
-pub fn withCapacity(capacity: usize) callconv(.C) RocStr {
-    var str = RocStr.allocate(capacity);
+pub fn withCapacity(capacity: u64) callconv(.C) RocStr {
+    var str = RocStr.allocate(@intCast(capacity));
     str.setLen(0);
     return str;
 }

--- a/crates/compiler/builtins/roc/Dict.roc
+++ b/crates/compiler/builtins/roc/Dict.roc
@@ -34,7 +34,7 @@ interface Dict
         Result.{ Result },
         List,
         Str,
-        Num.{ Nat, U64, F32, U32, U8, I8 },
+        Num.{ U64, F32, U32, U8, I8 },
         Hash.{ Hasher, Hash },
         Inspect.{ Inspect, Inspector, InspectFormatter },
     ]
@@ -151,26 +151,25 @@ empty = \{} ->
 ## Return a dictionary with space allocated for a number of entries. This
 ## may provide a performance optimization if you know how many entries will be
 ## inserted.
-withCapacity : Nat -> Dict * *
+withCapacity : U64 -> Dict * *
 withCapacity = \requested ->
     empty {}
     |> reserve requested
 
 ## Enlarge the dictionary for at least capacity additional elements
-reserve : Dict k v, Nat -> Dict k v
+reserve : Dict k v, U64 -> Dict k v
 reserve = \@Dict { buckets, data, maxBucketCapacity: originalMaxBucketCapacity, maxLoadFactor, shifts }, requested ->
     currentSize = List.len data
-    requestedSize = currentSize + requested
-    size = Num.min (Num.toU64 requestedSize) maxSize
+    requestedSize = Num.addWrap currentSize requested
+    size = Num.min requestedSize maxSize
 
     requestedShifts = calcShiftsForSize size maxLoadFactor
     if (List.isEmpty buckets) || requestedShifts > shifts then
         (buckets0, maxBucketCapacity) = allocBucketsFromShift requestedShifts maxLoadFactor
         buckets1 = fillBucketsFromData buckets0 data requestedShifts
-        sizeNat = Num.toNat size
         @Dict {
             buckets: buckets1,
-            data: List.reserve data (Num.subSaturated sizeNat currentSize),
+            data: List.reserve data (Num.subSaturated size currentSize),
             maxBucketCapacity,
             maxLoadFactor,
             shifts: requestedShifts,
@@ -186,7 +185,7 @@ releaseExcessCapacity = \@Dict { buckets, data, maxBucketCapacity: originalMaxBu
     size = List.len data
 
     # NOTE: If we want, we technically could increase the load factor here to potentially minimize size more.
-    minShifts = calcShiftsForSize (Num.toU64 size) maxLoadFactor
+    minShifts = calcShiftsForSize size maxLoadFactor
     if minShifts < shifts then
         (buckets0, maxBucketCapacity) = allocBucketsFromShift minShifts maxLoadFactor
         buckets1 = fillBucketsFromData buckets0 data minShifts
@@ -208,9 +207,9 @@ releaseExcessCapacity = \@Dict { buckets, data, maxBucketCapacity: originalMaxBu
 ##
 ## capacityOfDict = Dict.capacity foodDict
 ## ```
-capacity : Dict * * -> Nat
+capacity : Dict * * -> U64
 capacity = \@Dict { maxBucketCapacity } ->
-    Num.toNat maxBucketCapacity
+    maxBucketCapacity
 
 ## Returns a dictionary containing the key and value provided as input.
 ## ```
@@ -251,7 +250,7 @@ fromList = \data ->
 ##     |> Dict.len
 ##     |> Bool.isEq 3
 ## ```
-len : Dict * * -> Nat
+len : Dict * * -> U64
 len = \@Dict { data } ->
     List.len data
 
@@ -372,14 +371,14 @@ keepIf : Dict k v, ((k, v) -> Bool) -> Dict k v
 keepIf = \dict, predicate ->
     keepIfHelp dict predicate 0 (Dict.len dict)
 
-keepIfHelp : Dict k v, ((k, v) -> Bool), Nat, Nat -> Dict k v
+keepIfHelp : Dict k v, ((k, v) -> Bool), U64, U64 -> Dict k v
 keepIfHelp = \@Dict dict, predicate, index, length ->
     if index < length then
         (key, value) = listGetUnsafe dict.data index
         if predicate (key, value) then
-            keepIfHelp (@Dict dict) predicate (index + 1) length
+            keepIfHelp (@Dict dict) predicate (index |> Num.addWrap 1) length
         else
-            keepIfHelp (Dict.remove (@Dict dict) key) predicate index (length - 1)
+            keepIfHelp (Dict.remove (@Dict dict) key) predicate index (length |> Num.subWrap 1)
     else
         @Dict dict
 
@@ -450,13 +449,13 @@ insert = \dict, key, value ->
 
     insertHelper buckets data bucketIndex distAndFingerprint key value maxBucketCapacity maxLoadFactor shifts
 
-insertHelper : List Bucket, List (k, v), Nat, U32, k, v, U64, F32, U8 -> Dict k v
+insertHelper : List Bucket, List (k, v), U64, U32, k, v, U64, F32, U8 -> Dict k v
 insertHelper = \buckets0, data0, bucketIndex0, distAndFingerprint0, key, value, maxBucketCapacity, maxLoadFactor, shifts ->
-    loaded = listGetUnsafe buckets0 (Num.toNat bucketIndex0)
+    loaded = listGetUnsafe buckets0 bucketIndex0
     if distAndFingerprint0 == loaded.distAndFingerprint then
-        (foundKey, _) = listGetUnsafe data0 (Num.toNat loaded.dataIndex)
+        (foundKey, _) = listGetUnsafe data0 (Num.toU64 loaded.dataIndex)
         if foundKey == key then
-            data1 = List.set data0 (Num.toNat loaded.dataIndex) (key, value)
+            data1 = List.set data0 (Num.toU64 loaded.dataIndex) (key, value)
             @Dict { buckets: buckets0, data: data1, maxBucketCapacity, maxLoadFactor, shifts }
         else
             bucketIndex1 = nextBucketIndex bucketIndex0 (List.len buckets0)
@@ -464,7 +463,7 @@ insertHelper = \buckets0, data0, bucketIndex0, distAndFingerprint0, key, value, 
             insertHelper buckets0 data0 bucketIndex1 distAndFingerprint1 key value maxBucketCapacity maxLoadFactor shifts
     else if distAndFingerprint0 > loaded.distAndFingerprint then
         data1 = List.append data0 (key, value)
-        dataIndex = (List.len data1) - 1
+        dataIndex = (List.len data1) |> Num.subWrap 1
         buckets1 = placeAndShiftUp buckets0 { distAndFingerprint: distAndFingerprint0, dataIndex: Num.toU32 dataIndex } bucketIndex0
         @Dict { buckets: buckets1, data: data1, maxBucketCapacity, maxLoadFactor, shifts }
     else
@@ -487,7 +486,7 @@ remove = \@Dict { buckets, data, maxBucketCapacity, maxLoadFactor, shifts }, key
         (bucketIndex0, distAndFingerprint0) = nextWhileLess buckets key shifts
         (bucketIndex1, distAndFingerprint1) = removeHelper buckets bucketIndex0 distAndFingerprint0 data key
 
-        bucket = listGetUnsafe buckets (Num.toNat bucketIndex1)
+        bucket = listGetUnsafe buckets bucketIndex1
         if distAndFingerprint1 != bucket.distAndFingerprint then
             @Dict { buckets, data, maxBucketCapacity, maxLoadFactor, shifts }
         else
@@ -495,10 +494,11 @@ remove = \@Dict { buckets, data, maxBucketCapacity, maxLoadFactor, shifts }, key
     else
         @Dict { buckets, data, maxBucketCapacity, maxLoadFactor, shifts }
 
+removeHelper : List Bucket, U64, U32, List (k, *), k -> (U64, U32) where k implements Eq
 removeHelper = \buckets, bucketIndex, distAndFingerprint, data, key ->
-    bucket = listGetUnsafe buckets (Num.toNat bucketIndex)
+    bucket = listGetUnsafe buckets bucketIndex
     if distAndFingerprint == bucket.distAndFingerprint then
-        (foundKey, _) = listGetUnsafe data (Num.toNat bucket.dataIndex)
+        (foundKey, _) = listGetUnsafe data (Num.toU64 bucket.dataIndex)
         if foundKey == key then
             (bucketIndex, distAndFingerprint)
         else
@@ -529,7 +529,7 @@ update = \@Dict { buckets, data, maxBucketCapacity, maxLoadFactor, shifts }, key
             when alter (Present value) is
                 Present newValue ->
                     bucket = listGetUnsafe buckets bucketIndex
-                    newData = List.set data (Num.toNat bucket.dataIndex) (key, newValue)
+                    newData = List.set data (Num.toU64 bucket.dataIndex) (key, newValue)
                     @Dict { buckets, data: newData, maxBucketCapacity, maxLoadFactor, shifts }
 
                 Missing ->
@@ -538,7 +538,7 @@ update = \@Dict { buckets, data, maxBucketCapacity, maxLoadFactor, shifts }, key
         Err KeyNotFound ->
             when alter Missing is
                 Present newValue ->
-                    if List.len data >= (Num.toNat maxBucketCapacity) then
+                    if List.len data >= maxBucketCapacity then
                         # Need to reallocate let regular insert handle that.
                         insert (@Dict { buckets, data, maxBucketCapacity, maxLoadFactor, shifts }) key newValue
                     else
@@ -721,20 +721,20 @@ emptyBucket = { distAndFingerprint: 0, dataIndex: 0 }
 distInc = Num.shiftLeftBy 1u32 8 # skip 1 byte fingerprint
 fingerprintMask = Num.subWrap distInc 1 # mask for 1 byte of fingerprint
 defaultMaxLoadFactor = 0.8
-initialShifts = 64 - 3 # 2^(64-shifts) number of buckets
+initialShifts = 64 |> Num.subWrap 3 # 2^(64-shifts) number of buckets
 maxSize = Num.shiftLeftBy 1u64 32
 maxBucketCount = maxSize
 
 incrementDist = \distAndFingerprint ->
-    distAndFingerprint + distInc
+    Num.addWrap distAndFingerprint distInc
 
 incrementDistN = \distAndFingerprint, n ->
-    distAndFingerprint + (n * distInc)
+    Num.addWrap distAndFingerprint (Num.mulWrap n distInc)
 
 decrementDist = \distAndFingerprint ->
-    distAndFingerprint - distInc
+    distAndFingerprint |> Num.subWrap distInc
 
-find : Dict k v, k -> { bucketIndex : Nat, result : Result v [KeyNotFound] }
+find : Dict k v, k -> { bucketIndex : U64, result : Result v [KeyNotFound] }
 find = \@Dict { buckets, data, shifts }, key ->
     hash = hashKey key
     distAndFingerprint = distAndFingerprintFromHash hash
@@ -749,13 +749,13 @@ find = \@Dict { buckets, data, shifts }, key ->
 
 findManualUnrolls = 2
 
-findFirstUnroll : List Bucket, Nat, U32, List (k, v), k -> { bucketIndex : Nat, result : Result v [KeyNotFound] } where k implements Eq
+findFirstUnroll : List Bucket, U64, U32, List (k, v), k -> { bucketIndex : U64, result : Result v [KeyNotFound] } where k implements Eq
 findFirstUnroll = \buckets, bucketIndex, distAndFingerprint, data, key ->
     # TODO: once we have short circuit evaluation, use it here and other similar locations in this file.
     # Avoid the nested if with else block inconvenience.
     bucket = listGetUnsafe buckets bucketIndex
     if distAndFingerprint == bucket.distAndFingerprint then
-        (foundKey, value) = listGetUnsafe data (Num.toNat bucket.dataIndex)
+        (foundKey, value) = listGetUnsafe data (Num.toU64 bucket.dataIndex)
         if foundKey == key then
             { bucketIndex, result: Ok value }
         else
@@ -763,11 +763,11 @@ findFirstUnroll = \buckets, bucketIndex, distAndFingerprint, data, key ->
     else
         findSecondUnroll buckets (nextBucketIndex bucketIndex (List.len buckets)) (incrementDist distAndFingerprint) data key
 
-findSecondUnroll : List Bucket, Nat, U32, List (k, v), k -> { bucketIndex : Nat, result : Result v [KeyNotFound] } where k implements Eq
+findSecondUnroll : List Bucket, U64, U32, List (k, v), k -> { bucketIndex : U64, result : Result v [KeyNotFound] } where k implements Eq
 findSecondUnroll = \buckets, bucketIndex, distAndFingerprint, data, key ->
     bucket = listGetUnsafe buckets bucketIndex
     if distAndFingerprint == bucket.distAndFingerprint then
-        (foundKey, value) = listGetUnsafe data (Num.toNat bucket.dataIndex)
+        (foundKey, value) = listGetUnsafe data (Num.toU64 bucket.dataIndex)
         if foundKey == key then
             { bucketIndex, result: Ok value }
         else
@@ -775,11 +775,11 @@ findSecondUnroll = \buckets, bucketIndex, distAndFingerprint, data, key ->
     else
         findHelper buckets (nextBucketIndex bucketIndex (List.len buckets)) (incrementDist distAndFingerprint) data key
 
-findHelper : List Bucket, Nat, U32, List (k, v), k -> { bucketIndex : Nat, result : Result v [KeyNotFound] } where k implements Eq
+findHelper : List Bucket, U64, U32, List (k, v), k -> { bucketIndex : U64, result : Result v [KeyNotFound] } where k implements Eq
 findHelper = \buckets, bucketIndex, distAndFingerprint, data, key ->
     bucket = listGetUnsafe buckets bucketIndex
     if distAndFingerprint == bucket.distAndFingerprint then
-        (foundKey, value) = listGetUnsafe data (Num.toNat bucket.dataIndex)
+        (foundKey, value) = listGetUnsafe data (Num.toU64 bucket.dataIndex)
         if foundKey == key then
             { bucketIndex, result: Ok value }
         else
@@ -789,18 +789,19 @@ findHelper = \buckets, bucketIndex, distAndFingerprint, data, key ->
     else
         findHelper buckets (nextBucketIndex bucketIndex (List.len buckets)) (incrementDist distAndFingerprint) data key
 
-removeBucket : Dict k v, Nat -> Dict k v
+removeBucket : Dict k v, U64 -> Dict k v
 removeBucket = \@Dict { buckets: buckets0, data: data0, maxBucketCapacity, maxLoadFactor, shifts }, bucketIndex0 ->
-    { dataIndex: dataIndexToRemove } = listGetUnsafe buckets0 bucketIndex0
+    dataIndexToRemove = (listGetUnsafe buckets0 bucketIndex0).dataIndex
+    dataIndexToRemoveU64 = Num.toU64 dataIndexToRemove
 
     (buckets1, bucketIndex1) = removeBucketHelper buckets0 bucketIndex0
     buckets2 = List.set buckets1 bucketIndex1 emptyBucket
 
-    lastDataIndex = List.len data0 - 1
-    if (Num.toNat dataIndexToRemove) != lastDataIndex then
+    lastDataIndex = List.len data0 |> Num.subWrap 1
+    if dataIndexToRemoveU64 != lastDataIndex then
         # Swap removed item to the end
-        data1 = List.swap data0 (Num.toNat dataIndexToRemove) lastDataIndex
-        (key, _) = listGetUnsafe data1 (Num.toNat dataIndexToRemove)
+        data1 = List.swap data0 dataIndexToRemoveU64 lastDataIndex
+        (key, _) = listGetUnsafe data1 dataIndexToRemoveU64
 
         # Update the data index of the new value.
         hash = hashKey key
@@ -824,7 +825,7 @@ removeBucket = \@Dict { buckets: buckets0, data: data0, maxBucketCapacity, maxLo
             shifts,
         }
 
-scanForIndex : List Bucket, Nat, U32 -> Nat
+scanForIndex : List Bucket, U64, U32 -> U64
 scanForIndex = \buckets, bucketIndex, dataIndex ->
     bucket = listGetUnsafe buckets bucketIndex
     if bucket.dataIndex != dataIndex then
@@ -832,7 +833,7 @@ scanForIndex = \buckets, bucketIndex, dataIndex ->
     else
         bucketIndex
 
-removeBucketHelper : List Bucket, Nat -> (List Bucket, Nat)
+removeBucketHelper : List Bucket, U64 -> (List Bucket, U64)
 removeBucketHelper = \buckets, bucketIndex ->
     nextIndex = nextBucketIndex bucketIndex (List.len buckets)
     nextBucket = listGetUnsafe buckets nextIndex
@@ -846,7 +847,7 @@ removeBucketHelper = \buckets, bucketIndex ->
 increaseSize : Dict k v -> Dict k v
 increaseSize = \@Dict { data, maxBucketCapacity, maxLoadFactor, shifts } ->
     if maxBucketCapacity != maxBucketCount then
-        newShifts = shifts - 1
+        newShifts = shifts |> Num.subWrap 1
         (buckets0, newMaxBucketCapacity) = allocBucketsFromShift newShifts maxLoadFactor
         buckets1 = fillBucketsFromData buckets0 data newShifts
         @Dict {
@@ -864,14 +865,14 @@ allocBucketsFromShift = \shifts, maxLoadFactor ->
     bucketCount = calcNumBuckets shifts
     if bucketCount == maxBucketCount then
         # reached the maximum, make sure we can use each bucket
-        (List.repeat emptyBucket (Num.toNat maxBucketCount), maxBucketCount)
+        (List.repeat emptyBucket maxBucketCount, maxBucketCount)
     else
         maxBucketCapacity =
             bucketCount
             |> Num.toF32
             |> Num.mul maxLoadFactor
             |> Num.floor
-        (List.repeat emptyBucket (Num.toNat bucketCount), maxBucketCapacity)
+        (List.repeat emptyBucket bucketCount, maxBucketCapacity)
 
 calcShiftsForSize : U64, F32 -> U8
 calcShiftsForSize = \size, maxLoadFactor ->
@@ -885,13 +886,13 @@ calcShiftsForSizeHelper = \shifts, size, maxLoadFactor ->
         |> Num.mul maxLoadFactor
         |> Num.floor
     if shifts > 0 && maxBucketCapacity < size then
-        calcShiftsForSizeHelper (shifts - 1) size maxLoadFactor
+        calcShiftsForSizeHelper (shifts |> Num.subWrap 1) size maxLoadFactor
     else
         shifts
 
 calcNumBuckets = \shifts ->
     Num.min
-        (Num.shiftLeftBy 1 (64 - shifts))
+        (Num.shiftLeftBy 1 (64 |> Num.subWrap shifts))
         maxBucketCount
 
 fillBucketsFromData = \buckets0, data, shifts ->
@@ -899,7 +900,7 @@ fillBucketsFromData = \buckets0, data, shifts ->
     (bucketIndex, distAndFingerprint) = nextWhileLess buckets1 key shifts
     placeAndShiftUp buckets1 { distAndFingerprint, dataIndex: Num.toU32 dataIndex } bucketIndex
 
-nextWhileLess : List Bucket, k, U8 -> (Nat, U32) where k implements Hash & Eq
+nextWhileLess : List Bucket, k, U8 -> (U64, U32) where k implements Hash & Eq
 nextWhileLess = \buckets, key, shifts ->
     hash = hashKey key
     distAndFingerprint = distAndFingerprintFromHash hash
@@ -908,22 +909,22 @@ nextWhileLess = \buckets, key, shifts ->
     nextWhileLessHelper buckets bucketIndex distAndFingerprint
 
 nextWhileLessHelper = \buckets, bucketIndex, distAndFingerprint ->
-    loaded = listGetUnsafe buckets (Num.toNat bucketIndex)
+    loaded = listGetUnsafe buckets bucketIndex
     if distAndFingerprint < loaded.distAndFingerprint then
         nextWhileLessHelper buckets (nextBucketIndex bucketIndex (List.len buckets)) (incrementDist distAndFingerprint)
     else
         (bucketIndex, distAndFingerprint)
 
 placeAndShiftUp = \buckets0, bucket, bucketIndex ->
-    loaded = listGetUnsafe buckets0 (Num.toNat bucketIndex)
+    loaded = listGetUnsafe buckets0 bucketIndex
     if loaded.distAndFingerprint != 0 then
-        buckets1 = List.set buckets0 (Num.toNat bucketIndex) bucket
+        buckets1 = List.set buckets0 bucketIndex bucket
         placeAndShiftUp
             buckets1
             { loaded & distAndFingerprint: incrementDist loaded.distAndFingerprint }
             (nextBucketIndex bucketIndex (List.len buckets1))
     else
-        List.set buckets0 (Num.toNat bucketIndex) bucket
+        List.set buckets0 bucketIndex bucket
 
 nextBucketIndex = \bucketIndex, maxBuckets ->
     # I just ported this impl directly.
@@ -947,11 +948,10 @@ distAndFingerprintFromHash = \hash ->
     |> Num.bitwiseAnd fingerprintMask
     |> Num.bitwiseOr distInc
 
-bucketIndexFromHash : U64, U8 -> Nat
+bucketIndexFromHash : U64, U8 -> U64
 bucketIndexFromHash = \hash, shifts ->
     hash
     |> Num.shiftRightZfBy shifts
-    |> Num.toNat
 
 expect
     val =
@@ -1185,12 +1185,6 @@ expect
     |> len
     |> Bool.isEq 0
 
-# Makes sure a Dict with Nat keys works
-expect
-    empty {}
-    |> insert 7nat "Testing"
-    |> get 7
-    |> Bool.isEq (Ok "Testing")
 
 # All BadKey's hash to the same location.
 # This is needed to test some robinhood logic.
@@ -1225,7 +1219,7 @@ expect
         acc, k <- List.walk badKeys (Dict.empty {})
         Dict.update acc k \val ->
             when val is
-                Present p -> Present (p + 1)
+                Present p -> Present (p |> Num.addWrap 1)
                 Missing -> Present 0
 
     allInsertedCorrectly =
@@ -1236,7 +1230,7 @@ expect
 
 # Note, there are a number of places we should probably use set and replace unsafe.
 # unsafe primitive that does not perform a bounds check
-listGetUnsafe : List a, Nat -> a
+listGetUnsafe : List a, U64 -> a
 
 # We have decided not to expose the standard roc hashing algorithm.
 # This is to avoid external dependence and the need for versioning.
@@ -1368,9 +1362,9 @@ addBytes = \@LowLevelHasher { initializedSeed, state }, list ->
         else
             hashBytesHelper48 initializedSeed initializedSeed initializedSeed list 0 length
 
-    combineState (@LowLevelHasher { initializedSeed, state }) { a: abs.a, b: abs.b, seed: abs.seed, length: Num.toU64 length }
+    combineState (@LowLevelHasher { initializedSeed, state }) { a: abs.a, b: abs.b, seed: abs.seed, length }
 
-hashBytesHelper48 : U64, U64, U64, List U8, Nat, Nat -> { a : U64, b : U64, seed : U64 }
+hashBytesHelper48 : U64, U64, U64, List U8, U64, U64 -> { a : U64, b : U64, seed : U64 }
 hashBytesHelper48 = \seed, see1, see2, list, index, remaining ->
     newSeed = wymix (Num.bitwiseXor (wyr8 list index) wyp1) (Num.bitwiseXor (wyr8 list (Num.addWrap index 8)) seed)
     newSee1 = wymix (Num.bitwiseXor (wyr8 list (Num.addWrap index 16)) wyp2) (Num.bitwiseXor (wyr8 list (Num.addWrap index 24)) see1)
@@ -1389,7 +1383,7 @@ hashBytesHelper48 = \seed, see1, see2, list, index, remaining ->
 
         { a: wyr8 list (Num.subWrap newRemaining 16 |> Num.addWrap newIndex), b: wyr8 list (Num.subWrap newRemaining 8 |> Num.addWrap newIndex), seed: finalSeed }
 
-hashBytesHelper16 : U64, List U8, Nat, Nat -> { a : U64, b : U64, seed : U64 }
+hashBytesHelper16 : U64, List U8, U64, U64 -> { a : U64, b : U64, seed : U64 }
 hashBytesHelper16 = \seed, list, index, remaining ->
     newSeed = wymix (Num.bitwiseXor (wyr8 list index) wyp1) (Num.bitwiseXor (wyr8 list (Num.addWrap index 8)) seed)
     newRemaining = Num.subWrap remaining 16
@@ -1426,7 +1420,7 @@ wymum = \a, b ->
     { lower, upper }
 
 # Get the next 8 bytes as a U64
-wyr8 : List U8, Nat -> U64
+wyr8 : List U8, U64 -> U64
 wyr8 = \list, index ->
     # With seamless slices and Num.fromBytes, this should be possible to make faster and nicer.
     # It would also deal with the fact that on big endian systems we want to invert the order here.
@@ -1447,7 +1441,7 @@ wyr8 = \list, index ->
     Num.bitwiseOr (Num.bitwiseOr a b) (Num.bitwiseOr c d)
 
 # Get the next 4 bytes as a U64 with some shifting.
-wyr4 : List U8, Nat -> U64
+wyr4 : List U8, U64 -> U64
 wyr4 = \list, index ->
     p1 = listGetUnsafe list index |> Num.toU64
     p2 = listGetUnsafe list (Num.addWrap index 1) |> Num.toU64
@@ -1460,7 +1454,7 @@ wyr4 = \list, index ->
 
 # Get the next K bytes with some shifting.
 # K must be 3 or less.
-wyr3 : List U8, Nat, Nat -> U64
+wyr3 : List U8, U64, U64 -> U64
 wyr3 = \list, index, k ->
     # ((uint64_t)p[0])<<16)|(((uint64_t)p[k>>1])<<8)|p[k-1]
     p1 = listGetUnsafe list index |> Num.toU64

--- a/crates/compiler/builtins/roc/List.roc
+++ b/crates/compiler/builtins/roc/List.roc
@@ -74,7 +74,7 @@ interface List
     imports [
         Bool.{ Bool, Eq },
         Result.{ Result },
-        Num.{ Nat, Num, Int },
+        Num.{ U64, Num, Int },
     ]
 
 ## ## Types
@@ -91,14 +91,14 @@ interface List
 ## is normally enabled, not having enough memory could result in the list appearing
 ## to be created just fine, but then crashing later.)
 ##
-## > The theoretical maximum length for a list created in Roc is half of
-## > `Num.maxNat`. Attempting to create a list bigger than that
+## > The theoretical maximum length for a list created in Roc is `Num.maxI32` on 32-bit systems
+## > and `Num.maxI64` on 64-bit systems. Attempting to create a list bigger than that
 ## > in Roc code will always fail, although in practice it is likely to fail
 ## > at much smaller lengths due to insufficient memory being available.
 ##
 ## ## Performance Details
 ##
-## Under the hood, a list is a record containing a `len : Nat` field, a `capacity : Nat`
+## Under the hood, a list is a record containing a `len : U64` field, a `capacity : U64`
 ## field, and a pointer to a reference count and a flat array of bytes.
 ##
 ## ## Shared Lists
@@ -227,7 +227,7 @@ isEmpty = \list ->
 
 # unsafe primitive that does not perform a bounds check
 # but will cause a reference count increment on the value it got out of the list
-getUnsafe : List a, Nat -> a
+getUnsafe : List a, U64 -> a
 
 ## Returns an element from a list at the given index.
 ##
@@ -236,7 +236,7 @@ getUnsafe : List a, Nat -> a
 ## expect List.get [100, 200, 300] 1 == Ok 200
 ## expect List.get [100, 200, 300] 5 == Err OutOfBounds
 ## ```
-get : List a, Nat -> Result a [OutOfBounds]
+get : List a, U64 -> Result a [OutOfBounds]
 get = \list, index ->
     if index < List.len list then
         Ok (List.getUnsafe list index)
@@ -245,9 +245,9 @@ get = \list, index ->
 
 # unsafe primitive that does not perform a bounds check
 # but will cause a reference count increment on the value it got out of the list
-replaceUnsafe : List a, Nat, a -> { list : List a, value : a }
+replaceUnsafe : List a, U64, a -> { list : List a, value : a }
 
-replace : List a, Nat, a -> { list : List a, value : a }
+replace : List a, U64, a -> { list : List a, value : a }
 replace = \list, index, newValue ->
     if index < List.len list then
         List.replaceUnsafe list index newValue
@@ -262,7 +262,7 @@ replace = \list, index, newValue ->
 ## list unmodified.
 ##
 ## To drop the element at a given index, instead of replacing it, see [List.dropAt].
-set : List a, Nat, a -> List a
+set : List a, U64, a -> List a
 set = \list, index, value ->
     (List.replace list index value).list
 
@@ -275,7 +275,7 @@ set = \list, index, value ->
 ##
 ## To replace the element at a given index, instead of updating based on the current value,
 ## see [List.set] and [List.replace]
-update : List a, Nat, (a -> a) -> List a
+update : List a, U64, (a -> a) -> List a
 update = \list, index, func ->
     when List.get list index is
         Err OutOfBounds -> list
@@ -285,7 +285,7 @@ update = \list, index, func ->
 
 # Update one element in bounds
 expect
-    list : List Nat
+    list : List U64
     list = [1, 2, 3]
     got = update list 1 (\x -> x + 42)
     want = [1, 44, 3]
@@ -293,14 +293,14 @@ expect
 
 # Update out of bounds
 expect
-    list : List Nat
+    list : List U64
     list = [1, 2, 3]
     got = update list 5 (\x -> x + 42)
     got == list
 
 # Update chain
 expect
-    list : List Nat
+    list : List U64
     list = [1, 2, 3]
     got =
         list
@@ -374,13 +374,13 @@ prependIfOk = \list, result ->
 ## One [List] can store up to 2,147,483,648 elements (just over 2 billion), which
 ## is exactly equal to the highest valid #I32 value. This means the #U32 this function
 ## returns can always be safely converted to an #I32 without losing any data.
-len : List * -> Nat
+len : List * -> U64
 
 ## Create a list with space for at least capacity elements
-withCapacity : Nat -> List *
+withCapacity : U64 -> List *
 
 ## Enlarge the list for at least capacity additional elements
-reserve : List a, Nat -> List a
+reserve : List a, U64 -> List a
 
 ## Shrink the memory footprint of a list such that it's capacity and length are equal.
 ## Note: This will also convert seamless slices to regular lists.
@@ -418,11 +418,11 @@ single : a -> List a
 single = \x -> [x]
 
 ## Returns a list with the given length, where every element is the given value.
-repeat : a, Nat -> List a
+repeat : a, U64 -> List a
 repeat = \value, count ->
     repeatHelp value count (List.withCapacity count)
 
-repeatHelp : a, Nat, List a -> List a
+repeatHelp : a, U64, List a -> List a
 repeatHelp = \value, count, accum ->
     if count > 0 then
         repeatHelp value (Num.subWrap count 1) (List.appendUnsafe accum value)
@@ -501,7 +501,7 @@ walk = \list, init, func ->
     walkHelp list init func 0 (List.len list)
 
 ## internal helper
-walkHelp : List elem, s, (s, elem -> s), Nat, Nat -> s
+walkHelp : List elem, s, (s, elem -> s), U64, U64 -> s
 walkHelp = \list, state, f, index, length ->
     if index < length then
         nextState = f state (List.getUnsafe list index)
@@ -511,12 +511,12 @@ walkHelp = \list, state, f, index, length ->
         state
 
 ## Like [walk], but at each step the function also receives the index of the current element.
-walkWithIndex : List elem, state, (state, elem, Nat -> state) -> state
+walkWithIndex : List elem, state, (state, elem, U64 -> state) -> state
 walkWithIndex = \list, init, func ->
     walkWithIndexHelp list init func 0 (List.len list)
 
 ## internal helper
-walkWithIndexHelp : List elem, s, (s, elem, Nat -> s), Nat, Nat -> s
+walkWithIndexHelp : List elem, s, (s, elem, U64 -> s), U64, U64 -> s
 walkWithIndexHelp = \list, state, f, index, length ->
     if index < length then
         nextState = f state (List.getUnsafe list index) index
@@ -526,14 +526,14 @@ walkWithIndexHelp = \list, state, f, index, length ->
         state
 
 ## Like [walkUntil], but at each step the function also receives the index of the current element.
-walkWithIndexUntil : List elem, state, (state, elem, Nat -> [Continue state, Break state]) -> state
+walkWithIndexUntil : List elem, state, (state, elem, U64 -> [Continue state, Break state]) -> state
 walkWithIndexUntil = \list, state, f ->
     when walkWithIndexUntilHelp list state f 0 (List.len list) is
         Continue new -> new
         Break new -> new
 
 ## internal helper
-walkWithIndexUntilHelp : List elem, s, (s, elem, Nat -> [Continue s, Break b]), Nat, Nat -> [Continue s, Break b]
+walkWithIndexUntilHelp : List elem, s, (s, elem, U64 -> [Continue s, Break b]), U64, U64 -> [Continue s, Break b]
 walkWithIndexUntilHelp = \list, state, f, index, length ->
     if index < length then
         when f state (List.getUnsafe list index) index is
@@ -551,7 +551,7 @@ walkBackwards = \list, state, func ->
     walkBackwardsHelp list state func (len list)
 
 ## internal helper
-walkBackwardsHelp : List elem, state, (state, elem -> state), Nat -> state
+walkBackwardsHelp : List elem, state, (state, elem -> state), U64 -> state
 walkBackwardsHelp = \list, state, f, indexPlusOne ->
     if indexPlusOne == 0 then
         state
@@ -586,7 +586,7 @@ walkBackwardsUntil = \list, initial, func ->
         Break new -> new
 
 ## Walks to the end of the list from a specified starting index
-walkFrom : List elem, Nat, state, (state, elem -> state) -> state
+walkFrom : List elem, U64, state, (state, elem -> state) -> state
 walkFrom = \list, index, state, func ->
     step : _, _ -> [Continue _, Break []]
     step = \currentState, element -> Continue (func currentState element)
@@ -595,7 +595,7 @@ walkFrom = \list, index, state, func ->
         Continue new -> new
 
 ## A combination of [List.walkFrom] and [List.walkUntil]
-walkFromUntil : List elem, Nat, state, (state, elem -> [Continue state, Break state]) -> state
+walkFromUntil : List elem, U64, state, (state, elem -> [Continue state, Break state]) -> state
 walkFromUntil = \list, index, state, func ->
     when List.iterHelp list state func index (List.len list) is
         Continue new -> new
@@ -664,7 +664,7 @@ keepIf = \list, predicate ->
 
     keepIfHelp list predicate 0 0 length
 
-keepIfHelp : List a, (a -> Bool), Nat, Nat, Nat -> List a
+keepIfHelp : List a, (a -> Bool), U64, U64, U64 -> List a
 keepIfHelp = \list, predicate, kept, index, length ->
     if index < length then
         if predicate (List.getUnsafe list index) then
@@ -693,7 +693,7 @@ dropIf = \list, predicate ->
 ## expect List.countIf [1, -2, -3] Num.isNegative == 2
 ## expect List.countIf [1, 2, 3] (\num -> num > 1 ) == 2
 ## ```
-countIf : List a, (a -> Bool) -> Nat
+countIf : List a, (a -> Bool) -> U64
 countIf = \list, predicate ->
     walkState = \state, elem ->
         if predicate elem then
@@ -775,7 +775,7 @@ map4 : List a, List b, List c, List d, (a, b, c, d -> e) -> List e
 ## ```
 ## expect List.mapWithIndex [10, 20, 30] (\num, index -> num + index) == [10, 21, 32]
 ## ```
-mapWithIndex : List a, (a, Nat -> b) -> List b
+mapWithIndex : List a, (a, U64 -> b) -> List b
 mapWithIndex = \src, func ->
     length = len src
     dest = withCapacity length
@@ -783,7 +783,7 @@ mapWithIndex = \src, func ->
     mapWithIndexHelp src dest func 0 length
 
 # Internal helper
-mapWithIndexHelp : List a, List b, (a, Nat -> b), Nat, Nat -> List b
+mapWithIndexHelp : List a, List b, (a, U64 -> b), U64, U64 -> List b
 mapWithIndexHelp = \src, dest, func, index, length ->
     if index < length then
         elem = getUnsafe src index
@@ -958,7 +958,7 @@ sortAsc = \list -> List.sortWith list Num.compare
 sortDesc : List (Num a) -> List (Num a)
 sortDesc = \list -> List.sortWith list (\a, b -> Num.compare b a)
 
-swap : List a, Nat, Nat -> List a
+swap : List a, U64, U64 -> List a
 
 ## Returns the first element in the list, or `ListWasEmpty` if it was empty.
 first : List a -> Result a [ListWasEmpty]
@@ -983,7 +983,7 @@ first = \list ->
 ##
 ## To split the list into two lists, use `List.split`.
 ##
-takeFirst : List elem, Nat -> List elem
+takeFirst : List elem, U64 -> List elem
 takeFirst = \list, outputLength ->
     List.sublist list { start: 0, len: outputLength }
 
@@ -1003,19 +1003,19 @@ takeFirst = \list, outputLength ->
 ##
 ## To split the list into two lists, use `List.split`.
 ##
-takeLast : List elem, Nat -> List elem
+takeLast : List elem, U64 -> List elem
 takeLast = \list, outputLength ->
     List.sublist list { start: Num.subSaturated (List.len list) outputLength, len: outputLength }
 
 ## Drops n elements from the beginning of the list.
-dropFirst : List elem, Nat -> List elem
+dropFirst : List elem, U64 -> List elem
 dropFirst = \list, n ->
     remaining = Num.subSaturated (List.len list) n
 
     List.takeLast list remaining
 
 ## Drops n elements from the end of the list.
-dropLast : List elem, Nat -> List elem
+dropLast : List elem, U64 -> List elem
 dropLast = \list, n ->
     remaining = Num.subSaturated (List.len list) n
 
@@ -1026,7 +1026,7 @@ dropLast = \list, n ->
 ## This has no effect if the given index is outside the bounds of the list.
 ##
 ## To replace the element at a given index, instead of dropping it, see [List.set].
-dropAt : List elem, Nat -> List elem
+dropAt : List elem, U64 -> List elem
 
 min : List (Num a) -> Result (Num a) [ListWasEmpty]
 min = \list ->
@@ -1101,7 +1101,7 @@ findLast = \list, pred ->
 ## Returns the index at which the first element in the list
 ## satisfying a predicate function can be found.
 ## If no satisfying element is found, an `Err NotFound` is returned.
-findFirstIndex : List elem, (elem -> Bool) -> Result Nat [NotFound]
+findFirstIndex : List elem, (elem -> Bool) -> Result U64 [NotFound]
 findFirstIndex = \list, matcher ->
     foundIndex = List.iterate list 0 \index, elem ->
         if matcher elem then
@@ -1116,7 +1116,7 @@ findFirstIndex = \list, matcher ->
 ## Returns the last index at which the first element in the list
 ## satisfying a predicate function can be found.
 ## If no satisfying element is found, an `Err NotFound` is returned.
-findLastIndex : List elem, (elem -> Bool) -> Result Nat [NotFound]
+findLastIndex : List elem, (elem -> Bool) -> Result U64 [NotFound]
 findLastIndex = \list, matches ->
     foundIndex = List.iterateBackwards list (List.len list) \prevIndex, elem ->
         answer = Num.subWrap prevIndex 1
@@ -1145,12 +1145,12 @@ findLastIndex = \list, matches ->
 ## > matter how long the list is, `List.takeLast` can do that more efficiently.
 ##
 ## Some languages have a function called **`slice`** which works similarly to this.
-sublist : List elem, { start : Nat, len : Nat } -> List elem
+sublist : List elem, { start : U64, len : U64 } -> List elem
 sublist = \list, config ->
     sublistLowlevel list config.start config.len
 
 ## low-level slicing operation that does no bounds checking
-sublistLowlevel : List elem, Nat, Nat -> List elem
+sublistLowlevel : List elem, U64, U64 -> List elem
 
 ## Intersperses `sep` between the elements of `list`
 ## ```
@@ -1202,7 +1202,7 @@ endsWith = \list, suffix ->
 ## than the given index, # and the `others` list will be all the others. (This
 ## means if you give an index of 0, the `before` list will be empty and the
 ## `others` list will have the same elements as the original list.)
-split : List elem, Nat -> { before : List elem, others : List elem }
+split : List elem, U64 -> { before : List elem, others : List elem }
 split = \elements, userSplitIndex ->
     length = List.len elements
     splitIndex = if length > userSplitIndex then userSplitIndex else length
@@ -1247,7 +1247,7 @@ splitLast = \list, delimiter ->
 ## size. The last chunk will be shorter if the list does not evenly divide by the
 ## chunk size. If the provided list is empty or if the chunk size is 0 then the
 ## result is an empty list.
-chunksOf : List a, Nat -> List (List a)
+chunksOf : List a, U64 -> List (List a)
 chunksOf = \list, chunkSize ->
     if chunkSize == 0 || List.isEmpty list then
         []
@@ -1255,7 +1255,7 @@ chunksOf = \list, chunkSize ->
         chunkCapacity = Num.divCeil (List.len list) chunkSize
         chunksOfHelp list chunkSize (List.withCapacity chunkCapacity)
 
-chunksOfHelp : List a, Nat, List (List a) -> List (List a)
+chunksOfHelp : List a, U64, List (List a) -> List (List a)
 chunksOfHelp = \listRest, chunkSize, chunks ->
     if List.isEmpty listRest then
         chunks
@@ -1288,7 +1288,7 @@ walkTry = \list, init, func ->
     walkTryHelp list init func 0 (List.len list)
 
 ## internal helper
-walkTryHelp : List elem, state, (state, elem -> Result state err), Nat, Nat -> Result state err
+walkTryHelp : List elem, state, (state, elem -> Result state err), U64, U64 -> Result state err
 walkTryHelp = \list, state, f, index, length ->
     if index < length then
         when f state (List.getUnsafe list index) is
@@ -1303,7 +1303,7 @@ iterate = \list, init, func ->
     iterHelp list init func 0 (List.len list)
 
 ## internal helper
-iterHelp : List elem, s, (s, elem -> [Continue s, Break b]), Nat, Nat -> [Continue s, Break b]
+iterHelp : List elem, s, (s, elem -> [Continue s, Break b]), U64, U64 -> [Continue s, Break b]
 iterHelp = \list, state, f, index, length ->
     if index < length then
         when f state (List.getUnsafe list index) is
@@ -1319,7 +1319,7 @@ iterateBackwards = \list, init, func ->
     iterBackwardsHelp list init func (List.len list)
 
 ## internal helper
-iterBackwardsHelp : List elem, s, (s, elem -> [Continue s, Break b]), Nat -> [Continue s, Break b]
+iterBackwardsHelp : List elem, s, (s, elem -> [Continue s, Break b]), U64 -> [Continue s, Break b]
 iterBackwardsHelp = \list, state, f, prevIndex ->
     if prevIndex > 0 then
         index = Num.subWrap prevIndex 1

--- a/crates/compiler/builtins/roc/Result.roc
+++ b/crates/compiler/builtins/roc/Result.roc
@@ -84,8 +84,8 @@ try = \result, transform ->
 ## function on the value the `Err` holds. Then returns that new result. If the
 ## result is `Ok`, this has no effect. Use `try` to transform an `Ok`.
 ## ```
-## Result.onErr (Ok 10) \errorNum -> Str.toNat errorNum
-## Result.onErr (Err "42") \errorNum -> Str.toNat errorNum
+## Result.onErr (Ok 10) \errorNum -> Str.toU64 errorNum
+## Result.onErr (Err "42") \errorNum -> Str.toU64 errorNum
 ## ```
 onErr : Result a err, (err -> Result a otherErr) -> Result a otherErr
 onErr = \result, transform ->

--- a/crates/compiler/builtins/roc/Set.roc
+++ b/crates/compiler/builtins/roc/Set.roc
@@ -28,7 +28,7 @@ interface Set
         List,
         Bool.{ Bool, Eq },
         Dict.{ Dict },
-        Num.{ Nat },
+        Num.{ U64 },
         Hash.{ Hash, Hasher },
         Inspect.{ Inspect, Inspector, InspectFormatter },
     ]
@@ -80,12 +80,12 @@ empty = \{} -> @Set (Dict.empty {})
 ## Return a set with space allocated for a number of entries. This
 ## may provide a performance optimization if you know how many entries will be
 ## inserted.
-withCapacity : Nat -> Set *
+withCapacity : U64 -> Set *
 withCapacity = \cap ->
     @Set (Dict.withCapacity cap)
 
 ## Enlarge the set for at least capacity additional elements
-reserve : Set k, Nat -> Set k
+reserve : Set k, U64 -> Set k
 reserve = \@Set dict, requested ->
     @Set (Dict.reserve dict requested)
 
@@ -152,7 +152,7 @@ expect
 ##
 ## expect countValues == 3
 ## ```
-len : Set * -> Nat
+len : Set * -> U64
 len = \@Set dict ->
     Dict.len dict
 
@@ -164,7 +164,7 @@ len = \@Set dict ->
 ##
 ## capacityOfSet = Set.capacity foodSet
 ## ```
-capacity : Set * -> Nat
+capacity : Set * -> U64
 capacity = \@Set dict ->
     Dict.capacity dict
 
@@ -462,22 +462,22 @@ expect
     x == fromList (toList x)
 
 expect
-    orderOne : Set Nat
+    orderOne : Set U64
     orderOne =
         single 1
         |> insert 2
 
-    orderTwo : Set Nat
+    orderTwo : Set U64
     orderTwo =
         single 2
         |> insert 1
 
-    wrapperOne : Set (Set Nat)
+    wrapperOne : Set (Set U64)
     wrapperOne =
         single orderOne
         |> insert orderTwo
 
-    wrapperTwo : Set (Set Nat)
+    wrapperTwo : Set (Set U64)
     wrapperTwo =
         single orderTwo
         |> insert orderOne

--- a/crates/compiler/builtins/roc/Str.roc
+++ b/crates/compiler/builtins/roc/Str.roc
@@ -539,7 +539,7 @@ toUtf8 : Str -> List U8
 ## ```
 fromUtf8 : List U8 -> Result Str [BadUtf8 Utf8ByteProblem U64]
 fromUtf8 = \bytes ->
-    result = fromUtf8RangeLowlevel bytes 0 (List.len bytes |> Num.toU64)
+    result = fromUtf8RangeLowlevel bytes 0 (List.len bytes)
 
     if result.cIsOk then
         Ok result.bString
@@ -559,7 +559,7 @@ expect (Str.fromUtf8 [255]) |> Result.isErr
 ## ```
 fromUtf8Range : List U8, { start : U64, count : U64 } -> Result Str [BadUtf8 Utf8ByteProblem U64, OutOfBounds]
 fromUtf8Range = \bytes, config ->
-    if Num.addSaturated config.start config.count <= (List.len bytes |> Num.toU64) then
+    if Num.addSaturated config.start config.count <= List.len bytes then
         result = fromUtf8RangeLowlevel bytes config.start config.count
 
         if result.cIsOk then

--- a/crates/compiler/builtins/roc/Str.roc
+++ b/crates/compiler/builtins/roc/Str.roc
@@ -345,7 +345,6 @@ interface Str
         toDec,
         toF64,
         toF32,
-        toNat,
         toU128,
         toI128,
         toU64,
@@ -373,7 +372,7 @@ interface Str
         Bool.{ Bool, Eq },
         Result.{ Result },
         List,
-        Num.{ Nat, Num, U8, U16, U32, U64, U128, I8, I16, I32, I64, I128, F32, F64, Dec },
+        Num.{ Num, U8, U16, U32, U64, U128, I8, I16, I32, I64, I128, F32, F64, Dec },
     ]
 
 Utf8ByteProblem : [
@@ -385,7 +384,7 @@ Utf8ByteProblem : [
     EncodesSurrogateHalf,
 ]
 
-Utf8Problem : { byteIndex : Nat, problem : Utf8ByteProblem }
+Utf8Problem : { byteIndex : U64, problem : Utf8ByteProblem }
 
 ## Returns [Bool.true] if the string is empty, and [Bool.false] otherwise.
 ## ```
@@ -426,7 +425,7 @@ concat : Str, Str -> Str
 ## the cost of using more memory than is necessary.
 ##
 ## For more details on how the performance optimization works, see [Str.reserve].
-withCapacity : Nat -> Str
+withCapacity : U64 -> Str
 
 ## Increase a string's capacity by at least the given number of additional bytes.
 ##
@@ -484,7 +483,7 @@ withCapacity : Nat -> Str
 ## reallocations but will also waste a lot of memory!
 ##
 ## If you plan to use [Str.reserve] on an empty string, it's generally better to use [Str.withCapacity] instead.
-reserve : Str, Nat -> Str
+reserve : Str, U64 -> Str
 
 ## Combines a [List] of strings into a single string, with a separator
 ## string in between each.
@@ -514,7 +513,7 @@ split : Str, Str -> List Str
 ## expect Str.repeat "" 10 == ""
 ## expect Str.repeat "anything" 0 == ""
 ## ```
-repeat : Str, Nat -> Str
+repeat : Str, U64 -> Str
 
 ## Returns a [List] of the string's [U8] UTF-8 [code units](https://unicode.org/glossary/#code_unit).
 ## (To split the string into a [List] of smaller [Str] values instead of [U8] values,
@@ -538,9 +537,9 @@ toUtf8 : Str -> List U8
 ## expect Str.fromUtf8 [] == Ok ""
 ## expect Str.fromUtf8 [255] |> Result.isErr
 ## ```
-fromUtf8 : List U8 -> Result Str [BadUtf8 Utf8ByteProblem Nat]
+fromUtf8 : List U8 -> Result Str [BadUtf8 Utf8ByteProblem U64]
 fromUtf8 = \bytes ->
-    result = fromUtf8RangeLowlevel bytes 0 (List.len bytes)
+    result = fromUtf8RangeLowlevel bytes 0 (List.len bytes |> Num.toU64)
 
     if result.cIsOk then
         Ok result.bString
@@ -558,9 +557,9 @@ expect (Str.fromUtf8 [255]) |> Result.isErr
 ## ```
 ## expect Str.fromUtf8Range [72, 105, 80, 103] { start : 0, count : 2 } == Ok "Hi"
 ## ```
-fromUtf8Range : List U8, { start : Nat, count : Nat } -> Result Str [BadUtf8 Utf8ByteProblem Nat, OutOfBounds]
+fromUtf8Range : List U8, { start : U64, count : U64 } -> Result Str [BadUtf8 Utf8ByteProblem U64, OutOfBounds]
 fromUtf8Range = \bytes, config ->
-    if Num.addSaturated config.start config.count <= List.len bytes then
+    if Num.addSaturated config.start config.count <= (List.len bytes |> Num.toU64) then
         result = fromUtf8RangeLowlevel bytes config.start config.count
 
         if result.cIsOk then
@@ -577,13 +576,13 @@ expect (Str.fromUtf8Range [] { start: 0, count: 0 }) == Ok ""
 expect (Str.fromUtf8Range [72, 105, 80, 103] { start: 2, count: 3 }) |> Result.isErr
 
 FromUtf8Result : {
-    aByteIndex : Nat,
+    aByteIndex : U64,
     bString : Str,
     cIsOk : Bool,
     dProblemCode : Utf8ByteProblem,
 }
 
-fromUtf8RangeLowlevel : List U8, Nat, Nat -> FromUtf8Result
+fromUtf8RangeLowlevel : List U8, U64, U64 -> FromUtf8Result
 
 ## Check if the given [Str] starts with a value.
 ## ```
@@ -647,25 +646,6 @@ toF64 = \string -> strToNumHelp string
 ## ```
 toF32 : Str -> Result F32 [InvalidNumStr]
 toF32 = \string -> strToNumHelp string
-
-## Convert a [Str] to a [Nat]. If the given number doesn't fit in [Nat], it will be [truncated](https://www.ualberta.ca/computing-science/media-library/teaching-resources/java/truncation-rounding.html).
-## [Nat] has a different maximum number depending on the system you're building
-## for, so this may give a different answer on different systems.
-##
-## For example, on a 32-bit system, `Num.maxNat` will return the same answer as
-## `Num.maxU32`. This means that calling `Str.toNat "9_000_000_000"` on a 32-bit
-## system will return `Num.maxU32` instead of 9 billion, because 9 billion is
-## larger than `Num.maxU32` and will not fit in a [Nat] on a 32-bit system.
-##
-## Calling `Str.toNat "9_000_000_000"` on a 64-bit system will return
-## the [Nat] value of 9_000_000_000. This is because on a 64-bit system, [Nat] can
-## hold up to `Num.maxU64`, and 9_000_000_000 is smaller than `Num.maxU64`.
-## ```
-## expect Str.toNat "9_000_000_000" == Ok 9000000000
-## expect Str.toNat "not a number" == Err InvalidNumStr
-## ```
-toNat : Str -> Result Nat [InvalidNumStr]
-toNat = \string -> strToNumHelp string
 
 ## Encode a [Str] to an unsigned [U128] integer. A [U128] value can hold numbers
 ## from `0` to `340_282_366_920_938_463_463_374_607_431_768_211_455` (over
@@ -786,16 +766,16 @@ toI8 : Str -> Result I8 [InvalidNumStr]
 toI8 = \string -> strToNumHelp string
 
 ## Get the byte at the given index, without performing a bounds check.
-getUnsafe : Str, Nat -> U8
+getUnsafe : Str, U64 -> U8
 
 ## Gives the number of bytes in a [Str] value.
 ## ```
 ## expect Str.countUtf8Bytes "Hello World" == 11
 ## ```
-countUtf8Bytes : Str -> Nat
+countUtf8Bytes : Str -> U64
 
 ## string slice that does not do bounds checking or utf-8 verification
-substringUnsafe : Str, Nat, Nat -> Str
+substringUnsafe : Str, U64, U64 -> Str
 
 ## Returns the given [Str] with each occurrence of a substring replaced.
 ## If the substring is not found, returns the original string.
@@ -903,7 +883,7 @@ expect splitFirst "hullabaloo" "ab" == Ok { before: "hull", after: "aloo" }
 # splitFirst when needle is haystack
 expect splitFirst "foo" "foo" == Ok { before: "", after: "" }
 
-firstMatch : Str, Str -> [Some Nat, None]
+firstMatch : Str, Str -> [Some U64, None]
 firstMatch = \haystack, needle ->
     haystackLength = Str.countUtf8Bytes haystack
     needleLength = Str.countUtf8Bytes needle
@@ -911,7 +891,7 @@ firstMatch = \haystack, needle ->
 
     firstMatchHelp haystack needle 0 lastPossible
 
-firstMatchHelp : Str, Str, Nat, Nat -> [Some Nat, None]
+firstMatchHelp : Str, Str, U64, U64 -> [Some U64, None]
 firstMatchHelp = \haystack, needle, index, lastPossible ->
     if index <= lastPossible then
         if matchesAt haystack index needle then
@@ -954,7 +934,7 @@ expect Str.splitLast "hullabaloo" "ab" == Ok { before: "hull", after: "aloo" }
 # splitLast when needle is haystack
 expect Str.splitLast "foo" "foo" == Ok { before: "", after: "" }
 
-lastMatch : Str, Str -> [Some Nat, None]
+lastMatch : Str, Str -> [Some U64, None]
 lastMatch = \haystack, needle ->
     haystackLength = Str.countUtf8Bytes haystack
     needleLength = Str.countUtf8Bytes needle
@@ -962,7 +942,7 @@ lastMatch = \haystack, needle ->
 
     lastMatchHelp haystack needle lastPossibleIndex
 
-lastMatchHelp : Str, Str, Nat -> [Some Nat, None]
+lastMatchHelp : Str, Str, U64 -> [Some U64, None]
 lastMatchHelp = \haystack, needle, index ->
     if matchesAt haystack index needle then
         Some index
@@ -976,7 +956,7 @@ lastMatchHelp = \haystack, needle, index ->
 
 min = \x, y -> if x < y then x else y
 
-matchesAt : Str, Nat, Str -> Bool
+matchesAt : Str, U64, Str -> Bool
 matchesAt = \haystack, haystackIndex, needle ->
     haystackLength = Str.countUtf8Bytes haystack
     needleLength = Str.countUtf8Bytes needle
@@ -1017,15 +997,15 @@ matchesAtHelp = \state ->
 ## state for each byte. The index for that byte in the string is provided
 ## to the update function.
 ## ```
-## f : List U8, U8, Nat -> List U8
+## f : List U8, U8, U64 -> List U8
 ## f = \state, byte, _ -> List.append state byte
 ## expect Str.walkUtf8WithIndex "ABC" [] f == [65, 66, 67]
 ## ```
-walkUtf8WithIndex : Str, state, (state, U8, Nat -> state) -> state
+walkUtf8WithIndex : Str, state, (state, U8, U64 -> state) -> state
 walkUtf8WithIndex = \string, state, step ->
     walkUtf8WithIndexHelp string state step 0 (Str.countUtf8Bytes string)
 
-walkUtf8WithIndexHelp : Str, state, (state, U8, Nat -> state), Nat, Nat -> state
+walkUtf8WithIndexHelp : Str, state, (state, U8, U64 -> state), U64, U64 -> state
 walkUtf8WithIndexHelp = \string, state, step, index, length ->
     if index < length then
         byte = Str.getUnsafe string index
@@ -1049,7 +1029,7 @@ walkUtf8 : Str, state, (state, U8 -> state) -> state
 walkUtf8 = \str, initial, step ->
     walkUtf8Help str initial step 0 (Str.countUtf8Bytes str)
 
-walkUtf8Help : Str, state, (state, U8 -> state), Nat, Nat -> state
+walkUtf8Help : Str, state, (state, U8 -> state), U64, U64 -> state
 walkUtf8Help = \str, state, step, index, length ->
     if index < length then
         byte = Str.getUnsafe str index

--- a/crates/compiler/builtins/roc/TotallyNotJson.roc
+++ b/crates/compiler/builtins/roc/TotallyNotJson.roc
@@ -34,7 +34,6 @@ interface TotallyNotJson
             I128,
             F32,
             F64,
-            Nat,
             Dec,
         },
         Bool.{ Bool, Eq },
@@ -678,21 +677,21 @@ numberHelp = \state, byte ->
 
 NumberState : [
     Start,
-    Minus Nat,
-    Zero Nat,
-    Integer Nat,
-    FractionA Nat,
-    FractionB Nat,
-    ExponentA Nat,
-    ExponentB Nat,
-    ExponentC Nat,
+    Minus U64,
+    Zero U64,
+    Integer U64,
+    FractionA U64,
+    FractionB U64,
+    ExponentA U64,
+    ExponentB U64,
+    ExponentC U64,
     Invalid,
-    Finish Nat,
+    Finish U64,
 ]
 
 # TODO confirm if we would like to be able to decode
 # "340282366920938463463374607431768211455" which is MAX U128 and 39 bytes
-maxBytes : Nat
+maxBytes : U64
 maxBytes = 21 # Max bytes in a double precision float
 
 isDigit0to9 : U8 -> Bool
@@ -894,13 +893,13 @@ stringHelp = \state, byte ->
 
 StringState : [
     Start,
-    Chars Nat,
-    Escaped Nat,
-    UnicodeA Nat,
-    UnicodeB Nat,
-    UnicodeC Nat,
-    UnicodeD Nat,
-    Finish Nat,
+    Chars U64,
+    Escaped U64,
+    UnicodeA U64,
+    UnicodeB U64,
+    UnicodeC U64,
+    UnicodeD U64,
+    Finish U64,
     InvalidNumber,
 ]
 
@@ -1176,14 +1175,14 @@ expect
     actual == expected
 
 ArrayOpeningState : [
-    BeforeOpeningBracket Nat,
-    AfterOpeningBracket Nat,
+    BeforeOpeningBracket U64,
+    AfterOpeningBracket U64,
 ]
 
 ArrayClosingState : [
-    BeforeNextElemOrClosingBracket Nat,
-    BeforeNextElement Nat,
-    AfterClosingBracket Nat,
+    BeforeNextElemOrClosingBracket U64,
+    BeforeNextElement U64,
+    AfterClosingBracket U64,
 ]
 
 # Test decoding an empty array
@@ -1317,13 +1316,13 @@ objectHelp = \state, byte ->
         _ -> Break InvalidObject
 
 ObjectState : [
-    BeforeOpeningBrace Nat,
-    AfterOpeningBrace Nat,
-    ObjectFieldNameStart Nat,
-    BeforeColon Nat,
-    AfterColon Nat,
-    AfterObjectValue Nat,
-    AfterComma Nat,
-    AfterClosingBrace Nat,
+    BeforeOpeningBrace U64,
+    AfterOpeningBrace U64,
+    ObjectFieldNameStart U64,
+    BeforeColon U64,
+    AfterColon U64,
+    AfterObjectValue U64,
+    AfterComma U64,
+    AfterClosingBrace U64,
     InvalidObject,
 ]

--- a/crates/compiler/can/src/builtins.rs
+++ b/crates/compiler/can/src/builtins.rs
@@ -226,7 +226,7 @@ map_symbol_to_lowlevel_and_arity! {
 /// Some builtins cannot be constructed in code gen alone, and need to be defined
 /// as separate Roc defs. For example, List.get has this type:
 ///
-/// List.get : List elem, Nat -> Result elem [OutOfBounds]*
+/// List.get : List elem, U64 -> Result elem [OutOfBounds]*
 ///
 /// Because this returns an open tag union for its Err type, it's not possible
 /// for code gen to return a hardcoded value for OutOfBounds. For example,

--- a/crates/compiler/gen_llvm/src/llvm/build_list.rs
+++ b/crates/compiler/gen_llvm/src/llvm/build_list.rs
@@ -143,6 +143,8 @@ pub(crate) fn list_get_unsafe<'a, 'ctx>(
         layout_interner,
         layout_interner.get_repr(element_layout),
     );
+    // listGetUnsafe takes a U64, but we need to convert that to usize for index calculation.
+    let elem_index = builder.new_build_int_cast(elem_index, env.ptr_int(), "u64_to_usize");
     let ptr_type = elem_type.ptr_type(AddressSpace::default());
     // Load the pointer to the array data
     let array_data_ptr = load_list_ptr(builder, wrapper_struct, ptr_type);
@@ -423,7 +425,7 @@ fn bounds_check_comparison<'ctx>(
     builder.new_build_int_compare(IntPredicate::ULT, elem_index, len, "bounds_check")
 }
 
-/// List.len : List * -> Nat
+/// List.len : List * -> usize (return value will be cast to usize in user-facing API)
 pub(crate) fn list_len<'ctx>(
     builder: &Builder<'ctx>,
     wrapper_struct: StructValue<'ctx>,

--- a/crates/compiler/gen_llvm/src/llvm/lowlevel.rs
+++ b/crates/compiler/gen_llvm/src/llvm/lowlevel.rs
@@ -618,10 +618,15 @@ pub(crate) fn run_low_level<'a, 'ctx>(
             )
         }
         ListLen => {
-            // List.len : List * -> Nat
+            // List.len : List * -> U64
             arguments!(list);
 
-            list_len(env.builder, list.into_struct_value()).into()
+            let len_usize = list_len(env.builder, list.into_struct_value());
+
+            // List.len returns U64, although length is stored as usize
+            env.builder
+                .new_build_int_cast(len_usize, env.context.i64_type(), "usize_to_u64")
+                .into()
         }
         ListGetCapacity => {
             // List.capacity: List a -> Nat

--- a/crates/compiler/gen_wasm/src/low_level.rs
+++ b/crates/compiler/gen_wasm/src/low_level.rs
@@ -279,6 +279,9 @@ impl<'a> LowLevelCall<'a> {
                     backend
                         .code_builder
                         .i32_load(Align::Bytes4, offset + (4 * Builtin::WRAPPER_LEN));
+
+                    // Length is stored as 32 bits in memory, but List.len returns U64
+                    backend.code_builder.i64_extend_u_i32();
                 }
                 _ => internal_error!("invalid storage for List"),
             },
@@ -321,6 +324,7 @@ impl<'a> LowLevelCall<'a> {
                 backend
                     .storage
                     .load_symbols(&mut backend.code_builder, &[index]);
+                backend.code_builder.i32_wrap_i64(); // listGetUnsafe takes a U64, but we do 32-bit indexing on wasm.
                 let elem_size = backend.layout_interner.stack_size(self.ret_layout);
                 backend.code_builder.i32_const(elem_size as i32);
                 backend.code_builder.i32_mul(); // index*size

--- a/crates/compiler/load_internal/src/file.rs
+++ b/crates/compiler/load_internal/src/file.rs
@@ -4828,7 +4828,7 @@ fn import_variable_for_symbol(
                             // Today we define builtins in each module that uses them
                             // so even though they have a different module name from
                             // the surrounding module, they are not technically imported
-                            debug_assert!(symbol.is_builtin());
+                            debug_assert!(symbol.is_builtin(), "The symbol {:?} was not found and was assumed to be a builtin, but it wasn't a builtin.", symbol);
                             return;
                         }
                         AbilityMemberMustBeAvailable => {

--- a/crates/compiler/test_gen/src/gen_str.rs
+++ b/crates/compiler/test_gen/src/gen_str.rs
@@ -1371,11 +1371,11 @@ fn str_to_nat() {
     assert_evals_to!(
         indoc!(
             r#"
-            Str.toNat "1"
+            Str.toU64 "1"
             "#
         ),
         RocResult::ok(1),
-        RocResult<usize, ()>
+        RocResult<u64, ()>
     );
 }
 

--- a/crates/compiler/test_gen/src/wasm_str.rs
+++ b/crates/compiler/test_gen/src/wasm_str.rs
@@ -1029,21 +1029,6 @@ fn str_trim_end_small_to_small_shared() {
 }
 
 #[test]
-fn str_to_nat() {
-    assert_evals_to!(
-        indoc!(
-            r#"
-             when Str.toNat "1" is
-                 Ok n -> n
-                 Err _ -> 0
-                "#
-        ),
-        1,
-        usize
-    );
-}
-
-#[test]
 fn str_to_i128() {
     assert_evals_to!(
         indoc!(

--- a/examples/Community.roc
+++ b/examples/Community.roc
@@ -13,7 +13,7 @@ interface Community
 
 Community := {
     people : List Person,
-    friends : List (Set Nat),
+    friends : List (Set U64),
 }
     implements [Inspect]
 
@@ -81,4 +81,3 @@ walkFriendNames = \@Community { people, friends }, s0, nextFn ->
 
         (nextFn s1 personName friendNames, id + 1)
     out
-

--- a/examples/cli/false-interpreter/Context.roc
+++ b/examples/cli/false-interpreter/Context.roc
@@ -8,8 +8,8 @@ Option a : [Some a, None]
 Data : [Lambda (List U8), Number I32, Var Variable]
 # While loops are special and have their own Scope specific state.
 WhileState : { cond : List U8, body : List U8, state : [InCond, InBody] }
-Scope : { data : Option File.Handle, index : Nat, buf : List U8, whileInfo : Option WhileState }
-State : [Executing, InComment, InLambda Nat (List U8), InString (List U8), InNumber I32, InSpecialChar, LoadChar]
+Scope : { data : Option File.Handle, index : U64, buf : List U8, whileInfo : Option WhileState }
+State : [Executing, InComment, InLambda U64 (List U8), InString (List U8), InNumber I32, InSpecialChar, LoadChar]
 Context : { scopes : List Scope, stack : List Data, vars : List Data, state : State }
 
 pushStack : Context, Data -> Context

--- a/examples/cli/false-interpreter/Variable.roc
+++ b/examples/cli/false-interpreter/Variable.roc
@@ -6,7 +6,7 @@ interface Variable
 # This opaque type deals with ensure we always have valid variables.
 Variable := U8
 
-totalCount : Nat
+totalCount : U64
 totalCount =
     0x7A # "z"
     - 0x61 # "a"
@@ -30,7 +30,7 @@ fromUtf8 = \char ->
     else
         Err InvalidVariableUtf8
 
-toIndex : Variable -> Nat
+toIndex : Variable -> U64
 toIndex = \@Variable char ->
     Num.intCast (char - 0x61) # "a"
 # List.first (Str.toUtf8 "a")

--- a/examples/parser/Parser/CSV.roc
+++ b/examples/parser/Parser/CSV.roc
@@ -9,7 +9,7 @@ interface Parser.CSV
         parseStrToCSVRecord,
         field,
         string,
-        nat,
+        i64,
         f64,
     ]
     imports [
@@ -120,18 +120,18 @@ field = \fieldParser ->
 string : Parser CSVField Str
 string = Parser.Str.anyString
 
-## Parse a natural number from a CSV field
-nat : Parser CSVField Nat
-nat =
+## Parse a 64-bit signed integer from a CSV field
+i64 : Parser CSVField I64
+i64 =
     string
     |> map
         (\val ->
-            when Str.toNat val is
+            when Str.toI64 val is
                 Ok num ->
                     Ok num
 
                 Err _ ->
-                    Err "\(val) is not a Nat."
+                    Err "\(val) is not an I64."
         )
     |> flatten
 

--- a/examples/parser/examples/parse-movies-csv.roc
+++ b/examples/parser/examples/parse-movies-csv.roc
@@ -38,7 +38,7 @@ main =
                 SyntaxError error ->
                     "Parsing failure. Syntax error in the CSV: \(error)"
 
-MovieInfo := { title : Str, releaseYear : Nat, actors : List Str }
+MovieInfo := { title : Str, releaseYear : U64, actors : List Str }
 
 movieInfoParser =
     record (\title -> \releaseYear -> \actors -> @MovieInfo { title, releaseYear, actors })

--- a/examples/parser/examples/parse-movies-csv.roc
+++ b/examples/parser/examples/parse-movies-csv.roc
@@ -6,7 +6,7 @@ app "example"
     imports [
         parser.ParserCore.{ Parser, map, keep },
         parser.ParserStr.{ RawStr, strFromRaw },
-        parser.ParserCSV.{ CSV, record, field, string, nat, parseStr },
+        parser.ParserCSV.{ CSV, record, field, string, u64, parseStr },
     ]
     provides [main] to pf
 
@@ -43,7 +43,7 @@ MovieInfo := { title : Str, releaseYear : U64, actors : List Str }
 movieInfoParser =
     record (\title -> \releaseYear -> \actors -> @MovieInfo { title, releaseYear, actors })
     |> keep (field string)
-    |> keep (field nat)
+    |> keep (field u64)
     |> keep (field actorsParser)
 
 actorsParser =

--- a/examples/parser/package/ParserCSV.roc
+++ b/examples/parser/package/ParserCSV.roc
@@ -10,6 +10,7 @@ interface ParserCSV
         field,
         string,
         i64,
+        u64,
         f64,
     ]
     imports [
@@ -132,6 +133,21 @@ i64 =
 
                 Err _ ->
                     Err "\(val) is not an I64."
+        )
+    |> flatten
+
+## Parse a 64-bit unsigned integer from a CSV field
+u64 : Parser CSVField U64
+u64 =
+    string
+    |> map
+        (\val ->
+            when Str.toU64 val is
+                Ok num ->
+                    Ok num
+
+                Err _ ->
+                    Err "\(val) is not an U64."
         )
     |> flatten
 

--- a/examples/parser/package/ParserCSV.roc
+++ b/examples/parser/package/ParserCSV.roc
@@ -9,7 +9,7 @@ interface ParserCSV
         parseStrToCSVRecord,
         field,
         string,
-        nat,
+        i64,
         f64,
     ]
     imports [
@@ -120,18 +120,18 @@ field = \fieldParser ->
 string : Parser CSVField Str
 string = ParserStr.anyString
 
-## Parse a natural number from a CSV field
-nat : Parser CSVField Nat
-nat =
+## Parse a 64-bit signed integer from a CSV field
+i64 : Parser CSVField I64
+i64 =
     string
     |> map
         (\val ->
-            when Str.toNat val is
+            when Str.toI64 val is
                 Ok num ->
                     Ok num
 
                 Err _ ->
-                    Err "\(val) is not a Nat."
+                    Err "\(val) is not an I64."
         )
     |> flatten
 

--- a/examples/static-site-gen/platform/Html.roc
+++ b/examples/static-site-gen/platform/Html.roc
@@ -126,8 +126,8 @@ interface Html
 
 Node : [
     Text Str,
-    Element Str Nat (List Attribute) (List Node),
-    UnclosedElem Str Nat (List Attribute),
+    Element Str U64 (List Attribute) (List Node),
+    UnclosedElem Str U64 (List Attribute),
 ]
 
 Attribute : Html.Attributes.Attribute
@@ -172,7 +172,7 @@ unclosedElem = \tagName ->
         UnclosedElem tagName totalSize attrs
 
 # internal helper
-nodeSize : Node -> Nat
+nodeSize : Node -> U64
 nodeSize = \node ->
     when node is
         Text content ->

--- a/examples/virtual-dom-wip/platform/Effect.roc
+++ b/examples/virtual-dom-wip/platform/Effect.roc
@@ -29,8 +29,8 @@ hosted Effect
     generates Effect with [after, always, map]
 
 # TODO: private types
-NodeId : Nat
-HandlerId : Nat
+NodeId : U64
+HandlerId : U64
 
 # TODO: make these tag unions to avoid encoding/decoding standard names
 # but for now, this is much easier to code and debug!

--- a/examples/virtual-dom-wip/platform/Html/Internal/Client.roc
+++ b/examples/virtual-dom-wip/platform/Html/Internal/Client.roc
@@ -131,7 +131,7 @@ initClientAppHelp = \json, app ->
 # In Roc, we maintain a matching List of virtual DOM nodes with the same indices.
 # They are both initialised separately, but use the same indexing algorithm.
 # (We *could* pass this data in as JSON from the HTML file, but it would roughly double the size of that HTML file!)
-indexNodes : { nodes : List RenderedNode, siblingIds : List Nat }, Html state -> { nodes : List RenderedNode, siblingIds : List Nat }
+indexNodes : { nodes : List RenderedNode, siblingIds : List U64 }, Html state -> { nodes : List RenderedNode, siblingIds : List U64 }
 indexNodes = \{ nodes, siblingIds }, unrendered ->
     when unrendered is
         Text content ->
@@ -667,11 +667,11 @@ expect
     html =
         Element "a" 43 [HtmlAttr "href" "https://www.roc-lang.org/"] [Text "Roc"]
 
-    actual : { nodes : List RenderedNode, siblingIds : List Nat }
+    actual : { nodes : List RenderedNode, siblingIds : List U64 }
     actual =
         indexNodes { nodes: [], siblingIds: [] } html
 
-    expected : { nodes : List RenderedNode, siblingIds : List Nat }
+    expected : { nodes : List RenderedNode, siblingIds : List U64 }
     expected = {
         nodes: [
             RenderedText "Roc",

--- a/examples/virtual-dom-wip/platform/Html/Internal/Shared.roc
+++ b/examples/virtual-dom-wip/platform/Html/Internal/Shared.roc
@@ -32,7 +32,7 @@ Html state : [
 ]
 
 # The pre-calculated byte size of the rendered HTML string
-Size : Nat
+Size : U64
 
 Attribute state : [
     EventListener Str (List CyclicStructureAccessor) (Handler state),
@@ -74,14 +74,14 @@ text = \content -> Text content
 none : Html state
 none = None
 
-nodeSize : Html state -> Nat
+nodeSize : Html state -> U64
 nodeSize = \node ->
     when node is
         Text content -> Str.countUtf8Bytes content
         Element _ size _ _ -> size
         None -> 0
 
-attrSize : Attribute state -> Nat
+attrSize : Attribute state -> U64
 attrSize = \attr ->
     when attr is
         EventListener _ _ _ -> 0

--- a/examples/virtual-dom-wip/platform/client-side.roc
+++ b/examples/virtual-dom-wip/platform/client-side.roc
@@ -11,7 +11,7 @@ platform "client-side"
 
 # Fields sorted by alignment, then alphabetically
 FromHost state initData : {
-    eventHandlerId : Nat,
+    eventHandlerId : U64,
     eventJsonList : List (List U8),
     eventPlatformState : Box (PlatformState state initData),
     initJson : List U8,

--- a/examples/virtual-dom-wip/platform/src/client-side/host.zig
+++ b/examples/virtual-dom-wip/platform/src/client-side/host.zig
@@ -54,7 +54,7 @@ const RocList = extern struct {
 };
 
 const FromHost = extern struct {
-    eventHandlerId: usize,
+    eventHandlerId: u64,
     eventJsonList: ?RocList,
     eventPlatformState: ?*anyopaque,
     initJson: RocList,
@@ -79,7 +79,7 @@ export fn roc_vdom_init(init_pointer: ?[*]u8, init_length: usize, init_capacity:
         .capacity = init_capacity,
     };
     const from_host = FromHost{
-        .eventHandlerId = std.math.maxInt(usize),
+        .eventHandlerId = std.math.maxInt(u64),
         .eventJsonList = null,
         .eventPlatformState = null,
         .initJson = init_json,
@@ -90,7 +90,7 @@ export fn roc_vdom_init(init_pointer: ?[*]u8, init_length: usize, init_capacity:
 }
 
 // Called from JS
-export fn roc_dispatch_event(list_ptr: ?[*]u8, list_length: usize, handler_id: usize) usize {
+export fn roc_dispatch_event(list_ptr: ?[*]u8, list_length: usize, handler_id: u64) usize {
     const json_list = RocList{
         .bytes = list_ptr,
         .length = list_length,


### PR DESCRIPTION
To reproduce, go to the commit before 3ee8a1c306317e42ac0701b2f5922d7677549581 (linking to that commit because it nicely illustrates the fix) and run:

```
cargo run -- check examples/parser/examples/parse-movies-csv.roc
```

The problem is that `nat` is not exposed at all from that module.