### PR TITLE
[Tokenizer] create malformed nodes for numbers with no digits

### DIFF
--- a/src/snapshots/fuzz_crash/fuzz_crash_014.txt
+++ b/src/snapshots/fuzz_crash/fuzz_crash_014.txt
@@ -1,0 +1,24 @@
+~~~META
+description=fuzz crash
+~~~SOURCE
+0b.0
+0bu22
+0u22
+~~~PROBLEMS
+PARSER: missing_header
+PARSER: unexpected_token
+PARSER: unexpected_token
+PARSER: unexpected_token
+~~~TOKENS
+MalformedNumberNoDigits,NoSpaceDotInt,Newline,MalformedNumberNoDigits,Newline,MalformedNumberBadSuffix,EndOfFile
+~~~PARSE
+(file (1:1-3:5)
+    (malformed_header "missing_header")
+    (malformed_expr "unexpected_token")
+    (malformed_expr "unexpected_token")
+    (malformed_expr "unexpected_token"))
+~~~FORMATTED
+
+
+
+~~~END


### PR DESCRIPTION
Minor tokenizer cleanup to deal with cases where there are no digits in a number. For example `0b` is invalid without `0b010`. It is required that the prefix be followed by at least one digit. Same with exponents. `7e` is invalid without `7e22`.

Also moved a few functions under `Token.Tag` so that they can be used directly (ex. `token.tag.isKeyword()`)