### PR TITLE
De-sugar bang `!` operator - part 2

### DIFF
--- a/crates/compiler/parse/src/pattern.rs
+++ b/crates/compiler/parse/src/pattern.rs
@@ -381,7 +381,9 @@ fn loc_ident_pattern_help<'a>(
                     Ok((MadeProgress, loc_pat, state))
                 }
             }
-            Ident::Access { module_name, parts } => {
+            Ident::Access {
+                module_name, parts, ..
+            } => {
                 // Plain identifiers (e.g. `foo`) are allowed in patterns, but
                 // more complex ones (e.g. `Foo.bar` or `foo.bar.baz`) are not.
 

--- a/crates/compiler/test_syntax/tests/snapshots/pass/suffixed_nested.expr.result-ast
+++ b/crates/compiler/test_syntax/tests/snapshots/pass/suffixed_nested.expr.result-ast
@@ -1,5 +1,5 @@
 Apply(
-    @0-3 Suffixed(
+    @0-4 Suffixed(
         Var {
             module_name: "",
             ident: "foo",
@@ -8,7 +8,7 @@ Apply(
     [
         @9-17 ParensAround(
             Apply(
-                @9-12 Suffixed(
+                @9-13 Suffixed(
                     Var {
                         module_name: "",
                         ident: "bar",

--- a/crates/docs/src/lib.rs
+++ b/crates/docs/src/lib.rs
@@ -999,7 +999,13 @@ fn markdown_to_html(
                 arena.reset();
 
                 match parse_ident(&arena, state, 0) {
-                    Ok((_, Ident::Access { module_name, parts }, _)) => {
+                    Ok((
+                        _,
+                        Ident::Access {
+                            module_name, parts, ..
+                        },
+                        _,
+                    )) => {
                         let mut iter = parts.iter();
 
                         match iter.next() {


### PR DESCRIPTION
This PR;
- Moves the parsing for suffixed things into `chomp_identifier_chain` to improve reliability (only valid `Idents` can be suffixed) and enable nesting within expressions.


Tested using 

```roc
app "desugar-bang"
    packages {
        cli: "../basic-cli/platform/main.roc",
    }
    imports [
        cli.Stdout, 
        cli.Task,
        cli.File,
        cli.Path,
    ]
    provides [main] to cli

main =
    path = Path.fromStr "echo.txt"

    {} = 
        "Opening file: " 
        |> Str.concat (Path.display path) 
        |> Stdout.line!

    str =
        File.readUtf8 path
        |> Task.onErr! \err -> Task.ok (Inspect.toStr err)

    Stdout.line str
```

