### PR TITLE
Update Swift example

### DIFF
--- a/examples/platform-switching/swift-platform/host.h
+++ b/examples/platform-switching/swift-platform/host.h
@@ -1,9 +1,0 @@
-#include <stdlib.h>
-
-struct RocStr {
-    char* bytes;
-    size_t len;
-    size_t capacity;
-};
-
-extern void roc__mainForHost_1_exposed_generic(const struct RocStr *data);


### PR DESCRIPTION
Hi! I was browsing the examples and noticed that Swift needed some love. The language improved a lot for low level use cases since this example was written and I thought I'd make it more up to date 🙂 

- Converted the example to pure Swift
  - removed the C header thanks to `extern` support
  - Removed Foundation. It is not portable and unavailable in embedded mode. Creating Swift strings now writes String memory directly, instead of using a complicated objc-bridged data structure.
  - Used naming conventions idiomatic to the language (count vs length etc)
  - Removed free functions in favor of methods and computed properties
- Used the new embedded mode to make binaries portable, tiny, faster and easier to link with
- Used native Swift allocation APIs instead of using libc directly, which is more portable and doesn't require importing anything.
- Removed return keywords in single expression functions
- Used native pointer types instead of integers

Is there somewhere else I have to modify to build using the new flags?

Where can I find any resources/documentation I'd need if I wanted to implement a library for seamless Swift/Roc integration? I saw that Rust and Zig have some "glue" code but Swift does not appear to, it would be fun to write if that's useful 🙂