### PR TITLE
Add builtins for dec and float

### DIFF
--- a/crates/cli/tests/cli_run.rs
+++ b/crates/cli/tests/cli_run.rs
@@ -520,7 +520,6 @@ mod cli_run {
     #[test]
     #[serial(zig_platform_parser_package_basic_cli_url)]
     #[cfg_attr(windows, ignore)]
-    #[ignore = "bug with surgical linker: https://github.com/roc-lang/roc/pull/6591#issuecomment-2030983248"]
     fn platform_switching_zig() {
         test_roc_app_slim(
             "examples/platform-switching",

--- a/crates/cli/tests/cli_run.rs
+++ b/crates/cli/tests/cli_run.rs
@@ -520,6 +520,7 @@ mod cli_run {
     #[test]
     #[serial(zig_platform_parser_package_basic_cli_url)]
     #[cfg_attr(windows, ignore)]
+    #[ignore = "bug with surgical linker: https://github.com/roc-lang/roc/pull/6591#issuecomment-2030983248"]
     fn platform_switching_zig() {
         test_roc_app_slim(
             "examples/platform-switching",

--- a/crates/compiler/build/src/link.rs
+++ b/crates/compiler/build/src/link.rs
@@ -486,7 +486,10 @@ pub fn rebuild_host(
                 &env_home,
                 host_dest.to_str().unwrap(),
                 zig_host_src.to_str().unwrap(),
-                "native",
+                // This used to be "native" but that caused segfaults that were hard to
+                // reproduce and investigate.
+                // For context: github.com/roc-lang/roc/pull/6591#issuecomment-2039808944
+                "x86_64-native",
                 opt_level,
                 shared_lib_path,
                 builtins_host_tempfile.path(),

--- a/crates/compiler/builtins/bitcode/src/dec.zig
+++ b/crates/compiler/builtins/bitcode/src/dec.zig
@@ -226,6 +226,10 @@ pub const RocDec = extern struct {
         return self.num;
     }
 
+    pub fn fromI128(num: i128) RocDec {
+        return .{ .num = num };
+    }
+
     pub fn eq(self: RocDec, other: RocDec) bool {
         return self.num == other.num;
     }
@@ -1473,6 +1477,10 @@ pub fn fromU64C(arg: u64) callconv(.C) i128 {
 
 pub fn toI128(arg: RocDec) callconv(.C) i128 {
     return @call(.always_inline, RocDec.toI128, .{arg});
+}
+
+pub fn fromI128(arg: i128) callconv(.C) RocDec {
+    return @call(.always_inline, RocDec.fromI128, .{arg});
 }
 
 pub fn eqC(arg1: RocDec, arg2: RocDec) callconv(.C) bool {

--- a/crates/compiler/builtins/bitcode/src/main.zig
+++ b/crates/compiler/builtins/bitcode/src/main.zig
@@ -49,6 +49,7 @@ comptime {
     exportDecFn(dec.tanC, "tan");
     exportDecFn(dec.toF64, "to_f64");
     exportDecFn(dec.toI128, "to_i128");
+    exportDecFn(dec.fromI128, "from_i128");
     exportDecFn(dec.toStr, "to_str");
 
     inline for (INTEGERS) |T| {

--- a/crates/compiler/builtins/bitcode/src/main.zig
+++ b/crates/compiler/builtins/bitcode/src/main.zig
@@ -111,6 +111,8 @@ comptime {
     exportNumFn(num.lessThanOrEqualU128, "less_than_or_equal.u128");
     exportNumFn(num.greaterThanU128, "greater_than.u128");
     exportNumFn(num.greaterThanOrEqualU128, "greater_than_or_equal.u128");
+    exportNumFn(num.f32ToParts, "f32_to_parts");
+    exportNumFn(num.f64ToParts, "f64_to_parts");
 
     inline for (INTEGERS, 0..) |T, i| {
         num.exportPow(T, ROC_BUILTINS ++ "." ++ NUM ++ ".pow_int.");

--- a/crates/compiler/builtins/bitcode/src/main.zig
+++ b/crates/compiler/builtins/bitcode/src/main.zig
@@ -113,6 +113,8 @@ comptime {
     exportNumFn(num.greaterThanOrEqualU128, "greater_than_or_equal.u128");
     exportNumFn(num.f32ToParts, "f32_to_parts");
     exportNumFn(num.f64ToParts, "f64_to_parts");
+    exportNumFn(num.f32FromParts, "f32_from_parts");
+    exportNumFn(num.f64FromParts, "f64_from_parts");
 
     inline for (INTEGERS, 0..) |T, i| {
         num.exportPow(T, ROC_BUILTINS ++ "." ++ NUM ++ ".pow_int.");

--- a/crates/compiler/builtins/bitcode/src/num.zig
+++ b/crates/compiler/builtins/bitcode/src/num.zig
@@ -660,3 +660,11 @@ pub fn f64ToParts(self: f64) callconv(.C) F64Parts {
         .sign = u64Value >> 63 & 1 == 1,
     };
 }
+
+pub fn f32FromParts(parts: F32Parts) callconv(.C) f32 {
+    return @as(f32, @bitCast(parts.fraction | (@as(u32, parts.exponent) << 23) | (@as(u32, @intFromBool(parts.sign)) << 31)));
+}
+
+pub fn f64FromParts(parts: F64Parts) callconv(.C) f64 {
+    return @as(f64, @bitCast(parts.fraction | (@as(u64, parts.exponent) << 52) | (@as(u64, @intFromBool(parts.sign)) << 63)));
+}

--- a/crates/compiler/builtins/bitcode/src/num.zig
+++ b/crates/compiler/builtins/bitcode/src/num.zig
@@ -15,6 +15,18 @@ pub fn NumParseResult(comptime T: type) type {
     };
 }
 
+pub const F32Parts = extern struct {
+    fraction: u32,
+    exponent: u8,
+    sign: bool,
+};
+
+pub const F64Parts = extern struct {
+    fraction: u64,
+    exponent: u16,
+    sign: bool,
+};
+
 pub const U256 = struct {
     hi: u128,
     lo: u128,
@@ -629,4 +641,22 @@ pub fn exportCountOneBits(comptime T: type, comptime name: []const u8) void {
         }
     }.func;
     @export(f, .{ .name = name ++ @typeName(T), .linkage = .Strong });
+}
+
+pub fn f32ToParts(self: f32) callconv(.C) F32Parts {
+    const u32Value = @as(u32, @bitCast(self));
+    return F32Parts{
+        .fraction = u32Value & 0x7fffff,
+        .exponent = @truncate(u32Value >> 23 & 0xff),
+        .sign = u32Value >> 31 & 1 == 1,
+    };
+}
+
+pub fn f64ToParts(self: f64) callconv(.C) F64Parts {
+    const u64Value = @as(u64, @bitCast(self));
+    return F64Parts{
+        .fraction = u64Value & 0xfffffffffffff,
+        .exponent = @truncate(u64Value >> 52 & 0x7ff),
+        .sign = u64Value >> 63 & 1 == 1,
+    };
 }

--- a/crates/compiler/builtins/bitcode/src/num.zig
+++ b/crates/compiler/builtins/bitcode/src/num.zig
@@ -662,9 +662,9 @@ pub fn f64ToParts(self: f64) callconv(.C) F64Parts {
 }
 
 pub fn f32FromParts(parts: F32Parts) callconv(.C) f32 {
-    return @as(f32, @bitCast(parts.fraction | (@as(u32, parts.exponent) << 23) | (@as(u32, @intFromBool(parts.sign)) << 31)));
+    return @as(f32, @bitCast(parts.fraction & 0x7fffff | (@as(u32, parts.exponent) << 23) | (@as(u32, @intFromBool(parts.sign)) << 31)));
 }
 
 pub fn f64FromParts(parts: F64Parts) callconv(.C) f64 {
-    return @as(f64, @bitCast(parts.fraction | (@as(u64, parts.exponent) << 52) | (@as(u64, @intFromBool(parts.sign)) << 63)));
+    return @as(f64, @bitCast(parts.fraction & 0xfffffffffffff | (@as(u64, parts.exponent & 0x7ff) << 52) | (@as(u64, @intFromBool(parts.sign)) << 63)));
 }

--- a/crates/compiler/builtins/roc/Hash.roc
+++ b/crates/compiler/builtins/roc/Hash.roc
@@ -97,12 +97,9 @@ hashI64 = \hasher, n -> addU64 hasher (Num.toU64 n)
 hashI128 : a, I128 -> a where a implements Hasher
 hashI128 = \hasher, n -> addU128 hasher (Num.toU128 n)
 
-## LOWLEVEL get the i128 representation of a Dec.
-i128OfDec : Dec -> I128
-
 ## Adds a single [Dec] to a hasher.
 hashDec : a, Dec -> a where a implements Hasher
-hashDec = \hasher, n -> hashI128 hasher (i128OfDec n)
+hashDec = \hasher, n -> hashI128 hasher (Num.withoutDecimalPoint n)
 
 ## Adds a container of [Hash]able elements to a [Hasher] by hashing each element.
 ## The container is iterated using the walk method passed in.

--- a/crates/compiler/builtins/roc/Num.roc
+++ b/crates/compiler/builtins/roc/Num.roc
@@ -151,7 +151,9 @@ interface Num
         toF64,
         toF64Checked,
         withoutDecimalPoint,
-        withDecimalPoint
+        withDecimalPoint,
+        f32ToParts,
+        f64ToParts
     ]
     imports [
         Bool.{ Bool },
@@ -1410,8 +1412,12 @@ toF32Checked : Num * -> Result F32 [OutOfBounds]
 toF64Checked : Num * -> Result F64 [OutOfBounds]
 
 
-## Turns a [Dec] into its [I128] representation, effectifely removing the decimal point.
+## Turns a [Dec] into its [I128] representation by removing the decimal point.
 withoutDecimalPoint : Dec -> I128
 
-## Turns a [I128] into the coresponding [Dec], effectifely addoing the decimal point.
+## Turns a [I128] into the coresponding [Dec] by adding the decimal point.
 withDecimalPoint : I128 -> Dec
+
+f32ToParts: F32 -> { sign : Bool, exponent : U8, fraction : U32 }
+
+f64ToParts: F64 -> { sign : Bool, exponent : U16, fraction : U64 }

--- a/crates/compiler/builtins/roc/Num.roc
+++ b/crates/compiler/builtins/roc/Num.roc
@@ -151,7 +151,7 @@ interface Num
         toF64,
         toF64Checked,
         withoutDecimalPoint,
-        # withDecimalPoint
+        withDecimalPoint
     ]
     imports [
         Bool.{ Bool },
@@ -1414,4 +1414,4 @@ toF64Checked : Num * -> Result F64 [OutOfBounds]
 withoutDecimalPoint : Dec -> I128
 
 ## Turns a [I128] into the coresponding [Dec], effectifely addoing the decimal point.
-#withDecimalPoint : I128 -> Dec
+withDecimalPoint : I128 -> Dec

--- a/crates/compiler/builtins/roc/Num.roc
+++ b/crates/compiler/builtins/roc/Num.roc
@@ -153,7 +153,9 @@ interface Num
         withoutDecimalPoint,
         withDecimalPoint,
         f32ToParts,
-        f64ToParts
+        f64ToParts,
+        f32FromParts,
+        f64FromParts
     ]
     imports [
         Bool.{ Bool },
@@ -1421,3 +1423,7 @@ withDecimalPoint : I128 -> Dec
 f32ToParts: F32 -> { sign : Bool, exponent : U8, fraction : U32 }
 
 f64ToParts: F64 -> { sign : Bool, exponent : U16, fraction : U64 }
+
+f32FromParts: { sign : Bool, exponent : U8, fraction : U32 } -> F32
+
+f64FromParts: { sign : Bool, exponent : U16, fraction : U64 } -> F64

--- a/crates/compiler/builtins/roc/Num.roc
+++ b/crates/compiler/builtins/roc/Num.roc
@@ -150,6 +150,8 @@ interface Num
         toF32Checked,
         toF64,
         toF64Checked,
+        withoutDecimalPoint,
+        # withDecimalPoint
     ]
     imports [
         Bool.{ Bool },
@@ -1406,3 +1408,10 @@ toU64Checked : Int * -> Result U64 [OutOfBounds]
 toU128Checked : Int * -> Result U128 [OutOfBounds]
 toF32Checked : Num * -> Result F32 [OutOfBounds]
 toF64Checked : Num * -> Result F64 [OutOfBounds]
+
+
+## Turns a [Dec] into its [I128] representation, effectifely removing the decimal point.
+withoutDecimalPoint : Dec -> I128
+
+## Turns a [I128] into the coresponding [Dec], effectifely addoing the decimal point.
+#withDecimalPoint : I128 -> Dec

--- a/crates/compiler/builtins/roc/Num.roc
+++ b/crates/compiler/builtins/roc/Num.roc
@@ -155,7 +155,7 @@ interface Num
         f32ToParts,
         f64ToParts,
         f32FromParts,
-        f64FromParts
+        f64FromParts,
     ]
     imports [
         Bool.{ Bool },
@@ -1413,17 +1413,16 @@ toU128Checked : Int * -> Result U128 [OutOfBounds]
 toF32Checked : Num * -> Result F32 [OutOfBounds]
 toF64Checked : Num * -> Result F64 [OutOfBounds]
 
-
 ## Turns a [Dec] into its [I128] representation by removing the decimal point.
 withoutDecimalPoint : Dec -> I128
 
 ## Turns a [I128] into the coresponding [Dec] by adding the decimal point.
 withDecimalPoint : I128 -> Dec
 
-f32ToParts: F32 -> { sign : Bool, exponent : U8, fraction : U32 }
+f32ToParts : F32 -> { sign : Bool, exponent : U8, fraction : U32 }
 
-f64ToParts: F64 -> { sign : Bool, exponent : U16, fraction : U64 }
+f64ToParts : F64 -> { sign : Bool, exponent : U16, fraction : U64 }
 
-f32FromParts: { sign : Bool, exponent : U8, fraction : U32 } -> F32
+f32FromParts : { sign : Bool, exponent : U8, fraction : U32 } -> F32
 
-f64FromParts: { sign : Bool, exponent : U16, fraction : U64 } -> F64
+f64FromParts : { sign : Bool, exponent : U16, fraction : U64 } -> F64

--- a/crates/compiler/builtins/roc/Num.roc
+++ b/crates/compiler/builtins/roc/Num.roc
@@ -1414,15 +1414,21 @@ toF32Checked : Num * -> Result F32 [OutOfBounds]
 toF64Checked : Num * -> Result F64 [OutOfBounds]
 
 ## Turns a [Dec] into its [I128] representation by removing the decimal point.
+## This is equivalent to multiplying the [Dec] by 10^18.
 withoutDecimalPoint : Dec -> I128
 
 ## Turns a [I128] into the coresponding [Dec] by adding the decimal point.
+## This is equivalent to dividing the [I128] by 10^18.
 withDecimalPoint : I128 -> Dec
 
+## Splits a [F32] into its components according to IEEE 754 standard.
 f32ToParts : F32 -> { sign : Bool, exponent : U8, fraction : U32 }
 
+## Splits a [F64] into its components according to IEEE 754 standard.
 f64ToParts : F64 -> { sign : Bool, exponent : U16, fraction : U64 }
 
+## Compine parts of a [F32] according to IEEE 754 standard.
 f32FromParts : { sign : Bool, exponent : U8, fraction : U32 } -> F32
 
+## Compine parts of a [F46] according to IEEE 754 standard.
 f64FromParts : { sign : Bool, exponent : U16, fraction : U64 } -> F64

--- a/crates/compiler/builtins/roc/Num.roc
+++ b/crates/compiler/builtins/roc/Num.roc
@@ -1427,8 +1427,8 @@ f32ToParts : F32 -> { sign : Bool, exponent : U8, fraction : U32 }
 ## Splits a [F64] into its components according to IEEE 754 standard.
 f64ToParts : F64 -> { sign : Bool, exponent : U16, fraction : U64 }
 
-## Compine parts of a [F32] according to IEEE 754 standard.
+## Combine parts of a [F32] according to IEEE 754 standard.
 f32FromParts : { sign : Bool, exponent : U8, fraction : U32 } -> F32
 
-## Compine parts of a [F46] according to IEEE 754 standard.
+## Combine parts of a [F64] according to IEEE 754 standard.
 f64FromParts : { sign : Bool, exponent : U16, fraction : U64 } -> F64

--- a/crates/compiler/builtins/roc/Num.roc
+++ b/crates/compiler/builtins/roc/Num.roc
@@ -1428,7 +1428,10 @@ f32ToParts : F32 -> { sign : Bool, exponent : U8, fraction : U32 }
 f64ToParts : F64 -> { sign : Bool, exponent : U16, fraction : U64 }
 
 ## Combine parts of a [F32] according to IEEE 754 standard.
+## The fraction should not be bigger than 0x007F_FFFF, any bigger value will be truncated.
 f32FromParts : { sign : Bool, exponent : U8, fraction : U32 } -> F32
 
 ## Combine parts of a [F64] according to IEEE 754 standard.
+## The fraction should not be bigger than 0x000F_FFFF_FFFF_FFFF, any bigger value will be truncated.
+## The exponent should not be bigger than 0x07FF, any bigger value will be truncated.
 f64FromParts : { sign : Bool, exponent : U16, fraction : U64 } -> F64

--- a/crates/compiler/builtins/src/bitcode.rs
+++ b/crates/compiler/builtins/src/bitcode.rs
@@ -334,6 +334,8 @@ pub const NUM_COUNT_LEADING_ZERO_BITS: IntrinsicName =
 pub const NUM_COUNT_TRAILING_ZERO_BITS: IntrinsicName =
     int_intrinsic!("roc_builtins.num.count_trailing_zero_bits");
 pub const NUM_COUNT_ONE_BITS: IntrinsicName = int_intrinsic!("roc_builtins.num.count_one_bits");
+pub const NUM_F32_TO_PARTS: &str = "roc_builtins.num.f32_to_parts";
+pub const NUM_F64_TO_PARTS: &str = "roc_builtins.num.f64_to_parts";
 
 pub const STR_INIT: &str = "roc_builtins.str.init";
 pub const STR_COUNT_SEGMENTS: &str = "roc_builtins.str.count_segments";

--- a/crates/compiler/builtins/src/bitcode.rs
+++ b/crates/compiler/builtins/src/bitcode.rs
@@ -336,6 +336,8 @@ pub const NUM_COUNT_TRAILING_ZERO_BITS: IntrinsicName =
 pub const NUM_COUNT_ONE_BITS: IntrinsicName = int_intrinsic!("roc_builtins.num.count_one_bits");
 pub const NUM_F32_TO_PARTS: &str = "roc_builtins.num.f32_to_parts";
 pub const NUM_F64_TO_PARTS: &str = "roc_builtins.num.f64_to_parts";
+pub const NUM_F32_FROM_PARTS: &str = "roc_builtins.num.f32_from_parts";
+pub const NUM_F64_FROM_PARTS: &str = "roc_builtins.num.f64_from_parts";
 
 pub const STR_INIT: &str = "roc_builtins.str.init";
 pub const STR_COUNT_SEGMENTS: &str = "roc_builtins.str.count_segments";

--- a/crates/compiler/builtins/src/bitcode.rs
+++ b/crates/compiler/builtins/src/bitcode.rs
@@ -415,6 +415,7 @@ pub const DEC_SUB_SATURATED: &str = "roc_builtins.dec.sub_saturated";
 pub const DEC_SUB_WITH_OVERFLOW: &str = "roc_builtins.dec.sub_with_overflow";
 pub const DEC_TAN: &str = "roc_builtins.dec.tan";
 pub const DEC_TO_I128: &str = "roc_builtins.dec.to_i128";
+pub const DEC_FROM_I128: &str = "roc_builtins.dec.from_i128";
 pub const DEC_TO_STR: &str = "roc_builtins.dec.to_str";
 pub const DEC_ROUND: IntrinsicName = int_intrinsic!("roc_builtins.dec.round");
 pub const DEC_FLOOR: IntrinsicName = int_intrinsic!("roc_builtins.dec.floor");

--- a/crates/compiler/can/src/builtins.rs
+++ b/crates/compiler/can/src/builtins.rs
@@ -205,7 +205,8 @@ map_symbol_to_lowlevel_and_arity! {
     NumCountTrailingZeroBits; NUM_COUNT_TRAILING_ZERO_BITS; 1,
     NumCountOneBits; NUM_COUNT_ONE_BITS; 1,
     I128OfDec; I128_OF_DEC; 1,
-    DecWithoutDecimalPoint; NUM_DEC_WITHOUT_DECIMAL_POINT; 1,
+    NumWithoutDecimalPoint; NUM_WITHOUT_DECIMAL_POINT; 1,
+    NumWithDecimalPoint; NUM_WITH_DECIMAL_POINT; 1,
 
     Eq; BOOL_STRUCTURAL_EQ; 2,
     NotEq; BOOL_STRUCTURAL_NOT_EQ; 2,

--- a/crates/compiler/can/src/builtins.rs
+++ b/crates/compiler/can/src/builtins.rs
@@ -204,7 +204,6 @@ map_symbol_to_lowlevel_and_arity! {
     NumCountLeadingZeroBits; NUM_COUNT_LEADING_ZERO_BITS; 1,
     NumCountTrailingZeroBits; NUM_COUNT_TRAILING_ZERO_BITS; 1,
     NumCountOneBits; NUM_COUNT_ONE_BITS; 1,
-    I128OfDec; I128_OF_DEC; 1,
     NumWithoutDecimalPoint; NUM_WITHOUT_DECIMAL_POINT; 1,
     NumWithDecimalPoint; NUM_WITH_DECIMAL_POINT; 1,
     NumF32ToParts; NUM_F32_TO_PARTS; 1,

--- a/crates/compiler/can/src/builtins.rs
+++ b/crates/compiler/can/src/builtins.rs
@@ -205,6 +205,7 @@ map_symbol_to_lowlevel_and_arity! {
     NumCountTrailingZeroBits; NUM_COUNT_TRAILING_ZERO_BITS; 1,
     NumCountOneBits; NUM_COUNT_ONE_BITS; 1,
     I128OfDec; I128_OF_DEC; 1,
+    DecWithoutDecimalPoint; NUM_DEC_WITHOUT_DECIMAL_POINT; 1,
 
     Eq; BOOL_STRUCTURAL_EQ; 2,
     NotEq; BOOL_STRUCTURAL_NOT_EQ; 2,

--- a/crates/compiler/can/src/builtins.rs
+++ b/crates/compiler/can/src/builtins.rs
@@ -209,6 +209,8 @@ map_symbol_to_lowlevel_and_arity! {
     NumWithDecimalPoint; NUM_WITH_DECIMAL_POINT; 1,
     NumF32ToParts; NUM_F32_TO_PARTS; 1,
     NumF64ToParts; NUM_F64_TO_PARTS; 1,
+    NumF32FromParts; NUM_F32_FROM_PARTS; 1,
+    NumF64FromParts; NUM_F64_FROM_PARTS; 1,
 
     Eq; BOOL_STRUCTURAL_EQ; 2,
     NotEq; BOOL_STRUCTURAL_NOT_EQ; 2,

--- a/crates/compiler/can/src/builtins.rs
+++ b/crates/compiler/can/src/builtins.rs
@@ -207,6 +207,8 @@ map_symbol_to_lowlevel_and_arity! {
     I128OfDec; I128_OF_DEC; 1,
     NumWithoutDecimalPoint; NUM_WITHOUT_DECIMAL_POINT; 1,
     NumWithDecimalPoint; NUM_WITH_DECIMAL_POINT; 1,
+    NumF32ToParts; NUM_F32_TO_PARTS; 1,
+    NumF64ToParts; NUM_F64_TO_PARTS; 1,
 
     Eq; BOOL_STRUCTURAL_EQ; 2,
     NotEq; BOOL_STRUCTURAL_NOT_EQ; 2,

--- a/crates/compiler/gen_dev/src/lib.rs
+++ b/crates/compiler/gen_dev/src/lib.rs
@@ -2039,6 +2039,16 @@ trait Backend<'a> {
                 self.build_fn_call(sym, intrinsic, args, arg_layouts, ret_layout)
             }
 
+            LowLevel::NumF32ToParts => {
+                let intrinsic = bitcode::NUM_F32_TO_PARTS.to_string();
+                self.build_fn_call(sym, intrinsic, args, arg_layouts, ret_layout)
+            }
+
+            LowLevel::NumF64ToParts => {
+                let intrinsic = bitcode::NUM_F64_TO_PARTS.to_string();
+                self.build_fn_call(sym, intrinsic, args, arg_layouts, ret_layout)
+            }
+
             x => todo!("low level, {:?}", x),
         }
     }

--- a/crates/compiler/gen_dev/src/lib.rs
+++ b/crates/compiler/gen_dev/src/lib.rs
@@ -2029,6 +2029,11 @@ trait Backend<'a> {
                 }
             }
 
+            LowLevel::DecWithoutDecimalPoint => {
+                let intrinsic = bitcode::DEC_TO_I128.to_string();
+                self.build_fn_call(sym, intrinsic, args, arg_layouts, ret_layout)
+            }
+
             x => todo!("low level, {:?}", x),
         }
     }

--- a/crates/compiler/gen_dev/src/lib.rs
+++ b/crates/compiler/gen_dev/src/lib.rs
@@ -2049,6 +2049,16 @@ trait Backend<'a> {
                 self.build_fn_call(sym, intrinsic, args, arg_layouts, ret_layout)
             }
 
+            LowLevel::NumF32FromParts => {
+                let intrinsic = bitcode::NUM_F32_FROM_PARTS.to_string();
+                self.build_fn_call(sym, intrinsic, args, arg_layouts, ret_layout)
+            }
+
+            LowLevel::NumF64FromParts => {
+                let intrinsic = bitcode::NUM_F64_FROM_PARTS.to_string();
+                self.build_fn_call(sym, intrinsic, args, arg_layouts, ret_layout)
+            }
+
             x => todo!("low level, {:?}", x),
         }
     }

--- a/crates/compiler/gen_dev/src/lib.rs
+++ b/crates/compiler/gen_dev/src/lib.rs
@@ -2029,8 +2029,13 @@ trait Backend<'a> {
                 }
             }
 
-            LowLevel::DecWithoutDecimalPoint => {
+            LowLevel::NumWithoutDecimalPoint => {
                 let intrinsic = bitcode::DEC_TO_I128.to_string();
+                self.build_fn_call(sym, intrinsic, args, arg_layouts, ret_layout)
+            }
+
+            LowLevel::NumWithDecimalPoint => {
+                let intrinsic = bitcode::DEC_FROM_I128.to_string();
                 self.build_fn_call(sym, intrinsic, args, arg_layouts, ret_layout)
             }
 

--- a/crates/compiler/gen_llvm/src/llvm/bitcode.rs
+++ b/crates/compiler/gen_llvm/src/llvm/bitcode.rs
@@ -1226,7 +1226,7 @@ pub(crate) fn call_bitcode_fn_returning_record<'ctx>(
     let zig_return_alloca;
     let layout_repr = layout_interner.get_repr(layout);
     let fn_val = env.module.get_function(fn_name).unwrap();
-    if fn_val.get_type().get_return_type() == None {
+    if fn_val.get_type().get_return_type().is_none() {
         // return by pointer
         let bitcode_return_type = env
             .module
@@ -1235,7 +1235,7 @@ pub(crate) fn call_bitcode_fn_returning_record<'ctx>(
         zig_return_alloca = env
             .builder
             .new_build_alloca(bitcode_return_type, "zig_return_alloca");
-        call_void_bitcode_fn(env, &[zig_return_alloca.into(), arg.into()], fn_name);
+        call_void_bitcode_fn(env, &[zig_return_alloca.into(), arg], fn_name);
     } else {
         // direct return
         let zig_result = call_bitcode_fn(env, &[arg], fn_name);

--- a/crates/compiler/gen_llvm/src/llvm/bitcode.rs
+++ b/crates/compiler/gen_llvm/src/llvm/bitcode.rs
@@ -1168,3 +1168,88 @@ pub(crate) fn call_list_bitcode_fn<'ctx>(
         }
     }
 }
+
+pub(crate) fn call_bitcode_fn_with_record_arg<'ctx>(
+    env: &Env<'_, 'ctx, '_>,
+    arg: BasicValueEnum<'ctx>,
+    fn_name: &str,
+) -> BasicValueEnum<'ctx> {
+    let roc_call_alloca = env
+        .builder
+        .new_build_alloca(arg.get_type(), "roc_call_alloca");
+    env.builder.new_build_store(roc_call_alloca, arg);
+
+    let fn_val = env.module.get_function(fn_name).unwrap();
+
+    let mut args: Vec<BasicValueEnum<'ctx>> = Vec::with_capacity(fn_val.count_params() as usize);
+    if fn_val.get_first_param().unwrap().is_pointer_value() {
+        // call by pointer
+        let zig_call_alloca = env
+            .builder
+            .new_build_alloca(arg.get_type(), "zig_return_alloca");
+        env.builder.new_build_store(zig_call_alloca, arg);
+        args.push(zig_call_alloca.into());
+    } else if fn_val.count_params() == 1 {
+        //c all single with arg as
+        let zig_param_type = fn_val.get_params()[0].get_type();
+        let zig_value = env
+            .builder
+            .new_build_load(zig_param_type, roc_call_alloca, "zig_value");
+        args.push(zig_value);
+    } else {
+        // split arg
+        let zig_params_types: Vec<_> = fn_val.get_param_iter().map(|p| p.get_type()).collect();
+        let zig_record_type = env.context.struct_type(&zig_params_types, false);
+        let zig_recode_value = env
+            .builder
+            .new_build_load(zig_record_type, roc_call_alloca, "zig_value")
+            .into_struct_value();
+        for i in 0..fn_val.count_params() {
+            let zig_value = env
+                .builder
+                .build_extract_value(zig_recode_value, i, "zig_value")
+                .unwrap();
+            args.push(zig_value);
+        }
+    }
+    call_bitcode_fn(env, &args, fn_name)
+}
+
+pub(crate) fn call_bitcode_fn_returning_record<'ctx>(
+    env: &Env<'_, 'ctx, '_>,
+    layout: InLayout<'_>,
+    layout_interner: &STLayoutInterner<'_>,
+    bitcode_return_type_name: &str,
+    arg: BasicValueEnum<'ctx>,
+    fn_name: &str,
+) -> BasicValueEnum<'ctx> {
+    let zig_return_alloca;
+    let layout_repr = layout_interner.get_repr(layout);
+    let fn_val = env.module.get_function(fn_name).unwrap();
+    if fn_val.get_type().get_return_type() == None {
+        // return by pointer
+        let bitcode_return_type = env
+            .module
+            .get_struct_type(bitcode_return_type_name)
+            .unwrap();
+        zig_return_alloca = env
+            .builder
+            .new_build_alloca(bitcode_return_type, "zig_return_alloca");
+        call_void_bitcode_fn(env, &[zig_return_alloca.into(), arg.into()], fn_name);
+    } else {
+        // direct return
+        let zig_result = call_bitcode_fn(env, &[arg], fn_name);
+        zig_return_alloca = env
+            .builder
+            .new_build_alloca(zig_result.get_type(), "zig_return_alloca");
+        env.builder.new_build_store(zig_return_alloca, zig_result);
+    }
+
+    load_roc_value(
+        env,
+        layout_interner,
+        layout_repr,
+        zig_return_alloca,
+        "result",
+    )
+}

--- a/crates/compiler/gen_llvm/src/llvm/lowlevel.rs
+++ b/crates/compiler/gen_llvm/src/llvm/lowlevel.rs
@@ -1178,6 +1178,8 @@ pub(crate) fn run_low_level<'a, 'ctx>(
         }
         NumF32ToParts => todo!("NumF32ToParts"),
         NumF64ToParts => todo!("NumF64ToParts"),
+        NumF32FromParts => todo!("NumF32FromParts"),
+        NumF64FromParts => todo!("NumF64FromParts"),
         Eq => {
             arguments_with_layouts!((lhs_arg, lhs_layout), (rhs_arg, rhs_layout));
 

--- a/crates/compiler/gen_llvm/src/llvm/lowlevel.rs
+++ b/crates/compiler/gen_llvm/src/llvm/lowlevel.rs
@@ -54,7 +54,6 @@ use crate::llvm::{
         LLVM_SUB_WITH_OVERFLOW,
     },
     refcounting::PointerToRefcount,
-    struct_::struct_from_fields,
 };
 
 use super::{build::Env, convert::zig_dec_type};

--- a/crates/compiler/gen_llvm/src/llvm/lowlevel.rs
+++ b/crates/compiler/gen_llvm/src/llvm/lowlevel.rs
@@ -1173,6 +1173,7 @@ pub(crate) fn run_low_level<'a, 'ctx>(
             todo!("implement checked float conversion");
         }
         NumWithoutDecimalPoint | NumWithDecimalPoint => {
+            // Dec uses an I128 under the hood, so no conversion is needed.
             arguments!(arg);
             arg
         }

--- a/crates/compiler/gen_llvm/src/llvm/lowlevel.rs
+++ b/crates/compiler/gen_llvm/src/llvm/lowlevel.rs
@@ -1176,6 +1176,8 @@ pub(crate) fn run_low_level<'a, 'ctx>(
             arguments!(arg);
             arg
         }
+        NumF32ToParts => todo!("NumF32ToParts"),
+        NumF64ToParts => todo!("NumF64ToParts"),
         Eq => {
             arguments_with_layouts!((lhs_arg, lhs_layout), (rhs_arg, rhs_layout));
 

--- a/crates/compiler/gen_llvm/src/llvm/lowlevel.rs
+++ b/crates/compiler/gen_llvm/src/llvm/lowlevel.rs
@@ -1172,7 +1172,7 @@ pub(crate) fn run_low_level<'a, 'ctx>(
             // which could be useful to look at when implementing this.
             todo!("implement checked float conversion");
         }
-        I128OfDec | NumWithoutDecimalPoint | NumWithDecimalPoint => {
+        NumWithoutDecimalPoint | NumWithDecimalPoint => {
             arguments!(arg);
             arg
         }

--- a/crates/compiler/gen_llvm/src/llvm/lowlevel.rs
+++ b/crates/compiler/gen_llvm/src/llvm/lowlevel.rs
@@ -54,6 +54,7 @@ use crate::llvm::{
         LLVM_SUB_WITH_OVERFLOW,
     },
     refcounting::PointerToRefcount,
+    struct_::struct_from_fields,
 };
 
 use super::{build::Env, convert::zig_dec_type};
@@ -1178,58 +1179,63 @@ pub(crate) fn run_low_level<'a, 'ctx>(
         }
         NumF32ToParts => {
             arguments!(arg);
-            let zig_result = call_bitcode_fn(env, &[arg], bitcode::NUM_F32_TO_PARTS);
-            let zig_return_alloca = env
-                .builder
-                .new_build_alloca(zig_result.get_type(), "zig_return_alloca");
-            env.builder.new_build_store(zig_return_alloca, zig_result);
-
-            let roc_return_type =
-                basic_type_from_layout(env, layout_interner, layout_interner.get_repr(layout))
-                    .ptr_type(AddressSpace::default());
-
-            let roc_return_alloca = env.builder.new_build_pointer_cast(
-                zig_return_alloca,
-                roc_return_type,
-                "cast_to_roc",
-            );
-
-            load_roc_value(
-                env,
-                layout_interner,
-                layout_interner.get_repr(layout),
-                roc_return_alloca,
-                "f64_to_parts_result",
-            )
+            let fn_name = bitcode::NUM_F32_TO_PARTS;
+            call_bitcode_fn_and_cast_result(env, &[arg], fn_name, layout_interner, layout)
         }
         NumF64ToParts => {
             arguments!(arg);
-            let zig_result = call_bitcode_fn(env, &[arg], bitcode::NUM_F64_TO_PARTS);
-            let zig_return_alloca = env
-                .builder
-                .new_build_alloca(zig_result.get_type(), "zig_return_alloca");
-            env.builder.new_build_store(zig_return_alloca, zig_result);
-
-            let roc_return_type =
-                basic_type_from_layout(env, layout_interner, layout_interner.get_repr(layout))
-                    .ptr_type(AddressSpace::default());
-
-            let roc_return_alloca = env.builder.new_build_pointer_cast(
-                zig_return_alloca,
-                roc_return_type,
-                "cast_to_roc",
-            );
-
-            load_roc_value(
-                env,
-                layout_interner,
-                layout_interner.get_repr(layout),
-                roc_return_alloca,
-                "f64_to_parts_result",
-            )
+            let fn_name = bitcode::NUM_F64_TO_PARTS;
+            call_bitcode_fn_and_cast_result(env, &[arg], fn_name, layout_interner, layout)
         }
-        NumF32FromParts => todo!("NumF32FromParts"),
-        NumF64FromParts => todo!("NumF64FromParts"),
+        NumF32FromParts => {
+            arguments!(arg);
+            let fn_name = bitcode::NUM_F32_FROM_PARTS;
+
+            let roc_call_alloca = env
+                .builder
+                .new_build_alloca(arg.get_type(), "roc_call_alloca");
+            env.builder.new_build_store(roc_call_alloca, arg);
+
+            let fn_val = env.module.get_function(fn_name).unwrap();
+            let zig_param_type = fn_val.get_params()[0].get_type();
+            let zig_value =
+                env.builder
+                    .new_build_load(zig_param_type, roc_call_alloca, "zig_value");
+
+            call_bitcode_fn(env, &[zig_value], fn_name)
+        }
+        NumF64FromParts => {
+            arguments!(arg);
+            let fn_name = bitcode::NUM_F64_FROM_PARTS;
+
+            let roc_call_alloca = env
+                .builder
+                .new_build_alloca(arg.get_type(), "roc_call_alloca");
+            env.builder.new_build_store(roc_call_alloca, arg);
+
+            let fn_val = env.module.get_function(fn_name).unwrap();
+
+            let zig_params_types: Vec<_> =
+                fn_val.get_params().iter().map(|p| p.get_type()).collect();
+
+            let zig_record_type = env.context.struct_type(&zig_params_types, false);
+            let zig_recode_value = env
+                .builder
+                .new_build_load(zig_record_type, roc_call_alloca, "zig_value")
+                .into_struct_value();
+
+            let zig_value_0 = env
+                .builder
+                .build_extract_value(zig_recode_value, 0, "zig_value_0")
+                .unwrap();
+
+            let zig_value_1 = env
+                .builder
+                .build_extract_value(zig_recode_value, 1, "zig_value_1")
+                .unwrap();
+
+            call_bitcode_fn(env, &[zig_value_0, zig_value_1], fn_name)
+        }
         Eq => {
             arguments_with_layouts!((lhs_arg, lhs_layout), (rhs_arg, rhs_layout));
 
@@ -1398,6 +1404,28 @@ pub(crate) fn run_low_level<'a, 'ctx>(
 
         SetJmp | LongJmp | SetLongJmpBuffer => unreachable!("only inserted in dev backend codegen"),
     }
+}
+
+fn call_bitcode_fn_and_cast_result<'ctx>(
+    env: &Env<'_, 'ctx, '_>,
+    args: &[BasicValueEnum<'ctx>],
+    fn_name: &str,
+    layout_interner: &STLayoutInterner<'_>,
+    layout: InLayout<'_>,
+) -> BasicValueEnum<'ctx> {
+    let zig_result = call_bitcode_fn(env, args, fn_name);
+    let zig_return_alloca = env
+        .builder
+        .new_build_alloca(zig_result.get_type(), "zig_return_alloca");
+    env.builder.new_build_store(zig_return_alloca, zig_result);
+
+    load_roc_value(
+        env,
+        layout_interner,
+        layout_interner.get_repr(layout),
+        zig_return_alloca,
+        "f64_to_parts_result",
+    )
 }
 
 fn intwidth_from_layout(layout: InLayout) -> IntWidth {

--- a/crates/compiler/gen_llvm/src/llvm/lowlevel.rs
+++ b/crates/compiler/gen_llvm/src/llvm/lowlevel.rs
@@ -1172,9 +1172,9 @@ pub(crate) fn run_low_level<'a, 'ctx>(
             // which could be useful to look at when implementing this.
             todo!("implement checked float conversion");
         }
-        I128OfDec | DecWithoutDecimalPoint => {
-            arguments!(dec);
-            dec_unary_op(env, bitcode::DEC_TO_I128, dec)
+        I128OfDec | NumWithoutDecimalPoint | NumWithDecimalPoint => {
+            arguments!(arg);
+            arg
         }
         Eq => {
             arguments_with_layouts!((lhs_arg, lhs_layout), (rhs_arg, rhs_layout));

--- a/crates/compiler/gen_llvm/src/llvm/lowlevel.rs
+++ b/crates/compiler/gen_llvm/src/llvm/lowlevel.rs
@@ -1176,7 +1176,93 @@ pub(crate) fn run_low_level<'a, 'ctx>(
             arguments!(arg);
             arg
         }
-        NumF32ToParts => todo!("NumF32ToParts"),
+        NumF32ToParts => {
+            // Splits a [F32] into its components according to IEEE 754 standard.
+            // F32 -> { sign : Bool, exponent : U8, fraction : U32 }
+
+            // temp for inspiration
+            /*pub fn f32ToParts(self: f32) callconv(.C) F32Parts {
+                const u32Value = @as(u32, @bitCast(self));
+                return F32Parts{
+                    .fraction = u32Value & 0x7fffff,
+                    .exponent = @truncate(u32Value >> 23 & 0xff),
+                    .sign = u32Value >> 31 & 1 == 1,
+                };
+            } */
+            arguments!(arg);
+            let float_val = arg.into_float_value();
+
+            let float_bits = env.builder.new_build_bitcast(
+                float_val, 
+                env.context.i32_type(), 
+                "float_as_int"
+            ).into_int_value();
+            
+            let sign_bit = env.builder.new_build_right_shift(
+                float_bits,
+                env.context.i32_type().const_int(31, false),
+                false,
+                "sign_bit"
+            );
+        
+            let exponent_mask = env.context.i32_type().const_int(0x7F80_0000, false);
+            let exponent_bits = env.builder.new_build_and(
+                float_bits, 
+                exponent_mask,
+                "exponent_bits"
+            );
+            let exponent = env.builder.new_build_right_shift(
+                exponent_bits,
+                env.context.i32_type().const_int(23, false),
+                false,
+                "exponent"
+            );
+        
+            let fraction_mask = env.context.i32_type().const_int(0x007F_FFFF, false);  
+            let fraction = env.builder.new_build_and(
+                float_bits,
+                fraction_mask,
+                "fraction"
+            );
+
+            // Not sure if order is correct
+            let fields = [Layout::BOOL, Layout::U16, Layout::U64];
+            // Not sure if order is correct
+            let (sign_index, exponent_index, fraction_index) = (0, 1, 2);
+
+            let result_layout = LayoutRepr::Struct(env.arena.alloc(fields));
+
+            let result_struct_type =
+                basic_type_from_layout(env, layout_interner, result_layout).into_struct_type();
+        
+            let result = result_struct_type.const_zero();
+
+            // We have sign_bit, not sure how to convert it to Roc Bool representation
+            let sign = sign_bit;
+
+            let result = env
+                .builder
+                .build_insert_value(result, sign, sign_index, "insert_sign")
+                .unwrap();
+
+            let result = env
+                .builder
+                .build_insert_value(result, exponent, exponent_index, "insert_exponent")
+                .unwrap();
+
+            let result = env
+                .builder
+                .build_insert_value(result, fraction, fraction_index, "insert_fraction")
+                .unwrap();
+
+            use_roc_value(
+                env,
+                layout_interner,
+                result_layout,
+                result.into_struct_value().into(),
+                "use_f32_to_parts_result_record",
+            )
+        }
         NumF64ToParts => todo!("NumF64ToParts"),
         NumF32FromParts => todo!("NumF32FromParts"),
         NumF64FromParts => todo!("NumF64FromParts"),

--- a/crates/compiler/gen_llvm/src/llvm/lowlevel.rs
+++ b/crates/compiler/gen_llvm/src/llvm/lowlevel.rs
@@ -1172,7 +1172,7 @@ pub(crate) fn run_low_level<'a, 'ctx>(
             // which could be useful to look at when implementing this.
             todo!("implement checked float conversion");
         }
-        I128OfDec => {
+        I128OfDec | DecWithoutDecimalPoint => {
             arguments!(dec);
             dec_unary_op(env, bitcode::DEC_TO_I128, dec)
         }

--- a/crates/compiler/gen_wasm/src/low_level.rs
+++ b/crates/compiler/gen_wasm/src/low_level.rs
@@ -2017,7 +2017,9 @@ impl<'a> LowLevelCall<'a> {
             NumToFloatChecked => {
                 todo!("implement toF32Checked and toF64Checked");
             }
-            I128OfDec => self.load_args_and_call_zig(backend, bitcode::DEC_TO_I128),
+            I128OfDec | DecWithoutDecimalPoint => {
+                self.load_args_and_call_zig(backend, bitcode::DEC_TO_I128)
+            }
             And => {
                 self.load_args(backend);
                 backend.code_builder.i32_and();

--- a/crates/compiler/gen_wasm/src/low_level.rs
+++ b/crates/compiler/gen_wasm/src/low_level.rs
@@ -2103,6 +2103,8 @@ impl<'a> LowLevelCall<'a> {
             SetJmp | LongJmp | SetLongJmpBuffer => {
                 unreachable!("only inserted in dev backend codegen")
             }
+            NumF32ToParts => todo!("NumF32ToParts"),
+            NumF64ToParts => todo!("NumF64ToParts"),
         }
     }
 

--- a/crates/compiler/gen_wasm/src/low_level.rs
+++ b/crates/compiler/gen_wasm/src/low_level.rs
@@ -2021,6 +2021,10 @@ impl<'a> LowLevelCall<'a> {
                 self.load_args_and_call_zig(backend, bitcode::DEC_TO_I128)
             }
             NumWithDecimalPoint => self.load_args_and_call_zig(backend, bitcode::DEC_FROM_I128),
+            NumF32ToParts => self.load_args_and_call_zig(backend, bitcode::NUM_F32_TO_PARTS),
+            NumF64ToParts => self.load_args_and_call_zig(backend, bitcode::NUM_F64_TO_PARTS),
+            NumF32FromParts => self.load_args_and_call_zig(backend, bitcode::NUM_F32_FROM_PARTS),
+            NumF64FromParts => self.load_args_and_call_zig(backend, bitcode::NUM_F64_FROM_PARTS),
             And => {
                 self.load_args(backend);
                 backend.code_builder.i32_and();
@@ -2103,10 +2107,6 @@ impl<'a> LowLevelCall<'a> {
             SetJmp | LongJmp | SetLongJmpBuffer => {
                 unreachable!("only inserted in dev backend codegen")
             }
-            NumF32ToParts => todo!("NumF32ToParts"),
-            NumF64ToParts => todo!("NumF64ToParts"),
-            NumF32FromParts => todo!("NumF32FromParts"),
-            NumF64FromParts => todo!("NumF64FromParts"),
         }
     }
 

--- a/crates/compiler/gen_wasm/src/low_level.rs
+++ b/crates/compiler/gen_wasm/src/low_level.rs
@@ -2105,6 +2105,8 @@ impl<'a> LowLevelCall<'a> {
             }
             NumF32ToParts => todo!("NumF32ToParts"),
             NumF64ToParts => todo!("NumF64ToParts"),
+            NumF32FromParts => todo!("NumF32FromParts"),
+            NumF64FromParts => todo!("NumF64FromParts"),
         }
     }
 

--- a/crates/compiler/gen_wasm/src/low_level.rs
+++ b/crates/compiler/gen_wasm/src/low_level.rs
@@ -2017,9 +2017,10 @@ impl<'a> LowLevelCall<'a> {
             NumToFloatChecked => {
                 todo!("implement toF32Checked and toF64Checked");
             }
-            I128OfDec | DecWithoutDecimalPoint => {
+            I128OfDec | NumWithoutDecimalPoint => {
                 self.load_args_and_call_zig(backend, bitcode::DEC_TO_I128)
             }
+            NumWithDecimalPoint => self.load_args_and_call_zig(backend, bitcode::DEC_FROM_I128),
             And => {
                 self.load_args(backend);
                 backend.code_builder.i32_and();

--- a/crates/compiler/gen_wasm/src/low_level.rs
+++ b/crates/compiler/gen_wasm/src/low_level.rs
@@ -2017,9 +2017,7 @@ impl<'a> LowLevelCall<'a> {
             NumToFloatChecked => {
                 todo!("implement toF32Checked and toF64Checked");
             }
-            I128OfDec | NumWithoutDecimalPoint => {
-                self.load_args_and_call_zig(backend, bitcode::DEC_TO_I128)
-            }
+            NumWithoutDecimalPoint => self.load_args_and_call_zig(backend, bitcode::DEC_TO_I128),
             NumWithDecimalPoint => self.load_args_and_call_zig(backend, bitcode::DEC_FROM_I128),
             NumF32ToParts => self.load_args_and_call_zig(backend, bitcode::NUM_F32_TO_PARTS),
             NumF64ToParts => self.load_args_and_call_zig(backend, bitcode::NUM_F64_TO_PARTS),

--- a/crates/compiler/module/src/low_level.rs
+++ b/crates/compiler/module/src/low_level.rs
@@ -103,6 +103,7 @@ pub enum LowLevel {
     NumCountTrailingZeroBits,
     NumCountOneBits,
     I128OfDec,
+    DecWithoutDecimalPoint,
     Eq,
     NotEq,
     And,
@@ -337,6 +338,7 @@ map_symbol_to_lowlevel! {
     NumCountTrailingZeroBits <= NUM_COUNT_TRAILING_ZERO_BITS;
     NumCountOneBits <= NUM_COUNT_ONE_BITS;
     I128OfDec <= I128_OF_DEC;
+    DecWithoutDecimalPoint <= I128_OF_DEC;
     Eq <= BOOL_STRUCTURAL_EQ;
     NotEq <= BOOL_STRUCTURAL_NOT_EQ;
     And <= BOOL_AND;

--- a/crates/compiler/module/src/low_level.rs
+++ b/crates/compiler/module/src/low_level.rs
@@ -108,7 +108,6 @@ pub enum LowLevel {
     NumF64ToParts,
     NumF32FromParts,
     NumF64FromParts,
-    I128OfDec,
     Eq,
     NotEq,
     And,
@@ -342,7 +341,6 @@ map_symbol_to_lowlevel! {
     NumCountLeadingZeroBits <= NUM_COUNT_LEADING_ZERO_BITS;
     NumCountTrailingZeroBits <= NUM_COUNT_TRAILING_ZERO_BITS;
     NumCountOneBits <= NUM_COUNT_ONE_BITS;
-    I128OfDec <= I128_OF_DEC;
     NumWithoutDecimalPoint <= NUM_WITHOUT_DECIMAL_POINT;
     NumWithDecimalPoint <= NUM_WITH_DECIMAL_POINT;
     NumF32ToParts <= NUM_F32_TO_PARTS;

--- a/crates/compiler/module/src/low_level.rs
+++ b/crates/compiler/module/src/low_level.rs
@@ -106,6 +106,8 @@ pub enum LowLevel {
     NumWithDecimalPoint,
     NumF32ToParts,
     NumF64ToParts,
+    NumF32FromParts,
+    NumF64FromParts,
     I128OfDec,
     Eq,
     NotEq,
@@ -345,6 +347,8 @@ map_symbol_to_lowlevel! {
     NumWithDecimalPoint <= NUM_WITH_DECIMAL_POINT;
     NumF32ToParts <= NUM_F32_TO_PARTS;
     NumF64ToParts <= NUM_F64_TO_PARTS;
+    NumF32FromParts <= NUM_F32_FROM_PARTS;
+    NumF64FromParts <= NUM_F64_FROM_PARTS;
     Eq <= BOOL_STRUCTURAL_EQ;
     NotEq <= BOOL_STRUCTURAL_NOT_EQ;
     And <= BOOL_AND;

--- a/crates/compiler/module/src/low_level.rs
+++ b/crates/compiler/module/src/low_level.rs
@@ -104,6 +104,8 @@ pub enum LowLevel {
     NumCountOneBits,
     NumWithoutDecimalPoint,
     NumWithDecimalPoint,
+    NumF32ToParts,
+    NumF64ToParts,
     I128OfDec,
     Eq,
     NotEq,
@@ -341,6 +343,8 @@ map_symbol_to_lowlevel! {
     I128OfDec <= I128_OF_DEC;
     NumWithoutDecimalPoint <= NUM_WITHOUT_DECIMAL_POINT;
     NumWithDecimalPoint <= NUM_WITH_DECIMAL_POINT;
+    NumF32ToParts <= NUM_F32_TO_PARTS;
+    NumF64ToParts <= NUM_F64_TO_PARTS;
     Eq <= BOOL_STRUCTURAL_EQ;
     NotEq <= BOOL_STRUCTURAL_NOT_EQ;
     And <= BOOL_AND;

--- a/crates/compiler/module/src/low_level.rs
+++ b/crates/compiler/module/src/low_level.rs
@@ -102,8 +102,9 @@ pub enum LowLevel {
     NumCountLeadingZeroBits,
     NumCountTrailingZeroBits,
     NumCountOneBits,
+    NumWithoutDecimalPoint,
+    NumWithDecimalPoint,
     I128OfDec,
-    DecWithoutDecimalPoint,
     Eq,
     NotEq,
     And,
@@ -338,7 +339,8 @@ map_symbol_to_lowlevel! {
     NumCountTrailingZeroBits <= NUM_COUNT_TRAILING_ZERO_BITS;
     NumCountOneBits <= NUM_COUNT_ONE_BITS;
     I128OfDec <= I128_OF_DEC;
-    DecWithoutDecimalPoint <= I128_OF_DEC;
+    NumWithoutDecimalPoint <= NUM_WITHOUT_DECIMAL_POINT;
+    NumWithDecimalPoint <= NUM_WITH_DECIMAL_POINT;
     Eq <= BOOL_STRUCTURAL_EQ;
     NotEq <= BOOL_STRUCTURAL_NOT_EQ;
     And <= BOOL_AND;

--- a/crates/compiler/module/src/symbol.rs
+++ b/crates/compiler/module/src/symbol.rs
@@ -1270,6 +1270,8 @@ define_builtins! {
         158 NUM_REM_UNCHECKED: "remUnchecked" // traps on division by zero
         159 NUM_WITHOUT_DECIMAL_POINT: "withoutDecimalPoint"
         160 NUM_WITH_DECIMAL_POINT: "withDecimalPoint"
+        161 NUM_F32_TO_PARTS: "f32ToParts"
+        162 NUM_F64_TO_PARTS: "f64ToParts"
     }
     4 BOOL: "Bool" => {
         0 BOOL_BOOL: "Bool" exposed_type=true // the Bool.Bool type alias

--- a/crates/compiler/module/src/symbol.rs
+++ b/crates/compiler/module/src/symbol.rs
@@ -1272,6 +1272,8 @@ define_builtins! {
         160 NUM_WITH_DECIMAL_POINT: "withDecimalPoint"
         161 NUM_F32_TO_PARTS: "f32ToParts"
         162 NUM_F64_TO_PARTS: "f64ToParts"
+        163 NUM_F32_FROM_PARTS: "f32FromParts"
+        164 NUM_F64_FROM_PARTS: "f64FromParts"
     }
     4 BOOL: "Bool" => {
         0 BOOL_BOOL: "Bool" exposed_type=true // the Bool.Bool type alias

--- a/crates/compiler/module/src/symbol.rs
+++ b/crates/compiler/module/src/symbol.rs
@@ -1268,7 +1268,8 @@ define_builtins! {
         156 NUM_BYTES_TO_U128_LOWLEVEL: "bytesToU128Lowlevel"
         157 NUM_DIV_TRUNC_UNCHECKED: "divTruncUnchecked" // traps on division by zero
         158 NUM_REM_UNCHECKED: "remUnchecked" // traps on division by zero
-        159 NUM_DEC_WITHOUT_DECIMAL_POINT: "withoutDecimalPoint"
+        159 NUM_WITHOUT_DECIMAL_POINT: "withoutDecimalPoint"
+        160 NUM_WITH_DECIMAL_POINT: "withDecimalPoint"
     }
     4 BOOL: "Bool" => {
         0 BOOL_BOOL: "Bool" exposed_type=true // the Bool.Bool type alias

--- a/crates/compiler/module/src/symbol.rs
+++ b/crates/compiler/module/src/symbol.rs
@@ -1268,6 +1268,7 @@ define_builtins! {
         156 NUM_BYTES_TO_U128_LOWLEVEL: "bytesToU128Lowlevel"
         157 NUM_DIV_TRUNC_UNCHECKED: "divTruncUnchecked" // traps on division by zero
         158 NUM_REM_UNCHECKED: "remUnchecked" // traps on division by zero
+        159 NUM_DEC_WITHOUT_DECIMAL_POINT: "withoutDecimalPoint"
     }
     4 BOOL: "Bool" => {
         0 BOOL_BOOL: "Bool" exposed_type=true // the Bool.Bool type alias

--- a/crates/compiler/mono/src/drop_specialization.rs
+++ b/crates/compiler/mono/src/drop_specialization.rs
@@ -1594,7 +1594,9 @@ fn low_level_no_rc(lowlevel: &LowLevel) -> RC {
         | NumCountTrailingZeroBits
         | NumCountOneBits
         | NumF32ToParts
-        | NumF64ToParts => RC::NoRc,
+        | NumF64ToParts
+        | NumF32FromParts
+        | NumF64FromParts => RC::NoRc,
         I128OfDec | NumWithoutDecimalPoint | NumWithDecimalPoint => RC::NoRc,
         DictPseudoSeed => RC::NoRc,
         StrStartsWith | StrEndsWith => RC::NoRc,

--- a/crates/compiler/mono/src/drop_specialization.rs
+++ b/crates/compiler/mono/src/drop_specialization.rs
@@ -1592,7 +1592,9 @@ fn low_level_no_rc(lowlevel: &LowLevel) -> RC {
         | NumToFloatChecked
         | NumCountLeadingZeroBits
         | NumCountTrailingZeroBits
-        | NumCountOneBits => RC::NoRc,
+        | NumCountOneBits
+        | NumF32ToParts
+        | NumF64ToParts => RC::NoRc,
         I128OfDec | NumWithoutDecimalPoint | NumWithDecimalPoint => RC::NoRc,
         DictPseudoSeed => RC::NoRc,
         StrStartsWith | StrEndsWith => RC::NoRc,

--- a/crates/compiler/mono/src/drop_specialization.rs
+++ b/crates/compiler/mono/src/drop_specialization.rs
@@ -1593,7 +1593,7 @@ fn low_level_no_rc(lowlevel: &LowLevel) -> RC {
         | NumCountLeadingZeroBits
         | NumCountTrailingZeroBits
         | NumCountOneBits => RC::NoRc,
-        I128OfDec | DecWithoutDecimalPoint => RC::NoRc,
+        I128OfDec | NumWithoutDecimalPoint | NumWithDecimalPoint => RC::NoRc,
         DictPseudoSeed => RC::NoRc,
         StrStartsWith | StrEndsWith => RC::NoRc,
         StrFromUtf8 => RC::Rc,

--- a/crates/compiler/mono/src/drop_specialization.rs
+++ b/crates/compiler/mono/src/drop_specialization.rs
@@ -1593,7 +1593,7 @@ fn low_level_no_rc(lowlevel: &LowLevel) -> RC {
         | NumCountLeadingZeroBits
         | NumCountTrailingZeroBits
         | NumCountOneBits => RC::NoRc,
-        I128OfDec => RC::NoRc,
+        I128OfDec | DecWithoutDecimalPoint => RC::NoRc,
         DictPseudoSeed => RC::NoRc,
         StrStartsWith | StrEndsWith => RC::NoRc,
         StrFromUtf8 => RC::Rc,

--- a/crates/compiler/mono/src/drop_specialization.rs
+++ b/crates/compiler/mono/src/drop_specialization.rs
@@ -1597,7 +1597,7 @@ fn low_level_no_rc(lowlevel: &LowLevel) -> RC {
         | NumF64ToParts
         | NumF32FromParts
         | NumF64FromParts => RC::NoRc,
-        I128OfDec | NumWithoutDecimalPoint | NumWithDecimalPoint => RC::NoRc,
+        NumWithoutDecimalPoint | NumWithDecimalPoint => RC::NoRc,
         DictPseudoSeed => RC::NoRc,
         StrStartsWith | StrEndsWith => RC::NoRc,
         StrFromUtf8 => RC::Rc,

--- a/crates/compiler/mono/src/inc_dec.rs
+++ b/crates/compiler/mono/src/inc_dec.rs
@@ -1345,7 +1345,6 @@ pub(crate) fn lowlevel_borrow_signature(op: LowLevel) -> &'static [Ownership] {
         | NumCountLeadingZeroBits
         | NumCountTrailingZeroBits
         | NumCountOneBits
-        | I128OfDec
         | NumWithoutDecimalPoint
         | NumWithDecimalPoint
         | NumF32ToParts

--- a/crates/compiler/mono/src/inc_dec.rs
+++ b/crates/compiler/mono/src/inc_dec.rs
@@ -1345,7 +1345,8 @@ pub(crate) fn lowlevel_borrow_signature(op: LowLevel) -> &'static [Ownership] {
         | NumCountLeadingZeroBits
         | NumCountTrailingZeroBits
         | NumCountOneBits
-        | I128OfDec => &[IRRELEVANT],
+        | I128OfDec
+        | DecWithoutDecimalPoint => &[IRRELEVANT],
         StrStartsWith | StrEndsWith => &[BORROWED, BORROWED],
         StrFromUtf8 => &[OWNED],
         StrToUtf8 => &[OWNED],

--- a/crates/compiler/mono/src/inc_dec.rs
+++ b/crates/compiler/mono/src/inc_dec.rs
@@ -1346,7 +1346,8 @@ pub(crate) fn lowlevel_borrow_signature(op: LowLevel) -> &'static [Ownership] {
         | NumCountTrailingZeroBits
         | NumCountOneBits
         | I128OfDec
-        | DecWithoutDecimalPoint => &[IRRELEVANT],
+        | NumWithoutDecimalPoint
+        | NumWithDecimalPoint => &[IRRELEVANT],
         StrStartsWith | StrEndsWith => &[BORROWED, BORROWED],
         StrFromUtf8 => &[OWNED],
         StrToUtf8 => &[OWNED],

--- a/crates/compiler/mono/src/inc_dec.rs
+++ b/crates/compiler/mono/src/inc_dec.rs
@@ -1349,7 +1349,9 @@ pub(crate) fn lowlevel_borrow_signature(op: LowLevel) -> &'static [Ownership] {
         | NumWithoutDecimalPoint
         | NumWithDecimalPoint
         | NumF32ToParts
-        | NumF64ToParts => &[IRRELEVANT],
+        | NumF64ToParts
+        | NumF32FromParts
+        | NumF64FromParts => &[IRRELEVANT],
         StrStartsWith | StrEndsWith => &[BORROWED, BORROWED],
         StrFromUtf8 => &[OWNED],
         StrToUtf8 => &[OWNED],

--- a/crates/compiler/mono/src/inc_dec.rs
+++ b/crates/compiler/mono/src/inc_dec.rs
@@ -1347,7 +1347,9 @@ pub(crate) fn lowlevel_borrow_signature(op: LowLevel) -> &'static [Ownership] {
         | NumCountOneBits
         | I128OfDec
         | NumWithoutDecimalPoint
-        | NumWithDecimalPoint => &[IRRELEVANT],
+        | NumWithDecimalPoint
+        | NumF32ToParts
+        | NumF64ToParts => &[IRRELEVANT],
         StrStartsWith | StrEndsWith => &[BORROWED, BORROWED],
         StrFromUtf8 => &[OWNED],
         StrToUtf8 => &[OWNED],

--- a/crates/compiler/test_gen/src/gen_num.rs
+++ b/crates/compiler/test_gen/src/gen_num.rs
@@ -3731,3 +3731,105 @@ fn without_decimal_point() {
         i128
     );
 }
+
+#[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-dev", feature = "gen-wasm"))]
+fn f32_to_parts() {
+    assert_evals_to!(r"Num.f32ToParts 0", (0, 0, false), (u32, u8, bool));
+    assert_evals_to!(
+        r"Num.f32ToParts Num.maxF32",
+        (0x7FFFFF, 0xFE, false),
+        (u32, u8, bool)
+    );
+    assert_evals_to!(
+        r"Num.f32ToParts Num.minF32",
+        (0x7FFFFF, 0xFE, true),
+        (u32, u8, bool)
+    );
+}
+
+#[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-dev", feature = "gen-wasm"))]
+fn f64_to_parts() {
+    assert_evals_to!(r"Num.f64ToParts 0", (0, 0, false), (u64, u16, bool));
+    assert_evals_to!(
+        r"Num.f64ToParts Num.maxF64",
+        (0xFFFFFFFFFFFFF, 0x7FE, false),
+        (u64, u16, bool)
+    );
+    assert_evals_to!(
+        r"Num.f64ToParts Num.minF64",
+        (0xFFFFFFFFFFFFF, 0x7FE, true),
+        (u64, u16, bool)
+    );
+}
+
+#[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-dev", feature = "gen-wasm"))]
+fn f32_from_parts() {
+    assert_evals_to!(
+        r"
+    Num.f32FromParts {
+        sign: Bool.false,
+        exponent: 0,
+        fraction: 0
+    }",
+        0.0,
+        f32
+    );
+    assert_evals_to!(
+        r"
+    Num.f32FromParts {
+        sign: Bool.false,
+        exponent: 0xFE,
+        fraction: 0x7FFFFF
+    }",
+        f32::MAX,
+        f32
+    );
+    assert_evals_to!(
+        r"
+    Num.f32FromParts {
+        sign: Bool.true,
+        exponent: 0xFE,
+        fraction: 0x7FFFFF
+    }",
+        f32::MIN,
+        f32
+    );
+}
+
+#[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-dev", feature = "gen-wasm"))]
+fn f64_from_parts() {
+    assert_evals_to!(
+        r"
+    Num.f64FromParts {
+        sign: Bool.false,
+        exponent: 0,
+        fraction: 0
+    }",
+        0.0,
+        f64
+    );
+    assert_evals_to!(
+        r"
+    Num.f64FromParts {
+        sign: Bool.false,
+        exponent: 0x7FE,
+        fraction: 0xFFFFFFFFFFFFF
+    }",
+        f64::MAX,
+        f64
+    );
+    assert_evals_to!(
+        r"
+    Num.f64FromParts {
+        sign: Bool.true,
+        exponent: 0x7FE,
+        fraction: 0xFFFFFFFFFFFFF
+    }",
+        f64::MIN,
+        f64
+    );
+}

--- a/crates/compiler/test_gen/src/gen_num.rs
+++ b/crates/compiler/test_gen/src/gen_num.rs
@@ -3681,3 +3681,53 @@ fn num_max() {
     assert_evals_to!(r"Num.max Num.minI64 Num.maxI64", i64::MAX, i64);
     assert_evals_to!(r"Num.max Num.maxI64 Num.minI64", i64::MAX, i64);
 }
+
+#[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-dev", feature = "gen-wasm"))]
+fn with_decimal_point() {
+    assert_evals_to!(
+        r"Num.withDecimalPoint 0",
+        RocDec::from_str("0").unwrap(),
+        RocDec
+    );
+    assert_evals_to!(
+        r"Num.withDecimalPoint 123000000000000000000",
+        RocDec::from_str("123.0").unwrap(),
+        RocDec
+    );
+    assert_evals_to!(
+        r"Num.withDecimalPoint Num.maxI128",
+        RocDec::from_str("170141183460469231731.687303715884105727").unwrap(),
+        RocDec
+    );
+    assert_evals_to!(
+        r"Num.withDecimalPoint Num.minI128",
+        RocDec::from_str("-170141183460469231731.687303715884105728").unwrap(),
+        RocDec
+    );
+}
+
+#[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-dev", feature = "gen-wasm"))]
+fn without_decimal_point() {
+    assert_evals_to!(
+        r"Num.withoutDecimalPoint 0",
+        RocDec::from_str("0").unwrap(),
+        RocDec
+    );
+    assert_evals_to!(
+        r"Num.withoutDecimalPoint 123.000000000000000000",
+        123000000000000000000,
+        i128
+    );
+    assert_evals_to!(
+        r"Num.withoutDecimalPoint 170141183460469231731.687303715884105727",
+        i128::MAX,
+        i128
+    );
+    assert_evals_to!(
+        r"Num.withoutDecimalPoint -170141183460469231731.687303715884105728",
+        i128::MIN,
+        i128
+    );
+}

--- a/crates/compiler/test_mono/generated/anonymous_closure_in_polymorphic_expression_issue_4717.txt
+++ b/crates/compiler/test_mono/generated/anonymous_closure_in_polymorphic_expression_issue_4717.txt
@@ -78,16 +78,16 @@ procedure List.80 (#Derived_gen.0, #Derived_gen.1, #Derived_gen.2, #Derived_gen.
     jump List.592 #Derived_gen.0 #Derived_gen.1 #Derived_gen.2 #Derived_gen.3 #Derived_gen.4;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.272 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.272;
+    let Num.278 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.278;
 
 procedure Num.51 (#Attr.2, #Attr.3):
-    let Num.271 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
-    ret Num.271;
+    let Num.277 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
+    ret Num.277;
 
 procedure Num.77 (#Attr.2, #Attr.3):
-    let Num.270 : U64 = lowlevel NumSubSaturated #Attr.2 #Attr.3;
-    ret Num.270;
+    let Num.276 : U64 = lowlevel NumSubSaturated #Attr.2 #Attr.3;
+    ret Num.276;
 
 procedure Test.1 (Test.2):
     let Test.13 : U64 = 0i64;

--- a/crates/compiler/test_mono/generated/binary_tree_fbip.txt
+++ b/crates/compiler/test_mono/generated/binary_tree_fbip.txt
@@ -1,6 +1,6 @@
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.269 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.269;
+    let Num.275 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.275;
 
 procedure Test.4 (Test.27):
     let Test.39 : [<rnu>C [<rnu><null>, C *self *self] *self, <null>] = TagId(0) ;

--- a/crates/compiler/test_mono/generated/capture_void_layout_task.txt
+++ b/crates/compiler/test_mono/generated/capture_void_layout_task.txt
@@ -28,12 +28,12 @@ procedure List.91 (#Derived_gen.9, #Derived_gen.10, #Derived_gen.11, #Derived_ge
     jump List.575 #Derived_gen.9 #Derived_gen.10 #Derived_gen.11 #Derived_gen.12 #Derived_gen.13;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.270 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.270;
+    let Num.276 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.276;
 
 procedure Num.51 (#Attr.2, #Attr.3):
-    let Num.269 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
-    ret Num.269;
+    let Num.275 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
+    ret Num.275;
 
 procedure Test.10 (Test.69, #Attr.12):
     let Test.72 : {} = UnionAtIndex (Id 0) (Index 0) #Attr.12;

--- a/crates/compiler/test_mono/generated/choose_correct_recursion_var_under_record.txt
+++ b/crates/compiler/test_mono/generated/choose_correct_recursion_var_under_record.txt
@@ -47,8 +47,8 @@ procedure List.9 (List.334):
         ret List.574;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.269 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.269;
+    let Num.275 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.275;
 
 procedure Result.5 (Result.12, Result.13):
     let Result.39 : U8 = 1i64;

--- a/crates/compiler/test_mono/generated/choose_i128_layout.txt
+++ b/crates/compiler/test_mono/generated/choose_i128_layout.txt
@@ -1,6 +1,6 @@
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.270 : I128 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.270;
+    let Num.276 : I128 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.276;
 
 procedure Test.0 ():
     let Test.6 : I128 = 18446744073709551616i64;

--- a/crates/compiler/test_mono/generated/choose_u128_layout.txt
+++ b/crates/compiler/test_mono/generated/choose_u128_layout.txt
@@ -1,6 +1,6 @@
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.269 : U128 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.269;
+    let Num.275 : U128 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.275;
 
 procedure Test.0 ():
     let Test.2 : U128 = 170141183460469231731687303715884105728u128;

--- a/crates/compiler/test_mono/generated/choose_u64_layout.txt
+++ b/crates/compiler/test_mono/generated/choose_u64_layout.txt
@@ -1,6 +1,6 @@
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.269 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.269;
+    let Num.275 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.275;
 
 procedure Test.0 ():
     let Test.2 : U64 = 9999999999999999999i64;

--- a/crates/compiler/test_mono/generated/compose_recursive_lambda_set_productive_nullable_wrapped.txt
+++ b/crates/compiler/test_mono/generated/compose_recursive_lambda_set_productive_nullable_wrapped.txt
@@ -32,12 +32,12 @@ procedure List.91 (#Derived_gen.7, #Derived_gen.8, #Derived_gen.9, #Derived_gen.
     jump List.575 #Derived_gen.7 #Derived_gen.8 #Derived_gen.9 #Derived_gen.10 #Derived_gen.11;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.270 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.270;
+    let Num.276 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.276;
 
 procedure Num.51 (#Attr.2, #Attr.3):
-    let Num.269 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
-    ret Num.269;
+    let Num.275 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
+    ret Num.275;
 
 procedure Str.3 (#Attr.2, #Attr.3):
     let Str.234 : Str = lowlevel StrConcat #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/dict.txt
+++ b/crates/compiler/test_mono/generated/dict.txt
@@ -30,8 +30,8 @@ procedure List.6 (#Attr.2):
     ret List.572;
 
 procedure Num.75 (#Attr.2, #Attr.3):
-    let Num.269 : U8 = lowlevel NumSubWrap #Attr.2 #Attr.3;
-    ret Num.269;
+    let Num.275 : U8 = lowlevel NumSubWrap #Attr.2 #Attr.3;
+    ret Num.275;
 
 procedure Test.0 ():
     let Test.3 : {} = Struct {};

--- a/crates/compiler/test_mono/generated/empty_list_of_function_type.txt
+++ b/crates/compiler/test_mono/generated/empty_list_of_function_type.txt
@@ -25,8 +25,8 @@ procedure List.66 (#Attr.2, #Attr.3):
     ret List.577;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.269 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.269;
+    let Num.275 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.275;
 
 procedure Test.2 (Test.5):
     dec Test.5;

--- a/crates/compiler/test_mono/generated/encode_derived_nested_record_string.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_nested_record_string.txt
@@ -250,40 +250,40 @@ procedure List.91 (#Derived_gen.47, #Derived_gen.48, #Derived_gen.49, #Derived_g
     jump List.629 #Derived_gen.47 #Derived_gen.48 #Derived_gen.49 #Derived_gen.50 #Derived_gen.51;
 
 procedure Num.127 (#Attr.2):
-    let Num.284 : U8 = lowlevel NumIntCast #Attr.2;
-    ret Num.284;
-
-procedure Num.137 (#Attr.2, #Attr.3):
-    let Num.289 : U64 = lowlevel NumDivCeilUnchecked #Attr.2 #Attr.3;
-    ret Num.289;
-
-procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.288 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.288;
-
-procedure Num.20 (#Attr.2, #Attr.3):
-    let Num.285 : U64 = lowlevel NumSub #Attr.2 #Attr.3;
-    ret Num.285;
-
-procedure Num.21 (#Attr.2, #Attr.3):
-    let Num.290 : U64 = lowlevel NumMul #Attr.2 #Attr.3;
+    let Num.290 : U8 = lowlevel NumIntCast #Attr.2;
     ret Num.290;
 
-procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.296 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+procedure Num.137 (#Attr.2, #Attr.3):
+    let Num.295 : U64 = lowlevel NumDivCeilUnchecked #Attr.2 #Attr.3;
+    ret Num.295;
+
+procedure Num.19 (#Attr.2, #Attr.3):
+    let Num.294 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.294;
+
+procedure Num.20 (#Attr.2, #Attr.3):
+    let Num.291 : U64 = lowlevel NumSub #Attr.2 #Attr.3;
+    ret Num.291;
+
+procedure Num.21 (#Attr.2, #Attr.3):
+    let Num.296 : U64 = lowlevel NumMul #Attr.2 #Attr.3;
     ret Num.296;
 
+procedure Num.22 (#Attr.2, #Attr.3):
+    let Num.302 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.302;
+
 procedure Num.24 (#Attr.2, #Attr.3):
-    let Num.298 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
-    ret Num.298;
+    let Num.304 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
+    ret Num.304;
 
 procedure Num.51 (#Attr.2, #Attr.3):
-    let Num.293 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
-    ret Num.293;
+    let Num.299 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
+    ret Num.299;
 
 procedure Num.75 (#Attr.2, #Attr.3):
-    let Num.297 : U64 = lowlevel NumSubWrap #Attr.2 #Attr.3;
-    ret Num.297;
+    let Num.303 : U64 = lowlevel NumSubWrap #Attr.2 #Attr.3;
+    ret Num.303;
 
 procedure Str.12 (#Attr.2):
     let Str.242 : List U8 = lowlevel StrToUtf8 #Attr.2;

--- a/crates/compiler/test_mono/generated/encode_derived_record_one_field_string.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_record_one_field_string.txt
@@ -193,40 +193,40 @@ procedure List.91 (#Derived_gen.26, #Derived_gen.27, #Derived_gen.28, #Derived_g
     jump List.595 #Derived_gen.26 #Derived_gen.27 #Derived_gen.28 #Derived_gen.29 #Derived_gen.30;
 
 procedure Num.127 (#Attr.2):
-    let Num.274 : U8 = lowlevel NumIntCast #Attr.2;
-    ret Num.274;
-
-procedure Num.137 (#Attr.2, #Attr.3):
-    let Num.279 : U64 = lowlevel NumDivCeilUnchecked #Attr.2 #Attr.3;
-    ret Num.279;
-
-procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.278 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.278;
-
-procedure Num.20 (#Attr.2, #Attr.3):
-    let Num.275 : U64 = lowlevel NumSub #Attr.2 #Attr.3;
-    ret Num.275;
-
-procedure Num.21 (#Attr.2, #Attr.3):
-    let Num.280 : U64 = lowlevel NumMul #Attr.2 #Attr.3;
+    let Num.280 : U8 = lowlevel NumIntCast #Attr.2;
     ret Num.280;
 
-procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.286 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+procedure Num.137 (#Attr.2, #Attr.3):
+    let Num.285 : U64 = lowlevel NumDivCeilUnchecked #Attr.2 #Attr.3;
+    ret Num.285;
+
+procedure Num.19 (#Attr.2, #Attr.3):
+    let Num.284 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.284;
+
+procedure Num.20 (#Attr.2, #Attr.3):
+    let Num.281 : U64 = lowlevel NumSub #Attr.2 #Attr.3;
+    ret Num.281;
+
+procedure Num.21 (#Attr.2, #Attr.3):
+    let Num.286 : U64 = lowlevel NumMul #Attr.2 #Attr.3;
     ret Num.286;
 
+procedure Num.22 (#Attr.2, #Attr.3):
+    let Num.292 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.292;
+
 procedure Num.24 (#Attr.2, #Attr.3):
-    let Num.288 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
-    ret Num.288;
+    let Num.294 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
+    ret Num.294;
 
 procedure Num.51 (#Attr.2, #Attr.3):
-    let Num.283 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
-    ret Num.283;
+    let Num.289 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
+    ret Num.289;
 
 procedure Num.75 (#Attr.2, #Attr.3):
-    let Num.287 : U64 = lowlevel NumSubWrap #Attr.2 #Attr.3;
-    ret Num.287;
+    let Num.293 : U64 = lowlevel NumSubWrap #Attr.2 #Attr.3;
+    ret Num.293;
 
 procedure Str.12 (#Attr.2):
     let Str.241 : List U8 = lowlevel StrToUtf8 #Attr.2;

--- a/crates/compiler/test_mono/generated/encode_derived_record_two_field_strings.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_record_two_field_strings.txt
@@ -200,40 +200,40 @@ procedure List.91 (#Derived_gen.30, #Derived_gen.31, #Derived_gen.32, #Derived_g
     jump List.595 #Derived_gen.30 #Derived_gen.31 #Derived_gen.32 #Derived_gen.33 #Derived_gen.34;
 
 procedure Num.127 (#Attr.2):
-    let Num.274 : U8 = lowlevel NumIntCast #Attr.2;
-    ret Num.274;
-
-procedure Num.137 (#Attr.2, #Attr.3):
-    let Num.279 : U64 = lowlevel NumDivCeilUnchecked #Attr.2 #Attr.3;
-    ret Num.279;
-
-procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.278 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.278;
-
-procedure Num.20 (#Attr.2, #Attr.3):
-    let Num.275 : U64 = lowlevel NumSub #Attr.2 #Attr.3;
-    ret Num.275;
-
-procedure Num.21 (#Attr.2, #Attr.3):
-    let Num.280 : U64 = lowlevel NumMul #Attr.2 #Attr.3;
+    let Num.280 : U8 = lowlevel NumIntCast #Attr.2;
     ret Num.280;
 
-procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.286 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+procedure Num.137 (#Attr.2, #Attr.3):
+    let Num.285 : U64 = lowlevel NumDivCeilUnchecked #Attr.2 #Attr.3;
+    ret Num.285;
+
+procedure Num.19 (#Attr.2, #Attr.3):
+    let Num.284 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.284;
+
+procedure Num.20 (#Attr.2, #Attr.3):
+    let Num.281 : U64 = lowlevel NumSub #Attr.2 #Attr.3;
+    ret Num.281;
+
+procedure Num.21 (#Attr.2, #Attr.3):
+    let Num.286 : U64 = lowlevel NumMul #Attr.2 #Attr.3;
     ret Num.286;
 
+procedure Num.22 (#Attr.2, #Attr.3):
+    let Num.292 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.292;
+
 procedure Num.24 (#Attr.2, #Attr.3):
-    let Num.288 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
-    ret Num.288;
+    let Num.294 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
+    ret Num.294;
 
 procedure Num.51 (#Attr.2, #Attr.3):
-    let Num.283 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
-    ret Num.283;
+    let Num.289 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
+    ret Num.289;
 
 procedure Num.75 (#Attr.2, #Attr.3):
-    let Num.287 : U64 = lowlevel NumSubWrap #Attr.2 #Attr.3;
-    ret Num.287;
+    let Num.293 : U64 = lowlevel NumSubWrap #Attr.2 #Attr.3;
+    ret Num.293;
 
 procedure Str.12 (#Attr.2):
     let Str.241 : List U8 = lowlevel StrToUtf8 #Attr.2;

--- a/crates/compiler/test_mono/generated/encode_derived_string.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_string.txt
@@ -122,32 +122,32 @@ procedure List.91 (#Derived_gen.8, #Derived_gen.9, #Derived_gen.10, #Derived_gen
     jump List.587 #Derived_gen.8 #Derived_gen.9 #Derived_gen.10 #Derived_gen.11 #Derived_gen.12;
 
 procedure Num.137 (#Attr.2, #Attr.3):
-    let Num.271 : U64 = lowlevel NumDivCeilUnchecked #Attr.2 #Attr.3;
-    ret Num.271;
+    let Num.277 : U64 = lowlevel NumDivCeilUnchecked #Attr.2 #Attr.3;
+    ret Num.277;
 
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.270 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.270;
-
-procedure Num.21 (#Attr.2, #Attr.3):
-    let Num.272 : U64 = lowlevel NumMul #Attr.2 #Attr.3;
-    ret Num.272;
-
-procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.276 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    let Num.276 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
     ret Num.276;
 
-procedure Num.24 (#Attr.2, #Attr.3):
-    let Num.278 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
+procedure Num.21 (#Attr.2, #Attr.3):
+    let Num.278 : U64 = lowlevel NumMul #Attr.2 #Attr.3;
     ret Num.278;
 
+procedure Num.22 (#Attr.2, #Attr.3):
+    let Num.282 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.282;
+
+procedure Num.24 (#Attr.2, #Attr.3):
+    let Num.284 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
+    ret Num.284;
+
 procedure Num.51 (#Attr.2, #Attr.3):
-    let Num.274 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
-    ret Num.274;
+    let Num.280 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
+    ret Num.280;
 
 procedure Num.75 (#Attr.2, #Attr.3):
-    let Num.277 : U64 = lowlevel NumSubWrap #Attr.2 #Attr.3;
-    ret Num.277;
+    let Num.283 : U64 = lowlevel NumSubWrap #Attr.2 #Attr.3;
+    ret Num.283;
 
 procedure Str.12 (#Attr.2):
     let Str.240 : List U8 = lowlevel StrToUtf8 #Attr.2;

--- a/crates/compiler/test_mono/generated/encode_derived_tag_one_field_string.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_tag_one_field_string.txt
@@ -195,40 +195,40 @@ procedure List.91 (#Derived_gen.23, #Derived_gen.24, #Derived_gen.25, #Derived_g
     jump List.613 #Derived_gen.23 #Derived_gen.24 #Derived_gen.25 #Derived_gen.26 #Derived_gen.27;
 
 procedure Num.127 (#Attr.2):
-    let Num.276 : U8 = lowlevel NumIntCast #Attr.2;
-    ret Num.276;
-
-procedure Num.137 (#Attr.2, #Attr.3):
-    let Num.281 : U64 = lowlevel NumDivCeilUnchecked #Attr.2 #Attr.3;
-    ret Num.281;
-
-procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.280 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.280;
-
-procedure Num.20 (#Attr.2, #Attr.3):
-    let Num.277 : U64 = lowlevel NumSub #Attr.2 #Attr.3;
-    ret Num.277;
-
-procedure Num.21 (#Attr.2, #Attr.3):
-    let Num.282 : U64 = lowlevel NumMul #Attr.2 #Attr.3;
+    let Num.282 : U8 = lowlevel NumIntCast #Attr.2;
     ret Num.282;
 
-procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.288 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+procedure Num.137 (#Attr.2, #Attr.3):
+    let Num.287 : U64 = lowlevel NumDivCeilUnchecked #Attr.2 #Attr.3;
+    ret Num.287;
+
+procedure Num.19 (#Attr.2, #Attr.3):
+    let Num.286 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.286;
+
+procedure Num.20 (#Attr.2, #Attr.3):
+    let Num.283 : U64 = lowlevel NumSub #Attr.2 #Attr.3;
+    ret Num.283;
+
+procedure Num.21 (#Attr.2, #Attr.3):
+    let Num.288 : U64 = lowlevel NumMul #Attr.2 #Attr.3;
     ret Num.288;
 
+procedure Num.22 (#Attr.2, #Attr.3):
+    let Num.294 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.294;
+
 procedure Num.24 (#Attr.2, #Attr.3):
-    let Num.290 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
-    ret Num.290;
+    let Num.296 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
+    ret Num.296;
 
 procedure Num.51 (#Attr.2, #Attr.3):
-    let Num.285 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
-    ret Num.285;
+    let Num.291 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
+    ret Num.291;
 
 procedure Num.75 (#Attr.2, #Attr.3):
-    let Num.289 : U64 = lowlevel NumSubWrap #Attr.2 #Attr.3;
-    ret Num.289;
+    let Num.295 : U64 = lowlevel NumSubWrap #Attr.2 #Attr.3;
+    ret Num.295;
 
 procedure Str.12 (#Attr.2):
     let Str.241 : List U8 = lowlevel StrToUtf8 #Attr.2;

--- a/crates/compiler/test_mono/generated/encode_derived_tag_two_payloads_string.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_tag_two_payloads_string.txt
@@ -198,40 +198,40 @@ procedure List.91 (#Derived_gen.22, #Derived_gen.23, #Derived_gen.24, #Derived_g
     jump List.613 #Derived_gen.22 #Derived_gen.23 #Derived_gen.24 #Derived_gen.25 #Derived_gen.26;
 
 procedure Num.127 (#Attr.2):
-    let Num.276 : U8 = lowlevel NumIntCast #Attr.2;
-    ret Num.276;
-
-procedure Num.137 (#Attr.2, #Attr.3):
-    let Num.281 : U64 = lowlevel NumDivCeilUnchecked #Attr.2 #Attr.3;
-    ret Num.281;
-
-procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.280 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.280;
-
-procedure Num.20 (#Attr.2, #Attr.3):
-    let Num.277 : U64 = lowlevel NumSub #Attr.2 #Attr.3;
-    ret Num.277;
-
-procedure Num.21 (#Attr.2, #Attr.3):
-    let Num.282 : U64 = lowlevel NumMul #Attr.2 #Attr.3;
+    let Num.282 : U8 = lowlevel NumIntCast #Attr.2;
     ret Num.282;
 
-procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.288 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+procedure Num.137 (#Attr.2, #Attr.3):
+    let Num.287 : U64 = lowlevel NumDivCeilUnchecked #Attr.2 #Attr.3;
+    ret Num.287;
+
+procedure Num.19 (#Attr.2, #Attr.3):
+    let Num.286 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.286;
+
+procedure Num.20 (#Attr.2, #Attr.3):
+    let Num.283 : U64 = lowlevel NumSub #Attr.2 #Attr.3;
+    ret Num.283;
+
+procedure Num.21 (#Attr.2, #Attr.3):
+    let Num.288 : U64 = lowlevel NumMul #Attr.2 #Attr.3;
     ret Num.288;
 
+procedure Num.22 (#Attr.2, #Attr.3):
+    let Num.294 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.294;
+
 procedure Num.24 (#Attr.2, #Attr.3):
-    let Num.290 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
-    ret Num.290;
+    let Num.296 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
+    ret Num.296;
 
 procedure Num.51 (#Attr.2, #Attr.3):
-    let Num.285 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
-    ret Num.285;
+    let Num.291 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
+    ret Num.291;
 
 procedure Num.75 (#Attr.2, #Attr.3):
-    let Num.289 : U64 = lowlevel NumSubWrap #Attr.2 #Attr.3;
-    ret Num.289;
+    let Num.295 : U64 = lowlevel NumSubWrap #Attr.2 #Attr.3;
+    ret Num.295;
 
 procedure Str.12 (#Attr.2):
     let Str.241 : List U8 = lowlevel StrToUtf8 #Attr.2;

--- a/crates/compiler/test_mono/generated/factorial.txt
+++ b/crates/compiler/test_mono/generated/factorial.txt
@@ -1,10 +1,10 @@
 procedure Num.20 (#Attr.2, #Attr.3):
-    let Num.270 : I64 = lowlevel NumSub #Attr.2 #Attr.3;
-    ret Num.270;
+    let Num.276 : I64 = lowlevel NumSub #Attr.2 #Attr.3;
+    ret Num.276;
 
 procedure Num.21 (#Attr.2, #Attr.3):
-    let Num.269 : I64 = lowlevel NumMul #Attr.2 #Attr.3;
-    ret Num.269;
+    let Num.275 : I64 = lowlevel NumMul #Attr.2 #Attr.3;
+    ret Num.275;
 
 procedure Test.1 (#Derived_gen.0, #Derived_gen.1):
     joinpoint Test.7 Test.2 Test.3:

--- a/crates/compiler/test_mono/generated/function_specialization_information_in_lambda_set_thunk.txt
+++ b/crates/compiler/test_mono/generated/function_specialization_information_in_lambda_set_thunk.txt
@@ -1,6 +1,6 @@
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.269 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.269;
+    let Num.275 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.275;
 
 procedure Test.1 (Test.8):
     let Test.3 : I64 = 10i64;

--- a/crates/compiler/test_mono/generated/function_specialization_information_in_lambda_set_thunk_independent_defs.txt
+++ b/crates/compiler/test_mono/generated/function_specialization_information_in_lambda_set_thunk_independent_defs.txt
@@ -1,6 +1,6 @@
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.270 : U8 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.270;
+    let Num.276 : U8 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.276;
 
 procedure Test.1 (Test.9):
     let Test.4 : U8 = 10i64;

--- a/crates/compiler/test_mono/generated/inline_return_joinpoints_in_bool_lambda_set.txt
+++ b/crates/compiler/test_mono/generated/inline_return_joinpoints_in_bool_lambda_set.txt
@@ -3,8 +3,8 @@ procedure Bool.1 ():
     ret Bool.23;
 
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.269 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.269;
+    let Num.275 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.275;
 
 procedure Test.3 (Test.4):
     ret Test.4;

--- a/crates/compiler/test_mono/generated/inline_return_joinpoints_in_enum_lambda_set.txt
+++ b/crates/compiler/test_mono/generated/inline_return_joinpoints_in_enum_lambda_set.txt
@@ -1,6 +1,6 @@
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.271 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.271;
+    let Num.277 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.277;
 
 procedure Test.2 (Test.3):
     switch Test.3:

--- a/crates/compiler/test_mono/generated/inline_return_joinpoints_in_union_lambda_set.txt
+++ b/crates/compiler/test_mono/generated/inline_return_joinpoints_in_union_lambda_set.txt
@@ -1,6 +1,6 @@
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.270 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.270;
+    let Num.276 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.276;
 
 procedure Test.2 (Test.3, Test.1):
     let Test.18 : Int1 = false;

--- a/crates/compiler/test_mono/generated/inspect_derived_dict.txt
+++ b/crates/compiler/test_mono/generated/inspect_derived_dict.txt
@@ -1044,131 +1044,131 @@ procedure List.92 (#Derived_gen.38, #Derived_gen.39, #Derived_gen.40, #Derived_g
     jump List.614 #Derived_gen.38 #Derived_gen.39 #Derived_gen.40 #Derived_gen.41 #Derived_gen.42;
 
 procedure Num.131 (#Attr.2):
-    let Num.277 : U32 = lowlevel NumIntCast #Attr.2;
-    ret Num.277;
-
-procedure Num.133 (#Attr.2):
-    let Num.285 : U64 = lowlevel NumIntCast #Attr.2;
-    ret Num.285;
-
-procedure Num.133 (#Attr.2):
-    let Num.334 : U64 = lowlevel NumIntCast #Attr.2;
-    ret Num.334;
-
-procedure Num.133 (#Attr.2):
-    let Num.349 : U64 = lowlevel NumIntCast #Attr.2;
-    ret Num.349;
-
-procedure Num.135 (#Attr.2):
-    let Num.355 : U128 = lowlevel NumIntCast #Attr.2;
-    ret Num.355;
-
-procedure Num.139 (#Attr.2):
-    let Num.303 : Float32 = lowlevel NumToFloatCast #Attr.2;
-    ret Num.303;
-
-procedure Num.148 (Num.213, Num.214):
-    let Num.305 : Int1 = CallByName Num.22 Num.213 Num.214;
-    if Num.305 then
-        ret Num.213;
-    else
-        ret Num.214;
-
-procedure Num.21 (#Attr.2, #Attr.3):
-    let Num.302 : Float32 = lowlevel NumMul #Attr.2 #Attr.3;
-    ret Num.302;
-
-procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.299 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.299;
-
-procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.428 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.428;
-
-procedure Num.23 (#Attr.2, #Attr.3):
-    let Num.421 : Int1 = lowlevel NumLte #Attr.2 #Attr.3;
-    ret Num.421;
-
-procedure Num.24 (#Attr.2, #Attr.3):
-    let Num.283 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
+    let Num.283 : U32 = lowlevel NumIntCast #Attr.2;
     ret Num.283;
 
-procedure Num.24 (#Attr.2, #Attr.3):
-    let Num.424 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
-    ret Num.424;
-
-procedure Num.25 (#Attr.2, #Attr.3):
-    let Num.425 : Int1 = lowlevel NumGte #Attr.2 #Attr.3;
-    ret Num.425;
-
-procedure Num.50 (#Attr.2):
-    let Num.301 : U64 = lowlevel NumFloor #Attr.2;
-    ret Num.301;
-
-procedure Num.51 (#Attr.2, #Attr.3):
-    let Num.269 : U32 = lowlevel NumAddWrap #Attr.2 #Attr.3;
-    ret Num.269;
-
-procedure Num.51 (#Attr.2, #Attr.3):
-    let Num.427 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
-    ret Num.427;
-
-procedure Num.69 (#Attr.2, #Attr.3):
-    let Num.291 : U32 = lowlevel NumBitwiseAnd #Attr.2 #Attr.3;
+procedure Num.133 (#Attr.2):
+    let Num.291 : U64 = lowlevel NumIntCast #Attr.2;
     ret Num.291;
 
+procedure Num.133 (#Attr.2):
+    let Num.340 : U64 = lowlevel NumIntCast #Attr.2;
+    ret Num.340;
+
+procedure Num.133 (#Attr.2):
+    let Num.355 : U64 = lowlevel NumIntCast #Attr.2;
+    ret Num.355;
+
+procedure Num.135 (#Attr.2):
+    let Num.361 : U128 = lowlevel NumIntCast #Attr.2;
+    ret Num.361;
+
+procedure Num.139 (#Attr.2):
+    let Num.309 : Float32 = lowlevel NumToFloatCast #Attr.2;
+    ret Num.309;
+
+procedure Num.148 (Num.219, Num.220):
+    let Num.311 : Int1 = CallByName Num.22 Num.219 Num.220;
+    if Num.311 then
+        ret Num.219;
+    else
+        ret Num.220;
+
+procedure Num.21 (#Attr.2, #Attr.3):
+    let Num.308 : Float32 = lowlevel NumMul #Attr.2 #Attr.3;
+    ret Num.308;
+
+procedure Num.22 (#Attr.2, #Attr.3):
+    let Num.305 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.305;
+
+procedure Num.22 (#Attr.2, #Attr.3):
+    let Num.434 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.434;
+
+procedure Num.23 (#Attr.2, #Attr.3):
+    let Num.427 : Int1 = lowlevel NumLte #Attr.2 #Attr.3;
+    ret Num.427;
+
+procedure Num.24 (#Attr.2, #Attr.3):
+    let Num.289 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
+    ret Num.289;
+
+procedure Num.24 (#Attr.2, #Attr.3):
+    let Num.430 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
+    ret Num.430;
+
+procedure Num.25 (#Attr.2, #Attr.3):
+    let Num.431 : Int1 = lowlevel NumGte #Attr.2 #Attr.3;
+    ret Num.431;
+
+procedure Num.50 (#Attr.2):
+    let Num.307 : U64 = lowlevel NumFloor #Attr.2;
+    ret Num.307;
+
+procedure Num.51 (#Attr.2, #Attr.3):
+    let Num.275 : U32 = lowlevel NumAddWrap #Attr.2 #Attr.3;
+    ret Num.275;
+
+procedure Num.51 (#Attr.2, #Attr.3):
+    let Num.433 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
+    ret Num.433;
+
+procedure Num.69 (#Attr.2, #Attr.3):
+    let Num.297 : U32 = lowlevel NumBitwiseAnd #Attr.2 #Attr.3;
+    ret Num.297;
+
 procedure Num.70 (#Attr.2, #Attr.3):
-    let Num.332 : U64 = lowlevel NumBitwiseXor #Attr.2 #Attr.3;
-    ret Num.332;
+    let Num.338 : U64 = lowlevel NumBitwiseXor #Attr.2 #Attr.3;
+    ret Num.338;
 
 procedure Num.71 (#Attr.2, #Attr.3):
-    let Num.290 : U32 = lowlevel NumBitwiseOr #Attr.2 #Attr.3;
-    ret Num.290;
+    let Num.296 : U32 = lowlevel NumBitwiseOr #Attr.2 #Attr.3;
+    ret Num.296;
 
 procedure Num.71 (#Attr.2, #Attr.3):
-    let Num.369 : U64 = lowlevel NumBitwiseOr #Attr.2 #Attr.3;
-    ret Num.369;
+    let Num.375 : U64 = lowlevel NumBitwiseOr #Attr.2 #Attr.3;
+    ret Num.375;
 
 procedure Num.72 (#Attr.2, #Attr.3):
-    let Num.272 : U32 = lowlevel NumShiftLeftBy #Attr.2 #Attr.3;
-    ret Num.272;
+    let Num.278 : U32 = lowlevel NumShiftLeftBy #Attr.2 #Attr.3;
+    ret Num.278;
 
 procedure Num.72 (#Attr.2, #Attr.3):
-    let Num.384 : U64 = lowlevel NumShiftLeftBy #Attr.2 #Attr.3;
-    ret Num.384;
+    let Num.390 : U64 = lowlevel NumShiftLeftBy #Attr.2 #Attr.3;
+    ret Num.390;
 
 procedure Num.74 (#Attr.2, #Attr.3):
-    let Num.350 : U128 = lowlevel NumShiftRightZfBy #Attr.2 #Attr.3;
-    ret Num.350;
+    let Num.356 : U128 = lowlevel NumShiftRightZfBy #Attr.2 #Attr.3;
+    ret Num.356;
 
 procedure Num.74 (#Attr.2, #Attr.3):
-    let Num.352 : U64 = lowlevel NumShiftRightZfBy #Attr.2 #Attr.3;
-    ret Num.352;
+    let Num.358 : U64 = lowlevel NumShiftRightZfBy #Attr.2 #Attr.3;
+    ret Num.358;
 
 procedure Num.75 (#Attr.2, #Attr.3):
-    let Num.279 : U32 = lowlevel NumSubWrap #Attr.2 #Attr.3;
-    ret Num.279;
+    let Num.285 : U32 = lowlevel NumSubWrap #Attr.2 #Attr.3;
+    ret Num.285;
 
 procedure Num.75 (#Attr.2, #Attr.3):
-    let Num.282 : U8 = lowlevel NumSubWrap #Attr.2 #Attr.3;
-    ret Num.282;
+    let Num.288 : U8 = lowlevel NumSubWrap #Attr.2 #Attr.3;
+    ret Num.288;
 
 procedure Num.75 (#Attr.2, #Attr.3):
-    let Num.418 : U64 = lowlevel NumSubWrap #Attr.2 #Attr.3;
-    ret Num.418;
+    let Num.424 : U64 = lowlevel NumSubWrap #Attr.2 #Attr.3;
+    ret Num.424;
 
 procedure Num.78 (#Attr.2, #Attr.3):
-    let Num.353 : U128 = lowlevel NumMulWrap #Attr.2 #Attr.3;
-    ret Num.353;
+    let Num.359 : U128 = lowlevel NumMulWrap #Attr.2 #Attr.3;
+    ret Num.359;
 
 procedure Num.96 (#Attr.2):
-    let Num.298 : Str = lowlevel NumToStr #Attr.2;
-    ret Num.298;
+    let Num.304 : Str = lowlevel NumToStr #Attr.2;
+    ret Num.304;
 
 procedure Num.96 (#Attr.2):
-    let Num.426 : Str = lowlevel NumToStr #Attr.2;
-    ret Num.426;
+    let Num.432 : Str = lowlevel NumToStr #Attr.2;
+    ret Num.432;
 
 procedure Str.12 (#Attr.2):
     let Str.234 : List U8 = lowlevel StrToUtf8 #Attr.2;

--- a/crates/compiler/test_mono/generated/inspect_derived_list.txt
+++ b/crates/compiler/test_mono/generated/inspect_derived_list.txt
@@ -155,16 +155,16 @@ procedure List.91 (#Derived_gen.17, #Derived_gen.18, #Derived_gen.19, #Derived_g
     jump List.575 #Derived_gen.17 #Derived_gen.18 #Derived_gen.19 #Derived_gen.20 #Derived_gen.21;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.271 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.271;
+    let Num.277 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.277;
 
 procedure Num.51 (#Attr.2, #Attr.3):
-    let Num.270 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
-    ret Num.270;
+    let Num.276 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
+    ret Num.276;
 
 procedure Num.96 (#Attr.2):
-    let Num.269 : Str = lowlevel NumToStr #Attr.2;
-    ret Num.269;
+    let Num.275 : Str = lowlevel NumToStr #Attr.2;
+    ret Num.275;
 
 procedure Str.3 (#Attr.2, #Attr.3):
     let Str.232 : Str = lowlevel StrConcat #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/inspect_derived_nested_record_string.txt
+++ b/crates/compiler/test_mono/generated/inspect_derived_nested_record_string.txt
@@ -261,12 +261,12 @@ procedure List.91 (#Derived_gen.39, #Derived_gen.40, #Derived_gen.41, #Derived_g
     jump List.587 #Derived_gen.39 #Derived_gen.40 #Derived_gen.41 #Derived_gen.42 #Derived_gen.43;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.272 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.272;
+    let Num.278 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.278;
 
 procedure Num.51 (#Attr.2, #Attr.3):
-    let Num.271 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
-    ret Num.271;
+    let Num.277 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
+    ret Num.277;
 
 procedure Str.3 (#Attr.2, #Attr.3):
     let Str.233 : Str = lowlevel StrConcat #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/inspect_derived_record.txt
+++ b/crates/compiler/test_mono/generated/inspect_derived_record.txt
@@ -181,20 +181,20 @@ procedure List.91 (#Derived_gen.24, #Derived_gen.25, #Derived_gen.26, #Derived_g
     jump List.575 #Derived_gen.24 #Derived_gen.25 #Derived_gen.26 #Derived_gen.27 #Derived_gen.28;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.272 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.272;
+    let Num.278 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.278;
 
 procedure Num.51 (#Attr.2, #Attr.3):
-    let Num.271 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
-    ret Num.271;
+    let Num.277 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
+    ret Num.277;
 
 procedure Num.96 (#Attr.2):
-    let Num.269 : Str = lowlevel NumToStr #Attr.2;
-    ret Num.269;
+    let Num.275 : Str = lowlevel NumToStr #Attr.2;
+    ret Num.275;
 
 procedure Num.96 (#Attr.2):
-    let Num.270 : Str = lowlevel NumToStr #Attr.2;
-    ret Num.270;
+    let Num.276 : Str = lowlevel NumToStr #Attr.2;
+    ret Num.276;
 
 procedure Str.3 (#Attr.2, #Attr.3):
     let Str.232 : Str = lowlevel StrConcat #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/inspect_derived_record_one_field_string.txt
+++ b/crates/compiler/test_mono/generated/inspect_derived_record_one_field_string.txt
@@ -158,12 +158,12 @@ procedure List.91 (#Derived_gen.18, #Derived_gen.19, #Derived_gen.20, #Derived_g
     jump List.575 #Derived_gen.18 #Derived_gen.19 #Derived_gen.20 #Derived_gen.21 #Derived_gen.22;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.270 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.270;
+    let Num.276 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.276;
 
 procedure Num.51 (#Attr.2, #Attr.3):
-    let Num.269 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
-    ret Num.269;
+    let Num.275 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
+    ret Num.275;
 
 procedure Str.3 (#Attr.2, #Attr.3):
     let Str.232 : Str = lowlevel StrConcat #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/inspect_derived_record_two_field_strings.txt
+++ b/crates/compiler/test_mono/generated/inspect_derived_record_two_field_strings.txt
@@ -165,12 +165,12 @@ procedure List.91 (#Derived_gen.22, #Derived_gen.23, #Derived_gen.24, #Derived_g
     jump List.575 #Derived_gen.22 #Derived_gen.23 #Derived_gen.24 #Derived_gen.25 #Derived_gen.26;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.270 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.270;
+    let Num.276 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.276;
 
 procedure Num.51 (#Attr.2, #Attr.3):
-    let Num.269 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
-    ret Num.269;
+    let Num.275 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
+    ret Num.275;
 
 procedure Str.3 (#Attr.2, #Attr.3):
     let Str.232 : Str = lowlevel StrConcat #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/inspect_derived_tag_one_field_string.txt
+++ b/crates/compiler/test_mono/generated/inspect_derived_tag_one_field_string.txt
@@ -160,12 +160,12 @@ procedure List.91 (#Derived_gen.10, #Derived_gen.11, #Derived_gen.12, #Derived_g
     jump List.575 #Derived_gen.10 #Derived_gen.11 #Derived_gen.12 #Derived_gen.13 #Derived_gen.14;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.270 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.270;
+    let Num.276 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.276;
 
 procedure Num.51 (#Attr.2, #Attr.3):
-    let Num.269 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
-    ret Num.269;
+    let Num.275 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
+    ret Num.275;
 
 procedure Str.3 (#Attr.2, #Attr.3):
     let Str.232 : Str = lowlevel StrConcat #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/inspect_derived_tag_two_payloads_string.txt
+++ b/crates/compiler/test_mono/generated/inspect_derived_tag_two_payloads_string.txt
@@ -163,12 +163,12 @@ procedure List.91 (#Derived_gen.13, #Derived_gen.14, #Derived_gen.15, #Derived_g
     jump List.575 #Derived_gen.13 #Derived_gen.14 #Derived_gen.15 #Derived_gen.16 #Derived_gen.17;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.270 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.270;
+    let Num.276 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.276;
 
 procedure Num.51 (#Attr.2, #Attr.3):
-    let Num.269 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
-    ret Num.269;
+    let Num.275 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
+    ret Num.275;
 
 procedure Str.3 (#Attr.2, #Attr.3):
     let Str.232 : Str = lowlevel StrConcat #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/ir_int_add.txt
+++ b/crates/compiler/test_mono/generated/ir_int_add.txt
@@ -3,8 +3,8 @@ procedure List.6 (#Attr.2):
     ret List.572;
 
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.271 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.271;
+    let Num.277 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.277;
 
 procedure Test.0 ():
     let Test.1 : List I64 = Array [1i64, 2i64];

--- a/crates/compiler/test_mono/generated/ir_plus.txt
+++ b/crates/compiler/test_mono/generated/ir_plus.txt
@@ -1,6 +1,6 @@
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.269 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.269;
+    let Num.275 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.275;
 
 procedure Test.0 ():
     let Test.2 : I64 = 1i64;

--- a/crates/compiler/test_mono/generated/ir_round.txt
+++ b/crates/compiler/test_mono/generated/ir_round.txt
@@ -1,6 +1,6 @@
 procedure Num.45 (#Attr.2):
-    let Num.269 : I64 = lowlevel NumRound #Attr.2;
-    ret Num.269;
+    let Num.275 : I64 = lowlevel NumRound #Attr.2;
+    ret Num.275;
 
 procedure Test.0 ():
     let Test.2 : Decimal = 3.6dec;

--- a/crates/compiler/test_mono/generated/ir_two_defs.txt
+++ b/crates/compiler/test_mono/generated/ir_two_defs.txt
@@ -1,6 +1,6 @@
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.269 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.269;
+    let Num.275 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.275;
 
 procedure Test.0 ():
     let Test.1 : I64 = 3i64;

--- a/crates/compiler/test_mono/generated/ir_when_idiv.txt
+++ b/crates/compiler/test_mono/generated/ir_when_idiv.txt
@@ -1,22 +1,22 @@
 procedure Num.157 (#Attr.2, #Attr.3):
-    let Num.271 : I64 = lowlevel NumDivTruncUnchecked #Attr.2 #Attr.3;
-    ret Num.271;
+    let Num.277 : I64 = lowlevel NumDivTruncUnchecked #Attr.2 #Attr.3;
+    ret Num.277;
 
 procedure Num.30 (#Attr.2):
-    let Num.276 : I64 = 0i64;
-    let Num.275 : Int1 = lowlevel Eq #Attr.2 Num.276;
-    ret Num.275;
+    let Num.282 : I64 = 0i64;
+    let Num.281 : Int1 = lowlevel Eq #Attr.2 Num.282;
+    ret Num.281;
 
-procedure Num.40 (Num.237, Num.238):
-    let Num.272 : Int1 = CallByName Num.30 Num.238;
-    if Num.272 then
-        let Num.274 : {} = Struct {};
-        let Num.273 : [C {}, C I64] = TagId(0) Num.274;
-        ret Num.273;
+procedure Num.40 (Num.243, Num.244):
+    let Num.278 : Int1 = CallByName Num.30 Num.244;
+    if Num.278 then
+        let Num.280 : {} = Struct {};
+        let Num.279 : [C {}, C I64] = TagId(0) Num.280;
+        ret Num.279;
     else
-        let Num.270 : I64 = CallByName Num.157 Num.237 Num.238;
-        let Num.269 : [C {}, C I64] = TagId(1) Num.270;
-        ret Num.269;
+        let Num.276 : I64 = CallByName Num.157 Num.243 Num.244;
+        let Num.275 : [C {}, C I64] = TagId(1) Num.276;
+        ret Num.275;
 
 procedure Test.0 ():
     let Test.8 : I64 = 1000i64;

--- a/crates/compiler/test_mono/generated/ir_when_just.txt
+++ b/crates/compiler/test_mono/generated/ir_when_just.txt
@@ -1,6 +1,6 @@
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.269 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.269;
+    let Num.275 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.275;
 
 procedure Test.0 ():
     let Test.10 : I64 = 41i64;

--- a/crates/compiler/test_mono/generated/issue_2583_specialize_errors_behind_unified_branches.txt
+++ b/crates/compiler/test_mono/generated/issue_2583_specialize_errors_behind_unified_branches.txt
@@ -44,8 +44,8 @@ procedure List.9 (List.334):
         ret List.574;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.269 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.269;
+    let Num.275 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.275;
 
 procedure Str.27 (Str.78):
     let Str.232 : [C Int1, C I64] = CallByName Str.60 Str.78;

--- a/crates/compiler/test_mono/generated/issue_4749.txt
+++ b/crates/compiler/test_mono/generated/issue_4749.txt
@@ -179,44 +179,44 @@ procedure List.80 (#Derived_gen.1, #Derived_gen.2, #Derived_gen.3, #Derived_gen.
     jump List.637 #Derived_gen.1 #Derived_gen.2 #Derived_gen.3 #Derived_gen.4 #Derived_gen.5;
 
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.272 : U8 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.272;
+    let Num.278 : U8 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.278;
 
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.281 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.281;
+    let Num.287 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.287;
 
 procedure Num.20 (#Attr.2, #Attr.3):
-    let Num.284 : U8 = lowlevel NumSub #Attr.2 #Attr.3;
-    ret Num.284;
-
-procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.306 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.306;
-
-procedure Num.23 (#Attr.2, #Attr.3):
-    let Num.290 : Int1 = lowlevel NumLte #Attr.2 #Attr.3;
+    let Num.290 : U8 = lowlevel NumSub #Attr.2 #Attr.3;
     ret Num.290;
 
-procedure Num.25 (#Attr.2, #Attr.3):
-    let Num.296 : Int1 = lowlevel NumGte #Attr.2 #Attr.3;
+procedure Num.22 (#Attr.2, #Attr.3):
+    let Num.312 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.312;
+
+procedure Num.23 (#Attr.2, #Attr.3):
+    let Num.296 : Int1 = lowlevel NumLte #Attr.2 #Attr.3;
     ret Num.296;
 
+procedure Num.25 (#Attr.2, #Attr.3):
+    let Num.302 : Int1 = lowlevel NumGte #Attr.2 #Attr.3;
+    ret Num.302;
+
 procedure Num.51 (#Attr.2, #Attr.3):
-    let Num.307 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
-    ret Num.307;
+    let Num.313 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
+    ret Num.313;
 
 procedure Num.71 (#Attr.2, #Attr.3):
-    let Num.269 : U8 = lowlevel NumBitwiseOr #Attr.2 #Attr.3;
-    ret Num.269;
+    let Num.275 : U8 = lowlevel NumBitwiseOr #Attr.2 #Attr.3;
+    ret Num.275;
 
 procedure Num.72 (#Attr.2, #Attr.3):
-    let Num.270 : U8 = lowlevel NumShiftLeftBy #Attr.2 #Attr.3;
-    ret Num.270;
+    let Num.276 : U8 = lowlevel NumShiftLeftBy #Attr.2 #Attr.3;
+    ret Num.276;
 
 procedure Num.77 (#Attr.2, #Attr.3):
-    let Num.303 : U64 = lowlevel NumSubSaturated #Attr.2 #Attr.3;
-    ret Num.303;
+    let Num.309 : U64 = lowlevel NumSubSaturated #Attr.2 #Attr.3;
+    ret Num.309;
 
 procedure Str.43 (#Attr.2):
     let Str.239 : {U64, Str, Int1, U8} = lowlevel StrFromUtf8 #Attr.2;

--- a/crates/compiler/test_mono/generated/issue_4770.txt
+++ b/crates/compiler/test_mono/generated/issue_4770.txt
@@ -82,16 +82,16 @@ procedure List.80 (#Derived_gen.1, #Derived_gen.2, #Derived_gen.3, #Derived_gen.
     jump List.588 #Derived_gen.1 #Derived_gen.2 #Derived_gen.3 #Derived_gen.4 #Derived_gen.5;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.269 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.269;
+    let Num.275 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.275;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.272 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.272;
+    let Num.278 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.278;
 
 procedure Num.51 (#Attr.2, #Attr.3):
-    let Num.271 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
-    ret Num.271;
+    let Num.277 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
+    ret Num.277;
 
 procedure Test.1 (#Derived_gen.0):
     joinpoint Test.26 Test.6:

--- a/crates/compiler/test_mono/generated/issue_4772_weakened_monomorphic_destructure.txt
+++ b/crates/compiler/test_mono/generated/issue_4772_weakened_monomorphic_destructure.txt
@@ -153,44 +153,44 @@ procedure List.80 (#Derived_gen.0, #Derived_gen.1, #Derived_gen.2, #Derived_gen.
     jump List.633 #Derived_gen.0 #Derived_gen.1 #Derived_gen.2 #Derived_gen.3 #Derived_gen.4;
 
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.272 : U8 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.272;
+    let Num.278 : U8 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.278;
 
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.281 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.281;
+    let Num.287 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.287;
 
 procedure Num.20 (#Attr.2, #Attr.3):
-    let Num.284 : U8 = lowlevel NumSub #Attr.2 #Attr.3;
-    ret Num.284;
-
-procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.306 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.306;
-
-procedure Num.23 (#Attr.2, #Attr.3):
-    let Num.290 : Int1 = lowlevel NumLte #Attr.2 #Attr.3;
+    let Num.290 : U8 = lowlevel NumSub #Attr.2 #Attr.3;
     ret Num.290;
 
-procedure Num.25 (#Attr.2, #Attr.3):
-    let Num.296 : Int1 = lowlevel NumGte #Attr.2 #Attr.3;
+procedure Num.22 (#Attr.2, #Attr.3):
+    let Num.312 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.312;
+
+procedure Num.23 (#Attr.2, #Attr.3):
+    let Num.296 : Int1 = lowlevel NumLte #Attr.2 #Attr.3;
     ret Num.296;
 
+procedure Num.25 (#Attr.2, #Attr.3):
+    let Num.302 : Int1 = lowlevel NumGte #Attr.2 #Attr.3;
+    ret Num.302;
+
 procedure Num.51 (#Attr.2, #Attr.3):
-    let Num.307 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
-    ret Num.307;
+    let Num.313 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
+    ret Num.313;
 
 procedure Num.71 (#Attr.2, #Attr.3):
-    let Num.269 : U8 = lowlevel NumBitwiseOr #Attr.2 #Attr.3;
-    ret Num.269;
+    let Num.275 : U8 = lowlevel NumBitwiseOr #Attr.2 #Attr.3;
+    ret Num.275;
 
 procedure Num.72 (#Attr.2, #Attr.3):
-    let Num.270 : U8 = lowlevel NumShiftLeftBy #Attr.2 #Attr.3;
-    ret Num.270;
+    let Num.276 : U8 = lowlevel NumShiftLeftBy #Attr.2 #Attr.3;
+    ret Num.276;
 
 procedure Num.77 (#Attr.2, #Attr.3):
-    let Num.303 : U64 = lowlevel NumSubSaturated #Attr.2 #Attr.3;
-    ret Num.303;
+    let Num.309 : U64 = lowlevel NumSubSaturated #Attr.2 #Attr.3;
+    ret Num.309;
 
 procedure Str.12 (#Attr.2):
     let Str.241 : List U8 = lowlevel StrToUtf8 #Attr.2;

--- a/crates/compiler/test_mono/generated/issue_6196.txt
+++ b/crates/compiler/test_mono/generated/issue_6196.txt
@@ -1,6 +1,6 @@
 procedure Num.20 (#Attr.2, #Attr.3):
-    let Num.269 : U64 = lowlevel NumSub #Attr.2 #Attr.3;
-    ret Num.269;
+    let Num.275 : U64 = lowlevel NumSub #Attr.2 #Attr.3;
+    ret Num.275;
 
 procedure Test.1 (#Derived_gen.0, #Derived_gen.1):
     joinpoint Test.12 Test.2 Test.3:

--- a/crates/compiler/test_mono/generated/lambda_capture_niche_u8_vs_u64.txt
+++ b/crates/compiler/test_mono/generated/lambda_capture_niche_u8_vs_u64.txt
@@ -1,10 +1,10 @@
 procedure Num.96 (#Attr.2):
-    let Num.269 : Str = lowlevel NumToStr #Attr.2;
-    ret Num.269;
+    let Num.275 : Str = lowlevel NumToStr #Attr.2;
+    ret Num.275;
 
 procedure Num.96 (#Attr.2):
-    let Num.270 : Str = lowlevel NumToStr #Attr.2;
-    ret Num.270;
+    let Num.276 : Str = lowlevel NumToStr #Attr.2;
+    ret Num.276;
 
 procedure Test.1 (Test.4):
     let Test.13 : [C U8, C U64] = TagId(1) Test.4;

--- a/crates/compiler/test_mono/generated/lambda_set_with_imported_toplevels_issue_4733.txt
+++ b/crates/compiler/test_mono/generated/lambda_set_with_imported_toplevels_issue_4733.txt
@@ -7,12 +7,12 @@ procedure Bool.2 ():
     ret Bool.24;
 
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.269 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.269;
+    let Num.275 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.275;
 
 procedure Num.21 (#Attr.2, #Attr.3):
-    let Num.270 : U64 = lowlevel NumMul #Attr.2 #Attr.3;
-    ret Num.270;
+    let Num.276 : U64 = lowlevel NumMul #Attr.2 #Attr.3;
+    ret Num.276;
 
 procedure Test.0 (Test.8):
     let Test.20 : Int1 = CallByName Bool.2;

--- a/crates/compiler/test_mono/generated/layout_cache_structure_with_multiple_recursive_structures.txt
+++ b/crates/compiler/test_mono/generated/layout_cache_structure_with_multiple_recursive_structures.txt
@@ -29,12 +29,12 @@ procedure List.91 (#Derived_gen.0, #Derived_gen.1, #Derived_gen.2, #Derived_gen.
     jump List.575 #Derived_gen.0 #Derived_gen.1 #Derived_gen.2 #Derived_gen.3 #Derived_gen.4;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.270 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.270;
+    let Num.276 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.276;
 
 procedure Num.51 (#Attr.2, #Attr.3):
-    let Num.269 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
-    ret Num.269;
+    let Num.275 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
+    ret Num.275;
 
 procedure Test.7 (Test.11, Test.12):
     let Test.17 : {[<rnu>C *self, <null>], [<rnu><null>, C {[<rnu>C *self, <null>], *self}]} = Struct {Test.12, Test.11};

--- a/crates/compiler/test_mono/generated/linked_list_filter.txt
+++ b/crates/compiler/test_mono/generated/linked_list_filter.txt
@@ -1,11 +1,11 @@
-procedure Num.31 (Num.207):
-    let Num.270 : I64 = 2i64;
-    let Num.269 : Int1 = CallByName Num.86 Num.207 Num.270;
-    ret Num.269;
+procedure Num.31 (Num.213):
+    let Num.276 : I64 = 2i64;
+    let Num.275 : Int1 = CallByName Num.86 Num.213 Num.276;
+    ret Num.275;
 
 procedure Num.86 (#Attr.2, #Attr.3):
-    let Num.271 : Int1 = lowlevel NumIsMultipleOf #Attr.2 #Attr.3;
-    ret Num.271;
+    let Num.277 : Int1 = lowlevel NumIsMultipleOf #Attr.2 #Attr.3;
+    ret Num.277;
 
 procedure Test.2 (#Derived_gen.0, #Derived_gen.1):
     let #Derived_gen.3 : [<rnu><null>, C I64 *self] = NullPointer;

--- a/crates/compiler/test_mono/generated/linked_list_map.txt
+++ b/crates/compiler/test_mono/generated/linked_list_map.txt
@@ -1,6 +1,6 @@
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.269 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.269;
+    let Num.275 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.275;
 
 procedure Test.10 (Test.11):
     let Test.28 : I64 = 1i64;

--- a/crates/compiler/test_mono/generated/list_cannot_update_inplace.txt
+++ b/crates/compiler/test_mono/generated/list_cannot_update_inplace.txt
@@ -22,12 +22,12 @@ procedure List.67 (#Attr.2, #Attr.3, #Attr.4):
     ret List.579;
 
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.269 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.269;
+    let Num.275 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.275;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.270 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.270;
+    let Num.276 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.276;
 
 procedure Test.1 ():
     let Test.8 : List I64 = Array [1i64, 2i64, 3i64];

--- a/crates/compiler/test_mono/generated/list_get.txt
+++ b/crates/compiler/test_mono/generated/list_get.txt
@@ -21,8 +21,8 @@ procedure List.66 (#Attr.2, #Attr.3):
     ret List.577;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.269 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.269;
+    let Num.275 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.275;
 
 procedure Test.1 (Test.2):
     let Test.6 : List I64 = Array [1i64, 2i64, 3i64];

--- a/crates/compiler/test_mono/generated/list_len.txt
+++ b/crates/compiler/test_mono/generated/list_len.txt
@@ -7,8 +7,8 @@ procedure List.6 (#Attr.2):
     ret List.573;
 
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.269 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.269;
+    let Num.275 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.275;
 
 procedure Test.0 ():
     let Test.1 : List I64 = Array [1i64, 2i64, 3i64];

--- a/crates/compiler/test_mono/generated/list_map_closure_borrows.txt
+++ b/crates/compiler/test_mono/generated/list_map_closure_borrows.txt
@@ -27,8 +27,8 @@ procedure List.66 (#Attr.2, #Attr.3):
     ret List.577;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.269 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.269;
+    let Num.275 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.275;
 
 procedure Str.16 (#Attr.2, #Attr.3):
     let Str.232 : Str = lowlevel StrRepeat #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/list_map_closure_owns.txt
+++ b/crates/compiler/test_mono/generated/list_map_closure_owns.txt
@@ -27,8 +27,8 @@ procedure List.66 (#Attr.2, #Attr.3):
     ret List.577;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.269 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.269;
+    let Num.275 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.275;
 
 procedure Str.3 (#Attr.2, #Attr.3):
     let Str.233 : Str = lowlevel StrConcat #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/list_map_take_capturing_or_noncapturing.txt
+++ b/crates/compiler/test_mono/generated/list_map_take_capturing_or_noncapturing.txt
@@ -21,8 +21,8 @@ procedure List.5 (#Attr.2, #Attr.3):
     
 
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.271 : U8 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.271;
+    let Num.277 : U8 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.277;
 
 procedure Test.4 (Test.5, #Attr.12):
     let Test.16 : U8 = UnionAtIndex (Id 0) (Index 0) #Attr.12;

--- a/crates/compiler/test_mono/generated/list_pass_to_function.txt
+++ b/crates/compiler/test_mono/generated/list_pass_to_function.txt
@@ -22,8 +22,8 @@ procedure List.67 (#Attr.2, #Attr.3, #Attr.4):
     ret List.577;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.269 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.269;
+    let Num.275 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.275;
 
 procedure Test.2 (Test.3):
     let Test.6 : U64 = 0i64;

--- a/crates/compiler/test_mono/generated/list_sort_asc.txt
+++ b/crates/compiler/test_mono/generated/list_sort_asc.txt
@@ -8,8 +8,8 @@ procedure List.59 (List.329):
     ret List.572;
 
 procedure Num.46 (#Attr.2, #Attr.3):
-    let Num.269 : U8 = lowlevel NumCompare #Attr.2 #Attr.3;
-    ret Num.269;
+    let Num.275 : U8 = lowlevel NumCompare #Attr.2 #Attr.3;
+    ret Num.275;
 
 procedure Test.0 ():
     let Test.2 : List I64 = Array [4i64, 3i64, 2i64, 1i64];

--- a/crates/compiler/test_mono/generated/multiline_record_pattern.txt
+++ b/crates/compiler/test_mono/generated/multiline_record_pattern.txt
@@ -1,6 +1,6 @@
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.270 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.270;
+    let Num.276 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.276;
 
 procedure Test.0 ():
     let Test.7 : I64 = 1i64;

--- a/crates/compiler/test_mono/generated/nested_optional_field_with_binary_op.txt
+++ b/crates/compiler/test_mono/generated/nested_optional_field_with_binary_op.txt
@@ -1,6 +1,6 @@
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.269 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.269;
+    let Num.275 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.275;
 
 procedure Test.0 ():
     let Test.17 : {} = Struct {};

--- a/crates/compiler/test_mono/generated/nested_pattern_match.txt
+++ b/crates/compiler/test_mono/generated/nested_pattern_match.txt
@@ -1,6 +1,6 @@
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.269 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.269;
+    let Num.275 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.275;
 
 procedure Test.0 ():
     let Test.19 : I64 = 41i64;

--- a/crates/compiler/test_mono/generated/num_width_gt_u8_layout_as_float.txt
+++ b/crates/compiler/test_mono/generated/num_width_gt_u8_layout_as_float.txt
@@ -1,6 +1,6 @@
 procedure Num.37 (#Attr.2, #Attr.3):
-    let Num.269 : Decimal = lowlevel NumDivFrac #Attr.2 #Attr.3;
-    ret Num.269;
+    let Num.275 : Decimal = lowlevel NumDivFrac #Attr.2 #Attr.3;
+    ret Num.275;
 
 procedure Test.0 ():
     let Test.2 : Decimal = 1dec;

--- a/crates/compiler/test_mono/generated/optional_field_with_binary_op.txt
+++ b/crates/compiler/test_mono/generated/optional_field_with_binary_op.txt
@@ -1,6 +1,6 @@
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.269 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.269;
+    let Num.275 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.275;
 
 procedure Test.0 ():
     let Test.5 : {} = Struct {};

--- a/crates/compiler/test_mono/generated/optional_when.txt
+++ b/crates/compiler/test_mono/generated/optional_when.txt
@@ -1,6 +1,6 @@
 procedure Num.21 (#Attr.2, #Attr.3):
-    let Num.271 : I64 = lowlevel NumMul #Attr.2 #Attr.3;
-    ret Num.271;
+    let Num.277 : I64 = lowlevel NumMul #Attr.2 #Attr.3;
+    ret Num.277;
 
 procedure Test.1 (Test.6):
     let Test.21 : Int1 = false;

--- a/crates/compiler/test_mono/generated/quicksort_help.txt
+++ b/crates/compiler/test_mono/generated/quicksort_help.txt
@@ -1,14 +1,14 @@
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.269 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.269;
+    let Num.275 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.275;
 
 procedure Num.20 (#Attr.2, #Attr.3):
-    let Num.270 : I64 = lowlevel NumSub #Attr.2 #Attr.3;
-    ret Num.270;
+    let Num.276 : I64 = lowlevel NumSub #Attr.2 #Attr.3;
+    ret Num.276;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.271 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.271;
+    let Num.277 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.277;
 
 procedure Test.1 (#Derived_gen.0, #Derived_gen.1, #Derived_gen.2):
     joinpoint Test.12 Test.2 Test.3 Test.4:

--- a/crates/compiler/test_mono/generated/quicksort_swap.txt
+++ b/crates/compiler/test_mono/generated/quicksort_swap.txt
@@ -40,8 +40,8 @@ procedure List.67 (#Attr.2, #Attr.3, #Attr.4):
     ret List.577;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.271 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.271;
+    let Num.277 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.277;
 
 procedure Test.1 (Test.2):
     let Test.28 : U64 = 0i64;

--- a/crates/compiler/test_mono/generated/rb_tree_fbip.txt
+++ b/crates/compiler/test_mono/generated/rb_tree_fbip.txt
@@ -1,10 +1,10 @@
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.272 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.272;
+    let Num.278 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.278;
 
 procedure Num.24 (#Attr.2, #Attr.3):
-    let Num.270 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
-    ret Num.270;
+    let Num.276 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
+    ret Num.276;
 
 procedure Test.3 (#Derived_gen.0, #Derived_gen.1, #Derived_gen.2):
     let #Derived_gen.4 : [<rnu>C *self I64 *self I32 Int1, <null>] = NullPointer;

--- a/crates/compiler/test_mono/generated/record_optional_field_function_no_use_default.txt
+++ b/crates/compiler/test_mono/generated/record_optional_field_function_no_use_default.txt
@@ -1,6 +1,6 @@
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.269 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.269;
+    let Num.275 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.275;
 
 procedure Test.1 (Test.4):
     let Test.2 : I64 = StructAtIndex 0 Test.4;

--- a/crates/compiler/test_mono/generated/record_optional_field_function_use_default.txt
+++ b/crates/compiler/test_mono/generated/record_optional_field_function_use_default.txt
@@ -1,6 +1,6 @@
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.269 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.269;
+    let Num.275 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.275;
 
 procedure Test.1 (Test.4):
     let Test.2 : I64 = 10i64;

--- a/crates/compiler/test_mono/generated/record_optional_field_let_no_use_default.txt
+++ b/crates/compiler/test_mono/generated/record_optional_field_let_no_use_default.txt
@@ -1,6 +1,6 @@
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.269 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.269;
+    let Num.275 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.275;
 
 procedure Test.1 (Test.2):
     let Test.3 : I64 = StructAtIndex 0 Test.2;

--- a/crates/compiler/test_mono/generated/record_optional_field_let_use_default.txt
+++ b/crates/compiler/test_mono/generated/record_optional_field_let_use_default.txt
@@ -1,6 +1,6 @@
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.269 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.269;
+    let Num.275 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.275;
 
 procedure Test.1 (Test.2):
     let Test.3 : I64 = 10i64;

--- a/crates/compiler/test_mono/generated/record_update.txt
+++ b/crates/compiler/test_mono/generated/record_update.txt
@@ -22,8 +22,8 @@ procedure List.67 (#Attr.2, #Attr.3, #Attr.4):
     ret List.577;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.269 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.269;
+    let Num.275 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.275;
 
 procedure Test.1 (Test.2):
     let Test.6 : List U64 = StructAtIndex 0 Test.2;

--- a/crates/compiler/test_mono/generated/recursive_call_capturing_function.txt
+++ b/crates/compiler/test_mono/generated/recursive_call_capturing_function.txt
@@ -3,8 +3,8 @@ procedure Bool.2 ():
     ret Bool.23;
 
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.269 : U32 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.269;
+    let Num.275 : U32 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.275;
 
 procedure Test.1 (Test.2):
     let Test.8 : U32 = 0i64;

--- a/crates/compiler/test_mono/generated/recursive_lambda_set_resolved_only_upon_specialization.txt
+++ b/crates/compiler/test_mono/generated/recursive_lambda_set_resolved_only_upon_specialization.txt
@@ -3,12 +3,12 @@ procedure Bool.11 (#Attr.2, #Attr.3):
     ret Bool.23;
 
 procedure Num.20 (#Attr.2, #Attr.3):
-    let Num.270 : U8 = lowlevel NumSub #Attr.2 #Attr.3;
-    ret Num.270;
+    let Num.276 : U8 = lowlevel NumSub #Attr.2 #Attr.3;
+    ret Num.276;
 
 procedure Num.21 (#Attr.2, #Attr.3):
-    let Num.269 : U8 = lowlevel NumMul #Attr.2 #Attr.3;
-    ret Num.269;
+    let Num.275 : U8 = lowlevel NumMul #Attr.2 #Attr.3;
+    ret Num.275;
 
 procedure Test.1 (#Derived_gen.2, #Derived_gen.3):
     joinpoint Test.11 Test.2 Test.3:

--- a/crates/compiler/test_mono/generated/recursively_build_effect.txt
+++ b/crates/compiler/test_mono/generated/recursively_build_effect.txt
@@ -1,6 +1,6 @@
 procedure Num.20 (#Attr.2, #Attr.3):
-    let Num.269 : I64 = lowlevel NumSub #Attr.2 #Attr.3;
-    ret Num.269;
+    let Num.275 : I64 = lowlevel NumSub #Attr.2 #Attr.3;
+    ret Num.275;
 
 procedure Str.3 (#Attr.2, #Attr.3):
     let Str.234 : Str = lowlevel StrConcat #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/rigids.txt
+++ b/crates/compiler/test_mono/generated/rigids.txt
@@ -40,8 +40,8 @@ procedure List.67 (#Attr.2, #Attr.3, #Attr.4):
     ret List.577;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.271 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.271;
+    let Num.277 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.277;
 
 procedure Test.1 (Test.2, Test.3, Test.4):
     inc 2 Test.4;

--- a/crates/compiler/test_mono/generated/specialize_after_match.txt
+++ b/crates/compiler/test_mono/generated/specialize_after_match.txt
@@ -1,10 +1,10 @@
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.270 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.270;
+    let Num.276 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.276;
 
 procedure Num.24 (#Attr.2, #Attr.3):
-    let Num.271 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
-    ret Num.271;
+    let Num.277 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
+    ret Num.277;
 
 procedure Test.2 (Test.9, Test.10):
     let Test.38 : U8 = 1i64;

--- a/crates/compiler/test_mono/generated/specialize_closures.txt
+++ b/crates/compiler/test_mono/generated/specialize_closures.txt
@@ -3,12 +3,12 @@ procedure Bool.2 ():
     ret Bool.24;
 
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.270 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.270;
+    let Num.276 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.276;
 
 procedure Num.21 (#Attr.2, #Attr.3):
-    let Num.269 : I64 = lowlevel NumMul #Attr.2 #Attr.3;
-    ret Num.269;
+    let Num.275 : I64 = lowlevel NumMul #Attr.2 #Attr.3;
+    ret Num.275;
 
 procedure Test.1 (Test.2, Test.3):
     let Test.15 : U8 = GetTagId Test.2;

--- a/crates/compiler/test_mono/generated/specialize_lowlevel.txt
+++ b/crates/compiler/test_mono/generated/specialize_lowlevel.txt
@@ -3,12 +3,12 @@ procedure Bool.2 ():
     ret Bool.23;
 
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.270 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.270;
+    let Num.276 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.276;
 
 procedure Num.21 (#Attr.2, #Attr.3):
-    let Num.269 : I64 = lowlevel NumMul #Attr.2 #Attr.3;
-    ret Num.269;
+    let Num.275 : I64 = lowlevel NumMul #Attr.2 #Attr.3;
+    ret Num.275;
 
 procedure Test.6 (Test.8, #Attr.12):
     let Test.20 : I64 = UnionAtIndex (Id 0) (Index 0) #Attr.12;

--- a/crates/compiler/test_mono/generated/tail_call_elimination.txt
+++ b/crates/compiler/test_mono/generated/tail_call_elimination.txt
@@ -1,10 +1,10 @@
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.269 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.269;
+    let Num.275 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.275;
 
 procedure Num.20 (#Attr.2, #Attr.3):
-    let Num.270 : I64 = lowlevel NumSub #Attr.2 #Attr.3;
-    ret Num.270;
+    let Num.276 : I64 = lowlevel NumSub #Attr.2 #Attr.3;
+    ret Num.276;
 
 procedure Test.1 (#Derived_gen.0, #Derived_gen.1):
     joinpoint Test.7 Test.2 Test.3:

--- a/crates/compiler/test_mono/generated/unspecialized_lambda_set_unification_does_not_duplicate_identical_concrete_types.txt
+++ b/crates/compiler/test_mono/generated/unspecialized_lambda_set_unification_does_not_duplicate_identical_concrete_types.txt
@@ -184,40 +184,40 @@ procedure List.91 (#Derived_gen.6, #Derived_gen.7, #Derived_gen.8, #Derived_gen.
     jump List.601 #Derived_gen.6 #Derived_gen.7 #Derived_gen.8 #Derived_gen.9 #Derived_gen.10;
 
 procedure Num.127 (#Attr.2):
-    let Num.276 : U8 = lowlevel NumIntCast #Attr.2;
-    ret Num.276;
-
-procedure Num.137 (#Attr.2, #Attr.3):
-    let Num.281 : U64 = lowlevel NumDivCeilUnchecked #Attr.2 #Attr.3;
-    ret Num.281;
-
-procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.280 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.280;
-
-procedure Num.20 (#Attr.2, #Attr.3):
-    let Num.277 : U64 = lowlevel NumSub #Attr.2 #Attr.3;
-    ret Num.277;
-
-procedure Num.21 (#Attr.2, #Attr.3):
-    let Num.282 : U64 = lowlevel NumMul #Attr.2 #Attr.3;
+    let Num.282 : U8 = lowlevel NumIntCast #Attr.2;
     ret Num.282;
 
-procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.288 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+procedure Num.137 (#Attr.2, #Attr.3):
+    let Num.287 : U64 = lowlevel NumDivCeilUnchecked #Attr.2 #Attr.3;
+    ret Num.287;
+
+procedure Num.19 (#Attr.2, #Attr.3):
+    let Num.286 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.286;
+
+procedure Num.20 (#Attr.2, #Attr.3):
+    let Num.283 : U64 = lowlevel NumSub #Attr.2 #Attr.3;
+    ret Num.283;
+
+procedure Num.21 (#Attr.2, #Attr.3):
+    let Num.288 : U64 = lowlevel NumMul #Attr.2 #Attr.3;
     ret Num.288;
 
+procedure Num.22 (#Attr.2, #Attr.3):
+    let Num.294 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.294;
+
 procedure Num.24 (#Attr.2, #Attr.3):
-    let Num.290 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
-    ret Num.290;
+    let Num.296 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
+    ret Num.296;
 
 procedure Num.51 (#Attr.2, #Attr.3):
-    let Num.285 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
-    ret Num.285;
+    let Num.291 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
+    ret Num.291;
 
 procedure Num.75 (#Attr.2, #Attr.3):
-    let Num.289 : U64 = lowlevel NumSubWrap #Attr.2 #Attr.3;
-    ret Num.289;
+    let Num.295 : U64 = lowlevel NumSubWrap #Attr.2 #Attr.3;
+    ret Num.295;
 
 procedure Str.12 (#Attr.2):
     let Str.233 : List U8 = lowlevel StrToUtf8 #Attr.2;

--- a/crates/compiler/test_mono/generated/unspecialized_lambda_set_unification_keeps_all_concrete_types_without_unification_of_unifiable.txt
+++ b/crates/compiler/test_mono/generated/unspecialized_lambda_set_unification_keeps_all_concrete_types_without_unification_of_unifiable.txt
@@ -158,24 +158,24 @@ procedure List.91 (#Derived_gen.40, #Derived_gen.41, #Derived_gen.42, #Derived_g
     jump List.601 #Derived_gen.40 #Derived_gen.41 #Derived_gen.42 #Derived_gen.43 #Derived_gen.44;
 
 procedure Num.127 (#Attr.2):
-    let Num.288 : U8 = lowlevel NumIntCast #Attr.2;
-    ret Num.288;
+    let Num.294 : U8 = lowlevel NumIntCast #Attr.2;
+    ret Num.294;
 
 procedure Num.20 (#Attr.2, #Attr.3):
-    let Num.289 : U64 = lowlevel NumSub #Attr.2 #Attr.3;
-    ret Num.289;
+    let Num.295 : U64 = lowlevel NumSub #Attr.2 #Attr.3;
+    ret Num.295;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.292 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.292;
+    let Num.298 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.298;
 
 procedure Num.24 (#Attr.2, #Attr.3):
-    let Num.290 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
-    ret Num.290;
+    let Num.296 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
+    ret Num.296;
 
 procedure Num.51 (#Attr.2, #Attr.3):
-    let Num.291 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
-    ret Num.291;
+    let Num.297 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
+    ret Num.297;
 
 procedure Str.12 (#Attr.2):
     let Str.233 : List U8 = lowlevel StrToUtf8 #Attr.2;

--- a/crates/compiler/test_mono/generated/weakening_avoids_overspecialization.txt
+++ b/crates/compiler/test_mono/generated/weakening_avoids_overspecialization.txt
@@ -78,16 +78,16 @@ procedure List.80 (#Derived_gen.0, #Derived_gen.1, #Derived_gen.2, #Derived_gen.
     jump List.592 #Derived_gen.0 #Derived_gen.1 #Derived_gen.2 #Derived_gen.3 #Derived_gen.4;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.272 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.272;
+    let Num.278 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.278;
 
 procedure Num.51 (#Attr.2, #Attr.3):
-    let Num.271 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
-    ret Num.271;
+    let Num.277 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
+    ret Num.277;
 
 procedure Num.77 (#Attr.2, #Attr.3):
-    let Num.270 : U64 = lowlevel NumSubSaturated #Attr.2 #Attr.3;
-    ret Num.270;
+    let Num.276 : U64 = lowlevel NumSubSaturated #Attr.2 #Attr.3;
+    ret Num.276;
 
 procedure Test.3 (Test.4, Test.12):
     let Test.13 : [C U64, C U64] = TagId(0) Test.4;

--- a/crates/compiler/test_mono/generated/when_guard_appears_multiple_times_in_compiled_decision_tree_issue_5176.txt
+++ b/crates/compiler/test_mono/generated/when_guard_appears_multiple_times_in_compiled_decision_tree_issue_5176.txt
@@ -3,8 +3,8 @@ procedure Bool.2 ():
     ret Bool.25;
 
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.269 : U8 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.269;
+    let Num.275 : U8 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.275;
 
 procedure Test.1 (Test.2):
     joinpoint Test.12:

--- a/crates/compiler/test_mono/generated/when_nested_maybe.txt
+++ b/crates/compiler/test_mono/generated/when_nested_maybe.txt
@@ -1,6 +1,6 @@
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.269 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.269;
+    let Num.275 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.275;
 
 procedure Test.0 ():
     let Test.19 : I64 = 41i64;

--- a/crates/compiler/test_mono/generated/when_on_record.txt
+++ b/crates/compiler/test_mono/generated/when_on_record.txt
@@ -1,6 +1,6 @@
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.269 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.269;
+    let Num.275 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.275;
 
 procedure Test.0 ():
     let Test.5 : I64 = 2i64;

--- a/crates/compiler/test_mono/generated/when_on_two_values.txt
+++ b/crates/compiler/test_mono/generated/when_on_two_values.txt
@@ -1,6 +1,6 @@
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.269 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.269;
+    let Num.275 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.275;
 
 procedure Test.0 ():
     let Test.15 : I64 = 3i64;


### PR DESCRIPTION
Discussion: https://roc.zulipchat.com/#narrow/stream/383402-API-Design/topic/reading.20integers.20from.20bytes/near/418549425

I implemented it as far as I "easily" could.
The two new `Dec` functions worked in the repl and llvm, but I have no idea if what I did is a good idea.
For the `F32`/`F64` functions, they work in the repl, but for llvm I don't know what to do exactly.
I don't know how to test `wasm` so I just copied stuff from other implementations and hope it works.

I also don't know how/where/if to add tests for this.


I'm happy for hints in the right direction so I can finish this.