### PR TITLE
Remove `||` and `&&` from tokenizer

### DIFF
--- a/src/check/parse/tokenize.zig
+++ b/src/check/parse/tokenize.zig
@@ -954,13 +954,8 @@ pub const Tokenizer = struct {
 
                 // Ampersand (&)
                 '&' => {
-                    if (self.cursor.peekAt(1) == '&') {
-                        self.cursor.pos += 2;
-                        self.output.pushTokenNormal(.OpAnd, start, 2);
-                    } else {
-                        self.cursor.pos += 1;
-                        self.output.pushTokenNormal(.OpAmpersand, start, 1);
-                    }
+                    self.cursor.pos += 1;
+                    self.output.pushTokenNormal(.OpAmpersand, start, 1);
                 },
 
                 // Comma (,)
@@ -982,10 +977,7 @@ pub const Tokenizer = struct {
 
                 // Pipe (|)
                 '|' => {
-                    if (self.cursor.peekAt(1) == '|') {
-                        self.cursor.pos += 2;
-                        self.output.pushTokenNormal(.OpOr, start, 2);
-                    } else if (self.cursor.peekAt(1) == '>') {
+                    if (self.cursor.peekAt(1) == '>') {
                         self.cursor.pos += 2;
                         self.output.pushTokenNormal(.OpPizza, start, 2);
                     } else {
@@ -1620,15 +1612,10 @@ fn rebuildBufferForTesting(buf: []const u8, tokens: *TokenizedBuffer, alloc: std
                 try buf2.append(alloc, '!');
             },
             .OpAnd => {
-                std.debug.assert(length == 2 or length == 3);
-                if (length == 2) {
-                    try buf2.append(alloc, '&');
-                    try buf2.append(alloc, '&');
-                } else {
-                    try buf2.append(alloc, 'a');
-                    try buf2.append(alloc, 'n');
-                    try buf2.append(alloc, 'd');
-                }
+                std.debug.assert(length == 3);
+                try buf2.append(alloc, 'a');
+                try buf2.append(alloc, 'n');
+                try buf2.append(alloc, 'd');
             },
             .OpAmpersand => {
                 std.debug.assert(length == 1);
@@ -1645,13 +1632,8 @@ fn rebuildBufferForTesting(buf: []const u8, tokens: *TokenizedBuffer, alloc: std
             },
             .OpOr => {
                 std.debug.assert(length == 2);
-                if (buf[token.offset] == 'o') {
-                    try buf2.append(alloc, 'o');
-                    try buf2.append(alloc, 'r');
-                } else {
-                    try buf2.append(alloc, '|');
-                    try buf2.append(alloc, '|');
-                }
+                try buf2.append(alloc, 'o');
+                try buf2.append(alloc, 'r');
             },
             .OpBar => {
                 std.debug.assert(length == 1);


### PR DESCRIPTION
As discussed here: https://roc.zulipchat.com/#narrow/channel/395097-compiler-development/topic/zig.20compiler.20-.20spike/near/504579627

I assume in the long term, support will be added to the parser to notice when double opBar or opAmpersand should be consider an `and` or `or`. Then the formatter will fix things up.

For now, double bar is always a lambda and double ampersand is invalid.