### PR TITLE
fix wasm repl warnings

### DIFF
--- a/crates/compiler/load_internal/src/file.rs
+++ b/crates/compiler/load_internal/src/file.rs
@@ -2986,8 +2986,10 @@ fn update<'a>(
 fn register_package_shorthands<'a>(
     shorthands: &mut MutMap<&'a str, ShorthandPath>,
     package_entries: &MutMap<&'a str, header::PackageName<'a>>,
+    #[allow(unused_variables)] // for wasm
     module_path: &Path,
     src_dir: &Path,
+    #[allow(unused_variables)] // for wasm
     cache_dir: &Path,
 ) -> Result<(), LoadingProblem<'a>> {
     for (shorthand, package_name) in package_entries.iter() {
@@ -3650,6 +3652,8 @@ fn load_module<'a>(
 #[derive(Debug)]
 enum ShorthandPath {
     /// e.g. "/home/rtfeldman/.cache/roc/0.1.0/oUkxSOI9zFGtSoIaMB40QPdrXphr1p1780eiui2iO9Mz"
+    #[allow(dead_code)]
+    // wasm warns FromHttpsUrl is unused, but errors if it is removed ¯\_(ツ)_/¯
     FromHttpsUrl {
         /// e.g. "/home/rtfeldman/.cache/roc/0.1.0/oUkxSOI9zFGtSoIaMB40QPdrXphr1p1780eiui2iO9Mz"
         root_module_dir: PathBuf,
@@ -4060,6 +4064,7 @@ fn load_packages<'a>(
     app_module_id: Option<ModuleId>,
     module_ids: Arc<Mutex<PackageModuleIds<'a>>>,
     ident_ids_by_module: SharedIdentIdsByModule,
+    #[allow(unused_variables)] // for wasm
     filename: PathBuf,
 ) {
     // Load all the packages

--- a/crates/compiler/parse/src/src64.rs
+++ b/crates/compiler/parse/src/src64.rs
@@ -228,6 +228,7 @@ impl<'a> Src64<'a> {
                 // chunk(s) won't be a cache miss anymore because they'll already be in cache.
                 //
                 // We can do further prefetches in the actual tokenization loop.
+                #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
                 {
                     // We know capacity >= 64, so this will never wrap.
                     let last_chunk_offset = capacity - 64;
@@ -366,6 +367,7 @@ unsafe fn write_newlines(dest: *mut u8, len: usize) {
     }
 }
 
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 #[inline(always)]
 fn prefetch_read<T>(non_null_ptr: NonNull<T>, offset: usize) {
     // Use inline asm until this is stabilized:
@@ -386,8 +388,6 @@ fn prefetch_read<T>(non_null_ptr: NonNull<T>, offset: usize) {
             in(reg) non_null_ptr.as_ptr().add(offset)
         );
     }
-
-    // If we're not on x64 or aarch64, just do nothing!
 }
 
 #[cfg(test)]


### PR DESCRIPTION
`./crates/repl_wasm/build-www.sh` used to generate some rust warnings, now they're gone :)