### PR TITLE
add diagnostic for nonprintable unicode in str literals

### DIFF
--- a/src/check/parse/tokenize.zig
+++ b/src/check/parse/tokenize.zig
@@ -482,6 +482,7 @@ pub const Diagnostic = struct {
         UnclosedSingleQuote,
         OverClosedBrace,
         MismatchedBrace,
+        NonPrintableUnicodeInStrLiteral,
     };
 
     pub fn toStr(self: Diagnostic, gpa: Allocator, source: []const u8, writer: anytype) !void {
@@ -1525,6 +1526,11 @@ pub const Tokenizer = struct {
                     return;
                 } else {
                     escape = c == '\\';
+
+                    if (!std.ascii.isPrint(c)) {
+                        self.cursor.pushMessageHere(.NonPrintableUnicodeInStrLiteral);
+                    }
+
                     self.cursor.pos += 1;
                 }
             }


### PR DESCRIPTION
resolves #6928

- Should it store some state while iterating through the characters, and combine multiple consecutive non-printable chars into a single diagnostic?
- Is there anything else I need to do to implement a new diagnostic type other than just adding a new enum variant?
- Are there any display concerns with pointing the diagnostic at solely non-printable chars? Are they escaped when displayed to the user? I wasn't able to figure out how the diagnostics get presented to the user, I just used the `repro-tokenize` binary to ensure that my diagnostic was received by the tokenizer.