### PR TITLE
[cli] minor cleanup

### DIFF
--- a/src/check/parse/IR.zig
+++ b/src/check/parse/IR.zig
@@ -1712,7 +1712,7 @@ pub const NodeStore = struct {
                     return import_node;
                 },
                 else => {
-                    std.log.err("format for statement {}", .{self});
+                    std.debug.print("format for statement {}", .{self});
                     @panic("not implemented");
                 },
             }
@@ -1943,7 +1943,7 @@ pub const NodeStore = struct {
                     return ident_sexpr;
                 },
                 else => {
-                    std.log.err("Format for Expr {}", .{self});
+                    std.debug.print("Format for Expr {}", .{self});
                     @panic("not implemented yet");
                 },
             }

--- a/src/main.zig
+++ b/src/main.zig
@@ -38,7 +38,7 @@ const usage =
 
 /// Log a fatal error and exit the process with a non-zero code.
 pub fn fatal(comptime format: []const u8, args: anytype) noreturn {
-    std.log.err(format, args);
+    std.io.getStdErr().writer().print(format, args) catch unreachable;
     std.process.exit(1);
 }
 
@@ -53,8 +53,9 @@ pub fn main() !void {
 }
 
 fn mainArgs(gpa: Allocator, args: []const []const u8) !void {
+    const stderr = std.io.getStdErr().writer();
     if (args.len <= 1) {
-        std.log.info("{s}", .{usage});
+        try stderr.print("{s}", .{usage});
         fatal("expected command argument", .{});
     }
 
@@ -80,7 +81,7 @@ fn mainArgs(gpa: Allocator, args: []const []const u8) !void {
     } else if (std.mem.eql(u8, cmd, "-h") or std.mem.eql(u8, cmd, "--help")) {
         try rocHelp();
     } else {
-        std.log.info("{s}", .{usage});
+        try stderr.print("{s}", .{usage});
         fatal("unknown command: {s}", .{cmd});
     }
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -140,6 +140,10 @@ fn rocFormat(gpa: Allocator, args: []const []const u8) !void {
 
     var parse_ast = parse.parse(&module_env, contents);
     defer parse_ast.deinit();
+    if (parse_ast.errors.len > 0) {
+        // TODO: pretty print the parse failures.
+        fatal("Failed to parse '{s}' for formatting.\nErrors:\n{any}\n", .{ roc_file_path, parse_ast.errors });
+    }
 
     var formatter = fmt.init(parse_ast);
     defer formatter.deinit();


### PR DESCRIPTION
1. Get rid of std.log. We want to directly write our output io and not use a logger framework
2. Make the formatter fail and exit early on parse failures.