### PR TITLE
Update platforms page to match new syntax

### DIFF
--- a/www/content/platforms.md
+++ b/www/content/platforms.md
@@ -7,10 +7,10 @@ Something that sets Roc apart from other programming languages is its <span clas
 Here is a Roc application that prints `"Hello, World!"` to the command line:
 
 ```roc
-app "hello"
-    packages { pf: "https://github.com/roc-lang/basic-cli/releases/download/0.10.0/vNe6s9hWzoTZtFmNkvEICPErI9ptji_ySjicO6CkucY.tar.br" }
-    imports [pf.Stdout, pf.Task]
-    provides [main] to pf
+app [main] { pf: platform "https://github.com/roc-lang/basic-cli/releases/download/0.10.0/vNe6s9hWzoTZtFmNkvEICPErI9ptji_ySjicO6CkucY.tar.br" }
+
+import pf.Stdout
+import pf.Task
 
 main =
     Stdout.line "Hello, World!"


### PR DESCRIPTION
Since this page was last updated, the snippet at the top is no longer accurate.

This is similar to #6781 and #6795 

FYI, I would love some more documentation on how to implement custom platforms. I will be looking into this myself though and might write some :)