### PR TITLE
Dev backend glue primitives

### DIFF
--- a/crates/compiler/builtins/bitcode/src/main.zig
+++ b/crates/compiler/builtins/bitcode/src/main.zig
@@ -122,6 +122,9 @@ comptime {
         num.exportCeiling(f32, T, ROC_BUILTINS ++ "." ++ NUM ++ ".ceiling_f32.");
         num.exportCeiling(f64, T, ROC_BUILTINS ++ "." ++ NUM ++ ".ceiling_f64.");
 
+        num.exportNumToFloatCast(T, f32, ROC_BUILTINS ++ "." ++ NUM ++ ".num_to_float_cast_f32.");
+        num.exportNumToFloatCast(T, f64, ROC_BUILTINS ++ "." ++ NUM ++ ".num_to_float_cast_f64.");
+
         num.exportAddWithOverflow(T, ROC_BUILTINS ++ "." ++ NUM ++ ".add_with_overflow.");
         num.exportAddOrPanic(T, ROC_BUILTINS ++ "." ++ NUM ++ ".add_or_panic.");
         num.exportAddSaturatedInt(T, ROC_BUILTINS ++ "." ++ NUM ++ ".add_saturated.");

--- a/crates/compiler/builtins/bitcode/src/num.zig
+++ b/crates/compiler/builtins/bitcode/src/num.zig
@@ -86,6 +86,15 @@ pub fn exportParseFloat(comptime T: type, comptime name: []const u8) void {
     @export(f, .{ .name = name ++ @typeName(T), .linkage = .Strong });
 }
 
+pub fn exportNumToFloatCast(comptime T: type, comptime F: type, comptime name: []const u8) void {
+    comptime var f = struct {
+        fn func(x: T) callconv(.C) F {
+            return @floatFromInt(x);
+        }
+    }.func;
+    @export(f, .{ .name = name ++ @typeName(T), .linkage = .Strong });
+}
+
 pub fn exportPow(comptime T: type, comptime name: []const u8) void {
     comptime var f = struct {
         fn func(base: T, exp: T) callconv(.C) T {

--- a/crates/compiler/builtins/src/bitcode.rs
+++ b/crates/compiler/builtins/src/bitcode.rs
@@ -292,6 +292,10 @@ pub const NUM_FLOOR_F32: IntrinsicName = int_intrinsic!("roc_builtins.num.floor_
 pub const NUM_FLOOR_F64: IntrinsicName = int_intrinsic!("roc_builtins.num.floor_f64");
 pub const NUM_ROUND_F32: IntrinsicName = int_intrinsic!("roc_builtins.num.round_f32");
 pub const NUM_ROUND_F64: IntrinsicName = int_intrinsic!("roc_builtins.num.round_f64");
+pub const INT_TO_FLOAT_CAST_F32: IntrinsicName =
+    int_intrinsic!("roc_builtins.num.num_to_float_cast_f32");
+pub const INT_TO_FLOAT_CAST_F64: IntrinsicName =
+    int_intrinsic!("roc_builtins.num.num_to_float_cast_f64");
 
 pub const NUM_ADD_OR_PANIC_INT: IntrinsicName = int_intrinsic!("roc_builtins.num.add_or_panic");
 pub const NUM_ADD_SATURATED_INT: IntrinsicName = int_intrinsic!("roc_builtins.num.add_saturated");

--- a/crates/compiler/gen_dev/src/generic64/aarch64.rs
+++ b/crates/compiler/gen_dev/src/generic64/aarch64.rs
@@ -1669,6 +1669,11 @@ impl Assembler<AArch64GeneralReg, AArch64FloatReg> for AArch64Assembler {
     }
 
     #[inline(always)]
+    fn mov_freg32_base32(buf: &mut Vec<'_, u8>, dst: AArch64FloatReg, offset: i32) {
+        Self::mov_freg32_mem32_offset32(buf, dst, AArch64GeneralReg::FP, offset)
+    }
+
+    #[inline(always)]
     fn mov_reg_mem_offset32(
         buf: &mut Vec<'_, u8>,
         register_width: RegisterWidth,

--- a/crates/compiler/gen_dev/src/generic64/mod.rs
+++ b/crates/compiler/gen_dev/src/generic64/mod.rs
@@ -5002,38 +5002,50 @@ impl<
     }
 
     fn num_to_f32(&mut self, dst: &Symbol, src: &Symbol, arg_layout: &InLayout<'a>) {
-        let dst_reg = self.storage_manager.claim_float_reg(&mut self.buf, dst);
         match self.layout_interner.get_repr(*arg_layout) {
             LayoutRepr::Builtin(Builtin::Int(IntWidth::I32 | IntWidth::I64)) => {
+                let dst_reg = self.storage_manager.claim_float_reg(&mut self.buf, dst);
                 let src_reg = self.storage_manager.load_to_general_reg(&mut self.buf, src);
                 ASM::to_float_freg32_reg64(&mut self.buf, dst_reg, src_reg);
             }
             LayoutRepr::Builtin(Builtin::Float(FloatWidth::F64)) => {
+                let dst_reg = self.storage_manager.claim_float_reg(&mut self.buf, dst);
                 let src_reg = self.storage_manager.load_to_float_reg(&mut self.buf, src);
                 ASM::to_float_freg32_freg64(&mut self.buf, dst_reg, src_reg);
             }
             LayoutRepr::Builtin(Builtin::Float(FloatWidth::F32)) => {
+                let dst_reg = self.storage_manager.claim_float_reg(&mut self.buf, dst);
                 let src_reg = self.storage_manager.load_to_float_reg(&mut self.buf, src);
                 ASM::mov_freg64_freg64(&mut self.buf, dst_reg, src_reg);
+            }
+            LayoutRepr::Builtin(Builtin::Int(_)) => {
+                let int_width = arg_layout.to_int_width();
+                self.build_int_to_float_cast(dst, src, int_width, FloatWidth::F32);
             }
             arg => todo!("NumToFrac: layout, arg {arg:?}, ret {:?}", Layout::F32),
         }
     }
 
     fn num_to_f64(&mut self, dst: &Symbol, src: &Symbol, arg_layout: &InLayout<'a>) {
-        let dst_reg = self.storage_manager.claim_float_reg(&mut self.buf, dst);
         match self.layout_interner.get_repr(*arg_layout) {
             LayoutRepr::Builtin(Builtin::Int(IntWidth::I32 | IntWidth::I64)) => {
+                let dst_reg = self.storage_manager.claim_float_reg(&mut self.buf, dst);
                 let src_reg = self.storage_manager.load_to_general_reg(&mut self.buf, src);
                 ASM::to_float_freg64_reg64(&mut self.buf, dst_reg, src_reg);
             }
             LayoutRepr::Builtin(Builtin::Float(FloatWidth::F32)) => {
+                let dst_reg = self.storage_manager.claim_float_reg(&mut self.buf, dst);
                 let src_reg = self.storage_manager.load_to_float_reg(&mut self.buf, src);
                 ASM::to_float_freg64_freg32(&mut self.buf, dst_reg, src_reg);
             }
             LayoutRepr::Builtin(Builtin::Float(FloatWidth::F64)) => {
+                let dst_reg = self.storage_manager.claim_float_reg(&mut self.buf, dst);
                 let src_reg = self.storage_manager.load_to_float_reg(&mut self.buf, src);
                 ASM::mov_freg64_freg64(&mut self.buf, dst_reg, src_reg);
+            }
+            LayoutRepr::Builtin(Builtin::Int(_)) => {
+                let int_width = arg_layout.to_int_width();
+                self.build_int_to_float_cast(dst, src, int_width, FloatWidth::F64);
             }
             arg => todo!("NumToFrac: layout, arg {arg:?}, ret {:?}", Layout::F64),
         }

--- a/crates/compiler/gen_dev/src/generic64/mod.rs
+++ b/crates/compiler/gen_dev/src/generic64/mod.rs
@@ -358,6 +358,7 @@ pub trait Assembler<GeneralReg: RegTrait, FloatReg: RegTrait>: Sized + Copy {
 
     // base32 is similar to stack based instructions but they reference the base/frame pointer.
     fn mov_freg64_base32(buf: &mut Vec<'_, u8>, dst: FloatReg, offset: i32);
+    fn mov_freg32_base32(buf: &mut Vec<'_, u8>, dst: FloatReg, offset: i32);
 
     fn mov_reg_base32(
         buf: &mut Vec<'_, u8>,
@@ -2150,6 +2151,30 @@ impl<
                     }
                     _ => unreachable!(),
                 }
+            },
+        );
+    }
+
+    fn build_int_to_float_cast(
+        &mut self,
+        dst: &Symbol,
+        src: &Symbol,
+        int_width: IntWidth,
+        float_width: FloatWidth,
+    ) {
+        use roc_builtins::bitcode::{INT_TO_FLOAT_CAST_F32, INT_TO_FLOAT_CAST_F64};
+
+        self.build_fn_call(
+            dst,
+            match float_width {
+                FloatWidth::F32 => INT_TO_FLOAT_CAST_F32[int_width].to_string(),
+                FloatWidth::F64 => INT_TO_FLOAT_CAST_F64[int_width].to_string(),
+            },
+            &[*src],
+            &[Layout::from_int_width(int_width)],
+            match float_width {
+                FloatWidth::F32 => &Layout::F32,
+                FloatWidth::F64 => &Layout::F64,
             },
         );
     }

--- a/crates/compiler/gen_dev/src/generic64/x86_64.rs
+++ b/crates/compiler/gen_dev/src/generic64/x86_64.rs
@@ -2434,6 +2434,11 @@ impl Assembler<X86_64GeneralReg, X86_64FloatReg> for X86_64Assembler {
     }
 
     #[inline(always)]
+    fn mov_freg32_base32(buf: &mut Vec<'_, u8>, dst: X86_64FloatReg, offset: i32) {
+        movss_freg32_base32_offset32(buf, dst, X86_64GeneralReg::RBP, offset)
+    }
+
+    #[inline(always)]
     fn mov_reg_base32(
         buf: &mut Vec<'_, u8>,
         register_width: RegisterWidth,

--- a/crates/compiler/gen_dev/src/lib.rs
+++ b/crates/compiler/gen_dev/src/lib.rs
@@ -2019,6 +2019,24 @@ trait Backend<'a> {
                 self.build_num_cmp(sym, &args[0], &args[1], &arg_layouts[0]);
             }
 
+            LowLevel::NumToFloatCast => {
+                let float_width = match *ret_layout {
+                    Layout::F64 => FloatWidth::F64,
+                    Layout::F32 => FloatWidth::F32,
+                    _ => unreachable!("invalid return layout for NumToFloatCast"),
+                };
+
+                match arg_layouts[0].try_to_int_width() {
+                    Some(int_width) => {
+                        self.build_int_to_float_cast(sym, &args[0], int_width, float_width);
+                    }
+                    None => {
+                        //
+                        todo!("other NumToFloatCast cases");
+                    }
+                }
+            }
+
             x => todo!("low level, {:?}", x),
         }
     }
@@ -2133,6 +2151,14 @@ trait Backend<'a> {
         src: &Symbol,
         source: IntWidth,
         target: IntWidth,
+    );
+
+    fn build_int_to_float_cast(
+        &mut self,
+        dst: &Symbol,
+        src: &Symbol,
+        int_width: IntWidth,
+        float_width: FloatWidth,
     );
 
     /// build_num_abs stores the absolute value of src into dst.

--- a/crates/compiler/gen_dev/src/lib.rs
+++ b/crates/compiler/gen_dev/src/lib.rs
@@ -2031,8 +2031,7 @@ trait Backend<'a> {
                         self.build_int_to_float_cast(sym, &args[0], int_width, float_width);
                     }
                     None => {
-                        //
-                        todo!("other NumToFloatCast cases");
+                        self.build_num_to_frac(sym, &args[0], &arg_layouts[0], ret_layout);
                     }
                 }
             }

--- a/crates/compiler/mono/src/layout/intern.rs
+++ b/crates/compiler/mono/src/layout/intern.rs
@@ -103,6 +103,13 @@ macro_rules! impl_to_from_int_width {
                     _ => roc_error_macros::internal_error!("not an integer layout!")
                 }
             }
+
+            pub fn try_to_int_width(&self) -> Option<IntWidth> {
+                match self {
+                    $(&$layout => Some($int_width),)*
+                    _ => None,
+                }
+            }
         }
     };
 }

--- a/crates/compiler/test_gen/src/gen_num.rs
+++ b/crates/compiler/test_gen/src/gen_num.rs
@@ -2333,34 +2333,34 @@ num_conversion_tests! {
         to_nat_truncate, "115i128", 115
     )
     "Num.toF32", f32, (
-        to_f32_from_i8, "15i8", 15.0
-        to_f32_from_i16, "15i16", 15.0
-        to_f32_from_i32, "15i32", 15.0
-        to_f32_from_i64, "15i64", 15.0
-        to_f32_from_i128, "15i128", 15.0
-        to_f32_from_u8, "15u8", 15.0
-        to_f32_from_u16, "15u16", 15.0
-        to_f32_from_u32, "15u32", 15.0
-        to_f32_from_u64, "15u64", 15.0
-        to_f32_from_u128, "15u128", 15.0
-        to_f32_from_nat, "15nat", 15.0
-        to_f32_from_f32, "1.5f32", 1.5
-        to_f32_from_f64, "1.5f64", 1.5
+        to_f32_from_i8, "15i8", 15.0, ["gen-wasm", "gen-dev"]
+        to_f32_from_i16, "15i16", 15.0, ["gen-wasm", "gen-dev"]
+        to_f32_from_i32, "15i32", 15.0, ["gen-wasm", "gen-dev"]
+        to_f32_from_i64, "15i64", 15.0, ["gen-wasm", "gen-dev"]
+        to_f32_from_i128, "15i128", 15.0, ["gen-dev"]
+        to_f32_from_u8, "15u8", 15.0, ["gen-wasm", "gen-dev"]
+        to_f32_from_u16, "15u16", 15.0, ["gen-wasm", "gen-dev"]
+        to_f32_from_u32, "15u32", 15.0, ["gen-wasm", "gen-dev"]
+        to_f32_from_u64, "15u64", 15.0, ["gen-wasm", "gen-dev"]
+        to_f32_from_u128, "15u128", 15.0, ["gen-dev"]
+        to_f32_from_nat, "15nat", 15.0, ["gen-wasm", "gen-dev"]
+        to_f32_from_f32, "1.5f32", 1.5, ["gen-wasm", "gen-dev"]
+        to_f32_from_f64, "1.5f64", 1.5, ["gen-wasm", "gen-dev"]
     )
     "Num.toF64", f64, (
-        to_f64_from_i8, "15i8", 15.0
-        to_f64_from_i16, "15i16", 15.0
-        to_f64_from_i32, "15i32", 15.0
-        to_f64_from_i64, "15i64", 15.0
-        to_f64_from_i128, "15i128", 15.0
-        to_f64_from_u8, "15u8", 15.0
-        to_f64_from_u16, "15u16", 15.0
-        to_f64_from_u32, "15u32", 15.0
-        to_f64_from_u64, "15u64", 15.0
-        to_f64_from_u128, "15u128", 15.0
-        to_f64_from_nat, "15nat", 15.0
-        to_f64_from_f32, "1.5f32", 1.5
-        to_f64_from_f64, "1.5f64", 1.5
+        to_f64_from_i8, "15i8", 15.0, ["gen-wasm", "gen-dev"]
+        to_f64_from_i16, "15i16", 15.0, ["gen-wasm", "gen-dev"]
+        to_f64_from_i32, "15i32", 15.0, ["gen-wasm", "gen-dev"]
+        to_f64_from_i64, "15i64", 15.0, ["gen-wasm", "gen-dev"]
+        to_f64_from_i128, "15i128", 15.0, ["gen-dev"]
+        to_f64_from_u8, "15u8", 15.0, ["gen-wasm", "gen-dev"]
+        to_f64_from_u16, "15u16", 15.0, ["gen-wasm", "gen-dev"]
+        to_f64_from_u32, "15u32", 15.0, ["gen-wasm", "gen-dev"]
+        to_f64_from_u64, "15u64", 15.0, ["gen-wasm", "gen-dev"]
+        to_f64_from_u128, "15u128", 15.0, ["gen-dev"]
+        to_f64_from_nat, "15nat", 15.0, ["gen-wasm", "gen-dev"]
+        to_f64_from_f32, "1.5f32", 1.5, ["gen-dev"]
+        to_f64_from_f64, "1.5f64", 1.5, ["gen-wasm", "gen-dev"]
     )
 }
 
@@ -3434,7 +3434,7 @@ fn monomorphized_ints_aliased() {
 }
 
 #[test]
-#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm", feature = "gen-dev"))]
 fn to_float_f32() {
     assert_evals_to!(
         indoc!(
@@ -3453,7 +3453,7 @@ fn to_float_f32() {
 }
 
 #[test]
-#[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm", feature = "gen-dev"))]
 fn to_float_f64() {
     assert_evals_to!(
         indoc!(


### PR DESCRIPTION
fixes #6348

some implementations needed to run glue with the `--dev` flag. That still does not work, so some glue-specific stuff will follow in a later PR.