### PR TITLE
[parser] crashing is better than looping forever

### DIFF
--- a/src/check/parse/Parser.zig
+++ b/src/check/parse/Parser.zig
@@ -664,7 +664,7 @@ pub fn parsePattern(self: *Parser, alternatives: Alternatives) IR.NodeStore.Patt
                     .region = .{ .start = start, .end = self.pos },
                 } });
             },
-            else => {},
+            else => std.debug.panic("TODO: Handle parsing pattern starting with: {s}", .{@tagName(self.peek())}),
         }
 
         if (pattern) |p| {


### PR DESCRIPTION
Just a bug caught by the fuzzer. Parser was hanging. It is preferably to crash with a message instead of looping forever.