### PR TITLE
Allow suffixed pure functions that are exposed to the host

### DIFF
--- a/crates/compiler/can/src/constraint.rs
+++ b/crates/compiler/can/src/constraint.rs
@@ -957,6 +957,13 @@ impl FxSuffixKind {
             Self::UnsuffixedRecordField => IdentSuffix::None,
         }
     }
+
+    pub fn symbol(&self) -> Option<&Symbol> {
+        match self {
+            Self::Let(symbol) | Self::Pattern(symbol) => Some(symbol),
+            Self::UnsuffixedRecordField => None,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/crates/compiler/load/tests/helpers/mod.rs
+++ b/crates/compiler/load/tests/helpers/mod.rs
@@ -51,10 +51,11 @@ pub fn infer_expr(
         exposed_by_module: &Default::default(),
         derived_module,
         function_kind: FunctionKind::LambdaSet,
-        #[cfg(debug_assertions)]
-        checkmate: None,
         module_params: None,
         module_params_vars: Default::default(),
+        host_exposed_symbols: None,
+        #[cfg(debug_assertions)]
+        checkmate: None,
     };
 
     let RunSolveOutput { solved, .. } =

--- a/crates/compiler/load/tests/test_reporting.rs
+++ b/crates/compiler/load/tests/test_reporting.rs
@@ -14812,7 +14812,7 @@ All branches in an `if` must have the same type!
                 Str.trim msg
             "#
         ),
-        @r###"
+        @r#"
     ── EFFECT IN PURE FUNCTION in /code/proj/Main.roc ──────────────────────────────
 
     This call to `Effect.putLine!` might produce an effect:
@@ -14829,18 +14829,7 @@ All branches in an `if` must have the same type!
 
     You can still run the program with this error, which can be helpful
     when you're debugging.
-
-    ── UNNECESSARY EXCLAMATION in /code/proj/Main.roc ──────────────────────────────
-
-    This function is pure, but its name suggests otherwise:
-
-    5│  main! = \{} ->
-        ^^^^^
-
-    The exclamation mark at the end is reserved for effectful functions.
-
-    Hint: Did you forget to run an effect? Is the type annotation wrong?
-    "###
+    "#
     );
 
     test_report!(
@@ -15423,7 +15412,7 @@ All branches in an `if` must have the same type!
             pureHigherOrder = \f, x -> f x
             "#
         ),
-        @r###"
+        @r#"
     ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     This 1st argument to `pureHigherOrder` has an unexpected type:
@@ -15438,18 +15427,7 @@ All branches in an `if` must have the same type!
     But `pureHigherOrder` needs its 1st argument to be:
 
         Str -> {}
-
-    ── UNNECESSARY EXCLAMATION in /code/proj/Main.roc ──────────────────────────────
-
-    This function is pure, but its name suggests otherwise:
-
-    5│  main! = \{} ->
-        ^^^^^
-
-    The exclamation mark at the end is reserved for effectful functions.
-
-    Hint: Did you forget to run an effect? Is the type annotation wrong?
-    "###
+    "#
     );
 
     test_report!(
@@ -15467,7 +15445,7 @@ All branches in an `if` must have the same type!
             pureHigherOrder = \f, x -> f x
             "#
         ),
-        @r###"
+        @r#"
     ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
 
     This 1st argument to `pureHigherOrder` has an unexpected type:
@@ -15482,17 +15460,6 @@ All branches in an `if` must have the same type!
     But `pureHigherOrder` needs its 1st argument to be:
 
         Str -> {}
-
-    ── UNNECESSARY EXCLAMATION in /code/proj/Main.roc ──────────────────────────────
-
-    This function is pure, but its name suggests otherwise:
-
-    5│  main! = \{} ->
-        ^^^^^
-
-    The exclamation mark at the end is reserved for effectful functions.
-
-    Hint: Did you forget to run an effect? Is the type annotation wrong?
-    "###
+    "#
     );
 }

--- a/crates/compiler/load_internal/src/file.rs
+++ b/crates/compiler/load_internal/src/file.rs
@@ -350,6 +350,8 @@ fn start_phase<'a>(
                     None
                 };
 
+                let is_host_exposed = state.root_id == module.module_id;
+
                 BuildTask::solve_module(
                     module,
                     ident_ids,
@@ -367,6 +369,7 @@ fn start_phase<'a>(
                     state.cached_types.clone(),
                     derived_module,
                     state.exec_mode,
+                    is_host_exposed,
                     //
                     #[cfg(debug_assertions)]
                     checkmate,
@@ -922,6 +925,7 @@ enum BuildTask<'a> {
         cached_subs: CachedTypeState,
         derived_module: SharedDerivedModule,
         exec_mode: ExecutionMode,
+        is_host_exposed: bool,
 
         #[cfg(debug_assertions)]
         checkmate: Option<roc_checkmate::Collector>,
@@ -4331,6 +4335,7 @@ impl<'a> BuildTask<'a> {
         cached_subs: CachedTypeState,
         derived_module: SharedDerivedModule,
         exec_mode: ExecutionMode,
+        is_host_exposed: bool,
 
         #[cfg(debug_assertions)] checkmate: Option<roc_checkmate::Collector>,
     ) -> Self {
@@ -4355,6 +4360,7 @@ impl<'a> BuildTask<'a> {
             cached_subs,
             derived_module,
             exec_mode,
+            is_host_exposed,
 
             #[cfg(debug_assertions)]
             checkmate,
@@ -4661,6 +4667,7 @@ fn run_solve_solve(
     var_store: VarStore,
     module: Module,
     derived_module: SharedDerivedModule,
+    is_host_exposed: bool,
 
     #[cfg(debug_assertions)] checkmate: Option<roc_checkmate::Collector>,
 ) -> SolveResult {
@@ -4711,6 +4718,12 @@ fn run_solve_solve(
     let (solve_output, solved_implementations, exposed_vars_by_symbol) = {
         let module_id = module.module_id;
 
+        let host_exposed_idents = if is_host_exposed {
+            Some(&exposed_symbols)
+        } else {
+            None
+        };
+
         let solve_config = SolveConfig {
             home: module_id,
             types,
@@ -4724,6 +4737,7 @@ fn run_solve_solve(
             checkmate,
             module_params,
             module_params_vars: imported_param_vars,
+            host_exposed_symbols: host_exposed_idents,
         };
 
         let solve_output = roc_solve::module::run_solve(
@@ -4800,6 +4814,7 @@ fn run_solve<'a>(
     cached_types: CachedTypeState,
     derived_module: SharedDerivedModule,
     exec_mode: ExecutionMode,
+    is_host_exposed: bool,
 
     #[cfg(debug_assertions)] checkmate: Option<roc_checkmate::Collector>,
 ) -> Msg<'a> {
@@ -4831,6 +4846,7 @@ fn run_solve<'a>(
                     var_store,
                     module,
                     derived_module,
+                    is_host_exposed,
                     //
                     #[cfg(debug_assertions)]
                     checkmate,
@@ -4863,6 +4879,7 @@ fn run_solve<'a>(
                 var_store,
                 module,
                 derived_module,
+                is_host_exposed,
                 //
                 #[cfg(debug_assertions)]
                 checkmate,
@@ -6256,6 +6273,7 @@ fn run_task<'a>(
             cached_subs,
             derived_module,
             exec_mode,
+            is_host_exposed,
 
             #[cfg(debug_assertions)]
             checkmate,
@@ -6275,6 +6293,7 @@ fn run_task<'a>(
             cached_subs,
             derived_module,
             exec_mode,
+            is_host_exposed,
             //
             #[cfg(debug_assertions)]
             checkmate,

--- a/crates/compiler/solve/src/module.rs
+++ b/crates/compiler/solve/src/module.rs
@@ -6,7 +6,7 @@ use roc_can::constraint::{Constraint, Constraints};
 use roc_can::expr::PendingDerives;
 use roc_can::module::{ExposedByModule, ModuleParams, ResolvedImplementations, RigidVariables};
 use roc_collections::all::MutMap;
-use roc_collections::VecMap;
+use roc_collections::{VecMap, VecSet};
 use roc_derive::SharedDerivedModule;
 use roc_error_macros::internal_error;
 use roc_module::symbol::{ModuleId, Symbol};
@@ -76,6 +76,8 @@ pub struct SolveConfig<'a> {
     /// Needed during solving to resolve lambda sets from derived implementations that escape into
     /// the user module.
     pub derived_module: SharedDerivedModule,
+    ///
+    pub host_exposed_symbols: Option<&'a VecSet<Symbol>>,
 
     #[cfg(debug_assertions)]
     /// The checkmate collector for this module.

--- a/crates/compiler/solve/src/module.rs
+++ b/crates/compiler/solve/src/module.rs
@@ -76,7 +76,7 @@ pub struct SolveConfig<'a> {
     /// Needed during solving to resolve lambda sets from derived implementations that escape into
     /// the user module.
     pub derived_module: SharedDerivedModule,
-    ///
+    /// Symbols that are exposed to the host which might need special treatment.
     pub host_exposed_symbols: Option<&'a VecSet<Symbol>>,
 
     #[cfg(debug_assertions)]

--- a/crates/compiler/test_derive/src/util.rs
+++ b/crates/compiler/test_derive/src/util.rs
@@ -439,6 +439,7 @@ fn check_derived_typechecks_and_golden(
         derived_module: Default::default(),
         module_params: None,
         module_params_vars: imported_param_vars,
+        host_exposed_symbols: None,
 
         #[cfg(debug_assertions)]
         checkmate: None,

--- a/crates/test_compile/src/help_solve.rs
+++ b/crates/test_compile/src/help_solve.rs
@@ -49,6 +49,7 @@ impl SolvedExpr {
             derived_module: SharedDerivedModule::default(),
             module_params: None,
             module_params_vars: VecMap::default(),
+            host_exposed_symbols: None,
             #[cfg(debug_assertions)]
             checkmate: None,
         };


### PR DESCRIPTION
When a function is `!`-suffixed but pure we produce a warning. This is what we want in most cases, but as Brendan [pointed out in Zulip](https://roc.zulipchat.com/#narrow/channel/316715-contributing/topic/Help.20upgrade.2Ftest.20purity.20inference/near/484085983), an app should be able to provide a pure function to a platform that allows an effectful one.