### PR TITLE
Add a short paragraph to explain dbg forwarding, fixes #7061

### DIFF
--- a/www/content/tutorial.md
+++ b/www/content/tutorial.md
@@ -440,6 +440,12 @@ You can give `dbg` any expression you like, for example:
 dbg Str.concat singular plural
 ```
 
+You can also use `dbg` inside an expression: it will print its input to stderr and return it to the caller. For example:
+
+```roc
+inc = \n -> 1 + dbg n
+```
+
 ### [Tuples](#tuples) {#tuples}
 
 One way to have `dbg` print multiple values at a time is to wrap them in a record:

--- a/www/content/tutorial.md
+++ b/www/content/tutorial.md
@@ -440,7 +440,7 @@ You can give `dbg` any expression you like, for example:
 dbg Str.concat singular plural
 ```
 
-You can also use `dbg` inside an expression: it will print its input to stderr and return it to the caller. For example:
+You can also use `dbg` as a function inside an expression, which will print the function argument to stderr and then return the argument to the caller. For example:
 
 ```roc
 inc = \n -> 1 + dbg n


### PR DESCRIPTION
I tried to keep it as short and simple as possible.
I used `1 + dbg n` instead of `dbg n + 1` to avoid any confusion about operator precedence.