### PR TITLE
Fix hang on qualified import with builtin name

### DIFF
--- a/crates/compiler/load/tests/test_reporting.rs
+++ b/crates/compiler/load/tests/test_reporting.rs
@@ -11783,6 +11783,30 @@ In roc, functions are always written as a lambda, like{}
     );
 
     test_report!(
+        import_qualified_builtin,
+        indoc!(
+            r#"
+            app [main] { pf: platform "../../tests/platform.roc" }
+
+            import pf.Bool
+
+            main =
+                ""
+            "#
+        ),
+        @r###"
+    [1;36m── FILE NOT FOUND in tmp/import_qualified_builtin/../../tests/Bool.roc ─────────[0m
+
+    I am looking for this file, but it's not there:
+
+        [1;33mtmp/import_qualified_builtin/../../tests/Bool.roc[0m
+
+    Is the file supposed to be there? Maybe there is a typo in the file
+    name?
+    "###
+    );
+
+    test_report!(
         invalid_toplevel_cycle,
         indoc!(
             r#"

--- a/crates/compiler/load_internal/src/file.rs
+++ b/crates/compiler/load_internal/src/file.rs
@@ -3599,9 +3599,9 @@ fn load_module<'a>(
 
     macro_rules! load_builtins {
         ($($name:literal, $module_id:path)*) => {
-            match module_name.as_inner().as_str() {
+            match module_name.unqualified().map(|name| name.as_str()) {
             $(
-                $name => {
+                Some($name) => {
                     let (module_id, msg) = load_builtin_module(
                         arena,
                         module_ids,

--- a/crates/compiler/module/src/symbol.rs
+++ b/crates/compiler/module/src/symbol.rs
@@ -462,6 +462,13 @@ impl<'a, T> PackageQualified<'a, T> {
         }
     }
 
+    pub fn unqualified(&self) -> Option<&T> {
+        match self {
+            PackageQualified::Unqualified(name) => Some(name),
+            PackageQualified::Qualified(_, _) => None,
+        }
+    }
+
     pub fn package_shorthand(&self) -> Option<&'a str> {
         match self {
             PackageQualified::Unqualified(_) => None,


### PR DESCRIPTION
The compiler would hang when it encountered an import with a module name that matched a builtin name regardless of whether it was package-qualified.

```roc
import pf.List
```

Instead of hanging we will now report the usual `FILE NOT FOUND` error, or `IMPORT NAME CONFLICT` if it exists.

This will help prevent some confusion when `Task` becomes a builtin.