### PR TITLE
remove measleading fmt code from snapshots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2347,7 +2347,6 @@ dependencies = [
  "roc_collections",
  "roc_error_macros",
  "roc_exhaustive",
- "roc_fmt",
  "roc_module",
  "roc_parse",
  "roc_problem",

--- a/crates/compiler/can/Cargo.toml
+++ b/crates/compiler/can/Cargo.toml
@@ -25,7 +25,6 @@ bumpalo.workspace = true
 static_assertions.workspace = true
 
 [dev-dependencies]
-roc_fmt = { path = "../fmt" }
 indoc.workspace = true
 insta.workspace = true
 pretty_assertions.workspace = true

--- a/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__apply_argument_multiple.snap
+++ b/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__apply_argument_multiple.snap
@@ -2,9 +2,6 @@
 source: crates/compiler/can/tests/test_suffixed.rs
 expression: snapshot
 ---
-main = Task.await a \#!a0 -> Task.await x \#!a1 -> c = b #!a0 #!a1
-        c
----
 Defs {
     tags: [
         Index(2147483648),

--- a/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__apply_argument_single.snap
+++ b/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__apply_argument_single.snap
@@ -2,9 +2,6 @@
 source: crates/compiler/can/tests/test_suffixed.rs
 expression: snapshot
 ---
-main = Task.await a \#!a0 -> c = b #!a0
-    c
----
 Defs {
     tags: [
         Index(2147483648),

--- a/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__apply_argument_suffixed.snap
+++ b/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__apply_argument_suffixed.snap
@@ -2,9 +2,6 @@
 source: crates/compiler/can/tests/test_suffixed.rs
 expression: snapshot
 ---
-main = Task.await (foo "hello") \#!a0 -> x = bar (#!a0)
-    baz x
----
 Defs {
     tags: [
         Index(2147483648),

--- a/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__apply_function_suffixed.snap
+++ b/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__apply_function_suffixed.snap
@@ -2,9 +2,6 @@
 source: crates/compiler/can/tests/test_suffixed.rs
 expression: snapshot
 ---
-main = Task.await (foo "bar") \#!a0 -> x = (#!a0) "hello"
-    baz x
----
 Defs {
     tags: [
         Index(2147483648),

--- a/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__bang_in_pipe_root.snap
+++ b/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__bang_in_pipe_root.snap
@@ -2,9 +2,6 @@
 source: crates/compiler/can/tests/test_suffixed.rs
 expression: snapshot
 ---
-main = Task.await a \#!a0 -> c = b #!a0
-    c
----
 Defs {
     tags: [
         Index(2147483648),

--- a/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__basic.snap
+++ b/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__basic.snap
@@ -2,8 +2,6 @@
 source: crates/compiler/can/tests/test_suffixed.rs
 expression: snapshot
 ---
-main = Task.await foo \{} -> ok {}
----
 Defs {
     tags: [
         Index(2147483648),

--- a/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__body_parens_apply.snap
+++ b/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__body_parens_apply.snap
@@ -2,9 +2,6 @@
 source: crates/compiler/can/tests/test_suffixed.rs
 expression: snapshot
 ---
-main = Task.await sayMultiple \#!a0 -> do = (#!a0) "hi"
-    do
----
 Defs {
     tags: [
         Index(2147483648),

--- a/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__closure_simple.snap
+++ b/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__closure_simple.snap
@@ -2,10 +2,6 @@
 source: crates/compiler/can/tests/test_suffixed.rs
 expression: snapshot
 ---
-main =
-    x = \msg -> Task.await (line msg) \{} -> ok {}
-    x "hi"
----
 Defs {
     tags: [
         Index(2147483648),

--- a/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__closure_with_annotations.snap
+++ b/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__closure_with_annotations.snap
@@ -2,11 +2,6 @@
 source: crates/compiler/can/tests/test_suffixed.rs
 expression: snapshot
 ---
-main =
-    x : Str -> Task _ _
-    x = \msg -> Task.await (line msg) \y -> y
-    x "foo"
----
 Defs {
     tags: [
         Index(2147483648),

--- a/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__closure_with_defs.snap
+++ b/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__closure_with_defs.snap
@@ -2,11 +2,6 @@
 source: crates/compiler/can/tests/test_suffixed.rs
 expression: snapshot
 ---
-main =
-    foo : Str, {}, Str -> Task {} I32
-    foo = \a, _, b -> Task.await (line a) \{} -> Task.await (line b) \{} -> Task.ok {}
-    foo "bar" {} "baz"
----
 Defs {
     tags: [
         Index(2147483648),

--- a/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__deep_when.snap
+++ b/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__deep_when.snap
@@ -2,12 +2,6 @@
 source: crates/compiler/can/tests/test_suffixed.rs
 expression: snapshot
 ---
-main =
-    when a is
-        0 ->
-            when b is
-                1 -> c
----
 Defs {
     tags: [
         Index(2147483648),

--- a/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__defs_suffixed_middle.snap
+++ b/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__defs_suffixed_middle.snap
@@ -2,14 +2,6 @@
 source: crates/compiler/can/tests/test_suffixed.rs
 expression: snapshot
 ---
-main =
-    a = "Foo"
-    Task.await (Stdout.line a) \{} -> printBar
-
-printBar =
-    b = "Bar"
-    Stdout.line b
----
 Defs {
     tags: [
         Index(2147483648),

--- a/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__deps_final_expr.snap
+++ b/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__deps_final_expr.snap
@@ -2,14 +2,6 @@
 source: crates/compiler/can/tests/test_suffixed.rs
 expression: snapshot
 ---
-main =
-    when x is
-        A ->
-            y = 42
-            if a then b else c
-
-        B -> d
----
 Defs {
     tags: [
         Index(2147483648),

--- a/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__expect_then_bang.snap
+++ b/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__expect_then_bang.snap
@@ -2,11 +2,6 @@
 source: crates/compiler/can/tests/test_suffixed.rs
 expression: snapshot
 ---
-main =
-expect Bool.isEq 1 2
-
-x
----
 Defs {
     tags: [
         Index(2147483648),

--- a/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__if_complex.snap
+++ b/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__if_complex.snap
@@ -2,13 +2,6 @@
 source: crates/compiler/can/tests/test_suffixed.rs
 expression: snapshot
 ---
-main =
-    isTrue = Task.ok Bool.true
-    isFalsey = \x -> Task.ok x
-    msg : Task {} I32
-    msg = Task.await isTrue \#!a0 -> if Bool.not (#!a0) then Task.await (line "fail") \{} -> err 1 else Task.await (isFalsey Bool.false) \#!a1 -> if #!a1 then Task.await (line "nope") \{} -> ok {} else line "success"
-    msg
----
 Defs {
     tags: [
         Index(2147483648),

--- a/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__if_simple.snap
+++ b/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__if_simple.snap
@@ -2,11 +2,6 @@
 source: crates/compiler/can/tests/test_suffixed.rs
 expression: snapshot
 ---
-main =
-    isTrue = Task.ok Bool.true
-    isFalse = Task.ok Bool.false
-    Task.await isFalse \#!a0 -> if #!a0 then line "fail" else Task.await isTrue \#!a1 -> if #!a1 then line "success" else line "fail"
----
 Defs {
     tags: [
         Index(2147483648),

--- a/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__last_stmt_not_top_level_suffixed.snap
+++ b/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__last_stmt_not_top_level_suffixed.snap
@@ -2,10 +2,6 @@
 source: crates/compiler/can/tests/test_suffixed.rs
 expression: snapshot
 ---
-main =
-    x = 42
-    Task.await b \#!a0 -> a #!a0
----
 Defs {
     tags: [
         Index(2147483648),

--- a/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__last_suffixed_multiple.snap
+++ b/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__last_suffixed_multiple.snap
@@ -2,8 +2,6 @@
 source: crates/compiler/can/tests/test_suffixed.rs
 expression: snapshot
 ---
-main = Task.await foo \{} -> Task.await bar \{} -> baz
----
 Defs {
     tags: [
         Index(2147483648),

--- a/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__last_suffixed_single.snap
+++ b/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__last_suffixed_single.snap
@@ -2,8 +2,6 @@
 source: crates/compiler/can/tests/test_suffixed.rs
 expression: snapshot
 ---
-main = foo "bar" {} "baz"
----
 Defs {
     tags: [
         Index(2147483648),

--- a/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__multi_defs_stmts.snap
+++ b/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__multi_defs_stmts.snap
@@ -2,8 +2,6 @@
 source: crates/compiler/can/tests/test_suffixed.rs
 expression: snapshot
 ---
-main = Task.await (line "Ahoy") \{} -> Task.await (Stdout.line "There") \{} -> Task.ok {}
----
 Defs {
     tags: [
         Index(2147483648),

--- a/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__multiple_def_first_suffixed.snap
+++ b/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__multiple_def_first_suffixed.snap
@@ -2,10 +2,6 @@
 source: crates/compiler/can/tests/test_suffixed.rs
 expression: snapshot
 ---
-main =
-    msg = "hello"
-    Task.await (foo msg) \x -> bar x
----
 Defs {
     tags: [
         Index(2147483648),

--- a/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__multiple_suffix.snap
+++ b/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__multiple_suffix.snap
@@ -2,8 +2,6 @@
 source: crates/compiler/can/tests/test_suffixed.rs
 expression: snapshot
 ---
-main = Task.await foo \#!a0 -> Task.await #!a0 \{} -> bar
----
 Defs {
     tags: [
         Index(2147483648),

--- a/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__nested_complex.snap
+++ b/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__nested_complex.snap
@@ -2,8 +2,6 @@
 source: crates/compiler/can/tests/test_suffixed.rs
 expression: snapshot
 ---
-main = Task.await (bar baz) \#!a0 -> Task.await (foo (#!a0) (blah stuff)) \z -> doSomething z
----
 Defs {
     tags: [
         Index(2147483648),

--- a/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__nested_defs.snap
+++ b/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__nested_defs.snap
@@ -2,10 +2,6 @@
 source: crates/compiler/can/tests/test_suffixed.rs
 expression: snapshot
 ---
-main =
-    x = Task.await b \a -> c a
-    x
----
 Defs {
     tags: [
         Index(2147483648),

--- a/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__nested_simple.snap
+++ b/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__nested_simple.snap
@@ -2,8 +2,6 @@
 source: crates/compiler/can/tests/test_suffixed.rs
 expression: snapshot
 ---
-run = Task.await nextMsg \#!a0 -> line (#!a0)
----
 Defs {
     tags: [
         Index(2147483648),

--- a/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__simple_pizza.snap
+++ b/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__simple_pizza.snap
@@ -2,8 +2,6 @@
 source: crates/compiler/can/tests/test_suffixed.rs
 expression: snapshot
 ---
-main = Task.await (line (Str.concat "hello" "world")) \{} -> Task.ok {}
----
 Defs {
     tags: [
         Index(2147483648),

--- a/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__trailing_binops.snap
+++ b/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__trailing_binops.snap
@@ -2,8 +2,6 @@
 source: crates/compiler/can/tests/test_suffixed.rs
 expression: snapshot
 ---
-copy = \a, b -> Task.await (line "FOO") \{} -> mapErr (CMD.new "cp") ERR
----
 Defs {
     tags: [
         Index(2147483648),

--- a/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__trailing_suffix_inside_when.snap
+++ b/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__trailing_suffix_inside_when.snap
@@ -2,11 +2,6 @@
 source: crates/compiler/can/tests/test_suffixed.rs
 expression: snapshot
 ---
-main = Task.await Stdin.line \result ->
-    when result is
-        End -> Task.ok {}
-        Input name -> Stdout.line "Hello, $(name)"
----
 Defs {
     tags: [
         Index(2147483648),

--- a/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__var_suffixes.snap
+++ b/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__var_suffixes.snap
@@ -2,8 +2,6 @@
 source: crates/compiler/can/tests/test_suffixed.rs
 expression: snapshot
 ---
-main = Task.await foo \a -> Task.await bar \#!a0 -> Task.await #!a0 \b -> baz a b
----
 Defs {
     tags: [
         Index(2147483648),

--- a/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__when_branches.snap
+++ b/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__when_branches.snap
@@ -2,11 +2,6 @@
 source: crates/compiler/can/tests/test_suffixed.rs
 expression: snapshot
 ---
-list = Task.await getList \#!a1 ->
-    when #!a1 is
-        [] -> Task.await (line "foo") \{} -> line "bar"
-        _ -> ok {}
----
 Defs {
     tags: [
         Index(2147483648),

--- a/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__when_simple.snap
+++ b/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__when_simple.snap
@@ -2,11 +2,6 @@
 source: crates/compiler/can/tests/test_suffixed.rs
 expression: snapshot
 ---
-list = Task.await getList \#!a0 ->
-    when #!a0 is
-        [] -> "empty"
-        _ -> "non-empty"
----
 Defs {
     tags: [
         Index(2147483648),

--- a/crates/compiler/can/tests/test_suffixed.rs
+++ b/crates/compiler/can/tests/test_suffixed.rs
@@ -14,24 +14,6 @@ mod suffixed_tests {
             let mut defs = parse_defs_with(arena, indoc!($src)).unwrap();
             desugar_defs_node_values(arena, &mut defs, $src, &mut None, "test.roc", true);
 
-            let mut fmt_buf = roc_fmt::Buf::new_in(arena);
-            roc_fmt::def::fmt_defs(&mut fmt_buf, &defs, 0);
-            fmt_buf.fmt_end_of_file();
-            let fmt_str = fmt_buf.as_str().trim();
-
-            // Collect fmt desugared output for easier review process
-            let snapshot = format!("{}\n---\n{:#?}", fmt_str, &defs);
-            println!("{}", snapshot);
-            assert_snapshot!(snapshot);
-        }};
-    }
-
-    macro_rules! run_test_skip_fmt {
-        ($src:expr) => {{
-            let arena = &Bump::new();
-            let mut defs = parse_defs_with(arena, indoc!($src)).unwrap();
-            desugar_defs_node_values(arena, &mut defs, $src, &mut None, "test.roc", true);
-
             let snapshot = format!("{:#?}", &defs);
             println!("{}", snapshot);
             assert_snapshot!(snapshot);
@@ -441,7 +423,7 @@ mod suffixed_tests {
 
     #[test]
     fn dbg_simple() {
-        run_test_skip_fmt!(
+        run_test!(
             r#"
             main =
                 foo = getFoo!
@@ -530,7 +512,7 @@ mod suffixed_tests {
 
     #[test]
     fn dbg_stmt_arg() {
-        run_test_skip_fmt!(
+        run_test!(
             r#"
             main =
                 dbg a!


### PR DESCRIPTION
Removes misleading incorrectly formatted code from tests

Follow-up to https://github.com/roc-lang/roc/pull/6900

Can be reverted after https://github.com/roc-lang/roc/issues/6903 is resolved