### PR TITLE
Add commit information to roc versions built from source

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -384,11 +384,11 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.83"
+version = "1.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
+checksum = "57b6a275aa2903740dc87da01c62040406b8812552e97129a63ea8850a17c6e6"
 dependencies = [
- "libc",
+ "shlex",
 ]
 
 [[package]]
@@ -1666,6 +1666,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
 name = "num-traits"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1873,9 +1879,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.69"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
@@ -1941,9 +1947,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
@@ -2374,6 +2380,7 @@ name = "roc_cli"
 version = "0.0.1"
 dependencies = [
  "bumpalo",
+ "chrono",
  "clap 4.4.6",
  "cli_utils",
  "const_format",
@@ -3314,9 +3321,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.14"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
+checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "rusty-fork"
@@ -3543,6 +3550,12 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook"
@@ -3957,12 +3970,13 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.30"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4a34ab300f2dee6e562c10a046fc05e358b29f9bf92277f30c3c8d82275f6f5"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa",
+ "num-conv",
  "powerfmt",
  "serde",
  "time-core",
@@ -3977,10 +3991,11 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.15"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ad70d68dba9e1f8aceda7aa6711965dfec1cac869f311a51bd08b3a2ccbce20"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
+ "num-conv",
  "time-core",
 ]
 

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -2,6 +2,7 @@
 name = "roc_cli"
 description = "The Roc binary that brings together all functionality in the Roc toolset."
 default-run = "roc"
+build = "build.rs"
 
 authors.workspace = true
 edition.workspace = true
@@ -30,7 +31,13 @@ target-wasm32 = ["roc_build/target-wasm32"]
 target-x86 = ["roc_build/target-x86", "roc_repl_cli/target-x86"]
 target-x86_64 = ["roc_build/target-x86_64", "roc_repl_cli/target-x86_64"]
 
-target-all = ["target-aarch64", "target-arm", "target-x86", "target-x86_64", "target-wasm32"]
+target-all = [
+  "target-aarch64",
+  "target-arm",
+  "target-x86",
+  "target-x86_64",
+  "target-wasm32",
+]
 
 sanitizers = ["roc_build/sanitizers"]
 
@@ -92,6 +99,9 @@ indoc.workspace = true
 parking_lot.workspace = true
 pretty_assertions.workspace = true
 serial_test.workspace = true
+
+[build-dependencies]
+chrono.workspace = true
 
 [[bench]]
 name = "time_bench"

--- a/crates/cli/build.rs
+++ b/crates/cli/build.rs
@@ -1,0 +1,71 @@
+use chrono::prelude::*;
+use std::fs;
+use std::process::Command;
+use std::str;
+
+fn main() {
+    // Rebuild if this build.rs file changes
+    println!("cargo:rerun-if-changed=build.rs");
+
+    // The version file is located at the root of the repository
+    let version_file_path = "../../version.txt";
+
+    // Rebuild if version file changes
+    println!("cargo:rerun-if-changed={}", version_file_path);
+
+    // Read the version file
+    let version_file_contents = fs::read_to_string(version_file_path).unwrap();
+
+    // If the version is "built-from-source", replace it with the git commit information
+    let version = match version_file_contents.trim() {
+        "built-from-source" => {
+            let git_head_file_path = "../../.git/HEAD";
+            // Rebuild if a new Git commit is made
+            println!("cargo:rerun-if-changed={}", git_head_file_path);
+
+            // Check if the .git/HEAD file exists
+            let git_head_exists = fs::metadata(git_head_file_path).is_ok();
+            if git_head_exists {
+                // Get the hash of the current commit
+                let git_describe_output = Command::new("git")
+                    .arg("describe")
+                    .arg("--always")
+                    .arg("--dirty= with additional changes") // Add a suffix if the working directory is dirty
+                    .output()
+                    .expect("Failed to execute git describe command");
+                println!("git_describe_output: {:?}", git_describe_output);
+                let git_commit_hash = str::from_utf8(&git_describe_output.stdout)
+                    .expect("Failed to parse git describe output")
+                    .trim();
+
+                // Get the datetime of the last commit
+                let git_show_output = Command::new("git")
+                    .arg("show")
+                    .arg("--no-patch")
+                    .arg("--format=%ct") // Outputting a UNIX timestamp is the only way to always use UTC
+                    .output()
+                    .expect("Failed to execute git show command");
+                println!("git_show_output: {:?}", git_show_output);
+                let git_commit_timestamp = {
+                    let timestamp = str::from_utf8(&git_show_output.stdout)
+                        .expect("Failed to parse git show output as a string")
+                        .trim()
+                        .parse::<i64>()
+                        .expect("Failed to parse timestamp as an integer");
+                    DateTime::from_timestamp(timestamp, 0)
+                        .expect("Failed to parse timestamp")
+                        .format("%Y-%m-%d %H:%M:%S")
+                };
+                format!(
+                    "built from commit {git_commit_hash}, committed at {git_commit_timestamp} UTC"
+                )
+            } else {
+                // If the .git/HEAD file does not exist, e.g. in a Nix build, use a generic message
+                "built from source".to_string()
+            }
+        }
+        _ => version_file_contents.trim().to_string(),
+    };
+    // Emit the version to a build-time environment variable
+    println!("cargo:rustc-env=ROC_VERSION={}", version);
+}

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -90,7 +90,7 @@ pub const FLAG_PP_HOST: &str = "host";
 pub const FLAG_PP_PLATFORM: &str = "platform";
 pub const FLAG_PP_DYLIB: &str = "lib";
 
-const VERSION: &str = include_str!("../../../version.txt");
+pub const VERSION: &str = env!("ROC_VERSION");
 const DEFAULT_GENERATED_DOCS_DIR: &str = "generated-docs";
 
 pub fn build_app() -> Command {
@@ -182,7 +182,7 @@ pub fn build_app() -> Command {
         PossibleValuesParser::new(Target::iter().map(Into::<&'static str>::into));
 
     Command::new("roc")
-        .version(concatcp!(VERSION, "\n"))
+        .version(VERSION)
         .about("Run the given .roc file, if there are no compilation errors.\nYou can use one of the SUBCOMMANDS below to do something else!")
         .args_conflicts_with_subcommands(true)
         .subcommand(Command::new(CMD_BUILD)

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -8,7 +8,7 @@ use roc_cli::{
     CMD_RUN, CMD_TEST, CMD_VERSION, DIRECTORY_OR_FILES, FLAG_CHECK, FLAG_DEV, FLAG_LIB, FLAG_MAIN,
     FLAG_NO_COLOR, FLAG_NO_HEADER, FLAG_NO_LINK, FLAG_OUTPUT, FLAG_PP_DYLIB, FLAG_PP_HOST,
     FLAG_PP_PLATFORM, FLAG_STDIN, FLAG_STDOUT, FLAG_TARGET, FLAG_TIME, GLUE_DIR, GLUE_SPEC,
-    ROC_FILE,
+    ROC_FILE, VERSION,
 };
 use roc_docs::generate_docs_html;
 use roc_error_macros::user_error;
@@ -22,9 +22,6 @@ use std::io::{self, Read, Write};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use target_lexicon::Triple;
-
-#[macro_use]
-extern crate const_format;
 
 #[global_allocator]
 static ALLOC: mimalloc::MiMalloc = mimalloc::MiMalloc;
@@ -364,11 +361,7 @@ fn main() -> io::Result<()> {
             Ok(format_exit_code)
         }
         Some((CMD_VERSION, _)) => {
-            print!(
-                "{}",
-                concatcp!("roc ", include_str!("../../../version.txt"))
-            );
-
+            println!("roc {}", VERSION);
             Ok(0)
         }
         _ => unreachable!(),


### PR DESCRIPTION
Addresses #7030.

I'm not that experienced with Rust and I'm not familiar with the style and priorities of the Roc compiler team, so I'd appreciate feedback on anything that looks out of place or inefficient :sweat_smile: 

I think this is nearly done, but I'm getting a default commit timestamp when I run it locally:

```
roc built from commit 6d0a9b69d, committed at 1980-01-01T00:00:00.000000000Z
```

I think it's a default timestamp, maybe for reproducible builds? But that doesn't make sense to me because it's not a build timestamp, it's a commit timestamp :thinking:

Again, any help is appreciated! :grinning: 