### PR TITLE
Borrow inference

### DIFF
--- a/crates/compiler/mono/src/borrow.rs
+++ b/crates/compiler/mono/src/borrow.rs
@@ -1,20 +1,159 @@
 use bumpalo::{collections::Vec, Bump};
+use roc_collections::{MutMap, ReferenceMatrix};
+use roc_error_macros::todo_lambda_erasure;
 use roc_module::symbol::Symbol;
 
 use crate::{
     inc_dec::Ownership,
-    ir::{Call, CallType, Expr, Proc, Stmt},
-    layout::{Builtin, InLayout, LayoutInterner, LayoutRepr},
+    ir::{Call, CallType, Expr, Proc, ProcLayout, Stmt},
+    layout::{Builtin, InLayout, LayoutInterner, LayoutRepr, Niche},
 };
 
-#[allow(unused)]
-pub(crate) fn infer_borrow_signature<'a>(
+#[derive(Clone, Copy)]
+pub(crate) struct BorrowSignature(u64);
+
+impl std::fmt::Debug for BorrowSignature {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut f = &mut f.debug_struct("BorrowSignature");
+
+        dbg!(self.0);
+
+        for (i, ownership) in self.iter().enumerate() {
+            f = f.field(&format!("_{i}"), &ownership);
+        }
+
+        f.finish()
+    }
+}
+
+impl BorrowSignature {
+    fn new(len: usize) -> Self {
+        assert!(len < 64 - 8);
+
+        Self(len as _)
+    }
+
+    fn len(&self) -> usize {
+        (self.0 & 0xFF) as usize
+    }
+
+    fn get(&self, index: usize) -> Option<&Ownership> {
+        if index >= self.len() {
+            return None;
+        }
+
+        match self.0 & (1 << (index + 8)) {
+            0 => Some(&Ownership::Borrowed),
+            _ => Some(&Ownership::Owned),
+        }
+    }
+
+    fn set(&mut self, index: usize, ownership: Ownership) {
+        assert!(index < self.len());
+
+        let mask = 1 << (index + 8);
+
+        match ownership {
+            Ownership::Owned => self.0 |= mask,
+            Ownership::Borrowed => self.0 &= !mask,
+        }
+    }
+
+    fn iter(&self) -> impl Iterator<Item = Ownership> + '_ {
+        let mut i = 0;
+
+        std::iter::from_fn(move || {
+            let value = self.get(i)?;
+            i += 1;
+            Some(*value)
+        })
+    }
+}
+
+impl std::ops::Index<usize> for BorrowSignature {
+    type Output = Ownership;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        self.get(index).unwrap()
+    }
+}
+
+pub(crate) type BorrowSignatures<'a> = MutMap<(Symbol, ProcLayout<'a>), BorrowSignature>;
+
+pub(crate) fn infer_borrow_signatures<'a>(
     arena: &'a Bump,
     interner: &impl LayoutInterner<'a>,
+    procs: &'a MutMap<(Symbol, ProcLayout<'a>), Proc<'a>>,
+) -> BorrowSignatures<'a> {
+    let host_exposed_procs = &[];
+
+    let mut borrow_signatures = procs
+        .iter()
+        .map(|(key, proc)| {
+            let mut signature = BorrowSignature::new(proc.args.len());
+
+            for (i, in_layout) in key.1.arguments.iter().enumerate() {
+                signature.set(i, layout_to_ownership(*in_layout, interner));
+            }
+
+            (*key, signature)
+        })
+        .collect();
+
+    // next we first partition the functions into strongly connected components, then do a
+    // topological sort on these components, finally run the fix-point borrow analysis on each
+    // component (in top-sorted order, from primitives (std-lib) to main)
+
+    let matrix = construct_reference_matrix(arena, procs);
+    let sccs = matrix.strongly_connected_components_all();
+
+    let mut env = ();
+
+    for (group, _) in sccs.groups() {
+        // This is a fixed-point analysis
+        //
+        // all functions initially own all their parameters
+        // through a series of checks and heuristics, some arguments are set to borrowed
+        // when that doesn't lead to conflicts the change is kept, otherwise it may be reverted
+        //
+        // when the signatures no longer change, the analysis stops and returns the signatures
+        loop {
+            for index in group.iter_ones() {
+                let (key, proc) = procs.iter().nth(index).unwrap();
+
+                if proc.args.is_empty() {
+                    continue;
+                }
+
+                // host-exposed functions must always own their arguments.
+                let is_host_exposed = host_exposed_procs.contains(&key.0);
+
+                let mut state = State::new(arena, interner, &mut borrow_signatures, proc);
+                state.inspect_stmt(&mut borrow_signatures, &proc.body);
+
+                borrow_signatures.insert(*key, state.borrow_signature);
+            }
+
+            // if there were no modifications, we're done
+            // if !env.modified {
+            if true {
+                break;
+            }
+        }
+    }
+
+    borrow_signatures
+}
+
+#[allow(unused)]
+fn infer_borrow_signature<'a>(
+    arena: &'a Bump,
+    interner: &impl LayoutInterner<'a>,
+    borrow_signatures: &'a mut BorrowSignatures<'a>,
     proc: &'a Proc<'a>,
-) -> &'a [Ownership] {
-    let mut state = State::new(arena, interner, proc);
-    state.inspect_stmt(&proc.body);
+) -> BorrowSignature {
+    let mut state = State::new(arena, interner, borrow_signatures, proc);
+    state.inspect_stmt(borrow_signatures, &proc.body);
     state.borrow_signature
 }
 
@@ -22,7 +161,7 @@ struct State<'a> {
     /// Argument symbols with a layout of `List *` or `Str`, i.e. the layouts
     /// for which borrow inference might decide to pass as borrowed
     args: &'a [(InLayout<'a>, Symbol)],
-    borrow_signature: &'a mut [Ownership],
+    borrow_signature: BorrowSignature,
 }
 
 fn layout_to_ownership<'a>(
@@ -39,32 +178,45 @@ fn layout_to_ownership<'a>(
 }
 
 impl<'a> State<'a> {
-    fn new(arena: &'a Bump, interner: &impl LayoutInterner<'a>, proc: &'a Proc<'a>) -> Self {
-        let borrow_signature = Vec::from_iter_in(
-            proc.args
-                .iter()
-                .map(|(in_layout, _)| layout_to_ownership(*in_layout, interner)),
-            arena,
-        )
-        .into_bump_slice_mut();
+    fn new(
+        arena: &'a Bump,
+        interner: &impl LayoutInterner<'a>,
+        borrow_signatures: &mut BorrowSignatures<'a>,
+        proc: &'a Proc<'a>,
+    ) -> Self {
+        let key = (proc.name.name(), proc.proc_layout(arena));
+
+        // initialize the borrow signature based on the layout if first time
+        let borrow_signature = borrow_signatures.entry(key).or_insert_with(|| {
+            let mut borrow_signature = BorrowSignature::new(proc.args.len());
+
+            for (i, in_layout) in key.1.arguments.iter().enumerate() {
+                borrow_signature.set(i, layout_to_ownership(*in_layout, interner));
+            }
+
+            borrow_signature
+        });
 
         Self {
             args: proc.args,
-            borrow_signature,
+            borrow_signature: *borrow_signature,
         }
     }
 
+    /// Mark the given argument symbol as Owned if the symbol participates in borrow inference
+    ///
+    /// Currently argument symbols participate if `layout_to_ownership` returns `Borrowed` for their layout.
     fn mark_owned(&mut self, symbol: Symbol) {
         if let Some(index) = self.args.iter().position(|(_, s)| *s == symbol) {
-            self.borrow_signature[index] = Ownership::Owned;
+            self.borrow_signature.set(index, Ownership::Owned);
         }
     }
 
-    fn inspect_stmt(&mut self, stmt: &'a Stmt<'a>) {
+    fn inspect_stmt(&mut self, borrow_signatures: &mut BorrowSignatures<'a>, stmt: &'a Stmt<'a>) {
         match stmt {
             Stmt::Let(_, expr, _, stmt) => {
-                self.inspect_expr(expr);
-                self.inspect_stmt(stmt);
+                self.inspect_expr(borrow_signatures, expr);
+                self.inspect_stmt(borrow_signatures, stmt);
             }
             Stmt::Switch {
                 branches,
@@ -72,12 +224,16 @@ impl<'a> State<'a> {
                 ..
             } => {
                 for (_, _, stmt) in branches.iter() {
-                    self.inspect_stmt(stmt);
+                    self.inspect_stmt(borrow_signatures, stmt);
                 }
-                self.inspect_stmt(default_branch.1);
+                self.inspect_stmt(borrow_signatures, default_branch.1);
             }
-            Stmt::Ret(_) => todo!(),
-            Stmt::Refcounting(_, _) => todo!(),
+            Stmt::Ret(s) => {
+                // to return a value we must own it
+                // (with the current implementation anyway)
+                self.mark_owned(*s);
+            }
+            Stmt::Refcounting(_, _) => unreachable!("not inserted yet"),
             Stmt::Expect { .. } | Stmt::ExpectFx { .. } => {
                 // TODO do we rely on values being passed by-value here?
                 // it would be better to pass by-reference in general
@@ -89,31 +245,48 @@ impl<'a> State<'a> {
             Stmt::Join {
                 body, remainder, ..
             } => {
-                self.inspect_stmt(body);
-                self.inspect_stmt(remainder);
+                self.inspect_stmt(borrow_signatures, body);
+                self.inspect_stmt(borrow_signatures, remainder);
             }
 
             Stmt::Jump(_, _) | Stmt::Crash(_, _) => { /* not relevant for ownership */ }
         }
     }
 
-    fn inspect_expr(&mut self, expr: &'a Expr<'a>) {
+    fn inspect_expr(&mut self, borrow_signatures: &mut BorrowSignatures<'a>, expr: &'a Expr<'a>) {
         if let Expr::Call(call) = expr {
-            self.inspect_call(call)
+            self.inspect_call(borrow_signatures, call)
         }
     }
 
-    fn inspect_call(&mut self, call: &'a Call<'a>) {
+    fn inspect_call(&mut self, borrow_signatures: &mut BorrowSignatures<'a>, call: &'a Call<'a>) {
         let Call {
             call_type,
             arguments,
         } = call;
 
         match call_type {
-            CallType::ByName { name: _, .. } => {
-                // TODO ownership should depend on the borrow signature of the called function
-                for argument in arguments.iter() {
-                    self.mark_owned(*argument)
+            CallType::ByName {
+                name,
+                arg_layouts,
+                ret_layout,
+                ..
+            } => {
+                let proc_layout = ProcLayout {
+                    arguments: arg_layouts,
+                    result: *ret_layout,
+                    niche: Niche::NONE,
+                };
+
+                let borrow_signature = match borrow_signatures.get(&(name.name(), proc_layout)) {
+                    Some(s) => s,
+                    None => todo!("no borrow signature for function/layout"),
+                };
+
+                for (argument, ownership) in arguments.iter().zip(borrow_signature.iter()) {
+                    if let Ownership::Owned = ownership {
+                        self.mark_owned(*argument);
+                    }
                 }
             }
             CallType::LowLevel { op, .. } => {
@@ -129,6 +302,113 @@ impl<'a> State<'a> {
             CallType::ByPointer { .. } | CallType::Foreign { .. } | CallType::HigherOrder(_) => {
                 for argument in arguments.iter() {
                     self.mark_owned(*argument)
+                }
+            }
+        }
+    }
+}
+
+fn construct_reference_matrix<'a>(
+    arena: &'a Bump,
+    procs: &MutMap<(Symbol, ProcLayout<'a>), Proc<'a>>,
+) -> ReferenceMatrix {
+    let mut matrix = ReferenceMatrix::new(procs.len());
+
+    let mut call_info = CallInfo::new(arena);
+
+    for (row, proc) in procs.values().enumerate() {
+        call_info.clear();
+        call_info.stmt(arena, &proc.body);
+
+        for key in call_info.keys.iter() {
+            // the same symbol can be in `keys` multiple times (with different layouts)
+            for (col, (k, _)) in procs.keys().enumerate() {
+                if k == key {
+                    matrix.set_row_col(row, col, true);
+                }
+            }
+        }
+    }
+
+    matrix
+}
+
+struct CallInfo<'a> {
+    keys: Vec<'a, Symbol>,
+}
+
+impl<'a> CallInfo<'a> {
+    fn new(arena: &'a Bump) -> Self {
+        CallInfo {
+            keys: Vec::new_in(arena),
+        }
+    }
+
+    fn clear(&mut self) {
+        self.keys.clear()
+    }
+
+    fn call(&mut self, call: &crate::ir::Call<'a>) {
+        use crate::ir::CallType::*;
+        use crate::ir::HigherOrderLowLevel;
+        use crate::ir::PassedFunction;
+
+        match call.call_type {
+            ByName { name, .. } => {
+                self.keys.push(name.name());
+            }
+            ByPointer { .. } => {
+                todo_lambda_erasure!()
+            }
+            Foreign { .. } => {}
+            LowLevel { .. } => {}
+            HigherOrder(HigherOrderLowLevel {
+                passed_function: PassedFunction { name, .. },
+                ..
+            }) => {
+                self.keys.push(name.name());
+            }
+        }
+    }
+
+    fn stmt(&mut self, arena: &'a Bump, stmt: &Stmt<'a>) {
+        use Stmt::*;
+
+        let mut stack = bumpalo::vec![in arena; stmt];
+
+        while let Some(stmt) = stack.pop() {
+            match stmt {
+                Join {
+                    remainder: v,
+                    body: b,
+                    ..
+                } => {
+                    stack.push(v);
+                    stack.push(b);
+                }
+                Let(_, expr, _, cont) => {
+                    if let Expr::Call(call) = expr {
+                        self.call(call);
+                    }
+                    stack.push(cont);
+                }
+                Switch {
+                    branches,
+                    default_branch,
+                    ..
+                } => {
+                    stack.extend(branches.iter().map(|b| &b.2));
+                    stack.push(default_branch.1);
+                }
+
+                Dbg { remainder, .. } => stack.push(remainder),
+                Expect { remainder, .. } => stack.push(remainder),
+                ExpectFx { remainder, .. } => stack.push(remainder),
+
+                Refcounting(_, _) => unreachable!("these have not been introduced yet"),
+
+                Ret(_) | Jump(_, _) | Crash(..) => {
+                    // these are terminal, do nothing
                 }
             }
         }

--- a/crates/compiler/mono/src/borrow.rs
+++ b/crates/compiler/mono/src/borrow.rs
@@ -361,7 +361,7 @@ impl<'a> CallInfo<'a> {
                 self.keys.push(name.name());
             }
             ByPointer { .. } => {
-                todo_lambda_erasure!()
+                // nothing to be done
             }
             Foreign { .. } => {}
             LowLevel { .. } => {}

--- a/crates/compiler/mono/src/inc_dec.rs
+++ b/crates/compiler/mono/src/inc_dec.rs
@@ -15,13 +15,12 @@ use roc_module::low_level::LowLevel;
 use roc_module::{low_level::LowLevelWrapperType, symbol::Symbol};
 
 use crate::ir::ErasedField;
-use crate::layout::{LambdaName, Niche};
 use crate::{
     ir::{
         BranchInfo, Call, CallType, Expr, HigherOrderLowLevel, JoinPointId, ListLiteralElement,
         ModifyRc, Param, Proc, ProcLayout, Stmt,
     },
-    layout::{InLayout, LayoutInterner, STLayoutInterner},
+    layout::{InLayout, LayoutInterner, Niche, STLayoutInterner},
     low_level::HigherOrder,
 };
 

--- a/crates/compiler/mono/src/ir.rs
+++ b/crates/compiler/mono/src/ir.rs
@@ -396,6 +396,16 @@ impl<'a> Proc<'a> {
         w.push(b'\n');
         String::from_utf8(w).unwrap()
     }
+
+    pub fn proc_layout(&self, arena: &'a Bump) -> ProcLayout<'a> {
+        let args = Vec::from_iter_in(self.args.iter().map(|(a, b)| *a), arena);
+
+        ProcLayout {
+            arguments: args.into_bump_slice(),
+            result: self.ret_layout,
+            niche: Niche::NONE,
+        }
+    }
 }
 
 /// A host-exposed function must be specialized; it's a seed for subsequent specializations

--- a/crates/compiler/mono/src/ir.rs
+++ b/crates/compiler/mono/src/ir.rs
@@ -398,7 +398,7 @@ impl<'a> Proc<'a> {
     }
 
     pub fn proc_layout(&self, arena: &'a Bump) -> ProcLayout<'a> {
-        let args = Vec::from_iter_in(self.args.iter().map(|(a, b)| *a), arena);
+        let args = Vec::from_iter_in(self.args.iter().map(|(a, _)| *a), arena);
 
         ProcLayout {
             arguments: args.into_bump_slice(),

--- a/crates/compiler/test_mono/generated/anonymous_closure_in_polymorphic_expression_issue_4717.txt
+++ b/crates/compiler/test_mono/generated/anonymous_closure_in_polymorphic_expression_issue_4717.txt
@@ -6,10 +6,12 @@ procedure List.103 (List.487, List.488, List.489):
     let List.590 : U64 = 0i64;
     let List.591 : U64 = CallByName List.6 List.487;
     let List.589 : [C U64, C U64] = CallByName List.80 List.487 List.488 List.489 List.590 List.591;
+    dec List.487;
     ret List.589;
 
 procedure List.26 (List.200, List.201, List.202):
     let List.583 : [C U64, C U64] = CallByName List.103 List.200 List.201 List.202;
+    dec List.200;
     let List.586 : U8 = 1i64;
     let List.587 : U8 = GetTagId List.583;
     let List.588 : Int1 = lowlevel Eq List.586 List.587;
@@ -92,7 +94,6 @@ procedure Num.77 (#Attr.2, #Attr.3):
 procedure Test.1 (Test.2):
     let Test.13 : U64 = 0i64;
     let Test.14 : {} = Struct {};
-    inc Test.2;
     let Test.3 : U64 = CallByName List.26 Test.2 Test.13 Test.14;
     let Test.12 : U64 = 0i64;
     let Test.10 : Int1 = CallByName Bool.11 Test.3 Test.12;

--- a/crates/compiler/test_mono/generated/anonymous_closure_in_polymorphic_expression_issue_4717.txt
+++ b/crates/compiler/test_mono/generated/anonymous_closure_in_polymorphic_expression_issue_4717.txt
@@ -6,12 +6,10 @@ procedure List.103 (List.487, List.488, List.489):
     let List.590 : U64 = 0i64;
     let List.591 : U64 = CallByName List.6 List.487;
     let List.589 : [C U64, C U64] = CallByName List.80 List.487 List.488 List.489 List.590 List.591;
-    dec List.487;
     ret List.589;
 
 procedure List.26 (List.200, List.201, List.202):
     let List.583 : [C U64, C U64] = CallByName List.103 List.200 List.201 List.202;
-    dec List.200;
     let List.586 : U8 = 1i64;
     let List.587 : U8 = GetTagId List.583;
     let List.588 : Int1 = lowlevel Eq List.586 List.587;
@@ -77,6 +75,7 @@ procedure List.80 (#Derived_gen.0, #Derived_gen.1, #Derived_gen.2, #Derived_gen.
             let List.593 : [C U64, C U64] = TagId(1) List.491;
             ret List.593;
     in
+    inc #Derived_gen.0;
     jump List.592 #Derived_gen.0 #Derived_gen.1 #Derived_gen.2 #Derived_gen.3 #Derived_gen.4;
 
 procedure Num.22 (#Attr.2, #Attr.3):

--- a/crates/compiler/test_mono/generated/capture_void_layout_task.txt
+++ b/crates/compiler/test_mono/generated/capture_void_layout_task.txt
@@ -2,6 +2,7 @@ procedure List.18 (List.159, List.160, List.161):
     let List.573 : U64 = 0i64;
     let List.574 : U64 = CallByName List.6 List.159;
     let List.572 : [<r>C {}, C *self {{}, []}] = CallByName List.91 List.159 List.160 List.161 List.573 List.574;
+    dec List.159;
     ret List.572;
 
 procedure List.6 (#Attr.2):
@@ -133,6 +134,7 @@ procedure Test.6 (Test.27, Test.28):
     let Test.67 : {} = Struct {};
     let Test.38 : [<r>C {}, C *self {{}, []}] = CallByName Test.3 Test.67;
     let Test.37 : [<r>C {}, C *self {{}, []}] = CallByName List.18 Test.27 Test.38 Test.28;
+    dec Test.27;
     ret Test.37;
 
 procedure Test.81 (Test.82):
@@ -163,4 +165,5 @@ procedure Test.0 ():
     let Test.35 : List [] = Array [];
     let Test.36 : {} = Struct {};
     let Test.34 : [<r>C {}, C *self {{}, []}] = CallByName Test.6 Test.35 Test.36;
+    dec Test.35;
     ret Test.34;

--- a/crates/compiler/test_mono/generated/capture_void_layout_task.txt
+++ b/crates/compiler/test_mono/generated/capture_void_layout_task.txt
@@ -2,7 +2,6 @@ procedure List.18 (List.159, List.160, List.161):
     let List.573 : U64 = 0i64;
     let List.574 : U64 = CallByName List.6 List.159;
     let List.572 : [<r>C {}, C *self {{}, []}] = CallByName List.91 List.159 List.160 List.161 List.573 List.574;
-    dec List.159;
     ret List.572;
 
 procedure List.6 (#Attr.2):
@@ -26,6 +25,7 @@ procedure List.91 (#Derived_gen.9, #Derived_gen.10, #Derived_gen.11, #Derived_ge
             dec List.162;
             ret List.163;
     in
+    inc #Derived_gen.9;
     jump List.575 #Derived_gen.9 #Derived_gen.10 #Derived_gen.11 #Derived_gen.12 #Derived_gen.13;
 
 procedure Num.22 (#Attr.2, #Attr.3):
@@ -134,7 +134,6 @@ procedure Test.6 (Test.27, Test.28):
     let Test.67 : {} = Struct {};
     let Test.38 : [<r>C {}, C *self {{}, []}] = CallByName Test.3 Test.67;
     let Test.37 : [<r>C {}, C *self {{}, []}] = CallByName List.18 Test.27 Test.38 Test.28;
-    dec Test.27;
     ret Test.37;
 
 procedure Test.81 (Test.82):

--- a/crates/compiler/test_mono/generated/choose_correct_recursion_var_under_record.txt
+++ b/crates/compiler/test_mono/generated/choose_correct_recursion_var_under_record.txt
@@ -33,6 +33,7 @@ procedure List.66 (#Attr.2, #Attr.3):
 procedure List.9 (List.334):
     let List.579 : U64 = 0i64;
     let List.572 : [C {}, C Str] = CallByName List.2 List.334 List.579;
+    dec List.334;
     let List.576 : U8 = 1i64;
     let List.577 : U8 = GetTagId List.572;
     let List.578 : Int1 = lowlevel Eq List.576 List.577;
@@ -102,6 +103,7 @@ procedure Test.2 (Test.6):
             let Test.24 : {} = Struct {};
             let Test.23 : List Str = CallByName List.5 Test.9 Test.24;
             let Test.21 : [C {}, C Str] = CallByName List.9 Test.23;
+            dec Test.23;
             let Test.22 : Str = "foo";
             let Test.20 : Str = CallByName Result.5 Test.21 Test.22;
             ret Test.20;

--- a/crates/compiler/test_mono/generated/choose_correct_recursion_var_under_record.txt
+++ b/crates/compiler/test_mono/generated/choose_correct_recursion_var_under_record.txt
@@ -8,11 +8,9 @@ procedure List.2 (List.107, List.108):
     if List.582 then
         let List.584 : Str = CallByName List.66 List.107 List.108;
         inc List.584;
-        dec List.107;
         let List.583 : [C {}, C Str] = TagId(1) List.584;
         ret List.583;
     else
-        dec List.107;
         let List.581 : {} = Struct {};
         let List.580 : [C {}, C Str] = TagId(0) List.581;
         ret List.580;
@@ -33,7 +31,6 @@ procedure List.66 (#Attr.2, #Attr.3):
 procedure List.9 (List.334):
     let List.579 : U64 = 0i64;
     let List.572 : [C {}, C Str] = CallByName List.2 List.334 List.579;
-    dec List.334;
     let List.576 : U8 = 1i64;
     let List.577 : U8 = GetTagId List.572;
     let List.578 : Int1 = lowlevel Eq List.576 List.577;

--- a/crates/compiler/test_mono/generated/compose_recursive_lambda_set_productive_nullable_wrapped.txt
+++ b/crates/compiler/test_mono/generated/compose_recursive_lambda_set_productive_nullable_wrapped.txt
@@ -6,6 +6,7 @@ procedure List.18 (List.159, List.160, List.161):
     let List.573 : U64 = 0i64;
     let List.574 : U64 = CallByName List.6 List.159;
     let List.572 : [<rnw><null>, C *self Int1, C *self Int1] = CallByName List.91 List.159 List.160 List.161 List.573 List.574;
+    dec List.159;
     ret List.572;
 
 procedure List.6 (#Attr.2):
@@ -142,6 +143,7 @@ procedure Test.9 (Test.10, #Attr.12):
         
             default:
                 let Test.41 : Str = CallByName Test.11 Test.10 Test.42;
+                dec Test.10;
                 jump Test.40 Test.41;
         
     in
@@ -162,6 +164,7 @@ procedure Test.0 ():
     let Test.23 : Int1 = CallByName Bool.2;
     let Test.22 : Int1 = CallByName Test.1 Test.23;
     let Test.16 : [<rnw><null>, C *self Int1, C *self Int1] = CallByName List.18 Test.20 Test.21 Test.22;
+    dec Test.20;
     let Test.18 : Str = "hello";
     let Test.19 : U8 = GetTagId Test.16;
     switch Test.19:
@@ -176,5 +179,6 @@ procedure Test.0 ():
     
         default:
             let Test.17 : Str = CallByName Test.11 Test.18 Test.16;
+            dec Test.18;
             ret Test.17;
     

--- a/crates/compiler/test_mono/generated/compose_recursive_lambda_set_productive_nullable_wrapped.txt
+++ b/crates/compiler/test_mono/generated/compose_recursive_lambda_set_productive_nullable_wrapped.txt
@@ -6,7 +6,6 @@ procedure List.18 (List.159, List.160, List.161):
     let List.573 : U64 = 0i64;
     let List.574 : U64 = CallByName List.6 List.159;
     let List.572 : [<rnw><null>, C *self Int1, C *self Int1] = CallByName List.91 List.159 List.160 List.161 List.573 List.574;
-    dec List.159;
     ret List.572;
 
 procedure List.6 (#Attr.2):
@@ -30,6 +29,7 @@ procedure List.91 (#Derived_gen.7, #Derived_gen.8, #Derived_gen.9, #Derived_gen.
             dec List.162;
             ret List.163;
     in
+    inc #Derived_gen.7;
     jump List.575 #Derived_gen.7 #Derived_gen.8 #Derived_gen.9 #Derived_gen.10 #Derived_gen.11;
 
 procedure Num.22 (#Attr.2, #Attr.3):
@@ -51,7 +51,7 @@ procedure Test.11 (#Derived_gen.3, #Derived_gen.4):
     joinpoint Test.27 Test.12 #Attr.12:
         let Test.34 : Int1 = UnionAtIndex (Id 2) (Index 1) #Attr.12;
         let Test.33 : [<rnw><null>, C *self Int1, C *self Int1] = UnionAtIndex (Id 2) (Index 0) #Attr.12;
-        joinpoint #Derived_gen.12:
+        joinpoint #Derived_gen.14:
             joinpoint Test.31 Test.29:
                 let Test.30 : U8 = GetTagId Test.33;
                 switch Test.30:
@@ -78,15 +78,16 @@ procedure Test.11 (#Derived_gen.3, #Derived_gen.4):
                     jump Test.31 Test.32;
             
         in
-        let #Derived_gen.13 : Int1 = lowlevel RefCountIsUnique #Attr.12;
-        if #Derived_gen.13 then
+        let #Derived_gen.15 : Int1 = lowlevel RefCountIsUnique #Attr.12;
+        if #Derived_gen.15 then
             free #Attr.12;
-            jump #Derived_gen.12;
+            jump #Derived_gen.14;
         else
             inc Test.33;
             decref #Attr.12;
-            jump #Derived_gen.12;
+            jump #Derived_gen.14;
     in
+    inc #Derived_gen.3;
     jump Test.27 #Derived_gen.3 #Derived_gen.4;
 
 procedure Test.2 (Test.13):
@@ -118,7 +119,7 @@ procedure Test.6 (Test.7, Test.8, Test.5):
 procedure Test.9 (Test.10, #Attr.12):
     let Test.43 : Int1 = UnionAtIndex (Id 1) (Index 1) #Attr.12;
     let Test.42 : [<rnw><null>, C *self Int1, C *self Int1] = UnionAtIndex (Id 1) (Index 0) #Attr.12;
-    joinpoint #Derived_gen.14:
+    joinpoint #Derived_gen.16:
         let Test.39 : U8 = GetTagId Test.42;
         joinpoint Test.40 Test.38:
             switch Test.43:
@@ -147,14 +148,14 @@ procedure Test.9 (Test.10, #Attr.12):
                 jump Test.40 Test.41;
         
     in
-    let #Derived_gen.15 : Int1 = lowlevel RefCountIsUnique #Attr.12;
-    if #Derived_gen.15 then
+    let #Derived_gen.17 : Int1 = lowlevel RefCountIsUnique #Attr.12;
+    if #Derived_gen.17 then
         free #Attr.12;
-        jump #Derived_gen.14;
+        jump #Derived_gen.16;
     else
         inc Test.42;
         decref #Attr.12;
-        jump #Derived_gen.14;
+        jump #Derived_gen.16;
 
 procedure Test.0 ():
     let Test.45 : Int1 = false;

--- a/crates/compiler/test_mono/generated/dbg_in_expect.txt
+++ b/crates/compiler/test_mono/generated/dbg_in_expect.txt
@@ -7,7 +7,6 @@ procedure Inspect.246 (Inspect.247, Inspect.245):
     let Inspect.318 : Str = CallByName Inspect.59 Inspect.247 Inspect.319;
     dec Inspect.319;
     let Inspect.314 : Str = CallByName Inspect.59 Inspect.318 Inspect.245;
-    dec Inspect.245;
     let Inspect.315 : Str = "\"";
     let Inspect.313 : Str = CallByName Inspect.59 Inspect.314 Inspect.315;
     dec Inspect.315;
@@ -39,7 +38,6 @@ procedure Inspect.5 (Inspect.146):
 
 procedure Inspect.59 (Inspect.296, Inspect.292):
     let Inspect.317 : Str = CallByName Str.3 Inspect.296 Inspect.292;
-    dec Inspect.292;
     ret Inspect.317;
 
 procedure Inspect.60 (Inspect.298):

--- a/crates/compiler/test_mono/generated/dbg_in_expect.txt
+++ b/crates/compiler/test_mono/generated/dbg_in_expect.txt
@@ -5,9 +5,12 @@ procedure Bool.2 ():
 procedure Inspect.246 (Inspect.247, Inspect.245):
     let Inspect.319 : Str = "\"";
     let Inspect.318 : Str = CallByName Inspect.59 Inspect.247 Inspect.319;
+    dec Inspect.319;
     let Inspect.314 : Str = CallByName Inspect.59 Inspect.318 Inspect.245;
+    dec Inspect.245;
     let Inspect.315 : Str = "\"";
     let Inspect.313 : Str = CallByName Inspect.59 Inspect.314 Inspect.315;
+    dec Inspect.315;
     ret Inspect.313;
 
 procedure Inspect.30 (Inspect.143):
@@ -31,6 +34,7 @@ procedure Inspect.5 (Inspect.146):
     let Inspect.305 : {} = Struct {};
     let Inspect.304 : Str = CallByName Inspect.35 Inspect.305;
     let Inspect.303 : Str = CallByName Inspect.246 Inspect.304 Inspect.308;
+    dec Inspect.308;
     ret Inspect.303;
 
 procedure Inspect.59 (Inspect.296, Inspect.292):

--- a/crates/compiler/test_mono/generated/dbg_str_followed_by_number.txt
+++ b/crates/compiler/test_mono/generated/dbg_str_followed_by_number.txt
@@ -3,7 +3,6 @@ procedure Inspect.246 (Inspect.247, Inspect.245):
     let Inspect.318 : Str = CallByName Inspect.59 Inspect.247 Inspect.319;
     dec Inspect.319;
     let Inspect.314 : Str = CallByName Inspect.59 Inspect.318 Inspect.245;
-    dec Inspect.245;
     let Inspect.315 : Str = "\"";
     let Inspect.313 : Str = CallByName Inspect.59 Inspect.314 Inspect.315;
     dec Inspect.315;
@@ -35,7 +34,6 @@ procedure Inspect.5 (Inspect.146):
 
 procedure Inspect.59 (Inspect.296, Inspect.292):
     let Inspect.317 : Str = CallByName Str.3 Inspect.296 Inspect.292;
-    dec Inspect.292;
     ret Inspect.317;
 
 procedure Inspect.60 (Inspect.298):

--- a/crates/compiler/test_mono/generated/dbg_str_followed_by_number.txt
+++ b/crates/compiler/test_mono/generated/dbg_str_followed_by_number.txt
@@ -1,9 +1,12 @@
 procedure Inspect.246 (Inspect.247, Inspect.245):
     let Inspect.319 : Str = "\"";
     let Inspect.318 : Str = CallByName Inspect.59 Inspect.247 Inspect.319;
+    dec Inspect.319;
     let Inspect.314 : Str = CallByName Inspect.59 Inspect.318 Inspect.245;
+    dec Inspect.245;
     let Inspect.315 : Str = "\"";
     let Inspect.313 : Str = CallByName Inspect.59 Inspect.314 Inspect.315;
+    dec Inspect.315;
     ret Inspect.313;
 
 procedure Inspect.30 (Inspect.143):
@@ -27,6 +30,7 @@ procedure Inspect.5 (Inspect.146):
     let Inspect.305 : {} = Struct {};
     let Inspect.304 : Str = CallByName Inspect.35 Inspect.305;
     let Inspect.303 : Str = CallByName Inspect.246 Inspect.304 Inspect.308;
+    dec Inspect.308;
     ret Inspect.303;
 
 procedure Inspect.59 (Inspect.296, Inspect.292):

--- a/crates/compiler/test_mono/generated/empty_list_of_function_type.txt
+++ b/crates/compiler/test_mono/generated/empty_list_of_function_type.txt
@@ -7,11 +7,9 @@ procedure List.2 (List.107, List.108):
     let List.574 : Int1 = CallByName Num.22 List.108 List.578;
     if List.574 then
         let List.576 : {} = CallByName List.66 List.107 List.108;
-        dec List.107;
         let List.575 : [C {}, C {}] = TagId(1) List.576;
         ret List.575;
     else
-        dec List.107;
         let List.573 : {} = Struct {};
         let List.572 : [C {}, C {}] = TagId(0) List.573;
         ret List.572;
@@ -29,7 +27,6 @@ procedure Num.22 (#Attr.2, #Attr.3):
     ret Num.269;
 
 procedure Test.2 (Test.5):
-    dec Test.5;
     let Test.17 : Str = "bar";
     ret Test.17;
 

--- a/crates/compiler/test_mono/generated/empty_list_of_function_type.txt
+++ b/crates/compiler/test_mono/generated/empty_list_of_function_type.txt
@@ -38,6 +38,7 @@ procedure Test.0 ():
     joinpoint Test.15 Test.3:
         let Test.13 : U64 = 0i64;
         let Test.6 : [C {}, C {}] = CallByName List.2 Test.3 Test.13;
+        dec Test.3;
         let Test.10 : U8 = 1i64;
         let Test.11 : U8 = GetTagId Test.6;
         let Test.12 : Int1 = lowlevel Eq Test.10 Test.11;
@@ -45,6 +46,7 @@ procedure Test.0 ():
             let Test.4 : {} = UnionAtIndex (Id 1) (Index 0) Test.6;
             let Test.8 : Str = "foo";
             let Test.7 : Str = CallByName Test.2 Test.8;
+            dec Test.8;
             ret Test.7;
         else
             let Test.9 : Str = "bad!";

--- a/crates/compiler/test_mono/generated/encode_derived_nested_record_string.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_nested_record_string.txt
@@ -9,6 +9,8 @@ procedure #Derived.2 (#Derived.3, #Derived.4, #Derived.1):
     let #Derived_gen.5 : List {Str, Str} = Array [#Derived_gen.6];
     let #Derived_gen.4 : List {Str, Str} = CallByName TotallyNotJson.29 #Derived_gen.5;
     let #Derived_gen.3 : List U8 = CallByName Encode.24 #Derived.3 #Derived_gen.4 #Derived.4;
+    dec #Derived_gen.4;
+    dec #Derived.3;
     ret #Derived_gen.3;
 
 procedure #Derived.5 (#Derived.6):
@@ -22,6 +24,7 @@ procedure #Derived.7 (#Derived.8, #Derived.9, #Derived.6):
     let #Derived_gen.15 : List {Str, Str} = Array [#Derived_gen.16];
     let #Derived_gen.14 : List {Str, Str} = CallByName TotallyNotJson.29 #Derived_gen.15;
     let #Derived_gen.13 : List U8 = CallByName Encode.24 #Derived.8 #Derived_gen.14 #Derived.9;
+    dec #Derived_gen.14;
     ret #Derived_gen.13;
 
 procedure Encode.23 (Encode.98):
@@ -41,10 +44,12 @@ procedure Encode.23 (Encode.98):
 
 procedure Encode.24 (Encode.99, Encode.107, Encode.101):
     let Encode.111 : List U8 = CallByName #Derived.2 Encode.99 Encode.101 Encode.107;
+    dec Encode.99;
     ret Encode.111;
 
 procedure Encode.24 (Encode.99, Encode.107, Encode.101):
     let Encode.113 : List U8 = CallByName TotallyNotJson.201 Encode.99 Encode.101 Encode.107;
+    dec Encode.107;
     ret Encode.113;
 
 procedure Encode.24 (Encode.99, Encode.107, Encode.101):
@@ -53,44 +58,53 @@ procedure Encode.24 (Encode.99, Encode.107, Encode.101):
 
 procedure Encode.24 (Encode.99, Encode.107, Encode.101):
     let Encode.117 : List U8 = CallByName TotallyNotJson.201 Encode.99 Encode.101 Encode.107;
+    dec Encode.107;
     ret Encode.117;
 
 procedure Encode.24 (Encode.99, Encode.107, Encode.101):
     let Encode.120 : List U8 = CallByName TotallyNotJson.150 Encode.99 Encode.101 Encode.107;
+    dec Encode.107;
     ret Encode.120;
 
 procedure Encode.26 (Encode.105, Encode.106):
     let Encode.109 : List U8 = Array [];
     let Encode.110 : Str = CallByName #Derived.0 Encode.105;
     let Encode.108 : List U8 = CallByName Encode.24 Encode.109 Encode.110 Encode.106;
+    dec Encode.109;
     ret Encode.108;
 
 procedure List.103 (List.487, List.488, List.489):
     let List.683 : U64 = 0i64;
     let List.684 : U64 = CallByName List.6 List.487;
     let List.682 : [C {U64, Int1}, C {U64, Int1}] = CallByName List.80 List.487 List.488 List.489 List.683 List.684;
+    dec List.487;
     ret List.682;
 
 procedure List.18 (List.159, List.160, List.161):
     let List.593 : U64 = 0i64;
     let List.594 : U64 = CallByName List.6 List.159;
     let List.592 : {List U8, U64} = CallByName List.91 List.159 List.160 List.161 List.593 List.594;
+    dec List.159;
     ret List.592;
 
 procedure List.18 (List.159, List.160, List.161):
     let List.627 : U64 = 0i64;
     let List.628 : U64 = CallByName List.6 List.159;
     let List.626 : {List U8, U64} = CallByName List.91 List.159 List.160 List.161 List.627 List.628;
+    dec List.159;
     ret List.626;
 
 procedure List.18 (List.159, List.160, List.161):
     let List.639 : U64 = 0i64;
     let List.640 : U64 = CallByName List.6 List.159;
     let List.638 : List U8 = CallByName List.91 List.159 List.160 List.161 List.639 List.640;
+    dec List.160;
+    dec List.159;
     ret List.638;
 
 procedure List.26 (List.200, List.201, List.202):
     let List.676 : [C {U64, Int1}, C {U64, Int1}] = CallByName List.103 List.200 List.201 List.202;
+    dec List.200;
     let List.679 : U8 = 1i64;
     let List.680 : U8 = GetTagId List.676;
     let List.681 : Int1 = lowlevel Eq List.679 List.680;
@@ -387,6 +401,7 @@ procedure TotallyNotJson.201 (TotallyNotJson.202, TotallyNotJson.973, TotallyNot
     let TotallyNotJson.981 : {List U8, U64} = Struct {TotallyNotJson.204, TotallyNotJson.1004};
     let TotallyNotJson.982 : {} = Struct {};
     let TotallyNotJson.980 : {List U8, U64} = CallByName List.18 TotallyNotJson.200 TotallyNotJson.981 TotallyNotJson.982;
+    dec TotallyNotJson.200;
     let TotallyNotJson.206 : List U8 = StructAtIndex 0 TotallyNotJson.980;
     let TotallyNotJson.979 : I64 = 125i64;
     let TotallyNotJson.978 : U8 = CallByName Num.127 TotallyNotJson.979;
@@ -401,6 +416,7 @@ procedure TotallyNotJson.201 (TotallyNotJson.202, TotallyNotJson.973, TotallyNot
     let TotallyNotJson.1015 : {List U8, U64} = Struct {TotallyNotJson.204, TotallyNotJson.1038};
     let TotallyNotJson.1016 : {} = Struct {};
     let TotallyNotJson.1014 : {List U8, U64} = CallByName List.18 TotallyNotJson.200 TotallyNotJson.1015 TotallyNotJson.1016;
+    dec TotallyNotJson.200;
     let TotallyNotJson.206 : List U8 = StructAtIndex 0 TotallyNotJson.1014;
     let TotallyNotJson.1013 : I64 = 125i64;
     let TotallyNotJson.1012 : U8 = CallByName Num.127 TotallyNotJson.1013;
@@ -425,6 +441,8 @@ procedure TotallyNotJson.203 (TotallyNotJson.975, TotallyNotJson.976):
     let TotallyNotJson.992 : List U8 = CallByName List.4 TotallyNotJson.994 TotallyNotJson.995;
     let TotallyNotJson.993 : {} = Struct {};
     let TotallyNotJson.212 : List U8 = CallByName Encode.24 TotallyNotJson.992 TotallyNotJson.210 TotallyNotJson.993;
+    dec TotallyNotJson.992;
+    dec TotallyNotJson.210;
     joinpoint TotallyNotJson.987 TotallyNotJson.213:
         let TotallyNotJson.985 : U64 = 1i64;
         let TotallyNotJson.984 : U64 = CallByName Num.20 TotallyNotJson.208 TotallyNotJson.985;
@@ -459,6 +477,8 @@ procedure TotallyNotJson.203 (TotallyNotJson.975, TotallyNotJson.976):
     let TotallyNotJson.1026 : List U8 = CallByName List.4 TotallyNotJson.1028 TotallyNotJson.1029;
     let TotallyNotJson.1027 : {} = Struct {};
     let TotallyNotJson.212 : List U8 = CallByName Encode.24 TotallyNotJson.1026 TotallyNotJson.210 TotallyNotJson.1027;
+    dec TotallyNotJson.210;
+    dec TotallyNotJson.1026;
     joinpoint TotallyNotJson.1021 TotallyNotJson.213:
         let TotallyNotJson.1019 : U64 = 1i64;
         let TotallyNotJson.1018 : U64 = CallByName Num.20 TotallyNotJson.208 TotallyNotJson.1019;
@@ -485,7 +505,6 @@ procedure TotallyNotJson.26 (TotallyNotJson.152):
     let TotallyNotJson.1124 : Int1 = true;
     let TotallyNotJson.154 : {U64, Int1} = Struct {TotallyNotJson.1123, TotallyNotJson.1124};
     let TotallyNotJson.1093 : {} = Struct {};
-    inc TotallyNotJson.153;
     let TotallyNotJson.155 : {U64, Int1} = CallByName List.26 TotallyNotJson.153 TotallyNotJson.154 TotallyNotJson.1093;
     let TotallyNotJson.1047 : Int1 = StructAtIndex 1 TotallyNotJson.155;
     let TotallyNotJson.1091 : Int1 = true;
@@ -504,8 +523,8 @@ procedure TotallyNotJson.26 (TotallyNotJson.152):
         let TotallyNotJson.1048 : List U8 = CallByName List.8 TotallyNotJson.1049 TotallyNotJson.1050;
         ret TotallyNotJson.1048;
     else
-        inc TotallyNotJson.153;
         let TotallyNotJson.1090 : U64 = StructAtIndex 0 TotallyNotJson.155;
+        inc TotallyNotJson.153;
         let TotallyNotJson.1089 : {List U8, List U8} = CallByName List.52 TotallyNotJson.153 TotallyNotJson.1090;
         let TotallyNotJson.179 : List U8 = StructAtIndex 0 TotallyNotJson.1089;
         let TotallyNotJson.181 : List U8 = StructAtIndex 1 TotallyNotJson.1089;
@@ -522,6 +541,8 @@ procedure TotallyNotJson.26 (TotallyNotJson.152):
         let TotallyNotJson.182 : List U8 = CallByName List.8 TotallyNotJson.1080 TotallyNotJson.179;
         let TotallyNotJson.1063 : {} = Struct {};
         let TotallyNotJson.1060 : List U8 = CallByName List.18 TotallyNotJson.181 TotallyNotJson.182 TotallyNotJson.1063;
+        dec TotallyNotJson.182;
+        dec TotallyNotJson.181;
         let TotallyNotJson.1062 : U8 = 34i64;
         let TotallyNotJson.1061 : List U8 = Array [TotallyNotJson.1062];
         let TotallyNotJson.1059 : List U8 = CallByName List.8 TotallyNotJson.1060 TotallyNotJson.1061;

--- a/crates/compiler/test_mono/generated/encode_derived_nested_record_string.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_nested_record_string.txt
@@ -10,7 +10,6 @@ procedure #Derived.2 (#Derived.3, #Derived.4, #Derived.1):
     let #Derived_gen.4 : List {Str, Str} = CallByName TotallyNotJson.29 #Derived_gen.5;
     let #Derived_gen.3 : List U8 = CallByName Encode.24 #Derived.3 #Derived_gen.4 #Derived.4;
     dec #Derived_gen.4;
-    dec #Derived.3;
     ret #Derived_gen.3;
 
 procedure #Derived.5 (#Derived.6):
@@ -44,12 +43,10 @@ procedure Encode.23 (Encode.98):
 
 procedure Encode.24 (Encode.99, Encode.107, Encode.101):
     let Encode.111 : List U8 = CallByName #Derived.2 Encode.99 Encode.101 Encode.107;
-    dec Encode.99;
     ret Encode.111;
 
 procedure Encode.24 (Encode.99, Encode.107, Encode.101):
     let Encode.113 : List U8 = CallByName TotallyNotJson.201 Encode.99 Encode.101 Encode.107;
-    dec Encode.107;
     ret Encode.113;
 
 procedure Encode.24 (Encode.99, Encode.107, Encode.101):
@@ -58,53 +55,44 @@ procedure Encode.24 (Encode.99, Encode.107, Encode.101):
 
 procedure Encode.24 (Encode.99, Encode.107, Encode.101):
     let Encode.117 : List U8 = CallByName TotallyNotJson.201 Encode.99 Encode.101 Encode.107;
-    dec Encode.107;
     ret Encode.117;
 
 procedure Encode.24 (Encode.99, Encode.107, Encode.101):
     let Encode.120 : List U8 = CallByName TotallyNotJson.150 Encode.99 Encode.101 Encode.107;
-    dec Encode.107;
     ret Encode.120;
 
 procedure Encode.26 (Encode.105, Encode.106):
     let Encode.109 : List U8 = Array [];
     let Encode.110 : Str = CallByName #Derived.0 Encode.105;
     let Encode.108 : List U8 = CallByName Encode.24 Encode.109 Encode.110 Encode.106;
-    dec Encode.109;
     ret Encode.108;
 
 procedure List.103 (List.487, List.488, List.489):
     let List.683 : U64 = 0i64;
     let List.684 : U64 = CallByName List.6 List.487;
     let List.682 : [C {U64, Int1}, C {U64, Int1}] = CallByName List.80 List.487 List.488 List.489 List.683 List.684;
-    dec List.487;
     ret List.682;
 
 procedure List.18 (List.159, List.160, List.161):
     let List.593 : U64 = 0i64;
     let List.594 : U64 = CallByName List.6 List.159;
     let List.592 : {List U8, U64} = CallByName List.91 List.159 List.160 List.161 List.593 List.594;
-    dec List.159;
     ret List.592;
 
 procedure List.18 (List.159, List.160, List.161):
     let List.627 : U64 = 0i64;
     let List.628 : U64 = CallByName List.6 List.159;
     let List.626 : {List U8, U64} = CallByName List.91 List.159 List.160 List.161 List.627 List.628;
-    dec List.159;
     ret List.626;
 
 procedure List.18 (List.159, List.160, List.161):
     let List.639 : U64 = 0i64;
     let List.640 : U64 = CallByName List.6 List.159;
     let List.638 : List U8 = CallByName List.91 List.159 List.160 List.161 List.639 List.640;
-    dec List.160;
-    dec List.159;
     ret List.638;
 
 procedure List.26 (List.200, List.201, List.202):
     let List.676 : [C {U64, Int1}, C {U64, Int1}] = CallByName List.103 List.200 List.201 List.202;
-    dec List.200;
     let List.679 : U8 = 1i64;
     let List.680 : U8 = GetTagId List.676;
     let List.681 : Int1 = lowlevel Eq List.679 List.680;
@@ -214,6 +202,7 @@ procedure List.80 (#Derived_gen.31, #Derived_gen.32, #Derived_gen.33, #Derived_g
             let List.686 : [C {U64, Int1}, C {U64, Int1}] = TagId(1) List.491;
             ret List.686;
     in
+    inc #Derived_gen.31;
     jump List.685 #Derived_gen.31 #Derived_gen.32 #Derived_gen.33 #Derived_gen.34 #Derived_gen.35;
 
 procedure List.91 (#Derived_gen.23, #Derived_gen.24, #Derived_gen.25, #Derived_gen.26, #Derived_gen.27):
@@ -230,6 +219,7 @@ procedure List.91 (#Derived_gen.23, #Derived_gen.24, #Derived_gen.25, #Derived_g
             dec List.162;
             ret List.163;
     in
+    inc #Derived_gen.23;
     jump List.595 #Derived_gen.23 #Derived_gen.24 #Derived_gen.25 #Derived_gen.26 #Derived_gen.27;
 
 procedure List.91 (#Derived_gen.39, #Derived_gen.40, #Derived_gen.41, #Derived_gen.42, #Derived_gen.43):
@@ -245,6 +235,8 @@ procedure List.91 (#Derived_gen.39, #Derived_gen.40, #Derived_gen.41, #Derived_g
             dec List.162;
             ret List.163;
     in
+    inc #Derived_gen.40;
+    inc #Derived_gen.39;
     jump List.641 #Derived_gen.39 #Derived_gen.40 #Derived_gen.41 #Derived_gen.42 #Derived_gen.43;
 
 procedure List.91 (#Derived_gen.47, #Derived_gen.48, #Derived_gen.49, #Derived_gen.50, #Derived_gen.51):
@@ -261,6 +253,7 @@ procedure List.91 (#Derived_gen.47, #Derived_gen.48, #Derived_gen.49, #Derived_g
             dec List.162;
             ret List.163;
     in
+    inc #Derived_gen.47;
     jump List.629 #Derived_gen.47 #Derived_gen.48 #Derived_gen.49 #Derived_gen.50 #Derived_gen.51;
 
 procedure Num.127 (#Attr.2):
@@ -401,7 +394,6 @@ procedure TotallyNotJson.201 (TotallyNotJson.202, TotallyNotJson.973, TotallyNot
     let TotallyNotJson.981 : {List U8, U64} = Struct {TotallyNotJson.204, TotallyNotJson.1004};
     let TotallyNotJson.982 : {} = Struct {};
     let TotallyNotJson.980 : {List U8, U64} = CallByName List.18 TotallyNotJson.200 TotallyNotJson.981 TotallyNotJson.982;
-    dec TotallyNotJson.200;
     let TotallyNotJson.206 : List U8 = StructAtIndex 0 TotallyNotJson.980;
     let TotallyNotJson.979 : I64 = 125i64;
     let TotallyNotJson.978 : U8 = CallByName Num.127 TotallyNotJson.979;
@@ -416,7 +408,6 @@ procedure TotallyNotJson.201 (TotallyNotJson.202, TotallyNotJson.973, TotallyNot
     let TotallyNotJson.1015 : {List U8, U64} = Struct {TotallyNotJson.204, TotallyNotJson.1038};
     let TotallyNotJson.1016 : {} = Struct {};
     let TotallyNotJson.1014 : {List U8, U64} = CallByName List.18 TotallyNotJson.200 TotallyNotJson.1015 TotallyNotJson.1016;
-    dec TotallyNotJson.200;
     let TotallyNotJson.206 : List U8 = StructAtIndex 0 TotallyNotJson.1014;
     let TotallyNotJson.1013 : I64 = 125i64;
     let TotallyNotJson.1012 : U8 = CallByName Num.127 TotallyNotJson.1013;
@@ -441,8 +432,6 @@ procedure TotallyNotJson.203 (TotallyNotJson.975, TotallyNotJson.976):
     let TotallyNotJson.992 : List U8 = CallByName List.4 TotallyNotJson.994 TotallyNotJson.995;
     let TotallyNotJson.993 : {} = Struct {};
     let TotallyNotJson.212 : List U8 = CallByName Encode.24 TotallyNotJson.992 TotallyNotJson.210 TotallyNotJson.993;
-    dec TotallyNotJson.992;
-    dec TotallyNotJson.210;
     joinpoint TotallyNotJson.987 TotallyNotJson.213:
         let TotallyNotJson.985 : U64 = 1i64;
         let TotallyNotJson.984 : U64 = CallByName Num.20 TotallyNotJson.208 TotallyNotJson.985;
@@ -477,8 +466,6 @@ procedure TotallyNotJson.203 (TotallyNotJson.975, TotallyNotJson.976):
     let TotallyNotJson.1026 : List U8 = CallByName List.4 TotallyNotJson.1028 TotallyNotJson.1029;
     let TotallyNotJson.1027 : {} = Struct {};
     let TotallyNotJson.212 : List U8 = CallByName Encode.24 TotallyNotJson.1026 TotallyNotJson.210 TotallyNotJson.1027;
-    dec TotallyNotJson.210;
-    dec TotallyNotJson.1026;
     joinpoint TotallyNotJson.1021 TotallyNotJson.213:
         let TotallyNotJson.1019 : U64 = 1i64;
         let TotallyNotJson.1018 : U64 = CallByName Num.20 TotallyNotJson.208 TotallyNotJson.1019;

--- a/crates/compiler/test_mono/generated/encode_derived_record_one_field_string.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_record_one_field_string.txt
@@ -9,6 +9,7 @@ procedure #Derived.2 (#Derived.3, #Derived.4, #Derived.1):
     let #Derived_gen.5 : List {Str, Str} = Array [#Derived_gen.6];
     let #Derived_gen.4 : List {Str, Str} = CallByName TotallyNotJson.29 #Derived_gen.5;
     let #Derived_gen.3 : List U8 = CallByName Encode.24 #Derived.3 #Derived_gen.4 #Derived.4;
+    dec #Derived_gen.4;
     ret #Derived_gen.3;
 
 procedure Encode.23 (Encode.98):
@@ -26,38 +27,47 @@ procedure Encode.24 (Encode.99, Encode.107, Encode.101):
 
 procedure Encode.24 (Encode.99, Encode.107, Encode.101):
     let Encode.113 : List U8 = CallByName TotallyNotJson.201 Encode.99 Encode.101 Encode.107;
+    dec Encode.107;
     ret Encode.113;
 
 procedure Encode.24 (Encode.99, Encode.107, Encode.101):
     let Encode.116 : List U8 = CallByName TotallyNotJson.150 Encode.99 Encode.101 Encode.107;
+    dec Encode.107;
     ret Encode.116;
 
 procedure Encode.26 (Encode.105, Encode.106):
     let Encode.109 : List U8 = Array [];
     let Encode.110 : Str = CallByName #Derived.0 Encode.105;
     let Encode.108 : List U8 = CallByName Encode.24 Encode.109 Encode.110 Encode.106;
+    dec Encode.109;
+    dec Encode.110;
     ret Encode.108;
 
 procedure List.103 (List.487, List.488, List.489):
     let List.649 : U64 = 0i64;
     let List.650 : U64 = CallByName List.6 List.487;
     let List.648 : [C {U64, Int1}, C {U64, Int1}] = CallByName List.80 List.487 List.488 List.489 List.649 List.650;
+    dec List.487;
     ret List.648;
 
 procedure List.18 (List.159, List.160, List.161):
     let List.593 : U64 = 0i64;
     let List.594 : U64 = CallByName List.6 List.159;
     let List.592 : {List U8, U64} = CallByName List.91 List.159 List.160 List.161 List.593 List.594;
+    dec List.159;
     ret List.592;
 
 procedure List.18 (List.159, List.160, List.161):
     let List.605 : U64 = 0i64;
     let List.606 : U64 = CallByName List.6 List.159;
     let List.604 : List U8 = CallByName List.91 List.159 List.160 List.161 List.605 List.606;
+    dec List.160;
+    dec List.159;
     ret List.604;
 
 procedure List.26 (List.200, List.201, List.202):
     let List.642 : [C {U64, Int1}, C {U64, Int1}] = CallByName List.103 List.200 List.201 List.202;
+    dec List.200;
     let List.645 : U8 = 1i64;
     let List.646 : U8 = GetTagId List.642;
     let List.647 : Int1 = lowlevel Eq List.645 List.646;
@@ -330,6 +340,7 @@ procedure TotallyNotJson.201 (TotallyNotJson.202, TotallyNotJson.973, TotallyNot
     let TotallyNotJson.981 : {List U8, U64} = Struct {TotallyNotJson.204, TotallyNotJson.1004};
     let TotallyNotJson.982 : {} = Struct {};
     let TotallyNotJson.980 : {List U8, U64} = CallByName List.18 TotallyNotJson.200 TotallyNotJson.981 TotallyNotJson.982;
+    dec TotallyNotJson.200;
     let TotallyNotJson.206 : List U8 = StructAtIndex 0 TotallyNotJson.980;
     let TotallyNotJson.979 : I64 = 125i64;
     let TotallyNotJson.978 : U8 = CallByName Num.127 TotallyNotJson.979;
@@ -354,6 +365,7 @@ procedure TotallyNotJson.203 (TotallyNotJson.975, TotallyNotJson.976):
     let TotallyNotJson.992 : List U8 = CallByName List.4 TotallyNotJson.994 TotallyNotJson.995;
     let TotallyNotJson.993 : {} = Struct {};
     let TotallyNotJson.212 : List U8 = CallByName Encode.24 TotallyNotJson.992 TotallyNotJson.210 TotallyNotJson.993;
+    dec TotallyNotJson.210;
     joinpoint TotallyNotJson.987 TotallyNotJson.213:
         let TotallyNotJson.985 : U64 = 1i64;
         let TotallyNotJson.984 : U64 = CallByName Num.20 TotallyNotJson.208 TotallyNotJson.985;
@@ -380,7 +392,6 @@ procedure TotallyNotJson.26 (TotallyNotJson.152):
     let TotallyNotJson.1090 : Int1 = true;
     let TotallyNotJson.154 : {U64, Int1} = Struct {TotallyNotJson.1089, TotallyNotJson.1090};
     let TotallyNotJson.1059 : {} = Struct {};
-    inc TotallyNotJson.153;
     let TotallyNotJson.155 : {U64, Int1} = CallByName List.26 TotallyNotJson.153 TotallyNotJson.154 TotallyNotJson.1059;
     let TotallyNotJson.1013 : Int1 = StructAtIndex 1 TotallyNotJson.155;
     let TotallyNotJson.1057 : Int1 = true;
@@ -399,8 +410,8 @@ procedure TotallyNotJson.26 (TotallyNotJson.152):
         let TotallyNotJson.1014 : List U8 = CallByName List.8 TotallyNotJson.1015 TotallyNotJson.1016;
         ret TotallyNotJson.1014;
     else
-        inc TotallyNotJson.153;
         let TotallyNotJson.1056 : U64 = StructAtIndex 0 TotallyNotJson.155;
+        inc TotallyNotJson.153;
         let TotallyNotJson.1055 : {List U8, List U8} = CallByName List.52 TotallyNotJson.153 TotallyNotJson.1056;
         let TotallyNotJson.179 : List U8 = StructAtIndex 0 TotallyNotJson.1055;
         let TotallyNotJson.181 : List U8 = StructAtIndex 1 TotallyNotJson.1055;
@@ -417,6 +428,8 @@ procedure TotallyNotJson.26 (TotallyNotJson.152):
         let TotallyNotJson.182 : List U8 = CallByName List.8 TotallyNotJson.1046 TotallyNotJson.179;
         let TotallyNotJson.1029 : {} = Struct {};
         let TotallyNotJson.1026 : List U8 = CallByName List.18 TotallyNotJson.181 TotallyNotJson.182 TotallyNotJson.1029;
+        dec TotallyNotJson.182;
+        dec TotallyNotJson.181;
         let TotallyNotJson.1028 : U8 = 34i64;
         let TotallyNotJson.1027 : List U8 = Array [TotallyNotJson.1028];
         let TotallyNotJson.1025 : List U8 = CallByName List.8 TotallyNotJson.1026 TotallyNotJson.1027;

--- a/crates/compiler/test_mono/generated/encode_derived_record_one_field_string.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_record_one_field_string.txt
@@ -27,47 +27,38 @@ procedure Encode.24 (Encode.99, Encode.107, Encode.101):
 
 procedure Encode.24 (Encode.99, Encode.107, Encode.101):
     let Encode.113 : List U8 = CallByName TotallyNotJson.201 Encode.99 Encode.101 Encode.107;
-    dec Encode.107;
     ret Encode.113;
 
 procedure Encode.24 (Encode.99, Encode.107, Encode.101):
     let Encode.116 : List U8 = CallByName TotallyNotJson.150 Encode.99 Encode.101 Encode.107;
-    dec Encode.107;
     ret Encode.116;
 
 procedure Encode.26 (Encode.105, Encode.106):
     let Encode.109 : List U8 = Array [];
     let Encode.110 : Str = CallByName #Derived.0 Encode.105;
     let Encode.108 : List U8 = CallByName Encode.24 Encode.109 Encode.110 Encode.106;
-    dec Encode.109;
-    dec Encode.110;
     ret Encode.108;
 
 procedure List.103 (List.487, List.488, List.489):
     let List.649 : U64 = 0i64;
     let List.650 : U64 = CallByName List.6 List.487;
     let List.648 : [C {U64, Int1}, C {U64, Int1}] = CallByName List.80 List.487 List.488 List.489 List.649 List.650;
-    dec List.487;
     ret List.648;
 
 procedure List.18 (List.159, List.160, List.161):
     let List.593 : U64 = 0i64;
     let List.594 : U64 = CallByName List.6 List.159;
     let List.592 : {List U8, U64} = CallByName List.91 List.159 List.160 List.161 List.593 List.594;
-    dec List.159;
     ret List.592;
 
 procedure List.18 (List.159, List.160, List.161):
     let List.605 : U64 = 0i64;
     let List.606 : U64 = CallByName List.6 List.159;
     let List.604 : List U8 = CallByName List.91 List.159 List.160 List.161 List.605 List.606;
-    dec List.160;
-    dec List.159;
     ret List.604;
 
 procedure List.26 (List.200, List.201, List.202):
     let List.642 : [C {U64, Int1}, C {U64, Int1}] = CallByName List.103 List.200 List.201 List.202;
-    dec List.200;
     let List.645 : U8 = 1i64;
     let List.646 : U8 = GetTagId List.642;
     let List.647 : Int1 = lowlevel Eq List.645 List.646;
@@ -169,6 +160,7 @@ procedure List.80 (#Derived_gen.16, #Derived_gen.17, #Derived_gen.18, #Derived_g
             let List.652 : [C {U64, Int1}, C {U64, Int1}] = TagId(1) List.491;
             ret List.652;
     in
+    inc #Derived_gen.16;
     jump List.651 #Derived_gen.16 #Derived_gen.17 #Derived_gen.18 #Derived_gen.19 #Derived_gen.20;
 
 procedure List.91 (#Derived_gen.21, #Derived_gen.22, #Derived_gen.23, #Derived_gen.24, #Derived_gen.25):
@@ -184,6 +176,8 @@ procedure List.91 (#Derived_gen.21, #Derived_gen.22, #Derived_gen.23, #Derived_g
             dec List.162;
             ret List.163;
     in
+    inc #Derived_gen.21;
+    inc #Derived_gen.22;
     jump List.607 #Derived_gen.21 #Derived_gen.22 #Derived_gen.23 #Derived_gen.24 #Derived_gen.25;
 
 procedure List.91 (#Derived_gen.26, #Derived_gen.27, #Derived_gen.28, #Derived_gen.29, #Derived_gen.30):
@@ -200,6 +194,7 @@ procedure List.91 (#Derived_gen.26, #Derived_gen.27, #Derived_gen.28, #Derived_g
             dec List.162;
             ret List.163;
     in
+    inc #Derived_gen.26;
     jump List.595 #Derived_gen.26 #Derived_gen.27 #Derived_gen.28 #Derived_gen.29 #Derived_gen.30;
 
 procedure Num.127 (#Attr.2):
@@ -340,7 +335,6 @@ procedure TotallyNotJson.201 (TotallyNotJson.202, TotallyNotJson.973, TotallyNot
     let TotallyNotJson.981 : {List U8, U64} = Struct {TotallyNotJson.204, TotallyNotJson.1004};
     let TotallyNotJson.982 : {} = Struct {};
     let TotallyNotJson.980 : {List U8, U64} = CallByName List.18 TotallyNotJson.200 TotallyNotJson.981 TotallyNotJson.982;
-    dec TotallyNotJson.200;
     let TotallyNotJson.206 : List U8 = StructAtIndex 0 TotallyNotJson.980;
     let TotallyNotJson.979 : I64 = 125i64;
     let TotallyNotJson.978 : U8 = CallByName Num.127 TotallyNotJson.979;
@@ -365,7 +359,6 @@ procedure TotallyNotJson.203 (TotallyNotJson.975, TotallyNotJson.976):
     let TotallyNotJson.992 : List U8 = CallByName List.4 TotallyNotJson.994 TotallyNotJson.995;
     let TotallyNotJson.993 : {} = Struct {};
     let TotallyNotJson.212 : List U8 = CallByName Encode.24 TotallyNotJson.992 TotallyNotJson.210 TotallyNotJson.993;
-    dec TotallyNotJson.210;
     joinpoint TotallyNotJson.987 TotallyNotJson.213:
         let TotallyNotJson.985 : U64 = 1i64;
         let TotallyNotJson.984 : U64 = CallByName Num.20 TotallyNotJson.208 TotallyNotJson.985;

--- a/crates/compiler/test_mono/generated/encode_derived_record_two_field_strings.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_record_two_field_strings.txt
@@ -34,46 +34,38 @@ procedure Encode.24 (Encode.99, Encode.107, Encode.101):
 
 procedure Encode.24 (Encode.99, Encode.107, Encode.101):
     let Encode.113 : List U8 = CallByName TotallyNotJson.201 Encode.99 Encode.101 Encode.107;
-    dec Encode.107;
     ret Encode.113;
 
 procedure Encode.24 (Encode.99, Encode.107, Encode.101):
     let Encode.117 : List U8 = CallByName TotallyNotJson.150 Encode.99 Encode.101 Encode.107;
-    dec Encode.107;
     ret Encode.117;
 
 procedure Encode.26 (Encode.105, Encode.106):
     let Encode.109 : List U8 = Array [];
     let Encode.110 : {Str, Str} = CallByName #Derived.0 Encode.105;
     let Encode.108 : List U8 = CallByName Encode.24 Encode.109 Encode.110 Encode.106;
-    dec Encode.109;
     ret Encode.108;
 
 procedure List.103 (List.487, List.488, List.489):
     let List.649 : U64 = 0i64;
     let List.650 : U64 = CallByName List.6 List.487;
     let List.648 : [C {U64, Int1}, C {U64, Int1}] = CallByName List.80 List.487 List.488 List.489 List.649 List.650;
-    dec List.487;
     ret List.648;
 
 procedure List.18 (List.159, List.160, List.161):
     let List.593 : U64 = 0i64;
     let List.594 : U64 = CallByName List.6 List.159;
     let List.592 : {List U8, U64} = CallByName List.91 List.159 List.160 List.161 List.593 List.594;
-    dec List.159;
     ret List.592;
 
 procedure List.18 (List.159, List.160, List.161):
     let List.605 : U64 = 0i64;
     let List.606 : U64 = CallByName List.6 List.159;
     let List.604 : List U8 = CallByName List.91 List.159 List.160 List.161 List.605 List.606;
-    dec List.160;
-    dec List.159;
     ret List.604;
 
 procedure List.26 (List.200, List.201, List.202):
     let List.642 : [C {U64, Int1}, C {U64, Int1}] = CallByName List.103 List.200 List.201 List.202;
-    dec List.200;
     let List.645 : U8 = 1i64;
     let List.646 : U8 = GetTagId List.642;
     let List.647 : Int1 = lowlevel Eq List.645 List.646;
@@ -175,6 +167,7 @@ procedure List.80 (#Derived_gen.20, #Derived_gen.21, #Derived_gen.22, #Derived_g
             let List.652 : [C {U64, Int1}, C {U64, Int1}] = TagId(1) List.491;
             ret List.652;
     in
+    inc #Derived_gen.20;
     jump List.651 #Derived_gen.20 #Derived_gen.21 #Derived_gen.22 #Derived_gen.23 #Derived_gen.24;
 
 procedure List.91 (#Derived_gen.25, #Derived_gen.26, #Derived_gen.27, #Derived_gen.28, #Derived_gen.29):
@@ -190,6 +183,8 @@ procedure List.91 (#Derived_gen.25, #Derived_gen.26, #Derived_gen.27, #Derived_g
             dec List.162;
             ret List.163;
     in
+    inc #Derived_gen.25;
+    inc #Derived_gen.26;
     jump List.607 #Derived_gen.25 #Derived_gen.26 #Derived_gen.27 #Derived_gen.28 #Derived_gen.29;
 
 procedure List.91 (#Derived_gen.30, #Derived_gen.31, #Derived_gen.32, #Derived_gen.33, #Derived_gen.34):
@@ -206,6 +201,7 @@ procedure List.91 (#Derived_gen.30, #Derived_gen.31, #Derived_gen.32, #Derived_g
             dec List.162;
             ret List.163;
     in
+    inc #Derived_gen.30;
     jump List.595 #Derived_gen.30 #Derived_gen.31 #Derived_gen.32 #Derived_gen.33 #Derived_gen.34;
 
 procedure Num.127 (#Attr.2):
@@ -346,7 +342,6 @@ procedure TotallyNotJson.201 (TotallyNotJson.202, TotallyNotJson.973, TotallyNot
     let TotallyNotJson.981 : {List U8, U64} = Struct {TotallyNotJson.204, TotallyNotJson.1004};
     let TotallyNotJson.982 : {} = Struct {};
     let TotallyNotJson.980 : {List U8, U64} = CallByName List.18 TotallyNotJson.200 TotallyNotJson.981 TotallyNotJson.982;
-    dec TotallyNotJson.200;
     let TotallyNotJson.206 : List U8 = StructAtIndex 0 TotallyNotJson.980;
     let TotallyNotJson.979 : I64 = 125i64;
     let TotallyNotJson.978 : U8 = CallByName Num.127 TotallyNotJson.979;
@@ -371,7 +366,6 @@ procedure TotallyNotJson.203 (TotallyNotJson.975, TotallyNotJson.976):
     let TotallyNotJson.992 : List U8 = CallByName List.4 TotallyNotJson.994 TotallyNotJson.995;
     let TotallyNotJson.993 : {} = Struct {};
     let TotallyNotJson.212 : List U8 = CallByName Encode.24 TotallyNotJson.992 TotallyNotJson.210 TotallyNotJson.993;
-    dec TotallyNotJson.210;
     joinpoint TotallyNotJson.987 TotallyNotJson.213:
         let TotallyNotJson.985 : U64 = 1i64;
         let TotallyNotJson.984 : U64 = CallByName Num.20 TotallyNotJson.208 TotallyNotJson.985;

--- a/crates/compiler/test_mono/generated/encode_derived_record_two_field_strings.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_record_two_field_strings.txt
@@ -16,6 +16,7 @@ procedure #Derived.2 (#Derived.3, #Derived.4, #Derived.1):
     let #Derived_gen.5 : List {Str, Str} = Array [#Derived_gen.6, #Derived_gen.7];
     let #Derived_gen.4 : List {Str, Str} = CallByName TotallyNotJson.29 #Derived_gen.5;
     let #Derived_gen.3 : List U8 = CallByName Encode.24 #Derived.3 #Derived_gen.4 #Derived.4;
+    dec #Derived_gen.4;
     ret #Derived_gen.3;
 
 procedure Encode.23 (Encode.98):
@@ -33,38 +34,46 @@ procedure Encode.24 (Encode.99, Encode.107, Encode.101):
 
 procedure Encode.24 (Encode.99, Encode.107, Encode.101):
     let Encode.113 : List U8 = CallByName TotallyNotJson.201 Encode.99 Encode.101 Encode.107;
+    dec Encode.107;
     ret Encode.113;
 
 procedure Encode.24 (Encode.99, Encode.107, Encode.101):
     let Encode.117 : List U8 = CallByName TotallyNotJson.150 Encode.99 Encode.101 Encode.107;
+    dec Encode.107;
     ret Encode.117;
 
 procedure Encode.26 (Encode.105, Encode.106):
     let Encode.109 : List U8 = Array [];
     let Encode.110 : {Str, Str} = CallByName #Derived.0 Encode.105;
     let Encode.108 : List U8 = CallByName Encode.24 Encode.109 Encode.110 Encode.106;
+    dec Encode.109;
     ret Encode.108;
 
 procedure List.103 (List.487, List.488, List.489):
     let List.649 : U64 = 0i64;
     let List.650 : U64 = CallByName List.6 List.487;
     let List.648 : [C {U64, Int1}, C {U64, Int1}] = CallByName List.80 List.487 List.488 List.489 List.649 List.650;
+    dec List.487;
     ret List.648;
 
 procedure List.18 (List.159, List.160, List.161):
     let List.593 : U64 = 0i64;
     let List.594 : U64 = CallByName List.6 List.159;
     let List.592 : {List U8, U64} = CallByName List.91 List.159 List.160 List.161 List.593 List.594;
+    dec List.159;
     ret List.592;
 
 procedure List.18 (List.159, List.160, List.161):
     let List.605 : U64 = 0i64;
     let List.606 : U64 = CallByName List.6 List.159;
     let List.604 : List U8 = CallByName List.91 List.159 List.160 List.161 List.605 List.606;
+    dec List.160;
+    dec List.159;
     ret List.604;
 
 procedure List.26 (List.200, List.201, List.202):
     let List.642 : [C {U64, Int1}, C {U64, Int1}] = CallByName List.103 List.200 List.201 List.202;
+    dec List.200;
     let List.645 : U8 = 1i64;
     let List.646 : U8 = GetTagId List.642;
     let List.647 : Int1 = lowlevel Eq List.645 List.646;
@@ -337,6 +346,7 @@ procedure TotallyNotJson.201 (TotallyNotJson.202, TotallyNotJson.973, TotallyNot
     let TotallyNotJson.981 : {List U8, U64} = Struct {TotallyNotJson.204, TotallyNotJson.1004};
     let TotallyNotJson.982 : {} = Struct {};
     let TotallyNotJson.980 : {List U8, U64} = CallByName List.18 TotallyNotJson.200 TotallyNotJson.981 TotallyNotJson.982;
+    dec TotallyNotJson.200;
     let TotallyNotJson.206 : List U8 = StructAtIndex 0 TotallyNotJson.980;
     let TotallyNotJson.979 : I64 = 125i64;
     let TotallyNotJson.978 : U8 = CallByName Num.127 TotallyNotJson.979;
@@ -361,6 +371,7 @@ procedure TotallyNotJson.203 (TotallyNotJson.975, TotallyNotJson.976):
     let TotallyNotJson.992 : List U8 = CallByName List.4 TotallyNotJson.994 TotallyNotJson.995;
     let TotallyNotJson.993 : {} = Struct {};
     let TotallyNotJson.212 : List U8 = CallByName Encode.24 TotallyNotJson.992 TotallyNotJson.210 TotallyNotJson.993;
+    dec TotallyNotJson.210;
     joinpoint TotallyNotJson.987 TotallyNotJson.213:
         let TotallyNotJson.985 : U64 = 1i64;
         let TotallyNotJson.984 : U64 = CallByName Num.20 TotallyNotJson.208 TotallyNotJson.985;
@@ -387,7 +398,6 @@ procedure TotallyNotJson.26 (TotallyNotJson.152):
     let TotallyNotJson.1090 : Int1 = true;
     let TotallyNotJson.154 : {U64, Int1} = Struct {TotallyNotJson.1089, TotallyNotJson.1090};
     let TotallyNotJson.1059 : {} = Struct {};
-    inc TotallyNotJson.153;
     let TotallyNotJson.155 : {U64, Int1} = CallByName List.26 TotallyNotJson.153 TotallyNotJson.154 TotallyNotJson.1059;
     let TotallyNotJson.1013 : Int1 = StructAtIndex 1 TotallyNotJson.155;
     let TotallyNotJson.1057 : Int1 = true;
@@ -406,8 +416,8 @@ procedure TotallyNotJson.26 (TotallyNotJson.152):
         let TotallyNotJson.1014 : List U8 = CallByName List.8 TotallyNotJson.1015 TotallyNotJson.1016;
         ret TotallyNotJson.1014;
     else
-        inc TotallyNotJson.153;
         let TotallyNotJson.1056 : U64 = StructAtIndex 0 TotallyNotJson.155;
+        inc TotallyNotJson.153;
         let TotallyNotJson.1055 : {List U8, List U8} = CallByName List.52 TotallyNotJson.153 TotallyNotJson.1056;
         let TotallyNotJson.179 : List U8 = StructAtIndex 0 TotallyNotJson.1055;
         let TotallyNotJson.181 : List U8 = StructAtIndex 1 TotallyNotJson.1055;
@@ -424,6 +434,8 @@ procedure TotallyNotJson.26 (TotallyNotJson.152):
         let TotallyNotJson.182 : List U8 = CallByName List.8 TotallyNotJson.1046 TotallyNotJson.179;
         let TotallyNotJson.1029 : {} = Struct {};
         let TotallyNotJson.1026 : List U8 = CallByName List.18 TotallyNotJson.181 TotallyNotJson.182 TotallyNotJson.1029;
+        dec TotallyNotJson.182;
+        dec TotallyNotJson.181;
         let TotallyNotJson.1028 : U8 = 34i64;
         let TotallyNotJson.1027 : List U8 = Array [TotallyNotJson.1028];
         let TotallyNotJson.1025 : List U8 = CallByName List.8 TotallyNotJson.1026 TotallyNotJson.1027;

--- a/crates/compiler/test_mono/generated/encode_derived_string.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_string.txt
@@ -15,16 +15,20 @@ procedure List.103 (List.487, List.488, List.489):
     let List.614 : U64 = 0i64;
     let List.615 : U64 = CallByName List.6 List.487;
     let List.613 : [C {U64, Int1}, C {U64, Int1}] = CallByName List.80 List.487 List.488 List.489 List.614 List.615;
+    dec List.487;
     ret List.613;
 
 procedure List.18 (List.159, List.160, List.161):
     let List.585 : U64 = 0i64;
     let List.586 : U64 = CallByName List.6 List.159;
     let List.584 : List U8 = CallByName List.91 List.159 List.160 List.161 List.585 List.586;
+    dec List.160;
+    dec List.159;
     ret List.584;
 
 procedure List.26 (List.200, List.201, List.202):
     let List.607 : [C {U64, Int1}, C {U64, Int1}] = CallByName List.103 List.200 List.201 List.202;
+    dec List.200;
     let List.610 : U8 = 1i64;
     let List.611 : U8 = GetTagId List.607;
     let List.612 : Int1 = lowlevel Eq List.610 List.611;
@@ -253,7 +257,6 @@ procedure TotallyNotJson.26 (TotallyNotJson.152):
     let TotallyNotJson.1054 : Int1 = true;
     let TotallyNotJson.154 : {U64, Int1} = Struct {TotallyNotJson.1053, TotallyNotJson.1054};
     let TotallyNotJson.1023 : {} = Struct {};
-    inc TotallyNotJson.153;
     let TotallyNotJson.155 : {U64, Int1} = CallByName List.26 TotallyNotJson.153 TotallyNotJson.154 TotallyNotJson.1023;
     let TotallyNotJson.977 : Int1 = StructAtIndex 1 TotallyNotJson.155;
     let TotallyNotJson.1021 : Int1 = true;
@@ -272,8 +275,8 @@ procedure TotallyNotJson.26 (TotallyNotJson.152):
         let TotallyNotJson.978 : List U8 = CallByName List.8 TotallyNotJson.979 TotallyNotJson.980;
         ret TotallyNotJson.978;
     else
-        inc TotallyNotJson.153;
         let TotallyNotJson.1020 : U64 = StructAtIndex 0 TotallyNotJson.155;
+        inc TotallyNotJson.153;
         let TotallyNotJson.1019 : {List U8, List U8} = CallByName List.52 TotallyNotJson.153 TotallyNotJson.1020;
         let TotallyNotJson.179 : List U8 = StructAtIndex 0 TotallyNotJson.1019;
         let TotallyNotJson.181 : List U8 = StructAtIndex 1 TotallyNotJson.1019;
@@ -290,6 +293,8 @@ procedure TotallyNotJson.26 (TotallyNotJson.152):
         let TotallyNotJson.182 : List U8 = CallByName List.8 TotallyNotJson.1010 TotallyNotJson.179;
         let TotallyNotJson.993 : {} = Struct {};
         let TotallyNotJson.990 : List U8 = CallByName List.18 TotallyNotJson.181 TotallyNotJson.182 TotallyNotJson.993;
+        dec TotallyNotJson.182;
+        dec TotallyNotJson.181;
         let TotallyNotJson.992 : U8 = 34i64;
         let TotallyNotJson.991 : List U8 = Array [TotallyNotJson.992];
         let TotallyNotJson.989 : List U8 = CallByName List.8 TotallyNotJson.990 TotallyNotJson.991;

--- a/crates/compiler/test_mono/generated/encode_derived_string.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_string.txt
@@ -15,20 +15,16 @@ procedure List.103 (List.487, List.488, List.489):
     let List.614 : U64 = 0i64;
     let List.615 : U64 = CallByName List.6 List.487;
     let List.613 : [C {U64, Int1}, C {U64, Int1}] = CallByName List.80 List.487 List.488 List.489 List.614 List.615;
-    dec List.487;
     ret List.613;
 
 procedure List.18 (List.159, List.160, List.161):
     let List.585 : U64 = 0i64;
     let List.586 : U64 = CallByName List.6 List.159;
     let List.584 : List U8 = CallByName List.91 List.159 List.160 List.161 List.585 List.586;
-    dec List.160;
-    dec List.159;
     ret List.584;
 
 procedure List.26 (List.200, List.201, List.202):
     let List.607 : [C {U64, Int1}, C {U64, Int1}] = CallByName List.103 List.200 List.201 List.202;
-    dec List.200;
     let List.610 : U8 = 1i64;
     let List.611 : U8 = GetTagId List.607;
     let List.612 : Int1 = lowlevel Eq List.610 List.611;
@@ -108,6 +104,7 @@ procedure List.80 (#Derived_gen.0, #Derived_gen.1, #Derived_gen.2, #Derived_gen.
             let List.617 : [C {U64, Int1}, C {U64, Int1}] = TagId(1) List.491;
             ret List.617;
     in
+    inc #Derived_gen.0;
     jump List.616 #Derived_gen.0 #Derived_gen.1 #Derived_gen.2 #Derived_gen.3 #Derived_gen.4;
 
 procedure List.91 (#Derived_gen.8, #Derived_gen.9, #Derived_gen.10, #Derived_gen.11, #Derived_gen.12):
@@ -123,6 +120,8 @@ procedure List.91 (#Derived_gen.8, #Derived_gen.9, #Derived_gen.10, #Derived_gen
             dec List.162;
             ret List.163;
     in
+    inc #Derived_gen.8;
+    inc #Derived_gen.9;
     jump List.587 #Derived_gen.8 #Derived_gen.9 #Derived_gen.10 #Derived_gen.11 #Derived_gen.12;
 
 procedure Num.137 (#Attr.2, #Attr.3):

--- a/crates/compiler/test_mono/generated/encode_derived_tag_one_field_string.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_tag_one_field_string.txt
@@ -5,12 +5,15 @@ procedure #Derived.0 (#Derived.1):
 procedure #Derived.3 (#Derived.4, #Derived.5, #Derived.1):
     joinpoint #Derived_gen.5 #Derived_gen.4:
         let #Derived_gen.3 : List U8 = CallByName Encode.24 #Derived.4 #Derived_gen.4 #Derived.5;
+        dec #Derived.4;
         ret #Derived_gen.3;
     in
     let #Derived_gen.7 : Str = "A";
     let #Derived_gen.9 : Str = CallByName TotallyNotJson.25 #Derived.1;
     let #Derived_gen.8 : List Str = Array [#Derived_gen.9];
     let #Derived_gen.6 : {Str, List Str} = CallByName TotallyNotJson.31 #Derived_gen.7 #Derived_gen.8;
+    dec #Derived_gen.8;
+    dec #Derived_gen.7;
     jump #Derived_gen.5 #Derived_gen.6;
 
 procedure Encode.23 (Encode.98):
@@ -24,6 +27,7 @@ procedure Encode.23 (Encode.98):
 
 procedure Encode.24 (Encode.99, Encode.107, Encode.101):
     let Encode.111 : List U8 = CallByName #Derived.3 Encode.99 Encode.101 Encode.107;
+    dec Encode.99;
     ret Encode.111;
 
 procedure Encode.24 (Encode.99, Encode.107, Encode.101):
@@ -32,34 +36,42 @@ procedure Encode.24 (Encode.99, Encode.107, Encode.101):
 
 procedure Encode.24 (Encode.99, Encode.107, Encode.101):
     let Encode.116 : List U8 = CallByName TotallyNotJson.150 Encode.99 Encode.101 Encode.107;
+    dec Encode.107;
     ret Encode.116;
 
 procedure Encode.26 (Encode.105, Encode.106):
     let Encode.109 : List U8 = Array [];
     let Encode.110 : Str = CallByName #Derived.0 Encode.105;
     let Encode.108 : List U8 = CallByName Encode.24 Encode.109 Encode.110 Encode.106;
+    dec Encode.109;
+    dec Encode.110;
     ret Encode.108;
 
 procedure List.103 (List.487, List.488, List.489):
     let List.655 : U64 = 0i64;
     let List.656 : U64 = CallByName List.6 List.487;
     let List.654 : [C {U64, Int1}, C {U64, Int1}] = CallByName List.80 List.487 List.488 List.489 List.655 List.656;
+    dec List.487;
     ret List.654;
 
 procedure List.18 (List.159, List.160, List.161):
     let List.599 : U64 = 0i64;
     let List.600 : U64 = CallByName List.6 List.159;
     let List.598 : {List U8, U64} = CallByName List.91 List.159 List.160 List.161 List.599 List.600;
+    dec List.159;
     ret List.598;
 
 procedure List.18 (List.159, List.160, List.161):
     let List.611 : U64 = 0i64;
     let List.612 : U64 = CallByName List.6 List.159;
     let List.610 : List U8 = CallByName List.91 List.159 List.160 List.161 List.611 List.612;
+    dec List.160;
+    dec List.159;
     ret List.610;
 
 procedure List.26 (List.200, List.201, List.202):
     let List.648 : [C {U64, Int1}, C {U64, Int1}] = CallByName List.103 List.200 List.201 List.202;
+    dec List.200;
     let List.651 : U8 = 1i64;
     let List.652 : U8 = GetTagId List.648;
     let List.653 : Int1 = lowlevel Eq List.651 List.652;
@@ -170,6 +182,7 @@ procedure List.91 (#Derived_gen.10, #Derived_gen.11, #Derived_gen.12, #Derived_g
             let List.607 : Str = CallByName List.66 List.162 List.165;
             inc List.607;
             let List.167 : {List U8, U64} = CallByName TotallyNotJson.230 List.163 List.607;
+            dec List.607;
             let List.606 : U64 = 1i64;
             let List.605 : U64 = CallByName Num.51 List.165 List.606;
             jump List.601 List.162 List.167 List.164 List.605 List.166;
@@ -348,6 +361,7 @@ procedure TotallyNotJson.228 (TotallyNotJson.229, TotallyNotJson.973, #Attr.12):
     let TotallyNotJson.983 : {List U8, U64} = Struct {TotallyNotJson.231, TotallyNotJson.995};
     let TotallyNotJson.984 : {} = Struct {};
     let TotallyNotJson.982 : {List U8, U64} = CallByName List.18 TotallyNotJson.227 TotallyNotJson.983 TotallyNotJson.984;
+    dec TotallyNotJson.227;
     let TotallyNotJson.233 : List U8 = StructAtIndex 0 TotallyNotJson.982;
     let TotallyNotJson.981 : I64 = 93i64;
     let TotallyNotJson.980 : U8 = CallByName Num.127 TotallyNotJson.981;
@@ -362,6 +376,7 @@ procedure TotallyNotJson.230 (TotallyNotJson.975, TotallyNotJson.236):
     let TotallyNotJson.235 : U64 = StructAtIndex 1 TotallyNotJson.975;
     let TotallyNotJson.994 : {} = Struct {};
     let TotallyNotJson.237 : List U8 = CallByName Encode.24 TotallyNotJson.234 TotallyNotJson.236 TotallyNotJson.994;
+    dec TotallyNotJson.236;
     joinpoint TotallyNotJson.989 TotallyNotJson.238:
         let TotallyNotJson.987 : U64 = 1i64;
         let TotallyNotJson.986 : U64 = CallByName Num.20 TotallyNotJson.235 TotallyNotJson.987;
@@ -388,7 +403,6 @@ procedure TotallyNotJson.26 (TotallyNotJson.152):
     let TotallyNotJson.1095 : Int1 = true;
     let TotallyNotJson.154 : {U64, Int1} = Struct {TotallyNotJson.1094, TotallyNotJson.1095};
     let TotallyNotJson.1064 : {} = Struct {};
-    inc TotallyNotJson.153;
     let TotallyNotJson.155 : {U64, Int1} = CallByName List.26 TotallyNotJson.153 TotallyNotJson.154 TotallyNotJson.1064;
     let TotallyNotJson.1018 : Int1 = StructAtIndex 1 TotallyNotJson.155;
     let TotallyNotJson.1062 : Int1 = true;
@@ -407,8 +421,8 @@ procedure TotallyNotJson.26 (TotallyNotJson.152):
         let TotallyNotJson.1019 : List U8 = CallByName List.8 TotallyNotJson.1020 TotallyNotJson.1021;
         ret TotallyNotJson.1019;
     else
-        inc TotallyNotJson.153;
         let TotallyNotJson.1061 : U64 = StructAtIndex 0 TotallyNotJson.155;
+        inc TotallyNotJson.153;
         let TotallyNotJson.1060 : {List U8, List U8} = CallByName List.52 TotallyNotJson.153 TotallyNotJson.1061;
         let TotallyNotJson.179 : List U8 = StructAtIndex 0 TotallyNotJson.1060;
         let TotallyNotJson.181 : List U8 = StructAtIndex 1 TotallyNotJson.1060;
@@ -425,6 +439,8 @@ procedure TotallyNotJson.26 (TotallyNotJson.152):
         let TotallyNotJson.182 : List U8 = CallByName List.8 TotallyNotJson.1051 TotallyNotJson.179;
         let TotallyNotJson.1034 : {} = Struct {};
         let TotallyNotJson.1031 : List U8 = CallByName List.18 TotallyNotJson.181 TotallyNotJson.182 TotallyNotJson.1034;
+        dec TotallyNotJson.182;
+        dec TotallyNotJson.181;
         let TotallyNotJson.1033 : U8 = 34i64;
         let TotallyNotJson.1032 : List U8 = Array [TotallyNotJson.1033];
         let TotallyNotJson.1030 : List U8 = CallByName List.8 TotallyNotJson.1031 TotallyNotJson.1032;

--- a/crates/compiler/test_mono/generated/encode_derived_tag_one_field_string.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_tag_one_field_string.txt
@@ -5,7 +5,6 @@ procedure #Derived.0 (#Derived.1):
 procedure #Derived.3 (#Derived.4, #Derived.5, #Derived.1):
     joinpoint #Derived_gen.5 #Derived_gen.4:
         let #Derived_gen.3 : List U8 = CallByName Encode.24 #Derived.4 #Derived_gen.4 #Derived.5;
-        dec #Derived.4;
         ret #Derived_gen.3;
     in
     let #Derived_gen.7 : Str = "A";
@@ -27,7 +26,6 @@ procedure Encode.23 (Encode.98):
 
 procedure Encode.24 (Encode.99, Encode.107, Encode.101):
     let Encode.111 : List U8 = CallByName #Derived.3 Encode.99 Encode.101 Encode.107;
-    dec Encode.99;
     ret Encode.111;
 
 procedure Encode.24 (Encode.99, Encode.107, Encode.101):
@@ -36,42 +34,34 @@ procedure Encode.24 (Encode.99, Encode.107, Encode.101):
 
 procedure Encode.24 (Encode.99, Encode.107, Encode.101):
     let Encode.116 : List U8 = CallByName TotallyNotJson.150 Encode.99 Encode.101 Encode.107;
-    dec Encode.107;
     ret Encode.116;
 
 procedure Encode.26 (Encode.105, Encode.106):
     let Encode.109 : List U8 = Array [];
     let Encode.110 : Str = CallByName #Derived.0 Encode.105;
     let Encode.108 : List U8 = CallByName Encode.24 Encode.109 Encode.110 Encode.106;
-    dec Encode.109;
-    dec Encode.110;
     ret Encode.108;
 
 procedure List.103 (List.487, List.488, List.489):
     let List.655 : U64 = 0i64;
     let List.656 : U64 = CallByName List.6 List.487;
     let List.654 : [C {U64, Int1}, C {U64, Int1}] = CallByName List.80 List.487 List.488 List.489 List.655 List.656;
-    dec List.487;
     ret List.654;
 
 procedure List.18 (List.159, List.160, List.161):
     let List.599 : U64 = 0i64;
     let List.600 : U64 = CallByName List.6 List.159;
     let List.598 : {List U8, U64} = CallByName List.91 List.159 List.160 List.161 List.599 List.600;
-    dec List.159;
     ret List.598;
 
 procedure List.18 (List.159, List.160, List.161):
     let List.611 : U64 = 0i64;
     let List.612 : U64 = CallByName List.6 List.159;
     let List.610 : List U8 = CallByName List.91 List.159 List.160 List.161 List.611 List.612;
-    dec List.160;
-    dec List.159;
     ret List.610;
 
 procedure List.26 (List.200, List.201, List.202):
     let List.648 : [C {U64, Int1}, C {U64, Int1}] = CallByName List.103 List.200 List.201 List.202;
-    dec List.200;
     let List.651 : U8 = 1i64;
     let List.652 : U8 = GetTagId List.648;
     let List.653 : Int1 = lowlevel Eq List.651 List.652;
@@ -173,6 +163,7 @@ procedure List.80 (#Derived_gen.18, #Derived_gen.19, #Derived_gen.20, #Derived_g
             let List.658 : [C {U64, Int1}, C {U64, Int1}] = TagId(1) List.491;
             ret List.658;
     in
+    inc #Derived_gen.18;
     jump List.657 #Derived_gen.18 #Derived_gen.19 #Derived_gen.20 #Derived_gen.21 #Derived_gen.22;
 
 procedure List.91 (#Derived_gen.10, #Derived_gen.11, #Derived_gen.12, #Derived_gen.13, #Derived_gen.14):
@@ -182,7 +173,6 @@ procedure List.91 (#Derived_gen.10, #Derived_gen.11, #Derived_gen.12, #Derived_g
             let List.607 : Str = CallByName List.66 List.162 List.165;
             inc List.607;
             let List.167 : {List U8, U64} = CallByName TotallyNotJson.230 List.163 List.607;
-            dec List.607;
             let List.606 : U64 = 1i64;
             let List.605 : U64 = CallByName Num.51 List.165 List.606;
             jump List.601 List.162 List.167 List.164 List.605 List.166;
@@ -190,6 +180,7 @@ procedure List.91 (#Derived_gen.10, #Derived_gen.11, #Derived_gen.12, #Derived_g
             dec List.162;
             ret List.163;
     in
+    inc #Derived_gen.10;
     jump List.601 #Derived_gen.10 #Derived_gen.11 #Derived_gen.12 #Derived_gen.13 #Derived_gen.14;
 
 procedure List.91 (#Derived_gen.23, #Derived_gen.24, #Derived_gen.25, #Derived_gen.26, #Derived_gen.27):
@@ -205,6 +196,8 @@ procedure List.91 (#Derived_gen.23, #Derived_gen.24, #Derived_gen.25, #Derived_g
             dec List.162;
             ret List.163;
     in
+    inc #Derived_gen.24;
+    inc #Derived_gen.23;
     jump List.613 #Derived_gen.23 #Derived_gen.24 #Derived_gen.25 #Derived_gen.26 #Derived_gen.27;
 
 procedure Num.127 (#Attr.2):
@@ -376,7 +369,6 @@ procedure TotallyNotJson.230 (TotallyNotJson.975, TotallyNotJson.236):
     let TotallyNotJson.235 : U64 = StructAtIndex 1 TotallyNotJson.975;
     let TotallyNotJson.994 : {} = Struct {};
     let TotallyNotJson.237 : List U8 = CallByName Encode.24 TotallyNotJson.234 TotallyNotJson.236 TotallyNotJson.994;
-    dec TotallyNotJson.236;
     joinpoint TotallyNotJson.989 TotallyNotJson.238:
         let TotallyNotJson.987 : U64 = 1i64;
         let TotallyNotJson.986 : U64 = CallByName Num.20 TotallyNotJson.235 TotallyNotJson.987;
@@ -491,6 +483,8 @@ procedure TotallyNotJson.27 (TotallyNotJson.186):
     
 
 procedure TotallyNotJson.31 (TotallyNotJson.226, TotallyNotJson.227):
+    inc TotallyNotJson.227;
+    inc TotallyNotJson.226;
     let TotallyNotJson.972 : {Str, List Str} = Struct {TotallyNotJson.226, TotallyNotJson.227};
     let TotallyNotJson.971 : {Str, List Str} = CallByName Encode.23 TotallyNotJson.972;
     ret TotallyNotJson.971;

--- a/crates/compiler/test_mono/generated/encode_derived_tag_two_payloads_string.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_tag_two_payloads_string.txt
@@ -14,6 +14,8 @@ procedure #Derived.4 (#Derived.5, #Derived.6, #Derived.1):
     let #Derived_gen.10 : Str = CallByName TotallyNotJson.25 #Derived.3;
     let #Derived_gen.8 : List Str = Array [#Derived_gen.9, #Derived_gen.10];
     let #Derived_gen.6 : {Str, List Str} = CallByName TotallyNotJson.31 #Derived_gen.7 #Derived_gen.8;
+    dec #Derived_gen.8;
+    dec #Derived_gen.7;
     jump #Derived_gen.5 #Derived_gen.6;
 
 procedure Encode.23 (Encode.98):
@@ -35,34 +37,41 @@ procedure Encode.24 (Encode.99, Encode.107, Encode.101):
 
 procedure Encode.24 (Encode.99, Encode.107, Encode.101):
     let Encode.117 : List U8 = CallByName TotallyNotJson.150 Encode.99 Encode.101 Encode.107;
+    dec Encode.107;
     ret Encode.117;
 
 procedure Encode.26 (Encode.105, Encode.106):
     let Encode.109 : List U8 = Array [];
     let Encode.110 : {Str, Str} = CallByName #Derived.0 Encode.105;
     let Encode.108 : List U8 = CallByName Encode.24 Encode.109 Encode.110 Encode.106;
+    dec Encode.109;
     ret Encode.108;
 
 procedure List.103 (List.487, List.488, List.489):
     let List.655 : U64 = 0i64;
     let List.656 : U64 = CallByName List.6 List.487;
     let List.654 : [C {U64, Int1}, C {U64, Int1}] = CallByName List.80 List.487 List.488 List.489 List.655 List.656;
+    dec List.487;
     ret List.654;
 
 procedure List.18 (List.159, List.160, List.161):
     let List.599 : U64 = 0i64;
     let List.600 : U64 = CallByName List.6 List.159;
     let List.598 : {List U8, U64} = CallByName List.91 List.159 List.160 List.161 List.599 List.600;
+    dec List.159;
     ret List.598;
 
 procedure List.18 (List.159, List.160, List.161):
     let List.611 : U64 = 0i64;
     let List.612 : U64 = CallByName List.6 List.159;
     let List.610 : List U8 = CallByName List.91 List.159 List.160 List.161 List.611 List.612;
+    dec List.160;
+    dec List.159;
     ret List.610;
 
 procedure List.26 (List.200, List.201, List.202):
     let List.648 : [C {U64, Int1}, C {U64, Int1}] = CallByName List.103 List.200 List.201 List.202;
+    dec List.200;
     let List.651 : U8 = 1i64;
     let List.652 : U8 = GetTagId List.648;
     let List.653 : Int1 = lowlevel Eq List.651 List.652;
@@ -173,6 +182,7 @@ procedure List.91 (#Derived_gen.14, #Derived_gen.15, #Derived_gen.16, #Derived_g
             let List.607 : Str = CallByName List.66 List.162 List.165;
             inc List.607;
             let List.167 : {List U8, U64} = CallByName TotallyNotJson.230 List.163 List.607;
+            dec List.607;
             let List.606 : U64 = 1i64;
             let List.605 : U64 = CallByName Num.51 List.165 List.606;
             jump List.601 List.162 List.167 List.164 List.605 List.166;
@@ -351,6 +361,7 @@ procedure TotallyNotJson.228 (TotallyNotJson.229, TotallyNotJson.973, #Attr.12):
     let TotallyNotJson.983 : {List U8, U64} = Struct {TotallyNotJson.231, TotallyNotJson.995};
     let TotallyNotJson.984 : {} = Struct {};
     let TotallyNotJson.982 : {List U8, U64} = CallByName List.18 TotallyNotJson.227 TotallyNotJson.983 TotallyNotJson.984;
+    dec TotallyNotJson.227;
     let TotallyNotJson.233 : List U8 = StructAtIndex 0 TotallyNotJson.982;
     let TotallyNotJson.981 : I64 = 93i64;
     let TotallyNotJson.980 : U8 = CallByName Num.127 TotallyNotJson.981;
@@ -365,6 +376,7 @@ procedure TotallyNotJson.230 (TotallyNotJson.975, TotallyNotJson.236):
     let TotallyNotJson.235 : U64 = StructAtIndex 1 TotallyNotJson.975;
     let TotallyNotJson.994 : {} = Struct {};
     let TotallyNotJson.237 : List U8 = CallByName Encode.24 TotallyNotJson.234 TotallyNotJson.236 TotallyNotJson.994;
+    dec TotallyNotJson.236;
     joinpoint TotallyNotJson.989 TotallyNotJson.238:
         let TotallyNotJson.987 : U64 = 1i64;
         let TotallyNotJson.986 : U64 = CallByName Num.20 TotallyNotJson.235 TotallyNotJson.987;
@@ -391,7 +403,6 @@ procedure TotallyNotJson.26 (TotallyNotJson.152):
     let TotallyNotJson.1095 : Int1 = true;
     let TotallyNotJson.154 : {U64, Int1} = Struct {TotallyNotJson.1094, TotallyNotJson.1095};
     let TotallyNotJson.1064 : {} = Struct {};
-    inc TotallyNotJson.153;
     let TotallyNotJson.155 : {U64, Int1} = CallByName List.26 TotallyNotJson.153 TotallyNotJson.154 TotallyNotJson.1064;
     let TotallyNotJson.1018 : Int1 = StructAtIndex 1 TotallyNotJson.155;
     let TotallyNotJson.1062 : Int1 = true;
@@ -410,8 +421,8 @@ procedure TotallyNotJson.26 (TotallyNotJson.152):
         let TotallyNotJson.1019 : List U8 = CallByName List.8 TotallyNotJson.1020 TotallyNotJson.1021;
         ret TotallyNotJson.1019;
     else
-        inc TotallyNotJson.153;
         let TotallyNotJson.1061 : U64 = StructAtIndex 0 TotallyNotJson.155;
+        inc TotallyNotJson.153;
         let TotallyNotJson.1060 : {List U8, List U8} = CallByName List.52 TotallyNotJson.153 TotallyNotJson.1061;
         let TotallyNotJson.179 : List U8 = StructAtIndex 0 TotallyNotJson.1060;
         let TotallyNotJson.181 : List U8 = StructAtIndex 1 TotallyNotJson.1060;
@@ -428,6 +439,8 @@ procedure TotallyNotJson.26 (TotallyNotJson.152):
         let TotallyNotJson.182 : List U8 = CallByName List.8 TotallyNotJson.1051 TotallyNotJson.179;
         let TotallyNotJson.1034 : {} = Struct {};
         let TotallyNotJson.1031 : List U8 = CallByName List.18 TotallyNotJson.181 TotallyNotJson.182 TotallyNotJson.1034;
+        dec TotallyNotJson.182;
+        dec TotallyNotJson.181;
         let TotallyNotJson.1033 : U8 = 34i64;
         let TotallyNotJson.1032 : List U8 = Array [TotallyNotJson.1033];
         let TotallyNotJson.1030 : List U8 = CallByName List.8 TotallyNotJson.1031 TotallyNotJson.1032;

--- a/crates/compiler/test_mono/generated/encode_derived_tag_two_payloads_string.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_tag_two_payloads_string.txt
@@ -37,41 +37,34 @@ procedure Encode.24 (Encode.99, Encode.107, Encode.101):
 
 procedure Encode.24 (Encode.99, Encode.107, Encode.101):
     let Encode.117 : List U8 = CallByName TotallyNotJson.150 Encode.99 Encode.101 Encode.107;
-    dec Encode.107;
     ret Encode.117;
 
 procedure Encode.26 (Encode.105, Encode.106):
     let Encode.109 : List U8 = Array [];
     let Encode.110 : {Str, Str} = CallByName #Derived.0 Encode.105;
     let Encode.108 : List U8 = CallByName Encode.24 Encode.109 Encode.110 Encode.106;
-    dec Encode.109;
     ret Encode.108;
 
 procedure List.103 (List.487, List.488, List.489):
     let List.655 : U64 = 0i64;
     let List.656 : U64 = CallByName List.6 List.487;
     let List.654 : [C {U64, Int1}, C {U64, Int1}] = CallByName List.80 List.487 List.488 List.489 List.655 List.656;
-    dec List.487;
     ret List.654;
 
 procedure List.18 (List.159, List.160, List.161):
     let List.599 : U64 = 0i64;
     let List.600 : U64 = CallByName List.6 List.159;
     let List.598 : {List U8, U64} = CallByName List.91 List.159 List.160 List.161 List.599 List.600;
-    dec List.159;
     ret List.598;
 
 procedure List.18 (List.159, List.160, List.161):
     let List.611 : U64 = 0i64;
     let List.612 : U64 = CallByName List.6 List.159;
     let List.610 : List U8 = CallByName List.91 List.159 List.160 List.161 List.611 List.612;
-    dec List.160;
-    dec List.159;
     ret List.610;
 
 procedure List.26 (List.200, List.201, List.202):
     let List.648 : [C {U64, Int1}, C {U64, Int1}] = CallByName List.103 List.200 List.201 List.202;
-    dec List.200;
     let List.651 : U8 = 1i64;
     let List.652 : U8 = GetTagId List.648;
     let List.653 : Int1 = lowlevel Eq List.651 List.652;
@@ -173,6 +166,7 @@ procedure List.80 (#Derived_gen.27, #Derived_gen.28, #Derived_gen.29, #Derived_g
             let List.658 : [C {U64, Int1}, C {U64, Int1}] = TagId(1) List.491;
             ret List.658;
     in
+    inc #Derived_gen.27;
     jump List.657 #Derived_gen.27 #Derived_gen.28 #Derived_gen.29 #Derived_gen.30 #Derived_gen.31;
 
 procedure List.91 (#Derived_gen.14, #Derived_gen.15, #Derived_gen.16, #Derived_gen.17, #Derived_gen.18):
@@ -182,7 +176,6 @@ procedure List.91 (#Derived_gen.14, #Derived_gen.15, #Derived_gen.16, #Derived_g
             let List.607 : Str = CallByName List.66 List.162 List.165;
             inc List.607;
             let List.167 : {List U8, U64} = CallByName TotallyNotJson.230 List.163 List.607;
-            dec List.607;
             let List.606 : U64 = 1i64;
             let List.605 : U64 = CallByName Num.51 List.165 List.606;
             jump List.601 List.162 List.167 List.164 List.605 List.166;
@@ -190,6 +183,7 @@ procedure List.91 (#Derived_gen.14, #Derived_gen.15, #Derived_gen.16, #Derived_g
             dec List.162;
             ret List.163;
     in
+    inc #Derived_gen.14;
     jump List.601 #Derived_gen.14 #Derived_gen.15 #Derived_gen.16 #Derived_gen.17 #Derived_gen.18;
 
 procedure List.91 (#Derived_gen.22, #Derived_gen.23, #Derived_gen.24, #Derived_gen.25, #Derived_gen.26):
@@ -205,6 +199,8 @@ procedure List.91 (#Derived_gen.22, #Derived_gen.23, #Derived_gen.24, #Derived_g
             dec List.162;
             ret List.163;
     in
+    inc #Derived_gen.23;
+    inc #Derived_gen.22;
     jump List.613 #Derived_gen.22 #Derived_gen.23 #Derived_gen.24 #Derived_gen.25 #Derived_gen.26;
 
 procedure Num.127 (#Attr.2):
@@ -376,7 +372,6 @@ procedure TotallyNotJson.230 (TotallyNotJson.975, TotallyNotJson.236):
     let TotallyNotJson.235 : U64 = StructAtIndex 1 TotallyNotJson.975;
     let TotallyNotJson.994 : {} = Struct {};
     let TotallyNotJson.237 : List U8 = CallByName Encode.24 TotallyNotJson.234 TotallyNotJson.236 TotallyNotJson.994;
-    dec TotallyNotJson.236;
     joinpoint TotallyNotJson.989 TotallyNotJson.238:
         let TotallyNotJson.987 : U64 = 1i64;
         let TotallyNotJson.986 : U64 = CallByName Num.20 TotallyNotJson.235 TotallyNotJson.987;
@@ -491,6 +486,8 @@ procedure TotallyNotJson.27 (TotallyNotJson.186):
     
 
 procedure TotallyNotJson.31 (TotallyNotJson.226, TotallyNotJson.227):
+    inc TotallyNotJson.227;
+    inc TotallyNotJson.226;
     let TotallyNotJson.972 : {Str, List Str} = Struct {TotallyNotJson.226, TotallyNotJson.227};
     let TotallyNotJson.971 : {Str, List Str} = CallByName Encode.23 TotallyNotJson.972;
     ret TotallyNotJson.971;

--- a/crates/compiler/test_mono/generated/fst.txt
+++ b/crates/compiler/test_mono/generated/fst.txt
@@ -6,4 +6,5 @@ procedure Test.0 ():
     let Test.5 : List I64 = Array [1i64, 2i64, 3i64];
     let Test.6 : List I64 = Array [3i64, 2i64, 1i64];
     let Test.4 : List I64 = CallByName Test.1 Test.5 Test.6;
+    dec Test.6;
     ret Test.4;

--- a/crates/compiler/test_mono/generated/fst.txt
+++ b/crates/compiler/test_mono/generated/fst.txt
@@ -1,5 +1,4 @@
 procedure Test.1 (Test.2, Test.3):
-    dec Test.3;
     ret Test.2;
 
 procedure Test.0 ():

--- a/crates/compiler/test_mono/generated/inspect_derived_dict.txt
+++ b/crates/compiler/test_mono/generated/inspect_derived_dict.txt
@@ -56,7 +56,6 @@ procedure Dict.12 (Dict.151):
     let Dict.731 : {List {U32, U32}, List {Str, I64}, U64, Float32, U8} = CallByName Dict.1 Dict.883;
     let Dict.732 : {} = Struct {};
     let Dict.730 : {List {U32, U32}, List {Str, I64}, U64, Float32, U8} = CallByName List.18 Dict.151 Dict.731 Dict.732;
-    dec Dict.151;
     ret Dict.730;
 
 procedure Dict.120 (Dict.121, Dict.119):
@@ -65,7 +64,6 @@ procedure Dict.120 (Dict.121, Dict.119):
     let Dict.1100 : {} = Struct {};
     let Dict.1097 : {{List {U32, U32}, List {Str, I64}, U64, Float32, U8}, {}, {}, {}} = CallByName Inspect.38 Dict.119 Dict.1098 Dict.1099 Dict.1100;
     let Dict.1096 : Str = CallByName Inspect.31 Dict.1097 Dict.121;
-    dec Dict.121;
     ret Dict.1096;
 
 procedure Dict.152 (Dict.153, Dict.733):
@@ -152,6 +150,9 @@ procedure Dict.38 (#Derived_gen.0, #Derived_gen.1, #Derived_gen.2, #Derived_gen.
                 let Dict.239 : U32 = CallByName Dict.48 Dict.224;
                 jump Dict.736 Dict.221 Dict.222 Dict.238 Dict.239 Dict.225 Dict.226 Dict.227 Dict.228 Dict.229;
     in
+    inc #Derived_gen.0;
+    inc #Derived_gen.1;
+    inc #Derived_gen.4;
     jump Dict.736 #Derived_gen.0 #Derived_gen.1 #Derived_gen.2 #Derived_gen.3 #Derived_gen.4 #Derived_gen.5 #Derived_gen.6 #Derived_gen.7 #Derived_gen.8;
 
 procedure Dict.398 (Dict.399, Dict.840, Dict.401, Dict.397):
@@ -162,7 +163,6 @@ procedure Dict.398 (Dict.399, Dict.840, Dict.401, Dict.397):
     let Dict.844 : U32 = CallByName Num.131 Dict.401;
     let Dict.843 : {U32, U32} = Struct {Dict.844, Dict.403};
     let Dict.842 : List {U32, U32} = CallByName Dict.67 Dict.399 Dict.843 Dict.402;
-    dec Dict.399;
     ret Dict.842;
 
 procedure Dict.4 (Dict.729):
@@ -278,8 +278,6 @@ procedure Dict.63 (Dict.394):
 
 procedure Dict.64 (Dict.395, Dict.396, Dict.397):
     let Dict.838 : List {U32, U32} = CallByName List.83 Dict.396 Dict.395 Dict.397;
-    dec Dict.395;
-    dec Dict.396;
     ret Dict.838;
 
 procedure Dict.65 (Dict.404, Dict.405, Dict.406):
@@ -287,7 +285,6 @@ procedure Dict.65 (Dict.404, Dict.405, Dict.406):
     let Dict.408 : U32 = CallByName Dict.70 Dict.407;
     let Dict.409 : U64 = CallByName Dict.71 Dict.407 Dict.406;
     let Dict.846 : {U64, U32} = CallByName Dict.66 Dict.404 Dict.409 Dict.408;
-    dec Dict.404;
     ret Dict.846;
 
 procedure Dict.66 (#Derived_gen.45, #Derived_gen.46, #Derived_gen.47):
@@ -305,6 +302,7 @@ procedure Dict.66 (#Derived_gen.45, #Derived_gen.46, #Derived_gen.47):
             let Dict.848 : {U64, U32} = Struct {Dict.411, Dict.412};
             ret Dict.848;
     in
+    inc #Derived_gen.45;
     jump Dict.847 #Derived_gen.45 #Derived_gen.46 #Derived_gen.47;
 
 procedure Dict.67 (#Derived_gen.31, #Derived_gen.32, #Derived_gen.33):
@@ -326,6 +324,7 @@ procedure Dict.67 (#Derived_gen.31, #Derived_gen.32, #Derived_gen.33):
             let Dict.754 : List {U32, U32} = CallByName List.3 Dict.414 Dict.416 Dict.415;
             ret Dict.754;
     in
+    inc #Derived_gen.31;
     jump Dict.753 #Derived_gen.31 #Derived_gen.32 #Derived_gen.33;
 
 procedure Dict.68 (Dict.419, Dict.420):
@@ -479,7 +478,6 @@ procedure Dict.82 (Dict.702, Dict.480):
             let Dict.1077 : U64 = CallByName Num.75 Dict.481 Dict.1078;
             let Dict.1059 : U64 = CallByName Num.75 Dict.1077 Dict.483;
             let Dict.1058 : U64 = CallByName Dict.92 Dict.480 Dict.1059;
-            dec Dict.480;
             let Dict.485 : U64 = CallByName Num.71 Dict.1057 Dict.1058;
             let Dict.1033 : {U64, U64, U64} = Struct {Dict.484, Dict.485, Dict.478};
             jump Dict.1034 Dict.1033;
@@ -489,12 +487,10 @@ procedure Dict.82 (Dict.702, Dict.480):
             if Dict.1037 then
                 let Dict.1040 : U64 = 0i64;
                 let Dict.1038 : U64 = CallByName Dict.93 Dict.480 Dict.1040 Dict.481;
-                dec Dict.480;
                 let Dict.1039 : U64 = 0i64;
                 let Dict.1033 : {U64, U64, U64} = Struct {Dict.1038, Dict.1039, Dict.478};
                 jump Dict.1034 Dict.1033;
             else
-                dec Dict.480;
                 let Dict.1035 : U64 = 0i64;
                 let Dict.1036 : U64 = 0i64;
                 let Dict.1033 : {U64, U64, U64} = Struct {Dict.1035, Dict.1036, Dict.478};
@@ -505,12 +501,10 @@ procedure Dict.82 (Dict.702, Dict.480):
         if Dict.1029 then
             let Dict.1030 : U64 = 0i64;
             let Dict.917 : {U64, U64, U64} = CallByName Dict.84 Dict.478 Dict.480 Dict.1030 Dict.481;
-            dec Dict.480;
             jump Dict.918 Dict.917;
         else
             let Dict.919 : U64 = 0i64;
             let Dict.917 : {U64, U64, U64} = CallByName Dict.83 Dict.478 Dict.478 Dict.478 Dict.480 Dict.919 Dict.481;
-            dec Dict.480;
             jump Dict.918 Dict.917;
 
 procedure Dict.83 (#Derived_gen.9, #Derived_gen.10, #Derived_gen.11, #Derived_gen.12, #Derived_gen.13, #Derived_gen.14):
@@ -575,6 +569,7 @@ procedure Dict.83 (#Derived_gen.9, #Derived_gen.10, #Derived_gen.11, #Derived_ge
                 let Dict.921 : {U64, U64, U64} = Struct {Dict.922, Dict.923, Dict.498};
                 ret Dict.921;
     in
+    inc #Derived_gen.12;
     jump Dict.920 #Derived_gen.9 #Derived_gen.10 #Derived_gen.11 #Derived_gen.12 #Derived_gen.13 #Derived_gen.14;
 
 procedure Dict.84 (#Derived_gen.48, #Derived_gen.49, #Derived_gen.50, #Derived_gen.51):
@@ -608,6 +603,7 @@ procedure Dict.84 (#Derived_gen.48, #Derived_gen.49, #Derived_gen.50, #Derived_g
         else
             jump Dict.973 Dict.503 Dict.500 Dict.505 Dict.504;
     in
+    inc #Derived_gen.49;
     jump Dict.973 #Derived_gen.48 #Derived_gen.49 #Derived_gen.50 #Derived_gen.51;
 
 procedure Dict.85 ():
@@ -674,7 +670,6 @@ procedure Dict.91 (Dict.515, Dict.516):
     let Dict.945 : U64 = 7i64;
     let Dict.943 : U64 = CallByName Num.51 Dict.516 Dict.945;
     let Dict.942 : U8 = CallByName Dict.22 Dict.515 Dict.943;
-    dec Dict.515;
     let Dict.524 : U64 = CallByName Num.133 Dict.942;
     let Dict.941 : U8 = 8i64;
     let Dict.940 : U64 = CallByName Num.72 Dict.518 Dict.941;
@@ -713,7 +708,6 @@ procedure Dict.92 (Dict.529, Dict.530):
     let Dict.1069 : U64 = 3i64;
     let Dict.1068 : U64 = CallByName Num.51 Dict.530 Dict.1069;
     let Dict.1067 : U8 = CallByName Dict.22 Dict.529 Dict.1068;
-    dec Dict.529;
     let Dict.534 : U64 = CallByName Num.133 Dict.1067;
     let Dict.1066 : U8 = 8i64;
     let Dict.1065 : U64 = CallByName Num.72 Dict.532 Dict.1066;
@@ -738,7 +732,6 @@ procedure Dict.93 (Dict.537, Dict.538, Dict.539):
     let Dict.1048 : U64 = CallByName Num.75 Dict.539 Dict.1049;
     let Dict.1047 : U64 = CallByName Num.51 Dict.1048 Dict.538;
     let Dict.1046 : U8 = CallByName Dict.22 Dict.537 Dict.1047;
-    dec Dict.537;
     let Dict.542 : U64 = CallByName Num.133 Dict.1046;
     let Dict.1045 : U8 = 16i64;
     let Dict.1042 : U64 = CallByName Num.72 Dict.540 Dict.1045;
@@ -778,6 +771,7 @@ procedure Inspect.185 (Inspect.186, #Attr.12):
     let Inspect.180 : {} = StructAtIndex 1 #Attr.12;
     let Inspect.179 : {List {U32, U32}, List {Str, I64}, U64, Float32, U8} = StructAtIndex 0 #Attr.12;
     let Inspect.350 : Int1 = CallByName Bool.1;
+    inc Inspect.186;
     let Inspect.328 : {Str, Int1} = Struct {Inspect.186, Inspect.350};
     let Inspect.329 : {{}, {}} = Struct {Inspect.181, Inspect.182};
     let Inspect.327 : {Str, Int1} = CallByName Dict.10 Inspect.179 Inspect.328 Inspect.329;
@@ -819,6 +813,7 @@ procedure Inspect.193 (Inspect.194, #Attr.12):
 
 procedure Inspect.195 (Inspect.196):
     let Inspect.336 : Int1 = CallByName Bool.2;
+    inc Inspect.196;
     let Inspect.335 : {Str, Int1} = Struct {Inspect.196, Inspect.336};
     ret Inspect.335;
 
@@ -831,7 +826,6 @@ procedure Inspect.246 (Inspect.247, Inspect.245):
     let Inspect.365 : Str = CallByName Inspect.59 Inspect.247 Inspect.366;
     dec Inspect.366;
     let Inspect.363 : Str = CallByName Inspect.59 Inspect.365 Inspect.245;
-    dec Inspect.245;
     let Inspect.364 : Str = "\"";
     let Inspect.362 : Str = CallByName Inspect.59 Inspect.363 Inspect.364;
     dec Inspect.364;
@@ -865,7 +859,6 @@ procedure Inspect.31 (Inspect.299, Inspect.145):
 
 procedure Inspect.31 (Inspect.299, Inspect.145):
     let Inspect.346 : Str = CallByName Inspect.246 Inspect.145 Inspect.299;
-    dec Inspect.299;
     ret Inspect.346;
 
 procedure Inspect.33 (Inspect.148):
@@ -891,7 +884,6 @@ procedure Inspect.5 (Inspect.146):
     let Inspect.305 : {} = Struct {};
     let Inspect.304 : Str = CallByName Inspect.35 Inspect.305;
     let Inspect.303 : Str = CallByName Dict.120 Inspect.304 Inspect.308;
-    dec Inspect.304;
     ret Inspect.303;
 
 procedure Inspect.53 (Inspect.273):
@@ -900,7 +892,6 @@ procedure Inspect.53 (Inspect.273):
 
 procedure Inspect.59 (Inspect.296, Inspect.292):
     let Inspect.319 : Str = CallByName Str.3 Inspect.296 Inspect.292;
-    dec Inspect.292;
     ret Inspect.319;
 
 procedure Inspect.60 (Inspect.298):
@@ -916,14 +907,12 @@ procedure List.18 (List.159, List.160, List.161):
     let List.573 : U64 = 0i64;
     let List.574 : U64 = CallByName List.6 List.159;
     let List.572 : {List {U32, U32}, List {Str, I64}, U64, Float32, U8} = CallByName List.91 List.159 List.160 List.161 List.573 List.574;
-    dec List.159;
     ret List.572;
 
 procedure List.18 (List.159, List.160, List.161):
     let List.637 : U64 = 0i64;
     let List.638 : U64 = CallByName List.6 List.159;
     let List.636 : {Str, Int1} = CallByName List.91 List.159 List.160 List.161 List.637 List.638;
-    dec List.159;
     ret List.636;
 
 procedure List.3 (List.115, List.116, List.117):
@@ -1008,8 +997,6 @@ procedure List.83 (List.168, List.169, List.170):
     let List.612 : U64 = 0i64;
     let List.613 : U64 = CallByName List.6 List.168;
     let List.611 : List {U32, U32} = CallByName List.92 List.168 List.169 List.170 List.612 List.613;
-    dec List.168;
-    dec List.169;
     ret List.611;
 
 procedure List.89 (#Derived_gen.28, #Derived_gen.29, #Derived_gen.30):
@@ -1024,6 +1011,7 @@ procedure List.89 (#Derived_gen.28, #Derived_gen.29, #Derived_gen.30):
         else
             ret List.141;
     in
+    inc #Derived_gen.30;
     jump List.623 #Derived_gen.28 #Derived_gen.29 #Derived_gen.30;
 
 procedure List.91 (#Derived_gen.23, #Derived_gen.24, #Derived_gen.25, #Derived_gen.26, #Derived_gen.27):
@@ -1040,6 +1028,7 @@ procedure List.91 (#Derived_gen.23, #Derived_gen.24, #Derived_gen.25, #Derived_g
             dec List.162;
             ret List.163;
     in
+    inc #Derived_gen.23;
     jump List.575 #Derived_gen.23 #Derived_gen.24 #Derived_gen.25 #Derived_gen.26 #Derived_gen.27;
 
 procedure List.91 (#Derived_gen.59, #Derived_gen.60, #Derived_gen.61, #Derived_gen.62, #Derived_gen.63):
@@ -1056,6 +1045,7 @@ procedure List.91 (#Derived_gen.59, #Derived_gen.60, #Derived_gen.61, #Derived_g
             dec List.162;
             ret List.163;
     in
+    inc #Derived_gen.59;
     jump List.639 #Derived_gen.59 #Derived_gen.60 #Derived_gen.61 #Derived_gen.62 #Derived_gen.63;
 
 procedure List.92 (#Derived_gen.38, #Derived_gen.39, #Derived_gen.40, #Derived_gen.41, #Derived_gen.42):
@@ -1073,6 +1063,8 @@ procedure List.92 (#Derived_gen.38, #Derived_gen.39, #Derived_gen.40, #Derived_g
             dec List.171;
             ret List.172;
     in
+    inc #Derived_gen.38;
+    inc #Derived_gen.39;
     jump List.614 #Derived_gen.38 #Derived_gen.39 #Derived_gen.40 #Derived_gen.41 #Derived_gen.42;
 
 procedure Num.131 (#Attr.2):

--- a/crates/compiler/test_mono/generated/inspect_derived_dict.txt
+++ b/crates/compiler/test_mono/generated/inspect_derived_dict.txt
@@ -48,6 +48,7 @@ procedure Dict.10 (Dict.724, Dict.179, Dict.180):
     let #Derived_gen.68 : List {U32, U32} = StructAtIndex 0 Dict.724;
     dec #Derived_gen.68;
     let Dict.1101 : {Str, Int1} = CallByName List.18 Dict.178 Dict.179 Dict.180;
+    dec Dict.178;
     ret Dict.1101;
 
 procedure Dict.12 (Dict.151):
@@ -55,6 +56,7 @@ procedure Dict.12 (Dict.151):
     let Dict.731 : {List {U32, U32}, List {Str, I64}, U64, Float32, U8} = CallByName Dict.1 Dict.883;
     let Dict.732 : {} = Struct {};
     let Dict.730 : {List {U32, U32}, List {Str, I64}, U64, Float32, U8} = CallByName List.18 Dict.151 Dict.731 Dict.732;
+    dec Dict.151;
     ret Dict.730;
 
 procedure Dict.120 (Dict.121, Dict.119):
@@ -63,6 +65,7 @@ procedure Dict.120 (Dict.121, Dict.119):
     let Dict.1100 : {} = Struct {};
     let Dict.1097 : {{List {U32, U32}, List {Str, I64}, U64, Float32, U8}, {}, {}, {}} = CallByName Inspect.38 Dict.119 Dict.1098 Dict.1099 Dict.1100;
     let Dict.1096 : Str = CallByName Inspect.31 Dict.1097 Dict.121;
+    dec Dict.121;
     ret Dict.1096;
 
 procedure Dict.152 (Dict.153, Dict.733):
@@ -140,6 +143,7 @@ procedure Dict.38 (#Derived_gen.0, #Derived_gen.1, #Derived_gen.2, #Derived_gen.
                 let Dict.766 : U32 = CallByName Num.131 Dict.236;
                 let Dict.752 : {U32, U32} = Struct {Dict.766, Dict.224};
                 let Dict.237 : List {U32, U32} = CallByName Dict.67 Dict.221 Dict.752 Dict.223;
+                dec Dict.221;
                 let Dict.751 : {List {U32, U32}, List {Str, I64}, U64, Float32, U8} = Struct {Dict.237, Dict.235, Dict.227, Dict.228, Dict.229};
                 ret Dict.751;
             else
@@ -152,13 +156,13 @@ procedure Dict.38 (#Derived_gen.0, #Derived_gen.1, #Derived_gen.2, #Derived_gen.
 
 procedure Dict.398 (Dict.399, Dict.840, Dict.401, Dict.397):
     let Dict.400 : Str = StructAtIndex 0 Dict.840;
-    inc Dict.399;
     let Dict.845 : {U64, U32} = CallByName Dict.65 Dict.399 Dict.400 Dict.397;
     let Dict.402 : U64 = StructAtIndex 0 Dict.845;
     let Dict.403 : U32 = StructAtIndex 1 Dict.845;
     let Dict.844 : U32 = CallByName Num.131 Dict.401;
     let Dict.843 : {U32, U32} = Struct {Dict.844, Dict.403};
     let Dict.842 : List {U32, U32} = CallByName Dict.67 Dict.399 Dict.843 Dict.402;
+    dec Dict.399;
     ret Dict.842;
 
 procedure Dict.4 (Dict.729):
@@ -222,13 +226,13 @@ procedure Dict.59 (Dict.719):
     let Dict.877 : U64 = CallByName Dict.47;
     let Dict.836 : Int1 = CallByName Bool.7 Dict.377 Dict.877;
     if Dict.836 then
-        inc Dict.376;
         let Dict.876 : U8 = 1i64;
         let Dict.380 : U8 = CallByName Num.75 Dict.379 Dict.876;
         let Dict.855 : {List {U32, U32}, U64} = CallByName Dict.60 Dict.380 Dict.378;
         let Dict.381 : List {U32, U32} = StructAtIndex 0 Dict.855;
         let Dict.382 : U64 = StructAtIndex 1 Dict.855;
         let Dict.383 : List {U32, U32} = CallByName Dict.64 Dict.381 Dict.376 Dict.380;
+        dec Dict.381;
         let Dict.837 : {List {U32, U32}, List {Str, I64}, U64, Float32, U8} = Struct {Dict.383, Dict.376, Dict.382, Dict.378, Dict.380};
         ret Dict.837;
     else
@@ -274,6 +278,8 @@ procedure Dict.63 (Dict.394):
 
 procedure Dict.64 (Dict.395, Dict.396, Dict.397):
     let Dict.838 : List {U32, U32} = CallByName List.83 Dict.396 Dict.395 Dict.397;
+    dec Dict.395;
+    dec Dict.396;
     ret Dict.838;
 
 procedure Dict.65 (Dict.404, Dict.405, Dict.406):
@@ -281,6 +287,7 @@ procedure Dict.65 (Dict.404, Dict.405, Dict.406):
     let Dict.408 : U32 = CallByName Dict.70 Dict.407;
     let Dict.409 : U64 = CallByName Dict.71 Dict.407 Dict.406;
     let Dict.846 : {U64, U32} = CallByName Dict.66 Dict.404 Dict.409 Dict.408;
+    dec Dict.404;
     ret Dict.846;
 
 procedure Dict.66 (#Derived_gen.45, #Derived_gen.46, #Derived_gen.47):
@@ -416,6 +423,9 @@ procedure Dict.8 (Dict.210, Dict.211, Dict.212):
         let Dict.219 : U32 = CallByName Dict.70 Dict.218;
         let Dict.220 : U64 = CallByName Dict.71 Dict.218 Dict.217;
         let Dict.735 : {List {U32, U32}, List {Str, I64}, U64, Float32, U8} = CallByName Dict.38 Dict.213 Dict.214 Dict.220 Dict.219 Dict.211 Dict.212 Dict.215 Dict.216 Dict.217;
+        dec Dict.214;
+        dec Dict.213;
+        dec Dict.211;
         ret Dict.735;
     in
     inc 2 Dict.210;
@@ -455,7 +465,6 @@ procedure Dict.82 (Dict.702, Dict.480):
             let Dict.1089 : U8 = 2i64;
             let Dict.483 : U64 = CallByName Num.72 Dict.1088 Dict.1089;
             let Dict.1087 : U64 = 0i64;
-            inc 3 Dict.480;
             let Dict.1085 : U64 = CallByName Dict.92 Dict.480 Dict.1087;
             let Dict.1086 : U8 = 32i64;
             let Dict.1083 : U64 = CallByName Num.72 Dict.1085 Dict.1086;
@@ -470,6 +479,7 @@ procedure Dict.82 (Dict.702, Dict.480):
             let Dict.1077 : U64 = CallByName Num.75 Dict.481 Dict.1078;
             let Dict.1059 : U64 = CallByName Num.75 Dict.1077 Dict.483;
             let Dict.1058 : U64 = CallByName Dict.92 Dict.480 Dict.1059;
+            dec Dict.480;
             let Dict.485 : U64 = CallByName Num.71 Dict.1057 Dict.1058;
             let Dict.1033 : {U64, U64, U64} = Struct {Dict.484, Dict.485, Dict.478};
             jump Dict.1034 Dict.1033;
@@ -479,6 +489,7 @@ procedure Dict.82 (Dict.702, Dict.480):
             if Dict.1037 then
                 let Dict.1040 : U64 = 0i64;
                 let Dict.1038 : U64 = CallByName Dict.93 Dict.480 Dict.1040 Dict.481;
+                dec Dict.480;
                 let Dict.1039 : U64 = 0i64;
                 let Dict.1033 : {U64, U64, U64} = Struct {Dict.1038, Dict.1039, Dict.478};
                 jump Dict.1034 Dict.1033;
@@ -494,15 +505,16 @@ procedure Dict.82 (Dict.702, Dict.480):
         if Dict.1029 then
             let Dict.1030 : U64 = 0i64;
             let Dict.917 : {U64, U64, U64} = CallByName Dict.84 Dict.478 Dict.480 Dict.1030 Dict.481;
+            dec Dict.480;
             jump Dict.918 Dict.917;
         else
             let Dict.919 : U64 = 0i64;
             let Dict.917 : {U64, U64, U64} = CallByName Dict.83 Dict.478 Dict.478 Dict.478 Dict.480 Dict.919 Dict.481;
+            dec Dict.480;
             jump Dict.918 Dict.917;
 
 procedure Dict.83 (#Derived_gen.9, #Derived_gen.10, #Derived_gen.11, #Derived_gen.12, #Derived_gen.13, #Derived_gen.14):
     joinpoint Dict.920 Dict.486 Dict.487 Dict.488 Dict.489 Dict.490 Dict.491:
-        inc 6 Dict.489;
         let Dict.1027 : U64 = CallByName Dict.91 Dict.489 Dict.490;
         let Dict.1028 : U64 = CallByName Dict.86;
         let Dict.1022 : U64 = CallByName Num.70 Dict.1027 Dict.1028;
@@ -546,9 +558,9 @@ procedure Dict.83 (#Derived_gen.9, #Derived_gen.10, #Derived_gen.11, #Derived_ge
                 let Dict.995 : U64 = CallByName Num.70 Dict.493 Dict.492;
                 let Dict.497 : U64 = CallByName Num.70 Dict.494 Dict.995;
                 let Dict.972 : {U64, U64, U64} = CallByName Dict.84 Dict.497 Dict.489 Dict.496 Dict.495;
+                dec Dict.489;
                 ret Dict.972;
             else
-                inc Dict.489;
                 let Dict.970 : U64 = CallByName Num.70 Dict.493 Dict.492;
                 let Dict.498 : U64 = CallByName Num.70 Dict.494 Dict.970;
                 let Dict.969 : U64 = 16i64;
@@ -559,6 +571,7 @@ procedure Dict.83 (#Derived_gen.9, #Derived_gen.10, #Derived_gen.11, #Derived_ge
                 let Dict.965 : U64 = CallByName Num.75 Dict.495 Dict.966;
                 let Dict.924 : U64 = CallByName Num.51 Dict.965 Dict.496;
                 let Dict.923 : U64 = CallByName Dict.91 Dict.489 Dict.924;
+                dec Dict.489;
                 let Dict.921 : {U64, U64, U64} = Struct {Dict.922, Dict.923, Dict.498};
                 ret Dict.921;
     in
@@ -566,7 +579,6 @@ procedure Dict.83 (#Derived_gen.9, #Derived_gen.10, #Derived_gen.11, #Derived_ge
 
 procedure Dict.84 (#Derived_gen.48, #Derived_gen.49, #Derived_gen.50, #Derived_gen.51):
     joinpoint Dict.973 Dict.499 Dict.500 Dict.501 Dict.502:
-        inc 2 Dict.500;
         let Dict.993 : U64 = CallByName Dict.91 Dict.500 Dict.501;
         let Dict.994 : U64 = CallByName Dict.86;
         let Dict.988 : U64 = CallByName Num.70 Dict.993 Dict.994;
@@ -582,7 +594,6 @@ procedure Dict.84 (#Derived_gen.48, #Derived_gen.49, #Derived_gen.50, #Derived_g
         let Dict.985 : U64 = 16i64;
         let Dict.975 : Int1 = CallByName Num.23 Dict.504 Dict.985;
         if Dict.975 then
-            inc Dict.500;
             let Dict.984 : U64 = 16i64;
             let Dict.983 : U64 = CallByName Num.75 Dict.504 Dict.984;
             let Dict.982 : U64 = CallByName Num.51 Dict.983 Dict.505;
@@ -591,6 +602,7 @@ procedure Dict.84 (#Derived_gen.48, #Derived_gen.49, #Derived_gen.50, #Derived_g
             let Dict.980 : U64 = CallByName Num.75 Dict.504 Dict.981;
             let Dict.979 : U64 = CallByName Num.51 Dict.980 Dict.505;
             let Dict.978 : U64 = CallByName Dict.91 Dict.500 Dict.979;
+            dec Dict.500;
             let Dict.976 : {U64, U64, U64} = Struct {Dict.977, Dict.978, Dict.503};
             ret Dict.976;
         else
@@ -739,6 +751,7 @@ procedure Dict.93 (Dict.537, Dict.538, Dict.539):
 procedure Hash.19 (Hash.38, Hash.39):
     let Hash.71 : List U8 = CallByName Str.12 Hash.39;
     let Hash.70 : {U64, U64} = CallByName Dict.82 Hash.38 Hash.71;
+    dec Hash.71;
     ret Hash.70;
 
 procedure Inspect.183 (Inspect.184, #Attr.12):
@@ -748,12 +761,15 @@ procedure Inspect.183 (Inspect.184, #Attr.12):
     let Inspect.179 : {List {U32, U32}, List {Str, I64}, U64, Float32, U8} = StructAtIndex 0 #Attr.12;
     let Inspect.351 : Str = "{";
     let Inspect.324 : Str = CallByName Inspect.59 Inspect.184 Inspect.351;
+    dec Inspect.351;
     let Inspect.325 : {{List {U32, U32}, List {Str, I64}, U64, Float32, U8}, {}, {}, {}} = Struct {Inspect.179, Inspect.180, Inspect.181, Inspect.182};
     let Inspect.320 : {Str, Int1} = CallByName Inspect.185 Inspect.324 Inspect.325;
+    dec Inspect.324;
     let Inspect.321 : {} = Struct {};
     let Inspect.316 : Str = CallByName Inspect.197 Inspect.320;
     let Inspect.317 : Str = "}";
     let Inspect.315 : Str = CallByName Inspect.59 Inspect.316 Inspect.317;
+    dec Inspect.317;
     ret Inspect.315;
 
 procedure Inspect.185 (Inspect.186, #Attr.12):
@@ -775,17 +791,21 @@ procedure Inspect.187 (Inspect.330, Inspect.190, Inspect.191, #Attr.12):
     joinpoint Inspect.348 Inspect.192:
         let Inspect.345 : Str = CallByName Inspect.43 Inspect.190;
         let Inspect.343 : Str = CallByName Inspect.31 Inspect.345 Inspect.192;
+        dec Inspect.345;
         let Inspect.344 : Str = ": ";
         let Inspect.337 : Str = CallByName Inspect.59 Inspect.343 Inspect.344;
+        dec Inspect.344;
         let Inspect.338 : {I64, {}} = Struct {Inspect.191, Inspect.182};
         let Inspect.333 : Str = CallByName Inspect.193 Inspect.337 Inspect.338;
         let Inspect.334 : {} = Struct {};
         let Inspect.332 : {Str, Int1} = CallByName Inspect.195 Inspect.333;
+        dec Inspect.333;
         ret Inspect.332;
     in
     if Inspect.189 then
         let Inspect.349 : Str = ", ";
         let Inspect.347 : Str = CallByName Inspect.59 Inspect.188 Inspect.349;
+        dec Inspect.349;
         jump Inspect.348 Inspect.347;
     else
         jump Inspect.348 Inspect.188;
@@ -809,14 +829,18 @@ procedure Inspect.197 (Inspect.322):
 procedure Inspect.246 (Inspect.247, Inspect.245):
     let Inspect.366 : Str = "\"";
     let Inspect.365 : Str = CallByName Inspect.59 Inspect.247 Inspect.366;
+    dec Inspect.366;
     let Inspect.363 : Str = CallByName Inspect.59 Inspect.365 Inspect.245;
+    dec Inspect.245;
     let Inspect.364 : Str = "\"";
     let Inspect.362 : Str = CallByName Inspect.59 Inspect.363 Inspect.364;
+    dec Inspect.364;
     ret Inspect.362;
 
 procedure Inspect.274 (Inspect.275, Inspect.273):
     let Inspect.357 : Str = CallByName Num.96 Inspect.273;
     let Inspect.356 : Str = CallByName Inspect.59 Inspect.275 Inspect.357;
+    dec Inspect.357;
     ret Inspect.356;
 
 procedure Inspect.30 (Inspect.143):
@@ -841,6 +865,7 @@ procedure Inspect.31 (Inspect.299, Inspect.145):
 
 procedure Inspect.31 (Inspect.299, Inspect.145):
     let Inspect.346 : Str = CallByName Inspect.246 Inspect.145 Inspect.299;
+    dec Inspect.299;
     ret Inspect.346;
 
 procedure Inspect.33 (Inspect.148):
@@ -866,6 +891,7 @@ procedure Inspect.5 (Inspect.146):
     let Inspect.305 : {} = Struct {};
     let Inspect.304 : Str = CallByName Inspect.35 Inspect.305;
     let Inspect.303 : Str = CallByName Dict.120 Inspect.304 Inspect.308;
+    dec Inspect.304;
     ret Inspect.303;
 
 procedure Inspect.53 (Inspect.273):
@@ -883,18 +909,21 @@ procedure Inspect.60 (Inspect.298):
 procedure List.11 (List.137, List.138):
     let List.634 : List {U32, U32} = CallByName List.68 List.138;
     let List.633 : List {U32, U32} = CallByName List.89 List.137 List.138 List.634;
+    dec List.634;
     ret List.633;
 
 procedure List.18 (List.159, List.160, List.161):
     let List.573 : U64 = 0i64;
     let List.574 : U64 = CallByName List.6 List.159;
     let List.572 : {List {U32, U32}, List {Str, I64}, U64, Float32, U8} = CallByName List.91 List.159 List.160 List.161 List.573 List.574;
+    dec List.159;
     ret List.572;
 
 procedure List.18 (List.159, List.160, List.161):
     let List.637 : U64 = 0i64;
     let List.638 : U64 = CallByName List.6 List.159;
     let List.636 : {Str, Int1} = CallByName List.91 List.159 List.160 List.161 List.637 List.638;
+    dec List.159;
     ret List.636;
 
 procedure List.3 (List.115, List.116, List.117):
@@ -979,6 +1008,8 @@ procedure List.83 (List.168, List.169, List.170):
     let List.612 : U64 = 0i64;
     let List.613 : U64 = CallByName List.6 List.168;
     let List.611 : List {U32, U32} = CallByName List.92 List.168 List.169 List.170 List.612 List.613;
+    dec List.168;
+    dec List.169;
     ret List.611;
 
 procedure List.89 (#Derived_gen.28, #Derived_gen.29, #Derived_gen.30):
@@ -1034,6 +1065,7 @@ procedure List.92 (#Derived_gen.38, #Derived_gen.39, #Derived_gen.40, #Derived_g
             let List.620 : {Str, I64} = CallByName List.66 List.171 List.174;
             inc List.620;
             let List.176 : List {U32, U32} = CallByName Dict.398 List.172 List.620 List.174 List.173;
+            dec List.172;
             let List.619 : U64 = 1i64;
             let List.618 : U64 = CallByName Num.51 List.174 List.619;
             jump List.614 List.171 List.176 List.173 List.618 List.175;
@@ -1187,5 +1219,6 @@ procedure Test.0 ():
     let Test.5 : {Str, I64} = Struct {Test.6, Test.7};
     let Test.3 : List {Str, I64} = Array [Test.4, Test.5];
     let Test.2 : {List {U32, U32}, List {Str, I64}, U64, Float32, U8} = CallByName Dict.12 Test.3;
+    dec Test.3;
     let Test.1 : Str = CallByName Inspect.33 Test.2;
     ret Test.1;

--- a/crates/compiler/test_mono/generated/inspect_derived_list.txt
+++ b/crates/compiler/test_mono/generated/inspect_derived_list.txt
@@ -10,7 +10,9 @@ procedure #Derived.4 (#Derived.5, #Derived.1):
     let #Derived_gen.5 : {} = Struct {};
     let #Derived_gen.6 : {} = Struct {};
     let #Derived_gen.4 : {List I64, {}, {}} = CallByName Inspect.36 #Derived.1 #Derived_gen.5 #Derived_gen.6;
+    dec #Derived.1;
     let #Derived_gen.3 : Str = CallByName Inspect.31 #Derived_gen.4 #Derived.5;
+    dec #Derived.5;
     ret #Derived_gen.3;
 
 procedure Bool.1 ():
@@ -27,12 +29,15 @@ procedure Inspect.152 (Inspect.153, #Attr.12):
     let Inspect.149 : List I64 = StructAtIndex 0 #Attr.12;
     let Inspect.343 : Str = "[";
     let Inspect.324 : Str = CallByName Inspect.59 Inspect.153 Inspect.343;
+    dec Inspect.343;
     let Inspect.325 : {List I64, {}, {}} = Struct {Inspect.149, Inspect.150, Inspect.151};
     let Inspect.320 : {Str, Int1} = CallByName Inspect.154 Inspect.324 Inspect.325;
+    dec Inspect.324;
     let Inspect.321 : {} = Struct {};
     let Inspect.316 : Str = CallByName Inspect.163 Inspect.320;
     let Inspect.317 : Str = "]";
     let Inspect.315 : Str = CallByName Inspect.59 Inspect.316 Inspect.317;
+    dec Inspect.317;
     ret Inspect.315;
 
 procedure Inspect.154 (Inspect.155, #Attr.12):
@@ -42,6 +47,7 @@ procedure Inspect.154 (Inspect.155, #Attr.12):
     let Inspect.342 : Int1 = CallByName Bool.1;
     let Inspect.328 : {Str, Int1} = Struct {Inspect.155, Inspect.342};
     let Inspect.327 : {Str, Int1} = CallByName List.18 Inspect.149 Inspect.328 Inspect.151;
+    dec Inspect.149;
     ret Inspect.327;
 
 procedure Inspect.156 (Inspect.330, Inspect.159, Inspect.151):
@@ -52,11 +58,13 @@ procedure Inspect.156 (Inspect.330, Inspect.159, Inspect.151):
         let Inspect.333 : Str = CallByName Inspect.31 Inspect.337 Inspect.160;
         let Inspect.334 : {} = Struct {};
         let Inspect.332 : {Str, Int1} = CallByName Inspect.161 Inspect.333;
+        dec Inspect.333;
         ret Inspect.332;
     in
     if Inspect.158 then
         let Inspect.341 : Str = ", ";
         let Inspect.339 : Str = CallByName Inspect.59 Inspect.157 Inspect.341;
+        dec Inspect.341;
         jump Inspect.340 Inspect.339;
     else
         jump Inspect.340 Inspect.157;
@@ -73,6 +81,7 @@ procedure Inspect.163 (Inspect.322):
 procedure Inspect.274 (Inspect.275, Inspect.273):
     let Inspect.349 : Str = CallByName Num.96 Inspect.273;
     let Inspect.348 : Str = CallByName Inspect.59 Inspect.275 Inspect.349;
+    dec Inspect.349;
     ret Inspect.348;
 
 procedure Inspect.30 (Inspect.143):
@@ -111,6 +120,8 @@ procedure Inspect.5 (Inspect.146):
     let Inspect.305 : {} = Struct {};
     let Inspect.304 : Str = CallByName Inspect.35 Inspect.305;
     let Inspect.303 : Str = CallByName #Derived.4 Inspect.304 Inspect.308;
+    dec Inspect.304;
+    dec Inspect.308;
     ret Inspect.303;
 
 procedure Inspect.53 (Inspect.273):
@@ -129,6 +140,7 @@ procedure List.18 (List.159, List.160, List.161):
     let List.573 : U64 = 0i64;
     let List.574 : U64 = CallByName List.6 List.159;
     let List.572 : {Str, Int1} = CallByName List.91 List.159 List.160 List.161 List.573 List.574;
+    dec List.159;
     ret List.572;
 
 procedure List.6 (#Attr.2):

--- a/crates/compiler/test_mono/generated/inspect_derived_list.txt
+++ b/crates/compiler/test_mono/generated/inspect_derived_list.txt
@@ -10,9 +10,7 @@ procedure #Derived.4 (#Derived.5, #Derived.1):
     let #Derived_gen.5 : {} = Struct {};
     let #Derived_gen.6 : {} = Struct {};
     let #Derived_gen.4 : {List I64, {}, {}} = CallByName Inspect.36 #Derived.1 #Derived_gen.5 #Derived_gen.6;
-    dec #Derived.1;
     let #Derived_gen.3 : Str = CallByName Inspect.31 #Derived_gen.4 #Derived.5;
-    dec #Derived.5;
     ret #Derived_gen.3;
 
 procedure Bool.1 ():
@@ -45,6 +43,7 @@ procedure Inspect.154 (Inspect.155, #Attr.12):
     let Inspect.150 : {} = StructAtIndex 1 #Attr.12;
     let Inspect.149 : List I64 = StructAtIndex 0 #Attr.12;
     let Inspect.342 : Int1 = CallByName Bool.1;
+    inc Inspect.155;
     let Inspect.328 : {Str, Int1} = Struct {Inspect.155, Inspect.342};
     let Inspect.327 : {Str, Int1} = CallByName List.18 Inspect.149 Inspect.328 Inspect.151;
     dec Inspect.149;
@@ -71,6 +70,7 @@ procedure Inspect.156 (Inspect.330, Inspect.159, Inspect.151):
 
 procedure Inspect.161 (Inspect.162):
     let Inspect.336 : Int1 = CallByName Bool.2;
+    inc Inspect.162;
     let Inspect.335 : {Str, Int1} = Struct {Inspect.162, Inspect.336};
     ret Inspect.335;
 
@@ -111,6 +111,7 @@ procedure Inspect.35 (Inspect.297):
     ret Inspect.307;
 
 procedure Inspect.36 (Inspect.149, Inspect.150, Inspect.151):
+    inc Inspect.149;
     let Inspect.312 : {List I64, {}, {}} = Struct {Inspect.149, Inspect.150, Inspect.151};
     let Inspect.311 : {List I64, {}, {}} = CallByName Inspect.30 Inspect.312;
     ret Inspect.311;
@@ -120,7 +121,6 @@ procedure Inspect.5 (Inspect.146):
     let Inspect.305 : {} = Struct {};
     let Inspect.304 : Str = CallByName Inspect.35 Inspect.305;
     let Inspect.303 : Str = CallByName #Derived.4 Inspect.304 Inspect.308;
-    dec Inspect.304;
     dec Inspect.308;
     ret Inspect.303;
 
@@ -130,7 +130,6 @@ procedure Inspect.53 (Inspect.273):
 
 procedure Inspect.59 (Inspect.296, Inspect.292):
     let Inspect.319 : Str = CallByName Str.3 Inspect.296 Inspect.292;
-    dec Inspect.292;
     ret Inspect.319;
 
 procedure Inspect.60 (Inspect.298):
@@ -140,7 +139,6 @@ procedure List.18 (List.159, List.160, List.161):
     let List.573 : U64 = 0i64;
     let List.574 : U64 = CallByName List.6 List.159;
     let List.572 : {Str, Int1} = CallByName List.91 List.159 List.160 List.161 List.573 List.574;
-    dec List.159;
     ret List.572;
 
 procedure List.6 (#Attr.2):
@@ -164,6 +162,7 @@ procedure List.91 (#Derived_gen.17, #Derived_gen.18, #Derived_gen.19, #Derived_g
             dec List.162;
             ret List.163;
     in
+    inc #Derived_gen.17;
     jump List.575 #Derived_gen.17 #Derived_gen.18 #Derived_gen.19 #Derived_gen.20 #Derived_gen.21;
 
 procedure Num.22 (#Attr.2, #Attr.3):

--- a/crates/compiler/test_mono/generated/inspect_derived_nested_record_string.txt
+++ b/crates/compiler/test_mono/generated/inspect_derived_nested_record_string.txt
@@ -40,7 +40,6 @@ procedure Inspect.225 (Inspect.226, Inspect.224):
     dec Inspect.348;
     let Inspect.320 : {Str, Int1} = CallByName Inspect.227 Inspect.324 Inspect.224;
     dec Inspect.324;
-    dec Inspect.224;
     let Inspect.321 : {} = Struct {};
     let Inspect.316 : Str = CallByName Inspect.239 Inspect.320;
     let Inspect.317 : Str = "}";
@@ -53,7 +52,6 @@ procedure Inspect.225 (Inspect.226, Inspect.224):
     let Inspect.364 : Str = CallByName Inspect.59 Inspect.226 Inspect.388;
     dec Inspect.388;
     let Inspect.360 : {Str, Int1} = CallByName Inspect.227 Inspect.364 Inspect.224;
-    dec Inspect.224;
     dec Inspect.364;
     let Inspect.361 : {} = Struct {};
     let Inspect.356 : Str = CallByName Inspect.239 Inspect.360;
@@ -64,18 +62,18 @@ procedure Inspect.225 (Inspect.226, Inspect.224):
 
 procedure Inspect.227 (Inspect.228, Inspect.224):
     let Inspect.347 : Int1 = CallByName Bool.1;
+    inc Inspect.228;
     let Inspect.328 : {Str, Int1} = Struct {Inspect.228, Inspect.347};
     let Inspect.329 : {} = Struct {};
     let Inspect.327 : {Str, Int1} = CallByName List.18 Inspect.224 Inspect.328 Inspect.329;
-    dec Inspect.224;
     ret Inspect.327;
 
 procedure Inspect.227 (Inspect.228, Inspect.224):
     let Inspect.387 : Int1 = CallByName Bool.1;
+    inc Inspect.228;
     let Inspect.368 : {Str, Int1} = Struct {Inspect.228, Inspect.387};
     let Inspect.369 : {} = Struct {};
     let Inspect.367 : {Str, Int1} = CallByName List.18 Inspect.224 Inspect.368 Inspect.369;
-    dec Inspect.224;
     ret Inspect.367;
 
 procedure Inspect.229 (Inspect.330, Inspect.331):
@@ -90,8 +88,6 @@ procedure Inspect.229 (Inspect.330, Inspect.331):
         let Inspect.337 : Str = CallByName Inspect.59 Inspect.342 Inspect.343;
         dec Inspect.343;
         let Inspect.333 : Str = CallByName Inspect.235 Inspect.337 Inspect.233;
-        dec Inspect.233;
-        dec Inspect.337;
         let Inspect.334 : {} = Struct {};
         let Inspect.332 : {Str, Int1} = CallByName Inspect.237 Inspect.333;
         dec Inspect.333;
@@ -133,17 +129,15 @@ procedure Inspect.229 (Inspect.330, Inspect.331):
 
 procedure Inspect.235 (Inspect.236, Inspect.233):
     let Inspect.340 : Str = CallByName Inspect.31 Inspect.233 Inspect.236;
-    dec Inspect.233;
-    dec Inspect.236;
     ret Inspect.340;
 
 procedure Inspect.235 (Inspect.236, Inspect.233):
     let Inspect.380 : Str = CallByName Inspect.31 Inspect.233 Inspect.236;
-    dec Inspect.233;
     ret Inspect.380;
 
 procedure Inspect.237 (Inspect.238):
     let Inspect.376 : Int1 = CallByName Bool.2;
+    inc Inspect.238;
     let Inspect.375 : {Str, Int1} = Struct {Inspect.238, Inspect.376};
     ret Inspect.375;
 
@@ -156,7 +150,6 @@ procedure Inspect.246 (Inspect.247, Inspect.245):
     let Inspect.396 : Str = CallByName Inspect.59 Inspect.247 Inspect.397;
     dec Inspect.397;
     let Inspect.394 : Str = CallByName Inspect.59 Inspect.396 Inspect.245;
-    dec Inspect.245;
     let Inspect.395 : Str = "\"";
     let Inspect.393 : Str = CallByName Inspect.59 Inspect.394 Inspect.395;
     dec Inspect.395;
@@ -179,7 +172,6 @@ procedure Inspect.30 (Inspect.143):
 
 procedure Inspect.31 (Inspect.299, Inspect.145):
     let Inspect.310 : Str = CallByName Inspect.225 Inspect.145 Inspect.299;
-    dec Inspect.299;
     ret Inspect.310;
 
 procedure Inspect.31 (Inspect.299, Inspect.145):
@@ -188,12 +180,10 @@ procedure Inspect.31 (Inspect.299, Inspect.145):
 
 procedure Inspect.31 (Inspect.299, Inspect.145):
     let Inspect.350 : Str = CallByName Inspect.225 Inspect.145 Inspect.299;
-    dec Inspect.299;
     ret Inspect.350;
 
 procedure Inspect.31 (Inspect.299, Inspect.145):
     let Inspect.381 : Str = CallByName Inspect.246 Inspect.145 Inspect.299;
-    dec Inspect.299;
     ret Inspect.381;
 
 procedure Inspect.33 (Inspect.148):
@@ -226,7 +216,6 @@ procedure Inspect.5 (Inspect.146):
 
 procedure Inspect.59 (Inspect.296, Inspect.292):
     let Inspect.359 : Str = CallByName Str.3 Inspect.296 Inspect.292;
-    dec Inspect.292;
     ret Inspect.359;
 
 procedure Inspect.60 (Inspect.298):
@@ -236,14 +225,12 @@ procedure List.18 (List.159, List.160, List.161):
     let List.573 : U64 = 0i64;
     let List.574 : U64 = CallByName List.6 List.159;
     let List.572 : {Str, Int1} = CallByName List.91 List.159 List.160 List.161 List.573 List.574;
-    dec List.159;
     ret List.572;
 
 procedure List.18 (List.159, List.160, List.161):
     let List.585 : U64 = 0i64;
     let List.586 : U64 = CallByName List.6 List.159;
     let List.584 : {Str, Int1} = CallByName List.91 List.159 List.160 List.161 List.585 List.586;
-    dec List.159;
     ret List.584;
 
 procedure List.6 (#Attr.2):
@@ -276,6 +263,7 @@ procedure List.91 (#Derived_gen.34, #Derived_gen.35, #Derived_gen.36, #Derived_g
             dec List.162;
             ret List.163;
     in
+    inc #Derived_gen.34;
     jump List.575 #Derived_gen.34 #Derived_gen.35 #Derived_gen.36 #Derived_gen.37 #Derived_gen.38;
 
 procedure List.91 (#Derived_gen.39, #Derived_gen.40, #Derived_gen.41, #Derived_gen.42, #Derived_gen.43):
@@ -292,6 +280,7 @@ procedure List.91 (#Derived_gen.39, #Derived_gen.40, #Derived_gen.41, #Derived_g
             dec List.162;
             ret List.163;
     in
+    inc #Derived_gen.39;
     jump List.587 #Derived_gen.39 #Derived_gen.40 #Derived_gen.41 #Derived_gen.42 #Derived_gen.43;
 
 procedure Num.22 (#Attr.2, #Attr.3):

--- a/crates/compiler/test_mono/generated/inspect_derived_nested_record_string.txt
+++ b/crates/compiler/test_mono/generated/inspect_derived_nested_record_string.txt
@@ -9,6 +9,7 @@ procedure #Derived.2 (#Derived.3, #Derived.1):
     let #Derived_gen.5 : List {Str, Str} = Array [#Derived_gen.6];
     let #Derived_gen.4 : List {Str, Str} = CallByName Inspect.41 #Derived_gen.5;
     let #Derived_gen.3 : Str = CallByName Inspect.31 #Derived_gen.4 #Derived.3;
+    dec #Derived_gen.4;
     ret #Derived_gen.3;
 
 procedure #Derived.4 (#Derived.5):
@@ -22,6 +23,7 @@ procedure #Derived.6 (#Derived.7, #Derived.5):
     let #Derived_gen.15 : List {Str, Str} = Array [#Derived_gen.16];
     let #Derived_gen.14 : List {Str, Str} = CallByName Inspect.41 #Derived_gen.15;
     let #Derived_gen.13 : Str = CallByName Inspect.31 #Derived_gen.14 #Derived.7;
+    dec #Derived_gen.14;
     ret #Derived_gen.13;
 
 procedure Bool.1 ():
@@ -35,21 +37,29 @@ procedure Bool.2 ():
 procedure Inspect.225 (Inspect.226, Inspect.224):
     let Inspect.348 : Str = "{";
     let Inspect.324 : Str = CallByName Inspect.59 Inspect.226 Inspect.348;
+    dec Inspect.348;
     let Inspect.320 : {Str, Int1} = CallByName Inspect.227 Inspect.324 Inspect.224;
+    dec Inspect.324;
+    dec Inspect.224;
     let Inspect.321 : {} = Struct {};
     let Inspect.316 : Str = CallByName Inspect.239 Inspect.320;
     let Inspect.317 : Str = "}";
     let Inspect.315 : Str = CallByName Inspect.59 Inspect.316 Inspect.317;
+    dec Inspect.317;
     ret Inspect.315;
 
 procedure Inspect.225 (Inspect.226, Inspect.224):
     let Inspect.388 : Str = "{";
     let Inspect.364 : Str = CallByName Inspect.59 Inspect.226 Inspect.388;
+    dec Inspect.388;
     let Inspect.360 : {Str, Int1} = CallByName Inspect.227 Inspect.364 Inspect.224;
+    dec Inspect.224;
+    dec Inspect.364;
     let Inspect.361 : {} = Struct {};
     let Inspect.356 : Str = CallByName Inspect.239 Inspect.360;
     let Inspect.357 : Str = "}";
     let Inspect.355 : Str = CallByName Inspect.59 Inspect.356 Inspect.357;
+    dec Inspect.357;
     ret Inspect.355;
 
 procedure Inspect.227 (Inspect.228, Inspect.224):
@@ -57,6 +67,7 @@ procedure Inspect.227 (Inspect.228, Inspect.224):
     let Inspect.328 : {Str, Int1} = Struct {Inspect.228, Inspect.347};
     let Inspect.329 : {} = Struct {};
     let Inspect.327 : {Str, Int1} = CallByName List.18 Inspect.224 Inspect.328 Inspect.329;
+    dec Inspect.224;
     ret Inspect.327;
 
 procedure Inspect.227 (Inspect.228, Inspect.224):
@@ -64,6 +75,7 @@ procedure Inspect.227 (Inspect.228, Inspect.224):
     let Inspect.368 : {Str, Int1} = Struct {Inspect.228, Inspect.387};
     let Inspect.369 : {} = Struct {};
     let Inspect.367 : {Str, Int1} = CallByName List.18 Inspect.224 Inspect.368 Inspect.369;
+    dec Inspect.224;
     ret Inspect.367;
 
 procedure Inspect.229 (Inspect.330, Inspect.331):
@@ -73,16 +85,22 @@ procedure Inspect.229 (Inspect.330, Inspect.331):
     let Inspect.231 : Int1 = StructAtIndex 1 Inspect.330;
     joinpoint Inspect.345 Inspect.234:
         let Inspect.342 : Str = CallByName Inspect.59 Inspect.234 Inspect.232;
+        dec Inspect.232;
         let Inspect.343 : Str = ": ";
         let Inspect.337 : Str = CallByName Inspect.59 Inspect.342 Inspect.343;
+        dec Inspect.343;
         let Inspect.333 : Str = CallByName Inspect.235 Inspect.337 Inspect.233;
+        dec Inspect.233;
+        dec Inspect.337;
         let Inspect.334 : {} = Struct {};
         let Inspect.332 : {Str, Int1} = CallByName Inspect.237 Inspect.333;
+        dec Inspect.333;
         ret Inspect.332;
     in
     if Inspect.231 then
         let Inspect.346 : Str = ", ";
         let Inspect.344 : Str = CallByName Inspect.59 Inspect.230 Inspect.346;
+        dec Inspect.346;
         jump Inspect.345 Inspect.344;
     else
         jump Inspect.345 Inspect.230;
@@ -94,26 +112,34 @@ procedure Inspect.229 (Inspect.330, Inspect.331):
     let Inspect.231 : Int1 = StructAtIndex 1 Inspect.330;
     joinpoint Inspect.385 Inspect.234:
         let Inspect.382 : Str = CallByName Inspect.59 Inspect.234 Inspect.232;
+        dec Inspect.232;
         let Inspect.383 : Str = ": ";
         let Inspect.377 : Str = CallByName Inspect.59 Inspect.382 Inspect.383;
+        dec Inspect.383;
         let Inspect.373 : Str = CallByName Inspect.235 Inspect.377 Inspect.233;
+        dec Inspect.233;
         let Inspect.374 : {} = Struct {};
         let Inspect.372 : {Str, Int1} = CallByName Inspect.237 Inspect.373;
+        dec Inspect.373;
         ret Inspect.372;
     in
     if Inspect.231 then
         let Inspect.386 : Str = ", ";
         let Inspect.384 : Str = CallByName Inspect.59 Inspect.230 Inspect.386;
+        dec Inspect.386;
         jump Inspect.385 Inspect.384;
     else
         jump Inspect.385 Inspect.230;
 
 procedure Inspect.235 (Inspect.236, Inspect.233):
     let Inspect.340 : Str = CallByName Inspect.31 Inspect.233 Inspect.236;
+    dec Inspect.233;
+    dec Inspect.236;
     ret Inspect.340;
 
 procedure Inspect.235 (Inspect.236, Inspect.233):
     let Inspect.380 : Str = CallByName Inspect.31 Inspect.233 Inspect.236;
+    dec Inspect.233;
     ret Inspect.380;
 
 procedure Inspect.237 (Inspect.238):
@@ -128,9 +154,12 @@ procedure Inspect.239 (Inspect.322):
 procedure Inspect.246 (Inspect.247, Inspect.245):
     let Inspect.397 : Str = "\"";
     let Inspect.396 : Str = CallByName Inspect.59 Inspect.247 Inspect.397;
+    dec Inspect.397;
     let Inspect.394 : Str = CallByName Inspect.59 Inspect.396 Inspect.245;
+    dec Inspect.245;
     let Inspect.395 : Str = "\"";
     let Inspect.393 : Str = CallByName Inspect.59 Inspect.394 Inspect.395;
+    dec Inspect.395;
     ret Inspect.393;
 
 procedure Inspect.30 (Inspect.143):
@@ -150,6 +179,7 @@ procedure Inspect.30 (Inspect.143):
 
 procedure Inspect.31 (Inspect.299, Inspect.145):
     let Inspect.310 : Str = CallByName Inspect.225 Inspect.145 Inspect.299;
+    dec Inspect.299;
     ret Inspect.310;
 
 procedure Inspect.31 (Inspect.299, Inspect.145):
@@ -158,10 +188,12 @@ procedure Inspect.31 (Inspect.299, Inspect.145):
 
 procedure Inspect.31 (Inspect.299, Inspect.145):
     let Inspect.350 : Str = CallByName Inspect.225 Inspect.145 Inspect.299;
+    dec Inspect.299;
     ret Inspect.350;
 
 procedure Inspect.31 (Inspect.299, Inspect.145):
     let Inspect.381 : Str = CallByName Inspect.246 Inspect.145 Inspect.299;
+    dec Inspect.299;
     ret Inspect.381;
 
 procedure Inspect.33 (Inspect.148):
@@ -204,12 +236,14 @@ procedure List.18 (List.159, List.160, List.161):
     let List.573 : U64 = 0i64;
     let List.574 : U64 = CallByName List.6 List.159;
     let List.572 : {Str, Int1} = CallByName List.91 List.159 List.160 List.161 List.573 List.574;
+    dec List.159;
     ret List.572;
 
 procedure List.18 (List.159, List.160, List.161):
     let List.585 : U64 = 0i64;
     let List.586 : U64 = CallByName List.6 List.159;
     let List.584 : {Str, Int1} = CallByName List.91 List.159 List.160 List.161 List.585 List.586;
+    dec List.159;
     ret List.584;
 
 procedure List.6 (#Attr.2):

--- a/crates/compiler/test_mono/generated/inspect_derived_record.txt
+++ b/crates/compiler/test_mono/generated/inspect_derived_record.txt
@@ -31,7 +31,6 @@ procedure Inspect.225 (Inspect.226, Inspect.224):
     dec Inspect.349;
     let Inspect.320 : {Str, Int1} = CallByName Inspect.227 Inspect.324 Inspect.224;
     dec Inspect.324;
-    dec Inspect.224;
     let Inspect.321 : {} = Struct {};
     let Inspect.316 : Str = CallByName Inspect.239 Inspect.320;
     let Inspect.317 : Str = "}";
@@ -41,10 +40,10 @@ procedure Inspect.225 (Inspect.226, Inspect.224):
 
 procedure Inspect.227 (Inspect.228, Inspect.224):
     let Inspect.348 : Int1 = CallByName Bool.1;
+    inc Inspect.228;
     let Inspect.328 : {Str, Int1} = Struct {Inspect.228, Inspect.348};
     let Inspect.329 : {} = Struct {};
     let Inspect.327 : {Str, Int1} = CallByName List.18 Inspect.224 Inspect.328 Inspect.329;
-    dec Inspect.224;
     ret Inspect.327;
 
 procedure Inspect.229 (Inspect.330, Inspect.331):
@@ -78,6 +77,7 @@ procedure Inspect.235 (Inspect.236, Inspect.233):
 
 procedure Inspect.237 (Inspect.238):
     let Inspect.336 : Int1 = CallByName Bool.2;
+    inc Inspect.238;
     let Inspect.335 : {Str, Int1} = Struct {Inspect.238, Inspect.336};
     ret Inspect.335;
 
@@ -110,7 +110,6 @@ procedure Inspect.30 (Inspect.143):
 
 procedure Inspect.31 (Inspect.299, Inspect.145):
     let Inspect.310 : Str = CallByName Inspect.225 Inspect.145 Inspect.299;
-    dec Inspect.299;
     ret Inspect.310;
 
 procedure Inspect.31 (Inspect.299, Inspect.145):
@@ -157,7 +156,6 @@ procedure Inspect.58 (Inspect.288):
 
 procedure Inspect.59 (Inspect.296, Inspect.292):
     let Inspect.319 : Str = CallByName Str.3 Inspect.296 Inspect.292;
-    dec Inspect.292;
     ret Inspect.319;
 
 procedure Inspect.60 (Inspect.298):
@@ -167,7 +165,6 @@ procedure List.18 (List.159, List.160, List.161):
     let List.573 : U64 = 0i64;
     let List.574 : U64 = CallByName List.6 List.159;
     let List.572 : {Str, Int1} = CallByName List.91 List.159 List.160 List.161 List.573 List.574;
-    dec List.159;
     ret List.572;
 
 procedure List.6 (#Attr.2):
@@ -192,6 +189,7 @@ procedure List.91 (#Derived_gen.24, #Derived_gen.25, #Derived_gen.26, #Derived_g
             dec List.162;
             ret List.163;
     in
+    inc #Derived_gen.24;
     jump List.575 #Derived_gen.24 #Derived_gen.25 #Derived_gen.26 #Derived_gen.27 #Derived_gen.28;
 
 procedure Num.22 (#Attr.2, #Attr.3):

--- a/crates/compiler/test_mono/generated/inspect_derived_record.txt
+++ b/crates/compiler/test_mono/generated/inspect_derived_record.txt
@@ -14,6 +14,7 @@ procedure #Derived.2 (#Derived.3, #Derived.1):
     let #Derived_gen.5 : List {[C I64, C Decimal], Str} = Array [#Derived_gen.6, #Derived_gen.7];
     let #Derived_gen.4 : List {[C I64, C Decimal], Str} = CallByName Inspect.41 #Derived_gen.5;
     let #Derived_gen.3 : Str = CallByName Inspect.31 #Derived_gen.4 #Derived.3;
+    dec #Derived_gen.4;
     ret #Derived_gen.3;
 
 procedure Bool.1 ():
@@ -27,11 +28,15 @@ procedure Bool.2 ():
 procedure Inspect.225 (Inspect.226, Inspect.224):
     let Inspect.349 : Str = "{";
     let Inspect.324 : Str = CallByName Inspect.59 Inspect.226 Inspect.349;
+    dec Inspect.349;
     let Inspect.320 : {Str, Int1} = CallByName Inspect.227 Inspect.324 Inspect.224;
+    dec Inspect.324;
+    dec Inspect.224;
     let Inspect.321 : {} = Struct {};
     let Inspect.316 : Str = CallByName Inspect.239 Inspect.320;
     let Inspect.317 : Str = "}";
     let Inspect.315 : Str = CallByName Inspect.59 Inspect.316 Inspect.317;
+    dec Inspect.317;
     ret Inspect.315;
 
 procedure Inspect.227 (Inspect.228, Inspect.224):
@@ -39,6 +44,7 @@ procedure Inspect.227 (Inspect.228, Inspect.224):
     let Inspect.328 : {Str, Int1} = Struct {Inspect.228, Inspect.348};
     let Inspect.329 : {} = Struct {};
     let Inspect.327 : {Str, Int1} = CallByName List.18 Inspect.224 Inspect.328 Inspect.329;
+    dec Inspect.224;
     ret Inspect.327;
 
 procedure Inspect.229 (Inspect.330, Inspect.331):
@@ -48,16 +54,20 @@ procedure Inspect.229 (Inspect.330, Inspect.331):
     let Inspect.231 : Int1 = StructAtIndex 1 Inspect.330;
     joinpoint Inspect.346 Inspect.234:
         let Inspect.343 : Str = CallByName Inspect.59 Inspect.234 Inspect.232;
+        dec Inspect.232;
         let Inspect.344 : Str = ": ";
         let Inspect.337 : Str = CallByName Inspect.59 Inspect.343 Inspect.344;
+        dec Inspect.344;
         let Inspect.333 : Str = CallByName Inspect.235 Inspect.337 Inspect.233;
         let Inspect.334 : {} = Struct {};
         let Inspect.332 : {Str, Int1} = CallByName Inspect.237 Inspect.333;
+        dec Inspect.333;
         ret Inspect.332;
     in
     if Inspect.231 then
         let Inspect.347 : Str = ", ";
         let Inspect.345 : Str = CallByName Inspect.59 Inspect.230 Inspect.347;
+        dec Inspect.347;
         jump Inspect.346 Inspect.345;
     else
         jump Inspect.346 Inspect.230;
@@ -79,12 +89,14 @@ procedure Inspect.274 (Inspect.275, #Attr.12):
     let Inspect.362 : I64 = UnionAtIndex (Id 0) (Index 0) #Attr.12;
     let Inspect.361 : Str = CallByName Num.96 Inspect.362;
     let Inspect.360 : Str = CallByName Inspect.59 Inspect.275 Inspect.361;
+    dec Inspect.361;
     ret Inspect.360;
 
 procedure Inspect.289 (Inspect.290, #Attr.12):
     let Inspect.356 : Decimal = UnionAtIndex (Id 1) (Index 0) #Attr.12;
     let Inspect.355 : Str = CallByName Num.96 Inspect.356;
     let Inspect.354 : Str = CallByName Inspect.59 Inspect.290 Inspect.355;
+    dec Inspect.355;
     ret Inspect.354;
 
 procedure Inspect.30 (Inspect.143):
@@ -98,6 +110,7 @@ procedure Inspect.30 (Inspect.143):
 
 procedure Inspect.31 (Inspect.299, Inspect.145):
     let Inspect.310 : Str = CallByName Inspect.225 Inspect.145 Inspect.299;
+    dec Inspect.299;
     ret Inspect.310;
 
 procedure Inspect.31 (Inspect.299, Inspect.145):
@@ -154,6 +167,7 @@ procedure List.18 (List.159, List.160, List.161):
     let List.573 : U64 = 0i64;
     let List.574 : U64 = CallByName List.6 List.159;
     let List.572 : {Str, Int1} = CallByName List.91 List.159 List.160 List.161 List.573 List.574;
+    dec List.159;
     ret List.572;
 
 procedure List.6 (#Attr.2):

--- a/crates/compiler/test_mono/generated/inspect_derived_record_one_field_string.txt
+++ b/crates/compiler/test_mono/generated/inspect_derived_record_one_field_string.txt
@@ -26,7 +26,6 @@ procedure Inspect.225 (Inspect.226, Inspect.224):
     dec Inspect.348;
     let Inspect.320 : {Str, Int1} = CallByName Inspect.227 Inspect.324 Inspect.224;
     dec Inspect.324;
-    dec Inspect.224;
     let Inspect.321 : {} = Struct {};
     let Inspect.316 : Str = CallByName Inspect.239 Inspect.320;
     let Inspect.317 : Str = "}";
@@ -36,10 +35,10 @@ procedure Inspect.225 (Inspect.226, Inspect.224):
 
 procedure Inspect.227 (Inspect.228, Inspect.224):
     let Inspect.347 : Int1 = CallByName Bool.1;
+    inc Inspect.228;
     let Inspect.328 : {Str, Int1} = Struct {Inspect.228, Inspect.347};
     let Inspect.329 : {} = Struct {};
     let Inspect.327 : {Str, Int1} = CallByName List.18 Inspect.224 Inspect.328 Inspect.329;
-    dec Inspect.224;
     ret Inspect.327;
 
 procedure Inspect.229 (Inspect.330, Inspect.331):
@@ -70,11 +69,11 @@ procedure Inspect.229 (Inspect.330, Inspect.331):
 
 procedure Inspect.235 (Inspect.236, Inspect.233):
     let Inspect.340 : Str = CallByName Inspect.31 Inspect.233 Inspect.236;
-    dec Inspect.233;
     ret Inspect.340;
 
 procedure Inspect.237 (Inspect.238):
     let Inspect.336 : Int1 = CallByName Bool.2;
+    inc Inspect.238;
     let Inspect.335 : {Str, Int1} = Struct {Inspect.238, Inspect.336};
     ret Inspect.335;
 
@@ -87,7 +86,6 @@ procedure Inspect.246 (Inspect.247, Inspect.245):
     let Inspect.356 : Str = CallByName Inspect.59 Inspect.247 Inspect.357;
     dec Inspect.357;
     let Inspect.354 : Str = CallByName Inspect.59 Inspect.356 Inspect.245;
-    dec Inspect.245;
     let Inspect.355 : Str = "\"";
     let Inspect.353 : Str = CallByName Inspect.59 Inspect.354 Inspect.355;
     dec Inspect.355;
@@ -104,12 +102,10 @@ procedure Inspect.30 (Inspect.143):
 
 procedure Inspect.31 (Inspect.299, Inspect.145):
     let Inspect.310 : Str = CallByName Inspect.225 Inspect.145 Inspect.299;
-    dec Inspect.299;
     ret Inspect.310;
 
 procedure Inspect.31 (Inspect.299, Inspect.145):
     let Inspect.341 : Str = CallByName Inspect.246 Inspect.145 Inspect.299;
-    dec Inspect.299;
     ret Inspect.341;
 
 procedure Inspect.33 (Inspect.148):
@@ -138,7 +134,6 @@ procedure Inspect.5 (Inspect.146):
 
 procedure Inspect.59 (Inspect.296, Inspect.292):
     let Inspect.319 : Str = CallByName Str.3 Inspect.296 Inspect.292;
-    dec Inspect.292;
     ret Inspect.319;
 
 procedure Inspect.60 (Inspect.298):
@@ -148,7 +143,6 @@ procedure List.18 (List.159, List.160, List.161):
     let List.573 : U64 = 0i64;
     let List.574 : U64 = CallByName List.6 List.159;
     let List.572 : {Str, Int1} = CallByName List.91 List.159 List.160 List.161 List.573 List.574;
-    dec List.159;
     ret List.572;
 
 procedure List.6 (#Attr.2):
@@ -173,6 +167,7 @@ procedure List.91 (#Derived_gen.18, #Derived_gen.19, #Derived_gen.20, #Derived_g
             dec List.162;
             ret List.163;
     in
+    inc #Derived_gen.18;
     jump List.575 #Derived_gen.18 #Derived_gen.19 #Derived_gen.20 #Derived_gen.21 #Derived_gen.22;
 
 procedure Num.22 (#Attr.2, #Attr.3):

--- a/crates/compiler/test_mono/generated/inspect_derived_record_one_field_string.txt
+++ b/crates/compiler/test_mono/generated/inspect_derived_record_one_field_string.txt
@@ -9,6 +9,7 @@ procedure #Derived.2 (#Derived.3, #Derived.1):
     let #Derived_gen.5 : List {Str, Str} = Array [#Derived_gen.6];
     let #Derived_gen.4 : List {Str, Str} = CallByName Inspect.41 #Derived_gen.5;
     let #Derived_gen.3 : Str = CallByName Inspect.31 #Derived_gen.4 #Derived.3;
+    dec #Derived_gen.4;
     ret #Derived_gen.3;
 
 procedure Bool.1 ():
@@ -22,11 +23,15 @@ procedure Bool.2 ():
 procedure Inspect.225 (Inspect.226, Inspect.224):
     let Inspect.348 : Str = "{";
     let Inspect.324 : Str = CallByName Inspect.59 Inspect.226 Inspect.348;
+    dec Inspect.348;
     let Inspect.320 : {Str, Int1} = CallByName Inspect.227 Inspect.324 Inspect.224;
+    dec Inspect.324;
+    dec Inspect.224;
     let Inspect.321 : {} = Struct {};
     let Inspect.316 : Str = CallByName Inspect.239 Inspect.320;
     let Inspect.317 : Str = "}";
     let Inspect.315 : Str = CallByName Inspect.59 Inspect.316 Inspect.317;
+    dec Inspect.317;
     ret Inspect.315;
 
 procedure Inspect.227 (Inspect.228, Inspect.224):
@@ -34,6 +39,7 @@ procedure Inspect.227 (Inspect.228, Inspect.224):
     let Inspect.328 : {Str, Int1} = Struct {Inspect.228, Inspect.347};
     let Inspect.329 : {} = Struct {};
     let Inspect.327 : {Str, Int1} = CallByName List.18 Inspect.224 Inspect.328 Inspect.329;
+    dec Inspect.224;
     ret Inspect.327;
 
 procedure Inspect.229 (Inspect.330, Inspect.331):
@@ -43,22 +49,28 @@ procedure Inspect.229 (Inspect.330, Inspect.331):
     let Inspect.231 : Int1 = StructAtIndex 1 Inspect.330;
     joinpoint Inspect.345 Inspect.234:
         let Inspect.342 : Str = CallByName Inspect.59 Inspect.234 Inspect.232;
+        dec Inspect.232;
         let Inspect.343 : Str = ": ";
         let Inspect.337 : Str = CallByName Inspect.59 Inspect.342 Inspect.343;
+        dec Inspect.343;
         let Inspect.333 : Str = CallByName Inspect.235 Inspect.337 Inspect.233;
+        dec Inspect.233;
         let Inspect.334 : {} = Struct {};
         let Inspect.332 : {Str, Int1} = CallByName Inspect.237 Inspect.333;
+        dec Inspect.333;
         ret Inspect.332;
     in
     if Inspect.231 then
         let Inspect.346 : Str = ", ";
         let Inspect.344 : Str = CallByName Inspect.59 Inspect.230 Inspect.346;
+        dec Inspect.346;
         jump Inspect.345 Inspect.344;
     else
         jump Inspect.345 Inspect.230;
 
 procedure Inspect.235 (Inspect.236, Inspect.233):
     let Inspect.340 : Str = CallByName Inspect.31 Inspect.233 Inspect.236;
+    dec Inspect.233;
     ret Inspect.340;
 
 procedure Inspect.237 (Inspect.238):
@@ -73,9 +85,12 @@ procedure Inspect.239 (Inspect.322):
 procedure Inspect.246 (Inspect.247, Inspect.245):
     let Inspect.357 : Str = "\"";
     let Inspect.356 : Str = CallByName Inspect.59 Inspect.247 Inspect.357;
+    dec Inspect.357;
     let Inspect.354 : Str = CallByName Inspect.59 Inspect.356 Inspect.245;
+    dec Inspect.245;
     let Inspect.355 : Str = "\"";
     let Inspect.353 : Str = CallByName Inspect.59 Inspect.354 Inspect.355;
+    dec Inspect.355;
     ret Inspect.353;
 
 procedure Inspect.30 (Inspect.143):
@@ -89,10 +104,12 @@ procedure Inspect.30 (Inspect.143):
 
 procedure Inspect.31 (Inspect.299, Inspect.145):
     let Inspect.310 : Str = CallByName Inspect.225 Inspect.145 Inspect.299;
+    dec Inspect.299;
     ret Inspect.310;
 
 procedure Inspect.31 (Inspect.299, Inspect.145):
     let Inspect.341 : Str = CallByName Inspect.246 Inspect.145 Inspect.299;
+    dec Inspect.299;
     ret Inspect.341;
 
 procedure Inspect.33 (Inspect.148):
@@ -131,6 +148,7 @@ procedure List.18 (List.159, List.160, List.161):
     let List.573 : U64 = 0i64;
     let List.574 : U64 = CallByName List.6 List.159;
     let List.572 : {Str, Int1} = CallByName List.91 List.159 List.160 List.161 List.573 List.574;
+    dec List.159;
     ret List.572;
 
 procedure List.6 (#Attr.2):

--- a/crates/compiler/test_mono/generated/inspect_derived_record_two_field_strings.txt
+++ b/crates/compiler/test_mono/generated/inspect_derived_record_two_field_strings.txt
@@ -16,6 +16,7 @@ procedure #Derived.2 (#Derived.3, #Derived.1):
     let #Derived_gen.5 : List {Str, Str} = Array [#Derived_gen.6, #Derived_gen.7];
     let #Derived_gen.4 : List {Str, Str} = CallByName Inspect.41 #Derived_gen.5;
     let #Derived_gen.3 : Str = CallByName Inspect.31 #Derived_gen.4 #Derived.3;
+    dec #Derived_gen.4;
     ret #Derived_gen.3;
 
 procedure Bool.1 ():
@@ -29,11 +30,15 @@ procedure Bool.2 ():
 procedure Inspect.225 (Inspect.226, Inspect.224):
     let Inspect.348 : Str = "{";
     let Inspect.324 : Str = CallByName Inspect.59 Inspect.226 Inspect.348;
+    dec Inspect.348;
     let Inspect.320 : {Str, Int1} = CallByName Inspect.227 Inspect.324 Inspect.224;
+    dec Inspect.324;
+    dec Inspect.224;
     let Inspect.321 : {} = Struct {};
     let Inspect.316 : Str = CallByName Inspect.239 Inspect.320;
     let Inspect.317 : Str = "}";
     let Inspect.315 : Str = CallByName Inspect.59 Inspect.316 Inspect.317;
+    dec Inspect.317;
     ret Inspect.315;
 
 procedure Inspect.227 (Inspect.228, Inspect.224):
@@ -41,6 +46,7 @@ procedure Inspect.227 (Inspect.228, Inspect.224):
     let Inspect.328 : {Str, Int1} = Struct {Inspect.228, Inspect.347};
     let Inspect.329 : {} = Struct {};
     let Inspect.327 : {Str, Int1} = CallByName List.18 Inspect.224 Inspect.328 Inspect.329;
+    dec Inspect.224;
     ret Inspect.327;
 
 procedure Inspect.229 (Inspect.330, Inspect.331):
@@ -50,22 +56,28 @@ procedure Inspect.229 (Inspect.330, Inspect.331):
     let Inspect.231 : Int1 = StructAtIndex 1 Inspect.330;
     joinpoint Inspect.345 Inspect.234:
         let Inspect.342 : Str = CallByName Inspect.59 Inspect.234 Inspect.232;
+        dec Inspect.232;
         let Inspect.343 : Str = ": ";
         let Inspect.337 : Str = CallByName Inspect.59 Inspect.342 Inspect.343;
+        dec Inspect.343;
         let Inspect.333 : Str = CallByName Inspect.235 Inspect.337 Inspect.233;
+        dec Inspect.233;
         let Inspect.334 : {} = Struct {};
         let Inspect.332 : {Str, Int1} = CallByName Inspect.237 Inspect.333;
+        dec Inspect.333;
         ret Inspect.332;
     in
     if Inspect.231 then
         let Inspect.346 : Str = ", ";
         let Inspect.344 : Str = CallByName Inspect.59 Inspect.230 Inspect.346;
+        dec Inspect.346;
         jump Inspect.345 Inspect.344;
     else
         jump Inspect.345 Inspect.230;
 
 procedure Inspect.235 (Inspect.236, Inspect.233):
     let Inspect.340 : Str = CallByName Inspect.31 Inspect.233 Inspect.236;
+    dec Inspect.233;
     ret Inspect.340;
 
 procedure Inspect.237 (Inspect.238):
@@ -80,9 +92,12 @@ procedure Inspect.239 (Inspect.322):
 procedure Inspect.246 (Inspect.247, Inspect.245):
     let Inspect.357 : Str = "\"";
     let Inspect.356 : Str = CallByName Inspect.59 Inspect.247 Inspect.357;
+    dec Inspect.357;
     let Inspect.354 : Str = CallByName Inspect.59 Inspect.356 Inspect.245;
+    dec Inspect.245;
     let Inspect.355 : Str = "\"";
     let Inspect.353 : Str = CallByName Inspect.59 Inspect.354 Inspect.355;
+    dec Inspect.355;
     ret Inspect.353;
 
 procedure Inspect.30 (Inspect.143):
@@ -96,10 +111,12 @@ procedure Inspect.30 (Inspect.143):
 
 procedure Inspect.31 (Inspect.299, Inspect.145):
     let Inspect.310 : Str = CallByName Inspect.225 Inspect.145 Inspect.299;
+    dec Inspect.299;
     ret Inspect.310;
 
 procedure Inspect.31 (Inspect.299, Inspect.145):
     let Inspect.341 : Str = CallByName Inspect.246 Inspect.145 Inspect.299;
+    dec Inspect.299;
     ret Inspect.341;
 
 procedure Inspect.33 (Inspect.148):
@@ -138,6 +155,7 @@ procedure List.18 (List.159, List.160, List.161):
     let List.573 : U64 = 0i64;
     let List.574 : U64 = CallByName List.6 List.159;
     let List.572 : {Str, Int1} = CallByName List.91 List.159 List.160 List.161 List.573 List.574;
+    dec List.159;
     ret List.572;
 
 procedure List.6 (#Attr.2):

--- a/crates/compiler/test_mono/generated/inspect_derived_record_two_field_strings.txt
+++ b/crates/compiler/test_mono/generated/inspect_derived_record_two_field_strings.txt
@@ -33,7 +33,6 @@ procedure Inspect.225 (Inspect.226, Inspect.224):
     dec Inspect.348;
     let Inspect.320 : {Str, Int1} = CallByName Inspect.227 Inspect.324 Inspect.224;
     dec Inspect.324;
-    dec Inspect.224;
     let Inspect.321 : {} = Struct {};
     let Inspect.316 : Str = CallByName Inspect.239 Inspect.320;
     let Inspect.317 : Str = "}";
@@ -43,10 +42,10 @@ procedure Inspect.225 (Inspect.226, Inspect.224):
 
 procedure Inspect.227 (Inspect.228, Inspect.224):
     let Inspect.347 : Int1 = CallByName Bool.1;
+    inc Inspect.228;
     let Inspect.328 : {Str, Int1} = Struct {Inspect.228, Inspect.347};
     let Inspect.329 : {} = Struct {};
     let Inspect.327 : {Str, Int1} = CallByName List.18 Inspect.224 Inspect.328 Inspect.329;
-    dec Inspect.224;
     ret Inspect.327;
 
 procedure Inspect.229 (Inspect.330, Inspect.331):
@@ -77,11 +76,11 @@ procedure Inspect.229 (Inspect.330, Inspect.331):
 
 procedure Inspect.235 (Inspect.236, Inspect.233):
     let Inspect.340 : Str = CallByName Inspect.31 Inspect.233 Inspect.236;
-    dec Inspect.233;
     ret Inspect.340;
 
 procedure Inspect.237 (Inspect.238):
     let Inspect.336 : Int1 = CallByName Bool.2;
+    inc Inspect.238;
     let Inspect.335 : {Str, Int1} = Struct {Inspect.238, Inspect.336};
     ret Inspect.335;
 
@@ -94,7 +93,6 @@ procedure Inspect.246 (Inspect.247, Inspect.245):
     let Inspect.356 : Str = CallByName Inspect.59 Inspect.247 Inspect.357;
     dec Inspect.357;
     let Inspect.354 : Str = CallByName Inspect.59 Inspect.356 Inspect.245;
-    dec Inspect.245;
     let Inspect.355 : Str = "\"";
     let Inspect.353 : Str = CallByName Inspect.59 Inspect.354 Inspect.355;
     dec Inspect.355;
@@ -111,12 +109,10 @@ procedure Inspect.30 (Inspect.143):
 
 procedure Inspect.31 (Inspect.299, Inspect.145):
     let Inspect.310 : Str = CallByName Inspect.225 Inspect.145 Inspect.299;
-    dec Inspect.299;
     ret Inspect.310;
 
 procedure Inspect.31 (Inspect.299, Inspect.145):
     let Inspect.341 : Str = CallByName Inspect.246 Inspect.145 Inspect.299;
-    dec Inspect.299;
     ret Inspect.341;
 
 procedure Inspect.33 (Inspect.148):
@@ -145,7 +141,6 @@ procedure Inspect.5 (Inspect.146):
 
 procedure Inspect.59 (Inspect.296, Inspect.292):
     let Inspect.319 : Str = CallByName Str.3 Inspect.296 Inspect.292;
-    dec Inspect.292;
     ret Inspect.319;
 
 procedure Inspect.60 (Inspect.298):
@@ -155,7 +150,6 @@ procedure List.18 (List.159, List.160, List.161):
     let List.573 : U64 = 0i64;
     let List.574 : U64 = CallByName List.6 List.159;
     let List.572 : {Str, Int1} = CallByName List.91 List.159 List.160 List.161 List.573 List.574;
-    dec List.159;
     ret List.572;
 
 procedure List.6 (#Attr.2):
@@ -180,6 +174,7 @@ procedure List.91 (#Derived_gen.22, #Derived_gen.23, #Derived_gen.24, #Derived_g
             dec List.162;
             ret List.163;
     in
+    inc #Derived_gen.22;
     jump List.575 #Derived_gen.22 #Derived_gen.23 #Derived_gen.24 #Derived_gen.25 #Derived_gen.26;
 
 procedure Num.22 (#Attr.2, #Attr.3):

--- a/crates/compiler/test_mono/generated/inspect_derived_string.txt
+++ b/crates/compiler/test_mono/generated/inspect_derived_string.txt
@@ -3,7 +3,6 @@ procedure Inspect.246 (Inspect.247, Inspect.245):
     let Inspect.318 : Str = CallByName Inspect.59 Inspect.247 Inspect.319;
     dec Inspect.319;
     let Inspect.314 : Str = CallByName Inspect.59 Inspect.318 Inspect.245;
-    dec Inspect.245;
     let Inspect.315 : Str = "\"";
     let Inspect.313 : Str = CallByName Inspect.59 Inspect.314 Inspect.315;
     dec Inspect.315;
@@ -35,7 +34,6 @@ procedure Inspect.5 (Inspect.146):
 
 procedure Inspect.59 (Inspect.296, Inspect.292):
     let Inspect.317 : Str = CallByName Str.3 Inspect.296 Inspect.292;
-    dec Inspect.292;
     ret Inspect.317;
 
 procedure Inspect.60 (Inspect.298):

--- a/crates/compiler/test_mono/generated/inspect_derived_string.txt
+++ b/crates/compiler/test_mono/generated/inspect_derived_string.txt
@@ -1,9 +1,12 @@
 procedure Inspect.246 (Inspect.247, Inspect.245):
     let Inspect.319 : Str = "\"";
     let Inspect.318 : Str = CallByName Inspect.59 Inspect.247 Inspect.319;
+    dec Inspect.319;
     let Inspect.314 : Str = CallByName Inspect.59 Inspect.318 Inspect.245;
+    dec Inspect.245;
     let Inspect.315 : Str = "\"";
     let Inspect.313 : Str = CallByName Inspect.59 Inspect.314 Inspect.315;
+    dec Inspect.315;
     ret Inspect.313;
 
 procedure Inspect.30 (Inspect.143):
@@ -27,6 +30,7 @@ procedure Inspect.5 (Inspect.146):
     let Inspect.305 : {} = Struct {};
     let Inspect.304 : Str = CallByName Inspect.35 Inspect.305;
     let Inspect.303 : Str = CallByName Inspect.246 Inspect.304 Inspect.308;
+    dec Inspect.308;
     ret Inspect.303;
 
 procedure Inspect.59 (Inspect.296, Inspect.292):

--- a/crates/compiler/test_mono/generated/inspect_derived_tag_one_field_string.txt
+++ b/crates/compiler/test_mono/generated/inspect_derived_tag_one_field_string.txt
@@ -44,8 +44,6 @@ procedure Inspect.202 (Inspect.203, #Attr.12):
 procedure Inspect.204 (Inspect.205, Inspect.199):
     let Inspect.325 : {} = Struct {};
     let Inspect.324 : Str = CallByName List.18 Inspect.199 Inspect.205 Inspect.325;
-    dec Inspect.205;
-    dec Inspect.199;
     ret Inspect.324;
 
 procedure Inspect.206 (Inspect.207, Inspect.208):
@@ -53,12 +51,10 @@ procedure Inspect.206 (Inspect.207, Inspect.208):
     let Inspect.327 : Str = CallByName Inspect.59 Inspect.207 Inspect.332;
     dec Inspect.332;
     let Inspect.326 : Str = CallByName Inspect.209 Inspect.327 Inspect.208;
-    dec Inspect.208;
     ret Inspect.326;
 
 procedure Inspect.209 (Inspect.210, Inspect.208):
     let Inspect.330 : Str = CallByName Inspect.31 Inspect.208 Inspect.210;
-    dec Inspect.208;
     ret Inspect.330;
 
 procedure Inspect.246 (Inspect.247, Inspect.245):
@@ -66,7 +62,6 @@ procedure Inspect.246 (Inspect.247, Inspect.245):
     let Inspect.350 : Str = CallByName Inspect.59 Inspect.247 Inspect.351;
     dec Inspect.351;
     let Inspect.348 : Str = CallByName Inspect.59 Inspect.350 Inspect.245;
-    dec Inspect.245;
     let Inspect.349 : Str = "\"";
     let Inspect.347 : Str = CallByName Inspect.59 Inspect.348 Inspect.349;
     dec Inspect.349;
@@ -95,7 +90,6 @@ procedure Inspect.31 (Inspect.299, Inspect.145):
 
 procedure Inspect.31 (Inspect.299, Inspect.145):
     let Inspect.331 : Str = CallByName Inspect.246 Inspect.145 Inspect.299;
-    dec Inspect.299;
     ret Inspect.331;
 
 procedure Inspect.33 (Inspect.148):
@@ -110,11 +104,13 @@ procedure Inspect.35 (Inspect.297):
 procedure Inspect.39 (Inspect.198, Inspect.199):
     let Inspect.337 : Int1 = CallByName List.1 Inspect.199;
     if Inspect.337 then
-        dec Inspect.199;
+        inc Inspect.198;
         let Inspect.339 : [C Str, C Str List Str] = TagId(0) Inspect.198;
         let Inspect.338 : [C Str, C Str List Str] = CallByName Inspect.30 Inspect.339;
         ret Inspect.338;
     else
+        inc Inspect.199;
+        inc Inspect.198;
         let Inspect.313 : [C Str, C Str List Str] = TagId(1) Inspect.198 Inspect.199;
         let Inspect.312 : [C Str, C Str List Str] = CallByName Inspect.30 Inspect.313;
         ret Inspect.312;
@@ -132,7 +128,6 @@ procedure Inspect.5 (Inspect.146):
 
 procedure Inspect.59 (Inspect.296, Inspect.292):
     let Inspect.320 : Str = CallByName Str.3 Inspect.296 Inspect.292;
-    dec Inspect.292;
     ret Inspect.320;
 
 procedure Inspect.60 (Inspect.298):
@@ -140,7 +135,6 @@ procedure Inspect.60 (Inspect.298):
 
 procedure List.1 (List.106):
     let List.585 : U64 = CallByName List.6 List.106;
-    dec List.106;
     let List.586 : U64 = 0i64;
     let List.584 : Int1 = CallByName Bool.11 List.585 List.586;
     ret List.584;
@@ -149,8 +143,6 @@ procedure List.18 (List.159, List.160, List.161):
     let List.573 : U64 = 0i64;
     let List.574 : U64 = CallByName List.6 List.159;
     let List.572 : Str = CallByName List.91 List.159 List.160 List.161 List.573 List.574;
-    dec List.160;
-    dec List.159;
     ret List.572;
 
 procedure List.6 (#Attr.2):
@@ -176,6 +168,8 @@ procedure List.91 (#Derived_gen.10, #Derived_gen.11, #Derived_gen.12, #Derived_g
             dec List.162;
             ret List.163;
     in
+    inc #Derived_gen.11;
+    inc #Derived_gen.10;
     jump List.575 #Derived_gen.10 #Derived_gen.11 #Derived_gen.12 #Derived_gen.13 #Derived_gen.14;
 
 procedure Num.22 (#Attr.2, #Attr.3):

--- a/crates/compiler/test_mono/generated/inspect_derived_tag_one_field_string.txt
+++ b/crates/compiler/test_mono/generated/inspect_derived_tag_one_field_string.txt
@@ -11,6 +11,8 @@ procedure #Derived.3 (#Derived.4, #Derived.1):
     let #Derived_gen.9 : Str = CallByName Inspect.43 #Derived.1;
     let #Derived_gen.8 : List Str = Array [#Derived_gen.9];
     let #Derived_gen.6 : [C Str, C Str List Str] = CallByName Inspect.39 #Derived_gen.7 #Derived_gen.8;
+    dec #Derived_gen.8;
+    dec #Derived_gen.7;
     jump #Derived_gen.5 #Derived_gen.6;
 
 procedure Bool.11 (#Attr.2, #Attr.3):
@@ -20,6 +22,7 @@ procedure Bool.11 (#Attr.2, #Attr.3):
 procedure Inspect.200 (Inspect.201, #Attr.12):
     let Inspect.342 : Str = UnionAtIndex (Id 0) (Index 0) #Attr.12;
     let Inspect.341 : Str = CallByName Inspect.59 Inspect.201 Inspect.342;
+    dec Inspect.342;
     ret Inspect.341;
 
 procedure Inspect.202 (Inspect.203, #Attr.12):
@@ -27,33 +30,46 @@ procedure Inspect.202 (Inspect.203, #Attr.12):
     let Inspect.335 : Str = UnionAtIndex (Id 1) (Index 0) #Attr.12;
     let Inspect.334 : Str = "(";
     let Inspect.333 : Str = CallByName Inspect.59 Inspect.203 Inspect.334;
+    dec Inspect.334;
     let Inspect.321 : Str = CallByName Inspect.59 Inspect.333 Inspect.335;
+    dec Inspect.335;
     let Inspect.317 : Str = CallByName Inspect.204 Inspect.321 Inspect.336;
+    dec Inspect.321;
+    dec Inspect.336;
     let Inspect.318 : Str = ")";
     let Inspect.316 : Str = CallByName Inspect.59 Inspect.317 Inspect.318;
+    dec Inspect.318;
     ret Inspect.316;
 
 procedure Inspect.204 (Inspect.205, Inspect.199):
     let Inspect.325 : {} = Struct {};
     let Inspect.324 : Str = CallByName List.18 Inspect.199 Inspect.205 Inspect.325;
+    dec Inspect.205;
+    dec Inspect.199;
     ret Inspect.324;
 
 procedure Inspect.206 (Inspect.207, Inspect.208):
     let Inspect.332 : Str = " ";
     let Inspect.327 : Str = CallByName Inspect.59 Inspect.207 Inspect.332;
+    dec Inspect.332;
     let Inspect.326 : Str = CallByName Inspect.209 Inspect.327 Inspect.208;
+    dec Inspect.208;
     ret Inspect.326;
 
 procedure Inspect.209 (Inspect.210, Inspect.208):
     let Inspect.330 : Str = CallByName Inspect.31 Inspect.208 Inspect.210;
+    dec Inspect.208;
     ret Inspect.330;
 
 procedure Inspect.246 (Inspect.247, Inspect.245):
     let Inspect.351 : Str = "\"";
     let Inspect.350 : Str = CallByName Inspect.59 Inspect.247 Inspect.351;
+    dec Inspect.351;
     let Inspect.348 : Str = CallByName Inspect.59 Inspect.350 Inspect.245;
+    dec Inspect.245;
     let Inspect.349 : Str = "\"";
     let Inspect.347 : Str = CallByName Inspect.59 Inspect.348 Inspect.349;
+    dec Inspect.349;
     ret Inspect.347;
 
 procedure Inspect.30 (Inspect.143):
@@ -79,6 +95,7 @@ procedure Inspect.31 (Inspect.299, Inspect.145):
 
 procedure Inspect.31 (Inspect.299, Inspect.145):
     let Inspect.331 : Str = CallByName Inspect.246 Inspect.145 Inspect.299;
+    dec Inspect.299;
     ret Inspect.331;
 
 procedure Inspect.33 (Inspect.148):
@@ -91,7 +108,6 @@ procedure Inspect.35 (Inspect.297):
     ret Inspect.307;
 
 procedure Inspect.39 (Inspect.198, Inspect.199):
-    inc Inspect.199;
     let Inspect.337 : Int1 = CallByName List.1 Inspect.199;
     if Inspect.337 then
         dec Inspect.199;
@@ -133,6 +149,8 @@ procedure List.18 (List.159, List.160, List.161):
     let List.573 : U64 = 0i64;
     let List.574 : U64 = CallByName List.6 List.159;
     let List.572 : Str = CallByName List.91 List.159 List.160 List.161 List.573 List.574;
+    dec List.160;
+    dec List.159;
     ret List.572;
 
 procedure List.6 (#Attr.2):
@@ -150,6 +168,7 @@ procedure List.91 (#Derived_gen.10, #Derived_gen.11, #Derived_gen.12, #Derived_g
             let List.581 : Str = CallByName List.66 List.162 List.165;
             inc List.581;
             let List.167 : Str = CallByName Inspect.206 List.163 List.581;
+            dec List.581;
             let List.580 : U64 = 1i64;
             let List.579 : U64 = CallByName Num.51 List.165 List.580;
             jump List.575 List.162 List.167 List.164 List.579 List.166;

--- a/crates/compiler/test_mono/generated/inspect_derived_tag_two_payloads_string.txt
+++ b/crates/compiler/test_mono/generated/inspect_derived_tag_two_payloads_string.txt
@@ -47,8 +47,6 @@ procedure Inspect.202 (Inspect.203, #Attr.12):
 procedure Inspect.204 (Inspect.205, Inspect.199):
     let Inspect.325 : {} = Struct {};
     let Inspect.324 : Str = CallByName List.18 Inspect.199 Inspect.205 Inspect.325;
-    dec Inspect.205;
-    dec Inspect.199;
     ret Inspect.324;
 
 procedure Inspect.206 (Inspect.207, Inspect.208):
@@ -56,12 +54,10 @@ procedure Inspect.206 (Inspect.207, Inspect.208):
     let Inspect.327 : Str = CallByName Inspect.59 Inspect.207 Inspect.332;
     dec Inspect.332;
     let Inspect.326 : Str = CallByName Inspect.209 Inspect.327 Inspect.208;
-    dec Inspect.208;
     ret Inspect.326;
 
 procedure Inspect.209 (Inspect.210, Inspect.208):
     let Inspect.330 : Str = CallByName Inspect.31 Inspect.208 Inspect.210;
-    dec Inspect.208;
     ret Inspect.330;
 
 procedure Inspect.246 (Inspect.247, Inspect.245):
@@ -69,7 +65,6 @@ procedure Inspect.246 (Inspect.247, Inspect.245):
     let Inspect.350 : Str = CallByName Inspect.59 Inspect.247 Inspect.351;
     dec Inspect.351;
     let Inspect.348 : Str = CallByName Inspect.59 Inspect.350 Inspect.245;
-    dec Inspect.245;
     let Inspect.349 : Str = "\"";
     let Inspect.347 : Str = CallByName Inspect.59 Inspect.348 Inspect.349;
     dec Inspect.349;
@@ -98,7 +93,6 @@ procedure Inspect.31 (Inspect.299, Inspect.145):
 
 procedure Inspect.31 (Inspect.299, Inspect.145):
     let Inspect.331 : Str = CallByName Inspect.246 Inspect.145 Inspect.299;
-    dec Inspect.299;
     ret Inspect.331;
 
 procedure Inspect.33 (Inspect.148):
@@ -113,11 +107,13 @@ procedure Inspect.35 (Inspect.297):
 procedure Inspect.39 (Inspect.198, Inspect.199):
     let Inspect.337 : Int1 = CallByName List.1 Inspect.199;
     if Inspect.337 then
-        dec Inspect.199;
+        inc Inspect.198;
         let Inspect.339 : [C Str, C Str List Str] = TagId(0) Inspect.198;
         let Inspect.338 : [C Str, C Str List Str] = CallByName Inspect.30 Inspect.339;
         ret Inspect.338;
     else
+        inc Inspect.199;
+        inc Inspect.198;
         let Inspect.313 : [C Str, C Str List Str] = TagId(1) Inspect.198 Inspect.199;
         let Inspect.312 : [C Str, C Str List Str] = CallByName Inspect.30 Inspect.313;
         ret Inspect.312;
@@ -135,7 +131,6 @@ procedure Inspect.5 (Inspect.146):
 
 procedure Inspect.59 (Inspect.296, Inspect.292):
     let Inspect.320 : Str = CallByName Str.3 Inspect.296 Inspect.292;
-    dec Inspect.292;
     ret Inspect.320;
 
 procedure Inspect.60 (Inspect.298):
@@ -143,7 +138,6 @@ procedure Inspect.60 (Inspect.298):
 
 procedure List.1 (List.106):
     let List.585 : U64 = CallByName List.6 List.106;
-    dec List.106;
     let List.586 : U64 = 0i64;
     let List.584 : Int1 = CallByName Bool.11 List.585 List.586;
     ret List.584;
@@ -152,8 +146,6 @@ procedure List.18 (List.159, List.160, List.161):
     let List.573 : U64 = 0i64;
     let List.574 : U64 = CallByName List.6 List.159;
     let List.572 : Str = CallByName List.91 List.159 List.160 List.161 List.573 List.574;
-    dec List.160;
-    dec List.159;
     ret List.572;
 
 procedure List.6 (#Attr.2):
@@ -179,6 +171,8 @@ procedure List.91 (#Derived_gen.13, #Derived_gen.14, #Derived_gen.15, #Derived_g
             dec List.162;
             ret List.163;
     in
+    inc #Derived_gen.14;
+    inc #Derived_gen.13;
     jump List.575 #Derived_gen.13 #Derived_gen.14 #Derived_gen.15 #Derived_gen.16 #Derived_gen.17;
 
 procedure Num.22 (#Attr.2, #Attr.3):

--- a/crates/compiler/test_mono/generated/inspect_derived_tag_two_payloads_string.txt
+++ b/crates/compiler/test_mono/generated/inspect_derived_tag_two_payloads_string.txt
@@ -14,6 +14,8 @@ procedure #Derived.4 (#Derived.5, #Derived.1):
     let #Derived_gen.10 : Str = CallByName Inspect.43 #Derived.3;
     let #Derived_gen.8 : List Str = Array [#Derived_gen.9, #Derived_gen.10];
     let #Derived_gen.6 : [C Str, C Str List Str] = CallByName Inspect.39 #Derived_gen.7 #Derived_gen.8;
+    dec #Derived_gen.8;
+    dec #Derived_gen.7;
     jump #Derived_gen.5 #Derived_gen.6;
 
 procedure Bool.11 (#Attr.2, #Attr.3):
@@ -23,6 +25,7 @@ procedure Bool.11 (#Attr.2, #Attr.3):
 procedure Inspect.200 (Inspect.201, #Attr.12):
     let Inspect.342 : Str = UnionAtIndex (Id 0) (Index 0) #Attr.12;
     let Inspect.341 : Str = CallByName Inspect.59 Inspect.201 Inspect.342;
+    dec Inspect.342;
     ret Inspect.341;
 
 procedure Inspect.202 (Inspect.203, #Attr.12):
@@ -30,33 +33,46 @@ procedure Inspect.202 (Inspect.203, #Attr.12):
     let Inspect.335 : Str = UnionAtIndex (Id 1) (Index 0) #Attr.12;
     let Inspect.334 : Str = "(";
     let Inspect.333 : Str = CallByName Inspect.59 Inspect.203 Inspect.334;
+    dec Inspect.334;
     let Inspect.321 : Str = CallByName Inspect.59 Inspect.333 Inspect.335;
+    dec Inspect.335;
     let Inspect.317 : Str = CallByName Inspect.204 Inspect.321 Inspect.336;
+    dec Inspect.321;
+    dec Inspect.336;
     let Inspect.318 : Str = ")";
     let Inspect.316 : Str = CallByName Inspect.59 Inspect.317 Inspect.318;
+    dec Inspect.318;
     ret Inspect.316;
 
 procedure Inspect.204 (Inspect.205, Inspect.199):
     let Inspect.325 : {} = Struct {};
     let Inspect.324 : Str = CallByName List.18 Inspect.199 Inspect.205 Inspect.325;
+    dec Inspect.205;
+    dec Inspect.199;
     ret Inspect.324;
 
 procedure Inspect.206 (Inspect.207, Inspect.208):
     let Inspect.332 : Str = " ";
     let Inspect.327 : Str = CallByName Inspect.59 Inspect.207 Inspect.332;
+    dec Inspect.332;
     let Inspect.326 : Str = CallByName Inspect.209 Inspect.327 Inspect.208;
+    dec Inspect.208;
     ret Inspect.326;
 
 procedure Inspect.209 (Inspect.210, Inspect.208):
     let Inspect.330 : Str = CallByName Inspect.31 Inspect.208 Inspect.210;
+    dec Inspect.208;
     ret Inspect.330;
 
 procedure Inspect.246 (Inspect.247, Inspect.245):
     let Inspect.351 : Str = "\"";
     let Inspect.350 : Str = CallByName Inspect.59 Inspect.247 Inspect.351;
+    dec Inspect.351;
     let Inspect.348 : Str = CallByName Inspect.59 Inspect.350 Inspect.245;
+    dec Inspect.245;
     let Inspect.349 : Str = "\"";
     let Inspect.347 : Str = CallByName Inspect.59 Inspect.348 Inspect.349;
+    dec Inspect.349;
     ret Inspect.347;
 
 procedure Inspect.30 (Inspect.143):
@@ -82,6 +98,7 @@ procedure Inspect.31 (Inspect.299, Inspect.145):
 
 procedure Inspect.31 (Inspect.299, Inspect.145):
     let Inspect.331 : Str = CallByName Inspect.246 Inspect.145 Inspect.299;
+    dec Inspect.299;
     ret Inspect.331;
 
 procedure Inspect.33 (Inspect.148):
@@ -94,7 +111,6 @@ procedure Inspect.35 (Inspect.297):
     ret Inspect.307;
 
 procedure Inspect.39 (Inspect.198, Inspect.199):
-    inc Inspect.199;
     let Inspect.337 : Int1 = CallByName List.1 Inspect.199;
     if Inspect.337 then
         dec Inspect.199;
@@ -136,6 +152,8 @@ procedure List.18 (List.159, List.160, List.161):
     let List.573 : U64 = 0i64;
     let List.574 : U64 = CallByName List.6 List.159;
     let List.572 : Str = CallByName List.91 List.159 List.160 List.161 List.573 List.574;
+    dec List.160;
+    dec List.159;
     ret List.572;
 
 procedure List.6 (#Attr.2):
@@ -153,6 +171,7 @@ procedure List.91 (#Derived_gen.13, #Derived_gen.14, #Derived_gen.15, #Derived_g
             let List.581 : Str = CallByName List.66 List.162 List.165;
             inc List.581;
             let List.167 : Str = CallByName Inspect.206 List.163 List.581;
+            dec List.581;
             let List.580 : U64 = 1i64;
             let List.579 : U64 = CallByName Num.51 List.165 List.580;
             jump List.575 List.162 List.167 List.164 List.579 List.166;

--- a/crates/compiler/test_mono/generated/issue_2583_specialize_errors_behind_unified_branches.txt
+++ b/crates/compiler/test_mono/generated/issue_2583_specialize_errors_behind_unified_branches.txt
@@ -31,6 +31,7 @@ procedure List.66 (#Attr.2, #Attr.3):
 procedure List.9 (List.334):
     let List.579 : U64 = 0i64;
     let List.572 : [C {}, C I64] = CallByName List.2 List.334 List.579;
+    dec List.334;
     let List.576 : U8 = 1i64;
     let List.577 : U8 = GetTagId List.572;
     let List.578 : Int1 = lowlevel Eq List.576 List.577;
@@ -49,6 +50,7 @@ procedure Num.22 (#Attr.2, #Attr.3):
 
 procedure Str.27 (Str.78):
     let Str.232 : [C Int1, C I64] = CallByName Str.60 Str.78;
+    dec Str.78;
     ret Str.232;
 
 procedure Str.42 (#Attr.2):
@@ -75,8 +77,10 @@ procedure Test.0 ():
     if Test.3 then
         let Test.5 : List I64 = Array [];
         let Test.4 : [C Int1, C I64] = CallByName List.9 Test.5;
+        dec Test.5;
         ret Test.4;
     else
         let Test.2 : Str = "";
         let Test.1 : [C Int1, C I64] = CallByName Str.27 Test.2;
+        dec Test.2;
         ret Test.1;

--- a/crates/compiler/test_mono/generated/issue_2583_specialize_errors_behind_unified_branches.txt
+++ b/crates/compiler/test_mono/generated/issue_2583_specialize_errors_behind_unified_branches.txt
@@ -11,11 +11,9 @@ procedure List.2 (List.107, List.108):
     let List.582 : Int1 = CallByName Num.22 List.108 List.586;
     if List.582 then
         let List.584 : I64 = CallByName List.66 List.107 List.108;
-        dec List.107;
         let List.583 : [C {}, C I64] = TagId(1) List.584;
         ret List.583;
     else
-        dec List.107;
         let List.581 : {} = Struct {};
         let List.580 : [C {}, C I64] = TagId(0) List.581;
         ret List.580;
@@ -31,7 +29,6 @@ procedure List.66 (#Attr.2, #Attr.3):
 procedure List.9 (List.334):
     let List.579 : U64 = 0i64;
     let List.572 : [C {}, C I64] = CallByName List.2 List.334 List.579;
-    dec List.334;
     let List.576 : U8 = 1i64;
     let List.577 : U8 = GetTagId List.572;
     let List.578 : Int1 = lowlevel Eq List.576 List.577;
@@ -50,7 +47,6 @@ procedure Num.22 (#Attr.2, #Attr.3):
 
 procedure Str.27 (Str.78):
     let Str.232 : [C Int1, C I64] = CallByName Str.60 Str.78;
-    dec Str.78;
     ret Str.232;
 
 procedure Str.42 (#Attr.2):
@@ -59,7 +55,6 @@ procedure Str.42 (#Attr.2):
 
 procedure Str.60 (Str.185):
     let Str.186 : {I64, U8} = CallByName Str.42 Str.185;
-    dec Str.185;
     let Str.238 : U8 = StructAtIndex 1 Str.186;
     let Str.239 : U8 = 0i64;
     let Str.235 : Int1 = CallByName Bool.11 Str.238 Str.239;

--- a/crates/compiler/test_mono/generated/issue_4749.txt
+++ b/crates/compiler/test_mono/generated/issue_4749.txt
@@ -65,7 +65,6 @@ procedure Decode.27 (Decode.107, Decode.108):
 
 procedure List.1 (List.106):
     let List.626 : U64 = CallByName List.6 List.106;
-    dec List.106;
     let List.627 : U64 = 0i64;
     let List.625 : Int1 = CallByName Bool.11 List.626 List.627;
     ret List.625;
@@ -74,7 +73,6 @@ procedure List.103 (List.487, List.488, List.489):
     let List.635 : U64 = 0i64;
     let List.636 : U64 = CallByName List.6 List.487;
     let List.634 : [C [C U64, C U64, C U64, C , C , C U64, C U64, C U64, C U64], C [C U64, C U64, C U64, C , C , C U64, C U64, C U64, C U64]] = CallByName List.80 List.487 List.488 List.489 List.635 List.636;
-    dec List.487;
     ret List.634;
 
 procedure List.2 (List.107, List.108):
@@ -82,18 +80,15 @@ procedure List.2 (List.107, List.108):
     let List.614 : Int1 = CallByName Num.22 List.108 List.617;
     if List.614 then
         let List.616 : U8 = CallByName List.66 List.107 List.108;
-        dec List.107;
         let List.615 : [C {}, C U8] = TagId(1) List.616;
         ret List.615;
     else
-        dec List.107;
         let List.613 : {} = Struct {};
         let List.612 : [C {}, C U8] = TagId(0) List.613;
         ret List.612;
 
 procedure List.26 (List.200, List.201, List.202):
     let List.628 : [C [C U64, C U64, C U64, C , C , C U64, C U64, C U64, C U64], C [C U64, C U64, C U64, C , C , C U64, C U64, C U64, C U64]] = CallByName List.103 List.200 List.201 List.202;
-    dec List.200;
     let List.631 : U8 = 1i64;
     let List.632 : U8 = GetTagId List.628;
     let List.633 : Int1 = lowlevel Eq List.631 List.632;
@@ -177,6 +172,7 @@ procedure List.80 (#Derived_gen.1, #Derived_gen.2, #Derived_gen.3, #Derived_gen.
             let List.638 : [C [C U64, C U64, C U64, C , C , C U64, C U64, C U64, C U64], C [C U64, C U64, C U64, C , C , C U64, C U64, C U64, C U64]] = TagId(1) List.491;
             ret List.638;
     in
+    inc #Derived_gen.1;
     jump List.637 #Derived_gen.1 #Derived_gen.2 #Derived_gen.3 #Derived_gen.4 #Derived_gen.5;
 
 procedure Num.19 (#Attr.2, #Attr.3):
@@ -341,6 +337,7 @@ procedure TotallyNotJson.488 (TotallyNotJson.489, TotallyNotJson.973):
 
 procedure TotallyNotJson.497 (TotallyNotJson.498):
     let TotallyNotJson.1116 : List U8 = Array [];
+    inc TotallyNotJson.498;
     let TotallyNotJson.995 : {List U8, List U8} = Struct {TotallyNotJson.498, TotallyNotJson.1116};
     let TotallyNotJson.994 : {List U8, List U8} = CallByName TotallyNotJson.69 TotallyNotJson.995;
     ret TotallyNotJson.994;

--- a/crates/compiler/test_mono/generated/issue_4749.txt
+++ b/crates/compiler/test_mono/generated/issue_4749.txt
@@ -41,7 +41,6 @@ procedure Decode.26 (Decode.105, Decode.106):
 procedure Decode.27 (Decode.107, Decode.108):
     let Decode.122 : {List U8, [C {}, C Str]} = CallByName Decode.26 Decode.107 Decode.108;
     let Decode.110 : List U8 = StructAtIndex 0 Decode.122;
-    inc Decode.110;
     let Decode.109 : [C {}, C Str] = StructAtIndex 1 Decode.122;
     let Decode.125 : Int1 = CallByName List.1 Decode.110;
     if Decode.125 then
@@ -75,6 +74,7 @@ procedure List.103 (List.487, List.488, List.489):
     let List.635 : U64 = 0i64;
     let List.636 : U64 = CallByName List.6 List.487;
     let List.634 : [C [C U64, C U64, C U64, C , C , C U64, C U64, C U64, C U64], C [C U64, C U64, C U64, C , C , C U64, C U64, C U64, C U64]] = CallByName List.80 List.487 List.488 List.489 List.635 List.636;
+    dec List.487;
     ret List.634;
 
 procedure List.2 (List.107, List.108):
@@ -93,6 +93,7 @@ procedure List.2 (List.107, List.108):
 
 procedure List.26 (List.200, List.201, List.202):
     let List.628 : [C [C U64, C U64, C U64, C , C , C U64, C U64, C U64, C U64], C [C U64, C U64, C U64, C , C , C U64, C U64, C U64, C U64]] = CallByName List.103 List.200 List.201 List.202;
+    dec List.200;
     let List.631 : U8 = 1i64;
     let List.632 : U8 = GetTagId List.628;
     let List.633 : Int1 = lowlevel Eq List.631 List.632;
@@ -259,7 +260,6 @@ procedure TotallyNotJson.488 (TotallyNotJson.489, TotallyNotJson.973):
         let TotallyNotJson.1126 : {List U8, List U8} = CallByName TotallyNotJson.60 TotallyNotJson.489;
         let TotallyNotJson.493 : List U8 = StructAtIndex 0 TotallyNotJson.1126;
         let TotallyNotJson.492 : List U8 = StructAtIndex 1 TotallyNotJson.1126;
-        inc TotallyNotJson.492;
         let TotallyNotJson.1122 : Int1 = CallByName List.1 TotallyNotJson.492;
         if TotallyNotJson.1122 then
             dec TotallyNotJson.492;
@@ -277,6 +277,7 @@ procedure TotallyNotJson.488 (TotallyNotJson.489, TotallyNotJson.973):
             let TotallyNotJson.992 : List U8 = CallByName List.49 TotallyNotJson.492 TotallyNotJson.1117;
             let TotallyNotJson.993 : {} = Struct {};
             let TotallyNotJson.988 : {List U8, List U8} = CallByName TotallyNotJson.497 TotallyNotJson.992;
+            dec TotallyNotJson.992;
             let TotallyNotJson.989 : {} = Struct {};
             let TotallyNotJson.987 : List U8 = CallByName TotallyNotJson.499 TotallyNotJson.988;
             let TotallyNotJson.496 : [C {U64, U8}, C Str] = CallByName Str.9 TotallyNotJson.987;
@@ -358,14 +359,13 @@ procedure TotallyNotJson.59 ():
 procedure TotallyNotJson.60 (TotallyNotJson.504):
     let TotallyNotJson.1138 : [C U64, C U64, C U64, C , C , C U64, C U64, C U64, C U64] = TagId(4) ;
     let TotallyNotJson.1139 : {} = Struct {};
-    inc TotallyNotJson.504;
     let TotallyNotJson.1127 : [C U64, C U64, C U64, C , C , C U64, C U64, C U64, C U64] = CallByName List.26 TotallyNotJson.504 TotallyNotJson.1138 TotallyNotJson.1139;
     let TotallyNotJson.1135 : U8 = 2i64;
     let TotallyNotJson.1136 : U8 = GetTagId TotallyNotJson.1127;
     let TotallyNotJson.1137 : Int1 = lowlevel Eq TotallyNotJson.1135 TotallyNotJson.1136;
     if TotallyNotJson.1137 then
-        inc TotallyNotJson.504;
         let TotallyNotJson.506 : U64 = UnionAtIndex (Id 2) (Index 0) TotallyNotJson.1127;
+        inc TotallyNotJson.504;
         let TotallyNotJson.1129 : List U8 = CallByName List.38 TotallyNotJson.504 TotallyNotJson.506;
         let TotallyNotJson.1132 : U64 = 0i64;
         let TotallyNotJson.1131 : {U64, U64} = Struct {TotallyNotJson.506, TotallyNotJson.1132};
@@ -717,7 +717,7 @@ procedure TotallyNotJson.68 ():
 procedure TotallyNotJson.69 (#Derived_gen.0):
     joinpoint TotallyNotJson.996 TotallyNotJson.967:
         let TotallyNotJson.563 : List U8 = StructAtIndex 0 TotallyNotJson.967;
-        inc 4 TotallyNotJson.563;
+        inc 2 TotallyNotJson.563;
         let TotallyNotJson.564 : List U8 = StructAtIndex 1 TotallyNotJson.967;
         let TotallyNotJson.1115 : U64 = 0i64;
         let TotallyNotJson.565 : [C {}, C U8] = CallByName List.2 TotallyNotJson.563 TotallyNotJson.1115;

--- a/crates/compiler/test_mono/generated/issue_4770.txt
+++ b/crates/compiler/test_mono/generated/issue_4770.txt
@@ -10,6 +10,7 @@ procedure List.103 (List.487, List.488, List.489):
     let List.586 : U64 = 0i64;
     let List.587 : U64 = CallByName List.6 List.487;
     let List.585 : [C {}, C {}] = CallByName List.80 List.487 List.488 List.489 List.586 List.587;
+    dec List.487;
     ret List.585;
 
 procedure List.23 (#Attr.2, #Attr.3, #Attr.4):
@@ -32,6 +33,7 @@ procedure List.235 (List.574, List.236, List.234):
 procedure List.56 (List.233, List.234):
     let List.583 : {} = Struct {};
     let List.575 : [C {}, C {}] = CallByName List.103 List.233 List.583 List.234;
+    dec List.233;
     let List.580 : U8 = 1i64;
     let List.581 : U8 = GetTagId List.575;
     let List.582 : Int1 = lowlevel Eq List.580 List.581;
@@ -146,6 +148,7 @@ procedure Test.1 (#Derived_gen.0):
                     let Test.33 : List {[<r>C I64, C List *self], [<r>C I64, C List *self]} = CallByName List.23 Test.12 Test.14 Test.35;
                     let Test.34 : {} = Struct {};
                     let Test.29 : Int1 = CallByName List.56 Test.33 Test.34;
+                    dec Test.33;
                     if Test.29 then
                         let Test.31 : U64 = CallByName List.6 Test.12;
                         dec Test.12;

--- a/crates/compiler/test_mono/generated/issue_4770.txt
+++ b/crates/compiler/test_mono/generated/issue_4770.txt
@@ -10,7 +10,6 @@ procedure List.103 (List.487, List.488, List.489):
     let List.586 : U64 = 0i64;
     let List.587 : U64 = CallByName List.6 List.487;
     let List.585 : [C {}, C {}] = CallByName List.80 List.487 List.488 List.489 List.586 List.587;
-    dec List.487;
     ret List.585;
 
 procedure List.23 (#Attr.2, #Attr.3, #Attr.4):
@@ -33,7 +32,6 @@ procedure List.235 (List.574, List.236, List.234):
 procedure List.56 (List.233, List.234):
     let List.583 : {} = Struct {};
     let List.575 : [C {}, C {}] = CallByName List.103 List.233 List.583 List.234;
-    dec List.233;
     let List.580 : U8 = 1i64;
     let List.581 : U8 = GetTagId List.575;
     let List.582 : Int1 = lowlevel Eq List.580 List.581;
@@ -81,6 +79,7 @@ procedure List.80 (#Derived_gen.1, #Derived_gen.2, #Derived_gen.3, #Derived_gen.
             let List.589 : [C {}, C {}] = TagId(1) List.491;
             ret List.589;
     in
+    inc #Derived_gen.1;
     jump List.588 #Derived_gen.1 #Derived_gen.2 #Derived_gen.3 #Derived_gen.4 #Derived_gen.5;
 
 procedure Num.22 (#Attr.2, #Attr.3):

--- a/crates/compiler/test_mono/generated/issue_4772_weakened_monomorphic_destructure.txt
+++ b/crates/compiler/test_mono/generated/issue_4772_weakened_monomorphic_destructure.txt
@@ -40,7 +40,6 @@ procedure Decode.26 (Decode.105, Decode.106):
 
 procedure List.1 (List.106):
     let List.622 : U64 = CallByName List.6 List.106;
-    dec List.106;
     let List.623 : U64 = 0i64;
     let List.621 : Int1 = CallByName Bool.11 List.622 List.623;
     ret List.621;
@@ -49,7 +48,6 @@ procedure List.103 (List.487, List.488, List.489):
     let List.631 : U64 = 0i64;
     let List.632 : U64 = CallByName List.6 List.487;
     let List.630 : [C [C U64, C U64, C U64, C , C , C U64, C U64, C U64, C U64], C [C U64, C U64, C U64, C , C , C U64, C U64, C U64, C U64]] = CallByName List.80 List.487 List.488 List.489 List.631 List.632;
-    dec List.487;
     ret List.630;
 
 procedure List.2 (List.107, List.108):
@@ -57,18 +55,15 @@ procedure List.2 (List.107, List.108):
     let List.610 : Int1 = CallByName Num.22 List.108 List.613;
     if List.610 then
         let List.612 : U8 = CallByName List.66 List.107 List.108;
-        dec List.107;
         let List.611 : [C {}, C U8] = TagId(1) List.612;
         ret List.611;
     else
-        dec List.107;
         let List.609 : {} = Struct {};
         let List.608 : [C {}, C U8] = TagId(0) List.609;
         ret List.608;
 
 procedure List.26 (List.200, List.201, List.202):
     let List.624 : [C [C U64, C U64, C U64, C , C , C U64, C U64, C U64, C U64], C [C U64, C U64, C U64, C , C , C U64, C U64, C U64, C U64]] = CallByName List.103 List.200 List.201 List.202;
-    dec List.200;
     let List.627 : U8 = 1i64;
     let List.628 : U8 = GetTagId List.624;
     let List.629 : Int1 = lowlevel Eq List.627 List.628;
@@ -152,6 +147,7 @@ procedure List.80 (#Derived_gen.0, #Derived_gen.1, #Derived_gen.2, #Derived_gen.
             let List.634 : [C [C U64, C U64, C U64, C , C , C U64, C U64, C U64, C U64], C [C U64, C U64, C U64, C , C , C U64, C U64, C U64, C U64]] = TagId(1) List.491;
             ret List.634;
     in
+    inc #Derived_gen.0;
     jump List.633 #Derived_gen.0 #Derived_gen.1 #Derived_gen.2 #Derived_gen.3 #Derived_gen.4;
 
 procedure Num.19 (#Attr.2, #Attr.3):
@@ -200,7 +196,6 @@ procedure Str.12 (#Attr.2):
 
 procedure Str.27 (Str.78):
     let Str.232 : [C {}, C I64] = CallByName Str.60 Str.78;
-    dec Str.78;
     ret Str.232;
 
 procedure Str.42 (#Attr.2):
@@ -213,7 +208,6 @@ procedure Str.43 (#Attr.2):
 
 procedure Str.60 (Str.185):
     let Str.186 : {I64, U8} = CallByName Str.42 Str.185;
-    dec Str.185;
     let Str.238 : U8 = StructAtIndex 1 Str.186;
     let Str.239 : U8 = 0i64;
     let Str.235 : Int1 = CallByName Bool.11 Str.238 Str.239;
@@ -376,6 +370,7 @@ procedure TotallyNotJson.488 (TotallyNotJson.489, TotallyNotJson.973):
 
 procedure TotallyNotJson.497 (TotallyNotJson.498):
     let TotallyNotJson.1116 : List U8 = Array [];
+    inc TotallyNotJson.498;
     let TotallyNotJson.995 : {List U8, List U8} = Struct {TotallyNotJson.498, TotallyNotJson.1116};
     let TotallyNotJson.994 : {List U8, List U8} = CallByName TotallyNotJson.69 TotallyNotJson.995;
     ret TotallyNotJson.994;

--- a/crates/compiler/test_mono/generated/issue_4772_weakened_monomorphic_destructure.txt
+++ b/crates/compiler/test_mono/generated/issue_4772_weakened_monomorphic_destructure.txt
@@ -49,6 +49,7 @@ procedure List.103 (List.487, List.488, List.489):
     let List.631 : U64 = 0i64;
     let List.632 : U64 = CallByName List.6 List.487;
     let List.630 : [C [C U64, C U64, C U64, C , C , C U64, C U64, C U64, C U64], C [C U64, C U64, C U64, C , C , C U64, C U64, C U64, C U64]] = CallByName List.80 List.487 List.488 List.489 List.631 List.632;
+    dec List.487;
     ret List.630;
 
 procedure List.2 (List.107, List.108):
@@ -67,6 +68,7 @@ procedure List.2 (List.107, List.108):
 
 procedure List.26 (List.200, List.201, List.202):
     let List.624 : [C [C U64, C U64, C U64, C , C , C U64, C U64, C U64, C U64], C [C U64, C U64, C U64, C , C , C U64, C U64, C U64, C U64]] = CallByName List.103 List.200 List.201 List.202;
+    dec List.200;
     let List.627 : U8 = 1i64;
     let List.628 : U8 = GetTagId List.624;
     let List.629 : Int1 = lowlevel Eq List.627 List.628;
@@ -198,6 +200,7 @@ procedure Str.12 (#Attr.2):
 
 procedure Str.27 (Str.78):
     let Str.232 : [C {}, C I64] = CallByName Str.60 Str.78;
+    dec Str.78;
     ret Str.232;
 
 procedure Str.42 (#Attr.2):
@@ -252,6 +255,7 @@ procedure Test.0 ():
     if Test.33 then
         let Test.3 : Str = UnionAtIndex (Id 1) (Index 0) Test.1;
         let Test.19 : [C {}, C I64] = CallByName Str.27 Test.3;
+        dec Test.3;
         let Test.25 : U8 = 1i64;
         let Test.26 : U8 = GetTagId Test.19;
         let Test.27 : Int1 = lowlevel Eq Test.25 Test.26;
@@ -291,7 +295,6 @@ procedure TotallyNotJson.488 (TotallyNotJson.489, TotallyNotJson.973):
         let TotallyNotJson.1126 : {List U8, List U8} = CallByName TotallyNotJson.60 TotallyNotJson.489;
         let TotallyNotJson.493 : List U8 = StructAtIndex 0 TotallyNotJson.1126;
         let TotallyNotJson.492 : List U8 = StructAtIndex 1 TotallyNotJson.1126;
-        inc TotallyNotJson.492;
         let TotallyNotJson.1122 : Int1 = CallByName List.1 TotallyNotJson.492;
         if TotallyNotJson.1122 then
             dec TotallyNotJson.492;
@@ -309,6 +312,7 @@ procedure TotallyNotJson.488 (TotallyNotJson.489, TotallyNotJson.973):
             let TotallyNotJson.992 : List U8 = CallByName List.49 TotallyNotJson.492 TotallyNotJson.1117;
             let TotallyNotJson.993 : {} = Struct {};
             let TotallyNotJson.988 : {List U8, List U8} = CallByName TotallyNotJson.497 TotallyNotJson.992;
+            dec TotallyNotJson.992;
             let TotallyNotJson.989 : {} = Struct {};
             let TotallyNotJson.987 : List U8 = CallByName TotallyNotJson.499 TotallyNotJson.988;
             let TotallyNotJson.496 : [C {U64, U8}, C Str] = CallByName Str.9 TotallyNotJson.987;
@@ -390,14 +394,13 @@ procedure TotallyNotJson.59 ():
 procedure TotallyNotJson.60 (TotallyNotJson.504):
     let TotallyNotJson.1138 : [C U64, C U64, C U64, C , C , C U64, C U64, C U64, C U64] = TagId(4) ;
     let TotallyNotJson.1139 : {} = Struct {};
-    inc TotallyNotJson.504;
     let TotallyNotJson.1127 : [C U64, C U64, C U64, C , C , C U64, C U64, C U64, C U64] = CallByName List.26 TotallyNotJson.504 TotallyNotJson.1138 TotallyNotJson.1139;
     let TotallyNotJson.1135 : U8 = 2i64;
     let TotallyNotJson.1136 : U8 = GetTagId TotallyNotJson.1127;
     let TotallyNotJson.1137 : Int1 = lowlevel Eq TotallyNotJson.1135 TotallyNotJson.1136;
     if TotallyNotJson.1137 then
-        inc TotallyNotJson.504;
         let TotallyNotJson.506 : U64 = UnionAtIndex (Id 2) (Index 0) TotallyNotJson.1127;
+        inc TotallyNotJson.504;
         let TotallyNotJson.1129 : List U8 = CallByName List.38 TotallyNotJson.504 TotallyNotJson.506;
         let TotallyNotJson.1132 : U64 = 0i64;
         let TotallyNotJson.1131 : {U64, U64} = Struct {TotallyNotJson.506, TotallyNotJson.1132};
@@ -749,7 +752,7 @@ procedure TotallyNotJson.68 ():
 procedure TotallyNotJson.69 (#Derived_gen.5):
     joinpoint TotallyNotJson.996 TotallyNotJson.967:
         let TotallyNotJson.563 : List U8 = StructAtIndex 0 TotallyNotJson.967;
-        inc 4 TotallyNotJson.563;
+        inc 2 TotallyNotJson.563;
         let TotallyNotJson.564 : List U8 = StructAtIndex 1 TotallyNotJson.967;
         let TotallyNotJson.1115 : U64 = 0i64;
         let TotallyNotJson.565 : [C {}, C U8] = CallByName List.2 TotallyNotJson.563 TotallyNotJson.1115;

--- a/crates/compiler/test_mono/generated/issue_6196.txt
+++ b/crates/compiler/test_mono/generated/issue_6196.txt
@@ -37,6 +37,7 @@ procedure Test.1 (#Derived_gen.0, #Derived_gen.1):
             let Test.14 : [C {}, C Str] = TagId(0) Test.15;
             ret Test.14;
     in
+    inc #Derived_gen.0;
     jump Test.12 #Derived_gen.0 #Derived_gen.1;
 
 procedure Test.0 ():

--- a/crates/compiler/test_mono/generated/issue_6196.txt
+++ b/crates/compiler/test_mono/generated/issue_6196.txt
@@ -44,4 +44,5 @@ procedure Test.0 ():
     let Test.10 : List Str = Array [Test.35];
     let Test.11 : U64 = 0i64;
     let Test.9 : [C {}, C Str] = CallByName Test.1 Test.10 Test.11;
+    dec Test.10;
     ret Test.9;

--- a/crates/compiler/test_mono/generated/lambda_capture_niches_have_captured_function_in_closure.txt
+++ b/crates/compiler/test_mono/generated/lambda_capture_niches_have_captured_function_in_closure.txt
@@ -35,6 +35,7 @@ procedure Test.9 (Test.26, #Attr.12):
     let Test.32 : {} = Struct {};
     let Test.31 : Str = CallByName Test.15 Test.32;
     let Test.28 : {} = CallByName Test.3 Test.31;
+    dec Test.31;
     let Test.30 : {} = Struct {};
     let Test.29 : Str = CallByName Test.11 Test.30;
     ret Test.29;

--- a/crates/compiler/test_mono/generated/lambda_capture_niches_have_captured_function_in_closure.txt
+++ b/crates/compiler/test_mono/generated/lambda_capture_niches_have_captured_function_in_closure.txt
@@ -22,7 +22,6 @@ procedure Test.2 (Test.7, Test.8):
     ret Test.43;
 
 procedure Test.3 (Test.17):
-    dec Test.17;
     let Test.35 : {} = Struct {};
     ret Test.35;
 

--- a/crates/compiler/test_mono/generated/lambda_capture_niches_with_other_lambda_capture.txt
+++ b/crates/compiler/test_mono/generated/lambda_capture_niches_with_other_lambda_capture.txt
@@ -11,6 +11,7 @@ procedure Test.1 (Test.5):
     ret Test.31;
 
 procedure Test.2 (Test.7):
+    inc Test.7;
     let Test.23 : [C {}, C U64, C Str] = TagId(2) Test.7;
     ret Test.23;
 

--- a/crates/compiler/test_mono/generated/lambda_capture_niches_with_other_lambda_capture.txt
+++ b/crates/compiler/test_mono/generated/lambda_capture_niches_with_other_lambda_capture.txt
@@ -59,6 +59,7 @@ procedure Test.0 ():
         case 1:
             let Test.22 : Str = "foo";
             let Test.21 : [C {}, C U64, C Str] = CallByName Test.2 Test.22;
+            dec Test.22;
             jump Test.13 Test.21;
     
         default:

--- a/crates/compiler/test_mono/generated/lambda_set_niche_same_layout_different_constructor.txt
+++ b/crates/compiler/test_mono/generated/lambda_set_niche_same_layout_different_constructor.txt
@@ -1,8 +1,10 @@
 procedure Test.1 (Test.4):
+    inc Test.4;
     let Test.13 : [C Str, C Str] = TagId(0) Test.4;
     ret Test.13;
 
 procedure Test.1 (Test.4):
+    inc Test.4;
     let Test.19 : [C Str, C Str] = TagId(0) Test.4;
     ret Test.19;
 

--- a/crates/compiler/test_mono/generated/lambda_set_niche_same_layout_different_constructor.txt
+++ b/crates/compiler/test_mono/generated/lambda_set_niche_same_layout_different_constructor.txt
@@ -22,8 +22,10 @@ procedure Test.0 ():
     if Test.22 then
         let Test.16 : Str = "";
         let Test.10 : [C Str, C Str] = CallByName Test.1 Test.16;
+        dec Test.16;
         jump Test.9 Test.10;
     else
         let Test.20 : Str = "";
         let Test.17 : [C Str, C Str] = CallByName Test.1 Test.20;
+        dec Test.20;
         jump Test.9 Test.17;

--- a/crates/compiler/test_mono/generated/layout_cache_structure_with_multiple_recursive_structures.txt
+++ b/crates/compiler/test_mono/generated/layout_cache_structure_with_multiple_recursive_structures.txt
@@ -2,7 +2,6 @@ procedure List.18 (List.159, List.160, List.161):
     let List.573 : U64 = 0i64;
     let List.574 : U64 = CallByName List.6 List.159;
     let List.572 : [<rnu><null>, C {[<rnu>C *self, <null>], *self}] = CallByName List.91 List.159 List.160 List.161 List.573 List.574;
-    dec List.159;
     ret List.572;
 
 procedure List.6 (#Attr.2):
@@ -27,6 +26,7 @@ procedure List.91 (#Derived_gen.0, #Derived_gen.1, #Derived_gen.2, #Derived_gen.
             dec List.162;
             ret List.163;
     in
+    inc #Derived_gen.0;
     jump List.575 #Derived_gen.0 #Derived_gen.1 #Derived_gen.2 #Derived_gen.3 #Derived_gen.4;
 
 procedure Num.22 (#Attr.2, #Attr.3):

--- a/crates/compiler/test_mono/generated/layout_cache_structure_with_multiple_recursive_structures.txt
+++ b/crates/compiler/test_mono/generated/layout_cache_structure_with_multiple_recursive_structures.txt
@@ -2,6 +2,7 @@ procedure List.18 (List.159, List.160, List.161):
     let List.573 : U64 = 0i64;
     let List.574 : U64 = CallByName List.6 List.159;
     let List.572 : [<rnu><null>, C {[<rnu>C *self, <null>], *self}] = CallByName List.91 List.159 List.160 List.161 List.573 List.574;
+    dec List.159;
     ret List.572;
 
 procedure List.6 (#Attr.2):
@@ -46,4 +47,5 @@ procedure Test.0 ():
     let Test.8 : List [<rnu>C *self, <null>] = Array [];
     let Test.15 : {} = Struct {};
     let Test.9 : [<rnu><null>, C {[<rnu>C *self, <null>], *self}] = CallByName List.18 Test.8 Test.6 Test.15;
+    dec Test.8;
     ret Test.9;

--- a/crates/compiler/test_mono/generated/list_get.txt
+++ b/crates/compiler/test_mono/generated/list_get.txt
@@ -3,11 +3,9 @@ procedure List.2 (List.107, List.108):
     let List.574 : Int1 = CallByName Num.22 List.108 List.578;
     if List.574 then
         let List.576 : I64 = CallByName List.66 List.107 List.108;
-        dec List.107;
         let List.575 : [C {}, C I64] = TagId(1) List.576;
         ret List.575;
     else
-        dec List.107;
         let List.573 : {} = Struct {};
         let List.572 : [C {}, C I64] = TagId(0) List.573;
         ret List.572;
@@ -28,6 +26,7 @@ procedure Test.1 (Test.2):
     let Test.6 : List I64 = Array [1i64, 2i64, 3i64];
     let Test.7 : U64 = 0i64;
     let Test.5 : [C {}, C I64] = CallByName List.2 Test.6 Test.7;
+    dec Test.6;
     ret Test.5;
 
 procedure Test.0 ():

--- a/crates/compiler/test_mono/generated/list_map_closure_borrows.txt
+++ b/crates/compiler/test_mono/generated/list_map_closure_borrows.txt
@@ -4,11 +4,9 @@ procedure List.2 (List.107, List.108):
     if List.574 then
         let List.576 : Str = CallByName List.66 List.107 List.108;
         inc List.576;
-        dec List.107;
         let List.575 : [C {}, C Str] = TagId(1) List.576;
         ret List.575;
     else
-        dec List.107;
         let List.573 : {} = Struct {};
         let List.572 : [C {}, C Str] = TagId(0) List.573;
         ret List.572;
@@ -55,7 +53,6 @@ procedure Test.2 ():
 procedure Test.3 (Test.4):
     let Test.18 : U64 = 2i64;
     let Test.17 : Str = CallByName Str.16 Test.4 Test.18;
-    dec Test.4;
     ret Test.17;
 
 procedure Test.0 ():

--- a/crates/compiler/test_mono/generated/list_map_closure_borrows.txt
+++ b/crates/compiler/test_mono/generated/list_map_closure_borrows.txt
@@ -62,6 +62,7 @@ procedure Test.0 ():
     let Test.12 : List Str = CallByName Test.2;
     let Test.13 : U64 = 0i64;
     let Test.6 : [C {}, C Str] = CallByName List.2 Test.12 Test.13;
+    dec Test.12;
     let Test.9 : U8 = 1i64;
     let Test.10 : U8 = GetTagId Test.6;
     let Test.11 : Int1 = lowlevel Eq Test.9 Test.10;

--- a/crates/compiler/test_mono/generated/list_map_closure_owns.txt
+++ b/crates/compiler/test_mono/generated/list_map_closure_owns.txt
@@ -4,11 +4,9 @@ procedure List.2 (List.107, List.108):
     if List.574 then
         let List.576 : Str = CallByName List.66 List.107 List.108;
         inc List.576;
-        dec List.107;
         let List.575 : [C {}, C Str] = TagId(1) List.576;
         ret List.575;
     else
-        dec List.107;
         let List.573 : {} = Struct {};
         let List.572 : [C {}, C Str] = TagId(0) List.573;
         ret List.572;

--- a/crates/compiler/test_mono/generated/list_map_closure_owns.txt
+++ b/crates/compiler/test_mono/generated/list_map_closure_owns.txt
@@ -58,6 +58,7 @@ procedure Test.0 ():
     let Test.12 : List Str = CallByName Test.2;
     let Test.13 : U64 = 0i64;
     let Test.6 : [C {}, C Str] = CallByName List.2 Test.12 Test.13;
+    dec Test.12;
     let Test.9 : U8 = 1i64;
     let Test.10 : U8 = GetTagId Test.6;
     let Test.11 : Int1 = lowlevel Eq Test.9 Test.10;

--- a/crates/compiler/test_mono/generated/mk_pair_of.txt
+++ b/crates/compiler/test_mono/generated/mk_pair_of.txt
@@ -1,5 +1,5 @@
 procedure Test.1 (Test.2):
-    inc Test.2;
+    inc 2 Test.2;
     let Test.6 : {List I64, List I64} = Struct {Test.2, Test.2};
     ret Test.6;
 

--- a/crates/compiler/test_mono/generated/mk_pair_of.txt
+++ b/crates/compiler/test_mono/generated/mk_pair_of.txt
@@ -6,4 +6,5 @@ procedure Test.1 (Test.2):
 procedure Test.0 ():
     let Test.5 : List I64 = Array [1i64, 2i64, 3i64];
     let Test.4 : {List I64, List I64} = CallByName Test.1 Test.5;
+    dec Test.5;
     ret Test.4;

--- a/crates/compiler/test_mono/generated/monomorphized_list.txt
+++ b/crates/compiler/test_mono/generated/monomorphized_list.txt
@@ -18,4 +18,6 @@ procedure Test.0 ():
     let Test.10 : {} = Struct {};
     let Test.8 : List U16 = CallByName Test.1 Test.10;
     let Test.6 : U64 = CallByName Test.2 Test.7 Test.8;
+    dec Test.8;
+    dec Test.7;
     ret Test.6;

--- a/crates/compiler/test_mono/generated/monomorphized_list.txt
+++ b/crates/compiler/test_mono/generated/monomorphized_list.txt
@@ -7,8 +7,6 @@ procedure Test.1 (Test.3):
     ret Test.13;
 
 procedure Test.2 (Test.4, Test.5):
-    dec Test.5;
-    dec Test.4;
     let Test.9 : U64 = 18i64;
     ret Test.9;
 

--- a/crates/compiler/test_mono/generated/quicksort_help.txt
+++ b/crates/compiler/test_mono/generated/quicksort_help.txt
@@ -23,6 +23,7 @@ procedure Test.1 (#Derived_gen.0, #Derived_gen.1, #Derived_gen.2):
             let Test.20 : I64 = 1i64;
             let Test.19 : I64 = CallByName Num.20 Test.5 Test.20;
             let Test.16 : List I64 = CallByName Test.1 Test.6 Test.3 Test.19;
+            dec Test.6;
             let Test.18 : I64 = 1i64;
             let Test.17 : I64 = CallByName Num.19 Test.5 Test.18;
             jump Test.12 Test.16 Test.17 Test.4;
@@ -36,4 +37,5 @@ procedure Test.0 ():
     let Test.10 : I64 = 0i64;
     let Test.11 : I64 = 0i64;
     let Test.8 : List I64 = CallByName Test.1 Test.9 Test.10 Test.11;
+    dec Test.9;
     ret Test.8;

--- a/crates/compiler/test_mono/generated/quicksort_help.txt
+++ b/crates/compiler/test_mono/generated/quicksort_help.txt
@@ -30,6 +30,7 @@ procedure Test.1 (#Derived_gen.0, #Derived_gen.1, #Derived_gen.2):
         else
             ret Test.2;
     in
+    inc #Derived_gen.0;
     jump Test.12 #Derived_gen.0 #Derived_gen.1 #Derived_gen.2;
 
 procedure Test.0 ():

--- a/crates/compiler/test_mono/generated/quicksort_swap.txt
+++ b/crates/compiler/test_mono/generated/quicksort_swap.txt
@@ -3,11 +3,9 @@ procedure List.2 (List.107, List.108):
     let List.591 : Int1 = CallByName Num.22 List.108 List.594;
     if List.591 then
         let List.593 : I64 = CallByName List.66 List.107 List.108;
-        dec List.107;
         let List.592 : [C {}, C I64] = TagId(1) List.593;
         ret List.592;
     else
-        dec List.107;
         let List.590 : {} = Struct {};
         let List.589 : [C {}, C I64] = TagId(0) List.590;
         ret List.589;

--- a/crates/compiler/test_mono/generated/quicksort_swap.txt
+++ b/crates/compiler/test_mono/generated/quicksort_swap.txt
@@ -45,7 +45,6 @@ procedure Num.22 (#Attr.2, #Attr.3):
 
 procedure Test.1 (Test.2):
     let Test.28 : U64 = 0i64;
-    inc 2 Test.2;
     let Test.26 : [C {}, C I64] = CallByName List.2 Test.2 Test.28;
     let Test.27 : U64 = 0i64;
     let Test.25 : [C {}, C I64] = CallByName List.2 Test.2 Test.27;

--- a/crates/compiler/test_mono/generated/recursive_lambda_set_has_nested_non_recursive_lambda_sets_issue_5026.txt
+++ b/crates/compiler/test_mono/generated/recursive_lambda_set_has_nested_non_recursive_lambda_sets_issue_5026.txt
@@ -3,7 +3,6 @@ procedure Bool.2 ():
     ret Bool.23;
 
 procedure Test.10 (Test.26):
-    dec Test.26;
     let Test.30 : Int1 = CallByName Bool.2;
     if Test.30 then
         let Test.31 : [<rnu><null>, C {}] = CallByName Test.0;
@@ -53,7 +52,6 @@ procedure Test.6 (Test.16, #Attr.12):
 
 procedure Test.8 (Test.9, Test.7):
     let Test.25 : [<rnu><null>, C {}] = CallByName Test.10 Test.9;
-    dec Test.9;
     ret Test.25;
 
 procedure Test.0 ():

--- a/crates/compiler/test_mono/generated/recursive_lambda_set_has_nested_non_recursive_lambda_sets_issue_5026.txt
+++ b/crates/compiler/test_mono/generated/recursive_lambda_set_has_nested_non_recursive_lambda_sets_issue_5026.txt
@@ -30,6 +30,7 @@ procedure Test.6 (Test.16, #Attr.12):
         let Test.19 : {} = Struct {};
         let Test.22 : Str = "foobar";
         let Test.20 : [<rnu><null>, C {}] = CallByName Test.8 Test.22 Test.23;
+        dec Test.22;
         let Test.21 : U8 = GetTagId Test.20;
         switch Test.21:
             case 0:
@@ -52,6 +53,7 @@ procedure Test.6 (Test.16, #Attr.12):
 
 procedure Test.8 (Test.9, Test.7):
     let Test.25 : [<rnu><null>, C {}] = CallByName Test.10 Test.9;
+    dec Test.9;
     ret Test.25;
 
 procedure Test.0 ():

--- a/crates/compiler/test_mono/generated/rigids.txt
+++ b/crates/compiler/test_mono/generated/rigids.txt
@@ -44,7 +44,6 @@ procedure Num.22 (#Attr.2, #Attr.3):
     ret Num.271;
 
 procedure Test.1 (Test.2, Test.3, Test.4):
-    inc 2 Test.4;
     let Test.29 : [C {}, C I64] = CallByName List.2 Test.4 Test.3;
     let Test.28 : [C {}, C I64] = CallByName List.2 Test.4 Test.2;
     let Test.13 : {[C {}, C I64], [C {}, C I64]} = Struct {Test.28, Test.29};

--- a/crates/compiler/test_mono/generated/rigids.txt
+++ b/crates/compiler/test_mono/generated/rigids.txt
@@ -3,11 +3,9 @@ procedure List.2 (List.107, List.108):
     let List.591 : Int1 = CallByName Num.22 List.108 List.594;
     if List.591 then
         let List.593 : I64 = CallByName List.66 List.107 List.108;
-        dec List.107;
         let List.592 : [C {}, C I64] = TagId(1) List.593;
         ret List.592;
     else
-        dec List.107;
         let List.590 : {} = Struct {};
         let List.589 : [C {}, C I64] = TagId(0) List.590;
         ret List.589;

--- a/crates/compiler/test_mono/generated/unreachable_branch_is_eliminated_but_produces_lambda_specializations.txt
+++ b/crates/compiler/test_mono/generated/unreachable_branch_is_eliminated_but_produces_lambda_specializations.txt
@@ -14,6 +14,7 @@ procedure Test.4 (Test.13):
 procedure Test.0 ():
     let Test.16 : Str = "abc";
     let Test.6 : Int1 = CallByName Test.1 Test.16;
+    dec Test.16;
     let Test.9 : {} = Struct {};
     switch Test.6:
         case 0:

--- a/crates/compiler/test_mono/generated/unreachable_branch_is_eliminated_but_produces_lambda_specializations.txt
+++ b/crates/compiler/test_mono/generated/unreachable_branch_is_eliminated_but_produces_lambda_specializations.txt
@@ -1,5 +1,4 @@
 procedure Test.1 (Test.2):
-    dec Test.2;
     let Test.11 : Int1 = false;
     ret Test.11;
 

--- a/crates/compiler/test_mono/generated/unspecialized_lambda_set_unification_does_not_duplicate_identical_concrete_types.txt
+++ b/crates/compiler/test_mono/generated/unspecialized_lambda_set_unification_does_not_duplicate_identical_concrete_types.txt
@@ -13,7 +13,6 @@ procedure Encode.23 (Encode.98):
 
 procedure Encode.24 (Encode.99, Encode.107, Encode.101):
     let Encode.111 : List U8 = CallByName Test.5 Encode.99 Encode.101 Encode.107;
-    dec Encode.99;
     ret Encode.111;
 
 procedure Encode.24 (Encode.99, Encode.107, Encode.101):
@@ -22,41 +21,34 @@ procedure Encode.24 (Encode.99, Encode.107, Encode.101):
 
 procedure Encode.24 (Encode.99, Encode.107, Encode.101):
     let Encode.118 : List U8 = CallByName TotallyNotJson.150 Encode.99 Encode.101 Encode.107;
-    dec Encode.107;
     ret Encode.118;
 
 procedure Encode.26 (Encode.105, Encode.106):
     let Encode.109 : List U8 = Array [];
     let Encode.110 : {Str, Str} = CallByName Test.2 Encode.105;
     let Encode.108 : List U8 = CallByName Encode.24 Encode.109 Encode.110 Encode.106;
-    dec Encode.109;
     ret Encode.108;
 
 procedure List.103 (List.487, List.488, List.489):
     let List.655 : U64 = 0i64;
     let List.656 : U64 = CallByName List.6 List.487;
     let List.654 : [C {U64, Int1}, C {U64, Int1}] = CallByName List.80 List.487 List.488 List.489 List.655 List.656;
-    dec List.487;
     ret List.654;
 
 procedure List.18 (List.159, List.160, List.161):
     let List.599 : U64 = 0i64;
     let List.600 : U64 = CallByName List.6 List.159;
     let List.598 : {List U8, U64} = CallByName List.91 List.159 List.160 List.161 List.599 List.600;
-    dec List.159;
     ret List.598;
 
 procedure List.18 (List.159, List.160, List.161):
     let List.611 : U64 = 0i64;
     let List.612 : U64 = CallByName List.6 List.159;
     let List.610 : List U8 = CallByName List.91 List.159 List.160 List.161 List.611 List.612;
-    dec List.160;
-    dec List.159;
     ret List.610;
 
 procedure List.26 (List.200, List.201, List.202):
     let List.648 : [C {U64, Int1}, C {U64, Int1}] = CallByName List.103 List.200 List.201 List.202;
-    dec List.200;
     let List.651 : U8 = 1i64;
     let List.652 : U8 = GetTagId List.648;
     let List.653 : Int1 = lowlevel Eq List.651 List.652;
@@ -158,6 +150,7 @@ procedure List.80 (#Derived_gen.16, #Derived_gen.17, #Derived_gen.18, #Derived_g
             let List.658 : [C {U64, Int1}, C {U64, Int1}] = TagId(1) List.491;
             ret List.658;
     in
+    inc #Derived_gen.16;
     jump List.657 #Derived_gen.16 #Derived_gen.17 #Derived_gen.18 #Derived_gen.19 #Derived_gen.20;
 
 procedure List.91 (#Derived_gen.11, #Derived_gen.12, #Derived_gen.13, #Derived_gen.14, #Derived_gen.15):
@@ -173,6 +166,8 @@ procedure List.91 (#Derived_gen.11, #Derived_gen.12, #Derived_gen.13, #Derived_g
             dec List.162;
             ret List.163;
     in
+    inc #Derived_gen.11;
+    inc #Derived_gen.12;
     jump List.613 #Derived_gen.11 #Derived_gen.12 #Derived_gen.13 #Derived_gen.14 #Derived_gen.15;
 
 procedure List.91 (#Derived_gen.6, #Derived_gen.7, #Derived_gen.8, #Derived_gen.9, #Derived_gen.10):
@@ -182,7 +177,6 @@ procedure List.91 (#Derived_gen.6, #Derived_gen.7, #Derived_gen.8, #Derived_gen.
             let List.607 : Str = CallByName List.66 List.162 List.165;
             inc List.607;
             let List.167 : {List U8, U64} = CallByName TotallyNotJson.230 List.163 List.607;
-            dec List.607;
             let List.606 : U64 = 1i64;
             let List.605 : U64 = CallByName Num.51 List.165 List.606;
             jump List.601 List.162 List.167 List.164 List.605 List.166;
@@ -190,6 +184,7 @@ procedure List.91 (#Derived_gen.6, #Derived_gen.7, #Derived_gen.8, #Derived_gen.
             dec List.162;
             ret List.163;
     in
+    inc #Derived_gen.6;
     jump List.601 #Derived_gen.6 #Derived_gen.7 #Derived_gen.8 #Derived_gen.9 #Derived_gen.10;
 
 procedure Num.127 (#Attr.2):
@@ -380,7 +375,6 @@ procedure TotallyNotJson.230 (TotallyNotJson.975, TotallyNotJson.236):
     let TotallyNotJson.235 : U64 = StructAtIndex 1 TotallyNotJson.975;
     let TotallyNotJson.994 : {} = Struct {};
     let TotallyNotJson.237 : List U8 = CallByName Encode.24 TotallyNotJson.234 TotallyNotJson.236 TotallyNotJson.994;
-    dec TotallyNotJson.236;
     joinpoint TotallyNotJson.989 TotallyNotJson.238:
         let TotallyNotJson.987 : U64 = 1i64;
         let TotallyNotJson.986 : U64 = CallByName Num.20 TotallyNotJson.235 TotallyNotJson.987;
@@ -495,6 +489,8 @@ procedure TotallyNotJson.27 (TotallyNotJson.186):
     
 
 procedure TotallyNotJson.31 (TotallyNotJson.226, TotallyNotJson.227):
+    inc TotallyNotJson.227;
+    inc TotallyNotJson.226;
     let TotallyNotJson.1013 : {Str, List Str} = Struct {TotallyNotJson.226, TotallyNotJson.227};
     let TotallyNotJson.1012 : {Str, List Str} = CallByName Encode.23 TotallyNotJson.1013;
     ret TotallyNotJson.1012;

--- a/crates/compiler/test_mono/generated/unspecialized_lambda_set_unification_does_not_duplicate_identical_concrete_types.txt
+++ b/crates/compiler/test_mono/generated/unspecialized_lambda_set_unification_does_not_duplicate_identical_concrete_types.txt
@@ -13,6 +13,7 @@ procedure Encode.23 (Encode.98):
 
 procedure Encode.24 (Encode.99, Encode.107, Encode.101):
     let Encode.111 : List U8 = CallByName Test.5 Encode.99 Encode.101 Encode.107;
+    dec Encode.99;
     ret Encode.111;
 
 procedure Encode.24 (Encode.99, Encode.107, Encode.101):
@@ -21,34 +22,41 @@ procedure Encode.24 (Encode.99, Encode.107, Encode.101):
 
 procedure Encode.24 (Encode.99, Encode.107, Encode.101):
     let Encode.118 : List U8 = CallByName TotallyNotJson.150 Encode.99 Encode.101 Encode.107;
+    dec Encode.107;
     ret Encode.118;
 
 procedure Encode.26 (Encode.105, Encode.106):
     let Encode.109 : List U8 = Array [];
     let Encode.110 : {Str, Str} = CallByName Test.2 Encode.105;
     let Encode.108 : List U8 = CallByName Encode.24 Encode.109 Encode.110 Encode.106;
+    dec Encode.109;
     ret Encode.108;
 
 procedure List.103 (List.487, List.488, List.489):
     let List.655 : U64 = 0i64;
     let List.656 : U64 = CallByName List.6 List.487;
     let List.654 : [C {U64, Int1}, C {U64, Int1}] = CallByName List.80 List.487 List.488 List.489 List.655 List.656;
+    dec List.487;
     ret List.654;
 
 procedure List.18 (List.159, List.160, List.161):
     let List.599 : U64 = 0i64;
     let List.600 : U64 = CallByName List.6 List.159;
     let List.598 : {List U8, U64} = CallByName List.91 List.159 List.160 List.161 List.599 List.600;
+    dec List.159;
     ret List.598;
 
 procedure List.18 (List.159, List.160, List.161):
     let List.611 : U64 = 0i64;
     let List.612 : U64 = CallByName List.6 List.159;
     let List.610 : List U8 = CallByName List.91 List.159 List.160 List.161 List.611 List.612;
+    dec List.160;
+    dec List.159;
     ret List.610;
 
 procedure List.26 (List.200, List.201, List.202):
     let List.648 : [C {U64, Int1}, C {U64, Int1}] = CallByName List.103 List.200 List.201 List.202;
+    dec List.200;
     let List.651 : U8 = 1i64;
     let List.652 : U8 = GetTagId List.648;
     let List.653 : Int1 = lowlevel Eq List.651 List.652;
@@ -174,6 +182,7 @@ procedure List.91 (#Derived_gen.6, #Derived_gen.7, #Derived_gen.8, #Derived_gen.
             let List.607 : Str = CallByName List.66 List.162 List.165;
             inc List.607;
             let List.167 : {List U8, U64} = CallByName TotallyNotJson.230 List.163 List.607;
+            dec List.607;
             let List.606 : U64 = 1i64;
             let List.605 : U64 = CallByName Num.51 List.165 List.606;
             jump List.601 List.162 List.167 List.164 List.605 List.166;
@@ -247,6 +256,8 @@ procedure Test.5 (Test.6, Test.7, Test.4):
         let Test.28 : Str = CallByName TotallyNotJson.25 Test.29;
         let Test.27 : List Str = Array [Test.28];
         let Test.19 : {Str, List Str} = CallByName TotallyNotJson.31 Test.26 Test.27;
+        dec Test.26;
+        dec Test.27;
         jump Test.20 Test.19;
     else
         let Test.21 : Str = "B";
@@ -256,6 +267,8 @@ procedure Test.5 (Test.6, Test.7, Test.4):
         let Test.23 : Str = CallByName TotallyNotJson.25 Test.24;
         let Test.22 : List Str = Array [Test.23];
         let Test.19 : {Str, List Str} = CallByName TotallyNotJson.31 Test.21 Test.22;
+        dec Test.21;
+        dec Test.22;
         jump Test.20 Test.19;
 
 procedure TotallyNotJson.150 (TotallyNotJson.151, TotallyNotJson.1017, TotallyNotJson.149):
@@ -352,6 +365,7 @@ procedure TotallyNotJson.228 (TotallyNotJson.229, TotallyNotJson.973, #Attr.12):
     let TotallyNotJson.983 : {List U8, U64} = Struct {TotallyNotJson.231, TotallyNotJson.995};
     let TotallyNotJson.984 : {} = Struct {};
     let TotallyNotJson.982 : {List U8, U64} = CallByName List.18 TotallyNotJson.227 TotallyNotJson.983 TotallyNotJson.984;
+    dec TotallyNotJson.227;
     let TotallyNotJson.233 : List U8 = StructAtIndex 0 TotallyNotJson.982;
     let TotallyNotJson.981 : I64 = 93i64;
     let TotallyNotJson.980 : U8 = CallByName Num.127 TotallyNotJson.981;
@@ -366,6 +380,7 @@ procedure TotallyNotJson.230 (TotallyNotJson.975, TotallyNotJson.236):
     let TotallyNotJson.235 : U64 = StructAtIndex 1 TotallyNotJson.975;
     let TotallyNotJson.994 : {} = Struct {};
     let TotallyNotJson.237 : List U8 = CallByName Encode.24 TotallyNotJson.234 TotallyNotJson.236 TotallyNotJson.994;
+    dec TotallyNotJson.236;
     joinpoint TotallyNotJson.989 TotallyNotJson.238:
         let TotallyNotJson.987 : U64 = 1i64;
         let TotallyNotJson.986 : U64 = CallByName Num.20 TotallyNotJson.235 TotallyNotJson.987;
@@ -392,7 +407,6 @@ procedure TotallyNotJson.26 (TotallyNotJson.152):
     let TotallyNotJson.1098 : Int1 = true;
     let TotallyNotJson.154 : {U64, Int1} = Struct {TotallyNotJson.1097, TotallyNotJson.1098};
     let TotallyNotJson.1067 : {} = Struct {};
-    inc TotallyNotJson.153;
     let TotallyNotJson.155 : {U64, Int1} = CallByName List.26 TotallyNotJson.153 TotallyNotJson.154 TotallyNotJson.1067;
     let TotallyNotJson.1021 : Int1 = StructAtIndex 1 TotallyNotJson.155;
     let TotallyNotJson.1065 : Int1 = true;
@@ -411,8 +425,8 @@ procedure TotallyNotJson.26 (TotallyNotJson.152):
         let TotallyNotJson.1022 : List U8 = CallByName List.8 TotallyNotJson.1023 TotallyNotJson.1024;
         ret TotallyNotJson.1022;
     else
-        inc TotallyNotJson.153;
         let TotallyNotJson.1064 : U64 = StructAtIndex 0 TotallyNotJson.155;
+        inc TotallyNotJson.153;
         let TotallyNotJson.1063 : {List U8, List U8} = CallByName List.52 TotallyNotJson.153 TotallyNotJson.1064;
         let TotallyNotJson.179 : List U8 = StructAtIndex 0 TotallyNotJson.1063;
         let TotallyNotJson.181 : List U8 = StructAtIndex 1 TotallyNotJson.1063;
@@ -429,6 +443,8 @@ procedure TotallyNotJson.26 (TotallyNotJson.152):
         let TotallyNotJson.182 : List U8 = CallByName List.8 TotallyNotJson.1054 TotallyNotJson.179;
         let TotallyNotJson.1037 : {} = Struct {};
         let TotallyNotJson.1034 : List U8 = CallByName List.18 TotallyNotJson.181 TotallyNotJson.182 TotallyNotJson.1037;
+        dec TotallyNotJson.182;
+        dec TotallyNotJson.181;
         let TotallyNotJson.1036 : U8 = 34i64;
         let TotallyNotJson.1035 : List U8 = Array [TotallyNotJson.1036];
         let TotallyNotJson.1033 : List U8 = CallByName List.8 TotallyNotJson.1034 TotallyNotJson.1035;

--- a/crates/compiler/test_mono/generated/unspecialized_lambda_set_unification_keeps_all_concrete_types_without_unification.txt
+++ b/crates/compiler/test_mono/generated/unspecialized_lambda_set_unification_keeps_all_concrete_types_without_unification.txt
@@ -55,6 +55,7 @@ procedure Test.43 (Test.44, Test.42):
     if Test.75 then
         let Test.77 : Str = StructAtIndex 0 Test.42;
         let Test.76 : Int1 = CallByName Test.16 Test.77;
+        dec Test.77;
         let Test.61 : Int1 = CallByName Test.14 Test.76;
         jump Test.62 Test.61;
     else

--- a/crates/compiler/test_mono/generated/unspecialized_lambda_set_unification_keeps_all_concrete_types_without_unification.txt
+++ b/crates/compiler/test_mono/generated/unspecialized_lambda_set_unification_keeps_all_concrete_types_without_unification.txt
@@ -19,7 +19,6 @@ procedure Test.15 (Test.49):
     ret Test.70;
 
 procedure Test.16 (Test.48):
-    dec Test.48;
     let Test.79 : {} = Struct {};
     let Test.78 : Int1 = CallByName Test.13 Test.79;
     ret Test.78;

--- a/crates/compiler/test_mono/generated/unspecialized_lambda_set_unification_keeps_all_concrete_types_without_unification_of_unifiable.txt
+++ b/crates/compiler/test_mono/generated/unspecialized_lambda_set_unification_keeps_all_concrete_types_without_unification_of_unifiable.txt
@@ -7,7 +7,6 @@ procedure #Derived.2 (#Derived.3, #Derived.4, #Attr.12):
     let #Derived_gen.19 : {} = UnionAtIndex (Id 0) (Index 0) #Attr.12;
     joinpoint #Derived_gen.15 #Derived_gen.14:
         let #Derived_gen.13 : List U8 = CallByName Encode.24 #Derived.3 #Derived_gen.14 #Derived.4;
-        dec #Derived.3;
         ret #Derived_gen.13;
     in
     let #Derived_gen.17 : Str = "A";
@@ -26,7 +25,6 @@ procedure #Derived.7 (#Derived.8, #Derived.9, #Attr.12):
     let #Derived_gen.9 : {} = UnionAtIndex (Id 1) (Index 0) #Attr.12;
     joinpoint #Derived_gen.5 #Derived_gen.4:
         let #Derived_gen.3 : List U8 = CallByName Encode.24 #Derived.8 #Derived_gen.4 #Derived.9;
-        dec #Derived.8;
         ret #Derived_gen.3;
     in
     let #Derived_gen.7 : Str = "B";
@@ -53,11 +51,6 @@ procedure Encode.23 (Encode.98):
     ret Encode.98;
 
 procedure Encode.24 (Encode.99, Encode.107, Encode.101):
-    dec Encode.99;
-    let Encode.125 : Str = "a Lambda Set is empty. Most likely there is a type error in your program.";
-    Crash Encode.125
-
-procedure Encode.24 (Encode.99, Encode.107, Encode.101):
     let Encode.111 : List U8 = CallByName Test.5 Encode.99 Encode.101 Encode.107;
     ret Encode.111;
 
@@ -70,12 +63,10 @@ procedure Encode.24 (Encode.99, Encode.107, Encode.101):
     switch Encode.117:
         case 0:
             let Encode.116 : List U8 = CallByName #Derived.2 Encode.99 Encode.101 Encode.107;
-            dec Encode.99;
             ret Encode.116;
     
         default:
             let Encode.116 : List U8 = CallByName #Derived.7 Encode.99 Encode.101 Encode.107;
-            dec Encode.99;
             ret Encode.116;
     
 
@@ -83,25 +74,26 @@ procedure Encode.24 (Encode.99, Encode.107, Encode.101):
     let Encode.121 : List U8 = CallByName TotallyNotJson.228 Encode.99 Encode.101 Encode.107;
     ret Encode.121;
 
+procedure Encode.24 (Encode.99, Encode.107, Encode.101):
+    let Encode.125 : Str = "a Lambda Set is empty. Most likely there is a type error in your program.";
+    Crash Encode.125
+
 procedure Encode.26 (Encode.105, Encode.106):
     let Encode.109 : List U8 = Array [];
     let Encode.110 : {{}, {}} = CallByName Test.2 Encode.105;
     let Encode.108 : List U8 = CallByName Encode.24 Encode.109 Encode.110 Encode.106;
-    dec Encode.109;
     ret Encode.108;
 
 procedure List.18 (List.159, List.160, List.161):
     let List.599 : U64 = 0i64;
     let List.600 : U64 = CallByName List.6 List.159;
     let List.598 : {List U8, U64} = CallByName List.91 List.159 List.160 List.161 List.599 List.600;
-    dec List.159;
     ret List.598;
 
 procedure List.18 (List.159, List.160, List.161):
     let List.639 : U64 = 0i64;
     let List.640 : U64 = CallByName List.6 List.159;
     let List.638 : {List U8, U64} = CallByName List.91 List.159 List.160 List.161 List.639 List.640;
-    dec List.159;
     ret List.638;
 
 procedure List.4 (List.123, List.124):
@@ -151,6 +143,7 @@ procedure List.91 (#Derived_gen.26, #Derived_gen.27, #Derived_gen.28, #Derived_g
             dec List.162;
             ret List.163;
     in
+    inc #Derived_gen.26;
     jump List.641 #Derived_gen.26 #Derived_gen.27 #Derived_gen.28 #Derived_gen.29 #Derived_gen.30;
 
 procedure List.91 (#Derived_gen.40, #Derived_gen.41, #Derived_gen.42, #Derived_gen.43, #Derived_gen.44):
@@ -166,6 +159,7 @@ procedure List.91 (#Derived_gen.40, #Derived_gen.41, #Derived_gen.42, #Derived_g
             dec List.162;
             ret List.163;
     in
+    inc #Derived_gen.40;
     jump List.601 #Derived_gen.40 #Derived_gen.41 #Derived_gen.42 #Derived_gen.43 #Derived_gen.44;
 
 procedure Num.127 (#Attr.2):
@@ -322,7 +316,6 @@ procedure TotallyNotJson.230 (TotallyNotJson.975, TotallyNotJson.236):
     let TotallyNotJson.235 : U64 = StructAtIndex 1 TotallyNotJson.975;
     let TotallyNotJson.994 : {} = Struct {};
     let TotallyNotJson.237 : List U8 = CallByName Encode.24 TotallyNotJson.234 TotallyNotJson.236 TotallyNotJson.994;
-    dec TotallyNotJson.234;
     joinpoint TotallyNotJson.989 TotallyNotJson.238:
         let TotallyNotJson.987 : U64 = 1i64;
         let TotallyNotJson.986 : U64 = CallByName Num.20 TotallyNotJson.235 TotallyNotJson.987;
@@ -340,11 +333,15 @@ procedure TotallyNotJson.230 (TotallyNotJson.975, TotallyNotJson.236):
         jump TotallyNotJson.989 TotallyNotJson.237;
 
 procedure TotallyNotJson.31 (TotallyNotJson.226, TotallyNotJson.227):
+    inc TotallyNotJson.227;
+    inc TotallyNotJson.226;
     let TotallyNotJson.1013 : {Str, List [C {}, C {}]} = Struct {TotallyNotJson.226, TotallyNotJson.227};
     let TotallyNotJson.1012 : {Str, List [C {}, C {}]} = CallByName Encode.23 TotallyNotJson.1013;
     ret TotallyNotJson.1012;
 
 procedure TotallyNotJson.31 (TotallyNotJson.226, TotallyNotJson.227):
+    inc TotallyNotJson.227;
+    inc TotallyNotJson.226;
     let TotallyNotJson.1056 : {Str, List []} = Struct {TotallyNotJson.226, TotallyNotJson.227};
     let TotallyNotJson.1055 : {Str, List []} = CallByName Encode.23 TotallyNotJson.1056;
     ret TotallyNotJson.1055;

--- a/crates/compiler/test_mono/generated/unspecialized_lambda_set_unification_keeps_all_concrete_types_without_unification_of_unifiable.txt
+++ b/crates/compiler/test_mono/generated/unspecialized_lambda_set_unification_keeps_all_concrete_types_without_unification_of_unifiable.txt
@@ -7,11 +7,14 @@ procedure #Derived.2 (#Derived.3, #Derived.4, #Attr.12):
     let #Derived_gen.19 : {} = UnionAtIndex (Id 0) (Index 0) #Attr.12;
     joinpoint #Derived_gen.15 #Derived_gen.14:
         let #Derived_gen.13 : List U8 = CallByName Encode.24 #Derived.3 #Derived_gen.14 #Derived.4;
+        dec #Derived.3;
         ret #Derived_gen.13;
     in
     let #Derived_gen.17 : Str = "A";
     let #Derived_gen.18 : List [] = Array [];
     let #Derived_gen.16 : {Str, List []} = CallByName TotallyNotJson.31 #Derived_gen.17 #Derived_gen.18;
+    dec #Derived_gen.17;
+    dec #Derived_gen.18;
     jump #Derived_gen.15 #Derived_gen.16;
 
 procedure #Derived.5 (#Derived.6):
@@ -23,11 +26,14 @@ procedure #Derived.7 (#Derived.8, #Derived.9, #Attr.12):
     let #Derived_gen.9 : {} = UnionAtIndex (Id 1) (Index 0) #Attr.12;
     joinpoint #Derived_gen.5 #Derived_gen.4:
         let #Derived_gen.3 : List U8 = CallByName Encode.24 #Derived.8 #Derived_gen.4 #Derived.9;
+        dec #Derived.8;
         ret #Derived_gen.3;
     in
     let #Derived_gen.7 : Str = "B";
     let #Derived_gen.8 : List [] = Array [];
     let #Derived_gen.6 : {Str, List []} = CallByName TotallyNotJson.31 #Derived_gen.7 #Derived_gen.8;
+    dec #Derived_gen.8;
+    dec #Derived_gen.7;
     jump #Derived_gen.5 #Derived_gen.6;
 
 procedure Bool.2 ():
@@ -64,10 +70,12 @@ procedure Encode.24 (Encode.99, Encode.107, Encode.101):
     switch Encode.117:
         case 0:
             let Encode.116 : List U8 = CallByName #Derived.2 Encode.99 Encode.101 Encode.107;
+            dec Encode.99;
             ret Encode.116;
     
         default:
             let Encode.116 : List U8 = CallByName #Derived.7 Encode.99 Encode.101 Encode.107;
+            dec Encode.99;
             ret Encode.116;
     
 
@@ -79,18 +87,21 @@ procedure Encode.26 (Encode.105, Encode.106):
     let Encode.109 : List U8 = Array [];
     let Encode.110 : {{}, {}} = CallByName Test.2 Encode.105;
     let Encode.108 : List U8 = CallByName Encode.24 Encode.109 Encode.110 Encode.106;
+    dec Encode.109;
     ret Encode.108;
 
 procedure List.18 (List.159, List.160, List.161):
     let List.599 : U64 = 0i64;
     let List.600 : U64 = CallByName List.6 List.159;
     let List.598 : {List U8, U64} = CallByName List.91 List.159 List.160 List.161 List.599 List.600;
+    dec List.159;
     ret List.598;
 
 procedure List.18 (List.159, List.160, List.161):
     let List.639 : U64 = 0i64;
     let List.640 : U64 = CallByName List.6 List.159;
     let List.638 : {List U8, U64} = CallByName List.91 List.159 List.160 List.161 List.639 List.640;
+    dec List.159;
     ret List.638;
 
 procedure List.4 (List.123, List.124):
@@ -203,6 +214,8 @@ procedure Test.5 (Test.6, Test.7, Test.4):
         let Test.31 : [C {}, C {}] = CallByName #Derived.0 Test.32;
         let Test.30 : List [C {}, C {}] = Array [Test.31];
         let Test.22 : {Str, List [C {}, C {}]} = CallByName TotallyNotJson.31 Test.29 Test.30;
+        dec Test.30;
+        dec Test.29;
         jump Test.23 Test.22;
     else
         let Test.24 : Str = "B";
@@ -210,6 +223,8 @@ procedure Test.5 (Test.6, Test.7, Test.4):
         let Test.26 : [C {}, C {}] = CallByName #Derived.5 Test.27;
         let Test.25 : List [C {}, C {}] = Array [Test.26];
         let Test.22 : {Str, List [C {}, C {}]} = CallByName TotallyNotJson.31 Test.24 Test.25;
+        dec Test.24;
+        dec Test.25;
         jump Test.23 Test.22;
 
 procedure TotallyNotJson.228 (TotallyNotJson.229, TotallyNotJson.973, #Attr.12):
@@ -236,6 +251,7 @@ procedure TotallyNotJson.228 (TotallyNotJson.229, TotallyNotJson.973, #Attr.12):
     let TotallyNotJson.983 : {List U8, U64} = Struct {TotallyNotJson.231, TotallyNotJson.995};
     let TotallyNotJson.984 : {} = Struct {};
     let TotallyNotJson.982 : {List U8, U64} = CallByName List.18 TotallyNotJson.227 TotallyNotJson.983 TotallyNotJson.984;
+    dec TotallyNotJson.227;
     let TotallyNotJson.233 : List U8 = StructAtIndex 0 TotallyNotJson.982;
     let TotallyNotJson.981 : I64 = 93i64;
     let TotallyNotJson.980 : U8 = CallByName Num.127 TotallyNotJson.981;
@@ -269,6 +285,7 @@ procedure TotallyNotJson.228 (TotallyNotJson.229, TotallyNotJson.973, #Attr.12):
     let TotallyNotJson.1026 : {List U8, U64} = Struct {TotallyNotJson.231, TotallyNotJson.1038};
     let TotallyNotJson.1027 : {} = Struct {};
     let TotallyNotJson.1025 : {List U8, U64} = CallByName List.18 TotallyNotJson.227 TotallyNotJson.1026 TotallyNotJson.1027;
+    dec TotallyNotJson.227;
     let TotallyNotJson.233 : List U8 = StructAtIndex 0 TotallyNotJson.1025;
     let TotallyNotJson.1024 : I64 = 93i64;
     let TotallyNotJson.1023 : U8 = CallByName Num.127 TotallyNotJson.1024;
@@ -283,6 +300,7 @@ procedure TotallyNotJson.230 (TotallyNotJson.975, TotallyNotJson.236):
     let TotallyNotJson.235 : U64 = StructAtIndex 1 TotallyNotJson.975;
     let TotallyNotJson.1037 : {} = Struct {};
     let TotallyNotJson.237 : List U8 = CallByName Encode.24 TotallyNotJson.234 TotallyNotJson.236 TotallyNotJson.1037;
+    dec TotallyNotJson.234;
     joinpoint TotallyNotJson.1032 TotallyNotJson.238:
         let TotallyNotJson.1030 : U64 = 1i64;
         let TotallyNotJson.1029 : U64 = CallByName Num.20 TotallyNotJson.235 TotallyNotJson.1030;
@@ -304,6 +322,7 @@ procedure TotallyNotJson.230 (TotallyNotJson.975, TotallyNotJson.236):
     let TotallyNotJson.235 : U64 = StructAtIndex 1 TotallyNotJson.975;
     let TotallyNotJson.994 : {} = Struct {};
     let TotallyNotJson.237 : List U8 = CallByName Encode.24 TotallyNotJson.234 TotallyNotJson.236 TotallyNotJson.994;
+    dec TotallyNotJson.234;
     joinpoint TotallyNotJson.989 TotallyNotJson.238:
         let TotallyNotJson.987 : U64 = 1i64;
         let TotallyNotJson.986 : U64 = CallByName Num.20 TotallyNotJson.235 TotallyNotJson.987;

--- a/crates/compiler/test_mono/generated/weakening_avoids_overspecialization.txt
+++ b/crates/compiler/test_mono/generated/weakening_avoids_overspecialization.txt
@@ -6,10 +6,12 @@ procedure List.103 (List.487, List.488, List.489):
     let List.590 : U64 = 0i64;
     let List.591 : U64 = CallByName List.6 List.487;
     let List.589 : [C U64, C U64] = CallByName List.80 List.487 List.488 List.489 List.590 List.591;
+    dec List.487;
     ret List.589;
 
 procedure List.26 (List.200, List.201, List.202):
     let List.583 : [C U64, C U64] = CallByName List.103 List.200 List.201 List.202;
+    dec List.200;
     let List.586 : U8 = 1i64;
     let List.587 : U8 = GetTagId List.583;
     let List.588 : Int1 = lowlevel Eq List.586 List.587;
@@ -96,7 +98,6 @@ procedure Test.3 (Test.4, Test.12):
 procedure Test.0 (Test.1):
     let Test.10 : U64 = 0i64;
     let Test.11 : {} = Struct {};
-    inc Test.1;
     let Test.2 : U64 = CallByName List.26 Test.1 Test.10 Test.11;
     let Test.9 : U64 = 0i64;
     let Test.7 : Int1 = CallByName Bool.11 Test.2 Test.9;

--- a/crates/compiler/test_mono/generated/weakening_avoids_overspecialization.txt
+++ b/crates/compiler/test_mono/generated/weakening_avoids_overspecialization.txt
@@ -6,12 +6,10 @@ procedure List.103 (List.487, List.488, List.489):
     let List.590 : U64 = 0i64;
     let List.591 : U64 = CallByName List.6 List.487;
     let List.589 : [C U64, C U64] = CallByName List.80 List.487 List.488 List.489 List.590 List.591;
-    dec List.487;
     ret List.589;
 
 procedure List.26 (List.200, List.201, List.202):
     let List.583 : [C U64, C U64] = CallByName List.103 List.200 List.201 List.202;
-    dec List.200;
     let List.586 : U8 = 1i64;
     let List.587 : U8 = GetTagId List.583;
     let List.588 : Int1 = lowlevel Eq List.586 List.587;
@@ -77,6 +75,7 @@ procedure List.80 (#Derived_gen.0, #Derived_gen.1, #Derived_gen.2, #Derived_gen.
             let List.593 : [C U64, C U64] = TagId(1) List.491;
             ret List.593;
     in
+    inc #Derived_gen.0;
     jump List.592 #Derived_gen.0 #Derived_gen.1 #Derived_gen.2 #Derived_gen.3 #Derived_gen.4;
 
 procedure Num.22 (#Attr.2, #Attr.3):

--- a/crates/glue/tests/test_glue_cli.rs
+++ b/crates/glue/tests/test_glue_cli.rs
@@ -117,7 +117,7 @@ mod glue_cli_run {
             `Bar 123` is: NonRecursive::Bar(123)
             `Baz` is: NonRecursive::Baz(())
             `Blah 456` is: NonRecursive::Blah(456)
-        "#), 
+        "#),
         nullable_wrapped:"nullable-wrapped" => indoc!(r#"
             tag_union was: StrFingerTree::More("foo", StrFingerTree::More("bar", StrFingerTree::Empty))
             `More "small str" (Single "other str")` is: StrFingerTree::More("small str", StrFingerTree::Single("other str"))
@@ -232,7 +232,7 @@ mod glue_cli_run {
             .join("RustGlue.roc");
 
         // Generate a fresh test_glue for this platform
-        let glue_out = run_glue(
+        let parts : Vec<_> =
             // converting these all to String avoids lifetime issues
             std::iter::once("glue".to_string()).chain(
                 args.into_iter().map(|arg| arg.to_string()).chain([
@@ -240,12 +240,13 @@ mod glue_cli_run {
                     glue_dir.to_str().unwrap().to_string(),
                     platform_module_path.to_str().unwrap().to_string(),
                 ]),
-            ),
-        );
+            ).collect();
+        let glue_out = run_glue(parts.iter());
 
         if has_error(&glue_out.stderr) {
             panic!(
-                "`roc glue` command had unexpected stderr: {}",
+                "`roc {}` command had unexpected stderr: {}",
+                parts.join(" "),
                 glue_out.stderr
             );
         }

--- a/examples/platform-switching/rocLovesZig.roc
+++ b/examples/platform-switching/rocLovesZig.roc
@@ -3,4 +3,6 @@ app "rocLovesZig"
     imports []
     provides [main] to pf
 
-main = "Roc <3 Zig!\n"
+helper = \a, b -> Str.concat a b
+
+main = helper "Roc <" "3 Zig!\n"


### PR DESCRIPTION
Adds borrow inference for arguments of type `List _` and `Str` (not tag unions of any kind, not structs containing these types). 

Our observation has been for a while that while perceus etc. are excellent for algebraic types, they cause suboptimal behavior for roc's builtin data structures (list and str). 

In the perceus implementation, arguments are always passed as `Owned` to another function. This is desirable when the callee can perform an update to the argument value: if the argument is unique at runtime, the update can occur in-place.

But passing as owned is suboptimal when the callee only reads from the argument (e.g. `List.get`). Passing the argument as owned in this case likely requires an extra reference count increment, because it is likely that the code performs another read of the data. That means the data needs to be kept alive, hence the additional increment.

A concrete example:

    helper = \list, index -> List.get index

    x = helper list i
    y = helper list j

    x + y

with the old approach, `helper` takes its arguments as owned values. To make that work, an additional `inc` is needed: 

    helper = \list, index -> 
        tmp = List.get list index
        dec list
        tmp

    inc list
    x = helper list i
    y = helper list j

    x + y

With borrow inference, because no updates can ever happen to `list` in the body of `helper`, the argument is inferred as borrowed. 
That means the inferred incs/decs are instead

    helper = \list, index -> 
        List.get list index

    x = helper list i
    y = helper list j
    dec list

    x + y

---

I've opened the PR now mostly for CI reasons: I don't know for sure if the implementation is entirely correct. 

I've disabled an assert in `inc_dec.rs` that verifies that initially join point arguments are owned. No idea if that is correct. 

cc @JTeeuwissen @bhansconnect 