### PR TITLE
llvm still needs zstd

### DIFF
--- a/.github/workflows/nightly_macos_apple_silicon.yml
+++ b/.github/workflows/nightly_macos_apple_silicon.yml
@@ -14,6 +14,8 @@ jobs:
   test-and-build:
     name: Rust tests, build and package nightly release
     runs-on: [self-hosted, macOS, ARM64]
+    env:
+      LIBRARY_PATH: /opt/homebrew/Cellar/zstd/1.5.6/lib
     timeout-minutes: 90
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
The nightly won't build without this line