### PR TITLE
Highlight after special-casing repl snippets

### DIFF
--- a/crates/highlight/src/lib.rs
+++ b/crates/highlight/src/lib.rs
@@ -14,7 +14,6 @@ pub fn highlight_roc_code_inline(code: &str) -> String {
 }
 
 pub fn highlight(code: &str) -> Vec<String> {
-    let locations: Vec<Loc<Token>> = roc_parse::highlight::highlight(code);
     let mut buf: Vec<String> = Vec::new();
     let mut offset = 0;
 
@@ -29,8 +28,8 @@ pub fn highlight(code: &str) -> Vec<String> {
     } else {
         code
     };
-
-    for location in locations {
+    
+    for location in roc_parse::highlight::highlight(code) {
         let current_text = &code[offset..location.byte_range().end];
 
         match location.value {

--- a/crates/highlight/src/lib.rs
+++ b/crates/highlight/src/lib.rs
@@ -28,7 +28,7 @@ pub fn highlight(code: &str) -> Vec<String> {
     } else {
         code
     };
-    
+
     for location in roc_parse::highlight::highlight(code) {
         let current_text = &code[offset..location.byte_range().end];
 

--- a/crates/highlight/src/lib.rs
+++ b/crates/highlight/src/lib.rs
@@ -1,5 +1,4 @@
 use roc_parse::highlight::Token;
-use roc_region::all::Loc;
 
 pub fn highlight_roc_code(code: &str) -> String {
     let buf = highlight(code);


### PR DESCRIPTION
This should fix repl snippets in docs (code snippets beginning with `»`) rendering empty after the `»` prompt.