### PR TITLE
Convert unused dbg!()s to eprintln!()s

### DIFF
--- a/crates/compiler/can/src/suffixed.rs
+++ b/crates/compiler/can/src/suffixed.rs
@@ -164,7 +164,7 @@ pub fn unwrap_suffixed_expression<'a>(
     // USEFUL TO SEE THE UNWRAPPING
     // OF AST NODES AS THEY DESCEND
     // if is_expr_suffixed(&loc_expr.value) {
-    //     dbg!(&maybe_def_pat, &loc_expr, &unwrapped_expression);
+    //     eprintln!("{:?}, {:?}, {:?}", &maybe_def_pat, &loc_expr, &unwrapped_expression);
     // }
 
     unwrapped_expression

--- a/crates/compiler/gen_dev/src/run_roc.rs
+++ b/crates/compiler/gen_dev/src/run_roc.rs
@@ -19,7 +19,7 @@ macro_rules! run_jit_function_raw {
             let result = main();
 
             if !$errors.is_empty() {
-                dbg!(&$errors);
+                eprintln!("{:?}", &$errors);
 
                 assert_eq!(
                     $errors,

--- a/crates/compiler/parse/tests/test_parse.rs
+++ b/crates/compiler/parse/tests/test_parse.rs
@@ -372,10 +372,10 @@ mod test_parse {
         let parsed = parse_module_defs(arena, state, ast::Defs::default());
         match parsed {
             Ok(_) => {
-                // dbg!(_state);
+                // eprintln!("{:?}", _state);
             }
             Err(_) => {
-                // dbg!(_fail, _state);
+                // eprintln!("{:?}, {:?}", _fail, _state);
                 panic!("Failed to parse!");
             }
         }

--- a/crates/compiler/specialize_types/src/specialize_type.rs
+++ b/crates/compiler/specialize_types/src/specialize_type.rs
@@ -155,7 +155,7 @@ impl<'a, 'c, 'd, 'e, 'f, 'm, 'p, P: Push<Problem>> Env<'a, 'c, 'd, 'e, 'f, 'm, '
         }
 
         // Convert the Content to a MonoType, often by passing an iterator. None of these iterators introduce allocations.
-        let mono_id = match dbg!(*subs.get_content_without_compacting(root_var)) {
+        let mono_id = match *subs.get_content_without_compacting(root_var) {
             Content::Structure(flat_type) => match flat_type {
                 FlatType::Apply(symbol, args) => {
                     if symbol.is_builtin() {

--- a/crates/compiler/test_gen/src/helpers/dev.rs
+++ b/crates/compiler/test_gen/src/helpers/dev.rs
@@ -340,8 +340,6 @@ pub(crate) fn asm_evals_to<T, U, F>(
     let result = crate::helpers::dev::run_test_main::<T>(&lib);
 
     if !errors.is_empty() {
-        dbg!(&errors);
-
         assert_eq!(
             errors,
             std::vec::Vec::new(),

--- a/crates/compiler/unify/src/unify.rs
+++ b/crates/compiler/unify/src/unify.rs
@@ -448,9 +448,9 @@ fn debug_print_unified_types<M: MetaCollector>(
         //        let (type1, _problems1) = subs.var_to_error_type(ctx.first);
         //        let (type2, _problems2) = subs.var_to_error_type(ctx.second);
         //        println!("\n --------------- \n");
-        //        dbg!(ctx.first, type1);
+        //        eprintln!("{:?}, {:?}", ctx.first, type1);
         //        println!("\n --- \n");
-        //        dbg!(ctx.second, type2);
+        //        eprintln!({:?}, {:?}", ctx.second, type2);
         //        println!("\n --------------- \n");
         let content_1 = env.get(ctx.first).content;
         let content_2 = env.get(ctx.second).content;

--- a/crates/linker/src/macho.rs
+++ b/crates/linker/src/macho.rs
@@ -763,11 +763,6 @@ fn gen_macho_le(
                 //             .set(LE , old_offset + md.added_byte_count as u32);
                 //     }
 
-                //     // dbg!(&section.reloff.get(LE));
-                //     // dbg!(section.reloff.get(LE) as i32);
-                //     // dbg!(&section);
-                //     // dbg!(&md.added_byte_count);
-                //     // dbg!(String::from_utf8_lossy(&section.sectname));
                 //     if section.nreloc.get(LE) > 0 {
                 //         section.reloff.set(
                 //             LE ,

--- a/crates/linker/src/pe.rs
+++ b/crates/linker/src/pe.rs
@@ -614,7 +614,6 @@ impl DynamicRelocationsPe {
         let mut it = import_table.descriptors()?;
         while let Some(descriptor) = it.next()? {
             let name = import_table.name(descriptor.name.get(LE))?;
-            // dbg!(String::from_utf8_lossy(name));
 
             if name == APP_DLL.as_bytes() {
                 return Ok(Some((*descriptor, index)));

--- a/crates/repl_test/test_wasm.sh
+++ b/crates/repl_test/test_wasm.sh
@@ -6,7 +6,7 @@ set -euxo pipefail
 # If we ever decide to do that, one of the cargo processes will need to use the `--target-dir` option.
 
 # We need to clear RUSTFLAGS for this command, as CI sets normally some flags that are specific to CPU targets.
-# Tests target wasm32-wasi instead of wasm32-unknown-unknown, so that we can debug with println! and dbg!
+# Tests target wasm32-wasi instead of wasm32-unknown-unknown, so that we can debug with println! and dbg
 # This has to be built with lto for now. If we do not use lto, it will pull in system calls we don't yet support.
 # TODO: Add system calls to our wasi interp so that this can just be built in release without lto.
 RUSTFLAGS="" cargo build --locked --profile release-with-lto --target wasm32-wasi -p roc_repl_wasm --no-default-features --features wasi_test

--- a/crates/repl_wasm/src/externs_js.rs
+++ b/crates/repl_wasm/src/externs_js.rs
@@ -20,7 +20,7 @@ extern "C" {
 
 // To debug in the browser, start up the web REPL as per instructions in repl_www/README.md
 // and sprinkle your code with console_log!("{:?}", my_value);
-// (Or if you're running the unit tests with WASI, you can just use println! or dbg!)
+// (Or if you're running the unit tests with WASI, you can just use println! or dbg)
 #[macro_export]
 macro_rules! console_log {
     ($($t:tt)*) => (log(&format_args!($($t)*).to_string()))


### PR DESCRIPTION
This makes it nicer to work with dbg! normally, because grepping the code base for dbg!() reveals only the usages of it that are currently active.