### PR TITLE
Improve Result-chaining documentation

### DIFF
--- a/roc-for-elm-programmers.md
+++ b/roc-for-elm-programmers.md
@@ -931,6 +931,8 @@ foo 1 2 if something then 3 else 4
 
 ## Backpassing
 
+Note: the backpassing syntax will likely be replaced with a new `?` operator in the future, see [this discussion](https://github.com/roc-lang/roc/issues/6828) for more details.
+
 Suppose I'm using a platform for making a CLI, and I want to run several
 `Task`s in a row which read some files from the disk. Here's one way I could do
 that, assuming `Task.await` is like Elm's `Task.andThen` with arguments flipped:

--- a/www/content/tutorial.md
+++ b/www/content/tutorial.md
@@ -819,6 +819,20 @@ Result.isOk (List.get ["a", "b", "c"] 1)
 # Note: There's a Result.isErr function that works similarly.
 ```
 
+```roc
+Result.try (Str.toU64 "2") \idx -> List.get ["a", "b", "c", "d"] idx
+# returns `Ok "c"`
+
+# Notes:
+#  - `Str.toU64 "2"` parses the string "2" to the integer 2, and returns `Ok 2` (more on
+#    integer types later)
+#  - since parsing is successful, `Result.try` passes 2 to the function `\idx -> ...`
+#  - passing "abc" or "1000" instead of "2" would have resulted in `Err InvalidNumStr`
+#    or `Err OutOfBounds` respectively
+```
+
+`Result.try` is often used to chain functions that can fail (as in the example above), returning the first error if any occurs. There is [a discussion](https://github.com/roc-lang/roc/issues/6828) to add syntax sugar for such chaining.
+
 ### [Walking the elements in a list](#walking-the-elements-in-a-list) {#walking-the-elements-in-a-list}
 
 We've now seen a few different ways you can transform lists. Sometimes, though, there's nothing


### PR DESCRIPTION
This PR updates the documentation to clarify how to chain functions that return a `Result`.

1. Added a note about the upcoming syntax sugar for that (i.e., the `?` operator) in the `roc-for-elm-programmers.md` page, at the start of the backpassing section (since backpassing will be replaced, IIUC). The note links to #6828.
2. Added a `Result`-chaining example in the tutorial, as well as a note that some syntax sugar for this is coming.