### PR TITLE
Update the alignment of 128 bit numeric types

### DIFF
--- a/crates/compiler/builtins/src/bitcode.rs
+++ b/crates/compiler/builtins/src/bitcode.rs
@@ -130,10 +130,12 @@ impl IntWidth {
                 // according to https://reviews.llvm.org/D28990#655487
                 //
                 // however, rust does not always think that this is true
+                // This matches what is currently reported by rust and zig.
+                // When finally updates the alignment, this will likely change.
                 match target_info.architecture {
-                    Architecture::X86_64 => 16,
-                    Architecture::Aarch64 | Architecture::Aarch32 | Architecture::Wasm32 => 16,
-                    Architecture::X86_32 => 8,
+                    Architecture::Aarch64 => 16,
+                    Architecture::X86_64 | Architecture::Aarch32 | Architecture::Wasm32 => 8,
+                    Architecture::X86_32 => 4,
                 }
             }
         }

--- a/crates/compiler/mono/src/layout.rs
+++ b/crates/compiler/mono/src/layout.rs
@@ -4840,6 +4840,6 @@ mod test {
     #[test]
     fn align_u128_in_tag_union() {
         let interner = STLayoutInterner::with_capacity(4, TargetInfo::default_x86_64());
-        assert_eq!(interner.alignment_bytes(Layout::U128), 16);
+        assert_eq!(interner.alignment_bytes(Layout::U128), 8);
     }
 }

--- a/crates/compiler/test_gen/src/gen_tags.rs
+++ b/crates/compiler/test_gen/src/gen_tags.rs
@@ -15,7 +15,7 @@ use indoc::indoc;
 
 use roc_mono::layout::{LayoutRepr, STLayoutInterner};
 #[cfg(test)]
-use roc_std::{RocList, RocStr, U128};
+use roc_std::{RocList, RocStr};
 
 #[test]
 fn width_and_alignment_u8_u8() {

--- a/crates/compiler/test_gen/src/gen_tags.rs
+++ b/crates/compiler/test_gen/src/gen_tags.rs
@@ -1779,9 +1779,10 @@ fn alignment_i128() {
                 x
                 #"
         ),
+        // This note will matter again when LLVM actually aligns u128 to 16 bytes.
         // NOTE: roc_std::U128 is always aligned to 16, unlike rust's u128
-        ((U128::from(42), true), 1),
-        ((U128, bool), u8)
+        ((42u128, true), 1),
+        ((u128, bool), u8)
     );
 }
 

--- a/crates/compiler/test_mono/generated/inspect_derived_record.txt
+++ b/crates/compiler/test_mono/generated/inspect_derived_record.txt
@@ -1,18 +1,18 @@
 procedure #Derived.0 (#Derived.1):
-    let #Derived_gen.0 : {Decimal, I64} = CallByName Inspect.30 #Derived.1;
+    let #Derived_gen.0 : {I64, Decimal} = CallByName Inspect.30 #Derived.1;
     ret #Derived_gen.0;
 
 procedure #Derived.2 (#Derived.3, #Derived.1):
-    let #Derived_gen.13 : I64 = StructAtIndex 1 #Derived.1;
-    let #Derived_gen.11 : [C I64, C Decimal] = CallByName Inspect.54 #Derived_gen.13;
-    let #Derived_gen.12 : Str = "a";
-    let #Derived_gen.6 : {[C I64, C Decimal], Str} = Struct {#Derived_gen.11, #Derived_gen.12};
-    let #Derived_gen.10 : Decimal = StructAtIndex 0 #Derived.1;
-    let #Derived_gen.8 : [C I64, C Decimal] = CallByName Inspect.60 #Derived_gen.10;
-    let #Derived_gen.9 : Str = "b";
-    let #Derived_gen.7 : {[C I64, C Decimal], Str} = Struct {#Derived_gen.8, #Derived_gen.9};
-    let #Derived_gen.5 : List {[C I64, C Decimal], Str} = Array [#Derived_gen.6, #Derived_gen.7];
-    let #Derived_gen.4 : List {[C I64, C Decimal], Str} = CallByName Inspect.42 #Derived_gen.5;
+    let #Derived_gen.11 : Str = "a";
+    let #Derived_gen.13 : I64 = StructAtIndex 0 #Derived.1;
+    let #Derived_gen.12 : [C I64, C Decimal] = CallByName Inspect.54 #Derived_gen.13;
+    let #Derived_gen.6 : {Str, [C I64, C Decimal]} = Struct {#Derived_gen.11, #Derived_gen.12};
+    let #Derived_gen.8 : Str = "b";
+    let #Derived_gen.10 : Decimal = StructAtIndex 1 #Derived.1;
+    let #Derived_gen.9 : [C I64, C Decimal] = CallByName Inspect.60 #Derived_gen.10;
+    let #Derived_gen.7 : {Str, [C I64, C Decimal]} = Struct {#Derived_gen.8, #Derived_gen.9};
+    let #Derived_gen.5 : List {Str, [C I64, C Decimal]} = Array [#Derived_gen.6, #Derived_gen.7];
+    let #Derived_gen.4 : List {Str, [C I64, C Decimal]} = CallByName Inspect.42 #Derived_gen.5;
     let #Derived_gen.3 : Str = CallByName Inspect.31 #Derived_gen.4 #Derived.3;
     ret #Derived_gen.3;
 
@@ -42,8 +42,8 @@ procedure Inspect.232 (Inspect.233, Inspect.229):
     ret Inspect.335;
 
 procedure Inspect.234 (Inspect.338, Inspect.339):
-    let Inspect.238 : [C I64, C Decimal] = StructAtIndex 0 Inspect.339;
-    let Inspect.237 : Str = StructAtIndex 1 Inspect.339;
+    let Inspect.237 : Str = StructAtIndex 0 Inspect.339;
+    let Inspect.238 : [C I64, C Decimal] = StructAtIndex 1 Inspect.339;
     let Inspect.235 : Str = StructAtIndex 0 Inspect.338;
     let Inspect.236 : Int1 = StructAtIndex 1 Inspect.338;
     joinpoint Inspect.354 Inspect.239:
@@ -122,11 +122,11 @@ procedure Inspect.36 (Inspect.305):
     ret Inspect.315;
 
 procedure Inspect.42 (Inspect.229):
-    let Inspect.319 : List {[C I64, C Decimal], Str} = CallByName Inspect.30 Inspect.229;
+    let Inspect.319 : List {Str, [C I64, C Decimal]} = CallByName Inspect.30 Inspect.229;
     ret Inspect.319;
 
 procedure Inspect.5 (Inspect.151):
-    let Inspect.316 : {Decimal, I64} = CallByName #Derived.0 Inspect.151;
+    let Inspect.316 : {I64, Decimal} = CallByName #Derived.0 Inspect.151;
     let Inspect.313 : {} = Struct {};
     let Inspect.312 : Str = CallByName Inspect.36 Inspect.313;
     let Inspect.311 : Str = CallByName #Derived.2 Inspect.312 Inspect.316;
@@ -161,14 +161,14 @@ procedure List.6 (#Attr.2):
     ret List.582;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.581 : {[C I64, C Decimal], Str} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    let List.581 : {Str, [C I64, C Decimal]} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
     ret List.581;
 
 procedure List.90 (#Derived_gen.16, #Derived_gen.17, #Derived_gen.18, #Derived_gen.19, #Derived_gen.20):
     joinpoint List.574 List.161 List.162 List.163 List.164 List.165:
         let List.576 : Int1 = CallByName Num.22 List.164 List.165;
         if List.576 then
-            let List.580 : {[C I64, C Decimal], Str} = CallByName List.66 List.161 List.164;
+            let List.580 : {Str, [C I64, C Decimal]} = CallByName List.66 List.161 List.164;
             inc List.580;
             let List.166 : {Str, Int1} = CallByName Inspect.234 List.162 List.580;
             let List.579 : U64 = 1i64;
@@ -201,8 +201,8 @@ procedure Str.3 (#Attr.2, #Attr.3):
     ret Str.251;
 
 procedure Test.0 ():
-    let Test.3 : Decimal = 3dec;
-    let Test.4 : I64 = 7i64;
-    let Test.2 : {Decimal, I64} = Struct {Test.3, Test.4};
+    let Test.3 : I64 = 7i64;
+    let Test.4 : Decimal = 3dec;
+    let Test.2 : {I64, Decimal} = Struct {Test.3, Test.4};
     let Test.1 : Str = CallByName Inspect.34 Test.2;
     ret Test.1;

--- a/crates/compiler/test_mono/generated/ir_when_record.txt
+++ b/crates/compiler/test_mono/generated/ir_when_record.txt
@@ -1,6 +1,6 @@
 procedure Test.0 ():
-    let Test.4 : Decimal = 3.14dec;
-    let Test.5 : I64 = 1i64;
-    let Test.2 : {Decimal, I64} = Struct {Test.4, Test.5};
-    let Test.1 : I64 = StructAtIndex 1 Test.2;
+    let Test.4 : I64 = 1i64;
+    let Test.5 : Decimal = 3.14dec;
+    let Test.2 : {I64, Decimal} = Struct {Test.4, Test.5};
+    let Test.1 : I64 = StructAtIndex 0 Test.2;
     ret Test.1;

--- a/crates/compiler/test_mono/generated/let_with_record_pattern.txt
+++ b/crates/compiler/test_mono/generated/let_with_record_pattern.txt
@@ -1,6 +1,6 @@
 procedure Test.0 ():
-    let Test.4 : Decimal = 3.14dec;
-    let Test.5 : I64 = 2i64;
-    let Test.3 : {Decimal, I64} = Struct {Test.4, Test.5};
-    let Test.1 : I64 = StructAtIndex 1 Test.3;
+    let Test.4 : I64 = 2i64;
+    let Test.5 : Decimal = 3.14dec;
+    let Test.3 : {I64, Decimal} = Struct {Test.4, Test.5};
+    let Test.1 : I64 = StructAtIndex 0 Test.3;
     ret Test.1;

--- a/crates/compiler/test_mono/generated/let_with_record_pattern_list.txt
+++ b/crates/compiler/test_mono/generated/let_with_record_pattern_list.txt
@@ -1,6 +1,6 @@
 procedure Test.0 ():
-    let Test.4 : Decimal = 3.14dec;
-    let Test.5 : List I64 = Array [1i64, 3i64, 4i64];
-    let Test.3 : {Decimal, List I64} = Struct {Test.4, Test.5};
-    let Test.1 : List I64 = StructAtIndex 1 Test.3;
+    let Test.4 : List I64 = Array [1i64, 3i64, 4i64];
+    let Test.5 : Decimal = 3.14dec;
+    let Test.3 : {List I64, Decimal} = Struct {Test.4, Test.5};
+    let Test.1 : List I64 = StructAtIndex 0 Test.3;
     ret Test.1;

--- a/crates/glue/tests/test_glue_cli.rs
+++ b/crates/glue/tests/test_glue_cli.rs
@@ -79,7 +79,7 @@ mod glue_cli_run {
     }
 
     fixtures! {
-        basic_record:"basic-record" => "Record was: MyRcd { b: 42, a: 1995 }\n",
+        basic_record:"basic-record" => "Record was: MyRcd { a: 1995, b: 42 }\n",
         nested_record:"nested-record" => "Record was: Outer { y: \"foo\", z: [1, 2], x: Inner { b: 24.0, a: 5 } }\n",
         enumeration:"enumeration" => "tag_union was: MyEnum::Foo, Bar is: MyEnum::Bar, Baz is: MyEnum::Baz\n",
         single_tag_union:"single-tag-union" => indoc!(r#"

--- a/crates/roc_std/src/lib.rs
+++ b/crates/roc_std/src/lib.rs
@@ -372,7 +372,7 @@ impl RocDec {
         }
 
         match hi.checked_mul(Self::ONE_POINT_ZERO) {
-            Some(hi) => hi.checked_add(lo).map(|num| Self(num)),
+            Some(hi) => hi.checked_add(lo).map(Self),
             None => None,
         }
     }

--- a/crates/roc_std/src/lib.rs
+++ b/crates/roc_std/src/lib.rs
@@ -267,8 +267,7 @@ impl<T, E> Drop for RocResult<T, E> {
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
-#[repr(C, align(16))]
-pub struct RocDec([u8; 16]);
+pub struct RocDec(i128);
 
 impl Debug for RocDec {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -280,8 +279,8 @@ impl Debug for RocDec {
 }
 
 impl RocDec {
-    pub const MIN: Self = Self(i128::MIN.to_ne_bytes());
-    pub const MAX: Self = Self(i128::MAX.to_ne_bytes());
+    pub const MIN: Self = Self(i128::MIN);
+    pub const MAX: Self = Self(i128::MAX);
 
     const DECIMAL_PLACES: usize = 18;
     const ONE_POINT_ZERO: i128 = 10i128.pow(Self::DECIMAL_PLACES as u32);
@@ -289,7 +288,7 @@ impl RocDec {
     const MAX_STR_LENGTH: usize = Self::MAX_DIGITS + 2; // + 2 here to account for the sign & decimal dot
 
     pub fn new(num: i128) -> Self {
-        Self(num.to_ne_bytes())
+        Self(num)
     }
 
     pub fn as_bits(&self) -> (i64, u64) {
@@ -373,7 +372,7 @@ impl RocDec {
         }
 
         match hi.checked_mul(Self::ONE_POINT_ZERO) {
-            Some(hi) => hi.checked_add(lo).map(|num| Self(num.to_ne_bytes())),
+            Some(hi) => hi.checked_add(lo).map(|num| Self(num)),
             None => None,
         }
     }
@@ -385,15 +384,15 @@ impl RocDec {
     /// This is private because RocDec being an i128 is an implementation detail
     #[inline(always)]
     fn as_i128(&self) -> i128 {
-        i128::from_ne_bytes(self.0)
+        self.0
     }
 
     pub fn from_ne_bytes(bytes: [u8; 16]) -> Self {
-        Self(bytes)
+        Self(i128::from_ne_bytes(bytes))
     }
 
     pub fn to_ne_bytes(&self) -> [u8; 16] {
-        self.0
+        self.0.to_ne_bytes()
     }
 
     fn to_str_helper(self, string: &mut ArrayString<{ Self::MAX_STR_LENGTH }>) -> &str {


### PR DESCRIPTION
With current llvm and languages we work with (rust and zig), i128/u128/dec are not aligned to 16 bytes.

This commit sets their alignment to match what is found in zig and rust. Once that is update, we can change back to 16 byte alignment for these. That may take a while, it will at least be the next llvm release. It is unclear when the changes will then be pulled into rust and zig.