### PR TITLE
Fix lang-server nix package build crash

### DIFF
--- a/nix/builder.nix
+++ b/nix/builder.nix
@@ -3,7 +3,7 @@ let
   inherit (compile-deps) zigPkg llvmPkgs llvmVersion llvmMajorMinorStr glibcPath libGccSPath;
 
   subPackagePath = if subPackage != null then "crates/${subPackage}" else null;
-  mainBin = if subPackage == "lang_srv" then "roc_language_server" else "roc";
+  mainBin = if subPackage == "language_server" then "roc_language_server" else "roc";
   filteredSource = pkgs.callPackage ./fileFilter.nix { };
 in
 rustPlatform.buildRustPackage {

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -18,7 +18,7 @@ let
 
     # all rust crates in workspace.members of Cargo.toml
     roc-full = callPackage ./builder.nix { };
-    roc-lang-server = callPackage ./builder.nix { subPackage = "lang_srv"; };
+    roc-lang-server = callPackage ./builder.nix { subPackage = "language_server"; };
     # only the CLI crate = executable provided in nightly releases
     roc-cli = callPackage ./builder.nix { subPackage = "cli"; };
   };


### PR DESCRIPTION
Looks like 88c4a3af4e23d00aaf95c8f79bbf8d9e1056f363 broke nix builds for the `lang-server` package. This PR fixes it.