### PR TITLE
rm dead FIXME comment

### DIFF
--- a/crates/compiler/test_gen/src/gen_num.rs
+++ b/crates/compiler/test_gen/src/gen_num.rs
@@ -2161,8 +2161,6 @@ fn shift_right_zf_by() {
 #[test]
 #[cfg(any(feature = "gen-llvm", feature = "gen-wasm", feature = "gen-dev"))]
 fn shift_right_cast_i8() {
-    // FIXME (Brian) Something funny happening with 8-bit binary literals in tests
-
     // arithmetic
     assert_evals_to!(
         "Num.shiftRightBy (Num.toI8 0b1100_0000u8) 2",


### PR DESCRIPTION
this comment was added originally in 24e6cd80e7, but was a comment on a `if cfg!(not(wasm)) {...}` block. Later that `if` was removed but the comment was not, and eventually got copied to another location making it even harder to figure out why it's there.