### PR TITLE
Allow search on qualified names in docs

### DIFF
--- a/crates/docs/src/static/search.js
+++ b/crates/docs/src/static/search.js
@@ -95,6 +95,9 @@
                     let totalResults = 0;
                     // Firsttype-ahead-signature", show/hide all the sub-entries within each module (top-level functions etc.)
                     searchTypeAhead.querySelectorAll("li").forEach((entry) => {
+                        const entryModule = entry
+                            .querySelector(".type-ahead-module-name")
+                            .textContent.toLowerCase()
                         const entryName = entry
                             .querySelector(".type-ahead-def-name")
                             .textContent.toLowerCase();
@@ -103,7 +106,9 @@
                             ?.textContent?.toLowerCase()
                             ?.replace(/\s+/g, "");
 
-                        if ((entryName.includes(text) || entrySignature?.includes(text.replace(/\s+/g, "")))) {
+                        const qualifiedEntryName = `${entryModule}.${entryName}`
+
+                        if ((qualifiedEntryName.includes(text) || entrySignature?.includes(text.replace(/\s+/g, "")))) {
                             totalResults++;
                             entry.classList.remove("hidden");
                             if (topSearchResultListItem === undefined) {


### PR DESCRIPTION
Search on `<module>.<entry>`

<img width="735" alt="Screenshot 2024-12-07 at 15 14 12" src="https://github.com/user-attachments/assets/7c35305d-1e2b-4722-a328-58058704c768">

Searching on `<entry>` still works

<img width="730" alt="Screenshot 2024-12-07 at 15 14 31" src="https://github.com/user-attachments/assets/02e449a1-a191-4332-a180-5001927639e9">

Module is case insensitive:

<img width="725" alt="Screenshot 2024-12-07 at 15 15 05" src="https://github.com/user-attachments/assets/470360a7-98ff-4301-b0a1-81478f970369">
