### PR TITLE
Add spaces to doc comments

### DIFF
--- a/crates/compiler/fmt/src/spaces.rs
+++ b/crates/compiler/fmt/src/spaces.rs
@@ -208,7 +208,7 @@ fn fmt_docs(buf: &mut Buf, docs: &str) {
 /// * Removing comments
 /// * Removing parens in Exprs
 ///
-/// Long term, we actuall want this transform to preserve comments (so we can assert they're maintained by formatting)
+/// Long term, we actually want this transform to preserve comments (so we can assert they're maintained by formatting)
 /// - but there are currently several bugs where they're _not_ preserved.
 /// TODO: ensure formatting retains comments
 pub trait RemoveSpaces<'a> {

--- a/crates/compiler/load_internal/tests/fixtures/build/no_deps/Docs.roc
+++ b/crates/compiler/load_internal/tests/fixtures/build/no_deps/Docs.roc
@@ -7,6 +7,8 @@ interface Docs
 User : { name : Str }
 
 ## Makes a user
+##
+## Takes a name Str.
 makeUser : Str -> User
 makeUser = \name ->
     { name }

--- a/crates/compiler/load_internal/tests/test_load.rs
+++ b/crates/compiler/load_internal/tests/test_load.rs
@@ -450,7 +450,7 @@ fn load_docs() {
     let expected = vec![
         (None, Some("An interface for docs tests\n")),
         (Some("User"), Some("This is a user\n")),
-        (Some("makeUser"), Some("Makes a user\n")),
+        (Some("makeUser"), Some("Makes a user\n\nTakes a name Str.\n")),
         (Some("getName"), Some("Gets the user's name\n")),
         (Some("getNameExposed"), None),
     ]

--- a/crates/compiler/load_internal/tests/test_load.rs
+++ b/crates/compiler/load_internal/tests/test_load.rs
@@ -450,7 +450,10 @@ fn load_docs() {
     let expected = vec![
         (None, Some("An interface for docs tests\n")),
         (Some("User"), Some("This is a user\n")),
-        (Some("makeUser"), Some("Makes a user\n\nTakes a name Str.\n")),
+        (
+            Some("makeUser"),
+            Some("Makes a user\n\nTakes a name Str.\n"),
+        ),
         (Some("getName"), Some("Gets the user's name\n")),
         (Some("getNameExposed"), None),
     ]

--- a/crates/compiler/parse/src/ast.rs
+++ b/crates/compiler/parse/src/ast.rs
@@ -847,15 +847,6 @@ impl<'a> CommentOrNewline<'a> {
         }
     }
 
-    pub fn to_string_repr(&self) -> std::string::String {
-        use CommentOrNewline::*;
-        match self {
-            Newline => "\n".to_owned(),
-            LineComment(comment_str) => format!("#{comment_str}"),
-            DocComment(comment_str) => format!("##{comment_str}"),
-        }
-    }
-
     pub fn comment_str(&'a self) -> Option<&'a str> {
         match self {
             CommentOrNewline::LineComment(s) => Some(*s),

--- a/crates/compiler/parse/src/blankspace.rs
+++ b/crates/compiler/parse/src/blankspace.rs
@@ -437,11 +437,8 @@ where
             Some(b'#') => {
                 state.advance_mut(1);
 
-                let is_doc_comment = state.bytes().first() == Some(&b'#')
-                    && (state.bytes().get(1) == Some(&b' ')
-                        || state.bytes().get(1) == Some(&b'\n')
-                        || begins_with_crlf(&state.bytes()[1..])
-                        || Option::is_none(&state.bytes().get(1)));
+                let is_doc_comment =
+                    state.bytes().first() == Some(&b'#') && state.bytes().get(1) != Some(&b'#');
 
                 if is_doc_comment {
                     state.advance_mut(1);

--- a/crates/compiler/parse/src/highlight.rs
+++ b/crates/compiler/parse/src/highlight.rs
@@ -413,7 +413,7 @@ mod tests {
 
     #[test]
     fn test_highlight_doc_comments() {
-        let text = "## a\n##b\n##c";
+        let text = "## a\n##b\n##c\n##\n";
         let tokens = highlight(text);
         assert_eq!(
             tokens,
@@ -422,14 +422,17 @@ mod tests {
                     Region::between(Position::new(0), Position::new(4)),
                     Token::DocComment
                 ),
-                // the next two are line comments because there's not a space at the beginning
                 Loc::at(
                     Region::between(Position::new(5), Position::new(8)),
-                    Token::LineComment
+                    Token::DocComment
                 ),
                 Loc::at(
                     Region::between(Position::new(9), Position::new(12)),
-                    Token::LineComment
+                    Token::DocComment
+                ),
+                Loc::at(
+                    Region::between(Position::new(13), Position::new(15)),
+                    Token::DocComment
                 ),
             ]
         );

--- a/crates/compiler/test_syntax/tests/snapshots/pass/docs.expr.formatted.roc
+++ b/crates/compiler/test_syntax/tests/snapshots/pass/docs.expr.formatted.roc
@@ -1,6 +1,7 @@
 #######
 ### not docs!
-##still not docs
+## actually docs
+##
 ######
 x = 5
 

--- a/crates/compiler/test_syntax/tests/snapshots/pass/docs.expr.result-ast
+++ b/crates/compiler/test_syntax/tests/snapshots/pass/docs.expr.result-ast
@@ -5,7 +5,7 @@ SpaceBefore(
                 Index(2147483648),
             ],
             regions: [
-                @46-51,
+                @48-53,
             ],
             space_before: [
                 Slice(start = 0, length = 0),
@@ -17,16 +17,16 @@ SpaceBefore(
             type_defs: [],
             value_defs: [
                 Body(
-                    @46-47 Identifier(
+                    @48-49 Identifier(
                         "x",
                     ),
-                    @50-51 Num(
+                    @52-53 Num(
                         "5",
                     ),
                 ),
             ],
         },
-        @53-55 SpaceBefore(
+        @55-57 SpaceBefore(
             Num(
                 "42",
             ),
@@ -43,8 +43,11 @@ SpaceBefore(
         LineComment(
             "## not docs!",
         ),
-        LineComment(
-            "#still not docs",
+        DocComment(
+            "actually docs",
+        ),
+        DocComment(
+            "",
         ),
         LineComment(
             "#####",

--- a/crates/compiler/test_syntax/tests/snapshots/pass/docs.expr.roc
+++ b/crates/compiler/test_syntax/tests/snapshots/pass/docs.expr.roc
@@ -1,0 +1,8 @@
+#######
+### not docs!
+##actually docs
+##
+######
+x = 5
+
+42

--- a/crates/compiler/test_syntax/tests/test_snapshots.rs
+++ b/crates/compiler/test_syntax/tests/test_snapshots.rs
@@ -377,7 +377,7 @@ mod test_snapshots {
         pass/nonempty_hosted_header.header,
         pass/nonempty_package_header.header,
         pass/nonempty_platform_header.header,
-        pass/not_docs.expr,
+        pass/docs.expr,
         pass/not_multiline_string.expr,
         pass/number_literal_suffixes.expr,
         pass/one_backpassing.expr,


### PR DESCRIPTION
This turned out to be more of a parsing issue -- `##foo` was not being parsed as a doc comment. The formatting code already adds a space between `##` and the comment content (see https://github.com/jschear/roc/blob/81be1441841f2005edd3e49eaa010e9085d53a7c/crates/compiler/fmt/src/spaces.rs#L190).

Closes #6582.