### PR TITLE
nix.md

### DIFF
--- a/getting_started/nix.md
+++ b/getting_started/nix.md
@@ -2,10 +2,10 @@
 
 To quickly try out roc without installing, use `nix run`:
 ```shell
-nix run roc-lang/roc -- <roc args>
+nix run github:roc-lang/roc -- <roc args>
 # examples:
-# - nix run roc-lang/roc -- repl
-# - nix run roc-lang/roc -- dev main.roc
+# - nix run github:roc-lang/roc -- repl
+# - nix run github:roc-lang/roc -- dev main.roc
 ```
 
 ## Use with Flakes


### PR DESCRIPTION
added the github: prefix to the nix run command. Without that, the command only works when you have previously cloned this repo and pwd is in the root folder of the repo. With the prefix, there's no need to clone anything, nix just runs roc.