### PR TITLE
if the user reserves a specific number of elements, trust them

### DIFF
--- a/crates/compiler/builtins/bitcode/src/str.zig
+++ b/crates/compiler/builtins/bitcode/src/str.zig
@@ -2057,7 +2057,7 @@ test "strTrim: null byte" {
     defer original_with_capacity.decref();
 
     try expectEqual(@as(usize, 1), original_with_capacity.len());
-    try expectEqual(@as(usize, 64), original_with_capacity.getCapacity());
+    try expectEqual(@as(usize, 41), original_with_capacity.getCapacity());
 
     const trimmed = strTrim(original.clone());
     defer trimmed.decref();

--- a/crates/compiler/builtins/bitcode/src/utils.zig
+++ b/crates/compiler/builtins/bitcode/src/utils.zig
@@ -469,15 +469,16 @@ pub inline fn calculateCapacity(
     requested_length: usize,
     element_width: usize,
 ) usize {
-    // TODO: there are two adjustments that would likely lead to better results for Roc.
-    // 1. Deal with the fact we allocate an extra u64 for refcount.
-    //    This may lead to allocating page size + 8 bytes.
-    //    That could mean allocating an entire page for 8 bytes of data which isn't great.
-    // 2. Deal with the fact that we can request more than 1 element at a time.
-    //    fbvector assumes just appending 1 element at a time when using this algorithm.
-    //    As such, they will generally grow in a way that should better match certain memory multiple.
-    //    This is also the normal case for roc, but we could also grow by a much larger amount.
-    //    We may want to round to multiples of 2 or something similar.
+    // TODO: Deal with the fact we allocate an extra u64 for refcount.
+    // This may lead to allocating page size + 8 bytes.
+    // That could mean allocating an entire page for 8 bytes of data which isn't great.
+
+    if (requested_length != old_capacity + 1) {
+        // The user is explicitly requesting n elements.
+        // Trust the user and just reserve that amount.
+        return requested_length;
+    }
+
     var new_capacity: usize = 0;
     if (element_width == 0) {
         return requested_length;


### PR DESCRIPTION
It is minorly debatable if this is the best behaviour, but if a user requests exactly `n` elements, we should trust that they only need `n` elements. This increases the chances of reallocating in-place instead of needing to copy all the data in the array. The only special case is requesting 1 more element. In the case of only requesting 1 element, we keep the old behaviour of growing in larger chunks. This behaviour now matches reserve and push_back in the folly library more fully. Though technically if you request reserving 1 in folly, it will only add 1 element of capacity. This doesn't work with current roc, cause we always reserve 1 before appending. I think this is fine though.

Some context from zulip: https://roc.zulipchat.com/#narrow/channel/302903-platform-development/topic/Should.20lists.20always.20have.20a.20minimum.20capacity.20of.2064.3F