### PR TITLE
Generate copy functions in roc and pass them into zig

### DIFF
--- a/crates/compiler/builtins/bitcode/src/list.zig
+++ b/crates/compiler/builtins/bitcode/src/list.zig
@@ -1032,10 +1032,10 @@ pub fn listConcatUtf8(
 
 fn copy_element_fn(element_width: usize) CopyFn {
     const max_inline = @sizeOf(u256);
-    return switch (element_width) {
-        inline 0...max_inline => |i| memcpy_sized(i),
-        else => &memcpy_opaque,
-    };
+    switch (element_width) {
+        inline 0...max_inline => |i| return memcpy_sized(i),
+        else => return &memcpy_opaque,
+    }
 }
 
 fn memcpy_opaque(dst: Opaque, src: Opaque, element_width: usize) void {

--- a/crates/compiler/gen_llvm/src/llvm/lowlevel.rs
+++ b/crates/compiler/gen_llvm/src/llvm/lowlevel.rs
@@ -670,7 +670,14 @@ pub(crate) fn run_low_level<'a, 'ctx>(
             let original_wrapper = scope.load_symbol(&args[0]).into_struct_value();
             let (elem, elem_layout) = scope.load_symbol_and_layout(&args[1]);
 
-            list_append_unsafe(env, layout_interner, original_wrapper, elem, elem_layout)
+            list_append_unsafe(
+                env,
+                layout_interner,
+                layout_ids,
+                original_wrapper,
+                elem,
+                elem_layout,
+            )
         }
         ListPrepend => {
             // List.prepend : List elem, elem -> List elem

--- a/crates/compiler/module/src/symbol.rs
+++ b/crates/compiler/module/src/symbol.rs
@@ -1175,41 +1175,42 @@ define_builtins! {
 
         16 GENERIC_EQ_REF: "#generic_eq_by_ref" // equality of arbitrary layouts, passed as an opaque pointer
         17 GENERIC_RC_REF: "#generic_rc_by_ref" // refcount of arbitrary layouts, passed as an opaque pointer
+        18 GENERIC_COPY_REF: "#generic_copy_by_ref" // copy of arbitrary layouts, passed as an opaque pointer
 
-        18 GENERIC_EQ: "#generic_eq" // internal function that checks generic equality
+        19 GENERIC_EQ: "#generic_eq" // internal function that checks generic equality
 
         // a user-defined function that we need to capture in a closure
         // see e.g. Set.walk
-        19 USER_FUNCTION: "#user_function"
+        20 USER_FUNCTION: "#user_function"
 
         // A caller (wrapper) that we pass to zig for it to be able to call Roc functions
-        20 ZIG_FUNCTION_CALLER: "#zig_function_caller"
+        21 ZIG_FUNCTION_CALLER: "#zig_function_caller"
 
         // a caller (wrapper) for comparison
-        21 GENERIC_COMPARE_REF: "#generic_compare_ref"
+        22 GENERIC_COMPARE_REF: "#generic_compare_ref"
 
         // used to initialize parameters in borrow.rs
-        22 EMPTY_PARAM: "#empty_param"
+        23 EMPTY_PARAM: "#empty_param"
 
         // used by the dev backend to store the pointer to where to store large return types
-        23 RET_POINTER: "#ret_pointer"
+        24 RET_POINTER: "#ret_pointer"
 
         // used in wasm dev backend to mark temporary values in the VM stack
-        24 WASM_TMP: "#wasm_tmp"
+        25 WASM_TMP: "#wasm_tmp"
 
         // the _ used in mono when a specialized symbol is deleted
-        25 REMOVED_SPECIALIZATION: "#removed_specialization"
+        26 REMOVED_SPECIALIZATION: "#removed_specialization"
 
         // used in dev backend
-        26 DEV_TMP: "#dev_tmp"
-        27 DEV_TMP2: "#dev_tmp2"
-        28 DEV_TMP3: "#dev_tmp3"
-        29 DEV_TMP4: "#dev_tmp4"
-        30 DEV_TMP5: "#dev_tmp5"
+        27 DEV_TMP: "#dev_tmp"
+        28 DEV_TMP2: "#dev_tmp2"
+        29 DEV_TMP3: "#dev_tmp3"
+        30 DEV_TMP4: "#dev_tmp4"
+        31 DEV_TMP5: "#dev_tmp5"
 
-        31 ATTR_INVALID: "#attr_invalid"
+        32 ATTR_INVALID: "#attr_invalid"
 
-        32 CLONE: "#clone" // internal function that clones a value into a buffer
+        33 CLONE: "#clone" // internal function that clones a value into a buffer
     }
     // Fake module for synthesizing and storing derived implementations
     1 DERIVED_SYNTH: "#Derived" => {

--- a/crates/compiler/mono/src/code_gen_help/copy.rs
+++ b/crates/compiler/mono/src/code_gen_help/copy.rs
@@ -1,0 +1,38 @@
+use roc_module::symbol::{IdentIds, Symbol};
+
+use crate::ir::{Expr, Stmt};
+use crate::layout::{InLayout, Layout, STLayoutInterner};
+
+use super::{CodeGenHelp, Context};
+
+const ARG_1: Symbol = Symbol::ARG_1;
+const ARG_2: Symbol = Symbol::ARG_2;
+
+pub fn copy_indirect<'a>(
+    root: &mut CodeGenHelp<'a>,
+    ident_ids: &mut IdentIds,
+    _ctx: &mut Context<'a>,
+    _layout_interner: &mut STLayoutInterner<'a>,
+    layout: InLayout<'a>,
+) -> Stmt<'a> {
+    let arena = root.arena;
+    let unit = root.create_symbol(ident_ids, "unit");
+    let loaded = root.create_symbol(ident_ids, "loaded");
+    Stmt::Let(
+        loaded,
+        Expr::ptr_load(arena.alloc(ARG_2)),
+        layout,
+        arena.alloc(
+            //
+            Stmt::Let(
+                unit,
+                Expr::ptr_store(arena.alloc([ARG_1, loaded])),
+                Layout::UNIT,
+                arena.alloc(
+                    //
+                    Stmt::Ret(unit),
+                ),
+            ),
+        ),
+    )
+}


### PR DESCRIPTION
Generate element copying functions in roc to avoid `memcpy` as much as possible. If size and alignment are know at compile time, copying can be way faster.

This is a huge perf gain for sorting. I still think we have room to grow in the algorithm we use (and maybe falling back to pointer sorting for large sized elements), but a great start:
```shell
$ hyperfine /tmp/tmp-old /tmp/tmp
Benchmark 1: /tmp/tmp-old
  Time (mean ± σ):      2.871 s ±  0.007 s    [User: 2.858 s, System: 0.003 s]
  Range (min … max):    2.865 s …  2.889 s    10 runs
 
Benchmark 2: /tmp/tmp
  Time (mean ± σ):     193.4 ms ±   1.4 ms    [User: 189.7 ms, System: 1.7 ms]
  Range (min … max):   192.3 ms … 197.8 ms    14 runs
 
Summary
  /tmp/tmp ran
   14.84 ± 0.11 times faster than /tmp/tmp-old
```


helps #6294
fixes #6450