### PR TITLE
Stop ignoring `--optimize` in `roc --optimize main.roc`

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -871,11 +871,7 @@ pub fn build(
     // so we don't want to spend time freeing these values
     let arena = ManuallyDrop::new(Bump::new());
 
-    let opt_level = if let BuildConfig::BuildAndRunIfNoErrors = config {
-        OptLevel::Development
-    } else {
-        opt_level_from_flags(matches)
-    };
+    let opt_level = opt_level_from_flags(matches);
 
     // Note: This allows using `--dev` with `--optimize`.
     // This means frontend optimizations and dev backend.


### PR DESCRIPTION
This is just inconvenient and does not make our api better. Leads to users thinking that roc does not optimize well. This also allows `roc dev --optimize` (which is the exact same as `roc --optimize`). If a user wants to do that, it should be fine.

This will all eventually be replaced by the larger cli rewrite.