### PR TITLE
Ignore comments in repl

### DIFF
--- a/crates/compiler/parse/src/expr.rs
+++ b/crates/compiler/parse/src/expr.rs
@@ -2346,10 +2346,13 @@ fn parse_expr_end<'a>(
 }
 
 pub fn loc_expr<'a>(accept_multi_backpassing: bool) -> impl Parser<'a, Loc<Expr<'a>>, EExpr<'a>> {
-    expr_start(ExprParseOptions {
-        accept_multi_backpassing,
-        check_for_arrow: true,
-    })
+    space0_before_e(
+        expr_start(ExprParseOptions {
+            accept_multi_backpassing,
+            check_for_arrow: true,
+        }),
+        EExpr::IndentEnd,
+    )
 }
 
 pub fn merge_spaces<'a>(

--- a/crates/repl_ui/src/repl_state.rs
+++ b/crates/repl_ui/src/repl_state.rs
@@ -275,6 +275,9 @@ pub fn parse_src<'a>(arena: &'a Bump, line: &'a str) -> ParseOutcome<'a> {
 
             match roc_parse::expr::loc_expr(true).parse(arena, State::new(src_bytes), 0) {
                 Ok((_, loc_expr, _)) => ParseOutcome::Expr(loc_expr.value),
+                Err((roc_parse::parser::Progress::MadeProgress, EExpr::Start(_))) => {
+                    ParseOutcome::Empty
+                }
                 // Special case some syntax errors to allow for multi-line inputs
                 Err((_, EExpr::Closure(EClosure::Body(_, _), _)))
                 | Err((_, EExpr::When(EWhen::Pattern(EPattern::Start(_), _), _)))


### PR DESCRIPTION
Close https://github.com/roc-lang/roc/issues/6574

- [ ] Add tests

Tested manually these scenarios:

1. type `# comment` and evaluate

```
» # comment

Enter an expression to evaluate, or a definition (like x = 1) to use later.

  - ctrl-v + ctrl-j makes a newline
  - :q quits
  - :help shows this text again

»
```

2. paste multiline code and evaluate

```
» # comment
… x = 42

42 : Num *
```