### PR TITLE
Fix dbg expression desugaring and improve dbg error reporting

### DIFF
--- a/crates/compiler/can/src/module.rs
+++ b/crates/compiler/can/src/module.rs
@@ -268,7 +268,7 @@ pub fn canonicalize_module_defs<'a>(
 
     crate::desugar::desugar_defs_node_values(
         arena,
-        var_store,
+        &mut scope,
         loc_defs,
         src,
         &mut None,

--- a/crates/compiler/can/src/scope.rs
+++ b/crates/compiler/can/src/scope.rs
@@ -466,13 +466,19 @@ impl Scope {
         self.home.register_debug_idents(&self.locals.ident_ids)
     }
 
-    /// Generates a unique, new symbol like "$1" or "$5",
+    /// Generates a unique, new symbol like "1" or "5",
     /// using the home module as the module_id.
     ///
     /// This is used, for example, during canonicalization of an Expr::Closure
     /// to generate a unique symbol to refer to that closure.
     pub fn gen_unique_symbol(&mut self) -> Symbol {
         Symbol::new(self.home, self.locals.gen_unique())
+    }
+
+    /// Generates a unique new symbol and return the symbol's unqualified identifier name.
+    pub fn gen_unique_symbol_name(&mut self) -> &str {
+        let ident_id = self.locals.gen_unique();
+        self.locals.ident_ids.get_name(ident_id).unwrap()
     }
 
     /// Introduce a new ignored variable (variable starting with an underscore).

--- a/crates/compiler/can/tests/helpers/mod.rs
+++ b/crates/compiler/can/tests/helpers/mod.rs
@@ -46,6 +46,13 @@ pub fn can_expr_with(arena: &Bump, home: ModuleId, expr_str: &str) -> CanExprOut
     let var = var_store.fresh();
     let qualified_module_ids = PackageModuleIds::default();
 
+    let mut scope = Scope::new(
+        home,
+        "TestPath".into(),
+        IdentIds::default(),
+        Default::default(),
+    );
+
     // Desugar operators (convert them to Apply calls, taking into account
     // operator precedence and associativity rules), before doing other canonicalization.
     //
@@ -55,7 +62,7 @@ pub fn can_expr_with(arena: &Bump, home: ModuleId, expr_str: &str) -> CanExprOut
     // rules multiple times unnecessarily.
     let loc_expr = desugar::desugar_expr(
         arena,
-        &mut var_store,
+        &mut scope,
         &loc_expr,
         expr_str,
         &mut None,
@@ -63,12 +70,6 @@ pub fn can_expr_with(arena: &Bump, home: ModuleId, expr_str: &str) -> CanExprOut
         &mut Default::default(),
     );
 
-    let mut scope = Scope::new(
-        home,
-        "TestPath".into(),
-        IdentIds::default(),
-        Default::default(),
-    );
     scope.add_alias(
         Symbol::NUM_INT,
         Region::zero(),

--- a/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__dbg_expr.snap
+++ b/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__dbg_expr.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/compiler/can/tests/test_suffixed.rs
-assertion_line: 449
+assertion_line: 463
 expression: snapshot
 ---
 Defs {
@@ -44,7 +44,7 @@ Defs {
                     value_defs: [
                         Body(
                             @15-26 Identifier {
-                                ident: "64",
+                                ident: "1",
                             },
                             @15-26 ParensAround(
                                 Defs(
@@ -66,7 +66,7 @@ Defs {
                                         value_defs: [
                                             Body(
                                                 @20-25 Identifier {
-                                                    ident: "63",
+                                                    ident: "0",
                                                 },
                                                 @20-25 Apply(
                                                     @22-23 Var {
@@ -101,14 +101,14 @@ Defs {
                                             [
                                                 @20-25 Var {
                                                     module_name: "",
-                                                    ident: "63",
+                                                    ident: "0",
                                                 },
                                             ],
                                             Space,
                                         ),
                                         @20-25 Var {
                                             module_name: "",
-                                            ident: "63",
+                                            ident: "0",
                                         },
                                     ),
                                 ),
@@ -129,14 +129,14 @@ Defs {
                         [
                             @15-26 Var {
                                 module_name: "",
-                                ident: "64",
+                                ident: "1",
                             },
                         ],
                         Space,
                     ),
                     @15-26 Var {
                         module_name: "",
-                        ident: "64",
+                        ident: "1",
                     },
                 ),
             ),

--- a/crates/compiler/can/tests/test_suffixed.rs
+++ b/crates/compiler/can/tests/test_suffixed.rs
@@ -6,17 +6,24 @@ mod suffixed_tests {
     use bumpalo::Bump;
     use insta::assert_snapshot;
     use roc_can::desugar::desugar_defs_node_values;
+    use roc_can::scope::Scope;
+    use roc_module::symbol::{IdentIds, ModuleIds};
     use roc_parse::test_helpers::parse_defs_with;
-    use roc_types::subs::VarStore;
 
     macro_rules! run_test {
         ($src:expr) => {{
             let arena = &Bump::new();
-            let mut var_store = VarStore::default();
+            let home = ModuleIds::default().get_or_insert(&"Test".into());
+            let mut scope = Scope::new(
+                home,
+                "TestPath".into(),
+                IdentIds::default(),
+                Default::default(),
+            );
             let mut defs = parse_defs_with(arena, indoc!($src)).unwrap();
             desugar_defs_node_values(
                 arena,
-                &mut var_store,
+                &mut scope,
                 &mut defs,
                 $src,
                 &mut None,

--- a/crates/compiler/load/tests/helpers/mod.rs
+++ b/crates/compiler/load/tests/helpers/mod.rs
@@ -161,6 +161,13 @@ pub fn can_expr_with<'a>(
     // ensure the Test module is accessible in our tests
     module_ids.get_or_insert(&PQModuleName::Unqualified("Test".into()));
 
+    let mut scope = Scope::new(
+        home,
+        "TestPath".into(),
+        IdentIds::default(),
+        Default::default(),
+    );
+
     // Desugar operators (convert them to Apply calls, taking into account
     // operator precedence and associativity rules), before doing other canonicalization.
     //
@@ -170,19 +177,12 @@ pub fn can_expr_with<'a>(
     // rules multiple times unnecessarily.
     let loc_expr = desugar::desugar_expr(
         arena,
-        &mut var_store,
+        &mut scope,
         &loc_expr,
         expr_str,
         &mut None,
         arena.alloc("TestPath"),
         &mut Default::default(),
-    );
-
-    let mut scope = Scope::new(
-        home,
-        "TestPath".into(),
-        IdentIds::default(),
-        Default::default(),
     );
 
     let dep_idents = IdentIds::exposed_builtins(0);

--- a/crates/compiler/load/tests/test_reporting.rs
+++ b/crates/compiler/load/tests/test_reporting.rs
@@ -14521,7 +14521,7 @@ All branches in an `if` must have the same type!
     4│      1 + dbg + 2
                 ^^^
 
-    This `63` value is a:
+    This value is a:
 
         {}
 
@@ -14555,7 +14555,7 @@ All branches in an `if` must have the same type!
     4│      1 + dbg "" "" + 2
                 ^^^^^^^^^
 
-    This `63` value is a:
+    This value is a:
 
         {}
 

--- a/crates/compiler/module/src/symbol.rs
+++ b/crates/compiler/module/src/symbol.rs
@@ -123,6 +123,21 @@ impl Symbol {
                 .any(|(_, (s, _))| *s == self)
     }
 
+    pub fn is_generated(self, interns: &Interns) -> bool {
+        let ident_ids = interns
+            .all_ident_ids
+            .get(&self.module_id())
+            .unwrap_or_else(|| {
+                internal_error!(
+                    "ident_string could not find IdentIds for module {:?} in {:?}",
+                    self.module_id(),
+                    interns
+                )
+            });
+
+        ident_ids.is_generated_id(self.ident_id())
+    }
+
     pub fn module_string<'a>(&self, interns: &'a Interns) -> &'a ModuleName {
         interns
             .module_ids
@@ -705,6 +720,12 @@ impl IdentIds {
     /// to generate a unique symbol to refer to that closure.
     pub fn gen_unique(&mut self) -> IdentId {
         IdentId(self.interner.insert_index_str() as u32)
+    }
+
+    pub fn is_generated_id(&self, id: IdentId) -> bool {
+        self.interner
+            .try_get(id.0 as usize)
+            .map_or(false, |str| str.starts_with(|c: char| c.is_ascii_digit()))
     }
 
     #[inline(always)]

--- a/crates/compiler/module/src/symbol.rs
+++ b/crates/compiler/module/src/symbol.rs
@@ -124,18 +124,7 @@ impl Symbol {
     }
 
     pub fn is_generated(self, interns: &Interns) -> bool {
-        let ident_ids = interns
-            .all_ident_ids
-            .get(&self.module_id())
-            .unwrap_or_else(|| {
-                internal_error!(
-                    "ident_string could not find IdentIds for module {:?} in {:?}",
-                    self.module_id(),
-                    interns
-                )
-            });
-
-        ident_ids.is_generated_id(self.ident_id())
+        self.ident_ids(interns).is_generated_id(self.ident_id())
     }
 
     pub fn module_string<'a>(&self, interns: &'a Interns) -> &'a ModuleName {
@@ -152,24 +141,15 @@ impl Symbol {
     }
 
     pub fn as_str(self, interns: &Interns) -> &str {
-        let ident_ids = interns
-            .all_ident_ids
-            .get(&self.module_id())
+        self.ident_ids(interns)
+            .get_name(self.ident_id())
             .unwrap_or_else(|| {
                 internal_error!(
-                    "ident_string could not find IdentIds for module {:?} in {:?}",
-                    self.module_id(),
-                    interns
+                    "ident_string's IdentIds did not contain an entry for {} in module {:?}",
+                    self.ident_id().0,
+                    self.module_id()
                 )
-            });
-
-        ident_ids.get_name(self.ident_id()).unwrap_or_else(|| {
-            internal_error!(
-                "ident_string's IdentIds did not contain an entry for {} in module {:?}",
-                self.ident_id().0,
-                self.module_id()
-            )
-        })
+            })
     }
 
     pub const fn as_u64(self) -> u64 {
@@ -200,6 +180,19 @@ impl Symbol {
     #[cfg(debug_assertions)]
     pub fn contains(self, needle: &str) -> bool {
         format!("{self:?}").contains(needle)
+    }
+
+    fn ident_ids(self, interns: &Interns) -> &IdentIds {
+        interns
+            .all_ident_ids
+            .get(&self.module_id())
+            .unwrap_or_else(|| {
+                internal_error!(
+                    "ident_string could not find IdentIds for module {:?} in {:?}",
+                    self.module_id(),
+                    interns
+                )
+            })
     }
 }
 

--- a/crates/compiler/test_mono/generated/dbg_expr.txt
+++ b/crates/compiler/test_mono/generated/dbg_expr.txt
@@ -47,10 +47,10 @@ procedure Str.3 (#Attr.2, #Attr.3):
     ret Str.236;
 
 procedure Test.0 ():
-    let Test.4 : I64 = 1i64;
-    let Test.1 : I64 = 2i64;
-    let Test.2 : Str = CallByName Inspect.33 Test.1;
-    dbg Test.2;
-    dec Test.2;
-    let Test.3 : I64 = CallByName Num.19 Test.4 Test.1;
-    ret Test.3;
+    let Test.5 : I64 = 1i64;
+    let Test.2 : I64 = 2i64;
+    let Test.3 : Str = CallByName Inspect.33 Test.2;
+    dbg Test.3;
+    dec Test.3;
+    let Test.4 : I64 = CallByName Num.19 Test.5 Test.2;
+    ret Test.4;

--- a/crates/compiler/test_mono/generated/dbg_inside_string.txt
+++ b/crates/compiler/test_mono/generated/dbg_inside_string.txt
@@ -44,15 +44,15 @@ procedure Str.3 (#Attr.2, #Attr.3):
     ret Str.238;
 
 procedure Test.0 ():
-    let Test.4 : Str = "Hello ";
-    let Test.1 : Str = "world";
-    inc Test.1;
-    let Test.2 : Str = CallByName Inspect.33 Test.1;
-    dbg Test.2;
-    dec Test.2;
-    let Test.7 : Str = "!";
-    let Test.5 : Str = CallByName Str.3 Test.1 Test.7;
-    dec Test.7;
-    let Test.3 : Str = CallByName Str.3 Test.4 Test.5;
-    dec Test.5;
-    ret Test.3;
+    let Test.5 : Str = "Hello ";
+    let Test.2 : Str = "world";
+    inc Test.2;
+    let Test.3 : Str = CallByName Inspect.33 Test.2;
+    dbg Test.3;
+    dec Test.3;
+    let Test.8 : Str = "!";
+    let Test.6 : Str = CallByName Str.3 Test.2 Test.8;
+    dec Test.8;
+    let Test.4 : Str = CallByName Str.3 Test.5 Test.6;
+    dec Test.6;
+    ret Test.4;

--- a/crates/compiler/test_mono/generated/dbg_nested_expr.txt
+++ b/crates/compiler/test_mono/generated/dbg_nested_expr.txt
@@ -43,14 +43,14 @@ procedure Str.3 (#Attr.2, #Attr.3):
     ret Str.236;
 
 procedure Test.0 ():
-    let Test.3 : I64 = 1i64;
-    let Test.4 : Str = CallByName Inspect.33 Test.3;
-    dbg Test.4;
-    dec Test.4;
-    let Test.5 : Str = CallByName Inspect.33 Test.3;
-    dbg Test.5;
-    dec Test.5;
-    let Test.6 : Str = CallByName Inspect.33 Test.3;
-    dbg Test.6;
-    dec Test.6;
-    ret Test.3;
+    let Test.6 : I64 = 1i64;
+    let Test.7 : Str = CallByName Inspect.33 Test.6;
+    dbg Test.7;
+    dec Test.7;
+    let Test.8 : Str = CallByName Inspect.33 Test.6;
+    dbg Test.8;
+    dec Test.8;
+    let Test.9 : Str = CallByName Inspect.33 Test.6;
+    dbg Test.9;
+    dec Test.9;
+    ret Test.6;

--- a/crates/reporting/src/error/type.rs
+++ b/crates/reporting/src/error/type.rs
@@ -1796,6 +1796,9 @@ fn format_category<'b>(
     let t = if capitalize_start { "T" } else { "t" };
 
     match category {
+        Lookup(name) if name.is_generated(alloc.interns) => {
+            (text!(alloc, "{}his value", t), alloc.text(" is a:"))
+        }
         Lookup(name) => (
             alloc.concat([
                 text!(alloc, "{}his ", t),
@@ -1804,7 +1807,6 @@ fn format_category<'b>(
             ]),
             alloc.text(" is a:"),
         ),
-
         If => (
             alloc.concat([
                 text!(alloc, "{}his ", t),


### PR DESCRIPTION
This PR builds on https://github.com/roc-lang/roc/pull/7038, fixing some issues with the initial implementation. The PR following this one will add support for `dbg` in pipelines.

### Use module scope instead of var store to generate idents in dbg desugar

Fix a bug in `dbg` expression desugaring by using the module scope to generate unique identifiers instead of the variable store.

In the initial implementation of `dbg` expressions we used the `VarStore` to generate unique identifiers for new variables created during desugaring. We should have instead used the current module's `Scope`, which handles identifiers within the module. Each scope has its own incrementing variable count which is independent of the shared variable store. The scope is used to generate new identifiers at other points in canonicalization, such as when assigning a global identifier to closures and `expect`s. It's possible that the identifier generated for `dbg` could conflict with an identifier generated by the scope, resulting in a confusing error.

### Do not display generated symbol names in error messages

When an error message reports on a symbol that was generated during canonicalization, use text like "This value" instead of "This `123` value". Generated symbols use the identifier index as the symbol name, since valid Roc variables cannot begin with a number so there's no chance of collision. We don't want to display generated symbols to the user, so when building the error message we check if the symbol's name starts with a digit.