### PR TITLE
Implement Occurs Check

### DIFF
--- a/src/check/check_types/occurs.zig
+++ b/src/check/check_types/occurs.zig
@@ -1,0 +1,489 @@
+//! This module contains the logic for checking if a variable is recursive
+
+const std = @import("std");
+
+const base = @import("../../base.zig");
+const collections = @import("../../collections.zig");
+const types = @import("../../types/types.zig");
+const store = @import("../../types/store.zig");
+
+const Ident = base.Ident;
+
+const exitOnOutOfMemory = collections.utils.exitOnOom;
+
+const Store = store.Store;
+
+const Desc = types.Descriptor;
+const Content = types.Content;
+const Mark = types.Mark;
+const Var = types.Var;
+const TagUnion = types.TagUnion;
+const Tag = types.Tag;
+
+/// Check if a variable is recursive
+///
+/// This function uses `Scratch` as to hold intermediate values. It resets it
+/// before running.
+pub fn occurs(types_store: *const Store, scratch: *Scratch, var_: Var) bool {
+    scratch.reset();
+
+    var result = false;
+
+    var check_occurs = CheckOccurs.init(types_store, scratch);
+    check_occurs.occurs(var_) catch |err| switch (err) {
+        error.Occurs => {
+            result = true;
+        },
+    };
+
+    return result;
+}
+
+/// This is an intermediate struct used when checking occurrences.
+const CheckOccurs = struct {
+    const Self = @This();
+
+    types_store: *const Store,
+    scratch: *Scratch,
+
+    /// Init CheckOccurs
+    ///
+    /// Note that this struct does not own any of it's fields
+    fn init(types_store: *const Store, scratch: *Scratch) Self {
+        return .{ .types_store = types_store, .scratch = scratch };
+    }
+
+    const Error = error{Occurs};
+
+    /// Recursively check if a type is referenced by it's children
+    fn occurs(self: *Self, var_: Var) error{Occurs}!void {
+        const root = self.types_store.resolveVar(var_);
+
+        if (self.scratch.hasSeenVar(root.var_)) {
+            // If we've already seen this var, then it's recursive
+            return error.Occurs;
+        } else if (self.scratch.hasVisitedVar(root.var_)) {
+            // If we've already visited this var and not errored, then it's not recursive
+            return;
+        } else {
+            self.scratch.appendSeen(var_);
+
+            switch (root.desc.content) {
+                .structure => |flat_type| {
+                    switch (flat_type) {
+                        .str => {},
+                        .box => |sub_var| {
+                            try self.occursSubVar(root.var_, sub_var);
+                        },
+                        .list => |sub_var| {
+                            try self.occursSubVar(root.var_, sub_var);
+                        },
+                        .tuple => |tuple| {
+                            const elems = self.types_store.getTupleElemsSlice(tuple.elems);
+                            try self.occursSubVars(root.var_, elems);
+                        },
+                        .num => {},
+                        .custom_type => |custom_type| {
+                            const args = self.types_store.getCustomTypeArgsSlice(custom_type.args);
+                            try self.occursSubVars(root.var_, args);
+                        },
+                        .func => |func| {
+                            const args = self.types_store.getFuncArgsSlice(func.args);
+                            try self.occursSubVars(root.var_, args);
+                            try self.occursSubVar(root.var_, func.ret);
+                            try self.occursSubVar(root.var_, func.eff);
+                        },
+                        .record => |record| {
+                            const fields = self.types_store.getRecordFieldsSlice(record.fields);
+                            try self.occursSubVars(root.var_, fields.items(.var_));
+                            try self.occursSubVar(root.var_, record.ext);
+                        },
+                        .tag_union => |tag_union| {
+                            const tags = self.types_store.getTagsSlice(tag_union.tags);
+                            for (tags.items(.args)) |tag_args| {
+                                const args = self.types_store.getTagArgsSlice(tag_args);
+                                try self.occursSubVars(root.var_, args);
+                            }
+                            try self.occursSubVar(root.var_, tag_union.ext);
+                        },
+                        .empty_record => {},
+                        .empty_tag_union => {},
+                    }
+                },
+                .alias => |alias| {
+                    const args = self.types_store.getAliasArgsSlice(alias.args);
+                    try self.occursSubVars(root.var_, args);
+                    try self.occursSubVar(root.var_, alias.backing_var);
+                },
+                .flex_var => {},
+                .rigid_var => {},
+                .effectful => {},
+                .pure => {},
+                .err => {},
+            }
+
+            self.scratch.popSeen();
+            self.scratch.appendVisited(var_);
+        }
+    }
+
+    /// Check if a sub var is recursive
+    /// In the event of an error, append the root var to the chain
+    fn occursSubVar(self: *Self, root_var: Var, sub_var: Var) error{Occurs}!void {
+        self.occurs(sub_var) catch |err| switch (err) {
+            error.Occurs => {
+                self.scratch.appendErrChain(root_var);
+                return error.Occurs;
+            },
+        };
+    }
+
+    /// Check if a slice of sub vars are recursive
+    /// In the event of an error, append the root var to the chain
+    fn occursSubVars(self: *Self, root_var: Var, sub_vars: []Var) error{Occurs}!void {
+        for (sub_vars) |sub_var| {
+            try self.occursSubVar(root_var, sub_var);
+        }
+    }
+};
+
+/// Struct to hold intermediate values used during occurs check
+const Scratch = struct {
+    const Self = @This();
+
+    gpa: std.mem.Allocator,
+
+    seen: Var.SafeList,
+    visited: Var.SafeList,
+    err_chain: Var.SafeList,
+
+    fn init(gpa: std.mem.Allocator) Self {
+        // TODO: eventually use herusitics here to determine sensible defaults
+        // Rust compiler inits with 1024 capacity. But that feels like a lot.
+        // Typical recursion cases should only be a few layers deep?
+        return .{
+            .gpa = gpa,
+            .seen = Var.SafeList.initCapacity(gpa, 32),
+            .visited = Var.SafeList.initCapacity(gpa, 32),
+            .err_chain = Var.SafeList.initCapacity(gpa, 32),
+        };
+    }
+
+    fn deinit(self: *Self) void {
+        self.seen.deinit(self.gpa);
+        self.visited.deinit(self.gpa);
+        self.err_chain.deinit(self.gpa);
+    }
+
+    fn reset(self: *Self) void {
+        self.seen.items.clearRetainingCapacity();
+        self.visited.items.clearRetainingCapacity();
+        self.err_chain.items.clearRetainingCapacity();
+    }
+
+    fn hasSeenVar(self: *const Self, var_: Var) bool {
+        for (self.seen.items.items) |seen_var| {
+            if (seen_var == var_) return true;
+        }
+        return false;
+    }
+
+    fn appendSeen(self: *Self, var_: Var) void {
+        _ = self.seen.append(self.gpa, var_);
+    }
+
+    fn popSeen(self: *Self) void {
+        _ = self.seen.items.pop();
+    }
+
+    fn hasVisitedVar(self: *const Self, var_: Var) bool {
+        for (self.visited.items.items) |visited_var| {
+            if (visited_var == var_) return true;
+        }
+        return false;
+    }
+
+    fn appendVisited(self: *Self, var_: Var) void {
+        _ = self.visited.append(self.gpa, var_);
+    }
+
+    fn appendErrChain(self: *Self, var_: Var) void {
+        _ = self.err_chain.append(self.gpa, var_);
+    }
+
+    fn errChainSlice(self: *const Scratch) []const Var {
+        return self.err_chain.items.items;
+    }
+};
+
+test "occurs: no recurcion (v = Str)" {
+    const gpa = std.testing.allocator;
+
+    var module_env = base.ModuleEnv.init(gpa);
+    defer module_env.deinit();
+
+    var types_store = Store.init(&module_env);
+    defer types_store.deinit();
+
+    var scratch = Scratch.init(gpa);
+    defer scratch.deinit();
+
+    const str_var = types_store.freshFromContent(Content{ .structure = .str });
+
+    const result = occurs(&types_store, &scratch, str_var);
+    try std.testing.expectEqual(false, result);
+}
+
+test "occurs: direct recursion (v = List v)" {
+    const gpa = std.testing.allocator;
+    var module_env = base.ModuleEnv.init(gpa);
+    defer module_env.deinit();
+
+    var types_store = Store.init(&module_env);
+    defer types_store.deinit();
+
+    var scratch = Scratch.init(gpa);
+    defer scratch.deinit();
+
+    const list_var = types_store.fresh();
+    const list_content = Content{
+        .structure = .{ .list = list_var },
+    };
+    try types_store.setRootVarContent(list_var, list_content);
+
+    const result = occurs(&types_store, &scratch, list_var);
+    try std.testing.expectEqual(true, result);
+
+    const err_chain = scratch.errChainSlice();
+    try std.testing.expectEqual(1, err_chain.len);
+    try std.testing.expectEqual(list_var, err_chain[0]);
+}
+
+test "occurs: indirect recursion (v1 = Box v2, v2 = List v1)" {
+    const gpa = std.testing.allocator;
+    var module_env = base.ModuleEnv.init(gpa);
+    defer module_env.deinit();
+
+    var types_store = Store.init(&module_env);
+    defer types_store.deinit();
+
+    var scratch = Scratch.init(gpa);
+    defer scratch.deinit();
+
+    const v1 = types_store.fresh();
+    const v2 = types_store.fresh();
+
+    try types_store.setRootVarContent(v1, Content{ .structure = .{ .box = v2 } });
+    try types_store.setRootVarContent(v2, Content{ .structure = .{ .list = v1 } });
+
+    const result = occurs(&types_store, &scratch, v1);
+    try std.testing.expectEqual(true, result);
+
+    const err_chain = scratch.errChainSlice();
+    try std.testing.expectEqual(2, err_chain.len);
+    try std.testing.expectEqual(v2, err_chain[0]);
+    try std.testing.expectEqual(v1, err_chain[1]);
+}
+
+test "occurs: no recursion through two levels (v1 = Box v2, v2 = Str)" {
+    const gpa = std.testing.allocator;
+    var module_env = base.ModuleEnv.init(gpa);
+    defer module_env.deinit();
+
+    var types_store = Store.init(&module_env);
+    defer types_store.deinit();
+
+    var scratch = Scratch.init(gpa);
+    defer scratch.deinit();
+
+    const v1 = types_store.fresh();
+    const v2 = types_store.fresh();
+
+    try types_store.setRootVarContent(v1, Content{ .structure = .{ .box = v2 } });
+    try types_store.setRootVarContent(v2, Content{ .structure = .str });
+
+    const result = occurs(&types_store, &scratch, v1);
+    try std.testing.expectEqual(false, result);
+}
+
+test "occurs: tuple recursion (v = Tuple(v, Str))" {
+    const gpa = std.testing.allocator;
+    var module_env = base.ModuleEnv.init(gpa);
+    defer module_env.deinit();
+
+    var types_store = Store.init(&module_env);
+    defer types_store.deinit();
+
+    var scratch = Scratch.init(gpa);
+    defer scratch.deinit();
+
+    const v = types_store.fresh();
+    const str_var = types_store.freshFromContent(Content{ .structure = .str });
+
+    const elems_range = types_store.appendTupleElems(&[_]Var{ v, str_var });
+    const tuple = types.Tuple{ .elems = elems_range };
+
+    try types_store.setRootVarContent(v, Content{ .structure = .{ .tuple = tuple } });
+
+    const result = occurs(&types_store, &scratch, v);
+    try std.testing.expectEqual(true, result);
+
+    const err_chain = scratch.errChainSlice();
+    try std.testing.expectEqual(1, err_chain.len);
+    try std.testing.expectEqual(v, err_chain[0]);
+}
+
+test "occurs: tuple not recursive (v = Tuple(Str, Str))" {
+    const gpa = std.testing.allocator;
+    var module_env = base.ModuleEnv.init(gpa);
+    defer module_env.deinit();
+
+    var types_store = Store.init(&module_env);
+    defer types_store.deinit();
+
+    var scratch = Scratch.init(gpa);
+    defer scratch.deinit();
+
+    const str_var = types_store.freshFromContent(Content{ .structure = .str });
+
+    const elems_range = types_store.appendTupleElems(&[_]Var{ str_var, str_var });
+    const tuple = types.Tuple{ .elems = elems_range };
+
+    const v = types_store.freshFromContent(Content{ .structure = .{ .tuple = tuple } });
+
+    const result = occurs(&types_store, &scratch, v);
+    try std.testing.expectEqual(false, result);
+
+    try std.testing.expectEqual(2, scratch.visited.len());
+}
+
+test "occurs: recursive alias (v = Alias(List v))" {
+    const gpa = std.testing.allocator;
+    var module_env = base.ModuleEnv.init(gpa);
+    defer module_env.deinit();
+
+    var types_store = Store.init(&module_env);
+    defer types_store.deinit();
+
+    var scratch = Scratch.init(gpa);
+    defer scratch.deinit();
+
+    const backing_var = types_store.fresh();
+    const v = types_store.fresh();
+
+    const args = types_store.appendAliasArgs(&[_]Var{v});
+
+    try types_store.setRootVarContent(v, Content{
+        .alias = .{
+            .ident = types.TypeIdent{ .ident_idx = undefined },
+            .args = args,
+            .backing_var = backing_var,
+        },
+    });
+
+    const result = occurs(&types_store, &scratch, v);
+    try std.testing.expectEqual(true, result);
+
+    const err_chain = scratch.errChainSlice();
+    try std.testing.expectEqual(1, err_chain.len);
+    try std.testing.expectEqual(v, err_chain[0]);
+}
+
+test "occurs: alias with no recursion (v = Alias Str)" {
+    const gpa = std.testing.allocator;
+    var module_env = base.ModuleEnv.init(gpa);
+    defer module_env.deinit();
+
+    var types_store = Store.init(&module_env);
+    defer types_store.deinit();
+
+    var scratch = Scratch.init(gpa);
+    defer scratch.deinit();
+
+    const backing_var = types_store.fresh();
+    const str_var = types_store.freshFromContent(Content{ .structure = .str });
+    const args = types_store.appendAliasArgs(&[_]Var{str_var});
+
+    const alias_var = types_store.fresh();
+    try types_store.setRootVarContent(alias_var, Content{ .alias = .{
+        .ident = types.TypeIdent{ .ident_idx = undefined },
+        .args = args,
+        .backing_var = backing_var,
+    } });
+
+    const result = occurs(&types_store, &scratch, alias_var);
+    try std.testing.expectEqual(false, result);
+}
+
+test "occurs: recursive tag union (v = TagUnion { Foo(v) } with ext = v)" {
+    const gpa = std.testing.allocator;
+    var module_env = base.ModuleEnv.init(gpa);
+    defer module_env.deinit();
+
+    var types_store = Store.init(&module_env);
+    defer types_store.deinit();
+
+    var scratch = Scratch.init(gpa);
+    defer scratch.deinit();
+
+    const linked_list = types_store.fresh();
+    const elem = types_store.fresh();
+    const ext = types_store.fresh();
+
+    const cons_tag_args = types_store.appendTagArgs(&[_]Var{ elem, linked_list });
+    const cons_tag = types.Tag{ .name = undefined, .args = cons_tag_args };
+
+    const nil_tag = types.Tag{ .name = undefined, .args = Var.SafeList.Range.empty };
+
+    const tags = types_store.appendTags(&[_]Tag{ cons_tag, nil_tag });
+
+    const tag_union = TagUnion{ .tags = tags, .ext = ext };
+
+    try types_store.setRootVarContent(linked_list, .{ .structure = .{ .tag_union = tag_union } });
+
+    const result = occurs(&types_store, &scratch, linked_list);
+    try std.testing.expectEqual(true, result);
+
+    const err_chain = scratch.errChainSlice();
+    try std.testing.expectEqual(1, err_chain.len);
+    try std.testing.expectEqual(linked_list, err_chain[0]);
+}
+
+test "occurs: nested recursive tag union (v = TagUnion { Cons(elem, Box(v)) } )" {
+    const gpa = std.testing.allocator;
+    var module_env = base.ModuleEnv.init(gpa);
+    defer module_env.deinit();
+
+    var types_store = Store.init(&module_env);
+    defer types_store.deinit();
+
+    var scratch = Scratch.init(gpa);
+    defer scratch.deinit();
+
+    const linked_list = types_store.fresh();
+    const elem = types_store.fresh();
+
+    // Wrap the recursive var in a Box to simulate nesting
+    const boxed_linked_list = types_store.fresh();
+    try types_store.setRootVarContent(boxed_linked_list, .{ .structure = .{ .box = linked_list } });
+
+    // Build tag args: (elem, Box(linked_list))
+    const cons_tag_args = types_store.appendTagArgs(&[_]Var{ elem, boxed_linked_list });
+
+    const cons_tag = types.Tag{ .name = undefined, .args = cons_tag_args };
+    const nil_tag = types.Tag{ .name = undefined, .args = Var.SafeList.Range.empty };
+
+    const tags = types_store.appendTags(&[_]Tag{ cons_tag, nil_tag });
+
+    const tag_union = TagUnion{ .tags = tags, .ext = types_store.fresh() };
+
+    try types_store.setRootVarContent(linked_list, .{ .structure = .{ .tag_union = tag_union } });
+
+    const result = occurs(&types_store, &scratch, linked_list);
+    try std.testing.expectEqual(true, result);
+
+    const err_chain = scratch.errChainSlice();
+    try std.testing.expect(err_chain.len == 2);
+    try std.testing.expectEqual(err_chain[0], boxed_linked_list);
+    try std.testing.expectEqual(err_chain[1], linked_list);
+}

--- a/src/check/check_types/occurs.zig
+++ b/src/check/check_types/occurs.zig
@@ -88,7 +88,7 @@ pub fn occurs(types_store: *Store, scratch: *Scratch, var_: Var) Result {
         },
     };
 
-    // Reset the marks for all visited nodex
+    // Reset the marks for all visited nodes
     for (scratch.visited.items.items[0..]) |visited_desc_idx| {
         types_store.setDescMark(visited_desc_idx, Mark.none);
     }
@@ -99,7 +99,7 @@ pub fn occurs(types_store: *Store, scratch: *Scratch, var_: Var) Result {
 /// Performs an occurs check on a type variable.
 ///
 /// This struct encapsulates the recursive traversal logic used to detect
-/// whether a variable is recursively defined through its children.
+/// whether a variable is recursively defined through it's children.
 ///
 /// It uses a scratch space to track visited nodes and maintain state across
 /// recursive calls. It is intended for one-time use per `occurs()` call.

--- a/src/check/check_types/occurs.zig
+++ b/src/check/check_types/occurs.zig
@@ -1,4 +1,18 @@
-//! This module contains the logic for checking if a variable is recursive
+//! Checks whether a type variable is recursively defined.
+//!
+//! This module implements an "occurs check" to detect:
+//! - structurally infinite types (e.g., `a = List a`)
+//! - recursion through unnamed constructs (anonymous recursion)
+//! - recursion through named nominal types (permitted in Roc under some rules)
+//!
+//! The main entrypoint is `occurs()`. It analyzes the type graph rooted at a variable
+//! and reports whether the structure is recursive, and if so, what kind of recursion.
+//!
+//! The traversal uses a shared `Scratch` value to track visited nodes, recursion
+//! chains, and to temporarily mark variables during analysis. This is reset between runs.
+//!
+//! The check only mutates the `Mark` field of descriptors in `Store`, and all marks
+//! are reset before returning. Other descriptor state remains unchanged.
 
 const std = @import("std");
 
@@ -14,18 +28,34 @@ const exitOnOutOfMemory = collections.utils.exitOnOom;
 
 const Store = store.Store;
 const DescStoreIdx = store.DescStoreIdx;
+const ResolvedVarDesc = store.ResolvedVarDesc;
 
 const Desc = types.Descriptor;
 const Content = types.Content;
 const Mark = types.Mark;
 const Var = types.Var;
+const CustomType = types.CustomType;
 const TagUnion = types.TagUnion;
 const Tag = types.Tag;
+
+/// The result of checking for recursion
+///
+/// If the result is `recursive_nominal`, you can use `scratch.err_chain_nominal_vars`
+/// to check what nominal vars were encountered
+pub const Result = enum {
+    not_recursive,
+    recursive_nominal,
+    recursive_anonymous,
+    infinite,
+};
 
 /// Check if a variable is recursive
 ///
 /// This uses `Scratch` as to hold intermediate values. `occurs` will reset it
 /// before each run.
+///
+/// If the result is `recursive_nominal`, you can use `scratch.err_chain_nominal_vars`
+/// to check what nominal vars were encountered
 ///
 /// This function accepts a mutable reference to `Store`, but guarantees that it
 /// _only_ modifies a variable's `Mark`. Before returning, all visited nodes'
@@ -35,18 +65,30 @@ const Tag = types.Tag;
 /// switch the types_store descriptors to use a multi list (which we should do
 /// anyway), maybe we can only pass in only a mutable ref to the backing `Mark`s
 /// array?
-pub fn occurs(types_store: *Store, scratch: *Scratch, var_: Var) bool {
+pub fn occurs(types_store: *Store, scratch: *Scratch, var_: Var) Result {
     scratch.reset();
 
-    var result = false;
+    var result: Result = .not_recursive;
 
+    // Check for recursion
     var check_occurs = CheckOccurs.init(types_store, scratch);
-    check_occurs.occurs(var_) catch |err| switch (err) {
-        error.Occurs => {
-            result = true;
+    check_occurs.occurs(var_, Context.init()) catch |err| switch (err) {
+        error.InfiniteType => {
+            result = .infinite;
+        },
+        error.RecursiveAnonymous => {
+            result = .recursive_anonymous;
+        },
+        error.RecursiveNominal => {
+            // We we somehow threw `RecursiveNominal` but didn't find any
+            // nominal vars, this is a bug!
+            std.debug.assert(scratch.err_chain_nominal_vars.len() > 0);
+
+            result = .recursive_nominal;
         },
     };
 
+    // Reset the marks for all visited nodex
     for (scratch.visited.items.items[0..]) |visited_desc_idx| {
         types_store.setDescMark(visited_desc_idx, Mark.none);
     }
@@ -54,7 +96,17 @@ pub fn occurs(types_store: *Store, scratch: *Scratch, var_: Var) bool {
     return result;
 }
 
-/// This is an intermediate struct used when checking occurrences.
+/// Performs an occurs check on a type variable.
+///
+/// This struct encapsulates the recursive traversal logic used to detect
+/// whether a variable is recursively defined through its children.
+///
+/// It uses a scratch space to track visited nodes and maintain state across
+/// recursive calls. It is intended for one-time use per `occurs()` call.
+///
+/// Ownership: `CheckOccurs` does not allocate or deallocate memory. It borrows
+/// both the `types_store` and `scratch` passed during initialization. These
+/// outlive the `CheckOccurs` value.
 const CheckOccurs = struct {
     const Self = @This();
 
@@ -71,18 +123,34 @@ const CheckOccurs = struct {
         return .{ .types_store = types_store, .scratch = scratch };
     }
 
-    const Error = error{Occurs};
+    const Error = error{ InfiniteType, RecursiveAnonymous, RecursiveNominal };
 
     /// Recursively check if a type is referenced by it's children
-    fn occurs(self: *Self, var_: Var) error{Occurs}!void {
+    ///
+    /// This method appends intermediate error chain information to the `scratch`,
+    /// which can be queried after the run.
+    fn occurs(self: *Self, var_: Var, ctx: Context) Error!void {
         const root = self.types_store.resolveVar(var_);
 
         if (root.desc.mark == .visited) {
             // If we've already visited this var and not errored, then it's not recursive
             return;
         } else if (self.scratch.hasSeenVar(root.var_)) {
-            // If we've already seen this var, then it's recursive
-            return error.Occurs;
+            // Recursion point! We've already seen this var during traversal.
+            if (ctx.recursion_allowed and ctx.seen_nominal) {
+                // If recursion is allowed (we've passed through a Box, List or
+                // Tag Union) AND at somepoint in the chain we've seen a nominal
+                // type, then this recursion is okay
+                return error.RecursiveNominal;
+            } else if (ctx.recursion_allowed and !ctx.seen_nominal) {
+                // If recursion is allowed (we've passed through a Box, List or
+                // Tag Union) BUT we haven't seen any nominal types, then this
+                // recursion is anonymous and not okay
+                return error.RecursiveAnonymous;
+            } else {
+                // Otherwise, this is an infinite type
+                return error.InfiniteType;
+            }
         } else {
             self.scratch.appendSeen(var_);
             switch (root.desc.content) {
@@ -90,38 +158,39 @@ const CheckOccurs = struct {
                     switch (flat_type) {
                         .str => {},
                         .box => |sub_var| {
-                            try self.occursSubVar(root.var_, sub_var);
+                            try self.occursSubVar(root, sub_var, ctx.allowRecursion());
                         },
                         .list => |sub_var| {
-                            try self.occursSubVar(root.var_, sub_var);
+                            try self.occursSubVar(root, sub_var, ctx.allowRecursion());
                         },
                         .tuple => |tuple| {
                             const elems = self.types_store.getTupleElemsSlice(tuple.elems);
-                            try self.occursSubVars(root.var_, elems);
+                            try self.occursSubVars(root, elems, ctx);
                         },
                         .num => {},
                         .custom_type => |custom_type| {
                             const args = self.types_store.getCustomTypeArgsSlice(custom_type.args);
-                            try self.occursSubVars(root.var_, args);
+                            try self.occursSubVars(root, args, ctx);
+                            try self.occursSubVar(root, custom_type.backing_var, ctx.markNominal());
                         },
                         .func => |func| {
                             const args = self.types_store.getFuncArgsSlice(func.args);
-                            try self.occursSubVars(root.var_, args);
-                            try self.occursSubVar(root.var_, func.ret);
-                            try self.occursSubVar(root.var_, func.eff);
+                            try self.occursSubVars(root, args, ctx);
+                            try self.occursSubVar(root, func.ret, ctx);
+                            try self.occursSubVar(root, func.eff, ctx);
                         },
                         .record => |record| {
                             const fields = self.types_store.getRecordFieldsSlice(record.fields);
-                            try self.occursSubVars(root.var_, fields.items(.var_));
-                            try self.occursSubVar(root.var_, record.ext);
+                            try self.occursSubVars(root, fields.items(.var_), ctx.allowRecursion());
+                            try self.occursSubVar(root, record.ext, ctx);
                         },
                         .tag_union => |tag_union| {
                             const tags = self.types_store.getTagsSlice(tag_union.tags);
                             for (tags.items(.args)) |tag_args| {
                                 const args = self.types_store.getTagArgsSlice(tag_args);
-                                try self.occursSubVars(root.var_, args);
+                                try self.occursSubVars(root, args, ctx.allowRecursion());
                             }
-                            try self.occursSubVar(root.var_, tag_union.ext);
+                            try self.occursSubVar(root, tag_union.ext, ctx);
                         },
                         .empty_record => {},
                         .empty_tag_union => {},
@@ -129,8 +198,8 @@ const CheckOccurs = struct {
                 },
                 .alias => |alias| {
                     const args = self.types_store.getAliasArgsSlice(alias.args);
-                    try self.occursSubVars(root.var_, args);
-                    try self.occursSubVar(root.var_, alias.backing_var);
+                    try self.occursSubVars(root, args, ctx);
+                    try self.occursSubVar(root, alias.backing_var, ctx);
                 },
                 .flex_var => {},
                 .rigid_var => {},
@@ -147,21 +216,52 @@ const CheckOccurs = struct {
 
     /// Check if a sub var is recursive
     /// In the event of an error, append the root var to the chain
-    fn occursSubVar(self: *Self, root_var: Var, sub_var: Var) error{Occurs}!void {
-        self.occurs(sub_var) catch |err| switch (err) {
-            error.Occurs => {
-                self.scratch.appendErrChain(root_var);
-                return error.Occurs;
-            },
+    fn occursSubVar(self: *Self, root: ResolvedVarDesc, sub_var: Var, ctx: Context) Error!void {
+        self.occurs(sub_var, ctx) catch |err| {
+            self.scratch.appendErrChain(root.var_);
+            if (root.desc.content.unwrapCustomType() != null) {
+                self.scratch.appendErrChainNominalVar(root.var_);
+            }
+            return err;
         };
     }
 
     /// Check if a slice of sub vars are recursive
     /// In the event of an error, append the root var to the chain
-    fn occursSubVars(self: *Self, root_var: Var, sub_vars: []Var) error{Occurs}!void {
+    fn occursSubVars(self: *Self, root_var: ResolvedVarDesc, sub_vars: []Var, ctx: Context) Error!void {
         for (sub_vars) |sub_var| {
-            try self.occursSubVar(root_var, sub_var);
+            try self.occursSubVar(root_var, sub_var, ctx);
         }
+    }
+};
+
+/// This type represents the context of a recursive branch in the occurs check
+///
+/// This types is passed down through the occurs check and is modified to keep
+/// track of whatever we've seen so far in this branch.
+const Context = struct {
+    recursion_allowed: bool,
+    seen_nominal: bool,
+
+    fn init() Context {
+        return .{ .recursion_allowed = false, .seen_nominal = false };
+    }
+
+    /// Mark that recursion is allowed
+    /// ie the chain passes through a Box, List or Tag Union
+    fn allowRecursion(self: Context) Context {
+        return .{
+            .recursion_allowed = true,
+            .seen_nominal = self.seen_nominal,
+        };
+    }
+
+    /// Mark that we have seen a nominal type
+    fn markNominal(self: Context) Context {
+        return .{
+            .recursion_allowed = self.recursion_allowed,
+            .seen_nominal = true,
+        };
     }
 };
 
@@ -173,6 +273,7 @@ const Scratch = struct {
 
     seen: Var.SafeList,
     err_chain: Var.SafeList,
+    err_chain_nominal_vars: Var.SafeList,
     visited: MkSafeList(DescStoreIdx),
 
     fn init(gpa: std.mem.Allocator) Self {
@@ -183,6 +284,7 @@ const Scratch = struct {
             .gpa = gpa,
             .seen = Var.SafeList.initCapacity(gpa, 32),
             .err_chain = Var.SafeList.initCapacity(gpa, 32),
+            .err_chain_nominal_vars = Var.SafeList.initCapacity(gpa, 8),
             .visited = MkSafeList(DescStoreIdx).initCapacity(gpa, 64),
         };
     }
@@ -190,12 +292,14 @@ const Scratch = struct {
     fn deinit(self: *Self) void {
         self.seen.deinit(self.gpa);
         self.err_chain.deinit(self.gpa);
+        self.err_chain_nominal_vars.deinit(self.gpa);
         self.visited.deinit(self.gpa);
     }
 
     fn reset(self: *Self) void {
         self.seen.items.clearRetainingCapacity();
         self.err_chain.items.clearRetainingCapacity();
+        self.err_chain_nominal_vars.items.clearRetainingCapacity();
         self.visited.items.clearRetainingCapacity();
     }
 
@@ -222,8 +326,16 @@ const Scratch = struct {
         _ = self.err_chain.append(self.gpa, var_);
     }
 
+    fn appendErrChainNominalVar(self: *Self, var_: Var) void {
+        _ = self.err_chain_nominal_vars.append(self.gpa, var_);
+    }
+
     fn errChainSlice(self: *const Scratch) []const Var {
         return self.err_chain.items.items;
+    }
+
+    fn errChainNominalVarsSlice(self: *const Scratch) []const Var {
+        return self.err_chain_nominal_vars.items.items;
     }
 };
 
@@ -242,7 +354,7 @@ test "occurs: no recurcion (v = Str)" {
     const str_var = types_store.freshFromContent(Content{ .structure = .str });
 
     const result = occurs(&types_store, &scratch, str_var);
-    try std.testing.expectEqual(false, result);
+    try std.testing.expectEqual(.not_recursive, result);
 }
 
 test "occurs: direct recursion (v = List v)" {
@@ -263,7 +375,7 @@ test "occurs: direct recursion (v = List v)" {
     try types_store.setRootVarContent(list_var, list_content);
 
     const result = occurs(&types_store, &scratch, list_var);
-    try std.testing.expectEqual(true, result);
+    try std.testing.expectEqual(.recursive_anonymous, result);
 
     const err_chain = scratch.errChainSlice();
     try std.testing.expectEqual(1, err_chain.len);
@@ -288,7 +400,7 @@ test "occurs: indirect recursion (v1 = Box v2, v2 = List v1)" {
     try types_store.setRootVarContent(v2, Content{ .structure = .{ .list = v1 } });
 
     const result = occurs(&types_store, &scratch, v1);
-    try std.testing.expectEqual(true, result);
+    try std.testing.expectEqual(.recursive_anonymous, result);
 
     const err_chain = scratch.errChainSlice();
     try std.testing.expectEqual(2, err_chain.len);
@@ -314,7 +426,7 @@ test "occurs: no recursion through two levels (v1 = Box v2, v2 = Str)" {
     try types_store.setRootVarContent(v2, Content{ .structure = .str });
 
     const result = occurs(&types_store, &scratch, v1);
-    try std.testing.expectEqual(false, result);
+    try std.testing.expectEqual(.not_recursive, result);
 }
 
 test "occurs: tuple recursion (v = Tuple(v, Str))" {
@@ -337,7 +449,7 @@ test "occurs: tuple recursion (v = Tuple(v, Str))" {
     try types_store.setRootVarContent(v, Content{ .structure = .{ .tuple = tuple } });
 
     const result = occurs(&types_store, &scratch, v);
-    try std.testing.expectEqual(true, result);
+    try std.testing.expectEqual(.infinite, result);
 
     const err_chain = scratch.errChainSlice();
     try std.testing.expectEqual(1, err_chain.len);
@@ -363,7 +475,7 @@ test "occurs: tuple not recursive (v = Tuple(Str, Str))" {
     const v = types_store.freshFromContent(Content{ .structure = .{ .tuple = tuple } });
 
     const result = occurs(&types_store, &scratch, v);
-    try std.testing.expectEqual(false, result);
+    try std.testing.expectEqual(.not_recursive, result);
 
     try std.testing.expectEqual(2, scratch.visited.len());
 }
@@ -393,7 +505,7 @@ test "occurs: recursive alias (v = Alias(List v))" {
     });
 
     const result = occurs(&types_store, &scratch, v);
-    try std.testing.expectEqual(true, result);
+    try std.testing.expectEqual(.infinite, result);
 
     const err_chain = scratch.errChainSlice();
     try std.testing.expectEqual(1, err_chain.len);
@@ -423,10 +535,10 @@ test "occurs: alias with no recursion (v = Alias Str)" {
     } });
 
     const result = occurs(&types_store, &scratch, alias_var);
-    try std.testing.expectEqual(false, result);
+    try std.testing.expectEqual(.not_recursive, result);
 }
 
-test "occurs: recursive tag union (v = TagUnion { Foo(v) } with ext = v)" {
+test "occurs: recursive tag union (v = [ Cons(elem, v), Nil ]" {
     const gpa = std.testing.allocator;
     var module_env = base.ModuleEnv.init(gpa);
     defer module_env.deinit();
@@ -453,7 +565,7 @@ test "occurs: recursive tag union (v = TagUnion { Foo(v) } with ext = v)" {
     try types_store.setRootVarContent(linked_list, .{ .structure = .{ .tag_union = tag_union } });
 
     const result = occurs(&types_store, &scratch, linked_list);
-    try std.testing.expectEqual(true, result);
+    try std.testing.expectEqual(.recursive_anonymous, result);
 
     const err_chain = scratch.errChainSlice();
     try std.testing.expectEqual(1, err_chain.len);
@@ -463,8 +575,7 @@ test "occurs: recursive tag union (v = TagUnion { Foo(v) } with ext = v)" {
         try std.testing.expectEqual(Mark.none, types_store.getDesc(visited_desc_idx).mark);
     }
 }
-
-test "occurs: nested recursive tag union (v = TagUnion { Cons(elem, Box(v)) } )" {
+test "occurs: nested recursive tag union (v = [ Cons(elem, Box(v)) ] )" {
     const gpa = std.testing.allocator;
     var module_env = base.ModuleEnv.init(gpa);
     defer module_env.deinit();
@@ -495,12 +606,178 @@ test "occurs: nested recursive tag union (v = TagUnion { Cons(elem, Box(v)) } )"
     try types_store.setRootVarContent(linked_list, .{ .structure = .{ .tag_union = tag_union } });
 
     const result = occurs(&types_store, &scratch, linked_list);
-    try std.testing.expectEqual(true, result);
+    try std.testing.expectEqual(.recursive_anonymous, result);
 
     const err_chain = scratch.errChainSlice();
     try std.testing.expect(err_chain.len == 2);
     try std.testing.expectEqual(err_chain[0], boxed_linked_list);
     try std.testing.expectEqual(err_chain[1], linked_list);
+
+    for (scratch.visited.items.items[0..]) |visited_desc_idx| {
+        try std.testing.expectEqual(Mark.none, types_store.getDesc(visited_desc_idx).mark);
+    }
+}
+
+test "occurs: recursive tag union (v = List: [ Cons(Elem, List), Nil ])" {
+    const gpa = std.testing.allocator;
+    var module_env = base.ModuleEnv.init(gpa);
+    defer module_env.deinit();
+
+    var types_store = Store.init(&module_env);
+    defer types_store.deinit();
+
+    var scratch = Scratch.init(gpa);
+    defer scratch.deinit();
+
+    const custom_type = types_store.fresh();
+
+    const elem = types_store.fresh();
+    const ext = types_store.fresh();
+
+    const cons_tag_args = types_store.appendTagArgs(&[_]Var{ elem, custom_type });
+    const cons_tag = types.Tag{ .name = undefined, .args = cons_tag_args };
+
+    const nil_tag = types.Tag{ .name = undefined, .args = Var.SafeList.Range.empty };
+
+    const tags = types_store.appendTags(&[_]Tag{ cons_tag, nil_tag });
+
+    const tag_union = types_store.freshFromContent(.{ .structure = .{ .tag_union = TagUnion{ .tags = tags, .ext = ext } } });
+
+    try types_store.setRootVarContent(custom_type, .{ .structure = .{ .custom_type = CustomType{
+        .ident = undefined,
+        .args = Var.SafeList.Range.empty,
+        .backing_var = tag_union,
+    } } });
+
+    // assert that starting from the nominal type, it works
+
+    const result1 = occurs(&types_store, &scratch, custom_type);
+    try std.testing.expectEqual(.recursive_nominal, result1);
+
+    const err_chain1 = scratch.errChainSlice();
+    try std.testing.expectEqual(2, err_chain1.len);
+    try std.testing.expectEqual(tag_union, err_chain1[0]);
+    try std.testing.expectEqual(custom_type, err_chain1[1]);
+
+    const err_chain_nominal1 = scratch.errChainNominalVarsSlice();
+    try std.testing.expectEqual(1, err_chain_nominal1.len);
+    try std.testing.expectEqual(custom_type, err_chain_nominal1[0]);
+
+    for (scratch.visited.items.items[0..]) |visited_desc_idx| {
+        try std.testing.expectEqual(Mark.none, types_store.getDesc(visited_desc_idx).mark);
+    }
+
+    // assert that starting from the the tag union, it works
+
+    const result2 = occurs(&types_store, &scratch, tag_union);
+    try std.testing.expectEqual(.recursive_nominal, result2);
+
+    const err_chain2 = scratch.errChainSlice();
+    try std.testing.expectEqual(2, err_chain2.len);
+    try std.testing.expectEqual(custom_type, err_chain2[0]);
+    try std.testing.expectEqual(tag_union, err_chain2[1]);
+
+    const err_chain_nominal2 = scratch.errChainNominalVarsSlice();
+    try std.testing.expectEqual(1, err_chain_nominal2.len);
+    try std.testing.expectEqual(custom_type, err_chain_nominal2[0]);
+
+    for (scratch.visited.items.items[0..]) |visited_desc_idx| {
+        try std.testing.expectEqual(Mark.none, types_store.getDesc(visited_desc_idx).mark);
+    }
+}
+
+test "occurs: recursive tag union with multiple nominals (TypeA := TypeB, TypeB := [ Cons(Elem, TypeA), Nil ])" {
+    const gpa = std.testing.allocator;
+    var module_env = base.ModuleEnv.init(gpa);
+    defer module_env.deinit();
+
+    var types_store = Store.init(&module_env);
+    defer types_store.deinit();
+
+    var scratch = Scratch.init(gpa);
+    defer scratch.deinit();
+
+    const type_a_nominal = types_store.fresh();
+    const type_b_nominal = types_store.fresh();
+
+    const elem = types_store.fresh();
+    const ext = types_store.fresh();
+
+    const cons_tag_args = types_store.appendTagArgs(&[_]Var{ elem, type_a_nominal });
+    const cons_tag = types.Tag{ .name = undefined, .args = cons_tag_args };
+    const nil_tag = types.Tag{ .name = undefined, .args = Var.SafeList.Range.empty };
+    const tags = types_store.appendTags(&[_]Tag{ cons_tag, nil_tag });
+    const tag_union = types_store.freshFromContent(.{ .structure = .{ .tag_union = TagUnion{ .tags = tags, .ext = ext } } });
+
+    // TypeB = [ Cons(Elem, TypeA), Nil ]
+    try types_store.setRootVarContent(type_b_nominal, .{ .structure = .{ .custom_type = CustomType{
+        .ident = undefined,
+        .args = Var.SafeList.Range.empty,
+        .backing_var = tag_union,
+    } } });
+
+    // TypeA = TypeB
+    try types_store.setRootVarContent(type_a_nominal, .{ .structure = .{ .custom_type = CustomType{
+        .ident = undefined,
+        .args = Var.SafeList.Range.empty,
+        .backing_var = type_b_nominal,
+    } } });
+
+    // assert that starting from the `TypeA` nominal, it works
+
+    const result1 = occurs(&types_store, &scratch, type_a_nominal);
+    try std.testing.expectEqual(.recursive_nominal, result1);
+
+    const err_chain1 = scratch.errChainSlice();
+    try std.testing.expectEqual(3, err_chain1.len);
+    try std.testing.expectEqual(tag_union, err_chain1[0]);
+    try std.testing.expectEqual(type_b_nominal, err_chain1[1]);
+    try std.testing.expectEqual(type_a_nominal, err_chain1[2]);
+
+    const err_chain_nominal1 = scratch.errChainNominalVarsSlice();
+    try std.testing.expectEqual(2, err_chain_nominal1.len);
+    try std.testing.expectEqual(type_b_nominal, err_chain_nominal1[0]);
+    try std.testing.expectEqual(type_a_nominal, err_chain_nominal1[1]);
+
+    for (scratch.visited.items.items[0..]) |visited_desc_idx| {
+        try std.testing.expectEqual(Mark.none, types_store.getDesc(visited_desc_idx).mark);
+    }
+
+    // assert that starting from the `TypeB` nominal, it works
+
+    const result2 = occurs(&types_store, &scratch, type_b_nominal);
+    try std.testing.expectEqual(.recursive_nominal, result2);
+
+    const err_chain2 = scratch.errChainSlice();
+    try std.testing.expectEqual(3, err_chain2.len);
+    try std.testing.expectEqual(type_a_nominal, err_chain2[0]);
+    try std.testing.expectEqual(tag_union, err_chain2[1]);
+    try std.testing.expectEqual(type_b_nominal, err_chain2[2]);
+
+    const err_chain_nominal2 = scratch.errChainNominalVarsSlice();
+    try std.testing.expectEqual(2, err_chain_nominal2.len);
+    try std.testing.expectEqual(type_a_nominal, err_chain_nominal2[0]);
+    try std.testing.expectEqual(type_b_nominal, err_chain_nominal2[1]);
+
+    for (scratch.visited.items.items[0..]) |visited_desc_idx| {
+        try std.testing.expectEqual(Mark.none, types_store.getDesc(visited_desc_idx).mark);
+    }
+
+    // assert that starting from the the tag union, it works
+
+    const result3 = occurs(&types_store, &scratch, tag_union);
+    try std.testing.expectEqual(.recursive_nominal, result3);
+
+    const err_chain3 = scratch.errChainSlice();
+    try std.testing.expectEqual(3, err_chain3.len);
+    try std.testing.expectEqual(type_b_nominal, err_chain3[0]);
+    try std.testing.expectEqual(type_a_nominal, err_chain3[1]);
+    try std.testing.expectEqual(tag_union, err_chain3[2]);
+
+    const err_chain_nominal3 = scratch.errChainNominalVarsSlice();
+    try std.testing.expectEqual(2, err_chain_nominal3.len);
+    try std.testing.expectEqual(type_b_nominal, err_chain_nominal3[0]);
+    try std.testing.expectEqual(type_a_nominal, err_chain_nominal3[1]);
 
     for (scratch.visited.items.items[0..]) |visited_desc_idx| {
         try std.testing.expectEqual(Mark.none, types_store.getDesc(visited_desc_idx).mark);

--- a/src/check/check_types/unify.zig
+++ b/src/check/check_types/unify.zig
@@ -1585,8 +1585,8 @@ const Unifier = struct {
         const range_start: TagSafeMultiList.Idx = @enumFromInt(self.types_store.tags.len());
 
         for (shared_tags) |tags| {
-            const tag_a_args = self.types_store.tag_args.rangeToSlice(tags.a.args);
-            const tag_b_args = self.types_store.tag_args.rangeToSlice(tags.b.args);
+            const tag_a_args = self.types_store.getTagArgsSlice(tags.a.args);
+            const tag_b_args = self.types_store.getTagArgsSlice(tags.b.args);
 
             if (tag_a_args.len != tag_b_args.len) return error.TypeMismatch;
 

--- a/src/test.zig
+++ b/src/test.zig
@@ -5,5 +5,8 @@ test {
     testing.refAllDeclsRecursive(@import("main.zig"));
     testing.refAllDeclsRecursive(@import("snapshot.zig"));
     testing.refAllDeclsRecursive(@import("builtins/main.zig"));
+
+    // TODO: Remove after hooking up
     testing.refAllDeclsRecursive(@import("eval/stack.zig"));
+    testing.refAllDeclsRecursive(@import("check/check_types/occurs.zig"));
 }

--- a/src/types/store.zig
+++ b/src/types/store.zig
@@ -166,33 +166,47 @@ pub const Store = struct {
     // sub list getters //
 
     /// Given a range, get a slice of alias args from the backing array
-    pub fn getAliasArgsSlice(self: *Self, range: VarSafeList.Range) VarSafeList.Slice {
+    pub fn getAliasArgsSlice(self: *const Self, range: VarSafeList.Range) VarSafeList.Slice {
         return self.alias_args.rangeToSlice(range);
     }
 
     /// Given a range, get a slice of tuple from the backing list
-    pub fn getTupleElemsSlice(self: *Self, range: VarSafeList.Range) VarSafeList.Slice {
+    pub fn getTupleElemsSlice(self: *const Self, range: VarSafeList.Range) VarSafeList.Slice {
         return self.tuple_elems.rangeToSlice(range);
     }
 
     /// Given a range, get a slice of type from to the backing
-    pub fn getCustomTypeArgsSlice(self: *Self, range: VarSafeList.Range) VarSafeList.Slice {
+    pub fn getCustomTypeArgsSlice(self: *const Self, range: VarSafeList.Range) VarSafeList.Slice {
         return self.custom_type_args.rangeToSlice(range);
     }
 
     /// Given a range, get a slice of func from the backing list
-    pub fn getFuncArgsSlice(self: *Self, range: VarSafeList.Range) VarSafeList.Slice {
+    pub fn getFuncArgsSlice(self: *const Self, range: VarSafeList.Range) VarSafeList.Slice {
         return self.func_args.rangeToSlice(range);
     }
 
     /// Given a range, get a slice of record fields from the backing array
-    pub fn getRecordFieldsSlice(self: *Self, range: RecordFieldSafeMultiList.Range) RecordFieldSafeMultiList.Slice {
+    pub fn getRecordFieldsSlice(self: *const Self, range: RecordFieldSafeMultiList.Range) RecordFieldSafeMultiList.Slice {
         return self.record_fields.rangeToSlice(range);
     }
 
     /// Given a range, get a slice of tags from the backing array
-    pub fn getTagsSlice(self: *Self, range: TagSafeMultiList.Range) TagSafeMultiList.Slice {
+    pub fn getTagsSlice(self: *const Self, range: TagSafeMultiList.Range) TagSafeMultiList.Slice {
         return self.tags.rangeToSlice(range);
+    }
+
+    /// Given a range, get a slice of tag args from the backing array
+    pub fn getTagArgsSlice(self: *const Self, range: VarSafeList.Range) VarSafeList.Slice {
+        return self.tag_args.rangeToSlice(range);
+    }
+
+    // mark & rank //
+
+    /// Set the mark for a descriptor
+    pub fn setDescMark(self: *Self, desc_idx: DescStore.Idx, mark: Mark) void {
+        var desc = self.descs.get(desc_idx);
+        desc.mark = mark;
+        self.descs.set(desc_idx, desc);
     }
 
     // resolvers //
@@ -314,6 +328,24 @@ pub const Store = struct {
     /// Used in tests
     pub fn getDesc(self: *Self, desc_idx: DescStore.Idx) Desc {
         return self.descs.get(desc_idx);
+    }
+
+    const Error = error{VarNotRoot};
+
+    /// Set a root var to be the specified content
+    /// Used in tests
+    pub fn setRootVarContent(self: *Self, var_: Var, content: Content) error{VarNotRoot}!void {
+        const slot = self.slots.get(Self.varToSlotIdx(var_));
+        switch (slot) {
+            .root => |desc_idx| {
+                var desc = self.descs.get(desc_idx);
+                desc.content = content;
+                self.descs.set(desc_idx, desc);
+            },
+            .redirect => {
+                return error.VarNotRoot;
+            },
+        }
     }
 
     // helpers //

--- a/src/types/store.zig
+++ b/src/types/store.zig
@@ -432,8 +432,12 @@ const DescStore = struct {
     }
 
     /// A type-safe index into the store
+    /// This type is made public below
     const Idx = enum(u32) { _ };
 };
+
+/// An index into the desc store
+pub const DescStoreIdx = DescStore.Idx;
 
 // path compression
 

--- a/src/types/types.zig
+++ b/src/types/types.zig
@@ -52,12 +52,16 @@ pub const Rank = enum(u4) {
 };
 
 /// A type variable mark
+///
+/// Marks are temporary annotations used during various phases of type inference
+/// and type checking to track state and avoid redundant work.
+///
+/// Some places `Mark` is used:
+/// * Marking variables for generalizing during solving
 pub const Mark = enum(u32) {
     const Self = @This();
 
-    getVarNames = 0,
-    occurs = 1,
-    none = 2,
+    none = 0,
     _,
 
     /// Get the next mark

--- a/src/types/types.zig
+++ b/src/types/types.zig
@@ -117,6 +117,21 @@ pub const Content = union(enum) {
             else => return null,
         }
     }
+
+    /// Unwrap a custom type or return null
+    pub fn unwrapCustomType(content: Self) ?CustomType {
+        switch (content) {
+            .structure => |flat_type| {
+                switch (flat_type) {
+                    .custom_type => |custom_type| {
+                        return custom_type;
+                    },
+                    else => return null,
+                }
+            },
+            else => return null,
+        }
+    }
 };
 
 // alias //

--- a/src/types/types.zig
+++ b/src/types/types.zig
@@ -54,14 +54,16 @@ pub const Rank = enum(u4) {
 /// A type variable mark
 ///
 /// Marks are temporary annotations used during various phases of type inference
-/// and type checking to track state and avoid redundant work.
+/// and type checking to track state.
 ///
 /// Some places `Mark` is used:
+/// * Marking variables as visited in occurs checks to avoid redundant work
 /// * Marking variables for generalizing during solving
 pub const Mark = enum(u32) {
     const Self = @This();
 
-    none = 0,
+    visited = 0,
+    none = 1,
     _,
 
     /// Get the next mark


### PR DESCRIPTION
## Overview

This PR implements the `occurs` check for type variables. This means, for a given type variable:
* Resolve it to its type (ie follow `redirect`s until we get a concrete type)
* Recursively unwrap all subtype variables for the type (ie all tags in tag unions, record fields in records, etc)
* Check if we run into a variable we've seen already before

This is the 1st step in the larger project of supporting recursive types in the type system, but only for nominal types – [as outlined here](https://github.com/roc-lang/rfcs/blob/ayaz/compile-with-lambda-sets/0101-compiling-recursive-types.md#1-recursive-types-must-have-a-explicit-point-of-recursion). This check is not yet used anywhere, that will come in a follow-up PR.

> There has been some discussion in Zulip recently around if it's possible to allow non-nominal-recursion. Depending on how that shakes out, this implementation may change in the future.

## Memory Management

During the occurs check, there are things we need to write down:
* What variables we've `seen` so far (pushed & popped for each recursive branch)
* All the variables we've `visited` and confirmed are not recursive (to avoid redundant work)
* In the case of an error, what the chain of recursive types was (for error messages)

To capture this, we use a `Scratch` struct that allocates some array lists that can be re-used across many occurs check. This is the same pattern that `unify` uses to hold intermediate data.

## Differences from the Rust Compiler

This implementation has not significant difference from the Rust compiler version. Originally, I did things slightly differently, but ultimately decided that it probably made the most sense to match the semantics of the Rust version. That said, if those reviewing like the original approach, we can easily revert.

### Original "Differences from the Rust Compiler"

The Rust implementation of occurs takes a different approach to avoiding redundant work

* It uses each variable’s `Mark` field to track visited state during the check
* After the traversal, it resets all visited marks

This requires:
* Mutably updating `Mark` values on each visited descriptor
* Tracking visited variables separately in order to reset them

The Zig version does not use `Mark` at all. Instead:
* It tracks visited variables explicitly in an array
* Redundancy is avoided by checking this array during traversal

This results in the same number of allocations, but with two key differences:
1. No need to mutate or reset `Mark` fields on descriptors
2. Possibly slightly worse per-step performance due to linear O(n) check of the already `visited` array
    * Note that both the Zig and Rust versions do a linear scan of `seen` variables, though the total number of `seen` vars for any given recursive branch would be less than the total visited nodes.

That said, I'm unsure what the average number of variables in a type is, but this approach assumes it would be relatively small. (We could also use a Map to check for seen/visited vars, which may perform better than an array)
