### PR TITLE
Fix alignment of 16 byte types

### DIFF
--- a/crates/compiler/gen_llvm/src/llvm/convert.rs
+++ b/crates/compiler/gen_llvm/src/llvm/convert.rs
@@ -263,7 +263,7 @@ fn alignment_type(context: &Context, alignment: u32) -> BasicTypeEnum {
         2 => context.i16_type().into(),
         4 => context.i32_type().into(),
         8 => context.i64_type().into(),
-        16 => context.i128_type().into(),
+        16 => context.f128_type().into(),
         _ => unimplemented!("weird alignment: {alignment}"),
     }
 }


### PR DESCRIPTION
With the version of llvm we are on, `i128` is only aligned to 8 bytes. We were using `i128` to set the alignment of aggregate types. This was leading the the wrong alignment. Instead use `f128` which is actually aligned to 16 bytes on our current version of llvm