### PR TITLE
Fix minor heading issue in tutorial

### DIFF
--- a/www/content/tutorial.md
+++ b/www/content/tutorial.md
@@ -1715,7 +1715,7 @@ We could also use `Task.onErr` instead, which is like `mapErr` except instead of
 
 Since we don't have any extra tasks to run, `mapErr` is more concise because we don't have to say `Task.err` at the end of each branch.
 
-### [The \_ type](#_) {#\_}
+### [The \_ type](#underscore) {#underscore}
 
 In a larger program, we might want to split `main` into different pieces for logic and handling errors:
 


### PR DESCRIPTION
## From
<img width="619" alt="Screenshot 2024-04-28 at 11 05 59" src="https://github.com/roc-lang/roc/assets/2679227/e3d377df-0ccc-4250-a16d-ca3bb9b549bc">

## To

<img width="644" alt="Screenshot 2024-04-28 at 11 07 29" src="https://github.com/roc-lang/roc/assets/2679227/da5ce40d-8413-43d9-ada0-e920304bce1e">
