### PR TITLE
Fix platform root module flag

### DIFF
--- a/crates/compiler/load_internal/src/file.rs
+++ b/crates/compiler/load_internal/src/file.rs
@@ -4268,7 +4268,7 @@ fn parse_header<'a>(
             let (module_id, _, header) = build_platform_header(
                 arena,
                 None,
-                false,
+                is_root_module,
                 None,
                 filename,
                 parse_state,


### PR DESCRIPTION
When loading a platform module as the root, the `is_root_module` flag in `HeaderInfo` would get set to `false`. This caused issues with docs generation.

Closes: #6804