### PR TITLE
Floating point special values

### DIFF
--- a/crates/compiler/builtins/roc/Num.roc
+++ b/crates/compiler/builtins/roc/Num.roc
@@ -155,6 +155,10 @@ module [
     f64ToParts,
     f32FromParts,
     f64FromParts,
+    nanF32,
+    nanF64,
+    infinityF32,
+    infinityF64,
 ]
 
 import Bool exposing [Bool]
@@ -1433,3 +1437,19 @@ f32FromParts : { sign : Bool, exponent : U8, fraction : U32 } -> F32
 ## The fraction should not be bigger than 0x000F_FFFF_FFFF_FFFF, any bigger value will be truncated.
 ## The exponent should not be bigger than 0x07FF, any bigger value will be truncated.
 f64FromParts : { sign : Bool, exponent : U16, fraction : U64 } -> F64
+
+## The value for not-a-number for a [F32] according to the IEEE 754 standard.
+nanF32 : F32
+nanF32 = 0.0f32 / 0.0
+
+## The value for not-a-number for a [F64] according to the IEEE 754 standard.
+nanF64 : F64
+nanF64 = 0.0f64 / 0.0
+
+## The value for infinity for a [F32] according to the IEEE 754 standard.
+infinityF32 : F32
+infinityF32 = 1.0f32 / 0.0
+
+## The value for infinity for a [F64] according to the IEEE 754 standard.
+infinityF64 : F64
+infinityF64 = 1.0f64 / 0.0

--- a/crates/compiler/module/src/symbol.rs
+++ b/crates/compiler/module/src/symbol.rs
@@ -1370,6 +1370,10 @@ define_builtins! {
         162 NUM_F64_TO_PARTS: "f64ToParts"
         163 NUM_F32_FROM_PARTS: "f32FromParts"
         164 NUM_F64_FROM_PARTS: "f64FromParts"
+        165 NUM_NAN_F32: "nanF32"
+        166 NUM_NAN_F64: "nanF64"
+        167 NUM_INFINITY_F32: "infinityF32"
+        168 NUM_INFINITY_F64: "infinityF64"
     }
     4 BOOL: "Bool" => {
         0 BOOL_BOOL: "Bool" exposed_type=true // the Bool.Bool type alias

--- a/crates/compiler/test_gen/src/gen_num.rs
+++ b/crates/compiler/test_gen/src/gen_num.rs
@@ -3905,41 +3905,23 @@ fn f64_from_parts() {
 #[test]
 #[cfg(any(feature = "gen-llvm", feature = "gen-dev", feature = "gen-wasm"))]
 fn nan_f32() {
-    assert_evals_to!(
-        r"Num.nanF32",
-        true,
-        f32,
-        |f: f32| f.is_nan()
-    );
+    assert_evals_to!(r"Num.nanF32", true, f32, |f: f32| f.is_nan());
 }
 
 #[test]
 #[cfg(any(feature = "gen-llvm", feature = "gen-dev", feature = "gen-wasm"))]
 fn nan_f64() {
-    assert_evals_to!(
-        r"Num.nanF64",
-        true,
-        f64,
-        |f: f64| f.is_nan()
-    );
+    assert_evals_to!(r"Num.nanF64", true, f64, |f: f64| f.is_nan());
 }
 
 #[test]
 #[cfg(any(feature = "gen-llvm", feature = "gen-dev", feature = "gen-wasm"))]
 fn infinity_f32() {
-    assert_evals_to!(
-        r"Num.infinityF32",
-        f32::INFINITY,
-        f32
-    );
+    assert_evals_to!(r"Num.infinityF32", f32::INFINITY, f32);
 }
 
 #[test]
 #[cfg(any(feature = "gen-llvm", feature = "gen-dev", feature = "gen-wasm"))]
 fn infinity_f64() {
-    assert_evals_to!(
-        r"Num.infinityF64",
-        f64::INFINITY,
-        f64
-    );
+    assert_evals_to!(r"Num.infinityF64", f64::INFINITY, f64);
 }

--- a/crates/compiler/test_gen/src/gen_num.rs
+++ b/crates/compiler/test_gen/src/gen_num.rs
@@ -3901,3 +3901,43 @@ fn f64_from_parts() {
         f64
     );
 }
+
+#[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-dev", feature = "gen-wasm"))]
+fn nan_f32() {
+    assert_evals_to!(
+        r"Num.nanF32",
+        f32::NAN,
+        f32
+    );
+}
+
+#[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-dev", feature = "gen-wasm"))]
+fn nan_f64() {
+    assert_evals_to!(
+        r"Num.nanF64",
+        f64::NAN,
+        f64
+    );
+}
+
+#[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-dev", feature = "gen-wasm"))]
+fn infinity_f32() {
+    assert_evals_to!(
+        r"Num.infinityF32",
+        f32::INFINITY,
+        f32
+    );
+}
+
+#[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-dev", feature = "gen-wasm"))]
+fn infinity_f64() {
+    assert_evals_to!(
+        r"Num.infinityF64",
+        f64::INFINITY,
+        f64
+    );
+}

--- a/crates/compiler/test_gen/src/gen_num.rs
+++ b/crates/compiler/test_gen/src/gen_num.rs
@@ -3907,8 +3907,9 @@ fn f64_from_parts() {
 fn nan_f32() {
     assert_evals_to!(
         r"Num.nanF32",
-        f32::NAN,
-        f32
+        true,
+        f32,
+        |f: f32| f.is_nan()
     );
 }
 
@@ -3917,8 +3918,9 @@ fn nan_f32() {
 fn nan_f64() {
     assert_evals_to!(
         r"Num.nanF64",
-        f64::NAN,
-        f64
+        true,
+        f64,
+        |f: f64| f.is_nan()
     );
 }
 

--- a/crates/compiler/test_mono/generated/anonymous_closure_in_polymorphic_expression_issue_4717.txt
+++ b/crates/compiler/test_mono/generated/anonymous_closure_in_polymorphic_expression_issue_4717.txt
@@ -78,16 +78,16 @@ procedure List.80 (#Derived_gen.0, #Derived_gen.1, #Derived_gen.2, #Derived_gen.
     jump List.592 #Derived_gen.0 #Derived_gen.1 #Derived_gen.2 #Derived_gen.3 #Derived_gen.4;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.278 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.278;
+    let Num.282 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.282;
 
 procedure Num.51 (#Attr.2, #Attr.3):
-    let Num.277 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
-    ret Num.277;
+    let Num.281 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
+    ret Num.281;
 
 procedure Num.77 (#Attr.2, #Attr.3):
-    let Num.276 : U64 = lowlevel NumSubSaturated #Attr.2 #Attr.3;
-    ret Num.276;
+    let Num.280 : U64 = lowlevel NumSubSaturated #Attr.2 #Attr.3;
+    ret Num.280;
 
 procedure Test.1 (Test.2):
     let Test.13 : U64 = 0i64;

--- a/crates/compiler/test_mono/generated/binary_tree_fbip.txt
+++ b/crates/compiler/test_mono/generated/binary_tree_fbip.txt
@@ -1,6 +1,6 @@
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.275 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.275;
+    let Num.279 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.279;
 
 procedure Test.4 (Test.27):
     let Test.39 : [<rnu>C [<rnu><null>, C *self *self] *self, <null>] = TagId(0) ;

--- a/crates/compiler/test_mono/generated/capture_void_layout_task.txt
+++ b/crates/compiler/test_mono/generated/capture_void_layout_task.txt
@@ -28,12 +28,12 @@ procedure List.91 (#Derived_gen.9, #Derived_gen.10, #Derived_gen.11, #Derived_ge
     jump List.575 #Derived_gen.9 #Derived_gen.10 #Derived_gen.11 #Derived_gen.12 #Derived_gen.13;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.276 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.276;
+    let Num.280 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.280;
 
 procedure Num.51 (#Attr.2, #Attr.3):
-    let Num.275 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
-    ret Num.275;
+    let Num.279 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
+    ret Num.279;
 
 procedure Test.10 (Test.69, #Attr.12):
     let Test.72 : {} = UnionAtIndex (Id 0) (Index 0) #Attr.12;

--- a/crates/compiler/test_mono/generated/choose_correct_recursion_var_under_record.txt
+++ b/crates/compiler/test_mono/generated/choose_correct_recursion_var_under_record.txt
@@ -47,8 +47,8 @@ procedure List.9 (List.334):
         ret List.574;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.275 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.275;
+    let Num.279 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.279;
 
 procedure Result.5 (Result.10, Result.11):
     let Result.37 : U8 = 1i64;

--- a/crates/compiler/test_mono/generated/choose_i128_layout.txt
+++ b/crates/compiler/test_mono/generated/choose_i128_layout.txt
@@ -1,6 +1,6 @@
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.276 : I128 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.276;
+    let Num.280 : I128 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.280;
 
 procedure Test.0 ():
     let Test.6 : I128 = 18446744073709551616i64;

--- a/crates/compiler/test_mono/generated/choose_u128_layout.txt
+++ b/crates/compiler/test_mono/generated/choose_u128_layout.txt
@@ -1,6 +1,6 @@
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.275 : U128 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.275;
+    let Num.279 : U128 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.279;
 
 procedure Test.0 ():
     let Test.2 : U128 = 170141183460469231731687303715884105728u128;

--- a/crates/compiler/test_mono/generated/choose_u64_layout.txt
+++ b/crates/compiler/test_mono/generated/choose_u64_layout.txt
@@ -1,6 +1,6 @@
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.275 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.275;
+    let Num.279 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.279;
 
 procedure Test.0 ():
     let Test.2 : U64 = 9999999999999999999i64;

--- a/crates/compiler/test_mono/generated/compose_recursive_lambda_set_productive_nullable_wrapped.txt
+++ b/crates/compiler/test_mono/generated/compose_recursive_lambda_set_productive_nullable_wrapped.txt
@@ -32,12 +32,12 @@ procedure List.91 (#Derived_gen.7, #Derived_gen.8, #Derived_gen.9, #Derived_gen.
     jump List.575 #Derived_gen.7 #Derived_gen.8 #Derived_gen.9 #Derived_gen.10 #Derived_gen.11;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.276 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.276;
+    let Num.280 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.280;
 
 procedure Num.51 (#Attr.2, #Attr.3):
-    let Num.275 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
-    ret Num.275;
+    let Num.279 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
+    ret Num.279;
 
 procedure Str.3 (#Attr.2, #Attr.3):
     let Str.234 : Str = lowlevel StrConcat #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/dict.txt
+++ b/crates/compiler/test_mono/generated/dict.txt
@@ -30,8 +30,8 @@ procedure List.6 (#Attr.2):
     ret List.572;
 
 procedure Num.75 (#Attr.2, #Attr.3):
-    let Num.275 : U8 = lowlevel NumSubWrap #Attr.2 #Attr.3;
-    ret Num.275;
+    let Num.279 : U8 = lowlevel NumSubWrap #Attr.2 #Attr.3;
+    ret Num.279;
 
 procedure Test.0 ():
     let Test.3 : {} = Struct {};

--- a/crates/compiler/test_mono/generated/empty_list_of_function_type.txt
+++ b/crates/compiler/test_mono/generated/empty_list_of_function_type.txt
@@ -25,8 +25,8 @@ procedure List.66 (#Attr.2, #Attr.3):
     ret List.577;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.275 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.275;
+    let Num.279 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.279;
 
 procedure Test.2 (Test.5):
     dec Test.5;

--- a/crates/compiler/test_mono/generated/encode_derived_nested_record_string.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_nested_record_string.txt
@@ -254,40 +254,40 @@ procedure List.91 (#Derived_gen.50, #Derived_gen.51, #Derived_gen.52, #Derived_g
     jump List.630 #Derived_gen.50 #Derived_gen.51 #Derived_gen.52 #Derived_gen.53 #Derived_gen.54;
 
 procedure Num.127 (#Attr.2):
-    let Num.291 : U8 = lowlevel NumIntCast #Attr.2;
-    ret Num.291;
+    let Num.295 : U8 = lowlevel NumIntCast #Attr.2;
+    ret Num.295;
 
 procedure Num.137 (#Attr.2, #Attr.3):
-    let Num.297 : U64 = lowlevel NumDivCeilUnchecked #Attr.2 #Attr.3;
-    ret Num.297;
-
-procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.296 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.296;
-
-procedure Num.20 (#Attr.2, #Attr.3):
-    let Num.293 : U64 = lowlevel NumSub #Attr.2 #Attr.3;
-    ret Num.293;
-
-procedure Num.21 (#Attr.2, #Attr.3):
-    let Num.298 : U64 = lowlevel NumMul #Attr.2 #Attr.3;
-    ret Num.298;
-
-procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.304 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.304;
-
-procedure Num.24 (#Attr.2, #Attr.3):
-    let Num.306 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
-    ret Num.306;
-
-procedure Num.51 (#Attr.2, #Attr.3):
-    let Num.301 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
+    let Num.301 : U64 = lowlevel NumDivCeilUnchecked #Attr.2 #Attr.3;
     ret Num.301;
 
-procedure Num.75 (#Attr.2, #Attr.3):
-    let Num.305 : U64 = lowlevel NumSubWrap #Attr.2 #Attr.3;
+procedure Num.19 (#Attr.2, #Attr.3):
+    let Num.300 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.300;
+
+procedure Num.20 (#Attr.2, #Attr.3):
+    let Num.297 : U64 = lowlevel NumSub #Attr.2 #Attr.3;
+    ret Num.297;
+
+procedure Num.21 (#Attr.2, #Attr.3):
+    let Num.302 : U64 = lowlevel NumMul #Attr.2 #Attr.3;
+    ret Num.302;
+
+procedure Num.22 (#Attr.2, #Attr.3):
+    let Num.308 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.308;
+
+procedure Num.24 (#Attr.2, #Attr.3):
+    let Num.310 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
+    ret Num.310;
+
+procedure Num.51 (#Attr.2, #Attr.3):
+    let Num.305 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
     ret Num.305;
+
+procedure Num.75 (#Attr.2, #Attr.3):
+    let Num.309 : U64 = lowlevel NumSubWrap #Attr.2 #Attr.3;
+    ret Num.309;
 
 procedure Str.12 (#Attr.2):
     let Str.242 : List U8 = lowlevel StrToUtf8 #Attr.2;

--- a/crates/compiler/test_mono/generated/encode_derived_record_one_field_string.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_record_one_field_string.txt
@@ -197,40 +197,40 @@ procedure List.91 (#Derived_gen.23, #Derived_gen.24, #Derived_gen.25, #Derived_g
     jump List.595 #Derived_gen.23 #Derived_gen.24 #Derived_gen.25 #Derived_gen.26 #Derived_gen.27;
 
 procedure Num.127 (#Attr.2):
-    let Num.280 : U8 = lowlevel NumIntCast #Attr.2;
-    ret Num.280;
+    let Num.284 : U8 = lowlevel NumIntCast #Attr.2;
+    ret Num.284;
 
 procedure Num.137 (#Attr.2, #Attr.3):
-    let Num.286 : U64 = lowlevel NumDivCeilUnchecked #Attr.2 #Attr.3;
-    ret Num.286;
-
-procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.285 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.285;
-
-procedure Num.20 (#Attr.2, #Attr.3):
-    let Num.282 : U64 = lowlevel NumSub #Attr.2 #Attr.3;
-    ret Num.282;
-
-procedure Num.21 (#Attr.2, #Attr.3):
-    let Num.287 : U64 = lowlevel NumMul #Attr.2 #Attr.3;
-    ret Num.287;
-
-procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.293 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.293;
-
-procedure Num.24 (#Attr.2, #Attr.3):
-    let Num.295 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
-    ret Num.295;
-
-procedure Num.51 (#Attr.2, #Attr.3):
-    let Num.290 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
+    let Num.290 : U64 = lowlevel NumDivCeilUnchecked #Attr.2 #Attr.3;
     ret Num.290;
 
-procedure Num.75 (#Attr.2, #Attr.3):
-    let Num.294 : U64 = lowlevel NumSubWrap #Attr.2 #Attr.3;
+procedure Num.19 (#Attr.2, #Attr.3):
+    let Num.289 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.289;
+
+procedure Num.20 (#Attr.2, #Attr.3):
+    let Num.286 : U64 = lowlevel NumSub #Attr.2 #Attr.3;
+    ret Num.286;
+
+procedure Num.21 (#Attr.2, #Attr.3):
+    let Num.291 : U64 = lowlevel NumMul #Attr.2 #Attr.3;
+    ret Num.291;
+
+procedure Num.22 (#Attr.2, #Attr.3):
+    let Num.297 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.297;
+
+procedure Num.24 (#Attr.2, #Attr.3):
+    let Num.299 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
+    ret Num.299;
+
+procedure Num.51 (#Attr.2, #Attr.3):
+    let Num.294 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
     ret Num.294;
+
+procedure Num.75 (#Attr.2, #Attr.3):
+    let Num.298 : U64 = lowlevel NumSubWrap #Attr.2 #Attr.3;
+    ret Num.298;
 
 procedure Str.12 (#Attr.2):
     let Str.241 : List U8 = lowlevel StrToUtf8 #Attr.2;

--- a/crates/compiler/test_mono/generated/encode_derived_record_two_field_strings.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_record_two_field_strings.txt
@@ -204,40 +204,40 @@ procedure List.91 (#Derived_gen.27, #Derived_gen.28, #Derived_gen.29, #Derived_g
     jump List.595 #Derived_gen.27 #Derived_gen.28 #Derived_gen.29 #Derived_gen.30 #Derived_gen.31;
 
 procedure Num.127 (#Attr.2):
-    let Num.280 : U8 = lowlevel NumIntCast #Attr.2;
-    ret Num.280;
+    let Num.284 : U8 = lowlevel NumIntCast #Attr.2;
+    ret Num.284;
 
 procedure Num.137 (#Attr.2, #Attr.3):
-    let Num.286 : U64 = lowlevel NumDivCeilUnchecked #Attr.2 #Attr.3;
-    ret Num.286;
-
-procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.285 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.285;
-
-procedure Num.20 (#Attr.2, #Attr.3):
-    let Num.282 : U64 = lowlevel NumSub #Attr.2 #Attr.3;
-    ret Num.282;
-
-procedure Num.21 (#Attr.2, #Attr.3):
-    let Num.287 : U64 = lowlevel NumMul #Attr.2 #Attr.3;
-    ret Num.287;
-
-procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.293 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.293;
-
-procedure Num.24 (#Attr.2, #Attr.3):
-    let Num.295 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
-    ret Num.295;
-
-procedure Num.51 (#Attr.2, #Attr.3):
-    let Num.290 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
+    let Num.290 : U64 = lowlevel NumDivCeilUnchecked #Attr.2 #Attr.3;
     ret Num.290;
 
-procedure Num.75 (#Attr.2, #Attr.3):
-    let Num.294 : U64 = lowlevel NumSubWrap #Attr.2 #Attr.3;
+procedure Num.19 (#Attr.2, #Attr.3):
+    let Num.289 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.289;
+
+procedure Num.20 (#Attr.2, #Attr.3):
+    let Num.286 : U64 = lowlevel NumSub #Attr.2 #Attr.3;
+    ret Num.286;
+
+procedure Num.21 (#Attr.2, #Attr.3):
+    let Num.291 : U64 = lowlevel NumMul #Attr.2 #Attr.3;
+    ret Num.291;
+
+procedure Num.22 (#Attr.2, #Attr.3):
+    let Num.297 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.297;
+
+procedure Num.24 (#Attr.2, #Attr.3):
+    let Num.299 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
+    ret Num.299;
+
+procedure Num.51 (#Attr.2, #Attr.3):
+    let Num.294 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
     ret Num.294;
+
+procedure Num.75 (#Attr.2, #Attr.3):
+    let Num.298 : U64 = lowlevel NumSubWrap #Attr.2 #Attr.3;
+    ret Num.298;
 
 procedure Str.12 (#Attr.2):
     let Str.241 : List U8 = lowlevel StrToUtf8 #Attr.2;

--- a/crates/compiler/test_mono/generated/encode_derived_string.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_string.txt
@@ -122,32 +122,32 @@ procedure List.91 (#Derived_gen.8, #Derived_gen.9, #Derived_gen.10, #Derived_gen
     jump List.587 #Derived_gen.8 #Derived_gen.9 #Derived_gen.10 #Derived_gen.11 #Derived_gen.12;
 
 procedure Num.137 (#Attr.2, #Attr.3):
-    let Num.277 : U64 = lowlevel NumDivCeilUnchecked #Attr.2 #Attr.3;
-    ret Num.277;
+    let Num.281 : U64 = lowlevel NumDivCeilUnchecked #Attr.2 #Attr.3;
+    ret Num.281;
 
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.276 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.276;
-
-procedure Num.21 (#Attr.2, #Attr.3):
-    let Num.278 : U64 = lowlevel NumMul #Attr.2 #Attr.3;
-    ret Num.278;
-
-procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.282 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.282;
-
-procedure Num.24 (#Attr.2, #Attr.3):
-    let Num.284 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
-    ret Num.284;
-
-procedure Num.51 (#Attr.2, #Attr.3):
-    let Num.280 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
+    let Num.280 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
     ret Num.280;
 
+procedure Num.21 (#Attr.2, #Attr.3):
+    let Num.282 : U64 = lowlevel NumMul #Attr.2 #Attr.3;
+    ret Num.282;
+
+procedure Num.22 (#Attr.2, #Attr.3):
+    let Num.286 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.286;
+
+procedure Num.24 (#Attr.2, #Attr.3):
+    let Num.288 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
+    ret Num.288;
+
+procedure Num.51 (#Attr.2, #Attr.3):
+    let Num.284 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
+    ret Num.284;
+
 procedure Num.75 (#Attr.2, #Attr.3):
-    let Num.283 : U64 = lowlevel NumSubWrap #Attr.2 #Attr.3;
-    ret Num.283;
+    let Num.287 : U64 = lowlevel NumSubWrap #Attr.2 #Attr.3;
+    ret Num.287;
 
 procedure Str.12 (#Attr.2):
     let Str.240 : List U8 = lowlevel StrToUtf8 #Attr.2;

--- a/crates/compiler/test_mono/generated/encode_derived_tag_one_field_string.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_tag_one_field_string.txt
@@ -195,40 +195,40 @@ procedure List.91 (#Derived_gen.23, #Derived_gen.24, #Derived_gen.25, #Derived_g
     jump List.613 #Derived_gen.23 #Derived_gen.24 #Derived_gen.25 #Derived_gen.26 #Derived_gen.27;
 
 procedure Num.127 (#Attr.2):
-    let Num.282 : U8 = lowlevel NumIntCast #Attr.2;
-    ret Num.282;
-
-procedure Num.137 (#Attr.2, #Attr.3):
-    let Num.287 : U64 = lowlevel NumDivCeilUnchecked #Attr.2 #Attr.3;
-    ret Num.287;
-
-procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.286 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    let Num.286 : U8 = lowlevel NumIntCast #Attr.2;
     ret Num.286;
 
-procedure Num.20 (#Attr.2, #Attr.3):
-    let Num.283 : U64 = lowlevel NumSub #Attr.2 #Attr.3;
-    ret Num.283;
-
-procedure Num.21 (#Attr.2, #Attr.3):
-    let Num.288 : U64 = lowlevel NumMul #Attr.2 #Attr.3;
-    ret Num.288;
-
-procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.294 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.294;
-
-procedure Num.24 (#Attr.2, #Attr.3):
-    let Num.296 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
-    ret Num.296;
-
-procedure Num.51 (#Attr.2, #Attr.3):
-    let Num.291 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
+procedure Num.137 (#Attr.2, #Attr.3):
+    let Num.291 : U64 = lowlevel NumDivCeilUnchecked #Attr.2 #Attr.3;
     ret Num.291;
 
-procedure Num.75 (#Attr.2, #Attr.3):
-    let Num.295 : U64 = lowlevel NumSubWrap #Attr.2 #Attr.3;
+procedure Num.19 (#Attr.2, #Attr.3):
+    let Num.290 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.290;
+
+procedure Num.20 (#Attr.2, #Attr.3):
+    let Num.287 : U64 = lowlevel NumSub #Attr.2 #Attr.3;
+    ret Num.287;
+
+procedure Num.21 (#Attr.2, #Attr.3):
+    let Num.292 : U64 = lowlevel NumMul #Attr.2 #Attr.3;
+    ret Num.292;
+
+procedure Num.22 (#Attr.2, #Attr.3):
+    let Num.298 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.298;
+
+procedure Num.24 (#Attr.2, #Attr.3):
+    let Num.300 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
+    ret Num.300;
+
+procedure Num.51 (#Attr.2, #Attr.3):
+    let Num.295 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
     ret Num.295;
+
+procedure Num.75 (#Attr.2, #Attr.3):
+    let Num.299 : U64 = lowlevel NumSubWrap #Attr.2 #Attr.3;
+    ret Num.299;
 
 procedure Str.12 (#Attr.2):
     let Str.241 : List U8 = lowlevel StrToUtf8 #Attr.2;

--- a/crates/compiler/test_mono/generated/encode_derived_tag_two_payloads_string.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_tag_two_payloads_string.txt
@@ -198,40 +198,40 @@ procedure List.91 (#Derived_gen.19, #Derived_gen.20, #Derived_gen.21, #Derived_g
     jump List.613 #Derived_gen.19 #Derived_gen.20 #Derived_gen.21 #Derived_gen.22 #Derived_gen.23;
 
 procedure Num.127 (#Attr.2):
-    let Num.282 : U8 = lowlevel NumIntCast #Attr.2;
-    ret Num.282;
-
-procedure Num.137 (#Attr.2, #Attr.3):
-    let Num.287 : U64 = lowlevel NumDivCeilUnchecked #Attr.2 #Attr.3;
-    ret Num.287;
-
-procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.286 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    let Num.286 : U8 = lowlevel NumIntCast #Attr.2;
     ret Num.286;
 
-procedure Num.20 (#Attr.2, #Attr.3):
-    let Num.283 : U64 = lowlevel NumSub #Attr.2 #Attr.3;
-    ret Num.283;
-
-procedure Num.21 (#Attr.2, #Attr.3):
-    let Num.288 : U64 = lowlevel NumMul #Attr.2 #Attr.3;
-    ret Num.288;
-
-procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.294 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.294;
-
-procedure Num.24 (#Attr.2, #Attr.3):
-    let Num.296 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
-    ret Num.296;
-
-procedure Num.51 (#Attr.2, #Attr.3):
-    let Num.291 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
+procedure Num.137 (#Attr.2, #Attr.3):
+    let Num.291 : U64 = lowlevel NumDivCeilUnchecked #Attr.2 #Attr.3;
     ret Num.291;
 
-procedure Num.75 (#Attr.2, #Attr.3):
-    let Num.295 : U64 = lowlevel NumSubWrap #Attr.2 #Attr.3;
+procedure Num.19 (#Attr.2, #Attr.3):
+    let Num.290 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.290;
+
+procedure Num.20 (#Attr.2, #Attr.3):
+    let Num.287 : U64 = lowlevel NumSub #Attr.2 #Attr.3;
+    ret Num.287;
+
+procedure Num.21 (#Attr.2, #Attr.3):
+    let Num.292 : U64 = lowlevel NumMul #Attr.2 #Attr.3;
+    ret Num.292;
+
+procedure Num.22 (#Attr.2, #Attr.3):
+    let Num.298 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.298;
+
+procedure Num.24 (#Attr.2, #Attr.3):
+    let Num.300 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
+    ret Num.300;
+
+procedure Num.51 (#Attr.2, #Attr.3):
+    let Num.295 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
     ret Num.295;
+
+procedure Num.75 (#Attr.2, #Attr.3):
+    let Num.299 : U64 = lowlevel NumSubWrap #Attr.2 #Attr.3;
+    ret Num.299;
 
 procedure Str.12 (#Attr.2):
     let Str.241 : List U8 = lowlevel StrToUtf8 #Attr.2;

--- a/crates/compiler/test_mono/generated/factorial.txt
+++ b/crates/compiler/test_mono/generated/factorial.txt
@@ -1,10 +1,10 @@
 procedure Num.20 (#Attr.2, #Attr.3):
-    let Num.276 : I64 = lowlevel NumSub #Attr.2 #Attr.3;
-    ret Num.276;
+    let Num.280 : I64 = lowlevel NumSub #Attr.2 #Attr.3;
+    ret Num.280;
 
 procedure Num.21 (#Attr.2, #Attr.3):
-    let Num.275 : I64 = lowlevel NumMul #Attr.2 #Attr.3;
-    ret Num.275;
+    let Num.279 : I64 = lowlevel NumMul #Attr.2 #Attr.3;
+    ret Num.279;
 
 procedure Test.1 (#Derived_gen.0, #Derived_gen.1):
     joinpoint Test.7 Test.2 Test.3:

--- a/crates/compiler/test_mono/generated/function_specialization_information_in_lambda_set_thunk.txt
+++ b/crates/compiler/test_mono/generated/function_specialization_information_in_lambda_set_thunk.txt
@@ -1,6 +1,6 @@
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.275 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.275;
+    let Num.279 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.279;
 
 procedure Test.1 (Test.8):
     let Test.3 : I64 = 10i64;

--- a/crates/compiler/test_mono/generated/function_specialization_information_in_lambda_set_thunk_independent_defs.txt
+++ b/crates/compiler/test_mono/generated/function_specialization_information_in_lambda_set_thunk_independent_defs.txt
@@ -1,6 +1,6 @@
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.276 : U8 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.276;
+    let Num.280 : U8 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.280;
 
 procedure Test.1 (Test.9):
     let Test.4 : U8 = 10i64;

--- a/crates/compiler/test_mono/generated/inline_return_joinpoints_in_bool_lambda_set.txt
+++ b/crates/compiler/test_mono/generated/inline_return_joinpoints_in_bool_lambda_set.txt
@@ -3,8 +3,8 @@ procedure Bool.1 ():
     ret Bool.23;
 
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.275 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.275;
+    let Num.279 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.279;
 
 procedure Test.3 (Test.4):
     ret Test.4;

--- a/crates/compiler/test_mono/generated/inline_return_joinpoints_in_enum_lambda_set.txt
+++ b/crates/compiler/test_mono/generated/inline_return_joinpoints_in_enum_lambda_set.txt
@@ -1,6 +1,6 @@
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.277 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.277;
+    let Num.281 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.281;
 
 procedure Test.2 (Test.3):
     switch Test.3:

--- a/crates/compiler/test_mono/generated/inline_return_joinpoints_in_union_lambda_set.txt
+++ b/crates/compiler/test_mono/generated/inline_return_joinpoints_in_union_lambda_set.txt
@@ -1,6 +1,6 @@
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.276 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.276;
+    let Num.280 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.280;
 
 procedure Test.2 (Test.3, Test.1):
     let Test.18 : Int1 = false;

--- a/crates/compiler/test_mono/generated/inspect_derived_dict.txt
+++ b/crates/compiler/test_mono/generated/inspect_derived_dict.txt
@@ -1044,131 +1044,131 @@ procedure List.92 (#Derived_gen.38, #Derived_gen.39, #Derived_gen.40, #Derived_g
     jump List.614 #Derived_gen.38 #Derived_gen.39 #Derived_gen.40 #Derived_gen.41 #Derived_gen.42;
 
 procedure Num.131 (#Attr.2):
-    let Num.283 : U32 = lowlevel NumIntCast #Attr.2;
-    ret Num.283;
+    let Num.287 : U32 = lowlevel NumIntCast #Attr.2;
+    ret Num.287;
 
 procedure Num.133 (#Attr.2):
-    let Num.291 : U64 = lowlevel NumIntCast #Attr.2;
-    ret Num.291;
+    let Num.295 : U64 = lowlevel NumIntCast #Attr.2;
+    ret Num.295;
 
 procedure Num.133 (#Attr.2):
-    let Num.340 : U64 = lowlevel NumIntCast #Attr.2;
-    ret Num.340;
+    let Num.344 : U64 = lowlevel NumIntCast #Attr.2;
+    ret Num.344;
 
 procedure Num.133 (#Attr.2):
-    let Num.355 : U64 = lowlevel NumIntCast #Attr.2;
-    ret Num.355;
-
-procedure Num.135 (#Attr.2):
-    let Num.361 : U128 = lowlevel NumIntCast #Attr.2;
-    ret Num.361;
-
-procedure Num.139 (#Attr.2):
-    let Num.309 : Float32 = lowlevel NumToFloatCast #Attr.2;
-    ret Num.309;
-
-procedure Num.148 (Num.219, Num.220):
-    let Num.311 : Int1 = CallByName Num.22 Num.219 Num.220;
-    if Num.311 then
-        ret Num.219;
-    else
-        ret Num.220;
-
-procedure Num.21 (#Attr.2, #Attr.3):
-    let Num.308 : Float32 = lowlevel NumMul #Attr.2 #Attr.3;
-    ret Num.308;
-
-procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.305 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.305;
-
-procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.434 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.434;
-
-procedure Num.23 (#Attr.2, #Attr.3):
-    let Num.427 : Int1 = lowlevel NumLte #Attr.2 #Attr.3;
-    ret Num.427;
-
-procedure Num.24 (#Attr.2, #Attr.3):
-    let Num.289 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
-    ret Num.289;
-
-procedure Num.24 (#Attr.2, #Attr.3):
-    let Num.430 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
-    ret Num.430;
-
-procedure Num.25 (#Attr.2, #Attr.3):
-    let Num.431 : Int1 = lowlevel NumGte #Attr.2 #Attr.3;
-    ret Num.431;
-
-procedure Num.50 (#Attr.2):
-    let Num.307 : U64 = lowlevel NumFloor #Attr.2;
-    ret Num.307;
-
-procedure Num.51 (#Attr.2, #Attr.3):
-    let Num.275 : U32 = lowlevel NumAddWrap #Attr.2 #Attr.3;
-    ret Num.275;
-
-procedure Num.51 (#Attr.2, #Attr.3):
-    let Num.433 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
-    ret Num.433;
-
-procedure Num.69 (#Attr.2, #Attr.3):
-    let Num.297 : U32 = lowlevel NumBitwiseAnd #Attr.2 #Attr.3;
-    ret Num.297;
-
-procedure Num.70 (#Attr.2, #Attr.3):
-    let Num.338 : U64 = lowlevel NumBitwiseXor #Attr.2 #Attr.3;
-    ret Num.338;
-
-procedure Num.71 (#Attr.2, #Attr.3):
-    let Num.296 : U32 = lowlevel NumBitwiseOr #Attr.2 #Attr.3;
-    ret Num.296;
-
-procedure Num.71 (#Attr.2, #Attr.3):
-    let Num.375 : U64 = lowlevel NumBitwiseOr #Attr.2 #Attr.3;
-    ret Num.375;
-
-procedure Num.72 (#Attr.2, #Attr.3):
-    let Num.278 : U32 = lowlevel NumShiftLeftBy #Attr.2 #Attr.3;
-    ret Num.278;
-
-procedure Num.72 (#Attr.2, #Attr.3):
-    let Num.390 : U64 = lowlevel NumShiftLeftBy #Attr.2 #Attr.3;
-    ret Num.390;
-
-procedure Num.74 (#Attr.2, #Attr.3):
-    let Num.356 : U128 = lowlevel NumShiftRightZfBy #Attr.2 #Attr.3;
-    ret Num.356;
-
-procedure Num.74 (#Attr.2, #Attr.3):
-    let Num.358 : U64 = lowlevel NumShiftRightZfBy #Attr.2 #Attr.3;
-    ret Num.358;
-
-procedure Num.75 (#Attr.2, #Attr.3):
-    let Num.285 : U32 = lowlevel NumSubWrap #Attr.2 #Attr.3;
-    ret Num.285;
-
-procedure Num.75 (#Attr.2, #Attr.3):
-    let Num.288 : U8 = lowlevel NumSubWrap #Attr.2 #Attr.3;
-    ret Num.288;
-
-procedure Num.75 (#Attr.2, #Attr.3):
-    let Num.424 : U64 = lowlevel NumSubWrap #Attr.2 #Attr.3;
-    ret Num.424;
-
-procedure Num.78 (#Attr.2, #Attr.3):
-    let Num.359 : U128 = lowlevel NumMulWrap #Attr.2 #Attr.3;
+    let Num.359 : U64 = lowlevel NumIntCast #Attr.2;
     ret Num.359;
 
-procedure Num.96 (#Attr.2):
-    let Num.304 : Str = lowlevel NumToStr #Attr.2;
-    ret Num.304;
+procedure Num.135 (#Attr.2):
+    let Num.365 : U128 = lowlevel NumIntCast #Attr.2;
+    ret Num.365;
+
+procedure Num.139 (#Attr.2):
+    let Num.313 : Float32 = lowlevel NumToFloatCast #Attr.2;
+    ret Num.313;
+
+procedure Num.148 (Num.223, Num.224):
+    let Num.315 : Int1 = CallByName Num.22 Num.223 Num.224;
+    if Num.315 then
+        ret Num.223;
+    else
+        ret Num.224;
+
+procedure Num.21 (#Attr.2, #Attr.3):
+    let Num.312 : Float32 = lowlevel NumMul #Attr.2 #Attr.3;
+    ret Num.312;
+
+procedure Num.22 (#Attr.2, #Attr.3):
+    let Num.309 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.309;
+
+procedure Num.22 (#Attr.2, #Attr.3):
+    let Num.438 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.438;
+
+procedure Num.23 (#Attr.2, #Attr.3):
+    let Num.431 : Int1 = lowlevel NumLte #Attr.2 #Attr.3;
+    ret Num.431;
+
+procedure Num.24 (#Attr.2, #Attr.3):
+    let Num.293 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
+    ret Num.293;
+
+procedure Num.24 (#Attr.2, #Attr.3):
+    let Num.434 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
+    ret Num.434;
+
+procedure Num.25 (#Attr.2, #Attr.3):
+    let Num.435 : Int1 = lowlevel NumGte #Attr.2 #Attr.3;
+    ret Num.435;
+
+procedure Num.50 (#Attr.2):
+    let Num.311 : U64 = lowlevel NumFloor #Attr.2;
+    ret Num.311;
+
+procedure Num.51 (#Attr.2, #Attr.3):
+    let Num.279 : U32 = lowlevel NumAddWrap #Attr.2 #Attr.3;
+    ret Num.279;
+
+procedure Num.51 (#Attr.2, #Attr.3):
+    let Num.437 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
+    ret Num.437;
+
+procedure Num.69 (#Attr.2, #Attr.3):
+    let Num.301 : U32 = lowlevel NumBitwiseAnd #Attr.2 #Attr.3;
+    ret Num.301;
+
+procedure Num.70 (#Attr.2, #Attr.3):
+    let Num.342 : U64 = lowlevel NumBitwiseXor #Attr.2 #Attr.3;
+    ret Num.342;
+
+procedure Num.71 (#Attr.2, #Attr.3):
+    let Num.300 : U32 = lowlevel NumBitwiseOr #Attr.2 #Attr.3;
+    ret Num.300;
+
+procedure Num.71 (#Attr.2, #Attr.3):
+    let Num.379 : U64 = lowlevel NumBitwiseOr #Attr.2 #Attr.3;
+    ret Num.379;
+
+procedure Num.72 (#Attr.2, #Attr.3):
+    let Num.282 : U32 = lowlevel NumShiftLeftBy #Attr.2 #Attr.3;
+    ret Num.282;
+
+procedure Num.72 (#Attr.2, #Attr.3):
+    let Num.394 : U64 = lowlevel NumShiftLeftBy #Attr.2 #Attr.3;
+    ret Num.394;
+
+procedure Num.74 (#Attr.2, #Attr.3):
+    let Num.360 : U128 = lowlevel NumShiftRightZfBy #Attr.2 #Attr.3;
+    ret Num.360;
+
+procedure Num.74 (#Attr.2, #Attr.3):
+    let Num.362 : U64 = lowlevel NumShiftRightZfBy #Attr.2 #Attr.3;
+    ret Num.362;
+
+procedure Num.75 (#Attr.2, #Attr.3):
+    let Num.289 : U32 = lowlevel NumSubWrap #Attr.2 #Attr.3;
+    ret Num.289;
+
+procedure Num.75 (#Attr.2, #Attr.3):
+    let Num.292 : U8 = lowlevel NumSubWrap #Attr.2 #Attr.3;
+    ret Num.292;
+
+procedure Num.75 (#Attr.2, #Attr.3):
+    let Num.428 : U64 = lowlevel NumSubWrap #Attr.2 #Attr.3;
+    ret Num.428;
+
+procedure Num.78 (#Attr.2, #Attr.3):
+    let Num.363 : U128 = lowlevel NumMulWrap #Attr.2 #Attr.3;
+    ret Num.363;
 
 procedure Num.96 (#Attr.2):
-    let Num.432 : Str = lowlevel NumToStr #Attr.2;
-    ret Num.432;
+    let Num.308 : Str = lowlevel NumToStr #Attr.2;
+    ret Num.308;
+
+procedure Num.96 (#Attr.2):
+    let Num.436 : Str = lowlevel NumToStr #Attr.2;
+    ret Num.436;
 
 procedure Str.12 (#Attr.2):
     let Str.234 : List U8 = lowlevel StrToUtf8 #Attr.2;

--- a/crates/compiler/test_mono/generated/inspect_derived_list.txt
+++ b/crates/compiler/test_mono/generated/inspect_derived_list.txt
@@ -155,16 +155,16 @@ procedure List.91 (#Derived_gen.17, #Derived_gen.18, #Derived_gen.19, #Derived_g
     jump List.575 #Derived_gen.17 #Derived_gen.18 #Derived_gen.19 #Derived_gen.20 #Derived_gen.21;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.277 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.277;
+    let Num.281 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.281;
 
 procedure Num.51 (#Attr.2, #Attr.3):
-    let Num.276 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
-    ret Num.276;
+    let Num.280 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
+    ret Num.280;
 
 procedure Num.96 (#Attr.2):
-    let Num.275 : Str = lowlevel NumToStr #Attr.2;
-    ret Num.275;
+    let Num.279 : Str = lowlevel NumToStr #Attr.2;
+    ret Num.279;
 
 procedure Str.3 (#Attr.2, #Attr.3):
     let Str.232 : Str = lowlevel StrConcat #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/inspect_derived_nested_record_string.txt
+++ b/crates/compiler/test_mono/generated/inspect_derived_nested_record_string.txt
@@ -261,12 +261,12 @@ procedure List.91 (#Derived_gen.39, #Derived_gen.40, #Derived_gen.41, #Derived_g
     jump List.587 #Derived_gen.39 #Derived_gen.40 #Derived_gen.41 #Derived_gen.42 #Derived_gen.43;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.278 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.278;
+    let Num.282 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.282;
 
 procedure Num.51 (#Attr.2, #Attr.3):
-    let Num.277 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
-    ret Num.277;
+    let Num.281 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
+    ret Num.281;
 
 procedure Str.3 (#Attr.2, #Attr.3):
     let Str.233 : Str = lowlevel StrConcat #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/inspect_derived_record.txt
+++ b/crates/compiler/test_mono/generated/inspect_derived_record.txt
@@ -181,20 +181,20 @@ procedure List.91 (#Derived_gen.24, #Derived_gen.25, #Derived_gen.26, #Derived_g
     jump List.575 #Derived_gen.24 #Derived_gen.25 #Derived_gen.26 #Derived_gen.27 #Derived_gen.28;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.278 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.278;
+    let Num.282 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.282;
 
 procedure Num.51 (#Attr.2, #Attr.3):
-    let Num.277 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
-    ret Num.277;
+    let Num.281 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
+    ret Num.281;
 
 procedure Num.96 (#Attr.2):
-    let Num.275 : Str = lowlevel NumToStr #Attr.2;
-    ret Num.275;
+    let Num.279 : Str = lowlevel NumToStr #Attr.2;
+    ret Num.279;
 
 procedure Num.96 (#Attr.2):
-    let Num.276 : Str = lowlevel NumToStr #Attr.2;
-    ret Num.276;
+    let Num.280 : Str = lowlevel NumToStr #Attr.2;
+    ret Num.280;
 
 procedure Str.3 (#Attr.2, #Attr.3):
     let Str.232 : Str = lowlevel StrConcat #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/inspect_derived_record_one_field_string.txt
+++ b/crates/compiler/test_mono/generated/inspect_derived_record_one_field_string.txt
@@ -158,12 +158,12 @@ procedure List.91 (#Derived_gen.18, #Derived_gen.19, #Derived_gen.20, #Derived_g
     jump List.575 #Derived_gen.18 #Derived_gen.19 #Derived_gen.20 #Derived_gen.21 #Derived_gen.22;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.276 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.276;
+    let Num.280 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.280;
 
 procedure Num.51 (#Attr.2, #Attr.3):
-    let Num.275 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
-    ret Num.275;
+    let Num.279 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
+    ret Num.279;
 
 procedure Str.3 (#Attr.2, #Attr.3):
     let Str.232 : Str = lowlevel StrConcat #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/inspect_derived_record_two_field_strings.txt
+++ b/crates/compiler/test_mono/generated/inspect_derived_record_two_field_strings.txt
@@ -165,12 +165,12 @@ procedure List.91 (#Derived_gen.22, #Derived_gen.23, #Derived_gen.24, #Derived_g
     jump List.575 #Derived_gen.22 #Derived_gen.23 #Derived_gen.24 #Derived_gen.25 #Derived_gen.26;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.276 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.276;
+    let Num.280 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.280;
 
 procedure Num.51 (#Attr.2, #Attr.3):
-    let Num.275 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
-    ret Num.275;
+    let Num.279 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
+    ret Num.279;
 
 procedure Str.3 (#Attr.2, #Attr.3):
     let Str.232 : Str = lowlevel StrConcat #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/inspect_derived_tag_one_field_string.txt
+++ b/crates/compiler/test_mono/generated/inspect_derived_tag_one_field_string.txt
@@ -160,12 +160,12 @@ procedure List.91 (#Derived_gen.10, #Derived_gen.11, #Derived_gen.12, #Derived_g
     jump List.575 #Derived_gen.10 #Derived_gen.11 #Derived_gen.12 #Derived_gen.13 #Derived_gen.14;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.276 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.276;
+    let Num.280 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.280;
 
 procedure Num.51 (#Attr.2, #Attr.3):
-    let Num.275 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
-    ret Num.275;
+    let Num.279 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
+    ret Num.279;
 
 procedure Str.3 (#Attr.2, #Attr.3):
     let Str.232 : Str = lowlevel StrConcat #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/inspect_derived_tag_two_payloads_string.txt
+++ b/crates/compiler/test_mono/generated/inspect_derived_tag_two_payloads_string.txt
@@ -163,12 +163,12 @@ procedure List.91 (#Derived_gen.13, #Derived_gen.14, #Derived_gen.15, #Derived_g
     jump List.575 #Derived_gen.13 #Derived_gen.14 #Derived_gen.15 #Derived_gen.16 #Derived_gen.17;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.276 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.276;
+    let Num.280 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.280;
 
 procedure Num.51 (#Attr.2, #Attr.3):
-    let Num.275 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
-    ret Num.275;
+    let Num.279 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
+    ret Num.279;
 
 procedure Str.3 (#Attr.2, #Attr.3):
     let Str.232 : Str = lowlevel StrConcat #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/ir_int_add.txt
+++ b/crates/compiler/test_mono/generated/ir_int_add.txt
@@ -3,8 +3,8 @@ procedure List.6 (#Attr.2):
     ret List.572;
 
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.277 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.277;
+    let Num.281 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.281;
 
 procedure Test.0 ():
     let Test.1 : List I64 = Array [1i64, 2i64];

--- a/crates/compiler/test_mono/generated/ir_plus.txt
+++ b/crates/compiler/test_mono/generated/ir_plus.txt
@@ -1,6 +1,6 @@
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.275 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.275;
+    let Num.279 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.279;
 
 procedure Test.0 ():
     let Test.2 : I64 = 1i64;

--- a/crates/compiler/test_mono/generated/ir_round.txt
+++ b/crates/compiler/test_mono/generated/ir_round.txt
@@ -1,6 +1,6 @@
 procedure Num.45 (#Attr.2):
-    let Num.275 : I64 = lowlevel NumRound #Attr.2;
-    ret Num.275;
+    let Num.279 : I64 = lowlevel NumRound #Attr.2;
+    ret Num.279;
 
 procedure Test.0 ():
     let Test.2 : Decimal = 3.6dec;

--- a/crates/compiler/test_mono/generated/ir_two_defs.txt
+++ b/crates/compiler/test_mono/generated/ir_two_defs.txt
@@ -1,6 +1,6 @@
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.275 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.275;
+    let Num.279 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.279;
 
 procedure Test.0 ():
     let Test.1 : I64 = 3i64;

--- a/crates/compiler/test_mono/generated/ir_when_idiv.txt
+++ b/crates/compiler/test_mono/generated/ir_when_idiv.txt
@@ -1,22 +1,22 @@
 procedure Num.157 (#Attr.2, #Attr.3):
-    let Num.277 : I64 = lowlevel NumDivTruncUnchecked #Attr.2 #Attr.3;
-    ret Num.277;
-
-procedure Num.30 (#Attr.2):
-    let Num.282 : I64 = 0i64;
-    let Num.281 : Int1 = lowlevel Eq #Attr.2 Num.282;
+    let Num.281 : I64 = lowlevel NumDivTruncUnchecked #Attr.2 #Attr.3;
     ret Num.281;
 
-procedure Num.40 (Num.243, Num.244):
-    let Num.278 : Int1 = CallByName Num.30 Num.244;
-    if Num.278 then
-        let Num.280 : {} = Struct {};
-        let Num.279 : [C {}, C I64] = TagId(0) Num.280;
-        ret Num.279;
+procedure Num.30 (#Attr.2):
+    let Num.286 : I64 = 0i64;
+    let Num.285 : Int1 = lowlevel Eq #Attr.2 Num.286;
+    ret Num.285;
+
+procedure Num.40 (Num.247, Num.248):
+    let Num.282 : Int1 = CallByName Num.30 Num.248;
+    if Num.282 then
+        let Num.284 : {} = Struct {};
+        let Num.283 : [C {}, C I64] = TagId(0) Num.284;
+        ret Num.283;
     else
-        let Num.276 : I64 = CallByName Num.157 Num.243 Num.244;
-        let Num.275 : [C {}, C I64] = TagId(1) Num.276;
-        ret Num.275;
+        let Num.280 : I64 = CallByName Num.157 Num.247 Num.248;
+        let Num.279 : [C {}, C I64] = TagId(1) Num.280;
+        ret Num.279;
 
 procedure Test.0 ():
     let Test.8 : I64 = 1000i64;

--- a/crates/compiler/test_mono/generated/ir_when_just.txt
+++ b/crates/compiler/test_mono/generated/ir_when_just.txt
@@ -1,6 +1,6 @@
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.275 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.275;
+    let Num.279 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.279;
 
 procedure Test.0 ():
     let Test.10 : I64 = 41i64;

--- a/crates/compiler/test_mono/generated/issue_2583_specialize_errors_behind_unified_branches.txt
+++ b/crates/compiler/test_mono/generated/issue_2583_specialize_errors_behind_unified_branches.txt
@@ -44,8 +44,8 @@ procedure List.9 (List.334):
         ret List.574;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.275 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.275;
+    let Num.279 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.279;
 
 procedure Str.27 (Str.78):
     let Str.232 : [C Int1, C I64] = CallByName Str.60 Str.78;

--- a/crates/compiler/test_mono/generated/issue_4749.txt
+++ b/crates/compiler/test_mono/generated/issue_4749.txt
@@ -179,44 +179,44 @@ procedure List.80 (#Derived_gen.1, #Derived_gen.2, #Derived_gen.3, #Derived_gen.
     jump List.637 #Derived_gen.1 #Derived_gen.2 #Derived_gen.3 #Derived_gen.4 #Derived_gen.5;
 
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.278 : U8 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.278;
+    let Num.282 : U8 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.282;
 
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.287 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.287;
+    let Num.291 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.291;
 
 procedure Num.20 (#Attr.2, #Attr.3):
-    let Num.290 : U8 = lowlevel NumSub #Attr.2 #Attr.3;
-    ret Num.290;
+    let Num.294 : U8 = lowlevel NumSub #Attr.2 #Attr.3;
+    ret Num.294;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.312 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.312;
+    let Num.316 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.316;
 
 procedure Num.23 (#Attr.2, #Attr.3):
-    let Num.296 : Int1 = lowlevel NumLte #Attr.2 #Attr.3;
-    ret Num.296;
+    let Num.300 : Int1 = lowlevel NumLte #Attr.2 #Attr.3;
+    ret Num.300;
 
 procedure Num.25 (#Attr.2, #Attr.3):
-    let Num.302 : Int1 = lowlevel NumGte #Attr.2 #Attr.3;
-    ret Num.302;
+    let Num.306 : Int1 = lowlevel NumGte #Attr.2 #Attr.3;
+    ret Num.306;
 
 procedure Num.51 (#Attr.2, #Attr.3):
-    let Num.313 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
-    ret Num.313;
+    let Num.317 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
+    ret Num.317;
 
 procedure Num.71 (#Attr.2, #Attr.3):
-    let Num.275 : U8 = lowlevel NumBitwiseOr #Attr.2 #Attr.3;
-    ret Num.275;
+    let Num.279 : U8 = lowlevel NumBitwiseOr #Attr.2 #Attr.3;
+    ret Num.279;
 
 procedure Num.72 (#Attr.2, #Attr.3):
-    let Num.276 : U8 = lowlevel NumShiftLeftBy #Attr.2 #Attr.3;
-    ret Num.276;
+    let Num.280 : U8 = lowlevel NumShiftLeftBy #Attr.2 #Attr.3;
+    ret Num.280;
 
 procedure Num.77 (#Attr.2, #Attr.3):
-    let Num.309 : U64 = lowlevel NumSubSaturated #Attr.2 #Attr.3;
-    ret Num.309;
+    let Num.313 : U64 = lowlevel NumSubSaturated #Attr.2 #Attr.3;
+    ret Num.313;
 
 procedure Str.43 (#Attr.2):
     let Str.239 : {U64, Str, Int1, U8} = lowlevel StrFromUtf8 #Attr.2;

--- a/crates/compiler/test_mono/generated/issue_4770.txt
+++ b/crates/compiler/test_mono/generated/issue_4770.txt
@@ -82,16 +82,16 @@ procedure List.80 (#Derived_gen.1, #Derived_gen.2, #Derived_gen.3, #Derived_gen.
     jump List.588 #Derived_gen.1 #Derived_gen.2 #Derived_gen.3 #Derived_gen.4 #Derived_gen.5;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.275 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.275;
+    let Num.279 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.279;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.278 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.278;
+    let Num.282 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.282;
 
 procedure Num.51 (#Attr.2, #Attr.3):
-    let Num.277 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
-    ret Num.277;
+    let Num.281 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
+    ret Num.281;
 
 procedure Test.1 (#Derived_gen.0):
     joinpoint Test.26 Test.6:

--- a/crates/compiler/test_mono/generated/issue_4772_weakened_monomorphic_destructure.txt
+++ b/crates/compiler/test_mono/generated/issue_4772_weakened_monomorphic_destructure.txt
@@ -153,44 +153,44 @@ procedure List.80 (#Derived_gen.0, #Derived_gen.1, #Derived_gen.2, #Derived_gen.
     jump List.633 #Derived_gen.0 #Derived_gen.1 #Derived_gen.2 #Derived_gen.3 #Derived_gen.4;
 
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.278 : U8 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.278;
+    let Num.282 : U8 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.282;
 
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.287 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.287;
+    let Num.291 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.291;
 
 procedure Num.20 (#Attr.2, #Attr.3):
-    let Num.290 : U8 = lowlevel NumSub #Attr.2 #Attr.3;
-    ret Num.290;
+    let Num.294 : U8 = lowlevel NumSub #Attr.2 #Attr.3;
+    ret Num.294;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.312 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.312;
+    let Num.316 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.316;
 
 procedure Num.23 (#Attr.2, #Attr.3):
-    let Num.296 : Int1 = lowlevel NumLte #Attr.2 #Attr.3;
-    ret Num.296;
+    let Num.300 : Int1 = lowlevel NumLte #Attr.2 #Attr.3;
+    ret Num.300;
 
 procedure Num.25 (#Attr.2, #Attr.3):
-    let Num.302 : Int1 = lowlevel NumGte #Attr.2 #Attr.3;
-    ret Num.302;
+    let Num.306 : Int1 = lowlevel NumGte #Attr.2 #Attr.3;
+    ret Num.306;
 
 procedure Num.51 (#Attr.2, #Attr.3):
-    let Num.313 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
-    ret Num.313;
+    let Num.317 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
+    ret Num.317;
 
 procedure Num.71 (#Attr.2, #Attr.3):
-    let Num.275 : U8 = lowlevel NumBitwiseOr #Attr.2 #Attr.3;
-    ret Num.275;
+    let Num.279 : U8 = lowlevel NumBitwiseOr #Attr.2 #Attr.3;
+    ret Num.279;
 
 procedure Num.72 (#Attr.2, #Attr.3):
-    let Num.276 : U8 = lowlevel NumShiftLeftBy #Attr.2 #Attr.3;
-    ret Num.276;
+    let Num.280 : U8 = lowlevel NumShiftLeftBy #Attr.2 #Attr.3;
+    ret Num.280;
 
 procedure Num.77 (#Attr.2, #Attr.3):
-    let Num.309 : U64 = lowlevel NumSubSaturated #Attr.2 #Attr.3;
-    ret Num.309;
+    let Num.313 : U64 = lowlevel NumSubSaturated #Attr.2 #Attr.3;
+    ret Num.313;
 
 procedure Str.12 (#Attr.2):
     let Str.241 : List U8 = lowlevel StrToUtf8 #Attr.2;

--- a/crates/compiler/test_mono/generated/issue_6196.txt
+++ b/crates/compiler/test_mono/generated/issue_6196.txt
@@ -1,6 +1,6 @@
 procedure Num.20 (#Attr.2, #Attr.3):
-    let Num.275 : U64 = lowlevel NumSub #Attr.2 #Attr.3;
-    ret Num.275;
+    let Num.279 : U64 = lowlevel NumSub #Attr.2 #Attr.3;
+    ret Num.279;
 
 procedure Test.1 (#Derived_gen.0, #Derived_gen.1):
     joinpoint Test.12 Test.2 Test.3:

--- a/crates/compiler/test_mono/generated/lambda_capture_niche_u8_vs_u64.txt
+++ b/crates/compiler/test_mono/generated/lambda_capture_niche_u8_vs_u64.txt
@@ -1,10 +1,10 @@
 procedure Num.96 (#Attr.2):
-    let Num.275 : Str = lowlevel NumToStr #Attr.2;
-    ret Num.275;
+    let Num.279 : Str = lowlevel NumToStr #Attr.2;
+    ret Num.279;
 
 procedure Num.96 (#Attr.2):
-    let Num.276 : Str = lowlevel NumToStr #Attr.2;
-    ret Num.276;
+    let Num.280 : Str = lowlevel NumToStr #Attr.2;
+    ret Num.280;
 
 procedure Test.1 (Test.4):
     let Test.13 : [C U8, C U64] = TagId(1) Test.4;

--- a/crates/compiler/test_mono/generated/lambda_set_with_imported_toplevels_issue_4733.txt
+++ b/crates/compiler/test_mono/generated/lambda_set_with_imported_toplevels_issue_4733.txt
@@ -7,12 +7,12 @@ procedure Bool.2 ():
     ret Bool.24;
 
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.275 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.275;
+    let Num.279 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.279;
 
 procedure Num.21 (#Attr.2, #Attr.3):
-    let Num.276 : U64 = lowlevel NumMul #Attr.2 #Attr.3;
-    ret Num.276;
+    let Num.280 : U64 = lowlevel NumMul #Attr.2 #Attr.3;
+    ret Num.280;
 
 procedure Test.0 (Test.8):
     let Test.20 : Int1 = CallByName Bool.2;

--- a/crates/compiler/test_mono/generated/layout_cache_structure_with_multiple_recursive_structures.txt
+++ b/crates/compiler/test_mono/generated/layout_cache_structure_with_multiple_recursive_structures.txt
@@ -29,12 +29,12 @@ procedure List.91 (#Derived_gen.0, #Derived_gen.1, #Derived_gen.2, #Derived_gen.
     jump List.575 #Derived_gen.0 #Derived_gen.1 #Derived_gen.2 #Derived_gen.3 #Derived_gen.4;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.276 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.276;
+    let Num.280 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.280;
 
 procedure Num.51 (#Attr.2, #Attr.3):
-    let Num.275 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
-    ret Num.275;
+    let Num.279 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
+    ret Num.279;
 
 procedure Test.7 (Test.11, Test.12):
     let Test.17 : {[<rnu>C *self, <null>], [<rnu><null>, C {[<rnu>C *self, <null>], *self}]} = Struct {Test.12, Test.11};

--- a/crates/compiler/test_mono/generated/linked_list_filter.txt
+++ b/crates/compiler/test_mono/generated/linked_list_filter.txt
@@ -1,11 +1,11 @@
-procedure Num.31 (Num.213):
-    let Num.276 : I64 = 2i64;
-    let Num.275 : Int1 = CallByName Num.86 Num.213 Num.276;
-    ret Num.275;
+procedure Num.31 (Num.217):
+    let Num.280 : I64 = 2i64;
+    let Num.279 : Int1 = CallByName Num.86 Num.217 Num.280;
+    ret Num.279;
 
 procedure Num.86 (#Attr.2, #Attr.3):
-    let Num.277 : Int1 = lowlevel NumIsMultipleOf #Attr.2 #Attr.3;
-    ret Num.277;
+    let Num.281 : Int1 = lowlevel NumIsMultipleOf #Attr.2 #Attr.3;
+    ret Num.281;
 
 procedure Test.2 (#Derived_gen.0, #Derived_gen.1):
     let #Derived_gen.3 : [<rnu><null>, C I64 *self] = NullPointer;

--- a/crates/compiler/test_mono/generated/linked_list_map.txt
+++ b/crates/compiler/test_mono/generated/linked_list_map.txt
@@ -1,6 +1,6 @@
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.275 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.275;
+    let Num.279 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.279;
 
 procedure Test.10 (Test.11):
     let Test.28 : I64 = 1i64;

--- a/crates/compiler/test_mono/generated/list_cannot_update_inplace.txt
+++ b/crates/compiler/test_mono/generated/list_cannot_update_inplace.txt
@@ -22,12 +22,12 @@ procedure List.67 (#Attr.2, #Attr.3, #Attr.4):
     ret List.579;
 
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.275 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.275;
+    let Num.279 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.279;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.276 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.276;
+    let Num.280 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.280;
 
 procedure Test.1 ():
     let Test.8 : List I64 = Array [1i64, 2i64, 3i64];

--- a/crates/compiler/test_mono/generated/list_get.txt
+++ b/crates/compiler/test_mono/generated/list_get.txt
@@ -21,8 +21,8 @@ procedure List.66 (#Attr.2, #Attr.3):
     ret List.577;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.275 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.275;
+    let Num.279 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.279;
 
 procedure Test.1 (Test.2):
     let Test.6 : List I64 = Array [1i64, 2i64, 3i64];

--- a/crates/compiler/test_mono/generated/list_len.txt
+++ b/crates/compiler/test_mono/generated/list_len.txt
@@ -7,8 +7,8 @@ procedure List.6 (#Attr.2):
     ret List.573;
 
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.275 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.275;
+    let Num.279 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.279;
 
 procedure Test.0 ():
     let Test.1 : List I64 = Array [1i64, 2i64, 3i64];

--- a/crates/compiler/test_mono/generated/list_map_closure_borrows.txt
+++ b/crates/compiler/test_mono/generated/list_map_closure_borrows.txt
@@ -27,8 +27,8 @@ procedure List.66 (#Attr.2, #Attr.3):
     ret List.577;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.275 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.275;
+    let Num.279 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.279;
 
 procedure Str.16 (#Attr.2, #Attr.3):
     let Str.232 : Str = lowlevel StrRepeat #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/list_map_closure_owns.txt
+++ b/crates/compiler/test_mono/generated/list_map_closure_owns.txt
@@ -27,8 +27,8 @@ procedure List.66 (#Attr.2, #Attr.3):
     ret List.577;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.275 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.275;
+    let Num.279 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.279;
 
 procedure Str.3 (#Attr.2, #Attr.3):
     let Str.233 : Str = lowlevel StrConcat #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/list_map_take_capturing_or_noncapturing.txt
+++ b/crates/compiler/test_mono/generated/list_map_take_capturing_or_noncapturing.txt
@@ -21,8 +21,8 @@ procedure List.5 (#Attr.2, #Attr.3):
     
 
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.277 : U8 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.277;
+    let Num.281 : U8 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.281;
 
 procedure Test.4 (Test.5, #Attr.12):
     let Test.16 : U8 = UnionAtIndex (Id 0) (Index 0) #Attr.12;

--- a/crates/compiler/test_mono/generated/list_pass_to_function.txt
+++ b/crates/compiler/test_mono/generated/list_pass_to_function.txt
@@ -22,8 +22,8 @@ procedure List.67 (#Attr.2, #Attr.3, #Attr.4):
     ret List.577;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.275 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.275;
+    let Num.279 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.279;
 
 procedure Test.2 (Test.3):
     let Test.6 : U64 = 0i64;

--- a/crates/compiler/test_mono/generated/list_sort_asc.txt
+++ b/crates/compiler/test_mono/generated/list_sort_asc.txt
@@ -8,8 +8,8 @@ procedure List.59 (List.329):
     ret List.572;
 
 procedure Num.46 (#Attr.2, #Attr.3):
-    let Num.275 : U8 = lowlevel NumCompare #Attr.2 #Attr.3;
-    ret Num.275;
+    let Num.279 : U8 = lowlevel NumCompare #Attr.2 #Attr.3;
+    ret Num.279;
 
 procedure Test.0 ():
     let Test.2 : List I64 = Array [4i64, 3i64, 2i64, 1i64];

--- a/crates/compiler/test_mono/generated/multiline_record_pattern.txt
+++ b/crates/compiler/test_mono/generated/multiline_record_pattern.txt
@@ -1,6 +1,6 @@
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.276 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.276;
+    let Num.280 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.280;
 
 procedure Test.0 ():
     let Test.7 : I64 = 1i64;

--- a/crates/compiler/test_mono/generated/nested_optional_field_with_binary_op.txt
+++ b/crates/compiler/test_mono/generated/nested_optional_field_with_binary_op.txt
@@ -1,6 +1,6 @@
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.275 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.275;
+    let Num.279 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.279;
 
 procedure Test.0 ():
     let Test.17 : {} = Struct {};

--- a/crates/compiler/test_mono/generated/nested_pattern_match.txt
+++ b/crates/compiler/test_mono/generated/nested_pattern_match.txt
@@ -1,6 +1,6 @@
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.275 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.275;
+    let Num.279 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.279;
 
 procedure Test.0 ():
     let Test.19 : I64 = 41i64;

--- a/crates/compiler/test_mono/generated/num_width_gt_u8_layout_as_float.txt
+++ b/crates/compiler/test_mono/generated/num_width_gt_u8_layout_as_float.txt
@@ -1,6 +1,6 @@
 procedure Num.37 (#Attr.2, #Attr.3):
-    let Num.275 : Decimal = lowlevel NumDivFrac #Attr.2 #Attr.3;
-    ret Num.275;
+    let Num.279 : Decimal = lowlevel NumDivFrac #Attr.2 #Attr.3;
+    ret Num.279;
 
 procedure Test.0 ():
     let Test.2 : Decimal = 1dec;

--- a/crates/compiler/test_mono/generated/optional_field_with_binary_op.txt
+++ b/crates/compiler/test_mono/generated/optional_field_with_binary_op.txt
@@ -1,6 +1,6 @@
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.275 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.275;
+    let Num.279 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.279;
 
 procedure Test.0 ():
     let Test.5 : {} = Struct {};

--- a/crates/compiler/test_mono/generated/optional_when.txt
+++ b/crates/compiler/test_mono/generated/optional_when.txt
@@ -1,6 +1,6 @@
 procedure Num.21 (#Attr.2, #Attr.3):
-    let Num.277 : I64 = lowlevel NumMul #Attr.2 #Attr.3;
-    ret Num.277;
+    let Num.281 : I64 = lowlevel NumMul #Attr.2 #Attr.3;
+    ret Num.281;
 
 procedure Test.1 (Test.6):
     let Test.21 : Int1 = false;

--- a/crates/compiler/test_mono/generated/quicksort_help.txt
+++ b/crates/compiler/test_mono/generated/quicksort_help.txt
@@ -1,14 +1,14 @@
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.275 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.275;
+    let Num.279 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.279;
 
 procedure Num.20 (#Attr.2, #Attr.3):
-    let Num.276 : I64 = lowlevel NumSub #Attr.2 #Attr.3;
-    ret Num.276;
+    let Num.280 : I64 = lowlevel NumSub #Attr.2 #Attr.3;
+    ret Num.280;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.277 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.277;
+    let Num.281 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.281;
 
 procedure Test.1 (#Derived_gen.0, #Derived_gen.1, #Derived_gen.2):
     joinpoint Test.12 Test.2 Test.3 Test.4:

--- a/crates/compiler/test_mono/generated/quicksort_swap.txt
+++ b/crates/compiler/test_mono/generated/quicksort_swap.txt
@@ -40,8 +40,8 @@ procedure List.67 (#Attr.2, #Attr.3, #Attr.4):
     ret List.577;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.277 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.277;
+    let Num.281 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.281;
 
 procedure Test.1 (Test.2):
     let Test.28 : U64 = 0i64;

--- a/crates/compiler/test_mono/generated/rb_tree_fbip.txt
+++ b/crates/compiler/test_mono/generated/rb_tree_fbip.txt
@@ -1,10 +1,10 @@
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.278 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.278;
+    let Num.282 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.282;
 
 procedure Num.24 (#Attr.2, #Attr.3):
-    let Num.276 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
-    ret Num.276;
+    let Num.280 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
+    ret Num.280;
 
 procedure Test.3 (#Derived_gen.0, #Derived_gen.1, #Derived_gen.2):
     let #Derived_gen.4 : [<rnu>C *self I64 *self I32 Int1, <null>] = NullPointer;

--- a/crates/compiler/test_mono/generated/record_optional_field_function_no_use_default.txt
+++ b/crates/compiler/test_mono/generated/record_optional_field_function_no_use_default.txt
@@ -1,6 +1,6 @@
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.275 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.275;
+    let Num.279 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.279;
 
 procedure Test.1 (Test.4):
     let Test.2 : I64 = StructAtIndex 0 Test.4;

--- a/crates/compiler/test_mono/generated/record_optional_field_function_use_default.txt
+++ b/crates/compiler/test_mono/generated/record_optional_field_function_use_default.txt
@@ -1,6 +1,6 @@
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.275 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.275;
+    let Num.279 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.279;
 
 procedure Test.1 (Test.4):
     let Test.2 : I64 = 10i64;

--- a/crates/compiler/test_mono/generated/record_optional_field_let_no_use_default.txt
+++ b/crates/compiler/test_mono/generated/record_optional_field_let_no_use_default.txt
@@ -1,6 +1,6 @@
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.275 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.275;
+    let Num.279 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.279;
 
 procedure Test.1 (Test.2):
     let Test.3 : I64 = StructAtIndex 0 Test.2;

--- a/crates/compiler/test_mono/generated/record_optional_field_let_use_default.txt
+++ b/crates/compiler/test_mono/generated/record_optional_field_let_use_default.txt
@@ -1,6 +1,6 @@
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.275 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.275;
+    let Num.279 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.279;
 
 procedure Test.1 (Test.2):
     let Test.3 : I64 = 10i64;

--- a/crates/compiler/test_mono/generated/record_update.txt
+++ b/crates/compiler/test_mono/generated/record_update.txt
@@ -22,8 +22,8 @@ procedure List.67 (#Attr.2, #Attr.3, #Attr.4):
     ret List.577;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.275 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.275;
+    let Num.279 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.279;
 
 procedure Test.1 (Test.2):
     let Test.6 : List U64 = StructAtIndex 0 Test.2;

--- a/crates/compiler/test_mono/generated/recursive_call_capturing_function.txt
+++ b/crates/compiler/test_mono/generated/recursive_call_capturing_function.txt
@@ -3,8 +3,8 @@ procedure Bool.2 ():
     ret Bool.23;
 
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.275 : U32 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.275;
+    let Num.279 : U32 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.279;
 
 procedure Test.1 (Test.2):
     let Test.8 : U32 = 0i64;

--- a/crates/compiler/test_mono/generated/recursive_lambda_set_resolved_only_upon_specialization.txt
+++ b/crates/compiler/test_mono/generated/recursive_lambda_set_resolved_only_upon_specialization.txt
@@ -3,12 +3,12 @@ procedure Bool.11 (#Attr.2, #Attr.3):
     ret Bool.23;
 
 procedure Num.20 (#Attr.2, #Attr.3):
-    let Num.276 : U8 = lowlevel NumSub #Attr.2 #Attr.3;
-    ret Num.276;
+    let Num.280 : U8 = lowlevel NumSub #Attr.2 #Attr.3;
+    ret Num.280;
 
 procedure Num.21 (#Attr.2, #Attr.3):
-    let Num.275 : U8 = lowlevel NumMul #Attr.2 #Attr.3;
-    ret Num.275;
+    let Num.279 : U8 = lowlevel NumMul #Attr.2 #Attr.3;
+    ret Num.279;
 
 procedure Test.1 (#Derived_gen.2, #Derived_gen.3):
     joinpoint Test.11 Test.2 Test.3:

--- a/crates/compiler/test_mono/generated/recursively_build_effect.txt
+++ b/crates/compiler/test_mono/generated/recursively_build_effect.txt
@@ -1,6 +1,6 @@
 procedure Num.20 (#Attr.2, #Attr.3):
-    let Num.275 : I64 = lowlevel NumSub #Attr.2 #Attr.3;
-    ret Num.275;
+    let Num.279 : I64 = lowlevel NumSub #Attr.2 #Attr.3;
+    ret Num.279;
 
 procedure Str.3 (#Attr.2, #Attr.3):
     let Str.234 : Str = lowlevel StrConcat #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/rigids.txt
+++ b/crates/compiler/test_mono/generated/rigids.txt
@@ -40,8 +40,8 @@ procedure List.67 (#Attr.2, #Attr.3, #Attr.4):
     ret List.577;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.277 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.277;
+    let Num.281 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.281;
 
 procedure Test.1 (Test.2, Test.3, Test.4):
     inc 2 Test.4;

--- a/crates/compiler/test_mono/generated/specialize_after_match.txt
+++ b/crates/compiler/test_mono/generated/specialize_after_match.txt
@@ -1,10 +1,10 @@
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.276 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.276;
+    let Num.280 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.280;
 
 procedure Num.24 (#Attr.2, #Attr.3):
-    let Num.277 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
-    ret Num.277;
+    let Num.281 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
+    ret Num.281;
 
 procedure Test.2 (Test.9, Test.10):
     let Test.38 : U8 = 1i64;

--- a/crates/compiler/test_mono/generated/specialize_closures.txt
+++ b/crates/compiler/test_mono/generated/specialize_closures.txt
@@ -3,12 +3,12 @@ procedure Bool.2 ():
     ret Bool.24;
 
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.276 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.276;
+    let Num.280 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.280;
 
 procedure Num.21 (#Attr.2, #Attr.3):
-    let Num.275 : I64 = lowlevel NumMul #Attr.2 #Attr.3;
-    ret Num.275;
+    let Num.279 : I64 = lowlevel NumMul #Attr.2 #Attr.3;
+    ret Num.279;
 
 procedure Test.1 (Test.2, Test.3):
     let Test.15 : U8 = GetTagId Test.2;

--- a/crates/compiler/test_mono/generated/specialize_lowlevel.txt
+++ b/crates/compiler/test_mono/generated/specialize_lowlevel.txt
@@ -3,12 +3,12 @@ procedure Bool.2 ():
     ret Bool.23;
 
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.276 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.276;
+    let Num.280 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.280;
 
 procedure Num.21 (#Attr.2, #Attr.3):
-    let Num.275 : I64 = lowlevel NumMul #Attr.2 #Attr.3;
-    ret Num.275;
+    let Num.279 : I64 = lowlevel NumMul #Attr.2 #Attr.3;
+    ret Num.279;
 
 procedure Test.6 (Test.8, #Attr.12):
     let Test.20 : I64 = UnionAtIndex (Id 0) (Index 0) #Attr.12;

--- a/crates/compiler/test_mono/generated/tail_call_elimination.txt
+++ b/crates/compiler/test_mono/generated/tail_call_elimination.txt
@@ -1,10 +1,10 @@
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.275 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.275;
+    let Num.279 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.279;
 
 procedure Num.20 (#Attr.2, #Attr.3):
-    let Num.276 : I64 = lowlevel NumSub #Attr.2 #Attr.3;
-    ret Num.276;
+    let Num.280 : I64 = lowlevel NumSub #Attr.2 #Attr.3;
+    ret Num.280;
 
 procedure Test.1 (#Derived_gen.0, #Derived_gen.1):
     joinpoint Test.7 Test.2 Test.3:

--- a/crates/compiler/test_mono/generated/unspecialized_lambda_set_unification_does_not_duplicate_identical_concrete_types.txt
+++ b/crates/compiler/test_mono/generated/unspecialized_lambda_set_unification_does_not_duplicate_identical_concrete_types.txt
@@ -184,40 +184,40 @@ procedure List.91 (#Derived_gen.8, #Derived_gen.9, #Derived_gen.10, #Derived_gen
     jump List.613 #Derived_gen.8 #Derived_gen.9 #Derived_gen.10 #Derived_gen.11 #Derived_gen.12;
 
 procedure Num.127 (#Attr.2):
-    let Num.282 : U8 = lowlevel NumIntCast #Attr.2;
-    ret Num.282;
-
-procedure Num.137 (#Attr.2, #Attr.3):
-    let Num.287 : U64 = lowlevel NumDivCeilUnchecked #Attr.2 #Attr.3;
-    ret Num.287;
-
-procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.286 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    let Num.286 : U8 = lowlevel NumIntCast #Attr.2;
     ret Num.286;
 
-procedure Num.20 (#Attr.2, #Attr.3):
-    let Num.283 : U64 = lowlevel NumSub #Attr.2 #Attr.3;
-    ret Num.283;
-
-procedure Num.21 (#Attr.2, #Attr.3):
-    let Num.288 : U64 = lowlevel NumMul #Attr.2 #Attr.3;
-    ret Num.288;
-
-procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.294 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.294;
-
-procedure Num.24 (#Attr.2, #Attr.3):
-    let Num.296 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
-    ret Num.296;
-
-procedure Num.51 (#Attr.2, #Attr.3):
-    let Num.291 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
+procedure Num.137 (#Attr.2, #Attr.3):
+    let Num.291 : U64 = lowlevel NumDivCeilUnchecked #Attr.2 #Attr.3;
     ret Num.291;
 
-procedure Num.75 (#Attr.2, #Attr.3):
-    let Num.295 : U64 = lowlevel NumSubWrap #Attr.2 #Attr.3;
+procedure Num.19 (#Attr.2, #Attr.3):
+    let Num.290 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.290;
+
+procedure Num.20 (#Attr.2, #Attr.3):
+    let Num.287 : U64 = lowlevel NumSub #Attr.2 #Attr.3;
+    ret Num.287;
+
+procedure Num.21 (#Attr.2, #Attr.3):
+    let Num.292 : U64 = lowlevel NumMul #Attr.2 #Attr.3;
+    ret Num.292;
+
+procedure Num.22 (#Attr.2, #Attr.3):
+    let Num.298 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.298;
+
+procedure Num.24 (#Attr.2, #Attr.3):
+    let Num.300 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
+    ret Num.300;
+
+procedure Num.51 (#Attr.2, #Attr.3):
+    let Num.295 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
     ret Num.295;
+
+procedure Num.75 (#Attr.2, #Attr.3):
+    let Num.299 : U64 = lowlevel NumSubWrap #Attr.2 #Attr.3;
+    ret Num.299;
 
 procedure Str.12 (#Attr.2):
     let Str.233 : List U8 = lowlevel StrToUtf8 #Attr.2;

--- a/crates/compiler/test_mono/generated/unspecialized_lambda_set_unification_keeps_all_concrete_types_without_unification_of_unifiable.txt
+++ b/crates/compiler/test_mono/generated/unspecialized_lambda_set_unification_keeps_all_concrete_types_without_unification_of_unifiable.txt
@@ -158,24 +158,24 @@ procedure List.91 (#Derived_gen.40, #Derived_gen.41, #Derived_gen.42, #Derived_g
     jump List.601 #Derived_gen.40 #Derived_gen.41 #Derived_gen.42 #Derived_gen.43 #Derived_gen.44;
 
 procedure Num.127 (#Attr.2):
-    let Num.294 : U8 = lowlevel NumIntCast #Attr.2;
-    ret Num.294;
-
-procedure Num.20 (#Attr.2, #Attr.3):
-    let Num.295 : U64 = lowlevel NumSub #Attr.2 #Attr.3;
-    ret Num.295;
-
-procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.298 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    let Num.298 : U8 = lowlevel NumIntCast #Attr.2;
     ret Num.298;
 
+procedure Num.20 (#Attr.2, #Attr.3):
+    let Num.299 : U64 = lowlevel NumSub #Attr.2 #Attr.3;
+    ret Num.299;
+
+procedure Num.22 (#Attr.2, #Attr.3):
+    let Num.302 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.302;
+
 procedure Num.24 (#Attr.2, #Attr.3):
-    let Num.296 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
-    ret Num.296;
+    let Num.300 : Int1 = lowlevel NumGt #Attr.2 #Attr.3;
+    ret Num.300;
 
 procedure Num.51 (#Attr.2, #Attr.3):
-    let Num.297 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
-    ret Num.297;
+    let Num.301 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
+    ret Num.301;
 
 procedure Str.12 (#Attr.2):
     let Str.233 : List U8 = lowlevel StrToUtf8 #Attr.2;

--- a/crates/compiler/test_mono/generated/weakening_avoids_overspecialization.txt
+++ b/crates/compiler/test_mono/generated/weakening_avoids_overspecialization.txt
@@ -78,16 +78,16 @@ procedure List.80 (#Derived_gen.0, #Derived_gen.1, #Derived_gen.2, #Derived_gen.
     jump List.592 #Derived_gen.0 #Derived_gen.1 #Derived_gen.2 #Derived_gen.3 #Derived_gen.4;
 
 procedure Num.22 (#Attr.2, #Attr.3):
-    let Num.278 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
-    ret Num.278;
+    let Num.282 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
+    ret Num.282;
 
 procedure Num.51 (#Attr.2, #Attr.3):
-    let Num.277 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
-    ret Num.277;
+    let Num.281 : U64 = lowlevel NumAddWrap #Attr.2 #Attr.3;
+    ret Num.281;
 
 procedure Num.77 (#Attr.2, #Attr.3):
-    let Num.276 : U64 = lowlevel NumSubSaturated #Attr.2 #Attr.3;
-    ret Num.276;
+    let Num.280 : U64 = lowlevel NumSubSaturated #Attr.2 #Attr.3;
+    ret Num.280;
 
 procedure Test.3 (Test.4, Test.12):
     let Test.13 : [C U64, C U64] = TagId(0) Test.4;

--- a/crates/compiler/test_mono/generated/when_guard_appears_multiple_times_in_compiled_decision_tree_issue_5176.txt
+++ b/crates/compiler/test_mono/generated/when_guard_appears_multiple_times_in_compiled_decision_tree_issue_5176.txt
@@ -3,8 +3,8 @@ procedure Bool.2 ():
     ret Bool.25;
 
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.275 : U8 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.275;
+    let Num.279 : U8 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.279;
 
 procedure Test.1 (Test.2):
     joinpoint Test.12:

--- a/crates/compiler/test_mono/generated/when_nested_maybe.txt
+++ b/crates/compiler/test_mono/generated/when_nested_maybe.txt
@@ -1,6 +1,6 @@
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.275 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.275;
+    let Num.279 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.279;
 
 procedure Test.0 ():
     let Test.19 : I64 = 41i64;

--- a/crates/compiler/test_mono/generated/when_on_record.txt
+++ b/crates/compiler/test_mono/generated/when_on_record.txt
@@ -1,6 +1,6 @@
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.275 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.275;
+    let Num.279 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.279;
 
 procedure Test.0 ():
     let Test.5 : I64 = 2i64;

--- a/crates/compiler/test_mono/generated/when_on_two_values.txt
+++ b/crates/compiler/test_mono/generated/when_on_two_values.txt
@@ -1,6 +1,6 @@
 procedure Num.19 (#Attr.2, #Attr.3):
-    let Num.275 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
-    ret Num.275;
+    let Num.279 : I64 = lowlevel NumAdd #Attr.2 #Attr.3;
+    ret Num.279;
 
 procedure Test.0 ():
     let Test.15 : I64 = 3i64;


### PR DESCRIPTION
Here we add some new constants to `Num` for floating-point NaN and Infinity values. Addresses part of #6709.

I am having trouble getting rust to accept `NaN == NaN`, as the logic for comparison seems burried within the macro (and my rust is only so good...). Does anyone have any pointers?