### PR TITLE
switch roc to atomic refcounts

### DIFF
--- a/crates/compiler/builtins/bitcode/src/utils.zig
+++ b/crates/compiler/builtins/bitcode/src/utils.zig
@@ -203,7 +203,7 @@ const Refcount = enum {
     atomic,
 };
 
-const RC_TYPE: Refcount = .normal;
+const RC_TYPE: Refcount = .atomic;
 
 pub fn increfRcPtrC(ptr_to_refcount: *isize, amount: isize) callconv(.C) void {
     if (RC_TYPE == .none) return;

--- a/crates/compiler/builtins/bitcode/src/utils.zig
+++ b/crates/compiler/builtins/bitcode/src/utils.zig
@@ -179,10 +179,6 @@ pub const IncN = fn (?[*]u8, u64) callconv(.C) void;
 pub const Dec = fn (?[*]u8) callconv(.C) void;
 
 const REFCOUNT_MAX_ISIZE: isize = 0;
-// Only top bit set.
-const REFCOUNT_IS_ATOMIC_MASK: isize = std.math.minInt(isize);
-// All other bits of the refcount.
-const REFCOUNT_VALUE_MASK = ~REFCOUNT_IS_ATOMIC_MASK;
 
 pub const IntWidth = enum(u8) {
     U8 = 0,
@@ -229,12 +225,7 @@ pub fn increfRcPtrC(ptr_to_refcount: *isize, amount: isize) callconv(.C) void {
                 ptr_to_refcount.* = refcount +% amount;
             },
             .atomic => {
-                // If the first bit of the refcount is set, this variable is atomic.
-                if (refcount & REFCOUNT_IS_ATOMIC_MASK != 0) {
-                    _ = @atomicRmw(isize, ptr_to_refcount, .Add, amount, .monotonic);
-                } else {
-                    ptr_to_refcount.* = refcount +% amount;
-                }
+                _ = @atomicRmw(isize, ptr_to_refcount, .Add, amount, .monotonic);
             },
             .none => unreachable,
         }
@@ -393,17 +384,9 @@ inline fn decref_ptr_to_refcount(
                 }
             },
             .atomic => {
-                // If the first bit of the refcount is set, this variable is atomic.
-                if (refcount_ptr[0] & REFCOUNT_IS_ATOMIC_MASK != 0) {
-                    const last = @atomicRmw(isize, &refcount_ptr[0], .Sub, 1, .monotonic);
-                    if (last & REFCOUNT_VALUE_MASK == 1) {
-                        free_ptr_to_refcount(refcount_ptr, alignment, elements_refcounted);
-                    }
-                } else {
-                    refcount_ptr[0] = refcount -% 1;
-                    if (refcount == 1) {
-                        free_ptr_to_refcount(refcount_ptr, alignment, elements_refcounted);
-                    }
+                const last = @atomicRmw(isize, &refcount_ptr[0], .Sub, 1, .monotonic);
+                if (last == 1) {
+                    free_ptr_to_refcount(refcount_ptr, alignment, elements_refcounted);
                 }
             },
             .none => unreachable,
@@ -437,7 +420,7 @@ pub inline fn rcUnique(refcount: isize) bool {
             return refcount == 1;
         },
         .atomic => {
-            return refcount & REFCOUNT_VALUE_MASK == 1;
+            return refcount == 1;
         },
         .none => {
             return false;
@@ -451,7 +434,7 @@ pub inline fn rcConstant(refcount: isize) bool {
             return refcount == REFCOUNT_MAX_ISIZE;
         },
         .atomic => {
-            return refcount & REFCOUNT_VALUE_MASK == REFCOUNT_MAX_ISIZE & REFCOUNT_VALUE_MASK;
+            return refcount == REFCOUNT_MAX_ISIZE;
         },
         .none => {
             return true;


### PR DESCRIPTION
This unlocks new use cases like multithreading. Hopefully can unblock background threads in basic webserver. Simplifies multithreaded use cases in general.

This is just direct use of atomic refcounting always. Surprisingly, atomtic refcounts are pretty fast and this generally is not a perf hit. That said, deeply nested tags (like cons lists) and other worst case scenarios can see major pain from this. Still like worth just tell people to avoid crazy data schemes with tons of pointer chasing. I would guess that most users won't really notice this except in very specific benchmarks. If this does lead to significant perf issue, we can roll back or look into a few other optimizations. This also is likely to disproportionately hurt older and lower power hardware.