### PR TITLE
Use new try impl for ? operator

### DIFF
--- a/crates/compiler/can/src/constraint.rs
+++ b/crates/compiler/can/src/constraint.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use crate::abilities::SpecializationId;
 use crate::exhaustive::{ExhaustiveContext, SketchedRows};
 use crate::expected::{Expected, PExpected};
+use crate::expr::TryKind;
 use roc_collections::soa::{index_push_new, slice_extend_new};
 use roc_module::ident::{IdentSuffix, TagName};
 use roc_module::symbol::{ModuleId, Symbol};
@@ -643,12 +644,14 @@ impl Constraints {
         ok_payload_var: Variable,
         err_payload_var: Variable,
         region: Region,
+        kind: TryKind,
     ) -> Constraint {
         let constraint = TryTargetConstraint {
             target_type_index: result_type_index,
             ok_payload_var,
             err_payload_var,
             region,
+            kind,
         };
 
         let constraint_index = index_push_new(&mut self.try_target_constraints, constraint);
@@ -939,6 +942,7 @@ pub struct TryTargetConstraint {
     pub ok_payload_var: Variable,
     pub err_payload_var: Variable,
     pub region: Region,
+    pub kind: TryKind,
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/crates/compiler/can/src/copy.rs
+++ b/crates/compiler/can/src/copy.rs
@@ -725,6 +725,7 @@ fn deep_copy_expr_help<C: CopyEnv>(env: &mut C, copied: &mut Vec<Variable>, expr
             ok_payload_var,
             err_payload_var,
             err_ext_var,
+            kind,
         } => Try {
             result_expr: Box::new(result_expr.map(|e| go_help!(e))),
             result_var: sub!(*result_var),
@@ -732,6 +733,7 @@ fn deep_copy_expr_help<C: CopyEnv>(env: &mut C, copied: &mut Vec<Variable>, expr
             ok_payload_var: sub!(*ok_payload_var),
             err_payload_var: sub!(*err_payload_var),
             err_ext_var: sub!(*err_ext_var),
+            kind: *kind,
         },
 
         RuntimeError(err) => RuntimeError(err.clone()),

--- a/crates/compiler/can/src/traverse.rs
+++ b/crates/compiler/can/src/traverse.rs
@@ -407,6 +407,7 @@ pub fn walk_expr<V: Visitor>(visitor: &mut V, expr: &Expr, var: Variable) {
             ok_payload_var: _,
             err_payload_var: _,
             err_ext_var: _,
+            kind: _,
         } => {
             visitor.visit_expr(&result_expr.value, result_expr.region, *result_var);
         }

--- a/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__issue_7081.snap
+++ b/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__issue_7081.snap
@@ -178,15 +178,10 @@ Defs {
                                                                         ident: "inc",
                                                                     },
                                                                     [
-                                                                        @132-133 SpaceAfter(
-                                                                            Var {
-                                                                                module_name: "",
-                                                                                ident: "i",
-                                                                            },
-                                                                            [
-                                                                                Newline,
-                                                                            ],
-                                                                        ),
+                                                                        @132-133 Var {
+                                                                            module_name: "",
+                                                                            ident: "i",
+                                                                        },
                                                                     ],
                                                                     Try,
                                                                 ),

--- a/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__issue_7081.snap
+++ b/crates/compiler/can/tests/snapshots/test_suffixed__suffixed_tests__issue_7081.snap
@@ -143,79 +143,75 @@ Defs {
                                         ident: "i",
                                     },
                                 ],
-                                @132-172 Apply(
-                                    @132-172 Var {
-                                        module_name: "Result",
-                                        ident: "try",
-                                    },
-                                    [
-                                        @132-152 Apply(
-                                            @132-152 Var {
-                                                module_name: "",
-                                                ident: "inc",
-                                            },
-                                            [
-                                                @132-133 Var {
-                                                    module_name: "",
-                                                    ident: "i",
+                                @113-189 Defs(
+                                    Defs {
+                                        tags: [
+                                            EitherIndex(2147483648),
+                                        ],
+                                        regions: [
+                                            @132-172,
+                                        ],
+                                        space_before: [
+                                            Slice<roc_parse::ast::CommentOrNewline> { start: 0, length: 0 },
+                                        ],
+                                        space_after: [
+                                            Slice<roc_parse::ast::CommentOrNewline> { start: 0, length: 0 },
+                                        ],
+                                        spaces: [],
+                                        type_defs: [],
+                                        value_defs: [
+                                            Body(
+                                                @113-117 Identifier {
+                                                    ident: "newi",
                                                 },
-                                            ],
-                                            BinOp(
-                                                Pizza,
-                                            ),
-                                        ),
-                                        @132-172 Closure(
-                                            [
-                                                @132-152 Identifier {
-                                                    ident: "#!0_arg",
-                                                },
-                                            ],
-                                            @132-172 Apply(
-                                                @132-172 Var {
-                                                    module_name: "Result",
-                                                    ident: "try",
-                                                },
-                                                [
+                                                @132-172 LowLevelTry(
                                                     @132-172 Apply(
-                                                        @132-172 Var {
+                                                        @169-172 Var {
                                                             module_name: "",
                                                             ident: "inc",
                                                         },
                                                         [
-                                                            @132-152 Var {
-                                                                module_name: "",
-                                                                ident: "#!0_arg",
-                                                            },
-                                                        ],
-                                                        BinOp(
-                                                            Pizza,
-                                                        ),
-                                                    ),
-                                                    @132-172 Closure(
-                                                        [
-                                                            @113-117 Identifier {
-                                                                ident: "newi",
-                                                            },
-                                                        ],
-                                                        @182-189 Apply(
-                                                            @182-184 Tag(
-                                                                "Ok",
+                                                            @132-152 LowLevelTry(
+                                                                @132-152 Apply(
+                                                                    @149-152 Var {
+                                                                        module_name: "",
+                                                                        ident: "inc",
+                                                                    },
+                                                                    [
+                                                                        @132-133 SpaceAfter(
+                                                                            Var {
+                                                                                module_name: "",
+                                                                                ident: "i",
+                                                                            },
+                                                                            [
+                                                                                Newline,
+                                                                            ],
+                                                                        ),
+                                                                    ],
+                                                                    Try,
+                                                                ),
+                                                                OperatorSuffix,
                                                             ),
-                                                            [
-                                                                @185-189 Var {
-                                                                    module_name: "",
-                                                                    ident: "newi",
-                                                                },
-                                                            ],
-                                                            Space,
-                                                        ),
+                                                        ],
+                                                        Try,
                                                     ),
-                                                ],
-                                                QuestionSuffix,
+                                                    OperatorSuffix,
+                                                ),
                                             ),
+                                        ],
+                                    },
+                                    @182-189 Apply(
+                                        @182-184 Tag(
+                                            "Ok",
                                         ),
-                                    ],
-                                    QuestionSuffix,
+                                        [
+                                            @185-189 Var {
+                                                module_name: "",
+                                                ident: "newi",
+                                            },
+                                        ],
+                                        Space,
+                                    ),
                                 ),
                             ),
                         ),

--- a/crates/compiler/can/tests/test_can.rs
+++ b/crates/compiler/can/tests/test_can.rs
@@ -890,7 +890,7 @@ mod test_can {
         let cond_expr = assert_try_expr(&out.loc_expr.value);
         let cond_args = assert_func_call(cond_expr, "toU64", CalledVia::Try, &out.interns);
 
-        assert_eq!(cond_args.len(), 1);
+        assert_eq!(cond_args.len(), 2);
 
         let ok_tag = assert_try_expr(&cond_args[0].1.value);
         let tag_args = assert_tag_application(ok_tag, "Ok");

--- a/crates/compiler/can/tests/test_can.rs
+++ b/crates/compiler/can/tests/test_can.rs
@@ -892,7 +892,9 @@ mod test_can {
 
         assert_eq!(cond_args.len(), 2);
 
-        let ok_tag = assert_try_expr(&cond_args[0].1.value);
+        assert_str_value(&cond_args[0].1.value, "123");
+
+        let ok_tag = assert_try_expr(&cond_args[1].1.value);
         let tag_args = assert_tag_application(ok_tag, "Ok");
 
         assert_eq!(tag_args.len(), 1);

--- a/crates/compiler/constrain/src/expr.rs
+++ b/crates/compiler/constrain/src/expr.rs
@@ -870,6 +870,7 @@ pub fn constrain_expr(
             ok_payload_var,
             err_payload_var,
             err_ext_var,
+            kind,
         } => {
             let result_var_index = constraints.push_variable(*result_var);
             let result_expected_type = constraints.push_expected_type(ForReason(
@@ -891,6 +892,7 @@ pub fn constrain_expr(
                 *ok_payload_var,
                 *err_payload_var,
                 result_expr.region,
+                *kind,
             );
 
             let return_type_index = constraints.push_variable(*return_var);

--- a/crates/compiler/fmt/src/expr.rs
+++ b/crates/compiler/fmt/src/expr.rs
@@ -201,7 +201,7 @@ impl<'a> Formattable for Expr<'a> {
                 buf.indent(indent);
                 buf.push_str("try");
             }
-            LowLevelTry(_) => unreachable!(
+            LowLevelTry(_, _) => unreachable!(
                 "LowLevelTry should only exist after desugaring, not during formatting"
             ),
             Return(return_value, after_return) => {
@@ -370,7 +370,7 @@ pub fn expr_is_multiline(me: &Expr<'_>, comments_only: bool) -> bool {
         | Expr::Crash
         | Expr::Dbg
         | Expr::Try => false,
-        Expr::LowLevelTry(_) => {
+        Expr::LowLevelTry(_, _) => {
             unreachable!("LowLevelTry should only exist after desugaring, not during formatting")
         }
 

--- a/crates/compiler/load/tests/test_reporting.rs
+++ b/crates/compiler/load/tests/test_reporting.rs
@@ -14998,11 +14998,12 @@ All branches in an `if` must have the same type!
     );
 
     test_report!(
-        try_with_non_result_target,
+        keyword_try_with_non_result_target,
         indoc!(
             r#"
             invalidTry = \{} ->
-                x = try 64
+                nonResult = "abc"
+                x = try nonResult
 
                 Ok (x * 2)
 
@@ -15014,12 +15015,41 @@ All branches in an `if` must have the same type!
 
     This expression cannot be used as a `try` target:
 
-    5│          x = try 64
-                        ^^
+    6│          x = try nonResult
+                        ^^^^^^^^^
 
     I expected a Result, but it actually has type:
 
-        Num *
+        Str
+
+    Hint: Did you forget to wrap the value with an `Ok` or an `Err` tag?
+    "
+    );
+
+    test_report!(
+        question_try_with_non_result_target,
+        indoc!(
+            r#"
+            invalidTry = \{} ->
+                nonResult = "abc"
+                x = nonResult?
+
+                Ok (x * 2)
+
+            invalidTry {}
+            "#
+        ),
+        @r"
+    ── INVALID TRY TARGET in /code/proj/Main.roc ───────────────────────────────────
+
+    This expression cannot be tried with the `?` operator:
+
+    6│          x = nonResult?
+                    ^^^^^^^^^^
+
+    I expected a Result, but it actually has type:
+
+        Str
 
     Hint: Did you forget to wrap the value with an `Ok` or an `Err` tag?
     "
@@ -15062,7 +15092,7 @@ All branches in an `if` must have the same type!
     );
 
     test_report!(
-        try_prefix_in_pipe,
+        keyword_try_prefix_in_pipe,
         indoc!(
             r#"
             readFile : Str -> Str
@@ -15097,7 +15127,7 @@ All branches in an `if` must have the same type!
     );
 
     test_report!(
-        try_suffix_in_pipe,
+        keyword_try_suffix_in_pipe,
         indoc!(
             r#"
             readFile : Str -> Str
@@ -15127,6 +15157,41 @@ All branches in an `if` must have the same type!
         Str
 
     But |> needs its 1st argument to be:
+
+        Result ok a
+    "
+    );
+
+    test_report!(
+        question_try_in_pipe,
+        indoc!(
+            r#"
+            readFile : Str -> Str
+
+            getFileContents : Str -> Result Str _
+            getFileContents = \filePath ->
+                contents =
+                    readFile filePath
+                    |> Result.mapErr? ErrWrapper
+
+                contents
+
+            getFileContents "file.txt"
+            "#
+        ),
+        @r"
+    ── TYPE MISMATCH in /code/proj/Main.roc ────────────────────────────────────────
+
+    This 1st argument to this function has an unexpected type:
+
+     9│>              readFile filePath
+    10│               |> Result.mapErr? ErrWrapper
+
+    This `readFile` call produces:
+
+        Str
+
+    But this function needs its 1st argument to be:
 
         Result ok a
     "

--- a/crates/compiler/lower_params/src/lower.rs
+++ b/crates/compiler/lower_params/src/lower.rs
@@ -380,6 +380,7 @@ impl<'a> LowerParams<'a> {
                     ok_payload_var: _,
                     err_payload_var: _,
                     err_ext_var: _,
+                    kind: _,
                 } => {
                     expr_stack.push(&mut result_expr.value);
                 }

--- a/crates/compiler/lower_params/src/type_error.rs
+++ b/crates/compiler/lower_params/src/type_error.rs
@@ -105,7 +105,7 @@ pub fn remove_module_param_arguments(
             | TypeError::ExpectedEffectful(_, _)
             | TypeError::UnsuffixedEffectfulFunction(_, _)
             | TypeError::SuffixedPureFunction(_, _)
-            | TypeError::InvalidTryTarget(_, _) => {}
+            | TypeError::InvalidTryTarget(_, _, _) => {}
         }
     }
 }

--- a/crates/compiler/mono/src/ir.rs
+++ b/crates/compiler/mono/src/ir.rs
@@ -5878,6 +5878,7 @@ pub fn with_hole<'a>(
             ok_payload_var,
             err_payload_var,
             err_ext_var,
+            kind: _,
         } => {
             let ok_symbol = env.unique_symbol();
             let err_symbol = env.unique_symbol();

--- a/crates/compiler/parse/src/expr.rs
+++ b/crates/compiler/parse/src/expr.rs
@@ -2180,7 +2180,7 @@ fn expr_to_pattern_help<'a>(arena: &'a Bump, expr: &Expr<'a>) -> Result<Pattern<
         | Expr::Dbg
         | Expr::DbgStmt { .. }
         | Expr::LowLevelDbg(_, _, _)
-        | Expr::LowLevelTry(_)
+        | Expr::LowLevelTry(_, _)
         | Expr::Return(_, _)
         | Expr::MalformedSuffixed(..)
         | Expr::PrecedenceConflict { .. }

--- a/crates/compiler/parse/src/normalize.rs
+++ b/crates/compiler/parse/src/normalize.rs
@@ -727,7 +727,7 @@ impl<'a> Normalize<'a> for Expr<'a> {
                 arena.alloc(b.normalize(arena)),
             ),
             Expr::Try => Expr::Try,
-            Expr::LowLevelTry(a) => Expr::LowLevelTry(arena.alloc(a.normalize(arena))),
+            Expr::LowLevelTry(a, kind) => Expr::LowLevelTry(arena.alloc(a.normalize(arena)), kind),
             Expr::Return(a, b) => Expr::Return(
                 arena.alloc(a.normalize(arena)),
                 b.map(|loc_b| &*arena.alloc(loc_b.normalize(arena))),

--- a/crates/compiler/solve/src/solve.rs
+++ b/crates/compiler/solve/src/solve.rs
@@ -917,6 +917,7 @@ fn solve(
                     ok_payload_var,
                     err_payload_var,
                     region,
+                    kind,
                 } = try_target_constraint;
 
                 let target_actual = either_type_index_to_var(
@@ -990,7 +991,7 @@ fn solve(
                     Failure(vars, actual_type, _expected_type, _bad_impls) => {
                         env.introduce(rank, &vars);
 
-                        let problem = TypeError::InvalidTryTarget(*region, actual_type);
+                        let problem = TypeError::InvalidTryTarget(*region, actual_type, *kind);
 
                         problems.push(problem);
 

--- a/crates/compiler/solve_problem/src/lib.rs
+++ b/crates/compiler/solve_problem/src/lib.rs
@@ -2,6 +2,7 @@
 use std::{path::PathBuf, str::Utf8Error};
 
 use roc_can::constraint::{ExpectEffectfulReason, FxSuffixKind};
+use roc_can::expr::TryKind;
 use roc_can::{
     constraint::FxCallKind,
     expected::{Expected, PExpected},
@@ -48,7 +49,7 @@ pub enum TypeError {
     ExpectedEffectful(Region, ExpectEffectfulReason),
     UnsuffixedEffectfulFunction(Region, FxSuffixKind),
     SuffixedPureFunction(Region, FxSuffixKind),
-    InvalidTryTarget(Region, ErrorType),
+    InvalidTryTarget(Region, ErrorType, TryKind),
 }
 
 impl TypeError {
@@ -78,7 +79,7 @@ impl TypeError {
             TypeError::FxInTopLevel(_, _) => Warning,
             TypeError::UnsuffixedEffectfulFunction(_, _) => Warning,
             TypeError::SuffixedPureFunction(_, _) => Warning,
-            TypeError::InvalidTryTarget(_, _) => RuntimeError,
+            TypeError::InvalidTryTarget(_, _, _) => RuntimeError,
         }
     }
 
@@ -100,7 +101,7 @@ impl TypeError {
             | TypeError::ExpectedEffectful(region, _)
             | TypeError::UnsuffixedEffectfulFunction(region, _)
             | TypeError::SuffixedPureFunction(region, _)
-            | TypeError::InvalidTryTarget(region, _) => Some(*region),
+            | TypeError::InvalidTryTarget(region, _, _) => Some(*region),
             TypeError::UnfulfilledAbility(ab, ..) => ab.region(),
             TypeError::Exhaustive(e) => Some(e.region()),
             TypeError::CircularDef(c) => c.first().map(|ce| ce.symbol_region),

--- a/crates/language_server/src/analysis/tokens.rs
+++ b/crates/language_server/src/analysis/tokens.rs
@@ -699,7 +699,7 @@ impl IterTokens for Loc<Expr<'_>> {
                 .chain(e2.iter_tokens(arena))
                 .collect_in(arena),
             Expr::Try => onetoken(Token::Keyword, region, arena),
-            Expr::LowLevelTry(e1) => e1.iter_tokens(arena),
+            Expr::LowLevelTry(e1, _) => e1.iter_tokens(arena),
             Expr::Apply(e1, e2, _called_via) => (e1.iter_tokens(arena).into_iter())
                 .chain(e2.iter_tokens(arena))
                 .collect_in(arena),

--- a/crates/reporting/src/error/type.rs
+++ b/crates/reporting/src/error/type.rs
@@ -6,6 +6,7 @@ use itertools::EitherOrBoth;
 use itertools::Itertools;
 use roc_can::constraint::{ExpectEffectfulReason, FxCallKind, FxSuffixKind};
 use roc_can::expected::{Expected, PExpected};
+use roc_can::expr::TryKind;
 use roc_collections::all::{HumanIndex, MutSet, SendMap};
 use roc_collections::VecMap;
 use roc_error_macros::internal_error;
@@ -472,13 +473,22 @@ pub fn type_problem<'b>(
                 severity,
             })
         }
-        InvalidTryTarget(region, actual_type) => {
-            let stack = [
-                alloc.concat([
+        InvalidTryTarget(region, actual_type, try_kind) => {
+            let invalid_usage_message = match try_kind {
+                TryKind::KeywordPrefix => alloc.concat([
                     alloc.reflow("This expression cannot be used as a "),
                     alloc.keyword("try"),
                     alloc.reflow(" target:"),
                 ]),
+                TryKind::OperatorSuffix => alloc.concat([
+                    alloc.reflow("This expression cannot be tried with the "),
+                    alloc.keyword("?"),
+                    alloc.reflow(" operator:"),
+                ]),
+            };
+
+            let stack = [
+                invalid_usage_message,
                 alloc.region(lines.convert_region(region), severity),
                 alloc.concat([
                     alloc.reflow("I expected a "),

--- a/crates/reporting/src/error/type.rs
+++ b/crates/reporting/src/error/type.rs
@@ -2306,30 +2306,15 @@ fn format_category<'b>(
             alloc.text(" of type:"),
         ),
         TryTarget => (
-            alloc.concat([
-                this_is,
-                alloc.reflow(" a "),
-                alloc.keyword("try"),
-                alloc.reflow(" target"),
-            ]),
+            alloc.concat([this_is, alloc.reflow(" a try target")]),
             alloc.text(" of type:"),
         ),
         TrySuccess => (
-            alloc.concat([
-                this_is,
-                alloc.reflow(" a "),
-                alloc.keyword("try"),
-                alloc.reflow(" expression"),
-            ]),
+            alloc.concat([this_is, alloc.reflow(" a try expression")]),
             alloc.text(" that succeeds with type:"),
         ),
         TryFailure => (
-            alloc.concat([
-                this_is,
-                alloc.reflow(" a "),
-                alloc.keyword("try"),
-                alloc.reflow(" expression"),
-            ]),
+            alloc.concat([this_is, alloc.reflow(" a try expression")]),
             alloc.text(" that fails with type:"),
         ),
     }


### PR DESCRIPTION
This uses the implementation of a proper `try` keyword in the recent https://github.com/roc-lang/roc/pull/7296 PR to implement the existing ? operator more robustly. We also specialize our error messages to display `try` vs. `?` accurately.