### PR TITLE
Stop caching the zig cache

### DIFF
--- a/.github/workflows/ci_zig.yml
+++ b/.github/workflows/ci_zig.yml
@@ -15,6 +15,10 @@ jobs:
       - uses: mlugg/setup-zig@aa9ad5c14eb3452e235a441c4f9a8e89f20d97bd # ratchet:mlugg/setup-zig@v2
         with:
           version: 0.14.0
+          # Do not cache the zig cache.
+          # Just cache the zig executable.
+          # Zig cache corrupts sometimes and uses tons of space.
+          use-cache: false
 
       - name: zig lints
         run: |
@@ -50,6 +54,10 @@ jobs:
       - uses: mlugg/setup-zig@aa9ad5c14eb3452e235a441c4f9a8e89f20d97bd # ratchet:mlugg/setup-zig@v2
         with:
           version: 0.14.0
+          # Do not cache the zig cache.
+          # Just cache the zig executable.
+          # Zig cache corrupts sometimes and uses tons of space.
+          use-cache: false
 
       - name: build roc
         run: |
@@ -134,6 +142,10 @@ jobs:
       - uses: mlugg/setup-zig@aa9ad5c14eb3452e235a441c4f9a8e89f20d97bd # ratchet:mlugg/setup-zig@v2
         with:
           version: 0.14.0
+          # Do not cache the zig cache.
+          # Just cache the zig executable.
+          # Zig cache corrupts sometimes and uses tons of space.
+          use-cache: false
 
       - name: cross compile with llvm
         run: |


### PR DESCRIPTION
This is bloating our cache storage and occasionally leads to CI failures. Instead, just cache the zig executable, but rebuild roc from scratch.