### PR TITLE
[tokenizer] fix int printing

### DIFF
--- a/src/snapshots/fuzz_crash/fuzz_crash_015.txt
+++ b/src/snapshots/fuzz_crash/fuzz_crash_015.txt
@@ -1,0 +1,30 @@
+~~~META
+description=fuzz crash
+~~~SOURCE
+0o0.0
+0_0
+0u8.0
+0_
+~~~PROBLEMS
+TOKENIZE: (2:3-2:3) LeadingZero:
+0_0
+  ^
+PARSER: missing_header
+PARSER: unexpected_token
+PARSER: expr_no_space_dot_int
+~~~TOKENS
+Int,NoSpaceDotInt,Newline,Int,Newline,Int,NoSpaceDotInt,Newline,Int,EndOfFile
+~~~PARSE
+(file (1:1-4:3)
+    (malformed_header "missing_header")
+    (malformed_expr "unexpected_token")
+    (int (2:1-2:4) "0_0")
+    (malformed_expr "expr_no_space_dot_int")
+    (int (4:1-4:3) "0_"))
+~~~FORMATTED
+
+0_0
+
+
+0_
+~~~END


### PR DESCRIPTION
With the old printing, ints would sometimes turn into floats after print. For example `0o0.0` would reprint as `111.1`.
Instead, for any int 3 characters or longer, we always print with the base. This ensures it will tokenize as an int and only an int. The reprint above becomes `0x0.0` which tokenizes the same.

All 1 and 2 character ints should still be fine.
They are guaranteed to only be numbers or to already be invalid. `0b` is invalid due to missing the digits.

Also adds a handful of doc comments.