### PR TITLE
#7407: Register package dependent packages

### DIFF
--- a/crates/compiler/load_internal/src/file.rs
+++ b/crates/compiler/load_internal/src/file.rs
@@ -1342,7 +1342,31 @@ fn handle_root_type<'a>(
 
                 Ok((header_output, RootType::Module { main_path }))
             }
-            App { .. } | Package { .. } | Platform { .. } => Ok((header_output, RootType::Main)),
+            Package { .. } => {
+                let main_path = opt_main_path.or_else(|| find_main_roc_recursively(src_dir));
+
+                let cache_dir = roc_cache_dir.as_persistent_path();
+
+                if let (Some(main_path), Some(cache_dir)) = (main_path.clone(), cache_dir) {
+                    let mut messages = Vec::with_capacity(4);
+                    messages.push(header_output.msg);
+                    load_packages_from_main(
+                        arena,
+                        src_dir.clone(),
+                        main_path,
+                        &mut messages,
+                        Arc::clone(&arc_modules),
+                        Arc::clone(&ident_ids_by_module),
+                        Arc::clone(&arc_shorthands),
+                        cache_dir,
+                    )?;
+
+                    header_output.msg = Msg::Many(messages);
+                }
+
+                Ok((header_output, RootType::Main))
+            }
+            App { .. } | Platform { .. } => Ok((header_output, RootType::Main)),
         }
     } else {
         Ok((header_output, RootType::Main))

--- a/crates/compiler/load_internal/tests/test_load.rs
+++ b/crates/compiler/load_internal/tests/test_load.rs
@@ -2131,3 +2131,51 @@ fn roc_file_no_extension() {
 
     assert_eq!(err, expected, "\n{}", err);
 }
+
+#[test]
+fn roc_package_depends_on_other_package() {
+    let modules = vec![
+        (
+            "main",
+            indoc!(
+                r#"
+            package [Module] { other: "other/main.roc" }
+            "#
+            ),
+        ),
+        (
+            "Module.roc",
+            indoc!(
+                r#"
+            module [foo]
+
+            import other.OtherMod
+
+            foo = OtherMod.say "hello"
+            "#
+            ),
+        ),
+        (
+            "other/main.roc",
+            indoc!(
+                r#"
+            package [OtherMod] {}
+            "#
+            ),
+        ),
+        (
+            "other/OtherMod.roc",
+            indoc!(
+                r#"
+            module [say]
+
+            say = \msg -> "$(msg), world!"
+            "#
+            ),
+        ),
+    ];
+
+    let result = multiple_modules("roc_package_depends_on_other_package", modules);
+
+    assert!(result.is_ok());
+}


### PR DESCRIPTION
A package that depended on another package would hang forever because nothing registered the other package as a module to load like it would with an App.  This fixes that.

Closes #7407