### PR TITLE
Added search by signature in docs

### DIFF
--- a/crates/docs/src/static/index.html
+++ b/crates/docs/src/static/index.html
@@ -19,9 +19,6 @@
 
 <body>
     <nav id="sidebar-nav">
-        <input id="module-search" aria-labelledby="search-link" type="text" placeholder="Search" />
-        <label for="module-search" id="search-link"><span id="search-link-text">Search</span> <span
-                id="search-link-hint">(press <span id="search-shortcut-key">s</span>)</span></label>
         <div class="module-links">
             <!-- Module links -->
         </div>
@@ -41,6 +38,23 @@
             </a>
             <!-- Package Name -->
         </div>
+        <form id="module-search-form">
+            <input
+                id="module-search"
+                aria-labelledby="search-link"
+                type="text"
+                placeholder="Search"
+                role="combobox"
+                aria-autocomplete="list"
+                aria-expanded="false"
+                aria-controls="search-type-ahead"
+            />
+            <label for="module-search" id="search-link">Search (press s)</label>
+            <span id="search-shortcut-key" aria-hidden="true">s</span>
+            <ul id="search-type-ahead" role="listbox" aria-label="Search Results" class="hidden">
+                <!-- Search Type Ahead -->
+            </ul>
+        </form>
         <div class="top-header-triangle">
             <!-- if the window gets big, this extends the purple bar on the top header to the left edge of the window -->
         </div>

--- a/crates/docs/src/static/styles.css
+++ b/crates/docs/src/static/styles.css
@@ -24,6 +24,9 @@
       monospace;
   --top-header-height: 67px;
   --sidebar-width: 280px;
+  --module-search-height: 48px;
+  --module-search-padding-height: 12px;
+  --module-search-form-padding-width: 20px;
 }
 
 a {
@@ -439,46 +442,99 @@ pre>samp {
   display: none !important;
 }
 
-#module-search:placeholder-shown {
-  padding: 0;
-  opacity: 0;
-  height: 0;
+#module-search-form {
+  display: flex;
+  align-items: center;
+  align-content: center;
+  height: 100%;
+  background-color: var(--violet-bg);
+  position: relative;
+  max-width: 500px;
+  flex-grow: 1;
+  box-sizing: border-box;
+  padding: 0px var(--module-search-form-padding-width);
 }
 
 #module-search,
 #module-search:focus {
   opacity: 1;
   padding: 12px 16px;
-  height: 48px;
-}
-
-/* Show the "Search" label link when the text input has a placeholder */
-#module-search:placeholder-shown + #search-link {
-  display: flex;
-}
-
-/* Hide the "Search" label link when the text input has focus */
-#module-search:focus + #search-link {
-  display: none;
+  height: var(--module-search-height);
 }
 
 #module-search {
   display: block;
+  position: relative;
   box-sizing: border-box;
   width: 100%;
   box-sizing: border-box;
   font-size: 18px;
   line-height: 18px;
-  margin-top: 6px;
   border: none;
   color: var(--faded-color);
-  background-color: var(--code-bg);
+  background-color: var(--body-bg-color);
   font-family: var(--font-serif);
 }
 
 #module-search::placeholder {
   color: var(--faded-color);
   opacity: 1;
+}
+
+#module-search-form:focus-within #search-type-ahead {
+  display: flex;
+  gap: 20px;
+  flex-direction: column;
+  position: absolute;
+  top: calc(var(--module-search-padding-height) + var(--module-search-height));
+  left: var(--module-search-form-padding-width);
+  width: calc(100% - 2 * var(--module-search-form-padding-width));
+}
+
+#search-type-ahead {
+  box-sizing: border-box;
+  display: none;
+  z-index: 100;
+  background-color: var(--body-bg-color);
+  border-width: 1px;
+  border-style: solid;
+  border-color: var(--border-color);
+  list-style-type: none;
+  margin: 0;
+  padding: 10px;
+}
+
+#search-type-ahead .type-ahead-link {
+  font-size: 0.875rem;
+  color: var(--text-color);
+  p {
+    margin: 0px;
+  }
+
+  p.type-ahead-def-name {
+    color: var(--violet);
+    font-size: 1rem;
+  }
+  p.type-ahead-doc-path {
+    font-size: 0.75rem;
+    color: var(--faded-color);
+  }
+}
+#search-type-ahead li {
+  box-sizing: border-box;
+  padding: 4px;
+}
+
+/*use browser defaults for focus outline*/
+#search-type-ahead li:focus-within {
+  /*firefox*/
+  outline: 5px auto Highlight;
+  /*chrome and safari*/
+  outline: 5px auto -webkit-focus-ring-color;
+}
+
+.type-ahead-link:focus-visible {
+  outline: none;
 }
 
 #search-link {
@@ -492,21 +548,16 @@ pre>samp {
   cursor: pointer;
 }
 
-#search-link:hover #search-link-text {
-  text-decoration: underline;
-}
-
-#search-link-hint {
-  margin-left: 1em;
-  opacity: 0.6;
-}
-
 #search-shortcut-key {
   font-family: monospace;
   border: 1px solid #666;
+  border-radius: 5px;
   padding: 1px 3px 3px;
   font-style: normal;
   line-height: 15px;
+  opacity: 0.6;
+  position: absolute;
+  right: 30px;
 }
 
 .builtins-tip {
@@ -546,7 +597,11 @@ pre>samp {
 }
 
 @media only screen and (max-device-width: 480px) and (orientation: portrait) {
-  #search-link-hint {
+  :root {
+      --top-header-height: 140px;
+  }
+
+  #search-shortcut-key {
       display: none;
   }
 
@@ -555,8 +610,9 @@ pre>samp {
   }
 
   .top-header {
+      flex-direction: column;
+      height: auto;
       justify-content: space-between;
-      width: auto;
       /* min-width must be set to something (even 0) for text-overflow: ellipsis to work in descendants. */
       min-width: 0;
   }


### PR DESCRIPTION
closes roc-lang/roc#6540

I use this [example from w3.org](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/examples/combobox-autocomplete-list/) to help with the Aria labeling on the search type ahead.

![light mode](https://github.com/user-attachments/assets/a5754d09-ed38-4c15-a3b1-8a4d2c53b05d)


![dark mode](https://github.com/user-attachments/assets/fa0ed0fc-d0de-4508-8660-c47e1909fff9)
