### PR TITLE
Fix importing ingested file when bundling packages

### DIFF
--- a/crates/packaging/src/tarball.rs
+++ b/crates/packaging/src/tarball.rs
@@ -300,14 +300,14 @@ fn add_ingested_files<W: Write>(
 
                 if relative_path_str.contains("..") {
                     panic!(
-                        "Cannot bundle {} (imported in {}) since it contains a relative `..` which would access files outside {}",
+                        "Cannot bundle {} (imported in {}) since it contains a relative `..` which would access files outside {}.",
                         &relative_path.display(),
                         dot_roc_path.display(),
                         root_dir.display()
                     );
                 }
 
-                builder.append_path_with_name(dbg!(root_dir.join(&relative_path)), relative_path.display().to_string())
+                builder.append_path_with_name(root_dir.join(&relative_path), relative_path.display().to_string())
 
             } else {
                 unreachable!()


### PR DESCRIPTION
Follow up from #6757 with a fix for the ingested file paths. 

The current implementation duplicates the relative path, so for example `go-builtins/roc_std.h` will be `go-builtins/go-builtins/roc_std.h`.

```
thread 'main' panicked at crates/packaging/src/tarball.rs:306:25:
Cannot bundle go-builtins/go-builtins/roc_std.h (imported in package/Go.roc) since it's outside package
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

I changed to look for `..` in the path instead, as this prevents importing files above the package root.

This patch used to create [this release bundle](https://github.com/lukewilliamboswell/roc-glue-code-gen/releases/tag/0.1.0).