### PR TITLE
Add List.getUnchecked

### DIFF
--- a/crates/compiler/builtins/roc/List.roc
+++ b/crates/compiler/builtins/roc/List.roc
@@ -2,6 +2,7 @@ interface List
     exposes [
         isEmpty,
         get,
+        getUnchecked,
         set,
         replace,
         update,
@@ -228,6 +229,13 @@ isEmpty = \list ->
 # unsafe primitive that does not perform a bounds check
 # but will cause a reference count increment on the value it got out of the list
 getUnsafe : List a, U64 -> a
+
+getUnchecked : List a, U64 -> a
+getUnchecked\ list,index->
+    if index < List.len list then
+        Ok (List.getUnsafe list index)
+    else
+        crash "Index:$(index) is out of bounds"
 
 ## Returns an element from a list at the given index.
 ##


### PR DESCRIPTION
I am writing some performance sensitive code and want to try using a lookup table to minimize branching. Obviously List.get returning a Tag is both slow and pointless because the lookup table is a known length.

Based on [this conversation](https://roc.zulipchat.com/#narrow/stream/304641-ideas/topic/panic.20on.20out-of-bounds
) it seemed basically approved to add a getUnchecked function. So I did :) 
