### PR TITLE
move everything in getting_started folder to website

### DIFF
--- a/www/content/install/getting_started.md
+++ b/www/content/install/getting_started.md
@@ -4,18 +4,18 @@ Roc is a language for making delightful software. It does not have an 0.1 releas
 certainly don't recommend using it in production in its current state! However, it can be fun to
 play around with as long as you have a tolerance for missing features and compiler bugs. :)
 
-The [tutorial](/tutorial.html) is the best place to learn about how to use the language - it assumes no prior knowledge of Roc or similar languages. (If you already know [Elm](https://elm-lang.org/), then [Roc for Elm Programmers](https://github.com/roc-lang/roc/blob/main/roc-for-elm-programmers.md) may be of interest.)
+The [tutorial](/tutorial) is the best place to learn about how to use the language - it assumes no prior knowledge of Roc or similar languages. (If you already know [Elm](https://elm-lang.org/), then [Roc for Elm Programmers](https://github.com/roc-lang/roc/blob/main/roc-for-elm-programmers.md) may be of interest.)
 
-If you have a specific question, the [FAQ](/faq.html) might have an answer, although [Roc Zulip chat](https://roc.zulipchat.com) is overall the best place to ask questions and get help! It's also where we discuss [ideas](https://roc.zulipchat.com/#narrow/stream/304641-ideas) for the language. If you want to get involved in contributing to the language, Zulip is also a great place to ask about good first projects.
+If you have a specific question, the [FAQ](/faq) might have an answer, although [Roc Zulip chat](https://roc.zulipchat.com) is overall the best place to ask questions and get help! It's also where we discuss [ideas](https://roc.zulipchat.com/#narrow/stream/304641-ideas) for the language. If you want to get involved in contributing to the language, Zulip is also a great place to ask about good first projects.
 
 ## [Installation](#installation){#installation}
 
-- [🐧 Linux x86_64](/install/linux_x86_64.html)
-- [❄️ Nix Linux/MacOS](/install/nix.html)
-- [🍏 MacOS Apple Silicon](/install/macos_apple_silicon.html)
-- [🍏 MacOS x86_64](/install/macos_x86_64.html)
-- [🟦 Windows](/install/windows.html)
-- [Other](/install/other.html)
+- [🐧 Linux x86_64](/install/linux_x86_64)
+- [❄️ Nix Linux/MacOS](/install/nix)
+- [🍏 MacOS Apple Silicon](/install/macos_apple_silicon)
+- [🍏 MacOS x86_64](/install/macos_x86_64)
+- [🟦 Windows](/install/windows)
+- [Other](/install/other)
 
 ## Editor
 

--- a/www/content/install/getting_started.md
+++ b/www/content/install/getting_started.md
@@ -10,12 +10,12 @@ If you have a specific question, the [FAQ](../www/content/faq.md) might have an 
 
 ## Installation
 
-- [🐧 Linux x86_64](linux_x86_64.md)
-- [❄️ Nix Linux/MacOS](nix.md)
-- [🍏 MacOS Apple Silicon](macos_apple_silicon.md)
-- [🍏 MacOS x86_64](macos_x86_64.md)
-- [🟦 Windows](windows.md)
-- [Other](other.md)
+- [🐧 Linux x86_64](/install/linux_x86_64.html)
+- [❄️ Nix Linux/MacOS](/install/nix.html)
+- [🍏 MacOS Apple Silicon](/install/macos_apple_silicon.html)
+- [🍏 MacOS x86_64](/install/macos_x86_64.html)
+- [🟦 Windows](/install/windows.html)
+- [Other](/install/other.html)
 
 ## Editor
 
@@ -37,7 +37,6 @@ roc dev helloWorld.roc
 ```
 
 [crates/cli/tests/benchmarks](https://github.com/roc-lang/roc/tree/main/crates/cli/tests/benchmarks) contains more examples.
-
 
 ## Getting Involved
 

--- a/www/content/install/getting_started.md
+++ b/www/content/install/getting_started.md
@@ -4,11 +4,11 @@ Roc is a language for making delightful software. It does not have an 0.1 releas
 certainly don't recommend using it in production in its current state! However, it can be fun to
 play around with as long as you have a tolerance for missing features and compiler bugs. :)
 
-The [tutorial](https://roc-lang.org/tutorial) is the best place to learn about how to use the language - it assumes no prior knowledge of Roc or similar languages. (If you already know [Elm](https://elm-lang.org/), then [Roc for Elm Programmers](https://github.com/roc-lang/roc/blob/main/roc-for-elm-programmers.md) may be of interest.)
+The [tutorial](/tutorial.html) is the best place to learn about how to use the language - it assumes no prior knowledge of Roc or similar languages. (If you already know [Elm](https://elm-lang.org/), then [Roc for Elm Programmers](https://github.com/roc-lang/roc/blob/main/roc-for-elm-programmers.md) may be of interest.)
 
-If you have a specific question, the [FAQ](../www/content/faq.md) might have an answer, although [Roc Zulip chat](https://roc.zulipchat.com) is overall the best place to ask questions and get help! It's also where we discuss [ideas](https://roc.zulipchat.com/#narrow/stream/304641-ideas) for the language. If you want to get involved in contributing to the language, Zulip is also a great place to ask about good first projects.
+If you have a specific question, the [FAQ](/faq.html) might have an answer, although [Roc Zulip chat](https://roc.zulipchat.com) is overall the best place to ask questions and get help! It's also where we discuss [ideas](https://roc.zulipchat.com/#narrow/stream/304641-ideas) for the language. If you want to get involved in contributing to the language, Zulip is also a great place to ask about good first projects.
 
-## Installation
+## [Installation](#installation){#installation}
 
 - [🐧 Linux x86_64](/install/linux_x86_64.html)
 - [❄️ Nix Linux/MacOS](/install/nix.html)

--- a/www/content/install/index.md
+++ b/www/content/install/index.md
@@ -13,12 +13,12 @@ There are currently a few known OS-specific issues:
 Here are some Getting Started guides for different operating systems:
 <!-- TODO detect current OS with browser and only show link for that, provide other button for others  -->
 
-- [Linux x86-64](/install/linux_x86_64.html)
-- [Nix Linux/MacOS](/install/nix.html)
-- [MacOS Apple Silicon](/install/macos_apple_silicon.html)
-- [MacOS x86-64](/install/macos_x86_64.html)
-- [Windows](/install/windows.html)
-- [Other Systems](/install/other.html)
+- [Linux x86-64](/install/linux_x86_64)
+- [Nix Linux/MacOS](/install/nix)
+- [MacOS Apple Silicon](/install/macos_apple_silicon)
+- [MacOS x86-64](/install/macos_x86_64)
+- [Windows](/install/windows)
+- [Other Systems](/install/other)
 
 ### [Editor Extensions/Plugins](#editor-extensions) {#editor-extensions}
 

--- a/www/content/install/index.md
+++ b/www/content/install/index.md
@@ -13,12 +13,12 @@ There are currently a few known OS-specific issues:
 Here are some Getting Started guides for different operating systems:
 <!-- TODO detect current OS with browser and only show link for that, provide other button for others  -->
 
-- [Linux x86-64](https://github.com/roc-lang/roc/blob/main/getting_started/linux_x86_64.md)
-- [Nix Linux/MacOS](https://github.com/roc-lang/roc/blob/main/getting_started/nix.md)
-- [MacOS Apple Silicon](https://github.com/roc-lang/roc/blob/main/getting_started/macos_apple_silicon.md)
-- [MacOS x86-64](https://github.com/roc-lang/roc/blob/main/getting_started/macos_x86_64.md)
-- [Windows](https://github.com/roc-lang/roc/blob/main/getting_started/windows.md)
-- [Other Systems](https://github.com/roc-lang/roc/blob/main/getting_started/other.md)
+- [Linux x86-64](/install/linux_x86_64.html)
+- [Nix Linux/MacOS](/install/nix.html)
+- [MacOS Apple Silicon](/install/macos_apple_silicon.html)
+- [MacOS x86-64](/install/macos_x86_64.html)
+- [Windows](/install/windows.html)
+- [Other Systems](/install/other.html)
 
 ### [Editor Extensions/Plugins](#editor-extensions) {#editor-extensions}
 

--- a/www/content/install/linux_x86_64.md
+++ b/www/content/install/linux_x86_64.md
@@ -1,4 +1,4 @@
-# Roc installation guide for x86_64 Linux systems
+# Linux x86_64
 
 ## How to install Roc
 

--- a/www/content/install/macos_apple_silicon.md
+++ b/www/content/install/macos_apple_silicon.md
@@ -1,4 +1,4 @@
-# Roc installation guide for Apple silicon systems
+# Apple Silicon
 
 ## How to install Roc
 

--- a/www/content/install/macos_x86_64.md
+++ b/www/content/install/macos_x86_64.md
@@ -1,4 +1,4 @@
-# Roc installation guide for x86_64 MacOS systems
+# MacOS x86_64
 
 ## How to install Roc
 

--- a/www/content/install/nix.md
+++ b/www/content/install/nix.md
@@ -1,3 +1,5 @@
+# Nix
+
 ## Try out
 
 To quickly try out roc without installing, use `nix run`:

--- a/www/content/install/other.md
+++ b/www/content/install/other.md
@@ -2,7 +2,7 @@
 
 1. [Install Rust](https://rustup.rs/)
 
-1. [Build Roc from source](../BUILDING_FROM_SOURCE.md)
+1. [Build Roc from source](https://github.com/roc-lang/roc/blob/main/BUILDING_FROM_SOURCE.md)
 
 1. Run examples:
 

--- a/www/content/install/other.md
+++ b/www/content/install/other.md
@@ -1,4 +1,4 @@
-# Roc installation guide for other systems
+# Other Systems
 
 1. [Install Rust](https://rustup.rs/)
 

--- a/www/content/install/windows.md
+++ b/www/content/install/windows.md
@@ -1,4 +1,4 @@
-# Roc installation guide for Windows systems
+# Windows systems
 
 Windows support is limited, [folkertdev](https://github.com/folkertdev) and [lukewilliamboswell](https://github.com/lukewilliamboswell) are working on improving this 🚀. Until that is done we recommend using [Ubuntu 22.04](https://apps.microsoft.com/detail/9pn20msr04dw?hl=en-us&gl=US) through the "Windows Subsystem for Linux" (WSL).
 

--- a/www/content/install/windows.md
+++ b/www/content/install/windows.md
@@ -2,4 +2,4 @@
 
 Windows support is limited, [folkertdev](https://github.com/folkertdev) and [lukewilliamboswell](https://github.com/lukewilliamboswell) are working on improving this 🚀. Until that is done we recommend using [Ubuntu 22.04](https://apps.microsoft.com/detail/9pn20msr04dw?hl=en-us&gl=US) through the "Windows Subsystem for Linux" (WSL).
 
-Once you're inside Ubuntu, [install Roc](https://github.com/roc-lang/roc/blob/main/getting_started/linux_x86_64.md).
+Once you're inside Ubuntu, [install Roc](/install/linux_x86_64.html).

--- a/www/content/install/windows.md
+++ b/www/content/install/windows.md
@@ -2,4 +2,4 @@
 
 Windows support is limited, [folkertdev](https://github.com/folkertdev) and [lukewilliamboswell](https://github.com/lukewilliamboswell) are working on improving this 🚀. Until that is done we recommend using [Ubuntu 22.04](https://apps.microsoft.com/detail/9pn20msr04dw?hl=en-us&gl=US) through the "Windows Subsystem for Linux" (WSL).
 
-Once you're inside Ubuntu, [install Roc](/install/linux_x86_64.html).
+Once you're inside Ubuntu, [install Roc](/install/linux_x86_64).

--- a/www/content/tutorial.md
+++ b/www/content/tutorial.md
@@ -22,7 +22,7 @@
     </section>
     <section>
         <h2 id="installation"><a href="#installation">Installation</a></h2>
-        <p>Roc doesn’t have a numbered release or an installer yet, but you can follow the install instructions for your OS<a href="https://github.com/roc-lang/roc/tree/main/getting_started#installation"> here </a>. If you get stuck, friendly people will be happy to help if you open a topic in<a href="https://roc.zulipchat.com/#narrow/stream/231634-beginners"> #beginners </a>on<a href="https://roc.zulipchat.com/"> Roc Zulip Chat </a>and ask for assistance!</p>
+        <p>Roc doesn’t have a numbered release or an installer yet, but you can follow the install instructions for your OS<a href="/install/getting_started.html#installation"> here </a>. If you get stuck, friendly people will be happy to help if you open a topic in<a href="https://roc.zulipchat.com/#narrow/stream/231634-beginners"> #beginners </a>on<a href="https://roc.zulipchat.com/"> Roc Zulip Chat </a>and ask for assistance!</p>
     </section>
 
 ## [REPL](#repl) {#repl}

--- a/www/main.roc
+++ b/www/main.roc
@@ -36,12 +36,19 @@ pageData =
     |> Dict.insert "/friendly.html" { title: "Friendly | Roc", description: "What does it mean that the Roc programming language is friendly?" }
     |> Dict.insert "/functional.html" { title: "Functional | Roc", description: "What does it mean that the Roc programming language is functional?" }
     |> Dict.insert "/index.html" { title: "The Roc Programming Language", description: "A fast, friendly, functional language." }
-    |> Dict.insert "/install.html" { title: "Install | Roc", description: "How to install the Roc programming language." }
+    |> Dict.insert "/install/index.html" { title: "Install | Roc", description: "How to install the Roc programming language." }
     |> Dict.insert "/plans.html" { title: "Planned Changes | Roc", description: "Planned changes to the Roc programming language." }
     |> Dict.insert "/platforms.html" { title: "Platforms and Apps | Roc", description: "Learn about the platforms and applications architecture in the Roc programming language." }
     |> Dict.insert "/tutorial.html" { title: "Tutorial | Roc", description: "Learn the Roc programming language." }
     |> Dict.insert "/repl/index.html" { title: "REPL | Roc", description: "Try the Roc programming language in an online REPL." }
     |> Dict.insert "/examples/index.html" { title: "Examples | Roc", description: "All kinds of examples implemented in the Roc programming language." }
+    |> Dict.insert "/install/other.html" { title: "Getting started on other systems | Roc", description: "Roc installation guide for other systems" }
+    |> Dict.insert "/install/linux_x86_64.html" { title: "Getting started on Linux x86_64 | Roc", description: "Roc installation guide for Linux x86_64" }
+    |> Dict.insert "/install/macos_apple_silicon.html" { title: "Getting started on MacOS Apple Silicon | Roc", description: "Roc installation guide for MacOS Apple Silicon" }
+    |> Dict.insert "/install/macos_x86_64.html" { title: "Getting started on MacOS x86_64 | Roc", description: "Roc installation guide for MacOS x86_64" }
+    |> Dict.insert "/install/windows.html" { title: "Getting started on Windows | Roc", description: "Roc installation guide for Windows" }
+    |> Dict.insert "/install/nix.html" { title: "Getting started with Nix | Roc", description: "Roc installation guide for Nix" }
+    |> Dict.insert "/install/getting_started.html" { title: "Getting started | Roc", description: "How to get started with Roc" }
 
 getPageInfo : Str -> { title : Str, description : Str }
 getPageInfo = \pagePathStr ->


### PR DESCRIPTION
Addresses #6764 

Key changes

- `install.md` is now in `www/content/install/index.md`
- guides from `getting_started/` are now in `www/content/install/`
- guides' h1 headings were shortened to fit better on the site
- urls were updated within the install/ files

Questions

- I moved the `getting_started/README.md` to `www/content/install/getting_started.md`. It has a lot of overlap with the `install/index.md`. Would it be desirable to combine them somehow? Or is it intended to replace it? I found that it was linked from the Tutorial installation section, so I also updated that link in the meantime.
- I used relative paths with `.html` extensions. Was that ok? Or are we supposed to leave the .html extension off of the URL paths? 
- Any other changes?