### PR TITLE
Fix language server crash on UTF-8 completion

### DIFF
--- a/crates/language_server/src/analysis/analysed_doc.rs
+++ b/crates/language_server/src/analysis/analysed_doc.rs
@@ -83,6 +83,11 @@ impl DocInfo {
             .rev()
             .take_while(|&a| is_roc_identifier_char(&(*a as char)))
             .count();
+
+        if symbol_len == 0 {
+            return String::from("");
+        }
+
         let symbol = &self.source[offset - symbol_len..offset];
 
         String::from(symbol)

--- a/crates/language_server/src/server.rs
+++ b/crates/language_server/src/server.rs
@@ -620,4 +620,28 @@ mod tests {
         "#]]
         .assert_debug_eq(&actual);
     }
+
+    #[tokio::test]
+    async fn test_completion_on_utf8() {
+        let actual = completion_test(
+            indoc! {r"
+            main =
+              "},
+            "ç",
+            Position::new(4, 3),
+        )
+        .await;
+
+        expect![[r#"
+            Some(
+                [
+                    (
+                        "main",
+                        None,
+                    ),
+                ],
+            )
+        "#]]
+        .assert_debug_eq(&actual);
+    }
 }


### PR DESCRIPTION
Previously, the language server would crash on the following program when requesting completions with the cursor after `ç`:

```roc
module []

a = ç
```