### PR TITLE
Add a newline when reporting test failures

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -531,7 +531,7 @@ pub fn test(matches: &ArgMatches, triple: Triple) -> io::Result<i32> {
             "if there were errors, we would have already exited."
         );
         if problems.warnings > 0 {
-            problems.print_to_stdout(start_time.elapsed());
+            problems.print_error_warning_count(start_time.elapsed());
             println!(".\n\nRunning tests…\n\n\x1B[36m{}\x1B[39m", "─".repeat(80));
         }
     }
@@ -824,7 +824,7 @@ pub fn build(
                     // since the process is about to exit anyway.
                     // std::mem::forget(arena);
 
-                    problems.print_to_stdout(total_time);
+                    problems.print_error_warning_count(total_time);
                     println!(" while successfully building:\n\n    {generated_filename}");
 
                     // Return a nonzero exit code if there were problems
@@ -832,7 +832,7 @@ pub fn build(
                 }
                 BuildAndRun => {
                     if problems.fatally_errored {
-                        problems.print_to_stdout(total_time);
+                        problems.print_error_warning_count(total_time);
                         println!(
                             ".\n\nCannot run program due to fatal error…\n\n\x1B[36m{}\x1B[39m",
                             "─".repeat(80)
@@ -842,7 +842,7 @@ pub fn build(
                         return Ok(problems.exit_code());
                     }
                     if problems.errors > 0 || problems.warnings > 0 {
-                        problems.print_to_stdout(total_time);
+                        problems.print_error_warning_count(total_time);
                         println!(
                             ".\n\nRunning program anyway…\n\n\x1B[36m{}\x1B[39m",
                             "─".repeat(80)
@@ -862,7 +862,7 @@ pub fn build(
                 }
                 BuildAndRunIfNoErrors => {
                     if problems.fatally_errored {
-                        problems.print_to_stdout(total_time);
+                        problems.print_error_warning_count(total_time);
                         println!(
                             ".\n\nCannot run program due to fatal error…\n\n\x1B[36m{}\x1B[39m",
                             "─".repeat(80)
@@ -877,7 +877,7 @@ pub fn build(
                     );
 
                     if problems.warnings > 0 {
-                        problems.print_to_stdout(total_time);
+                        problems.print_error_warning_count(total_time);
                         println!(
                             ".\n\nRunning program…\n\n\x1B[36m{}\x1B[39m",
                             "─".repeat(80)

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -210,7 +210,7 @@ fn main() -> io::Result<()> {
                 threading,
             ) {
                 Ok((problems, total_time)) => {
-                    problems.print_to_stdout(total_time);
+                    problems.print_error_warning_count(total_time);
                     Ok(problems.exit_code())
                 }
 

--- a/crates/compiler/build/src/program.rs
+++ b/crates/compiler/build/src/program.rs
@@ -649,7 +649,7 @@ pub fn handle_error_module(
 
     let problems = report_problems_typechecked(&mut module);
 
-    problems.print_to_stdout(total_time);
+    problems.print_error_warning_count(total_time);
 
     if print_run_anyway_hint {
         // If you're running "main.roc" then you can just do `roc run`

--- a/crates/compiler/load_internal/src/file.rs
+++ b/crates/compiler/load_internal/src/file.rs
@@ -1901,7 +1901,7 @@ fn load_multi_threaded<'a>(
             //     &mut can_problems_recorded,
             //     &mut type_problems_recorded,
             // )
-            // .print_to_stdout(Duration::default()); // TODO determine total elapsed time and use it here
+            // .print_error_warning_count(Duration::default()); // TODO determine total elapsed time and use it here
 
             Err(LoadingProblem::FormattedReport(
                 concat!(

--- a/crates/glue/src/load.rs
+++ b/crates/glue/src/load.rs
@@ -123,7 +123,7 @@ pub fn generate(
                         "if there are errors, they should have been returned as an error variant"
                     );
                     if problems.warnings > 0 {
-                        problems.print_to_stdout(total_time);
+                        problems.print_error_warning_count(total_time);
                         println!(
                             ".\n\nRunning glue despite warnings…\n\n\x1B[36m{}\x1B[39m",
                             "─".repeat(80)

--- a/crates/reporting/src/cli.rs
+++ b/crates/reporting/src/cli.rs
@@ -27,12 +27,13 @@ impl Problems {
         }
     }
 
-    pub fn print_to_stdout(&self, total_time: std::time::Duration) {
+    // prints e.g. `1 error and 0 warnings found in 63 ms.`
+    pub fn print_error_warning_count(&self, total_time: std::time::Duration) {
         const GREEN: &str = ANSI_STYLE_CODES.green;
         const YELLOW: &str = ANSI_STYLE_CODES.yellow;
 
-        print!(
-            "{}{}\x1B[39m {} and {}{}\x1B[39m {} found in {} ms\n",
+        println!(
+            "{}{}\x1B[39m {} and {}{}\x1B[39m {} found in {} ms",
             match self.errors {
                 0 => GREEN,
                 _ => YELLOW,
@@ -54,39 +55,6 @@ impl Problems {
             total_time.as_millis()
         );
     }
-}
-
-// prints e.g. `1 error and 0 warnings found in 63 ms.`
-pub fn print_error_warning_count(
-    error_count: usize,
-    warning_count: usize,
-    total_time: std::time::Duration,
-) {
-    const GREEN: &str = ANSI_STYLE_CODES.green;
-    const YELLOW: &str = ANSI_STYLE_CODES.yellow;
-
-    print!(
-        "{}{}\x1B[39m {} and {}{}\x1B[39m {} found in {} ms",
-        match error_count {
-            0 => GREEN,
-            _ => YELLOW,
-        },
-        error_count,
-        match error_count {
-            1 => "error",
-            _ => "errors",
-        },
-        match warning_count {
-            0 => GREEN,
-            _ => YELLOW,
-        },
-        warning_count,
-        match warning_count {
-            1 => "warning",
-            _ => "warnings",
-        },
-        total_time.as_millis()
-    );
 }
 
 pub fn report_problems(

--- a/crates/reporting/src/cli.rs
+++ b/crates/reporting/src/cli.rs
@@ -32,7 +32,7 @@ impl Problems {
         const YELLOW: &str = ANSI_STYLE_CODES.yellow;
 
         print!(
-            "{}{}\x1B[39m {} and {}{}\x1B[39m {} found in {} ms",
+            "{}{}\x1B[39m {} and {}{}\x1B[39m {} found in {} ms\n",
             match self.errors {
                 0 => GREEN,
                 _ => YELLOW,


### PR DESCRIPTION
## Summary

When running `roc test`, I've noticed that when there are errors reported, there's no newline character at the end of the report, which depending on the OS, will output the prompt immediately after the report.

On the other hand, there is a newline character, in the absence of any errors, as a result of `roc test`.

This PR proposes, for consistency purposes, adding a newline character to the end of the report in the aforementioned first case.

## Tangential observations

It seems that `print_error_warning_count`, which was introduced in [this](https://github.com/roc-lang/roc/commit/00d1ac0aef9c6e60b93dc4c4b3f1c5fbc192289d) commit is currently unused. Just wanted to double-check, if this has been intentional.

## Examples
The following are abbreviated execution runs, demonstrating the state of matters, prior to introducing the proposed changes.

### Test failures
```bash
> roc test                                                                                                                     
                                                                                                                      
── TYPE MISMATCH in main.roc ───────────────────────────────────────────────────                                                                    
                                                                                                                                   
...                                                                                                                           
────────────────────────────────────────────────────────────────────────────────                   
                                                                                                           
1 error and 0 warnings found in 95 ms<prompt starts here>
```

### No test failures
```bash
> roc test                                                                                                                                     
                                                                                                                                            
0 failed and 4 passed in 220 ms.

<prompt starts here>
```