### PR TITLE
point basic-cli docs to latest release

### DIFF
--- a/www/content/docs.md
+++ b/www/content/docs.md
@@ -2,7 +2,7 @@
 
 - [builtins](/builtins) - docs for modules built into the language—`Str`, `Num`, etc.
 - [basic-webserver](https://roc-lang.github.io/basic-webserver/) - a platform for making Web servers ([source code](https://github.com/roc-lang/basic-webserver))
-- [basic-cli](/packages/basic-cli) - a platform for making command-line interfaces ([source code](https://github.com/roc-lang/basic-cli))
+- [basic-cli](/packages/basic-cli/0.10.0) - a platform for making command-line interfaces ([source code](https://github.com/roc-lang/basic-cli))
 - [plans](/plans) - current plans for future changes to the language
 
 In the future, a language reference will be on this page too.


### PR DESCRIPTION
The old link points to the docs of the main branch, for which the docs are currently broken (I'm investigating). We do want this to point to the docs of the latest release anyway, see also github.com/roc-lang/roc/issues/6796.