### PR TITLE
Update and clarify reserved vs non-reserved keywords in the tutorial

### DIFF
--- a/www/content/tutorial.md
+++ b/www/content/tutorial.md
@@ -2246,9 +2246,13 @@ See the [Record Builder Example](https://www.roc-lang.org/examples/RecordBuilder
 
 ### [Reserved Keywords](#reserved-keywords) {#reserved-keywords}
 
-These are all the reserved keywords in Roc. You can't choose any of these as names, except as record field names.
+These are reserved keywords in Roc. You can't choose any of them as names, except as record field names.
 
-`if`, `then`, `else`, `when`, `as`, `is`, `dbg`, `import`, `expect`, `expect-fx`, `crash`, `module`, `app`, `package`, `platform`, `hosted`, `exposes`, `with`, `generates`, `packages`, `requires`
+`as`, `crash`, `dbg`, `else`, `expect`, `expect-fx`, `if`, `import`, `is`, `then`, `when`
+
+Other keywords are used in unambiguous contexts, so they are not reserved. This includes:
+
+`app`, `exposes`, `exposing`, `generates`, `implements`, `module`, `package`, `packages`, `platform`, `requires`, `where`, `with`
 
 ## [Operator Desugaring Table](#operator-desugaring-table) {#operator-desugaring-table}
 

--- a/www/content/tutorial.md
+++ b/www/content/tutorial.md
@@ -2250,7 +2250,7 @@ These are reserved keywords in Roc. You can't choose any of them as names, excep
 
 `as`, `crash`, `dbg`, `else`, `expect`, `expect-fx`, `if`, `import`, `is`, `then`, `when`
 
-Other keywords are used in unambiguous contexts, so they are not reserved. This includes:
+Other keywords are used only in specific places, so they are not reserved. This includes:
 
 `app`, `exposes`, `exposing`, `generates`, `implements`, `module`, `package`, `packages`, `platform`, `requires`, `where`, `with`
 


### PR DESCRIPTION
The **Reserved Keywords** paragraph in the tutorial was not quite up to date, as some keywords were missing (e.g., `exposing`) while others were deprecated (e.g., `hosted`). Moreover, many keywords are not actually reserved: you can create a def called `app` or `module`, this does not cause any issues because these keywords are used in a different context, so there is no risk of ambiguity or conflict.

Therefore I updated this paragraph to clearly distinguish the *reserved* keywords from the other keywords. I also sorted the keywords alphabetically for the reader's convenience.