### PR TITLE
Fix List.first anchor link on the different-names webpage

### DIFF
--- a/www/public/different-names/index.html
+++ b/www/public/different-names/index.html
@@ -66,7 +66,7 @@
                 </td>
             </tr>
             <tr>
-                <td><a href="/builtins/List#join">List.first</a></td>
+                <td><a href="/builtins/List#first">List.first</a></td>
                 <td>
                     <ul>
                         <li>head</li>


### PR DESCRIPTION
List.first on https://www.roc-lang.org/different-names is linking to https://www.roc-lang.org/builtins/List#join instead of https://www.roc-lang.org/builtins/List#first so this PR corrects that. 

Discussion: https://roc.zulipchat.com/#narrow/stream/316715-contributing/topic/2023.20website.20update/near/419937244