### PR TITLE
fix: different-names style upgrade

### DIFF
--- a/www/public/different-names/index.html
+++ b/www/public/different-names/index.html
@@ -16,131 +16,134 @@
 </head>
 
 <body>
-    <h1>Different Names</h1>
-    <p>Different programming languages sometimes choose different names for similar operations.
-        If you're new to Roc, you may be searching for a familiar operation and not find it because
-        that operation (or a similar one) goes by a different name in Roc.
-    </p>
+    <main>
+        <h1>Different Names</h1>
+        <p>Different programming languages sometimes choose different names for similar operations.
+            If you're new to Roc, you may be searching for a familiar operation and not find it because
+            that operation (or a similar one) goes by a different name in Roc.
+        </p>
 
-    <p>To help with this, here are some Roc operations along with some names found in other languages
-        for similar operations.
-    </p>
+        <p>To help with this, here are some Roc operations along with some names found in other languages
+            for similar operations.
+        </p>
 
-    <table>
-        <thead>
-            <tr>
-                <th>Roc Name</th>
-                <th>Other Names</th>
-            </tr>
-        </thead>
-        <tbody id="different-names-body">
-            <tr>
-                <td><a href="/builtins/List#walk">List.walk</a></td>
-                <td>
-                    <ul>
-                        <li>fold</li>
-                        <li>foldl</li>
-                        <li>foldLeft</li>
-                        <li>fold_left</li>
-                        <li>fold-left</li>
-                        <li>reduce</li>
-                        <li>lreduce</li>
-                        <li>array_reduce</li>
-                        <li>inject</li>
-                        <li>accumulate</li>
-                        <li>Aggregate</li>
-                    </ul>
-                </td>
-            </tr>
-            <tr>
-                <td><a href="/builtins/List#walkBackwards">List.walkBackwards</a></td>
-                <td>
-                    <ul>
-                        <li>foldr</li>
-                        <li>foldRight</li>
-                        <li>fold_right</li>
-                        <li>fold-right</li>
-                        <li>reduceRight</li>
-                        <li>rreduce</li>
-                    </ul>
-                </td>
-            </tr>
-            <tr>
-                <td><a href="/builtins/List#first">List.first</a></td>
-                <td>
-                    <ul>
-                        <li>head</li>
-                        <li>get(0)</li>
-                        <li>[0]</li>
-                    </ul>
-                </td>
-            </tr>
-            <tr>
-                <td><a href="/builtins/List#keepIf">List.keepIf</a></td>
-                <td>
-                    <ul>
-                        <li>filter</li>
-                        <li>select</li>
-                        <li>copy_if</li>
-                        <li>remove-if-not</li>
-                    </ul>
-                </td>
-            </tr>
-            <tr>
-                <td><a href="/builtins/List#dropIf">List.dropIf</a></td>
-                <td>
-                    <ul>
-                        <li>reject</li>
-                        <li>remove_copy_if</li>
-                        <li>remove-if</li>
-                    </ul>
-                </td>
-            </tr>
-            <tr>
-                <td><a href="/builtins/List#join">List.join</a></td>
-                <td>
-                    <ul>
-                        <li>flatten</li>
-                        <li>flat</li>
-                        <li>concat</li>
-                        <li>smoosh</li>
-                    </ul>
-                </td>
-            </tr>
-            <tr>
-                <td><a href="/builtins/List#joinMap">List.joinMap</a></td>
-                <td>
-                    <ul>
-                        <li>filterMap</li>
-                        <li>filter_map</li>
-                    </ul>
-                </td>
-            </tr>
-            <tr>
-                <td><a href="/builtins/List#keepOks">List.keepOks</a></td>
-                <td>
-                    <ul>
-                        <li>compact</li>
-                        <li>filterMap(identity)</li>
-                    </ul>
-                </td>
-            </tr>
-            <tr>
-                <td><a href="/builtins/Result#try">Result.try</a></td>
-                <td>
-                    <ul>
-                        <li>bind</li>
-                        <li>flatMap</li>
-                        <li>andThen</li>
-                        <li>(&gt;&gt;=)</li>
-                    </ul>
-                </td>
-            </tr>
-        </tbody>
-    </table>
+        <table>
+            <thead>
+                <tr>
+                    <th>Roc Name</th>
+                    <th>Other Names</th>
+                </tr>
+            </thead>
+            <tbody id="different-names-body">
+                <tr>
+                    <td><a href="/builtins/List#walk">List.walk</a></td>
+                    <td>
+                        <ul>
+                            <li>fold</li>
+                            <li>foldl</li>
+                            <li>foldLeft</li>
+                            <li>fold_left</li>
+                            <li>fold-left</li>
+                            <li>reduce</li>
+                            <li>lreduce</li>
+                            <li>array_reduce</li>
+                            <li>inject</li>
+                            <li>accumulate</li>
+                            <li>Aggregate</li>
+                        </ul>
+                    </td>
+                </tr>
+                <tr>
+                    <td><a href="/builtins/List#walkBackwards">List.walkBackwards</a></td>
+                    <td>
+                        <ul>
+                            <li>foldr</li>
+                            <li>foldRight</li>
+                            <li>fold_right</li>
+                            <li>fold-right</li>
+                            <li>reduceRight</li>
+                            <li>rreduce</li>
+                        </ul>
+                    </td>
+                </tr>
+                <tr>
+                    <td><a href="/builtins/List#first">List.first</a></td>
+                    <td>
+                        <ul>
+                            <li>head</li>
+                            <li>get(0)</li>
+                            <li>[0]</li>
+                        </ul>
+                    </td>
+                </tr>
+                <tr>
+                    <td><a href="/builtins/List#keepIf">List.keepIf</a></td>
+                    <td>
+                        <ul>
+                            <li>filter</li>
+                            <li>select</li>
+                            <li>copy_if</li>
+                            <li>remove-if-not</li>
+                        </ul>
+                    </td>
+                </tr>
+                <tr>
+                    <td><a href="/builtins/List#dropIf">List.dropIf</a></td>
+                    <td>
+                        <ul>
+                            <li>reject</li>
+                            <li>remove_copy_if</li>
+                            <li>remove-if</li>
+                        </ul>
+                    </td>
+                </tr>
+                <tr>
+                    <td><a href="/builtins/List#join">List.join</a></td>
+                    <td>
+                        <ul>
+                            <li>flatten</li>
+                            <li>flat</li>
+                            <li>concat</li>
+                            <li>smoosh</li>
+                        </ul>
+                    </td>
+                </tr>
+                <tr>
+                    <td><a href="/builtins/List#joinMap">List.joinMap</a></td>
+                    <td>
+                        <ul>
+                            <li>filterMap</li>
+                            <li>filter_map</li>
+                        </ul>
+                    </td>
+                </tr>
+                <tr>
+                    <td><a href="/builtins/List#keepOks">List.keepOks</a></td>
+                    <td>
+                        <ul>
+                            <li>compact</li>
+                            <li>filterMap(identity)</li>
+                        </ul>
+                    </td>
+                </tr>
+                <tr>
+                    <td><a href="/builtins/Result#try">Result.try</a></td>
+                    <td>
+                        <ul>
+                            <li>bind</li>
+                            <li>flatMap</li>
+                            <li>andThen</li>
+                            <li>(&gt;&gt;=)</li>
+                        </ul>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+    </main>
     <footer>
+        <div id="footer">
         <p>Made by people who like to make nice things.</p>
+        </div>
     </footer>
 </body>
-
 </html>


### PR DESCRIPTION
The /site.css has a new outline

Added the `<main>` tag to the document.
This gives room on the left to the page

https://github.com/roc-lang/roc/issues/6470

Tested in desktop emulating 

desktop 1440x900
![Screen Shot 2024-02-14 at 21 03 07](https://github.com/roc-lang/roc/assets/15113/57e1b264-9a7e-483e-a9c0-304c7c872415)


