### PR TITLE
Highlight current :target entry name (#7299)

### DIFF
--- a/crates/docs/src/static/styles.css
+++ b/crates/docs/src/static/styles.css
@@ -85,6 +85,10 @@ table tr td {
   border-left: 2px solid var(--violet);
 }
 
+.entry-name:target {
+  background-color: var(--violet-bg);
+}
+
 .entry-name a {
   visibility: hidden;
   display: inline-block;


### PR DESCRIPTION
See #7299.

![1](https://github.com/user-attachments/assets/58b8fc42-bed6-4ac3-9807-a450f6c0afeb)

I did not add the flash discussed in the issue, so perhaps this PR will not close the issue.

@Anton-4  I like the Roc website because it is plain and simple. I think adding flashes, animations etc. will not improve the user experience. In my opinion the current highlighting does the job.

However, if you insist on adding some transition effects, I can probably do it in another PR, when I find another moment of free time. 

-------------------------

Designs that I also considered and found them inferior (but I'm open to discussion):

![2](https://github.com/user-attachments/assets/e52ea607-2e14-4fff-9361-8d6ce9a17cbf)

![3](https://github.com/user-attachments/assets/ac1c2ffb-715c-4d31-84c5-9ce71fdb9c35)



