### PR TITLE
Re-add REPL prompt CSS to tutorial

### DIFF
--- a/www/public/site.css
+++ b/www/public/site.css
@@ -40,6 +40,7 @@
     --header-link-hover: #222;
     --h1-color: #8055e4;
     --tutorial-h3-color: #8c5ce3; /* Slightly darker than --primary-1, which looks washed-out in <h3>s */
+    --repl-prompt: #0064ff;
 }
 
 html {
@@ -1573,4 +1574,9 @@ code .dim {
 #gh-link-text {
     margin-left: 8px;
     vertical-align: middle;
+}
+
+.repl-prompt:before {
+    color: var(--repl-prompt);
+    content: "» ";
 }


### PR DESCRIPTION
## Description
This re-adds the CSS corresponding to the REPL prompt in the tutorial section.

When code is copied, the prompt symbol (`» `) doesn't get copied alongside the code, which matches the expected behaviour.

The behaviour has been tested by building the website locally and inspecting the output corresponding to the tutorial page.


## References
- ZulipChat [thread](https://roc.zulipchat.com/#narrow/stream/316715-contributing/topic/tutorial.20repl.20prompt/near/437026456).