### PR TITLE
fix: wasi-libc.a library packaging

### DIFF
--- a/ci/package_release.sh
+++ b/ci/package_release.sh
@@ -10,19 +10,17 @@ strip ./target/release-with-lto/roc_language_server
 # to be able to delete "target" later
 cp target/release-with-lto/roc ./roc
 cp target/release-with-lto/roc_language_server ./roc_language_server
+cp target/release-with-lto/wasi-libc.a wasi-libc.a
 
 # delete unnecessary files and folders
-git clean -fdx --exclude roc --exclude roc_language_server
+git clean -fdx --exclude roc --exclude roc_language_server --exclude wasi-libc.a
 
-mkdir $1
+mkdir -p $1 $1/examples $1/crates/compiler/builtins/bitcode
 
+mv roc roc_language_server lib LICENSE LEGAL_DETAILS $1
 
-mv roc roc_language_server LICENSE LEGAL_DETAILS $1
-
-mkdir $1/examples
 mv examples/helloWorld.roc examples/platform-switching examples/cli $1/examples
 
-mkdir -p $1/crates/compiler/builtins/bitcode
 mv crates/roc_std $1/crates
 mv crates/compiler/builtins/bitcode/src $1/crates/compiler/builtins/bitcode
  

--- a/ci/package_release.sh
+++ b/ci/package_release.sh
@@ -7,21 +7,17 @@ set -euxo pipefail
 strip ./target/release-with-lto/roc
 strip ./target/release-with-lto/roc_language_server
 
-# to be able to delete "target" later
-cp target/release-with-lto/roc ./roc
-cp target/release-with-lto/roc_language_server ./roc_language_server
-cp target/release-with-lto/wasi-libc.a wasi-libc.a
-
-# delete unnecessary files and folders
-git clean -fdx --exclude roc --exclude roc_language_server --exclude wasi-libc.a
-
 mkdir -p $1 $1/examples $1/crates/compiler/builtins/bitcode
 
-mv roc roc_language_server lib LICENSE LEGAL_DETAILS $1
+mv target/release-with-lto/{roc,roc_language_server,lib} $1
+mv LICENSE LEGAL_DETAILS $1
 
-mv examples/helloWorld.roc examples/platform-switching examples/cli $1/examples
+mv examples/{helloWorld.roc,platform-switching,cli} $1/examples
 
 mv crates/roc_std $1/crates
 mv crates/compiler/builtins/bitcode/src $1/crates/compiler/builtins/bitcode
  
 tar -czvf "$1.tar.gz" $1
+
+# delete unnecessary files and folders
+git clean -fdx --exclude $1.tar.gz

--- a/ci/package_release.sh
+++ b/ci/package_release.sh
@@ -18,6 +18,3 @@ mv crates/roc_std $1/crates
 mv crates/compiler/builtins/bitcode/src $1/crates/compiler/builtins/bitcode
  
 tar -czvf "$1.tar.gz" $1
-
-# delete unnecessary files and folders
-git clean -fdx --exclude $1.tar.gz

--- a/crates/compiler/build/src/link.rs
+++ b/crates/compiler/build/src/link.rs
@@ -127,7 +127,7 @@ fn find_wasi_libc_path() -> PathBuf {
     }
 
     // This path is available in the release tarball
-    match get_relative_path(Path::new("wasi-libc.a")) {
+    match get_relative_path(Path::new("lib/wasi-libc.a")) {
         Some(path) if path.exists() => return path,
         _ => (),
     }
@@ -1352,12 +1352,14 @@ pub fn preprocess_host_wasm32(host_input_path: &Path, preprocessed_host_path: &P
     let builtins_host_tempfile = roc_bitcode::host_wasm_tempfile()
         .expect("failed to write host builtins object to tempfile");
 
+    let wasi_libc_path = find_wasi_libc_path();
+
     let mut zig_cmd = zig();
     let args = &[
         "wasm-ld",
         builtins_host_tempfile.path().to_str().unwrap(),
         host_input,
-        WASI_LIBC_PATH,
+        wasi_libc_path.to_str().unwrap(),
         WASI_COMPILER_RT_PATH, // builtins need __multi3, __udivti3, __fixdfti
         "-o",
         output_file,

--- a/crates/compiler/build/src/link.rs
+++ b/crates/compiler/build/src/link.rs
@@ -119,10 +119,17 @@ fn find_zig_glue_path() -> PathBuf {
 }
 
 fn find_wasi_libc_path() -> PathBuf {
+    // This path is available when built and run from source
     // Environment variable defined in wasi-libc-sys/build.rs
-    let wasi_libc_pathbuf = PathBuf::from(WASI_LIBC_PATH);
-    if std::path::Path::exists(&wasi_libc_pathbuf) {
-        return wasi_libc_pathbuf;
+    let build_path = PathBuf::from(WASI_LIBC_PATH);
+    if std::path::Path::exists(&build_path) {
+        return build_path;
+    }
+
+    // This path is available in the release tarball
+    match get_relative_path(Path::new("wasi-libc.a")) {
+        Some(path) if path.exists() => return path,
+        _ => (),
     }
 
     internal_error!("cannot find `wasi-libc.a`")

--- a/crates/wasi-libc-sys/build.rs
+++ b/crates/wasi-libc-sys/build.rs
@@ -8,9 +8,17 @@ fn main() {
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-changed=src/dummy.c");
 
+    // out_dir == "<project_root>/target/[<platform>/]<profile>/build/wasi_libc_sys_<hex>/"
     let out_dir = env::var("OUT_DIR").unwrap();
     let zig_cache_dir = PathBuf::from(&out_dir).join("zig-cache");
-    let out_file = PathBuf::from(&out_dir).join("wasi-libc.a");
+
+    // out_file == "<project_root>/target/[<platform>/]<profile>/lib/wasi-libc.a"
+    let mut out_file = PathBuf::from(&out_dir);
+    out_file.pop();
+    out_file.pop();
+    out_file.pop();
+    out_file.push("lib");
+    out_file.push("wasi-libc.a");
 
     // Compile a dummy C program with Zig, with our own private cache directory
     zig()
@@ -38,6 +46,7 @@ fn main() {
         .unwrap();
 
     // Copy libc to where Cargo expects the output of this crate
+    fs::create_dir_all(out_file.parent().unwrap()).unwrap();
     fs::copy(libc_path, &out_file).unwrap();
 
     println!(


### PR DESCRIPTION
This PR addresses the following issues:
* #6029 
* #5573 

The net result of this PR is the roc binary in the release package is able to run the `nodejs-interop/wasm` example using the instructions in the README.

The release package now looks like:
```shell
$ earthly +build-nightly-release --RELEASE_FOLDER_NAME=out
$ tar tf out.tar.gz
(truncated for brevity where globs are shown)
out/
out/examples/**
out/crates/
out/crates/compiler/builtins/bitcode/*
out/crates/roc_std/**
out/roc
out/roc_language_server
out/lib/
out/lib/wasi-libc.a
out/LICENSE
out/LEGAL_DETAILS
```

The original issue was the roc CLI was using the [WASI_LIBC_PATH](https://github.com/roc-lang/roc/blob/794c20956de5f22019fe1bf1cad6bf7b738add52/crates/wasi-libc-sys/src/lib.rs#L22) to lookup the path to `wasi-libc.a`. When building locally this would work fine. This would end up pointing to `$PROJECT_ROOT/target/$PROFILE/build/wasi_libc_sys-$BUILD_ID/wasi-libc.a`. In the release package this would result in the roc binary looking for the library in the static location of `/earthlybuild/...` which inevitably would not exist on the end user's machine. The new logic for the wasi-libc.a lookup matches the logic for looking up [zig glue](https://github.com/roc-lang/roc/blob/794c20956de5f22019fe1bf1cad6bf7b738add52/crates/compiler/build/src/link.rs#L106) where it checks in a lib folder next to the binary. This logic works for the current release format assuming the user keeps the contents of the release package together and either executes roc from the package or symlinks the roc binary into their path.

Potential followup:

There are a few points of cleanup that I think are probably good followup work, but since I am a new contributor I did not want to change too much in this initial PR.

* Given that `WASI_LIBC_PATH` rarely points at what you want I suggest removing the public constant and the machinery that sets it so it is not misused in the future.
* The `WASI_COMPILER_RT_PATH` is generated in the same way the `WASI_LIBC_PATH` constant is. Given the issues I found with `WASI_LIBC_PATH` I would suggest investigating `WASI_COMPILER_RT_PATH` does not have the same issues. I did not have enough context to trigger the errors that would be caused by misuse of this constant.
* The `git clean` call in the `package_release.sh` seems redundant and should be removed since the environment being cleaned is disposed at the end of the build anyways.