### PR TITLE
Unify import params on copied variable

### DIFF
--- a/crates/cli/tests/cli_run.rs
+++ b/crates/cli/tests/cli_run.rs
@@ -924,6 +924,21 @@ mod cli_run {
 
     #[test]
     #[cfg_attr(windows, ignore)]
+    fn module_params_different_types() {
+        test_roc_app(
+            "crates/cli/tests/module_params",
+            "different_types.roc",
+            &["42"],
+            &[],
+            &[],
+            "Write something:\n42\n",
+            UseValgrind::No,
+            TestCliCommands::Run,
+        );
+    }
+
+    #[test]
+    #[cfg_attr(windows, ignore)]
     fn module_params_multiline_pattern() {
         test_roc_app(
             "crates/cli/tests/module_params",

--- a/crates/cli/tests/cli_run.rs
+++ b/crates/cli/tests/cli_run.rs
@@ -939,6 +939,21 @@ mod cli_run {
 
     #[test]
     #[cfg_attr(windows, ignore)]
+    fn module_params_issue_7116() {
+        test_roc_app(
+            "crates/cli/tests/module_params",
+            "issue_7116.roc",
+            &[],
+            &[],
+            &[],
+            "",
+            UseValgrind::No,
+            TestCliCommands::Run,
+        );
+    }
+
+    #[test]
+    #[cfg_attr(windows, ignore)]
     fn module_params_multiline_pattern() {
         test_roc_app(
             "crates/cli/tests/module_params",

--- a/crates/cli/tests/module_params/Alias.roc
+++ b/crates/cli/tests/module_params/Alias.roc
@@ -1,0 +1,3 @@
+module { passed } -> [exposed]
+
+exposed = passed

--- a/crates/cli/tests/module_params/different_types.roc
+++ b/crates/cli/tests/module_params/different_types.roc
@@ -1,0 +1,14 @@
+app [main] {
+    cli: platform "https://github.com/roc-lang/basic-cli/releases/download/0.15.0/SlwdbJ-3GR7uBWQo6zlmYWNYOxnvo8r6YABXD-45UOw.tar.br",
+}
+
+import cli.Stdout
+import cli.Stdin
+
+import Alias { passed: Stdin.line } as In
+import Alias { passed: Stdout.line } as Out
+
+main =
+    Out.exposed! "Write something:"
+    input = In.exposed!
+    Out.exposed! input

--- a/crates/cli/tests/module_params/issue_7116.roc
+++ b/crates/cli/tests/module_params/issue_7116.roc
@@ -1,0 +1,11 @@
+app [main] {
+    cli: platform "https://github.com/roc-lang/basic-cli/releases/download/0.15.0/SlwdbJ-3GR7uBWQo6zlmYWNYOxnvo8r6YABXD-45UOw.tar.br",
+}
+
+import Alias { passed: Task.ok {} }
+
+main =
+    Task.loop! {} loop
+
+loop = \{} ->
+    Task.map Alias.exposed \x -> Done x


### PR DESCRIPTION
When a module depends on another one with params, we copy the params' variable of the latter into the former, which we later use to unify against the record expression in the `import`. However, we were using a single copy of the variable for all imports of a given module which can cause the expected type to become more restricted than it really is.

We didn't have a general issue for this problem, but this fixes #7116 which is related.