### PR TITLE
Remove redundant ModuleIdent

### DIFF
--- a/src/base.zig
+++ b/src/base.zig
@@ -1,7 +1,6 @@
 pub const Ident = @import("base/Ident.zig");
 pub const Module = @import("base/Module.zig");
 pub const ModuleEnv = @import("base/ModuleEnv.zig");
-pub const ModuleIdent = @import("base/ModuleIdent.zig");
 pub const Package = @import("base/Package.zig");
 pub const Region = @import("base/Region.zig");
 

--- a/src/base/Ident.zig
+++ b/src/base/Ident.zig
@@ -7,7 +7,6 @@ const collections = @import("../collections.zig");
 const problem = @import("../problem.zig");
 
 const Problem = problem.Problem;
-const ModuleIdent = @import("ModuleIdent.zig");
 const exitOnOom = utils.exitOnOom;
 
 const Ident = @This();
@@ -39,13 +38,6 @@ pub fn for_text(text: []u8) Ident {
 pub const Idx = packed struct(u32) {
     attributes: Attributes,
     id: u29,
-
-    pub fn in_home_module(self: *Idx) ModuleIdent {
-        return ModuleIdent{
-            .ident_id = self,
-            .module_id = @enumFromInt(0),
-        };
-    }
 };
 
 /// Identifier attributes such as if it is effectful, ignored, or reassignable packed into 3-bits.

--- a/src/base/Module.zig
+++ b/src/base/Module.zig
@@ -9,7 +9,6 @@ const collections = @import("../collections.zig");
 
 const Ident = @import("Ident.zig");
 const Region = @import("Region.zig");
-const ModuleIdent = @import("ModuleIdent.zig");
 const Problem = problem.Problem;
 
 const Module = @This();
@@ -124,21 +123,22 @@ pub const Store = struct {
     /// method that will also set the ident's exposing module.
     pub fn addExposedIdent(
         self: *Store,
-        module_ident: ModuleIdent,
+        module: Module.Idx,
+        ident: Ident.Idx,
         problems: *collections.SafeList(problem.Problem),
     ) void {
-        const module_index = @intFromEnum(module_ident.module_id);
+        const module_index = @intFromEnum(module);
         const module_exposed_idents = self.modules.items.items(.exposed_idents)[module_index];
         for (module_exposed_idents) |exposed_ident| {
-            if (exposed_ident == module_ident.ident_id) {
+            if (exposed_ident == ident) {
                 problems.append(Problem.Canonicalize.make(.DuplicateExposes{
                     .first_exposes = exposed_ident,
-                    .duplicate_exposes = module_ident.ident_id,
+                    .duplicate_exposes = ident,
                 }));
                 return;
             }
         }
 
-        module_exposed_idents.append(module_ident.ident_id);
+        module_exposed_idents.append(ident);
     }
 };

--- a/src/base/ModuleEnv.zig
+++ b/src/base/ModuleEnv.zig
@@ -7,6 +7,8 @@ const base = @import("../base.zig");
 const collections = @import("../collections.zig");
 const problem = @import("../problem.zig");
 
+const Ident = base.Ident;
+const Module = base.Module;
 const Problem = problem.Problem;
 
 const ModuleEnv = @This();
@@ -61,7 +63,7 @@ pub fn addFieldNameSlice(
     return self.field_ids_for_slicing.appendSlice(names);
 }
 
-pub fn addExposedIdentForModule(self: *ModuleEnv, module_ident: base.ModuleIdent) void {
-    self.modules.addExposedIdent(module_ident, self.problems);
-    self.idents.setExposingModule(module_ident.ident_idx, module_ident.module_idx);
+pub fn addExposedIdentForModule(self: *ModuleEnv, ident: Ident.Idx, module: Module.Idx) void {
+    self.modules.addExposedIdent(module, ident, self.problems);
+    self.idents.setExposingModule(ident, module);
 }

--- a/src/base/ModuleIdent.zig
+++ b/src/base/ModuleIdent.zig
@@ -1,9 +1,0 @@
-//! Indexes of a specific identifier and a specific module.
-const Module = @import("Module.zig");
-const Ident = @import("Ident.zig");
-
-/// The module index.
-module_idx: Module.Idx,
-
-/// The identifier index.
-ident_idx: Ident.Idx,

--- a/src/build/lift_functions/IR.zig
+++ b/src/build/lift_functions/IR.zig
@@ -5,7 +5,6 @@ const problem = @import("../../problem.zig");
 const collections = @import("../../collections.zig");
 
 const Ident = base.Ident;
-const ModuleIdent = base.ModuleIdent;
 const Problem = problem.Problem;
 const FieldName = collections.FieldName;
 const StringLiteral = collections.StringLiteral;
@@ -75,7 +74,7 @@ pub const Expr = union(enum) {
         elems: Expr.Slice,
     },
     Lookup: struct {
-        ident: ModuleIdent,
+        ident: Ident.Idx,
         type: Type.Idx,
     },
 

--- a/src/build/lower_statements/IR.zig
+++ b/src/build/lower_statements/IR.zig
@@ -5,7 +5,6 @@ const problem = @import("../../problem.zig");
 const collections = @import("../../collections.zig");
 
 const Ident = base.Ident;
-const ModuleIdent = base.ModuleIdent;
 const TagName = collections.TagName;
 const FieldName = collections.FieldName;
 const StringLiteral = collections.StringLiteral;
@@ -114,19 +113,19 @@ pub const Expr = union(enum) {
     },
 
     GetTagId: struct {
-        structure: ModuleIdent,
+        structure: Ident.Idx,
         union_layout: UnionLayout,
     },
 
     UnionAtIndex: struct {
-        structure: ModuleIdent,
+        structure: Ident.Idx,
         tag_id: TagIdIntType,
         union_layout: UnionLayout,
         index: u64,
     },
 
     GetElementPointer: struct {
-        structure: ModuleIdent,
+        structure: Ident.Idx,
         union_layout: UnionLayout,
         indices: []u64,
     },
@@ -140,22 +139,22 @@ pub const Expr = union(enum) {
 
     /// Returns a pointer to the given function.
     FunctionPointer: struct {
-        module_ident: ModuleIdent,
+        module_ident: Ident.Idx,
     },
 
     Alloca: struct {
         element_layout: Layout.Idx,
-        initializer: ?ModuleIdent,
+        initializer: ?Ident.Idx,
     },
 
     Reset: struct {
-        module_ident: ModuleIdent,
+        module_ident: Ident.Idx,
     },
 
     // Just like Reset, but does not recursively decrement the children.
     // Used in reuse analysis to replace a decref with a resetRef to avoid decrementing when the dec ref didn't.
     ResetRef: struct {
-        module_ident: ModuleIdent,
+        module_ident: Ident.Idx,
     },
 
     pub const List = collections.SafeList(@This());
@@ -167,7 +166,7 @@ pub const Expr = union(enum) {
 pub const ListLiteralElem = union(enum) {
     StringLiteralId: []const u8,
     Number: base.NumberLiteral,
-    Ident: ModuleIdent,
+    Ident: Ident.Idx,
 
     pub const List = collections.SafeList(@This());
     pub const Slice = List.Slice;
@@ -179,12 +178,12 @@ pub const Call = struct {
 
     pub const Kind = union(enum) {
         ByName: struct {
-            ident: ModuleIdent,
+            ident: Ident.Idx,
             ret_layout: Layout.Idx,
             arg_layouts: Layout.Slice,
         },
         ByPointer: struct {
-            pointer: ModuleIdent,
+            pointer: Ident.Idx,
             ret_layout: Layout.Idx,
             arg_layouts: []Layout.Idx,
         },
@@ -257,21 +256,21 @@ pub const Branch = struct {
     pub const Kind = union(enum) {
         None,
         Constructor: struct {
-            scrutinee: ModuleIdent,
+            scrutinee: Ident.Idx,
             layout: Layout.Idx,
             tag_id: TagIdIntType,
         },
         List: struct {
-            scrutinee: ModuleIdent,
+            scrutinee: Ident.Idx,
             len: u64,
         },
         Unique: struct {
-            scrutinee: ModuleIdent,
+            scrutinee: Ident.Idx,
             unique: bool,
         },
     };
 };
 
 pub const JoinPoint = struct {
-    pub const Idx = base.Ident.Idx;
+    pub const Idx = Ident.Idx;
 };

--- a/src/build/reference_count/IR.zig
+++ b/src/build/reference_count/IR.zig
@@ -5,7 +5,6 @@ const problem = @import("../../problem.zig");
 const collections = @import("../../collections.zig");
 
 const Ident = base.Ident;
-const ModuleIdent = base.ModuleIdent;
 const TagName = collections.TagName;
 const FieldName = collections.FieldName;
 const StringLiteral = collections.StringLiteral;
@@ -114,19 +113,19 @@ pub const Expr = union(enum) {
     },
 
     GetTagId: struct {
-        structure: ModuleIdent,
+        structure: Ident.Idx,
         union_layout: UnionLayout,
     },
 
     UnionAtIndex: struct {
-        structure: ModuleIdent,
+        structure: Ident.Idx,
         tag_id: TagIdIntType,
         union_layout: UnionLayout,
         index: u64,
     },
 
     GetElementPointer: struct {
-        structure: ModuleIdent,
+        structure: Ident.Idx,
         union_layout: UnionLayout,
         indices: []u64,
     },
@@ -140,22 +139,22 @@ pub const Expr = union(enum) {
 
     /// Returns a pointer to the given function.
     FunctionPointer: struct {
-        module_ident: ModuleIdent,
+        module_ident: Ident.Idx,
     },
 
     Alloca: struct {
         element_layout: Layout.Idx,
-        initializer: ?ModuleIdent,
+        initializer: ?Ident.Idx,
     },
 
     Reset: struct {
-        module_ident: ModuleIdent,
+        module_ident: Ident.Idx,
     },
 
     // Just like Reset, but does not recursively decrement the children.
     // Used in reuse analysis to replace a decref with a resetRef to avoid decrementing when the dec ref didn't.
     ResetRef: struct {
-        module_ident: ModuleIdent,
+        module_ident: Ident.Idx,
     },
 
     pub const List = collections.SafeList(@This());
@@ -167,7 +166,7 @@ pub const Expr = union(enum) {
 pub const ListLiteralElem = union(enum) {
     StringLiteralId: []const u8,
     Number: base.NumberLiteral,
-    Ident: ModuleIdent,
+    Ident: Ident.Idx,
 
     pub const List = collections.SafeList(@This());
     pub const Slice = List.Slice;
@@ -179,12 +178,12 @@ pub const Call = struct {
 
     pub const Kind = union(enum) {
         ByName: struct {
-            ident: ModuleIdent,
+            ident: Ident.Idx,
             ret_layout: Layout.Idx,
             arg_layouts: Layout.Slice,
         },
         ByPointer: struct {
-            pointer: ModuleIdent,
+            pointer: Ident.Idx,
             ret_layout: Layout.Idx,
             arg_layouts: []Layout.Idx,
         },
@@ -225,7 +224,7 @@ pub const Stmt = union(enum) {
     },
     Ret: Ident.Idx,
     RefCount: struct {
-        symbol: base.ModuleIdent,
+        symbol: Ident.Idx,
         change: ModifyRefCount,
     },
     /// a join point `join f <params> = <continuation> in remainder`
@@ -261,16 +260,16 @@ pub const Branch = struct {
     pub const Kind = union(enum) {
         None,
         Constructor: struct {
-            scrutinee: ModuleIdent,
+            scrutinee: Ident.Idx,
             layout: Layout.Idx,
             tag_id: TagIdIntType,
         },
         List: struct {
-            scrutinee: ModuleIdent,
+            scrutinee: Ident.Idx,
             len: u64,
         },
         Unique: struct {
-            scrutinee: ModuleIdent,
+            scrutinee: Ident.Idx,
             unique: bool,
         },
     };
@@ -279,12 +278,12 @@ pub const Branch = struct {
 pub const ModifyRefCount = union(enum) {
     /// Increment a reference count
     Inc: struct {
-        target: base.ModuleIdent,
+        target: Ident.Idx,
         count: u64,
     },
 
     /// Decrement a reference count
-    Dec: base.ModuleIdent,
+    Dec: Ident.Idx,
 
     /// A DecRef is a non-recursive reference count decrement
     /// e.g. If we Dec a list of lists, then if the reference count of the outer list is one,
@@ -293,13 +292,13 @@ pub const ModifyRefCount = union(enum) {
     /// That is dangerous because you may not free the elements, but in our Zig builtins,
     /// sometimes we know we already dealt with the elements (e.g. by copying them all over
     /// to a new list) and so we can just do a DecRef, which is much cheaper in such a case.
-    DecRef: base.ModuleIdent,
+    DecRef: Ident.Idx,
 
     /// Unconditionally deallocate the memory. For tag union that do pointer tagging (store the tag
     /// id in the pointer) the backend has to clear the tag id!
-    Free: base.ModuleIdent,
+    Free: Ident.Idx,
 };
 
 pub const JoinPoint = struct {
-    pub const Idx = base.Ident.Idx;
+    pub const Idx = Ident.Idx;
 };

--- a/src/build/specialize_functions/IR.zig
+++ b/src/build/specialize_functions/IR.zig
@@ -5,7 +5,6 @@ const problem = @import("../../problem.zig");
 const collections = @import("../../collections.zig");
 
 const Ident = base.Ident;
-const ModuleIdent = base.ModuleIdent;
 const Problem = problem.Problem;
 const FieldName = collections.FieldName;
 const StringLiteral = collections.StringLiteral;
@@ -72,7 +71,7 @@ pub const Expr = union(enum) {
         elems: Expr.Slice,
     },
     Lookup: struct {
-        ident: ModuleIdent,
+        ident: Ident.Idx,
         type: Type.Idx,
     },
 

--- a/src/build/specialize_types/IR.zig
+++ b/src/build/specialize_types/IR.zig
@@ -5,7 +5,6 @@ const problem = @import("../../problem.zig");
 const collections = @import("../../collections.zig");
 
 const Ident = base.Ident;
-const ModuleIdent = base.ModuleIdent;
 const Problem = problem.Problem;
 const FieldName = collections.FieldName;
 const StringLiteral = collections.StringLiteral;
@@ -75,7 +74,7 @@ pub const Expr = union(enum) {
         elems: Expr.Slice,
     },
     Lookup: struct {
-        ident: ModuleIdent,
+        ident: Ident.Idx,
         type: Type.Idx,
     },
 

--- a/src/check/canonicalize.zig
+++ b/src/check/canonicalize.zig
@@ -49,12 +49,7 @@ pub fn canonicalize(
                 }
 
                 for (import.exposing.items.items) |exposed_ident| {
-                    const module_ident = base.ModuleIdent{
-                        .module_idx = res.module_idx,
-                        .ident_idx = exposed_ident,
-                    };
-
-                    env.addExposedIdentForModule(module_ident);
+                    env.addExposedIdentForModule(exposed_ident, res.module_idx);
                 }
             },
         }


### PR DESCRIPTION
Because of our new module + ident resolution mechanism, all idents within a module have unique IDs, even when imported from other modules. We now store which module exported which ident both in the `Module.Store` and the `Ident.Store` for a 2-way relationship, meaning we always know the exporting module of an ident given its `Idx`, meaning a pairing of `Module.Idx` and `Ident.Idx` is no longer needed.