### PR TITLE
Load packages of packages

### DIFF
--- a/crates/cli/tests/cli_run.rs
+++ b/crates/cli/tests/cli_run.rs
@@ -1437,6 +1437,54 @@ mod cli_run {
     }
 
     #[test]
+    #[serial(multi_dep_thunk)]
+    #[cfg_attr(windows, ignore)]
+    fn run_transitive_deps_app() {
+        check_output_with_stdin(
+            &fixture_file("transitive-deps", "direct-one.roc"),
+            &[],
+            &[],
+            &[],
+            &[],
+            "[One imports Two: From two]\n",
+            UseValgrind::Yes,
+            TestCliCommands::Run,
+        );
+    }
+
+    #[test]
+    #[serial(multi_dep_thunk)]
+    #[cfg_attr(windows, ignore)]
+    fn run_transitive_and_direct_dep_app() {
+        check_output_with_stdin(
+            &fixture_file("transitive-deps", "direct-one-and-two.roc"),
+            &[],
+            &[],
+            &[],
+            &[],
+            "[One imports Two: From two] | From two\n",
+            UseValgrind::Yes,
+            TestCliCommands::Run,
+        );
+    }
+
+    #[test]
+    #[serial(multi_dep_thunk)]
+    #[cfg_attr(windows, ignore)]
+    fn run_double_transitive_dep_app() {
+        check_output_with_stdin(
+            &fixture_file("transitive-deps", "direct-zero.roc"),
+            &[],
+            &[],
+            &[],
+            &[],
+            "[Zero imports One: [One imports Two: From two]]\n",
+            UseValgrind::Yes,
+            TestCliCommands::Run,
+        );
+    }
+
+    #[test]
     fn known_type_error() {
         check_compile_error(
             &known_bad_file("TypeError.roc"),

--- a/crates/cli/tests/fixtures/transitive-deps/direct-one-and-two.roc
+++ b/crates/cli/tests/fixtures/transitive-deps/direct-one-and-two.roc
@@ -1,0 +1,10 @@
+app [main] { 
+  pf: platform "../packages/platform/main.roc", 
+  one: "one/main.roc",
+  two: "two/main.roc",
+}
+
+import one.One
+import two.Two
+
+main = "$(One.example) | $(Two.example)"

--- a/crates/cli/tests/fixtures/transitive-deps/direct-one.roc
+++ b/crates/cli/tests/fixtures/transitive-deps/direct-one.roc
@@ -1,0 +1,8 @@
+app [main] { 
+  pf: platform "../packages/platform/main.roc", 
+  one: "one/main.roc",
+}
+
+import one.One
+
+main = One.example

--- a/crates/cli/tests/fixtures/transitive-deps/direct-zero.roc
+++ b/crates/cli/tests/fixtures/transitive-deps/direct-zero.roc
@@ -1,0 +1,8 @@
+app [main] { 
+  pf: platform "../packages/platform/main.roc", 
+  zero: "zero/main.roc",
+}
+
+import zero.Zero
+
+main = Zero.example

--- a/crates/cli/tests/fixtures/transitive-deps/one/One.roc
+++ b/crates/cli/tests/fixtures/transitive-deps/one/One.roc
@@ -1,0 +1,5 @@
+module [example] 
+
+import two.Two
+
+example = "[One imports Two: $(Two.example)]"

--- a/crates/cli/tests/fixtures/transitive-deps/one/main.roc
+++ b/crates/cli/tests/fixtures/transitive-deps/one/main.roc
@@ -1,0 +1,3 @@
+package [One] {
+    two: "../two/main.roc",
+}

--- a/crates/cli/tests/fixtures/transitive-deps/two/Two.roc
+++ b/crates/cli/tests/fixtures/transitive-deps/two/Two.roc
@@ -1,0 +1,3 @@
+module [example]
+
+example = "From two"

--- a/crates/cli/tests/fixtures/transitive-deps/two/main.roc
+++ b/crates/cli/tests/fixtures/transitive-deps/two/main.roc
@@ -1,0 +1,1 @@
+package [Two] {}

--- a/crates/cli/tests/fixtures/transitive-deps/zero/Zero.roc
+++ b/crates/cli/tests/fixtures/transitive-deps/zero/Zero.roc
@@ -1,0 +1,5 @@
+module [example]
+
+import one.One
+
+example = "[Zero imports One: $(One.example)]"

--- a/crates/cli/tests/fixtures/transitive-deps/zero/main.roc
+++ b/crates/cli/tests/fixtures/transitive-deps/zero/main.roc
@@ -1,0 +1,3 @@
+package [Zero] {
+  one: "../one/main.roc"
+}


### PR DESCRIPTION
We were never loading the packages of a package / platform. This caused the compiler to hang if your app depended on a package transitively.