### PR TITLE
Export all symbols on wasm builds

### DIFF
--- a/crates/compiler/build/src/link.rs
+++ b/crates/compiler/build/src/link.rs
@@ -1232,6 +1232,7 @@ fn link_wasm32(
             "-fstrip",
             "-O",
             "ReleaseSmall",
+            "-rdynamic",
             // useful for debugging
             // "-femit-llvm-ir=/home/folkertdev/roc/roc/crates/cli_testing_examples/benchmarks/platform/host.ll",
         ])


### PR DESCRIPTION
This exports all symbols on wasm builds. This is necessary since zig 0.11. When there are individual build scripts for platforms, then it will be possible only to export the necessary symbols. For now, this is the only way to export functions to the wasm host.