### PR TITLE
Print special float values as Num.nanF64, etc

### DIFF
--- a/crates/repl_test/src/tests.rs
+++ b/crates/repl_test/src/tests.rs
@@ -102,8 +102,13 @@ fn num_ceil_checked_division_success() {
 
 #[test]
 fn float_division_by_zero() {
-    expect_success("1f64 / 0", "∞ : F64");
-    expect_success("-1f64 / 0", "-∞ : F64");
+    expect_success("1f64 / 0", "Num.infinityF64 : F64");
+    expect_success("-1f64 / 0", "-Num.infinityF64 : F64");
+    expect_success("0f64 / 0", "Num.nanF64 : F64");
+
+    expect_success("1f32 / 0", "Num.infinityF32 : F32");
+    expect_success("-1f32 / 0", "-Num.infinityF32 : F32");
+    expect_success("0f32 / 0", "Num.nanF32 : F32");
 }
 
 #[test]


### PR DESCRIPTION
Addresses part of #6709. I might need a little bit of help on this one.

My understanding of rust macros is limited - I suspect the `f64_helper!` and `f32_helper!` macros could be elided. I was trying to avoid adding a trait just for dispatching on the number printing function at the end.

I also think my usage of `Expr::Num("Num.nanF64")` is wrong since we aren't actually implementing these as literals - there must be another AST node type for getting something from a module?

There are a few pieces of documentation in `Num.roc` that could be updated to reflect these changes.

Finally, I wasn't sure if there was any runtime (zig) code for printing numbers as strings that we also want to consider? (Sorry, my understanding of the system as a whole is limited at this stage).