### PR TITLE
Website Tutorial: add full, scrollable table of contents.

### DIFF
--- a/www/content/tutorial.md
+++ b/www/content/tutorial.md
@@ -3,14 +3,94 @@
     <label id="close-tutorial-toc" for="tutorial-toc-toggle">close</label>
     <!-- TODO fix search: input [id "toc-search", type "text", placeholder "Search"] [] -->
     <ol>
-    <li><a href="#repl">REPL</a></li>
-    <li><a href="#building-an-application">Building an Application</a></li>
-    <li><a href="#pattern-matching">Pattern Matching</a></li>
-    <li><a href="#types">Types</a></li>
-    <li><a href="#crashing">Crashing</a></li>
-    <li><a href="#testing">Testing</a></li>
-    <li><a href="#modules">Modules</a></li>
-    <li><a href="#advanced-concepts">Advanced Concepts</a></li>
+        <li class="tut-1"><a href="#ai-docs">AI Docs</a></li>
+        <li class="tut-1"><a href="#repl">REPL</a></li>
+        <li class="tut-2"><a href="#hello-world">Hello, World!</a></li>
+        <li class="tut-2"><a href="#naming-things">Naming Things</a></li>
+        <li class="tut-2"><a href="#arithmetic">Arithmetic</a></li>
+        <li class="tut-2"><a href="#calling-functions">Calling Functions</a></li>
+        <li class="tut-2"><a href="#string-interpolation">String Interpolation</a></li>
+        <li class="tut-1"><a href="#building-an-application">Building an Application</a></li>
+        <li class="tut-2"><a href="#defs">Defs</a></li>
+        <li class="tut-2"><a href="#defining-functions">Defining Functions</a></li>
+        <li class="tut-2"><a href="#if-then-else">`if`-`then`-`else` expressions</a></li>
+        <li class="tut-2"><a href="#else-if">`else if` expressions</a></li>
+        <li class="tut-2"><a href="#comments">Comments</a></li>
+        <li class="tut-2"><a href="#doc-comments">Doc Comments</a></li>
+        <li class="tut-2"><a href="#records">Records</a></li>
+        <li class="tut-2"><a href="#accepting-extra-fields">Accepting extra fields</a></li>
+        <li class="tut-2"><a href="#record-shorthands">Record shorthands</a></li>
+        <li class="tut-2"><a href="#record-destructuring">Record destructuring</a></li>
+        <li class="tut-2"><a href="#making-records-from-other-records">Making records from other records</a></li>
+        <li class="tut-2"><a href="#dbg">Debugging with `dbg`</a></li>
+        <li class="tut-2"><a href="#tuples">Tuples</a></li>
+        <li class="tut-2"><a href="#tuple-access">Accessing values in tuples</a></li>
+        <li class="tut-1"><a href="#pattern-matching">Pattern Matching</a></li>
+        <li class="tut-2"><a href="#tags">Tags</a></li>
+        <li class="tut-2"><a href="#tags-with-payloads">Tags with payloads</a></li>
+        <li class="tut-2"><a href="#booleans">Booleans</a></li>
+        <li class="tut-2"><a href="#lists">Lists</a></li>
+        <li class="tut-2"><a href="#list-map">List.map</a></li>
+        <li class="tut-2"><a href="#list-element-type-compatibility">List element type compatibility</a></li>
+        <li class="tut-2"><a href="#lists-that-hold-elements-of-different-types">Lists that hold elements of different types</a></li>
+        <li class="tut-2"><a href="#using-tags-as-functions">Using tags as functions</a></li>
+        <li class="tut-2"><a href="#list-any-and-list-all">List.any and List.all</a></li>
+        <li class="tut-2"><a href="#removing-elements-from-a-list">Removing elements from a list</a></li>
+        <li class="tut-2"><a href="#getting-an-individual-element-from-a-list">Getting an individual element from a list</a></li>
+        <li class="tut-2"><a href="#error-handling">Error Handling</a></li>
+        <li class="tut-2"><a href="#the-question-postfix-operator">The `?` postfix operator</a></li>
+        <li class="tut-2"><a href="#recovering-from-errors">Recovering from errors with the `??` infix operator</a></li>
+        <li class="tut-2"><a href="#walking-the-elements-in-a-list">Walking the elements in a list</a></li>
+        <li class="tut-2"><a href="#pattern-matching-on-lists">Pattern Matching on Lists</a></li>
+        <li class="tut-2"><a href="#the-pipe-operator">The pipe operator</a></li>
+        <li class="tut-1"><a href="#types">Types</a></li>
+        <li class="tut-2"><a href="#type-annotations">Type Annotations</a></li>
+        <li class="tut-2"><a href="#type-aliases">Type Aliases</a></li>
+        <li class="tut-2"><a href="#type-parameters">Type Parameters</a></li>
+        <li class="tut-2"><a href="#wildcard-type">Wildcard Types</a></li>
+        <li class="tut-2"><a href="#type-variables">Type Variables</a></li>
+        <li class="tut-2"><a href="#tag-union-types">Tag Union Types</a></li>
+        <li class="tut-2"><a href="#accumulating-tag-types">Accumulating Tag Types</a></li>
+        <li class="tut-2"><a href="#opaque-types">Opaque Types</a></li>
+        <li class="tut-2"><a href="#integers">Integers</a></li>
+        <li class="tut-2"><a href="#fractions">Fractions</a></li>
+        <li class="tut-2"><a href="#num-int-and-frac">Num, Int, and Frac</a></li>
+        <li class="tut-2"><a href="#number-literals">Number Literals</a></li>
+        <li class="tut-2"><a href="#default-value-record-fields">Default-Value Record Fields</a></li>
+        <li class="tut-1"><a href="#crashing">Crashing</a></li>
+        <li class="tut-2"><a href="#crashing-in-unreachable-branches">Crashing in unreachable branches</a></li>
+        <li class="tut-2"><a href="#crashing-for-todos">Crashing for TODOs</a></li>
+        <li class="tut-2"><a href="#crashing-for-error-handling">Crashing for error handling</a></li>
+        <li class="tut-1"><a href="#testing">Testing</a></li>
+        <li class="tut-2"><a href="#inline-expects">Inline Expectations</a></li>
+        <li class="tut-1"><a href="#modules">Modules</a></li>
+        <li class="tut-2"><a href="#builtin-modules">Builtin Modules</a></li>
+        <li class="tut-2"><a href="#app-module-header">App Module Header</a></li>
+        <li class="tut-2"><a href="#package-modules">Package Modules</a></li>
+        <li class="tut-2"><a href="#regular-modules">Regular Modules</a></li>
+        <li class="tut-2"><a href="#platform-modules">Platform Modules</a></li>
+        <li class="tut-2"><a href="#importing-files">Importing Files</a></li>
+        <li class="tut-1"><a href="#efffectful-functions">Effectful functions</a></li>
+        <li class="tut-2"><a href="#reading-values">Reading values</a></li>
+        <li class="tut-2"><a href="#failure">Effectful failure</a></li>
+        <li class="tut-2"><a href="#handling-failure">Handling failure</a></li>
+        <li class="tut-2"><a href="#underscore">The \_ type</a></li>
+        <li class="tut-2"><a href="#ignoring-informationless-return-values">Ignoring informationless return values</a></li>
+        <li class="tut-2"><a href="#tagging-errors">Tagging errors</a></li>
+        <li class="tut-2"><a href="#inspect">Displaying Roc values with `Inspect.to_str`</a></li>
+        <li class="tut-2"><a href="#the-early-return-keyword">The early `return` keyword</a></li>
+        <li class="tut-1"><a href="#examples">Examples</a></li>
+        <li class="tut-1"><a href="#advanced-concepts">Advanced Concepts</a></li>
+        <li class="tut-2"><a href="#open-records-and-closed-records">Open Records and Closed Records</a></li>
+        <li class="tut-2"><a href="#constrained-records">Constrained Records</a></li>
+        <li class="tut-2"><a href="#type-variables-in-record-annotations">Type Variables in Record Annotations</a></li>
+        <li class="tut-2"><a href="#open-and-closed-tag-unions">Open and Closed Tag Unions</a></li>
+        <li class="tut-2"><a href="#combining-open-unions">Combining Open Unions</a></li>
+        <li class="tut-2"><a href="#type-variables-in-tag-unions">Type Variables in Tag Unions</a></li>
+        <li class="tut-2"><a href="#record-builder">Record Builder</a></li>
+        <li class="tut-2"><a href="#reserved-keywords">Reserved Keywords</a></li>
+        <li class="tut-1"><a href="#operator-desugaring-table">Operator Desugaring Table</a></li>
+        <li class="tut-2"><a href="#additional-resources">Additional Resources</a></li>
     </ol>
 </nav>
 <section id="tutorial-body">

--- a/www/public/site.css
+++ b/www/public/site.css
@@ -217,10 +217,6 @@ a:hover code {
     text-decoration: inherit;
 }
 
-li {
-    margin-bottom: 0.5rem;
-}
-
 h1,
 h2,
 h3,
@@ -250,7 +246,6 @@ h2 {
 }
 
 .article-layout p,
-.article-layout li,
 .article-layout pre,
 .article-layout details {
     font-size: 20px;
@@ -496,10 +491,15 @@ td:last-child {
 
 p,
 aside,
-li,
 details {
     font-size: var(--font-size-normal);
     line-height: 1.85rem;
+}
+
+li {
+    font-size: 0.75em;
+    line-height: 1.25rem;
+    margin-bottom: 0.25rem;
 }
 
 /* Homepage */
@@ -574,8 +574,8 @@ details {
 
     #tutorial-toc {
         display: none;
-        position: fixed;
-        top: 0;
+        position: relative !important;
+        top: 0 !important;
         left: 0;
         right: 0;
         bottom: 0;
@@ -583,6 +583,20 @@ details {
         margin: 0 !important;
         padding-right: 120px;
         border: 0;
+        height: fit-content !important;
+        overflow: none;
+    }
+
+    #tutorial-toc-toggle:checked + #tutorial-toc li {
+        display: none;
+    }
+
+    #tutorial-toc-toggle:checked + #tutorial-toc li.tut-1 {
+        display: block;
+    }
+
+    #tutorial-toc ol {
+        padding-bottom: 0 !important;
     }
 
     #homepage-logo {
@@ -1217,7 +1231,7 @@ code .dim {
 #tutorial-main h5 {
     font-family: "Permanent Marker";
     line-height: 1rem;
-    margin-top: 1.75rem;
+    margin-top: 1.5rem;
     margin-bottom: 0;
     border: none;
 }
@@ -1243,8 +1257,8 @@ code .dim {
 }
 
 #tutorial-main h1 {
-    font-size: 7rem;
-    line-height: 7rem;
+    font-size: 4rem;
+    line-height: 4rem;
     color: var(--h1-color);
     margin-top: 24px;
     margin-bottom: 1.75rem;
@@ -1252,23 +1266,23 @@ code .dim {
 }
 
 #tutorial-main h2 {
-    font-size: 4rem;
-    line-height: 4rem;
+    font-size: 2rem;
+    line-height: 2rem;
     text-shadow: 1px 1px 1px #010101;
     padding: 0.8rem 0;
-    margin-top: 2.5rem;
+    margin-top: 1.5rem;
     width: 60rem; /* Without this, "Building an application" wraps and looks awkward */
 }
 
 #tutorial-main h3 {
     font-family: inherit;
-    font-size: 1.65rem;
+    font-size: 1.5rem;
     line-height: 3rem;
     margin-bottom: 0.5rem;
 }
 
 #tutorial-main h4 {
-    font-size: 2rem;
+    font-size: 1.25rem;
     text-shadow: 1px 1px 1px #010101;
 }
 
@@ -1278,15 +1292,24 @@ code .dim {
 }
 
 #tutorial-toc {
-    position: relative;
+    /* Tutorial TOC is fixed on the right and scrollable */
+    position: sticky;
+    top: 30px;
+    height: calc(100vh - 80px); /* Subtract 80 to account for header and bottom margin */
+    overflow: auto;
+
     background-color: var(--gray-bg);
-    flex: 0 0 auto; /* Take up as much space as it needs */
-    margin-top: 30px;
+    margin-top: 40px;
     background: var(--code-bg);
     padding: 12px 24px;
     margin-left: 64px;
     align-self: flex-start; /* Aligns to the start, not stretching in height */
     z-index: 2;
+}
+
+/* Indent the second layer of headings */
+#tutorial-toc .tut-2 {
+    padding-left: 1rem;
 }
 
 #tutorial-toc > ul {
@@ -1316,7 +1339,7 @@ code .dim {
     padding: 3px;
     margin: 8px 0;
     list-style: none;
-    padding-bottom: 0;
+    padding-bottom: 30px;
     margin-bottom: 0;
 }
 


### PR DESCRIPTION
## Overview
A few updates to make the **Tutorial** section of the website easier to navigate. I believe this will help new Roc developers by showing off the full contents of the **Tutorial** quickly and easily. It will also help current devs by making the documentation easier to navigate. I took some inspiration from the [Odin lang overview page](https://odin-lang.org/docs/overview/).

Changes:
- Adds the full contents of the tutorial to the **Table of Contents (TOC)**
- Makes the TOC scrollable to accommodate all of the content
- Makes the TOC fixed on the right hand side in desktop view
- Adjusts some font sizes to fit more content onto the page

I kept the mobile TOC as it is now.

## Desktop
<img width="1383" alt="Screenshot 2025-05-10 at 11 36 59 AM" src="https://github.com/user-attachments/assets/150e7813-db92-4ed6-ab04-fd32eca7c408" />

## Mobile
<img width="518" alt="Screenshot 2025-05-10 at 5 09 35 PM" src="https://github.com/user-attachments/assets/682b0afd-050a-44ce-b9ea-036b3eeb9293" />
