### PR TITLE
Change Pattern to preserve user intent of ParensAround

### DIFF
--- a/crates/check/can_solo/src/desugar.rs
+++ b/crates/check/can_solo/src/desugar.rs
@@ -1464,6 +1464,7 @@ fn desugar_pattern<'a>(
         | MalformedIdent(_, _)
         | MalformedExpr(_)
         | QualifiedIdentifier { .. } => pattern,
+        ParensAround(inner) => desugar_pattern(env, scope, *inner),
 
         Apply(tag, arg_patterns) => {
             // Skip desugaring the tag, it should either be a Tag or OpaqueRef

--- a/crates/compiler/can/src/pattern.rs
+++ b/crates/compiler/can/src/pattern.rs
@@ -624,7 +624,7 @@ pub fn canonicalize_pattern<'a>(
             }
         }
 
-        SpaceBefore(sub_pattern, _) | SpaceAfter(sub_pattern, _) => {
+        ParensAround(sub_pattern) | SpaceBefore(sub_pattern, _) | SpaceAfter(sub_pattern, _) => {
             return canonicalize_pattern(
                 env,
                 var_store,

--- a/crates/compiler/parse/src/ast.rs
+++ b/crates/compiler/parse/src/ast.rs
@@ -1656,6 +1656,7 @@ pub enum Pattern<'a> {
     // Space
     SpaceBefore(&'a Pattern<'a>, &'a [CommentOrNewline<'a>]),
     SpaceAfter(&'a Pattern<'a>, &'a [CommentOrNewline<'a>]),
+    ParensAround(&'a Pattern<'a>),
 
     // Malformed
     Malformed(&'a str),
@@ -1804,8 +1805,8 @@ impl<'a> Pattern<'a> {
                     false
                 }
             }
-            SpaceBefore(x, _) | SpaceAfter(x, _) => match other {
-                SpaceBefore(y, _) | SpaceAfter(y, _) => x.equivalent(y),
+            SpaceBefore(x, _) | SpaceAfter(x, _) | ParensAround(x) => match other {
+                SpaceBefore(y, _) | SpaceAfter(y, _) | ParensAround(y) => x.equivalent(y),
                 y => x.equivalent(y),
             },
             Malformed(x) => {
@@ -2581,7 +2582,8 @@ impl<'a> Malformed for Pattern<'a> {
             ListRest(_) =>false,
             As(pat, _) => pat.is_malformed(),
             SpaceBefore(pat, _) |
-            SpaceAfter(pat, _) => pat.is_malformed(),
+            SpaceAfter(pat, _) |
+            ParensAround(pat) => pat.is_malformed(),
 
             Malformed(_) |
             MalformedIdent(_, _) |

--- a/crates/compiler/parse/src/normalize.rs
+++ b/crates/compiler/parse/src/normalize.rs
@@ -785,7 +785,8 @@ impl<'a> Normalize<'a> for Expr<'a> {
             },
             Expr::When(a, b) => Expr::When(arena.alloc(a.normalize(arena)), b.normalize(arena)),
             Expr::ParensAround(a) => {
-                // The formatter can remove redundant parentheses, so also remove these when normalizing for comparison.
+                // The formatter can remove redundant parentheses,
+                // so also remove these when normalizing for comparison.
                 a.normalize(arena)
             }
             Expr::MalformedIdent(a, b) => Expr::MalformedIdent(a, remove_spaces_bad_ident(b)),
@@ -937,6 +938,11 @@ impl<'a> Normalize<'a> for Pattern<'a> {
             }
             Pattern::SpaceBefore(a, _) => a.normalize(arena),
             Pattern::SpaceAfter(a, _) => a.normalize(arena),
+            Pattern::ParensAround(a) => {
+                // The formatter can remove redundant parentheses,
+                // so also remove these when normalizing for comparison.
+                a.normalize(arena)
+            }
             Pattern::SingleQuote(a) => Pattern::SingleQuote(a),
             Pattern::List(pats) => Pattern::List(pats.normalize(arena)),
             Pattern::Tuple(pats) => Pattern::Tuple(pats.normalize(arena)),

--- a/crates/compiler/test_syntax/tests/snapshots/pass/ann_pattern_comment_before_body.expr.result-ast
+++ b/crates/compiler/test_syntax/tests/snapshots/pass/ann_pattern_comment_before_body.expr.result-ast
@@ -33,15 +33,17 @@
             ],
             value_defs: [
                 Body(
-                    @7-8 SpaceBefore(
-                        Identifier {
-                            ident: "s",
-                        },
-                        [
-                            LineComment(
-                                "",
-                            ),
-                        ],
+                    @7-8 ParensAround(
+                        SpaceBefore(
+                            Identifier {
+                                ident: "s",
+                            },
+                            [
+                                LineComment(
+                                    "",
+                                ),
+                            ],
+                        ),
                     ),
                     @10-11 Var {
                         module_name: "",

--- a/crates/compiler/test_syntax/tests/snapshots/pass/arg_pattern_as.expr.result-ast
+++ b/crates/compiler/test_syntax/tests/snapshots/pass/arg_pattern_as.expr.result-ast
@@ -1,37 +1,41 @@
 @0-64 SpaceAfter(
     Closure(
         [
-            @2-19 As(
-                @2-10 RecordDestructure(
-                    [
-                        @4-5 Identifier {
-                            ident: "x",
-                        },
-                        @7-8 Identifier {
-                            ident: "y",
-                        },
-                    ],
-                ),
-                PatternAs {
-                    spaces_before: [],
-                    identifier: @14-19 "point",
-                },
-            ),
-            @23-47 As(
-                @23-38 Apply(
-                    @23-32 OpaqueRef(
-                        "@Location",
+            @2-19 ParensAround(
+                As(
+                    @2-10 RecordDestructure(
+                        [
+                            @4-5 Identifier {
+                                ident: "x",
+                            },
+                            @7-8 Identifier {
+                                ident: "y",
+                            },
+                        ],
                     ),
-                    [
-                        @33-38 Identifier {
-                            ident: "inner",
-                        },
-                    ],
+                    PatternAs {
+                        spaces_before: [],
+                        identifier: @14-19 "point",
+                    },
                 ),
-                PatternAs {
-                    spaces_before: [],
-                    identifier: @42-47 "outer",
-                },
+            ),
+            @23-47 ParensAround(
+                As(
+                    @23-38 Apply(
+                        @23-32 OpaqueRef(
+                            "@Location",
+                        ),
+                        [
+                            @33-38 Identifier {
+                                ident: "inner",
+                            },
+                        ],
+                    ),
+                    PatternAs {
+                        spaces_before: [],
+                        identifier: @42-47 "outer",
+                    },
+                ),
             ),
         ],
         @56-64 SpaceBefore(

--- a/crates/compiler/test_syntax/tests/snapshots/pass/closure_arg_parens_then_comment.expr.result-ast
+++ b/crates/compiler/test_syntax/tests/snapshots/pass/closure_arg_parens_then_comment.expr.result-ast
@@ -1,8 +1,10 @@
 @0-7 SpaceAfter(
     Closure(
         [
-            @2-3 NumLiteral(
-                "8",
+            @2-3 ParensAround(
+                NumLiteral(
+                    "8",
+                ),
             ),
         ],
         @6-7 Tag(

--- a/crates/compiler/test_syntax/tests/snapshots/pass/closure_parens_double_newlines.expr.result-ast
+++ b/crates/compiler/test_syntax/tests/snapshots/pass/closure_parens_double_newlines.expr.result-ast
@@ -7,13 +7,15 @@
                 ),
                 [
                     @4-5 SpaceAfter(
-                        SpaceAfter(
-                            Identifier {
-                                ident: "z",
-                            },
-                            [
-                                Newline,
-                            ],
+                        ParensAround(
+                            SpaceAfter(
+                                Identifier {
+                                    ident: "z",
+                                },
+                                [
+                                    Newline,
+                                ],
+                            ),
                         ),
                         [
                             Newline,

--- a/crates/compiler/test_syntax/tests/snapshots/pass/comment_before_pat_in_parens.expr.result-ast
+++ b/crates/compiler/test_syntax/tests/snapshots/pass/comment_before_pat_in_parens.expr.result-ast
@@ -17,16 +17,18 @@
             type_defs: [],
             value_defs: [
                 Annotation(
-                    @4-5 SpaceBefore(
-                        NumLiteral(
-                            "6",
-                        ),
-                        [
-                            Newline,
-                            LineComment(
-                                "",
+                    @4-5 ParensAround(
+                        SpaceBefore(
+                            NumLiteral(
+                                "6",
                             ),
-                        ],
+                            [
+                                Newline,
+                                LineComment(
+                                    "",
+                                ),
+                            ],
+                        ),
                     ),
                     @7-8 BoundVariable(
                         "s",

--- a/crates/compiler/test_syntax/tests/snapshots/pass/comment_indent_in_parens.expr.result-ast
+++ b/crates/compiler/test_syntax/tests/snapshots/pass/comment_indent_in_parens.expr.result-ast
@@ -22,13 +22,19 @@
                     ),
                     [
                         @2-7 SpaceAfter(
-                            NumLiteral(
-                                "0",
+                            ParensAround(
+                                SpaceAfter(
+                                    NumLiteral(
+                                        "0",
+                                    ),
+                                    [
+                                        LineComment(
+                                            "",
+                                        ),
+                                    ],
+                                ),
                             ),
                             [
-                                LineComment(
-                                    "",
-                                ),
                                 LineComment(
                                     "",
                                 ),

--- a/crates/compiler/test_syntax/tests/snapshots/pass/crazy_annotation_left.expr.result-ast
+++ b/crates/compiler/test_syntax/tests/snapshots/pass/crazy_annotation_left.expr.result-ast
@@ -23,27 +23,29 @@
                                 "1",
                             ),
                             [
-                                @2-11 SpaceAfter(
-                                    PncApply(
-                                        @3-4 NumLiteral(
-                                            "0",
+                                @2-11 ParensAround(
+                                    SpaceAfter(
+                                        PncApply(
+                                            @3-4 NumLiteral(
+                                                "0",
+                                            ),
+                                            [
+                                                @7-8 SpaceBefore(
+                                                    NumLiteral(
+                                                        "0",
+                                                    ),
+                                                    [
+                                                        LineComment(
+                                                            "",
+                                                        ),
+                                                    ],
+                                                ),
+                                            ],
                                         ),
                                         [
-                                            @7-8 SpaceBefore(
-                                                NumLiteral(
-                                                    "0",
-                                                ),
-                                                [
-                                                    LineComment(
-                                                        "",
-                                                    ),
-                                                ],
-                                            ),
+                                            Newline,
                                         ],
                                     ),
-                                    [
-                                        Newline,
-                                    ],
                                 ),
                             ],
                         ),

--- a/crates/compiler/test_syntax/tests/snapshots/pass/crazy_annotation_left2.expr.result-ast
+++ b/crates/compiler/test_syntax/tests/snapshots/pass/crazy_annotation_left2.expr.result-ast
@@ -29,11 +29,17 @@
                                     },
                                     [
                                         @5-9 SpaceAfter(
-                                            NumLiteral(
-                                                "0",
+                                            ParensAround(
+                                                SpaceAfter(
+                                                    NumLiteral(
+                                                        "0",
+                                                    ),
+                                                    [
+                                                        Newline,
+                                                    ],
+                                                ),
                                             ),
                                             [
-                                                Newline,
                                                 Newline,
                                                 LineComment(
                                                     "",

--- a/crates/compiler/test_syntax/tests/snapshots/pass/crazy_pat_ann.expr.result-ast
+++ b/crates/compiler/test_syntax/tests/snapshots/pass/crazy_pat_ann.expr.result-ast
@@ -18,16 +18,28 @@
             value_defs: [
                 Annotation(
                     @1-11 Apply(
-                        @1-11 SpaceAfter(
-                            NumLiteral(
-                                "0",
-                            ),
-                            [
-                                Newline,
-                                LineComment(
-                                    "",
+                        @1-11 ParensAround(
+                            ParensAround(
+                                SpaceAfter(
+                                    ParensAround(
+                                        SpaceAfter(
+                                            ParensAround(
+                                                NumLiteral(
+                                                    "0",
+                                                ),
+                                            ),
+                                            [
+                                                Newline,
+                                            ],
+                                        ),
+                                    ),
+                                    [
+                                        LineComment(
+                                            "",
+                                        ),
+                                    ],
                                 ),
-                            ],
+                            ),
                         ),
                         [
                             @12-13 Identifier {

--- a/crates/compiler/test_syntax/tests/snapshots/pass/double_parens_comment_tuple_pat.expr.result-ast
+++ b/crates/compiler/test_syntax/tests/snapshots/pass/double_parens_comment_tuple_pat.expr.result-ast
@@ -20,15 +20,17 @@
                     @0-15 Tuple(
                         [
                             @1-7 Apply(
-                                @2-3 SpaceAfter(
-                                    NumLiteral(
-                                        "0",
-                                    ),
-                                    [
-                                        LineComment(
-                                            "",
+                                @2-3 ParensAround(
+                                    SpaceAfter(
+                                        NumLiteral(
+                                            "0",
                                         ),
-                                    ],
+                                        [
+                                            LineComment(
+                                                "",
+                                            ),
+                                        ],
+                                    ),
                                 ),
                                 [
                                     @6-7 Identifier {
@@ -37,15 +39,17 @@
                                 ],
                             ),
                             @8-14 Apply(
-                                @9-10 SpaceAfter(
-                                    NumLiteral(
-                                        "0",
-                                    ),
-                                    [
-                                        LineComment(
-                                            "",
+                                @9-10 ParensAround(
+                                    SpaceAfter(
+                                        NumLiteral(
+                                            "0",
                                         ),
-                                    ],
+                                        [
+                                            LineComment(
+                                                "",
+                                            ),
+                                        ],
+                                    ),
                                 ),
                                 [
                                     @13-14 Identifier {

--- a/crates/compiler/test_syntax/tests/snapshots/pass/mega_parens_pat.expr.result-ast
+++ b/crates/compiler/test_syntax/tests/snapshots/pass/mega_parens_pat.expr.result-ast
@@ -24,15 +24,17 @@
                             ),
                             [
                                 @2-8 Apply(
-                                    @3-4 SpaceAfter(
-                                        NumLiteral(
-                                            "0",
-                                        ),
-                                        [
-                                            LineComment(
-                                                "",
+                                    @3-4 ParensAround(
+                                        SpaceAfter(
+                                            NumLiteral(
+                                                "0",
                                             ),
-                                        ],
+                                            [
+                                                LineComment(
+                                                    "",
+                                                ),
+                                            ],
+                                        ),
                                     ),
                                     [
                                         @7-8 Identifier {
@@ -44,15 +46,17 @@
                         ),
                         [
                             @10-16 Apply(
-                                @11-12 SpaceAfter(
-                                    NumLiteral(
-                                        "0",
-                                    ),
-                                    [
-                                        LineComment(
-                                            "",
+                                @11-12 ParensAround(
+                                    SpaceAfter(
+                                        NumLiteral(
+                                            "0",
                                         ),
-                                    ],
+                                        [
+                                            LineComment(
+                                                "",
+                                            ),
+                                        ],
+                                    ),
                                 ),
                                 [
                                     @15-16 Identifier {

--- a/crates/compiler/test_syntax/tests/snapshots/pass/multiline_str_after_newlines_in_pat.expr.result-ast
+++ b/crates/compiler/test_syntax/tests/snapshots/pass/multiline_str_after_newlines_in_pat.expr.result-ast
@@ -18,14 +18,16 @@
             value_defs: [
                 Annotation(
                     @1-2 Apply(
-                        @1-2 SpaceAfter(
-                            NumLiteral(
-                                "4",
+                        @1-2 ParensAround(
+                            SpaceAfter(
+                                NumLiteral(
+                                    "4",
+                                ),
+                                [
+                                    Newline,
+                                    Newline,
+                                ],
                             ),
-                            [
-                                Newline,
-                                Newline,
-                            ],
                         ),
                         [
                             @5-11 StrLiteral(

--- a/crates/compiler/test_syntax/tests/snapshots/pass/multiline_str_and_str_in_alias.expr.result-ast
+++ b/crates/compiler/test_syntax/tests/snapshots/pass/multiline_str_and_str_in_alias.expr.result-ast
@@ -29,19 +29,21 @@
                 ),
                 Annotation(
                     @3-11 Apply(
-                        @3-11 Apply(
-                            @3-9 StrLiteral(
-                                Block(
-                                    [],
-                                ),
-                            ),
-                            [
-                                @9-11 StrLiteral(
-                                    PlainLine(
-                                        "",
+                        @3-11 ParensAround(
+                            Apply(
+                                @3-9 StrLiteral(
+                                    Block(
+                                        [],
                                     ),
                                 ),
-                            ],
+                                [
+                                    @9-11 StrLiteral(
+                                        PlainLine(
+                                            "",
+                                        ),
+                                    ),
+                                ],
+                            ),
                         ),
                         [
                             @12-13 Identifier {

--- a/crates/compiler/test_syntax/tests/snapshots/pass/multiline_str_apply_in_parens_pat.expr.result-ast
+++ b/crates/compiler/test_syntax/tests/snapshots/pass/multiline_str_apply_in_parens_pat.expr.result-ast
@@ -22,17 +22,21 @@
                             ident: "u",
                         },
                         [
-                            @3-13 Apply(
-                                @3-9 StrLiteral(
-                                    Block(
-                                        [],
+                            @3-13 ParensAround(
+                                Apply(
+                                    @3-9 StrLiteral(
+                                        Block(
+                                            [],
+                                        ),
                                     ),
+                                    [
+                                        @11-12 ParensAround(
+                                            NumLiteral(
+                                                "0",
+                                            ),
+                                        ),
+                                    ],
                                 ),
-                                [
-                                    @11-12 NumLiteral(
-                                        "0",
-                                    ),
-                                ],
                             ),
                         ],
                     ),

--- a/crates/compiler/test_syntax/tests/snapshots/pass/neg_float_literal_pnc_apply_pat.expr.result-ast
+++ b/crates/compiler/test_syntax/tests/snapshots/pass/neg_float_literal_pnc_apply_pat.expr.result-ast
@@ -18,8 +18,10 @@
             value_defs: [
                 Annotation(
                     @1-7 PncApply(
-                        @1-4 FloatLiteral(
-                            "-8.",
+                        @1-4 ParensAround(
+                            FloatLiteral(
+                                "-8.",
+                            ),
                         ),
                         [],
                     ),

--- a/crates/compiler/test_syntax/tests/snapshots/pass/nested_parens_in_pattern.expr.result-ast
+++ b/crates/compiler/test_syntax/tests/snapshots/pass/nested_parens_in_pattern.expr.result-ast
@@ -16,15 +16,19 @@
         type_defs: [],
         value_defs: [
             Annotation(
-                @1-5 Apply(
-                    @2-3 Tag(
-                        "J",
+                @1-5 ParensAround(
+                    Apply(
+                        @2-3 ParensAround(
+                            Tag(
+                                "J",
+                            ),
+                        ),
+                        [
+                            @4-5 Identifier {
+                                ident: "x",
+                            },
+                        ],
                     ),
-                    [
-                        @4-5 Identifier {
-                            ident: "x",
-                        },
-                    ],
                 ),
                 @7-8 BoundVariable(
                     "i",

--- a/crates/compiler/test_syntax/tests/snapshots/pass/pat_parens_newline_before_pipe_when.expr.result-ast
+++ b/crates/compiler/test_syntax/tests/snapshots/pass/pat_parens_newline_before_pipe_when.expr.result-ast
@@ -17,13 +17,15 @@
                         ),
                         [
                             @15-16 SpaceBefore(
-                                SpaceAfter(
-                                    Tag(
-                                        "H",
+                                ParensAround(
+                                    SpaceAfter(
+                                        Tag(
+                                            "H",
+                                        ),
+                                        [
+                                            Newline,
+                                        ],
                                     ),
-                                    [
-                                        Newline,
-                                    ],
                                 ),
                                 [
                                     LineComment(

--- a/crates/compiler/test_syntax/tests/snapshots/pass/pattern_with_as_parens.expr.result-ast
+++ b/crates/compiler/test_syntax/tests/snapshots/pass/pattern_with_as_parens.expr.result-ast
@@ -13,14 +13,16 @@
                                 "Ok",
                             ),
                             [
-                                @18-25 As(
-                                    @18-20 RecordDestructure(
-                                        [],
+                                @18-25 ParensAround(
+                                    As(
+                                        @18-20 RecordDestructure(
+                                            [],
+                                        ),
+                                        PatternAs {
+                                            spaces_before: [],
+                                            identifier: @24-25 "d",
+                                        },
                                     ),
-                                    PatternAs {
-                                        spaces_before: [],
-                                        identifier: @24-25 "d",
-                                    },
                                 ),
                             ],
                         ),

--- a/crates/compiler/test_syntax/tests/snapshots/pass/pattern_with_space_in_parens.expr.result-ast
+++ b/crates/compiler/test_syntax/tests/snapshots/pass/pattern_with_space_in_parens.expr.result-ast
@@ -34,15 +34,17 @@
                                 "Delmin",
                             ),
                             [
-                                @38-44 Apply(
-                                    @38-41 Tag(
-                                        "Del",
+                                @38-44 ParensAround(
+                                    Apply(
+                                        @38-41 Tag(
+                                            "Del",
+                                        ),
+                                        [
+                                            @42-44 Identifier {
+                                                ident: "ry",
+                                            },
+                                        ],
                                     ),
-                                    [
-                                        @42-44 Identifier {
-                                            ident: "ry",
-                                        },
-                                    ],
                                 ),
                                 @47-48 Underscore(
                                     "",

--- a/crates/compiler/test_syntax/tests/snapshots/pass/pnc_apply_neg_pattern.expr.result-ast
+++ b/crates/compiler/test_syntax/tests/snapshots/pass/pnc_apply_neg_pattern.expr.result-ast
@@ -18,8 +18,10 @@
             value_defs: [
                 Annotation(
                     @1-6 PncApply(
-                        @1-3 NumLiteral(
-                            "-8",
+                        @1-3 ParensAround(
+                            NumLiteral(
+                                "-8",
+                            ),
                         ),
                         [],
                     ),

--- a/crates/compiler/test_syntax/tests/snapshots/pass/pnc_parens_apply_etc.expr.result-ast
+++ b/crates/compiler/test_syntax/tests/snapshots/pass/pnc_parens_apply_etc.expr.result-ast
@@ -18,13 +18,15 @@
             value_defs: [
                 Annotation(
                     @2-6 PncApply(
-                        @2-3 SpaceBefore(
-                            NumLiteral(
-                                "3",
+                        @2-3 ParensAround(
+                            SpaceBefore(
+                                NumLiteral(
+                                    "3",
+                                ),
+                                [
+                                    Newline,
+                                ],
                             ),
-                            [
-                                Newline,
-                            ],
                         ),
                         [],
                     ),

--- a/crates/compiler/test_syntax/tests/snapshots/pass/repr_7342.expr.result-ast
+++ b/crates/compiler/test_syntax/tests/snapshots/pass/repr_7342.expr.result-ast
@@ -19,15 +19,17 @@
                 value_defs: [
                     Annotation(
                         @2-3 Apply(
-                            @2-3 SpaceAfter(
-                                NumLiteral(
-                                    "1",
-                                ),
-                                [
-                                    LineComment(
-                                        "",
+                            @2-3 ParensAround(
+                                SpaceAfter(
+                                    NumLiteral(
+                                        "1",
                                     ),
-                                ],
+                                    [
+                                        LineComment(
+                                            "",
+                                        ),
+                                    ],
+                                ),
                             ),
                             [
                                 @6-7 Tag(

--- a/crates/compiler/test_syntax/tests/snapshots/pass/triple_paren_pat_ann.expr.result-ast
+++ b/crates/compiler/test_syntax/tests/snapshots/pass/triple_paren_pat_ann.expr.result-ast
@@ -23,20 +23,22 @@
                                 "1",
                             ),
                             [
-                                @2-9 PncApply(
-                                    @3-4 NumLiteral(
-                                        "0",
-                                    ),
-                                    [
-                                        @5-6 SpaceAfter(
-                                            NumLiteral(
-                                                "0",
-                                            ),
-                                            [
-                                                Newline,
-                                            ],
+                                @2-9 ParensAround(
+                                    PncApply(
+                                        @3-4 NumLiteral(
+                                            "0",
                                         ),
-                                    ],
+                                        [
+                                            @5-6 SpaceAfter(
+                                                NumLiteral(
+                                                    "0",
+                                                ),
+                                                [
+                                                    Newline,
+                                                ],
+                                            ),
+                                        ],
+                                    ),
                                 ),
                             ],
                         ),

--- a/crates/compiler/test_syntax/tests/snapshots/pass/underscore_in_assignment_pattern.expr.result-ast
+++ b/crates/compiler/test_syntax/tests/snapshots/pass/underscore_in_assignment_pattern.expr.result-ast
@@ -149,31 +149,35 @@
                             "Pair",
                         ),
                         [
-                            @79-87 Apply(
-                                @79-83 Tag(
-                                    "Pair",
-                                ),
-                                [
-                                    @84-85 Identifier {
-                                        ident: "x",
-                                    },
-                                    @86-87 Underscore(
-                                        "",
+                            @79-87 ParensAround(
+                                Apply(
+                                    @79-83 Tag(
+                                        "Pair",
                                     ),
-                                ],
+                                    [
+                                        @84-85 Identifier {
+                                            ident: "x",
+                                        },
+                                        @86-87 Underscore(
+                                            "",
+                                        ),
+                                    ],
+                                ),
                             ),
-                            @90-98 Apply(
-                                @90-94 Tag(
-                                    "Pair",
-                                ),
-                                [
-                                    @95-96 Underscore(
-                                        "",
+                            @90-98 ParensAround(
+                                Apply(
+                                    @90-94 Tag(
+                                        "Pair",
                                     ),
-                                    @97-98 Identifier {
-                                        ident: "y",
-                                    },
-                                ],
+                                    [
+                                        @95-96 Underscore(
+                                            "",
+                                        ),
+                                        @97-98 Identifier {
+                                            ident: "y",
+                                        },
+                                    ],
+                                ),
                             ),
                         ],
                     ),


### PR DESCRIPTION
Also, stop dropping final comments in parenthesized patterns/exprs.

In the future, this will allow more specificity in things like:
* More accurately capturing user intent in formatting
* Removing alias->annotation conversion, in favor of requiring parens if that's really what you want
* Simplifying some formatter edge cases

... but for now, this is a plain refactoring PR
