### PR TITLE
make an inline expect triggered by a top-level expect work

### DIFF
--- a/crates/cli/tests/cli_run.rs
+++ b/crates/cli/tests/cli_run.rs
@@ -553,9 +553,11 @@ mod cli_run {
             &[],
             indoc!(
                 r#"
+                ── EXPECT FAILED in ...roc/roc/crates/cli_testing_examples/expects/expects.roc ─
+
                 This expectation failed:
 
-                19│      expect words == []
+                28│      expect words == []
                                 ^^^^^^^^^^^
 
                 When it failed, these variables had these values:
@@ -563,12 +565,12 @@ mod cli_run {
                 words : List Str
                 words = ["this", "will", "for", "sure", "be", "a", "large", "string", "so", "when", "we", "split", "it", "it", "will", "use", "seamless", "slices", "which", "affect", "printing"]
 
-                [<ignored for tests>:22] x = 42
-                [<ignored for tests>:23] "Fjoer en ferdjer frieten oan dyn geve lea" = "Fjoer en ferdjer frieten oan dyn geve lea"
-                [<ignored for tests>:24] "this is line 24" = "this is line 24"
-                [<ignored for tests>:13] x = "abc"
-                [<ignored for tests>:13] x = 10
-                [<ignored for tests>:13] x = (A (B C))
+                [<ignored for tests>:31] x = 42
+                [<ignored for tests>:33] "Fjoer en ferdjer frieten oan dyn geve lea" = "Fjoer en ferdjer frieten oan dyn geve lea"
+                [<ignored for tests>:35] "this is line 24" = "this is line 24"
+                [<ignored for tests>:21] x = "abc"
+                [<ignored for tests>:21] x = 10
+                [<ignored for tests>:21] x = (A (B C))
                 Program finished!
                 "#
             ),
@@ -584,20 +586,46 @@ mod cli_run {
             &[],
             indoc!(
                 r#"
+                ── EXPECT FAILED in ...roc/roc/crates/cli_testing_examples/expects/expects.roc ─
+
                 This expectation failed:
 
-                 6│>  expect
-                 7│>      a = 1
-                 8│>      b = 2
-                 9│>
-                10│>      a == b
+                9│      expect a == 2
+                               ^^^^^^
 
                 When it failed, these variables had these values:
 
                 a : Num *
                 a = 1
 
-                b : Num *
+                ── EXPECT FAILED in ...roc/roc/crates/cli_testing_examples/expects/expects.roc ─
+
+                This expectation failed:
+
+                10│      expect a == 3
+                                ^^^^^^
+
+                When it failed, these variables had these values:
+
+                a : Num *
+                a = 1
+
+                ── EXPECT FAILED in ...roc/roc/crates/cli_testing_examples/expects/expects.roc ─
+
+                This expectation failed:
+
+                14│>  expect
+                15│>      a = makeA
+                16│>      b = 2i64
+                17│>
+                18│>      a == b
+
+                When it failed, these variables had these values:
+
+                a : Int Signed64
+                a = 1
+
+                b : I64
                 b = 2
 
 

--- a/crates/cli_testing_examples/expects/expects.roc
+++ b/crates/cli_testing_examples/expects/expects.roc
@@ -3,14 +3,23 @@ app "expects-test"
     imports []
     provides [main] to pf
 
-expect
+makeA =
     a = 1
-    b = 2
+
+    expect a == 2
+    expect a == 3
+
+    a
+
+expect
+    a = makeA
+    b = 2i64
 
     a == b
 
 polyDbg = \x ->
     dbg x
+
     x
 
 main =
@@ -20,10 +29,12 @@ main =
 
     x = 42
     dbg x
+
     dbg "Fjoer en ferdjer frieten oan dyn geve lea"
+
     dbg "this is line 24"
 
-    r = {x : polyDbg "abc", y: polyDbg 10u8, z : polyDbg (A (B C))}
+    r = { x: polyDbg "abc", y: polyDbg 10u8, z: polyDbg (A (B C)) }
 
     when r is
         _ -> "Program finished!\n"

--- a/crates/compiler/build/src/link.rs
+++ b/crates/compiler/build/src/link.rs
@@ -613,7 +613,8 @@ pub fn rebuild_host(
 
             // Clean up c_host.o
             if c_host_dest.exists() {
-                std::fs::remove_file(c_host_dest).unwrap();
+                // there can be a race condition on this file cleanup
+                let _ = std::fs::remove_file(c_host_dest);
             }
         }
     } else if rust_host_src.exists() {

--- a/crates/repl_expect/src/run.rs
+++ b/crates/repl_expect/src/run.rs
@@ -273,7 +273,7 @@ fn run_expect_pure<'a, W: std::io::Write>(
             let mut offset = ExpectSequence::START_OFFSET;
 
             for _ in 0..sequence.count_failures() {
-                offset += render_expect_failure(
+                offset = render_expect_failure(
                     writer,
                     &renderer,
                     arena,
@@ -729,6 +729,10 @@ pub fn expect_mono_module_to_dylib<'a>(
             "Errors defining module:\n{}\n\nUncomment things nearby to see more details. IR written to `{:?}`",
             errors.to_string(), path,
         );
+    }
+
+    if let Ok(path) = std::env::var("ROC_DEBUG_LLVM") {
+        env.module.print_to_file(path).unwrap();
     }
 
     llvm_module_to_dylib(env.module, &target, opt_level).map(|lib| (lib, expects, layout_interner))


### PR DESCRIPTION
fixes https://github.com/roc-lang/roc/issues/6350

this only works though if the inline expect is in some other binding. if it is within a top-level expect it hits a mono todo. That should be straightforward to fix, but will happen later/separately