### PR TITLE
Update to zig 0.14.0

### DIFF
--- a/.github/workflows/ci_zig.yml
+++ b/.github/workflows/ci_zig.yml
@@ -11,7 +11,7 @@ jobs:
               uses: actions/checkout@v4
             - uses: mlugg/setup-zig@v1
               with:
-                version: 0.13.0
+                version: 0.14.0
 
             - run: |
                 ./ci/zig_lints.sh
@@ -34,7 +34,7 @@ jobs:
               uses: actions/checkout@v4
             - uses: mlugg/setup-zig@v1
               with:
-                version: 0.13.0
+                version: 0.14.0
 
             - name: build roc
               run: |
@@ -118,7 +118,7 @@ jobs:
               uses: actions/checkout@v4
             - uses: mlugg/setup-zig@v1
               with:
-                version: 0.13.0
+                version: 0.14.0
 
             - name: cross compile with llvm
               run: |

--- a/build.zig
+++ b/build.zig
@@ -182,7 +182,7 @@ fn add_fuzz_target(
         const fuzz_step = b.step(name_exe, b.fmt("Generate fuzz executable for {s}", .{name}));
         b.default_step.dependOn(fuzz_step);
 
-        const afl = b.lazyImport(@This(), "zig-afl-kit") orelse return;
+        const afl = b.lazyImport(@This(), "zig_afl_kit") orelse return;
         const fuzz_exe = afl.addInstrumentedExe(b, target, .ReleaseSafe, &.{}, use_system_afl, fuzz_obj) orelse return;
         fuzz_step.dependOn(&b.addInstallBinFile(fuzz_exe, name_exe).step);
     }

--- a/build.zig
+++ b/build.zig
@@ -182,7 +182,7 @@ fn add_fuzz_target(
         const fuzz_step = b.step(name_exe, b.fmt("Generate fuzz executable for {s}", .{name}));
         b.default_step.dependOn(fuzz_step);
 
-        const afl = b.lazyImport(@This(), "zig_afl_kit") orelse return;
+        const afl = b.lazyImport(@This(), "afl_kit") orelse return;
         const fuzz_exe = afl.addInstrumentedExe(b, target, .ReleaseSafe, &.{}, use_system_afl, fuzz_obj) orelse return;
         fuzz_step.dependOn(&b.addInstallBinFile(fuzz_exe, name_exe).step);
     }

--- a/build.zig
+++ b/build.zig
@@ -143,7 +143,7 @@ fn add_fuzz_target(
         .optimize = .ReleaseSafe,
     });
 
-    // TODO: Once 0.14.0 is released, uncomment this. Will make fuzzing work better.
+    // TODO: look into enabling this, I think it may only work on linux for 0.14.0
     // fuzz_obj.root_module.fuzz = true;
     fuzz_obj.root_module.stack_check = false; // not linking with compiler-rt
     fuzz_obj.root_module.link_libc = true; // afl runtime depends on libc
@@ -158,7 +158,7 @@ fn add_fuzz_target(
         .optimize = .Debug,
         .link_libc = true,
     });
-    install_repro.root_module.addImport("fuzz_test", &fuzz_obj.root_module);
+    install_repro.root_module.addImport("fuzz_test", fuzz_obj.root_module);
     b.installArtifact(install_repro);
 
     const run_cmd = b.addRunArtifact(install_repro);
@@ -175,7 +175,7 @@ fn add_fuzz_target(
         .optimize = .Debug,
         .link_libc = true,
     });
-    check_repro.root_module.addImport("fuzz_test", &fuzz_obj.root_module);
+    check_repro.root_module.addImport("fuzz_test", fuzz_obj.root_module);
     check_step.dependOn(&check_repro.step);
 
     if (fuzz and build_afl) {
@@ -215,7 +215,7 @@ fn addMainExe(
 
         exe.addLibraryPath(.{ .cwd_relative = llvm_paths.lib });
         exe.addIncludePath(.{ .cwd_relative = llvm_paths.include });
-        try addStaticLlvmOptionsToModule(&exe.root_module);
+        try addStaticLlvmOptionsToModule(exe.root_module);
     }
 
     return exe;
@@ -269,7 +269,7 @@ fn llvmPaths(
         std.process.exit(1);
     }
     const triple = supported_deps_triples.get(raw_triple).?;
-    const deps_name = b.fmt("roc-deps-{s}", .{triple});
+    const deps_name = b.fmt("roc_deps_{s}", .{triple});
     const deps = b.lazyDependency(deps_name, .{}) orelse return null;
     const lazy_llvm_path = deps.path(".");
     // TODO: Is this ok to do in the zig build system?
@@ -283,20 +283,20 @@ fn llvmPaths(
 }
 
 const supported_deps_triples = std.StaticStringMap([]const u8).initComptime(.{
-    .{ "aarch64-macos-none", "aarch64-macos-none" },
-    .{ "aarch64-linux-musl", "aarch64-linux-musl" },
-    .{ "aarch64-windows-gnu", "aarch64-windows-gnu" },
-    .{ "arm-linux-musleabihf", "arm-linux-musleabihf" },
-    .{ "x86-linux-musl", "x86-linux-musl" },
-    .{ "x86_64-linux-musl", "x86_64-linux-musl" },
-    .{ "x86_64-macos-none", "x86_64-macos-none" },
-    .{ "x86_64-windows-gnu", "x86_64-windows-gnu" },
+    .{ "aarch64-macos-none", "aarch64_macos_none" },
+    .{ "aarch64-linux-musl", "aarch64_linux_musl" },
+    .{ "aarch64-windows-gnu", "aarch64_windows_gnu" },
+    .{ "arm-linux-musleabihf", "arm_linux_musleabihf" },
+    .{ "x86-linux-musl", "x86_linux_musl" },
+    .{ "x86_64-linux-musl", "x86_64_linux_musl" },
+    .{ "x86_64-macos-none", "x86_64_macos_none" },
+    .{ "x86_64-windows-gnu", "x86_64_windows_gnu" },
     // We also support the gnu linux targets.
     // For those, we just map to musl.
-    .{ "aarch64-linux-gnu", "aarch64-linux-musl" },
-    .{ "arm-linux-gnueabihf", "arm-linux-musleabihf" },
-    .{ "x86-linux-gnu", "x86-linux-musl" },
-    .{ "x86_64-linux-gnu", "x86_64-linux-musl" },
+    .{ "aarch64-linux-gnu", "aarch64_linux_musl" },
+    .{ "arm-linux-gnueabihf", "arm_linux_musleabihf" },
+    .{ "x86-linux-gnu", "x86_linux_musl" },
+    .{ "x86_64-linux-gnu", "x86_64_linux_musl" },
 });
 
 // The following is lifted from the zig compiler.

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .name = .roc,
     .version = "0.0.0",
-    .minimum_zig_version = "0.13.0",
+    .minimum_zig_version = "0.14.0",
     .dependencies = .{
         .zig_afl_kit = .{
             .url = "git+https://github.com/kristoff-it/zig-afl-kit#1e9fcaa08361307d16a9bde82b4a7fd4560ce502",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,54 +1,55 @@
 .{
-    .name = "roc",
+    .name = .roc,
     .version = "0.0.0",
     .minimum_zig_version = "0.13.0",
     .dependencies = .{
-        .@"zig-afl-kit" = .{
-            .url = "git+https://github.com/bhansconnect/zig-afl-kit#ff8533581f52411aba68a64843251fe12bd76b43",
+        .zig_afl_kit = .{
+            .url = "git+https://github.com/kristoff-it/zig-afl-kit#1e9fcaa08361307d16a9bde82b4a7fd4560ce502",
             .hash = "122065a5f839ca9174542c621a0311695b49db71b58b50b232891571902775405642",
             .lazy = true,
         },
-        .@"roc-deps-aarch64-macos-none" = .{
+        .roc_deps_aarch64_macos_none = .{
             .url = "https://github.com/roc-lang/roc-bootstrap/releases/download/zig-0.13.0/aarch64-macos-none.tar.xz",
             .hash = "122044a065bfe8f6286901b110a1b0b5a764f9fcb2d1472a5eeb3423527e95419427",
             .lazy = true,
         },
-        .@"roc-deps-aarch64-linux-musl" = .{
+        .roc_deps_aarch64_linux_musl = .{
             .url = "https://github.com/roc-lang/roc-bootstrap/releases/download/zig-0.13.0/aarch64-linux-musl.tar.xz",
             .hash = "1220949c8b509cbdac3eb9de5656906ea3e777dfea9e7333f32462754cb1d7708bf2",
             .lazy = true,
         },
-        .@"roc-deps-aarch64-windows-gnu" = .{
+        .roc_deps_aarch64_windows_gnu = .{
             .url = "https://github.com/roc-lang/roc-bootstrap/releases/download/zig-0.13.0/aarch64-windows-gnu.zip",
             .hash = "1220fcd7dcb6768b907f20369ec6390adb4de41bd5c1c34dc0f1611af50a331b3e01",
             .lazy = true,
         },
-        .@"roc-deps-arm-linux-musleabihf" = .{
+        .roc_deps_arm_linux_musleabihf = .{
             .url = "https://github.com/roc-lang/roc-bootstrap/releases/download/zig-0.13.0/arm-linux-musleabihf.tar.xz",
             .hash = "122037ecc8654feb3d34da5424ca6a73f140dbd30475e3d4f23a6f29844e799d51a3",
             .lazy = true,
         },
-        .@"roc-deps-x86-linux-musl" = .{
+        .roc_deps_x86_linux_musl = .{
             .url = "https://github.com/roc-lang/roc-bootstrap/releases/download/zig-0.13.0/x86-linux-musl.tar.xz",
             .hash = "12208fbefa56ba6571399c60d96810d00a561af1926cf566e07fc32c748fbbb70ccf",
             .lazy = true,
         },
-        .@"roc-deps-x86_64-linux-musl" = .{
+        .roc_deps_x86_64_linux_musl = .{
             .url = "https://github.com/roc-lang/roc-bootstrap/releases/download/zig-0.13.0/x86_64-linux-musl.tar.xz",
             .hash = "1220aff2ba681359149edde57256206d87695f84d33375082a3a442da9ba8dfc177f",
             .lazy = true,
         },
-        .@"roc-deps-x86_64-macos-none" = .{
+        .roc_deps_x86_64_macos_none = .{
             .url = "https://github.com/roc-lang/roc-bootstrap/releases/download/zig-0.13.0/x86_64-macos-none.tar.xz",
             .hash = "1220a0714d1cd12799885b5217252511012cca5d2d679d318520515d2487b80533db",
             .lazy = true,
         },
-        .@"roc-deps-x86_64-windows-gnu" = .{
+        .roc_deps_x86_64_windows_gnu = .{
             .url = "https://github.com/roc-lang/roc-bootstrap/releases/download/zig-0.13.0/x86_64-windows-gnu.zip",
             .hash = "122070972a9f996fc1a167b78d3a6a8c10f85349f9369383f5e26af1c5eed3cc41b0",
             .lazy = true,
         },
     },
+    .fingerprint = 0x9eea22a6c3bd0034,
     .paths = .{
         "build.zig",
         "build.zig.zon",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,7 +5,7 @@
     .dependencies = .{
         .zig_afl_kit = .{
             .url = "git+https://github.com/kristoff-it/zig-afl-kit#1e9fcaa08361307d16a9bde82b4a7fd4560ce502",
-            .hash = "122065a5f839ca9174542c621a0311695b49db71b58b50b232891571902775405642",
+            .hash = "12200b1b5e8c711d81e1bf10c11510dac6bd5dd8034c55d15904d8b2587572378a7b",
             .lazy = true,
         },
         .roc_deps_aarch64_macos_none = .{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -3,9 +3,9 @@
     .version = "0.0.0",
     .minimum_zig_version = "0.14.0",
     .dependencies = .{
-        .zig_afl_kit = .{
-            .url = "git+https://github.com/kristoff-it/zig-afl-kit#1e9fcaa08361307d16a9bde82b4a7fd4560ce502",
-            .hash = "12200b1b5e8c711d81e1bf10c11510dac6bd5dd8034c55d15904d8b2587572378a7b",
+        .afl_kit = .{
+            .url = "git+https://github.com/bhansconnect/zig-afl-kit?ref=zig-0.14.0#323ec465fe33f0e4820648e713b70ffc494fb0c6",
+            .hash = "afl_kit-0.1.0-uhOgGDQdAADv-nfytsC3tGTQMfaG11pR-NV87LKev3H8",
             .lazy = true,
         },
         .roc_deps_aarch64_macos_none = .{

--- a/src/base.zig
+++ b/src/base.zig
@@ -37,39 +37,39 @@ pub const CalledVia = enum {};
 
 /// Represents a value written as-is in a Roc source file.
 pub const Literal = union(enum) {
-    Int: Int,
-    Float: Float,
+    Int: IntLiteral,
+    Float: FloatLiteral,
     Bool: bool,
     Str: StringLiteral.Idx,
     /// A crash with a textual message describing why a crash occurred.
     Crash: StringLiteral.Idx,
+};
 
-    /// An integer number literal.
-    pub const Int = union(enum) {
-        I8: i8,
-        U8: u8,
-        I16: i16,
-        U16: u16,
-        I32: i32,
-        U32: u32,
-        I64: i64,
-        U64: u64,
-        I128: i128,
-        U128: u128,
-    };
+/// An integer number literal.
+pub const IntLiteral = union(enum) {
+    I8: i8,
+    U8: u8,
+    I16: i16,
+    U16: u16,
+    I32: i32,
+    U32: u32,
+    I64: i64,
+    U64: u64,
+    I128: i128,
+    U128: u128,
+};
 
-    /// A fractional number literal.
-    pub const Float = union(enum) {
-        F32: f32,
-        F64: f64,
-        // We represent Dec as a large integer divided by 10^18, which is the maximum
-        // number of decimal places that allow lossless conversion of U64 to Dec.
-        Dec: u128,
-    };
+/// A fractional number literal.
+pub const FloatLiteral = union(enum) {
+    F32: f32,
+    F64: f64,
+    // We represent Dec as a large integer divided by 10^18, which is the maximum
+    // number of decimal places that allow lossless conversion of U64 to Dec.
+    Dec: u128,
+};
 
-    /// An integer or fractional number literal.
-    pub const Num = union(enum) {
-        Int: Int,
-        Float: Float,
-    };
+/// An integer or fractional number literal.
+pub const NumLiteral = union(enum) {
+    Int: IntLiteral,
+    Float: FloatLiteral,
 };

--- a/src/build/lift_functions/IR.zig
+++ b/src/build/lift_functions/IR.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
 const base = @import("../../base.zig");
-const types = @import("../../types.zig");
+const types_module = @import("../../types.zig");
 const problem = @import("../../problem.zig");
 const collections = @import("../../collections.zig");
 
@@ -52,7 +52,7 @@ pub fn deinit(self: *Self) void {
 
 /// todo
 pub const Type = union(enum) {
-    primitive: types.Primitive,
+    primitive: types_module.Primitive,
     box: Type.Idx,
     list: Type.Idx,
     @"struct": Type.NonEmptySlice,

--- a/src/build/specialize_functions/IR.zig
+++ b/src/build/specialize_functions/IR.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
 const base = @import("../../base.zig");
-const types = @import("../../types.zig");
+const types_module = @import("../../types.zig");
 const problem = @import("../../problem.zig");
 const collections = @import("../../collections.zig");
 
@@ -52,7 +52,7 @@ pub fn deinit(self: *Self) void {
 
 /// todo
 pub const Type = union(enum) {
-    primitive: types.Primitive,
+    primitive: types_module.Primitive,
     box: Type.Idx,
     list: Type.Idx,
     @"struct": Type.NonEmptySlice,

--- a/src/build/specialize_types/IR.zig
+++ b/src/build/specialize_types/IR.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
 const base = @import("../../base.zig");
-const types = @import("../../types.zig");
+const types_module = @import("../../types.zig");
 const problem = @import("../../problem.zig");
 const collections = @import("../../collections.zig");
 
@@ -52,7 +52,7 @@ pub fn deinit(self: *Self) void {
 
 /// todo
 pub const Type = union(enum) {
-    primitive: types.Primitive,
+    primitive: types_module.Primitive,
     box: Type.Idx,
     list: Type.Idx,
     @"struct": Type.NonEmptySlice,

--- a/src/check/canonicalize/Scope.zig
+++ b/src/check/canonicalize/Scope.zig
@@ -214,7 +214,7 @@ pub const Levels = struct {
         scope_item: Level.Item(item_kind),
     ) Level.Item(item_kind) {
         if (self.contains(item_kind, scope_item.scope_name)) |item_in_scope| {
-            const can_problem = switch (item_kind) {
+            const can_problem: Problem.Canonicalize = switch (item_kind) {
                 .ident => .{ .IdentAlreadyInScope = .{
                     .original_ident = item_in_scope.scope_name,
                     .shadow = scope_item.scope_name,

--- a/src/check/parse/IR.zig
+++ b/src/check/parse/IR.zig
@@ -1500,10 +1500,9 @@ pub const NodeStore = struct {
                 } };
             },
             .ty_fn => {
-                const ret = .{ .id = store.extra_data.items[@as(usize, @intCast(node.main_token))] };
                 return .{ .@"fn" = .{
                     .region = emptyRegion(),
-                    .ret = ret,
+                    .ret = .{ .id = store.extra_data.items[@as(usize, @intCast(node.main_token))] },
                     .args = .{ .span = .{
                         .start = node.data.lhs,
                         .len = node.data.rhs,

--- a/src/check/parse/Parser.zig
+++ b/src/check/parse/Parser.zig
@@ -862,11 +862,10 @@ pub fn parseExprWithBp(self: *Parser, min_bp: u8) IR.NodeStore.ExprIdx {
 
                 const statements = self.store.statementSpanFrom(scratch_top);
 
-                const body = .{
+                expr = self.store.addExpr(.{ .block = .{
                     .statements = statements,
                     .region = .{ .start = start, .end = self.pos },
-                };
-                expr = self.store.addExpr(.{ .block = body });
+                } });
             }
         },
         .OpBar => {

--- a/src/check/parse/tokenize.zig
+++ b/src/check/parse/tokenize.zig
@@ -801,13 +801,13 @@ pub const Tokenizer = struct {
 
     fn consumeBraceCloseAndContinueStringInterp(self: *Tokenizer, brace: BraceKind) void {
         std.debug.assert(self.cursor.peek() == close_curly or self.cursor.peek() == ']' or self.cursor.peek() == ')');
-        if (self.stack.items.len == 0) {
+        const last = self.stack.pop();
+        if (last == null) {
             self.cursor.pushMessageHere(.OverClosedBrace);
             self.cursor.pos += 1;
             return;
         }
-        const last = self.stack.pop();
-        switch (last) {
+        switch (last.?) {
             .round => {
                 if (brace != .round) {
                     self.cursor.pushMessageHere(.MismatchedBrace);

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -113,7 +113,7 @@ fn splitArgs(allocator: std.mem.Allocator, str: []const u8) ![]const []const u8 
     var args = std.ArrayList([]const u8).init(allocator);
     errdefer args.deinit();
 
-    var iter = std.mem.split(u8, str, " ");
+    var iter = std.mem.splitScalar(u8, str, ' ');
     while (iter.next()) |arg| {
         if (arg.len > 0) {
             try args.append(arg);

--- a/src/coordinate.zig
+++ b/src/coordinate.zig
@@ -327,7 +327,7 @@ fn discoverModulesStartingFromEntry(
         gpa,
     )) |err| return .{ .err = .{ .parse_deps = err } };
 
-    while (desired_dep_queue.popOrNull()) |next_dep| {
+    while (desired_dep_queue.pop()) |next_dep| {
         const dep_package_idx = if (package_store.findWithUrl(next_dep.url)) |dep_idx|
             dep_idx
         else blk: {

--- a/src/coordinate/Filesystem.zig
+++ b/src/coordinate/Filesystem.zig
@@ -22,12 +22,12 @@ canonicalize: *const fn (relative_path: []const u8, allocator: Allocator) Canoni
 /// Get the default filesystem manager.
 pub fn default() Self {
     return Self{
-        .fileExists = &fileExists,
-        .readFile = &readFile,
-        .openDir = &openDir,
-        .dirName = &dirName,
-        .baseName = &baseName,
-        .canonicalize = &canonicalize,
+        .fileExists = &fileExistsDefault,
+        .readFile = &readFileDefault,
+        .openDir = &openDirDefault,
+        .dirName = &dirNameDefault,
+        .baseName = &baseNameDefault,
+        .canonicalize = &canonicalizeDefault,
     };
 }
 
@@ -121,7 +121,7 @@ pub const Dir = struct {
     }
 };
 
-fn fileExists(absolute_path: []const u8) OpenError!bool {
+fn fileExistsDefault(absolute_path: []const u8) OpenError!bool {
     std.fs.accessAbsolute(absolute_path, .{}) catch |err| {
         switch (err) {
             error.FileNotFound => return false,
@@ -133,7 +133,7 @@ fn fileExists(absolute_path: []const u8) OpenError!bool {
 }
 
 /// Reads the contents of a file at the given relative path.
-fn readFile(relative_path: []const u8, allocator: std.mem.Allocator) ReadError![]const u8 {
+fn readFileDefault(relative_path: []const u8, allocator: std.mem.Allocator) ReadError![]const u8 {
     const file = try std.fs.cwd().openFile(relative_path, .{});
     defer file.close();
 
@@ -143,7 +143,7 @@ fn readFile(relative_path: []const u8, allocator: std.mem.Allocator) ReadError![
     return contents;
 }
 
-fn openDir(absolute_path: []const u8) OpenError!Dir {
+fn openDirDefault(absolute_path: []const u8) OpenError!Dir {
     const dir = std.fs.openDirAbsolute(absolute_path, Dir.openOptions) catch |err| {
         return switch (err) {
             error.FileNotFound => error.FileNotFound,
@@ -154,15 +154,15 @@ fn openDir(absolute_path: []const u8) OpenError!Dir {
     return Dir{ .dir = dir };
 }
 
-fn dirName(absolute_path: []const u8) ?[]const u8 {
+fn dirNameDefault(absolute_path: []const u8) ?[]const u8 {
     return std.fs.path.dirname(absolute_path);
 }
 
-fn baseName(absolute_path: []const u8) ?[]const u8 {
+fn baseNameDefault(absolute_path: []const u8) ?[]const u8 {
     return std.fs.path.basename(absolute_path);
 }
 
-fn canonicalize(root_relative_path: []const u8, allocator: Allocator) CanonicalizeError![]const u8 {
+fn canonicalizeDefault(root_relative_path: []const u8, allocator: Allocator) CanonicalizeError![]const u8 {
     return std.fs.realpathAlloc(allocator, root_relative_path) catch |err| {
         return switch (err) {
             error.FileNotFound => error.FileNotFound,

--- a/src/coordinate/ModuleGraph.zig
+++ b/src/coordinate/ModuleGraph.zig
@@ -285,7 +285,9 @@ fn sccRecurseIntoGraph(
         var scc = std.ArrayList(usize).init(self.gpa);
 
         while (true) {
-            const scc_item = stack.pop();
+            // Current must be on the stack.
+            // We are guaranteed to find it before emptying the stack.
+            const scc_item = stack.pop() orelse unreachable;
             all_attributes[scc_item].on_stack = false;
             scc.append(scc_item) catch |err| exitOnOom(err);
 

--- a/src/fuzz-parse.zig
+++ b/src/fuzz-parse.zig
@@ -34,16 +34,16 @@ pub fn zig_fuzz_test_inner(buf: [*]u8, len: isize, debug: bool) void {
 
     const result = fmt.moduleFmtsStable(gpa, input, debug) catch |err|
         switch (err) {
-        error.ParseFailed => {
-            // No issue. Just bad input we couldn't parse.
-            return;
-        },
-        error.SecondParseFailed => {
-            @panic("Parsing of formatter output failed");
-        },
-        error.FormattingNotStable => {
-            @panic("Formatting not stable");
-        },
-    };
+            error.ParseFailed => {
+                // No issue. Just bad input we couldn't parse.
+                return;
+            },
+            error.SecondParseFailed => {
+                @panic("Parsing of formatter output failed");
+            },
+            error.FormattingNotStable => {
+                @panic("Formatting not stable");
+            },
+        };
     gpa.free(result);
 }

--- a/src/snapshot.zig
+++ b/src/snapshot.zig
@@ -6,7 +6,7 @@ const parse = @import("check/parse.zig");
 const fmt = @import("fmt.zig");
 
 var verbose_log: bool = false;
-var prng = std.rand.DefaultPrng.init(1234567890);
+var prng = std.Random.DefaultPrng.init(1234567890);
 
 const rand = prng.random();
 

--- a/src/types.zig
+++ b/src/types.zig
@@ -12,31 +12,31 @@ pub const Primitive = union(enum) {
     Bool,
     Str,
     Crash,
+};
 
-    /// todo
-    pub const Int = enum {
-        U8,
-        I8,
-        U16,
-        I16,
-        U32,
-        I32,
-        U64,
-        I64,
-        U128,
-        I128,
-    };
-    /// todo
-    pub const Float = enum {
-        F32,
-        F64,
-        Dec,
-    };
-    /// todo
-    pub const Num = union(enum) {
-        Int: Int,
-        Float: Float,
-    };
+/// todo
+pub const Int = enum {
+    U8,
+    I8,
+    U16,
+    I16,
+    U32,
+    I32,
+    U64,
+    I64,
+    U128,
+    I128,
+};
+/// todo
+pub const Float = enum {
+    F32,
+    F64,
+    Dec,
+};
+/// todo
+pub const Num = union(enum) {
+    Int: Int,
+    Float: Float,
 };
 
 /// Marks whether a when branch is redundant using a variable.


### PR DESCRIPTION
Note, this is still using stale llvm. But that doesn't actually matter:
1. We don't actually use llvm yet
2. Due to eventually generating bitcode directly, llvm version is not strictly tied to zig.

Will update llvm version in a follow up. Just waiting on https://github.com/ziglang/zig-bootstrap to update to 0.14.0 (I could do it, but as mentioned above, no rush)