### PR TITLE
Format allow more hashtags

### DIFF
--- a/crates/compiler/fmt/src/spaces.rs
+++ b/crates/compiler/fmt/src/spaces.rs
@@ -154,7 +154,9 @@ fn fmt_comment(buf: &mut Buf, comment: &str) {
     }
 
     buf.push('#');
-    if !comment.starts_with(' ') {
+    // Add a space between the starting `#` and the rest of the comment,
+    // unless there already is one or the comment is of the form `#### something`.
+    if !comment.starts_with(' ') && !comment.starts_with('#') {
         buf.spaces(1);
     }
     buf.push_str(comment.trim_end());

--- a/crates/compiler/fmt/src/spaces.rs
+++ b/crates/compiler/fmt/src/spaces.rs
@@ -155,7 +155,7 @@ fn fmt_comment(buf: &mut Buf, comment: &str) {
 
     buf.push('#');
     // Add a space between the starting `#` and the rest of the comment,
-    // unless there already is one or the comment is of the form `#### something`.
+    // unless there already is a space or the comment is of the form `#### something`.
     if !comment.starts_with(' ') && !comment.starts_with('#') {
         buf.spaces(1);
     }

--- a/crates/compiler/test_syntax/tests/snapshots/pass/mixed_docs.expr.formatted.roc
+++ b/crates/compiler/test_syntax/tests/snapshots/pass/mixed_docs.expr.formatted.roc
@@ -1,7 +1,0 @@
-# ## not docs!
-## docs, but with a problem
-## (namely that this is a mix of docs and regular comments)
-# not docs
-x = 5
-
-42

--- a/crates/compiler/test_syntax/tests/snapshots/pass/not_docs.expr.formatted.roc
+++ b/crates/compiler/test_syntax/tests/snapshots/pass/not_docs.expr.formatted.roc
@@ -1,7 +1,0 @@
-# ######
-# ## not docs!
-# #still not docs
-# #####
-x = 5
-
-42


### PR DESCRIPTION
The formatter used to replace `###` with `# ##` but this can be not what you want in some cases, like [here](https://github.com/roc-lang/roc/issues/6328#issuecomment-1902691185).

This change does prevent the autofixing of scenarios like this:
```
### docs markdown header (wrong, this won't be detected as a doc comment)
## ...
x = \y ->
``` 
to:
```
## # docs markdown header (correct)
## ...
x = \y ->
```
Warning for this scenario seems to be best suited for a future Roc linter.