### PR TITLE
New flag `roc docs --root-dir`

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -89,6 +89,7 @@ pub const FLAG_PP_HOST: &str = "host";
 pub const FLAG_PP_PLATFORM: &str = "platform";
 pub const FLAG_PP_DYLIB: &str = "lib";
 pub const FLAG_MIGRATE: &str = "migrate";
+pub const FLAG_DOCS_ROOT: &str = "root-dir";
 
 pub const VERSION: &str = env!("ROC_VERSION");
 const DEFAULT_GENERATED_DOCS_DIR: &str = "generated-docs";
@@ -183,6 +184,12 @@ pub fn build_app() -> Command {
         .value_parser(value_parser!(OsString))
         .num_args(0..)
         .allow_hyphen_values(true);
+
+    let flag_docs_root_dir = Arg::new(FLAG_DOCS_ROOT)
+        .long(FLAG_DOCS_ROOT)
+        .help("Set a root directory path to be used as a prefix for URL links in the generated documentation files.")
+        .value_parser(value_parser!(Option<String>))
+        .required(false);
 
     let build_target_values_parser =
         PossibleValuesParser::new(Target::iter().map(Into::<&'static str>::into));
@@ -405,6 +412,7 @@ pub fn build_app() -> Command {
                     .required(false)
                     .default_value(DEFAULT_ROC_FILENAME),
                 )
+                .arg(flag_docs_root_dir)
         )
         .subcommand(Command::new(CMD_GLUE)
             .about("Generate glue code between a platform's Roc API and its host language")

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -5,10 +5,10 @@ use roc_build::program::{check_file, CodeGenBackend};
 use roc_cli::{
     build_app, default_linking_strategy, format_files, format_src, test, BuildConfig, FormatMode,
     CMD_BUILD, CMD_CHECK, CMD_DEV, CMD_DOCS, CMD_FORMAT, CMD_GLUE, CMD_PREPROCESS_HOST, CMD_REPL,
-    CMD_RUN, CMD_TEST, CMD_VERSION, DIRECTORY_OR_FILES, FLAG_CHECK, FLAG_DEV, FLAG_LIB, FLAG_MAIN,
-    FLAG_MIGRATE, FLAG_NO_COLOR, FLAG_NO_HEADER, FLAG_NO_LINK, FLAG_OUTPUT, FLAG_PP_DYLIB,
-    FLAG_PP_HOST, FLAG_PP_PLATFORM, FLAG_STDIN, FLAG_STDOUT, FLAG_TARGET, FLAG_TIME, FLAG_VERBOSE,
-    GLUE_DIR, GLUE_SPEC, ROC_FILE, VERSION,
+    CMD_RUN, CMD_TEST, CMD_VERSION, DIRECTORY_OR_FILES, FLAG_CHECK, FLAG_DEV, FLAG_DOCS_ROOT,
+    FLAG_LIB, FLAG_MAIN, FLAG_MIGRATE, FLAG_NO_COLOR, FLAG_NO_HEADER, FLAG_NO_LINK, FLAG_OUTPUT,
+    FLAG_PP_DYLIB, FLAG_PP_HOST, FLAG_PP_PLATFORM, FLAG_STDIN, FLAG_STDOUT, FLAG_TARGET, FLAG_TIME,
+    FLAG_VERBOSE, GLUE_DIR, GLUE_SPEC, ROC_FILE, VERSION,
 };
 use roc_docs::generate_docs_html;
 use roc_error_macros::user_error;
@@ -324,7 +324,25 @@ fn main() -> io::Result<()> {
             let root_path = matches.get_one::<PathBuf>(ROC_FILE).unwrap();
             let out_dir = matches.get_one::<OsString>(FLAG_OUTPUT).unwrap();
 
-            generate_docs_html(root_path.to_owned(), out_dir.as_ref());
+            let maybe_root_dir: Option<String> = {
+                if let Ok(root_dir) = std::env::var("ROC_DOCS_URL_ROOT") {
+                    // if the env var is set, it should override the flag for now
+                    // TODO -- confirm we no longer need this and remove
+                    // once docs are migrated to individual repositories and not roc website
+                    Some(root_dir)
+                } else {
+                    matches
+                        .get_one::<Option<String>>(FLAG_DOCS_ROOT)
+                        .unwrap()
+                        .clone()
+                }
+            };
+
+            generate_docs_html(
+                root_path.to_owned(),
+                out_dir.as_ref(),
+                maybe_root_dir.clone(),
+            );
 
             Ok(0)
         }

--- a/crates/docs_cli/src/main.rs
+++ b/crates/docs_cli/src/main.rs
@@ -19,10 +19,10 @@ fn main() -> io::Result<()> {
         )
         .get_matches();
 
-    // Populate roc_files
     generate_docs_html(
         matches.get_one::<PathBuf>(ROC_FILE).unwrap().to_owned(),
         &PathBuf::from("./generated-docs"),
+        std::env::var("ROC_DOCS_URL_ROOT").ok(),
     );
 
     Ok(())


### PR DESCRIPTION
The functionality was piped through as a new flag from the existing `ROC_DOCS_URL_ROOT` env var. 

If the old env var is present it will override the flag. This will prevent breaking the nightly scripts, until docs can be migrated from the roc website to GH pages websites.