### PR TITLE
Update site.css so titles wrap properly 

### DIFF
--- a/www/public/site.css
+++ b/www/public/site.css
@@ -220,6 +220,7 @@ h4 {
 
 h1 {
     font-size: 5rem;
+    line-height: 1.2; 
 }
 
 h2 {


### PR DESCRIPTION
Adding `line-height` prevents squashed titles like these 

<img width="1195" alt="Screenshot 2024-06-09 at 14 24 03" src="https://github.com/roc-lang/roc/assets/344454/79b1356f-e229-4301-8148-4ba9ffaf49c3">

