### PR TITLE
Fix and test for generating stub lib for macho 

### DIFF
--- a/crates/linker/src/generate_dylib/macho.rs
+++ b/crates/linker/src/generate_dylib/macho.rs
@@ -68,10 +68,10 @@ pub fn create_dylib_macho(
     if !output.status.success() {
         match std::str::from_utf8(&output.stderr) {
             Ok(stderr) => panic!(
-                "Failed to link dummy shared library - stderr of the `ld` command was:\n{stderr}"
+                "Failed to link dummy shared library - stderr of the `zig build-lib` command was:\n{stderr}"
             ),
             Err(utf8_err) => panic!(
-                "Failed to link dummy shared library  - stderr of the `ld` command was invalid utf8 ({utf8_err:?})"
+                "Failed to link dummy shared library  - stderr of the `zig build-lib` command was invalid utf8 ({utf8_err:?})"
             ),
         }
     }

--- a/crates/linker/src/generate_dylib/macho.rs
+++ b/crates/linker/src/generate_dylib/macho.rs
@@ -1,7 +1,6 @@
 use object::write;
 use object::{Architecture, BinaryFormat, Endianness, SymbolFlags, SymbolKind, SymbolScope};
 use roc_error_macros::internal_error;
-use std::path::Path;
 use std::process::Command;
 use target_lexicon::Triple;
 
@@ -11,10 +10,10 @@ pub fn create_dylib_macho(
     triple: &Triple,
 ) -> object::read::Result<Vec<u8>> {
     let dummy_obj_file = tempfile::Builder::new()
-    .prefix("roc_lib")
-    .suffix(".o")
-    .tempfile()
-    .unwrap_or_else(|e| internal_error!("{}", e));
+        .prefix("roc_lib")
+        .suffix(".o")
+        .tempfile()
+        .unwrap_or_else(|e| internal_error!("{}", e));
     let tmp = tempfile::tempdir().unwrap_or_else(|e| internal_error!("{}", e));
     let dummy_lib_file = tmp.path().to_path_buf().with_file_name("libapp.dylib");
 

--- a/crates/linker/src/generate_dylib/macho.rs
+++ b/crates/linker/src/generate_dylib/macho.rs
@@ -18,9 +18,9 @@ pub fn create_dylib_macho(
     let dummy_lib_file = tmp.path().to_path_buf().with_file_name("libapp.dylib");
 
     let obj_target = BinaryFormat::MachO;
-    let obj_arch = match triple.architecture {
-        target_lexicon::Architecture::X86_64 => Architecture::X86_64,
-        target_lexicon::Architecture::Aarch64(_) => Architecture::Aarch64,
+    let (obj_arch, zig_target) = match triple.architecture {
+        target_lexicon::Architecture::X86_64 => (Architecture::X86_64, "x86_64-macos-none"),
+        target_lexicon::Architecture::Aarch64(_) => (Architecture::Aarch64, "aarch64-macos-none"),
         _ => {
             // We should have verified this via supported() before calling this function
             unreachable!()
@@ -52,9 +52,11 @@ pub fn create_dylib_macho(
     let output = Command::new("zig")
         .arg("build-lib")
         .args([
-            format!("-femit-bin={}", dummy_lib_file.as_path().display()),
-            "-dynamic".to_string(),
-            dummy_obj_file.path().to_str().unwrap().to_string(),
+            "-target",
+            zig_target,
+            format!("-femit-bin={}", dummy_lib_file.as_path().display()).as_str(),
+            "-dynamic",
+            dummy_obj_file.path().to_str().unwrap(),
         ])
         .output()
         .unwrap();

--- a/crates/linker/src/generate_dylib/mod.rs
+++ b/crates/linker/src/generate_dylib/mod.rs
@@ -64,9 +64,13 @@ mod tests {
     fn check_exports_macho() {
         let target = target_lexicon::Triple {
             architecture: target_lexicon::Architecture::Aarch64(
-                target_lexicon::Aarch64Architecture::Aarch64
+                target_lexicon::Aarch64Architecture::Aarch64,
             ),
-            operating_system: target_lexicon::OperatingSystem::MacOSX { major: 1, minor: 0, patch: 0 },
+            operating_system: target_lexicon::OperatingSystem::MacOSX {
+                major: 1,
+                minor: 0,
+                patch: 0,
+            },
             binary_format: target_lexicon::BinaryFormat::Macho,
             ..target_lexicon::Triple::host()
         };


### PR DESCRIPTION
I tried a few different things and found using `zig build-lib` instead of `ld` to be quite reliable for generating a `.dylib` with the correct symbols.

I noticed that for macOS the exported symbols are prepended with an `_` underscore which I don't know if this is an issue for roc linking in future.