### PR TITLE
linker/macho: redo bits of preprocessing host

### DIFF
--- a/crates/linker/src/macho.rs
+++ b/crates/linker/src/macho.rs
@@ -62,7 +62,9 @@ struct Metadata {
     exec_len: u64,
     load_align_constraint: u64,
     last_vaddr: u64,
-    macho_cmd_loc: u64,
+    // Offset just after the last load command.
+    // TODO: this is easy to re-calculate on the fly from just the header.
+    end_of_load_commands: usize,
     // Offset of the first section following the load commands.
     start_of_first_section: u64,
     // List of all __LINKEDIT load commands and their offset in file.
@@ -739,7 +741,7 @@ fn gen_macho_le(
     }
 
     // cmd_loc should be where the last offset ended
-    md.macho_cmd_loc = offset as u64;
+    md.end_of_load_commands = offset;
 
     out_mmap
 }


### PR DESCRIPTION
The general idea behind this changeset is that we actually do not want shift any of the loadable segments (and sections) in memory/file offsets. Instead we can ensure prior to generating host that we have enough room in the load commands section via linker flag `-headerpad <size>` which instructs the linker to leave `size` space between the end of the load commands and the start of the first section.

With this out of the way, my proposal is to pre-insert the maximum number of load commands that may be required, set their vmaddr/offset/size values to 0, and then prune in the surgical link stage. We will pre-insert those segment load commands after existing segment load commands but before `__LINKEDIT` segment load command to please Apple tooling (or die trying).

To illustrate this, here's what a set of load commands may look like before preprocessing:

```
Input load commands:
  LC_SEGMENT_64(25) => 72 @ 32                       // __PAGEZERO
  LC_SEGMENT_64(25) => 712 @ 104                     // __TEXT
  LC_SEGMENT_64(25) => 232 @ 816                     // __DATA_CONST
  LC_SEGMENT_64(25) => 632 @ 1048                    // __DATA
  LC_SEGMENT_64(25) => 72 @ 1680                     // __LINKEDIT
  LC_DYLD_INFO_ONLY(2147483682) => 48 @ 1752
  LC_SYMTAB(2) => 24 @ 1800
  LC_DYSYMTAB(11) => 80 @ 1824
  LC_LOAD_DYLINKER(14) => 32 @ 1904
  LC_UUID(27) => 24 @ 1936
  LC_BUILD_VERSION(50) => 32 @ 1960
  LC_SOURCE_VERSION(42) => 16 @ 1992
  LC_MAIN(2147483688) => 24 @ 2008
  LC_LOAD_DYLIB(12) => 48 @ 2032
  LC_LOAD_DYLIB(12) => 96 @ 2080
  LC_LOAD_DYLIB(12) => 104 @ 2176
  LC_LOAD_DYLIB(12) => 104 @ 2280
  LC_LOAD_DYLIB(12) => 56 @ 2384
  LC_FUNCTION_STARTS(38) => 16 @ 2440
  LC_DATA_IN_CODE(41) => 16 @ 2456
  LC_CODE_SIGNATURE(29) => 16 @ 2472
```

and now after preprocessing

```
Output load commands:
  LC_SEGMENT_64(25) => 72 @ 32                              // __PAGEZERO
  LC_SEGMENT_64(25) => 712 @ 104                            // __TEXT
  LC_SEGMENT_64(25) => 232 @ 816                            // __DATA_CONST
  LC_SEGMENT_64(25) => 632 @ 1048                           // __DATA
  LC_SEGMENT_64(25) => 152 @ 1680                           // __ROC_TEXT
  LC_SEGMENT_64(25) => 152 @ 1832                           // __ROC_DATA_CONST
  LC_SEGMENT_64(25) => 232 @ 1984                           // __ROC_DATA
  LC_SEGMENT_64(25) => 72 @ 2216                            // __LINKEDIT
  LC_DYLD_INFO_ONLY(2147483682) => 48 @ 2288
  LC_SYMTAB(2) => 24 @ 2336
  LC_DYSYMTAB(11) => 80 @ 2360
  LC_LOAD_DYLINKER(14) => 32 @ 2440
  LC_UUID(27) => 24 @ 2472
  LC_BUILD_VERSION(50) => 32 @ 2496
  LC_SOURCE_VERSION(42) => 16 @ 2528
  LC_MAIN(2147483688) => 24 @ 2544
  LC_LOAD_DYLIB(12) => 96 @ 2568
  LC_LOAD_DYLIB(12) => 104 @ 2664
  LC_LOAD_DYLIB(12) => 104 @ 2768
  LC_LOAD_DYLIB(12) => 56 @ 2872
  LC_FUNCTION_STARTS(38) => 16 @ 2928
  LC_DATA_IN_CODE(41) => 16 @ 2944
  LC_CODE_SIGNATURE(29) => 16 @ 2960
```

Also, to make it easier for debugging, I named the segments prefix with `__ROC_`.

This entire scheme should only require updating the offsets in `__LINKEDIT` segment, initially that would be `LC_DYLD_INFO_ONLY` sections and `LC_CODE_SIGNATURE`. On the topic of code signature, it would be possible to re-calculate only hashes of pages that actually were touched/added by the surgical linker, but this is a future optimisation - first, the Roc linker need to learn how to emit a code signature.