### PR TITLE
Always format sexprs with three or fewer elements on one line

### DIFF
--- a/src/check/parse.zig
+++ b/src/check/parse.zig
@@ -124,19 +124,13 @@ test "example s-expr" {
 
     const expected =
         \\(file
-        \\    (header
-        \\        'foo'
-        \\        'bar')
+        \\    (header 'foo' 'bar')
         \\    (decl
-        \\        (ident
-        \\            'foo')
-        \\        (string
-        \\            'hey'))
+        \\        (ident 'foo')
+        \\        (string 'hey'))
         \\    (decl
-        \\        (ident
-        \\            'bar')
-        \\        (string
-        \\            'yo')))
+        \\        (ident 'bar')
+        \\        (string 'yo')))
     ;
 
     try testSExprHelper(source, expected);

--- a/src/check/parse/IR.zig
+++ b/src/check/parse/IR.zig
@@ -2351,5 +2351,5 @@ pub fn toSExprStr(ir: *@This(), env: *base.ModuleEnv, writer: std.io.AnyWriter) 
     var node = file.toSExpr(env, ir);
     defer node.deinit(env.gpa);
 
-    node.toStringPretty(writer, 4);
+    node.toStringPretty(writer);
 }

--- a/src/snapshots/001.txt
+++ b/src/snapshots/001.txt
@@ -15,10 +15,7 @@ module [foo]
 foo = "one"
 ~~~PARSE
 (file
-    (header
-        'foo')
+    (header 'foo')
     (decl
-        (ident
-            'foo')
-        (string
-            'one')))
+        (ident 'foo')
+        (string 'one')))

--- a/src/snapshots/some_folder/002.txt
+++ b/src/snapshots/some_folder/002.txt
@@ -8,16 +8,10 @@ foo = "one"
 bar = "two"
 ~~~PARSE
 (file
-    (header
-        'foo'
-        'bar')
+    (header 'foo' 'bar')
     (decl
-        (ident
-            'foo')
-        (string
-            'one'))
+        (ident 'foo')
+        (string 'one'))
     (decl
-        (ident
-            'bar')
-        (string
-            'two')))
+        (ident 'bar')
+        (string 'two')))


### PR DESCRIPTION
This should make the snapshots a bit more compact and easy to read
