### PR TITLE
Remove indented-else syntax from the formatter

### DIFF
--- a/crates/compiler/fmt/src/expr.rs
+++ b/crates/compiler/fmt/src/expr.rs
@@ -233,16 +233,9 @@ fn format_expr_only(
         Expr::If {
             if_thens: branches,
             final_else,
-            indented_else,
+            indented_else: _,
         } => {
-            fmt_if(
-                buf,
-                branches,
-                final_else,
-                item.is_multiline(),
-                *indented_else,
-                indent,
-            );
+            fmt_if(buf, branches, final_else, item.is_multiline(), indent);
         }
         Expr::When(loc_condition, branches) => fmt_when(buf, loc_condition, branches, indent),
         Expr::Tuple(items) => fmt_expr_collection(buf, indent, Braces::Round, *items, Newlines::No),
@@ -1927,8 +1920,6 @@ fn fmt_if<'a>(
     branches: &'a [(Loc<Expr<'a>>, Loc<Expr<'a>>)],
     final_else: &'a Loc<Expr<'a>>,
     is_multiline: bool,
-    indented_else: bool,
-
     indent: u16,
 ) {
     //    let is_multiline_then = loc_then.is_multiline();
@@ -1972,29 +1963,20 @@ fn fmt_if<'a>(
     }
 
     buf.ensure_ends_with_whitespace();
-    if indented_else {
-        buf.indent(indent + INDENT);
-        buf.push_str("else");
-        buf.newline();
-        buf.newline();
-    } else if is_multiline {
-        buf.indent(indent);
-        buf.push_str("else");
+    buf.indent(indent);
+    buf.push_str("else");
+    if is_multiline {
         buf.newline();
     } else {
-        buf.indent(indent);
-        buf.push_str("else");
         buf.spaces(1);
     }
-    let indent = if indented_else { indent } else { return_indent };
-    final_else.format(buf, indent);
+    final_else.format(buf, return_indent);
 }
 
 fn fmt_closure<'a>(
     buf: &mut Buf,
     loc_patterns: &'a [Loc<Pattern<'a>>],
     loc_ret: &'a Loc<Expr<'a>>,
-
     indent: u16,
 ) {
     use self::Expr::*;

--- a/crates/compiler/parse/src/normalize.rs
+++ b/crates/compiler/parse/src/normalize.rs
@@ -778,11 +778,11 @@ impl<'a> Normalize<'a> for Expr<'a> {
             Expr::If {
                 if_thens,
                 final_else,
-                indented_else,
+                indented_else: _,
             } => Expr::If {
                 if_thens: if_thens.normalize(arena),
                 final_else: arena.alloc(final_else.normalize(arena)),
-                indented_else,
+                indented_else: false,
             },
             Expr::When(a, b) => Expr::When(arena.alloc(a.normalize(arena)), b.normalize(arena)),
             Expr::ParensAround(a) => {

--- a/crates/compiler/test_syntax/tests/snapshots/pass/if_bang_then_bang_indented_else.expr.formatted.roc
+++ b/crates/compiler/test_syntax/tests/snapshots/pass/if_bang_then_bang_indented_else.expr.formatted.roc
@@ -1,0 +1,5 @@
+if !a! then
+    t
+else
+    l
+5

--- a/crates/compiler/test_syntax/tests/snapshots/pass/if_bang_then_bang_indented_else.expr.result-ast
+++ b/crates/compiler/test_syntax/tests/snapshots/pass/if_bang_then_bang_indented_else.expr.result-ast
@@ -1,0 +1,72 @@
+@1-24 SpaceAfter(
+    Defs(
+        Defs {
+            tags: [
+                EitherIndex(2147483648),
+            ],
+            regions: [
+                @1-22,
+            ],
+            space_before: [
+                Slice<roc_parse::ast::CommentOrNewline> { start: 0, length: 0 },
+            ],
+            space_after: [
+                Slice<roc_parse::ast::CommentOrNewline> { start: 0, length: 0 },
+            ],
+            spaces: [],
+            type_defs: [],
+            value_defs: [
+                Stmt(
+                    @1-22 If {
+                        if_thens: [
+                            (
+                                @3-6 UnaryOp(
+                                    @4-6 Var {
+                                        module_name: "",
+                                        ident: "a!",
+                                    },
+                                    @3-4 Not,
+                                ),
+                                @11-12 SpaceBefore(
+                                    SpaceAfter(
+                                        Var {
+                                            module_name: "",
+                                            ident: "t",
+                                        },
+                                        [
+                                            Newline,
+                                        ],
+                                    ),
+                                    [
+                                        Newline,
+                                    ],
+                                ),
+                            ),
+                        ],
+                        final_else: @21-22 SpaceBefore(
+                            Var {
+                                module_name: "",
+                                ident: "l",
+                            },
+                            [
+                                Newline,
+                            ],
+                        ),
+                        indented_else: true,
+                    },
+                ),
+            ],
+        },
+        @23-24 SpaceBefore(
+            Num(
+                "5",
+            ),
+            [
+                Newline,
+            ],
+        ),
+    ),
+    [
+        Newline,
+    ],
+)

--- a/crates/compiler/test_syntax/tests/snapshots/pass/if_bang_then_bang_indented_else.expr.roc
+++ b/crates/compiler/test_syntax/tests/snapshots/pass/if_bang_then_bang_indented_else.expr.roc
@@ -1,0 +1,5 @@
+ if!a!then
+t
+  else
+ l
+5

--- a/crates/compiler/test_syntax/tests/snapshots/pass/if_then_weird_indent.expr.formatted.roc
+++ b/crates/compiler/test_syntax/tests/snapshots/pass/if_then_weird_indent.expr.formatted.roc
@@ -2,7 +2,6 @@ if
     k
 then
     A
-    else
-
-e
-r
+else
+    e
+    r

--- a/crates/compiler/test_syntax/tests/test_fmt.rs
+++ b/crates/compiler/test_syntax/tests/test_fmt.rs
@@ -3061,7 +3061,7 @@ mod test_fmt {
                    x,
                    y
                 }| a
- 
+
            identity 43
            "
             ),
@@ -3069,7 +3069,7 @@ mod test_fmt {
                 r"
            identity =
                |{ x, y }| a
- 
+
            identity 43
            "
             ),
@@ -3083,7 +3083,7 @@ mod test_fmt {
                    x,
                    y
                 } -> a
- 
+
            identity 43
            "
             ),
@@ -3091,7 +3091,7 @@ mod test_fmt {
                 r"
            identity =
                |{ x, y }| a
- 
+
            identity 43
            "
             ),
@@ -3996,15 +3996,25 @@ mod test_fmt {
 
     #[test]
     fn early_return_else() {
-        expr_formats_same(indoc!(
-            r"
-            if foo then
-                bar
-                else
+        expr_formats_to(
+            indoc!(
+                r"
+                if foo then
+                    bar
+                    else
 
-            baz
-            "
-        ));
+                baz
+                "
+            ),
+            indoc!(
+                r"
+                if foo then
+                    bar
+                else
+                    baz
+                "
+            ),
+        );
 
         expr_formats_to(
             indoc!(
@@ -4019,9 +4029,8 @@ mod test_fmt {
                 r"
                 if thing then
                     whatever
-                    else
-
-                too close
+                else
+                    too close
                 "
             ),
         );
@@ -4031,8 +4040,7 @@ mod test_fmt {
                 r"
                 if isGrowing plant then
                     LetBe
-                    else
-
+                else
                     Water
                 "
             ),
@@ -4040,9 +4048,8 @@ mod test_fmt {
                 r"
                 if isGrowing plant then
                     LetBe
-                    else
-
-                Water
+                else
+                    Water
                 "
             ),
         );

--- a/crates/compiler/test_syntax/tests/test_snapshots.rs
+++ b/crates/compiler/test_syntax/tests/test_snapshots.rs
@@ -472,6 +472,7 @@ mod test_snapshots {
         pass/highest_float.expr,
         pass/highest_int.expr,
         pass/i_over_not_g.expr,
+        pass/if_bang_then_bang_indented_else.expr,
         pass/if_bang_then_else_one_line.expr,
         pass/if_def.expr,
         pass/if_newline_then_negate_else_recordupdater.expr,


### PR DESCRIPTION
This is step 1 in removing the syntax all together. The formatter will now seemlessly migrate everyone to the usual if/then/else syntax. After everyone has had a chance to upgrade, we can then remove this from the parser (in a future PR).
