### PR TITLE
Add `!` suffix to parser

### DIFF
--- a/crates/compiler/can/src/expr.rs
+++ b/crates/compiler/can/src/expr.rs
@@ -1441,6 +1441,7 @@ pub fn canonicalize_expr<'a>(
                 bad_expr
             );
         }
+        ast::Expr::Suffixed(_) => todo!(),
     };
 
     // At the end, diff used_idents and defined_idents to see which were unused.
@@ -2506,6 +2507,7 @@ pub fn is_valid_interpolation(expr: &ast::Expr<'_>) -> bool {
             ast::RecordBuilderField::SpaceBefore(_, _)
             | ast::RecordBuilderField::SpaceAfter(_, _) => false,
         }),
+        ast::Expr::Suffixed(_) => todo!(),
     }
 }
 

--- a/crates/compiler/can/src/operator.rs
+++ b/crates/compiler/can/src/operator.rs
@@ -619,6 +619,7 @@ pub fn desugar_expr<'a>(
             })
         }
         LowLevelDbg(_, _, _) => unreachable!("Only exists after desugaring"),
+        Suffixed(_) => todo!(),
     }
 }
 

--- a/crates/compiler/fmt/src/expr.rs
+++ b/crates/compiler/fmt/src/expr.rs
@@ -513,7 +513,10 @@ impl<'a> Formattable for Expr<'a> {
             MultipleRecordBuilders { .. } => {}
             UnappliedRecordBuilder { .. } => {}
             IngestedFile(_, _) => {}
-            Suffixed(sub_expr) => sub_expr.format_with_options(buf, parens, newlines, indent),
+            Suffixed(sub_expr) => {
+                sub_expr.format_with_options(buf, parens, newlines, indent);
+                buf.push('!');
+            }
         }
     }
 }

--- a/crates/compiler/fmt/src/expr.rs
+++ b/crates/compiler/fmt/src/expr.rs
@@ -107,6 +107,7 @@ impl<'a> Formattable for Expr<'a> {
             Tuple(fields) => is_collection_multiline(fields),
             RecordUpdate { fields, .. } => is_collection_multiline(fields),
             RecordBuilder(fields) => is_collection_multiline(fields),
+            Suffixed(subexpr) => subexpr.is_multiline(),
         }
     }
 
@@ -512,6 +513,7 @@ impl<'a> Formattable for Expr<'a> {
             MultipleRecordBuilders { .. } => {}
             UnappliedRecordBuilder { .. } => {}
             IngestedFile(_, _) => {}
+            Suffixed(sub_expr) => sub_expr.format_with_options(buf, parens, newlines, indent),
         }
     }
 }

--- a/crates/compiler/fmt/src/spaces.rs
+++ b/crates/compiler/fmt/src/spaces.rs
@@ -761,6 +761,7 @@ impl<'a> RemoveSpaces<'a> for Expr<'a> {
             Expr::SpaceBefore(a, _) => a.remove_spaces(arena),
             Expr::SpaceAfter(a, _) => a.remove_spaces(arena),
             Expr::SingleQuote(a) => Expr::Num(a),
+            Expr::Suffixed(a) => a.remove_spaces(arena),
         }
     }
 }

--- a/crates/compiler/parse/src/ast.rs
+++ b/crates/compiler/parse/src/ast.rs
@@ -267,6 +267,9 @@ pub enum Expr<'a> {
     // Collection Literals
     List(Collection<'a, &'a Loc<Expr<'a>>>),
 
+    /// An expression followed by `!``
+    Suffixed(&'a Expr<'a>),
+
     RecordUpdate {
         update: &'a Loc<Expr<'a>>,
         fields: Collection<'a, Loc<AssignedField<'a, Expr<'a>>>>,

--- a/crates/compiler/parse/src/ast.rs
+++ b/crates/compiler/parse/src/ast.rs
@@ -1571,6 +1571,7 @@ impl<'a> Malformed for Expr<'a> {
             PrecedenceConflict(_) |
             MultipleRecordBuilders(_) |
             UnappliedRecordBuilder(_) => true,
+            Suffixed(expr) => expr.is_malformed(),
         }
     }
 }

--- a/crates/compiler/parse/src/expr.rs
+++ b/crates/compiler/parse/src/expr.rs
@@ -1640,7 +1640,7 @@ fn parse_expr_end<'a>(
         Err((MadeProgress, f)) => Err((MadeProgress, f)),
         Ok((
             _,
-            has @ Loc {
+            implements @ Loc {
                 value:
                     Expr::Var {
                         module_name: "",
@@ -1672,17 +1672,17 @@ fn parse_expr_end<'a>(
             }
 
             // Attach any spaces to the `implements` keyword
-            let has = if !expr_state.spaces_after.is_empty() {
+            let implements = if !expr_state.spaces_after.is_empty() {
                 arena
                     .alloc(Implements::Implements)
-                    .with_spaces_before(expr_state.spaces_after, has.region)
+                    .with_spaces_before(expr_state.spaces_after, implements.region)
             } else {
-                Loc::at(has.region, Implements::Implements)
+                Loc::at(implements.region, Implements::Implements)
             };
 
             let args = arguments.into_bump_slice();
             let (_, (type_def, def_region), state) =
-                finish_parsing_ability_def_help(min_indent, name, args, has, arena, state)?;
+                finish_parsing_ability_def_help(min_indent, name, args, implements, arena, state)?;
 
             let mut defs = Defs::default();
 

--- a/crates/compiler/parse/src/expr.rs
+++ b/crates/compiler/parse/src/expr.rs
@@ -1817,6 +1817,18 @@ fn parse_expr_end<'a>(
             }
         }
     }
+    .map(|(progress, expr, state)| {
+        // If the next thing after the expression is a `!`, then it's Suffixed
+        if state.bytes().starts_with(b"!") {
+            (
+                progress,
+                Expr::Suffixed(arena.alloc(expr)),
+                state.advance(1),
+            )
+        } else {
+            (progress, expr, state)
+        }
+    })
 }
 
 pub fn loc_expr<'a>(accept_multi_backpassing: bool) -> impl Parser<'a, Loc<Expr<'a>>, EExpr<'a>> {

--- a/crates/compiler/parse/src/expr.rs
+++ b/crates/compiler/parse/src/expr.rs
@@ -1957,6 +1957,7 @@ fn expr_to_pattern_help<'a>(arena: &'a Bump, expr: &Expr<'a>) -> Result<Pattern<
         Expr::Str(string) => Pattern::StrLiteral(string),
         Expr::SingleQuote(string) => Pattern::SingleQuote(string),
         Expr::MalformedIdent(string, problem) => Pattern::MalformedIdent(string, problem),
+        Expr::Suffixed(_) => todo!(),
     };
 
     // Now we re-add the spaces
@@ -3009,6 +3010,7 @@ where
             Err((NoProgress, to_error("->", state.pos())))
         }
         "<-" => good!(BinOp::Backpassing, 2),
+        "!" => Err((NoProgress, to_error("!", state.pos()))),
         _ => bad_made_progress!(chomped),
     }
 }

--- a/crates/compiler/test_syntax/tests/snapshots/pass/suffixed.expr.formatted.roc
+++ b/crates/compiler/test_syntax/tests/snapshots/pass/suffixed.expr.formatted.roc
@@ -1,1 +1,0 @@
-Stdout.line!

--- a/crates/compiler/test_syntax/tests/snapshots/pass/suffixed.expr.formatted.roc
+++ b/crates/compiler/test_syntax/tests/snapshots/pass/suffixed.expr.formatted.roc
@@ -1,1 +1,1 @@
-Stdout.line
+Stdout.line!

--- a/crates/compiler/test_syntax/tests/snapshots/pass/suffixed.expr.formatted.roc
+++ b/crates/compiler/test_syntax/tests/snapshots/pass/suffixed.expr.formatted.roc
@@ -1,0 +1,1 @@
+Stdout.line

--- a/crates/compiler/test_syntax/tests/snapshots/pass/suffixed.expr.result-ast
+++ b/crates/compiler/test_syntax/tests/snapshots/pass/suffixed.expr.result-ast
@@ -1,0 +1,6 @@
+Suffixed(
+    Var {
+        module_name: "Stdout",
+        ident: "line",
+    },
+)

--- a/crates/compiler/test_syntax/tests/snapshots/pass/suffixed.expr.roc
+++ b/crates/compiler/test_syntax/tests/snapshots/pass/suffixed.expr.roc
@@ -1,0 +1,1 @@
+Stdout.line!

--- a/crates/compiler/test_syntax/tests/snapshots/pass/suffixed_nested.expr.formatted.roc
+++ b/crates/compiler/test_syntax/tests/snapshots/pass/suffixed_nested.expr.formatted.roc
@@ -1,0 +1,1 @@
+foo! (bar! baz) (blah stuff)

--- a/crates/compiler/test_syntax/tests/snapshots/pass/suffixed_nested.expr.result-ast
+++ b/crates/compiler/test_syntax/tests/snapshots/pass/suffixed_nested.expr.result-ast
@@ -1,0 +1,43 @@
+Apply(
+    @0-3 Suffixed(
+        Var {
+            module_name: "",
+            ident: "foo",
+        },
+    ),
+    [
+        @9-17 ParensAround(
+            Apply(
+                @9-12 Suffixed(
+                    Var {
+                        module_name: "",
+                        ident: "bar",
+                    },
+                ),
+                [
+                    @14-17 Var {
+                        module_name: "",
+                        ident: "baz",
+                    },
+                ],
+                Space,
+            ),
+        ),
+        @22-32 ParensAround(
+            Apply(
+                @22-26 Var {
+                    module_name: "",
+                    ident: "blah",
+                },
+                [
+                    @27-32 Var {
+                        module_name: "",
+                        ident: "stuff",
+                    },
+                ],
+                Space,
+            ),
+        ),
+    ],
+    Space,
+)

--- a/crates/compiler/test_syntax/tests/snapshots/pass/suffixed_nested.expr.roc
+++ b/crates/compiler/test_syntax/tests/snapshots/pass/suffixed_nested.expr.roc
@@ -1,0 +1,1 @@
+foo!  (  bar! baz)  ( blah stuff)

--- a/crates/compiler/test_syntax/tests/test_snapshots.rs
+++ b/crates/compiler/test_syntax/tests/test_snapshots.rs
@@ -441,6 +441,7 @@ mod test_snapshots {
         pass/string_without_escape.expr,
         pass/sub_var_with_spaces.expr,
         pass/sub_with_spaces.expr,
+        pass/suffixed.expr,
         pass/tag_pattern.expr,
         pass/ten_times_eleven.expr,
         pass/three_arg_closure.expr,

--- a/crates/compiler/test_syntax/tests/test_snapshots.rs
+++ b/crates/compiler/test_syntax/tests/test_snapshots.rs
@@ -442,6 +442,7 @@ mod test_snapshots {
         pass/sub_var_with_spaces.expr,
         pass/sub_with_spaces.expr,
         pass/suffixed.expr,
+        pass/suffixed_nested.expr,
         pass/tag_pattern.expr,
         pass/ten_times_eleven.expr,
         pass/three_arg_closure.expr,

--- a/crates/lang_srv/src/analysis/tokens.rs
+++ b/crates/lang_srv/src/analysis/tokens.rs
@@ -700,6 +700,7 @@ impl IterTokens for Loc<Expr<'_>> {
             Expr::MalformedIdent(_, _) | Expr::MalformedClosure | Expr::PrecedenceConflict(_) => {
                 bumpvec![in arena;]
             }
+            Expr::Suffixed(_) => todo!(),
         }
     }
 }


### PR DESCRIPTION
This PR;
- Adds support for parsing and formatting the suffix `!` for idents e.g. `foo! (bar! baz) (blah stuff)` as described in [chaining syntax proposal](https://docs.google.com/document/d/1mTEZlOKqtMonmVsIGEC1A9ufs1TQHhVgZ52Vn-13GeU/edit)