### PR TITLE
linker: introduce SupportLevel to designate completeness

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -767,6 +767,29 @@ fn nearest_match<'a>(reference: &str, options: &'a [String]) -> Option<(&'a Stri
         .min_by(|(_, a), (_, b)| a.cmp(b))
 }
 
+pub fn default_linking_strategy(
+    matches: &ArgMatches,
+    link_type: LinkType,
+    target: Target,
+) -> LinkingStrategy {
+    let linker_support_level = roc_linker::support_level(link_type, target);
+    match matches.get_one::<String>(FLAG_LINKER).map(AsRef::as_ref) {
+        Some("legacy") => LinkingStrategy::Legacy,
+        Some("surgical") => match linker_support_level {
+            roc_linker::SupportLevel::Full => LinkingStrategy::Surgical,
+            roc_linker::SupportLevel::Wip => {
+                println!("Warning! Using an unfinished surgical linker for target {target}");
+                LinkingStrategy::Surgical
+            }
+            roc_linker::SupportLevel::None => LinkingStrategy::Legacy,
+        },
+        _ => match linker_support_level {
+            roc_linker::SupportLevel::Full => LinkingStrategy::Surgical,
+            _ => LinkingStrategy::Legacy,
+        },
+    }
+}
+
 pub fn build(
     matches: &ArgMatches,
     subcommands: &[String],
@@ -917,17 +940,8 @@ pub fn build(
 
     let linking_strategy = if wasm_dev_backend {
         LinkingStrategy::Additive
-    } else if matches.get_one::<String>(FLAG_LINKER).map(|s| s.as_str()) == Some("legacy") {
-        LinkingStrategy::Legacy
     } else {
-        match roc_linker::support_level(link_type, target) {
-            roc_linker::SupportLevel::Full => LinkingStrategy::Surgical,
-            roc_linker::SupportLevel::Wip => {
-                println!("Warning! Using an unfinished surgical linker for target {target}");
-                LinkingStrategy::Surgical
-            }
-            roc_linker::SupportLevel::None => LinkingStrategy::Legacy,
-        }
+        default_linking_strategy(matches, link_type, target)
     };
 
     // All hosts should be prebuilt, this flag keeps the rebuilding behvaiour

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,14 +1,14 @@
 //! The `roc` binary that brings together all functionality in the Roc toolset.
 use bumpalo::Bump;
-use roc_build::link::LinkType;
+use roc_build::link::{LinkType, LinkingStrategy};
 use roc_build::program::{check_file, CodeGenBackend};
 use roc_cli::{
     build_app, format_files, format_src, test, BuildConfig, FormatMode, CMD_BUILD, CMD_CHECK,
     CMD_DEV, CMD_DOCS, CMD_FORMAT, CMD_GLUE, CMD_PREPROCESS_HOST, CMD_REPL, CMD_RUN, CMD_TEST,
-    CMD_VERSION, DIRECTORY_OR_FILES, FLAG_CHECK, FLAG_DEV, FLAG_LIB, FLAG_MAIN, FLAG_MIGRATE,
-    FLAG_NO_COLOR, FLAG_NO_HEADER, FLAG_NO_LINK, FLAG_OUTPUT, FLAG_PP_DYLIB, FLAG_PP_HOST,
-    FLAG_PP_PLATFORM, FLAG_STDIN, FLAG_STDOUT, FLAG_TARGET, FLAG_TIME, GLUE_DIR, GLUE_SPEC,
-    ROC_FILE, VERSION,
+    CMD_VERSION, DIRECTORY_OR_FILES, FLAG_CHECK, FLAG_DEV, FLAG_LIB, FLAG_LINKER, FLAG_MAIN,
+    FLAG_MIGRATE, FLAG_NO_COLOR, FLAG_NO_HEADER, FLAG_NO_LINK, FLAG_OUTPUT, FLAG_PP_DYLIB,
+    FLAG_PP_HOST, FLAG_PP_PLATFORM, FLAG_STDIN, FLAG_STDOUT, FLAG_TARGET, FLAG_TIME, GLUE_DIR,
+    GLUE_SPEC, ROC_FILE, VERSION,
 };
 use roc_docs::generate_docs_html;
 use roc_error_macros::user_error;
@@ -113,8 +113,33 @@ fn main() -> io::Result<()> {
                 false => CodeGenBackend::Llvm(LlvmBackendMode::BinaryGlue),
             };
 
+            let link_type = LinkType::Dylib;
+            let linking_strategy =
+                if matches.get_one::<String>(FLAG_LINKER).map(|s| s.as_str()) == Some("legacy") {
+                    LinkingStrategy::Legacy
+                } else {
+                    let target = Triple::host().into();
+                    match roc_linker::support_level(link_type, target) {
+                        roc_linker::SupportLevel::Full => LinkingStrategy::Surgical,
+                        roc_linker::SupportLevel::Wip => {
+                            println!(
+                                "Warning! Using an unfinished surgical linker for target {target}"
+                            );
+                            LinkingStrategy::Surgical
+                        }
+                        roc_linker::SupportLevel::None => LinkingStrategy::Legacy,
+                    }
+                };
+
             if !output_path.exists() || output_path.is_dir() {
-                roc_glue::generate(input_path, output_path, spec_path, backend)
+                roc_glue::generate(
+                    input_path,
+                    output_path,
+                    spec_path,
+                    backend,
+                    link_type,
+                    linking_strategy,
+                )
             } else {
                 eprintln!("`roc glue` must be given a directory to output into, because the glue might generate multiple files.");
 

--- a/crates/compiler/build/src/link.rs
+++ b/crates/compiler/build/src/link.rs
@@ -1048,6 +1048,9 @@ fn link_macos(
             // slightly easier than unpacking compressed info from the __got section
             // and fixups load command.
             "-no_fixup_chains",
+            // Suppress all warnings, at least for now. Ideally, there are no warnings
+            // from the linker.
+            "-w",
         ])
         .args(input_paths)
         .args(extra_link_flags());

--- a/crates/glue/src/load.rs
+++ b/crates/glue/src/load.rs
@@ -40,6 +40,8 @@ pub fn generate(
     output_path: &Path,
     spec_path: &Path,
     backend: CodeGenBackend,
+    link_type: LinkType,
+    linking_strategy: LinkingStrategy,
 ) -> io::Result<i32> {
     let target = Triple::host().into();
     // TODO: Add verification around the paths. Make sure they have the correct file extension and what not.
@@ -68,13 +70,6 @@ pub fn generate(
             );
 
             let arena = ManuallyDrop::new(Bump::new());
-            let link_type = LinkType::Dylib;
-            let linking_strategy = if roc_linker::supported(link_type, target) {
-                LinkingStrategy::Surgical
-            } else {
-                LinkingStrategy::Legacy
-            };
-
             let tempdir_res = tempfile::tempdir();
 
             // we don't need a host for glue, we will generate a dylib

--- a/crates/linker/src/lib.rs
+++ b/crates/linker/src/lib.rs
@@ -28,18 +28,25 @@ pub enum LinkType {
     None = 2,
 }
 
-pub fn supported(link_type: LinkType, target: Target) -> bool {
+#[derive(Debug, PartialEq, Eq)]
+pub enum SupportLevel {
+    Full,
+    Wip,
+    None,
+}
+
+pub fn support_level(link_type: LinkType, target: Target) -> SupportLevel {
     if let LinkType::Executable = link_type {
         match target {
-            Target::LinuxX64 => true,
-            Target::WinX64 => true,
+            Target::LinuxX64 => SupportLevel::Full,
+            Target::WinX64 => SupportLevel::Full,
             // macho support is incomplete
-            Target::MacX64 => false,
-            Target::MacArm64 => true,
-            _ => false,
+            Target::MacX64 => SupportLevel::None,
+            Target::MacArm64 => SupportLevel::Wip,
+            _ => SupportLevel::None,
         }
     } else {
-        false
+        SupportLevel::None
     }
 }
 


### PR DESCRIPTION
If a linker is `SupportLevel::Full` it can safely be used as a substitute for the legacy linker. If on the other hand, it's `SupportLevel::None` then only legacy linker is a viable option. The third new option is `SupportLevel::Wip` which will enable surgical linker warning the user that it is a work-in-progress, your mileage may vary, a lot.

cc @bhansconnect 