### PR TITLE
Reduce lsp crashes

### DIFF
--- a/crates/language_server/src/registry.rs
+++ b/crates/language_server/src/registry.rs
@@ -74,7 +74,7 @@ impl Registry {
         if &document.doc_info.url == updating_url {
             //Write the newly analysed document into the oncelock that any request requiring the latest document will be waiting on
             if let Some(a) = documents.get_mut(updating_url) {
-                //We don't care if this fails becasue we expect the document to sometimes alreday be there
+                //We don't care if this fails because we expect the document to sometimes already be there
                 a.latest_document.set(document.clone()).unwrap_or(())
             }
         }

--- a/crates/language_server/src/registry.rs
+++ b/crates/language_server/src/registry.rs
@@ -74,7 +74,7 @@ impl Registry {
         if &document.doc_info.url == updating_url {
             //Write the newly analysed document into the oncelock that any request requiring the latest document will be waiting on
             if let Some(a) = documents.get_mut(updating_url) {
-                //We don't care if this fails because we expect the document to sometimes already be there
+                // We don't care if this fails because we expect the document to sometimes already be there
                 a.latest_document.set(document.clone()).unwrap_or(())
             }
         }

--- a/crates/language_server/src/registry.rs
+++ b/crates/language_server/src/registry.rs
@@ -74,7 +74,8 @@ impl Registry {
         if &document.doc_info.url == updating_url {
             //Write the newly analysed document into the oncelock that any request requiring the latest document will be waiting on
             if let Some(a) = documents.get_mut(updating_url) {
-                a.latest_document.set(document.clone()).unwrap()
+                //We don't care if this fails becasue we expect the document to sometimes alreday be there
+                a.latest_document.set(document.clone()).unwrap_or(())
             }
         }
 

--- a/crates/language_server/src/server.rs
+++ b/crates/language_server/src/server.rs
@@ -3,7 +3,7 @@ use analysis::HIGHLIGHT_TOKENS_LEGEND;
 use log::{debug, trace};
 use registry::{Registry, RegistryConfig};
 use std::future::Future;
-use std::panic::AssertUnwindSafe;
+use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::time::Duration;
 
 use tower_lsp::jsonrpc::{self, Result};
@@ -173,10 +173,17 @@ impl RocServerState {
                 return Err("Not latest version skipping analysis".to_string());
             }
 
-            let results = match tokio::task::spawn_blocking(|| global_analysis(doc_info)).await {
-                Err(e) => return Err(format!("Document analysis failed. reason:{:?}", e)),
-                Ok(a) => a,
-            };
+            let results =
+                match tokio::task::spawn_blocking(|| catch_unwind(|| global_analysis(doc_info)))
+                    .await
+                {
+                    Err(e) => {
+                        return Err(format!("Document analysis thread failed. reason:{:?}", e))
+                    }
+                    Ok(res) => {
+                        res.map_err(|err| format!("Document analysis panicked with: {:?}", err))?
+                    }
+                };
             let latest_version = inner_ref.registry.get_latest_version(fi).await;
 
             //if this version is not the latest another change must have come in and this analysis is useless
@@ -230,8 +237,11 @@ impl LanguageServer for RocServer {
 
         // NOTE: We specify that we expect full-content syncs in the server capabilities,
         // so here we assume the only change passed is a change of the entire document's content.
-        let TextDocumentContentChangeEvent { text, .. } =
-            params.content_changes.into_iter().next().unwrap();
+        let TextDocumentContentChangeEvent { text, .. } = params
+            .content_changes
+            .into_iter()
+            .last()
+            .expect("textDocument change event had no changes ");
 
         self.change(uri, text, version).await;
     }


### PR DESCRIPTION
This is an attempt to fix some of the main crashes and hangs in the language server process.

from looking at logs I'm seeing two main issues: 
- Occasional panics crashing the process.
- Analysis hangs that eat memory and make the process unresponsive

This tries to fix the hangs with a timeout and removes instances of unwrap that can cause panics