### PR TITLE
[zig] fix fuzz crash

### DIFF
--- a/src/check/parse/IR.zig
+++ b/src/check/parse/IR.zig
@@ -986,7 +986,6 @@ pub const NodeStore = struct {
                 node.region = u.region;
             },
             .alternatives => |a| {
-                std.debug.assert(a.patterns.span.len > 1);
                 node.region = a.region;
                 node.tag = .alternatives_patt;
                 node.data.lhs = a.patterns.span.start;

--- a/src/snapshots/fuzz_crash/fuzz_crash_018.txt
+++ b/src/snapshots/fuzz_crash/fuzz_crash_018.txt
@@ -1,0 +1,20 @@
+~~~META
+description=fuzz crash
+~~~SOURCE
+F ||(|(l888888888|
+~~~PROBLEMS
+PARSER: missing_header
+PARSER: pattern_unexpected_token
+PARSER: expected_expr_bar
+PARSER: expected_expr_close_round_or_comma
+~~~TOKENS
+UpperIdent(1:1-1:2),OpBar(1:3-1:4),OpBar(1:4-1:5),NoSpaceOpenRound(1:5-1:6),OpBar(1:6-1:7),NoSpaceOpenRound(1:7-1:8),LowerIdent(1:8-1:18),OpBar(1:18-1:19),EndOfFile(1:19-1:19),
+~~~PARSE
+(file
+    (malformed_header (1:1-1:2) "missing_header")
+    (lambda (1:3-1:19)
+        (args)
+        (malformed_expr (1:19-1:19) "expected_expr_close_round_or_comma")))
+~~~FORMATTED
+|| 
+~~~END


### PR DESCRIPTION
This debug assertion was causing the parser to crash. Removing it seems to resolve the issue. 

@gamebox does this look ok?

```
$ zig build snapshot -- src/snapshots/fuzz_crash/fuzz_crash_018.txt
thread 4022156 panic: reached unreachable code
/Users/luke/zig-macos-aarch64-0.14.0/lib/std/debug.zig:522:14: 0x104f47c93 in assert (snapshot)
    if (!ok) unreachable; // assertion failure
             ^
/Users/luke/Documents/GitHub/roc/src/check/parse/IR.zig:989:33: 0x10503eb3b in addPattern (snapshot)
                std.debug.assert(a.patterns.span.len > 1);
                                ^
/Users/luke/Documents/GitHub/roc/src/check/parse/Parser.zig:1177:33: 0x10506cb93 in parsePattern (snapshot)
    return self.store.addPattern(.{ .alternatives = .{
                                ^
/Users/luke/Documents/GitHub/roc/src/check/parse/Parser.zig:1187:29: 0x105084e73 in parsePatternWithAlts (snapshot)
    return self.parsePattern(.alternatives_allowed);

<snipped...>
```