### PR TITLE
Fix up SmallStringInterner and use GPA

### DIFF
--- a/src/base/Ident.zig
+++ b/src/base/Ident.zig
@@ -57,13 +57,17 @@ pub const Store = struct {
     exposing_modules: std.ArrayList(Module.Idx),
     next_unique_name: u32,
 
-    pub fn init(arena: *std.heap.ArenaAllocator) Store {
+    pub fn init(gpa: std.mem.Allocator) Store {
         return Store{
-            .interner = SmallStringInterner.init(arena),
-            // error: expected type 'heap.arena_allocator.ArenaAllocator', found '*heap.arena_allocator.ArenaAllocator'
-            .exposing_modules = std.ArrayList(Module.Idx).init(arena.allocator()),
+            .interner = SmallStringInterner.init(gpa),
+            .exposing_modules = std.ArrayList(Module.Idx).init(gpa),
             .next_unique_name = 0,
         };
+    }
+
+    pub fn deinit(self: *Store) void {
+        self.interner.deinit();
+        self.exposing_modules.deinit();
     }
 
     pub fn insert(self: *Store, ident: Ident, region: Region) Idx {
@@ -140,11 +144,5 @@ pub const Store = struct {
     /// module is zero because it hasn't been set yet or if it's actually zero.
     pub fn setExposingModule(self: *Store, idx: Idx, exposing_module: Module.Idx) void {
         self.exposing_modules.items[@as(usize, idx.idx)] = exposing_module;
-    }
-
-    /// Look up text in this store, returning a slice of all string interner IDs
-    /// that match this ident's text.
-    pub fn lookup(self: *Store, string: []u8) []SmallStringInterner.Idx {
-        return self.interner.lookup(string);
     }
 };

--- a/src/base/Module.zig
+++ b/src/base/Module.zig
@@ -64,7 +64,6 @@ pub const Store = struct {
             module.exposed_idents.deinit();
         }
         self.modules.deinit();
-        self.ident_store.deinit();
     }
 
     /// Search for a module that's visible to the main module.

--- a/src/base/ModuleEnv.zig
+++ b/src/base/ModuleEnv.zig
@@ -38,9 +38,9 @@ pub fn init(gpa: std.mem.Allocator) Self {
 }
 
 pub fn deinit(self: *Self) void {
+    self.modules.deinit();
     self.idents.deinit();
     self.ident_ids_for_slicing.deinit();
-    self.modules.deinit();
     self.strings.deinit();
     self.problems.deinit();
     self.type_store.deinit();

--- a/src/base/ModuleEnv.zig
+++ b/src/base/ModuleEnv.zig
@@ -23,20 +23,27 @@ modules: Module.Store,
 strings: StringLiteral.Store,
 problems: std.ArrayList(Problem),
 type_store: Type.Store,
-arena: *std.heap.ArenaAllocator,
 
-pub fn init(arena: *std.heap.ArenaAllocator) Self {
-    var ident_store = Ident.Store.init(arena);
+pub fn init(gpa: std.mem.Allocator) Self {
+    var ident_store = Ident.Store.init(gpa);
 
     return Self{
         .idents = ident_store,
-        .ident_ids_for_slicing = collections.SafeList(Ident.Idx).init(arena.allocator()),
-        .modules = Module.Store.init(arena, &ident_store),
-        .strings = StringLiteral.Store.init(arena.allocator()),
-        .problems = std.ArrayList(Problem).init(arena.allocator()),
-        .type_store = Type.Store.init(arena.allocator()),
-        .arena = arena,
+        .ident_ids_for_slicing = collections.SafeList(Ident.Idx).init(gpa),
+        .modules = Module.Store.init(gpa, &ident_store),
+        .strings = StringLiteral.Store.init(gpa),
+        .problems = std.ArrayList(Problem).init(gpa),
+        .type_store = Type.Store.init(gpa),
     };
+}
+
+pub fn deinit(self: *Self) void {
+    self.idents.deinit();
+    self.ident_ids_for_slicing.deinit();
+    self.modules.deinit();
+    self.strings.deinit();
+    self.problems.deinit();
+    self.type_store.deinit();
 }
 
 pub fn addExposedIdentForModule(self: *Self, ident: Ident.Idx, module: Module.Idx) void {

--- a/src/base/StringLiteral.zig
+++ b/src/base/StringLiteral.zig
@@ -32,9 +32,9 @@ pub const Store = struct {
     /// continues to the previous byte
     buffer: std.ArrayList(u8),
 
-    pub fn init(allocator: std.mem.Allocator) Store {
+    pub fn init(gpa: std.mem.Allocator) Store {
         return Store{
-            .buffer = std.ArrayList(u8).init(allocator),
+            .buffer = std.ArrayList(u8).init(gpa),
         };
     }
 

--- a/src/build/solve_functions.zig
+++ b/src/build/solve_functions.zig
@@ -48,10 +48,9 @@ test "solves for uncaptured functions" {
     // It will then run `solveFunctions` on that IR and assert that the
     // resulting FunctionSet.List correctly labels each function
 
-    var arena = std.heap.ArenaAllocator.init(testing.allocator);
-    defer arena.deinit();
-
-    _ = base.Ident.Store.init(&arena);
+    const gpa = testing.allocator;
+    var store = base.Ident.Store.init(gpa);
+    defer store.deinit();
 
     try testing.expect(true);
 }

--- a/src/check/canonicalize/IR.zig
+++ b/src/check/canonicalize/IR.zig
@@ -39,22 +39,38 @@ ingested_files: IngestedFile.List,
 ///
 /// Since the can IR holds indices into the `ModuleEnv`, we need
 /// the `ModuleEnv` to also be owned by the can IR to cache it.
-pub fn init(arena: *std.heap.ArenaAllocator) Self {
+pub fn init(gpa: std.mem.Allocator) Self {
     return Self{
-        .env = base.ModuleEnv.init(arena),
-        .aliases = Alias.List.init(arena.allocator()),
-        .defs = Def.List.init(arena.allocator()),
-        .exprs = Expr.List.init(arena.allocator()),
-        .exprs_at_regions = ExprAtRegion.List.init(arena.allocator()),
-        .typed_exprs_at_regions = TypedExprAtRegion.List.init(arena.allocator()),
-        .when_branches = WhenBranch.List.init(arena.allocator()),
-        .patterns = Pattern.List.init(arena.allocator()),
-        .patterns_at_regions = PatternAtRegion.List.init(arena.allocator()),
-        .typed_patterns_at_regions = TypedPatternAtRegion.List.init(arena.allocator()),
-        .type_vars = collections.SafeList(TypeVar).init(arena.allocator()),
-        // .type_var_names = Ident.Store.init(arena.allocator()),
-        .ingested_files = IngestedFile.List.init(arena.allocator()),
+        .env = base.ModuleEnv.init(gpa),
+        .aliases = Alias.List.init(gpa),
+        .defs = Def.List.init(gpa),
+        .exprs = Expr.List.init(gpa),
+        .exprs_at_regions = ExprAtRegion.List.init(gpa),
+        .typed_exprs_at_regions = TypedExprAtRegion.List.init(gpa),
+        .when_branches = WhenBranch.List.init(gpa),
+        .patterns = Pattern.List.init(gpa),
+        .patterns_at_regions = PatternAtRegion.List.init(gpa),
+        .typed_patterns_at_regions = TypedPatternAtRegion.List.init(gpa),
+        .type_vars = collections.SafeList(TypeVar).init(gpa),
+        // .type_var_names = Ident.Store.init(gpa),
+        .ingested_files = IngestedFile.List.init(gpa),
     };
+}
+
+pub fn deinit(self: *Self) void {
+    self.env.deinit();
+    self.aliases.deinit();
+    self.defs.deinit();
+    self.exprs.deinit();
+    self.exprs_at_regions.deinit();
+    self.typed_exprs_at_regions.deinit();
+    self.when_branches.deinit();
+    self.patterns.deinit();
+    self.patterns_at_regions.deinit();
+    self.typed_patterns_at_regions.deinit();
+    self.type_vars.deinit();
+    // self.type_var_names.deinit();
+    self.ingested_files.deinit();
 }
 
 pub const RigidVariables = struct {

--- a/src/check/canonicalize/Scope.zig
+++ b/src/check/canonicalize/Scope.zig
@@ -342,6 +342,7 @@ pub const Levels = struct {
 fn createTestScope(idents: [][]Level.IdentInScope, aliases: [][]Level.AliasInScope) Self {
     const gpa = std.testing.allocator;
     var env = base.ModuleEnv.init(gpa);
+    defer env.deinit();
 
     var scope = Self{
         .env = &env,

--- a/src/check/parse.zig
+++ b/src/check/parse.zig
@@ -101,10 +101,10 @@ test "example s-expr" {
         \\
         \\foo = "bar"
     ;
-    var arena = std.heap.ArenaAllocator.init(testing.allocator);
-    defer arena.deinit();
-    var env = base.ModuleEnv.init(&arena);
-    var parse_ir = parse(&env, testing.allocator, source);
+    const gpa = testing.allocator;
+    var env = base.ModuleEnv.init(gpa);
+    defer env.deinit();
+    var parse_ir = parse(&env, gpa, source);
     defer parse_ir.deinit();
 
     // std.debug.print("{}", .{parse_ir});

--- a/src/collections/SmallStringInterner.zig
+++ b/src/collections/SmallStringInterner.zig
@@ -11,77 +11,72 @@ const utils = @import("./utils.zig");
 const Region = @import("../base/Region.zig");
 
 const exitOnOom = utils.exitOnOom;
-const fnvStringHash = utils.fnvStringHash;
+
+// This uses an unmanaged hash map due to context management requirements.
+// It enables us to ensure that an update context is always used with the newest pointer to the underlying bytes allocation.
+const StringIndexMap = std.HashMapUnmanaged(u32, struct {}, StringIndexContext, std.hash_map.default_max_load_percentage);
 
 const Self = @This();
 
-/// A deduplicated list of strings
-strings: std.ArrayList([]u8),
-/// All string indices that have the given hash
-string_indices_per_hash: std.AutoHashMap(u32, std.ArrayList(u32)),
-/// All outer indices that have the given string index
-outer_ids_per_string_index: std.AutoHashMap(u32, std.ArrayList(Idx)),
-/// A unique ID for every string, which may or may not correspond
-/// to the same underlying string
-outer_indices: std.ArrayList(u32),
-regions: std.ArrayList(Region),
-arena: *std.heap.ArenaAllocator,
+/// The raw underlying bytes for all strings.
+/// Since strings are small, they are simply null terminated.
+/// This uses only 1 byte to encode the size and is cheap to scan.
+bytes: std.ArrayListUnmanaged(u8),
+/// A deduplicated set of strings indicies referencing into bytes.
+/// The key is the offset into bytes.
+strings: StringIndexMap,
+/// A unique ID for every string. This is fundamentally an index into bytes.
+/// It also maps 1:1 with a region at the same index.
+outer_indices: std.ArrayListUnmanaged(u32),
+regions: std.ArrayListUnmanaged(Region),
+gpa: std.mem.Allocator,
 
 /// A unique index for a deduped string in this interner.
 pub const Idx = enum(u32) { _ };
 
-pub fn init(arena: *std.heap.ArenaAllocator) Self {
+pub fn init(gpa: std.mem.Allocator) Self {
     return Self{
-        .strings = std.ArrayList([]u8).init(arena.allocator()),
-        .string_indices_per_hash = std.AutoHashMap(u32, std.ArrayList(u32)).init(arena.allocator()),
-        .outer_ids_per_string_index = std.AutoHashMap(u32, std.ArrayList(Idx)).init(arena.allocator()),
-        .outer_indices = std.ArrayList(u32).init(arena.allocator()),
-        .regions = std.ArrayList(Region).init(arena.allocator()),
-        .arena = arena,
+        .bytes = .{},
+        .strings = .{},
+        .outer_indices = .{},
+        .regions = .{},
+        .gpa = gpa,
     };
+}
+
+/// Free all memory consumed by this interner.
+/// Will invalidate all slices referencing the interner.
+pub fn deinit(self: *Self) void {
+    self.bytes.deinit(self.gpa);
+    self.strings.deinit(self.gpa);
+    self.outer_indices.deinit(self.gpa);
+    self.regions.deinit(self.gpa);
 }
 
 /// Add a string to this interner, returning a unique, serial index.
 pub fn insert(self: *Self, string: []const u8, region: Region) Idx {
-    const hash = fnvStringHash(string);
+    const entry = self.strings.getOrPutContextAdapted(
+        self.gpa,
+        string,
+        StringIndexAdapter{ .bytes = &self.bytes },
+        StringIndexContext{ .bytes = &self.bytes },
+    ) catch exitOnOom();
+    if (entry.found_existing) return self.addOuterIdForStringIndex(entry.key_ptr.*, region);
 
-    const string_indices = self.stringIndicesForHash(hash);
-    for (string_indices.items) |string_index| {
-        const interned = self.strings.items[string_index];
-        if (std.mem.eql(u8, string, interned)) {
-            return self.addOuterIdForStringIndex(string_index, region);
-        }
-    }
+    self.bytes.ensureUnusedCapacity(self.gpa, string.len + 1) catch exitOnOom();
+    const string_offset: u32 = @intCast(self.bytes.items.len);
 
-    const copied_string = self.arena.allocator().alloc(u8, string.len) catch exitOnOom();
-    std.mem.copyForwards(u8, copied_string, string);
+    self.bytes.appendSliceAssumeCapacity(string);
+    self.bytes.appendAssumeCapacity(0);
 
-    const strings_len: u32 = @truncate(self.strings.items.len);
-    self.strings.append(copied_string) catch exitOnOom();
-
-    return self.addOuterIdForStringIndex(strings_len, region);
+    entry.key_ptr.* = string_offset;
+    return self.addOuterIdForStringIndex(string_offset, region);
 }
 
-fn stringIndicesForHash(self: *Self, hash: u32) *std.ArrayList(u32) {
-    const res = self.string_indices_per_hash.getOrPut(hash) catch exitOnOom();
-    if (!res.found_existing) {
-        res.value_ptr.* = std.ArrayList(u32).init(self.arena.allocator());
-    }
-
-    return res.value_ptr;
-}
-
-fn addOuterIdForStringIndex(self: *Self, string_index: u32, region: Region) Idx {
+fn addOuterIdForStringIndex(self: *Self, string_offset: u32, region: Region) Idx {
     const len: Idx = @enumFromInt(@as(u32, @truncate(self.outer_indices.items.len)));
-    self.outer_indices.append(string_index) catch exitOnOom();
-    self.regions.append(region) catch exitOnOom();
-
-    const res = self.outer_ids_per_string_index.getOrPut(string_index) catch exitOnOom();
-    if (!res.found_existing) {
-        res.value_ptr.* = std.ArrayList(Idx).init(self.arena.allocator());
-    }
-
-    res.value_ptr.append(len) catch exitOnOom();
+    self.outer_indices.append(self.gpa, string_offset) catch exitOnOom();
+    self.regions.append(self.gpa, region) catch exitOnOom();
 
     return len;
 }
@@ -98,30 +93,42 @@ pub fn indicesHaveSameText(
     return first_string_index == second_string_index;
 }
 
-/// Return a slice of all indices of strings interned with the given text.
-pub fn lookup(self: *Self, string: []u8) []Idx {
-    const hash = fnvStringHash(string);
-    const indices_for_hash = if (self.string_indices_per_hash.get(hash)) |list|
-        list.items
-    else
-        return &.{};
-
-    for (indices_for_hash) |string_index| {
-        if (std.mem.eql(u8, self.strings.items[string_index], string)) {
-            return self.outer_ids_per_string_index.get(string_index).?.items;
-        }
-    }
-
-    return &.{};
-}
-
 /// Get a reference to the text for an interned string.
 pub fn getText(self: *Self, idx: Idx) []u8 {
     const string_index = self.outer_indices.items[@as(usize, @intFromEnum(idx))];
-    return self.strings.items[@as(usize, string_index)];
+
+    return std.mem.sliceTo(self.bytes.items[string_index..], 0);
 }
 
 /// Get the region for an interned string.
 pub fn getRegion(self: *Self, idx: Idx) Region {
     return self.regions.items[@as(usize, @intFromEnum(idx))];
 }
+
+/// These are copied straight out of the zig standard library.
+/// They are simply modified to use fnv hash instead of wyhash.
+/// TODO: Revaluate hash function choice.
+const StringIndexContext = struct {
+    bytes: *const std.ArrayListUnmanaged(u8),
+
+    pub fn eql(_: @This(), a: u32, b: u32) bool {
+        return a == b;
+    }
+
+    pub fn hash(ctx: @This(), key: u32) u64 {
+        return std.hash.Fnv1a_64.hash(std.mem.sliceTo(ctx.bytes.items[key..], 0));
+    }
+};
+
+const StringIndexAdapter = struct {
+    bytes: *const std.ArrayListUnmanaged(u8),
+
+    pub fn eql(ctx: @This(), a: []const u8, b: u32) bool {
+        return std.mem.eql(u8, a, std.mem.sliceTo(ctx.bytes.items[b..], 0));
+    }
+
+    pub fn hash(_: @This(), adapted_key: []const u8) u64 {
+        std.debug.assert(std.mem.indexOfScalar(u8, adapted_key, 0) == null);
+        return std.hash.Fnv1a_64.hash(adapted_key);
+    }
+};

--- a/src/collections/SmallStringInterner.zig
+++ b/src/collections/SmallStringInterner.zig
@@ -87,17 +87,17 @@ pub fn indicesHaveSameText(
     first_idx: Idx,
     second_idx: Idx,
 ) bool {
-    const first_string_index = self.outer_indices.items[@as(usize, @intFromEnum(first_idx))];
-    const second_string_index = self.outer_indices.items[@as(usize, @intFromEnum(second_idx))];
+    const first_string_offset = self.outer_indices.items[@as(usize, @intFromEnum(first_idx))];
+    const second_string_offset = self.outer_indices.items[@as(usize, @intFromEnum(second_idx))];
 
-    return first_string_index == second_string_index;
+    return first_string_offset == second_string_offset;
 }
 
 /// Get a reference to the text for an interned string.
 pub fn getText(self: *Self, idx: Idx) []u8 {
-    const string_index = self.outer_indices.items[@as(usize, @intFromEnum(idx))];
+    const string_offset = self.outer_indices.items[@as(usize, @intFromEnum(idx))];
 
-    return std.mem.sliceTo(self.bytes.items[string_index..], 0);
+    return std.mem.sliceTo(self.bytes.items[string_offset..], 0);
 }
 
 /// Get the region for an interned string.

--- a/src/collections/utils.zig
+++ b/src/collections/utils.zig
@@ -1,29 +1,6 @@
 const std = @import("std");
 const testing = std.testing;
 
-/// A simple, linear-time string hash.
-///
-/// http://isthe.com/chongo/tech/comp/fnv/#FNV-1a
-pub fn fnvStringHash(string: []const u8) u32 {
-    const fnv_prime_32_bit: u32 = 16777619;
-    const offset_basis_32_bit: u32 = 2166136261;
-
-    var hash = offset_basis_32_bit;
-
-    for (string) |byte| {
-        hash ^= byte;
-        hash *%= fnv_prime_32_bit;
-    }
-
-    return hash;
-}
-
-test "fnv1a hashes correctly" {
-    try testing.expect(fnvStringHash("") == 0x811c9dc5);
-    try testing.expect(fnvStringHash("a") == 0xe40c292c);
-    try testing.expect(fnvStringHash("foobar") == 0xbf9cf968);
-}
-
 /// Exit the current process when we hit an out-of-memory error.
 ///
 /// Since there's nothing we can do to recover from such an issue,

--- a/src/fmt.zig
+++ b/src/fmt.zig
@@ -558,10 +558,10 @@ fn pushTokenText(fmt: *Formatter, ti: TokenIdx) void {
 fn moduleFmtsSame(source: []const u8) !void {
     const parse = @import("check/parse.zig").parse;
 
-    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
-    defer arena.deinit();
+    const gpa = std.testing.allocator;
 
-    var env = base.ModuleEnv.init(&arena);
+    var env = base.ModuleEnv.init(gpa);
+    defer env.deinit();
 
     var parse_ast = parse(&env, std.testing.allocator, source);
     defer parse_ast.deinit();
@@ -581,9 +581,9 @@ fn moduleFmtsSame(source: []const u8) !void {
 
 fn moduleFmtsTo(source: []const u8, to: []const u8) !void {
     const parse = @import("check/parse.zig").parse;
-    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
-    defer arena.deinit();
-    var env = base.ModuleEnv.init(&arena);
+    const gpa = std.testing.allocator;
+    var env = base.ModuleEnv.init(gpa);
+    defer env.deinit();
     var parse_ast = parse(&env, std.testing.allocator, source);
     defer parse_ast.deinit();
     defer std.testing.allocator.free(parse_ast.errors);


### PR DESCRIPTION
This PR ended up mixing two things kinda unintentionally.

Firstly, it improves the small string interner.
The interner uses an unmanaged hash map with context to store deduplicated strings. Since the strings are all meant to be small, instead of storing lengths, it just null terminates the strings. Also, removed some extra mappins that are not needed to be in the small string interner. It only deals with storing unique small strings and giving them an index

As part of the above update, I changed the interner to use a general purpose allocator instead of an arena.

That change led to a much larger change of following the error trailing and updating many things from an arena to a general purpose allocator. In general, roc will actually use very few arenas in the default path. Arenas are only for allocations that never grow in size. Since roc is storing everything very densely, almost everything is in some form of an arraylist. These all regularly grow in size and are not good for arena use.