### PR TITLE
Add newline after "Failed with error" msg

### DIFF
--- a/crates/compiler/build/src/program.rs
+++ b/crates/compiler/build/src/program.rs
@@ -687,7 +687,7 @@ pub fn handle_loading_problem(problem: LoadingProblem) -> std::io::Result<i32> {
         _ => {
             // TODO: tighten up the types here, we should always end up with a
             // formatted report from load.
-            print!("Failed with error: {problem:?}\n");
+            println!("Failed with error: {problem:?}");
             Ok(1)
         }
     }

--- a/crates/compiler/build/src/program.rs
+++ b/crates/compiler/build/src/program.rs
@@ -687,7 +687,7 @@ pub fn handle_loading_problem(problem: LoadingProblem) -> std::io::Result<i32> {
         _ => {
             // TODO: tighten up the types here, we should always end up with a
             // formatted report from load.
-            print!("Failed with error: {problem:?}");
+            print!("Failed with error: {problem:?}\n");
             Ok(1)
         }
     }


### PR DESCRIPTION
Reproducible via the following:
```elm
> cat ./test.roc 
app "test"
    packages { pf: "../platform/main.roc" }
    imports []
    provides [] to pf

tmp = "Test!"

> roc test ./test.roc
Failed with error: FileProblem { filename: "../platform/main.roc", error: NotFound }<command prompt starts here>
```