### PR TITLE
Do not exit the repl when Ctrl-C is pressed, fixes #6870

### DIFF
--- a/crates/repl_cli/src/lib.rs
+++ b/crates/repl_cli/src/lib.rs
@@ -92,8 +92,8 @@ pub fn main() -> i32 {
                 return 0;
             }
             Err(ReadlineError::Interrupted) => {
+                // Ctrl-C was pressed
                 eprintln!("CTRL-C");
-                return 1;
             }
             Err(err) => {
                 eprintln!("REPL error: {err:?}");


### PR DESCRIPTION
Ctrl-C currently exists the REPL. In virtually every other REPL, Ctrl-C just cancels the current command, it doesn't exit. This means that users will accidently close their ROC REPL and lose their current work. It's also convenient to be able to cancel the current command very simply (without having to type Ctrl-A + Ctrl-K).

See the discussion in #6870.
