### PR TITLE
Add plans banner to `/install` page

### DIFF
--- a/www/content/install/index.md
+++ b/www/content/install/index.md
@@ -3,7 +3,7 @@
 Roc is a very young language with many incomplete features and known bugs. It doesn't even have a numbered release yet, but it does have [nightly builds](https://github.com/roc-lang/roc/releases) that you can download if you'd like to try it out without [building from source](https://github.com/roc-lang/roc/blob/main/BUILDING_FROM_SOURCE.md)!
 
 <div class="banner">
-    Roc is a <b>Work in Progress</b>, see our <a href="/plans">plans</a> page for more information.
+    Roc is a <b>Work in Progress</b>! see our <a href="/plans">plans</a> page for more information.
 </div>
 
 There are currently a few known OS-specific issues:

--- a/www/content/install/index.md
+++ b/www/content/install/index.md
@@ -3,7 +3,7 @@
 Roc is a very young language with many incomplete features and known bugs. It doesn't even have a numbered release yet, but it does have [nightly builds](https://github.com/roc-lang/roc/releases) that you can download if you'd like to try it out without [building from source](https://github.com/roc-lang/roc/blob/main/BUILDING_FROM_SOURCE.md)!
 
 <div class="banner">
-    Roc is a <b>Work in Progress</b>! see our <a href="/plans">plans</a> page for more information.
+    Roc is a <b>Work in Progress!</b> see our <a href="/plans">plans</a> page for more information.
 </div>
 
 There are currently a few known OS-specific issues:

--- a/www/content/install/index.md
+++ b/www/content/install/index.md
@@ -3,7 +3,7 @@
 Roc is a very young language with many incomplete features and known bugs. It doesn't even have a numbered release yet, but it does have [nightly builds](https://github.com/roc-lang/roc/releases) that you can download if you'd like to try it out without [building from source](https://github.com/roc-lang/roc/blob/main/BUILDING_FROM_SOURCE.md)!
 
 <div class="banner">
-    Roc is a <b>Work in Progress!</b> see our <a href="/plans">plans</a> page for more information.
+    Roc is a <b>Work in Progress!</b> See the <a href="/plans">plans</a> page for more information.
 </div>
 
 There are currently a few known OS-specific issues:

--- a/www/content/install/index.md
+++ b/www/content/install/index.md
@@ -2,6 +2,10 @@
 
 Roc is a very young language with many incomplete features and known bugs. It doesn't even have a numbered release yet, but it does have [nightly builds](https://github.com/roc-lang/roc/releases) that you can download if you'd like to try it out without [building from source](https://github.com/roc-lang/roc/blob/main/BUILDING_FROM_SOURCE.md)!
 
+<div class="banner">
+    Roc is a <b>Work in Progress</b>, see our <a href="/plans">plans</a> page for more information.
+</div>
+
 There are currently a few known OS-specific issues:
 * **macOS:** There are no known compatibility issues, but the compiler doesn't run as fast as it does on Linux or Windows, because we don't (yet) do our own linking like we do on those targets. (Linking works similarly on Linux and Windows, but the way macOS does it is both different and significantly more complicated.)
 * **Windows:** There are some known Windows-specific compiler bugs, and probably some other unknown ones because more people have tried out Roc on Mac and Linux than on Windows.

--- a/www/public/site.css
+++ b/www/public/site.css
@@ -1580,3 +1580,18 @@ code .dim {
     color: var(--light-cyan);
     content: "» ";
 }
+
+.banner {
+    background-color: var(--gray-bg);
+    padding: 1rem;
+    text-align: center;
+    font-family: var(--font-sans);
+    border: 1px solid var(--primary-1);
+    margin-bottom: 20px;
+}
+
+.banner a {
+    color: var(--link-color);
+    text-decoration: underline;
+    font-weight: bold;
+}


### PR DESCRIPTION
This PR adds a banner to the `/plans` page on the `/install` page of the website. 

## Light version

<img width="781" alt="Screenshot 2024-07-04 at 10 37 10" src="https://github.com/roc-lang/roc/assets/2679227/e5d57f75-77fb-4fa3-9e06-fc0fe186464a">

## Dark version
<img width="787" alt="Screenshot 2024-07-04 at 10 37 19" src="https://github.com/roc-lang/roc/assets/2679227/0db58685-a270-4a95-835d-efa5cce6c43f">
