### PR TITLE
Remove unused EmptyTuple variant from FlatType enum

### DIFF
--- a/crates/compiler/can/src/copy.rs
+++ b/crates/compiler/can/src/copy.rs
@@ -960,7 +960,7 @@ fn deep_copy_type_vars<C: CopyEnv>(
 
             // Everything else is a mechanical descent.
             Structure(flat_type) => match flat_type {
-                EmptyRecord | EmptyTuple | EmptyTagUnion => Structure(flat_type),
+                EmptyRecord | EmptyTagUnion => Structure(flat_type),
                 Apply(symbol, arguments) => {
                     descend_slice!(arguments);
 

--- a/crates/compiler/can/src/exhaustive.rs
+++ b/crates/compiler/can/src/exhaustive.rs
@@ -237,9 +237,6 @@ fn index_var(
                     };
                     return Ok(std::iter::repeat(Variable::NULL).take(num_fields).collect());
                 }
-                FlatType::EmptyTuple => {
-                    return Ok(std::iter::repeat(Variable::NULL).take(0).collect());
-                }
                 FlatType::EmptyTagUnion => {
                     internal_error!("empty tag unions are not indexable")
                 }

--- a/crates/compiler/checkmate/schema.json
+++ b/crates/compiler/checkmate/schema.json
@@ -505,20 +505,6 @@
             "type": {
               "type": "string",
               "enum": [
-                "EmptyTuple"
-              ]
-            }
-          }
-        },
-        {
-          "type": "object",
-          "required": [
-            "type"
-          ],
-          "properties": {
-            "type": {
-              "type": "string",
-              "enum": [
                 "EmptyTagUnion"
               ]
             }

--- a/crates/compiler/checkmate/src/convert.rs
+++ b/crates/compiler/checkmate/src/convert.rs
@@ -123,7 +123,6 @@ impl AsSchema<Content> for subs::FlatType {
                 ext.as_schema(subs),
             ),
             subs::FlatType::EmptyRecord => Content::EmptyRecord(),
-            subs::FlatType::EmptyTuple => Content::EmptyTuple(),
             subs::FlatType::EmptyTagUnion => Content::EmptyTagUnion(),
         }
     }

--- a/crates/compiler/checkmate/www/src/components/Content/HeadConstructor.tsx
+++ b/crates/compiler/checkmate/www/src/components/Content/HeadConstructor.tsx
@@ -221,9 +221,6 @@ export default function DrawHeadConstructor({
     case "EmptyRecord": {
       return <>{"{}"}</>;
     }
-    case "EmptyTuple": {
-      return <>()</>;
-    }
     case "EmptyTagUnion": {
       return <>[]</>;
     }

--- a/crates/compiler/checkmate/www/src/components/Content/index.ts
+++ b/crates/compiler/checkmate/www/src/components/Content/index.ts
@@ -56,8 +56,6 @@ export function contentStyles(desc: TypeDescriptor | undefined): ContentStyles {
       return { name: "ℕ", bg: "bg-lime-400" };
     case "EmptyRecord":
       return { name: "{}", bg: "bg-purple-400" };
-    case "EmptyTuple":
-      return { name: "()", bg: "bg-deep-purple-400" };
     case "EmptyTagUnion":
       return { name: "[]", bg: "bg-cyan-200" };
     case "Error":

--- a/crates/compiler/checkmate/www/src/components/Graph/VariableNode.tsx
+++ b/crates/compiler/checkmate/www/src/components/Graph/VariableNode.tsx
@@ -251,7 +251,6 @@ function VariableNodeContent(
       return {};
     }
     case "EmptyRecord":
-    case "EmptyTuple":
     case "EmptyTagUnion":
     case "Error": {
       return {};

--- a/crates/compiler/checkmate/www/src/schema.d.ts
+++ b/crates/compiler/checkmate/www/src/schema.d.ts
@@ -149,10 +149,6 @@ export type Content =
       [k: string]: unknown;
     }
   | {
-      type: "EmptyTuple";
-      [k: string]: unknown;
-    }
-  | {
       type: "EmptyTagUnion";
       [k: string]: unknown;
     }

--- a/crates/compiler/checkmate_schema/src/lib.rs
+++ b/crates/compiler/checkmate_schema/src/lib.rs
@@ -97,7 +97,6 @@ impl_content! {
         extension: TagUnionExtension,
     },
     EmptyRecord {},
-    EmptyTuple {},
     EmptyTagUnion {},
     RangedNumber {
         range: NumericRange,

--- a/crates/compiler/derive_key/src/decoding.rs
+++ b/crates/compiler/derive_key/src/decoding.rs
@@ -66,9 +66,7 @@ impl FlatDecodable {
                 FlatType::Tuple(elems, ext) => {
                     let (elems_iter, ext) = elems.sorted_iterator_and_ext(subs, ext);
 
-                    check_derivable_ext_var(subs, ext, |ext| {
-                        matches!(ext, Content::Structure(FlatType::EmptyTuple))
-                    })?;
+                    check_derivable_ext_var(subs, ext, |_| false)?;
 
                     Ok(Key(FlatDecodableKey::Tuple(elems_iter.count() as _)))
                 }
@@ -79,7 +77,6 @@ impl FlatDecodable {
                     Err(Underivable) // yet
                 }
                 FlatType::EmptyRecord => Ok(Key(FlatDecodableKey::Record(vec![]))),
-                FlatType::EmptyTuple => todo!(),
                 FlatType::EmptyTagUnion => {
                     Err(Underivable) // yet
                 }

--- a/crates/compiler/derive_key/src/encoding.rs
+++ b/crates/compiler/derive_key/src/encoding.rs
@@ -73,9 +73,7 @@ impl FlatEncodable {
                     let (elems_iter, ext) = elems.sorted_iterator_and_ext(subs, ext);
 
                     // TODO someday we can put #[cfg(debug_assertions)] around this, but for now let's always do it.
-                    check_derivable_ext_var(subs, ext, |ext| {
-                        matches!(ext, Content::Structure(FlatType::EmptyTuple))
-                    })?;
+                    check_derivable_ext_var(subs, ext, |_| false)?;
 
                     Ok(Key(FlatEncodableKey::Tuple(elems_iter.count() as _)))
                 }
@@ -120,7 +118,6 @@ impl FlatEncodable {
                 FlatType::EmptyRecord => Ok(Key(FlatEncodableKey::Record(vec![]))),
                 FlatType::EmptyTagUnion => Ok(Key(FlatEncodableKey::TagUnion(vec![]))),
                 FlatType::Func(..) => Err(Underivable),
-                FlatType::EmptyTuple => unreachable!("Somehow Encoding derivation got an expression that's an empty tuple, which shouldn't be possible!"),
             },
             Content::Alias(sym, _, real_var, _) => match from_builtin_symbol(sym) {
                 Some(lambda) => lambda,

--- a/crates/compiler/derive_key/src/hash.rs
+++ b/crates/compiler/derive_key/src/hash.rs
@@ -70,9 +70,7 @@ impl FlatHash {
                 FlatType::Tuple(elems, ext) => {
                     let (elems_iter, ext) = elems.sorted_iterator_and_ext(subs, ext);
 
-                    check_derivable_ext_var(subs, ext, |ext| {
-                        matches!(ext, Content::Structure(FlatType::EmptyTuple))
-                    })?;
+                    check_derivable_ext_var(subs, ext, |_| false)?;
 
                     Ok(Key(FlatHashKey::Tuple(elems_iter.count() as _)))
                 }
@@ -112,7 +110,6 @@ impl FlatHash {
                         .collect(),
                 ))),
                 FlatType::EmptyRecord => Ok(Key(FlatHashKey::Record(vec![]))),
-                FlatType::EmptyTuple => todo!(),
                 FlatType::EmptyTagUnion => Ok(Key(FlatHashKey::TagUnion(vec![]))),
                 //
                 FlatType::Func(..) => Err(Underivable),

--- a/crates/compiler/derive_key/src/inspect.rs
+++ b/crates/compiler/derive_key/src/inspect.rs
@@ -82,8 +82,8 @@ impl FlatInspectable {
                     let (elems_iter, ext) = elems.sorted_iterator_and_ext(subs, ext);
 
                     // TODO someday we can put #[cfg(debug_assertions)] around this, but for now let's always do it.
-                    check_derivable_ext_var(subs, ext, |ext| {
-                        matches!(ext, Content::Structure(FlatType::EmptyTuple))
+                    check_derivable_ext_var(subs, ext, |_| {
+                        false
                     }).expect("Compiler error: unexpected nonempty ext var when deriving Inspect for tuple");
 
                     Key(FlatInspectableKey::Tuple(elems_iter.count() as _))
@@ -128,26 +128,24 @@ impl FlatInspectable {
                 }
                 FlatType::EmptyRecord => Key(FlatInspectableKey::Record(Vec::new())),
                 FlatType::EmptyTagUnion => Key(FlatInspectableKey::TagUnion(Vec::new())),
-                FlatType::Func(..) => {
-                    Immediate(Symbol::INSPECT_FUNCTION)
-                }
-                FlatType::EmptyTuple => unreachable!("Somehow Inspect derivation got an expression that's an empty tuple, which shouldn't be possible!"),
+                FlatType::Func(..) => Immediate(Symbol::INSPECT_FUNCTION),
             },
             Content::Alias(sym, _, real_var, kind) => match Self::from_builtin_alias(sym) {
                 Some(lambda) => lambda,
 
                 _ => {
                     match kind {
-                        AliasKind::Structural => {
-                            Self::from_var(subs, real_var)
-                        }
+                        AliasKind::Structural => Self::from_var(subs, real_var),
                         // Special case, an unbound `Frac *` will become a `Dec`.
-                        AliasKind::Opaque if matches!(*subs.get_content_without_compacting(real_var), Content::FlexVar(_) | Content::FlexAbleVar(_, _)) => {
+                        AliasKind::Opaque
+                            if matches!(
+                                *subs.get_content_without_compacting(real_var),
+                                Content::FlexVar(_) | Content::FlexAbleVar(_, _)
+                            ) =>
+                        {
                             Immediate(Symbol::INSPECT_DEC)
                         }
-                        AliasKind::Opaque if sym.is_builtin() => {
-                            Self::from_var(subs, real_var)
-                        }
+                        AliasKind::Opaque if sym.is_builtin() => Self::from_var(subs, real_var),
                         AliasKind::Opaque => {
                             // There are two cases in which `Inspect` can be derived for an opaque
                             // type.
@@ -169,7 +167,6 @@ impl FlatInspectable {
                         }
                     }
                 }
-
             },
             Content::RangedNumber(range) => {
                 Self::from_var(subs, range.default_compilation_variable())
@@ -180,7 +177,8 @@ impl FlatInspectable {
             | Content::RigidVar(_)
             | Content::FlexAbleVar(_, _)
             | Content::RigidAbleVar(_, _)
-            | Content::LambdaSet(_) | Content::ErasedLambda => {
+            | Content::LambdaSet(_)
+            | Content::ErasedLambda => {
                 unreachable!("There must have been a bug in the solver, because we're trying to derive Inspect on a non-concrete type.");
             }
         }

--- a/crates/compiler/mono/src/ir.rs
+++ b/crates/compiler/mono/src/ir.rs
@@ -10136,7 +10136,6 @@ fn find_lambda_sets_help(
                     }
                 }
                 FlatType::EmptyRecord => {}
-                FlatType::EmptyTuple => {}
                 FlatType::EmptyTagUnion => {}
             },
             Content::Alias(_, _, actual, _) => {

--- a/crates/compiler/mono/src/layout.rs
+++ b/crates/compiler/mono/src/layout.rs
@@ -2191,7 +2191,7 @@ fn lambda_set_size(subs: &Subs, var: Variable) -> (usize, usize, usize) {
                     }
                     stack.push((ext.var(), depth_any + 1, depth_lset));
                 }
-                FlatType::EmptyRecord | FlatType::EmptyTuple | FlatType::EmptyTagUnion => {}
+                FlatType::EmptyRecord | FlatType::EmptyTagUnion => {}
             },
             Content::FlexVar(_)
             | Content::RigidVar(_)
@@ -3459,7 +3459,6 @@ fn layout_from_flat_type<'a>(
         }
         EmptyTagUnion => cacheable(Ok(Layout::VOID)),
         EmptyRecord => cacheable(Ok(Layout::UNIT)),
-        EmptyTuple => cacheable(Ok(Layout::UNIT)),
     }
 }
 

--- a/crates/compiler/solve/src/ability.rs
+++ b/crates/compiler/solve/src/ability.rs
@@ -613,14 +613,6 @@ trait DerivableVisitor {
     }
 
     #[inline(always)]
-    fn visit_empty_tuple(var: Variable) -> Result<(), NotDerivable> {
-        Err(NotDerivable {
-            var,
-            context: NotDerivableContext::NoContext,
-        })
-    }
-
-    #[inline(always)]
     fn visit_empty_tag_union(var: Variable) -> Result<(), NotDerivable> {
         Err(NotDerivable {
             var,
@@ -786,7 +778,6 @@ trait DerivableVisitor {
                         }
                     }
                     EmptyRecord => Self::visit_empty_record(var)?,
-                    EmptyTuple => Self::visit_empty_tuple(var)?,
                     EmptyTagUnion => Self::visit_empty_tag_union(var)?,
                 },
                 Alias(

--- a/crates/compiler/solve/src/deep_copy.rs
+++ b/crates/compiler/solve/src/deep_copy.rs
@@ -185,7 +185,7 @@ fn deep_copy_var_help(
                         Func(new_arguments, new_closure_var, new_ret_var)
                     }
 
-                    same @ EmptyRecord | same @ EmptyTuple | same @ EmptyTagUnion => same,
+                    same @ EmptyRecord | same @ EmptyTagUnion => same,
 
                     Record(fields, ext_var) => {
                         let record_fields = {

--- a/crates/compiler/solve/src/solve.rs
+++ b/crates/compiler/solve/src/solve.rs
@@ -2184,7 +2184,7 @@ fn adjust_rank_content(
                     rank
                 }
 
-                EmptyRecord | EmptyTuple => {
+                EmptyRecord => {
                     // from elm-compiler: THEORY: an empty record never needs to get generalized
                     //
                     // But for us, that theory does not hold, because there might be type variables hidden

--- a/crates/compiler/types/src/pretty_print.rs
+++ b/crates/compiler/types/src/pretty_print.rs
@@ -16,9 +16,6 @@ pub static WILDCARD: &str = "*";
 static EMPTY_RECORD: &str = "{}";
 static EMPTY_TAG_UNION: &str = "[]";
 
-// TODO: since we technically don't support empty tuples at the source level, this should probably be removed
-static EMPTY_TUPLE: &str = "()";
-
 /// Requirements for parentheses.
 ///
 /// If we're inside a function (that is, this is either an argument or a return
@@ -402,11 +399,7 @@ fn find_names_needed(
                 find_under_alias,
             );
         }
-        Error
-        | Structure(EmptyRecord)
-        | Structure(EmptyTuple)
-        | Structure(EmptyTagUnion)
-        | ErasedLambda => {
+        Error | Structure(EmptyRecord) | Structure(EmptyTagUnion) | ErasedLambda => {
             // Errors and empty records don't need names.
         }
     }
@@ -1113,7 +1106,6 @@ fn write_flat_type<'a>(
             pol,
         ),
         EmptyRecord => buf.push_str(EMPTY_RECORD),
-        EmptyTuple => buf.push_str(EMPTY_TUPLE),
         EmptyTagUnion => buf.push_str(EMPTY_TAG_UNION),
         Func(args, closure, ret) => write_fn(
             env,
@@ -1220,19 +1212,12 @@ fn write_flat_type<'a>(
 
             buf.push_str(" )");
 
-            match subs.get_content_without_compacting(ext_var) {
-                Content::Structure(EmptyTuple) => {
-                    // This is a closed tuple. We're done!
-                }
-                _ => {
-                    // This is an open tuple, so print the variable
-                    // right after the ')'
-                    //
-                    // e.g. the "*" at the end of `( I64, I64 )*`
-                    // or the "r" at the end of `( I64, I64 )r`
-                    write_content(env, ctx, ext_var, subs, buf, parens, pol)
-                }
-            }
+            // This is an open tuple, so print the variable
+            // right after the ')'
+            //
+            // e.g. the "*" at the end of `( I64, I64 )*`
+            // or the "r" at the end of `( I64, I64 )r`
+            write_content(env, ctx, ext_var, subs, buf, parens, pol)
         }
         TagUnion(tags, ext_var) => {
             buf.push('[');

--- a/crates/compiler/types/src/subs.rs
+++ b/crates/compiler/types/src/subs.rs
@@ -815,7 +815,6 @@ fn subs_fmt_flat_type(this: &FlatType, subs: &Subs, f: &mut fmt::Formatter) -> f
             write!(f, "]<{new_ext:?}> as <{rec:?}>")
         }
         FlatType::EmptyRecord => write!(f, "EmptyRecord"),
-        FlatType::EmptyTuple => write!(f, "EmptyTuple"),
         FlatType::EmptyTagUnion => write!(f, "EmptyTagUnion"),
     }
 }
@@ -2512,7 +2511,6 @@ pub enum FlatType {
 
     RecursiveTagUnion(Variable, UnionTags, TagExt),
     EmptyRecord,
-    EmptyTuple,
     EmptyTagUnion,
 }
 
@@ -3409,7 +3407,7 @@ fn occurs(
 
                     short_circuit_help(subs, root_var, ctx, ext_var)
                 }
-                EmptyRecord | EmptyTuple | EmptyTagUnion => Ok(()),
+                EmptyRecord | EmptyTagUnion => Ok(()),
             },
             Alias(_, args, _, _) => {
                 // THEORY: we only need to explore the args, as that is the surface of all
@@ -3599,7 +3597,7 @@ fn explicit_substitute(
                         subs.set_content(in_var, Structure(Tuple(vars_by_elem, new_ext)));
                     }
 
-                    EmptyRecord | EmptyTuple | EmptyTagUnion => {}
+                    EmptyRecord | EmptyTagUnion => {}
                 }
 
                 in_var
@@ -3782,9 +3780,7 @@ fn get_var_names(
                     accum
                 }
 
-                FlatType::EmptyRecord | FlatType::EmptyTuple | FlatType::EmptyTagUnion => {
-                    taken_names
-                }
+                FlatType::EmptyRecord | FlatType::EmptyTagUnion => taken_names,
 
                 FlatType::Record(vars_by_field, ext) => {
                     let mut accum = get_var_names(subs, ext, taken_names);
@@ -4130,7 +4126,6 @@ fn flat_type_to_err_type(
         }
 
         EmptyRecord => ErrorType::Record(SendMap::default(), TypeExt::Closed),
-        EmptyTuple => ErrorType::Tuple(Vec::default(), TypeExt::Closed),
         EmptyTagUnion => ErrorType::TagUnion(SendMap::default(), TypeExt::Closed, pol),
 
         Record(vars_by_field, ext) => {
@@ -4586,7 +4581,6 @@ impl StorageSubs {
                 ext.map(|v| Self::offset_variable(offsets, v)),
             ),
             FlatType::EmptyRecord => FlatType::EmptyRecord,
-            FlatType::EmptyTuple => FlatType::EmptyTuple,
             FlatType::EmptyTagUnion => FlatType::EmptyTagUnion,
         }
     }
@@ -4881,7 +4875,7 @@ fn storage_copy_var_to_help(env: &mut StorageCopyVarToEnv<'_>, var: Variable) ->
                     Func(new_arguments, new_closure_var, new_ret_var)
                 }
 
-                same @ EmptyRecord | same @ EmptyTuple | same @ EmptyTagUnion => same,
+                same @ EmptyRecord | same @ EmptyTagUnion => same,
 
                 Record(fields, ext) => {
                     let record_fields = {
@@ -5351,7 +5345,7 @@ fn copy_import_to_help(env: &mut CopyImportEnv<'_>, max_rank: Rank, var: Variabl
                     Func(new_arguments, new_closure_var, new_ret_var)
                 }
 
-                same @ EmptyRecord | same @ EmptyTuple | same @ EmptyTagUnion => same,
+                same @ EmptyRecord | same @ EmptyTagUnion => same,
 
                 Record(fields, ext) => {
                     let record_fields = {
@@ -5729,7 +5723,7 @@ fn instantiate_rigids_help(subs: &mut Subs, max_rank: Rank, initial: Variable) {
                     stack.push(closure_var);
                 }
 
-                EmptyRecord | EmptyTuple | EmptyTagUnion => (),
+                EmptyRecord | EmptyTagUnion => (),
 
                 Record(fields, ext) => {
                     let fields = *fields;
@@ -5880,7 +5874,7 @@ pub fn get_member_lambda_sets_at_region(subs: &Subs, var: Variable, target_regio
                     );
                     stack.push(ext.var());
                 }
-                FlatType::EmptyRecord | FlatType::EmptyTuple | FlatType::EmptyTagUnion => {}
+                FlatType::EmptyRecord | FlatType::EmptyTagUnion => {}
             },
             Content::Alias(_, _, real_var, _) => {
                 stack.push(*real_var);
@@ -5955,7 +5949,6 @@ fn is_inhabited(subs: &Subs, var: Variable) -> bool {
                 }
                 FlatType::FunctionOrTagUnion(_, _, _) => {}
                 FlatType::EmptyRecord => {}
-                FlatType::EmptyTuple => {}
                 FlatType::EmptyTagUnion => {
                     return false;
                 }

--- a/crates/glue/src/load.rs
+++ b/crates/glue/src/load.rs
@@ -318,7 +318,6 @@ fn number_lambda_sets(subs: &Subs, initial: Variable) -> Vec<Variable> {
 
                 EmptyRecord => (),
                 EmptyTagUnion => (),
-                EmptyTuple => (),
 
                 Record(fields, ext) => {
                     let fields = *fields;

--- a/crates/glue/src/types.rs
+++ b/crates/glue/src/types.rs
@@ -1424,9 +1424,6 @@ fn add_type_help<'a>(
         Content::Structure(FlatType::EmptyRecord) => {
             types.add_anonymous(&env.layout_cache.interner, RocType::Unit, layout)
         }
-        Content::Structure(FlatType::EmptyTuple) => {
-            types.add_anonymous(&env.layout_cache.interner, RocType::Unit, layout)
-        }
         Content::Structure(FlatType::EmptyTagUnion) => {
             types.add_anonymous(&env.layout_cache.interner, RocType::EmptyTagUnion, layout)
         }


### PR DESCRIPTION
Remove a variant of `FlatType` that I noticed was unused.