### PR TITLE
[tracy] wait for shutdown

### DIFF
--- a/src/README.profiling.md
+++ b/src/README.profiling.md
@@ -80,11 +80,9 @@ Often times, it is worth profiling once with `-Dtracy-callstack=false` to have m
 Now that I have the compiler built with tracy, I can launch the tracy server on my mac machine to record the result (you can also run it on the same machine if wanted).
 Run `tracy-profiler`, input the correct ip address, and press connect.
 Then run the instrumented version of zig: `./zig-out/bin/roc format /tmp/new.roc`.
-For best results `export TRACY_NO_EXIT=1` before running. This ensures that all tracing data is uploaded before roc exits.
 Also, run with the root user to capture more information.
 In this case, I ran:
 ```
-export TRACY_NO_EXIT=1
 sudo ./zig-out/bin/roc format /tmp/new.roc
 ```
 

--- a/src/base/StringLiteral.zig
+++ b/src/base/StringLiteral.zig
@@ -34,6 +34,8 @@ pub const Store = struct {
     buffer: std.ArrayListUnmanaged(u8) = .{},
 
     /// Intiizalizes a `StringLiteral.Store` with capacity `bytes` of space.
+    /// Note this specifically is the number of bytes for storing strings.
+    /// The string `hello, world!` will use 14 bytes including the null terminator.
     pub fn initCapacityBytes(gpa: std.mem.Allocator, bytes: usize) Store {
         return .{
             .buffer = std.ArrayListUnmanaged(u8).initCapacity(gpa, bytes) catch |err| exitOnOom(err),

--- a/src/collections/utils.zig
+++ b/src/collections/utils.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const tracy = @import("../tracy.zig");
 
 /// Exit the current process when we hit an out-of-memory error.
 ///
@@ -21,5 +22,8 @@ pub fn exitOnOom(err: std.mem.Allocator.Error) noreturn {
 /// Log a fatal error and exit the process with a non-zero code.
 pub fn fatal(comptime format: []const u8, args: anytype) noreturn {
     std.io.getStdErr().writer().print(format, args) catch unreachable;
+    if (tracy.enable) {
+        tracy.waitForShutdown() catch unreachable;
+    }
     std.process.exit(1);
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -52,7 +52,12 @@ pub fn main() !void {
     const arena = arena_impl.allocator();
 
     const args = try std.process.argsAlloc(arena);
-    return mainArgs(gpa, arena, args);
+
+    const result = mainArgs(gpa, arena, args);
+    if (tracy.enable) {
+        try tracy.waitForShutdown();
+    }
+    return result;
 }
 
 fn mainArgs(gpa: Allocator, arena: Allocator, args: []const []const u8) !void {

--- a/src/tracy-shutdown.cpp
+++ b/src/tracy-shutdown.cpp
@@ -1,0 +1,11 @@
+#include <chrono>
+#include <thread>
+
+#include "public/client/TracyProfiler.hpp"
+
+extern "C" void ___tracy_wait_shutdown(void) {
+  tracy::GetProfiler().RequestShutdown();
+  while(!tracy::GetProfiler().HasShutdownFinished()) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  };
+}

--- a/src/tracy.zig
+++ b/src/tracy.zig
@@ -353,6 +353,7 @@ extern fn ___tracy_emit_messageLC(txt: [*:0]const u8, color: u32, callstack: c_i
 extern fn ___tracy_emit_frame_mark(name: ?[*:0]const u8) void;
 extern fn ___tracy_wait_shutdown() void;
 
+/// Wait for the tracy profiler to fully shutdown and finish syncing data.
 pub fn waitForShutdown() !void {
     if (!enable) return;
 

--- a/src/tracy.zig
+++ b/src/tracy.zig
@@ -351,6 +351,14 @@ extern fn ___tracy_emit_messageL(txt: [*:0]const u8, callstack: c_int) void;
 extern fn ___tracy_emit_messageC(txt: [*]const u8, size: usize, color: u32, callstack: c_int) void;
 extern fn ___tracy_emit_messageLC(txt: [*:0]const u8, color: u32, callstack: c_int) void;
 extern fn ___tracy_emit_frame_mark(name: ?[*:0]const u8) void;
+extern fn ___tracy_wait_shutdown() void;
+
+pub fn waitForShutdown() !void {
+    if (!enable) return;
+
+    try std.io.getStdErr().writeAll("Program ended, waiting for tracy to finish collecting data.\n");
+    ___tracy_wait_shutdown();
+}
 
 const ___tracy_source_location_data = extern struct {
     name: ?[*:0]const u8,


### PR DESCRIPTION
TRACY_NO_EXIT is used to force tracy to wait for the profiler to finish collecting data before shutting down. Sadly, it doesn't work on macos.

As a workaround, directly call into the tracy profiler on exit. Request shutdown (which will start flushing data) and wait for shutdown to complete. This makes the equivalent of TRACY_NO_EXIT the default.

Not, this only works on clean shutdown through `main` or `fatal`. Any other shutdown will miss this codepath and exit before tracy fully dumps data.