### PR TITLE
Fix typos in creates/glue/README.md

### DIFF
--- a/crates/glue/README.md
+++ b/crates/glue/README.md
@@ -1,10 +1,10 @@
 # Glue
 
-Glue is a bit of tooling built into Roc to help with platform development. Roc platforms are written in a different language than Roc, and some it requires some finesse to let other languages to read and write Roc types like records and unions in a way compatible with how Roc uses those types.
+Glue is a bit of tooling built into Roc to help with platform development. Roc platforms are written in a different language than Roc, and it requires some finesse to let other languages read and write Roc types like records and unions in a way that's compatible with how Roc uses those types.
 
 The `roc glue` command generates code in other languages for interacting with the Roc types used by your platform. It takes three arguments:
 
-1. A 'glue spec', this is a Roc file specifying how to output type helpers fora particular language. You can find some examples in the src/ subdirectory:
+1. A 'glue spec', this is a Roc file specifying how to output type helpers for a particular language. You can find some examples in the src/ subdirectory:
 
     - **RustGlue.roc:** Generates Roc bindings for rust platforms.
     - **ZigGlue.roc:** Generates Roc bindings for zig platforms (out of date).


### PR DESCRIPTION
Addresses a couple of review comments from @tannerntannern and @lishaduck on #7174 that I didn't address before merge.