### PR TITLE
Minor cleanup zig

### DIFF
--- a/.github/workflows/ci_manager.yml
+++ b/.github/workflows/ci_manager.yml
@@ -26,11 +26,13 @@ jobs:
               - 'src/**'
               - 'build.zig'
               - 'build.zig.zon'
+              - '.github/workflows/ci_zig.yml'
             other_than_zig:
               - '**/*'
               - '!src/**'
               - '!build.zig'
               - '!build.zig.zon'
+              - '!.github/workflows/ci_zig.yml'
 
   call-zig-workflow:
     needs: check-changes

--- a/.github/workflows/ci_zig.yml
+++ b/.github/workflows/ci_zig.yml
@@ -40,13 +40,8 @@ jobs:
               run: |
                 zig-out\bin\roc.exe -h | findstr "Usage:"
 
-            - name: zig tests (Unix)
-              if: runner.os != 'Windows'
-              run: ./zig-out/bin/test
-
-            - name: zig tests (Windows)
-              if: runner.os == 'Windows'
-              run: zig-out\bin\test.exe
+            - name: zig tests
+              run: zig build test
 
             - name: check if statically linked (ubuntu)
               if: startsWith(matrix.os, 'ubuntu')

--- a/build.zig
+++ b/build.zig
@@ -7,7 +7,9 @@ const OptimizeMode = std.builtin.OptimizeMode;
 const Import = std.Build.Module.Import;
 
 pub fn build(b: *std.Build) void {
-    const target = if (builtin.target.os.tag == .linux) b.standardTargetOptions(.{ .default = .{ .abi = .musl } }) else b.standardTargetOptions(.{});
+    const target = b.standardTargetOptions(.{ .default_target = .{
+        .abi = if (builtin.target.os.tag == .linux) .musl else null,
+    } });
     const optimize = b.standardOptimizeOption(.{});
 
     // Zig unicode library - https://codeberg.org/atman/zg

--- a/build.zig
+++ b/build.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const afl = @import("zig-afl-kit");
 const LazyPath = std.Build.LazyPath;
 const ResolvedTarget = std.Build.ResolvedTarget;
@@ -6,7 +7,7 @@ const OptimizeMode = std.builtin.OptimizeMode;
 const Import = std.Build.Module.Import;
 
 pub fn build(b: *std.Build) void {
-    const target = b.standardTargetOptions(.{});
+    const target = if (builtin.target.os.tag == .linux) b.standardTargetOptions(.{ .default = .{ .abi = .musl } }) else b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
     // Zig unicode library - https://codeberg.org/atman/zg
@@ -17,13 +18,12 @@ pub fn build(b: *std.Build) void {
         .root_source_file = b.path("src/main.zig"),
         .target = target,
         .optimize = optimize,
+        .link_libc = true,
     });
     exe.root_module.addImport("GenCatData", zg.module("GenCatData"));
 
     b.installArtifact(exe);
-
     const run_cmd = b.addRunArtifact(exe);
-
     run_cmd.step.dependOn(b.getInstallStep());
 
     if (b.args) |args| {
@@ -37,6 +37,7 @@ pub fn build(b: *std.Build) void {
         .root_source_file = b.path("src/test.zig"),
         .target = target,
         .optimize = optimize,
+        .link_libc = true,
     });
     all_tests.root_module.addImport("GenCatData", zg.module("GenCatData"));
 
@@ -47,9 +48,7 @@ pub fn build(b: *std.Build) void {
     b.installArtifact(all_tests);
 
     const run_tests = b.addRunArtifact(all_tests);
-
     const test_step = b.step("test", "Run all tests included in src/tests.zig");
-
     test_step.dependOn(&run_tests.step);
 
     // Fuzz targets
@@ -62,7 +61,6 @@ pub fn build(b: *std.Build) void {
         b,
         fuzz,
         target,
-        optimize,
         "cli",
         b.path("src/fuzz/cli.zig"),
         &[_]Import{
@@ -75,7 +73,6 @@ fn add_fuzz_target(
     b: *std.Build,
     fuzz: *std.Build.Step,
     target: ResolvedTarget,
-    optimize: OptimizeMode,
     name: []const u8,
     root_source_file: LazyPath,
     imports: []const Import,
@@ -96,7 +93,7 @@ fn add_fuzz_target(
         .name = name_obj.items,
         .root_source_file = root_source_file,
         .target = target,
-        .optimize = .Debug,
+        .optimize = .ReleaseSafe,
     });
 
     for (imports) |import| {
@@ -108,7 +105,7 @@ fn add_fuzz_target(
     fuzz_obj.root_module.stack_check = false; // not linking with compiler-rt
     fuzz_obj.root_module.link_libc = true; // afl runtime depends on libc
 
-    const fuzz_exe = afl.addInstrumentedExe(b, target, optimize, fuzz_obj);
+    const fuzz_exe = afl.addInstrumentedExe(b, target, .ReleaseSafe, fuzz_obj);
     const fuzz_step = b.step(name_exe.items, step_msg.items);
     fuzz_step.dependOn(&b.addInstallBinFile(fuzz_exe, name_exe.items).step);
 

--- a/src/fuzz/cli.zig
+++ b/src/fuzz/cli.zig
@@ -1,6 +1,8 @@
 /// This is just a silly fuzz test to start getting the infra setup.
 /// It shows the basic that other fuzz tests likely should build off of.
 ///
+/// Note: Compiling the fuzz tests requires llvm and does not currently work in our nix shell on all systems.
+///
 /// To run:
 ///  1. zig build fuzz-cli
 ///  2. ./zig-out/AFLplusplus/bin/afl-fuzz -i src/fuzz/cli-corpus/ -o /tmp/cli-out/ zig-out/bin/fuzz-cli

--- a/src/main.zig
+++ b/src/main.zig
@@ -32,11 +32,7 @@ pub fn fatal(comptime format: []const u8, args: anytype) noreturn {
 }
 
 pub fn main() !void {
-    var general_purpose_allocator = std.heap.GeneralPurposeAllocator(.{}){};
-    defer {
-        _ = general_purpose_allocator.deinit();
-    }
-    const gpa = general_purpose_allocator.allocator();
+    const gpa = std.heap.c_allocator;
 
     var arena_instance = std.heap.ArenaAllocator.init(gpa);
     defer arena_instance.deinit();


### PR DESCRIPTION
1. Switch fuzzer to ReleaseSafe
2. Update not on fuzzer needing llvm
3. Use c allocator as our gpa
4. Use musl on linux.
5. Just `zig build test` in CI.