### PR TITLE
Show all search results, each with max of 3 lines

### DIFF
--- a/crates/docs/src/static/search.js
+++ b/crates/docs/src/static/search.js
@@ -27,6 +27,13 @@
     let searchForm = document.getElementById("module-search-form");
     let topSearchResultListItem = undefined;
 
+    // Hide the results whenever anyone clicks outside the search results.
+    window.addEventListener("click", function(event) {
+        if (!searchForm?.contains(event.target)) {
+            searchTypeAhead.classList.add("hidden");
+        }
+    });
+
     if (searchBox != null) {
         function searchKeyDown(event) {
           switch (event.key) {

--- a/crates/docs/src/static/search.js
+++ b/crates/docs/src/static/search.js
@@ -96,11 +96,7 @@
                             ?.textContent?.toLowerCase()
                             ?.replace(/\s+/g, "");
 
-                        if (
-                            totalResults < 5 &&
-                            (entryName.includes(text) ||
-                                entrySignature?.includes(text.replace(/\s+/g, "")))
-                        ) {
+                        if ((entryName.includes(text) || entrySignature?.includes(text.replace(/\s+/g, "")))) {
                             totalResults++;
                             entry.classList.remove("hidden");
                             if (topSearchResultListItem === undefined) {

--- a/crates/docs/src/static/styles.css
+++ b/crates/docs/src/static/styles.css
@@ -509,12 +509,18 @@ pre>samp {
   font-size: 1rem;
   color: var(--text-color);
   line-height: 2em;
-  display: inline-block;
   position: relative;
   box-sizing: border-box;
   width: 100%;
   height: 100%;
   padding: 4px 8px;
+
+  max-height: 6em;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
 
   /* if it wraps, indent after the first line */
   padding-left: calc(2em + 8px);


### PR DESCRIPTION
https://github.com/roc-lang/roc/pull/7272 should be merged first!

Now we show all search results rather than limiting them to 5. Otherwise, there's no way to scroll to see the rest of the results - and the most straightforward way to let you scroll through the results is to just show them all!

Also, we truncate to ellipses if a search result takes more than 3 lines to display. (You can see that happen in the first result.)

<img width="1072" alt="Screenshot 2024-11-29 at 1 25 48 PM" src="https://github.com/user-attachments/assets/21453bf3-7c34-484a-a275-9f21489405e4">

