### PR TITLE
Remove redundant test snapshot from root dir

### DIFF
--- a/module_with_params_and_multiline_exposes.header.roc
+++ b/module_with_params_and_multiline_exposes.header.roc
@@ -1,2 +1,0 @@
-module {echo, read } -> [mainMenu,
-    credits ]


### PR DESCRIPTION
This removes what seems to be a leftover copy of `crates/compiler/test_syntax/tests/snapshots/pass/module_with_params_and_multiline_exposes.header.roc` from the root dir of the project.

This is the reference [commit](https://github.com/roc-lang/roc/commit/370013b9604d187b5362e9bb12a585ab13187732).