### PR TITLE
Desugar suffixed `ValueDef::Expect` nodes

### DIFF
--- a/crates/compiler/can/src/desugar.rs
+++ b/crates/compiler/can/src/desugar.rs
@@ -290,8 +290,21 @@ pub fn desugar_value_def_suffixed<'a>(arena: &'a Bump, value_def: ValueDef<'a>) 
             }
         }
 
+        Expect {
+            condition,
+            preceding_comment,
+        } => match unwrap_suffixed_expression(arena, condition, None) {
+            Ok(new_condition) => ValueDef::Expect {
+                condition: new_condition,
+                preceding_comment,
+            },
+            Err(..) => {
+                internal_error!("Unable to desugar the suffix inside an Expect value def");
+            }
+        },
+
         // TODO support desugaring of Dbg, Expect, and ExpectFx
-        Dbg { .. } | Expect { .. } | ExpectFx { .. } => value_def,
+        Dbg { .. } | ExpectFx { .. } => value_def,
         ModuleImport { .. } | IngestedFileImport(_) => value_def,
 
         Stmt(..) => {

--- a/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__issue_7081.snap
+++ b/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__issue_7081.snap
@@ -1,0 +1,289 @@
+---
+source: crates/compiler/can/tests/test_suffixed.rs
+expression: snapshot
+---
+Defs {
+    tags: [
+        Index(2147483648),
+        Index(2147483649),
+        Index(2147483650),
+    ],
+    regions: [
+        @0-80,
+        @82-227,
+        @229-266,
+    ],
+    space_before: [
+        Slice(start = 0, length = 0),
+        Slice(start = 0, length = 2),
+        Slice(start = 2, length = 2),
+    ],
+    space_after: [
+        Slice(start = 0, length = 0),
+        Slice(start = 2, length = 0),
+        Slice(start = 4, length = 1),
+    ],
+    spaces: [
+        Newline,
+        Newline,
+        Newline,
+        Newline,
+        Newline,
+    ],
+    type_defs: [],
+    value_defs: [
+        Body(
+            @0-3 Identifier {
+                ident: "inc",
+            },
+            @6-80 Closure(
+                [
+                    @7-8 Identifier {
+                        ident: "i",
+                    },
+                ],
+                @16-80 If {
+                    if_thens: [
+                        (
+                            @19-24 Apply(
+                                @21-22 Var {
+                                    module_name: "Num",
+                                    ident: "isGt",
+                                },
+                                [
+                                    @19-20 Var {
+                                        module_name: "",
+                                        ident: "i",
+                                    },
+                                    @23-24 Num(
+                                        "2",
+                                    ),
+                                ],
+                                BinOp(
+                                    GreaterThan,
+                                ),
+                            ),
+                            @38-52 Apply(
+                                @38-41 Tag(
+                                    "Err",
+                                ),
+                                [
+                                    @42-52 Tag(
+                                        "MaxReached",
+                                    ),
+                                ],
+                                Space,
+                            ),
+                        ),
+                    ],
+                    final_else: @70-80 Apply(
+                        @70-72 Tag(
+                            "Ok",
+                        ),
+                        [
+                            @74-79 ParensAround(
+                                Apply(
+                                    @76-77 Var {
+                                        module_name: "Num",
+                                        ident: "add",
+                                    },
+                                    [
+                                        @74-75 Var {
+                                            module_name: "",
+                                            ident: "i",
+                                        },
+                                        @78-79 Num(
+                                            "1",
+                                        ),
+                                    ],
+                                    BinOp(
+                                        Plus,
+                                    ),
+                                ),
+                            ),
+                        ],
+                        Space,
+                    ),
+                    indented_else: false,
+                },
+            ),
+        ),
+        Expect {
+            condition: @93-227 Defs(
+                Defs {
+                    tags: [
+                        Index(2147483648),
+                        Index(2147483649),
+                    ],
+                    regions: [
+                        @99-189,
+                        @203-208,
+                    ],
+                    space_before: [
+                        Slice(start = 0, length = 0),
+                        Slice(start = 0, length = 1),
+                    ],
+                    space_after: [
+                        Slice(start = 0, length = 0),
+                        Slice(start = 1, length = 0),
+                    ],
+                    spaces: [
+                        Newline,
+                    ],
+                    type_defs: [],
+                    value_defs: [
+                        Body(
+                            @93-96 Identifier {
+                                ident: "run",
+                            },
+                            @99-189 Closure(
+                                [
+                                    @100-101 Identifier {
+                                        ident: "i",
+                                    },
+                                ],
+                                @132-172 Apply(
+                                    @132-172 Var {
+                                        module_name: "Result",
+                                        ident: "try",
+                                    },
+                                    [
+                                        @132-152 Apply(
+                                            @132-152 Var {
+                                                module_name: "",
+                                                ident: "inc",
+                                            },
+                                            [
+                                                @132-133 Var {
+                                                    module_name: "",
+                                                    ident: "i",
+                                                },
+                                            ],
+                                            BinOp(
+                                                Pizza,
+                                            ),
+                                        ),
+                                        @132-172 Closure(
+                                            [
+                                                @132-152 Identifier {
+                                                    ident: "#!0_arg",
+                                                },
+                                            ],
+                                            @132-172 Apply(
+                                                @132-172 Var {
+                                                    module_name: "Result",
+                                                    ident: "try",
+                                                },
+                                                [
+                                                    @132-172 Apply(
+                                                        @132-172 Var {
+                                                            module_name: "",
+                                                            ident: "inc",
+                                                        },
+                                                        [
+                                                            @132-152 Var {
+                                                                module_name: "",
+                                                                ident: "#!0_arg",
+                                                            },
+                                                        ],
+                                                        BinOp(
+                                                            Pizza,
+                                                        ),
+                                                    ),
+                                                    @132-172 Closure(
+                                                        [
+                                                            @113-117 Identifier {
+                                                                ident: "newi",
+                                                            },
+                                                        ],
+                                                        @182-189 Apply(
+                                                            @182-184 Tag(
+                                                                "Ok",
+                                                            ),
+                                                            [
+                                                                @185-189 Var {
+                                                                    module_name: "",
+                                                                    ident: "newi",
+                                                                },
+                                                            ],
+                                                            Space,
+                                                        ),
+                                                    ),
+                                                ],
+                                                QuestionSuffix,
+                                            ),
+                                        ),
+                                    ],
+                                    QuestionSuffix,
+                                ),
+                            ),
+                        ),
+                        Body(
+                            @194-200 Identifier {
+                                ident: "result",
+                            },
+                            @203-208 Apply(
+                                @203-206 Var {
+                                    module_name: "",
+                                    ident: "run",
+                                },
+                                [
+                                    @207-208 Num(
+                                        "0",
+                                    ),
+                                ],
+                                Space,
+                            ),
+                        ),
+                    ],
+                },
+                @213-227 Apply(
+                    @220-222 Var {
+                        module_name: "Bool",
+                        ident: "isEq",
+                    },
+                    [
+                        @213-219 Var {
+                            module_name: "",
+                            ident: "result",
+                        },
+                        @223-227 Apply(
+                            @223-225 Tag(
+                                "Ok",
+                            ),
+                            [
+                                @226-227 Num(
+                                    "2",
+                                ),
+                            ],
+                            Space,
+                        ),
+                    ],
+                    BinOp(
+                        Equals,
+                    ),
+                ),
+            ),
+            preceding_comment: @82-82,
+        },
+        Body(
+            @229-233 Identifier {
+                ident: "main",
+            },
+            @240-266 Apply(
+                @240-266 Var {
+                    module_name: "Stdout",
+                    ident: "line",
+                },
+                [
+                    @253-266 Str(
+                        PlainLine(
+                            "Hello world",
+                        ),
+                    ),
+                ],
+                Space,
+            ),
+        ),
+    ],
+}

--- a/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__issue_7081.snap.new
+++ b/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__issue_7081.snap.new
@@ -1,0 +1,290 @@
+---
+source: crates/compiler/can/tests/test_suffixed.rs
+assertion_line: 612
+expression: snapshot
+---
+Defs {
+    tags: [
+        Index(2147483648),
+        Index(2147483649),
+        Index(2147483650),
+    ],
+    regions: [
+        @0-80,
+        @82-227,
+        @229-266,
+    ],
+    space_before: [
+        Slice(start = 0, length = 0),
+        Slice(start = 0, length = 2),
+        Slice(start = 2, length = 2),
+    ],
+    space_after: [
+        Slice(start = 0, length = 0),
+        Slice(start = 2, length = 0),
+        Slice(start = 4, length = 1),
+    ],
+    spaces: [
+        Newline,
+        Newline,
+        Newline,
+        Newline,
+        Newline,
+    ],
+    type_defs: [],
+    value_defs: [
+        Body(
+            @0-3 Identifier {
+                ident: "inc",
+            },
+            @6-80 Closure(
+                [
+                    @7-8 Identifier {
+                        ident: "i",
+                    },
+                ],
+                @16-80 If {
+                    if_thens: [
+                        (
+                            @19-24 Apply(
+                                @21-22 Var {
+                                    module_name: "Num",
+                                    ident: "isGt",
+                                },
+                                [
+                                    @19-20 Var {
+                                        module_name: "",
+                                        ident: "i",
+                                    },
+                                    @23-24 Num(
+                                        "2",
+                                    ),
+                                ],
+                                BinOp(
+                                    GreaterThan,
+                                ),
+                            ),
+                            @38-52 Apply(
+                                @38-41 Tag(
+                                    "Err",
+                                ),
+                                [
+                                    @42-52 Tag(
+                                        "MaxReached",
+                                    ),
+                                ],
+                                Space,
+                            ),
+                        ),
+                    ],
+                    final_else: @70-80 Apply(
+                        @70-72 Tag(
+                            "Ok",
+                        ),
+                        [
+                            @74-79 ParensAround(
+                                Apply(
+                                    @76-77 Var {
+                                        module_name: "Num",
+                                        ident: "add",
+                                    },
+                                    [
+                                        @74-75 Var {
+                                            module_name: "",
+                                            ident: "i",
+                                        },
+                                        @78-79 Num(
+                                            "1",
+                                        ),
+                                    ],
+                                    BinOp(
+                                        Plus,
+                                    ),
+                                ),
+                            ),
+                        ],
+                        Space,
+                    ),
+                    indented_else: false,
+                },
+            ),
+        ),
+        Expect {
+            condition: @93-227 Defs(
+                Defs {
+                    tags: [
+                        Index(2147483648),
+                        Index(2147483649),
+                    ],
+                    regions: [
+                        @99-189,
+                        @203-208,
+                    ],
+                    space_before: [
+                        Slice(start = 0, length = 0),
+                        Slice(start = 0, length = 1),
+                    ],
+                    space_after: [
+                        Slice(start = 0, length = 0),
+                        Slice(start = 1, length = 0),
+                    ],
+                    spaces: [
+                        Newline,
+                    ],
+                    type_defs: [],
+                    value_defs: [
+                        Body(
+                            @93-96 Identifier {
+                                ident: "run",
+                            },
+                            @99-189 Closure(
+                                [
+                                    @100-101 Identifier {
+                                        ident: "i",
+                                    },
+                                ],
+                                @132-172 Apply(
+                                    @132-172 Var {
+                                        module_name: "Result",
+                                        ident: "try",
+                                    },
+                                    [
+                                        @132-152 Apply(
+                                            @132-152 Var {
+                                                module_name: "",
+                                                ident: "inc",
+                                            },
+                                            [
+                                                @132-133 Var {
+                                                    module_name: "",
+                                                    ident: "i",
+                                                },
+                                            ],
+                                            BinOp(
+                                                Pizza,
+                                            ),
+                                        ),
+                                        @132-172 Closure(
+                                            [
+                                                @132-152 Identifier {
+                                                    ident: "#!0_arg",
+                                                },
+                                            ],
+                                            @132-172 Apply(
+                                                @132-172 Var {
+                                                    module_name: "Result",
+                                                    ident: "try",
+                                                },
+                                                [
+                                                    @132-172 Apply(
+                                                        @132-172 Var {
+                                                            module_name: "",
+                                                            ident: "inc",
+                                                        },
+                                                        [
+                                                            @132-152 Var {
+                                                                module_name: "",
+                                                                ident: "#!0_arg",
+                                                            },
+                                                        ],
+                                                        BinOp(
+                                                            Pizza,
+                                                        ),
+                                                    ),
+                                                    @132-172 Closure(
+                                                        [
+                                                            @113-117 Identifier {
+                                                                ident: "newi",
+                                                            },
+                                                        ],
+                                                        @182-189 Apply(
+                                                            @182-184 Tag(
+                                                                "Ok",
+                                                            ),
+                                                            [
+                                                                @185-189 Var {
+                                                                    module_name: "",
+                                                                    ident: "newi",
+                                                                },
+                                                            ],
+                                                            Space,
+                                                        ),
+                                                    ),
+                                                ],
+                                                QuestionSuffix,
+                                            ),
+                                        ),
+                                    ],
+                                    QuestionSuffix,
+                                ),
+                            ),
+                        ),
+                        Body(
+                            @194-200 Identifier {
+                                ident: "result",
+                            },
+                            @203-208 Apply(
+                                @203-206 Var {
+                                    module_name: "",
+                                    ident: "run",
+                                },
+                                [
+                                    @207-208 Num(
+                                        "0",
+                                    ),
+                                ],
+                                Space,
+                            ),
+                        ),
+                    ],
+                },
+                @213-227 Apply(
+                    @220-222 Var {
+                        module_name: "Bool",
+                        ident: "isEq",
+                    },
+                    [
+                        @213-219 Var {
+                            module_name: "",
+                            ident: "result",
+                        },
+                        @223-227 Apply(
+                            @223-225 Tag(
+                                "Ok",
+                            ),
+                            [
+                                @226-227 Num(
+                                    "2",
+                                ),
+                            ],
+                            Space,
+                        ),
+                    ],
+                    BinOp(
+                        Equals,
+                    ),
+                ),
+            ),
+            preceding_comment: @82-82,
+        },
+        Body(
+            @229-233 Identifier {
+                ident: "main",
+            },
+            @240-266 Apply(
+                @240-266 Var {
+                    module_name: "Stdout",
+                    ident: "line",
+                },
+                [
+                    @253-266 Str(
+                        PlainLine(
+                            "Hello world",
+                        ),
+                    ),
+                ],
+                Space,
+            ),
+        ),
+    ],
+}

--- a/crates/compiler/can/tests/test_suffixed.rs
+++ b/crates/compiler/can/tests/test_suffixed.rs
@@ -606,6 +606,32 @@ mod suffixed_tests {
             "##
         );
     }
+
+    #[test]
+    fn issue_7081() {
+        run_test!(
+            r##"
+            inc = \i ->
+                if i > 2 then
+                    Err MaxReached
+                else
+                    Ok (i + 1)
+
+            expect
+                run = \i ->
+                    newi =
+                        i
+                        |> inc?
+                        |> inc?
+                    Ok newi
+                result = run 0
+                result == Ok 2
+
+            main =
+                Stdout.line! "Hello world"
+            "##
+        );
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Fix #7081 

Tested using `main.roc` below

```roc
app [main] {
    pf: platform "https://github.com/roc-lang/basic-cli/releases/download/0.15.0/SlwdbJ-3GR7uBWQo6zlmYWNYOxnvo8r6YABXD-45UOw.tar.br",
}

import pf.Stdout

inc = \i ->
    if i > 2 then
        Err MaxReached
    else
        Ok (i + 1)

expect
    run = \i ->
        newi =
            i
            |> inc?
            |> inc?
        Ok newi
    result = run 0
    result == Ok 2

main =
    Stdout.line! "Hello world"
```

```sh
$ nix develop
$ cargo run -- test main.roc
    Finished dev [unoptimized + debuginfo] target(s) in 0.42s
     Running `target/debug/roc test main.roc`
0 failed and 1 passed in 566 ms.
```