### PR TITLE
Num.powInt: panic on overflow

### DIFF
--- a/crates/compiler/gen_wasm/src/low_level.rs
+++ b/crates/compiler/gen_wasm/src/low_level.rs
@@ -1829,24 +1829,12 @@ impl<'a> LowLevelCall<'a> {
                     _ => panic_ret_type(),
                 }
             }
-            NumPowInt => {
-                self.load_args(backend);
-                let base_type = CodeGenNumType::for_symbol(backend, self.arguments[0]);
-                let exponent_type = CodeGenNumType::for_symbol(backend, self.arguments[1]);
-                let ret_type = CodeGenNumType::from(self.ret_layout);
-
-                debug_assert!(base_type == exponent_type);
-                debug_assert!(exponent_type == ret_type);
-
-                let width = match ret_type {
-                    CodeGenNumType::I32 => IntWidth::I32,
-                    CodeGenNumType::I64 => IntWidth::I64,
-                    CodeGenNumType::I128 => todo!("{:?} for I128", self.lowlevel),
-                    _ => internal_error!("Invalid return type for pow: {:?}", ret_type),
-                };
-
-                self.load_args_and_call_zig(backend, &bitcode::NUM_POW_INT[width])
-            }
+            NumPowInt => match self.ret_layout_raw {
+                LayoutRepr::Builtin(Builtin::Int(width)) => {
+                    self.load_args_and_call_zig(backend, &bitcode::NUM_POW_INT[width])
+                }
+                _ => panic_ret_type(),
+            },
 
             NumIsNan => num_is_nan(backend, self.arguments[0]),
             NumIsInfinite => num_is_infinite(backend, self.arguments[0]),

--- a/crates/compiler/test_gen/src/gen_num.rs
+++ b/crates/compiler/test_gen/src/gen_num.rs
@@ -1928,6 +1928,13 @@ fn pow_int() {
 
 #[test]
 #[cfg(any(feature = "gen-llvm", feature = "gen-wasm", feature = "gen-dev"))]
+#[should_panic(expected = r#"Roc failed with message: "Integer raised to power overflowed!"#)]
+fn pow_int_overflow() {
+    assert_evals_to!("Num.powInt 2u8 8", 0, u8);
+}
+
+#[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-wasm", feature = "gen-dev"))]
 fn atan() {
     assert_evals_to!("Num.atan 10f64", 1.4711276743037347, f64);
 }


### PR DESCRIPTION
The intent of this change is to catch integer overflow in the zig bitcode implementation of `NumPowInt`, and turn that into a `roc_panic` with a good error message. This change also ends up implementing `PowInt` in gen-wasm for all integer types.

Closes #7062 