### PR TITLE
Fix lang_srv build command argument?

### DIFF
--- a/crates/lang_srv/README.md
+++ b/crates/lang_srv/README.md
@@ -44,7 +44,7 @@ Follow the [building from source](https://github.com/roc-lang/roc/blob/main/BUIL
 
 ```
 # do `nix develop` first if you're using nix!
-cargo build -p roc_language_server --release
+cargo build --bin roc_language_server --release
 ```
 
 This will give you the language server binary at:


### PR DESCRIPTION
Hello again! :) I'm currently going through the installation process, and I got stuck on this command in the "build it from source" step [here](   Compiling roc_lang_srv v0.0.1 (/home/jan/_code/_roc/roc/crates/lang_srv)
    Finished release [optimized] target(s) in 3m 07s). As written with `-p roc_language_server`, I get
```
...
  Downloaded 17 crates (1.4 MB) in 0.70s
error: package ID specification `roc_language_server` did not match any packages
```
but with `--bin roc_language_server` (inspired by seeing that in `Earthfile`), I get
```
   Compiling roc_lang_srv v0.0.1 (/home/jan/_code/_roc/roc/crates/lang_srv)
    Finished release [optimized] target(s) in 3m 07s
```

Let me know if there's anything else I can do to align this and future PRs with your latest contribution process!