### PR TITLE
Deprecate backpassing to prepare for eventual removal

### DIFF
--- a/crates/cli/tests/benchmarks/cFold.roc
+++ b/crates/cli/tests/benchmarks/cFold.roc
@@ -1,12 +1,11 @@
-app "cfold"
-    packages { pf: "platform/main.roc" }
-    imports [pf.Task]
-    provides [main] to pf
+app [main] { pf: platform "platform/main.roc" }
+
+import pf.Task
 
 # adapted from https://github.com/koka-lang/koka/blob/master/test/bench/haskell/cfold.hs
 main : Task.Task {} []
 main =
-    inputResult <- Task.attempt Task.getInt
+    inputResult = Task.getInt |> Task.result!
 
     when inputResult is
         Ok n ->

--- a/crates/cli/tests/benchmarks/nQueens.roc
+++ b/crates/cli/tests/benchmarks/nQueens.roc
@@ -1,11 +1,10 @@
-app "nqueens"
-    packages { pf: "platform/main.roc" }
-    imports [pf.Task]
-    provides [main] to pf
+app [main] { pf: platform "platform/main.roc" }
+
+import pf.Task
 
 main : Task.Task {} []
 main =
-    inputResult <- Task.attempt Task.getInt
+    inputResult = Task.getInt |> Task.result!
 
     when inputResult is
         Ok n ->

--- a/crates/cli/tests/benchmarks/platform/Task.roc
+++ b/crates/cli/tests/benchmarks/platform/Task.roc
@@ -38,7 +38,7 @@ loop = \state, step ->
             \res ->
                 when res is
                     Ok (Step newState) -> Step newState
-                    Ok (Done result) -> Done (Ok result)
+                    Ok (Done res2) -> Done (Ok res2)
                     Err e -> Done (Err e)
 
     Effect.loop state looper
@@ -55,8 +55,8 @@ after : Task a err, (a -> Task b err) -> Task b err
 after = \effect, transform ->
     Effect.after
         effect
-        \result ->
-            when result is
+        \res ->
+            when res is
                 Ok a -> transform a
                 Err err -> Task.fail err
 
@@ -64,8 +64,8 @@ await : Task a err, (a -> Task b err) -> Task b err
 await = \effect, transform ->
     Effect.after
         effect
-        \result ->
-            when result is
+        \res ->
+            when res is
                 Ok a -> transform a
                 Err err -> Task.fail err
 
@@ -73,8 +73,8 @@ attempt : Task a b, (Result a b -> Task c d) -> Task c d
 attempt = \task, transform ->
     Effect.after
         task
-        \result ->
-            when result is
+        \res ->
+            when res is
                 Ok ok -> transform (Ok ok)
                 Err err -> transform (Err err)
 
@@ -82,8 +82,8 @@ map : Task a err, (a -> b) -> Task b err
 map = \effect, transform ->
     Effect.map
         effect
-        \result ->
-            when result is
+        \res ->
+            when res is
                 Ok a -> Ok (transform a)
                 Err err -> Err err
 
@@ -91,7 +91,7 @@ result : Task ok err -> Task (Result ok err) *
 result = \effect ->
     Effect.after
         effect
-        \result -> Task.succeed result
+        \res -> Task.succeed res
 
 putLine : Str -> Task {} *
 putLine = \line -> Effect.map (Effect.putLine line) (\_ -> Ok {})

--- a/crates/cli/tests/benchmarks/quicksortApp.roc
+++ b/crates/cli/tests/benchmarks/quicksortApp.roc
@@ -1,11 +1,11 @@
-app "quicksortapp"
-    packages { pf: "platform/main.roc" }
-    imports [pf.Task, Quicksort]
-    provides [main] to pf
+app [main] { pf: platform "platform/main.roc" }
+
+import pf.Task
+import Quicksort
 
 main : Task.Task {} []
 main =
-    inputResult <- Task.attempt Task.getInt
+    inputResult = Task.getInt |> Task.result!
 
     when inputResult is
         Ok n ->

--- a/crates/cli/tests/benchmarks/rBTreeCk.roc
+++ b/crates/cli/tests/benchmarks/rBTreeCk.roc
@@ -1,7 +1,6 @@
-app "rbtree-ck"
-    packages { pf: "platform/main.roc" }
-    imports [pf.Task]
-    provides [main] to pf
+app [main] { pf: platform "platform/main.roc" }
+
+import pf.Task
 
 Color : [Red, Black]
 
@@ -40,7 +39,7 @@ fold = \f, tree, b ->
 
 main : Task.Task {} []
 main =
-    inputResult <- Task.attempt Task.getInt
+    inputResult = Task.getInt |> Task.result!
 
     when inputResult is
         Ok n ->

--- a/crates/cli/tests/benchmarks/rBTreeDel.roc
+++ b/crates/cli/tests/benchmarks/rBTreeDel.roc
@@ -1,7 +1,6 @@
-app "rbtree-del"
-    packages { pf: "platform/main.roc" }
-    imports [pf.Task]
-    provides [main] to pf
+app [main] { pf: platform "platform/main.roc" }
+
+import pf.Task
 
 Color : [Red, Black]
 
@@ -13,7 +12,7 @@ ConsList a : [Nil, Cons a (ConsList a)]
 
 main : Task.Task {} []
 main =
-    inputResult <- Task.attempt Task.getInt
+    inputResult = Task.getInt |> Task.result!
 
     when inputResult is
         Ok n ->

--- a/crates/cli/tests/cli/countdown.roc
+++ b/crates/cli/tests/cli/countdown.roc
@@ -2,18 +2,18 @@ app [main] { pf: platform "https://github.com/roc-lang/basic-cli/releases/downlo
 
 import pf.Stdin
 import pf.Stdout
-import pf.Task exposing [await, loop]
+import pf.Task exposing [Task, loop]
 
 main =
-    _ <- await (Stdout.line "\nLet's count down from 3 together - all you have to do is press <ENTER>.")
-    _ <- await Stdin.line
+    Stdout.line! "\nLet's count down from 3 together - all you have to do is press <ENTER>."
+    _ = Stdin.line!
     loop 3 tick
 
 tick = \n ->
     if n == 0 then
-        _ <- await (Stdout.line "🎉 SURPRISE! Happy Birthday! 🎂")
+        Stdout.line! "🎉 SURPRISE! Happy Birthday! 🎂"
         Task.ok (Done {})
     else
-        _ <- await (n |> Num.toStr |> \s -> "$(s)..." |> Stdout.line)
-        _ <- await Stdin.line
+        Stdout.line! (n |> Num.toStr |> \s -> "$(s)...")
+        _ = Stdin.line!
         Task.ok (Step (n - 1))

--- a/crates/cli/tests/cli/echo.roc
+++ b/crates/cli/tests/cli/echo.roc
@@ -5,7 +5,7 @@ import pf.Stdout
 import pf.Task exposing [Task]
 
 main =
-    _ <- Task.await (Stdout.line "🗣  Shout into this cave and hear the echo! 👂👂👂")
+    Stdout.line! "🗣  Shout into this cave and hear the echo! 👂👂👂"
 
     Task.loop {} tick
 

--- a/crates/cli/tests/cli/parse-args.roc
+++ b/crates/cli/tests/cli/parse-args.roc
@@ -55,23 +55,23 @@ numParam = \{ name } ->
     { params: [param], parser }
 
 cliMap : ArgParser a, (a -> b) -> ArgParser b
-cliMap = \{ params, parser }, mapper -> {
-    params,
-    parser: \args ->
-        (data, afterData) <- parser args
-            |> Result.try
+cliMap = \{ params, parser }, mapper ->
+    mappedParser = \args ->
+        (data, afterData) = parser? args
 
-        Ok (mapper data, afterData),
-}
+        Ok (mapper data, afterData)
+
+    {
+        params,
+        parser: mappedParser,
+    }
 
 cliBuild : ArgParser a, ArgParser b, (a, b -> c) -> ArgParser c
 cliBuild = \firstWeaver, secondWeaver, combine ->
     allParams = List.concat firstWeaver.params secondWeaver.params
     combinedParser = \args ->
-        (firstValue, afterFirst) <- firstWeaver.parser args
-            |> Result.try
-        (secondValue, afterSecond) <- secondWeaver.parser afterFirst
-            |> Result.try
+        (firstValue, afterFirst) = firstWeaver.parser? args
+        (secondValue, afterSecond) = secondWeaver.parser? afterFirst
 
         Ok (combine firstValue secondValue, afterSecond)
 

--- a/crates/cli/tests/cli/parser-letter-counts.roc
+++ b/crates/cli/tests/cli/parser-letter-counts.roc
@@ -26,18 +26,17 @@ Letter : [A, B, C, Other]
 
 letterParser : Parser (List U8) Letter
 letterParser =
-    input <- buildPrimitiveParser
+    buildPrimitiveParser \input ->
+        valResult =
+            when input is
+                [] -> Err (ParsingFailure "Nothing to parse")
+                ['A', ..] -> Ok A
+                ['B', ..] -> Ok B
+                ['C', ..] -> Ok C
+                _ -> Ok Other
 
-    valResult =
-        when input is
-            [] -> Err (ParsingFailure "Nothing to parse")
-            ['A', ..] -> Ok A
-            ['B', ..] -> Ok B
-            ['C', ..] -> Ok C
-            _ -> Ok Other
-
-    valResult
-    |> Result.map \val -> { val, input: List.dropFirst input 1 }
+        valResult
+        |> Result.map \val -> { val, input: List.dropFirst input 1 }
 
 expect
     input = "B"

--- a/crates/cli/tests/cli_run.rs
+++ b/crates/cli/tests/cli_run.rs
@@ -23,6 +23,7 @@ mod cli_run {
     use serial_test::serial;
     use std::iter;
     use std::path::Path;
+    use std::process::ExitStatus;
 
     #[cfg(all(unix, not(target_os = "macos")))]
     const ALLOW_VALGRIND: bool = true;
@@ -104,6 +105,11 @@ mod cli_run {
         let err = err.replace('\r', "");
 
         assert_multiline_str_eq!(err.as_str(), expected);
+    }
+
+    fn assert_valid_roc_check_status(status: ExitStatus) {
+        // 0 means no errors or warnings, 2 means just warnings
+        assert!(status.code().is_some_and(|code| code == 0 || code == 2))
     }
 
     fn check_format_check_as_expected(file: &Path, expects_success_exit_code: bool) {
@@ -803,7 +809,7 @@ mod cli_run {
     fn check_virtual_dom_server() {
         let path = file_path_from_root("examples/virtual-dom-wip", "example-server.roc");
         let out = run_roc([CMD_CHECK, path.to_str().unwrap()], &[], &[]);
-        assert!(out.status.success());
+        assert_valid_roc_check_status(out.status);
     }
 
     // TODO: write a new test once mono bugs are resolved in investigation
@@ -812,7 +818,7 @@ mod cli_run {
     fn check_virtual_dom_client() {
         let path = file_path_from_root("examples/virtual-dom-wip", "example-client.roc");
         let out = run_roc([CMD_CHECK, path.to_str().unwrap()], &[], &[]);
-        assert!(out.status.success());
+        assert_valid_roc_check_status(out.status);
     }
 
     #[test]
@@ -821,7 +827,7 @@ mod cli_run {
     fn cli_countdown_check() {
         let path = file_path_from_root("crates/cli/tests/cli", "countdown.roc");
         let out = run_roc([CMD_CHECK, path.to_str().unwrap()], &[], &[]);
-        assert!(out.status.success());
+        assert_valid_roc_check_status(out.status);
     }
 
     #[test]
@@ -830,7 +836,7 @@ mod cli_run {
     fn cli_echo_check() {
         let path = file_path_from_root("crates/cli/tests/cli", "echo.roc");
         let out = run_roc([CMD_CHECK, path.to_str().unwrap()], &[], &[]);
-        assert!(out.status.success());
+        assert_valid_roc_check_status(out.status);
     }
 
     #[test]
@@ -839,7 +845,7 @@ mod cli_run {
     fn cli_file_check() {
         let path = file_path_from_root("crates/cli/tests/cli", "fileBROKEN.roc");
         let out = run_roc([CMD_CHECK, path.to_str().unwrap()], &[], &[]);
-        assert!(out.status.success());
+        assert_valid_roc_check_status(out.status);
     }
 
     #[test]
@@ -848,7 +854,8 @@ mod cli_run {
     fn cli_form_check() {
         let path = file_path_from_root("crates/cli/tests/cli", "form.roc");
         let out = run_roc([CMD_CHECK, path.to_str().unwrap()], &[], &[]);
-        assert!(out.status.success());
+        dbg!(out.stdout, out.stderr);
+        assert_valid_roc_check_status(out.status);
     }
 
     #[test]
@@ -857,7 +864,7 @@ mod cli_run {
     fn cli_http_get_check() {
         let path = file_path_from_root("crates/cli/tests/cli", "http-get.roc");
         let out = run_roc([CMD_CHECK, path.to_str().unwrap()], &[], &[]);
-        assert!(out.status.success());
+        assert_valid_roc_check_status(out.status);
     }
 
     #[test]
@@ -1482,9 +1489,9 @@ mod cli_run {
 
                 Something is off with the body of the main definition:
 
-                6│  main : Str -> Task {} []
-                7│  main = /_ ->
-                8│      "this is a string, not a Task {} [] function like the platform expects."
+                5│  main : Str -> Task {} []
+                6│  main = /_ ->
+                7│      "this is a string, not a Task {} [] function like the platform expects."
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
                 The body is a string of type:

--- a/crates/cli/tests/known_bad/TypeError.roc
+++ b/crates/cli/tests/known_bad/TypeError.roc
@@ -1,7 +1,6 @@
-app "type-error"
-    packages { pf: "../../../../examples/cli/false-interpreter/platform/main.roc" }
-    imports [pf.Task.{ Task }]
-    provides [main] to pf
+app [main] { pf: platform "../../../../examples/cli/false-interpreter/platform/main.roc" }
+
+import pf.Task exposing [Task]
 
 main : Str -> Task {} []
 main = \_ ->

--- a/crates/compiler/builtins/roc/Dict.roc
+++ b/crates/compiler/builtins/roc/Dict.roc
@@ -129,8 +129,8 @@ hashDict = \hasher, dict -> Hash.hashUnordered hasher (toList dict) List.walk
 
 toInspectorDict : Dict k v -> Inspector f where k implements Inspect & Hash & Eq, v implements Inspect, f implements InspectFormatter
 toInspectorDict = \dict ->
-    fmt <- Inspect.custom
-    Inspect.apply (Inspect.dict dict walk Inspect.toInspector Inspect.toInspector) fmt
+    Inspect.custom \fmt ->
+        Inspect.apply (Inspect.dict dict walk Inspect.toInspector Inspect.toInspector) fmt
 
 ## Return an empty dictionary.
 ## ```roc
@@ -894,9 +894,9 @@ calcNumBuckets = \shifts ->
         maxBucketCount
 
 fillBucketsFromData = \buckets0, data, shifts ->
-    buckets1, (key, _), dataIndex <- List.walkWithIndex data buckets0
-    (bucketIndex, distAndFingerprint) = nextWhileLess buckets1 key shifts
-    placeAndShiftUp buckets1 { distAndFingerprint, dataIndex: Num.toU32 dataIndex } bucketIndex
+    List.walkWithIndex data buckets0 \buckets1, (key, _), dataIndex ->
+        (bucketIndex, distAndFingerprint) = nextWhileLess buckets1 key shifts
+        placeAndShiftUp buckets1 { distAndFingerprint, dataIndex: Num.toU32 dataIndex } bucketIndex
 
 nextWhileLess : List Bucket, k, U8 -> (U64, U32) where k implements Hash & Eq
 nextWhileLess = \buckets, key, shifts ->
@@ -1213,15 +1213,15 @@ expect
     ]
 
     dict =
-        acc, k <- List.walk badKeys (Dict.empty {})
-        Dict.update acc k \val ->
-            when val is
-                Present p -> Present (p |> Num.addWrap 1)
-                Missing -> Present 0
+        List.walk badKeys (Dict.empty {}) \acc, k ->
+            Dict.update acc k \val ->
+                when val is
+                    Present p -> Present (p |> Num.addWrap 1)
+                    Missing -> Present 0
 
     allInsertedCorrectly =
-        acc, k <- List.walk badKeys Bool.true
-        acc && Dict.contains dict k
+        List.walk badKeys Bool.true \acc, k ->
+            acc && Dict.contains dict k
 
     allInsertedCorrectly
 

--- a/crates/compiler/builtins/roc/Inspect.roc
+++ b/crates/compiler/builtins/roc/Inspect.roc
@@ -138,203 +138,203 @@ dbgInit = \{} -> @DbgFormatter { data: "" }
 
 dbgList : list, ElemWalker (DbgFormatter, Bool) list elem, (elem -> Inspector DbgFormatter) -> Inspector DbgFormatter
 dbgList = \content, walkFn, toDbgInspector ->
-    f0 <- custom
-    dbgWrite f0 "["
-    |> \f1 ->
-        (f2, prependSep), elem <- walkFn content (f1, Bool.false)
-        f3 =
-            if prependSep then
-                dbgWrite f2 ", "
-            else
-                f2
+    custom \f0 ->
+        dbgWrite f0 "["
+        |> \f1 ->
+            walkFn content (f1, Bool.false) \(f2, prependSep), elem ->
+                f3 =
+                    if prependSep then
+                        dbgWrite f2 ", "
+                    else
+                        f2
 
-        elem
-        |> toDbgInspector
-        |> apply f3
-        |> \f4 -> (f4, Bool.true)
-    |> .0
-    |> dbgWrite "]"
+                elem
+                |> toDbgInspector
+                |> apply f3
+                |> \f4 -> (f4, Bool.true)
+        |> .0
+        |> dbgWrite "]"
 
 dbgSet : set, ElemWalker (DbgFormatter, Bool) set elem, (elem -> Inspector DbgFormatter) -> Inspector DbgFormatter
 dbgSet = \content, walkFn, toDbgInspector ->
-    f0 <- custom
-    dbgWrite f0 "{"
-    |> \f1 ->
-        (f2, prependSep), elem <- walkFn content (f1, Bool.false)
-        f3 =
-            if prependSep then
-                dbgWrite f2 ", "
-            else
-                f2
+    custom \f0 ->
+        dbgWrite f0 "{"
+        |> \f1 ->
+            walkFn content (f1, Bool.false) \(f2, prependSep), elem ->
+                f3 =
+                    if prependSep then
+                        dbgWrite f2 ", "
+                    else
+                        f2
 
-        elem
-        |> toDbgInspector
-        |> apply f3
-        |> \f4 -> (f4, Bool.true)
-    |> .0
-    |> dbgWrite "}"
+                elem
+                |> toDbgInspector
+                |> apply f3
+                |> \f4 -> (f4, Bool.true)
+        |> .0
+        |> dbgWrite "}"
 
 dbgDict : dict, KeyValWalker (DbgFormatter, Bool) dict key value, (key -> Inspector DbgFormatter), (value -> Inspector DbgFormatter) -> Inspector DbgFormatter
 dbgDict = \d, walkFn, keyToInspector, valueToInspector ->
-    f0 <- custom
-    dbgWrite f0 "{"
-    |> \f1 ->
-        (f2, prependSep), key, value <- walkFn d (f1, Bool.false)
-        f3 =
-            if prependSep then
-                dbgWrite f2 ", "
-            else
-                f2
+    custom \f0 ->
+        dbgWrite f0 "{"
+        |> \f1 ->
+            walkFn d (f1, Bool.false) \(f2, prependSep), key, value ->
+                f3 =
+                    if prependSep then
+                        dbgWrite f2 ", "
+                    else
+                        f2
 
-        apply (keyToInspector key) f3
-        |> dbgWrite ": "
-        |> \x -> apply (valueToInspector value) x
-        |> \f4 -> (f4, Bool.true)
-    |> .0
-    |> dbgWrite "}"
+                apply (keyToInspector key) f3
+                |> dbgWrite ": "
+                |> \x -> apply (valueToInspector value) x
+                |> \f4 -> (f4, Bool.true)
+        |> .0
+        |> dbgWrite "}"
 
 dbgTag : Str, List (Inspector DbgFormatter) -> Inspector DbgFormatter
 dbgTag = \name, fields ->
     if List.isEmpty fields then
-        f0 <- custom
-        dbgWrite f0 name
+        custom \f0 ->
+            dbgWrite f0 name
     else
-        f0 <- custom
-        dbgWrite f0 "("
-        |> dbgWrite name
-        |> \f1 ->
-            f2, inspector <- List.walk fields f1
-            dbgWrite f2 " "
-            |> \x -> apply inspector x
-        |> dbgWrite ")"
+        custom \f0 ->
+            dbgWrite f0 "("
+            |> dbgWrite name
+            |> \f1 ->
+                List.walk fields f1 \f2, inspector ->
+                    dbgWrite f2 " "
+                    |> \x -> apply inspector x
+            |> dbgWrite ")"
 
 dbgTuple : List (Inspector DbgFormatter) -> Inspector DbgFormatter
 dbgTuple = \fields ->
-    f0 <- custom
-    dbgWrite f0 "("
-    |> \f1 ->
-        (f2, prependSep), inspector <- List.walk fields (f1, Bool.false)
-        f3 =
-            if prependSep then
-                dbgWrite f2 ", "
-            else
-                f2
+    custom \f0 ->
+        dbgWrite f0 "("
+        |> \f1 ->
+            List.walk fields (f1, Bool.false) \(f2, prependSep), inspector ->
+                f3 =
+                    if prependSep then
+                        dbgWrite f2 ", "
+                    else
+                        f2
 
-        apply inspector f3
-        |> \f4 -> (f4, Bool.true)
-    |> .0
-    |> dbgWrite ")"
+                apply inspector f3
+                |> \f4 -> (f4, Bool.true)
+        |> .0
+        |> dbgWrite ")"
 
 dbgRecord : List { key : Str, value : Inspector DbgFormatter } -> Inspector DbgFormatter
 dbgRecord = \fields ->
-    f0 <- custom
-    dbgWrite f0 "{"
-    |> \f1 ->
-        (f2, prependSep), { key, value } <- List.walk fields (f1, Bool.false)
-        f3 =
-            if prependSep then
-                dbgWrite f2 ", "
-            else
-                f2
+    custom \f0 ->
+        dbgWrite f0 "{"
+        |> \f1 ->
+            List.walk fields (f1, Bool.false) \(f2, prependSep), { key, value } ->
+                f3 =
+                    if prependSep then
+                        dbgWrite f2 ", "
+                    else
+                        f2
 
-        dbgWrite f3 key
-        |> dbgWrite ": "
-        |> \x -> apply value x
-        |> \f4 -> (f4, Bool.true)
-    |> .0
-    |> dbgWrite "}"
+                dbgWrite f3 key
+                |> dbgWrite ": "
+                |> \x -> apply value x
+                |> \f4 -> (f4, Bool.true)
+        |> .0
+        |> dbgWrite "}"
 
 dbgBool : Bool -> Inspector DbgFormatter
 dbgBool = \b ->
     if b then
-        f0 <- custom
-        dbgWrite f0 "Bool.true"
+        custom \f0 ->
+            dbgWrite f0 "Bool.true"
     else
-        f0 <- custom
-        dbgWrite f0 "Bool.false"
+        custom \f0 ->
+            dbgWrite f0 "Bool.false"
 
 dbgStr : Str -> Inspector DbgFormatter
 dbgStr = \s ->
-    f0 <- custom
-    f0
-    |> dbgWrite "\""
-    |> dbgWrite s # TODO: Should we be escaping strings for dbg/logging?
-    |> dbgWrite "\""
+    custom \f0 ->
+        f0
+        |> dbgWrite "\""
+        |> dbgWrite s # TODO: Should we be escaping strings for dbg/logging?
+        |> dbgWrite "\""
 
 dbgOpaque : * -> Inspector DbgFormatter
 dbgOpaque = \_ ->
-    f0 <- custom
-    dbgWrite f0 "<opaque>"
+    custom \f0 ->
+        dbgWrite f0 "<opaque>"
 
 dbgFunction : * -> Inspector DbgFormatter
 dbgFunction = \_ ->
-    f0 <- custom
-    dbgWrite f0 "<function>"
+    custom \f0 ->
+        dbgWrite f0 "<function>"
 
 dbgU8 : U8 -> Inspector DbgFormatter
 dbgU8 = \num ->
-    f0 <- custom
-    dbgWrite f0 (num |> Num.toStr)
+    custom \f0 ->
+        dbgWrite f0 (num |> Num.toStr)
 
 dbgI8 : I8 -> Inspector DbgFormatter
 dbgI8 = \num ->
-    f0 <- custom
-    dbgWrite f0 (num |> Num.toStr)
+    custom \f0 ->
+        dbgWrite f0 (num |> Num.toStr)
 
 dbgU16 : U16 -> Inspector DbgFormatter
 dbgU16 = \num ->
-    f0 <- custom
-    dbgWrite f0 (num |> Num.toStr)
+    custom \f0 ->
+        dbgWrite f0 (num |> Num.toStr)
 
 dbgI16 : I16 -> Inspector DbgFormatter
 dbgI16 = \num ->
-    f0 <- custom
-    dbgWrite f0 (num |> Num.toStr)
+    custom \f0 ->
+        dbgWrite f0 (num |> Num.toStr)
 
 dbgU32 : U32 -> Inspector DbgFormatter
 dbgU32 = \num ->
-    f0 <- custom
-    dbgWrite f0 (num |> Num.toStr)
+    custom \f0 ->
+        dbgWrite f0 (num |> Num.toStr)
 
 dbgI32 : I32 -> Inspector DbgFormatter
 dbgI32 = \num ->
-    f0 <- custom
-    dbgWrite f0 (num |> Num.toStr)
+    custom \f0 ->
+        dbgWrite f0 (num |> Num.toStr)
 
 dbgU64 : U64 -> Inspector DbgFormatter
 dbgU64 = \num ->
-    f0 <- custom
-    dbgWrite f0 (num |> Num.toStr)
+    custom \f0 ->
+        dbgWrite f0 (num |> Num.toStr)
 
 dbgI64 : I64 -> Inspector DbgFormatter
 dbgI64 = \num ->
-    f0 <- custom
-    dbgWrite f0 (num |> Num.toStr)
+    custom \f0 ->
+        dbgWrite f0 (num |> Num.toStr)
 
 dbgU128 : U128 -> Inspector DbgFormatter
 dbgU128 = \num ->
-    f0 <- custom
-    dbgWrite f0 (num |> Num.toStr)
+    custom \f0 ->
+        dbgWrite f0 (num |> Num.toStr)
 
 dbgI128 : I128 -> Inspector DbgFormatter
 dbgI128 = \num ->
-    f0 <- custom
-    dbgWrite f0 (num |> Num.toStr)
+    custom \f0 ->
+        dbgWrite f0 (num |> Num.toStr)
 
 dbgF32 : F32 -> Inspector DbgFormatter
 dbgF32 = \num ->
-    f0 <- custom
-    dbgWrite f0 (num |> Num.toStr)
+    custom \f0 ->
+        dbgWrite f0 (num |> Num.toStr)
 
 dbgF64 : F64 -> Inspector DbgFormatter
 dbgF64 = \num ->
-    f0 <- custom
-    dbgWrite f0 (num |> Num.toStr)
+    custom \f0 ->
+        dbgWrite f0 (num |> Num.toStr)
 
 dbgDec : Dec -> Inspector DbgFormatter
 dbgDec = \num ->
-    f0 <- custom
-    dbgWrite f0 (num |> Num.toStr)
+    custom \f0 ->
+        dbgWrite f0 (num |> Num.toStr)
 
 dbgWrite : DbgFormatter, Str -> DbgFormatter
 dbgWrite = \@DbgFormatter { data }, added ->

--- a/crates/compiler/builtins/roc/Set.roc
+++ b/crates/compiler/builtins/roc/Set.roc
@@ -62,8 +62,8 @@ hashSet = \hasher, @Set inner -> Hash.hash hasher inner
 
 toInspectorSet : Set k -> Inspector f where k implements Inspect & Hash & Eq, f implements InspectFormatter
 toInspectorSet = \set ->
-    fmt <- Inspect.custom
-    Inspect.apply (Inspect.set set walk Inspect.toInspector) fmt
+    Inspect.custom \fmt ->
+        Inspect.apply (Inspect.set set walk Inspect.toInspector) fmt
 
 ## Creates a new empty `Set`.
 ## ```roc

--- a/crates/compiler/can/src/desugar.rs
+++ b/crates/compiler/can/src/desugar.rs
@@ -12,6 +12,7 @@ use roc_parse::ast::{
     AssignedField, Collection, ModuleImportParams, OldRecordBuilderField, Pattern, StrLiteral,
     StrSegment, TypeAnnotation, ValueDef, WhenBranch,
 };
+use roc_problem::can::Problem;
 use roc_region::all::{LineInfo, Loc, Region};
 
 // BinOp precedence logic adapted from Gluon by Markus Westerlind
@@ -74,13 +75,14 @@ fn desugar_value_def<'a>(
     src: &'a str,
     line_info: &mut Option<LineInfo>,
     module_path: &str,
+    problems: &mut std::vec::Vec<Problem>,
 ) -> ValueDef<'a> {
     use ValueDef::*;
 
     match def {
         Body(loc_pattern, loc_expr) => Body(
-            desugar_loc_pattern(arena, loc_pattern, src, line_info, module_path),
-            desugar_expr(arena, loc_expr, src, line_info, module_path),
+            desugar_loc_pattern(arena, loc_pattern, src, line_info, module_path, problems),
+            desugar_expr(arena, loc_expr, src, line_info, module_path, problems),
         ),
         ann @ Annotation(_, _) => *ann,
         AnnotatedBody {
@@ -93,16 +95,29 @@ fn desugar_value_def<'a>(
             ann_pattern,
             ann_type,
             lines_between,
-            body_pattern: desugar_loc_pattern(arena, body_pattern, src, line_info, module_path),
-            body_expr: desugar_expr(arena, body_expr, src, line_info, module_path),
+            body_pattern: desugar_loc_pattern(
+                arena,
+                body_pattern,
+                src,
+                line_info,
+                module_path,
+                problems,
+            ),
+            body_expr: desugar_expr(arena, body_expr, src, line_info, module_path, problems),
         },
 
         Dbg {
             condition,
             preceding_comment,
         } => {
-            let desugared_condition =
-                &*arena.alloc(desugar_expr(arena, condition, src, line_info, module_path));
+            let desugared_condition = &*arena.alloc(desugar_expr(
+                arena,
+                condition,
+                src,
+                line_info,
+                module_path,
+                problems,
+            ));
             Dbg {
                 condition: desugared_condition,
                 preceding_comment: *preceding_comment,
@@ -112,8 +127,14 @@ fn desugar_value_def<'a>(
             condition,
             preceding_comment,
         } => {
-            let desugared_condition =
-                &*arena.alloc(desugar_expr(arena, condition, src, line_info, module_path));
+            let desugared_condition = &*arena.alloc(desugar_expr(
+                arena,
+                condition,
+                src,
+                line_info,
+                module_path,
+                problems,
+            ));
             Expect {
                 condition: desugared_condition,
                 preceding_comment: *preceding_comment,
@@ -123,8 +144,14 @@ fn desugar_value_def<'a>(
             condition,
             preceding_comment,
         } => {
-            let desugared_condition =
-                &*arena.alloc(desugar_expr(arena, condition, src, line_info, module_path));
+            let desugared_condition = &*arena.alloc(desugar_expr(
+                arena,
+                condition,
+                src,
+                line_info,
+                module_path,
+                problems,
+            ));
             ExpectFx {
                 condition: desugared_condition,
                 preceding_comment: *preceding_comment,
@@ -141,7 +168,14 @@ fn desugar_value_def<'a>(
                 params.map(|ModuleImportParams { before, params }| ModuleImportParams {
                     before,
                     params: params.map(|params| {
-                        desugar_field_collection(arena, *params, src, line_info, module_path)
+                        desugar_field_collection(
+                            arena,
+                            *params,
+                            src,
+                            line_info,
+                            module_path,
+                            problems,
+                        )
                     }),
                 });
 
@@ -174,7 +208,7 @@ fn desugar_value_def<'a>(
                 )),
                 lines_between: &[],
                 body_pattern: new_pat,
-                body_expr: desugar_expr(arena, stmt_expr, src, line_info, module_path),
+                body_expr: desugar_expr(arena, stmt_expr, src, line_info, module_path, problems),
             }
         }
     }
@@ -187,9 +221,17 @@ pub fn desugar_defs_node_values<'a>(
     line_info: &mut Option<LineInfo>,
     module_path: &str,
     top_level_def: bool,
+    problems: &mut std::vec::Vec<Problem>,
 ) {
     for value_def in defs.value_defs.iter_mut() {
-        *value_def = desugar_value_def(arena, arena.alloc(*value_def), src, line_info, module_path);
+        *value_def = desugar_value_def(
+            arena,
+            arena.alloc(*value_def),
+            src,
+            line_info,
+            module_path,
+            problems,
+        );
     }
 
     // `desugar_defs_node_values` is called recursively in `desugar_expr`
@@ -312,6 +354,7 @@ pub fn desugar_expr<'a>(
     src: &'a str,
     line_info: &mut Option<LineInfo>,
     module_path: &str,
+    problems: &mut std::vec::Vec<Problem>,
 ) -> &'a Loc<Expr<'a>> {
     match &loc_expr.value {
         Float(..)
@@ -344,6 +387,7 @@ pub fn desugar_expr<'a>(
                     src,
                     line_info,
                     module_path,
+                    problems,
                 )));
 
                 arena.alloc(Loc { region, value })
@@ -352,7 +396,7 @@ pub fn desugar_expr<'a>(
                 let region = loc_expr.region;
                 let new_lines = Vec::from_iter_in(
                     lines.iter().map(|segments| {
-                        desugar_str_segments(arena, segments, src, line_info, module_path)
+                        desugar_str_segments(arena, segments, src, line_info, module_path, problems)
                     }),
                     arena,
                 );
@@ -375,6 +419,7 @@ pub fn desugar_expr<'a>(
                     src,
                     line_info,
                     module_path,
+                    problems,
                 )
                 .value,
                 paths,
@@ -389,7 +434,8 @@ pub fn desugar_expr<'a>(
             target,
         } => {
             let intermediate = arena.alloc(Loc::at(loc_expr.region, **sub_expr));
-            let new_sub_loc_expr = desugar_expr(arena, intermediate, src, line_info, module_path);
+            let new_sub_loc_expr =
+                desugar_expr(arena, intermediate, src, line_info, module_path, problems);
             let new_sub_expr = arena.alloc(new_sub_loc_expr.value);
 
             arena.alloc(Loc::at(
@@ -413,6 +459,7 @@ pub fn desugar_expr<'a>(
                     src,
                     line_info,
                     module_path,
+                    problems,
                 )
                 .value,
                 paths,
@@ -424,7 +471,14 @@ pub fn desugar_expr<'a>(
             let mut new_items = Vec::with_capacity_in(items.len(), arena);
 
             for item in items.iter() {
-                new_items.push(desugar_expr(arena, item, src, line_info, module_path));
+                new_items.push(desugar_expr(
+                    arena,
+                    item,
+                    src,
+                    line_info,
+                    module_path,
+                    problems,
+                ));
             }
             let new_items = new_items.into_bump_slice();
             let value: Expr<'a> = List(items.replace_items(new_items));
@@ -435,7 +489,8 @@ pub fn desugar_expr<'a>(
             })
         }
         Record(fields) => {
-            let fields = desugar_field_collection(arena, *fields, src, line_info, module_path);
+            let fields =
+                desugar_field_collection(arena, *fields, src, line_info, module_path, problems);
             arena.alloc(Loc {
                 region: loc_expr.region,
                 value: Record(fields),
@@ -444,7 +499,7 @@ pub fn desugar_expr<'a>(
         Tuple(fields) => {
             let mut allocated = Vec::with_capacity_in(fields.len(), arena);
             for field in fields.iter() {
-                let expr = desugar_expr(arena, field, src, line_info, module_path);
+                let expr = desugar_expr(arena, field, src, line_info, module_path, problems);
                 allocated.push(expr);
             }
             let fields = fields.replace_items(allocated.into_bump_slice());
@@ -456,11 +511,12 @@ pub fn desugar_expr<'a>(
         RecordUpdate { fields, update } => {
             // NOTE the `update` field is always a `Var { .. }`, we only desugar it to get rid of
             // any spaces before/after
-            let new_update = desugar_expr(arena, update, src, line_info, module_path);
+            let new_update = desugar_expr(arena, update, src, line_info, module_path, problems);
 
             let mut allocated = Vec::with_capacity_in(fields.len(), arena);
             for field in fields.iter() {
-                let value = desugar_field(arena, &field.value, src, line_info, module_path);
+                let value =
+                    desugar_field(arena, &field.value, src, line_info, module_path, problems);
                 allocated.push(Loc {
                     value,
                     region: field.region,
@@ -479,8 +535,8 @@ pub fn desugar_expr<'a>(
         Closure(loc_patterns, loc_ret) => arena.alloc(Loc {
             region: loc_expr.region,
             value: Closure(
-                desugar_loc_patterns(arena, loc_patterns, src, line_info, module_path),
-                desugar_expr(arena, loc_ret, src, line_info, module_path),
+                desugar_loc_patterns(arena, loc_patterns, src, line_info, module_path, problems),
+                desugar_expr(arena, loc_ret, src, line_info, module_path, problems),
             ),
         }),
         Backpassing(loc_patterns, loc_body, loc_ret) => {
@@ -488,12 +544,19 @@ pub fn desugar_expr<'a>(
             //
             // loc_ret
 
-            // first desugar the body, because it may contain |>
-            let desugared_body = desugar_expr(arena, loc_body, src, line_info, module_path);
+            let problem_region = Region::span_across(
+                &Region::across_all(loc_patterns.iter().map(|loc_pattern| &loc_pattern.region)),
+                &loc_body.region,
+            );
+            problems.push(Problem::DeprecatedBackpassing(problem_region));
 
-            let desugared_ret = desugar_expr(arena, loc_ret, src, line_info, module_path);
+            // first desugar the body, because it may contain |>
+            let desugared_body =
+                desugar_expr(arena, loc_body, src, line_info, module_path, problems);
+
+            let desugared_ret = desugar_expr(arena, loc_ret, src, line_info, module_path, problems);
             let desugared_loc_patterns =
-                desugar_loc_patterns(arena, loc_patterns, src, line_info, module_path);
+                desugar_loc_patterns(arena, loc_patterns, src, line_info, module_path, problems);
             let closure = Expr::Closure(desugared_loc_patterns, desugared_ret);
             let loc_closure = Loc::at(loc_expr.region, closure);
 
@@ -529,7 +592,7 @@ pub fn desugar_expr<'a>(
         RecordBuilder { mapper, fields } => {
             // NOTE the `mapper` is always a `Var { .. }`, we only desugar it to get rid of
             // any spaces before/after
-            let new_mapper = desugar_expr(arena, mapper, src, line_info, module_path);
+            let new_mapper = desugar_expr(arena, mapper, src, line_info, module_path, problems);
 
             if fields.is_empty() {
                 return arena.alloc(Loc {
@@ -553,7 +616,8 @@ pub fn desugar_expr<'a>(
 
             for field in fields.items {
                 let (name, value, ignored) =
-                    match desugar_field(arena, &field.value, src, line_info, module_path) {
+                    match desugar_field(arena, &field.value, src, line_info, module_path, problems)
+                    {
                         AssignedField::RequiredValue(loc_name, _, loc_val) => {
                             (loc_name, loc_val, false)
                         }
@@ -791,11 +855,20 @@ pub fn desugar_expr<'a>(
             src,
             line_info,
             module_path,
+            problems,
         ),
         Defs(defs, loc_ret) => {
             let mut defs = (*defs).clone();
-            desugar_defs_node_values(arena, &mut defs, src, line_info, module_path, false);
-            let loc_ret = desugar_expr(arena, loc_ret, src, line_info, module_path);
+            desugar_defs_node_values(
+                arena,
+                &mut defs,
+                src,
+                line_info,
+                module_path,
+                false,
+                problems,
+            );
+            let loc_ret = desugar_expr(arena, loc_ret, src, line_info, module_path, problems);
 
             arena.alloc(Loc::at(loc_expr.region, Defs(arena.alloc(defs), loc_ret)))
         }
@@ -827,14 +900,21 @@ pub fn desugar_expr<'a>(
                     }
                 };
 
-                desugared_args.push(desugar_expr(arena, arg, src, line_info, module_path));
+                desugared_args.push(desugar_expr(
+                    arena,
+                    arg,
+                    src,
+                    line_info,
+                    module_path,
+                    problems,
+                ));
             }
 
             let desugared_args = desugared_args.into_bump_slice();
 
             let mut apply: &Loc<Expr> = arena.alloc(Loc {
                 value: Apply(
-                    desugar_expr(arena, loc_fn, src, line_info, module_path),
+                    desugar_expr(arena, loc_fn, src, line_info, module_path, problems),
                     desugared_args,
                     *called_via,
                 ),
@@ -846,7 +926,8 @@ pub fn desugar_expr<'a>(
 
                 Some(apply_exprs) => {
                     for expr in apply_exprs {
-                        let desugared_expr = desugar_expr(arena, expr, src, line_info, module_path);
+                        let desugared_expr =
+                            desugar_expr(arena, expr, src, line_info, module_path, problems);
 
                         let args = std::slice::from_ref(arena.alloc(apply));
 
@@ -867,17 +948,31 @@ pub fn desugar_expr<'a>(
                 src,
                 line_info,
                 module_path,
+                problems,
             ));
             let mut desugared_branches = Vec::with_capacity_in(branches.len(), arena);
 
             for branch in branches.iter() {
                 let desugared_expr =
-                    desugar_expr(arena, &branch.value, src, line_info, module_path);
-                let desugared_patterns =
-                    desugar_loc_patterns(arena, branch.patterns, src, line_info, module_path);
+                    desugar_expr(arena, &branch.value, src, line_info, module_path, problems);
+                let desugared_patterns = desugar_loc_patterns(
+                    arena,
+                    branch.patterns,
+                    src,
+                    line_info,
+                    module_path,
+                    problems,
+                );
 
                 let desugared_guard = if let Some(guard) = &branch.guard {
-                    Some(*desugar_expr(arena, guard, src, line_info, module_path))
+                    Some(*desugar_expr(
+                        arena,
+                        guard,
+                        src,
+                        line_info,
+                        module_path,
+                        problems,
+                    ))
                 } else {
                     None
                 };
@@ -915,8 +1010,14 @@ pub fn desugar_expr<'a>(
                 },
             };
             let loc_fn_var = arena.alloc(Loc { region, value });
-            let desugared_args =
-                arena.alloc([desugar_expr(arena, loc_arg, src, line_info, module_path)]);
+            let desugared_args = arena.alloc([desugar_expr(
+                arena,
+                loc_arg,
+                src,
+                line_info,
+                module_path,
+                problems,
+            )]);
 
             arena.alloc(Loc {
                 value: Apply(loc_fn_var, desugared_args, CalledVia::UnaryOp(op)),
@@ -935,6 +1036,7 @@ pub fn desugar_expr<'a>(
                 src,
                 line_info,
                 module_path,
+                problems,
             )
         }
         ParensAround(expr) => {
@@ -947,6 +1049,7 @@ pub fn desugar_expr<'a>(
                 src,
                 line_info,
                 module_path,
+                problems,
             );
 
             arena.alloc(Loc {
@@ -962,14 +1065,15 @@ pub fn desugar_expr<'a>(
                 src,
                 line_info,
                 module_path,
+                problems,
             ));
 
             let mut desugared_if_thens = Vec::with_capacity_in(if_thens.len(), arena);
 
             for (condition, then_branch) in if_thens.iter() {
                 desugared_if_thens.push((
-                    *desugar_expr(arena, condition, src, line_info, module_path),
-                    *desugar_expr(arena, then_branch, src, line_info, module_path),
+                    *desugar_expr(arena, condition, src, line_info, module_path, problems),
+                    *desugar_expr(arena, then_branch, src, line_info, module_path, problems),
                 ));
             }
 
@@ -979,14 +1083,21 @@ pub fn desugar_expr<'a>(
             })
         }
         Expect(condition, continuation) => {
-            let desugared_condition =
-                &*arena.alloc(desugar_expr(arena, condition, src, line_info, module_path));
+            let desugared_condition = &*arena.alloc(desugar_expr(
+                arena,
+                condition,
+                src,
+                line_info,
+                module_path,
+                problems,
+            ));
             let desugared_continuation = &*arena.alloc(desugar_expr(
                 arena,
                 continuation,
                 src,
                 line_info,
                 module_path,
+                problems,
             ));
             arena.alloc(Loc {
                 value: Expect(desugared_condition, desugared_continuation),
@@ -1002,6 +1113,7 @@ pub fn desugar_expr<'a>(
                 src,
                 line_info,
                 module_path,
+                problems,
             ));
 
             let region = condition.region;
@@ -1014,8 +1126,14 @@ pub fn desugar_expr<'a>(
                 value: inspect_fn,
                 region,
             });
-            let desugared_inspect_args =
-                arena.alloc([desugar_expr(arena, condition, src, line_info, module_path)]);
+            let desugared_inspect_args = arena.alloc([desugar_expr(
+                arena,
+                condition,
+                src,
+                line_info,
+                module_path,
+                problems,
+            )]);
 
             let dbg_str = arena.alloc(Loc {
                 value: Apply(loc_inspect_fn_var, desugared_inspect_args, CalledVia::Space),
@@ -1060,6 +1178,7 @@ fn desugar_str_segments<'a>(
     src: &'a str,
     line_info: &mut Option<LineInfo>,
     module_path: &str,
+    problems: &mut std::vec::Vec<Problem>,
 ) -> &'a [StrSegment<'a>] {
     Vec::from_iter_in(
         segments.iter().map(|segment| match segment {
@@ -1076,6 +1195,7 @@ fn desugar_str_segments<'a>(
                     src,
                     line_info,
                     module_path,
+                    problems,
                 );
                 StrSegment::DeprecatedInterpolated(Loc {
                     region: loc_desugared.region,
@@ -1092,6 +1212,7 @@ fn desugar_str_segments<'a>(
                     src,
                     line_info,
                     module_path,
+                    problems,
                 );
                 StrSegment::Interpolated(Loc {
                     region: loc_desugared.region,
@@ -1110,11 +1231,12 @@ fn desugar_field_collection<'a>(
     src: &'a str,
     line_info: &mut Option<LineInfo>,
     module_path: &str,
+    problems: &mut std::vec::Vec<Problem>,
 ) -> Collection<'a, Loc<AssignedField<'a, Expr<'a>>>> {
     let mut allocated = Vec::with_capacity_in(fields.len(), arena);
 
     for field in fields.iter() {
-        let value = desugar_field(arena, &field.value, src, line_info, module_path);
+        let value = desugar_field(arena, &field.value, src, line_info, module_path, problems);
 
         allocated.push(Loc::at(field.region, value));
     }
@@ -1128,6 +1250,7 @@ fn desugar_field<'a>(
     src: &'a str,
     line_info: &mut Option<LineInfo>,
     module_path: &str,
+    problems: &mut std::vec::Vec<Problem>,
 ) -> AssignedField<'a, Expr<'a>> {
     use roc_parse::ast::AssignedField::*;
 
@@ -1138,7 +1261,7 @@ fn desugar_field<'a>(
                 region: loc_str.region,
             },
             spaces,
-            desugar_expr(arena, loc_expr, src, line_info, module_path),
+            desugar_expr(arena, loc_expr, src, line_info, module_path, problems),
         ),
         OptionalValue(loc_str, spaces, loc_expr) => OptionalValue(
             Loc {
@@ -1146,7 +1269,7 @@ fn desugar_field<'a>(
                 region: loc_str.region,
             },
             spaces,
-            desugar_expr(arena, loc_expr, src, line_info, module_path),
+            desugar_expr(arena, loc_expr, src, line_info, module_path, problems),
         ),
         IgnoredValue(loc_str, spaces, loc_expr) => IgnoredValue(
             Loc {
@@ -1154,7 +1277,7 @@ fn desugar_field<'a>(
                 region: loc_str.region,
             },
             spaces,
-            desugar_expr(arena, loc_expr, src, line_info, module_path),
+            desugar_expr(arena, loc_expr, src, line_info, module_path, problems),
         ),
         LabelOnly(loc_str) => {
             // Desugar { x } into { x: x }
@@ -1172,11 +1295,22 @@ fn desugar_field<'a>(
                     region: loc_str.region,
                 },
                 &[],
-                desugar_expr(arena, arena.alloc(loc_expr), src, line_info, module_path),
+                desugar_expr(
+                    arena,
+                    arena.alloc(loc_expr),
+                    src,
+                    line_info,
+                    module_path,
+                    problems,
+                ),
             )
         }
-        SpaceBefore(field, _spaces) => desugar_field(arena, field, src, line_info, module_path),
-        SpaceAfter(field, _spaces) => desugar_field(arena, field, src, line_info, module_path),
+        SpaceBefore(field, _spaces) => {
+            desugar_field(arena, field, src, line_info, module_path, problems)
+        }
+        SpaceAfter(field, _spaces) => {
+            desugar_field(arena, field, src, line_info, module_path, problems)
+        }
 
         Malformed(string) => Malformed(string),
     }
@@ -1188,11 +1322,19 @@ fn desugar_loc_patterns<'a>(
     src: &'a str,
     line_info: &mut Option<LineInfo>,
     module_path: &str,
+    problems: &mut std::vec::Vec<Problem>,
 ) -> &'a [Loc<Pattern<'a>>] {
     Vec::from_iter_in(
         loc_patterns.iter().map(|loc_pattern| Loc {
             region: loc_pattern.region,
-            value: desugar_pattern(arena, loc_pattern.value, src, line_info, module_path),
+            value: desugar_pattern(
+                arena,
+                loc_pattern.value,
+                src,
+                line_info,
+                module_path,
+                problems,
+            ),
         }),
         arena,
     )
@@ -1205,10 +1347,18 @@ fn desugar_loc_pattern<'a>(
     src: &'a str,
     line_info: &mut Option<LineInfo>,
     module_path: &str,
+    problems: &mut std::vec::Vec<Problem>,
 ) -> &'a Loc<Pattern<'a>> {
     arena.alloc(Loc {
         region: loc_pattern.region,
-        value: desugar_pattern(arena, loc_pattern.value, src, line_info, module_path),
+        value: desugar_pattern(
+            arena,
+            loc_pattern.value,
+            src,
+            line_info,
+            module_path,
+            problems,
+        ),
     })
 }
 
@@ -1218,6 +1368,7 @@ fn desugar_pattern<'a>(
     src: &'a str,
     line_info: &mut Option<LineInfo>,
     module_path: &str,
+    problems: &mut std::vec::Vec<Problem>,
 ) -> Pattern<'a> {
     use roc_parse::ast::Pattern::*;
 
@@ -1241,7 +1392,14 @@ fn desugar_pattern<'a>(
             let desugared_arg_patterns = Vec::from_iter_in(
                 arg_patterns.iter().map(|arg_pattern| Loc {
                     region: arg_pattern.region,
-                    value: desugar_pattern(arena, arg_pattern.value, src, line_info, module_path),
+                    value: desugar_pattern(
+                        arena,
+                        arg_pattern.value,
+                        src,
+                        line_info,
+                        module_path,
+                        problems,
+                    ),
                 }),
                 arena,
             )
@@ -1252,8 +1410,14 @@ fn desugar_pattern<'a>(
         RecordDestructure(field_patterns) => {
             let mut allocated = Vec::with_capacity_in(field_patterns.len(), arena);
             for field_pattern in field_patterns.iter() {
-                let value =
-                    desugar_pattern(arena, field_pattern.value, src, line_info, module_path);
+                let value = desugar_pattern(
+                    arena,
+                    field_pattern.value,
+                    src,
+                    line_info,
+                    module_path,
+                    problems,
+                );
                 allocated.push(Loc {
                     value,
                     region: field_pattern.region,
@@ -1265,15 +1429,17 @@ fn desugar_pattern<'a>(
         }
         RequiredField(name, field_pattern) => RequiredField(
             name,
-            desugar_loc_pattern(arena, field_pattern, src, line_info, module_path),
+            desugar_loc_pattern(arena, field_pattern, src, line_info, module_path, problems),
         ),
-        OptionalField(name, expr) => {
-            OptionalField(name, desugar_expr(arena, expr, src, line_info, module_path))
-        }
+        OptionalField(name, expr) => OptionalField(
+            name,
+            desugar_expr(arena, expr, src, line_info, module_path, problems),
+        ),
         Tuple(patterns) => {
             let mut allocated = Vec::with_capacity_in(patterns.len(), arena);
             for pattern in patterns.iter() {
-                let value = desugar_pattern(arena, pattern.value, src, line_info, module_path);
+                let value =
+                    desugar_pattern(arena, pattern.value, src, line_info, module_path, problems);
                 allocated.push(Loc {
                     value,
                     region: pattern.region,
@@ -1286,7 +1452,8 @@ fn desugar_pattern<'a>(
         List(patterns) => {
             let mut allocated = Vec::with_capacity_in(patterns.len(), arena);
             for pattern in patterns.iter() {
-                let value = desugar_pattern(arena, pattern.value, src, line_info, module_path);
+                let value =
+                    desugar_pattern(arena, pattern.value, src, line_info, module_path, problems);
                 allocated.push(Loc {
                     value,
                     region: pattern.region,
@@ -1297,14 +1464,14 @@ fn desugar_pattern<'a>(
             List(patterns)
         }
         As(sub_pattern, symbol) => As(
-            desugar_loc_pattern(arena, sub_pattern, src, line_info, module_path),
+            desugar_loc_pattern(arena, sub_pattern, src, line_info, module_path, problems),
             symbol,
         ),
         SpaceBefore(sub_pattern, _spaces) => {
-            desugar_pattern(arena, *sub_pattern, src, line_info, module_path)
+            desugar_pattern(arena, *sub_pattern, src, line_info, module_path, problems)
         }
         SpaceAfter(sub_pattern, _spaces) => {
-            desugar_pattern(arena, *sub_pattern, src, line_info, module_path)
+            desugar_pattern(arena, *sub_pattern, src, line_info, module_path, problems)
         }
     }
 }
@@ -1425,6 +1592,7 @@ fn binop_to_function(binop: BinOp) -> (&'static str, &'static str) {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn desugar_bin_ops<'a>(
     arena: &'a Bump,
     whole_region: Region,
@@ -1433,19 +1601,27 @@ fn desugar_bin_ops<'a>(
     src: &'a str,
     line_info: &mut Option<LineInfo>,
     module_path: &str,
+    problems: &mut std::vec::Vec<Problem>,
 ) -> &'a Loc<Expr<'a>> {
     let mut arg_stack: Vec<&'a Loc<Expr>> = Vec::with_capacity_in(lefts.len() + 1, arena);
     let mut op_stack: Vec<Loc<BinOp>> = Vec::with_capacity_in(lefts.len(), arena);
 
     for (loc_expr, loc_op) in lefts {
-        arg_stack.push(desugar_expr(arena, loc_expr, src, line_info, module_path));
+        arg_stack.push(desugar_expr(
+            arena,
+            loc_expr,
+            src,
+            line_info,
+            module_path,
+            problems,
+        ));
         match run_binop_step(arena, whole_region, &mut arg_stack, &mut op_stack, *loc_op) {
             Err(problem) => return problem,
             Ok(()) => continue,
         }
     }
 
-    let mut expr = desugar_expr(arena, right, src, line_info, module_path);
+    let mut expr = desugar_expr(arena, right, src, line_info, module_path, problems);
 
     for (left, loc_op) in arg_stack.into_iter().zip(op_stack.into_iter()).rev() {
         expr = arena.alloc(new_op_call_expr(arena, left, loc_op, expr));

--- a/crates/compiler/can/src/module.rs
+++ b/crates/compiler/can/src/module.rs
@@ -337,7 +337,15 @@ pub fn canonicalize_module_defs<'a>(
     // operators, and then again on *their* nested operators, ultimately applying the
     // rules multiple times unnecessarily.
 
-    crate::desugar::desugar_defs_node_values(arena, loc_defs, src, &mut None, module_path, true);
+    crate::desugar::desugar_defs_node_values(
+        arena,
+        loc_defs,
+        src,
+        &mut None,
+        module_path,
+        true,
+        &mut env.problems,
+    );
 
     let mut rigid_variables = RigidVariables::default();
 

--- a/crates/compiler/can/tests/helpers/mod.rs
+++ b/crates/compiler/can/tests/helpers/mod.rs
@@ -59,6 +59,7 @@ pub fn can_expr_with(arena: &Bump, home: ModuleId, expr_str: &str) -> CanExprOut
         expr_str,
         &mut None,
         arena.alloc("TestPath"),
+        &mut Default::default(),
     );
 
     let mut scope = Scope::new(

--- a/crates/compiler/can/tests/test_suffixed.rs
+++ b/crates/compiler/can/tests/test_suffixed.rs
@@ -12,7 +12,15 @@ mod suffixed_tests {
         ($src:expr) => {{
             let arena = &Bump::new();
             let mut defs = parse_defs_with(arena, indoc!($src)).unwrap();
-            desugar_defs_node_values(arena, &mut defs, $src, &mut None, "test.roc", true);
+            desugar_defs_node_values(
+                arena,
+                &mut defs,
+                $src,
+                &mut None,
+                "test.roc",
+                true,
+                &mut Default::default(),
+            );
 
             let snapshot = format!("{:#?}", &defs);
             println!("{}", snapshot);

--- a/crates/compiler/load/tests/helpers/mod.rs
+++ b/crates/compiler/load/tests/helpers/mod.rs
@@ -174,6 +174,7 @@ pub fn can_expr_with<'a>(
         expr_str,
         &mut None,
         arena.alloc("TestPath"),
+        &mut Default::default(),
     );
 
     let mut scope = Scope::new(

--- a/crates/compiler/module/src/called_via.rs
+++ b/crates/compiler/module/src/called_via.rs
@@ -119,6 +119,23 @@ impl std::fmt::Display for UnaryOp {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Suffix {
+    /// (!), e.g. (Stdin.line!)
+    Bang,
+    /// (?), e.g. (parseData? data)
+    Question,
+}
+
+impl std::fmt::Display for Suffix {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Suffix::Bang => write!(f, "!"),
+            Suffix::Question => write!(f, "?"),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum BinOp {
     // highest precedence
     Caret,

--- a/crates/compiler/problem/src/can.rs
+++ b/crates/compiler/problem/src/can.rs
@@ -54,6 +54,7 @@ pub enum Problem {
         new_symbol: Symbol,
         existing_symbol_region: Region,
     },
+    DeprecatedBackpassing(Region),
     /// First symbol is the name of the closure with that argument
     /// Bool is whether the closure is anonymous
     /// Second symbol is the name of the argument that is unused
@@ -257,6 +258,7 @@ impl Problem {
             Problem::ExplicitBuiltinImport(_, _) => Warning,
             Problem::ExplicitBuiltinTypeImport(_, _) => Warning,
             Problem::ImportShadowsSymbol { .. } => RuntimeError,
+            Problem::DeprecatedBackpassing(_) => Warning,
             Problem::ExposedButNotDefined(_) => RuntimeError,
             Problem::UnknownGeneratesWith(_) => RuntimeError,
             Problem::UnusedArgument(_, _, _, _) => Warning,
@@ -340,6 +342,7 @@ impl Problem {
             | Problem::ExplicitBuiltinImport(_, region)
             | Problem::ExplicitBuiltinTypeImport(_, region)
             | Problem::ImportShadowsSymbol { region, .. }
+            | Problem::DeprecatedBackpassing(region)
             | Problem::UnknownGeneratesWith(Loc { region, .. })
             | Problem::UnusedArgument(_, _, _, region)
             | Problem::UnusedBranchDef(_, region)

--- a/crates/compiler/test_gen/src/gen_primitives.rs
+++ b/crates/compiler/test_gen/src/gen_primitives.rs
@@ -2480,39 +2480,6 @@ fn expanded_result() {
 }
 
 #[test]
-#[cfg(any(feature = "gen-llvm", feature = "gen-wasm", feature = "gen-dev"))]
-fn backpassing_result() {
-    assert_evals_to!(
-        indoc!(
-            r#"
-            app "test" provides [main] to "./platform"
-
-            a : Result I64 Str
-            a = Ok 1
-
-            f = \x -> Ok (x + 1)
-            g = \y -> Ok (y * 2)
-
-            main : I64
-            main =
-                helper =
-                    x <- Result.try a
-                    y <- Result.try (f x)
-                    z <- Result.try (g y)
-
-                    Ok z
-
-                helper
-                    |> Result.withDefault 0
-
-            "#
-        ),
-        4,
-        i64
-    );
-}
-
-#[test]
 #[cfg(any(feature = "gen-llvm", feature = "gen-wasm"))]
 #[should_panic(expected = "Shadowing { original_region: @55-56, shadow: @72-73 Ident")]
 fn function_malformed_pattern() {

--- a/crates/compiler/test_mono/src/tests.rs
+++ b/crates/compiler/test_mono/src/tests.rs
@@ -3389,8 +3389,8 @@ fn inspect_custom_type() {
 
         myToInspector : HelloWorld -> Inspector f where f implements InspectFormatter
         myToInspector = \@HellowWorld {} ->
-            fmt <- Inspect.custom
-            Inspect.apply (Inspect.str "Hello, World!\n") fmt
+            Inspect.custom \fmt ->
+                Inspect.apply (Inspect.str "Hello, World!\n") fmt
 
         main =
             Inspect.inspect (@HelloWorld {})

--- a/crates/reporting/src/error/canonicalize.rs
+++ b/crates/reporting/src/error/canonicalize.rs
@@ -1,4 +1,5 @@
 use roc_collections::all::MutSet;
+use roc_module::called_via::Suffix;
 use roc_module::ident::{Ident, Lowercase, ModuleName};
 use roc_module::symbol::DERIVABLE_ABILITIES;
 use roc_problem::can::PrecedenceProblem::BothNonAssociative;
@@ -246,6 +247,26 @@ pub fn can_problem<'b>(
             title = DUPLICATE_NAME.to_string();
         }
 
+        Problem::DeprecatedBackpassing(region) => {
+            doc = alloc.stack([
+                alloc.concat([
+                    alloc.reflow("Backpassing ("),
+                    alloc.backpassing_arrow(),
+                    alloc.reflow(") like this will soon be deprecated:"),
+                ]),
+                alloc.region(lines.convert_region(region), severity),
+                alloc.concat([
+                    alloc.reflow("You should use a "),
+                    alloc.suffix(Suffix::Bang),
+                    alloc.reflow(" for awaiting tasks or a "),
+                    alloc.suffix(Suffix::Question),
+                    alloc.reflow(" for trying results, and functions everywhere else."),
+                ]),
+            ]);
+
+            title = "BACKPASSING DEPRECATED".to_string();
+        }
+
         Problem::DefsOnlyUsedInRecursion(1, region) => {
             doc = alloc.stack([
                 alloc.reflow("This definition is only used in recursion with itself:"),
@@ -270,7 +291,7 @@ pub fn can_problem<'b>(
                 ),
             ]);
 
-            title = "DEFINITIONs ONLY USED IN RECURSION".to_string();
+            title = "DEFINITIONS ONLY USED IN RECURSION".to_string();
         }
         Problem::ExposedButNotDefined(symbol) => {
             doc = alloc.stack([

--- a/crates/reporting/src/error/type.rs
+++ b/crates/reporting/src/error/type.rs
@@ -1265,7 +1265,7 @@ fn to_expr_report<'b>(
                                     alloc.concat([
                                         alloc.tip(),
                                         alloc.reflow("Remove "),
-                                        alloc.keyword("<-"),
+                                        alloc.backpassing_arrow(),
                                         alloc.reflow(" to assign the field directly.")
                                     ])
                                 }
@@ -1273,7 +1273,7 @@ fn to_expr_report<'b>(
                                     alloc.concat([
                                         alloc.note(""),
                                         alloc.reflow("Record builders need a mapper function before the "),
-                                        alloc.keyword("<-"),
+                                        alloc.backpassing_arrow(),
                                         alloc.reflow(" to combine fields together with.")
                                     ])
                                 }

--- a/crates/reporting/src/report.rs
+++ b/crates/reporting/src/report.rs
@@ -509,6 +509,10 @@ impl<'a> RocDocAllocator<'a> {
         self.text(name).annotate(Annotation::Shorthand)
     }
 
+    pub fn backpassing_arrow(&'a self) -> DocBuilder<'a, Self, Annotation> {
+        self.text("<-").annotate(Annotation::BinOp)
+    }
+
     pub fn binop(
         &'a self,
         content: roc_module::called_via::BinOp,
@@ -519,6 +523,13 @@ impl<'a> RocDocAllocator<'a> {
     pub fn unop(
         &'a self,
         content: roc_module::called_via::UnaryOp,
+    ) -> DocBuilder<'a, Self, Annotation> {
+        self.text(content.to_string()).annotate(Annotation::UnaryOp)
+    }
+
+    pub fn suffix(
+        &'a self,
+        content: roc_module::called_via::Suffix,
     ) -> DocBuilder<'a, Self, Annotation> {
         self.text(content.to_string()).annotate(Annotation::UnaryOp)
     }

--- a/examples/Community.roc
+++ b/examples/Community.roc
@@ -55,27 +55,28 @@ addFriend = \@Community { people, friends }, from, to ->
 walkFriendNames : Community, state, (state, Str, Set Str -> state) -> state
 walkFriendNames = \@Community { people, friends }, s0, nextFn ->
     (out, _) =
-        (s1, id), friendSet <- List.walk friends (s0, 0)
-        (@Person person) =
-            when List.get people id is
-                Ok v -> v
-                Err _ -> crash "Unknown Person"
-        personName =
-            person.firstName
-            |> Str.concat " "
-            |> Str.concat person.lastName
-
-        friendNames =
-            friendsSet, friendId <- Set.walk friendSet (Set.empty {})
-            (@Person friend) =
-                when List.get people friendId is
+        List.walk friends (s0, 0) \(s1, id), friendSet ->
+            (@Person person) =
+                when List.get people id is
                     Ok v -> v
                     Err _ -> crash "Unknown Person"
-            friendName =
-                friend.firstName
+            personName =
+                person.firstName
                 |> Str.concat " "
-                |> Str.concat friend.lastName
-            Set.insert friendsSet friendName
+                |> Str.concat person.lastName
 
-        (nextFn s1 personName friendNames, id + 1)
+            friendNames =
+                Set.walk friendSet (Set.empty {}) \friendsSet, friendId ->
+                    (@Person friend) =
+                        when List.get people friendId is
+                            Ok v -> v
+                            Err _ -> crash "Unknown Person"
+                    friendName =
+                        friend.firstName
+                        |> Str.concat " "
+                        |> Str.concat friend.lastName
+                    Set.insert friendsSet friendName
+
+            (nextFn s1 personName friendNames, id + 1)
+
     out

--- a/examples/cli/false-interpreter/platform/File.roc
+++ b/examples/cli/false-interpreter/platform/File.roc
@@ -22,7 +22,8 @@ close = \@Handle handle -> Effect.after (Effect.closeFile handle) Task.succeed
 
 withOpen : Str, (Handle -> Task {} a) -> Task {} a
 withOpen = \path, callback ->
-    handle <- Task.await (open path)
-    result <- Task.attempt (callback handle)
-    {} <- Task.await (close handle)
+    handle = open! path
+    result = callback handle |> Task.result!
+    close! handle
+
     Task.fromResult result

--- a/examples/cli/false-interpreter/platform/Task.roc
+++ b/examples/cli/false-interpreter/platform/Task.roc
@@ -1,4 +1,14 @@
-module [Task, succeed, fail, await, map, onFail, attempt, fromResult, loop]
+module [
+    Task,
+    succeed,
+    fail,
+    await,
+    map,
+    onFail,
+    attempt,
+    fromResult,
+    loop,
+]
 
 import pf.Effect
 
@@ -66,3 +76,9 @@ map = \effect, transform ->
             when result is
                 Ok a -> Task.succeed (transform a)
                 Err err -> Task.fail err
+
+result : Task ok err -> Task (Result ok err) *
+result = \effect ->
+    Effect.after
+        effect
+        \result -> Task.succeed result

--- a/examples/virtual-dom-wip/platform/Html/Internal/Client.roc
+++ b/examples/virtual-dom-wip/platform/Html/Internal/Client.roc
@@ -88,13 +88,12 @@ initClientApp = \json, app ->
         initClientAppHelp json app
 
     # Call out to JS to patch the DOM, attaching the event listeners
-    _ <- applyPatches patches |> Effect.after
-
-    Effect.always {
-        app,
-        state,
-        rendered,
-    }
+    Effect.after (applyPatches patches) \_ ->
+        Effect.always {
+            app,
+            state,
+            rendered,
+        }
 
 # Testable helper function to initialise the app
 initClientAppHelp : List U8, App state initData -> { state, rendered : RenderedTree state, patches : List Patch } where initData implements Decoding
@@ -222,16 +221,16 @@ dispatchEvent = \platformState, eventData, handlerId ->
             { rendered: newRendered, patches } =
                 diff { rendered, patches: [] } newViewUnrendered
 
-            _ <- applyPatches patches |> Effect.after
-            Effect.always {
-                platformState: {
-                    app,
-                    state: newState,
-                    rendered: newRendered,
-                },
-                stopPropagation,
-                preventDefault,
-            }
+            Effect.after (applyPatches patches) \_ ->
+                Effect.always {
+                    platformState: {
+                        app,
+                        state: newState,
+                        rendered: newRendered,
+                    },
+                    stopPropagation,
+                    preventDefault,
+                }
 
         None ->
             Effect.always { platformState, stopPropagation, preventDefault }

--- a/examples/virtual-dom-wip/platform/Json.roc
+++ b/examples/virtual-dom-wip/platform/Json.roc
@@ -540,32 +540,35 @@ expect
 decodeTuple = \initialState, stepElem, finalizer -> Decode.custom \initialBytes, @Json {} ->
         # NB: the stepper function must be passed explicitly until #2894 is resolved.
         decodeElems = \stepper, state, index, bytes ->
-            { val: newState, rest: beforeCommaOrBreak } <- tryDecode
-                    (
-                        when stepper state index is
-                            TooLong ->
-                                { rest: beforeCommaOrBreak } <- bytes |> anything |> tryDecode
-                                { result: Ok state, rest: beforeCommaOrBreak }
+            (
+                when stepper state index is
+                    TooLong ->
+                        bytes
+                        |> anything
+                        |> tryDecode \{ rest: beforeCommaOrBreak } ->
+                            { result: Ok state, rest: beforeCommaOrBreak }
 
-                            Next decoder ->
-                                Decode.decodeWith bytes decoder json
-                    )
+                    Next decoder ->
+                        Decode.decodeWith bytes decoder json
+            )
+            |> tryDecode \{ val: newState, rest: beforeCommaOrBreak } ->
+                { result: commaResult, rest: nextBytes } = comma beforeCommaOrBreak
 
-            { result: commaResult, rest: nextBytes } = comma beforeCommaOrBreak
+                when commaResult is
+                    Ok {} -> decodeElems stepElem newState (index + 1) nextBytes
+                    Err _ -> { result: Ok newState, rest: nextBytes }
 
-            when commaResult is
-                Ok {} -> decodeElems stepElem newState (index + 1) nextBytes
-                Err _ -> { result: Ok newState, rest: nextBytes }
-
-        { rest: afterBracketBytes } <- initialBytes |> openBracket |> tryDecode
-
-        { val: endStateResult, rest: beforeClosingBracketBytes } <- decodeElems stepElem initialState 0 afterBracketBytes |> tryDecode
-
-        { rest: afterTupleBytes } <- beforeClosingBracketBytes |> closingBracket |> tryDecode
-
-        when finalizer endStateResult is
-            Ok val -> { result: Ok val, rest: afterTupleBytes }
-            Err e -> { result: Err e, rest: afterTupleBytes }
+        initialBytes
+        |> openBracket
+        |> tryDecode \{ rest: afterBracketBytes } ->
+            decodeElems stepElem initialState 0 afterBracketBytes
+            |> tryDecode \{ val: endStateResult, rest: beforeClosingBracketBytes } ->
+                beforeClosingBracketBytes
+                |> closingBracket
+                |> tryDecode \{ rest: afterTupleBytes } ->
+                    when finalizer endStateResult is
+                        Ok val -> { result: Ok val, rest: afterTupleBytes }
+                        Err e -> { result: Err e, rest: afterTupleBytes }
 
 # Test decode of tuple
 expect
@@ -1225,44 +1228,42 @@ decodeRecord = \initialState, stepField, finalizer -> Decode.custom \bytes, @Jso
 
                 Ok objectName ->
                     # Decode the json value
-                    { val: updatedRecord, rest: bytesAfterValue } <-
-                        (
-                            fieldName = objectName
+                    (
+                        fieldName = objectName
 
-                            # Retrieve value decoder for the current field
-                            when stepField recordState fieldName is
-                                Skip ->
-                                    # TODO This doesn't seem right, shouldn't we eat
-                                    # the remaining json object value bytes if we are skipping this
-                                    # field?
-                                    { result: Ok recordState, rest: valueBytes }
+                        # Retrieve value decoder for the current field
+                        when stepField recordState fieldName is
+                            Skip ->
+                                # TODO This doesn't seem right, shouldn't we eat
+                                # the remaining json object value bytes if we are skipping this
+                                # field?
+                                { result: Ok recordState, rest: valueBytes }
 
-                                Keep valueDecoder ->
-                                    # Decode the value using the decoder from the recordState
-                                    # Note we need to pass json config options recursively here
-                                    Decode.decodeWith valueBytes valueDecoder (@Json {})
-                        )
-                        |> tryDecode
+                            Keep valueDecoder ->
+                                # Decode the value using the decoder from the recordState
+                                # Note we need to pass json config options recursively here
+                                Decode.decodeWith valueBytes valueDecoder (@Json {})
+                    )
+                    |> tryDecode \{ val: updatedRecord, rest: bytesAfterValue } ->
+                        # Check if another field or '}' for end of object
+                        when List.walkUntil bytesAfterValue (AfterObjectValue 0) objectHelp is
+                            ObjectFieldNameStart n ->
+                                rest = List.dropFirst bytesAfterValue n
 
-                    # Check if another field or '}' for end of object
-                    when List.walkUntil bytesAfterValue (AfterObjectValue 0) objectHelp is
-                        ObjectFieldNameStart n ->
-                            rest = List.dropFirst bytesAfterValue n
+                                # Decode the next field and value
+                                decodeFields updatedRecord rest
 
-                            # Decode the next field and value
-                            decodeFields updatedRecord rest
+                            AfterClosingBrace n ->
+                                rest = List.dropFirst bytesAfterValue n
 
-                        AfterClosingBrace n ->
-                            rest = List.dropFirst bytesAfterValue n
+                                # Build final record from decoded fields and values
+                                when finalizer updatedRecord json is
+                                    Ok val -> { result: Ok val, rest }
+                                    Err e -> { result: Err e, rest }
 
-                            # Build final record from decoded fields and values
-                            when finalizer updatedRecord json is
-                                Ok val -> { result: Ok val, rest }
-                                Err e -> { result: Err e, rest }
-
-                        _ ->
-                            # Invalid object
-                            { result: Err TooShort, rest: bytesAfterValue }
+                            _ ->
+                                # Invalid object
+                                { result: Err TooShort, rest: bytesAfterValue }
 
         countBytesBeforeFirstField =
             when List.walkUntil bytes (BeforeOpeningBrace 0) objectHelp is


### PR DESCRIPTION
Fixes the first half of https://github.com/roc-lang/roc/issues/6829 to deprecate the backpassing operator, `<-`.

![backpassing-deprecation-warning](https://github.com/user-attachments/assets/e3dead92-6a55-4445-9b53-17429d8af5de)

Now that `?` and `!` desugaring are in place, we want to see how users fare without the backpassing operator before we fully remove it. This throws a warning on every usage of the operator.

I was trying to throw said warning in the `crates/compiler/can/src/expr.rs` code, but desugaring happens before then, so I needed to plumb `problem` propagation through the `desugar.rs` code. Not ideal, but we can at least remove it once backpassing is fully removed.

Apologies to those reading the code changes, most of the testing updates are not meaningful, just hard to read because of large indentation changes.