### PR TITLE
Fix recursion for suffixed `!` in top-level def

### DIFF
--- a/crates/compiler/can/src/desugar.rs
+++ b/crates/compiler/can/src/desugar.rs
@@ -189,14 +189,17 @@ pub fn desugar_value_def_suffixed<'a>(arena: &'a Bump, value_def: ValueDef<'a>) 
                     sub_arg,
                     sub_pat,
                     sub_new,
-                }) => Body(
-                    loc_pattern,
-                    apply_task_await(
-                        arena,
-                        loc_expr.region,
-                        sub_arg,
-                        sub_pat,
-                        wrap_in_task_ok(arena, sub_new),
+                }) => desugar_value_def_suffixed(
+                    arena,
+                    Body(
+                        loc_pattern,
+                        apply_task_await(
+                            arena,
+                            loc_expr.region,
+                            sub_arg,
+                            sub_pat,
+                            wrap_in_task_ok(arena, sub_new),
+                        ),
                     ),
                 ),
                 Err(..) => Body(
@@ -226,19 +229,22 @@ pub fn desugar_value_def_suffixed<'a>(arena: &'a Bump, value_def: ValueDef<'a>) 
                     sub_arg,
                     sub_pat,
                     sub_new,
-                }) => AnnotatedBody {
-                    ann_pattern,
-                    ann_type,
-                    comment,
-                    body_pattern,
-                    body_expr: apply_task_await(
-                        arena,
-                        body_expr.region,
-                        sub_arg,
-                        sub_pat,
-                        wrap_in_task_ok(arena, sub_new),
-                    ),
-                },
+                }) => desugar_value_def_suffixed(
+                    arena,
+                    AnnotatedBody {
+                        ann_pattern,
+                        ann_type,
+                        comment,
+                        body_pattern,
+                        body_expr: apply_task_await(
+                            arena,
+                            body_expr.region,
+                            sub_arg,
+                            sub_pat,
+                            wrap_in_task_ok(arena, sub_new),
+                        ),
+                    },
+                ),
                 Err(..) => AnnotatedBody {
                     ann_pattern,
                     ann_type,

--- a/crates/compiler/can/tests/test_suffixed.rs
+++ b/crates/compiler/can/tests/test_suffixed.rs
@@ -423,6 +423,26 @@ mod suffixed_tests {
     /**
      * Nested suffixed expressions
     ```roc
+    run = line! (nextMsg!)
+
+    run = Task.await nextMsg \#!a0 -> line! (#!a0)
+
+    run = Task.await nextMsg \#!a0 -> line (#!a0)
+    ```
+    */
+    #[test]
+    fn nested_simple() {
+        run_test(
+            r#"
+            run = line! (nextMsg!)
+            "#,
+            r##"Defs { tags: [Index(2147483648)], regions: [@0-22], space_before: [Slice(start = 0, length = 0)], space_after: [Slice(start = 0, length = 0)], spaces: [], type_defs: [], value_defs: [Body(@0-3 Identifier { ident: "run", suffixed: 0 }, @0-22 Apply(@0-22 Var { module_name: "Task", ident: "await", suffixed: 0 }, [Var { module_name: "", ident: "nextMsg", suffixed: 0 }, @0-22 Closure([Identifier { ident: "#!a0", suffixed: 0 }], @0-22 Apply(@0-22 Var { module_name: "", ident: "line", suffixed: 0 }, [@13-21 ParensAround(Var { module_name: "", ident: "#!a0", suffixed: 0 })], Space))], BangSuffix))] }"##,
+        );
+    }
+
+    /**
+     * Nested suffixed expressions
+    ```roc
     main =
         z = foo! (bar! baz) (blah stuff)
         doSomething z
@@ -437,9 +457,8 @@ mod suffixed_tests {
             Task.await [foo (#!a0) (blah stuff)] \z -> doSomething z
     ```
     */
-
     #[test]
-    fn nested_suffixed() {
+    fn nested_complex() {
         run_test(
             r#"
             main = 


### PR DESCRIPTION
The PR fixes the recursion to unwrap a nested suffixed for top level def.

For example, the following would not have been fully unwrapped and therefore is fixed with this change.

```roc
run = line! (nextMsg!)
```