### PR TITLE
Block PRs that increase the amount of panics in non-test code

### DIFF
--- a/.github/workflows/ci_manager.yml
+++ b/.github/workflows/ci_manager.yml
@@ -124,6 +124,11 @@ jobs:
         if: needs.check-changes.outputs.run_tests == 'full'
         uses: ./.github/workflows/benchmarks.yml
 
+    start-panic-check:
+        needs: check-changes
+        if: needs.check-changes.outputs.run_tests == 'full'
+        uses: ./.github/workflows/improve_panics.yml
+
     ran-full:
         runs-on: ubuntu-22.04
         needs: [
@@ -136,7 +141,8 @@ jobs:
                 start-ubuntu-x86-64-nix-tests-debug,
                 start-windows-release-build-test,
                 start-windows-tests,
-                start-roc-benchmarks
+                start-roc-benchmarks,
+                start-panic-check
             ]
         steps:
             - run: echo "all workflows succeeded!"

--- a/.github/workflows/improve_panics.yml
+++ b/.github/workflows/improve_panics.yml
@@ -1,9 +1,9 @@
 on:
-  pull_request:
+  workflow_call:
 
 # Check that the number of panicking function/macro calls has not increased
 # https://github.com/roc-lang/roc/issues/2046
-name: Improve panics
+name: Improve panics/unwrap/expect
 
 # this cancels workflows currently in progress if you start a new one
 concurrency:
@@ -28,31 +28,34 @@ jobs:
         uses: actions/checkout@v4
         with:
           clean: true
-          path: source
+          path: source_branch_dir
           ref: ${{ github.ref }}
 
       - name: checkout target branch in separate directory
         uses: actions/checkout@v4
         with:
           clean: false
-          path: target
+          path: target_branch_dir
           ref: ${{ github.base_ref }}
 
-      - name: compare violations
+      - name: Compare panics, expects, and unwraps between source and target brach
         run: |
-          for d in source target; do
-            cd $d
-            echo "Cleaning $d..."
-            cargo clean
-            echo "Calculating $d violations..."
-            VIOLATIONS=$(nix develop -c cargo clippy --no-deps -- -W clippy::unwrap_used -W clippy::expect_used -W clippy::panic -W clippy::unreachable 2> >(grep -e "warning: \`panic\`" -e "warning: used" -e "warning: usage of" | wc -l ))
+          for branch_dir in source_branch_dir target_branch_dir; do
+            cd $branch_dir
+            echo "Calculating violations in &branch_dir..."
+            VIOLATIONS=$(nix develop -c cargo clippy --no-deps -- -W clippy::unwrap_used -W clippy::expect_used -W clippy::panic 2> >(grep -e "warning: \`panic\`" -e "warning: used" -e "warning: usage of" | wc -l ))
             echo $VIOLATIONS > violations
             cd ..
           done
-          SOURCE_VIOLATIONS=$(cat source/violations)
-          TARGET_VIOLATIONS=$(cat target/violations)
+          
+          SOURCE_VIOLATIONS=$(cat source_branch_dir/violations)
+          TARGET_VIOLATIONS=$(cat target_branch_dir/violations)
           if [ "$SOURCE_VIOLATIONS" -gt "$TARGET_VIOLATIONS" ]; then
-            echo "panic/unwrap/expect/unreachable count increased from $TARGET_VIOLATIONS to $SOURCE_VIOLATIONS"
-            echo "We want this to decrease, or at least stay the same"
+            echo "You added panic/unwrap/expect, in this PR their count increased from $TARGET_VIOLATIONS to $SOURCE_VIOLATIONS."
+            echo "These calls can kill the REPL, try alternative error handling."
+            echo ""
+            echo "TIP: Ask AI \"In rust, how can I rewrite code that contains panic or unwrap so it doesn't crash?\""
+            echo ""
+            echo "If you believe your panic/unwrap/expect is justified, ask Anton-4, rtfeldman or lukewilliamboswell to bypass this workflow failure."
             exit 1
           fi

--- a/.github/workflows/improve_panics.yml
+++ b/.github/workflows/improve_panics.yml
@@ -5,11 +5,6 @@ on:
 # https://github.com/roc-lang/roc/issues/2046
 name: Improve panics/unwrap/expect
 
-# this cancels workflows currently in progress if you start a new one
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   improve-panics:
     name: improve panics

--- a/.github/workflows/improve_panics.yml
+++ b/.github/workflows/improve_panics.yml
@@ -1,0 +1,58 @@
+on:
+  pull_request:
+
+# Check that the number of panicking function/macro calls has not increased
+# https://github.com/roc-lang/roc/issues/2046
+name: Improve panics
+
+# this cancels workflows currently in progress if you start a new one
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  improve-panics:
+    name: improve panics
+    runs-on: [ubuntu-22.04]
+    timeout-minutes: 15
+    env:
+      FORCE_COLOR: 1
+      RUST_BACKTRACE: 1
+    steps:
+      # install nix
+      - uses: cachix/install-nix-action@v23
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+
+      - name: checkout source branch in separate directory
+        uses: actions/checkout@v4
+        with:
+          clean: true
+          path: source
+          ref: ${{ github.ref }}
+
+      - name: checkout target branch in separate directory
+        uses: actions/checkout@v4
+        with:
+          clean: false
+          path: target
+          ref: ${{ github.base_ref }}
+
+      - name: compare violations
+        run: |
+          for d in source target; do
+            cd $d
+            echo "Cleaning $d..."
+            cargo clean
+            echo "Calculating $d violations..."
+            VIOLATIONS=$(nix develop -c cargo clippy --no-deps -- -W clippy::unwrap_used -W clippy::expect_used -W clippy::panic -W clippy::unreachable 2> >(grep -e "warning: \`panic\`" -e "warning: used" -e "warning: usage of" | wc -l ))
+            echo $VIOLATIONS > violations
+            cd ..
+          done
+          SOURCE_VIOLATIONS=$(cat source/violations)
+          TARGET_VIOLATIONS=$(cat target/violations)
+          if [ "$SOURCE_VIOLATIONS" -gt "$TARGET_VIOLATIONS" ]; then
+            echo "panic/unwrap/expect/unreachable count increased from $TARGET_VIOLATIONS to $SOURCE_VIOLATIONS"
+            echo "We want this to decrease, or at least stay the same"
+            exit 1
+          fi


### PR DESCRIPTION
Implements @Anton-4's idea on #2046 for automatically checking when the number of panics/expects/etc., increases.

Clippy doesn't scan test code by default, so this won't get in the way of using `unwrap` in tests, to @rtfeldman's point.  I also manually verified this by adding/removing `unwrap`s within and outside of test modules, and verifying that the count went up or down as expected.

I wasn't sure if I should make this new workflow be triggered by `ci_manager.yml` or if it's fine to be triggered on every PR pipeline.  At least one other workflow is like this (`spellcheck.yml`) so I went with the latter, but I'm happy to change it however you'd like.