### PR TITLE
Desugar module param patterns before canonicalization

### DIFF
--- a/crates/cli/tests/cli_run.rs
+++ b/crates/cli/tests/cli_run.rs
@@ -924,6 +924,25 @@ mod cli_run {
 
     #[test]
     #[cfg_attr(windows, ignore)]
+    fn module_params_multiline_pattern() {
+        test_roc_app(
+            "crates/cli/tests/module_params",
+            "multiline_params.roc",
+            &[],
+            &[],
+            &[],
+            indoc!(
+                r#"
+                hi
+                "#
+            ),
+            UseValgrind::No,
+            TestCliCommands::Dev,
+        );
+    }
+
+    #[test]
+    #[cfg_attr(windows, ignore)]
     fn transitive_expects() {
         test_roc_expect(
             "crates/cli/tests/expects_transitive",

--- a/crates/cli/tests/module_params/MultilineParams.roc
+++ b/crates/cli/tests/module_params/MultilineParams.roc
@@ -1,0 +1,8 @@
+module {
+    sendHttpReq,
+    getEnvVar
+} -> [hi]
+
+hi : Str
+hi =
+    "hi"

--- a/crates/cli/tests/module_params/multiline_params.roc
+++ b/crates/cli/tests/module_params/multiline_params.roc
@@ -1,0 +1,11 @@
+app [main] {
+     pf: platform "../fixtures/multi-dep-str/platform/main.roc",
+}
+
+import MultilineParams {
+    sendHttpReq: \_ -> crash "todo",
+    getEnvVar: \_ -> crash "todo",
+}
+
+main =
+    MultilineParams.hi

--- a/crates/compiler/can/src/desugar.rs
+++ b/crates/compiler/can/src/desugar.rs
@@ -1226,17 +1226,7 @@ fn desugar_pattern<'a>(env: &mut Env<'a>, scope: &mut Scope, pattern: Pattern<'a
             Apply(tag, desugared_arg_patterns.into_bump_slice())
         }
         RecordDestructure(field_patterns) => {
-            let mut allocated = Vec::with_capacity_in(field_patterns.len(), env.arena);
-            for field_pattern in field_patterns.iter() {
-                let value = desugar_pattern(env, scope, field_pattern.value);
-                allocated.push(Loc {
-                    value,
-                    region: field_pattern.region,
-                });
-            }
-            let field_patterns = field_patterns.replace_items(allocated.into_bump_slice());
-
-            RecordDestructure(field_patterns)
+            RecordDestructure(desugar_record_destructures(env, scope, field_patterns))
         }
         RequiredField(name, field_pattern) => {
             RequiredField(name, desugar_loc_pattern(env, scope, field_pattern))
@@ -1272,6 +1262,23 @@ fn desugar_pattern<'a>(env: &mut Env<'a>, scope: &mut Scope, pattern: Pattern<'a
         SpaceBefore(sub_pattern, _spaces) => desugar_pattern(env, scope, *sub_pattern),
         SpaceAfter(sub_pattern, _spaces) => desugar_pattern(env, scope, *sub_pattern),
     }
+}
+
+pub fn desugar_record_destructures<'a>(
+    env: &mut Env<'a>,
+    scope: &mut Scope,
+    field_patterns: Collection<'a, Loc<Pattern<'a>>>,
+) -> Collection<'a, Loc<Pattern<'a>>> {
+    let mut allocated = Vec::with_capacity_in(field_patterns.len(), env.arena);
+    for field_pattern in field_patterns.iter() {
+        let value = desugar_pattern(env, scope, field_pattern.value);
+        allocated.push(Loc {
+            value,
+            region: field_pattern.region,
+        });
+    }
+
+    field_patterns.replace_items(allocated.into_bump_slice())
 }
 
 /// Desugars a `dbg expr` expression into a statement block that prints and returns the

--- a/crates/compiler/can/src/module.rs
+++ b/crates/compiler/can/src/module.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 use crate::abilities::{AbilitiesStore, ImplKey, PendingAbilitiesStore, ResolvedImpl};
 use crate::annotation::{canonicalize_annotation, AnnotationFor};
 use crate::def::{canonicalize_defs, report_unused_imports, Def};
+use crate::desugar::desugar_record_destructures;
 use crate::env::Env;
 use crate::expr::{
     ClosureData, DbgLookup, Declarations, ExpectLookup, Expr, Output, PendingDerives,
@@ -326,13 +327,16 @@ pub fn canonicalize_module_defs<'a>(
              before_arrow: _,
              after_arrow: _,
          }| {
+            let desugared_patterns =
+                desugar_record_destructures(&mut env, &mut scope, pattern.value);
+
             let (destructs, _) = canonicalize_record_destructs(
                 &mut env,
                 var_store,
                 &mut scope,
                 &mut output,
                 PatternType::ModuleParams,
-                &pattern.value,
+                &desugared_patterns,
                 pattern.region,
                 PermitShadows(false),
             );

--- a/crates/compiler/can/src/pattern.rs
+++ b/crates/compiler/can/src/pattern.rs
@@ -914,7 +914,10 @@ pub fn canonicalize_record_destructs<'a>(
                     }
                 };
             }
-            _ => unreachable!("Any other pattern should have given a parse error"),
+            _ => unreachable!(
+                "Any other pattern should have given a parse error: {:?}",
+                loc_pattern.value
+            ),
         }
     }
 


### PR DESCRIPTION
Module param patterns do not appear in defs and therefore weren't automatically run through desugaring. 

Amongst other, this fixes an [issue](https://roc.zulipchat.com/#narrow/stream/231634-beginners/topic/Compiler.20panic.20with.20module.20params/near/471801244) where `canonicalize_record_destructures` would panic when it run into a multiline params pattern because it didn't expect `Pattern::SpaceBefore` nodes to exist at that point.