### PR TITLE
Update GitHub Action step versions (#6428)

### DIFF
--- a/.github/workflows/basic_cli_build_release.yml
+++ b/.github/workflows/basic_cli_build_release.yml
@@ -51,7 +51,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Download the previously uploaded roc_nightly archives
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
 
       - name: build basic-cli with surgical linker and also with legacy linker
         env:
@@ -75,7 +75,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Download the previously uploaded roc_nightly archives
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
 
       - name: build basic-cli
         env:
@@ -99,7 +99,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Download the previously uploaded roc_nightly archives
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
 
       - run: ./ci/build_basic_cli.sh macos_x86_64
 
@@ -118,7 +118,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Download the previously uploaded roc_nightly archives
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
 
       - run: ./ci/build_basic_cli.sh macos_apple_silicon
 
@@ -140,7 +140,7 @@ jobs:
         run: ls | grep -v  ci | xargs rm -rf
 
       - name: Download the previously uploaded files
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
 
       - name: mv roc nightly and simplify name
         run: mv $(ls -d artifact/* | grep "roc_nightly.*tar\.gz" | grep "linux_x86_64") ./roc_nightly.tar.gz
@@ -196,7 +196,7 @@ jobs:
     steps:
 
       - name: Download the previously uploaded files
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
 
       - name: mv roc nightly and simplify name
         run: mv $(ls -d artifact/* | grep "roc_nightly.*tar\.gz" | grep "linux_x86_64") ./roc_nightly.tar.gz

--- a/.github/workflows/basic_cli_build_release.yml
+++ b/.github/workflows/basic_cli_build_release.yml
@@ -6,7 +6,7 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-  
+
 env:
   # use .tar.gz for quick testing
   ARCHIVE_FORMAT: .tar.br
@@ -17,7 +17,7 @@ jobs:
   prepare:
     runs-on: [ubuntu-20.04]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           repository: roc-lang/basic-cli
 
@@ -40,7 +40,7 @@ jobs:
       - run: curl -fOL https://github.com/roc-lang/roc/releases/download/nightly/roc_nightly-macos_apple_silicon-latest.tar.gz
 
       - name: Save roc_nightly archives
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           path:  roc_nightly-*
 
@@ -48,7 +48,7 @@ jobs:
     runs-on: [ubuntu-20.04]
     needs: [prepare]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Download the previously uploaded roc_nightly archives
         uses: actions/download-artifact@v3
@@ -58,8 +58,8 @@ jobs:
           CARGO_BUILD_TARGET: x86_64-unknown-linux-musl
         run: ./ci/build_basic_cli.sh linux_x86_64 "--linker legacy"
 
-      - name: Save .rh, .rm and .o file 
-        uses: actions/upload-artifact@v3
+      - name: Save .rh, .rm and .o file
+        uses: actions/upload-artifact@v4
         with:
           name: linux-x86_64-files
           path: |
@@ -72,7 +72,7 @@ jobs:
     runs-on: [self-hosted, Linux, ARM64]
     needs: [prepare]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Download the previously uploaded roc_nightly archives
         uses: actions/download-artifact@v3
@@ -85,8 +85,8 @@ jobs:
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_RUSTFLAGS: "-Clink-self-contained=yes -Clinker=rust-lld"
         run: ./ci/build_basic_cli.sh linux_arm64
 
-      - name: Save .o file 
-        uses: actions/upload-artifact@v3
+      - name: Save .o file
+        uses: actions/upload-artifact@v4
         with:
           name: linux-arm64-files
           path: |
@@ -96,7 +96,7 @@ jobs:
     runs-on: [macos-11] # I expect the generated files to work on macOS 12 and up
     needs: [prepare]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Download the previously uploaded roc_nightly archives
         uses: actions/download-artifact@v3
@@ -104,7 +104,7 @@ jobs:
       - run: ./ci/build_basic_cli.sh macos_x86_64
 
       - name: Save .o files
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: macos-x86_64-files
           path: |
@@ -115,7 +115,7 @@ jobs:
     runs-on: [self-hosted, macOS, ARM64]
     needs: [prepare]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Download the previously uploaded roc_nightly archives
         uses: actions/download-artifact@v3
@@ -123,7 +123,7 @@ jobs:
       - run: ./ci/build_basic_cli.sh macos_apple_silicon
 
       - name: Save macos-arm64.o file
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: macos-apple-silicon-files
           path: |
@@ -134,7 +134,7 @@ jobs:
     name: create release archive
     runs-on: [ubuntu-20.04]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: remove all folders except the ci folder
         run: ls | grep -v  ci | xargs rm -rf
@@ -157,7 +157,7 @@ jobs:
       - run: git clone https://github.com/roc-lang/basic-cli.git
 
       - run: cp macos-apple-silicon-files/* ./basic-cli/platform
-      
+
       - run: cp linux-x86_64-files/* ./basic-cli/platform
 
       - run: cp linux-arm64-files/* ./basic-cli/platform
@@ -177,14 +177,14 @@ jobs:
       - run: echo "TAR_FILENAME=$(ls -d basic-cli/platform/* | grep ${{ env.ARCHIVE_FORMAT }})" >> $GITHUB_ENV
 
       - name: Upload platform archive
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: basic-cli-platform
           path: |
             ${{ env.TAR_FILENAME }}
 
       - name: Upload docs archive
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: release-assets-docs
           path: |
@@ -232,7 +232,7 @@ jobs:
           mkdir platform
           # move all files to platform dir
           find . -maxdepth 1 -type f -exec mv {} platform/ \;
-          
+
           mkdir temp-basic-cli
           cd temp-basic-cli
           git clone https://github.com/roc-lang/basic-cli.git
@@ -242,9 +242,8 @@ jobs:
           cp -r ci ../..
           cp -r LICENSE ../..
           # LICENSE is necessary for command test
-          
+
       - name: run tests
         run: |
           cd basic-cli-platform
           ROC=./roc_nightly/roc EXAMPLES_DIR=./examples/ ROC_BUILD_FLAGS=--prebuilt-platform ./ci/all_tests.sh
-

--- a/.github/workflows/basic_cli_test_arm64.yml
+++ b/.github/workflows/basic_cli_test_arm64.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: [self-hosted, Linux, ARM64]
     steps:
       - name: clone basic-cli repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: roc-lang/basic-cli
           ref: main
@@ -19,7 +19,7 @@ jobs:
       - name: get latest roc nightly
         run: |
           curl -fOL https://github.com/roc-lang/roc/releases/download/nightly/roc_nightly-linux_arm64-latest.tar.gz
-  
+
       - name: rename nightly tar
         run: mv $(ls | grep "roc_nightly.*tar\.gz") roc_nightly.tar.gz
 
@@ -35,7 +35,7 @@ jobs:
 
       - run: expect -v
 
-      # Run all tests 
+      # Run all tests
       - run: ROC=./roc_nightly/roc EXAMPLES_DIR=./examples/ ./ci/all_tests.sh
 
       ######
@@ -44,7 +44,7 @@ jobs:
 
       - name: Remove roc_nightly folder to keep things simple (we'll download it again later)
         run: rm -rf roc_nightly
-      
+
       - name: Get the repo of the latest basic-cli release
         run: |
           git clone --depth 1 https://github.com/roc-lang/basic-cli

--- a/.github/workflows/basic_webserver_build_release.yml
+++ b/.github/workflows/basic_webserver_build_release.yml
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Download the previously uploaded roc_nightly archives
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
 
       - name: build basic-webserver with legacy linker
         env:
@@ -59,7 +59,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Download the previously uploaded roc_nightly archives
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
 
       - name: build basic-webserver
         env:
@@ -83,7 +83,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Download the previously uploaded roc_nightly archives
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
 
       - run: ./ci/build_basic_webserver.sh macos_x86_64
 
@@ -102,7 +102,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Download the previously uploaded roc_nightly archives
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
 
       - run: ./ci/build_basic_webserver.sh macos_apple_silicon
 
@@ -124,7 +124,7 @@ jobs:
         run: ls | grep -v  ci | xargs rm -rf
 
       - name: Download the previously uploaded files
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
 
       - name: mv roc nightly and simplify name
         run: mv $(ls -d artifact/* | grep "roc_nightly.*tar\.gz" | grep "linux_x86_64") ./roc_nightly.tar.gz

--- a/.github/workflows/basic_webserver_build_release.yml
+++ b/.github/workflows/basic_webserver_build_release.yml
@@ -6,7 +6,7 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-  
+
 env:
   # use .tar.gz for quick testing
   ARCHIVE_FORMAT: .tar.br
@@ -16,7 +16,7 @@ jobs:
   fetch-releases:
     runs-on: [ubuntu-20.04]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - run: curl -fOL https://github.com/roc-lang/roc/releases/download/nightly/roc_nightly-linux_x86_64-latest.tar.gz
       - run: curl -fOL https://github.com/roc-lang/roc/releases/download/nightly/roc_nightly-linux_arm64-latest.tar.gz
@@ -32,7 +32,7 @@ jobs:
     runs-on: [ubuntu-20.04]
     needs: [fetch-releases]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Download the previously uploaded roc_nightly archives
         uses: actions/download-artifact@v3
@@ -42,7 +42,7 @@ jobs:
           CARGO_BUILD_TARGET: x86_64-unknown-linux-musl
         run: ./ci/build_basic_webserver.sh linux_x86_64 "--linker legacy"
 
-      - name: Save .rh, .rm and .o file 
+      - name: Save .rh, .rm and .o file
         uses: actions/upload-artifact@v3
         with:
           name: linux-x86_64-files
@@ -56,7 +56,7 @@ jobs:
     runs-on: [self-hosted, Linux, ARM64]
     needs: [fetch-releases]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Download the previously uploaded roc_nightly archives
         uses: actions/download-artifact@v3
@@ -69,7 +69,7 @@ jobs:
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_RUSTFLAGS: "-Clink-self-contained=yes -Clinker=rust-lld"
         run: ./ci/build_basic_webserver.sh linux_arm64
 
-      - name: Save .o file 
+      - name: Save .o file
         uses: actions/upload-artifact@v3
         with:
           name: linux-arm64-files
@@ -80,7 +80,7 @@ jobs:
     runs-on: [macos-11] # I expect the generated files to work on macOS 12 and 13
     needs: [fetch-releases]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Download the previously uploaded roc_nightly archives
         uses: actions/download-artifact@v3
@@ -99,7 +99,7 @@ jobs:
     runs-on: [self-hosted, macOS, ARM64]
     needs: [fetch-releases]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Download the previously uploaded roc_nightly archives
         uses: actions/download-artifact@v3
@@ -118,7 +118,7 @@ jobs:
     name: create release archive
     runs-on: [ubuntu-20.04]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: remove all folders except the ci folder
         run: ls | grep -v  ci | xargs rm -rf
@@ -145,7 +145,7 @@ jobs:
           cd ..
 
       - run: cp macos-apple-silicon-files/* ./basic-webserver/platform
-      
+
       - run: cp linux-x86_64-files/* ./basic-webserver/platform
 
       - run: cp linux-arm64-files/* ./basic-webserver/platform

--- a/.github/workflows/basic_webserver_build_release.yml
+++ b/.github/workflows/basic_webserver_build_release.yml
@@ -24,7 +24,7 @@ jobs:
       - run: curl -fOL https://github.com/roc-lang/roc/releases/download/nightly/roc_nightly-macos_apple_silicon-latest.tar.gz
 
       - name: Save roc_nightly archives
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           path:  roc_nightly-*
 
@@ -43,7 +43,7 @@ jobs:
         run: ./ci/build_basic_webserver.sh linux_x86_64 "--linker legacy"
 
       - name: Save .rh, .rm and .o file
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: linux-x86_64-files
           path: |
@@ -70,7 +70,7 @@ jobs:
         run: ./ci/build_basic_webserver.sh linux_arm64
 
       - name: Save .o file
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: linux-arm64-files
           path: |
@@ -88,7 +88,7 @@ jobs:
       - run: ./ci/build_basic_webserver.sh macos_x86_64
 
       - name: Save .o files
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: macos-x86_64-files
           path: |
@@ -107,7 +107,7 @@ jobs:
       - run: ./ci/build_basic_webserver.sh macos_apple_silicon
 
       - name: Save macos-arm64.o file
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: macos-apple-silicon-files
           path: |
@@ -157,7 +157,7 @@ jobs:
       - run: echo "TAR_FILENAME=$(ls -d basic-webserver/platform/* | grep ${{ env.ARCHIVE_FORMAT }})" >> $GITHUB_ENV
 
       - name: Upload platform archive
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: basic-webserver-platform
           path: |

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -15,7 +15,7 @@ jobs:
     env:
       FORCE_COLOR: 1
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: "main"
           clean: "true"
@@ -23,7 +23,7 @@ jobs:
       - name: on main; prepare a self-contained benchmark folder
         run: nix develop -c ./ci/benchmarks/prep_folder.sh main
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           clean: "false" # we want to keep the benchmark folder
 

--- a/.github/workflows/ci_manager.yml
+++ b/.github/workflows/ci_manager.yml
@@ -15,7 +15,7 @@ jobs:
             run_tests: ${{ steps.filecheck.outputs.run_tests }}
         steps:
             - name: Checkout
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: Check if only css, html or md files changed
               id: filecheck
@@ -112,7 +112,3 @@ jobs:
             fi
 
         - run: echo "Workflow succeeded :)"
-
-
-
-

--- a/.github/workflows/devtools_test_linux_x86_64.yml
+++ b/.github/workflows/devtools_test_linux_x86_64.yml
@@ -1,6 +1,6 @@
 on:
   pull_request:
-  
+
 name: devtools nix files test - linux
 
 concurrency:
@@ -13,7 +13,7 @@ jobs:
         runs-on: [ubuntu-20.04]
         timeout-minutes: 120
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
 
             - name: Only run all steps if a nix file changed
               run: |
@@ -25,7 +25,7 @@ jobs:
                   echo "A nix file was changed. No need to run tests."
                   echo "nix_changed=false" >> $GITHUB_ENV
                 fi
-            
+
 
             - uses: cachix/install-nix-action@v23
               if: env.nix_changed == 'true'
@@ -53,6 +53,3 @@ jobs:
                 echo "locally deleting devtools/flake.lock and following the"
                 echo "instructions in devtools/README.md. This will create a"
                 echo "new flake.lock you should use to replace the old devtools/flake.lock"
-
-
-  

--- a/.github/workflows/devtools_test_macos_apple_silicon.yml
+++ b/.github/workflows/devtools_test_macos_apple_silicon.yml
@@ -13,7 +13,7 @@ jobs:
         runs-on: [self-hosted, macOS, ARM64]
         timeout-minutes: 120
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
 
             - name: Only run all steps if a nix file changed
               run: |
@@ -47,6 +47,3 @@ jobs:
                 echo "locally deleting devtools/flake.lock and following the"
                 echo "instructions in devtools/README.md. This will create a"
                 echo "new flake.lock you should use to replace the old devtools/flake.lock"
-
-
-  

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: [ubuntu-22.04]
     timeout-minutes: 120
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Copy example docker file
         run: cp docker/nightly-ubuntu-latest/docker-compose.example.yml docker/nightly-ubuntu-latest/docker-compose.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: [ubuntu-22.04]
     timeout-minutes: 120
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Copy example docker file
         run: cp docker/nightly-ubuntu-2204/docker-compose.example.yml docker/nightly-ubuntu-2204/docker-compose.yml
@@ -42,7 +42,7 @@ jobs:
     runs-on: [ubuntu-22.04]
     timeout-minutes: 120
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Copy example docker file
         run: cp docker/nightly-ubuntu-2004/docker-compose.example.yml docker/nightly-ubuntu-2004/docker-compose.yml
@@ -58,7 +58,7 @@ jobs:
     runs-on: [ubuntu-22.04]
     timeout-minutes: 120
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Copy example docker file
         run: cp docker/nightly-debian-latest/docker-compose.example.yml docker/nightly-debian-latest/docker-compose.yml
@@ -74,7 +74,7 @@ jobs:
     runs-on: [ubuntu-22.04]
     timeout-minutes: 120
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Copy example docker file
         run: cp docker/nightly-debian-bookworm/docker-compose.example.yml docker/nightly-debian-bookworm/docker-compose.yml
@@ -90,7 +90,7 @@ jobs:
     runs-on: [ubuntu-22.04]
     timeout-minutes: 120
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Copy example docker file
         run: cp docker/nightly-debian-buster/docker-compose.example.yml docker/nightly-debian-buster/docker-compose.yml
@@ -100,4 +100,3 @@ jobs:
 
       - name: Run hello world test
         run: docker-compose -f docker/nightly-debian-buster/docker-compose.yml run roc examples/helloWorld.roc
-

--- a/.github/workflows/macos_x86_64.yml
+++ b/.github/workflows/macos_x86_64.yml
@@ -13,7 +13,7 @@ jobs:
         env:
             RUSTC_WRAPPER: /Users/username1/.cargo/bin/sccache
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
 
             - name: set LLVM_SYS_160_PREFIX
               run: echo "LLVM_SYS_160_PREFIX=$(brew --prefix llvm@16)" >> $GITHUB_ENV

--- a/.github/workflows/markdown_link_check.yml
+++ b/.github/workflows/markdown_link_check.yml
@@ -13,7 +13,7 @@ jobs:
   markdown-link-check:
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: gaurav-nelson/github-action-markdown-link-check@v1
       with:
         use-quiet-mode: 'yes'

--- a/.github/workflows/markdown_link_check.yml
+++ b/.github/workflows/markdown_link_check.yml
@@ -14,14 +14,14 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
-    - uses: gaurav-nelson/github-action-markdown-link-check@v1.0.15
+    - uses: gaurav-nelson/github-action-markdown-link-check@v1
       with:
         use-quiet-mode: 'yes'
         use-verbose-mode: 'yes'
         base-branch: 'main'
         check-modified-files-only: 'yes'
       if: ${{ github.event_name == 'pull_request' }}
-    - uses: gaurav-nelson/github-action-markdown-link-check@v1.0.15
+    - uses: gaurav-nelson/github-action-markdown-link-check@v1
       with:
         use-quiet-mode: 'yes'
         use-verbose-mode: 'yes'

--- a/.github/workflows/markdown_link_check.yml
+++ b/.github/workflows/markdown_link_check.yml
@@ -14,14 +14,14 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
-    - uses: gaurav-nelson/github-action-markdown-link-check@v1
+    - uses: gaurav-nelson/github-action-markdown-link-check@v1.0.15
       with:
         use-quiet-mode: 'yes'
         use-verbose-mode: 'yes'
         base-branch: 'main'
         check-modified-files-only: 'yes'
       if: ${{ github.event_name == 'pull_request' }}
-    - uses: gaurav-nelson/github-action-markdown-link-check@v1
+    - uses: gaurav-nelson/github-action-markdown-link-check@v1.0.15
       with:
         use-quiet-mode: 'yes'
         use-verbose-mode: 'yes'

--- a/.github/workflows/nightly_linux_arm64.yml
+++ b/.github/workflows/nightly_linux_arm64.yml
@@ -5,7 +5,7 @@ on:
     - cron:  '0 9 * * *'
 
 name: Nightly Release Linux arm64/aarch64
-    
+
 jobs:
   build:
     name: build and package nightly release
@@ -13,12 +13,12 @@ jobs:
     timeout-minutes: 90
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Update PATH to use zig 11
         run: |
           echo "PATH=/home/username/Downloads/zig-linux-aarch64-0.11.0:$PATH" >> $GITHUB_ENV
-      
+
       - run: zig version
 
       - name: create version.txt
@@ -29,10 +29,10 @@ jobs:
 
       - name: get commit SHA
         run:  echo "SHA=$(git rev-parse --short "$GITHUB_SHA")" >> $GITHUB_ENV
-        
+
       - name: get date
         run: echo "DATE=$(date "+%Y-%m-%d")" >> $GITHUB_ENV
-        
+
       - name: build file name
         env:
             DATE: ${{ env.DATE }}
@@ -42,7 +42,7 @@ jobs:
       # this makes the roc binary a lot smaller
       - name: strip debug info
         run: strip ./target/release-with-lto/roc
-       
+
       - name: Make nightly release tar archive
         run: ./ci/package_release.sh ${{ env.RELEASE_FOLDER_NAME }}
 

--- a/.github/workflows/nightly_linux_arm64.yml
+++ b/.github/workflows/nightly_linux_arm64.yml
@@ -47,7 +47,7 @@ jobs:
         run: ./ci/package_release.sh ${{ env.RELEASE_FOLDER_NAME }}
 
       - name: Upload roc nightly tar. Actually uploading to github releases has to be done manually.
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
            name: ${{ env.RELEASE_FOLDER_NAME }}.tar.gz
            path: ${{ env.RELEASE_FOLDER_NAME }}.tar.gz

--- a/.github/workflows/nightly_linux_x86_64.yml
+++ b/.github/workflows/nightly_linux_x86_64.yml
@@ -5,20 +5,20 @@ on:
     - cron:  '0 9 * * *'
 
 name: Nightly Release Linux x86_64
-    
+
 jobs:
   build:
     name: build and package nightly release
     runs-on: [self-hosted, i7-6700K]
     timeout-minutes: 90
-    
+
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Update PATH to use zig 11
         run: |
           echo "PATH=/home/big-ci-user/Downloads/zig-linux-x86_64-0.11.0:$PATH" >> $GITHUB_ENV
-      
+
       - run: zig version
 
       - name: create version.txt
@@ -30,7 +30,7 @@ jobs:
 
       - name: get commit SHA
         run:  echo "SHA=$(git rev-parse --short "$GITHUB_SHA")" >> $GITHUB_ENV
-        
+
       - name: get date
         run: echo "DATE=$(date "+%Y-%m-%d")" >> $GITHUB_ENV
 
@@ -43,7 +43,7 @@ jobs:
            name: roc_repl_wasm.tar.gz
            path: roc_repl_wasm.tar.gz
            retention-days: 4
-        
+
       - name: build file name
         env:
             DATE: ${{ env.DATE }}
@@ -53,7 +53,7 @@ jobs:
       # this makes the roc binary a lot smaller
       - name: strip debug info
         run: strip ./target/release-with-lto/roc
-       
+
       - name: Make nightly release tar archive
         run: ./ci/package_release.sh ${{ env.RELEASE_FOLDER_NAME }}
 

--- a/.github/workflows/nightly_linux_x86_64.yml
+++ b/.github/workflows/nightly_linux_x86_64.yml
@@ -38,7 +38,7 @@ jobs:
         run: ./ci/www-repl.sh
 
       - name: Upload wasm repl tar. Actually uploading to github releases has to be done manually.
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
            name: roc_repl_wasm.tar.gz
            path: roc_repl_wasm.tar.gz
@@ -58,7 +58,7 @@ jobs:
         run: ./ci/package_release.sh ${{ env.RELEASE_FOLDER_NAME }}
 
       - name: Upload roc nightly tar. Actually uploading to github releases has to be done manually.
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
            name: ${{ env.RELEASE_FOLDER_NAME }}.tar.gz
            path: ${{ env.RELEASE_FOLDER_NAME }}.tar.gz

--- a/.github/workflows/nightly_macos_apple_silicon.yml
+++ b/.github/workflows/nightly_macos_apple_silicon.yml
@@ -16,8 +16,8 @@ jobs:
     runs-on: [self-hosted, macOS, ARM64]
     timeout-minutes: 90
     steps:
-      - uses: actions/checkout@v3
-      
+      - uses: actions/checkout@v4
+
       - run: zig version
 
       - name: llvm version
@@ -25,18 +25,18 @@ jobs:
 
       - name: run tests
         run: cargo test --locked --release
-        
+
       - name: get commit SHA
         run:  echo "SHA=$(git rev-parse --short "$GITHUB_SHA")" >> $GITHUB_ENV
-        
+
       - name: get date
         run: echo "DATE=$(date "+%Y-%m-%d")" >> $GITHUB_ENV
-        
+
       - name: build file name
         env:
             DATE: ${{ env.DATE }}
             SHA: ${{ env.SHA }}
-        run: echo "RELEASE_FOLDER_NAME=roc_nightly-macos_apple_silicon-$DATE-$SHA" >> $GITHUB_ENV  
+        run: echo "RELEASE_FOLDER_NAME=roc_nightly-macos_apple_silicon-$DATE-$SHA" >> $GITHUB_ENV
 
       - name: write version to file
         run: ./ci/write_version.sh

--- a/.github/workflows/nightly_macos_apple_silicon.yml
+++ b/.github/workflows/nightly_macos_apple_silicon.yml
@@ -61,7 +61,7 @@ jobs:
       - name: print date
         run: date
       - name: Upload artifact Actually uploading to github releases has to be done manually
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
            name: ${{ env.RELEASE_FOLDER_NAME }}.tar.gz
            path: ${{ env.RELEASE_FOLDER_NAME }}.tar.gz

--- a/.github/workflows/nightly_macos_x86_64.yml
+++ b/.github/workflows/nightly_macos_x86_64.yml
@@ -15,7 +15,7 @@ jobs:
         runs-on: [self-hosted, macOS, X64]
         timeout-minutes: 120
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
 
             - name: Update PATH to use zig 11
               run: |

--- a/.github/workflows/nightly_macos_x86_64.yml
+++ b/.github/workflows/nightly_macos_x86_64.yml
@@ -55,7 +55,7 @@ jobs:
               run: ./ci/package_release.sh ${{ env.RELEASE_FOLDER_NAME }}
 
             - name: Upload artifact. Actually uploading to github releases has to be done manually.
-              uses: actions/upload-artifact@v3
+              uses: actions/upload-artifact@v4
               with:
                   name: ${{ env.RELEASE_FOLDER_NAME }}.tar.gz
                   path: ${{ env.RELEASE_FOLDER_NAME }}.tar.gz

--- a/.github/workflows/nightly_old_linux_arm64.yml
+++ b/.github/workflows/nightly_old_linux_arm64.yml
@@ -32,7 +32,7 @@ jobs:
         run: earthly +build-nightly-release  --RELEASE_FOLDER_NAME=${{ env.RELEASE_FOLDER_NAME }} --ZIG_ARCH=aarch64
 
       - name: Upload roc nightly tar. Actually uploading to github releases has to be done manually.
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
            name: ${{ env.RELEASE_FOLDER_NAME }}.tar.gz
            path: ${{ env.RELEASE_FOLDER_NAME }}.tar.gz

--- a/.github/workflows/nightly_old_linux_arm64.yml
+++ b/.github/workflows/nightly_old_linux_arm64.yml
@@ -5,21 +5,21 @@ on:
     - cron:  '0 9 * * *'
 
 name: Nightly Release Old Linux arm64 using Earthly
-    
+
 jobs:
   build:
     name: build and package nightly release
     runs-on: [self-hosted, Linux, ARM64]
     timeout-minutes: 180
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: get commit SHA
         run:  echo "SHA=$(git rev-parse --short "$GITHUB_SHA")" >> $GITHUB_ENV
-        
+
       - name: get date
         run: echo "DATE=$(date "+%Y-%m-%d")" >> $GITHUB_ENV
-        
+
       - name: build file name
         env:
             DATE: ${{ env.DATE }}

--- a/.github/workflows/nightly_old_linux_x86_64.yml
+++ b/.github/workflows/nightly_old_linux_x86_64.yml
@@ -35,7 +35,7 @@ jobs:
         run: earthly +build-nightly-release  --RELEASE_FOLDER_NAME=${{ env.RELEASE_FOLDER_NAME }} --RUSTFLAGS="-C target-cpu=x86-64"
 
       - name: Upload roc nightly tar. Actually uploading to github releases has to be done manually.
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
            name: ${{ env.RELEASE_FOLDER_NAME }}.tar.gz
            path: ${{ env.RELEASE_FOLDER_NAME }}.tar.gz

--- a/.github/workflows/nightly_old_linux_x86_64.yml
+++ b/.github/workflows/nightly_old_linux_x86_64.yml
@@ -5,30 +5,30 @@ on:
     - cron:  '0 9 * * *'
 
 name: Nightly Release Old Linux x86_64 using Earthly
-    
+
 jobs:
   build:
     name: build and package nightly release
     runs-on: [ubuntu-20.04]
     timeout-minutes: 90
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: get commit SHA
         run:  echo "SHA=$(git rev-parse --short "$GITHUB_SHA")" >> $GITHUB_ENV
-        
+
       - name: get date
         run: echo "DATE=$(date "+%Y-%m-%d")" >> $GITHUB_ENV
-        
+
       - name: build file name
         env:
             DATE: ${{ env.DATE }}
             SHA: ${{ env.SHA }}
         run: echo "RELEASE_FOLDER_NAME=roc_nightly-old_linux_x86_64-$DATE-$SHA" >> $GITHUB_ENV
-       
+
       - name: install earthly
         run: sudo /bin/sh -c 'wget https://github.com/earthly/earthly/releases/latest/download/earthly-linux-amd64 -O /usr/local/bin/earthly && chmod +x /usr/local/bin/earthly && /usr/local/bin/earthly bootstrap --with-autocomplete'
-      
+
       - run: earthly --version
 
       - name: build release with earthly

--- a/.github/workflows/nix_linux_arm64_cargo.yml
+++ b/.github/workflows/nix_linux_arm64_cargo.yml
@@ -1,6 +1,6 @@
 on:
     workflow_call:
-    
+
 name: test cargo build on linux arm64 inside nix
 
 env:
@@ -12,11 +12,11 @@ jobs:
         runs-on: [self-hosted, Linux, ARM64]
         timeout-minutes: 150
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
 
             - name: test release build
               run: nix develop -c cargo build --release --locked
 
-            # TODO  
+            # TODO
             #- name: build tests without running
             #  run: cargo test --no-run --release

--- a/.github/workflows/nix_linux_arm64_default.yml
+++ b/.github/workflows/nix_linux_arm64_default.yml
@@ -1,7 +1,7 @@
 on:
     workflow_call:
-  
-name: test default.nix on linux arm64 
+
+name: test default.nix on linux arm64
 
 env:
     RUST_BACKTRACE: 1
@@ -12,7 +12,7 @@ jobs:
         runs-on: [self-hosted, Linux, ARM64]
         timeout-minutes: 150
         steps:
-            - uses: actions/checkout@v3
-               
+            - uses: actions/checkout@v4
+
             - name: test building default.nix
               run: nix-build

--- a/.github/workflows/nix_linux_x86_64.yml
+++ b/.github/workflows/nix_linux_x86_64.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: [self-hosted, i5-4690K]
     timeout-minutes: 90
     steps:
-      - uses: actions/checkout@v3
-          
+      - uses: actions/checkout@v4
+
       - name: test building default.nix
-        run: nix-build 
+        run: nix-build
 
       - name: execute tests with --release
         run: nix develop -c cargo test --locked --release

--- a/.github/workflows/nix_macos_apple_silicon.yml
+++ b/.github/workflows/nix_macos_apple_silicon.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: [self-hosted, macOS, ARM64]
     timeout-minutes: 90
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       # These started to accumulate quickly since #5990, not sure why
       - name: Clean up old nix shells

--- a/.github/workflows/nix_macos_x86_64.yml
+++ b/.github/workflows/nix_macos_x86_64.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: [macos-12]
     timeout-minutes: 90
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: cachix/install-nix-action@v22
 

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -18,7 +18,7 @@ jobs:
     env:
       FORCE_COLOR: 1
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - run: cargo install typos-cli --version 1.0.11
 

--- a/.github/workflows/test_nightly_macos_apple_silicon.yml
+++ b/.github/workflows/test_nightly_macos_apple_silicon.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: [self-hosted, macOS, ARM64]
     timeout-minutes: 90
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: get the latest release archive
         run: curl -fOL https://github.com/roc-lang/roc/releases/download/nightly/roc_nightly-macos_apple_silicon-latest.tar.gz
@@ -45,6 +45,3 @@ jobs:
           cp target/release/repl_basic_test ../../roc_nightly
           cd ../../roc_nightly
           ./repl_basic_test
-
-
-        

--- a/.github/workflows/test_nightly_many_os.yml
+++ b/.github/workflows/test_nightly_many_os.yml
@@ -13,14 +13,14 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 90
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: goto-bus-stop/setup-zig@v2
         with:
           version: 0.11.0
 
       - name: get the latest release archive for linux (x86_64)
         if: startsWith(matrix.os, 'ubuntu')
-        run:  | 
+        run:  |
           curl -fOL https://github.com/roc-lang/roc/releases/download/nightly/roc_nightly-linux_x86_64-latest.tar.gz
 
 
@@ -40,7 +40,3 @@ jobs:
           rm -rf roc_nightly
           curl -fOL https://github.com/roc-lang/roc/releases/download/nightly/roc_nightly-old_linux_x86_64-latest.tar.gz
           ./ci/basic_nightly_test.sh
-
-
-
-

--- a/.github/workflows/ubuntu_x86_64.yml
+++ b/.github/workflows/ubuntu_x86_64.yml
@@ -14,7 +14,7 @@ jobs:
     env:
       RUSTC_WRAPPER: /home/big-ci-user/.cargo/bin/sccache
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Check for duplicate AUTHORS
         run: diff <(sort AUTHORS) <(sort AUTHORS | uniq) # The < operator treats a string as a file. diff 'succeeds' if no difference.
@@ -22,7 +22,7 @@ jobs:
       - name: Update PATH to use zig 11
         run: |
           echo "PATH=/home/big-ci-user/Downloads/zig-linux-x86_64-0.11.0:$PATH" >> $GITHUB_ENV
-      
+
       - run: zig version
 
       - name: zig fmt check, zig tests
@@ -40,7 +40,7 @@ jobs:
 
       - name: check that the platform`s produced dylib is loadable
         run: cd examples/platform-switching/rust-platform && LD_LIBRARY_PATH=. cargo test --release --locked
-        
+
       - name: test the dev backend # these tests require an explicit feature flag
         run: cargo test --locked --release --package test_gen --no-default-features --features gen-dev && sccache --show-stats
 

--- a/.github/workflows/windows_release_build.yml
+++ b/.github/workflows/windows_release_build.yml
@@ -15,7 +15,7 @@ jobs:
 
     timeout-minutes: 150
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - run: Add-Content -Path "$env:GITHUB_ENV" -Value "GITHUB_RUNNER_CPU=$((Get-CimInstance Win32_Processor).Name)"
 

--- a/.github/workflows/windows_tests.yml
+++ b/.github/workflows/windows_tests.yml
@@ -15,7 +15,7 @@ jobs:
 
     timeout-minutes: 150
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - run: Add-Content -Path "$env:GITHUB_ENV" -Value "GITHUB_RUNNER_CPU=$((Get-CimInstance Win32_Processor).Name)"
 
@@ -45,21 +45,18 @@ jobs:
           curl.exe -f -L -O -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" https://github.com/roc-lang/llvm-package-windows/releases/download/v16.0.6/LLVM-16.0.6-win64.7z
           7z x LLVM-16.0.6-win64.7z -oC:\LLVM-16.0.6-win64
 
-      - name: Build tests --release without running. 
+      - name: Build tests --release without running.
         run: cargo test --locked --release --no-run
 
       # Why are these tests not build with previous command? => fingerprint error. Use `CARGO_LOG=cargo::core::compiler::fingerprint=info` to investigate
-      - name: Build specific tests without running. 
-        run: cargo test --locked --release --no-run -p roc_ident -p roc_region -p roc_collections -p roc_can -p roc_types -p roc_solve -p roc_mono -p roc_gen_dev -p roc_gen_wasm -p roc_serialize -p roc_linker -p roc_cli -p test_gen 
+      - name: Build specific tests without running.
+        run: cargo test --locked --release --no-run -p roc_ident -p roc_region -p roc_collections -p roc_can -p roc_types -p roc_solve -p roc_mono -p roc_gen_dev -p roc_gen_wasm -p roc_serialize -p roc_linker -p roc_cli -p test_gen
 
       - name: Test setjmp/longjmp logic
         run: cargo test-gen-dev --locked --release nat_alias && cargo test-gen-dev --locked --release a_crash
 
       - name: Run gen tests
-        run: cargo test-gen-llvm --locked --release gen_str 
-        
+        run: cargo test-gen-llvm --locked --release gen_str
+
       - name: Actually run the tests.
         run: cargo test --locked --release -p roc_ident -p roc_region -p roc_collections -p roc_can -p roc_types -p roc_solve -p roc_mono -p roc_gen_dev -p roc_gen_wasm -p roc_serialize -p roc_linker -p roc_cli
-
-      
-


### PR DESCRIPTION
This PR updates the GitHub Action steps to get rid of the warnings displayed in CI, see https://github.com/roc-lang/roc/issues/6428.

There are also a few whitespace cleanup changes my editor made automatically :-)