### PR TITLE
Narrower reports from language server

### DIFF
--- a/.github/workflows/ubuntu_x86_64.yml
+++ b/.github/workflows/ubuntu_x86_64.yml
@@ -39,12 +39,6 @@ jobs:
         # see #5904 for skipped test
         run: cargo test --locked --release -- --skip cli_run::expects_dev_and_test
 
-      - name: Valgrind on failure
-        if: ${{ failure() }}
-        run: |
-          valgrind --leak-check=full ./examples/static-site-gen/static-site examples/static-site-gen/input/ examples/static-site-gen/output
-          cp ./examples/static-site-gen/static-site /home/big-ci-user/Desktop/
-
       - name: tests examples in docs
         run:  cargo test --doc --release
         

--- a/.github/workflows/ubuntu_x86_64.yml
+++ b/.github/workflows/ubuntu_x86_64.yml
@@ -43,7 +43,9 @@ jobs:
 
       - name: Valgrind on failure
         if: ${{ failure() }}
-        run: valgrind --leak-check=full ./examples/static-site-gen/static-site examples/static-site-gen/input/ examples/static-site-gen/output
+        run: |
+          valgrind --leak-check=full ./examples/static-site-gen/static-site examples/static-site-gen/input/ examples/static-site-gen/output
+          cp ./examples/static-site-gen/static-site /home/big-ci-user/Desktop/
 
       - name: tests examples in docs
         run:  cargo test --doc --release

--- a/.github/workflows/ubuntu_x86_64.yml
+++ b/.github/workflows/ubuntu_x86_64.yml
@@ -11,8 +11,6 @@ jobs:
     name: test zig, rust, wasm...
     runs-on: [self-hosted, i7-6700K]
     timeout-minutes: 90
-    env:
-      RUSTC_WRAPPER: /home/big-ci-user/.cargo/bin/sccache
     steps:
       - uses: actions/checkout@v4
 
@@ -39,7 +37,7 @@ jobs:
 
       - name: regular rust tests
         # see #5904 for skipped test
-        run: cargo test --locked --release -- --skip cli_run::expects_dev_and_test && sccache --show-stats
+        run: cargo test --locked --release -- --skip cli_run::expects_dev_and_test
 
       - name: Valgrind on failure
         if: ${{ failure() }}
@@ -54,19 +52,19 @@ jobs:
         run: cd examples/platform-switching/rust-platform && LD_LIBRARY_PATH=. cargo test --release --locked
 
       - name: test the dev backend # these tests require an explicit feature flag
-        run: cargo test --locked --release --package test_gen --no-default-features --features gen-dev && sccache --show-stats
+        run: cargo test --locked --release --package test_gen --no-default-features --features gen-dev
 
       - name: test gen-wasm single threaded # gen-wasm has some multithreading problems to do with the wasmer runtime
-        run: cargo test --locked --release --package test_gen --no-default-features --features gen-wasm -- --test-threads=1 && sccache --show-stats
+        run: cargo test --locked --release --package test_gen --no-default-features --features gen-wasm -- --test-threads=1
 
       - name: roc test all builtins
         run: ./ci/roc_test_builtins.sh
 
       - name: wasm repl test
-        run: crates/repl_test/test_wasm.sh && sccache --show-stats
+        run: crates/repl_test/test_wasm.sh
 
       - name: test building wasm repl
-        run: ./ci/www-repl.sh && sccache --show-stats
+        run: ./ci/www-repl.sh
 
       #TODO i386 (32-bit linux) cli tests
       #TODO verify-no-git-changes

--- a/.github/workflows/ubuntu_x86_64.yml
+++ b/.github/workflows/ubuntu_x86_64.yml
@@ -41,6 +41,10 @@ jobs:
         # see #5904 for skipped test
         run: cargo test --locked --release -- --skip cli_run::expects_dev_and_test && sccache --show-stats
 
+      - name: Valgrind on failure
+        if: ${{ failure() }}
+        run: valgrind --leak-check=full ./examples/static-site-gen/static-site examples/static-site-gen/input/ examples/static-site-gen/output
+
       - name: tests examples in docs
         run:  cargo test --doc --release
         

--- a/crates/language_server/src/analysis.rs
+++ b/crates/language_server/src/analysis.rs
@@ -112,7 +112,7 @@ pub(crate) fn global_analysis(doc_info: DocInfo) -> Vec<AnalyzedDocument> {
         src_dir,
         roc_target::Target::LinuxX64,
         roc_load::FunctionKind::LambdaSet,
-        roc_reporting::report::RenderTarget::Generic,
+        roc_reporting::report::RenderTarget::LanguageServer,
         RocCacheDir::Persistent(cache::roc_cache_dir().as_path()),
         roc_reporting::report::DEFAULT_PALETTE,
     );

--- a/crates/language_server/src/convert.rs
+++ b/crates/language_server/src/convert.rs
@@ -202,9 +202,8 @@ pub(crate) mod diag {
             );
 
             let severity = report.severity.into_lsp_severity();
-
             let mut msg = String::new();
-            report.render_ci(&mut msg, fmt.alloc);
+            report.render_ls(&mut msg, fmt.alloc);
 
             Some(Diagnostic {
                 range,
@@ -239,7 +238,7 @@ pub(crate) mod diag {
             let severity = report.severity.into_lsp_severity();
 
             let mut msg = String::new();
-            report.render_ci(&mut msg, fmt.alloc);
+            report.render_ls(&mut msg, fmt.alloc);
 
             Some(Diagnostic {
                 range,

--- a/crates/language_server/src/convert.rs
+++ b/crates/language_server/src/convert.rs
@@ -203,7 +203,7 @@ pub(crate) mod diag {
 
             let severity = report.severity.into_lsp_severity();
             let mut msg = String::new();
-            report.render_ls(&mut msg, fmt.alloc);
+            report.render_language_server(&mut msg, fmt.alloc);
 
             Some(Diagnostic {
                 range,
@@ -238,7 +238,7 @@ pub(crate) mod diag {
             let severity = report.severity.into_lsp_severity();
 
             let mut msg = String::new();
-            report.render_ls(&mut msg, fmt.alloc);
+            report.render_language_server(&mut msg, fmt.alloc);
 
             Some(Diagnostic {
                 range,

--- a/crates/reporting/src/report.rs
+++ b/crates/reporting/src/report.rs
@@ -176,6 +176,17 @@ impl<'b> Report<'b> {
         }
     }
 
+    /// Render report for the language server, where the window is narrower.
+    pub fn render_ls(self, buf: &mut String, alloc: &'b RocDocAllocator<'b>) {
+        let err_msg = "<buffer is not a utf-8 encoded string>";
+
+        alloc
+            .stack([alloc.text(self.title), self.doc])
+            .1
+            .render_raw(60, &mut CiWrite::new(buf))
+            .expect(err_msg)
+    }
+
     pub fn horizontal_rule(palette: &'b Palette) -> String {
         format!("{}{}", palette.header, "─".repeat(80))
     }

--- a/crates/reporting/src/report.rs
+++ b/crates/reporting/src/report.rs
@@ -112,6 +112,7 @@ pub fn pretty_header_with_path(title: &str, path: &Path) -> String {
 pub enum RenderTarget {
     ColorTerminal,
     Generic,
+    LanguageServer,
 }
 
 /// A textual report.
@@ -133,6 +134,7 @@ impl<'b> Report<'b> {
         match target {
             RenderTarget::Generic => self.render_ci(buf, alloc),
             RenderTarget::ColorTerminal => self.render_color_terminal(buf, alloc, palette),
+            RenderTarget::LanguageServer => self.render_language_server(buf, alloc),
         }
     }
 
@@ -177,7 +179,7 @@ impl<'b> Report<'b> {
     }
 
     /// Render report for the language server, where the window is narrower.
-    pub fn render_ls(self, buf: &mut String, alloc: &'b RocDocAllocator<'b>) {
+    pub fn render_language_server(self, buf: &mut String, alloc: &'b RocDocAllocator<'b>) {
         let err_msg = "<buffer is not a utf-8 encoded string>";
 
         alloc

--- a/crates/reporting/src/report.rs
+++ b/crates/reporting/src/report.rs
@@ -179,6 +179,7 @@ impl<'b> Report<'b> {
     }
 
     /// Render report for the language server, where the window is narrower.
+    /// Path is not included, and the header is not emphasized with "─".
     pub fn render_language_server(self, buf: &mut String, alloc: &'b RocDocAllocator<'b>) {
         let err_msg = "<buffer is not a utf-8 encoded string>";
 


### PR DESCRIPTION
The language server uses the `Generic` error reporting style which assumes the window is a little wider than editor diagnostic popups typically are.

<img width=600 src="https://github.com/roc-lang/roc/assets/1724813/a1917734-452a-4118-9d38-26409e9d4212"></img>

This PR changes that so that only the report title is included without decorators or path:

<img width=400 src="https://github.com/roc-lang/roc/assets/1724813/ea7182ae-caee-4e7e-b74a-6a59a6e1baf6"></img>

In the future, we could probably improve LS reports further under this new mode.
