### PR TITLE
Fix syntax errors from RustGlue's tag generated code

### DIFF
--- a/crates/glue/src/RustGlue.roc
+++ b/crates/glue/src/RustGlue.roc
@@ -167,7 +167,7 @@ generateEntryPoint = \buf, types, name, id ->
                 when Types.shape types rocFn.ret is
                     Function _ ->
                         ("(_: *mut u8, \(arguments))", ret, Bool.true)
-                    _ -> 
+                    _ ->
                         ("(_: *mut \(ret), \(arguments))", ret, Bool.false)
 
             _ ->
@@ -1605,7 +1605,7 @@ generateMultiElementSingleTagStruct = \buf, types, name, tagName, payloadFields,
         }
     |> \{ b, args, fields, fieldTypes, fieldAccesses } ->
         argsStr = Str.joinWith args ", "
-        fieldsStr = Str.joinWith fields "\n\(indent)\(indent)\(indent)"
+        fieldsStr = Str.joinWith fields ",\n\(indent)\(indent)\(indent)"
 
         {
             b: Str.concat


### PR DESCRIPTION
```rs
    /// A tag named ``DirReadErr``, with the given payload.
    pub fn DirReadErr(f0: UnwrappedPath, f1: roc_std::RocStr) -> Self {
        Self {
            f0
            f1
        }
    }
```
becomes
```rs
    /// A tag named ``DirReadErr``, with the given payload.
    pub fn DirReadErr(f0: UnwrappedPath, f1: roc_std::RocStr) -> Self {
        Self {
            f0,
            f1
        }
    }
```