### PR TITLE
support .a archives in bundling

### DIFF
--- a/crates/packaging/src/tarball.rs
+++ b/crates/packaging/src/tarball.rs
@@ -156,6 +156,7 @@ fn write_archive<W: Write>(path: &Path, writer: W) -> io::Result<()> {
                     Some("rm"),
                     // legacy linker formats
                     Some("o"),
+                    Some("a"),
                     Some("obj"),
                     Some("wasm"),
                     // optimized wasm builds compile to .zig for now,


### PR DESCRIPTION
They are also a supported format for the legacy linker.