### PR TITLE
Upgrade header imports when formatting through lang server

### DIFF
--- a/crates/language_server/src/analysis/parse_ast.rs
+++ b/crates/language_server/src/analysis/parse_ast.rs
@@ -26,7 +26,9 @@ impl<'a> Ast<'a> {
         let (module, state) = parse_header(arena, State::new(src.as_bytes()))
             .map_err(|e| SyntaxError::Header(e.problem))?;
 
-        let defs = parse_module_defs(arena, state, Defs::default())?;
+        let (module, defs) = module.upgrade_header_imports(arena);
+
+        let defs = parse_module_defs(arena, state, defs)?;
 
         Ok(Ast {
             module,


### PR DESCRIPTION
[This Zulip thread](https://roc.zulipchat.com/#narrow/stream/231634-beginners/topic/Syntax.20error.20in.20the.20tutorial.3F/near/437730768) mentioned that saving an old app header in Zed "removes a lot of stuff". So, I tried it myself and I found that it was indeed dropping imports:

![CleanShot 2024-05-09 at 08 15 45](https://github.com/roc-lang/roc/assets/1724813/7f996d7b-ab25-489a-965c-43ddf56af168)

It looks like I forgot to upgrade header imports when calling the formatter through the language server. When this PR is merged, it should work like the CLI formatter:


https://github.com/roc-lang/roc/assets/1724813/441a99e6-c429-4c2e-89cb-4b8899852f0c

