### PR TITLE
Remove "backpassing" and add "the `!` operator"

### DIFF
--- a/www/content/index.md
+++ b/www/content/index.md
@@ -110,7 +110,7 @@ Here's a code sample that shows a few different aspects of Roc:
 - File I/O and HTTP requests
 - Pattern matching for error handling
 - JSON deserialization via type inference
-- Common syntax sugar: string interpolation, pipelines, and backpassing
+- Common syntax sugar: pipelines, the `!` operator, and string interpolation
 
 The [tutorial](/tutorial) introduces these gradually and in more depth, but this gives a brief overview.
 


### PR DESCRIPTION
This interactive code example does not include backpassing, unless I'm mistaken. Instead, it uses the `!` operator.
I also reordered the syntax sugar list to match the order they appear in the example.