### PR TITLE
Add error reporting for unexpected comma

### DIFF
--- a/crates/compiler/parse/src/expr.rs
+++ b/crates/compiler/parse/src/expr.rs
@@ -1778,7 +1778,17 @@ fn parse_expr_end<'a>(
                                 ),
                             ),
                         )
-                        .parse(arena, state, min_indent)?;
+                        .parse(arena, state, min_indent)
+                        .map_err(|(progress, err)| {
+                            // We were expecting the end of an expression, and parsed a comma
+                            // therefore we are either on the LHS of backpassing or this is was
+                            // in an invalid position.
+                            if let EExpr::Pattern(EPattern::IndentEnd(_), pos) = err {
+                                (progress, EExpr::UnexpectedComma(pos.sub(1)))
+                            } else {
+                                (progress, err)
+                            }
+                        })?;
 
                         expr_state.consume_spaces(arena);
                         let call = to_call(arena, expr_state.arguments, expr_state.expr);

--- a/crates/compiler/parse/src/parser.rs
+++ b/crates/compiler/parse/src/parser.rs
@@ -364,6 +364,8 @@ pub enum EExpr<'a> {
 
     IndentStart(Position),
     IndentEnd(Position),
+
+    UnexpectedComma(Position),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/reporting/src/error/parse.rs
+++ b/crates/reporting/src/error/parse.rs
@@ -687,6 +687,23 @@ fn to_expr_report<'a>(
                 severity: Severity::RuntimeError,
             }
         }
+        EExpr::UnexpectedComma(pos) => {
+            let surroundings = Region::new(start, *pos);
+            let region = LineColumnRegion::from_pos(lines.convert_pos(*pos));
+
+            let doc = alloc.stack([
+                alloc.reflow(r"I am trying to parse an expression, but I got stuck here:"),
+                alloc.region_with_subregion(lines.convert_region(surroundings), region),
+                alloc.concat([alloc.reflow("This comma in an invalid position.")]),
+            ]);
+
+            Report {
+                filename,
+                doc,
+                title: "UNEXPECTED COMMA".to_string(),
+                severity: Severity::RuntimeError,
+            }
+        }
         _ => todo!("unhandled parse error: {:?}", parse_problem),
     }
 }


### PR DESCRIPTION
Fix #6618 

```
── UNEXPECTED COMMA in test.roc ────────────────────────────────────────────────

I am trying to parse an expression, but I got stuck here:

 1│  app "Test"
 2│      packages {
 3│          pf: "https://github.com/roc-lang/basic-cli/releases/download/0.8.1/x8URkvfyi9I0QhmVG98roKBUs_AZRkLFwFJVJ3942YA.tar.br",
 4│      }
 5│      imports [
 6│          pf.Stdout,
 7│      ]
 8│      provides [main] to pf
 9│
10│  main =
11│      # Not the "," which shouldn't be in the function call here.
12│      a = myFunction 1, 2
                         ^

This comma in an invalid position.
```