### PR TITLE
Fix "Installation guide" link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [Roc](https://www.roc-lang.org) is not ready for a 0.1 release yet, but we do have:
 
-- [**installation** guide](https://github.com/roc-lang/roc/tree/main/getting_started)
+- [**installation** guide](https://www.roc-lang.org/install)
 - [**tutorial**](https://roc-lang.org/tutorial)
 - [**docs** for the standard library](https://www.roc-lang.org/builtins)
 - [**examples**](https://www.roc-lang.org/examples)


### PR DESCRIPTION
Reopening https://github.com/roc-lang/roc/pull/6787 - hopefully CI will pass this time :slightly_smiling_face: 