### PR TITLE
Update tutorial _

### DIFF
--- a/www/content/tutorial.md
+++ b/www/content/tutorial.md
@@ -1807,22 +1807,6 @@ This is a useful technique to use when we don't want to write out a bunch of err
 - If we're using an editor that supports it, hovering over the `_` might display the inferred type that goes there.
 - We can put an obviously wrong type in there (e.g. replace the `{}` with `Str`, which is totally wrong) and look at the compiler error to see what it inferred as the correct type.
 
-We can also use `_` in type aliases, to express that two types are the same without annotating either of them. For example:
-
-```roc
-RunErr : _
-```
-
-```roc
-run : Task {} RunErr
-```
-
-```roc
-handleErr : RunErr -> [Exit I32 Str]
-```
-
-Of course, we could also choose not to use `_` at all and populate the `RunErr` type alias with the full list of errors that could happen in our `run` task. All of these are totally reasonable stylistic choices, depending on how you prefer the code to look. They all compile to exactly the same thing, and have the same runtime characteristics.
-
 ### [The ! suffix](#the-!-suffix) {#the-!-suffix}
 
 The `!` suffix operator is syntax sugar for the `Task.await` function, which has this type:


### PR DESCRIPTION
Support for e.g. `RunErr : _` got removed 4 months ago, see https://github.com/roc-lang/roc/commit/8357bd8c91a811b171912d072f24fa17a08019a8 . [More context](https://roc.zulipchat.com/#narrow/stream/231634-beginners/topic/.E2.9C.94.20Type.20alias.20definitions.20may.20not.20use.20inferred.20types/near/472047806).