### PR TITLE
Format shebangs correctly

### DIFF
--- a/crates/compiler/fmt/src/spaces.rs
+++ b/crates/compiler/fmt/src/spaces.rs
@@ -149,6 +149,14 @@ pub fn fmt_comments_only<'a, 'buf, I>(
 }
 
 fn fmt_comment(buf: &mut Buf, comment: &str) {
+    // Format shebangs without whitespace. We look for " !" as well to fix incorrect formatting from
+    // the past.
+    if buf.is_empty() && (comment.starts_with('!') || comment.starts_with(" !")) {
+        buf.push('#');
+        buf.push_str(comment.trim());
+        return;
+    }
+
     // The '#' in a comment should always be preceded by a newline or a space,
     // unless it's the very beginning of the buffer.
     if !buf.is_empty() && !buf.ends_with_space() && !buf.ends_with_newline() {

--- a/crates/compiler/test_syntax/tests/test_fmt.rs
+++ b/crates/compiler/test_syntax/tests/test_fmt.rs
@@ -148,6 +148,62 @@ mod test_fmt {
     }
 
     #[test]
+    fn shebang_comment() {
+        // Correct shebangs are left alone
+        expr_formats_same(indoc!(
+            r#"
+            #!/usr/bin/env roc
+            x = 0
+
+            x
+            "#
+        ));
+
+        // Incorrect shebang formatting from the past is fixed
+        expr_formats_to(
+            indoc!(
+                r#"
+                # !/usr/bin/env roc
+                x = 0
+
+                x
+                "#
+            ),
+            indoc!(
+                r#"
+                #!/usr/bin/env roc
+                x = 0
+
+                x
+                "#
+            ),
+        );
+
+        // Other whitespace from the user is left alone
+        expr_formats_to(
+            &format!(
+                indoc!(
+                    r#"
+                    #  !/usr/bin/env roc{space}
+                    x = 0
+
+                    x
+                    "#
+                ),
+                space = " "
+            ),
+            indoc!(
+                r#"
+                #  !/usr/bin/env roc
+                x = 0
+
+                x
+                "#
+            ),
+        );
+    }
+
+    #[test]
     fn comment_with_trailing_space() {
         expr_formats_to(
             &format!(


### PR DESCRIPTION
Fixes the regression in shebang handling I described [here](https://github.com/roc-lang/roc/issues/1135#issuecomment-2103719233).