### PR TITLE
Give an error for record builders in patterns instead of crashing

### DIFF
--- a/crates/compiler/parse/src/expr.rs
+++ b/crates/compiler/parse/src/expr.rs
@@ -2113,11 +2113,7 @@ fn expr_to_pattern_help<'a>(arena: &'a Bump, expr: &Expr<'a>) -> Result<Pattern<
             pattern
         }
 
-        Expr::SpaceBefore(..)
-        | Expr::SpaceAfter(..)
-        | Expr::ParensAround(..)
-        | Expr::OldRecordBuilder(..)
-        | Expr::RecordBuilder { .. } => unreachable!(),
+        Expr::SpaceBefore(..) | Expr::SpaceAfter(..) | Expr::ParensAround(..) => unreachable!(),
 
         Expr::Record(fields) => {
             let patterns = fields.map_items_result(arena, |loc_assigned_field| {
@@ -2172,7 +2168,9 @@ fn expr_to_pattern_help<'a>(arena: &'a Bump, expr: &Expr<'a>) -> Result<Pattern<
         | Expr::RecordUpdate { .. }
         | Expr::UnaryOp(_, _)
         | Expr::TaskAwaitBang(..)
-        | Expr::Crash => return Err(()),
+        | Expr::Crash
+        | Expr::OldRecordBuilder(..)
+        | Expr::RecordBuilder { .. } => return Err(()),
 
         Expr::Str(string) => Pattern::StrLiteral(string),
         Expr::SingleQuote(string) => Pattern::SingleQuote(string),


### PR DESCRIPTION
(found by fuzzing)
