### PR TITLE
Better error message for bad packages list

### DIFF
--- a/crates/reporting/src/error/parse.rs
+++ b/crates/reporting/src/error/parse.rs
@@ -3916,7 +3916,7 @@ fn to_packages_report<'a>(
 
             let doc = alloc.stack([
                 alloc.reflow(
-                    r"I am partway through parsing a header packages list, but I got stuck here:",
+                    r"I am partway through parsing a list of packages, but I got stuck here:",
                 ),
                 alloc.region_with_subregion(lines.convert_region(surroundings), region),
                 alloc.concat([alloc.reflow("I am expecting a comma or end of list, like")]),

--- a/crates/reporting/src/error/parse.rs
+++ b/crates/reporting/src/error/parse.rs
@@ -3910,6 +3910,28 @@ fn to_packages_report<'a>(
                 severity: Severity::RuntimeError,
             }
         }
+        EPackages::ListEnd(pos) => {
+            let surroundings = Region::new(start, pos);
+            let region = LineColumnRegion::from_pos(lines.convert_pos(pos));
+
+            let doc = alloc.stack([
+                alloc.reflow(
+                    r"I am partway through parsing a header packages list, but I got stuck here:",
+                ),
+                alloc.region_with_subregion(lines.convert_region(surroundings), region),
+                alloc.concat([alloc.reflow("I am expecting a comma or end of list, like")]),
+                alloc
+                    .parser_suggestion("packages { package_name: \"url-or-path\", }")
+                    .indent(4),
+            ]);
+
+            Report {
+                filename,
+                doc,
+                title: "WEIRD PACKAGES LIST".to_string(),
+                severity: Severity::RuntimeError,
+            }
+        }
 
         EPackages::Space(error, pos) => to_space_report(alloc, lines, filename, &error, pos),
 


### PR DESCRIPTION
I hit one these errors when first trying out roc, and the error message was not helpful. I don't know roc well at all, so suggestions for improving the error message would be appreciated.

When a packages section in the header has a missing or misplaced comma, roc just spits out the string. After this commit, we get a nicer error message.

Examples of wrong syntax and the error messages:
```shell
# Misplaced additional comma:
$ RUST_BACKTRACE=full roc dev ./hello.roc
── WEIRD PACKAGES LIST in ./hello.roc ──────────────────────────────────────────────

I am partway through parsing a header packages list, but I got stuck
here:

1│  app "hello"
2│      packages {
3│          ,
            ^

I am expecting a comma or end of list, like

    packages { package_name: "url-or-path", }
```

```shell
# Missing comma at the end of a packages entry:
$ RUST_BACKTRACE=full roc dev ./hello.roc
── WEIRD PACKAGES LIST in ./hello.roc ──────────────────────────────────────────────

I am partway through parsing a header packages list, but I got stuck
here:

1│  app "hello"
2│      packages {
3│          pf: "https://github.com/roc-lang/basic-cli/releases/download/0.7.1/Icc3xJoIixF3hCcfXrDwLCu4wQHtNdPyoJkEbkgIElA.tar.br"
4│          parser: "./tpl/roc-parser/package/main.roc",
            ^

I am expecting a comma or end of list, like

    packages { package_name: "url-or-path", }
```