### PR TITLE
Have zig directly generating fuzzing instrumentation

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -141,13 +141,9 @@ fn add_fuzz_target(
         .name = b.fmt("{s}_obj", .{name}),
         .root_source_file = root_source_file,
         .target = target,
-        .optimize = .ReleaseSafe,
+        // Work around instrumentation bugs on mac without giving up perf on linux.
+        .optimize = if (target.result.os.tag == .macos) .Debug else .ReleaseSafe,
     });
-
-    // TODO: look into enabling this, I think it may only work on linux for 0.14.0
-    // fuzz_obj.root_module.fuzz = true;
-    fuzz_obj.root_module.stack_check = false; // not linking with compiler-rt
-    fuzz_obj.root_module.link_libc = true; // afl runtime depends on libc
 
     const name_exe = b.fmt("fuzz-{s}", .{name});
     const name_repro = b.fmt("repro-{s}", .{name});

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -4,8 +4,8 @@
     .minimum_zig_version = "0.14.0",
     .dependencies = .{
         .afl_kit = .{
-            .url = "git+https://github.com/bhansconnect/zig-afl-kit?ref=zig-0.14.0#323ec465fe33f0e4820648e713b70ffc494fb0c6",
-            .hash = "afl_kit-0.1.0-uhOgGDQdAADv-nfytsC3tGTQMfaG11pR-NV87LKev3H8",
+            .url = "git+https://github.com/bhansconnect/zig-afl-kit?ref=zig-0.14.0#9f09f8e5c29102b94d775305801315320515a2b8",
+            .hash = "afl_kit-0.1.0-uhOgGEEbAADSSVtFLWc0eoZFxVLiELWLNldB9K_f9x5L",
             .lazy = true,
         },
         .roc_deps_aarch64_macos_none = .{


### PR DESCRIPTION
Fixes fuzzing on macos.
Since 0.14.0, macos fuzzing has not been coverage guided. It has just been random.