### PR TITLE
Fix threading params that produce Task

### DIFF
--- a/crates/cli/tests/cli_run.rs
+++ b/crates/cli/tests/cli_run.rs
@@ -905,6 +905,25 @@ mod cli_run {
 
     #[test]
     #[cfg_attr(windows, ignore)]
+    fn module_params_pass_task() {
+        test_roc_app(
+            "crates/cli/tests/module_params",
+            "pass_task.roc",
+            &[],
+            &[],
+            &[],
+            indoc!(
+                r#"
+                Hi, Agus!
+                "#
+            ),
+            UseValgrind::No,
+            TestCliCommands::Run,
+        );
+    }
+
+    #[test]
+    #[cfg_attr(windows, ignore)]
     fn transitive_expects() {
         test_roc_expect(
             "crates/cli/tests/expects_transitive",

--- a/crates/cli/tests/module_params/Menu.roc
+++ b/crates/cli/tests/module_params/Menu.roc
@@ -1,0 +1,7 @@
+module { echo } -> [menu]
+
+menu = \name ->
+    indirect name
+
+indirect = \name ->
+    echo "Hi, $(name)!"

--- a/crates/cli/tests/module_params/pass_task.roc
+++ b/crates/cli/tests/module_params/pass_task.roc
@@ -1,0 +1,7 @@
+app [main] { pf: platform "https://github.com/roc-lang/basic-cli/releases/download/0.15.0/SlwdbJ-3GR7uBWQo6zlmYWNYOxnvo8r6YABXD-45UOw.tar.br" }
+
+import pf.Stdout
+import Menu { echo: Stdout.line }
+
+main =
+    Menu.menu "Agus"

--- a/crates/compiler/lower_params/src/lower.rs
+++ b/crates/compiler/lower_params/src/lower.rs
@@ -184,14 +184,14 @@ impl<'a> LowerParams<'a> {
                                 }
                             }
                         }
-                        Var(symbol, _var) => {
+                        Var(symbol, var) => {
                             if let Some((params, arity)) = self.params_extended_home_symbol(&symbol)
                             {
                                 if arity == 0 {
                                     // Calling the result of a top-level value def in the current module
                                     fun.1.value = self.call_value_def_with_params(
                                         symbol,
-                                        params.whole_var,
+                                        var,
                                         params.whole_symbol,
                                         params.whole_var,
                                     );


### PR DESCRIPTION
Passing functions that produce `Task` through params would work if used directly:

```roc
module { echo } -> [menu]

menu = \name ->
    echo "Hi, $(name)!"
```

However, it would cause an error when the param was threaded to another top-level function.

```roc
menu = \name ->
    indirect name

indirect = \name ->
    echo "Hi, $(name)!"
```

The issue seems to be caused by reusing `Variable`s for the destructures added to each top-level function. We will now create a fresh var, and let the type checker unify them properly.