### PR TITLE
Look for a generic default host `libhost` for prebuilt platform binary

### DIFF
--- a/crates/compiler/build/src/link.rs
+++ b/crates/compiler/build/src/link.rs
@@ -50,8 +50,15 @@ pub fn legacy_host_file(target: Target, platform_main_roc: &Path) -> PathBuf {
         .replace(roc_linker::PRECOMPILED_HOST_EXT, lib_ext);
 
     let lib_path = platform_main_roc.with_file_name(file_name);
+
+    let default_host_path: PathBuf = platform_main_roc
+        .with_file_name("libhost")
+        .with_extension(lib_ext);
+
     if lib_path.exists() {
         lib_path
+    } else if default_host_path.exists() {
+        default_host_path
     } else {
         let obj_ext = target.object_file_ext();
         lib_path.with_extension(obj_ext)


### PR DESCRIPTION
If the target specific prebuilt static binary `legacy_host_file` is not found, check for a generic e.g. `libhost.a`  on macOS or `libhost.so` on linux.

This change simplifies the build process when developing a platform locally. A dedicated build script which can translate between the targets for native and roc filenames is no longer required. 

For example, when using `cargo build` or `zig build` to produce a static library named `host` for the native target, a generic  `libhost` file is produced. This is the default behaviour and produces a debug build. 

To use this prebuilt binary it needs to be renamed to the equivalent roc target specific name for the current target using an alternate build script. This can be done using build tools such as `build.rs`, and `build.zig`, or alternatively using a `build.roc` script. However, this approach requires information about which roc targets (arch and os) are supported and what roc names these files. 

This change provides an alternative solution, which eliminates this requirement by defaulting to a `libhost` file if the more specific `macos-arm64.a` prebuilt binary is not found. The build tool then only needs to output the library into the correct folder with the `platform/main.roc` file.