### PR TITLE
Purity inference module params fixes

### DIFF
--- a/crates/cli/tests/cli_tests.rs
+++ b/crates/cli/tests/cli_tests.rs
@@ -1434,6 +1434,20 @@ mod cli_tests {
         .run()
         .assert_clean_success();
     }
+
+    #[test]
+    fn module_params_effectful_param() {
+        let cli_check = ExecCli::new(
+            CMD_CHECK,
+            file_from_root(
+                "crates/cli/tests/test-projects/module_params",
+                "effect_module.roc",
+            ),
+        );
+
+        let cli_check_out = cli_check.run();
+        cli_check_out.assert_clean_success();
+    }
 }
 
 #[cfg(feature = "wasm32-cli-run")]

--- a/crates/cli/tests/test-projects/module_params/effect_module.roc
+++ b/crates/cli/tests/test-projects/module_params/effect_module.roc
@@ -1,0 +1,3 @@
+module { stdout! } -> [log!]
+
+log! = \msg, level -> stdout! "$(level):$(msg)"

--- a/crates/compiler/load_internal/src/file.rs
+++ b/crates/compiler/load_internal/src/file.rs
@@ -2269,18 +2269,18 @@ fn update<'a>(
                         state.fx_mode = FxMode::PurityInference;
                     }
                 }
-                Builtin { .. } | Module { .. } => {
+                Builtin { .. } => {
                     if header.is_root_module {
                         debug_assert!(matches!(state.platform_path, PlatformPath::NotSpecified));
                         state.platform_path = PlatformPath::RootIsModule;
                     }
                 }
-                Hosted { exposes, .. } => {
+                Hosted { exposes, .. } | Module { exposes, .. } => {
                     if header.is_root_module {
                         debug_assert!(matches!(state.platform_path, PlatformPath::NotSpecified));
                         state.platform_path = PlatformPath::RootIsHosted;
                     }
-
+                    // WARNING: This will be bypassed if we export a record of effectful functions. This is a temporary hacky method
                     if exposes
                         .iter()
                         .any(|exposed| exposed.value.is_effectful_fn())

--- a/crates/compiler/unify/src/unify.rs
+++ b/crates/compiler/unify/src/unify.rs
@@ -3345,6 +3345,17 @@ fn unify_flat_type<M: MetaCollector>(
 
             outcome
         }
+        (Func(args, closure, ret, fx), EffectfulFunc) => {
+            let mut outcome = unify_pool(env, pool, *fx, Variable::EFFECTFUL, ctx.mode);
+
+            outcome.union(merge(
+                env,
+                ctx,
+                Structure(Func(*args, *closure, *ret, Variable::EFFECTFUL)),
+            ));
+
+            outcome
+        }
         (FunctionOrTagUnion(tag_names, tag_symbols, ext), Func(args, closure, ret, fx)) => {
             unify_function_or_tag_union_and_func(
                 env,


### PR DESCRIPTION
This fixes two issues:
1. when running rock check on a module using purity inference the compiler think it's in task effect mode and looks for "stdout" instead of "stdout!"
2. effectful functions provided as module params not unifying properly, causing errors like this:
```
This is the type I inferred:

    { stdin! : {} => Result (List U8) [
        EndOfFile,
        StdinErr [
            AlreadyExists,
            BrokenPipe,
            Interrupted,
            NotFound,
            Other Str,
            OutOfMemory,
            PermissionDenied,
            Unsupported,
        ],
    ], … }

However, AoC expects:

    { stdin! : effectful function, … }
 ```

