### PR TITLE
Fix incorrect hash link in tutorial

### DIFF
--- a/www/content/tutorial.md
+++ b/www/content/tutorial.md
@@ -475,6 +475,7 @@ third = tuple.2 # ["list"]
 # tuple destructuring
 (first, second, third) = ("hello", 42, ["list"])
 ```
+
 <details>
     <summary>Pronouncing Tuple</summary>
     By the way, there are two common ways to pronounce "tuple"—one sounds like "two-pull" and the other rhymes with "supple"—and although no clear consensus has emerged in the programming world, people seem generally accepting when others pronounce it differently than they do.
@@ -1631,7 +1632,7 @@ Stdin.line : Task [Input Str, End] *
 
 Once this task runs, we'll end up with the [tag union](https://www.roc-lang.org/tutorial#tags-with-payloads) `[Input Str, End]`. Then we can check whether we got an `End` or some actual `Input`, and print out a message accordingly.
 
-### [Reading values from tasks](#inspect) {#task-input}
+### [Reading values from tasks](#task-input) {#task-input}
 
 Let's change `main` to read a line from `stdin`, and then print what we got:
 
@@ -1645,7 +1646,6 @@ main =
     Stdout.line! "Type in something and press Enter:"
     input = Stdin.line!
     Stdout.line! "Your input was: $(input)"
-
 ```
 
 If you run this program, it will print "Type in something and press Enter:" and then pause.


### PR DESCRIPTION
While following the tutorial I came across two problems that this PR addresses:

- The example for **Reading values from tasks** does not work when copied and pasted.
<img width="597" alt="image" src="https://github.com/user-attachments/assets/ddaef725-548e-4d2f-b3b9-f051fe93c2e3">

- And the hash link for the heading `### [Reading values from tasks](#inspect) {#task-input}` seems to link to the wrong "[Displaying Roc values with Inspect.toStr](https://www.roc-lang.org/tutorial#inspect)" section further down the page.