### PR TITLE
Enable incremental compilation

### DIFF
--- a/.github/workflows/ci_zig.yml
+++ b/.github/workflows/ci_zig.yml
@@ -23,7 +23,7 @@ jobs:
               run: |
                 # -Dllvm incurs a costly download step, leave that for later.
                 # Just the do super fast check step for now.
-                zig build check -Dfuzz
+                zig build -Dno-bin -Dfuzz
 
     zig-tests:
         needs: check-zig

--- a/.gitignore
+++ b/.gitignore
@@ -25,9 +25,6 @@
 target
 generated-docs
 
-# todo remove after upgrade to zig 0.13.0
-zig-cache
-
 zig-out
 .zig-cache
 .direnv

--- a/src/README.md
+++ b/src/README.md
@@ -21,3 +21,36 @@ This table provides a summary of progress for the zig compiler re-write and shou
 - 🚧    Work Started
 - 🪫    Tests Passing
 - 🔋    Polished
+
+## Fast Feedback Loop
+
+The roc zig compiler can have a very fast feedback loop. We support zigs incremental compilation and watch mode.
+By avoiding generating final executables, we can build and typecheck much much faster.
+
+Try it with `zig build -Dno-bin -fincremental --watch`
+
+### Expanding to ZLS
+
+This fast config can also be used with `zls`. Simply follow these steps:
+1. run `zls --version` and make sure it is `0.14.0`.
+2. run `zls env` and grab the `config_file` path.
+3. Edit the config file to include
+```json
+{
+  "enable_build_on_save": true,
+  "build_on_save_args": ["-Dno-bin", "-fincremental"]
+}
+```
+4. Advised, also changing the cache dir, I use `--cache-dir .zig-cache/zls`.
+Otherwise, zig commands run manually can lead to the lsp breaking and requiring a restart.
+5. Optionally, add `-Dfuzz` above as well to get type checking of fuzz scripts as well.
+6. Note, I had to fully delete my `.zig-cache` to get `zls` to start.
+Make sure to check the logs if you aren't geting type failures.
+7. Enjoy better lsp results.
+
+### Simply testing feedback loop
+
+Sadly, this is not nearly as fast due to building binaries.
+One day, we will get dev zig backends, and it should be fast.
+
+Try it with `zig build test -fincremental --watch`


### PR DESCRIPTION
This gets us incremental compilation and a fast feedback loop. Instead of a `check` step, this depends on `-Dno-bin`.

Note, we should look into [per-build config](https://zigtools.org/zls/configure/per-build/) and switching back to simply `check` at some point. Currently that doesn't seem to play nice with `-fincremental`.