### PR TITLE
Use constant ANSI code to reset boldfaced colors in reporting

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -575,8 +575,10 @@ pub fn test(matches: &ArgMatches, triple: Triple) -> io::Result<i32> {
 
         let passed_color = ANSI_STYLE_CODES.green;
 
+        let reset = ANSI_STYLE_CODES.reset;
+
         println!(
-            "\n{failed_color}{failed_count}\x1B[39m failed and {passed_color}{passed_count}\x1B[39m passed in {} ms.\n",
+            "\n{failed_color}{failed_count}{reset} failed and {passed_color}{passed_count}{reset} passed in {} ms.\n",
             total_time.as_millis(),
         );
 

--- a/crates/reporting/src/cli.rs
+++ b/crates/reporting/src/cli.rs
@@ -31,14 +31,16 @@ impl Problems {
     pub fn print_error_warning_count(&self, total_time: std::time::Duration) {
         const GREEN: &str = ANSI_STYLE_CODES.green;
         const YELLOW: &str = ANSI_STYLE_CODES.yellow;
+        const RESET: &str = ANSI_STYLE_CODES.reset;
 
         println!(
-            "{}{}\x1B[39m {} and {}{}\x1B[39m {} found in {} ms",
+            "{}{}{} {} and {}{}{} {} found in {} ms",
             match self.errors {
                 0 => GREEN,
                 _ => YELLOW,
             },
             self.errors,
+            RESET,
             match self.errors {
                 1 => "error",
                 _ => "errors",
@@ -48,6 +50,7 @@ impl Problems {
                 _ => YELLOW,
             },
             self.warnings,
+            RESET,
             match self.warnings {
                 1 => "warning",
                 _ => "warnings",

--- a/crates/reporting/src/report.rs
+++ b/crates/reporting/src/report.rs
@@ -254,7 +254,6 @@ pub struct StyleCodes {
     pub bold: &'static str,
     pub underline: &'static str,
     pub reset: &'static str,
-    pub color_reset: &'static str,
 }
 
 pub const ANSI_STYLE_CODES: StyleCodes = StyleCodes {
@@ -266,7 +265,6 @@ pub const ANSI_STYLE_CODES: StyleCodes = StyleCodes {
     bold: "\u{001b}[1m",
     underline: "\u{001b}[4m",
     reset: "\u{001b}[0m",
-    color_reset: "\u{1b}[39m",
 };
 
 macro_rules! html_color {
@@ -284,7 +282,6 @@ pub const HTML_STYLE_CODES: StyleCodes = StyleCodes {
     bold: "<span class='bold'>",
     underline: "<span class='underline'>",
     reset: "</span>",
-    color_reset: "</span>",
 };
 
 // useful for tests
@@ -297,7 +294,6 @@ pub fn strip_colors(str: &str) -> String {
         .replace(ANSI_STYLE_CODES.bold, "")
         .replace(ANSI_STYLE_CODES.underline, "")
         .replace(ANSI_STYLE_CODES.reset, "")
-        .replace(ANSI_STYLE_CODES.color_reset, "")
 }
 
 // define custom allocator struct so we can `impl RocDocAllocator` custom helpers


### PR DESCRIPTION
Currently the console is boldfaced (and stays so) after running `roc check` or `roc test`. This is because the definition in https://github.com/roc-lang/roc/blob/main/crates/reporting/src/report.rs#L260 contains a `[1;` in front of the color code. This improves the readability of the colored numbers but is not reset properly by the code `[39m` that we currently have in these two cases. This code only resets the color but not the type face.

I used the constant code `[0m` to reset both, the color and the type face.

Another way would be an explicit reset of color and type face but this seems to be too noisy for me.

By the way I removed the buggy and unused `color_reset` constant.