### PR TITLE
Split `test_utils`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,9 +40,9 @@ dependencies = [
 
 [[package]]
 name = "aligned"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80a21b9440a626c7fc8573a9e3d3a06b75c7c97754c2949bc7857b90353ca655"
+checksum = "377e4c0ba83e4431b10df45c1d4666f178ea9c552cac93e60c3a88bf32785923"
 dependencies = [
  "as-slice",
 ]
@@ -2743,7 +2743,7 @@ dependencies = [
  "roc_solve",
  "roc_solve_problem",
  "roc_target",
- "roc_test_utils",
+ "roc_test_utils_dir",
  "roc_types",
  "ven_pretty",
 ]
@@ -2778,7 +2778,7 @@ dependencies = [
  "roc_solve",
  "roc_solve_problem",
  "roc_target",
- "roc_test_utils",
+ "roc_test_utils_dir",
  "roc_tracing",
  "roc_types",
  "roc_unify",
@@ -3129,6 +3129,12 @@ name = "roc_test_utils"
 version = "0.0.1"
 dependencies = [
  "pretty_assertions",
+]
+
+[[package]]
+name = "roc_test_utils_dir"
+version = "0.0.1"
+dependencies = [
  "remove_dir_all 0.8.2",
 ]
 
@@ -3867,6 +3873,7 @@ dependencies = [
  "roc_parse",
  "roc_region",
  "roc_test_utils",
+ "roc_test_utils_dir",
  "walkdir",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
   "crates/repl_expect",
   "crates/roc_std",
   "crates/test_utils",
+  "crates/test_utils_dir",
   "crates/valgrind",
   "crates/tracing",
   "crates/utils/*",

--- a/crates/compiler/load/Cargo.toml
+++ b/crates/compiler/load/Cargo.toml
@@ -40,7 +40,7 @@ roc_problem = { path = "../problem" }
 roc_region = { path = "../region" }
 roc_solve_problem = { path = "../solve_problem" }
 ven_pretty = { path = "../../vendor/pretty" }
-roc_test_utils = { path = "../../test_utils" }
+roc_test_utils_dir = { path = "../../test_utils_dir" }
 
 indoc.workspace = true
 insta.workspace = true

--- a/crates/compiler/load/tests/test_reporting.rs
+++ b/crates/compiler/load/tests/test_reporting.rs
@@ -28,6 +28,7 @@ mod test_reporting {
     use roc_reporting::report::{RocDocAllocator, RocDocBuilder};
     use roc_solve::FunctionKind;
     use roc_solve_problem::TypeError;
+    use roc_test_utils_dir::TmpDir;
     use roc_types::subs::Subs;
     use std::path::PathBuf;
 
@@ -115,7 +116,7 @@ mod test_reporting {
             // We can't have all tests use "tmp" because tests run in parallel,
             // so append the test name to the tmp path.
             let tmp = format!("tmp/{subdir}");
-            let dir = roc_test_utils::TmpDir::new(&tmp);
+            let dir = TmpDir::new(&tmp);
 
             let filename = PathBuf::from("Test.roc");
             let file_path = dir.path().join(filename);

--- a/crates/compiler/load_internal/Cargo.toml
+++ b/crates/compiler/load_internal/Cargo.toml
@@ -40,7 +40,7 @@ parking_lot.workspace = true
 tempfile.workspace = true
 
 [dev-dependencies]
-roc_test_utils = { path = "../../test_utils" }
+roc_test_utils_dir = { path = "../../test_utils_dir" }
 
 indoc.workspace = true
 maplit.workspace = true

--- a/crates/compiler/load_internal/tests/test_load.rs
+++ b/crates/compiler/load_internal/tests/test_load.rs
@@ -32,6 +32,7 @@ use roc_reporting::report::{can_problem, DEFAULT_PALETTE};
 use roc_reporting::report::{strip_colors, RenderTarget};
 use roc_solve::FunctionKind;
 use roc_target::Target;
+use roc_test_utils_dir::TmpDir;
 use roc_types::pretty_print::name_and_print_var;
 use roc_types::pretty_print::DebugPrint;
 use std::collections::HashMap;
@@ -153,7 +154,7 @@ fn multiple_modules_help<'a>(
     // We can't have all tests use "tmp" because tests run in parallel,
     // so append the test name to the tmp path.
     let tmp = format!("tmp/{subdir}");
-    let dir = roc_test_utils::TmpDir::new(&tmp);
+    let dir = TmpDir::new(&tmp);
 
     let app_module = files.pop().unwrap();
 

--- a/crates/compiler/test_syntax/Cargo.toml
+++ b/crates/compiler/test_syntax/Cargo.toml
@@ -18,6 +18,7 @@ roc_module = { path = "../module" }
 roc_parse = { path = "../parse" }
 roc_region = { path = "../region" }
 roc_test_utils = { path = "../../test_utils" }
+roc_test_utils_dir = { path = "../../test_utils_dir" }
 
 [dev-dependencies]
 indoc.workspace = true

--- a/crates/compiler/test_syntax/tests/test_fmt.rs
+++ b/crates/compiler/test_syntax/tests/test_fmt.rs
@@ -11,7 +11,8 @@ mod test_fmt {
     use roc_parse::module::{self, module_defs};
     use roc_parse::parser::Parser;
     use roc_parse::state::State;
-    use roc_test_utils::{assert_multiline_str_eq, workspace_root};
+    use roc_test_utils::assert_multiline_str_eq;
+    use roc_test_utils_dir::workspace_root;
     use test_syntax::test_helpers::Input;
 
     fn check_formatting(expected: &'_ str) -> impl Fn(Input) + '_ {

--- a/crates/test_utils/src/lib.rs
+++ b/crates/test_utils/src/lib.rs
@@ -1,5 +1,4 @@
 //! Provides testing utility functions for use throughout the Rust code base.
-use std::path::PathBuf;
 
 #[doc(hidden)]
 pub use pretty_assertions::assert_eq as _pretty_assert_eq;
@@ -18,40 +17,4 @@ macro_rules! assert_multiline_str_eq {
     ($a:expr, $b:expr) => {
         $crate::_pretty_assert_eq!($crate::DebugAsDisplay($a), $crate::DebugAsDisplay($b))
     };
-}
-
-/**
- * Creates a temporary empty directory that gets deleted when this goes out of scope.
- */
-pub struct TmpDir {
-    path: std::path::PathBuf,
-}
-
-impl TmpDir {
-    pub fn new(dir: &str) -> TmpDir {
-        let path = std::path::Path::new(dir);
-        // ensure_empty_dir will fail if the dir doesn't already exist
-        std::fs::create_dir_all(path).unwrap();
-        remove_dir_all::ensure_empty_dir(path).unwrap();
-
-        let mut pathbuf = std::path::PathBuf::new();
-        pathbuf.push(path);
-        TmpDir { path: pathbuf }
-    }
-
-    pub fn path(&self) -> &std::path::Path {
-        self.path.as_path()
-    }
-}
-
-impl Drop for TmpDir {
-    fn drop(&mut self) {
-        // we "discard" the Result because there is no problem when a dir was already removed before we call remove_dir_all
-        let _ = remove_dir_all::remove_dir_all(&self.path);
-    }
-}
-
-pub fn workspace_root() -> PathBuf {
-    let root = std::env::var("ROC_WORKSPACE_DIR").expect("Can't find the ROC_WORKSPACE_DIR variable expected to be set in .cargo/config.toml. Are you running tests outside of cargo?");
-    PathBuf::from(root)
 }

--- a/crates/test_utils_dir/Cargo.toml
+++ b/crates/test_utils_dir/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "roc_test_utils"
+name = "roc_test_utils_dir"
 description = "Utility functions used all over the code base."
 
 authors.workspace = true
@@ -8,6 +8,6 @@ license.workspace = true
 version.workspace = true
 
 [dependencies]
-pretty_assertions.workspace = true
+remove_dir_all.workspace = true
 
 [dev-dependencies]

--- a/crates/test_utils_dir/src/lib.rs
+++ b/crates/test_utils_dir/src/lib.rs
@@ -1,0 +1,36 @@
+/**
+ * Creates a temporary empty directory that gets deleted when this goes out of scope.
+ */
+use std::path::PathBuf;
+pub struct TmpDir {
+    path: std::path::PathBuf,
+}
+
+impl TmpDir {
+    pub fn new(dir: &str) -> TmpDir {
+        let path = std::path::Path::new(dir);
+        // ensure_empty_dir will fail if the dir doesn't already exist
+        std::fs::create_dir_all(path).unwrap();
+        remove_dir_all::ensure_empty_dir(path).unwrap();
+
+        let mut pathbuf = std::path::PathBuf::new();
+        pathbuf.push(path);
+        TmpDir { path: pathbuf }
+    }
+
+    pub fn path(&self) -> &std::path::Path {
+        self.path.as_path()
+    }
+}
+
+impl Drop for TmpDir {
+    fn drop(&mut self) {
+        // we "discard" the Result because there is no problem when a dir was already removed before we call remove_dir_all
+        let _ = remove_dir_all::remove_dir_all(&self.path);
+    }
+}
+
+pub fn workspace_root() -> PathBuf {
+    let root = std::env::var("ROC_WORKSPACE_DIR").expect("Can't find the ROC_WORKSPACE_DIR variable expected to be set in .cargo/config.toml. Are you running tests outside of cargo?");
+    PathBuf::from(root)
+}


### PR DESCRIPTION
This PR splits test_utils into two as the dependencies for `remove_dir_all` are not compatible with WASM tests, and these utils are helpful for test in `roc_can`.