### PR TITLE
Add lsp range info for file load errors 

### DIFF
--- a/ci/repl_basic_test/src/main.rs
+++ b/ci/repl_basic_test/src/main.rs
@@ -17,13 +17,14 @@ fn roc_repl_session() -> Result<PtyReplSession, Error> {
 
 fn main() -> Result<(), Error> {
     let mut repl = roc_repl_session()?;
-    
+
     repl.exp_regex(".*roc repl.*")?;
     repl.send_line("1+1")?;
-    
+
     thread::sleep(Duration::from_secs(1));
 
-    match repl.exp_regex(r".*2\u{1b}\[1;32m : \u{1b}\[0mNum *.*") { // 2 : Num
+    match repl.exp_regex(r".*2\u{1b}\[1;32m : \u{1b}\[0mNum *.*") {
+        // 2 : Num
         Ok(_) => {
             println!("Expected output received.");
             return Ok(());

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -254,7 +254,7 @@ fn main() -> io::Result<()> {
                                 exit_code = problems.exit_code();
                             }
 
-                            Err(LoadingProblem::FormattedReport(report)) => {
+                            Err(LoadingProblem::FormattedReport(report, _)) => {
                                 print!("{report}");
 
                                 exit_code = 1;
@@ -285,7 +285,7 @@ fn main() -> io::Result<()> {
                             Ok(problems.exit_code())
                         }
 
-                        Err(LoadingProblem::FormattedReport(report)) => {
+                        Err(LoadingProblem::FormattedReport(report, _)) => {
                             print!("{report}");
 
                             Ok(1)

--- a/crates/compiler/build/src/program.rs
+++ b/crates/compiler/build/src/program.rs
@@ -702,7 +702,7 @@ pub fn handle_error_module(
 
 pub fn handle_loading_problem(problem: LoadingProblem) -> std::io::Result<i32> {
     match problem {
-        LoadingProblem::FormattedReport(report) => {
+        LoadingProblem::FormattedReport(report,_) => {
             print!("{report}");
             Ok(1)
         }

--- a/crates/compiler/build/src/program.rs
+++ b/crates/compiler/build/src/program.rs
@@ -702,7 +702,7 @@ pub fn handle_error_module(
 
 pub fn handle_loading_problem(problem: LoadingProblem) -> std::io::Result<i32> {
     match problem {
-        LoadingProblem::FormattedReport(report,_) => {
+        LoadingProblem::FormattedReport(report, _) => {
             print!("{report}");
             Ok(1)
         }

--- a/crates/compiler/load/build.rs
+++ b/crates/compiler/load/build.rs
@@ -88,7 +88,7 @@ fn write_types_for_module_real(module_id: ModuleId, filename: &str, output_path:
 
     let mut module = match res_module {
         Ok(v) => v,
-        Err(LoadingProblem::FormattedReport(report, None)) => {
+        Err(LoadingProblem::FormattedReport(report, _)) => {
             internal_error!("{}", report);
         }
         Err(other) => {

--- a/crates/compiler/load/build.rs
+++ b/crates/compiler/load/build.rs
@@ -88,7 +88,7 @@ fn write_types_for_module_real(module_id: ModuleId, filename: &str, output_path:
 
     let mut module = match res_module {
         Ok(v) => v,
-        Err(LoadingProblem::FormattedReport(report,None)) => {
+        Err(LoadingProblem::FormattedReport(report, None)) => {
             internal_error!("{}", report);
         }
         Err(other) => {

--- a/crates/compiler/load/build.rs
+++ b/crates/compiler/load/build.rs
@@ -88,7 +88,7 @@ fn write_types_for_module_real(module_id: ModuleId, filename: &str, output_path:
 
     let mut module = match res_module {
         Ok(v) => v,
-        Err(LoadingProblem::FormattedReport(report)) => {
+        Err(LoadingProblem::FormattedReport(report,None)) => {
             internal_error!("{}", report);
         }
         Err(other) => {

--- a/crates/compiler/load/tests/test_reporting.rs
+++ b/crates/compiler/load/tests/test_reporting.rs
@@ -187,7 +187,7 @@ mod test_reporting {
         let mut buf = String::new();
 
         match infer_expr_help_new(subdir, arena, src) {
-            Err(LoadingProblem::FormattedReport(fail)) => fail,
+            Err(LoadingProblem::FormattedReport(fail,_)) => fail,
             Ok((module_src, type_problems, can_problems, home, interns)) => {
                 let lines = LineInfo::new(&module_src);
                 let src_lines: Vec<&str> = module_src.split('\n').collect();

--- a/crates/compiler/load/tests/test_reporting.rs
+++ b/crates/compiler/load/tests/test_reporting.rs
@@ -187,7 +187,7 @@ mod test_reporting {
         let mut buf = String::new();
 
         match infer_expr_help_new(subdir, arena, src) {
-            Err(LoadingProblem::FormattedReport(fail,_)) => fail,
+            Err(LoadingProblem::FormattedReport(fail, _)) => fail,
             Ok((module_src, type_problems, can_problems, home, interns)) => {
                 let lines = LineInfo::new(&module_src);
                 let src_lines: Vec<&str> = module_src.split('\n').collect();

--- a/crates/compiler/load_internal/src/file.rs
+++ b/crates/compiler/load_internal/src/file.rs
@@ -1010,26 +1010,29 @@ impl<'a> LoadingProblem<'a> {
         match self {
             LoadingProblem::ParsingFailed(err) => err.problem.problem.get_region(),
             LoadingProblem::MultiplePlatformPackages {
-                filename,
-                module_id,
-                source,
+                filename: _,
+                module_id: _,
+                source: _,
                 region,
             } => Some(*region),
             LoadingProblem::NoPlatformPackage {
-                filename,
-                module_id,
-                source,
+                filename: _,
+                module_id: _,
+                source: _,
                 region,
             } => Some(*region),
             LoadingProblem::UnrecognizedPackageShorthand {
-                filename,
-                module_id,
-                source,
+                filename: _,
+                module_id: _,
+                source: _,
                 region,
-                shorthand,
-                available,
+                shorthand: _,
+                available: _,
             } => Some(*region),
-            LoadingProblem::FileProblem { filename, error } => None,
+            LoadingProblem::FileProblem {
+                filename: _,
+                error: _,
+            } => None,
             LoadingProblem::UnexpectedHeader(_) => None,
             LoadingProblem::ErrJoiningWorkerThreads => None,
             LoadingProblem::TriedToImportAppModule => None,
@@ -1215,7 +1218,7 @@ impl<'a> LoadStart<'a> {
                     })
                     .into_inner()
                     .into_module_ids();
-                let region=problem.get_region();
+                let region = problem.get_region();
                 let report = report_loading_problem(problem, module_ids, render, palette);
 
                 // TODO try to gracefully recover and continue
@@ -1645,7 +1648,6 @@ fn state_thread_step<'a>(
     msg_tx: &crossbeam::channel::Sender<Msg<'a>>,
     msg_rx: &crossbeam::channel::Receiver<Msg<'a>>,
 ) -> Result<ControlFlow<LoadResult<'a>, State<'a>>, LoadingProblem<'a>> {
-    
     match msg_rx.try_recv() {
         Ok(msg) => {
             match msg {
@@ -1709,11 +1711,11 @@ fn state_thread_step<'a>(
                 }
                 Msg::FailedToReadFile { filename, error } => {
                     let buf = to_file_problem_report_string(filename, error, true);
-                    Err(LoadingProblem::FormattedReport(buf,None))
+                    Err(LoadingProblem::FormattedReport(buf, None))
                 }
 
                 Msg::FailedToParse(problem) => {
-                    let region=problem.problem.problem.get_region();
+                    let region = problem.problem.problem.get_region();
                     let module_ids = (*state.arc_modules).lock().clone().into_module_ids();
                     let buf = to_parse_problem_report(
                         problem,
@@ -1722,7 +1724,7 @@ fn state_thread_step<'a>(
                         state.render,
                         state.palette,
                     );
-                    Err(LoadingProblem::FormattedReport(buf,region))
+                    Err(LoadingProblem::FormattedReport(buf, region))
                 }
                 Msg::IncorrectModuleName(FileError {
                     problem: SourceError { problem, bytes },
@@ -1737,7 +1739,7 @@ fn state_thread_step<'a>(
                         bytes,
                         state.render,
                     );
-                    Err(LoadingProblem::FormattedReport(buf,Some(region)))
+                    Err(LoadingProblem::FormattedReport(buf, Some(region)))
                 }
                 msg => {
                     // This is where most of the main thread's work gets done.
@@ -1754,7 +1756,7 @@ fn state_thread_step<'a>(
                     match res_state {
                         Ok(new_state) => Ok(ControlFlow::Continue(new_state)),
                         Err(LoadingProblem::ParsingFailed(problem)) => {
-                            let region=problem.problem.problem.get_region();
+                            let region = problem.problem.problem.get_region();
                             let module_ids = Arc::try_unwrap(arc_modules)
                                 .unwrap_or_else(|_| {
                                     panic!(
@@ -1786,7 +1788,7 @@ fn state_thread_step<'a>(
                                 filename,
                                 render,
                             );
-                            return Err(LoadingProblem::FormattedReport(buf,None));
+                            return Err(LoadingProblem::FormattedReport(buf, None));
                         }
                         Err(LoadingProblem::IncorrectModuleName(FileError {
                             problem: SourceError { problem, bytes },
@@ -1803,7 +1805,7 @@ fn state_thread_step<'a>(
                                 bytes,
                                 render,
                             );
-                            return Err(LoadingProblem::FormattedReport(buf,Some(region)));
+                            return Err(LoadingProblem::FormattedReport(buf, Some(region)));
                         }
                         Err(LoadingProblem::UnrecognizedPackageShorthand {
                             filename,
@@ -1827,7 +1829,7 @@ fn state_thread_step<'a>(
                                 available,
                                 render,
                             );
-                            return Err(LoadingProblem::FormattedReport(buf,Some(region)));
+                            return Err(LoadingProblem::FormattedReport(buf, Some(region)));
                         }
                         Err(e) => Err(e),
                     }
@@ -1874,9 +1876,10 @@ pub fn report_loading_problem(
                 filename,
                 bytes,
                 render,
-            ).0
+            )
+            .0
         }
-        LoadingProblem::FormattedReport(report,region) => report,
+        LoadingProblem::FormattedReport(report, _region) => report,
         LoadingProblem::FileProblem { filename, error } => {
             to_file_problem_report_string(filename, error, true)
         }
@@ -3085,7 +3088,7 @@ fn register_package_shorthands<'a>(
                             Problem::InvalidUrl(url_err),
                             module_path.to_path_buf(),
                         );
-                        return Err(LoadingProblem::FormattedReport(buf,None));
+                        return Err(LoadingProblem::FormattedReport(buf, None));
                     }
                 }
             }
@@ -3203,7 +3206,7 @@ fn finish_specialization<'a>(
                     Valid(To::NewPackage(p_or_p)) => PathBuf::from(p_or_p.as_str()),
                     other => {
                         let buf = report_cannot_run(state.root_id, state.root_path, other);
-                        return Err(LoadingProblem::FormattedReport(buf,None));
+                        return Err(LoadingProblem::FormattedReport(buf, None));
                     }
                 };
 
@@ -4168,7 +4171,9 @@ fn load_packages<'a>(
                     Err(problem) => {
                         let buf = to_https_problem_report_string(src, problem, filename);
 
-                        load_messages.push(Msg::FailedToLoad(LoadingProblem::FormattedReport(buf,None)));
+                        load_messages.push(Msg::FailedToLoad(LoadingProblem::FormattedReport(
+                            buf, None,
+                        )));
                         return;
                     }
                 }
@@ -6486,7 +6491,7 @@ fn to_incorrect_module_name_report<'a>(
     filename: PathBuf,
     src: &'a [u8],
     render: RenderTarget,
-) -> (String,Region) {
+) -> (String, Region) {
     use roc_reporting::report::{Report, RocDocAllocator, DEFAULT_PALETTE};
     use ven_pretty::DocAllocator;
 

--- a/crates/compiler/load_internal/tests/test_load.rs
+++ b/crates/compiler/load_internal/tests/test_load.rs
@@ -141,7 +141,7 @@ fn multiple_modules(subdir: &str, files: Vec<(&str, &str)>) -> Result<LoadedModu
 
     match multiple_modules_help(subdir, arena, files) {
         Err(io_error) => panic!("IO trouble: {io_error:?}"),
-        Ok(Err(LoadingProblem::FormattedReport(buf, None))) => Err(buf),
+        Ok(Err(LoadingProblem::FormattedReport(buf, _))) => Err(buf),
         Ok(Err(loading_problem)) => Err(format!("{loading_problem:?}")),
         Ok(Ok(mut loaded_module)) => {
             let home = loaded_module.module_id;
@@ -247,7 +247,7 @@ fn load_fixture(
     );
     let mut loaded_module = match loaded {
         Ok(x) => x,
-        Err(roc_load_internal::file::LoadingProblem::FormattedReport(report,None)) => {
+        Err(roc_load_internal::file::LoadingProblem::FormattedReport(report, _)) => {
             println!("{report}");
             panic!("{}", report);
         }

--- a/crates/compiler/load_internal/tests/test_load.rs
+++ b/crates/compiler/load_internal/tests/test_load.rs
@@ -141,7 +141,7 @@ fn multiple_modules(subdir: &str, files: Vec<(&str, &str)>) -> Result<LoadedModu
 
     match multiple_modules_help(subdir, arena, files) {
         Err(io_error) => panic!("IO trouble: {io_error:?}"),
-        Ok(Err(LoadingProblem::FormattedReport(buf))) => Err(buf),
+        Ok(Err(LoadingProblem::FormattedReport(buf, None))) => Err(buf),
         Ok(Err(loading_problem)) => Err(format!("{loading_problem:?}")),
         Ok(Ok(mut loaded_module)) => {
             let home = loaded_module.module_id;
@@ -247,7 +247,7 @@ fn load_fixture(
     );
     let mut loaded_module = match loaded {
         Ok(x) => x,
-        Err(roc_load_internal::file::LoadingProblem::FormattedReport(report)) => {
+        Err(roc_load_internal::file::LoadingProblem::FormattedReport(report,None)) => {
             println!("{report}");
             panic!("{}", report);
         }

--- a/crates/compiler/parse/src/parser.rs
+++ b/crates/compiler/parse/src/parser.rs
@@ -65,7 +65,7 @@ pub enum SyntaxError<'a> {
 }
 impl<'a> SyntaxError<'a> {
     pub fn get_region(&self) -> Option<Region> {
-        let region = match self {
+        match self {
             SyntaxError::Unexpected(r) => Some(*r),
             SyntaxError::Eof(r) => Some(*r),
             SyntaxError::ReservedKeyword(r) => Some(*r),
@@ -80,9 +80,8 @@ impl<'a> SyntaxError<'a> {
             SyntaxError::Todo => None,
             SyntaxError::InvalidPattern => None,
             SyntaxError::BadUtf8 => None,
-            SyntaxError::Space(bad_input) => None,
-        };
-        region
+            SyntaxError::Space(_bad_input) => None,
+        }
     }
 }
 pub trait SpaceProblem: std::fmt::Debug {
@@ -158,18 +157,18 @@ pub enum EHeader<'a> {
 impl<'a> EHeader<'a> {
     pub fn get_region(&self) -> Region {
         match self {
-            EHeader::Provides(provides, pos) => provides.get_region(),
-            EHeader::Params(params, pos) => params.get_region(),
+            EHeader::Provides(provides, _pos) => provides.get_region(),
+            EHeader::Params(params, _pos) => params.get_region(),
             EHeader::Exposes(_, pos) => Region::from_pos(*pos),
             EHeader::Imports(_, pos) => Region::from_pos(*pos),
-            EHeader::Requires(requires, pos) => requires.get_region(),
-            EHeader::Packages(packages, pos) => packages.get_region(),
+            EHeader::Requires(requires, _pos) => requires.get_region(),
+            EHeader::Packages(packages, _pos) => packages.get_region(),
             EHeader::Space(_, pos) => Region::from_pos(*pos),
             EHeader::Start(pos) => Region::from_pos(*pos),
             EHeader::ModuleName(pos) => Region::from_pos(*pos),
-            EHeader::AppName(app_name, pos) => app_name.get_region(),
-            EHeader::PackageName(package_name, pos) => package_name.get_region(),
-            EHeader::PlatformName(platform_name, pos) => platform_name.get_region(),
+            EHeader::AppName(app_name, _pos) => app_name.get_region(),
+            EHeader::PackageName(package_name, _pos) => package_name.get_region(),
+            EHeader::PlatformName(platform_name, _pos) => platform_name.get_region(),
             EHeader::IndentStart(pos) => Region::from_pos(*pos),
             EHeader::InconsistentModuleName(region) => *region,
         }
@@ -566,7 +565,7 @@ impl<'a> EExpr<'a> {
             EExpr::Ability(e_ability, _) => e_ability.get_region(),
             EExpr::When(e_when, _) => e_when.get_region(),
             EExpr::If(e_if, _) => e_if.get_region(),
-            EExpr::Expect(e_expect, _) => e_expect.get_region(), 
+            EExpr::Expect(e_expect, _) => e_expect.get_region(),
             EExpr::Dbg(e_expect, _) => e_expect.get_region(),
             EExpr::Import(e_import, _) => e_import.get_region(),
             EExpr::Return(e_return, _) => e_return.get_region(),
@@ -650,7 +649,7 @@ impl<'a> EString<'a> {
         match self {
             // Case with child node that has get_region()
             EString::Format(expr, _) => expr.get_region(),
-            
+
             // Cases with Position values
             EString::Open(p)
             | EString::CodePtOpen(p)
@@ -699,7 +698,7 @@ impl<'a> ERecord<'a> {
         match self {
             // Cases with child node that has get_region()
             ERecord::Expr(expr, _) => expr.get_region(),
-            
+
             // Cases with Position values
             ERecord::End(p)
             | ERecord::Open(p)
@@ -735,7 +734,7 @@ impl<'a> EInParens<'a> {
         match self {
             // Cases with child node that has get_region()
             EInParens::Expr(expr, _) => expr.get_region(),
-            
+
             // Cases with Position values
             EInParens::End(p)
             | EInParens::Open(p)
@@ -766,7 +765,7 @@ impl<'a> EClosure<'a> {
             // Cases with child nodes that have get_region()
             EClosure::Pattern(pattern, _) => pattern.get_region(),
             EClosure::Body(expr, _) => expr.get_region(),
-            
+
             // Cases with Position values
             EClosure::Space(_, p)
             | EClosure::Start(p)
@@ -794,7 +793,7 @@ impl<'a> EList<'a> {
         match self {
             // Case with child node that has get_region()
             EList::Expr(expr, _) => expr.get_region(),
-            
+
             // Cases with Position values
             EList::Open(p) | EList::End(p) | EList::Space(_, p) => Region::from_pos(*p),
         }
@@ -865,7 +864,7 @@ impl<'a> EAbility<'a> {
         match self {
             // Case with child node that has get_region()
             EAbility::Type(e_type, _) => e_type.get_region(),
-            
+
             // Cases with Position values
             EAbility::Space(_, p)
             | EAbility::DemandAlignment(_, p)
@@ -897,7 +896,9 @@ pub enum EIf<'a> {
 impl<'a> EIf<'a> {
     pub fn get_region(&self) -> Region {
         match self {
-            EIf::Condition(expr, _) | EIf::ThenBranch(expr, _) | EIf::ElseBranch(expr, _) => expr.get_region(),
+            EIf::Condition(expr, _) | EIf::ThenBranch(expr, _) | EIf::ElseBranch(expr, _) => {
+                expr.get_region()
+            }
             EIf::Space(_, p)
             | EIf::If(p)
             | EIf::Then(p)
@@ -945,9 +946,9 @@ impl<'a> EReturn<'a> {
     pub fn get_region(&self) -> Region {
         match self {
             EReturn::ReturnValue(expr, _) => expr.get_region(),
-            EReturn::Space(_, p)
-            | EReturn::Return(p)
-            | EReturn::IndentReturnValue(p) => Region::from_pos(*p),
+            EReturn::Space(_, p) | EReturn::Return(p) | EReturn::IndentReturnValue(p) => {
+                Region::from_pos(*p)
+            }
         }
     }
 }
@@ -988,10 +989,10 @@ impl<'a> EImport<'a> {
             // Cases with child nodes that have get_region()
             EImport::Params(params, _) => params.get_region(),
             EImport::Annotation(e_type, _) => e_type.get_region(),
-            
+
             // Case with direct Region value
             EImport::LowercaseAlias(r) => *r,
-            
+
             // Cases with Position values
             EImport::Import(p)
             | EImport::IndentStart(p)
@@ -1074,7 +1075,7 @@ impl<'a> EPattern<'a> {
             EPattern::Record(expr, _) => expr.get_region(),
             EPattern::List(expr, _) => expr.get_region(),
             EPattern::PInParens(expr, _) => expr.get_region(),
-            
+
             // Cases with Position values
             EPattern::AsKeyword(position)
             | EPattern::AsIdentifier(position)
@@ -1083,7 +1084,6 @@ impl<'a> EPattern<'a> {
             | EPattern::Start(position)
             | EPattern::End(position)
             | EPattern::Space(_, position)
-            | EPattern::PInParens(_, position)
             | EPattern::NumLiteral(_, position)
             | EPattern::IndentStart(position)
             | EPattern::IndentEnd(position)
@@ -1115,7 +1115,7 @@ impl<'a> PRecord<'a> {
             // Cases with child nodes that have get_region()
             PRecord::Pattern(pattern, _) => pattern.get_region(),
             PRecord::Expr(expr, _) => expr.get_region(),
-            
+
             // Cases with Position values
             PRecord::End(p)
             | PRecord::Open(p)
@@ -1143,12 +1143,11 @@ impl<'a> PList<'a> {
         match self {
             // Case with child node that has get_region()
             PList::Pattern(pattern, _) => pattern.get_region(),
-            
+
             // Cases with Position values
-            PList::End(p)
-            | PList::Open(p)
-            | PList::Rest(p)
-            | PList::Space(_, p) => Region::from_pos(*p),
+            PList::End(p) | PList::Open(p) | PList::Rest(p) | PList::Space(_, p) => {
+                Region::from_pos(*p)
+            }
         }
     }
 }
@@ -1168,7 +1167,7 @@ impl<'a> PInParens<'a> {
         match self {
             // Case with child node that has get_region()
             PInParens::Pattern(pattern, _) => pattern.get_region(),
-            
+
             // Cases with Position values
             PInParens::Empty(p)
             | PInParens::End(p)
@@ -1210,10 +1209,10 @@ impl<'a> EType<'a> {
             EType::TRecord(expr, _) => expr.get_region(),
             EType::TTagUnion(expr, _) => expr.get_region(),
             EType::TInParens(expr, _) => expr.get_region(),
-            EType::TApply(eapply,_, )=> eapply.get_region(),
+            EType::TApply(eapply, _) => eapply.get_region(),
             EType::TInlineAlias(einline, _) => einline.get_region(),
             EType::TAbilityImpl(eability, _) => eability.get_region(),
-            
+
             // Cases with Position values
             EType::Space(_, p)
             | EType::UnderscoreSpacing(p)
@@ -1255,7 +1254,7 @@ impl<'a> ETypeRecord<'a> {
         match self {
             // Case with child node that has get_region()
             ETypeRecord::Type(type_expr, _) => type_expr.get_region(),
-            
+
             // Cases with Position values
             ETypeRecord::End(p)
             | ETypeRecord::Open(p)
@@ -1286,11 +1285,11 @@ impl<'a> ETypeTagUnion<'a> {
         match self {
             // Case with child node that has get_region()
             ETypeTagUnion::Type(type_expr, _) => type_expr.get_region(),
-            
+
             // Cases with Position values
-            ETypeTagUnion::End(p)
-            | ETypeTagUnion::Open(p)
-            | ETypeTagUnion::Space(_, p) => Region::from_pos(*p),
+            ETypeTagUnion::End(p) | ETypeTagUnion::Open(p) | ETypeTagUnion::Space(_, p) => {
+                Region::from_pos(*p)
+            }
         }
     }
 }
@@ -1317,15 +1316,14 @@ impl<'a> ETypeInParens<'a> {
         match self {
             // Cases with child nodes that have get_region()
             ETypeInParens::Type(type_expr, _) => type_expr.get_region(),
-            
+
             // Cases with Position values
             ETypeInParens::Empty(p)
             | ETypeInParens::End(p)
             | ETypeInParens::Open(p)
             | ETypeInParens::Space(_, p)
             | ETypeInParens::IndentOpen(p)
-            | ETypeInParens::IndentEnd(p) =>    Region::from_pos(*p),
-        
+            | ETypeInParens::IndentEnd(p) => Region::from_pos(*p),
         }
     }
 }
@@ -1401,7 +1399,7 @@ impl<'a> ETypeAbilityImpl<'a> {
             // Case with child node that has get_region()
             ETypeAbilityImpl::Type(type_expr, _) => type_expr.get_region(),
             ETypeAbilityImpl::Expr(expr, _) => expr.get_region(),
-            // Cases with Position values     
+            // Cases with Position values
             ETypeAbilityImpl::End(p)
             | ETypeAbilityImpl::Open(p)
             | ETypeAbilityImpl::Field(p)
@@ -1409,12 +1407,10 @@ impl<'a> ETypeAbilityImpl<'a> {
             | ETypeAbilityImpl::Colon(p)
             | ETypeAbilityImpl::Arrow(p)
             | ETypeAbilityImpl::Optional(p)
-
             | ETypeAbilityImpl::Space(_, p)
             | ETypeAbilityImpl::Prefix(p)
             | ETypeAbilityImpl::QuestionMark(p)
             | ETypeAbilityImpl::Ampersand(p)
-
             | ETypeAbilityImpl::IndentBar(p)
             | ETypeAbilityImpl::IndentAmpersand(p) => Region::from_pos(*p),
         }

--- a/crates/compiler/parse/src/parser.rs
+++ b/crates/compiler/parse/src/parser.rs
@@ -73,7 +73,7 @@ impl<'a> SyntaxError<'a> {
             SyntaxError::Type(e_type) => Some(e_type.get_region()),
             SyntaxError::Pattern(e_pattern) => Some(e_pattern.get_region()),
             SyntaxError::NotEndOfFile(pos) => Some(Region::from_pos(*pos)),
-            SyntaxError::Expr(e_expr, pos) => Some(Region::from_pos(*pos)),
+            SyntaxError::Expr(e_expr, _) => Some(e_expr.get_region()),
             SyntaxError::Header(e_header) => Some(e_header.get_region()),
             SyntaxError::NotYetImplemented(_) => None,
             SyntaxError::OutdentedTooFar => None,
@@ -158,19 +158,19 @@ pub enum EHeader<'a> {
 impl<'a> EHeader<'a> {
     pub fn get_region(&self) -> Region {
         match self {
-            EHeader::Provides(_, pos)
-            | EHeader::Params(_, pos)
-            | EHeader::Exposes(_, pos)
-            | EHeader::Imports(_, pos)
-            | EHeader::Requires(_, pos)
-            | EHeader::Packages(_, pos)
-            | EHeader::Space(_, pos)
-            | EHeader::Start(pos)
-            | EHeader::ModuleName(pos)
-            | EHeader::AppName(_, pos)
-            | EHeader::PackageName(_, pos)
-            | EHeader::PlatformName(_, pos)
-            | EHeader::IndentStart(pos) => Region::from_pos(*pos),
+            EHeader::Provides(provides, pos) => provides.get_region(),
+            EHeader::Params(params, pos) => params.get_region(),
+            EHeader::Exposes(_, pos) => Region::from_pos(*pos),
+            EHeader::Imports(_, pos) => Region::from_pos(*pos),
+            EHeader::Requires(requires, pos) => requires.get_region(),
+            EHeader::Packages(packages, pos) => packages.get_region(),
+            EHeader::Space(_, pos) => Region::from_pos(*pos),
+            EHeader::Start(pos) => Region::from_pos(*pos),
+            EHeader::ModuleName(pos) => Region::from_pos(*pos),
+            EHeader::AppName(app_name, pos) => app_name.get_region(),
+            EHeader::PackageName(package_name, pos) => package_name.get_region(),
+            EHeader::PlatformName(platform_name, pos) => platform_name.get_region(),
+            EHeader::IndentStart(pos) => Region::from_pos(*pos),
             EHeader::InconsistentModuleName(region) => *region,
         }
     }
@@ -192,6 +192,26 @@ pub enum EProvides<'a> {
     Space(BadInputError, Position),
 }
 
+impl<'a> EProvides<'a> {
+    pub fn get_region(&self) -> Region {
+        let pos = match self {
+            EProvides::Provides(p)
+            | EProvides::Open(p)
+            | EProvides::To(p)
+            | EProvides::IndentProvides(p)
+            | EProvides::IndentTo(p)
+            | EProvides::IndentListStart(p)
+            | EProvides::IndentPackage(p)
+            | EProvides::ListStart(p)
+            | EProvides::ListEnd(p)
+            | EProvides::Identifier(p)
+            | EProvides::Package(_, p)
+            | EProvides::Space(_, p) => p,
+        };
+        Region::from_pos(*pos)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum EParams<'a> {
     Pattern(PRecord<'a>, Position),
@@ -199,6 +219,19 @@ pub enum EParams<'a> {
     Arrow(Position),
     AfterArrow(Position),
     Space(BadInputError, Position),
+}
+
+impl<'a> EParams<'a> {
+    pub fn get_region(&self) -> Region {
+        let pos = match self {
+            EParams::Pattern(_, p)
+            | EParams::BeforeArrow(p)
+            | EParams::Arrow(p)
+            | EParams::AfterArrow(p)
+            | EParams::Space(_, p) => p,
+        };
+        Region::from_pos(*pos)
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -211,6 +244,22 @@ pub enum EExposes {
     ListEnd(Position),
     Identifier(Position),
     Space(BadInputError, Position),
+}
+
+impl EExposes {
+    pub fn get_region(&self) -> Region {
+        let pos = match self {
+            EExposes::Exposes(p)
+            | EExposes::Open(p)
+            | EExposes::IndentExposes(p)
+            | EExposes::IndentListStart(p)
+            | EExposes::ListStart(p)
+            | EExposes::ListEnd(p)
+            | EExposes::Identifier(p)
+            | EExposes::Space(_, p) => p,
+        };
+        Region::from_pos(*pos)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -226,6 +275,23 @@ pub enum ERequires<'a> {
     Space(BadInputError, Position),
 }
 
+impl<'a> ERequires<'a> {
+    pub fn get_region(&self) -> Region {
+        let pos = match self {
+            ERequires::Requires(p)
+            | ERequires::Open(p)
+            | ERequires::IndentRequires(p)
+            | ERequires::IndentListStart(p)
+            | ERequires::ListStart(p)
+            | ERequires::ListEnd(p)
+            | ERequires::TypedIdent(_, p)
+            | ERequires::Rigid(p)
+            | ERequires::Space(_, p) => p,
+        };
+        Region::from_pos(*pos)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ETypedIdent<'a> {
     Space(BadInputError, Position),
@@ -235,6 +301,21 @@ pub enum ETypedIdent<'a> {
     Type(EType<'a>, Position),
     IndentType(Position),
     Identifier(Position),
+}
+
+impl<'a> ETypedIdent<'a> {
+    pub fn get_region(&self) -> Region {
+        let pos = match self {
+            ETypedIdent::Space(_, p)
+            | ETypedIdent::HasType(p)
+            | ETypedIdent::IndentHasType(p)
+            | ETypedIdent::Name(p)
+            | ETypedIdent::Type(_, p)
+            | ETypedIdent::IndentType(p)
+            | ETypedIdent::Identifier(p) => p,
+        };
+        Region::from_pos(*pos)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -250,11 +331,39 @@ pub enum EPackages<'a> {
     PackageEntry(EPackageEntry<'a>, Position),
 }
 
+impl<'a> EPackages<'a> {
+    pub fn get_region(&self) -> Region {
+        let pos = match self {
+            EPackages::Open(p)
+            | EPackages::Space(_, p)
+            | EPackages::Packages(p)
+            | EPackages::IndentPackages(p)
+            | EPackages::ListStart(p)
+            | EPackages::ListEnd(p)
+            | EPackages::IndentListStart(p)
+            | EPackages::IndentListEnd(p)
+            | EPackages::PackageEntry(_, p) => p,
+        };
+        Region::from_pos(*pos)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum EPackageName<'a> {
     BadPath(EString<'a>, Position),
     Escapes(Position),
     Multiline(Position),
+}
+
+impl<'a> EPackageName<'a> {
+    pub fn get_region(&self) -> Region {
+        let pos = match self {
+            EPackageName::BadPath(_, p) | EPackageName::Escapes(p) | EPackageName::Multiline(p) => {
+                p
+            }
+        };
+        Region::from_pos(*pos)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -266,6 +375,21 @@ pub enum EPackageEntry<'a> {
     IndentPlatform(Position),
     Platform(Position),
     Space(BadInputError, Position),
+}
+
+impl<'a> EPackageEntry<'a> {
+    pub fn get_region(&self) -> Region {
+        let pos = match self {
+            EPackageEntry::BadPackage(_, p)
+            | EPackageEntry::Shorthand(p)
+            | EPackageEntry::Colon(p)
+            | EPackageEntry::IndentPackage(p)
+            | EPackageEntry::IndentPlatform(p)
+            | EPackageEntry::Platform(p)
+            | EPackageEntry::Space(_, p) => p,
+        };
+        Region::from_pos(*pos)
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -289,6 +413,33 @@ pub enum EImports {
     TypedIdent(Position),
     AsKeyword(Position),
     StrLiteral(Position),
+}
+
+impl EImports {
+    pub fn get_region(&self) -> Region {
+        let pos = match self {
+            EImports::Open(p)
+            | EImports::Imports(p)
+            | EImports::IndentImports(p)
+            | EImports::IndentListStart(p)
+            | EImports::IndentListEnd(p)
+            | EImports::ListStart(p)
+            | EImports::ListEnd(p)
+            | EImports::Identifier(p)
+            | EImports::ExposingDot(p)
+            | EImports::ShorthandDot(p)
+            | EImports::Shorthand(p)
+            | EImports::ModuleName(p)
+            | EImports::Space(_, p)
+            | EImports::IndentSetStart(p)
+            | EImports::SetStart(p)
+            | EImports::SetEnd(p)
+            | EImports::TypedIdent(p)
+            | EImports::AsKeyword(p)
+            | EImports::StrLiteral(p) => p,
+        };
+        Region::from_pos(*pos)
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -406,6 +557,69 @@ pub enum EExpr<'a> {
     UnexpectedTopLevelExpr(Position),
 }
 
+impl<'a> EExpr<'a> {
+    pub fn get_region(&self) -> Region {
+        match self {
+            // Cases with child nodes that have get_region()
+            EExpr::Type(e_type, _) => e_type.get_region(),
+            EExpr::Pattern(e_pattern, _) => e_pattern.get_region(),
+            EExpr::Ability(e_ability, _) => e_ability.get_region(),
+            EExpr::When(e_when, _) => e_when.get_region(),
+            EExpr::If(e_if, _) => e_if.get_region(),
+            EExpr::Expect(e_expect, _) => e_expect.get_region(), 
+            EExpr::Dbg(e_expect, _) => e_expect.get_region(),
+            EExpr::Import(e_import, _) => e_import.get_region(),
+            EExpr::Return(e_return, _) => e_return.get_region(),
+            EExpr::Closure(e_closure, _) => e_closure.get_region(),
+            EExpr::InParens(e_in_parens, _) => e_in_parens.get_region(),
+            EExpr::Record(e_record, _) => e_record.get_region(),
+            EExpr::Str(e_string, _) => e_string.get_region(),
+            EExpr::List(e_list, _) => e_list.get_region(),
+
+            // Cases with direct Region values
+            EExpr::RecordUpdateOldBuilderField(r)
+            | EExpr::RecordUpdateIgnoredField(r)
+            | EExpr::RecordBuilderOldBuilderField(r) => *r,
+
+            // Cases with Position values
+            EExpr::TrailingOperator(p)
+            | EExpr::Start(p)
+            | EExpr::End(p)
+            | EExpr::BadExprEnd(p)
+            | EExpr::Space(_, p)
+            | EExpr::Dot(p)
+            | EExpr::Access(p)
+            | EExpr::UnaryNot(p)
+            | EExpr::UnaryNegate(p)
+            | EExpr::BadOperator(_, p)
+            | EExpr::DefMissingFinalExpr(p)
+            | EExpr::DefMissingFinalExpr2(_, p)
+            | EExpr::IndentDefBody(p)
+            | EExpr::IndentEquals(p)
+            | EExpr::IndentAnnotation(p)
+            | EExpr::Equals(p)
+            | EExpr::Colon(p)
+            | EExpr::DoubleColon(p)
+            | EExpr::Ident(p)
+            | EExpr::ElmStyleFunction(_, p)
+            | EExpr::MalformedPattern(p)
+            | EExpr::QualifiedTag(p)
+            | EExpr::BackpassComma(p)
+            | EExpr::BackpassArrow(p)
+            | EExpr::BackpassContinue(p)
+            | EExpr::DbgContinue(p)
+            | EExpr::Underscore(p)
+            | EExpr::Crash(p)
+            | EExpr::Try(p)
+            | EExpr::Number(_, p)
+            | EExpr::IndentStart(p)
+            | EExpr::IndentEnd(p)
+            | EExpr::UnexpectedComma(p)
+            | EExpr::UnexpectedTopLevelExpr(p) => Region::from_pos(*p),
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ENumber {
     End,
@@ -429,6 +643,29 @@ pub enum EString<'a> {
     FormatEnd(Position),
     MultilineInsufficientIndent(Position),
     ExpectedDoubleQuoteGotSingleQuote(Position),
+}
+
+impl<'a> EString<'a> {
+    pub fn get_region(&self) -> Region {
+        match self {
+            // Case with child node that has get_region()
+            EString::Format(expr, _) => expr.get_region(),
+            
+            // Cases with Position values
+            EString::Open(p)
+            | EString::CodePtOpen(p)
+            | EString::CodePtEnd(p)
+            | EString::InvalidSingleQuote(_, p)
+            | EString::Space(_, p)
+            | EString::EndlessSingleLine(p)
+            | EString::EndlessMultiLine(p)
+            | EString::EndlessSingleQuote(p)
+            | EString::UnknownEscape(p)
+            | EString::FormatEnd(p)
+            | EString::MultilineInsufficientIndent(p)
+            | EString::ExpectedDoubleQuoteGotSingleQuote(p) => Region::from_pos(*p),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -457,6 +694,27 @@ pub enum ERecord<'a> {
     Space(BadInputError, Position),
 }
 
+impl<'a> ERecord<'a> {
+    pub fn get_region(&self) -> Region {
+        match self {
+            // Cases with child node that has get_region()
+            ERecord::Expr(expr, _) => expr.get_region(),
+            
+            // Cases with Position values
+            ERecord::End(p)
+            | ERecord::Open(p)
+            | ERecord::Prefix(p)
+            | ERecord::Field(p)
+            | ERecord::UnderscoreField(p)
+            | ERecord::Colon(p)
+            | ERecord::QuestionMark(p)
+            | ERecord::Arrow(p)
+            | ERecord::Ampersand(p)
+            | ERecord::Space(_, p) => Region::from_pos(*p),
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum EInParens<'a> {
     End(Position),
@@ -470,6 +728,21 @@ pub enum EInParens<'a> {
 
     ///
     Space(BadInputError, Position),
+}
+
+impl<'a> EInParens<'a> {
+    pub fn get_region(&self) -> Region {
+        match self {
+            // Cases with child node that has get_region()
+            EInParens::Expr(expr, _) => expr.get_region(),
+            
+            // Cases with Position values
+            EInParens::End(p)
+            | EInParens::Open(p)
+            | EInParens::Empty(p)
+            | EInParens::Space(_, p) => Region::from_pos(*p),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -487,6 +760,26 @@ pub enum EClosure<'a> {
     IndentArg(Position),
 }
 
+impl<'a> EClosure<'a> {
+    pub fn get_region(&self) -> Region {
+        match self {
+            // Cases with child nodes that have get_region()
+            EClosure::Pattern(pattern, _) => pattern.get_region(),
+            EClosure::Body(expr, _) => expr.get_region(),
+            
+            // Cases with Position values
+            EClosure::Space(_, p)
+            | EClosure::Start(p)
+            | EClosure::Arrow(p)
+            | EClosure::Comma(p)
+            | EClosure::Arg(p)
+            | EClosure::IndentArrow(p)
+            | EClosure::IndentBody(p)
+            | EClosure::IndentArg(p) => Region::from_pos(*p),
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum EList<'a> {
     Open(Position),
@@ -494,6 +787,18 @@ pub enum EList<'a> {
     Space(BadInputError, Position),
 
     Expr(&'a EExpr<'a>, Position),
+}
+
+impl<'a> EList<'a> {
+    pub fn get_region(&self) -> Region {
+        match self {
+            // Case with child node that has get_region()
+            EList::Expr(expr, _) => expr.get_region(),
+            
+            // Cases with Position values
+            EList::Open(p) | EList::End(p) | EList::Space(_, p) => Region::from_pos(*p),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -519,6 +824,32 @@ pub enum EWhen<'a> {
     PatternAlignment(u32, Position),
 }
 
+impl<'a> EWhen<'a> {
+    pub fn get_region(&self) -> Region {
+        match self {
+            // Cases with child nodes that have get_region()
+            EWhen::Pattern(pattern, _) => pattern.get_region(),
+            EWhen::IfGuard(expr, _) => expr.get_region(),
+            EWhen::Condition(expr, _) => expr.get_region(),
+            EWhen::Branch(expr, _) => expr.get_region(),
+
+            // Cases with Position values
+            EWhen::Space(_, p)
+            | EWhen::When(p)
+            | EWhen::Is(p)
+            | EWhen::Arrow(p)
+            | EWhen::Bar(p)
+            | EWhen::IfToken(p)
+            | EWhen::IndentCondition(p)
+            | EWhen::IndentPattern(p)
+            | EWhen::IndentArrow(p)
+            | EWhen::IndentBranch(p)
+            | EWhen::IndentIfGuard(p)
+            | EWhen::PatternAlignment(_, p) => Region::from_pos(*p),
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum EAbility<'a> {
     Space(BadInputError, Position),
@@ -527,6 +858,21 @@ pub enum EAbility<'a> {
     DemandAlignment(i32, Position),
     DemandName(Position),
     DemandColon(Position),
+}
+
+impl<'a> EAbility<'a> {
+    pub fn get_region(&self) -> Region {
+        match self {
+            // Case with child node that has get_region()
+            EAbility::Type(e_type, _) => e_type.get_region(),
+            
+            // Cases with Position values
+            EAbility::Space(_, p)
+            | EAbility::DemandAlignment(_, p)
+            | EAbility::DemandName(p)
+            | EAbility::DemandColon(p) => Region::from_pos(*p),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -548,6 +894,24 @@ pub enum EIf<'a> {
     IndentElseBranch(Position),
 }
 
+impl<'a> EIf<'a> {
+    pub fn get_region(&self) -> Region {
+        match self {
+            EIf::Condition(expr, _) | EIf::ThenBranch(expr, _) | EIf::ElseBranch(expr, _) => expr.get_region(),
+            EIf::Space(_, p)
+            | EIf::If(p)
+            | EIf::Then(p)
+            | EIf::Else(p)
+            | EIf::IndentCondition(p)
+            | EIf::IndentIf(p)
+            | EIf::IndentThenToken(p)
+            | EIf::IndentElseToken(p)
+            | EIf::IndentThenBranch(p)
+            | EIf::IndentElseBranch(p) => Region::from_pos(*p),
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum EExpect<'a> {
     Space(BadInputError, Position),
@@ -558,12 +922,34 @@ pub enum EExpect<'a> {
     IndentCondition(Position),
 }
 
+impl<'a> EExpect<'a> {
+    pub fn get_region(&self) -> Region {
+        match self {
+            EExpect::Condition(expr, _) | EExpect::Continuation(expr, _) => expr.get_region(),
+            EExpect::Space(_, p)
+            | EExpect::Dbg(p)
+            | EExpect::Expect(p)
+            | EExpect::IndentCondition(p) => Region::from_pos(*p),
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum EReturn<'a> {
     Space(BadInputError, Position),
     Return(Position),
     ReturnValue(&'a EExpr<'a>, Position),
     IndentReturnValue(Position),
+}
+impl<'a> EReturn<'a> {
+    pub fn get_region(&self) -> Region {
+        match self {
+            EReturn::ReturnValue(expr, _) => expr.get_region(),
+            EReturn::Space(_, p)
+            | EReturn::Return(p)
+            | EReturn::IndentReturnValue(p) => Region::from_pos(*p),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -596,6 +982,44 @@ pub enum EImport<'a> {
     EndNewline(Position),
 }
 
+impl<'a> EImport<'a> {
+    pub fn get_region(&self) -> Region {
+        match self {
+            // Cases with child nodes that have get_region()
+            EImport::Params(params, _) => params.get_region(),
+            EImport::Annotation(e_type, _) => e_type.get_region(),
+            
+            // Case with direct Region value
+            EImport::LowercaseAlias(r) => *r,
+            
+            // Cases with Position values
+            EImport::Import(p)
+            | EImport::IndentStart(p)
+            | EImport::PackageShorthand(p)
+            | EImport::PackageShorthandDot(p)
+            | EImport::ModuleName(p)
+            | EImport::IndentAs(p)
+            | EImport::As(p)
+            | EImport::IndentAlias(p)
+            | EImport::Alias(p)
+            | EImport::IndentExposing(p)
+            | EImport::Exposing(p)
+            | EImport::ExposingListStart(p)
+            | EImport::ExposedName(p)
+            | EImport::ExposingListEnd(p)
+            | EImport::IndentIngestedPath(p)
+            | EImport::IngestedPath(p)
+            | EImport::IndentIngestedName(p)
+            | EImport::IngestedName(p)
+            | EImport::IndentColon(p)
+            | EImport::Colon(p)
+            | EImport::IndentAnnotation(p)
+            | EImport::Space(_, p)
+            | EImport::EndNewline(p) => Region::from_pos(*p),
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum EImportParams<'a> {
     Indent(Position),
@@ -604,6 +1028,19 @@ pub enum EImportParams<'a> {
     RecordBuilderFound(Region),
     RecordIgnoredFieldFound(Region),
     Space(BadInputError, Position),
+}
+
+impl<'a> EImportParams<'a> {
+    pub fn get_region(&self) -> Region {
+        match self {
+            EImportParams::Indent(p) | EImportParams::Record(_, p) | EImportParams::Space(_, p) => {
+                Region::from_pos(*p)
+            }
+            EImportParams::RecordUpdateFound(r)
+            | EImportParams::RecordBuilderFound(r)
+            | EImportParams::RecordIgnoredFieldFound(r) => *r,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -632,10 +1069,14 @@ pub enum EPattern<'a> {
 
 impl<'a> EPattern<'a> {
     pub fn get_region(&self) -> Region {
-        let pos = match self {
-            EPattern::Record(_, position)
-            | EPattern::List(_, position)
-            | EPattern::AsKeyword(position)
+        match self {
+            // Cases with child nodes that have get_region()
+            EPattern::Record(expr, _) => expr.get_region(),
+            EPattern::List(expr, _) => expr.get_region(),
+            EPattern::PInParens(expr, _) => expr.get_region(),
+            
+            // Cases with Position values
+            EPattern::AsKeyword(position)
             | EPattern::AsIdentifier(position)
             | EPattern::Underscore(position)
             | EPattern::NotAPattern(position)
@@ -648,9 +1089,8 @@ impl<'a> EPattern<'a> {
             | EPattern::IndentEnd(position)
             | EPattern::AsIndentStart(position)
             | EPattern::AccessorFunction(position)
-            | EPattern::RecordUpdaterFunction(position) => position,
-        };
-        Region::from_pos(*pos)
+            | EPattern::RecordUpdaterFunction(position) => Region::from_pos(*position),
+        }
     }
 }
 
@@ -669,6 +1109,24 @@ pub enum PRecord<'a> {
     Space(BadInputError, Position),
 }
 
+impl<'a> PRecord<'a> {
+    pub fn get_region(&self) -> Region {
+        match self {
+            // Cases with child nodes that have get_region()
+            PRecord::Pattern(pattern, _) => pattern.get_region(),
+            PRecord::Expr(expr, _) => expr.get_region(),
+            
+            // Cases with Position values
+            PRecord::End(p)
+            | PRecord::Open(p)
+            | PRecord::Field(p)
+            | PRecord::Colon(p)
+            | PRecord::Optional(p)
+            | PRecord::Space(_, p) => Region::from_pos(*p),
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PList<'a> {
     End(Position),
@@ -680,6 +1138,21 @@ pub enum PList<'a> {
     Space(BadInputError, Position),
 }
 
+impl<'a> PList<'a> {
+    pub fn get_region(&self) -> Region {
+        match self {
+            // Case with child node that has get_region()
+            PList::Pattern(pattern, _) => pattern.get_region(),
+            
+            // Cases with Position values
+            PList::End(p)
+            | PList::Open(p)
+            | PList::Rest(p)
+            | PList::Space(_, p) => Region::from_pos(*p),
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PInParens<'a> {
     Empty(Position),
@@ -688,6 +1161,21 @@ pub enum PInParens<'a> {
     Pattern(&'a EPattern<'a>, Position),
 
     Space(BadInputError, Position),
+}
+
+impl<'a> PInParens<'a> {
+    pub fn get_region(&self) -> Region {
+        match self {
+            // Case with child node that has get_region()
+            PInParens::Pattern(pattern, _) => pattern.get_region(),
+            
+            // Cases with Position values
+            PInParens::Empty(p)
+            | PInParens::End(p)
+            | PInParens::Open(p)
+            | PInParens::Space(_, p) => Region::from_pos(*p),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -715,31 +1203,32 @@ pub enum EType<'a> {
     TIndentEnd(Position),
     TAsIndentStart(Position),
 }
-
 impl<'a> EType<'a> {
     pub fn get_region(&self) -> Region {
-        let pos = match self {
-            EType::Space(_, position)
-            | EType::UnderscoreSpacing(position)
-            | EType::TRecord(_, position)
-            | EType::TTagUnion(_, position)
-            | EType::TInParens(_, position)
-            | EType::TApply(_, position)
-            | EType::TInlineAlias(_, position)
-            | EType::TBadTypeVariable(position)
-            | EType::TWildcard(position)
-            | EType::TInferred(position)
-            | EType::TStart(position)
-            | EType::TEnd(position)
-            | EType::TFunctionArgument(position)
-            | EType::TWhereBar(position)
-            | EType::TImplementsClause(position)
-            | EType::TAbilityImpl(_, position)
-            | EType::TIndentStart(position)
-            | EType::TIndentEnd(position)
-            | EType::TAsIndentStart(position) => position,
-        };
-        Region::from_pos(*pos)
+        match self {
+            // Cases with child nodes that have get_region()
+            EType::TRecord(expr, _) => expr.get_region(),
+            EType::TTagUnion(expr, _) => expr.get_region(),
+            EType::TInParens(expr, _) => expr.get_region(),
+            EType::TApply(eapply,_, )=> eapply.get_region(),
+            EType::TInlineAlias(einline, _) => einline.get_region(),
+            EType::TAbilityImpl(eability, _) => eability.get_region(),
+            
+            // Cases with Position values
+            EType::Space(_, p)
+            | EType::UnderscoreSpacing(p)
+            | EType::TBadTypeVariable(p)
+            | EType::TWildcard(p)
+            | EType::TInferred(p)
+            | EType::TStart(p)
+            | EType::TEnd(p)
+            | EType::TFunctionArgument(p)
+            | EType::TWhereBar(p)
+            | EType::TImplementsClause(p)
+            | EType::TIndentStart(p)
+            | EType::TIndentEnd(p)
+            | EType::TAsIndentStart(p) => Region::from_pos(*p),
+        }
     }
 }
 
@@ -761,6 +1250,27 @@ pub enum ETypeRecord<'a> {
     IndentEnd(Position),
 }
 
+impl<'a> ETypeRecord<'a> {
+    pub fn get_region(&self) -> Region {
+        match self {
+            // Case with child node that has get_region()
+            ETypeRecord::Type(type_expr, _) => type_expr.get_region(),
+            
+            // Cases with Position values
+            ETypeRecord::End(p)
+            | ETypeRecord::Open(p)
+            | ETypeRecord::Field(p)
+            | ETypeRecord::Colon(p)
+            | ETypeRecord::Optional(p)
+            | ETypeRecord::Space(_, p)
+            | ETypeRecord::IndentOpen(p)
+            | ETypeRecord::IndentColon(p)
+            | ETypeRecord::IndentOptional(p)
+            | ETypeRecord::IndentEnd(p) => Region::from_pos(*p),
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ETypeTagUnion<'a> {
     End(Position),
@@ -769,6 +1279,20 @@ pub enum ETypeTagUnion<'a> {
     Type(&'a EType<'a>, Position),
 
     Space(BadInputError, Position),
+}
+
+impl<'a> ETypeTagUnion<'a> {
+    pub fn get_region(&self) -> Region {
+        match self {
+            // Case with child node that has get_region()
+            ETypeTagUnion::Type(type_expr, _) => type_expr.get_region(),
+            
+            // Cases with Position values
+            ETypeTagUnion::End(p)
+            | ETypeTagUnion::Open(p)
+            | ETypeTagUnion::Space(_, p) => Region::from_pos(*p),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -788,6 +1312,24 @@ pub enum ETypeInParens<'a> {
     IndentEnd(Position),
 }
 
+impl<'a> ETypeInParens<'a> {
+    pub fn get_region(&self) -> Region {
+        match self {
+            // Cases with child nodes that have get_region()
+            ETypeInParens::Type(type_expr, _) => type_expr.get_region(),
+            
+            // Cases with Position values
+            ETypeInParens::Empty(p)
+            | ETypeInParens::End(p)
+            | ETypeInParens::Open(p)
+            | ETypeInParens::Space(_, p)
+            | ETypeInParens::IndentOpen(p)
+            | ETypeInParens::IndentEnd(p) =>    Region::from_pos(*p),
+        
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ETypeApply {
     ///
@@ -800,11 +1342,36 @@ pub enum ETypeApply {
     StartIsNumber(Position),
 }
 
+impl ETypeApply {
+    pub fn get_region(&self) -> Region {
+        let pos = match self {
+            ETypeApply::StartNotUppercase(p)
+            | ETypeApply::End(p)
+            | ETypeApply::Space(_, p)
+            | ETypeApply::DoubleDot(p)
+            | ETypeApply::TrailingDot(p)
+            | ETypeApply::StartIsNumber(p) => p,
+        };
+        Region::from_pos(*pos)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ETypeInlineAlias {
     NotAnAlias(Position),
     Qualified(Position),
     ArgumentNotLowercase(Position),
+}
+
+impl ETypeInlineAlias {
+    pub fn get_region(&self) -> Region {
+        let pos = match self {
+            ETypeInlineAlias::NotAnAlias(p)
+            | ETypeInlineAlias::Qualified(p)
+            | ETypeInlineAlias::ArgumentNotLowercase(p) => p,
+        };
+        Region::from_pos(*pos)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -827,6 +1394,31 @@ pub enum ETypeAbilityImpl<'a> {
     Expr(&'a EExpr<'a>, Position),
     IndentBar(Position),
     IndentAmpersand(Position),
+}
+impl<'a> ETypeAbilityImpl<'a> {
+    pub fn get_region(&self) -> Region {
+        match self {
+            // Case with child node that has get_region()
+            ETypeAbilityImpl::Type(type_expr, _) => type_expr.get_region(),
+            ETypeAbilityImpl::Expr(expr, _) => expr.get_region(),
+            // Cases with Position values     
+            ETypeAbilityImpl::End(p)
+            | ETypeAbilityImpl::Open(p)
+            | ETypeAbilityImpl::Field(p)
+            | ETypeAbilityImpl::UnderscoreField(p)
+            | ETypeAbilityImpl::Colon(p)
+            | ETypeAbilityImpl::Arrow(p)
+            | ETypeAbilityImpl::Optional(p)
+
+            | ETypeAbilityImpl::Space(_, p)
+            | ETypeAbilityImpl::Prefix(p)
+            | ETypeAbilityImpl::QuestionMark(p)
+            | ETypeAbilityImpl::Ampersand(p)
+
+            | ETypeAbilityImpl::IndentBar(p)
+            | ETypeAbilityImpl::IndentAmpersand(p) => Region::from_pos(*p),
+        }
+    }
 }
 
 impl<'a> From<ERecord<'a>> for ETypeAbilityImpl<'a> {

--- a/crates/compiler/test_gen/src/helpers/llvm.rs
+++ b/crates/compiler/test_gen/src/helpers/llvm.rs
@@ -91,6 +91,7 @@ fn create_llvm_module<'a>(
         Ok(x) => x,
         Err(LoadMonomorphizedError::LoadingProblem(roc_load::LoadingProblem::FormattedReport(
             report,
+            _,
         ))) => {
             println!("{report}");
             panic!();

--- a/crates/compiler/test_mono/src/tests.rs
+++ b/crates/compiler/test_mono/src/tests.rs
@@ -172,7 +172,8 @@ fn compiles_to_ir(test_name: &str, src: &str, mode: &str, allow_type_errors: boo
     let mut loaded = match loaded {
         Ok(x) => x,
         Err(LoadMonomorphizedError::LoadingProblem(roc_load::LoadingProblem::FormattedReport(
-            report,_
+            report,
+            _,
         ))) => {
             println!("{report}");
             panic!();

--- a/crates/compiler/test_mono/src/tests.rs
+++ b/crates/compiler/test_mono/src/tests.rs
@@ -172,7 +172,7 @@ fn compiles_to_ir(test_name: &str, src: &str, mode: &str, allow_type_errors: boo
     let mut loaded = match loaded {
         Ok(x) => x,
         Err(LoadMonomorphizedError::LoadingProblem(roc_load::LoadingProblem::FormattedReport(
-            report,
+            report,_
         ))) => {
             println!("{report}");
             panic!();

--- a/crates/compiler/uitest/src/mono.rs
+++ b/crates/compiler/uitest/src/mono.rs
@@ -63,7 +63,8 @@ pub(crate) fn write_compiled_ir<'a>(
     let loaded = match loaded {
         Ok(x) => x,
         Err(LoadMonomorphizedError::LoadingProblem(roc_load::LoadingProblem::FormattedReport(
-            report,_
+            report,
+            _,
         ))) => {
             println!("{report}");
             panic!();

--- a/crates/compiler/uitest/src/mono.rs
+++ b/crates/compiler/uitest/src/mono.rs
@@ -63,7 +63,7 @@ pub(crate) fn write_compiled_ir<'a>(
     let loaded = match loaded {
         Ok(x) => x,
         Err(LoadMonomorphizedError::LoadingProblem(roc_load::LoadingProblem::FormattedReport(
-            report,
+            report,_
         ))) => {
             println!("{report}");
             panic!();

--- a/crates/docs/src/lib.rs
+++ b/crates/docs/src/lib.rs
@@ -674,7 +674,7 @@ pub fn load_module_for_docs(filename: PathBuf) -> LoadedModule {
         load_config,
     ) {
         Ok(loaded) => loaded,
-        Err(LoadingProblem::FormattedReport(report)) => {
+        Err(LoadingProblem::FormattedReport(report,_)) => {
             eprintln!("{report}");
             std::process::exit(1);
         }

--- a/crates/docs/src/lib.rs
+++ b/crates/docs/src/lib.rs
@@ -674,7 +674,7 @@ pub fn load_module_for_docs(filename: PathBuf) -> LoadedModule {
         load_config,
     ) {
         Ok(loaded) => loaded,
-        Err(LoadingProblem::FormattedReport(report,_)) => {
+        Err(LoadingProblem::FormattedReport(report, _)) => {
             eprintln!("{report}");
             std::process::exit(1);
         }

--- a/crates/glue/src/load.rs
+++ b/crates/glue/src/load.rs
@@ -437,7 +437,7 @@ pub fn load_types(
         },
     )
     .unwrap_or_else(|problem| match problem {
-        LoadingProblem::FormattedReport(report) => {
+        LoadingProblem::FormattedReport(report, _) => {
             eprintln!("{report}");
 
             process::exit(1);

--- a/crates/language_server/src/analysis.rs
+++ b/crates/language_server/src/analysis.rs
@@ -122,7 +122,7 @@ pub(crate) fn global_analysis(doc_info: DocInfo) -> Vec<AnalyzedDocument> {
         Ok(module) => module,
         Err(problem) => {
             let all_problems = problem
-                .into_lsp_diagnostic(&())
+                .into_lsp_diagnostic(&doc_info.line_info)
                 .into_iter()
                 .collect::<Vec<_>>();
 

--- a/crates/language_server/src/convert.rs
+++ b/crates/language_server/src/convert.rs
@@ -75,6 +75,7 @@ impl ToRocPosition for tower_lsp::lsp_types::Position {
 pub(crate) mod diag {
     use std::{fmt::Debug, path::Path};
 
+    use log::debug;
     use roc_load::LoadingProblem;
     use roc_region::all::{LineInfo, Region};
     use roc_solve_problem::TypeError;
@@ -117,6 +118,8 @@ pub(crate) mod diag {
                 ))
                 .to_range(line_info);
 
+            debug!("range is {:?}", range);
+
             let msg = match self {
                 LoadingProblem::FileProblem { filename, error } => {
                     format!(
@@ -153,10 +156,8 @@ pub(crate) mod diag {
                 LoadingProblem::TriedToImportAppModule => {
                     "Attempted to import app module".to_string()
                 }
-                LoadingProblem::FormattedReport(report, region) => {
-                    range = region.unwrap_or(Region::zero()).to_range(line_info);
-                    report.clone()
-                }
+                LoadingProblem::FormattedReport(report, region) => 
+                    report.clone(),
                 LoadingProblem::ImportCycle(_, _) => {
                     "Circular dependency between modules".to_string()
                 }
@@ -204,6 +205,7 @@ pub(crate) mod diag {
                 ))
                 .to_range(fmt.line_info);
 
+            debug!("range is {:?}", range);
             let report = roc_reporting::report::can_problem(
                 fmt.alloc,
                 fmt.line_info,

--- a/crates/language_server/src/convert.rs
+++ b/crates/language_server/src/convert.rs
@@ -1,7 +1,3 @@
-use std::any::Any;
-
-use roc_load::LoadingProblem;
-use roc_parse::parser::{EHeader, EPattern, EType, SourceError, SyntaxError};
 use roc_region::all::{LineColumn, LineColumnRegion, LineInfo, Region};
 use tower_lsp::lsp_types::{Position, Range};
 
@@ -73,7 +69,7 @@ impl ToRocPosition for tower_lsp::lsp_types::Position {
 }
 
 pub(crate) mod diag {
-    use std::{fmt::Debug, path::Path};
+    use std::path::Path;
 
     use log::debug;
     use roc_load::LoadingProblem;
@@ -82,7 +78,7 @@ pub(crate) mod diag {
 
     use roc_problem::Severity;
     use roc_reporting::report::RocDocAllocator;
-    use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, Position, Range};
+    use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity};
 
     use super::ToRange;
 
@@ -110,7 +106,7 @@ pub(crate) mod diag {
         type Feed = LineInfo;
 
         fn into_lsp_diagnostic(self, line_info: &LineInfo) -> Option<Diagnostic> {
-            let mut range = self
+            let range = self
                 .get_region()
                 .unwrap_or(Region::new(
                     roc_region::all::Position::new(0),
@@ -156,8 +152,7 @@ pub(crate) mod diag {
                 LoadingProblem::TriedToImportAppModule => {
                     "Attempted to import app module".to_string()
                 }
-                LoadingProblem::FormattedReport(report, region) => 
-                    report.clone(),
+                LoadingProblem::FormattedReport(report, _region) => report.clone(),
                 LoadingProblem::ImportCycle(_, _) => {
                     "Circular dependency between modules".to_string()
                 }

--- a/crates/language_server/src/convert.rs
+++ b/crates/language_server/src/convert.rs
@@ -71,7 +71,6 @@ impl ToRocPosition for tower_lsp::lsp_types::Position {
 pub(crate) mod diag {
     use std::path::Path;
 
-    use log::debug;
     use roc_load::LoadingProblem;
     use roc_region::all::{LineInfo, Region};
     use roc_solve_problem::TypeError;
@@ -110,11 +109,9 @@ pub(crate) mod diag {
                 .get_region()
                 .unwrap_or(Region::new(
                     roc_region::all::Position::new(0),
-                    roc_region::all::Position::new(10000000),
+                    roc_region::all::Position::new(10_000_000),
                 ))
                 .to_range(line_info);
-
-            debug!("range is {:?}", range);
 
             let msg = match self {
                 LoadingProblem::FileProblem { filename, error } => {
@@ -200,7 +197,6 @@ pub(crate) mod diag {
                 ))
                 .to_range(fmt.line_info);
 
-            debug!("range is {:?}", range);
             let report = roc_reporting::report::can_problem(
                 fmt.alloc,
                 fmt.line_info,

--- a/crates/repl_eval/src/gen.rs
+++ b/crates/repl_eval/src/gen.rs
@@ -80,7 +80,7 @@ pub fn compile_to_mono<'a, 'i, I: Iterator<Item = &'i str>>(
                 (m.can_problems, m.type_problems)
             );
         }
-        Err(LoadMonomorphizedError::LoadingProblem(LoadingProblem::FormattedReport(report,_))) => {
+        Err(LoadMonomorphizedError::LoadingProblem(LoadingProblem::FormattedReport(report, _))) => {
             return (
                 None,
                 Problems {

--- a/crates/repl_eval/src/gen.rs
+++ b/crates/repl_eval/src/gen.rs
@@ -80,7 +80,7 @@ pub fn compile_to_mono<'a, 'i, I: Iterator<Item = &'i str>>(
                 (m.can_problems, m.type_problems)
             );
         }
-        Err(LoadMonomorphizedError::LoadingProblem(LoadingProblem::FormattedReport(report))) => {
+        Err(LoadMonomorphizedError::LoadingProblem(LoadingProblem::FormattedReport(report,_))) => {
             return (
                 None,
                 Problems {

--- a/crates/valgrind_tests/src/lib.rs
+++ b/crates/valgrind_tests/src/lib.rs
@@ -164,7 +164,7 @@ fn valgrind_test_linux(source: &str) {
             run_with_valgrind(&binary_path);
         }
         Err(roc_build::program::BuildFileError::LoadingProblem(
-            roc_load::LoadingProblem::FormattedReport(report),
+            roc_load::LoadingProblem::FormattedReport(report, _),
         )) => {
             eprintln!("{report}");
             panic!("");


### PR DESCRIPTION
This now makes the language server use the correct range when encountering a file load error.

So now parse errors won't all appear at the very top!