### PR TITLE
allow using system installed AFLPlusPlus

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -93,6 +93,9 @@ pub fn build(b: *std.Build) void {
             std.log.warn("Cross compilation does not support fuzzing (Only building repro executables)", .{});
         } else if (is_windows) {
             std.log.warn("Windows does not support fuzzing (Only building repro executables)", .{});
+        } else if (use_system_afl) {
+            // If we have system afl, no need for llvm-config.
+            build_afl = true;
         } else {
             // AFL++ does not work with our prebuilt static llvm.
             // Check for llvm-config program in user_llvm_path or on the system.
@@ -168,7 +171,7 @@ fn add_fuzz_target(
     check_repro.root_module.addImport("fuzz_test", &fuzz_obj.root_module);
     check_step.dependOn(&check_repro.step);
 
-    if (build_afl or use_system_afl) {
+    if (build_afl) {
         const afl = b.lazyImport(@This(), "zig-afl-kit") orelse return;
         const fuzz_exe = afl.addInstrumentedExe(b, target, .ReleaseSafe, &.{}, use_system_afl, fuzz_obj) orelse return;
         fuzz_step.dependOn(&b.addInstallBinFile(fuzz_exe, name_exe).step);

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -4,8 +4,8 @@
     .minimum_zig_version = "0.13.0",
     .dependencies = .{
         .@"zig-afl-kit" = .{
-            .url = "git+https://github.com/kristoff-it/zig-afl-kit#21d80a52213a469c6921e4ff890d4b0129c9aeb0",
-            .hash = "1220ca5642b07f784121cd268e2b57eb5d103b24f217cedf5b1dfe8fd4ecda079139",
+            .url = "git+https://github.com/bhansconnect/zig-afl-kit#1e396e1358264acbcf2c8aa58ceb554a30f82e66",
+            .hash = "122065a5f839ca9174542c621a0311695b49db71b58b50b232891571902775405642",
             .lazy = true,
         },
         .@"roc-deps-aarch64-macos-none" = .{


### PR DESCRIPTION
This enables fuzzing on linux. Users need to manually install `afl++`, but then they can use `-Dsystem-afl`.

Hopefully a proper fix to zig afl can happen at some point, but until then, this is good enough.