### PR TITLE
Make sure FunctionKind is determined in all entry points

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -516,8 +516,7 @@ pub fn test(matches: &ArgMatches, target: Target) -> io::Result<i32> {
     }
 
     let arena = &arena;
-    // TODO may need to determine this dynamically based on dev builds.
-    let function_kind = FunctionKind::LambdaSet;
+    let function_kind = FunctionKind::from_env();
 
     let opt_main_path = matches.get_one::<PathBuf>(FLAG_MAIN);
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -126,7 +126,7 @@ fn main() -> io::Result<()> {
                 .get_one::<String>(FLAG_TARGET)
                 .and_then(|s| Target::from_str(s).ok())
                 .unwrap_or_default();
-            let function_kind = FunctionKind::LambdaSet;
+            let function_kind = FunctionKind::from_env();
             roc_linker::generate_stub_lib(
                 input_path,
                 RocCacheDir::Persistent(cache::roc_cache_dir().as_path()),

--- a/crates/compiler/build/src/program.rs
+++ b/crates/compiler/build/src/program.rs
@@ -695,20 +695,9 @@ pub fn standard_load_config(
         BuildOrdering::AlwaysBuild => ExecutionMode::Executable,
     };
 
-    // UNSTABLE(lambda-erasure)
-    let function_kind = if cfg!(debug_assertions) {
-        if std::env::var("EXPERIMENTAL_ROC_ERASE").is_ok() {
-            FunctionKind::Erased
-        } else {
-            FunctionKind::LambdaSet
-        }
-    } else {
-        FunctionKind::LambdaSet
-    };
-
     LoadConfig {
         target,
-        function_kind,
+        function_kind: FunctionKind::from_env(),
         render: RenderTarget::ColorTerminal,
         palette: DEFAULT_PALETTE,
         threading,
@@ -1202,8 +1191,7 @@ pub fn check_file<'a>(
 
     let load_config = LoadConfig {
         target,
-        // TODO: we may not want this for just checking.
-        function_kind: FunctionKind::LambdaSet,
+        function_kind: FunctionKind::from_env(),
         // TODO: expose this from CLI?
         render: RenderTarget::ColorTerminal,
         palette: DEFAULT_PALETTE,

--- a/crates/compiler/solve/src/kinds.rs
+++ b/crates/compiler/solve/src/kinds.rs
@@ -6,3 +6,17 @@ pub enum FunctionKind {
     /// Function values are erased, no kind is introduced.
     Erased,
 }
+
+impl FunctionKind {
+    pub fn from_env() -> Self {
+        if cfg!(debug_assertions) {
+            if std::env::var("EXPERIMENTAL_ROC_ERASE").is_ok() {
+                FunctionKind::Erased
+            } else {
+                FunctionKind::LambdaSet
+            }
+        } else {
+            FunctionKind::LambdaSet
+        }
+    }
+}

--- a/crates/error_macros/src/lib.rs
+++ b/crates/error_macros/src/lib.rs
@@ -109,13 +109,16 @@ pub const INTERNAL_ERROR_MESSAGE: &str = concat!(
 #[macro_export]
 macro_rules! internal_error {
     () => ({
-        $crate::error_and_exit(format_args!("{}", $crate::INTERNAL_ERROR_MESSAGE))
+        $crate::error_and_exit(format_args!("{}\nLocation: {}:{}:{}", $crate::INTERNAL_ERROR_MESSAGE, file!(), line!(), column!()))
     });
     ($($arg:tt)*) => ({
         $crate::error_and_exit(format_args!(
-            "{}{}",
+            "{}{}\nLocation: {}:{}:{}",
             $crate::INTERNAL_ERROR_MESSAGE,
-            format_args!($($arg)*)
+            format_args!($($arg)*),
+            file!(),
+            line!(),
+            column!(),
         ))
     })
 }
@@ -132,13 +135,16 @@ pub const USER_ERROR_MESSAGE: &str = concat!(
 #[macro_export]
 macro_rules! user_error {
     () => ({
-        $crate::error_and_exit(format_args!("{}", $crate::USER_ERROR_MESSAGE))
+        $crate::error_and_exit(format_args!("{}\nLocation: {}:{}:{}", $crate::USER_ERROR_MESSAGE, file!(), line!(), column!()))
     });
     ($($arg:tt)*) => ({
         $crate::error_and_exit(format_args!(
-            "{}{}",
+            "{}{}\nLocation: {}:{}:{}",
             $crate::USER_ERROR_MESSAGE,
-            format_args!($($arg)*)
+            format_args!($($arg)*),
+            file!(),
+            line!(),
+            column!(),
         ))
     })
 }

--- a/crates/glue/src/load.rs
+++ b/crates/glue/src/load.rs
@@ -399,8 +399,7 @@ pub fn load_types(
     ignore_errors: IgnoreErrors,
     target: Target,
 ) -> Result<Vec<Types>, io::Error> {
-    // TODO the function kind may need to be parameterizable.
-    let function_kind = FunctionKind::LambdaSet;
+    let function_kind = FunctionKind::from_env();
     let arena = &Bump::new();
     let LoadedModule {
         module_id: home,


### PR DESCRIPTION
There are a lot of entry points for a Roc program. They should probably
be all consolidated into one, but for now, when FunctionKind is needed,
determine it from the environment. This fixes EXPERIMENTAL_ROC_ERASE for
`roc test` etc.

Also print the location of a failure when `internal_error!` is called. I
think this should panic instead, and I thought it used to - does anyone
know if that changed?
