### PR TITLE
Tolerant Block Parsing

### DIFF
--- a/crates/compiler/can/src/desugar.rs
+++ b/crates/compiler/can/src/desugar.rs
@@ -317,6 +317,7 @@ pub fn desugar_expr<'a>(
         | AccessorFunction(_)
         | Var { .. }
         | Underscore { .. }
+        | EmptyBlock(_)
         | MalformedIdent(_, _)
         | MalformedClosure
         | MalformedSuffixed(..)

--- a/crates/compiler/can/src/expr.rs
+++ b/crates/compiler/can/src/expr.rs
@@ -1337,6 +1337,14 @@ pub fn canonicalize_expr<'a>(
                 Output::default(),
             )
         }
+        ast::Expr::EmptyBlock(parent) => {
+            use roc_problem::can::RuntimeError::*;
+
+            let problem = EmptyBlock(*parent, region);
+            env.problem(Problem::RuntimeError(problem.clone()));
+
+            (RuntimeError(problem), Output::default())
+        }
         ast::Expr::MalformedClosure => {
             use roc_problem::can::RuntimeError::*;
             (RuntimeError(MalformedClosure(region)), Output::default())
@@ -2490,7 +2498,8 @@ pub fn is_valid_interpolation(expr: &ast::Expr<'_>) -> bool {
         | ast::Expr::MalformedIdent(_, _)
         | ast::Expr::Tag(_)
         | ast::Expr::OpaqueRef(_)
-        | ast::Expr::MalformedClosure => true,
+        | ast::Expr::MalformedClosure
+        | ast::Expr::EmptyBlock(_) => true,
         // Newlines are disallowed inside interpolation, and these all require newlines
         ast::Expr::DbgStmt(_, _)
         | ast::Expr::LowLevelDbg(_, _, _)

--- a/crates/compiler/fmt/src/expr.rs
+++ b/crates/compiler/fmt/src/expr.rs
@@ -42,6 +42,7 @@ impl<'a> Formattable for Expr<'a> {
             | RecordUpdater(_)
             | Var { .. }
             | Underscore { .. }
+            | EmptyBlock(_)
             | MalformedIdent(_, _)
             | MalformedClosure
             | Tag(_)
@@ -545,6 +546,7 @@ impl<'a> Formattable for Expr<'a> {
                 buf.indent(indent);
                 loc_expr.format_with_options(buf, parens, newlines, indent);
             }
+            EmptyBlock(_) => {}
             MalformedClosure => {}
             PrecedenceConflict { .. } => {}
             EmptyRecordBuilder { .. } => {}

--- a/crates/compiler/parse/src/normalize.rs
+++ b/crates/compiler/parse/src/normalize.rs
@@ -785,6 +785,7 @@ impl<'a> Normalize<'a> for Expr<'a> {
                 // The formatter can remove redundant parentheses, so also remove these when normalizing for comparison.
                 a.normalize(arena)
             }
+            Expr::EmptyBlock(parent) => Expr::EmptyBlock(parent),
             Expr::MalformedIdent(a, b) => Expr::MalformedIdent(a, remove_spaces_bad_ident(b)),
             Expr::MalformedClosure => Expr::MalformedClosure,
             Expr::MalformedSuffixed(a) => Expr::MalformedSuffixed(a),

--- a/crates/compiler/problem/src/can.rs
+++ b/crates/compiler/problem/src/can.rs
@@ -5,7 +5,7 @@ use roc_collections::all::MutSet;
 use roc_module::called_via::BinOp;
 use roc_module::ident::{Ident, Lowercase, ModuleName, TagName};
 use roc_module::symbol::{ModuleId, Symbol};
-use roc_parse::ast::Base;
+use roc_parse::ast::{Base, EmptyBlockParent};
 use roc_parse::pattern::PatternType;
 use roc_region::all::{Loc, Region};
 use roc_types::types::AliasKind;
@@ -434,6 +434,7 @@ impl Problem {
                 field: region,
             })
             | Problem::RuntimeError(RuntimeError::ReadIngestedFileError { region, .. })
+            | Problem::RuntimeError(RuntimeError::EmptyBlock(_, region))
             | Problem::InvalidAliasRigid { region, .. }
             | Problem::InvalidInterpolation(region)
             | Problem::InvalidHexadecimal(region)
@@ -662,6 +663,8 @@ pub enum RuntimeError {
 
     NonExhaustivePattern,
 
+    EmptyBlock(EmptyBlockParent, Region),
+
     InvalidInterpolation(Region),
     InvalidHexadecimal(Region),
     InvalidUnicodeCodePt(Region),
@@ -740,7 +743,8 @@ impl RuntimeError {
                 record: _,
                 field: region,
             }
-            | RuntimeError::ReadIngestedFileError { region, .. } => *region,
+            | RuntimeError::ReadIngestedFileError { region, .. }
+            | RuntimeError::EmptyBlock(_, region) => *region,
             RuntimeError::InvalidUnicodeCodePt(region) => *region,
             RuntimeError::UnresolvedTypeVar | RuntimeError::ErroneousType => Region::zero(),
             RuntimeError::LookupNotInScope { loc_name, .. } => loc_name.region,

--- a/crates/language_server/src/analysis/tokens.rs
+++ b/crates/language_server/src/analysis/tokens.rs
@@ -725,7 +725,8 @@ impl IterTokens for Loc<Expr<'_>> {
             Expr::EmptyRecordBuilder(e) => e.iter_tokens(arena),
             Expr::SingleFieldRecordBuilder(e) => e.iter_tokens(arena),
             Expr::OptionalFieldInRecordBuilder(_name, e) => e.iter_tokens(arena),
-            Expr::MalformedIdent(_, _)
+            Expr::EmptyBlock(_)
+            | Expr::MalformedIdent(_, _)
             | Expr::MalformedClosure
             | Expr::PrecedenceConflict(_)
             | Expr::MalformedSuffixed(_) => {


### PR DESCRIPTION
This PR plans to convert empty blocks into malformed blocks and add malformed expressions to the end of blocks not already ending in expressions. In doing so, we can make the user experience better for Roc devs by more consistently continuing to parse and analyze incorrect code.

An example error:

```
── MISSING BODY in /home/smores/dev/test.roc ───────────────────────────────────

This definition has no body:

26│  { x, y } =
     ^^^^^^^^^^

I would need to crash if I used it!
```

The PR is only partially done, but I figured I'd release a draft to get eyes on the overall plan.

