### PR TITLE
Mark :target entry using border

### DIFF
--- a/crates/docs/src/static/styles.css
+++ b/crates/docs/src/static/styles.css
@@ -90,7 +90,7 @@ table tr td {
 }
 
 .entry-name:target {
-  background-color: var(--violet-bg);
+  border: 4px solid var(--violet);
 }
 
 .entry-name a {


### PR DESCRIPTION
Commit a3762f60ad1dbac3e40faa3db8f104bbd92d38d9 marked the current (:target) entry using background color. But then 11e736f3e8993ee39a7733bcb99c79c04a8857e5 set the background color for all entries. Thus we need another way to highlight the entry pointed at by the URL fragment.

See https://github.com/roc-lang/roc/pull/7377#issuecomment-2565529772.

Closes #7299 (see https://github.com/roc-lang/roc/issues/7299#issuecomment-2567111453).

Screenshots:

![screen1](https://github.com/user-attachments/assets/02ba679f-ac41-455e-9e06-522669b4202f)

![screen2](https://github.com/user-attachments/assets/a9856602-7d87-41cd-92f2-036445260104)
