### PR TITLE
Improve experience for unhandled parse errors

### DIFF
--- a/crates/compiler/load/tests/test_reporting.rs
+++ b/crates/compiler/load/tests/test_reporting.rs
@@ -5821,6 +5821,36 @@ mod test_reporting {
     "#
     );
 
+    test_report!(
+        unhandled_parse_error,
+        indoc!(
+            r#"
+            app "test" provides [main] to "./platform"
+
+            42
+            "#
+        ),
+        @r#"
+    ── UNHANDLED PARSE ERROR in tmp/unhandled_parse_error/Test.roc ─────────────────
+
+    I got stuck while parsing this:
+
+    1│  app "test" provides [main] to "./platform"
+    2│
+    3│  42
+        ^
+
+    Here's the internal parse problem:
+
+        UnexpectedTopLevelExpr(@44)
+
+    Unfortunately, I'm not able to provide a more insightful error message
+    for this syntax problem yet. This is considered a bug in the compiler.
+
+    Note: If you'd like to contribute to Roc, this would be a good first issue!
+    "#
+    );
+
     // https://github.com/roc-lang/roc/issues/1714
     test_report!(
     interpolate_concat_is_transparent_1714,

--- a/crates/reporting/src/error/parse.rs
+++ b/crates/reporting/src/error/parse.rs
@@ -703,8 +703,8 @@ fn to_expr_report<'a>(
         EExpr::Return(EReturn::Space(parse_problem, pos), _) => {
             to_space_report(alloc, lines, filename, parse_problem, *pos)
         }
-        // If you're adding or changing syntax, please handle the case with a good error message
-        // above instead of adding more unhandled cases below.
+        // If you're adding or changing syntax, please handle the case with a
+        // good error message above instead of adding more unhandled cases below.
         EExpr::End(pos)
         | EExpr::Dot(pos)
         | EExpr::Access(pos)
@@ -2256,6 +2256,8 @@ fn to_pattern_report<'a>(
         &EPattern::NumLiteral(ENumber::End, pos) => {
             to_malformed_number_literal_report(alloc, lines, filename, pos)
         }
+        // If you're adding or changing syntax, please handle the case with a
+        // good error message above instead of adding more unhandled cases below.
         EPattern::AsKeyword(pos)
         | EPattern::AsIdentifier(pos)
         | EPattern::Underscore(pos)
@@ -2780,17 +2782,23 @@ fn to_type_report<'a>(
                 severity,
             }
         }
-
-        EType::Space(_, _)
-        | EType::UnderscoreSpacing(_)
-        | EType::TWildcard(_)
-        | EType::TInferred(_)
-        | EType::TEnd(_)
-        | EType::TWhereBar(_)
-        | EType::TImplementsClause(_)
-        | EType::TAbilityImpl(_, _) => {
-            todo!("unhandled type parse error: {:?}", &parse_problem)
-        }
+        // If you're adding or changing syntax, please handle the case with a
+        // good error message above instead of adding more unhandled cases below.
+        EType::Space(_, pos)
+        | EType::UnderscoreSpacing(pos)
+        | EType::TWildcard(pos)
+        | EType::TInferred(pos)
+        | EType::TEnd(pos)
+        | EType::TWhereBar(pos)
+        | EType::TImplementsClause(pos)
+        | EType::TAbilityImpl(_, pos) => to_unhandled_parse_error_report(
+            alloc,
+            lines,
+            filename,
+            format!("{:?}", parse_problem),
+            *pos,
+            start,
+        ),
     }
 }
 

--- a/crates/reporting/src/error/parse.rs
+++ b/crates/reporting/src/error/parse.rs
@@ -3949,11 +3949,12 @@ fn to_provides_report<'a>(
                 severity,
             }
         }
-        EProvides::Open(_) |
-        EProvides::To(_) |
-        EProvides::IndentPackage(_) |
-        EProvides::ListStart(_) |
-        EProvides::Package(_, _) => todo!("unhandled parse error {:?}", parse_problem)
+        EProvides::Open(pos) |
+        EProvides::To(pos) |
+        EProvides::IndentPackage(pos) |
+        EProvides::ListStart(pos) |
+        EProvides::Package(_, pos) =>
+            to_unhandled_parse_error_report(alloc, lines, filename, format!("{:?}", parse_problem), pos, start),
     }
 }
 

--- a/crates/reporting/src/error/parse.rs
+++ b/crates/reporting/src/error/parse.rs
@@ -4484,7 +4484,16 @@ fn to_space_report<'a>(
             }
         }
 
-        BadInputError::BadUtf8 => todo!("unhandled type parse error: {:?}", &parse_problem),
+        // If you're adding or changing syntax, please handle the case with a
+        // good error message above instead of adding more unhandled cases below.
+        BadInputError::BadUtf8 => to_unhandled_parse_error_report(
+            alloc,
+            lines,
+            filename,
+            format!("{:?}", parse_problem),
+            pos,
+            pos,
+        ),
     }
 }
 

--- a/crates/reporting/src/error/parse.rs
+++ b/crates/reporting/src/error/parse.rs
@@ -4401,12 +4401,21 @@ fn to_packages_report<'a>(
 
         EPackages::Space(error, pos) => to_space_report(alloc, lines, filename, &error, pos),
 
-        EPackages::Open(_)
-        | EPackages::IndentPackages(_)
-        | EPackages::ListStart(_)
-        | EPackages::IndentListStart(_)
-        | EPackages::IndentListEnd(_)
-        | EPackages::PackageEntry(_, _) => todo!("unhandled parse error {:?}", parse_problem),
+        // If you're adding or changing syntax, please handle the case with a
+        // good error message above instead of adding more unhandled cases below.
+        EPackages::Open(pos)
+        | EPackages::IndentPackages(pos)
+        | EPackages::ListStart(pos)
+        | EPackages::IndentListStart(pos)
+        | EPackages::IndentListEnd(pos)
+        | EPackages::PackageEntry(_, pos) => to_unhandled_parse_error_report(
+            alloc,
+            lines,
+            filename,
+            format!("{:?}", parse_problem),
+            pos,
+            start,
+        ),
     }
 }
 

--- a/crates/reporting/src/error/parse.rs
+++ b/crates/reporting/src/error/parse.rs
@@ -4178,21 +4178,26 @@ fn to_imports_report<'a>(
             }
         }
 
-        EImports::Open(_)
-        | EImports::IndentListStart(_)
-        | EImports::IndentListEnd(_)
-        | EImports::ListStart(_)
-        | EImports::ExposingDot(_)
-        | EImports::ShorthandDot(_)
-        | EImports::Shorthand(_)
-        | EImports::IndentSetStart(_)
-        | EImports::SetStart(_)
-        | EImports::SetEnd(_)
-        | EImports::TypedIdent(_)
-        | EImports::AsKeyword(_)
-        | EImports::StrLiteral(_) => {
-            todo!("unhandled parse error {:?}", parse_problem)
-        }
+        EImports::Open(pos)
+        | EImports::IndentListStart(pos)
+        | EImports::IndentListEnd(pos)
+        | EImports::ListStart(pos)
+        | EImports::ExposingDot(pos)
+        | EImports::ShorthandDot(pos)
+        | EImports::Shorthand(pos)
+        | EImports::IndentSetStart(pos)
+        | EImports::SetStart(pos)
+        | EImports::SetEnd(pos)
+        | EImports::TypedIdent(pos)
+        | EImports::AsKeyword(pos)
+        | EImports::StrLiteral(pos) => to_unhandled_parse_error_report(
+            alloc,
+            lines,
+            filename,
+            format!("{:?}", parse_problem),
+            pos,
+            start,
+        ),
     }
 }
 

--- a/crates/reporting/src/error/parse.rs
+++ b/crates/reporting/src/error/parse.rs
@@ -148,7 +148,9 @@ fn to_syntax_report<'a>(
             Position::default(),
         ),
         Header(header) => to_header_report(alloc, lines, filename, header, Position::default()),
-        _ => todo!("unhandled parse error: {:?}", parse_problem),
+        InvalidPattern | BadUtf8 | ReservedKeyword(_) | NotYetImplemented(_) | Todo | Space(_) => {
+            todo!("unhandled parse error: {:?}", parse_problem)
+        }
     }
 }
 
@@ -701,7 +703,30 @@ fn to_expr_report<'a>(
         EExpr::Return(EReturn::Space(parse_problem, pos), _) => {
             to_space_report(alloc, lines, filename, parse_problem, *pos)
         }
-        _ => todo!("unhandled parse error: {:?}", parse_problem),
+        EExpr::End(_)
+        | EExpr::Dot(_)
+        | EExpr::Access(_)
+        | EExpr::UnaryNot(_)
+        | EExpr::UnaryNegate(_)
+        | EExpr::Pattern(_, _)
+        | EExpr::IndentDefBody(_)
+        | EExpr::IndentEquals(_)
+        | EExpr::IndentAnnotation(_)
+        | EExpr::Equals(_)
+        | EExpr::DoubleColon(_)
+        | EExpr::MalformedPattern(_)
+        | EExpr::BackpassComma(_)
+        | EExpr::BackpassContinue(_)
+        | EExpr::DbgContinue(_)
+        | EExpr::Underscore(_)
+        | EExpr::Crash(_)
+        | EExpr::Try(_)
+        | EExpr::RecordUpdateOldBuilderField(_)
+        | EExpr::RecordUpdateIgnoredField(_)
+        | EExpr::RecordBuilderOldBuilderField(_)
+        | EExpr::UnexpectedTopLevelExpr(_) => {
+            todo!("unhandled parse error: {:?}", parse_problem)
+        }
     }
 }
 
@@ -2188,7 +2213,17 @@ fn to_pattern_report<'a>(
         &EPattern::NumLiteral(ENumber::End, pos) => {
             to_malformed_number_literal_report(alloc, lines, filename, pos)
         }
-        _ => todo!("unhandled parse error: {:?}", parse_problem),
+        EPattern::AsKeyword(_)
+        | EPattern::AsIdentifier(_)
+        | EPattern::Underscore(_)
+        | EPattern::NotAPattern(_)
+        | EPattern::End(_)
+        | EPattern::Space(_, _)
+        | EPattern::IndentStart(_)
+        | EPattern::IndentEnd(_)
+        | EPattern::AsIndentStart(_)
+        | EPattern::AccessorFunction(_)
+        | EPattern::RecordUpdaterFunction(_) => todo!("unhandled parse error: {:?}", parse_problem),
     }
 }
 
@@ -2597,7 +2632,7 @@ fn to_type_report<'a>(
                         severity,
                     }
                 }
-                _ => todo!(),
+                Next::Other(_) | Next::Keyword(_) | Next::Close(_, _) | Next::Token(_) => todo!(),
             }
         }
 
@@ -2696,7 +2731,16 @@ fn to_type_report<'a>(
             }
         }
 
-        _ => todo!("unhandled type parse error: {:?}", &parse_problem),
+        EType::Space(_, _)
+        | EType::UnderscoreSpacing(_)
+        | EType::TWildcard(_)
+        | EType::TInferred(_)
+        | EType::TEnd(_)
+        | EType::TWhereBar(_)
+        | EType::TImplementsClause(_)
+        | EType::TAbilityImpl(_, _) => {
+            todo!("unhandled type parse error: {:?}", &parse_problem)
+        }
     }
 }
 
@@ -3847,8 +3891,11 @@ fn to_provides_report<'a>(
                 severity,
             }
         }
-
-        _ => todo!("unhandled parse error {:?}", parse_problem),
+        EProvides::Open(_) |
+        EProvides::To(_) |
+        EProvides::IndentPackage(_) |
+        EProvides::ListStart(_) |
+        EProvides::Package(_, _) => todo!("unhandled parse error {:?}", parse_problem)
     }
 }
 
@@ -3959,7 +4006,10 @@ fn to_exposes_report<'a>(
 
         EExposes::Space(error, pos) => to_space_report(alloc, lines, filename, &error, pos),
 
-        _ => todo!("unhandled `exposes` parsing error {:?}", parse_problem),
+        EExposes::Open(_) |
+        EExposes::IndentExposes(_) |
+        EExposes::IndentListStart(_) |
+        EExposes::ListStart(_) => todo!("unhandled `exposes` parsing error {:?}", parse_problem),
     }
 }
 
@@ -4068,7 +4118,21 @@ fn to_imports_report<'a>(
             }
         }
 
-        _ => todo!("unhandled parse error {:?}", parse_problem),
+        EImports::Open(_)
+        | EImports::IndentListStart(_)
+        | EImports::IndentListEnd(_)
+        | EImports::ListStart(_)
+        | EImports::ExposingDot(_)
+        | EImports::ShorthandDot(_)
+        | EImports::Shorthand(_)
+        | EImports::IndentSetStart(_)
+        | EImports::SetStart(_)
+        | EImports::SetEnd(_)
+        | EImports::TypedIdent(_)
+        | EImports::AsKeyword(_)
+        | EImports::StrLiteral(_) => {
+            todo!("unhandled parse error {:?}", parse_problem)
+        }
     }
 }
 
@@ -4194,7 +4258,9 @@ fn to_requires_report<'a>(
             }
         }
 
-        _ => todo!("unhandled parse error {:?}", parse_problem),
+        ERequires::IndentRequires(_)
+        | ERequires::IndentListStart(_)
+        | ERequires::TypedIdent(_, _) => todo!("unhandled parse error {:?}", parse_problem),
     }
 }
 
@@ -4257,7 +4323,12 @@ fn to_packages_report<'a>(
 
         EPackages::Space(error, pos) => to_space_report(alloc, lines, filename, &error, pos),
 
-        _ => todo!("unhandled parse error {:?}", parse_problem),
+        EPackages::Open(_)
+        | EPackages::IndentPackages(_)
+        | EPackages::ListStart(_)
+        | EPackages::IndentListStart(_)
+        | EPackages::IndentListEnd(_)
+        | EPackages::PackageEntry(_, _) => todo!("unhandled parse error {:?}", parse_problem),
     }
 }
 
@@ -4326,7 +4397,7 @@ fn to_space_report<'a>(
             }
         }
 
-        _ => todo!("unhandled type parse error: {:?}", &parse_problem),
+        BadInputError::BadUtf8 => todo!("unhandled type parse error: {:?}", &parse_problem),
     }
 }
 

--- a/crates/reporting/src/error/parse.rs
+++ b/crates/reporting/src/error/parse.rs
@@ -723,16 +723,21 @@ fn to_expr_report<'a>(
         | EExpr::Underscore(pos)
         | EExpr::Crash(pos)
         | EExpr::Try(pos)
-        | EExpr::UnexpectedTopLevelExpr(pos) => {
-            to_unhandled_parse_error_report(alloc, lines, filename, parse_problem, *pos, start)
-        }
+        | EExpr::UnexpectedTopLevelExpr(pos) => to_unhandled_parse_error_report(
+            alloc,
+            lines,
+            filename,
+            format!("{:?}", parse_problem),
+            *pos,
+            start,
+        ),
         EExpr::RecordUpdateOldBuilderField(region)
         | EExpr::RecordUpdateIgnoredField(region)
         | EExpr::RecordBuilderOldBuilderField(region) => to_unhandled_parse_error_report(
             alloc,
             lines,
             filename,
-            parse_problem,
+            format!("{:?}", parse_problem),
             region.start(),
             start,
         ),
@@ -743,7 +748,7 @@ fn to_unhandled_parse_error_report<'a>(
     alloc: &'a RocDocAllocator<'a>,
     lines: &LineInfo,
     filename: PathBuf,
-    parse_problem: &roc_parse::parser::EExpr<'a>,
+    parse_problem_str: String,
     pos: Position,
     start: Position,
 ) -> Report<'a> {
@@ -755,7 +760,7 @@ fn to_unhandled_parse_error_report<'a>(
         alloc.reflow("I got stuck while parsing this:"),
         alloc.region_with_subregion(lines.convert_region(surroundings), region, severity),
         alloc.reflow("Here's the internal parse problem:"),
-        alloc.text(format!("{:?}", parse_problem)).indent(4),
+        alloc.string(parse_problem_str).indent(4),
         alloc.reflow("Unfortunately, I'm not able to provide a more insightful error message for this syntax problem yet. This is considered a bug in the compiler."),
         alloc.note("If you'd like to contribute to Roc, this would be a good first issue!")
     ]);
@@ -2251,17 +2256,24 @@ fn to_pattern_report<'a>(
         &EPattern::NumLiteral(ENumber::End, pos) => {
             to_malformed_number_literal_report(alloc, lines, filename, pos)
         }
-        EPattern::AsKeyword(_)
-        | EPattern::AsIdentifier(_)
-        | EPattern::Underscore(_)
-        | EPattern::NotAPattern(_)
-        | EPattern::End(_)
-        | EPattern::Space(_, _)
-        | EPattern::IndentStart(_)
-        | EPattern::IndentEnd(_)
-        | EPattern::AsIndentStart(_)
-        | EPattern::AccessorFunction(_)
-        | EPattern::RecordUpdaterFunction(_) => todo!("unhandled parse error: {:?}", parse_problem),
+        EPattern::AsKeyword(pos)
+        | EPattern::AsIdentifier(pos)
+        | EPattern::Underscore(pos)
+        | EPattern::NotAPattern(pos)
+        | EPattern::End(pos)
+        | EPattern::Space(_, pos)
+        | EPattern::IndentStart(pos)
+        | EPattern::IndentEnd(pos)
+        | EPattern::AsIndentStart(pos)
+        | EPattern::AccessorFunction(pos)
+        | EPattern::RecordUpdaterFunction(pos) => to_unhandled_parse_error_report(
+            alloc,
+            lines,
+            filename,
+            format!("{:?}", parse_problem),
+            *pos,
+            start,
+        ),
     }
 }
 

--- a/crates/reporting/src/error/parse.rs
+++ b/crates/reporting/src/error/parse.rs
@@ -4065,10 +4065,11 @@ fn to_exposes_report<'a>(
 
         EExposes::Space(error, pos) => to_space_report(alloc, lines, filename, &error, pos),
 
-        EExposes::Open(_) |
-        EExposes::IndentExposes(_) |
-        EExposes::IndentListStart(_) |
-        EExposes::ListStart(_) => todo!("unhandled `exposes` parsing error {:?}", parse_problem),
+        EExposes::Open(pos) |
+        EExposes::IndentExposes(pos) |
+        EExposes::IndentListStart(pos) |
+        EExposes::ListStart(pos) =>
+            to_unhandled_parse_error_report(alloc, lines, filename, format!("{:?}", parse_problem), pos, start)
     }
 }
 

--- a/crates/reporting/src/error/parse.rs
+++ b/crates/reporting/src/error/parse.rs
@@ -3949,6 +3949,8 @@ fn to_provides_report<'a>(
                 severity,
             }
         }
+        // If you're adding or changing syntax, please handle the case with a
+        // good error message above instead of adding more unhandled cases below.
         EProvides::Open(pos) |
         EProvides::To(pos) |
         EProvides::IndentPackage(pos) |
@@ -4065,6 +4067,8 @@ fn to_exposes_report<'a>(
 
         EExposes::Space(error, pos) => to_space_report(alloc, lines, filename, &error, pos),
 
+        // If you're adding or changing syntax, please handle the case with a
+        // good error message above instead of adding more unhandled cases below.
         EExposes::Open(pos) |
         EExposes::IndentExposes(pos) |
         EExposes::IndentListStart(pos) |
@@ -4177,7 +4181,8 @@ fn to_imports_report<'a>(
                 severity,
             }
         }
-
+        // If you're adding or changing syntax, please handle the case with a
+        // good error message above instead of adding more unhandled cases below.
         EImports::Open(pos)
         | EImports::IndentListStart(pos)
         | EImports::IndentListEnd(pos)
@@ -4322,10 +4327,18 @@ fn to_requires_report<'a>(
                 severity,
             }
         }
-
-        ERequires::IndentRequires(_)
-        | ERequires::IndentListStart(_)
-        | ERequires::TypedIdent(_, _) => todo!("unhandled parse error {:?}", parse_problem),
+        // If you're adding or changing syntax, please handle the case with a
+        // good error message above instead of adding more unhandled cases below.
+        ERequires::IndentRequires(pos)
+        | ERequires::IndentListStart(pos)
+        | ERequires::TypedIdent(_, pos) => to_unhandled_parse_error_report(
+            alloc,
+            lines,
+            filename,
+            format!("{:?}", parse_problem),
+            pos,
+            start,
+        ),
     }
 }
 


### PR DESCRIPTION
Quite a few unhandled syntax errors have accumulated over the years. It's easy to forget to handle these in reporting because we have wildcard `match` branches that just call `todo!()`:

```
thread 'main' panicked at crates/reporting/src/error/parse.rs:681:14:
not yet implemented: unhandled parse error: Return(ReturnValue(Start(@11579), @11579), @11572)
```

That experience is pretty bad when you hit one. You don't know which file the error is in, and you only get byte offsets instead of a line and column.

We should handle all of those, but in the meantime, this PR removes all wildcard pattern matching on parser errors to prevent more cases from accumulating.

Furthermore, it improves the experience for the existing unhandled cases by printing a more intentional report that includes the file and region:

```
── UNHANDLED PARSE ERROR in src/Pg/BasicCliClient.roc ──────────────────────────

I got stuck while parsing this:

437│  return : a -> Task [Done a] *
             ^

Here's the internal parse problem:

    Return(ReturnValue(Start(@11579), @11579), @11572)

Unfortunately, I'm not able to provide a more insightful error message
for this syntax problem yet. This is considered a bug in the compiler.

Note: If you'd like to contribute to Roc, this would be a good first issue!                                                                                
```

Let me know what you think of that note. I thought it was a nice opportunity to encourage contributions, but I'm happy it to drop it if we don't want the compiler to do that.