### PR TITLE
Fix: `AppHeader::iter_tokens` iterates `provides` twice

### DIFF
--- a/crates/language_server/src/analysis/tokens.rs
+++ b/crates/language_server/src/analysis/tokens.rs
@@ -254,7 +254,6 @@ impl IterTokens for AppHeader<'_> {
 
         (provides.iter_tokens(arena).into_iter())
             .chain(packages.value.iter_tokens(arena))
-            .chain(provides.iter_tokens(arena))
             .chain(old_imports.iter().flat_map(|i| i.item.iter_tokens(arena)))
             .collect_in(arena)
     }


### PR DESCRIPTION
Fixes panic:
```
thread 'main' panicked at crates/language_server/src/analysis/semantic_tokens.rs:31:13:
attempt to subtract with overflow
[Error - 11:21:33 AM] Request textDocument/semanticTokens/full failed.
  Message: Any { .. }
  Code: -32603
```

Panics because `analysis::semantic_tokens::arrange_semantic_tokens` expects token positions to always be increasing.