### PR TITLE
Suppress TrySuffix movement around PncApply unless --migrate is passed

### DIFF
--- a/.github/workflows/fuzzer.yml
+++ b/.github/workflows/fuzzer.yml
@@ -19,5 +19,7 @@ jobs:
           cargo +nightly-2024-02-03 install --locked cargo-fuzz
           cd crates/compiler/test_syntax/fuzz && cargo +nightly-2024-02-03 fuzz run -j4 fuzz_expr --sanitizer=none -- -dict=dict.txt -max_total_time=60 || true
           cd ..
-          for x in fuzz/artifacts/fuzz_expr/crash-*; do cargo run --bin minimize expr $x; done
-          if ls fuzz/artifacts/fuzz_expr/ | grep crash-; then exit 1; fi
+          if ls fuzz/artifacts/fuzz_expr/ | grep crash-; then
+            for x in fuzz/artifacts/fuzz_expr/crash-*; do cargo run --bin minimize expr $x; done
+            exit 1
+          fi

--- a/crates/compiler/fmt/src/expr.rs
+++ b/crates/compiler/fmt/src/expr.rs
@@ -98,7 +98,9 @@ fn format_expr_only(
                 region,
             },
             loc_args,
-        ) => {
+        ) if buf.flags().parens_and_commas => {
+            // TODO: the conversion we do here is _wrong_ and should be removed in the near future
+            // For now this is helpful to fix up code that was incorrectly partially migrated
             let arena = buf.text.bump();
             let apply = arena.alloc(Expr::PncApply(
                 arena.alloc(Loc {


### PR DESCRIPTION
This is currently causing a bunch of fuzzing noise in main. Also added a comment to clarify this behavior is intended to be short-lived.
