### PR TITLE
Type annotations for suffixed sugar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2347,6 +2347,7 @@ dependencies = [
  "roc_collections",
  "roc_error_macros",
  "roc_exhaustive",
+ "roc_fmt",
  "roc_module",
  "roc_parse",
  "roc_problem",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2347,7 +2347,6 @@ dependencies = [
  "roc_collections",
  "roc_error_macros",
  "roc_exhaustive",
- "roc_fmt",
  "roc_module",
  "roc_parse",
  "roc_problem",

--- a/crates/compiler/can/Cargo.toml
+++ b/crates/compiler/can/Cargo.toml
@@ -13,7 +13,6 @@ roc_error_macros = { path = "../../error_macros" }
 roc_exhaustive = { path = "../exhaustive" }
 roc_module = { path = "../module" }
 roc_parse = { path = "../parse" }
-roc_fmt = { path = "../fmt" }
 roc_problem = { path = "../problem" }
 roc_region = { path = "../region" }
 roc_serialize = { path = "../serialize" }

--- a/crates/compiler/can/Cargo.toml
+++ b/crates/compiler/can/Cargo.toml
@@ -13,6 +13,7 @@ roc_error_macros = { path = "../../error_macros" }
 roc_exhaustive = { path = "../exhaustive" }
 roc_module = { path = "../module" }
 roc_parse = { path = "../parse" }
+roc_fmt = { path = "../fmt" }
 roc_problem = { path = "../problem" }
 roc_region = { path = "../region" }
 roc_serialize = { path = "../serialize" }

--- a/crates/compiler/can/src/desugar.rs
+++ b/crates/compiler/can/src/desugar.rs
@@ -159,7 +159,7 @@ fn desugar_value_def<'a>(
             // _ = stmt_expr!
 
             let region = stmt_expr.region;
-            let new_pat = arena.alloc(Loc::at(region, Pattern::Underscore("")));
+            let new_pat = arena.alloc(Loc::at(region, Pattern::Underscore("#!stmt")));
 
             ValueDef::AnnotatedBody {
                 ann_pattern: new_pat,
@@ -265,7 +265,7 @@ pub fn desugar_value_def_suffixed<'a>(arena: &'a Bump, value_def: ValueDef<'a>) 
                             sub_arg,
                             sub_pat,
                             sub_new,
-                            Some(ann_type),
+                            Some((ann_pattern, ann_type)),
                         ),
                     },
                 ),

--- a/crates/compiler/can/src/desugar.rs
+++ b/crates/compiler/can/src/desugar.rs
@@ -10,7 +10,7 @@ use roc_module::ident::ModuleName;
 use roc_parse::ast::Expr::{self, *};
 use roc_parse::ast::{
     AssignedField, Collection, ModuleImportParams, OldRecordBuilderField, Pattern, StrLiteral,
-    StrSegment, ValueDef, WhenBranch,
+    StrSegment, TypeAnnotation, ValueDef, WhenBranch,
 };
 use roc_region::all::{LineInfo, Loc, Region};
 
@@ -154,15 +154,26 @@ fn desugar_value_def<'a>(
         IngestedFileImport(_) => *def,
 
         Stmt(stmt_expr) => {
-            // desugar into a Body({}, stmt_expr)
-            let loc_pattern = arena.alloc(Loc::at(
-                stmt_expr.region,
-                Pattern::RecordDestructure(Collection::empty()),
-            ));
-            Body(
-                loc_pattern,
-                desugar_expr(arena, stmt_expr, src, line_info, module_path),
-            )
+            // desugar `stmt_expr!` to
+            // _ : {}
+            // _ = stmt_expr!
+
+            let region = stmt_expr.region;
+            let new_pat = arena.alloc(Loc::at(region, Pattern::Underscore("")));
+
+            ValueDef::AnnotatedBody {
+                ann_pattern: new_pat,
+                ann_type: arena.alloc(Loc::at(
+                    region,
+                    TypeAnnotation::Record {
+                        fields: Collection::empty(),
+                        ext: None,
+                    },
+                )),
+                comment: None,
+                body_pattern: new_pat,
+                body_expr: desugar_expr(arena, stmt_expr, src, line_info, module_path),
+            }
         }
     }
 }
@@ -211,7 +222,7 @@ pub fn desugar_value_def_suffixed<'a>(arena: &'a Bump, value_def: ValueDef<'a>) 
                     arena,
                     Body(
                         loc_pattern,
-                        apply_task_await(arena, loc_expr.region, sub_arg, sub_pat, sub_new),
+                        apply_task_await(arena, loc_expr.region, sub_arg, sub_pat, sub_new, None),
                     ),
                 ),
                 Err(..) => Body(
@@ -254,6 +265,7 @@ pub fn desugar_value_def_suffixed<'a>(arena: &'a Bump, value_def: ValueDef<'a>) 
                             sub_arg,
                             sub_pat,
                             sub_new,
+                            Some(ann_type),
                         ),
                     },
                 ),

--- a/crates/compiler/can/src/suffixed.rs
+++ b/crates/compiler/can/src/suffixed.rs
@@ -645,7 +645,7 @@ pub fn unwrap_suffixed_expression_defs_help<'a>(
                                         Ok(next_expr) => next_expr,
                                         Err(EUnwrapped::UnwrappedSubExpr { sub_arg, sub_pat, sub_new }) => {
                                             // We need to apply Task.ok here as the defs final expression was unwrapped
-                                            apply_task_await(arena,def_expr.region,sub_arg,sub_pat,sub_new, ann_type)
+                                            apply_task_await(arena,def_expr.region,sub_arg,sub_pat,sub_new, None)
                                         }
                                         Err(EUnwrapped::UnwrappedDefExpr(..)) | Err(EUnwrapped::Malformed) => {
                                             // TODO handle case when we have maybe_def_pat so can return an unwrapped up
@@ -660,7 +660,7 @@ pub fn unwrap_suffixed_expression_defs_help<'a>(
                                     let next_expr = match unwrap_suffixed_expression(arena,new_defs,maybe_def_pat){
                                         Ok(next_expr) => next_expr,
                                         Err(EUnwrapped::UnwrappedSubExpr { sub_arg, sub_pat, sub_new }) => {
-                                            apply_task_await(arena, def_expr.region, sub_arg, sub_pat, sub_new, ann_type)
+                                            apply_task_await(arena, def_expr.region, sub_arg, sub_pat, sub_new, None)
                                         }
                                         Err(EUnwrapped::UnwrappedDefExpr(..)) | Err(EUnwrapped::Malformed) => {
                                             // TODO handle case when we have maybe_def_pat so can return an unwrapped up
@@ -668,7 +668,7 @@ pub fn unwrap_suffixed_expression_defs_help<'a>(
                                         },
                                     };
 
-                                    return unwrap_suffixed_expression(arena, apply_task_await(arena,def_expr.region,unwrapped_expr,def_pattern,next_expr, ann_type), maybe_def_pat);
+                                    return unwrap_suffixed_expression(arena, apply_task_await(arena,def_expr.region,unwrapped_expr,def_pattern,next_expr,ann_type), maybe_def_pat);
                                 } else if after_empty {
                                     // SOME before, NIL after -> LAST DEF
                                     // We pass None as a def pattern here because it's desugaring of the ret expression
@@ -679,7 +679,7 @@ pub fn unwrap_suffixed_expression_defs_help<'a>(
                                             return unwrap_suffixed_expression(arena, new_defs, maybe_def_pat);
                                         },
                                         Err(EUnwrapped::UnwrappedSubExpr { sub_arg, sub_pat, sub_new }) => {
-                                            let new_loc_ret = apply_task_await(arena,def_expr.region,sub_arg,sub_pat,sub_new, ann_type);
+                                            let new_loc_ret = apply_task_await(arena,def_expr.region,sub_arg,sub_pat,sub_new, None);
                                             let applied_task_await = apply_task_await(arena, loc_expr.region, unwrapped_expr, def_pattern, new_loc_ret, ann_type);
                                             let new_defs = arena.alloc(Loc::at(loc_expr.region,Defs(arena.alloc(split_defs.before), applied_task_await)));
                                             return unwrap_suffixed_expression(arena, new_defs, maybe_def_pat);
@@ -703,7 +703,7 @@ pub fn unwrap_suffixed_expression_defs_help<'a>(
                                             return unwrap_suffixed_expression(arena, new_defs, maybe_def_pat);
                                         },
                                         Err(EUnwrapped::UnwrappedSubExpr { sub_arg, sub_pat, sub_new }) => {
-                                            let new_loc_ret = apply_task_await(arena, def_expr.region, sub_arg, sub_pat, sub_new, ann_type);
+                                            let new_loc_ret = apply_task_await(arena, def_expr.region, sub_arg, sub_pat, sub_new, None);
                                             let applied_await = apply_task_await(arena, loc_expr.region, unwrapped_expr, def_pattern, new_loc_ret, ann_type);
                                             let new_defs = arena.alloc(Loc::at(loc_expr.region,Defs(arena.alloc(split_defs.before), applied_await)));
                                             return unwrap_suffixed_expression(arena, new_defs, maybe_def_pat);
@@ -729,14 +729,14 @@ pub fn unwrap_suffixed_expression_defs_help<'a>(
             }
 
             // try to unwrap the loc_ret
-            match unwrap_suffixed_expression(arena,loc_ret,maybe_def_pat){
+            match unwrap_suffixed_expression(arena,loc_ret,None){
                 Ok(new_loc_ret) => {
                     Ok(arena.alloc(Loc::at(loc_expr.region,Defs(arena.alloc(local_defs), new_loc_ret))))
                 },
                 Err(EUnwrapped::UnwrappedSubExpr { sub_arg, sub_pat, sub_new }) => {
                     let new_loc_ret = apply_task_await(arena, loc_expr.region,sub_arg,sub_pat,sub_new, None);
                     let new_defs = arena.alloc(Loc::at(loc_expr.region,Defs(arena.alloc(local_defs), new_loc_ret)));
-                    unwrap_suffixed_expression(arena, new_defs, maybe_def_pat)
+                    unwrap_suffixed_expression(arena, new_defs, None)
                 }
                 Err(EUnwrapped::UnwrappedDefExpr(..)) => {
                     // TODO confirm this is correct with test case

--- a/crates/compiler/can/src/suffixed.rs
+++ b/crates/compiler/can/src/suffixed.rs
@@ -901,12 +901,6 @@ pub fn apply_task_await<'a>(
             arena.alloc(Loc::at(region, Defs(arena.alloc(defs), new_var)))
         }
         _ => {
-            // If the pattern and the new are matching answers then we don't need to unwrap anything
-            // e.g. `Task.await foo \#!a1 -> Task.ok #!a1` is the same as `foo`
-            if is_matching_intermediate_answer(loc_pat, loc_cont) {
-                return loc_expr;
-            }
-
             // loc_pat = loc_expr!
             // loc_cont
 
@@ -915,6 +909,12 @@ pub fn apply_task_await<'a>(
             loc_expr
         }
     };
+
+    // If the pattern and the new are matching answers then we don't need to unwrap anything
+    // e.g. `Task.await foo \#!a1 -> Task.ok #!a1` is the same as `foo`
+    if is_matching_intermediate_answer(loc_pat, loc_cont) {
+        return task_await_first_arg;
+    }
 
     // \loc_pat -> loc_cont
     let closure = arena.alloc(Loc::at(region, Closure(arena.alloc([*loc_pat]), loc_cont)));

--- a/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__apply_argument_multiple.snap
+++ b/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__apply_argument_multiple.snap
@@ -35,7 +35,7 @@ Defs {
                     @15-22 Closure(
                         [
                             @17-18 Identifier {
-                                ident: "#!a0",
+                                ident: "#!0_arg",
                             },
                         ],
                         @15-22 Apply(
@@ -51,7 +51,7 @@ Defs {
                                 @15-22 Closure(
                                     [
                                         @20-21 Identifier {
-                                            ident: "#!a1",
+                                            ident: "#!1_arg",
                                         },
                                     ],
                                     @15-22 Defs(
@@ -83,11 +83,11 @@ Defs {
                                                         [
                                                             @17-18 Var {
                                                                 module_name: "",
-                                                                ident: "#!a0",
+                                                                ident: "#!0_arg",
                                                             },
                                                             @20-21 Var {
                                                                 module_name: "",
-                                                                ident: "#!a1",
+                                                                ident: "#!1_arg",
                                                             },
                                                         ],
                                                         Space,

--- a/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__apply_argument_single.snap
+++ b/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__apply_argument_single.snap
@@ -35,7 +35,7 @@ Defs {
                     @15-19 Closure(
                         [
                             @17-18 Identifier {
-                                ident: "#!a0",
+                                ident: "#!0_arg",
                             },
                         ],
                         @15-19 Defs(
@@ -67,7 +67,7 @@ Defs {
                                             [
                                                 @17-18 Var {
                                                     module_name: "",
-                                                    ident: "#!a0",
+                                                    ident: "#!0_arg",
                                                 },
                                             ],
                                             Space,

--- a/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__apply_argument_suffixed.snap
+++ b/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__apply_argument_suffixed.snap
@@ -45,7 +45,7 @@ Defs {
                     @15-33 Closure(
                         [
                             Identifier {
-                                ident: "#!a0",
+                                ident: "#!0_arg",
                             },
                         ],
                         @15-33 Defs(
@@ -78,7 +78,7 @@ Defs {
                                                 @20-32 ParensAround(
                                                     Var {
                                                         module_name: "",
-                                                        ident: "#!a0",
+                                                        ident: "#!0_arg",
                                                     },
                                                 ),
                                             ],

--- a/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__apply_function_suffixed.snap
+++ b/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__apply_function_suffixed.snap
@@ -45,7 +45,7 @@ Defs {
                     @15-35 Closure(
                         [
                             Identifier {
-                                ident: "#!a0",
+                                ident: "#!0_arg",
                             },
                         ],
                         @15-35 Defs(
@@ -73,7 +73,7 @@ Defs {
                                             @16-26 ParensAround(
                                                 Var {
                                                     module_name: "",
-                                                    ident: "#!a0",
+                                                    ident: "#!0_arg",
                                                 },
                                             ),
                                             [

--- a/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__bang_in_pipe_root.snap
+++ b/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__bang_in_pipe_root.snap
@@ -35,7 +35,7 @@ Defs {
                     @15-22 Closure(
                         [
                             @15-16 Identifier {
-                                ident: "#!a0",
+                                ident: "#!0_arg",
                             },
                         ],
                         @15-22 Defs(
@@ -67,7 +67,7 @@ Defs {
                                             [
                                                 @15-16 Var {
                                                     module_name: "",
-                                                    ident: "#!a0",
+                                                    ident: "#!0_arg",
                                                 },
                                             ],
                                             BinOp(

--- a/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__basic.snap
+++ b/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__basic.snap
@@ -28,14 +28,58 @@ Defs {
                     ident: "await",
                 },
                 [
-                    @11-15 Var {
-                        module_name: "",
-                        ident: "foo",
-                    },
+                    @11-15 Defs(
+                        Defs {
+                            tags: [
+                                Index(2147483648),
+                            ],
+                            regions: [
+                                @11-15,
+                            ],
+                            space_before: [
+                                Slice(start = 0, length = 0),
+                            ],
+                            space_after: [
+                                Slice(start = 0, length = 0),
+                            ],
+                            spaces: [],
+                            type_defs: [],
+                            value_defs: [
+                                AnnotatedBody {
+                                    ann_pattern: @11-15 Identifier {
+                                        ident: "#!0_stmt",
+                                    },
+                                    ann_type: @11-15 Apply(
+                                        "",
+                                        "Task",
+                                        [
+                                            @11-15 Record {
+                                                fields: [],
+                                                ext: None,
+                                            },
+                                            @11-15 Inferred,
+                                        ],
+                                    ),
+                                    comment: None,
+                                    body_pattern: @11-15 Identifier {
+                                        ident: "#!0_stmt",
+                                    },
+                                    body_expr: @11-15 Var {
+                                        module_name: "",
+                                        ident: "foo",
+                                    },
+                                },
+                            ],
+                        },
+                        @11-15 Var {
+                            module_name: "",
+                            ident: "#!0_stmt",
+                        },
+                    ),
                     @11-15 Closure(
                         [
-                            @11-15 RecordDestructure(
-                                [],
+                            @11-15 Underscore(
+                                "#!stmt",
                             ),
                         ],
                         @21-26 Apply(

--- a/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__body_parens_apply.snap
+++ b/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__body_parens_apply.snap
@@ -35,7 +35,7 @@ Defs {
                     @16-35 Closure(
                         [
                             Identifier {
-                                ident: "#!a0",
+                                ident: "#!0_arg",
                             },
                         ],
                         @16-35 Defs(
@@ -63,7 +63,7 @@ Defs {
                                             @17-29 ParensAround(
                                                 Var {
                                                     module_name: "",
-                                                    ident: "#!a0",
+                                                    ident: "#!0_arg",
                                                 },
                                             ),
                                             [

--- a/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__closure_simple.snap
+++ b/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__closure_simple.snap
@@ -55,25 +55,69 @@ Defs {
                                         ident: "await",
                                     },
                                     [
-                                        @31-42 Apply(
+                                        @31-42 Defs(
+                                            Defs {
+                                                tags: [
+                                                    Index(2147483648),
+                                                ],
+                                                regions: [
+                                                    @31-42,
+                                                ],
+                                                space_before: [
+                                                    Slice(start = 0, length = 0),
+                                                ],
+                                                space_after: [
+                                                    Slice(start = 0, length = 0),
+                                                ],
+                                                spaces: [],
+                                                type_defs: [],
+                                                value_defs: [
+                                                    AnnotatedBody {
+                                                        ann_pattern: @31-42 Identifier {
+                                                            ident: "#!0_stmt",
+                                                        },
+                                                        ann_type: @31-42 Apply(
+                                                            "",
+                                                            "Task",
+                                                            [
+                                                                @31-42 Record {
+                                                                    fields: [],
+                                                                    ext: None,
+                                                                },
+                                                                @31-42 Inferred,
+                                                            ],
+                                                        ),
+                                                        comment: None,
+                                                        body_pattern: @31-42 Identifier {
+                                                            ident: "#!0_stmt",
+                                                        },
+                                                        body_expr: @31-42 Apply(
+                                                            @31-42 Var {
+                                                                module_name: "",
+                                                                ident: "line",
+                                                            },
+                                                            [
+                                                                @31-34 Var {
+                                                                    module_name: "",
+                                                                    ident: "msg",
+                                                                },
+                                                            ],
+                                                            BinOp(
+                                                                Pizza,
+                                                            ),
+                                                        ),
+                                                    },
+                                                ],
+                                            },
                                             @31-42 Var {
                                                 module_name: "",
-                                                ident: "line",
+                                                ident: "#!0_stmt",
                                             },
-                                            [
-                                                @31-34 Var {
-                                                    module_name: "",
-                                                    ident: "msg",
-                                                },
-                                            ],
-                                            BinOp(
-                                                Pizza,
-                                            ),
                                         ),
                                         @31-42 Closure(
                                             [
-                                                @31-42 RecordDestructure(
-                                                    [],
+                                                @31-42 Underscore(
+                                                    "#!stmt",
                                                 ),
                                             ],
                                             @52-57 Apply(

--- a/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__closure_with_annotations.snap
+++ b/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__closure_with_annotations.snap
@@ -70,38 +70,69 @@ Defs {
                                         ident: "msg",
                                     },
                                 ],
-                                @78-91 Apply(
-                                    @78-91 Var {
-                                        module_name: "Task",
-                                        ident: "await",
+                                @56-91 Defs(
+                                    Defs {
+                                        tags: [
+                                            Index(2147483648),
+                                        ],
+                                        regions: [
+                                            @78-91,
+                                        ],
+                                        space_before: [
+                                            Slice(start = 0, length = 0),
+                                        ],
+                                        space_after: [
+                                            Slice(start = 0, length = 0),
+                                        ],
+                                        spaces: [],
+                                        type_defs: [],
+                                        value_defs: [
+                                            AnnotatedBody {
+                                                ann_pattern: @56-57 Identifier {
+                                                    ident: "#!0_expr",
+                                                },
+                                                ann_type: @60-69 Apply(
+                                                    "",
+                                                    "Task",
+                                                    [
+                                                        @60-69 Apply(
+                                                            "",
+                                                            "Task",
+                                                            [
+                                                                @65-67 Record {
+                                                                    fields: [],
+                                                                    ext: None,
+                                                                },
+                                                                @68-69 Inferred,
+                                                            ],
+                                                        ),
+                                                        @60-69 Inferred,
+                                                    ],
+                                                ),
+                                                comment: None,
+                                                body_pattern: @78-79 Identifier {
+                                                    ident: "#!0_expr",
+                                                },
+                                                body_expr: @78-91 Apply(
+                                                    @78-91 Var {
+                                                        module_name: "",
+                                                        ident: "line",
+                                                    },
+                                                    [
+                                                        @88-91 Var {
+                                                            module_name: "",
+                                                            ident: "msg",
+                                                        },
+                                                    ],
+                                                    Space,
+                                                ),
+                                            },
+                                        ],
                                     },
-                                    [
-                                        @78-91 Apply(
-                                            @78-91 Var {
-                                                module_name: "",
-                                                ident: "line",
-                                            },
-                                            [
-                                                @88-91 Var {
-                                                    module_name: "",
-                                                    ident: "msg",
-                                                },
-                                            ],
-                                            Space,
-                                        ),
-                                        @78-91 Closure(
-                                            [
-                                                @78-79 Identifier {
-                                                    ident: "y",
-                                                },
-                                            ],
-                                            @100-101 Var {
-                                                module_name: "",
-                                                ident: "y",
-                                            },
-                                        ),
-                                    ],
-                                    BangSuffix,
+                                    @78-91 Var {
+                                        module_name: "",
+                                        ident: "#!0_expr",
+                                    },
                                 ),
                             ),
                         },

--- a/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__closure_with_defs.snap
+++ b/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__closure_with_defs.snap
@@ -98,23 +98,67 @@ Defs {
                                         ident: "await",
                                     },
                                     [
-                                        @76-83 Apply(
+                                        @76-83 Defs(
+                                            Defs {
+                                                tags: [
+                                                    Index(2147483648),
+                                                ],
+                                                regions: [
+                                                    @76-83,
+                                                ],
+                                                space_before: [
+                                                    Slice(start = 0, length = 0),
+                                                ],
+                                                space_after: [
+                                                    Slice(start = 0, length = 0),
+                                                ],
+                                                spaces: [],
+                                                type_defs: [],
+                                                value_defs: [
+                                                    AnnotatedBody {
+                                                        ann_pattern: @76-83 Identifier {
+                                                            ident: "#!1_stmt",
+                                                        },
+                                                        ann_type: @76-83 Apply(
+                                                            "",
+                                                            "Task",
+                                                            [
+                                                                @76-83 Record {
+                                                                    fields: [],
+                                                                    ext: None,
+                                                                },
+                                                                @76-83 Inferred,
+                                                            ],
+                                                        ),
+                                                        comment: None,
+                                                        body_pattern: @76-83 Identifier {
+                                                            ident: "#!1_stmt",
+                                                        },
+                                                        body_expr: @76-83 Apply(
+                                                            @76-83 Var {
+                                                                module_name: "",
+                                                                ident: "line",
+                                                            },
+                                                            [
+                                                                @82-83 Var {
+                                                                    module_name: "",
+                                                                    ident: "a",
+                                                                },
+                                                            ],
+                                                            Space,
+                                                        ),
+                                                    },
+                                                ],
+                                            },
                                             @76-83 Var {
                                                 module_name: "",
-                                                ident: "line",
+                                                ident: "#!1_stmt",
                                             },
-                                            [
-                                                @82-83 Var {
-                                                    module_name: "",
-                                                    ident: "a",
-                                                },
-                                            ],
-                                            Space,
                                         ),
                                         @76-83 Closure(
                                             [
-                                                @76-83 RecordDestructure(
-                                                    [],
+                                                @76-83 Underscore(
+                                                    "#!stmt",
                                                 ),
                                             ],
                                             @92-99 Apply(
@@ -123,23 +167,67 @@ Defs {
                                                     ident: "await",
                                                 },
                                                 [
-                                                    @92-99 Apply(
+                                                    @92-99 Defs(
+                                                        Defs {
+                                                            tags: [
+                                                                Index(2147483648),
+                                                            ],
+                                                            regions: [
+                                                                @92-99,
+                                                            ],
+                                                            space_before: [
+                                                                Slice(start = 0, length = 0),
+                                                            ],
+                                                            space_after: [
+                                                                Slice(start = 0, length = 0),
+                                                            ],
+                                                            spaces: [],
+                                                            type_defs: [],
+                                                            value_defs: [
+                                                                AnnotatedBody {
+                                                                    ann_pattern: @92-99 Identifier {
+                                                                        ident: "#!0_stmt",
+                                                                    },
+                                                                    ann_type: @92-99 Apply(
+                                                                        "",
+                                                                        "Task",
+                                                                        [
+                                                                            @92-99 Record {
+                                                                                fields: [],
+                                                                                ext: None,
+                                                                            },
+                                                                            @92-99 Inferred,
+                                                                        ],
+                                                                    ),
+                                                                    comment: None,
+                                                                    body_pattern: @92-99 Identifier {
+                                                                        ident: "#!0_stmt",
+                                                                    },
+                                                                    body_expr: @92-99 Apply(
+                                                                        @92-99 Var {
+                                                                            module_name: "",
+                                                                            ident: "line",
+                                                                        },
+                                                                        [
+                                                                            @98-99 Var {
+                                                                                module_name: "",
+                                                                                ident: "b",
+                                                                            },
+                                                                        ],
+                                                                        Space,
+                                                                    ),
+                                                                },
+                                                            ],
+                                                        },
                                                         @92-99 Var {
                                                             module_name: "",
-                                                            ident: "line",
+                                                            ident: "#!0_stmt",
                                                         },
-                                                        [
-                                                            @98-99 Var {
-                                                                module_name: "",
-                                                                ident: "b",
-                                                            },
-                                                        ],
-                                                        Space,
                                                     ),
                                                     @92-99 Closure(
                                                         [
-                                                            @92-99 RecordDestructure(
-                                                                [],
+                                                            @92-99 Underscore(
+                                                                "#!stmt",
                                                             ),
                                                         ],
                                                         @109-119 Apply(

--- a/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__dbg_stmt_arg.snap
+++ b/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__dbg_stmt_arg.snap
@@ -35,7 +35,7 @@ Defs {
                     @11-24 Closure(
                         [
                             @15-17 Identifier {
-                                ident: "#!a0",
+                                ident: "#!0_arg",
                             },
                         ],
                         @11-24 LowLevelDbg(
@@ -51,7 +51,7 @@ Defs {
                                 [
                                     @15-17 Var {
                                         module_name: "",
-                                        ident: "#!a0",
+                                        ident: "#!0_arg",
                                     },
                                 ],
                                 Space,

--- a/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__defs_suffixed_middle.snap
+++ b/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__defs_suffixed_middle.snap
@@ -64,23 +64,67 @@ Defs {
                         ident: "await",
                     },
                     [
-                        @25-39 Apply(
-                            @25-39 Var {
-                                module_name: "Stdout",
-                                ident: "line",
+                        @25-39 Defs(
+                            Defs {
+                                tags: [
+                                    Index(2147483648),
+                                ],
+                                regions: [
+                                    @25-39,
+                                ],
+                                space_before: [
+                                    Slice(start = 0, length = 0),
+                                ],
+                                space_after: [
+                                    Slice(start = 0, length = 0),
+                                ],
+                                spaces: [],
+                                type_defs: [],
+                                value_defs: [
+                                    AnnotatedBody {
+                                        ann_pattern: @25-39 Identifier {
+                                            ident: "#!1_stmt",
+                                        },
+                                        ann_type: @25-39 Apply(
+                                            "",
+                                            "Task",
+                                            [
+                                                @25-39 Record {
+                                                    fields: [],
+                                                    ext: None,
+                                                },
+                                                @25-39 Inferred,
+                                            ],
+                                        ),
+                                        comment: None,
+                                        body_pattern: @25-39 Identifier {
+                                            ident: "#!1_stmt",
+                                        },
+                                        body_expr: @25-39 Apply(
+                                            @25-39 Var {
+                                                module_name: "Stdout",
+                                                ident: "line",
+                                            },
+                                            [
+                                                @38-39 Var {
+                                                    module_name: "",
+                                                    ident: "a",
+                                                },
+                                            ],
+                                            Space,
+                                        ),
+                                    },
+                                ],
                             },
-                            [
-                                @38-39 Var {
-                                    module_name: "",
-                                    ident: "a",
-                                },
-                            ],
-                            Space,
+                            @11-54 Var {
+                                module_name: "",
+                                ident: "#!1_stmt",
+                            },
                         ),
                         @11-54 Closure(
                             [
-                                @25-39 RecordDestructure(
-                                    [],
+                                @25-39 Underscore(
+                                    "#!stmt",
                                 ),
                             ],
                             @45-54 Var {

--- a/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__if_complex.snap
+++ b/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__if_complex.snap
@@ -129,7 +129,7 @@ Defs {
                                     Closure(
                                         [
                                             Identifier {
-                                                ident: "#!a0",
+                                                ident: "#!1_arg",
                                             },
                                         ],
                                         @109-298 If(
@@ -144,7 +144,7 @@ Defs {
                                                             @114-121 ParensAround(
                                                                 Var {
                                                                     module_name: "",
-                                                                    ident: "#!a0",
+                                                                    ident: "#!1_arg",
                                                                 },
                                                             ),
                                                         ],
@@ -158,24 +158,68 @@ Defs {
                                                             ident: "await",
                                                         },
                                                         [
-                                                            @140-152 Apply(
+                                                            @140-152 Defs(
+                                                                Defs {
+                                                                    tags: [
+                                                                        Index(2147483648),
+                                                                    ],
+                                                                    regions: [
+                                                                        @140-152,
+                                                                    ],
+                                                                    space_before: [
+                                                                        Slice(start = 0, length = 0),
+                                                                    ],
+                                                                    space_after: [
+                                                                        Slice(start = 0, length = 0),
+                                                                    ],
+                                                                    spaces: [],
+                                                                    type_defs: [],
+                                                                    value_defs: [
+                                                                        AnnotatedBody {
+                                                                            ann_pattern: @140-152 Identifier {
+                                                                                ident: "#!0_stmt",
+                                                                            },
+                                                                            ann_type: @140-152 Apply(
+                                                                                "",
+                                                                                "Task",
+                                                                                [
+                                                                                    @140-152 Record {
+                                                                                        fields: [],
+                                                                                        ext: None,
+                                                                                    },
+                                                                                    @140-152 Inferred,
+                                                                                ],
+                                                                            ),
+                                                                            comment: None,
+                                                                            body_pattern: @140-152 Identifier {
+                                                                                ident: "#!0_stmt",
+                                                                            },
+                                                                            body_expr: @140-152 Apply(
+                                                                                @140-152 Var {
+                                                                                    module_name: "",
+                                                                                    ident: "line",
+                                                                                },
+                                                                                [
+                                                                                    @146-152 Str(
+                                                                                        PlainLine(
+                                                                                            "fail",
+                                                                                        ),
+                                                                                    ),
+                                                                                ],
+                                                                                Space,
+                                                                            ),
+                                                                        },
+                                                                    ],
+                                                                },
                                                                 @140-152 Var {
                                                                     module_name: "",
-                                                                    ident: "line",
+                                                                    ident: "#!0_stmt",
                                                                 },
-                                                                [
-                                                                    @146-152 Str(
-                                                                        PlainLine(
-                                                                            "fail",
-                                                                        ),
-                                                                    ),
-                                                                ],
-                                                                Space,
                                                             ),
                                                             @140-152 Closure(
                                                                 [
-                                                                    @140-152 RecordDestructure(
-                                                                        [],
+                                                                    @140-152 Underscore(
+                                                                        "#!stmt",
                                                                     ),
                                                                 ],
                                                                 @165-170 Apply(
@@ -218,7 +262,7 @@ Defs {
                                                     Closure(
                                                         [
                                                             Identifier {
-                                                                ident: "#!a1",
+                                                                ident: "#!3_arg",
                                                             },
                                                         ],
                                                         @109-298 If(
@@ -227,7 +271,7 @@ Defs {
                                                                     @187-209 ParensAround(
                                                                         Var {
                                                                             module_name: "",
-                                                                            ident: "#!a1",
+                                                                            ident: "#!3_arg",
                                                                         },
                                                                     ),
                                                                     @227-239 Apply(
@@ -236,24 +280,68 @@ Defs {
                                                                             ident: "await",
                                                                         },
                                                                         [
-                                                                            @227-239 Apply(
+                                                                            @227-239 Defs(
+                                                                                Defs {
+                                                                                    tags: [
+                                                                                        Index(2147483648),
+                                                                                    ],
+                                                                                    regions: [
+                                                                                        @227-239,
+                                                                                    ],
+                                                                                    space_before: [
+                                                                                        Slice(start = 0, length = 0),
+                                                                                    ],
+                                                                                    space_after: [
+                                                                                        Slice(start = 0, length = 0),
+                                                                                    ],
+                                                                                    spaces: [],
+                                                                                    type_defs: [],
+                                                                                    value_defs: [
+                                                                                        AnnotatedBody {
+                                                                                            ann_pattern: @227-239 Identifier {
+                                                                                                ident: "#!2_stmt",
+                                                                                            },
+                                                                                            ann_type: @227-239 Apply(
+                                                                                                "",
+                                                                                                "Task",
+                                                                                                [
+                                                                                                    @227-239 Record {
+                                                                                                        fields: [],
+                                                                                                        ext: None,
+                                                                                                    },
+                                                                                                    @227-239 Inferred,
+                                                                                                ],
+                                                                                            ),
+                                                                                            comment: None,
+                                                                                            body_pattern: @227-239 Identifier {
+                                                                                                ident: "#!2_stmt",
+                                                                                            },
+                                                                                            body_expr: @227-239 Apply(
+                                                                                                @227-239 Var {
+                                                                                                    module_name: "",
+                                                                                                    ident: "line",
+                                                                                                },
+                                                                                                [
+                                                                                                    @233-239 Str(
+                                                                                                        PlainLine(
+                                                                                                            "nope",
+                                                                                                        ),
+                                                                                                    ),
+                                                                                                ],
+                                                                                                Space,
+                                                                                            ),
+                                                                                        },
+                                                                                    ],
+                                                                                },
                                                                                 @227-239 Var {
                                                                                     module_name: "",
-                                                                                    ident: "line",
+                                                                                    ident: "#!2_stmt",
                                                                                 },
-                                                                                [
-                                                                                    @233-239 Str(
-                                                                                        PlainLine(
-                                                                                            "nope",
-                                                                                        ),
-                                                                                    ),
-                                                                                ],
-                                                                                Space,
                                                                             ),
                                                                             @227-239 Closure(
                                                                                 [
-                                                                                    @227-239 RecordDestructure(
-                                                                                        [],
+                                                                                    @227-239 Underscore(
+                                                                                        "#!stmt",
                                                                                     ),
                                                                                 ],
                                                                                 @252-257 Apply(

--- a/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__if_simple.snap
+++ b/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__if_simple.snap
@@ -96,7 +96,7 @@ Defs {
                         @79-87 Closure(
                             [
                                 @79-87 Identifier {
-                                    ident: "#!a0",
+                                    ident: "#!0_arg",
                                 },
                             ],
                             @76-189 If(
@@ -104,7 +104,7 @@ Defs {
                                     (
                                         @79-87 Var {
                                             module_name: "",
-                                            ident: "#!a0",
+                                            ident: "#!0_arg",
                                         },
                                         @101-112 Apply(
                                             @101-105 Var {
@@ -135,7 +135,7 @@ Defs {
                                         @125-132 Closure(
                                             [
                                                 @125-132 Identifier {
-                                                    ident: "#!a1",
+                                                    ident: "#!1_arg",
                                                 },
                                             ],
                                             @76-189 If(
@@ -143,7 +143,7 @@ Defs {
                                                     (
                                                         @125-132 Var {
                                                             module_name: "",
-                                                            ident: "#!a1",
+                                                            ident: "#!1_arg",
                                                         },
                                                         @146-160 Apply(
                                                             @146-150 Var {

--- a/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__last_stmt_not_top_level_suffixed.snap
+++ b/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__last_stmt_not_top_level_suffixed.snap
@@ -62,7 +62,7 @@ Defs {
                         @11-26 Closure(
                             [
                                 @24-25 Identifier {
-                                    ident: "#!a0",
+                                    ident: "#!0_arg",
                                 },
                             ],
                             @22-26 Apply(
@@ -73,7 +73,7 @@ Defs {
                                 [
                                     @24-25 Var {
                                         module_name: "",
-                                        ident: "#!a0",
+                                        ident: "#!0_arg",
                                     },
                                 ],
                                 Space,

--- a/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__last_suffixed_multiple.snap
+++ b/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__last_suffixed_multiple.snap
@@ -28,14 +28,58 @@ Defs {
                     ident: "await",
                 },
                 [
-                    @11-15 Var {
-                        module_name: "",
-                        ident: "foo",
-                    },
+                    @11-15 Defs(
+                        Defs {
+                            tags: [
+                                Index(2147483648),
+                            ],
+                            regions: [
+                                @11-15,
+                            ],
+                            space_before: [
+                                Slice(start = 0, length = 0),
+                            ],
+                            space_after: [
+                                Slice(start = 0, length = 0),
+                            ],
+                            spaces: [],
+                            type_defs: [],
+                            value_defs: [
+                                AnnotatedBody {
+                                    ann_pattern: @11-15 Identifier {
+                                        ident: "#!2_stmt",
+                                    },
+                                    ann_type: @11-15 Apply(
+                                        "",
+                                        "Task",
+                                        [
+                                            @11-15 Record {
+                                                fields: [],
+                                                ext: None,
+                                            },
+                                            @11-15 Inferred,
+                                        ],
+                                    ),
+                                    comment: None,
+                                    body_pattern: @11-15 Identifier {
+                                        ident: "#!2_stmt",
+                                    },
+                                    body_expr: @11-15 Var {
+                                        module_name: "",
+                                        ident: "foo",
+                                    },
+                                },
+                            ],
+                        },
+                        @11-15 Var {
+                            module_name: "",
+                            ident: "#!2_stmt",
+                        },
+                    ),
                     @11-15 Closure(
                         [
-                            @11-15 RecordDestructure(
-                                [],
+                            @11-15 Underscore(
+                                "#!stmt",
                             ),
                         ],
                         @20-24 Apply(
@@ -44,14 +88,58 @@ Defs {
                                 ident: "await",
                             },
                             [
-                                @20-24 Var {
-                                    module_name: "",
-                                    ident: "bar",
-                                },
+                                @20-24 Defs(
+                                    Defs {
+                                        tags: [
+                                            Index(2147483648),
+                                        ],
+                                        regions: [
+                                            @20-24,
+                                        ],
+                                        space_before: [
+                                            Slice(start = 0, length = 0),
+                                        ],
+                                        space_after: [
+                                            Slice(start = 0, length = 0),
+                                        ],
+                                        spaces: [],
+                                        type_defs: [],
+                                        value_defs: [
+                                            AnnotatedBody {
+                                                ann_pattern: @20-24 Identifier {
+                                                    ident: "#!1_stmt",
+                                                },
+                                                ann_type: @20-24 Apply(
+                                                    "",
+                                                    "Task",
+                                                    [
+                                                        @20-24 Record {
+                                                            fields: [],
+                                                            ext: None,
+                                                        },
+                                                        @20-24 Inferred,
+                                                    ],
+                                                ),
+                                                comment: None,
+                                                body_pattern: @20-24 Identifier {
+                                                    ident: "#!1_stmt",
+                                                },
+                                                body_expr: @20-24 Var {
+                                                    module_name: "",
+                                                    ident: "bar",
+                                                },
+                                            },
+                                        ],
+                                    },
+                                    @20-24 Var {
+                                        module_name: "",
+                                        ident: "#!1_stmt",
+                                    },
+                                ),
                                 @20-24 Closure(
                                     [
-                                        @20-24 RecordDestructure(
-                                            [],
+                                        @20-24 Underscore(
+                                            "#!stmt",
                                         ),
                                     ],
                                     @29-33 Var {

--- a/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__multi_defs_stmts.snap
+++ b/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__multi_defs_stmts.snap
@@ -28,24 +28,68 @@ Defs {
                     ident: "await",
                 },
                 [
-                    @11-23 Apply(
+                    @11-23 Defs(
+                        Defs {
+                            tags: [
+                                Index(2147483648),
+                            ],
+                            regions: [
+                                @11-23,
+                            ],
+                            space_before: [
+                                Slice(start = 0, length = 0),
+                            ],
+                            space_after: [
+                                Slice(start = 0, length = 0),
+                            ],
+                            spaces: [],
+                            type_defs: [],
+                            value_defs: [
+                                AnnotatedBody {
+                                    ann_pattern: @11-23 Identifier {
+                                        ident: "#!0_stmt",
+                                    },
+                                    ann_type: @11-23 Apply(
+                                        "",
+                                        "Task",
+                                        [
+                                            @11-23 Record {
+                                                fields: [],
+                                                ext: None,
+                                            },
+                                            @11-23 Inferred,
+                                        ],
+                                    ),
+                                    comment: None,
+                                    body_pattern: @11-23 Identifier {
+                                        ident: "#!0_stmt",
+                                    },
+                                    body_expr: @11-23 Apply(
+                                        @11-23 Var {
+                                            module_name: "",
+                                            ident: "line",
+                                        },
+                                        [
+                                            @17-23 Str(
+                                                PlainLine(
+                                                    "Ahoy",
+                                                ),
+                                            ),
+                                        ],
+                                        Space,
+                                    ),
+                                },
+                            ],
+                        },
                         @11-23 Var {
                             module_name: "",
-                            ident: "line",
+                            ident: "#!0_stmt",
                         },
-                        [
-                            @17-23 Str(
-                                PlainLine(
-                                    "Ahoy",
-                                ),
-                            ),
-                        ],
-                        Space,
                     ),
                     @11-23 Closure(
                         [
-                            @11-23 RecordDestructure(
-                                [],
+                            @11-23 Underscore(
+                                "#!stmt",
                             ),
                         ],
                         @33-55 Apply(

--- a/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__multiple_suffix.snap
+++ b/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__multiple_suffix.snap
@@ -22,46 +22,77 @@ Defs {
             @0-4 Identifier {
                 ident: "main",
             },
-            @11-24 Apply(
-                @11-24 Var {
+            @11-16 Apply(
+                @11-16 Var {
                     module_name: "Task",
                     ident: "await",
                 },
                 [
-                    @11-16 Var {
-                        module_name: "",
-                        ident: "foo",
-                    },
-                    @11-24 Closure(
-                        [
-                            @11-16 Identifier {
-                                ident: "#!a0",
-                            },
-                        ],
-                        @11-16 Apply(
-                            @11-16 Var {
-                                module_name: "Task",
-                                ident: "await",
-                            },
-                            [
-                                @11-16 Var {
-                                    module_name: "",
-                                    ident: "#!a0",
-                                },
-                                @11-16 Closure(
-                                    [
-                                        @11-16 RecordDestructure(
-                                            [],
-                                        ),
-                                    ],
-                                    @21-24 Var {
-                                        module_name: "",
-                                        ident: "bar",
-                                    },
-                                ),
+                    @11-16 Defs(
+                        Defs {
+                            tags: [
+                                Index(2147483648),
                             ],
-                            BangSuffix,
-                        ),
+                            regions: [
+                                @11-16,
+                            ],
+                            space_before: [
+                                Slice(start = 0, length = 0),
+                            ],
+                            space_after: [
+                                Slice(start = 0, length = 0),
+                            ],
+                            spaces: [],
+                            type_defs: [],
+                            value_defs: [
+                                AnnotatedBody {
+                                    ann_pattern: @11-16 Identifier {
+                                        ident: "#!1_stmt",
+                                    },
+                                    ann_type: @11-16 Apply(
+                                        "",
+                                        "Task",
+                                        [
+                                            @11-16 Apply(
+                                                "",
+                                                "Task",
+                                                [
+                                                    @11-16 Record {
+                                                        fields: [],
+                                                        ext: None,
+                                                    },
+                                                    @11-16 Inferred,
+                                                ],
+                                            ),
+                                            @11-16 Inferred,
+                                        ],
+                                    ),
+                                    comment: None,
+                                    body_pattern: @11-16 Identifier {
+                                        ident: "#!1_stmt",
+                                    },
+                                    body_expr: @11-16 Var {
+                                        module_name: "",
+                                        ident: "foo",
+                                    },
+                                },
+                            ],
+                        },
+                        @11-16 Var {
+                            module_name: "",
+                            ident: "#!1_stmt",
+                        },
+                    ),
+                    @11-16 Closure(
+                        [
+                            @11-16 Underscore(
+                                "#!stmt",
+                            ),
+                        ],
+                        @21-24 Var {
+                            module_name: "",
+                            ident: "bar",
+                        },
                     ),
                 ],
                 BangSuffix,

--- a/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__nested_complex.snap
+++ b/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__nested_complex.snap
@@ -44,7 +44,7 @@ Defs {
                     @15-43 Closure(
                         [
                             Identifier {
-                                ident: "#!a0",
+                                ident: "#!0_arg",
                             },
                         ],
                         @15-43 Apply(
@@ -62,7 +62,7 @@ Defs {
                                         @21-29 ParensAround(
                                             Var {
                                                 module_name: "",
-                                                ident: "#!a0",
+                                                ident: "#!0_arg",
                                             },
                                         ),
                                         @32-42 ParensAround(

--- a/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__nested_simple.snap
+++ b/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__nested_simple.snap
@@ -35,7 +35,7 @@ Defs {
                     @0-22 Closure(
                         [
                             Identifier {
-                                ident: "#!a0",
+                                ident: "#!0_arg",
                             },
                         ],
                         @0-22 Apply(
@@ -47,7 +47,7 @@ Defs {
                                 @13-21 ParensAround(
                                     Var {
                                         module_name: "",
-                                        ident: "#!a0",
+                                        ident: "#!0_arg",
                                     },
                                 ),
                             ],

--- a/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__simple_pizza.snap
+++ b/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__simple_pizza.snap
@@ -28,42 +28,86 @@ Defs {
                     ident: "await",
                 },
                 [
-                    @11-56 Apply(
+                    @26-56 Defs(
+                        Defs {
+                            tags: [
+                                Index(2147483648),
+                            ],
+                            regions: [
+                                @11-56,
+                            ],
+                            space_before: [
+                                Slice(start = 0, length = 0),
+                            ],
+                            space_after: [
+                                Slice(start = 0, length = 0),
+                            ],
+                            spaces: [],
+                            type_defs: [],
+                            value_defs: [
+                                AnnotatedBody {
+                                    ann_pattern: @26-56 Identifier {
+                                        ident: "#!0_stmt",
+                                    },
+                                    ann_type: @26-56 Apply(
+                                        "",
+                                        "Task",
+                                        [
+                                            @26-56 Record {
+                                                fields: [],
+                                                ext: None,
+                                            },
+                                            @26-56 Inferred,
+                                        ],
+                                    ),
+                                    comment: None,
+                                    body_pattern: @26-56 Identifier {
+                                        ident: "#!0_stmt",
+                                    },
+                                    body_expr: @11-56 Apply(
+                                        @11-56 Var {
+                                            module_name: "",
+                                            ident: "line",
+                                        },
+                                        [
+                                            @11-44 Apply(
+                                                @26-36 Var {
+                                                    module_name: "Str",
+                                                    ident: "concat",
+                                                },
+                                                [
+                                                    @11-18 Str(
+                                                        PlainLine(
+                                                            "hello",
+                                                        ),
+                                                    ),
+                                                    @37-44 Str(
+                                                        PlainLine(
+                                                            "world",
+                                                        ),
+                                                    ),
+                                                ],
+                                                BinOp(
+                                                    Pizza,
+                                                ),
+                                            ),
+                                        ],
+                                        BinOp(
+                                            Pizza,
+                                        ),
+                                    ),
+                                },
+                            ],
+                        },
                         @11-56 Var {
                             module_name: "",
-                            ident: "line",
+                            ident: "#!0_stmt",
                         },
-                        [
-                            @11-44 Apply(
-                                @26-36 Var {
-                                    module_name: "Str",
-                                    ident: "concat",
-                                },
-                                [
-                                    @11-18 Str(
-                                        PlainLine(
-                                            "hello",
-                                        ),
-                                    ),
-                                    @37-44 Str(
-                                        PlainLine(
-                                            "world",
-                                        ),
-                                    ),
-                                ],
-                                BinOp(
-                                    Pizza,
-                                ),
-                            ),
-                        ],
-                        BinOp(
-                            Pizza,
-                        ),
                     ),
                     @11-56 Closure(
                         [
-                            @26-56 RecordDestructure(
-                                [],
+                            @26-56 Underscore(
+                                "#!stmt",
                             ),
                         ],
                         @63-73 Apply(

--- a/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__trailing_binops.snap
+++ b/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__trailing_binops.snap
@@ -37,24 +37,68 @@ Defs {
                         ident: "await",
                     },
                     [
-                        @19-30 Apply(
+                        @19-30 Defs(
+                            Defs {
+                                tags: [
+                                    Index(2147483648),
+                                ],
+                                regions: [
+                                    @19-30,
+                                ],
+                                space_before: [
+                                    Slice(start = 0, length = 0),
+                                ],
+                                space_after: [
+                                    Slice(start = 0, length = 0),
+                                ],
+                                spaces: [],
+                                type_defs: [],
+                                value_defs: [
+                                    AnnotatedBody {
+                                        ann_pattern: @19-30 Identifier {
+                                            ident: "#!1_stmt",
+                                        },
+                                        ann_type: @19-30 Apply(
+                                            "",
+                                            "Task",
+                                            [
+                                                @19-30 Record {
+                                                    fields: [],
+                                                    ext: None,
+                                                },
+                                                @19-30 Inferred,
+                                            ],
+                                        ),
+                                        comment: None,
+                                        body_pattern: @19-30 Identifier {
+                                            ident: "#!1_stmt",
+                                        },
+                                        body_expr: @19-30 Apply(
+                                            @19-30 Var {
+                                                module_name: "",
+                                                ident: "line",
+                                            },
+                                            [
+                                                @25-30 Str(
+                                                    PlainLine(
+                                                        "FOO",
+                                                    ),
+                                                ),
+                                            ],
+                                            Space,
+                                        ),
+                                    },
+                                ],
+                            },
                             @19-30 Var {
                                 module_name: "",
-                                ident: "line",
+                                ident: "#!1_stmt",
                             },
-                            [
-                                @25-30 Str(
-                                    PlainLine(
-                                        "FOO",
-                                    ),
-                                ),
-                            ],
-                            Space,
                         ),
                         @19-30 Closure(
                             [
-                                @19-30 RecordDestructure(
-                                    [],
+                                @19-30 Underscore(
+                                    "#!stmt",
                                 ),
                             ],
                             @36-67 Apply(

--- a/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__type_annotation.snap
+++ b/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__type_annotation.snap
@@ -1,0 +1,112 @@
+---
+source: crates/compiler/can/tests/test_suffixed.rs
+expression: snapshot
+---
+Defs {
+    tags: [
+        Index(2147483648),
+    ],
+    regions: [
+        @0-44,
+    ],
+    space_before: [
+        Slice(start = 0, length = 0),
+    ],
+    space_after: [
+        Slice(start = 0, length = 0),
+    ],
+    spaces: [],
+    type_defs: [],
+    value_defs: [
+        Body(
+            @0-1 Identifier {
+                ident: "f",
+            },
+            @4-44 Closure(
+                [
+                    @5-6 Identifier {
+                        ident: "x",
+                    },
+                ],
+                @24-30 Apply(
+                    @24-30 Var {
+                        module_name: "Task",
+                        ident: "await",
+                    },
+                    [
+                        @14-30 Defs(
+                            Defs {
+                                tags: [
+                                    Index(2147483648),
+                                ],
+                                regions: [
+                                    @24-30,
+                                ],
+                                space_before: [
+                                    Slice(start = 0, length = 0),
+                                ],
+                                space_after: [
+                                    Slice(start = 0, length = 0),
+                                ],
+                                spaces: [],
+                                type_defs: [],
+                                value_defs: [
+                                    AnnotatedBody {
+                                        ann_pattern: @14-15 Identifier {
+                                            ident: "#!0_expr",
+                                        },
+                                        ann_type: @18-19 Apply(
+                                            "",
+                                            "Task",
+                                            [
+                                                @18-19 Apply(
+                                                    "",
+                                                    "A",
+                                                    [],
+                                                ),
+                                                @18-19 Inferred,
+                                            ],
+                                        ),
+                                        comment: None,
+                                        body_pattern: @24-25 Identifier {
+                                            ident: "#!0_expr",
+                                        },
+                                        body_expr: @24-30 Var {
+                                            module_name: "",
+                                            ident: "x",
+                                        },
+                                    },
+                                ],
+                            },
+                            @24-30 Var {
+                                module_name: "",
+                                ident: "#!0_expr",
+                            },
+                        ),
+                        @24-30 Closure(
+                            [
+                                @24-25 Identifier {
+                                    ident: "r",
+                                },
+                            ],
+                            @35-44 Apply(
+                                @35-42 Var {
+                                    module_name: "Task",
+                                    ident: "ok",
+                                },
+                                [
+                                    @43-44 Var {
+                                        module_name: "",
+                                        ident: "r",
+                                    },
+                                ],
+                                Space,
+                            ),
+                        ),
+                    ],
+                    BangSuffix,
+                ),
+            ),
+        ),
+    ],
+}

--- a/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__var_suffixes.snap
+++ b/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__var_suffixes.snap
@@ -51,7 +51,7 @@ Defs {
                                 @15-19 Closure(
                                     [
                                         @24-33 Identifier {
-                                            ident: "#!a0",
+                                            ident: "#!0_arg",
                                         },
                                     ],
                                     @24-33 Apply(
@@ -62,7 +62,7 @@ Defs {
                                         [
                                             @24-33 Var {
                                                 module_name: "",
-                                                ident: "#!a0",
+                                                ident: "#!0_arg",
                                             },
                                             @24-33 Closure(
                                                 [

--- a/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__when_branches.snap
+++ b/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__when_branches.snap
@@ -35,13 +35,13 @@ Defs {
                     @11-120 Closure(
                         [
                             @16-24 Identifier {
-                                ident: "#!a1",
+                                ident: "#!2_arg",
                             },
                         ],
                         @11-120 When(
                             @16-24 Var {
                                 module_name: "",
-                                ident: "#!a1",
+                                ident: "#!2_arg",
                             },
                             [
                                 WhenBranch {
@@ -56,24 +56,68 @@ Defs {
                                             ident: "await",
                                         },
                                         [
-                                            @54-65 Apply(
+                                            @54-65 Defs(
+                                                Defs {
+                                                    tags: [
+                                                        Index(2147483648),
+                                                    ],
+                                                    regions: [
+                                                        @54-65,
+                                                    ],
+                                                    space_before: [
+                                                        Slice(start = 0, length = 0),
+                                                    ],
+                                                    space_after: [
+                                                        Slice(start = 0, length = 0),
+                                                    ],
+                                                    spaces: [],
+                                                    type_defs: [],
+                                                    value_defs: [
+                                                        AnnotatedBody {
+                                                            ann_pattern: @54-65 Identifier {
+                                                                ident: "#!1_stmt",
+                                                            },
+                                                            ann_type: @54-65 Apply(
+                                                                "",
+                                                                "Task",
+                                                                [
+                                                                    @54-65 Record {
+                                                                        fields: [],
+                                                                        ext: None,
+                                                                    },
+                                                                    @54-65 Inferred,
+                                                                ],
+                                                            ),
+                                                            comment: None,
+                                                            body_pattern: @54-65 Identifier {
+                                                                ident: "#!1_stmt",
+                                                            },
+                                                            body_expr: @54-65 Apply(
+                                                                @54-65 Var {
+                                                                    module_name: "",
+                                                                    ident: "line",
+                                                                },
+                                                                [
+                                                                    @60-65 Str(
+                                                                        PlainLine(
+                                                                            "foo",
+                                                                        ),
+                                                                    ),
+                                                                ],
+                                                                Space,
+                                                            ),
+                                                        },
+                                                    ],
+                                                },
                                                 @54-65 Var {
                                                     module_name: "",
-                                                    ident: "line",
+                                                    ident: "#!1_stmt",
                                                 },
-                                                [
-                                                    @60-65 Str(
-                                                        PlainLine(
-                                                            "foo",
-                                                        ),
-                                                    ),
-                                                ],
-                                                Space,
                                             ),
                                             @54-65 Closure(
                                                 [
-                                                    @54-65 RecordDestructure(
-                                                        [],
+                                                    @54-65 Underscore(
+                                                        "#!stmt",
                                                     ),
                                                 ],
                                                 @78-89 Apply(

--- a/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__when_simple.snap
+++ b/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__when_simple.snap
@@ -35,13 +35,13 @@ Defs {
                     @11-74 Closure(
                         [
                             @16-24 Identifier {
-                                ident: "#!a0",
+                                ident: "#!0_arg",
                             },
                         ],
                         @11-74 When(
                             @16-24 Var {
                                 module_name: "",
-                                ident: "#!a0",
+                                ident: "#!0_arg",
                             },
                             [
                                 WhenBranch {

--- a/crates/compiler/can/tests/test_suffixed.rs
+++ b/crates/compiler/can/tests/test_suffixed.rs
@@ -546,6 +546,18 @@ mod suffixed_tests {
             "##
         );
     }
+
+    #[test]
+    fn type_annotation() {
+        run_test!(
+            r##"
+            f = \x ->
+                r : A
+                r = x!
+                Task.ok r
+            "##
+        );
+    }
 }
 
 #[cfg(test)]

--- a/crates/compiler/can/tests/test_suffixed.rs
+++ b/crates/compiler/can/tests/test_suffixed.rs
@@ -564,8 +564,6 @@ mod suffixed_tests {
 mod test_suffixed_helpers {
 
     use roc_can::suffixed::is_matching_intermediate_answer;
-    use roc_module::called_via::CalledVia;
-    use roc_module::ident::ModuleName;
     use roc_parse::ast::Expr;
     use roc_parse::ast::Pattern;
     use roc_region::all::Loc;
@@ -577,23 +575,6 @@ mod test_suffixed_helpers {
             module_name: "",
             ident: "#!a0",
         });
-
-        std::assert!(is_matching_intermediate_answer(&loc_pat, &loc_new));
-    }
-
-    #[test]
-    fn test_matching_answer_task_ok() {
-        let loc_pat = Loc::at_zero(Pattern::Identifier { ident: "#!a0" });
-        let intermetiate = &[&Loc::at_zero(Expr::Var {
-            module_name: "",
-            ident: "#!a0",
-        })];
-        let task_ok = Loc::at_zero(Expr::Var {
-            module_name: ModuleName::TASK,
-            ident: "ok",
-        });
-
-        let loc_new = Loc::at_zero(Expr::Apply(&task_ok, intermetiate, CalledVia::BangSuffix));
 
         std::assert!(is_matching_intermediate_answer(&loc_pat, &loc_new));
     }

--- a/crates/compiler/can/tests/test_suffixed.rs
+++ b/crates/compiler/can/tests/test_suffixed.rs
@@ -128,7 +128,7 @@ mod suffixed_tests {
      * Example with a parens suffixed sub-expression
      * in the function part of an Apply.
      *
-     * Note how the parens unwraps into an intermediate answer #!a0 instead of
+     * Note how the parens unwraps into an intermediate answer #!0_arg instead of
      * unwrapping the def `do`.
      *
      */
@@ -162,7 +162,7 @@ mod suffixed_tests {
     /**
      * Example with a multiple suffixed Var
      *
-     * Note it unwraps into an intermediate answer `#!a0`
+     * Note it unwraps into an intermediate answer `#!0_arg`
      *
      */
     #[test]
@@ -570,10 +570,10 @@ mod test_suffixed_helpers {
 
     #[test]
     fn test_matching_answer() {
-        let loc_pat = Loc::at_zero(Pattern::Identifier { ident: "#!a0" });
+        let loc_pat = Loc::at_zero(Pattern::Identifier { ident: "#!0_arg" });
         let loc_new = Loc::at_zero(Expr::Var {
             module_name: "",
-            ident: "#!a0",
+            ident: "#!0_arg",
         });
 
         std::assert!(is_matching_intermediate_answer(&loc_pat, &loc_new));

--- a/crates/compiler/load/tests/test_reporting.rs
+++ b/crates/compiler/load/tests/test_reporting.rs
@@ -14503,4 +14503,38 @@ In roc, functions are always written as a lambda, like{}
     make partial application explicit.
     "
     );
+
+    // TODO: add the following tests after built-in Tasks are added
+    // https://github.com/roc-lang/roc/pull/6836
+
+    // test_report!(
+    // suffixed_stmt_invalid_type,
+    //     indoc!(
+    //         r###"
+    //         app "test" provides [main] to "./platform"
+
+    //         main : Task U64 _ -> _
+    //         main = \task ->
+    //             task!
+    //             42
+    //         "###
+    //     ),
+    //     @r""
+    // );
+
+    // test_report!(
+    // suffixed_expr_invalid_type,
+    //     indoc!(
+    //         r###"
+    //         app "test" provides [main] to "./platform"
+
+    //         main : Task U64 _ -> _
+    //         main = \task ->
+    //             result : U32
+    //             result = task!
+    //             result
+    //         "###
+    //     ),
+    //     @r""
+    // );
 }


### PR DESCRIPTION
From [Zulip thread](https://roc.zulipchat.com/#narrow/stream/316715-contributing/topic/TaskAwaitBang.20statement.20desugaring/near/449124639)

In this implementation, type annotations are propagated this way:

Annotated assignments: 
```roc
f = \x ->
    r : A
    r = x!
    Task.ok r

f = \x ->
    Task.await
        (
            # Type annotation goes here as the first Task arg
            a0 : Task A _
            a0 = x 
            a0
        )
        \r -> Task.ok r
```

Statements:
```roc
f = \x ->
    x!
    Task.ok {}

f = \x ->
    # Stmt desugared to AnnotatedBody with unit type
    _ : {}
    _ = x!
    Task.ok {}

f = \x ->
    Task.await
        (
            # Type annotation goes here as the first Task arg
            a0 : Task {} _
            a0 = x
            a0
        )
        \_ -> Task.ok {}
```