### PR TITLE
Add abilities for glue types

### DIFF
--- a/crates/glue/platform/TypeId.roc
+++ b/crates/glue/platform/TypeId.roc
@@ -1,11 +1,13 @@
 interface TypeId
-    exposes [TypeId, fromU64, toU64]
+    exposes [TypeId, typeIDfromU64, typeIDtoU64]
     imports []
 
-TypeId := U64 implements [Eq, Hash]
+TypeId := U64 implements [Eq, Hash, Inspect, Encoding]
 
-toU64 : TypeId -> U64
-toU64 = \@TypeId x -> x
+# renamed here so we can import the functions directly as a workaround for
+# https://github.com/roc-lang/roc/issues/5477
+typeIDtoU64 : TypeId -> U64
+typeIDtoU64 = \@TypeId x -> x
 
-fromU64 : U64 -> TypeId
-fromU64 = @TypeId
+typeIDfromU64 : U64 -> TypeId
+typeIDfromU64 = @TypeId

--- a/crates/glue/platform/Types.roc
+++ b/crates/glue/platform/Types.roc
@@ -1,6 +1,6 @@
 interface Types
     exposes [Types, shape, size, alignment, target, walkShapes, entryPoints]
-    imports [Shape.{ Shape }, TypeId.{ TypeId }, Target.{ Target }, TypeId]
+    imports [Shape.{ Shape }, TypeId.{ TypeId, typeIDfromU64, typeIDtoU64 }, Target.{ Target }]
 
 # TODO: switch AssocList uses to Dict once roc_std is updated.
 Tuple1 : [T Str TypeId]
@@ -23,7 +23,7 @@ Types := {
     ## Names and types of the entry points of the program (e.g. mainForHost)
     entrypoints : List Tuple1,
     target : Target,
-}
+} implements [Inspect, Encoding]
 
 target : Types -> Target
 target = \@Types types -> types.target
@@ -34,33 +34,33 @@ entryPoints = \@Types { entrypoints } -> entrypoints
 walkShapes : Types, state, (state, Shape, TypeId -> state) -> state
 walkShapes = \@Types { types: shapes }, originalState, update ->
     List.walkWithIndex shapes originalState \state, elem, index ->
-        id = TypeId.fromU64 index
+        id = typeIDfromU64 index
 
         update state elem id
 
 shape : Types, TypeId -> Shape
 shape = \@Types types, id ->
-    when List.get types.types (TypeId.toU64 id) is
+    when List.get types.types (typeIDtoU64 id) is
         Ok answer -> answer
         Err OutOfBounds ->
-            idStr = Num.toStr (TypeId.toU64 id)
+            idStr = Num.toStr (typeIDtoU64 id)
 
             crash "TypeId #$(idStr) was not found in Types. This should never happen, and means there was a bug in `roc glue`. If you have time, please open an issue at <https://github.com/roc-lang/roc/issues>"
 
 alignment : Types, TypeId -> U32
 alignment = \@Types types, id ->
-    when List.get types.aligns (TypeId.toU64 id) is
+    when List.get types.aligns (typeIDtoU64 id) is
         Ok answer -> answer
         Err OutOfBounds ->
-            idStr = Num.toStr (TypeId.toU64 id)
+            idStr = Num.toStr (typeIDtoU64 id)
 
             crash "TypeId #$(idStr) was not found in Types. This should never happen, and means there was a bug in `roc glue`. If you have time, please open an issue at <https://github.com/roc-lang/roc/issues>"
 
 size : Types, TypeId -> U32
 size = \@Types types, id ->
-    when List.get types.sizes (TypeId.toU64 id) is
+    when List.get types.sizes (typeIDtoU64 id) is
         Ok answer -> answer
         Err OutOfBounds ->
-            idStr = Num.toStr (TypeId.toU64 id)
+            idStr = Num.toStr (typeIDtoU64 id)
 
             crash "TypeId #$(idStr) was not found in Types. This should never happen, and means there was a bug in `roc glue`. If you have time, please open an issue at <https://github.com/roc-lang/roc/issues>"


### PR DESCRIPTION
Tested using `cargo run -- glue crates/glue/src/JsonGlue.roc test-glue/ test-platform.roc`

```roc 
# test-platform.roc
platform "test"
    requires {} { main : Foo }
    exposes []
    packages {}
    imports []
    provides [mainForHost]

Foo := [Number U8, String Str]

mainForHost : Foo
mainForHost = main
```

```roc 
# test.roc
app "main"
    packages {
        pf: "https://github.com/roc-lang/basic-cli/releases/download/0.9.0/oKWkaruh2zXxin_xfsYsCJobH1tO8_JvNkFzDwwzNUQ.tar.br",
    }
    imports [
        pf.Stdin,
        pf.Stdout,
        pf.Task,
    ]
    provides [
        main,
    ] to pf

main =
    result = Stdin.line!

    when result is
        End ->
            Task.ok {}

        Input name ->
            Stdout.line! "Hello, $(name)"
```

```roc
# crates/glue/src/JsonGlue.roc
app "json-glue"
    packages {
        pf: "../platform/main.roc",
        json: "https://github.com/lukewilliamboswell/roc-json/releases/download/0.7.0/xuaMzXRVG_SEhOFZucS3iBozlRdObWsfKaYZMHVE_q0.tar.br",
    }
    imports [
        pf.Types.{ Types },
        pf.File.{ File },
        json.Core.{json},
    ]
    provides [makeGlue] to pf

makeGlue : List Types -> Result (List File) Str
makeGlue = \typesByArch ->
    typesByArch
    |> List.map convertTypesToFile
    |> List.concat staticFiles
    |> Ok

staticFiles : List File
staticFiles = []

convertTypesToFile : Types -> File
convertTypesToFile = \types ->

    content =
        Encode.toBytes types json
        |> Str.fromUtf8
        |> Result.withDefault "INVALID UTF8 ENCODED FROM JSON"

    { name: "types.json", content  }

```