### PR TITLE
Make search box keyboard-friendly

### DIFF
--- a/crates/docs/src/static/search.js
+++ b/crates/docs/src/static/search.js
@@ -148,9 +148,13 @@
                 // De-focus and clear input box
                 searchBox.value = "";
                 searchBox.blur();
-              } else if (searchTypeAhead.contains(document.activeElement)) {
+              } else {
+                // Hide the search results
                 searchTypeAhead.classList.add("hidden");
-                searchBox.focus();
+
+                if (searchTypeAhead.contains(document.activeElement)) {
+                  searchBox.focus();
+                }
               }
             }
         });

--- a/crates/docs/src/static/search.js
+++ b/crates/docs/src/static/search.js
@@ -28,6 +28,56 @@
     let topSearchResultListItem = undefined;
 
     if (searchBox != null) {
+        function searchKeyDown(event) {
+          switch (event.key) {
+            case "ArrowDown": {
+              event.preventDefault();
+
+              const focused = document.querySelector("#search-type-ahead > li:not([class*='hidden']) > a:focus");
+
+              // Find the next element to focus.
+              let nextToFocus = focused?.parentElement?.nextElementSibling;
+
+              while (nextToFocus != null && nextToFocus.classList.contains("hidden")) {
+                nextToFocus = nextToFocus.nextElementSibling;
+              }
+
+              if (nextToFocus == null) {
+                // If none of the links were focused, focus the first one.
+                // Also if we've reached the last one in the list, wrap around to the first.
+                document.querySelector("#search-type-ahead > li:not([class*='hidden']) > a")?.focus();
+              } else {
+                nextToFocus.querySelector("a").focus();
+              }
+
+              break;
+            }
+            case "ArrowUp": {
+              event.preventDefault();
+
+              const focused = document.querySelector("#search-type-ahead > li:not([class*='hidden']) > a:focus");
+
+              // Find the next element to focus.
+              let nextToFocus = focused?.parentElement?.previousElementSibling;
+              while (nextToFocus != null && nextToFocus.classList.contains("hidden")) {
+                nextToFocus = nextToFocus.previousElementSibling;
+              }
+
+              if (nextToFocus == null) {
+                // If none of the links were focused, or we're at the first one, focus the search box again.
+                searchBox?.focus();
+              } else {
+                // If one of the links was focused, focus the previous one
+                nextToFocus.querySelector("a").focus();
+              }
+
+              break;
+            }
+          }
+        }
+
+        searchForm.addEventListener("keydown", searchKeyDown);
+
         function search() {
             topSearchResultListItem = undefined;
             let text = searchBox.value.toLowerCase(); // Search is case-insensitive.
@@ -88,29 +138,23 @@
         // Capture '/' keypress for quick search
         window.addEventListener("keyup", (e) => {
             if (e.key === "s" && document.activeElement !== searchBox) {
-                e.preventDefault;
+                e.preventDefault();
                 searchBox.focus();
                 searchBox.value = "";
             }
 
-            if (e.key === "Escape" && document.activeElement === searchBox) {
-                e.preventDefault;
-
-                // De-focus input box
+            if (e.key === "Escape") {
+              if (document.activeElement === searchBox) {
+                // De-focus and clear input box
+                searchBox.value = "";
                 searchBox.blur();
-            } else if (
-                e.key === "Escape" &&
-                searchTypeAhead.contains(document.activeElement)
-            ) {
-                e.preventDefault;
-
-                // De-focus type ahead
+              } else if (searchTypeAhead.contains(document.activeElement)) {
+                searchTypeAhead.classList.add("hidden");
                 searchBox.focus();
-                searchBox.blur();
+              }
             }
         });
     }
-
 
     const isTouchSupported = () => {
         try {

--- a/crates/docs/src/static/styles.css
+++ b/crates/docs/src/static/styles.css
@@ -498,7 +498,7 @@ pre>samp {
   border-color: var(--border-color);
   list-style-type: none;
   margin: 0;
-  padding: 10px;
+  padding: 0;
 }
 
 #search-type-ahead .type-ahead-link {
@@ -506,10 +506,16 @@ pre>samp {
   color: var(--text-color);
   line-height: 2em;
   display: inline-block;
+  position: relative;
+  box-sizing: border-box;
+  width: 100%;
+  height: 100%;
+  padding: 4px 8px;
 
   /* if it wraps, indent after the first line */
-  padding-left: 2em;
+  padding-left: calc(2em + 8px);
   text-indent: -2em;
+
 
   span {
     margin: 0px;
@@ -520,21 +526,24 @@ pre>samp {
     font-size: 1rem;
   }
 }
+
 #search-type-ahead li {
   box-sizing: border-box;
-  padding: 4px;
+  position: relative;
 }
 
-/*use browser defaults for focus outline*/
-#search-type-ahead li:focus-within {
-  /*firefox*/
-  outline: 5px auto Highlight;
-  /*chrome and safari*/
-  outline: 5px auto -webkit-focus-ring-color;
+#search-type-ahead:hover li:focus-within a:focus {
+  background: none;
 }
 
-.type-ahead-link:focus-visible {
+#search-type-ahead a:focus {
   outline: none;
+  background: var(--violet-bg);
+}
+
+#search-type-ahead a:hover {
+  background: var(--violet-bg) !important;
+  text-decoration: none;
 }
 
 #search-link {

--- a/crates/docs/src/static/styles.css
+++ b/crates/docs/src/static/styles.css
@@ -481,6 +481,10 @@ pre>samp {
   opacity: 1;
 }
 
+#module-search:focus {
+  outline: 2px solid var(--faded-color);
+}
+
 #search-type-ahead {
   font-family: var(--font-mono);
   display: flex;
@@ -532,18 +536,9 @@ pre>samp {
   position: relative;
 }
 
-#search-type-ahead:hover li:focus-within a:focus {
-  background: none;
-}
-
 #search-type-ahead a:focus {
   outline: none;
   background: var(--violet-bg);
-}
-
-#search-type-ahead a:hover {
-  background: var(--violet-bg) !important;
-  text-decoration: none;
 }
 
 #search-link {


### PR DESCRIPTION
Now you can use the arrow keys to move up and down the results, press Enter to select to one, and press Esc to hide the search results.

<img width="963" alt="Screenshot 2024-11-29 at 12 58 10 PM" src="https://github.com/user-attachments/assets/19f314fa-5f17-456e-927a-df04364dabd9">
