### PR TITLE
fix tutorial styling

### DIFF
--- a/www/content/install/index.md
+++ b/www/content/install/index.md
@@ -44,7 +44,7 @@ Once you've installed <code>roc</code>, check out the [tutorial](/tutorial) to l
 
 <a class="btn-small" href="/tutorial">Start Tutorial</a>
 
-### [Additional Learning Resources] {#additional-learning-resources}
+### [Additional Learning Resources](#additional-learning-resources) {#additional-learning-resources}
 
 If you are looking for more resources to learn about Roc, check out the following:
 

--- a/www/content/tutorial.md
+++ b/www/content/tutorial.md
@@ -2333,11 +2333,11 @@ Here are various Roc expressions involving operators, and what they desugar to.
 | `f!`                         | [see example](https://www.roc-lang.org/examples/DesugaringAwait/README.html)     |
 | `f?`                         | [see example](https://www.roc-lang.org/examples/DesugaringTry/README.html)     |
 
-</section>
-<script type="text/javascript" src="/builtins/search.js" defer></script>
-
-### [Additional Resources]
+### [Additional Resources](#additional-resources) {#additional-resources}
 
 You've completed the tutorial, well done!
 
 If you are looking for more resources to learn Roc, check out [these links](/install#additional-learning-resources).
+
+</section>
+<script type="text/javascript" src="/builtins/search.js" defer></script>


### PR DESCRIPTION
# Tutorial Page
## Before

<img width="1173" alt="Screenshot 2024-12-01 at 15 42 03" src="https://github.com/user-attachments/assets/7fdb34d9-6d36-44d8-ae72-596e2a9387a6">

## After
<img width="1319" alt="Screenshot 2024-12-01 at 15 45 25" src="https://github.com/user-attachments/assets/6d0be058-f3f3-4524-b8fb-c912bfc5adac">

# Install Page
## Before 

<img width="1013" alt="Screenshot 2024-12-01 at 15 45 54" src="https://github.com/user-attachments/assets/ee16e33a-b113-441c-bb5d-5b6a7b574b68">
## After

<img width="1087" alt="Screenshot 2024-12-01 at 15 46 30" src="https://github.com/user-attachments/assets/b1018ab8-ea7f-4b2a-890c-aab69a645b7e">
