### PR TITLE
with_ascii_lowercased zig builtin

### DIFF
--- a/crates/compiler/builtins/bitcode/src/main.zig
+++ b/crates/compiler/builtins/bitcode/src/main.zig
@@ -211,6 +211,7 @@ comptime {
     exportStrFn(str.withCapacityC, "with_capacity");
     exportStrFn(str.strAllocationPtr, "allocation_ptr");
     exportStrFn(str.strReleaseExcessCapacity, "release_excess_capacity");
+    exportStrFn(str.strWithAsciiLowercased, "with_ascii_lowercased");
 
     for (INTEGERS) |T| {
         str.exportFromInt(T, ROC_BUILTINS ++ "." ++ STR ++ ".from_int.");

--- a/crates/compiler/builtins/bitcode/src/str.zig
+++ b/crates/compiler/builtins/bitcode/src/str.zig
@@ -371,11 +371,12 @@ pub const RocStr = extern struct {
     }
 
     fn refcount(self: RocStr) usize {
-        if ((self.getCapacity() == 0 and !self.isSeamlessSlice()) or self.isSmallStr()) {
+        const is_seamless_slice = self.isSeamlessSlice();
+        if ((self.getCapacity() == 0 and !is_seamless_slice) or self.isSmallStr()) {
             return 1;
         }
 
-        const data_ptr = if (self.isSeamlessSlice())
+        const data_ptr = if (is_seamless_slice)
             self.getAllocationPtr()
         else
             self.bytes;

--- a/crates/compiler/builtins/roc/Str.roc
+++ b/crates/compiler/builtins/roc/Str.roc
@@ -1107,4 +1107,4 @@ drop_suffix = |haystack, suffix|
 ## To do a case-insensitive comparison of the ASCII characters in a string, use [`caseless_ascii_equals`](#caseless_ascii_equals).
 with_ascii_lowercased : Str -> Str
 
-expect Str.with_ascii_lowercased "cOFFÉ" == "XYZFÉ"
+expect Str.with_ascii_lowercased("cOFFÉ") == "coffÉ"

--- a/crates/compiler/builtins/roc/Str.roc
+++ b/crates/compiler/builtins/roc/Str.roc
@@ -369,6 +369,7 @@ module [
     contains,
     drop_prefix,
     drop_suffix,
+    with_ascii_lowercased,
 ]
 
 import Bool exposing [Bool]
@@ -1092,3 +1093,18 @@ drop_suffix = |haystack, suffix|
         substring_unsafe(haystack, start, len)
     else
         haystack
+
+## Returns a version of the string with all [ASCII characters](https://en.wikipedia.org/wiki/ASCII) lowercased. Non-ASCII characters are left unmodified. For example:
+##
+## ```roc
+## expect "CAFÉ".with_ascii_lowercased() == "cafÉ"
+## ```
+##
+## This function is useful for things like [command-line options](https://en.wikipedia.org/wiki/Command-line_interface#Command-line_option) and [environment variables](https://en.wikipedia.org/wiki/Environment_variablewhere you ## know in advance that you're dealing with a hardcoded string containing only ASCII characters. It has better performance than lowercasing operations which take Unicode into account.
+##
+## That said, strings received from user input can always contain non-ASCII Unicode characters, and lowercasing [Unicode](https://unicode.org) works differently in different languages. For example, the string `"I"lowercases to `"i"## ` in English and to `"ı"` (a [dotless i](https://en.wikipedia.org/wiki/Dotless_I)) in Turkish. These rules can also change in each [Unicode release](https://www.unicode.org/releases/), so we have separate [`unicode` package]## (https://github.com/roc-lang/unicode) for Unicode capitalization that can be upgraded independently from the language's builtins.
+##
+## To do a case-insensitive comparison of the ASCII characters in a string, use [`caseless_ascii_equals`](#caseless_ascii_equals).
+with_ascii_lowercased: Str -> Str
+
+expect Str.with_ascii_lowercased "cOFFÉ" == "XYZFÉ"

--- a/crates/compiler/builtins/roc/Str.roc
+++ b/crates/compiler/builtins/roc/Str.roc
@@ -1094,17 +1094,28 @@ drop_suffix = |haystack, suffix|
     else
         haystack
 
-## Returns a version of the string with all [ASCII characters](https://en.wikipedia.org/wiki/ASCII) lowercased. Non-ASCII characters are left unmodified. For example:
+## Returns a version of the string with all [ASCII characters](https://en.wikipedia.org/wiki/ASCII) lowercased.
+## Non-ASCII characters are left unmodified. For example:
 ##
 ## ```roc
 ## expect "CAFÉ".with_ascii_lowercased() == "cafÉ"
 ## ```
 ##
-## This function is useful for things like [command-line options](https://en.wikipedia.org/wiki/Command-line_interface#Command-line_option) and [environment variables](https://en.wikipedia.org/wiki/Environment_variablewhere you ## know in advance that you're dealing with a hardcoded string containing only ASCII characters. It has better performance than lowercasing operations which take Unicode into account.
+## This function is useful for things like [command-line options](https://en.wikipedia.org/wiki/Command-line_interface#Command-line_option)
+## and [environment variables](https://en.wikipedia.org/wiki/Environment_variable)
+## know in advance that you're dealing with a hardcoded string containing only ASCII characters.
+## It has better performance than lowercasing operations which take Unicode into account.
 ##
-## That said, strings received from user input can always contain non-ASCII Unicode characters, and lowercasing [Unicode](https://unicode.org) works differently in different languages. For example, the string `"I"lowercases to `"i"## ` in English and to `"ı"` (a [dotless i](https://en.wikipedia.org/wiki/Dotless_I)) in Turkish. These rules can also change in each [Unicode release](https://www.unicode.org/releases/), so we have separate [`unicode` package]## (https://github.com/roc-lang/unicode) for Unicode capitalization that can be upgraded independently from the language's builtins.
+## That said, strings received from user input can always contain
+## non-ASCII Unicode characters, and lowercasing [Unicode](https://unicode.org) works
+## differently in different languages. For example, the string `"I"` lowercases to `"i"`
+## in English and to `"ı"` (a [dotless i](https://en.wikipedia.org/wiki/Dotless_I))
+## in Turkish. These rules can also change in each [Unicode release](https://www.unicode.org/releases/),
+## so we have separate [`unicode` package](https://github.com/roc-lang/unicode)
+## for Unicode capitalization that can be upgraded independently from the language's builtins.
 ##
-## To do a case-insensitive comparison of the ASCII characters in a string, use [`caseless_ascii_equals`](#caseless_ascii_equals).
+## To do a case-insensitive comparison of the ASCII characters in a string,
+## use [`caseless_ascii_equals`](#caseless_ascii_equals).
 with_ascii_lowercased : Str -> Str
 
 expect Str.with_ascii_lowercased("cOFFÉ") == "coffÉ"

--- a/crates/compiler/builtins/roc/Str.roc
+++ b/crates/compiler/builtins/roc/Str.roc
@@ -1105,6 +1105,6 @@ drop_suffix = |haystack, suffix|
 ## That said, strings received from user input can always contain non-ASCII Unicode characters, and lowercasing [Unicode](https://unicode.org) works differently in different languages. For example, the string `"I"lowercases to `"i"## ` in English and to `"ı"` (a [dotless i](https://en.wikipedia.org/wiki/Dotless_I)) in Turkish. These rules can also change in each [Unicode release](https://www.unicode.org/releases/), so we have separate [`unicode` package]## (https://github.com/roc-lang/unicode) for Unicode capitalization that can be upgraded independently from the language's builtins.
 ##
 ## To do a case-insensitive comparison of the ASCII characters in a string, use [`caseless_ascii_equals`](#caseless_ascii_equals).
-with_ascii_lowercased: Str -> Str
+with_ascii_lowercased : Str -> Str
 
 expect Str.with_ascii_lowercased "cOFFÉ" == "XYZFÉ"

--- a/crates/compiler/builtins/src/bitcode.rs
+++ b/crates/compiler/builtins/src/bitcode.rs
@@ -358,6 +358,7 @@ pub const STR_CLONE_TO: &str = "roc_builtins.str.clone_to";
 pub const STR_WITH_CAPACITY: &str = "roc_builtins.str.with_capacity";
 pub const STR_ALLOCATION_PTR: &str = "roc_builtins.str.allocation_ptr";
 pub const STR_RELEASE_EXCESS_CAPACITY: &str = "roc_builtins.str.release_excess_capacity";
+pub const STR_WITH_ASCII_LOWERCASED: &str = "roc_builtins.str.with_ascii_lowercased";
 
 pub const LIST_MAP: &str = "roc_builtins.list.map";
 pub const LIST_MAP2: &str = "roc_builtins.list.map2";

--- a/crates/compiler/can/src/builtins.rs
+++ b/crates/compiler/can/src/builtins.rs
@@ -130,6 +130,7 @@ map_symbol_to_lowlevel_and_arity! {
     StrToNum; STR_TO_NUM; 1,
     StrWithCapacity; STR_WITH_CAPACITY; 1,
     StrReleaseExcessCapacity; STR_RELEASE_EXCESS_CAPACITY; 1,
+    StrWithAsciiLowercased; STR_WITH_ASCII_LOWERCASED; 1,
 
     ListLenUsize; LIST_LEN_USIZE; 1,
     ListLenU64; LIST_LEN_U64; 1,

--- a/crates/compiler/gen_dev/src/lib.rs
+++ b/crates/compiler/gen_dev/src/lib.rs
@@ -1712,6 +1712,13 @@ trait Backend<'a> {
                 arg_layouts,
                 ret_layout,
             ),
+            LowLevel::StrWithAsciiLowercased => self.build_fn_call(
+                sym,
+                bitcode::STR_WITH_ASCII_LOWERCASED.to_string(),
+                args,
+                arg_layouts,
+                ret_layout,
+            ),
             LowLevel::StrToNum => {
                 let number_layout = match self.interner().get_repr(*ret_layout) {
                     LayoutRepr::Struct(field_layouts) => field_layouts[0], // TODO: why is it sometimes a struct?

--- a/crates/compiler/gen_llvm/src/llvm/lowlevel.rs
+++ b/crates/compiler/gen_llvm/src/llvm/lowlevel.rs
@@ -593,6 +593,7 @@ pub(crate) fn run_low_level<'a, 'ctx>(
                 bitcode::STR_WITH_CAPACITY,
             )
         }
+
         ListLenU64 => {
             // List.len : List * -> U64
             arguments!(list);
@@ -633,6 +634,17 @@ pub(crate) fn run_low_level<'a, 'ctx>(
                 layout_ids,
                 list_len.into_int_value(),
                 list_element_layout!(layout_interner, result_layout),
+            )
+        }
+        StrWithAsciiLowercased => {
+            arguments!(string);
+
+            call_str_bitcode_fn(
+                env,
+                &[string],
+                &[],
+                BitcodeReturns::Str,
+                bitcode::STR_WITH_ASCII_LOWERCASED,
             )
         }
         ListConcat => {

--- a/crates/compiler/gen_wasm/src/low_level.rs
+++ b/crates/compiler/gen_wasm/src/low_level.rs
@@ -258,6 +258,9 @@ impl<'a> LowLevelCall<'a> {
                 self.load_args_and_call_zig(backend, bitcode::STR_SUBSTRING_UNSAFE)
             }
             StrWithCapacity => self.load_args_and_call_zig(backend, bitcode::STR_WITH_CAPACITY),
+            StrWithAsciiLowercased => {
+                self.load_args_and_call_zig(backend, bitcode::STR_WITH_ASCII_LOWERCASED)
+            }
 
             // List
             ListLenU64 => {

--- a/crates/compiler/module/src/low_level.rs
+++ b/crates/compiler/module/src/low_level.rs
@@ -26,6 +26,7 @@ pub enum LowLevel {
     StrReserve,
     StrWithCapacity,
     StrReleaseExcessCapacity,
+    StrWithAsciiLowercased,
     ListLenUsize,
     ListLenU64,
     ListWithCapacity,
@@ -265,6 +266,7 @@ map_symbol_to_lowlevel! {
     StrToNum <= STR_TO_NUM;
     StrWithCapacity <= STR_WITH_CAPACITY;
     StrReleaseExcessCapacity <= STR_RELEASE_EXCESS_CAPACITY;
+    StrWithAsciiLowercased <= STR_WITH_ASCII_LOWERCASED;
     ListLenU64 <= LIST_LEN_U64;
     ListLenUsize <= LIST_LEN_USIZE;
     ListGetCapacity <= LIST_CAPACITY;

--- a/crates/compiler/module/src/symbol.rs
+++ b/crates/compiler/module/src/symbol.rs
@@ -1420,6 +1420,7 @@ define_builtins! {
         48 STR_RELEASE_EXCESS_CAPACITY: "release_excess_capacity"
         49 STR_DROP_PREFIX: "drop_prefix"
         50 STR_DROP_SUFFIX: "drop_suffix"
+        51 STR_WITH_ASCII_LOWERCASED: "with_ascii_lowercased"
     }
     6 LIST: "List" => {
         0 LIST_LIST: "List" exposed_apply_type=true // the List.List type alias

--- a/crates/compiler/mono/src/drop_specialization.rs
+++ b/crates/compiler/mono/src/drop_specialization.rs
@@ -1549,6 +1549,7 @@ fn low_level_no_rc(lowlevel: &LowLevel) -> RC {
         ListPrepend => RC::Rc,
         StrJoinWith => RC::NoRc,
         ListSortWith => RC::Rc,
+        StrWithAsciiLowercased => RC::Rc,
 
         ListAppendUnsafe
         | ListReserve

--- a/crates/compiler/mono/src/inc_dec.rs
+++ b/crates/compiler/mono/src/inc_dec.rs
@@ -1258,6 +1258,7 @@ pub(crate) fn lowlevel_borrow_signature(op: LowLevel) -> &'static [Ownership] {
         StrReleaseExcessCapacity => &[OWNED],
         ListIncref => &[OWNED],
         ListDecref => &[OWNED],
+        StrWithAsciiLowercased => &[OWNED],
 
         Eq | NotEq => &[BORROWED, BORROWED],
 

--- a/crates/compiler/solve/tests/solve_expr.rs
+++ b/crates/compiler/solve/tests/solve_expr.rs
@@ -3827,6 +3827,18 @@ mod solve_expr {
     }
 
     #[test]
+    fn str_with_ascii_lowercased() {
+        infer_eq_without_problem(
+            indoc!(
+                r"
+                Str.with_ascii_lowercased
+                "
+            ),
+            "Str -> Str",
+        );
+    }
+
+    #[test]
     fn list_take_first() {
         infer_eq_without_problem(
             indoc!(

--- a/crates/compiler/test_gen/src/gen_str.rs
+++ b/crates/compiler/test_gen/src/gen_str.rs
@@ -2066,7 +2066,7 @@ fn str_drop_suffix() {
 fn with_ascii_lowercased() {
     assert_evals_to!(
         r#"
-        Str.with_ascii_lowercased "cOFFÉ"
+        Str.with_ascii_lowercased("cOFFÉ")
         "#,
         RocStr::from("coffÉ"),
         RocStr
@@ -2079,8 +2079,8 @@ fn with_ascii_lowercased_non_zero_refcount() {
     assert_evals_to!(
         r#"
         original = "cOFFÉ cOFFÉ cOFFÉ cOFFÉ cOFFÉ cOFFÉ cOFFÉ cOFFÉ cOFFÉ cOFFÉ cOFFÉ cOFFÉ"
-        res = Str.with_ascii_lowercased original
-        Str.drop_prefix res original
+        res = Str.with_ascii_lowercased(original)
+        Str.drop_prefix(res, original)
         "#,
         RocStr::from("coffÉ coffÉ coffÉ coffÉ coffÉ coffÉ coffÉ coffÉ coffÉ coffÉ coffÉ coffÉ"),
         RocStr

--- a/crates/compiler/test_gen/src/gen_str.rs
+++ b/crates/compiler/test_gen/src/gen_str.rs
@@ -2080,7 +2080,7 @@ fn with_ascii_lowercased_non_zero_refcount() {
         r#"
         original = "cOFFÉ cOFFÉ cOFFÉ cOFFÉ cOFFÉ cOFFÉ cOFFÉ cOFFÉ cOFFÉ cOFFÉ cOFFÉ cOFFÉ"
         res = Str.with_ascii_lowercased original
-        Str.dropPrefix res original
+        Str.drop_prefix res original
         "#,
         RocStr::from("coffÉ coffÉ coffÉ coffÉ coffÉ coffÉ coffÉ coffÉ coffÉ coffÉ coffÉ coffÉ"),
         RocStr

--- a/crates/compiler/test_gen/src/gen_str.rs
+++ b/crates/compiler/test_gen/src/gen_str.rs
@@ -2060,3 +2060,29 @@ fn str_drop_suffix() {
         RocStr
     );
 }
+
+#[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-dev", feature = "gen-wasm"))]
+fn with_ascii_lowercased() {
+    assert_evals_to!(
+        r#"
+        Str.with_ascii_lowercased "cOFFÉ"
+        "#,
+        RocStr::from("coffÉ"),
+        RocStr
+    );
+}
+
+#[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-dev", feature = "gen-wasm"))]
+fn with_ascii_lowercased_non_zero_refcount() {
+    assert_evals_to!(
+        r#"
+        original = "cOFFÉ cOFFÉ cOFFÉ cOFFÉ cOFFÉ cOFFÉ cOFFÉ cOFFÉ cOFFÉ cOFFÉ cOFFÉ cOFFÉ"
+        res = Str.with_ascii_lowercased original
+        Str.dropPrefix res original
+        "#,
+        RocStr::from("coffÉ coffÉ coffÉ coffÉ coffÉ coffÉ coffÉ coffÉ coffÉ coffÉ coffÉ coffÉ"),
+        RocStr
+    );
+}

--- a/crates/compiler/test_mono/generated/compose_recursive_lambda_set_productive_nullable_wrapped.txt
+++ b/crates/compiler/test_mono/generated/compose_recursive_lambda_set_productive_nullable_wrapped.txt
@@ -41,8 +41,8 @@ procedure Num.51 (#Attr.2, #Attr.3):
     ret Num.283;
 
 procedure Str.3 (#Attr.2, #Attr.3):
-    let Str.248 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
-    ret Str.248;
+    let Str.250 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
+    ret Str.250;
 
 procedure Test.1 (Test.5):
     ret Test.5;

--- a/crates/compiler/test_mono/generated/dbg_expr.txt
+++ b/crates/compiler/test_mono/generated/dbg_expr.txt
@@ -43,8 +43,8 @@ procedure Num.96 (#Attr.2):
     ret Num.284;
 
 procedure Str.3 (#Attr.2, #Attr.3):
-    let Str.246 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
-    ret Str.246;
+    let Str.248 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
+    ret Str.248;
 
 procedure Test.0 ():
     let Test.4 : I64 = 1i64;

--- a/crates/compiler/test_mono/generated/dbg_in_expect.txt
+++ b/crates/compiler/test_mono/generated/dbg_in_expect.txt
@@ -104,184 +104,184 @@ procedure Num.77 (#Attr.2, #Attr.3):
     ret Num.293;
 
 procedure Str.20 (#Attr.2):
-    let Str.314 : Str = lowlevel StrWithCapacity #Attr.2;
-    ret Str.314;
+    let Str.316 : Str = lowlevel StrWithCapacity #Attr.2;
+    ret Str.316;
 
 procedure Str.3 (#Attr.2, #Attr.3):
-    let Str.246 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
-    ret Str.246;
+    let Str.248 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
+    ret Str.248;
 
 procedure Str.35 (#Attr.2, #Attr.3):
-    let Str.304 : U8 = lowlevel StrGetUnsafe #Attr.2 #Attr.3;
-    ret Str.304;
+    let Str.306 : U8 = lowlevel StrGetUnsafe #Attr.2 #Attr.3;
+    ret Str.306;
 
 procedure Str.36 (#Attr.2):
-    let Str.266 : U64 = lowlevel StrCountUtf8Bytes #Attr.2;
-    ret Str.266;
+    let Str.268 : U64 = lowlevel StrCountUtf8Bytes #Attr.2;
+    ret Str.268;
 
 procedure Str.37 (#Attr.2, #Attr.3, #Attr.4):
-    let Str.264 : Str = lowlevel StrSubstringUnsafe #Attr.2 #Attr.3 #Attr.4;
-    ret Str.264;
+    let Str.266 : Str = lowlevel StrSubstringUnsafe #Attr.2 #Attr.3 #Attr.4;
+    ret Str.266;
 
-procedure Str.38 (Str.112, Str.113):
-    let Str.260 : [C , C U64] = CallByName Str.57 Str.112 Str.113;
-    let Str.273 : U8 = 1i64;
-    let Str.274 : U8 = GetTagId Str.260;
-    let Str.275 : Int1 = lowlevel Eq Str.273 Str.274;
-    if Str.275 then
-        let Str.114 : U64 = UnionAtIndex (Id 1) (Index 0) Str.260;
-        let Str.269 : U64 = CallByName Str.36 Str.112;
-        let Str.270 : U64 = CallByName Str.36 Str.113;
-        let Str.268 : U64 = CallByName Num.20 Str.269 Str.270;
-        let Str.115 : U64 = CallByName Num.20 Str.268 Str.114;
-        let Str.267 : U64 = 0i64;
-        inc Str.112;
-        let Str.116 : Str = CallByName Str.37 Str.112 Str.267 Str.114;
-        let Str.265 : U64 = CallByName Str.36 Str.113;
-        let Str.263 : U64 = CallByName Num.51 Str.114 Str.265;
-        let Str.117 : Str = CallByName Str.37 Str.112 Str.263 Str.115;
-        let Str.262 : {Str, Str} = Struct {Str.117, Str.116};
-        let Str.261 : [C {}, C {Str, Str}] = TagId(1) Str.262;
-        ret Str.261;
+procedure Str.38 (Str.113, Str.114):
+    let Str.262 : [C , C U64] = CallByName Str.58 Str.113 Str.114;
+    let Str.275 : U8 = 1i64;
+    let Str.276 : U8 = GetTagId Str.262;
+    let Str.277 : Int1 = lowlevel Eq Str.275 Str.276;
+    if Str.277 then
+        let Str.115 : U64 = UnionAtIndex (Id 1) (Index 0) Str.262;
+        let Str.271 : U64 = CallByName Str.36 Str.113;
+        let Str.272 : U64 = CallByName Str.36 Str.114;
+        let Str.270 : U64 = CallByName Num.20 Str.271 Str.272;
+        let Str.116 : U64 = CallByName Num.20 Str.270 Str.115;
+        let Str.269 : U64 = 0i64;
+        inc Str.113;
+        let Str.117 : Str = CallByName Str.37 Str.113 Str.269 Str.115;
+        let Str.267 : U64 = CallByName Str.36 Str.114;
+        let Str.265 : U64 = CallByName Num.51 Str.115 Str.267;
+        let Str.118 : Str = CallByName Str.37 Str.113 Str.265 Str.116;
+        let Str.264 : {Str, Str} = Struct {Str.118, Str.117};
+        let Str.263 : [C {}, C {Str, Str}] = TagId(1) Str.264;
+        ret Str.263;
     else
-        dec Str.112;
-        let Str.272 : {} = Struct {};
-        let Str.271 : [C {}, C {Str, Str}] = TagId(0) Str.272;
-        ret Str.271;
+        dec Str.113;
+        let Str.274 : {} = Struct {};
+        let Str.273 : [C {}, C {Str, Str}] = TagId(0) Str.274;
+        ret Str.273;
 
-procedure Str.45 (Str.91, Str.92, Str.93):
-    inc Str.91;
-    let Str.342 : [C {}, C {Str, Str}] = CallByName Str.38 Str.91 Str.92;
-    let Str.350 : U8 = 1i64;
-    let Str.351 : U8 = GetTagId Str.342;
-    let Str.352 : Int1 = lowlevel Eq Str.350 Str.351;
-    if Str.352 then
-        let Str.349 : {Str, Str} = UnionAtIndex (Id 1) (Index 0) Str.342;
-        let Str.95 : Str = StructAtIndex 0 Str.349;
-        let Str.94 : Str = StructAtIndex 1 Str.349;
-        let Str.347 : U64 = CallByName Str.36 Str.91;
-        dec Str.91;
-        let Str.346 : Str = CallByName Str.20 Str.347;
-        let Str.345 : Str = CallByName Str.3 Str.346 Str.94;
-        dec Str.94;
-        let Str.344 : Str = CallByName Str.3 Str.345 Str.93;
-        let Str.343 : Str = CallByName Str.56 Str.344 Str.95 Str.92 Str.93;
-        ret Str.343;
+procedure Str.45 (Str.92, Str.93, Str.94):
+    inc Str.92;
+    let Str.344 : [C {}, C {Str, Str}] = CallByName Str.38 Str.92 Str.93;
+    let Str.352 : U8 = 1i64;
+    let Str.353 : U8 = GetTagId Str.344;
+    let Str.354 : Int1 = lowlevel Eq Str.352 Str.353;
+    if Str.354 then
+        let Str.351 : {Str, Str} = UnionAtIndex (Id 1) (Index 0) Str.344;
+        let Str.96 : Str = StructAtIndex 0 Str.351;
+        let Str.95 : Str = StructAtIndex 1 Str.351;
+        let Str.349 : U64 = CallByName Str.36 Str.92;
+        dec Str.92;
+        let Str.348 : Str = CallByName Str.20 Str.349;
+        let Str.347 : Str = CallByName Str.3 Str.348 Str.95;
+        dec Str.95;
+        let Str.346 : Str = CallByName Str.3 Str.347 Str.94;
+        let Str.345 : Str = CallByName Str.57 Str.346 Str.96 Str.93 Str.94;
+        ret Str.345;
     else
-        dec Str.342;
-        ret Str.91;
+        dec Str.344;
+        ret Str.92;
 
-procedure Str.56 (#Derived_gen.0, #Derived_gen.1, #Derived_gen.2, #Derived_gen.3):
-    joinpoint Str.250 Str.96 Str.97 Str.98 Str.99:
-        inc Str.97;
-        let Str.251 : [C {}, C {Str, Str}] = CallByName Str.38 Str.97 Str.98;
-        let Str.257 : U8 = 1i64;
-        let Str.258 : U8 = GetTagId Str.251;
-        let Str.259 : Int1 = lowlevel Eq Str.257 Str.258;
-        if Str.259 then
-            dec Str.97;
-            let Str.256 : {Str, Str} = UnionAtIndex (Id 1) (Index 0) Str.251;
-            let Str.101 : Str = StructAtIndex 0 Str.256;
-            let Str.100 : Str = StructAtIndex 1 Str.256;
-            let Str.254 : Str = CallByName Str.3 Str.96 Str.100;
-            dec Str.100;
-            let Str.253 : Str = CallByName Str.3 Str.254 Str.99;
-            jump Str.250 Str.253 Str.101 Str.98 Str.99;
-        else
+procedure Str.57 (#Derived_gen.0, #Derived_gen.1, #Derived_gen.2, #Derived_gen.3):
+    joinpoint Str.252 Str.97 Str.98 Str.99 Str.100:
+        inc Str.98;
+        let Str.253 : [C {}, C {Str, Str}] = CallByName Str.38 Str.98 Str.99;
+        let Str.259 : U8 = 1i64;
+        let Str.260 : U8 = GetTagId Str.253;
+        let Str.261 : Int1 = lowlevel Eq Str.259 Str.260;
+        if Str.261 then
             dec Str.98;
-            dec Str.251;
+            let Str.258 : {Str, Str} = UnionAtIndex (Id 1) (Index 0) Str.253;
+            let Str.102 : Str = StructAtIndex 0 Str.258;
+            let Str.101 : Str = StructAtIndex 1 Str.258;
+            let Str.256 : Str = CallByName Str.3 Str.97 Str.101;
+            dec Str.101;
+            let Str.255 : Str = CallByName Str.3 Str.256 Str.100;
+            jump Str.252 Str.255 Str.102 Str.99 Str.100;
+        else
+            dec Str.100;
             dec Str.99;
-            let Str.255 : Str = CallByName Str.3 Str.96 Str.97;
-            dec Str.97;
-            ret Str.255;
+            dec Str.253;
+            let Str.257 : Str = CallByName Str.3 Str.97 Str.98;
+            dec Str.98;
+            ret Str.257;
     in
     inc #Derived_gen.3;
     inc #Derived_gen.2;
-    jump Str.250 #Derived_gen.0 #Derived_gen.1 #Derived_gen.2 #Derived_gen.3;
+    jump Str.252 #Derived_gen.0 #Derived_gen.1 #Derived_gen.2 #Derived_gen.3;
 
-procedure Str.57 (Str.121, Str.122):
-    let Str.123 : U64 = CallByName Str.36 Str.121;
+procedure Str.58 (Str.122, Str.123):
     let Str.124 : U64 = CallByName Str.36 Str.122;
-    let Str.125 : U64 = CallByName Num.77 Str.123 Str.124;
-    let Str.277 : U64 = 0i64;
-    let Str.276 : [C , C U64] = CallByName Str.58 Str.121 Str.122 Str.277 Str.125;
-    ret Str.276;
+    let Str.125 : U64 = CallByName Str.36 Str.123;
+    let Str.126 : U64 = CallByName Num.77 Str.124 Str.125;
+    let Str.279 : U64 = 0i64;
+    let Str.278 : [C , C U64] = CallByName Str.59 Str.122 Str.123 Str.279 Str.126;
+    ret Str.278;
 
-procedure Str.58 (#Derived_gen.4, #Derived_gen.5, #Derived_gen.6, #Derived_gen.7):
-    joinpoint Str.278 Str.126 Str.127 Str.128 Str.129:
-        let Str.280 : Int1 = CallByName Num.23 Str.128 Str.129;
-        if Str.280 then
-            let Str.284 : Int1 = CallByName Str.62 Str.126 Str.128 Str.127;
-            if Str.284 then
+procedure Str.59 (#Derived_gen.4, #Derived_gen.5, #Derived_gen.6, #Derived_gen.7):
+    joinpoint Str.280 Str.127 Str.128 Str.129 Str.130:
+        let Str.282 : Int1 = CallByName Num.23 Str.129 Str.130;
+        if Str.282 then
+            let Str.286 : Int1 = CallByName Str.63 Str.127 Str.129 Str.128;
+            if Str.286 then
                 dec Str.127;
-                dec Str.126;
-                let Str.285 : [C , C U64] = TagId(1) Str.128;
-                ret Str.285;
+                dec Str.128;
+                let Str.287 : [C , C U64] = TagId(1) Str.129;
+                ret Str.287;
             else
-                let Str.283 : U64 = 1i64;
-                let Str.282 : U64 = CallByName Num.51 Str.128 Str.283;
-                jump Str.278 Str.126 Str.127 Str.282 Str.129;
+                let Str.285 : U64 = 1i64;
+                let Str.284 : U64 = CallByName Num.51 Str.129 Str.285;
+                jump Str.280 Str.127 Str.128 Str.284 Str.130;
         else
             dec Str.127;
-            dec Str.126;
-            let Str.279 : [C , C U64] = TagId(0) ;
-            ret Str.279;
+            dec Str.128;
+            let Str.281 : [C , C U64] = TagId(0) ;
+            ret Str.281;
     in
     inc #Derived_gen.5;
     inc #Derived_gen.4;
-    jump Str.278 #Derived_gen.4 #Derived_gen.5 #Derived_gen.6 #Derived_gen.7;
+    jump Str.280 #Derived_gen.4 #Derived_gen.5 #Derived_gen.6 #Derived_gen.7;
 
-procedure Str.61 (Str.152, Str.153):
-    let Str.309 : Int1 = CallByName Num.22 Str.152 Str.153;
-    if Str.309 then
-        ret Str.152;
-    else
+procedure Str.62 (Str.153, Str.154):
+    let Str.311 : Int1 = CallByName Num.22 Str.153 Str.154;
+    if Str.311 then
         ret Str.153;
-
-procedure Str.62 (Str.154, Str.155, Str.156):
-    let Str.157 : U64 = CallByName Str.36 Str.154;
-    let Str.158 : U64 = CallByName Str.36 Str.156;
-    let Str.307 : U64 = CallByName Num.53 Str.155 Str.158;
-    let Str.159 : U64 = CallByName Str.61 Str.307 Str.157;
-    let Str.306 : U64 = 0i64;
-    inc Str.156;
-    inc Str.154;
-    let Str.287 : {U64, Str, U64, Str, U64, U64} = Struct {Str.159, Str.154, Str.155, Str.156, Str.306, Str.158};
-    let Str.286 : Int1 = CallByName Str.63 Str.287;
-    ret Str.286;
-
-procedure Str.63 (Str.160):
-    let Str.166 : U64 = StructAtIndex 0 Str.160;
-    let Str.161 : Str = StructAtIndex 1 Str.160;
-    let Str.162 : U64 = StructAtIndex 2 Str.160;
-    let Str.163 : Str = StructAtIndex 3 Str.160;
-    let Str.164 : U64 = StructAtIndex 4 Str.160;
-    let Str.165 : U64 = StructAtIndex 5 Str.160;
-    let Str.167 : Int1 = CallByName Num.25 Str.162 Str.166;
-    if Str.167 then
-        dec Str.163;
-        dec Str.161;
-        let Str.168 : Int1 = CallByName Bool.9 Str.164 Str.165;
-        ret Str.168;
     else
-        let Str.302 : U8 = CallByName Str.35 Str.161 Str.162;
-        let Str.303 : U8 = CallByName Str.35 Str.163 Str.164;
-        let Str.169 : Int1 = CallByName Bool.9 Str.302 Str.303;
-        let Str.292 : U64 = StructAtIndex 0 Str.160;
-        let Str.293 : Str = StructAtIndex 1 Str.160;
-        let Str.295 : Str = StructAtIndex 3 Str.160;
-        let Str.297 : U64 = StructAtIndex 5 Str.160;
-        let Str.301 : U64 = 1i64;
-        let Str.299 : U64 = CallByName Num.51 Str.164 Str.301;
-        let Str.300 : U64 = 1i64;
-        let Str.298 : U64 = CallByName Num.51 Str.162 Str.300;
-        let Str.291 : {U64, Str, U64, Str, U64, U64} = Struct {Str.292, Str.293, Str.298, Str.295, Str.299, Str.297};
-        let Str.170 : Int1 = CallByName Str.63 Str.291;
-        if Str.169 then
-            ret Str.170;
+        ret Str.154;
+
+procedure Str.63 (Str.155, Str.156, Str.157):
+    let Str.158 : U64 = CallByName Str.36 Str.155;
+    let Str.159 : U64 = CallByName Str.36 Str.157;
+    let Str.309 : U64 = CallByName Num.53 Str.156 Str.159;
+    let Str.160 : U64 = CallByName Str.62 Str.309 Str.158;
+    let Str.308 : U64 = 0i64;
+    inc Str.157;
+    inc Str.155;
+    let Str.289 : {U64, Str, U64, Str, U64, U64} = Struct {Str.160, Str.155, Str.156, Str.157, Str.308, Str.159};
+    let Str.288 : Int1 = CallByName Str.64 Str.289;
+    ret Str.288;
+
+procedure Str.64 (Str.161):
+    let Str.167 : U64 = StructAtIndex 0 Str.161;
+    let Str.162 : Str = StructAtIndex 1 Str.161;
+    let Str.163 : U64 = StructAtIndex 2 Str.161;
+    let Str.164 : Str = StructAtIndex 3 Str.161;
+    let Str.165 : U64 = StructAtIndex 4 Str.161;
+    let Str.166 : U64 = StructAtIndex 5 Str.161;
+    let Str.168 : Int1 = CallByName Num.25 Str.163 Str.167;
+    if Str.168 then
+        dec Str.162;
+        dec Str.164;
+        let Str.169 : Int1 = CallByName Bool.9 Str.165 Str.166;
+        ret Str.169;
+    else
+        let Str.304 : U8 = CallByName Str.35 Str.162 Str.163;
+        let Str.305 : U8 = CallByName Str.35 Str.164 Str.165;
+        let Str.170 : Int1 = CallByName Bool.9 Str.304 Str.305;
+        let Str.294 : U64 = StructAtIndex 0 Str.161;
+        let Str.295 : Str = StructAtIndex 1 Str.161;
+        let Str.297 : Str = StructAtIndex 3 Str.161;
+        let Str.299 : U64 = StructAtIndex 5 Str.161;
+        let Str.303 : U64 = 1i64;
+        let Str.301 : U64 = CallByName Num.51 Str.165 Str.303;
+        let Str.302 : U64 = 1i64;
+        let Str.300 : U64 = CallByName Num.51 Str.163 Str.302;
+        let Str.293 : {U64, Str, U64, Str, U64, U64} = Struct {Str.294, Str.295, Str.300, Str.297, Str.301, Str.299};
+        let Str.171 : Int1 = CallByName Str.64 Str.293;
+        if Str.170 then
+            ret Str.171;
         else
-            let Str.289 : Int1 = CallByName Bool.1;
-            ret Str.289;
+            let Str.291 : Int1 = CallByName Bool.1;
+            ret Str.291;
 
 procedure Test.1 ():
     let Test.4 : Str = "";

--- a/crates/compiler/test_mono/generated/dbg_inside_string.txt
+++ b/crates/compiler/test_mono/generated/dbg_inside_string.txt
@@ -100,184 +100,184 @@ procedure Num.77 (#Attr.2, #Attr.3):
     ret Num.293;
 
 procedure Str.20 (#Attr.2):
-    let Str.316 : Str = lowlevel StrWithCapacity #Attr.2;
-    ret Str.316;
+    let Str.318 : Str = lowlevel StrWithCapacity #Attr.2;
+    ret Str.318;
 
 procedure Str.3 (#Attr.2, #Attr.3):
-    let Str.248 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
-    ret Str.248;
+    let Str.250 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
+    ret Str.250;
 
 procedure Str.35 (#Attr.2, #Attr.3):
-    let Str.306 : U8 = lowlevel StrGetUnsafe #Attr.2 #Attr.3;
-    ret Str.306;
+    let Str.308 : U8 = lowlevel StrGetUnsafe #Attr.2 #Attr.3;
+    ret Str.308;
 
 procedure Str.36 (#Attr.2):
-    let Str.268 : U64 = lowlevel StrCountUtf8Bytes #Attr.2;
-    ret Str.268;
+    let Str.270 : U64 = lowlevel StrCountUtf8Bytes #Attr.2;
+    ret Str.270;
 
 procedure Str.37 (#Attr.2, #Attr.3, #Attr.4):
-    let Str.266 : Str = lowlevel StrSubstringUnsafe #Attr.2 #Attr.3 #Attr.4;
-    ret Str.266;
+    let Str.268 : Str = lowlevel StrSubstringUnsafe #Attr.2 #Attr.3 #Attr.4;
+    ret Str.268;
 
-procedure Str.38 (Str.112, Str.113):
-    let Str.262 : [C , C U64] = CallByName Str.57 Str.112 Str.113;
-    let Str.275 : U8 = 1i64;
-    let Str.276 : U8 = GetTagId Str.262;
-    let Str.277 : Int1 = lowlevel Eq Str.275 Str.276;
-    if Str.277 then
-        let Str.114 : U64 = UnionAtIndex (Id 1) (Index 0) Str.262;
-        let Str.271 : U64 = CallByName Str.36 Str.112;
-        let Str.272 : U64 = CallByName Str.36 Str.113;
-        let Str.270 : U64 = CallByName Num.20 Str.271 Str.272;
-        let Str.115 : U64 = CallByName Num.20 Str.270 Str.114;
-        let Str.269 : U64 = 0i64;
-        inc Str.112;
-        let Str.116 : Str = CallByName Str.37 Str.112 Str.269 Str.114;
-        let Str.267 : U64 = CallByName Str.36 Str.113;
-        let Str.265 : U64 = CallByName Num.51 Str.114 Str.267;
-        let Str.117 : Str = CallByName Str.37 Str.112 Str.265 Str.115;
-        let Str.264 : {Str, Str} = Struct {Str.117, Str.116};
-        let Str.263 : [C {}, C {Str, Str}] = TagId(1) Str.264;
-        ret Str.263;
+procedure Str.38 (Str.113, Str.114):
+    let Str.264 : [C , C U64] = CallByName Str.58 Str.113 Str.114;
+    let Str.277 : U8 = 1i64;
+    let Str.278 : U8 = GetTagId Str.264;
+    let Str.279 : Int1 = lowlevel Eq Str.277 Str.278;
+    if Str.279 then
+        let Str.115 : U64 = UnionAtIndex (Id 1) (Index 0) Str.264;
+        let Str.273 : U64 = CallByName Str.36 Str.113;
+        let Str.274 : U64 = CallByName Str.36 Str.114;
+        let Str.272 : U64 = CallByName Num.20 Str.273 Str.274;
+        let Str.116 : U64 = CallByName Num.20 Str.272 Str.115;
+        let Str.271 : U64 = 0i64;
+        inc Str.113;
+        let Str.117 : Str = CallByName Str.37 Str.113 Str.271 Str.115;
+        let Str.269 : U64 = CallByName Str.36 Str.114;
+        let Str.267 : U64 = CallByName Num.51 Str.115 Str.269;
+        let Str.118 : Str = CallByName Str.37 Str.113 Str.267 Str.116;
+        let Str.266 : {Str, Str} = Struct {Str.118, Str.117};
+        let Str.265 : [C {}, C {Str, Str}] = TagId(1) Str.266;
+        ret Str.265;
     else
-        dec Str.112;
-        let Str.274 : {} = Struct {};
-        let Str.273 : [C {}, C {Str, Str}] = TagId(0) Str.274;
-        ret Str.273;
+        dec Str.113;
+        let Str.276 : {} = Struct {};
+        let Str.275 : [C {}, C {Str, Str}] = TagId(0) Str.276;
+        ret Str.275;
 
-procedure Str.45 (Str.91, Str.92, Str.93):
-    inc Str.91;
-    let Str.344 : [C {}, C {Str, Str}] = CallByName Str.38 Str.91 Str.92;
-    let Str.352 : U8 = 1i64;
-    let Str.353 : U8 = GetTagId Str.344;
-    let Str.354 : Int1 = lowlevel Eq Str.352 Str.353;
-    if Str.354 then
-        let Str.351 : {Str, Str} = UnionAtIndex (Id 1) (Index 0) Str.344;
-        let Str.95 : Str = StructAtIndex 0 Str.351;
-        let Str.94 : Str = StructAtIndex 1 Str.351;
-        let Str.349 : U64 = CallByName Str.36 Str.91;
-        dec Str.91;
-        let Str.348 : Str = CallByName Str.20 Str.349;
-        let Str.347 : Str = CallByName Str.3 Str.348 Str.94;
-        dec Str.94;
-        let Str.346 : Str = CallByName Str.3 Str.347 Str.93;
-        let Str.345 : Str = CallByName Str.56 Str.346 Str.95 Str.92 Str.93;
-        ret Str.345;
+procedure Str.45 (Str.92, Str.93, Str.94):
+    inc Str.92;
+    let Str.346 : [C {}, C {Str, Str}] = CallByName Str.38 Str.92 Str.93;
+    let Str.354 : U8 = 1i64;
+    let Str.355 : U8 = GetTagId Str.346;
+    let Str.356 : Int1 = lowlevel Eq Str.354 Str.355;
+    if Str.356 then
+        let Str.353 : {Str, Str} = UnionAtIndex (Id 1) (Index 0) Str.346;
+        let Str.96 : Str = StructAtIndex 0 Str.353;
+        let Str.95 : Str = StructAtIndex 1 Str.353;
+        let Str.351 : U64 = CallByName Str.36 Str.92;
+        dec Str.92;
+        let Str.350 : Str = CallByName Str.20 Str.351;
+        let Str.349 : Str = CallByName Str.3 Str.350 Str.95;
+        dec Str.95;
+        let Str.348 : Str = CallByName Str.3 Str.349 Str.94;
+        let Str.347 : Str = CallByName Str.57 Str.348 Str.96 Str.93 Str.94;
+        ret Str.347;
     else
-        dec Str.344;
-        ret Str.91;
+        dec Str.346;
+        ret Str.92;
 
-procedure Str.56 (Bool.24, Bool.25, Bool.26, Bool.27):
-    joinpoint Str.252 Str.96 Str.97 Str.98 Str.99:
-        inc Str.97;
-        let Str.253 : [C {}, C {Str, Str}] = CallByName Str.38 Str.97 Str.98;
-        let Str.259 : U8 = 1i64;
-        let Str.260 : U8 = GetTagId Str.253;
-        let Str.261 : Int1 = lowlevel Eq Str.259 Str.260;
-        if Str.261 then
-            dec Str.97;
-            let Str.258 : {Str, Str} = UnionAtIndex (Id 1) (Index 0) Str.253;
-            let Str.101 : Str = StructAtIndex 0 Str.258;
-            let Str.100 : Str = StructAtIndex 1 Str.258;
-            let Str.256 : Str = CallByName Str.3 Str.96 Str.100;
-            dec Str.100;
-            let Str.255 : Str = CallByName Str.3 Str.256 Str.99;
-            jump Str.252 Str.255 Str.101 Str.98 Str.99;
-        else
+procedure Str.57 (Bool.24, Bool.25, Bool.26, Bool.27):
+    joinpoint Str.254 Str.97 Str.98 Str.99 Str.100:
+        inc Str.98;
+        let Str.255 : [C {}, C {Str, Str}] = CallByName Str.38 Str.98 Str.99;
+        let Str.261 : U8 = 1i64;
+        let Str.262 : U8 = GetTagId Str.255;
+        let Str.263 : Int1 = lowlevel Eq Str.261 Str.262;
+        if Str.263 then
             dec Str.98;
+            let Str.260 : {Str, Str} = UnionAtIndex (Id 1) (Index 0) Str.255;
+            let Str.102 : Str = StructAtIndex 0 Str.260;
+            let Str.101 : Str = StructAtIndex 1 Str.260;
+            let Str.258 : Str = CallByName Str.3 Str.97 Str.101;
+            dec Str.101;
+            let Str.257 : Str = CallByName Str.3 Str.258 Str.100;
+            jump Str.254 Str.257 Str.102 Str.99 Str.100;
+        else
+            dec Str.100;
             dec Str.99;
-            dec Str.253;
-            let Str.257 : Str = CallByName Str.3 Str.96 Str.97;
-            dec Str.97;
-            ret Str.257;
+            dec Str.255;
+            let Str.259 : Str = CallByName Str.3 Str.97 Str.98;
+            dec Str.98;
+            ret Str.259;
     in
     inc Bool.26;
     inc Bool.27;
-    jump Str.252 Bool.24 Bool.25 Bool.26 Bool.27;
+    jump Str.254 Bool.24 Bool.25 Bool.26 Bool.27;
 
-procedure Str.57 (Str.121, Str.122):
-    let Str.123 : U64 = CallByName Str.36 Str.121;
+procedure Str.58 (Str.122, Str.123):
     let Str.124 : U64 = CallByName Str.36 Str.122;
-    let Str.125 : U64 = CallByName Num.77 Str.123 Str.124;
-    let Str.279 : U64 = 0i64;
-    let Str.278 : [C , C U64] = CallByName Str.58 Str.121 Str.122 Str.279 Str.125;
-    ret Str.278;
+    let Str.125 : U64 = CallByName Str.36 Str.123;
+    let Str.126 : U64 = CallByName Num.77 Str.124 Str.125;
+    let Str.281 : U64 = 0i64;
+    let Str.280 : [C , C U64] = CallByName Str.59 Str.122 Str.123 Str.281 Str.126;
+    ret Str.280;
 
-procedure Str.58 (Bool.28, Bool.29, Bool.30, Bool.31):
-    joinpoint Str.280 Str.126 Str.127 Str.128 Str.129:
-        let Str.282 : Int1 = CallByName Num.23 Str.128 Str.129;
-        if Str.282 then
-            let Str.286 : Int1 = CallByName Str.62 Str.126 Str.128 Str.127;
-            if Str.286 then
+procedure Str.59 (Bool.28, Bool.29, Bool.30, Bool.31):
+    joinpoint Str.282 Str.127 Str.128 Str.129 Str.130:
+        let Str.284 : Int1 = CallByName Num.23 Str.129 Str.130;
+        if Str.284 then
+            let Str.288 : Int1 = CallByName Str.63 Str.127 Str.129 Str.128;
+            if Str.288 then
                 dec Str.127;
-                dec Str.126;
-                let Str.287 : [C , C U64] = TagId(1) Str.128;
-                ret Str.287;
+                dec Str.128;
+                let Str.289 : [C , C U64] = TagId(1) Str.129;
+                ret Str.289;
             else
-                let Str.285 : U64 = 1i64;
-                let Str.284 : U64 = CallByName Num.51 Str.128 Str.285;
-                jump Str.280 Str.126 Str.127 Str.284 Str.129;
+                let Str.287 : U64 = 1i64;
+                let Str.286 : U64 = CallByName Num.51 Str.129 Str.287;
+                jump Str.282 Str.127 Str.128 Str.286 Str.130;
         else
             dec Str.127;
-            dec Str.126;
-            let Str.281 : [C , C U64] = TagId(0) ;
-            ret Str.281;
+            dec Str.128;
+            let Str.283 : [C , C U64] = TagId(0) ;
+            ret Str.283;
     in
     inc Bool.29;
     inc Bool.28;
-    jump Str.280 Bool.28 Bool.29 Bool.30 Bool.31;
+    jump Str.282 Bool.28 Bool.29 Bool.30 Bool.31;
 
-procedure Str.61 (Str.152, Str.153):
-    let Str.311 : Int1 = CallByName Num.22 Str.152 Str.153;
-    if Str.311 then
-        ret Str.152;
-    else
+procedure Str.62 (Str.153, Str.154):
+    let Str.313 : Int1 = CallByName Num.22 Str.153 Str.154;
+    if Str.313 then
         ret Str.153;
-
-procedure Str.62 (Str.154, Str.155, Str.156):
-    let Str.157 : U64 = CallByName Str.36 Str.154;
-    let Str.158 : U64 = CallByName Str.36 Str.156;
-    let Str.309 : U64 = CallByName Num.53 Str.155 Str.158;
-    let Str.159 : U64 = CallByName Str.61 Str.309 Str.157;
-    let Str.308 : U64 = 0i64;
-    inc Str.156;
-    inc Str.154;
-    let Str.289 : {U64, Str, U64, Str, U64, U64} = Struct {Str.159, Str.154, Str.155, Str.156, Str.308, Str.158};
-    let Str.288 : Int1 = CallByName Str.63 Str.289;
-    ret Str.288;
-
-procedure Str.63 (Str.160):
-    let Str.166 : U64 = StructAtIndex 0 Str.160;
-    let Str.161 : Str = StructAtIndex 1 Str.160;
-    let Str.162 : U64 = StructAtIndex 2 Str.160;
-    let Str.163 : Str = StructAtIndex 3 Str.160;
-    let Str.164 : U64 = StructAtIndex 4 Str.160;
-    let Str.165 : U64 = StructAtIndex 5 Str.160;
-    let Str.167 : Int1 = CallByName Num.25 Str.162 Str.166;
-    if Str.167 then
-        dec Str.163;
-        dec Str.161;
-        let Str.168 : Int1 = CallByName Bool.9 Str.164 Str.165;
-        ret Str.168;
     else
-        let Str.304 : U8 = CallByName Str.35 Str.161 Str.162;
-        let Str.305 : U8 = CallByName Str.35 Str.163 Str.164;
-        let Str.169 : Int1 = CallByName Bool.9 Str.304 Str.305;
-        let Str.294 : U64 = StructAtIndex 0 Str.160;
-        let Str.295 : Str = StructAtIndex 1 Str.160;
-        let Str.297 : Str = StructAtIndex 3 Str.160;
-        let Str.299 : U64 = StructAtIndex 5 Str.160;
-        let Str.303 : U64 = 1i64;
-        let Str.301 : U64 = CallByName Num.51 Str.164 Str.303;
-        let Str.302 : U64 = 1i64;
-        let Str.300 : U64 = CallByName Num.51 Str.162 Str.302;
-        let Str.293 : {U64, Str, U64, Str, U64, U64} = Struct {Str.294, Str.295, Str.300, Str.297, Str.301, Str.299};
-        let Str.170 : Int1 = CallByName Str.63 Str.293;
-        if Str.169 then
-            ret Str.170;
+        ret Str.154;
+
+procedure Str.63 (Str.155, Str.156, Str.157):
+    let Str.158 : U64 = CallByName Str.36 Str.155;
+    let Str.159 : U64 = CallByName Str.36 Str.157;
+    let Str.311 : U64 = CallByName Num.53 Str.156 Str.159;
+    let Str.160 : U64 = CallByName Str.62 Str.311 Str.158;
+    let Str.310 : U64 = 0i64;
+    inc Str.157;
+    inc Str.155;
+    let Str.291 : {U64, Str, U64, Str, U64, U64} = Struct {Str.160, Str.155, Str.156, Str.157, Str.310, Str.159};
+    let Str.290 : Int1 = CallByName Str.64 Str.291;
+    ret Str.290;
+
+procedure Str.64 (Str.161):
+    let Str.167 : U64 = StructAtIndex 0 Str.161;
+    let Str.162 : Str = StructAtIndex 1 Str.161;
+    let Str.163 : U64 = StructAtIndex 2 Str.161;
+    let Str.164 : Str = StructAtIndex 3 Str.161;
+    let Str.165 : U64 = StructAtIndex 4 Str.161;
+    let Str.166 : U64 = StructAtIndex 5 Str.161;
+    let Str.168 : Int1 = CallByName Num.25 Str.163 Str.167;
+    if Str.168 then
+        dec Str.162;
+        dec Str.164;
+        let Str.169 : Int1 = CallByName Bool.9 Str.165 Str.166;
+        ret Str.169;
+    else
+        let Str.306 : U8 = CallByName Str.35 Str.162 Str.163;
+        let Str.307 : U8 = CallByName Str.35 Str.164 Str.165;
+        let Str.170 : Int1 = CallByName Bool.9 Str.306 Str.307;
+        let Str.296 : U64 = StructAtIndex 0 Str.161;
+        let Str.297 : Str = StructAtIndex 1 Str.161;
+        let Str.299 : Str = StructAtIndex 3 Str.161;
+        let Str.301 : U64 = StructAtIndex 5 Str.161;
+        let Str.305 : U64 = 1i64;
+        let Str.303 : U64 = CallByName Num.51 Str.165 Str.305;
+        let Str.304 : U64 = 1i64;
+        let Str.302 : U64 = CallByName Num.51 Str.163 Str.304;
+        let Str.295 : {U64, Str, U64, Str, U64, U64} = Struct {Str.296, Str.297, Str.302, Str.299, Str.303, Str.301};
+        let Str.171 : Int1 = CallByName Str.64 Str.295;
+        if Str.170 then
+            ret Str.171;
         else
-            let Str.291 : Int1 = CallByName Bool.1;
-            ret Str.291;
+            let Str.293 : Int1 = CallByName Bool.1;
+            ret Str.293;
 
 procedure Test.0 ():
     let Test.4 : Str = "Hello ";

--- a/crates/compiler/test_mono/generated/dbg_nested_expr.txt
+++ b/crates/compiler/test_mono/generated/dbg_nested_expr.txt
@@ -39,8 +39,8 @@ procedure Num.96 (#Attr.2):
     ret Num.283;
 
 procedure Str.3 (#Attr.2, #Attr.3):
-    let Str.246 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
-    ret Str.246;
+    let Str.248 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
+    ret Str.248;
 
 procedure Test.0 ():
     let Test.3 : I64 = 1i64;

--- a/crates/compiler/test_mono/generated/dbg_str_followed_by_number.txt
+++ b/crates/compiler/test_mono/generated/dbg_str_followed_by_number.txt
@@ -100,184 +100,184 @@ procedure Num.77 (#Attr.2, #Attr.3):
     ret Num.293;
 
 procedure Str.20 (#Attr.2):
-    let Str.314 : Str = lowlevel StrWithCapacity #Attr.2;
-    ret Str.314;
+    let Str.316 : Str = lowlevel StrWithCapacity #Attr.2;
+    ret Str.316;
 
 procedure Str.3 (#Attr.2, #Attr.3):
-    let Str.246 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
-    ret Str.246;
+    let Str.248 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
+    ret Str.248;
 
 procedure Str.35 (#Attr.2, #Attr.3):
-    let Str.304 : U8 = lowlevel StrGetUnsafe #Attr.2 #Attr.3;
-    ret Str.304;
+    let Str.306 : U8 = lowlevel StrGetUnsafe #Attr.2 #Attr.3;
+    ret Str.306;
 
 procedure Str.36 (#Attr.2):
-    let Str.266 : U64 = lowlevel StrCountUtf8Bytes #Attr.2;
-    ret Str.266;
+    let Str.268 : U64 = lowlevel StrCountUtf8Bytes #Attr.2;
+    ret Str.268;
 
 procedure Str.37 (#Attr.2, #Attr.3, #Attr.4):
-    let Str.264 : Str = lowlevel StrSubstringUnsafe #Attr.2 #Attr.3 #Attr.4;
-    ret Str.264;
+    let Str.266 : Str = lowlevel StrSubstringUnsafe #Attr.2 #Attr.3 #Attr.4;
+    ret Str.266;
 
-procedure Str.38 (Str.112, Str.113):
-    let Str.260 : [C , C U64] = CallByName Str.57 Str.112 Str.113;
-    let Str.273 : U8 = 1i64;
-    let Str.274 : U8 = GetTagId Str.260;
-    let Str.275 : Int1 = lowlevel Eq Str.273 Str.274;
-    if Str.275 then
-        let Str.114 : U64 = UnionAtIndex (Id 1) (Index 0) Str.260;
-        let Str.269 : U64 = CallByName Str.36 Str.112;
-        let Str.270 : U64 = CallByName Str.36 Str.113;
-        let Str.268 : U64 = CallByName Num.20 Str.269 Str.270;
-        let Str.115 : U64 = CallByName Num.20 Str.268 Str.114;
-        let Str.267 : U64 = 0i64;
-        inc Str.112;
-        let Str.116 : Str = CallByName Str.37 Str.112 Str.267 Str.114;
-        let Str.265 : U64 = CallByName Str.36 Str.113;
-        let Str.263 : U64 = CallByName Num.51 Str.114 Str.265;
-        let Str.117 : Str = CallByName Str.37 Str.112 Str.263 Str.115;
-        let Str.262 : {Str, Str} = Struct {Str.117, Str.116};
-        let Str.261 : [C {}, C {Str, Str}] = TagId(1) Str.262;
-        ret Str.261;
+procedure Str.38 (Str.113, Str.114):
+    let Str.262 : [C , C U64] = CallByName Str.58 Str.113 Str.114;
+    let Str.275 : U8 = 1i64;
+    let Str.276 : U8 = GetTagId Str.262;
+    let Str.277 : Int1 = lowlevel Eq Str.275 Str.276;
+    if Str.277 then
+        let Str.115 : U64 = UnionAtIndex (Id 1) (Index 0) Str.262;
+        let Str.271 : U64 = CallByName Str.36 Str.113;
+        let Str.272 : U64 = CallByName Str.36 Str.114;
+        let Str.270 : U64 = CallByName Num.20 Str.271 Str.272;
+        let Str.116 : U64 = CallByName Num.20 Str.270 Str.115;
+        let Str.269 : U64 = 0i64;
+        inc Str.113;
+        let Str.117 : Str = CallByName Str.37 Str.113 Str.269 Str.115;
+        let Str.267 : U64 = CallByName Str.36 Str.114;
+        let Str.265 : U64 = CallByName Num.51 Str.115 Str.267;
+        let Str.118 : Str = CallByName Str.37 Str.113 Str.265 Str.116;
+        let Str.264 : {Str, Str} = Struct {Str.118, Str.117};
+        let Str.263 : [C {}, C {Str, Str}] = TagId(1) Str.264;
+        ret Str.263;
     else
-        dec Str.112;
-        let Str.272 : {} = Struct {};
-        let Str.271 : [C {}, C {Str, Str}] = TagId(0) Str.272;
-        ret Str.271;
+        dec Str.113;
+        let Str.274 : {} = Struct {};
+        let Str.273 : [C {}, C {Str, Str}] = TagId(0) Str.274;
+        ret Str.273;
 
-procedure Str.45 (Str.91, Str.92, Str.93):
-    inc Str.91;
-    let Str.342 : [C {}, C {Str, Str}] = CallByName Str.38 Str.91 Str.92;
-    let Str.350 : U8 = 1i64;
-    let Str.351 : U8 = GetTagId Str.342;
-    let Str.352 : Int1 = lowlevel Eq Str.350 Str.351;
-    if Str.352 then
-        let Str.349 : {Str, Str} = UnionAtIndex (Id 1) (Index 0) Str.342;
-        let Str.95 : Str = StructAtIndex 0 Str.349;
-        let Str.94 : Str = StructAtIndex 1 Str.349;
-        let Str.347 : U64 = CallByName Str.36 Str.91;
-        dec Str.91;
-        let Str.346 : Str = CallByName Str.20 Str.347;
-        let Str.345 : Str = CallByName Str.3 Str.346 Str.94;
-        dec Str.94;
-        let Str.344 : Str = CallByName Str.3 Str.345 Str.93;
-        let Str.343 : Str = CallByName Str.56 Str.344 Str.95 Str.92 Str.93;
-        ret Str.343;
+procedure Str.45 (Str.92, Str.93, Str.94):
+    inc Str.92;
+    let Str.344 : [C {}, C {Str, Str}] = CallByName Str.38 Str.92 Str.93;
+    let Str.352 : U8 = 1i64;
+    let Str.353 : U8 = GetTagId Str.344;
+    let Str.354 : Int1 = lowlevel Eq Str.352 Str.353;
+    if Str.354 then
+        let Str.351 : {Str, Str} = UnionAtIndex (Id 1) (Index 0) Str.344;
+        let Str.96 : Str = StructAtIndex 0 Str.351;
+        let Str.95 : Str = StructAtIndex 1 Str.351;
+        let Str.349 : U64 = CallByName Str.36 Str.92;
+        dec Str.92;
+        let Str.348 : Str = CallByName Str.20 Str.349;
+        let Str.347 : Str = CallByName Str.3 Str.348 Str.95;
+        dec Str.95;
+        let Str.346 : Str = CallByName Str.3 Str.347 Str.94;
+        let Str.345 : Str = CallByName Str.57 Str.346 Str.96 Str.93 Str.94;
+        ret Str.345;
     else
-        dec Str.342;
-        ret Str.91;
+        dec Str.344;
+        ret Str.92;
 
-procedure Str.56 (Bool.24, Bool.25, Bool.26, Bool.27):
-    joinpoint Str.250 Str.96 Str.97 Str.98 Str.99:
-        inc Str.97;
-        let Str.251 : [C {}, C {Str, Str}] = CallByName Str.38 Str.97 Str.98;
-        let Str.257 : U8 = 1i64;
-        let Str.258 : U8 = GetTagId Str.251;
-        let Str.259 : Int1 = lowlevel Eq Str.257 Str.258;
-        if Str.259 then
-            dec Str.97;
-            let Str.256 : {Str, Str} = UnionAtIndex (Id 1) (Index 0) Str.251;
-            let Str.101 : Str = StructAtIndex 0 Str.256;
-            let Str.100 : Str = StructAtIndex 1 Str.256;
-            let Str.254 : Str = CallByName Str.3 Str.96 Str.100;
-            dec Str.100;
-            let Str.253 : Str = CallByName Str.3 Str.254 Str.99;
-            jump Str.250 Str.253 Str.101 Str.98 Str.99;
-        else
+procedure Str.57 (Bool.24, Bool.25, Bool.26, Bool.27):
+    joinpoint Str.252 Str.97 Str.98 Str.99 Str.100:
+        inc Str.98;
+        let Str.253 : [C {}, C {Str, Str}] = CallByName Str.38 Str.98 Str.99;
+        let Str.259 : U8 = 1i64;
+        let Str.260 : U8 = GetTagId Str.253;
+        let Str.261 : Int1 = lowlevel Eq Str.259 Str.260;
+        if Str.261 then
             dec Str.98;
-            dec Str.251;
+            let Str.258 : {Str, Str} = UnionAtIndex (Id 1) (Index 0) Str.253;
+            let Str.102 : Str = StructAtIndex 0 Str.258;
+            let Str.101 : Str = StructAtIndex 1 Str.258;
+            let Str.256 : Str = CallByName Str.3 Str.97 Str.101;
+            dec Str.101;
+            let Str.255 : Str = CallByName Str.3 Str.256 Str.100;
+            jump Str.252 Str.255 Str.102 Str.99 Str.100;
+        else
+            dec Str.100;
             dec Str.99;
-            let Str.255 : Str = CallByName Str.3 Str.96 Str.97;
-            dec Str.97;
-            ret Str.255;
+            dec Str.253;
+            let Str.257 : Str = CallByName Str.3 Str.97 Str.98;
+            dec Str.98;
+            ret Str.257;
     in
     inc Bool.26;
     inc Bool.27;
-    jump Str.250 Bool.24 Bool.25 Bool.26 Bool.27;
+    jump Str.252 Bool.24 Bool.25 Bool.26 Bool.27;
 
-procedure Str.57 (Str.121, Str.122):
-    let Str.123 : U64 = CallByName Str.36 Str.121;
+procedure Str.58 (Str.122, Str.123):
     let Str.124 : U64 = CallByName Str.36 Str.122;
-    let Str.125 : U64 = CallByName Num.77 Str.123 Str.124;
-    let Str.277 : U64 = 0i64;
-    let Str.276 : [C , C U64] = CallByName Str.58 Str.121 Str.122 Str.277 Str.125;
-    ret Str.276;
+    let Str.125 : U64 = CallByName Str.36 Str.123;
+    let Str.126 : U64 = CallByName Num.77 Str.124 Str.125;
+    let Str.279 : U64 = 0i64;
+    let Str.278 : [C , C U64] = CallByName Str.59 Str.122 Str.123 Str.279 Str.126;
+    ret Str.278;
 
-procedure Str.58 (Bool.28, Bool.29, Bool.30, Bool.31):
-    joinpoint Str.278 Str.126 Str.127 Str.128 Str.129:
-        let Str.280 : Int1 = CallByName Num.23 Str.128 Str.129;
-        if Str.280 then
-            let Str.284 : Int1 = CallByName Str.62 Str.126 Str.128 Str.127;
-            if Str.284 then
+procedure Str.59 (Bool.28, Bool.29, Bool.30, Bool.31):
+    joinpoint Str.280 Str.127 Str.128 Str.129 Str.130:
+        let Str.282 : Int1 = CallByName Num.23 Str.129 Str.130;
+        if Str.282 then
+            let Str.286 : Int1 = CallByName Str.63 Str.127 Str.129 Str.128;
+            if Str.286 then
                 dec Str.127;
-                dec Str.126;
-                let Str.285 : [C , C U64] = TagId(1) Str.128;
-                ret Str.285;
+                dec Str.128;
+                let Str.287 : [C , C U64] = TagId(1) Str.129;
+                ret Str.287;
             else
-                let Str.283 : U64 = 1i64;
-                let Str.282 : U64 = CallByName Num.51 Str.128 Str.283;
-                jump Str.278 Str.126 Str.127 Str.282 Str.129;
+                let Str.285 : U64 = 1i64;
+                let Str.284 : U64 = CallByName Num.51 Str.129 Str.285;
+                jump Str.280 Str.127 Str.128 Str.284 Str.130;
         else
             dec Str.127;
-            dec Str.126;
-            let Str.279 : [C , C U64] = TagId(0) ;
-            ret Str.279;
+            dec Str.128;
+            let Str.281 : [C , C U64] = TagId(0) ;
+            ret Str.281;
     in
     inc Bool.29;
     inc Bool.28;
-    jump Str.278 Bool.28 Bool.29 Bool.30 Bool.31;
+    jump Str.280 Bool.28 Bool.29 Bool.30 Bool.31;
 
-procedure Str.61 (Str.152, Str.153):
-    let Str.309 : Int1 = CallByName Num.22 Str.152 Str.153;
-    if Str.309 then
-        ret Str.152;
-    else
+procedure Str.62 (Str.153, Str.154):
+    let Str.311 : Int1 = CallByName Num.22 Str.153 Str.154;
+    if Str.311 then
         ret Str.153;
-
-procedure Str.62 (Str.154, Str.155, Str.156):
-    let Str.157 : U64 = CallByName Str.36 Str.154;
-    let Str.158 : U64 = CallByName Str.36 Str.156;
-    let Str.307 : U64 = CallByName Num.53 Str.155 Str.158;
-    let Str.159 : U64 = CallByName Str.61 Str.307 Str.157;
-    let Str.306 : U64 = 0i64;
-    inc Str.156;
-    inc Str.154;
-    let Str.287 : {U64, Str, U64, Str, U64, U64} = Struct {Str.159, Str.154, Str.155, Str.156, Str.306, Str.158};
-    let Str.286 : Int1 = CallByName Str.63 Str.287;
-    ret Str.286;
-
-procedure Str.63 (Str.160):
-    let Str.166 : U64 = StructAtIndex 0 Str.160;
-    let Str.161 : Str = StructAtIndex 1 Str.160;
-    let Str.162 : U64 = StructAtIndex 2 Str.160;
-    let Str.163 : Str = StructAtIndex 3 Str.160;
-    let Str.164 : U64 = StructAtIndex 4 Str.160;
-    let Str.165 : U64 = StructAtIndex 5 Str.160;
-    let Str.167 : Int1 = CallByName Num.25 Str.162 Str.166;
-    if Str.167 then
-        dec Str.163;
-        dec Str.161;
-        let Str.168 : Int1 = CallByName Bool.9 Str.164 Str.165;
-        ret Str.168;
     else
-        let Str.302 : U8 = CallByName Str.35 Str.161 Str.162;
-        let Str.303 : U8 = CallByName Str.35 Str.163 Str.164;
-        let Str.169 : Int1 = CallByName Bool.9 Str.302 Str.303;
-        let Str.292 : U64 = StructAtIndex 0 Str.160;
-        let Str.293 : Str = StructAtIndex 1 Str.160;
-        let Str.295 : Str = StructAtIndex 3 Str.160;
-        let Str.297 : U64 = StructAtIndex 5 Str.160;
-        let Str.301 : U64 = 1i64;
-        let Str.299 : U64 = CallByName Num.51 Str.164 Str.301;
-        let Str.300 : U64 = 1i64;
-        let Str.298 : U64 = CallByName Num.51 Str.162 Str.300;
-        let Str.291 : {U64, Str, U64, Str, U64, U64} = Struct {Str.292, Str.293, Str.298, Str.295, Str.299, Str.297};
-        let Str.170 : Int1 = CallByName Str.63 Str.291;
-        if Str.169 then
-            ret Str.170;
+        ret Str.154;
+
+procedure Str.63 (Str.155, Str.156, Str.157):
+    let Str.158 : U64 = CallByName Str.36 Str.155;
+    let Str.159 : U64 = CallByName Str.36 Str.157;
+    let Str.309 : U64 = CallByName Num.53 Str.156 Str.159;
+    let Str.160 : U64 = CallByName Str.62 Str.309 Str.158;
+    let Str.308 : U64 = 0i64;
+    inc Str.157;
+    inc Str.155;
+    let Str.289 : {U64, Str, U64, Str, U64, U64} = Struct {Str.160, Str.155, Str.156, Str.157, Str.308, Str.159};
+    let Str.288 : Int1 = CallByName Str.64 Str.289;
+    ret Str.288;
+
+procedure Str.64 (Str.161):
+    let Str.167 : U64 = StructAtIndex 0 Str.161;
+    let Str.162 : Str = StructAtIndex 1 Str.161;
+    let Str.163 : U64 = StructAtIndex 2 Str.161;
+    let Str.164 : Str = StructAtIndex 3 Str.161;
+    let Str.165 : U64 = StructAtIndex 4 Str.161;
+    let Str.166 : U64 = StructAtIndex 5 Str.161;
+    let Str.168 : Int1 = CallByName Num.25 Str.163 Str.167;
+    if Str.168 then
+        dec Str.162;
+        dec Str.164;
+        let Str.169 : Int1 = CallByName Bool.9 Str.165 Str.166;
+        ret Str.169;
+    else
+        let Str.304 : U8 = CallByName Str.35 Str.162 Str.163;
+        let Str.305 : U8 = CallByName Str.35 Str.164 Str.165;
+        let Str.170 : Int1 = CallByName Bool.9 Str.304 Str.305;
+        let Str.294 : U64 = StructAtIndex 0 Str.161;
+        let Str.295 : Str = StructAtIndex 1 Str.161;
+        let Str.297 : Str = StructAtIndex 3 Str.161;
+        let Str.299 : U64 = StructAtIndex 5 Str.161;
+        let Str.303 : U64 = 1i64;
+        let Str.301 : U64 = CallByName Num.51 Str.165 Str.303;
+        let Str.302 : U64 = 1i64;
+        let Str.300 : U64 = CallByName Num.51 Str.163 Str.302;
+        let Str.293 : {U64, Str, U64, Str, U64, U64} = Struct {Str.294, Str.295, Str.300, Str.297, Str.301, Str.299};
+        let Str.171 : Int1 = CallByName Str.64 Str.293;
+        if Str.170 then
+            ret Str.171;
         else
-            let Str.289 : Int1 = CallByName Bool.1;
-            ret Str.289;
+            let Str.291 : Int1 = CallByName Bool.1;
+            ret Str.291;
 
 procedure Test.0 ():
     let Test.3 : Str = "";

--- a/crates/compiler/test_mono/generated/dec_refcount_for_usage_after_early_return_in_if.txt
+++ b/crates/compiler/test_mono/generated/dec_refcount_for_usage_after_early_return_in_if.txt
@@ -11,8 +11,8 @@ procedure Num.96 (#Attr.2):
     ret Num.284;
 
 procedure Str.3 (#Attr.2, #Attr.3):
-    let Str.247 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
-    ret Str.247;
+    let Str.249 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
+    ret Str.249;
 
 procedure Test.1 (Test.2):
     let Test.3 : Str = CallByName Num.96 Test.2;

--- a/crates/compiler/test_mono/generated/encode_derived_nested_record_string.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_nested_record_string.txt
@@ -164,32 +164,32 @@ procedure Num.96 (#Attr.2):
     ret Num.287;
 
 procedure Str.12 (#Attr.2):
-    let Str.259 : List U8 = lowlevel StrToUtf8 #Attr.2;
-    ret Str.259;
+    let Str.261 : List U8 = lowlevel StrToUtf8 #Attr.2;
+    ret Str.261;
 
 procedure Str.36 (#Attr.2):
-    let Str.260 : U64 = lowlevel StrCountUtf8Bytes #Attr.2;
-    ret Str.260;
+    let Str.262 : U64 = lowlevel StrCountUtf8Bytes #Attr.2;
+    ret Str.262;
 
 procedure Str.43 (#Attr.2):
-    let Str.254 : {U64, Str, Int1, U8} = lowlevel StrFromUtf8 #Attr.2;
-    ret Str.254;
+    let Str.256 : {U64, Str, Int1, U8} = lowlevel StrFromUtf8 #Attr.2;
+    ret Str.256;
 
-procedure Str.9 (Str.73):
-    let Str.74 : {U64, Str, Int1, U8} = CallByName Str.43 Str.73;
-    let Str.251 : Int1 = StructAtIndex 2 Str.74;
-    if Str.251 then
-        let Str.253 : Str = StructAtIndex 1 Str.74;
-        let Str.252 : [C {U64, U8}, C Str] = TagId(1) Str.253;
-        ret Str.252;
+procedure Str.9 (Str.74):
+    let Str.75 : {U64, Str, Int1, U8} = CallByName Str.43 Str.74;
+    let Str.253 : Int1 = StructAtIndex 2 Str.75;
+    if Str.253 then
+        let Str.255 : Str = StructAtIndex 1 Str.75;
+        let Str.254 : [C {U64, U8}, C Str] = TagId(1) Str.255;
+        ret Str.254;
     else
-        let Str.249 : U64 = StructAtIndex 0 Str.74;
-        let Str.250 : U8 = StructAtIndex 3 Str.74;
-        let #Derived_gen.45 : Str = StructAtIndex 1 Str.74;
+        let Str.251 : U64 = StructAtIndex 0 Str.75;
+        let Str.252 : U8 = StructAtIndex 3 Str.75;
+        let #Derived_gen.45 : Str = StructAtIndex 1 Str.75;
         dec #Derived_gen.45;
-        let Str.248 : {U64, U8} = Struct {Str.249, Str.250};
-        let Str.246 : [C {U64, U8}, C Str] = TagId(0) Str.248;
-        ret Str.246;
+        let Str.250 : {U64, U8} = Struct {Str.251, Str.252};
+        let Str.248 : [C {U64, U8}, C Str] = TagId(0) Str.250;
+        ret Str.248;
 
 procedure Test.20 (Test.56):
     let Test.325 : Str = CallByName Encode.23 Test.56;

--- a/crates/compiler/test_mono/generated/encode_derived_record_one_field_string.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_record_one_field_string.txt
@@ -105,32 +105,32 @@ procedure Num.96 (#Attr.2):
     ret Num.283;
 
 procedure Str.12 (#Attr.2):
-    let Str.256 : List U8 = lowlevel StrToUtf8 #Attr.2;
-    ret Str.256;
+    let Str.258 : List U8 = lowlevel StrToUtf8 #Attr.2;
+    ret Str.258;
 
 procedure Str.36 (#Attr.2):
-    let Str.257 : U64 = lowlevel StrCountUtf8Bytes #Attr.2;
-    ret Str.257;
+    let Str.259 : U64 = lowlevel StrCountUtf8Bytes #Attr.2;
+    ret Str.259;
 
 procedure Str.43 (#Attr.2):
-    let Str.254 : {U64, Str, Int1, U8} = lowlevel StrFromUtf8 #Attr.2;
-    ret Str.254;
+    let Str.256 : {U64, Str, Int1, U8} = lowlevel StrFromUtf8 #Attr.2;
+    ret Str.256;
 
-procedure Str.9 (Str.73):
-    let Str.74 : {U64, Str, Int1, U8} = CallByName Str.43 Str.73;
-    let Str.251 : Int1 = StructAtIndex 2 Str.74;
-    if Str.251 then
-        let Str.253 : Str = StructAtIndex 1 Str.74;
-        let Str.252 : [C {U64, U8}, C Str] = TagId(1) Str.253;
-        ret Str.252;
+procedure Str.9 (Str.74):
+    let Str.75 : {U64, Str, Int1, U8} = CallByName Str.43 Str.74;
+    let Str.253 : Int1 = StructAtIndex 2 Str.75;
+    if Str.253 then
+        let Str.255 : Str = StructAtIndex 1 Str.75;
+        let Str.254 : [C {U64, U8}, C Str] = TagId(1) Str.255;
+        ret Str.254;
     else
-        let Str.249 : U64 = StructAtIndex 0 Str.74;
-        let Str.250 : U8 = StructAtIndex 3 Str.74;
-        let #Derived_gen.24 : Str = StructAtIndex 1 Str.74;
+        let Str.251 : U64 = StructAtIndex 0 Str.75;
+        let Str.252 : U8 = StructAtIndex 3 Str.75;
+        let #Derived_gen.24 : Str = StructAtIndex 1 Str.75;
         dec #Derived_gen.24;
-        let Str.248 : {U64, U8} = Struct {Str.249, Str.250};
-        let Str.246 : [C {U64, U8}, C Str] = TagId(0) Str.248;
-        ret Str.246;
+        let Str.250 : {U64, U8} = Struct {Str.251, Str.252};
+        let Str.248 : [C {U64, U8}, C Str] = TagId(0) Str.250;
+        ret Str.248;
 
 procedure Test.20 (Test.56):
     let Test.292 : Str = CallByName Encode.23 Test.56;

--- a/crates/compiler/test_mono/generated/encode_derived_record_two_field_strings.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_record_two_field_strings.txt
@@ -112,32 +112,32 @@ procedure Num.96 (#Attr.2):
     ret Num.283;
 
 procedure Str.12 (#Attr.2):
-    let Str.256 : List U8 = lowlevel StrToUtf8 #Attr.2;
-    ret Str.256;
+    let Str.258 : List U8 = lowlevel StrToUtf8 #Attr.2;
+    ret Str.258;
 
 procedure Str.36 (#Attr.2):
-    let Str.257 : U64 = lowlevel StrCountUtf8Bytes #Attr.2;
-    ret Str.257;
+    let Str.259 : U64 = lowlevel StrCountUtf8Bytes #Attr.2;
+    ret Str.259;
 
 procedure Str.43 (#Attr.2):
-    let Str.254 : {U64, Str, Int1, U8} = lowlevel StrFromUtf8 #Attr.2;
-    ret Str.254;
+    let Str.256 : {U64, Str, Int1, U8} = lowlevel StrFromUtf8 #Attr.2;
+    ret Str.256;
 
-procedure Str.9 (Str.73):
-    let Str.74 : {U64, Str, Int1, U8} = CallByName Str.43 Str.73;
-    let Str.251 : Int1 = StructAtIndex 2 Str.74;
-    if Str.251 then
-        let Str.253 : Str = StructAtIndex 1 Str.74;
-        let Str.252 : [C {U64, U8}, C Str] = TagId(1) Str.253;
-        ret Str.252;
+procedure Str.9 (Str.74):
+    let Str.75 : {U64, Str, Int1, U8} = CallByName Str.43 Str.74;
+    let Str.253 : Int1 = StructAtIndex 2 Str.75;
+    if Str.253 then
+        let Str.255 : Str = StructAtIndex 1 Str.75;
+        let Str.254 : [C {U64, U8}, C Str] = TagId(1) Str.255;
+        ret Str.254;
     else
-        let Str.249 : U64 = StructAtIndex 0 Str.74;
-        let Str.250 : U8 = StructAtIndex 3 Str.74;
-        let #Derived_gen.28 : Str = StructAtIndex 1 Str.74;
+        let Str.251 : U64 = StructAtIndex 0 Str.75;
+        let Str.252 : U8 = StructAtIndex 3 Str.75;
+        let #Derived_gen.28 : Str = StructAtIndex 1 Str.75;
         dec #Derived_gen.28;
-        let Str.248 : {U64, U8} = Struct {Str.249, Str.250};
-        let Str.246 : [C {U64, U8}, C Str] = TagId(0) Str.248;
-        ret Str.246;
+        let Str.250 : {U64, U8} = Struct {Str.251, Str.252};
+        let Str.248 : [C {U64, U8}, C Str] = TagId(0) Str.250;
+        ret Str.248;
 
 procedure Test.20 (Test.56):
     let Test.296 : Str = CallByName Encode.23 Test.56;

--- a/crates/compiler/test_mono/generated/encode_derived_string.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_string.txt
@@ -38,32 +38,32 @@ procedure Num.96 (#Attr.2):
     ret Num.283;
 
 procedure Str.12 (#Attr.2):
-    let Str.256 : List U8 = lowlevel StrToUtf8 #Attr.2;
-    ret Str.256;
+    let Str.258 : List U8 = lowlevel StrToUtf8 #Attr.2;
+    ret Str.258;
 
 procedure Str.36 (#Attr.2):
-    let Str.257 : U64 = lowlevel StrCountUtf8Bytes #Attr.2;
-    ret Str.257;
+    let Str.259 : U64 = lowlevel StrCountUtf8Bytes #Attr.2;
+    ret Str.259;
 
 procedure Str.43 (#Attr.2):
-    let Str.254 : {U64, Str, Int1, U8} = lowlevel StrFromUtf8 #Attr.2;
-    ret Str.254;
+    let Str.256 : {U64, Str, Int1, U8} = lowlevel StrFromUtf8 #Attr.2;
+    ret Str.256;
 
-procedure Str.9 (Str.73):
-    let Str.74 : {U64, Str, Int1, U8} = CallByName Str.43 Str.73;
-    let Str.251 : Int1 = StructAtIndex 2 Str.74;
-    if Str.251 then
-        let Str.253 : Str = StructAtIndex 1 Str.74;
-        let Str.252 : [C {U64, U8}, C Str] = TagId(1) Str.253;
-        ret Str.252;
+procedure Str.9 (Str.74):
+    let Str.75 : {U64, Str, Int1, U8} = CallByName Str.43 Str.74;
+    let Str.253 : Int1 = StructAtIndex 2 Str.75;
+    if Str.253 then
+        let Str.255 : Str = StructAtIndex 1 Str.75;
+        let Str.254 : [C {U64, U8}, C Str] = TagId(1) Str.255;
+        ret Str.254;
     else
-        let Str.249 : U64 = StructAtIndex 0 Str.74;
-        let Str.250 : U8 = StructAtIndex 3 Str.74;
-        let #Derived_gen.3 : Str = StructAtIndex 1 Str.74;
+        let Str.251 : U64 = StructAtIndex 0 Str.75;
+        let Str.252 : U8 = StructAtIndex 3 Str.75;
+        let #Derived_gen.3 : Str = StructAtIndex 1 Str.75;
         dec #Derived_gen.3;
-        let Str.248 : {U64, U8} = Struct {Str.249, Str.250};
-        let Str.246 : [C {U64, U8}, C Str] = TagId(0) Str.248;
-        ret Str.246;
+        let Str.250 : {U64, U8} = Struct {Str.251, Str.252};
+        let Str.248 : [C {U64, U8}, C Str] = TagId(0) Str.250;
+        ret Str.248;
 
 procedure Test.20 (Test.56):
     let Test.259 : Str = CallByName Encode.23 Test.56;

--- a/crates/compiler/test_mono/generated/encode_derived_tag_one_field_string.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_tag_one_field_string.txt
@@ -110,32 +110,32 @@ procedure Num.96 (#Attr.2):
     ret Num.283;
 
 procedure Str.12 (#Attr.2):
-    let Str.256 : List U8 = lowlevel StrToUtf8 #Attr.2;
-    ret Str.256;
+    let Str.258 : List U8 = lowlevel StrToUtf8 #Attr.2;
+    ret Str.258;
 
 procedure Str.36 (#Attr.2):
-    let Str.257 : U64 = lowlevel StrCountUtf8Bytes #Attr.2;
-    ret Str.257;
+    let Str.259 : U64 = lowlevel StrCountUtf8Bytes #Attr.2;
+    ret Str.259;
 
 procedure Str.43 (#Attr.2):
-    let Str.254 : {U64, Str, Int1, U8} = lowlevel StrFromUtf8 #Attr.2;
-    ret Str.254;
+    let Str.256 : {U64, Str, Int1, U8} = lowlevel StrFromUtf8 #Attr.2;
+    ret Str.256;
 
-procedure Str.9 (Str.73):
-    let Str.74 : {U64, Str, Int1, U8} = CallByName Str.43 Str.73;
-    let Str.251 : Int1 = StructAtIndex 2 Str.74;
-    if Str.251 then
-        let Str.253 : Str = StructAtIndex 1 Str.74;
-        let Str.252 : [C {U64, U8}, C Str] = TagId(1) Str.253;
-        ret Str.252;
+procedure Str.9 (Str.74):
+    let Str.75 : {U64, Str, Int1, U8} = CallByName Str.43 Str.74;
+    let Str.253 : Int1 = StructAtIndex 2 Str.75;
+    if Str.253 then
+        let Str.255 : Str = StructAtIndex 1 Str.75;
+        let Str.254 : [C {U64, U8}, C Str] = TagId(1) Str.255;
+        ret Str.254;
     else
-        let Str.249 : U64 = StructAtIndex 0 Str.74;
-        let Str.250 : U8 = StructAtIndex 3 Str.74;
-        let #Derived_gen.27 : Str = StructAtIndex 1 Str.74;
+        let Str.251 : U64 = StructAtIndex 0 Str.75;
+        let Str.252 : U8 = StructAtIndex 3 Str.75;
+        let #Derived_gen.27 : Str = StructAtIndex 1 Str.75;
         dec #Derived_gen.27;
-        let Str.248 : {U64, U8} = Struct {Str.249, Str.250};
-        let Str.246 : [C {U64, U8}, C Str] = TagId(0) Str.248;
-        ret Str.246;
+        let Str.250 : {U64, U8} = Struct {Str.251, Str.252};
+        let Str.248 : [C {U64, U8}, C Str] = TagId(0) Str.250;
+        ret Str.248;
 
 procedure Test.20 (Test.56):
     let Test.297 : Str = CallByName Encode.23 Test.56;

--- a/crates/compiler/test_mono/generated/encode_derived_tag_two_payloads_string.txt
+++ b/crates/compiler/test_mono/generated/encode_derived_tag_two_payloads_string.txt
@@ -113,32 +113,32 @@ procedure Num.96 (#Attr.2):
     ret Num.283;
 
 procedure Str.12 (#Attr.2):
-    let Str.256 : List U8 = lowlevel StrToUtf8 #Attr.2;
-    ret Str.256;
+    let Str.258 : List U8 = lowlevel StrToUtf8 #Attr.2;
+    ret Str.258;
 
 procedure Str.36 (#Attr.2):
-    let Str.257 : U64 = lowlevel StrCountUtf8Bytes #Attr.2;
-    ret Str.257;
+    let Str.259 : U64 = lowlevel StrCountUtf8Bytes #Attr.2;
+    ret Str.259;
 
 procedure Str.43 (#Attr.2):
-    let Str.254 : {U64, Str, Int1, U8} = lowlevel StrFromUtf8 #Attr.2;
-    ret Str.254;
+    let Str.256 : {U64, Str, Int1, U8} = lowlevel StrFromUtf8 #Attr.2;
+    ret Str.256;
 
-procedure Str.9 (Str.73):
-    let Str.74 : {U64, Str, Int1, U8} = CallByName Str.43 Str.73;
-    let Str.251 : Int1 = StructAtIndex 2 Str.74;
-    if Str.251 then
-        let Str.253 : Str = StructAtIndex 1 Str.74;
-        let Str.252 : [C {U64, U8}, C Str] = TagId(1) Str.253;
-        ret Str.252;
+procedure Str.9 (Str.74):
+    let Str.75 : {U64, Str, Int1, U8} = CallByName Str.43 Str.74;
+    let Str.253 : Int1 = StructAtIndex 2 Str.75;
+    if Str.253 then
+        let Str.255 : Str = StructAtIndex 1 Str.75;
+        let Str.254 : [C {U64, U8}, C Str] = TagId(1) Str.255;
+        ret Str.254;
     else
-        let Str.249 : U64 = StructAtIndex 0 Str.74;
-        let Str.250 : U8 = StructAtIndex 3 Str.74;
-        let #Derived_gen.28 : Str = StructAtIndex 1 Str.74;
+        let Str.251 : U64 = StructAtIndex 0 Str.75;
+        let Str.252 : U8 = StructAtIndex 3 Str.75;
+        let #Derived_gen.28 : Str = StructAtIndex 1 Str.75;
         dec #Derived_gen.28;
-        let Str.248 : {U64, U8} = Struct {Str.249, Str.250};
-        let Str.246 : [C {U64, U8}, C Str] = TagId(0) Str.248;
-        ret Str.246;
+        let Str.250 : {U64, U8} = Struct {Str.251, Str.252};
+        let Str.248 : [C {U64, U8}, C Str] = TagId(0) Str.250;
+        ret Str.248;
 
 procedure Test.20 (Test.56):
     let Test.301 : Str = CallByName Encode.23 Test.56;

--- a/crates/compiler/test_mono/generated/inspect_derived_dict.txt
+++ b/crates/compiler/test_mono/generated/inspect_derived_dict.txt
@@ -1204,188 +1204,188 @@ procedure Num.96 (#Attr.2):
     ret Num.440;
 
 procedure Str.12 (#Attr.2):
-    let Str.248 : List U8 = lowlevel StrToUtf8 #Attr.2;
-    ret Str.248;
+    let Str.250 : List U8 = lowlevel StrToUtf8 #Attr.2;
+    ret Str.250;
 
 procedure Str.20 (#Attr.2):
-    let Str.317 : Str = lowlevel StrWithCapacity #Attr.2;
-    ret Str.317;
+    let Str.319 : Str = lowlevel StrWithCapacity #Attr.2;
+    ret Str.319;
 
 procedure Str.3 (#Attr.2, #Attr.3):
-    let Str.249 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
-    ret Str.249;
+    let Str.251 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
+    ret Str.251;
 
 procedure Str.35 (#Attr.2, #Attr.3):
-    let Str.307 : U8 = lowlevel StrGetUnsafe #Attr.2 #Attr.3;
-    ret Str.307;
+    let Str.309 : U8 = lowlevel StrGetUnsafe #Attr.2 #Attr.3;
+    ret Str.309;
 
 procedure Str.36 (#Attr.2):
-    let Str.269 : U64 = lowlevel StrCountUtf8Bytes #Attr.2;
-    ret Str.269;
+    let Str.271 : U64 = lowlevel StrCountUtf8Bytes #Attr.2;
+    ret Str.271;
 
 procedure Str.37 (#Attr.2, #Attr.3, #Attr.4):
-    let Str.267 : Str = lowlevel StrSubstringUnsafe #Attr.2 #Attr.3 #Attr.4;
-    ret Str.267;
+    let Str.269 : Str = lowlevel StrSubstringUnsafe #Attr.2 #Attr.3 #Attr.4;
+    ret Str.269;
 
-procedure Str.38 (Str.112, Str.113):
-    let Str.263 : [C , C U64] = CallByName Str.57 Str.112 Str.113;
-    let Str.276 : U8 = 1i64;
-    let Str.277 : U8 = GetTagId Str.263;
-    let Str.278 : Int1 = lowlevel Eq Str.276 Str.277;
-    if Str.278 then
-        let Str.114 : U64 = UnionAtIndex (Id 1) (Index 0) Str.263;
-        let Str.272 : U64 = CallByName Str.36 Str.112;
-        let Str.273 : U64 = CallByName Str.36 Str.113;
-        let Str.271 : U64 = CallByName Num.20 Str.272 Str.273;
-        let Str.115 : U64 = CallByName Num.20 Str.271 Str.114;
-        let Str.270 : U64 = 0i64;
-        inc Str.112;
-        let Str.116 : Str = CallByName Str.37 Str.112 Str.270 Str.114;
-        let Str.268 : U64 = CallByName Str.36 Str.113;
-        let Str.266 : U64 = CallByName Num.51 Str.114 Str.268;
-        let Str.117 : Str = CallByName Str.37 Str.112 Str.266 Str.115;
-        let Str.265 : {Str, Str} = Struct {Str.117, Str.116};
-        let Str.264 : [C {}, C {Str, Str}] = TagId(1) Str.265;
-        ret Str.264;
+procedure Str.38 (Str.113, Str.114):
+    let Str.265 : [C , C U64] = CallByName Str.58 Str.113 Str.114;
+    let Str.278 : U8 = 1i64;
+    let Str.279 : U8 = GetTagId Str.265;
+    let Str.280 : Int1 = lowlevel Eq Str.278 Str.279;
+    if Str.280 then
+        let Str.115 : U64 = UnionAtIndex (Id 1) (Index 0) Str.265;
+        let Str.274 : U64 = CallByName Str.36 Str.113;
+        let Str.275 : U64 = CallByName Str.36 Str.114;
+        let Str.273 : U64 = CallByName Num.20 Str.274 Str.275;
+        let Str.116 : U64 = CallByName Num.20 Str.273 Str.115;
+        let Str.272 : U64 = 0i64;
+        inc Str.113;
+        let Str.117 : Str = CallByName Str.37 Str.113 Str.272 Str.115;
+        let Str.270 : U64 = CallByName Str.36 Str.114;
+        let Str.268 : U64 = CallByName Num.51 Str.115 Str.270;
+        let Str.118 : Str = CallByName Str.37 Str.113 Str.268 Str.116;
+        let Str.267 : {Str, Str} = Struct {Str.118, Str.117};
+        let Str.266 : [C {}, C {Str, Str}] = TagId(1) Str.267;
+        ret Str.266;
     else
-        dec Str.112;
-        let Str.275 : {} = Struct {};
-        let Str.274 : [C {}, C {Str, Str}] = TagId(0) Str.275;
-        ret Str.274;
+        dec Str.113;
+        let Str.277 : {} = Struct {};
+        let Str.276 : [C {}, C {Str, Str}] = TagId(0) Str.277;
+        ret Str.276;
 
-procedure Str.45 (Str.91, Str.92, Str.93):
-    inc Str.91;
-    let Str.345 : [C {}, C {Str, Str}] = CallByName Str.38 Str.91 Str.92;
-    let Str.353 : U8 = 1i64;
-    let Str.354 : U8 = GetTagId Str.345;
-    let Str.355 : Int1 = lowlevel Eq Str.353 Str.354;
-    if Str.355 then
-        let Str.352 : {Str, Str} = UnionAtIndex (Id 1) (Index 0) Str.345;
-        let Str.95 : Str = StructAtIndex 0 Str.352;
-        let Str.94 : Str = StructAtIndex 1 Str.352;
-        let Str.350 : U64 = CallByName Str.36 Str.91;
-        dec Str.91;
-        let Str.349 : Str = CallByName Str.20 Str.350;
-        let Str.348 : Str = CallByName Str.3 Str.349 Str.94;
-        dec Str.94;
-        let Str.347 : Str = CallByName Str.3 Str.348 Str.93;
-        let Str.346 : Str = CallByName Str.56 Str.347 Str.95 Str.92 Str.93;
-        ret Str.346;
+procedure Str.45 (Str.92, Str.93, Str.94):
+    inc Str.92;
+    let Str.347 : [C {}, C {Str, Str}] = CallByName Str.38 Str.92 Str.93;
+    let Str.355 : U8 = 1i64;
+    let Str.356 : U8 = GetTagId Str.347;
+    let Str.357 : Int1 = lowlevel Eq Str.355 Str.356;
+    if Str.357 then
+        let Str.354 : {Str, Str} = UnionAtIndex (Id 1) (Index 0) Str.347;
+        let Str.96 : Str = StructAtIndex 0 Str.354;
+        let Str.95 : Str = StructAtIndex 1 Str.354;
+        let Str.352 : U64 = CallByName Str.36 Str.92;
+        dec Str.92;
+        let Str.351 : Str = CallByName Str.20 Str.352;
+        let Str.350 : Str = CallByName Str.3 Str.351 Str.95;
+        dec Str.95;
+        let Str.349 : Str = CallByName Str.3 Str.350 Str.94;
+        let Str.348 : Str = CallByName Str.57 Str.349 Str.96 Str.93 Str.94;
+        ret Str.348;
     else
-        dec Str.345;
-        ret Str.91;
+        dec Str.347;
+        ret Str.92;
 
-procedure Str.56 (#Derived_gen.9, #Derived_gen.10, #Derived_gen.11, #Derived_gen.12):
-    joinpoint Str.253 Str.96 Str.97 Str.98 Str.99:
-        inc Str.97;
-        let Str.254 : [C {}, C {Str, Str}] = CallByName Str.38 Str.97 Str.98;
-        let Str.260 : U8 = 1i64;
-        let Str.261 : U8 = GetTagId Str.254;
-        let Str.262 : Int1 = lowlevel Eq Str.260 Str.261;
-        if Str.262 then
-            dec Str.97;
-            let Str.259 : {Str, Str} = UnionAtIndex (Id 1) (Index 0) Str.254;
-            let Str.101 : Str = StructAtIndex 0 Str.259;
-            let Str.100 : Str = StructAtIndex 1 Str.259;
-            let Str.257 : Str = CallByName Str.3 Str.96 Str.100;
-            dec Str.100;
-            let Str.256 : Str = CallByName Str.3 Str.257 Str.99;
-            jump Str.253 Str.256 Str.101 Str.98 Str.99;
-        else
+procedure Str.57 (#Derived_gen.9, #Derived_gen.10, #Derived_gen.11, #Derived_gen.12):
+    joinpoint Str.255 Str.97 Str.98 Str.99 Str.100:
+        inc Str.98;
+        let Str.256 : [C {}, C {Str, Str}] = CallByName Str.38 Str.98 Str.99;
+        let Str.262 : U8 = 1i64;
+        let Str.263 : U8 = GetTagId Str.256;
+        let Str.264 : Int1 = lowlevel Eq Str.262 Str.263;
+        if Str.264 then
             dec Str.98;
+            let Str.261 : {Str, Str} = UnionAtIndex (Id 1) (Index 0) Str.256;
+            let Str.102 : Str = StructAtIndex 0 Str.261;
+            let Str.101 : Str = StructAtIndex 1 Str.261;
+            let Str.259 : Str = CallByName Str.3 Str.97 Str.101;
+            dec Str.101;
+            let Str.258 : Str = CallByName Str.3 Str.259 Str.100;
+            jump Str.255 Str.258 Str.102 Str.99 Str.100;
+        else
+            dec Str.100;
             dec Str.99;
-            dec Str.254;
-            let Str.258 : Str = CallByName Str.3 Str.96 Str.97;
-            dec Str.97;
-            ret Str.258;
+            dec Str.256;
+            let Str.260 : Str = CallByName Str.3 Str.97 Str.98;
+            dec Str.98;
+            ret Str.260;
     in
     inc #Derived_gen.12;
     inc #Derived_gen.11;
-    jump Str.253 #Derived_gen.9 #Derived_gen.10 #Derived_gen.11 #Derived_gen.12;
+    jump Str.255 #Derived_gen.9 #Derived_gen.10 #Derived_gen.11 #Derived_gen.12;
 
-procedure Str.57 (Str.121, Str.122):
-    let Str.123 : U64 = CallByName Str.36 Str.121;
+procedure Str.58 (Str.122, Str.123):
     let Str.124 : U64 = CallByName Str.36 Str.122;
-    let Str.125 : U64 = CallByName Num.77 Str.123 Str.124;
-    let Str.280 : U64 = 0i64;
-    let Str.279 : [C , C U64] = CallByName Str.58 Str.121 Str.122 Str.280 Str.125;
-    ret Str.279;
+    let Str.125 : U64 = CallByName Str.36 Str.123;
+    let Str.126 : U64 = CallByName Num.77 Str.124 Str.125;
+    let Str.282 : U64 = 0i64;
+    let Str.281 : [C , C U64] = CallByName Str.59 Str.122 Str.123 Str.282 Str.126;
+    ret Str.281;
 
-procedure Str.58 (#Derived_gen.13, #Derived_gen.14, #Derived_gen.15, #Derived_gen.16):
-    joinpoint Str.281 Str.126 Str.127 Str.128 Str.129:
-        let Str.283 : Int1 = CallByName Num.23 Str.128 Str.129;
-        if Str.283 then
-            let Str.287 : Int1 = CallByName Str.62 Str.126 Str.128 Str.127;
-            if Str.287 then
+procedure Str.59 (#Derived_gen.13, #Derived_gen.14, #Derived_gen.15, #Derived_gen.16):
+    joinpoint Str.283 Str.127 Str.128 Str.129 Str.130:
+        let Str.285 : Int1 = CallByName Num.23 Str.129 Str.130;
+        if Str.285 then
+            let Str.289 : Int1 = CallByName Str.63 Str.127 Str.129 Str.128;
+            if Str.289 then
                 dec Str.127;
-                dec Str.126;
-                let Str.288 : [C , C U64] = TagId(1) Str.128;
-                ret Str.288;
+                dec Str.128;
+                let Str.290 : [C , C U64] = TagId(1) Str.129;
+                ret Str.290;
             else
-                let Str.286 : U64 = 1i64;
-                let Str.285 : U64 = CallByName Num.51 Str.128 Str.286;
-                jump Str.281 Str.126 Str.127 Str.285 Str.129;
+                let Str.288 : U64 = 1i64;
+                let Str.287 : U64 = CallByName Num.51 Str.129 Str.288;
+                jump Str.283 Str.127 Str.128 Str.287 Str.130;
         else
             dec Str.127;
-            dec Str.126;
-            let Str.282 : [C , C U64] = TagId(0) ;
-            ret Str.282;
+            dec Str.128;
+            let Str.284 : [C , C U64] = TagId(0) ;
+            ret Str.284;
     in
     inc #Derived_gen.14;
     inc #Derived_gen.13;
-    jump Str.281 #Derived_gen.13 #Derived_gen.14 #Derived_gen.15 #Derived_gen.16;
+    jump Str.283 #Derived_gen.13 #Derived_gen.14 #Derived_gen.15 #Derived_gen.16;
 
-procedure Str.61 (Str.152, Str.153):
-    let Str.312 : Int1 = CallByName Num.22 Str.152 Str.153;
-    if Str.312 then
-        ret Str.152;
-    else
+procedure Str.62 (Str.153, Str.154):
+    let Str.314 : Int1 = CallByName Num.22 Str.153 Str.154;
+    if Str.314 then
         ret Str.153;
-
-procedure Str.62 (Str.154, Str.155, Str.156):
-    let Str.157 : U64 = CallByName Str.36 Str.154;
-    let Str.158 : U64 = CallByName Str.36 Str.156;
-    let Str.310 : U64 = CallByName Num.53 Str.155 Str.158;
-    let Str.159 : U64 = CallByName Str.61 Str.310 Str.157;
-    let Str.309 : U64 = 0i64;
-    inc Str.156;
-    inc Str.154;
-    let Str.290 : {U64, Str, U64, Str, U64, U64} = Struct {Str.159, Str.154, Str.155, Str.156, Str.309, Str.158};
-    let Str.289 : Int1 = CallByName Str.63 Str.290;
-    ret Str.289;
-
-procedure Str.63 (Str.160):
-    let Str.166 : U64 = StructAtIndex 0 Str.160;
-    let Str.161 : Str = StructAtIndex 1 Str.160;
-    let Str.162 : U64 = StructAtIndex 2 Str.160;
-    let Str.163 : Str = StructAtIndex 3 Str.160;
-    let Str.164 : U64 = StructAtIndex 4 Str.160;
-    let Str.165 : U64 = StructAtIndex 5 Str.160;
-    let Str.167 : Int1 = CallByName Num.25 Str.162 Str.166;
-    if Str.167 then
-        dec Str.163;
-        dec Str.161;
-        let Str.168 : Int1 = CallByName Bool.9 Str.164 Str.165;
-        ret Str.168;
     else
-        let Str.305 : U8 = CallByName Str.35 Str.161 Str.162;
-        let Str.306 : U8 = CallByName Str.35 Str.163 Str.164;
-        let Str.169 : Int1 = CallByName Bool.9 Str.305 Str.306;
-        let Str.295 : U64 = StructAtIndex 0 Str.160;
-        let Str.296 : Str = StructAtIndex 1 Str.160;
-        let Str.298 : Str = StructAtIndex 3 Str.160;
-        let Str.300 : U64 = StructAtIndex 5 Str.160;
-        let Str.304 : U64 = 1i64;
-        let Str.302 : U64 = CallByName Num.51 Str.164 Str.304;
-        let Str.303 : U64 = 1i64;
-        let Str.301 : U64 = CallByName Num.51 Str.162 Str.303;
-        let Str.294 : {U64, Str, U64, Str, U64, U64} = Struct {Str.295, Str.296, Str.301, Str.298, Str.302, Str.300};
-        let Str.170 : Int1 = CallByName Str.63 Str.294;
-        if Str.169 then
-            ret Str.170;
+        ret Str.154;
+
+procedure Str.63 (Str.155, Str.156, Str.157):
+    let Str.158 : U64 = CallByName Str.36 Str.155;
+    let Str.159 : U64 = CallByName Str.36 Str.157;
+    let Str.312 : U64 = CallByName Num.53 Str.156 Str.159;
+    let Str.160 : U64 = CallByName Str.62 Str.312 Str.158;
+    let Str.311 : U64 = 0i64;
+    inc Str.157;
+    inc Str.155;
+    let Str.292 : {U64, Str, U64, Str, U64, U64} = Struct {Str.160, Str.155, Str.156, Str.157, Str.311, Str.159};
+    let Str.291 : Int1 = CallByName Str.64 Str.292;
+    ret Str.291;
+
+procedure Str.64 (Str.161):
+    let Str.167 : U64 = StructAtIndex 0 Str.161;
+    let Str.162 : Str = StructAtIndex 1 Str.161;
+    let Str.163 : U64 = StructAtIndex 2 Str.161;
+    let Str.164 : Str = StructAtIndex 3 Str.161;
+    let Str.165 : U64 = StructAtIndex 4 Str.161;
+    let Str.166 : U64 = StructAtIndex 5 Str.161;
+    let Str.168 : Int1 = CallByName Num.25 Str.163 Str.167;
+    if Str.168 then
+        dec Str.162;
+        dec Str.164;
+        let Str.169 : Int1 = CallByName Bool.9 Str.165 Str.166;
+        ret Str.169;
+    else
+        let Str.307 : U8 = CallByName Str.35 Str.162 Str.163;
+        let Str.308 : U8 = CallByName Str.35 Str.164 Str.165;
+        let Str.170 : Int1 = CallByName Bool.9 Str.307 Str.308;
+        let Str.297 : U64 = StructAtIndex 0 Str.161;
+        let Str.298 : Str = StructAtIndex 1 Str.161;
+        let Str.300 : Str = StructAtIndex 3 Str.161;
+        let Str.302 : U64 = StructAtIndex 5 Str.161;
+        let Str.306 : U64 = 1i64;
+        let Str.304 : U64 = CallByName Num.51 Str.165 Str.306;
+        let Str.305 : U64 = 1i64;
+        let Str.303 : U64 = CallByName Num.51 Str.163 Str.305;
+        let Str.296 : {U64, Str, U64, Str, U64, U64} = Struct {Str.297, Str.298, Str.303, Str.300, Str.304, Str.302};
+        let Str.171 : Int1 = CallByName Str.64 Str.296;
+        if Str.170 then
+            ret Str.171;
         else
-            let Str.292 : Int1 = CallByName Bool.1;
-            ret Str.292;
+            let Str.294 : Int1 = CallByName Bool.1;
+            ret Str.294;
 
 procedure Test.0 ():
     let Test.8 : Str = "a";

--- a/crates/compiler/test_mono/generated/inspect_derived_list.txt
+++ b/crates/compiler/test_mono/generated/inspect_derived_list.txt
@@ -163,8 +163,8 @@ procedure Num.96 (#Attr.2):
     ret Num.283;
 
 procedure Str.3 (#Attr.2, #Attr.3):
-    let Str.246 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
-    ret Str.246;
+    let Str.248 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
+    ret Str.248;
 
 procedure Test.0 ():
     let Test.2 : List I64 = Array [1i64, 2i64, 3i64];

--- a/crates/compiler/test_mono/generated/inspect_derived_nested_record_string.txt
+++ b/crates/compiler/test_mono/generated/inspect_derived_nested_record_string.txt
@@ -322,184 +322,184 @@ procedure Num.77 (#Attr.2, #Attr.3):
     ret Num.295;
 
 procedure Str.20 (#Attr.2):
-    let Str.315 : Str = lowlevel StrWithCapacity #Attr.2;
-    ret Str.315;
+    let Str.317 : Str = lowlevel StrWithCapacity #Attr.2;
+    ret Str.317;
 
 procedure Str.3 (#Attr.2, #Attr.3):
-    let Str.247 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
-    ret Str.247;
+    let Str.249 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
+    ret Str.249;
 
 procedure Str.35 (#Attr.2, #Attr.3):
-    let Str.305 : U8 = lowlevel StrGetUnsafe #Attr.2 #Attr.3;
-    ret Str.305;
+    let Str.307 : U8 = lowlevel StrGetUnsafe #Attr.2 #Attr.3;
+    ret Str.307;
 
 procedure Str.36 (#Attr.2):
-    let Str.267 : U64 = lowlevel StrCountUtf8Bytes #Attr.2;
-    ret Str.267;
+    let Str.269 : U64 = lowlevel StrCountUtf8Bytes #Attr.2;
+    ret Str.269;
 
 procedure Str.37 (#Attr.2, #Attr.3, #Attr.4):
-    let Str.265 : Str = lowlevel StrSubstringUnsafe #Attr.2 #Attr.3 #Attr.4;
-    ret Str.265;
+    let Str.267 : Str = lowlevel StrSubstringUnsafe #Attr.2 #Attr.3 #Attr.4;
+    ret Str.267;
 
-procedure Str.38 (Str.112, Str.113):
-    let Str.261 : [C , C U64] = CallByName Str.57 Str.112 Str.113;
-    let Str.274 : U8 = 1i64;
-    let Str.275 : U8 = GetTagId Str.261;
-    let Str.276 : Int1 = lowlevel Eq Str.274 Str.275;
-    if Str.276 then
-        let Str.114 : U64 = UnionAtIndex (Id 1) (Index 0) Str.261;
-        let Str.270 : U64 = CallByName Str.36 Str.112;
-        let Str.271 : U64 = CallByName Str.36 Str.113;
-        let Str.269 : U64 = CallByName Num.20 Str.270 Str.271;
-        let Str.115 : U64 = CallByName Num.20 Str.269 Str.114;
-        let Str.268 : U64 = 0i64;
-        inc Str.112;
-        let Str.116 : Str = CallByName Str.37 Str.112 Str.268 Str.114;
-        let Str.266 : U64 = CallByName Str.36 Str.113;
-        let Str.264 : U64 = CallByName Num.51 Str.114 Str.266;
-        let Str.117 : Str = CallByName Str.37 Str.112 Str.264 Str.115;
-        let Str.263 : {Str, Str} = Struct {Str.117, Str.116};
-        let Str.262 : [C {}, C {Str, Str}] = TagId(1) Str.263;
-        ret Str.262;
+procedure Str.38 (Str.113, Str.114):
+    let Str.263 : [C , C U64] = CallByName Str.58 Str.113 Str.114;
+    let Str.276 : U8 = 1i64;
+    let Str.277 : U8 = GetTagId Str.263;
+    let Str.278 : Int1 = lowlevel Eq Str.276 Str.277;
+    if Str.278 then
+        let Str.115 : U64 = UnionAtIndex (Id 1) (Index 0) Str.263;
+        let Str.272 : U64 = CallByName Str.36 Str.113;
+        let Str.273 : U64 = CallByName Str.36 Str.114;
+        let Str.271 : U64 = CallByName Num.20 Str.272 Str.273;
+        let Str.116 : U64 = CallByName Num.20 Str.271 Str.115;
+        let Str.270 : U64 = 0i64;
+        inc Str.113;
+        let Str.117 : Str = CallByName Str.37 Str.113 Str.270 Str.115;
+        let Str.268 : U64 = CallByName Str.36 Str.114;
+        let Str.266 : U64 = CallByName Num.51 Str.115 Str.268;
+        let Str.118 : Str = CallByName Str.37 Str.113 Str.266 Str.116;
+        let Str.265 : {Str, Str} = Struct {Str.118, Str.117};
+        let Str.264 : [C {}, C {Str, Str}] = TagId(1) Str.265;
+        ret Str.264;
     else
-        dec Str.112;
-        let Str.273 : {} = Struct {};
-        let Str.272 : [C {}, C {Str, Str}] = TagId(0) Str.273;
-        ret Str.272;
+        dec Str.113;
+        let Str.275 : {} = Struct {};
+        let Str.274 : [C {}, C {Str, Str}] = TagId(0) Str.275;
+        ret Str.274;
 
-procedure Str.45 (Str.91, Str.92, Str.93):
-    inc Str.91;
-    let Str.343 : [C {}, C {Str, Str}] = CallByName Str.38 Str.91 Str.92;
-    let Str.351 : U8 = 1i64;
-    let Str.352 : U8 = GetTagId Str.343;
-    let Str.353 : Int1 = lowlevel Eq Str.351 Str.352;
-    if Str.353 then
-        let Str.350 : {Str, Str} = UnionAtIndex (Id 1) (Index 0) Str.343;
-        let Str.95 : Str = StructAtIndex 0 Str.350;
-        let Str.94 : Str = StructAtIndex 1 Str.350;
-        let Str.348 : U64 = CallByName Str.36 Str.91;
-        dec Str.91;
-        let Str.347 : Str = CallByName Str.20 Str.348;
-        let Str.346 : Str = CallByName Str.3 Str.347 Str.94;
-        dec Str.94;
-        let Str.345 : Str = CallByName Str.3 Str.346 Str.93;
-        let Str.344 : Str = CallByName Str.56 Str.345 Str.95 Str.92 Str.93;
-        ret Str.344;
+procedure Str.45 (Str.92, Str.93, Str.94):
+    inc Str.92;
+    let Str.345 : [C {}, C {Str, Str}] = CallByName Str.38 Str.92 Str.93;
+    let Str.353 : U8 = 1i64;
+    let Str.354 : U8 = GetTagId Str.345;
+    let Str.355 : Int1 = lowlevel Eq Str.353 Str.354;
+    if Str.355 then
+        let Str.352 : {Str, Str} = UnionAtIndex (Id 1) (Index 0) Str.345;
+        let Str.96 : Str = StructAtIndex 0 Str.352;
+        let Str.95 : Str = StructAtIndex 1 Str.352;
+        let Str.350 : U64 = CallByName Str.36 Str.92;
+        dec Str.92;
+        let Str.349 : Str = CallByName Str.20 Str.350;
+        let Str.348 : Str = CallByName Str.3 Str.349 Str.95;
+        dec Str.95;
+        let Str.347 : Str = CallByName Str.3 Str.348 Str.94;
+        let Str.346 : Str = CallByName Str.57 Str.347 Str.96 Str.93 Str.94;
+        ret Str.346;
     else
-        dec Str.343;
-        ret Str.91;
+        dec Str.345;
+        ret Str.92;
 
-procedure Str.56 (#Derived_gen.24, #Derived_gen.25, #Derived_gen.26, #Derived_gen.27):
-    joinpoint Str.251 Str.96 Str.97 Str.98 Str.99:
-        inc Str.97;
-        let Str.252 : [C {}, C {Str, Str}] = CallByName Str.38 Str.97 Str.98;
-        let Str.258 : U8 = 1i64;
-        let Str.259 : U8 = GetTagId Str.252;
-        let Str.260 : Int1 = lowlevel Eq Str.258 Str.259;
-        if Str.260 then
-            dec Str.97;
-            let Str.257 : {Str, Str} = UnionAtIndex (Id 1) (Index 0) Str.252;
-            let Str.101 : Str = StructAtIndex 0 Str.257;
-            let Str.100 : Str = StructAtIndex 1 Str.257;
-            let Str.255 : Str = CallByName Str.3 Str.96 Str.100;
-            dec Str.100;
-            let Str.254 : Str = CallByName Str.3 Str.255 Str.99;
-            jump Str.251 Str.254 Str.101 Str.98 Str.99;
-        else
+procedure Str.57 (#Derived_gen.24, #Derived_gen.25, #Derived_gen.26, #Derived_gen.27):
+    joinpoint Str.253 Str.97 Str.98 Str.99 Str.100:
+        inc Str.98;
+        let Str.254 : [C {}, C {Str, Str}] = CallByName Str.38 Str.98 Str.99;
+        let Str.260 : U8 = 1i64;
+        let Str.261 : U8 = GetTagId Str.254;
+        let Str.262 : Int1 = lowlevel Eq Str.260 Str.261;
+        if Str.262 then
             dec Str.98;
-            dec Str.252;
+            let Str.259 : {Str, Str} = UnionAtIndex (Id 1) (Index 0) Str.254;
+            let Str.102 : Str = StructAtIndex 0 Str.259;
+            let Str.101 : Str = StructAtIndex 1 Str.259;
+            let Str.257 : Str = CallByName Str.3 Str.97 Str.101;
+            dec Str.101;
+            let Str.256 : Str = CallByName Str.3 Str.257 Str.100;
+            jump Str.253 Str.256 Str.102 Str.99 Str.100;
+        else
+            dec Str.100;
             dec Str.99;
-            let Str.256 : Str = CallByName Str.3 Str.96 Str.97;
-            dec Str.97;
-            ret Str.256;
+            dec Str.254;
+            let Str.258 : Str = CallByName Str.3 Str.97 Str.98;
+            dec Str.98;
+            ret Str.258;
     in
     inc #Derived_gen.27;
     inc #Derived_gen.26;
-    jump Str.251 #Derived_gen.24 #Derived_gen.25 #Derived_gen.26 #Derived_gen.27;
+    jump Str.253 #Derived_gen.24 #Derived_gen.25 #Derived_gen.26 #Derived_gen.27;
 
-procedure Str.57 (Str.121, Str.122):
-    let Str.123 : U64 = CallByName Str.36 Str.121;
+procedure Str.58 (Str.122, Str.123):
     let Str.124 : U64 = CallByName Str.36 Str.122;
-    let Str.125 : U64 = CallByName Num.77 Str.123 Str.124;
-    let Str.278 : U64 = 0i64;
-    let Str.277 : [C , C U64] = CallByName Str.58 Str.121 Str.122 Str.278 Str.125;
-    ret Str.277;
+    let Str.125 : U64 = CallByName Str.36 Str.123;
+    let Str.126 : U64 = CallByName Num.77 Str.124 Str.125;
+    let Str.280 : U64 = 0i64;
+    let Str.279 : [C , C U64] = CallByName Str.59 Str.122 Str.123 Str.280 Str.126;
+    ret Str.279;
 
-procedure Str.58 (#Derived_gen.28, #Derived_gen.29, #Derived_gen.30, #Derived_gen.31):
-    joinpoint Str.279 Str.126 Str.127 Str.128 Str.129:
-        let Str.281 : Int1 = CallByName Num.23 Str.128 Str.129;
-        if Str.281 then
-            let Str.285 : Int1 = CallByName Str.62 Str.126 Str.128 Str.127;
-            if Str.285 then
+procedure Str.59 (#Derived_gen.28, #Derived_gen.29, #Derived_gen.30, #Derived_gen.31):
+    joinpoint Str.281 Str.127 Str.128 Str.129 Str.130:
+        let Str.283 : Int1 = CallByName Num.23 Str.129 Str.130;
+        if Str.283 then
+            let Str.287 : Int1 = CallByName Str.63 Str.127 Str.129 Str.128;
+            if Str.287 then
                 dec Str.127;
-                dec Str.126;
-                let Str.286 : [C , C U64] = TagId(1) Str.128;
-                ret Str.286;
+                dec Str.128;
+                let Str.288 : [C , C U64] = TagId(1) Str.129;
+                ret Str.288;
             else
-                let Str.284 : U64 = 1i64;
-                let Str.283 : U64 = CallByName Num.51 Str.128 Str.284;
-                jump Str.279 Str.126 Str.127 Str.283 Str.129;
+                let Str.286 : U64 = 1i64;
+                let Str.285 : U64 = CallByName Num.51 Str.129 Str.286;
+                jump Str.281 Str.127 Str.128 Str.285 Str.130;
         else
             dec Str.127;
-            dec Str.126;
-            let Str.280 : [C , C U64] = TagId(0) ;
-            ret Str.280;
+            dec Str.128;
+            let Str.282 : [C , C U64] = TagId(0) ;
+            ret Str.282;
     in
     inc #Derived_gen.29;
     inc #Derived_gen.28;
-    jump Str.279 #Derived_gen.28 #Derived_gen.29 #Derived_gen.30 #Derived_gen.31;
+    jump Str.281 #Derived_gen.28 #Derived_gen.29 #Derived_gen.30 #Derived_gen.31;
 
-procedure Str.61 (Str.152, Str.153):
-    let Str.310 : Int1 = CallByName Num.22 Str.152 Str.153;
-    if Str.310 then
-        ret Str.152;
-    else
+procedure Str.62 (Str.153, Str.154):
+    let Str.312 : Int1 = CallByName Num.22 Str.153 Str.154;
+    if Str.312 then
         ret Str.153;
-
-procedure Str.62 (Str.154, Str.155, Str.156):
-    let Str.157 : U64 = CallByName Str.36 Str.154;
-    let Str.158 : U64 = CallByName Str.36 Str.156;
-    let Str.308 : U64 = CallByName Num.53 Str.155 Str.158;
-    let Str.159 : U64 = CallByName Str.61 Str.308 Str.157;
-    let Str.307 : U64 = 0i64;
-    inc Str.156;
-    inc Str.154;
-    let Str.288 : {U64, Str, U64, Str, U64, U64} = Struct {Str.159, Str.154, Str.155, Str.156, Str.307, Str.158};
-    let Str.287 : Int1 = CallByName Str.63 Str.288;
-    ret Str.287;
-
-procedure Str.63 (Str.160):
-    let Str.166 : U64 = StructAtIndex 0 Str.160;
-    let Str.161 : Str = StructAtIndex 1 Str.160;
-    let Str.162 : U64 = StructAtIndex 2 Str.160;
-    let Str.163 : Str = StructAtIndex 3 Str.160;
-    let Str.164 : U64 = StructAtIndex 4 Str.160;
-    let Str.165 : U64 = StructAtIndex 5 Str.160;
-    let Str.167 : Int1 = CallByName Num.25 Str.162 Str.166;
-    if Str.167 then
-        dec Str.163;
-        dec Str.161;
-        let Str.168 : Int1 = CallByName Bool.9 Str.164 Str.165;
-        ret Str.168;
     else
-        let Str.303 : U8 = CallByName Str.35 Str.161 Str.162;
-        let Str.304 : U8 = CallByName Str.35 Str.163 Str.164;
-        let Str.169 : Int1 = CallByName Bool.9 Str.303 Str.304;
-        let Str.293 : U64 = StructAtIndex 0 Str.160;
-        let Str.294 : Str = StructAtIndex 1 Str.160;
-        let Str.296 : Str = StructAtIndex 3 Str.160;
-        let Str.298 : U64 = StructAtIndex 5 Str.160;
-        let Str.302 : U64 = 1i64;
-        let Str.300 : U64 = CallByName Num.51 Str.164 Str.302;
-        let Str.301 : U64 = 1i64;
-        let Str.299 : U64 = CallByName Num.51 Str.162 Str.301;
-        let Str.292 : {U64, Str, U64, Str, U64, U64} = Struct {Str.293, Str.294, Str.299, Str.296, Str.300, Str.298};
-        let Str.170 : Int1 = CallByName Str.63 Str.292;
-        if Str.169 then
-            ret Str.170;
+        ret Str.154;
+
+procedure Str.63 (Str.155, Str.156, Str.157):
+    let Str.158 : U64 = CallByName Str.36 Str.155;
+    let Str.159 : U64 = CallByName Str.36 Str.157;
+    let Str.310 : U64 = CallByName Num.53 Str.156 Str.159;
+    let Str.160 : U64 = CallByName Str.62 Str.310 Str.158;
+    let Str.309 : U64 = 0i64;
+    inc Str.157;
+    inc Str.155;
+    let Str.290 : {U64, Str, U64, Str, U64, U64} = Struct {Str.160, Str.155, Str.156, Str.157, Str.309, Str.159};
+    let Str.289 : Int1 = CallByName Str.64 Str.290;
+    ret Str.289;
+
+procedure Str.64 (Str.161):
+    let Str.167 : U64 = StructAtIndex 0 Str.161;
+    let Str.162 : Str = StructAtIndex 1 Str.161;
+    let Str.163 : U64 = StructAtIndex 2 Str.161;
+    let Str.164 : Str = StructAtIndex 3 Str.161;
+    let Str.165 : U64 = StructAtIndex 4 Str.161;
+    let Str.166 : U64 = StructAtIndex 5 Str.161;
+    let Str.168 : Int1 = CallByName Num.25 Str.163 Str.167;
+    if Str.168 then
+        dec Str.162;
+        dec Str.164;
+        let Str.169 : Int1 = CallByName Bool.9 Str.165 Str.166;
+        ret Str.169;
+    else
+        let Str.305 : U8 = CallByName Str.35 Str.162 Str.163;
+        let Str.306 : U8 = CallByName Str.35 Str.164 Str.165;
+        let Str.170 : Int1 = CallByName Bool.9 Str.305 Str.306;
+        let Str.295 : U64 = StructAtIndex 0 Str.161;
+        let Str.296 : Str = StructAtIndex 1 Str.161;
+        let Str.298 : Str = StructAtIndex 3 Str.161;
+        let Str.300 : U64 = StructAtIndex 5 Str.161;
+        let Str.304 : U64 = 1i64;
+        let Str.302 : U64 = CallByName Num.51 Str.165 Str.304;
+        let Str.303 : U64 = 1i64;
+        let Str.301 : U64 = CallByName Num.51 Str.163 Str.303;
+        let Str.294 : {U64, Str, U64, Str, U64, U64} = Struct {Str.295, Str.296, Str.301, Str.298, Str.302, Str.300};
+        let Str.171 : Int1 = CallByName Str.64 Str.294;
+        if Str.170 then
+            ret Str.171;
         else
-            let Str.290 : Int1 = CallByName Bool.1;
-            ret Str.290;
+            let Str.292 : Int1 = CallByName Bool.1;
+            ret Str.292;
 
 procedure Test.0 ():
     let Test.4 : Str = "bar";

--- a/crates/compiler/test_mono/generated/inspect_derived_record.txt
+++ b/crates/compiler/test_mono/generated/inspect_derived_record.txt
@@ -198,8 +198,8 @@ procedure Num.96 (#Attr.2):
     ret Num.284;
 
 procedure Str.3 (#Attr.2, #Attr.3):
-    let Str.246 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
-    ret Str.246;
+    let Str.248 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
+    ret Str.248;
 
 procedure Test.0 ():
     let Test.3 : Decimal = 3dec;

--- a/crates/compiler/test_mono/generated/inspect_derived_record_one_field_string.txt
+++ b/crates/compiler/test_mono/generated/inspect_derived_record_one_field_string.txt
@@ -216,184 +216,184 @@ procedure Num.77 (#Attr.2, #Attr.3):
     ret Num.293;
 
 procedure Str.20 (#Attr.2):
-    let Str.314 : Str = lowlevel StrWithCapacity #Attr.2;
-    ret Str.314;
+    let Str.316 : Str = lowlevel StrWithCapacity #Attr.2;
+    ret Str.316;
 
 procedure Str.3 (#Attr.2, #Attr.3):
-    let Str.246 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
-    ret Str.246;
+    let Str.248 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
+    ret Str.248;
 
 procedure Str.35 (#Attr.2, #Attr.3):
-    let Str.304 : U8 = lowlevel StrGetUnsafe #Attr.2 #Attr.3;
-    ret Str.304;
+    let Str.306 : U8 = lowlevel StrGetUnsafe #Attr.2 #Attr.3;
+    ret Str.306;
 
 procedure Str.36 (#Attr.2):
-    let Str.266 : U64 = lowlevel StrCountUtf8Bytes #Attr.2;
-    ret Str.266;
+    let Str.268 : U64 = lowlevel StrCountUtf8Bytes #Attr.2;
+    ret Str.268;
 
 procedure Str.37 (#Attr.2, #Attr.3, #Attr.4):
-    let Str.264 : Str = lowlevel StrSubstringUnsafe #Attr.2 #Attr.3 #Attr.4;
-    ret Str.264;
+    let Str.266 : Str = lowlevel StrSubstringUnsafe #Attr.2 #Attr.3 #Attr.4;
+    ret Str.266;
 
-procedure Str.38 (Str.112, Str.113):
-    let Str.260 : [C , C U64] = CallByName Str.57 Str.112 Str.113;
-    let Str.273 : U8 = 1i64;
-    let Str.274 : U8 = GetTagId Str.260;
-    let Str.275 : Int1 = lowlevel Eq Str.273 Str.274;
-    if Str.275 then
-        let Str.114 : U64 = UnionAtIndex (Id 1) (Index 0) Str.260;
-        let Str.269 : U64 = CallByName Str.36 Str.112;
-        let Str.270 : U64 = CallByName Str.36 Str.113;
-        let Str.268 : U64 = CallByName Num.20 Str.269 Str.270;
-        let Str.115 : U64 = CallByName Num.20 Str.268 Str.114;
-        let Str.267 : U64 = 0i64;
-        inc Str.112;
-        let Str.116 : Str = CallByName Str.37 Str.112 Str.267 Str.114;
-        let Str.265 : U64 = CallByName Str.36 Str.113;
-        let Str.263 : U64 = CallByName Num.51 Str.114 Str.265;
-        let Str.117 : Str = CallByName Str.37 Str.112 Str.263 Str.115;
-        let Str.262 : {Str, Str} = Struct {Str.117, Str.116};
-        let Str.261 : [C {}, C {Str, Str}] = TagId(1) Str.262;
-        ret Str.261;
+procedure Str.38 (Str.113, Str.114):
+    let Str.262 : [C , C U64] = CallByName Str.58 Str.113 Str.114;
+    let Str.275 : U8 = 1i64;
+    let Str.276 : U8 = GetTagId Str.262;
+    let Str.277 : Int1 = lowlevel Eq Str.275 Str.276;
+    if Str.277 then
+        let Str.115 : U64 = UnionAtIndex (Id 1) (Index 0) Str.262;
+        let Str.271 : U64 = CallByName Str.36 Str.113;
+        let Str.272 : U64 = CallByName Str.36 Str.114;
+        let Str.270 : U64 = CallByName Num.20 Str.271 Str.272;
+        let Str.116 : U64 = CallByName Num.20 Str.270 Str.115;
+        let Str.269 : U64 = 0i64;
+        inc Str.113;
+        let Str.117 : Str = CallByName Str.37 Str.113 Str.269 Str.115;
+        let Str.267 : U64 = CallByName Str.36 Str.114;
+        let Str.265 : U64 = CallByName Num.51 Str.115 Str.267;
+        let Str.118 : Str = CallByName Str.37 Str.113 Str.265 Str.116;
+        let Str.264 : {Str, Str} = Struct {Str.118, Str.117};
+        let Str.263 : [C {}, C {Str, Str}] = TagId(1) Str.264;
+        ret Str.263;
     else
-        dec Str.112;
-        let Str.272 : {} = Struct {};
-        let Str.271 : [C {}, C {Str, Str}] = TagId(0) Str.272;
-        ret Str.271;
+        dec Str.113;
+        let Str.274 : {} = Struct {};
+        let Str.273 : [C {}, C {Str, Str}] = TagId(0) Str.274;
+        ret Str.273;
 
-procedure Str.45 (Str.91, Str.92, Str.93):
-    inc Str.91;
-    let Str.342 : [C {}, C {Str, Str}] = CallByName Str.38 Str.91 Str.92;
-    let Str.350 : U8 = 1i64;
-    let Str.351 : U8 = GetTagId Str.342;
-    let Str.352 : Int1 = lowlevel Eq Str.350 Str.351;
-    if Str.352 then
-        let Str.349 : {Str, Str} = UnionAtIndex (Id 1) (Index 0) Str.342;
-        let Str.95 : Str = StructAtIndex 0 Str.349;
-        let Str.94 : Str = StructAtIndex 1 Str.349;
-        let Str.347 : U64 = CallByName Str.36 Str.91;
-        dec Str.91;
-        let Str.346 : Str = CallByName Str.20 Str.347;
-        let Str.345 : Str = CallByName Str.3 Str.346 Str.94;
-        dec Str.94;
-        let Str.344 : Str = CallByName Str.3 Str.345 Str.93;
-        let Str.343 : Str = CallByName Str.56 Str.344 Str.95 Str.92 Str.93;
-        ret Str.343;
+procedure Str.45 (Str.92, Str.93, Str.94):
+    inc Str.92;
+    let Str.344 : [C {}, C {Str, Str}] = CallByName Str.38 Str.92 Str.93;
+    let Str.352 : U8 = 1i64;
+    let Str.353 : U8 = GetTagId Str.344;
+    let Str.354 : Int1 = lowlevel Eq Str.352 Str.353;
+    if Str.354 then
+        let Str.351 : {Str, Str} = UnionAtIndex (Id 1) (Index 0) Str.344;
+        let Str.96 : Str = StructAtIndex 0 Str.351;
+        let Str.95 : Str = StructAtIndex 1 Str.351;
+        let Str.349 : U64 = CallByName Str.36 Str.92;
+        dec Str.92;
+        let Str.348 : Str = CallByName Str.20 Str.349;
+        let Str.347 : Str = CallByName Str.3 Str.348 Str.95;
+        dec Str.95;
+        let Str.346 : Str = CallByName Str.3 Str.347 Str.94;
+        let Str.345 : Str = CallByName Str.57 Str.346 Str.96 Str.93 Str.94;
+        ret Str.345;
     else
-        dec Str.342;
-        ret Str.91;
+        dec Str.344;
+        ret Str.92;
 
-procedure Str.56 (#Derived_gen.12, #Derived_gen.13, #Derived_gen.14, #Derived_gen.15):
-    joinpoint Str.250 Str.96 Str.97 Str.98 Str.99:
-        inc Str.97;
-        let Str.251 : [C {}, C {Str, Str}] = CallByName Str.38 Str.97 Str.98;
-        let Str.257 : U8 = 1i64;
-        let Str.258 : U8 = GetTagId Str.251;
-        let Str.259 : Int1 = lowlevel Eq Str.257 Str.258;
-        if Str.259 then
-            dec Str.97;
-            let Str.256 : {Str, Str} = UnionAtIndex (Id 1) (Index 0) Str.251;
-            let Str.101 : Str = StructAtIndex 0 Str.256;
-            let Str.100 : Str = StructAtIndex 1 Str.256;
-            let Str.254 : Str = CallByName Str.3 Str.96 Str.100;
-            dec Str.100;
-            let Str.253 : Str = CallByName Str.3 Str.254 Str.99;
-            jump Str.250 Str.253 Str.101 Str.98 Str.99;
-        else
+procedure Str.57 (#Derived_gen.12, #Derived_gen.13, #Derived_gen.14, #Derived_gen.15):
+    joinpoint Str.252 Str.97 Str.98 Str.99 Str.100:
+        inc Str.98;
+        let Str.253 : [C {}, C {Str, Str}] = CallByName Str.38 Str.98 Str.99;
+        let Str.259 : U8 = 1i64;
+        let Str.260 : U8 = GetTagId Str.253;
+        let Str.261 : Int1 = lowlevel Eq Str.259 Str.260;
+        if Str.261 then
             dec Str.98;
-            dec Str.251;
+            let Str.258 : {Str, Str} = UnionAtIndex (Id 1) (Index 0) Str.253;
+            let Str.102 : Str = StructAtIndex 0 Str.258;
+            let Str.101 : Str = StructAtIndex 1 Str.258;
+            let Str.256 : Str = CallByName Str.3 Str.97 Str.101;
+            dec Str.101;
+            let Str.255 : Str = CallByName Str.3 Str.256 Str.100;
+            jump Str.252 Str.255 Str.102 Str.99 Str.100;
+        else
+            dec Str.100;
             dec Str.99;
-            let Str.255 : Str = CallByName Str.3 Str.96 Str.97;
-            dec Str.97;
-            ret Str.255;
+            dec Str.253;
+            let Str.257 : Str = CallByName Str.3 Str.97 Str.98;
+            dec Str.98;
+            ret Str.257;
     in
     inc #Derived_gen.14;
     inc #Derived_gen.15;
-    jump Str.250 #Derived_gen.12 #Derived_gen.13 #Derived_gen.14 #Derived_gen.15;
+    jump Str.252 #Derived_gen.12 #Derived_gen.13 #Derived_gen.14 #Derived_gen.15;
 
-procedure Str.57 (Str.121, Str.122):
-    let Str.123 : U64 = CallByName Str.36 Str.121;
+procedure Str.58 (Str.122, Str.123):
     let Str.124 : U64 = CallByName Str.36 Str.122;
-    let Str.125 : U64 = CallByName Num.77 Str.123 Str.124;
-    let Str.277 : U64 = 0i64;
-    let Str.276 : [C , C U64] = CallByName Str.58 Str.121 Str.122 Str.277 Str.125;
-    ret Str.276;
+    let Str.125 : U64 = CallByName Str.36 Str.123;
+    let Str.126 : U64 = CallByName Num.77 Str.124 Str.125;
+    let Str.279 : U64 = 0i64;
+    let Str.278 : [C , C U64] = CallByName Str.59 Str.122 Str.123 Str.279 Str.126;
+    ret Str.278;
 
-procedure Str.58 (#Derived_gen.16, #Derived_gen.17, #Derived_gen.18, #Derived_gen.19):
-    joinpoint Str.278 Str.126 Str.127 Str.128 Str.129:
-        let Str.280 : Int1 = CallByName Num.23 Str.128 Str.129;
-        if Str.280 then
-            let Str.284 : Int1 = CallByName Str.62 Str.126 Str.128 Str.127;
-            if Str.284 then
+procedure Str.59 (#Derived_gen.16, #Derived_gen.17, #Derived_gen.18, #Derived_gen.19):
+    joinpoint Str.280 Str.127 Str.128 Str.129 Str.130:
+        let Str.282 : Int1 = CallByName Num.23 Str.129 Str.130;
+        if Str.282 then
+            let Str.286 : Int1 = CallByName Str.63 Str.127 Str.129 Str.128;
+            if Str.286 then
                 dec Str.127;
-                dec Str.126;
-                let Str.285 : [C , C U64] = TagId(1) Str.128;
-                ret Str.285;
+                dec Str.128;
+                let Str.287 : [C , C U64] = TagId(1) Str.129;
+                ret Str.287;
             else
-                let Str.283 : U64 = 1i64;
-                let Str.282 : U64 = CallByName Num.51 Str.128 Str.283;
-                jump Str.278 Str.126 Str.127 Str.282 Str.129;
+                let Str.285 : U64 = 1i64;
+                let Str.284 : U64 = CallByName Num.51 Str.129 Str.285;
+                jump Str.280 Str.127 Str.128 Str.284 Str.130;
         else
             dec Str.127;
-            dec Str.126;
-            let Str.279 : [C , C U64] = TagId(0) ;
-            ret Str.279;
+            dec Str.128;
+            let Str.281 : [C , C U64] = TagId(0) ;
+            ret Str.281;
     in
     inc #Derived_gen.17;
     inc #Derived_gen.16;
-    jump Str.278 #Derived_gen.16 #Derived_gen.17 #Derived_gen.18 #Derived_gen.19;
+    jump Str.280 #Derived_gen.16 #Derived_gen.17 #Derived_gen.18 #Derived_gen.19;
 
-procedure Str.61 (Str.152, Str.153):
-    let Str.309 : Int1 = CallByName Num.22 Str.152 Str.153;
-    if Str.309 then
-        ret Str.152;
-    else
+procedure Str.62 (Str.153, Str.154):
+    let Str.311 : Int1 = CallByName Num.22 Str.153 Str.154;
+    if Str.311 then
         ret Str.153;
-
-procedure Str.62 (Str.154, Str.155, Str.156):
-    let Str.157 : U64 = CallByName Str.36 Str.154;
-    let Str.158 : U64 = CallByName Str.36 Str.156;
-    let Str.307 : U64 = CallByName Num.53 Str.155 Str.158;
-    let Str.159 : U64 = CallByName Str.61 Str.307 Str.157;
-    let Str.306 : U64 = 0i64;
-    inc Str.156;
-    inc Str.154;
-    let Str.287 : {U64, Str, U64, Str, U64, U64} = Struct {Str.159, Str.154, Str.155, Str.156, Str.306, Str.158};
-    let Str.286 : Int1 = CallByName Str.63 Str.287;
-    ret Str.286;
-
-procedure Str.63 (Str.160):
-    let Str.166 : U64 = StructAtIndex 0 Str.160;
-    let Str.161 : Str = StructAtIndex 1 Str.160;
-    let Str.162 : U64 = StructAtIndex 2 Str.160;
-    let Str.163 : Str = StructAtIndex 3 Str.160;
-    let Str.164 : U64 = StructAtIndex 4 Str.160;
-    let Str.165 : U64 = StructAtIndex 5 Str.160;
-    let Str.167 : Int1 = CallByName Num.25 Str.162 Str.166;
-    if Str.167 then
-        dec Str.163;
-        dec Str.161;
-        let Str.168 : Int1 = CallByName Bool.9 Str.164 Str.165;
-        ret Str.168;
     else
-        let Str.302 : U8 = CallByName Str.35 Str.161 Str.162;
-        let Str.303 : U8 = CallByName Str.35 Str.163 Str.164;
-        let Str.169 : Int1 = CallByName Bool.9 Str.302 Str.303;
-        let Str.292 : U64 = StructAtIndex 0 Str.160;
-        let Str.293 : Str = StructAtIndex 1 Str.160;
-        let Str.295 : Str = StructAtIndex 3 Str.160;
-        let Str.297 : U64 = StructAtIndex 5 Str.160;
-        let Str.301 : U64 = 1i64;
-        let Str.299 : U64 = CallByName Num.51 Str.164 Str.301;
-        let Str.300 : U64 = 1i64;
-        let Str.298 : U64 = CallByName Num.51 Str.162 Str.300;
-        let Str.291 : {U64, Str, U64, Str, U64, U64} = Struct {Str.292, Str.293, Str.298, Str.295, Str.299, Str.297};
-        let Str.170 : Int1 = CallByName Str.63 Str.291;
-        if Str.169 then
-            ret Str.170;
+        ret Str.154;
+
+procedure Str.63 (Str.155, Str.156, Str.157):
+    let Str.158 : U64 = CallByName Str.36 Str.155;
+    let Str.159 : U64 = CallByName Str.36 Str.157;
+    let Str.309 : U64 = CallByName Num.53 Str.156 Str.159;
+    let Str.160 : U64 = CallByName Str.62 Str.309 Str.158;
+    let Str.308 : U64 = 0i64;
+    inc Str.157;
+    inc Str.155;
+    let Str.289 : {U64, Str, U64, Str, U64, U64} = Struct {Str.160, Str.155, Str.156, Str.157, Str.308, Str.159};
+    let Str.288 : Int1 = CallByName Str.64 Str.289;
+    ret Str.288;
+
+procedure Str.64 (Str.161):
+    let Str.167 : U64 = StructAtIndex 0 Str.161;
+    let Str.162 : Str = StructAtIndex 1 Str.161;
+    let Str.163 : U64 = StructAtIndex 2 Str.161;
+    let Str.164 : Str = StructAtIndex 3 Str.161;
+    let Str.165 : U64 = StructAtIndex 4 Str.161;
+    let Str.166 : U64 = StructAtIndex 5 Str.161;
+    let Str.168 : Int1 = CallByName Num.25 Str.163 Str.167;
+    if Str.168 then
+        dec Str.162;
+        dec Str.164;
+        let Str.169 : Int1 = CallByName Bool.9 Str.165 Str.166;
+        ret Str.169;
+    else
+        let Str.304 : U8 = CallByName Str.35 Str.162 Str.163;
+        let Str.305 : U8 = CallByName Str.35 Str.164 Str.165;
+        let Str.170 : Int1 = CallByName Bool.9 Str.304 Str.305;
+        let Str.294 : U64 = StructAtIndex 0 Str.161;
+        let Str.295 : Str = StructAtIndex 1 Str.161;
+        let Str.297 : Str = StructAtIndex 3 Str.161;
+        let Str.299 : U64 = StructAtIndex 5 Str.161;
+        let Str.303 : U64 = 1i64;
+        let Str.301 : U64 = CallByName Num.51 Str.165 Str.303;
+        let Str.302 : U64 = 1i64;
+        let Str.300 : U64 = CallByName Num.51 Str.163 Str.302;
+        let Str.293 : {U64, Str, U64, Str, U64, U64} = Struct {Str.294, Str.295, Str.300, Str.297, Str.301, Str.299};
+        let Str.171 : Int1 = CallByName Str.64 Str.293;
+        if Str.170 then
+            ret Str.171;
         else
-            let Str.289 : Int1 = CallByName Bool.1;
-            ret Str.289;
+            let Str.291 : Int1 = CallByName Bool.1;
+            ret Str.291;
 
 procedure Test.0 ():
     let Test.3 : Str = "foo";

--- a/crates/compiler/test_mono/generated/inspect_derived_record_two_field_strings.txt
+++ b/crates/compiler/test_mono/generated/inspect_derived_record_two_field_strings.txt
@@ -223,184 +223,184 @@ procedure Num.77 (#Attr.2, #Attr.3):
     ret Num.293;
 
 procedure Str.20 (#Attr.2):
-    let Str.314 : Str = lowlevel StrWithCapacity #Attr.2;
-    ret Str.314;
+    let Str.316 : Str = lowlevel StrWithCapacity #Attr.2;
+    ret Str.316;
 
 procedure Str.3 (#Attr.2, #Attr.3):
-    let Str.246 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
-    ret Str.246;
+    let Str.248 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
+    ret Str.248;
 
 procedure Str.35 (#Attr.2, #Attr.3):
-    let Str.304 : U8 = lowlevel StrGetUnsafe #Attr.2 #Attr.3;
-    ret Str.304;
+    let Str.306 : U8 = lowlevel StrGetUnsafe #Attr.2 #Attr.3;
+    ret Str.306;
 
 procedure Str.36 (#Attr.2):
-    let Str.266 : U64 = lowlevel StrCountUtf8Bytes #Attr.2;
-    ret Str.266;
+    let Str.268 : U64 = lowlevel StrCountUtf8Bytes #Attr.2;
+    ret Str.268;
 
 procedure Str.37 (#Attr.2, #Attr.3, #Attr.4):
-    let Str.264 : Str = lowlevel StrSubstringUnsafe #Attr.2 #Attr.3 #Attr.4;
-    ret Str.264;
+    let Str.266 : Str = lowlevel StrSubstringUnsafe #Attr.2 #Attr.3 #Attr.4;
+    ret Str.266;
 
-procedure Str.38 (Str.112, Str.113):
-    let Str.260 : [C , C U64] = CallByName Str.57 Str.112 Str.113;
-    let Str.273 : U8 = 1i64;
-    let Str.274 : U8 = GetTagId Str.260;
-    let Str.275 : Int1 = lowlevel Eq Str.273 Str.274;
-    if Str.275 then
-        let Str.114 : U64 = UnionAtIndex (Id 1) (Index 0) Str.260;
-        let Str.269 : U64 = CallByName Str.36 Str.112;
-        let Str.270 : U64 = CallByName Str.36 Str.113;
-        let Str.268 : U64 = CallByName Num.20 Str.269 Str.270;
-        let Str.115 : U64 = CallByName Num.20 Str.268 Str.114;
-        let Str.267 : U64 = 0i64;
-        inc Str.112;
-        let Str.116 : Str = CallByName Str.37 Str.112 Str.267 Str.114;
-        let Str.265 : U64 = CallByName Str.36 Str.113;
-        let Str.263 : U64 = CallByName Num.51 Str.114 Str.265;
-        let Str.117 : Str = CallByName Str.37 Str.112 Str.263 Str.115;
-        let Str.262 : {Str, Str} = Struct {Str.117, Str.116};
-        let Str.261 : [C {}, C {Str, Str}] = TagId(1) Str.262;
-        ret Str.261;
+procedure Str.38 (Str.113, Str.114):
+    let Str.262 : [C , C U64] = CallByName Str.58 Str.113 Str.114;
+    let Str.275 : U8 = 1i64;
+    let Str.276 : U8 = GetTagId Str.262;
+    let Str.277 : Int1 = lowlevel Eq Str.275 Str.276;
+    if Str.277 then
+        let Str.115 : U64 = UnionAtIndex (Id 1) (Index 0) Str.262;
+        let Str.271 : U64 = CallByName Str.36 Str.113;
+        let Str.272 : U64 = CallByName Str.36 Str.114;
+        let Str.270 : U64 = CallByName Num.20 Str.271 Str.272;
+        let Str.116 : U64 = CallByName Num.20 Str.270 Str.115;
+        let Str.269 : U64 = 0i64;
+        inc Str.113;
+        let Str.117 : Str = CallByName Str.37 Str.113 Str.269 Str.115;
+        let Str.267 : U64 = CallByName Str.36 Str.114;
+        let Str.265 : U64 = CallByName Num.51 Str.115 Str.267;
+        let Str.118 : Str = CallByName Str.37 Str.113 Str.265 Str.116;
+        let Str.264 : {Str, Str} = Struct {Str.118, Str.117};
+        let Str.263 : [C {}, C {Str, Str}] = TagId(1) Str.264;
+        ret Str.263;
     else
-        dec Str.112;
-        let Str.272 : {} = Struct {};
-        let Str.271 : [C {}, C {Str, Str}] = TagId(0) Str.272;
-        ret Str.271;
+        dec Str.113;
+        let Str.274 : {} = Struct {};
+        let Str.273 : [C {}, C {Str, Str}] = TagId(0) Str.274;
+        ret Str.273;
 
-procedure Str.45 (Str.91, Str.92, Str.93):
-    inc Str.91;
-    let Str.386 : [C {}, C {Str, Str}] = CallByName Str.38 Str.91 Str.92;
-    let Str.394 : U8 = 1i64;
-    let Str.395 : U8 = GetTagId Str.386;
-    let Str.396 : Int1 = lowlevel Eq Str.394 Str.395;
-    if Str.396 then
-        let Str.393 : {Str, Str} = UnionAtIndex (Id 1) (Index 0) Str.386;
-        let Str.95 : Str = StructAtIndex 0 Str.393;
-        let Str.94 : Str = StructAtIndex 1 Str.393;
-        let Str.391 : U64 = CallByName Str.36 Str.91;
-        dec Str.91;
-        let Str.390 : Str = CallByName Str.20 Str.391;
-        let Str.389 : Str = CallByName Str.3 Str.390 Str.94;
-        dec Str.94;
-        let Str.388 : Str = CallByName Str.3 Str.389 Str.93;
-        let Str.387 : Str = CallByName Str.56 Str.388 Str.95 Str.92 Str.93;
-        ret Str.387;
+procedure Str.45 (Str.92, Str.93, Str.94):
+    inc Str.92;
+    let Str.388 : [C {}, C {Str, Str}] = CallByName Str.38 Str.92 Str.93;
+    let Str.396 : U8 = 1i64;
+    let Str.397 : U8 = GetTagId Str.388;
+    let Str.398 : Int1 = lowlevel Eq Str.396 Str.397;
+    if Str.398 then
+        let Str.395 : {Str, Str} = UnionAtIndex (Id 1) (Index 0) Str.388;
+        let Str.96 : Str = StructAtIndex 0 Str.395;
+        let Str.95 : Str = StructAtIndex 1 Str.395;
+        let Str.393 : U64 = CallByName Str.36 Str.92;
+        dec Str.92;
+        let Str.392 : Str = CallByName Str.20 Str.393;
+        let Str.391 : Str = CallByName Str.3 Str.392 Str.95;
+        dec Str.95;
+        let Str.390 : Str = CallByName Str.3 Str.391 Str.94;
+        let Str.389 : Str = CallByName Str.57 Str.390 Str.96 Str.93 Str.94;
+        ret Str.389;
     else
-        dec Str.386;
-        ret Str.91;
+        dec Str.388;
+        ret Str.92;
 
-procedure Str.56 (#Derived_gen.16, #Derived_gen.17, #Derived_gen.18, #Derived_gen.19):
-    joinpoint Str.250 Str.96 Str.97 Str.98 Str.99:
-        inc Str.97;
-        let Str.251 : [C {}, C {Str, Str}] = CallByName Str.38 Str.97 Str.98;
-        let Str.257 : U8 = 1i64;
-        let Str.258 : U8 = GetTagId Str.251;
-        let Str.259 : Int1 = lowlevel Eq Str.257 Str.258;
-        if Str.259 then
-            dec Str.97;
-            let Str.256 : {Str, Str} = UnionAtIndex (Id 1) (Index 0) Str.251;
-            let Str.101 : Str = StructAtIndex 0 Str.256;
-            let Str.100 : Str = StructAtIndex 1 Str.256;
-            let Str.254 : Str = CallByName Str.3 Str.96 Str.100;
-            dec Str.100;
-            let Str.253 : Str = CallByName Str.3 Str.254 Str.99;
-            jump Str.250 Str.253 Str.101 Str.98 Str.99;
-        else
+procedure Str.57 (#Derived_gen.16, #Derived_gen.17, #Derived_gen.18, #Derived_gen.19):
+    joinpoint Str.252 Str.97 Str.98 Str.99 Str.100:
+        inc Str.98;
+        let Str.253 : [C {}, C {Str, Str}] = CallByName Str.38 Str.98 Str.99;
+        let Str.259 : U8 = 1i64;
+        let Str.260 : U8 = GetTagId Str.253;
+        let Str.261 : Int1 = lowlevel Eq Str.259 Str.260;
+        if Str.261 then
             dec Str.98;
-            dec Str.251;
+            let Str.258 : {Str, Str} = UnionAtIndex (Id 1) (Index 0) Str.253;
+            let Str.102 : Str = StructAtIndex 0 Str.258;
+            let Str.101 : Str = StructAtIndex 1 Str.258;
+            let Str.256 : Str = CallByName Str.3 Str.97 Str.101;
+            dec Str.101;
+            let Str.255 : Str = CallByName Str.3 Str.256 Str.100;
+            jump Str.252 Str.255 Str.102 Str.99 Str.100;
+        else
+            dec Str.100;
             dec Str.99;
-            let Str.255 : Str = CallByName Str.3 Str.96 Str.97;
-            dec Str.97;
-            ret Str.255;
+            dec Str.253;
+            let Str.257 : Str = CallByName Str.3 Str.97 Str.98;
+            dec Str.98;
+            ret Str.257;
     in
     inc #Derived_gen.18;
     inc #Derived_gen.19;
-    jump Str.250 #Derived_gen.16 #Derived_gen.17 #Derived_gen.18 #Derived_gen.19;
+    jump Str.252 #Derived_gen.16 #Derived_gen.17 #Derived_gen.18 #Derived_gen.19;
 
-procedure Str.57 (Str.121, Str.122):
-    let Str.123 : U64 = CallByName Str.36 Str.121;
+procedure Str.58 (Str.122, Str.123):
     let Str.124 : U64 = CallByName Str.36 Str.122;
-    let Str.125 : U64 = CallByName Num.77 Str.123 Str.124;
-    let Str.277 : U64 = 0i64;
-    let Str.276 : [C , C U64] = CallByName Str.58 Str.121 Str.122 Str.277 Str.125;
-    ret Str.276;
+    let Str.125 : U64 = CallByName Str.36 Str.123;
+    let Str.126 : U64 = CallByName Num.77 Str.124 Str.125;
+    let Str.279 : U64 = 0i64;
+    let Str.278 : [C , C U64] = CallByName Str.59 Str.122 Str.123 Str.279 Str.126;
+    ret Str.278;
 
-procedure Str.58 (#Derived_gen.20, #Derived_gen.21, #Derived_gen.22, #Derived_gen.23):
-    joinpoint Str.278 Str.126 Str.127 Str.128 Str.129:
-        let Str.280 : Int1 = CallByName Num.23 Str.128 Str.129;
-        if Str.280 then
-            let Str.284 : Int1 = CallByName Str.62 Str.126 Str.128 Str.127;
-            if Str.284 then
+procedure Str.59 (#Derived_gen.20, #Derived_gen.21, #Derived_gen.22, #Derived_gen.23):
+    joinpoint Str.280 Str.127 Str.128 Str.129 Str.130:
+        let Str.282 : Int1 = CallByName Num.23 Str.129 Str.130;
+        if Str.282 then
+            let Str.286 : Int1 = CallByName Str.63 Str.127 Str.129 Str.128;
+            if Str.286 then
                 dec Str.127;
-                dec Str.126;
-                let Str.285 : [C , C U64] = TagId(1) Str.128;
-                ret Str.285;
+                dec Str.128;
+                let Str.287 : [C , C U64] = TagId(1) Str.129;
+                ret Str.287;
             else
-                let Str.283 : U64 = 1i64;
-                let Str.282 : U64 = CallByName Num.51 Str.128 Str.283;
-                jump Str.278 Str.126 Str.127 Str.282 Str.129;
+                let Str.285 : U64 = 1i64;
+                let Str.284 : U64 = CallByName Num.51 Str.129 Str.285;
+                jump Str.280 Str.127 Str.128 Str.284 Str.130;
         else
             dec Str.127;
-            dec Str.126;
-            let Str.279 : [C , C U64] = TagId(0) ;
-            ret Str.279;
+            dec Str.128;
+            let Str.281 : [C , C U64] = TagId(0) ;
+            ret Str.281;
     in
     inc #Derived_gen.20;
     inc #Derived_gen.21;
-    jump Str.278 #Derived_gen.20 #Derived_gen.21 #Derived_gen.22 #Derived_gen.23;
+    jump Str.280 #Derived_gen.20 #Derived_gen.21 #Derived_gen.22 #Derived_gen.23;
 
-procedure Str.61 (Str.152, Str.153):
-    let Str.309 : Int1 = CallByName Num.22 Str.152 Str.153;
-    if Str.309 then
-        ret Str.152;
-    else
+procedure Str.62 (Str.153, Str.154):
+    let Str.311 : Int1 = CallByName Num.22 Str.153 Str.154;
+    if Str.311 then
         ret Str.153;
-
-procedure Str.62 (Str.154, Str.155, Str.156):
-    let Str.157 : U64 = CallByName Str.36 Str.154;
-    let Str.158 : U64 = CallByName Str.36 Str.156;
-    let Str.307 : U64 = CallByName Num.53 Str.155 Str.158;
-    let Str.159 : U64 = CallByName Str.61 Str.307 Str.157;
-    let Str.306 : U64 = 0i64;
-    inc Str.156;
-    inc Str.154;
-    let Str.287 : {U64, Str, U64, Str, U64, U64} = Struct {Str.159, Str.154, Str.155, Str.156, Str.306, Str.158};
-    let Str.286 : Int1 = CallByName Str.63 Str.287;
-    ret Str.286;
-
-procedure Str.63 (Str.160):
-    let Str.166 : U64 = StructAtIndex 0 Str.160;
-    let Str.161 : Str = StructAtIndex 1 Str.160;
-    let Str.162 : U64 = StructAtIndex 2 Str.160;
-    let Str.163 : Str = StructAtIndex 3 Str.160;
-    let Str.164 : U64 = StructAtIndex 4 Str.160;
-    let Str.165 : U64 = StructAtIndex 5 Str.160;
-    let Str.167 : Int1 = CallByName Num.25 Str.162 Str.166;
-    if Str.167 then
-        dec Str.163;
-        dec Str.161;
-        let Str.168 : Int1 = CallByName Bool.9 Str.164 Str.165;
-        ret Str.168;
     else
-        let Str.302 : U8 = CallByName Str.35 Str.161 Str.162;
-        let Str.303 : U8 = CallByName Str.35 Str.163 Str.164;
-        let Str.169 : Int1 = CallByName Bool.9 Str.302 Str.303;
-        let Str.292 : U64 = StructAtIndex 0 Str.160;
-        let Str.293 : Str = StructAtIndex 1 Str.160;
-        let Str.295 : Str = StructAtIndex 3 Str.160;
-        let Str.297 : U64 = StructAtIndex 5 Str.160;
-        let Str.301 : U64 = 1i64;
-        let Str.299 : U64 = CallByName Num.51 Str.164 Str.301;
-        let Str.300 : U64 = 1i64;
-        let Str.298 : U64 = CallByName Num.51 Str.162 Str.300;
-        let Str.291 : {U64, Str, U64, Str, U64, U64} = Struct {Str.292, Str.293, Str.298, Str.295, Str.299, Str.297};
-        let Str.170 : Int1 = CallByName Str.63 Str.291;
-        if Str.169 then
-            ret Str.170;
+        ret Str.154;
+
+procedure Str.63 (Str.155, Str.156, Str.157):
+    let Str.158 : U64 = CallByName Str.36 Str.155;
+    let Str.159 : U64 = CallByName Str.36 Str.157;
+    let Str.309 : U64 = CallByName Num.53 Str.156 Str.159;
+    let Str.160 : U64 = CallByName Str.62 Str.309 Str.158;
+    let Str.308 : U64 = 0i64;
+    inc Str.157;
+    inc Str.155;
+    let Str.289 : {U64, Str, U64, Str, U64, U64} = Struct {Str.160, Str.155, Str.156, Str.157, Str.308, Str.159};
+    let Str.288 : Int1 = CallByName Str.64 Str.289;
+    ret Str.288;
+
+procedure Str.64 (Str.161):
+    let Str.167 : U64 = StructAtIndex 0 Str.161;
+    let Str.162 : Str = StructAtIndex 1 Str.161;
+    let Str.163 : U64 = StructAtIndex 2 Str.161;
+    let Str.164 : Str = StructAtIndex 3 Str.161;
+    let Str.165 : U64 = StructAtIndex 4 Str.161;
+    let Str.166 : U64 = StructAtIndex 5 Str.161;
+    let Str.168 : Int1 = CallByName Num.25 Str.163 Str.167;
+    if Str.168 then
+        dec Str.162;
+        dec Str.164;
+        let Str.169 : Int1 = CallByName Bool.9 Str.165 Str.166;
+        ret Str.169;
+    else
+        let Str.304 : U8 = CallByName Str.35 Str.162 Str.163;
+        let Str.305 : U8 = CallByName Str.35 Str.164 Str.165;
+        let Str.170 : Int1 = CallByName Bool.9 Str.304 Str.305;
+        let Str.294 : U64 = StructAtIndex 0 Str.161;
+        let Str.295 : Str = StructAtIndex 1 Str.161;
+        let Str.297 : Str = StructAtIndex 3 Str.161;
+        let Str.299 : U64 = StructAtIndex 5 Str.161;
+        let Str.303 : U64 = 1i64;
+        let Str.301 : U64 = CallByName Num.51 Str.165 Str.303;
+        let Str.302 : U64 = 1i64;
+        let Str.300 : U64 = CallByName Num.51 Str.163 Str.302;
+        let Str.293 : {U64, Str, U64, Str, U64, U64} = Struct {Str.294, Str.295, Str.300, Str.297, Str.301, Str.299};
+        let Str.171 : Int1 = CallByName Str.64 Str.293;
+        if Str.170 then
+            ret Str.171;
         else
-            let Str.289 : Int1 = CallByName Bool.1;
-            ret Str.289;
+            let Str.291 : Int1 = CallByName Bool.1;
+            ret Str.291;
 
 procedure Test.0 ():
     let Test.3 : Str = "foo";

--- a/crates/compiler/test_mono/generated/inspect_derived_string.txt
+++ b/crates/compiler/test_mono/generated/inspect_derived_string.txt
@@ -100,184 +100,184 @@ procedure Num.77 (#Attr.2, #Attr.3):
     ret Num.293;
 
 procedure Str.20 (#Attr.2):
-    let Str.314 : Str = lowlevel StrWithCapacity #Attr.2;
-    ret Str.314;
+    let Str.316 : Str = lowlevel StrWithCapacity #Attr.2;
+    ret Str.316;
 
 procedure Str.3 (#Attr.2, #Attr.3):
-    let Str.246 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
-    ret Str.246;
+    let Str.248 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
+    ret Str.248;
 
 procedure Str.35 (#Attr.2, #Attr.3):
-    let Str.304 : U8 = lowlevel StrGetUnsafe #Attr.2 #Attr.3;
-    ret Str.304;
+    let Str.306 : U8 = lowlevel StrGetUnsafe #Attr.2 #Attr.3;
+    ret Str.306;
 
 procedure Str.36 (#Attr.2):
-    let Str.266 : U64 = lowlevel StrCountUtf8Bytes #Attr.2;
-    ret Str.266;
+    let Str.268 : U64 = lowlevel StrCountUtf8Bytes #Attr.2;
+    ret Str.268;
 
 procedure Str.37 (#Attr.2, #Attr.3, #Attr.4):
-    let Str.264 : Str = lowlevel StrSubstringUnsafe #Attr.2 #Attr.3 #Attr.4;
-    ret Str.264;
+    let Str.266 : Str = lowlevel StrSubstringUnsafe #Attr.2 #Attr.3 #Attr.4;
+    ret Str.266;
 
-procedure Str.38 (Str.112, Str.113):
-    let Str.260 : [C , C U64] = CallByName Str.57 Str.112 Str.113;
-    let Str.273 : U8 = 1i64;
-    let Str.274 : U8 = GetTagId Str.260;
-    let Str.275 : Int1 = lowlevel Eq Str.273 Str.274;
-    if Str.275 then
-        let Str.114 : U64 = UnionAtIndex (Id 1) (Index 0) Str.260;
-        let Str.269 : U64 = CallByName Str.36 Str.112;
-        let Str.270 : U64 = CallByName Str.36 Str.113;
-        let Str.268 : U64 = CallByName Num.20 Str.269 Str.270;
-        let Str.115 : U64 = CallByName Num.20 Str.268 Str.114;
-        let Str.267 : U64 = 0i64;
-        inc Str.112;
-        let Str.116 : Str = CallByName Str.37 Str.112 Str.267 Str.114;
-        let Str.265 : U64 = CallByName Str.36 Str.113;
-        let Str.263 : U64 = CallByName Num.51 Str.114 Str.265;
-        let Str.117 : Str = CallByName Str.37 Str.112 Str.263 Str.115;
-        let Str.262 : {Str, Str} = Struct {Str.117, Str.116};
-        let Str.261 : [C {}, C {Str, Str}] = TagId(1) Str.262;
-        ret Str.261;
+procedure Str.38 (Str.113, Str.114):
+    let Str.262 : [C , C U64] = CallByName Str.58 Str.113 Str.114;
+    let Str.275 : U8 = 1i64;
+    let Str.276 : U8 = GetTagId Str.262;
+    let Str.277 : Int1 = lowlevel Eq Str.275 Str.276;
+    if Str.277 then
+        let Str.115 : U64 = UnionAtIndex (Id 1) (Index 0) Str.262;
+        let Str.271 : U64 = CallByName Str.36 Str.113;
+        let Str.272 : U64 = CallByName Str.36 Str.114;
+        let Str.270 : U64 = CallByName Num.20 Str.271 Str.272;
+        let Str.116 : U64 = CallByName Num.20 Str.270 Str.115;
+        let Str.269 : U64 = 0i64;
+        inc Str.113;
+        let Str.117 : Str = CallByName Str.37 Str.113 Str.269 Str.115;
+        let Str.267 : U64 = CallByName Str.36 Str.114;
+        let Str.265 : U64 = CallByName Num.51 Str.115 Str.267;
+        let Str.118 : Str = CallByName Str.37 Str.113 Str.265 Str.116;
+        let Str.264 : {Str, Str} = Struct {Str.118, Str.117};
+        let Str.263 : [C {}, C {Str, Str}] = TagId(1) Str.264;
+        ret Str.263;
     else
-        dec Str.112;
-        let Str.272 : {} = Struct {};
-        let Str.271 : [C {}, C {Str, Str}] = TagId(0) Str.272;
-        ret Str.271;
+        dec Str.113;
+        let Str.274 : {} = Struct {};
+        let Str.273 : [C {}, C {Str, Str}] = TagId(0) Str.274;
+        ret Str.273;
 
-procedure Str.45 (Str.91, Str.92, Str.93):
-    inc Str.91;
-    let Str.342 : [C {}, C {Str, Str}] = CallByName Str.38 Str.91 Str.92;
-    let Str.350 : U8 = 1i64;
-    let Str.351 : U8 = GetTagId Str.342;
-    let Str.352 : Int1 = lowlevel Eq Str.350 Str.351;
-    if Str.352 then
-        let Str.349 : {Str, Str} = UnionAtIndex (Id 1) (Index 0) Str.342;
-        let Str.95 : Str = StructAtIndex 0 Str.349;
-        let Str.94 : Str = StructAtIndex 1 Str.349;
-        let Str.347 : U64 = CallByName Str.36 Str.91;
-        dec Str.91;
-        let Str.346 : Str = CallByName Str.20 Str.347;
-        let Str.345 : Str = CallByName Str.3 Str.346 Str.94;
-        dec Str.94;
-        let Str.344 : Str = CallByName Str.3 Str.345 Str.93;
-        let Str.343 : Str = CallByName Str.56 Str.344 Str.95 Str.92 Str.93;
-        ret Str.343;
+procedure Str.45 (Str.92, Str.93, Str.94):
+    inc Str.92;
+    let Str.344 : [C {}, C {Str, Str}] = CallByName Str.38 Str.92 Str.93;
+    let Str.352 : U8 = 1i64;
+    let Str.353 : U8 = GetTagId Str.344;
+    let Str.354 : Int1 = lowlevel Eq Str.352 Str.353;
+    if Str.354 then
+        let Str.351 : {Str, Str} = UnionAtIndex (Id 1) (Index 0) Str.344;
+        let Str.96 : Str = StructAtIndex 0 Str.351;
+        let Str.95 : Str = StructAtIndex 1 Str.351;
+        let Str.349 : U64 = CallByName Str.36 Str.92;
+        dec Str.92;
+        let Str.348 : Str = CallByName Str.20 Str.349;
+        let Str.347 : Str = CallByName Str.3 Str.348 Str.95;
+        dec Str.95;
+        let Str.346 : Str = CallByName Str.3 Str.347 Str.94;
+        let Str.345 : Str = CallByName Str.57 Str.346 Str.96 Str.93 Str.94;
+        ret Str.345;
     else
-        dec Str.342;
-        ret Str.91;
+        dec Str.344;
+        ret Str.92;
 
-procedure Str.56 (Bool.24, Bool.25, Bool.26, Bool.27):
-    joinpoint Str.250 Str.96 Str.97 Str.98 Str.99:
-        inc Str.97;
-        let Str.251 : [C {}, C {Str, Str}] = CallByName Str.38 Str.97 Str.98;
-        let Str.257 : U8 = 1i64;
-        let Str.258 : U8 = GetTagId Str.251;
-        let Str.259 : Int1 = lowlevel Eq Str.257 Str.258;
-        if Str.259 then
-            dec Str.97;
-            let Str.256 : {Str, Str} = UnionAtIndex (Id 1) (Index 0) Str.251;
-            let Str.101 : Str = StructAtIndex 0 Str.256;
-            let Str.100 : Str = StructAtIndex 1 Str.256;
-            let Str.254 : Str = CallByName Str.3 Str.96 Str.100;
-            dec Str.100;
-            let Str.253 : Str = CallByName Str.3 Str.254 Str.99;
-            jump Str.250 Str.253 Str.101 Str.98 Str.99;
-        else
+procedure Str.57 (Bool.24, Bool.25, Bool.26, Bool.27):
+    joinpoint Str.252 Str.97 Str.98 Str.99 Str.100:
+        inc Str.98;
+        let Str.253 : [C {}, C {Str, Str}] = CallByName Str.38 Str.98 Str.99;
+        let Str.259 : U8 = 1i64;
+        let Str.260 : U8 = GetTagId Str.253;
+        let Str.261 : Int1 = lowlevel Eq Str.259 Str.260;
+        if Str.261 then
             dec Str.98;
-            dec Str.251;
+            let Str.258 : {Str, Str} = UnionAtIndex (Id 1) (Index 0) Str.253;
+            let Str.102 : Str = StructAtIndex 0 Str.258;
+            let Str.101 : Str = StructAtIndex 1 Str.258;
+            let Str.256 : Str = CallByName Str.3 Str.97 Str.101;
+            dec Str.101;
+            let Str.255 : Str = CallByName Str.3 Str.256 Str.100;
+            jump Str.252 Str.255 Str.102 Str.99 Str.100;
+        else
+            dec Str.100;
             dec Str.99;
-            let Str.255 : Str = CallByName Str.3 Str.96 Str.97;
-            dec Str.97;
-            ret Str.255;
+            dec Str.253;
+            let Str.257 : Str = CallByName Str.3 Str.97 Str.98;
+            dec Str.98;
+            ret Str.257;
     in
     inc Bool.26;
     inc Bool.27;
-    jump Str.250 Bool.24 Bool.25 Bool.26 Bool.27;
+    jump Str.252 Bool.24 Bool.25 Bool.26 Bool.27;
 
-procedure Str.57 (Str.121, Str.122):
-    let Str.123 : U64 = CallByName Str.36 Str.121;
+procedure Str.58 (Str.122, Str.123):
     let Str.124 : U64 = CallByName Str.36 Str.122;
-    let Str.125 : U64 = CallByName Num.77 Str.123 Str.124;
-    let Str.277 : U64 = 0i64;
-    let Str.276 : [C , C U64] = CallByName Str.58 Str.121 Str.122 Str.277 Str.125;
-    ret Str.276;
+    let Str.125 : U64 = CallByName Str.36 Str.123;
+    let Str.126 : U64 = CallByName Num.77 Str.124 Str.125;
+    let Str.279 : U64 = 0i64;
+    let Str.278 : [C , C U64] = CallByName Str.59 Str.122 Str.123 Str.279 Str.126;
+    ret Str.278;
 
-procedure Str.58 (Bool.28, Bool.29, Bool.30, Bool.31):
-    joinpoint Str.278 Str.126 Str.127 Str.128 Str.129:
-        let Str.280 : Int1 = CallByName Num.23 Str.128 Str.129;
-        if Str.280 then
-            let Str.284 : Int1 = CallByName Str.62 Str.126 Str.128 Str.127;
-            if Str.284 then
+procedure Str.59 (Bool.28, Bool.29, Bool.30, Bool.31):
+    joinpoint Str.280 Str.127 Str.128 Str.129 Str.130:
+        let Str.282 : Int1 = CallByName Num.23 Str.129 Str.130;
+        if Str.282 then
+            let Str.286 : Int1 = CallByName Str.63 Str.127 Str.129 Str.128;
+            if Str.286 then
                 dec Str.127;
-                dec Str.126;
-                let Str.285 : [C , C U64] = TagId(1) Str.128;
-                ret Str.285;
+                dec Str.128;
+                let Str.287 : [C , C U64] = TagId(1) Str.129;
+                ret Str.287;
             else
-                let Str.283 : U64 = 1i64;
-                let Str.282 : U64 = CallByName Num.51 Str.128 Str.283;
-                jump Str.278 Str.126 Str.127 Str.282 Str.129;
+                let Str.285 : U64 = 1i64;
+                let Str.284 : U64 = CallByName Num.51 Str.129 Str.285;
+                jump Str.280 Str.127 Str.128 Str.284 Str.130;
         else
             dec Str.127;
-            dec Str.126;
-            let Str.279 : [C , C U64] = TagId(0) ;
-            ret Str.279;
+            dec Str.128;
+            let Str.281 : [C , C U64] = TagId(0) ;
+            ret Str.281;
     in
     inc Bool.29;
     inc Bool.28;
-    jump Str.278 Bool.28 Bool.29 Bool.30 Bool.31;
+    jump Str.280 Bool.28 Bool.29 Bool.30 Bool.31;
 
-procedure Str.61 (Str.152, Str.153):
-    let Str.309 : Int1 = CallByName Num.22 Str.152 Str.153;
-    if Str.309 then
-        ret Str.152;
-    else
+procedure Str.62 (Str.153, Str.154):
+    let Str.311 : Int1 = CallByName Num.22 Str.153 Str.154;
+    if Str.311 then
         ret Str.153;
-
-procedure Str.62 (Str.154, Str.155, Str.156):
-    let Str.157 : U64 = CallByName Str.36 Str.154;
-    let Str.158 : U64 = CallByName Str.36 Str.156;
-    let Str.307 : U64 = CallByName Num.53 Str.155 Str.158;
-    let Str.159 : U64 = CallByName Str.61 Str.307 Str.157;
-    let Str.306 : U64 = 0i64;
-    inc Str.156;
-    inc Str.154;
-    let Str.287 : {U64, Str, U64, Str, U64, U64} = Struct {Str.159, Str.154, Str.155, Str.156, Str.306, Str.158};
-    let Str.286 : Int1 = CallByName Str.63 Str.287;
-    ret Str.286;
-
-procedure Str.63 (Str.160):
-    let Str.166 : U64 = StructAtIndex 0 Str.160;
-    let Str.161 : Str = StructAtIndex 1 Str.160;
-    let Str.162 : U64 = StructAtIndex 2 Str.160;
-    let Str.163 : Str = StructAtIndex 3 Str.160;
-    let Str.164 : U64 = StructAtIndex 4 Str.160;
-    let Str.165 : U64 = StructAtIndex 5 Str.160;
-    let Str.167 : Int1 = CallByName Num.25 Str.162 Str.166;
-    if Str.167 then
-        dec Str.163;
-        dec Str.161;
-        let Str.168 : Int1 = CallByName Bool.9 Str.164 Str.165;
-        ret Str.168;
     else
-        let Str.302 : U8 = CallByName Str.35 Str.161 Str.162;
-        let Str.303 : U8 = CallByName Str.35 Str.163 Str.164;
-        let Str.169 : Int1 = CallByName Bool.9 Str.302 Str.303;
-        let Str.292 : U64 = StructAtIndex 0 Str.160;
-        let Str.293 : Str = StructAtIndex 1 Str.160;
-        let Str.295 : Str = StructAtIndex 3 Str.160;
-        let Str.297 : U64 = StructAtIndex 5 Str.160;
-        let Str.301 : U64 = 1i64;
-        let Str.299 : U64 = CallByName Num.51 Str.164 Str.301;
-        let Str.300 : U64 = 1i64;
-        let Str.298 : U64 = CallByName Num.51 Str.162 Str.300;
-        let Str.291 : {U64, Str, U64, Str, U64, U64} = Struct {Str.292, Str.293, Str.298, Str.295, Str.299, Str.297};
-        let Str.170 : Int1 = CallByName Str.63 Str.291;
-        if Str.169 then
-            ret Str.170;
+        ret Str.154;
+
+procedure Str.63 (Str.155, Str.156, Str.157):
+    let Str.158 : U64 = CallByName Str.36 Str.155;
+    let Str.159 : U64 = CallByName Str.36 Str.157;
+    let Str.309 : U64 = CallByName Num.53 Str.156 Str.159;
+    let Str.160 : U64 = CallByName Str.62 Str.309 Str.158;
+    let Str.308 : U64 = 0i64;
+    inc Str.157;
+    inc Str.155;
+    let Str.289 : {U64, Str, U64, Str, U64, U64} = Struct {Str.160, Str.155, Str.156, Str.157, Str.308, Str.159};
+    let Str.288 : Int1 = CallByName Str.64 Str.289;
+    ret Str.288;
+
+procedure Str.64 (Str.161):
+    let Str.167 : U64 = StructAtIndex 0 Str.161;
+    let Str.162 : Str = StructAtIndex 1 Str.161;
+    let Str.163 : U64 = StructAtIndex 2 Str.161;
+    let Str.164 : Str = StructAtIndex 3 Str.161;
+    let Str.165 : U64 = StructAtIndex 4 Str.161;
+    let Str.166 : U64 = StructAtIndex 5 Str.161;
+    let Str.168 : Int1 = CallByName Num.25 Str.163 Str.167;
+    if Str.168 then
+        dec Str.162;
+        dec Str.164;
+        let Str.169 : Int1 = CallByName Bool.9 Str.165 Str.166;
+        ret Str.169;
+    else
+        let Str.304 : U8 = CallByName Str.35 Str.162 Str.163;
+        let Str.305 : U8 = CallByName Str.35 Str.164 Str.165;
+        let Str.170 : Int1 = CallByName Bool.9 Str.304 Str.305;
+        let Str.294 : U64 = StructAtIndex 0 Str.161;
+        let Str.295 : Str = StructAtIndex 1 Str.161;
+        let Str.297 : Str = StructAtIndex 3 Str.161;
+        let Str.299 : U64 = StructAtIndex 5 Str.161;
+        let Str.303 : U64 = 1i64;
+        let Str.301 : U64 = CallByName Num.51 Str.165 Str.303;
+        let Str.302 : U64 = 1i64;
+        let Str.300 : U64 = CallByName Num.51 Str.163 Str.302;
+        let Str.293 : {U64, Str, U64, Str, U64, U64} = Struct {Str.294, Str.295, Str.300, Str.297, Str.301, Str.299};
+        let Str.171 : Int1 = CallByName Str.64 Str.293;
+        if Str.170 then
+            ret Str.171;
         else
-            let Str.289 : Int1 = CallByName Bool.1;
-            ret Str.289;
+            let Str.291 : Int1 = CallByName Bool.1;
+            ret Str.291;
 
 procedure Test.0 ():
     let Test.2 : Str = "abc";

--- a/crates/compiler/test_mono/generated/inspect_derived_tag_one_field_string.txt
+++ b/crates/compiler/test_mono/generated/inspect_derived_tag_one_field_string.txt
@@ -223,184 +223,184 @@ procedure Num.77 (#Attr.2, #Attr.3):
     ret Num.293;
 
 procedure Str.20 (#Attr.2):
-    let Str.314 : Str = lowlevel StrWithCapacity #Attr.2;
-    ret Str.314;
+    let Str.316 : Str = lowlevel StrWithCapacity #Attr.2;
+    ret Str.316;
 
 procedure Str.3 (#Attr.2, #Attr.3):
-    let Str.246 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
-    ret Str.246;
+    let Str.248 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
+    ret Str.248;
 
 procedure Str.35 (#Attr.2, #Attr.3):
-    let Str.304 : U8 = lowlevel StrGetUnsafe #Attr.2 #Attr.3;
-    ret Str.304;
+    let Str.306 : U8 = lowlevel StrGetUnsafe #Attr.2 #Attr.3;
+    ret Str.306;
 
 procedure Str.36 (#Attr.2):
-    let Str.266 : U64 = lowlevel StrCountUtf8Bytes #Attr.2;
-    ret Str.266;
+    let Str.268 : U64 = lowlevel StrCountUtf8Bytes #Attr.2;
+    ret Str.268;
 
 procedure Str.37 (#Attr.2, #Attr.3, #Attr.4):
-    let Str.264 : Str = lowlevel StrSubstringUnsafe #Attr.2 #Attr.3 #Attr.4;
-    ret Str.264;
+    let Str.266 : Str = lowlevel StrSubstringUnsafe #Attr.2 #Attr.3 #Attr.4;
+    ret Str.266;
 
-procedure Str.38 (Str.112, Str.113):
-    let Str.260 : [C , C U64] = CallByName Str.57 Str.112 Str.113;
-    let Str.273 : U8 = 1i64;
-    let Str.274 : U8 = GetTagId Str.260;
-    let Str.275 : Int1 = lowlevel Eq Str.273 Str.274;
-    if Str.275 then
-        let Str.114 : U64 = UnionAtIndex (Id 1) (Index 0) Str.260;
-        let Str.269 : U64 = CallByName Str.36 Str.112;
-        let Str.270 : U64 = CallByName Str.36 Str.113;
-        let Str.268 : U64 = CallByName Num.20 Str.269 Str.270;
-        let Str.115 : U64 = CallByName Num.20 Str.268 Str.114;
-        let Str.267 : U64 = 0i64;
-        inc Str.112;
-        let Str.116 : Str = CallByName Str.37 Str.112 Str.267 Str.114;
-        let Str.265 : U64 = CallByName Str.36 Str.113;
-        let Str.263 : U64 = CallByName Num.51 Str.114 Str.265;
-        let Str.117 : Str = CallByName Str.37 Str.112 Str.263 Str.115;
-        let Str.262 : {Str, Str} = Struct {Str.117, Str.116};
-        let Str.261 : [C {}, C {Str, Str}] = TagId(1) Str.262;
-        ret Str.261;
+procedure Str.38 (Str.113, Str.114):
+    let Str.262 : [C , C U64] = CallByName Str.58 Str.113 Str.114;
+    let Str.275 : U8 = 1i64;
+    let Str.276 : U8 = GetTagId Str.262;
+    let Str.277 : Int1 = lowlevel Eq Str.275 Str.276;
+    if Str.277 then
+        let Str.115 : U64 = UnionAtIndex (Id 1) (Index 0) Str.262;
+        let Str.271 : U64 = CallByName Str.36 Str.113;
+        let Str.272 : U64 = CallByName Str.36 Str.114;
+        let Str.270 : U64 = CallByName Num.20 Str.271 Str.272;
+        let Str.116 : U64 = CallByName Num.20 Str.270 Str.115;
+        let Str.269 : U64 = 0i64;
+        inc Str.113;
+        let Str.117 : Str = CallByName Str.37 Str.113 Str.269 Str.115;
+        let Str.267 : U64 = CallByName Str.36 Str.114;
+        let Str.265 : U64 = CallByName Num.51 Str.115 Str.267;
+        let Str.118 : Str = CallByName Str.37 Str.113 Str.265 Str.116;
+        let Str.264 : {Str, Str} = Struct {Str.118, Str.117};
+        let Str.263 : [C {}, C {Str, Str}] = TagId(1) Str.264;
+        ret Str.263;
     else
-        dec Str.112;
-        let Str.272 : {} = Struct {};
-        let Str.271 : [C {}, C {Str, Str}] = TagId(0) Str.272;
-        ret Str.271;
+        dec Str.113;
+        let Str.274 : {} = Struct {};
+        let Str.273 : [C {}, C {Str, Str}] = TagId(0) Str.274;
+        ret Str.273;
 
-procedure Str.45 (Str.91, Str.92, Str.93):
-    inc Str.91;
-    let Str.342 : [C {}, C {Str, Str}] = CallByName Str.38 Str.91 Str.92;
-    let Str.350 : U8 = 1i64;
-    let Str.351 : U8 = GetTagId Str.342;
-    let Str.352 : Int1 = lowlevel Eq Str.350 Str.351;
-    if Str.352 then
-        let Str.349 : {Str, Str} = UnionAtIndex (Id 1) (Index 0) Str.342;
-        let Str.95 : Str = StructAtIndex 0 Str.349;
-        let Str.94 : Str = StructAtIndex 1 Str.349;
-        let Str.347 : U64 = CallByName Str.36 Str.91;
-        dec Str.91;
-        let Str.346 : Str = CallByName Str.20 Str.347;
-        let Str.345 : Str = CallByName Str.3 Str.346 Str.94;
-        dec Str.94;
-        let Str.344 : Str = CallByName Str.3 Str.345 Str.93;
-        let Str.343 : Str = CallByName Str.56 Str.344 Str.95 Str.92 Str.93;
-        ret Str.343;
+procedure Str.45 (Str.92, Str.93, Str.94):
+    inc Str.92;
+    let Str.344 : [C {}, C {Str, Str}] = CallByName Str.38 Str.92 Str.93;
+    let Str.352 : U8 = 1i64;
+    let Str.353 : U8 = GetTagId Str.344;
+    let Str.354 : Int1 = lowlevel Eq Str.352 Str.353;
+    if Str.354 then
+        let Str.351 : {Str, Str} = UnionAtIndex (Id 1) (Index 0) Str.344;
+        let Str.96 : Str = StructAtIndex 0 Str.351;
+        let Str.95 : Str = StructAtIndex 1 Str.351;
+        let Str.349 : U64 = CallByName Str.36 Str.92;
+        dec Str.92;
+        let Str.348 : Str = CallByName Str.20 Str.349;
+        let Str.347 : Str = CallByName Str.3 Str.348 Str.95;
+        dec Str.95;
+        let Str.346 : Str = CallByName Str.3 Str.347 Str.94;
+        let Str.345 : Str = CallByName Str.57 Str.346 Str.96 Str.93 Str.94;
+        ret Str.345;
     else
-        dec Str.342;
-        ret Str.91;
+        dec Str.344;
+        ret Str.92;
 
-procedure Str.56 (#Derived_gen.12, #Derived_gen.13, #Derived_gen.14, #Derived_gen.15):
-    joinpoint Str.250 Str.96 Str.97 Str.98 Str.99:
-        inc Str.97;
-        let Str.251 : [C {}, C {Str, Str}] = CallByName Str.38 Str.97 Str.98;
-        let Str.257 : U8 = 1i64;
-        let Str.258 : U8 = GetTagId Str.251;
-        let Str.259 : Int1 = lowlevel Eq Str.257 Str.258;
-        if Str.259 then
-            dec Str.97;
-            let Str.256 : {Str, Str} = UnionAtIndex (Id 1) (Index 0) Str.251;
-            let Str.101 : Str = StructAtIndex 0 Str.256;
-            let Str.100 : Str = StructAtIndex 1 Str.256;
-            let Str.254 : Str = CallByName Str.3 Str.96 Str.100;
-            dec Str.100;
-            let Str.253 : Str = CallByName Str.3 Str.254 Str.99;
-            jump Str.250 Str.253 Str.101 Str.98 Str.99;
-        else
+procedure Str.57 (#Derived_gen.12, #Derived_gen.13, #Derived_gen.14, #Derived_gen.15):
+    joinpoint Str.252 Str.97 Str.98 Str.99 Str.100:
+        inc Str.98;
+        let Str.253 : [C {}, C {Str, Str}] = CallByName Str.38 Str.98 Str.99;
+        let Str.259 : U8 = 1i64;
+        let Str.260 : U8 = GetTagId Str.253;
+        let Str.261 : Int1 = lowlevel Eq Str.259 Str.260;
+        if Str.261 then
             dec Str.98;
-            dec Str.251;
+            let Str.258 : {Str, Str} = UnionAtIndex (Id 1) (Index 0) Str.253;
+            let Str.102 : Str = StructAtIndex 0 Str.258;
+            let Str.101 : Str = StructAtIndex 1 Str.258;
+            let Str.256 : Str = CallByName Str.3 Str.97 Str.101;
+            dec Str.101;
+            let Str.255 : Str = CallByName Str.3 Str.256 Str.100;
+            jump Str.252 Str.255 Str.102 Str.99 Str.100;
+        else
+            dec Str.100;
             dec Str.99;
-            let Str.255 : Str = CallByName Str.3 Str.96 Str.97;
-            dec Str.97;
-            ret Str.255;
+            dec Str.253;
+            let Str.257 : Str = CallByName Str.3 Str.97 Str.98;
+            dec Str.98;
+            ret Str.257;
     in
     inc #Derived_gen.14;
     inc #Derived_gen.15;
-    jump Str.250 #Derived_gen.12 #Derived_gen.13 #Derived_gen.14 #Derived_gen.15;
+    jump Str.252 #Derived_gen.12 #Derived_gen.13 #Derived_gen.14 #Derived_gen.15;
 
-procedure Str.57 (Str.121, Str.122):
-    let Str.123 : U64 = CallByName Str.36 Str.121;
+procedure Str.58 (Str.122, Str.123):
     let Str.124 : U64 = CallByName Str.36 Str.122;
-    let Str.125 : U64 = CallByName Num.77 Str.123 Str.124;
-    let Str.277 : U64 = 0i64;
-    let Str.276 : [C , C U64] = CallByName Str.58 Str.121 Str.122 Str.277 Str.125;
-    ret Str.276;
+    let Str.125 : U64 = CallByName Str.36 Str.123;
+    let Str.126 : U64 = CallByName Num.77 Str.124 Str.125;
+    let Str.279 : U64 = 0i64;
+    let Str.278 : [C , C U64] = CallByName Str.59 Str.122 Str.123 Str.279 Str.126;
+    ret Str.278;
 
-procedure Str.58 (#Derived_gen.16, #Derived_gen.17, #Derived_gen.18, #Derived_gen.19):
-    joinpoint Str.278 Str.126 Str.127 Str.128 Str.129:
-        let Str.280 : Int1 = CallByName Num.23 Str.128 Str.129;
-        if Str.280 then
-            let Str.284 : Int1 = CallByName Str.62 Str.126 Str.128 Str.127;
-            if Str.284 then
+procedure Str.59 (#Derived_gen.16, #Derived_gen.17, #Derived_gen.18, #Derived_gen.19):
+    joinpoint Str.280 Str.127 Str.128 Str.129 Str.130:
+        let Str.282 : Int1 = CallByName Num.23 Str.129 Str.130;
+        if Str.282 then
+            let Str.286 : Int1 = CallByName Str.63 Str.127 Str.129 Str.128;
+            if Str.286 then
                 dec Str.127;
-                dec Str.126;
-                let Str.285 : [C , C U64] = TagId(1) Str.128;
-                ret Str.285;
+                dec Str.128;
+                let Str.287 : [C , C U64] = TagId(1) Str.129;
+                ret Str.287;
             else
-                let Str.283 : U64 = 1i64;
-                let Str.282 : U64 = CallByName Num.51 Str.128 Str.283;
-                jump Str.278 Str.126 Str.127 Str.282 Str.129;
+                let Str.285 : U64 = 1i64;
+                let Str.284 : U64 = CallByName Num.51 Str.129 Str.285;
+                jump Str.280 Str.127 Str.128 Str.284 Str.130;
         else
             dec Str.127;
-            dec Str.126;
-            let Str.279 : [C , C U64] = TagId(0) ;
-            ret Str.279;
+            dec Str.128;
+            let Str.281 : [C , C U64] = TagId(0) ;
+            ret Str.281;
     in
     inc #Derived_gen.17;
     inc #Derived_gen.16;
-    jump Str.278 #Derived_gen.16 #Derived_gen.17 #Derived_gen.18 #Derived_gen.19;
+    jump Str.280 #Derived_gen.16 #Derived_gen.17 #Derived_gen.18 #Derived_gen.19;
 
-procedure Str.61 (Str.152, Str.153):
-    let Str.309 : Int1 = CallByName Num.22 Str.152 Str.153;
-    if Str.309 then
-        ret Str.152;
-    else
+procedure Str.62 (Str.153, Str.154):
+    let Str.311 : Int1 = CallByName Num.22 Str.153 Str.154;
+    if Str.311 then
         ret Str.153;
-
-procedure Str.62 (Str.154, Str.155, Str.156):
-    let Str.157 : U64 = CallByName Str.36 Str.154;
-    let Str.158 : U64 = CallByName Str.36 Str.156;
-    let Str.307 : U64 = CallByName Num.53 Str.155 Str.158;
-    let Str.159 : U64 = CallByName Str.61 Str.307 Str.157;
-    let Str.306 : U64 = 0i64;
-    inc Str.156;
-    inc Str.154;
-    let Str.287 : {U64, Str, U64, Str, U64, U64} = Struct {Str.159, Str.154, Str.155, Str.156, Str.306, Str.158};
-    let Str.286 : Int1 = CallByName Str.63 Str.287;
-    ret Str.286;
-
-procedure Str.63 (Str.160):
-    let Str.166 : U64 = StructAtIndex 0 Str.160;
-    let Str.161 : Str = StructAtIndex 1 Str.160;
-    let Str.162 : U64 = StructAtIndex 2 Str.160;
-    let Str.163 : Str = StructAtIndex 3 Str.160;
-    let Str.164 : U64 = StructAtIndex 4 Str.160;
-    let Str.165 : U64 = StructAtIndex 5 Str.160;
-    let Str.167 : Int1 = CallByName Num.25 Str.162 Str.166;
-    if Str.167 then
-        dec Str.163;
-        dec Str.161;
-        let Str.168 : Int1 = CallByName Bool.9 Str.164 Str.165;
-        ret Str.168;
     else
-        let Str.302 : U8 = CallByName Str.35 Str.161 Str.162;
-        let Str.303 : U8 = CallByName Str.35 Str.163 Str.164;
-        let Str.169 : Int1 = CallByName Bool.9 Str.302 Str.303;
-        let Str.292 : U64 = StructAtIndex 0 Str.160;
-        let Str.293 : Str = StructAtIndex 1 Str.160;
-        let Str.295 : Str = StructAtIndex 3 Str.160;
-        let Str.297 : U64 = StructAtIndex 5 Str.160;
-        let Str.301 : U64 = 1i64;
-        let Str.299 : U64 = CallByName Num.51 Str.164 Str.301;
-        let Str.300 : U64 = 1i64;
-        let Str.298 : U64 = CallByName Num.51 Str.162 Str.300;
-        let Str.291 : {U64, Str, U64, Str, U64, U64} = Struct {Str.292, Str.293, Str.298, Str.295, Str.299, Str.297};
-        let Str.170 : Int1 = CallByName Str.63 Str.291;
-        if Str.169 then
-            ret Str.170;
+        ret Str.154;
+
+procedure Str.63 (Str.155, Str.156, Str.157):
+    let Str.158 : U64 = CallByName Str.36 Str.155;
+    let Str.159 : U64 = CallByName Str.36 Str.157;
+    let Str.309 : U64 = CallByName Num.53 Str.156 Str.159;
+    let Str.160 : U64 = CallByName Str.62 Str.309 Str.158;
+    let Str.308 : U64 = 0i64;
+    inc Str.157;
+    inc Str.155;
+    let Str.289 : {U64, Str, U64, Str, U64, U64} = Struct {Str.160, Str.155, Str.156, Str.157, Str.308, Str.159};
+    let Str.288 : Int1 = CallByName Str.64 Str.289;
+    ret Str.288;
+
+procedure Str.64 (Str.161):
+    let Str.167 : U64 = StructAtIndex 0 Str.161;
+    let Str.162 : Str = StructAtIndex 1 Str.161;
+    let Str.163 : U64 = StructAtIndex 2 Str.161;
+    let Str.164 : Str = StructAtIndex 3 Str.161;
+    let Str.165 : U64 = StructAtIndex 4 Str.161;
+    let Str.166 : U64 = StructAtIndex 5 Str.161;
+    let Str.168 : Int1 = CallByName Num.25 Str.163 Str.167;
+    if Str.168 then
+        dec Str.162;
+        dec Str.164;
+        let Str.169 : Int1 = CallByName Bool.9 Str.165 Str.166;
+        ret Str.169;
+    else
+        let Str.304 : U8 = CallByName Str.35 Str.162 Str.163;
+        let Str.305 : U8 = CallByName Str.35 Str.164 Str.165;
+        let Str.170 : Int1 = CallByName Bool.9 Str.304 Str.305;
+        let Str.294 : U64 = StructAtIndex 0 Str.161;
+        let Str.295 : Str = StructAtIndex 1 Str.161;
+        let Str.297 : Str = StructAtIndex 3 Str.161;
+        let Str.299 : U64 = StructAtIndex 5 Str.161;
+        let Str.303 : U64 = 1i64;
+        let Str.301 : U64 = CallByName Num.51 Str.165 Str.303;
+        let Str.302 : U64 = 1i64;
+        let Str.300 : U64 = CallByName Num.51 Str.163 Str.302;
+        let Str.293 : {U64, Str, U64, Str, U64, U64} = Struct {Str.294, Str.295, Str.300, Str.297, Str.301, Str.299};
+        let Str.171 : Int1 = CallByName Str.64 Str.293;
+        if Str.170 then
+            ret Str.171;
         else
-            let Str.289 : Int1 = CallByName Bool.1;
-            ret Str.289;
+            let Str.291 : Int1 = CallByName Bool.1;
+            ret Str.291;
 
 procedure Test.0 ():
     let Test.4 : Str = "foo";

--- a/crates/compiler/test_mono/generated/inspect_derived_tag_two_payloads_string.txt
+++ b/crates/compiler/test_mono/generated/inspect_derived_tag_two_payloads_string.txt
@@ -226,184 +226,184 @@ procedure Num.77 (#Attr.2, #Attr.3):
     ret Num.293;
 
 procedure Str.20 (#Attr.2):
-    let Str.314 : Str = lowlevel StrWithCapacity #Attr.2;
-    ret Str.314;
+    let Str.316 : Str = lowlevel StrWithCapacity #Attr.2;
+    ret Str.316;
 
 procedure Str.3 (#Attr.2, #Attr.3):
-    let Str.246 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
-    ret Str.246;
+    let Str.248 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
+    ret Str.248;
 
 procedure Str.35 (#Attr.2, #Attr.3):
-    let Str.304 : U8 = lowlevel StrGetUnsafe #Attr.2 #Attr.3;
-    ret Str.304;
+    let Str.306 : U8 = lowlevel StrGetUnsafe #Attr.2 #Attr.3;
+    ret Str.306;
 
 procedure Str.36 (#Attr.2):
-    let Str.266 : U64 = lowlevel StrCountUtf8Bytes #Attr.2;
-    ret Str.266;
+    let Str.268 : U64 = lowlevel StrCountUtf8Bytes #Attr.2;
+    ret Str.268;
 
 procedure Str.37 (#Attr.2, #Attr.3, #Attr.4):
-    let Str.264 : Str = lowlevel StrSubstringUnsafe #Attr.2 #Attr.3 #Attr.4;
-    ret Str.264;
+    let Str.266 : Str = lowlevel StrSubstringUnsafe #Attr.2 #Attr.3 #Attr.4;
+    ret Str.266;
 
-procedure Str.38 (Str.112, Str.113):
-    let Str.260 : [C , C U64] = CallByName Str.57 Str.112 Str.113;
-    let Str.273 : U8 = 1i64;
-    let Str.274 : U8 = GetTagId Str.260;
-    let Str.275 : Int1 = lowlevel Eq Str.273 Str.274;
-    if Str.275 then
-        let Str.114 : U64 = UnionAtIndex (Id 1) (Index 0) Str.260;
-        let Str.269 : U64 = CallByName Str.36 Str.112;
-        let Str.270 : U64 = CallByName Str.36 Str.113;
-        let Str.268 : U64 = CallByName Num.20 Str.269 Str.270;
-        let Str.115 : U64 = CallByName Num.20 Str.268 Str.114;
-        let Str.267 : U64 = 0i64;
-        inc Str.112;
-        let Str.116 : Str = CallByName Str.37 Str.112 Str.267 Str.114;
-        let Str.265 : U64 = CallByName Str.36 Str.113;
-        let Str.263 : U64 = CallByName Num.51 Str.114 Str.265;
-        let Str.117 : Str = CallByName Str.37 Str.112 Str.263 Str.115;
-        let Str.262 : {Str, Str} = Struct {Str.117, Str.116};
-        let Str.261 : [C {}, C {Str, Str}] = TagId(1) Str.262;
-        ret Str.261;
+procedure Str.38 (Str.113, Str.114):
+    let Str.262 : [C , C U64] = CallByName Str.58 Str.113 Str.114;
+    let Str.275 : U8 = 1i64;
+    let Str.276 : U8 = GetTagId Str.262;
+    let Str.277 : Int1 = lowlevel Eq Str.275 Str.276;
+    if Str.277 then
+        let Str.115 : U64 = UnionAtIndex (Id 1) (Index 0) Str.262;
+        let Str.271 : U64 = CallByName Str.36 Str.113;
+        let Str.272 : U64 = CallByName Str.36 Str.114;
+        let Str.270 : U64 = CallByName Num.20 Str.271 Str.272;
+        let Str.116 : U64 = CallByName Num.20 Str.270 Str.115;
+        let Str.269 : U64 = 0i64;
+        inc Str.113;
+        let Str.117 : Str = CallByName Str.37 Str.113 Str.269 Str.115;
+        let Str.267 : U64 = CallByName Str.36 Str.114;
+        let Str.265 : U64 = CallByName Num.51 Str.115 Str.267;
+        let Str.118 : Str = CallByName Str.37 Str.113 Str.265 Str.116;
+        let Str.264 : {Str, Str} = Struct {Str.118, Str.117};
+        let Str.263 : [C {}, C {Str, Str}] = TagId(1) Str.264;
+        ret Str.263;
     else
-        dec Str.112;
-        let Str.272 : {} = Struct {};
-        let Str.271 : [C {}, C {Str, Str}] = TagId(0) Str.272;
-        ret Str.271;
+        dec Str.113;
+        let Str.274 : {} = Struct {};
+        let Str.273 : [C {}, C {Str, Str}] = TagId(0) Str.274;
+        ret Str.273;
 
-procedure Str.45 (Str.91, Str.92, Str.93):
-    inc Str.91;
-    let Str.386 : [C {}, C {Str, Str}] = CallByName Str.38 Str.91 Str.92;
-    let Str.394 : U8 = 1i64;
-    let Str.395 : U8 = GetTagId Str.386;
-    let Str.396 : Int1 = lowlevel Eq Str.394 Str.395;
-    if Str.396 then
-        let Str.393 : {Str, Str} = UnionAtIndex (Id 1) (Index 0) Str.386;
-        let Str.95 : Str = StructAtIndex 0 Str.393;
-        let Str.94 : Str = StructAtIndex 1 Str.393;
-        let Str.391 : U64 = CallByName Str.36 Str.91;
-        dec Str.91;
-        let Str.390 : Str = CallByName Str.20 Str.391;
-        let Str.389 : Str = CallByName Str.3 Str.390 Str.94;
-        dec Str.94;
-        let Str.388 : Str = CallByName Str.3 Str.389 Str.93;
-        let Str.387 : Str = CallByName Str.56 Str.388 Str.95 Str.92 Str.93;
-        ret Str.387;
+procedure Str.45 (Str.92, Str.93, Str.94):
+    inc Str.92;
+    let Str.388 : [C {}, C {Str, Str}] = CallByName Str.38 Str.92 Str.93;
+    let Str.396 : U8 = 1i64;
+    let Str.397 : U8 = GetTagId Str.388;
+    let Str.398 : Int1 = lowlevel Eq Str.396 Str.397;
+    if Str.398 then
+        let Str.395 : {Str, Str} = UnionAtIndex (Id 1) (Index 0) Str.388;
+        let Str.96 : Str = StructAtIndex 0 Str.395;
+        let Str.95 : Str = StructAtIndex 1 Str.395;
+        let Str.393 : U64 = CallByName Str.36 Str.92;
+        dec Str.92;
+        let Str.392 : Str = CallByName Str.20 Str.393;
+        let Str.391 : Str = CallByName Str.3 Str.392 Str.95;
+        dec Str.95;
+        let Str.390 : Str = CallByName Str.3 Str.391 Str.94;
+        let Str.389 : Str = CallByName Str.57 Str.390 Str.96 Str.93 Str.94;
+        ret Str.389;
     else
-        dec Str.386;
-        ret Str.91;
+        dec Str.388;
+        ret Str.92;
 
-procedure Str.56 (#Derived_gen.13, #Derived_gen.14, #Derived_gen.15, #Derived_gen.16):
-    joinpoint Str.250 Str.96 Str.97 Str.98 Str.99:
-        inc Str.97;
-        let Str.251 : [C {}, C {Str, Str}] = CallByName Str.38 Str.97 Str.98;
-        let Str.257 : U8 = 1i64;
-        let Str.258 : U8 = GetTagId Str.251;
-        let Str.259 : Int1 = lowlevel Eq Str.257 Str.258;
-        if Str.259 then
-            dec Str.97;
-            let Str.256 : {Str, Str} = UnionAtIndex (Id 1) (Index 0) Str.251;
-            let Str.101 : Str = StructAtIndex 0 Str.256;
-            let Str.100 : Str = StructAtIndex 1 Str.256;
-            let Str.254 : Str = CallByName Str.3 Str.96 Str.100;
-            dec Str.100;
-            let Str.253 : Str = CallByName Str.3 Str.254 Str.99;
-            jump Str.250 Str.253 Str.101 Str.98 Str.99;
-        else
+procedure Str.57 (#Derived_gen.13, #Derived_gen.14, #Derived_gen.15, #Derived_gen.16):
+    joinpoint Str.252 Str.97 Str.98 Str.99 Str.100:
+        inc Str.98;
+        let Str.253 : [C {}, C {Str, Str}] = CallByName Str.38 Str.98 Str.99;
+        let Str.259 : U8 = 1i64;
+        let Str.260 : U8 = GetTagId Str.253;
+        let Str.261 : Int1 = lowlevel Eq Str.259 Str.260;
+        if Str.261 then
             dec Str.98;
-            dec Str.251;
+            let Str.258 : {Str, Str} = UnionAtIndex (Id 1) (Index 0) Str.253;
+            let Str.102 : Str = StructAtIndex 0 Str.258;
+            let Str.101 : Str = StructAtIndex 1 Str.258;
+            let Str.256 : Str = CallByName Str.3 Str.97 Str.101;
+            dec Str.101;
+            let Str.255 : Str = CallByName Str.3 Str.256 Str.100;
+            jump Str.252 Str.255 Str.102 Str.99 Str.100;
+        else
+            dec Str.100;
             dec Str.99;
-            let Str.255 : Str = CallByName Str.3 Str.96 Str.97;
-            dec Str.97;
-            ret Str.255;
+            dec Str.253;
+            let Str.257 : Str = CallByName Str.3 Str.97 Str.98;
+            dec Str.98;
+            ret Str.257;
     in
     inc #Derived_gen.15;
     inc #Derived_gen.16;
-    jump Str.250 #Derived_gen.13 #Derived_gen.14 #Derived_gen.15 #Derived_gen.16;
+    jump Str.252 #Derived_gen.13 #Derived_gen.14 #Derived_gen.15 #Derived_gen.16;
 
-procedure Str.57 (Str.121, Str.122):
-    let Str.123 : U64 = CallByName Str.36 Str.121;
+procedure Str.58 (Str.122, Str.123):
     let Str.124 : U64 = CallByName Str.36 Str.122;
-    let Str.125 : U64 = CallByName Num.77 Str.123 Str.124;
-    let Str.277 : U64 = 0i64;
-    let Str.276 : [C , C U64] = CallByName Str.58 Str.121 Str.122 Str.277 Str.125;
-    ret Str.276;
+    let Str.125 : U64 = CallByName Str.36 Str.123;
+    let Str.126 : U64 = CallByName Num.77 Str.124 Str.125;
+    let Str.279 : U64 = 0i64;
+    let Str.278 : [C , C U64] = CallByName Str.59 Str.122 Str.123 Str.279 Str.126;
+    ret Str.278;
 
-procedure Str.58 (#Derived_gen.17, #Derived_gen.18, #Derived_gen.19, #Derived_gen.20):
-    joinpoint Str.278 Str.126 Str.127 Str.128 Str.129:
-        let Str.280 : Int1 = CallByName Num.23 Str.128 Str.129;
-        if Str.280 then
-            let Str.284 : Int1 = CallByName Str.62 Str.126 Str.128 Str.127;
-            if Str.284 then
+procedure Str.59 (#Derived_gen.17, #Derived_gen.18, #Derived_gen.19, #Derived_gen.20):
+    joinpoint Str.280 Str.127 Str.128 Str.129 Str.130:
+        let Str.282 : Int1 = CallByName Num.23 Str.129 Str.130;
+        if Str.282 then
+            let Str.286 : Int1 = CallByName Str.63 Str.127 Str.129 Str.128;
+            if Str.286 then
                 dec Str.127;
-                dec Str.126;
-                let Str.285 : [C , C U64] = TagId(1) Str.128;
-                ret Str.285;
+                dec Str.128;
+                let Str.287 : [C , C U64] = TagId(1) Str.129;
+                ret Str.287;
             else
-                let Str.283 : U64 = 1i64;
-                let Str.282 : U64 = CallByName Num.51 Str.128 Str.283;
-                jump Str.278 Str.126 Str.127 Str.282 Str.129;
+                let Str.285 : U64 = 1i64;
+                let Str.284 : U64 = CallByName Num.51 Str.129 Str.285;
+                jump Str.280 Str.127 Str.128 Str.284 Str.130;
         else
             dec Str.127;
-            dec Str.126;
-            let Str.279 : [C , C U64] = TagId(0) ;
-            ret Str.279;
+            dec Str.128;
+            let Str.281 : [C , C U64] = TagId(0) ;
+            ret Str.281;
     in
     inc #Derived_gen.17;
     inc #Derived_gen.18;
-    jump Str.278 #Derived_gen.17 #Derived_gen.18 #Derived_gen.19 #Derived_gen.20;
+    jump Str.280 #Derived_gen.17 #Derived_gen.18 #Derived_gen.19 #Derived_gen.20;
 
-procedure Str.61 (Str.152, Str.153):
-    let Str.309 : Int1 = CallByName Num.22 Str.152 Str.153;
-    if Str.309 then
-        ret Str.152;
-    else
+procedure Str.62 (Str.153, Str.154):
+    let Str.311 : Int1 = CallByName Num.22 Str.153 Str.154;
+    if Str.311 then
         ret Str.153;
-
-procedure Str.62 (Str.154, Str.155, Str.156):
-    let Str.157 : U64 = CallByName Str.36 Str.154;
-    let Str.158 : U64 = CallByName Str.36 Str.156;
-    let Str.307 : U64 = CallByName Num.53 Str.155 Str.158;
-    let Str.159 : U64 = CallByName Str.61 Str.307 Str.157;
-    let Str.306 : U64 = 0i64;
-    inc Str.156;
-    inc Str.154;
-    let Str.287 : {U64, Str, U64, Str, U64, U64} = Struct {Str.159, Str.154, Str.155, Str.156, Str.306, Str.158};
-    let Str.286 : Int1 = CallByName Str.63 Str.287;
-    ret Str.286;
-
-procedure Str.63 (Str.160):
-    let Str.166 : U64 = StructAtIndex 0 Str.160;
-    let Str.161 : Str = StructAtIndex 1 Str.160;
-    let Str.162 : U64 = StructAtIndex 2 Str.160;
-    let Str.163 : Str = StructAtIndex 3 Str.160;
-    let Str.164 : U64 = StructAtIndex 4 Str.160;
-    let Str.165 : U64 = StructAtIndex 5 Str.160;
-    let Str.167 : Int1 = CallByName Num.25 Str.162 Str.166;
-    if Str.167 then
-        dec Str.163;
-        dec Str.161;
-        let Str.168 : Int1 = CallByName Bool.9 Str.164 Str.165;
-        ret Str.168;
     else
-        let Str.302 : U8 = CallByName Str.35 Str.161 Str.162;
-        let Str.303 : U8 = CallByName Str.35 Str.163 Str.164;
-        let Str.169 : Int1 = CallByName Bool.9 Str.302 Str.303;
-        let Str.292 : U64 = StructAtIndex 0 Str.160;
-        let Str.293 : Str = StructAtIndex 1 Str.160;
-        let Str.295 : Str = StructAtIndex 3 Str.160;
-        let Str.297 : U64 = StructAtIndex 5 Str.160;
-        let Str.301 : U64 = 1i64;
-        let Str.299 : U64 = CallByName Num.51 Str.164 Str.301;
-        let Str.300 : U64 = 1i64;
-        let Str.298 : U64 = CallByName Num.51 Str.162 Str.300;
-        let Str.291 : {U64, Str, U64, Str, U64, U64} = Struct {Str.292, Str.293, Str.298, Str.295, Str.299, Str.297};
-        let Str.170 : Int1 = CallByName Str.63 Str.291;
-        if Str.169 then
-            ret Str.170;
+        ret Str.154;
+
+procedure Str.63 (Str.155, Str.156, Str.157):
+    let Str.158 : U64 = CallByName Str.36 Str.155;
+    let Str.159 : U64 = CallByName Str.36 Str.157;
+    let Str.309 : U64 = CallByName Num.53 Str.156 Str.159;
+    let Str.160 : U64 = CallByName Str.62 Str.309 Str.158;
+    let Str.308 : U64 = 0i64;
+    inc Str.157;
+    inc Str.155;
+    let Str.289 : {U64, Str, U64, Str, U64, U64} = Struct {Str.160, Str.155, Str.156, Str.157, Str.308, Str.159};
+    let Str.288 : Int1 = CallByName Str.64 Str.289;
+    ret Str.288;
+
+procedure Str.64 (Str.161):
+    let Str.167 : U64 = StructAtIndex 0 Str.161;
+    let Str.162 : Str = StructAtIndex 1 Str.161;
+    let Str.163 : U64 = StructAtIndex 2 Str.161;
+    let Str.164 : Str = StructAtIndex 3 Str.161;
+    let Str.165 : U64 = StructAtIndex 4 Str.161;
+    let Str.166 : U64 = StructAtIndex 5 Str.161;
+    let Str.168 : Int1 = CallByName Num.25 Str.163 Str.167;
+    if Str.168 then
+        dec Str.162;
+        dec Str.164;
+        let Str.169 : Int1 = CallByName Bool.9 Str.165 Str.166;
+        ret Str.169;
+    else
+        let Str.304 : U8 = CallByName Str.35 Str.162 Str.163;
+        let Str.305 : U8 = CallByName Str.35 Str.164 Str.165;
+        let Str.170 : Int1 = CallByName Bool.9 Str.304 Str.305;
+        let Str.294 : U64 = StructAtIndex 0 Str.161;
+        let Str.295 : Str = StructAtIndex 1 Str.161;
+        let Str.297 : Str = StructAtIndex 3 Str.161;
+        let Str.299 : U64 = StructAtIndex 5 Str.161;
+        let Str.303 : U64 = 1i64;
+        let Str.301 : U64 = CallByName Num.51 Str.165 Str.303;
+        let Str.302 : U64 = 1i64;
+        let Str.300 : U64 = CallByName Num.51 Str.163 Str.302;
+        let Str.293 : {U64, Str, U64, Str, U64, U64} = Struct {Str.294, Str.295, Str.300, Str.297, Str.301, Str.299};
+        let Str.171 : Int1 = CallByName Str.64 Str.293;
+        if Str.170 then
+            ret Str.171;
         else
-            let Str.289 : Int1 = CallByName Bool.1;
-            ret Str.289;
+            let Str.291 : Int1 = CallByName Bool.1;
+            ret Str.291;
 
 procedure Test.0 ():
     let Test.5 : Str = "foo";

--- a/crates/compiler/test_mono/generated/issue_2583_specialize_errors_behind_unified_branches.txt
+++ b/crates/compiler/test_mono/generated/issue_2583_specialize_errors_behind_unified_branches.txt
@@ -45,27 +45,27 @@ procedure Num.22 (#Attr.2, #Attr.3):
     let Num.283 : Int1 = lowlevel NumLt #Attr.2 #Attr.3;
     ret Num.283;
 
-procedure Str.27 (Str.84):
-    let Str.246 : [C Int1, C I64] = CallByName Str.66 Str.84;
-    ret Str.246;
+procedure Str.27 (Str.85):
+    let Str.248 : [C Int1, C I64] = CallByName Str.67 Str.85;
+    ret Str.248;
 
 procedure Str.42 (#Attr.2):
-    let Str.254 : {I64, U8} = lowlevel StrToNum #Attr.2;
-    ret Str.254;
+    let Str.256 : {I64, U8} = lowlevel StrToNum #Attr.2;
+    ret Str.256;
 
-procedure Str.66 (Str.191):
-    let Str.192 : {I64, U8} = CallByName Str.42 Str.191;
-    let Str.252 : U8 = StructAtIndex 1 Str.192;
-    let Str.253 : U8 = 0i64;
-    let Str.249 : Int1 = CallByName Bool.9 Str.252 Str.253;
-    if Str.249 then
-        let Str.251 : I64 = StructAtIndex 0 Str.192;
-        let Str.250 : [C Int1, C I64] = TagId(1) Str.251;
-        ret Str.250;
+procedure Str.67 (Str.192):
+    let Str.193 : {I64, U8} = CallByName Str.42 Str.192;
+    let Str.254 : U8 = StructAtIndex 1 Str.193;
+    let Str.255 : U8 = 0i64;
+    let Str.251 : Int1 = CallByName Bool.9 Str.254 Str.255;
+    if Str.251 then
+        let Str.253 : I64 = StructAtIndex 0 Str.193;
+        let Str.252 : [C Int1, C I64] = TagId(1) Str.253;
+        ret Str.252;
     else
-        let Str.248 : Int1 = false;
-        let Str.247 : [C Int1, C I64] = TagId(0) Str.248;
-        ret Str.247;
+        let Str.250 : Int1 = false;
+        let Str.249 : [C Int1, C I64] = TagId(0) Str.250;
+        ret Str.249;
 
 procedure Test.0 ():
     let Test.3 : Int1 = CallByName Bool.2;

--- a/crates/compiler/test_mono/generated/issue_4772_weakened_monomorphic_destructure.txt
+++ b/crates/compiler/test_mono/generated/issue_4772_weakened_monomorphic_destructure.txt
@@ -19,30 +19,30 @@ procedure Decode.26 (Decode.109, Decode.110):
     ret Decode.126;
 
 procedure Str.12 (#Attr.2):
-    let Str.255 : List U8 = lowlevel StrToUtf8 #Attr.2;
-    ret Str.255;
+    let Str.257 : List U8 = lowlevel StrToUtf8 #Attr.2;
+    ret Str.257;
 
-procedure Str.27 (Str.84):
-    let Str.246 : [C {}, C I64] = CallByName Str.66 Str.84;
-    ret Str.246;
+procedure Str.27 (Str.85):
+    let Str.248 : [C {}, C I64] = CallByName Str.67 Str.85;
+    ret Str.248;
 
 procedure Str.42 (#Attr.2):
-    let Str.254 : {I64, U8} = lowlevel StrToNum #Attr.2;
-    ret Str.254;
+    let Str.256 : {I64, U8} = lowlevel StrToNum #Attr.2;
+    ret Str.256;
 
-procedure Str.66 (Str.191):
-    let Str.192 : {I64, U8} = CallByName Str.42 Str.191;
-    let Str.252 : U8 = StructAtIndex 1 Str.192;
-    let Str.253 : U8 = 0i64;
-    let Str.249 : Int1 = CallByName Bool.9 Str.252 Str.253;
-    if Str.249 then
-        let Str.251 : I64 = StructAtIndex 0 Str.192;
-        let Str.250 : [C {}, C I64] = TagId(1) Str.251;
-        ret Str.250;
+procedure Str.67 (Str.192):
+    let Str.193 : {I64, U8} = CallByName Str.42 Str.192;
+    let Str.254 : U8 = StructAtIndex 1 Str.193;
+    let Str.255 : U8 = 0i64;
+    let Str.251 : Int1 = CallByName Bool.9 Str.254 Str.255;
+    if Str.251 then
+        let Str.253 : I64 = StructAtIndex 0 Str.193;
+        let Str.252 : [C {}, C I64] = TagId(1) Str.253;
+        ret Str.252;
     else
-        let Str.248 : {} = Struct {};
-        let Str.247 : [C {}, C I64] = TagId(0) Str.248;
-        ret Str.247;
+        let Str.250 : {} = Struct {};
+        let Str.249 : [C {}, C I64] = TagId(0) Str.250;
+        ret Str.249;
 
 procedure Test.103 ():
     let Test.101 : [C Str, C {List U8, I64}] = CallByName Test.19;

--- a/crates/compiler/test_mono/generated/lambda_capture_niches_with_other_lambda_capture.txt
+++ b/crates/compiler/test_mono/generated/lambda_capture_niches_with_other_lambda_capture.txt
@@ -1,6 +1,6 @@
 procedure Str.3 (#Attr.2, #Attr.3):
-    let Str.246 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
-    ret Str.246;
+    let Str.248 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
+    ret Str.248;
 
 procedure Test.1 (Test.5):
     let Test.16 : [C {}, C U64, C Str] = TagId(0) Test.5;

--- a/crates/compiler/test_mono/generated/list_map_closure_borrows.txt
+++ b/crates/compiler/test_mono/generated/list_map_closure_borrows.txt
@@ -71,12 +71,12 @@ procedure Num.51 (#Attr.2, #Attr.3):
     ret Num.285;
 
 procedure Str.16 (#Attr.2, #Attr.3):
-    let Str.246 : Str = lowlevel StrRepeat #Attr.2 #Attr.3;
-    ret Str.246;
+    let Str.248 : Str = lowlevel StrRepeat #Attr.2 #Attr.3;
+    ret Str.248;
 
 procedure Str.3 (#Attr.2, #Attr.3):
-    let Str.247 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
-    ret Str.247;
+    let Str.249 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
+    ret Str.249;
 
 procedure Test.1 ():
     let Test.21 : Str = "lllllllllllllllllllllooooooooooong";

--- a/crates/compiler/test_mono/generated/list_map_closure_owns.txt
+++ b/crates/compiler/test_mono/generated/list_map_closure_owns.txt
@@ -70,8 +70,8 @@ procedure Num.51 (#Attr.2, #Attr.3):
     ret Num.285;
 
 procedure Str.3 (#Attr.2, #Attr.3):
-    let Str.247 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
-    ret Str.247;
+    let Str.249 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
+    ret Str.249;
 
 procedure Test.1 ():
     let Test.21 : Str = "lllllllllllllllllllllooooooooooong";

--- a/crates/compiler/test_mono/generated/pizza_dbg.txt
+++ b/crates/compiler/test_mono/generated/pizza_dbg.txt
@@ -43,8 +43,8 @@ procedure Num.96 (#Attr.2):
     ret Num.284;
 
 procedure Str.3 (#Attr.2, #Attr.3):
-    let Str.246 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
-    ret Str.246;
+    let Str.248 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
+    ret Str.248;
 
 procedure Test.0 ():
     let Test.2 : I64 = 1i64;

--- a/crates/compiler/test_mono/generated/polymorphic_expression_unification.txt
+++ b/crates/compiler/test_mono/generated/polymorphic_expression_unification.txt
@@ -3,8 +3,8 @@ procedure Bool.9 (#Attr.2, #Attr.3):
     ret Bool.21;
 
 procedure Str.3 (#Attr.2, #Attr.3):
-    let Str.247 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
-    ret Str.247;
+    let Str.249 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
+    ret Str.249;
 
 procedure Test.2 (Test.7):
     let Test.24 : Str = ".trace(\"";

--- a/crates/compiler/test_mono/generated/recursively_build_effect.txt
+++ b/crates/compiler/test_mono/generated/recursively_build_effect.txt
@@ -3,8 +3,8 @@ procedure Num.20 (#Attr.2, #Attr.3):
     ret Num.283;
 
 procedure Str.3 (#Attr.2, #Attr.3):
-    let Str.248 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
-    ret Str.248;
+    let Str.250 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
+    ret Str.250;
 
 procedure Test.11 (Test.29, #Attr.12):
     let Test.32 : {} = UnionAtIndex (Id 0) (Index 0) #Attr.12;

--- a/crates/compiler/test_mono/generated/return_annotated.txt
+++ b/crates/compiler/test_mono/generated/return_annotated.txt
@@ -2,27 +2,27 @@ procedure Bool.9 (#Attr.2, #Attr.3):
     let Bool.21 : Int1 = lowlevel Eq #Attr.2 #Attr.3;
     ret Bool.21;
 
-procedure Str.26 (Str.83):
-    let Str.246 : [C {}, C U64] = CallByName Str.66 Str.83;
-    ret Str.246;
+procedure Str.26 (Str.84):
+    let Str.248 : [C {}, C U64] = CallByName Str.67 Str.84;
+    ret Str.248;
 
 procedure Str.42 (#Attr.2):
-    let Str.254 : {U64, U8} = lowlevel StrToNum #Attr.2;
-    ret Str.254;
+    let Str.256 : {U64, U8} = lowlevel StrToNum #Attr.2;
+    ret Str.256;
 
-procedure Str.66 (Str.191):
-    let Str.192 : {U64, U8} = CallByName Str.42 Str.191;
-    let Str.252 : U8 = StructAtIndex 1 Str.192;
-    let Str.253 : U8 = 0i64;
-    let Str.249 : Int1 = CallByName Bool.9 Str.252 Str.253;
-    if Str.249 then
-        let Str.251 : U64 = StructAtIndex 0 Str.192;
-        let Str.250 : [C {}, C U64] = TagId(1) Str.251;
-        ret Str.250;
+procedure Str.67 (Str.192):
+    let Str.193 : {U64, U8} = CallByName Str.42 Str.192;
+    let Str.254 : U8 = StructAtIndex 1 Str.193;
+    let Str.255 : U8 = 0i64;
+    let Str.251 : Int1 = CallByName Bool.9 Str.254 Str.255;
+    if Str.251 then
+        let Str.253 : U64 = StructAtIndex 0 Str.193;
+        let Str.252 : [C {}, C U64] = TagId(1) Str.253;
+        ret Str.252;
     else
-        let Str.248 : {} = Struct {};
-        let Str.247 : [C {}, C U64] = TagId(0) Str.248;
-        ret Str.247;
+        let Str.250 : {} = Struct {};
+        let Str.249 : [C {}, C U64] = TagId(0) Str.250;
+        ret Str.249;
 
 procedure Test.1 (Test.2):
     joinpoint Test.11 Test.3:

--- a/crates/compiler/test_mono/generated/unspecialized_lambda_set_unification_does_not_duplicate_identical_concrete_types.txt
+++ b/crates/compiler/test_mono/generated/unspecialized_lambda_set_unification_does_not_duplicate_identical_concrete_types.txt
@@ -99,12 +99,12 @@ procedure Num.96 (#Attr.2):
     ret Num.283;
 
 procedure Str.12 (#Attr.2):
-    let Str.247 : List U8 = lowlevel StrToUtf8 #Attr.2;
-    ret Str.247;
+    let Str.249 : List U8 = lowlevel StrToUtf8 #Attr.2;
+    ret Str.249;
 
 procedure Str.36 (#Attr.2):
-    let Str.248 : U64 = lowlevel StrCountUtf8Bytes #Attr.2;
-    ret Str.248;
+    let Str.250 : U64 = lowlevel StrCountUtf8Bytes #Attr.2;
+    ret Str.250;
 
 procedure Test.20 (Test.58):
     let Test.295 : Str = CallByName Encode.23 Test.58;

--- a/crates/compiler/test_mono/generated/unspecialized_lambda_set_unification_keeps_all_concrete_types_without_unification_of_unifiable.txt
+++ b/crates/compiler/test_mono/generated/unspecialized_lambda_set_unification_keeps_all_concrete_types_without_unification_of_unifiable.txt
@@ -192,12 +192,12 @@ procedure Num.96 (#Attr.2):
     ret Num.287;
 
 procedure Str.12 (#Attr.2):
-    let Str.250 : List U8 = lowlevel StrToUtf8 #Attr.2;
-    ret Str.250;
+    let Str.252 : List U8 = lowlevel StrToUtf8 #Attr.2;
+    ret Str.252;
 
 procedure Str.36 (#Attr.2):
-    let Str.251 : U64 = lowlevel StrCountUtf8Bytes #Attr.2;
-    ret Str.251;
+    let Str.253 : U64 = lowlevel StrCountUtf8Bytes #Attr.2;
+    ret Str.253;
 
 procedure Test.20 (Test.58):
     inc Test.58;

--- a/crates/compiler/uitest/tests/ability/specialize/inspect/opaque_automatic.txt
+++ b/crates/compiler/uitest/tests/ability/specialize/inspect/opaque_automatic.txt
@@ -46,8 +46,8 @@ procedure Inspect.64 (Inspect.297):
     ret Inspect.297;
 
 procedure Str.3 (#Attr.2, #Attr.3):
-    let Str.246 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
-    ret Str.246;
+    let Str.248 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
+    ret Str.248;
 
 procedure Test.0 ():
     let Test.4 : {} = Struct {};

--- a/crates/compiler/uitest/tests/ability/specialize/inspect/opaque_automatic_late.txt
+++ b/crates/compiler/uitest/tests/ability/specialize/inspect/opaque_automatic_late.txt
@@ -49,8 +49,8 @@ procedure Inspect.64 (Inspect.297):
     ret Inspect.297;
 
 procedure Str.3 (#Attr.2, #Attr.3):
-    let Str.246 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
-    ret Str.246;
+    let Str.248 : Str = lowlevel StrConcat #Attr.2 #Attr.3;
+    ret Str.248;
 
 procedure Test.2 (Test.3):
     let Test.4 : Str = CallByName Inspect.33 Test.3;


### PR DESCRIPTION
Please, before you approve, check out the zig code changes, since I'm unsure about handling reference counts. Tests were passing whether I put a referece count decrement statement in the with_ascii_lowercased function or not for the non-unique strings branch, so the `string.decref();` is in there quiet arbitrarily.

`initFromBigStr` isn't used anywhere, so I deleted it.

The test `with_ascii_lowercased_non_zero_refcounttest` in `crates/compiler/test_gen/src/gen_str.rs` is an attempt at testing the function when the refcount of it's input string is > 1, but I'm not sure if that's what it does actually.