### PR TITLE
Specialize types pass

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3138,13 +3138,22 @@ dependencies = [
  "hashbrown",
  "indoc",
  "parking_lot",
+ "pretty_assertions",
+ "roc_builtins",
  "roc_can",
  "roc_collections",
- "roc_debug_flags",
+ "roc_derive",
+ "roc_load",
  "roc_module",
+ "roc_parse",
+ "roc_problem",
  "roc_region",
+ "roc_reporting",
+ "roc_solve",
+ "roc_target",
  "roc_types",
  "static_assertions",
+ "test_solve_helpers",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3141,6 +3141,7 @@ dependencies = [
  "roc_can",
  "roc_collections",
  "roc_debug_flags",
+ "roc_module",
  "roc_region",
  "roc_types",
  "static_assertions",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3152,6 +3152,7 @@ dependencies = [
  "roc_solve",
  "roc_target",
  "roc_types",
+ "soa",
  "static_assertions",
  "test_solve_helpers",
 ]
@@ -3621,6 +3622,10 @@ name = "smallvec"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
+
+[[package]]
+name = "soa"
+version = "0.0.1"
 
 [[package]]
 name = "socket2"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3129,6 +3129,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "roc_specialize_types"
+version = "0.0.1"
+dependencies = [
+ "arrayvec 0.7.4",
+ "bitvec",
+ "bumpalo",
+ "hashbrown",
+ "indoc",
+ "parking_lot",
+ "roc_can",
+ "roc_collections",
+ "roc_debug_flags",
+ "roc_region",
+ "roc_types",
+ "static_assertions",
+]
+
+[[package]]
 name = "roc_std"
 version = "0.0.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,8 @@ inkwell = { git = "https://github.com/roc-lang/inkwell", branch = "inkwell-llvm-
     "llvm16-0",
 ] }
 
+roc_specialize_types = { path = "crates/compiler/specialize_types" }
+
 arrayvec = "0.7.2" # update roc_std/Cargo.toml on change
 backtrace = "0.3.67"
 base64-url = "1.4.13"
@@ -138,7 +140,10 @@ maplit = "1.0.2"
 memmap2 = "0.5.10"
 mimalloc = { version = "0.1.34", default-features = false }
 nonempty = "0.8.1"
-object = { version = "0.32.2", default-features = false, features = ["read", "write"] }
+object = { version = "0.32.2", default-features = false, features = [
+    "read",
+    "write",
+] }
 packed_struct = "0.10.1"
 page_size = "0.5.0"
 palette = "0.6.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,7 @@ inkwell = { git = "https://github.com/roc-lang/inkwell", branch = "inkwell-llvm-
     "llvm16-0",
 ] }
 
+soa = { path = "crates/soa" }
 roc_specialize_types = { path = "crates/compiler/specialize_types" }
 
 arrayvec = "0.7.2" # update roc_std/Cargo.toml on change

--- a/crates/compiler/collections/src/lib.rs
+++ b/crates/compiler/collections/src/lib.rs
@@ -4,6 +4,7 @@
 #![allow(clippy::large_enum_variant)]
 
 pub mod all;
+mod push;
 mod reference_matrix;
 mod small_string_interner;
 mod small_vec;
@@ -12,6 +13,7 @@ mod vec_map;
 mod vec_set;
 
 pub use all::{default_hasher, BumpMap, ImEntry, ImMap, ImSet, MutMap, MutSet, SendMap};
+pub use push::Push;
 pub use reference_matrix::{ReferenceMatrix, Sccs, TopologicalSort};
 pub use small_string_interner::SmallStringInterner;
 pub use small_vec::SmallVec;

--- a/crates/compiler/collections/src/push.rs
+++ b/crates/compiler/collections/src/push.rs
@@ -1,0 +1,3 @@
+pub trait Push<T> {
+    fn push(&mut self, entry: T);
+}

--- a/crates/compiler/load/tests/test_reporting.rs
+++ b/crates/compiler/load/tests/test_reporting.rs
@@ -10971,7 +10971,7 @@ All branches in an `if` must have the same type!
     4│      Recursive := [Infinitely Recursive]
             ^^^^^^^^^
 
-    Recursion in opaquees is only allowed if recursion happens behind a
+    Recursion in opaques is only allowed if recursion happens behind a
     tagged union, at least one variant of which is not recursive.
     "
     );

--- a/crates/compiler/specialize_types/Cargo.toml
+++ b/crates/compiler/specialize_types/Cargo.toml
@@ -13,6 +13,8 @@ roc_region = { path = "../region" }
 roc_types = { path = "../types" }
 roc_collections = { path = "../collections" }
 roc_debug_flags = { path = "../debug_flags" }
+# roc_module is only used for TagName
+roc_module = { path = "../module" }
 
 bitvec.workspace = true
 arrayvec.workspace = true

--- a/crates/compiler/specialize_types/Cargo.toml
+++ b/crates/compiler/specialize_types/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "roc_specialize_types"
+description = "Convert a type-checked canonical IR to a monomorphized IR by creating specializations of all functions, such that they are monomorphic in types. We will specialize again later after computing lambda sets, which happens after this pass."
+
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+version.workspace = true
+
+[dependencies]
+roc_can = { path = "../can" }
+roc_region = { path = "../region" }
+roc_types = { path = "../types" }
+roc_collections = { path = "../collections" }
+roc_debug_flags = { path = "../debug_flags" }
+
+bitvec.workspace = true
+arrayvec.workspace = true
+bumpalo.workspace = true
+hashbrown.workspace = true
+parking_lot.workspace = true
+static_assertions.workspace = true
+indoc.workspace = true

--- a/crates/compiler/specialize_types/Cargo.toml
+++ b/crates/compiler/specialize_types/Cargo.toml
@@ -12,8 +12,6 @@ roc_can = { path = "../can" }
 roc_region = { path = "../region" }
 roc_types = { path = "../types" }
 roc_collections = { path = "../collections" }
-roc_debug_flags = { path = "../debug_flags" }
-# roc_module is only used for TagName
 roc_module = { path = "../module" }
 
 bitvec.workspace = true
@@ -23,3 +21,16 @@ hashbrown.workspace = true
 parking_lot.workspace = true
 static_assertions.workspace = true
 indoc.workspace = true
+
+[dev-dependencies]
+roc_builtins = { path = "../builtins" }
+roc_derive = { path = "../derive", features = ["debug-derived-symbols"] }
+roc_load = { path = "../load" }
+roc_parse = { path = "../parse" }
+roc_problem = { path = "../problem" }
+roc_reporting = { path = "../../reporting" }
+roc_target = { path = "../roc_target" }
+roc_solve = { path = "../solve" }
+test_solve_helpers = { path = "../test_solve_helpers" }
+
+pretty_assertions.workspace = true

--- a/crates/compiler/specialize_types/Cargo.toml
+++ b/crates/compiler/specialize_types/Cargo.toml
@@ -22,6 +22,8 @@ parking_lot.workspace = true
 static_assertions.workspace = true
 indoc.workspace = true
 
+soa.workspace = true
+
 [dev-dependencies]
 roc_builtins = { path = "../builtins" }
 roc_derive = { path = "../derive", features = ["debug-derived-symbols"] }

--- a/crates/compiler/specialize_types/src/expr.rs
+++ b/crates/compiler/specialize_types/src/expr.rs
@@ -1,0 +1,646 @@
+use roc_can::expr::{
+    ClosureData, Expr, Field, OpaqueWrapFunctionData, StructAccessorData, WhenBranch,
+    WhenBranchPattern,
+};
+use roc_region::all::Loc;
+use roc_types::subs::{
+    AliasVariables, Content, Descriptor, FlatType, LambdaSet, RecordFields, Subs, SubsSlice,
+    TupleElems, UnionLabels, Variable, VariableSubsSlice,
+};
+use roc_types::types::{Type, Uls};
+
+pub fn monomorphize(expr: Loc<Expr>, subs: &mut Subs) -> Loc<Expr> {
+    Loc {
+        region: expr.region,
+        value: monomorphize_expr(expr.value, subs),
+    }
+}
+
+fn monomorphize_expr(expr: Expr, subs: &mut Subs) -> Expr {
+    match expr {
+        Expr::Num(var, str, int_value, bound) => {
+            Expr::Num(monomorphize_var(var, subs), str, int_value, bound)
+        }
+        Expr::Int(var1, var2, str, int_value, bound) => Expr::Int(
+            monomorphize_var(var1, subs),
+            monomorphize_var(var2, subs),
+            str,
+            int_value,
+            bound,
+        ),
+        Expr::Float(var1, var2, str, float_value, bound) => Expr::Float(
+            monomorphize_var(var1, subs),
+            monomorphize_var(var2, subs),
+            str,
+            float_value,
+            bound,
+        ),
+        Expr::Str(s) => Expr::Str(s),
+        Expr::IngestedFile(path, bytes, var) => {
+            Expr::IngestedFile(path, bytes, monomorphize_var(var, subs))
+        }
+        Expr::SingleQuote(var1, var2, c, bound) => Expr::SingleQuote(
+            monomorphize_var(var1, subs),
+            monomorphize_var(var2, subs),
+            c,
+            bound,
+        ),
+        Expr::List {
+            elem_var,
+            loc_elems,
+        } => Expr::List {
+            elem_var: monomorphize_var(elem_var, subs),
+            loc_elems: loc_elems
+                .into_iter()
+                .map(|loc_elem| monomorphize(loc_elem, subs))
+                .collect(),
+        },
+        Expr::Var(symbol, var) => Expr::Var(symbol, monomorphize_var(var, subs)),
+        Expr::ParamsVar {
+            symbol,
+            var,
+            params_symbol,
+            params_var,
+        } => Expr::ParamsVar {
+            symbol,
+            var: monomorphize_var(var, subs),
+            params_symbol,
+            params_var: monomorphize_var(params_var, subs),
+        },
+        Expr::AbilityMember(symbol, spec_id, var) => {
+            Expr::AbilityMember(symbol, spec_id, monomorphize_var(var, subs))
+        }
+        Expr::When {
+            cond_var,
+            expr_var,
+            region,
+            loc_cond,
+            branches,
+            branches_cond_var,
+            exhaustive,
+        } => Expr::When {
+            cond_var: monomorphize_var(cond_var, subs),
+            expr_var: monomorphize_var(expr_var, subs),
+            region,
+            loc_cond: Box::new(monomorphize(*loc_cond, subs)),
+            branches: branches
+                .into_iter()
+                .map(|branch| monomorphize_when_branch(branch, subs))
+                .collect(),
+            branches_cond_var: monomorphize_var(branches_cond_var, subs),
+            exhaustive,
+        },
+        Expr::If {
+            cond_var,
+            branch_var,
+            branches,
+            final_else,
+        } => Expr::If {
+            cond_var: monomorphize_var(cond_var, subs),
+            branch_var: monomorphize_var(branch_var, subs),
+            branches: branches
+                .into_iter()
+                .map(|(cond, expr)| (monomorphize(cond, subs), monomorphize(expr, subs)))
+                .collect(),
+            final_else: Box::new(monomorphize(*final_else, subs)),
+        },
+        Expr::LetRec(defs, expr, cycle_mark) => Expr::LetRec(
+            defs.into_iter()
+                .map(|def| monomorphize_def(def, subs))
+                .collect(),
+            Box::new(monomorphize(*expr, subs)),
+            cycle_mark,
+        ),
+        Expr::LetNonRec(def, expr) => Expr::LetNonRec(
+            Box::new(monomorphize_def(*def, subs)),
+            Box::new(monomorphize(*expr, subs)),
+        ),
+        Expr::Call(boxed, args, called_via) => {
+            let (fn_var, loc_expr, lambda_set_var, ret_var) = *boxed;
+            Expr::Call(
+                Box::new((
+                    monomorphize_var(fn_var, subs),
+                    monomorphize(loc_expr, subs),
+                    monomorphize_var(lambda_set_var, subs),
+                    monomorphize_var(ret_var, subs),
+                )),
+                args.into_iter()
+                    .map(|(var, loc_expr)| {
+                        (monomorphize_var(var, subs), monomorphize(loc_expr, subs))
+                    })
+                    .collect(),
+                called_via,
+            )
+        }
+        Expr::Closure(closure_data) => Expr::Closure(monomorphize_closure_data(closure_data, subs)),
+        Expr::Record { record_var, fields } => Expr::Record {
+            record_var: monomorphize_var(record_var, subs),
+            fields: fields
+                .into_iter()
+                .map(|(k, v)| (k, monomorphize_field(v, subs)))
+                .collect(),
+        },
+        Expr::EmptyRecord => Expr::EmptyRecord,
+        Expr::Tuple { tuple_var, elems } => Expr::Tuple {
+            tuple_var: monomorphize_var(tuple_var, subs),
+            elems: elems
+                .into_iter()
+                .map(|(var, loc_expr)| {
+                    (
+                        monomorphize_var(var, subs),
+                        Box::new(monomorphize(*loc_expr, subs)),
+                    )
+                })
+                .collect(),
+        },
+        Expr::ImportParams(module_id, region, params) => Expr::ImportParams(
+            module_id,
+            region,
+            params.map(|(var, expr)| {
+                (
+                    monomorphize_var(var, subs),
+                    Box::new(monomorphize_expr(*expr, subs)),
+                )
+            }),
+        ),
+        Expr::Crash { msg, ret_var } => Expr::Crash {
+            msg: Box::new(monomorphize(*msg, subs)),
+            ret_var: monomorphize_var(ret_var, subs),
+        },
+        Expr::RecordAccess {
+            record_var,
+            ext_var,
+            field_var,
+            loc_expr,
+            field,
+        } => Expr::RecordAccess {
+            record_var: monomorphize_var(record_var, subs),
+            ext_var: monomorphize_var(ext_var, subs),
+            field_var: monomorphize_var(field_var, subs),
+            loc_expr: Box::new(monomorphize(*loc_expr, subs)),
+            field,
+        },
+        Expr::RecordAccessor(data) => {
+            Expr::RecordAccessor(monomorphize_struct_accessor_data(data, subs))
+        }
+        Expr::TupleAccess {
+            tuple_var,
+            ext_var,
+            elem_var,
+            loc_expr,
+            index,
+        } => Expr::TupleAccess {
+            tuple_var: monomorphize_var(tuple_var, subs),
+            ext_var: monomorphize_var(ext_var, subs),
+            elem_var: monomorphize_var(elem_var, subs),
+            loc_expr: Box::new(monomorphize(*loc_expr, subs)),
+            index,
+        },
+        Expr::RecordUpdate {
+            record_var,
+            ext_var,
+            symbol,
+            updates,
+        } => Expr::RecordUpdate {
+            record_var: monomorphize_var(record_var, subs),
+            ext_var: monomorphize_var(ext_var, subs),
+            symbol,
+            updates: updates
+                .into_iter()
+                .map(|(k, v)| (k, monomorphize_field(v, subs)))
+                .collect(),
+        },
+        Expr::Tag {
+            tag_union_var,
+            ext_var,
+            name,
+            arguments,
+        } => Expr::Tag {
+            tag_union_var: monomorphize_var(tag_union_var, subs),
+            ext_var: monomorphize_var(ext_var, subs),
+            name,
+            arguments: arguments
+                .into_iter()
+                .map(|(var, loc_expr)| (monomorphize_var(var, subs), monomorphize(loc_expr, subs)))
+                .collect(),
+        },
+        Expr::ZeroArgumentTag {
+            closure_name,
+            variant_var,
+            ext_var,
+            name,
+        } => Expr::ZeroArgumentTag {
+            closure_name,
+            variant_var: monomorphize_var(variant_var, subs),
+            ext_var: monomorphize_var(ext_var, subs),
+            name,
+        },
+        Expr::OpaqueRef {
+            opaque_var,
+            name,
+            argument,
+            specialized_def_type,
+            type_arguments,
+            lambda_set_variables,
+        } => Expr::OpaqueRef {
+            opaque_var: monomorphize_var(opaque_var, subs),
+            name,
+            argument: Box::new((
+                monomorphize_var(argument.0, subs),
+                monomorphize(argument.1, subs),
+            )),
+            specialized_def_type: Box::new(monomorphize_type(*specialized_def_type, subs)),
+            type_arguments,
+            lambda_set_variables,
+        },
+        Expr::OpaqueWrapFunction(data) => {
+            Expr::OpaqueWrapFunction(monomorphize_opaque_wrap_function_data(data, subs))
+        }
+        Expr::Expect {
+            loc_condition,
+            loc_continuation,
+            lookups_in_cond,
+        } => Expr::Expect {
+            loc_condition: Box::new(monomorphize(*loc_condition, subs)),
+            loc_continuation: Box::new(monomorphize(*loc_continuation, subs)),
+            lookups_in_cond,
+        },
+        Expr::ExpectFx {
+            loc_condition,
+            loc_continuation,
+            lookups_in_cond,
+        } => Expr::ExpectFx {
+            loc_condition: Box::new(monomorphize(*loc_condition, subs)),
+            loc_continuation: Box::new(monomorphize(*loc_continuation, subs)),
+            lookups_in_cond,
+        },
+        Expr::Dbg {
+            source_location,
+            source,
+            loc_message,
+            loc_continuation,
+            variable,
+            symbol,
+        } => Expr::Dbg {
+            source_location,
+            source,
+            loc_message: Box::new(monomorphize(*loc_message, subs)),
+            loc_continuation: Box::new(monomorphize(*loc_continuation, subs)),
+            variable: monomorphize_var(variable, subs),
+            symbol,
+        },
+        Expr::TypedHole(var) => Expr::TypedHole(monomorphize_var(var, subs)),
+        Expr::RuntimeError(error) => Expr::RuntimeError(error),
+        Expr::RunLowLevel { op, args, ret_var } => Expr::RunLowLevel {
+            op,
+            args: args
+                .into_iter()
+                .map(|(var, expr)| (monomorphize_var(var, subs), monomorphize_expr(expr, subs)))
+                .collect(),
+            ret_var: monomorphize_var(ret_var, subs),
+        },
+        Expr::ForeignCall {
+            foreign_symbol,
+            args,
+            ret_var,
+        } => Expr::ForeignCall {
+            foreign_symbol,
+            args: args
+                .into_iter()
+                .map(|(var, expr)| (monomorphize_var(var, subs), monomorphize_expr(expr, subs)))
+                .collect(),
+            ret_var: monomorphize_var(ret_var, subs),
+        },
+    }
+}
+
+fn monomorphize_var(var: Variable, subs: &mut Subs) -> Variable {
+    let root = subs.get_root_key_without_compacting(var);
+    let content = subs.get_content_without_compacting(root).clone();
+
+    match content {
+        Content::Structure(flat_type) => match flat_type {
+            FlatType::Apply(symbol, args) => {
+                let new_args: Vec<Variable> = args
+                    .into_iter()
+                    .map(|arg| monomorphize_var(subs[arg], subs))
+                    .collect();
+                let new_slice = VariableSubsSlice::insert_into_subs(subs, new_args);
+                let new_flat_type = FlatType::Apply(symbol, new_slice);
+                subs.fresh(Descriptor::from(Content::Structure(new_flat_type)))
+            }
+            FlatType::Func(args, closure_var, ret_var) => {
+                let new_args: Vec<Variable> = args
+                    .into_iter()
+                    .map(|arg| monomorphize_var(subs[arg], subs))
+                    .collect();
+                let new_args_slice = VariableSubsSlice::insert_into_subs(subs, new_args);
+                let new_closure_var = monomorphize_var(closure_var, subs);
+                let new_ret_var = monomorphize_var(ret_var, subs);
+                let new_flat_type = FlatType::Func(new_args_slice, new_closure_var, new_ret_var);
+                subs.fresh(Descriptor::from(Content::Structure(new_flat_type)))
+            }
+            FlatType::Record(record_fields, ext_var) => {
+                let new_variables: Vec<Variable> = record_fields
+                    .variables()
+                    .into_iter()
+                    .map(|v| monomorphize_var(subs[v], subs))
+                    .collect();
+                let new_variables_slice = VariableSubsSlice::insert_into_subs(subs, new_variables);
+                let new_record_fields = RecordFields {
+                    length: record_fields.length,
+                    field_names_start: record_fields.field_names_start,
+                    variables_start: new_variables_slice.start,
+                    field_types_start: record_fields.field_types_start,
+                };
+                let new_ext_var = monomorphize_var(ext_var, subs);
+                let new_flat_type = FlatType::Record(new_record_fields, new_ext_var);
+                subs.fresh(Descriptor::from(Content::Structure(new_flat_type)))
+            }
+            FlatType::Tuple(tuple_elems, ext_var) => {
+                let new_variables: Vec<Variable> = tuple_elems
+                    .variables()
+                    .into_iter()
+                    .map(|v| monomorphize_var(subs[v], subs))
+                    .collect();
+                let new_variables_slice = VariableSubsSlice::insert_into_subs(subs, new_variables);
+                let new_tuple_elems = TupleElems {
+                    length: tuple_elems.length,
+                    elem_index_start: tuple_elems.elem_index_start,
+                    variables_start: new_variables_slice.start,
+                };
+                let new_ext_var = monomorphize_var(ext_var, subs);
+                let new_flat_type = FlatType::Tuple(new_tuple_elems, new_ext_var);
+                subs.fresh(Descriptor::from(Content::Structure(new_flat_type)))
+            }
+            FlatType::TagUnion(union_labels, tag_ext) => {
+                let new_variable_slices =
+                    SubsSlice::reserve_variable_slices(subs, union_labels.len());
+                for (old_slice_index, new_slice_index) in union_labels
+                    .variables()
+                    .into_iter()
+                    .zip(new_variable_slices)
+                {
+                    let old_slice = subs[old_slice_index];
+                    let new_variables: Vec<Variable> = old_slice
+                        .into_iter()
+                        .map(|v| monomorphize_var(subs[v], subs))
+                        .collect();
+                    let new_slice = VariableSubsSlice::insert_into_subs(subs, new_variables);
+                    subs[new_slice_index] = new_slice;
+                }
+                let new_union_labels =
+                    UnionLabels::from_slices(union_labels.labels(), new_variable_slices);
+                let new_tag_ext = tag_ext.map(|v| monomorphize_var(v, subs));
+                let new_flat_type = FlatType::TagUnion(new_union_labels, new_tag_ext);
+                subs.fresh(Descriptor::from(Content::Structure(new_flat_type)))
+            }
+            FlatType::FunctionOrTagUnion(tag_names, symbols, tag_ext) => {
+                let new_tag_ext = tag_ext.map(|v| monomorphize_var(v, subs));
+                let new_flat_type = FlatType::FunctionOrTagUnion(tag_names, symbols, new_tag_ext);
+                subs.fresh(Descriptor::from(Content::Structure(new_flat_type)))
+            }
+            FlatType::RecursiveTagUnion(rec_var, union_labels, tag_ext) => {
+                let new_rec_var = monomorphize_var(rec_var, subs);
+                let new_variable_slices =
+                    SubsSlice::reserve_variable_slices(subs, union_labels.len());
+                for (old_slice_index, new_slice_index) in union_labels
+                    .variables()
+                    .into_iter()
+                    .zip(new_variable_slices)
+                {
+                    let old_slice = subs[old_slice_index];
+                    let new_variables: Vec<Variable> = old_slice
+                        .into_iter()
+                        .map(|v| monomorphize_var(subs[v], subs))
+                        .collect();
+                    let new_slice = VariableSubsSlice::insert_into_subs(subs, new_variables);
+                    subs[new_slice_index] = new_slice;
+                }
+                let new_union_labels =
+                    UnionLabels::from_slices(union_labels.labels(), new_variable_slices);
+                let new_tag_ext = tag_ext.map(|v| monomorphize_var(v, subs));
+                let new_flat_type =
+                    FlatType::RecursiveTagUnion(new_rec_var, new_union_labels, new_tag_ext);
+                subs.fresh(Descriptor::from(Content::Structure(new_flat_type)))
+            }
+            FlatType::EmptyRecord | FlatType::EmptyTuple | FlatType::EmptyTagUnion => var,
+        },
+        Content::Alias(symbol, alias_variables, aliased_var, alias_kind) => {
+            let new_variables: Vec<Variable> = alias_variables
+                .all_variables()
+                .into_iter()
+                .map(|v| monomorphize_var(subs[v], subs))
+                .collect();
+            let new_variables_slice = VariableSubsSlice::insert_into_subs(subs, new_variables);
+            let new_alias_variables = AliasVariables {
+                variables_start: new_variables_slice.start,
+                all_variables_len: alias_variables.all_variables_len,
+                lambda_set_variables_len: alias_variables.lambda_set_variables_len,
+                type_variables_len: alias_variables.type_variables_len,
+            };
+            let new_aliased_var = monomorphize_var(aliased_var, subs);
+            let new_content =
+                Content::Alias(symbol, new_alias_variables, new_aliased_var, alias_kind);
+            subs.fresh(Descriptor::from(new_content))
+        }
+        Content::LambdaSet(lambda_set) => {
+            let new_solved_slices =
+                SubsSlice::reserve_variable_slices(subs, lambda_set.solved.len());
+            for (old_slice_index, new_slice_index) in lambda_set
+                .solved
+                .variables()
+                .into_iter()
+                .zip(new_solved_slices)
+            {
+                let old_slice = subs[old_slice_index];
+                let new_variables: Vec<Variable> = old_slice
+                    .into_iter()
+                    .map(|v| monomorphize_var(subs[v], subs))
+                    .collect();
+                let new_slice = VariableSubsSlice::insert_into_subs(subs, new_variables);
+                subs[new_slice_index] = new_slice;
+            }
+            let new_solved =
+                UnionLabels::from_slices(lambda_set.solved.labels(), new_solved_slices);
+            let new_recursion_var = lambda_set.recursion_var.map(|v| monomorphize_var(v, subs));
+            let new_unspecialized =
+                SubsSlice::reserve_uls_slice(subs, lambda_set.unspecialized.len());
+            for (i, uls) in lambda_set.unspecialized.into_iter().enumerate() {
+                let Uls(var, sym, region) = subs[uls];
+                let new_var = monomorphize_var(var, subs);
+                subs[new_unspecialized.into_iter().nth(i).unwrap()] = Uls(new_var, sym, region);
+            }
+            let new_ambient_function = monomorphize_var(lambda_set.ambient_function, subs);
+            let new_lambda_set = LambdaSet {
+                solved: new_solved,
+                recursion_var: new_recursion_var,
+                unspecialized: new_unspecialized,
+                ambient_function: new_ambient_function,
+            };
+            let new_content = Content::LambdaSet(new_lambda_set);
+            subs.fresh(Descriptor::from(new_content))
+        }
+        Content::FlexVar(_)
+        | Content::RigidVar(_)
+        | Content::FlexAbleVar(_, _)
+        | Content::RigidAbleVar(_, _)
+        | Content::RecursionVar { .. }
+        | Content::ErasedLambda
+        | Content::RangedNumber(_)
+        | Content::Error => var,
+    }
+}
+
+fn monomorphize_when_branch(branch: WhenBranch, subs: &mut Subs) -> WhenBranch {
+    WhenBranch {
+        patterns: branch
+            .patterns
+            .into_iter()
+            .map(|p| WhenBranchPattern {
+                pattern: p.pattern,
+                degenerate: p.degenerate,
+            })
+            .collect(),
+        value: monomorphize(branch.value, subs),
+        guard: branch.guard.map(|g| monomorphize(g, subs)),
+        redundant: branch.redundant,
+    }
+}
+
+fn monomorphize_def(def: roc_can::def::Def, subs: &mut Subs) -> roc_can::def::Def {
+    roc_can::def::Def {
+        loc_pattern: def.loc_pattern,
+        loc_expr: monomorphize(def.loc_expr, subs),
+        expr_var: monomorphize_var(def.expr_var, subs),
+        pattern_vars: def
+            .pattern_vars
+            .into_iter()
+            .map(|(k, v)| (k, monomorphize_var(v, subs)))
+            .collect(),
+        annotation: def.annotation.map(|a| monomorphize_annotation(a, subs)),
+    }
+}
+
+fn monomorphize_closure_data(data: ClosureData, subs: &mut Subs) -> ClosureData {
+    ClosureData {
+        function_type: monomorphize_var(data.function_type, subs),
+        closure_type: monomorphize_var(data.closure_type, subs),
+        return_type: monomorphize_var(data.return_type, subs),
+        name: data.name,
+        captured_symbols: data
+            .captured_symbols
+            .into_iter()
+            .map(|(s, v)| (s, monomorphize_var(v, subs)))
+            .collect(),
+        recursive: data.recursive,
+        arguments: data
+            .arguments
+            .into_iter()
+            .map(|(v, m, p)| (monomorphize_var(v, subs), m, p))
+            .collect(),
+        loc_body: Box::new(monomorphize(*data.loc_body, subs)),
+    }
+}
+
+fn monomorphize_field(field: Field, subs: &mut Subs) -> Field {
+    Field {
+        var: monomorphize_var(field.var, subs),
+        region: field.region,
+        loc_expr: Box::new(monomorphize(*field.loc_expr, subs)),
+    }
+}
+
+fn monomorphize_struct_accessor_data(
+    data: StructAccessorData,
+    subs: &mut Subs,
+) -> StructAccessorData {
+    StructAccessorData {
+        name: data.name,
+        function_var: monomorphize_var(data.function_var, subs),
+        record_var: monomorphize_var(data.record_var, subs),
+        closure_var: monomorphize_var(data.closure_var, subs),
+        ext_var: monomorphize_var(data.ext_var, subs),
+        field_var: monomorphize_var(data.field_var, subs),
+        field: data.field,
+    }
+}
+
+fn monomorphize_opaque_wrap_function_data(
+    data: OpaqueWrapFunctionData,
+    subs: &mut Subs,
+) -> OpaqueWrapFunctionData {
+    OpaqueWrapFunctionData {
+        opaque_name: data.opaque_name,
+        opaque_var: monomorphize_var(data.opaque_var, subs),
+        specialized_def_type: monomorphize_type(data.specialized_def_type, subs),
+        type_arguments: data.type_arguments,
+        lambda_set_variables: data.lambda_set_variables,
+        function_name: data.function_name,
+        function_var: monomorphize_var(data.function_var, subs),
+        argument_var: monomorphize_var(data.argument_var, subs),
+        closure_var: monomorphize_var(data.closure_var, subs),
+    }
+}
+
+fn monomorphize_annotation(
+    annotation: roc_can::def::Annotation,
+    subs: &mut Subs,
+) -> roc_can::def::Annotation {
+    roc_can::def::Annotation {
+        signature: monomorphize_type(annotation.signature, subs),
+        introduced_variables: annotation.introduced_variables,
+        aliases: annotation.aliases,
+        region: annotation.region,
+    }
+}
+
+fn monomorphize_type(typ: Type, subs: &mut Subs) -> Type {
+    match typ {
+        Type::Tuple(elems, ext) => Type::Tuple(
+            elems
+                .into_iter()
+                .map(|(idx, elem)| (idx, monomorphize_type(elem, subs)))
+                .collect(),
+            ext,
+        ),
+        Type::Record(fields, ext) => Type::Record(
+            fields
+                .into_iter()
+                .map(|(name, field_type)| {
+                    (name, field_type.map(|t| monomorphize_type(t.clone(), subs)))
+                })
+                .collect(),
+            ext,
+        ),
+        Type::Apply(name, args, region) => Type::Apply(
+            name,
+            args.into_iter()
+                .map(|arg| arg.map(|t| monomorphize_type(t.clone(), subs)))
+                .collect(),
+            region,
+        ),
+        Type::Function(args, ret, ext) => Type::Function(
+            args.into_iter()
+                .map(|arg| monomorphize_type(arg, subs))
+                .collect(),
+            Box::new(monomorphize_type(*ret, subs)),
+            ext,
+        ),
+        Type::TagUnion(tags, ext) => Type::TagUnion(
+            tags.into_iter()
+                .map(|(name, tag_types)| {
+                    (
+                        name,
+                        tag_types
+                            .into_iter()
+                            .map(|t| monomorphize_type(t, subs))
+                            .collect(),
+                    )
+                })
+                .collect(),
+            ext,
+        ),
+        other => other,
+    }
+}

--- a/crates/compiler/specialize_types/src/lib.rs
+++ b/crates/compiler/specialize_types/src/lib.rs
@@ -1,210 +1,330 @@
-use roc_collections::MutMap;
+use bitvec::vec::BitVec;
 use roc_module::ident::{Lowercase, TagName};
 use roc_types::{
     subs::{
-        Content, FlatType, RecordFields, Subs, TagExt, TupleElems, UnionTags, Variable,
-        VariableSubsSlice,
+        Content, FlatType, RecordFields, Subs, TagExt, TupleElems, UnionLabels, UnionTags,
+        Variable, VariableSubsSlice,
     },
     types::RecordField,
 };
 
-pub type MonoCache = MutMap<Variable, Content>;
-
-fn ty_unfilled() -> Content {
-    Content::Structure(FlatType::TagUnion(
-        UnionTags::default(),
-        TagExt::Any(Variable::EMPTY_TAG_UNION),
-    ))
+#[derive(Debug, PartialEq, Eq)]
+pub enum Problem {
+    /// Compiler bug; this should never happen!
+    TagUnionExtWasNotTagUnion,
+    RecordExtWasNotRecord,
+    TupleExtWasNotTuple,
 }
 
-pub fn monomorphize_var(cache: &mut MonoCache, subs: &Subs, var: Variable) -> Variable {
-    let root_var = subs.get_root_key_without_compacting(var);
-    if cache.contains_key(&root_var) {
-        return root_var;
+/// Variables that have already been monomorphized.
+pub struct MonoCache {
+    inner: BitVec,
+}
+
+impl MonoCache {
+    pub fn from_subs(subs: &Subs) -> Self {
+        Self {
+            inner: BitVec::repeat(false, subs.len()),
+        }
     }
-    cache.insert(root_var, ty_unfilled());
-    let content = lower_content(cache, subs, subs.get_content_without_compacting(root_var));
-    cache.insert(root_var, content);
+
+    /// Returns true iff we know this Variable is monomorphic because
+    /// we've visited it before in the monomorphization process
+    /// (and either it was already monomorphic, or we made it so).
+    pub fn is_known_monomorphic(&self, var: Variable) -> bool {
+        match self.inner.get(var.index() as usize) {
+            Some(initialized) => {
+                // false if it has never been set, because we initialized all the bits to 0
+                *initialized
+            }
+            None => false,
+        }
+    }
+
+    /// Records that the given variable is now known to be monomorphic.
+    fn set_monomorphic(&mut self, var: Variable) {
+        self.inner.set(var.index() as usize, true);
+    }
+
+    pub fn monomorphize_var(
+        &mut self,
+        subs: &mut Subs,
+        problems: &mut Vec<Problem>,
+        var: Variable,
+    ) {
+        lower_var(self, subs, problems, var);
+    }
+}
+
+fn lower_var(
+    cache: &mut MonoCache,
+    subs: &mut Subs,
+    problems: &mut Vec<Problem>,
+    var: Variable,
+) -> Variable {
+    let root_var = subs.get_root_key_without_compacting(var);
+
+    if !cache.is_known_monomorphic(root_var) {
+        let content = subs.get_content_without_compacting(root_var).clone();
+        let content = lower_content(cache, subs, problems, &content);
+
+        // Update Subs so when we look up this var in the future, it's the monomorphized Content.
+        subs.set_content(root_var, content);
+
+        // This var is now known to be monomorphic.
+        cache.set_monomorphic(root_var);
+    }
+
     root_var
 }
 
-fn lower_content(cache: &mut MonoCache, subs: &Subs, content: &Content) -> Content {
-    match content {
+fn lower_content(
+    cache: &mut MonoCache,
+    subs: &mut Subs,
+    problems: &mut Vec<Problem>,
+    content: &Content,
+) -> Content {
+    match dbg!(content) {
         Content::Structure(flat_type) => match flat_type {
             FlatType::Apply(symbol, args) => {
                 let new_args = args
                     .into_iter()
-                    .map(|var_index| monomorphize_var(cache, subs, subs[var_index]))
-                    .collect::<Vec<_>>();
+                    .map(|var_index| lower_var(cache, subs, problems, subs[var_index]))
+                    // TODO there might be a way to remove this heap allocation
+                    .collect::<Vec<Variable>>();
+
                 Content::Structure(FlatType::Apply(
                     *symbol,
-                    VariableSubsSlice::new(new_args.as_ptr() as u32, new_args.len() as u16),
+                    VariableSubsSlice::insert_into_subs(subs, new_args),
                 ))
             }
             FlatType::Func(args, closure, ret) => {
                 let new_args = args
                     .into_iter()
-                    .map(|var_index| monomorphize_var(cache, subs, subs[var_index]))
+                    .map(|var_index| lower_var(cache, subs, problems, subs[var_index]))
                     .collect::<Vec<_>>();
-                let new_closure = monomorphize_var(cache, subs, *closure);
-                let new_ret = monomorphize_var(cache, subs, *ret);
+                let new_closure = lower_var(cache, subs, problems, *closure);
+                let new_ret = lower_var(cache, subs, problems, *ret);
                 Content::Structure(FlatType::Func(
-                    VariableSubsSlice::new(new_args.as_ptr() as u32, new_args.len() as u16),
+                    VariableSubsSlice::insert_into_subs(subs, new_args),
                     new_closure,
                     new_ret,
                 ))
             }
             FlatType::Record(fields, ext) => {
-                let (fields, ext) = chase_fields(subs, *fields, *ext);
-                let new_fields = fields
-                    .into_iter()
-                    .map(|(field, var)| {
-                        (
-                            Lowercase::from(field),
-                            RecordField::Required(monomorphize_var(cache, subs, var)),
-                        )
-                    })
-                    .collect::<Vec<_>>();
-                let new_ext = monomorphize_var(cache, subs, ext);
+                let mut fields = flatten_fields(subs, problems, *fields, *ext);
+
+                // Now lower all the fields we gathered. Do this in a separate pass to avoid borrow errors on Subs.
+                for (_, field) in fields.iter_mut() {
+                    let var = match field {
+                        RecordField::Required(v) | RecordField::Optional(v) | RecordField::Demanded(v) => v,
+                        RecordField::RigidRequired(v) | RecordField::RigidOptional(v) => v,
+                    };
+
+                    *var = lower_var(cache, subs, problems, *var);
+                }
+
                 Content::Structure(FlatType::Record(
-                    RecordFields::insert_into_subs(&mut Subs::new(), new_fields.into_iter()),
-                    new_ext,
+                    RecordFields::insert_into_subs(subs, fields.into_iter()),
+                    Variable::EMPTY_RECORD,
                 ))
             }
             FlatType::Tuple(elems, ext) => {
-                let new_elems = elems
-                    .iter_all()
-                    .map(|(idx, var_index)| {
-                        (
-                            idx.index as usize,
-                            monomorphize_var(cache, subs, subs[var_index]),
-                        )
-                    })
-                    .collect::<Vec<_>>();
-                let new_ext = monomorphize_var(cache, subs, *ext);
+                let mut elems = flatten_tuple(subs, problems, *elems, *ext);
+
+                // Now lower all the elems we gathered. Do this in a separate pass to avoid borrow errors on Subs.
+                for (_, var) in elems.iter_mut() {
+                    *var = lower_var(cache, subs, problems, *var);
+                }
+
                 Content::Structure(FlatType::Tuple(
-                    TupleElems::insert_into_subs(&mut Subs::new(), new_elems.into_iter()),
-                    new_ext,
+                    TupleElems::insert_into_subs(subs, elems.into_iter()),
+                    Variable::EMPTY_TUPLE,
                 ))
             }
             FlatType::TagUnion(tags, ext) => {
-                let (tags, ext) = chase_tags(subs, *tags, *ext);
-                let new_tags = tags
-                    .into_iter()
-                    .map(|(tag, vars)| {
-                        (
-                            tag,
-                            vars.into_iter()
-                                .map(|var| monomorphize_var(cache, subs, var))
-                                .collect::<Vec<Variable>>(),
-                        )
-                    })
-                    .collect::<Vec<_>>();
-                let new_ext = TagExt::Any(monomorphize_var(cache, subs, ext));
+                let mut tags = flatten_tags(subs, problems, *tags, *ext);
+
+                // Now lower all the tags we gathered. Do this in a separate pass to avoid borrow errors on Subs.
+                for (_, vars) in tags.iter_mut() {
+                    for var in vars.iter_mut() {
+                        *var = lower_var(cache, subs, problems, *var);
+                    }
+                }
+
                 Content::Structure(FlatType::TagUnion(
-                    UnionTags::insert_into_subs(&mut Subs::new(), new_tags.into_iter()),
-                    new_ext,
+                    UnionTags::insert_into_subs(subs, tags.into_iter()),
+                    TagExt::Any(Variable::EMPTY_TAG_UNION),
                 ))
             }
             FlatType::FunctionOrTagUnion(tag_names, symbols, ext) => {
-                let new_ext = TagExt::Any(monomorphize_var(cache, subs, ext.var()));
+                let new_ext = TagExt::Any(lower_var(cache, subs, problems, ext.var()));
                 Content::Structure(FlatType::FunctionOrTagUnion(*tag_names, *symbols, new_ext))
             }
             FlatType::RecursiveTagUnion(rec, tags, ext) => {
-                let new_rec = monomorphize_var(cache, subs, *rec);
-                let (tags, ext_var) = chase_tags(subs, *tags, *ext);
-                let new_tags = tags
-                    .into_iter()
-                    .map(|(tag, vars)| {
-                        (
-                            tag,
-                            vars.into_iter()
-                                .map(|var| monomorphize_var(cache, subs, var))
-                                .collect::<Vec<Variable>>(),
-                        )
-                    })
-                    .collect::<Vec<_>>();
-                let new_ext = TagExt::Any(monomorphize_var(cache, subs, ext_var));
+                let mut new_tags = flatten_tags(subs, problems, *tags, *ext);
+
+                // Now lower all the tags we gathered. Do this in a separate pass to avoid borrow errors on Subs.
+                for (_, vars) in new_tags.iter_mut() {
+                    for var in vars.iter_mut() {
+                        *var = lower_var(cache, subs, problems, *var);
+                    }
+                }
+
                 Content::Structure(FlatType::RecursiveTagUnion(
-                    new_rec,
-                    UnionTags::insert_into_subs(&mut Subs::new(), new_tags.into_iter()),
-                    new_ext,
+                    lower_var(cache, subs, problems, *rec),
+                    UnionTags::insert_into_subs(subs, new_tags.into_iter()),
+                    TagExt::Any(Variable::EMPTY_TAG_UNION),
                 ))
             }
             FlatType::EmptyRecord => Content::Structure(FlatType::EmptyRecord),
             FlatType::EmptyTuple => Content::Structure(FlatType::EmptyTuple),
             FlatType::EmptyTagUnion => Content::Structure(FlatType::EmptyTagUnion),
         },
-        Content::FlexVar(opt_name) => Content::FlexVar(*opt_name),
-        Content::RigidVar(name) => Content::RigidVar(*name),
-        Content::FlexAbleVar(opt_name, abilities) => Content::FlexAbleVar(*opt_name, *abilities),
-        Content::RigidAbleVar(name, abilities) => Content::RigidAbleVar(*name, *abilities),
-        Content::RecursionVar {
-            structure,
-            opt_name,
-        } => Content::RecursionVar {
-            structure: monomorphize_var(cache, subs, *structure),
-            opt_name: *opt_name,
-        },
+        Content::RangedNumber(_) // RangedNumber goes in Num's type parameter slot, so monomorphize it to []
+        | Content::FlexVar(_)
+        | Content::RigidVar(_)
+        | Content::FlexAbleVar(_, _)
+        | Content::RigidAbleVar(_, _)
+        | Content::RecursionVar { .. } => Content::Structure(FlatType::EmptyTagUnion),
         Content::LambdaSet(lambda_set) => Content::LambdaSet(lambda_set.clone()),
         Content::ErasedLambda => Content::ErasedLambda,
         Content::Alias(symbol, args, real, kind) => {
-            let new_real = monomorphize_var(cache, subs, *real);
+            let new_real = lower_var(cache, subs, problems, *real);
             Content::Alias(*symbol, args.clone(), new_real, *kind)
         }
-        Content::RangedNumber(range) => Content::RangedNumber(*range),
         Content::Error => Content::Error,
     }
 }
 
-fn chase_tags(
-    subs: &Subs,
+fn flatten_tags(
+    subs: &mut Subs,
+    problems: &mut Vec<Problem>,
     mut tags: UnionTags,
     mut ext: TagExt,
-) -> (Vec<(TagName, Vec<Variable>)>, Variable) {
+) -> Vec<(TagName, Vec<Variable>)> {
     let mut all_tags = Vec::new();
+
+    // First, collapse (recursively) all the tags in ext_var into a flat list of tags.
     loop {
         for (tag, vars) in tags.iter_from_subs(subs) {
             all_tags.push((tag.clone(), vars.to_vec()));
         }
+
         match subs.get_content_without_compacting(ext.var()) {
             Content::Structure(FlatType::TagUnion(new_tags, new_ext)) => {
+                // Update tags and ext and loop back again to process them.
                 tags = *new_tags;
                 ext = *new_ext;
             }
             Content::Structure(FlatType::EmptyTagUnion) => break,
             Content::FlexVar(_) | Content::FlexAbleVar(_, _) => break,
-            Content::Alias(_, _, real, _) => ext = TagExt::Any(*real),
-            _ => panic!("Invalid tag union extension"),
+            Content::Alias(_, _, real, _) => {
+                // Follow the alias and process it on the next iteration of the loop.
+                ext = TagExt::Any(*real);
+
+                // We just processed these tags, so don't process them again!
+                tags = UnionLabels::default();
+            }
+            _ => {
+                // This should never happen! If it does, record a Problem and break.
+                problems.push(Problem::TagUnionExtWasNotTagUnion);
+
+                break;
+            }
         }
     }
-    (all_tags, ext.var())
+
+    // ext should have ended up being empty
+    debug_assert_eq!(ext.var(), Variable::EMPTY_TAG_UNION);
+
+    all_tags
 }
 
-fn chase_fields(
-    subs: &Subs,
+fn flatten_fields(
+    subs: &mut Subs,
+    problems: &mut Vec<Problem>,
     mut fields: RecordFields,
     mut ext: Variable,
-) -> (Vec<(String, Variable)>, Variable) {
+) -> Vec<(Lowercase, RecordField<Variable>)> {
     let mut all_fields = Vec::new();
+
+    // First, collapse (recursively) all the fields in ext into a flat list of fields.
     loop {
-        for (field, record_field) in fields.sorted_iterator(subs, ext) {
-            let var = match record_field {
-                RecordField::Required(v) | RecordField::Optional(v) | RecordField::Demanded(v) => v,
-                RecordField::RigidRequired(v) | RecordField::RigidOptional(v) => v,
-            };
-            all_fields.push((field.to_string(), var));
+        for (label, field) in fields.sorted_iterator(subs, ext) {
+            all_fields.push((label.clone(), field.clone()));
         }
+
         match subs.get_content_without_compacting(ext) {
             Content::Structure(FlatType::Record(new_fields, new_ext)) => {
+                // Update fields and ext and loop back again to process them.
                 fields = *new_fields;
                 ext = *new_ext;
             }
             Content::Structure(FlatType::EmptyRecord) => break,
             Content::FlexVar(_) | Content::FlexAbleVar(_, _) => break,
-            Content::Alias(_, _, real, _) => ext = *real,
-            _ => panic!("Invalid record extension"),
+            Content::Alias(_, _, real, _) => {
+                // Follow the alias and process it on the next iteration of the loop.
+                ext = *real;
+
+                // We just processed these fields, so don't process them again!
+                fields = RecordFields::empty();
+            }
+            _ => {
+                // This should never happen! If it does, record a Problem and break.
+                problems.push(Problem::RecordExtWasNotRecord);
+
+                break;
+            }
         }
     }
-    (all_fields, ext)
+
+    // ext should have ended up being empty
+    debug_assert_eq!(ext, Variable::EMPTY_RECORD);
+
+    all_fields
+}
+
+fn flatten_tuple(
+    subs: &mut Subs,
+    problems: &mut Vec<Problem>,
+    mut elems: TupleElems,
+    mut ext: Variable,
+) -> Vec<(usize, Variable)> {
+    let mut all_elems = Vec::new();
+
+    // First, collapse (recursively) all the elements in ext into a flat list of elements.
+    loop {
+        for (idx, var_index) in elems.iter_all() {
+            all_elems.push((idx.index as usize, subs[var_index]));
+        }
+
+        match subs.get_content_without_compacting(ext) {
+            Content::Structure(FlatType::Tuple(new_elems, new_ext)) => {
+                // Update elems and ext and loop back again to process them.
+                elems = *new_elems;
+                ext = *new_ext;
+            }
+            Content::Structure(FlatType::EmptyTuple) => break,
+            Content::FlexVar(_) | Content::FlexAbleVar(_, _) => break,
+            Content::Alias(_, _, real, _) => {
+                // Follow the alias and process it on the next iteration of the loop.
+                ext = *real;
+
+                // We just processed these elements, so don't process them again!
+                elems = TupleElems::empty();
+            }
+            _ => {
+                // This should never happen! If it does, record a Problem and break.
+                problems.push(Problem::TupleExtWasNotTuple);
+
+                break;
+            }
+        }
+    }
+
+    // ext should have ended up being empty
+    debug_assert_eq!(ext, Variable::EMPTY_TUPLE);
+
+    all_elems
 }

--- a/crates/compiler/specialize_types/src/lib.rs
+++ b/crates/compiler/specialize_types/src/lib.rs
@@ -157,10 +157,10 @@ fn lower_content(
                 let mut tags = resolve_tag_ext(subs, problems, UnionTags::default(), *ext);
 
                 // Now lower all the tags we gathered from the ext var.
-                // Do this in a separate pass to avoid borrow errors on Subs.
+                // (Do this in a separate pass to avoid borrow errors on Subs.)
                 lower_vars(tags.iter_mut().flat_map(|(_, vars)| vars.iter_mut()), cache, subs, problems);
 
-                // Then, add the tag names with no payloads. (There's nothing to lower here.)
+                // Then, add the tag names with no payloads. (There are no variables to lower here.)
                 for index in tag_names.into_iter() {
                     tags.push(((&subs[index]).clone(), Vec::new()));
                 }
@@ -287,9 +287,6 @@ fn resolve_record_ext(
         }
     }
 
-    // ext should have ended up being empty
-    debug_assert_eq!(ext, Variable::EMPTY_RECORD);
-
     all_fields
 }
 
@@ -330,9 +327,6 @@ fn resolve_tuple_ext(
             }
         }
     }
-
-    // ext should have ended up being empty
-    debug_assert_eq!(ext, Variable::EMPTY_TUPLE);
 
     all_elems
 }

--- a/crates/compiler/specialize_types/src/lib.rs
+++ b/crates/compiler/specialize_types/src/lib.rs
@@ -1,0 +1,414 @@
+use roc_can::expr::Expr;
+use roc_types::subs::Subs;
+use std::collections::VecDeque;
+
+use roc_can::expr::{Expr, WhenBranch, ClosureData, Field, FunctionDef};
+use roc_types::subs::Subs;
+use std::collections::VecDeque;
+use roc_region::all::{Loc, Region};
+
+pub fn specialize_expr(expr: Expr, subs: &Subs) -> Expr {
+    let mut stack = VecDeque::new();
+    stack.push_back(expr);
+
+    let mut result_stack = VecDeque::new();
+
+    while let Some(current_expr) = stack.pop_back() {
+        let specialized = match current_expr {
+            Expr::When {
+                mut loc_cond,
+                cond_var,
+                expr_var,
+                region,
+                mut branches,
+                branches_cond_var,
+                exhaustive,
+            } => {
+                stack.push_back(*loc_cond.value);
+                for branch in branches.iter_mut() {
+                    stack.push_back(branch.value.value.clone());
+                    if let Some(guard) = &branch.guard {
+                        stack.push_back(guard.value.clone());
+                    }
+                }
+
+                let specialized_cond = result_stack.pop_back().unwrap();
+                let specialized_branches: Vec<WhenBranch> = branches
+                    .into_iter()
+                    .rev()
+                    .map(|mut branch| {
+                        let specialized_value = result_stack.pop_back().unwrap();
+                        let specialized_guard = branch.guard.map(|_| result_stack.pop_back().unwrap());
+                        WhenBranch {
+                            patterns: branch.patterns,
+                            value: Loc::at(branch.value.region, specialized_value),
+                            guard: specialized_guard.map(|g| Loc::at(branch.value.region, g)),
+                            redundant: branch.redundant,
+                        }
+                    })
+                    .collect();
+
+                Expr::When {
+                    loc_cond: Box::new(Loc::at(loc_cond.region, specialized_cond)),
+                    cond_var: subs.specialize_var(cond_var),
+                    expr_var: subs.specialize_var(expr_var),
+                    region,
+                    branches: specialized_branches,
+                    branches_cond_var: subs.specialize_var(branches_cond_var),
+                    exhaustive,
+                }
+            },
+            Expr::If {
+                cond_var,
+                branch_var,
+                mut branches,
+                mut final_else,
+            } => {
+                for (cond, body) in branches.iter_mut() {
+                    stack.push_back(cond.value.clone());
+                    stack.push_back(body.value.clone());
+                }
+                stack.push_back(final_else.value.clone());
+
+                let specialized_final_else = result_stack.pop_back().unwrap();
+                let specialized_branches: Vec<(Loc<Expr>, Loc<Expr>)> = branches
+                    .into_iter()
+                    .rev()
+                    .map(|(cond, body)| {
+                        let specialized_body = result_stack.pop_back().unwrap();
+                        let specialized_cond = result_stack.pop_back().unwrap();
+                        (
+                            Loc::at(cond.region, specialized_cond),
+                            Loc::at(body.region, specialized_body),
+                        )
+                    })
+                    .collect();
+
+                Expr::If {
+                    cond_var: subs.specialize_var(cond_var),
+                    branch_var: subs.specialize_var(branch_var),
+                    branches: specialized_branches,
+                    final_else: Box::new(Loc::at(final_else.region, specialized_final_else)),
+                }
+            },
+            Expr::LetRec(mut defs, mut body, illegal_cycle_mark) => {
+                for def in defs.iter_mut() {
+                    stack.push_back(def.loc_expr.value.clone());
+                }
+                stack.push_back(body.value.clone());
+
+                let specialized_body = result_stack.pop_back().unwrap();
+                let specialized_defs: Vec<Def> = defs
+                    .into_iter()
+                    .rev()
+                    .map(|mut def| {
+                        let specialized_expr = result_stack.pop_back().unwrap();
+                        Def {
+                            loc_pattern: def.loc_pattern,
+                            loc_expr: Loc::at(def.loc_expr.region, specialized_expr),
+                            expr_var: subs.specialize_var(def.expr_var),
+                            pattern_vars: def.pattern_vars.into_iter().map(|(k, v)| (k, subs.specialize_var(v))).collect(),
+                            annotation: def.annotation.map(|a| a.specialize(subs)),
+                        }
+                    })
+                    .collect();
+
+                Expr::LetRec(
+                    specialized_defs,
+                    Box::new(Loc::at(body.region, specialized_body)),
+                    illegal_cycle_mark,
+                )
+            },
+            Expr::LetNonRec(mut def, mut body) => {
+                stack.push_back(def.loc_expr.value.clone());
+                stack.push_back(body.value.clone());
+
+                let specialized_body = result_stack.pop_back().unwrap();
+                let specialized_expr = result_stack.pop_back().unwrap();
+
+                Expr::LetNonRec(
+                    Box::new(Def {
+                        loc_pattern: def.loc_pattern,
+                        loc_expr: Loc::at(def.loc_expr.region, specialized_expr),
+                        expr_var: subs.specialize_var(def.expr_var),
+                        pattern_vars: def.pattern_vars.into_iter().map(|(k, v)| (k, subs.specialize_var(v))).collect(),
+                        annotation: def.annotation.map(|a| a.specialize(subs)),
+                    }),
+                    Box::new(Loc::at(body.region, specialized_body)),
+                )
+            },
+            Expr::Call(mut boxed_tuple, mut args, called_via) => {
+                stack.push_back(boxed_tuple.1.value.clone());
+                for (_, arg) in args.iter_mut() {
+                    stack.push_back(arg.value.clone());
+                }
+
+                let specialized_args: Vec<(Variable, Loc<Expr>)> = args
+                    .into_iter()
+                    .rev()
+                    .map(|(var, loc_expr)| {
+                        let specialized_expr = result_stack.pop_back().unwrap();
+                        (subs.specialize_var(var), Loc::at(loc_expr.region, specialized_expr))
+                    })
+                    .collect();
+
+                let specialized_fn = result_stack.pop_back().unwrap();
+                let (fn_var, _, closure_var, expr_var) = *boxed_tuple;
+
+                Expr::Call(
+                    Box::new((
+                        subs.specialize_var(fn_var),
+                        Loc::at(boxed_tuple.1.region, specialized_fn),
+                        subs.specialize_var(closure_var),
+                        subs.specialize_var(expr_var),
+                    )),
+                    specialized_args,
+                    called_via,
+                )
+            },
+            Expr::Closure(mut closure_data) => {
+                stack.push_back(closure_data.loc_body.value.clone());
+
+                let specialized_body = result_stack.pop_back().unwrap();
+
+                Expr::Closure(ClosureData {
+                    function_type: subs.specialize_var(closure_data.function_type),
+                    closure_type: subs.specialize_var(closure_data.closure_type),
+                    return_type: subs.specialize_var(closure_data.return_type),
+                    name: closure_data.name,
+                    captured_symbols: closure_data.captured_symbols
+                        .into_iter()
+                        .map(|(s, v)| (s, subs.specialize_var(v)))
+                        .collect(),
+                    recursive: closure_data.recursive,
+                    arguments: closure_data.arguments
+                        .into_iter()
+                        .map(|(v, am, p)| (subs.specialize_var(v), am, p))
+                        .collect(),
+                    loc_body: Box::new(Loc::at(closure_data.loc_body.region, specialized_body)),
+                })
+            },
+            Expr::Record { record_var, mut fields } => {
+                for (_, field) in fields.iter_mut() {
+                    stack.push_back(field.loc_expr.value.clone());
+                }
+
+                let specialized_fields: SendMap<Lowercase, Field> = fields
+                    .into_iter()
+                    .map(|(label, mut field)| {
+                        let specialized_expr = result_stack.pop_back().unwrap();
+                        (label, Field {
+                            var: subs.specialize_var(field.var),
+                            region: field.region,
+                            loc_expr: Box::new(Loc::at(field.loc_expr.region, specialized_expr)),
+                        })
+                    })
+                    .collect();
+
+                Expr::Record {
+                    record_var: subs.specialize_var(record_var),
+                    fields: specialized_fields,
+                }
+            },
+            Expr::Tuple { tuple_var, mut elems } => {
+                for (_, elem) in elems.iter_mut() {
+                    stack.push_back(elem.value.clone());
+                }
+
+                let specialized_elems: Vec<(Variable, Box<Loc<Expr>>)> = elems
+                    .into_iter()
+                    .rev()
+                    .map(|(var, elem)| {
+                        let specialized_expr = result_stack.pop_back().unwrap();
+                        (subs.specialize_var(var), Box::new(Loc::at(elem.region, specialized_expr)))
+                    })
+                    .collect();
+
+                Expr::Tuple {
+                    tuple_var: subs.specialize_var(tuple_var),
+                    elems: specialized_elems,
+                }
+            },
+            Expr::RecordAccess { record_var, ext_var, field_var, mut loc_expr, field } => {
+                stack.push_back(loc_expr.value.clone());
+
+                let specialized_expr = result_stack.pop_back().unwrap();
+
+                Expr::RecordAccess {
+                    record_var: subs.specialize_var(record_var),
+                    ext_var: subs.specialize_var(ext_var),
+                    field_var: subs.specialize_var(field_var),
+                    loc_expr: Box::new(Loc::at(loc_expr.region, specialized_expr)),
+                    field,
+                }
+            },
+            Expr::TupleAccess { tuple_var, ext_var, elem_var, mut loc_expr, index } => {
+                stack.push_back(loc_expr.value.clone());
+
+                let specialized_expr = result_stack.pop_back().unwrap();
+
+                Expr::TupleAccess {
+                    tuple_var: subs.specialize_var(tuple_var),
+                    ext_var: subs.specialize_var(ext_var),
+                    elem_var: subs.specialize_var(elem_var),
+                    loc_expr: Box::new(Loc::at(loc_expr.region, specialized_expr)),
+                    index,
+                }
+            },
+            Expr::Tag { tag_union_var, ext_var, name, mut arguments } => {
+                for (_, arg) in arguments.iter_mut() {
+                    stack.push_back(arg.value.clone());
+                }
+
+                let specialized_arguments: Vec<(Variable, Loc<Expr>)> = arguments
+                    .into_iter()
+                    .rev()
+                    .map(|(var, loc_expr)| {
+                        let specialized_expr = result_stack.pop_back().unwrap();
+                        (subs.specialize_var(var), Loc::at(loc_expr.region, specialized_expr))
+                    })
+                    .collect();
+
+                Expr::Tag {
+                    tag_union_var: subs.specialize_var(tag_union_var),
+                    ext_var: subs.specialize_var(ext_var),
+                    name,
+                    arguments: specialized_arguments,
+                }
+            },
+            Expr::OpaqueRef { opaque_var, name, mut argument, specialized_def_type, type_arguments, lambda_set_variables } => {
+                stack.push_back(argument.1.value.clone());
+
+                let specialized_arg_expr = result_stack.pop_back().unwrap();
+
+                Expr::OpaqueRef {
+                    opaque_var: subs.specialize_var(opaque_var),
+                    name,
+                    argument: Box::new((subs.specialize_var(argument.0), Loc::at(argument.1.region, specialized_arg_expr))),
+                    specialized_def_type: Box::new(subs.specialize_type(*specialized_def_type)),
+                    type_arguments: type_arguments.into_iter().map(|v| subs.specialize_optable_var(v)).collect(),
+                    lambda_set_variables,
+                }
+            },
+            Expr::Expect { mut loc_condition, mut loc_continuation, lookups_in_cond } => {
+                stack.push_back(loc_condition.value.clone());
+                stack.push_back(loc_continuation.value.clone());
+
+                let specialized_continuation = result_stack.pop_back().unwrap();
+                let specialized_condition = result_stack.pop_back().unwrap();
+
+                Expr::Expect {
+                    loc_condition: Box::new(Loc::at(loc_condition.region, specialized_condition)),
+                    loc_continuation: Box::new(Loc::at(loc_continuation.region, specialized_continuation)),
+                    lookups_in_cond: lookups_in_cond.into_iter().map(|l| ExpectLookup {
+                        symbol: l.symbol,
+                        var: subs.specialize_var(l.var),
+                        ability_info: l.ability_info,
+                    }).collect(),
+                }
+            },
+            Expr::ExpectFx { mut loc_condition, mut loc_continuation, lookups_in_cond } => {
+                stack.push_back(loc_condition.value.clone());
+                stack.push_back(loc_continuation.value.clone());
+
+                let specialized_continuation = result_stack.pop_back().unwrap();
+                let specialized_condition = result_stack.pop_back().unwrap();
+
+                Expr::ExpectFx {
+                    loc_condition: Box::new(Loc::at(loc_condition.region, specialized_condition)),
+                    loc_continuation: Box::new(Loc::at(loc_continuation.region, specialized_continuation)),
+                    lookups_in_cond: lookups_in_cond.into_iter().map(|l| ExpectLookup {
+                        symbol: l.symbol,
+                        var: subs.specialize_var(l.var),
+                        ability_info: l.ability_info,
+                    }).collect(),
+                }
+            },
+            Expr::Dbg { source_location, source, mut loc_message, mut loc_continuation, variable, symbol } => {
+                stack.push_back(loc_message.value.clone());
+                stack.push_back(loc_continuation.value.clone());
+
+                let specialized_continuation = result_stack.pop_back().unwrap();
+                let specialized_message = result_stack.pop_back().unwrap();
+
+                Expr::Dbg {
+                    source_location,
+                    source,
+                    loc_message: Box::new(Loc::at(loc_message.region, specialized_message)),
+                    loc_continuation: Box::new(Loc::at(loc_continuation.region, specialized_continuation)),
+                    variable: subs.specialize_var(variable),
+                    symbol,
+                }
+            },
+            // For other expression types that don't contain nested expressions,
+            // implement the specialization logic directly here
+            Expr::Num(var, str, int_value, num_bound) =>
+                Expr::Num(subs.specialize_var(var), str, int_value, num_bound),
+            Expr::Int(var1, var2, str, int_value, int_bound) =>
+                Expr::Int(subs.specialize_var(var1), subs.specialize_var(var2), str, int_value, int_bound),
+            Expr::Float(var1, var2, str, f64, float_bound) =>
+                Expr::Float(subs.specialize_var(var1), subs.specialize_var(var2), str, f64, float_bound),
+            Expr::Str(str) => Expr::Str(str),
+            Expr::SingleQuote(var1, var2, ch, single_quote_bound) =>
+                Expr::SingleQuote(subs.specialize_var(var1), subs.specialize_var(var2), ch, single_quote_bound),
+            Expr::IngestedFile(path_buf, arc, var) =>
+                Expr::IngestedFile(path_buf, arc, subs.specialize_var(var)),
+            Expr::Var(symbol, var) =>
+                Expr::Var(symbol, subs.specialize_var(var)),
+            Expr::ParamsVar { symbol, var, params_symbol, params_var } =>
+                Expr::ParamsVar {
+                    symbol,
+                    var: subs.specialize_var(var),
+                    params_symbol,
+                    params_var: subs.specialize_var(params_var)
+                },
+            Expr::AbilityMember(symbol, specialization_i(struct_accessor_data) =>
+                Expr::RecordAccessor(StructAccessorData {
+                    name: struct_accessor_data.name,
+                    function_var: subs.specialize_var(struct_accessor_data.function_var),
+                    record_var: subs.specialize_var(struct_accessor_data.record_var),
+                    closure_var: subs.specialize_var(struct_accessor_data.closure_var),
+                    ext_var: subs.specialize_var(struct_accessor_data.ext_var),
+                    field_var: subs.specialize_var(struct_accessor_data.field_var),
+                    field: struct_accessor_data.field,
+                }),
+            Expr::RecordUpdate { record_var, ext_var, symbol, updates } =>
+                Expr::RecordUpdate {
+                    record_var: subs.specialize_var(record_var),
+                    ext_var: subs.specialize_var(ext_var),
+                    symbol,
+                    updates: updates.into_iter().map(|(k, v)| (k, Field {
+                        var: subs.specialize_var(v.var),
+                        region: v.region,
+                        loc_expr: Box::new(Loc::at(v.loc_expr.region, specialize_expr(v.loc_expr.value, subs))),
+                    })).collect(),
+                },
+            Expr::ZeroArgumentTag { closure_name, variant_var, ext_var, name } =>
+                Expr::ZeroArgumentTag {
+                    closure_name,
+                    variant_var: subs.specialize_var(variant_var),
+                    ext_var: subs.specialize_var(ext_var),
+                    name,
+                },
+            Expr::OpaqueWrapFunction(opaque_wrap_function_data) =>
+                Expr::OpaqueWrapFunction(OpaqueWrapFunctionData {
+                    opaque_name: opaque_wrap_function_data.opaque_name,
+                    opaque_var: subs.specialize_var(opaque_wrap_function_data.opaque_var),
+                    specialized_def_type: subs.specialize_type(opaque_wrap_function_data.specialized_def_type),
+                    type_arguments: opaque_wrap_function_data.type_arguments.into_iter().map(|v| subs.specialize_optable_var(v)).collect(),
+                    lambda_set_variables: opaque_wrap_function_data.lambda_set_variables,
+                    function_name: opaque_wrap_function_data.function_name,
+                    function_var: subs.specialize_var(opaque_wrap_function_data.function_var),
+                    argument_var: subs.specialize_var(opaque_wrap_function_data.argument_var),
+                    closure_var: subs.specialize_var(opaque_wrap_function_data.closure_var),
+                }),
+            Expr::TypedHole(var) =>
+                Expr::TypedHole(subs.specialize_var(var)),
+            Expr::RuntimeError(runtime_error) =>
+                Expr::RuntimeError(runtime_error),
+        };
+        result_stack.push_back(specialized);
+    }
+
+    result_stack.pop_back().unwrap()
+}

--- a/crates/compiler/specialize_types/src/lib.rs
+++ b/crates/compiler/specialize_types/src/lib.rs
@@ -1,414 +1,178 @@
-use roc_can::expr::Expr;
-use roc_types::subs::Subs;
-use std::collections::VecDeque;
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::rc::Rc;
 
-use roc_can::expr::{Expr, WhenBranch, ClosureData, Field, FunctionDef};
-use roc_types::subs::Subs;
-use std::collections::VecDeque;
-use roc_region::all::{Loc, Region};
+use roc_types::{
+    subs::{Content, FlatType, RecordFields, Subs, TagExt, UnionTags, Variable},
+    types::RecordField,
+};
 
-pub fn specialize_expr(expr: Expr, subs: &Subs) -> Expr {
-    let mut stack = VecDeque::new();
-    stack.push_back(expr);
+#[derive(Clone, Debug)]
+pub enum TyContent {
+    TFn(Rc<Ty>, Rc<Ty>),
+    TTag(Vec<(String, Vec<Rc<Ty>>)>),
+    TRecord(Vec<(String, Rc<Ty>)>),
+    TPrim(Primitive),
+}
 
-    let mut result_stack = VecDeque::new();
+#[derive(Clone, Debug)]
+pub enum Primitive {
+    Str,
+    Int,
+    Erased,
+}
 
-    while let Some(current_expr) = stack.pop_back() {
-        let specialized = match current_expr {
-            Expr::When {
-                mut loc_cond,
-                cond_var,
-                expr_var,
-                region,
-                mut branches,
-                branches_cond_var,
-                exhaustive,
-            } => {
-                stack.push_back(*loc_cond.value);
-                for branch in branches.iter_mut() {
-                    stack.push_back(branch.value.value.clone());
-                    if let Some(guard) = &branch.guard {
-                        stack.push_back(guard.value.clone());
-                    }
-                }
+#[derive(Clone, Debug)]
+pub struct Ty(RefCell<TyContent>);
 
-                let specialized_cond = result_stack.pop_back().unwrap();
-                let specialized_branches: Vec<WhenBranch> = branches
-                    .into_iter()
-                    .rev()
-                    .map(|mut branch| {
-                        let specialized_value = result_stack.pop_back().unwrap();
-                        let specialized_guard = branch.guard.map(|_| result_stack.pop_back().unwrap());
-                        WhenBranch {
-                            patterns: branch.patterns,
-                            value: Loc::at(branch.value.region, specialized_value),
-                            guard: specialized_guard.map(|g| Loc::at(branch.value.region, g)),
-                            redundant: branch.redundant,
-                        }
-                    })
-                    .collect();
+type MonoCache = RefCell<HashMap<Variable, Rc<Ty>>>;
 
-                Expr::When {
-                    loc_cond: Box::new(Loc::at(loc_cond.region, specialized_cond)),
-                    cond_var: subs.specialize_var(cond_var),
-                    expr_var: subs.specialize_var(expr_var),
-                    region,
-                    branches: specialized_branches,
-                    branches_cond_var: subs.specialize_var(branches_cond_var),
-                    exhaustive,
-                }
-            },
-            Expr::If {
-                cond_var,
-                branch_var,
-                mut branches,
-                mut final_else,
-            } => {
-                for (cond, body) in branches.iter_mut() {
-                    stack.push_back(cond.value.clone());
-                    stack.push_back(body.value.clone());
-                }
-                stack.push_back(final_else.value.clone());
+pub fn fresh_mono_cache() -> MonoCache {
+    RefCell::new(HashMap::new())
+}
 
-                let specialized_final_else = result_stack.pop_back().unwrap();
-                let specialized_branches: Vec<(Loc<Expr>, Loc<Expr>)> = branches
-                    .into_iter()
-                    .rev()
-                    .map(|(cond, body)| {
-                        let specialized_body = result_stack.pop_back().unwrap();
-                        let specialized_cond = result_stack.pop_back().unwrap();
-                        (
-                            Loc::at(cond.region, specialized_cond),
-                            Loc::at(body.region, specialized_body),
-                        )
-                    })
-                    .collect();
+fn unlink_tvar(subs: &Subs, mut var: Variable) -> Variable {
+    loop {
+        match subs.get_content_without_compacting(var) {
+            Content::Alias(_, _, real, _) => var = *real,
+            _ => break var,
+        }
+    }
+}
 
-                Expr::If {
-                    cond_var: subs.specialize_var(cond_var),
-                    branch_var: subs.specialize_var(branch_var),
-                    branches: specialized_branches,
-                    final_else: Box::new(Loc::at(final_else.region, specialized_final_else)),
-                }
-            },
-            Expr::LetRec(mut defs, mut body, illegal_cycle_mark) => {
-                for def in defs.iter_mut() {
-                    stack.push_back(def.loc_expr.value.clone());
-                }
-                stack.push_back(body.value.clone());
+fn ty_unfilled() -> TyContent {
+    TyContent::TTag(vec![("__unfilled".to_string(), vec![])])
+}
 
-                let specialized_body = result_stack.pop_back().unwrap();
-                let specialized_defs: Vec<Def> = defs
-                    .into_iter()
-                    .rev()
-                    .map(|mut def| {
-                        let specialized_expr = result_stack.pop_back().unwrap();
-                        Def {
-                            loc_pattern: def.loc_pattern,
-                            loc_expr: Loc::at(def.loc_expr.region, specialized_expr),
-                            expr_var: subs.specialize_var(def.expr_var),
-                            pattern_vars: def.pattern_vars.into_iter().map(|(k, v)| (k, subs.specialize_var(v))).collect(),
-                            annotation: def.annotation.map(|a| a.specialize(subs)),
-                        }
-                    })
-                    .collect();
-
-                Expr::LetRec(
-                    specialized_defs,
-                    Box::new(Loc::at(body.region, specialized_body)),
-                    illegal_cycle_mark,
-                )
-            },
-            Expr::LetNonRec(mut def, mut body) => {
-                stack.push_back(def.loc_expr.value.clone());
-                stack.push_back(body.value.clone());
-
-                let specialized_body = result_stack.pop_back().unwrap();
-                let specialized_expr = result_stack.pop_back().unwrap();
-
-                Expr::LetNonRec(
-                    Box::new(Def {
-                        loc_pattern: def.loc_pattern,
-                        loc_expr: Loc::at(def.loc_expr.region, specialized_expr),
-                        expr_var: subs.specialize_var(def.expr_var),
-                        pattern_vars: def.pattern_vars.into_iter().map(|(k, v)| (k, subs.specialize_var(v))).collect(),
-                        annotation: def.annotation.map(|a| a.specialize(subs)),
-                    }),
-                    Box::new(Loc::at(body.region, specialized_body)),
-                )
-            },
-            Expr::Call(mut boxed_tuple, mut args, called_via) => {
-                stack.push_back(boxed_tuple.1.value.clone());
-                for (_, arg) in args.iter_mut() {
-                    stack.push_back(arg.value.clone());
-                }
-
-                let specialized_args: Vec<(Variable, Loc<Expr>)> = args
-                    .into_iter()
-                    .rev()
-                    .map(|(var, loc_expr)| {
-                        let specialized_expr = result_stack.pop_back().unwrap();
-                        (subs.specialize_var(var), Loc::at(loc_expr.region, specialized_expr))
-                    })
-                    .collect();
-
-                let specialized_fn = result_stack.pop_back().unwrap();
-                let (fn_var, _, closure_var, expr_var) = *boxed_tuple;
-
-                Expr::Call(
-                    Box::new((
-                        subs.specialize_var(fn_var),
-                        Loc::at(boxed_tuple.1.region, specialized_fn),
-                        subs.specialize_var(closure_var),
-                        subs.specialize_var(expr_var),
-                    )),
-                    specialized_args,
-                    called_via,
-                )
-            },
-            Expr::Closure(mut closure_data) => {
-                stack.push_back(closure_data.loc_body.value.clone());
-
-                let specialized_body = result_stack.pop_back().unwrap();
-
-                Expr::Closure(ClosureData {
-                    function_type: subs.specialize_var(closure_data.function_type),
-                    closure_type: subs.specialize_var(closure_data.closure_type),
-                    return_type: subs.specialize_var(closure_data.return_type),
-                    name: closure_data.name,
-                    captured_symbols: closure_data.captured_symbols
-                        .into_iter()
-                        .map(|(s, v)| (s, subs.specialize_var(v)))
-                        .collect(),
-                    recursive: closure_data.recursive,
-                    arguments: closure_data.arguments
-                        .into_iter()
-                        .map(|(v, am, p)| (subs.specialize_var(v), am, p))
-                        .collect(),
-                    loc_body: Box::new(Loc::at(closure_data.loc_body.region, specialized_body)),
-                })
-            },
-            Expr::Record { record_var, mut fields } => {
-                for (_, field) in fields.iter_mut() {
-                    stack.push_back(field.loc_expr.value.clone());
-                }
-
-                let specialized_fields: SendMap<Lowercase, Field> = fields
-                    .into_iter()
-                    .map(|(label, mut field)| {
-                        let specialized_expr = result_stack.pop_back().unwrap();
-                        (label, Field {
-                            var: subs.specialize_var(field.var),
-                            region: field.region,
-                            loc_expr: Box::new(Loc::at(field.loc_expr.region, specialized_expr)),
-                        })
-                    })
-                    .collect();
-
-                Expr::Record {
-                    record_var: subs.specialize_var(record_var),
-                    fields: specialized_fields,
-                }
-            },
-            Expr::Tuple { tuple_var, mut elems } => {
-                for (_, elem) in elems.iter_mut() {
-                    stack.push_back(elem.value.clone());
-                }
-
-                let specialized_elems: Vec<(Variable, Box<Loc<Expr>>)> = elems
-                    .into_iter()
-                    .rev()
-                    .map(|(var, elem)| {
-                        let specialized_expr = result_stack.pop_back().unwrap();
-                        (subs.specialize_var(var), Box::new(Loc::at(elem.region, specialized_expr)))
-                    })
-                    .collect();
-
-                Expr::Tuple {
-                    tuple_var: subs.specialize_var(tuple_var),
-                    elems: specialized_elems,
-                }
-            },
-            Expr::RecordAccess { record_var, ext_var, field_var, mut loc_expr, field } => {
-                stack.push_back(loc_expr.value.clone());
-
-                let specialized_expr = result_stack.pop_back().unwrap();
-
-                Expr::RecordAccess {
-                    record_var: subs.specialize_var(record_var),
-                    ext_var: subs.specialize_var(ext_var),
-                    field_var: subs.specialize_var(field_var),
-                    loc_expr: Box::new(Loc::at(loc_expr.region, specialized_expr)),
-                    field,
-                }
-            },
-            Expr::TupleAccess { tuple_var, ext_var, elem_var, mut loc_expr, index } => {
-                stack.push_back(loc_expr.value.clone());
-
-                let specialized_expr = result_stack.pop_back().unwrap();
-
-                Expr::TupleAccess {
-                    tuple_var: subs.specialize_var(tuple_var),
-                    ext_var: subs.specialize_var(ext_var),
-                    elem_var: subs.specialize_var(elem_var),
-                    loc_expr: Box::new(Loc::at(loc_expr.region, specialized_expr)),
-                    index,
-                }
-            },
-            Expr::Tag { tag_union_var, ext_var, name, mut arguments } => {
-                for (_, arg) in arguments.iter_mut() {
-                    stack.push_back(arg.value.clone());
-                }
-
-                let specialized_arguments: Vec<(Variable, Loc<Expr>)> = arguments
-                    .into_iter()
-                    .rev()
-                    .map(|(var, loc_expr)| {
-                        let specialized_expr = result_stack.pop_back().unwrap();
-                        (subs.specialize_var(var), Loc::at(loc_expr.region, specialized_expr))
-                    })
-                    .collect();
-
-                Expr::Tag {
-                    tag_union_var: subs.specialize_var(tag_union_var),
-                    ext_var: subs.specialize_var(ext_var),
-                    name,
-                    arguments: specialized_arguments,
-                }
-            },
-            Expr::OpaqueRef { opaque_var, name, mut argument, specialized_def_type, type_arguments, lambda_set_variables } => {
-                stack.push_back(argument.1.value.clone());
-
-                let specialized_arg_expr = result_stack.pop_back().unwrap();
-
-                Expr::OpaqueRef {
-                    opaque_var: subs.specialize_var(opaque_var),
-                    name,
-                    argument: Box::new((subs.specialize_var(argument.0), Loc::at(argument.1.region, specialized_arg_expr))),
-                    specialized_def_type: Box::new(subs.specialize_type(*specialized_def_type)),
-                    type_arguments: type_arguments.into_iter().map(|v| subs.specialize_optable_var(v)).collect(),
-                    lambda_set_variables,
-                }
-            },
-            Expr::Expect { mut loc_condition, mut loc_continuation, lookups_in_cond } => {
-                stack.push_back(loc_condition.value.clone());
-                stack.push_back(loc_continuation.value.clone());
-
-                let specialized_continuation = result_stack.pop_back().unwrap();
-                let specialized_condition = result_stack.pop_back().unwrap();
-
-                Expr::Expect {
-                    loc_condition: Box::new(Loc::at(loc_condition.region, specialized_condition)),
-                    loc_continuation: Box::new(Loc::at(loc_continuation.region, specialized_continuation)),
-                    lookups_in_cond: lookups_in_cond.into_iter().map(|l| ExpectLookup {
-                        symbol: l.symbol,
-                        var: subs.specialize_var(l.var),
-                        ability_info: l.ability_info,
-                    }).collect(),
-                }
-            },
-            Expr::ExpectFx { mut loc_condition, mut loc_continuation, lookups_in_cond } => {
-                stack.push_back(loc_condition.value.clone());
-                stack.push_back(loc_continuation.value.clone());
-
-                let specialized_continuation = result_stack.pop_back().unwrap();
-                let specialized_condition = result_stack.pop_back().unwrap();
-
-                Expr::ExpectFx {
-                    loc_condition: Box::new(Loc::at(loc_condition.region, specialized_condition)),
-                    loc_continuation: Box::new(Loc::at(loc_continuation.region, specialized_continuation)),
-                    lookups_in_cond: lookups_in_cond.into_iter().map(|l| ExpectLookup {
-                        symbol: l.symbol,
-                        var: subs.specialize_var(l.var),
-                        ability_info: l.ability_info,
-                    }).collect(),
-                }
-            },
-            Expr::Dbg { source_location, source, mut loc_message, mut loc_continuation, variable, symbol } => {
-                stack.push_back(loc_message.value.clone());
-                stack.push_back(loc_continuation.value.clone());
-
-                let specialized_continuation = result_stack.pop_back().unwrap();
-                let specialized_message = result_stack.pop_back().unwrap();
-
-                Expr::Dbg {
-                    source_location,
-                    source,
-                    loc_message: Box::new(Loc::at(loc_message.region, specialized_message)),
-                    loc_continuation: Box::new(Loc::at(loc_continuation.region, specialized_continuation)),
-                    variable: subs.specialize_var(variable),
-                    symbol,
-                }
-            },
-            // For other expression types that don't contain nested expressions,
-            // implement the specialization logic directly here
-            Expr::Num(var, str, int_value, num_bound) =>
-                Expr::Num(subs.specialize_var(var), str, int_value, num_bound),
-            Expr::Int(var1, var2, str, int_value, int_bound) =>
-                Expr::Int(subs.specialize_var(var1), subs.specialize_var(var2), str, int_value, int_bound),
-            Expr::Float(var1, var2, str, f64, float_bound) =>
-                Expr::Float(subs.specialize_var(var1), subs.specialize_var(var2), str, f64, float_bound),
-            Expr::Str(str) => Expr::Str(str),
-            Expr::SingleQuote(var1, var2, ch, single_quote_bound) =>
-                Expr::SingleQuote(subs.specialize_var(var1), subs.specialize_var(var2), ch, single_quote_bound),
-            Expr::IngestedFile(path_buf, arc, var) =>
-                Expr::IngestedFile(path_buf, arc, subs.specialize_var(var)),
-            Expr::Var(symbol, var) =>
-                Expr::Var(symbol, subs.specialize_var(var)),
-            Expr::ParamsVar { symbol, var, params_symbol, params_var } =>
-                Expr::ParamsVar {
-                    symbol,
-                    var: subs.specialize_var(var),
-                    params_symbol,
-                    params_var: subs.specialize_var(params_var)
-                },
-            Expr::AbilityMember(symbol, specialization_i(struct_accessor_data) =>
-                Expr::RecordAccessor(StructAccessorData {
-                    name: struct_accessor_data.name,
-                    function_var: subs.specialize_var(struct_accessor_data.function_var),
-                    record_var: subs.specialize_var(struct_accessor_data.record_var),
-                    closure_var: subs.specialize_var(struct_accessor_data.closure_var),
-                    ext_var: subs.specialize_var(struct_accessor_data.ext_var),
-                    field_var: subs.specialize_var(struct_accessor_data.field_var),
-                    field: struct_accessor_data.field,
-                }),
-            Expr::RecordUpdate { record_var, ext_var, symbol, updates } =>
-                Expr::RecordUpdate {
-                    record_var: subs.specialize_var(record_var),
-                    ext_var: subs.specialize_var(ext_var),
-                    symbol,
-                    updates: updates.into_iter().map(|(k, v)| (k, Field {
-                        var: subs.specialize_var(v.var),
-                        region: v.region,
-                        loc_expr: Box::new(Loc::at(v.loc_expr.region, specialize_expr(v.loc_expr.value, subs))),
-                    })).collect(),
-                },
-            Expr::ZeroArgumentTag { closure_name, variant_var, ext_var, name } =>
-                Expr::ZeroArgumentTag {
-                    closure_name,
-                    variant_var: subs.specialize_var(variant_var),
-                    ext_var: subs.specialize_var(ext_var),
-                    name,
-                },
-            Expr::OpaqueWrapFunction(opaque_wrap_function_data) =>
-                Expr::OpaqueWrapFunction(OpaqueWrapFunctionData {
-                    opaque_name: opaque_wrap_function_data.opaque_name,
-                    opaque_var: subs.specialize_var(opaque_wrap_function_data.opaque_var),
-                    specialized_def_type: subs.specialize_type(opaque_wrap_function_data.specialized_def_type),
-                    type_arguments: opaque_wrap_function_data.type_arguments.into_iter().map(|v| subs.specialize_optable_var(v)).collect(),
-                    lambda_set_variables: opaque_wrap_function_data.lambda_set_variables,
-                    function_name: opaque_wrap_function_data.function_name,
-                    function_var: subs.specialize_var(opaque_wrap_function_data.function_var),
-                    argument_var: subs.specialize_var(opaque_wrap_function_data.argument_var),
-                    closure_var: subs.specialize_var(opaque_wrap_function_data.closure_var),
-                }),
-            Expr::TypedHole(var) =>
-                Expr::TypedHole(subs.specialize_var(var)),
-            Expr::RuntimeError(runtime_error) =>
-                Expr::RuntimeError(runtime_error),
-        };
-        result_stack.push_back(specialized);
+pub fn lower_type(cache: &MonoCache, subs: &Subs, var: Variable) -> Rc<Ty> {
+    fn fail(s: &str, var: Variable) -> ! {
+        panic!("lower_type: {}: {:?}", s, var)
     }
 
-    result_stack.pop_back().unwrap()
+    fn go_content(cache: &MonoCache, subs: &Subs, content: &Content) -> TyContent {
+        match content {
+            Content::Structure(flat_type) => match flat_type {
+                FlatType::Apply(_, _) => unimplemented!("FlatType::Apply"),
+                FlatType::Func(args, closure, ret) => {
+                    let in_ty = go(cache, subs, subs.variables[args.start as usize]);
+                    let out_ty = go(cache, subs, *ret);
+                    TyContent::TFn(in_ty, out_ty)
+                }
+                FlatType::Record(fields, ext) => {
+                    let (fields, ext) = chase_fields(subs, *fields, *ext);
+                    let fields = fields
+                        .into_iter()
+                        .map(|(field, var)| (field, go(cache, subs, var)))
+                        .collect::<Vec<_>>();
+                    assert!(
+                        matches!(*go(cache, subs, ext).0.borrow(), TyContent::TTag(ref tags) if tags.is_empty())
+                            || matches!(*go(cache, subs, ext).0.borrow(), TyContent::TRecord(ref fields) if fields.is_empty())
+                    );
+                    TyContent::TRecord(fields)
+                }
+                FlatType::Tuple(_, _) => unimplemented!("FlatType::Tuple"),
+                FlatType::TagUnion(tags, ext) => {
+                    let (tags, ext) = chase_tags(subs, *tags, *ext);
+                    let tags = tags
+                        .into_iter()
+                        .map(|(tag, vars)| {
+                            (
+                                tag,
+                                vars.into_iter().map(|var| go(cache, subs, var)).collect(),
+                            )
+                        })
+                        .collect::<Vec<_>>();
+                    assert!(
+                        matches!(*go(cache, subs, ext).0.borrow(), TyContent::TTag(ref t) if t.is_empty())
+                    );
+                    TyContent::TTag(tags)
+                }
+                FlatType::FunctionOrTagUnion(_, _, _) => {
+                    unimplemented!("FlatType::FunctionOrTagUnion")
+                }
+                FlatType::RecursiveTagUnion(_, _, _) => {
+                    unimplemented!("FlatType::RecursiveTagUnion")
+                }
+                FlatType::EmptyRecord => TyContent::TRecord(vec![]),
+                FlatType::EmptyTuple => unimplemented!("FlatType::EmptyTuple"),
+                FlatType::EmptyTagUnion => TyContent::TTag(vec![]),
+            },
+            Content::FlexVar(_) => TyContent::TTag(vec![]),
+            Content::RigidVar(_) => fail("unexpected rigid var", Variable::NULL),
+            Content::FlexAbleVar(_, _) => TyContent::TTag(vec![]),
+            Content::RigidAbleVar(_, _) => fail("unexpected rigid able var", Variable::NULL),
+            Content::RecursionVar { .. } => fail("unexpected recursion var", Variable::NULL),
+            Content::LambdaSet(_) => fail("unexpected lambda set", Variable::NULL),
+            Content::ErasedLambda => TyContent::TPrim(Primitive::Erased),
+            Content::Alias(_, _, _, _) => fail("unexpected alias", Variable::NULL),
+            Content::RangedNumber(_) => unimplemented!("Content::RangedNumber"),
+            Content::Error => fail("error type", Variable::NULL),
+        }
+    }
+
+    fn go(cache: &MonoCache, subs: &Subs, var: Variable) -> Rc<Ty> {
+        let var = unlink_tvar(subs, var);
+        if let Some(ty) = cache.borrow().get(&var) {
+            return ty.clone();
+        }
+        let ty = Rc::new(Ty(RefCell::new(ty_unfilled())));
+        cache.borrow_mut().insert(var, ty.clone());
+        let content = go_content(cache, subs, subs.get_content_without_compacting(var));
+        *ty.0.borrow_mut() = content;
+        ty
+    }
+
+    go(cache, subs, var)
+}
+
+fn chase_tags(
+    subs: &Subs,
+    mut tags: UnionTags,
+    mut ext: TagExt,
+) -> (Vec<(String, Vec<Variable>)>, Variable) {
+    let mut all_tags = Vec::new();
+    loop {
+        for (tag, vars) in tags.iter_from_subs(subs) {
+            all_tags.push((tag.0.to_string(), vars.to_vec()));
+        }
+        match subs.get_content_without_compacting(ext.var()) {
+            Content::Structure(FlatType::TagUnion(new_tags, new_ext)) => {
+                tags = *new_tags;
+                ext = *new_ext;
+            }
+            Content::Structure(FlatType::EmptyTagUnion) => break,
+            Content::FlexVar(_) | Content::FlexAbleVar(_, _) => break,
+            Content::Alias(_, _, real, _) => ext = TagExt::Any(*real),
+            _ => panic!("Invalid tag union extension"),
+        }
+    }
+    (all_tags, ext.var())
+}
+
+fn chase_fields(
+    subs: &Subs,
+    mut fields: RecordFields,
+    mut ext: Variable,
+) -> (Vec<(String, Variable)>, Variable) {
+    let mut all_fields = Vec::new();
+    loop {
+        for (field, record_field) in fields.sorted_iterator(subs, ext) {
+            let var = match record_field {
+                RecordField::Required(v) | RecordField::Optional(v) | RecordField::Demanded(v) => v,
+                RecordField::RigidRequired(v) | RecordField::RigidOptional(v) => v,
+            };
+            all_fields.push((field.to_string(), var));
+        }
+        match subs.get_content_without_compacting(ext) {
+            Content::Structure(FlatType::Record(new_fields, new_ext)) => {
+                fields = *new_fields;
+                ext = *new_ext;
+            }
+            Content::Structure(FlatType::EmptyRecord) => break,
+            Content::FlexVar(_) | Content::FlexAbleVar(_, _) => break,
+            Content::Alias(_, _, real, _) => ext = *real,
+            _ => panic!("Invalid record extension"),
+        }
+    }
+    (all_fields, ext)
 }

--- a/crates/compiler/specialize_types/src/lib.rs
+++ b/crates/compiler/specialize_types/src/lib.rs
@@ -14,6 +14,7 @@ use roc_types::{
 };
 
 mod mono_type;
+mod specialize_type;
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum Problem {

--- a/crates/compiler/specialize_types/src/lib.rs
+++ b/crates/compiler/specialize_types/src/lib.rs
@@ -1,3 +1,8 @@
+/// Given a Subs that's been populated from type inference, and a Variable,
+/// ensure that Variable is monomorphic by going through and creating
+/// specializations of that type wherever necessary.
+///
+/// This only operates at the type level. It does not create new function implementations (for example).
 use bitvec::vec::BitVec;
 use roc_module::ident::{Lowercase, TagName};
 use roc_types::{

--- a/crates/compiler/specialize_types/src/mono_type.rs
+++ b/crates/compiler/specialize_types/src/mono_type.rs
@@ -1,0 +1,76 @@
+use core::fmt;
+
+/// A slice into the Vec<T> of MonoTypes
+///
+/// The starting position is a u32 which should be plenty
+/// We limit slices to u16::MAX = 65535 elements
+pub struct MonoSlice<T> {
+    pub start: u32,
+    pub length: u16,
+    _marker: std::marker::PhantomData<T>,
+}
+
+impl<T> Copy for MonoSlice<T> {}
+
+impl<T> Clone for MonoSlice<T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<T> std::fmt::Debug for MonoSlice<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "MonoSlice {{ start: {}, length: {} }}",
+            self.start, self.length
+        )
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct Symbol {
+    inner: u64,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct MonoTypeId {
+    inner: u32,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum MonoType {
+    Apply(Symbol, MonoSlice<MonoTypeId>),
+    Func {
+        args: MonoSlice<MonoTypeId>,
+        ret: MonoTypeId,
+    },
+    Record(RecordFields),
+    Tuple(TupleElems),
+    TagUnion(UnionTags),
+    EmptyRecord,
+    EmptyTuple,
+    EmptyTagUnion,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct RecordFields {
+    pub length: u16,
+    pub field_names_start: u32,
+    pub field_type_ids_start: u32,
+    pub field_types_start: u32,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct TupleElems {
+    pub length: u16,
+    pub elem_index_start: u32,
+    pub type_ids_start: u32,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct UnionTags {
+    pub length: u16,
+    pub labels_start: u32,
+    pub values_start: u32,
+}

--- a/crates/compiler/specialize_types/src/specialize_expr.rs
+++ b/crates/compiler/specialize_types/src/specialize_expr.rs
@@ -1,0 +1,310 @@
+use crate::expr::{self, Declarations, Expr, FunctionDef};
+use crate::specialize_type::{MonoCache, Problem};
+use crate::subs::{Subs, Variable};
+use crate::symbol::Symbol;
+use roc_collections::VecMap;
+
+struct Context {
+    symbols: Symbol,
+    fresh_tvar: Box<dyn Fn() -> Variable>,
+    specializations: Specializations,
+}
+
+struct Specializations {
+    symbols: Symbol,
+    fenv: Vec<(Symbol, expr::FunctionDef)>,
+    specializations: Vec<(SpecializationKey, NeededSpecialization)>,
+}
+
+#[derive(PartialEq, Eq)]
+struct SpecializationKey(Symbol, Variable);
+
+struct NeededSpecialization {
+    def: expr::FunctionDef,
+    name_new: Symbol,
+    t_new: Variable,
+    specialized: Option<expr::Def>,
+}
+
+impl Specializations {
+    fn make(symbols: Symbol, program: &expr::Declarations) -> Self {
+        let fenv = program
+            .iter_top_down()
+            .filter_map(|(_, tag)| match tag {
+                expr::DeclarationTag::Function(idx)
+                | expr::DeclarationTag::Recursive(idx)
+                | expr::DeclarationTag::TailRecursive(idx) => {
+                    let func = &program.function_bodies[idx.index()];
+                    Some((func.value.name, func.value.clone()))
+                }
+                _ => None,
+            })
+            .collect();
+
+        Specializations {
+            symbols,
+            fenv,
+            specializations: Vec::new(),
+        }
+    }
+
+    fn specialize_fn(
+        &mut self,
+        mono_cache: &mut MonoCache,
+        name: Symbol,
+        t_new: Variable,
+    ) -> Option<Symbol> {
+        let specialization = (name, t_new);
+
+        if let Some((_, needed)) = self
+            .specializations
+            .iter()
+            .find(|(key, _)| *key == specialization)
+        {
+            Some(needed.name_new)
+        } else {
+            let def = self.fenv.iter().find(|(n, _)| *n == name)?.1.clone();
+            let name_new = self.symbols.fresh_symbol_named(name);
+            let needed_specialization = NeededSpecialization {
+                def,
+                name_new,
+                t_new,
+                specialized: None,
+            };
+            self.specializations
+                .push((specialization, needed_specialization));
+            Some(name_new)
+        }
+    }
+
+    fn next_needed_specialization(&mut self) -> Option<&mut NeededSpecialization> {
+        self.specializations.iter_mut().find_map(|(_, ns)| {
+            if ns.specialized.is_none() {
+                Some(ns)
+            } else {
+                None
+            }
+        })
+    }
+
+    fn solved_specializations(&self) -> Vec<expr::Def> {
+        self.specializations
+            .iter()
+            .filter_map(|(_, ns)| ns.specialized.clone())
+            .collect()
+    }
+}
+
+fn specialize_expr(
+    ctx: &mut Context,
+    ty_cache: &mut Subs,
+    mono_cache: &mut MonoCache,
+    expr: &Expr,
+) -> Expr {
+    match expr {
+        Expr::Var(x) => {
+            if let Some(y) = ctx
+                .specializations
+                .specialize_fn(mono_cache, *x, expr.get_type())
+            {
+                Expr::Var(y)
+            } else {
+                expr.clone()
+            }
+        }
+        Expr::Int(i) => Expr::Int(*i),
+        Expr::Str(s) => Expr::Str(s.clone()),
+        Expr::Tag(t, args) => {
+            let new_args = args
+                .iter()
+                .map(|a| specialize_expr(ctx, ty_cache, mono_cache, a))
+                .collect();
+            Expr::Tag(*t, new_args)
+        }
+        Expr::Record(fields) => {
+            let new_fields = fields
+                .iter()
+                .map(|(f, e)| (*f, specialize_expr(ctx, ty_cache, mono_cache, e)))
+                .collect();
+            Expr::Record(new_fields)
+        }
+        Expr::Access(e, f) => {
+            Expr::Access(Box::new(specialize_expr(ctx, ty_cache, mono_cache, e)), *f)
+        }
+        Expr::Let(def, rest) => {
+            let new_def = match def {
+                expr::Def::Letfn(f) => expr::Def::Letfn(FunctionDef {
+                    recursive: f.recursive,
+                    bind: (
+                        mono_cache.monomorphize_var(ty_cache, &mut Vec::new(), f.bind.0),
+                        f.bind.1,
+                    ),
+                    arg: (
+                        mono_cache.monomorphize_var(ty_cache, &mut Vec::new(), f.arg.0),
+                        f.arg.1,
+                    ),
+                    body: Box::new(specialize_expr(ctx, ty_cache, mono_cache, &f.body)),
+                }),
+                expr::Def::Letval(v) => expr::Def::Letval(expr::Letval {
+                    bind: (
+                        mono_cache.monomorphize_var(ty_cache, &mut Vec::new(), v.bind.0),
+                        v.bind.1,
+                    ),
+                    body: Box::new(specialize_expr(ctx, ty_cache, mono_cache, &v.body)),
+                }),
+            };
+            let new_rest = Box::new(specialize_expr(ctx, ty_cache, mono_cache, rest));
+            Expr::Let(Box::new(new_def), new_rest)
+        }
+        Expr::Clos { arg, body } => {
+            let new_arg = (
+                mono_cache.monomorphize_var(ty_cache, &mut Vec::new(), arg.0),
+                arg.1,
+            );
+            let new_body = Box::new(specialize_expr(ctx, ty_cache, mono_cache, body));
+            Expr::Clos {
+                arg: new_arg,
+                body: new_body,
+            }
+        }
+        Expr::Call(f, a) => {
+            let new_f = Box::new(specialize_expr(ctx, ty_cache, mono_cache, f));
+            let new_a = Box::new(specialize_expr(ctx, ty_cache, mono_cache, a));
+            Expr::Call(new_f, new_a)
+        }
+        Expr::KCall(kfn, args) => {
+            let new_args = args
+                .iter()
+                .map(|a| specialize_expr(ctx, ty_cache, mono_cache, a))
+                .collect();
+            Expr::KCall(*kfn, new_args)
+        }
+        Expr::When(e, branches) => {
+            let new_e = Box::new(specialize_expr(ctx, ty_cache, mono_cache, e));
+            let new_branches = branches
+                .iter()
+                .map(|(p, e)| {
+                    let new_p = specialize_pattern(ctx, ty_cache, mono_cache, p);
+                    let new_e = specialize_expr(ctx, ty_cache, mono_cache, e);
+                    (new_p, new_e)
+                })
+                .collect();
+            Expr::When(new_e, new_branches)
+        }
+    }
+}
+
+fn specialize_pattern(
+    ctx: &mut Context,
+    ty_cache: &mut Subs,
+    mono_cache: &mut MonoCache,
+    pattern: &expr::Pattern,
+) -> expr::Pattern {
+    match pattern {
+        expr::Pattern::PVar(x) => expr::Pattern::PVar(*x),
+        expr::Pattern::PTag(tag, args) => {
+            let new_args = args
+                .iter()
+                .map(|a| specialize_pattern(ctx, ty_cache, mono_cache, a))
+                .collect();
+            expr::Pattern::PTag(*tag, new_args)
+        }
+    }
+}
+
+fn specialize_let_fn(
+    ctx: &mut Context,
+    ty_cache: &mut Subs,
+    mono_cache: &mut MonoCache,
+    t_new: Variable,
+    name_new: Symbol,
+    f: &expr::FunctionDef,
+) -> expr::Def {
+    mono_cache.monomorphize_var(ty_cache, &mut Vec::new(), t_new);
+    let t = mono_cache.monomorphize_var(ty_cache, &mut Vec::new(), f.bind.0);
+    let t_arg = mono_cache.monomorphize_var(ty_cache, &mut Vec::new(), f.arg.0);
+    let body = specialize_expr(ctx, ty_cache, mono_cache, &f.body);
+
+    expr::Def::Letfn(FunctionDef {
+        recursive: f.recursive,
+        bind: (t, name_new),
+        arg: (t_arg, f.arg.1),
+        body: Box::new(body),
+    })
+}
+
+fn specialize_let_val(ctx: &mut Context, v: &expr::Letval) -> expr::Def {
+    let mut ty_cache = Subs::new();
+    let mut mono_cache = MonoCache::from_subs(&ty_cache);
+    let t = mono_cache.monomorphize_var(&mut ty_cache, &mut Vec::new(), v.bind.0);
+    let body = specialize_expr(ctx, &mut ty_cache, &mut mono_cache, &v.body);
+    expr::Def::Letval(expr::Letval {
+        bind: (t, v.bind.1),
+        body: Box::new(body),
+    })
+}
+
+fn specialize_run_def(ctx: &mut Context, run: &expr::Run) -> expr::Run {
+    let mut ty_cache = Subs::new();
+    let mut mono_cache = MonoCache::from_subs(&ty_cache);
+    let t = mono_cache.monomorphize_var(&mut ty_cache, &mut Vec::new(), run.bind.0);
+    let body = specialize_expr(ctx, &mut ty_cache, &mut mono_cache, &run.body);
+    expr::Run {
+        bind: (t, run.bind.1),
+        body: Box::new(body),
+        ty: run.ty,
+    }
+}
+
+fn make_context(
+    symbols: Symbol,
+    fresh_tvar: Box<dyn Fn() -> Variable>,
+    program: &expr::Declarations,
+) -> Context {
+    Context {
+        symbols,
+        fresh_tvar,
+        specializations: Specializations::make(symbols, program),
+    }
+}
+
+fn loop_specializations(ctx: &mut Context) {
+    while let Some(needed) = ctx.specializations.next_needed_specialization() {
+        let mut ty_cache = Subs::new();
+        let mut mono_cache = MonoCache::from_subs(&ty_cache);
+        let def = specialize_let_fn(
+            ctx,
+            &mut ty_cache,
+            &mut mono_cache,
+            needed.t_new,
+            needed.name_new,
+            &needed.def,
+        );
+        needed.specialized = Some(def);
+    }
+}
+
+pub fn lower(ctx: &mut Context, program: &expr::Declarations) -> expr::Declarations {
+    let mut new_program = expr::Declarations::new();
+
+    for (idx, tag) in program.iter_top_down() {
+        match tag {
+            expr::DeclarationTag::Value => {
+                let def = specialize_let_val(ctx, &program.expressions[idx]);
+                new_program.push_def(def);
+            }
+            expr::DeclarationTag::Run(run_idx) => {
+                let run = specialize_run_def(ctx, &program.expressions[run_idx.index()]);
+                new_program.push_run(run);
+            }
+            _ => {}
+        }
+    }
+
+    loop_specializations(ctx);
+
+    let other_defs = ctx.specializations.solved_specializations();
+    new_program.extend(other_defs);
+
+    new_program
+}

--- a/crates/compiler/specialize_types/tests/test_specialize_types.rs
+++ b/crates/compiler/specialize_types/tests/test_specialize_types.rs
@@ -983,18 +983,18 @@ mod specialize_types {
         specializes_to(".0 (5, 3.14 )", "Num []");
     }
 
-    #[test]
-    fn tuple_literal_ty() {
-        specializes_to("(5, 3.14 )", "( Num [], Frac [] )");
-    }
+    // #[test]
+    // fn tuple_literal_ty() {
+    //     specializes_to("(5, 3.14 )", "( Num [], Frac [] )");
+    // }
 
-    #[test]
-    fn tuple_literal_accessor_ty() {
-        specializes_to(".0", "( [] ) -> []");
-        specializes_to(".4", "( _, _, _, _, [] ) -> []");
-        specializes_to(".5", "( ... 5 omitted, [] ) -> []");
-        specializes_to(".200", "( ... 200 omitted, [] ) -> []");
-    }
+    // #[test]
+    // fn tuple_literal_accessor_ty() {
+    //     specializes_to(".0", "( [] ) -> []");
+    //     specializes_to(".4", "( _, _, _, _, [] ) -> []");
+    //     specializes_to(".5", "( ... 5 omitted, [] ) -> []");
+    //     specializes_to(".200", "( ... 200 omitted, [] ) -> []");
+    // }
 
     #[test]
     fn tuple_accessor_generalization() {
@@ -2481,26 +2481,26 @@ mod specialize_types {
     //     );
     // }
 
-    #[test]
-    fn typecheck_linked_list_map() {
-        infer_eq_without_problem(
-            indoc!(
-                r"
-                    ConsList a := [Cons a (ConsList a), Nil]
+    // #[test]
+    // fn typecheck_linked_list_map() {
+    //     infer_eq_without_problem(
+    //         indoc!(
+    //             r"
+    //                 ConsList a := [Cons a (ConsList a), Nil]
 
-                    map : (a -> b), ConsList a -> ConsList b
-                    map = \f, list ->
-                        when list is
-                            Nil -> Nil
-                            Cons x xs ->
-                                Cons (f x) (map f xs)
+    //                 map : (a -> b), ConsList a -> ConsList b
+    //                 map = \f, list ->
+    //                     when list is
+    //                         Nil -> Nil
+    //                         Cons x xs ->
+    //                             Cons (f x) (map f xs)
 
-                    map
-                       "
-            ),
-            "([] -> []), ConsList [] -> ConsList []",
-        );
-    }
+    //                 map
+    //                    "
+    //         ),
+    //         "([] -> []), ConsList [] -> ConsList []",
+    //     );
+    // }
 
     #[test]
     fn mismatch_in_alias_args_gets_reported() {
@@ -2719,46 +2719,44 @@ mod specialize_types {
         );
     }
 
-    #[test]
-    fn peano_map_infer() {
-        specializes_to(
-            indoc!(
-                r#"
-                app "test" provides [main] to "./platform"
+    // #[test]
+    // fn peano_map_infer() {
+    //     specializes_to(
+    //         indoc!(
+    //             r#"
+    //             app "test" provides [main] to "./platform"
 
-                map =
-                    \peano ->
-                        when peano is
-                            Z -> Z
-                            S rest -> map rest |> S
+    //             map =
+    //                 \peano ->
+    //                     when peano is
+    //                         Z -> Z
+    //                         S rest -> map rest |> S
 
+    //             main =
+    //                 map
+    //             "#
+    //         ),
+    //         "[S a, Z] as a -> [S b, Z] as b",
+    //     );
+    // }
 
-                main =
-                    map
-                "#
-            ),
-            "[S a, Z] as a -> [S b, Z] as b",
-        );
-    }
+    // #[test]
+    // fn peano_map_infer_nested() {
+    //     specializes_to(
+    //         indoc!(
+    //             r"
+    //                 map = \peano ->
+    //                         when peano is
+    //                             Z -> Z
+    //                             S rest ->
+    //                                 map rest |> S
 
-    #[test]
-    fn peano_map_infer_nested() {
-        specializes_to(
-            indoc!(
-                r"
-                    map = \peano ->
-                            when peano is
-                                Z -> Z
-                                S rest ->
-                                    map rest |> S
-
-
-                    map
-                "
-            ),
-            "[S a, Z] as a -> [S b, Z] as b",
-        );
-    }
+    //                 map
+    //             "
+    //         ),
+    //         "[S a, Z] as a -> [S b, Z] as b",
+    //     );
+    // }
 
     #[test]
     fn let_record_pattern_with_alias_annotation() {
@@ -2831,32 +2829,32 @@ mod specialize_types {
     //     );
     // }
 
-    #[test]
-    fn typecheck_mutually_recursive_tag_union_2() {
-        infer_eq_without_problem(
-            indoc!(
-                r"
-                    ListA a b := [Cons a (ListB b a), Nil]
-                    ListB a b := [Cons a (ListA b a), Nil]
+    // #[test]
+    // fn typecheck_mutually_recursive_tag_union_2() {
+    //     infer_eq_without_problem(
+    //         indoc!(
+    //             r"
+    //                 ListA a b := [Cons a (ListB b a), Nil]
+    //                 ListB a b := [Cons a (ListA b a), Nil]
 
-                    ConsList q : [Cons q (ConsList q), Nil]
+    //                 ConsList q : [Cons q (ConsList q), Nil]
 
-                    toAs : (b -> a), ListA a b -> ConsList a
-                    toAs = \f, @ListA lista ->
-                        when lista is
-                            Nil -> Nil
-                            Cons a (@ListB listb) ->
-                                when listb is
-                                    Nil -> Nil
-                                    Cons b (@ListA newLista) ->
-                                        Cons a (Cons (f b) (toAs f newLista))
+    //                 toAs : (b -> a), ListA a b -> ConsList a
+    //                 toAs = \f, @ListA lista ->
+    //                     when lista is
+    //                         Nil -> Nil
+    //                         Cons a (@ListB listb) ->
+    //                             when listb is
+    //                                 Nil -> Nil
+    //                                 Cons b (@ListA newLista) ->
+    //                                     Cons a (Cons (f b) (toAs f newLista))
 
-                    toAs
-                "
-            ),
-            "([] -> []), ListA [] [] -> ConsList []",
-        );
-    }
+    //                 toAs
+    //             "
+    //         ),
+    //         "([] -> []), ListA [] [] -> ConsList []",
+    //     );
+    // }
 
     #[test]
     fn typecheck_mutually_recursive_tag_union_listabc() {
@@ -3156,26 +3154,26 @@ mod specialize_types {
         infer_eq_without_problem("Num.maxU32", "U32");
     }
 
-    #[test]
-    fn reconstruct_path() {
-        infer_eq_without_problem(
-            indoc!(
-                r"
-                reconstructPath : Dict position position, position -> List position where position implements Hash & Eq
-                reconstructPath = \cameFrom, goal ->
-                    when Dict.get cameFrom goal is
-                        Err KeyNotFound ->
-                            []
+    // #[test]
+    // fn reconstruct_path() {
+    //     infer_eq_without_problem(
+    //         indoc!(
+    //             r"
+    //             reconstructPath : Dict position position, position -> List position where position implements Hash & Eq
+    //             reconstructPath = \cameFrom, goal ->
+    //                 when Dict.get cameFrom goal is
+    //                     Err KeyNotFound ->
+    //                         []
 
-                        Ok next ->
-                            List.append (reconstructPath cameFrom next) goal
+    //                     Ok next ->
+    //                         List.append (reconstructPath cameFrom next) goal
 
-                reconstructPath
-                "
-            ),
-            "Dict position position, position -> List position where position implements Hash & Eq",
-        );
-    }
+    //             reconstructPath
+    //             "
+    //         ),
+    //         "Dict position position, position -> List position where position implements Hash & Eq",
+    //     );
+    // }
 
     #[test]
     fn use_correct_ext_record() {
@@ -3196,43 +3194,43 @@ mod specialize_types {
         );
     }
 
-    #[test]
-    fn use_correct_ext_tag_union() {
-        // related to a bug solved in 08c82bf151a85e62bce02beeed1e14444381069f
-        infer_eq_without_problem(
-            indoc!(
-                r#"
-                app "test" imports [] provides [main] to "./platform"
+    // #[test]
+    // fn use_correct_ext_tag_union() {
+    //     // related to a bug solved in 08c82bf151a85e62bce02beeed1e14444381069f
+    //     infer_eq_without_problem(
+    //         indoc!(
+    //             r#"
+    //             app "test" imports [] provides [main] to "./platform"
 
-                boom = \_ -> boom {}
+    //             boom = \_ -> boom {}
 
-                Model position : { openSet : Set position }
+    //             Model position : { openSet : Set position }
 
-                cheapestOpen : Model position -> Result position [KeyNotFound] where position implements Hash & Eq
-                cheapestOpen = \model ->
+    //             cheapestOpen : Model position -> Result position [KeyNotFound] where position implements Hash & Eq
+    //             cheapestOpen = \model ->
 
-                    folder = \resSmallestSoFar, position ->
-                                    when resSmallestSoFar is
-                                        Err _ -> resSmallestSoFar
-                                        Ok smallestSoFar ->
-                                            if position == smallestSoFar.position then resSmallestSoFar
+    //                 folder = \resSmallestSoFar, position ->
+    //                                 when resSmallestSoFar is
+    //                                     Err _ -> resSmallestSoFar
+    //                                     Ok smallestSoFar ->
+    //                                         if position == smallestSoFar.position then resSmallestSoFar
 
-                                            else
-                                                Ok { position, cost: 0.0 }
+    //                                         else
+    //                                             Ok { position, cost: 0.0 }
 
-                    Set.walk model.openSet (Ok { position: boom {}, cost: 0.0 }) folder
-                        |> Result.map (\x -> x.position)
+    //                 Set.walk model.openSet (Ok { position: boom {}, cost: 0.0 }) folder
+    //                     |> Result.map (\x -> x.position)
 
-                astar : Model position -> Result position [KeyNotFound] where position implements Hash & Eq
-                astar = \model -> cheapestOpen model
+    //             astar : Model position -> Result position [KeyNotFound] where position implements Hash & Eq
+    //             astar = \model -> cheapestOpen model
 
-                main =
-                    astar
-                "#
-            ),
-            "Model position -> Result position [KeyNotFound] where position implements Hash & Eq",
-        );
-    }
+    //             main =
+    //                 astar
+    //             "#
+    //         ),
+    //         "Model position -> Result position [KeyNotFound] where position implements Hash & Eq",
+    //     );
+    // }
 
     #[test]
     fn when_with_or_pattern_and_guard() {
@@ -3390,22 +3388,22 @@ mod specialize_types {
         );
     }
 
-    #[test]
-    fn open_optional_field_unifies_with_missing() {
-        infer_eq_without_problem(
-            indoc!(
-                r#"
-                    negatePoint : { x : I64, y : I64, z ? Num c }r -> { x : I64, y : I64, z : Num c }r
+    // #[test]
+    // fn open_optional_field_unifies_with_missing() {
+    //     infer_eq_without_problem(
+    //         indoc!(
+    //             r#"
+    //                 negatePoint : { x : I64, y : I64, z ? Num c }r -> { x : I64, y : I64, z : Num c }r
 
-                    a = negatePoint { x: 1, y: 2 }
-                    b = negatePoint { x: 1, y: 2, blah : "hi" }
+    //                 a = negatePoint { x: 1, y: 2 }
+    //                 b = negatePoint { x: 1, y: 2, blah : "hi" }
 
-                    { a, b }
-                "#
-            ),
-            "{ a : { x : I64, y : I64, z : Num [] }, b : { blah : Str, x : I64, y : I64, z : Num [] } }",
-        );
-    }
+    //                 { a, b }
+    //             "#
+    //         ),
+    //         "{ a : { x : I64, y : I64, z : Num [] }, b : { blah : Str, x : I64, y : I64, z : Num [] } }",
+    //     );
+    // }
 
     #[test]
     fn optional_field_unifies_with_present() {
@@ -3421,22 +3419,22 @@ mod specialize_types {
         );
     }
 
-    #[test]
-    fn open_optional_field_unifies_with_present() {
-        infer_eq_without_problem(
-            indoc!(
-                r#"
-                    negatePoint : { x : Num a, y : Num b, z ? c }r -> { x : Num a, y : Num b, z : c }r
+    // #[test]
+    // fn open_optional_field_unifies_with_present() {
+    //     infer_eq_without_problem(
+    //         indoc!(
+    //             r#"
+    //                 negatePoint : { x : Num a, y : Num b, z ? c }r -> { x : Num a, y : Num b, z : c }r
 
-                    a = negatePoint { x: 1, y: 2.1 }
-                    b = negatePoint { x: 1, y: 2.1, blah : "hi" }
+    //                 a = negatePoint { x: 1, y: 2.1 }
+    //                 b = negatePoint { x: 1, y: 2.1, blah : "hi" }
 
-                    { a, b }
-                "#
-            ),
-            "{ a : { x : Num [], y : Frac [], z : c }, b : { blah : Str, x : Num [], y : Frac [], z : c1 } }",
-        );
-    }
+    //                 { a, b }
+    //             "#
+    //         ),
+    //         "{ a : { x : Num [], y : Frac [], z : c }, b : { blah : Str, x : Num [], y : Frac [], z : c1 } }",
+    //     );
+    // }
 
     #[test]
     fn optional_field_function() {
@@ -3464,35 +3462,35 @@ mod specialize_types {
         );
     }
 
-    #[test]
-    fn optional_field_when() {
-        infer_eq_without_problem(
-            indoc!(
-                r"
-                \r ->
-                    when r is
-                        { x, y ? 0 } -> x + y
-                "
-            ),
-            "{ x : Num a, y ? Num a } -> Num a",
-        );
-    }
+    // #[test]
+    // fn optional_field_when() {
+    //     infer_eq_without_problem(
+    //         indoc!(
+    //             r"
+    //             \r ->
+    //                 when r is
+    //                     { x, y ? 0 } -> x + y
+    //             "
+    //         ),
+    //         "{ x : Num a, y ? Num a } -> Num a",
+    //     );
+    // }
 
-    #[test]
-    fn optional_field_let_with_signature() {
-        infer_eq_without_problem(
-            indoc!(
-                r"
-                \rec ->
-                    { x, y } : { x : I64, y ? Bool }*
-                    { x, y ? Bool.false } = rec
+    // #[test]
+    // fn optional_field_let_with_signature() {
+    //     infer_eq_without_problem(
+    //         indoc!(
+    //             r"
+    //             \rec ->
+    //                 { x, y } : { x : I64, y ? Bool }*
+    //                 { x, y ? Bool.false } = rec
 
-                    { x, y }
-                "
-            ),
-            "{ x : I64, y ? Bool }-> { x : I64, y : Bool }",
-        );
-    }
+    //                 { x, y }
+    //             "
+    //         ),
+    //         "{ x : I64, y ? Bool }-> { x : I64, y : Bool }",
+    //     );
+    // }
 
     #[test]
     fn list_walk_backwards() {

--- a/crates/compiler/specialize_types/tests/test_specialize_types.rs
+++ b/crates/compiler/specialize_types/tests/test_specialize_types.rs
@@ -2460,33 +2460,33 @@ mod specialize_types {
         );
     }
 
-    #[test]
-    fn infer_linked_list_map() {
-        infer_eq_without_problem(
-            indoc!(
-                r"
-                    map = \f, list ->
-                        when list is
-                            Nil -> Nil
-                            Cons x xs ->
-                                a = f x
-                                b = map f xs
+    // #[test]
+    // fn infer_linked_list_map() {
+    //     infer_eq_without_problem(
+    //         indoc!(
+    //             r"
+    //                 map = \f, list ->
+    //                     when list is
+    //                         Nil -> Nil
+    //                         Cons x xs ->
+    //                             a = f x
+    //                             b = map f xs
 
-                                Cons a b
+    //                             Cons a b
 
-                    map
-                       "
-            ),
-            "([] -> []), [Cons [] c, Nil] as c -> [Cons [] d, Nil] as d",
-        );
-    }
+    //                 map
+    //                    "
+    //         ),
+    //         "([] -> []), [Cons [] c, Nil] as c -> [Cons [] d, Nil] as d",
+    //     );
+    // }
 
     #[test]
     fn typecheck_linked_list_map() {
         infer_eq_without_problem(
             indoc!(
                 r"
-                    ConsList a : [Cons a (ConsList a), Nil]
+                    ConsList a := [Cons a (ConsList a), Nil]
 
                     map : (a -> b), ConsList a -> ConsList b
                     map = \f, list ->
@@ -2813,42 +2813,42 @@ mod specialize_types {
         );
     }
 
-    #[test]
-    fn infer_record_linked_list_map() {
-        infer_eq_without_problem(
-            indoc!(
-                r"
-                    map = \f, list ->
-                        when list is
-                            Nil -> Nil
-                            Cons { x,  xs } ->
-                                Cons { x: f x, xs : map f xs }
+    // #[test]
+    // fn infer_record_linked_list_map() {
+    //     infer_eq_without_problem(
+    //         indoc!(
+    //             r"
+    //                 map = \f, list ->
+    //                     when list is
+    //                         Nil -> Nil
+    //                         Cons { x,  xs } ->
+    //                             Cons { x: f x, xs : map f xs }
 
-                    map
-                "
-            ),
-            "(a -> b), [Cons { x : a, xs : c }, Nil] as c -> [Cons { x : b, xs : d }, Nil] as d",
-        );
-    }
+    //                 map
+    //             "
+    //         ),
+    //         "(a -> b), [Cons { x : a, xs : c }, Nil] as c -> [Cons { x : b, xs : d }, Nil] as d",
+    //     );
+    // }
 
     #[test]
     fn typecheck_mutually_recursive_tag_union_2() {
         infer_eq_without_problem(
             indoc!(
                 r"
-                    ListA a b : [Cons a (ListB b a), Nil]
-                    ListB a b : [Cons a (ListA b a), Nil]
+                    ListA a b := [Cons a (ListB b a), Nil]
+                    ListB a b := [Cons a (ListA b a), Nil]
 
                     ConsList q : [Cons q (ConsList q), Nil]
 
                     toAs : (b -> a), ListA a b -> ConsList a
-                    toAs = \f, lista ->
+                    toAs = \f, @ListA lista ->
                         when lista is
                             Nil -> Nil
-                            Cons a listb ->
+                            Cons a (@ListB listb) ->
                                 when listb is
                                     Nil -> Nil
-                                    Cons b newLista ->
+                                    Cons b (@ListA newLista) ->
                                         Cons a (Cons (f b) (toAs f newLista))
 
                     toAs
@@ -2877,26 +2877,26 @@ mod specialize_types {
         );
     }
 
-    #[test]
-    fn infer_mutually_recursive_tag_union() {
-        infer_eq_without_problem(
-            indoc!(
-                r"
-                   toAs = \f, lista ->
-                        when lista is
-                            Nil -> Nil
-                            Cons a listb ->
-                                when listb is
-                                    Nil -> Nil
-                                    Cons b newLista ->
-                                        Cons a (Cons (f b) (toAs f newLista))
+    // #[test]
+    // fn infer_mutually_recursive_tag_union() {
+    //     infer_eq_without_problem(
+    //         indoc!(
+    //             r"
+    //                toAs = \f, lista ->
+    //                     when lista is
+    //                         Nil -> Nil
+    //                         Cons a listb ->
+    //                             when listb is
+    //                                 Nil -> Nil
+    //                                 Cons b newLista ->
+    //                                     Cons a (Cons (f b) (toAs f newLista))
 
-                   toAs
-                "
-            ),
-            "(a -> b), [Cons c [Cons a d, Nil], Nil] as d -> [Cons c [Cons b e], Nil] as e",
-        );
-    }
+    //                toAs
+    //             "
+    //         ),
+    //         "(a -> b), [Cons c [Cons a d, Nil], Nil] as d -> [Cons c [Cons b e], Nil] as e",
+    //     );
+    // }
 
     #[test]
     fn solve_list_get() {
@@ -3039,10 +3039,7 @@ mod specialize_types {
 
     #[test]
     fn map_insert() {
-        infer_eq_without_problem(
-            "Dict.insert",
-            "Dict k v, k, v -> Dict k v where k implements Hash & Eq",
-        );
+        infer_eq_without_problem("Dict.insert", "Dict [] [], [], [] -> Dict [] []");
     }
 
     #[test]

--- a/crates/compiler/specialize_types/tests/test_specialize_types.rs
+++ b/crates/compiler/specialize_types/tests/test_specialize_types.rs
@@ -1,0 +1,5107 @@
+#[macro_use]
+extern crate pretty_assertions;
+#[macro_use]
+extern crate indoc;
+
+extern crate bumpalo;
+
+#[cfg(test)]
+mod specialize_types {
+    use roc_load::LoadedModule;
+    use roc_solve::FunctionKind;
+    use roc_specialize_types::MonoCache;
+    use test_solve_helpers::{format_problems, run_load_and_infer};
+
+    use roc_types::pretty_print::{name_and_print_var, DebugPrint};
+
+    // HELPERS
+
+    fn infer_eq_help(src: &str) -> Result<(String, String, String), std::io::Error> {
+        let (
+            LoadedModule {
+                module_id: home,
+                mut can_problems,
+                mut type_problems,
+                interns,
+                mut solved,
+                mut exposed_to_host,
+                abilities_store,
+                ..
+            },
+            src,
+        ) = run_load_and_infer(src, [], false, FunctionKind::LambdaSet)?;
+
+        let mut can_problems = can_problems.remove(&home).unwrap_or_default();
+        let type_problems = type_problems.remove(&home).unwrap_or_default();
+
+        // Disregard UnusedDef problems, because those are unavoidable when
+        // returning a function from the test expression.
+        can_problems.retain(|prob| {
+            !matches!(
+                prob,
+                roc_problem::can::Problem::UnusedDef(_, _)
+                    | roc_problem::can::Problem::UnusedBranchDef(..)
+            )
+        });
+
+        let (can_problems, type_problems) =
+            format_problems(&src, home, &interns, can_problems, type_problems);
+
+        let subs = solved.inner_mut();
+
+        exposed_to_host.retain(|s, _| !abilities_store.is_specialization_name(*s));
+
+        debug_assert!(exposed_to_host.len() == 1, "{exposed_to_host:?}");
+        let (_symbol, variable) = exposed_to_host.into_iter().next().unwrap();
+        let mut mono_cache = MonoCache::from_subs(subs);
+        let mut problems = Vec::new();
+
+        mono_cache.monomorphize_var(subs, &mut problems, variable);
+
+        assert_eq!(problems, Vec::new());
+
+        let actual_str = name_and_print_var(variable, subs, home, &interns, DebugPrint::NOTHING);
+
+        Ok((type_problems, can_problems, actual_str))
+    }
+
+    fn specializes_to(src: &str, expected: &str) {
+        let (_, can_problems, actual) = infer_eq_help(src).unwrap();
+
+        assert!(
+            can_problems.is_empty(),
+            "Canonicalization problems: {can_problems}"
+        );
+
+        assert_eq!(actual, expected.to_string());
+    }
+
+    fn infer_eq_without_problem(src: &str, expected: &str) {
+        let (type_problems, can_problems, actual) = infer_eq_help(src).unwrap();
+
+        assert!(
+            can_problems.is_empty(),
+            "Canonicalization problems: {can_problems}"
+        );
+
+        if !type_problems.is_empty() {
+            // fail with an assert, but print the problems normally so rust doesn't try to diff
+            // an empty vec with the problems.
+            panic!("expected:\n{expected:?}\ninferred:\n{actual:?}\nproblems:\n{type_problems}",);
+        }
+        assert_eq!(actual, expected.to_string());
+    }
+
+    #[test]
+    fn str_literal_solo() {
+        specializes_to("\"test\"", "Str");
+    }
+
+    #[test]
+    fn int_literal_solo() {
+        specializes_to("5", "Num []");
+    }
+
+    #[test]
+    fn frac_literal_solo() {
+        specializes_to("0.5", "Frac []");
+    }
+
+    #[test]
+    fn dec_literal() {
+        specializes_to(
+            indoc!(
+                r"
+                    val : Dec
+                    val = 1.2
+
+                    val
+                "
+            ),
+            "Dec",
+        );
+    }
+
+    #[test]
+    fn str_starts_with() {
+        specializes_to("Str.startsWith", "Str, Str -> Bool");
+    }
+
+    #[test]
+    fn str_from_int() {
+        infer_eq_without_problem("Num.toStr", "Num [] -> Str");
+    }
+
+    #[test]
+    fn str_from_utf8() {
+        infer_eq_without_problem(
+            "Str.fromUtf8",
+            "List U8 -> Result Str [BadUtf8 Utf8ByteProblem U64]",
+        );
+    }
+
+    #[test]
+    fn list_concat_utf8() {
+        infer_eq_without_problem("List.concatUtf8", "List U8, Str -> List U8")
+    }
+
+    // LIST
+
+    #[test]
+    fn empty_list() {
+        specializes_to(
+            indoc!(
+                r"
+                    []
+                "
+            ),
+            "List *",
+        );
+    }
+
+    #[test]
+    fn list_of_lists() {
+        specializes_to(
+            indoc!(
+                r"
+                    [[]]
+                "
+            ),
+            "List (List *)",
+        );
+    }
+
+    #[test]
+    fn triple_nested_list() {
+        specializes_to(
+            indoc!(
+                r"
+                    [[[]]]
+                "
+            ),
+            "List (List (List *))",
+        );
+    }
+
+    #[test]
+    fn nested_empty_list() {
+        specializes_to(
+            indoc!(
+                r"
+                    [[], [[]]]
+                "
+            ),
+            "List (List (List *))",
+        );
+    }
+
+    #[test]
+    fn list_of_one_int() {
+        specializes_to(
+            indoc!(
+                r"
+                    [42]
+                "
+            ),
+            "List (Num *)",
+        );
+    }
+
+    #[test]
+    fn triple_nested_int_list() {
+        specializes_to(
+            indoc!(
+                r"
+                    [[[5]]]
+                "
+            ),
+            "List (List (List (Num *)))",
+        );
+    }
+
+    #[test]
+    fn list_of_ints() {
+        specializes_to(
+            indoc!(
+                r"
+                    [1, 2, 3]
+                "
+            ),
+            "List (Num *)",
+        );
+    }
+
+    #[test]
+    fn nested_list_of_ints() {
+        specializes_to(
+            indoc!(
+                r"
+                    [[1], [2, 3]]
+                "
+            ),
+            "List (List (Num *))",
+        );
+    }
+
+    #[test]
+    fn list_of_one_string() {
+        specializes_to(
+            indoc!(
+                r#"
+                    ["cowabunga"]
+                "#
+            ),
+            "List Str",
+        );
+    }
+
+    #[test]
+    fn triple_nested_string_list() {
+        specializes_to(
+            indoc!(
+                r#"
+                    [[["foo"]]]
+                "#
+            ),
+            "List (List (List Str))",
+        );
+    }
+
+    #[test]
+    fn list_of_strings() {
+        specializes_to(
+            indoc!(
+                r#"
+                    ["foo", "bar"]
+                "#
+            ),
+            "List Str",
+        );
+    }
+
+    // INTERPOLATED STRING
+
+    #[test]
+    fn infer_interpolated_string() {
+        specializes_to(
+            indoc!(
+                r#"
+                whatItIs = "great"
+
+                "type inference is $(whatItIs)!"
+            "#
+            ),
+            "Str",
+        );
+    }
+
+    #[test]
+    fn infer_interpolated_var() {
+        specializes_to(
+            indoc!(
+                r#"
+                whatItIs = "great"
+
+                str = "type inference is $(whatItIs)!"
+
+                whatItIs
+            "#
+            ),
+            "Str",
+        );
+    }
+
+    #[test]
+    fn infer_interpolated_field() {
+        specializes_to(
+            indoc!(
+                r#"
+                rec = { whatItIs: "great" }
+
+                str = "type inference is $(rec.whatItIs)!"
+
+                rec
+            "#
+            ),
+            "{ whatItIs : Str }",
+        );
+    }
+
+    // LIST MISMATCH
+
+    #[test]
+    fn mismatch_heterogeneous_list() {
+        specializes_to(
+            indoc!(
+                r#"
+                    ["foo", 5]
+                "#
+            ),
+            "List <type mismatch>",
+        );
+    }
+
+    #[test]
+    fn mismatch_heterogeneous_nested_list() {
+        specializes_to(
+            indoc!(
+                r#"
+                    [["foo", 5]]
+                "#
+            ),
+            "List (List <type mismatch>)",
+        );
+    }
+
+    #[test]
+    fn mismatch_heterogeneous_nested_empty_list() {
+        specializes_to(
+            indoc!(
+                r"
+                [[1], [[]]]
+            "
+            ),
+            "List <type mismatch>",
+        );
+    }
+
+    // CLOSURE
+
+    #[test]
+    fn always_return_empty_record() {
+        specializes_to(
+            indoc!(
+                r"
+                    \_ -> {}
+                "
+            ),
+            "* -> {}",
+        );
+    }
+
+    #[test]
+    fn two_arg_return_int() {
+        specializes_to(
+            indoc!(
+                r"
+                    \_, _ -> 42
+                "
+            ),
+            "*, * -> Num *",
+        );
+    }
+
+    #[test]
+    fn three_arg_return_string() {
+        specializes_to(
+            indoc!(
+                r#"
+                    \_, _, _ -> "test!"
+                "#
+            ),
+            "*, *, * -> Str",
+        );
+    }
+
+    // DEF
+
+    #[test]
+    fn def_empty_record() {
+        specializes_to(
+            indoc!(
+                r"
+                    foo = {}
+
+                    foo
+                "
+            ),
+            "{}",
+        );
+    }
+
+    #[test]
+    fn def_string() {
+        specializes_to(
+            indoc!(
+                r#"
+                    str = "thing"
+
+                    str
+                "#
+            ),
+            "Str",
+        );
+    }
+
+    #[test]
+    fn def_1_arg_closure() {
+        specializes_to(
+            indoc!(
+                r"
+                    fn = \_ -> {}
+
+                    fn
+                "
+            ),
+            "* -> {}",
+        );
+    }
+
+    #[test]
+    fn applied_tag() {
+        infer_eq_without_problem(
+            indoc!(
+                r#"
+                List.map ["a", "b"] \elem -> Foo elem
+                "#
+            ),
+            "List [Foo Str]",
+        )
+    }
+
+    // Tests (TagUnion, Func)
+    #[test]
+    fn applied_tag_function() {
+        infer_eq_without_problem(
+            indoc!(
+                r#"
+                foo = Foo
+
+                foo "hi"
+                "#
+            ),
+            "[Foo Str]",
+        )
+    }
+
+    // Tests (TagUnion, Func)
+    #[test]
+    fn applied_tag_function_list_map() {
+        infer_eq_without_problem(
+            indoc!(
+                r#"
+                List.map ["a", "b"] Foo
+                "#
+            ),
+            "List [Foo Str]",
+        )
+    }
+
+    // Tests (TagUnion, Func)
+    #[test]
+    fn applied_tag_function_list() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                [\x -> Bar x, Foo]
+                "
+            ),
+            "List (a -> [Bar a, Foo a])",
+        )
+    }
+
+    // Tests (Func, TagUnion)
+    #[test]
+    fn applied_tag_function_list_other_way() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                [Foo, \x -> Bar x]
+                "
+            ),
+            "List (a -> [Bar a, Foo a])",
+        )
+    }
+
+    // Tests (Func, TagUnion)
+    #[test]
+    fn applied_tag_function_record() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                foo0 = Foo
+                foo1 = Foo
+                foo2 = Foo
+
+                {
+                    x: [foo0, Foo],
+                    y: [foo1, \x -> Foo x],
+                    z: [foo2, \x,y  -> Foo x y]
+                }
+                "
+            ),
+            "{ x : List [Foo], y : List (a -> [Foo a]), z : List (b, c -> [Foo b c]) }",
+        )
+    }
+
+    // Tests (TagUnion, Func)
+    #[test]
+    fn applied_tag_function_with_annotation() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                x : List [Foo I64]
+                x = List.map [1, 2] Foo
+
+                x
+                "
+            ),
+            "List [Foo I64]",
+        )
+    }
+
+    #[test]
+    fn def_2_arg_closure() {
+        specializes_to(
+            indoc!(
+                r"
+                    func = \_, _ -> 42
+
+                    func
+                "
+            ),
+            "*, * -> Num *",
+        );
+    }
+
+    #[test]
+    fn def_3_arg_closure() {
+        specializes_to(
+            indoc!(
+                r#"
+                    f = \_, _, _ -> "test!"
+
+                    f
+                "#
+            ),
+            "*, *, * -> Str",
+        );
+    }
+
+    #[test]
+    fn def_multiple_functions() {
+        specializes_to(
+            indoc!(
+                r#"
+                    a = \_, _, _ -> "test!"
+
+                    b = a
+
+                    b
+                "#
+            ),
+            "*, *, * -> Str",
+        );
+    }
+
+    #[test]
+    fn def_multiple_strings() {
+        specializes_to(
+            indoc!(
+                r#"
+                    a = "test!"
+
+                    b = a
+
+                    b
+                "#
+            ),
+            "Str",
+        );
+    }
+
+    #[test]
+    fn def_multiple_ints() {
+        specializes_to(
+            indoc!(
+                r"
+                    c = b
+
+                    b = a
+
+                    a = 42
+
+                    c
+                "
+            ),
+            "Num *",
+        );
+    }
+
+    #[test]
+    fn def_returning_closure() {
+        specializes_to(
+            indoc!(
+                r"
+                    f = \z -> z
+                    g = \z -> z
+
+                    (\x ->
+                        a = f x
+                        b = g x
+                        x
+                    )
+                "
+            ),
+            "a -> a",
+        );
+    }
+
+    // CALLING FUNCTIONS
+
+    #[test]
+    fn call_returns_int() {
+        specializes_to(
+            indoc!(
+                r#"
+                    alwaysFive = \_ -> 5
+
+                    alwaysFive "stuff"
+                "#
+            ),
+            "Num *",
+        );
+    }
+
+    #[test]
+    fn identity_returns_given_type() {
+        specializes_to(
+            indoc!(
+                r#"
+                    identity = \a -> a
+
+                    identity "hi"
+                "#
+            ),
+            "Str",
+        );
+    }
+
+    #[test]
+    fn identity_infers_principal_type() {
+        specializes_to(
+            indoc!(
+                r"
+                    identity = \x -> x
+
+                    y = identity 5
+
+                    identity
+                "
+            ),
+            "a -> a",
+        );
+    }
+
+    #[test]
+    fn identity_works_on_incompatible_types() {
+        specializes_to(
+            indoc!(
+                r#"
+                    identity = \a -> a
+
+                    x = identity 5
+                    y = identity "hi"
+
+                    x
+                "#
+            ),
+            "Num *",
+        );
+    }
+
+    #[test]
+    fn call_returns_list() {
+        specializes_to(
+            indoc!(
+                r"
+                    enlist = \val -> [val]
+
+                    enlist 5
+                "
+            ),
+            "List (Num *)",
+        );
+    }
+
+    #[test]
+    fn indirect_always() {
+        specializes_to(
+            indoc!(
+                r#"
+                    always = \val -> (\_ -> val)
+                    alwaysFoo = always "foo"
+
+                    alwaysFoo 42
+                "#
+            ),
+            "Str",
+        );
+    }
+
+    #[test]
+    fn pizza_desugar() {
+        specializes_to(
+            indoc!(
+                r"
+                    1 |> (\a -> a)
+                "
+            ),
+            "Num *",
+        );
+    }
+
+    #[test]
+    fn pizza_desugar_two_arguments() {
+        specializes_to(
+            indoc!(
+                r#"
+                always2 = \a, _ -> a
+
+                1 |> always2 "foo"
+                "#
+            ),
+            "Num *",
+        );
+    }
+
+    #[test]
+    fn anonymous_identity() {
+        specializes_to(
+            indoc!(
+                r"
+                    (\a -> a) 3.14
+                "
+            ),
+            "Frac *",
+        );
+    }
+
+    #[test]
+    fn identity_of_identity() {
+        specializes_to(
+            indoc!(
+                r"
+                    (\val -> val) (\val -> val)
+                "
+            ),
+            "a -> a",
+        );
+    }
+
+    #[test]
+    fn recursive_identity() {
+        specializes_to(
+            indoc!(
+                r"
+                    identity = \val -> val
+
+                    identity identity
+                "
+            ),
+            "a -> a",
+        );
+    }
+
+    #[test]
+    fn identity_function() {
+        specializes_to(
+            indoc!(
+                r"
+                    \val -> val
+                "
+            ),
+            "a -> a",
+        );
+    }
+
+    #[test]
+    fn use_apply() {
+        specializes_to(
+            indoc!(
+                r"
+                identity = \a -> a
+                apply = \f, x -> f x
+
+                apply identity 5
+                "
+            ),
+            "Num *",
+        );
+    }
+
+    #[test]
+    fn apply_function() {
+        specializes_to(
+            indoc!(
+                r"
+                    \f, x -> f x
+                "
+            ),
+            "(a -> b), a -> b",
+        );
+    }
+
+    // #[test]
+    // TODO FIXME this should pass, but instead fails to canonicalize
+    // fn use_flip() {
+    //     infer_eq(
+    //         indoc!(
+    //             r"
+    //                 flip = \f -> (\a b -> f b a)
+    //                 neverendingInt = \f int -> f int
+    //                 x = neverendingInt (\a -> a) 5
+
+    //                 flip neverendingInt
+    //             "
+    //         ),
+    //         "(Num *, (a -> a)) -> Num *",
+    //     );
+    // }
+
+    #[test]
+    fn flip_function() {
+        specializes_to(
+            indoc!(
+                r"
+                    \f -> (\a, b -> f b a)
+                "
+            ),
+            "(a, b -> c) -> (b, a -> c)",
+        );
+    }
+
+    #[test]
+    fn always_function() {
+        specializes_to(
+            indoc!(
+                r"
+                    \val -> \_ -> val
+                "
+            ),
+            "a -> (* -> a)",
+        );
+    }
+
+    #[test]
+    fn pass_a_function() {
+        specializes_to(
+            indoc!(
+                r"
+                    \f -> f {}
+                "
+            ),
+            "({} -> a) -> a",
+        );
+    }
+
+    // OPERATORS
+
+    // #[test]
+    // fn div_operator() {
+    //     infer_eq(
+    //         indoc!(
+    //             r"
+    //             \l r -> l / r
+    //         "
+    //         ),
+    //         "F64, F64 -> F64",
+    //     );
+    // }
+
+    //     #[test]
+    //     fn basic_float_division() {
+    //         infer_eq(
+    //             indoc!(
+    //                 r"
+    //                 1 / 2
+    //             "
+    //             ),
+    //             "F64",
+    //         );
+    //     }
+
+    //     #[test]
+    //     fn basic_int_division() {
+    //         infer_eq(
+    //             indoc!(
+    //                 r"
+    //                 1 // 2
+    //             "
+    //             ),
+    //             "Num *",
+    //         );
+    //     }
+
+    //     #[test]
+    //     fn basic_addition() {
+    //         infer_eq(
+    //             indoc!(
+    //                 r"
+    //                 1 + 2
+    //             "
+    //             ),
+    //             "Num *",
+    //         );
+    //     }
+
+    // #[test]
+    // fn basic_circular_type() {
+    //     infer_eq(
+    //         indoc!(
+    //             r"
+    //             \x -> x x
+    //         "
+    //         ),
+    //         "<Type Mismatch: Circular Type>",
+    //     );
+    // }
+
+    // #[test]
+    // fn y_combinator_has_circular_type() {
+    //     assert_eq!(
+    //         infer(indoc!(r"
+    //             \f -> (\x -> f x x) (\x -> f x x)
+    //         ")),
+    //         Erroneous(Problem::CircularType)
+    //     );
+    // }
+
+    // #[test]
+    // fn no_higher_ranked_types() {
+    //     // This should error because it can't type of alwaysFive
+    //     infer_eq(
+    //         indoc!(
+    //             r#"
+    //             \always -> [always [], always ""]
+    //        "#
+    //         ),
+    //         "<type mismatch>",
+    //     );
+    // }
+
+    #[test]
+    fn always_with_list() {
+        specializes_to(
+            indoc!(
+                r#"
+                    alwaysFive = \_ -> 5
+
+                    [alwaysFive "foo", alwaysFive []]
+                "#
+            ),
+            "List (Num *)",
+        );
+    }
+
+    #[test]
+    fn if_with_int_literals() {
+        specializes_to(
+            indoc!(
+                r"
+                    if Bool.true then
+                        42
+                    else
+                        24
+                "
+            ),
+            "Num *",
+        );
+    }
+
+    #[test]
+    fn when_with_int_literals() {
+        specializes_to(
+            indoc!(
+                r"
+                    when 1 is
+                    1 -> 2
+                    3 -> 4
+                "
+            ),
+            "Num *",
+        );
+    }
+
+    // RECORDS
+
+    #[test]
+    fn empty_record() {
+        specializes_to("{}", "{}");
+    }
+
+    #[test]
+    fn one_field_record() {
+        specializes_to("{ x: 5 }", "{ x : Num * }");
+    }
+
+    #[test]
+    fn two_field_record() {
+        specializes_to("{ x: 5, y : 3.14 }", "{ x : Num *, y : Frac * }");
+    }
+
+    #[test]
+    fn record_literal_accessor() {
+        specializes_to("{ x: 5, y : 3.14 }.x", "Num *");
+    }
+
+    #[test]
+    fn record_literal_accessor_function() {
+        specializes_to(".x { x: 5, y : 3.14 }", "Num *");
+    }
+
+    #[test]
+    fn tuple_literal_accessor() {
+        specializes_to("(5, 3.14 ).0", "Num *");
+    }
+
+    #[test]
+    fn tuple_literal_accessor_function() {
+        specializes_to(".0 (5, 3.14 )", "Num *");
+    }
+
+    #[test]
+    fn tuple_literal_ty() {
+        specializes_to("(5, 3.14 )", "( Num *, Frac * )*");
+    }
+
+    #[test]
+    fn tuple_literal_accessor_ty() {
+        specializes_to(".0", "( a )* -> a");
+        specializes_to(".4", "( _, _, _, _, a )* -> a");
+        specializes_to(".5", "( ... 5 omitted, a )* -> a");
+        specializes_to(".200", "( ... 200 omitted, a )* -> a");
+    }
+
+    #[test]
+    fn tuple_accessor_generalization() {
+        specializes_to(
+            indoc!(
+                r#"
+                    get0 = .0
+
+                    { a: get0 (1, 2), b: get0 ("a", "b", "c") }
+                "#
+            ),
+            "{ a : Num *, b : Str }",
+        );
+    }
+
+    #[test]
+    fn record_arg() {
+        specializes_to("\\rec -> rec.x", "{ x : a }* -> a");
+    }
+
+    #[test]
+    fn record_with_bound_var() {
+        specializes_to(
+            indoc!(
+                r"
+                    fn = \rec ->
+                        x = rec.x
+
+                        rec
+
+                    fn
+                "
+            ),
+            "{ x : a }b -> { x : a }b",
+        );
+    }
+
+    #[test]
+    fn using_type_signature() {
+        specializes_to(
+            indoc!(
+                r"
+                    bar : custom -> custom
+                    bar = \x -> x
+
+                    bar
+                "
+            ),
+            "custom -> custom",
+        );
+    }
+
+    #[test]
+    fn type_signature_without_body() {
+        specializes_to(
+            indoc!(
+                r#"
+                    foo: Str -> {}
+
+                    foo "hi"
+                "#
+            ),
+            "{}",
+        );
+    }
+
+    #[test]
+    fn type_signature_without_body_rigid() {
+        specializes_to(
+            indoc!(
+                r"
+                    foo : Num * -> custom
+
+                    foo 2
+                "
+            ),
+            "custom",
+        );
+    }
+
+    #[test]
+    fn accessor_function() {
+        specializes_to(".foo", "{ foo : a }* -> a");
+    }
+
+    #[test]
+    fn type_signature_without_body_record() {
+        specializes_to(
+            indoc!(
+                r"
+                    { x, y } : { x : ({} -> custom), y : {} }
+
+                    x
+                "
+            ),
+            "{} -> custom",
+        );
+    }
+
+    #[test]
+    fn empty_record_pattern() {
+        specializes_to(
+            indoc!(
+                r"
+                # technically, an empty record can be destructured
+                thunk = \{} -> 42
+
+                xEmpty = if thunk {} == 42 then { x: {} } else { x: {} }
+
+                when xEmpty is
+                    { x: {} } -> {}
+                "
+            ),
+            "{}",
+        );
+    }
+
+    #[test]
+    fn record_type_annotation() {
+        // check that a closed record remains closed
+        specializes_to(
+            indoc!(
+                r"
+                foo : { x : custom } -> custom
+                foo = \{ x } -> x
+
+                foo
+            "
+            ),
+            "{ x : custom } -> custom",
+        );
+    }
+
+    #[test]
+    fn record_update() {
+        specializes_to(
+            indoc!(
+                r#"
+                    user = { year: "foo", name: "Sam" }
+
+                    { user & year: "foo" }
+                "#
+            ),
+            "{ name : Str, year : Str }",
+        );
+    }
+
+    #[test]
+    fn bare_tag() {
+        specializes_to(
+            indoc!(
+                r"
+                    Foo
+                "
+            ),
+            "[Foo]",
+        );
+    }
+
+    #[test]
+    fn single_tag_pattern() {
+        specializes_to(
+            indoc!(
+                r"
+                    \Foo -> 42
+                "
+            ),
+            "[Foo] -> Num *",
+        );
+    }
+
+    #[test]
+    fn two_tag_pattern() {
+        specializes_to(
+            indoc!(
+                r"
+                    \x ->
+                        when x is
+                            True -> 1
+                            False -> 0
+                "
+            ),
+            "[False, True] -> Num *",
+        );
+    }
+
+    #[test]
+    fn tag_application() {
+        specializes_to(
+            indoc!(
+                r#"
+                    Foo "happy" 12
+                "#
+            ),
+            "[Foo Str (Num *)]",
+        );
+    }
+
+    #[test]
+    fn record_extraction() {
+        specializes_to(
+            indoc!(
+                r"
+                    f = \x ->
+                        when x is
+                            { a, b: _ } -> a
+
+                    f
+                "
+            ),
+            "{ a : a, b : * }* -> a",
+        );
+    }
+
+    #[test]
+    fn record_field_pattern_match_with_guard() {
+        specializes_to(
+            indoc!(
+                r"
+                    when { x: 5 } is
+                        { x: 4 } -> 4
+                "
+            ),
+            "Num *",
+        );
+    }
+
+    #[test]
+    fn tag_union_pattern_match() {
+        specializes_to(
+            indoc!(
+                r"
+                    \Foo x -> Foo x
+                "
+            ),
+            "[Foo a] -> [Foo a]",
+        );
+    }
+
+    #[test]
+    fn tag_union_pattern_match_ignored_field() {
+        specializes_to(
+            indoc!(
+                r#"
+                    \Foo x _ -> Foo x "y"
+                "#
+            ),
+            "[Foo a *] -> [Foo a Str]",
+        );
+    }
+
+    #[test]
+    fn tag_with_field() {
+        specializes_to(
+            indoc!(
+                r#"
+                    when Foo "blah" is
+                        Foo x -> x
+                "#
+            ),
+            "Str",
+        );
+    }
+
+    #[test]
+    fn qualified_annotation_num_integer() {
+        specializes_to(
+            indoc!(
+                r"
+                   int : Num.Num (Num.Integer Num.Signed64)
+
+                   int
+                "
+            ),
+            "I64",
+        );
+    }
+    #[test]
+    fn qualified_annotated_num_integer() {
+        specializes_to(
+            indoc!(
+                r"
+                   int : Num.Num (Num.Integer Num.Signed64)
+                   int = 5
+
+                   int
+                "
+            ),
+            "I64",
+        );
+    }
+    #[test]
+    fn annotation_num_integer() {
+        specializes_to(
+            indoc!(
+                r"
+                   int : Num (Integer Signed64)
+
+                   int
+                "
+            ),
+            "I64",
+        );
+    }
+    #[test]
+    fn annotated_num_integer() {
+        specializes_to(
+            indoc!(
+                r"
+                   int : Num (Integer Signed64)
+                   int = 5
+
+                   int
+                "
+            ),
+            "I64",
+        );
+    }
+
+    #[test]
+    fn qualified_annotation_using_i128() {
+        specializes_to(
+            indoc!(
+                r"
+                    int : Num.I128
+
+                    int
+                "
+            ),
+            "I128",
+        );
+    }
+    #[test]
+    fn qualified_annotated_using_i128() {
+        specializes_to(
+            indoc!(
+                r"
+                    int : Num.I128
+                    int = 5
+
+                    int
+                "
+            ),
+            "I128",
+        );
+    }
+    #[test]
+    fn annotation_using_i128() {
+        specializes_to(
+            indoc!(
+                r"
+                    int : I128
+
+                    int
+                "
+            ),
+            "I128",
+        );
+    }
+    #[test]
+    fn annotated_using_i128() {
+        specializes_to(
+            indoc!(
+                r"
+                    int : I128
+                    int = 5
+
+                    int
+                "
+            ),
+            "I128",
+        );
+    }
+
+    #[test]
+    fn qualified_annotation_using_u128() {
+        specializes_to(
+            indoc!(
+                r"
+                    int : Num.U128
+
+                    int
+                "
+            ),
+            "U128",
+        );
+    }
+    #[test]
+    fn qualified_annotated_using_u128() {
+        specializes_to(
+            indoc!(
+                r"
+                    int : Num.U128
+                    int = 5
+
+                    int
+                "
+            ),
+            "U128",
+        );
+    }
+    #[test]
+    fn annotation_using_u128() {
+        specializes_to(
+            indoc!(
+                r"
+                    int : U128
+
+                    int
+                "
+            ),
+            "U128",
+        );
+    }
+    #[test]
+    fn annotated_using_u128() {
+        specializes_to(
+            indoc!(
+                r"
+                    int : U128
+                    int = 5
+
+                    int
+                "
+            ),
+            "U128",
+        );
+    }
+
+    #[test]
+    fn qualified_annotation_using_i64() {
+        specializes_to(
+            indoc!(
+                r"
+                    int : Num.I64
+
+                    int
+                "
+            ),
+            "I64",
+        );
+    }
+    #[test]
+    fn qualified_annotated_using_i64() {
+        specializes_to(
+            indoc!(
+                r"
+                    int : Num.I64
+                    int = 5
+
+                    int
+                "
+            ),
+            "I64",
+        );
+    }
+    #[test]
+    fn annotation_using_i64() {
+        specializes_to(
+            indoc!(
+                r"
+                    int : I64
+
+                    int
+                "
+            ),
+            "I64",
+        );
+    }
+    #[test]
+    fn annotated_using_i64() {
+        specializes_to(
+            indoc!(
+                r"
+                    int : I64
+                    int = 5
+
+                    int
+                "
+            ),
+            "I64",
+        );
+    }
+
+    #[test]
+    fn qualified_annotation_using_u64() {
+        specializes_to(
+            indoc!(
+                r"
+                    int : Num.U64
+
+                    int
+                "
+            ),
+            "U64",
+        );
+    }
+    #[test]
+    fn qualified_annotated_using_u64() {
+        specializes_to(
+            indoc!(
+                r"
+                    int : Num.U64
+                    int = 5
+
+                    int
+                "
+            ),
+            "U64",
+        );
+    }
+    #[test]
+    fn annotation_using_u64() {
+        specializes_to(
+            indoc!(
+                r"
+                    int : U64
+
+                    int
+                "
+            ),
+            "U64",
+        );
+    }
+    #[test]
+    fn annotated_using_u64() {
+        specializes_to(
+            indoc!(
+                r"
+                    int : U64
+                    int = 5
+
+                    int
+                "
+            ),
+            "U64",
+        );
+    }
+
+    #[test]
+    fn qualified_annotation_using_i32() {
+        specializes_to(
+            indoc!(
+                r"
+                    int : Num.I32
+
+                    int
+                "
+            ),
+            "I32",
+        );
+    }
+    #[test]
+    fn qualified_annotated_using_i32() {
+        specializes_to(
+            indoc!(
+                r"
+                    int : Num.I32
+                    int = 5
+
+                    int
+                "
+            ),
+            "I32",
+        );
+    }
+    #[test]
+    fn annotation_using_i32() {
+        specializes_to(
+            indoc!(
+                r"
+                    int : I32
+
+                    int
+                "
+            ),
+            "I32",
+        );
+    }
+    #[test]
+    fn annotated_using_i32() {
+        specializes_to(
+            indoc!(
+                r"
+                    int : I32
+                    int = 5
+
+                    int
+                "
+            ),
+            "I32",
+        );
+    }
+
+    #[test]
+    fn qualified_annotation_using_u32() {
+        specializes_to(
+            indoc!(
+                r"
+                    int : Num.U32
+
+                    int
+                "
+            ),
+            "U32",
+        );
+    }
+    #[test]
+    fn qualified_annotated_using_u32() {
+        specializes_to(
+            indoc!(
+                r"
+                    int : Num.U32
+                    int = 5
+
+                    int
+                "
+            ),
+            "U32",
+        );
+    }
+    #[test]
+    fn annotation_using_u32() {
+        specializes_to(
+            indoc!(
+                r"
+                    int : U32
+
+                    int
+                "
+            ),
+            "U32",
+        );
+    }
+    #[test]
+    fn annotated_using_u32() {
+        specializes_to(
+            indoc!(
+                r"
+                    int : U32
+                    int = 5
+
+                    int
+                "
+            ),
+            "U32",
+        );
+    }
+
+    #[test]
+    fn qualified_annotation_using_i16() {
+        specializes_to(
+            indoc!(
+                r"
+                    int : Num.I16
+
+                    int
+                "
+            ),
+            "I16",
+        );
+    }
+    #[test]
+    fn qualified_annotated_using_i16() {
+        specializes_to(
+            indoc!(
+                r"
+                    int : Num.I16
+                    int = 5
+
+                    int
+                "
+            ),
+            "I16",
+        );
+    }
+    #[test]
+    fn annotation_using_i16() {
+        specializes_to(
+            indoc!(
+                r"
+                    int : I16
+
+                    int
+                "
+            ),
+            "I16",
+        );
+    }
+    #[test]
+    fn annotated_using_i16() {
+        specializes_to(
+            indoc!(
+                r"
+                    int : I16
+                    int = 5
+
+                    int
+                "
+            ),
+            "I16",
+        );
+    }
+
+    #[test]
+    fn qualified_annotation_using_u16() {
+        specializes_to(
+            indoc!(
+                r"
+                    int : Num.U16
+
+                    int
+                "
+            ),
+            "U16",
+        );
+    }
+    #[test]
+    fn qualified_annotated_using_u16() {
+        specializes_to(
+            indoc!(
+                r"
+                    int : Num.U16
+                    int = 5
+
+                    int
+                "
+            ),
+            "U16",
+        );
+    }
+    #[test]
+    fn annotation_using_u16() {
+        specializes_to(
+            indoc!(
+                r"
+                    int : U16
+
+                    int
+                "
+            ),
+            "U16",
+        );
+    }
+    #[test]
+    fn annotated_using_u16() {
+        specializes_to(
+            indoc!(
+                r"
+                    int : U16
+                    int = 5
+
+                    int
+                "
+            ),
+            "U16",
+        );
+    }
+
+    #[test]
+    fn qualified_annotation_using_i8() {
+        specializes_to(
+            indoc!(
+                r"
+                    int : Num.I8
+
+                    int
+                "
+            ),
+            "I8",
+        );
+    }
+    #[test]
+    fn qualified_annotated_using_i8() {
+        specializes_to(
+            indoc!(
+                r"
+                    int : Num.I8
+                    int = 5
+
+                    int
+                "
+            ),
+            "I8",
+        );
+    }
+    #[test]
+    fn annotation_using_i8() {
+        specializes_to(
+            indoc!(
+                r"
+                    int : I8
+
+                    int
+                "
+            ),
+            "I8",
+        );
+    }
+    #[test]
+    fn annotated_using_i8() {
+        specializes_to(
+            indoc!(
+                r"
+                    int : I8
+                    int = 5
+
+                    int
+                "
+            ),
+            "I8",
+        );
+    }
+
+    #[test]
+    fn qualified_annotation_using_u8() {
+        specializes_to(
+            indoc!(
+                r"
+                    int : Num.U8
+
+                    int
+                "
+            ),
+            "U8",
+        );
+    }
+    #[test]
+    fn qualified_annotated_using_u8() {
+        specializes_to(
+            indoc!(
+                r"
+                    int : Num.U8
+                    int = 5
+
+                    int
+                "
+            ),
+            "U8",
+        );
+    }
+    #[test]
+    fn annotation_using_u8() {
+        specializes_to(
+            indoc!(
+                r"
+                    int : U8
+
+                    int
+                "
+            ),
+            "U8",
+        );
+    }
+    #[test]
+    fn annotated_using_u8() {
+        specializes_to(
+            indoc!(
+                r"
+                    int : U8
+                    int = 5
+
+                    int
+                "
+            ),
+            "U8",
+        );
+    }
+
+    #[test]
+    fn qualified_annotation_num_floatingpoint() {
+        specializes_to(
+            indoc!(
+                r"
+                   float : Num.Num (Num.FloatingPoint Num.Binary64)
+
+                   float
+                "
+            ),
+            "F64",
+        );
+    }
+    #[test]
+    fn qualified_annotated_num_floatingpoint() {
+        specializes_to(
+            indoc!(
+                r"
+                   float : Num.Num (Num.FloatingPoint Num.Binary64)
+                   float = 5.5
+
+                   float
+                "
+            ),
+            "F64",
+        );
+    }
+    #[test]
+    fn annotation_num_floatingpoint() {
+        specializes_to(
+            indoc!(
+                r"
+                   float : Num (FloatingPoint Binary64)
+
+                   float
+                "
+            ),
+            "F64",
+        );
+    }
+    #[test]
+    fn annotated_num_floatingpoint() {
+        specializes_to(
+            indoc!(
+                r"
+                   float : Num (FloatingPoint Binary64)
+                   float = 5.5
+
+                   float
+                "
+            ),
+            "F64",
+        );
+    }
+
+    #[test]
+    fn qualified_annotation_f64() {
+        specializes_to(
+            indoc!(
+                r"
+                   float : Num.F64
+
+                   float
+                "
+            ),
+            "F64",
+        );
+    }
+    #[test]
+    fn qualified_annotated_f64() {
+        specializes_to(
+            indoc!(
+                r"
+                   float : Num.F64
+                   float = 5.5
+
+                   float
+                "
+            ),
+            "F64",
+        );
+    }
+    #[test]
+    fn annotation_f64() {
+        specializes_to(
+            indoc!(
+                r"
+                   float : F64
+
+                   float
+                "
+            ),
+            "F64",
+        );
+    }
+    #[test]
+    fn annotated_f64() {
+        specializes_to(
+            indoc!(
+                r"
+                   float : F64
+                   float = 5.5
+
+                   float
+                "
+            ),
+            "F64",
+        );
+    }
+
+    #[test]
+    fn qualified_annotation_f32() {
+        specializes_to(
+            indoc!(
+                r"
+                   float : Num.F32
+
+                   float
+                "
+            ),
+            "F32",
+        );
+    }
+    #[test]
+    fn qualified_annotated_f32() {
+        specializes_to(
+            indoc!(
+                r"
+                   float : Num.F32
+                   float = 5.5
+
+                   float
+                "
+            ),
+            "F32",
+        );
+    }
+    #[test]
+    fn annotation_f32() {
+        specializes_to(
+            indoc!(
+                r"
+                   float : F32
+
+                   float
+                "
+            ),
+            "F32",
+        );
+    }
+    #[test]
+    fn annotated_f32() {
+        specializes_to(
+            indoc!(
+                r"
+                   float : F32
+                   float = 5.5
+
+                   float
+                "
+            ),
+            "F32",
+        );
+    }
+
+    #[test]
+    fn fake_result_ok() {
+        specializes_to(
+            indoc!(
+                r"
+                    Res a e : [Okay a, Error e]
+
+                    ok : Res I64 *
+                    ok = Okay 5
+
+                    ok
+                "
+            ),
+            "Res I64 *",
+        );
+    }
+
+    #[test]
+    fn fake_result_err() {
+        specializes_to(
+            indoc!(
+                r#"
+                    Res a e : [Okay a, Error e]
+
+                    err : Res * Str
+                    err = Error "blah"
+
+                    err
+                "#
+            ),
+            "Res * Str",
+        );
+    }
+
+    #[test]
+    fn basic_result_ok() {
+        specializes_to(
+            indoc!(
+                r"
+                    ok : Result I64 *
+                    ok = Ok 5
+
+                    ok
+                "
+            ),
+            "Result I64 *",
+        );
+    }
+
+    #[test]
+    fn basic_result_err() {
+        specializes_to(
+            indoc!(
+                r#"
+                    err : Result * Str
+                    err = Err "blah"
+
+                    err
+                "#
+            ),
+            "Result * Str",
+        );
+    }
+
+    #[test]
+    fn basic_result_conditional() {
+        specializes_to(
+            indoc!(
+                r#"
+                    ok : Result I64 _
+                    ok = Ok 5
+
+                    err : Result _ Str
+                    err = Err "blah"
+
+                    if 1 > 0 then
+                        ok
+                    else
+                        err
+                "#
+            ),
+            "Result I64 Str",
+        );
+    }
+
+    // #[test]
+    // fn annotation_using_num_used() {
+    //     // There was a problem where `I64`, because it is only an annotation
+    //     // wasn't added to the vars_by_symbol.
+    //     infer_eq_without_problem(
+    //         indoc!(
+    //             r"
+    //                int : I64
+
+    //                p = (\x -> x) int
+
+    //                p
+    //                "
+    //         ),
+    //         "I64",
+    //     );
+    // }
+
+    #[test]
+    fn num_identity() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                    numIdentity : Num.Num a -> Num.Num a
+                    numIdentity = \x -> x
+
+                    y = numIdentity 3.14
+
+                    { numIdentity, x : numIdentity 42, y }
+                "
+            ),
+            "{ numIdentity : Num a -> Num a, x : Num *, y : Frac * }",
+        );
+    }
+
+    #[test]
+    fn when_with_annotation() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                    x : Num.Num (Num.Integer Num.Signed64)
+                    x =
+                        when 2 is
+                            3 -> 4
+                            _ -> 5
+
+                    x
+                "
+            ),
+            "I64",
+        );
+    }
+
+    // TODO add more realistic function when able
+    #[test]
+    fn integer_sum() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                    f = \n ->
+                        when n is
+                            0 -> 0
+                            _ -> f n
+
+                    f
+                "
+            ),
+            "Num * -> Num *",
+        );
+    }
+
+    #[test]
+    fn identity_map() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                    map : (a -> b), [Identity a] -> [Identity b]
+                    map = \f, identity ->
+                        when identity is
+                            Identity v -> Identity (f v)
+                    map
+                "
+            ),
+            "(a -> b), [Identity a] -> [Identity b]",
+        );
+    }
+
+    #[test]
+    fn to_bit() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                   toBit = \bool ->
+                       when bool is
+                           True -> 1
+                           False -> 0
+
+                   toBit
+                "
+            ),
+            "[False, True] -> Num *",
+        );
+    }
+
+    // this test is related to a bug where ext_var would have an incorrect rank.
+    // This match has duplicate cases, but we ignore that.
+    #[test]
+    fn to_bit_record() {
+        specializes_to(
+            indoc!(
+                r#"
+                    foo = \rec ->
+                        when rec is
+                            { x: _ } -> "1"
+                            { y: _ } -> "2"
+
+                    foo
+                "#
+            ),
+            "{ x : *, y : * }* -> Str",
+        );
+    }
+
+    #[test]
+    fn from_bit() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                   fromBit = \int ->
+                       when int is
+                           0 -> False
+                           _ -> True
+
+                   fromBit
+                "
+            ),
+            "Num * -> [False, True]",
+        );
+    }
+
+    #[test]
+    fn result_map_explicit() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                    map : (a -> b), [Err e, Ok a] -> [Err e, Ok b]
+                    map = \f, result ->
+                        when result is
+                            Ok v -> Ok (f v)
+                            Err e -> Err e
+
+                    map
+                "
+            ),
+            "(a -> b), [Err e, Ok a] -> [Err e, Ok b]",
+        );
+    }
+
+    #[test]
+    fn result_map_alias() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                    Res e a : [Ok a, Err e]
+
+                    map : (a -> b), Res e a -> Res e b
+                    map = \f, result ->
+                        when result is
+                            Ok v -> Ok (f v)
+                            Err e -> Err e
+
+                    map
+                       "
+            ),
+            "(a -> b), Res e a -> Res e b",
+        );
+    }
+
+    #[test]
+    fn record_from_load() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                    foo = \{ x } -> x
+
+                    foo { x: 5 }
+                "
+            ),
+            "Num *",
+        );
+    }
+
+    #[test]
+    fn defs_from_load() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                    alwaysThreePointZero = \_ -> 3.0
+
+                    answer = 42
+
+                    identity = \a -> a
+
+                    threePointZero = identity (alwaysThreePointZero {})
+
+                    threePointZero
+                "
+            ),
+            "Frac *",
+        );
+    }
+
+    #[test]
+    fn use_as_in_signature() {
+        infer_eq_without_problem(
+            indoc!(
+                r#"
+                    foo : Str.Str as Foo -> Foo
+                    foo = \_ -> "foo"
+
+                    foo
+                "#
+            ),
+            "Foo -> Foo",
+        );
+    }
+
+    #[test]
+    fn use_alias_in_let() {
+        infer_eq_without_problem(
+            indoc!(
+                r#"
+                    Foo : Str.Str
+
+                    foo : Foo -> Foo
+                    foo = \_ -> "foo"
+
+                    foo
+                "#
+            ),
+            "Foo -> Foo",
+        );
+    }
+
+    #[test]
+    fn use_alias_with_argument_in_let() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                Foo a : { foo : a }
+
+                v : Foo (Num.Num (Num.Integer Num.Signed64))
+                v = { foo: 42 }
+
+                v
+                "
+            ),
+            "Foo I64",
+        );
+    }
+
+    #[test]
+    fn identity_alias() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                Foo a : { foo : a }
+
+                id : Foo a -> Foo a
+                id = \x -> x
+
+                id
+                "
+            ),
+            "Foo a -> Foo a",
+        );
+    }
+
+    #[test]
+    fn linked_list_empty() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                    empty : [Cons a (ConsList a), Nil] as ConsList a
+                    empty = Nil
+
+                    empty
+                       "
+            ),
+            "ConsList a",
+        );
+    }
+
+    #[test]
+    fn linked_list_singleton() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                    singleton : a -> [Cons a (ConsList a), Nil] as ConsList a
+                    singleton = \x -> Cons x Nil
+
+                    singleton
+                       "
+            ),
+            "a -> ConsList a",
+        );
+    }
+
+    #[test]
+    fn peano_length() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                    Peano : [S Peano, Z]
+
+                    length : Peano -> Num.Num (Num.Integer Num.Signed64)
+                    length = \peano ->
+                        when peano is
+                            Z -> 0
+                            S v -> length v
+
+                    length
+                       "
+            ),
+            "Peano -> I64",
+        );
+    }
+
+    #[test]
+    fn peano_map() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                    map : [S Peano, Z] as Peano -> Peano
+                    map = \peano ->
+                        when peano is
+                            Z -> Z
+                            S v -> S (map v)
+
+                    map
+                       "
+            ),
+            "Peano -> Peano",
+        );
+    }
+
+    #[test]
+    fn infer_linked_list_map() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                    map = \f, list ->
+                        when list is
+                            Nil -> Nil
+                            Cons x xs ->
+                                a = f x
+                                b = map f xs
+
+                                Cons a b
+
+                    map
+                       "
+            ),
+            "(a -> b), [Cons a c, Nil] as c -> [Cons b d, Nil] as d",
+        );
+    }
+
+    #[test]
+    fn typecheck_linked_list_map() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                    ConsList a : [Cons a (ConsList a), Nil]
+
+                    map : (a -> b), ConsList a -> ConsList b
+                    map = \f, list ->
+                        when list is
+                            Nil -> Nil
+                            Cons x xs ->
+                                Cons (f x) (map f xs)
+
+                    map
+                       "
+            ),
+            "(a -> b), ConsList a -> ConsList b",
+        );
+    }
+
+    #[test]
+    fn mismatch_in_alias_args_gets_reported() {
+        specializes_to(
+            indoc!(
+                r#"
+                Foo a : a
+
+                r : Foo {}
+                r = {}
+
+                s : Foo Str.Str
+                s = "bar"
+
+                when {} is
+                    _ -> s
+                    _ -> r
+                "#
+            ),
+            "<type mismatch>",
+        );
+    }
+
+    #[test]
+    fn mismatch_in_apply_gets_reported() {
+        specializes_to(
+            indoc!(
+                r"
+                r : { x : (Num.Num (Num.Integer Signed64)) }
+                r = { x : 1 }
+
+                s : { left : { x : Num.Num (Num.FloatingPoint Num.Binary64) } }
+                s = { left: { x : 3.14 } }
+
+                when 0 is
+                    1 -> s.left
+                    0 -> r
+                   "
+            ),
+            "<type mismatch>",
+        );
+    }
+
+    #[test]
+    fn mismatch_in_tag_gets_reported() {
+        specializes_to(
+            indoc!(
+                r"
+                r : [Ok Str.Str]
+                r = Ok 1
+
+                s : { left: [Ok {}] }
+                s = { left: Ok 3.14  }
+
+                when 0 is
+                    1 -> s.left
+                    0 -> r
+                   "
+            ),
+            "<type mismatch>",
+        );
+    }
+
+    // TODO As intended, this fails, but it fails with the wrong error!
+    //
+    // #[test]
+    // fn nums() {
+    //     infer_eq_without_problem(
+    //         indoc!(
+    //             r"
+    //                 s : Num *
+    //                 s = 3.1
+
+    //                 s
+    //                 "
+    //         ),
+    //         "<Type Mismatch: _____________>",
+    //     );
+    // }
+
+    #[test]
+    fn peano_map_alias() {
+        specializes_to(
+            indoc!(
+                r#"
+                app "test" provides [main] to "./platform"
+
+                Peano : [S Peano, Z]
+
+                map : Peano -> Peano
+                map = \peano ->
+                        when peano is
+                            Z -> Z
+                            S rest -> S (map rest)
+
+                main =
+                    map
+                "#
+            ),
+            "Peano -> Peano",
+        );
+    }
+
+    #[test]
+    fn unit_alias() {
+        specializes_to(
+            indoc!(
+                r"
+                    Unit : [Unit]
+
+                    unit : Unit
+                    unit = Unit
+
+                    unit
+                "
+            ),
+            "Unit",
+        );
+    }
+
+    #[test]
+    fn rigid_in_letnonrec() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                    ConsList a : [Cons a (ConsList a), Nil]
+
+                    toEmpty : ConsList a -> ConsList a
+                    toEmpty = \_ ->
+                        result : ConsList a
+                        result = Nil
+
+                        result
+
+                    toEmpty
+                "
+            ),
+            "ConsList a -> ConsList a",
+        );
+    }
+
+    #[test]
+    fn rigid_in_letrec_ignored() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                    ConsList a : [Cons a (ConsList a), Nil]
+
+                    toEmpty : ConsList a -> ConsList a
+                    toEmpty = \_ ->
+                        result : ConsList _   # TODO to enable using `a` we need scoped variables
+                        result = Nil
+
+                        toEmpty result
+
+                    toEmpty
+                "
+            ),
+            "ConsList a -> ConsList a",
+        );
+    }
+
+    #[test]
+    fn rigid_in_letrec() {
+        infer_eq_without_problem(
+            indoc!(
+                r#"
+                app "test" provides [main] to "./platform"
+
+                ConsList a : [Cons a (ConsList a), Nil]
+
+                toEmpty : ConsList a -> ConsList a
+                toEmpty = \_ ->
+                    result : ConsList _   # TODO to enable using `a` we need scoped variables
+                    result = Nil
+
+                    toEmpty result
+
+                main =
+                    toEmpty
+                "#
+            ),
+            "ConsList a -> ConsList a",
+        );
+    }
+
+    #[test]
+    fn let_record_pattern_with_annotation() {
+        infer_eq_without_problem(
+            indoc!(
+                r#"
+                    { x, y } : { x : Str.Str, y : Num.Num (Num.FloatingPoint Num.Binary64) }
+                    { x, y } = { x : "foo", y : 3.14 }
+
+                    x
+                "#
+            ),
+            "Str",
+        );
+    }
+
+    #[test]
+    fn let_record_pattern_with_annotation_alias() {
+        specializes_to(
+            indoc!(
+                r#"
+                    Foo : { x : Str.Str, y : Num.Num (Num.FloatingPoint Num.Binary64) }
+
+                    { x, y } : Foo
+                    { x, y } = { x : "foo", y : 3.14 }
+
+                    x
+                "#
+            ),
+            "Str",
+        );
+    }
+
+    #[test]
+    fn peano_map_infer() {
+        specializes_to(
+            indoc!(
+                r#"
+                app "test" provides [main] to "./platform"
+
+                map =
+                    \peano ->
+                        when peano is
+                            Z -> Z
+                            S rest -> map rest |> S
+
+
+                main =
+                    map
+                "#
+            ),
+            "[S a, Z] as a -> [S b, Z] as b",
+        );
+    }
+
+    #[test]
+    fn peano_map_infer_nested() {
+        specializes_to(
+            indoc!(
+                r"
+                    map = \peano ->
+                            when peano is
+                                Z -> Z
+                                S rest ->
+                                    map rest |> S
+
+
+                    map
+                "
+            ),
+            "[S a, Z] as a -> [S b, Z] as b",
+        );
+    }
+
+    #[test]
+    fn let_record_pattern_with_alias_annotation() {
+        infer_eq_without_problem(
+            indoc!(
+                r#"
+                    Foo : { x : Str.Str, y : Num.Num (Num.FloatingPoint Num.Binary64) }
+
+                    { x, y } : Foo
+                    { x, y } = { x : "foo", y : 3.14 }
+
+                    x
+               "#
+            ),
+            "Str",
+        );
+    }
+
+    #[test]
+    fn let_tag_pattern_with_annotation() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                     UserId x : [UserId I64]
+                     UserId x = UserId 42
+
+                     x
+                 "
+            ),
+            "I64",
+        );
+    }
+
+    #[test]
+    fn typecheck_record_linked_list_map() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                    ConsList q : [Cons { x: q, xs: ConsList q }, Nil]
+
+                    map : (a -> b), ConsList a -> ConsList b
+                    map = \f, list ->
+                        when list is
+                            Nil -> Nil
+                            Cons { x,  xs } ->
+                                Cons { x: f x, xs : map f xs }
+
+                    map
+                "
+            ),
+            "(a -> b), ConsList a -> ConsList b",
+        );
+    }
+
+    #[test]
+    fn infer_record_linked_list_map() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                    map = \f, list ->
+                        when list is
+                            Nil -> Nil
+                            Cons { x,  xs } ->
+                                Cons { x: f x, xs : map f xs }
+
+                    map
+                "
+            ),
+            "(a -> b), [Cons { x : a, xs : c }*, Nil] as c -> [Cons { x : b, xs : d }, Nil] as d",
+        );
+    }
+
+    #[test]
+    fn typecheck_mutually_recursive_tag_union_2() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                    ListA a b : [Cons a (ListB b a), Nil]
+                    ListB a b : [Cons a (ListA b a), Nil]
+
+                    ConsList q : [Cons q (ConsList q), Nil]
+
+                    toAs : (b -> a), ListA a b -> ConsList a
+                    toAs = \f, lista ->
+                        when lista is
+                            Nil -> Nil
+                            Cons a listb ->
+                                when listb is
+                                    Nil -> Nil
+                                    Cons b newLista ->
+                                        Cons a (Cons (f b) (toAs f newLista))
+
+                    toAs
+                "
+            ),
+            "(b -> a), ListA a b -> ConsList a",
+        );
+    }
+
+    #[test]
+    fn typecheck_mutually_recursive_tag_union_listabc() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                    ListA a : [Cons a (ListB a)]
+                    ListB a : [Cons a (ListC a)]
+                    ListC a : [Cons a (ListA a), Nil]
+
+                    val : ListC Num.I64
+                    val = Cons 1 (Cons 2 (Cons 3 Nil))
+
+                    val
+                "
+            ),
+            "ListC I64",
+        );
+    }
+
+    #[test]
+    fn infer_mutually_recursive_tag_union() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                   toAs = \f, lista ->
+                        when lista is
+                            Nil -> Nil
+                            Cons a listb ->
+                                when listb is
+                                    Nil -> Nil
+                                    Cons b newLista ->
+                                        Cons a (Cons (f b) (toAs f newLista))
+
+                   toAs
+                "
+            ),
+            "(a -> b), [Cons c [Cons a d, Nil], Nil] as d -> [Cons c [Cons b e], Nil] as e",
+        );
+    }
+
+    #[test]
+    fn solve_list_get() {
+        infer_eq_without_problem(
+            indoc!(
+                r#"
+                    List.get ["a"] 0
+                "#
+            ),
+            "Result Str [OutOfBounds]",
+        );
+    }
+
+    #[test]
+    fn type_more_general_than_signature() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                partition : U64, U64, List (Int a) -> [Pair U64 (List (Int a))]
+                partition = \low, high, initialList ->
+                    when List.get initialList high is
+                        Ok _ ->
+                            Pair 0 []
+
+                        Err _ ->
+                            Pair (low - 1) initialList
+
+                partition
+                            "
+            ),
+            "U64, U64, List (Int a) -> [Pair U64 (List (Int a))]",
+        );
+    }
+
+    #[test]
+    fn quicksort_partition() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+            swap : U64, U64, List a -> List a
+            swap = \i, j, list ->
+                when Pair (List.get list i) (List.get list j) is
+                    Pair (Ok atI) (Ok atJ) ->
+                        list
+                            |> List.set i atJ
+                            |> List.set j atI
+
+                    _ ->
+                        list
+
+            partition : U64, U64, List (Int a) -> [Pair U64 (List (Int a))]
+            partition = \low, high, initialList ->
+                when List.get initialList high is
+                    Ok pivot ->
+                        go = \i, j, list ->
+                            if j < high then
+                                when List.get list j is
+                                    Ok value ->
+                                        if value <= pivot then
+                                            go (i + 1) (j + 1) (swap (i + 1) j list)
+                                        else
+                                            go i (j + 1) list
+
+                                    Err _ ->
+                                        Pair i list
+                            else
+                                Pair i list
+
+                        when go (low - 1) low initialList is
+                            Pair newI newList ->
+                                Pair (newI + 1) (swap (newI + 1) high newList)
+
+                    Err _ ->
+                        Pair (low - 1) initialList
+
+            partition
+        "
+            ),
+            "U64, U64, List (Int a) -> [Pair U64 (List (Int a))]",
+        );
+    }
+
+    #[test]
+    fn identity_list() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                idList : List a -> List a
+                idList = \list -> list
+
+                foo : List I64 -> List I64
+                foo = \initialList -> idList initialList
+
+
+                foo
+            "
+            ),
+            "List I64 -> List I64",
+        );
+    }
+
+    #[test]
+    fn list_get() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                    List.get [10, 9, 8, 7] 1
+                "
+            ),
+            "Result (Num *) [OutOfBounds]",
+        );
+
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                    List.get
+                "
+            ),
+            "List a, U64 -> Result a [OutOfBounds]",
+        );
+    }
+
+    #[test]
+    fn use_rigid_twice() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                id1 : q -> q
+                id1 = \x -> x
+
+                id2 : q -> q
+                id2 = \x -> x
+
+                { id1, id2 }
+                "
+            ),
+            "{ id1 : q -> q, id2 : q1 -> q1 }",
+        );
+    }
+
+    #[test]
+    fn map_insert() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                Dict.insert
+                "
+            ),
+            "Dict k v, k, v -> Dict k v where k implements Hash & Eq",
+        );
+    }
+
+    #[test]
+    fn num_to_frac() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                Num.toFrac
+                "
+            ),
+            "Num * -> Frac a",
+        );
+    }
+
+    #[test]
+    fn pow() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                Num.pow
+                "
+            ),
+            "Frac a, Frac a -> Frac a",
+        );
+    }
+
+    #[test]
+    fn ceiling() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                Num.ceiling
+                "
+            ),
+            "Frac * -> Int a",
+        );
+    }
+
+    #[test]
+    fn floor() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                Num.floor
+                "
+            ),
+            "Frac * -> Int a",
+        );
+    }
+
+    #[test]
+    fn div() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                Num.div
+                "
+            ),
+            "Frac a, Frac a -> Frac a",
+        )
+    }
+
+    #[test]
+    fn div_checked() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                Num.divChecked
+                "
+            ),
+            "Frac a, Frac a -> Result (Frac a) [DivByZero]",
+        )
+    }
+
+    #[test]
+    fn div_ceil() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                Num.divCeil
+                "
+            ),
+            "Int a, Int a -> Int a",
+        );
+    }
+
+    #[test]
+    fn div_ceil_checked() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                Num.divCeilChecked
+                "
+            ),
+            "Int a, Int a -> Result (Int a) [DivByZero]",
+        );
+    }
+
+    #[test]
+    fn div_trunc() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                Num.divTrunc
+                "
+            ),
+            "Int a, Int a -> Int a",
+        );
+    }
+
+    #[test]
+    fn div_trunc_checked() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                Num.divTruncChecked
+                "
+            ),
+            "Int a, Int a -> Result (Int a) [DivByZero]",
+        );
+    }
+
+    #[test]
+    fn atan() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                Num.atan
+                "
+            ),
+            "Frac a -> Frac a",
+        );
+    }
+
+    #[test]
+    fn min_i128() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                Num.minI128
+                "
+            ),
+            "I128",
+        );
+    }
+
+    #[test]
+    fn max_i128() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                Num.maxI128
+                "
+            ),
+            "I128",
+        );
+    }
+
+    #[test]
+    fn min_i64() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                Num.minI64
+                "
+            ),
+            "I64",
+        );
+    }
+
+    #[test]
+    fn max_i64() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                Num.maxI64
+                "
+            ),
+            "I64",
+        );
+    }
+
+    #[test]
+    fn min_u64() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                Num.minU64
+                "
+            ),
+            "U64",
+        );
+    }
+
+    #[test]
+    fn max_u64() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                Num.maxU64
+                "
+            ),
+            "U64",
+        );
+    }
+
+    #[test]
+    fn min_i32() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                Num.minI32
+                "
+            ),
+            "I32",
+        );
+    }
+
+    #[test]
+    fn max_i32() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                Num.maxI32
+                "
+            ),
+            "I32",
+        );
+    }
+
+    #[test]
+    fn min_u32() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                Num.minU32
+                "
+            ),
+            "U32",
+        );
+    }
+
+    #[test]
+    fn max_u32() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                Num.maxU32
+                "
+            ),
+            "U32",
+        );
+    }
+
+    #[test]
+    fn reconstruct_path() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                reconstructPath : Dict position position, position -> List position where position implements Hash & Eq
+                reconstructPath = \cameFrom, goal ->
+                    when Dict.get cameFrom goal is
+                        Err KeyNotFound ->
+                            []
+
+                        Ok next ->
+                            List.append (reconstructPath cameFrom next) goal
+
+                reconstructPath
+                "
+            ),
+            "Dict position position, position -> List position where position implements Hash & Eq",
+        );
+    }
+
+    #[test]
+    fn use_correct_ext_record() {
+        // Related to a bug solved in 81fbab0b3fe4765bc6948727e603fc2d49590b1c
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                f = \r ->
+                    g = r.q
+                    h = r.p
+
+                    42
+
+                f
+                "
+            ),
+            "{ p : *, q : * }* -> Num *",
+        );
+    }
+
+    #[test]
+    fn use_correct_ext_tag_union() {
+        // related to a bug solved in 08c82bf151a85e62bce02beeed1e14444381069f
+        infer_eq_without_problem(
+            indoc!(
+                r#"
+                app "test" imports [] provides [main] to "./platform"
+
+                boom = \_ -> boom {}
+
+                Model position : { openSet : Set position }
+
+                cheapestOpen : Model position -> Result position [KeyNotFound] where position implements Hash & Eq
+                cheapestOpen = \model ->
+
+                    folder = \resSmallestSoFar, position ->
+                                    when resSmallestSoFar is
+                                        Err _ -> resSmallestSoFar
+                                        Ok smallestSoFar ->
+                                            if position == smallestSoFar.position then resSmallestSoFar
+
+                                            else
+                                                Ok { position, cost: 0.0 }
+
+                    Set.walk model.openSet (Ok { position: boom {}, cost: 0.0 }) folder
+                        |> Result.map (\x -> x.position)
+
+                astar : Model position -> Result position [KeyNotFound] where position implements Hash & Eq
+                astar = \model -> cheapestOpen model
+
+                main =
+                    astar
+                "#
+            ),
+            "Model position -> Result position [KeyNotFound] where position implements Hash & Eq",
+        );
+    }
+
+    #[test]
+    fn when_with_or_pattern_and_guard() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                \x ->
+                    when x is
+                        2 | 3 -> 0
+                        a if a < 20 ->  1
+                        3 | 4 if Bool.false -> 2
+                        _ -> 3
+                "
+            ),
+            "Num * -> Num *",
+        );
+    }
+
+    #[test]
+    fn sorting() {
+        // based on https://github.com/elm/compiler/issues/2057
+        // Roc seems to do this correctly, tracking to make sure it stays that way
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                sort : ConsList cm -> ConsList cm
+                sort =
+                    \xs ->
+                        f : cm, cm -> Order
+                        f = \_, _ -> LT
+
+                        sortWith f xs
+
+                sortBy : (x -> cmpl), ConsList x -> ConsList x
+                sortBy =
+                    \_, list ->
+                        cmp : x, x -> Order
+                        cmp = \_, _ -> LT
+
+                        sortWith cmp list
+
+                always = \x, _ -> x
+
+                sortWith : (foobar, foobar -> Order), ConsList foobar -> ConsList foobar
+                sortWith =
+                    \_, list ->
+                        f = \arg ->
+                            g arg
+
+                        g = \bs ->
+                            when bs is
+                                bx -> f bx
+
+                        always Nil (f list)
+
+                Order : [LT, GT, EQ]
+                ConsList a : [Nil, Cons a (ConsList a)]
+
+                { x: sortWith, y: sort, z: sortBy }
+                "
+            ),
+            "{ x : (foobar, foobar -> Order), ConsList foobar -> ConsList foobar, y : ConsList cm -> ConsList cm, z : (x -> cmpl), ConsList x -> ConsList x }"
+        );
+    }
+
+    // Like in elm, this test now fails. Polymorphic recursion (even with an explicit signature)
+    // yields a type error.
+    //
+    // We should at some point investigate why that is. Elm did support polymorphic recursion in
+    // earlier versions.
+    //
+    //    #[test]
+    //    fn wrapper() {
+    //        // based on https://github.com/elm/compiler/issues/1964
+    //        // Roc seems to do this correctly, tracking to make sure it stays that way
+    //        infer_eq_without_problem(
+    //            indoc!(
+    //                r"
+    //                Type a : [TypeCtor (Type (Wrapper a))]
+    //
+    //                Wrapper a : [Wrapper a]
+    //
+    //                Opaque : [Opaque]
+    //
+    //                encodeType1 : Type a -> Opaque
+    //                encodeType1 = \thing ->
+    //                    when thing is
+    //                        TypeCtor v0 ->
+    //                            encodeType1 v0
+    //
+    //                encodeType1
+    //                "
+    //            ),
+    //            "Type a -> Opaque",
+    //        );
+    //    }
+
+    #[test]
+    fn rigids() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                f : List a -> List a
+                f = \input ->
+                    # let-polymorphism at work
+                    x : {} -> List b
+                    x = \{} -> []
+
+                    when List.get input 0 is
+                        Ok val -> List.append (x {}) val
+                        Err _ -> input
+                f
+                "
+            ),
+            "List a -> List a",
+        );
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic]
+    fn rigid_record_quantification() {
+        // the ext here is qualified on the outside (because we have rank 1 types, not rank 2).
+        // That means e.g. `f : { bar : String, foo : I64 } -> Bool }` is a valid argument, but
+        // that function could not be applied to the `{ foo : I64 }` list. Therefore, this function
+        // is not allowed.
+        //
+        // should hit a debug_assert! in debug mode, and produce a type error in release mode
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                test : ({ foo : I64 }ext -> Bool), { foo : I64 } -> Bool
+                test = \fn, a -> fn a
+
+                test
+                "
+            ),
+            "should fail",
+        );
+    }
+
+    // OPTIONAL RECORD FIELDS
+
+    #[test]
+    fn optional_field_unifies_with_missing() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                    negatePoint : { x : I64, y : I64, z ? Num c } -> { x : I64, y : I64, z : Num c }
+
+                    negatePoint { x: 1, y: 2 }
+                "
+            ),
+            "{ x : I64, y : I64, z : Num c }",
+        );
+    }
+
+    #[test]
+    fn open_optional_field_unifies_with_missing() {
+        infer_eq_without_problem(
+            indoc!(
+                r#"
+                    negatePoint : { x : I64, y : I64, z ? Num c }r -> { x : I64, y : I64, z : Num c }r
+
+                    a = negatePoint { x: 1, y: 2 }
+                    b = negatePoint { x: 1, y: 2, blah : "hi" }
+
+                    { a, b }
+                "#
+            ),
+            "{ a : { x : I64, y : I64, z : Num c }, b : { blah : Str, x : I64, y : I64, z : Num c1 } }",
+        );
+    }
+
+    #[test]
+    fn optional_field_unifies_with_present() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                    negatePoint : { x : Num a, y : Num b, z ? c } -> { x : Num a, y : Num b, z : c }
+
+                    negatePoint { x: 1, y: 2.1, z: 0x3 }
+                "
+            ),
+            "{ x : Num *, y : Frac *, z : Int * }",
+        );
+    }
+
+    #[test]
+    fn open_optional_field_unifies_with_present() {
+        infer_eq_without_problem(
+            indoc!(
+                r#"
+                    negatePoint : { x : Num a, y : Num b, z ? c }r -> { x : Num a, y : Num b, z : c }r
+
+                    a = negatePoint { x: 1, y: 2.1 }
+                    b = negatePoint { x: 1, y: 2.1, blah : "hi" }
+
+                    { a, b }
+                "#
+            ),
+            "{ a : { x : Num *, y : Frac *, z : c }, b : { blah : Str, x : Num *, y : Frac *, z : c1 } }",
+        );
+    }
+
+    #[test]
+    fn optional_field_function() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                \{ x, y ? 0 } -> x + y
+                "
+            ),
+            "{ x : Num a, y ? Num a }* -> Num a",
+        );
+    }
+
+    #[test]
+    fn optional_field_let() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                { x, y ? 0 } = { x: 32 }
+
+                x + y
+                "
+            ),
+            "Num *",
+        );
+    }
+
+    #[test]
+    fn optional_field_when() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                \r ->
+                    when r is
+                        { x, y ? 0 } -> x + y
+                "
+            ),
+            "{ x : Num a, y ? Num a }* -> Num a",
+        );
+    }
+
+    #[test]
+    fn optional_field_let_with_signature() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                \rec ->
+                    { x, y } : { x : I64, y ? Bool }*
+                    { x, y ? Bool.false } = rec
+
+                    { x, y }
+                "
+            ),
+            "{ x : I64, y ? Bool }* -> { x : I64, y : Bool }",
+        );
+    }
+
+    #[test]
+    fn list_walk_backwards() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                List.walkBackwards
+                "
+            ),
+            "List elem, state, (state, elem -> state) -> state",
+        );
+    }
+
+    #[test]
+    fn list_walk_backwards_example() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                empty : List I64
+                empty =
+                    []
+
+                List.walkBackwards empty 0 (\a, b -> a + b)
+                "
+            ),
+            "I64",
+        );
+    }
+
+    #[test]
+    fn list_walk_with_index_until() {
+        infer_eq_without_problem(
+            indoc!(r"List.walkWithIndexUntil"),
+            "List elem, state, (state, elem, U64 -> [Break state, Continue state]) -> state",
+        );
+    }
+
+    #[test]
+    fn list_drop_at() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                List.dropAt
+                "
+            ),
+            "List elem, U64 -> List elem",
+        );
+    }
+
+    #[test]
+    fn str_trim() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                Str.trim
+                "
+            ),
+            "Str -> Str",
+        );
+    }
+
+    #[test]
+    fn str_trim_start() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                Str.trimStart
+                "
+            ),
+            "Str -> Str",
+        );
+    }
+
+    #[test]
+    fn list_take_first() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                List.takeFirst
+                "
+            ),
+            "List elem, U64 -> List elem",
+        );
+    }
+
+    #[test]
+    fn list_take_last() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                List.takeLast
+                "
+            ),
+            "List elem, U64 -> List elem",
+        );
+    }
+
+    #[test]
+    fn list_sublist() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                List.sublist
+                "
+            ),
+            "List elem, { len : U64, start : U64 } -> List elem",
+        );
+    }
+
+    #[test]
+    fn list_split() {
+        infer_eq_without_problem(
+            indoc!("List.split"),
+            "List elem, U64 -> { before : List elem, others : List elem }",
+        );
+    }
+
+    #[test]
+    fn list_drop_last() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                List.dropLast
+                "
+            ),
+            "List elem, U64 -> List elem",
+        );
+    }
+
+    #[test]
+    fn list_intersperse() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                List.intersperse
+                "
+            ),
+            "List elem, elem -> List elem",
+        );
+    }
+    #[test]
+    fn function_that_captures_nothing_is_not_captured() {
+        // we should make sure that a function that doesn't capture anything it not itself captured
+        // such functions will be lifted to the top-level, and are thus globally available!
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                f = \x -> x + 1
+
+                g = \y -> f y
+
+                g
+                "
+            ),
+            "Num a -> Num a",
+        );
+    }
+
+    #[test]
+    fn double_named_rigids() {
+        infer_eq_without_problem(
+            indoc!(
+                r#"
+                app "test" provides [main] to "./platform"
+
+
+                main : List x
+                main =
+                    empty : List x
+                    empty = []
+
+                    empty
+                "#
+            ),
+            "List x",
+        );
+    }
+
+    #[test]
+    fn double_tag_application() {
+        infer_eq_without_problem(
+            indoc!(
+                r#"
+                app "test" provides [main] to "./platform"
+
+
+                main =
+                    if 1 == 1 then
+                        Foo (Bar) 1
+                    else
+                        Foo Bar 1
+                "#
+            ),
+            "[Foo [Bar] (Num *)]",
+        );
+
+        infer_eq_without_problem("Foo Bar 1", "[Foo [Bar] (Num *)]");
+    }
+
+    #[test]
+    fn double_tag_application_pattern() {
+        infer_eq_without_problem(
+            indoc!(
+                r#"
+                app "test" provides [main] to "./platform"
+
+                Bar : [Bar]
+                Foo : [Foo Bar I64, Empty]
+
+                foo : Foo
+                foo = Foo Bar 1
+
+                main =
+                    when foo is
+                        Foo Bar 1 ->
+                            Foo Bar 2
+
+                        x ->
+                            x
+                "#
+            ),
+            "[Empty, Foo [Bar] I64]",
+        );
+    }
+
+    #[test]
+    fn recursive_function_with_rigid() {
+        infer_eq_without_problem(
+            indoc!(
+                r#"
+                app "test" provides [main] to "./platform"
+
+                State a : { count : I64, x : a }
+
+                foo : State a -> I64
+                foo = \state ->
+                    if state.count == 0 then
+                        0
+                    else
+                        1 + foo { count: state.count - 1, x: state.x }
+
+                main : I64
+                main =
+                    foo { count: 3, x: {} }
+                "#
+            ),
+            "I64",
+        );
+    }
+
+    #[test]
+    fn rbtree_empty() {
+        infer_eq_without_problem(
+            indoc!(
+                r#"
+                app "test" provides [main] to "./platform"
+
+                # The color of a node. Leaves are considered Black.
+                NodeColor : [Red, Black]
+
+                RBTree k v : [Node NodeColor k v (RBTree k v) (RBTree k v), Empty]
+
+                # Create an empty dictionary.
+                empty : {} -> RBTree k v
+                empty = \{} ->
+                    Empty
+
+                foo : RBTree I64 I64
+                foo = empty {}
+
+                main : RBTree I64 I64
+                main =
+                    foo
+                "#
+            ),
+            "RBTree I64 I64",
+        );
+    }
+
+    #[test]
+    fn rbtree_insert() {
+        // exposed an issue where pattern variables were not introduced
+        // at the correct level in the constraint
+        //
+        // see 22592eff805511fbe1da63849771ee5f367a6a16
+        infer_eq_without_problem(
+            indoc!(
+                r#"
+                app "test" provides [main] to "./platform"
+
+                RBTree k : [Node k (RBTree k), Empty]
+
+                balance : RBTree  k -> RBTree k
+                balance = \left ->
+                    when left is
+                      Node _ Empty -> Empty
+
+                      _ -> Empty
+
+                main : RBTree {}
+                main =
+                    balance Empty
+                "#
+            ),
+            "RBTree {}",
+        );
+    }
+
+    #[test]
+    fn rbtree_full_remove_min() {
+        infer_eq_without_problem(
+            indoc!(
+                r#"
+                app "test" provides [main] to "./platform"
+
+                NodeColor : [Red, Black]
+
+                RBTree k v : [Node NodeColor k v (RBTree k v) (RBTree k v), Empty]
+
+                moveRedLeft : RBTree k v -> RBTree k v
+                moveRedLeft = \dict ->
+                  when dict is
+                    # Node clr k v (Node lClr lK lV lLeft lRight) (Node rClr rK rV ((Node Red rlK rlV rlL rlR) as rLeft) rRight) ->
+                    # Node clr k v (Node lClr lK lV lLeft lRight) (Node rClr rK rV rLeft rRight) ->
+                    Node clr k v (Node _ lK lV lLeft lRight) (Node _ rK rV rLeft rRight) ->
+                        when rLeft is
+                            Node Red rlK rlV rlL rlR ->
+                              Node
+                                Red
+                                rlK
+                                rlV
+                                (Node Black k v (Node Red lK lV lLeft lRight) rlL)
+                                (Node Black rK rV rlR rRight)
+
+                            _ ->
+                              when clr is
+                                Black ->
+                                  Node
+                                    Black
+                                    k
+                                    v
+                                    (Node Red lK lV lLeft lRight)
+                                    (Node Red rK rV rLeft rRight)
+
+                                Red ->
+                                  Node
+                                    Black
+                                    k
+                                    v
+                                    (Node Red lK lV lLeft lRight)
+                                    (Node Red rK rV rLeft rRight)
+
+                    _ ->
+                      dict
+
+                balance : NodeColor, k, v, RBTree k v, RBTree k v -> RBTree k v
+                balance = \color, key, value, left, right ->
+                  when right is
+                    Node Red rK rV rLeft rRight ->
+                      when left is
+                        Node Red lK lV lLeft lRight ->
+                          Node
+                            Red
+                            key
+                            value
+                            (Node Black lK lV lLeft lRight)
+                            (Node Black rK rV rLeft rRight)
+
+                        _ ->
+                          Node color rK rV (Node Red key value left rLeft) rRight
+
+                    _ ->
+                      when left is
+                        Node Red lK lV (Node Red llK llV llLeft llRight) lRight ->
+                          Node
+                            Red
+                            lK
+                            lV
+                            (Node Black llK llV llLeft llRight)
+                            (Node Black key value lRight right)
+
+                        _ ->
+                          Node color key value left right
+
+
+                Key k : Num k
+
+                removeHelpEQGT : Key k, RBTree (Key k) v -> RBTree (Key k) v where k implements Hash & Eq
+                removeHelpEQGT = \targetKey, dict ->
+                  when dict is
+                    Node color key value left right ->
+                      if targetKey == key then
+                        when getMin right is
+                          Node _ minKey minValue _ _ ->
+                            balance color minKey minValue left (removeMin right)
+
+                          Empty ->
+                            Empty
+                      else
+                        balance color key value left (removeHelp targetKey right)
+
+                    Empty ->
+                      Empty
+
+                getMin : RBTree k v -> RBTree k v
+                getMin = \dict ->
+                  when dict is
+                    # Node _ _ _ ((Node _ _ _ _ _) as left) _ ->
+                    Node _ _ _ left _ ->
+                        when left is
+                            Node _ _ _ _ _ -> getMin left
+                            _ -> dict
+
+                    _ ->
+                      dict
+
+
+                moveRedRight : RBTree k v -> RBTree k v
+                moveRedRight = \dict ->
+                  when dict is
+                    Node clr k v (Node lClr lK lV (Node Red llK llV llLeft llRight) lRight) (Node rClr rK rV rLeft rRight) ->
+                      Node
+                        Red
+                        lK
+                        lV
+                        (Node Black llK llV llLeft llRight)
+                        (Node Black k v lRight (Node Red rK rV rLeft rRight))
+
+                    Node clr k v (Node lClr lK lV lLeft lRight) (Node rClr rK rV rLeft rRight) ->
+                      when clr is
+                        Black ->
+                          Node
+                            Black
+                            k
+                            v
+                            (Node Red lK lV lLeft lRight)
+                            (Node Red rK rV rLeft rRight)
+
+                        Red ->
+                          Node
+                            Black
+                            k
+                            v
+                            (Node Red lK lV lLeft lRight)
+                            (Node Red rK rV rLeft rRight)
+
+                    _ ->
+                      dict
+
+
+                removeHelpPrepEQGT : Key k, RBTree (Key k) v, NodeColor, (Key k), v, RBTree (Key k) v, RBTree (Key k) v -> RBTree (Key k) v
+                removeHelpPrepEQGT = \_, dict, color, key, value, left, right ->
+                  when left is
+                    Node Red lK lV lLeft lRight ->
+                      Node
+                        color
+                        lK
+                        lV
+                        lLeft
+                        (Node Red key value lRight right)
+
+                    _ ->
+                      when right is
+                        Node Black _ _ (Node Black _ _ _ _) _ ->
+                          moveRedRight dict
+
+                        Node Black _ _ Empty _ ->
+                          moveRedRight dict
+
+                        _ ->
+                          dict
+
+
+                removeMin : RBTree k v -> RBTree k v
+                removeMin = \dict ->
+                  when dict is
+                    Node color key value left right ->
+                        when left is
+                            Node lColor _ _ lLeft _ ->
+                              when lColor is
+                                Black ->
+                                  when lLeft is
+                                    Node Red _ _ _ _ ->
+                                      Node color key value (removeMin left) right
+
+                                    _ ->
+                                      when moveRedLeft dict is # here 1
+                                        Node nColor nKey nValue nLeft nRight ->
+                                          balance nColor nKey nValue (removeMin nLeft) nRight
+
+                                        Empty ->
+                                          Empty
+
+                                _ ->
+                                  Node color key value (removeMin left) right
+
+                            _ ->
+                                Empty
+                    _ ->
+                      Empty
+
+                removeHelp : Key k, RBTree (Key k) v -> RBTree (Key k) v where k implements Hash & Eq
+                removeHelp = \targetKey, dict ->
+                  when dict is
+                    Empty ->
+                      Empty
+
+                    Node color key value left right ->
+                      if targetKey < key then
+                        when left is
+                          Node Black _ _ lLeft _ ->
+                            when lLeft is
+                              Node Red _ _ _ _ ->
+                                Node color key value (removeHelp targetKey left) right
+
+                              _ ->
+                                when moveRedLeft dict is # here 2
+                                  Node nColor nKey nValue nLeft nRight ->
+                                    balance nColor nKey nValue (removeHelp targetKey nLeft) nRight
+
+                                  Empty ->
+                                    Empty
+
+                          _ ->
+                            Node color key value (removeHelp targetKey left) right
+                      else
+                        removeHelpEQGT targetKey (removeHelpPrepEQGT targetKey dict color key value left right)
+
+
+                main : RBTree I64 I64
+                main =
+                    removeHelp 1i64 Empty
+                "#
+            ),
+            "RBTree (Key (Integer Signed64)) I64",
+        );
+    }
+
+    #[test]
+    fn rbtree_remove_min_1() {
+        infer_eq_without_problem(
+            indoc!(
+                r#"
+                app "test" provides [main] to "./platform"
+
+                RBTree k : [Node k (RBTree k) (RBTree k), Empty]
+
+                removeHelp : Num k, RBTree (Num k) -> RBTree (Num k)
+                removeHelp = \targetKey, dict ->
+                  when dict is
+                    Empty ->
+                      Empty
+
+                    Node key left right ->
+                      if targetKey < key then
+                        when left is
+                          Node _ lLeft _ ->
+                            when lLeft is
+                              Node _ _ _ ->
+                                Empty
+
+                              _ -> Empty
+
+                          _ ->
+                            Node key (removeHelp targetKey left) right
+                      else
+                        Empty
+
+
+                main : RBTree I64
+                main =
+                    removeHelp 1 Empty
+                "#
+            ),
+            "RBTree I64",
+        );
+    }
+
+    #[test]
+    fn rbtree_foobar() {
+        infer_eq_without_problem(
+            indoc!(
+                r#"
+                app "test" provides [main] to "./platform"
+
+                NodeColor : [Red, Black]
+
+                RBTree k v : [Node NodeColor k v (RBTree k v) (RBTree k v), Empty]
+
+                removeHelp : Num k, RBTree (Num k) v -> RBTree (Num k) v where k implements Hash & Eq
+                removeHelp = \targetKey, dict ->
+                  when dict is
+                    Empty ->
+                      Empty
+
+                    Node color key value left right ->
+                      if targetKey < key then
+                        when left is
+                          Node Black _ _ lLeft _ ->
+                            when lLeft is
+                              Node Red _ _ _ _ ->
+                                Node color key value (removeHelp targetKey left) right
+
+                              _ ->
+                                when moveRedLeft dict is # here 2
+                                  Node nColor nKey nValue nLeft nRight ->
+                                    balance nColor nKey nValue (removeHelp targetKey nLeft) nRight
+
+                                  Empty ->
+                                    Empty
+
+                          _ ->
+                            Node color key value (removeHelp targetKey left) right
+                      else
+                        removeHelpEQGT targetKey (removeHelpPrepEQGT targetKey dict color key value left right)
+
+                Key k : Num k
+
+                balance : NodeColor, k, v, RBTree k v, RBTree k v -> RBTree k v
+
+                moveRedLeft : RBTree k v -> RBTree k v
+
+                removeHelpPrepEQGT : Key k, RBTree (Key k) v, NodeColor, (Key k), v, RBTree (Key k) v, RBTree (Key k) v -> RBTree (Key k) v
+
+                removeHelpEQGT : Key k, RBTree (Key k) v -> RBTree (Key k) v where k implements Hash & Eq
+                removeHelpEQGT = \targetKey, dict ->
+                  when dict is
+                    Node color key value left right ->
+                      if targetKey == key then
+                        when getMin right is
+                          Node _ minKey minValue _ _ ->
+                            balance color minKey minValue left (removeMin right)
+
+                          Empty ->
+                            Empty
+                      else
+                        balance color key value left (removeHelp targetKey right)
+
+                    Empty ->
+                      Empty
+
+                getMin : RBTree k v -> RBTree k v
+
+                removeMin : RBTree k v -> RBTree k v
+
+                main : RBTree I64 I64
+                main =
+                    removeHelp 1i64 Empty
+                "#
+            ),
+            "RBTree I64 I64",
+        );
+    }
+
+    #[test]
+    fn quicksort_partition_help() {
+        infer_eq_without_problem(
+            indoc!(
+                r#"
+                app "test" provides [partitionHelp] to "./platform"
+
+                swap : U64, U64, List a -> List a
+                swap = \i, j, list ->
+                    when Pair (List.get list i) (List.get list j) is
+                        Pair (Ok atI) (Ok atJ) ->
+                            list
+                                |> List.set i atJ
+                                |> List.set j atI
+
+                        _ ->
+                            []
+
+                partitionHelp : U64, U64, List (Num a), U64, (Num a) -> [Pair U64 (List (Num a))]
+                partitionHelp = \i, j, list, high, pivot ->
+                    if j < high then
+                        when List.get list j is
+                            Ok value ->
+                                if value <= pivot then
+                                    partitionHelp (i + 1) (j + 1) (swap (i + 1) j list) high pivot
+                                else
+                                    partitionHelp i (j + 1) list high pivot
+
+                            Err _ ->
+                                Pair i list
+                    else
+                        Pair i list
+                "#
+            ),
+            "U64, U64, List (Num a), U64, Num a -> [Pair U64 (List (Num a))]",
+        );
+    }
+
+    #[test]
+    fn rbtree_old_balance_simplified() {
+        infer_eq_without_problem(
+            indoc!(
+                r#"
+                app "test" provides [main] to "./platform"
+
+                RBTree k : [Node k (RBTree k) (RBTree k), Empty]
+
+                balance : k, RBTree k -> RBTree k
+                balance = \key, left ->
+                    Node key left Empty
+
+                main : RBTree I64
+                main =
+                    balance 0 Empty
+                "#
+            ),
+            "RBTree I64",
+        );
+    }
+
+    #[test]
+    fn rbtree_balance_simplified() {
+        infer_eq_without_problem(
+            indoc!(
+                r#"
+                app "test" provides [main] to "./platform"
+
+                RBTree k : [Node k (RBTree k) (RBTree k), Empty]
+
+                node = \x,y,z -> Node x y z
+
+                balance : k, RBTree k -> RBTree k
+                balance = \key, left ->
+                    node key left Empty
+
+                main : RBTree I64
+                main =
+                    balance 0 Empty
+                "#
+            ),
+            "RBTree I64",
+        );
+    }
+
+    #[test]
+    fn rbtree_balance() {
+        infer_eq_without_problem(
+            indoc!(
+                r#"
+                app "test" provides [main] to "./platform"
+
+                NodeColor : [Red, Black]
+
+                RBTree k v : [Node NodeColor k v (RBTree k v) (RBTree k v), Empty]
+
+                balance : NodeColor, k, v, RBTree k v, RBTree k v -> RBTree k v
+                balance = \color, key, value, left, right ->
+                  when right is
+                    Node Red rK rV rLeft rRight ->
+                      when left is
+                        Node Red lK lV lLeft lRight ->
+                          Node
+                            Red
+                            key
+                            value
+                            (Node Black lK lV lLeft lRight)
+                            (Node Black rK rV rLeft rRight)
+
+                        _ ->
+                          Node color rK rV (Node Red key value left rLeft) rRight
+
+                    _ ->
+                      when left is
+                        Node Red lK lV (Node Red llK llV llLeft llRight) lRight ->
+                          Node
+                            Red
+                            lK
+                            lV
+                            (Node Black llK llV llLeft llRight)
+                            (Node Black key value lRight right)
+
+                        _ ->
+                          Node color key value left right
+
+                main : RBTree I64 I64
+                main =
+                    balance Red 0 0 Empty Empty
+                "#
+            ),
+            "RBTree I64 I64",
+        );
+    }
+
+    #[test]
+    fn pattern_rigid_problem() {
+        infer_eq_without_problem(
+            indoc!(
+                r#"
+                app "test" provides [main] to "./platform"
+
+                RBTree k : [Node k (RBTree k) (RBTree k), Empty]
+
+                balance : k, RBTree k -> RBTree k
+                balance = \key, left ->
+                      when left is
+                        Node _ _ lRight ->
+                            Node key lRight Empty
+
+                        _ ->
+                            Empty
+
+
+                main : RBTree I64
+                main =
+                    balance 0 Empty
+                "#
+            ),
+            "RBTree I64",
+        );
+    }
+
+    #[test]
+    fn expr_to_str() {
+        infer_eq_without_problem(
+            indoc!(
+                r#"
+                app "test" provides [main] to "./platform"
+
+                Expr : [Add Expr Expr, Val I64, Var I64]
+
+                printExpr : Expr -> Str
+                printExpr = \e ->
+                    when e is
+                        Add a b ->
+                            "Add ("
+                                |> Str.concat (printExpr a)
+                                |> Str.concat ") ("
+                                |> Str.concat (printExpr b)
+                                |> Str.concat ")"
+                        Val v -> Num.toStr v
+                        Var v -> "Var " |> Str.concat (Num.toStr v)
+
+                main : Str
+                main = printExpr (Var 3)
+                "#
+            ),
+            "Str",
+        );
+    }
+
+    #[test]
+    fn int_type_let_polymorphism() {
+        infer_eq_without_problem(
+            indoc!(
+                r#"
+                app "test" provides [main] to "./platform"
+
+                x = 4
+
+                f : U8 -> U32
+                f = \z -> Num.intCast z
+
+                y = f x
+
+                main =
+                    x
+                "#
+            ),
+            "Num *",
+        );
+    }
+
+    #[test]
+    fn rigid_type_variable_problem() {
+        // see https://github.com/roc-lang/roc/issues/1162
+        infer_eq_without_problem(
+            indoc!(
+                r#"
+        app "test" provides [main] to "./platform"
+
+        RBTree k : [Node k (RBTree k) (RBTree k), Empty]
+
+        balance : a, RBTree a -> RBTree a
+        balance = \key, left ->
+              when left is
+                Node _ _ lRight ->
+                    Node key lRight Empty
+
+                _ ->
+                    Empty
+
+
+        main : RBTree {}
+        main =
+            balance {} Empty
+            "#
+            ),
+            "RBTree {}",
+        );
+    }
+
+    #[test]
+    fn inference_var_inside_arrow() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                id : _ -> _
+                id = \x -> x
+                id
+                "
+            ),
+            "a -> a",
+        )
+    }
+
+    #[test]
+    fn inference_var_inside_ctor() {
+        infer_eq_without_problem(
+            indoc!(
+                r#"
+                canIGo : _ -> Result.Result _ _
+                canIGo = \color ->
+                    when color is
+                        "green" -> Ok "go!"
+                        "yellow" -> Err (SlowIt "whoa, let's slow down!")
+                        "red" -> Err (StopIt "absolutely not")
+                        _ -> Err (UnknownColor "this is a weird stoplight")
+                canIGo
+                "#
+            ),
+            "Str -> Result Str [SlowIt Str, StopIt Str, UnknownColor Str]",
+        )
+    }
+
+    #[test]
+    fn inference_var_inside_ctor_linked() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                swapRcd: {x: _, y: _} -> {x: _, y: _}
+                swapRcd = \{x, y} -> {x: y, y: x}
+                swapRcd
+                "
+            ),
+            "{ x : a, y : b } -> { x : b, y : a }",
+        )
+    }
+
+    #[test]
+    fn inference_var_link_with_rigid() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                swapRcd: {x: tx, y: ty} -> {x: _, y: _}
+                swapRcd = \{x, y} -> {x: y, y: x}
+                swapRcd
+                "
+            ),
+            "{ x : tx, y : ty } -> { x : ty, y : tx }",
+        )
+    }
+
+    #[test]
+    fn inference_var_inside_tag_ctor() {
+        infer_eq_without_problem(
+            indoc!(
+                r#"
+                badComics: [True, False] -> [CowTools _, Thagomizer _]
+                badComics = \c ->
+                    when c is
+                        True -> CowTools "The Far Side"
+                        False ->  Thagomizer "The Far Side"
+                badComics
+                "#
+            ),
+            "[False, True] -> [CowTools Str, Thagomizer Str]",
+        )
+    }
+
+    #[test]
+    fn inference_var_tag_union_ext() {
+        // TODO: we should really be inferring [Blue, Orange]a -> [Lavender, Peach]a here.
+        // See https://github.com/roc-lang/roc/issues/2053
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                pastelize: _ -> [Lavender, Peach]_
+                pastelize = \color ->
+                    when color is
+                        Blue -> Lavender
+                        Orange -> Peach
+                        col -> col
+                pastelize
+                "
+            ),
+            "[Blue, Lavender, Orange, Peach]a -> [Blue, Lavender, Orange, Peach]a",
+        )
+    }
+
+    #[test]
+    fn inference_var_rcd_union_ext() {
+        infer_eq_without_problem(
+            indoc!(
+                r#"
+                setRocEmail : _ -> { name: Str, email: Str }_
+                setRocEmail = \person ->
+                    { person & email: "$(person.name)@roclang.com" }
+                setRocEmail
+                "#
+            ),
+            "{ email : Str, name : Str }a -> { email : Str, name : Str }a",
+        )
+    }
+
+    #[test]
+    fn issue_2217() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                LinkedList elem : [Empty, Prepend (LinkedList elem) elem]
+
+                fromList : List elem -> LinkedList elem
+                fromList = \elems -> List.walk elems Empty Prepend
+
+                fromList
+                "
+            ),
+            "List elem -> LinkedList elem",
+        )
+    }
+
+    #[test]
+    fn issue_2217_inlined() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                fromList : List elem -> [Empty, Prepend (LinkedList elem) elem] as LinkedList elem
+                fromList = \elems -> List.walk elems Empty Prepend
+
+                fromList
+                "
+            ),
+            "List elem -> LinkedList elem",
+        )
+    }
+
+    #[test]
+    fn infer_union_input_position1() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                 \tag ->
+                     when tag is
+                       A -> X
+                       B -> Y
+                 "
+            ),
+            "[A, B] -> [X, Y]",
+        )
+    }
+
+    #[test]
+    fn infer_union_input_position2() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                 \tag ->
+                     when tag is
+                       A -> X
+                       B -> Y
+                       _ -> Z
+                 "
+            ),
+            "[A, B]* -> [X, Y, Z]",
+        )
+    }
+
+    #[test]
+    fn infer_union_input_position3() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                 \tag ->
+                     when tag is
+                       A M -> X
+                       A N -> Y
+                 "
+            ),
+            "[A [M, N]] -> [X, Y]",
+        )
+    }
+
+    #[test]
+    fn infer_union_input_position4() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                 \tag ->
+                     when tag is
+                       A M -> X
+                       A N -> Y
+                       A _ -> Z
+                 "
+            ),
+            "[A [M, N]*] -> [X, Y, Z]",
+        )
+    }
+
+    #[test]
+    fn infer_union_input_position5() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                 \tag ->
+                     when tag is
+                       A (M J) -> X
+                       A (N K) -> X
+                 "
+            ),
+            "[A [M [J], N [K]]] -> [X]",
+        )
+    }
+
+    #[test]
+    fn infer_union_input_position6() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                 \tag ->
+                     when tag is
+                       A M -> X
+                       B   -> X
+                       A N -> X
+                 "
+            ),
+            "[A [M, N], B] -> [X]",
+        )
+    }
+
+    #[test]
+    fn infer_union_input_position7() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                 \tag ->
+                     when tag is
+                         A -> X
+                         t -> t
+                 "
+            ),
+            "[A, X]a -> [A, X]a",
+        )
+    }
+
+    #[test]
+    fn infer_union_input_position8() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                 \opt ->
+                     when opt is
+                         Some ({tag: A}) -> 1
+                         Some ({tag: B}) -> 1
+                         None -> 0
+                 "
+            ),
+            "[None, Some { tag : [A, B] }*] -> Num *",
+        )
+    }
+
+    #[test]
+    fn infer_union_input_position9() {
+        infer_eq_without_problem(
+            indoc!(
+                r#"
+                 opt : [Some Str, None]
+                 opt = Some ""
+                 rcd = { opt }
+
+                 when rcd is
+                     { opt: Some s } -> s
+                     { opt: None } -> "?"
+                 "#
+            ),
+            "Str",
+        )
+    }
+
+    #[test]
+    fn infer_union_input_position10() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                 \r ->
+                     when r is
+                         { x: Blue, y ? 3 } -> y
+                         { x: Red, y ? 5 } -> y
+                 "
+            ),
+            "{ x : [Blue, Red], y ? Num a }* -> Num a",
+        )
+    }
+
+    #[test]
+    // Issue #2299
+    fn infer_union_argument_position() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                 \UserId id -> id + 1
+                 "
+            ),
+            "[UserId (Num a)] -> Num a",
+        )
+    }
+
+    #[test]
+    fn infer_union_def_position() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                 \email ->
+                    Email str = email
+                    Str.isEmpty str
+                 "
+            ),
+            "[Email Str] -> Bool",
+        )
+    }
+
+    #[test]
+    fn numeric_literal_suffixes() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                {
+                    u8:   123u8,
+                    u16:  123u16,
+                    u32:  123u32,
+                    u64:  123u64,
+                    u128: 123u128,
+
+                    i8:   123i8,
+                    i16:  123i16,
+                    i32:  123i32,
+                    i64:  123i64,
+                    i128: 123i128,
+
+                    bu8:   0b11u8,
+                    bu16:  0b11u16,
+                    bu32:  0b11u32,
+                    bu64:  0b11u64,
+                    bu128: 0b11u128,
+
+                    bi8:   0b11i8,
+                    bi16:  0b11i16,
+                    bi32:  0b11i32,
+                    bi64:  0b11i64,
+                    bi128: 0b11i128,
+
+                    dec:  123.0dec,
+                    f32:  123.0f32,
+                    f64:  123.0f64,
+
+                    fdec: 123dec,
+                    ff32: 123f32,
+                    ff64: 123f64,
+                }
+                "
+            ),
+            r"{ bi128 : I128, bi16 : I16, bi32 : I32, bi64 : I64, bi8 : I8, bu128 : U128, bu16 : U16, bu32 : U32, bu64 : U64, bu8 : U8, dec : Dec, f32 : F32, f64 : F64, fdec : Dec, ff32 : F32, ff64 : F64, i128 : I128, i16 : I16, i32 : I32, i64 : I64, i8 : I8, u128 : U128, u16 : U16, u32 : U32, u64 : U64, u8 : U8 }",
+        )
+    }
+
+    #[test]
+    fn numeric_literal_suffixes_in_pattern() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                {
+                    u8:   (\n ->
+                            when n is
+                              123u8 -> n
+                              _ -> n),
+                    u16:  (\n ->
+                            when n is
+                              123u16 -> n
+                              _ -> n),
+                    u32:  (\n ->
+                            when n is
+                              123u32 -> n
+                              _ -> n),
+                    u64:  (\n ->
+                            when n is
+                              123u64 -> n
+                              _ -> n),
+                    u128: (\n ->
+                            when n is
+                              123u128 -> n
+                              _ -> n),
+
+                    i8:   (\n ->
+                            when n is
+                              123i8 -> n
+                              _ -> n),
+                    i16:  (\n ->
+                            when n is
+                              123i16 -> n
+                              _ -> n),
+                    i32:  (\n ->
+                            when n is
+                              123i32 -> n
+                              _ -> n),
+                    i64:  (\n ->
+                            when n is
+                              123i64 -> n
+                              _ -> n),
+                    i128: (\n ->
+                            when n is
+                              123i128 -> n
+                              _ -> n),
+
+                    bu8:   (\n ->
+                            when n is
+                              0b11u8 -> n
+                              _ -> n),
+                    bu16:  (\n ->
+                            when n is
+                              0b11u16 -> n
+                              _ -> n),
+                    bu32:  (\n ->
+                            when n is
+                              0b11u32 -> n
+                              _ -> n),
+                    bu64:  (\n ->
+                            when n is
+                              0b11u64 -> n
+                              _ -> n),
+                    bu128: (\n ->
+                            when n is
+                              0b11u128 -> n
+                              _ -> n),
+
+                    bi8:   (\n ->
+                            when n is
+                              0b11i8 -> n
+                              _ -> n),
+                    bi16:  (\n ->
+                            when n is
+                              0b11i16 -> n
+                              _ -> n),
+                    bi32:  (\n ->
+                            when n is
+                              0b11i32 -> n
+                              _ -> n),
+                    bi64:  (\n ->
+                            when n is
+                              0b11i64 -> n
+                              _ -> n),
+                    bi128: (\n ->
+                            when n is
+                              0b11i128 -> n
+                              _ -> n),
+
+                    dec:  (\n ->
+                            when n is
+                              123.0dec -> n
+                              _ -> n),
+                    f32:  (\n ->
+                            when n is
+                              123.0f32 -> n
+                              _ -> n),
+                    f64:  (\n ->
+                            when n is
+                              123.0f64 -> n
+                              _ -> n),
+
+                    fdec: (\n ->
+                            when n is
+                              123dec -> n
+                              _ -> n),
+                    ff32: (\n ->
+                            when n is
+                              123f32 -> n
+                              _ -> n),
+                    ff64: (\n ->
+                            when n is
+                              123f64 -> n
+                              _ -> n),
+                }
+                "
+            ),
+            r"{ bi128 : I128 -> I128, bi16 : I16 -> I16, bi32 : I32 -> I32, bi64 : I64 -> I64, bi8 : I8 -> I8, bu128 : U128 -> U128, bu16 : U16 -> U16, bu32 : U32 -> U32, bu64 : U64 -> U64, bu8 : U8 -> U8, dec : Dec -> Dec, f32 : F32 -> F32, f64 : F64 -> F64, fdec : Dec -> Dec, ff32 : F32 -> F32, ff64 : F64 -> F64, i128 : I128 -> I128, i16 : I16 -> I16, i32 : I32 -> I32, i64 : I64 -> I64, i8 : I8 -> I8, u128 : U128 -> U128, u16 : U16 -> U16, u32 : U32 -> U32, u64 : U64 -> U64, u8 : U8 -> U8 }",
+        )
+    }
+}

--- a/crates/compiler/specialize_types/tests/test_specialize_types.rs
+++ b/crates/compiler/specialize_types/tests/test_specialize_types.rs
@@ -149,134 +149,57 @@ mod specialize_types {
 
     #[test]
     fn empty_list() {
-        specializes_to(
-            indoc!(
-                r"
-                    []
-                "
-            ),
-            "List *",
-        );
+        specializes_to("[]", "List []");
     }
 
     #[test]
     fn list_of_lists() {
-        specializes_to(
-            indoc!(
-                r"
-                    [[]]
-                "
-            ),
-            "List (List *)",
-        );
+        specializes_to("[[]]", "List (List [])");
     }
 
     #[test]
     fn triple_nested_list() {
-        specializes_to(
-            indoc!(
-                r"
-                    [[[]]]
-                "
-            ),
-            "List (List (List *))",
-        );
+        specializes_to("[[[]]]", "List (List (List []))");
     }
 
     #[test]
     fn nested_empty_list() {
-        specializes_to(
-            indoc!(
-                r"
-                    [[], [[]]]
-                "
-            ),
-            "List (List (List *))",
-        );
+        specializes_to("[[], [[]]]", "List (List (List []))");
     }
 
     #[test]
     fn list_of_one_int() {
-        specializes_to(
-            indoc!(
-                r"
-                    [42]
-                "
-            ),
-            "List (Num *)",
-        );
+        specializes_to("[42]", "List (Num [])");
     }
 
     #[test]
     fn triple_nested_int_list() {
-        specializes_to(
-            indoc!(
-                r"
-                    [[[5]]]
-                "
-            ),
-            "List (List (List (Num *)))",
-        );
+        specializes_to("[[[5]]]", "List (List (List (Num [])))");
     }
 
     #[test]
     fn list_of_ints() {
-        specializes_to(
-            indoc!(
-                r"
-                    [1, 2, 3]
-                "
-            ),
-            "List (Num *)",
-        );
+        specializes_to("[1, 2, 3]", "List (Num [])");
     }
 
     #[test]
     fn nested_list_of_ints() {
-        specializes_to(
-            indoc!(
-                r"
-                    [[1], [2, 3]]
-                "
-            ),
-            "List (List (Num *))",
-        );
+        specializes_to("[[1], [2, 3]]", "List (List (Num []))");
     }
 
     #[test]
     fn list_of_one_string() {
-        specializes_to(
-            indoc!(
-                r#"
-                    ["cowabunga"]
-                "#
-            ),
-            "List Str",
-        );
+        specializes_to(r#"["cowabunga"]"#, "List Str");
     }
 
     #[test]
     fn triple_nested_string_list() {
-        specializes_to(
-            indoc!(
-                r#"
-                    [[["foo"]]]
-                "#
-            ),
-            "List (List (List Str))",
-        );
+        specializes_to(r#"[[["foo"]]]"#, "List (List (List Str))");
     }
 
     #[test]
     fn list_of_strings() {
-        specializes_to(
-            indoc!(
-                r#"
-                    ["foo", "bar"]
-                "#
-            ),
-            "List Str",
-        );
+        specializes_to(r#"["foo", "bar"]"#, "List Str");
     }
 
     // INTERPOLATED STRING
@@ -300,12 +223,12 @@ mod specialize_types {
         specializes_to(
             indoc!(
                 r#"
-                whatItIs = "great"
+                    whatItIs = "great"
 
-                str = "type inference is $(whatItIs)!"
+                    str = "type inference is $(whatItIs)!"
 
-                whatItIs
-            "#
+                    whatItIs
+                "#
             ),
             "Str",
         );
@@ -316,12 +239,12 @@ mod specialize_types {
         specializes_to(
             indoc!(
                 r#"
-                rec = { whatItIs: "great" }
+                    rec = { whatItIs: "great" }
 
-                str = "type inference is $(rec.whatItIs)!"
+                    str = "type inference is $(rec.whatItIs)!"
 
-                rec
-            "#
+                    rec
+                "#
             ),
             "{ whatItIs : Str }",
         );
@@ -375,7 +298,7 @@ mod specialize_types {
                     \_ -> {}
                 "
             ),
-            "* -> {}",
+            "[] -> {}",
         );
     }
 
@@ -387,7 +310,7 @@ mod specialize_types {
                     \_, _ -> 42
                 "
             ),
-            "*, * -> Num *",
+            "[], [] -> Num []",
         );
     }
 
@@ -399,7 +322,7 @@ mod specialize_types {
                     \_, _, _ -> "test!"
                 "#
             ),
-            "*, *, * -> Str",
+            "[], [], [] -> Str",
         );
     }
 
@@ -443,7 +366,7 @@ mod specialize_types {
                     fn
                 "
             ),
-            "* -> {}",
+            "[] -> {}",
         );
     }
 
@@ -496,7 +419,7 @@ mod specialize_types {
                 [\x -> Bar x, Foo]
                 "
             ),
-            "List (a -> [Bar a, Foo a])",
+            "List ([] -> [Bar [], Foo []])",
         )
     }
 
@@ -509,7 +432,7 @@ mod specialize_types {
                 [Foo, \x -> Bar x]
                 "
             ),
-            "List (a -> [Bar a, Foo a])",
+            "List ([] -> [Bar [], Foo []])",
         )
     }
 
@@ -530,7 +453,7 @@ mod specialize_types {
                 }
                 "
             ),
-            "{ x : List [Foo], y : List (a -> [Foo a]), z : List (b, c -> [Foo b c]) }",
+            "{ x : List [Foo], y : List ([] -> [Foo []]), z : List ([], [] -> [Foo [] []]) }",
         )
     }
 
@@ -560,7 +483,7 @@ mod specialize_types {
                     func
                 "
             ),
-            "*, * -> Num *",
+            "[], [] -> Num []",
         );
     }
 
@@ -574,7 +497,7 @@ mod specialize_types {
                     f
                 "#
             ),
-            "*, *, * -> Str",
+            "[], [], [] -> Str",
         );
     }
 
@@ -590,7 +513,7 @@ mod specialize_types {
                     b
                 "#
             ),
-            "*, *, * -> Str",
+            "[], [], [] -> Str",
         );
     }
 
@@ -624,7 +547,7 @@ mod specialize_types {
                     c
                 "
             ),
-            "Num *",
+            "Num []",
         );
     }
 
@@ -643,7 +566,7 @@ mod specialize_types {
                     )
                 "
             ),
-            "a -> a",
+            "[] -> []",
         );
     }
 
@@ -659,7 +582,7 @@ mod specialize_types {
                     alwaysFive "stuff"
                 "#
             ),
-            "Num *",
+            "Num []",
         );
     }
 
@@ -689,7 +612,7 @@ mod specialize_types {
                     identity
                 "
             ),
-            "a -> a",
+            "[] -> []",
         );
     }
 
@@ -706,7 +629,7 @@ mod specialize_types {
                     x
                 "#
             ),
-            "Num *",
+            "Num []",
         );
     }
 
@@ -720,7 +643,7 @@ mod specialize_types {
                     enlist 5
                 "
             ),
-            "List (Num *)",
+            "List (Num [])",
         );
     }
 
@@ -747,7 +670,7 @@ mod specialize_types {
                     1 |> (\a -> a)
                 "
             ),
-            "Num *",
+            "Num []",
         );
     }
 
@@ -761,7 +684,7 @@ mod specialize_types {
                 1 |> always2 "foo"
                 "#
             ),
-            "Num *",
+            "Num []",
         );
     }
 
@@ -773,7 +696,7 @@ mod specialize_types {
                     (\a -> a) 3.14
                 "
             ),
-            "Frac *",
+            "Frac []",
         );
     }
 
@@ -785,7 +708,7 @@ mod specialize_types {
                     (\val -> val) (\val -> val)
                 "
             ),
-            "a -> a",
+            "[] -> []",
         );
     }
 
@@ -799,7 +722,7 @@ mod specialize_types {
                     identity identity
                 "
             ),
-            "a -> a",
+            "[] -> []",
         );
     }
 
@@ -811,7 +734,7 @@ mod specialize_types {
                     \val -> val
                 "
             ),
-            "a -> a",
+            "[] -> []",
         );
     }
 
@@ -826,7 +749,7 @@ mod specialize_types {
                 apply identity 5
                 "
             ),
-            "Num *",
+            "Num []",
         );
     }
 
@@ -838,7 +761,7 @@ mod specialize_types {
                     \f, x -> f x
                 "
             ),
-            "(a -> b), a -> b",
+            "([] -> []), [] -> []",
         );
     }
 
@@ -855,7 +778,7 @@ mod specialize_types {
     //                 flip neverendingInt
     //             "
     //         ),
-    //         "(Num *, (a -> a)) -> Num *",
+    //         "(Num [], (a -> a)) -> Num []",
     //     );
     // }
 
@@ -867,7 +790,7 @@ mod specialize_types {
                     \f -> (\a, b -> f b a)
                 "
             ),
-            "(a, b -> c) -> (b, a -> c)",
+            "([], [] -> []) -> ([], [] -> [])",
         );
     }
 
@@ -879,7 +802,7 @@ mod specialize_types {
                     \val -> \_ -> val
                 "
             ),
-            "a -> (* -> a)",
+            "[] -> ([] -> [])",
         );
     }
 
@@ -891,7 +814,7 @@ mod specialize_types {
                     \f -> f {}
                 "
             ),
-            "({} -> a) -> a",
+            "({} -> []) -> []",
         );
     }
 
@@ -929,7 +852,7 @@ mod specialize_types {
     //                 1 // 2
     //             "
     //             ),
-    //             "Num *",
+    //             "Num []",
     //         );
     //     }
 
@@ -941,7 +864,7 @@ mod specialize_types {
     //                 1 + 2
     //             "
     //             ),
-    //             "Num *",
+    //             "Num []",
     //         );
     //     }
 
@@ -990,7 +913,7 @@ mod specialize_types {
                     [alwaysFive "foo", alwaysFive []]
                 "#
             ),
-            "List (Num *)",
+            "List (Num [])",
         );
     }
 
@@ -1005,7 +928,7 @@ mod specialize_types {
                         24
                 "
             ),
-            "Num *",
+            "Num []",
         );
     }
 
@@ -1019,7 +942,7 @@ mod specialize_types {
                     3 -> 4
                 "
             ),
-            "Num *",
+            "Num []",
         );
     }
 
@@ -1032,45 +955,45 @@ mod specialize_types {
 
     #[test]
     fn one_field_record() {
-        specializes_to("{ x: 5 }", "{ x : Num * }");
+        specializes_to("{ x: 5 }", "{ x : Num [] }");
     }
 
     #[test]
     fn two_field_record() {
-        specializes_to("{ x: 5, y : 3.14 }", "{ x : Num *, y : Frac * }");
+        specializes_to("{ x: 5, y : 3.14 }", "{ x : Num [], y : Frac [] }");
     }
 
     #[test]
     fn record_literal_accessor() {
-        specializes_to("{ x: 5, y : 3.14 }.x", "Num *");
+        specializes_to("{ x: 5, y : 3.14 }.x", "Num []");
     }
 
     #[test]
     fn record_literal_accessor_function() {
-        specializes_to(".x { x: 5, y : 3.14 }", "Num *");
+        specializes_to(".x { x: 5, y : 3.14 }", "Num []");
     }
 
     #[test]
     fn tuple_literal_accessor() {
-        specializes_to("(5, 3.14 ).0", "Num *");
+        specializes_to("(5, 3.14 ).0", "Num []");
     }
 
     #[test]
     fn tuple_literal_accessor_function() {
-        specializes_to(".0 (5, 3.14 )", "Num *");
+        specializes_to(".0 (5, 3.14 )", "Num []");
     }
 
     #[test]
     fn tuple_literal_ty() {
-        specializes_to("(5, 3.14 )", "( Num *, Frac * )*");
+        specializes_to("(5, 3.14 )", "( Num [], Frac [] )");
     }
 
     #[test]
     fn tuple_literal_accessor_ty() {
-        specializes_to(".0", "( a )* -> a");
-        specializes_to(".4", "( _, _, _, _, a )* -> a");
-        specializes_to(".5", "( ... 5 omitted, a )* -> a");
-        specializes_to(".200", "( ... 200 omitted, a )* -> a");
+        specializes_to(".0", "( [] ) -> []");
+        specializes_to(".4", "( _, _, _, _, [] ) -> []");
+        specializes_to(".5", "( ... 5 omitted, [] ) -> []");
+        specializes_to(".200", "( ... 200 omitted, [] ) -> []");
     }
 
     #[test]
@@ -1083,13 +1006,13 @@ mod specialize_types {
                     { a: get0 (1, 2), b: get0 ("a", "b", "c") }
                 "#
             ),
-            "{ a : Num *, b : Str }",
+            "{ a : Num [], b : Str }",
         );
     }
 
     #[test]
     fn record_arg() {
-        specializes_to("\\rec -> rec.x", "{ x : a }* -> a");
+        specializes_to("\\rec -> rec.x", "{ x : [] } -> []");
     }
 
     #[test]
@@ -1105,7 +1028,7 @@ mod specialize_types {
                     fn
                 "
             ),
-            "{ x : a }b -> { x : a }b",
+            "{ x : [] } -> { x : [] }",
         );
     }
 
@@ -1120,7 +1043,7 @@ mod specialize_types {
                     bar
                 "
             ),
-            "custom -> custom",
+            "[] -> []",
         );
     }
 
@@ -1148,13 +1071,13 @@ mod specialize_types {
                     foo 2
                 "
             ),
-            "custom",
+            "[]",
         );
     }
 
     #[test]
     fn accessor_function() {
-        specializes_to(".foo", "{ foo : a }* -> a");
+        specializes_to(".foo", "{ foo : [] } -> []");
     }
 
     #[test]
@@ -1167,7 +1090,7 @@ mod specialize_types {
                     x
                 "
             ),
-            "{} -> custom",
+            "{} -> []",
         );
     }
 
@@ -1201,7 +1124,7 @@ mod specialize_types {
                 foo
             "
             ),
-            "{ x : custom } -> custom",
+            "{ x : [] } -> []",
         );
     }
 
@@ -1239,7 +1162,7 @@ mod specialize_types {
                     \Foo -> 42
                 "
             ),
-            "[Foo] -> Num *",
+            "[Foo] -> Num []",
         );
     }
 
@@ -1254,7 +1177,7 @@ mod specialize_types {
                             False -> 0
                 "
             ),
-            "[False, True] -> Num *",
+            "[False, True] -> Num []",
         );
     }
 
@@ -1266,7 +1189,7 @@ mod specialize_types {
                     Foo "happy" 12
                 "#
             ),
-            "[Foo Str (Num *)]",
+            "[Foo Str (Num [])]",
         );
     }
 
@@ -1282,7 +1205,7 @@ mod specialize_types {
                     f
                 "
             ),
-            "{ a : a, b : * }* -> a",
+            "{ a : [], b : [] } -> []",
         );
     }
 
@@ -1295,7 +1218,7 @@ mod specialize_types {
                         { x: 4 } -> 4
                 "
             ),
-            "Num *",
+            "Num []",
         );
     }
 
@@ -1307,7 +1230,7 @@ mod specialize_types {
                     \Foo x -> Foo x
                 "
             ),
-            "[Foo a] -> [Foo a]",
+            "[Foo []] -> [Foo []]",
         );
     }
 
@@ -1319,7 +1242,7 @@ mod specialize_types {
                     \Foo x _ -> Foo x "y"
                 "#
             ),
-            "[Foo a *] -> [Foo a Str]",
+            "[Foo [] []] -> [Foo [] Str]",
         );
     }
 
@@ -2119,7 +2042,7 @@ mod specialize_types {
                     ok
                 "
             ),
-            "Res I64 *",
+            "Res I64 []",
         );
     }
 
@@ -2136,7 +2059,7 @@ mod specialize_types {
                     err
                 "#
             ),
-            "Res * Str",
+            "Res [] Str",
         );
     }
 
@@ -2151,7 +2074,7 @@ mod specialize_types {
                     ok
                 "
             ),
-            "Result I64 *",
+            "Result I64 []",
         );
     }
 
@@ -2166,7 +2089,7 @@ mod specialize_types {
                     err
                 "#
             ),
-            "Result * Str",
+            "Result [] Str",
         );
     }
 
@@ -2222,7 +2145,7 @@ mod specialize_types {
                     { numIdentity, x : numIdentity 42, y }
                 "
             ),
-            "{ numIdentity : Num a -> Num a, x : Num *, y : Frac * }",
+            "{ numIdentity : Num [] -> Num [], x : Num [], y : Frac [] }",
         );
     }
 
@@ -2258,7 +2181,7 @@ mod specialize_types {
                     f
                 "
             ),
-            "Num * -> Num *",
+            "Num [] -> Num []",
         );
     }
 
@@ -2274,7 +2197,7 @@ mod specialize_types {
                     map
                 "
             ),
-            "(a -> b), [Identity a] -> [Identity b]",
+            "([] -> []), [Identity []] -> [Identity []]",
         );
     }
 
@@ -2291,7 +2214,7 @@ mod specialize_types {
                    toBit
                 "
             ),
-            "[False, True] -> Num *",
+            "[False, True] -> Num []",
         );
     }
 
@@ -2310,7 +2233,7 @@ mod specialize_types {
                     foo
                 "#
             ),
-            "{ x : *, y : * }* -> Str",
+            "{ x : [], y : [] } -> Str",
         );
     }
 
@@ -2327,7 +2250,7 @@ mod specialize_types {
                    fromBit
                 "
             ),
-            "Num * -> [False, True]",
+            "Num [] -> [False, True]",
         );
     }
 
@@ -2345,7 +2268,7 @@ mod specialize_types {
                     map
                 "
             ),
-            "(a -> b), [Err e, Ok a] -> [Err e, Ok b]",
+            "([] -> []), [Err [], Ok []] -> [Err [], Ok []]",
         );
     }
 
@@ -2365,7 +2288,7 @@ mod specialize_types {
                     map
                        "
             ),
-            "(a -> b), Res e a -> Res e b",
+            "([] -> []), Res [] [] -> Res [] []",
         );
     }
 
@@ -2379,7 +2302,7 @@ mod specialize_types {
                     foo { x: 5 }
                 "
             ),
-            "Num *",
+            "Num []",
         );
     }
 
@@ -2399,7 +2322,7 @@ mod specialize_types {
                     threePointZero
                 "
             ),
-            "Frac *",
+            "Frac []",
         );
     }
 
@@ -2465,7 +2388,7 @@ mod specialize_types {
                 id
                 "
             ),
-            "Foo a -> Foo a",
+            "Foo [] -> Foo []",
         );
     }
 
@@ -2480,7 +2403,7 @@ mod specialize_types {
                     empty
                        "
             ),
-            "ConsList a",
+            "ConsList []",
         );
     }
 
@@ -2495,7 +2418,7 @@ mod specialize_types {
                     singleton
                        "
             ),
-            "a -> ConsList a",
+            "[] -> ConsList []",
         );
     }
 
@@ -2554,7 +2477,7 @@ mod specialize_types {
                     map
                        "
             ),
-            "(a -> b), [Cons a c, Nil] as c -> [Cons b d, Nil] as d",
+            "([] -> []), [Cons [] c, Nil] as c -> [Cons [] d, Nil] as d",
         );
     }
 
@@ -2575,7 +2498,7 @@ mod specialize_types {
                     map
                        "
             ),
-            "(a -> b), ConsList a -> ConsList b",
+            "([] -> []), ConsList [] -> ConsList []",
         );
     }
 
@@ -2715,7 +2638,7 @@ mod specialize_types {
                     toEmpty
                 "
             ),
-            "ConsList a -> ConsList a",
+            "ConsList [] -> ConsList []",
         );
     }
 
@@ -2736,7 +2659,7 @@ mod specialize_types {
                     toEmpty
                 "
             ),
-            "ConsList a -> ConsList a",
+            "ConsList [] -> ConsList []",
         );
     }
 
@@ -2760,7 +2683,7 @@ mod specialize_types {
                     toEmpty
                 "#
             ),
-            "ConsList a -> ConsList a",
+            "ConsList [] -> ConsList []",
         );
     }
 
@@ -2886,7 +2809,7 @@ mod specialize_types {
                     map
                 "
             ),
-            "(a -> b), ConsList a -> ConsList b",
+            "([] -> []), ConsList [] -> ConsList []",
         );
     }
 
@@ -2904,7 +2827,7 @@ mod specialize_types {
                     map
                 "
             ),
-            "(a -> b), [Cons { x : a, xs : c }*, Nil] as c -> [Cons { x : b, xs : d }, Nil] as d",
+            "(a -> b), [Cons { x : a, xs : c }, Nil] as c -> [Cons { x : b, xs : d }, Nil] as d",
         );
     }
 
@@ -2931,7 +2854,7 @@ mod specialize_types {
                     toAs
                 "
             ),
-            "(b -> a), ListA a b -> ConsList a",
+            "([] -> []), ListA [] [] -> ConsList []",
         );
     }
 
@@ -3004,7 +2927,7 @@ mod specialize_types {
                 partition
                             "
             ),
-            "U64, U64, List (Int a) -> [Pair U64 (List (Int a))]",
+            "U64, U64, List (Int []) -> [Pair U64 (List (Int []))]",
         );
     }
 
@@ -3052,7 +2975,7 @@ mod specialize_types {
             partition
         "
             ),
-            "U64, U64, List (Int a) -> [Pair U64 (List (Int a))]",
+            "U64, U64, List (Int []) -> [Pair U64 (List (Int []))]",
         );
     }
 
@@ -3083,7 +3006,7 @@ mod specialize_types {
                     List.get [10, 9, 8, 7] 1
                 "
             ),
-            "Result (Num *) [OutOfBounds]",
+            "Result (Num []) [OutOfBounds]",
         );
 
         infer_eq_without_problem(
@@ -3092,7 +3015,7 @@ mod specialize_types {
                     List.get
                 "
             ),
-            "List a, U64 -> Result a [OutOfBounds]",
+            "List [], U64 -> Result [] [OutOfBounds]",
         );
     }
 
@@ -3110,272 +3033,130 @@ mod specialize_types {
                 { id1, id2 }
                 "
             ),
-            "{ id1 : q -> q, id2 : q1 -> q1 }",
+            "{ id1 : [] -> [], id2 : [] -> [] }",
         );
     }
 
     #[test]
     fn map_insert() {
         infer_eq_without_problem(
-            indoc!(
-                r"
-                Dict.insert
-                "
-            ),
+            "Dict.insert",
             "Dict k v, k, v -> Dict k v where k implements Hash & Eq",
         );
     }
 
     #[test]
     fn num_to_frac() {
-        infer_eq_without_problem(
-            indoc!(
-                r"
-                Num.toFrac
-                "
-            ),
-            "Num * -> Frac a",
-        );
+        infer_eq_without_problem("Num.toFrac", "Num [] -> Frac []");
     }
 
     #[test]
     fn pow() {
-        infer_eq_without_problem(
-            indoc!(
-                r"
-                Num.pow
-                "
-            ),
-            "Frac a, Frac a -> Frac a",
-        );
+        infer_eq_without_problem("Num.pow", "Frac [], Frac [] -> Frac []");
     }
 
     #[test]
     fn ceiling() {
-        infer_eq_without_problem(
-            indoc!(
-                r"
-                Num.ceiling
-                "
-            ),
-            "Frac * -> Int a",
-        );
+        infer_eq_without_problem("Num.ceiling", "Frac [] -> Int []");
     }
 
     #[test]
     fn floor() {
-        infer_eq_without_problem(
-            indoc!(
-                r"
-                Num.floor
-                "
-            ),
-            "Frac * -> Int a",
-        );
+        infer_eq_without_problem("Num.floor", "Frac [] -> Int []");
     }
 
     #[test]
     fn div() {
-        infer_eq_without_problem(
-            indoc!(
-                r"
-                Num.div
-                "
-            ),
-            "Frac a, Frac a -> Frac a",
-        )
+        infer_eq_without_problem("Num.div", "Frac [], Frac [] -> Frac []")
     }
 
     #[test]
     fn div_checked() {
         infer_eq_without_problem(
-            indoc!(
-                r"
-                Num.divChecked
-                "
-            ),
-            "Frac a, Frac a -> Result (Frac a) [DivByZero]",
+            "Num.divChecked",
+            "Frac [], Frac [] -> Result (Frac []) [DivByZero]",
         )
     }
 
     #[test]
     fn div_ceil() {
-        infer_eq_without_problem(
-            indoc!(
-                r"
-                Num.divCeil
-                "
-            ),
-            "Int a, Int a -> Int a",
-        );
+        infer_eq_without_problem("Num.divCeil", "Int [], Int [] -> Int []");
     }
 
     #[test]
     fn div_ceil_checked() {
         infer_eq_without_problem(
-            indoc!(
-                r"
-                Num.divCeilChecked
-                "
-            ),
-            "Int a, Int a -> Result (Int a) [DivByZero]",
+            "Num.divCeilChecked",
+            "Int [], Int [] -> Result (Int []) [DivByZero]",
         );
     }
 
     #[test]
     fn div_trunc() {
-        infer_eq_without_problem(
-            indoc!(
-                r"
-                Num.divTrunc
-                "
-            ),
-            "Int a, Int a -> Int a",
-        );
+        infer_eq_without_problem("Num.divTrunc", "Int [], Int [] -> Int []");
     }
 
     #[test]
     fn div_trunc_checked() {
         infer_eq_without_problem(
-            indoc!(
-                r"
-                Num.divTruncChecked
-                "
-            ),
-            "Int a, Int a -> Result (Int a) [DivByZero]",
+            "Num.divTruncChecked",
+            "Int [], Int [] -> Result (Int []) [DivByZero]",
         );
     }
 
     #[test]
     fn atan() {
-        infer_eq_without_problem(
-            indoc!(
-                r"
-                Num.atan
-                "
-            ),
-            "Frac a -> Frac a",
-        );
+        infer_eq_without_problem("Num.atan", "Frac [] -> Frac []");
     }
 
     #[test]
     fn min_i128() {
-        infer_eq_without_problem(
-            indoc!(
-                r"
-                Num.minI128
-                "
-            ),
-            "I128",
-        );
+        infer_eq_without_problem("Num.minI128", "I128");
     }
 
     #[test]
     fn max_i128() {
-        infer_eq_without_problem(
-            indoc!(
-                r"
-                Num.maxI128
-                "
-            ),
-            "I128",
-        );
+        infer_eq_without_problem("Num.maxI128", "I128");
     }
 
     #[test]
     fn min_i64() {
-        infer_eq_without_problem(
-            indoc!(
-                r"
-                Num.minI64
-                "
-            ),
-            "I64",
-        );
+        infer_eq_without_problem("Num.minI64", "I64");
     }
 
     #[test]
     fn max_i64() {
-        infer_eq_without_problem(
-            indoc!(
-                r"
-                Num.maxI64
-                "
-            ),
-            "I64",
-        );
+        infer_eq_without_problem("Num.maxI64", "I64");
     }
 
     #[test]
     fn min_u64() {
-        infer_eq_without_problem(
-            indoc!(
-                r"
-                Num.minU64
-                "
-            ),
-            "U64",
-        );
+        infer_eq_without_problem("Num.minU64", "U64");
     }
 
     #[test]
     fn max_u64() {
-        infer_eq_without_problem(
-            indoc!(
-                r"
-                Num.maxU64
-                "
-            ),
-            "U64",
-        );
+        infer_eq_without_problem("Num.maxU64", "U64");
     }
 
     #[test]
     fn min_i32() {
-        infer_eq_without_problem(
-            indoc!(
-                r"
-                Num.minI32
-                "
-            ),
-            "I32",
-        );
+        infer_eq_without_problem("Num.minI32", "I32");
     }
 
     #[test]
     fn max_i32() {
-        infer_eq_without_problem(
-            indoc!(
-                r"
-                Num.maxI32
-                "
-            ),
-            "I32",
-        );
+        infer_eq_without_problem("Num.maxI32", "I32");
     }
 
     #[test]
     fn min_u32() {
-        infer_eq_without_problem(
-            indoc!(
-                r"
-                Num.minU32
-                "
-            ),
-            "U32",
-        );
+        infer_eq_without_problem("Num.minU32", "U32");
     }
 
     #[test]
     fn max_u32() {
-        infer_eq_without_problem(
-            indoc!(
-                r"
-                Num.maxU32
-                "
-            ),
-            "U32",
-        );
+        infer_eq_without_problem("Num.maxU32", "U32");
     }
 
     #[test]
@@ -3414,7 +3195,7 @@ mod specialize_types {
                 f
                 "
             ),
-            "{ p : *, q : * }* -> Num *",
+            "{ p : [], q : [] } -> Num []",
         );
     }
 
@@ -3469,7 +3250,7 @@ mod specialize_types {
                         _ -> 3
                 "
             ),
-            "Num * -> Num *",
+            "Num [] -> Num []",
         );
     }
 
@@ -3516,7 +3297,7 @@ mod specialize_types {
                 { x: sortWith, y: sort, z: sortBy }
                 "
             ),
-            "{ x : (foobar, foobar -> Order), ConsList foobar -> ConsList foobar, y : ConsList cm -> ConsList cm, z : (x -> cmpl), ConsList x -> ConsList x }"
+            "{ x : ([], [] -> Order), ConsList [] -> ConsList [], y : ConsList [] -> ConsList [], z : ([] -> []), ConsList [] -> ConsList [] }"
         );
     }
 
@@ -3569,7 +3350,7 @@ mod specialize_types {
                 f
                 "
             ),
-            "List a -> List a",
+            "List [] -> List []",
         );
     }
 
@@ -3608,7 +3389,7 @@ mod specialize_types {
                     negatePoint { x: 1, y: 2 }
                 "
             ),
-            "{ x : I64, y : I64, z : Num c }",
+            "{ x : I64, y : I64, z : Num [] }",
         );
     }
 
@@ -3625,7 +3406,7 @@ mod specialize_types {
                     { a, b }
                 "#
             ),
-            "{ a : { x : I64, y : I64, z : Num c }, b : { blah : Str, x : I64, y : I64, z : Num c1 } }",
+            "{ a : { x : I64, y : I64, z : Num [] }, b : { blah : Str, x : I64, y : I64, z : Num [] } }",
         );
     }
 
@@ -3639,7 +3420,7 @@ mod specialize_types {
                     negatePoint { x: 1, y: 2.1, z: 0x3 }
                 "
             ),
-            "{ x : Num *, y : Frac *, z : Int * }",
+            "{ x : Num [], y : Frac [], z : Int [] }",
         );
     }
 
@@ -3656,7 +3437,7 @@ mod specialize_types {
                     { a, b }
                 "#
             ),
-            "{ a : { x : Num *, y : Frac *, z : c }, b : { blah : Str, x : Num *, y : Frac *, z : c1 } }",
+            "{ a : { x : Num [], y : Frac [], z : c }, b : { blah : Str, x : Num [], y : Frac [], z : c1 } }",
         );
     }
 
@@ -3668,7 +3449,7 @@ mod specialize_types {
                 \{ x, y ? 0 } -> x + y
                 "
             ),
-            "{ x : Num a, y ? Num a }* -> Num a",
+            "{ x : Num [], y ? Num [] } -> Num []",
         );
     }
 
@@ -3682,7 +3463,7 @@ mod specialize_types {
                 x + y
                 "
             ),
-            "Num *",
+            "Num []",
         );
     }
 
@@ -3696,7 +3477,7 @@ mod specialize_types {
                         { x, y ? 0 } -> x + y
                 "
             ),
-            "{ x : Num a, y ? Num a }* -> Num a",
+            "{ x : Num a, y ? Num a } -> Num a",
         );
     }
 
@@ -3712,7 +3493,7 @@ mod specialize_types {
                     { x, y }
                 "
             ),
-            "{ x : I64, y ? Bool }* -> { x : I64, y : Bool }",
+            "{ x : I64, y ? Bool }-> { x : I64, y : Bool }",
         );
     }
 
@@ -3724,7 +3505,7 @@ mod specialize_types {
                 List.walkBackwards
                 "
             ),
-            "List elem, state, (state, elem -> state) -> state",
+            "List [], [], ([], [] -> []) -> []",
         );
     }
 
@@ -3748,7 +3529,7 @@ mod specialize_types {
     fn list_walk_with_index_until() {
         infer_eq_without_problem(
             indoc!(r"List.walkWithIndexUntil"),
-            "List elem, state, (state, elem, U64 -> [Break state, Continue state]) -> state",
+            "List [], [], ([], [], U64 -> [Break [], Continue []]) -> []",
         );
     }
 
@@ -3760,7 +3541,7 @@ mod specialize_types {
                 List.dropAt
                 "
             ),
-            "List elem, U64 -> List elem",
+            "List [], U64 -> List []",
         );
     }
 
@@ -3796,7 +3577,7 @@ mod specialize_types {
                 List.takeFirst
                 "
             ),
-            "List elem, U64 -> List elem",
+            "List [], U64 -> List []",
         );
     }
 
@@ -3808,7 +3589,7 @@ mod specialize_types {
                 List.takeLast
                 "
             ),
-            "List elem, U64 -> List elem",
+            "List [], U64 -> List []",
         );
     }
 
@@ -3820,7 +3601,7 @@ mod specialize_types {
                 List.sublist
                 "
             ),
-            "List elem, { len : U64, start : U64 } -> List elem",
+            "List [], { len : U64, start : U64 } -> List []",
         );
     }
 
@@ -3828,7 +3609,7 @@ mod specialize_types {
     fn list_split() {
         infer_eq_without_problem(
             indoc!("List.split"),
-            "List elem, U64 -> { before : List elem, others : List elem }",
+            "List [], U64 -> { before : List [], others : List [] }",
         );
     }
 
@@ -3840,7 +3621,7 @@ mod specialize_types {
                 List.dropLast
                 "
             ),
-            "List elem, U64 -> List elem",
+            "List [], U64 -> List []",
         );
     }
 
@@ -3852,7 +3633,7 @@ mod specialize_types {
                 List.intersperse
                 "
             ),
-            "List elem, elem -> List elem",
+            "List [], [] -> List []",
         );
     }
     #[test]
@@ -3869,7 +3650,7 @@ mod specialize_types {
                 g
                 "
             ),
-            "Num a -> Num a",
+            "Num [] -> Num []",
         );
     }
 
@@ -3889,7 +3670,7 @@ mod specialize_types {
                     empty
                 "#
             ),
-            "List x",
+            "List []",
         );
     }
 
@@ -3908,10 +3689,10 @@ mod specialize_types {
                         Foo Bar 1
                 "#
             ),
-            "[Foo [Bar] (Num *)]",
+            "[Foo [Bar] (Num [])]",
         );
 
-        infer_eq_without_problem("Foo Bar 1", "[Foo [Bar] (Num *)]");
+        infer_eq_without_problem("Foo Bar 1", "[Foo [Bar] (Num [])]");
     }
 
     #[test]
@@ -4403,7 +4184,7 @@ mod specialize_types {
                         Pair i list
                 "#
             ),
-            "U64, U64, List (Num a), U64, Num a -> [Pair U64 (List (Num a))]",
+            "U64, U64, List (Num []), U64, Num [] -> [Pair U64 (List (Num []))]",
         );
     }
 
@@ -4577,7 +4358,7 @@ mod specialize_types {
                     x
                 "#
             ),
-            "Num *",
+            "Num []",
         );
     }
 
@@ -4620,7 +4401,7 @@ mod specialize_types {
                 id
                 "
             ),
-            "a -> a",
+            "[] -> []",
         )
     }
 
@@ -4653,7 +4434,7 @@ mod specialize_types {
                 swapRcd
                 "
             ),
-            "{ x : a, y : b } -> { x : b, y : a }",
+            "{ x : [], y : [] } -> { x : [], y : [] }",
         )
     }
 
@@ -4667,7 +4448,7 @@ mod specialize_types {
                 swapRcd
                 "
             ),
-            "{ x : tx, y : ty } -> { x : ty, y : tx }",
+            "{ x : [], y : [] } -> { x : [], y : [] }",
         )
     }
 
@@ -4704,7 +4485,7 @@ mod specialize_types {
                 pastelize
                 "
             ),
-            "[Blue, Lavender, Orange, Peach]a -> [Blue, Lavender, Orange, Peach]a",
+            "[Blue, Lavender, Orange, Peach] -> [Blue, Lavender, Orange, Peach]",
         )
     }
 
@@ -4719,7 +4500,7 @@ mod specialize_types {
                 setRocEmail
                 "#
             ),
-            "{ email : Str, name : Str }a -> { email : Str, name : Str }a",
+            "{ email : Str, name : Str } -> { email : Str, name : Str }",
         )
     }
 
@@ -4736,7 +4517,7 @@ mod specialize_types {
                 fromList
                 "
             ),
-            "List elem -> LinkedList elem",
+            "List [] -> LinkedList []",
         )
     }
 
@@ -4751,7 +4532,7 @@ mod specialize_types {
                 fromList
                 "
             ),
-            "List elem -> LinkedList elem",
+            "List [] -> LinkedList []",
         )
     }
 
@@ -4782,7 +4563,7 @@ mod specialize_types {
                        _ -> Z
                  "
             ),
-            "[A, B]* -> [X, Y, Z]",
+            "[A, B] -> [X, Y, Z]",
         )
     }
 
@@ -4813,7 +4594,7 @@ mod specialize_types {
                        A _ -> Z
                  "
             ),
-            "[A [M, N]*] -> [X, Y, Z]",
+            "[A [M, N]] -> [X, Y, Z]",
         )
     }
 
@@ -4859,7 +4640,7 @@ mod specialize_types {
                          t -> t
                  "
             ),
-            "[A, X]a -> [A, X]a",
+            "[A, X] -> [A, X]",
         )
     }
 
@@ -4875,7 +4656,7 @@ mod specialize_types {
                          None -> 0
                  "
             ),
-            "[None, Some { tag : [A, B] }*] -> Num *",
+            "[None, Some { tag : [A, B] }] -> Num []",
         )
     }
 
@@ -4908,7 +4689,7 @@ mod specialize_types {
                          { x: Red, y ? 5 } -> y
                  "
             ),
-            "{ x : [Blue, Red], y ? Num a }* -> Num a",
+            "{ x : [Blue, Red], y ? Num [] } -> Num []",
         )
     }
 
@@ -4921,7 +4702,7 @@ mod specialize_types {
                  \UserId id -> id + 1
                  "
             ),
-            "[UserId (Num a)] -> Num a",
+            "[UserId (Num [])] -> Num []",
         )
     }
 

--- a/crates/compiler/types/src/subs.rs
+++ b/crates/compiler/types/src/subs.rs
@@ -2699,6 +2699,12 @@ impl VariableSubsSlice {
     }
 }
 
+impl From<Variable> for VariableSubsSlice {
+    fn from(var: Variable) -> Self {
+        Self::new(var.0, 1)
+    }
+}
+
 pub trait Label: Sized + Clone {
     fn index_subs(subs: &Subs, idx: SubsIndex<Self>) -> &Self;
     fn get_subs_slice(subs: &Subs, slice: SubsSlice<Self>) -> &[Self];

--- a/crates/compiler/types/src/types.rs
+++ b/crates/compiler/types/src/types.rs
@@ -3516,6 +3516,13 @@ impl AliasKind {
             AliasKind::Opaque => "opaque",
         }
     }
+
+    pub fn as_str_plural(&self) -> &'static str {
+        match self {
+            AliasKind::Structural => "aliases",
+            AliasKind::Opaque => "opaques",
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/crates/reporting/src/error/type.rs
+++ b/crates/reporting/src/error/type.rs
@@ -518,8 +518,8 @@ pub fn cyclic_alias<'b>(
 ) -> (RocDocBuilder<'b>, String) {
     let when_is_recursion_legal =
         alloc.reflow("Recursion in ")
-        .append(alloc.reflow(alias_kind.as_str()))
-        .append(alloc.reflow("es is only allowed if recursion happens behind a tagged union, at least one variant of which is not recursive."));
+        .append(alloc.reflow(alias_kind.as_str_plural()))
+        .append(alloc.reflow(" is only allowed if recursion happens behind a tagged union, at least one variant of which is not recursive."));
 
     let doc = if others.is_empty() {
         alloc.stack([

--- a/crates/soa/Cargo.toml
+++ b/crates/soa/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "soa"
+description = "Struct-of-Array helpers"
+
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+version.workspace = true
+
+[dependencies]
+
+[dev-dependencies]

--- a/crates/soa/src/either_index.rs
+++ b/crates/soa/src/either_index.rs
@@ -1,0 +1,66 @@
+use core::{
+    fmt::{self, Formatter},
+    marker::PhantomData,
+};
+
+use crate::soa_index::Index;
+
+#[derive(PartialEq, Eq)]
+pub struct EitherIndex<T, U> {
+    index: u32,
+    _marker: PhantomData<(T, U)>,
+}
+
+impl<T, U> Clone for EitherIndex<T, U> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<T, U> Copy for EitherIndex<T, U> {}
+
+impl<T, U> fmt::Debug for EitherIndex<T, U> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "EitherIndex({})", self.index)
+    }
+}
+
+impl<T, U> EitherIndex<T, U> {
+    const MASK: u32 = 1 << 31;
+
+    pub const fn from_left(input: Index<T>) -> Self {
+        assert!(input.index & Self::MASK == 0);
+
+        Self {
+            index: input.index,
+            _marker: PhantomData,
+        }
+    }
+
+    pub const fn from_right(input: Index<U>) -> Self {
+        assert!(input.index & Self::MASK == 0);
+
+        Self {
+            index: input.index | Self::MASK,
+            _marker: std::marker::PhantomData,
+        }
+    }
+
+    pub const fn split(self) -> Result<Index<T>, Index<U>> {
+        if self.index & Self::MASK == 0 {
+            Ok(Index {
+                index: self.index,
+                _marker: PhantomData,
+            })
+        } else {
+            Err(Index {
+                index: self.index ^ Self::MASK,
+                _marker: PhantomData,
+            })
+        }
+    }
+
+    pub fn decrement_index(&mut self) {
+        self.index = self.index.saturating_sub(1);
+    }
+}

--- a/crates/soa/src/lib.rs
+++ b/crates/soa/src/lib.rs
@@ -1,0 +1,9 @@
+mod either_index;
+mod soa_index;
+mod soa_slice;
+mod soa_slice2;
+
+pub use either_index::*;
+pub use soa_index::*;
+pub use soa_slice::*;
+pub use soa_slice2::*;

--- a/crates/soa/src/soa_index.rs
+++ b/crates/soa/src/soa_index.rs
@@ -1,0 +1,98 @@
+use core::{
+    any,
+    cmp::Ordering,
+    fmt::{self, Formatter},
+    hash::{Hash, Hasher},
+    marker::PhantomData,
+};
+
+use crate::soa_slice::Slice;
+
+pub type Id<T> = Index<T>;
+
+/// An index into an array of values, based
+/// on an offset into the array rather than a pointer.
+///
+/// Unlike a Rust pointer, this is a u32 offset
+/// rather than usize.
+pub struct Index<T> {
+    pub index: u32,
+    pub _marker: PhantomData<T>,
+}
+
+impl<T> PartialEq for Index<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.index == other.index
+    }
+}
+
+impl<T> Eq for Index<T> {}
+
+impl<T> PartialOrd for Index<T> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<T> Ord for Index<T> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.index.cmp(&other.index)
+    }
+}
+
+impl<T> fmt::Debug for Index<T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "Index<{}>({})", any::type_name::<T>(), self.index)
+    }
+}
+
+// derive of copy and clone does not play well with PhantomData
+
+impl<T> Copy for Index<T> {}
+
+impl<T> Clone for Index<T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<T> Hash for Index<T> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.index.hash(state);
+    }
+}
+
+impl<T> Index<T> {
+    pub const fn new(start: u32) -> Self {
+        Self {
+            index: start,
+            _marker: PhantomData,
+        }
+    }
+
+    pub const fn as_slice(self) -> Slice<T> {
+        Slice {
+            start: self.index,
+            length: 1,
+            _marker: PhantomData,
+        }
+    }
+
+    pub const fn index(self) -> usize {
+        self.index as usize
+    }
+}
+
+impl<T> core::ops::Index<Index<T>> for [T] {
+    type Output = T;
+
+    fn index(&self, index: Index<T>) -> &Self::Output {
+        &self[index.index()]
+    }
+}
+
+impl<T> core::ops::IndexMut<Index<T>> for [T] {
+    fn index_mut(&mut self, index: Index<T>) -> &mut Self::Output {
+        &mut self[index.index()]
+    }
+}

--- a/crates/soa/src/soa_slice.rs
+++ b/crates/soa/src/soa_slice.rs
@@ -1,0 +1,151 @@
+use core::{fmt, marker::PhantomData, ops::Range};
+
+use crate::soa_index::Index;
+
+/// A slice into an array of values, based
+/// on an offset into the array rather than a pointer.
+///
+/// Unlike a Rust slice, this is a u32 offset
+/// rather than a pointer, and the length is u16.
+#[derive(PartialEq, Eq, PartialOrd, Ord)]
+pub struct Slice<T> {
+    pub start: u32,
+    pub length: u16,
+    pub _marker: core::marker::PhantomData<T>,
+}
+
+impl<T> fmt::Debug for Slice<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "Slice<{}> {{ start: {}, length: {} }}",
+            core::any::type_name::<T>(),
+            self.start,
+            self.length
+        )
+    }
+}
+
+// derive of copy and clone does not play well with PhantomData
+
+impl<T> Copy for Slice<T> {}
+
+impl<T> Clone for Slice<T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<T> Default for Slice<T> {
+    fn default() -> Self {
+        Self::empty()
+    }
+}
+
+impl<T> Slice<T> {
+    pub const fn empty() -> Self {
+        Self {
+            start: 0,
+            length: 0,
+            _marker: PhantomData,
+        }
+    }
+
+    pub const fn start(self) -> u32 {
+        self.start
+    }
+
+    pub fn advance(&mut self, amount: u32) {
+        self.start += amount
+    }
+
+    pub fn get_slice<'a>(&self, elems: &'a [T]) -> &'a [T] {
+        &elems[self.indices()]
+    }
+
+    pub fn get_slice_mut<'a>(&self, elems: &'a mut [T]) -> &'a mut [T] {
+        &mut elems[self.indices()]
+    }
+
+    #[inline(always)]
+    pub const fn indices(&self) -> Range<usize> {
+        self.start as usize..(self.start as usize + self.length as usize)
+    }
+
+    pub const fn len(&self) -> usize {
+        self.length as usize
+    }
+
+    pub const fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    pub fn at_start(&self) -> Index<T> {
+        Index {
+            index: self.start,
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn at(&self, i: usize) -> Index<T> {
+        Index {
+            index: self.start + i as u32,
+            _marker: PhantomData,
+        }
+    }
+
+    pub const fn new(start: u32, length: u16) -> Self {
+        Self {
+            start,
+            length,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<T> IntoIterator for Slice<T> {
+    type Item = Index<T>;
+    type IntoIter = SliceIterator<T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        SliceIterator {
+            slice: self,
+            current: self.start,
+        }
+    }
+}
+
+pub struct SliceIterator<T> {
+    slice: Slice<T>,
+    current: u32,
+}
+
+impl<T> Iterator for SliceIterator<T> {
+    type Item = Index<T>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.current < self.slice.start + self.slice.length as u32 {
+            let index = Index {
+                index: self.current,
+                _marker: PhantomData,
+            };
+
+            self.current += 1;
+
+            Some(index)
+        } else {
+            None
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let remaining = (self.slice.start + self.slice.length as u32 - self.current) as usize;
+        (remaining, Some(remaining))
+    }
+}
+
+impl<T> ExactSizeIterator for SliceIterator<T> {}
+
+pub trait GetSlice<T> {
+    fn get_slice(&self, slice: Slice<T>) -> &[T];
+}

--- a/crates/soa/src/soa_slice2.rs
+++ b/crates/soa/src/soa_slice2.rs
@@ -1,0 +1,139 @@
+use core::{fmt, marker::PhantomData, ops::Range};
+
+use crate::{soa_index::Index, soa_slice::Slice};
+
+/// Two slices of the same length, each based on a different
+/// offset into the same array (rather than a pointer).
+///
+/// Unlike a Rust slice, this is a u32 offset
+/// rather than a pointer, and the length is u16.
+#[derive(PartialEq, Eq, PartialOrd, Ord)]
+pub struct Slice2<T, U> {
+    pub start1: u32,
+    pub start2: u32,
+    pub length: u16,
+    pub _marker: core::marker::PhantomData<(T, U)>,
+}
+
+impl<T, U> fmt::Debug for Slice2<T, U> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "Slice2<{}, {}> {{ start1: {}, start2: {}, length: {} }}",
+            core::any::type_name::<T>(),
+            core::any::type_name::<U>(),
+            self.start1,
+            self.start2,
+            self.length
+        )
+    }
+}
+
+// derive of copy and clone does not play well with PhantomData
+
+impl<T, U> Copy for Slice2<T, U> {}
+
+impl<T, U> Clone for Slice2<T, U> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<T, U> Default for Slice2<T, U> {
+    fn default() -> Self {
+        Self::empty()
+    }
+}
+
+impl<T, U> Slice2<T, U> {
+    pub const fn empty() -> Self {
+        Self {
+            start1: 0,
+            start2: 0,
+            length: 0,
+            _marker: PhantomData,
+        }
+    }
+
+    pub const fn slice_first(self) -> Slice<T> {
+        Slice {
+            start: self.start1,
+            length: self.length,
+            _marker: PhantomData,
+        }
+    }
+
+    pub const fn slice_second(self) -> Slice<U> {
+        Slice {
+            start: self.start2,
+            length: self.length,
+            _marker: PhantomData,
+        }
+    }
+
+    pub const fn len(&self) -> usize {
+        self.length as usize
+    }
+
+    pub const fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    pub const fn new(start1: u32, start2: u32, length: u16) -> Self {
+        Self {
+            start1,
+            start2,
+            length,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<T, U> IntoIterator for Slice2<T, U> {
+    type Item = (Index<T>, Index<U>);
+    type IntoIter = SliceIterator<T, U>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        SliceIterator {
+            slice: self,
+            offset: 0,
+        }
+    }
+}
+
+pub struct SliceIterator<T, U> {
+    slice: Slice2<T, U>,
+    offset: u32,
+}
+
+impl<T, U> Iterator for SliceIterator<T, U> {
+    type Item = (Index<T>, Index<U>);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let offset = self.offset;
+
+        if offset < self.slice.length as u32 {
+            let index1 = Index {
+                index: self.slice.start1 + offset,
+                _marker: PhantomData,
+            };
+            let index2 = Index {
+                index: self.slice.start2 + offset,
+                _marker: PhantomData,
+            };
+
+            self.offset += 1;
+
+            Some((index1, index2))
+        } else {
+            None
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let remaining = (self.slice.length as u32 - self.offset) as usize;
+        (remaining, Some(remaining))
+    }
+}
+
+impl<T, U> ExactSizeIterator for SliceIterator<T, U> {}


### PR DESCRIPTION
This isn't trying to do anything with expressions yet; all it does is that you give it a `Variable` and `Subs` and it monomorphizes that variable.

This is based on the `cor` implementation at https://github.com/ayazhafiz/cor/blob/b67174d98b6dde16809b3606f9f88d4863d8743f/experiments/lss/monotype/lower_type.ml#L62-L63