### PR TITLE
[parser] Fix crash found by fuzzer

### DIFF
--- a/src/check/parse/Parser.zig
+++ b/src/check/parse/Parser.zig
@@ -179,7 +179,7 @@ fn parseCollection(self: *Parser, comptime T: type, end_token: Token.Tag, scratc
 ///
 /// Returns the ending position of the collection
 fn parseCollectionSpan(self: *Parser, comptime T: type, end_token: Token.Tag, scratch_fn: fn (*IR.NodeStore, T) void, parser: fn (*Parser) T) ExpectError!u32 {
-    while (self.peek() != end_token) {
+    while (self.peek() != end_token and self.peek() != .EndOfFile) {
         scratch_fn(&self.store, parser(self));
         self.expect(.Comma) catch {
             break;

--- a/src/snapshots/fuzz_crash/fuzz_crash_016.txt
+++ b/src/snapshots/fuzz_crash/fuzz_crash_016.txt
@@ -1,0 +1,16 @@
+~~~META
+description=fuzz crash
+~~~SOURCE
+0|
+~~~PROBLEMS
+PARSER: missing_header
+PARSER: unexpected_token
+~~~TOKENS
+Int,OpBar,EndOfFile
+~~~PARSE
+(file (1:1-1:3)
+    (malformed_header "missing_header")
+    (malformed_expr "unexpected_token"))
+~~~FORMATTED
+
+~~~END


### PR DESCRIPTION
Missed stopping on EndOfFile.
Leads to running a function expecting valid input and crashing.