### PR TITLE
add `--fuzz` option to roc

### DIFF
--- a/crates/compiler/build/src/program.rs
+++ b/crates/compiler/build/src/program.rs
@@ -86,6 +86,7 @@ pub struct CodeGenOptions {
     pub opt_level: OptLevel,
     pub emit_debug_info: bool,
     pub emit_llvm_ir: bool,
+    pub fuzz: bool,
 }
 
 type GenFromMono<'a> = (CodeObject, CodeGenTiming, ExpectMetadata<'a>);
@@ -103,6 +104,7 @@ pub fn gen_from_mono_module<'a>(
     let path = roc_file_path;
     let debug = code_gen_options.emit_debug_info;
     let emit_llvm_ir = code_gen_options.emit_llvm_ir;
+    let fuzz = code_gen_options.fuzz;
     let opt = code_gen_options.opt_level;
 
     match code_gen_options.backend {
@@ -131,6 +133,7 @@ pub fn gen_from_mono_module<'a>(
             backend_mode,
             debug,
             emit_llvm_ir,
+            fuzz,
         ),
     }
 }
@@ -148,6 +151,7 @@ fn gen_from_mono_module_llvm<'a>(
     backend_mode: LlvmBackendMode,
     emit_debug_info: bool,
     emit_llvm_ir: bool,
+    fuzz: bool,
 ) -> GenFromMono<'a> {
     use crate::target::{self, convert_opt_level};
     use inkwell::attributes::{Attribute, AttributeLoc};
@@ -284,7 +288,8 @@ fn gen_from_mono_module_llvm<'a>(
 
     // annotate the LLVM IR output with debug info
     // so errors are reported with the line number of the LLVM source
-    let memory_buffer = if cfg!(feature = "sanitizers") && std::env::var("ROC_SANITIZERS").is_ok() {
+    let gen_sanitizers = cfg!(feature = "sanitizers") && std::env::var("ROC_SANITIZERS").is_ok();
+    let memory_buffer = if fuzz || gen_sanitizers {
         let dir = tempfile::tempdir().unwrap();
         let dir = dir.into_path();
 
@@ -301,33 +306,27 @@ fn gen_from_mono_module_llvm<'a>(
         let mut passes = vec![];
         let mut extra_args = vec![];
         let mut unrecognized = vec![];
-        for sanitizer in std::env::var("ROC_SANITIZERS")
-            .unwrap()
-            .split(',')
-            .map(|x| x.trim())
-        {
-            match sanitizer {
-                "address" => passes.push("asan-module"),
-                "memory" => passes.push("msan-module"),
-                "thread" => passes.push("tsan-module"),
-                "cargo-fuzz" => {
-                    passes.push("sancov-module");
-                    extra_args.extend_from_slice(&[
-                        "-sanitizer-coverage-level=3",
-                        "-sanitizer-coverage-prune-blocks=0",
-                        "-sanitizer-coverage-inline-8bit-counters",
-                        "-sanitizer-coverage-pc-table",
-                    ]);
+        if fuzz {
+            passes.push("sancov-module");
+            extra_args.extend_from_slice(&[
+                "-sanitizer-coverage-level=4",
+                "-sanitizer-coverage-inline-8bit-counters",
+                "-sanitizer-coverage-pc-table",
+                "-sanitizer-coverage-trace-compares",
+            ]);
+        }
+        if gen_sanitizers {
+            for sanitizer in std::env::var("ROC_SANITIZERS")
+                .unwrap()
+                .split(',')
+                .map(|x| x.trim())
+            {
+                match sanitizer {
+                    "address" => passes.push("asan-module"),
+                    "memory" => passes.push("msan-module"),
+                    "thread" => passes.push("tsan-module"),
+                    x => unrecognized.push(x.to_owned()),
                 }
-                "afl.rs" => {
-                    passes.push("sancov-module");
-                    extra_args.extend_from_slice(&[
-                        "-sanitizer-coverage-level=3",
-                        "-sanitizer-coverage-prune-blocks=0",
-                        "-sanitizer-coverage-trace-pc-guard",
-                    ]);
-                }
-                x => unrecognized.push(x.to_owned()),
             }
         }
         if !unrecognized.is_empty() {
@@ -1291,6 +1290,7 @@ pub fn build_str_test<'a>(
         opt_level: OptLevel::Normal,
         emit_debug_info: false,
         emit_llvm_ir: false,
+        fuzz: false,
     };
 
     let emit_timings = false;

--- a/crates/glue/src/load.rs
+++ b/crates/glue/src/load.rs
@@ -57,6 +57,7 @@ pub fn generate(
                 opt_level: OptLevel::Development,
                 emit_debug_info: false,
                 emit_llvm_ir: false,
+                fuzz: false,
             };
 
             let load_config = standard_load_config(


### PR DESCRIPTION
@rtfeldman totally understand if this is consider too immature of a use case to be worth adding, but I am trying to enable a nice fuzz testing experience in Roc. I totally restarted by `roc-fuzz` platform and I think it can become a really nice experience for package authors, but it requires some sort of `--fuzz` flag to instrument the roc code.

I have a prototype that now works on mac as a prebuilt-platform. So I am pretty sure I will be able to bundle of this and distribute as a standard platform. The end user would just write a fuzz target and run: `ROC_LINK_FLAGS="-lc++" roc run fuzz-target.roc --fuzz -- fuzz`

Targets are a work in progress, but currently they look like this:
```elm
target : Target (List U8, U8)
target = {
    name: "my target",
    generator,
    test,
}

generator : Generator (List U8, U8)
generator =
    bytes <- Arbitrary.bytes |> andThen
    n <- Arbitrary.u8 |> andThen
    Arbitrary.value (bytes, n)

test : (List U8, U8) -> Status
test = \data ->
    when data is
        (['F', 'U', 'Z', 'Z', ..], 42) ->
            crash "this should be impossible"

        (['Q', ..], _) ->
            # All cases that start with 'Q' are invalid. Ignore them.
            Ignore

        _ ->
            Success
```