### PR TITLE
Initial snapshot testing tool

### DIFF
--- a/src/snapshot.zig
+++ b/src/snapshot.zig
@@ -1,0 +1,159 @@
+const std = @import("std");
+const base = @import("base.zig");
+const parse = @import("check/parse.zig");
+
+var verbose_log: bool = false;
+
+fn log(comptime fmt: []const u8, args: anytype) void {
+    if (verbose_log) {
+        std.log.info(fmt, args);
+    }
+}
+
+pub fn main() !void {
+    var gpa_impl = std.heap.GeneralPurposeAllocator(.{}){};
+    defer {
+        _ = gpa_impl.deinit();
+    }
+    const gpa = gpa_impl.allocator();
+
+    const args = try std.process.argsAlloc(gpa);
+    defer std.process.argsFree(gpa, args);
+
+    // Check for verbose flag
+    var target_snapshot: ?[]const u8 = null;
+
+    for (args[1..]) |arg| {
+        if (std.mem.eql(u8, arg, "--verbose")) {
+            verbose_log = true;
+        } else if (target_snapshot == null) {
+            target_snapshot = arg;
+        }
+    }
+
+    const snapshots_dir = "src/snapshots";
+    var file_count: usize = 0;
+    var timer = std.time.Timer.start() catch unreachable;
+
+    if (target_snapshot != null) {
+        // Only for the specified snapshot file
+        try processSnapshotFile(target_snapshot.?, gpa);
+        file_count += 1;
+    } else {
+        // For each of the files in the directory
+        var dir = try std.fs.cwd().openDir(snapshots_dir, .{ .iterate = true });
+        defer dir.close();
+
+        var dir_iterator = dir.iterate();
+        while (try dir_iterator.next()) |entry| {
+            if (entry.kind != .file) continue;
+            if (!std.mem.endsWith(u8, entry.name, ".txt")) continue;
+
+            const full_path = try std.fmt.allocPrint(gpa, "{s}/{s}", .{ snapshots_dir, entry.name });
+            defer gpa.free(full_path);
+
+            try processSnapshotFile(full_path, gpa);
+
+            file_count += 1;
+        }
+    }
+
+    const duration_ms = timer.read() / std.time.ns_per_ms;
+
+    // Print a summary
+    std.log.info("processed {d} snapshots in {d}ms.", .{ file_count, duration_ms });
+}
+
+/// Represents the different sections of a snapshot file.
+const Section = enum {
+    None,
+    Meta,
+    Source,
+    Parse,
+};
+
+/// Stores the contents for a snapshot to be written to file
+const SnapshotContents = struct {
+    meta: std.ArrayList(u8),
+    source: std.ArrayList(u8),
+    parse: std.ArrayList(u8),
+
+    fn init(allocator: std.mem.Allocator) SnapshotContents {
+        return .{
+            .meta = std.ArrayList(u8).init(allocator),
+            .source = std.ArrayList(u8).init(allocator),
+            .parse = std.ArrayList(u8).init(allocator),
+        };
+    }
+
+    fn deinit(self: *SnapshotContents) void {
+        self.meta.deinit();
+        self.source.deinit();
+        self.parse.deinit();
+    }
+};
+
+fn processSnapshotFile(snapshot_path: []const u8, allocator: std.mem.Allocator) !void {
+    var contents = SnapshotContents.init(allocator);
+    defer contents.deinit();
+
+    // Parse the file contents
+    {
+        // Read the file
+        const file_content = try std.fs.cwd().readFileAlloc(allocator, snapshot_path, 1024 * 1024);
+        defer allocator.free(file_content);
+
+        var current_section = Section.None;
+        var lines = std.mem.tokenizeScalar(u8, file_content, '\n');
+        while (lines.next()) |line| {
+            if (std.mem.eql(u8, line, "~~~META")) {
+                current_section = Section.Meta;
+                continue;
+            } else if (std.mem.eql(u8, line, "~~~SOURCE")) {
+                current_section = Section.Source;
+                continue;
+            } else if (std.mem.eql(u8, line, "~~~PARSE")) {
+                current_section = Section.Parse;
+                continue;
+            }
+
+            switch (current_section) {
+                .Meta => try contents.meta.writer().print("{s}\n", .{line}),
+                .Source => try contents.source.writer().print("{s}\n", .{line}),
+                .Parse => {}, // We'll regenerate this section, so we don't need to save it
+                .None => {},
+            }
+        }
+    }
+
+    // Generate the PARSE section
+    {
+        var env = base.ModuleEnv.init(allocator);
+        defer env.deinit();
+
+        var parse_ast = parse.parse(&env, allocator, contents.source.items);
+        defer parse_ast.deinit();
+
+        // shouldn't be required in future
+        parse_ast.store.emptyScratch();
+
+        // Clear the parse contents to ensure we start fresh
+        contents.parse.clearRetainingCapacity();
+
+        // Write the new AST to the parse section
+        try parse_ast.toSExprStr(allocator, &env, contents.parse.writer().any());
+    }
+
+    // Rewrite the file with updated sections
+    var file = try std.fs.cwd().createFile(snapshot_path, .{});
+    defer file.close();
+
+    try file.writer().writeAll("~~~META\n");
+    try file.writer().writeAll(contents.meta.items);
+    try file.writer().writeAll("~~~SOURCE\n");
+    try file.writer().writeAll(contents.source.items);
+    try file.writer().writeAll("~~~PARSE\n");
+    try file.writer().writeAll(contents.parse.items);
+
+    log("{s}", .{snapshot_path});
+}

--- a/src/snapshot.zig
+++ b/src/snapshot.zig
@@ -1,14 +1,22 @@
 const std = @import("std");
+const testing = std.testing;
+const Allocator = std.mem.Allocator;
 const base = @import("base.zig");
 const parse = @import("check/parse.zig");
 const fmt = @import("fmt.zig");
 
 var verbose_log: bool = false;
 
+/// Logs a message if verbose logging is enabled.
 fn log(comptime fmt_str: []const u8, args: anytype) void {
     if (verbose_log) {
         std.log.info(fmt_str, args);
     }
+}
+
+/// Always logs a warning message.
+fn warn(comptime fmt_str: []const u8, args: anytype) void {
+    std.log.warn(fmt_str, args);
 }
 
 pub fn main() !void {
@@ -47,16 +55,22 @@ pub fn main() !void {
 
     const duration_ms = timer.read() / std.time.ns_per_ms;
 
-    std.log.info("processed {d} snapshots in {d}ms.", .{ file_count, duration_ms });
+    std.log.info("processed {d} snapshots in {d} ms.", .{ file_count, duration_ms });
 }
 
-fn processPath(path: []const u8, gpa: std.mem.Allocator) !usize {
+fn processPath(path: []const u8, gpa: Allocator) !usize {
     var processed_count: usize = 0;
 
-    const canonical_path = try std.fs.cwd().realpathAlloc(gpa, path);
+    const canonical_path = std.fs.cwd().realpathAlloc(gpa, path) catch |err| {
+        log("failed to resolve path '{s}': {s}", .{ path, @errorName(err) });
+        return 0;
+    };
     defer gpa.free(canonical_path);
 
-    const stat = try std.fs.cwd().statFile(canonical_path);
+    const stat = std.fs.cwd().statFile(canonical_path) catch |err| {
+        log("failed to stat path '{s}': {s}", .{ canonical_path, @errorName(err) });
+        return 0;
+    };
 
     if (stat.kind == .directory) {
         var dir = try std.fs.cwd().openDir(path, .{ .iterate = true });
@@ -64,27 +78,26 @@ fn processPath(path: []const u8, gpa: std.mem.Allocator) !usize {
 
         var dir_iterator = dir.iterate();
         while (try dir_iterator.next()) |entry| {
-            const full_path = try std.fmt.allocPrint(gpa, "{s}/{s}", .{ path, entry.name });
+
+            // Skip hidden files and special directories
+            if (entry.name[0] == '.') continue;
+
+            const full_path = try std.fs.path.join(gpa, &[_][]const u8{ canonical_path, entry.name });
             defer gpa.free(full_path);
 
             if (entry.kind == .directory) {
                 processed_count += try processPath(full_path, gpa);
-            } else if (entry.kind == .file) {
-                processed_count += try processPath(full_path, gpa);
+            } else if (entry.kind == .file and std.mem.endsWith(u8, entry.name, ".txt")) {
+                if (try processSnapshotFile(full_path, gpa)) {
+                    processed_count += 1;
+                }
             }
         }
     } else if (stat.kind == .file) {
-        if (std.mem.endsWith(u8, path, ".txt")) {
-            processSnapshotFile(path, gpa) catch |err| {
-                switch (err) {
-                    Error.MissingSnapshotHeader, Error.MissingSnapshotSource => {
-                        // Ignore non-snapshot files
-                        log("ignoring non-snapshot file {s}", .{path});
-                    },
-                    else => return err,
-                }
-            };
-            processed_count += 1;
+        if (std.mem.endsWith(u8, canonical_path, ".txt")) {
+            if (try processSnapshotFile(canonical_path, gpa)) {
+                processed_count += 1;
+            }
         }
     }
 
@@ -92,17 +105,65 @@ fn processPath(path: []const u8, gpa: std.mem.Allocator) !usize {
 }
 
 /// Represents the different sections of a snapshot file.
-const Section = enum {
-    None,
-    Meta,
-    Source,
-    Formatted,
-    Parse,
+const Section = union(enum) {
+    meta,
+    source,
+    formatted,
+    parse,
 
-    const META = "~~~META";
-    const SOURCE = "~~~SOURCE";
-    const FORMATTED = "~~~FORMATTED";
-    const PARSE = "~~~PARSE";
+    pub const META = "~~~META";
+    pub const SOURCE = "~~~SOURCE";
+    pub const FORMATTED = "~~~FORMATTED";
+    pub const PARSE = "~~~PARSE";
+
+    fn next(self: Section) ?Section {
+        return switch (self) {
+            .meta => .source,
+            .source => .formatted,
+            .formatted => .parse,
+            .parse => null,
+        };
+    }
+
+    fn fromString(str: []const u8) ?Section {
+        if (std.mem.eql(u8, str, META)) return .meta;
+        if (std.mem.eql(u8, str, SOURCE)) return .source;
+        if (std.mem.eql(u8, str, FORMATTED)) return .formatted;
+        if (std.mem.eql(u8, str, PARSE)) return .parse;
+        return null;
+    }
+
+    fn asString(self: Section) []const u8 {
+        return switch (self) {
+            .meta => META,
+            .source => SOURCE,
+            .formatted => FORMATTED,
+            .parse => PARSE,
+            .None => "",
+        };
+    }
+
+    /// Captures the start and end positions of a section within the file content
+    const Range = struct {
+        start: ?usize,
+        end: ?usize,
+
+        fn empty() Range {
+            return .{
+                .start = null,
+                .end = null,
+            };
+        }
+
+        fn isComplete(self: Range) bool {
+            return self.start != null and self.end != null;
+        }
+
+        fn extract(self: Range, content: []const u8) ?[]const u8 {
+            if (!self.isComplete()) return null;
+            return std.mem.trimRight(u8, content[self.start.?..self.end.?], "\n");
+        }
+    };
 };
 
 /// Content of a snapshot file, references the Metadata and Source sections etc
@@ -122,6 +183,55 @@ const Content = struct {
     fn has_formatted_section(self: Content) bool {
         return self.formatted != null;
     }
+
+    fn from_ranges(ranges: std.AutoHashMap(Section, Section.Range), content: []const u8) Error!Content {
+        var meta: []const u8 = undefined;
+        var source: []const u8 = undefined;
+        var formatted: ?[]const u8 = undefined;
+
+        if (ranges.get(.meta)) |value| {
+            if (value.extract(content)) |src| {
+                meta = src;
+            } else {
+                return Error.MissingSnapshotHeader;
+            }
+        } else {
+            return Error.MissingSnapshotHeader;
+        }
+
+        if (ranges.get(.source)) |value| {
+            if (value.extract(content)) |src| {
+                source = src;
+            } else {
+                return Error.MissingSnapshotSource;
+            }
+        } else {
+            return Error.MissingSnapshotSource;
+        }
+
+        if (ranges.get(.formatted)) |value| {
+            formatted = value.extract(content);
+        } else {
+            formatted = null;
+        }
+
+        return Content.init(
+            meta,
+            source,
+            formatted,
+        );
+    }
+    pub fn format(self: Content, comptime fmt_str: []const u8, _: std.fmt.FormatOptions, writer: std.io.AnyWriter) !void {
+        _ = fmt_str;
+        try writer.print("SNAPSHOT CONTENTS\n", .{});
+        try writer.print("META:\n{s}\n---\n", .{self.meta});
+        try writer.print("SOURCE:\n{s}\n---\n", .{self.source});
+        if (self.formatted) |formatted| {
+            try writer.print("FORMATTED:\n{s}\n---\n", .{formatted});
+        } else {
+            try writer.print("FORMATTED: null\n", .{});
+        }
+    }
 };
 
 const Error = error{
@@ -129,18 +239,32 @@ const Error = error{
     MissingSnapshotSource,
 };
 
-fn processSnapshotFile(snapshot_path: []const u8, gpa: std.mem.Allocator) !void {
-    const file_content = try std.fs.cwd().readFileAlloc(gpa, snapshot_path, 1024 * 1024);
+fn processSnapshotFile(snapshot_path: []const u8, gpa: Allocator) !bool {
+    const file_content = std.fs.cwd().readFileAlloc(gpa, snapshot_path, 1024 * 1024) catch |err| {
+        log("failed to read file '{s}': {s}", .{ snapshot_path, @errorName(err) });
+        return false;
+    };
     defer gpa.free(file_content);
 
     // Check our file starts with the metadata section
     // so we can skip parsing and later steps if this isn't a snapshot file
     if (!std.mem.startsWith(u8, file_content, Section.META)) {
-        return Error.MissingSnapshotHeader;
+        log("ignoring non-snapshot file {s}", .{snapshot_path});
+        return false;
     }
 
     // Parse the file to find section boundaries
-    const content = try extractSections(file_content);
+    const content = extractSections(gpa, file_content) catch |err| {
+        switch (err) {
+            Error.MissingSnapshotHeader, Error.MissingSnapshotSource => {
+                warn("ignoring file {s}: {s}", .{ snapshot_path, @errorName(err) });
+                return false;
+            },
+            else => return err,
+        }
+    };
+
+    // std.debug.print("FILE: {s}\n{}\n", .{ snapshot_path, content });
 
     // Generate the PARSE section
     var parse_buffer = std.ArrayList(u8).init(gpa);
@@ -166,7 +290,10 @@ fn processSnapshotFile(snapshot_path: []const u8, gpa: std.mem.Allocator) !void 
     try parse_ast.toSExprStr(gpa, &module_env, parse_buffer.writer().any());
 
     // Rewrite the file with updated sections
-    var file = try std.fs.cwd().createFile(snapshot_path, .{});
+    var file = std.fs.cwd().createFile(snapshot_path, .{}) catch |err| {
+        log("failed to create file '{s}': {s}", .{ snapshot_path, @errorName(err) });
+        return false;
+    };
     defer file.close();
 
     try file.writer().writeAll(Section.META);
@@ -198,54 +325,118 @@ fn processSnapshotFile(snapshot_path: []const u8, gpa: std.mem.Allocator) !void 
     try file.writer().writeAll(parse_buffer.items);
 
     log("{s}", .{snapshot_path});
+
+    return true;
 }
 
-fn extractSections(content: []const u8) !Content {
-    var meta_start: ?usize = null;
-    var meta_end: ?usize = null;
-    var source_start: ?usize = null;
-    var source_end: ?usize = null;
-    var formatted_start: ?usize = null;
-    var formatted_end: ?usize = null;
+/// Extracts the sections from a snapshot file
+fn extractSections(gpa: Allocator, content: []const u8) !Content {
+    var ranges = std.AutoHashMap(Section, Section.Range).init(gpa);
+    defer ranges.deinit();
 
-    var lines = std.mem.tokenizeScalar(u8, content, '\n');
-    var current_pos: usize = 0;
+    var current_section: ?Section = null;
+    var line_start: usize = 0;
 
-    while (lines.next()) |line| {
-        const line_with_newline = line.len + 1;
+    var lines = std.mem.splitScalar(u8, content, '\n');
 
-        if (std.mem.eql(u8, line, Section.META)) {
-            meta_start = current_pos + line_with_newline;
-        } else if (std.mem.eql(u8, line, Section.SOURCE)) {
-            if (meta_start != null) meta_end = current_pos;
-            source_start = current_pos + line_with_newline;
-        } else if (std.mem.eql(u8, line, Section.FORMATTED)) {
-            if (source_start != null) source_end = current_pos;
-            formatted_start = current_pos + line_with_newline;
-        } else if (std.mem.eql(u8, line, Section.PARSE)) {
-            if (formatted_start != null) {
-                formatted_end = current_pos;
-            } else if (source_start != null) {
-                source_end = current_pos;
+    while (true) {
+        const line_opt = lines.next();
+        if (line_opt == null) break;
+
+        const line = line_opt.?;
+        const line_end = line_start + line.len;
+        const next_line_start = line_end + 1; // +1 for the newline
+
+        if (Section.fromString(line)) |new_section| {
+            // If we were in a section, finalize its range
+            if (current_section) |section| {
+                var range = ranges.get(section) orelse Section.Range.empty();
+                range.end = line_start;
+                try ranges.put(section, range);
             }
-            break;
+
+            // Start the new section
+            current_section = new_section;
+
+            // Initialize new section range (starting after this line)
+            var range = Section.Range.empty();
+            range.start = next_line_start;
+            try ranges.put(new_section, range);
         }
 
-        current_pos += line_with_newline;
+        line_start = next_line_start;
     }
 
-    const missing_header = (meta_start == null) or (meta_end == null);
-    const missing_source = (source_start == null) or (source_end == null);
-    if (missing_header) {
-        return Error.MissingSnapshotHeader;
-    } else if (missing_source) {
-        return Error.MissingSnapshotSource;
+    // Handle the last section if there is one
+    if (current_section) |section| {
+        var range = ranges.get(section) orelse Section.Range.empty();
+        range.end = line_start;
+        try ranges.put(section, range);
     }
 
-    var formatted: ?[]const u8 = null;
-    if (formatted_start != null and formatted_end != null) {
-        formatted = content[formatted_start.?..formatted_end.?];
-    }
+    return try Content.from_ranges(ranges, content);
+}
 
-    return Content.init(content[meta_start.?..meta_end.?], content[source_start.?..source_end.?], formatted);
+test "extractSections" {
+    const input =
+        \\~~~META
+        \\meta data line
+        \\~~~SOURCE
+        \\source code line
+        \\~~~FORMATTED
+        \\formatted output line
+        \\~~~PARSE
+        \\parse section line
+    ;
+
+    const content = try extractSections(testing.allocator, input);
+
+    try testing.expectEqualStrings("meta data line", content.meta);
+    try testing.expectEqualStrings("source code line", content.source);
+    try testing.expectEqualStrings("formatted output line", content.formatted.?);
+}
+
+test "extractSections complex" {
+    const input =
+        \\~~~META
+        \\description=Basic example to develop the snapshot methodology
+        \\~~~SOURCE
+        \\module [foo, bar]
+        \\
+        \\foo = "one"
+        \\
+        \\bar = "two"
+        \\~~~PARSE
+        \\(file
+        \\    (header
+        \\        'foo'
+        \\        'bar')
+        \\    (decl
+        \\        (ident
+        \\            'foo')
+        \\        (string_part))
+        \\    (decl
+        \\        (ident
+        \\            'bar')
+        \\        (string_part)))
+    ;
+
+    const expected_meta =
+        \\description=Basic example to develop the snapshot methodology
+    ;
+
+    const expected_source =
+        \\module [foo, bar]
+        \\
+        \\foo = "one"
+        \\
+        \\bar = "two"
+    ;
+
+    const expected_formatted = null;
+    const content = try extractSections(testing.allocator, input);
+
+    try testing.expectEqualStrings(expected_meta, content.meta);
+    try testing.expectEqualStrings(expected_source, content.source);
+    try testing.expectEqual(expected_formatted, content.formatted);
 }

--- a/src/snapshots/001.txt
+++ b/src/snapshots/001.txt
@@ -1,14 +1,19 @@
 ~~~META
-description=Basic example to develop the snapshot methodology
+description=Example to develop the snapshot methodology, includes FORMATTED section
 ~~~SOURCE
-module     [    foo           ]
+module     [
+# some crazy formatting
+ foo,
+     ]
 
 foo =
 
-    "one"~~~FORMATTED
+    "one"
+~~~FORMATTED
 module [foo]
 
-foo = "one"~~~PARSE
+foo = "one"
+~~~PARSE
 (file
     (header
         'foo')

--- a/src/snapshots/001.txt
+++ b/src/snapshots/001.txt
@@ -1,9 +1,14 @@
 ~~~META
 description=Basic example to develop the snapshot methodology
 ~~~SOURCE
+module     [    foo           ]
+
+foo =
+
+    "one"~~~FORMATTED
 module [foo]
-foo = "one"
-~~~PARSE
+
+foo = "one"~~~PARSE
 (file
     (header
         'foo')

--- a/src/snapshots/001.txt
+++ b/src/snapshots/001.txt
@@ -1,0 +1,13 @@
+~~~META
+description=Basic example to develop the snapshot methodology
+~~~SOURCE
+module [foo]
+foo = "one"
+~~~PARSE
+(file
+    (header
+        'foo')
+    (decl
+        (ident
+            'foo')
+        (string_part)))

--- a/src/snapshots/002.txt
+++ b/src/snapshots/002.txt
@@ -1,0 +1,19 @@
+~~~META
+description=Basic example to develop the snapshot methodology
+~~~SOURCE
+module [foo, bar]
+foo = "one"
+bar = "two"
+~~~PARSE
+(file
+    (header
+        'foo'
+        'bar')
+    (decl
+        (ident
+            'foo')
+        (string_part))
+    (decl
+        (ident
+            'bar')
+        (string_part)))

--- a/src/snapshots/002.txt
+++ b/src/snapshots/002.txt
@@ -2,9 +2,10 @@
 description=Basic example to develop the snapshot methodology
 ~~~SOURCE
 module [foo, bar]
+
 foo = "one"
-bar = "two"
-~~~PARSE
+
+bar = "two"~~~PARSE
 (file
     (header
         'foo'

--- a/src/snapshots/some_folder/002.txt
+++ b/src/snapshots/some_folder/002.txt
@@ -5,7 +5,8 @@ module [foo, bar]
 
 foo = "one"
 
-bar = "two"~~~PARSE
+bar = "two"
+~~~PARSE
 (file
     (header
         'foo'

--- a/src/test.zig
+++ b/src/test.zig
@@ -7,6 +7,7 @@ test {
     testing.refAllDeclsRecursive(@import("main.zig"));
     testing.refAllDeclsRecursive(@import("problem.zig"));
     testing.refAllDeclsRecursive(@import("types.zig"));
+    testing.refAllDeclsRecursive(@import("snapshot.zig"));
     testing.refAllDeclsRecursive(@import("types/type.zig"));
     testing.refAllDeclsRecursive(@import("types/num.zig"));
     testing.refAllDeclsRecursive(@import("collections.zig"));


### PR DESCRIPTION
Adds a snapshot tool that iterates through all the snapshot text files in `src/snapshots/*.txt` and re-generates the AST/IR's for each compiler stage.

```
$ zig build snapshot
info: processed 2 snapshots in 1ms.
$ zig build snapshot -- --verbose
info: src/snapshots/002.txt
info: src/snapshots/001.txt
info: processed 2 snapshots in 2ms.
```

Here is an example of a snapshot file.

```
~~~META
description=Basic example to develop the snapshot methodology
~~~SOURCE
module [foo, bar]
foo = "one"
bar = "two"
~~~PARSE
(file
    (header
        'foo'
        'bar')
    (decl
        (ident
            'foo')
        (string_part))
    (decl
        (ident
            'bar')
        (string_part)))
```