### PR TITLE
impl Num.neg for Dec,F32,F64 in repl

### DIFF
--- a/.github/workflows/nix_linux_x86_64.yml
+++ b/.github/workflows/nix_linux_x86_64.yml
@@ -24,7 +24,12 @@ jobs:
         run: nix develop -c ./ci/roc_test_builtins.sh
 
       - name: test wasm32 cli_tests
-        run: nix develop -c cargo test --locked --release --features="wasm32-cli-run"
+        # skipping glue tests due to difficult multithreading bug, we run them single threaded in the next step
+        run: nix develop -c cargo test --locked --release --features="wasm32-cli-run" -- --skip glue_cli_tests
+
+      - name: wasm32 glue_cli_tests
+        # single threaded due to difficult bug when multithreading
+        run: nix develop -c cargo test --locked --release --features="wasm32-cli-run" glue_cli_tests -- --test-threads=1
 
       - name: test the dev backend # these tests require an explicit feature flag
         run: nix develop -c cargo nextest run --locked --release --package test_gen --no-default-features --features gen-dev --no-fail-fast

--- a/crates/compiler/gen_dev/src/generic64/aarch64.rs
+++ b/crates/compiler/gen_dev/src/generic64/aarch64.rs
@@ -1847,6 +1847,26 @@ impl Assembler<AArch64GeneralReg, AArch64FloatReg> for AArch64Assembler {
     }
 
     #[inline(always)]
+    fn neg_freg64_freg64(
+        buf: &mut Vec<'_, u8>,
+        _relocs: &mut Vec<'_, Relocation>,
+        dst: AArch64FloatReg,
+        src: AArch64FloatReg,
+    ) {
+        fneg_freg_freg(buf, FloatWidth::F64, dst, src);
+    }
+
+    #[inline(always)]
+    fn neg_freg32_freg32(
+        buf: &mut Vec<'_, u8>,
+        _relocs: &mut Vec<'_, Relocation>,
+        dst: AArch64FloatReg,
+        src: AArch64FloatReg,
+    ) {
+        fneg_freg_freg(buf, FloatWidth::F32, dst, src);
+    }
+
+    #[inline(always)]
     fn sub_reg64_reg64_imm32(
         buf: &mut Vec<'_, u8>,
         dst: AArch64GeneralReg,
@@ -3950,6 +3970,24 @@ fn fsub_freg_freg_freg(
             rm: src2,
         });
 
+    buf.extend(inst.bytes());
+}
+
+/// `FNEG Sd/Dd, Sn/Dn`
+#[inline(always)]
+fn fneg_freg_freg(
+    buf: &mut Vec<'_, u8>,
+    ftype: FloatWidth,
+    dst: AArch64FloatReg,
+    src: AArch64FloatReg,
+) {
+    let inst =
+        FloatingPointDataProcessingOneSource::new(FloatingPointDataProcessingOneSourceParams {
+            ptype: ftype,
+            opcode: 0b00010,
+            rn: src,
+            rd: dst,
+        });
     buf.extend(inst.bytes());
 }
 

--- a/crates/compiler/gen_llvm/src/llvm/lowlevel.rs
+++ b/crates/compiler/gen_llvm/src/llvm/lowlevel.rs
@@ -2215,6 +2215,7 @@ fn build_dec_unary_op<'a, 'ctx>(
 
     match op {
         NumAbs => dec_unary_op(env, bitcode::DEC_ABS, arg),
+        NumNeg => dec_unary_op(env, bitcode::DEC_NEGATE, arg),
         NumAcos => dec_unary_op(env, bitcode::DEC_ACOS, arg),
         NumAsin => dec_unary_op(env, bitcode::DEC_ASIN, arg),
         NumAtan => dec_unary_op(env, bitcode::DEC_ATAN, arg),

--- a/crates/compiler/gen_wasm/src/low_level.rs
+++ b/crates/compiler/gen_wasm/src/low_level.rs
@@ -1624,6 +1624,7 @@ impl<'a> LowLevelCall<'a> {
                     }
                     F32 => backend.code_builder.f32_neg(),
                     F64 => backend.code_builder.f64_neg(),
+                    Decimal => self.load_args_and_call_zig(backend, bitcode::DEC_NEGATE),
                     _ => todo!("{:?} for {:?}", self.lowlevel, self.ret_layout),
                 }
             }

--- a/crates/compiler/test_gen/src/gen_num.rs
+++ b/crates/compiler/test_gen/src/gen_num.rs
@@ -1607,7 +1607,7 @@ fn tail_call_elimination() {
 
 #[test]
 #[cfg(any(feature = "gen-llvm", feature = "gen-wasm", feature = "gen-dev"))]
-fn int_negate() {
+fn num_negate() {
     assert_evals_to!("Num.neg 123i8", -123, i8);
     assert_evals_to!("Num.neg Num.maxI8", -i8::MAX, i8);
     assert_evals_to!("Num.neg (Num.minI8 + 1)", i8::MAX, i8);
@@ -1623,6 +1623,26 @@ fn int_negate() {
     assert_evals_to!("Num.neg 123", -123, i64);
     assert_evals_to!("Num.neg Num.maxI64", -i64::MAX, i64);
     assert_evals_to!("Num.neg (Num.minI64 + 1)", i64::MAX, i64);
+
+    assert_evals_to!("Num.neg 12.3f32", -12.3, f32);
+    assert_evals_to!("Num.neg 0.0f32", -0.0, f32);
+    assert_evals_to!("Num.neg Num.maxF32", -f32::MAX, f32);
+    assert_evals_to!("Num.neg Num.minF32", -f32::MIN, f32);
+    assert_evals_to!("Num.neg Num.infinityF32", -f32::INFINITY, f32);
+    // can't test equality for nan
+    assert_evals_to!("Num.isNaN (Num.neg Num.nanF32)", true, bool);
+
+    assert_evals_to!("Num.neg 12.3f64", -12.3, f64);
+    assert_evals_to!("Num.neg 0.0f64", -0.0, f64);
+    assert_evals_to!("Num.neg Num.maxF64", -f64::MAX, f64);
+    assert_evals_to!("Num.neg Num.minF64", -f64::MIN, f64);
+    assert_evals_to!("Num.neg Num.infinityF64", -f64::INFINITY, f64);
+    // can't test equality for nan
+    assert_evals_to!("Num.isNaN (Num.neg Num.nanF64)", true, bool);
+
+    assert_evals_to!("Num.neg 123dec", RocDec::from(-123), RocDec);
+    // 0 is signless, unlike f32/f64
+    assert_evals_to!("Num.neg 0dec", RocDec::from(0), RocDec);
 }
 
 #[test]


### PR DESCRIPTION
The intent of this change is to support `Num.neg` for Dec, F32, and F64 types in the repl.

Dec negation was implemented across gen-dev, gen-llvm, gen-wasm as a call to the compiled zig function `bitcode::DEC_NEGATE`.

f32 and f64 negation were implemented already for gen-llvm, gen-wasm.

for gen-dev x86_64, float negation is implemented by flipping the sign bit, which means `xorps` for f32, and `xorpd` for f64

for gen-dev aarch64, there is conveniently a `fneg` instruction

Closes #6959