### PR TITLE
Correct windows return by pointer calculation

### DIFF
--- a/crates/compiler/gen_llvm/src/llvm/build.rs
+++ b/crates/compiler/gen_llvm/src/llvm/build.rs
@@ -6751,9 +6751,7 @@ pub fn to_cc_return<'a>(
 ) -> CCReturn {
     let return_size = layout_interner.stack_size(layout);
     let pass_result_by_pointer = match env.target_info.operating_system {
-        roc_target::OperatingSystem::Windows => {
-            return_size >= 2 * env.target_info.ptr_width() as u32
-        }
+        roc_target::OperatingSystem::Windows => return_size > env.target_info.ptr_width() as u32,
         roc_target::OperatingSystem::Unix => return_size > 2 * env.target_info.ptr_width() as u32,
         roc_target::OperatingSystem::Wasi => return_size > 2 * env.target_info.ptr_width() as u32,
     };


### PR DESCRIPTION
I always thought this was wrong. Saw it again today and decided to look it up. Windows will return by pointer for anything over 64bits on an x86_64 machine.

Note: this is wrong for windows aarch64, but I will correct that in a PR where I clean up targets.
https://learn.microsoft.com/en-us/cpp/build/x64-calling-convention?view=msvc-170#return-values
https://learn.microsoft.com/en-us/cpp/build/arm64-windows-abi-conventions?view=msvc-170#return-values

@lukewilliamboswell I'm not sure the state of windows tests, but do you have anything you can do to double check this/test locally on windows?