### PR TITLE
Remove barely used zstd dependency

### DIFF
--- a/.github/workflows/nightly_macos_apple_silicon.yml
+++ b/.github/workflows/nightly_macos_apple_silicon.yml
@@ -14,8 +14,6 @@ jobs:
   test-and-build:
     name: Rust tests, build and package nightly release
     runs-on: [self-hosted, macOS, ARM64]
-    env:
-      LIBRARY_PATH: /opt/homebrew/Cellar/zstd/1.5.6/lib
     timeout-minutes: 90
     steps:
       - uses: actions/checkout@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2606,7 +2606,6 @@ dependencies = [
 name = "roc_glue"
 version = "0.0.1"
 dependencies = [
- "backtrace",
  "bumpalo",
  "cli_utils",
  "dircpy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -724,17 +724,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "derive_more"
-version = "0.99.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -783,12 +772,6 @@ name = "distance"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d9d8664cf849d7d0f3114a3a387d2f5e4303176d746d5a951aaddc66dfe9240"
-
-[[package]]
-name = "doc-comment"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "dunce"
@@ -1700,11 +1683,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
 dependencies = [
  "crc32fast",
- "flate2",
  "hashbrown",
  "indexmap",
  "memchr",
- "ruzstd",
 ]
 
 [[package]]
@@ -2516,7 +2497,6 @@ dependencies = [
  "roc_solve",
  "roc_target",
  "roc_types",
- "snafu",
  "ven_pretty",
 ]
 
@@ -2536,9 +2516,6 @@ version = "0.0.1"
 [[package]]
 name = "roc_error_utils"
 version = "0.0.1"
-dependencies = [
- "snafu",
-]
 
 [[package]]
 name = "roc_exhaustive"
@@ -2824,7 +2801,6 @@ dependencies = [
  "roc_error_macros",
  "roc_ident",
  "roc_region",
- "snafu",
  "static_assertions",
 ]
 
@@ -3357,17 +3333,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ruzstd"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58c4eb8a81997cf040a091d1f7e1938aeab6749d3a0dfa73af43cdc32393483d"
-dependencies = [
- "byteorder",
- "derive_more",
- "twox-hash",
-]
-
-[[package]]
 name = "ryu"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3598,29 +3563,6 @@ name = "smallvec"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
-
-[[package]]
-name = "snafu"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4de37ad025c587a29e8f3f5605c00f70b98715ef90b9061a815b9e59e9042d6"
-dependencies = [
- "backtrace",
- "doc-comment",
- "snafu-derive",
-]
-
-[[package]]
-name = "snafu-derive"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990079665f075b699031e9c08fd3ab99be5029b96f3b78dc0709e8f77e4efebf"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "socket2"
@@ -4226,16 +4168,6 @@ name = "try-lock"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
-
-[[package]]
-name = "twox-hash"
-version = "1.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
-dependencies = [
- "cfg-if",
- "static_assertions",
-]
 
 [[package]]
 name = "typed-arena"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,7 +137,7 @@ maplit = "1.0.2"
 memmap2 = "0.5.10"
 mimalloc = { version = "0.1.34", default-features = false }
 nonempty = "0.8.1"
-object = { version = "0.32.2", features = ["read", "write"] }
+object = { version = "0.32.2", default-features = false, features = ["read", "write"] }
 packed_struct = "0.10.1"
 page_size = "0.5.0"
 palette = "0.6.1"
@@ -171,7 +171,6 @@ serde_json = "1.0.94" # update roc_std/Cargo.toml on change
 serial_test = "1.0.0"
 signal-hook = "0.3.15"
 smallvec = { version = "1.10.0", features = ["const_generics", "const_new"] }
-snafu = { version = "0.7.4", features = ["backtraces"] }
 static_assertions = "1.1.0" # update roc_std/Cargo.toml on change
 strip-ansi-escapes = "0.1.1"
 strum = { version = "0.24.1", features = ["derive"] }

--- a/ci/basic_nightly_test.sh
+++ b/ci/basic_nightly_test.sh
@@ -17,10 +17,6 @@ if [ -n "$(ls | grep -v "roc_nightly.*tar\.gz"  | grep -v "^ci$")" ]; then
   done
 fi
 
-if [[ "$(uname)" == "Darwin" ]]; then
-    brew install z3 # used by llvm
-fi
-
 # decompress the tar
 ls | grep "roc_nightly.*tar\.gz" | xargs tar -xzvf
 

--- a/crates/compiler/module/Cargo.toml
+++ b/crates/compiler/module/Cargo.toml
@@ -14,7 +14,6 @@ roc_ident = { path = "../ident" }
 roc_region = { path = "../region" }
 
 bumpalo.workspace = true
-snafu.workspace = true
 static_assertions.workspace = true
 
 [features]

--- a/crates/compiler/module/src/module_err.rs
+++ b/crates/compiler/module/src/module_err.rs
@@ -1,30 +1,45 @@
-use snafu::{Backtrace, Snafu};
-
 use crate::symbol::IdentId;
 
-#[derive(Debug, Snafu)]
-#[snafu(visibility(pub))]
+#[derive(Debug)]
 pub enum ModuleError {
-    #[snafu(display(
-        "ModuleIdNotFound: I could not find the ModuleId {} in Interns.all_ident_ids: {}.",
-        module_id,
-        all_ident_ids
-    ))]
     ModuleIdNotFound {
         module_id: String,
         all_ident_ids: String,
-        backtrace: Backtrace,
     },
-    #[snafu(display(
-        "IdentIdNotFound: I could not find IdentId {:?} in ident_ids {:?}.",
-        ident_id,
-        ident_ids_str
-    ))]
     IdentIdNotFound {
         ident_id: IdentId,
         ident_ids_str: String,
-        backtrace: Backtrace,
     },
 }
+
+impl std::fmt::Display for ModuleError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ModuleIdNotFound {
+                module_id,
+                all_ident_ids,
+            } => {
+                write!(
+                    f,
+                    "ModuleIdNotFound: I could not find the ModuleId {} in Interns.all_ident_ids: {}.",
+                    module_id,
+                    all_ident_ids
+                )
+            }
+            Self::IdentIdNotFound {
+                ident_id,
+                ident_ids_str,
+            } => {
+                write!(
+                    f,
+                    "IdentIdNotFound: I could not find IdentId {:?} in ident_ids {:?}.",
+                    ident_id, ident_ids_str
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for ModuleError {}
 
 pub type ModuleResult<T, E = ModuleError> = std::result::Result<T, E>;

--- a/crates/docs/Cargo.toml
+++ b/crates/docs/Cargo.toml
@@ -27,4 +27,3 @@ ven_pretty = { path = "../vendor/pretty" }
 
 bumpalo.workspace = true
 pulldown-cmark.workspace = true
-snafu.workspace = true

--- a/crates/glue/Cargo.toml
+++ b/crates/glue/Cargo.toml
@@ -25,7 +25,6 @@ roc_target = { path = "../compiler/roc_target" }
 roc_tracing = { path = "../tracing" }
 roc_types = { path = "../compiler/types" }
 
-backtrace.workspace = true
 bumpalo.workspace = true
 fnv.workspace = true
 indexmap.workspace = true

--- a/crates/utils/error/Cargo.toml
+++ b/crates/utils/error/Cargo.toml
@@ -8,6 +8,5 @@ license.workspace = true
 version.workspace = true
 
 [dependencies]
-snafu.workspace = true
 
 [dev-dependencies]

--- a/www/content/install/macos_x86_64.md
+++ b/www/content/install/macos_x86_64.md
@@ -18,12 +18,6 @@ which includes the Roc compiler and some helpful utilities.
     cd roc_night<TAB TO AUTOCOMPLETE>
     ```
 
-1. Install required dependencies:
-
-   ```sh
-   brew install z3 zstd
-   ```
-
 1. To be able to run the `roc` command anywhere on your system; add the line below to your shell startup script (.profile, .zshrc, ...):
 
     ```sh


### PR DESCRIPTION
We were expecting `zstd` to be installed on Mac for Roc, but we only used it in two crates:
- snafu: there were two enums that used Snafu for deriving `Error`
- object: the compression/decompression feature uses `zstd`, but we weren't using the feature

By removing that code, we can remove the dependency