### PR TITLE
Fix imports in expects 

### DIFF
--- a/crates/cli/tests/cli_run.rs
+++ b/crates/cli/tests/cli_run.rs
@@ -943,6 +943,21 @@ mod cli_run {
 
     #[test]
     #[cfg_attr(windows, ignore)]
+    fn import_in_expect() {
+        test_roc_expect(
+            "crates/cli/tests/module_params",
+            "ImportInExpect.roc",
+            &[],
+            indoc!(
+                r#"
+                0 failed and 3 passed in <ignored for test> ms.
+                "#
+            ),
+        );
+    }
+
+    #[test]
+    #[cfg_attr(windows, ignore)]
     fn transitive_expects() {
         test_roc_expect(
             "crates/cli/tests/expects_transitive",

--- a/crates/cli/tests/module_params/ImportInExpect.roc
+++ b/crates/cli/tests/module_params/ImportInExpect.roc
@@ -1,0 +1,15 @@
+module []
+
+https = \url -> "https://$(url)"
+
+expect
+    import Api { appId: "one", protocol: https }
+    Api.baseUrl == "https://api.example.com/one"
+
+expect
+    import Api { appId: "two", protocol: https }
+    Api.getUser 1 == "https://api.example.com/two/users/1"
+
+expect
+    import NoParams
+    NoParams.hello == "hello!"

--- a/crates/cli/tests/module_params/NoParams.roc
+++ b/crates/cli/tests/module_params/NoParams.roc
@@ -1,0 +1,3 @@
+module [hello]
+
+hello = "hello!"

--- a/crates/compiler/mono/src/ir.rs
+++ b/crates/compiler/mono/src/ir.rs
@@ -2482,6 +2482,9 @@ fn from_can_let<'a>(
 
                 lower_rest!(variable, cont.value)
             }
+            ImportParams(_, _, None) => {
+                lower_rest!(variable, cont.value)
+            }
             Var(original, _) | AbilityMember(original, _, _)
                 if procs.get_partial_proc(original).is_none() =>
             {


### PR DESCRIPTION
During canonicalization, we create `ImportParams` expressions for all imports even none are supplied. This allows us to provide nice error messages during type checking if they're missing.

For nested defs and expects however, these would make it to mono where we would crash if we found them. We'll now drop them there.

Closes #7025