### PR TITLE
Basic tag completion

### DIFF
--- a/crates/language_server/src/analysis/analysed_doc.rs
+++ b/crates/language_server/src/analysis/analysed_doc.rs
@@ -13,7 +13,10 @@ use tower_lsp::lsp_types::{
 };
 
 use crate::{
-    analysis::completion::{field_completion, get_completion_items, get_module_completion_items},
+    analysis::completion::{
+        field_completion, get_completion_items, get_module_completion_items,
+        get_tag_completion_items,
+    },
     convert::{ToRange, ToRocPosition},
 };
 
@@ -261,7 +264,7 @@ impl AnalyzedDocument {
             if is_module_completion {
                 info!("Getting module dot completion...");
                 Some(get_module_completion_items(
-                    symbol_prefix,
+                    &symbol_prefix,
                     interns,
                     imports,
                     modules_info,
@@ -284,13 +287,16 @@ impl AnalyzedDocument {
 
             if is_module_or_type_completion {
                 info!("Getting module completion...");
-                let completions = get_module_completion_items(
-                    symbol_prefix,
+                let mut completions = get_module_completion_items(
+                    &symbol_prefix,
                     interns,
                     imports,
                     modules_info,
                     true,
                 );
+                let tag_completions =
+                    get_tag_completion_items(&symbol_prefix, module_id, modules_info);
+                completions.extend(tag_completions);
                 Some(completions)
             } else {
                 info!("Getting variable completion...");


### PR DESCRIPTION
Adds completion for tags into the language server:
![image](https://github.com/user-attachments/assets/1f50dd83-b30d-4b97-8bd8-58a94d581764)

Currently doesn't support any kind of type info. I'm sure it's possible but this was easy and getting that info doesn't appear to be. 
Low hanging fruit and all that.