### PR TITLE
Update zig-afl-kit

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -4,8 +4,8 @@
     .minimum_zig_version = "0.13.0",
     .dependencies = .{
         .@"zig-afl-kit" = .{
-            .url = "git+https://github.com/bhansconnect/zig-afl-kit#571fb02f4ee7df1f7e4446da6b1578620e46b1c5",
-            .hash = "12207a58d73d9d7eeb582f7fe54902591653ca562d3cf56ad42520949e767449ea16",
+            .url = "git+https://github.com/bhansconnect/zig-afl-kit#88b881af0fb7f4cff2cd458caffb7848a7c46061",
+            .hash = "1220d7d042cf4bee6c713484f7c685b36ab892bf385f1f4be9623f56a68c68e730af",
             .lazy = true,
         },
         .@"roc-deps-aarch64-macos-none" = .{


### PR DESCRIPTION
Another try at this.
Apparently using `afl-clang-lto` isn't a full solution. Zig will follow symlinks leading to running `afl-cc`. Instead updated the library again.
This time it explicitly sets the afl `AFL_CC_COMPILER` to `LTO`.

----


Sorry for the try 2 here. That said, this version looks to be working fully correctly. The last version worked but ended up having low instrumentation.