### PR TITLE
Make the top bar go the full width of docs page

### DIFF
--- a/crates/docs/src/lib.rs
+++ b/crates/docs/src/lib.rs
@@ -241,20 +241,45 @@ fn render_package_index(docs_by_module: &[(ModuleId, ModuleDocumentation)]) -> S
         push_html(&mut module_list_buf, "li", [], link_buf.as_str());
     }
 
+    let header = {
+        let mut header_buf = String::new();
+
+        push_html(
+            &mut header_buf,
+            "h2",
+            [("class", "module-name")],
+            "Exposed Modules",
+        );
+
+        push_html(
+            &mut header_buf,
+            "a",
+            [
+                ("class", "llm-prompt-link"),
+                ("title", "Documentation in a LLM-friendly format"),
+                ("href", "llms.txt"),
+            ],
+            "LLM docs",
+        );
+
+        header_buf
+    };
+
     // The HTML for the index page
     let mut index_buf = String::new();
 
     push_html(
         &mut index_buf,
-        "h2",
-        [("class", "module-name")],
-        "Exposed Modules",
+        "div",
+        [("class", "module-header-container")],
+        &header,
     );
+
     push_html(
         &mut index_buf,
         "ul",
         [("class", "index-module-links")],
-        module_list_buf.as_str(),
+        &module_list_buf,
     );
 
     index_buf

--- a/crates/docs/src/static/index.html
+++ b/crates/docs/src/static/index.html
@@ -93,15 +93,6 @@
                     <!-- Search Type Ahead -->
                 </ul>
             </form>
-            <div id="llm-prompt-container">
-                <a
-                    id="llm-prompt-link"
-                    href="llms.txt"
-                    title="Documentation in a LLM friendly format"
-                >
-                    LLM docs
-                </a>
-            </div>
         </header>
         <div class="header-end-extension">
             <!-- if the window gets big, this extends the purple bar on the top header to the right edge of the window -->

--- a/crates/docs/src/static/index.html
+++ b/crates/docs/src/static/index.html
@@ -1,75 +1,116 @@
 <!doctype html>
 <html lang="en">
-
-<head>
-    <meta charset="utf-8">
-    <!-- Page title -->
-    <!-- <meta name="description" content="TODO populate this based on the module's description"> -->
-    <meta name="viewport" content="width=device-width">
-    <base href="<!-- base -->">
-    <script type="text/javascript" src="search.js" defer></script>
-    <link rel="stylesheet" href="styles.css">
-    <link rel="icon" href="/favicon.svg">
-    <!-- Safari ignores rel="icon" and only respects rel="mask-icon". It will render the SVG with
+    <head>
+        <meta charset="utf-8" />
+        <!-- Page title -->
+        <!-- <meta name="description" content="TODO populate this based on the module's description"> -->
+        <meta name="viewport" content="width=device-width" />
+        <base href="<!-- base -->" />
+        <script type="text/javascript" src="search.js" defer></script>
+        <link rel="stylesheet" href="styles.css" />
+        <link rel="icon" href="/favicon.svg" />
+        <!-- Safari ignores rel="icon" and only respects rel="mask-icon". It will render the SVG with
     fill="#000" unless this `color` attribute here is hardcoded (not a CSS `var()`) to override it.
   -->
-    <link rel="mask-icon" href="/favicon.svg" color="#7d59dd">
-    <!-- Prefetch links -->
-</head>
+        <link rel="mask-icon" href="/favicon.svg" color="#7d59dd" />
+        <!-- Prefetch links -->
+    </head>
 
-<body>
-    <nav id="sidebar-nav">
-        <div class="module-links">
-            <!-- Module links -->
-        </div>
-    </nav>
-    <div class="top-header-extension">
-        <!-- if the window gets big, this extends the purple bar on the top header to the left edge of the window -->
-    </div>
-    <header class="top-header">
-        <div class="pkg-and-logo">
-            <a class="logo" href="/" aria-labelledby="logo-link">
-                <svg viewBox="0 -6 51 58" fill="none" xmlns="http://www.w3.org/2000/svg" aria-labelledby="logo-link"
-                    role="img">
-                    <title id="logo-link">Return to Roc packages</title>
-                    <polygon role="presentation"
-                        points="0,0 23.8834,3.21052 37.2438,19.0101 45.9665,16.6324 50.5,22 45,22 44.0315,26.3689 26.4673,39.3424 27.4527,45.2132 17.655,53 23.6751,22.7086" />
-                </svg>
-            </a>
-            <!-- Package Name -->
-        </div>
-        <form id="module-search-form">
-            <input
-                id="module-search"
-                aria-labelledby="search-link"
-                type="text"
-                placeholder="Search"
-                role="combobox"
-                aria-autocomplete="list"
-                aria-expanded="false"
-                aria-controls="search-type-ahead"
-            />
-            <label for="module-search" id="search-link">Search (press s)</label>
-            <span id="search-shortcut-key" aria-hidden="true">s</span>
-            <ul id="search-type-ahead" role="listbox" aria-label="Search Results" class="hidden">
-                <!-- Search Type Ahead -->
-            </ul>
-        </form>
-        <div id="llm-prompt-container">
-            <a id="llm-prompt-link" href="llms.txt" title="Documentation in a LLM friendly format">
-                LLM docs
-            </a>
-        </div>
-        <div class="top-header-triangle">
+    <body>
+        <nav id="sidebar-nav">
+            <div class="module-links">
+                <!-- Module links -->
+            </div>
+        </nav>
+        <div class="header-start-extension">
             <!-- if the window gets big, this extends the purple bar on the top header to the left edge of the window -->
         </div>
-    </header>
-    <main>
-        <!-- Module Docs -->
-    </main>
-    <footer>
-        <p>Made by people who like to make nice things.</p>
-    </footer>
-</body>
-
+        <header class="top-header">
+            <div class="pkg-and-logo">
+                <a class="logo" href="/" aria-labelledby="logo-link">
+                    <svg
+                        viewBox="0 -6 51 58"
+                        fill="none"
+                        xmlns="http://www.w3.org/2000/svg"
+                        aria-labelledby="logo-link"
+                        role="img"
+                    >
+                        <title id="logo-link">Return to Roc packages</title>
+                        <polygon
+                            role="presentation"
+                            points="0,0 23.8834,3.21052 37.2438,19.0101 45.9665,16.6324 50.5,22 45,22 44.0315,26.3689 26.4673,39.3424 27.4527,45.2132 17.655,53 23.6751,22.7086"
+                        />
+                    </svg>
+                </a>
+                <!-- Package Name -->
+            </div>
+            <form id="module-search-form">
+                <input
+                    id="module-search"
+                    aria-labelledby="search-label"
+                    type="text"
+                    placeholder="Search"
+                    role="combobox"
+                    aria-autocomplete="list"
+                    aria-expanded="false"
+                    aria-controls="search-type-ahead"
+                />
+                <label for="module-search" id="search-label"
+                    >(press
+                    <span id="search-shortcut-key" aria-hidden="true">s</span
+                    >)</label
+                >
+                <!-- Magnifying Glass icon -->
+                <svg
+                    version="1.1"
+                    xmlns="http://www.w3.org/2000/svg"
+                    class="search-icon"
+                    xmlns:xlink="http://www.w3.org/1999/xlink"
+                    width="24px"
+                    height="24px"
+                    viewBox="0 0 512 512"
+                    xml:space="preserve"
+                >
+                    <g>
+                        <path
+                            d="M449.803,62.197C408.443,20.807,353.85-0.037,299.646-0.006C245.428-0.037,190.85,20.807,149.49,62.197
+		C108.1,103.557,87.24,158.15,87.303,212.338c-0.047,37.859,10.359,75.766,30.547,109.359L15.021,424.525
+		c-20.016,20.016-20.016,52.453,0,72.469c20,20.016,52.453,20.016,72.453,0L190.318,394.15
+		c33.578,20.203,71.5,30.594,109.328,30.547c54.203,0.047,108.797-20.797,150.156-62.188
+		c41.375-41.359,62.234-95.938,62.188-150.172C512.053,158.15,491.178,103.557,449.803,62.197z M391.818,304.541
+		c-25.547,25.531-58.672,38.125-92.172,38.188c-33.5-0.063-66.609-12.656-92.188-38.188c-25.531-25.578-38.125-58.688-38.188-92.203
+		c0.063-33.484,12.656-66.609,38.188-92.172c25.578-25.531,58.688-38.125,92.188-38.188c33.5,0.063,66.625,12.656,92.188,38.188
+		c25.531,25.563,38.125,58.688,38.188,92.172C429.959,245.854,417.365,278.963,391.818,304.541z"
+                        ></path>
+                    </g>
+                </svg>
+                <ul
+                    id="search-type-ahead"
+                    role="listbox"
+                    aria-label="Search Results"
+                    class="hidden"
+                >
+                    <!-- Search Type Ahead -->
+                </ul>
+            </form>
+            <div id="llm-prompt-container">
+                <a
+                    id="llm-prompt-link"
+                    href="llms.txt"
+                    title="Documentation in a LLM friendly format"
+                >
+                    LLM docs
+                </a>
+            </div>
+        </header>
+        <div class="header-end-extension">
+            <!-- if the window gets big, this extends the purple bar on the top header to the right edge of the window -->
+        </div>
+        <main>
+            <!-- Module Docs -->
+        </main>
+        <footer>
+            <p>Made by people who like to make nice things.</p>
+        </footer>
+    </body>
 </html>

--- a/crates/docs/src/static/styles.css
+++ b/crates/docs/src/static/styles.css
@@ -636,6 +636,29 @@ pre>samp {
 }
 
 @media only screen and (max-device-width: 480px) and (orientation: portrait) {
+    body {
+      grid-template-areas:
+        "header"
+        "main"
+        "sidebar"
+        "footer";
+    }
+
+    #sidebar-nav {
+      grid-area: sidebar;
+    }
+
+    main {
+      grid-area: main;
+    }
+
+    .top-header {
+      grid-area: header;
+    }
+
+    footer {
+      grid-area: footer;
+    }
   :root {
       --top-header-height: 160px;
   }
@@ -702,20 +725,12 @@ pre>samp {
   }
 
   main {
-      grid-column-start: none;
-      grid-column-end: none;
-      grid-row-start: above-footer;
-      grid-row-end: above-footer;
       padding: 18px;
       font-size: 16px;
       max-width: 480px;
   }
 
   #sidebar-nav {
-      grid-column-start: none;
-      grid-column-end: none;
-      grid-row-start: sidebar;
-      grid-row-end: sidebar;
       margin-top: 0;
       padding-left: 0;
       width: auto;
@@ -738,9 +753,6 @@ pre>samp {
 
   body {
       grid-template-columns: auto;
-      grid-template-rows: [top-header] var(--top-header-height) [before-sidebar] auto [sidebar] auto [above-footer] auto [footer] auto;
-      /* [before-sidebar] 1fr [sidebar] var(--sidebar-width) [main-content] fit-content(calc(1280px - var(--sidebar-width))) [end] 1fr; */
-
       margin: 0;
       min-width: 320px;
       max-width: 100%;

--- a/crates/docs/src/static/styles.css
+++ b/crates/docs/src/static/styles.css
@@ -582,24 +582,26 @@ pre>samp {
   pointer-events: none;
 }
 
-#llm-prompt-container {
-  background-color: var(--violet-bg);
-  height: 100%;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  font-size: initial;
-}
-
-#llm-prompt-copy-button:hover {
-  border-color: var(--link-hover-color);
-  color: var(--link-hover-color);
-}
-
 .builtins-tip {
   padding: 1em;
   font-style: italic;
   line-height: 1.3em;
+}
+
+.module-header-container {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  margin-bottom: 48px;
+}
+
+.llm-prompt-link {
+  flex-shrink: 0;
+}
+
+.module-name {
+    flex-grow: 1;
+    margin-bottom: 0;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -637,7 +639,19 @@ pre>samp {
       --top-header-height: 160px;
   }
 
-  #search-shortcut-key {
+  #search-shortcut-key, .header-start-extension, .header-end-extension, #search-label {
+      display: none;
+  }
+
+  #module-search-form {
+      padding: 0 16px;
+      width: 100%;
+      height: auto;
+      margin-bottom: 16px;
+  }
+
+  /* Hide the Copy Link button on mobile. */
+  .entry-name a:first-of-type {
       display: none;
   }
 
@@ -682,7 +696,6 @@ pre>samp {
       font-size: 36px;
       margin-top: 8px;
       margin-bottom: 8px;
-      max-width: calc(100% - 18px);
       overflow: hidden;
       text-overflow: ellipsis;
   }

--- a/crates/docs/src/static/styles.css
+++ b/crates/docs/src/static/styles.css
@@ -180,6 +180,7 @@ main {
   max-width: 740px;
   /* necessary for text-overflow: ellipsis to work in descendants */
   min-width: 0;
+  overflow-x: auto;
   /* fixes issues with horizonatal scroll in cases where word is too long,
   like in one of the examples at https://www.roc-lang.org/builtins/Num#Dec */
   overflow-wrap: break-word;
@@ -707,7 +708,7 @@ pre>samp {
       grid-row-end: above-footer;
       padding: 18px;
       font-size: 16px;
-      max-width: none;
+      max-width: 480px;
   }
 
   #sidebar-nav {

--- a/crates/docs/src/static/styles.css
+++ b/crates/docs/src/static/styles.css
@@ -241,9 +241,17 @@ padding: 0px 16px;
   width: 100%;
 }
 
-.top-header-extension {
+.header-start-extension {
   grid-column-start: before-sidebar;
   grid-column-end: sidebar;
+  grid-row-start: top-header;
+  grid-row-end: top-header;
+  background-color: var(--violet-bg);
+}
+
+.header-end-extension {
+  grid-column-start: end;
+  grid-column-end: end;
   grid-row-start: top-header;
   grid-row-end: top-header;
   background-color: var(--violet-bg);
@@ -262,19 +270,9 @@ padding: 0px 16px;
   font-family: var(--font-sans);
   font-size: 24px;
   height: 100%;
+  background-color: var(--violet-bg);
   /* min-width must be set to something (even 0) for text-overflow: ellipsis to work in descendants, but we want this anyway. */
   min-width: 1024px;
-}
-
-.top-header-triangle {
-  /* This used to be a clip-path, but Firefox on Android (at least as of early 2020)
- * rendered the page extremely slowly in that version. With this approach it's super fast.
- */
-  width: 0;
-  height: 0;
-  border-style: solid;
-  border-width: var(--top-header-height) 0 0 48px;
-  border-color: transparent transparent transparent var(--violet-bg);
 }
 
 p {
@@ -449,7 +447,6 @@ pre>samp {
   height: 100%;
   background-color: var(--violet-bg);
   position: relative;
-  max-width: 500px;
   flex-grow: 1;
   box-sizing: border-box;
   padding: 0px var(--module-search-form-padding-width);
@@ -463,6 +460,7 @@ pre>samp {
 }
 
 #module-search {
+  border-radius: 8px;
   display: block;
   position: relative;
   box-sizing: border-box;
@@ -481,7 +479,7 @@ pre>samp {
   opacity: 1;
 }
 
-#module-search:focus {
+#module-search:focus, #module-search:hover {
   outline: 2px solid var(--faded-color);
 }
 
@@ -503,6 +501,14 @@ pre>samp {
   list-style-type: none;
   margin: 0;
   padding: 0;
+}
+
+.search-icon {
+    fill: var(--faded-color);
+    pointer-events: none;
+    opacity: 0.6;
+    position: absolute;
+    right: 32px;
 }
 
 #search-type-ahead .type-ahead-link {
@@ -547,15 +553,22 @@ pre>samp {
   background: var(--violet-bg);
 }
 
-#search-link {
-  box-sizing: border-box;
+#module-search-form:focus-within #search-label, #module-search-form:focus-within .search-icon {
   display: none;
+}
+
+#search-label {
+  color: var(--faded-color);
+  box-sizing: border-box;
   align-items: center;
   font-size: 18px;
   line-height: 18px;
   padding: 12px 16px;
   height: 48px;
-  cursor: pointer;
+  pointer-events: none;
+  position: absolute;
+  top: 12px;
+  left: 96px;
 }
 
 #search-shortcut-key {
@@ -566,8 +579,7 @@ pre>samp {
   font-style: normal;
   line-height: 15px;
   opacity: 0.6;
-  position: absolute;
-  right: 30px;
+  pointer-events: none;
 }
 
 #llm-prompt-container {


### PR DESCRIPTION
This design seems to fit the search bar better. 

<img width="1918" alt="Screenshot 2024-11-29 at 6 38 30 PM" src="https://github.com/user-attachments/assets/ec29522e-2a04-4389-8f51-ae108f8f09bf">

---

Also moved the "LLM docs" link to the package overview, to simplify the nav bar for the common case:

<img width="1918" alt="Screenshot 2024-11-29 at 6 37 05 PM" src="https://github.com/user-attachments/assets/65bdb244-ca0f-43e6-8262-3018767351d8">


---

On mobile, I also moved the nav to after the main content, on the theory that if you're coming from the main page, you have all the modules listed right away anyway, and otherwise you might just be searching anyway:

<img width="440" alt="Screenshot 2024-11-29 at 8 20 23 PM" src="https://github.com/user-attachments/assets/d57df0ca-c841-402f-afb3-8581168ced39">
