### PR TITLE
README: link to rendered FAQs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 - [**tutorial**](https://roc-lang.org/tutorial)
 - [**docs** for the standard library](https://www.roc-lang.org/builtins)
 - [**examples**](https://www.roc-lang.org/examples)
-- [**faq**: frequently asked questions](https://github.com/roc-lang/roc/blob/main/www/content/faq.md)
+- [**faq**: frequently asked questions](https://www.roc-lang.org/faq)
 - [**group chat**](https://roc.zulipchat.com) for help, questions and discussions
 
 If you'd like to contribute, [get started here](CONTRIBUTING.md). Don't hesitate to ask for help on our [group chat](https://roc.zulipchat.com), we're friendly!


### PR DESCRIPTION
Heya! Just a tiny change in the README 😅 

Previously, this linked to the templated docs file on GitHub. I believe the website rendering is so much nicer and it's in line with what's done for other links.

Thanks for working on Roc, you all. Can't wait to use it some when I find a chance.