### PR TITLE
gen-dev: complete Num{Mul,Add,Sub}Saturated impls

### DIFF
--- a/crates/compiler/gen_dev/src/generic64/mod.rs
+++ b/crates/compiler/gen_dev/src/generic64/mod.rs
@@ -1432,28 +1432,20 @@ impl<
         src2: Symbol,
         layout: InLayout<'a>,
     ) {
-        match self.layout_interner.get_repr(layout) {
-            LayoutRepr::Builtin(Builtin::Int(width @ quadword_and_smaller!())) => {
-                let intrinsic = bitcode::NUM_ADD_SATURATED_INT[width].to_string();
+        match self.interner().get_repr(layout) {
+            LayoutRepr::Builtin(Builtin::Int(int_width)) => {
+                let intrinsic = bitcode::NUM_ADD_SATURATED_INT[int_width].to_string();
                 self.build_fn_call(&dst, intrinsic, &[src1, src2], &[layout, layout], &layout);
             }
-            LayoutRepr::Builtin(Builtin::Float(FloatWidth::F64)) => {
-                let dst_reg = self.storage_manager.claim_float_reg(&mut self.buf, &dst);
-                let src1_reg = self.storage_manager.load_to_float_reg(&mut self.buf, &src1);
-                let src2_reg = self.storage_manager.load_to_float_reg(&mut self.buf, &src2);
-                ASM::add_freg64_freg64_freg64(&mut self.buf, dst_reg, src1_reg, src2_reg);
-            }
-            LayoutRepr::Builtin(Builtin::Float(FloatWidth::F32)) => {
-                let dst_reg = self.storage_manager.claim_float_reg(&mut self.buf, &dst);
-                let src1_reg = self.storage_manager.load_to_float_reg(&mut self.buf, &src1);
-                let src2_reg = self.storage_manager.load_to_float_reg(&mut self.buf, &src2);
-                ASM::add_freg32_freg32_freg32(&mut self.buf, dst_reg, src1_reg, src2_reg);
+            LayoutRepr::Builtin(Builtin::Float(_)) => {
+                // saturated add is just normal add
+                self.build_num_add(&dst, &src1, &src2, &layout)
             }
             LayoutRepr::Builtin(Builtin::Decimal) => {
                 let intrinsic = bitcode::DEC_ADD_SATURATED.to_string();
                 self.build_fn_call(&dst, intrinsic, &[src1, src2], &[layout, layout], &layout);
             }
-            x => todo!("NumAddSaturated: layout, {:?}", x),
+            other => internal_error!("NumAddSaturated is not defined for {other:?}"),
         }
     }
 
@@ -1479,6 +1471,30 @@ impl<
             &[*num_layout, *num_layout],
             return_layout,
         )
+    }
+
+    fn build_num_sub_saturated(
+        &mut self,
+        dst: Symbol,
+        src1: Symbol,
+        src2: Symbol,
+        layout: InLayout<'a>,
+    ) {
+        match self.interner().get_repr(layout) {
+            LayoutRepr::Builtin(Builtin::Int(int_width)) => {
+                let intrinsic = bitcode::NUM_SUB_SATURATED_INT[int_width].to_string();
+                self.build_fn_call(&dst, intrinsic, &[src1, src2], &[layout, layout], &layout);
+            }
+            LayoutRepr::Builtin(Builtin::Float(_)) => {
+                // saturated sub is just normal sub
+                self.build_num_sub(&dst, &src1, &src2, &layout)
+            }
+            LayoutRepr::Builtin(Builtin::Decimal) => {
+                let intrinsic = bitcode::DEC_SUB_SATURATED.to_string();
+                self.build_fn_call(&dst, intrinsic, &[src1, src2], &[layout, layout], &layout);
+            }
+            other => internal_error!("NumSubSaturated is not defined for {other:?}"),
+        }
     }
 
     fn build_num_sub_checked(
@@ -1619,28 +1635,20 @@ impl<
         src2: Symbol,
         layout: InLayout<'a>,
     ) {
-        match self.layout_interner.get_repr(layout) {
-            LayoutRepr::Builtin(Builtin::Int(width @ quadword_and_smaller!())) => {
-                let intrinsic = bitcode::NUM_MUL_SATURATED_INT[width].to_string();
+        match self.interner().get_repr(layout) {
+            LayoutRepr::Builtin(Builtin::Int(int_width)) => {
+                let intrinsic = bitcode::NUM_MUL_SATURATED_INT[int_width].to_string();
                 self.build_fn_call(&dst, intrinsic, &[src1, src2], &[layout, layout], &layout);
             }
-            LayoutRepr::Builtin(Builtin::Float(FloatWidth::F64)) => {
-                let dst_reg = self.storage_manager.claim_float_reg(&mut self.buf, &dst);
-                let src1_reg = self.storage_manager.load_to_float_reg(&mut self.buf, &src1);
-                let src2_reg = self.storage_manager.load_to_float_reg(&mut self.buf, &src2);
-                ASM::mul_freg64_freg64_freg64(&mut self.buf, dst_reg, src1_reg, src2_reg);
-            }
-            LayoutRepr::Builtin(Builtin::Float(FloatWidth::F32)) => {
-                let dst_reg = self.storage_manager.claim_float_reg(&mut self.buf, &dst);
-                let src1_reg = self.storage_manager.load_to_float_reg(&mut self.buf, &src1);
-                let src2_reg = self.storage_manager.load_to_float_reg(&mut self.buf, &src2);
-                ASM::mul_freg32_freg32_freg32(&mut self.buf, dst_reg, src1_reg, src2_reg);
+            LayoutRepr::Builtin(Builtin::Float(_)) => {
+                // saturated mul is just normal mul
+                self.build_num_mul(&dst, &src1, &src2, &layout)
             }
             LayoutRepr::Builtin(Builtin::Decimal) => {
                 let intrinsic = bitcode::DEC_MUL_SATURATED.to_string();
                 self.build_fn_call(&dst, intrinsic, &[src1, src2], &[layout, layout], &layout);
             }
-            x => todo!("NumMulSaturated: layout, {:?}", x),
+            other => internal_error!("NumMulSaturated is not defined for {other:?}"),
         }
     }
 

--- a/crates/compiler/gen_llvm/src/llvm/lowlevel.rs
+++ b/crates/compiler/gen_llvm/src/llvm/lowlevel.rs
@@ -1758,7 +1758,7 @@ fn build_float_binop<'ctx>(
     };
 
     match op {
-        NumAdd => bd.new_build_float_add(lhs, rhs, "add_float").into(),
+        NumAdd | NumAddSaturated => bd.new_build_float_add(lhs, rhs, "add_float").into(),
         NumAddChecked => {
             let context = env.context;
 
@@ -1785,7 +1785,7 @@ fn build_float_binop<'ctx>(
             struct_value.into()
         }
         NumAddWrap => unreachable!("wrapping addition is not defined on floats"),
-        NumSub => bd.new_build_float_sub(lhs, rhs, "sub_float").into(),
+        NumSub | NumSubSaturated => bd.new_build_float_sub(lhs, rhs, "sub_float").into(),
         NumSubChecked => {
             let context = env.context;
 
@@ -1812,8 +1812,7 @@ fn build_float_binop<'ctx>(
             struct_value.into()
         }
         NumSubWrap => unreachable!("wrapping subtraction is not defined on floats"),
-        NumMul => bd.new_build_float_mul(lhs, rhs, "mul_float").into(),
-        NumMulSaturated => bd.new_build_float_mul(lhs, rhs, "mul_float").into(),
+        NumMul | NumMulSaturated => bd.new_build_float_mul(lhs, rhs, "mul_float").into(),
         NumMulChecked => {
             let context = env.context;
 
@@ -1855,7 +1854,7 @@ fn build_float_binop<'ctx>(
             &bitcode::NUM_POW[float_width],
         ),
         _ => {
-            unreachable!("Unrecognized int binary operation: {:?}", op);
+            unreachable!("Unrecognized float binary operation: {:?}", op);
         }
     }
 }
@@ -2286,6 +2285,9 @@ fn build_dec_binop<'a, 'ctx>(
             rhs,
             "Decimal multiplication overflowed",
         ),
+        NumAddSaturated => dec_binary_op(env, bitcode::DEC_ADD_SATURATED, lhs, rhs),
+        NumSubSaturated => dec_binary_op(env, bitcode::DEC_SUB_SATURATED, lhs, rhs),
+        NumMulSaturated => dec_binary_op(env, bitcode::DEC_MUL_SATURATED, lhs, rhs),
         NumDivFrac => dec_binop_with_unchecked(env, bitcode::DEC_DIV, lhs, rhs),
 
         NumLt => call_bitcode_fn(env, &[lhs, rhs], &bitcode::NUM_LESS_THAN[IntWidth::I128]),

--- a/crates/compiler/test_gen/src/gen_num.rs
+++ b/crates/compiler/test_gen/src/gen_num.rs
@@ -3000,161 +3000,199 @@ fn u8_mul_greater_than_i8() {
 #[test]
 #[cfg(any(feature = "gen-llvm", feature = "gen-wasm", feature = "gen-dev"))]
 fn add_saturated() {
+    assert_evals_to!("Num.addSaturated 200u8 200u8", 255u8, u8);
+    assert_evals_to!("Num.addSaturated 100i8 100i8", 127i8, i8);
+    assert_evals_to!("Num.addSaturated -100i8 -100i8", -128i8, i8);
+    assert_evals_to!("Num.addSaturated 40000u16 40000u16", 65535u16, u16);
+    assert_evals_to!("Num.addSaturated 20000i16 20000i16", 32767i16, i16);
+    assert_evals_to!("Num.addSaturated -20000i16 -20000i16", -32768i16, i16);
     assert_evals_to!(
-        indoc!(
-            r"
-            x : U8
-            x = 200
-            y : U8
-            y = 200
-            Num.addSaturated x y
-            "
-        ),
-        255,
-        u8
+        "Num.addSaturated 3000000000u32 3000000000u32",
+        4294967295u32,
+        u32
+    );
+    assert_evals_to!(
+        "Num.addSaturated 2000000000i32 2000000000i32",
+        2147483647i32,
+        i32
+    );
+    assert_evals_to!(
+        "Num.addSaturated -2000000000i32 -2000000000i32",
+        -2147483648i32,
+        i32
+    );
+    assert_evals_to!(
+        "Num.addSaturated 10000000000000000000u64 10000000000000000000u64",
+        18446744073709551615u64,
+        u64
+    );
+    assert_evals_to!(
+        "Num.addSaturated 5000000000000000000i64 5000000000000000000i64 ",
+        9223372036854775807i64,
+        i64
+    );
+    assert_evals_to!(
+        "Num.addSaturated -5000000000000000000i64 -5000000000000000000i64 ",
+        -9223372036854775808i64,
+        i64
+    );
+    assert_evals_to!(
+        "Num.addSaturated -5000000000000000000i64 -5000000000000000000i64 ",
+        -9223372036854775808i64,
+        i64
+    );
+    assert_evals_to!(
+        "Num.addSaturated Num.maxF32 Num.maxF32",
+        std::f32::INFINITY,
+        f32
+    );
+    assert_evals_to!(
+        "Num.addSaturated Num.minF32 Num.minF32",
+        std::f32::NEG_INFINITY,
+        f32
+    );
+    assert_evals_to!(
+        "Num.addSaturated Num.maxF64 Num.maxF64",
+        std::f64::INFINITY,
+        f64
+    );
+    assert_evals_to!(
+        "Num.addSaturated Num.minF64 Num.minF64",
+        std::f64::NEG_INFINITY,
+        f64
     );
 
     assert_evals_to!(
-        indoc!(
-            r"
-            x : I8
-            x = 100
-            y : I8
-            y = 100
-            Num.addSaturated x y
-            "
-        ),
-        127,
-        i8
+        "Num.addSaturated 170_141_183_460_469_231_731dec 1",
+        RocDec::from_str("170141183460469231731.687303715884105727").unwrap(),
+        RocDec
     );
-
     assert_evals_to!(
-        indoc!(
-            r"
-            x : I8
-            x = -100
-            y : I8
-            y = -100
-            Num.addSaturated x y
-            "
-        ),
-        -128,
-        i8
+        "Num.addSaturated -170_141_183_460_469_231_731dec -1",
+        RocDec::from_str("-170141183460469231731.687303715884105728").unwrap(),
+        RocDec
     );
 }
 
 #[test]
 #[cfg(any(feature = "gen-llvm", feature = "gen-wasm", feature = "gen-dev"))]
 fn sub_saturated() {
+    assert_evals_to!("Num.subSaturated 1u8 10u8", 0u8, u8);
+    assert_evals_to!("Num.subSaturated 100i8 -100i8", 127i8, i8);
+    assert_evals_to!("Num.subSaturated -100i8 100i8", -128i8, i8);
+    assert_evals_to!("Num.subSaturated 1u16 10u16", 0u16, u16);
+    assert_evals_to!("Num.subSaturated 20000i16 -20000i16", 32767i16, i16);
+    assert_evals_to!("Num.subSaturated -20000i16 20000i16", -32768i16, i16);
+    assert_evals_to!("Num.subSaturated 1u32 10u32", 0u32, u32);
     assert_evals_to!(
-        indoc!(
-            r"
-            x : U8
-            x = 10
-            y : U8
-            y = 20
-            Num.subSaturated x y
-            "
-        ),
-        0,
-        u8
+        "Num.subSaturated 2000000000i32 -2000000000i32",
+        2147483647i32,
+        i32
     );
     assert_evals_to!(
-        indoc!(
-            r"
-            x : I8
-            x = -100
-            y : I8
-            y = 100
-            Num.subSaturated x y
-            "
-        ),
-        -128,
-        i8
+        "Num.subSaturated -2000000000i32 2000000000i32",
+        -2147483648i32,
+        i32
+    );
+    assert_evals_to!("Num.subSaturated 1u64 10u64", 0u64, u64);
+    assert_evals_to!(
+        "Num.subSaturated 5000000000000000000i64 -5000000000000000000i64 ",
+        9223372036854775807i64,
+        i64
     );
     assert_evals_to!(
-        indoc!(
-            r"
-            x : I8
-            x = 100
-            y : I8
-            y = -100
-            Num.subSaturated x y
-            "
-        ),
-        127,
-        i8
+        "Num.subSaturated -5000000000000000000i64 5000000000000000000i64 ",
+        -9223372036854775808i64,
+        i64
+    );
+    assert_evals_to!(
+        "Num.subSaturated -5000000000000000000i64 5000000000000000000i64 ",
+        -9223372036854775808i64,
+        i64
+    );
+    assert_evals_to!(
+        "Num.subSaturated Num.maxF32 -Num.maxF32",
+        std::f32::INFINITY,
+        f32
+    );
+    assert_evals_to!(
+        "Num.subSaturated Num.minF32 -Num.minF32",
+        std::f32::NEG_INFINITY,
+        f32
+    );
+    assert_evals_to!(
+        "Num.subSaturated Num.maxF64 -Num.maxF64",
+        std::f64::INFINITY,
+        f64
+    );
+    assert_evals_to!(
+        "Num.subSaturated Num.minF64 -Num.minF64",
+        std::f64::NEG_INFINITY,
+        f64
+    );
+
+    assert_evals_to!(
+        "Num.subSaturated 170_141_183_460_469_231_731dec -1",
+        RocDec::from_str("170141183460469231731.687303715884105727").unwrap(),
+        RocDec
+    );
+    assert_evals_to!(
+        "Num.subSaturated -170_141_183_460_469_231_731dec 1",
+        RocDec::from_str("-170141183460469231731.687303715884105728").unwrap(),
+        RocDec
     );
 }
 
 #[test]
 #[cfg(any(feature = "gen-llvm", feature = "gen-wasm", feature = "gen-dev"))]
 fn mul_saturated() {
+    assert_evals_to!("Num.mulSaturated 200u8 2", 255u8, u8);
+    assert_evals_to!("Num.mulSaturated 100i8 2", 127i8, i8);
+    assert_evals_to!("Num.mulSaturated -100i8 2", -128i8, i8);
+    assert_evals_to!("Num.mulSaturated 40000u16 2", 65535u16, u16);
+    assert_evals_to!("Num.mulSaturated 20000i16 2", 32767i16, i16);
+    assert_evals_to!("Num.mulSaturated -20000i16 2", -32768i16, i16);
+    assert_evals_to!("Num.mulSaturated 3000000000u32 2", 4294967295u32, u32);
+    assert_evals_to!("Num.mulSaturated 2000000000i32 2", 2147483647i32, i32);
+    assert_evals_to!("Num.mulSaturated -2000000000i32 2", -2147483648i32, i32);
     assert_evals_to!(
-        indoc!(
-            r"
-            x : U8
-            x = 20
-            y : U8
-            y = 20
-            Num.mulSaturated x y
-            "
-        ),
-        255,
-        u8
+        "Num.mulSaturated 10000000000000000000u64 2",
+        18446744073709551615u64,
+        u64
     );
     assert_evals_to!(
-        indoc!(
-            r"
-            x : I8
-            x = -20
-            y : I8
-            y = -20
-            Num.mulSaturated x y
-            "
-        ),
-        127,
-        i8
+        "Num.mulSaturated 5000000000000000000i64 2",
+        9223372036854775807i64,
+        i64
     );
     assert_evals_to!(
-        indoc!(
-            r"
-            x : I8
-            x = 20
-            y : I8
-            y = -20
-            Num.mulSaturated x y
-            "
-        ),
-        -128,
-        i8
+        "Num.mulSaturated -5000000000000000000i64 2",
+        -9223372036854775808i64,
+        i64
     );
     assert_evals_to!(
-        indoc!(
-            r"
-            x : I8
-            x = -20
-            y : I8
-            y = 20
-            Num.mulSaturated x y
-            "
-        ),
-        -128,
-        i8
+        "Num.mulSaturated -5000000000000000000i64 2",
+        -9223372036854775808i64,
+        i64
+    );
+    assert_evals_to!("Num.mulSaturated Num.maxF32 2", std::f32::INFINITY, f32);
+    assert_evals_to!("Num.mulSaturated Num.minF32 2", std::f32::NEG_INFINITY, f32);
+    assert_evals_to!("Num.mulSaturated Num.maxF64 2", std::f64::INFINITY, f64);
+    assert_evals_to!("Num.mulSaturated Num.minF64 2", std::f64::NEG_INFINITY, f64);
+
+    // TODO: This doesn't work anywhere? It returns -1.374607431768211456 : Dec ?
+    /*
+    assert_evals_to!(
+        "Num.mulSaturated 170_141_183_460_469_231_731dec 2",
+        RocDec::from_str("170141183460469231731.687303715884105727").unwrap(),
+        RocDec
     );
     assert_evals_to!(
-        indoc!(
-            r"
-            x : I8
-            x = 20
-            y : I8
-            y = 20
-            Num.mulSaturated x y
-            "
-        ),
-        127,
-        i8
+        "Num.mulSaturated -170_141_183_460_469_231_731dec 2",
+        RocDec::from_str("-170141183460469231731.687303715884105728").unwrap(),
+        RocDec
     );
+    */
 }
 
 #[test]


### PR DESCRIPTION
MulSaturated and AddSaturated are now implemented for u128, i128

SubSaturated is now implemented for Dec even if it's a little strange to saturate at a decimal value:

```
» Num.subSaturated -170_141_183_460_469_231_731dec 1

-170141183460469231731.687303715884105728 : Dec
```

I decided to rm the `build_num_{mul,add}_saturated` methods because they don't require any asm-specifics. They either call out to bitcode, or in the case of floats, use the non-saturated version.