### PR TITLE
Initial Sketch of roc check on Markdown

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -221,14 +221,14 @@ fn main() -> io::Result<()> {
 
             match roc_file_path.extension().and_then(OsStr::to_str) {
                 Some("md") => {
-                    // Extract the blocks of roc code, do this smarter!
-                    let f = fs::File::open(roc_file_path.as_path())?;
-                    let markdown_contents = io::BufReader::new(f);
+                    // Extract the blocks of roc code
+                    let file = fs::File::open(roc_file_path.as_path())?;
+                    let markdown_file_reader = io::BufReader::new(file);
                     let mut roc_blocks: Vec<String> = Vec::new();
                     let mut in_roc_block: bool = false;
                     let mut current_block = String::new();
 
-                    for line in markdown_contents.lines() {
+                    for line in markdown_file_reader.lines() {
                         let line = line.unwrap();
                         if line == "```roc" {
                             in_roc_block = true;

--- a/crates/cli/tests/cli/form.md
+++ b/crates/cli/tests/cli/form.md
@@ -1,0 +1,35 @@
+# A Simple Markdown Example
+
+This file contains `form.roc` embedded as a block in Markdown. It lets us test that `roc check` works with Markdown.
+
+```roc
+app [main] { pf: platform "https://github.com/roc-lang/basic-cli/releases/download/0.15.0/SlwdbJ-3GR7uBWQo6zlmYWNYOxnvo8r6YABXD-45UOw.tar.br" }
+
+import pf.Stdin
+import pf.Stdout
+
+main =
+    Stdout.line! "What's your first name?"
+    firstName = Stdin.line!
+    Stdout.line! "What's your last name?"
+    lastName = Stdin.line!
+
+    Stdout.line "Hi, $(firstName) $(lastName)! 👋"
+```
+
+Excitingly, we can have another block of Roc code as well! (In this case it is the same one...)
+
+```roc
+app [main] { pf: platform "https://github.com/roc-lang/basic-cli/releases/download/0.15.0/SlwdbJ-3GR7uBWQo6zlmYWNYOxnvo8r6YABXD-45UOw.tar.br" }
+
+import pf.Stdin
+import pf.Stdout
+
+main =
+    Stdout.line! "What's your first name?"
+    firstName = Stdin.line!
+    Stdout.line! "What's your last name?"
+    lastName = Stdin.line!
+
+    Stdout.line "Hi, $(firstName) $(lastName)! 👋"
+```

--- a/crates/cli/tests/cli_run.rs
+++ b/crates/cli/tests/cli_run.rs
@@ -1074,6 +1074,16 @@ mod cli_run {
     #[test]
     #[cfg_attr(windows, ignore)]
     #[serial(cli_platform)]
+    fn cli_form_markdown_check() {
+        let path = file_path_from_root("crates/cli/tests/cli", "form.md");
+        let out = run_roc([CMD_CHECK, path.to_str().unwrap()], &[], &[]);
+        dbg!(out.stdout, out.stderr);
+        assert_valid_roc_check_status(out.status);
+    }
+
+    #[test]
+    #[cfg_attr(windows, ignore)]
+    #[serial(cli_platform)]
     fn cli_http_get_check() {
         let path = file_path_from_root("crates/cli/tests/cli", "http-get.roc");
         let out = run_roc([CMD_CHECK, path.to_str().unwrap()], &[], &[]);

--- a/crates/cli/tests/cli_run.rs
+++ b/crates/cli/tests/cli_run.rs
@@ -1067,7 +1067,6 @@ mod cli_run {
     fn cli_form_check() {
         let path = file_path_from_root("crates/cli/tests/cli", "form.roc");
         let out = run_roc([CMD_CHECK, path.to_str().unwrap()], &[], &[]);
-        dbg!(out.stdout, out.stderr);
         assert_valid_roc_check_status(out.status);
     }
 
@@ -1077,7 +1076,6 @@ mod cli_run {
     fn cli_form_markdown_check() {
         let path = file_path_from_root("crates/cli/tests/cli", "form.md");
         let out = run_roc([CMD_CHECK, path.to_str().unwrap()], &[], &[]);
-        dbg!(out.stdout, out.stderr);
         assert_valid_roc_check_status(out.status);
     }
 


### PR DESCRIPTION
This commit alters `roc check` to be able to run on Markdown files. The overall flow is:
 - check if the file has a `.md` extension
  - if it does extract any fenced code blocks marked as Roc
  - write those blocks to temp files
  - run `roc check` sequentially on every temp file
  - print out the results of `roc check`
  - exit early if any individual `roc check` has non-zero exit status
 - if the file does not have `.md` extension proceed as before