### PR TITLE
use macos codesign

### DIFF
--- a/crates/compiler/build/src/link.rs
+++ b/crates/compiler/build/src/link.rs
@@ -1159,7 +1159,7 @@ fn link_macos(
         Architecture::Aarch64 => {
             ld_child.wait()?;
 
-            let mut codesign_cmd = Command::new("codesign");
+            let mut codesign_cmd = Command::new("/usr/bin/codesign");
             codesign_cmd.args(["-s", "-", output_path.to_str().unwrap()]);
             debug_print_command(&codesign_cmd);
             let codesign_child = codesign_cmd.spawn()?;


### PR DESCRIPTION
Anaconda also has a codesign and we want to use the macos one, see https://github.com/pyinstaller/pyinstaller/issues/8581#issuecomment-2147311833