### PR TITLE
Manually list files in test.zig and resolve errs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -93,8 +93,10 @@
           wasm-pack # for repl_wasm
           jq # used in several bash scripts
           cargo-nextest # used to give more info for segfaults for gen tests
-          zls # zig language server
           # cargo-udeps # to find unused dependencies
+           
+          zls # zig language server
+          watchexec
         ]);
 
         aliases = ''

--- a/src/base/Ident.zig
+++ b/src/base/Ident.zig
@@ -92,7 +92,7 @@ pub const Store = struct {
 
     pub fn insert(self: *Store, ident: Ident, region: Region, problems: *Problem.List) !Idx {
         if (ident.problems.has_problems()) {
-            _ = problems.append(Problem.Parse.make(Problem.Parse{ .IdentIssue = .{
+            _ = problems.append(Problem.Parse.make(.{ .IdentIssue = .{
                 .problems = ident.problems,
                 .region = region,
             } }));

--- a/src/base/Module.zig
+++ b/src/base/Module.zig
@@ -135,7 +135,7 @@ pub const Store = struct {
 
         for (module.exposed_idents.items.items) |exposed_ident| {
             if (std.meta.eql(exposed_ident, ident)) {
-                _ = problems.append(Problem.Canonicalize.make(Problem.Canonicalize{ .DuplicateExposes = .{
+                _ = problems.append(Problem.Canonicalize.make(.{ .DuplicateExposes = .{
                     .first_exposes = exposed_ident,
                     .duplicate_exposes = ident,
                 } }));

--- a/src/base/ModuleEnv.zig
+++ b/src/base/ModuleEnv.zig
@@ -30,6 +30,7 @@ problems: problem.Problem.List,
 pub fn init(allocator: std.mem.Allocator) ModuleEnv {
     return ModuleEnv{
         .modules = base.Module.Store.init(allocator),
+        .idents = base.Ident.Store.init(allocator),
         .strings = collections.StringLiteral.Interner.init(allocator),
         .tag_names = collections.TagName.Interner.init(allocator),
         .tag_ids_for_slicing = collections.SafeList(collections.TagName.Idx).init(allocator),
@@ -64,6 +65,6 @@ pub fn addFieldNameSlice(
 }
 
 pub fn addExposedIdentForModule(self: *ModuleEnv, ident: Ident.Idx, module: Module.Idx) void {
-    self.modules.addExposedIdent(module, ident, self.problems);
+    self.modules.addExposedIdent(module, ident, &self.problems);
     self.idents.setExposingModule(ident, module);
 }

--- a/src/base/ModuleEnv.zig
+++ b/src/base/ModuleEnv.zig
@@ -3,20 +3,19 @@
 //!
 //! This reduces the size the IR as it can use references to these interned values.
 const std = @import("std");
-const base = @import("../base.zig");
 const collections = @import("../collections.zig");
 const problem = @import("../problem.zig");
+const Ident = @import("./Ident.zig");
+const Module = @import("./Module.zig");
 
-const Ident = base.Ident;
-const Module = base.Module;
 const Problem = problem.Problem;
 
 const ModuleEnv = @This();
 
 // stores information about modules, includes each of
 // this module's dependencies
-modules: base.Module.Store,
-idents: base.Ident.Store,
+modules: Module.Store,
+idents: Ident.Store,
 strings: collections.StringLiteral.Interner,
 tag_names: collections.TagName.Interner,
 tag_ids_for_slicing: collections.SafeList(collections.TagName.Idx),
@@ -29,8 +28,8 @@ problems: problem.Problem.List,
 
 pub fn init(allocator: std.mem.Allocator) ModuleEnv {
     return ModuleEnv{
-        .modules = base.Module.Store.init(allocator),
-        .idents = base.Ident.Store.init(allocator),
+        .modules = Module.Store.init(allocator),
+        .idents = Ident.Store.init(allocator),
         .strings = collections.StringLiteral.Interner.init(allocator),
         .tag_names = collections.TagName.Interner.init(allocator),
         .tag_ids_for_slicing = collections.SafeList(collections.TagName.Idx).init(allocator),

--- a/src/base/ModuleEnv.zig
+++ b/src/base/ModuleEnv.zig
@@ -27,9 +27,10 @@ problems: problem.Problem.List,
 // pub record_fields: Vec<RecordField<()>>,
 
 pub fn init(allocator: std.mem.Allocator) ModuleEnv {
+    var ident_store = Ident.Store.init(allocator);
     return ModuleEnv{
-        .modules = Module.Store.init(allocator),
-        .idents = Ident.Store.init(allocator),
+        .modules = Module.Store.init(allocator, &ident_store),
+        .idents = ident_store,
         .strings = collections.StringLiteral.Interner.init(allocator),
         .tag_names = collections.TagName.Interner.init(allocator),
         .tag_ids_for_slicing = collections.SafeList(collections.TagName.Idx).init(allocator),

--- a/src/base/Package.zig
+++ b/src/base/Package.zig
@@ -1,7 +1,7 @@
 //! A package imported at the root of a Roc application/platform/package.
 const std = @import("std");
-const base = @import("../base.zig");
 const collections = @import("../collections.zig");
+const Region = @import("./Region.zig");
 
 // TODO: this is half-baked, we should finish it when we get to saving/loading packages
 
@@ -32,8 +32,8 @@ pub const Idx = List.Idx;
 
 pub const Dependency = struct {
     package: Idx,
-    shorthand_region: base.Region,
-    url_region: base.Region,
+    shorthand_region: Region,
+    url_region: Region,
 
     pub const AddResult = union(enum) {
         Success,

--- a/src/base/Region.zig
+++ b/src/base/Region.zig
@@ -18,7 +18,7 @@ pub fn zero() Region {
     };
 }
 
-pub fn format(self: *const Region, comptime fmt: []const u8, _: std.fmt.FormatOptions, writer: anytype) !void {
+pub fn format(self: *const Region, comptime fmt: []const u8, _: std.fmt.FormatOptions, writer: anytype) void {
     if (fmt.len != 0) {
         std.fmt.invalidFmtError(fmt, self);
     }

--- a/src/base/Region.zig
+++ b/src/base/Region.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 const collections = @import("../collections.zig");
 
-pub const Region = @This();
+const Region = @This();
 
 start: Position,
 end: Position,

--- a/src/build/lift_functions.zig
+++ b/src/build/lift_functions.zig
@@ -1,9 +1,9 @@
 const std = @import("std");
 const base = @import("../base.zig");
 const type_spec = @import("./specialize_types.zig");
-pub const IR = @import("./lift_functions/IR.zig");
 
 const lift_functions = @This();
+pub const IR = @import("./lift_functions/IR.zig");
 
 /// Lift all closures to the top-level and leave behind closure captures
 ///

--- a/src/build/lift_functions.zig
+++ b/src/build/lift_functions.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const base = @import("../base.zig");
 const type_spec = @import("./specialize_types.zig");
 
-const lift_functions = @This();
+const Self = @This();
 pub const IR = @import("./lift_functions/IR.zig");
 
 /// Lift all closures to the top-level and leave behind closure captures
@@ -10,7 +10,7 @@ pub const IR = @import("./lift_functions/IR.zig");
 /// after this step, the program has no more implicit closures
 ///
 /// Implementation notes from Ayaz https://github.com/roc-lang/rfcs/blob/b4731508b60bf0e69d41083f09a5738123dfcefe/0102-compiling-lambda-sets.md#function_lift
-pub fn liftFunctions(ir: type_spec.IR, other_modules: []lift_functions.IR) lift_functions.IR {
+pub fn liftFunctions(ir: type_spec.IR, other_modules: []Self.IR) Self.IR {
     _ = ir;
     _ = other_modules;
 

--- a/src/build/lift_functions.zig
+++ b/src/build/lift_functions.zig
@@ -1,9 +1,9 @@
 const std = @import("std");
 const base = @import("../base.zig");
-const type_spec = @import("specialize_types.zig");
+const type_spec = @import("./specialize_types.zig");
+pub const IR = @import("./lift_functions/IR.zig");
 
 const lift_functions = @This();
-pub const IR = @import("lift_functions/IR.zig");
 
 /// Lift all closures to the top-level and leave behind closure captures
 ///

--- a/src/build/lift_functions/IR.zig
+++ b/src/build/lift_functions/IR.zig
@@ -9,7 +9,7 @@ const Problem = problem.Problem;
 const FieldName = collections.FieldName;
 const StringLiteral = collections.StringLiteral;
 
-pub const IR = @This();
+const Self = @This();
 
 env: *base.ModuleEnv,
 exposed_values: std.AutoHashMap(Ident.Idx, Expr.Idx),
@@ -22,8 +22,8 @@ typed_patterns: Pattern.Typed.List,
 typed_idents: TypedIdent.List,
 when_branches: WhenBranch.List,
 
-pub fn init(env: *base.ModuleEnv, allocator: std.mem.Allocator) IR {
-    return IR{
+pub fn init(env: *base.ModuleEnv, allocator: std.mem.Allocator) Self {
+    return Self{
         .env = env,
         .exposed_values = std.AutoHashMap(Ident.Idx, Expr.Idx).init(allocator),
         .exposed_functions = std.AutoHashMap(Ident.Idx, Function).init(allocator),
@@ -37,7 +37,7 @@ pub fn init(env: *base.ModuleEnv, allocator: std.mem.Allocator) IR {
     };
 }
 
-pub fn deinit(self: *IR) void {
+pub fn deinit(self: *Self) void {
     self.exposed_values.deinit();
     self.exposed_functions.deinit();
     self.types.deinit();

--- a/src/build/lower_statements.zig
+++ b/src/build/lower_statements.zig
@@ -1,9 +1,9 @@
 const std = @import("std");
 const base = @import("../base.zig");
-const func_spec = @import("specialize_functions.zig");
+const func_spec = @import("./specialize_functions.zig");
 
 const lower_statements = @This();
-pub const IR = @import("lower_statements/IR.zig");
+pub const IR = @import("./lower_statements/IR.zig");
 
 /// Convert expressions into statements for consumption by codegen.
 ///

--- a/src/build/lower_statements.zig
+++ b/src/build/lower_statements.zig
@@ -2,13 +2,13 @@ const std = @import("std");
 const base = @import("../base.zig");
 const func_spec = @import("./specialize_functions.zig");
 
-const lower_statements = @This();
+const Self = @This();
 pub const IR = @import("./lower_statements/IR.zig");
 
 /// Convert expressions into statements for consumption by codegen.
 ///
 /// Implementation notes from Ayaz https://github.com/roc-lang/rfcs/blob/ayaz/compile-with-lambda-sets/0102-compiling-lambda-sets.md#lower_ir
-pub fn lowerStatements(ir: func_spec.IR, other_modules: []lower_statements.IR) lower_statements.IR {
+pub fn lowerStatements(ir: func_spec.IR, other_modules: []Self.IR) Self.IR {
     _ = ir;
     _ = other_modules;
 

--- a/src/build/lower_statements/IR.zig
+++ b/src/build/lower_statements/IR.zig
@@ -9,7 +9,7 @@ const TagName = collections.TagName;
 const FieldName = collections.FieldName;
 const StringLiteral = collections.StringLiteral;
 
-pub const IR = @This();
+const Self = @This();
 
 env: *base.ModuleEnv,
 procedures: std.AutoHashMap(Ident.Idx, Procedure),
@@ -20,8 +20,8 @@ stmts: Stmt.List,
 idents_with_layouts: IdentWithLayout.List,
 list_literal_elems: ListLiteralElem.List,
 
-pub fn init(env: *base.ModuleEnv, allocator: std.mem.Allocator) IR {
-    return IR{
+pub fn init(env: *base.ModuleEnv, allocator: std.mem.Allocator) Self {
+    return Self{
         .env = env,
         .procedures = std.AutoHashMap(Ident.Idx, Procedure).init(allocator),
         .constants = std.AutoHashMap(Ident.Idx, StmtWithLayout).init(allocator),
@@ -33,7 +33,7 @@ pub fn init(env: *base.ModuleEnv, allocator: std.mem.Allocator) IR {
     };
 }
 
-pub fn deinit(self: *IR) void {
+pub fn deinit(self: *Self) void {
     self.procedures.deinit();
     self.constants.deinit();
     self.exprs.deinit();

--- a/src/build/lower_statements/IR.zig
+++ b/src/build/lower_statements/IR.zig
@@ -158,14 +158,14 @@ pub const Expr = union(enum) {
     },
 
     pub const List = collections.SafeList(@This());
-    pub const Id = List.Id;
+    pub const Idx = List.Idx;
     pub const Slice = List.Slice;
     pub const NonEmptySlice = List.NonEmptySlice;
 };
 
 pub const ListLiteralElem = union(enum) {
     StringLiteralId: []const u8,
-    Number: base.NumberLiteral,
+    Number: base.Literal.Num,
     Ident: Ident.Idx,
 
     pub const List = collections.SafeList(@This());

--- a/src/build/reference_count.zig
+++ b/src/build/reference_count.zig
@@ -2,11 +2,11 @@ const std = @import("std");
 const base = @import("../base.zig");
 const lower = @import("./lower_statements.zig");
 
-const reference_count = @This();
+const Self = @This();
 pub const IR = @import("./reference_count/IR.zig");
 
 /// Check ownership of function arguments and add refcounting instructions where necessary.
-pub fn referenceCount(ir: lower.IR, other_modules: []reference_count.IR) reference_count.IR {
+pub fn referenceCount(ir: lower.IR, other_modules: []Self.IR) Self.IR {
     _ = ir;
     _ = other_modules;
 

--- a/src/build/reference_count.zig
+++ b/src/build/reference_count.zig
@@ -1,9 +1,9 @@
 const std = @import("std");
 const base = @import("../base.zig");
-const lower = @import("lower_statements.zig");
+const lower = @import("./lower_statements.zig");
 
 const reference_count = @This();
-pub const IR = @import("reference_count/IR.zig");
+pub const IR = @import("./reference_count/IR.zig");
 
 /// Check ownership of function arguments and add refcounting instructions where necessary.
 pub fn referenceCount(ir: lower.IR, other_modules: []reference_count.IR) reference_count.IR {

--- a/src/build/reference_count/IR.zig
+++ b/src/build/reference_count/IR.zig
@@ -9,7 +9,7 @@ const TagName = collections.TagName;
 const FieldName = collections.FieldName;
 const StringLiteral = collections.StringLiteral;
 
-pub const IR = @This();
+const Self = @This();
 
 env: *base.ModuleEnv,
 procedures: std.AutoHashMap(Ident.Idx, Procedure),
@@ -20,8 +20,8 @@ stmts: Stmt.List,
 idents_with_layouts: IdentWithLayout.List,
 list_literal_elems: ListLiteralElem.List,
 
-pub fn init(env: *base.ModuleEnv, allocator: std.mem.Allocator) IR {
-    return IR{
+pub fn init(env: *base.ModuleEnv, allocator: std.mem.Allocator) Self {
+    return Self{
         .env = env,
         .procedures = std.AutoHashMap(Ident.Idx, Procedure).init(allocator),
         .constants = std.AutoHashMap(Ident.Idx, StmtWithLayout).init(allocator),
@@ -33,7 +33,7 @@ pub fn init(env: *base.ModuleEnv, allocator: std.mem.Allocator) IR {
     };
 }
 
-pub fn deinit(self: *IR) void {
+pub fn deinit(self: *Self) void {
     self.procedures.deinit();
     self.constants.deinit();
     self.exprs.deinit();

--- a/src/build/reference_count/IR.zig
+++ b/src/build/reference_count/IR.zig
@@ -158,14 +158,14 @@ pub const Expr = union(enum) {
     },
 
     pub const List = collections.SafeList(@This());
-    pub const Id = List.Id;
+    pub const Idx = List.Idx;
     pub const Slice = List.Slice;
     pub const NonEmptySlice = List.NonEmptySlice;
 };
 
 pub const ListLiteralElem = union(enum) {
     StringLiteralId: []const u8,
-    Number: base.NumberLiteral,
+    Number: base.Literal.Num,
     Ident: Ident.Idx,
 
     pub const List = collections.SafeList(@This());

--- a/src/build/solve_functions.zig
+++ b/src/build/solve_functions.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
 const base = @import("../base.zig");
-const func_lift = @import("lift_functions.zig");
+const func_lift = @import("./lift_functions.zig");
 const collections = @import("../collections.zig");
 
 const testing = std.testing;

--- a/src/build/specialize_functions.zig
+++ b/src/build/specialize_functions.zig
@@ -2,9 +2,8 @@ const std = @import("std");
 const base = @import("../base.zig");
 const func_lift = @import("./lift_functions.zig");
 const func_solve = @import("./solve_functions.zig");
-const func_spec = @import("./specialize_functions.zig");
 
-const specialize_functions = @This();
+const Self = @This();
 pub const IR = @import("./specialize_functions/IR.zig");
 
 /// For every function that takes a function as an argument:
@@ -15,8 +14,8 @@ pub const IR = @import("./specialize_functions/IR.zig");
 pub fn specializeFunctions(
     ir: func_lift.IR,
     function_sets: func_solve.FunctionSet.List,
-    other_modules: []specialize_functions.IR,
-) specialize_functions.IR {
+    other_modules: []Self.IR,
+) Self.IR {
     _ = ir;
     _ = function_sets;
     _ = other_modules;

--- a/src/build/specialize_functions.zig
+++ b/src/build/specialize_functions.zig
@@ -1,11 +1,11 @@
 const std = @import("std");
 const base = @import("../base.zig");
-const func_lift = @import("lift_functions.zig");
-const func_solve = @import("solve_functions.zig");
-const func_spec = @import("specialize_functions.zig");
+const func_lift = @import("./lift_functions.zig");
+const func_solve = @import("./solve_functions.zig");
+const func_spec = @import("./specialize_functions.zig");
 
 const specialize_functions = @This();
-pub const IR = @import("specialize_functions/IR.zig");
+pub const IR = @import("./specialize_functions/IR.zig");
 
 /// For every function that takes a function as an argument:
 /// - replace each function arg with a new tag union based on the FunctionSet created during `solve_functions`

--- a/src/build/specialize_functions/IR.zig
+++ b/src/build/specialize_functions/IR.zig
@@ -109,7 +109,7 @@ pub const Expr = union(enum) {
         branches: WhenBranch.NonEmptySlice,
     },
 
-    CompilerBug: Problem.SpecializeTypes,
+    CompilerBug: Problem.Compiler.SpecializeTypes,
 
     pub const List = collections.SafeList(@This());
     pub const Idx = List.Idx;
@@ -145,8 +145,8 @@ pub const WhenBranch = struct {
     /// The expression to produce if the pattern matches
     value: Expr.Idx,
 
-    pub const List = collections.SafeMultiList(@This());
-    pub const Slice = List.Slice;
+    pub const List = collections.SafeList(@This());
+    pub const NonEmptySlice = List.NonEmptySlice;
 };
 
 pub const Function = struct {
@@ -197,7 +197,7 @@ pub const Pattern = union(enum) {
         },
     },
     Underscore,
-    CompilerBug: Problem.SpecializeTypes,
+    CompilerBug: Problem.Compiler.SpecializeTypes,
 
     pub const List = collections.SafeList(@This());
     pub const Idx = List.Idx;

--- a/src/build/specialize_functions/IR.zig
+++ b/src/build/specialize_functions/IR.zig
@@ -9,7 +9,7 @@ const Problem = problem.Problem;
 const FieldName = collections.FieldName;
 const StringLiteral = collections.StringLiteral;
 
-pub const IR = @This();
+const Self = @This();
 
 env: *base.ModuleEnv,
 exposed_values: std.AutoHashMap(Ident.Idx, Expr.Idx),
@@ -22,8 +22,8 @@ typed_patterns: Pattern.Typed.List,
 typed_idents: TypedIdent.List,
 when_branches: WhenBranch.List,
 
-pub fn init(env: *base.ModuleEnv, allocator: std.mem.Allocator) IR {
-    return IR{
+pub fn init(env: *base.ModuleEnv, allocator: std.mem.Allocator) Self {
+    return Self{
         .env = env,
         .exposed_values = std.AutoHashMap(Ident.Idx, Expr.Idx).init(allocator),
         .exposed_functions = std.AutoHashMap(Ident.Idx, Function).init(allocator),
@@ -37,7 +37,7 @@ pub fn init(env: *base.ModuleEnv, allocator: std.mem.Allocator) IR {
     };
 }
 
-pub fn deinit(self: *IR) void {
+pub fn deinit(self: *Self) void {
     self.exposed_values.deinit();
     self.exposed_functions.deinit();
     self.types.deinit();

--- a/src/build/specialize_types.zig
+++ b/src/build/specialize_types.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const base = @import("../base.zig");
 const resolve = @import("../check/resolve_imports.zig");
 
-const specialize_types = @This();
+const Self = @This();
 pub const IR = @import("specialize_types/IR.zig");
 
 /// Create a copy of every function in the program, by walking from the entrypoint down the tree, replacing type variables with concrete types.
@@ -11,7 +11,7 @@ pub const IR = @import("specialize_types/IR.zig");
 /// after this step, the program has no generic types
 ///
 /// Implementation notes from Ayaz https://github.com/roc-lang/rfcs/blob/ayaz/compile-with-lambda-sets/0102-compiling-lambda-sets.md#type_specialize
-pub fn specializeTypes(resolve_ir: resolve.IR, other_modules: []specialize_types.IR) specialize_types.IR {
+pub fn specializeTypes(resolve_ir: resolve.IR, other_modules: []Self.IR) Self.IR {
     _ = resolve_ir;
     _ = other_modules;
 

--- a/src/build/specialize_types.zig
+++ b/src/build/specialize_types.zig
@@ -3,7 +3,7 @@ const base = @import("../base.zig");
 const resolve = @import("../check/resolve_imports.zig");
 
 const specialize_types = @This();
-pub const IR = @import("specialize_types/IR.zig").IR;
+pub const IR = @import("specialize_types/IR.zig");
 
 /// Create a copy of every function in the program, by walking from the entrypoint down the tree, replacing type variables with concrete types.
 ///

--- a/src/build/specialize_types/IR.zig
+++ b/src/build/specialize_types/IR.zig
@@ -119,7 +119,7 @@ pub const Expr = union(enum) {
         branches: WhenBranch.NonEmptySlice,
     },
 
-    CompilerBug: Problem.SpecializeTypes,
+    CompilerBug: Problem.Compiler.SpecializeTypes,
 
     pub const List = collections.SafeList(@This());
     pub const Idx = List.Idx;
@@ -155,8 +155,8 @@ pub const WhenBranch = struct {
     /// The expression to produce if the pattern matches
     value: Expr.Idx,
 
-    pub const List = collections.SafeMultiList(@This());
-    pub const Slice = List.Slice;
+    pub const List = collections.SafeList(@This());
+    pub const NonEmptySlice = List.NonEmptySlice;
 };
 
 pub const Function = struct {
@@ -207,7 +207,7 @@ pub const Pattern = union(enum) {
         },
     },
     Underscore,
-    CompilerBug: Problem.SpecializeTypes,
+    CompilerBug: Problem.Compiler.SpecializeTypes,
 
     pub const List = collections.SafeList(@This());
     pub const Idx = List.Idx;

--- a/src/build/specialize_types/IR.zig
+++ b/src/build/specialize_types/IR.zig
@@ -9,7 +9,7 @@ const Problem = problem.Problem;
 const FieldName = collections.FieldName;
 const StringLiteral = collections.StringLiteral;
 
-pub const IR = @This();
+const Self = @This();
 
 env: *base.ModuleEnv,
 exposed_values: std.AutoHashMap(Ident.Idx, Expr.Idx),
@@ -22,8 +22,8 @@ typed_patterns: Pattern.Typed.List,
 typed_idents: TypedIdent.List,
 when_branches: WhenBranch.List,
 
-pub fn init(env: *base.ModuleEnv, allocator: std.mem.Allocator) IR {
-    return IR{
+pub fn init(env: *base.ModuleEnv, allocator: std.mem.Allocator) Self {
+    return Self{
         .env = env,
         .exposed_values = std.AutoHashMap(Ident.Idx, Expr.Idx).init(allocator),
         .exposed_functions = std.AutoHashMap(Ident.Idx, Function).init(allocator),
@@ -37,7 +37,7 @@ pub fn init(env: *base.ModuleEnv, allocator: std.mem.Allocator) IR {
     };
 }
 
-pub fn deinit(self: *IR) void {
+pub fn deinit(self: *Self) void {
     self.exposed_values.deinit();
     self.exposed_functions.deinit();
     self.types.deinit();

--- a/src/check/canonicalize.zig
+++ b/src/check/canonicalize.zig
@@ -8,7 +8,7 @@ const Problem = problem.Problem;
 const Ident = base.Ident;
 const Scope = @import("./canonicalize/Scope.zig");
 
-const can = @This();
+const Self = @This();
 pub const IR = @import("./canonicalize/IR.zig");
 
 /// After parsing a Roc program, the [ParseIR](src/check/parse/ir.zig) is transformed into a [canonical

--- a/src/check/canonicalize.zig
+++ b/src/check/canonicalize.zig
@@ -5,10 +5,11 @@ const problem = @import("../problem.zig");
 const collections = @import("../collections.zig");
 
 const Problem = problem.Problem;
-const Scope = @import("canonicalize/Scope.zig");
+const Ident = base.Ident;
+const Scope = @import("./canonicalize/Scope.zig");
 
 const can = @This();
-pub const IR = @import("canonicalize/IR.zig");
+pub const IR = @import("./canonicalize/IR.zig");
 
 /// After parsing a Roc program, the [ParseIR](src/check/parse/ir.zig) is transformed into a [canonical
 /// form](src/check/canonicalize/ir.zig) called CanIR.
@@ -30,8 +31,10 @@ pub fn canonicalize(
     parse_ir: parse.IR,
     allocator: std.mem.Allocator,
 ) void {
-    const env = can_ir.env;
-    const scope = Scope.init(can_ir.env, .{}, .{}, allocator);
+    var env = can_ir.env;
+    const builtin_aliases = [0]Scope.Alias{};
+    const imported_idents = [0]Ident.Idx{};
+    const scope = Scope.init(&env, &builtin_aliases, &imported_idents, allocator);
     _ = scope;
 
     for (parse_ir.defs.items.items) |stmt| {
@@ -43,12 +46,17 @@ pub fn canonicalize(
                 );
 
                 if (res.was_present) {
-                    env.problems.append(Problem.Canonicalize.make(.{.DuplicateImport{
+                    _ = env.problems.append(Problem.Canonicalize.make(.{ .DuplicateImport = .{
                         .duplicate_import_region = import.name_region,
-                    }}));
+                    } }));
                 }
 
-                for (import.exposing.items.items) |exposed_ident| {
+                for (import.exposing.items.items) |exposed| {
+                    const exposed_ident = switch (exposed) {
+                        .Value => |ident| ident,
+                        .Type => |ident| ident,
+                        .CustomTagUnion => |custom| custom.name,
+                    };
                     env.addExposedIdentForModule(exposed_ident, res.module_idx);
                 }
             },

--- a/src/check/canonicalize/IR.zig
+++ b/src/check/canonicalize/IR.zig
@@ -26,6 +26,7 @@ type_vars: collections.SafeList(TypeVar),
 pub fn init(allocator: std.mem.Allocator) Self {
     return Self{
         .env = base.ModuleEnv.init(allocator),
+        .aliases = std.AutoHashMap(Ident.Idx, Alias.WithVisibility).init(allocator),
         .exprs = Expr.List.init(allocator),
         .exprs_at_regions = ExprAtRegion.List.init(allocator),
         .typed_exprs_at_regions = TypedExprAtRegion.List.init(allocator),

--- a/src/check/canonicalize/IR.zig
+++ b/src/check/canonicalize/IR.zig
@@ -10,7 +10,7 @@ const TagName = collections.TagName;
 const FieldName = collections.FieldName;
 const StringLiteral = collections.StringLiteral;
 
-const IR = @This();
+const Self = @This();
 
 env: base.ModuleEnv,
 aliases: std.AutoHashMap(Ident.Idx, Alias.WithVisibility),
@@ -23,8 +23,8 @@ patterns_at_regions: PatternAtRegion.List,
 typed_patterns_at_regions: TypedPatternAtRegion.List,
 type_vars: collections.SafeList(TypeVar),
 
-pub fn init(allocator: std.mem.Allocator) IR {
-    return IR{
+pub fn init(allocator: std.mem.Allocator) Self {
+    return Self{
         .env = base.ModuleEnv.init(allocator),
         .exprs = Expr.List.init(allocator),
         .exprs_at_regions = ExprAtRegion.List.init(allocator),
@@ -37,7 +37,7 @@ pub fn init(allocator: std.mem.Allocator) IR {
     };
 }
 
-pub fn deinit(self: *IR) void {
+pub fn deinit(self: *Self) void {
     self.env.deinit();
     self.exprs.deinit();
     self.exprs_at_regions.deinit();

--- a/src/check/canonicalize/IR.zig
+++ b/src/check/canonicalize/IR.zig
@@ -5,7 +5,7 @@ const collections = @import("../../collections.zig");
 
 const Ident = base.Ident;
 const Region = base.Region;
-const TypeVar = types.Type.Var;
+const TypeVar = types.TypeVar;
 const TagName = collections.TagName;
 const FieldName = collections.FieldName;
 const StringLiteral = collections.StringLiteral;
@@ -66,7 +66,7 @@ pub const Alias = struct {
     /// Extension variables that should be inferred in output positions, and closed in input
     /// positions.
     infer_ext_in_output_variables: collections.SafeList(TypeVar).Slice,
-    recursion_variables: std.AutoHashMap(TypeVar, .{}),
+    recursion_variables: std.AutoHashMap(TypeVar, Ident.Idx),
 
     //     pub typ: Type,
     kind: Kind,
@@ -145,7 +145,7 @@ pub const Expr = union(enum) {
         type_var: TypeVar,
     },
 
-    When: When.Id,
+    When: When.Idx,
     If: struct {
         cond_var: TypeVar,
         branch_var: TypeVar,
@@ -238,10 +238,14 @@ pub const Def = struct {
         /// Ignored result, must be effectful
         Ignored: TypeVar,
     };
+
+    pub const List = collections.SafeList(@This());
+    pub const Idx = List.Idx;
+    pub const Slice = List.Slice;
 };
 
 pub const Annotation = struct {
-    signature: types.Type,
+    signature: types.TypeVar,
     // introduced_variables: IntroducedVariables,
     // aliases: VecMap<Symbol, Alias>,
     region: Region,
@@ -331,7 +335,7 @@ pub const WhenBranch = struct {
 /// A pattern, including possible problems (e.g. shadowing) so that
 /// codegen can generate a runtime error if this pattern is reached.
 pub const Pattern = union(enum) {
-    Identifier: base.Module.Ident,
+    Identifier: base.Module.Idx,
     As: struct {
         pattern: Pattern.Idx,
         region: Region,

--- a/src/check/parse/IR.zig
+++ b/src/check/parse/IR.zig
@@ -3,7 +3,7 @@ const collections = @import("../../collections.zig");
 
 const Ident = base.Ident;
 
-const IR = @This();
+const Self = @This();
 
 header: Header,
 defs: Stmt.List,

--- a/src/check/parse/IR.zig
+++ b/src/check/parse/IR.zig
@@ -36,9 +36,11 @@ pub const Stmt = union(enum) {
     Import: Import,
 
     pub const Import = struct {
-        name: base.Ident.Idx,
+        // TODO: this will all be changed when the 1st draft of the parser MR is merged
+        // Changing to get test working for now
+        name: []u8,
         name_region: base.Region,
-        package_shorthand: ?base.Ident.Idx,
+        package_shorthand: ?[]u8,
         exposing: collections.SafeList(Exposing),
 
         pub const Exposing = union(enum) {

--- a/src/check/resolve_imports.zig
+++ b/src/check/resolve_imports.zig
@@ -1,9 +1,9 @@
 const std = @import("std");
 const base = @import("../base.zig");
-const can = @import("canonicalize.zig");
+const can = @import("./canonicalize.zig");
 
 const resolve = @This();
-pub const IR = @import("resolve_imports/IR.zig");
+pub const IR = @import("./resolve_imports/IR.zig");
 
 pub fn resolveImports(
     can_ir: can.IR,

--- a/src/check/resolve_imports.zig
+++ b/src/check/resolve_imports.zig
@@ -2,13 +2,13 @@ const std = @import("std");
 const base = @import("../base.zig");
 const can = @import("./canonicalize.zig");
 
-const resolve = @This();
+const Self = @This();
 pub const IR = @import("./resolve_imports/IR.zig");
 
 pub fn resolveImports(
     can_ir: can.IR,
-    other_modules: []resolve.IR,
-) resolve.IR {
+    other_modules: []Self.IR,
+) Self.IR {
     _ = can_ir;
     _ = other_modules;
 

--- a/src/check/resolve_imports/IR.zig
+++ b/src/check/resolve_imports/IR.zig
@@ -65,10 +65,10 @@ pub const DestructureDef = union(enum) {
 
 pub const DeclarationTag = union(enum) {
     Value,
-    Function: collections.SafeList(FunctionDef).Id,
-    Recursive: collections.SafeList(FunctionDef).Id,
-    TailRecursive: collections.SafeList(FunctionDef).Id,
-    Destructure: collections.SafeList(DestructureDef).Id,
+    Function: collections.SafeList(FunctionDef).Idx,
+    Recursive: collections.SafeList(FunctionDef).Idx,
+    TailRecursive: collections.SafeList(FunctionDef).Idx,
+    Destructure: collections.SafeList(DestructureDef).Idx,
     MutualRecursion: struct {
         length: u16,
         cycle_mark: IllegalCycleMark,

--- a/src/check/resolve_imports/IR.zig
+++ b/src/check/resolve_imports/IR.zig
@@ -10,7 +10,7 @@ const Region = base.Region;
 const TypeVar = types.TypeVar;
 const CanIR = @import("../canonicalize/IR.zig");
 
-const IR = @This();
+const Self = @This();
 
 // utable: UnificationTable,
 // pub type_var_slices: Vec<TypeVarSubsSlice>,
@@ -24,8 +24,8 @@ type_vars: collections.SafeList(TypeVar),
 declarations: DeclarationTag.List,
 host_exposed_annotations: std.AutoHashMap(usize, TypeVar),
 
-pub fn init(env: *base.ModuleEnv, allocator: std.mem.Allocator) IR {
-    return IR{
+pub fn init(env: *base.ModuleEnv, allocator: std.mem.Allocator) Self {
+    return Self{
         .env = env,
         .regions = Region.List.init(allocator),
         .exprs = Expr.List.init(allocator),
@@ -38,7 +38,7 @@ pub fn init(env: *base.ModuleEnv, allocator: std.mem.Allocator) IR {
     };
 }
 
-pub fn deinit(self: *IR) void {
+pub fn deinit(self: *Self) void {
     self.regions.deinit();
     self.exprs.deinit();
     self.destructs.deinit();

--- a/src/collections/interner/FieldName.zig
+++ b/src/collections/interner/FieldName.zig
@@ -21,11 +21,12 @@ pub const Interner = struct {
         self.names.deinit();
     }
 
-    pub fn insert(self: *Interner, name: []u8) Idx {
-        return @enumFromInt(self.names.insert(name).id);
+    pub fn insert(self: *Interner, name: []u8) !Idx {
+        const name_idx = try self.names.insert(name);
+        return @enumFromInt(@intFromEnum(name_idx));
     }
 
     pub fn get(self: *Interner, id: Idx) []u8 {
-        return self.names.get(@intFromEnum(id));
+        return self.names.get(@enumFromInt(@intFromEnum(id)));
     }
 };

--- a/src/collections/interner/FieldName.zig
+++ b/src/collections/interner/FieldName.zig
@@ -1,6 +1,7 @@
 //! The name of a field in a record, e.g. `foo` in `{ foo: 123 }`.
 const std = @import("std");
 const IdentName = @import("IdentName.zig");
+const exitOnOom = @import("../utils.zig").exitOnOom;
 
 /// The index for a record field name in a FieldName.Interner.
 pub const Idx = enum(u32) { _ };
@@ -21,12 +22,12 @@ pub const Interner = struct {
         self.names.deinit();
     }
 
-    pub fn insert(self: *Interner, name: []u8) !Idx {
-        const name_idx = try self.names.insert(name);
+    pub fn insert(self: *Interner, name: []u8) Idx {
+        const name_idx = self.names.insert(name);
         return @enumFromInt(@intFromEnum(name_idx));
     }
 
-    pub fn get(self: *Interner, id: Idx) []u8 {
-        return self.names.get(@enumFromInt(@intFromEnum(id)));
+    pub fn get(self: *Interner, idx: Idx) []u8 {
+        return self.names.get(@enumFromInt(@intFromEnum(idx)));
     }
 };

--- a/src/collections/interner/IdentName.zig
+++ b/src/collections/interner/IdentName.zig
@@ -55,7 +55,7 @@ pub const Interner = struct {
     }
 
     /// Add an ident name to this interner, returning a unique, serial index.
-    pub fn insert(self: *Interner, string: []u8) !Idx {
+    pub fn insert(self: *Interner, string: []u8) Idx {
         const hash = fnvStringHash(string);
 
         const string_indices = self.stringIndicesForHash(hash);
@@ -66,7 +66,7 @@ pub const Interner = struct {
             }
         }
 
-        const copied_string = try self.strings.allocator.alloc(u8, string.len);
+        const copied_string = self.strings.allocator.alloc(u8, string.len) catch exitOnOom();
         std.mem.copyForwards(u8, copied_string, string);
 
         const strings_len = @as(u32, @intCast(self.strings.items.len));

--- a/src/collections/interner/StringLiteral.zig
+++ b/src/collections/interner/StringLiteral.zig
@@ -33,7 +33,7 @@ pub const Interner = struct {
 
         self.strings.append(copied_string) catch exitOnOom();
 
-        return @enumFromInt(@as(u32, len));
+        return @enumFromInt(@as(u32, @intCast(len)));
     }
 
     pub fn get(self: *Interner, idx: Idx) []u8 {

--- a/src/collections/interner/TagName.zig
+++ b/src/collections/interner/TagName.zig
@@ -21,11 +21,12 @@ pub const Interner = struct {
         self.names.deinit();
     }
 
-    pub fn insert(self: *Interner, name: []u8) Idx {
-        return @enumFromInt(self.names.insert(name).id);
+    pub fn insert(self: *Interner, name: []u8) !Idx {
+        const name_idx = try self.names.insert(name);
+        return @enumFromInt(@intFromEnum(name_idx));
     }
 
     pub fn get(self: *Interner, id: Idx) []u8 {
-        return self.names.get(@intFromEnum(id));
+        return self.names.get(@enumFromInt(@intFromEnum(id)));
     }
 };

--- a/src/collections/interner/TagName.zig
+++ b/src/collections/interner/TagName.zig
@@ -1,6 +1,7 @@
 //! The name of a tag, e.g. `Foo` in `Foo("abc", 123)`.
 const std = @import("std");
 const IdentName = @import("IdentName.zig");
+const exitOnOom = @import("../utils.zig").exitOnOom;
 
 /// The index for a tag name in a TagName.Interner.
 pub const Idx = enum(u32) { _ };
@@ -21,8 +22,8 @@ pub const Interner = struct {
         self.names.deinit();
     }
 
-    pub fn insert(self: *Interner, name: []u8) !Idx {
-        const name_idx = try self.names.insert(name);
+    pub fn insert(self: *Interner, name: []u8) Idx {
+        const name_idx = self.names.insert(name);
         return @enumFromInt(@intFromEnum(name_idx));
     }
 

--- a/src/collections/safe_list.zig
+++ b/src/collections/safe_list.zig
@@ -103,25 +103,25 @@ pub fn SafeMultiList(comptime T: type) type {
         pub const Slice = std.MultiArrayList(T).Slice;
 
         pub fn init(allocator: std.mem.Allocator) SafeMultiList(T) {
-            return SafeMultiList{
+            return SafeMultiList(T){
                 .items = std.MultiArrayList(T){},
                 .allocator = allocator,
             };
         }
 
         pub fn deinit(self: *SafeMultiList(T)) void {
-            self.items.deinit();
+            self.items.deinit(self.allocator);
         }
 
         pub fn len(self: *SafeMultiList(T)) usize {
-            return self.items.items.len;
+            return self.items.len;
         }
 
         pub fn append(self: *SafeMultiList(T), item: T) Idx {
             const length = self.len();
-            self.items.append(item) catch exitOnOom();
+            self.items.append(self.allocator, item) catch exitOnOom();
 
-            return @enumFromInt(@as(u32, length));
+            return @enumFromInt(@as(u32, @intCast(length)));
         }
     };
 }

--- a/src/coordinate.zig
+++ b/src/coordinate.zig
@@ -14,7 +14,7 @@ const tokenize = @import("check/parse/tokenize.zig");
 const Package = base.Package;
 const exitOnOom = @import("collections/utils.zig").exitOnOom;
 
-const ResolveIR = type_spec.IR;
+const ResolveIR = resolve.IR;
 const TypeSpecIR = type_spec.IR;
 const RefCountIR = refcount.IR;
 

--- a/src/test.zig
+++ b/src/test.zig
@@ -3,5 +3,14 @@ const testing = std.testing;
 
 test {
     testing.refAllDeclsRecursive(@import("main.zig"));
+    testing.refAllDeclsRecursive(@import("coordinate.zig"));
+    testing.refAllDeclsRecursive(@import("check/parse.zig"));
+    testing.refAllDeclsRecursive(@import("check/resolve_imports.zig"));
+    testing.refAllDeclsRecursive(@import("check/typecheck.zig"));
+    testing.refAllDeclsRecursive(@import("build/specialize_types.zig"));
+    testing.refAllDeclsRecursive(@import("build/lift_functions.zig"));
+    testing.refAllDeclsRecursive(@import("build/specialize_functions.zig"));
     testing.refAllDeclsRecursive(@import("build/solve_functions.zig"));
+    testing.refAllDeclsRecursive(@import("build/lower_statements.zig"));
+    testing.refAllDeclsRecursive(@import("build/reference_count.zig"));
 }

--- a/src/test.zig
+++ b/src/test.zig
@@ -19,6 +19,7 @@ test {
     testing.refAllDeclsRecursive(@import("check/parse.zig"));
     testing.refAllDeclsRecursive(@import("check/resolve_imports.zig"));
     testing.refAllDeclsRecursive(@import("check/typecheck.zig"));
+    testing.refAllDeclsRecursive(@import("check/canonicalize.zig"));
     testing.refAllDeclsRecursive(@import("build/specialize_types.zig"));
     testing.refAllDeclsRecursive(@import("build/lift_functions.zig"));
     testing.refAllDeclsRecursive(@import("build/specialize_functions.zig"));

--- a/src/test.zig
+++ b/src/test.zig
@@ -3,14 +3,15 @@ const testing = std.testing;
 
 test {
     testing.refAllDeclsRecursive(@import("main.zig"));
+    // testing.refAllDeclsRecursive(@import("base.zig"));
     testing.refAllDeclsRecursive(@import("coordinate.zig"));
     testing.refAllDeclsRecursive(@import("check/parse.zig"));
     testing.refAllDeclsRecursive(@import("check/resolve_imports.zig"));
     testing.refAllDeclsRecursive(@import("check/typecheck.zig"));
-    testing.refAllDeclsRecursive(@import("build/specialize_types.zig"));
-    testing.refAllDeclsRecursive(@import("build/lift_functions.zig"));
-    testing.refAllDeclsRecursive(@import("build/specialize_functions.zig"));
+    // testing.refAllDeclsRecursive(@import("build/specialize_types.zig"));
+    // testing.refAllDeclsRecursive(@import("build/lift_functions.zig"));
+    // testing.refAllDeclsRecursive(@import("build/specialize_functions.zig"));
     testing.refAllDeclsRecursive(@import("build/solve_functions.zig"));
-    testing.refAllDeclsRecursive(@import("build/lower_statements.zig"));
-    testing.refAllDeclsRecursive(@import("build/reference_count.zig"));
+    // testing.refAllDeclsRecursive(@import("build/lower_statements.zig"));
+    // testing.refAllDeclsRecursive(@import("build/reference_count.zig"));
 }

--- a/src/test.zig
+++ b/src/test.zig
@@ -19,10 +19,10 @@ test {
     testing.refAllDeclsRecursive(@import("check/parse.zig"));
     testing.refAllDeclsRecursive(@import("check/resolve_imports.zig"));
     testing.refAllDeclsRecursive(@import("check/typecheck.zig"));
-    // testing.refAllDeclsRecursive(@import("build/specialize_types.zig"));
-    // testing.refAllDeclsRecursive(@import("build/lift_functions.zig"));
-    // testing.refAllDeclsRecursive(@import("build/specialize_functions.zig"));
+    testing.refAllDeclsRecursive(@import("build/specialize_types.zig"));
+    testing.refAllDeclsRecursive(@import("build/lift_functions.zig"));
+    testing.refAllDeclsRecursive(@import("build/specialize_functions.zig"));
     testing.refAllDeclsRecursive(@import("build/solve_functions.zig"));
-    // testing.refAllDeclsRecursive(@import("build/lower_statements.zig"));
-    // testing.refAllDeclsRecursive(@import("build/reference_count.zig"));
+    testing.refAllDeclsRecursive(@import("build/lower_statements.zig"));
+    testing.refAllDeclsRecursive(@import("build/reference_count.zig"));
 }

--- a/src/test.zig
+++ b/src/test.zig
@@ -3,7 +3,18 @@ const testing = std.testing;
 
 test {
     testing.refAllDeclsRecursive(@import("main.zig"));
-    // testing.refAllDeclsRecursive(@import("base.zig"));
+    testing.refAllDeclsRecursive(@import("problem.zig"));
+    testing.refAllDeclsRecursive(@import("types.zig"));
+    testing.refAllDeclsRecursive(@import("collections.zig"));
+    testing.refAllDeclsRecursive(@import("collections/utils.zig"));
+    testing.refAllDeclsRecursive(@import("collections/safe_list.zig"));
+    testing.refAllDeclsRecursive(@import("collections/interner/StringLiteral.zig"));
+    testing.refAllDeclsRecursive(@import("base/Ident.zig"));
+    testing.refAllDeclsRecursive(@import("base/Module.zig"));
+    testing.refAllDeclsRecursive(@import("base/ModuleEnv.zig"));
+    testing.refAllDeclsRecursive(@import("base/Package.zig"));
+    testing.refAllDeclsRecursive(@import("base/Region.zig"));
+    testing.refAllDeclsRecursive(@import("base.zig"));
     testing.refAllDeclsRecursive(@import("coordinate.zig"));
     testing.refAllDeclsRecursive(@import("check/parse.zig"));
     testing.refAllDeclsRecursive(@import("check/resolve_imports.zig"));


### PR DESCRIPTION
Based on Brendan's comment [here](https://github.com/roc-lang/roc/pull/7600#discussion_r1950140222), this PR manually lists most compiler stagings & other files in `test.zig`, then resolves various errors.

There was a weird issue causing tests to pass, but `zig build test` to fail around public structs being re-exported. If you had a few files defined like:

```zig
// lower_statements/IR.zig
pub const Self = @This();

// lower_statements.zig
const lower_statements = @This();
pub const IR = @import("./lower_statements/IR.zig");
```
Then running tests fail with a very weird error:

```
Build Summary: 2/5 steps succeeded; 1 failed
test transitive failure
└─ run test transitive failure
   └─ zig test Debug native-native-musl 1 errors
      └─ run gencat (gencat.bin.z) cached
         └─ zig build-exe gencat Debug native cached 3ms MaxRSS:50M
error: the following build command failed with exit code 1:
```

The culprit here is the `pub` in `lower_statement/IR.zig`. If you remove that, things work correctly. This PR fixes this issue in most of the `stage/IR.zig` files & `base/Region.zig`.

While doing this, I noticed that most of those `*/IR.zig` files defined:
```
```zig
const IR = @This();
```
Which also caused some confusion for me when debugging. I updated these to be `const Self = @This()`, which is inline with the community conventions in Zig (afaict).

Then, lastly, this PR adds `watchexec` to the nix shell to easily re-run test on file change.