### PR TITLE
Remove unused ast::Expr::Expect

### DIFF
--- a/crates/compiler/can/src/desugar.rs
+++ b/crates/compiler/can/src/desugar.rs
@@ -1100,15 +1100,6 @@ pub fn desugar_expr<'a>(
                 region: loc_expr.region,
             })
         }
-        Expect(condition, continuation) => {
-            let desugared_condition = &*env.arena.alloc(desugar_expr(env, scope, condition));
-            let desugared_continuation = &*env.arena.alloc(desugar_expr(env, scope, continuation));
-
-            env.arena.alloc(Loc {
-                value: Expect(desugared_condition, desugared_continuation),
-                region: loc_expr.region,
-            })
-        }
         Dbg => {
             // Allow naked dbg, necessary for piping values into dbg with the `Pizza` binop
             loc_expr

--- a/crates/compiler/can/src/expr.rs
+++ b/crates/compiler/can/src/expr.rs
@@ -1188,36 +1188,6 @@ pub fn canonicalize_expr<'a>(
                 }
             }
         }
-        ast::Expr::Expect(condition, continuation) => {
-            let mut output = Output::default();
-
-            let (loc_condition, output1) =
-                canonicalize_expr(env, var_store, scope, condition.region, &condition.value);
-
-            // Get all the lookups that were referenced in the condition,
-            // so we can print their values later.
-            let lookups_in_cond = get_lookup_symbols(&loc_condition.value);
-
-            let (loc_continuation, output2) = canonicalize_expr(
-                env,
-                var_store,
-                scope,
-                continuation.region,
-                &continuation.value,
-            );
-
-            output.union(output1);
-            output.union(output2);
-
-            (
-                Expect {
-                    loc_condition: Box::new(loc_condition),
-                    loc_continuation: Box::new(loc_continuation),
-                    lookups_in_cond,
-                },
-                output,
-            )
-        }
         ast::Expr::Dbg => {
             // Dbg was not desugared as either part of an `Apply` or a `Pizza` binop, so it's
             // invalid.
@@ -2534,7 +2504,6 @@ pub fn is_valid_interpolation(expr: &ast::Expr<'_>) -> bool {
         // Newlines are disallowed inside interpolation, and these all require newlines
         ast::Expr::DbgStmt(_, _)
         | ast::Expr::LowLevelDbg(_, _, _)
-        | ast::Expr::Expect(_, _)
         | ast::Expr::Return(_, _)
         | ast::Expr::When(_, _)
         | ast::Expr::Backpassing(_, _, _)

--- a/crates/compiler/can/src/suffixed.rs
+++ b/crates/compiler/can/src/suffixed.rs
@@ -155,49 +155,6 @@ pub fn unwrap_suffixed_expression<'a>(
 
             Expr::LowLevelDbg(..) => unwrap_low_level_dbg(arena, loc_expr, maybe_def_pat),
 
-            Expr::Expect(condition, continuation) => {
-                if is_expr_suffixed(&condition.value) {
-                    // we cannot unwrap a suffixed expression within expect
-                    // e.g. expect (foo! "bar")
-                    return Err(EUnwrapped::Malformed);
-                }
-
-                match unwrap_suffixed_expression(arena, continuation, maybe_def_pat) {
-                    Ok(unwrapped_expr) => {
-                        let new_expect = arena
-                            .alloc(Loc::at(loc_expr.region, Expect(condition, unwrapped_expr)));
-                        return Ok(new_expect);
-                    }
-                    Err(EUnwrapped::UnwrappedDefExpr {
-                        loc_expr: unwrapped_expr,
-                        target,
-                    }) => {
-                        let new_expect = arena
-                            .alloc(Loc::at(loc_expr.region, Expect(condition, unwrapped_expr)));
-                        Err(EUnwrapped::UnwrappedDefExpr {
-                            loc_expr: new_expect,
-                            target,
-                        })
-                    }
-                    Err(EUnwrapped::UnwrappedSubExpr {
-                        sub_arg: unwrapped_expr,
-                        sub_pat,
-                        sub_new,
-                        target,
-                    }) => {
-                        let new_expect = arena
-                            .alloc(Loc::at(loc_expr.region, Expect(condition, unwrapped_expr)));
-                        Err(EUnwrapped::UnwrappedSubExpr {
-                            sub_arg: new_expect,
-                            sub_pat,
-                            sub_new,
-                            target,
-                        })
-                    }
-                    Err(EUnwrapped::Malformed) => Err(EUnwrapped::Malformed),
-                }
-            }
-
             // we only need to unwrap some expressions, leave the rest as is
             _ => Ok(loc_expr),
         }

--- a/crates/compiler/fmt/src/expr.rs
+++ b/crates/compiler/fmt/src/expr.rs
@@ -64,9 +64,6 @@ impl<'a> Formattable for Expr<'a> {
                 loc_expr.is_multiline() || args.iter().any(|loc_arg| loc_arg.is_multiline())
             }
 
-            Expect(condition, continuation) => {
-                condition.is_multiline() || continuation.is_multiline()
-            }
             DbgStmt(condition, _) => condition.is_multiline(),
             LowLevelDbg(_, _, _) => unreachable!(
                 "LowLevelDbg should only exist after desugaring, not during formatting"
@@ -444,9 +441,6 @@ impl<'a> Formattable for Expr<'a> {
                     buf.indent(indent);
                     buf.push(')');
                 }
-            }
-            Expect(condition, continuation) => {
-                fmt_expect(buf, condition, continuation, self.is_multiline(), indent);
             }
             Dbg => {
                 buf.indent(indent);
@@ -1066,33 +1060,6 @@ fn fmt_dbg_stmt<'a>(
     condition.format_with_options(buf, Parens::NotNeeded, newlines, inner_indent);
 
     // Always put a blank line after the `dbg` line(s)
-    buf.ensure_ends_with_blank_line();
-
-    continuation.format(buf, indent);
-}
-
-fn fmt_expect<'a>(
-    buf: &mut Buf,
-    condition: &'a Loc<Expr<'a>>,
-    continuation: &'a Loc<Expr<'a>>,
-    is_multiline: bool,
-    indent: u16,
-) {
-    buf.ensure_ends_with_newline();
-    buf.indent(indent);
-    buf.push_str("expect");
-
-    let return_indent = if is_multiline {
-        buf.newline();
-        indent + INDENT
-    } else {
-        buf.spaces(1);
-        indent
-    };
-
-    condition.format(buf, return_indent);
-
-    // Always put a blank line after the `expect` line(s)
     buf.ensure_ends_with_blank_line();
 
     continuation.format(buf, indent);

--- a/crates/compiler/parse/src/ast.rs
+++ b/crates/compiler/parse/src/ast.rs
@@ -489,7 +489,6 @@ pub enum Expr<'a> {
     Defs(&'a Defs<'a>, &'a Loc<Expr<'a>>),
 
     Backpassing(&'a [Loc<Pattern<'a>>], &'a Loc<Expr<'a>>, &'a Loc<Expr<'a>>),
-    Expect(&'a Loc<Expr<'a>>, &'a Loc<Expr<'a>>),
 
     Dbg,
     DbgStmt(&'a Loc<Expr<'a>>, &'a Loc<Expr<'a>>),
@@ -671,7 +670,6 @@ pub fn is_expr_suffixed(expr: &Expr) -> bool {
         Expr::Tag(_) => false,
         Expr::OpaqueRef(_) => false,
         Expr::Backpassing(_, _, _) => false, // TODO: we might want to check this?
-        Expr::Expect(a, b) => is_expr_suffixed(&a.value) || is_expr_suffixed(&b.value),
         Expr::Dbg => false,
         Expr::DbgStmt(a, b) => is_expr_suffixed(&a.value) || is_expr_suffixed(&b.value),
         Expr::LowLevelDbg(_, a, b) => is_expr_suffixed(&a.value) || is_expr_suffixed(&b.value),
@@ -931,11 +929,6 @@ impl<'a, 'b> RecursiveValueDefIter<'a, 'b> {
                     expr_stack.reserve(2);
                     expr_stack.push(&a.value);
                     expr_stack.push(&b.value);
-                }
-                Expect(condition, cont) => {
-                    expr_stack.reserve(2);
-                    expr_stack.push(&condition.value);
-                    expr_stack.push(&cont.value);
                 }
                 DbgStmt(condition, cont) => {
                     expr_stack.reserve(2);
@@ -2482,7 +2475,6 @@ impl<'a> Malformed for Expr<'a> {
             Closure(args, body) => args.iter().any(|arg| arg.is_malformed()) || body.is_malformed(),
             Defs(defs, body) => defs.is_malformed() || body.is_malformed(),
             Backpassing(args, call, body) => args.iter().any(|arg| arg.is_malformed()) || call.is_malformed() || body.is_malformed(),
-            Expect(condition, continuation) => condition.is_malformed() || continuation.is_malformed(),
             Dbg => false,
             DbgStmt(condition, continuation) => condition.is_malformed() || continuation.is_malformed(),
             LowLevelDbg(_, condition, continuation) => condition.is_malformed() || continuation.is_malformed(),

--- a/crates/compiler/parse/src/expr.rs
+++ b/crates/compiler/parse/src/expr.rs
@@ -2175,7 +2175,6 @@ fn expr_to_pattern_help<'a>(arena: &'a Bump, expr: &Expr<'a>) -> Result<Pattern<
         | Expr::Defs(_, _)
         | Expr::If { .. }
         | Expr::When(_, _)
-        | Expr::Expect(_, _)
         | Expr::Dbg
         | Expr::DbgStmt(_, _)
         | Expr::LowLevelDbg(_, _, _)

--- a/crates/compiler/parse/src/normalize.rs
+++ b/crates/compiler/parse/src/normalize.rs
@@ -735,10 +735,6 @@ impl<'a> Normalize<'a> for Expr<'a> {
                 arena.alloc(b.normalize(arena)),
                 arena.alloc(c.normalize(arena)),
             ),
-            Expr::Expect(a, b) => Expr::Expect(
-                arena.alloc(a.normalize(arena)),
-                arena.alloc(b.normalize(arena)),
-            ),
             Expr::Dbg => Expr::Dbg,
             Expr::DbgStmt(a, b) => Expr::DbgStmt(
                 arena.alloc(a.normalize(arena)),

--- a/crates/language_server/src/analysis/tokens.rs
+++ b/crates/language_server/src/analysis/tokens.rs
@@ -686,9 +686,6 @@ impl IterTokens for Loc<Expr<'_>> {
                 .chain(e1.iter_tokens(arena))
                 .chain(e2.iter_tokens(arena))
                 .collect_in(arena),
-            Expr::Expect(e1, e2) => (e1.iter_tokens(arena).into_iter())
-                .chain(e2.iter_tokens(arena))
-                .collect_in(arena),
             Expr::Dbg => onetoken(Token::Keyword, region, arena),
             Expr::DbgStmt(e1, e2) => (e1.iter_tokens(arena).into_iter())
                 .chain(e2.iter_tokens(arena))


### PR DESCRIPTION
While debugging an issue, I noticed the `Expect` variant of `ast::Expr` was unused