### PR TITLE
Improve fuzzing reproductions

### DIFF
--- a/src/fuzz-repro.zig
+++ b/src/fuzz-repro.zig
@@ -13,6 +13,18 @@ const fuzz_test = @import("fuzz_test");
 
 const MAX_SIZE = std.math.maxInt(u32);
 
+// TODO: rethink this interface and make it simpler (probably with full cli arg passing and more flags).
+const HELP =
+    \\ This script will run a single iteration of a fuzz test.
+    \\ It can read input in f ways:
+    \\   1. With no args: reads from stdin
+    \\   2. With file arg: reads from a file specified by the arg
+    \\   3. With `-b/--base64`: uses the base64 encoded arg as the repro input
+    \\
+    \\ Add `-v/--verbose` to get a more verbose print out.
+    \\
+;
+
 pub fn main() !void {
     var gpa_impl = std.heap.GeneralPurposeAllocator(.{}){};
     defer {
@@ -23,50 +35,56 @@ pub fn main() !void {
     const args = try std.process.argsAlloc(gpa);
     defer std.process.argsFree(gpa, args);
 
-    if (args.len == 1) {
-        // By default just read from stdin.
+    var data: ?[]const u8 = null;
+    var base64 = false;
+    var verbose = false;
+
+    for (args[1..]) |arg| {
+        if (std.mem.eql(u8, arg, "-v") or std.mem.eql(u8, arg, "--verbose")) {
+            verbose = true;
+        } else if (std.mem.eql(u8, arg, "-b") or std.mem.eql(u8, arg, "--base64")) {
+            base64 = true;
+        } else if (std.mem.eql(u8, arg, "-h") or std.mem.eql(u8, arg, "--help")) {
+            std.debug.print(HELP, .{});
+            std.process.exit(0);
+        } else if (data == null) {
+            data = arg;
+        } else {
+            std.debug.print("unexpected arg: '{s}'\n", .{arg});
+            std.process.exit(1);
+        }
+    }
+    if (data == null) {
+        if (base64) {
+            std.debug.print("Reading from stdin doesn't support base64\n", .{});
+            std.process.exit(1);
+        }
+        // No input data, just read from stdin.
         std.debug.print("Reading bytes for repro from stdin\n", .{});
         const bytes = try std.io.getStdIn().readToEndAlloc(gpa, @intCast(MAX_SIZE));
         defer gpa.free(bytes);
 
         fuzz_test.zig_fuzz_init();
-        fuzz_test.zig_fuzz_test_inner(bytes.ptr, @intCast(bytes.len), true);
-    } else if (args.len == 2) {
-        if (std.mem.eql(u8, args[1], "-h") or std.mem.eql(u8, args[1], "--help")) {
-            // Special case for help message.
-            std.debug.print(
-                \\ This script will run a single iteration of a fuzz test.
-                \\ It can read input in 3 ways:
-                \\   1. With no args: reads from stdin
-                \\   2. With 1 arg: reads from a file specified by the arg
-                \\   3. With N arg: uses the commandline args as the repro input
-            , .{});
-            return;
-        }
-        // Use the file passed in as the source.
-        const path = args[1];
-        std.debug.print("Reading bytes for repro from {s}\n", .{path});
-        const file = try std.fs.cwd().openFile(path, .{});
+        fuzz_test.zig_fuzz_test_inner(bytes.ptr, @intCast(bytes.len), verbose);
+    } else if (base64) {
+        // Read arg as base64 string.
+        std.debug.print("Using bytes as base64 encoded repro: {s}\n", .{data.?});
+        const decoded_size = try std.base64.standard.Decoder.calcSizeForSlice(data.?);
+        const bytes = try gpa.alloc(u8, decoded_size);
+        defer gpa.free(bytes);
+
+        try std.base64.standard.Decoder.decode(bytes, data.?);
+        fuzz_test.zig_fuzz_init();
+        fuzz_test.zig_fuzz_test_inner(bytes.ptr, @intCast(bytes.len), verbose);
+    } else {
+        // Read file pointed to by arg.
+        std.debug.print("Reading bytes for repro from {s}\n", .{data.?});
+        const file = try std.fs.cwd().openFile(data.?, .{});
+        defer file.close();
         const bytes = try file.readToEndAlloc(gpa, @intCast(MAX_SIZE));
         defer gpa.free(bytes);
 
         fuzz_test.zig_fuzz_init();
-        fuzz_test.zig_fuzz_test_inner(bytes.ptr, @intCast(bytes.len), true);
-    } else {
-        // If many args are passed in, use them as the fuzz input.
-        std.debug.print("Using commandline args as bytes for repro\n", .{});
-        var args_str = std.ArrayList(u8).init(gpa);
-        defer args_str.deinit();
-
-        var w = args_str.writer();
-        for (args, 0..) |arg, i| {
-            try w.writeAll(arg);
-            if (i != args.len - 1) {
-                try w.writeByte(' ');
-            }
-        }
-
-        fuzz_test.zig_fuzz_init();
-        fuzz_test.zig_fuzz_test_inner(args_str.items.ptr, @intCast(args_str.items.len), true);
+        fuzz_test.zig_fuzz_test_inner(bytes.ptr, @intCast(bytes.len), verbose);
     }
 }


### PR DESCRIPTION
Allow reproducing with a base64 input on the commandline. Also make verbosity of the script a toggle.
As part of this cleanup the `-Dfuzz` arg.
`zig build repro-x -- ...` will run a repro with args (no `-Dfuzz` needed). `zig build fuzz-x -Dfuzz` will still build a fuzzer.