### PR TITLE
Make `roc dev someFile.roc` forward exit status

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1244,7 +1244,13 @@ fn roc_dev_native(
                         let options = 0;
                         unsafe { libc::waitpid(pid, &mut status, options) };
 
-                        break status;
+                        // if `WIFEXITED` returns false, `WEXITSTATUS` will just return junk
+                        break if libc::WIFEXITED(status) {
+                            libc::WEXITSTATUS(status)
+                        } else {
+                            // we don't have an exit code, so we probably shouldn't make one up
+                            0
+                        };
                     }
                     ChildProcessMsg::Expect => {
                         roc_repl_expect::run::render_expects_in_memory(

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1205,13 +1205,10 @@ fn roc_dev_native(
         layout_interner,
     } = expect_metadata;
 
-    // let shm_name =
     let shm_name = format!("/roc_expect_buffer_{}", std::process::id());
     let mut memory = ExpectMemory::create_or_reuse_mmap(&shm_name);
 
     let layout_interner = layout_interner.into_global();
-
-    let mut writer = std::io::stdout();
 
     match unsafe { libc::fork() } {
         0 => unsafe {
@@ -1253,6 +1250,7 @@ fn roc_dev_native(
                         };
                     }
                     ChildProcessMsg::Expect => {
+                        let mut writer = std::io::stdout();
                         roc_repl_expect::run::render_expects_in_memory(
                             &mut writer,
                             arena,

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1099,28 +1099,26 @@ fn roc_run_native<I: IntoIterator<Item = S>, S: AsRef<OsStr>>(
 ) -> std::io::Result<i32> {
     use bumpalo::collections::CollectIn;
 
-    unsafe {
-        let executable = roc_run_executable_file_path(binary_bytes)?;
-        let (argv_cstrings, envp_cstrings) = make_argv_envp(arena, &executable, args);
+    let executable = roc_run_executable_file_path(binary_bytes)?;
+    let (argv_cstrings, envp_cstrings) = make_argv_envp(arena, &executable, args);
 
-        let argv: bumpalo::collections::Vec<*const c_char> = argv_cstrings
-            .iter()
-            .map(|s| s.as_ptr())
-            .chain([std::ptr::null()])
-            .collect_in(arena);
+    let argv: bumpalo::collections::Vec<*const c_char> = argv_cstrings
+        .iter()
+        .map(|s| s.as_ptr())
+        .chain([std::ptr::null()])
+        .collect_in(arena);
 
-        let envp: bumpalo::collections::Vec<*const c_char> = envp_cstrings
-            .iter()
-            .map(|s| s.as_ptr())
-            .chain([std::ptr::null()])
-            .collect_in(arena);
+    let envp: bumpalo::collections::Vec<*const c_char> = envp_cstrings
+        .iter()
+        .map(|s| s.as_ptr())
+        .chain([std::ptr::null()])
+        .collect_in(arena);
 
-        match opt_level {
-            OptLevel::Development => roc_dev_native(arena, executable, argv, envp, expect_metadata),
-            OptLevel::Normal | OptLevel::Size | OptLevel::Optimize => {
-                roc_run_native_fast(executable, &argv, &envp);
-            }
-        }
+    match opt_level {
+        OptLevel::Development => roc_dev_native(arena, executable, argv, envp, expect_metadata),
+        OptLevel::Normal | OptLevel::Size | OptLevel::Optimize => unsafe {
+            roc_run_native_fast(executable, &argv, &envp);
+        },
     }
 
     Ok(1)


### PR DESCRIPTION
Closes #6797 and also cleans up a few things I noticed (in separate commits).

The issue is that we get the "exit status" here...
https://github.com/roc-lang/roc/blob/6a074adcf235beaa171c962bf71742325e98cf9c/crates/cli/src/lib.rs#L1245-L1249
...but `status` isn't actually the _exit_ status.
Per [waitpid(2)](https://linux.die.net/man/2/waitpid), `libc::WEXITSTATUS(status)` is what we're looking for.