### PR TITLE
Minor simplifications to typechecker

### DIFF
--- a/crates/compiler/can/src/constraint.rs
+++ b/crates/compiler/can/src/constraint.rs
@@ -619,23 +619,6 @@ impl Constraints {
         Constraint::FxCall(constraint_index)
     }
 
-    pub fn fx_pattern_suffix(
-        &mut self,
-        symbol: Symbol,
-        type_index: TypeOrVar,
-        region: Region,
-    ) -> Constraint {
-        let constraint = FxSuffixConstraint {
-            kind: FxSuffixKind::Pattern(symbol),
-            type_index,
-            region,
-        };
-
-        let constraint_index = index_push_new(&mut self.fx_suffix_constraints, constraint);
-
-        Constraint::FxSuffix(constraint_index)
-    }
-
     pub fn fx_record_field_unsuffixed(&mut self, variable: Variable, region: Region) -> Constraint {
         let type_index = Self::push_type_variable(variable);
         let constraint = FxSuffixConstraint {

--- a/crates/compiler/can/src/constraint.rs
+++ b/crates/compiler/can/src/constraint.rs
@@ -18,6 +18,7 @@ pub struct Constraints {
     pub constraints: Vec<Constraint>,
     pub type_slices: Vec<TypeOrVar>,
     pub variables: Vec<Variable>,
+    loc_variables: Vec<Loc<Variable>>,
     pub loc_symbols: Vec<(Symbol, Region)>,
     pub let_constraints: Vec<LetConstraint>,
     pub categories: Vec<Category>,
@@ -42,6 +43,7 @@ impl std::fmt::Debug for Constraints {
             .field("types", &"<types>")
             .field("type_slices", &self.type_slices)
             .field("variables", &self.variables)
+            .field("loc_variables", &self.loc_variables)
             .field("loc_symbols", &self.loc_symbols)
             .field("let_constraints", &self.let_constraints)
             .field("categories", &self.categories)
@@ -75,6 +77,7 @@ impl Constraints {
         let constraints = Vec::new();
         let type_slices = Vec::with_capacity(16);
         let variables = Vec::new();
+        let loc_variables = Vec::new();
         let loc_symbols = Vec::new();
         let let_constraints = Vec::new();
         let mut categories = Vec::with_capacity(16);
@@ -126,6 +129,7 @@ impl Constraints {
             constraints,
             type_slices,
             variables,
+            loc_variables,
             loc_symbols,
             let_constraints,
             categories,
@@ -377,6 +381,17 @@ impl Constraints {
         Slice::new(start as _, length as _)
     }
 
+    pub fn loc_variable_slice<I>(&mut self, it: I) -> Slice<Loc<Variable>>
+    where
+        I: IntoIterator<Item = Loc<Variable>>,
+    {
+        let start = self.loc_variables.len();
+        self.loc_variables.extend(it);
+        let length = self.loc_variables.len() - start;
+
+        Slice::new(start as _, length as _)
+    }
+
     fn def_types_slice<I>(&mut self, it: I) -> DefTypes
     where
         I: IntoIterator<Item = (Symbol, Loc<TypeOrVar>)>,
@@ -473,8 +488,8 @@ impl Constraints {
         generalizable: Generalizable,
     ) -> Constraint
     where
-        I1: IntoIterator<Item = Variable>,
-        I2: IntoIterator<Item = Variable>,
+        I1: IntoIterator<Item = Loc<Variable>>,
+        I2: IntoIterator<Item = Loc<Variable>>,
         I3: IntoIterator<Item = (Symbol, Loc<TypeOrVar>)>,
         I3::IntoIter: ExactSizeIterator,
     {
@@ -485,8 +500,8 @@ impl Constraints {
         self.constraints.push(ret_constraint);
 
         let let_constraint = LetConstraint {
-            rigid_vars: self.variable_slice(rigid_vars),
-            flex_vars: self.variable_slice(flex_vars),
+            rigid_vars: self.loc_variable_slice(rigid_vars),
+            flex_vars: self.variable_slice(flex_vars.into_iter().map(|v| v.value)),
             def_types: self.def_types_slice(def_types),
             defs_and_ret_constraint,
             generalizable,
@@ -534,7 +549,7 @@ impl Constraints {
         self.constraints.push(module_constraint);
 
         let let_contraint = LetConstraint {
-            rigid_vars: self.variable_slice(rigid_vars),
+            rigid_vars: self.loc_variable_slice(rigid_vars.into_iter().map(Loc::at_zero)),
             flex_vars: self.variable_slice(flex_vars),
             def_types: self.def_types_slice(def_types),
             defs_and_ret_constraint,
@@ -809,6 +824,14 @@ impl std::ops::Index<PExpectedTypeIndex> for Constraints {
     }
 }
 
+impl std::ops::Index<Slice<Loc<Variable>>> for Constraints {
+    type Output = [Loc<Variable>];
+
+    fn index(&self, slice: Slice<Loc<Variable>>) -> &Self::Output {
+        &self.loc_variables[slice.indices()]
+    }
+}
+
 #[derive(Clone, Copy, Debug)]
 pub struct Eq(
     pub TypeOrVar,
@@ -914,7 +937,7 @@ pub struct Generalizable(pub bool);
 
 #[derive(Debug, Clone)]
 pub struct LetConstraint {
-    pub rigid_vars: Slice<Variable>,
+    pub rigid_vars: Slice<Loc<Variable>>,
     pub flex_vars: Slice<Variable>,
     pub def_types: DefTypes,
     pub defs_and_ret_constraint: Index<(Constraint, Constraint)>,

--- a/crates/compiler/constrain/src/expr.rs
+++ b/crates/compiler/constrain/src/expr.rs
@@ -3808,9 +3808,9 @@ fn instantiate_rigids(
         // wildcards are always freshly introduced in this annotation
         new_rigid_variables.extend(introduced_vars.wildcards.iter().copied());
 
-        // lambda set vars are always freshly introduced in this annotation
-        new_rigid_variables.extend(introduced_vars.lambda_sets.iter().map(|&v| Loc::at_zero(v)));
+        let has_explicit_inference_variables = !introduced_vars.inferred.is_empty();
 
+        new_infer_variables.extend(introduced_vars.inferred.iter().copied());
         // ext-infer vars are always freshly introduced in this annotation
         new_infer_variables.extend(
             introduced_vars
@@ -3818,9 +3818,8 @@ fn instantiate_rigids(
                 .iter()
                 .map(|&v| Loc::at_zero(v)),
         );
-
-        let has_explicit_inference_variables = !introduced_vars.inferred.is_empty();
-        new_infer_variables.extend(introduced_vars.inferred.iter().copied());
+        // lambda set vars are always freshly introduced in this annotation
+        new_infer_variables.extend(introduced_vars.lambda_sets.iter().map(|&v| Loc::at_zero(v)));
 
         // Instantiate rigid variables
         if !rigid_substitution.is_empty() {
@@ -3900,12 +3899,8 @@ fn instantiate_rigids_simple(
     // wildcards are always freshly introduced in this annotation
     new_rigid_variables.extend(introduced_vars.wildcards.iter().copied());
 
-    // lambda set vars are always freshly introduced in this annotation
-    new_rigid_variables.extend(introduced_vars.lambda_sets.iter().map(|&v| Loc::at_zero(v)));
-
     let has_explicit_inference_variables = !introduced_vars.inferred.is_empty();
     let mut new_infer_variables: Vec<Loc<Variable>> = introduced_vars.inferred.clone();
-
     // ext-infer vars are always freshly introduced in this annotation
     new_infer_variables.extend(
         introduced_vars
@@ -3913,6 +3908,8 @@ fn instantiate_rigids_simple(
             .iter()
             .map(|&v| Loc::at_zero(v)),
     );
+    // lambda set vars are always freshly introduced in this annotation
+    new_infer_variables.extend(introduced_vars.lambda_sets.iter().map(|&v| Loc::at_zero(v)));
 
     // Instantiate rigid variables
     if !rigid_substitution.is_empty() {

--- a/crates/compiler/constrain/src/module.rs
+++ b/crates/compiler/constrain/src/module.rs
@@ -83,7 +83,7 @@ fn constrain_params(
 
     let cons = constraints.let_constraint(
         [],
-        state.vars,
+        state.vars.into_iter().map(Loc::at_zero),
         state.headers,
         pattern_constraints,
         constraint,
@@ -199,8 +199,12 @@ pub fn frontload_ability_constraints(
 
             def_pattern_state.vars.push(signature_var);
 
-            let rigid_variables = vars.rigid_vars.iter().chain(vars.able_vars.iter()).copied();
-            let infer_variables = vars.flex_vars.iter().copied();
+            let rigid_variables = (vars.rigid_vars.iter())
+                .chain(vars.able_vars.iter())
+                .copied()
+                .map(Loc::at_zero);
+
+            let infer_variables = vars.flex_vars.iter().copied().map(Loc::at_zero);
 
             let signature_expectation =
                 constraints.push_expected_type(Expected::NoExpectation(signature_index));

--- a/crates/compiler/load/tests/test_reporting.rs
+++ b/crates/compiler/load/tests/test_reporting.rs
@@ -15666,7 +15666,7 @@ All branches in an `if` must have the same type!
         @r###"
     ── MISSING EXCLAMATION in /code/proj/Main.roc ──────────────────────────────────
 
-    This is an effectful function, but its name does not indicate so:
+    This function is effectful, but its name does not indicate so:
 
     10│  forEach! = \l, f ->
                         ^
@@ -15703,7 +15703,7 @@ All branches in an `if` must have the same type!
         @r###"
     ── UNNECESSARY EXCLAMATION in /code/proj/Main.roc ──────────────────────────────
 
-    This is a pure function, but its name suggests otherwise:
+    This function is pure, but its name suggests otherwise:
 
     12│  mapOk = \result, fn! ->
                           ^^^

--- a/crates/compiler/solve/src/deep_copy.rs
+++ b/crates/compiler/solve/src/deep_copy.rs
@@ -329,10 +329,6 @@ fn deep_copy_var_help(
                 }
 
                 let new_ambient_function_var = work!(ambient_function_var);
-                debug_assert_ne!(
-                    ambient_function_var, new_ambient_function_var,
-                    "lambda set cloned but its ambient function wasn't?"
-                );
 
                 subs.set_content_unchecked(
                     lambda_set_var,

--- a/crates/compiler/solve/src/solve.rs
+++ b/crates/compiler/solve/src/solve.rs
@@ -211,18 +211,7 @@ enum Work<'a> {
         constraint: &'a Constraint,
     },
     CheckForInfiniteTypes(LocalDefVarsVec<(Symbol, Loc<Variable>)>),
-    /// The ret_con part of a let constraint that does NOT introduces rigid and/or flex variables
-    LetConNoVariables {
-        scope: &'a Scope,
-        rank: Rank,
-        let_con: &'a LetConstraint,
-
-        /// The variables used to store imported types in the Subs.
-        /// The `Contents` are copied from the source module, but to
-        /// mimic `type_to_var`, we must add these variables to `Pools`
-        /// at the correct rank
-        pool_variables: &'a [Variable],
-    },
+    CheckSuffixFx(LocalDefVarsVec<(Symbol, Loc<Variable>)>),
     /// The ret_con part of a let constraint that introduces rigid and/or flex variables
     ///
     /// These introduced variables must be generalized, hence this variant
@@ -285,56 +274,6 @@ fn solve(
                 for (symbol, loc_var) in def_vars.iter() {
                     check_for_infinite_type(env, problems, *symbol, *loc_var);
                 }
-
-                continue;
-            }
-            Work::LetConNoVariables {
-                scope,
-                rank,
-                let_con,
-                pool_variables,
-            } => {
-                // NOTE be extremely careful with shadowing here
-                let offset = let_con.defs_and_ret_constraint.index();
-                let ret_constraint = &env.constraints.constraints[offset + 1];
-
-                // Add a variable for each def to new_vars_by_env.
-                let local_def_vars = LocalDefVarsVec::from_def_types(
-                    env,
-                    rank,
-                    problems,
-                    abilities_store,
-                    obligation_cache,
-                    &mut can_types,
-                    aliases,
-                    let_con.def_types,
-                );
-
-                env.pools.get_mut(rank).extend(pool_variables);
-
-                let mut new_scope = scope.clone();
-                for (symbol, loc_var) in local_def_vars.iter() {
-                    check_ability_specialization(
-                        env,
-                        rank,
-                        abilities_store,
-                        obligation_cache,
-                        awaiting_specializations,
-                        problems,
-                        *symbol,
-                        *loc_var,
-                    );
-
-                    new_scope.insert_symbol_var_if_vacant(*symbol, loc_var.value);
-                }
-
-                stack.push(Work::Constraint {
-                    scope: env.arena.alloc(new_scope),
-                    rank,
-                    constraint: ret_constraint,
-                });
-                // Check for infinite types first
-                stack.push(Work::CheckForInfiniteTypes(local_def_vars));
 
                 continue;
             }
@@ -456,14 +395,8 @@ fn solve(
 
                     new_scope.insert_symbol_var_if_vacant(*symbol, loc_var.value);
 
-                    solve_suffix_fx(
-                        env,
-                        problems,
-                        host_exposed_symbols,
-                        FxSuffixKind::Let(*symbol),
-                        loc_var.value,
-                        &loc_var.region,
-                    );
+                    // At the time of introduction, promote explicitly-effectful symbols.
+                    promote_effectful_symbol(env, FxSuffixKind::Let(*symbol), loc_var.value);
                 }
 
                 // Note that this vars_by_symbol is the one returned by the
@@ -473,18 +406,40 @@ fn solve(
                     mark: final_mark,
                 };
 
-                // Now solve the body, using the new vars_by_symbol which includes
-                // the assignments' name-to-variable mappings.
-                stack.push(Work::Constraint {
-                    scope: env.arena.alloc(new_scope),
-                    rank,
-                    constraint: ret_constraint,
-                });
-                // Check for infinite types first
-                stack.push(Work::CheckForInfiniteTypes(local_def_vars));
+                let next_work = [
+                    // Check for infinite types first
+                    Work::CheckForInfiniteTypes(local_def_vars.clone()),
+                    // Now solve the body, using the new vars_by_symbol which includes
+                    // the assignments' name-to-variable mappings.
+                    Work::Constraint {
+                        scope: env.arena.alloc(new_scope),
+                        rank,
+                        constraint: ret_constraint,
+                    },
+                    // Finally, check the suffix fx, after we have solved all types.
+                    Work::CheckSuffixFx(local_def_vars),
+                ];
+
+                for work in next_work.into_iter().rev() {
+                    stack.push(work);
+                }
 
                 state = state_for_ret_con;
 
+                continue;
+            }
+
+            Work::CheckSuffixFx(local_def_vars) => {
+                for (symbol, loc_var) in local_def_vars.iter() {
+                    solve_suffix_fx(
+                        env,
+                        problems,
+                        host_exposed_symbols,
+                        FxSuffixKind::Let(*symbol),
+                        loc_var.value,
+                        &loc_var.region,
+                    );
+                }
                 continue;
             }
         };
@@ -1004,100 +959,64 @@ fn solve(
 
                 let offset = let_con.defs_and_ret_constraint.index();
                 let defs_constraint = &env.constraints.constraints[offset];
-                let ret_constraint = &env.constraints.constraints[offset + 1];
 
                 let flex_vars = &env.constraints.variables[let_con.flex_vars.indices()];
                 let rigid_vars = &env.constraints[let_con.rigid_vars];
 
                 let pool_variables = &env.constraints.variables[pool_slice.indices()];
 
-                if matches!(&ret_constraint, True) && rigid_vars.is_empty() {
-                    debug_assert!(pool_variables.is_empty());
-
-                    env.introduce(rank, flex_vars);
-
-                    // If the return expression is guaranteed to solve,
-                    // solve the assignments themselves and move on.
-                    stack.push(Work::Constraint {
-                        scope,
-                        rank,
-                        constraint: defs_constraint,
-                    });
-
-                    state
-                } else if rigid_vars.is_empty() && let_con.flex_vars.is_empty() {
-                    // items are popped from the stack in reverse order. That means that we'll
-                    // first solve then defs_constraint, and then (eventually) the ret_constraint.
-                    //
-                    // Note that the LetConSimple gets the current env and rank,
-                    // and not the env/rank from after solving the defs_constraint
-                    stack.push(Work::LetConNoVariables {
-                        scope,
-                        rank,
-                        let_con,
-                        pool_variables,
-                    });
-                    stack.push(Work::Constraint {
-                        scope,
-                        rank,
-                        constraint: defs_constraint,
-                    });
-
-                    state
+                // If the let-binding is generalizable, work at the next rank (which will be
+                // the rank at which introduced variables will become generalized, if they end up
+                // staying there); otherwise, stay at the current level.
+                let binding_rank = if let_con.generalizable.0 {
+                    rank.next()
                 } else {
-                    // If the let-binding is generalizable, work at the next rank (which will be
-                    // the rank at which introduced variables will become generalized, if they end up
-                    // staying there); otherwise, stay at the current level.
-                    let binding_rank = if let_con.generalizable.0 {
-                        rank.next()
-                    } else {
-                        rank
-                    };
+                    rank
+                };
 
-                    // determine the next pool
-                    if binding_rank.into_usize() < env.pools.len() {
-                        // Nothing to do, we already accounted for the next rank, no need to
-                        // adjust the pools
-                    } else {
-                        // we should be off by one at this point
-                        debug_assert_eq!(binding_rank.into_usize(), 1 + env.pools.len());
-                        env.pools.extend_to(binding_rank.into_usize());
-                    }
-
-                    let pool: &mut Vec<Variable> = env.pools.get_mut(binding_rank);
-
-                    // Introduce the variables of this binding, and extend the pool at our binding
-                    // rank.
-                    for &var in rigid_vars.iter().map(|v| &v.value).chain(flex_vars.iter()) {
-                        env.subs.set_rank(var, binding_rank);
-                    }
-                    pool.reserve(rigid_vars.len() + flex_vars.len());
-                    pool.extend(rigid_vars.iter().map(|v| &v.value));
-                    pool.extend(flex_vars.iter());
-
-                    // Now, run our binding constraint, generalize, then solve the rest of the
-                    // program.
-                    //
-                    // Items are popped from the stack in reverse order. That means that we'll
-                    // first solve the defs_constraint, and then (eventually) the ret_constraint.
-                    //
-                    // NB: LetCon gets the current scope's env and rank, not the env/rank from after solving the defs_constraint.
-                    // That's because the defs constraints will be solved in next_rank if it is eligible for generalization.
-                    // The LetCon will then generalize variables that are at a higher rank than the rank of the current scope.
-                    stack.push(Work::LetConIntroducesVariables {
-                        scope,
-                        rank,
-                        let_con,
-                        pool_variables,
-                    });
-                    stack.push(Work::Constraint {
-                        scope,
-                        rank: binding_rank,
-                        constraint: defs_constraint,
-                    });
-
-                    state
+                // determine the next pool
+                if binding_rank.into_usize() < env.pools.len() {
+                    // Nothing to do, we already accounted for the next rank, no need to
+                    // adjust the pools
+                } else {
+                    // we should be off by one at this point
+                    debug_assert_eq!(binding_rank.into_usize(), 1 + env.pools.len());
+                    env.pools.extend_to(binding_rank.into_usize());
                 }
+
+                let pool: &mut Vec<Variable> = env.pools.get_mut(binding_rank);
+
+                // Introduce the variables of this binding, and extend the pool at our binding
+                // rank.
+                for &var in rigid_vars.iter().map(|v| &v.value).chain(flex_vars.iter()) {
+                    env.subs.set_rank(var, binding_rank);
+                }
+                pool.reserve(rigid_vars.len() + flex_vars.len());
+                pool.extend(rigid_vars.iter().map(|v| &v.value));
+                pool.extend(flex_vars.iter());
+
+                // Now, run our binding constraint, generalize, then solve the rest of the
+                // program.
+                //
+                // Items are popped from the stack in reverse order. That means that we'll
+                // first solve the defs_constraint, and then (eventually) the ret_constraint.
+                //
+                // NB: LetCon gets the current scope's env and rank, not the env/rank from after solving the defs_constraint.
+                // That's because the defs constraints will be solved in next_rank if it is eligible for generalization.
+                // The LetCon will then generalize variables that are at a higher rank than the rank of the current scope.
+                stack.push(Work::LetConIntroducesVariables {
+                    scope,
+                    rank,
+                    let_con,
+                    pool_variables,
+                });
+                stack.push(Work::Constraint {
+                    scope,
+                    rank: binding_rank,
+                    constraint: defs_constraint,
+                });
+
+                state
             }
             IsOpenType(type_index) => {
                 let actual = either_type_index_to_var(
@@ -1773,6 +1692,20 @@ fn solve_suffix_fx(
     }
 }
 
+fn promote_effectful_symbol(env: &mut InferenceEnv<'_>, kind: FxSuffixKind, variable: Variable) {
+    if kind.suffix() != IdentSuffix::Bang {
+        return;
+    }
+    if !matches!(
+        env.subs.get_content_without_compacting(variable),
+        Content::FlexVar(_)
+    ) {
+        return;
+    }
+    env.subs
+        .set_content(variable, Content::Structure(FlatType::EffectfulFunc));
+}
+
 fn chase_alias_content(subs: &Subs, mut var: Variable) -> (Variable, &Content) {
     loop {
         match subs.get_content_without_compacting(var) {
@@ -2147,7 +2080,7 @@ fn check_ability_specialization(
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 enum LocalDefVarsVec<T> {
     Stack(arrayvec::ArrayVec<T, 32>),
     Heap(Vec<T>),

--- a/crates/compiler/uitest/tests/recursion/calls_result_in_unique_specializations.txt
+++ b/crates/compiler/uitest/tests/recursion/calls_result_in_unique_specializations.txt
@@ -7,7 +7,7 @@ main =
 #   ^^^ a, Bool -[[foo(1)]]-> Str
 
     bar = \_ -> foo {} Bool.true
-#               ^^^ {}, Bool -[[]]-> Str
+#               ^^^ {}, Bool -[[foo(1)]]-> Str
 
     foo "" Bool.false
 #   ^^^{inst} Str, Bool -[[foo(1)]]-> Str

--- a/crates/compiler/uitest/tests/recursion/constrain_recursive_annotation_independently_issue_5256.txt
+++ b/crates/compiler/uitest/tests/recursion/constrain_recursive_annotation_independently_issue_5256.txt
@@ -5,8 +5,8 @@ main =
 
     map : { f1: (I64 -> I64) } -> List I64
     map = \{ f1 } -> List.concat [f1 1] (map { f1 })
-#                                        ^^^ { f1 : I64 -[[]]-> I64 } -[[map(2)]]-> List I64
-#   ^^^ { f1 : I64 -[[]]-> I64 } -[[map(2)]]-> List I64
+#                                        ^^^ { f1 : I64 -[[f(1)]]-> I64 } -[[map(2)]]-> List I64
+#   ^^^ { f1 : I64 -[[f(1)]]-> I64 } -[[map(2)]]-> List I64
 
 
     map { f1: f }


### PR DESCRIPTION
Landing some simplifications ahead of a change to make named type variables where things are known to be a concrete type illegal.

See individual commits for details.