### PR TITLE
Remove basic-cli docs gen from compiler

### DIFF
--- a/www/build.sh
+++ b/www/build.sh
@@ -26,7 +26,7 @@ rm -rf examples-main/
 unzip -o -q examples-main.zip
 cp -R examples-main/examples/ content/examples/
 
-# relace links in content/examples/index.md to work on the WIP site
+# replace links in content/examples/index.md to work on the WIP site
 perl -pi -e 's|\]\(/|\]\(/examples/|g' content/examples/index.md
 
 # clean up examples artifacts
@@ -143,45 +143,3 @@ echo "END Roc Exercism Exercises" >> prompt.md
 rm -rf exercism
 
 mv prompt.md www/build/
-
-
-echo 'Generating CLI example platform docs...'
-# Change ROC_DOCS_ROOT_DIR=builtins so that links will be generated relative to
-# "/packages/basic-cli/" rather than "/builtins/"
-export ROC_DOCS_URL_ROOT=/packages/basic-cli
-
-rm -rf ./downloaded-basic-cli
-
-git clone --depth 1 https://github.com/roc-lang/basic-cli.git downloaded-basic-cli
-
-cargo run --bin roc-docs downloaded-basic-cli/platform/main.roc
-
-rm -rf ./downloaded-basic-cli
-
-BASIC_CLI_PACKAGE_DIR="www/build/packages/basic-cli"
-mkdir -p $BASIC_CLI_PACKAGE_DIR
-mv generated-docs/* $BASIC_CLI_PACKAGE_DIR # move all the folders to build/packages/basic-cli
-
-# set up docs for older basic-cli versions
-# we need a github token
-if [ -v GITHUB_TOKEN_READ_ONLY ]; then
-
-  curl -v -H "Authorization: $GITHUB_TOKEN_READ_ONLY" -fL -o basic_cli_releases.json "https://api.github.com/repos/roc-lang/basic-cli/releases"
-
-  DOCS_LINKS=$(cat basic_cli_releases.json | jq -r '.[] | .assets[] | select(.name=="docs.tar.gz") | .browser_download_url')
-
-  rm basic_cli_releases.json
-
-  VERSION_NUMBERS=$(echo "$DOCS_LINKS" | grep -oP '(?<=/download/)[^/]+(?=/docs.tar.gz)')
-
-  while read -r VERSION_NR; do
-      echo $VERSION_NR
-      BASIC_CLI_DIR=$BASIC_CLI_PACKAGE_DIR/$VERSION_NR
-      mkdir -p $BASIC_CLI_DIR
-      curl -fL --output $BASIC_CLI_DIR/docs.tar.gz https://github.com/roc-lang/basic-cli/releases/download/$VERSION_NR/docs.tar.gz
-      tar -xf $BASIC_CLI_DIR/docs.tar.gz -C $BASIC_CLI_DIR/
-      rm $BASIC_CLI_DIR/docs.tar.gz
-      mv $BASIC_CLI_DIR/generated-docs/* $BASIC_CLI_DIR
-      rm -rf $BASIC_CLI_DIR/generated-docs
-  done <<< "$VERSION_NUMBERS"
-fi

--- a/www/content/docs.md
+++ b/www/content/docs.md
@@ -2,7 +2,7 @@
 
 - [builtins](/builtins) - docs for modules built into the language—`Str`, `Num`, etc.
 - [basic-webserver](https://roc-lang.github.io/basic-webserver/) - a platform for making Web servers ([source code](https://github.com/roc-lang/basic-webserver))
-- [basic-cli](/packages/basic-cli/0.17.0) - a platform for making command-line interfaces ([source code](https://github.com/roc-lang/basic-cli))
+- [basic-cli](https://roc-lang.github.io/basic-cli/) - a platform for making command-line interfaces ([source code](https://github.com/roc-lang/basic-cli))
 - [plans](/plans) - current plans for future changes to the language
 
 In the future, a language reference will be on this page too.


### PR DESCRIPTION
Now that we are building the docs for `basic-cli` and hosting them in their own repo, we can stop building them in this repo. The 2 PRs to enable this in `basic-cli`:

[add 0.17.0 and 0.18.0 static docs](https://github.com/roc-lang/basic-cli/pull/307) [MERGED]
[add docs from latest commit](https://github.com/roc-lang/basic-cli/pull/306) [AWAITING APPROVAL]

This change will unblock merging of [changing all builtins to snake_case](https://github.com/roc-lang/roc/pull/7463)