### PR TITLE
avoid writing to readonly refcounts

### DIFF
--- a/crates/roc_std/src/lib.rs
+++ b/crates/roc_std/src/lib.rs
@@ -582,6 +582,9 @@ impl Hash for U128 {
     }
 }
 
+pub const ROC_REFCOUNT_CONSTANT: usize = 0;
+pub const ROC_REFCOUNT_ONE: usize = isize::MIN as usize;
+
 /// All Roc types that are refcounted must implement this trait.
 ///
 /// For aggregate types, this must recurse down the structure.

--- a/crates/roc_std/src/roc_list.rs
+++ b/crates/roc_std/src/roc_list.rs
@@ -14,7 +14,9 @@ use core::{
 };
 use std::{cmp::max, ops::Range};
 
-use crate::{roc_alloc, roc_dealloc, roc_realloc, storage::Storage, RocRefcounted};
+use crate::{
+    roc_alloc, roc_dealloc, roc_realloc, storage::Storage, RocRefcounted, ROC_REFCOUNT_CONSTANT,
+};
 
 #[cfg(feature = "serde")]
 use core::marker::PhantomData;
@@ -680,7 +682,7 @@ where
         unsafe {
             let value = std::ptr::read(ptr);
             // Only safe to write to the pointer if it is not constant (0)
-            if value != 0 {
+            if value != ROC_REFCOUNT_CONSTANT {
                 std::ptr::write(ptr, (value as isize + 1) as usize);
             }
         }

--- a/crates/roc_std/src/roc_list.rs
+++ b/crates/roc_std/src/roc_list.rs
@@ -174,7 +174,10 @@ where
     /// should be considered for marking read-only.
     pub unsafe fn set_readonly(&mut self) {
         if let Some((_, storage)) = self.elements_and_storage() {
-            storage.set(Storage::Readonly);
+            // Only safe to write to the pointer if it is not constant (0)
+            if !matches!(storage.get(), Storage::Readonly) {
+                storage.set(Storage::Readonly);
+            }
         }
     }
 
@@ -676,7 +679,10 @@ where
         let ptr = self.ptr_to_refcount();
         unsafe {
             let value = std::ptr::read(ptr);
-            std::ptr::write(ptr, Ord::max(0, ((value as isize) + 1) as usize));
+            // Only safe to write to the pointer if it is not constant (0)
+            if value != 0 {
+                std::ptr::write(ptr, (value as isize + 1) as usize);
+            }
         }
     }
 

--- a/crates/roc_std/src/roc_str.rs
+++ b/crates/roc_std/src/roc_str.rs
@@ -943,14 +943,20 @@ impl BigString {
         assert_ne!(self.capacity(), 0);
 
         let ptr = self.ptr_to_refcount();
-        unsafe { std::ptr::write(ptr, 0) }
+        // Only safe to write to the pointer if it is not constant (0)
+        if unsafe { std::ptr::read(ptr) } != 0 {
+            unsafe { std::ptr::write(ptr, 0) }
+        }
     }
 
     fn inc(&mut self) {
         let ptr = self.ptr_to_refcount();
         unsafe {
             let value = std::ptr::read(ptr);
-            std::ptr::write(ptr, Ord::max(0, ((value as isize) + 1) as usize));
+            // Only safe to write to the pointer if it is not constant (0)
+            if value != 0 {
+                std::ptr::write(ptr, (value as isize + 1) as usize);
+            }
         }
     }
 

--- a/crates/roc_std/src/roc_str.rs
+++ b/crates/roc_std/src/roc_str.rs
@@ -21,7 +21,7 @@ use core::{
 use std::ffi::{CStr, CString};
 use std::{ops::Range, ptr::NonNull};
 
-use crate::{roc_realloc, RocList, RocRefcounted};
+use crate::{roc_realloc, RocList, RocRefcounted, ROC_REFCOUNT_CONSTANT};
 
 #[repr(transparent)]
 pub struct RocStr(RocStrInner);
@@ -944,8 +944,8 @@ impl BigString {
 
         let ptr = self.ptr_to_refcount();
         // Only safe to write to the pointer if it is not constant (0)
-        if unsafe { std::ptr::read(ptr) } != 0 {
-            unsafe { std::ptr::write(ptr, 0) }
+        if unsafe { std::ptr::read(ptr) } != ROC_REFCOUNT_CONSTANT {
+            unsafe { std::ptr::write(ptr, ROC_REFCOUNT_CONSTANT) }
         }
     }
 
@@ -954,7 +954,7 @@ impl BigString {
         unsafe {
             let value = std::ptr::read(ptr);
             // Only safe to write to the pointer if it is not constant (0)
-            if value != 0 {
+            if value != ROC_REFCOUNT_CONSTANT {
                 std::ptr::write(ptr, (value as isize + 1) as usize);
             }
         }


### PR DESCRIPTION
Found this bug when working on basic-cli. If we write a read only refcount to something that is already read only, we risk trying to write to the static section of the binary that is write protected. This will crash. Use a conditional to avoid the write.