### PR TITLE
Fix `roc_cache_dir()` and introduce `roc_cache_packages_dir()` (#6616)

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -564,7 +564,7 @@ pub fn test(matches: &ArgMatches, target: Target) -> io::Result<i32> {
         arena,
         path.to_path_buf(),
         opt_main_path.cloned(),
-        RocCacheDir::Persistent(cache::roc_cache_dir().as_path()),
+        RocCacheDir::Persistent(cache::roc_cache_packages_dir().as_path()),
         load_config,
     );
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -49,7 +49,7 @@ fn main() -> io::Result<()> {
                     BuildConfig::BuildAndRunIfNoErrors,
                     Triple::host().into(),
                     None,
-                    RocCacheDir::Persistent(cache::roc_cache_dir().as_path()),
+                    RocCacheDir::Persistent(cache::roc_cache_packages_dir().as_path()),
                     LinkType::Executable,
                 )
             } else {
@@ -64,7 +64,7 @@ fn main() -> io::Result<()> {
                     BuildConfig::BuildAndRun,
                     Triple::host().into(),
                     None,
-                    RocCacheDir::Persistent(cache::roc_cache_dir().as_path()),
+                    RocCacheDir::Persistent(cache::roc_cache_packages_dir().as_path()),
                     LinkType::Executable,
                 )
             } else {
@@ -90,7 +90,7 @@ fn main() -> io::Result<()> {
                     BuildConfig::BuildAndRunIfNoErrors,
                     Triple::host().into(),
                     None,
-                    RocCacheDir::Persistent(cache::roc_cache_dir().as_path()),
+                    RocCacheDir::Persistent(cache::roc_cache_packages_dir().as_path()),
                     LinkType::Executable,
                 )
             } else {
@@ -127,7 +127,7 @@ fn main() -> io::Result<()> {
             let function_kind = FunctionKind::from_env();
             roc_linker::generate_stub_lib(
                 input_path,
-                RocCacheDir::Persistent(cache::roc_cache_dir().as_path()),
+                RocCacheDir::Persistent(cache::roc_cache_packages_dir().as_path()),
                 target,
                 function_kind,
             );
@@ -199,7 +199,7 @@ fn main() -> io::Result<()> {
                 BuildConfig::BuildOnly,
                 target,
                 out_path,
-                RocCacheDir::Persistent(cache::roc_cache_dir().as_path()),
+                RocCacheDir::Persistent(cache::roc_cache_packages_dir().as_path()),
                 link_type,
             )?)
         }
@@ -222,7 +222,7 @@ fn main() -> io::Result<()> {
                 roc_file_path.to_owned(),
                 opt_main_path.cloned(),
                 emit_timings,
-                RocCacheDir::Persistent(cache::roc_cache_dir().as_path()),
+                RocCacheDir::Persistent(cache::roc_cache_packages_dir().as_path()),
                 threading,
             ) {
                 Ok((problems, total_time)) => {

--- a/crates/compiler/load_internal/src/file.rs
+++ b/crates/compiler/load_internal/src/file.rs
@@ -784,7 +784,7 @@ impl<'a> State<'a> {
         number_of_workers: usize,
         exec_mode: ExecutionMode,
     ) -> Self {
-        let cache_dir = roc_packaging::cache::roc_cache_dir();
+        let cache_dir = roc_packaging::cache::roc_cache_packages_dir();
         let dependencies = Dependencies::new(exec_mode.goal_phase());
 
         Self {

--- a/crates/docs/src/lib.rs
+++ b/crates/docs/src/lib.rs
@@ -483,7 +483,7 @@ pub fn load_module_for_docs(filename: PathBuf) -> LoadedModule {
         &arena,
         filename,
         None,
-        RocCacheDir::Persistent(cache::roc_cache_dir().as_path()),
+        RocCacheDir::Persistent(cache::roc_cache_packages_dir().as_path()),
         load_config,
     ) {
         Ok(loaded) => loaded,

--- a/crates/glue/src/load.rs
+++ b/crates/glue/src/load.rs
@@ -88,7 +88,7 @@ pub fn generate(
                     linking_strategy,
                     true,
                     None,
-                    RocCacheDir::Persistent(cache::roc_cache_dir().as_path()),
+                    RocCacheDir::Persistent(cache::roc_cache_packages_dir().as_path()),
                     load_config,
                     Some(dylib_dir.path()),
                 ),
@@ -414,7 +414,7 @@ pub fn load_types(
         arena,
         full_file_path,
         None,
-        RocCacheDir::Persistent(cache::roc_cache_dir().as_path()),
+        RocCacheDir::Persistent(cache::roc_cache_packages_dir().as_path()),
         LoadConfig {
             target,
             function_kind,

--- a/crates/language_server/src/analysis.rs
+++ b/crates/language_server/src/analysis.rs
@@ -114,7 +114,7 @@ pub(crate) fn global_analysis(doc_info: DocInfo) -> Vec<AnalyzedDocument> {
         roc_target::Target::LinuxX64,
         roc_load::FunctionKind::LambdaSet,
         roc_reporting::report::RenderTarget::LanguageServer,
-        RocCacheDir::Persistent(cache::roc_cache_dir().as_path()),
+        RocCacheDir::Persistent(cache::roc_cache_packages_dir().as_path()),
         roc_reporting::report::DEFAULT_PALETTE,
     );
 

--- a/crates/language_server/src/convert.rs
+++ b/crates/language_server/src/convert.rs
@@ -160,7 +160,7 @@ pub(crate) mod diag {
                 LoadingProblem::CouldNotFindCacheDir => {
                     format!(
                         "Could not find Roc cache directory {}",
-                        roc_packaging::cache::roc_cache_dir().display()
+                        roc_packaging::cache::roc_cache_packages_dir().display()
                     )
                 }
                 LoadingProblem::UnrecognizedPackageShorthand { shorthand, .. } => {

--- a/crates/packaging/src/cache.rs
+++ b/crates/packaging/src/cache.rs
@@ -207,7 +207,7 @@ const ROC_CACHE_DIR_NAME: &str = "roc";
 
 /// This looks up environment variables, so it should ideally be called once and then cached!
 ///
-/// Returns a path of the form cache_dir_path.join(ROC_CACHE_DIR_NAME).join("packages")
+/// Returns a path of the form cache_dir_path.join(ROC_CACHE_DIR_NAME)
 /// where cache_dir_path is:
 /// - The XDG_CACHE_HOME environment varaible, if it's set.
 /// - Otherwise, ~/.cache on UNIX and %APPDATA% on Windows.
@@ -222,14 +222,11 @@ const ROC_CACHE_DIR_NAME: &str = "roc";
 pub fn roc_cache_dir() -> PathBuf {
     use std::{env, process};
 
-    const PACKAGES_DIR_NAME: &str = "packages";
-
     // Respect XDG, if the system appears to be using it.
     // https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
     match env::var_os("XDG_CACHE_HOME") {
         Some(xdg_cache_home) => Path::new(&xdg_cache_home)
             .join(ROC_CACHE_DIR_NAME)
-            .join(PACKAGES_DIR_NAME),
         None => {
             #[cfg(windows)]
             {
@@ -241,7 +238,6 @@ pub fn roc_cache_dir() -> PathBuf {
                 {
                     Path::new(&appdata)
                         .join(ROC_CACHE_DIR_NAME)
-                        .join(PACKAGES_DIR_NAME)
                 } else {
                     eprintln!("roc needs either the %APPDATA% or else the %XDG_CACHE_HOME% environment variables set. Please set one of these environment variables and re-run roc!");
                     process::exit(1);
@@ -255,7 +251,6 @@ pub fn roc_cache_dir() -> PathBuf {
                     Path::new(&home)
                         .join(".cache")
                         .join(ROC_CACHE_DIR_NAME)
-                        .join(PACKAGES_DIR_NAME)
                 } else {
                     eprintln!("roc needs either the $HOME or else the $XDG_CACHE_HOME environment variables set. Please set one of these environment variables and re-run roc!");
                     process::exit(1);
@@ -265,9 +260,26 @@ pub fn roc_cache_dir() -> PathBuf {
     }
 }
 
+/// Returns a path of the form roc_cache_dir().join("packages")
+#[cfg(not(target_family = "wasm"))]
+pub fn roc_cache_packages_dir() -> PathBuf {
+    const PACKAGES_DIR_NAME: &str = "packages";
+    roc_cache_dir().join(PACKAGES_DIR_NAME)
+}
+
 /// WASI doesn't have a home directory, so just make the cache dir in the current directory
 /// https://github.com/WebAssembly/wasi-filesystem/issues/59
 #[cfg(target_family = "wasm")]
 pub fn roc_cache_dir() -> PathBuf {
     PathBuf::from(".cache").join(ROC_CACHE_DIR_NAME)
+}
+
+/// WASI doesn't have a home directory, so just make the cache dir in the current directory
+/// https://github.com/WebAssembly/wasi-filesystem/issues/59
+#[cfg(target_family = "wasm")]
+pub fn roc_cache_packages_dir() -> PathBuf {
+    const PACKAGES_DIR_NAME: &str = "packages";
+    PathBuf::from(".cache")
+        .join(ROC_CACHE_DIR_NAME)
+        .join(PACKAGES_DIR_NAME)
 }

--- a/crates/packaging/src/cache.rs
+++ b/crates/packaging/src/cache.rs
@@ -225,8 +225,7 @@ pub fn roc_cache_dir() -> PathBuf {
     // Respect XDG, if the system appears to be using it.
     // https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
     match env::var_os("XDG_CACHE_HOME") {
-        Some(xdg_cache_home) => Path::new(&xdg_cache_home)
-            .join(ROC_CACHE_DIR_NAME)
+        Some(xdg_cache_home) => Path::new(&xdg_cache_home).join(ROC_CACHE_DIR_NAME),
         None => {
             #[cfg(windows)]
             {
@@ -236,8 +235,7 @@ pub fn roc_cache_dir() -> PathBuf {
                     // https://learn.microsoft.com/en-us/windows/deployment/usmt/usmt-recognized-environment-variables
                     env::var_os("APPDATA").or_else(|| env::var_os("CSIDL_APPDATA"))
                 {
-                    Path::new(&appdata)
-                        .join(ROC_CACHE_DIR_NAME)
+                    Path::new(&appdata).join(ROC_CACHE_DIR_NAME)
                 } else {
                     eprintln!("roc needs either the %APPDATA% or else the %XDG_CACHE_HOME% environment variables set. Please set one of these environment variables and re-run roc!");
                     process::exit(1);
@@ -248,9 +246,7 @@ pub fn roc_cache_dir() -> PathBuf {
             {
                 // e.g. $HOME/.cache/roc
                 if let Some(home) = env::var_os("HOME") {
-                    Path::new(&home)
-                        .join(".cache")
-                        .join(ROC_CACHE_DIR_NAME)
+                    Path::new(&home).join(".cache").join(ROC_CACHE_DIR_NAME)
                 } else {
                     eprintln!("roc needs either the $HOME or else the $XDG_CACHE_HOME environment variables set. Please set one of these environment variables and re-run roc!");
                     process::exit(1);

--- a/crates/packaging/src/cache.rs
+++ b/crates/packaging/src/cache.rs
@@ -260,13 +260,6 @@ pub fn roc_cache_dir() -> PathBuf {
     }
 }
 
-/// Returns a path of the form roc_cache_dir().join("packages")
-#[cfg(not(target_family = "wasm"))]
-pub fn roc_cache_packages_dir() -> PathBuf {
-    const PACKAGES_DIR_NAME: &str = "packages";
-    roc_cache_dir().join(PACKAGES_DIR_NAME)
-}
-
 /// WASI doesn't have a home directory, so just make the cache dir in the current directory
 /// https://github.com/WebAssembly/wasi-filesystem/issues/59
 #[cfg(target_family = "wasm")]
@@ -274,12 +267,8 @@ pub fn roc_cache_dir() -> PathBuf {
     PathBuf::from(".cache").join(ROC_CACHE_DIR_NAME)
 }
 
-/// WASI doesn't have a home directory, so just make the cache dir in the current directory
-/// https://github.com/WebAssembly/wasi-filesystem/issues/59
-#[cfg(target_family = "wasm")]
+/// Returns a path of the form roc_cache_dir().join("packages")
 pub fn roc_cache_packages_dir() -> PathBuf {
     const PACKAGES_DIR_NAME: &str = "packages";
-    PathBuf::from(".cache")
-        .join(ROC_CACHE_DIR_NAME)
-        .join(PACKAGES_DIR_NAME)
+    roc_cache_dir().join(PACKAGES_DIR_NAME)
 }

--- a/crates/repl_eval/src/gen.rs
+++ b/crates/repl_eval/src/gen.rs
@@ -61,7 +61,7 @@ pub fn compile_to_mono<'a, 'i, I: Iterator<Item = &'i str>>(
         module_src,
         src_dir,
         None,
-        RocCacheDir::Persistent(cache::roc_cache_dir().as_path()),
+        RocCacheDir::Persistent(cache::roc_cache_packages_dir().as_path()),
         LoadConfig {
             target,
             function_kind: FunctionKind::LambdaSet,


### PR DESCRIPTION
Related to #6616, this pull request introduces the following changes: 

1. Changes the `roc_cache_dir()` function to return `~/.cache/roc` instead of `~/.cache/roc/packages`
2. Introduces a new function, `roc_cache_packages_dir()`, which returns `~/.cache/roc/packages`
3. Updates all existing uses of `roc_cache_dir()` with `roc_cache_packages_dir()` for parity with existing behavior