### PR TITLE
[parser] crash instead of hang

### DIFF
--- a/src/check/parse/Parser.zig
+++ b/src/check/parse/Parser.zig
@@ -948,6 +948,7 @@ pub fn parseExprWithBp(self: *Parser, min_bp: u8) IR.NodeStore.ExprIdx {
         while (self.peek() == .NoSpaceDotInt or self.peek() == .NoSpaceDotLowerIdent) {
             const tok = self.peek();
             if (tok == .NoSpaceDotInt) { // NoSpaceDotInt
+                std.debug.panic("TODO: Handle NoSpaceDotInt case", .{});
             } else { // NoSpaceDotLowerIdent
                 const s = self.pos;
                 const ident = self.store.addExpr(.{ .ident = .{


### PR DESCRIPTION
This is another case where the parser hangs.
Convert it to a crash instead.

repro: `zig build repro-parse -- -b cC4w -v`
text: `p.0`