### PR TITLE
Tail recursive hover and bug fix for correctly marking if else as tail recursive

### DIFF
--- a/crates/compiler/can/src/copy.rs
+++ b/crates/compiler/can/src/copy.rs
@@ -1,7 +1,8 @@
 use crate::{
     def::Def,
     expr::{
-        ClosureData, Expr, Field, OpaqueWrapFunctionData, StructAccessorData, WhenBranchPattern,
+        ClosureData, Expr, Field, OpaqueWrapFunctionData, Recursive, StructAccessorData,
+        WhenBranchPattern,
     },
     pattern::{DestructType, ListPatterns, Pattern, RecordDestruct, TupleDestruct},
 };
@@ -393,7 +394,7 @@ fn deep_copy_expr_help<C: CopyEnv>(env: &mut C, copied: &mut Vec<Variable>, expr
             LetNonRec(Box::new(def), Box::new(body.map(|e| go_help!(e))))
         }
 
-        Call(f, args, called_via) => {
+        Call(f, args, called_via, rec) => {
             let (fn_var, fn_expr, clos_var, ret_var) = &**f;
             Call(
                 Box::new((
@@ -406,6 +407,7 @@ fn deep_copy_expr_help<C: CopyEnv>(env: &mut C, copied: &mut Vec<Variable>, expr
                     .map(|(var, expr)| (sub!(*var), expr.map(|e| go_help!(e))))
                     .collect(),
                 *called_via,
+                *rec,
             )
         }
         Crash { msg, ret_var } => Crash {

--- a/crates/compiler/can/src/debug/pretty_print.rs
+++ b/crates/compiler/can/src/debug/pretty_print.rs
@@ -258,7 +258,8 @@ fn expr<'a>(c: &Ctx, p: EPrec, f: &'a Arena<'a>, e: &'a Expr) -> DocBuilder<'a, 
             .append(f.hardline())
             .append(expr(c, Free, f, &body.value))
             .group(),
-        Call(fun, args, _) => {
+        //TODO! add recursive to this
+        Call(fun, args, _, _) => {
             let (_, fun, _, _) = &**fun;
             maybe_paren!(
                 Free,

--- a/crates/compiler/can/src/def.rs
+++ b/crates/compiler/can/src/def.rs
@@ -2369,7 +2369,7 @@ fn canonicalize_pending_body<'a>(
                 // reset the tailcallable_symbol
                 env.tailcallable_symbol = outer_tailcallable;
 
-                // The closure is self tail recursive iff it tail calls itself (by defined name).
+                // The closure is self tail recursive if it tail calls itself (by defined name).
                 let is_recursive = match can_output.tail_call {
                     Some(tail_symbol) if tail_symbol == *defined_symbol => Recursive::TailRecursive,
                     _ => Recursive::NotRecursive,

--- a/crates/compiler/can/src/effect_module.rs
+++ b/crates/compiler/can/src/effect_module.rs
@@ -253,7 +253,12 @@ fn build_effect_map(
         );
 
         let arguments = vec![(var_store.fresh(), Loc::at_zero(Expr::EmptyRecord))];
-        Expr::Call(Box::new(boxed), arguments, CalledVia::Space)
+        Expr::Call(
+            Box::new(boxed),
+            arguments,
+            CalledVia::Space,
+            Recursive::NotRecursive,
+        )
     };
 
     // `toEffect (thunk {})`
@@ -266,7 +271,12 @@ fn build_effect_map(
         );
 
         let arguments = vec![(var_store.fresh(), Loc::at_zero(force_thunk_call))];
-        Expr::Call(Box::new(boxed), arguments, CalledVia::Space)
+        Expr::Call(
+            Box::new(boxed),
+            arguments,
+            CalledVia::Space,
+            Recursive::NotRecursive,
+        )
     };
 
     let inner_closure_symbol = {
@@ -423,7 +433,12 @@ fn force_thunk(expr: Expr, thunk_var: Variable, var_store: &mut VarStore) -> Exp
     );
 
     let arguments = vec![(var_store.fresh(), Loc::at_zero(Expr::EmptyRecord))];
-    Expr::Call(Box::new(boxed), arguments, CalledVia::Space)
+    Expr::Call(
+        Box::new(boxed),
+        arguments,
+        CalledVia::Space,
+        Recursive::NotRecursive,
+    )
 }
 
 fn build_effect_after(
@@ -462,7 +477,12 @@ fn build_effect_after(
         );
 
         let arguments = vec![(var_store.fresh(), Loc::at_zero(force_effect_call))];
-        Expr::Call(Box::new(boxed), arguments, CalledVia::Space)
+        Expr::Call(
+            Box::new(boxed),
+            arguments,
+            CalledVia::Space,
+            Recursive::NotRecursive,
+        )
     };
 
     // let @Effect thunk = toEffect (effect {}) in thunk {}
@@ -725,7 +745,12 @@ fn force_effect(
         );
 
         let arguments = vec![(var_store.fresh(), Loc::at_zero(Expr::EmptyRecord))];
-        let call = Expr::Call(Box::new(boxed), arguments, CalledVia::Space);
+        let call = Expr::Call(
+            Box::new(boxed),
+            arguments,
+            CalledVia::Space,
+            Recursive::NotRecursive,
+        );
 
         Loc::at_zero(call)
     };
@@ -943,7 +968,12 @@ fn build_effect_forever_inner_body(
         );
 
         let arguments = vec![(var_store.fresh(), Loc::at_zero(Expr::EmptyRecord))];
-        let call = Expr::Call(Box::new(boxed), arguments, CalledVia::Space);
+        let call = Expr::Call(
+            Box::new(boxed),
+            arguments,
+            CalledVia::Space,
+            Recursive::NotRecursive,
+        );
 
         Loc::at_zero(call)
     };
@@ -968,7 +998,12 @@ fn build_effect_forever_inner_body(
 
         let effect_var = var_store.fresh();
         let arguments = vec![(effect_var, Loc::at_zero(Expr::Var(effect, effect_var)))];
-        Expr::Call(Box::new(boxed), arguments, CalledVia::Space)
+        Expr::Call(
+            Box::new(boxed),
+            arguments,
+            CalledVia::Space,
+            Recursive::NotRecursive,
+        )
     };
 
     // ```
@@ -1226,7 +1261,12 @@ fn build_effect_loop_inner_body(
 
             let state_var = var_store.fresh();
             let arguments = vec![(state_var, Loc::at_zero(Expr::Var(state_symbol, state_var)))];
-            Expr::Call(Box::new(boxed), arguments, CalledVia::Space)
+            Expr::Call(
+                Box::new(boxed),
+                arguments,
+                CalledVia::Space,
+                Recursive::NotRecursive,
+            )
         };
 
         Def {
@@ -1250,7 +1290,12 @@ fn build_effect_loop_inner_body(
         );
 
         let arguments = vec![(var_store.fresh(), Loc::at_zero(Expr::EmptyRecord))];
-        let call = Expr::Call(Box::new(boxed), arguments, CalledVia::Space);
+        let call = Expr::Call(
+            Box::new(boxed),
+            arguments,
+            CalledVia::Space,
+            Recursive::NotRecursive,
+        );
 
         Loc::at_zero(call)
     };
@@ -1274,7 +1319,12 @@ fn build_effect_loop_inner_body(
             ),
             (step_var, Loc::at_zero(Expr::Var(step_symbol, step_var))),
         ];
-        Expr::Call(Box::new(boxed), arguments, CalledVia::Space)
+        Expr::Call(
+            Box::new(boxed),
+            arguments,
+            CalledVia::Space,
+            Recursive::NotRecursive,
+        )
     };
 
     // ```

--- a/crates/compiler/can/src/expr.rs
+++ b/crates/compiler/can/src/expr.rs
@@ -977,7 +977,7 @@ pub fn canonicalize_expr_with_tail<'a>(
                         output.references.insert_call(symbol);
 
                         // we're calling a symbol by name, check if it's the tail-callable symbol and if it's in the tail position
-                        output.rec_call = match &env.tailcallable_symbol {
+                        let is_recursive = match &env.tailcallable_symbol {
                             Some(tc_sym) if *tc_sym == symbol => {
                                 if is_tail {
                                     Recursive::TailRecursive
@@ -985,8 +985,9 @@ pub fn canonicalize_expr_with_tail<'a>(
                                     Recursive::Recursive
                                 }
                             }
-                            Some(_) | None => output.rec_call,
+                            Some(_) | None => Recursive::NotRecursive,
                         };
+                        output.rec_call.union_mut(is_recursive.clone());
 
                         Call(
                             Box::new((
@@ -997,7 +998,7 @@ pub fn canonicalize_expr_with_tail<'a>(
                             )),
                             args,
                             *application_style,
-                            output.rec_call.clone(),
+                            is_recursive,
                         )
                     }
                     RuntimeError(_) => {

--- a/crates/compiler/can/src/expr.rs
+++ b/crates/compiler/can/src/expr.rs
@@ -1308,6 +1308,7 @@ pub fn canonicalize_expr<'a>(
 
                 output.references.union_mut(&cond_output.references);
                 output.references.union_mut(&then_output.references);
+                output.union(then_output);
             }
 
             let (loc_else, else_output) = canonicalize_expr(
@@ -1319,6 +1320,7 @@ pub fn canonicalize_expr<'a>(
             );
 
             output.references.union_mut(&else_output.references);
+            output.union(else_output);
 
             (
                 If {
@@ -3077,14 +3079,14 @@ pub enum DeclarationTag {
 
 impl DeclarationTag {
     fn len(self) -> usize {
-        use DeclarationTag::*;
+        use DeclarationTag as dt;
 
         match self {
-            Function(_) | Recursive(_) | TailRecursive(_) => 1,
-            Value => 1,
-            Expectation | ExpectationFx => 1,
-            Destructure(_) => 1,
-            MutualRecursion { length, .. } => length as usize + 1,
+            dt::Function(_) | dt::Recursive(_) | dt::TailRecursive(_) => 1,
+            dt::Value => 1,
+            dt::Expectation | dt::ExpectationFx => 1,
+            dt::Destructure(_) => 1,
+            dt::MutualRecursion { length, .. } => length as usize + 1,
         }
     }
 }

--- a/crates/compiler/can/src/module.rs
+++ b/crates/compiler/can/src/module.rs
@@ -1171,7 +1171,7 @@ fn fix_values_captured_in_closure_expr(
             );
         }
 
-        Call(function, arguments, _) => {
+        Call(function, arguments, _, _) => {
             fix_values_captured_in_closure_expr(
                 &mut function.1.value,
                 no_capture_symbols,

--- a/crates/compiler/can/src/module.rs
+++ b/crates/compiler/can/src/module.rs
@@ -375,6 +375,7 @@ pub fn canonicalize_module_defs<'a>(
         &mut scope,
         loc_defs,
         PatternType::TopLevelDef,
+        false,
     );
 
     let pending_derives = output.pending_derives;

--- a/crates/compiler/can/src/traverse.rs
+++ b/crates/compiler/can/src/traverse.rs
@@ -289,8 +289,9 @@ pub fn walk_expr<V: Visitor>(visitor: &mut V, expr: &Expr, var: Variable) {
             visitor.visit_def(def);
             visitor.visit_expr(&body.value, body.region, var);
         }
-        Expr::Call(f, args, _called_via) => {
+        Expr::Call(f, args, _called_via, tail_call) => {
             let (fn_var, loc_fn, _closure_var, _ret_var) = &**f;
+
             walk_call(visitor, *fn_var, loc_fn, args);
         }
         Expr::Crash { msg, .. } => {

--- a/crates/compiler/can/src/traverse.rs
+++ b/crates/compiler/can/src/traverse.rs
@@ -671,14 +671,6 @@ struct RecursiveCallsVisitor {
     calls: Vec<(Region, Recursive)>,
 }
 impl Visitor for RecursiveCallsVisitor {
-    fn visit_def(&mut self, def: &Def) {
-        match &def.loc_expr.value {
-            Expr::Call(b, _, _, recursive) => self.calls.push((b.1.region, *recursive)),
-            _ => (),
-        };
-        walk_def(self, def);
-    }
-
     fn visit_expr(&mut self, expr: &Expr, region: Region, var: Variable) {
         //reset the decl type because we didn't end on a declaration
         match expr {

--- a/crates/compiler/constrain/src/expr.rs
+++ b/crates/compiler/constrain/src/expr.rs
@@ -449,7 +449,7 @@ pub fn constrain_expr(
                 constraints.exists([*elem_var], and_constraint)
             }
         }
-        Call(boxed, loc_args, called_via) => {
+        Call(boxed, loc_args, called_via, _) => {
             let (fn_var, loc_fn, closure_var, ret_var) = &**boxed;
             // The expression that evaluates to the function being called, e.g. `foo` in
             // (foo) bar baz
@@ -4097,7 +4097,7 @@ fn is_generalizable_expr(mut expr: &Expr) -> bool {
             | If { .. }
             | LetRec(_, _, _)
             | LetNonRec(_, _)
-            | Call(_, _, _)
+            | Call(_, _, _, _)
             | RunLowLevel { .. }
             | ForeignCall { .. }
             | EmptyRecord

--- a/crates/compiler/derive/src/decoding.rs
+++ b/crates/compiler/derive/src/decoding.rs
@@ -100,6 +100,7 @@ fn wrap_in_decode_custom_decode_with(
                 (fmt_var, Loc::at_zero(Var(fmt_sym, fmt_var))),
             ],
             CalledVia::Space,
+            Recursive::NotRecursive,
         );
 
         (decode_with_call, this_decode_with_ret_var)
@@ -200,6 +201,7 @@ fn wrap_in_decode_custom_decode_with(
             decode_custom_fn,
             vec![(custom_var, Loc::at_zero(custom_lambda))],
             CalledVia::Space,
+            Recursive::NotRecursive,
         );
 
         (decode_custom_call, this_decode_custom_ret_var)

--- a/crates/compiler/derive/src/decoding/list.rs
+++ b/crates/compiler/derive/src/decoding/list.rs
@@ -1,4 +1,4 @@
-use roc_can::expr::Expr;
+use roc_can::expr::{Expr, Recursive};
 
 use roc_error_macros::internal_error;
 use roc_module::called_via::CalledVia;
@@ -84,6 +84,7 @@ pub(crate) fn decoder(env: &mut Env<'_>, _def_symbol: Symbol) -> (Expr, Variable
             decode_list_fn,
             vec![(elem_decoder_var, Loc::at_zero(elem_decoder))],
             CalledVia::Space,
+            Recursive::NotRecursive,
         );
 
         (decode_list_call, this_decode_list_ret_var)

--- a/crates/compiler/derive/src/decoding/record.rs
+++ b/crates/compiler/derive/src/decoding/record.rs
@@ -123,6 +123,7 @@ pub(crate) fn decoder(
             (finalizer_var, Loc::at_zero(finalizer)),
         ],
         CalledVia::Space,
+        Recursive::NotRecursive,
     );
 
     let (call_decode_custom, decode_custom_ret_var) = {
@@ -508,6 +509,7 @@ fn step_field(
                         ),
                     ],
                     CalledVia::Space,
+                    Recursive::NotRecursive,
                 );
 
                 // when Decode.decodeWith bytes Decode.decoder fmt is
@@ -598,6 +600,7 @@ fn step_field(
                 )),
                 vec![(this_custom_callback_var, Loc::at_zero(custom_callback))],
                 CalledVia::Space,
+                Recursive::NotRecursive,
             )
         };
 

--- a/crates/compiler/derive/src/decoding/tuple.rs
+++ b/crates/compiler/derive/src/decoding/tuple.rs
@@ -126,6 +126,7 @@ pub(crate) fn decoder(env: &mut Env, _def_symbol: Symbol, arity: u32) -> (Expr, 
             (finalizer_var, Loc::at_zero(finalizer)),
         ],
         CalledVia::Space,
+        Recursive::NotRecursive,
     );
 
     let (call_decode_custom, decode_custom_ret_var) = {
@@ -510,6 +511,7 @@ fn step_elem(
                         ),
                     ],
                     CalledVia::Space,
+                    Recursive::NotRecursive,
                 );
 
                 // when Decode.decodeWith bytes Decode.decoder fmt is
@@ -600,6 +602,7 @@ fn step_elem(
                 )),
                 vec![(this_custom_callback_var, Loc::at_zero(custom_callback))],
                 CalledVia::Space,
+                Recursive::NotRecursive,
             )
         };
 

--- a/crates/compiler/derive/src/encoding.rs
+++ b/crates/compiler/derive/src/encoding.rs
@@ -154,6 +154,7 @@ fn to_encoder_list(env: &mut Env<'_>, fn_name: Symbol) -> (Expr, Variable) {
         to_encoder_fn,
         vec![(elem_var, Loc::at_zero(Var(elem_sym, elem_var)))],
         CalledVia::Space,
+        Recursive::NotRecursive,
     );
 
     // elem -[to_elem_encoder]-> toEncoder elem
@@ -239,6 +240,7 @@ fn to_encoder_list(env: &mut Env<'_>, fn_name: Symbol) -> (Expr, Variable) {
             (to_elem_encoder_fn_var, Loc::at_zero(to_elem_encoder)),
         ],
         CalledVia::Space,
+        Recursive::NotRecursive,
     );
 
     // Encode.custom \bytes, fmt -> Encode.appendWith bytes (Encode.list ..) fmt
@@ -373,6 +375,7 @@ fn to_encoder_record(
                 to_encoder_fn,
                 vec![(field_var, Loc::at_zero(field_access))],
                 CalledVia::Space,
+                Recursive::NotRecursive,
             );
 
             // value: toEncoder rcd.a
@@ -455,6 +458,7 @@ fn to_encoder_record(
         encode_record_fn,
         vec![(fields_list_var, Loc::at_zero(fields_list))],
         CalledVia::Space,
+        Recursive::NotRecursive,
     );
 
     // Encode.custom \bytes, fmt -> Encode.appendWith bytes (Encode.record ..) fmt
@@ -576,6 +580,7 @@ fn to_encoder_tuple(
                 to_encoder_fn,
                 vec![(elem_var, Loc::at_zero(tuple_access))],
                 CalledVia::Space,
+                Recursive::NotRecursive,
             );
 
             // NOTE: must be done to unify the lambda sets under `encoder_var`
@@ -638,6 +643,7 @@ fn to_encoder_tuple(
         encode_tuple_fn,
         vec![(elem_encoders_list_var, Loc::at_zero(elem_encoders_list))],
         CalledVia::Space,
+        Recursive::NotRecursive,
     );
 
     // Encode.custom \bytes, fmt -> Encode.appendWith bytes (Encode.tuple_var ..) fmt
@@ -778,6 +784,7 @@ fn to_encoder_tag_union(
                         to_encoder_fn,
                         vec![(sym_var, Loc::at_zero(Var(sym, sym_var)))],
                         CalledVia::Space,
+                        Recursive::NotRecursive,
                     );
 
                     // NOTE: must be done to unify the lambda sets under `encoder_var`
@@ -847,6 +854,7 @@ fn to_encoder_tag_union(
                     ),
                 ],
                 CalledVia::Space,
+                Recursive::NotRecursive,
             );
 
             // NOTE: must be done to unify the lambda sets under `encoder_var`
@@ -999,6 +1007,7 @@ fn wrap_in_encode_custom(
             (fmt_var, Loc::at_zero(Var(fmt_sym, fmt_var))),
         ],
         CalledVia::Space,
+        Recursive::NotRecursive,
     );
 
     // Create fn_var for ambient capture; we fix it up below.
@@ -1083,6 +1092,7 @@ fn wrap_in_encode_custom(
         custom_fn,
         vec![(fn_var, Loc::at_zero(clos))],
         CalledVia::Space,
+        Recursive::NotRecursive,
     );
 
     (custom_call, this_custom_encoder_var)

--- a/crates/compiler/derive/src/hash.rs
+++ b/crates/compiler/derive/src/hash.rs
@@ -496,7 +496,12 @@ fn call_hash_ability_member(
         (in_hasher_var, Loc::at_zero(in_hasher_expr)),
         (in_val_var, Loc::at_zero(in_val_expr)),
     ];
-    let call_hash = Expr::Call(hash_fn_data, hash_arguments, CalledVia::Space);
+    let call_hash = Expr::Call(
+        hash_fn_data,
+        hash_arguments,
+        CalledVia::Space,
+        Recursive::NotRecursive,
+    );
 
     (this_out_hasher_var, call_hash)
 }

--- a/crates/compiler/derive/src/inspect.rs
+++ b/crates/compiler/derive/src/inspect.rs
@@ -160,6 +160,7 @@ fn to_inspector_list(env: &mut Env<'_>, fn_name: Symbol) -> (Expr, Variable) {
         to_inspector_fn,
         vec![(elem_var, Loc::at_zero(Var(elem_sym, elem_var)))],
         CalledVia::Space,
+        Recursive::NotRecursive,
     );
 
     // elem -[to_elem_inspector]-> toInspector elem
@@ -252,6 +253,7 @@ fn to_inspector_list(env: &mut Env<'_>, fn_name: Symbol) -> (Expr, Variable) {
             (to_elem_inspector_fn_var, Loc::at_zero(to_elem_inspector)),
         ],
         CalledVia::Space,
+        Recursive::NotRecursive,
     );
 
     // Inspect.custom \fmt -> Inspect.apply (Inspect.list ..) fmt
@@ -387,6 +389,7 @@ fn to_inspector_record(
                 to_inspector_fn,
                 vec![(field_var, Loc::at_zero(field_access))],
                 CalledVia::Space,
+                Recursive::NotRecursive,
             );
 
             // value: toInspector rcd.a
@@ -469,6 +472,7 @@ fn to_inspector_record(
         inspect_record_fn,
         vec![(fields_list_var, Loc::at_zero(fields_list))],
         CalledVia::Space,
+        Recursive::NotRecursive,
     );
 
     // Inspect.custom \fmt -> Inspect.apply (Inspect.record ..) fmt
@@ -591,6 +595,7 @@ fn to_inspector_tuple(
                 to_inspector_fn,
                 vec![(elem_var, Loc::at_zero(tuple_access))],
                 CalledVia::Space,
+                Recursive::NotRecursive,
             );
 
             // NOTE: must be done to unify the lambda sets under `inspector_var`
@@ -653,6 +658,7 @@ fn to_inspector_tuple(
         inspect_tuple_fn,
         vec![(elem_inspectors_list_var, Loc::at_zero(elem_inspectors_list))],
         CalledVia::Space,
+        Recursive::NotRecursive,
     );
 
     // Inspect.custom \fmt -> Inspect.apply (Inspect.tuple_var ..) fmt
@@ -793,6 +799,7 @@ fn to_inspector_tag_union(
                         to_inspector_fn,
                         vec![(sym_var, Loc::at_zero(Var(sym, sym_var)))],
                         CalledVia::Space,
+                        Recursive::NotRecursive,
                     );
 
                     // NOTE: must be done to unify the lambda sets under `inspector_var`
@@ -865,6 +872,7 @@ fn to_inspector_tag_union(
                     ),
                 ],
                 CalledVia::Space,
+                Recursive::NotRecursive,
             );
 
             // NOTE: must be done to unify the lambda sets under `inspector_var`
@@ -1006,6 +1014,7 @@ fn wrap_in_inspect_custom(
             (fmt_var, Loc::at_zero(Var(fmt_sym, fmt_var))),
         ],
         CalledVia::Space,
+        Recursive::NotRecursive,
     );
 
     // Create fn_var for ambient capture; we fix it up below.
@@ -1083,6 +1092,7 @@ fn wrap_in_inspect_custom(
         custom_fn,
         vec![(fn_var, Loc::at_zero(clos))],
         CalledVia::Space,
+        Recursive::NotRecursive,
     );
 
     (custom_call, this_custom_inspector_var)

--- a/crates/compiler/mono/src/ir.rs
+++ b/crates/compiler/mono/src/ir.rs
@@ -5422,7 +5422,7 @@ pub fn with_hole<'a>(
             }
         }
 
-        Call(boxed, loc_args, _) => {
+        Call(boxed, loc_args, _, _) => {
             let (fn_var, loc_expr, _lambda_set_var, _ret_var) = *boxed;
 
             // even if a call looks like it's by name, it may in fact be by-pointer.

--- a/crates/compiler/test_mono/generated/tail_call_elimination_if_else.txt
+++ b/crates/compiler/test_mono/generated/tail_call_elimination_if_else.txt
@@ -3,12 +3,12 @@ procedure Bool.11 (#Attr.2, #Attr.3):
     ret Bool.23;
 
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.297 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.297;
+    let Num.303 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.303;
 
 procedure Num.20 (#Attr.2, #Attr.3):
-    let Num.298 : I64 = lowlevel NumSub #Attr.2 #Attr.3;
-    ret Num.298;
+    let Num.304 : I64 = lowlevel NumSub #Attr.2 #Attr.3;
+    ret Num.304;
 
 procedure Test.1 (#Derived_gen.0, #Derived_gen.1):
     joinpoint Test.7 Test.2 Test.3:

--- a/crates/compiler/test_mono/generated/tail_call_elimination_if_else.txt
+++ b/crates/compiler/test_mono/generated/tail_call_elimination_if_else.txt
@@ -1,0 +1,31 @@
+procedure Bool.11 (#Attr.2, #Attr.3):
+    let Bool.23 : Int1 = lowlevel Eq #Attr.2 #Attr.3;
+    ret Bool.23;
+
+procedure Num.19 (#Attr.2, #Attr.3):
+    let Num.297 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.297;
+
+procedure Num.20 (#Attr.2, #Attr.3):
+    let Num.298 : I64 = lowlevel NumSub #Attr.2 #Attr.3;
+    ret Num.298;
+
+procedure Test.1 (#Derived_gen.0, #Derived_gen.1):
+    joinpoint Test.7 Test.2 Test.3:
+        let Test.14 : I64 = 0i64;
+        let Test.12 : Int1 = CallByName Bool.11 Test.2 Test.14;
+        if Test.12 then
+            ret Test.3;
+        else
+            let Test.11 : I64 = 1i64;
+            let Test.9 : I64 = CallByName Num.20 Test.2 Test.11;
+            let Test.10 : I64 = CallByName Num.19 Test.2 Test.3;
+            jump Test.7 Test.9 Test.10;
+    in
+    jump Test.7 #Derived_gen.0 #Derived_gen.1;
+
+procedure Test.0 ():
+    let Test.5 : I64 = 1000000i64;
+    let Test.6 : I64 = 0i64;
+    let Test.4 : I64 = CallByName Test.1 Test.5 Test.6;
+    ret Test.4;

--- a/crates/compiler/test_mono/generated/tail_call_elimination_var.txt
+++ b/crates/compiler/test_mono/generated/tail_call_elimination_var.txt
@@ -1,0 +1,31 @@
+procedure Bool.11 (#Attr.2, #Attr.3):
+    let Bool.23 : Int1 = lowlevel Eq #Attr.2 #Attr.3;
+    ret Bool.23;
+
+procedure Num.19 (#Attr.2, #Attr.3):
+    let Num.303 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.303;
+
+procedure Num.20 (#Attr.2, #Attr.3):
+    let Num.304 : I64 = lowlevel NumSub #Attr.2 #Attr.3;
+    ret Num.304;
+
+procedure Test.1 (#Derived_gen.0, #Derived_gen.1):
+    joinpoint Test.8 Test.2 Test.3:
+        let Test.15 : I64 = 0i64;
+        let Test.13 : Int1 = CallByName Bool.11 Test.2 Test.15;
+        if Test.13 then
+            ret Test.3;
+        else
+            let Test.12 : I64 = 1i64;
+            let Test.10 : I64 = CallByName Num.20 Test.2 Test.12;
+            let Test.11 : I64 = CallByName Num.19 Test.2 Test.3;
+            jump Test.8 Test.10 Test.11;
+    in
+    jump Test.8 #Derived_gen.0 #Derived_gen.1;
+
+procedure Test.0 ():
+    let Test.6 : I64 = 1000000i64;
+    let Test.7 : I64 = 0i64;
+    let Test.5 : I64 = CallByName Test.1 Test.6 Test.7;
+    ret Test.5;

--- a/crates/compiler/test_mono/src/tests.rs
+++ b/crates/compiler/test_mono/src/tests.rs
@@ -1632,6 +1632,21 @@ fn tail_call_elimination_if_else() {
         "
     )
 }
+#[mono_test]
+fn tail_call_elimination_var() {
+    indoc!(
+        r"
+        sum = \n, accum ->
+            if n==0 then
+                accum
+            else 
+                res=sum (n - 1) (n + accum)
+                res
+
+        sum 1_000_000 0
+        "
+    )
+}
 
 #[mono_test]
 fn tail_call_with_same_layout_different_lambda_sets() {

--- a/crates/compiler/test_mono/src/tests.rs
+++ b/crates/compiler/test_mono/src/tests.rs
@@ -1620,6 +1620,20 @@ fn tail_call_elimination() {
 }
 
 #[mono_test]
+fn tail_call_elimination_if_else() {
+    indoc!(
+        r"
+        sum = \n, accum ->
+            if n==0 then
+                accum
+            else sum (n - 1) (n + accum)
+
+        sum 1_000_000 0
+        "
+    )
+}
+
+#[mono_test]
 fn tail_call_with_same_layout_different_lambda_sets() {
     indoc!(
         r#"

--- a/crates/lang_srv/src/analysis/analysed_doc.rs
+++ b/crates/lang_srv/src/analysis/analysed_doc.rs
@@ -153,7 +153,7 @@ impl AnalyzedDocument {
                     Some(Diagnostic {
                         range,
                         severity: Some(DiagnosticSeverity::HINT),
-                        message: "This call is recursive,not tail recursive".to_string(),
+                        message: "This call is recursive, not tail recursive".to_string(),
                         ..Default::default()
                     })
                 }


### PR DESCRIPTION
This is an exploration of showing information about whether a function or closure is tail recursive.

It shows when hovering the function definition:
![image](https://github.com/roc-lang/roc/assets/26968035/a8512ae4-cbd7-4715-9dec-d8a192570f4e)
And in diagnostics:

![image](https://github.com/roc-lang/roc/assets/26968035/f97437bb-1e4b-4df8-b208-0cc1a7238618)
![image](https://github.com/roc-lang/roc/assets/26968035/7e20e458-4cbb-4baa-89e2-793d7d50aa70)

This required me to change tail-recursive info gathered during canonicalization. I'm unsure if i can now remove the "mark_def_recursive" function or if there is some other kind of recursion I've not thought of.
