### PR TITLE
fix how benchmark script is loaded on main

### DIFF
--- a/ci/benchmarks/prep_folder.sh
+++ b/ci/benchmarks/prep_folder.sh
@@ -11,12 +11,12 @@ BENCH_SUFFIX=$1
 
 cargo criterion -V
 cd crates/cli && cargo criterion --no-run && cd ../..
-mkdir -p bench-folder/crates/cli/tests/benchmarks
-mkdir -p bench-folder/crates/compiler/builtins/bitcode/src
+mkdir -p bench-folder/crates/cli/tests/benchmarks/
 mkdir -p bench-folder/target/release/deps
+mkdir -p bench-folder/target/release/lib
 cp "crates/cli/tests/benchmarks/"*".roc" bench-folder/crates/cli/tests/benchmarks/
 cp -r crates/cli/tests/benchmarks/platform bench-folder/crates/cli/tests/benchmarks/
-cp crates/compiler/builtins/bitcode/src/str.zig bench-folder/crates/compiler/builtins/bitcode/src
+cp "crates/compiler/builtins/bitcode/src/*.zig" bench-folder/target/release/lib/
 cp target/release/roc bench-folder/target/release
 
 # copy the most recent time bench to bench-folder

--- a/crates/compiler/build/src/link.rs
+++ b/crates/compiler/build/src/link.rs
@@ -81,13 +81,13 @@ pub fn get_relative_path(sub_path: &Path) -> Option<PathBuf> {
 }
 
 fn find_zig_glue_path() -> PathBuf {
-    // First try using the repo path relative to the executable location.
-    let path = get_relative_path(Path::new("crates/compiler/builtins/bitcode/src/glue.zig"));
+    // First try using a lib path relative to the executable.
+    let path = get_relative_path(Path::new("lib/glue.zig"));
     if let Some(path) = path {
         return path;
     }
-    // Fallback on a lib path relative to the executable location.
-    let path = get_relative_path(Path::new("lib/glue.zig"));
+    // Fallback on the repo path relative to the executable location.
+    let path = get_relative_path(Path::new("crates/compiler/builtins/bitcode/src/glue.zig"));
     if let Some(path) = path {
         return path;
     }


### PR DESCRIPTION
To get #6921 working, we need the benchmark script to pull glue.zig correctly on main. As such, we need to load it into a lib dir such that it is found in the correct relative path. This hopefully will get the benchmarking working on the other PR.

Also, switch over to `lib` dir first cause that is what is seen in the wide.