### PR TITLE
change `roc build` to build only if check passes

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -992,7 +992,7 @@ pub fn build(
         .map(|x| x * 1024);
 
     let build_ordering = match config {
-        BuildAndRunIfNoErrors => BuildOrdering::BuildIfChecks,
+        BuildAndRunIfNoErrors | BuildOnly => BuildOrdering::BuildIfChecks,
         _ => BuildOrdering::AlwaysBuild,
     };
 


### PR DESCRIPTION
`roc build` used to try to build roc code even if there were errors, but this easily produces panics (like in #7779). Given that we're making a new compiler, it makes sense to change this "setting" in the old one for user friendliness.