### PR TITLE
Improve error message

### DIFF
--- a/crates/repl_ui/src/repl_state.rs
+++ b/crates/repl_ui/src/repl_state.rs
@@ -130,7 +130,9 @@ impl ReplState {
                     ValueDef::Annotation(_, _)
                     | ValueDef::Body(_, _)
                     | ValueDef::AnnotatedBody { .. } => {
-                        todo!("handle pattern other than identifier (which repl doesn't support)")
+                        todo!("handle pattern other than identifier (which repl doesn't support).\
+                              \nTip: this error can be triggered when trying to define a variable with a character that is not allowed,\
+                              like starting with an uppercase character.")
                     }
                     ValueDef::Dbg { .. } => {
                         todo!("handle receiving a `dbg` - what should the repl do for that?")


### PR DESCRIPTION
This error can be hit when entering for example `F = \x -> x % 3` so I added a tip for that.
Long term we want to further improve this error with https://github.com/roc-lang/roc/issues/6722.