### PR TITLE
remove mentions of --prebuilt-platform

### DIFF
--- a/ci/build_basic_cli.sh
+++ b/ci/build_basic_cli.sh
@@ -54,6 +54,6 @@ fi
 ./jump-start.sh
 
 # build the basic cli platform
-roc build.roc --prebuilt-platform
+roc build.roc
 
 cd ..

--- a/ci/build_basic_webserver.sh
+++ b/ci/build_basic_webserver.sh
@@ -47,6 +47,6 @@ cd ..
 
 cd basic-webserver
 
-roc build.roc --prebuilt-platform
+roc build.roc
 
 cd ..

--- a/crates/compiler/build/src/program.rs
+++ b/crates/compiler/build/src/program.rs
@@ -525,7 +525,7 @@ fn gen_from_mono_module_dev_wasm32<'a>(
 
     let host_bytes = std::fs::read(built_host_path).unwrap_or_else(|_| {
         internal_error!(
-            "Failed to read host object file {}! Try omitting --prebuilt-platform",
+            "Failed to read host object file {}!",
             built_host_path.display()
         )
     });

--- a/crates/packaging/src/cache.rs
+++ b/crates/packaging/src/cache.rs
@@ -55,7 +55,6 @@ fn nixos_error_if_dynamic(url: &str, dest_dir: &Path) {
                         You can:\n\n\t\
                             - Download the source of the platform and build it locally, like in this example:\n\t  \
                                 https://github.com/roc-lang/roc/blob/main/examples/platform-switching/rocLovesRust.roc.\n\t  \
-                                When building your roc application, you can use the flag `--prebuilt-platform` to prevent the platform from being rebuilt every time.\n\t  \
                                 For some graphical platforms you may need to use https://github.com/guibou/nixGL.\n\n\t\
                             - Contact the author of the platform to ask them to statically link their platform.\n\t  \
                                 musl can be used to prevent a dynamic dependency on the systems' libc.\n\t  \


### PR DESCRIPTION
This behavior is now enabled by default, the flag got removed in https://github.com/roc-lang/roc/pull/6859