### PR TITLE
fix: Remove parse panics and unreachables

### DIFF
--- a/src/check/parse/IR.zig
+++ b/src/check/parse/IR.zig
@@ -119,6 +119,7 @@ pub const Diagnostic = struct {
         header_expected_close_square,
         header_unexpected_token,
         pattern_unexpected_token,
+        pattern_unexpected_eof,
         ty_anno_unexpected_token,
         statement_unexpected_eof,
         statement_unexpected_token,

--- a/src/fmt.zig
+++ b/src/fmt.zig
@@ -1956,7 +1956,7 @@ fn parseAndFmt(gpa: std.mem.Allocator, input: []const u8, debug: bool) ![]const 
         std.debug.print("\n==========\n\n", .{});
     }
 
-    std.testing.expectEqualSlices(IR.Diagnostic, parse_ast.errors, &[_]IR.Diagnostic{}) catch {
+    std.testing.expectEqualSlices(IR.Diagnostic, &[_]IR.Diagnostic{}, parse_ast.errors) catch {
         return error.ParseFailed;
     };
 


### PR DESCRIPTION
Fixes a common source of fuzzer crashes, and just better for code health.  Motivated by [#compiler development > zig compiler - fuzzing @ 💬](https://roc.zulipchat.com/#narrow/channel/395097-compiler-development/topic/zig.20compiler.20-.20fuzzing/near/518841712)