### PR TITLE
Set argv[0] to .roc file passed to 'roc run'

### DIFF
--- a/crates/cli/tests/cli/argv0.roc
+++ b/crates/cli/tests/cli/argv0.roc
@@ -1,0 +1,12 @@
+app [main] {
+    pf: platform "https://github.com/roc-lang/basic-cli/releases/download/0.15.0/SlwdbJ-3GR7uBWQo6zlmYWNYOxnvo8r6YABXD-45UOw.tar.br",
+}
+
+import pf.Stdout
+import pf.Arg
+
+main =
+    args = Arg.list! {}
+    when List.first args is
+        Ok argv0 -> Stdout.line argv0
+        Err ListWasEmpty -> Stdout.line "Failed: argv was empty"

--- a/crates/cli/tests/cli_run.rs
+++ b/crates/cli/tests/cli_run.rs
@@ -305,7 +305,7 @@ mod cli_run {
                 }
             };
 
-            let self_path = file.display().to_string();
+            let self_path = file.parent().unwrap().display().to_string();
 
             let actual_cmd_stdout = ignore_test_timings(&strip_colors(&cmd_output.stdout))
                 .replace(&self_path, "<ignored for tests>");
@@ -573,12 +573,12 @@ mod cli_run {
                 words : List Str
                 words = ["this", "will", "for", "sure", "be", "a", "large", "string", "so", "when", "we", "split", "it", "it", "will", "use", "seamless", "slices", "which", "affect", "printing"]
 
-                [<ignored for tests>:31] x = 42
-                [<ignored for tests>:33] "Fjoer en ferdjer frieten oan dyn geve lea" = "Fjoer en ferdjer frieten oan dyn geve lea"
-                [<ignored for tests>:35] "this is line 24" = "this is line 24"
-                [<ignored for tests>:21] x = "abc"
-                [<ignored for tests>:21] x = 10
-                [<ignored for tests>:21] x = (A (B C))
+                [<ignored for tests>/expects.roc:31] x = 42
+                [<ignored for tests>/expects.roc:33] "Fjoer en ferdjer frieten oan dyn geve lea" = "Fjoer en ferdjer frieten oan dyn geve lea"
+                [<ignored for tests>/expects.roc:35] "this is line 24" = "this is line 24"
+                [<ignored for tests>/expects.roc:21] x = "abc"
+                [<ignored for tests>/expects.roc:21] x = 10
+                [<ignored for tests>/expects.roc:21] x = (A (B C))
                 Program finished!
                 "#
             ),
@@ -1198,6 +1198,23 @@ mod cli_run {
             &[],
             &[],
             "For multiple tasks: {a: 123, b: \"abc\", c: [123]}\n",
+            UseValgrind::No,
+            TestCliCommands::Run,
+        )
+    }
+
+    #[test]
+    #[serial(cli_platform)]
+    #[cfg_attr(windows, ignore)]
+    #[ignore = "broken because of a bug in basic-cli: https://github.com/roc-lang/basic-cli/issues/82"]
+    fn argv0() {
+        test_roc_app(
+            "crates/cli/tests/cli",
+            "argv0.roc",
+            &[],
+            &[],
+            &[],
+            "<ignored for tests>/argv0.roc\n",
             UseValgrind::No,
             TestCliCommands::Run,
         )


### PR DESCRIPTION
When we run `roc run <file>` or `roc <file>` then Roc will compile a binary and run it. Before this commit we would set the path to the compiled binary as argv[0]. This commit changes the behavior to make argv[0] in the binary correspond to the roc file being ran.

This is what shells like sh or bash do. If you create a file `test.sh` with the contents `echo "$0"` then run `bash test.sh`, that will print `test.sh` and not `bash`. Scripts can make use of $0 to get their own location, for instance to find files relative to themselves on the filesystem.

Related Zulip conversation:
https://roc.zulipchat.com/#narrow/channel/302903-platform-development/topic/getting.20args.20when.20using.20.60roc.20run.60.3F/near/477528914