### PR TITLE
Update REPL font color (ANSI colors to XTERM 256 colors)

### DIFF
--- a/crates/cli_utils/src/helpers.rs
+++ b/crates/cli_utils/src/helpers.rs
@@ -99,19 +99,19 @@ pub fn path_to_binary(binary_name: &str) -> PathBuf {
 }
 
 pub fn strip_colors(str: &str) -> String {
-    use roc_reporting::report::ANSI_STYLE_CODES;
+    use roc_reporting::report::XTERM_256_COLOR_STYLE_CODES;
 
-    str.replace(ANSI_STYLE_CODES.red, "")
-        .replace(ANSI_STYLE_CODES.green, "")
-        .replace(ANSI_STYLE_CODES.yellow, "")
-        .replace(ANSI_STYLE_CODES.blue, "")
-        .replace(ANSI_STYLE_CODES.magenta, "")
-        .replace(ANSI_STYLE_CODES.cyan, "")
-        .replace(ANSI_STYLE_CODES.white, "")
-        .replace(ANSI_STYLE_CODES.bold, "")
-        .replace(ANSI_STYLE_CODES.underline, "")
-        .replace(ANSI_STYLE_CODES.reset, "")
-        .replace(ANSI_STYLE_CODES.color_reset, "")
+    str.replace(XTERM_256_COLOR_STYLE_CODES.red, "")
+        .replace(XTERM_256_COLOR_STYLE_CODES.green, "")
+        .replace(XTERM_256_COLOR_STYLE_CODES.yellow, "")
+        .replace(XTERM_256_COLOR_STYLE_CODES.blue, "")
+        .replace(XTERM_256_COLOR_STYLE_CODES.magenta, "")
+        .replace(XTERM_256_COLOR_STYLE_CODES.cyan, "")
+        .replace(XTERM_256_COLOR_STYLE_CODES.white, "")
+        .replace(XTERM_256_COLOR_STYLE_CODES.bold, "")
+        .replace(XTERM_256_COLOR_STYLE_CODES.underline, "")
+        .replace(XTERM_256_COLOR_STYLE_CODES.reset, "")
+        .replace(XTERM_256_COLOR_STYLE_CODES.color_reset, "")
 }
 
 pub fn run_roc_with_stdin<I, S>(args: I, stdin_vals: &[&str]) -> Out

--- a/crates/compiler/load/tests/test_reporting.rs
+++ b/crates/compiler/load/tests/test_reporting.rs
@@ -22,8 +22,8 @@ mod test_reporting {
     use roc_problem::Severity;
     use roc_region::all::LineInfo;
     use roc_reporting::report::{
-        can_problem, parse_problem, type_problem, RenderTarget, Report, ANSI_STYLE_CODES,
-        DEFAULT_PALETTE,
+        can_problem, parse_problem, type_problem, RenderTarget, Report, DEFAULT_PALETTE,
+        XTERM_256_COLOR_STYLE_CODES,
     };
     use roc_reporting::report::{RocDocAllocator, RocDocBuilder};
     use roc_solve::FunctionKind;
@@ -460,16 +460,16 @@ mod test_reporting {
     }
 
     fn human_readable(str: &str) -> String {
-        str.replace(ANSI_STYLE_CODES.red, "<red>")
-            .replace(ANSI_STYLE_CODES.white, "<white>")
-            .replace(ANSI_STYLE_CODES.blue, "<blue>")
-            .replace(ANSI_STYLE_CODES.yellow, "<yellow>")
-            .replace(ANSI_STYLE_CODES.green, "<green>")
-            .replace(ANSI_STYLE_CODES.cyan, "<cyan>")
-            .replace(ANSI_STYLE_CODES.magenta, "<magenta>")
-            .replace(ANSI_STYLE_CODES.reset, "<reset>")
-            .replace(ANSI_STYLE_CODES.bold, "<bold>")
-            .replace(ANSI_STYLE_CODES.underline, "<underline>")
+        str.replace(XTERM_256_COLOR_STYLE_CODES.red, "<red>")
+            .replace(XTERM_256_COLOR_STYLE_CODES.white, "<white>")
+            .replace(XTERM_256_COLOR_STYLE_CODES.blue, "<blue>")
+            .replace(XTERM_256_COLOR_STYLE_CODES.yellow, "<yellow>")
+            .replace(XTERM_256_COLOR_STYLE_CODES.green, "<green>")
+            .replace(XTERM_256_COLOR_STYLE_CODES.cyan, "<cyan>")
+            .replace(XTERM_256_COLOR_STYLE_CODES.magenta, "<magenta>")
+            .replace(XTERM_256_COLOR_STYLE_CODES.reset, "<reset>")
+            .replace(XTERM_256_COLOR_STYLE_CODES.bold, "<bold>")
+            .replace(XTERM_256_COLOR_STYLE_CODES.underline, "<underline>")
     }
 
     test_report!(

--- a/crates/repl_cli/src/lib.rs
+++ b/crates/repl_cli/src/lib.rs
@@ -9,7 +9,7 @@ use roc_repl_eval::gen::Problems;
 use roc_repl_ui::colors::{BLUE, END_COL, PINK};
 use roc_repl_ui::repl_state::{ReplAction, ReplState};
 use roc_repl_ui::{format_output, is_incomplete, CONT_PROMPT, PROMPT, SHORT_INSTRUCTIONS, TIPS};
-use roc_reporting::report::{ANSI_STYLE_CODES, DEFAULT_PALETTE};
+use roc_reporting::report::{DEFAULT_PALETTE, XTERM_256_COLOR_STYLE_CODES};
 use roc_target::TargetInfo;
 use rustyline::highlight::{Highlighter, PromptInfo};
 use rustyline::validate::{self, ValidationContext, ValidationResult, Validator};
@@ -110,7 +110,7 @@ pub fn evaluate(
     target: &Triple,
 ) -> String {
     let opt_output = opt_mono.and_then(|mono| eval_llvm(mono, target, OptLevel::Normal));
-    format_output(ANSI_STYLE_CODES, opt_output, problems)
+    format_output(XTERM_256_COLOR_STYLE_CODES, opt_output, problems)
 }
 
 #[derive(Default)]

--- a/crates/repl_ui/src/colors.rs
+++ b/crates/repl_ui/src/colors.rs
@@ -1,9 +1,9 @@
-use roc_reporting::report::{StyleCodes, ANSI_STYLE_CODES, HTML_STYLE_CODES};
+use roc_reporting::report::{StyleCodes, HTML_STYLE_CODES, XTERM_256_COLOR_STYLE_CODES};
 
 const STYLE_CODES: StyleCodes = if cfg!(target_family = "wasm") {
     HTML_STYLE_CODES
 } else {
-    ANSI_STYLE_CODES
+    XTERM_256_COLOR_STYLE_CODES
 };
 
 pub const BLUE: &str = STYLE_CODES.blue;

--- a/crates/reporting/src/report.rs
+++ b/crates/reporting/src/report.rs
@@ -239,7 +239,7 @@ const fn default_palette_from_style_codes(codes: StyleCodes) -> Palette {
     }
 }
 
-pub const DEFAULT_PALETTE: Palette = default_palette_from_style_codes(ANSI_STYLE_CODES);
+pub const DEFAULT_PALETTE: Palette = default_palette_from_style_codes(XTERM_256_COLOR_STYLE_CODES);
 
 pub const DEFAULT_PALETTE_HTML: Palette = default_palette_from_style_codes(HTML_STYLE_CODES);
 
@@ -259,14 +259,14 @@ pub struct StyleCodes {
     pub color_reset: &'static str,
 }
 
-pub const ANSI_STYLE_CODES: StyleCodes = StyleCodes {
-    red: "\u{001b}[31m",
-    green: "\u{001b}[32m",
-    yellow: "\u{001b}[33m",
-    blue: "\u{001b}[34m",
-    magenta: "\u{001b}[35m",
-    cyan: "\u{001b}[36m",
-    white: "\u{001b}[37m",
+pub const XTERM_256_COLOR_STYLE_CODES: StyleCodes = StyleCodes {
+    red: "\u{001b}[38;5;9m",
+    green: "\u{001b}[38;5;10m",
+    yellow: "\u{001b}[38;5;11m",
+    blue: "\u{001b}[38;5;27m",
+    magenta: "\u{001b}[38;5;171m",
+    cyan: "\u{001b}[38;5;14m",
+    white: "\u{001b}[38;5;15m",
     bold: "\u{001b}[1m",
     underline: "\u{001b}[4m",
     reset: "\u{001b}[0m",


### PR DESCRIPTION
This is a PR to fix #6512.

I picked up brighter colors out of xterm 256 colors, and tested them using my macos terminal with black background:

<img width="538" alt="Screenshot 2024-02-10 at 6 33 31" src="https://github.com/roc-lang/roc/assets/6666092/650e0fda-fdbd-423b-9e6a-fae59657f022">

You can tell me if you prefer different ones. 
Also here is a code that will display all 256 colors in your terminal:

```bash
for i in {0..255}; do echo -e "\e[38;5;${i}mForeground color ${i}"; done
```
