### PR TITLE
Generalize return vars

### DIFF
--- a/crates/compiler/constrain/src/expr.rs
+++ b/crates/compiler/constrain/src/expr.rs
@@ -1438,14 +1438,16 @@ pub fn constrain_expr(
                 return_value.region,
             ));
 
-            constrain_expr(
+            let return_con = constrain_expr(
                 types,
                 constraints,
                 env,
                 return_value.region,
                 &return_value.value,
                 expected_return_value,
-            )
+            );
+
+            constraints.exists([*return_var], return_con)
         }
         Tag {
             tag_union_var: variant_var,

--- a/crates/compiler/load/tests/test_reporting.rs
+++ b/crates/compiler/load/tests/test_reporting.rs
@@ -14727,6 +14727,25 @@ All branches in an `if` must have the same type!
     );
 
     test_report!(
+        function_with_early_return_generalizes,
+        indoc!(
+            r#"
+            parseItemsWith = \parser ->
+                when List.mapTry ["123", "456"] parser is
+                    Ok ok -> Ok ok
+                    Err err ->
+                        return Err err
+
+            u64Nums = parseItemsWith Str.toU64
+            u8Nums = parseItemsWith Str.toU8
+
+            "$(Inspect.toStr u64Nums) $(Inspect.toStr u8Nums)"
+            "#
+        ),
+        @"" // no errors
+    );
+
+    test_report!(
         leftover_statement,
         indoc!(
             r#"


### PR DESCRIPTION
I thought that return type vars would auto-generalize with their containing functions, but I was incorrect, and Weaver was failing to type-check because of it. This generalizes return type vars and validates it works with an otherwise failing test case.