### PR TITLE
doc/example: Add site link and example source code link

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,3 +1,3 @@
 # Examples
 
-Checkout the [roc examples site](https://github.com/roc-lang/examples) to see examples of using roc.
+Checkout the [roc examples site](https://www.roc-lang.org/examples) or [roc examples source code](https://github.com/roc-lang/examples/tree/main/examples) to see examples of using roc.


### PR DESCRIPTION
I think this part of the documentation could be improved.

cc @smores56 PTAL, thanks