### PR TITLE
repl now uses replfile.roc behind the scenes.

### DIFF
--- a/crates/repl_eval/src/gen.rs
+++ b/crates/repl_eval/src/gen.rs
@@ -52,7 +52,7 @@ pub fn compile_to_mono<'a, 'i, I: Iterator<Item = &'i str>>(
     target_info: TargetInfo,
     palette: Palette,
 ) -> (Option<MonomorphizedModule<'a>>, Problems) {
-    let filename = PathBuf::from("");
+    let filename = PathBuf::from("replfile.roc");
     let src_dir = PathBuf::from("fake/test/path");
     let (bytes_before_expr, module_src) = promote_expr_to_module(arena, defs, expr);
     let loaded = roc_load::load_and_monomorphize_from_str(

--- a/crates/reporting/src/report.rs
+++ b/crates/reporting/src/report.rs
@@ -166,7 +166,7 @@ impl<'b> Report<'b> {
         if self.title.is_empty() {
             self.doc
         } else {
-            let header = if self.filename == PathBuf::from("") {
+            let header = if self.filename == PathBuf::from("replfile.roc") {
                 crate::report::pretty_header(&self.title)
             } else {
                 crate::report::pretty_header_with_path(&self.title, &self.filename)


### PR DESCRIPTION
Previously this was using an empty filename but that seems potentially confusing during debugging.
The empty filename also created issues with logical filename restrictions added in https://github.com/roc-lang/roc/pull/6506.