### PR TITLE
remove macos-11

### DIFF
--- a/.github/workflows/basic_cli_build_release.yml
+++ b/.github/workflows/basic_cli_build_release.yml
@@ -97,7 +97,7 @@ jobs:
             basic-cli/platform/linux-arm64.o
 
   build-macos-x86_64-files:
-    runs-on: [macos-11] # I expect the generated files to work on macOS 12 and up
+    runs-on: [macos-12] # I expect the generated files to work on macOS 12 and up
     needs: [prepare]
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/basic_webserver_build_release.yml
+++ b/.github/workflows/basic_webserver_build_release.yml
@@ -83,7 +83,7 @@ jobs:
             basic-webserver/platform/linux-arm64.o
 
   build-macos-x86_64-files:
-    runs-on: [macos-11] # I expect the generated files to work on macOS 12 and 13
+    runs-on: [macos-12] # I expect the generated files to work on macOS 12 and up
     needs: [fetch-releases]
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/macos_x86_64.yml
+++ b/.github/workflows/macos_x86_64.yml
@@ -29,5 +29,5 @@ jobs:
 
             - name: regular rust tests
               run: cargo test --locked --release -- --skip opaque_wrap_function --skip gen_list::bool_list_literal --skip platform_switching_swift --skip swift_ui --skip gen_tags::phantom_polymorphic_record && sccache --show-stats
-              # swift tests are skipped because of "Could not find or use auto-linked library 'swiftCompatibilityConcurrency'" on macos-11 x86_64 CI machine
+              # swift tests are skipped because of "Could not find or use auto-linked library 'swiftCompatibilityConcurrency'" on macos x86_64 CI machine
               # this issue may be caused by using older versions of XCode

--- a/.github/workflows/nightly_macos_x86_64.yml
+++ b/.github/workflows/nightly_macos_x86_64.yml
@@ -28,7 +28,7 @@ jobs:
 
             - name: execute rust tests
               run: cargo test --release --locked -- --skip opaque_wrap_function --skip gen_list::bool_list_literal --skip platform_switching_swift --skip swift_ui --skip gen_tags::phantom_polymorphic_record
-              # swift tests are skipped because of "Could not find or use auto-linked library 'swiftCompatibilityConcurrency'" on macos-11 x86_64 CI machine
+              # swift tests are skipped because of "Could not find or use auto-linked library 'swiftCompatibilityConcurrency'" on macos x86_64 CI machine
               # this issue may be caused by using older versions of XCode
 
             - name: build release

--- a/.github/workflows/test_nightly_many_os.yml
+++ b/.github/workflows/test_nightly_many_os.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ macos-11, macos-12, macos-13, ubuntu-20.04, ubuntu-22.04 ]
+        os: [ macos-12, macos-13, ubuntu-20.04, ubuntu-22.04 ]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 90
     steps:


### PR DESCRIPTION
[macos-11 CI runner is deprecated and will soon be removed](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories)