### PR TITLE
add RoxBox::as_refcount_ptr

### DIFF
--- a/crates/roc_std/src/roc_box.rs
+++ b/crates/roc_std/src/roc_box.rs
@@ -76,6 +76,10 @@ where
 
     /// The raw pointer to a roc box, including the leading refcount
     /// Intended for use by platforms in roc_dealloc
+    ///
+    /// # Safety
+    ///
+    /// Returns a raw pointer to the roc box
     pub unsafe fn as_refcount_ptr(&self) -> *mut c_void {
         let alignment = Self::alloc_alignment();
         let with_offset = unsafe { self.contents.as_ptr().cast::<u8>().sub(alignment) };

--- a/crates/roc_std/src/roc_box.rs
+++ b/crates/roc_std/src/roc_box.rs
@@ -76,7 +76,7 @@ where
 
     /// The raw pointer to a roc box, including the leading refcount
     /// Intended for use by platforms in roc_dealloc
-    pub unsafe fn as_ptr(&self) -> *mut c_void {
+    pub unsafe fn as_refcount_ptr(&self) -> *mut c_void {
         let alignment = Self::alloc_alignment();
         let with_offset = unsafe { self.contents.as_ptr().cast::<u8>().sub(alignment) };
         with_offset as *mut c_void

--- a/crates/roc_std/src/roc_box.rs
+++ b/crates/roc_std/src/roc_box.rs
@@ -71,7 +71,7 @@ where
     }
 
     fn storage(&self) -> &Cell<Storage> {
-        unsafe { &*self.as_ptr().cast::<Cell<Storage>>() }
+        unsafe { &*self.as_refcount_ptr().cast::<Cell<Storage>>() }
     }
 
     /// The raw pointer to a roc box, including the leading refcount


### PR DESCRIPTION
This is intended as a convenience for platform authors implementing roc_dealloc, addressing the use case in [this zulip thread](https://roc.zulipchat.com/#narrow/channel/304641-ideas/topic/Host.20iteration.20access.20to.20roc.20resource.20heaps).