### PR TITLE
Debug flags

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -30,7 +30,7 @@ rustflags = ["-Clink-args=/FORCE:UNRESOLVED"]
 # https://github.com/rust-lang/cargo/issues/3946#issuecomment-973132993
 ROC_WORKSPACE_DIR = { value = "", relative = true }
 
-# Debug flags. Keep this up-to-date with compiler/debug_flags/src/lib.rs.
+# Debug flags. Explanations for these are in compiler/debug_flags/src/lib.rs.
 # Set = "1" to turn a debug flag on.
 ROC_PRETTY_PRINT_ALIAS_CONTENTS        = "0"
 ROC_PRINT_UNIFICATIONS                 = "0"
@@ -49,6 +49,7 @@ ROC_PRINT_IR_AFTER_TRMC                = "0"
 ROC_PRINT_IR_AFTER_DROP_SPECIALIZATION = "0"
 ROC_DEBUG_ALIAS_ANALYSIS               = "0"
 ROC_PRINT_RUNTIME_ERROR_GEN            = "0"
+ROC_NO_UNBOUND_LAYOUT                  = "0"
 ROC_PRINT_LLVM_FN_VERIFICATION         = "0"
 ROC_WRITE_FINAL_WASM                   = "0"
 ROC_LOG_WASM_INTERP                    = "0"

--- a/.github/workflows/ubuntu_x86_64_debug.yml
+++ b/.github/workflows/ubuntu_x86_64_debug.yml
@@ -31,6 +31,9 @@ jobs:
             sudo ln -s /usr/bin/lld-16 /usr/bin/ld.lld
             sudo apt -y install libpolly-16-dev
 
+        - name: Check if debug flag files are in sync
+          run: ./ci/check_debug_vars.sh
+
         # for skipped tests; see #6946, #6947
         - name: cargo test without --release
           env:

--- a/.github/workflows/ubuntu_x86_64_debug.yml
+++ b/.github/workflows/ubuntu_x86_64_debug.yml
@@ -35,4 +35,5 @@ jobs:
         - name: cargo test without --release
           env:
             RUSTFLAGS: -C link-arg=-fuse-ld=lld
+            ROC_CHECK_MONO_IR: 1
           run: cargo test -- --skip tests/exhaustive/match_on_result_with_uninhabited_error_destructuring_in_lambda_syntax.txt --skip tests::identity_lambda --skip tests::issue_2300 --skip tests::issue_2582_specialize_result_value --skip tests::sum_lambda

--- a/ci/check_debug_vars.sh
+++ b/ci/check_debug_vars.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# https://vaneyckt.io/posts/safer_bash_scripts_with_set_euxo_pipefail/
+set -euo pipefail
+
+# Extract vars from .cargo/config.toml
+config_vars=$(grep -E "^ROC_.*= \"[01]\"" .cargo/config.toml | cut -d'=' -f1 | tr -d ' ')
+
+# Extract vars from crates/compiler/debug_flags/src/lib.rs
+lib_vars=$(grep -E "^    ROC_.*" crates/compiler/debug_flags/src/lib.rs | tr -d ' ')
+
+# Sort both lists
+sorted_config_vars=$(echo "$config_vars" | sort)
+sorted_lib_vars=$(echo "$lib_vars" | sort)
+
+# Compare the sorted lists
+if diff <(echo "$sorted_config_vars") <(echo "$sorted_lib_vars") > /dev/null; then
+    echo "The flags in both files are identical."
+else
+    echo "Looks like some flags are out of sync between .cargo/config.toml and crates/compiler/debug_flags/src/lib.rs:"
+    diff <(echo "$sorted_config_vars") <(echo "$sorted_lib_vars")
+fi


### PR DESCRIPTION
I added a CI check to make sure the flags in cargo/config.toml and crates/compiler/debug_flags/src/lib.rs are in sync. I also enabled `ROC_CHECK_MONO_IR` for the cargo tests in debug mode.