### PR TITLE
Update CI workflow to not run tests when only roc comments changed

### DIFF
--- a/.github/workflows/ci_manager.yml
+++ b/.github/workflows/ci_manager.yml
@@ -31,10 +31,24 @@ jobs:
               id: check_rs_comments
               run: |
                 git fetch origin ${{ github.base_ref }}
-                if git diff --name-only origin/${{ github.base_ref }} HEAD | grep -qvE '(\.md$|\.css$|\.html$|^AUTHORS$|\.rs)'; then
+                if git diff --name-only origin/${{ github.base_ref }} HEAD | grep -qvE '(\.md$|\.css$|\.html$|^AUTHORS$|\.rs|\.roc)'; then
                     echo "should_run_tests=y" >> $GITHUB_OUTPUT
                 else
-                  if git diff --unified=0 origin/${{ github.base_ref }} HEAD '*.rs' | grep -E --color=never '^[+-]' | grep -qvE '^(\+\+\+|\-\-\-|[+-]\s*($|\/\/|[+-]|\/\*.*\*\/\s*$))'; then
+                  if git diff --unified=0 origin/${{ github.base_ref }} HEAD '*.rs' | grep -E --color=never '^[+-]' | grep -qvE '^(\+\+\+|\-\-\-|[+-]\s*($|\/\/|\/\*.*\*\/\s*$))'; then
+                      echo "should_run_tests=y" >> $GITHUB_OUTPUT
+                  else
+                      echo "should_run_tests=n" >> $GITHUB_OUTPUT
+                  fi
+                fi
+
+            - name: Check if only comments changed in roc files
+              id: check_roc_comments
+              run: |
+                git fetch origin ${{ github.base_ref }}
+                if git diff --name-only origin/${{ github.base_ref }} HEAD | grep -qvE '(\.md$|\.css$|\.html$|^AUTHORS$|\.rs|\.roc)'; then
+                    echo "should_run_tests=y" >> $GITHUB_OUTPUT
+                else
+                  if git diff --unified=0 origin/${{ github.base_ref }} HEAD '*.roc' | grep -E --color=never '^[+-]' | grep -qvE '^(\+\+\+|\-\-\-|[+-]\s*($|#))'; then
                       echo "should_run_tests=y" >> $GITHUB_OUTPUT
                   else
                       echo "should_run_tests=n" >> $GITHUB_OUTPUT
@@ -48,7 +62,11 @@ jobs:
                   if [ ${{ steps.check_rs_comments.outputs.should_run_tests }} = "y" ]; then
                       echo "run_tests=full" >> $GITHUB_OUTPUT
                   else
-                    echo "run_tests=none" >> $GITHUB_OUTPUT
+                    if [ ${{ steps.check_roc_comments.outputs.should_run_tests }} = "y" ]; then
+                      echo "run_tests=full" >> $GITHUB_OUTPUT
+                    else
+                      echo "run_tests=none" >> $GITHUB_OUTPUT
+                    fi
                   fi
                 else
                   echo "run_tests=none" >> $GITHUB_OUTPUT
@@ -122,7 +140,7 @@ jobs:
         needs: [check-changes]
         if: needs.check-changes.outputs.run_tests == 'none'
         steps:
-            - run: echo "Only non-code files changed and/or rs comment lines changed. CI manager did not run any workflows."
+            - run: echo "Only non-code files changed and/or rs and/or roc comment lines changed. CI manager did not run any workflows."
 
     # we need a single end job for the required checks under branch protection rules
     finish:


### PR DESCRIPTION
# Overview

Closes https://github.com/roc-lang/roc/issues/6276.

## Rationale
The same rationale from https://github.com/roc-lang/roc/pull/6539 applies here analogously for `.roc` files.

The `check-changes` job still outputs only one result, namely `run_tests: ${{ steps.filecheck.outputs.run_tests }}`, but the `steps` are refactored in to work together in a map-reduce kind of a manner. There are individual steps for:
- checking whether there are any files we'd like to ignore or not (which is the already existing logic);
- checking whether there are any `.rs` file changes and whether those contain only comments or not;
- checking whether there are any `.roc` file changes and whether those contain only comments or not (this is a new step added in this PR);
- a "reduce" step which determines what subset of tests (amongst the original subsets, namely `none` and `full`) should be run, based on the results from the "map" steps.

# Notes

Please, note the following:
- The script ignores changes to `*.roc` file lines containing only whitespace, i.e., those are treated - in terms of deciding whether to run tests or not - as if they were comment-only lines.
- The script ignores both comments (`#`) and doc comments (`##`), because the pattern is based on the first character only.

# Unit tests
These were run firstly locally, as per these [instructions](https://github.com/hristog/roc/tree/workflow-tc-base/ci_workflow_tests) on my own fork.

Once the desired results were observed, the unit tests were run as workflow jobs on my own fork. The results are listed in the following table. In addition to this concise subset of tests, all 77 tests from https://github.com/roc-lang/roc/pull/6539 still pass OK.

| Test Case | Expected | Actual | Diff |
| ------------- | ------------- | ------------- | ------------- |
| `.roc` comment changes | `none`  | ✅ [`none`](https://github.com/hristog/roc/actions/runs/8125956914) | [diff](https://github.com/hristog/roc/compare/workflow-tc-base...78-workflow-tc-roc-comment-changes-only) |
| `.roc` non-comment changes | `full`  | ✅ [`full`](https://github.com/hristog/roc/actions/runs/8125957177) | [diff](https://github.com/hristog/roc/compare/workflow-tc-base...79-workflow-tc-roc-non-comment-changes-only) |
| `.roc` mixed comment and non-comment changes | `full`  | ✅ [`full`](https://github.com/hristog/roc/actions/runs/8125957885) | [diff](https://github.com/hristog/roc/compare/workflow-tc-base...80-workflow-tc-roc-mixed-comment-and-non-comment-changes) |
| `.roc` comment changes, ignored file, `.rs` comment changes| `none`  | ✅ [`none`](https://github.com/hristog/roc/actions/runs/8125958169) | [diff](https://github.com/hristog/roc/compare/workflow-tc-base...81-workflow-tc-roc-comment-changes-only-ignored-file-rs-comment-changes) |
| `.roc` comment changes, ignored file, `.rs` mixed comment and non-comment changes| `full`  | ✅ [`full`](https://github.com/hristog/roc/actions/runs/8125958660) | [diff](https://github.com/hristog/roc/compare/workflow-tc-base...82-workflow-tc-roc-comment-changes-only-ignored-file-rs-mixed-comment-and-non-comment-changes) |
| `.roc` non-comment changes, ignored file, `.rs` comment changes | `full`  | ✅ [`full`](https://github.com/hristog/roc/actions/runs/8125959334) | [diff](https://github.com/hristog/roc/compare/workflow-tc-base...83-workflow-tc-roc-non-comment-changes-only-ignored-file-rs-comment-changes) |
| `.roc` mixed comment and non-comment changes, `.rs` mixed comment and non-comment changes | `full`  | ✅ [`full`](https://github.com/hristog/roc/actions/runs/8125959473) | [diff](https://github.com/hristog/roc/compare/workflow-tc-base...84-workflow-tc-roc-mixed-comment-and-non-comment-changes-rs-mixed-comment-and-non-comment-changes) |
| `.roc` and `.rs` comment changes, ignored file | `none`  | ✅ [`none`](https://github.com/hristog/roc/actions/runs/8125960395) | [diff](https://github.com/hristog/roc/compare/workflow-tc-base...85-workflow-tc-roc-and-rs-comment-changes-only-ignored-files) |
| `.roc` and `.rs` comment changes, non-ignored file| `full`  | ✅ [`full`](https://github.com/hristog/roc/actions/runs/8125959714) | [diff](https://github.com/hristog/roc/compare/workflow-tc-base...86-workflow-tc-roc-and-rs-comment-changes-only-non-ignored-files) |