### PR TITLE
Revise errors for undeclared type vars in aliases

### DIFF
--- a/crates/compiler/load/tests/test_reporting.rs
+++ b/crates/compiler/load/tests/test_reporting.rs
@@ -4545,13 +4545,13 @@ mod test_reporting {
 
     test_report!(
         comment_with_tab,
-        "# comment with a \t\n4",
+        "# comment with a \t char\n4",
         @r###"
     ── TAB CHARACTER in tmp/comment_with_tab/Test.roc ──────────────────────────────
 
     I encountered a tab character:
 
-    4│      # comment with a 	
+    4│      # comment with a 	 char
                              ^
 
     Tab characters are not allowed in Roc code. Please use spaces instead!
@@ -4560,13 +4560,13 @@ mod test_reporting {
 
     test_report!(
         comment_with_control_character,
-        "# comment with a \x07\n",
+        "# comment with a \x07 char\n",
         @r###"
     ── ASCII CONTROL CHARACTER in tmp/comment_with_control_character/Test.roc ──────
 
     I encountered an ASCII control character:
 
-    4│      # comment with a 
+    4│      # comment with a  char
                              ^
 
     ASCII control characters are not allowed.

--- a/crates/compiler/load/tests/test_reporting.rs
+++ b/crates/compiler/load/tests/test_reporting.rs
@@ -8638,17 +8638,17 @@ In roc, functions are always written as a lambda, like{}
             a
             "
         ),
-        @r"
-    ── UNBOUND TYPE VARIABLE in /code/proj/Main.roc ────────────────────────────────
+        @r###"
+    ── WILDCARD NOT ALLOWED HERE in /code/proj/Main.roc ────────────────────────────
 
-    The definition of `I` has an unbound type variable:
+    The definition of `I` includes a wildcard (`*`) type variable:
 
     4│      I : Num.Int *
                         ^
 
-    Tip: Type variables must be bound before the `:`. Perhaps you intended
-    to add a type parameter to this type?
-    "
+    Type alias definitions may not use wildcard (`*`) type variables. Only
+    named type variables are allowed.
+    "###
     );
 
     test_report!(
@@ -8657,21 +8657,19 @@ In roc, functions are always written as a lambda, like{}
             r"
             I : Num.Int _
             a : I
-            a = 0x5
             a
             "
         ),
-        @r"
-    ── UNBOUND TYPE VARIABLE in /code/proj/Main.roc ────────────────────────────────
+        @r###"
+    ── UNDERSCORE NOT ALLOWED HERE in /code/proj/Main.roc ──────────────────────────
 
-    The definition of `I` has an unbound type variable:
+    The definition of `I` includes an inferred (`_`) type:
 
     4│      I : Num.Int _
                         ^
 
-    Tip: Type variables must be bound before the `:`. Perhaps you intended
-    to add a type parameter to this type?
-    "
+    Type alias definitions may not use inferred types (`_`).
+    "###
     );
 
     test_report!(
@@ -8683,17 +8681,17 @@ In roc, functions are always written as a lambda, like{}
             a
             "
         ),
-        @r"
-    ── UNBOUND TYPE VARIABLE in /code/proj/Main.roc ────────────────────────────────
+        @r###"
+    ── WILDCARD NOT ALLOWED HERE in /code/proj/Main.roc ────────────────────────────
 
-    The definition of `I` has an unbound type variable:
+    The definition of `I` includes a wildcard (`*`) type variable:
 
     4│      I := Num.Int *
                          ^
 
-    Tip: Type variables must be bound before the `:=`. Perhaps you intended
-    to add a type parameter to this type?
-    "
+    Opaque type definitions may not use wildcard (`*`) type variables. Only
+    named type variables are allowed.
+    "###
     );
 
     test_report!(
@@ -8705,19 +8703,18 @@ In roc, functions are always written as a lambda, like{}
             a
             "
         ),
-        @r"
-    ── UNBOUND TYPE VARIABLE in /code/proj/Main.roc ────────────────────────────────
+        @r###"
+    ── WILDCARD NOT ALLOWED HERE in /code/proj/Main.roc ────────────────────────────
 
-    The definition of `I` has 2 unbound type variables.
-
-    Here is one occurrence:
+    The definition of `I` includes 2 wildcard (`*`) type variables. Here is
+    one of them:
 
     4│      I : [A (Num.Int *), B (Num.Int *)]
                             ^
 
-    Tip: Type variables must be bound before the `:`. Perhaps you intended
-    to add a type parameter to this type?
-    "
+    Type alias definitions may not use wildcard (`*`) type variables. Only
+    named type variables are allowed.
+    "###
     );
 
     test_report!(
@@ -8729,17 +8726,16 @@ In roc, functions are always written as a lambda, like{}
             a
             "
         ),
-        @r"
-    ── UNBOUND TYPE VARIABLE in /code/proj/Main.roc ────────────────────────────────
+        @r###"
+    ── UNDERSCORE NOT ALLOWED HERE in /code/proj/Main.roc ──────────────────────────
 
-    The definition of `I` has an unbound type variable:
+    The definition of `I` includes an inferred (`_`) type:
 
     4│      I : Num.Int _
                         ^
 
-    Tip: Type variables must be bound before the `:`. Perhaps you intended
-    to add a type parameter to this type?
-    "
+    Type alias definitions may not use inferred types (`_`).
+    "###
     );
 
     test_report!(
@@ -8751,17 +8747,19 @@ In roc, functions are always written as a lambda, like{}
             a
             "
         ),
-        @r"
-    ── UNBOUND TYPE VARIABLE in /code/proj/Main.roc ────────────────────────────────
+        @r###"
+    ── UNDECLARED TYPE VARIABLE in /code/proj/Main.roc ─────────────────────────────
 
-    The definition of `I` has an unbound type variable:
+    The definition of `I` includes an undeclared type variable:
 
     4│      I : Num.Int a
                         ^
 
-    Tip: Type variables must be bound before the `:`. Perhaps you intended
-    to add a type parameter to this type?
-    "
+    All type variables in type alias definitions must be declared.
+
+    Tip: You can declare type variables by putting them right before the `:`
+    symbol, separated by spaces.
+    "###
     );
 
     test_report!(

--- a/crates/compiler/load/tests/test_reporting.rs
+++ b/crates/compiler/load/tests/test_reporting.rs
@@ -8652,6 +8652,29 @@ In roc, functions are always written as a lambda, like{}
     );
 
     test_report!(
+        underscore_in_alias,
+        indoc!(
+            r"
+            I : Num.Int _
+            a : I
+            a = 0x5
+            a
+            "
+        ),
+        @r"
+    ── UNBOUND TYPE VARIABLE in /code/proj/Main.roc ────────────────────────────────
+
+    The definition of `I` has an unbound type variable:
+
+    4│      I : Num.Int _
+                        ^
+
+    Tip: Type variables must be bound before the `:`. Perhaps you intended
+    to add a type parameter to this type?
+    "
+    );
+
+    test_report!(
         wildcard_in_opaque,
         indoc!(
             r"

--- a/crates/compiler/problem/src/can.rs
+++ b/crates/compiler/problem/src/can.rs
@@ -76,7 +76,7 @@ pub enum Problem {
         variable_name: Lowercase,
         alias_kind: AliasKind,
     },
-    UnboundTypeVariable {
+    UndeclaredTypeVar {
         typ: Symbol,
         num_unbound: usize,
         one_occurrence: Region,
@@ -99,7 +99,6 @@ pub enum Problem {
         record_region: Region,
         field_region: Region,
     },
-
     DuplicateTag {
         tag_name: TagName,
         tag_union_region: Region,
@@ -225,6 +224,18 @@ pub enum Problem {
         filename: PathBuf,
         error: io::ErrorKind,
     },
+    WildcardNotAllowed {
+        typ: Symbol,
+        num_wildcards: usize,
+        one_occurrence: Region,
+        kind: AliasKind,
+    },
+    UnderscoreNotAllowed {
+        typ: Symbol,
+        num_underscores: usize,
+        one_occurrence: Region,
+        kind: AliasKind,
+    },
 }
 
 impl Problem {
@@ -249,7 +260,9 @@ impl Problem {
             Problem::CyclicAlias(..) => RuntimeError,
             Problem::BadRecursion(_) => RuntimeError,
             Problem::PhantomTypeArgument { .. } => Warning,
-            Problem::UnboundTypeVariable { .. } => RuntimeError,
+            Problem::UndeclaredTypeVar { .. } => RuntimeError,
+            Problem::WildcardNotAllowed { .. } => RuntimeError,
+            Problem::UnderscoreNotAllowed { .. } => RuntimeError,
             Problem::DuplicateRecordFieldValue { .. } => Warning,
             Problem::DuplicateRecordFieldType { .. } => RuntimeError,
             Problem::InvalidOptionalValue { .. } => RuntimeError,
@@ -330,7 +343,15 @@ impl Problem {
                 variable_region: region,
                 ..
             }
-            | Problem::UnboundTypeVariable {
+            | Problem::WildcardNotAllowed {
+                one_occurrence: region,
+                ..
+            }
+            | Problem::UnderscoreNotAllowed {
+                one_occurrence: region,
+                ..
+            }
+            | Problem::UndeclaredTypeVar {
                 one_occurrence: region,
                 ..
             }

--- a/crates/reporting/src/error/canonicalize.rs
+++ b/crates/reporting/src/error/canonicalize.rs
@@ -23,7 +23,9 @@ const UNUSED_IMPORT: &str = "UNUSED IMPORT";
 const IMPORT_NAME_CONFLICT: &str = "IMPORT NAME CONFLICT";
 const EXPLICIT_BUILTIN_IMPORT: &str = "EXPLICIT BUILTIN IMPORT";
 const UNUSED_ALIAS_PARAM: &str = "UNUSED TYPE ALIAS PARAMETER";
-const UNBOUND_TYPE_VARIABLE: &str = "UNBOUND TYPE VARIABLE";
+const UNDECLARED_TYPE_VARIABLE: &str = "UNDECLARED TYPE VARIABLE";
+const WILDCARD_NOT_ALLOWED: &str = "WILDCARD NOT ALLOWED HERE";
+const UNDERSCORE_NOT_ALLOWED: &str = "UNDERSCORE NOT ALLOWED HERE";
 const UNUSED_ARG: &str = "UNUSED ARGUMENT";
 const MISSING_DEFINITION: &str = "MISSING DEFINITION";
 const UNKNOWN_GENERATES_WITH: &str = "UNKNOWN GENERATES FUNCTION";
@@ -457,41 +459,145 @@ pub fn can_problem<'b>(
 
             title = UNUSED_ALIAS_PARAM.to_string();
         }
-        Problem::UnboundTypeVariable {
+        Problem::WildcardNotAllowed {
             typ: alias,
-            num_unbound,
+            num_wildcards,
             one_occurrence,
             kind,
         } => {
             let mut stack = Vec::with_capacity(4);
-            if num_unbound == 1 {
+            if num_wildcards == 1 {
                 stack.push(alloc.concat([
                     alloc.reflow("The definition of "),
                     alloc.symbol_unqualified(alias),
-                    alloc.reflow(" has an unbound type variable:"),
+                    alloc.reflow(" includes a wildcard ("),
+                    alloc.keyword("*"),
+                    alloc.reflow(") type variable:"),
                 ]));
             } else {
                 stack.push(alloc.concat([
                     alloc.reflow("The definition of "),
                     alloc.symbol_unqualified(alias),
-                    alloc.reflow(" has "),
-                    text!(alloc, "{}", num_unbound),
-                    alloc.reflow(" unbound type variables."),
+                    alloc.reflow(" includes "),
+                    text!(alloc, "{}", num_wildcards),
+                    alloc.reflow(" wildcard ("),
+                    alloc.keyword("*"),
+                    alloc.reflow(") type variables:"),
                 ]));
-                stack.push(alloc.reflow("Here is one occurrence:"));
+                stack.push(alloc.reflow("Here is one of them:"));
             }
             stack.push(alloc.region(lines.convert_region(one_occurrence)));
             stack.push(alloc.tip().append(alloc.concat([
-                alloc.reflow("Type variables must be bound before the "),
+                alloc.reflow("All type variables in "),
+                alloc.reflow(match kind {
+                    AliasKind::Structural => "type alias",
+                    AliasKind::Opaque => "opaque type",
+                }),
+                alloc.reflow(" definitions must be named, and also declared before the "),
                 alloc.keyword(match kind {
                     AliasKind::Structural => ":",
                     AliasKind::Opaque => ":=",
                 }),
-                alloc.reflow(". Perhaps you intended to add a type parameter to this type?"),
+                alloc.reflow(" symbol. Wildcard type variables ("),
+                alloc.keyword("*"),
+                alloc.reflow(") may not be used."),
             ])));
             doc = alloc.stack(stack);
 
-            title = UNBOUND_TYPE_VARIABLE.to_string();
+            title = WILDCARD_NOT_ALLOWED.to_string();
+        }
+        Problem::UnderscoreNotAllowed {
+            typ: alias,
+            num_underscores,
+            one_occurrence,
+            kind,
+        } => {
+            let mut stack = Vec::with_capacity(4);
+            if num_underscores == 1 {
+                stack.push(alloc.concat([
+                    alloc.reflow("The definition of "),
+                    alloc.symbol_unqualified(alias),
+                    alloc.reflow(" includes an inferred ("),
+                    alloc.keyword("_"),
+                    alloc.reflow(") type:"),
+                ]));
+            } else {
+                stack.push(alloc.concat([
+                    alloc.reflow("The definition of "),
+                    alloc.symbol_unqualified(alias),
+                    alloc.reflow(" includes "),
+                    text!(alloc, "{}", num_underscores),
+                    alloc.reflow(" inferred ("),
+                    alloc.keyword("_"),
+                    alloc.reflow(") types:"),
+                ]));
+                stack.push(alloc.reflow("Here is one of them:"));
+            }
+            stack.push(alloc.region(lines.convert_region(one_occurrence)));
+            stack.push(alloc.tip().append(alloc.concat([
+                alloc.reflow(match kind {
+                    AliasKind::Structural => "Type alias",
+                    AliasKind::Opaque => "Opaque type",
+                }),
+                alloc.reflow(" definitions may not use inferred types ("),
+                alloc.keyword("_"),
+                alloc.reflow(")."),
+            ])));
+            doc = alloc.stack(stack);
+
+            title = UNDERSCORE_NOT_ALLOWED.to_string();
+        }
+        Problem::UndeclaredTypeVar {
+            typ: alias,
+            num_unbound,
+            one_occurrence,
+            kind,
+        } => {
+            let decl_symbol = match kind {
+                AliasKind::Structural => ":",
+                AliasKind::Opaque => ":=",
+            };
+            let mut stack = Vec::with_capacity(4);
+
+            if num_unbound == 1 {
+                stack.push(alloc.concat([
+                    alloc.reflow("The definition of "),
+                    alloc.symbol_unqualified(alias),
+                    alloc.reflow(" includes an undeclared type variable:"),
+                ]));
+            } else {
+                stack.push(alloc.concat([
+                    alloc.reflow("The definition of "),
+                    alloc.symbol_unqualified(alias),
+                    alloc.reflow(" includes "),
+                    text!(alloc, "{}", num_unbound),
+                    alloc.reflow(" undeclared type variables."),
+                ]));
+                stack.push(alloc.reflow("Here is one of them:"));
+            }
+            stack.push(alloc.region(lines.convert_region(one_occurrence)));
+            stack.push(alloc.tip().append(alloc.concat([
+                alloc.reflow("All type variables in "),
+                alloc.reflow(match kind {
+                    AliasKind::Structural => "type alias",
+                    AliasKind::Opaque => "opaque type",
+                }),
+                alloc.reflow(" definitions must be declared before the "),
+                alloc.keyword(decl_symbol),
+                alloc.reflow(" symbol."),
+                alloc.tip().append(alloc.stack(
+                    [
+                        alloc.reflow(
+                            "You can declare type variables by putting them right before the ",
+                        ),
+                        alloc.keyword(decl_symbol),
+                        alloc.reflow(" symbol, separated by spaces."),
+                    ],
+                )),
+            ])));
+            doc = alloc.stack(stack);
+
+            title = UNDECLARED_TYPE_VARIABLE.to_string();
         }
         Problem::BadRecursion(entries) => {
             doc = to_circular_def_doc(alloc, lines, &entries);

--- a/crates/reporting/src/error/canonicalize.rs
+++ b/crates/reporting/src/error/canonicalize.rs
@@ -482,26 +482,19 @@ pub fn can_problem<'b>(
                     text!(alloc, "{}", num_wildcards),
                     alloc.reflow(" wildcard ("),
                     alloc.keyword("*"),
-                    alloc.reflow(") type variables:"),
+                    alloc.reflow(") type variables. Here is one of them:"),
                 ]));
-                stack.push(alloc.reflow("Here is one of them:"));
             }
             stack.push(alloc.region(lines.convert_region(one_occurrence)));
-            stack.push(alloc.tip().append(alloc.concat([
-                alloc.reflow("All type variables in "),
+            stack.push(alloc.concat([
                 alloc.reflow(match kind {
-                    AliasKind::Structural => "type alias",
-                    AliasKind::Opaque => "opaque type",
+                    AliasKind::Structural => "Type alias",
+                    AliasKind::Opaque => "Opaque type",
                 }),
-                alloc.reflow(" definitions must be named, and also declared before the "),
-                alloc.keyword(match kind {
-                    AliasKind::Structural => ":",
-                    AliasKind::Opaque => ":=",
-                }),
-                alloc.reflow(" symbol. Wildcard type variables ("),
+                alloc.reflow(" definitions may not use wildcard ("),
                 alloc.keyword("*"),
-                alloc.reflow(") may not be used."),
-            ])));
+                alloc.reflow(") type variables. Only named type variables are allowed."),
+            ]));
             doc = alloc.stack(stack);
 
             title = WILDCARD_NOT_ALLOWED.to_string();
@@ -534,7 +527,7 @@ pub fn can_problem<'b>(
                 stack.push(alloc.reflow("Here is one of them:"));
             }
             stack.push(alloc.region(lines.convert_region(one_occurrence)));
-            stack.push(alloc.tip().append(alloc.concat([
+            stack.push(alloc.concat([
                 alloc.reflow(match kind {
                     AliasKind::Structural => "Type alias",
                     AliasKind::Opaque => "Opaque type",
@@ -542,7 +535,7 @@ pub fn can_problem<'b>(
                 alloc.reflow(" definitions may not use inferred types ("),
                 alloc.keyword("_"),
                 alloc.reflow(")."),
-            ])));
+            ]));
             doc = alloc.stack(stack);
 
             title = UNDERSCORE_NOT_ALLOWED.to_string();
@@ -576,24 +569,18 @@ pub fn can_problem<'b>(
                 stack.push(alloc.reflow("Here is one of them:"));
             }
             stack.push(alloc.region(lines.convert_region(one_occurrence)));
-            stack.push(alloc.tip().append(alloc.concat([
+            stack.push(alloc.concat([
                 alloc.reflow("All type variables in "),
                 alloc.reflow(match kind {
                     AliasKind::Structural => "type alias",
                     AliasKind::Opaque => "opaque type",
                 }),
-                alloc.reflow(" definitions must be declared before the "),
+                alloc.reflow(" definitions must be declared."),
+            ]));
+            stack.push(alloc.tip().append(alloc.concat([
+                alloc.reflow("You can declare type variables by putting them right before the "),
                 alloc.keyword(decl_symbol),
-                alloc.reflow(" symbol."),
-                alloc.tip().append(alloc.stack(
-                    [
-                        alloc.reflow(
-                            "You can declare type variables by putting them right before the ",
-                        ),
-                        alloc.keyword(decl_symbol),
-                        alloc.reflow(" symbol, separated by spaces."),
-                    ],
-                )),
+                alloc.reflow(" symbol, separated by spaces."),
             ])));
             doc = alloc.stack(stack);
 


### PR DESCRIPTION
Now we have separate error messages for if you use `*` or `_` in type aliases or opaque types.

In a future PR I'd like to also give special error messages for using `_` in ability member definitions.