### PR TITLE
cargo test in debug mode

### DIFF
--- a/.github/workflows/ci_manager.yml
+++ b/.github/workflows/ci_manager.yml
@@ -104,6 +104,11 @@ jobs:
         if: needs.check-changes.outputs.run_tests == 'full'
         uses: ./.github/workflows/ubuntu_x86_64.yml
 
+    start-ubuntu-x86-64-tests-debug:
+        needs: check-changes
+        if: needs.check-changes.outputs.run_tests == 'full'
+        uses: ./.github/workflows/ubuntu_x86_64_debug.yml
+
     start-windows-release-build-test:
         needs: check-changes
         if: needs.check-changes.outputs.run_tests == 'full'
@@ -128,6 +133,7 @@ jobs:
                 start-nix-macos-apple-silicon-tests,
                 start-macos-x86-64-tests,
                 start-ubuntu-x86-64-tests,
+                start-ubuntu-x86-64-tests-debug,
                 start-windows-release-build-test,
                 start-windows-tests,
                 start-roc-benchmarks

--- a/.github/workflows/ubuntu_x86_64_debug.yml
+++ b/.github/workflows/ubuntu_x86_64_debug.yml
@@ -1,0 +1,38 @@
+on:
+    workflow_call:
+  
+name: cargo test debug
+
+env:
+    RUST_BACKTRACE: 1
+
+jobs:
+    cargo-test-debug:
+        name: cargo test debug
+        runs-on: [ubuntu-22.04]
+        timeout-minutes: 90
+        steps:
+        - uses: actions/checkout@v4
+
+        - uses: goto-bus-stop/setup-zig@v2
+          with:
+            version: 0.11.0
+
+        - run: zig version
+
+        - name: Install dependencies
+          run: |
+            sudo apt -y install build-essential libunwind-dev pkg-config zlib1g-dev valgrind
+            wget https://apt.llvm.org/llvm.sh
+            chmod +x llvm.sh
+            sudo ./llvm.sh 16
+            sudo rm /usr/bin/clang
+            sudo ln -s /usr/bin/clang-16 /usr/bin/clang
+            sudo ln -s /usr/bin/lld-16 /usr/bin/ld.lld
+            sudo apt -y install libpolly-16-dev
+
+        # for skipped tests; see #6946, #6947
+        - name: cargo test without --release
+          env:
+            RUSTFLAGS: -C link-arg=-fuse-ld=lld
+          run: cargo test -- --skip tests/exhaustive/match_on_result_with_uninhabited_error_destructuring_in_lambda_syntax.txt --skip tests::identity_lambda --skip tests::issue_2300 --skip tests::issue_2582_specialize_result_value --skip tests::sum_lambda

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -468,6 +468,7 @@ version = "0.0.1"
 dependencies = [
  "bumpalo",
  "criterion",
+ "regex",
  "rlimit",
  "roc_collections",
  "roc_command_utils",

--- a/crates/cli_utils/Cargo.toml
+++ b/crates/cli_utils/Cargo.toml
@@ -17,6 +17,7 @@ roc_command_utils = { path = "../utils/command" }
 
 bumpalo.workspace = true
 criterion.workspace = true
+regex.workspace = true
 serde-xml-rs.workspace = true
 serde.workspace = true
 tempfile.workspace = true


### PR DESCRIPTION
We only used to test with `cargo test --release` in the past, in debug mode more assertions are checked.