### PR TITLE
Dbg and Expect Fixes and Improvements

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -873,17 +873,22 @@ pub fn build(
 
     let opt_level = opt_level_from_flags(matches);
 
-    // Note: This allows using `--dev` with `--optimize`.
-    // This means frontend optimizations and dev backend.
-    let code_gen_backend = if let OptLevel::Development = opt_level {
+    let should_run_expects = matches!(opt_level, OptLevel::Development | OptLevel::Normal) &&
+        // TODO: once expect is decoupled from roc launching the executable, remove this part of the conditional.
+        matches!(
+            config,
+            BuildConfig::BuildAndRun | BuildConfig::BuildAndRunIfNoErrors
+        );
+
+    let code_gen_backend = if matches!(opt_level, OptLevel::Development) {
         if matches!(target.architecture(), Architecture::Wasm32) {
             CodeGenBackend::Wasm
         } else {
             CodeGenBackend::Assembly(AssemblyBackendMode::Binary)
         }
     } else {
-        let backend_mode = if let BuildConfig::BuildAndRunIfNoErrors = config {
-            LlvmBackendMode::BinaryDev
+        let backend_mode = if should_run_expects {
+            LlvmBackendMode::BinaryWithExpect
         } else {
             LlvmBackendMode::Binary
         };
@@ -1023,7 +1028,7 @@ pub fn build(
                     roc_run(
                         &arena,
                         path,
-                        opt_level,
+                        should_run_expects,
                         target,
                         args,
                         bytes,
@@ -1066,7 +1071,7 @@ pub fn build(
                     roc_run(
                         &arena,
                         path,
-                        opt_level,
+                        should_run_expects,
                         target,
                         args,
                         bytes,
@@ -1085,7 +1090,7 @@ pub fn build(
 fn roc_run<'a, I: IntoIterator<Item = &'a OsStr>>(
     arena: &Bump,
     script_path: &Path,
-    opt_level: OptLevel,
+    should_run_expects: bool,
     target: Target,
     args: I,
     binary_bytes: &[u8],
@@ -1127,7 +1132,7 @@ fn roc_run<'a, I: IntoIterator<Item = &'a OsStr>>(
         _ => roc_run_native(
             arena,
             script_path,
-            opt_level,
+            should_run_expects,
             args,
             binary_bytes,
             expect_metadata,
@@ -1195,7 +1200,7 @@ fn make_argv_envp<'a, I: IntoIterator<Item = S>, S: AsRef<OsStr>>(
 fn roc_run_native<I: IntoIterator<Item = S>, S: AsRef<OsStr>>(
     arena: &Bump,
     script_path: &Path,
-    opt_level: OptLevel,
+    should_run_expects: bool,
     args: I,
     binary_bytes: &[u8],
     expect_metadata: ExpectMetadata,
@@ -1217,11 +1222,10 @@ fn roc_run_native<I: IntoIterator<Item = S>, S: AsRef<OsStr>>(
         .chain([std::ptr::null()])
         .collect_in(arena);
 
-    match opt_level {
-        OptLevel::Development => roc_dev_native(arena, executable, argv, envp, expect_metadata),
-        OptLevel::Normal | OptLevel::Size | OptLevel::Optimize => unsafe {
-            roc_run_native_fast(executable, &argv, &envp);
-        },
+    if should_run_expects {
+        roc_dev_native(arena, executable, argv, envp, expect_metadata);
+    } else {
+        unsafe { roc_run_native_fast(executable, &argv, &envp) };
     }
 
     Ok(1)
@@ -1459,7 +1463,7 @@ fn roc_run_executable_file_path(binary_bytes: &[u8]) -> std::io::Result<Executab
 fn roc_run_native<I: IntoIterator<Item = S>, S: AsRef<OsStr>>(
     arena: &Bump, // This should be passed an owned value, not a reference, so we can usefully mem::forget it!
     script_path: &Path,
-    opt_level: OptLevel,
+    should_run_expects: bool,
     args: I,
     binary_bytes: &[u8],
     _expect_metadata: ExpectMetadata,
@@ -1484,14 +1488,11 @@ fn roc_run_native<I: IntoIterator<Item = S>, S: AsRef<OsStr>>(
             .chain([std::ptr::null()])
             .collect_in(arena);
 
-        match opt_level {
-            OptLevel::Development => {
-                // roc_run_native_debug(executable, &argv, &envp, expectations, interns)
-                internal_error!("running `expect`s does not currently work on windows")
-            }
-            OptLevel::Normal | OptLevel::Size | OptLevel::Optimize => {
-                roc_run_native_fast(executable, &argv, &envp);
-            }
+        if should_run_expects {
+            // roc_run_native_debug(executable, &argv, &envp, expectations, interns)
+            internal_error!("running `expect`s does not currently work on windows");
+        } else {
+            roc_run_native_fast(executable, &argv, &envp);
         }
     }
 

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -875,16 +875,17 @@ pub fn build(
 
     // Note: This allows using `--dev` with `--optimize`.
     // This means frontend optimizations and dev backend.
-    let code_gen_backend = if matches.get_flag(FLAG_DEV) {
+    let code_gen_backend = if let OptLevel::Development = opt_level {
         if matches!(target.architecture(), Architecture::Wasm32) {
             CodeGenBackend::Wasm
         } else {
             CodeGenBackend::Assembly(AssemblyBackendMode::Binary)
         }
     } else {
-        let backend_mode = match opt_level {
-            OptLevel::Development => LlvmBackendMode::BinaryDev,
-            OptLevel::Normal | OptLevel::Size | OptLevel::Optimize => LlvmBackendMode::Binary,
+        let backend_mode = if let BuildConfig::BuildAndRunIfNoErrors = config {
+            LlvmBackendMode::BinaryDev
+        } else {
+            LlvmBackendMode::Binary
         };
 
         CodeGenBackend::Llvm(backend_mode)

--- a/crates/compiler/gen_llvm/src/llvm/build.rs
+++ b/crates/compiler/gen_llvm/src/llvm/build.rs
@@ -3559,12 +3559,10 @@ pub(crate) fn build_exp_stmt<'a, 'ctx>(
             variable: _,
             remainder,
         } => {
-            if env.mode.runs_expects() {
-                let location = build_string_literal(env, source_location);
-                let source = build_string_literal(env, source);
-                let message = scope.load_symbol(symbol);
-                env.call_dbg(env, location, source, message);
-            }
+            let location = build_string_literal(env, source_location);
+            let source = build_string_literal(env, source);
+            let message = scope.load_symbol(symbol);
+            env.call_dbg(env, location, source, message);
 
             build_exp_stmt(
                 env,

--- a/crates/compiler/gen_llvm/src/llvm/expect.rs
+++ b/crates/compiler/gen_llvm/src/llvm/expect.rs
@@ -29,7 +29,7 @@ pub(crate) struct SharedMemoryPointer<'ctx>(PointerValue<'ctx>);
 
 impl<'ctx> SharedMemoryPointer<'ctx> {
     pub(crate) fn get<'a, 'env>(env: &Env<'a, 'ctx, 'env>) -> Self {
-        let start_function = if let LlvmBackendMode::BinaryDev = env.mode {
+        let start_function = if let LlvmBackendMode::BinaryWithExpect = env.mode {
             bitcode::UTILS_EXPECT_FAILED_START_SHARED_FILE
         } else {
             bitcode::UTILS_EXPECT_FAILED_START_SHARED_BUFFER

--- a/crates/compiler/test_gen/src/helpers/llvm.rs
+++ b/crates/compiler/test_gen/src/helpers/llvm.rs
@@ -257,7 +257,7 @@ fn create_llvm_module<'a>(
     };
     let (main_fn_name, main_fn) = match config.mode {
         LlvmBackendMode::Binary => unreachable!(),
-        LlvmBackendMode::BinaryDev => unreachable!(),
+        LlvmBackendMode::BinaryWithExpect => unreachable!(),
         LlvmBackendMode::BinaryGlue => unreachable!(),
         LlvmBackendMode::CliTest => unreachable!(),
         LlvmBackendMode::WasmGenTest => roc_gen_llvm::llvm::build::build_wasm_test_wrapper(


### PR DESCRIPTION
Decouple `--dev` from generating `dbg` or `expect`. Instead
1. Always generate `dbg` outputs no matter the mode.
2. Generate `expect` in all development and normal runs via `roc run main.roc` or `roc main.roc`.

Note: expect conditionals are always generated, we should really remove expect nodes during Can to avoid generating their conditionals. When we do, we can remove `LlvmBackendMode::BinaryWithExpect`. I was going to do that in this pr, but it felt complex to wire the state I want into Can. Also, want to land this to fix `dbg` on main.