### PR TITLE
Add default capacities

### DIFF
--- a/src/base/Ident.zig
+++ b/src/base/Ident.zig
@@ -62,6 +62,15 @@ pub const Store = struct {
     attributes: std.ArrayListUnmanaged(Attributes) = .{},
     next_unique_name: u32 = 0,
 
+    /// Initialize the memory for an `Ident.Store` with a specific capaicty.
+    pub fn initCapacity(gpa: std.mem.Allocator, capacity: usize) Store {
+        return .{
+            .interner = SmallStringInterner.initCapacity(gpa, capacity),
+            .exposing_modules = std.ArrayListUnmanaged(ModuleImport.Idx).initCapacity(gpa, capacity) catch |err| exitOnOom(err),
+            .attributes = std.ArrayListUnmanaged(Attributes).initCapacity(gpa, capacity) catch |err| exitOnOom(err),
+        };
+    }
+
     /// Deinitialize the memory for an `Ident.Store`.
     pub fn deinit(self: *Store, gpa: std.mem.Allocator) void {
         self.interner.deinit(gpa);

--- a/src/base/ModuleEnv.zig
+++ b/src/base/ModuleEnv.zig
@@ -25,12 +25,13 @@ problems: Problem.List,
 
 /// Initialize the module environment.
 pub fn init(gpa: std.mem.Allocator) Self {
+    // TODO: maybe wire in smarter default based on the initial input text size.
     return Self{
         .gpa = gpa,
-        .idents = .{},
-        .ident_ids_for_slicing = .{},
-        .strings = .{},
-        .problems = .{},
+        .idents = Ident.Store.initCapacity(gpa, 256),
+        .ident_ids_for_slicing = collections.SafeList(Ident.Idx).initCapacity(gpa, 64),
+        .strings = StringLiteral.Store.initCapacityBytes(gpa, 256),
+        .problems = Problem.List.initCapacity(gpa, 16),
     };
 }
 

--- a/src/base/StringLiteral.zig
+++ b/src/base/StringLiteral.zig
@@ -33,6 +33,13 @@ pub const Store = struct {
     /// continues to the previous byte
     buffer: std.ArrayListUnmanaged(u8) = .{},
 
+    /// Intiizalizes a `StringLiteral.Store` with capacity `bytes` of space.
+    pub fn initCapacityBytes(gpa: std.mem.Allocator, bytes: usize) Store {
+        return .{
+            .buffer = std.ArrayListUnmanaged(u8).initCapacity(gpa, bytes) catch |err| exitOnOom(err),
+        };
+    }
+
     /// Deinitialize a `StringLiteral.Store`'s memory.
     pub fn deinit(self: *Store, gpa: std.mem.Allocator) void {
         self.buffer.deinit(gpa);

--- a/src/check/parse/Parser.zig
+++ b/src/check/parse/Parser.zig
@@ -24,7 +24,7 @@ diagnostics: std.ArrayListUnmanaged(IR.Diagnostic),
 /// init the parser from a buffer of tokens
 pub fn init(tokens: TokenizedBuffer) Parser {
     const estimated_node_count = (tokens.tokens.len + 2) / 2;
-    const store = IR.NodeStore.initWithCapacity(tokens.env.gpa, estimated_node_count);
+    const store = IR.NodeStore.initCapacity(tokens.env.gpa, estimated_node_count);
 
     return Parser{
         .gpa = tokens.env.gpa,

--- a/src/collections/safe_list.zig
+++ b/src/collections/safe_list.zig
@@ -49,6 +49,13 @@ pub fn SafeList(comptime T: type) type {
             }
         };
 
+        /// Intialize the `SafeList` with the specified capacity.
+        pub fn initCapacity(gpa: Allocator, capacity: usize) SafeList(T) {
+            return .{
+                .items = std.ArrayListUnmanaged(T).initCapacity(gpa, capacity) catch |err| exitOnOom(err),
+            };
+        }
+
         /// Deinitialize the memory of this `SafeList`.
         pub fn deinit(self: *SafeList(T), gpa: Allocator) void {
             self.items.deinit(gpa);
@@ -161,6 +168,15 @@ pub fn SafeMultiList(comptime T: type) type {
         /// The value for a specific field at a specific index in the list.
         pub fn fieldItem(self: *const SafeMultiList(T), comptime field_name: Field, idx: Idx) type {
             return self.items.items(field_name)[@as(usize, @intFromEnum(idx))];
+        }
+
+        /// Intialize the `SafeMultiList` with the specified capacity.
+        pub fn initCapacity(gpa: Allocator, capacity: usize) SafeMultiList(T) {
+            var items = std.MultiArrayList(T){};
+            items.ensureTotalCapacity(gpa, capacity) catch |err| exitOnOom(err);
+            return .{
+                .items = items,
+            };
         }
 
         /// Deinitialize the memory of a `SafeMultiList`.


### PR DESCRIPTION
Switches over to using `initCapacity` for many types. Likely in the long term, everything should always use `initCapacity`. The sizes are all guesses currently, but they have meaningful performance impacts for limitted overhead. Once we have a larger corpus, would be great to tune.

This is another 5-10% perf gain on top of everything else.