### PR TITLE
Deal with bad offset for identifier

### DIFF
--- a/src/check/parse/Parser.zig
+++ b/src/check/parse/Parser.zig
@@ -1804,18 +1804,19 @@ pub fn parseTypeAnno(self: *Parser, looking_for_args: TyFnArgs) IR.NodeStore.Typ
         .UpperIdent => {
             self.advance(); // Advance past UpperIdent
             if (self.peek() == .NoSpaceDotUpperIdent or self.peek() == .DotUpperIdent) {
+                const second_ident = self.pos;
                 self.advance(); // Advance past NoSpaceDotUpperIdent
                 anno = self.store.addTypeAnno(.{ .mod_ty = .{
                     .region = .{ .start = start, .end = start },
                     .tok = start,
-                    .ty_ident = self.tok_buf.resolve_identifier(start),
-                    .mod_ident = self.tok_buf.resolve_identifier(start + 1),
+                    .ty_ident = self.tok_buf.resolveIdentifier(start).?,
+                    .mod_ident = self.tok_buf.resolveIdentifier(second_ident).?,
                 } });
             } else {
                 anno = self.store.addTypeAnno(.{ .ty = .{
                     .region = .{ .start = start, .end = start },
                     .tok = start,
-                    .ident = self.tok_buf.resolve_identifier(start),
+                    .ident = self.tok_buf.resolveIdentifier(start).?,
                 } });
             }
 

--- a/src/check/parse/Parser.zig
+++ b/src/check/parse/Parser.zig
@@ -1807,15 +1807,13 @@ pub fn parseTypeAnno(self: *Parser, looking_for_args: TyFnArgs) IR.NodeStore.Typ
                 const second_ident = self.pos;
                 self.advance(); // Advance past NoSpaceDotUpperIdent
                 anno = self.store.addTypeAnno(.{ .mod_ty = .{
-                    .region = .{ .start = start, .end = start },
-                    .tok = start,
+                    .region = .{ .start = start, .end = second_ident },
                     .ty_ident = self.tok_buf.resolveIdentifier(start).?,
                     .mod_ident = self.tok_buf.resolveIdentifier(second_ident).?,
                 } });
             } else {
                 anno = self.store.addTypeAnno(.{ .ty = .{
                     .region = .{ .start = start, .end = start },
-                    .tok = start,
                     .ident = self.tok_buf.resolveIdentifier(start).?,
                 } });
             }

--- a/src/check/parse/tokenize.zig
+++ b/src/check/parse/tokenize.zig
@@ -405,7 +405,9 @@ pub const TokenizedBuffer = struct {
         }
     }
 
-    pub fn resolve_identifier(self: *TokenizedBuffer, token: Token.Idx) base.Ident.Idx {
+    /// Loads the current token if it is an identifier.
+    /// Otherwise returns null.
+    pub fn resolveIdentifier(self: *TokenizedBuffer, token: Token.Idx) ?base.Ident.Idx {
         const tag = self.tokens.items(.tag)[@intCast(token)];
         const extra = self.tokens.items(.extra)[@intCast(token)];
         switch (tag) {
@@ -421,7 +423,7 @@ pub const TokenizedBuffer = struct {
                 return extra.interned;
             },
             else => {
-                std.debug.panic("not an identifier", .{});
+                return null;
             },
         }
     }

--- a/src/fmt.zig
+++ b/src/fmt.zig
@@ -1621,12 +1621,12 @@ const Formatter = struct {
                 try fmt.pushTokenText(v.tok);
             },
             .ty => |t| {
-                try fmt.pushTokenText(t.tok);
+                try fmt.pushTokenText(t.region.start);
             },
             .mod_ty => |t| {
-                try fmt.pushTokenText(t.tok);
+                try fmt.pushTokenText(t.region.start);
                 try fmt.pushAll(".");
-                try fmt.pushTokenText(t.tok + 1);
+                try fmt.pushTokenText(t.region.end);
             },
             .tuple => |t| {
                 region = t.region;

--- a/src/snapshots/fuzz_crash/fuzz_crash_018.txt
+++ b/src/snapshots/fuzz_crash/fuzz_crash_018.txt
@@ -1,0 +1,18 @@
+~~~META
+description=fuzz crash
+type=file
+~~~SOURCE
+0 b:S
+.R
+~~~PROBLEMS
+PARSER: missing_header
+~~~TOKENS
+Int(1:1-1:2),LowerIdent(1:3-1:4),OpColon(1:4-1:5),UpperIdent(1:5-1:6),Newline(1:1-1:1),
+DotUpperIdent(2:1-2:3),EndOfFile(2:3-2:3),
+~~~PARSE
+(file
+	(malformed_header (1:1-1:2) "missing_header")
+	(type_anno (1:3-2:3)
+		"b"
+		(mod_ty "S" "")))
+~~~END

--- a/src/snapshots/fuzz_crash/fuzz_crash_018.txt
+++ b/src/snapshots/fuzz_crash/fuzz_crash_018.txt
@@ -14,5 +14,5 @@ DotUpperIdent(2:1-2:3),EndOfFile(2:3-2:3),
 	(malformed_header (1:1-1:2) "missing_header")
 	(type_anno (1:3-2:3)
 		"b"
-		(mod_ty "S" "")))
+		(mod_ty "S" ".R")))
 ~~~END


### PR DESCRIPTION
Advance can advance more than one position.
It will skip newlines.
As such, we need to get the correct offset here.