### PR TITLE
Fix alloc arg order, save gpa in ModuleEnv, safer OOM handling

### DIFF
--- a/src/base.zig
+++ b/src/base.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const parse = @import("check/parse.zig");
 const module_work = @import("base/module_work.zig");
+pub const sexpr = @import("base/sexpr.zig");
 
 pub const Ident = @import("base/Ident.zig");
 pub const Region = @import("base/Region.zig");

--- a/src/base/Ident.zig
+++ b/src/base/Ident.zig
@@ -52,35 +52,26 @@ pub const Attributes = packed struct(u3) {
 
 /// An interner for identifier names.
 pub const Store = struct {
-    interner: SmallStringInterner,
+    interner: SmallStringInterner = .{},
     /// The index of the local module import that this ident comes from.
     ///
     /// By default, this is set to index 0, the primary module being compiled.
     /// This needs to be set when the ident is first seen during canonicalization
     /// before doing anything else.
-    exposing_modules: std.ArrayList(ModuleImport.Idx),
-    attributes: std.ArrayList(Attributes),
-    next_unique_name: u32,
+    exposing_modules: std.ArrayListUnmanaged(ModuleImport.Idx) = .{},
+    attributes: std.ArrayListUnmanaged(Attributes) = .{},
+    next_unique_name: u32 = 0,
 
-    pub fn init(gpa: std.mem.Allocator) Store {
-        return Store{
-            .interner = SmallStringInterner.init(gpa),
-            .exposing_modules = std.ArrayList(ModuleImport.Idx).init(gpa),
-            .attributes = std.ArrayList(Attributes).init(gpa),
-            .next_unique_name = 0,
-        };
+    pub fn deinit(self: *Store, gpa: std.mem.Allocator) void {
+        self.interner.deinit(gpa);
+        self.exposing_modules.deinit(gpa);
+        self.attributes.deinit(gpa);
     }
 
-    pub fn deinit(self: *Store) void {
-        self.interner.deinit();
-        self.exposing_modules.deinit();
-        self.attributes.deinit();
-    }
-
-    pub fn insert(self: *Store, ident: Ident, region: Region) Idx {
-        const idx = self.interner.insert(ident.raw_text, region);
-        self.exposing_modules.append(@enumFromInt(0)) catch exitOnOom();
-        self.attributes.append(ident.attributes) catch exitOnOom();
+    pub fn insert(self: *Store, gpa: std.mem.Allocator, ident: Ident, region: Region) Idx {
+        const idx = self.interner.insert(gpa, ident.raw_text, region);
+        self.exposing_modules.append(gpa, @enumFromInt(0)) catch |err| exitOnOom(err);
+        self.attributes.append(gpa, ident.attributes) catch |err| exitOnOom(err);
 
         return Idx{
             .attributes = ident.attributes,
@@ -88,7 +79,7 @@ pub const Store = struct {
         };
     }
 
-    pub fn genUnique(self: *Store) Idx {
+    pub fn genUnique(self: *Store, gpa: std.mem.Allocator) Idx {
         var id = self.next_unique_name;
         self.next_unique_name += 1;
 
@@ -109,15 +100,15 @@ pub const Store = struct {
         // const name_length = if (id < 10) 1 else ;
         const name = str_buffer[digit_index..];
 
-        const idx = self.interner.insert(name, Region.zero());
-        self.exposing_modules.append(@enumFromInt(0)) catch exitOnOom();
+        const idx = self.interner.insert(gpa, name, Region.zero());
+        self.exposing_modules.append(gpa, @enumFromInt(0)) catch |err| exitOnOom(err);
 
         const attributes = Attributes{
             .effectful = false,
             .ignored = false,
             .reassignable = false,
         };
-        self.attributes.append(attributes) catch exitOnOom();
+        self.attributes.append(gpa, attributes) catch |err| exitOnOom(err);
 
         return Idx{
             .attributes = attributes,
@@ -126,7 +117,7 @@ pub const Store = struct {
     }
 
     pub fn identsHaveSameText(
-        self: *Store,
+        self: *const Store,
         first_idx: Idx,
         second_idx: Idx,
     ) bool {
@@ -136,15 +127,15 @@ pub const Store = struct {
         );
     }
 
-    pub fn getText(self: *Store, idx: Idx) []u8 {
+    pub fn getText(self: *const Store, idx: Idx) []u8 {
         return self.interner.getText(@enumFromInt(@as(u32, idx.idx)));
     }
 
-    pub fn getRegion(self: *Store, idx: Idx) Region {
+    pub fn getRegion(self: *const Store, idx: Idx) Region {
         return self.interner.getRegion(@enumFromInt(@as(u32, idx.idx)));
     }
 
-    pub fn getExposingModule(self: *Store, idx: Idx) ModuleImport.Idx {
+    pub fn getExposingModule(self: *const Store, idx: Idx) ModuleImport.Idx {
         return self.exposing_modules.items[@as(usize, idx.idx)];
     }
 
@@ -153,7 +144,7 @@ pub const Store = struct {
     /// NOTE: This should be called as soon as an ident is encountered during
     /// canonicalization to make sure that we don't have to worry if the exposing
     /// module is zero because it hasn't been set yet or if it's actually zero.
-    pub fn setExposingModule(self: *Store, idx: Idx, exposing_module: ModuleImport.Idx) void {
+    pub fn setExposingModule(self: *const Store, idx: Idx, exposing_module: ModuleImport.Idx) void {
         self.exposing_modules.items[@as(usize, idx.idx)] = exposing_module;
     }
 };

--- a/src/base/ModuleEnv.zig
+++ b/src/base/ModuleEnv.zig
@@ -1,6 +1,6 @@
-//! The common state or environment for a module for things that live for the duration of the compilation.
+//! The common state for a module: any data useful over the full lifetime of its compilation.
 //!
-//! Stores all interned data like symbols, strings, tag names, field names, and problems.
+//! Stores all interned data like idents, strings, and problems.
 //!
 //! This reduces the size of this module's IRs as they can store references to this
 //! interned (and deduplicated) data instead of storing the values themselves.
@@ -17,23 +17,25 @@ const Problem = problem.Problem;
 
 const Self = @This();
 
-idents: Ident.Store,
+gpa: std.mem.Allocator,
+idents: Ident.Store = .{},
 ident_ids_for_slicing: collections.SafeList(Ident.Idx),
 strings: StringLiteral.Store,
-problems: std.ArrayList(Problem),
+problems: Problem.List,
 
 pub fn init(gpa: std.mem.Allocator) Self {
     return Self{
-        .idents = Ident.Store.init(gpa),
-        .ident_ids_for_slicing = collections.SafeList(Ident.Idx).init(gpa),
-        .strings = StringLiteral.Store.init(gpa),
-        .problems = std.ArrayList(Problem).init(gpa),
+        .gpa = gpa,
+        .idents = .{},
+        .ident_ids_for_slicing = .{},
+        .strings = .{},
+        .problems = .{},
     };
 }
 
 pub fn deinit(self: *Self) void {
-    self.idents.deinit();
-    self.ident_ids_for_slicing.deinit();
-    self.strings.deinit();
-    self.problems.deinit();
+    self.idents.deinit(self.gpa);
+    self.ident_ids_for_slicing.deinit(self.gpa);
+    self.strings.deinit(self.gpa);
+    self.problems.deinit(self.gpa);
 }

--- a/src/base/module_work.zig
+++ b/src/base/module_work.zig
@@ -49,7 +49,7 @@ pub fn ModuleWork(comptime Work: type) type {
                 can_irs: []const ModuleWork(can.IR),
             ) Store {
                 var items = std.MultiArrayList(ModuleWork(Work)){};
-                items.ensureTotalCapacity(gpa, can_irs.len) catch exitOnOom();
+                items.ensureTotalCapacity(gpa, can_irs.len) catch |err| exitOnOom(err);
 
                 for (can_irs) |work| {
                     items.appendAssumeCapacity(.{
@@ -67,7 +67,7 @@ pub fn ModuleWork(comptime Work: type) type {
                 can_irs: *const ModuleWork(can.IR).Store,
             ) Store {
                 var items = std.MultiArrayList(ModuleWork(Work)){};
-                items.ensureTotalCapacity(gpa, can_irs.items.len) catch exitOnOom();
+                items.ensureTotalCapacity(gpa, can_irs.items.len) catch |err| exitOnOom(err);
 
                 for (0..can_irs.items.len) |index| {
                     const work_idx: ModuleWorkIdx = @enumFromInt(index);
@@ -75,7 +75,7 @@ pub fn ModuleWork(comptime Work: type) type {
                     items.appendAssumeCapacity(.{
                         .package_idx = can_irs.getPackageIdx(work_idx),
                         .module_idx = can_irs.getModuleIdx(work_idx),
-                        .work = Work.init(&can_irs.getWork(work_idx).env, gpa),
+                        .work = Work.init(&can_irs.getWork(work_idx).env),
                     });
                 }
 

--- a/src/build/lift_functions/IR.zig
+++ b/src/build/lift_functions/IR.zig
@@ -21,31 +21,31 @@ typed_patterns: Pattern.Typed.List,
 typed_idents: TypedIdent.List,
 when_branches: WhenBranch.List,
 
-pub fn init(env: *base.ModuleEnv, gpa: std.mem.Allocator) Self {
+pub fn init(env: *base.ModuleEnv) Self {
     return Self{
         .env = env,
-        .exposed_values = std.AutoHashMap(Ident.Idx, Expr.Idx).init(gpa),
-        .exposed_functions = std.AutoHashMap(Ident.Idx, Function).init(gpa),
-        .types = Type.List.init(gpa),
-        .exprs = Expr.List.init(gpa),
-        .typed_exprs = Expr.Typed.List.init(gpa),
-        .patterns = Pattern.List.init(gpa),
-        .typed_patterns = Pattern.Typed.List.init(gpa),
-        .typed_idents = TypedIdent.List.init(gpa),
-        .when_branches = WhenBranch.List.init(gpa),
+        .exposed_values = std.AutoHashMap(Ident.Idx, Expr.Idx).init(env.gpa),
+        .exposed_functions = std.AutoHashMap(Ident.Idx, Function).init(env.gpa),
+        .types = .{},
+        .exprs = .{},
+        .typed_exprs = .{},
+        .patterns = .{},
+        .typed_patterns = .{},
+        .typed_idents = .{},
+        .when_branches = .{},
     };
 }
 
 pub fn deinit(self: *Self) void {
-    self.exposed_values.deinit();
-    self.exposed_functions.deinit();
-    self.types.deinit();
-    self.exprs.deinit();
-    self.typed_exprs.deinit();
-    self.patterns.deinit();
-    self.typed_patterns.deinit();
-    self.typed_idents.deinit();
-    self.when_branches.deinit();
+    self.exposed_values.deinit(self.env.gpa);
+    self.exposed_functions.deinit(self.env.gpa);
+    self.types.deinit(self.env.gpa);
+    self.exprs.deinit(self.env.gpa);
+    self.typed_exprs.deinit(self.env.gpa);
+    self.patterns.deinit(self.env.gpa);
+    self.typed_patterns.deinit(self.env.gpa);
+    self.typed_idents.deinit(self.env.gpa);
+    self.when_branches.deinit(self.env.gpa);
 }
 
 pub const Type = union(enum) {

--- a/src/build/lower_statements/IR.zig
+++ b/src/build/lower_statements/IR.zig
@@ -18,27 +18,27 @@ stmts: Stmt.List,
 idents_with_layouts: IdentWithLayout.List,
 list_literal_elems: ListLiteralElem.List,
 
-pub fn init(env: *base.ModuleEnv, gpa: std.mem.Allocator) Self {
+pub fn init(env: *base.ModuleEnv) Self {
     return Self{
         .env = env,
-        .procedures = std.AutoHashMap(Ident.Idx, Procedure).init(gpa),
-        .constants = std.AutoHashMap(Ident.Idx, StmtWithLayout).init(gpa),
-        .exprs = Expr.List.init(gpa),
-        .layouts = Layout.List.init(gpa),
-        .stmts = Stmt.List.init(gpa),
-        .idents_with_layouts = IdentWithLayout.List.init(gpa),
-        .list_literal_elems = ListLiteralElem.List.init(gpa),
+        .procedures = std.AutoHashMap(Ident.Idx, Procedure).init(env.gpa),
+        .constants = std.AutoHashMap(Ident.Idx, StmtWithLayout).init(env.gpa),
+        .exprs = .{},
+        .layouts = .{},
+        .stmts = .{},
+        .idents_with_layouts = .{},
+        .list_literal_elems = .{},
     };
 }
 
 pub fn deinit(self: *Self) void {
-    self.procedures.deinit();
-    self.constants.deinit();
-    self.exprs.deinit();
-    self.layouts.deinit();
-    self.stmts.deinit();
-    self.idents_with_layouts.deinit();
-    self.list_literal_elems.deinit();
+    self.procedures.deinit(self.env.gpa);
+    self.constants.deinit(self.env.gpa);
+    self.exprs.deinit(self.env.gpa);
+    self.layouts.deinit(self.env.gpa);
+    self.stmts.deinit(self.env.gpa);
+    self.idents_with_layouts.deinit(self.env.gpa);
+    self.list_literal_elems.deinit(self.env.gpa);
 }
 
 pub const Procedure = struct {

--- a/src/build/reference_count/IR.zig
+++ b/src/build/reference_count/IR.zig
@@ -18,27 +18,27 @@ stmts: Stmt.List,
 idents_with_layouts: IdentWithLayout.List,
 list_literal_elems: ListLiteralElem.List,
 
-pub fn init(env: *base.ModuleEnv, gpa: std.mem.Allocator) Self {
+pub fn init(env: *base.ModuleEnv) Self {
     return Self{
         .env = env,
-        .procedures = std.AutoHashMap(Ident.Idx, Procedure).init(gpa),
-        .constants = std.AutoHashMap(Ident.Idx, StmtWithLayout).init(gpa),
-        .exprs = Expr.List.init(gpa),
-        .layouts = Layout.List.init(gpa),
-        .stmts = Stmt.List.init(gpa),
-        .idents_with_layouts = IdentWithLayout.List.init(gpa),
-        .list_literal_elems = ListLiteralElem.List.init(gpa),
+        .procedures = std.AutoHashMap(Ident.Idx, Procedure).init(env.gpa),
+        .constants = std.AutoHashMap(Ident.Idx, StmtWithLayout).init(env.gpa),
+        .exprs = .{},
+        .layouts = .{},
+        .stmts = .{},
+        .idents_with_layouts = .{},
+        .list_literal_elems = .{},
     };
 }
 
 pub fn deinit(self: *Self) void {
-    self.procedures.deinit();
-    self.constants.deinit();
-    self.exprs.deinit();
-    self.layouts.deinit();
-    self.stmts.deinit();
-    self.idents_with_layouts.deinit();
-    self.list_literal_elems.deinit();
+    self.procedures.deinit(self.env.gpa);
+    self.constants.deinit(self.env.gpa);
+    self.exprs.deinit(self.env.gpa);
+    self.layouts.deinit(self.env.gpa);
+    self.stmts.deinit(self.env.gpa);
+    self.idents_with_layouts.deinit(self.env.gpa);
+    self.list_literal_elems.deinit(self.env.gpa);
 }
 
 pub const Procedure = struct {

--- a/src/build/solve_functions.zig
+++ b/src/build/solve_functions.zig
@@ -24,15 +24,15 @@ pub const IR = struct {
     env: *base.ModuleEnv,
     function_sets: FunctionSet.List,
 
-    pub fn init(env: *base.ModuleEnv, gpa: std.mem.Allocator) IR {
+    pub fn init(env: *base.ModuleEnv) IR {
         return IR{
             .env = env,
-            .function_sets = FunctionSet.List.init(gpa),
+            .function_sets = .{},
         };
     }
 
     pub fn deinit(self: *IR) void {
-        self.function_sets.deinit();
+        self.function_sets.deinit(self.env.gpa);
     }
 };
 

--- a/src/build/specialize_functions/IR.zig
+++ b/src/build/specialize_functions/IR.zig
@@ -21,31 +21,31 @@ typed_patterns: Pattern.Typed.List,
 typed_idents: TypedIdent.List,
 when_branches: WhenBranch.List,
 
-pub fn init(env: *base.ModuleEnv, gpa: std.mem.Allocator) Self {
+pub fn init(env: *base.ModuleEnv) Self {
     return Self{
         .env = env,
-        .exposed_values = std.AutoHashMap(Ident.Idx, Expr.Idx).init(gpa),
-        .exposed_functions = std.AutoHashMap(Ident.Idx, Function).init(gpa),
-        .types = Type.List.init(gpa),
-        .exprs = Expr.List.init(gpa),
-        .typed_exprs = Expr.Typed.List.init(gpa),
-        .patterns = Pattern.List.init(gpa),
-        .typed_patterns = Pattern.Typed.List.init(gpa),
-        .typed_idents = TypedIdent.List.init(gpa),
-        .when_branches = WhenBranch.List.init(gpa),
+        .exposed_values = std.AutoHashMap(Ident.Idx, Expr.Idx).init(env.gpa),
+        .exposed_functions = std.AutoHashMap(Ident.Idx, Function).init(env.gpa),
+        .types = .{},
+        .exprs = .{},
+        .typed_exprs = .{},
+        .patterns = .{},
+        .typed_patterns = .{},
+        .typed_idents = .{},
+        .when_branches = .{},
     };
 }
 
 pub fn deinit(self: *Self) void {
-    self.exposed_values.deinit();
-    self.exposed_functions.deinit();
-    self.types.deinit();
-    self.exprs.deinit();
-    self.typed_exprs.deinit();
-    self.patterns.deinit();
-    self.typed_patterns.deinit();
-    self.typed_idents.deinit();
-    self.when_branches.deinit();
+    self.exposed_values.deinit(self.env.gpa);
+    self.exposed_functions.deinit(self.env.gpa);
+    self.types.deinit(self.env.gpa);
+    self.exprs.deinit(self.env.gpa);
+    self.typed_exprs.deinit(self.env.gpa);
+    self.patterns.deinit(self.env.gpa);
+    self.typed_patterns.deinit(self.env.gpa);
+    self.typed_idents.deinit(self.env.gpa);
+    self.when_branches.deinit(self.env.gpa);
 }
 
 pub const Type = union(enum) {

--- a/src/build/specialize_types/IR.zig
+++ b/src/build/specialize_types/IR.zig
@@ -21,31 +21,31 @@ typed_patterns: Pattern.Typed.List,
 typed_idents: TypedIdent.List,
 when_branches: WhenBranch.List,
 
-pub fn init(env: *base.ModuleEnv, gpa: std.mem.Allocator) Self {
+pub fn init(env: *base.ModuleEnv) Self {
     return Self{
         .env = env,
-        .exposed_values = std.AutoHashMap(Ident.Idx, Expr.Idx).init(gpa),
-        .exposed_functions = std.AutoHashMap(Ident.Idx, Function).init(gpa),
-        .types = Type.List.init(gpa),
-        .exprs = Expr.List.init(gpa),
-        .typed_exprs = Expr.Typed.List.init(gpa),
-        .patterns = Pattern.List.init(gpa),
-        .typed_patterns = Pattern.Typed.List.init(gpa),
-        .typed_idents = TypedIdent.List.init(gpa),
-        .when_branches = WhenBranch.List.init(gpa),
+        .exposed_values = std.AutoHashMap(Ident.Idx, Expr.Idx).init(env.gpa),
+        .exposed_functions = std.AutoHashMap(Ident.Idx, Function).init(env.gpa),
+        .types = .{},
+        .exprs = .{},
+        .typed_exprs = .{},
+        .patterns = .{},
+        .typed_patterns = .{},
+        .typed_idents = .{},
+        .when_branches = .{},
     };
 }
 
 pub fn deinit(self: *Self) void {
-    self.exposed_values.deinit();
-    self.exposed_functions.deinit();
-    self.types.deinit();
-    self.exprs.deinit();
-    self.typed_exprs.deinit();
-    self.patterns.deinit();
-    self.typed_patterns.deinit();
-    self.typed_idents.deinit();
-    self.when_branches.deinit();
+    self.exposed_values.deinit(self.env.gpa);
+    self.exposed_functions.deinit(self.env.gpa);
+    self.types.deinit(self.env.gpa);
+    self.exprs.deinit(self.env.gpa);
+    self.typed_exprs.deinit(self.env.gpa);
+    self.patterns.deinit(self.env.gpa);
+    self.typed_patterns.deinit(self.env.gpa);
+    self.typed_idents.deinit(self.env.gpa);
+    self.when_branches.deinit(self.env.gpa);
 }
 
 pub const Type = union(enum) {

--- a/src/check/canonicalize.zig
+++ b/src/check/canonicalize.zig
@@ -34,12 +34,11 @@ pub const IR = @import("canonicalize/IR.zig");
 pub fn canonicalize(
     can_ir: *IR,
     parse_ir: *parse.IR,
-    allocator: std.mem.Allocator,
 ) void {
     var env = can_ir.env;
     const builtin_aliases = &.{};
     const imported_idents = &.{};
-    var scope = Scope.init(&env, builtin_aliases, imported_idents, allocator);
+    var scope = Scope.init(&env, builtin_aliases, imported_idents);
 
     const file = parse_ir.store.getFile();
 
@@ -73,12 +72,12 @@ fn bringImportIntoScope(
         .end = Region.Position.zero(),
     };
 
-    const res = ir.imports.getOrInsert(import_name, shorthand);
+    const res = ir.imports.getOrInsert(ir.env.gpa, import_name, shorthand);
 
     if (res.was_present) {
-        ir.env.problems.append(Problem.Canonicalize.make(.{ .DuplicateImport = .{
+        _ = ir.env.problems.append(ir.env.gpa, Problem.Canonicalize.make(.{ .DuplicateImport = .{
             .duplicate_import_region = region,
-        } })) catch exitOnOom();
+        } }));
     }
 
     // for (import.exposing.items.items) |exposed| {

--- a/src/check/canonicalize/IR.zig
+++ b/src/check/canonicalize/IR.zig
@@ -45,37 +45,37 @@ pub fn init(gpa: std.mem.Allocator) Self {
 
     return Self{
         .env = env,
-        .aliases = Alias.List.init(gpa),
+        .aliases = .{},
         .imports = ModuleImport.Store.init(&.{}, &env.idents, gpa),
-        .defs = Def.List.init(gpa),
-        .exprs = Expr.List.init(gpa),
-        .exprs_at_regions = ExprAtRegion.List.init(gpa),
-        .typed_exprs_at_regions = TypedExprAtRegion.List.init(gpa),
-        .when_branches = WhenBranch.List.init(gpa),
-        .patterns = Pattern.List.init(gpa),
-        .patterns_at_regions = PatternAtRegion.List.init(gpa),
-        .typed_patterns_at_regions = TypedPatternAtRegion.List.init(gpa),
-        .type_indices = collections.SafeList(TypeIdx).init(gpa),
+        .defs = .{},
+        .exprs = .{},
+        .exprs_at_regions = .{},
+        .typed_exprs_at_regions = .{},
+        .when_branches = .{},
+        .patterns = .{},
+        .patterns_at_regions = .{},
+        .typed_patterns_at_regions = .{},
+        .type_indices = .{},
         // .type_var_names = Ident.Store.init(gpa),
-        .ingested_files = IngestedFile.List.init(gpa),
+        .ingested_files = .{},
     };
 }
 
 pub fn deinit(self: *Self) void {
     self.env.deinit();
-    self.aliases.deinit();
-    self.imports.deinit();
-    self.defs.deinit();
-    self.exprs.deinit();
-    self.exprs_at_regions.deinit();
-    self.typed_exprs_at_regions.deinit();
-    self.when_branches.deinit();
-    self.patterns.deinit();
-    self.patterns_at_regions.deinit();
-    self.typed_patterns_at_regions.deinit();
-    self.type_indices.deinit();
-    // self.type_var_names.deinit();
-    self.ingested_files.deinit();
+    self.aliases.deinit(self.env.gpa);
+    self.imports.deinit(self.env.gpa);
+    self.defs.deinit(self.env.gpa);
+    self.exprs.deinit(self.env.gpa);
+    self.exprs_at_regions.deinit(self.env.gpa);
+    self.typed_exprs_at_regions.deinit(self.env.gpa);
+    self.when_branches.deinit(self.env.gpa);
+    self.patterns.deinit(self.env.gpa);
+    self.patterns_at_regions.deinit(self.env.gpa);
+    self.typed_patterns_at_regions.deinit(self.env.gpa);
+    self.type_indices.deinit(self.env.gpa);
+    // self.type_var_names.deinit(self.env.gpa);
+    self.ingested_files.deinit(self.env.gpa);
 }
 
 pub const RigidVariables = struct {

--- a/src/check/check_types.zig
+++ b/src/check/check_types.zig
@@ -60,7 +60,8 @@ test "checkTypes - basic type unification" {
 
     // Test that we can perform basic type unification
     const a_type = Type{ .flex_var = null };
-    const int_type = Type{ .rigid_var = env.idents.insert(Ident.for_text("Int"), Region.zero()) };
+    const int_name = env.idents.insert(env.gpa, Ident.for_text("Int"), Region.zero());
+    const int_type = Type{ .rigid_var = int_name };
 
     type_store.set(type_id_1, a_type);
     type_store.set(type_id_2, int_type);

--- a/src/check/resolve_imports/IR.zig
+++ b/src/check/resolve_imports/IR.zig
@@ -22,28 +22,28 @@ type_indices: collections.SafeList(Type.Idx),
 declarations: DeclarationTag.List,
 host_exposed_annotations: std.AutoHashMap(usize, Type.Idx),
 
-pub fn init(env: *base.ModuleEnv, gpa: std.mem.Allocator) Self {
+pub fn init(env: *base.ModuleEnv) Self {
     return Self{
         .env = env,
-        .regions = Region.List.init(gpa),
-        .exprs = Expr.List.init(gpa),
-        .destructs = DestructureDef.List.init(gpa),
-        .function_bodies = FunctionDef.List.init(gpa),
-        .function_args = FunctionDef.Arg.List.init(gpa),
-        .type_indices = collections.SafeList(Type.Idx).init(gpa),
-        .declarations = DeclarationTag.List.init(gpa),
-        .host_exposed_annotations = std.AutoHashMap(usize, Type.Idx).init(gpa),
+        .regions = .{},
+        .exprs = .{},
+        .destructs = .{},
+        .function_bodies = .{},
+        .function_args = .{},
+        .type_indices = .{},
+        .declarations = .{},
+        .host_exposed_annotations = std.AutoHashMap(usize, Type.Idx).init(env.gpa),
     };
 }
 
 pub fn deinit(self: *Self) void {
-    self.regions.deinit();
-    self.exprs.deinit();
-    self.destructs.deinit();
-    self.function_bodies.deinit();
-    self.function_args.deinit();
-    self.type_indices.deinit();
-    self.declarations.deinit();
+    self.regions.deinit(self.env.gpa);
+    self.exprs.deinit(self.env.gpa);
+    self.destructs.deinit(self.env.gpa);
+    self.function_bodies.deinit(self.env.gpa);
+    self.function_args.deinit(self.env.gpa);
+    self.type_indices.deinit(self.env.gpa);
+    self.declarations.deinit(self.env.gpa);
     self.host_exposed_annotations.deinit();
 }
 

--- a/src/collections/utils.zig
+++ b/src/collections/utils.zig
@@ -5,12 +5,16 @@ const std = @import("std");
 /// Since there's nothing we can do to recover from such an issue,
 /// it's best to always exit the process with a nice message than to
 /// propagate unrecoverable errors all over the compiler.
-pub fn exitOnOom() noreturn {
-    const oom_message =
-        \\I ran out of memory! I can't do anything to recover, so I'm exiting.
-        \\Try reducing memory usage on your machine and then running again.
-    ;
+pub fn exitOnOom(err: std.mem.Allocator.Error) noreturn {
+    switch (err) {
+        error.OutOfMemory => {
+            const oom_message =
+                \\I ran out of memory! I can't do anything to recover, so I'm exiting.
+                \\Try reducing memory usage on your machine and then running again.
+            ;
 
-    std.debug.print(oom_message, .{});
-    std.process.exit(1);
+            std.debug.print(oom_message, .{});
+            std.process.exit(1);
+        },
+    }
 }

--- a/src/snapshot.zig
+++ b/src/snapshot.zig
@@ -262,11 +262,11 @@ fn processSnapshotFile(snapshot_path: []const u8, gpa: Allocator) !bool {
     defer module_env.deinit();
 
     // Parse the source code
-    var parse_ast = parse.parse(&module_env, gpa, content.source);
+    var parse_ast = parse.parse(&module_env, content.source);
     defer parse_ast.deinit();
 
     // Format the source code
-    var formatter = fmt.init(parse_ast, gpa);
+    var formatter = fmt.init(parse_ast);
     defer formatter.deinit();
     const formatted_output = formatter.formatFile();
     defer gpa.free(formatted_output);
@@ -275,7 +275,7 @@ fn processSnapshotFile(snapshot_path: []const u8, gpa: Allocator) !bool {
     parse_ast.store.emptyScratch();
 
     // Write the new AST to the parse section
-    try parse_ast.toSExprStr(gpa, &module_env, parse_buffer.writer().any());
+    try parse_ast.toSExprStr(&module_env, parse_buffer.writer().any());
 
     // Rewrite the file with updated sections
     var file = std.fs.cwd().createFile(snapshot_path, .{}) catch |err| {


### PR DESCRIPTION
A few cleanups for memory usage and convention following:
- Prefer passing the `std.mem.Allocator` as the first argument to functions (this is Zig convention)
- Put the `gpa: std.mem.Allocator` in `base.ModuleEnv` and prefer that for passing around the `Allocator`
  - the `ModuleEnv` should be used enough to usually be in the L1 cache, meaning the double indirection of `ir.env.gpa` shouldn't be expensive
- Prefer `ArrayListUnmanaged` over `ArrayList` (same for all list-backed collections) since it avoids storing a pointer to the `Allocator` in every collection
  - Not enforced for testing collections/buffers
- Use Andrew Kelley's suggestion for catching OOM errors by capturing the `Allocator.Error` instead of discarding it, this should prevent us from accidentally over/under-catching errors