### PR TITLE
Include ingested files in package tarballs

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -747,7 +747,7 @@ pub fn build(
             }
 
             // Rather than building an executable or library, we're building
-            // a tarball so this code can be distributed via a HTTPS
+            // a tarball so this code can be distributed via HTTPS
             let filename = roc_packaging::tarball::build(path, compression)?;
             let total_time_ms = start_time.elapsed().as_millis();
             let total_time = if total_time_ms > 1000 {

--- a/crates/packaging/src/tarball.rs
+++ b/crates/packaging/src/tarball.rs
@@ -274,11 +274,9 @@ fn read_header<'a>(
     // (We can't use that for the parser state and still return Module<'a> unfortunately.)
     let arena_buf = bumpalo::collections::Vec::from_iter_in(buf.iter().copied(), arena);
     let parse_state = State::new(arena_buf.into_bump_slice());
-    let result = parse_header(arena, parse_state).unwrap_or_else(|_err| {
+    parse_header(arena, parse_state).map_err(|_err| {
         todo!(); // TODO report a nice error and exit 1 - or maybe just return Err, for better testability?
-    });
-
-    Ok(result)
+    })
 }
 
 fn add_ingested_files<W: Write>(

--- a/crates/packaging/src/tarball.rs
+++ b/crates/packaging/src/tarball.rs
@@ -274,11 +274,11 @@ fn read_header<'a>(
     // (We can't use that for the parser state and still return Module<'a> unfortunately.)
     let arena_buf = bumpalo::collections::Vec::from_iter_in(buf.iter().copied(), arena);
     let parse_state = State::new(arena_buf.into_bump_slice());
-    let (module, state) = parse_header(arena, parse_state).unwrap_or_else(|_err| {
+    let result = parse_header(arena, parse_state).unwrap_or_else(|_err| {
         todo!(); // TODO report a nice error and exit 1 - or maybe just return Err, for better testability?
     });
 
-    Ok((module, state))
+    Ok(result)
 }
 
 fn add_ingested_files<W: Write>(


### PR DESCRIPTION
If any of the modules in a package has an ingested file import, we will now add it to the tarball bundle. 

Fails if the file is outside the dir containing the entry point.

