### PR TITLE
Remove stale RUSTFLAGS export

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -136,9 +136,7 @@
           shellHook = ''
             export LLVM_SYS_${llvmMajorMinorStr}_PREFIX="${llvmPkgs.llvm.dev}"
             ${aliases}
-          '' + pkgs.lib.optionalString (system == "aarch64-darwin") ''
-            export RUSTFLAGS="-C link-arg=-lc++abi"
-          ''; # lc++abi as workaround for github.com/NixOS/nixpkgs/issues/166205, see also github.com/roc-lang/roc/issues/6303
+          '';
         };
 
         formatter = pkgs.nixpkgs-fmt;


### PR DESCRIPTION
1. The issue is fixed upstream.
2. It blocks all other rustflags set by end users like "fuse-ld=lld" which improves compilation perf.