### PR TITLE
Fix the filter

### DIFF
--- a/.github/workflows/ci_manager.yml
+++ b/.github/workflows/ci_manager.yml
@@ -15,7 +15,7 @@ jobs:
       pull-requests: read
     outputs:
       zig: ${{ steps.filter.outputs.zig }}
-      other_than_zig: ${{ steps.filter.outputs.other_than_zig }}
+      other_than_zig: ${{ steps.other_filter.outputs.other_than_zig }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v2

--- a/.github/workflows/ci_manager.yml
+++ b/.github/workflows/ci_manager.yml
@@ -27,6 +27,17 @@ jobs:
               - 'build.zig'
               - 'build.zig.zon'
               - '.github/workflows/ci_zig.yml'
+      - uses: dorny/paths-filter@v2
+        id: other_filter
+        with:
+          predicate-quantifier: 'every'
+          filters: |
+            other_than_zig:
+              - '**/*'
+              - '!src/**'
+              - '!build.zig'
+              - '!build.zig.zon'
+              - '!.github/workflows/ci_zig.yml'
 
   call-zig-workflow:
     needs: check-changes
@@ -35,7 +46,7 @@ jobs:
 
   call-old-workflow:
     needs: check-changes
-    if: needs.check-changes.outputs.zig == 'false'
+    if: needs.check-changes.outputs.other_than_zig == 'true'
     uses: ./.github/workflows/ci_manager_old.yml
     
   finish:
@@ -51,7 +62,7 @@ jobs:
               exit 1
             fi
           fi
-          if [[ "${{ needs.check-changes.outputs.zig }}" == "false" ]]; then
+          if [[ "${{ needs.check-changes.outputs.other_than_zig }}" == "true" ]]; then
             if [[ "${{ needs.call-old-workflow.result }}" != "success" ]]; then
               echo "ci_manager_old.yml failed."
               exit 1

--- a/.github/workflows/ci_manager.yml
+++ b/.github/workflows/ci_manager.yml
@@ -27,12 +27,6 @@ jobs:
               - 'build.zig'
               - 'build.zig.zon'
               - '.github/workflows/ci_zig.yml'
-            other_than_zig:
-              - '**/*'
-              - '!src/**'
-              - '!build.zig'
-              - '!build.zig.zon'
-              - '!.github/workflows/ci_zig.yml'
 
   call-zig-workflow:
     needs: check-changes
@@ -41,7 +35,7 @@ jobs:
 
   call-old-workflow:
     needs: check-changes
-    if: needs.check-changes.outputs.other_than_zig == 'true'
+    if: needs.check-changes.outputs.zig == 'false'
     uses: ./.github/workflows/ci_manager_old.yml
     
   finish:
@@ -57,7 +51,7 @@ jobs:
               exit 1
             fi
           fi
-          if [[ "${{ needs.check-changes.outputs.other_than_zig }}" == "true" ]]; then
+          if [[ "${{ needs.check-changes.outputs.zig }}" == "false" ]]; then
             if [[ "${{ needs.call-old-workflow.result }}" != "success" ]]; then
               echo "ci_manager_old.yml failed."
               exit 1


### PR DESCRIPTION
The filter system matches if any filter matches.
This meant that the old `other_than_zig` was always matching everything.

~~Changed to simpler system where we only check for zig changes. On zig changes we run zig, otherwise, we run the old compiler.~~

Changed to two separate filter. For the filter with negatives, everything has to match. This leads to the negatives properly removing files. For the zig filter, any one piece has to match.