### PR TITLE
Minor fix to the docstring of `Num.shiftLeftBy`

### DIFF
--- a/crates/compiler/builtins/roc/Num.roc
+++ b/crates/compiler/builtins/roc/Num.roc
@@ -1001,7 +1001,7 @@ bitwiseNot = \n ->
 ## ```roc
 ## shiftLeftBy 0b0000_0011 2 == 0b0000_1100
 ##
-## 0b0000_0101 |> shiftLeftBy 2 == 0b0000_1100
+## 0b0000_0101 |> shiftLeftBy 2 == 0b0001_0100
 ## ```
 ## In some languages `shiftLeftBy` is implemented as a binary operator `<<`.
 shiftLeftBy : Int a, U8 -> Int a


### PR DESCRIPTION
This commit has a minor fix to the example in the docstring of `Num.shiftLeftBy`.

One line in the example reads:

```roc
0b0000_0101 |> shiftLeftBy 2 == 0b0000_1100
```

which is false:

```sh
zsh ❯ roc repl

  The rockin' roc repl
────────────────────────

Enter an expression, or :help, or :q to quit.

» 0b0000_0101 |> Num.shiftLeftBy 2 == 0b0000_1100

Bool.false : Bool
```

The result should instead be `0b0001_0100`:

```sh
zsh ❯ roc repl

  The rockin' roc repl
────────────────────────

Enter an expression, or :help, or :q to quit.

» 0b0000_0101 |> Num.shiftLeftBy 2 == 0b0001_0100

Bool.true : Bool
```