### PR TITLE
Remove unused malformed related variants

### DIFF
--- a/crates/compiler/can/src/annotation.rs
+++ b/crates/compiler/can/src/annotation.rs
@@ -482,7 +482,6 @@ pub fn find_type_def_symbols(
                         AssignedField::LabelOnly(_) => {}
                         AssignedField::SpaceBefore(inner, _)
                         | AssignedField::SpaceAfter(inner, _) => inner_stack.push(inner),
-                        AssignedField::Malformed(_) => {}
                     }
                 }
 
@@ -507,7 +506,6 @@ pub fn find_type_def_symbols(
                         Tag::SpaceBefore(inner, _) | Tag::SpaceAfter(inner, _) => {
                             inner_stack.push(inner)
                         }
-                        Tag::Malformed(_) => {}
                     }
                 }
 
@@ -1355,7 +1353,7 @@ fn can_assigned_fields<'a>(
     // field names we've seen so far in this record
     let mut seen = std::collections::HashMap::with_capacity(fields.len());
 
-    'outer: for loc_field in fields.iter() {
+    for loc_field in fields.iter() {
         let mut field = &loc_field.value;
 
         // use this inner loop to unwrap the SpaceAfter/SpaceBefore
@@ -1429,12 +1427,6 @@ fn can_assigned_fields<'a>(
                     // check the nested field instead
                     field = nested;
                     continue 'inner;
-                }
-                Malformed(string) => {
-                    malformed(env, region, string);
-
-                    // completely skip this element, advance to the next tag
-                    continue 'outer;
                 }
             }
         };
@@ -1522,7 +1514,7 @@ fn can_tags<'a>(
     // tag names we've seen so far in this tag union
     let mut seen = std::collections::HashMap::with_capacity(tags.len());
 
-    'outer: for loc_tag in tags.iter() {
+    for loc_tag in tags.iter() {
         let mut tag = &loc_tag.value;
 
         // use this inner loop to unwrap the SpaceAfter/SpaceBefore
@@ -1560,12 +1552,6 @@ fn can_tags<'a>(
                     // check the nested tag instead
                     tag = nested;
                     continue 'inner;
-                }
-                Tag::Malformed(string) => {
-                    malformed(env, region, string);
-
-                    // completely skip this element, advance to the next tag
-                    continue 'outer;
                 }
             }
         };

--- a/crates/compiler/can/src/def.rs
+++ b/crates/compiler/can/src/def.rs
@@ -715,10 +715,6 @@ fn canonicalize_claimed_ability_impl<'a>(
             });
             Err(())
         }
-        AssignedField::Malformed(_) => {
-            // An error will already have been reported
-            Err(())
-        }
         AssignedField::SpaceBefore(_, _)
         | AssignedField::SpaceAfter(_, _)
         | AssignedField::IgnoredValue(_, _, _) => {

--- a/crates/compiler/can/src/desugar.rs
+++ b/crates/compiler/can/src/desugar.rs
@@ -407,7 +407,6 @@ pub fn desugar_expr<'a>(
         | AccessorFunction(_)
         | Underscore { .. }
         | MalformedIdent(_, _)
-        | MalformedClosure
         | MalformedSuffixed(..)
         | PrecedenceConflict { .. }
         | EmptyRecordBuilder(_)
@@ -712,7 +711,6 @@ pub fn desugar_expr<'a>(
                     AssignedField::SpaceBefore(_, _) | AssignedField::SpaceAfter(_, _) => {
                         unreachable!("Should have been desugared in `desugar_field`")
                     }
-                    AssignedField::Malformed(_name) => continue,
                 };
 
                 field_data.push(FieldData {
@@ -1316,8 +1314,6 @@ fn desugar_field<'a>(
         }
         SpaceBefore(field, _spaces) => desugar_field(env, scope, field),
         SpaceAfter(field, _spaces) => desugar_field(env, scope, field),
-
-        Malformed(string) => Malformed(string),
     }
 }
 

--- a/crates/compiler/can/src/expr.rs
+++ b/crates/compiler/can/src/expr.rs
@@ -1391,10 +1391,6 @@ pub fn canonicalize_expr<'a>(
                 Output::default(),
             )
         }
-        ast::Expr::MalformedClosure => {
-            use roc_problem::can::RuntimeError::*;
-            (RuntimeError(MalformedClosure(region)), Output::default())
-        }
         ast::Expr::MalformedIdent(name, bad_ident) => {
             use roc_problem::can::RuntimeError::*;
 
@@ -1975,10 +1971,6 @@ fn canonicalize_field<'a>(
 
         SpaceBefore(sub_field, _) | SpaceAfter(sub_field, _) => {
             canonicalize_field(env, var_store, scope, sub_field)
-        }
-
-        Malformed(_string) => {
-            internal_error!("TODO canonicalize malformed record field");
         }
     }
 }
@@ -2568,8 +2560,7 @@ pub fn is_valid_interpolation(expr: &ast::Expr<'_>) -> bool {
         | ast::Expr::Underscore(_)
         | ast::Expr::MalformedIdent(_, _)
         | ast::Expr::Tag(_)
-        | ast::Expr::OpaqueRef(_)
-        | ast::Expr::MalformedClosure => true,
+        | ast::Expr::OpaqueRef(_) => true,
         // Newlines are disallowed inside interpolation, and these all require newlines
         ast::Expr::DbgStmt(_, _)
         | ast::Expr::LowLevelDbg(_, _, _)
@@ -2604,7 +2595,7 @@ pub fn is_valid_interpolation(expr: &ast::Expr<'_>) -> bool {
             | ast::AssignedField::IgnoredValue(_label, loc_comments, loc_val) => {
                 loc_comments.is_empty() && is_valid_interpolation(&loc_val.value)
             }
-            ast::AssignedField::Malformed(_) | ast::AssignedField::LabelOnly(_) => true,
+            ast::AssignedField::LabelOnly(_) => true,
             ast::AssignedField::SpaceBefore(_, _) | ast::AssignedField::SpaceAfter(_, _) => false,
         }),
         ast::Expr::Tuple(fields) => fields
@@ -2655,7 +2646,7 @@ pub fn is_valid_interpolation(expr: &ast::Expr<'_>) -> bool {
                     | ast::AssignedField::IgnoredValue(_label, loc_comments, loc_val) => {
                         loc_comments.is_empty() && is_valid_interpolation(&loc_val.value)
                     }
-                    ast::AssignedField::Malformed(_) | ast::AssignedField::LabelOnly(_) => true,
+                    ast::AssignedField::LabelOnly(_) => true,
                     ast::AssignedField::SpaceBefore(_, _)
                     | ast::AssignedField::SpaceAfter(_, _) => false,
                 })
@@ -2668,7 +2659,7 @@ pub fn is_valid_interpolation(expr: &ast::Expr<'_>) -> bool {
                     | ast::AssignedField::IgnoredValue(_label, loc_comments, loc_val) => {
                         loc_comments.is_empty() && is_valid_interpolation(&loc_val.value)
                     }
-                    ast::AssignedField::Malformed(_) | ast::AssignedField::LabelOnly(_) => true,
+                    ast::AssignedField::LabelOnly(_) => true,
                     ast::AssignedField::SpaceBefore(_, _)
                     | ast::AssignedField::SpaceAfter(_, _) => false,
                 })

--- a/crates/compiler/fmt/src/annotation.rs
+++ b/crates/compiler/fmt/src/annotation.rs
@@ -438,7 +438,6 @@ fn is_multiline_assigned_field_help<T: Formattable>(afield: &AssignedField<'_, T
         | IgnoredValue(_, spaces, ann) => !spaces.is_empty() || ann.value.is_multiline(),
         LabelOnly(_) => false,
         AssignedField::SpaceBefore(_, _) | AssignedField::SpaceAfter(_, _) => true,
-        Malformed(text) => text.chars().any(|c| c == '\n'),
     }
 }
 
@@ -522,9 +521,6 @@ fn format_assigned_field_help<T>(
             format_assigned_field_help(sub_field, buf, indent, separator_spaces, is_multiline);
             fmt_comments_only(buf, spaces.iter(), NewlineAt::Bottom, indent);
         }
-        Malformed(raw) => {
-            buf.push_str(raw);
-        }
     }
 }
 
@@ -535,7 +531,6 @@ impl<'a> Formattable for Tag<'a> {
         match self {
             Apply { args, .. } => args.iter().any(|arg| arg.value.is_multiline()),
             Tag::SpaceBefore(_, _) | Tag::SpaceAfter(_, _) => true,
-            Malformed(text) => text.chars().any(|c| c == '\n'),
         }
     }
 
@@ -572,10 +567,6 @@ impl<'a> Formattable for Tag<'a> {
                 }
             }
             Tag::SpaceBefore(_, _) | Tag::SpaceAfter(_, _) => unreachable!(),
-            Tag::Malformed(raw) => {
-                buf.indent(indent);
-                buf.push_str(raw);
-            }
         }
     }
 }

--- a/crates/compiler/fmt/src/expr.rs
+++ b/crates/compiler/fmt/src/expr.rs
@@ -44,7 +44,6 @@ impl<'a> Formattable for Expr<'a> {
             | Var { .. }
             | Underscore { .. }
             | MalformedIdent(_, _)
-            | MalformedClosure
             | Tag(_)
             | OpaqueRef(_)
             | Crash
@@ -557,7 +556,6 @@ impl<'a> Formattable for Expr<'a> {
                 buf.indent(indent);
                 loc_expr.format_with_options(buf, parens, newlines, indent);
             }
-            MalformedClosure => {}
             PrecedenceConflict { .. } => {}
             EmptyRecordBuilder { .. } => {}
             SingleFieldRecordBuilder { .. } => {}
@@ -1645,9 +1643,6 @@ fn format_assigned_field_multiline<T>(
             // ```
             format_assigned_field_multiline(buf, sub_field, indent, separator_prefix);
             fmt_comments_only(buf, spaces.iter(), NewlineAt::Top, indent);
-        }
-        Malformed(raw) => {
-            buf.push_str(raw);
         }
     }
 }

--- a/crates/compiler/load_internal/src/docs.rs
+++ b/crates/compiler/load_internal/src/docs.rs
@@ -476,7 +476,7 @@ fn contains_unexposed_type(
                             return true;
                         }
                     }
-                    AssignedField::Malformed(_) | AssignedField::LabelOnly(_) => {
+                    AssignedField::LabelOnly(_) => {
                         // contains no unexposed types, so continue
                     }
                     AssignedField::SpaceBefore(field, _) | AssignedField::SpaceAfter(field, _) => {
@@ -523,9 +523,6 @@ fn contains_unexposed_type(
                                 return true;
                             }
                         }
-                    }
-                    Tag::Malformed(_) => {
-                        // contains no unexposed types, so continue
                     }
                     Tag::SpaceBefore(tag, _) | Tag::SpaceAfter(tag, _) => {
                         tags_to_process.push(*tag);
@@ -728,7 +725,7 @@ fn record_field_to_doc(
         AssignedField::LabelOnly(label) => Some(RecordField::LabelOnly {
             name: label.value.to_string(),
         }),
-        AssignedField::Malformed(_) | AssignedField::IgnoredValue(_, _, _) => None,
+        AssignedField::IgnoredValue(_, _, _) => None,
     }
 }
 
@@ -749,7 +746,6 @@ fn tag_to_doc(in_func_ann: bool, tag: ast::Tag) -> Option<Tag> {
         }),
         ast::Tag::SpaceBefore(&sub_tag, _) => tag_to_doc(in_func_ann, sub_tag),
         ast::Tag::SpaceAfter(&sub_tag, _) => tag_to_doc(in_func_ann, sub_tag),
-        ast::Tag::Malformed(_) => None,
     }
 }
 

--- a/crates/compiler/parse/src/ast.rs
+++ b/crates/compiler/parse/src/ast.rs
@@ -539,7 +539,6 @@ pub enum Expr<'a> {
 
     // Problems
     MalformedIdent(&'a str, crate::ident::BadIdent),
-    MalformedClosure,
     MalformedSuffixed(&'a Loc<Expr<'a>>),
     // Both operators were non-associative, e.g. (True == False == False).
     // We should tell the author to disambiguate by grouping them with parens.
@@ -687,7 +686,6 @@ pub fn is_expr_suffixed(expr: &Expr) -> bool {
         Expr::SpaceBefore(a, _) => is_expr_suffixed(a),
         Expr::SpaceAfter(a, _) => is_expr_suffixed(a),
         Expr::MalformedIdent(_, _) => false,
-        Expr::MalformedClosure => false,
         Expr::MalformedSuffixed(_) => false,
         Expr::PrecedenceConflict(_) => false,
         Expr::EmptyRecordBuilder(_) => false,
@@ -713,7 +711,6 @@ fn is_assigned_value_suffixed<'a>(value: &AssignedField<'a, Expr<'a>>) -> bool {
         AssignedField::SpaceBefore(a, _) | AssignedField::SpaceAfter(a, _) => {
             is_assigned_value_suffixed(a)
         }
-        AssignedField::Malformed(_) => false,
     }
 }
 
@@ -889,7 +886,7 @@ impl<'a, 'b> RecursiveValueDefIter<'a, 'b> {
                             | OptionalValue(_, _, loc_val)
                             | IgnoredValue(_, _, loc_val) => break expr_stack.push(&loc_val.value),
                             SpaceBefore(next, _) | SpaceAfter(next, _) => current = *next,
-                            LabelOnly(_) | Malformed(_) => break,
+                            LabelOnly(_) => break,
                         }
                     }
                 }
@@ -1038,7 +1035,6 @@ impl<'a, 'b> RecursiveValueDefIter<'a, 'b> {
                 | Tag(_)
                 | OpaqueRef(_)
                 | MalformedIdent(_, _)
-                | MalformedClosure
                 | PrecedenceConflict(_)
                 | MalformedSuffixed(_) => { /* terminal */ }
             }
@@ -1614,9 +1610,6 @@ pub enum Tag<'a> {
     // We preserve this for the formatter; canonicalization ignores it.
     SpaceBefore(&'a Tag<'a>, &'a [CommentOrNewline<'a>]),
     SpaceAfter(&'a Tag<'a>, &'a [CommentOrNewline<'a>]),
-
-    /// A malformed tag, which will code gen to a runtime error
-    Malformed(&'a str),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -1639,9 +1632,6 @@ pub enum AssignedField<'a, Val> {
     // We preserve this for the formatter; canonicalization ignores it.
     SpaceBefore(&'a AssignedField<'a, Val>, &'a [CommentOrNewline<'a>]),
     SpaceAfter(&'a AssignedField<'a, Val>, &'a [CommentOrNewline<'a>]),
-
-    /// A malformed assigned field, which will code gen to a runtime error
-    Malformed(&'a str),
 }
 
 impl<'a, Val> AssignedField<'a, Val> {
@@ -1653,7 +1643,7 @@ impl<'a, Val> AssignedField<'a, Val> {
                 Self::RequiredValue(_, _, val)
                 | Self::OptionalValue(_, _, val)
                 | Self::IgnoredValue(_, _, val) => break Some(val),
-                Self::LabelOnly(_) | Self::Malformed(_) => break None,
+                Self::LabelOnly(_) => break None,
                 Self::SpaceBefore(next, _) | Self::SpaceAfter(next, _) => current = *next,
             }
         }
@@ -2518,7 +2508,6 @@ impl<'a> Malformed for Expr<'a> {
             ParensAround(expr) => expr.is_malformed(),
 
             MalformedIdent(_, _) |
-            MalformedClosure |
             MalformedSuffixed(..) |
             PrecedenceConflict(_) |
             EmptyRecordBuilder(_) |
@@ -2593,7 +2582,6 @@ impl<'a, T: Malformed> Malformed for AssignedField<'a, T> {
             AssignedField::SpaceBefore(field, _) | AssignedField::SpaceAfter(field, _) => {
                 field.is_malformed()
             }
-            AssignedField::Malformed(_) => true,
         }
     }
 }
@@ -2815,7 +2803,6 @@ impl<'a> Malformed for Tag<'a> {
         match self {
             Tag::Apply { name: _, args } => args.iter().any(|arg| arg.is_malformed()),
             Tag::SpaceBefore(tag, _) | Tag::SpaceAfter(tag, _) => tag.is_malformed(),
-            Tag::Malformed(_) => true,
         }
     }
 }

--- a/crates/compiler/parse/src/expr.rs
+++ b/crates/compiler/parse/src/expr.rs
@@ -2180,7 +2180,6 @@ fn expr_to_pattern_help<'a>(arena: &'a Bump, expr: &Expr<'a>) -> Result<Pattern<
         | Expr::DbgStmt(_, _)
         | Expr::LowLevelDbg(_, _, _)
         | Expr::Return(_, _)
-        | Expr::MalformedClosure
         | Expr::MalformedSuffixed(..)
         | Expr::PrecedenceConflict { .. }
         | Expr::EmptyRecordBuilder(_)
@@ -2254,7 +2253,6 @@ fn assigned_expr_field_to_pattern_help<'a>(
             arena.alloc(assigned_expr_field_to_pattern_help(arena, nested)?),
             spaces,
         ),
-        AssignedField::Malformed(string) => Pattern::Malformed(string),
         AssignedField::IgnoredValue(_, _, _) => return Err(()),
     })
 }

--- a/crates/compiler/parse/src/normalize.rs
+++ b/crates/compiler/parse/src/normalize.rs
@@ -556,7 +556,6 @@ impl<'a, T: Normalize<'a> + Copy + std::fmt::Debug> Normalize<'a> for AssignedFi
                 arena.alloc(c.normalize(arena)),
             ),
             AssignedField::LabelOnly(a) => AssignedField::LabelOnly(a.normalize(arena)),
-            AssignedField::Malformed(a) => AssignedField::Malformed(a),
             AssignedField::SpaceBefore(a, _) => a.normalize(arena),
             AssignedField::SpaceAfter(a, _) => a.normalize(arena),
         }
@@ -784,7 +783,6 @@ impl<'a> Normalize<'a> for Expr<'a> {
                 a.normalize(arena)
             }
             Expr::MalformedIdent(a, b) => Expr::MalformedIdent(a, remove_spaces_bad_ident(b)),
-            Expr::MalformedClosure => Expr::MalformedClosure,
             Expr::MalformedSuffixed(a) => Expr::MalformedSuffixed(a),
             Expr::PrecedenceConflict(a) => Expr::PrecedenceConflict(a),
             Expr::SpaceBefore(a, _) => a.normalize(arena),
@@ -938,7 +936,6 @@ impl<'a> Normalize<'a> for Tag<'a> {
                 name: name.normalize(arena),
                 args: args.normalize(arena),
             },
-            Tag::Malformed(a) => Tag::Malformed(a),
             Tag::SpaceBefore(a, _) => a.normalize(arena),
             Tag::SpaceAfter(a, _) => a.normalize(arena),
         }

--- a/crates/compiler/problem/src/can.rs
+++ b/crates/compiler/problem/src/can.rs
@@ -435,7 +435,6 @@ impl Problem {
             | Problem::RuntimeError(RuntimeError::InvalidPrecedence(_, region))
             | Problem::RuntimeError(RuntimeError::MalformedIdentifier(_, _, region))
             | Problem::RuntimeError(RuntimeError::MalformedTypeName(_, region))
-            | Problem::RuntimeError(RuntimeError::MalformedClosure(region))
             | Problem::RuntimeError(RuntimeError::MalformedSuffixed(region))
             | Problem::RuntimeError(RuntimeError::InvalidRecordUpdate { region })
             | Problem::RuntimeError(RuntimeError::InvalidFloat(_, region, _))
@@ -678,7 +677,6 @@ pub enum RuntimeError {
     InvalidPrecedence(PrecedenceProblem, Region),
     MalformedIdentifier(Box<str>, roc_parse::ident::BadIdent, Region),
     MalformedTypeName(Box<str>, Region),
-    MalformedClosure(Region),
     InvalidRecordUpdate {
         region: Region,
     },
@@ -750,7 +748,6 @@ impl RuntimeError {
             | RuntimeError::InvalidPrecedence(_, region)
             | RuntimeError::MalformedIdentifier(_, _, region)
             | RuntimeError::MalformedTypeName(_, region)
-            | RuntimeError::MalformedClosure(region)
             | RuntimeError::MalformedSuffixed(region)
             | RuntimeError::InvalidRecordUpdate { region }
             | RuntimeError::InvalidFloat(_, region, _)

--- a/crates/language_server/src/analysis/tokens.rs
+++ b/crates/language_server/src/analysis/tokens.rs
@@ -443,7 +443,6 @@ where
             AssignedField::SpaceBefore(af, _) | AssignedField::SpaceAfter(af, _) => {
                 af.iter_tokens(arena)
             }
-            AssignedField::Malformed(_) => bumpvec![in arena;],
         }
     }
 }
@@ -461,7 +460,6 @@ impl IterTokens for Tag<'_> {
                 .chain(args.iter_tokens(arena))
                 .collect_in(arena),
             Tag::SpaceBefore(t, _) | Tag::SpaceAfter(t, _) => t.iter_tokens(arena),
-            Tag::Malformed(_) => bumpvec![in arena;],
         }
     }
 }
@@ -735,7 +733,6 @@ impl IterTokens for Loc<Expr<'_>> {
             Expr::SingleFieldRecordBuilder(e) => e.iter_tokens(arena),
             Expr::OptionalFieldInRecordBuilder(_name, e) => e.iter_tokens(arena),
             Expr::MalformedIdent(_, _)
-            | Expr::MalformedClosure
             | Expr::PrecedenceConflict(_)
             | Expr::MalformedSuffixed(_) => {
                 bumpvec![in arena;]

--- a/crates/repl_eval/src/gen.rs
+++ b/crates/repl_eval/src/gen.rs
@@ -22,7 +22,7 @@ pub struct ReplOutput {
 
 pub fn format_answer<'a>(arena: &'a Bump, answer: Expr<'_>) -> &'a str {
     match answer {
-        Expr::Closure(_, _) | Expr::MalformedClosure => "<function>",
+        Expr::Closure(_, _) => "<function>",
         _ => {
             let mut expr = roc_fmt::Buf::new_in(arena);
 

--- a/crates/reporting/src/error/canonicalize.rs
+++ b/crates/reporting/src/error/canonicalize.rs
@@ -2194,9 +2194,6 @@ fn pretty_runtime_error<'b>(
 
             title = SYNTAX_PROBLEM;
         }
-        RuntimeError::MalformedClosure(_) => {
-            todo!("");
-        }
         RuntimeError::MalformedSuffixed(_) => {
             todo!("error for malformed suffix");
         }


### PR DESCRIPTION
Remove enum variants that I noticed were unused:
`Expr::MalformedClosure`
`RuntimeError::MalformedClosure`
`AssignedField::Malformed`
`Tag::Malformed`