### PR TITLE
make target an argument for preprocess-host

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -432,6 +432,14 @@ pub fn build_app() -> Command {
                     .action(ArgAction::SetTrue)
                     .required(false)
             )
+            .arg(
+                Arg::new(FLAG_TARGET)
+                    .long(FLAG_TARGET)
+                    .help("Choose a different target")
+                    .default_value(Into::<&'static str>::into(Target::default()))
+                    .value_parser(build_target_values_parser.clone())
+                    .required(false),
+            )
         )
         .arg(flag_optimize)
         .arg(flag_max_threads)


### PR DESCRIPTION
We were [trying to get the target argument](https://github.com/roc-lang/roc/blob/0bffd6001c7b27794222db76ba0eb48506935871/crates/cli/src/main.rs#L165) when the preprocess-host command was called, but that command did not actually have the target argument, it was always using the default value.

I was able to discover his by running the debug compiler with basic-cli's build.roc. Clap has a debug_assertion that checks this.

This was the error I got:
```
thread 'main' panicked at crates/cli/src/main.rs:166:18:
Mismatch between definition and access of `target`. Unknown argument or group id.  Make sure you are using the argument id and not the short or long flags
```