### PR TITLE
Add Task.combine

### DIFF
--- a/crates/compiler/builtins/roc/Task.roc
+++ b/crates/compiler/builtins/roc/Task.roc
@@ -191,20 +191,6 @@ fromResult = \res ->
 ## Apply a task to another task applicatively.
 ##
 ## DEPRECATED: Modern record builders use [combine].
-##
-## This can be used with [ok] to build a [Task] that returns a record.
-##
-## The following example returns a Record with two fields, `apples` and
-## `oranges`, each of which is a `List Str`. If it fails it returns the tag
-## `NoFruitAvailable`.
-##
-## ```
-## getFruitBasket : Task { apples : List Str, oranges : List Str } [NoFruitAvailable]
-## getFruitBasket = Task.ok {
-##     apples: <- getFruit Apples |> Task.batch,
-##     oranges: <- getFruit Oranges |> Task.batch,
-## }
-## ```
 batch : Task a c -> (Task (a -> b) c -> Task b c)
 batch = \current ->
     \next ->

--- a/crates/compiler/builtins/roc/Task.roc
+++ b/crates/compiler/builtins/roc/Task.roc
@@ -11,6 +11,7 @@ module [
     loop,
     fromResult,
     batch,
+    combine,
     sequence,
     forEach,
     result,
@@ -187,8 +188,11 @@ fromResult : Result a b -> Task a b
 fromResult = \res ->
     @Task \{} -> res
 
-## Apply a task to another task applicatively. This can be used with
-## [ok] to build a [Task] that returns a record.
+## Apply a task to another task applicatively.
+##
+## DEPRECATED: Modern record builders use [combine].
+##
+## This can be used with [ok] to build a [Task] that returns a record.
 ##
 ## The following example returns a Record with two fields, `apples` and
 ## `oranges`, each of which is a `List Str`. If it fails it returns the tag
@@ -206,6 +210,26 @@ batch = \current ->
     \next ->
         await next \f ->
             map current f
+
+## Combine the values of two tasks with a custom combining function.
+##
+## This is primarily used with record builders.
+##
+## ```
+## { a, b, c } =
+##     { Task.combine <-
+##         a: Task.ok 123,
+##         b: File.read "file.txt",
+##         c: Http.get "http://api.com/",
+##     }!
+## ```
+combine : Task a err, Task b err, (a, b -> c) -> Task c err
+combine = \@Task leftTask, @Task rightTask, combiner ->
+    @Task \{} ->
+        left = try leftTask {}
+        right = try rightTask {}
+
+        Ok (combiner left right)
 
 ## Apply each task in a list sequentially, and return a list of the resulting values.
 ## Each task will be awaited before beginning the next task.

--- a/crates/compiler/module/src/symbol.rs
+++ b/crates/compiler/module/src/symbol.rs
@@ -1730,9 +1730,10 @@ define_builtins! {
         9 TASK_MAP_ERR: "mapErr"
         10 TASK_FROM_RESULT: "fromResult"
         11 TASK_BATCH: "batch"
-        12 TASK_SEQUENCE: "sequence"
-        13 TASK_FOR_EACH: "forEach"
-        14 TASK_RESULT: "result"
+        12 TASK_COMBINE: "combine"
+        13 TASK_SEQUENCE: "sequence"
+        14 TASK_FOR_EACH: "forEach"
+        15 TASK_RESULT: "result"
     }
 
     num_modules: 16 // Keep this count up to date by hand! (TODO: see the mut_map! macro for how we could determine this count correctly in the macro)


### PR DESCRIPTION
Add `Task.combine` to facilitate using record builders with Tasks while they're still part of Roc.

Also, put a message by the top of the `Task.batch` function that `Task.combine` is what should now be used for record builders.