### PR TITLE
Restore `roc build --no-link` pipeline

### DIFF
--- a/crates/compiler/build/src/program.rs
+++ b/crates/compiler/build/src/program.rs
@@ -872,7 +872,7 @@ fn build_loaded_file<'a>(
 
     let built_host_opt =
         // Not sure if this is correct for all calls with LinkType::Dylib...
-        if link_type == LinkType::Dylib || target == Target::Wasm32 {
+        if link_type == LinkType::None || link_type == LinkType::Dylib || target == Target::Wasm32 {
             BuiltHostOpt::None
         } else {
             let prebuilt_host = determine_built_host_path(&platform_main_roc_path, target, build_host_requested, link_type, linking_strategy, suppress_build_host_warning);


### PR DESCRIPTION
This PR restores the functionality to build a roc app into an object file without a host gives an error `Legacy linking failed`. 

```
 $ roc build --no-link --emit-llvm-ir examples/simple.roc
Legacy linking failed: Failed to find any legacy linking files; I need one of these three paths to exist:
    examples/../platform/macos-arm64.a
    examples/../platform/macos-arm64.o
    examples/../platform/libhost.a
```

This was likely broken in #6859, here is the previous implementation that provided this functionality. 

```rust 
// We don't need to spawn a rebuild thread when using a prebuilt host.
     let rebuild_thread = if matches!(link_type, LinkType::Dylib | LinkType::None) {
         None
     } else if is_platform_prebuilt {
// <---snipped--->
```