### PR TITLE
Fixed broken link for doc search on ios

### DIFF
--- a/crates/docs/src/static/styles.css
+++ b/crates/docs/src/static/styles.css
@@ -481,7 +481,7 @@ pre>samp {
   opacity: 1;
 }
 
-#module-search-form:focus-within #search-type-ahead {
+#search-type-ahead {
   display: flex;
   gap: 20px;
   flex-direction: column;
@@ -489,11 +489,7 @@ pre>samp {
   top: calc(var(--module-search-padding-height) + var(--module-search-height));
   left: var(--module-search-form-padding-width);
   width: calc(100% - 2 * var(--module-search-form-padding-width));
-}
-
-#search-type-ahead {
   box-sizing: border-box;
-  display: none;
   z-index: 100;
   background-color: var(--body-bg-color);
   border-width: 1px;


### PR DESCRIPTION
This fixes the link no working on search results on ios.

Seems like ios's focus-within event doesn't work quite right so I changed the css so it doesn't use it.
