### PR TITLE
builtin: List.concatUtf8 : List U8, Str -> Str

### DIFF
--- a/crates/compiler/builtins/README.md
+++ b/crates/compiler/builtins/README.md
@@ -80,7 +80,7 @@ It's one thing to actually write these functions, it's _another_ thing to let th
 
 ## Specifying how we pass args to the function
 
-### builtins/mono/src/borrow.rs
+### builtins/mono/src/inc_dec.rs
 
 After we have all of this, we need to specify if the arguments we're passing are owned, borrowed or irrelevant. Towards the bottom of this file, add a new case for your builtin and specify each arg. Be sure to read the comment, as it explains this in more detail.
 

--- a/crates/compiler/builtins/bitcode/src/main.zig
+++ b/crates/compiler/builtins/bitcode/src/main.zig
@@ -210,6 +210,7 @@ comptime {
     exportStrFn(str.withCapacityC, "with_capacity");
     exportStrFn(str.strAllocationPtr, "allocation_ptr");
     exportStrFn(str.strReleaseExcessCapacity, "release_excess_capacity");
+    exportStrFn(str.strConcatUtf8, "concat_utf8");
 
     inline for (INTEGERS) |T| {
         str.exportFromInt(T, ROC_BUILTINS ++ "." ++ STR ++ ".from_int.");

--- a/crates/compiler/builtins/bitcode/src/main.zig
+++ b/crates/compiler/builtins/bitcode/src/main.zig
@@ -85,6 +85,7 @@ comptime {
     exportListFn(list.listCapacity, "capacity");
     exportListFn(list.listAllocationPtr, "allocation_ptr");
     exportListFn(list.listReleaseExcessCapacity, "release_excess_capacity");
+    exportListFn(list.listConcatUtf8, "concat_utf8");
 }
 
 // Num Module
@@ -210,7 +211,6 @@ comptime {
     exportStrFn(str.withCapacityC, "with_capacity");
     exportStrFn(str.strAllocationPtr, "allocation_ptr");
     exportStrFn(str.strReleaseExcessCapacity, "release_excess_capacity");
-    exportStrFn(str.strConcatUtf8, "concat_utf8");
 
     inline for (INTEGERS) |T| {
         str.exportFromInt(T, ROC_BUILTINS ++ "." ++ STR ++ ".from_int.");

--- a/crates/compiler/builtins/bitcode/src/str.zig
+++ b/crates/compiler/builtins/bitcode/src/str.zig
@@ -2390,34 +2390,3 @@ pub fn strReleaseExcessCapacity(
         return output;
     }
 }
-
-pub fn strConcatUtf8(
-    list: RocList,
-    string: RocStr,
-) callconv(.C) RocList {
-    if (string.len() == 0) {
-        return list;
-    } else {
-        const combined_length = list.len() + string.len();
-
-        // XXX: I assume List U8 has alignment 1 and element_width 1?
-        var result = list.reallocate(1, combined_length, 1);
-        // We just allocated combined_length, which is > 0 because string.len() > 0
-        var bytes = result.bytes orelse unreachable;
-        @memcpy(bytes[list.len()..combined_length], string.asU8ptr()[0..string.len()]);
-
-        return result;
-    }
-}
-
-test "strConcatUtf8" {
-    const list = RocList.fromSlice(u8, &[_]u8{ 1, 2, 3, 4 });
-    defer list.decref(1);
-    const string_bytes = "🐦";
-    const string = RocStr.init(string_bytes, string_bytes.len);
-    defer string.decref();
-    const ret = strConcatUtf8(list, string);
-    const expected = RocList.fromSlice(u8, &[_]u8{ 1, 2, 3, 4, 240, 159, 144, 166 });
-    defer expected.decref(1);
-    try expect(ret.eql(expected));
-}

--- a/crates/compiler/builtins/roc/List.roc
+++ b/crates/compiler/builtins/roc/List.roc
@@ -69,11 +69,12 @@ module [
     walkBackwardsUntil,
     countIf,
     chunksOf,
+    concatUtf8,
 ]
 
 import Bool exposing [Bool, Eq]
 import Result exposing [Result]
-import Num exposing [U64, Num]
+import Num exposing [U64, Num, U8]
 
 ## ## Types
 ##
@@ -1324,3 +1325,12 @@ iterBackwardsHelp = \list, state, f, prevIndex ->
             Break b -> Break b
     else
         Continue state
+
+## Concatenates the bytes of a string encoded as utf8 to a list of bytes.
+## ```roc
+## expect (List.concatUtf8 [1, 2, 3, 4] "🐦") == [1, 2, 3, 4, 240, 159, 144, 166]
+## ```
+concatUtf8 : List U8, Str -> List U8
+
+expect (List.concatUtf8 [1, 2, 3, 4] "🐦") == [1, 2, 3, 4, 240, 159, 144, 166]
+

--- a/crates/compiler/builtins/roc/Str.roc
+++ b/crates/compiler/builtins/roc/Str.roc
@@ -367,7 +367,6 @@ module [
     withCapacity,
     withPrefix,
     contains,
-    concatUtf8,
 ]
 
 import Bool exposing [Bool]
@@ -560,14 +559,6 @@ FromUtf8Result : {
 }
 
 fromUtf8Lowlevel : List U8 -> FromUtf8Result
-
-## Concatenates the bytes of a string encoded as utf8 to a list of bytes.
-## ```roc
-## expect (Str.concatUtf8 [1, 2, 3, 4] "🐦") == [1, 2, 3, 4, 240, 159, 144, 166]
-## ```
-concatUtf8 : List U8, Str -> List U8
-
-expect (Str.concatUtf8 [1, 2, 3, 4] "🐦") == [1, 2, 3, 4, 240, 159, 144, 166]
 
 ## Check if the given [Str] starts with a value.
 ## ```roc

--- a/crates/compiler/builtins/roc/Str.roc
+++ b/crates/compiler/builtins/roc/Str.roc
@@ -367,6 +367,7 @@ module [
     withCapacity,
     withPrefix,
     contains,
+    concatUtf8,
 ]
 
 import Bool exposing [Bool]
@@ -559,6 +560,14 @@ FromUtf8Result : {
 }
 
 fromUtf8Lowlevel : List U8 -> FromUtf8Result
+
+## Concatenates the bytes of a string encoded as utf8 to a list of bytes.
+## ```roc
+## expect (Str.concatUtf8 [1, 2, 3, 4] "🐦") == [1, 2, 3, 4, 240, 159, 144, 166]
+## ```
+concatUtf8 : List U8, Str -> List U8
+
+expect (Str.concatUtf8 [1, 2, 3, 4] "🐦") == [1, 2, 3, 4, 240, 159, 144, 166]
 
 ## Check if the given [Str] starts with a value.
 ## ```roc

--- a/crates/compiler/builtins/src/bitcode.rs
+++ b/crates/compiler/builtins/src/bitcode.rs
@@ -369,6 +369,7 @@ pub const STR_CLONE_TO: &str = "roc_builtins.str.clone_to";
 pub const STR_WITH_CAPACITY: &str = "roc_builtins.str.with_capacity";
 pub const STR_ALLOCATION_PTR: &str = "roc_builtins.str.allocation_ptr";
 pub const STR_RELEASE_EXCESS_CAPACITY: &str = "roc_builtins.str.release_excess_capacity";
+pub const STR_CONCAT_UTF8: &str = "roc_builtins.str.concat_utf8";
 
 pub const LIST_MAP: &str = "roc_builtins.list.map";
 pub const LIST_MAP2: &str = "roc_builtins.list.map2";

--- a/crates/compiler/builtins/src/bitcode.rs
+++ b/crates/compiler/builtins/src/bitcode.rs
@@ -369,7 +369,6 @@ pub const STR_CLONE_TO: &str = "roc_builtins.str.clone_to";
 pub const STR_WITH_CAPACITY: &str = "roc_builtins.str.with_capacity";
 pub const STR_ALLOCATION_PTR: &str = "roc_builtins.str.allocation_ptr";
 pub const STR_RELEASE_EXCESS_CAPACITY: &str = "roc_builtins.str.release_excess_capacity";
-pub const STR_CONCAT_UTF8: &str = "roc_builtins.str.concat_utf8";
 
 pub const LIST_MAP: &str = "roc_builtins.list.map";
 pub const LIST_MAP2: &str = "roc_builtins.list.map2";
@@ -391,6 +390,7 @@ pub const LIST_RESERVE: &str = "roc_builtins.list.reserve";
 pub const LIST_CAPACITY: &str = "roc_builtins.list.capacity";
 pub const LIST_ALLOCATION_PTR: &str = "roc_builtins.list.allocation_ptr";
 pub const LIST_RELEASE_EXCESS_CAPACITY: &str = "roc_builtins.list.release_excess_capacity";
+pub const LIST_CONCAT_UTF8: &str = "roc_builtins.list.concat_utf8";
 
 pub const DEC_ABS: &str = "roc_builtins.dec.abs";
 pub const DEC_ACOS: &str = "roc_builtins.dec.acos";

--- a/crates/compiler/can/src/builtins.rs
+++ b/crates/compiler/can/src/builtins.rs
@@ -128,7 +128,6 @@ map_symbol_to_lowlevel_and_arity! {
     StrToNum; STR_TO_NUM; 1,
     StrWithCapacity; STR_WITH_CAPACITY; 1,
     StrReleaseExcessCapacity; STR_RELEASE_EXCESS_CAPACITY; 1,
-    StrConcatUtf8; STR_CONCAT_UTF8; 2,
 
     ListLenUsize; LIST_LEN_USIZE; 1,
     ListLenU64; LIST_LEN_U64; 1,
@@ -151,6 +150,7 @@ map_symbol_to_lowlevel_and_arity! {
     ListSwap; LIST_SWAP; 3,
     ListGetCapacity; LIST_CAPACITY; 1,
     ListReleaseExcessCapacity; LIST_RELEASE_EXCESS_CAPACITY; 1,
+    ListConcatUtf8; LIST_CONCAT_UTF8; 2,
 
     ListGetUnsafe; DICT_LIST_GET_UNSAFE; 2,
 

--- a/crates/compiler/can/src/builtins.rs
+++ b/crates/compiler/can/src/builtins.rs
@@ -128,6 +128,7 @@ map_symbol_to_lowlevel_and_arity! {
     StrToNum; STR_TO_NUM; 1,
     StrWithCapacity; STR_WITH_CAPACITY; 1,
     StrReleaseExcessCapacity; STR_RELEASE_EXCESS_CAPACITY; 1,
+    StrConcatUtf8; STR_CONCAT_UTF8; 2,
 
     ListLenUsize; LIST_LEN_USIZE; 1,
     ListLenU64; LIST_LEN_U64; 1,

--- a/crates/compiler/gen_dev/src/lib.rs
+++ b/crates/compiler/gen_dev/src/lib.rs
@@ -1704,6 +1704,13 @@ trait Backend<'a> {
 
                 self.build_fn_call(sym, intrinsic.to_string(), args, arg_layouts, ret_layout)
             }
+            LowLevel::StrConcatUtf8 => self.build_fn_call(
+                sym,
+                bitcode::STR_CONCAT_UTF8.to_string(),
+                args,
+                arg_layouts,
+                ret_layout,
+            ),
             LowLevel::PtrCast => {
                 debug_assert_eq!(
                     1,

--- a/crates/compiler/gen_dev/src/lib.rs
+++ b/crates/compiler/gen_dev/src/lib.rs
@@ -1704,9 +1704,9 @@ trait Backend<'a> {
 
                 self.build_fn_call(sym, intrinsic.to_string(), args, arg_layouts, ret_layout)
             }
-            LowLevel::StrConcatUtf8 => self.build_fn_call(
+            LowLevel::ListConcatUtf8 => self.build_fn_call(
                 sym,
-                bitcode::STR_CONCAT_UTF8.to_string(),
+                bitcode::LIST_CONCAT_UTF8.to_string(),
                 args,
                 arg_layouts,
                 ret_layout,

--- a/crates/compiler/gen_llvm/src/llvm/lowlevel.rs
+++ b/crates/compiler/gen_llvm/src/llvm/lowlevel.rs
@@ -608,6 +608,28 @@ pub(crate) fn run_low_level<'a, 'ctx>(
                 bitcode::STR_WITH_CAPACITY,
             )
         }
+        StrConcatUtf8 => {
+            // Str.concatUtf8: List U8, Str -> List U8
+            arguments!(list, string);
+
+            // XXX: I don't know why I need to call different functions based on the target pointer width, but the test_gen tests panic if I don't
+            match env.target.ptr_width() {
+                PtrWidth::Bytes4 => call_str_bitcode_fn(
+                    env,
+                    &[list, string],
+                    &[],
+                    BitcodeReturns::List,
+                    bitcode::STR_CONCAT_UTF8,
+                ),
+                PtrWidth::Bytes8 => call_list_bitcode_fn(
+                    env,
+                    &[list.into_struct_value()],
+                    &[string],
+                    BitcodeReturns::List,
+                    bitcode::STR_CONCAT_UTF8,
+                ),
+            }
+        }
         ListLenU64 => {
             // List.len : List * -> U64
             arguments!(list);

--- a/crates/compiler/gen_llvm/src/llvm/lowlevel.rs
+++ b/crates/compiler/gen_llvm/src/llvm/lowlevel.rs
@@ -608,28 +608,6 @@ pub(crate) fn run_low_level<'a, 'ctx>(
                 bitcode::STR_WITH_CAPACITY,
             )
         }
-        StrConcatUtf8 => {
-            // Str.concatUtf8: List U8, Str -> List U8
-            arguments!(list, string);
-
-            // XXX: I don't know why I need to call different functions based on the target pointer width, but the test_gen tests panic if I don't
-            match env.target.ptr_width() {
-                PtrWidth::Bytes4 => call_str_bitcode_fn(
-                    env,
-                    &[list, string],
-                    &[],
-                    BitcodeReturns::List,
-                    bitcode::STR_CONCAT_UTF8,
-                ),
-                PtrWidth::Bytes8 => call_list_bitcode_fn(
-                    env,
-                    &[list.into_struct_value()],
-                    &[string],
-                    BitcodeReturns::List,
-                    bitcode::STR_CONCAT_UTF8,
-                ),
-            }
-        }
         ListLenU64 => {
             // List.len : List * -> U64
             arguments!(list);
@@ -866,6 +844,18 @@ pub(crate) fn run_low_level<'a, 'ctx>(
                     list
                 }
             }
+        }
+        ListConcatUtf8 => {
+            // List.concatUtf8: List U8, Str -> List U8
+            arguments!(list, string);
+
+            call_list_bitcode_fn(
+                env,
+                &[list.into_struct_value()],
+                &[string],
+                BitcodeReturns::List,
+                bitcode::LIST_CONCAT_UTF8,
+            )
         }
         NumToStr => {
             // Num.toStr : Num a -> Str

--- a/crates/compiler/gen_llvm/src/llvm/lowlevel.rs
+++ b/crates/compiler/gen_llvm/src/llvm/lowlevel.rs
@@ -849,13 +849,22 @@ pub(crate) fn run_low_level<'a, 'ctx>(
             // List.concatUtf8: List U8, Str -> List U8
             arguments!(list, string);
 
-            call_list_bitcode_fn(
-                env,
-                &[list.into_struct_value()],
-                &[string],
-                BitcodeReturns::List,
-                bitcode::LIST_CONCAT_UTF8,
-            )
+            match env.target.ptr_width() {
+                PtrWidth::Bytes4 => call_str_bitcode_fn(
+                    env,
+                    &[list, string],
+                    &[],
+                    BitcodeReturns::List,
+                    bitcode::LIST_CONCAT_UTF8,
+                ),
+                PtrWidth::Bytes8 => call_list_bitcode_fn(
+                    env,
+                    &[list.into_struct_value()],
+                    &[string],
+                    BitcodeReturns::List,
+                    bitcode::LIST_CONCAT_UTF8,
+                ),
+            }
         }
         NumToStr => {
             // Num.toStr : Num a -> Str

--- a/crates/compiler/gen_wasm/src/low_level.rs
+++ b/crates/compiler/gen_wasm/src/low_level.rs
@@ -258,7 +258,6 @@ impl<'a> LowLevelCall<'a> {
                 self.load_args_and_call_zig(backend, bitcode::STR_SUBSTRING_UNSAFE)
             }
             StrWithCapacity => self.load_args_and_call_zig(backend, bitcode::STR_WITH_CAPACITY),
-            StrConcatUtf8 => self.load_args_and_call_zig(backend, bitcode::STR_CONCAT_UTF8),
 
             // List
             ListLenU64 => {
@@ -482,6 +481,7 @@ impl<'a> LowLevelCall<'a> {
 
                 backend.call_host_fn_after_loading_args(bitcode::LIST_CONCAT);
             }
+            ListConcatUtf8 => self.load_args_and_call_zig(backend, bitcode::LIST_CONCAT_UTF8),
 
             ListReserve => {
                 // List.reserve : List elem, U64 -> List elem

--- a/crates/compiler/gen_wasm/src/low_level.rs
+++ b/crates/compiler/gen_wasm/src/low_level.rs
@@ -258,6 +258,7 @@ impl<'a> LowLevelCall<'a> {
                 self.load_args_and_call_zig(backend, bitcode::STR_SUBSTRING_UNSAFE)
             }
             StrWithCapacity => self.load_args_and_call_zig(backend, bitcode::STR_WITH_CAPACITY),
+            StrConcatUtf8 => self.load_args_and_call_zig(backend, bitcode::STR_CONCAT_UTF8),
 
             // List
             ListLenU64 => {

--- a/crates/compiler/module/src/low_level.rs
+++ b/crates/compiler/module/src/low_level.rs
@@ -26,7 +26,6 @@ pub enum LowLevel {
     StrReserve,
     StrWithCapacity,
     StrReleaseExcessCapacity,
-    StrConcatUtf8,
     ListLenUsize,
     ListLenU64,
     ListWithCapacity,
@@ -48,6 +47,7 @@ pub enum LowLevel {
     ListGetCapacity,
     ListIsUnique,
     ListClone,
+    ListConcatUtf8,
     NumAdd,
     NumAddWrap,
     NumAddChecked,
@@ -275,7 +275,6 @@ map_symbol_to_lowlevel! {
     StrToNum <= STR_TO_NUM;
     StrWithCapacity <= STR_WITH_CAPACITY;
     StrReleaseExcessCapacity <= STR_RELEASE_EXCESS_CAPACITY;
-    StrConcatUtf8 <= STR_CONCAT_UTF8;
     ListLenU64 <= LIST_LEN_U64;
     ListLenUsize <= LIST_LEN_USIZE;
     ListGetCapacity <= LIST_CAPACITY;
@@ -292,6 +291,7 @@ map_symbol_to_lowlevel! {
     ListSublist <= LIST_SUBLIST_LOWLEVEL;
     ListDropAt <= LIST_DROP_AT;
     ListSwap <= LIST_SWAP;
+    ListConcatUtf8 <= LIST_CONCAT_UTF8;
     NumAdd <= NUM_ADD;
     NumAddWrap <= NUM_ADD_WRAP;
     NumAddChecked <= NUM_ADD_CHECKED_LOWLEVEL;

--- a/crates/compiler/module/src/low_level.rs
+++ b/crates/compiler/module/src/low_level.rs
@@ -26,6 +26,7 @@ pub enum LowLevel {
     StrReserve,
     StrWithCapacity,
     StrReleaseExcessCapacity,
+    StrConcatUtf8,
     ListLenUsize,
     ListLenU64,
     ListWithCapacity,
@@ -274,6 +275,7 @@ map_symbol_to_lowlevel! {
     StrToNum <= STR_TO_NUM;
     StrWithCapacity <= STR_WITH_CAPACITY;
     StrReleaseExcessCapacity <= STR_RELEASE_EXCESS_CAPACITY;
+    StrConcatUtf8 <= STR_CONCAT_UTF8;
     ListLenU64 <= LIST_LEN_U64;
     ListLenUsize <= LIST_LEN_USIZE;
     ListGetCapacity <= LIST_CAPACITY;

--- a/crates/compiler/module/src/symbol.rs
+++ b/crates/compiler/module/src/symbol.rs
@@ -1440,7 +1440,6 @@ define_builtins! {
         46 STR_REPLACE_FIRST: "replaceFirst"
         47 STR_REPLACE_LAST: "replaceLast"
         48 STR_RELEASE_EXCESS_CAPACITY: "releaseExcessCapacity"
-        49 STR_CONCAT_UTF8: "concatUtf8"
     }
     6 LIST: "List" => {
         0 LIST_LIST: "List" exposed_apply_type=true // the List.List type alias
@@ -1532,6 +1531,7 @@ define_builtins! {
         86 LIST_WALK_WITH_INDEX_UNTIL: "walkWithIndexUntil"
         87 LIST_CLONE: "clone"
         88 LIST_LEN_USIZE: "lenUsize"
+        89 LIST_CONCAT_UTF8: "concatUtf8"
     }
     7 RESULT: "Result" => {
         0 RESULT_RESULT: "Result" exposed_type=true // the Result.Result type alias

--- a/crates/compiler/module/src/symbol.rs
+++ b/crates/compiler/module/src/symbol.rs
@@ -1440,6 +1440,7 @@ define_builtins! {
         46 STR_REPLACE_FIRST: "replaceFirst"
         47 STR_REPLACE_LAST: "replaceLast"
         48 STR_RELEASE_EXCESS_CAPACITY: "releaseExcessCapacity"
+        49 STR_CONCAT_UTF8: "concatUtf8"
     }
     6 LIST: "List" => {
         0 LIST_LIST: "List" exposed_apply_type=true // the List.List type alias

--- a/crates/compiler/mono/src/drop_specialization.rs
+++ b/crates/compiler/mono/src/drop_specialization.rs
@@ -1539,6 +1539,7 @@ fn low_level_no_rc(lowlevel: &LowLevel) -> RC {
         StrGetUnsafe | ListGetUnsafe => RC::NoRc,
         ListConcat => RC::Rc,
         StrConcat => RC::Rc,
+        StrConcatUtf8 => RC::Rc,
         StrSubstringUnsafe => RC::Rc,
         StrReserve => RC::Rc,
         StrTrim => RC::Rc,

--- a/crates/compiler/mono/src/drop_specialization.rs
+++ b/crates/compiler/mono/src/drop_specialization.rs
@@ -1539,7 +1539,7 @@ fn low_level_no_rc(lowlevel: &LowLevel) -> RC {
         StrGetUnsafe | ListGetUnsafe => RC::NoRc,
         ListConcat => RC::Rc,
         StrConcat => RC::Rc,
-        StrConcatUtf8 => RC::Rc,
+        ListConcatUtf8 => RC::Rc,
         StrSubstringUnsafe => RC::Rc,
         StrReserve => RC::Rc,
         StrTrim => RC::Rc,

--- a/crates/compiler/mono/src/inc_dec.rs
+++ b/crates/compiler/mono/src/inc_dec.rs
@@ -1288,7 +1288,7 @@ pub(crate) fn lowlevel_borrow_signature(op: LowLevel) -> &'static [Ownership] {
         StrGetUnsafe | ListGetUnsafe => &[BORROWED, IRRELEVANT],
         ListConcat => &[OWNED, OWNED],
         StrConcat => &[OWNED, BORROWED],
-        StrConcatUtf8 => &[OWNED, BORROWED],
+        ListConcatUtf8 => &[OWNED, BORROWED],
         StrSubstringUnsafe => &[OWNED, IRRELEVANT, IRRELEVANT],
         StrReserve => &[OWNED, IRRELEVANT],
         StrTrim => &[OWNED],

--- a/crates/compiler/mono/src/inc_dec.rs
+++ b/crates/compiler/mono/src/inc_dec.rs
@@ -1288,6 +1288,7 @@ pub(crate) fn lowlevel_borrow_signature(op: LowLevel) -> &'static [Ownership] {
         StrGetUnsafe | ListGetUnsafe => &[BORROWED, IRRELEVANT],
         ListConcat => &[OWNED, OWNED],
         StrConcat => &[OWNED, BORROWED],
+        StrConcatUtf8 => &[OWNED, BORROWED],
         StrSubstringUnsafe => &[OWNED, IRRELEVANT, IRRELEVANT],
         StrReserve => &[OWNED, IRRELEVANT],
         StrTrim => &[OWNED],

--- a/crates/compiler/solve/tests/solve_expr.rs
+++ b/crates/compiler/solve/tests/solve_expr.rs
@@ -170,11 +170,11 @@ mod solve_expr {
     }
 
     #[test]
-    fn string_concat_utf8() {
+    fn list_concat_utf8() {
         infer_eq_without_problem(
             indoc!(
                 r"
-                Str.concatUtf8
+                List.concatUtf8
                 "
             ),
             "List U8, Str -> List U8",

--- a/crates/compiler/solve/tests/solve_expr.rs
+++ b/crates/compiler/solve/tests/solve_expr.rs
@@ -169,6 +169,18 @@ mod solve_expr {
         );
     }
 
+    #[test]
+    fn string_concat_utf8() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                Str.concatUtf8
+                "
+            ),
+            "List U8, Str -> List U8",
+        )
+    }
+
     // LIST
 
     #[test]

--- a/crates/compiler/test_gen/src/gen_list.rs
+++ b/crates/compiler/test_gen/src/gen_list.rs
@@ -4123,3 +4123,15 @@ mod pattern_match {
         )
     }
 }
+
+#[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm", feature = "gen-dev"))]
+fn list_concat_utf8() {
+    assert_evals_to!(
+        r#"
+        List.concatUtf8 [1, 2, 3, 4] "🐦"
+        "#,
+        RocList::from_slice(&[1u8, 2, 3, 4, 240, 159, 144, 166]),
+        RocList<u8>
+    )
+}

--- a/crates/compiler/test_gen/src/gen_str.rs
+++ b/crates/compiler/test_gen/src/gen_str.rs
@@ -1988,15 +1988,3 @@ fn str_contains_self() {
         bool
     );
 }
-
-#[test]
-#[cfg(any(feature = "gen-llvm", feature = "gen-wasm", feature = "gen-dev"))]
-fn str_concat_utf8() {
-    assert_evals_to!(
-        r#"
-        Str.concatUtf8 [1, 2, 3, 4] "🐦"
-        "#,
-        RocList::from_slice(&[1u8, 2, 3, 4, 240, 159, 144, 166]),
-        RocList<u8>
-    )
-}

--- a/crates/compiler/test_gen/src/gen_str.rs
+++ b/crates/compiler/test_gen/src/gen_str.rs
@@ -1988,3 +1988,15 @@ fn str_contains_self() {
         bool
     );
 }
+
+#[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm", feature = "gen-dev"))]
+fn str_concat_utf8() {
+    assert_evals_to!(
+        r#"
+        Str.concatUtf8 [1, 2, 3, 4] "🐦"
+        "#,
+        RocList::from_slice(&[1u8, 2, 3, 4, 240, 159, 144, 166]),
+        RocList<u8>
+    )
+}

--- a/crates/compiler/test_mono/generated/anonymous_closure_in_polymorphic_expression_issue_4717.txt
+++ b/crates/compiler/test_mono/generated/anonymous_closure_in_polymorphic_expression_issue_4717.txt
@@ -2,80 +2,80 @@ procedure Bool.11 (#Attr.2, #Attr.3):
     let Bool.23 : Int1 = lowlevel Eq #Attr.2 #Attr.3;
     ret Bool.23;
 
-procedure List.103 (List.487, List.488, List.489):
-    let List.590 : U64 = 0i64;
-    let List.591 : U64 = CallByName List.6 List.487;
-    let List.589 : [C U64, C U64] = CallByName List.80 List.487 List.488 List.489 List.590 List.591;
-    ret List.589;
+procedure List.104 (List.488, List.489, List.490):
+    let List.592 : U64 = 0i64;
+    let List.593 : U64 = CallByName List.6 List.488;
+    let List.591 : [C U64, C U64] = CallByName List.80 List.488 List.489 List.490 List.592 List.593;
+    ret List.591;
 
-procedure List.26 (List.200, List.201, List.202):
-    let List.583 : [C U64, C U64] = CallByName List.103 List.200 List.201 List.202;
-    let List.586 : U8 = 1i64;
-    let List.587 : U8 = GetTagId List.583;
-    let List.588 : Int1 = lowlevel Eq List.586 List.587;
-    if List.588 then
-        let List.203 : U64 = UnionAtIndex (Id 1) (Index 0) List.583;
-        ret List.203;
-    else
-        let List.204 : U64 = UnionAtIndex (Id 0) (Index 0) List.583;
+procedure List.26 (List.201, List.202, List.203):
+    let List.585 : [C U64, C U64] = CallByName List.104 List.201 List.202 List.203;
+    let List.588 : U8 = 1i64;
+    let List.589 : U8 = GetTagId List.585;
+    let List.590 : Int1 = lowlevel Eq List.588 List.589;
+    if List.590 then
+        let List.204 : U64 = UnionAtIndex (Id 1) (Index 0) List.585;
         ret List.204;
+    else
+        let List.205 : U64 = UnionAtIndex (Id 0) (Index 0) List.585;
+        ret List.205;
 
-procedure List.38 (List.343, List.344):
-    let List.582 : U64 = CallByName List.6 List.343;
-    let List.345 : U64 = CallByName Num.77 List.582 List.344;
-    let List.572 : List U8 = CallByName List.43 List.343 List.345;
-    ret List.572;
+procedure List.38 (List.344, List.345):
+    let List.584 : U64 = CallByName List.6 List.344;
+    let List.346 : U64 = CallByName Num.77 List.584 List.345;
+    let List.574 : List U8 = CallByName List.43 List.344 List.346;
+    ret List.574;
 
-procedure List.43 (List.341, List.342):
-    let List.580 : U64 = CallByName List.6 List.341;
-    let List.579 : U64 = CallByName Num.77 List.580 List.342;
-    let List.574 : {U64, U64} = Struct {List.342, List.579};
-    let List.573 : List U8 = CallByName List.49 List.341 List.574;
-    ret List.573;
-
-procedure List.49 (List.419, List.420):
-    let List.576 : U64 = StructAtIndex 1 List.420;
-    let List.577 : U64 = StructAtIndex 0 List.420;
-    let List.575 : List U8 = CallByName List.72 List.419 List.576 List.577;
+procedure List.43 (List.342, List.343):
+    let List.582 : U64 = CallByName List.6 List.342;
+    let List.581 : U64 = CallByName Num.77 List.582 List.343;
+    let List.576 : {U64, U64} = Struct {List.343, List.581};
+    let List.575 : List U8 = CallByName List.49 List.342 List.576;
     ret List.575;
 
+procedure List.49 (List.420, List.421):
+    let List.578 : U64 = StructAtIndex 1 List.421;
+    let List.579 : U64 = StructAtIndex 0 List.421;
+    let List.577 : List U8 = CallByName List.72 List.420 List.578 List.579;
+    ret List.577;
+
 procedure List.6 (#Attr.2):
-    let List.581 : U64 = lowlevel ListLenU64 #Attr.2;
-    ret List.581;
+    let List.583 : U64 = lowlevel ListLenU64 #Attr.2;
+    ret List.583;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.604 : U8 = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.604;
+    let List.606 : U8 = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.606;
 
 procedure List.72 (#Attr.2, #Attr.3, #Attr.4):
-    let List.578 : List U8 = lowlevel ListSublist #Attr.2 #Attr.3 #Attr.4;
-    ret List.578;
+    let List.580 : List U8 = lowlevel ListSublist #Attr.2 #Attr.3 #Attr.4;
+    ret List.580;
 
 procedure List.80 (#Derived_gen.0, #Derived_gen.1, #Derived_gen.2, #Derived_gen.3, #Derived_gen.4):
-    joinpoint List.592 List.490 List.491 List.492 List.493 List.494:
-        let List.594 : Int1 = CallByName Num.22 List.493 List.494;
-        if List.594 then
-            let List.603 : U8 = CallByName List.66 List.490 List.493;
-            let List.595 : [C U64, C U64] = CallByName Test.4 List.491 List.603;
-            let List.600 : U8 = 1i64;
-            let List.601 : U8 = GetTagId List.595;
-            let List.602 : Int1 = lowlevel Eq List.600 List.601;
-            if List.602 then
-                let List.495 : U64 = UnionAtIndex (Id 1) (Index 0) List.595;
-                let List.598 : U64 = 1i64;
-                let List.597 : U64 = CallByName Num.51 List.493 List.598;
-                jump List.592 List.490 List.495 List.492 List.597 List.494;
+    joinpoint List.594 List.491 List.492 List.493 List.494 List.495:
+        let List.596 : Int1 = CallByName Num.22 List.494 List.495;
+        if List.596 then
+            let List.605 : U8 = CallByName List.66 List.491 List.494;
+            let List.597 : [C U64, C U64] = CallByName Test.4 List.492 List.605;
+            let List.602 : U8 = 1i64;
+            let List.603 : U8 = GetTagId List.597;
+            let List.604 : Int1 = lowlevel Eq List.602 List.603;
+            if List.604 then
+                let List.496 : U64 = UnionAtIndex (Id 1) (Index 0) List.597;
+                let List.600 : U64 = 1i64;
+                let List.599 : U64 = CallByName Num.51 List.494 List.600;
+                jump List.594 List.491 List.496 List.493 List.599 List.495;
             else
-                dec List.490;
-                let List.496 : U64 = UnionAtIndex (Id 0) (Index 0) List.595;
-                let List.599 : [C U64, C U64] = TagId(0) List.496;
-                ret List.599;
+                dec List.491;
+                let List.497 : U64 = UnionAtIndex (Id 0) (Index 0) List.597;
+                let List.601 : [C U64, C U64] = TagId(0) List.497;
+                ret List.601;
         else
-            dec List.490;
-            let List.593 : [C U64, C U64] = TagId(1) List.491;
-            ret List.593;
+            dec List.491;
+            let List.595 : [C U64, C U64] = TagId(1) List.492;
+            ret List.595;
     in
-    jump List.592 #Derived_gen.0 #Derived_gen.1 #Derived_gen.2 #Derived_gen.3 #Derived_gen.4;
+    jump List.594 #Derived_gen.0 #Derived_gen.1 #Derived_gen.2 #Derived_gen.3 #Derived_gen.4;
 
 procedure Num.22 (#Attr.2, #Attr.3):
     let Num.282 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/call_function_in_empty_list.txt
+++ b/crates/compiler/test_mono/generated/call_function_in_empty_list.txt
@@ -1,7 +1,7 @@
 procedure List.5 (#Attr.2, #Attr.3):
-    let List.572 : List {} = lowlevel ListMap { xs: `#Attr.#arg1` } #Attr.2 Test.2 #Attr.3;
+    let List.574 : List {} = lowlevel ListMap { xs: `#Attr.#arg1` } #Attr.2 Test.2 #Attr.3;
     decref #Attr.2;
-    ret List.572;
+    ret List.574;
 
 procedure Test.2 (Test.3):
     let Test.7 : {} = Struct {};

--- a/crates/compiler/test_mono/generated/call_function_in_empty_list_unbound.txt
+++ b/crates/compiler/test_mono/generated/call_function_in_empty_list_unbound.txt
@@ -1,7 +1,7 @@
 procedure List.5 (#Attr.2, #Attr.3):
-    let List.572 : List [] = lowlevel ListMap { xs: `#Attr.#arg1` } #Attr.2 Test.2 #Attr.3;
+    let List.574 : List [] = lowlevel ListMap { xs: `#Attr.#arg1` } #Attr.2 Test.2 #Attr.3;
     decref #Attr.2;
-    ret List.572;
+    ret List.574;
 
 procedure Test.2 (Test.3):
     let Test.7 : {} = Struct {};

--- a/crates/compiler/test_mono/generated/capture_void_layout_task.txt
+++ b/crates/compiler/test_mono/generated/capture_void_layout_task.txt
@@ -1,31 +1,31 @@
-procedure List.18 (List.159, List.160, List.161):
-    let List.573 : U64 = 0i64;
-    let List.574 : U64 = CallByName List.6 List.159;
-    let List.572 : [<r>C {}, C *self {{}, []}] = CallByName List.91 List.159 List.160 List.161 List.573 List.574;
-    ret List.572;
+procedure List.18 (List.160, List.161, List.162):
+    let List.575 : U64 = 0i64;
+    let List.576 : U64 = CallByName List.6 List.160;
+    let List.574 : [<r>C {}, C *self {{}, []}] = CallByName List.92 List.160 List.161 List.162 List.575 List.576;
+    ret List.574;
 
 procedure List.6 (#Attr.2):
-    let List.583 : U64 = lowlevel ListLenU64 #Attr.2;
-    ret List.583;
+    let List.585 : U64 = lowlevel ListLenU64 #Attr.2;
+    ret List.585;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.582 : [] = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.582;
+    let List.584 : [] = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.584;
 
-procedure List.91 (#Derived_gen.9, #Derived_gen.10, #Derived_gen.11, #Derived_gen.12, #Derived_gen.13):
-    joinpoint List.575 List.162 List.163 List.164 List.165 List.166:
-        let List.577 : Int1 = CallByName Num.22 List.165 List.166;
-        if List.577 then
-            let List.581 : [] = CallByName List.66 List.162 List.165;
-            let List.167 : [<r>C {}, C *self {{}, []}] = CallByName Test.29 List.163 List.581 List.164;
-            let List.580 : U64 = 1i64;
-            let List.579 : U64 = CallByName Num.51 List.165 List.580;
-            jump List.575 List.162 List.167 List.164 List.579 List.166;
+procedure List.92 (#Derived_gen.13, #Derived_gen.14, #Derived_gen.15, #Derived_gen.16, #Derived_gen.17):
+    joinpoint List.577 List.163 List.164 List.165 List.166 List.167:
+        let List.579 : Int1 = CallByName Num.22 List.166 List.167;
+        if List.579 then
+            let List.583 : [] = CallByName List.66 List.163 List.166;
+            let List.168 : [<r>C {}, C *self {{}, []}] = CallByName Test.29 List.164 List.583 List.165;
+            let List.582 : U64 = 1i64;
+            let List.581 : U64 = CallByName Num.51 List.166 List.582;
+            jump List.577 List.163 List.168 List.165 List.581 List.167;
         else
-            dec List.162;
-            ret List.163;
+            dec List.163;
+            ret List.164;
     in
-    jump List.575 #Derived_gen.9 #Derived_gen.10 #Derived_gen.11 #Derived_gen.12 #Derived_gen.13;
+    jump List.577 #Derived_gen.13 #Derived_gen.14 #Derived_gen.15 #Derived_gen.16 #Derived_gen.17;
 
 procedure Num.22 (#Attr.2, #Attr.3):
     let Num.280 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/choose_correct_recursion_var_under_record.txt
+++ b/crates/compiler/test_mono/generated/choose_correct_recursion_var_under_record.txt
@@ -2,49 +2,49 @@ procedure Bool.1 ():
     let Bool.24 : Int1 = false;
     ret Bool.24;
 
-procedure List.2 (List.107, List.108):
-    let List.586 : U64 = CallByName List.6 List.107;
-    let List.582 : Int1 = CallByName Num.22 List.108 List.586;
-    if List.582 then
-        let List.584 : Str = CallByName List.66 List.107 List.108;
-        inc List.584;
-        dec List.107;
-        let List.583 : [C {}, C Str] = TagId(1) List.584;
-        ret List.583;
+procedure List.2 (List.108, List.109):
+    let List.588 : U64 = CallByName List.6 List.108;
+    let List.584 : Int1 = CallByName Num.22 List.109 List.588;
+    if List.584 then
+        let List.586 : Str = CallByName List.66 List.108 List.109;
+        inc List.586;
+        dec List.108;
+        let List.585 : [C {}, C Str] = TagId(1) List.586;
+        ret List.585;
     else
-        dec List.107;
-        let List.581 : {} = Struct {};
-        let List.580 : [C {}, C Str] = TagId(0) List.581;
-        ret List.580;
+        dec List.108;
+        let List.583 : {} = Struct {};
+        let List.582 : [C {}, C Str] = TagId(0) List.583;
+        ret List.582;
 
 procedure List.5 (#Attr.2, #Attr.3):
-    let List.588 : List Str = lowlevel ListMap { xs: `#Attr.#arg1` } #Attr.2 Test.10 #Attr.3;
+    let List.590 : List Str = lowlevel ListMap { xs: `#Attr.#arg1` } #Attr.2 Test.10 #Attr.3;
     decref #Attr.2;
-    ret List.588;
+    ret List.590;
 
 procedure List.6 (#Attr.2):
-    let List.587 : U64 = lowlevel ListLenU64 #Attr.2;
-    ret List.587;
+    let List.589 : U64 = lowlevel ListLenU64 #Attr.2;
+    ret List.589;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.585 : Str = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.585;
+    let List.587 : Str = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.587;
 
-procedure List.9 (List.334):
-    let List.579 : U64 = 0i64;
-    let List.572 : [C {}, C Str] = CallByName List.2 List.334 List.579;
-    let List.576 : U8 = 1i64;
-    let List.577 : U8 = GetTagId List.572;
-    let List.578 : Int1 = lowlevel Eq List.576 List.577;
-    if List.578 then
-        let List.335 : Str = UnionAtIndex (Id 1) (Index 0) List.572;
-        let List.573 : [C {}, C Str] = TagId(1) List.335;
-        ret List.573;
+procedure List.9 (List.335):
+    let List.581 : U64 = 0i64;
+    let List.574 : [C {}, C Str] = CallByName List.2 List.335 List.581;
+    let List.578 : U8 = 1i64;
+    let List.579 : U8 = GetTagId List.574;
+    let List.580 : Int1 = lowlevel Eq List.578 List.579;
+    if List.580 then
+        let List.336 : Str = UnionAtIndex (Id 1) (Index 0) List.574;
+        let List.575 : [C {}, C Str] = TagId(1) List.336;
+        ret List.575;
     else
-        dec List.572;
-        let List.575 : {} = Struct {};
-        let List.574 : [C {}, C Str] = TagId(0) List.575;
-        ret List.574;
+        dec List.574;
+        let List.577 : {} = Struct {};
+        let List.576 : [C {}, C Str] = TagId(0) List.577;
+        ret List.576;
 
 procedure Num.22 (#Attr.2, #Attr.3):
     let Num.279 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/closure_in_list.txt
+++ b/crates/compiler/test_mono/generated/closure_in_list.txt
@@ -1,6 +1,6 @@
 procedure List.6 (#Attr.2):
-    let List.572 : U64 = lowlevel ListLenU64 #Attr.2;
-    ret List.572;
+    let List.574 : U64 = lowlevel ListLenU64 #Attr.2;
+    ret List.574;
 
 procedure Test.1 (Test.5):
     let Test.2 : I64 = 41i64;

--- a/crates/compiler/test_mono/generated/compose_recursive_lambda_set_productive_nullable_wrapped.txt
+++ b/crates/compiler/test_mono/generated/compose_recursive_lambda_set_productive_nullable_wrapped.txt
@@ -2,34 +2,34 @@ procedure Bool.2 ():
     let Bool.23 : Int1 = true;
     ret Bool.23;
 
-procedure List.18 (List.159, List.160, List.161):
-    let List.573 : U64 = 0i64;
-    let List.574 : U64 = CallByName List.6 List.159;
-    let List.572 : [<rnw><null>, C *self Int1, C *self Int1] = CallByName List.91 List.159 List.160 List.161 List.573 List.574;
-    ret List.572;
+procedure List.18 (List.160, List.161, List.162):
+    let List.575 : U64 = 0i64;
+    let List.576 : U64 = CallByName List.6 List.160;
+    let List.574 : [<rnw><null>, C *self Int1, C *self Int1] = CallByName List.92 List.160 List.161 List.162 List.575 List.576;
+    ret List.574;
 
 procedure List.6 (#Attr.2):
-    let List.583 : U64 = lowlevel ListLenU64 #Attr.2;
-    ret List.583;
+    let List.585 : U64 = lowlevel ListLenU64 #Attr.2;
+    ret List.585;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.582 : Int1 = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.582;
+    let List.584 : Int1 = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.584;
 
-procedure List.91 (#Derived_gen.7, #Derived_gen.8, #Derived_gen.9, #Derived_gen.10, #Derived_gen.11):
-    joinpoint List.575 List.162 List.163 List.164 List.165 List.166:
-        let List.577 : Int1 = CallByName Num.22 List.165 List.166;
-        if List.577 then
-            let List.581 : Int1 = CallByName List.66 List.162 List.165;
-            let List.167 : [<rnw><null>, C *self Int1, C *self Int1] = CallByName Test.6 List.163 List.581 List.164;
-            let List.580 : U64 = 1i64;
-            let List.579 : U64 = CallByName Num.51 List.165 List.580;
-            jump List.575 List.162 List.167 List.164 List.579 List.166;
+procedure List.92 (#Derived_gen.5, #Derived_gen.6, #Derived_gen.7, #Derived_gen.8, #Derived_gen.9):
+    joinpoint List.577 List.163 List.164 List.165 List.166 List.167:
+        let List.579 : Int1 = CallByName Num.22 List.166 List.167;
+        if List.579 then
+            let List.583 : Int1 = CallByName List.66 List.163 List.166;
+            let List.168 : [<rnw><null>, C *self Int1, C *self Int1] = CallByName Test.6 List.164 List.583 List.165;
+            let List.582 : U64 = 1i64;
+            let List.581 : U64 = CallByName Num.51 List.166 List.582;
+            jump List.577 List.163 List.168 List.165 List.581 List.167;
         else
-            dec List.162;
-            ret List.163;
+            dec List.163;
+            ret List.164;
     in
-    jump List.575 #Derived_gen.7 #Derived_gen.8 #Derived_gen.9 #Derived_gen.10 #Derived_gen.11;
+    jump List.577 #Derived_gen.5 #Derived_gen.6 #Derived_gen.7 #Derived_gen.8 #Derived_gen.9;
 
 procedure Num.22 (#Attr.2, #Attr.3):
     let Num.280 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/dict.txt
+++ b/crates/compiler/test_mono/generated/dict.txt
@@ -26,8 +26,8 @@ procedure Dict.45 ():
     ret Dict.735;
 
 procedure List.6 (#Attr.2):
-    let List.572 : U64 = lowlevel ListLenU64 #Attr.2;
-    ret List.572;
+    let List.574 : U64 = lowlevel ListLenU64 #Attr.2;
+    ret List.574;
 
 procedure Num.75 (#Attr.2, #Attr.3):
     let Num.279 : U8 = lowlevel NumSubWrap #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/empty_list_of_function_type.txt
+++ b/crates/compiler/test_mono/generated/empty_list_of_function_type.txt
@@ -2,27 +2,27 @@ procedure Bool.1 ():
     let Bool.23 : Int1 = false;
     ret Bool.23;
 
-procedure List.2 (List.107, List.108):
-    let List.578 : U64 = CallByName List.6 List.107;
-    let List.574 : Int1 = CallByName Num.22 List.108 List.578;
-    if List.574 then
-        let List.576 : {} = CallByName List.66 List.107 List.108;
-        dec List.107;
-        let List.575 : [C {}, C {}] = TagId(1) List.576;
-        ret List.575;
+procedure List.2 (List.108, List.109):
+    let List.580 : U64 = CallByName List.6 List.108;
+    let List.576 : Int1 = CallByName Num.22 List.109 List.580;
+    if List.576 then
+        let List.578 : {} = CallByName List.66 List.108 List.109;
+        dec List.108;
+        let List.577 : [C {}, C {}] = TagId(1) List.578;
+        ret List.577;
     else
-        dec List.107;
-        let List.573 : {} = Struct {};
-        let List.572 : [C {}, C {}] = TagId(0) List.573;
-        ret List.572;
+        dec List.108;
+        let List.575 : {} = Struct {};
+        let List.574 : [C {}, C {}] = TagId(0) List.575;
+        ret List.574;
 
 procedure List.6 (#Attr.2):
-    let List.579 : U64 = lowlevel ListLenU64 #Attr.2;
-    ret List.579;
+    let List.581 : U64 = lowlevel ListLenU64 #Attr.2;
+    ret List.581;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.577 : {} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.577;
+    let List.579 : {} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.579;
 
 procedure Num.22 (#Attr.2, #Attr.3):
     let Num.279 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/encode.txt
+++ b/crates/compiler/test_mono/generated/encode.txt
@@ -1,16 +1,16 @@
-procedure List.4 (List.123, List.124):
-    let List.575 : U64 = 1i64;
-    let List.573 : List U8 = CallByName List.70 List.123 List.575;
-    let List.572 : List U8 = CallByName List.71 List.573 List.124;
-    ret List.572;
+procedure List.4 (List.124, List.125):
+    let List.577 : U64 = 1i64;
+    let List.575 : List U8 = CallByName List.70 List.124 List.577;
+    let List.574 : List U8 = CallByName List.71 List.575 List.125;
+    ret List.574;
 
 procedure List.70 (#Attr.2, #Attr.3):
-    let List.576 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
-    ret List.576;
+    let List.578 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
+    ret List.578;
 
 procedure List.71 (#Attr.2, #Attr.3):
-    let List.574 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
-    ret List.574;
+    let List.576 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
+    ret List.576;
 
 procedure Test.23 (Test.24, Test.35, Test.22):
     let Test.37 : List U8 = CallByName List.4 Test.24 Test.22;

--- a/crates/compiler/test_mono/generated/encode_derived_nested_record_string.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_nested_record_string.txt
@@ -69,189 +69,189 @@ procedure Encode.26 (Encode.105, Encode.106):
     let Encode.108 : List U8 = CallByName Encode.24 Encode.109 Encode.110 Encode.106;
     ret Encode.108;
 
-procedure List.103 (List.487, List.488, List.489):
-    let List.685 : U64 = 0i64;
-    let List.686 : U64 = CallByName List.6 List.487;
-    let List.684 : [C {U64, Int1}, C {U64, Int1}] = CallByName List.80 List.487 List.488 List.489 List.685 List.686;
-    ret List.684;
+procedure List.104 (List.488, List.489, List.490):
+    let List.687 : U64 = 0i64;
+    let List.688 : U64 = CallByName List.6 List.488;
+    let List.686 : [C {U64, Int1}, C {U64, Int1}] = CallByName List.80 List.488 List.489 List.490 List.687 List.688;
+    ret List.686;
 
-procedure List.18 (List.159, List.160, List.161):
-    let List.593 : U64 = 0i64;
-    let List.594 : U64 = CallByName List.6 List.159;
-    let List.592 : {List U8, U64} = CallByName List.91 List.159 List.160 List.161 List.593 List.594;
-    ret List.592;
+procedure List.18 (List.160, List.161, List.162):
+    let List.595 : U64 = 0i64;
+    let List.596 : U64 = CallByName List.6 List.160;
+    let List.594 : {List U8, U64} = CallByName List.92 List.160 List.161 List.162 List.595 List.596;
+    ret List.594;
 
-procedure List.18 (List.159, List.160, List.161):
-    let List.628 : U64 = 0i64;
-    let List.629 : U64 = CallByName List.6 List.159;
-    let List.627 : {List U8, U64} = CallByName List.91 List.159 List.160 List.161 List.628 List.629;
-    ret List.627;
+procedure List.18 (List.160, List.161, List.162):
+    let List.630 : U64 = 0i64;
+    let List.631 : U64 = CallByName List.6 List.160;
+    let List.629 : {List U8, U64} = CallByName List.92 List.160 List.161 List.162 List.630 List.631;
+    ret List.629;
 
-procedure List.18 (List.159, List.160, List.161):
-    let List.640 : U64 = 0i64;
-    let List.641 : U64 = CallByName List.6 List.159;
-    let List.639 : List U8 = CallByName List.91 List.159 List.160 List.161 List.640 List.641;
-    ret List.639;
+procedure List.18 (List.160, List.161, List.162):
+    let List.642 : U64 = 0i64;
+    let List.643 : U64 = CallByName List.6 List.160;
+    let List.641 : List U8 = CallByName List.92 List.160 List.161 List.162 List.642 List.643;
+    ret List.641;
 
-procedure List.26 (List.200, List.201, List.202):
-    let List.678 : [C {U64, Int1}, C {U64, Int1}] = CallByName List.103 List.200 List.201 List.202;
-    let List.681 : U8 = 1i64;
-    let List.682 : U8 = GetTagId List.678;
-    let List.683 : Int1 = lowlevel Eq List.681 List.682;
-    if List.683 then
-        let List.203 : {U64, Int1} = UnionAtIndex (Id 1) (Index 0) List.678;
-        ret List.203;
-    else
-        let List.204 : {U64, Int1} = UnionAtIndex (Id 0) (Index 0) List.678;
+procedure List.26 (List.201, List.202, List.203):
+    let List.680 : [C {U64, Int1}, C {U64, Int1}] = CallByName List.104 List.201 List.202 List.203;
+    let List.683 : U8 = 1i64;
+    let List.684 : U8 = GetTagId List.680;
+    let List.685 : Int1 = lowlevel Eq List.683 List.684;
+    if List.685 then
+        let List.204 : {U64, Int1} = UnionAtIndex (Id 1) (Index 0) List.680;
         ret List.204;
-
-procedure List.4 (List.123, List.124):
-    let List.626 : U64 = 1i64;
-    let List.625 : List U8 = CallByName List.70 List.123 List.626;
-    let List.624 : List U8 = CallByName List.71 List.625 List.124;
-    ret List.624;
-
-procedure List.49 (List.419, List.420):
-    let List.669 : U64 = StructAtIndex 1 List.420;
-    let List.670 : U64 = StructAtIndex 0 List.420;
-    let List.668 : List U8 = CallByName List.72 List.419 List.669 List.670;
-    ret List.668;
-
-procedure List.52 (List.434, List.435):
-    let List.436 : U64 = CallByName List.6 List.434;
-    joinpoint List.676 List.437:
-        let List.674 : U64 = 0i64;
-        let List.673 : {U64, U64} = Struct {List.437, List.674};
-        inc List.434;
-        let List.438 : List U8 = CallByName List.49 List.434 List.673;
-        let List.672 : U64 = CallByName Num.75 List.436 List.437;
-        let List.667 : {U64, U64} = Struct {List.672, List.437};
-        let List.439 : List U8 = CallByName List.49 List.434 List.667;
-        let List.666 : {List U8, List U8} = Struct {List.438, List.439};
-        ret List.666;
-    in
-    let List.677 : Int1 = CallByName Num.24 List.436 List.435;
-    if List.677 then
-        jump List.676 List.435;
     else
-        jump List.676 List.436;
+        let List.205 : {U64, Int1} = UnionAtIndex (Id 0) (Index 0) List.680;
+        ret List.205;
+
+procedure List.4 (List.124, List.125):
+    let List.628 : U64 = 1i64;
+    let List.627 : List U8 = CallByName List.70 List.124 List.628;
+    let List.626 : List U8 = CallByName List.71 List.627 List.125;
+    ret List.626;
+
+procedure List.49 (List.420, List.421):
+    let List.671 : U64 = StructAtIndex 1 List.421;
+    let List.672 : U64 = StructAtIndex 0 List.421;
+    let List.670 : List U8 = CallByName List.72 List.420 List.671 List.672;
+    ret List.670;
+
+procedure List.52 (List.435, List.436):
+    let List.437 : U64 = CallByName List.6 List.435;
+    joinpoint List.678 List.438:
+        let List.676 : U64 = 0i64;
+        let List.675 : {U64, U64} = Struct {List.438, List.676};
+        inc List.435;
+        let List.439 : List U8 = CallByName List.49 List.435 List.675;
+        let List.674 : U64 = CallByName Num.75 List.437 List.438;
+        let List.669 : {U64, U64} = Struct {List.674, List.438};
+        let List.440 : List U8 = CallByName List.49 List.435 List.669;
+        let List.668 : {List U8, List U8} = Struct {List.439, List.440};
+        ret List.668;
+    in
+    let List.679 : Int1 = CallByName Num.24 List.437 List.436;
+    if List.679 then
+        jump List.678 List.436;
+    else
+        jump List.678 List.437;
 
 procedure List.6 (#Attr.2):
-    let List.606 : U64 = lowlevel ListLenU64 #Attr.2;
-    ret List.606;
-
-procedure List.6 (#Attr.2):
-    let List.661 : U64 = lowlevel ListLenU64 #Attr.2;
-    ret List.661;
+    let List.608 : U64 = lowlevel ListLenU64 #Attr.2;
+    ret List.608;
 
 procedure List.6 (#Attr.2):
     let List.663 : U64 = lowlevel ListLenU64 #Attr.2;
     ret List.663;
 
-procedure List.66 (#Attr.2, #Attr.3):
-    let List.602 : {Str, Str} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.602;
-
-procedure List.66 (#Attr.2, #Attr.3):
-    let List.637 : {Str, Str} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.637;
-
-procedure List.66 (#Attr.2, #Attr.3):
-    let List.649 : U8 = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.649;
-
-procedure List.68 (#Attr.2):
-    let List.665 : List U8 = lowlevel ListWithCapacity #Attr.2;
+procedure List.6 (#Attr.2):
+    let List.665 : U64 = lowlevel ListLenU64 #Attr.2;
     ret List.665;
 
+procedure List.66 (#Attr.2, #Attr.3):
+    let List.604 : {Str, Str} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.604;
+
+procedure List.66 (#Attr.2, #Attr.3):
+    let List.639 : {Str, Str} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.639;
+
+procedure List.66 (#Attr.2, #Attr.3):
+    let List.651 : U8 = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.651;
+
+procedure List.68 (#Attr.2):
+    let List.667 : List U8 = lowlevel ListWithCapacity #Attr.2;
+    ret List.667;
+
 procedure List.70 (#Attr.2, #Attr.3):
-    let List.611 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
-    ret List.611;
+    let List.613 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
+    ret List.613;
 
 procedure List.71 (#Attr.2, #Attr.3):
-    let List.609 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
-    ret List.609;
+    let List.611 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
+    ret List.611;
 
 procedure List.72 (#Attr.2, #Attr.3, #Attr.4):
-    let List.671 : List U8 = lowlevel ListSublist #Attr.2 #Attr.3 #Attr.4;
-    ret List.671;
+    let List.673 : List U8 = lowlevel ListSublist #Attr.2 #Attr.3 #Attr.4;
+    ret List.673;
 
 procedure List.8 (#Attr.2, #Attr.3):
-    let List.660 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
-    ret List.660;
+    let List.662 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
+    ret List.662;
 
 procedure List.80 (#Derived_gen.26, #Derived_gen.27, #Derived_gen.28, #Derived_gen.29, #Derived_gen.30):
-    joinpoint List.687 List.490 List.491 List.492 List.493 List.494:
-        let List.689 : Int1 = CallByName Num.22 List.493 List.494;
-        if List.689 then
-            let List.698 : U8 = CallByName List.66 List.490 List.493;
-            let List.690 : [C {U64, Int1}, C {U64, Int1}] = CallByName TotallyNotJson.157 List.491 List.698;
-            let List.695 : U8 = 1i64;
-            let List.696 : U8 = GetTagId List.690;
-            let List.697 : Int1 = lowlevel Eq List.695 List.696;
-            if List.697 then
-                let List.495 : {U64, Int1} = UnionAtIndex (Id 1) (Index 0) List.690;
-                let List.693 : U64 = 1i64;
-                let List.692 : U64 = CallByName Num.51 List.493 List.693;
-                jump List.687 List.490 List.495 List.492 List.692 List.494;
+    joinpoint List.689 List.491 List.492 List.493 List.494 List.495:
+        let List.691 : Int1 = CallByName Num.22 List.494 List.495;
+        if List.691 then
+            let List.700 : U8 = CallByName List.66 List.491 List.494;
+            let List.692 : [C {U64, Int1}, C {U64, Int1}] = CallByName TotallyNotJson.157 List.492 List.700;
+            let List.697 : U8 = 1i64;
+            let List.698 : U8 = GetTagId List.692;
+            let List.699 : Int1 = lowlevel Eq List.697 List.698;
+            if List.699 then
+                let List.496 : {U64, Int1} = UnionAtIndex (Id 1) (Index 0) List.692;
+                let List.695 : U64 = 1i64;
+                let List.694 : U64 = CallByName Num.51 List.494 List.695;
+                jump List.689 List.491 List.496 List.493 List.694 List.495;
             else
-                dec List.490;
-                let List.496 : {U64, Int1} = UnionAtIndex (Id 0) (Index 0) List.690;
-                let List.694 : [C {U64, Int1}, C {U64, Int1}] = TagId(0) List.496;
-                ret List.694;
+                dec List.491;
+                let List.497 : {U64, Int1} = UnionAtIndex (Id 0) (Index 0) List.692;
+                let List.696 : [C {U64, Int1}, C {U64, Int1}] = TagId(0) List.497;
+                ret List.696;
         else
-            dec List.490;
-            let List.688 : [C {U64, Int1}, C {U64, Int1}] = TagId(1) List.491;
-            ret List.688;
+            dec List.491;
+            let List.690 : [C {U64, Int1}, C {U64, Int1}] = TagId(1) List.492;
+            ret List.690;
     in
-    jump List.687 #Derived_gen.26 #Derived_gen.27 #Derived_gen.28 #Derived_gen.29 #Derived_gen.30;
+    jump List.689 #Derived_gen.26 #Derived_gen.27 #Derived_gen.28 #Derived_gen.29 #Derived_gen.30;
 
-procedure List.91 (#Derived_gen.31, #Derived_gen.32, #Derived_gen.33, #Derived_gen.34, #Derived_gen.35):
-    joinpoint List.595 List.162 List.163 List.164 List.165 List.166:
-        let List.597 : Int1 = CallByName Num.22 List.165 List.166;
-        if List.597 then
-            let List.601 : {Str, Str} = CallByName List.66 List.162 List.165;
-            inc List.601;
-            let List.167 : {List U8, U64} = CallByName TotallyNotJson.204 List.163 List.601;
-            let List.600 : U64 = 1i64;
-            let List.599 : U64 = CallByName Num.51 List.165 List.600;
-            jump List.595 List.162 List.167 List.164 List.599 List.166;
+procedure List.92 (#Derived_gen.31, #Derived_gen.32, #Derived_gen.33, #Derived_gen.34, #Derived_gen.35):
+    joinpoint List.597 List.163 List.164 List.165 List.166 List.167:
+        let List.599 : Int1 = CallByName Num.22 List.166 List.167;
+        if List.599 then
+            let List.603 : {Str, Str} = CallByName List.66 List.163 List.166;
+            inc List.603;
+            let List.168 : {List U8, U64} = CallByName TotallyNotJson.204 List.164 List.603;
+            let List.602 : U64 = 1i64;
+            let List.601 : U64 = CallByName Num.51 List.166 List.602;
+            jump List.597 List.163 List.168 List.165 List.601 List.167;
         else
-            dec List.162;
-            ret List.163;
+            dec List.163;
+            ret List.164;
     in
-    jump List.595 #Derived_gen.31 #Derived_gen.32 #Derived_gen.33 #Derived_gen.34 #Derived_gen.35;
+    jump List.597 #Derived_gen.31 #Derived_gen.32 #Derived_gen.33 #Derived_gen.34 #Derived_gen.35;
 
-procedure List.91 (#Derived_gen.36, #Derived_gen.37, #Derived_gen.38, #Derived_gen.39, #Derived_gen.40):
-    joinpoint List.642 List.162 List.163 List.164 List.165 List.166:
-        let List.644 : Int1 = CallByName Num.22 List.165 List.166;
-        if List.644 then
-            let List.648 : U8 = CallByName List.66 List.162 List.165;
-            let List.167 : List U8 = CallByName TotallyNotJson.183 List.163 List.648;
-            let List.647 : U64 = 1i64;
-            let List.646 : U64 = CallByName Num.51 List.165 List.647;
-            jump List.642 List.162 List.167 List.164 List.646 List.166;
+procedure List.92 (#Derived_gen.36, #Derived_gen.37, #Derived_gen.38, #Derived_gen.39, #Derived_gen.40):
+    joinpoint List.632 List.163 List.164 List.165 List.166 List.167:
+        let List.634 : Int1 = CallByName Num.22 List.166 List.167;
+        if List.634 then
+            let List.638 : {Str, Str} = CallByName List.66 List.163 List.166;
+            inc List.638;
+            let List.168 : {List U8, U64} = CallByName TotallyNotJson.204 List.164 List.638;
+            let List.637 : U64 = 1i64;
+            let List.636 : U64 = CallByName Num.51 List.166 List.637;
+            jump List.632 List.163 List.168 List.165 List.636 List.167;
         else
-            dec List.162;
-            ret List.163;
+            dec List.163;
+            ret List.164;
     in
-    jump List.642 #Derived_gen.36 #Derived_gen.37 #Derived_gen.38 #Derived_gen.39 #Derived_gen.40;
+    jump List.632 #Derived_gen.36 #Derived_gen.37 #Derived_gen.38 #Derived_gen.39 #Derived_gen.40;
 
-procedure List.91 (#Derived_gen.50, #Derived_gen.51, #Derived_gen.52, #Derived_gen.53, #Derived_gen.54):
-    joinpoint List.630 List.162 List.163 List.164 List.165 List.166:
-        let List.632 : Int1 = CallByName Num.22 List.165 List.166;
-        if List.632 then
-            let List.636 : {Str, Str} = CallByName List.66 List.162 List.165;
-            inc List.636;
-            let List.167 : {List U8, U64} = CallByName TotallyNotJson.204 List.163 List.636;
-            let List.635 : U64 = 1i64;
-            let List.634 : U64 = CallByName Num.51 List.165 List.635;
-            jump List.630 List.162 List.167 List.164 List.634 List.166;
+procedure List.92 (#Derived_gen.47, #Derived_gen.48, #Derived_gen.49, #Derived_gen.50, #Derived_gen.51):
+    joinpoint List.644 List.163 List.164 List.165 List.166 List.167:
+        let List.646 : Int1 = CallByName Num.22 List.166 List.167;
+        if List.646 then
+            let List.650 : U8 = CallByName List.66 List.163 List.166;
+            let List.168 : List U8 = CallByName TotallyNotJson.183 List.164 List.650;
+            let List.649 : U64 = 1i64;
+            let List.648 : U64 = CallByName Num.51 List.166 List.649;
+            jump List.644 List.163 List.168 List.165 List.648 List.167;
         else
-            dec List.162;
-            ret List.163;
+            dec List.163;
+            ret List.164;
     in
-    jump List.630 #Derived_gen.50 #Derived_gen.51 #Derived_gen.52 #Derived_gen.53 #Derived_gen.54;
+    jump List.644 #Derived_gen.47 #Derived_gen.48 #Derived_gen.49 #Derived_gen.50 #Derived_gen.51;
 
 procedure Num.127 (#Attr.2):
     let Num.295 : U8 = lowlevel NumIntCast #Attr.2;

--- a/crates/compiler/test_mono/generated/encode_derived_record_one_field_string.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_record_one_field_string.txt
@@ -42,159 +42,159 @@ procedure Encode.26 (Encode.105, Encode.106):
     let Encode.108 : List U8 = CallByName Encode.24 Encode.109 Encode.110 Encode.106;
     ret Encode.108;
 
-procedure List.103 (List.487, List.488, List.489):
-    let List.650 : U64 = 0i64;
-    let List.651 : U64 = CallByName List.6 List.487;
-    let List.649 : [C {U64, Int1}, C {U64, Int1}] = CallByName List.80 List.487 List.488 List.489 List.650 List.651;
-    ret List.649;
+procedure List.104 (List.488, List.489, List.490):
+    let List.652 : U64 = 0i64;
+    let List.653 : U64 = CallByName List.6 List.488;
+    let List.651 : [C {U64, Int1}, C {U64, Int1}] = CallByName List.80 List.488 List.489 List.490 List.652 List.653;
+    ret List.651;
 
-procedure List.18 (List.159, List.160, List.161):
-    let List.593 : U64 = 0i64;
-    let List.594 : U64 = CallByName List.6 List.159;
-    let List.592 : {List U8, U64} = CallByName List.91 List.159 List.160 List.161 List.593 List.594;
-    ret List.592;
+procedure List.18 (List.160, List.161, List.162):
+    let List.595 : U64 = 0i64;
+    let List.596 : U64 = CallByName List.6 List.160;
+    let List.594 : {List U8, U64} = CallByName List.92 List.160 List.161 List.162 List.595 List.596;
+    ret List.594;
 
-procedure List.18 (List.159, List.160, List.161):
-    let List.605 : U64 = 0i64;
-    let List.606 : U64 = CallByName List.6 List.159;
-    let List.604 : List U8 = CallByName List.91 List.159 List.160 List.161 List.605 List.606;
-    ret List.604;
+procedure List.18 (List.160, List.161, List.162):
+    let List.607 : U64 = 0i64;
+    let List.608 : U64 = CallByName List.6 List.160;
+    let List.606 : List U8 = CallByName List.92 List.160 List.161 List.162 List.607 List.608;
+    ret List.606;
 
-procedure List.26 (List.200, List.201, List.202):
-    let List.643 : [C {U64, Int1}, C {U64, Int1}] = CallByName List.103 List.200 List.201 List.202;
-    let List.646 : U8 = 1i64;
-    let List.647 : U8 = GetTagId List.643;
-    let List.648 : Int1 = lowlevel Eq List.646 List.647;
-    if List.648 then
-        let List.203 : {U64, Int1} = UnionAtIndex (Id 1) (Index 0) List.643;
-        ret List.203;
-    else
-        let List.204 : {U64, Int1} = UnionAtIndex (Id 0) (Index 0) List.643;
+procedure List.26 (List.201, List.202, List.203):
+    let List.645 : [C {U64, Int1}, C {U64, Int1}] = CallByName List.104 List.201 List.202 List.203;
+    let List.648 : U8 = 1i64;
+    let List.649 : U8 = GetTagId List.645;
+    let List.650 : Int1 = lowlevel Eq List.648 List.649;
+    if List.650 then
+        let List.204 : {U64, Int1} = UnionAtIndex (Id 1) (Index 0) List.645;
         ret List.204;
-
-procedure List.4 (List.123, List.124):
-    let List.591 : U64 = 1i64;
-    let List.590 : List U8 = CallByName List.70 List.123 List.591;
-    let List.589 : List U8 = CallByName List.71 List.590 List.124;
-    ret List.589;
-
-procedure List.49 (List.419, List.420):
-    let List.634 : U64 = StructAtIndex 1 List.420;
-    let List.635 : U64 = StructAtIndex 0 List.420;
-    let List.633 : List U8 = CallByName List.72 List.419 List.634 List.635;
-    ret List.633;
-
-procedure List.52 (List.434, List.435):
-    let List.436 : U64 = CallByName List.6 List.434;
-    joinpoint List.641 List.437:
-        let List.639 : U64 = 0i64;
-        let List.638 : {U64, U64} = Struct {List.437, List.639};
-        inc List.434;
-        let List.438 : List U8 = CallByName List.49 List.434 List.638;
-        let List.637 : U64 = CallByName Num.75 List.436 List.437;
-        let List.632 : {U64, U64} = Struct {List.637, List.437};
-        let List.439 : List U8 = CallByName List.49 List.434 List.632;
-        let List.631 : {List U8, List U8} = Struct {List.438, List.439};
-        ret List.631;
-    in
-    let List.642 : Int1 = CallByName Num.24 List.436 List.435;
-    if List.642 then
-        jump List.641 List.435;
     else
-        jump List.641 List.436;
+        let List.205 : {U64, Int1} = UnionAtIndex (Id 0) (Index 0) List.645;
+        ret List.205;
 
-procedure List.6 (#Attr.2):
-    let List.626 : U64 = lowlevel ListLenU64 #Attr.2;
-    ret List.626;
+procedure List.4 (List.124, List.125):
+    let List.593 : U64 = 1i64;
+    let List.592 : List U8 = CallByName List.70 List.124 List.593;
+    let List.591 : List U8 = CallByName List.71 List.592 List.125;
+    ret List.591;
+
+procedure List.49 (List.420, List.421):
+    let List.636 : U64 = StructAtIndex 1 List.421;
+    let List.637 : U64 = StructAtIndex 0 List.421;
+    let List.635 : List U8 = CallByName List.72 List.420 List.636 List.637;
+    ret List.635;
+
+procedure List.52 (List.435, List.436):
+    let List.437 : U64 = CallByName List.6 List.435;
+    joinpoint List.643 List.438:
+        let List.641 : U64 = 0i64;
+        let List.640 : {U64, U64} = Struct {List.438, List.641};
+        inc List.435;
+        let List.439 : List U8 = CallByName List.49 List.435 List.640;
+        let List.639 : U64 = CallByName Num.75 List.437 List.438;
+        let List.634 : {U64, U64} = Struct {List.639, List.438};
+        let List.440 : List U8 = CallByName List.49 List.435 List.634;
+        let List.633 : {List U8, List U8} = Struct {List.439, List.440};
+        ret List.633;
+    in
+    let List.644 : Int1 = CallByName Num.24 List.437 List.436;
+    if List.644 then
+        jump List.643 List.436;
+    else
+        jump List.643 List.437;
 
 procedure List.6 (#Attr.2):
     let List.628 : U64 = lowlevel ListLenU64 #Attr.2;
     ret List.628;
 
-procedure List.66 (#Attr.2, #Attr.3):
-    let List.602 : {Str, Str} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.602;
-
-procedure List.66 (#Attr.2, #Attr.3):
-    let List.614 : U8 = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.614;
-
-procedure List.68 (#Attr.2):
-    let List.630 : List U8 = lowlevel ListWithCapacity #Attr.2;
+procedure List.6 (#Attr.2):
+    let List.630 : U64 = lowlevel ListLenU64 #Attr.2;
     ret List.630;
 
+procedure List.66 (#Attr.2, #Attr.3):
+    let List.604 : {Str, Str} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.604;
+
+procedure List.66 (#Attr.2, #Attr.3):
+    let List.616 : U8 = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.616;
+
+procedure List.68 (#Attr.2):
+    let List.632 : List U8 = lowlevel ListWithCapacity #Attr.2;
+    ret List.632;
+
 procedure List.70 (#Attr.2, #Attr.3):
-    let List.576 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
-    ret List.576;
+    let List.578 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
+    ret List.578;
 
 procedure List.71 (#Attr.2, #Attr.3):
-    let List.574 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
-    ret List.574;
+    let List.576 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
+    ret List.576;
 
 procedure List.72 (#Attr.2, #Attr.3, #Attr.4):
-    let List.636 : List U8 = lowlevel ListSublist #Attr.2 #Attr.3 #Attr.4;
-    ret List.636;
+    let List.638 : List U8 = lowlevel ListSublist #Attr.2 #Attr.3 #Attr.4;
+    ret List.638;
 
 procedure List.8 (#Attr.2, #Attr.3):
-    let List.625 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
-    ret List.625;
+    let List.627 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
+    ret List.627;
 
-procedure List.80 (#Derived_gen.18, #Derived_gen.19, #Derived_gen.20, #Derived_gen.21, #Derived_gen.22):
-    joinpoint List.652 List.490 List.491 List.492 List.493 List.494:
-        let List.654 : Int1 = CallByName Num.22 List.493 List.494;
-        if List.654 then
-            let List.663 : U8 = CallByName List.66 List.490 List.493;
-            let List.655 : [C {U64, Int1}, C {U64, Int1}] = CallByName TotallyNotJson.157 List.491 List.663;
-            let List.660 : U8 = 1i64;
-            let List.661 : U8 = GetTagId List.655;
-            let List.662 : Int1 = lowlevel Eq List.660 List.661;
-            if List.662 then
-                let List.495 : {U64, Int1} = UnionAtIndex (Id 1) (Index 0) List.655;
-                let List.658 : U64 = 1i64;
-                let List.657 : U64 = CallByName Num.51 List.493 List.658;
-                jump List.652 List.490 List.495 List.492 List.657 List.494;
+procedure List.80 (#Derived_gen.13, #Derived_gen.14, #Derived_gen.15, #Derived_gen.16, #Derived_gen.17):
+    joinpoint List.654 List.491 List.492 List.493 List.494 List.495:
+        let List.656 : Int1 = CallByName Num.22 List.494 List.495;
+        if List.656 then
+            let List.665 : U8 = CallByName List.66 List.491 List.494;
+            let List.657 : [C {U64, Int1}, C {U64, Int1}] = CallByName TotallyNotJson.157 List.492 List.665;
+            let List.662 : U8 = 1i64;
+            let List.663 : U8 = GetTagId List.657;
+            let List.664 : Int1 = lowlevel Eq List.662 List.663;
+            if List.664 then
+                let List.496 : {U64, Int1} = UnionAtIndex (Id 1) (Index 0) List.657;
+                let List.660 : U64 = 1i64;
+                let List.659 : U64 = CallByName Num.51 List.494 List.660;
+                jump List.654 List.491 List.496 List.493 List.659 List.495;
             else
-                dec List.490;
-                let List.496 : {U64, Int1} = UnionAtIndex (Id 0) (Index 0) List.655;
-                let List.659 : [C {U64, Int1}, C {U64, Int1}] = TagId(0) List.496;
-                ret List.659;
+                dec List.491;
+                let List.497 : {U64, Int1} = UnionAtIndex (Id 0) (Index 0) List.657;
+                let List.661 : [C {U64, Int1}, C {U64, Int1}] = TagId(0) List.497;
+                ret List.661;
         else
-            dec List.490;
-            let List.653 : [C {U64, Int1}, C {U64, Int1}] = TagId(1) List.491;
-            ret List.653;
+            dec List.491;
+            let List.655 : [C {U64, Int1}, C {U64, Int1}] = TagId(1) List.492;
+            ret List.655;
     in
-    jump List.652 #Derived_gen.18 #Derived_gen.19 #Derived_gen.20 #Derived_gen.21 #Derived_gen.22;
+    jump List.654 #Derived_gen.13 #Derived_gen.14 #Derived_gen.15 #Derived_gen.16 #Derived_gen.17;
 
-procedure List.91 (#Derived_gen.13, #Derived_gen.14, #Derived_gen.15, #Derived_gen.16, #Derived_gen.17):
-    joinpoint List.607 List.162 List.163 List.164 List.165 List.166:
-        let List.609 : Int1 = CallByName Num.22 List.165 List.166;
-        if List.609 then
-            let List.613 : U8 = CallByName List.66 List.162 List.165;
-            let List.167 : List U8 = CallByName TotallyNotJson.183 List.163 List.613;
-            let List.612 : U64 = 1i64;
-            let List.611 : U64 = CallByName Num.51 List.165 List.612;
-            jump List.607 List.162 List.167 List.164 List.611 List.166;
+procedure List.92 (#Derived_gen.24, #Derived_gen.25, #Derived_gen.26, #Derived_gen.27, #Derived_gen.28):
+    joinpoint List.597 List.163 List.164 List.165 List.166 List.167:
+        let List.599 : Int1 = CallByName Num.22 List.166 List.167;
+        if List.599 then
+            let List.603 : {Str, Str} = CallByName List.66 List.163 List.166;
+            inc List.603;
+            let List.168 : {List U8, U64} = CallByName TotallyNotJson.204 List.164 List.603;
+            let List.602 : U64 = 1i64;
+            let List.601 : U64 = CallByName Num.51 List.166 List.602;
+            jump List.597 List.163 List.168 List.165 List.601 List.167;
         else
-            dec List.162;
-            ret List.163;
+            dec List.163;
+            ret List.164;
     in
-    jump List.607 #Derived_gen.13 #Derived_gen.14 #Derived_gen.15 #Derived_gen.16 #Derived_gen.17;
+    jump List.597 #Derived_gen.24 #Derived_gen.25 #Derived_gen.26 #Derived_gen.27 #Derived_gen.28;
 
-procedure List.91 (#Derived_gen.23, #Derived_gen.24, #Derived_gen.25, #Derived_gen.26, #Derived_gen.27):
-    joinpoint List.595 List.162 List.163 List.164 List.165 List.166:
-        let List.597 : Int1 = CallByName Num.22 List.165 List.166;
-        if List.597 then
-            let List.601 : {Str, Str} = CallByName List.66 List.162 List.165;
-            inc List.601;
-            let List.167 : {List U8, U64} = CallByName TotallyNotJson.204 List.163 List.601;
-            let List.600 : U64 = 1i64;
-            let List.599 : U64 = CallByName Num.51 List.165 List.600;
-            jump List.595 List.162 List.167 List.164 List.599 List.166;
+procedure List.92 (#Derived_gen.29, #Derived_gen.30, #Derived_gen.31, #Derived_gen.32, #Derived_gen.33):
+    joinpoint List.609 List.163 List.164 List.165 List.166 List.167:
+        let List.611 : Int1 = CallByName Num.22 List.166 List.167;
+        if List.611 then
+            let List.615 : U8 = CallByName List.66 List.163 List.166;
+            let List.168 : List U8 = CallByName TotallyNotJson.183 List.164 List.615;
+            let List.614 : U64 = 1i64;
+            let List.613 : U64 = CallByName Num.51 List.166 List.614;
+            jump List.609 List.163 List.168 List.165 List.613 List.167;
         else
-            dec List.162;
-            ret List.163;
+            dec List.163;
+            ret List.164;
     in
-    jump List.595 #Derived_gen.23 #Derived_gen.24 #Derived_gen.25 #Derived_gen.26 #Derived_gen.27;
+    jump List.609 #Derived_gen.29 #Derived_gen.30 #Derived_gen.31 #Derived_gen.32 #Derived_gen.33;
 
 procedure Num.127 (#Attr.2):
     let Num.284 : U8 = lowlevel NumIntCast #Attr.2;

--- a/crates/compiler/test_mono/generated/encode_derived_record_two_field_strings.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_record_two_field_strings.txt
@@ -49,159 +49,159 @@ procedure Encode.26 (Encode.105, Encode.106):
     let Encode.108 : List U8 = CallByName Encode.24 Encode.109 Encode.110 Encode.106;
     ret Encode.108;
 
-procedure List.103 (List.487, List.488, List.489):
-    let List.650 : U64 = 0i64;
-    let List.651 : U64 = CallByName List.6 List.487;
-    let List.649 : [C {U64, Int1}, C {U64, Int1}] = CallByName List.80 List.487 List.488 List.489 List.650 List.651;
-    ret List.649;
+procedure List.104 (List.488, List.489, List.490):
+    let List.652 : U64 = 0i64;
+    let List.653 : U64 = CallByName List.6 List.488;
+    let List.651 : [C {U64, Int1}, C {U64, Int1}] = CallByName List.80 List.488 List.489 List.490 List.652 List.653;
+    ret List.651;
 
-procedure List.18 (List.159, List.160, List.161):
-    let List.593 : U64 = 0i64;
-    let List.594 : U64 = CallByName List.6 List.159;
-    let List.592 : {List U8, U64} = CallByName List.91 List.159 List.160 List.161 List.593 List.594;
-    ret List.592;
+procedure List.18 (List.160, List.161, List.162):
+    let List.595 : U64 = 0i64;
+    let List.596 : U64 = CallByName List.6 List.160;
+    let List.594 : {List U8, U64} = CallByName List.92 List.160 List.161 List.162 List.595 List.596;
+    ret List.594;
 
-procedure List.18 (List.159, List.160, List.161):
-    let List.605 : U64 = 0i64;
-    let List.606 : U64 = CallByName List.6 List.159;
-    let List.604 : List U8 = CallByName List.91 List.159 List.160 List.161 List.605 List.606;
-    ret List.604;
+procedure List.18 (List.160, List.161, List.162):
+    let List.607 : U64 = 0i64;
+    let List.608 : U64 = CallByName List.6 List.160;
+    let List.606 : List U8 = CallByName List.92 List.160 List.161 List.162 List.607 List.608;
+    ret List.606;
 
-procedure List.26 (List.200, List.201, List.202):
-    let List.643 : [C {U64, Int1}, C {U64, Int1}] = CallByName List.103 List.200 List.201 List.202;
-    let List.646 : U8 = 1i64;
-    let List.647 : U8 = GetTagId List.643;
-    let List.648 : Int1 = lowlevel Eq List.646 List.647;
-    if List.648 then
-        let List.203 : {U64, Int1} = UnionAtIndex (Id 1) (Index 0) List.643;
-        ret List.203;
-    else
-        let List.204 : {U64, Int1} = UnionAtIndex (Id 0) (Index 0) List.643;
+procedure List.26 (List.201, List.202, List.203):
+    let List.645 : [C {U64, Int1}, C {U64, Int1}] = CallByName List.104 List.201 List.202 List.203;
+    let List.648 : U8 = 1i64;
+    let List.649 : U8 = GetTagId List.645;
+    let List.650 : Int1 = lowlevel Eq List.648 List.649;
+    if List.650 then
+        let List.204 : {U64, Int1} = UnionAtIndex (Id 1) (Index 0) List.645;
         ret List.204;
-
-procedure List.4 (List.123, List.124):
-    let List.591 : U64 = 1i64;
-    let List.590 : List U8 = CallByName List.70 List.123 List.591;
-    let List.589 : List U8 = CallByName List.71 List.590 List.124;
-    ret List.589;
-
-procedure List.49 (List.419, List.420):
-    let List.634 : U64 = StructAtIndex 1 List.420;
-    let List.635 : U64 = StructAtIndex 0 List.420;
-    let List.633 : List U8 = CallByName List.72 List.419 List.634 List.635;
-    ret List.633;
-
-procedure List.52 (List.434, List.435):
-    let List.436 : U64 = CallByName List.6 List.434;
-    joinpoint List.641 List.437:
-        let List.639 : U64 = 0i64;
-        let List.638 : {U64, U64} = Struct {List.437, List.639};
-        inc List.434;
-        let List.438 : List U8 = CallByName List.49 List.434 List.638;
-        let List.637 : U64 = CallByName Num.75 List.436 List.437;
-        let List.632 : {U64, U64} = Struct {List.637, List.437};
-        let List.439 : List U8 = CallByName List.49 List.434 List.632;
-        let List.631 : {List U8, List U8} = Struct {List.438, List.439};
-        ret List.631;
-    in
-    let List.642 : Int1 = CallByName Num.24 List.436 List.435;
-    if List.642 then
-        jump List.641 List.435;
     else
-        jump List.641 List.436;
+        let List.205 : {U64, Int1} = UnionAtIndex (Id 0) (Index 0) List.645;
+        ret List.205;
 
-procedure List.6 (#Attr.2):
-    let List.626 : U64 = lowlevel ListLenU64 #Attr.2;
-    ret List.626;
+procedure List.4 (List.124, List.125):
+    let List.593 : U64 = 1i64;
+    let List.592 : List U8 = CallByName List.70 List.124 List.593;
+    let List.591 : List U8 = CallByName List.71 List.592 List.125;
+    ret List.591;
+
+procedure List.49 (List.420, List.421):
+    let List.636 : U64 = StructAtIndex 1 List.421;
+    let List.637 : U64 = StructAtIndex 0 List.421;
+    let List.635 : List U8 = CallByName List.72 List.420 List.636 List.637;
+    ret List.635;
+
+procedure List.52 (List.435, List.436):
+    let List.437 : U64 = CallByName List.6 List.435;
+    joinpoint List.643 List.438:
+        let List.641 : U64 = 0i64;
+        let List.640 : {U64, U64} = Struct {List.438, List.641};
+        inc List.435;
+        let List.439 : List U8 = CallByName List.49 List.435 List.640;
+        let List.639 : U64 = CallByName Num.75 List.437 List.438;
+        let List.634 : {U64, U64} = Struct {List.639, List.438};
+        let List.440 : List U8 = CallByName List.49 List.435 List.634;
+        let List.633 : {List U8, List U8} = Struct {List.439, List.440};
+        ret List.633;
+    in
+    let List.644 : Int1 = CallByName Num.24 List.437 List.436;
+    if List.644 then
+        jump List.643 List.436;
+    else
+        jump List.643 List.437;
 
 procedure List.6 (#Attr.2):
     let List.628 : U64 = lowlevel ListLenU64 #Attr.2;
     ret List.628;
 
-procedure List.66 (#Attr.2, #Attr.3):
-    let List.602 : {Str, Str} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.602;
-
-procedure List.66 (#Attr.2, #Attr.3):
-    let List.614 : U8 = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.614;
-
-procedure List.68 (#Attr.2):
-    let List.630 : List U8 = lowlevel ListWithCapacity #Attr.2;
+procedure List.6 (#Attr.2):
+    let List.630 : U64 = lowlevel ListLenU64 #Attr.2;
     ret List.630;
 
+procedure List.66 (#Attr.2, #Attr.3):
+    let List.604 : {Str, Str} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.604;
+
+procedure List.66 (#Attr.2, #Attr.3):
+    let List.616 : U8 = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.616;
+
+procedure List.68 (#Attr.2):
+    let List.632 : List U8 = lowlevel ListWithCapacity #Attr.2;
+    ret List.632;
+
 procedure List.70 (#Attr.2, #Attr.3):
-    let List.576 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
-    ret List.576;
+    let List.578 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
+    ret List.578;
 
 procedure List.71 (#Attr.2, #Attr.3):
-    let List.574 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
-    ret List.574;
+    let List.576 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
+    ret List.576;
 
 procedure List.72 (#Attr.2, #Attr.3, #Attr.4):
-    let List.636 : List U8 = lowlevel ListSublist #Attr.2 #Attr.3 #Attr.4;
-    ret List.636;
+    let List.638 : List U8 = lowlevel ListSublist #Attr.2 #Attr.3 #Attr.4;
+    ret List.638;
 
 procedure List.8 (#Attr.2, #Attr.3):
-    let List.625 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
-    ret List.625;
+    let List.627 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
+    ret List.627;
 
-procedure List.80 (#Derived_gen.22, #Derived_gen.23, #Derived_gen.24, #Derived_gen.25, #Derived_gen.26):
-    joinpoint List.652 List.490 List.491 List.492 List.493 List.494:
-        let List.654 : Int1 = CallByName Num.22 List.493 List.494;
-        if List.654 then
-            let List.663 : U8 = CallByName List.66 List.490 List.493;
-            let List.655 : [C {U64, Int1}, C {U64, Int1}] = CallByName TotallyNotJson.157 List.491 List.663;
-            let List.660 : U8 = 1i64;
-            let List.661 : U8 = GetTagId List.655;
-            let List.662 : Int1 = lowlevel Eq List.660 List.661;
-            if List.662 then
-                let List.495 : {U64, Int1} = UnionAtIndex (Id 1) (Index 0) List.655;
-                let List.658 : U64 = 1i64;
-                let List.657 : U64 = CallByName Num.51 List.493 List.658;
-                jump List.652 List.490 List.495 List.492 List.657 List.494;
+procedure List.80 (#Derived_gen.17, #Derived_gen.18, #Derived_gen.19, #Derived_gen.20, #Derived_gen.21):
+    joinpoint List.654 List.491 List.492 List.493 List.494 List.495:
+        let List.656 : Int1 = CallByName Num.22 List.494 List.495;
+        if List.656 then
+            let List.665 : U8 = CallByName List.66 List.491 List.494;
+            let List.657 : [C {U64, Int1}, C {U64, Int1}] = CallByName TotallyNotJson.157 List.492 List.665;
+            let List.662 : U8 = 1i64;
+            let List.663 : U8 = GetTagId List.657;
+            let List.664 : Int1 = lowlevel Eq List.662 List.663;
+            if List.664 then
+                let List.496 : {U64, Int1} = UnionAtIndex (Id 1) (Index 0) List.657;
+                let List.660 : U64 = 1i64;
+                let List.659 : U64 = CallByName Num.51 List.494 List.660;
+                jump List.654 List.491 List.496 List.493 List.659 List.495;
             else
-                dec List.490;
-                let List.496 : {U64, Int1} = UnionAtIndex (Id 0) (Index 0) List.655;
-                let List.659 : [C {U64, Int1}, C {U64, Int1}] = TagId(0) List.496;
-                ret List.659;
+                dec List.491;
+                let List.497 : {U64, Int1} = UnionAtIndex (Id 0) (Index 0) List.657;
+                let List.661 : [C {U64, Int1}, C {U64, Int1}] = TagId(0) List.497;
+                ret List.661;
         else
-            dec List.490;
-            let List.653 : [C {U64, Int1}, C {U64, Int1}] = TagId(1) List.491;
-            ret List.653;
+            dec List.491;
+            let List.655 : [C {U64, Int1}, C {U64, Int1}] = TagId(1) List.492;
+            ret List.655;
     in
-    jump List.652 #Derived_gen.22 #Derived_gen.23 #Derived_gen.24 #Derived_gen.25 #Derived_gen.26;
+    jump List.654 #Derived_gen.17 #Derived_gen.18 #Derived_gen.19 #Derived_gen.20 #Derived_gen.21;
 
-procedure List.91 (#Derived_gen.17, #Derived_gen.18, #Derived_gen.19, #Derived_gen.20, #Derived_gen.21):
-    joinpoint List.607 List.162 List.163 List.164 List.165 List.166:
-        let List.609 : Int1 = CallByName Num.22 List.165 List.166;
-        if List.609 then
-            let List.613 : U8 = CallByName List.66 List.162 List.165;
-            let List.167 : List U8 = CallByName TotallyNotJson.183 List.163 List.613;
-            let List.612 : U64 = 1i64;
-            let List.611 : U64 = CallByName Num.51 List.165 List.612;
-            jump List.607 List.162 List.167 List.164 List.611 List.166;
+procedure List.92 (#Derived_gen.28, #Derived_gen.29, #Derived_gen.30, #Derived_gen.31, #Derived_gen.32):
+    joinpoint List.597 List.163 List.164 List.165 List.166 List.167:
+        let List.599 : Int1 = CallByName Num.22 List.166 List.167;
+        if List.599 then
+            let List.603 : {Str, Str} = CallByName List.66 List.163 List.166;
+            inc List.603;
+            let List.168 : {List U8, U64} = CallByName TotallyNotJson.204 List.164 List.603;
+            let List.602 : U64 = 1i64;
+            let List.601 : U64 = CallByName Num.51 List.166 List.602;
+            jump List.597 List.163 List.168 List.165 List.601 List.167;
         else
-            dec List.162;
-            ret List.163;
+            dec List.163;
+            ret List.164;
     in
-    jump List.607 #Derived_gen.17 #Derived_gen.18 #Derived_gen.19 #Derived_gen.20 #Derived_gen.21;
+    jump List.597 #Derived_gen.28 #Derived_gen.29 #Derived_gen.30 #Derived_gen.31 #Derived_gen.32;
 
-procedure List.91 (#Derived_gen.27, #Derived_gen.28, #Derived_gen.29, #Derived_gen.30, #Derived_gen.31):
-    joinpoint List.595 List.162 List.163 List.164 List.165 List.166:
-        let List.597 : Int1 = CallByName Num.22 List.165 List.166;
-        if List.597 then
-            let List.601 : {Str, Str} = CallByName List.66 List.162 List.165;
-            inc List.601;
-            let List.167 : {List U8, U64} = CallByName TotallyNotJson.204 List.163 List.601;
-            let List.600 : U64 = 1i64;
-            let List.599 : U64 = CallByName Num.51 List.165 List.600;
-            jump List.595 List.162 List.167 List.164 List.599 List.166;
+procedure List.92 (#Derived_gen.33, #Derived_gen.34, #Derived_gen.35, #Derived_gen.36, #Derived_gen.37):
+    joinpoint List.609 List.163 List.164 List.165 List.166 List.167:
+        let List.611 : Int1 = CallByName Num.22 List.166 List.167;
+        if List.611 then
+            let List.615 : U8 = CallByName List.66 List.163 List.166;
+            let List.168 : List U8 = CallByName TotallyNotJson.183 List.164 List.615;
+            let List.614 : U64 = 1i64;
+            let List.613 : U64 = CallByName Num.51 List.166 List.614;
+            jump List.609 List.163 List.168 List.165 List.613 List.167;
         else
-            dec List.162;
-            ret List.163;
+            dec List.163;
+            ret List.164;
     in
-    jump List.595 #Derived_gen.27 #Derived_gen.28 #Derived_gen.29 #Derived_gen.30 #Derived_gen.31;
+    jump List.609 #Derived_gen.33 #Derived_gen.34 #Derived_gen.35 #Derived_gen.36 #Derived_gen.37;
 
 procedure Num.127 (#Attr.2):
     let Num.284 : U8 = lowlevel NumIntCast #Attr.2;

--- a/crates/compiler/test_mono/generated/encode_derived_string.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_string.txt
@@ -11,115 +11,115 @@ procedure Encode.26 (Encode.105, Encode.106):
     let Encode.108 : List U8 = CallByName Encode.24 Encode.109 Encode.110 Encode.106;
     ret Encode.108;
 
-procedure List.103 (List.487, List.488, List.489):
-    let List.614 : U64 = 0i64;
-    let List.615 : U64 = CallByName List.6 List.487;
-    let List.613 : [C {U64, Int1}, C {U64, Int1}] = CallByName List.80 List.487 List.488 List.489 List.614 List.615;
-    ret List.613;
+procedure List.104 (List.488, List.489, List.490):
+    let List.616 : U64 = 0i64;
+    let List.617 : U64 = CallByName List.6 List.488;
+    let List.615 : [C {U64, Int1}, C {U64, Int1}] = CallByName List.80 List.488 List.489 List.490 List.616 List.617;
+    ret List.615;
 
-procedure List.18 (List.159, List.160, List.161):
-    let List.585 : U64 = 0i64;
-    let List.586 : U64 = CallByName List.6 List.159;
-    let List.584 : List U8 = CallByName List.91 List.159 List.160 List.161 List.585 List.586;
-    ret List.584;
+procedure List.18 (List.160, List.161, List.162):
+    let List.587 : U64 = 0i64;
+    let List.588 : U64 = CallByName List.6 List.160;
+    let List.586 : List U8 = CallByName List.92 List.160 List.161 List.162 List.587 List.588;
+    ret List.586;
 
-procedure List.26 (List.200, List.201, List.202):
-    let List.607 : [C {U64, Int1}, C {U64, Int1}] = CallByName List.103 List.200 List.201 List.202;
-    let List.610 : U8 = 1i64;
-    let List.611 : U8 = GetTagId List.607;
-    let List.612 : Int1 = lowlevel Eq List.610 List.611;
-    if List.612 then
-        let List.203 : {U64, Int1} = UnionAtIndex (Id 1) (Index 0) List.607;
-        ret List.203;
-    else
-        let List.204 : {U64, Int1} = UnionAtIndex (Id 0) (Index 0) List.607;
+procedure List.26 (List.201, List.202, List.203):
+    let List.609 : [C {U64, Int1}, C {U64, Int1}] = CallByName List.104 List.201 List.202 List.203;
+    let List.612 : U8 = 1i64;
+    let List.613 : U8 = GetTagId List.609;
+    let List.614 : Int1 = lowlevel Eq List.612 List.613;
+    if List.614 then
+        let List.204 : {U64, Int1} = UnionAtIndex (Id 1) (Index 0) List.609;
         ret List.204;
-
-procedure List.49 (List.419, List.420):
-    let List.598 : U64 = StructAtIndex 1 List.420;
-    let List.599 : U64 = StructAtIndex 0 List.420;
-    let List.597 : List U8 = CallByName List.72 List.419 List.598 List.599;
-    ret List.597;
-
-procedure List.52 (List.434, List.435):
-    let List.436 : U64 = CallByName List.6 List.434;
-    joinpoint List.605 List.437:
-        let List.603 : U64 = 0i64;
-        let List.602 : {U64, U64} = Struct {List.437, List.603};
-        inc List.434;
-        let List.438 : List U8 = CallByName List.49 List.434 List.602;
-        let List.601 : U64 = CallByName Num.75 List.436 List.437;
-        let List.596 : {U64, U64} = Struct {List.601, List.437};
-        let List.439 : List U8 = CallByName List.49 List.434 List.596;
-        let List.595 : {List U8, List U8} = Struct {List.438, List.439};
-        ret List.595;
-    in
-    let List.606 : Int1 = CallByName Num.24 List.436 List.435;
-    if List.606 then
-        jump List.605 List.435;
     else
-        jump List.605 List.436;
+        let List.205 : {U64, Int1} = UnionAtIndex (Id 0) (Index 0) List.609;
+        ret List.205;
+
+procedure List.49 (List.420, List.421):
+    let List.600 : U64 = StructAtIndex 1 List.421;
+    let List.601 : U64 = StructAtIndex 0 List.421;
+    let List.599 : List U8 = CallByName List.72 List.420 List.600 List.601;
+    ret List.599;
+
+procedure List.52 (List.435, List.436):
+    let List.437 : U64 = CallByName List.6 List.435;
+    joinpoint List.607 List.438:
+        let List.605 : U64 = 0i64;
+        let List.604 : {U64, U64} = Struct {List.438, List.605};
+        inc List.435;
+        let List.439 : List U8 = CallByName List.49 List.435 List.604;
+        let List.603 : U64 = CallByName Num.75 List.437 List.438;
+        let List.598 : {U64, U64} = Struct {List.603, List.438};
+        let List.440 : List U8 = CallByName List.49 List.435 List.598;
+        let List.597 : {List U8, List U8} = Struct {List.439, List.440};
+        ret List.597;
+    in
+    let List.608 : Int1 = CallByName Num.24 List.437 List.436;
+    if List.608 then
+        jump List.607 List.436;
+    else
+        jump List.607 List.437;
 
 procedure List.6 (#Attr.2):
-    let List.583 : U64 = lowlevel ListLenU64 #Attr.2;
-    ret List.583;
+    let List.585 : U64 = lowlevel ListLenU64 #Attr.2;
+    ret List.585;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.594 : U8 = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.594;
+    let List.596 : U8 = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.596;
 
 procedure List.68 (#Attr.2):
-    let List.581 : List U8 = lowlevel ListWithCapacity #Attr.2;
-    ret List.581;
+    let List.583 : List U8 = lowlevel ListWithCapacity #Attr.2;
+    ret List.583;
 
 procedure List.72 (#Attr.2, #Attr.3, #Attr.4):
-    let List.600 : List U8 = lowlevel ListSublist #Attr.2 #Attr.3 #Attr.4;
-    ret List.600;
+    let List.602 : List U8 = lowlevel ListSublist #Attr.2 #Attr.3 #Attr.4;
+    ret List.602;
 
 procedure List.8 (#Attr.2, #Attr.3):
-    let List.579 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
-    ret List.579;
+    let List.581 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
+    ret List.581;
 
 procedure List.80 (#Derived_gen.0, #Derived_gen.1, #Derived_gen.2, #Derived_gen.3, #Derived_gen.4):
-    joinpoint List.616 List.490 List.491 List.492 List.493 List.494:
-        let List.618 : Int1 = CallByName Num.22 List.493 List.494;
-        if List.618 then
-            let List.627 : U8 = CallByName List.66 List.490 List.493;
-            let List.619 : [C {U64, Int1}, C {U64, Int1}] = CallByName TotallyNotJson.157 List.491 List.627;
-            let List.624 : U8 = 1i64;
-            let List.625 : U8 = GetTagId List.619;
-            let List.626 : Int1 = lowlevel Eq List.624 List.625;
-            if List.626 then
-                let List.495 : {U64, Int1} = UnionAtIndex (Id 1) (Index 0) List.619;
-                let List.622 : U64 = 1i64;
-                let List.621 : U64 = CallByName Num.51 List.493 List.622;
-                jump List.616 List.490 List.495 List.492 List.621 List.494;
+    joinpoint List.618 List.491 List.492 List.493 List.494 List.495:
+        let List.620 : Int1 = CallByName Num.22 List.494 List.495;
+        if List.620 then
+            let List.629 : U8 = CallByName List.66 List.491 List.494;
+            let List.621 : [C {U64, Int1}, C {U64, Int1}] = CallByName TotallyNotJson.157 List.492 List.629;
+            let List.626 : U8 = 1i64;
+            let List.627 : U8 = GetTagId List.621;
+            let List.628 : Int1 = lowlevel Eq List.626 List.627;
+            if List.628 then
+                let List.496 : {U64, Int1} = UnionAtIndex (Id 1) (Index 0) List.621;
+                let List.624 : U64 = 1i64;
+                let List.623 : U64 = CallByName Num.51 List.494 List.624;
+                jump List.618 List.491 List.496 List.493 List.623 List.495;
             else
-                dec List.490;
-                let List.496 : {U64, Int1} = UnionAtIndex (Id 0) (Index 0) List.619;
-                let List.623 : [C {U64, Int1}, C {U64, Int1}] = TagId(0) List.496;
-                ret List.623;
+                dec List.491;
+                let List.497 : {U64, Int1} = UnionAtIndex (Id 0) (Index 0) List.621;
+                let List.625 : [C {U64, Int1}, C {U64, Int1}] = TagId(0) List.497;
+                ret List.625;
         else
-            dec List.490;
-            let List.617 : [C {U64, Int1}, C {U64, Int1}] = TagId(1) List.491;
-            ret List.617;
+            dec List.491;
+            let List.619 : [C {U64, Int1}, C {U64, Int1}] = TagId(1) List.492;
+            ret List.619;
     in
-    jump List.616 #Derived_gen.0 #Derived_gen.1 #Derived_gen.2 #Derived_gen.3 #Derived_gen.4;
+    jump List.618 #Derived_gen.0 #Derived_gen.1 #Derived_gen.2 #Derived_gen.3 #Derived_gen.4;
 
-procedure List.91 (#Derived_gen.8, #Derived_gen.9, #Derived_gen.10, #Derived_gen.11, #Derived_gen.12):
-    joinpoint List.587 List.162 List.163 List.164 List.165 List.166:
-        let List.589 : Int1 = CallByName Num.22 List.165 List.166;
-        if List.589 then
-            let List.593 : U8 = CallByName List.66 List.162 List.165;
-            let List.167 : List U8 = CallByName TotallyNotJson.183 List.163 List.593;
-            let List.592 : U64 = 1i64;
-            let List.591 : U64 = CallByName Num.51 List.165 List.592;
-            jump List.587 List.162 List.167 List.164 List.591 List.166;
+procedure List.92 (#Derived_gen.5, #Derived_gen.6, #Derived_gen.7, #Derived_gen.8, #Derived_gen.9):
+    joinpoint List.589 List.163 List.164 List.165 List.166 List.167:
+        let List.591 : Int1 = CallByName Num.22 List.166 List.167;
+        if List.591 then
+            let List.595 : U8 = CallByName List.66 List.163 List.166;
+            let List.168 : List U8 = CallByName TotallyNotJson.183 List.164 List.595;
+            let List.594 : U64 = 1i64;
+            let List.593 : U64 = CallByName Num.51 List.166 List.594;
+            jump List.589 List.163 List.168 List.165 List.593 List.167;
         else
-            dec List.162;
-            ret List.163;
+            dec List.163;
+            ret List.164;
     in
-    jump List.587 #Derived_gen.8 #Derived_gen.9 #Derived_gen.10 #Derived_gen.11 #Derived_gen.12;
+    jump List.589 #Derived_gen.5 #Derived_gen.6 #Derived_gen.7 #Derived_gen.8 #Derived_gen.9;
 
 procedure Num.137 (#Attr.2, #Attr.3):
     let Num.281 : U64 = lowlevel NumDivCeilUnchecked #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/encode_derived_tag_one_field_string.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_tag_one_field_string.txt
@@ -40,159 +40,159 @@ procedure Encode.26 (Encode.105, Encode.106):
     let Encode.108 : List U8 = CallByName Encode.24 Encode.109 Encode.110 Encode.106;
     ret Encode.108;
 
-procedure List.103 (List.487, List.488, List.489):
-    let List.655 : U64 = 0i64;
-    let List.656 : U64 = CallByName List.6 List.487;
-    let List.654 : [C {U64, Int1}, C {U64, Int1}] = CallByName List.80 List.487 List.488 List.489 List.655 List.656;
-    ret List.654;
+procedure List.104 (List.488, List.489, List.490):
+    let List.657 : U64 = 0i64;
+    let List.658 : U64 = CallByName List.6 List.488;
+    let List.656 : [C {U64, Int1}, C {U64, Int1}] = CallByName List.80 List.488 List.489 List.490 List.657 List.658;
+    ret List.656;
 
-procedure List.18 (List.159, List.160, List.161):
-    let List.599 : U64 = 0i64;
-    let List.600 : U64 = CallByName List.6 List.159;
-    let List.598 : {List U8, U64} = CallByName List.91 List.159 List.160 List.161 List.599 List.600;
-    ret List.598;
+procedure List.18 (List.160, List.161, List.162):
+    let List.601 : U64 = 0i64;
+    let List.602 : U64 = CallByName List.6 List.160;
+    let List.600 : {List U8, U64} = CallByName List.92 List.160 List.161 List.162 List.601 List.602;
+    ret List.600;
 
-procedure List.18 (List.159, List.160, List.161):
-    let List.611 : U64 = 0i64;
-    let List.612 : U64 = CallByName List.6 List.159;
-    let List.610 : List U8 = CallByName List.91 List.159 List.160 List.161 List.611 List.612;
-    ret List.610;
+procedure List.18 (List.160, List.161, List.162):
+    let List.613 : U64 = 0i64;
+    let List.614 : U64 = CallByName List.6 List.160;
+    let List.612 : List U8 = CallByName List.92 List.160 List.161 List.162 List.613 List.614;
+    ret List.612;
 
-procedure List.26 (List.200, List.201, List.202):
-    let List.648 : [C {U64, Int1}, C {U64, Int1}] = CallByName List.103 List.200 List.201 List.202;
-    let List.651 : U8 = 1i64;
-    let List.652 : U8 = GetTagId List.648;
-    let List.653 : Int1 = lowlevel Eq List.651 List.652;
-    if List.653 then
-        let List.203 : {U64, Int1} = UnionAtIndex (Id 1) (Index 0) List.648;
-        ret List.203;
-    else
-        let List.204 : {U64, Int1} = UnionAtIndex (Id 0) (Index 0) List.648;
+procedure List.26 (List.201, List.202, List.203):
+    let List.650 : [C {U64, Int1}, C {U64, Int1}] = CallByName List.104 List.201 List.202 List.203;
+    let List.653 : U8 = 1i64;
+    let List.654 : U8 = GetTagId List.650;
+    let List.655 : Int1 = lowlevel Eq List.653 List.654;
+    if List.655 then
+        let List.204 : {U64, Int1} = UnionAtIndex (Id 1) (Index 0) List.650;
         ret List.204;
-
-procedure List.4 (List.123, List.124):
-    let List.597 : U64 = 1i64;
-    let List.596 : List U8 = CallByName List.70 List.123 List.597;
-    let List.595 : List U8 = CallByName List.71 List.596 List.124;
-    ret List.595;
-
-procedure List.49 (List.419, List.420):
-    let List.639 : U64 = StructAtIndex 1 List.420;
-    let List.640 : U64 = StructAtIndex 0 List.420;
-    let List.638 : List U8 = CallByName List.72 List.419 List.639 List.640;
-    ret List.638;
-
-procedure List.52 (List.434, List.435):
-    let List.436 : U64 = CallByName List.6 List.434;
-    joinpoint List.646 List.437:
-        let List.644 : U64 = 0i64;
-        let List.643 : {U64, U64} = Struct {List.437, List.644};
-        inc List.434;
-        let List.438 : List U8 = CallByName List.49 List.434 List.643;
-        let List.642 : U64 = CallByName Num.75 List.436 List.437;
-        let List.637 : {U64, U64} = Struct {List.642, List.437};
-        let List.439 : List U8 = CallByName List.49 List.434 List.637;
-        let List.636 : {List U8, List U8} = Struct {List.438, List.439};
-        ret List.636;
-    in
-    let List.647 : Int1 = CallByName Num.24 List.436 List.435;
-    if List.647 then
-        jump List.646 List.435;
     else
-        jump List.646 List.436;
+        let List.205 : {U64, Int1} = UnionAtIndex (Id 0) (Index 0) List.650;
+        ret List.205;
 
-procedure List.6 (#Attr.2):
-    let List.622 : U64 = lowlevel ListLenU64 #Attr.2;
-    ret List.622;
+procedure List.4 (List.124, List.125):
+    let List.599 : U64 = 1i64;
+    let List.598 : List U8 = CallByName List.70 List.124 List.599;
+    let List.597 : List U8 = CallByName List.71 List.598 List.125;
+    ret List.597;
+
+procedure List.49 (List.420, List.421):
+    let List.641 : U64 = StructAtIndex 1 List.421;
+    let List.642 : U64 = StructAtIndex 0 List.421;
+    let List.640 : List U8 = CallByName List.72 List.420 List.641 List.642;
+    ret List.640;
+
+procedure List.52 (List.435, List.436):
+    let List.437 : U64 = CallByName List.6 List.435;
+    joinpoint List.648 List.438:
+        let List.646 : U64 = 0i64;
+        let List.645 : {U64, U64} = Struct {List.438, List.646};
+        inc List.435;
+        let List.439 : List U8 = CallByName List.49 List.435 List.645;
+        let List.644 : U64 = CallByName Num.75 List.437 List.438;
+        let List.639 : {U64, U64} = Struct {List.644, List.438};
+        let List.440 : List U8 = CallByName List.49 List.435 List.639;
+        let List.638 : {List U8, List U8} = Struct {List.439, List.440};
+        ret List.638;
+    in
+    let List.649 : Int1 = CallByName Num.24 List.437 List.436;
+    if List.649 then
+        jump List.648 List.436;
+    else
+        jump List.648 List.437;
 
 procedure List.6 (#Attr.2):
     let List.624 : U64 = lowlevel ListLenU64 #Attr.2;
     ret List.624;
 
-procedure List.66 (#Attr.2, #Attr.3):
-    let List.608 : Str = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.608;
+procedure List.6 (#Attr.2):
+    let List.626 : U64 = lowlevel ListLenU64 #Attr.2;
+    ret List.626;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.620 : U8 = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.620;
+    let List.610 : Str = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.610;
+
+procedure List.66 (#Attr.2, #Attr.3):
+    let List.622 : U8 = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.622;
 
 procedure List.68 (#Attr.2):
-    let List.635 : List U8 = lowlevel ListWithCapacity #Attr.2;
-    ret List.635;
+    let List.637 : List U8 = lowlevel ListWithCapacity #Attr.2;
+    ret List.637;
 
 procedure List.70 (#Attr.2, #Attr.3):
-    let List.576 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
-    ret List.576;
+    let List.578 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
+    ret List.578;
 
 procedure List.71 (#Attr.2, #Attr.3):
-    let List.574 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
-    ret List.574;
+    let List.576 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
+    ret List.576;
 
 procedure List.72 (#Attr.2, #Attr.3, #Attr.4):
-    let List.641 : List U8 = lowlevel ListSublist #Attr.2 #Attr.3 #Attr.4;
-    ret List.641;
+    let List.643 : List U8 = lowlevel ListSublist #Attr.2 #Attr.3 #Attr.4;
+    ret List.643;
 
 procedure List.8 (#Attr.2, #Attr.3):
-    let List.633 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
-    ret List.633;
+    let List.635 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
+    ret List.635;
 
 procedure List.80 (#Derived_gen.18, #Derived_gen.19, #Derived_gen.20, #Derived_gen.21, #Derived_gen.22):
-    joinpoint List.657 List.490 List.491 List.492 List.493 List.494:
-        let List.659 : Int1 = CallByName Num.22 List.493 List.494;
-        if List.659 then
-            let List.668 : U8 = CallByName List.66 List.490 List.493;
-            let List.660 : [C {U64, Int1}, C {U64, Int1}] = CallByName TotallyNotJson.157 List.491 List.668;
-            let List.665 : U8 = 1i64;
-            let List.666 : U8 = GetTagId List.660;
-            let List.667 : Int1 = lowlevel Eq List.665 List.666;
-            if List.667 then
-                let List.495 : {U64, Int1} = UnionAtIndex (Id 1) (Index 0) List.660;
-                let List.663 : U64 = 1i64;
-                let List.662 : U64 = CallByName Num.51 List.493 List.663;
-                jump List.657 List.490 List.495 List.492 List.662 List.494;
+    joinpoint List.659 List.491 List.492 List.493 List.494 List.495:
+        let List.661 : Int1 = CallByName Num.22 List.494 List.495;
+        if List.661 then
+            let List.670 : U8 = CallByName List.66 List.491 List.494;
+            let List.662 : [C {U64, Int1}, C {U64, Int1}] = CallByName TotallyNotJson.157 List.492 List.670;
+            let List.667 : U8 = 1i64;
+            let List.668 : U8 = GetTagId List.662;
+            let List.669 : Int1 = lowlevel Eq List.667 List.668;
+            if List.669 then
+                let List.496 : {U64, Int1} = UnionAtIndex (Id 1) (Index 0) List.662;
+                let List.665 : U64 = 1i64;
+                let List.664 : U64 = CallByName Num.51 List.494 List.665;
+                jump List.659 List.491 List.496 List.493 List.664 List.495;
             else
-                dec List.490;
-                let List.496 : {U64, Int1} = UnionAtIndex (Id 0) (Index 0) List.660;
-                let List.664 : [C {U64, Int1}, C {U64, Int1}] = TagId(0) List.496;
-                ret List.664;
+                dec List.491;
+                let List.497 : {U64, Int1} = UnionAtIndex (Id 0) (Index 0) List.662;
+                let List.666 : [C {U64, Int1}, C {U64, Int1}] = TagId(0) List.497;
+                ret List.666;
         else
-            dec List.490;
-            let List.658 : [C {U64, Int1}, C {U64, Int1}] = TagId(1) List.491;
-            ret List.658;
+            dec List.491;
+            let List.660 : [C {U64, Int1}, C {U64, Int1}] = TagId(1) List.492;
+            ret List.660;
     in
-    jump List.657 #Derived_gen.18 #Derived_gen.19 #Derived_gen.20 #Derived_gen.21 #Derived_gen.22;
+    jump List.659 #Derived_gen.18 #Derived_gen.19 #Derived_gen.20 #Derived_gen.21 #Derived_gen.22;
 
-procedure List.91 (#Derived_gen.10, #Derived_gen.11, #Derived_gen.12, #Derived_gen.13, #Derived_gen.14):
-    joinpoint List.601 List.162 List.163 List.164 List.165 List.166:
-        let List.603 : Int1 = CallByName Num.22 List.165 List.166;
-        if List.603 then
-            let List.607 : Str = CallByName List.66 List.162 List.165;
-            inc List.607;
-            let List.167 : {List U8, U64} = CallByName TotallyNotJson.233 List.163 List.607;
-            let List.606 : U64 = 1i64;
-            let List.605 : U64 = CallByName Num.51 List.165 List.606;
-            jump List.601 List.162 List.167 List.164 List.605 List.166;
+procedure List.92 (#Derived_gen.10, #Derived_gen.11, #Derived_gen.12, #Derived_gen.13, #Derived_gen.14):
+    joinpoint List.603 List.163 List.164 List.165 List.166 List.167:
+        let List.605 : Int1 = CallByName Num.22 List.166 List.167;
+        if List.605 then
+            let List.609 : Str = CallByName List.66 List.163 List.166;
+            inc List.609;
+            let List.168 : {List U8, U64} = CallByName TotallyNotJson.233 List.164 List.609;
+            let List.608 : U64 = 1i64;
+            let List.607 : U64 = CallByName Num.51 List.166 List.608;
+            jump List.603 List.163 List.168 List.165 List.607 List.167;
         else
-            dec List.162;
-            ret List.163;
+            dec List.163;
+            ret List.164;
     in
-    jump List.601 #Derived_gen.10 #Derived_gen.11 #Derived_gen.12 #Derived_gen.13 #Derived_gen.14;
+    jump List.603 #Derived_gen.10 #Derived_gen.11 #Derived_gen.12 #Derived_gen.13 #Derived_gen.14;
 
-procedure List.91 (#Derived_gen.23, #Derived_gen.24, #Derived_gen.25, #Derived_gen.26, #Derived_gen.27):
-    joinpoint List.613 List.162 List.163 List.164 List.165 List.166:
-        let List.615 : Int1 = CallByName Num.22 List.165 List.166;
-        if List.615 then
-            let List.619 : U8 = CallByName List.66 List.162 List.165;
-            let List.167 : List U8 = CallByName TotallyNotJson.183 List.163 List.619;
-            let List.618 : U64 = 1i64;
-            let List.617 : U64 = CallByName Num.51 List.165 List.618;
-            jump List.613 List.162 List.167 List.164 List.617 List.166;
+procedure List.92 (#Derived_gen.23, #Derived_gen.24, #Derived_gen.25, #Derived_gen.26, #Derived_gen.27):
+    joinpoint List.615 List.163 List.164 List.165 List.166 List.167:
+        let List.617 : Int1 = CallByName Num.22 List.166 List.167;
+        if List.617 then
+            let List.621 : U8 = CallByName List.66 List.163 List.166;
+            let List.168 : List U8 = CallByName TotallyNotJson.183 List.164 List.621;
+            let List.620 : U64 = 1i64;
+            let List.619 : U64 = CallByName Num.51 List.166 List.620;
+            jump List.615 List.163 List.168 List.165 List.619 List.167;
         else
-            dec List.162;
-            ret List.163;
+            dec List.163;
+            ret List.164;
     in
-    jump List.613 #Derived_gen.23 #Derived_gen.24 #Derived_gen.25 #Derived_gen.26 #Derived_gen.27;
+    jump List.615 #Derived_gen.23 #Derived_gen.24 #Derived_gen.25 #Derived_gen.26 #Derived_gen.27;
 
 procedure Num.127 (#Attr.2):
     let Num.286 : U8 = lowlevel NumIntCast #Attr.2;

--- a/crates/compiler/test_mono/generated/encode_derived_tag_two_payloads_string.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_tag_two_payloads_string.txt
@@ -43,159 +43,159 @@ procedure Encode.26 (Encode.105, Encode.106):
     let Encode.108 : List U8 = CallByName Encode.24 Encode.109 Encode.110 Encode.106;
     ret Encode.108;
 
-procedure List.103 (List.487, List.488, List.489):
-    let List.655 : U64 = 0i64;
-    let List.656 : U64 = CallByName List.6 List.487;
-    let List.654 : [C {U64, Int1}, C {U64, Int1}] = CallByName List.80 List.487 List.488 List.489 List.655 List.656;
-    ret List.654;
+procedure List.104 (List.488, List.489, List.490):
+    let List.657 : U64 = 0i64;
+    let List.658 : U64 = CallByName List.6 List.488;
+    let List.656 : [C {U64, Int1}, C {U64, Int1}] = CallByName List.80 List.488 List.489 List.490 List.657 List.658;
+    ret List.656;
 
-procedure List.18 (List.159, List.160, List.161):
-    let List.599 : U64 = 0i64;
-    let List.600 : U64 = CallByName List.6 List.159;
-    let List.598 : {List U8, U64} = CallByName List.91 List.159 List.160 List.161 List.599 List.600;
-    ret List.598;
+procedure List.18 (List.160, List.161, List.162):
+    let List.601 : U64 = 0i64;
+    let List.602 : U64 = CallByName List.6 List.160;
+    let List.600 : {List U8, U64} = CallByName List.92 List.160 List.161 List.162 List.601 List.602;
+    ret List.600;
 
-procedure List.18 (List.159, List.160, List.161):
-    let List.611 : U64 = 0i64;
-    let List.612 : U64 = CallByName List.6 List.159;
-    let List.610 : List U8 = CallByName List.91 List.159 List.160 List.161 List.611 List.612;
-    ret List.610;
+procedure List.18 (List.160, List.161, List.162):
+    let List.613 : U64 = 0i64;
+    let List.614 : U64 = CallByName List.6 List.160;
+    let List.612 : List U8 = CallByName List.92 List.160 List.161 List.162 List.613 List.614;
+    ret List.612;
 
-procedure List.26 (List.200, List.201, List.202):
-    let List.648 : [C {U64, Int1}, C {U64, Int1}] = CallByName List.103 List.200 List.201 List.202;
-    let List.651 : U8 = 1i64;
-    let List.652 : U8 = GetTagId List.648;
-    let List.653 : Int1 = lowlevel Eq List.651 List.652;
-    if List.653 then
-        let List.203 : {U64, Int1} = UnionAtIndex (Id 1) (Index 0) List.648;
-        ret List.203;
-    else
-        let List.204 : {U64, Int1} = UnionAtIndex (Id 0) (Index 0) List.648;
+procedure List.26 (List.201, List.202, List.203):
+    let List.650 : [C {U64, Int1}, C {U64, Int1}] = CallByName List.104 List.201 List.202 List.203;
+    let List.653 : U8 = 1i64;
+    let List.654 : U8 = GetTagId List.650;
+    let List.655 : Int1 = lowlevel Eq List.653 List.654;
+    if List.655 then
+        let List.204 : {U64, Int1} = UnionAtIndex (Id 1) (Index 0) List.650;
         ret List.204;
-
-procedure List.4 (List.123, List.124):
-    let List.597 : U64 = 1i64;
-    let List.596 : List U8 = CallByName List.70 List.123 List.597;
-    let List.595 : List U8 = CallByName List.71 List.596 List.124;
-    ret List.595;
-
-procedure List.49 (List.419, List.420):
-    let List.639 : U64 = StructAtIndex 1 List.420;
-    let List.640 : U64 = StructAtIndex 0 List.420;
-    let List.638 : List U8 = CallByName List.72 List.419 List.639 List.640;
-    ret List.638;
-
-procedure List.52 (List.434, List.435):
-    let List.436 : U64 = CallByName List.6 List.434;
-    joinpoint List.646 List.437:
-        let List.644 : U64 = 0i64;
-        let List.643 : {U64, U64} = Struct {List.437, List.644};
-        inc List.434;
-        let List.438 : List U8 = CallByName List.49 List.434 List.643;
-        let List.642 : U64 = CallByName Num.75 List.436 List.437;
-        let List.637 : {U64, U64} = Struct {List.642, List.437};
-        let List.439 : List U8 = CallByName List.49 List.434 List.637;
-        let List.636 : {List U8, List U8} = Struct {List.438, List.439};
-        ret List.636;
-    in
-    let List.647 : Int1 = CallByName Num.24 List.436 List.435;
-    if List.647 then
-        jump List.646 List.435;
     else
-        jump List.646 List.436;
+        let List.205 : {U64, Int1} = UnionAtIndex (Id 0) (Index 0) List.650;
+        ret List.205;
 
-procedure List.6 (#Attr.2):
-    let List.622 : U64 = lowlevel ListLenU64 #Attr.2;
-    ret List.622;
+procedure List.4 (List.124, List.125):
+    let List.599 : U64 = 1i64;
+    let List.598 : List U8 = CallByName List.70 List.124 List.599;
+    let List.597 : List U8 = CallByName List.71 List.598 List.125;
+    ret List.597;
+
+procedure List.49 (List.420, List.421):
+    let List.641 : U64 = StructAtIndex 1 List.421;
+    let List.642 : U64 = StructAtIndex 0 List.421;
+    let List.640 : List U8 = CallByName List.72 List.420 List.641 List.642;
+    ret List.640;
+
+procedure List.52 (List.435, List.436):
+    let List.437 : U64 = CallByName List.6 List.435;
+    joinpoint List.648 List.438:
+        let List.646 : U64 = 0i64;
+        let List.645 : {U64, U64} = Struct {List.438, List.646};
+        inc List.435;
+        let List.439 : List U8 = CallByName List.49 List.435 List.645;
+        let List.644 : U64 = CallByName Num.75 List.437 List.438;
+        let List.639 : {U64, U64} = Struct {List.644, List.438};
+        let List.440 : List U8 = CallByName List.49 List.435 List.639;
+        let List.638 : {List U8, List U8} = Struct {List.439, List.440};
+        ret List.638;
+    in
+    let List.649 : Int1 = CallByName Num.24 List.437 List.436;
+    if List.649 then
+        jump List.648 List.436;
+    else
+        jump List.648 List.437;
 
 procedure List.6 (#Attr.2):
     let List.624 : U64 = lowlevel ListLenU64 #Attr.2;
     ret List.624;
 
-procedure List.66 (#Attr.2, #Attr.3):
-    let List.608 : Str = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.608;
+procedure List.6 (#Attr.2):
+    let List.626 : U64 = lowlevel ListLenU64 #Attr.2;
+    ret List.626;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.620 : U8 = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.620;
+    let List.610 : Str = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.610;
+
+procedure List.66 (#Attr.2, #Attr.3):
+    let List.622 : U8 = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.622;
 
 procedure List.68 (#Attr.2):
-    let List.635 : List U8 = lowlevel ListWithCapacity #Attr.2;
-    ret List.635;
+    let List.637 : List U8 = lowlevel ListWithCapacity #Attr.2;
+    ret List.637;
 
 procedure List.70 (#Attr.2, #Attr.3):
-    let List.576 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
-    ret List.576;
+    let List.578 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
+    ret List.578;
 
 procedure List.71 (#Attr.2, #Attr.3):
-    let List.574 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
-    ret List.574;
+    let List.576 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
+    ret List.576;
 
 procedure List.72 (#Attr.2, #Attr.3, #Attr.4):
-    let List.641 : List U8 = lowlevel ListSublist #Attr.2 #Attr.3 #Attr.4;
-    ret List.641;
+    let List.643 : List U8 = lowlevel ListSublist #Attr.2 #Attr.3 #Attr.4;
+    ret List.643;
 
 procedure List.8 (#Attr.2, #Attr.3):
-    let List.633 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
-    ret List.633;
+    let List.635 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
+    ret List.635;
 
-procedure List.80 (#Derived_gen.24, #Derived_gen.25, #Derived_gen.26, #Derived_gen.27, #Derived_gen.28):
-    joinpoint List.657 List.490 List.491 List.492 List.493 List.494:
-        let List.659 : Int1 = CallByName Num.22 List.493 List.494;
-        if List.659 then
-            let List.668 : U8 = CallByName List.66 List.490 List.493;
-            let List.660 : [C {U64, Int1}, C {U64, Int1}] = CallByName TotallyNotJson.157 List.491 List.668;
-            let List.665 : U8 = 1i64;
-            let List.666 : U8 = GetTagId List.660;
-            let List.667 : Int1 = lowlevel Eq List.665 List.666;
-            if List.667 then
-                let List.495 : {U64, Int1} = UnionAtIndex (Id 1) (Index 0) List.660;
-                let List.663 : U64 = 1i64;
-                let List.662 : U64 = CallByName Num.51 List.493 List.663;
-                jump List.657 List.490 List.495 List.492 List.662 List.494;
+procedure List.80 (#Derived_gen.19, #Derived_gen.20, #Derived_gen.21, #Derived_gen.22, #Derived_gen.23):
+    joinpoint List.659 List.491 List.492 List.493 List.494 List.495:
+        let List.661 : Int1 = CallByName Num.22 List.494 List.495;
+        if List.661 then
+            let List.670 : U8 = CallByName List.66 List.491 List.494;
+            let List.662 : [C {U64, Int1}, C {U64, Int1}] = CallByName TotallyNotJson.157 List.492 List.670;
+            let List.667 : U8 = 1i64;
+            let List.668 : U8 = GetTagId List.662;
+            let List.669 : Int1 = lowlevel Eq List.667 List.668;
+            if List.669 then
+                let List.496 : {U64, Int1} = UnionAtIndex (Id 1) (Index 0) List.662;
+                let List.665 : U64 = 1i64;
+                let List.664 : U64 = CallByName Num.51 List.494 List.665;
+                jump List.659 List.491 List.496 List.493 List.664 List.495;
             else
-                dec List.490;
-                let List.496 : {U64, Int1} = UnionAtIndex (Id 0) (Index 0) List.660;
-                let List.664 : [C {U64, Int1}, C {U64, Int1}] = TagId(0) List.496;
-                ret List.664;
+                dec List.491;
+                let List.497 : {U64, Int1} = UnionAtIndex (Id 0) (Index 0) List.662;
+                let List.666 : [C {U64, Int1}, C {U64, Int1}] = TagId(0) List.497;
+                ret List.666;
         else
-            dec List.490;
-            let List.658 : [C {U64, Int1}, C {U64, Int1}] = TagId(1) List.491;
-            ret List.658;
+            dec List.491;
+            let List.660 : [C {U64, Int1}, C {U64, Int1}] = TagId(1) List.492;
+            ret List.660;
     in
-    jump List.657 #Derived_gen.24 #Derived_gen.25 #Derived_gen.26 #Derived_gen.27 #Derived_gen.28;
+    jump List.659 #Derived_gen.19 #Derived_gen.20 #Derived_gen.21 #Derived_gen.22 #Derived_gen.23;
 
-procedure List.91 (#Derived_gen.14, #Derived_gen.15, #Derived_gen.16, #Derived_gen.17, #Derived_gen.18):
-    joinpoint List.601 List.162 List.163 List.164 List.165 List.166:
-        let List.603 : Int1 = CallByName Num.22 List.165 List.166;
-        if List.603 then
-            let List.607 : Str = CallByName List.66 List.162 List.165;
-            inc List.607;
-            let List.167 : {List U8, U64} = CallByName TotallyNotJson.233 List.163 List.607;
-            let List.606 : U64 = 1i64;
-            let List.605 : U64 = CallByName Num.51 List.165 List.606;
-            jump List.601 List.162 List.167 List.164 List.605 List.166;
+procedure List.92 (#Derived_gen.14, #Derived_gen.15, #Derived_gen.16, #Derived_gen.17, #Derived_gen.18):
+    joinpoint List.615 List.163 List.164 List.165 List.166 List.167:
+        let List.617 : Int1 = CallByName Num.22 List.166 List.167;
+        if List.617 then
+            let List.621 : U8 = CallByName List.66 List.163 List.166;
+            let List.168 : List U8 = CallByName TotallyNotJson.183 List.164 List.621;
+            let List.620 : U64 = 1i64;
+            let List.619 : U64 = CallByName Num.51 List.166 List.620;
+            jump List.615 List.163 List.168 List.165 List.619 List.167;
         else
-            dec List.162;
-            ret List.163;
+            dec List.163;
+            ret List.164;
     in
-    jump List.601 #Derived_gen.14 #Derived_gen.15 #Derived_gen.16 #Derived_gen.17 #Derived_gen.18;
+    jump List.615 #Derived_gen.14 #Derived_gen.15 #Derived_gen.16 #Derived_gen.17 #Derived_gen.18;
 
-procedure List.91 (#Derived_gen.19, #Derived_gen.20, #Derived_gen.21, #Derived_gen.22, #Derived_gen.23):
-    joinpoint List.613 List.162 List.163 List.164 List.165 List.166:
-        let List.615 : Int1 = CallByName Num.22 List.165 List.166;
-        if List.615 then
-            let List.619 : U8 = CallByName List.66 List.162 List.165;
-            let List.167 : List U8 = CallByName TotallyNotJson.183 List.163 List.619;
-            let List.618 : U64 = 1i64;
-            let List.617 : U64 = CallByName Num.51 List.165 List.618;
-            jump List.613 List.162 List.167 List.164 List.617 List.166;
+procedure List.92 (#Derived_gen.30, #Derived_gen.31, #Derived_gen.32, #Derived_gen.33, #Derived_gen.34):
+    joinpoint List.603 List.163 List.164 List.165 List.166 List.167:
+        let List.605 : Int1 = CallByName Num.22 List.166 List.167;
+        if List.605 then
+            let List.609 : Str = CallByName List.66 List.163 List.166;
+            inc List.609;
+            let List.168 : {List U8, U64} = CallByName TotallyNotJson.233 List.164 List.609;
+            let List.608 : U64 = 1i64;
+            let List.607 : U64 = CallByName Num.51 List.166 List.608;
+            jump List.603 List.163 List.168 List.165 List.607 List.167;
         else
-            dec List.162;
-            ret List.163;
+            dec List.163;
+            ret List.164;
     in
-    jump List.613 #Derived_gen.19 #Derived_gen.20 #Derived_gen.21 #Derived_gen.22 #Derived_gen.23;
+    jump List.603 #Derived_gen.30 #Derived_gen.31 #Derived_gen.32 #Derived_gen.33 #Derived_gen.34;
 
 procedure Num.127 (#Attr.2):
     let Num.286 : U8 = lowlevel NumIntCast #Attr.2;

--- a/crates/compiler/test_mono/generated/inspect_derived_dict.txt
+++ b/crates/compiler/test_mono/generated/inspect_derived_dict.txt
@@ -283,7 +283,7 @@ procedure Dict.65 (Dict.404, Dict.405, Dict.406):
     let Dict.846 : {U64, U32} = CallByName Dict.66 Dict.404 Dict.409 Dict.408;
     ret Dict.846;
 
-procedure Dict.66 (#Derived_gen.45, #Derived_gen.46, #Derived_gen.47):
+procedure Dict.66 (#Derived_gen.40, #Derived_gen.41, #Derived_gen.42):
     joinpoint Dict.847 Dict.410 Dict.411 Dict.412:
         let Dict.413 : {U32, U32} = CallByName Dict.22 Dict.410 Dict.411;
         let Dict.854 : U32 = StructAtIndex 1 Dict.413;
@@ -298,9 +298,9 @@ procedure Dict.66 (#Derived_gen.45, #Derived_gen.46, #Derived_gen.47):
             let Dict.848 : {U64, U32} = Struct {Dict.411, Dict.412};
             ret Dict.848;
     in
-    jump Dict.847 #Derived_gen.45 #Derived_gen.46 #Derived_gen.47;
+    jump Dict.847 #Derived_gen.40 #Derived_gen.41 #Derived_gen.42;
 
-procedure Dict.67 (#Derived_gen.31, #Derived_gen.32, #Derived_gen.33):
+procedure Dict.67 (#Derived_gen.28, #Derived_gen.29, #Derived_gen.30):
     joinpoint Dict.753 Dict.414 Dict.415 Dict.416:
         let Dict.417 : {U32, U32} = CallByName Dict.22 Dict.414 Dict.416;
         let Dict.763 : U32 = StructAtIndex 1 Dict.417;
@@ -319,7 +319,7 @@ procedure Dict.67 (#Derived_gen.31, #Derived_gen.32, #Derived_gen.33):
             let Dict.754 : List {U32, U32} = CallByName List.3 Dict.414 Dict.416 Dict.415;
             ret Dict.754;
     in
-    jump Dict.753 #Derived_gen.31 #Derived_gen.32 #Derived_gen.33;
+    jump Dict.753 #Derived_gen.28 #Derived_gen.29 #Derived_gen.30;
 
 procedure Dict.68 (Dict.419, Dict.420):
     let Dict.749 : U64 = 1i64;
@@ -564,7 +564,7 @@ procedure Dict.83 (#Derived_gen.9, #Derived_gen.10, #Derived_gen.11, #Derived_ge
     in
     jump Dict.920 #Derived_gen.9 #Derived_gen.10 #Derived_gen.11 #Derived_gen.12 #Derived_gen.13 #Derived_gen.14;
 
-procedure Dict.84 (#Derived_gen.48, #Derived_gen.49, #Derived_gen.50, #Derived_gen.51):
+procedure Dict.84 (#Derived_gen.43, #Derived_gen.44, #Derived_gen.45, #Derived_gen.46):
     joinpoint Dict.973 Dict.499 Dict.500 Dict.501 Dict.502:
         inc 2 Dict.500;
         let Dict.993 : U64 = CallByName Dict.91 Dict.500 Dict.501;
@@ -596,7 +596,7 @@ procedure Dict.84 (#Derived_gen.48, #Derived_gen.49, #Derived_gen.50, #Derived_g
         else
             jump Dict.973 Dict.503 Dict.500 Dict.505 Dict.504;
     in
-    jump Dict.973 #Derived_gen.48 #Derived_gen.49 #Derived_gen.50 #Derived_gen.51;
+    jump Dict.973 #Derived_gen.43 #Derived_gen.44 #Derived_gen.45 #Derived_gen.46;
 
 procedure Dict.85 ():
     let Dict.910 : U64 = 11562461410679940143i64;
@@ -880,168 +880,168 @@ procedure Inspect.59 (Inspect.296, Inspect.292):
 procedure Inspect.60 (Inspect.298):
     ret Inspect.298;
 
-procedure List.11 (List.137, List.138):
-    let List.634 : List {U32, U32} = CallByName List.68 List.138;
-    let List.633 : List {U32, U32} = CallByName List.89 List.137 List.138 List.634;
-    ret List.633;
-
-procedure List.18 (List.159, List.160, List.161):
-    let List.573 : U64 = 0i64;
-    let List.574 : U64 = CallByName List.6 List.159;
-    let List.572 : {List {U32, U32}, List {Str, I64}, U64, Float32, U8} = CallByName List.91 List.159 List.160 List.161 List.573 List.574;
-    ret List.572;
-
-procedure List.18 (List.159, List.160, List.161):
-    let List.637 : U64 = 0i64;
-    let List.638 : U64 = CallByName List.6 List.159;
-    let List.636 : {Str, Int1} = CallByName List.91 List.159 List.160 List.161 List.637 List.638;
-    ret List.636;
-
-procedure List.3 (List.115, List.116, List.117):
-    let List.598 : {List {U32, U32}, {U32, U32}} = CallByName List.64 List.115 List.116 List.117;
-    let List.597 : List {U32, U32} = StructAtIndex 0 List.598;
-    ret List.597;
-
-procedure List.3 (List.115, List.116, List.117):
-    let List.600 : {List {Str, I64}, {Str, I64}} = CallByName List.64 List.115 List.116 List.117;
-    let List.599 : List {Str, I64} = StructAtIndex 0 List.600;
-    let #Derived_gen.71 : {Str, I64} = StructAtIndex 1 List.600;
-    dec #Derived_gen.71;
-    ret List.599;
-
-procedure List.4 (List.123, List.124):
-    let List.609 : U64 = 1i64;
-    let List.607 : List {Str, I64} = CallByName List.70 List.123 List.609;
-    let List.606 : List {Str, I64} = CallByName List.71 List.607 List.124;
-    ret List.606;
-
-procedure List.6 (#Attr.2):
-    let List.588 : U64 = lowlevel ListLenU64 #Attr.2;
-    ret List.588;
-
-procedure List.6 (#Attr.2):
-    let List.635 : U64 = lowlevel ListLenU64 #Attr.2;
+procedure List.11 (List.138, List.139):
+    let List.636 : List {U32, U32} = CallByName List.68 List.139;
+    let List.635 : List {U32, U32} = CallByName List.90 List.138 List.139 List.636;
     ret List.635;
 
+procedure List.18 (List.160, List.161, List.162):
+    let List.575 : U64 = 0i64;
+    let List.576 : U64 = CallByName List.6 List.160;
+    let List.574 : {List {U32, U32}, List {Str, I64}, U64, Float32, U8} = CallByName List.92 List.160 List.161 List.162 List.575 List.576;
+    ret List.574;
+
+procedure List.18 (List.160, List.161, List.162):
+    let List.639 : U64 = 0i64;
+    let List.640 : U64 = CallByName List.6 List.160;
+    let List.638 : {Str, Int1} = CallByName List.92 List.160 List.161 List.162 List.639 List.640;
+    ret List.638;
+
+procedure List.3 (List.116, List.117, List.118):
+    let List.600 : {List {U32, U32}, {U32, U32}} = CallByName List.64 List.116 List.117 List.118;
+    let List.599 : List {U32, U32} = StructAtIndex 0 List.600;
+    ret List.599;
+
+procedure List.3 (List.116, List.117, List.118):
+    let List.602 : {List {Str, I64}, {Str, I64}} = CallByName List.64 List.116 List.117 List.118;
+    let List.601 : List {Str, I64} = StructAtIndex 0 List.602;
+    let #Derived_gen.71 : {Str, I64} = StructAtIndex 1 List.602;
+    dec #Derived_gen.71;
+    ret List.601;
+
+procedure List.4 (List.124, List.125):
+    let List.611 : U64 = 1i64;
+    let List.609 : List {Str, I64} = CallByName List.70 List.124 List.611;
+    let List.608 : List {Str, I64} = CallByName List.71 List.609 List.125;
+    ret List.608;
+
 procedure List.6 (#Attr.2):
-    let List.647 : U64 = lowlevel ListLenU64 #Attr.2;
-    ret List.647;
+    let List.590 : U64 = lowlevel ListLenU64 #Attr.2;
+    ret List.590;
 
-procedure List.64 (List.112, List.113, List.114):
-    let List.596 : U64 = CallByName List.6 List.112;
-    let List.593 : Int1 = CallByName Num.22 List.113 List.596;
-    if List.593 then
-        let List.594 : {List {U32, U32}, {U32, U32}} = CallByName List.67 List.112 List.113 List.114;
+procedure List.6 (#Attr.2):
+    let List.637 : U64 = lowlevel ListLenU64 #Attr.2;
+    ret List.637;
+
+procedure List.6 (#Attr.2):
+    let List.649 : U64 = lowlevel ListLenU64 #Attr.2;
+    ret List.649;
+
+procedure List.64 (List.113, List.114, List.115):
+    let List.598 : U64 = CallByName List.6 List.113;
+    let List.595 : Int1 = CallByName Num.22 List.114 List.598;
+    if List.595 then
+        let List.596 : {List {U32, U32}, {U32, U32}} = CallByName List.67 List.113 List.114 List.115;
+        ret List.596;
+    else
+        let List.594 : {List {U32, U32}, {U32, U32}} = Struct {List.113, List.115};
         ret List.594;
-    else
-        let List.592 : {List {U32, U32}, {U32, U32}} = Struct {List.112, List.114};
-        ret List.592;
 
-procedure List.64 (List.112, List.113, List.114):
-    let List.605 : U64 = CallByName List.6 List.112;
-    let List.602 : Int1 = CallByName Num.22 List.113 List.605;
-    if List.602 then
-        let List.603 : {List {Str, I64}, {Str, I64}} = CallByName List.67 List.112 List.113 List.114;
-        ret List.603;
+procedure List.64 (List.113, List.114, List.115):
+    let List.607 : U64 = CallByName List.6 List.113;
+    let List.604 : Int1 = CallByName Num.22 List.114 List.607;
+    if List.604 then
+        let List.605 : {List {Str, I64}, {Str, I64}} = CallByName List.67 List.113 List.114 List.115;
+        ret List.605;
     else
-        let List.601 : {List {Str, I64}, {Str, I64}} = Struct {List.112, List.114};
-        ret List.601;
+        let List.603 : {List {Str, I64}, {Str, I64}} = Struct {List.113, List.115};
+        ret List.603;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.646 : {Str, I64} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.646;
+    let List.648 : {Str, I64} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.648;
 
 procedure List.67 (#Attr.2, #Attr.3, #Attr.4):
-    let List.595 : {List {U32, U32}, {U32, U32}} = lowlevel ListReplaceUnsafe #Attr.2 #Attr.3 #Attr.4;
-    ret List.595;
+    let List.597 : {List {U32, U32}, {U32, U32}} = lowlevel ListReplaceUnsafe #Attr.2 #Attr.3 #Attr.4;
+    ret List.597;
 
 procedure List.67 (#Attr.2, #Attr.3, #Attr.4):
-    let List.604 : {List {Str, I64}, {Str, I64}} = lowlevel ListReplaceUnsafe #Attr.2 #Attr.3 #Attr.4;
-    ret List.604;
+    let List.606 : {List {Str, I64}, {Str, I64}} = lowlevel ListReplaceUnsafe #Attr.2 #Attr.3 #Attr.4;
+    ret List.606;
 
 procedure List.68 (#Attr.2):
-    let List.632 : List {U32, U32} = lowlevel ListWithCapacity #Attr.2;
-    ret List.632;
+    let List.634 : List {U32, U32} = lowlevel ListWithCapacity #Attr.2;
+    ret List.634;
 
 procedure List.70 (#Attr.2, #Attr.3):
-    let List.610 : List {Str, I64} = lowlevel ListReserve #Attr.2 #Attr.3;
+    let List.612 : List {Str, I64} = lowlevel ListReserve #Attr.2 #Attr.3;
+    ret List.612;
+
+procedure List.71 (#Attr.2, #Attr.3):
+    let List.610 : List {Str, I64} = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
     ret List.610;
 
 procedure List.71 (#Attr.2, #Attr.3):
-    let List.608 : List {Str, I64} = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
-    ret List.608;
+    let List.631 : List {U32, U32} = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
+    ret List.631;
 
-procedure List.71 (#Attr.2, #Attr.3):
-    let List.629 : List {U32, U32} = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
-    ret List.629;
+procedure List.83 (List.169, List.170, List.171):
+    let List.614 : U64 = 0i64;
+    let List.615 : U64 = CallByName List.6 List.169;
+    let List.613 : List {U32, U32} = CallByName List.93 List.169 List.170 List.171 List.614 List.615;
+    ret List.613;
 
-procedure List.83 (List.168, List.169, List.170):
-    let List.612 : U64 = 0i64;
-    let List.613 : U64 = CallByName List.6 List.168;
-    let List.611 : List {U32, U32} = CallByName List.92 List.168 List.169 List.170 List.612 List.613;
-    ret List.611;
-
-procedure List.89 (#Derived_gen.28, #Derived_gen.29, #Derived_gen.30):
-    joinpoint List.623 List.139 List.140 List.141:
-        let List.631 : U64 = 0i64;
-        let List.625 : Int1 = CallByName Num.24 List.140 List.631;
-        if List.625 then
-            let List.630 : U64 = 1i64;
-            let List.627 : U64 = CallByName Num.75 List.140 List.630;
-            let List.628 : List {U32, U32} = CallByName List.71 List.141 List.139;
-            jump List.623 List.139 List.627 List.628;
+procedure List.90 (#Derived_gen.33, #Derived_gen.34, #Derived_gen.35):
+    joinpoint List.625 List.140 List.141 List.142:
+        let List.633 : U64 = 0i64;
+        let List.627 : Int1 = CallByName Num.24 List.141 List.633;
+        if List.627 then
+            let List.632 : U64 = 1i64;
+            let List.629 : U64 = CallByName Num.75 List.141 List.632;
+            let List.630 : List {U32, U32} = CallByName List.71 List.142 List.140;
+            jump List.625 List.140 List.629 List.630;
         else
-            ret List.141;
+            ret List.142;
     in
-    jump List.623 #Derived_gen.28 #Derived_gen.29 #Derived_gen.30;
+    jump List.625 #Derived_gen.33 #Derived_gen.34 #Derived_gen.35;
 
-procedure List.91 (#Derived_gen.23, #Derived_gen.24, #Derived_gen.25, #Derived_gen.26, #Derived_gen.27):
-    joinpoint List.575 List.162 List.163 List.164 List.165 List.166:
-        let List.577 : Int1 = CallByName Num.22 List.165 List.166;
-        if List.577 then
-            let List.581 : {Str, I64} = CallByName List.66 List.162 List.165;
-            inc List.581;
-            let List.167 : {List {U32, U32}, List {Str, I64}, U64, Float32, U8} = CallByName Dict.152 List.163 List.581;
-            let List.580 : U64 = 1i64;
-            let List.579 : U64 = CallByName Num.51 List.165 List.580;
-            jump List.575 List.162 List.167 List.164 List.579 List.166;
+procedure List.92 (#Derived_gen.50, #Derived_gen.51, #Derived_gen.52, #Derived_gen.53, #Derived_gen.54):
+    joinpoint List.577 List.163 List.164 List.165 List.166 List.167:
+        let List.579 : Int1 = CallByName Num.22 List.166 List.167;
+        if List.579 then
+            let List.583 : {Str, I64} = CallByName List.66 List.163 List.166;
+            inc List.583;
+            let List.168 : {List {U32, U32}, List {Str, I64}, U64, Float32, U8} = CallByName Dict.152 List.164 List.583;
+            let List.582 : U64 = 1i64;
+            let List.581 : U64 = CallByName Num.51 List.166 List.582;
+            jump List.577 List.163 List.168 List.165 List.581 List.167;
         else
-            dec List.162;
-            ret List.163;
+            dec List.163;
+            ret List.164;
     in
-    jump List.575 #Derived_gen.23 #Derived_gen.24 #Derived_gen.25 #Derived_gen.26 #Derived_gen.27;
+    jump List.577 #Derived_gen.50 #Derived_gen.51 #Derived_gen.52 #Derived_gen.53 #Derived_gen.54;
 
-procedure List.91 (#Derived_gen.59, #Derived_gen.60, #Derived_gen.61, #Derived_gen.62, #Derived_gen.63):
-    joinpoint List.639 List.162 List.163 List.164 List.165 List.166:
-        let List.641 : Int1 = CallByName Num.22 List.165 List.166;
-        if List.641 then
-            let List.645 : {Str, I64} = CallByName List.66 List.162 List.165;
-            inc List.645;
-            let List.167 : {Str, Int1} = CallByName Dict.181 List.163 List.645 List.164;
-            let List.644 : U64 = 1i64;
-            let List.643 : U64 = CallByName Num.51 List.165 List.644;
-            jump List.639 List.162 List.167 List.164 List.643 List.166;
+procedure List.92 (#Derived_gen.59, #Derived_gen.60, #Derived_gen.61, #Derived_gen.62, #Derived_gen.63):
+    joinpoint List.641 List.163 List.164 List.165 List.166 List.167:
+        let List.643 : Int1 = CallByName Num.22 List.166 List.167;
+        if List.643 then
+            let List.647 : {Str, I64} = CallByName List.66 List.163 List.166;
+            inc List.647;
+            let List.168 : {Str, Int1} = CallByName Dict.181 List.164 List.647 List.165;
+            let List.646 : U64 = 1i64;
+            let List.645 : U64 = CallByName Num.51 List.166 List.646;
+            jump List.641 List.163 List.168 List.165 List.645 List.167;
         else
-            dec List.162;
-            ret List.163;
+            dec List.163;
+            ret List.164;
     in
-    jump List.639 #Derived_gen.59 #Derived_gen.60 #Derived_gen.61 #Derived_gen.62 #Derived_gen.63;
+    jump List.641 #Derived_gen.59 #Derived_gen.60 #Derived_gen.61 #Derived_gen.62 #Derived_gen.63;
 
-procedure List.92 (#Derived_gen.38, #Derived_gen.39, #Derived_gen.40, #Derived_gen.41, #Derived_gen.42):
-    joinpoint List.614 List.171 List.172 List.173 List.174 List.175:
-        let List.616 : Int1 = CallByName Num.22 List.174 List.175;
-        if List.616 then
-            let List.620 : {Str, I64} = CallByName List.66 List.171 List.174;
-            inc List.620;
-            let List.176 : List {U32, U32} = CallByName Dict.398 List.172 List.620 List.174 List.173;
-            let List.619 : U64 = 1i64;
-            let List.618 : U64 = CallByName Num.51 List.174 List.619;
-            jump List.614 List.171 List.176 List.173 List.618 List.175;
+procedure List.93 (#Derived_gen.23, #Derived_gen.24, #Derived_gen.25, #Derived_gen.26, #Derived_gen.27):
+    joinpoint List.616 List.172 List.173 List.174 List.175 List.176:
+        let List.618 : Int1 = CallByName Num.22 List.175 List.176;
+        if List.618 then
+            let List.622 : {Str, I64} = CallByName List.66 List.172 List.175;
+            inc List.622;
+            let List.177 : List {U32, U32} = CallByName Dict.398 List.173 List.622 List.175 List.174;
+            let List.621 : U64 = 1i64;
+            let List.620 : U64 = CallByName Num.51 List.175 List.621;
+            jump List.616 List.172 List.177 List.174 List.620 List.176;
         else
-            dec List.171;
-            ret List.172;
+            dec List.172;
+            ret List.173;
     in
-    jump List.614 #Derived_gen.38 #Derived_gen.39 #Derived_gen.40 #Derived_gen.41 #Derived_gen.42;
+    jump List.616 #Derived_gen.23 #Derived_gen.24 #Derived_gen.25 #Derived_gen.26 #Derived_gen.27;
 
 procedure Num.131 (#Attr.2):
     let Num.287 : U32 = lowlevel NumIntCast #Attr.2;

--- a/crates/compiler/test_mono/generated/inspect_derived_list.txt
+++ b/crates/compiler/test_mono/generated/inspect_derived_list.txt
@@ -125,34 +125,34 @@ procedure Inspect.59 (Inspect.296, Inspect.292):
 procedure Inspect.60 (Inspect.298):
     ret Inspect.298;
 
-procedure List.18 (List.159, List.160, List.161):
-    let List.573 : U64 = 0i64;
-    let List.574 : U64 = CallByName List.6 List.159;
-    let List.572 : {Str, Int1} = CallByName List.91 List.159 List.160 List.161 List.573 List.574;
-    ret List.572;
+procedure List.18 (List.160, List.161, List.162):
+    let List.575 : U64 = 0i64;
+    let List.576 : U64 = CallByName List.6 List.160;
+    let List.574 : {Str, Int1} = CallByName List.92 List.160 List.161 List.162 List.575 List.576;
+    ret List.574;
 
 procedure List.6 (#Attr.2):
-    let List.583 : U64 = lowlevel ListLenU64 #Attr.2;
-    ret List.583;
+    let List.585 : U64 = lowlevel ListLenU64 #Attr.2;
+    ret List.585;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.582 : I64 = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.582;
+    let List.584 : I64 = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.584;
 
-procedure List.91 (#Derived_gen.17, #Derived_gen.18, #Derived_gen.19, #Derived_gen.20, #Derived_gen.21):
-    joinpoint List.575 List.162 List.163 List.164 List.165 List.166:
-        let List.577 : Int1 = CallByName Num.22 List.165 List.166;
-        if List.577 then
-            let List.581 : I64 = CallByName List.66 List.162 List.165;
-            let List.167 : {Str, Int1} = CallByName Inspect.156 List.163 List.581 List.164;
-            let List.580 : U64 = 1i64;
-            let List.579 : U64 = CallByName Num.51 List.165 List.580;
-            jump List.575 List.162 List.167 List.164 List.579 List.166;
+procedure List.92 (#Derived_gen.19, #Derived_gen.20, #Derived_gen.21, #Derived_gen.22, #Derived_gen.23):
+    joinpoint List.577 List.163 List.164 List.165 List.166 List.167:
+        let List.579 : Int1 = CallByName Num.22 List.166 List.167;
+        if List.579 then
+            let List.583 : I64 = CallByName List.66 List.163 List.166;
+            let List.168 : {Str, Int1} = CallByName Inspect.156 List.164 List.583 List.165;
+            let List.582 : U64 = 1i64;
+            let List.581 : U64 = CallByName Num.51 List.166 List.582;
+            jump List.577 List.163 List.168 List.165 List.581 List.167;
         else
-            dec List.162;
-            ret List.163;
+            dec List.163;
+            ret List.164;
     in
-    jump List.575 #Derived_gen.17 #Derived_gen.18 #Derived_gen.19 #Derived_gen.20 #Derived_gen.21;
+    jump List.577 #Derived_gen.19 #Derived_gen.20 #Derived_gen.21 #Derived_gen.22 #Derived_gen.23;
 
 procedure Num.22 (#Attr.2, #Attr.3):
     let Num.281 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/inspect_derived_nested_record_string.txt
+++ b/crates/compiler/test_mono/generated/inspect_derived_nested_record_string.txt
@@ -200,65 +200,65 @@ procedure Inspect.59 (Inspect.296, Inspect.292):
 procedure Inspect.60 (Inspect.298):
     ret Inspect.298;
 
-procedure List.18 (List.159, List.160, List.161):
-    let List.573 : U64 = 0i64;
-    let List.574 : U64 = CallByName List.6 List.159;
-    let List.572 : {Str, Int1} = CallByName List.91 List.159 List.160 List.161 List.573 List.574;
-    ret List.572;
+procedure List.18 (List.160, List.161, List.162):
+    let List.575 : U64 = 0i64;
+    let List.576 : U64 = CallByName List.6 List.160;
+    let List.574 : {Str, Int1} = CallByName List.92 List.160 List.161 List.162 List.575 List.576;
+    ret List.574;
 
-procedure List.18 (List.159, List.160, List.161):
-    let List.585 : U64 = 0i64;
-    let List.586 : U64 = CallByName List.6 List.159;
-    let List.584 : {Str, Int1} = CallByName List.91 List.159 List.160 List.161 List.585 List.586;
+procedure List.18 (List.160, List.161, List.162):
+    let List.587 : U64 = 0i64;
+    let List.588 : U64 = CallByName List.6 List.160;
+    let List.586 : {Str, Int1} = CallByName List.92 List.160 List.161 List.162 List.587 List.588;
+    ret List.586;
+
+procedure List.6 (#Attr.2):
+    let List.585 : U64 = lowlevel ListLenU64 #Attr.2;
+    ret List.585;
+
+procedure List.6 (#Attr.2):
+    let List.597 : U64 = lowlevel ListLenU64 #Attr.2;
+    ret List.597;
+
+procedure List.66 (#Attr.2, #Attr.3):
+    let List.584 : {Str, Str} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
     ret List.584;
 
-procedure List.6 (#Attr.2):
-    let List.583 : U64 = lowlevel ListLenU64 #Attr.2;
-    ret List.583;
-
-procedure List.6 (#Attr.2):
-    let List.595 : U64 = lowlevel ListLenU64 #Attr.2;
-    ret List.595;
-
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.582 : {Str, Str} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.582;
+    let List.596 : {Str, Str} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.596;
 
-procedure List.66 (#Attr.2, #Attr.3):
-    let List.594 : {Str, Str} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.594;
-
-procedure List.91 (#Derived_gen.34, #Derived_gen.35, #Derived_gen.36, #Derived_gen.37, #Derived_gen.38):
-    joinpoint List.575 List.162 List.163 List.164 List.165 List.166:
-        let List.577 : Int1 = CallByName Num.22 List.165 List.166;
-        if List.577 then
-            let List.581 : {Str, Str} = CallByName List.66 List.162 List.165;
-            inc List.581;
-            let List.167 : {Str, Int1} = CallByName Inspect.229 List.163 List.581;
-            let List.580 : U64 = 1i64;
-            let List.579 : U64 = CallByName Num.51 List.165 List.580;
-            jump List.575 List.162 List.167 List.164 List.579 List.166;
+procedure List.92 (#Derived_gen.26, #Derived_gen.27, #Derived_gen.28, #Derived_gen.29, #Derived_gen.30):
+    joinpoint List.589 List.163 List.164 List.165 List.166 List.167:
+        let List.591 : Int1 = CallByName Num.22 List.166 List.167;
+        if List.591 then
+            let List.595 : {Str, Str} = CallByName List.66 List.163 List.166;
+            inc List.595;
+            let List.168 : {Str, Int1} = CallByName Inspect.229 List.164 List.595;
+            let List.594 : U64 = 1i64;
+            let List.593 : U64 = CallByName Num.51 List.166 List.594;
+            jump List.589 List.163 List.168 List.165 List.593 List.167;
         else
-            dec List.162;
-            ret List.163;
+            dec List.163;
+            ret List.164;
     in
-    jump List.575 #Derived_gen.34 #Derived_gen.35 #Derived_gen.36 #Derived_gen.37 #Derived_gen.38;
+    jump List.589 #Derived_gen.26 #Derived_gen.27 #Derived_gen.28 #Derived_gen.29 #Derived_gen.30;
 
-procedure List.91 (#Derived_gen.39, #Derived_gen.40, #Derived_gen.41, #Derived_gen.42, #Derived_gen.43):
-    joinpoint List.587 List.162 List.163 List.164 List.165 List.166:
-        let List.589 : Int1 = CallByName Num.22 List.165 List.166;
-        if List.589 then
-            let List.593 : {Str, Str} = CallByName List.66 List.162 List.165;
-            inc List.593;
-            let List.167 : {Str, Int1} = CallByName Inspect.229 List.163 List.593;
-            let List.592 : U64 = 1i64;
-            let List.591 : U64 = CallByName Num.51 List.165 List.592;
-            jump List.587 List.162 List.167 List.164 List.591 List.166;
+procedure List.92 (#Derived_gen.39, #Derived_gen.40, #Derived_gen.41, #Derived_gen.42, #Derived_gen.43):
+    joinpoint List.577 List.163 List.164 List.165 List.166 List.167:
+        let List.579 : Int1 = CallByName Num.22 List.166 List.167;
+        if List.579 then
+            let List.583 : {Str, Str} = CallByName List.66 List.163 List.166;
+            inc List.583;
+            let List.168 : {Str, Int1} = CallByName Inspect.229 List.164 List.583;
+            let List.582 : U64 = 1i64;
+            let List.581 : U64 = CallByName Num.51 List.166 List.582;
+            jump List.577 List.163 List.168 List.165 List.581 List.167;
         else
-            dec List.162;
-            ret List.163;
+            dec List.163;
+            ret List.164;
     in
-    jump List.587 #Derived_gen.39 #Derived_gen.40 #Derived_gen.41 #Derived_gen.42 #Derived_gen.43;
+    jump List.577 #Derived_gen.39 #Derived_gen.40 #Derived_gen.41 #Derived_gen.42 #Derived_gen.43;
 
 procedure Num.22 (#Attr.2, #Attr.3):
     let Num.282 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/inspect_derived_record.txt
+++ b/crates/compiler/test_mono/generated/inspect_derived_record.txt
@@ -150,35 +150,35 @@ procedure Inspect.59 (Inspect.296, Inspect.292):
 procedure Inspect.60 (Inspect.298):
     ret Inspect.298;
 
-procedure List.18 (List.159, List.160, List.161):
-    let List.573 : U64 = 0i64;
-    let List.574 : U64 = CallByName List.6 List.159;
-    let List.572 : {Str, Int1} = CallByName List.91 List.159 List.160 List.161 List.573 List.574;
-    ret List.572;
+procedure List.18 (List.160, List.161, List.162):
+    let List.575 : U64 = 0i64;
+    let List.576 : U64 = CallByName List.6 List.160;
+    let List.574 : {Str, Int1} = CallByName List.92 List.160 List.161 List.162 List.575 List.576;
+    ret List.574;
 
 procedure List.6 (#Attr.2):
-    let List.583 : U64 = lowlevel ListLenU64 #Attr.2;
-    ret List.583;
+    let List.585 : U64 = lowlevel ListLenU64 #Attr.2;
+    ret List.585;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.582 : {[C I64, C Decimal], Str} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.582;
+    let List.584 : {[C I64, C Decimal], Str} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.584;
 
-procedure List.91 (#Derived_gen.24, #Derived_gen.25, #Derived_gen.26, #Derived_gen.27, #Derived_gen.28):
-    joinpoint List.575 List.162 List.163 List.164 List.165 List.166:
-        let List.577 : Int1 = CallByName Num.22 List.165 List.166;
-        if List.577 then
-            let List.581 : {[C I64, C Decimal], Str} = CallByName List.66 List.162 List.165;
-            inc List.581;
-            let List.167 : {Str, Int1} = CallByName Inspect.229 List.163 List.581;
-            let List.580 : U64 = 1i64;
-            let List.579 : U64 = CallByName Num.51 List.165 List.580;
-            jump List.575 List.162 List.167 List.164 List.579 List.166;
+procedure List.92 (#Derived_gen.26, #Derived_gen.27, #Derived_gen.28, #Derived_gen.29, #Derived_gen.30):
+    joinpoint List.577 List.163 List.164 List.165 List.166 List.167:
+        let List.579 : Int1 = CallByName Num.22 List.166 List.167;
+        if List.579 then
+            let List.583 : {[C I64, C Decimal], Str} = CallByName List.66 List.163 List.166;
+            inc List.583;
+            let List.168 : {Str, Int1} = CallByName Inspect.229 List.164 List.583;
+            let List.582 : U64 = 1i64;
+            let List.581 : U64 = CallByName Num.51 List.166 List.582;
+            jump List.577 List.163 List.168 List.165 List.581 List.167;
         else
-            dec List.162;
-            ret List.163;
+            dec List.163;
+            ret List.164;
     in
-    jump List.575 #Derived_gen.24 #Derived_gen.25 #Derived_gen.26 #Derived_gen.27 #Derived_gen.28;
+    jump List.577 #Derived_gen.26 #Derived_gen.27 #Derived_gen.28 #Derived_gen.29 #Derived_gen.30;
 
 procedure Num.22 (#Attr.2, #Attr.3):
     let Num.282 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/inspect_derived_record_one_field_string.txt
+++ b/crates/compiler/test_mono/generated/inspect_derived_record_one_field_string.txt
@@ -127,35 +127,35 @@ procedure Inspect.59 (Inspect.296, Inspect.292):
 procedure Inspect.60 (Inspect.298):
     ret Inspect.298;
 
-procedure List.18 (List.159, List.160, List.161):
-    let List.573 : U64 = 0i64;
-    let List.574 : U64 = CallByName List.6 List.159;
-    let List.572 : {Str, Int1} = CallByName List.91 List.159 List.160 List.161 List.573 List.574;
-    ret List.572;
+procedure List.18 (List.160, List.161, List.162):
+    let List.575 : U64 = 0i64;
+    let List.576 : U64 = CallByName List.6 List.160;
+    let List.574 : {Str, Int1} = CallByName List.92 List.160 List.161 List.162 List.575 List.576;
+    ret List.574;
 
 procedure List.6 (#Attr.2):
-    let List.583 : U64 = lowlevel ListLenU64 #Attr.2;
-    ret List.583;
+    let List.585 : U64 = lowlevel ListLenU64 #Attr.2;
+    ret List.585;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.582 : {Str, Str} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.582;
+    let List.584 : {Str, Str} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.584;
 
-procedure List.91 (#Derived_gen.18, #Derived_gen.19, #Derived_gen.20, #Derived_gen.21, #Derived_gen.22):
-    joinpoint List.575 List.162 List.163 List.164 List.165 List.166:
-        let List.577 : Int1 = CallByName Num.22 List.165 List.166;
-        if List.577 then
-            let List.581 : {Str, Str} = CallByName List.66 List.162 List.165;
-            inc List.581;
-            let List.167 : {Str, Int1} = CallByName Inspect.229 List.163 List.581;
-            let List.580 : U64 = 1i64;
-            let List.579 : U64 = CallByName Num.51 List.165 List.580;
-            jump List.575 List.162 List.167 List.164 List.579 List.166;
+procedure List.92 (#Derived_gen.10, #Derived_gen.11, #Derived_gen.12, #Derived_gen.13, #Derived_gen.14):
+    joinpoint List.577 List.163 List.164 List.165 List.166 List.167:
+        let List.579 : Int1 = CallByName Num.22 List.166 List.167;
+        if List.579 then
+            let List.583 : {Str, Str} = CallByName List.66 List.163 List.166;
+            inc List.583;
+            let List.168 : {Str, Int1} = CallByName Inspect.229 List.164 List.583;
+            let List.582 : U64 = 1i64;
+            let List.581 : U64 = CallByName Num.51 List.166 List.582;
+            jump List.577 List.163 List.168 List.165 List.581 List.167;
         else
-            dec List.162;
-            ret List.163;
+            dec List.163;
+            ret List.164;
     in
-    jump List.575 #Derived_gen.18 #Derived_gen.19 #Derived_gen.20 #Derived_gen.21 #Derived_gen.22;
+    jump List.577 #Derived_gen.10 #Derived_gen.11 #Derived_gen.12 #Derived_gen.13 #Derived_gen.14;
 
 procedure Num.22 (#Attr.2, #Attr.3):
     let Num.280 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/inspect_derived_record_two_field_strings.txt
+++ b/crates/compiler/test_mono/generated/inspect_derived_record_two_field_strings.txt
@@ -134,35 +134,35 @@ procedure Inspect.59 (Inspect.296, Inspect.292):
 procedure Inspect.60 (Inspect.298):
     ret Inspect.298;
 
-procedure List.18 (List.159, List.160, List.161):
-    let List.573 : U64 = 0i64;
-    let List.574 : U64 = CallByName List.6 List.159;
-    let List.572 : {Str, Int1} = CallByName List.91 List.159 List.160 List.161 List.573 List.574;
-    ret List.572;
+procedure List.18 (List.160, List.161, List.162):
+    let List.575 : U64 = 0i64;
+    let List.576 : U64 = CallByName List.6 List.160;
+    let List.574 : {Str, Int1} = CallByName List.92 List.160 List.161 List.162 List.575 List.576;
+    ret List.574;
 
 procedure List.6 (#Attr.2):
-    let List.583 : U64 = lowlevel ListLenU64 #Attr.2;
-    ret List.583;
+    let List.585 : U64 = lowlevel ListLenU64 #Attr.2;
+    ret List.585;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.582 : {Str, Str} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.582;
+    let List.584 : {Str, Str} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.584;
 
-procedure List.91 (#Derived_gen.22, #Derived_gen.23, #Derived_gen.24, #Derived_gen.25, #Derived_gen.26):
-    joinpoint List.575 List.162 List.163 List.164 List.165 List.166:
-        let List.577 : Int1 = CallByName Num.22 List.165 List.166;
-        if List.577 then
-            let List.581 : {Str, Str} = CallByName List.66 List.162 List.165;
-            inc List.581;
-            let List.167 : {Str, Int1} = CallByName Inspect.229 List.163 List.581;
-            let List.580 : U64 = 1i64;
-            let List.579 : U64 = CallByName Num.51 List.165 List.580;
-            jump List.575 List.162 List.167 List.164 List.579 List.166;
+procedure List.92 (#Derived_gen.14, #Derived_gen.15, #Derived_gen.16, #Derived_gen.17, #Derived_gen.18):
+    joinpoint List.577 List.163 List.164 List.165 List.166 List.167:
+        let List.579 : Int1 = CallByName Num.22 List.166 List.167;
+        if List.579 then
+            let List.583 : {Str, Str} = CallByName List.66 List.163 List.166;
+            inc List.583;
+            let List.168 : {Str, Int1} = CallByName Inspect.229 List.164 List.583;
+            let List.582 : U64 = 1i64;
+            let List.581 : U64 = CallByName Num.51 List.166 List.582;
+            jump List.577 List.163 List.168 List.165 List.581 List.167;
         else
-            dec List.162;
-            ret List.163;
+            dec List.163;
+            ret List.164;
     in
-    jump List.575 #Derived_gen.22 #Derived_gen.23 #Derived_gen.24 #Derived_gen.25 #Derived_gen.26;
+    jump List.577 #Derived_gen.14 #Derived_gen.15 #Derived_gen.16 #Derived_gen.17 #Derived_gen.18;
 
 procedure Num.22 (#Attr.2, #Attr.3):
     let Num.280 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/inspect_derived_tag_one_field_string.txt
+++ b/crates/compiler/test_mono/generated/inspect_derived_tag_one_field_string.txt
@@ -122,42 +122,42 @@ procedure Inspect.59 (Inspect.296, Inspect.292):
 procedure Inspect.60 (Inspect.298):
     ret Inspect.298;
 
-procedure List.1 (List.106):
-    let List.585 : U64 = CallByName List.6 List.106;
-    dec List.106;
-    let List.586 : U64 = 0i64;
-    let List.584 : Int1 = CallByName Bool.11 List.585 List.586;
-    ret List.584;
+procedure List.1 (List.107):
+    let List.587 : U64 = CallByName List.6 List.107;
+    dec List.107;
+    let List.588 : U64 = 0i64;
+    let List.586 : Int1 = CallByName Bool.11 List.587 List.588;
+    ret List.586;
 
-procedure List.18 (List.159, List.160, List.161):
-    let List.573 : U64 = 0i64;
-    let List.574 : U64 = CallByName List.6 List.159;
-    let List.572 : Str = CallByName List.91 List.159 List.160 List.161 List.573 List.574;
-    ret List.572;
+procedure List.18 (List.160, List.161, List.162):
+    let List.575 : U64 = 0i64;
+    let List.576 : U64 = CallByName List.6 List.160;
+    let List.574 : Str = CallByName List.92 List.160 List.161 List.162 List.575 List.576;
+    ret List.574;
 
 procedure List.6 (#Attr.2):
-    let List.583 : U64 = lowlevel ListLenU64 #Attr.2;
-    ret List.583;
+    let List.585 : U64 = lowlevel ListLenU64 #Attr.2;
+    ret List.585;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.582 : Str = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.582;
+    let List.584 : Str = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.584;
 
-procedure List.91 (#Derived_gen.10, #Derived_gen.11, #Derived_gen.12, #Derived_gen.13, #Derived_gen.14):
-    joinpoint List.575 List.162 List.163 List.164 List.165 List.166:
-        let List.577 : Int1 = CallByName Num.22 List.165 List.166;
-        if List.577 then
-            let List.581 : Str = CallByName List.66 List.162 List.165;
-            inc List.581;
-            let List.167 : Str = CallByName Inspect.206 List.163 List.581;
-            let List.580 : U64 = 1i64;
-            let List.579 : U64 = CallByName Num.51 List.165 List.580;
-            jump List.575 List.162 List.167 List.164 List.579 List.166;
+procedure List.92 (#Derived_gen.10, #Derived_gen.11, #Derived_gen.12, #Derived_gen.13, #Derived_gen.14):
+    joinpoint List.577 List.163 List.164 List.165 List.166 List.167:
+        let List.579 : Int1 = CallByName Num.22 List.166 List.167;
+        if List.579 then
+            let List.583 : Str = CallByName List.66 List.163 List.166;
+            inc List.583;
+            let List.168 : Str = CallByName Inspect.206 List.164 List.583;
+            let List.582 : U64 = 1i64;
+            let List.581 : U64 = CallByName Num.51 List.166 List.582;
+            jump List.577 List.163 List.168 List.165 List.581 List.167;
         else
-            dec List.162;
-            ret List.163;
+            dec List.163;
+            ret List.164;
     in
-    jump List.575 #Derived_gen.10 #Derived_gen.11 #Derived_gen.12 #Derived_gen.13 #Derived_gen.14;
+    jump List.577 #Derived_gen.10 #Derived_gen.11 #Derived_gen.12 #Derived_gen.13 #Derived_gen.14;
 
 procedure Num.22 (#Attr.2, #Attr.3):
     let Num.280 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/inspect_derived_tag_two_payloads_string.txt
+++ b/crates/compiler/test_mono/generated/inspect_derived_tag_two_payloads_string.txt
@@ -125,42 +125,42 @@ procedure Inspect.59 (Inspect.296, Inspect.292):
 procedure Inspect.60 (Inspect.298):
     ret Inspect.298;
 
-procedure List.1 (List.106):
-    let List.585 : U64 = CallByName List.6 List.106;
-    dec List.106;
-    let List.586 : U64 = 0i64;
-    let List.584 : Int1 = CallByName Bool.11 List.585 List.586;
-    ret List.584;
+procedure List.1 (List.107):
+    let List.587 : U64 = CallByName List.6 List.107;
+    dec List.107;
+    let List.588 : U64 = 0i64;
+    let List.586 : Int1 = CallByName Bool.11 List.587 List.588;
+    ret List.586;
 
-procedure List.18 (List.159, List.160, List.161):
-    let List.573 : U64 = 0i64;
-    let List.574 : U64 = CallByName List.6 List.159;
-    let List.572 : Str = CallByName List.91 List.159 List.160 List.161 List.573 List.574;
-    ret List.572;
+procedure List.18 (List.160, List.161, List.162):
+    let List.575 : U64 = 0i64;
+    let List.576 : U64 = CallByName List.6 List.160;
+    let List.574 : Str = CallByName List.92 List.160 List.161 List.162 List.575 List.576;
+    ret List.574;
 
 procedure List.6 (#Attr.2):
-    let List.583 : U64 = lowlevel ListLenU64 #Attr.2;
-    ret List.583;
+    let List.585 : U64 = lowlevel ListLenU64 #Attr.2;
+    ret List.585;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.582 : Str = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.582;
+    let List.584 : Str = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.584;
 
-procedure List.91 (#Derived_gen.13, #Derived_gen.14, #Derived_gen.15, #Derived_gen.16, #Derived_gen.17):
-    joinpoint List.575 List.162 List.163 List.164 List.165 List.166:
-        let List.577 : Int1 = CallByName Num.22 List.165 List.166;
-        if List.577 then
-            let List.581 : Str = CallByName List.66 List.162 List.165;
-            inc List.581;
-            let List.167 : Str = CallByName Inspect.206 List.163 List.581;
-            let List.580 : U64 = 1i64;
-            let List.579 : U64 = CallByName Num.51 List.165 List.580;
-            jump List.575 List.162 List.167 List.164 List.579 List.166;
+procedure List.92 (#Derived_gen.13, #Derived_gen.14, #Derived_gen.15, #Derived_gen.16, #Derived_gen.17):
+    joinpoint List.577 List.163 List.164 List.165 List.166 List.167:
+        let List.579 : Int1 = CallByName Num.22 List.166 List.167;
+        if List.579 then
+            let List.583 : Str = CallByName List.66 List.163 List.166;
+            inc List.583;
+            let List.168 : Str = CallByName Inspect.206 List.164 List.583;
+            let List.582 : U64 = 1i64;
+            let List.581 : U64 = CallByName Num.51 List.166 List.582;
+            jump List.577 List.163 List.168 List.165 List.581 List.167;
         else
-            dec List.162;
-            ret List.163;
+            dec List.163;
+            ret List.164;
     in
-    jump List.575 #Derived_gen.13 #Derived_gen.14 #Derived_gen.15 #Derived_gen.16 #Derived_gen.17;
+    jump List.577 #Derived_gen.13 #Derived_gen.14 #Derived_gen.15 #Derived_gen.16 #Derived_gen.17;
 
 procedure Num.22 (#Attr.2, #Attr.3):
     let Num.280 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/ir_int_add.txt
+++ b/crates/compiler/test_mono/generated/ir_int_add.txt
@@ -1,6 +1,6 @@
 procedure List.6 (#Attr.2):
-    let List.572 : U64 = lowlevel ListLenU64 #Attr.2;
-    ret List.572;
+    let List.574 : U64 = lowlevel ListLenU64 #Attr.2;
+    ret List.574;
 
 procedure Num.19 (#Attr.2, #Attr.3):
     let Num.281 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/issue_2583_specialize_errors_behind_unified_branches.txt
+++ b/crates/compiler/test_mono/generated/issue_2583_specialize_errors_behind_unified_branches.txt
@@ -6,42 +6,42 @@ procedure Bool.2 ():
     let Bool.23 : Int1 = true;
     ret Bool.23;
 
-procedure List.2 (List.107, List.108):
-    let List.586 : U64 = CallByName List.6 List.107;
-    let List.582 : Int1 = CallByName Num.22 List.108 List.586;
-    if List.582 then
-        let List.584 : I64 = CallByName List.66 List.107 List.108;
-        dec List.107;
-        let List.583 : [C {}, C I64] = TagId(1) List.584;
-        ret List.583;
+procedure List.2 (List.108, List.109):
+    let List.588 : U64 = CallByName List.6 List.108;
+    let List.584 : Int1 = CallByName Num.22 List.109 List.588;
+    if List.584 then
+        let List.586 : I64 = CallByName List.66 List.108 List.109;
+        dec List.108;
+        let List.585 : [C {}, C I64] = TagId(1) List.586;
+        ret List.585;
     else
-        dec List.107;
-        let List.581 : {} = Struct {};
-        let List.580 : [C {}, C I64] = TagId(0) List.581;
-        ret List.580;
+        dec List.108;
+        let List.583 : {} = Struct {};
+        let List.582 : [C {}, C I64] = TagId(0) List.583;
+        ret List.582;
 
 procedure List.6 (#Attr.2):
-    let List.587 : U64 = lowlevel ListLenU64 #Attr.2;
-    ret List.587;
+    let List.589 : U64 = lowlevel ListLenU64 #Attr.2;
+    ret List.589;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.585 : I64 = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.585;
+    let List.587 : I64 = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.587;
 
-procedure List.9 (List.334):
-    let List.579 : U64 = 0i64;
-    let List.572 : [C {}, C I64] = CallByName List.2 List.334 List.579;
-    let List.576 : U8 = 1i64;
-    let List.577 : U8 = GetTagId List.572;
-    let List.578 : Int1 = lowlevel Eq List.576 List.577;
-    if List.578 then
-        let List.335 : I64 = UnionAtIndex (Id 1) (Index 0) List.572;
-        let List.573 : [C Int1, C I64] = TagId(1) List.335;
-        ret List.573;
+procedure List.9 (List.335):
+    let List.581 : U64 = 0i64;
+    let List.574 : [C {}, C I64] = CallByName List.2 List.335 List.581;
+    let List.578 : U8 = 1i64;
+    let List.579 : U8 = GetTagId List.574;
+    let List.580 : Int1 = lowlevel Eq List.578 List.579;
+    if List.580 then
+        let List.336 : I64 = UnionAtIndex (Id 1) (Index 0) List.574;
+        let List.575 : [C Int1, C I64] = TagId(1) List.336;
+        ret List.575;
     else
-        let List.575 : Int1 = true;
-        let List.574 : [C Int1, C I64] = TagId(0) List.575;
-        ret List.574;
+        let List.577 : Int1 = true;
+        let List.576 : [C Int1, C I64] = TagId(0) List.577;
+        ret List.576;
 
 procedure Num.22 (#Attr.2, #Attr.3):
     let Num.279 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/issue_4749.txt
+++ b/crates/compiler/test_mono/generated/issue_4749.txt
@@ -64,119 +64,119 @@ procedure Decode.27 (Decode.107, Decode.108):
         let Decode.123 : [C [C List U8, C ], C Str] = TagId(0) Decode.124;
         ret Decode.123;
 
-procedure List.1 (List.106):
-    let List.626 : U64 = CallByName List.6 List.106;
-    dec List.106;
-    let List.627 : U64 = 0i64;
-    let List.625 : Int1 = CallByName Bool.11 List.626 List.627;
-    ret List.625;
+procedure List.1 (List.107):
+    let List.628 : U64 = CallByName List.6 List.107;
+    dec List.107;
+    let List.629 : U64 = 0i64;
+    let List.627 : Int1 = CallByName Bool.11 List.628 List.629;
+    ret List.627;
 
-procedure List.103 (List.487, List.488, List.489):
-    let List.635 : U64 = 0i64;
-    let List.636 : U64 = CallByName List.6 List.487;
-    let List.634 : [C [C U64, C U64, C U64, C , C , C U64, C U64, C U64, C U64], C [C U64, C U64, C U64, C , C , C U64, C U64, C U64, C U64]] = CallByName List.80 List.487 List.488 List.489 List.635 List.636;
-    ret List.634;
+procedure List.104 (List.488, List.489, List.490):
+    let List.637 : U64 = 0i64;
+    let List.638 : U64 = CallByName List.6 List.488;
+    let List.636 : [C [C U64, C U64, C U64, C , C , C U64, C U64, C U64, C U64], C [C U64, C U64, C U64, C , C , C U64, C U64, C U64, C U64]] = CallByName List.80 List.488 List.489 List.490 List.637 List.638;
+    ret List.636;
 
-procedure List.2 (List.107, List.108):
-    let List.617 : U64 = CallByName List.6 List.107;
-    let List.614 : Int1 = CallByName Num.22 List.108 List.617;
-    if List.614 then
-        let List.616 : U8 = CallByName List.66 List.107 List.108;
-        dec List.107;
-        let List.615 : [C {}, C U8] = TagId(1) List.616;
-        ret List.615;
+procedure List.2 (List.108, List.109):
+    let List.619 : U64 = CallByName List.6 List.108;
+    let List.616 : Int1 = CallByName Num.22 List.109 List.619;
+    if List.616 then
+        let List.618 : U8 = CallByName List.66 List.108 List.109;
+        dec List.108;
+        let List.617 : [C {}, C U8] = TagId(1) List.618;
+        ret List.617;
     else
-        dec List.107;
-        let List.613 : {} = Struct {};
-        let List.612 : [C {}, C U8] = TagId(0) List.613;
-        ret List.612;
+        dec List.108;
+        let List.615 : {} = Struct {};
+        let List.614 : [C {}, C U8] = TagId(0) List.615;
+        ret List.614;
 
-procedure List.26 (List.200, List.201, List.202):
-    let List.628 : [C [C U64, C U64, C U64, C , C , C U64, C U64, C U64, C U64], C [C U64, C U64, C U64, C , C , C U64, C U64, C U64, C U64]] = CallByName List.103 List.200 List.201 List.202;
-    let List.631 : U8 = 1i64;
-    let List.632 : U8 = GetTagId List.628;
-    let List.633 : Int1 = lowlevel Eq List.631 List.632;
-    if List.633 then
-        let List.203 : [C U64, C U64, C U64, C , C , C U64, C U64, C U64, C U64] = UnionAtIndex (Id 1) (Index 0) List.628;
-        ret List.203;
-    else
-        let List.204 : [C U64, C U64, C U64, C , C , C U64, C U64, C U64, C U64] = UnionAtIndex (Id 0) (Index 0) List.628;
+procedure List.26 (List.201, List.202, List.203):
+    let List.630 : [C [C U64, C U64, C U64, C , C , C U64, C U64, C U64, C U64], C [C U64, C U64, C U64, C , C , C U64, C U64, C U64, C U64]] = CallByName List.104 List.201 List.202 List.203;
+    let List.633 : U8 = 1i64;
+    let List.634 : U8 = GetTagId List.630;
+    let List.635 : Int1 = lowlevel Eq List.633 List.634;
+    if List.635 then
+        let List.204 : [C U64, C U64, C U64, C , C , C U64, C U64, C U64, C U64] = UnionAtIndex (Id 1) (Index 0) List.630;
         ret List.204;
+    else
+        let List.205 : [C U64, C U64, C U64, C , C , C U64, C U64, C U64, C U64] = UnionAtIndex (Id 0) (Index 0) List.630;
+        ret List.205;
 
-procedure List.38 (List.343, List.344):
-    let List.594 : U64 = CallByName List.6 List.343;
-    let List.345 : U64 = CallByName Num.77 List.594 List.344;
-    let List.593 : List U8 = CallByName List.43 List.343 List.345;
-    ret List.593;
+procedure List.38 (List.344, List.345):
+    let List.596 : U64 = CallByName List.6 List.344;
+    let List.346 : U64 = CallByName Num.77 List.596 List.345;
+    let List.595 : List U8 = CallByName List.43 List.344 List.346;
+    ret List.595;
 
-procedure List.4 (List.123, List.124):
-    let List.604 : U64 = 1i64;
-    let List.603 : List U8 = CallByName List.70 List.123 List.604;
-    let List.602 : List U8 = CallByName List.71 List.603 List.124;
-    ret List.602;
+procedure List.4 (List.124, List.125):
+    let List.606 : U64 = 1i64;
+    let List.605 : List U8 = CallByName List.70 List.124 List.606;
+    let List.604 : List U8 = CallByName List.71 List.605 List.125;
+    ret List.604;
 
-procedure List.43 (List.341, List.342):
-    let List.584 : U64 = CallByName List.6 List.341;
-    let List.583 : U64 = CallByName Num.77 List.584 List.342;
-    let List.578 : {U64, U64} = Struct {List.342, List.583};
-    let List.577 : List U8 = CallByName List.49 List.341 List.578;
-    ret List.577;
+procedure List.43 (List.342, List.343):
+    let List.586 : U64 = CallByName List.6 List.342;
+    let List.585 : U64 = CallByName Num.77 List.586 List.343;
+    let List.580 : {U64, U64} = Struct {List.343, List.585};
+    let List.579 : List U8 = CallByName List.49 List.342 List.580;
+    ret List.579;
 
-procedure List.49 (List.419, List.420):
-    let List.622 : U64 = StructAtIndex 1 List.420;
-    let List.623 : U64 = StructAtIndex 0 List.420;
-    let List.621 : List U8 = CallByName List.72 List.419 List.622 List.623;
-    ret List.621;
+procedure List.49 (List.420, List.421):
+    let List.624 : U64 = StructAtIndex 1 List.421;
+    let List.625 : U64 = StructAtIndex 0 List.421;
+    let List.623 : List U8 = CallByName List.72 List.420 List.624 List.625;
+    ret List.623;
 
 procedure List.6 (#Attr.2):
-    let List.624 : U64 = lowlevel ListLenU64 #Attr.2;
-    ret List.624;
+    let List.626 : U64 = lowlevel ListLenU64 #Attr.2;
+    ret List.626;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.610 : U8 = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.610;
+    let List.612 : U8 = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.612;
 
 procedure List.70 (#Attr.2, #Attr.3):
-    let List.601 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
-    ret List.601;
+    let List.603 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
+    ret List.603;
 
 procedure List.71 (#Attr.2, #Attr.3):
-    let List.599 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
-    ret List.599;
+    let List.601 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
+    ret List.601;
 
 procedure List.72 (#Attr.2, #Attr.3, #Attr.4):
-    let List.582 : List U8 = lowlevel ListSublist #Attr.2 #Attr.3 #Attr.4;
-    ret List.582;
+    let List.584 : List U8 = lowlevel ListSublist #Attr.2 #Attr.3 #Attr.4;
+    ret List.584;
 
 procedure List.8 (#Attr.2, #Attr.3):
-    let List.596 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
-    ret List.596;
+    let List.598 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
+    ret List.598;
 
 procedure List.80 (#Derived_gen.1, #Derived_gen.2, #Derived_gen.3, #Derived_gen.4, #Derived_gen.5):
-    joinpoint List.637 List.490 List.491 List.492 List.493 List.494:
-        let List.639 : Int1 = CallByName Num.22 List.493 List.494;
-        if List.639 then
-            let List.648 : U8 = CallByName List.66 List.490 List.493;
-            let List.640 : [C [C U64, C U64, C U64, C , C , C U64, C U64, C U64, C U64], C [C U64, C U64, C U64, C , C , C U64, C U64, C U64, C U64]] = CallByName TotallyNotJson.61 List.491 List.648;
-            let List.645 : U8 = 1i64;
-            let List.646 : U8 = GetTagId List.640;
-            let List.647 : Int1 = lowlevel Eq List.645 List.646;
-            if List.647 then
-                let List.495 : [C U64, C U64, C U64, C , C , C U64, C U64, C U64, C U64] = UnionAtIndex (Id 1) (Index 0) List.640;
-                let List.643 : U64 = 1i64;
-                let List.642 : U64 = CallByName Num.51 List.493 List.643;
-                jump List.637 List.490 List.495 List.492 List.642 List.494;
+    joinpoint List.639 List.491 List.492 List.493 List.494 List.495:
+        let List.641 : Int1 = CallByName Num.22 List.494 List.495;
+        if List.641 then
+            let List.650 : U8 = CallByName List.66 List.491 List.494;
+            let List.642 : [C [C U64, C U64, C U64, C , C , C U64, C U64, C U64, C U64], C [C U64, C U64, C U64, C , C , C U64, C U64, C U64, C U64]] = CallByName TotallyNotJson.61 List.492 List.650;
+            let List.647 : U8 = 1i64;
+            let List.648 : U8 = GetTagId List.642;
+            let List.649 : Int1 = lowlevel Eq List.647 List.648;
+            if List.649 then
+                let List.496 : [C U64, C U64, C U64, C , C , C U64, C U64, C U64, C U64] = UnionAtIndex (Id 1) (Index 0) List.642;
+                let List.645 : U64 = 1i64;
+                let List.644 : U64 = CallByName Num.51 List.494 List.645;
+                jump List.639 List.491 List.496 List.493 List.644 List.495;
             else
-                dec List.490;
-                let List.496 : [C U64, C U64, C U64, C , C , C U64, C U64, C U64, C U64] = UnionAtIndex (Id 0) (Index 0) List.640;
-                let List.644 : [C [C U64, C U64, C U64, C , C , C U64, C U64, C U64, C U64], C [C U64, C U64, C U64, C , C , C U64, C U64, C U64, C U64]] = TagId(0) List.496;
-                ret List.644;
+                dec List.491;
+                let List.497 : [C U64, C U64, C U64, C , C , C U64, C U64, C U64, C U64] = UnionAtIndex (Id 0) (Index 0) List.642;
+                let List.646 : [C [C U64, C U64, C U64, C , C , C U64, C U64, C U64, C U64], C [C U64, C U64, C U64, C , C , C U64, C U64, C U64, C U64]] = TagId(0) List.497;
+                ret List.646;
         else
-            dec List.490;
-            let List.638 : [C [C U64, C U64, C U64, C , C , C U64, C U64, C U64, C U64], C [C U64, C U64, C U64, C , C , C U64, C U64, C U64, C U64]] = TagId(1) List.491;
-            ret List.638;
+            dec List.491;
+            let List.640 : [C [C U64, C U64, C U64, C , C , C U64, C U64, C U64, C U64], C [C U64, C U64, C U64, C , C , C U64, C U64, C U64, C U64]] = TagId(1) List.492;
+            ret List.640;
     in
-    jump List.637 #Derived_gen.1 #Derived_gen.2 #Derived_gen.3 #Derived_gen.4 #Derived_gen.5;
+    jump List.639 #Derived_gen.1 #Derived_gen.2 #Derived_gen.3 #Derived_gen.4 #Derived_gen.5;
 
 procedure Num.19 (#Attr.2, #Attr.3):
     let Num.282 : U8 = lowlevel NumAdd #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/issue_4770.txt
+++ b/crates/compiler/test_mono/generated/issue_4770.txt
@@ -6,80 +6,80 @@ procedure Bool.2 ():
     let Bool.24 : Int1 = true;
     ret Bool.24;
 
-procedure List.103 (List.487, List.488, List.489):
-    let List.586 : U64 = 0i64;
-    let List.587 : U64 = CallByName List.6 List.487;
-    let List.585 : [C {}, C {}] = CallByName List.80 List.487 List.488 List.489 List.586 List.587;
-    ret List.585;
+procedure List.104 (List.488, List.489, List.490):
+    let List.588 : U64 = 0i64;
+    let List.589 : U64 = CallByName List.6 List.488;
+    let List.587 : [C {}, C {}] = CallByName List.80 List.488 List.489 List.490 List.588 List.589;
+    ret List.587;
 
 procedure List.23 (#Attr.2, #Attr.3, #Attr.4):
-    let List.607 : List {[<r>C I64, C List *self], [<r>C I64, C List *self]} = lowlevel ListMap2 { xs: `#Attr.#arg1`, ys: `#Attr.#arg2` } #Attr.2 #Attr.3 Test.15 #Attr.4;
+    let List.609 : List {[<r>C I64, C List *self], [<r>C I64, C List *self]} = lowlevel ListMap2 { xs: `#Attr.#arg1`, ys: `#Attr.#arg2` } #Attr.2 #Attr.3 Test.15 #Attr.4;
     decref #Attr.3;
     decref #Attr.2;
-    ret List.607;
+    ret List.609;
 
-procedure List.235 (List.574, List.236, List.234):
-    let List.604 : Int1 = CallByName Test.1 List.236;
-    if List.604 then
-        let List.606 : {} = Struct {};
-        let List.605 : [C {}, C {}] = TagId(1) List.606;
-        ret List.605;
+procedure List.236 (List.576, List.237, List.235):
+    let List.606 : Int1 = CallByName Test.1 List.237;
+    if List.606 then
+        let List.608 : {} = Struct {};
+        let List.607 : [C {}, C {}] = TagId(1) List.608;
+        ret List.607;
     else
-        let List.603 : {} = Struct {};
-        let List.602 : [C {}, C {}] = TagId(0) List.603;
-        ret List.602;
+        let List.605 : {} = Struct {};
+        let List.604 : [C {}, C {}] = TagId(0) List.605;
+        ret List.604;
 
-procedure List.56 (List.233, List.234):
-    let List.583 : {} = Struct {};
-    let List.575 : [C {}, C {}] = CallByName List.103 List.233 List.583 List.234;
-    let List.580 : U8 = 1i64;
-    let List.581 : U8 = GetTagId List.575;
-    let List.582 : Int1 = lowlevel Eq List.580 List.581;
-    if List.582 then
-        let List.576 : Int1 = CallByName Bool.2;
-        ret List.576;
+procedure List.56 (List.234, List.235):
+    let List.585 : {} = Struct {};
+    let List.577 : [C {}, C {}] = CallByName List.104 List.234 List.585 List.235;
+    let List.582 : U8 = 1i64;
+    let List.583 : U8 = GetTagId List.577;
+    let List.584 : Int1 = lowlevel Eq List.582 List.583;
+    if List.584 then
+        let List.578 : Int1 = CallByName Bool.2;
+        ret List.578;
     else
-        let List.577 : Int1 = CallByName Bool.1;
-        ret List.577;
+        let List.579 : Int1 = CallByName Bool.1;
+        ret List.579;
 
 procedure List.6 (#Attr.2):
-    let List.573 : U64 = lowlevel ListLenU64 #Attr.2;
-    ret List.573;
+    let List.575 : U64 = lowlevel ListLenU64 #Attr.2;
+    ret List.575;
 
 procedure List.6 (#Attr.2):
-    let List.601 : U64 = lowlevel ListLenU64 #Attr.2;
-    ret List.601;
+    let List.603 : U64 = lowlevel ListLenU64 #Attr.2;
+    ret List.603;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.600 : {[<r>C I64, C List *self], [<r>C I64, C List *self]} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.600;
+    let List.602 : {[<r>C I64, C List *self], [<r>C I64, C List *self]} = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.602;
 
 procedure List.80 (#Derived_gen.1, #Derived_gen.2, #Derived_gen.3, #Derived_gen.4, #Derived_gen.5):
-    joinpoint List.588 List.490 List.491 List.492 List.493 List.494:
-        let List.590 : Int1 = CallByName Num.22 List.493 List.494;
-        if List.590 then
-            let List.599 : {[<r>C I64, C List *self], [<r>C I64, C List *self]} = CallByName List.66 List.490 List.493;
-            inc List.599;
-            let List.591 : [C {}, C {}] = CallByName List.235 List.491 List.599 List.492;
-            let List.596 : U8 = 1i64;
-            let List.597 : U8 = GetTagId List.591;
-            let List.598 : Int1 = lowlevel Eq List.596 List.597;
-            if List.598 then
-                let List.495 : {} = UnionAtIndex (Id 1) (Index 0) List.591;
-                let List.594 : U64 = 1i64;
-                let List.593 : U64 = CallByName Num.51 List.493 List.594;
-                jump List.588 List.490 List.495 List.492 List.593 List.494;
+    joinpoint List.590 List.491 List.492 List.493 List.494 List.495:
+        let List.592 : Int1 = CallByName Num.22 List.494 List.495;
+        if List.592 then
+            let List.601 : {[<r>C I64, C List *self], [<r>C I64, C List *self]} = CallByName List.66 List.491 List.494;
+            inc List.601;
+            let List.593 : [C {}, C {}] = CallByName List.236 List.492 List.601 List.493;
+            let List.598 : U8 = 1i64;
+            let List.599 : U8 = GetTagId List.593;
+            let List.600 : Int1 = lowlevel Eq List.598 List.599;
+            if List.600 then
+                let List.496 : {} = UnionAtIndex (Id 1) (Index 0) List.593;
+                let List.596 : U64 = 1i64;
+                let List.595 : U64 = CallByName Num.51 List.494 List.596;
+                jump List.590 List.491 List.496 List.493 List.595 List.495;
             else
-                dec List.490;
-                let List.496 : {} = UnionAtIndex (Id 0) (Index 0) List.591;
-                let List.595 : [C {}, C {}] = TagId(0) List.496;
-                ret List.595;
+                dec List.491;
+                let List.497 : {} = UnionAtIndex (Id 0) (Index 0) List.593;
+                let List.597 : [C {}, C {}] = TagId(0) List.497;
+                ret List.597;
         else
-            dec List.490;
-            let List.589 : [C {}, C {}] = TagId(1) List.491;
-            ret List.589;
+            dec List.491;
+            let List.591 : [C {}, C {}] = TagId(1) List.492;
+            ret List.591;
     in
-    jump List.588 #Derived_gen.1 #Derived_gen.2 #Derived_gen.3 #Derived_gen.4 #Derived_gen.5;
+    jump List.590 #Derived_gen.1 #Derived_gen.2 #Derived_gen.3 #Derived_gen.4 #Derived_gen.5;
 
 procedure Num.22 (#Attr.2, #Attr.3):
     let Num.279 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/issue_4772_weakened_monomorphic_destructure.txt
+++ b/crates/compiler/test_mono/generated/issue_4772_weakened_monomorphic_destructure.txt
@@ -38,119 +38,119 @@ procedure Decode.26 (Decode.105, Decode.106):
     let Decode.122 : {List U8, [C {}, C Str]} = CallByName Decode.25 Decode.105 Decode.123 Decode.106;
     ret Decode.122;
 
-procedure List.1 (List.106):
-    let List.622 : U64 = CallByName List.6 List.106;
-    dec List.106;
-    let List.623 : U64 = 0i64;
-    let List.621 : Int1 = CallByName Bool.11 List.622 List.623;
-    ret List.621;
+procedure List.1 (List.107):
+    let List.624 : U64 = CallByName List.6 List.107;
+    dec List.107;
+    let List.625 : U64 = 0i64;
+    let List.623 : Int1 = CallByName Bool.11 List.624 List.625;
+    ret List.623;
 
-procedure List.103 (List.487, List.488, List.489):
-    let List.631 : U64 = 0i64;
-    let List.632 : U64 = CallByName List.6 List.487;
-    let List.630 : [C [C U64, C U64, C U64, C , C , C U64, C U64, C U64, C U64], C [C U64, C U64, C U64, C , C , C U64, C U64, C U64, C U64]] = CallByName List.80 List.487 List.488 List.489 List.631 List.632;
-    ret List.630;
+procedure List.104 (List.488, List.489, List.490):
+    let List.633 : U64 = 0i64;
+    let List.634 : U64 = CallByName List.6 List.488;
+    let List.632 : [C [C U64, C U64, C U64, C , C , C U64, C U64, C U64, C U64], C [C U64, C U64, C U64, C , C , C U64, C U64, C U64, C U64]] = CallByName List.80 List.488 List.489 List.490 List.633 List.634;
+    ret List.632;
 
-procedure List.2 (List.107, List.108):
-    let List.613 : U64 = CallByName List.6 List.107;
-    let List.610 : Int1 = CallByName Num.22 List.108 List.613;
-    if List.610 then
-        let List.612 : U8 = CallByName List.66 List.107 List.108;
-        dec List.107;
-        let List.611 : [C {}, C U8] = TagId(1) List.612;
-        ret List.611;
+procedure List.2 (List.108, List.109):
+    let List.615 : U64 = CallByName List.6 List.108;
+    let List.612 : Int1 = CallByName Num.22 List.109 List.615;
+    if List.612 then
+        let List.614 : U8 = CallByName List.66 List.108 List.109;
+        dec List.108;
+        let List.613 : [C {}, C U8] = TagId(1) List.614;
+        ret List.613;
     else
-        dec List.107;
-        let List.609 : {} = Struct {};
-        let List.608 : [C {}, C U8] = TagId(0) List.609;
-        ret List.608;
+        dec List.108;
+        let List.611 : {} = Struct {};
+        let List.610 : [C {}, C U8] = TagId(0) List.611;
+        ret List.610;
 
-procedure List.26 (List.200, List.201, List.202):
-    let List.624 : [C [C U64, C U64, C U64, C , C , C U64, C U64, C U64, C U64], C [C U64, C U64, C U64, C , C , C U64, C U64, C U64, C U64]] = CallByName List.103 List.200 List.201 List.202;
-    let List.627 : U8 = 1i64;
-    let List.628 : U8 = GetTagId List.624;
-    let List.629 : Int1 = lowlevel Eq List.627 List.628;
-    if List.629 then
-        let List.203 : [C U64, C U64, C U64, C , C , C U64, C U64, C U64, C U64] = UnionAtIndex (Id 1) (Index 0) List.624;
-        ret List.203;
-    else
-        let List.204 : [C U64, C U64, C U64, C , C , C U64, C U64, C U64, C U64] = UnionAtIndex (Id 0) (Index 0) List.624;
+procedure List.26 (List.201, List.202, List.203):
+    let List.626 : [C [C U64, C U64, C U64, C , C , C U64, C U64, C U64, C U64], C [C U64, C U64, C U64, C , C , C U64, C U64, C U64, C U64]] = CallByName List.104 List.201 List.202 List.203;
+    let List.629 : U8 = 1i64;
+    let List.630 : U8 = GetTagId List.626;
+    let List.631 : Int1 = lowlevel Eq List.629 List.630;
+    if List.631 then
+        let List.204 : [C U64, C U64, C U64, C , C , C U64, C U64, C U64, C U64] = UnionAtIndex (Id 1) (Index 0) List.626;
         ret List.204;
+    else
+        let List.205 : [C U64, C U64, C U64, C , C , C U64, C U64, C U64, C U64] = UnionAtIndex (Id 0) (Index 0) List.626;
+        ret List.205;
 
-procedure List.38 (List.343, List.344):
-    let List.590 : U64 = CallByName List.6 List.343;
-    let List.345 : U64 = CallByName Num.77 List.590 List.344;
-    let List.589 : List U8 = CallByName List.43 List.343 List.345;
-    ret List.589;
+procedure List.38 (List.344, List.345):
+    let List.592 : U64 = CallByName List.6 List.344;
+    let List.346 : U64 = CallByName Num.77 List.592 List.345;
+    let List.591 : List U8 = CallByName List.43 List.344 List.346;
+    ret List.591;
 
-procedure List.4 (List.123, List.124):
-    let List.600 : U64 = 1i64;
-    let List.599 : List U8 = CallByName List.70 List.123 List.600;
-    let List.598 : List U8 = CallByName List.71 List.599 List.124;
-    ret List.598;
+procedure List.4 (List.124, List.125):
+    let List.602 : U64 = 1i64;
+    let List.601 : List U8 = CallByName List.70 List.124 List.602;
+    let List.600 : List U8 = CallByName List.71 List.601 List.125;
+    ret List.600;
 
-procedure List.43 (List.341, List.342):
-    let List.580 : U64 = CallByName List.6 List.341;
-    let List.579 : U64 = CallByName Num.77 List.580 List.342;
-    let List.574 : {U64, U64} = Struct {List.342, List.579};
-    let List.573 : List U8 = CallByName List.49 List.341 List.574;
-    ret List.573;
+procedure List.43 (List.342, List.343):
+    let List.582 : U64 = CallByName List.6 List.342;
+    let List.581 : U64 = CallByName Num.77 List.582 List.343;
+    let List.576 : {U64, U64} = Struct {List.343, List.581};
+    let List.575 : List U8 = CallByName List.49 List.342 List.576;
+    ret List.575;
 
-procedure List.49 (List.419, List.420):
-    let List.618 : U64 = StructAtIndex 1 List.420;
-    let List.619 : U64 = StructAtIndex 0 List.420;
-    let List.617 : List U8 = CallByName List.72 List.419 List.618 List.619;
-    ret List.617;
+procedure List.49 (List.420, List.421):
+    let List.620 : U64 = StructAtIndex 1 List.421;
+    let List.621 : U64 = StructAtIndex 0 List.421;
+    let List.619 : List U8 = CallByName List.72 List.420 List.620 List.621;
+    ret List.619;
 
 procedure List.6 (#Attr.2):
-    let List.620 : U64 = lowlevel ListLenU64 #Attr.2;
-    ret List.620;
+    let List.622 : U64 = lowlevel ListLenU64 #Attr.2;
+    ret List.622;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.606 : U8 = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.606;
+    let List.608 : U8 = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.608;
 
 procedure List.70 (#Attr.2, #Attr.3):
-    let List.597 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
-    ret List.597;
+    let List.599 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
+    ret List.599;
 
 procedure List.71 (#Attr.2, #Attr.3):
-    let List.595 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
-    ret List.595;
+    let List.597 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
+    ret List.597;
 
 procedure List.72 (#Attr.2, #Attr.3, #Attr.4):
-    let List.578 : List U8 = lowlevel ListSublist #Attr.2 #Attr.3 #Attr.4;
-    ret List.578;
+    let List.580 : List U8 = lowlevel ListSublist #Attr.2 #Attr.3 #Attr.4;
+    ret List.580;
 
 procedure List.8 (#Attr.2, #Attr.3):
-    let List.592 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
-    ret List.592;
+    let List.594 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
+    ret List.594;
 
 procedure List.80 (#Derived_gen.0, #Derived_gen.1, #Derived_gen.2, #Derived_gen.3, #Derived_gen.4):
-    joinpoint List.633 List.490 List.491 List.492 List.493 List.494:
-        let List.635 : Int1 = CallByName Num.22 List.493 List.494;
-        if List.635 then
-            let List.644 : U8 = CallByName List.66 List.490 List.493;
-            let List.636 : [C [C U64, C U64, C U64, C , C , C U64, C U64, C U64, C U64], C [C U64, C U64, C U64, C , C , C U64, C U64, C U64, C U64]] = CallByName TotallyNotJson.61 List.491 List.644;
-            let List.641 : U8 = 1i64;
-            let List.642 : U8 = GetTagId List.636;
-            let List.643 : Int1 = lowlevel Eq List.641 List.642;
-            if List.643 then
-                let List.495 : [C U64, C U64, C U64, C , C , C U64, C U64, C U64, C U64] = UnionAtIndex (Id 1) (Index 0) List.636;
-                let List.639 : U64 = 1i64;
-                let List.638 : U64 = CallByName Num.51 List.493 List.639;
-                jump List.633 List.490 List.495 List.492 List.638 List.494;
+    joinpoint List.635 List.491 List.492 List.493 List.494 List.495:
+        let List.637 : Int1 = CallByName Num.22 List.494 List.495;
+        if List.637 then
+            let List.646 : U8 = CallByName List.66 List.491 List.494;
+            let List.638 : [C [C U64, C U64, C U64, C , C , C U64, C U64, C U64, C U64], C [C U64, C U64, C U64, C , C , C U64, C U64, C U64, C U64]] = CallByName TotallyNotJson.61 List.492 List.646;
+            let List.643 : U8 = 1i64;
+            let List.644 : U8 = GetTagId List.638;
+            let List.645 : Int1 = lowlevel Eq List.643 List.644;
+            if List.645 then
+                let List.496 : [C U64, C U64, C U64, C , C , C U64, C U64, C U64, C U64] = UnionAtIndex (Id 1) (Index 0) List.638;
+                let List.641 : U64 = 1i64;
+                let List.640 : U64 = CallByName Num.51 List.494 List.641;
+                jump List.635 List.491 List.496 List.493 List.640 List.495;
             else
-                dec List.490;
-                let List.496 : [C U64, C U64, C U64, C , C , C U64, C U64, C U64, C U64] = UnionAtIndex (Id 0) (Index 0) List.636;
-                let List.640 : [C [C U64, C U64, C U64, C , C , C U64, C U64, C U64, C U64], C [C U64, C U64, C U64, C , C , C U64, C U64, C U64, C U64]] = TagId(0) List.496;
-                ret List.640;
+                dec List.491;
+                let List.497 : [C U64, C U64, C U64, C , C , C U64, C U64, C U64, C U64] = UnionAtIndex (Id 0) (Index 0) List.638;
+                let List.642 : [C [C U64, C U64, C U64, C , C , C U64, C U64, C U64, C U64], C [C U64, C U64, C U64, C , C , C U64, C U64, C U64, C U64]] = TagId(0) List.497;
+                ret List.642;
         else
-            dec List.490;
-            let List.634 : [C [C U64, C U64, C U64, C , C , C U64, C U64, C U64, C U64], C [C U64, C U64, C U64, C , C , C U64, C U64, C U64, C U64]] = TagId(1) List.491;
-            ret List.634;
+            dec List.491;
+            let List.636 : [C [C U64, C U64, C U64, C , C , C U64, C U64, C U64, C U64], C [C U64, C U64, C U64, C , C , C U64, C U64, C U64, C U64]] = TagId(1) List.492;
+            ret List.636;
     in
-    jump List.633 #Derived_gen.0 #Derived_gen.1 #Derived_gen.2 #Derived_gen.3 #Derived_gen.4;
+    jump List.635 #Derived_gen.0 #Derived_gen.1 #Derived_gen.2 #Derived_gen.3 #Derived_gen.4;
 
 procedure Num.19 (#Attr.2, #Attr.3):
     let Num.282 : U8 = lowlevel NumAdd #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/layout_cache_structure_with_multiple_recursive_structures.txt
+++ b/crates/compiler/test_mono/generated/layout_cache_structure_with_multiple_recursive_structures.txt
@@ -1,32 +1,32 @@
-procedure List.18 (List.159, List.160, List.161):
-    let List.573 : U64 = 0i64;
-    let List.574 : U64 = CallByName List.6 List.159;
-    let List.572 : [<rnu><null>, C {[<rnu>C *self, <null>], *self}] = CallByName List.91 List.159 List.160 List.161 List.573 List.574;
-    ret List.572;
+procedure List.18 (List.160, List.161, List.162):
+    let List.575 : U64 = 0i64;
+    let List.576 : U64 = CallByName List.6 List.160;
+    let List.574 : [<rnu><null>, C {[<rnu>C *self, <null>], *self}] = CallByName List.92 List.160 List.161 List.162 List.575 List.576;
+    ret List.574;
 
 procedure List.6 (#Attr.2):
-    let List.583 : U64 = lowlevel ListLenU64 #Attr.2;
-    ret List.583;
+    let List.585 : U64 = lowlevel ListLenU64 #Attr.2;
+    ret List.585;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.582 : [<rnu>C *self, <null>] = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.582;
+    let List.584 : [<rnu>C *self, <null>] = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.584;
 
-procedure List.91 (#Derived_gen.0, #Derived_gen.1, #Derived_gen.2, #Derived_gen.3, #Derived_gen.4):
-    joinpoint List.575 List.162 List.163 List.164 List.165 List.166:
-        let List.577 : Int1 = CallByName Num.22 List.165 List.166;
-        if List.577 then
-            let List.581 : [<rnu>C *self, <null>] = CallByName List.66 List.162 List.165;
-            inc List.581;
-            let List.167 : [<rnu><null>, C {[<rnu>C *self, <null>], *self}] = CallByName Test.7 List.163 List.581;
-            let List.580 : U64 = 1i64;
-            let List.579 : U64 = CallByName Num.51 List.165 List.580;
-            jump List.575 List.162 List.167 List.164 List.579 List.166;
+procedure List.92 (#Derived_gen.0, #Derived_gen.1, #Derived_gen.2, #Derived_gen.3, #Derived_gen.4):
+    joinpoint List.577 List.163 List.164 List.165 List.166 List.167:
+        let List.579 : Int1 = CallByName Num.22 List.166 List.167;
+        if List.579 then
+            let List.583 : [<rnu>C *self, <null>] = CallByName List.66 List.163 List.166;
+            inc List.583;
+            let List.168 : [<rnu><null>, C {[<rnu>C *self, <null>], *self}] = CallByName Test.7 List.164 List.583;
+            let List.582 : U64 = 1i64;
+            let List.581 : U64 = CallByName Num.51 List.166 List.582;
+            jump List.577 List.163 List.168 List.165 List.581 List.167;
         else
-            dec List.162;
-            ret List.163;
+            dec List.163;
+            ret List.164;
     in
-    jump List.575 #Derived_gen.0 #Derived_gen.1 #Derived_gen.2 #Derived_gen.3 #Derived_gen.4;
+    jump List.577 #Derived_gen.0 #Derived_gen.1 #Derived_gen.2 #Derived_gen.3 #Derived_gen.4;
 
 procedure Num.22 (#Attr.2, #Attr.3):
     let Num.280 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/list_append.txt
+++ b/crates/compiler/test_mono/generated/list_append.txt
@@ -1,16 +1,16 @@
-procedure List.4 (List.123, List.124):
-    let List.575 : U64 = 1i64;
-    let List.573 : List I64 = CallByName List.70 List.123 List.575;
-    let List.572 : List I64 = CallByName List.71 List.573 List.124;
-    ret List.572;
+procedure List.4 (List.124, List.125):
+    let List.577 : U64 = 1i64;
+    let List.575 : List I64 = CallByName List.70 List.124 List.577;
+    let List.574 : List I64 = CallByName List.71 List.575 List.125;
+    ret List.574;
 
 procedure List.70 (#Attr.2, #Attr.3):
-    let List.576 : List I64 = lowlevel ListReserve #Attr.2 #Attr.3;
-    ret List.576;
+    let List.578 : List I64 = lowlevel ListReserve #Attr.2 #Attr.3;
+    ret List.578;
 
 procedure List.71 (#Attr.2, #Attr.3):
-    let List.574 : List I64 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
-    ret List.574;
+    let List.576 : List I64 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
+    ret List.576;
 
 procedure Test.0 ():
     let Test.2 : List I64 = Array [1i64];

--- a/crates/compiler/test_mono/generated/list_append_closure.txt
+++ b/crates/compiler/test_mono/generated/list_append_closure.txt
@@ -1,16 +1,16 @@
-procedure List.4 (List.123, List.124):
-    let List.575 : U64 = 1i64;
-    let List.573 : List I64 = CallByName List.70 List.123 List.575;
-    let List.572 : List I64 = CallByName List.71 List.573 List.124;
-    ret List.572;
+procedure List.4 (List.124, List.125):
+    let List.577 : U64 = 1i64;
+    let List.575 : List I64 = CallByName List.70 List.124 List.577;
+    let List.574 : List I64 = CallByName List.71 List.575 List.125;
+    ret List.574;
 
 procedure List.70 (#Attr.2, #Attr.3):
-    let List.576 : List I64 = lowlevel ListReserve #Attr.2 #Attr.3;
-    ret List.576;
+    let List.578 : List I64 = lowlevel ListReserve #Attr.2 #Attr.3;
+    ret List.578;
 
 procedure List.71 (#Attr.2, #Attr.3):
-    let List.574 : List I64 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
-    ret List.574;
+    let List.576 : List I64 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
+    ret List.576;
 
 procedure Test.1 (Test.2):
     let Test.6 : I64 = 42i64;

--- a/crates/compiler/test_mono/generated/list_cannot_update_inplace.txt
+++ b/crates/compiler/test_mono/generated/list_cannot_update_inplace.txt
@@ -1,25 +1,25 @@
-procedure List.3 (List.115, List.116, List.117):
-    let List.575 : {List I64, I64} = CallByName List.64 List.115 List.116 List.117;
-    let List.574 : List I64 = StructAtIndex 0 List.575;
-    ret List.574;
+procedure List.3 (List.116, List.117, List.118):
+    let List.577 : {List I64, I64} = CallByName List.64 List.116 List.117 List.118;
+    let List.576 : List I64 = StructAtIndex 0 List.577;
+    ret List.576;
 
 procedure List.6 (#Attr.2):
-    let List.573 : U64 = lowlevel ListLenU64 #Attr.2;
-    ret List.573;
+    let List.575 : U64 = lowlevel ListLenU64 #Attr.2;
+    ret List.575;
 
-procedure List.64 (List.112, List.113, List.114):
-    let List.580 : U64 = CallByName List.6 List.112;
-    let List.577 : Int1 = CallByName Num.22 List.113 List.580;
-    if List.577 then
-        let List.578 : {List I64, I64} = CallByName List.67 List.112 List.113 List.114;
-        ret List.578;
+procedure List.64 (List.113, List.114, List.115):
+    let List.582 : U64 = CallByName List.6 List.113;
+    let List.579 : Int1 = CallByName Num.22 List.114 List.582;
+    if List.579 then
+        let List.580 : {List I64, I64} = CallByName List.67 List.113 List.114 List.115;
+        ret List.580;
     else
-        let List.576 : {List I64, I64} = Struct {List.112, List.114};
-        ret List.576;
+        let List.578 : {List I64, I64} = Struct {List.113, List.115};
+        ret List.578;
 
 procedure List.67 (#Attr.2, #Attr.3, #Attr.4):
-    let List.579 : {List I64, I64} = lowlevel ListReplaceUnsafe #Attr.2 #Attr.3 #Attr.4;
-    ret List.579;
+    let List.581 : {List I64, I64} = lowlevel ListReplaceUnsafe #Attr.2 #Attr.3 #Attr.4;
+    ret List.581;
 
 procedure Num.19 (#Attr.2, #Attr.3):
     let Num.279 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/list_get.txt
+++ b/crates/compiler/test_mono/generated/list_get.txt
@@ -1,24 +1,24 @@
-procedure List.2 (List.107, List.108):
-    let List.578 : U64 = CallByName List.6 List.107;
-    let List.574 : Int1 = CallByName Num.22 List.108 List.578;
-    if List.574 then
-        let List.576 : I64 = CallByName List.66 List.107 List.108;
-        dec List.107;
-        let List.575 : [C {}, C I64] = TagId(1) List.576;
-        ret List.575;
+procedure List.2 (List.108, List.109):
+    let List.580 : U64 = CallByName List.6 List.108;
+    let List.576 : Int1 = CallByName Num.22 List.109 List.580;
+    if List.576 then
+        let List.578 : I64 = CallByName List.66 List.108 List.109;
+        dec List.108;
+        let List.577 : [C {}, C I64] = TagId(1) List.578;
+        ret List.577;
     else
-        dec List.107;
-        let List.573 : {} = Struct {};
-        let List.572 : [C {}, C I64] = TagId(0) List.573;
-        ret List.572;
+        dec List.108;
+        let List.575 : {} = Struct {};
+        let List.574 : [C {}, C I64] = TagId(0) List.575;
+        ret List.574;
 
 procedure List.6 (#Attr.2):
-    let List.579 : U64 = lowlevel ListLenU64 #Attr.2;
-    ret List.579;
+    let List.581 : U64 = lowlevel ListLenU64 #Attr.2;
+    ret List.581;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.577 : I64 = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.577;
+    let List.579 : I64 = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.579;
 
 procedure Num.22 (#Attr.2, #Attr.3):
     let Num.279 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/list_len.txt
+++ b/crates/compiler/test_mono/generated/list_len.txt
@@ -1,10 +1,10 @@
 procedure List.6 (#Attr.2):
-    let List.572 : U64 = lowlevel ListLenU64 #Attr.2;
-    ret List.572;
+    let List.574 : U64 = lowlevel ListLenU64 #Attr.2;
+    ret List.574;
 
 procedure List.6 (#Attr.2):
-    let List.573 : U64 = lowlevel ListLenU64 #Attr.2;
-    ret List.573;
+    let List.575 : U64 = lowlevel ListLenU64 #Attr.2;
+    ret List.575;
 
 procedure Num.19 (#Attr.2, #Attr.3):
     let Num.279 : U64 = lowlevel NumAdd #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/list_map_closure_borrows.txt
+++ b/crates/compiler/test_mono/generated/list_map_closure_borrows.txt
@@ -1,30 +1,30 @@
-procedure List.2 (List.107, List.108):
-    let List.578 : U64 = CallByName List.6 List.107;
-    let List.574 : Int1 = CallByName Num.22 List.108 List.578;
-    if List.574 then
-        let List.576 : Str = CallByName List.66 List.107 List.108;
-        inc List.576;
-        dec List.107;
-        let List.575 : [C {}, C Str] = TagId(1) List.576;
-        ret List.575;
+procedure List.2 (List.108, List.109):
+    let List.580 : U64 = CallByName List.6 List.108;
+    let List.576 : Int1 = CallByName Num.22 List.109 List.580;
+    if List.576 then
+        let List.578 : Str = CallByName List.66 List.108 List.109;
+        inc List.578;
+        dec List.108;
+        let List.577 : [C {}, C Str] = TagId(1) List.578;
+        ret List.577;
     else
-        dec List.107;
-        let List.573 : {} = Struct {};
-        let List.572 : [C {}, C Str] = TagId(0) List.573;
-        ret List.572;
+        dec List.108;
+        let List.575 : {} = Struct {};
+        let List.574 : [C {}, C Str] = TagId(0) List.575;
+        ret List.574;
 
 procedure List.5 (#Attr.2, #Attr.3):
-    let List.580 : List Str = lowlevel ListMap { xs: `#Attr.#arg1` } #Attr.2 Test.3 #Attr.3;
+    let List.582 : List Str = lowlevel ListMap { xs: `#Attr.#arg1` } #Attr.2 Test.3 #Attr.3;
     decref #Attr.2;
-    ret List.580;
+    ret List.582;
 
 procedure List.6 (#Attr.2):
-    let List.579 : U64 = lowlevel ListLenU64 #Attr.2;
-    ret List.579;
+    let List.581 : U64 = lowlevel ListLenU64 #Attr.2;
+    ret List.581;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.577 : Str = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.577;
+    let List.579 : Str = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.579;
 
 procedure Num.22 (#Attr.2, #Attr.3):
     let Num.279 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/list_map_closure_owns.txt
+++ b/crates/compiler/test_mono/generated/list_map_closure_owns.txt
@@ -1,30 +1,30 @@
-procedure List.2 (List.107, List.108):
-    let List.578 : U64 = CallByName List.6 List.107;
-    let List.574 : Int1 = CallByName Num.22 List.108 List.578;
-    if List.574 then
-        let List.576 : Str = CallByName List.66 List.107 List.108;
-        inc List.576;
-        dec List.107;
-        let List.575 : [C {}, C Str] = TagId(1) List.576;
-        ret List.575;
+procedure List.2 (List.108, List.109):
+    let List.580 : U64 = CallByName List.6 List.108;
+    let List.576 : Int1 = CallByName Num.22 List.109 List.580;
+    if List.576 then
+        let List.578 : Str = CallByName List.66 List.108 List.109;
+        inc List.578;
+        dec List.108;
+        let List.577 : [C {}, C Str] = TagId(1) List.578;
+        ret List.577;
     else
-        dec List.107;
-        let List.573 : {} = Struct {};
-        let List.572 : [C {}, C Str] = TagId(0) List.573;
-        ret List.572;
+        dec List.108;
+        let List.575 : {} = Struct {};
+        let List.574 : [C {}, C Str] = TagId(0) List.575;
+        ret List.574;
 
 procedure List.5 (#Attr.2, #Attr.3):
-    let List.580 : List Str = lowlevel ListMap { xs: `#Attr.#arg1` } #Attr.2 Test.3 #Attr.3;
+    let List.582 : List Str = lowlevel ListMap { xs: `#Attr.#arg1` } #Attr.2 Test.3 #Attr.3;
     decref #Attr.2;
-    ret List.580;
+    ret List.582;
 
 procedure List.6 (#Attr.2):
-    let List.579 : U64 = lowlevel ListLenU64 #Attr.2;
-    ret List.579;
+    let List.581 : U64 = lowlevel ListLenU64 #Attr.2;
+    ret List.581;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.577 : Str = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.577;
+    let List.579 : Str = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.579;
 
 procedure Num.22 (#Attr.2, #Attr.3):
     let Num.279 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/list_map_take_capturing_or_noncapturing.txt
+++ b/crates/compiler/test_mono/generated/list_map_take_capturing_or_noncapturing.txt
@@ -1,23 +1,23 @@
 procedure List.5 (#Attr.2, #Attr.3):
-    let List.573 : U8 = GetTagId #Attr.3;
-    joinpoint List.574 List.572:
-        ret List.572;
+    let List.575 : U8 = GetTagId #Attr.3;
+    joinpoint List.576 List.574:
+        ret List.574;
     in
-    switch List.573:
+    switch List.575:
         case 0:
-            let List.575 : List U8 = lowlevel ListMap { xs: `#Attr.#arg1` } #Attr.2 Test.4 #Attr.3;
+            let List.577 : List U8 = lowlevel ListMap { xs: `#Attr.#arg1` } #Attr.2 Test.4 #Attr.3;
             decref #Attr.2;
-            jump List.574 List.575;
+            jump List.576 List.577;
     
         case 1:
-            let List.576 : List U8 = lowlevel ListMap { xs: `#Attr.#arg1` } #Attr.2 Test.6 #Attr.3;
+            let List.578 : List U8 = lowlevel ListMap { xs: `#Attr.#arg1` } #Attr.2 Test.6 #Attr.3;
             decref #Attr.2;
-            jump List.574 List.576;
+            jump List.576 List.578;
     
         default:
-            let List.577 : List U8 = lowlevel ListMap { xs: `#Attr.#arg1` } #Attr.2 Test.8 #Attr.3;
+            let List.579 : List U8 = lowlevel ListMap { xs: `#Attr.#arg1` } #Attr.2 Test.8 #Attr.3;
             decref #Attr.2;
-            jump List.574 List.577;
+            jump List.576 List.579;
     
 
 procedure Num.19 (#Attr.2, #Attr.3):

--- a/crates/compiler/test_mono/generated/list_pass_to_function.txt
+++ b/crates/compiler/test_mono/generated/list_pass_to_function.txt
@@ -1,25 +1,25 @@
-procedure List.3 (List.115, List.116, List.117):
-    let List.573 : {List I64, I64} = CallByName List.64 List.115 List.116 List.117;
-    let List.572 : List I64 = StructAtIndex 0 List.573;
-    ret List.572;
+procedure List.3 (List.116, List.117, List.118):
+    let List.575 : {List I64, I64} = CallByName List.64 List.116 List.117 List.118;
+    let List.574 : List I64 = StructAtIndex 0 List.575;
+    ret List.574;
 
 procedure List.6 (#Attr.2):
-    let List.579 : U64 = lowlevel ListLenU64 #Attr.2;
-    ret List.579;
+    let List.581 : U64 = lowlevel ListLenU64 #Attr.2;
+    ret List.581;
 
-procedure List.64 (List.112, List.113, List.114):
-    let List.578 : U64 = CallByName List.6 List.112;
-    let List.575 : Int1 = CallByName Num.22 List.113 List.578;
-    if List.575 then
-        let List.576 : {List I64, I64} = CallByName List.67 List.112 List.113 List.114;
-        ret List.576;
+procedure List.64 (List.113, List.114, List.115):
+    let List.580 : U64 = CallByName List.6 List.113;
+    let List.577 : Int1 = CallByName Num.22 List.114 List.580;
+    if List.577 then
+        let List.578 : {List I64, I64} = CallByName List.67 List.113 List.114 List.115;
+        ret List.578;
     else
-        let List.574 : {List I64, I64} = Struct {List.112, List.114};
-        ret List.574;
+        let List.576 : {List I64, I64} = Struct {List.113, List.115};
+        ret List.576;
 
 procedure List.67 (#Attr.2, #Attr.3, #Attr.4):
-    let List.577 : {List I64, I64} = lowlevel ListReplaceUnsafe #Attr.2 #Attr.3 #Attr.4;
-    ret List.577;
+    let List.579 : {List I64, I64} = lowlevel ListReplaceUnsafe #Attr.2 #Attr.3 #Attr.4;
+    ret List.579;
 
 procedure Num.22 (#Attr.2, #Attr.3):
     let Num.279 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/list_sort_asc.txt
+++ b/crates/compiler/test_mono/generated/list_sort_asc.txt
@@ -1,11 +1,11 @@
 procedure List.28 (#Attr.2, #Attr.3):
-    let List.574 : List I64 = lowlevel ListSortWith { xs: `#Attr.#arg1` } #Attr.2 Num.46 #Attr.3;
-    ret List.574;
+    let List.576 : List I64 = lowlevel ListSortWith { xs: `#Attr.#arg1` } #Attr.2 Num.46 #Attr.3;
+    ret List.576;
 
-procedure List.59 (List.329):
-    let List.573 : {} = Struct {};
-    let List.572 : List I64 = CallByName List.28 List.329 List.573;
-    ret List.572;
+procedure List.59 (List.330):
+    let List.575 : {} = Struct {};
+    let List.574 : List I64 = CallByName List.28 List.330 List.575;
+    ret List.574;
 
 procedure Num.46 (#Attr.2, #Attr.3):
     let Num.279 : U8 = lowlevel NumCompare #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/quicksort_swap.txt
+++ b/crates/compiler/test_mono/generated/quicksort_swap.txt
@@ -1,43 +1,43 @@
-procedure List.2 (List.107, List.108):
-    let List.594 : U64 = CallByName List.6 List.107;
-    let List.591 : Int1 = CallByName Num.22 List.108 List.594;
-    if List.591 then
-        let List.593 : I64 = CallByName List.66 List.107 List.108;
-        dec List.107;
-        let List.592 : [C {}, C I64] = TagId(1) List.593;
-        ret List.592;
+procedure List.2 (List.108, List.109):
+    let List.596 : U64 = CallByName List.6 List.108;
+    let List.593 : Int1 = CallByName Num.22 List.109 List.596;
+    if List.593 then
+        let List.595 : I64 = CallByName List.66 List.108 List.109;
+        dec List.108;
+        let List.594 : [C {}, C I64] = TagId(1) List.595;
+        ret List.594;
     else
-        dec List.107;
-        let List.590 : {} = Struct {};
-        let List.589 : [C {}, C I64] = TagId(0) List.590;
-        ret List.589;
+        dec List.108;
+        let List.592 : {} = Struct {};
+        let List.591 : [C {}, C I64] = TagId(0) List.592;
+        ret List.591;
 
-procedure List.3 (List.115, List.116, List.117):
-    let List.581 : {List I64, I64} = CallByName List.64 List.115 List.116 List.117;
-    let List.580 : List I64 = StructAtIndex 0 List.581;
-    ret List.580;
+procedure List.3 (List.116, List.117, List.118):
+    let List.583 : {List I64, I64} = CallByName List.64 List.116 List.117 List.118;
+    let List.582 : List I64 = StructAtIndex 0 List.583;
+    ret List.582;
 
 procedure List.6 (#Attr.2):
-    let List.579 : U64 = lowlevel ListLenU64 #Attr.2;
-    ret List.579;
+    let List.581 : U64 = lowlevel ListLenU64 #Attr.2;
+    ret List.581;
 
-procedure List.64 (List.112, List.113, List.114):
-    let List.578 : U64 = CallByName List.6 List.112;
-    let List.575 : Int1 = CallByName Num.22 List.113 List.578;
-    if List.575 then
-        let List.576 : {List I64, I64} = CallByName List.67 List.112 List.113 List.114;
-        ret List.576;
+procedure List.64 (List.113, List.114, List.115):
+    let List.580 : U64 = CallByName List.6 List.113;
+    let List.577 : Int1 = CallByName Num.22 List.114 List.580;
+    if List.577 then
+        let List.578 : {List I64, I64} = CallByName List.67 List.113 List.114 List.115;
+        ret List.578;
     else
-        let List.574 : {List I64, I64} = Struct {List.112, List.114};
-        ret List.574;
+        let List.576 : {List I64, I64} = Struct {List.113, List.115};
+        ret List.576;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.587 : I64 = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.587;
+    let List.589 : I64 = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.589;
 
 procedure List.67 (#Attr.2, #Attr.3, #Attr.4):
-    let List.577 : {List I64, I64} = lowlevel ListReplaceUnsafe #Attr.2 #Attr.3 #Attr.4;
-    ret List.577;
+    let List.579 : {List I64, I64} = lowlevel ListReplaceUnsafe #Attr.2 #Attr.3 #Attr.4;
+    ret List.579;
 
 procedure Num.22 (#Attr.2, #Attr.3):
     let Num.281 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/record_update.txt
+++ b/crates/compiler/test_mono/generated/record_update.txt
@@ -1,25 +1,25 @@
-procedure List.3 (List.115, List.116, List.117):
-    let List.581 : {List U64, U64} = CallByName List.64 List.115 List.116 List.117;
-    let List.580 : List U64 = StructAtIndex 0 List.581;
-    ret List.580;
+procedure List.3 (List.116, List.117, List.118):
+    let List.583 : {List U64, U64} = CallByName List.64 List.116 List.117 List.118;
+    let List.582 : List U64 = StructAtIndex 0 List.583;
+    ret List.582;
 
 procedure List.6 (#Attr.2):
-    let List.579 : U64 = lowlevel ListLenU64 #Attr.2;
-    ret List.579;
+    let List.581 : U64 = lowlevel ListLenU64 #Attr.2;
+    ret List.581;
 
-procedure List.64 (List.112, List.113, List.114):
-    let List.578 : U64 = CallByName List.6 List.112;
-    let List.575 : Int1 = CallByName Num.22 List.113 List.578;
-    if List.575 then
-        let List.576 : {List U64, U64} = CallByName List.67 List.112 List.113 List.114;
-        ret List.576;
+procedure List.64 (List.113, List.114, List.115):
+    let List.580 : U64 = CallByName List.6 List.113;
+    let List.577 : Int1 = CallByName Num.22 List.114 List.580;
+    if List.577 then
+        let List.578 : {List U64, U64} = CallByName List.67 List.113 List.114 List.115;
+        ret List.578;
     else
-        let List.574 : {List U64, U64} = Struct {List.112, List.114};
-        ret List.574;
+        let List.576 : {List U64, U64} = Struct {List.113, List.115};
+        ret List.576;
 
 procedure List.67 (#Attr.2, #Attr.3, #Attr.4):
-    let List.577 : {List U64, U64} = lowlevel ListReplaceUnsafe #Attr.2 #Attr.3 #Attr.4;
-    ret List.577;
+    let List.579 : {List U64, U64} = lowlevel ListReplaceUnsafe #Attr.2 #Attr.3 #Attr.4;
+    ret List.579;
 
 procedure Num.22 (#Attr.2, #Attr.3):
     let Num.279 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/recursive_function_and_union_with_inference_hole.txt
+++ b/crates/compiler/test_mono/generated/recursive_function_and_union_with_inference_hole.txt
@@ -1,7 +1,7 @@
 procedure List.5 (#Attr.2, #Attr.3):
-    let List.572 : List [<rnnu>C List *self] = lowlevel ListMap { xs: `#Attr.#arg1` } #Attr.2 Test.2 #Attr.3;
+    let List.574 : List [<rnnu>C List *self] = lowlevel ListMap { xs: `#Attr.#arg1` } #Attr.2 Test.2 #Attr.3;
     decref #Attr.2;
-    ret List.572;
+    ret List.574;
 
 procedure Test.2 (Test.5):
     let Test.6 : List [<rnnu>C List *self] = UnionAtIndex (Id 0) (Index 0) Test.5;

--- a/crates/compiler/test_mono/generated/rigids.txt
+++ b/crates/compiler/test_mono/generated/rigids.txt
@@ -1,43 +1,43 @@
-procedure List.2 (List.107, List.108):
-    let List.594 : U64 = CallByName List.6 List.107;
-    let List.591 : Int1 = CallByName Num.22 List.108 List.594;
-    if List.591 then
-        let List.593 : I64 = CallByName List.66 List.107 List.108;
-        dec List.107;
-        let List.592 : [C {}, C I64] = TagId(1) List.593;
-        ret List.592;
+procedure List.2 (List.108, List.109):
+    let List.596 : U64 = CallByName List.6 List.108;
+    let List.593 : Int1 = CallByName Num.22 List.109 List.596;
+    if List.593 then
+        let List.595 : I64 = CallByName List.66 List.108 List.109;
+        dec List.108;
+        let List.594 : [C {}, C I64] = TagId(1) List.595;
+        ret List.594;
     else
-        dec List.107;
-        let List.590 : {} = Struct {};
-        let List.589 : [C {}, C I64] = TagId(0) List.590;
-        ret List.589;
+        dec List.108;
+        let List.592 : {} = Struct {};
+        let List.591 : [C {}, C I64] = TagId(0) List.592;
+        ret List.591;
 
-procedure List.3 (List.115, List.116, List.117):
-    let List.581 : {List I64, I64} = CallByName List.64 List.115 List.116 List.117;
-    let List.580 : List I64 = StructAtIndex 0 List.581;
-    ret List.580;
+procedure List.3 (List.116, List.117, List.118):
+    let List.583 : {List I64, I64} = CallByName List.64 List.116 List.117 List.118;
+    let List.582 : List I64 = StructAtIndex 0 List.583;
+    ret List.582;
 
 procedure List.6 (#Attr.2):
-    let List.579 : U64 = lowlevel ListLenU64 #Attr.2;
-    ret List.579;
+    let List.581 : U64 = lowlevel ListLenU64 #Attr.2;
+    ret List.581;
 
-procedure List.64 (List.112, List.113, List.114):
-    let List.578 : U64 = CallByName List.6 List.112;
-    let List.575 : Int1 = CallByName Num.22 List.113 List.578;
-    if List.575 then
-        let List.576 : {List I64, I64} = CallByName List.67 List.112 List.113 List.114;
-        ret List.576;
+procedure List.64 (List.113, List.114, List.115):
+    let List.580 : U64 = CallByName List.6 List.113;
+    let List.577 : Int1 = CallByName Num.22 List.114 List.580;
+    if List.577 then
+        let List.578 : {List I64, I64} = CallByName List.67 List.113 List.114 List.115;
+        ret List.578;
     else
-        let List.574 : {List I64, I64} = Struct {List.112, List.114};
-        ret List.574;
+        let List.576 : {List I64, I64} = Struct {List.113, List.115};
+        ret List.576;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.587 : I64 = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.587;
+    let List.589 : I64 = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.589;
 
 procedure List.67 (#Attr.2, #Attr.3, #Attr.4):
-    let List.577 : {List I64, I64} = lowlevel ListReplaceUnsafe #Attr.2 #Attr.3 #Attr.4;
-    ret List.577;
+    let List.579 : {List I64, I64} = lowlevel ListReplaceUnsafe #Attr.2 #Attr.3 #Attr.4;
+    ret List.579;
 
 procedure Num.22 (#Attr.2, #Attr.3):
     let Num.281 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;

--- a/crates/compiler/test_mono/generated/unspecialized_lambda_set_unification_does_not_duplicate_identical_concrete_types.txt
+++ b/crates/compiler/test_mono/generated/unspecialized_lambda_set_unification_does_not_duplicate_identical_concrete_types.txt
@@ -29,159 +29,159 @@ procedure Encode.26 (Encode.105, Encode.106):
     let Encode.108 : List U8 = CallByName Encode.24 Encode.109 Encode.110 Encode.106;
     ret Encode.108;
 
-procedure List.103 (List.487, List.488, List.489):
-    let List.655 : U64 = 0i64;
-    let List.656 : U64 = CallByName List.6 List.487;
-    let List.654 : [C {U64, Int1}, C {U64, Int1}] = CallByName List.80 List.487 List.488 List.489 List.655 List.656;
-    ret List.654;
+procedure List.104 (List.488, List.489, List.490):
+    let List.657 : U64 = 0i64;
+    let List.658 : U64 = CallByName List.6 List.488;
+    let List.656 : [C {U64, Int1}, C {U64, Int1}] = CallByName List.80 List.488 List.489 List.490 List.657 List.658;
+    ret List.656;
 
-procedure List.18 (List.159, List.160, List.161):
-    let List.599 : U64 = 0i64;
-    let List.600 : U64 = CallByName List.6 List.159;
-    let List.598 : {List U8, U64} = CallByName List.91 List.159 List.160 List.161 List.599 List.600;
-    ret List.598;
+procedure List.18 (List.160, List.161, List.162):
+    let List.601 : U64 = 0i64;
+    let List.602 : U64 = CallByName List.6 List.160;
+    let List.600 : {List U8, U64} = CallByName List.92 List.160 List.161 List.162 List.601 List.602;
+    ret List.600;
 
-procedure List.18 (List.159, List.160, List.161):
-    let List.611 : U64 = 0i64;
-    let List.612 : U64 = CallByName List.6 List.159;
-    let List.610 : List U8 = CallByName List.91 List.159 List.160 List.161 List.611 List.612;
-    ret List.610;
+procedure List.18 (List.160, List.161, List.162):
+    let List.613 : U64 = 0i64;
+    let List.614 : U64 = CallByName List.6 List.160;
+    let List.612 : List U8 = CallByName List.92 List.160 List.161 List.162 List.613 List.614;
+    ret List.612;
 
-procedure List.26 (List.200, List.201, List.202):
-    let List.648 : [C {U64, Int1}, C {U64, Int1}] = CallByName List.103 List.200 List.201 List.202;
-    let List.651 : U8 = 1i64;
-    let List.652 : U8 = GetTagId List.648;
-    let List.653 : Int1 = lowlevel Eq List.651 List.652;
-    if List.653 then
-        let List.203 : {U64, Int1} = UnionAtIndex (Id 1) (Index 0) List.648;
-        ret List.203;
-    else
-        let List.204 : {U64, Int1} = UnionAtIndex (Id 0) (Index 0) List.648;
+procedure List.26 (List.201, List.202, List.203):
+    let List.650 : [C {U64, Int1}, C {U64, Int1}] = CallByName List.104 List.201 List.202 List.203;
+    let List.653 : U8 = 1i64;
+    let List.654 : U8 = GetTagId List.650;
+    let List.655 : Int1 = lowlevel Eq List.653 List.654;
+    if List.655 then
+        let List.204 : {U64, Int1} = UnionAtIndex (Id 1) (Index 0) List.650;
         ret List.204;
-
-procedure List.4 (List.123, List.124):
-    let List.597 : U64 = 1i64;
-    let List.596 : List U8 = CallByName List.70 List.123 List.597;
-    let List.595 : List U8 = CallByName List.71 List.596 List.124;
-    ret List.595;
-
-procedure List.49 (List.419, List.420):
-    let List.639 : U64 = StructAtIndex 1 List.420;
-    let List.640 : U64 = StructAtIndex 0 List.420;
-    let List.638 : List U8 = CallByName List.72 List.419 List.639 List.640;
-    ret List.638;
-
-procedure List.52 (List.434, List.435):
-    let List.436 : U64 = CallByName List.6 List.434;
-    joinpoint List.646 List.437:
-        let List.644 : U64 = 0i64;
-        let List.643 : {U64, U64} = Struct {List.437, List.644};
-        inc List.434;
-        let List.438 : List U8 = CallByName List.49 List.434 List.643;
-        let List.642 : U64 = CallByName Num.75 List.436 List.437;
-        let List.637 : {U64, U64} = Struct {List.642, List.437};
-        let List.439 : List U8 = CallByName List.49 List.434 List.637;
-        let List.636 : {List U8, List U8} = Struct {List.438, List.439};
-        ret List.636;
-    in
-    let List.647 : Int1 = CallByName Num.24 List.436 List.435;
-    if List.647 then
-        jump List.646 List.435;
     else
-        jump List.646 List.436;
+        let List.205 : {U64, Int1} = UnionAtIndex (Id 0) (Index 0) List.650;
+        ret List.205;
 
-procedure List.6 (#Attr.2):
-    let List.622 : U64 = lowlevel ListLenU64 #Attr.2;
-    ret List.622;
+procedure List.4 (List.124, List.125):
+    let List.599 : U64 = 1i64;
+    let List.598 : List U8 = CallByName List.70 List.124 List.599;
+    let List.597 : List U8 = CallByName List.71 List.598 List.125;
+    ret List.597;
+
+procedure List.49 (List.420, List.421):
+    let List.641 : U64 = StructAtIndex 1 List.421;
+    let List.642 : U64 = StructAtIndex 0 List.421;
+    let List.640 : List U8 = CallByName List.72 List.420 List.641 List.642;
+    ret List.640;
+
+procedure List.52 (List.435, List.436):
+    let List.437 : U64 = CallByName List.6 List.435;
+    joinpoint List.648 List.438:
+        let List.646 : U64 = 0i64;
+        let List.645 : {U64, U64} = Struct {List.438, List.646};
+        inc List.435;
+        let List.439 : List U8 = CallByName List.49 List.435 List.645;
+        let List.644 : U64 = CallByName Num.75 List.437 List.438;
+        let List.639 : {U64, U64} = Struct {List.644, List.438};
+        let List.440 : List U8 = CallByName List.49 List.435 List.639;
+        let List.638 : {List U8, List U8} = Struct {List.439, List.440};
+        ret List.638;
+    in
+    let List.649 : Int1 = CallByName Num.24 List.437 List.436;
+    if List.649 then
+        jump List.648 List.436;
+    else
+        jump List.648 List.437;
 
 procedure List.6 (#Attr.2):
     let List.624 : U64 = lowlevel ListLenU64 #Attr.2;
     ret List.624;
 
-procedure List.66 (#Attr.2, #Attr.3):
-    let List.608 : Str = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.608;
+procedure List.6 (#Attr.2):
+    let List.626 : U64 = lowlevel ListLenU64 #Attr.2;
+    ret List.626;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.620 : U8 = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.620;
+    let List.610 : Str = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.610;
+
+procedure List.66 (#Attr.2, #Attr.3):
+    let List.622 : U8 = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.622;
 
 procedure List.68 (#Attr.2):
-    let List.635 : List U8 = lowlevel ListWithCapacity #Attr.2;
-    ret List.635;
+    let List.637 : List U8 = lowlevel ListWithCapacity #Attr.2;
+    ret List.637;
 
 procedure List.70 (#Attr.2, #Attr.3):
-    let List.576 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
-    ret List.576;
+    let List.578 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
+    ret List.578;
 
 procedure List.71 (#Attr.2, #Attr.3):
-    let List.574 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
-    ret List.574;
+    let List.576 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
+    ret List.576;
 
 procedure List.72 (#Attr.2, #Attr.3, #Attr.4):
-    let List.641 : List U8 = lowlevel ListSublist #Attr.2 #Attr.3 #Attr.4;
-    ret List.641;
+    let List.643 : List U8 = lowlevel ListSublist #Attr.2 #Attr.3 #Attr.4;
+    ret List.643;
 
 procedure List.8 (#Attr.2, #Attr.3):
-    let List.633 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
-    ret List.633;
+    let List.635 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
+    ret List.635;
 
-procedure List.80 (#Derived_gen.13, #Derived_gen.14, #Derived_gen.15, #Derived_gen.16, #Derived_gen.17):
-    joinpoint List.657 List.490 List.491 List.492 List.493 List.494:
-        let List.659 : Int1 = CallByName Num.22 List.493 List.494;
-        if List.659 then
-            let List.668 : U8 = CallByName List.66 List.490 List.493;
-            let List.660 : [C {U64, Int1}, C {U64, Int1}] = CallByName TotallyNotJson.157 List.491 List.668;
-            let List.665 : U8 = 1i64;
-            let List.666 : U8 = GetTagId List.660;
-            let List.667 : Int1 = lowlevel Eq List.665 List.666;
-            if List.667 then
-                let List.495 : {U64, Int1} = UnionAtIndex (Id 1) (Index 0) List.660;
-                let List.663 : U64 = 1i64;
-                let List.662 : U64 = CallByName Num.51 List.493 List.663;
-                jump List.657 List.490 List.495 List.492 List.662 List.494;
+procedure List.80 (#Derived_gen.8, #Derived_gen.9, #Derived_gen.10, #Derived_gen.11, #Derived_gen.12):
+    joinpoint List.659 List.491 List.492 List.493 List.494 List.495:
+        let List.661 : Int1 = CallByName Num.22 List.494 List.495;
+        if List.661 then
+            let List.670 : U8 = CallByName List.66 List.491 List.494;
+            let List.662 : [C {U64, Int1}, C {U64, Int1}] = CallByName TotallyNotJson.157 List.492 List.670;
+            let List.667 : U8 = 1i64;
+            let List.668 : U8 = GetTagId List.662;
+            let List.669 : Int1 = lowlevel Eq List.667 List.668;
+            if List.669 then
+                let List.496 : {U64, Int1} = UnionAtIndex (Id 1) (Index 0) List.662;
+                let List.665 : U64 = 1i64;
+                let List.664 : U64 = CallByName Num.51 List.494 List.665;
+                jump List.659 List.491 List.496 List.493 List.664 List.495;
             else
-                dec List.490;
-                let List.496 : {U64, Int1} = UnionAtIndex (Id 0) (Index 0) List.660;
-                let List.664 : [C {U64, Int1}, C {U64, Int1}] = TagId(0) List.496;
-                ret List.664;
+                dec List.491;
+                let List.497 : {U64, Int1} = UnionAtIndex (Id 0) (Index 0) List.662;
+                let List.666 : [C {U64, Int1}, C {U64, Int1}] = TagId(0) List.497;
+                ret List.666;
         else
-            dec List.490;
-            let List.658 : [C {U64, Int1}, C {U64, Int1}] = TagId(1) List.491;
-            ret List.658;
+            dec List.491;
+            let List.660 : [C {U64, Int1}, C {U64, Int1}] = TagId(1) List.492;
+            ret List.660;
     in
-    jump List.657 #Derived_gen.13 #Derived_gen.14 #Derived_gen.15 #Derived_gen.16 #Derived_gen.17;
+    jump List.659 #Derived_gen.8 #Derived_gen.9 #Derived_gen.10 #Derived_gen.11 #Derived_gen.12;
 
-procedure List.91 (#Derived_gen.3, #Derived_gen.4, #Derived_gen.5, #Derived_gen.6, #Derived_gen.7):
-    joinpoint List.601 List.162 List.163 List.164 List.165 List.166:
-        let List.603 : Int1 = CallByName Num.22 List.165 List.166;
-        if List.603 then
-            let List.607 : Str = CallByName List.66 List.162 List.165;
-            inc List.607;
-            let List.167 : {List U8, U64} = CallByName TotallyNotJson.233 List.163 List.607;
-            let List.606 : U64 = 1i64;
-            let List.605 : U64 = CallByName Num.51 List.165 List.606;
-            jump List.601 List.162 List.167 List.164 List.605 List.166;
+procedure List.92 (#Derived_gen.16, #Derived_gen.17, #Derived_gen.18, #Derived_gen.19, #Derived_gen.20):
+    joinpoint List.615 List.163 List.164 List.165 List.166 List.167:
+        let List.617 : Int1 = CallByName Num.22 List.166 List.167;
+        if List.617 then
+            let List.621 : U8 = CallByName List.66 List.163 List.166;
+            let List.168 : List U8 = CallByName TotallyNotJson.183 List.164 List.621;
+            let List.620 : U64 = 1i64;
+            let List.619 : U64 = CallByName Num.51 List.166 List.620;
+            jump List.615 List.163 List.168 List.165 List.619 List.167;
         else
-            dec List.162;
-            ret List.163;
+            dec List.163;
+            ret List.164;
     in
-    jump List.601 #Derived_gen.3 #Derived_gen.4 #Derived_gen.5 #Derived_gen.6 #Derived_gen.7;
+    jump List.615 #Derived_gen.16 #Derived_gen.17 #Derived_gen.18 #Derived_gen.19 #Derived_gen.20;
 
-procedure List.91 (#Derived_gen.8, #Derived_gen.9, #Derived_gen.10, #Derived_gen.11, #Derived_gen.12):
-    joinpoint List.613 List.162 List.163 List.164 List.165 List.166:
-        let List.615 : Int1 = CallByName Num.22 List.165 List.166;
-        if List.615 then
-            let List.619 : U8 = CallByName List.66 List.162 List.165;
-            let List.167 : List U8 = CallByName TotallyNotJson.183 List.163 List.619;
-            let List.618 : U64 = 1i64;
-            let List.617 : U64 = CallByName Num.51 List.165 List.618;
-            jump List.613 List.162 List.167 List.164 List.617 List.166;
+procedure List.92 (#Derived_gen.3, #Derived_gen.4, #Derived_gen.5, #Derived_gen.6, #Derived_gen.7):
+    joinpoint List.603 List.163 List.164 List.165 List.166 List.167:
+        let List.605 : Int1 = CallByName Num.22 List.166 List.167;
+        if List.605 then
+            let List.609 : Str = CallByName List.66 List.163 List.166;
+            inc List.609;
+            let List.168 : {List U8, U64} = CallByName TotallyNotJson.233 List.164 List.609;
+            let List.608 : U64 = 1i64;
+            let List.607 : U64 = CallByName Num.51 List.166 List.608;
+            jump List.603 List.163 List.168 List.165 List.607 List.167;
         else
-            dec List.162;
-            ret List.163;
+            dec List.163;
+            ret List.164;
     in
-    jump List.613 #Derived_gen.8 #Derived_gen.9 #Derived_gen.10 #Derived_gen.11 #Derived_gen.12;
+    jump List.603 #Derived_gen.3 #Derived_gen.4 #Derived_gen.5 #Derived_gen.6 #Derived_gen.7;
 
 procedure Num.127 (#Attr.2):
     let Num.286 : U8 = lowlevel NumIntCast #Attr.2;

--- a/crates/compiler/test_mono/generated/unspecialized_lambda_set_unification_keeps_all_concrete_types_without_unification_of_unifiable.txt
+++ b/crates/compiler/test_mono/generated/unspecialized_lambda_set_unification_keeps_all_concrete_types_without_unification_of_unifiable.txt
@@ -81,81 +81,81 @@ procedure Encode.26 (Encode.105, Encode.106):
     let Encode.108 : List U8 = CallByName Encode.24 Encode.109 Encode.110 Encode.106;
     ret Encode.108;
 
-procedure List.18 (List.159, List.160, List.161):
-    let List.599 : U64 = 0i64;
-    let List.600 : U64 = CallByName List.6 List.159;
-    let List.598 : {List U8, U64} = CallByName List.91 List.159 List.160 List.161 List.599 List.600;
-    ret List.598;
+procedure List.18 (List.160, List.161, List.162):
+    let List.601 : U64 = 0i64;
+    let List.602 : U64 = CallByName List.6 List.160;
+    let List.600 : {List U8, U64} = CallByName List.92 List.160 List.161 List.162 List.601 List.602;
+    ret List.600;
 
-procedure List.18 (List.159, List.160, List.161):
-    let List.639 : U64 = 0i64;
-    let List.640 : U64 = CallByName List.6 List.159;
-    let List.638 : {List U8, U64} = CallByName List.91 List.159 List.160 List.161 List.639 List.640;
-    ret List.638;
+procedure List.18 (List.160, List.161, List.162):
+    let List.641 : U64 = 0i64;
+    let List.642 : U64 = CallByName List.6 List.160;
+    let List.640 : {List U8, U64} = CallByName List.92 List.160 List.161 List.162 List.641 List.642;
+    ret List.640;
 
-procedure List.4 (List.123, List.124):
-    let List.637 : U64 = 1i64;
-    let List.636 : List U8 = CallByName List.70 List.123 List.637;
-    let List.635 : List U8 = CallByName List.71 List.636 List.124;
-    ret List.635;
+procedure List.4 (List.124, List.125):
+    let List.639 : U64 = 1i64;
+    let List.638 : List U8 = CallByName List.70 List.124 List.639;
+    let List.637 : List U8 = CallByName List.71 List.638 List.125;
+    ret List.637;
 
 procedure List.6 (#Attr.2):
-    let List.610 : U64 = lowlevel ListLenU64 #Attr.2;
+    let List.612 : U64 = lowlevel ListLenU64 #Attr.2;
+    ret List.612;
+
+procedure List.6 (#Attr.2):
+    let List.652 : U64 = lowlevel ListLenU64 #Attr.2;
+    ret List.652;
+
+procedure List.66 (#Attr.2, #Attr.3):
+    let List.610 : [C {}, C {}] = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
     ret List.610;
 
-procedure List.6 (#Attr.2):
-    let List.650 : U64 = lowlevel ListLenU64 #Attr.2;
+procedure List.66 (#Attr.2, #Attr.3):
+    let List.650 : [] = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
     ret List.650;
 
-procedure List.66 (#Attr.2, #Attr.3):
-    let List.608 : [C {}, C {}] = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.608;
-
-procedure List.66 (#Attr.2, #Attr.3):
-    let List.648 : [] = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.648;
-
 procedure List.70 (#Attr.2, #Attr.3):
-    let List.616 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
-    ret List.616;
+    let List.618 : List U8 = lowlevel ListReserve #Attr.2 #Attr.3;
+    ret List.618;
 
 procedure List.71 (#Attr.2, #Attr.3):
-    let List.614 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
-    ret List.614;
+    let List.616 : List U8 = lowlevel ListAppendUnsafe #Attr.2 #Attr.3;
+    ret List.616;
 
 procedure List.8 (#Attr.2, #Attr.3):
-    let List.651 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
-    ret List.651;
+    let List.653 : List U8 = lowlevel ListConcat #Attr.2 #Attr.3;
+    ret List.653;
 
-procedure List.91 (#Derived_gen.26, #Derived_gen.27, #Derived_gen.28, #Derived_gen.29, #Derived_gen.30):
-    joinpoint List.641 List.162 List.163 List.164 List.165 List.166:
-        let List.643 : Int1 = CallByName Num.22 List.165 List.166;
-        if List.643 then
-            let List.647 : [] = CallByName List.66 List.162 List.165;
-            let List.167 : {List U8, U64} = CallByName TotallyNotJson.233 List.163 List.647;
-            let List.646 : U64 = 1i64;
-            let List.645 : U64 = CallByName Num.51 List.165 List.646;
-            jump List.641 List.162 List.167 List.164 List.645 List.166;
+procedure List.92 (#Derived_gen.20, #Derived_gen.21, #Derived_gen.22, #Derived_gen.23, #Derived_gen.24):
+    joinpoint List.603 List.163 List.164 List.165 List.166 List.167:
+        let List.605 : Int1 = CallByName Num.22 List.166 List.167;
+        if List.605 then
+            let List.609 : [C {}, C {}] = CallByName List.66 List.163 List.166;
+            let List.168 : {List U8, U64} = CallByName TotallyNotJson.233 List.164 List.609;
+            let List.608 : U64 = 1i64;
+            let List.607 : U64 = CallByName Num.51 List.166 List.608;
+            jump List.603 List.163 List.168 List.165 List.607 List.167;
         else
-            dec List.162;
-            ret List.163;
+            dec List.163;
+            ret List.164;
     in
-    jump List.641 #Derived_gen.26 #Derived_gen.27 #Derived_gen.28 #Derived_gen.29 #Derived_gen.30;
+    jump List.603 #Derived_gen.20 #Derived_gen.21 #Derived_gen.22 #Derived_gen.23 #Derived_gen.24;
 
-procedure List.91 (#Derived_gen.40, #Derived_gen.41, #Derived_gen.42, #Derived_gen.43, #Derived_gen.44):
-    joinpoint List.601 List.162 List.163 List.164 List.165 List.166:
-        let List.603 : Int1 = CallByName Num.22 List.165 List.166;
-        if List.603 then
-            let List.607 : [C {}, C {}] = CallByName List.66 List.162 List.165;
-            let List.167 : {List U8, U64} = CallByName TotallyNotJson.233 List.163 List.607;
-            let List.606 : U64 = 1i64;
-            let List.605 : U64 = CallByName Num.51 List.165 List.606;
-            jump List.601 List.162 List.167 List.164 List.605 List.166;
+procedure List.92 (#Derived_gen.40, #Derived_gen.41, #Derived_gen.42, #Derived_gen.43, #Derived_gen.44):
+    joinpoint List.643 List.163 List.164 List.165 List.166 List.167:
+        let List.645 : Int1 = CallByName Num.22 List.166 List.167;
+        if List.645 then
+            let List.649 : [] = CallByName List.66 List.163 List.166;
+            let List.168 : {List U8, U64} = CallByName TotallyNotJson.233 List.164 List.649;
+            let List.648 : U64 = 1i64;
+            let List.647 : U64 = CallByName Num.51 List.166 List.648;
+            jump List.643 List.163 List.168 List.165 List.647 List.167;
         else
-            dec List.162;
-            ret List.163;
+            dec List.163;
+            ret List.164;
     in
-    jump List.601 #Derived_gen.40 #Derived_gen.41 #Derived_gen.42 #Derived_gen.43 #Derived_gen.44;
+    jump List.643 #Derived_gen.40 #Derived_gen.41 #Derived_gen.42 #Derived_gen.43 #Derived_gen.44;
 
 procedure Num.127 (#Attr.2):
     let Num.298 : U8 = lowlevel NumIntCast #Attr.2;

--- a/crates/compiler/test_mono/generated/weakening_avoids_overspecialization.txt
+++ b/crates/compiler/test_mono/generated/weakening_avoids_overspecialization.txt
@@ -2,80 +2,80 @@ procedure Bool.11 (#Attr.2, #Attr.3):
     let Bool.23 : Int1 = lowlevel Eq #Attr.2 #Attr.3;
     ret Bool.23;
 
-procedure List.103 (List.487, List.488, List.489):
-    let List.590 : U64 = 0i64;
-    let List.591 : U64 = CallByName List.6 List.487;
-    let List.589 : [C U64, C U64] = CallByName List.80 List.487 List.488 List.489 List.590 List.591;
-    ret List.589;
+procedure List.104 (List.488, List.489, List.490):
+    let List.592 : U64 = 0i64;
+    let List.593 : U64 = CallByName List.6 List.488;
+    let List.591 : [C U64, C U64] = CallByName List.80 List.488 List.489 List.490 List.592 List.593;
+    ret List.591;
 
-procedure List.26 (List.200, List.201, List.202):
-    let List.583 : [C U64, C U64] = CallByName List.103 List.200 List.201 List.202;
-    let List.586 : U8 = 1i64;
-    let List.587 : U8 = GetTagId List.583;
-    let List.588 : Int1 = lowlevel Eq List.586 List.587;
-    if List.588 then
-        let List.203 : U64 = UnionAtIndex (Id 1) (Index 0) List.583;
-        ret List.203;
-    else
-        let List.204 : U64 = UnionAtIndex (Id 0) (Index 0) List.583;
+procedure List.26 (List.201, List.202, List.203):
+    let List.585 : [C U64, C U64] = CallByName List.104 List.201 List.202 List.203;
+    let List.588 : U8 = 1i64;
+    let List.589 : U8 = GetTagId List.585;
+    let List.590 : Int1 = lowlevel Eq List.588 List.589;
+    if List.590 then
+        let List.204 : U64 = UnionAtIndex (Id 1) (Index 0) List.585;
         ret List.204;
+    else
+        let List.205 : U64 = UnionAtIndex (Id 0) (Index 0) List.585;
+        ret List.205;
 
-procedure List.38 (List.343, List.344):
-    let List.582 : U64 = CallByName List.6 List.343;
-    let List.345 : U64 = CallByName Num.77 List.582 List.344;
-    let List.572 : List U8 = CallByName List.43 List.343 List.345;
-    ret List.572;
+procedure List.38 (List.344, List.345):
+    let List.584 : U64 = CallByName List.6 List.344;
+    let List.346 : U64 = CallByName Num.77 List.584 List.345;
+    let List.574 : List U8 = CallByName List.43 List.344 List.346;
+    ret List.574;
 
-procedure List.43 (List.341, List.342):
-    let List.580 : U64 = CallByName List.6 List.341;
-    let List.579 : U64 = CallByName Num.77 List.580 List.342;
-    let List.574 : {U64, U64} = Struct {List.342, List.579};
-    let List.573 : List U8 = CallByName List.49 List.341 List.574;
-    ret List.573;
-
-procedure List.49 (List.419, List.420):
-    let List.576 : U64 = StructAtIndex 1 List.420;
-    let List.577 : U64 = StructAtIndex 0 List.420;
-    let List.575 : List U8 = CallByName List.72 List.419 List.576 List.577;
+procedure List.43 (List.342, List.343):
+    let List.582 : U64 = CallByName List.6 List.342;
+    let List.581 : U64 = CallByName Num.77 List.582 List.343;
+    let List.576 : {U64, U64} = Struct {List.343, List.581};
+    let List.575 : List U8 = CallByName List.49 List.342 List.576;
     ret List.575;
 
+procedure List.49 (List.420, List.421):
+    let List.578 : U64 = StructAtIndex 1 List.421;
+    let List.579 : U64 = StructAtIndex 0 List.421;
+    let List.577 : List U8 = CallByName List.72 List.420 List.578 List.579;
+    ret List.577;
+
 procedure List.6 (#Attr.2):
-    let List.581 : U64 = lowlevel ListLenU64 #Attr.2;
-    ret List.581;
+    let List.583 : U64 = lowlevel ListLenU64 #Attr.2;
+    ret List.583;
 
 procedure List.66 (#Attr.2, #Attr.3):
-    let List.604 : U8 = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
-    ret List.604;
+    let List.606 : U8 = lowlevel ListGetUnsafe #Attr.2 #Attr.3;
+    ret List.606;
 
 procedure List.72 (#Attr.2, #Attr.3, #Attr.4):
-    let List.578 : List U8 = lowlevel ListSublist #Attr.2 #Attr.3 #Attr.4;
-    ret List.578;
+    let List.580 : List U8 = lowlevel ListSublist #Attr.2 #Attr.3 #Attr.4;
+    ret List.580;
 
 procedure List.80 (#Derived_gen.0, #Derived_gen.1, #Derived_gen.2, #Derived_gen.3, #Derived_gen.4):
-    joinpoint List.592 List.490 List.491 List.492 List.493 List.494:
-        let List.594 : Int1 = CallByName Num.22 List.493 List.494;
-        if List.594 then
-            let List.603 : U8 = CallByName List.66 List.490 List.493;
-            let List.595 : [C U64, C U64] = CallByName Test.3 List.491 List.603;
-            let List.600 : U8 = 1i64;
-            let List.601 : U8 = GetTagId List.595;
-            let List.602 : Int1 = lowlevel Eq List.600 List.601;
-            if List.602 then
-                let List.495 : U64 = UnionAtIndex (Id 1) (Index 0) List.595;
-                let List.598 : U64 = 1i64;
-                let List.597 : U64 = CallByName Num.51 List.493 List.598;
-                jump List.592 List.490 List.495 List.492 List.597 List.494;
+    joinpoint List.594 List.491 List.492 List.493 List.494 List.495:
+        let List.596 : Int1 = CallByName Num.22 List.494 List.495;
+        if List.596 then
+            let List.605 : U8 = CallByName List.66 List.491 List.494;
+            let List.597 : [C U64, C U64] = CallByName Test.3 List.492 List.605;
+            let List.602 : U8 = 1i64;
+            let List.603 : U8 = GetTagId List.597;
+            let List.604 : Int1 = lowlevel Eq List.602 List.603;
+            if List.604 then
+                let List.496 : U64 = UnionAtIndex (Id 1) (Index 0) List.597;
+                let List.600 : U64 = 1i64;
+                let List.599 : U64 = CallByName Num.51 List.494 List.600;
+                jump List.594 List.491 List.496 List.493 List.599 List.495;
             else
-                dec List.490;
-                let List.496 : U64 = UnionAtIndex (Id 0) (Index 0) List.595;
-                let List.599 : [C U64, C U64] = TagId(0) List.496;
-                ret List.599;
+                dec List.491;
+                let List.497 : U64 = UnionAtIndex (Id 0) (Index 0) List.597;
+                let List.601 : [C U64, C U64] = TagId(0) List.497;
+                ret List.601;
         else
-            dec List.490;
-            let List.593 : [C U64, C U64] = TagId(1) List.491;
-            ret List.593;
+            dec List.491;
+            let List.595 : [C U64, C U64] = TagId(1) List.492;
+            ret List.595;
     in
-    jump List.592 #Derived_gen.0 #Derived_gen.1 #Derived_gen.2 #Derived_gen.3 #Derived_gen.4;
+    jump List.594 #Derived_gen.0 #Derived_gen.1 #Derived_gen.2 #Derived_gen.3 #Derived_gen.4;
 
 procedure Num.22 (#Attr.2, #Attr.3):
     let Num.282 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;


### PR DESCRIPTION
The intent of this change is to implement a `Str.concatUtf8` builtin which allows a string to be concatenated to a `List U8` as utf-8 encoded bytes. The motivation for this change is #3251 .