### PR TITLE
improve opaque types tip

### DIFF
--- a/crates/cli/tests/cli_run.rs
+++ b/crates/cli/tests/cli_run.rs
@@ -1509,10 +1509,8 @@ mod cli_run {
 
                     Effect.Effect (Result {} [])
 
-                Tip: Type comparisons between an opaque type are only ever equal if
-                both types are the same opaque type. Did you mean to create an opaque
-                type by wrapping it? If I have an opaque type Age := U32 I can create
-                an instance of this opaque type by doing @Age 23.
+                Tip: Add type annotations to functions or values to help you figure
+                this out.
 
                 ────────────────────────────────────────────────────────────────────────────────
 

--- a/crates/compiler/load/tests/test_reporting.rs
+++ b/crates/compiler/load/tests/test_reporting.rs
@@ -8240,10 +8240,8 @@ In roc, functions are always written as a lambda, like{}
 
         F Str
 
-    Tip: Type comparisons between an opaque type are only ever equal if
-    both types are the same opaque type. Did you mean to create an opaque
-    type by wrapping it? If I have an opaque type Age := U32 I can create
-    an instance of this opaque type by doing @Age 23.
+    Tip: *Add type annotations* to functions or values to help you figure
+    this out.
     "#
     );
 
@@ -8277,10 +8275,8 @@ In roc, functions are always written as a lambda, like{}
 
         Age
 
-    Tip: Type comparisons between an opaque type are only ever equal if
-    both types are the same opaque type. Did you mean to create an opaque
-    type by wrapping it? If I have an opaque type Age := U32 I can create
-    an instance of this opaque type by doing @Age 23.
+    Tip: *Add type annotations* to functions or values to help you figure
+    this out.
     "
     );
 
@@ -10403,10 +10399,8 @@ In roc, functions are always written as a lambda, like{}
 
         OList
 
-    Tip: Type comparisons between an opaque type are only ever equal if
-    both types are the same opaque type. Did you mean to create an opaque
-    type by wrapping it? If I have an opaque type Age := U32 I can create
-    an instance of this opaque type by doing @Age 23.
+    Tip: *Add type annotations* to functions or values to help you figure
+    this out.
     "
     );
 

--- a/crates/reporting/src/error/type.rs
+++ b/crates/reporting/src/error/type.rs
@@ -4761,17 +4761,14 @@ fn type_problem_to_pretty<'b>(
             alloc.reflow("Learn more about optional fields at TODO."),
         ])),
 
-        (OpaqueComparedToNonOpaque, _) => alloc.tip().append(alloc.concat([
-            alloc.reflow(
-                "Type comparisons between an opaque type are only ever \
-                equal if both types are the same opaque type. Did you mean \
-                to create an opaque type by wrapping it? If I have an opaque type ",
-            ),
-            alloc.type_str("Age := U32"),
-            alloc.reflow(" I can create an instance of this opaque type by doing "),
-            alloc.type_str("@Age 23"),
-            alloc.reflow("."),
-        ])),
+        (OpaqueComparedToNonOpaque, _) => alloc.tip().append(
+            alloc.concat([
+                alloc
+                    .reflow("Add type annotations")
+                    .annotate(Annotation::Emphasized),
+                alloc.reflow(" to functions or values to help you figure this out."),
+            ]),
+        ),
 
         (BoolVsBoolTag(tag), _) => alloc.tip().append(alloc.concat([
             alloc.reflow("Did you mean to use "),


### PR DESCRIPTION
Errors like this come up often:
```
── TYPE MISMATCH in examples/helloWorld.roc ────────────────────────────────────

This 1st argument to this function has an unexpected type:

13│      args |> List.dropFirst 1 |> List.map parseNumber!
                                              ^^^^^^^^^^^

This parseNumber value is a:

    (Str -> Task.Task (Int Unsigned8) [Exit (Num *) Str])

But this function needs its 1st argument to be:

    InternalTask.Task a b

Tip: Type comparisons between an opaque type are only ever equal if
both types are the same opaque type. Did you mean to create an opaque
type by wrapping it? If I have an opaque type Age := U32 I can create
an instance of this opaque type by doing @Age 23.
```

In this case the tip would put you on the wrong path. Given that I strongly suspect that most times when users see this tip, it puts them on the wrong path, I replaced it with "Add type annotations to functions or values to help you figure this out.". That seems like the most helpful tip in most situations where this error is displayed.