### PR TITLE
Prevent roc format from reading $PWD when --stdin or --stdout options given

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -266,7 +266,7 @@ pub fn build_app() -> Command {
             .arg(args_for_app.clone().last(true))
         )
         .subcommand(Command::new(CMD_FORMAT)
-            .about("Format a .roc file using standard Roc formatting")
+            .about("Format a .roc file or the .roc files contained in a directory using standard\nRoc formatting")
             .arg(
                 Arg::new(DIRECTORY_OR_FILES)
                     .index(1)
@@ -294,6 +294,7 @@ pub fn build_app() -> Command {
                     .action(ArgAction::SetTrue)
                     .required(false),
             )
+            .after_help("If DIRECTORY_OR_FILES is omitted, the .roc files in the current working\ndirectory are formatted.")
         )
         .subcommand(Command::new(CMD_VERSION)
             .about(concatcp!("Print the Roc compiler’s version, which is currently ", VERSION)))

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -287,6 +287,7 @@ fn main() -> io::Result<()> {
                             values.push(os_string.to_owned());
                         }
                     }
+                    None if from_stdin || to_stdout => {}
                     None => {
                         let mut os_string_values: Vec<OsString> = Vec::new();
 


### PR DESCRIPTION
Closes #6419

If the file or directory to be formatted is not given on the `roc format` command line, the formatter assumes that the current working directory should be formatted. 

This pull request prevents this behavior if the ` --stdin` or `--stdout` options of the ` roc format`  command are present, 

This pull request also explains that `DIRECTORY_OR_FILES` defaults to the current working directory if missing on the command line.