### PR TITLE
enable zig ast check and target only the new compiler

### DIFF
--- a/.github/workflows/ci_zig.yml
+++ b/.github/workflows/ci_zig.yml
@@ -13,7 +13,7 @@ jobs:
               with:
                 version: 0.13.0
                 
-            - run: zig fmt --check .
+            - run: zig fmt --check --ast-check src build.zig
 
     zig-tests:
         needs: check-zig-fmt


### PR DESCRIPTION
This will fail until we get our tree together. Just making a PR so we make sure to circle back to this.