### PR TITLE
linker/macho: fix load_align_constraint to correct page size values

### DIFF
--- a/crates/linker/src/lib.rs
+++ b/crates/linker/src/lib.rs
@@ -325,6 +325,7 @@ pub fn preprocess_host(
 
         (_, OperatingSystem::Mac) => {
             crate::macho::preprocess_macho_le(
+                target.architecture(),
                 host_exe_path,
                 metadata_path,
                 preprocessed_path,

--- a/crates/linker/src/macho.rs
+++ b/crates/linker/src/macho.rs
@@ -547,9 +547,6 @@ pub(crate) fn preprocess_macho_le(
         }
     };
 
-    // TODO this is correct on modern Macs (they align to the page size)
-    // but maybe someone can override the alignment somehow? Maybe in the
-    // future this could change? Is there some way to make this more future-proof?
     md.load_align_constraint = page_size(arch);
 
     let out_mmap = gen_macho_le(


### PR DESCRIPTION
These are dependent on the CPU architecture and are 4KB for x86_64, and 16KB for aarch64.