### PR TITLE
Prevent compiler errors from terminating the language server process

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2683,6 +2683,7 @@ dependencies = [
  "parking_lot",
  "roc_can",
  "roc_collections",
+ "roc_error_macros",
  "roc_fmt",
  "roc_load",
  "roc_module",

--- a/crates/language_server/Cargo.toml
+++ b/crates/language_server/Cargo.toml
@@ -40,3 +40,5 @@ log.workspace = true
 indoc.workspace = true
 env_logger = "0.10.1"
 futures.workspace = true
+roc_error_macros.workspace = true
+


### PR DESCRIPTION
This prevents the compiler from calling exit when crashing when running within the language server. 
Instead, we panic and the language server then catches that panic.

I had no idea it was calling exit rather than panicking this  whole time and this was why I could never seem to unwind the panics  :facepalm: 

This will massively improve the language server experience!