### PR TITLE
more debug tips

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,23 +43,9 @@ Execute `cargo fmt --all` to fix the formatting.
 - The [compiler's README](https://github.com/roc-lang/roc/tree/main/crates/compiler) contains important info.
 - The AI chat in the [cursor editor](https://www.cursor.com/) can also help you find your way in the codebase.
 
-<details>
-<summary>:beetle: Debugging Tips</summary>
+### Debugging tips
 
-- When using github search to find similar errors/issues use `org:roc-lang`, for example `org:roc-lang valgrind unrecognised instruction`. This will search in basic-cli, basic-webserver, ... as well. Just using `roc` instead of `org:roc-lang` may yield useful results as well.
-- Use a debug build of the compiler. We have many asserts enabled in the debug compiler that can alert you to something going wrong. When building from source, build the debug compiler with `cargo build --bin roc`, the binary is at roc/target/debug/roc. When using roc through a nix flake like in [basic-cli](https://github.com/roc-lang/basic-cli), use `rocPkgs.cli-debug` instead of `rocPkgs.cli`.
-- At the bottom of [.cargo/config.toml](https://github.com/roc-lang/roc/blob/main/.cargo/config.toml) we have useful debug flags that activate certain debug prints and extra checks.
-- For Roc code; minimize the code that produces the issue.
-- If you plan to look at the data used and produced inside the compiler, try to reproduce your issue with a very simple platform like our [minimal Rust platform](https://github.com/roc-lang/roc/tree/main/examples/platform-switching/rust-platform) instead of for example basic-cli.
-- For segmentation faults:
-    + In general we recommend using linux to investigate, it has better tools for this. 
-    + If your segfault also happens when using `--linker=legacy`, using it will improve valgrind output. Use `roc build myApp.roc --linker=legacy` followed by `valgrind ./myApp`.
-    + Use gdb to step through the code, [this gdb script](https://roc.zulipchat.com/#narrow/stream/395097-compiler-development/topic/gdb.20script/near/424422545) can be helpful.
-    + Use objdump to look at the assembly of the code, for example `objdump -d -M intel ./examples/Arithmetic/main`. Replace `-M intel` with the appropriate flag for your CPU.
-    + Inspect the generated LLVM IR (`roc build myApp.roc --emit-llvm-ir`) between Roc code that encounters the segfault and code that doesn't.
-  
-
-</details>
+If you need to do some debugging, check out [our tips](devtools/debug_tips.md).
 
 ### Commit signing
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,14 +45,17 @@ Execute `cargo fmt --all` to fix the formatting.
 
 <details>
 <summary>:beetle: Debugging Tips</summary>
+
+- When using github search to find similar errors/issues use `org:roc-lang`, for example `org:roc-lang valgrind unrecognised instruction`. This will search in basic-cli, basic-webserver, ... as well. Just using `roc` instead of `org:roc-lang` may yield useful results as well.
 - Use a debug build of the compiler. We have many asserts enabled in the debug compiler that can alert you to something going wrong. When building from source, build the debug compiler with `cargo build --bin roc`, the binary is at roc/target/debug/roc. When using roc through a nix flake like in [basic-cli](https://github.com/roc-lang/basic-cli), use `rocPkgs.cli-debug` instead of `rocPkgs.cli`.
-- At the bottom of [.cargo/config.toml](https://github.com/roc-lang/roc/blob/main/.cargo/config.toml) we have useful debug flags that activate certain debug prints.
+- At the bottom of [.cargo/config.toml](https://github.com/roc-lang/roc/blob/main/.cargo/config.toml) we have useful debug flags that activate certain debug prints and extra checks.
 - For Roc code; minimize the code that produces the issue.
 - If you plan to look at the data used and produced inside the compiler, try to reproduce your issue with a very simple platform like our [minimal Rust platform](https://github.com/roc-lang/roc/tree/main/examples/platform-switching/rust-platform) instead of for example basic-cli.
 - For segmentation faults:
     + In general we recommend using linux to investigate, it has better tools for this. 
-    + Use `roc build myApp.roc --linker=legacy` followed by `valgrind ./myApp`.
+    + If your segfault also happens when using `--linker=legacy`, using it will improve valgrind output. Use `roc build myApp.roc --linker=legacy` followed by `valgrind ./myApp`.
     + Use gdb to step through the code, [this gdb script](https://roc.zulipchat.com/#narrow/stream/395097-compiler-development/topic/gdb.20script/near/424422545) can be helpful.
+    + Use objdump to look at the assembly of the code, for example `objdump -d -M intel ./examples/Arithmetic/main`. Replace `-M intel` with the appropriate flag for your CPU.
     + Inspect the generated LLVM IR (`roc build myApp.roc --emit-llvm-ir`) between Roc code that encounters the segfault and code that doesn't.
   
 

--- a/devtools/debug_tips.md
+++ b/devtools/debug_tips.md
@@ -1,0 +1,17 @@
+# Debug Tips
+
+## General
+
+- When using github search to find similar errors/issues use `org:roc-lang`, for example: `org:roc-lang valgrind unrecognised instruction`. This will search in basic-cli, basic-webserver, ... as well. Just using `roc` instead of `org:roc-lang` may yield useful results as well.
+- Use a debug build of the compiler. We have many asserts enabled in the debug compiler that can alert you to something going wrong. When building from source, build the debug compiler with `cargo build --bin roc`, the binary is at `roc/target/debug/roc`. When using roc through a nix flake like in [basic-cli](https://github.com/roc-lang/basic-cli), use `rocPkgs.cli-debug` instead of `rocPkgs.cli`.
+- At the bottom of [.cargo/config.toml](https://github.com/roc-lang/roc/blob/main/.cargo/config.toml) we have useful debug flags that activate certain debug prints and extra checks.
+- For Roc code; minimize the code that produces the issue.
+- If you plan to look at the data used and produced inside the compiler, try to reproduce your issue with a very simple platform like our [minimal Rust platform](https://github.com/roc-lang/roc/tree/main/examples/platform-switching/rust-platform) instead of for example basic-cli.
+
+## Segmentation Faults
+
+- In general we recommend using linux to investigate, it has better tools for this. 
+- If your segfault also happens when using `--linker=legacy`, use it to improve valgrind output. For example: `roc build myApp.roc --linker=legacy` followed by `valgrind ./myApp`.
+- Use gdb to step through the code, [this gdb script](https://roc.zulipchat.com/#narrow/stream/395097-compiler-development/topic/gdb.20script/near/424422545) can be helpful.
+- Use objdump to look at the assembly of the code, for example `objdump -d -M intel ./examples/Arithmetic/main`. Replace `-M intel` with the appropriate flag for your CPU.
+- Inspect the generated LLVM IR (`roc build myApp.roc --emit-llvm-ir`) between Roc code that encounters the segfault and code that doesn't.


### PR DESCRIPTION
I have added some debugging tips and moved them to their own md file. The details tag feels more suited for smaller blocks of text. Now we can also provide a link to the debug tips, instead of telling people to scroll down at contribution tips.