### PR TITLE
Fix various zig errors in base/collections

### DIFF
--- a/src/base/Ident.zig
+++ b/src/base/Ident.zig
@@ -73,6 +73,7 @@ pub const Store = struct {
     pub fn init(allocator: std.mem.Allocator) Store {
         return Store{
             .interner = collections.IdentName.Interner.init(allocator),
+            .next_unique_name = 0,
             .regions = std.ArrayList(base.Region).init(allocator),
             .exposing_modules = std.ArrayList(base.Module.Idx).init(allocator),
         };

--- a/src/build/lift_functions/IR.zig
+++ b/src/build/lift_functions/IR.zig
@@ -118,7 +118,7 @@ pub const Expr = union(enum) {
         branches: WhenBranch.NonEmptySlice,
     },
 
-    CompilerBug: Problem.SpecializeTypes,
+    CompilerBug: Problem.Compiler.LiftFunctions,
 
     pub const List = collections.SafeList(@This());
     pub const Idx = List.Idx;
@@ -154,8 +154,8 @@ pub const WhenBranch = struct {
     /// The expression to produce if the pattern matches
     value: Expr.Idx,
 
-    pub const List = collections.SafeMultiList(@This());
-    pub const Slice = List.Slice;
+    pub const List = collections.SafeList(@This());
+    pub const NonEmptySlice = List.NonEmptySlice;
 };
 
 pub const Function = struct {
@@ -206,7 +206,7 @@ pub const Pattern = union(enum) {
         },
     },
     Underscore,
-    CompilerBug: Problem.SpecializeTypes,
+    CompilerBug: Problem.Compiler.LiftFunctions,
 
     pub const List = collections.SafeList(@This());
     pub const Idx = List.Idx;

--- a/src/build/solve_functions.zig
+++ b/src/build/solve_functions.zig
@@ -3,6 +3,7 @@ const base = @import("../base.zig");
 const func_lift = @import("lift_functions.zig");
 const collections = @import("../collections.zig");
 
+const testing = std.testing;
 const Ident = base.Ident;
 
 pub const FunctionSet = struct {
@@ -28,4 +29,28 @@ pub fn solveFunctions(ir: func_lift.IR, other_modules: []FunctionSet.List) Funct
     _ = other_modules;
 
     @panic("not implemented");
+}
+
+test "solves for uncaptured functions" {
+    // This test will create the function lift IR for the following program:
+    //
+    //   apply : (U8 -> U8), U8 -> U8
+    //   apply = \f, x -> f x
+    //
+    //   fn : U8 -> U8
+    //   fn = \x -> x + 1
+    //
+    //   main : U8
+    //   main =
+    //     fn_pack = @fn_pack(fn)
+    //     apply fn_pack 2
+    //
+    // It will then run `solveFunctions` on that IR and assert that the
+    // resulting FunctionSet.List correctly labels each function
+
+    const ally = testing.allocator;
+    var store = base.Ident.Store.init(ally);
+    defer store.deinit();
+
+    try testing.expect(true);
 }

--- a/src/collections/interner/IdentName.zig
+++ b/src/collections/interner/IdentName.zig
@@ -32,7 +32,7 @@ pub const Interner = struct {
             .strings = std.ArrayList([]u8).init(allocator),
             .string_indices_per_hash = std.AutoHashMap(u32, std.ArrayList(u32)).init(allocator),
             .outer_ids_per_string_index = std.AutoHashMap(u32, std.ArrayList(Idx)).init(allocator),
-            .outer_indices = std.ArrayList(Idx).init(allocator),
+            .outer_indices = std.ArrayList(u32).init(allocator),
             .allocator = allocator,
         };
     }

--- a/src/collections/safe_list.zig
+++ b/src/collections/safe_list.zig
@@ -33,17 +33,17 @@ pub fn SafeList(comptime T: type) type {
         pub const NonEmptySlice = struct {
             slice: std.ArrayList(T).Slice,
 
-            pub fn makeUnchecked(items: []T) NonEmptySlice(T) {
-                return NonEmptySlice(T){ .slice = items };
+            pub fn makeUnchecked(items: []T) NonEmptySlice {
+                return NonEmptySlice{ .slice = items };
             }
 
-            pub fn first(slice: *NonEmptySlice(T)) *T {
+            pub fn first(slice: *NonEmptySlice) T {
                 return slice.slice[0];
             }
         };
 
         pub fn init(allocator: std.mem.Allocator) SafeList(T) {
-            return SafeList{ .items = std.ArrayList(T).init(allocator) };
+            return SafeList(T){ .items = std.ArrayList(T).init(allocator) };
         }
 
         pub fn deinit(self: *SafeList(T)) void {
@@ -58,7 +58,7 @@ pub fn SafeList(comptime T: type) type {
             const length = self.len();
             self.items.append(item) catch exitOnOom();
 
-            return @enumFromInt(@as(u32, length));
+            return @enumFromInt(@as(u32, @intCast(length)));
         }
 
         pub fn appendSlice(self: *SafeList(T), items: []const T) Slice {
@@ -68,7 +68,7 @@ pub fn SafeList(comptime T: type) type {
             return self.items.items[start_length..];
         }
 
-        pub fn get(self: *SafeList(T), id: Idx) *T {
+        pub fn get(self: *SafeList(T), id: Idx) T {
             return self.items.items[@as(usize, @intFromEnum(id))];
         }
     };
@@ -132,11 +132,11 @@ test "safe list_u32 inserting and getting" {
 
     try testing.expectEqual(list_u32.len(), 0);
 
-    const id = list_u32.insert(1);
+    const id = list_u32.append(1);
 
     try testing.expectEqual(list_u32.len(), 1);
 
     const item = list_u32.get(id);
 
-    try testing.expectEqual(item.* == 1);
+    try testing.expectEqual(item, 1);
 }

--- a/src/test.zig
+++ b/src/test.zig
@@ -3,4 +3,5 @@ const testing = std.testing;
 
 test {
     testing.refAllDeclsRecursive(@import("main.zig"));
+    testing.refAllDeclsRecursive(@import("build/solve_functions.zig"));
 }


### PR DESCRIPTION
When starting work on the function solve step of the compile, I immediately ran into several compile issues from various base functions when setting up a test. This MR fixes those compile issues. I went with my best guess for each issue, happy to change anything that's wrong - I'm far from a Zig expert.

Also, when running `zig build test`, tests in `src/build/solve_functions.zig` were not run unless I added that path to `src/test.zig`. I haven't used Zig in a while, so I'm not sure if there are some semantics I don't understand about `refAllDeclsRecursive`. Happy to revert that line if needed.