### PR TITLE
Increase default capacities

### DIFF
--- a/src/base/ModuleEnv.zig
+++ b/src/base/ModuleEnv.zig
@@ -28,10 +28,10 @@ pub fn init(gpa: std.mem.Allocator) Self {
     // TODO: maybe wire in smarter default based on the initial input text size.
     return Self{
         .gpa = gpa,
-        .idents = Ident.Store.initCapacity(gpa, 256),
-        .ident_ids_for_slicing = collections.SafeList(Ident.Idx).initCapacity(gpa, 64),
-        .strings = StringLiteral.Store.initCapacityBytes(gpa, 256),
-        .problems = Problem.List.initCapacity(gpa, 16),
+        .idents = Ident.Store.initCapacity(gpa, 1024),
+        .ident_ids_for_slicing = collections.SafeList(Ident.Idx).initCapacity(gpa, 256),
+        .strings = StringLiteral.Store.initCapacityBytes(gpa, 4096),
+        .problems = Problem.List.initCapacity(gpa, 64),
     };
 }
 

--- a/src/check/parse/IR.zig
+++ b/src/check/parse/IR.zig
@@ -606,7 +606,7 @@ pub const NodeStore = struct {
     /// Initialize the store with an assumed capacity to
     /// ensure resizing of underlying data structures happens
     /// very rarely.
-    pub fn initWithCapacity(gpa: std.mem.Allocator, capacity: usize) NodeStore {
+    pub fn initCapacity(gpa: std.mem.Allocator, capacity: usize) NodeStore {
         var store: NodeStore = .{
             .gpa = gpa,
             .nodes = Node.List.initCapacity(gpa, capacity),
@@ -633,12 +633,8 @@ pub const NodeStore = struct {
         return store;
     }
 
-    // This value is based on some observed characteristics of Roc code.
-    // Having an initial capacity of 10 ensures that the scratch slice
-    // will only have to be resized in >90th percentile case.
-    // It is not scientific, and should be tuned when we have enough
-    // Roc code to instrument this and determine a real 90th percentile.
-    const scratch_90th_percentile_capacity = std.math.ceilPowerOfTwoAssert(usize, 10);
+    // TODO: tune this base on real roc code. In general, these arrays are all really small, so oversize it.
+    const scratch_90th_percentile_capacity = std.math.ceilPowerOfTwoAssert(usize, 64);
 
     /// Deinitializes all data owned by the store.
     /// A caller should ensure that they have taken

--- a/src/check/parse/Parser.zig
+++ b/src/check/parse/Parser.zig
@@ -23,8 +23,8 @@ diagnostics: std.ArrayListUnmanaged(IR.Diagnostic),
 
 /// init the parser from a buffer of tokens
 pub fn init(tokens: TokenizedBuffer) Parser {
-    const estimated_node_count = (tokens.tokens.len + 2) / 2;
-    const store = IR.NodeStore.initWithCapacity(tokens.env.gpa, estimated_node_count);
+    const estimated_node_count = tokens.tokens.len;
+    const store = IR.NodeStore.initCapacity(tokens.env.gpa, estimated_node_count);
 
     return Parser{
         .gpa = tokens.env.gpa,

--- a/src/check/parse/tokenize.zig
+++ b/src/check/parse/tokenize.zig
@@ -1024,7 +1024,7 @@ pub const Tokenizer = struct {
         const cursor = Cursor.init(text, messages);
         // TODO: tune this more. Syntax grab bag is 3:1.
         // Generally, roc code will be less dense than that.
-        const output = TokenizedBuffer.initCapacity(env, @max(text.len / 8, 64));
+        const output = TokenizedBuffer.initCapacity(env, text.len);
         return Tokenizer{
             .cursor = cursor,
             .output = output,


### PR DESCRIPTION
Based on a discussion with Richard (quite a while ago at this point), lets default to over-allocating our array sizes. This is in hopes that the normal flow never reallocates. We really don't use that much memory in total and this enables the compiler to see solid speed gains. Until we find a reason not to or get better heuristics, lets use memory to save time.

Also removes and extraneous debug print and updates one case of `initWithCapacity` to `initCapacity`