### PR TITLE
Fast Builtin Sorting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ zig-cache
 .envrc
 *.rs.bk
 *.o
+*.a
 *.so
 *.so.*
 *.obj

--- a/crates/compiler/builtins/bitcode/.gitignore
+++ b/crates/compiler/builtins/bitcode/.gitignore
@@ -1,0 +1,1 @@
+.fuzz_data

--- a/crates/compiler/builtins/bitcode/fuzz_in_tmux.sh
+++ b/crates/compiler/builtins/bitcode/fuzz_in_tmux.sh
@@ -36,8 +36,7 @@ tmux new-window "$BASE_CMD -S fuzzer05 -Z -p coe ./fuzz-cmpcov"
 tmux split-window -h "$BASE_CMD -S fuzzer06 -P exploit ./fuzz"
 tmux split-window -v -t 1.0 "AFL_DISABLE_TRIM=1 $BASE_CMD -S fuzzer07 -p explore ./fuzz"
 tmux split-window -v -t 1.2 "htop"
-tmux new-window
-tmux send-keys "afl-whatsup -d $OUTPUT_DIR"
+tmux new-window "watch -c -n 30 afl-whatsup -s .fuzz_data/output"
 tmux select-window -t 1
 tmux select-window -t 0
 tmux -2 a -t "fuzz"

--- a/crates/compiler/builtins/bitcode/fuzz_in_tmux.sh
+++ b/crates/compiler/builtins/bitcode/fuzz_in_tmux.sh
@@ -38,5 +38,6 @@ tmux split-window -v -t 1.0 "AFL_DISABLE_TRIM=1 $BASE_CMD -S fuzzer07 -p explore
 tmux split-window -v -t 1.2 "htop"
 tmux new-window
 tmux send-keys "afl-whatsup -d $OUTPUT_DIR"
+tmux select-window -t 1
 tmux select-window -t 0
 tmux -2 a -t "fuzz"

--- a/crates/compiler/builtins/bitcode/fuzz_in_tmux.sh
+++ b/crates/compiler/builtins/bitcode/fuzz_in_tmux.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+# Run from this directory.
+SCRIPT_RELATIVE_DIR=`dirname "${BASH_SOURCE[0]}"`
+cd $SCRIPT_RELATIVE_DIR
+
+# First compile the fuzz target.
+zig build-lib -static -fcompiler-rt -flto -fPIC src/fuzz_sort.zig
+afl-clang-lto -o fuzz libfuzz_sort.a
+AFL_LLVM_CMPLOG=1 afl-clang-lto -o fuzz-cmplog libfuzz_sort.a
+AFL_LLVM_LAF_ALL=1 afl-clang-lto -o fuzz-cmpcov libfuzz_sort.a
+
+# Setup fuzz directory with dummy input.
+INPUT_DIR='.fuzz_data/input'
+OUTPUT_DIR='.fuzz_data/output'
+if [ ! -d .fuzz_data ]; then
+  mkdir -p $INPUT_DIR
+  echo '1234567887654321' > $INPUT_DIR/dummy_input
+else
+  # Resuming from existing run.
+  INPUT_DIR='-'
+fi
+
+# Just hardcoding to 7 fuzzers (this avoids overwhelming 8 core machines).
+BASE_CMD="AFL_TESTCACHE_SIZE=250 AFL_IMPORT_FIRST=1 afl-fuzz -i $INPUT_DIR -o $OUTPUT_DIR"
+
+# I'm trying to follow the guide around secondary fuzzers, but I don't quite follow the wording.
+# So I feel this may be correct, but it may also be more random then they expect.
+# Overkill anyway...so this is fine.
+tmux new-session -d -s "fuzz" "AFL_FINAL_SYNC=1 $BASE_CMD -M fuzzer01 ./fuzz"
+tmux split-window -h "$BASE_CMD -S fuzzer02 -c ./fuzz-cmplog -m none -l 2AT -p explore ./fuzz"
+tmux split-window -v -t 0.0 "$BASE_CMD -S fuzzer03 -c ./fuzz-cmplog -m none -L 0 -p exploit ./fuzz"
+tmux split-window -v -t 0.2 "$BASE_CMD -S fuzzer04 -p explore ./fuzz-cmpcov"
+tmux new-window "$BASE_CMD -S fuzzer05 -Z -p coe ./fuzz-cmpcov"
+tmux split-window -h "$BASE_CMD -S fuzzer06 -P exploit ./fuzz"
+tmux split-window -v -t 1.0 "AFL_DISABLE_TRIM=1 $BASE_CMD -S fuzzer07 -p explore ./fuzz"
+tmux split-window -v -t 1.2 "htop"
+tmux new-window
+tmux send-keys "afl-whatsup -d $OUTPUT_DIR"
+tmux select-window -t 0
+tmux -2 a -t "fuzz"

--- a/crates/compiler/builtins/bitcode/src/fuzz_sort.zig
+++ b/crates/compiler/builtins/bitcode/src/fuzz_sort.zig
@@ -1,0 +1,78 @@
+const std = @import("std");
+const sort = @import("sort.zig");
+
+pub fn main() !void {
+    const size = 1000000;
+    var arr_ptr: [*]i64 = @alignCast(@ptrCast(testing_roc_alloc(size * @sizeOf(i64), @alignOf(i64))));
+    defer testing_roc_dealloc(arr_ptr, @alignOf(i64));
+
+    for (0..size) |i| {
+        arr_ptr[i] = @intCast(i + 1);
+    }
+
+    const seed = 42;
+    var rng = std.rand.DefaultPrng.init(seed);
+    rng.random().shuffle(i64, arr_ptr[0..size]);
+
+    var timer = try std.time.Timer.start();
+    sort.quadsort(@ptrCast(arr_ptr), size, &test_i64_compare, null, false, &test_i64_inc_n, @sizeOf(i64), @alignOf(i64), &test_i64_copy);
+    const elapsed: f64 = @floatFromInt(timer.read());
+    std.debug.print("Time elapsed is: {d:.3}ms\n", .{
+        elapsed / std.time.ns_per_ms,
+    });
+}
+
+const Opaque = ?[*]u8;
+fn test_i64_compare(_: Opaque, a_ptr: Opaque, b_ptr: Opaque) callconv(.C) u8 {
+    const a = @as(*i64, @alignCast(@ptrCast(a_ptr))).*;
+    const b = @as(*i64, @alignCast(@ptrCast(b_ptr))).*;
+
+    const gt = @as(u8, @intFromBool(a > b));
+    const lt = @as(u8, @intFromBool(a < b));
+
+    // Eq = 0
+    // GT = 1
+    // LT = 2
+    return lt + lt + gt;
+}
+
+fn test_i64_copy(dst_ptr: Opaque, src_ptr: Opaque) callconv(.C) void {
+    @as(*i64, @alignCast(@ptrCast(dst_ptr))).* = @as(*i64, @alignCast(@ptrCast(src_ptr))).*;
+}
+
+fn test_i64_inc_n(_: ?[*]u8, _: usize) callconv(.C) void {}
+
+comptime {
+    @export(testing_roc_alloc, .{ .name = "roc_alloc", .linkage = .Strong });
+    @export(testing_roc_dealloc, .{ .name = "roc_dealloc", .linkage = .Strong });
+    @export(testing_roc_panic, .{ .name = "roc_panic", .linkage = .Strong });
+}
+
+var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+const allocator = gpa.allocator();
+
+fn testing_roc_alloc(size: usize, _: u32) callconv(.C) ?*anyopaque {
+    // We store an extra usize which is the size of the full allocation.
+    const full_size = size + @sizeOf(usize);
+    var raw_ptr = (allocator.alloc(u8, full_size) catch unreachable).ptr;
+    @as([*]usize, @alignCast(@ptrCast(raw_ptr)))[0] = full_size;
+    raw_ptr += @sizeOf(usize);
+    const ptr = @as(?*anyopaque, @ptrCast(raw_ptr));
+
+    return ptr;
+}
+
+fn testing_roc_dealloc(c_ptr: *anyopaque, _: u32) callconv(.C) void {
+    const raw_ptr = @as([*]u8, @ptrCast(c_ptr)) - @sizeOf(usize);
+    const full_size = @as([*]usize, @alignCast(@ptrCast(raw_ptr)))[0];
+    const slice = raw_ptr[0..full_size];
+
+    allocator.free(slice);
+}
+
+fn testing_roc_panic(c_ptr: *anyopaque, tag_id: u32) callconv(.C) void {
+    _ = c_ptr;
+    _ = tag_id;
+
+    @panic("Roc panicked");
+}

--- a/crates/compiler/builtins/bitcode/src/fuzz_sort.zig
+++ b/crates/compiler/builtins/bitcode/src/fuzz_sort.zig
@@ -1,3 +1,10 @@
+/// Sort Fuzzer!
+/// To fuzz: On linux, first install afl++.
+/// Then build this with:
+///   zig build-lib -static -fcompiler-rt -flto -fPIC src/fuzz_sort.zig
+///   afl-clang-lto -o fuzz libfuzz_sort.a
+/// Finally, run with afl
+///   afl-fuzz -i input -o output -- ./fuzz
 const std = @import("std");
 const sort = @import("sort.zig");
 

--- a/crates/compiler/builtins/bitcode/src/fuzz_sort.zig
+++ b/crates/compiler/builtins/bitcode/src/fuzz_sort.zig
@@ -1,7 +1,13 @@
 const std = @import("std");
 const sort = @import("sort.zig");
 
+var gpa: std.heap.GeneralPurposeAllocator(.{}) = undefined;
+var allocator: std.mem.Allocator = undefined;
+
 pub fn main() !void {
+    gpa = .{};
+    allocator = gpa.allocator();
+
     const size = 1000000;
     var arr_ptr: [*]i64 = @alignCast(@ptrCast(testing_roc_alloc(size * @sizeOf(i64), @alignOf(i64))));
     defer testing_roc_dealloc(arr_ptr, @alignOf(i64));
@@ -47,9 +53,6 @@ comptime {
     @export(testing_roc_dealloc, .{ .name = "roc_dealloc", .linkage = .Strong });
     @export(testing_roc_panic, .{ .name = "roc_panic", .linkage = .Strong });
 }
-
-var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-const allocator = gpa.allocator();
 
 fn testing_roc_alloc(size: usize, _: u32) callconv(.C) ?*anyopaque {
     // We store an extra usize which is the size of the full allocation.

--- a/crates/compiler/builtins/bitcode/src/fuzz_sort.zig
+++ b/crates/compiler/builtins/bitcode/src/fuzz_sort.zig
@@ -37,7 +37,7 @@ pub fn fuzz_main() !void {
     }
 
     var test_count: i64 = 0;
-    sort.quadsort(@ptrCast(arr_ptr), size, &test_i64_compare_refcounted, @ptrCast(&test_count), true, &test_inc_n_data, @sizeOf(i64), @alignOf(i64), &test_i64_copy);
+    sort.fluxsort(@ptrCast(arr_ptr), size, &test_i64_compare_refcounted, @ptrCast(&test_count), true, &test_inc_n_data, @sizeOf(i64), @alignOf(i64), &test_i64_copy);
 
     const sorted = std.sort.isSorted(i64, arr_ptr[0..size], {}, std.sort.asc(i64));
     if (DEBUG) {

--- a/crates/compiler/builtins/bitcode/src/fuzz_sort.zig
+++ b/crates/compiler/builtins/bitcode/src/fuzz_sort.zig
@@ -29,19 +29,19 @@ pub fn fuzz_main() !void {
     const data = try stdin.readToEndAlloc(allocator, std.math.maxInt(usize));
     defer allocator.free(data);
 
-    const size = data.len / @sizeOf(i64);
+    const len = data.len / @sizeOf(i64);
     const arr_ptr: [*]i64 = @alignCast(@ptrCast(data.ptr));
 
     if (DEBUG) {
-        std.debug.print("Input: [{d}]{d}\n", .{ size, arr_ptr[0..size] });
+        std.debug.print("Input: [{d}]{d}\n", .{ len, arr_ptr[0..len] });
     }
 
     var test_count: i64 = 0;
-    sort.fluxsort(@ptrCast(arr_ptr), size, &test_i64_compare_refcounted, @ptrCast(&test_count), true, &test_inc_n_data, @sizeOf(i64), @alignOf(i64), &test_i64_copy);
+    sort.fluxsort(@ptrCast(arr_ptr), len, &test_i64_compare_refcounted, @ptrCast(&test_count), true, &test_inc_n_data, @sizeOf(i64), @alignOf(i64), &test_i64_copy);
 
-    const sorted = std.sort.isSorted(i64, arr_ptr[0..size], {}, std.sort.asc(i64));
+    const sorted = std.sort.isSorted(i64, arr_ptr[0..len], {}, std.sort.asc(i64));
     if (DEBUG) {
-        std.debug.print("Output: [{d}]{d}\nSorted: {}\nFinal RC: {}\n", .{ size, arr_ptr[0..size], sorted, test_count });
+        std.debug.print("Output: [{d}]{d}\nSorted: {}\nFinal RC: {}\n", .{ len, arr_ptr[0..len], sorted, test_count });
     }
     std.debug.assert(sorted);
     std.debug.assert(test_count == 0);
@@ -55,6 +55,7 @@ fn test_i64_compare_refcounted(count_ptr: Opaque, a_ptr: Opaque, b_ptr: Opaque) 
     const gt = @as(u8, @intFromBool(a > b));
     const lt = @as(u8, @intFromBool(a < b));
 
+    std.debug.assert(@as(*isize, @ptrCast(@alignCast(count_ptr))).* > 0);
     @as(*isize, @ptrCast(@alignCast(count_ptr))).* -= 1;
     // Eq = 0
     // GT = 1

--- a/crates/compiler/builtins/bitcode/src/list.zig
+++ b/crates/compiler/builtins/bitcode/src/list.zig
@@ -710,7 +710,7 @@ pub fn listSortWith(
     var list = input.makeUnique(alignment, element_width, elements_refcounted, inc, dec);
 
     if (list.bytes) |source_ptr| {
-        sort.quadsort(source_ptr, list.len(), cmp, cmp_data, data_is_owned, inc_n_data, element_width, alignment, copy);
+        sort.fluxsort(source_ptr, list.len(), cmp, cmp_data, data_is_owned, inc_n_data, element_width, alignment, copy);
     }
 
     return list;

--- a/crates/compiler/builtins/bitcode/src/list.zig
+++ b/crates/compiler/builtins/bitcode/src/list.zig
@@ -710,7 +710,7 @@ pub fn listSortWith(
     var list = input.makeUnique(alignment, element_width, elements_refcounted, inc, dec);
 
     if (list.bytes) |source_ptr| {
-        sort.quadsort(source_ptr, list.len(), cmp, cmp_data, data_is_owned, inc_n_data, element_width, copy);
+        sort.quadsort(source_ptr, list.len(), cmp, cmp_data, data_is_owned, inc_n_data, element_width, alignment, copy);
     }
 
     return list;

--- a/crates/compiler/builtins/bitcode/src/main.zig
+++ b/crates/compiler/builtins/bitcode/src/main.zig
@@ -394,11 +394,13 @@ fn exportUtilsFn(comptime func: anytype, comptime func_name: []const u8) void {
 
 // Custom panic function, as builtin Zig version errors during LLVM verification
 pub fn panic(message: []const u8, stacktrace: ?*std.builtin.StackTrace, _: ?usize) noreturn {
-    if (builtin.is_test) {
-        std.debug.print("{s}: {?}", .{ message, stacktrace });
+    if (builtin.target.cpu.arch != .wasm32) {
+        std.debug.print("\nSomehow in unreachable zig panic!\nThis is a roc standard libarry bug\n{s}: {?}", .{ message, stacktrace });
+        std.process.abort();
+    } else {
+        // Can't call abort or print from wasm. Just leave it as unreachable.
+        unreachable;
     }
-
-    unreachable;
 }
 
 // Run all tests in imported modules

--- a/crates/compiler/builtins/bitcode/src/sort.zig
+++ b/crates/compiler/builtins/bitcode/src/sort.zig
@@ -1391,16 +1391,14 @@ fn quad_swap(
                     arr_ptr += 8 * element_width;
                     continue :outer;
                 },
-                // TODO: Figure out why the reversed case below is broken in some cases.
-                // Note, it seems like the reverse itself is not broken, but the count and pointer become off somehow.
-                // 15 => {
-                //     // potentially already reverse ordered, check rest!
-                //     if (compare(cmp, cmp_data, arr_ptr + 1 * element_width, arr_ptr + 2 * element_width) == GT and compare(cmp, cmp_data, arr_ptr + 3 * element_width, arr_ptr + 4 * element_width) == GT and compare(cmp, cmp_data, arr_ptr + 5 * element_width, arr_ptr + 6 * element_width) == GT) {
-                //         reverse_head = arr_ptr;
-                //         break :switch_state .reversed;
-                //     }
-                //     break :switch_state .not_ordered;
-                // },
+                15 => {
+                    // potentially already reverse ordered, check rest!
+                    if (compare(cmp, cmp_data, arr_ptr + 1 * element_width, arr_ptr + 2 * element_width) == GT and compare(cmp, cmp_data, arr_ptr + 3 * element_width, arr_ptr + 4 * element_width) == GT and compare(cmp, cmp_data, arr_ptr + 5 * element_width, arr_ptr + 6 * element_width) == GT) {
+                        reverse_head = arr_ptr;
+                        break :switch_state .reversed;
+                    }
+                    break :switch_state .not_ordered;
+                },
                 else => {
                     break :switch_state .not_ordered;
                 },
@@ -1491,7 +1489,6 @@ fn quad_swap(
                         }
 
                         // Just an unorderd block, do it inplace.
-
                         inline for ([4]u4{ v1, v2, v3, v4 }) |v| {
                             const x = if (v == 0) element_width else 0;
                             const not_x = if (v != 0) element_width else 0;
@@ -1505,7 +1502,7 @@ fn quad_swap(
                         if (compare(cmp, cmp_data, arr_ptr + 1 * element_width, arr_ptr + 2 * element_width) == GT or compare(cmp, cmp_data, arr_ptr + 3 * element_width, arr_ptr + 4 * element_width) == GT or compare(cmp, cmp_data, arr_ptr + 5 * element_width, arr_ptr + 6 * element_width) == GT) {
                             quad_swap_merge(arr_ptr, swap, cmp, cmp_data, element_width, copy);
                         }
-                        arr_ptr += 8;
+                        arr_ptr += 8 * element_width;
                         continue :outer;
                     }
 
@@ -1637,68 +1634,68 @@ fn quad_reversal(
     }
 }
 
-// test "quad_swap" {
-//     var arr: [75]i64 = undefined;
-//     var arr_ptr = @as([*]u8, @ptrCast(&arr[0]));
+test "quad_swap" {
+    var arr: [75]i64 = undefined;
+    var arr_ptr = @as([*]u8, @ptrCast(&arr[0]));
 
-//     arr = [75]i64{
-//         // multiple ordered chunks
-//         1,  3,  5,  7,  9,  11, 13, 15,
-//         //
-//         33, 34, 35, 36, 37, 38, 39, 40,
-//         // partially ordered
-//         41, 42, 45, 46, 43, 44, 47, 48,
-//         // multiple reverse chunks
-//         70, 69, 68, 67, 66, 65, 64, 63,
-//         //
-//         16, 14, 12, 10, 8,  6,  4,  2,
-//         // another ordered
-//         49, 50, 51, 52, 53, 54, 55, 56,
-//         // unordered
-//         23, 21, 19, 20, 24, 22, 18, 17,
-//         // partially reversed
-//         32, 31, 28, 27, 30, 29, 26, 25,
-//         // awkward tail
-//         62, 59, 61, 60, 71, 73, 75, 74,
-//         //
-//         72, 58, 57,
-//     };
+    arr = [75]i64{
+        // multiple ordered chunks
+        1,  3,  5,  7,  9,  11, 13, 15,
+        //
+        33, 34, 35, 36, 37, 38, 39, 40,
+        // partially ordered
+        41, 42, 45, 46, 43, 44, 47, 48,
+        // multiple reverse chunks
+        70, 69, 68, 67, 66, 65, 64, 63,
+        //
+        16, 14, 12, 10, 8,  6,  4,  2,
+        // another ordered
+        49, 50, 51, 52, 53, 54, 55, 56,
+        // unordered
+        23, 21, 19, 20, 24, 22, 18, 17,
+        // partially reversed
+        32, 31, 28, 27, 30, 29, 26, 25,
+        // awkward tail
+        62, 59, 61, 60, 71, 73, 75, 74,
+        //
+        72, 58, 57,
+    };
 
-//     var result = quad_swap(arr_ptr, 75, &test_i64_compare, null, @sizeOf(i64), &test_i64_copy);
-//     try testing.expectEqual(result, .unfinished);
-//     try testing.expectEqual(arr, [75]i64{
-//         // first 32 elements sorted (with 8 reversed that get flipped here)
-//         1,  2,  3,  4,  5,  6,  7,  8,
-//         //
-//         9,  10, 11, 12, 13, 14, 15, 16,
-//         //
-//         33, 34, 35, 36, 37, 38, 39, 40,
-//         //
-//         41, 42, 43, 44, 45, 46, 47, 48,
-//         // second 32 elements sorted (with 8 reversed that get flipped here)
-//         17, 18, 19, 20, 21, 22, 23, 24,
-//         //
-//         25, 26, 27, 28, 29, 30, 31, 32,
-//         //
-//         49, 50, 51, 52, 53, 54, 55, 56,
-//         //
-//         63, 64, 65, 66, 67, 68, 69, 70,
-//         // awkward tail
-//         57, 58, 59, 60, 61, 62, 71, 72,
-//         //
-//         73, 74, 75,
-//     });
+    var result = quad_swap(arr_ptr, 75, &test_i64_compare, null, @sizeOf(i64), &test_i64_copy);
+    try testing.expectEqual(result, .unfinished);
+    try testing.expectEqual(arr, [75]i64{
+        // first 32 elements sorted (with 8 reversed that get flipped here)
+        1,  2,  3,  4,  5,  6,  7,  8,
+        //
+        9,  10, 11, 12, 13, 14, 15, 16,
+        //
+        33, 34, 35, 36, 37, 38, 39, 40,
+        //
+        41, 42, 43, 44, 45, 46, 47, 48,
+        // second 32 elements sorted (with 8 reversed that get flipped here)
+        17, 18, 19, 20, 21, 22, 23, 24,
+        //
+        25, 26, 27, 28, 29, 30, 31, 32,
+        //
+        49, 50, 51, 52, 53, 54, 55, 56,
+        //
+        63, 64, 65, 66, 67, 68, 69, 70,
+        // awkward tail
+        57, 58, 59, 60, 61, 62, 71, 72,
+        //
+        73, 74, 75,
+    });
 
-//     // Just reversed.
-//     var expected: [75]i64 = undefined;
-//     for (0..75) |i| {
-//         expected[i] = @intCast(i + 1);
-//         arr[i] = @intCast(75 - i);
-//     }
-//     result = quad_swap(arr_ptr, 75, &test_i64_compare, null, @sizeOf(i64), &test_i64_copy);
-//     try testing.expectEqual(result, .sorted);
-//     try testing.expectEqual(arr, expected);
-// }
+    // Just reversed.
+    var expected: [75]i64 = undefined;
+    for (0..75) |i| {
+        expected[i] = @intCast(i + 1);
+        arr[i] = @intCast(75 - i);
+    }
+    result = quad_swap(arr_ptr, 75, &test_i64_compare, null, @sizeOf(i64), &test_i64_copy);
+    try testing.expectEqual(result, .sorted);
+    try testing.expectEqual(arr, expected);
+}
 
 test "quad_swap_merge" {
     var arr: [8]i64 = undefined;

--- a/crates/compiler/builtins/bitcode/src/sort.zig
+++ b/crates/compiler/builtins/bitcode/src/sort.zig
@@ -74,6 +74,8 @@ fn quadsort_direct(
 }
 // ================ Quad Merge Support ========================================
 
+// TODO: quad_merge, requires tail merge first.
+
 /// Merges 4 even sized blocks of sorted elements.
 fn quad_merge_block(
     array: [*]u8,
@@ -338,7 +340,7 @@ test "cross_merge" {
 // ================ 32 Element Blocks =========================================
 // This is basically a fast path to avoid `roc_alloc` for very sort arrays.
 
-// TODO: Implement quad_swap here.
+// TODO: quad_swap, requires tail merge first.
 // It deals with 32 elements without a large allocation.
 
 /// Merge 4 sorted arrays of length 2 into a sorted array of length 8 using swap space.

--- a/crates/compiler/builtins/bitcode/src/sort.zig
+++ b/crates/compiler/builtins/bitcode/src/sort.zig
@@ -14,7 +14,7 @@ const CopyFn = *const fn (Opaque, Opaque) callconv(.C) void;
 const IncN = *const fn (?[*]u8, usize) callconv(.C) void;
 
 /// Any size larger than the max element buffer will be sorted indirectly via pointers.
-/// TODO: tune this.
+/// TODO: tune this. I think due to llvm inlining the compare, the value likely should be lower.
 /// I did some basic basic testing on my M1 and x86 machines with the c version of fluxsort.
 /// The best tradeoff point is not the clearest and heavily depends on machine specifics.
 /// Generally speaking, the faster memcpy is and the larger the cache line, the larger this should be.
@@ -2528,8 +2528,7 @@ test "quad_merge_block" {
     // case 3 both haves sorted
     arr = [8]i64{ 1, 3, 5, 7, 2, 4, 6, 8 };
     quad_merge_block(arr_ptr, swap_ptr, 2, &test_i64_compare_refcounted, @ptrCast(&test_count), @sizeOf(i64), &test_i64_copy, true, &test_inc_n_data, false);
-    // TODO: fix
-    // try testing.expectEqual(test_count, 0);
+    try testing.expectEqual(test_count, 0);
     try testing.expectEqual(arr, expected);
 
     // case 3 - lucky, sorted

--- a/crates/compiler/builtins/bitcode/src/sort.zig
+++ b/crates/compiler/builtins/bitcode/src/sort.zig
@@ -73,7 +73,16 @@ fn quadsort_direct(
 
 /// Merges two neighboring sorted arrays into dest.
 /// Left must be equal to or 1 smaller than right.
-fn parity_merge(dest: [*]u8, src: [*]u8, left_len: usize, right_len: usize, cmp_data: Opaque, cmp: CompareFn, element_width: usize, copy: CopyFn) void {
+fn parity_merge(
+    dest: [*]u8,
+    src: [*]u8,
+    left_len: usize,
+    right_len: usize,
+    cmp_data: Opaque,
+    cmp: CompareFn,
+    element_width: usize,
+    copy: CopyFn,
+) void {
     std.debug.assert(left_len == right_len or left_len == right_len - 1);
 
     var left_head = src;
@@ -137,7 +146,15 @@ test "parity_merge" {
 // Below are functions for sorting 0 to 7 element arrays.
 
 /// Sort arrays of 0 to 7 elements.
-fn tiny_sort(array: [*]u8, len: usize, swap: [*]u8, cmp_data: Opaque, cmp: CompareFn, element_width: usize, copy: CopyFn) void {
+fn tiny_sort(
+    array: [*]u8,
+    len: usize,
+    swap: [*]u8,
+    cmp_data: Opaque,
+    cmp: CompareFn,
+    element_width: usize,
+    copy: CopyFn,
+) void {
     std.debug.assert(len < 8);
 
     var buffer: [MAX_ELEMENT_BUFFER_SIZE]u8 = undefined;
@@ -176,7 +193,14 @@ fn tiny_sort(array: [*]u8, len: usize, swap: [*]u8, cmp_data: Opaque, cmp: Compa
     }
 }
 
-fn parity_swap_four(array: [*]u8, tmp_ptr: [*]u8, cmp_data: Opaque, cmp: CompareFn, element_width: usize, copy: CopyFn) void {
+fn parity_swap_four(
+    array: [*]u8,
+    tmp_ptr: [*]u8,
+    cmp_data: Opaque,
+    cmp: CompareFn,
+    element_width: usize,
+    copy: CopyFn,
+) void {
     var arr_ptr = array;
     swap_branchless(arr_ptr, tmp_ptr, cmp_data, cmp, element_width, copy);
     arr_ptr += 2 * element_width;
@@ -197,7 +221,14 @@ fn parity_swap_four(array: [*]u8, tmp_ptr: [*]u8, cmp_data: Opaque, cmp: Compare
     }
 }
 
-fn parity_swap_five(array: [*]u8, tmp_ptr: [*]u8, cmp_data: Opaque, cmp: CompareFn, element_width: usize, copy: CopyFn) void {
+fn parity_swap_five(
+    array: [*]u8,
+    tmp_ptr: [*]u8,
+    cmp_data: Opaque,
+    cmp: CompareFn,
+    element_width: usize,
+    copy: CopyFn,
+) void {
     var arr_ptr = array;
     swap_branchless(arr_ptr, tmp_ptr, cmp_data, cmp, element_width, copy);
     arr_ptr += 2 * element_width;
@@ -223,7 +254,15 @@ fn parity_swap_five(array: [*]u8, tmp_ptr: [*]u8, cmp_data: Opaque, cmp: Compare
     }
 }
 
-fn parity_swap_six(array: [*]u8, tmp_ptr: [*]u8, swap: [*]u8, cmp_data: Opaque, cmp: CompareFn, element_width: usize, copy: CopyFn) void {
+fn parity_swap_six(
+    array: [*]u8,
+    tmp_ptr: [*]u8,
+    swap: [*]u8,
+    cmp_data: Opaque,
+    cmp: CompareFn,
+    element_width: usize,
+    copy: CopyFn,
+) void {
     var arr_ptr = array;
     swap_branchless(arr_ptr, tmp_ptr, cmp_data, cmp, element_width, copy);
     arr_ptr += element_width;
@@ -281,7 +320,15 @@ fn parity_swap_six(array: [*]u8, tmp_ptr: [*]u8, swap: [*]u8, cmp_data: Opaque, 
     copy(arr_ptr, from);
 }
 
-fn parity_swap_seven(array: [*]u8, tmp_ptr: [*]u8, swap: [*]u8, cmp_data: Opaque, cmp: CompareFn, element_width: usize, copy: CopyFn) void {
+fn parity_swap_seven(
+    array: [*]u8,
+    tmp_ptr: [*]u8,
+    swap: [*]u8,
+    cmp_data: Opaque,
+    cmp: CompareFn,
+    element_width: usize,
+    copy: CopyFn,
+) void {
     var arr_ptr = array;
     swap_branchless(arr_ptr, tmp_ptr, cmp_data, cmp, element_width, copy);
     arr_ptr += 2 * element_width;
@@ -419,7 +466,14 @@ test "tiny_sort" {
 // The are the smallest fundamental unit.
 
 /// Merge two neighboring sorted 4 element arrays into swap.
-inline fn parity_merge_four(array: [*]u8, swap: [*]u8, cmp_data: Opaque, cmp: CompareFn, element_width: usize, copy: CopyFn) void {
+inline fn parity_merge_four(
+    array: [*]u8,
+    swap: [*]u8,
+    cmp_data: Opaque,
+    cmp: CompareFn,
+    element_width: usize,
+    copy: CopyFn,
+) void {
     var left = array;
     var right = array + (4 * element_width);
     var swap_ptr = swap;
@@ -442,7 +496,14 @@ inline fn parity_merge_four(array: [*]u8, swap: [*]u8, cmp_data: Opaque, cmp: Co
 }
 
 /// Merge two neighboring sorted 2 element arrays into swap.
-inline fn parity_merge_two(array: [*]u8, swap: [*]u8, cmp_data: Opaque, cmp: CompareFn, element_width: usize, copy: CopyFn) void {
+inline fn parity_merge_two(
+    array: [*]u8,
+    swap: [*]u8,
+    cmp_data: Opaque,
+    cmp: CompareFn,
+    element_width: usize,
+    copy: CopyFn,
+) void {
     var left = array;
     var right = array + (2 * element_width);
     var swap_ptr = swap;
@@ -464,7 +525,15 @@ inline fn parity_merge_two(array: [*]u8, swap: [*]u8, cmp_data: Opaque, cmp: Com
 /// Will increment both dest and the smaller element ptr to their next index.
 /// Inlining will remove the extra level of pointer indirection here.
 /// It is just used to allow mutating the input pointers.
-inline fn head_branchless_merge(dest: *[*]u8, left: *[*]u8, right: *[*]u8, cmp_data: Opaque, cmp: CompareFn, element_width: usize, copy: CopyFn) void {
+inline fn head_branchless_merge(
+    dest: *[*]u8,
+    left: *[*]u8,
+    right: *[*]u8,
+    cmp_data: Opaque,
+    cmp: CompareFn,
+    element_width: usize,
+    copy: CopyFn,
+) void {
     // Note equivalent c code:
     //    *ptd++ = cmp(ptl, ptr) <= 0 ? *ptl++ : *ptr++;
     // While not guaranteed branchless, tested in godbolt for x86_64, aarch32, aarch64, riscv64, and wasm32.
@@ -479,7 +548,15 @@ inline fn head_branchless_merge(dest: *[*]u8, left: *[*]u8, right: *[*]u8, cmp_d
 /// Will decrement both dest and the smaller element ptr to their previous index.
 /// Inlining will remove the extra level of pointer indirection here.
 /// It is just used to allow mutating the input pointers.
-inline fn tail_branchless_merge(dest: *[*]u8, left: *[*]u8, right: *[*]u8, cmp_data: Opaque, cmp: CompareFn, element_width: usize, copy: CopyFn) void {
+inline fn tail_branchless_merge(
+    dest: *[*]u8,
+    left: *[*]u8,
+    right: *[*]u8,
+    cmp_data: Opaque,
+    cmp: CompareFn,
+    element_width: usize,
+    copy: CopyFn,
+) void {
     // Note equivalent c code:
     //    *tpd-- = cmp(tpl, tpr) > 0 ? *tpl-- : *tpr--;
     // While not guaranteed branchless, tested in godbolt for x86_64, aarch32, aarch64, riscv64, and wasm32.
@@ -491,12 +568,26 @@ inline fn tail_branchless_merge(dest: *[*]u8, left: *[*]u8, right: *[*]u8, cmp_d
 }
 
 /// Swaps the element at ptr with the element after it if the element is greater than the next.
-inline fn swap_branchless(ptr: [*]u8, tmp: [*]u8, cmp_data: Opaque, cmp: CompareFn, element_width: usize, copy: CopyFn) void {
+inline fn swap_branchless(
+    ptr: [*]u8,
+    tmp: [*]u8,
+    cmp_data: Opaque,
+    cmp: CompareFn,
+    element_width: usize,
+    copy: CopyFn,
+) void {
     // While not guaranteed branchless, tested in godbolt for x86_64, aarch32, aarch64, riscv64, and wasm32.
     _ = swap_branchless_return_gt(ptr, tmp, cmp_data, cmp, element_width, copy);
 }
 
-inline fn swap_branchless_return_gt(ptr: [*]u8, tmp: [*]u8, cmp_data: Opaque, cmp: CompareFn, element_width: usize, copy: CopyFn) u8 {
+inline fn swap_branchless_return_gt(
+    ptr: [*]u8,
+    tmp: [*]u8,
+    cmp_data: Opaque,
+    cmp: CompareFn,
+    element_width: usize,
+    copy: CopyFn,
+) u8 {
     // While not guaranteed branchless, tested in godbolt for x86_64, aarch32, aarch64, riscv64, and wasm32.
     const gt = compare(cmp, cmp_data, ptr, ptr + element_width) == GT;
     var x = if (gt) element_width else 0;

--- a/crates/compiler/builtins/bitcode/src/sort.zig
+++ b/crates/compiler/builtins/bitcode/src/sort.zig
@@ -1216,6 +1216,10 @@ fn quad_merge_block(
             @memcpy((swap + element_width * block_x_2)[0..(element_width * block_x_2)], block3[0..(element_width * block_x_2)]);
         },
         3 => {
+            // 1 guaranteed compares.
+            if (data_is_owned) {
+                inc_n_data(cmp_data, 1);
+            }
             const in_order_2_3 = compare(cmp, cmp_data, block3 - element_width, block3) != GT;
             if (in_order_2_3)
                 // Lucky, all sorted.
@@ -2803,7 +2807,7 @@ fn test_i64_compare_refcounted(count_ptr: Opaque, a_ptr: Opaque, b_ptr: Opaque) 
     const gt = @as(u8, @intFromBool(a > b));
     const lt = @as(u8, @intFromBool(a < b));
 
-    @as(*isize, @ptrCast(@alignCast(count_ptr))).* -= @intCast(1);
+    @as(*isize, @ptrCast(@alignCast(count_ptr))).* -= 1;
     // Eq = 0
     // GT = 1
     // LT = 2

--- a/crates/compiler/builtins/bitcode/src/sort.zig
+++ b/crates/compiler/builtins/bitcode/src/sort.zig
@@ -3017,7 +3017,7 @@ test "quad_reversal" {
 // Below are functions for sorting under 32 element arrays.
 
 /// Uses swap space to sort the tail of an array.
-/// The array should be under 32 elements in length.
+/// The array should generally be under 32 elements in length.
 fn tail_swap(
     array: [*]u8,
     len: usize,
@@ -3029,8 +3029,6 @@ fn tail_swap(
     comptime data_is_owned: bool,
     inc_n_data: IncN,
 ) void {
-    std.debug.assert(len < 32);
-
     if (len < 8) {
         tiny_sort(array, len, swap, cmp, cmp_data, element_width, copy, data_is_owned, inc_n_data);
         return;

--- a/crates/compiler/builtins/bitcode/src/sort.zig
+++ b/crates/compiler/builtins/bitcode/src/sort.zig
@@ -258,7 +258,7 @@ inline fn head_branchless_merge(dest: *[*]u8, left: *[*]u8, right: *[*]u8, cmp_d
     // That said, not sure how to write that in zig and guarantee it is branchless.
     // Thus using the longer form.
     const lte = compare(cmp, cmp_data, left.*, right.*) != GT;
-    // TODO: double check this is branchless.
+    // While not guaranteed branchless, tested in godbolt for x86_64, aarch32, aarch64, riscv64, and wasm32.
     const x = if (lte) element_width else 0;
     const not_x = if (lte) 0 else element_width;
     copy(dest.*, left.*);
@@ -277,7 +277,7 @@ inline fn tail_branchless_merge(dest: *[*]u8, left: *[*]u8, right: *[*]u8, cmp_d
     //    *tpd-- = cmp(tpl, tpr) > 0 ? *tpl-- : *tpr--;
     // That said, not sure how to write that in zig and guarantee it is branchless.
     const lte = compare(cmp, cmp_data, left.*, right.*) != GT;
-    // TODO: double check this is branchless.
+    // While not guaranteed branchless, tested in godbolt for x86_64, aarch32, aarch64, riscv64, and wasm32.
     const y = if (lte) element_width else 0;
     const not_y = if (lte) 0 else element_width;
     copy(dest.*, left.*);
@@ -290,8 +290,7 @@ inline fn tail_branchless_merge(dest: *[*]u8, left: *[*]u8, right: *[*]u8, cmp_d
 /// Swaps the element at ptr with the element after it if the element is greater than the next.
 inline fn swap_branchless(ptr: [*]u8, swap: [*]u8, cmp_data: Opaque, cmp: CompareFn, element_width: usize, copy: CopyFn) void {
     const gt = compare(cmp, cmp_data, ptr, ptr + element_width) == GT;
-    // TODO: double check this is branchless. I would expect llvm to optimize this to be branchless.
-    // But based on reading some comments in quadsort, llvm seems to prefer branches very often.
+    // While not guaranteed branchless, tested in godbolt for x86_64, aarch32, aarch64, riscv64, and wasm32.
     const x = if (gt) element_width else 0;
     const y = if (gt) 0 else element_width;
 

--- a/crates/compiler/builtins/bitcode/src/sort.zig
+++ b/crates/compiler/builtins/bitcode/src/sort.zig
@@ -1187,14 +1187,9 @@ fn cross_merge(
             break;
 
         // Large enough to warrent a two way merge.
-        var loops: usize = 8;
-        while (true) {
+        for (0..8) |_| {
             head_branchless_merge(&dest_head, &left_head, &right_head, cmp, cmp_data, element_width, copy);
             tail_branchless_merge(&dest_tail, &left_tail, &right_tail, cmp, cmp_data, element_width, copy);
-
-            loops -= 1;
-            if (loops == 0)
-                break;
         }
     }
 
@@ -1811,8 +1806,7 @@ fn parity_merge(
     }
     head_branchless_merge(&dest_head, &left_head, &right_head, cmp, cmp_data, element_width, copy);
 
-    var ll = left_len - 1;
-    while (ll != 0) : (ll -= 1) {
+    for (0..(left_len - 1)) |_| {
         head_branchless_merge(&dest_head, &left_head, &right_head, cmp, cmp_data, element_width, copy);
         tail_branchless_merge(&dest_tail, &left_tail, &right_tail, cmp, cmp_data, element_width, copy);
     }

--- a/crates/compiler/builtins/bitcode/src/sort.zig
+++ b/crates/compiler/builtins/bitcode/src/sort.zig
@@ -1252,68 +1252,68 @@ fn quad_reversal(
     }
 }
 
-test "quad_swap" {
-    var arr: [75]i64 = undefined;
-    var arr_ptr = @as([*]u8, @ptrCast(&arr[0]));
+// test "quad_swap" {
+//     var arr: [75]i64 = undefined;
+//     var arr_ptr = @as([*]u8, @ptrCast(&arr[0]));
 
-    arr = [75]i64{
-        // multiple ordered chunks
-        1,  3,  5,  7,  9,  11, 13, 15,
-        //
-        33, 34, 35, 36, 37, 38, 39, 40,
-        // partially ordered
-        41, 42, 45, 46, 43, 44, 47, 48,
-        // multiple reverse chunks
-        70, 69, 68, 67, 66, 65, 64, 63,
-        //
-        16, 14, 12, 10, 8,  6,  4,  2,
-        // another ordered
-        49, 50, 51, 52, 53, 54, 55, 56,
-        // unordered
-        23, 21, 19, 20, 24, 22, 18, 17,
-        // partially reversed
-        32, 31, 28, 27, 30, 29, 26, 25,
-        // awkward tail
-        62, 59, 61, 60, 71, 73, 75, 74,
-        //
-        72, 58, 57,
-    };
+//     arr = [75]i64{
+//         // multiple ordered chunks
+//         1,  3,  5,  7,  9,  11, 13, 15,
+//         //
+//         33, 34, 35, 36, 37, 38, 39, 40,
+//         // partially ordered
+//         41, 42, 45, 46, 43, 44, 47, 48,
+//         // multiple reverse chunks
+//         70, 69, 68, 67, 66, 65, 64, 63,
+//         //
+//         16, 14, 12, 10, 8,  6,  4,  2,
+//         // another ordered
+//         49, 50, 51, 52, 53, 54, 55, 56,
+//         // unordered
+//         23, 21, 19, 20, 24, 22, 18, 17,
+//         // partially reversed
+//         32, 31, 28, 27, 30, 29, 26, 25,
+//         // awkward tail
+//         62, 59, 61, 60, 71, 73, 75, 74,
+//         //
+//         72, 58, 57,
+//     };
 
-    var result = quad_swap(arr_ptr, 75, &test_i64_compare, null, @sizeOf(i64), &test_i64_copy);
-    try testing.expectEqual(result, .unfinished);
-    try testing.expectEqual(arr, [75]i64{
-        // first 32 elements sorted (with 8 reversed that get flipped here)
-        1,  2,  3,  4,  5,  6,  7,  8,
-        //
-        9,  10, 11, 12, 13, 14, 15, 16,
-        //
-        33, 34, 35, 36, 37, 38, 39, 40,
-        //
-        41, 42, 43, 44, 45, 46, 47, 48,
-        // second 32 elements sorted (with 8 reversed that get flipped here)
-        17, 18, 19, 20, 21, 22, 23, 24,
-        //
-        25, 26, 27, 28, 29, 30, 31, 32,
-        //
-        49, 50, 51, 52, 53, 54, 55, 56,
-        //
-        63, 64, 65, 66, 67, 68, 69, 70,
-        // awkward tail
-        57, 58, 59, 60, 61, 62, 71, 72,
-        //
-        73, 74, 75,
-    });
+//     var result = quad_swap(arr_ptr, 75, &test_i64_compare, null, @sizeOf(i64), &test_i64_copy);
+//     try testing.expectEqual(result, .unfinished);
+//     try testing.expectEqual(arr, [75]i64{
+//         // first 32 elements sorted (with 8 reversed that get flipped here)
+//         1,  2,  3,  4,  5,  6,  7,  8,
+//         //
+//         9,  10, 11, 12, 13, 14, 15, 16,
+//         //
+//         33, 34, 35, 36, 37, 38, 39, 40,
+//         //
+//         41, 42, 43, 44, 45, 46, 47, 48,
+//         // second 32 elements sorted (with 8 reversed that get flipped here)
+//         17, 18, 19, 20, 21, 22, 23, 24,
+//         //
+//         25, 26, 27, 28, 29, 30, 31, 32,
+//         //
+//         49, 50, 51, 52, 53, 54, 55, 56,
+//         //
+//         63, 64, 65, 66, 67, 68, 69, 70,
+//         // awkward tail
+//         57, 58, 59, 60, 61, 62, 71, 72,
+//         //
+//         73, 74, 75,
+//     });
 
-    // Just reversed.
-    var expected: [75]i64 = undefined;
-    for (0..75) |i| {
-        expected[i] = @intCast(i + 1);
-        arr[i] = @intCast(75 - i);
-    }
-    result = quad_swap(arr_ptr, 75, &test_i64_compare, null, @sizeOf(i64), &test_i64_copy);
-    try testing.expectEqual(result, .sorted);
-    try testing.expectEqual(arr, expected);
-}
+//     // Just reversed.
+//     var expected: [75]i64 = undefined;
+//     for (0..75) |i| {
+//         expected[i] = @intCast(i + 1);
+//         arr[i] = @intCast(75 - i);
+//     }
+//     result = quad_swap(arr_ptr, 75, &test_i64_compare, null, @sizeOf(i64), &test_i64_copy);
+//     try testing.expectEqual(result, .sorted);
+//     try testing.expectEqual(arr, expected);
+// }
 
 test "quad_swap_merge" {
     var arr: [8]i64 = undefined;

--- a/crates/compiler/builtins/bitcode/src/sort.zig
+++ b/crates/compiler/builtins/bitcode/src/sort.zig
@@ -1007,6 +1007,7 @@ fn quad_swap(
                     continue :outer;
                 },
                 // TODO: Figure out why the reversed case below is broken in some cases.
+                // Note, it seems like the reverse itself is not broken, but the count and pointer become off somehow.
                 // 15 => {
                 //     // potentially already reverse ordered, check rest!
                 //     if (compare(cmp, cmp_data, arr_ptr + 1 * element_width, arr_ptr + 2 * element_width) == GT and compare(cmp, cmp_data, arr_ptr + 3 * element_width, arr_ptr + 4 * element_width) == GT and compare(cmp, cmp_data, arr_ptr + 5 * element_width, arr_ptr + 6 * element_width) == GT) {

--- a/crates/compiler/builtins/bitcode/src/sort.zig
+++ b/crates/compiler/builtins/bitcode/src/sort.zig
@@ -1129,10 +1129,9 @@ fn cross_merge(
     var dest_head = dest;
     var dest_tail = dest + (left_len + right_len - 1) * element_width;
 
-    // TODO: For fluxsort, this can be while(true), for quadsort, it needs extra protection.
-    // That or I have a bug...not fully sure.
-    outer: while (@intFromPtr(left_tail) - @intFromPtr(left_head) > 8 * element_width and @intFromPtr(right_tail) - @intFromPtr(right_head) > 8 * element_width) {
-        if (@intFromPtr(left_tail) - @intFromPtr(left_head) > 8 * element_width) {
+    outer: while (true) {
+        // This has to be allowed to go negative to be correct. Thus, isize.
+        if (@as(isize, @intCast(@intFromPtr(left_tail))) - @as(isize, @intCast(@intFromPtr(left_head))) > @as(isize, @intCast(8 * element_width))) {
             // 8 elements all less than or equal to and can be moved together.
             while (compare(cmp, cmp_data, left_head + 7 * element_width, right_head) != GT) {
                 inline for (0..8) |_| {
@@ -1158,7 +1157,8 @@ fn cross_merge(
         }
 
         // Attempt to do the same for the right list.
-        if (@intFromPtr(right_tail) - @intFromPtr(right_head) > 8 * element_width) {
+        // This has to be allowed to go negative to be correct. Thus, isize.
+        if (@as(isize, @intCast(@intFromPtr(right_tail))) - @as(isize, @intCast(@intFromPtr(right_head))) > @as(isize, @intCast(8 * element_width))) {
             // left greater than 8 elements right and can be moved together.
             while (compare(cmp, cmp_data, left_head, right_head + 7 * element_width) == GT) {
                 inline for (0..8) |_| {

--- a/crates/compiler/builtins/bitcode/src/sort.zig
+++ b/crates/compiler/builtins/bitcode/src/sort.zig
@@ -46,7 +46,7 @@ pub fn quadsort(
     // Then have our builtin dispatch to the correct version.
     // llvm garbage collection would remove all other variants.
     // Also, for numeric types, inlining the compare function can be a 2x perf gain.
-    if (element_width <= MAX_ELEMENT_BUFFER_SIZE and false) {
+    if (element_width <= MAX_ELEMENT_BUFFER_SIZE) {
         quadsort_direct(source_ptr, len, cmp, cmp_data, data_is_owned, inc_n_data, element_width, alignment, copy);
     } else {
         if (utils.alloc(len * @sizeOf(usize), @alignOf(usize))) |alloc_ptr| {

--- a/crates/compiler/builtins/bitcode/src/sort.zig
+++ b/crates/compiler/builtins/bitcode/src/sort.zig
@@ -14,7 +14,15 @@ const CopyFn = *const fn (Opaque, Opaque) callconv(.C) void;
 const IncN = *const fn (?[*]u8, usize) callconv(.C) void;
 
 /// Any size larger than the max element buffer will be sorted indirectly via pointers.
-const MAX_ELEMENT_BUFFER_SIZE: usize = 64;
+/// TODO: tune this.
+/// I did some basic basic testing on my M1 and x86 machines with the c version of fluxsort.
+/// The best tradeoff point is not the clearest and heavily depends on machine specifics.
+/// Generally speaking, the faster memcpy is and the larger the cache line, the larger this should be.
+/// Also, to my surprise, sorting by pointer is more performant on short arrays than long arrays (probably reduces time of final gather to order main array).
+/// Anyway, there seems to be a hard cut off were the direct sort cost suddenly gets way larger.
+/// In my testing for long arrays, the cutoff seems to be around 96-128 bytes.
+/// For sort arrays, the custoff seems to be around 64-96 bytes.
+const MAX_ELEMENT_BUFFER_SIZE: usize = 96;
 
 pub fn quadsort(
     source_ptr: [*]u8,

--- a/crates/compiler/builtins/bitcode/src/sort.zig
+++ b/crates/compiler/builtins/bitcode/src/sort.zig
@@ -133,7 +133,7 @@ fn rotate_merge(
 ) void {
     var end_ptr = array + len * element_width;
 
-    if (len <= block_len * 2 and len - block_len <= swap_len) {
+    if (len <= block_len * 2 and len -% block_len <= swap_len) {
         partial_backwards_merge(array, len, swap, swap_len, block_len, cmp, cmp_data, element_width, copy);
         return;
     }
@@ -1129,7 +1129,9 @@ fn cross_merge(
     var dest_head = dest;
     var dest_tail = dest + (left_len + right_len - 1) * element_width;
 
-    outer: while (true) {
+    // TODO: For fluxsort, this can be while(true), for quadsort, it needs extra protection.
+    // That or I have a bug...not fully sure.
+    outer: while (@intFromPtr(left_tail) - @intFromPtr(left_head) > 8 * element_width and @intFromPtr(right_tail) - @intFromPtr(right_head) > 8 * element_width) {
         if (@intFromPtr(left_tail) - @intFromPtr(left_head) > 8 * element_width) {
             // 8 elements all less than or equal to and can be moved together.
             while (compare(cmp, cmp_data, left_head + 7 * element_width, right_head) != GT) {

--- a/crates/compiler/builtins/bitcode/src/sort.zig
+++ b/crates/compiler/builtins/bitcode/src/sort.zig
@@ -1780,7 +1780,7 @@ fn tail_swap(
 }
 
 /// Merges two neighboring sorted arrays into dest.
-/// Left must be equal to or 1 smaller than right.
+/// Left and right length mus be same or within 1 element.
 fn parity_merge(
     dest: [*]u8,
     src: [*]u8,
@@ -1791,7 +1791,7 @@ fn parity_merge(
     element_width: usize,
     copy: CopyFn,
 ) void {
-    std.debug.assert(left_len == right_len or left_len == right_len - 1);
+    std.debug.assert(left_len == right_len or left_len == right_len - 1 or left_len - 1 == right_len);
 
     var left_head = src;
     var right_head = src + left_len * element_width;

--- a/crates/compiler/builtins/bitcode/src/sort.zig
+++ b/crates/compiler/builtins/bitcode/src/sort.zig
@@ -83,7 +83,7 @@ fn quadsort_direct(
         }
 
         if (utils.alloc(swap_size * element_width, alignment)) |swap| {
-            const block_len = quad_merge(array, len, swap, 512, 32, cmp, cmp_data, element_width, copy);
+            const block_len = quad_merge(arr_ptr, len, swap, swap_size, 32, cmp, cmp_data, element_width, copy);
             _ = block_len;
 
             // TODO: final rotate merge.

--- a/crates/compiler/builtins/bitcode/src/sort.zig
+++ b/crates/compiler/builtins/bitcode/src/sort.zig
@@ -1520,7 +1520,7 @@ fn quad_swap(
                             break :reverse_block;
                         if (rem >= 1 and compare(cmp, cmp_data, arr_ptr - 1 * element_width, arr_ptr + 0 * element_width) != GT)
                             break :reverse_block;
-                        quad_reversal(reverse_head, arr_ptr + (rem - 1) * element_width, element_width, copy);
+                        quad_reversal(reverse_head, arr_ptr + rem * element_width - element_width, element_width, copy);
 
                         // If we just reversed the entire array, it is sorted.
                         if (reverse_head == array)

--- a/crates/compiler/builtins/bitcode/src/sort.zig
+++ b/crates/compiler/builtins/bitcode/src/sort.zig
@@ -437,7 +437,7 @@ fn flux_analyze(
     } else {
         if (compare_inc(cmp, cmp_data, ptr_c, ptr_c + element_width, data_is_owned, inc_n_data) != GT) {
             // First half needs merge, second half sorted.
-            @memcpy((swap + half2 * element_width)[0..(half2 * element_width)], (array + half2 * element_width)[0..(half2 * element_width)]);
+            @memcpy((swap + half1 * element_width)[0..(half2 * element_width)], (array + half1 * element_width)[0..(half2 * element_width)]);
             cross_merge(swap, array, quad1, quad2, cmp, cmp_data, element_width, copy, data_is_owned, inc_n_data);
         } else {
             // Both halves need merge.

--- a/crates/compiler/builtins/bitcode/src/sort.zig
+++ b/crates/compiler/builtins/bitcode/src/sort.zig
@@ -51,55 +51,29 @@ pub fn quadsort(
     } else {
         if (utils.alloc(len * @sizeOf(usize), @alignOf(usize))) |alloc_ptr| {
             // Build list of pointers to sort.
-            if (@import("builtin").target.cpu.arch != .wasm32) {
-                std.debug.print("Allocated! filling array.\n", .{});
-            }
             var arr_ptr = @as([*]Opaque, @ptrCast(@alignCast(alloc_ptr)));
             defer utils.dealloc(alloc_ptr, @alignOf(usize));
             for (0..len) |i| {
                 arr_ptr[i] = source_ptr + i * element_width;
             }
 
-            // Create indirect compare function.
-            if (@import("builtin").target.cpu.arch != .wasm32) {
-                std.debug.print("Creating indirect sort!\n", .{});
-            }
-            const IndirectSort = struct {
-                compare: CompareFn,
-                pub fn indirect_compare(compare_data: Opaque, lhs_ptr: Opaque, rhs_ptr: Opaque) callconv(.C) u8 {
-                    const lhs = @as(*Opaque, @ptrCast(@alignCast(lhs_ptr))).*;
-                    const rhs = @as(*Opaque, @ptrCast(@alignCast(rhs_ptr))).*;
-                    return compare(compare_data, lhs, rhs);
-                }
-            };
-            const indirect_sort = IndirectSort{ .compare = cmp };
+            // Setup for indirect comparison.
+            inner_cmp = cmp;
+            defer inner_cmp = null;
 
             // Sort.
-            if (@import("builtin").target.cpu.arch != .wasm32) {
-                std.debug.print("Sorting!\n", .{});
-            }
-            quadsort_direct(@ptrCast(arr_ptr), len, indirect_sort.compare, cmp_data, data_is_owned, inc_n_data, @sizeOf(usize), @alignOf(usize), &pointer_copy);
+            quadsort_direct(@ptrCast(arr_ptr), len, indirect_compare, cmp_data, data_is_owned, inc_n_data, @sizeOf(usize), @alignOf(usize), &pointer_copy);
 
             if (utils.alloc(len * element_width, alignment)) |collect_alloc_ptr| {
-                if (@import("builtin").target.cpu.arch != .wasm32) {
-                    std.debug.print("Allocated2! Collecting\n", .{});
-                }
                 // Collect sorted pointers into correct order.
                 var collect_ptr = collect_alloc_ptr;
                 defer utils.dealloc(collect_alloc_ptr, alignment);
                 for (0..len) |i| {
-                    copy(collect_ptr, arr_ptr[i]);
-                    collect_ptr += element_width;
+                    copy(collect_ptr + i * element_width, arr_ptr[i]);
                 }
 
                 // Copy to original array as sorted.
-                if (@import("builtin").target.cpu.arch != .wasm32) {
-                    std.debug.print("Copy out!\n", .{});
-                }
                 @memcpy(source_ptr[0..(len * element_width)], collect_ptr[0..(len * element_width)]);
-                if (@import("builtin").target.cpu.arch != .wasm32) {
-                    std.debug.print("Sorted:[{d}]{d}\nAll done!\n", .{ len, @as([*]i64, @ptrCast(@alignCast(source_ptr)))[0..len] });
-                }
             } else {
                 roc_panic("Out of memory while trying to allocate for sorting", 0);
             }
@@ -2494,6 +2468,14 @@ test "swap" {
     arr = [2]i64{ -22, -22 };
     swap_branchless(arr_ptr, tmp_ptr, &test_i64_compare, null, @sizeOf(i64), &test_i64_copy);
     try testing.expectEqual(arr, [2]i64{ -22, -22 });
+}
+
+// While I think it is technically safe, I'm not a fan of using a threadlocal for this.
+threadlocal var inner_cmp: ?CompareFn = null;
+pub fn indirect_compare(compare_data: Opaque, lhs_ptr: Opaque, rhs_ptr: Opaque) callconv(.C) u8 {
+    const lhs = @as(*[*]u8, @ptrCast(@alignCast(lhs_ptr))).*;
+    const rhs = @as(*[*]u8, @ptrCast(@alignCast(rhs_ptr))).*;
+    return (inner_cmp orelse unreachable)(compare_data, lhs, rhs);
 }
 
 pub fn pointer_copy(dst_ptr: Opaque, src_ptr: Opaque) callconv(.C) void {

--- a/crates/compiler/builtins/bitcode/src/sort.zig
+++ b/crates/compiler/builtins/bitcode/src/sort.zig
@@ -84,10 +84,10 @@ fn quad_swap_merge(
     element_width: usize,
     copy: CopyFn,
 ) void {
-    parity_merge_two(array, swap, cmp_data, cmp, element_width, copy);
-    parity_merge_two(array + 4 * element_width, swap + 4 * element_width, cmp_data, cmp, element_width, copy);
+    parity_merge_two(swap, array, cmp_data, cmp, element_width, copy);
+    parity_merge_two(swap + 4 * element_width, array + 4 * element_width, cmp_data, cmp, element_width, copy);
 
-    parity_merge_four(swap, array, cmp_data, cmp, element_width, copy);
+    parity_merge_four(array, swap, cmp_data, cmp, element_width, copy);
 }
 
 // Reverse values from start to end.
@@ -643,8 +643,8 @@ test "tiny_sort" {
 
 /// Merge two neighboring sorted 4 element arrays into dest.
 inline fn parity_merge_four(
-    array: [*]u8,
     dest: [*]u8,
+    array: [*]u8,
     cmp_data: Opaque,
     cmp: CompareFn,
     element_width: usize,
@@ -673,8 +673,8 @@ inline fn parity_merge_four(
 
 /// Merge two neighboring sorted 2 element arrays into dest.
 inline fn parity_merge_two(
-    array: [*]u8,
     dest: [*]u8,
+    array: [*]u8,
     cmp_data: Opaque,
     cmp: CompareFn,
     element_width: usize,
@@ -786,17 +786,17 @@ test "parity_merge_four" {
 
     arr = [8]i64{ 1, 2, 3, 4, 5, 6, 7, 8 };
     dest = [8]i64{ 0, 0, 0, 0, 0, 0, 0, 0 };
-    parity_merge_four(arr_ptr, dest_ptr, null, &test_i64_compare, @sizeOf(i64), &test_i64_copy);
+    parity_merge_four(dest_ptr, arr_ptr, null, &test_i64_compare, @sizeOf(i64), &test_i64_copy);
     try testing.expectEqual(dest, [8]i64{ 1, 2, 3, 4, 5, 6, 7, 8 });
 
     arr = [8]i64{ 5, 6, 7, 8, 1, 2, 3, 4 };
     dest = [8]i64{ 0, 0, 0, 0, 0, 0, 0, 0 };
-    parity_merge_four(arr_ptr, dest_ptr, null, &test_i64_compare, @sizeOf(i64), &test_i64_copy);
+    parity_merge_four(dest_ptr, arr_ptr, null, &test_i64_compare, @sizeOf(i64), &test_i64_copy);
     try testing.expectEqual(dest, [8]i64{ 1, 2, 3, 4, 5, 6, 7, 8 });
 
     arr = [8]i64{ 1, 3, 5, 7, 2, 4, 6, 8 };
     dest = [8]i64{ 0, 0, 0, 0, 0, 0, 0, 0 };
-    parity_merge_four(arr_ptr, dest_ptr, null, &test_i64_compare, @sizeOf(i64), &test_i64_copy);
+    parity_merge_four(dest_ptr, arr_ptr, null, &test_i64_compare, @sizeOf(i64), &test_i64_copy);
     try testing.expectEqual(dest, [8]i64{ 1, 2, 3, 4, 5, 6, 7, 8 });
 }
 
@@ -808,27 +808,27 @@ test "parity_merge_two" {
 
     arr = [4]i64{ 1, 2, 3, 4 };
     dest = [4]i64{ 0, 0, 0, 0 };
-    parity_merge_two(arr_ptr, dest_ptr, null, &test_i64_compare, @sizeOf(i64), &test_i64_copy);
+    parity_merge_two(dest_ptr, arr_ptr, null, &test_i64_compare, @sizeOf(i64), &test_i64_copy);
     try testing.expectEqual(dest, [4]i64{ 1, 2, 3, 4 });
 
     arr = [4]i64{ 1, 3, 2, 4 };
     dest = [4]i64{ 0, 0, 0, 0 };
-    parity_merge_two(arr_ptr, dest_ptr, null, &test_i64_compare, @sizeOf(i64), &test_i64_copy);
+    parity_merge_two(dest_ptr, arr_ptr, null, &test_i64_compare, @sizeOf(i64), &test_i64_copy);
     try testing.expectEqual(dest, [4]i64{ 1, 2, 3, 4 });
 
     arr = [4]i64{ 3, 4, 1, 2 };
     dest = [4]i64{ 0, 0, 0, 0 };
-    parity_merge_two(arr_ptr, dest_ptr, null, &test_i64_compare, @sizeOf(i64), &test_i64_copy);
+    parity_merge_two(dest_ptr, arr_ptr, null, &test_i64_compare, @sizeOf(i64), &test_i64_copy);
     try testing.expectEqual(dest, [4]i64{ 1, 2, 3, 4 });
 
     arr = [4]i64{ 2, 4, 1, 3 };
     dest = [4]i64{ 0, 0, 0, 0 };
-    parity_merge_two(arr_ptr, dest_ptr, null, &test_i64_compare, @sizeOf(i64), &test_i64_copy);
+    parity_merge_two(dest_ptr, arr_ptr, null, &test_i64_compare, @sizeOf(i64), &test_i64_copy);
     try testing.expectEqual(dest, [4]i64{ 1, 2, 3, 4 });
 
     arr = [4]i64{ 1, 4, 2, 3 };
     dest = [4]i64{ 0, 0, 0, 0 };
-    parity_merge_two(arr_ptr, dest_ptr, null, &test_i64_compare, @sizeOf(i64), &test_i64_copy);
+    parity_merge_two(dest_ptr, arr_ptr, null, &test_i64_compare, @sizeOf(i64), &test_i64_copy);
     try testing.expectEqual(dest, [4]i64{ 1, 2, 3, 4 });
 }
 

--- a/crates/compiler/builtins/bitcode/src/sort.zig
+++ b/crates/compiler/builtins/bitcode/src/sort.zig
@@ -76,11 +76,11 @@ fn quadsort_direct(
     } else if (quad_swap(arr_ptr, len, cmp, cmp_data, element_width, copy) != .sorted) {
         var swap_size = len;
 
-        // for crazy large arrays, limit swap.
-        if (len > 4194304) {
-            swap_size = 4194304;
-            while (swap_size * 8 <= len) : (swap_size *= 4) {}
-        }
+        // This is optional, for about 5% perf hit, lower memory usage on large arrays.
+        // if (len > 4194304) {
+        //     swap_size = 4194304;
+        //     while (swap_size * 8 <= len) : (swap_size *= 4) {}
+        // }
 
         if (utils.alloc(swap_size * element_width, alignment)) |swap| {
             const block_len = quad_merge(arr_ptr, len, swap, swap_size, 32, cmp, cmp_data, element_width, copy);
@@ -1006,14 +1006,15 @@ fn quad_swap(
                     arr_ptr += 8 * element_width;
                     continue :outer;
                 },
-                15 => {
-                    // potentially already reverse ordered, check rest!
-                    if (compare(cmp, cmp_data, arr_ptr + 1 * element_width, arr_ptr + 2 * element_width) == GT and compare(cmp, cmp_data, arr_ptr + 3 * element_width, arr_ptr + 4 * element_width) == GT and compare(cmp, cmp_data, arr_ptr + 5 * element_width, arr_ptr + 6 * element_width) == GT) {
-                        reverse_head = arr_ptr;
-                        break :switch_state .reversed;
-                    }
-                    break :switch_state .not_ordered;
-                },
+                // TODO: Figure out why the reversed case below is broken in some cases.
+                // 15 => {
+                //     // potentially already reverse ordered, check rest!
+                //     if (compare(cmp, cmp_data, arr_ptr + 1 * element_width, arr_ptr + 2 * element_width) == GT and compare(cmp, cmp_data, arr_ptr + 3 * element_width, arr_ptr + 4 * element_width) == GT and compare(cmp, cmp_data, arr_ptr + 5 * element_width, arr_ptr + 6 * element_width) == GT) {
+                //         reverse_head = arr_ptr;
+                //         break :switch_state .reversed;
+                //     }
+                //     break :switch_state .not_ordered;
+                // },
                 else => {
                     break :switch_state .not_ordered;
                 },

--- a/crates/compiler/builtins/bitcode/src/sort.zig
+++ b/crates/compiler/builtins/bitcode/src/sort.zig
@@ -308,7 +308,7 @@ fn partial_forward_merge_right_tail_2(
             right_tail.* -= element_width;
         }
         if (@intFromPtr(right_tail.*) > @intFromPtr(right_head.*) + element_width) {
-            return @call(.always_tail, partial_forward_merge_right_tail_2, .{ dest, left_head, left_tail, right_head, right_tail, cmp_data, cmp, element_width, copy });
+            return partial_forward_merge_right_tail_2(dest, left_head, left_tail, right_head, right_tail, cmp_data, cmp, element_width, copy);
         }
         return true;
     }
@@ -319,7 +319,7 @@ fn partial_forward_merge_right_tail_2(
             left_tail.* -= element_width;
         }
         if (@intFromPtr(left_tail.*) > @intFromPtr(left_head.*) + element_width) {
-            return @call(.always_tail, partial_forward_merge_left_tail_2, .{ dest, left_head, left_tail, right_head, right_tail, cmp_data, cmp, element_width, copy });
+            return partial_forward_merge_left_tail_2(dest, left_head, left_tail, right_head, right_tail, cmp_data, cmp, element_width, copy);
         }
         return true;
     }
@@ -344,7 +344,7 @@ fn partial_forward_merge_left_tail_2(
             left_tail.* -= element_width;
         }
         if (@intFromPtr(left_tail.*) > @intFromPtr(left_head.*) + element_width) {
-            return @call(.always_tail, partial_forward_merge_left_tail_2, .{ dest, left_head, left_tail, right_head, right_tail, cmp_data, cmp, element_width, copy });
+            return partial_forward_merge_left_tail_2(dest, left_head, left_tail, right_head, right_tail, cmp_data, cmp, element_width, copy);
         }
         return true;
     }
@@ -355,7 +355,7 @@ fn partial_forward_merge_left_tail_2(
             right_tail.* -= element_width;
         }
         if (@intFromPtr(right_tail.*) > @intFromPtr(right_head.*) + element_width) {
-            return @call(.always_tail, partial_forward_merge_right_tail_2, .{ dest, left_head, left_tail, right_head, right_tail, cmp_data, cmp, element_width, copy });
+            return partial_forward_merge_right_tail_2(dest, left_head, left_tail, right_head, right_tail, cmp_data, cmp, element_width, copy);
         }
         return true;
     }

--- a/crates/compiler/builtins/bitcode/src/sort.zig
+++ b/crates/compiler/builtins/bitcode/src/sort.zig
@@ -64,10 +64,9 @@ pub fn quadsort(
             // Sort.
             quadsort_direct(@ptrCast(arr_ptr), len, indirect_compare, cmp_data, data_is_owned, inc_n_data, @sizeOf(usize), @alignOf(usize), &pointer_copy);
 
-            if (utils.alloc(len * element_width, alignment)) |collect_alloc_ptr| {
+            if (utils.alloc(len * element_width, alignment)) |collect_ptr| {
                 // Collect sorted pointers into correct order.
-                var collect_ptr = collect_alloc_ptr;
-                defer utils.dealloc(collect_alloc_ptr, alignment);
+                defer utils.dealloc(collect_ptr, alignment);
                 for (0..len) |i| {
                     copy(collect_ptr + i * element_width, arr_ptr[i]);
                 }

--- a/crates/compiler/builtins/bitcode/src/sort.zig
+++ b/crates/compiler/builtins/bitcode/src/sort.zig
@@ -52,8 +52,7 @@ pub fn fluxsort(
     if (len < 132) {
         // Just quadsort it.
         quadsort(array, len, cmp, cmp_data, data_is_owned_runtime, inc_n_data, element_width, alignment, copy);
-    }
-    if (element_width <= MAX_ELEMENT_BUFFER_SIZE) {
+    } else if (element_width <= MAX_ELEMENT_BUFFER_SIZE) {
         if (data_is_owned_runtime) {
             fluxsort_direct(array, len, cmp, cmp_data, element_width, alignment, copy, true, inc_n_data);
         } else {

--- a/crates/compiler/builtins/bitcode/src/sort.zig
+++ b/crates/compiler/builtins/bitcode/src/sort.zig
@@ -837,7 +837,7 @@ fn partial_forward_merge_right_head_2(
             right_head.* += element_width;
         }
         if (@intFromPtr(right_head.*) < @intFromPtr(right_tail.*) - element_width) {
-            return @call(.always_tail, partial_forward_merge_right_head_2, .{ dest, left_head, left_tail, right_head, right_tail, cmp, cmp_data, element_width, copy });
+            return partial_forward_merge_right_head_2(dest, left_head, left_tail, right_head, right_tail, cmp, cmp_data, element_width, copy);
         }
         return true;
     }
@@ -848,7 +848,7 @@ fn partial_forward_merge_right_head_2(
             left_head.* += element_width;
         }
         if (@intFromPtr(left_head.*) < @intFromPtr(left_tail.*) - element_width) {
-            return @call(.always_tail, partial_forward_merge_left_head_2, .{ dest, left_head, left_tail, right_head, right_tail, cmp, cmp_data, element_width, copy });
+            return partial_forward_merge_left_head_2(dest, left_head, left_tail, right_head, right_tail, cmp, cmp_data, element_width, copy);
         }
         return true;
     }
@@ -873,7 +873,7 @@ fn partial_forward_merge_left_head_2(
             left_head.* += element_width;
         }
         if (@intFromPtr(left_head.*) < @intFromPtr(left_tail.*) - element_width) {
-            return @call(.always_tail, partial_forward_merge_left_head_2, .{ dest, left_head, left_tail, right_head, right_tail, cmp, cmp_data, element_width, copy });
+            return partial_forward_merge_left_head_2(dest, left_head, left_tail, right_head, right_tail, cmp, cmp_data, element_width, copy);
         }
         return true;
     }
@@ -884,7 +884,7 @@ fn partial_forward_merge_left_head_2(
             right_head.* += element_width;
         }
         if (@intFromPtr(right_head.*) < @intFromPtr(right_tail.*) - element_width) {
-            return @call(.always_tail, partial_forward_merge_right_head_2, .{ dest, left_head, left_tail, right_head, right_tail, cmp, cmp_data, element_width, copy });
+            return partial_forward_merge_right_head_2(dest, left_head, left_tail, right_head, right_tail, cmp, cmp_data, element_width, copy);
         }
         return true;
     }


### PR DESCRIPTION
Switch sorting over to [fluxsort](https://github.com/scandum/fluxsort). This is a modern and super fast sorting algorithm ([perf info here](https://roc.zulipchat.com/#narrow/stream/395097-compiler-development/topic/faster.20sorting/near/454705605)). 
As part of the change, end up generating 4 specialization of sorting based on whether or not the closure is refcount and whether the element size is so large that it is smarter to sort a list of pointers rather than sorting the actual list.

I am pretty confident in the implementation cause I have run a solid amount of fuzzing.


fixes #6293
fixes #6294