### PR TITLE
SIMD chompTrivia

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -108,6 +108,20 @@ pub fn build(b: *std.Build) void {
     add_tracy(b, build_options, snapshot_exe, target, false, tracy);
     install_and_run(b, no_bin, snapshot_exe, snapshot_step, snapshot_step);
 
+    // Add test_chomp_perf
+    const test_chomp_perf_exe = b.addExecutable(.{
+        .name = "test_chomp_perf",
+        .root_source_file = b.path("test_chomp_perf.zig"),
+        .target = target,
+        .optimize = optimize,
+        .link_libc = true,
+    });
+    test_chomp_perf_exe.root_module.addOptions("build_options", build_options);
+    add_tracy(b, build_options, test_chomp_perf_exe, target, false, tracy);
+
+    const test_chomp_perf_step = b.step("test_chomp_perf", "Quick chompTrivia performance test");
+    install_and_run(b, no_bin, test_chomp_perf_exe, test_chomp_perf_step, test_chomp_perf_step);
+
     const all_tests = b.addTest(.{
         .root_source_file = b.path("src/test.zig"),
         .target = target,

--- a/src/BigFile.roc
+++ b/src/BigFile.roc
@@ -1,0 +1,10046 @@
+# This is a module comment!
+app [main!] { pf: platform "../basic-cli/platform.roc" }
+                                                        import pf.Stdout exposing [line!, write!]
+
+import # Comment after import keyword
+	pf # Comment after qualifier
+		.StdoutMultiline # Comment after ident
+		exposing [ # Comment after exposing open
+			line!, # Comment after exposed item
+			write!, # Another after exposed item
+		] # Comment after exposing close
+
+import pkg.Something exposing [func as function, Type as ValueCategory, Custom.*]
+
+import BadName as GoodName
+import
+	BadNameMultiline
+		as
+		GoodNameMultiline
+
+Map(a, b) : List(a), (a -> b) -> List(b)
+MapML( # Comment here
+	a, # And here
+	b,
+) # And after the last arg
+	: # And after the colon
+		List( # Inside Tag args
+			a, # After tag arg
+		),
+		(a -> b) -> # After arrow
+			List( # Inside tag args
+				b,
+			) # And after the type decl
+
+Foo : (Bar, Baz)
+
+FooMultiline : ( # Comment after pattern tuple open
+	Bar, # Comment after pattern tuple item
+	Baz, # Another after pattern tuple item
+) # Comment after pattern tuple close
+
+Some(a) : { foo : Ok(a), bar : Something }
+SomeMl(a) : { # After record open
+	foo : Ok(a), # After field
+	bar : Something, # After last field
+}
+
+SomeMultiline(a) : { # Comment after pattern record open
+	foo # After field name
+		: # Before field anno
+			Ok(a), # Comment after pattern record field
+	bar : Something, # Another after pattern record field
+} # Comment after pattern record close
+
+Maybe(a) : [Some(a), None]
+
+MaybeMultiline(a) : [ # Comment after tag union open
+	Some(a), # Comment after tag union member
+	None, # Another after tag union member
+] # Comment after tag union close
+
+SomeFunc(a) : Maybe(a), a -> Maybe(a)
+
+add_one_oneline = |num| if num 2 else 5
+
+add_one : U64 -> U64
+add_one = |num| {
+	other = 1
+	if num {
+		dbg # After debug
+			some_func() # After debug expr
+		0
+	} else {
+		dbg 123
+		other
+	}
+}
+
+match_time = |
+	a, # After arg
+	b,
+| # After args
+	match a {
+		Blue | Green | Red => {
+			x = 12
+			x
+		}
+		Blue # After pattern in alt
+		| # Before pattern in alt
+			Green
+		| Red # After alt pattern
+			=> {
+				x = 12
+				x
+			}
+		lower # After pattern comment
+			=> 1
+		"foo" => # After arrow comment
+			100
+		"foo" | "bar" => 200
+		[1, 2, 3, .. as rest] # After pattern comment
+			=> # After arrow comment
+				123 # After branch comment
+
+		# Just a random comment
+
+		[1, 2 | 5, 3, .. as rest] => 123
+		[
+			1,
+			2 | 5,
+			3,
+			.. # After DoubleDot
+				as # Before alias
+					rest, # After last pattern in list
+		] => 123
+		3.14 => 314
+		3.14 | 6.28 => 314
+		(1, 2, 3) => 123
+		(1, 2 | 5, 3) => 123
+		{ foo: 1, bar: 2, ..rest } => 12->add(34)
+		{ # After pattern record open
+			foo # After pattern record field name
+				: # Before pattern record field value
+					1, # After pattern record field
+			bar: 2,
+			.. # After spread operator
+				rest, # After last field
+		} => 12
+		{ foo: 1, bar: 2 | 7 } => 12
+		{
+			foo: 1,
+			bar: 2 | 7, # After last record field
+		} => 12
+		Ok(123) => 123
+		Ok(Some(dude)) => dude
+		TwoArgs("hello", Some("world")) => 1000
+	}
+
+expect # Comment after expect keyword
+	blah == 1 # Comment after expect statement
+
+main! : List(String) -> Result({}, _)
+main! = |_| { # Yeah I can leave a comment here
+	world = "World"
+	var number = 123
+	expect blah == 1
+	tag = Blue
+	return # Comment after return keyword
+		tag # Comment after return statement
+
+	# Just a random comment!
+
+	...
+	match_time(
+		..., # Single args with comment
+	)
+	some_func(
+		dbg # After debug
+			42, # After debug expr
+	)
+	crash # Comment after crash keyword
+		"Unreachable!" # Comment after crash statement
+	tag_with_payload = Ok(number)
+	interpolated = "Hello, ${world}"
+	list = [
+		add_one(
+			dbg # After dbg in list
+				number, # after dbg expr as arg
+		), # Comment one
+		456, # Comment two
+		789, # Comment three
+	]
+	for n in list {
+		Stdout.line!("Adding ${n} to ${number}")
+		number = number + n
+	}
+	record = { foo: 123, bar: "Hello", baz: tag, qux: Ok(world), punned }
+	tuple = (123, "World", tag, Ok(world), (nested, tuple), [1, 2, 3])
+	multiline_tuple = (
+		123,
+		"World",
+		tag1,
+		Ok(world), # This one has a comment
+		(nested, tuple),
+		[1, 2, 3],
+	)
+	bin_op_result = Err(foo) ?? 12 > 5 * 5 or 13 + 2 < 5 and 10 - 1 >= 16 or 12 <= 3 / 5
+	static_dispatch_style = some_fn(arg1)?.static_dispatch_method()?.next_static_dispatch_method()?.record_field?
+	Stdout.line!(interpolated)?
+	Stdout.line!(
+		"How about ${ # Comment after string interpolation open
+			Num.toStr(number) # Comment after string interpolation expr
+		} as a string?",
+	)
+} # Comment after top-level decl
+
+empty : {}
+empty = {}
+
+tuple : Value((a, b, c))
+
+expect {
+	foo = 1 # This should work too
+	blah = 1
+	blah == foo
+}
+
+import pf.Stdout exposing [line!, write!]
+
+import # Comment after import keyword
+	pf # Comment after qualifier
+		.StdoutMultiline # Comment after ident
+		exposing [ # Comment after exposing open
+			line!, # Comment after exposed item
+			write!, # Another after exposed item
+		] # Comment after exposing close
+
+import pkg.Something exposing [func as function, Type as ValueCategory, Custom.*]
+
+import BadName as GoodName
+import
+	BadNameMultiline
+		as
+		GoodNameMultiline
+
+Map(a, b) : List(a), (a -> b) -> List(b)
+MapML( # Comment here
+	a, # And here
+	b,
+) # And after the last arg
+	: # And after the colon
+		List( # Inside Tag args
+			a, # After tag arg
+		),
+		(a -> b) -> # After arrow
+			List( # Inside tag args
+				b,
+			) # And after the type decl
+
+Foo : (Bar, Baz)
+
+FooMultiline : ( # Comment after pattern tuple open
+	Bar, # Comment after pattern tuple item
+	Baz, # Another after pattern tuple item
+) # Comment after pattern tuple close
+
+Some(a) : { foo : Ok(a), bar : Something }
+SomeMl(a) : { # After record open
+	foo : Ok(a), # After field
+	bar : Something, # After last field
+}
+
+SomeMultiline(a) : { # Comment after pattern record open
+	foo # After field name
+		: # Before field anno
+			Ok(a), # Comment after pattern record field
+	bar : Something, # Another after pattern record field
+} # Comment after pattern record close
+
+Maybe(a) : [Some(a), None]
+
+MaybeMultiline(a) : [ # Comment after tag union open
+	Some(a), # Comment after tag union member
+	None, # Another after tag union member
+] # Comment after tag union close
+
+SomeFunc(a) : Maybe(a), a -> Maybe(a)
+
+add_one_oneline = |num| if num 2 else 5
+
+add_one : U64 -> U64
+add_one = |num| {
+	other = 1
+	if num {
+		dbg # After debug
+			some_func() # After debug expr
+		0
+	} else {
+		dbg 123
+		other
+	}
+}
+
+match_time = |
+	a, # After arg
+	b,
+| # After args
+	match a {
+		Blue | Green | Red => {
+			x = 12
+			x
+		}
+		Blue # After pattern in alt
+		| # Before pattern in alt
+			Green
+		| Red # After alt pattern
+			=> {
+				x = 12
+				x
+			}
+		lower # After pattern comment
+			=> 1
+		"foo" => # After arrow comment
+			100
+		"foo" | "bar" => 200
+		[1, 2, 3, .. as rest] # After pattern comment
+			=> # After arrow comment
+				123 # After branch comment
+
+		# Just a random comment
+
+		[1, 2 | 5, 3, .. as rest] => 123
+		[
+			1,
+			2 | 5,
+			3,
+			.. # After DoubleDot
+				as # Before alias
+					rest, # After last pattern in list
+		] => 123
+		3.14 => 314
+		3.14 | 6.28 => 314
+		(1, 2, 3) => 123
+		(1, 2 | 5, 3) => 123
+		{ foo: 1, bar: 2, ..rest } => 12->add(34)
+		{ # After pattern record open
+			foo # After pattern record field name
+				: # Before pattern record field value
+					1, # After pattern record field
+			bar: 2,
+			.. # After spread operator
+				rest, # After last field
+		} => 12
+		{ foo: 1, bar: 2 | 7 } => 12
+		{
+			foo: 1,
+			bar: 2 | 7, # After last record field
+		} => 12
+		Ok(123) => 123
+		Ok(Some(dude)) => dude
+		TwoArgs("hello", Some("world")) => 1000
+	}
+
+expect # Comment after expect keyword
+	blah == 1 # Comment after expect statement
+
+main! : List(String) -> Result({}, _)
+main! = |_| { # Yeah I can leave a comment here
+	world = "World"
+	var number = 123
+	expect blah == 1
+	tag = Blue
+	return # Comment after return keyword
+		tag # Comment after return statement
+
+	# Just a random comment!
+
+	...
+	match_time(
+		..., # Single args with comment
+	)
+	some_func(
+		dbg # After debug
+			42, # After debug expr
+	)
+	crash # Comment after crash keyword
+		"Unreachable!" # Comment after crash statement
+	tag_with_payload = Ok(number)
+	interpolated = "Hello, ${world}"
+	list = [
+		add_one(
+			dbg # After dbg in list
+				number, # after dbg expr as arg
+		), # Comment one
+		456, # Comment two
+		789, # Comment three
+	]
+	for n in list {
+		Stdout.line!("Adding ${n} to ${number}")
+		number = number + n
+	}
+	record = { foo: 123, bar: "Hello", baz: tag, qux: Ok(world), punned }
+	tuple = (123, "World", tag, Ok(world), (nested, tuple), [1, 2, 3])
+	multiline_tuple = (
+		123,
+		"World",
+		tag1,
+		Ok(world), # This one has a comment
+		(nested, tuple),
+		[1, 2, 3],
+	)
+	bin_op_result = Err(foo) ?? 12 > 5 * 5 or 13 + 2 < 5 and 10 - 1 >= 16 or 12 <= 3 / 5
+	static_dispatch_style = some_fn(arg1)?.static_dispatch_method()?.next_static_dispatch_method()?.record_field?
+	Stdout.line!(interpolated)?
+	Stdout.line!(
+		"How about ${ # Comment after string interpolation open
+			Num.toStr(number) # Comment after string interpolation expr
+		} as a string?",
+	)
+} # Comment after top-level decl
+
+empty : {}
+empty = {}
+
+tuple : Value((a, b, c))
+
+expect {
+	foo = 1 # This should work too
+	blah = 1
+	blah == foo
+}
+
+import pf.Stdout exposing [line!, write!]
+
+import # Comment after import keyword
+	pf # Comment after qualifier
+		.StdoutMultiline # Comment after ident
+		exposing [ # Comment after exposing open
+			line!, # Comment after exposed item
+			write!, # Another after exposed item
+		] # Comment after exposing close
+
+import pkg.Something exposing [func as function, Type as ValueCategory, Custom.*]
+
+import BadName as GoodName
+import
+	BadNameMultiline
+		as
+		GoodNameMultiline
+
+Map(a, b) : List(a), (a -> b) -> List(b)
+MapML( # Comment here
+	a, # And here
+	b,
+) # And after the last arg
+	: # And after the colon
+		List( # Inside Tag args
+			a, # After tag arg
+		),
+		(a -> b) -> # After arrow
+			List( # Inside tag args
+				b,
+			) # And after the type decl
+
+Foo : (Bar, Baz)
+
+FooMultiline : ( # Comment after pattern tuple open
+	Bar, # Comment after pattern tuple item
+	Baz, # Another after pattern tuple item
+) # Comment after pattern tuple close
+
+Some(a) : { foo : Ok(a), bar : Something }
+SomeMl(a) : { # After record open
+	foo : Ok(a), # After field
+	bar : Something, # After last field
+}
+
+SomeMultiline(a) : { # Comment after pattern record open
+	foo # After field name
+		: # Before field anno
+			Ok(a), # Comment after pattern record field
+	bar : Something, # Another after pattern record field
+} # Comment after pattern record close
+
+Maybe(a) : [Some(a), None]
+
+MaybeMultiline(a) : [ # Comment after tag union open
+	Some(a), # Comment after tag union member
+	None, # Another after tag union member
+] # Comment after tag union close
+
+SomeFunc(a) : Maybe(a), a -> Maybe(a)
+
+add_one_oneline = |num| if num 2 else 5
+
+add_one : U64 -> U64
+add_one = |num| {
+	other = 1
+	if num {
+		dbg # After debug
+			some_func() # After debug expr
+		0
+	} else {
+		dbg 123
+		other
+	}
+}
+
+match_time = |
+	a, # After arg
+	b,
+| # After args
+	match a {
+		Blue | Green | Red => {
+			x = 12
+			x
+		}
+		Blue # After pattern in alt
+		| # Before pattern in alt
+			Green
+		| Red # After alt pattern
+			=> {
+				x = 12
+				x
+			}
+		lower # After pattern comment
+			=> 1
+		"foo" => # After arrow comment
+			100
+		"foo" | "bar" => 200
+		[1, 2, 3, .. as rest] # After pattern comment
+			=> # After arrow comment
+				123 # After branch comment
+
+		# Just a random comment
+
+		[1, 2 | 5, 3, .. as rest] => 123
+		[
+			1,
+			2 | 5,
+			3,
+			.. # After DoubleDot
+				as # Before alias
+					rest, # After last pattern in list
+		] => 123
+		3.14 => 314
+		3.14 | 6.28 => 314
+		(1, 2, 3) => 123
+		(1, 2 | 5, 3) => 123
+		{ foo: 1, bar: 2, ..rest } => 12->add(34)
+		{ # After pattern record open
+			foo # After pattern record field name
+				: # Before pattern record field value
+					1, # After pattern record field
+			bar: 2,
+			.. # After spread operator
+				rest, # After last field
+		} => 12
+		{ foo: 1, bar: 2 | 7 } => 12
+		{
+			foo: 1,
+			bar: 2 | 7, # After last record field
+		} => 12
+		Ok(123) => 123
+		Ok(Some(dude)) => dude
+		TwoArgs("hello", Some("world")) => 1000
+	}
+
+expect # Comment after expect keyword
+	blah == 1 # Comment after expect statement
+
+main! : List(String) -> Result({}, _)
+main! = |_| { # Yeah I can leave a comment here
+	world = "World"
+	var number = 123
+	expect blah == 1
+	tag = Blue
+	return # Comment after return keyword
+		tag # Comment after return statement
+
+	# Just a random comment!
+
+	...
+	match_time(
+		..., # Single args with comment
+	)
+	some_func(
+		dbg # After debug
+			42, # After debug expr
+	)
+	crash # Comment after crash keyword
+		"Unreachable!" # Comment after crash statement
+	tag_with_payload = Ok(number)
+	interpolated = "Hello, ${world}"
+	list = [
+		add_one(
+			dbg # After dbg in list
+				number, # after dbg expr as arg
+		), # Comment one
+		456, # Comment two
+		789, # Comment three
+	]
+	for n in list {
+		Stdout.line!("Adding ${n} to ${number}")
+		number = number + n
+	}
+	record = { foo: 123, bar: "Hello", baz: tag, qux: Ok(world), punned }
+	tuple = (123, "World", tag, Ok(world), (nested, tuple), [1, 2, 3])
+	multiline_tuple = (
+		123,
+		"World",
+		tag1,
+		Ok(world), # This one has a comment
+		(nested, tuple),
+		[1, 2, 3],
+	)
+	bin_op_result = Err(foo) ?? 12 > 5 * 5 or 13 + 2 < 5 and 10 - 1 >= 16 or 12 <= 3 / 5
+	static_dispatch_style = some_fn(arg1)?.static_dispatch_method()?.next_static_dispatch_method()?.record_field?
+	Stdout.line!(interpolated)?
+	Stdout.line!(
+		"How about ${ # Comment after string interpolation open
+			Num.toStr(number) # Comment after string interpolation expr
+		} as a string?",
+	)
+} # Comment after top-level decl
+
+empty : {}
+empty = {}
+
+tuple : Value((a, b, c))
+
+expect {
+	foo = 1 # This should work too
+	blah = 1
+	blah == foo
+}
+
+import pf.Stdout exposing [line!, write!]
+
+import # Comment after import keyword
+	pf # Comment after qualifier
+		.StdoutMultiline # Comment after ident
+		exposing [ # Comment after exposing open
+			line!, # Comment after exposed item
+			write!, # Another after exposed item
+		] # Comment after exposing close
+
+import pkg.Something exposing [func as function, Type as ValueCategory, Custom.*]
+
+import BadName as GoodName
+import
+	BadNameMultiline
+		as
+		GoodNameMultiline
+
+Map(a, b) : List(a), (a -> b) -> List(b)
+MapML( # Comment here
+	a, # And here
+	b,
+) # And after the last arg
+	: # And after the colon
+		List( # Inside Tag args
+			a, # After tag arg
+		),
+		(a -> b) -> # After arrow
+			List( # Inside tag args
+				b,
+			) # And after the type decl
+
+Foo : (Bar, Baz)
+
+FooMultiline : ( # Comment after pattern tuple open
+	Bar, # Comment after pattern tuple item
+	Baz, # Another after pattern tuple item
+) # Comment after pattern tuple close
+
+Some(a) : { foo : Ok(a), bar : Something }
+SomeMl(a) : { # After record open
+	foo : Ok(a), # After field
+	bar : Something, # After last field
+}
+
+SomeMultiline(a) : { # Comment after pattern record open
+	foo # After field name
+		: # Before field anno
+			Ok(a), # Comment after pattern record field
+	bar : Something, # Another after pattern record field
+} # Comment after pattern record close
+
+Maybe(a) : [Some(a), None]
+
+MaybeMultiline(a) : [ # Comment after tag union open
+	Some(a), # Comment after tag union member
+	None, # Another after tag union member
+] # Comment after tag union close
+
+SomeFunc(a) : Maybe(a), a -> Maybe(a)
+
+add_one_oneline = |num| if num 2 else 5
+
+add_one : U64 -> U64
+add_one = |num| {
+	other = 1
+	if num {
+		dbg # After debug
+			some_func() # After debug expr
+		0
+	} else {
+		dbg 123
+		other
+	}
+}
+
+match_time = |
+	a, # After arg
+	b,
+| # After args
+	match a {
+		Blue | Green | Red => {
+			x = 12
+			x
+		}
+		Blue # After pattern in alt
+		| # Before pattern in alt
+			Green
+		| Red # After alt pattern
+			=> {
+				x = 12
+				x
+			}
+		lower # After pattern comment
+			=> 1
+		"foo" => # After arrow comment
+			100
+		"foo" | "bar" => 200
+		[1, 2, 3, .. as rest] # After pattern comment
+			=> # After arrow comment
+				123 # After branch comment
+
+		# Just a random comment
+
+		[1, 2 | 5, 3, .. as rest] => 123
+		[
+			1,
+			2 | 5,
+			3,
+			.. # After DoubleDot
+				as # Before alias
+					rest, # After last pattern in list
+		] => 123
+		3.14 => 314
+		3.14 | 6.28 => 314
+		(1, 2, 3) => 123
+		(1, 2 | 5, 3) => 123
+		{ foo: 1, bar: 2, ..rest } => 12->add(34)
+		{ # After pattern record open
+			foo # After pattern record field name
+				: # Before pattern record field value
+					1, # After pattern record field
+			bar: 2,
+			.. # After spread operator
+				rest, # After last field
+		} => 12
+		{ foo: 1, bar: 2 | 7 } => 12
+		{
+			foo: 1,
+			bar: 2 | 7, # After last record field
+		} => 12
+		Ok(123) => 123
+		Ok(Some(dude)) => dude
+		TwoArgs("hello", Some("world")) => 1000
+	}
+
+expect # Comment after expect keyword
+	blah == 1 # Comment after expect statement
+
+main! : List(String) -> Result({}, _)
+main! = |_| { # Yeah I can leave a comment here
+	world = "World"
+	var number = 123
+	expect blah == 1
+	tag = Blue
+	return # Comment after return keyword
+		tag # Comment after return statement
+
+	# Just a random comment!
+
+	...
+	match_time(
+		..., # Single args with comment
+	)
+	some_func(
+		dbg # After debug
+			42, # After debug expr
+	)
+	crash # Comment after crash keyword
+		"Unreachable!" # Comment after crash statement
+	tag_with_payload = Ok(number)
+	interpolated = "Hello, ${world}"
+	list = [
+		add_one(
+			dbg # After dbg in list
+				number, # after dbg expr as arg
+		), # Comment one
+		456, # Comment two
+		789, # Comment three
+	]
+	for n in list {
+		Stdout.line!("Adding ${n} to ${number}")
+		number = number + n
+	}
+	record = { foo: 123, bar: "Hello", baz: tag, qux: Ok(world), punned }
+	tuple = (123, "World", tag, Ok(world), (nested, tuple), [1, 2, 3])
+	multiline_tuple = (
+		123,
+		"World",
+		tag1,
+		Ok(world), # This one has a comment
+		(nested, tuple),
+		[1, 2, 3],
+	)
+	bin_op_result = Err(foo) ?? 12 > 5 * 5 or 13 + 2 < 5 and 10 - 1 >= 16 or 12 <= 3 / 5
+	static_dispatch_style = some_fn(arg1)?.static_dispatch_method()?.next_static_dispatch_method()?.record_field?
+	Stdout.line!(interpolated)?
+	Stdout.line!(
+		"How about ${ # Comment after string interpolation open
+			Num.toStr(number) # Comment after string interpolation expr
+		} as a string?",
+	)
+} # Comment after top-level decl
+
+empty : {}
+empty = {}
+
+tuple : Value((a, b, c))
+
+expect {
+	foo = 1 # This should work too
+	blah = 1
+	blah == foo
+}
+
+import pf.Stdout exposing [line!, write!]
+
+import # Comment after import keyword
+	pf # Comment after qualifier
+		.StdoutMultiline # Comment after ident
+		exposing [ # Comment after exposing open
+			line!, # Comment after exposed item
+			write!, # Another after exposed item
+		] # Comment after exposing close
+
+import pkg.Something exposing [func as function, Type as ValueCategory, Custom.*]
+
+import BadName as GoodName
+import
+	BadNameMultiline
+		as
+		GoodNameMultiline
+
+Map(a, b) : List(a), (a -> b) -> List(b)
+MapML( # Comment here
+	a, # And here
+	b,
+) # And after the last arg
+	: # And after the colon
+		List( # Inside Tag args
+			a, # After tag arg
+		),
+		(a -> b) -> # After arrow
+			List( # Inside tag args
+				b,
+			) # And after the type decl
+
+Foo : (Bar, Baz)
+
+FooMultiline : ( # Comment after pattern tuple open
+	Bar, # Comment after pattern tuple item
+	Baz, # Another after pattern tuple item
+) # Comment after pattern tuple close
+
+Some(a) : { foo : Ok(a), bar : Something }
+SomeMl(a) : { # After record open
+	foo : Ok(a), # After field
+	bar : Something, # After last field
+}
+
+SomeMultiline(a) : { # Comment after pattern record open
+	foo # After field name
+		: # Before field anno
+			Ok(a), # Comment after pattern record field
+	bar : Something, # Another after pattern record field
+} # Comment after pattern record close
+
+Maybe(a) : [Some(a), None]
+
+MaybeMultiline(a) : [ # Comment after tag union open
+	Some(a), # Comment after tag union member
+	None, # Another after tag union member
+] # Comment after tag union close
+
+SomeFunc(a) : Maybe(a), a -> Maybe(a)
+
+add_one_oneline = |num| if num 2 else 5
+
+add_one : U64 -> U64
+add_one = |num| {
+	other = 1
+	if num {
+		dbg # After debug
+			some_func() # After debug expr
+		0
+	} else {
+		dbg 123
+		other
+	}
+}
+
+match_time = |
+	a, # After arg
+	b,
+| # After args
+	match a {
+		Blue | Green | Red => {
+			x = 12
+			x
+		}
+		Blue # After pattern in alt
+		| # Before pattern in alt
+			Green
+		| Red # After alt pattern
+			=> {
+				x = 12
+				x
+			}
+		lower # After pattern comment
+			=> 1
+		"foo" => # After arrow comment
+			100
+		"foo" | "bar" => 200
+		[1, 2, 3, .. as rest] # After pattern comment
+			=> # After arrow comment
+				123 # After branch comment
+
+		# Just a random comment
+
+		[1, 2 | 5, 3, .. as rest] => 123
+		[
+			1,
+			2 | 5,
+			3,
+			.. # After DoubleDot
+				as # Before alias
+					rest, # After last pattern in list
+		] => 123
+		3.14 => 314
+		3.14 | 6.28 => 314
+		(1, 2, 3) => 123
+		(1, 2 | 5, 3) => 123
+		{ foo: 1, bar: 2, ..rest } => 12->add(34)
+		{ # After pattern record open
+			foo # After pattern record field name
+				: # Before pattern record field value
+					1, # After pattern record field
+			bar: 2,
+			.. # After spread operator
+				rest, # After last field
+		} => 12
+		{ foo: 1, bar: 2 | 7 } => 12
+		{
+			foo: 1,
+			bar: 2 | 7, # After last record field
+		} => 12
+		Ok(123) => 123
+		Ok(Some(dude)) => dude
+		TwoArgs("hello", Some("world")) => 1000
+	}
+
+expect # Comment after expect keyword
+	blah == 1 # Comment after expect statement
+
+main! : List(String) -> Result({}, _)
+main! = |_| { # Yeah I can leave a comment here
+	world = "World"
+	var number = 123
+	expect blah == 1
+	tag = Blue
+	return # Comment after return keyword
+		tag # Comment after return statement
+
+	# Just a random comment!
+
+	...
+	match_time(
+		..., # Single args with comment
+	)
+	some_func(
+		dbg # After debug
+			42, # After debug expr
+	)
+	crash # Comment after crash keyword
+		"Unreachable!" # Comment after crash statement
+	tag_with_payload = Ok(number)
+	interpolated = "Hello, ${world}"
+	list = [
+		add_one(
+			dbg # After dbg in list
+				number, # after dbg expr as arg
+		), # Comment one
+		456, # Comment two
+		789, # Comment three
+	]
+	for n in list {
+		Stdout.line!("Adding ${n} to ${number}")
+		number = number + n
+	}
+	record = { foo: 123, bar: "Hello", baz: tag, qux: Ok(world), punned }
+	tuple = (123, "World", tag, Ok(world), (nested, tuple), [1, 2, 3])
+	multiline_tuple = (
+		123,
+		"World",
+		tag1,
+		Ok(world), # This one has a comment
+		(nested, tuple),
+		[1, 2, 3],
+	)
+	bin_op_result = Err(foo) ?? 12 > 5 * 5 or 13 + 2 < 5 and 10 - 1 >= 16 or 12 <= 3 / 5
+	static_dispatch_style = some_fn(arg1)?.static_dispatch_method()?.next_static_dispatch_method()?.record_field?
+	Stdout.line!(interpolated)?
+	Stdout.line!(
+		"How about ${ # Comment after string interpolation open
+			Num.toStr(number) # Comment after string interpolation expr
+		} as a string?",
+	)
+} # Comment after top-level decl
+
+empty : {}
+empty = {}
+
+tuple : Value((a, b, c))
+
+expect {
+	foo = 1 # This should work too
+	blah = 1
+	blah == foo
+}
+
+import pf.Stdout exposing [line!, write!]
+
+import # Comment after import keyword
+	pf # Comment after qualifier
+		.StdoutMultiline # Comment after ident
+		exposing [ # Comment after exposing open
+			line!, # Comment after exposed item
+			write!, # Another after exposed item
+		] # Comment after exposing close
+
+import pkg.Something exposing [func as function, Type as ValueCategory, Custom.*]
+
+import BadName as GoodName
+import
+	BadNameMultiline
+		as
+		GoodNameMultiline
+
+Map(a, b) : List(a), (a -> b) -> List(b)
+MapML( # Comment here
+	a, # And here
+	b,
+) # And after the last arg
+	: # And after the colon
+		List( # Inside Tag args
+			a, # After tag arg
+		),
+		(a -> b) -> # After arrow
+			List( # Inside tag args
+				b,
+			) # And after the type decl
+
+Foo : (Bar, Baz)
+
+FooMultiline : ( # Comment after pattern tuple open
+	Bar, # Comment after pattern tuple item
+	Baz, # Another after pattern tuple item
+) # Comment after pattern tuple close
+
+Some(a) : { foo : Ok(a), bar : Something }
+SomeMl(a) : { # After record open
+	foo : Ok(a), # After field
+	bar : Something, # After last field
+}
+
+SomeMultiline(a) : { # Comment after pattern record open
+	foo # After field name
+		: # Before field anno
+			Ok(a), # Comment after pattern record field
+	bar : Something, # Another after pattern record field
+} # Comment after pattern record close
+
+Maybe(a) : [Some(a), None]
+
+MaybeMultiline(a) : [ # Comment after tag union open
+	Some(a), # Comment after tag union member
+	None, # Another after tag union member
+] # Comment after tag union close
+
+SomeFunc(a) : Maybe(a), a -> Maybe(a)
+
+add_one_oneline = |num| if num 2 else 5
+
+add_one : U64 -> U64
+add_one = |num| {
+	other = 1
+	if num {
+		dbg # After debug
+			some_func() # After debug expr
+		0
+	} else {
+		dbg 123
+		other
+	}
+}
+
+match_time = |
+	a, # After arg
+	b,
+| # After args
+	match a {
+		Blue | Green | Red => {
+			x = 12
+			x
+		}
+		Blue # After pattern in alt
+		| # Before pattern in alt
+			Green
+		| Red # After alt pattern
+			=> {
+				x = 12
+				x
+			}
+		lower # After pattern comment
+			=> 1
+		"foo" => # After arrow comment
+			100
+		"foo" | "bar" => 200
+		[1, 2, 3, .. as rest] # After pattern comment
+			=> # After arrow comment
+				123 # After branch comment
+
+		# Just a random comment
+
+		[1, 2 | 5, 3, .. as rest] => 123
+		[
+			1,
+			2 | 5,
+			3,
+			.. # After DoubleDot
+				as # Before alias
+					rest, # After last pattern in list
+		] => 123
+		3.14 => 314
+		3.14 | 6.28 => 314
+		(1, 2, 3) => 123
+		(1, 2 | 5, 3) => 123
+		{ foo: 1, bar: 2, ..rest } => 12->add(34)
+		{ # After pattern record open
+			foo # After pattern record field name
+				: # Before pattern record field value
+					1, # After pattern record field
+			bar: 2,
+			.. # After spread operator
+				rest, # After last field
+		} => 12
+		{ foo: 1, bar: 2 | 7 } => 12
+		{
+			foo: 1,
+			bar: 2 | 7, # After last record field
+		} => 12
+		Ok(123) => 123
+		Ok(Some(dude)) => dude
+		TwoArgs("hello", Some("world")) => 1000
+	}
+
+expect # Comment after expect keyword
+	blah == 1 # Comment after expect statement
+
+main! : List(String) -> Result({}, _)
+main! = |_| { # Yeah I can leave a comment here
+	world = "World"
+	var number = 123
+	expect blah == 1
+	tag = Blue
+	return # Comment after return keyword
+		tag # Comment after return statement
+
+	# Just a random comment!
+
+	...
+	match_time(
+		..., # Single args with comment
+	)
+	some_func(
+		dbg # After debug
+			42, # After debug expr
+	)
+	crash # Comment after crash keyword
+		"Unreachable!" # Comment after crash statement
+	tag_with_payload = Ok(number)
+	interpolated = "Hello, ${world}"
+	list = [
+		add_one(
+			dbg # After dbg in list
+				number, # after dbg expr as arg
+		), # Comment one
+		456, # Comment two
+		789, # Comment three
+	]
+	for n in list {
+		Stdout.line!("Adding ${n} to ${number}")
+		number = number + n
+	}
+	record = { foo: 123, bar: "Hello", baz: tag, qux: Ok(world), punned }
+	tuple = (123, "World", tag, Ok(world), (nested, tuple), [1, 2, 3])
+	multiline_tuple = (
+		123,
+		"World",
+		tag1,
+		Ok(world), # This one has a comment
+		(nested, tuple),
+		[1, 2, 3],
+	)
+	bin_op_result = Err(foo) ?? 12 > 5 * 5 or 13 + 2 < 5 and 10 - 1 >= 16 or 12 <= 3 / 5
+	static_dispatch_style = some_fn(arg1)?.static_dispatch_method()?.next_static_dispatch_method()?.record_field?
+	Stdout.line!(interpolated)?
+	Stdout.line!(
+		"How about ${ # Comment after string interpolation open
+			Num.toStr(number) # Comment after string interpolation expr
+		} as a string?",
+	)
+} # Comment after top-level decl
+
+empty : {}
+empty = {}
+
+tuple : Value((a, b, c))
+
+expect {
+	foo = 1 # This should work too
+	blah = 1
+	blah == foo
+}
+
+import pf.Stdout exposing [line!, write!]
+
+import # Comment after import keyword
+	pf # Comment after qualifier
+		.StdoutMultiline # Comment after ident
+		exposing [ # Comment after exposing open
+			line!, # Comment after exposed item
+			write!, # Another after exposed item
+		] # Comment after exposing close
+
+import pkg.Something exposing [func as function, Type as ValueCategory, Custom.*]
+
+import BadName as GoodName
+import
+	BadNameMultiline
+		as
+		GoodNameMultiline
+
+Map(a, b) : List(a), (a -> b) -> List(b)
+MapML( # Comment here
+	a, # And here
+	b,
+) # And after the last arg
+	: # And after the colon
+		List( # Inside Tag args
+			a, # After tag arg
+		),
+		(a -> b) -> # After arrow
+			List( # Inside tag args
+				b,
+			) # And after the type decl
+
+Foo : (Bar, Baz)
+
+FooMultiline : ( # Comment after pattern tuple open
+	Bar, # Comment after pattern tuple item
+	Baz, # Another after pattern tuple item
+) # Comment after pattern tuple close
+
+Some(a) : { foo : Ok(a), bar : Something }
+SomeMl(a) : { # After record open
+	foo : Ok(a), # After field
+	bar : Something, # After last field
+}
+
+SomeMultiline(a) : { # Comment after pattern record open
+	foo # After field name
+		: # Before field anno
+			Ok(a), # Comment after pattern record field
+	bar : Something, # Another after pattern record field
+} # Comment after pattern record close
+
+Maybe(a) : [Some(a), None]
+
+MaybeMultiline(a) : [ # Comment after tag union open
+	Some(a), # Comment after tag union member
+	None, # Another after tag union member
+] # Comment after tag union close
+
+SomeFunc(a) : Maybe(a), a -> Maybe(a)
+
+add_one_oneline = |num| if num 2 else 5
+
+add_one : U64 -> U64
+add_one = |num| {
+	other = 1
+	if num {
+		dbg # After debug
+			some_func() # After debug expr
+		0
+	} else {
+		dbg 123
+		other
+	}
+}
+
+match_time = |
+	a, # After arg
+	b,
+| # After args
+	match a {
+		Blue | Green | Red => {
+			x = 12
+			x
+		}
+		Blue # After pattern in alt
+		| # Before pattern in alt
+			Green
+		| Red # After alt pattern
+			=> {
+				x = 12
+				x
+			}
+		lower # After pattern comment
+			=> 1
+		"foo" => # After arrow comment
+			100
+		"foo" | "bar" => 200
+		[1, 2, 3, .. as rest] # After pattern comment
+			=> # After arrow comment
+				123 # After branch comment
+
+		# Just a random comment
+
+		[1, 2 | 5, 3, .. as rest] => 123
+		[
+			1,
+			2 | 5,
+			3,
+			.. # After DoubleDot
+				as # Before alias
+					rest, # After last pattern in list
+		] => 123
+		3.14 => 314
+		3.14 | 6.28 => 314
+		(1, 2, 3) => 123
+		(1, 2 | 5, 3) => 123
+		{ foo: 1, bar: 2, ..rest } => 12->add(34)
+		{ # After pattern record open
+			foo # After pattern record field name
+				: # Before pattern record field value
+					1, # After pattern record field
+			bar: 2,
+			.. # After spread operator
+				rest, # After last field
+		} => 12
+		{ foo: 1, bar: 2 | 7 } => 12
+		{
+			foo: 1,
+			bar: 2 | 7, # After last record field
+		} => 12
+		Ok(123) => 123
+		Ok(Some(dude)) => dude
+		TwoArgs("hello", Some("world")) => 1000
+	}
+
+expect # Comment after expect keyword
+	blah == 1 # Comment after expect statement
+
+main! : List(String) -> Result({}, _)
+main! = |_| { # Yeah I can leave a comment here
+	world = "World"
+	var number = 123
+	expect blah == 1
+	tag = Blue
+	return # Comment after return keyword
+		tag # Comment after return statement
+
+	# Just a random comment!
+
+	...
+	match_time(
+		..., # Single args with comment
+	)
+	some_func(
+		dbg # After debug
+			42, # After debug expr
+	)
+	crash # Comment after crash keyword
+		"Unreachable!" # Comment after crash statement
+	tag_with_payload = Ok(number)
+	interpolated = "Hello, ${world}"
+	list = [
+		add_one(
+			dbg # After dbg in list
+				number, # after dbg expr as arg
+		), # Comment one
+		456, # Comment two
+		789, # Comment three
+	]
+	for n in list {
+		Stdout.line!("Adding ${n} to ${number}")
+		number = number + n
+	}
+	record = { foo: 123, bar: "Hello", baz: tag, qux: Ok(world), punned }
+	tuple = (123, "World", tag, Ok(world), (nested, tuple), [1, 2, 3])
+	multiline_tuple = (
+		123,
+		"World",
+		tag1,
+		Ok(world), # This one has a comment
+		(nested, tuple),
+		[1, 2, 3],
+	)
+	bin_op_result = Err(foo) ?? 12 > 5 * 5 or 13 + 2 < 5 and 10 - 1 >= 16 or 12 <= 3 / 5
+	static_dispatch_style = some_fn(arg1)?.static_dispatch_method()?.next_static_dispatch_method()?.record_field?
+	Stdout.line!(interpolated)?
+	Stdout.line!(
+		"How about ${ # Comment after string interpolation open
+			Num.toStr(number) # Comment after string interpolation expr
+		} as a string?",
+	)
+} # Comment after top-level decl
+
+empty : {}
+empty = {}
+
+tuple : Value((a, b, c))
+
+expect {
+	foo = 1 # This should work too
+	blah = 1
+	blah == foo
+}
+
+import pf.Stdout exposing [line!, write!]
+
+import # Comment after import keyword
+	pf # Comment after qualifier
+		.StdoutMultiline # Comment after ident
+		exposing [ # Comment after exposing open
+			line!, # Comment after exposed item
+			write!, # Another after exposed item
+		] # Comment after exposing close
+
+import pkg.Something exposing [func as function, Type as ValueCategory, Custom.*]
+
+import BadName as GoodName
+import
+	BadNameMultiline
+		as
+		GoodNameMultiline
+
+Map(a, b) : List(a), (a -> b) -> List(b)
+MapML( # Comment here
+	a, # And here
+	b,
+) # And after the last arg
+	: # And after the colon
+		List( # Inside Tag args
+			a, # After tag arg
+		),
+		(a -> b) -> # After arrow
+			List( # Inside tag args
+				b,
+			) # And after the type decl
+
+Foo : (Bar, Baz)
+
+FooMultiline : ( # Comment after pattern tuple open
+	Bar, # Comment after pattern tuple item
+	Baz, # Another after pattern tuple item
+) # Comment after pattern tuple close
+
+Some(a) : { foo : Ok(a), bar : Something }
+SomeMl(a) : { # After record open
+	foo : Ok(a), # After field
+	bar : Something, # After last field
+}
+
+SomeMultiline(a) : { # Comment after pattern record open
+	foo # After field name
+		: # Before field anno
+			Ok(a), # Comment after pattern record field
+	bar : Something, # Another after pattern record field
+} # Comment after pattern record close
+
+Maybe(a) : [Some(a), None]
+
+MaybeMultiline(a) : [ # Comment after tag union open
+	Some(a), # Comment after tag union member
+	None, # Another after tag union member
+] # Comment after tag union close
+
+SomeFunc(a) : Maybe(a), a -> Maybe(a)
+
+add_one_oneline = |num| if num 2 else 5
+
+add_one : U64 -> U64
+add_one = |num| {
+	other = 1
+	if num {
+		dbg # After debug
+			some_func() # After debug expr
+		0
+	} else {
+		dbg 123
+		other
+	}
+}
+
+match_time = |
+	a, # After arg
+	b,
+| # After args
+	match a {
+		Blue | Green | Red => {
+			x = 12
+			x
+		}
+		Blue # After pattern in alt
+		| # Before pattern in alt
+			Green
+		| Red # After alt pattern
+			=> {
+				x = 12
+				x
+			}
+		lower # After pattern comment
+			=> 1
+		"foo" => # After arrow comment
+			100
+		"foo" | "bar" => 200
+		[1, 2, 3, .. as rest] # After pattern comment
+			=> # After arrow comment
+				123 # After branch comment
+
+		# Just a random comment
+
+		[1, 2 | 5, 3, .. as rest] => 123
+		[
+			1,
+			2 | 5,
+			3,
+			.. # After DoubleDot
+				as # Before alias
+					rest, # After last pattern in list
+		] => 123
+		3.14 => 314
+		3.14 | 6.28 => 314
+		(1, 2, 3) => 123
+		(1, 2 | 5, 3) => 123
+		{ foo: 1, bar: 2, ..rest } => 12->add(34)
+		{ # After pattern record open
+			foo # After pattern record field name
+				: # Before pattern record field value
+					1, # After pattern record field
+			bar: 2,
+			.. # After spread operator
+				rest, # After last field
+		} => 12
+		{ foo: 1, bar: 2 | 7 } => 12
+		{
+			foo: 1,
+			bar: 2 | 7, # After last record field
+		} => 12
+		Ok(123) => 123
+		Ok(Some(dude)) => dude
+		TwoArgs("hello", Some("world")) => 1000
+	}
+
+expect # Comment after expect keyword
+	blah == 1 # Comment after expect statement
+
+main! : List(String) -> Result({}, _)
+main! = |_| { # Yeah I can leave a comment here
+	world = "World"
+	var number = 123
+	expect blah == 1
+	tag = Blue
+	return # Comment after return keyword
+		tag # Comment after return statement
+
+	# Just a random comment!
+
+	...
+	match_time(
+		..., # Single args with comment
+	)
+	some_func(
+		dbg # After debug
+			42, # After debug expr
+	)
+	crash # Comment after crash keyword
+		"Unreachable!" # Comment after crash statement
+	tag_with_payload = Ok(number)
+	interpolated = "Hello, ${world}"
+	list = [
+		add_one(
+			dbg # After dbg in list
+				number, # after dbg expr as arg
+		), # Comment one
+		456, # Comment two
+		789, # Comment three
+	]
+	for n in list {
+		Stdout.line!("Adding ${n} to ${number}")
+		number = number + n
+	}
+	record = { foo: 123, bar: "Hello", baz: tag, qux: Ok(world), punned }
+	tuple = (123, "World", tag, Ok(world), (nested, tuple), [1, 2, 3])
+	multiline_tuple = (
+		123,
+		"World",
+		tag1,
+		Ok(world), # This one has a comment
+		(nested, tuple),
+		[1, 2, 3],
+	)
+	bin_op_result = Err(foo) ?? 12 > 5 * 5 or 13 + 2 < 5 and 10 - 1 >= 16 or 12 <= 3 / 5
+	static_dispatch_style = some_fn(arg1)?.static_dispatch_method()?.next_static_dispatch_method()?.record_field?
+	Stdout.line!(interpolated)?
+	Stdout.line!(
+		"How about ${ # Comment after string interpolation open
+			Num.toStr(number) # Comment after string interpolation expr
+		} as a string?",
+	)
+} # Comment after top-level decl
+
+empty : {}
+empty = {}
+
+tuple : Value((a, b, c))
+
+expect {
+	foo = 1 # This should work too
+	blah = 1
+	blah == foo
+}
+
+import pf.Stdout exposing [line!, write!]
+
+import # Comment after import keyword
+	pf # Comment after qualifier
+		.StdoutMultiline # Comment after ident
+		exposing [ # Comment after exposing open
+			line!, # Comment after exposed item
+			write!, # Another after exposed item
+		] # Comment after exposing close
+
+import pkg.Something exposing [func as function, Type as ValueCategory, Custom.*]
+
+import BadName as GoodName
+import
+	BadNameMultiline
+		as
+		GoodNameMultiline
+
+Map(a, b) : List(a), (a -> b) -> List(b)
+MapML( # Comment here
+	a, # And here
+	b,
+) # And after the last arg
+	: # And after the colon
+		List( # Inside Tag args
+			a, # After tag arg
+		),
+		(a -> b) -> # After arrow
+			List( # Inside tag args
+				b,
+			) # And after the type decl
+
+Foo : (Bar, Baz)
+
+FooMultiline : ( # Comment after pattern tuple open
+	Bar, # Comment after pattern tuple item
+	Baz, # Another after pattern tuple item
+) # Comment after pattern tuple close
+
+Some(a) : { foo : Ok(a), bar : Something }
+SomeMl(a) : { # After record open
+	foo : Ok(a), # After field
+	bar : Something, # After last field
+}
+
+SomeMultiline(a) : { # Comment after pattern record open
+	foo # After field name
+		: # Before field anno
+			Ok(a), # Comment after pattern record field
+	bar : Something, # Another after pattern record field
+} # Comment after pattern record close
+
+Maybe(a) : [Some(a), None]
+
+MaybeMultiline(a) : [ # Comment after tag union open
+	Some(a), # Comment after tag union member
+	None, # Another after tag union member
+] # Comment after tag union close
+
+SomeFunc(a) : Maybe(a), a -> Maybe(a)
+
+add_one_oneline = |num| if num 2 else 5
+
+add_one : U64 -> U64
+add_one = |num| {
+	other = 1
+	if num {
+		dbg # After debug
+			some_func() # After debug expr
+		0
+	} else {
+		dbg 123
+		other
+	}
+}
+
+match_time = |
+	a, # After arg
+	b,
+| # After args
+	match a {
+		Blue | Green | Red => {
+			x = 12
+			x
+		}
+		Blue # After pattern in alt
+		| # Before pattern in alt
+			Green
+		| Red # After alt pattern
+			=> {
+				x = 12
+				x
+			}
+		lower # After pattern comment
+			=> 1
+		"foo" => # After arrow comment
+			100
+		"foo" | "bar" => 200
+		[1, 2, 3, .. as rest] # After pattern comment
+			=> # After arrow comment
+				123 # After branch comment
+
+		# Just a random comment
+
+		[1, 2 | 5, 3, .. as rest] => 123
+		[
+			1,
+			2 | 5,
+			3,
+			.. # After DoubleDot
+				as # Before alias
+					rest, # After last pattern in list
+		] => 123
+		3.14 => 314
+		3.14 | 6.28 => 314
+		(1, 2, 3) => 123
+		(1, 2 | 5, 3) => 123
+		{ foo: 1, bar: 2, ..rest } => 12->add(34)
+		{ # After pattern record open
+			foo # After pattern record field name
+				: # Before pattern record field value
+					1, # After pattern record field
+			bar: 2,
+			.. # After spread operator
+				rest, # After last field
+		} => 12
+		{ foo: 1, bar: 2 | 7 } => 12
+		{
+			foo: 1,
+			bar: 2 | 7, # After last record field
+		} => 12
+		Ok(123) => 123
+		Ok(Some(dude)) => dude
+		TwoArgs("hello", Some("world")) => 1000
+	}
+
+expect # Comment after expect keyword
+	blah == 1 # Comment after expect statement
+
+main! : List(String) -> Result({}, _)
+main! = |_| { # Yeah I can leave a comment here
+	world = "World"
+	var number = 123
+	expect blah == 1
+	tag = Blue
+	return # Comment after return keyword
+		tag # Comment after return statement
+
+	# Just a random comment!
+
+	...
+	match_time(
+		..., # Single args with comment
+	)
+	some_func(
+		dbg # After debug
+			42, # After debug expr
+	)
+	crash # Comment after crash keyword
+		"Unreachable!" # Comment after crash statement
+	tag_with_payload = Ok(number)
+	interpolated = "Hello, ${world}"
+	list = [
+		add_one(
+			dbg # After dbg in list
+				number, # after dbg expr as arg
+		), # Comment one
+		456, # Comment two
+		789, # Comment three
+	]
+	for n in list {
+		Stdout.line!("Adding ${n} to ${number}")
+		number = number + n
+	}
+	record = { foo: 123, bar: "Hello", baz: tag, qux: Ok(world), punned }
+	tuple = (123, "World", tag, Ok(world), (nested, tuple), [1, 2, 3])
+	multiline_tuple = (
+		123,
+		"World",
+		tag1,
+		Ok(world), # This one has a comment
+		(nested, tuple),
+		[1, 2, 3],
+	)
+	bin_op_result = Err(foo) ?? 12 > 5 * 5 or 13 + 2 < 5 and 10 - 1 >= 16 or 12 <= 3 / 5
+	static_dispatch_style = some_fn(arg1)?.static_dispatch_method()?.next_static_dispatch_method()?.record_field?
+	Stdout.line!(interpolated)?
+	Stdout.line!(
+		"How about ${ # Comment after string interpolation open
+			Num.toStr(number) # Comment after string interpolation expr
+		} as a string?",
+	)
+} # Comment after top-level decl
+
+empty : {}
+empty = {}
+
+tuple : Value((a, b, c))
+
+expect {
+	foo = 1 # This should work too
+	blah = 1
+	blah == foo
+}
+
+import pf.Stdout exposing [line!, write!]
+
+import # Comment after import keyword
+	pf # Comment after qualifier
+		.StdoutMultiline # Comment after ident
+		exposing [ # Comment after exposing open
+			line!, # Comment after exposed item
+			write!, # Another after exposed item
+		] # Comment after exposing close
+
+import pkg.Something exposing [func as function, Type as ValueCategory, Custom.*]
+
+import BadName as GoodName
+import
+	BadNameMultiline
+		as
+		GoodNameMultiline
+
+Map(a, b) : List(a), (a -> b) -> List(b)
+MapML( # Comment here
+	a, # And here
+	b,
+) # And after the last arg
+	: # And after the colon
+		List( # Inside Tag args
+			a, # After tag arg
+		),
+		(a -> b) -> # After arrow
+			List( # Inside tag args
+				b,
+			) # And after the type decl
+
+Foo : (Bar, Baz)
+
+FooMultiline : ( # Comment after pattern tuple open
+	Bar, # Comment after pattern tuple item
+	Baz, # Another after pattern tuple item
+) # Comment after pattern tuple close
+
+Some(a) : { foo : Ok(a), bar : Something }
+SomeMl(a) : { # After record open
+	foo : Ok(a), # After field
+	bar : Something, # After last field
+}
+
+SomeMultiline(a) : { # Comment after pattern record open
+	foo # After field name
+		: # Before field anno
+			Ok(a), # Comment after pattern record field
+	bar : Something, # Another after pattern record field
+} # Comment after pattern record close
+
+Maybe(a) : [Some(a), None]
+
+MaybeMultiline(a) : [ # Comment after tag union open
+	Some(a), # Comment after tag union member
+	None, # Another after tag union member
+] # Comment after tag union close
+
+SomeFunc(a) : Maybe(a), a -> Maybe(a)
+
+add_one_oneline = |num| if num 2 else 5
+
+add_one : U64 -> U64
+add_one = |num| {
+	other = 1
+	if num {
+		dbg # After debug
+			some_func() # After debug expr
+		0
+	} else {
+		dbg 123
+		other
+	}
+}
+
+match_time = |
+	a, # After arg
+	b,
+| # After args
+	match a {
+		Blue | Green | Red => {
+			x = 12
+			x
+		}
+		Blue # After pattern in alt
+		| # Before pattern in alt
+			Green
+		| Red # After alt pattern
+			=> {
+				x = 12
+				x
+			}
+		lower # After pattern comment
+			=> 1
+		"foo" => # After arrow comment
+			100
+		"foo" | "bar" => 200
+		[1, 2, 3, .. as rest] # After pattern comment
+			=> # After arrow comment
+				123 # After branch comment
+
+		# Just a random comment
+
+		[1, 2 | 5, 3, .. as rest] => 123
+		[
+			1,
+			2 | 5,
+			3,
+			.. # After DoubleDot
+				as # Before alias
+					rest, # After last pattern in list
+		] => 123
+		3.14 => 314
+		3.14 | 6.28 => 314
+		(1, 2, 3) => 123
+		(1, 2 | 5, 3) => 123
+		{ foo: 1, bar: 2, ..rest } => 12->add(34)
+		{ # After pattern record open
+			foo # After pattern record field name
+				: # Before pattern record field value
+					1, # After pattern record field
+			bar: 2,
+			.. # After spread operator
+				rest, # After last field
+		} => 12
+		{ foo: 1, bar: 2 | 7 } => 12
+		{
+			foo: 1,
+			bar: 2 | 7, # After last record field
+		} => 12
+		Ok(123) => 123
+		Ok(Some(dude)) => dude
+		TwoArgs("hello", Some("world")) => 1000
+	}
+
+expect # Comment after expect keyword
+	blah == 1 # Comment after expect statement
+
+main! : List(String) -> Result({}, _)
+main! = |_| { # Yeah I can leave a comment here
+	world = "World"
+	var number = 123
+	expect blah == 1
+	tag = Blue
+	return # Comment after return keyword
+		tag # Comment after return statement
+
+	# Just a random comment!
+
+	...
+	match_time(
+		..., # Single args with comment
+	)
+	some_func(
+		dbg # After debug
+			42, # After debug expr
+	)
+	crash # Comment after crash keyword
+		"Unreachable!" # Comment after crash statement
+	tag_with_payload = Ok(number)
+	interpolated = "Hello, ${world}"
+	list = [
+		add_one(
+			dbg # After dbg in list
+				number, # after dbg expr as arg
+		), # Comment one
+		456, # Comment two
+		789, # Comment three
+	]
+	for n in list {
+		Stdout.line!("Adding ${n} to ${number}")
+		number = number + n
+	}
+	record = { foo: 123, bar: "Hello", baz: tag, qux: Ok(world), punned }
+	tuple = (123, "World", tag, Ok(world), (nested, tuple), [1, 2, 3])
+	multiline_tuple = (
+		123,
+		"World",
+		tag1,
+		Ok(world), # This one has a comment
+		(nested, tuple),
+		[1, 2, 3],
+	)
+	bin_op_result = Err(foo) ?? 12 > 5 * 5 or 13 + 2 < 5 and 10 - 1 >= 16 or 12 <= 3 / 5
+	static_dispatch_style = some_fn(arg1)?.static_dispatch_method()?.next_static_dispatch_method()?.record_field?
+	Stdout.line!(interpolated)?
+	Stdout.line!(
+		"How about ${ # Comment after string interpolation open
+			Num.toStr(number) # Comment after string interpolation expr
+		} as a string?",
+	)
+} # Comment after top-level decl
+
+empty : {}
+empty = {}
+
+tuple : Value((a, b, c))
+
+expect {
+	foo = 1 # This should work too
+	blah = 1
+	blah == foo
+}
+
+import pf.Stdout exposing [line!, write!]
+
+import # Comment after import keyword
+	pf # Comment after qualifier
+		.StdoutMultiline # Comment after ident
+		exposing [ # Comment after exposing open
+			line!, # Comment after exposed item
+			write!, # Another after exposed item
+		] # Comment after exposing close
+
+import pkg.Something exposing [func as function, Type as ValueCategory, Custom.*]
+
+import BadName as GoodName
+import
+	BadNameMultiline
+		as
+		GoodNameMultiline
+
+Map(a, b) : List(a), (a -> b) -> List(b)
+MapML( # Comment here
+	a, # And here
+	b,
+) # And after the last arg
+	: # And after the colon
+		List( # Inside Tag args
+			a, # After tag arg
+		),
+		(a -> b) -> # After arrow
+			List( # Inside tag args
+				b,
+			) # And after the type decl
+
+Foo : (Bar, Baz)
+
+FooMultiline : ( # Comment after pattern tuple open
+	Bar, # Comment after pattern tuple item
+	Baz, # Another after pattern tuple item
+) # Comment after pattern tuple close
+
+Some(a) : { foo : Ok(a), bar : Something }
+SomeMl(a) : { # After record open
+	foo : Ok(a), # After field
+	bar : Something, # After last field
+}
+
+SomeMultiline(a) : { # Comment after pattern record open
+	foo # After field name
+		: # Before field anno
+			Ok(a), # Comment after pattern record field
+	bar : Something, # Another after pattern record field
+} # Comment after pattern record close
+
+Maybe(a) : [Some(a), None]
+
+MaybeMultiline(a) : [ # Comment after tag union open
+	Some(a), # Comment after tag union member
+	None, # Another after tag union member
+] # Comment after tag union close
+
+SomeFunc(a) : Maybe(a), a -> Maybe(a)
+
+add_one_oneline = |num| if num 2 else 5
+
+add_one : U64 -> U64
+add_one = |num| {
+	other = 1
+	if num {
+		dbg # After debug
+			some_func() # After debug expr
+		0
+	} else {
+		dbg 123
+		other
+	}
+}
+
+match_time = |
+	a, # After arg
+	b,
+| # After args
+	match a {
+		Blue | Green | Red => {
+			x = 12
+			x
+		}
+		Blue # After pattern in alt
+		| # Before pattern in alt
+			Green
+		| Red # After alt pattern
+			=> {
+				x = 12
+				x
+			}
+		lower # After pattern comment
+			=> 1
+		"foo" => # After arrow comment
+			100
+		"foo" | "bar" => 200
+		[1, 2, 3, .. as rest] # After pattern comment
+			=> # After arrow comment
+				123 # After branch comment
+
+		# Just a random comment
+
+		[1, 2 | 5, 3, .. as rest] => 123
+		[
+			1,
+			2 | 5,
+			3,
+			.. # After DoubleDot
+				as # Before alias
+					rest, # After last pattern in list
+		] => 123
+		3.14 => 314
+		3.14 | 6.28 => 314
+		(1, 2, 3) => 123
+		(1, 2 | 5, 3) => 123
+		{ foo: 1, bar: 2, ..rest } => 12->add(34)
+		{ # After pattern record open
+			foo # After pattern record field name
+				: # Before pattern record field value
+					1, # After pattern record field
+			bar: 2,
+			.. # After spread operator
+				rest, # After last field
+		} => 12
+		{ foo: 1, bar: 2 | 7 } => 12
+		{
+			foo: 1,
+			bar: 2 | 7, # After last record field
+		} => 12
+		Ok(123) => 123
+		Ok(Some(dude)) => dude
+		TwoArgs("hello", Some("world")) => 1000
+	}
+
+expect # Comment after expect keyword
+	blah == 1 # Comment after expect statement
+
+main! : List(String) -> Result({}, _)
+main! = |_| { # Yeah I can leave a comment here
+	world = "World"
+	var number = 123
+	expect blah == 1
+	tag = Blue
+	return # Comment after return keyword
+		tag # Comment after return statement
+
+	# Just a random comment!
+
+	...
+	match_time(
+		..., # Single args with comment
+	)
+	some_func(
+		dbg # After debug
+			42, # After debug expr
+	)
+	crash # Comment after crash keyword
+		"Unreachable!" # Comment after crash statement
+	tag_with_payload = Ok(number)
+	interpolated = "Hello, ${world}"
+	list = [
+		add_one(
+			dbg # After dbg in list
+				number, # after dbg expr as arg
+		), # Comment one
+		456, # Comment two
+		789, # Comment three
+	]
+	for n in list {
+		Stdout.line!("Adding ${n} to ${number}")
+		number = number + n
+	}
+	record = { foo: 123, bar: "Hello", baz: tag, qux: Ok(world), punned }
+	tuple = (123, "World", tag, Ok(world), (nested, tuple), [1, 2, 3])
+	multiline_tuple = (
+		123,
+		"World",
+		tag1,
+		Ok(world), # This one has a comment
+		(nested, tuple),
+		[1, 2, 3],
+	)
+	bin_op_result = Err(foo) ?? 12 > 5 * 5 or 13 + 2 < 5 and 10 - 1 >= 16 or 12 <= 3 / 5
+	static_dispatch_style = some_fn(arg1)?.static_dispatch_method()?.next_static_dispatch_method()?.record_field?
+	Stdout.line!(interpolated)?
+	Stdout.line!(
+		"How about ${ # Comment after string interpolation open
+			Num.toStr(number) # Comment after string interpolation expr
+		} as a string?",
+	)
+} # Comment after top-level decl
+
+empty : {}
+empty = {}
+
+tuple : Value((a, b, c))
+
+expect {
+	foo = 1 # This should work too
+	blah = 1
+	blah == foo
+}
+
+import pf.Stdout exposing [line!, write!]
+
+import # Comment after import keyword
+	pf # Comment after qualifier
+		.StdoutMultiline # Comment after ident
+		exposing [ # Comment after exposing open
+			line!, # Comment after exposed item
+			write!, # Another after exposed item
+		] # Comment after exposing close
+
+import pkg.Something exposing [func as function, Type as ValueCategory, Custom.*]
+
+import BadName as GoodName
+import
+	BadNameMultiline
+		as
+		GoodNameMultiline
+
+Map(a, b) : List(a), (a -> b) -> List(b)
+MapML( # Comment here
+	a, # And here
+	b,
+) # And after the last arg
+	: # And after the colon
+		List( # Inside Tag args
+			a, # After tag arg
+		),
+		(a -> b) -> # After arrow
+			List( # Inside tag args
+				b,
+			) # And after the type decl
+
+Foo : (Bar, Baz)
+
+FooMultiline : ( # Comment after pattern tuple open
+	Bar, # Comment after pattern tuple item
+	Baz, # Another after pattern tuple item
+) # Comment after pattern tuple close
+
+Some(a) : { foo : Ok(a), bar : Something }
+SomeMl(a) : { # After record open
+	foo : Ok(a), # After field
+	bar : Something, # After last field
+}
+
+SomeMultiline(a) : { # Comment after pattern record open
+	foo # After field name
+		: # Before field anno
+			Ok(a), # Comment after pattern record field
+	bar : Something, # Another after pattern record field
+} # Comment after pattern record close
+
+Maybe(a) : [Some(a), None]
+
+MaybeMultiline(a) : [ # Comment after tag union open
+	Some(a), # Comment after tag union member
+	None, # Another after tag union member
+] # Comment after tag union close
+
+SomeFunc(a) : Maybe(a), a -> Maybe(a)
+
+add_one_oneline = |num| if num 2 else 5
+
+add_one : U64 -> U64
+add_one = |num| {
+	other = 1
+	if num {
+		dbg # After debug
+			some_func() # After debug expr
+		0
+	} else {
+		dbg 123
+		other
+	}
+}
+
+match_time = |
+	a, # After arg
+	b,
+| # After args
+	match a {
+		Blue | Green | Red => {
+			x = 12
+			x
+		}
+		Blue # After pattern in alt
+		| # Before pattern in alt
+			Green
+		| Red # After alt pattern
+			=> {
+				x = 12
+				x
+			}
+		lower # After pattern comment
+			=> 1
+		"foo" => # After arrow comment
+			100
+		"foo" | "bar" => 200
+		[1, 2, 3, .. as rest] # After pattern comment
+			=> # After arrow comment
+				123 # After branch comment
+
+		# Just a random comment
+
+		[1, 2 | 5, 3, .. as rest] => 123
+		[
+			1,
+			2 | 5,
+			3,
+			.. # After DoubleDot
+				as # Before alias
+					rest, # After last pattern in list
+		] => 123
+		3.14 => 314
+		3.14 | 6.28 => 314
+		(1, 2, 3) => 123
+		(1, 2 | 5, 3) => 123
+		{ foo: 1, bar: 2, ..rest } => 12->add(34)
+		{ # After pattern record open
+			foo # After pattern record field name
+				: # Before pattern record field value
+					1, # After pattern record field
+			bar: 2,
+			.. # After spread operator
+				rest, # After last field
+		} => 12
+		{ foo: 1, bar: 2 | 7 } => 12
+		{
+			foo: 1,
+			bar: 2 | 7, # After last record field
+		} => 12
+		Ok(123) => 123
+		Ok(Some(dude)) => dude
+		TwoArgs("hello", Some("world")) => 1000
+	}
+
+expect # Comment after expect keyword
+	blah == 1 # Comment after expect statement
+
+main! : List(String) -> Result({}, _)
+main! = |_| { # Yeah I can leave a comment here
+	world = "World"
+	var number = 123
+	expect blah == 1
+	tag = Blue
+	return # Comment after return keyword
+		tag # Comment after return statement
+
+	# Just a random comment!
+
+	...
+	match_time(
+		..., # Single args with comment
+	)
+	some_func(
+		dbg # After debug
+			42, # After debug expr
+	)
+	crash # Comment after crash keyword
+		"Unreachable!" # Comment after crash statement
+	tag_with_payload = Ok(number)
+	interpolated = "Hello, ${world}"
+	list = [
+		add_one(
+			dbg # After dbg in list
+				number, # after dbg expr as arg
+		), # Comment one
+		456, # Comment two
+		789, # Comment three
+	]
+	for n in list {
+		Stdout.line!("Adding ${n} to ${number}")
+		number = number + n
+	}
+	record = { foo: 123, bar: "Hello", baz: tag, qux: Ok(world), punned }
+	tuple = (123, "World", tag, Ok(world), (nested, tuple), [1, 2, 3])
+	multiline_tuple = (
+		123,
+		"World",
+		tag1,
+		Ok(world), # This one has a comment
+		(nested, tuple),
+		[1, 2, 3],
+	)
+	bin_op_result = Err(foo) ?? 12 > 5 * 5 or 13 + 2 < 5 and 10 - 1 >= 16 or 12 <= 3 / 5
+	static_dispatch_style = some_fn(arg1)?.static_dispatch_method()?.next_static_dispatch_method()?.record_field?
+	Stdout.line!(interpolated)?
+	Stdout.line!(
+		"How about ${ # Comment after string interpolation open
+			Num.toStr(number) # Comment after string interpolation expr
+		} as a string?",
+	)
+} # Comment after top-level decl
+
+empty : {}
+empty = {}
+
+tuple : Value((a, b, c))
+
+expect {
+	foo = 1 # This should work too
+	blah = 1
+	blah == foo
+}
+
+import pf.Stdout exposing [line!, write!]
+
+import # Comment after import keyword
+	pf # Comment after qualifier
+		.StdoutMultiline # Comment after ident
+		exposing [ # Comment after exposing open
+			line!, # Comment after exposed item
+			write!, # Another after exposed item
+		] # Comment after exposing close
+
+import pkg.Something exposing [func as function, Type as ValueCategory, Custom.*]
+
+import BadName as GoodName
+import
+	BadNameMultiline
+		as
+		GoodNameMultiline
+
+Map(a, b) : List(a), (a -> b) -> List(b)
+MapML( # Comment here
+	a, # And here
+	b,
+) # And after the last arg
+	: # And after the colon
+		List( # Inside Tag args
+			a, # After tag arg
+		),
+		(a -> b) -> # After arrow
+			List( # Inside tag args
+				b,
+			) # And after the type decl
+
+Foo : (Bar, Baz)
+
+FooMultiline : ( # Comment after pattern tuple open
+	Bar, # Comment after pattern tuple item
+	Baz, # Another after pattern tuple item
+) # Comment after pattern tuple close
+
+Some(a) : { foo : Ok(a), bar : Something }
+SomeMl(a) : { # After record open
+	foo : Ok(a), # After field
+	bar : Something, # After last field
+}
+
+SomeMultiline(a) : { # Comment after pattern record open
+	foo # After field name
+		: # Before field anno
+			Ok(a), # Comment after pattern record field
+	bar : Something, # Another after pattern record field
+} # Comment after pattern record close
+
+Maybe(a) : [Some(a), None]
+
+MaybeMultiline(a) : [ # Comment after tag union open
+	Some(a), # Comment after tag union member
+	None, # Another after tag union member
+] # Comment after tag union close
+
+SomeFunc(a) : Maybe(a), a -> Maybe(a)
+
+add_one_oneline = |num| if num 2 else 5
+
+add_one : U64 -> U64
+add_one = |num| {
+	other = 1
+	if num {
+		dbg # After debug
+			some_func() # After debug expr
+		0
+	} else {
+		dbg 123
+		other
+	}
+}
+
+match_time = |
+	a, # After arg
+	b,
+| # After args
+	match a {
+		Blue | Green | Red => {
+			x = 12
+			x
+		}
+		Blue # After pattern in alt
+		| # Before pattern in alt
+			Green
+		| Red # After alt pattern
+			=> {
+				x = 12
+				x
+			}
+		lower # After pattern comment
+			=> 1
+		"foo" => # After arrow comment
+			100
+		"foo" | "bar" => 200
+		[1, 2, 3, .. as rest] # After pattern comment
+			=> # After arrow comment
+				123 # After branch comment
+
+		# Just a random comment
+
+		[1, 2 | 5, 3, .. as rest] => 123
+		[
+			1,
+			2 | 5,
+			3,
+			.. # After DoubleDot
+				as # Before alias
+					rest, # After last pattern in list
+		] => 123
+		3.14 => 314
+		3.14 | 6.28 => 314
+		(1, 2, 3) => 123
+		(1, 2 | 5, 3) => 123
+		{ foo: 1, bar: 2, ..rest } => 12->add(34)
+		{ # After pattern record open
+			foo # After pattern record field name
+				: # Before pattern record field value
+					1, # After pattern record field
+			bar: 2,
+			.. # After spread operator
+				rest, # After last field
+		} => 12
+		{ foo: 1, bar: 2 | 7 } => 12
+		{
+			foo: 1,
+			bar: 2 | 7, # After last record field
+		} => 12
+		Ok(123) => 123
+		Ok(Some(dude)) => dude
+		TwoArgs("hello", Some("world")) => 1000
+	}
+
+expect # Comment after expect keyword
+	blah == 1 # Comment after expect statement
+
+main! : List(String) -> Result({}, _)
+main! = |_| { # Yeah I can leave a comment here
+	world = "World"
+	var number = 123
+	expect blah == 1
+	tag = Blue
+	return # Comment after return keyword
+		tag # Comment after return statement
+
+	# Just a random comment!
+
+	...
+	match_time(
+		..., # Single args with comment
+	)
+	some_func(
+		dbg # After debug
+			42, # After debug expr
+	)
+	crash # Comment after crash keyword
+		"Unreachable!" # Comment after crash statement
+	tag_with_payload = Ok(number)
+	interpolated = "Hello, ${world}"
+	list = [
+		add_one(
+			dbg # After dbg in list
+				number, # after dbg expr as arg
+		), # Comment one
+		456, # Comment two
+		789, # Comment three
+	]
+	for n in list {
+		Stdout.line!("Adding ${n} to ${number}")
+		number = number + n
+	}
+	record = { foo: 123, bar: "Hello", baz: tag, qux: Ok(world), punned }
+	tuple = (123, "World", tag, Ok(world), (nested, tuple), [1, 2, 3])
+	multiline_tuple = (
+		123,
+		"World",
+		tag1,
+		Ok(world), # This one has a comment
+		(nested, tuple),
+		[1, 2, 3],
+	)
+	bin_op_result = Err(foo) ?? 12 > 5 * 5 or 13 + 2 < 5 and 10 - 1 >= 16 or 12 <= 3 / 5
+	static_dispatch_style = some_fn(arg1)?.static_dispatch_method()?.next_static_dispatch_method()?.record_field?
+	Stdout.line!(interpolated)?
+	Stdout.line!(
+		"How about ${ # Comment after string interpolation open
+			Num.toStr(number) # Comment after string interpolation expr
+		} as a string?",
+	)
+} # Comment after top-level decl
+
+empty : {}
+empty = {}
+
+tuple : Value((a, b, c))
+
+expect {
+	foo = 1 # This should work too
+	blah = 1
+	blah == foo
+}
+
+import pf.Stdout exposing [line!, write!]
+
+import # Comment after import keyword
+	pf # Comment after qualifier
+		.StdoutMultiline # Comment after ident
+		exposing [ # Comment after exposing open
+			line!, # Comment after exposed item
+			write!, # Another after exposed item
+		] # Comment after exposing close
+
+import pkg.Something exposing [func as function, Type as ValueCategory, Custom.*]
+
+import BadName as GoodName
+import
+	BadNameMultiline
+		as
+		GoodNameMultiline
+
+Map(a, b) : List(a), (a -> b) -> List(b)
+MapML( # Comment here
+	a, # And here
+	b,
+) # And after the last arg
+	: # And after the colon
+		List( # Inside Tag args
+			a, # After tag arg
+		),
+		(a -> b) -> # After arrow
+			List( # Inside tag args
+				b,
+			) # And after the type decl
+
+Foo : (Bar, Baz)
+
+FooMultiline : ( # Comment after pattern tuple open
+	Bar, # Comment after pattern tuple item
+	Baz, # Another after pattern tuple item
+) # Comment after pattern tuple close
+
+Some(a) : { foo : Ok(a), bar : Something }
+SomeMl(a) : { # After record open
+	foo : Ok(a), # After field
+	bar : Something, # After last field
+}
+
+SomeMultiline(a) : { # Comment after pattern record open
+	foo # After field name
+		: # Before field anno
+			Ok(a), # Comment after pattern record field
+	bar : Something, # Another after pattern record field
+} # Comment after pattern record close
+
+Maybe(a) : [Some(a), None]
+
+MaybeMultiline(a) : [ # Comment after tag union open
+	Some(a), # Comment after tag union member
+	None, # Another after tag union member
+] # Comment after tag union close
+
+SomeFunc(a) : Maybe(a), a -> Maybe(a)
+
+add_one_oneline = |num| if num 2 else 5
+
+add_one : U64 -> U64
+add_one = |num| {
+	other = 1
+	if num {
+		dbg # After debug
+			some_func() # After debug expr
+		0
+	} else {
+		dbg 123
+		other
+	}
+}
+
+match_time = |
+	a, # After arg
+	b,
+| # After args
+	match a {
+		Blue | Green | Red => {
+			x = 12
+			x
+		}
+		Blue # After pattern in alt
+		| # Before pattern in alt
+			Green
+		| Red # After alt pattern
+			=> {
+				x = 12
+				x
+			}
+		lower # After pattern comment
+			=> 1
+		"foo" => # After arrow comment
+			100
+		"foo" | "bar" => 200
+		[1, 2, 3, .. as rest] # After pattern comment
+			=> # After arrow comment
+				123 # After branch comment
+
+		# Just a random comment
+
+		[1, 2 | 5, 3, .. as rest] => 123
+		[
+			1,
+			2 | 5,
+			3,
+			.. # After DoubleDot
+				as # Before alias
+					rest, # After last pattern in list
+		] => 123
+		3.14 => 314
+		3.14 | 6.28 => 314
+		(1, 2, 3) => 123
+		(1, 2 | 5, 3) => 123
+		{ foo: 1, bar: 2, ..rest } => 12->add(34)
+		{ # After pattern record open
+			foo # After pattern record field name
+				: # Before pattern record field value
+					1, # After pattern record field
+			bar: 2,
+			.. # After spread operator
+				rest, # After last field
+		} => 12
+		{ foo: 1, bar: 2 | 7 } => 12
+		{
+			foo: 1,
+			bar: 2 | 7, # After last record field
+		} => 12
+		Ok(123) => 123
+		Ok(Some(dude)) => dude
+		TwoArgs("hello", Some("world")) => 1000
+	}
+
+expect # Comment after expect keyword
+	blah == 1 # Comment after expect statement
+
+main! : List(String) -> Result({}, _)
+main! = |_| { # Yeah I can leave a comment here
+	world = "World"
+	var number = 123
+	expect blah == 1
+	tag = Blue
+	return # Comment after return keyword
+		tag # Comment after return statement
+
+	# Just a random comment!
+
+	...
+	match_time(
+		..., # Single args with comment
+	)
+	some_func(
+		dbg # After debug
+			42, # After debug expr
+	)
+	crash # Comment after crash keyword
+		"Unreachable!" # Comment after crash statement
+	tag_with_payload = Ok(number)
+	interpolated = "Hello, ${world}"
+	list = [
+		add_one(
+			dbg # After dbg in list
+				number, # after dbg expr as arg
+		), # Comment one
+		456, # Comment two
+		789, # Comment three
+	]
+	for n in list {
+		Stdout.line!("Adding ${n} to ${number}")
+		number = number + n
+	}
+	record = { foo: 123, bar: "Hello", baz: tag, qux: Ok(world), punned }
+	tuple = (123, "World", tag, Ok(world), (nested, tuple), [1, 2, 3])
+	multiline_tuple = (
+		123,
+		"World",
+		tag1,
+		Ok(world), # This one has a comment
+		(nested, tuple),
+		[1, 2, 3],
+	)
+	bin_op_result = Err(foo) ?? 12 > 5 * 5 or 13 + 2 < 5 and 10 - 1 >= 16 or 12 <= 3 / 5
+	static_dispatch_style = some_fn(arg1)?.static_dispatch_method()?.next_static_dispatch_method()?.record_field?
+	Stdout.line!(interpolated)?
+	Stdout.line!(
+		"How about ${ # Comment after string interpolation open
+			Num.toStr(number) # Comment after string interpolation expr
+		} as a string?",
+	)
+} # Comment after top-level decl
+
+empty : {}
+empty = {}
+
+tuple : Value((a, b, c))
+
+expect {
+	foo = 1 # This should work too
+	blah = 1
+	blah == foo
+}
+
+import pf.Stdout exposing [line!, write!]
+
+import # Comment after import keyword
+	pf # Comment after qualifier
+		.StdoutMultiline # Comment after ident
+		exposing [ # Comment after exposing open
+			line!, # Comment after exposed item
+			write!, # Another after exposed item
+		] # Comment after exposing close
+
+import pkg.Something exposing [func as function, Type as ValueCategory, Custom.*]
+
+import BadName as GoodName
+import
+	BadNameMultiline
+		as
+		GoodNameMultiline
+
+Map(a, b) : List(a), (a -> b) -> List(b)
+MapML( # Comment here
+	a, # And here
+	b,
+) # And after the last arg
+	: # And after the colon
+		List( # Inside Tag args
+			a, # After tag arg
+		),
+		(a -> b) -> # After arrow
+			List( # Inside tag args
+				b,
+			) # And after the type decl
+
+Foo : (Bar, Baz)
+
+FooMultiline : ( # Comment after pattern tuple open
+	Bar, # Comment after pattern tuple item
+	Baz, # Another after pattern tuple item
+) # Comment after pattern tuple close
+
+Some(a) : { foo : Ok(a), bar : Something }
+SomeMl(a) : { # After record open
+	foo : Ok(a), # After field
+	bar : Something, # After last field
+}
+
+SomeMultiline(a) : { # Comment after pattern record open
+	foo # After field name
+		: # Before field anno
+			Ok(a), # Comment after pattern record field
+	bar : Something, # Another after pattern record field
+} # Comment after pattern record close
+
+Maybe(a) : [Some(a), None]
+
+MaybeMultiline(a) : [ # Comment after tag union open
+	Some(a), # Comment after tag union member
+	None, # Another after tag union member
+] # Comment after tag union close
+
+SomeFunc(a) : Maybe(a), a -> Maybe(a)
+
+add_one_oneline = |num| if num 2 else 5
+
+add_one : U64 -> U64
+add_one = |num| {
+	other = 1
+	if num {
+		dbg # After debug
+			some_func() # After debug expr
+		0
+	} else {
+		dbg 123
+		other
+	}
+}
+
+match_time = |
+	a, # After arg
+	b,
+| # After args
+	match a {
+		Blue | Green | Red => {
+			x = 12
+			x
+		}
+		Blue # After pattern in alt
+		| # Before pattern in alt
+			Green
+		| Red # After alt pattern
+			=> {
+				x = 12
+				x
+			}
+		lower # After pattern comment
+			=> 1
+		"foo" => # After arrow comment
+			100
+		"foo" | "bar" => 200
+		[1, 2, 3, .. as rest] # After pattern comment
+			=> # After arrow comment
+				123 # After branch comment
+
+		# Just a random comment
+
+		[1, 2 | 5, 3, .. as rest] => 123
+		[
+			1,
+			2 | 5,
+			3,
+			.. # After DoubleDot
+				as # Before alias
+					rest, # After last pattern in list
+		] => 123
+		3.14 => 314
+		3.14 | 6.28 => 314
+		(1, 2, 3) => 123
+		(1, 2 | 5, 3) => 123
+		{ foo: 1, bar: 2, ..rest } => 12->add(34)
+		{ # After pattern record open
+			foo # After pattern record field name
+				: # Before pattern record field value
+					1, # After pattern record field
+			bar: 2,
+			.. # After spread operator
+				rest, # After last field
+		} => 12
+		{ foo: 1, bar: 2 | 7 } => 12
+		{
+			foo: 1,
+			bar: 2 | 7, # After last record field
+		} => 12
+		Ok(123) => 123
+		Ok(Some(dude)) => dude
+		TwoArgs("hello", Some("world")) => 1000
+	}
+
+expect # Comment after expect keyword
+	blah == 1 # Comment after expect statement
+
+main! : List(String) -> Result({}, _)
+main! = |_| { # Yeah I can leave a comment here
+	world = "World"
+	var number = 123
+	expect blah == 1
+	tag = Blue
+	return # Comment after return keyword
+		tag # Comment after return statement
+
+	# Just a random comment!
+
+	...
+	match_time(
+		..., # Single args with comment
+	)
+	some_func(
+		dbg # After debug
+			42, # After debug expr
+	)
+	crash # Comment after crash keyword
+		"Unreachable!" # Comment after crash statement
+	tag_with_payload = Ok(number)
+	interpolated = "Hello, ${world}"
+	list = [
+		add_one(
+			dbg # After dbg in list
+				number, # after dbg expr as arg
+		), # Comment one
+		456, # Comment two
+		789, # Comment three
+	]
+	for n in list {
+		Stdout.line!("Adding ${n} to ${number}")
+		number = number + n
+	}
+	record = { foo: 123, bar: "Hello", baz: tag, qux: Ok(world), punned }
+	tuple = (123, "World", tag, Ok(world), (nested, tuple), [1, 2, 3])
+	multiline_tuple = (
+		123,
+		"World",
+		tag1,
+		Ok(world), # This one has a comment
+		(nested, tuple),
+		[1, 2, 3],
+	)
+	bin_op_result = Err(foo) ?? 12 > 5 * 5 or 13 + 2 < 5 and 10 - 1 >= 16 or 12 <= 3 / 5
+	static_dispatch_style = some_fn(arg1)?.static_dispatch_method()?.next_static_dispatch_method()?.record_field?
+	Stdout.line!(interpolated)?
+	Stdout.line!(
+		"How about ${ # Comment after string interpolation open
+			Num.toStr(number) # Comment after string interpolation expr
+		} as a string?",
+	)
+} # Comment after top-level decl
+
+empty : {}
+empty = {}
+
+tuple : Value((a, b, c))
+
+expect {
+	foo = 1 # This should work too
+	blah = 1
+	blah == foo
+}
+
+import pf.Stdout exposing [line!, write!]
+
+import # Comment after import keyword
+	pf # Comment after qualifier
+		.StdoutMultiline # Comment after ident
+		exposing [ # Comment after exposing open
+			line!, # Comment after exposed item
+			write!, # Another after exposed item
+		] # Comment after exposing close
+
+import pkg.Something exposing [func as function, Type as ValueCategory, Custom.*]
+
+import BadName as GoodName
+import
+	BadNameMultiline
+		as
+		GoodNameMultiline
+
+Map(a, b) : List(a), (a -> b) -> List(b)
+MapML( # Comment here
+	a, # And here
+	b,
+) # And after the last arg
+	: # And after the colon
+		List( # Inside Tag args
+			a, # After tag arg
+		),
+		(a -> b) -> # After arrow
+			List( # Inside tag args
+				b,
+			) # And after the type decl
+
+Foo : (Bar, Baz)
+
+FooMultiline : ( # Comment after pattern tuple open
+	Bar, # Comment after pattern tuple item
+	Baz, # Another after pattern tuple item
+) # Comment after pattern tuple close
+
+Some(a) : { foo : Ok(a), bar : Something }
+SomeMl(a) : { # After record open
+	foo : Ok(a), # After field
+	bar : Something, # After last field
+}
+
+SomeMultiline(a) : { # Comment after pattern record open
+	foo # After field name
+		: # Before field anno
+			Ok(a), # Comment after pattern record field
+	bar : Something, # Another after pattern record field
+} # Comment after pattern record close
+
+Maybe(a) : [Some(a), None]
+
+MaybeMultiline(a) : [ # Comment after tag union open
+	Some(a), # Comment after tag union member
+	None, # Another after tag union member
+] # Comment after tag union close
+
+SomeFunc(a) : Maybe(a), a -> Maybe(a)
+
+add_one_oneline = |num| if num 2 else 5
+
+add_one : U64 -> U64
+add_one = |num| {
+	other = 1
+	if num {
+		dbg # After debug
+			some_func() # After debug expr
+		0
+	} else {
+		dbg 123
+		other
+	}
+}
+
+match_time = |
+	a, # After arg
+	b,
+| # After args
+	match a {
+		Blue | Green | Red => {
+			x = 12
+			x
+		}
+		Blue # After pattern in alt
+		| # Before pattern in alt
+			Green
+		| Red # After alt pattern
+			=> {
+				x = 12
+				x
+			}
+		lower # After pattern comment
+			=> 1
+		"foo" => # After arrow comment
+			100
+		"foo" | "bar" => 200
+		[1, 2, 3, .. as rest] # After pattern comment
+			=> # After arrow comment
+				123 # After branch comment
+
+		# Just a random comment
+
+		[1, 2 | 5, 3, .. as rest] => 123
+		[
+			1,
+			2 | 5,
+			3,
+			.. # After DoubleDot
+				as # Before alias
+					rest, # After last pattern in list
+		] => 123
+		3.14 => 314
+		3.14 | 6.28 => 314
+		(1, 2, 3) => 123
+		(1, 2 | 5, 3) => 123
+		{ foo: 1, bar: 2, ..rest } => 12->add(34)
+		{ # After pattern record open
+			foo # After pattern record field name
+				: # Before pattern record field value
+					1, # After pattern record field
+			bar: 2,
+			.. # After spread operator
+				rest, # After last field
+		} => 12
+		{ foo: 1, bar: 2 | 7 } => 12
+		{
+			foo: 1,
+			bar: 2 | 7, # After last record field
+		} => 12
+		Ok(123) => 123
+		Ok(Some(dude)) => dude
+		TwoArgs("hello", Some("world")) => 1000
+	}
+
+expect # Comment after expect keyword
+	blah == 1 # Comment after expect statement
+
+main! : List(String) -> Result({}, _)
+main! = |_| { # Yeah I can leave a comment here
+	world = "World"
+	var number = 123
+	expect blah == 1
+	tag = Blue
+	return # Comment after return keyword
+		tag # Comment after return statement
+
+	# Just a random comment!
+
+	...
+	match_time(
+		..., # Single args with comment
+	)
+	some_func(
+		dbg # After debug
+			42, # After debug expr
+	)
+	crash # Comment after crash keyword
+		"Unreachable!" # Comment after crash statement
+	tag_with_payload = Ok(number)
+	interpolated = "Hello, ${world}"
+	list = [
+		add_one(
+			dbg # After dbg in list
+				number, # after dbg expr as arg
+		), # Comment one
+		456, # Comment two
+		789, # Comment three
+	]
+	for n in list {
+		Stdout.line!("Adding ${n} to ${number}")
+		number = number + n
+	}
+	record = { foo: 123, bar: "Hello", baz: tag, qux: Ok(world), punned }
+	tuple = (123, "World", tag, Ok(world), (nested, tuple), [1, 2, 3])
+	multiline_tuple = (
+		123,
+		"World",
+		tag1,
+		Ok(world), # This one has a comment
+		(nested, tuple),
+		[1, 2, 3],
+	)
+	bin_op_result = Err(foo) ?? 12 > 5 * 5 or 13 + 2 < 5 and 10 - 1 >= 16 or 12 <= 3 / 5
+	static_dispatch_style = some_fn(arg1)?.static_dispatch_method()?.next_static_dispatch_method()?.record_field?
+	Stdout.line!(interpolated)?
+	Stdout.line!(
+		"How about ${ # Comment after string interpolation open
+			Num.toStr(number) # Comment after string interpolation expr
+		} as a string?",
+	)
+} # Comment after top-level decl
+
+empty : {}
+empty = {}
+
+tuple : Value((a, b, c))
+
+expect {
+	foo = 1 # This should work too
+	blah = 1
+	blah == foo
+}
+
+import pf.Stdout exposing [line!, write!]
+
+import # Comment after import keyword
+	pf # Comment after qualifier
+		.StdoutMultiline # Comment after ident
+		exposing [ # Comment after exposing open
+			line!, # Comment after exposed item
+			write!, # Another after exposed item
+		] # Comment after exposing close
+
+import pkg.Something exposing [func as function, Type as ValueCategory, Custom.*]
+
+import BadName as GoodName
+import
+	BadNameMultiline
+		as
+		GoodNameMultiline
+
+Map(a, b) : List(a), (a -> b) -> List(b)
+MapML( # Comment here
+	a, # And here
+	b,
+) # And after the last arg
+	: # And after the colon
+		List( # Inside Tag args
+			a, # After tag arg
+		),
+		(a -> b) -> # After arrow
+			List( # Inside tag args
+				b,
+			) # And after the type decl
+
+Foo : (Bar, Baz)
+
+FooMultiline : ( # Comment after pattern tuple open
+	Bar, # Comment after pattern tuple item
+	Baz, # Another after pattern tuple item
+) # Comment after pattern tuple close
+
+Some(a) : { foo : Ok(a), bar : Something }
+SomeMl(a) : { # After record open
+	foo : Ok(a), # After field
+	bar : Something, # After last field
+}
+
+SomeMultiline(a) : { # Comment after pattern record open
+	foo # After field name
+		: # Before field anno
+			Ok(a), # Comment after pattern record field
+	bar : Something, # Another after pattern record field
+} # Comment after pattern record close
+
+Maybe(a) : [Some(a), None]
+
+MaybeMultiline(a) : [ # Comment after tag union open
+	Some(a), # Comment after tag union member
+	None, # Another after tag union member
+] # Comment after tag union close
+
+SomeFunc(a) : Maybe(a), a -> Maybe(a)
+
+add_one_oneline = |num| if num 2 else 5
+
+add_one : U64 -> U64
+add_one = |num| {
+	other = 1
+	if num {
+		dbg # After debug
+			some_func() # After debug expr
+		0
+	} else {
+		dbg 123
+		other
+	}
+}
+
+match_time = |
+	a, # After arg
+	b,
+| # After args
+	match a {
+		Blue | Green | Red => {
+			x = 12
+			x
+		}
+		Blue # After pattern in alt
+		| # Before pattern in alt
+			Green
+		| Red # After alt pattern
+			=> {
+				x = 12
+				x
+			}
+		lower # After pattern comment
+			=> 1
+		"foo" => # After arrow comment
+			100
+		"foo" | "bar" => 200
+		[1, 2, 3, .. as rest] # After pattern comment
+			=> # After arrow comment
+				123 # After branch comment
+
+		# Just a random comment
+
+		[1, 2 | 5, 3, .. as rest] => 123
+		[
+			1,
+			2 | 5,
+			3,
+			.. # After DoubleDot
+				as # Before alias
+					rest, # After last pattern in list
+		] => 123
+		3.14 => 314
+		3.14 | 6.28 => 314
+		(1, 2, 3) => 123
+		(1, 2 | 5, 3) => 123
+		{ foo: 1, bar: 2, ..rest } => 12->add(34)
+		{ # After pattern record open
+			foo # After pattern record field name
+				: # Before pattern record field value
+					1, # After pattern record field
+			bar: 2,
+			.. # After spread operator
+				rest, # After last field
+		} => 12
+		{ foo: 1, bar: 2 | 7 } => 12
+		{
+			foo: 1,
+			bar: 2 | 7, # After last record field
+		} => 12
+		Ok(123) => 123
+		Ok(Some(dude)) => dude
+		TwoArgs("hello", Some("world")) => 1000
+	}
+
+expect # Comment after expect keyword
+	blah == 1 # Comment after expect statement
+
+main! : List(String) -> Result({}, _)
+main! = |_| { # Yeah I can leave a comment here
+	world = "World"
+	var number = 123
+	expect blah == 1
+	tag = Blue
+	return # Comment after return keyword
+		tag # Comment after return statement
+
+	# Just a random comment!
+
+	...
+	match_time(
+		..., # Single args with comment
+	)
+	some_func(
+		dbg # After debug
+			42, # After debug expr
+	)
+	crash # Comment after crash keyword
+		"Unreachable!" # Comment after crash statement
+	tag_with_payload = Ok(number)
+	interpolated = "Hello, ${world}"
+	list = [
+		add_one(
+			dbg # After dbg in list
+				number, # after dbg expr as arg
+		), # Comment one
+		456, # Comment two
+		789, # Comment three
+	]
+	for n in list {
+		Stdout.line!("Adding ${n} to ${number}")
+		number = number + n
+	}
+	record = { foo: 123, bar: "Hello", baz: tag, qux: Ok(world), punned }
+	tuple = (123, "World", tag, Ok(world), (nested, tuple), [1, 2, 3])
+	multiline_tuple = (
+		123,
+		"World",
+		tag1,
+		Ok(world), # This one has a comment
+		(nested, tuple),
+		[1, 2, 3],
+	)
+	bin_op_result = Err(foo) ?? 12 > 5 * 5 or 13 + 2 < 5 and 10 - 1 >= 16 or 12 <= 3 / 5
+	static_dispatch_style = some_fn(arg1)?.static_dispatch_method()?.next_static_dispatch_method()?.record_field?
+	Stdout.line!(interpolated)?
+	Stdout.line!(
+		"How about ${ # Comment after string interpolation open
+			Num.toStr(number) # Comment after string interpolation expr
+		} as a string?",
+	)
+} # Comment after top-level decl
+
+empty : {}
+empty = {}
+
+tuple : Value((a, b, c))
+
+expect {
+	foo = 1 # This should work too
+	blah = 1
+	blah == foo
+}
+
+import pf.Stdout exposing [line!, write!]
+
+import # Comment after import keyword
+	pf # Comment after qualifier
+		.StdoutMultiline # Comment after ident
+		exposing [ # Comment after exposing open
+			line!, # Comment after exposed item
+			write!, # Another after exposed item
+		] # Comment after exposing close
+
+import pkg.Something exposing [func as function, Type as ValueCategory, Custom.*]
+
+import BadName as GoodName
+import
+	BadNameMultiline
+		as
+		GoodNameMultiline
+
+Map(a, b) : List(a), (a -> b) -> List(b)
+MapML( # Comment here
+	a, # And here
+	b,
+) # And after the last arg
+	: # And after the colon
+		List( # Inside Tag args
+			a, # After tag arg
+		),
+		(a -> b) -> # After arrow
+			List( # Inside tag args
+				b,
+			) # And after the type decl
+
+Foo : (Bar, Baz)
+
+FooMultiline : ( # Comment after pattern tuple open
+	Bar, # Comment after pattern tuple item
+	Baz, # Another after pattern tuple item
+) # Comment after pattern tuple close
+
+Some(a) : { foo : Ok(a), bar : Something }
+SomeMl(a) : { # After record open
+	foo : Ok(a), # After field
+	bar : Something, # After last field
+}
+
+SomeMultiline(a) : { # Comment after pattern record open
+	foo # After field name
+		: # Before field anno
+			Ok(a), # Comment after pattern record field
+	bar : Something, # Another after pattern record field
+} # Comment after pattern record close
+
+Maybe(a) : [Some(a), None]
+
+MaybeMultiline(a) : [ # Comment after tag union open
+	Some(a), # Comment after tag union member
+	None, # Another after tag union member
+] # Comment after tag union close
+
+SomeFunc(a) : Maybe(a), a -> Maybe(a)
+
+add_one_oneline = |num| if num 2 else 5
+
+add_one : U64 -> U64
+add_one = |num| {
+	other = 1
+	if num {
+		dbg # After debug
+			some_func() # After debug expr
+		0
+	} else {
+		dbg 123
+		other
+	}
+}
+
+match_time = |
+	a, # After arg
+	b,
+| # After args
+	match a {
+		Blue | Green | Red => {
+			x = 12
+			x
+		}
+		Blue # After pattern in alt
+		| # Before pattern in alt
+			Green
+		| Red # After alt pattern
+			=> {
+				x = 12
+				x
+			}
+		lower # After pattern comment
+			=> 1
+		"foo" => # After arrow comment
+			100
+		"foo" | "bar" => 200
+		[1, 2, 3, .. as rest] # After pattern comment
+			=> # After arrow comment
+				123 # After branch comment
+
+		# Just a random comment
+
+		[1, 2 | 5, 3, .. as rest] => 123
+		[
+			1,
+			2 | 5,
+			3,
+			.. # After DoubleDot
+				as # Before alias
+					rest, # After last pattern in list
+		] => 123
+		3.14 => 314
+		3.14 | 6.28 => 314
+		(1, 2, 3) => 123
+		(1, 2 | 5, 3) => 123
+		{ foo: 1, bar: 2, ..rest } => 12->add(34)
+		{ # After pattern record open
+			foo # After pattern record field name
+				: # Before pattern record field value
+					1, # After pattern record field
+			bar: 2,
+			.. # After spread operator
+				rest, # After last field
+		} => 12
+		{ foo: 1, bar: 2 | 7 } => 12
+		{
+			foo: 1,
+			bar: 2 | 7, # After last record field
+		} => 12
+		Ok(123) => 123
+		Ok(Some(dude)) => dude
+		TwoArgs("hello", Some("world")) => 1000
+	}
+
+expect # Comment after expect keyword
+	blah == 1 # Comment after expect statement
+
+main! : List(String) -> Result({}, _)
+main! = |_| { # Yeah I can leave a comment here
+	world = "World"
+	var number = 123
+	expect blah == 1
+	tag = Blue
+	return # Comment after return keyword
+		tag # Comment after return statement
+
+	# Just a random comment!
+
+	...
+	match_time(
+		..., # Single args with comment
+	)
+	some_func(
+		dbg # After debug
+			42, # After debug expr
+	)
+	crash # Comment after crash keyword
+		"Unreachable!" # Comment after crash statement
+	tag_with_payload = Ok(number)
+	interpolated = "Hello, ${world}"
+	list = [
+		add_one(
+			dbg # After dbg in list
+				number, # after dbg expr as arg
+		), # Comment one
+		456, # Comment two
+		789, # Comment three
+	]
+	for n in list {
+		Stdout.line!("Adding ${n} to ${number}")
+		number = number + n
+	}
+	record = { foo: 123, bar: "Hello", baz: tag, qux: Ok(world), punned }
+	tuple = (123, "World", tag, Ok(world), (nested, tuple), [1, 2, 3])
+	multiline_tuple = (
+		123,
+		"World",
+		tag1,
+		Ok(world), # This one has a comment
+		(nested, tuple),
+		[1, 2, 3],
+	)
+	bin_op_result = Err(foo) ?? 12 > 5 * 5 or 13 + 2 < 5 and 10 - 1 >= 16 or 12 <= 3 / 5
+	static_dispatch_style = some_fn(arg1)?.static_dispatch_method()?.next_static_dispatch_method()?.record_field?
+	Stdout.line!(interpolated)?
+	Stdout.line!(
+		"How about ${ # Comment after string interpolation open
+			Num.toStr(number) # Comment after string interpolation expr
+		} as a string?",
+	)
+} # Comment after top-level decl
+
+empty : {}
+empty = {}
+
+tuple : Value((a, b, c))
+
+expect {
+	foo = 1 # This should work too
+	blah = 1
+	blah == foo
+}
+
+import pf.Stdout exposing [line!, write!]
+
+import # Comment after import keyword
+	pf # Comment after qualifier
+		.StdoutMultiline # Comment after ident
+		exposing [ # Comment after exposing open
+			line!, # Comment after exposed item
+			write!, # Another after exposed item
+		] # Comment after exposing close
+
+import pkg.Something exposing [func as function, Type as ValueCategory, Custom.*]
+
+import BadName as GoodName
+import
+	BadNameMultiline
+		as
+		GoodNameMultiline
+
+Map(a, b) : List(a), (a -> b) -> List(b)
+MapML( # Comment here
+	a, # And here
+	b,
+) # And after the last arg
+	: # And after the colon
+		List( # Inside Tag args
+			a, # After tag arg
+		),
+		(a -> b) -> # After arrow
+			List( # Inside tag args
+				b,
+			) # And after the type decl
+
+Foo : (Bar, Baz)
+
+FooMultiline : ( # Comment after pattern tuple open
+	Bar, # Comment after pattern tuple item
+	Baz, # Another after pattern tuple item
+) # Comment after pattern tuple close
+
+Some(a) : { foo : Ok(a), bar : Something }
+SomeMl(a) : { # After record open
+	foo : Ok(a), # After field
+	bar : Something, # After last field
+}
+
+SomeMultiline(a) : { # Comment after pattern record open
+	foo # After field name
+		: # Before field anno
+			Ok(a), # Comment after pattern record field
+	bar : Something, # Another after pattern record field
+} # Comment after pattern record close
+
+Maybe(a) : [Some(a), None]
+
+MaybeMultiline(a) : [ # Comment after tag union open
+	Some(a), # Comment after tag union member
+	None, # Another after tag union member
+] # Comment after tag union close
+
+SomeFunc(a) : Maybe(a), a -> Maybe(a)
+
+add_one_oneline = |num| if num 2 else 5
+
+add_one : U64 -> U64
+add_one = |num| {
+	other = 1
+	if num {
+		dbg # After debug
+			some_func() # After debug expr
+		0
+	} else {
+		dbg 123
+		other
+	}
+}
+
+match_time = |
+	a, # After arg
+	b,
+| # After args
+	match a {
+		Blue | Green | Red => {
+			x = 12
+			x
+		}
+		Blue # After pattern in alt
+		| # Before pattern in alt
+			Green
+		| Red # After alt pattern
+			=> {
+				x = 12
+				x
+			}
+		lower # After pattern comment
+			=> 1
+		"foo" => # After arrow comment
+			100
+		"foo" | "bar" => 200
+		[1, 2, 3, .. as rest] # After pattern comment
+			=> # After arrow comment
+				123 # After branch comment
+
+		# Just a random comment
+
+		[1, 2 | 5, 3, .. as rest] => 123
+		[
+			1,
+			2 | 5,
+			3,
+			.. # After DoubleDot
+				as # Before alias
+					rest, # After last pattern in list
+		] => 123
+		3.14 => 314
+		3.14 | 6.28 => 314
+		(1, 2, 3) => 123
+		(1, 2 | 5, 3) => 123
+		{ foo: 1, bar: 2, ..rest } => 12->add(34)
+		{ # After pattern record open
+			foo # After pattern record field name
+				: # Before pattern record field value
+					1, # After pattern record field
+			bar: 2,
+			.. # After spread operator
+				rest, # After last field
+		} => 12
+		{ foo: 1, bar: 2 | 7 } => 12
+		{
+			foo: 1,
+			bar: 2 | 7, # After last record field
+		} => 12
+		Ok(123) => 123
+		Ok(Some(dude)) => dude
+		TwoArgs("hello", Some("world")) => 1000
+	}
+
+expect # Comment after expect keyword
+	blah == 1 # Comment after expect statement
+
+main! : List(String) -> Result({}, _)
+main! = |_| { # Yeah I can leave a comment here
+	world = "World"
+	var number = 123
+	expect blah == 1
+	tag = Blue
+	return # Comment after return keyword
+		tag # Comment after return statement
+
+	# Just a random comment!
+
+	...
+	match_time(
+		..., # Single args with comment
+	)
+	some_func(
+		dbg # After debug
+			42, # After debug expr
+	)
+	crash # Comment after crash keyword
+		"Unreachable!" # Comment after crash statement
+	tag_with_payload = Ok(number)
+	interpolated = "Hello, ${world}"
+	list = [
+		add_one(
+			dbg # After dbg in list
+				number, # after dbg expr as arg
+		), # Comment one
+		456, # Comment two
+		789, # Comment three
+	]
+	for n in list {
+		Stdout.line!("Adding ${n} to ${number}")
+		number = number + n
+	}
+	record = { foo: 123, bar: "Hello", baz: tag, qux: Ok(world), punned }
+	tuple = (123, "World", tag, Ok(world), (nested, tuple), [1, 2, 3])
+	multiline_tuple = (
+		123,
+		"World",
+		tag1,
+		Ok(world), # This one has a comment
+		(nested, tuple),
+		[1, 2, 3],
+	)
+	bin_op_result = Err(foo) ?? 12 > 5 * 5 or 13 + 2 < 5 and 10 - 1 >= 16 or 12 <= 3 / 5
+	static_dispatch_style = some_fn(arg1)?.static_dispatch_method()?.next_static_dispatch_method()?.record_field?
+	Stdout.line!(interpolated)?
+	Stdout.line!(
+		"How about ${ # Comment after string interpolation open
+			Num.toStr(number) # Comment after string interpolation expr
+		} as a string?",
+	)
+} # Comment after top-level decl
+
+empty : {}
+empty = {}
+
+tuple : Value((a, b, c))
+
+expect {
+	foo = 1 # This should work too
+	blah = 1
+	blah == foo
+}
+
+import pf.Stdout exposing [line!, write!]
+
+import # Comment after import keyword
+	pf # Comment after qualifier
+		.StdoutMultiline # Comment after ident
+		exposing [ # Comment after exposing open
+			line!, # Comment after exposed item
+			write!, # Another after exposed item
+		] # Comment after exposing close
+
+import pkg.Something exposing [func as function, Type as ValueCategory, Custom.*]
+
+import BadName as GoodName
+import
+	BadNameMultiline
+		as
+		GoodNameMultiline
+
+Map(a, b) : List(a), (a -> b) -> List(b)
+MapML( # Comment here
+	a, # And here
+	b,
+) # And after the last arg
+	: # And after the colon
+		List( # Inside Tag args
+			a, # After tag arg
+		),
+		(a -> b) -> # After arrow
+			List( # Inside tag args
+				b,
+			) # And after the type decl
+
+Foo : (Bar, Baz)
+
+FooMultiline : ( # Comment after pattern tuple open
+	Bar, # Comment after pattern tuple item
+	Baz, # Another after pattern tuple item
+) # Comment after pattern tuple close
+
+Some(a) : { foo : Ok(a), bar : Something }
+SomeMl(a) : { # After record open
+	foo : Ok(a), # After field
+	bar : Something, # After last field
+}
+
+SomeMultiline(a) : { # Comment after pattern record open
+	foo # After field name
+		: # Before field anno
+			Ok(a), # Comment after pattern record field
+	bar : Something, # Another after pattern record field
+} # Comment after pattern record close
+
+Maybe(a) : [Some(a), None]
+
+MaybeMultiline(a) : [ # Comment after tag union open
+	Some(a), # Comment after tag union member
+	None, # Another after tag union member
+] # Comment after tag union close
+
+SomeFunc(a) : Maybe(a), a -> Maybe(a)
+
+add_one_oneline = |num| if num 2 else 5
+
+add_one : U64 -> U64
+add_one = |num| {
+	other = 1
+	if num {
+		dbg # After debug
+			some_func() # After debug expr
+		0
+	} else {
+		dbg 123
+		other
+	}
+}
+
+match_time = |
+	a, # After arg
+	b,
+| # After args
+	match a {
+		Blue | Green | Red => {
+			x = 12
+			x
+		}
+		Blue # After pattern in alt
+		| # Before pattern in alt
+			Green
+		| Red # After alt pattern
+			=> {
+				x = 12
+				x
+			}
+		lower # After pattern comment
+			=> 1
+		"foo" => # After arrow comment
+			100
+		"foo" | "bar" => 200
+		[1, 2, 3, .. as rest] # After pattern comment
+			=> # After arrow comment
+				123 # After branch comment
+
+		# Just a random comment
+
+		[1, 2 | 5, 3, .. as rest] => 123
+		[
+			1,
+			2 | 5,
+			3,
+			.. # After DoubleDot
+				as # Before alias
+					rest, # After last pattern in list
+		] => 123
+		3.14 => 314
+		3.14 | 6.28 => 314
+		(1, 2, 3) => 123
+		(1, 2 | 5, 3) => 123
+		{ foo: 1, bar: 2, ..rest } => 12->add(34)
+		{ # After pattern record open
+			foo # After pattern record field name
+				: # Before pattern record field value
+					1, # After pattern record field
+			bar: 2,
+			.. # After spread operator
+				rest, # After last field
+		} => 12
+		{ foo: 1, bar: 2 | 7 } => 12
+		{
+			foo: 1,
+			bar: 2 | 7, # After last record field
+		} => 12
+		Ok(123) => 123
+		Ok(Some(dude)) => dude
+		TwoArgs("hello", Some("world")) => 1000
+	}
+
+expect # Comment after expect keyword
+	blah == 1 # Comment after expect statement
+
+main! : List(String) -> Result({}, _)
+main! = |_| { # Yeah I can leave a comment here
+	world = "World"
+	var number = 123
+	expect blah == 1
+	tag = Blue
+	return # Comment after return keyword
+		tag # Comment after return statement
+
+	# Just a random comment!
+
+	...
+	match_time(
+		..., # Single args with comment
+	)
+	some_func(
+		dbg # After debug
+			42, # After debug expr
+	)
+	crash # Comment after crash keyword
+		"Unreachable!" # Comment after crash statement
+	tag_with_payload = Ok(number)
+	interpolated = "Hello, ${world}"
+	list = [
+		add_one(
+			dbg # After dbg in list
+				number, # after dbg expr as arg
+		), # Comment one
+		456, # Comment two
+		789, # Comment three
+	]
+	for n in list {
+		Stdout.line!("Adding ${n} to ${number}")
+		number = number + n
+	}
+	record = { foo: 123, bar: "Hello", baz: tag, qux: Ok(world), punned }
+	tuple = (123, "World", tag, Ok(world), (nested, tuple), [1, 2, 3])
+	multiline_tuple = (
+		123,
+		"World",
+		tag1,
+		Ok(world), # This one has a comment
+		(nested, tuple),
+		[1, 2, 3],
+	)
+	bin_op_result = Err(foo) ?? 12 > 5 * 5 or 13 + 2 < 5 and 10 - 1 >= 16 or 12 <= 3 / 5
+	static_dispatch_style = some_fn(arg1)?.static_dispatch_method()?.next_static_dispatch_method()?.record_field?
+	Stdout.line!(interpolated)?
+	Stdout.line!(
+		"How about ${ # Comment after string interpolation open
+			Num.toStr(number) # Comment after string interpolation expr
+		} as a string?",
+	)
+} # Comment after top-level decl
+
+empty : {}
+empty = {}
+
+tuple : Value((a, b, c))
+
+expect {
+	foo = 1 # This should work too
+	blah = 1
+	blah == foo
+}
+
+import pf.Stdout exposing [line!, write!]
+
+import # Comment after import keyword
+	pf # Comment after qualifier
+		.StdoutMultiline # Comment after ident
+		exposing [ # Comment after exposing open
+			line!, # Comment after exposed item
+			write!, # Another after exposed item
+		] # Comment after exposing close
+
+import pkg.Something exposing [func as function, Type as ValueCategory, Custom.*]
+
+import BadName as GoodName
+import
+	BadNameMultiline
+		as
+		GoodNameMultiline
+
+Map(a, b) : List(a), (a -> b) -> List(b)
+MapML( # Comment here
+	a, # And here
+	b,
+) # And after the last arg
+	: # And after the colon
+		List( # Inside Tag args
+			a, # After tag arg
+		),
+		(a -> b) -> # After arrow
+			List( # Inside tag args
+				b,
+			) # And after the type decl
+
+Foo : (Bar, Baz)
+
+FooMultiline : ( # Comment after pattern tuple open
+	Bar, # Comment after pattern tuple item
+	Baz, # Another after pattern tuple item
+) # Comment after pattern tuple close
+
+Some(a) : { foo : Ok(a), bar : Something }
+SomeMl(a) : { # After record open
+	foo : Ok(a), # After field
+	bar : Something, # After last field
+}
+
+SomeMultiline(a) : { # Comment after pattern record open
+	foo # After field name
+		: # Before field anno
+			Ok(a), # Comment after pattern record field
+	bar : Something, # Another after pattern record field
+} # Comment after pattern record close
+
+Maybe(a) : [Some(a), None]
+
+MaybeMultiline(a) : [ # Comment after tag union open
+	Some(a), # Comment after tag union member
+	None, # Another after tag union member
+] # Comment after tag union close
+
+SomeFunc(a) : Maybe(a), a -> Maybe(a)
+
+add_one_oneline = |num| if num 2 else 5
+
+add_one : U64 -> U64
+add_one = |num| {
+	other = 1
+	if num {
+		dbg # After debug
+			some_func() # After debug expr
+		0
+	} else {
+		dbg 123
+		other
+	}
+}
+
+match_time = |
+	a, # After arg
+	b,
+| # After args
+	match a {
+		Blue | Green | Red => {
+			x = 12
+			x
+		}
+		Blue # After pattern in alt
+		| # Before pattern in alt
+			Green
+		| Red # After alt pattern
+			=> {
+				x = 12
+				x
+			}
+		lower # After pattern comment
+			=> 1
+		"foo" => # After arrow comment
+			100
+		"foo" | "bar" => 200
+		[1, 2, 3, .. as rest] # After pattern comment
+			=> # After arrow comment
+				123 # After branch comment
+
+		# Just a random comment
+
+		[1, 2 | 5, 3, .. as rest] => 123
+		[
+			1,
+			2 | 5,
+			3,
+			.. # After DoubleDot
+				as # Before alias
+					rest, # After last pattern in list
+		] => 123
+		3.14 => 314
+		3.14 | 6.28 => 314
+		(1, 2, 3) => 123
+		(1, 2 | 5, 3) => 123
+		{ foo: 1, bar: 2, ..rest } => 12->add(34)
+		{ # After pattern record open
+			foo # After pattern record field name
+				: # Before pattern record field value
+					1, # After pattern record field
+			bar: 2,
+			.. # After spread operator
+				rest, # After last field
+		} => 12
+		{ foo: 1, bar: 2 | 7 } => 12
+		{
+			foo: 1,
+			bar: 2 | 7, # After last record field
+		} => 12
+		Ok(123) => 123
+		Ok(Some(dude)) => dude
+		TwoArgs("hello", Some("world")) => 1000
+	}
+
+expect # Comment after expect keyword
+	blah == 1 # Comment after expect statement
+
+main! : List(String) -> Result({}, _)
+main! = |_| { # Yeah I can leave a comment here
+	world = "World"
+	var number = 123
+	expect blah == 1
+	tag = Blue
+	return # Comment after return keyword
+		tag # Comment after return statement
+
+	# Just a random comment!
+
+	...
+	match_time(
+		..., # Single args with comment
+	)
+	some_func(
+		dbg # After debug
+			42, # After debug expr
+	)
+	crash # Comment after crash keyword
+		"Unreachable!" # Comment after crash statement
+	tag_with_payload = Ok(number)
+	interpolated = "Hello, ${world}"
+	list = [
+		add_one(
+			dbg # After dbg in list
+				number, # after dbg expr as arg
+		), # Comment one
+		456, # Comment two
+		789, # Comment three
+	]
+	for n in list {
+		Stdout.line!("Adding ${n} to ${number}")
+		number = number + n
+	}
+	record = { foo: 123, bar: "Hello", baz: tag, qux: Ok(world), punned }
+	tuple = (123, "World", tag, Ok(world), (nested, tuple), [1, 2, 3])
+	multiline_tuple = (
+		123,
+		"World",
+		tag1,
+		Ok(world), # This one has a comment
+		(nested, tuple),
+		[1, 2, 3],
+	)
+	bin_op_result = Err(foo) ?? 12 > 5 * 5 or 13 + 2 < 5 and 10 - 1 >= 16 or 12 <= 3 / 5
+	static_dispatch_style = some_fn(arg1)?.static_dispatch_method()?.next_static_dispatch_method()?.record_field?
+	Stdout.line!(interpolated)?
+	Stdout.line!(
+		"How about ${ # Comment after string interpolation open
+			Num.toStr(number) # Comment after string interpolation expr
+		} as a string?",
+	)
+} # Comment after top-level decl
+
+empty : {}
+empty = {}
+
+tuple : Value((a, b, c))
+
+expect {
+	foo = 1 # This should work too
+	blah = 1
+	blah == foo
+}
+
+import pf.Stdout exposing [line!, write!]
+
+import # Comment after import keyword
+	pf # Comment after qualifier
+		.StdoutMultiline # Comment after ident
+		exposing [ # Comment after exposing open
+			line!, # Comment after exposed item
+			write!, # Another after exposed item
+		] # Comment after exposing close
+
+import pkg.Something exposing [func as function, Type as ValueCategory, Custom.*]
+
+import BadName as GoodName
+import
+	BadNameMultiline
+		as
+		GoodNameMultiline
+
+Map(a, b) : List(a), (a -> b) -> List(b)
+MapML( # Comment here
+	a, # And here
+	b,
+) # And after the last arg
+	: # And after the colon
+		List( # Inside Tag args
+			a, # After tag arg
+		),
+		(a -> b) -> # After arrow
+			List( # Inside tag args
+				b,
+			) # And after the type decl
+
+Foo : (Bar, Baz)
+
+FooMultiline : ( # Comment after pattern tuple open
+	Bar, # Comment after pattern tuple item
+	Baz, # Another after pattern tuple item
+) # Comment after pattern tuple close
+
+Some(a) : { foo : Ok(a), bar : Something }
+SomeMl(a) : { # After record open
+	foo : Ok(a), # After field
+	bar : Something, # After last field
+}
+
+SomeMultiline(a) : { # Comment after pattern record open
+	foo # After field name
+		: # Before field anno
+			Ok(a), # Comment after pattern record field
+	bar : Something, # Another after pattern record field
+} # Comment after pattern record close
+
+Maybe(a) : [Some(a), None]
+
+MaybeMultiline(a) : [ # Comment after tag union open
+	Some(a), # Comment after tag union member
+	None, # Another after tag union member
+] # Comment after tag union close
+
+SomeFunc(a) : Maybe(a), a -> Maybe(a)
+
+add_one_oneline = |num| if num 2 else 5
+
+add_one : U64 -> U64
+add_one = |num| {
+	other = 1
+	if num {
+		dbg # After debug
+			some_func() # After debug expr
+		0
+	} else {
+		dbg 123
+		other
+	}
+}
+
+match_time = |
+	a, # After arg
+	b,
+| # After args
+	match a {
+		Blue | Green | Red => {
+			x = 12
+			x
+		}
+		Blue # After pattern in alt
+		| # Before pattern in alt
+			Green
+		| Red # After alt pattern
+			=> {
+				x = 12
+				x
+			}
+		lower # After pattern comment
+			=> 1
+		"foo" => # After arrow comment
+			100
+		"foo" | "bar" => 200
+		[1, 2, 3, .. as rest] # After pattern comment
+			=> # After arrow comment
+				123 # After branch comment
+
+		# Just a random comment
+
+		[1, 2 | 5, 3, .. as rest] => 123
+		[
+			1,
+			2 | 5,
+			3,
+			.. # After DoubleDot
+				as # Before alias
+					rest, # After last pattern in list
+		] => 123
+		3.14 => 314
+		3.14 | 6.28 => 314
+		(1, 2, 3) => 123
+		(1, 2 | 5, 3) => 123
+		{ foo: 1, bar: 2, ..rest } => 12->add(34)
+		{ # After pattern record open
+			foo # After pattern record field name
+				: # Before pattern record field value
+					1, # After pattern record field
+			bar: 2,
+			.. # After spread operator
+				rest, # After last field
+		} => 12
+		{ foo: 1, bar: 2 | 7 } => 12
+		{
+			foo: 1,
+			bar: 2 | 7, # After last record field
+		} => 12
+		Ok(123) => 123
+		Ok(Some(dude)) => dude
+		TwoArgs("hello", Some("world")) => 1000
+	}
+
+expect # Comment after expect keyword
+	blah == 1 # Comment after expect statement
+
+main! : List(String) -> Result({}, _)
+main! = |_| { # Yeah I can leave a comment here
+	world = "World"
+	var number = 123
+	expect blah == 1
+	tag = Blue
+	return # Comment after return keyword
+		tag # Comment after return statement
+
+	# Just a random comment!
+
+	...
+	match_time(
+		..., # Single args with comment
+	)
+	some_func(
+		dbg # After debug
+			42, # After debug expr
+	)
+	crash # Comment after crash keyword
+		"Unreachable!" # Comment after crash statement
+	tag_with_payload = Ok(number)
+	interpolated = "Hello, ${world}"
+	list = [
+		add_one(
+			dbg # After dbg in list
+				number, # after dbg expr as arg
+		), # Comment one
+		456, # Comment two
+		789, # Comment three
+	]
+	for n in list {
+		Stdout.line!("Adding ${n} to ${number}")
+		number = number + n
+	}
+	record = { foo: 123, bar: "Hello", baz: tag, qux: Ok(world), punned }
+	tuple = (123, "World", tag, Ok(world), (nested, tuple), [1, 2, 3])
+	multiline_tuple = (
+		123,
+		"World",
+		tag1,
+		Ok(world), # This one has a comment
+		(nested, tuple),
+		[1, 2, 3],
+	)
+	bin_op_result = Err(foo) ?? 12 > 5 * 5 or 13 + 2 < 5 and 10 - 1 >= 16 or 12 <= 3 / 5
+	static_dispatch_style = some_fn(arg1)?.static_dispatch_method()?.next_static_dispatch_method()?.record_field?
+	Stdout.line!(interpolated)?
+	Stdout.line!(
+		"How about ${ # Comment after string interpolation open
+			Num.toStr(number) # Comment after string interpolation expr
+		} as a string?",
+	)
+} # Comment after top-level decl
+
+empty : {}
+empty = {}
+
+tuple : Value((a, b, c))
+
+expect {
+	foo = 1 # This should work too
+	blah = 1
+	blah == foo
+}
+
+import pf.Stdout exposing [line!, write!]
+
+import # Comment after import keyword
+	pf # Comment after qualifier
+		.StdoutMultiline # Comment after ident
+		exposing [ # Comment after exposing open
+			line!, # Comment after exposed item
+			write!, # Another after exposed item
+		] # Comment after exposing close
+
+import pkg.Something exposing [func as function, Type as ValueCategory, Custom.*]
+
+import BadName as GoodName
+import
+	BadNameMultiline
+		as
+		GoodNameMultiline
+
+Map(a, b) : List(a), (a -> b) -> List(b)
+MapML( # Comment here
+	a, # And here
+	b,
+) # And after the last arg
+	: # And after the colon
+		List( # Inside Tag args
+			a, # After tag arg
+		),
+		(a -> b) -> # After arrow
+			List( # Inside tag args
+				b,
+			) # And after the type decl
+
+Foo : (Bar, Baz)
+
+FooMultiline : ( # Comment after pattern tuple open
+	Bar, # Comment after pattern tuple item
+	Baz, # Another after pattern tuple item
+) # Comment after pattern tuple close
+
+Some(a) : { foo : Ok(a), bar : Something }
+SomeMl(a) : { # After record open
+	foo : Ok(a), # After field
+	bar : Something, # After last field
+}
+
+SomeMultiline(a) : { # Comment after pattern record open
+	foo # After field name
+		: # Before field anno
+			Ok(a), # Comment after pattern record field
+	bar : Something, # Another after pattern record field
+} # Comment after pattern record close
+
+Maybe(a) : [Some(a), None]
+
+MaybeMultiline(a) : [ # Comment after tag union open
+	Some(a), # Comment after tag union member
+	None, # Another after tag union member
+] # Comment after tag union close
+
+SomeFunc(a) : Maybe(a), a -> Maybe(a)
+
+add_one_oneline = |num| if num 2 else 5
+
+add_one : U64 -> U64
+add_one = |num| {
+	other = 1
+	if num {
+		dbg # After debug
+			some_func() # After debug expr
+		0
+	} else {
+		dbg 123
+		other
+	}
+}
+
+match_time = |
+	a, # After arg
+	b,
+| # After args
+	match a {
+		Blue | Green | Red => {
+			x = 12
+			x
+		}
+		Blue # After pattern in alt
+		| # Before pattern in alt
+			Green
+		| Red # After alt pattern
+			=> {
+				x = 12
+				x
+			}
+		lower # After pattern comment
+			=> 1
+		"foo" => # After arrow comment
+			100
+		"foo" | "bar" => 200
+		[1, 2, 3, .. as rest] # After pattern comment
+			=> # After arrow comment
+				123 # After branch comment
+
+		# Just a random comment
+
+		[1, 2 | 5, 3, .. as rest] => 123
+		[
+			1,
+			2 | 5,
+			3,
+			.. # After DoubleDot
+				as # Before alias
+					rest, # After last pattern in list
+		] => 123
+		3.14 => 314
+		3.14 | 6.28 => 314
+		(1, 2, 3) => 123
+		(1, 2 | 5, 3) => 123
+		{ foo: 1, bar: 2, ..rest } => 12->add(34)
+		{ # After pattern record open
+			foo # After pattern record field name
+				: # Before pattern record field value
+					1, # After pattern record field
+			bar: 2,
+			.. # After spread operator
+				rest, # After last field
+		} => 12
+		{ foo: 1, bar: 2 | 7 } => 12
+		{
+			foo: 1,
+			bar: 2 | 7, # After last record field
+		} => 12
+		Ok(123) => 123
+		Ok(Some(dude)) => dude
+		TwoArgs("hello", Some("world")) => 1000
+	}
+
+expect # Comment after expect keyword
+	blah == 1 # Comment after expect statement
+
+main! : List(String) -> Result({}, _)
+main! = |_| { # Yeah I can leave a comment here
+	world = "World"
+	var number = 123
+	expect blah == 1
+	tag = Blue
+	return # Comment after return keyword
+		tag # Comment after return statement
+
+	# Just a random comment!
+
+	...
+	match_time(
+		..., # Single args with comment
+	)
+	some_func(
+		dbg # After debug
+			42, # After debug expr
+	)
+	crash # Comment after crash keyword
+		"Unreachable!" # Comment after crash statement
+	tag_with_payload = Ok(number)
+	interpolated = "Hello, ${world}"
+	list = [
+		add_one(
+			dbg # After dbg in list
+				number, # after dbg expr as arg
+		), # Comment one
+		456, # Comment two
+		789, # Comment three
+	]
+	for n in list {
+		Stdout.line!("Adding ${n} to ${number}")
+		number = number + n
+	}
+	record = { foo: 123, bar: "Hello", baz: tag, qux: Ok(world), punned }
+	tuple = (123, "World", tag, Ok(world), (nested, tuple), [1, 2, 3])
+	multiline_tuple = (
+		123,
+		"World",
+		tag1,
+		Ok(world), # This one has a comment
+		(nested, tuple),
+		[1, 2, 3],
+	)
+	bin_op_result = Err(foo) ?? 12 > 5 * 5 or 13 + 2 < 5 and 10 - 1 >= 16 or 12 <= 3 / 5
+	static_dispatch_style = some_fn(arg1)?.static_dispatch_method()?.next_static_dispatch_method()?.record_field?
+	Stdout.line!(interpolated)?
+	Stdout.line!(
+		"How about ${ # Comment after string interpolation open
+			Num.toStr(number) # Comment after string interpolation expr
+		} as a string?",
+	)
+} # Comment after top-level decl
+
+empty : {}
+empty = {}
+
+tuple : Value((a, b, c))
+
+expect {
+	foo = 1 # This should work too
+	blah = 1
+	blah == foo
+}
+
+import pf.Stdout exposing [line!, write!]
+
+import # Comment after import keyword
+	pf # Comment after qualifier
+		.StdoutMultiline # Comment after ident
+		exposing [ # Comment after exposing open
+			line!, # Comment after exposed item
+			write!, # Another after exposed item
+		] # Comment after exposing close
+
+import pkg.Something exposing [func as function, Type as ValueCategory, Custom.*]
+
+import BadName as GoodName
+import
+	BadNameMultiline
+		as
+		GoodNameMultiline
+
+Map(a, b) : List(a), (a -> b) -> List(b)
+MapML( # Comment here
+	a, # And here
+	b,
+) # And after the last arg
+	: # And after the colon
+		List( # Inside Tag args
+			a, # After tag arg
+		),
+		(a -> b) -> # After arrow
+			List( # Inside tag args
+				b,
+			) # And after the type decl
+
+Foo : (Bar, Baz)
+
+FooMultiline : ( # Comment after pattern tuple open
+	Bar, # Comment after pattern tuple item
+	Baz, # Another after pattern tuple item
+) # Comment after pattern tuple close
+
+Some(a) : { foo : Ok(a), bar : Something }
+SomeMl(a) : { # After record open
+	foo : Ok(a), # After field
+	bar : Something, # After last field
+}
+
+SomeMultiline(a) : { # Comment after pattern record open
+	foo # After field name
+		: # Before field anno
+			Ok(a), # Comment after pattern record field
+	bar : Something, # Another after pattern record field
+} # Comment after pattern record close
+
+Maybe(a) : [Some(a), None]
+
+MaybeMultiline(a) : [ # Comment after tag union open
+	Some(a), # Comment after tag union member
+	None, # Another after tag union member
+] # Comment after tag union close
+
+SomeFunc(a) : Maybe(a), a -> Maybe(a)
+
+add_one_oneline = |num| if num 2 else 5
+
+add_one : U64 -> U64
+add_one = |num| {
+	other = 1
+	if num {
+		dbg # After debug
+			some_func() # After debug expr
+		0
+	} else {
+		dbg 123
+		other
+	}
+}
+
+match_time = |
+	a, # After arg
+	b,
+| # After args
+	match a {
+		Blue | Green | Red => {
+			x = 12
+			x
+		}
+		Blue # After pattern in alt
+		| # Before pattern in alt
+			Green
+		| Red # After alt pattern
+			=> {
+				x = 12
+				x
+			}
+		lower # After pattern comment
+			=> 1
+		"foo" => # After arrow comment
+			100
+		"foo" | "bar" => 200
+		[1, 2, 3, .. as rest] # After pattern comment
+			=> # After arrow comment
+				123 # After branch comment
+
+		# Just a random comment
+
+		[1, 2 | 5, 3, .. as rest] => 123
+		[
+			1,
+			2 | 5,
+			3,
+			.. # After DoubleDot
+				as # Before alias
+					rest, # After last pattern in list
+		] => 123
+		3.14 => 314
+		3.14 | 6.28 => 314
+		(1, 2, 3) => 123
+		(1, 2 | 5, 3) => 123
+		{ foo: 1, bar: 2, ..rest } => 12->add(34)
+		{ # After pattern record open
+			foo # After pattern record field name
+				: # Before pattern record field value
+					1, # After pattern record field
+			bar: 2,
+			.. # After spread operator
+				rest, # After last field
+		} => 12
+		{ foo: 1, bar: 2 | 7 } => 12
+		{
+			foo: 1,
+			bar: 2 | 7, # After last record field
+		} => 12
+		Ok(123) => 123
+		Ok(Some(dude)) => dude
+		TwoArgs("hello", Some("world")) => 1000
+	}
+
+expect # Comment after expect keyword
+	blah == 1 # Comment after expect statement
+
+main! : List(String) -> Result({}, _)
+main! = |_| { # Yeah I can leave a comment here
+	world = "World"
+	var number = 123
+	expect blah == 1
+	tag = Blue
+	return # Comment after return keyword
+		tag # Comment after return statement
+
+	# Just a random comment!
+
+	...
+	match_time(
+		..., # Single args with comment
+	)
+	some_func(
+		dbg # After debug
+			42, # After debug expr
+	)
+	crash # Comment after crash keyword
+		"Unreachable!" # Comment after crash statement
+	tag_with_payload = Ok(number)
+	interpolated = "Hello, ${world}"
+	list = [
+		add_one(
+			dbg # After dbg in list
+				number, # after dbg expr as arg
+		), # Comment one
+		456, # Comment two
+		789, # Comment three
+	]
+	for n in list {
+		Stdout.line!("Adding ${n} to ${number}")
+		number = number + n
+	}
+	record = { foo: 123, bar: "Hello", baz: tag, qux: Ok(world), punned }
+	tuple = (123, "World", tag, Ok(world), (nested, tuple), [1, 2, 3])
+	multiline_tuple = (
+		123,
+		"World",
+		tag1,
+		Ok(world), # This one has a comment
+		(nested, tuple),
+		[1, 2, 3],
+	)
+	bin_op_result = Err(foo) ?? 12 > 5 * 5 or 13 + 2 < 5 and 10 - 1 >= 16 or 12 <= 3 / 5
+	static_dispatch_style = some_fn(arg1)?.static_dispatch_method()?.next_static_dispatch_method()?.record_field?
+	Stdout.line!(interpolated)?
+	Stdout.line!(
+		"How about ${ # Comment after string interpolation open
+			Num.toStr(number) # Comment after string interpolation expr
+		} as a string?",
+	)
+} # Comment after top-level decl
+
+empty : {}
+empty = {}
+
+tuple : Value((a, b, c))
+
+expect {
+	foo = 1 # This should work too
+	blah = 1
+	blah == foo
+}
+
+import pf.Stdout exposing [line!, write!]
+
+import # Comment after import keyword
+	pf # Comment after qualifier
+		.StdoutMultiline # Comment after ident
+		exposing [ # Comment after exposing open
+			line!, # Comment after exposed item
+			write!, # Another after exposed item
+		] # Comment after exposing close
+
+import pkg.Something exposing [func as function, Type as ValueCategory, Custom.*]
+
+import BadName as GoodName
+import
+	BadNameMultiline
+		as
+		GoodNameMultiline
+
+Map(a, b) : List(a), (a -> b) -> List(b)
+MapML( # Comment here
+	a, # And here
+	b,
+) # And after the last arg
+	: # And after the colon
+		List( # Inside Tag args
+			a, # After tag arg
+		),
+		(a -> b) -> # After arrow
+			List( # Inside tag args
+				b,
+			) # And after the type decl
+
+Foo : (Bar, Baz)
+
+FooMultiline : ( # Comment after pattern tuple open
+	Bar, # Comment after pattern tuple item
+	Baz, # Another after pattern tuple item
+) # Comment after pattern tuple close
+
+Some(a) : { foo : Ok(a), bar : Something }
+SomeMl(a) : { # After record open
+	foo : Ok(a), # After field
+	bar : Something, # After last field
+}
+
+SomeMultiline(a) : { # Comment after pattern record open
+	foo # After field name
+		: # Before field anno
+			Ok(a), # Comment after pattern record field
+	bar : Something, # Another after pattern record field
+} # Comment after pattern record close
+
+Maybe(a) : [Some(a), None]
+
+MaybeMultiline(a) : [ # Comment after tag union open
+	Some(a), # Comment after tag union member
+	None, # Another after tag union member
+] # Comment after tag union close
+
+SomeFunc(a) : Maybe(a), a -> Maybe(a)
+
+add_one_oneline = |num| if num 2 else 5
+
+add_one : U64 -> U64
+add_one = |num| {
+	other = 1
+	if num {
+		dbg # After debug
+			some_func() # After debug expr
+		0
+	} else {
+		dbg 123
+		other
+	}
+}
+
+match_time = |
+	a, # After arg
+	b,
+| # After args
+	match a {
+		Blue | Green | Red => {
+			x = 12
+			x
+		}
+		Blue # After pattern in alt
+		| # Before pattern in alt
+			Green
+		| Red # After alt pattern
+			=> {
+				x = 12
+				x
+			}
+		lower # After pattern comment
+			=> 1
+		"foo" => # After arrow comment
+			100
+		"foo" | "bar" => 200
+		[1, 2, 3, .. as rest] # After pattern comment
+			=> # After arrow comment
+				123 # After branch comment
+
+		# Just a random comment
+
+		[1, 2 | 5, 3, .. as rest] => 123
+		[
+			1,
+			2 | 5,
+			3,
+			.. # After DoubleDot
+				as # Before alias
+					rest, # After last pattern in list
+		] => 123
+		3.14 => 314
+		3.14 | 6.28 => 314
+		(1, 2, 3) => 123
+		(1, 2 | 5, 3) => 123
+		{ foo: 1, bar: 2, ..rest } => 12->add(34)
+		{ # After pattern record open
+			foo # After pattern record field name
+				: # Before pattern record field value
+					1, # After pattern record field
+			bar: 2,
+			.. # After spread operator
+				rest, # After last field
+		} => 12
+		{ foo: 1, bar: 2 | 7 } => 12
+		{
+			foo: 1,
+			bar: 2 | 7, # After last record field
+		} => 12
+		Ok(123) => 123
+		Ok(Some(dude)) => dude
+		TwoArgs("hello", Some("world")) => 1000
+	}
+
+expect # Comment after expect keyword
+	blah == 1 # Comment after expect statement
+
+main! : List(String) -> Result({}, _)
+main! = |_| { # Yeah I can leave a comment here
+	world = "World"
+	var number = 123
+	expect blah == 1
+	tag = Blue
+	return # Comment after return keyword
+		tag # Comment after return statement
+
+	# Just a random comment!
+
+	...
+	match_time(
+		..., # Single args with comment
+	)
+	some_func(
+		dbg # After debug
+			42, # After debug expr
+	)
+	crash # Comment after crash keyword
+		"Unreachable!" # Comment after crash statement
+	tag_with_payload = Ok(number)
+	interpolated = "Hello, ${world}"
+	list = [
+		add_one(
+			dbg # After dbg in list
+				number, # after dbg expr as arg
+		), # Comment one
+		456, # Comment two
+		789, # Comment three
+	]
+	for n in list {
+		Stdout.line!("Adding ${n} to ${number}")
+		number = number + n
+	}
+	record = { foo: 123, bar: "Hello", baz: tag, qux: Ok(world), punned }
+	tuple = (123, "World", tag, Ok(world), (nested, tuple), [1, 2, 3])
+	multiline_tuple = (
+		123,
+		"World",
+		tag1,
+		Ok(world), # This one has a comment
+		(nested, tuple),
+		[1, 2, 3],
+	)
+	bin_op_result = Err(foo) ?? 12 > 5 * 5 or 13 + 2 < 5 and 10 - 1 >= 16 or 12 <= 3 / 5
+	static_dispatch_style = some_fn(arg1)?.static_dispatch_method()?.next_static_dispatch_method()?.record_field?
+	Stdout.line!(interpolated)?
+	Stdout.line!(
+		"How about ${ # Comment after string interpolation open
+			Num.toStr(number) # Comment after string interpolation expr
+		} as a string?",
+	)
+} # Comment after top-level decl
+
+empty : {}
+empty = {}
+
+tuple : Value((a, b, c))
+
+expect {
+	foo = 1 # This should work too
+	blah = 1
+	blah == foo
+}
+
+import pf.Stdout exposing [line!, write!]
+
+import # Comment after import keyword
+	pf # Comment after qualifier
+		.StdoutMultiline # Comment after ident
+		exposing [ # Comment after exposing open
+			line!, # Comment after exposed item
+			write!, # Another after exposed item
+		] # Comment after exposing close
+
+import pkg.Something exposing [func as function, Type as ValueCategory, Custom.*]
+
+import BadName as GoodName
+import
+	BadNameMultiline
+		as
+		GoodNameMultiline
+
+Map(a, b) : List(a), (a -> b) -> List(b)
+MapML( # Comment here
+	a, # And here
+	b,
+) # And after the last arg
+	: # And after the colon
+		List( # Inside Tag args
+			a, # After tag arg
+		),
+		(a -> b) -> # After arrow
+			List( # Inside tag args
+				b,
+			) # And after the type decl
+
+Foo : (Bar, Baz)
+
+FooMultiline : ( # Comment after pattern tuple open
+	Bar, # Comment after pattern tuple item
+	Baz, # Another after pattern tuple item
+) # Comment after pattern tuple close
+
+Some(a) : { foo : Ok(a), bar : Something }
+SomeMl(a) : { # After record open
+	foo : Ok(a), # After field
+	bar : Something, # After last field
+}
+
+SomeMultiline(a) : { # Comment after pattern record open
+	foo # After field name
+		: # Before field anno
+			Ok(a), # Comment after pattern record field
+	bar : Something, # Another after pattern record field
+} # Comment after pattern record close
+
+Maybe(a) : [Some(a), None]
+
+MaybeMultiline(a) : [ # Comment after tag union open
+	Some(a), # Comment after tag union member
+	None, # Another after tag union member
+] # Comment after tag union close
+
+SomeFunc(a) : Maybe(a), a -> Maybe(a)
+
+add_one_oneline = |num| if num 2 else 5
+
+add_one : U64 -> U64
+add_one = |num| {
+	other = 1
+	if num {
+		dbg # After debug
+			some_func() # After debug expr
+		0
+	} else {
+		dbg 123
+		other
+	}
+}
+
+match_time = |
+	a, # After arg
+	b,
+| # After args
+	match a {
+		Blue | Green | Red => {
+			x = 12
+			x
+		}
+		Blue # After pattern in alt
+		| # Before pattern in alt
+			Green
+		| Red # After alt pattern
+			=> {
+				x = 12
+				x
+			}
+		lower # After pattern comment
+			=> 1
+		"foo" => # After arrow comment
+			100
+		"foo" | "bar" => 200
+		[1, 2, 3, .. as rest] # After pattern comment
+			=> # After arrow comment
+				123 # After branch comment
+
+		# Just a random comment
+
+		[1, 2 | 5, 3, .. as rest] => 123
+		[
+			1,
+			2 | 5,
+			3,
+			.. # After DoubleDot
+				as # Before alias
+					rest, # After last pattern in list
+		] => 123
+		3.14 => 314
+		3.14 | 6.28 => 314
+		(1, 2, 3) => 123
+		(1, 2 | 5, 3) => 123
+		{ foo: 1, bar: 2, ..rest } => 12->add(34)
+		{ # After pattern record open
+			foo # After pattern record field name
+				: # Before pattern record field value
+					1, # After pattern record field
+			bar: 2,
+			.. # After spread operator
+				rest, # After last field
+		} => 12
+		{ foo: 1, bar: 2 | 7 } => 12
+		{
+			foo: 1,
+			bar: 2 | 7, # After last record field
+		} => 12
+		Ok(123) => 123
+		Ok(Some(dude)) => dude
+		TwoArgs("hello", Some("world")) => 1000
+	}
+
+expect # Comment after expect keyword
+	blah == 1 # Comment after expect statement
+
+main! : List(String) -> Result({}, _)
+main! = |_| { # Yeah I can leave a comment here
+	world = "World"
+	var number = 123
+	expect blah == 1
+	tag = Blue
+	return # Comment after return keyword
+		tag # Comment after return statement
+
+	# Just a random comment!
+
+	...
+	match_time(
+		..., # Single args with comment
+	)
+	some_func(
+		dbg # After debug
+			42, # After debug expr
+	)
+	crash # Comment after crash keyword
+		"Unreachable!" # Comment after crash statement
+	tag_with_payload = Ok(number)
+	interpolated = "Hello, ${world}"
+	list = [
+		add_one(
+			dbg # After dbg in list
+				number, # after dbg expr as arg
+		), # Comment one
+		456, # Comment two
+		789, # Comment three
+	]
+	for n in list {
+		Stdout.line!("Adding ${n} to ${number}")
+		number = number + n
+	}
+	record = { foo: 123, bar: "Hello", baz: tag, qux: Ok(world), punned }
+	tuple = (123, "World", tag, Ok(world), (nested, tuple), [1, 2, 3])
+	multiline_tuple = (
+		123,
+		"World",
+		tag1,
+		Ok(world), # This one has a comment
+		(nested, tuple),
+		[1, 2, 3],
+	)
+	bin_op_result = Err(foo) ?? 12 > 5 * 5 or 13 + 2 < 5 and 10 - 1 >= 16 or 12 <= 3 / 5
+	static_dispatch_style = some_fn(arg1)?.static_dispatch_method()?.next_static_dispatch_method()?.record_field?
+	Stdout.line!(interpolated)?
+	Stdout.line!(
+		"How about ${ # Comment after string interpolation open
+			Num.toStr(number) # Comment after string interpolation expr
+		} as a string?",
+	)
+} # Comment after top-level decl
+
+empty : {}
+empty = {}
+
+tuple : Value((a, b, c))
+
+expect {
+	foo = 1 # This should work too
+	blah = 1
+	blah == foo
+}
+
+import pf.Stdout exposing [line!, write!]
+
+import # Comment after import keyword
+	pf # Comment after qualifier
+		.StdoutMultiline # Comment after ident
+		exposing [ # Comment after exposing open
+			line!, # Comment after exposed item
+			write!, # Another after exposed item
+		] # Comment after exposing close
+
+import pkg.Something exposing [func as function, Type as ValueCategory, Custom.*]
+
+import BadName as GoodName
+import
+	BadNameMultiline
+		as
+		GoodNameMultiline
+
+Map(a, b) : List(a), (a -> b) -> List(b)
+MapML( # Comment here
+	a, # And here
+	b,
+) # And after the last arg
+	: # And after the colon
+		List( # Inside Tag args
+			a, # After tag arg
+		),
+		(a -> b) -> # After arrow
+			List( # Inside tag args
+				b,
+			) # And after the type decl
+
+Foo : (Bar, Baz)
+
+FooMultiline : ( # Comment after pattern tuple open
+	Bar, # Comment after pattern tuple item
+	Baz, # Another after pattern tuple item
+) # Comment after pattern tuple close
+
+Some(a) : { foo : Ok(a), bar : Something }
+SomeMl(a) : { # After record open
+	foo : Ok(a), # After field
+	bar : Something, # After last field
+}
+
+SomeMultiline(a) : { # Comment after pattern record open
+	foo # After field name
+		: # Before field anno
+			Ok(a), # Comment after pattern record field
+	bar : Something, # Another after pattern record field
+} # Comment after pattern record close
+
+Maybe(a) : [Some(a), None]
+
+MaybeMultiline(a) : [ # Comment after tag union open
+	Some(a), # Comment after tag union member
+	None, # Another after tag union member
+] # Comment after tag union close
+
+SomeFunc(a) : Maybe(a), a -> Maybe(a)
+
+add_one_oneline = |num| if num 2 else 5
+
+add_one : U64 -> U64
+add_one = |num| {
+	other = 1
+	if num {
+		dbg # After debug
+			some_func() # After debug expr
+		0
+	} else {
+		dbg 123
+		other
+	}
+}
+
+match_time = |
+	a, # After arg
+	b,
+| # After args
+	match a {
+		Blue | Green | Red => {
+			x = 12
+			x
+		}
+		Blue # After pattern in alt
+		| # Before pattern in alt
+			Green
+		| Red # After alt pattern
+			=> {
+				x = 12
+				x
+			}
+		lower # After pattern comment
+			=> 1
+		"foo" => # After arrow comment
+			100
+		"foo" | "bar" => 200
+		[1, 2, 3, .. as rest] # After pattern comment
+			=> # After arrow comment
+				123 # After branch comment
+
+		# Just a random comment
+
+		[1, 2 | 5, 3, .. as rest] => 123
+		[
+			1,
+			2 | 5,
+			3,
+			.. # After DoubleDot
+				as # Before alias
+					rest, # After last pattern in list
+		] => 123
+		3.14 => 314
+		3.14 | 6.28 => 314
+		(1, 2, 3) => 123
+		(1, 2 | 5, 3) => 123
+		{ foo: 1, bar: 2, ..rest } => 12->add(34)
+		{ # After pattern record open
+			foo # After pattern record field name
+				: # Before pattern record field value
+					1, # After pattern record field
+			bar: 2,
+			.. # After spread operator
+				rest, # After last field
+		} => 12
+		{ foo: 1, bar: 2 | 7 } => 12
+		{
+			foo: 1,
+			bar: 2 | 7, # After last record field
+		} => 12
+		Ok(123) => 123
+		Ok(Some(dude)) => dude
+		TwoArgs("hello", Some("world")) => 1000
+	}
+
+expect # Comment after expect keyword
+	blah == 1 # Comment after expect statement
+
+main! : List(String) -> Result({}, _)
+main! = |_| { # Yeah I can leave a comment here
+	world = "World"
+	var number = 123
+	expect blah == 1
+	tag = Blue
+	return # Comment after return keyword
+		tag # Comment after return statement
+
+	# Just a random comment!
+
+	...
+	match_time(
+		..., # Single args with comment
+	)
+	some_func(
+		dbg # After debug
+			42, # After debug expr
+	)
+	crash # Comment after crash keyword
+		"Unreachable!" # Comment after crash statement
+	tag_with_payload = Ok(number)
+	interpolated = "Hello, ${world}"
+	list = [
+		add_one(
+			dbg # After dbg in list
+				number, # after dbg expr as arg
+		), # Comment one
+		456, # Comment two
+		789, # Comment three
+	]
+	for n in list {
+		Stdout.line!("Adding ${n} to ${number}")
+		number = number + n
+	}
+	record = { foo: 123, bar: "Hello", baz: tag, qux: Ok(world), punned }
+	tuple = (123, "World", tag, Ok(world), (nested, tuple), [1, 2, 3])
+	multiline_tuple = (
+		123,
+		"World",
+		tag1,
+		Ok(world), # This one has a comment
+		(nested, tuple),
+		[1, 2, 3],
+	)
+	bin_op_result = Err(foo) ?? 12 > 5 * 5 or 13 + 2 < 5 and 10 - 1 >= 16 or 12 <= 3 / 5
+	static_dispatch_style = some_fn(arg1)?.static_dispatch_method()?.next_static_dispatch_method()?.record_field?
+	Stdout.line!(interpolated)?
+	Stdout.line!(
+		"How about ${ # Comment after string interpolation open
+			Num.toStr(number) # Comment after string interpolation expr
+		} as a string?",
+	)
+} # Comment after top-level decl
+
+empty : {}
+empty = {}
+
+tuple : Value((a, b, c))
+
+expect {
+	foo = 1 # This should work too
+	blah = 1
+	blah == foo
+}
+
+import pf.Stdout exposing [line!, write!]
+
+import # Comment after import keyword
+	pf # Comment after qualifier
+		.StdoutMultiline # Comment after ident
+		exposing [ # Comment after exposing open
+			line!, # Comment after exposed item
+			write!, # Another after exposed item
+		] # Comment after exposing close
+
+import pkg.Something exposing [func as function, Type as ValueCategory, Custom.*]
+
+import BadName as GoodName
+import
+	BadNameMultiline
+		as
+		GoodNameMultiline
+
+Map(a, b) : List(a), (a -> b) -> List(b)
+MapML( # Comment here
+	a, # And here
+	b,
+) # And after the last arg
+	: # And after the colon
+		List( # Inside Tag args
+			a, # After tag arg
+		),
+		(a -> b) -> # After arrow
+			List( # Inside tag args
+				b,
+			) # And after the type decl
+
+Foo : (Bar, Baz)
+
+FooMultiline : ( # Comment after pattern tuple open
+	Bar, # Comment after pattern tuple item
+	Baz, # Another after pattern tuple item
+) # Comment after pattern tuple close
+
+Some(a) : { foo : Ok(a), bar : Something }
+SomeMl(a) : { # After record open
+	foo : Ok(a), # After field
+	bar : Something, # After last field
+}
+
+SomeMultiline(a) : { # Comment after pattern record open
+	foo # After field name
+		: # Before field anno
+			Ok(a), # Comment after pattern record field
+	bar : Something, # Another after pattern record field
+} # Comment after pattern record close
+
+Maybe(a) : [Some(a), None]
+
+MaybeMultiline(a) : [ # Comment after tag union open
+	Some(a), # Comment after tag union member
+	None, # Another after tag union member
+] # Comment after tag union close
+
+SomeFunc(a) : Maybe(a), a -> Maybe(a)
+
+add_one_oneline = |num| if num 2 else 5
+
+add_one : U64 -> U64
+add_one = |num| {
+	other = 1
+	if num {
+		dbg # After debug
+			some_func() # After debug expr
+		0
+	} else {
+		dbg 123
+		other
+	}
+}
+
+match_time = |
+	a, # After arg
+	b,
+| # After args
+	match a {
+		Blue | Green | Red => {
+			x = 12
+			x
+		}
+		Blue # After pattern in alt
+		| # Before pattern in alt
+			Green
+		| Red # After alt pattern
+			=> {
+				x = 12
+				x
+			}
+		lower # After pattern comment
+			=> 1
+		"foo" => # After arrow comment
+			100
+		"foo" | "bar" => 200
+		[1, 2, 3, .. as rest] # After pattern comment
+			=> # After arrow comment
+				123 # After branch comment
+
+		# Just a random comment
+
+		[1, 2 | 5, 3, .. as rest] => 123
+		[
+			1,
+			2 | 5,
+			3,
+			.. # After DoubleDot
+				as # Before alias
+					rest, # After last pattern in list
+		] => 123
+		3.14 => 314
+		3.14 | 6.28 => 314
+		(1, 2, 3) => 123
+		(1, 2 | 5, 3) => 123
+		{ foo: 1, bar: 2, ..rest } => 12->add(34)
+		{ # After pattern record open
+			foo # After pattern record field name
+				: # Before pattern record field value
+					1, # After pattern record field
+			bar: 2,
+			.. # After spread operator
+				rest, # After last field
+		} => 12
+		{ foo: 1, bar: 2 | 7 } => 12
+		{
+			foo: 1,
+			bar: 2 | 7, # After last record field
+		} => 12
+		Ok(123) => 123
+		Ok(Some(dude)) => dude
+		TwoArgs("hello", Some("world")) => 1000
+	}
+
+expect # Comment after expect keyword
+	blah == 1 # Comment after expect statement
+
+main! : List(String) -> Result({}, _)
+main! = |_| { # Yeah I can leave a comment here
+	world = "World"
+	var number = 123
+	expect blah == 1
+	tag = Blue
+	return # Comment after return keyword
+		tag # Comment after return statement
+
+	# Just a random comment!
+
+	...
+	match_time(
+		..., # Single args with comment
+	)
+	some_func(
+		dbg # After debug
+			42, # After debug expr
+	)
+	crash # Comment after crash keyword
+		"Unreachable!" # Comment after crash statement
+	tag_with_payload = Ok(number)
+	interpolated = "Hello, ${world}"
+	list = [
+		add_one(
+			dbg # After dbg in list
+				number, # after dbg expr as arg
+		), # Comment one
+		456, # Comment two
+		789, # Comment three
+	]
+	for n in list {
+		Stdout.line!("Adding ${n} to ${number}")
+		number = number + n
+	}
+	record = { foo: 123, bar: "Hello", baz: tag, qux: Ok(world), punned }
+	tuple = (123, "World", tag, Ok(world), (nested, tuple), [1, 2, 3])
+	multiline_tuple = (
+		123,
+		"World",
+		tag1,
+		Ok(world), # This one has a comment
+		(nested, tuple),
+		[1, 2, 3],
+	)
+	bin_op_result = Err(foo) ?? 12 > 5 * 5 or 13 + 2 < 5 and 10 - 1 >= 16 or 12 <= 3 / 5
+	static_dispatch_style = some_fn(arg1)?.static_dispatch_method()?.next_static_dispatch_method()?.record_field?
+	Stdout.line!(interpolated)?
+	Stdout.line!(
+		"How about ${ # Comment after string interpolation open
+			Num.toStr(number) # Comment after string interpolation expr
+		} as a string?",
+	)
+} # Comment after top-level decl
+
+empty : {}
+empty = {}
+
+tuple : Value((a, b, c))
+
+expect {
+	foo = 1 # This should work too
+	blah = 1
+	blah == foo
+}
+
+import pf.Stdout exposing [line!, write!]
+
+import # Comment after import keyword
+	pf # Comment after qualifier
+		.StdoutMultiline # Comment after ident
+		exposing [ # Comment after exposing open
+			line!, # Comment after exposed item
+			write!, # Another after exposed item
+		] # Comment after exposing close
+
+import pkg.Something exposing [func as function, Type as ValueCategory, Custom.*]
+
+import BadName as GoodName
+import
+	BadNameMultiline
+		as
+		GoodNameMultiline
+
+Map(a, b) : List(a), (a -> b) -> List(b)
+MapML( # Comment here
+	a, # And here
+	b,
+) # And after the last arg
+	: # And after the colon
+		List( # Inside Tag args
+			a, # After tag arg
+		),
+		(a -> b) -> # After arrow
+			List( # Inside tag args
+				b,
+			) # And after the type decl
+
+Foo : (Bar, Baz)
+
+FooMultiline : ( # Comment after pattern tuple open
+	Bar, # Comment after pattern tuple item
+	Baz, # Another after pattern tuple item
+) # Comment after pattern tuple close
+
+Some(a) : { foo : Ok(a), bar : Something }
+SomeMl(a) : { # After record open
+	foo : Ok(a), # After field
+	bar : Something, # After last field
+}
+
+SomeMultiline(a) : { # Comment after pattern record open
+	foo # After field name
+		: # Before field anno
+			Ok(a), # Comment after pattern record field
+	bar : Something, # Another after pattern record field
+} # Comment after pattern record close
+
+Maybe(a) : [Some(a), None]
+
+MaybeMultiline(a) : [ # Comment after tag union open
+	Some(a), # Comment after tag union member
+	None, # Another after tag union member
+] # Comment after tag union close
+
+SomeFunc(a) : Maybe(a), a -> Maybe(a)
+
+add_one_oneline = |num| if num 2 else 5
+
+add_one : U64 -> U64
+add_one = |num| {
+	other = 1
+	if num {
+		dbg # After debug
+			some_func() # After debug expr
+		0
+	} else {
+		dbg 123
+		other
+	}
+}
+
+match_time = |
+	a, # After arg
+	b,
+| # After args
+	match a {
+		Blue | Green | Red => {
+			x = 12
+			x
+		}
+		Blue # After pattern in alt
+		| # Before pattern in alt
+			Green
+		| Red # After alt pattern
+			=> {
+				x = 12
+				x
+			}
+		lower # After pattern comment
+			=> 1
+		"foo" => # After arrow comment
+			100
+		"foo" | "bar" => 200
+		[1, 2, 3, .. as rest] # After pattern comment
+			=> # After arrow comment
+				123 # After branch comment
+
+		# Just a random comment
+
+		[1, 2 | 5, 3, .. as rest] => 123
+		[
+			1,
+			2 | 5,
+			3,
+			.. # After DoubleDot
+				as # Before alias
+					rest, # After last pattern in list
+		] => 123
+		3.14 => 314
+		3.14 | 6.28 => 314
+		(1, 2, 3) => 123
+		(1, 2 | 5, 3) => 123
+		{ foo: 1, bar: 2, ..rest } => 12->add(34)
+		{ # After pattern record open
+			foo # After pattern record field name
+				: # Before pattern record field value
+					1, # After pattern record field
+			bar: 2,
+			.. # After spread operator
+				rest, # After last field
+		} => 12
+		{ foo: 1, bar: 2 | 7 } => 12
+		{
+			foo: 1,
+			bar: 2 | 7, # After last record field
+		} => 12
+		Ok(123) => 123
+		Ok(Some(dude)) => dude
+		TwoArgs("hello", Some("world")) => 1000
+	}
+
+expect # Comment after expect keyword
+	blah == 1 # Comment after expect statement
+
+main! : List(String) -> Result({}, _)
+main! = |_| { # Yeah I can leave a comment here
+	world = "World"
+	var number = 123
+	expect blah == 1
+	tag = Blue
+	return # Comment after return keyword
+		tag # Comment after return statement
+
+	# Just a random comment!
+
+	...
+	match_time(
+		..., # Single args with comment
+	)
+	some_func(
+		dbg # After debug
+			42, # After debug expr
+	)
+	crash # Comment after crash keyword
+		"Unreachable!" # Comment after crash statement
+	tag_with_payload = Ok(number)
+	interpolated = "Hello, ${world}"
+	list = [
+		add_one(
+			dbg # After dbg in list
+				number, # after dbg expr as arg
+		), # Comment one
+		456, # Comment two
+		789, # Comment three
+	]
+	for n in list {
+		Stdout.line!("Adding ${n} to ${number}")
+		number = number + n
+	}
+	record = { foo: 123, bar: "Hello", baz: tag, qux: Ok(world), punned }
+	tuple = (123, "World", tag, Ok(world), (nested, tuple), [1, 2, 3])
+	multiline_tuple = (
+		123,
+		"World",
+		tag1,
+		Ok(world), # This one has a comment
+		(nested, tuple),
+		[1, 2, 3],
+	)
+	bin_op_result = Err(foo) ?? 12 > 5 * 5 or 13 + 2 < 5 and 10 - 1 >= 16 or 12 <= 3 / 5
+	static_dispatch_style = some_fn(arg1)?.static_dispatch_method()?.next_static_dispatch_method()?.record_field?
+	Stdout.line!(interpolated)?
+	Stdout.line!(
+		"How about ${ # Comment after string interpolation open
+			Num.toStr(number) # Comment after string interpolation expr
+		} as a string?",
+	)
+} # Comment after top-level decl
+
+empty : {}
+empty = {}
+
+tuple : Value((a, b, c))
+
+expect {
+	foo = 1 # This should work too
+	blah = 1
+	blah == foo
+}
+
+import pf.Stdout exposing [line!, write!]
+
+import # Comment after import keyword
+	pf # Comment after qualifier
+		.StdoutMultiline # Comment after ident
+		exposing [ # Comment after exposing open
+			line!, # Comment after exposed item
+			write!, # Another after exposed item
+		] # Comment after exposing close
+
+import pkg.Something exposing [func as function, Type as ValueCategory, Custom.*]
+
+import BadName as GoodName
+import
+	BadNameMultiline
+		as
+		GoodNameMultiline
+
+Map(a, b) : List(a), (a -> b) -> List(b)
+MapML( # Comment here
+	a, # And here
+	b,
+) # And after the last arg
+	: # And after the colon
+		List( # Inside Tag args
+			a, # After tag arg
+		),
+		(a -> b) -> # After arrow
+			List( # Inside tag args
+				b,
+			) # And after the type decl
+
+Foo : (Bar, Baz)
+
+FooMultiline : ( # Comment after pattern tuple open
+	Bar, # Comment after pattern tuple item
+	Baz, # Another after pattern tuple item
+) # Comment after pattern tuple close
+
+Some(a) : { foo : Ok(a), bar : Something }
+SomeMl(a) : { # After record open
+	foo : Ok(a), # After field
+	bar : Something, # After last field
+}
+
+SomeMultiline(a) : { # Comment after pattern record open
+	foo # After field name
+		: # Before field anno
+			Ok(a), # Comment after pattern record field
+	bar : Something, # Another after pattern record field
+} # Comment after pattern record close
+
+Maybe(a) : [Some(a), None]
+
+MaybeMultiline(a) : [ # Comment after tag union open
+	Some(a), # Comment after tag union member
+	None, # Another after tag union member
+] # Comment after tag union close
+
+SomeFunc(a) : Maybe(a), a -> Maybe(a)
+
+add_one_oneline = |num| if num 2 else 5
+
+add_one : U64 -> U64
+add_one = |num| {
+	other = 1
+	if num {
+		dbg # After debug
+			some_func() # After debug expr
+		0
+	} else {
+		dbg 123
+		other
+	}
+}
+
+match_time = |
+	a, # After arg
+	b,
+| # After args
+	match a {
+		Blue | Green | Red => {
+			x = 12
+			x
+		}
+		Blue # After pattern in alt
+		| # Before pattern in alt
+			Green
+		| Red # After alt pattern
+			=> {
+				x = 12
+				x
+			}
+		lower # After pattern comment
+			=> 1
+		"foo" => # After arrow comment
+			100
+		"foo" | "bar" => 200
+		[1, 2, 3, .. as rest] # After pattern comment
+			=> # After arrow comment
+				123 # After branch comment
+
+		# Just a random comment
+
+		[1, 2 | 5, 3, .. as rest] => 123
+		[
+			1,
+			2 | 5,
+			3,
+			.. # After DoubleDot
+				as # Before alias
+					rest, # After last pattern in list
+		] => 123
+		3.14 => 314
+		3.14 | 6.28 => 314
+		(1, 2, 3) => 123
+		(1, 2 | 5, 3) => 123
+		{ foo: 1, bar: 2, ..rest } => 12->add(34)
+		{ # After pattern record open
+			foo # After pattern record field name
+				: # Before pattern record field value
+					1, # After pattern record field
+			bar: 2,
+			.. # After spread operator
+				rest, # After last field
+		} => 12
+		{ foo: 1, bar: 2 | 7 } => 12
+		{
+			foo: 1,
+			bar: 2 | 7, # After last record field
+		} => 12
+		Ok(123) => 123
+		Ok(Some(dude)) => dude
+		TwoArgs("hello", Some("world")) => 1000
+	}
+
+expect # Comment after expect keyword
+	blah == 1 # Comment after expect statement
+
+main! : List(String) -> Result({}, _)
+main! = |_| { # Yeah I can leave a comment here
+	world = "World"
+	var number = 123
+	expect blah == 1
+	tag = Blue
+	return # Comment after return keyword
+		tag # Comment after return statement
+
+	# Just a random comment!
+
+	...
+	match_time(
+		..., # Single args with comment
+	)
+	some_func(
+		dbg # After debug
+			42, # After debug expr
+	)
+	crash # Comment after crash keyword
+		"Unreachable!" # Comment after crash statement
+	tag_with_payload = Ok(number)
+	interpolated = "Hello, ${world}"
+	list = [
+		add_one(
+			dbg # After dbg in list
+				number, # after dbg expr as arg
+		), # Comment one
+		456, # Comment two
+		789, # Comment three
+	]
+	for n in list {
+		Stdout.line!("Adding ${n} to ${number}")
+		number = number + n
+	}
+	record = { foo: 123, bar: "Hello", baz: tag, qux: Ok(world), punned }
+	tuple = (123, "World", tag, Ok(world), (nested, tuple), [1, 2, 3])
+	multiline_tuple = (
+		123,
+		"World",
+		tag1,
+		Ok(world), # This one has a comment
+		(nested, tuple),
+		[1, 2, 3],
+	)
+	bin_op_result = Err(foo) ?? 12 > 5 * 5 or 13 + 2 < 5 and 10 - 1 >= 16 or 12 <= 3 / 5
+	static_dispatch_style = some_fn(arg1)?.static_dispatch_method()?.next_static_dispatch_method()?.record_field?
+	Stdout.line!(interpolated)?
+	Stdout.line!(
+		"How about ${ # Comment after string interpolation open
+			Num.toStr(number) # Comment after string interpolation expr
+		} as a string?",
+	)
+} # Comment after top-level decl
+
+empty : {}
+empty = {}
+
+tuple : Value((a, b, c))
+
+expect {
+	foo = 1 # This should work too
+	blah = 1
+	blah == foo
+}
+
+import pf.Stdout exposing [line!, write!]
+
+import # Comment after import keyword
+	pf # Comment after qualifier
+		.StdoutMultiline # Comment after ident
+		exposing [ # Comment after exposing open
+			line!, # Comment after exposed item
+			write!, # Another after exposed item
+		] # Comment after exposing close
+
+import pkg.Something exposing [func as function, Type as ValueCategory, Custom.*]
+
+import BadName as GoodName
+import
+	BadNameMultiline
+		as
+		GoodNameMultiline
+
+Map(a, b) : List(a), (a -> b) -> List(b)
+MapML( # Comment here
+	a, # And here
+	b,
+) # And after the last arg
+	: # And after the colon
+		List( # Inside Tag args
+			a, # After tag arg
+		),
+		(a -> b) -> # After arrow
+			List( # Inside tag args
+				b,
+			) # And after the type decl
+
+Foo : (Bar, Baz)
+
+FooMultiline : ( # Comment after pattern tuple open
+	Bar, # Comment after pattern tuple item
+	Baz, # Another after pattern tuple item
+) # Comment after pattern tuple close
+
+Some(a) : { foo : Ok(a), bar : Something }
+SomeMl(a) : { # After record open
+	foo : Ok(a), # After field
+	bar : Something, # After last field
+}
+
+SomeMultiline(a) : { # Comment after pattern record open
+	foo # After field name
+		: # Before field anno
+			Ok(a), # Comment after pattern record field
+	bar : Something, # Another after pattern record field
+} # Comment after pattern record close
+
+Maybe(a) : [Some(a), None]
+
+MaybeMultiline(a) : [ # Comment after tag union open
+	Some(a), # Comment after tag union member
+	None, # Another after tag union member
+] # Comment after tag union close
+
+SomeFunc(a) : Maybe(a), a -> Maybe(a)
+
+add_one_oneline = |num| if num 2 else 5
+
+add_one : U64 -> U64
+add_one = |num| {
+	other = 1
+	if num {
+		dbg # After debug
+			some_func() # After debug expr
+		0
+	} else {
+		dbg 123
+		other
+	}
+}
+
+match_time = |
+	a, # After arg
+	b,
+| # After args
+	match a {
+		Blue | Green | Red => {
+			x = 12
+			x
+		}
+		Blue # After pattern in alt
+		| # Before pattern in alt
+			Green
+		| Red # After alt pattern
+			=> {
+				x = 12
+				x
+			}
+		lower # After pattern comment
+			=> 1
+		"foo" => # After arrow comment
+			100
+		"foo" | "bar" => 200
+		[1, 2, 3, .. as rest] # After pattern comment
+			=> # After arrow comment
+				123 # After branch comment
+
+		# Just a random comment
+
+		[1, 2 | 5, 3, .. as rest] => 123
+		[
+			1,
+			2 | 5,
+			3,
+			.. # After DoubleDot
+				as # Before alias
+					rest, # After last pattern in list
+		] => 123
+		3.14 => 314
+		3.14 | 6.28 => 314
+		(1, 2, 3) => 123
+		(1, 2 | 5, 3) => 123
+		{ foo: 1, bar: 2, ..rest } => 12->add(34)
+		{ # After pattern record open
+			foo # After pattern record field name
+				: # Before pattern record field value
+					1, # After pattern record field
+			bar: 2,
+			.. # After spread operator
+				rest, # After last field
+		} => 12
+		{ foo: 1, bar: 2 | 7 } => 12
+		{
+			foo: 1,
+			bar: 2 | 7, # After last record field
+		} => 12
+		Ok(123) => 123
+		Ok(Some(dude)) => dude
+		TwoArgs("hello", Some("world")) => 1000
+	}
+
+expect # Comment after expect keyword
+	blah == 1 # Comment after expect statement
+
+main! : List(String) -> Result({}, _)
+main! = |_| { # Yeah I can leave a comment here
+	world = "World"
+	var number = 123
+	expect blah == 1
+	tag = Blue
+	return # Comment after return keyword
+		tag # Comment after return statement
+
+	# Just a random comment!
+
+	...
+	match_time(
+		..., # Single args with comment
+	)
+	some_func(
+		dbg # After debug
+			42, # After debug expr
+	)
+	crash # Comment after crash keyword
+		"Unreachable!" # Comment after crash statement
+	tag_with_payload = Ok(number)
+	interpolated = "Hello, ${world}"
+	list = [
+		add_one(
+			dbg # After dbg in list
+				number, # after dbg expr as arg
+		), # Comment one
+		456, # Comment two
+		789, # Comment three
+	]
+	for n in list {
+		Stdout.line!("Adding ${n} to ${number}")
+		number = number + n
+	}
+	record = { foo: 123, bar: "Hello", baz: tag, qux: Ok(world), punned }
+	tuple = (123, "World", tag, Ok(world), (nested, tuple), [1, 2, 3])
+	multiline_tuple = (
+		123,
+		"World",
+		tag1,
+		Ok(world), # This one has a comment
+		(nested, tuple),
+		[1, 2, 3],
+	)
+	bin_op_result = Err(foo) ?? 12 > 5 * 5 or 13 + 2 < 5 and 10 - 1 >= 16 or 12 <= 3 / 5
+	static_dispatch_style = some_fn(arg1)?.static_dispatch_method()?.next_static_dispatch_method()?.record_field?
+	Stdout.line!(interpolated)?
+	Stdout.line!(
+		"How about ${ # Comment after string interpolation open
+			Num.toStr(number) # Comment after string interpolation expr
+		} as a string?",
+	)
+} # Comment after top-level decl
+
+empty : {}
+empty = {}
+
+tuple : Value((a, b, c))
+
+expect {
+	foo = 1 # This should work too
+	blah = 1
+	blah == foo
+}
+
+import pf.Stdout exposing [line!, write!]
+
+import # Comment after import keyword
+	pf # Comment after qualifier
+		.StdoutMultiline # Comment after ident
+		exposing [ # Comment after exposing open
+			line!, # Comment after exposed item
+			write!, # Another after exposed item
+		] # Comment after exposing close
+
+import pkg.Something exposing [func as function, Type as ValueCategory, Custom.*]
+
+import BadName as GoodName
+import
+	BadNameMultiline
+		as
+		GoodNameMultiline
+
+Map(a, b) : List(a), (a -> b) -> List(b)
+MapML( # Comment here
+	a, # And here
+	b,
+) # And after the last arg
+	: # And after the colon
+		List( # Inside Tag args
+			a, # After tag arg
+		),
+		(a -> b) -> # After arrow
+			List( # Inside tag args
+				b,
+			) # And after the type decl
+
+Foo : (Bar, Baz)
+
+FooMultiline : ( # Comment after pattern tuple open
+	Bar, # Comment after pattern tuple item
+	Baz, # Another after pattern tuple item
+) # Comment after pattern tuple close
+
+Some(a) : { foo : Ok(a), bar : Something }
+SomeMl(a) : { # After record open
+	foo : Ok(a), # After field
+	bar : Something, # After last field
+}
+
+SomeMultiline(a) : { # Comment after pattern record open
+	foo # After field name
+		: # Before field anno
+			Ok(a), # Comment after pattern record field
+	bar : Something, # Another after pattern record field
+} # Comment after pattern record close
+
+Maybe(a) : [Some(a), None]
+
+MaybeMultiline(a) : [ # Comment after tag union open
+	Some(a), # Comment after tag union member
+	None, # Another after tag union member
+] # Comment after tag union close
+
+SomeFunc(a) : Maybe(a), a -> Maybe(a)
+
+add_one_oneline = |num| if num 2 else 5
+
+add_one : U64 -> U64
+add_one = |num| {
+	other = 1
+	if num {
+		dbg # After debug
+			some_func() # After debug expr
+		0
+	} else {
+		dbg 123
+		other
+	}
+}
+
+match_time = |
+	a, # After arg
+	b,
+| # After args
+	match a {
+		Blue | Green | Red => {
+			x = 12
+			x
+		}
+		Blue # After pattern in alt
+		| # Before pattern in alt
+			Green
+		| Red # After alt pattern
+			=> {
+				x = 12
+				x
+			}
+		lower # After pattern comment
+			=> 1
+		"foo" => # After arrow comment
+			100
+		"foo" | "bar" => 200
+		[1, 2, 3, .. as rest] # After pattern comment
+			=> # After arrow comment
+				123 # After branch comment
+
+		# Just a random comment
+
+		[1, 2 | 5, 3, .. as rest] => 123
+		[
+			1,
+			2 | 5,
+			3,
+			.. # After DoubleDot
+				as # Before alias
+					rest, # After last pattern in list
+		] => 123
+		3.14 => 314
+		3.14 | 6.28 => 314
+		(1, 2, 3) => 123
+		(1, 2 | 5, 3) => 123
+		{ foo: 1, bar: 2, ..rest } => 12->add(34)
+		{ # After pattern record open
+			foo # After pattern record field name
+				: # Before pattern record field value
+					1, # After pattern record field
+			bar: 2,
+			.. # After spread operator
+				rest, # After last field
+		} => 12
+		{ foo: 1, bar: 2 | 7 } => 12
+		{
+			foo: 1,
+			bar: 2 | 7, # After last record field
+		} => 12
+		Ok(123) => 123
+		Ok(Some(dude)) => dude
+		TwoArgs("hello", Some("world")) => 1000
+	}
+
+expect # Comment after expect keyword
+	blah == 1 # Comment after expect statement
+
+main! : List(String) -> Result({}, _)
+main! = |_| { # Yeah I can leave a comment here
+	world = "World"
+	var number = 123
+	expect blah == 1
+	tag = Blue
+	return # Comment after return keyword
+		tag # Comment after return statement
+
+	# Just a random comment!
+
+	...
+	match_time(
+		..., # Single args with comment
+	)
+	some_func(
+		dbg # After debug
+			42, # After debug expr
+	)
+	crash # Comment after crash keyword
+		"Unreachable!" # Comment after crash statement
+	tag_with_payload = Ok(number)
+	interpolated = "Hello, ${world}"
+	list = [
+		add_one(
+			dbg # After dbg in list
+				number, # after dbg expr as arg
+		), # Comment one
+		456, # Comment two
+		789, # Comment three
+	]
+	for n in list {
+		Stdout.line!("Adding ${n} to ${number}")
+		number = number + n
+	}
+	record = { foo: 123, bar: "Hello", baz: tag, qux: Ok(world), punned }
+	tuple = (123, "World", tag, Ok(world), (nested, tuple), [1, 2, 3])
+	multiline_tuple = (
+		123,
+		"World",
+		tag1,
+		Ok(world), # This one has a comment
+		(nested, tuple),
+		[1, 2, 3],
+	)
+	bin_op_result = Err(foo) ?? 12 > 5 * 5 or 13 + 2 < 5 and 10 - 1 >= 16 or 12 <= 3 / 5
+	static_dispatch_style = some_fn(arg1)?.static_dispatch_method()?.next_static_dispatch_method()?.record_field?
+	Stdout.line!(interpolated)?
+	Stdout.line!(
+		"How about ${ # Comment after string interpolation open
+			Num.toStr(number) # Comment after string interpolation expr
+		} as a string?",
+	)
+} # Comment after top-level decl
+
+empty : {}
+empty = {}
+
+tuple : Value((a, b, c))
+
+expect {
+	foo = 1 # This should work too
+	blah = 1
+	blah == foo
+}
+
+import pf.Stdout exposing [line!, write!]
+
+import # Comment after import keyword
+	pf # Comment after qualifier
+		.StdoutMultiline # Comment after ident
+		exposing [ # Comment after exposing open
+			line!, # Comment after exposed item
+			write!, # Another after exposed item
+		] # Comment after exposing close
+
+import pkg.Something exposing [func as function, Type as ValueCategory, Custom.*]
+
+import BadName as GoodName
+import
+	BadNameMultiline
+		as
+		GoodNameMultiline
+
+Map(a, b) : List(a), (a -> b) -> List(b)
+MapML( # Comment here
+	a, # And here
+	b,
+) # And after the last arg
+	: # And after the colon
+		List( # Inside Tag args
+			a, # After tag arg
+		),
+		(a -> b) -> # After arrow
+			List( # Inside tag args
+				b,
+			) # And after the type decl
+
+Foo : (Bar, Baz)
+
+FooMultiline : ( # Comment after pattern tuple open
+	Bar, # Comment after pattern tuple item
+	Baz, # Another after pattern tuple item
+) # Comment after pattern tuple close
+
+Some(a) : { foo : Ok(a), bar : Something }
+SomeMl(a) : { # After record open
+	foo : Ok(a), # After field
+	bar : Something, # After last field
+}
+
+SomeMultiline(a) : { # Comment after pattern record open
+	foo # After field name
+		: # Before field anno
+			Ok(a), # Comment after pattern record field
+	bar : Something, # Another after pattern record field
+} # Comment after pattern record close
+
+Maybe(a) : [Some(a), None]
+
+MaybeMultiline(a) : [ # Comment after tag union open
+	Some(a), # Comment after tag union member
+	None, # Another after tag union member
+] # Comment after tag union close
+
+SomeFunc(a) : Maybe(a), a -> Maybe(a)
+
+add_one_oneline = |num| if num 2 else 5
+
+add_one : U64 -> U64
+add_one = |num| {
+	other = 1
+	if num {
+		dbg # After debug
+			some_func() # After debug expr
+		0
+	} else {
+		dbg 123
+		other
+	}
+}
+
+match_time = |
+	a, # After arg
+	b,
+| # After args
+	match a {
+		Blue | Green | Red => {
+			x = 12
+			x
+		}
+		Blue # After pattern in alt
+		| # Before pattern in alt
+			Green
+		| Red # After alt pattern
+			=> {
+				x = 12
+				x
+			}
+		lower # After pattern comment
+			=> 1
+		"foo" => # After arrow comment
+			100
+		"foo" | "bar" => 200
+		[1, 2, 3, .. as rest] # After pattern comment
+			=> # After arrow comment
+				123 # After branch comment
+
+		# Just a random comment
+
+		[1, 2 | 5, 3, .. as rest] => 123
+		[
+			1,
+			2 | 5,
+			3,
+			.. # After DoubleDot
+				as # Before alias
+					rest, # After last pattern in list
+		] => 123
+		3.14 => 314
+		3.14 | 6.28 => 314
+		(1, 2, 3) => 123
+		(1, 2 | 5, 3) => 123
+		{ foo: 1, bar: 2, ..rest } => 12->add(34)
+		{ # After pattern record open
+			foo # After pattern record field name
+				: # Before pattern record field value
+					1, # After pattern record field
+			bar: 2,
+			.. # After spread operator
+				rest, # After last field
+		} => 12
+		{ foo: 1, bar: 2 | 7 } => 12
+		{
+			foo: 1,
+			bar: 2 | 7, # After last record field
+		} => 12
+		Ok(123) => 123
+		Ok(Some(dude)) => dude
+		TwoArgs("hello", Some("world")) => 1000
+	}
+
+expect # Comment after expect keyword
+	blah == 1 # Comment after expect statement
+
+main! : List(String) -> Result({}, _)
+main! = |_| { # Yeah I can leave a comment here
+	world = "World"
+	var number = 123
+	expect blah == 1
+	tag = Blue
+	return # Comment after return keyword
+		tag # Comment after return statement
+
+	# Just a random comment!
+
+	...
+	match_time(
+		..., # Single args with comment
+	)
+	some_func(
+		dbg # After debug
+			42, # After debug expr
+	)
+	crash # Comment after crash keyword
+		"Unreachable!" # Comment after crash statement
+	tag_with_payload = Ok(number)
+	interpolated = "Hello, ${world}"
+	list = [
+		add_one(
+			dbg # After dbg in list
+				number, # after dbg expr as arg
+		), # Comment one
+		456, # Comment two
+		789, # Comment three
+	]
+	for n in list {
+		Stdout.line!("Adding ${n} to ${number}")
+		number = number + n
+	}
+	record = { foo: 123, bar: "Hello", baz: tag, qux: Ok(world), punned }
+	tuple = (123, "World", tag, Ok(world), (nested, tuple), [1, 2, 3])
+	multiline_tuple = (
+		123,
+		"World",
+		tag1,
+		Ok(world), # This one has a comment
+		(nested, tuple),
+		[1, 2, 3],
+	)
+	bin_op_result = Err(foo) ?? 12 > 5 * 5 or 13 + 2 < 5 and 10 - 1 >= 16 or 12 <= 3 / 5
+	static_dispatch_style = some_fn(arg1)?.static_dispatch_method()?.next_static_dispatch_method()?.record_field?
+	Stdout.line!(interpolated)?
+	Stdout.line!(
+		"How about ${ # Comment after string interpolation open
+			Num.toStr(number) # Comment after string interpolation expr
+		} as a string?",
+	)
+} # Comment after top-level decl
+
+empty : {}
+empty = {}
+
+tuple : Value((a, b, c))
+
+expect {
+	foo = 1 # This should work too
+	blah = 1
+	blah == foo
+}
+
+import pf.Stdout exposing [line!, write!]
+
+import # Comment after import keyword
+	pf # Comment after qualifier
+		.StdoutMultiline # Comment after ident
+		exposing [ # Comment after exposing open
+			line!, # Comment after exposed item
+			write!, # Another after exposed item
+		] # Comment after exposing close
+
+import pkg.Something exposing [func as function, Type as ValueCategory, Custom.*]
+
+import BadName as GoodName
+import
+	BadNameMultiline
+		as
+		GoodNameMultiline
+
+Map(a, b) : List(a), (a -> b) -> List(b)
+MapML( # Comment here
+	a, # And here
+	b,
+) # And after the last arg
+	: # And after the colon
+		List( # Inside Tag args
+			a, # After tag arg
+		),
+		(a -> b) -> # After arrow
+			List( # Inside tag args
+				b,
+			) # And after the type decl
+
+Foo : (Bar, Baz)
+
+FooMultiline : ( # Comment after pattern tuple open
+	Bar, # Comment after pattern tuple item
+	Baz, # Another after pattern tuple item
+) # Comment after pattern tuple close
+
+Some(a) : { foo : Ok(a), bar : Something }
+SomeMl(a) : { # After record open
+	foo : Ok(a), # After field
+	bar : Something, # After last field
+}
+
+SomeMultiline(a) : { # Comment after pattern record open
+	foo # After field name
+		: # Before field anno
+			Ok(a), # Comment after pattern record field
+	bar : Something, # Another after pattern record field
+} # Comment after pattern record close
+
+Maybe(a) : [Some(a), None]
+
+MaybeMultiline(a) : [ # Comment after tag union open
+	Some(a), # Comment after tag union member
+	None, # Another after tag union member
+] # Comment after tag union close
+
+SomeFunc(a) : Maybe(a), a -> Maybe(a)
+
+add_one_oneline = |num| if num 2 else 5
+
+add_one : U64 -> U64
+add_one = |num| {
+	other = 1
+	if num {
+		dbg # After debug
+			some_func() # After debug expr
+		0
+	} else {
+		dbg 123
+		other
+	}
+}
+
+match_time = |
+	a, # After arg
+	b,
+| # After args
+	match a {
+		Blue | Green | Red => {
+			x = 12
+			x
+		}
+		Blue # After pattern in alt
+		| # Before pattern in alt
+			Green
+		| Red # After alt pattern
+			=> {
+				x = 12
+				x
+			}
+		lower # After pattern comment
+			=> 1
+		"foo" => # After arrow comment
+			100
+		"foo" | "bar" => 200
+		[1, 2, 3, .. as rest] # After pattern comment
+			=> # After arrow comment
+				123 # After branch comment
+
+		# Just a random comment
+
+		[1, 2 | 5, 3, .. as rest] => 123
+		[
+			1,
+			2 | 5,
+			3,
+			.. # After DoubleDot
+				as # Before alias
+					rest, # After last pattern in list
+		] => 123
+		3.14 => 314
+		3.14 | 6.28 => 314
+		(1, 2, 3) => 123
+		(1, 2 | 5, 3) => 123
+		{ foo: 1, bar: 2, ..rest } => 12->add(34)
+		{ # After pattern record open
+			foo # After pattern record field name
+				: # Before pattern record field value
+					1, # After pattern record field
+			bar: 2,
+			.. # After spread operator
+				rest, # After last field
+		} => 12
+		{ foo: 1, bar: 2 | 7 } => 12
+		{
+			foo: 1,
+			bar: 2 | 7, # After last record field
+		} => 12
+		Ok(123) => 123
+		Ok(Some(dude)) => dude
+		TwoArgs("hello", Some("world")) => 1000
+	}
+
+expect # Comment after expect keyword
+	blah == 1 # Comment after expect statement
+
+main! : List(String) -> Result({}, _)
+main! = |_| { # Yeah I can leave a comment here
+	world = "World"
+	var number = 123
+	expect blah == 1
+	tag = Blue
+	return # Comment after return keyword
+		tag # Comment after return statement
+
+	# Just a random comment!
+
+	...
+	match_time(
+		..., # Single args with comment
+	)
+	some_func(
+		dbg # After debug
+			42, # After debug expr
+	)
+	crash # Comment after crash keyword
+		"Unreachable!" # Comment after crash statement
+	tag_with_payload = Ok(number)
+	interpolated = "Hello, ${world}"
+	list = [
+		add_one(
+			dbg # After dbg in list
+				number, # after dbg expr as arg
+		), # Comment one
+		456, # Comment two
+		789, # Comment three
+	]
+	for n in list {
+		Stdout.line!("Adding ${n} to ${number}")
+		number = number + n
+	}
+	record = { foo: 123, bar: "Hello", baz: tag, qux: Ok(world), punned }
+	tuple = (123, "World", tag, Ok(world), (nested, tuple), [1, 2, 3])
+	multiline_tuple = (
+		123,
+		"World",
+		tag1,
+		Ok(world), # This one has a comment
+		(nested, tuple),
+		[1, 2, 3],
+	)
+	bin_op_result = Err(foo) ?? 12 > 5 * 5 or 13 + 2 < 5 and 10 - 1 >= 16 or 12 <= 3 / 5
+	static_dispatch_style = some_fn(arg1)?.static_dispatch_method()?.next_static_dispatch_method()?.record_field?
+	Stdout.line!(interpolated)?
+	Stdout.line!(
+		"How about ${ # Comment after string interpolation open
+			Num.toStr(number) # Comment after string interpolation expr
+		} as a string?",
+	)
+} # Comment after top-level decl
+
+empty : {}
+empty = {}
+
+tuple : Value((a, b, c))
+
+expect {
+	foo = 1 # This should work too
+	blah = 1
+	blah == foo
+}
+
+import pf.Stdout exposing [line!, write!]
+
+import # Comment after import keyword
+	pf # Comment after qualifier
+		.StdoutMultiline # Comment after ident
+		exposing [ # Comment after exposing open
+			line!, # Comment after exposed item
+			write!, # Another after exposed item
+		] # Comment after exposing close
+
+import pkg.Something exposing [func as function, Type as ValueCategory, Custom.*]
+
+import BadName as GoodName
+import
+	BadNameMultiline
+		as
+		GoodNameMultiline
+
+Map(a, b) : List(a), (a -> b) -> List(b)
+MapML( # Comment here
+	a, # And here
+	b,
+) # And after the last arg
+	: # And after the colon
+		List( # Inside Tag args
+			a, # After tag arg
+		),
+		(a -> b) -> # After arrow
+			List( # Inside tag args
+				b,
+			) # And after the type decl
+
+Foo : (Bar, Baz)
+
+FooMultiline : ( # Comment after pattern tuple open
+	Bar, # Comment after pattern tuple item
+	Baz, # Another after pattern tuple item
+) # Comment after pattern tuple close
+
+Some(a) : { foo : Ok(a), bar : Something }
+SomeMl(a) : { # After record open
+	foo : Ok(a), # After field
+	bar : Something, # After last field
+}
+
+SomeMultiline(a) : { # Comment after pattern record open
+	foo # After field name
+		: # Before field anno
+			Ok(a), # Comment after pattern record field
+	bar : Something, # Another after pattern record field
+} # Comment after pattern record close
+
+Maybe(a) : [Some(a), None]
+
+MaybeMultiline(a) : [ # Comment after tag union open
+	Some(a), # Comment after tag union member
+	None, # Another after tag union member
+] # Comment after tag union close
+
+SomeFunc(a) : Maybe(a), a -> Maybe(a)
+
+add_one_oneline = |num| if num 2 else 5
+
+add_one : U64 -> U64
+add_one = |num| {
+	other = 1
+	if num {
+		dbg # After debug
+			some_func() # After debug expr
+		0
+	} else {
+		dbg 123
+		other
+	}
+}
+
+match_time = |
+	a, # After arg
+	b,
+| # After args
+	match a {
+		Blue | Green | Red => {
+			x = 12
+			x
+		}
+		Blue # After pattern in alt
+		| # Before pattern in alt
+			Green
+		| Red # After alt pattern
+			=> {
+				x = 12
+				x
+			}
+		lower # After pattern comment
+			=> 1
+		"foo" => # After arrow comment
+			100
+		"foo" | "bar" => 200
+		[1, 2, 3, .. as rest] # After pattern comment
+			=> # After arrow comment
+				123 # After branch comment
+
+		# Just a random comment
+
+		[1, 2 | 5, 3, .. as rest] => 123
+		[
+			1,
+			2 | 5,
+			3,
+			.. # After DoubleDot
+				as # Before alias
+					rest, # After last pattern in list
+		] => 123
+		3.14 => 314
+		3.14 | 6.28 => 314
+		(1, 2, 3) => 123
+		(1, 2 | 5, 3) => 123
+		{ foo: 1, bar: 2, ..rest } => 12->add(34)
+		{ # After pattern record open
+			foo # After pattern record field name
+				: # Before pattern record field value
+					1, # After pattern record field
+			bar: 2,
+			.. # After spread operator
+				rest, # After last field
+		} => 12
+		{ foo: 1, bar: 2 | 7 } => 12
+		{
+			foo: 1,
+			bar: 2 | 7, # After last record field
+		} => 12
+		Ok(123) => 123
+		Ok(Some(dude)) => dude
+		TwoArgs("hello", Some("world")) => 1000
+	}
+
+expect # Comment after expect keyword
+	blah == 1 # Comment after expect statement
+
+main! : List(String) -> Result({}, _)
+main! = |_| { # Yeah I can leave a comment here
+	world = "World"
+	var number = 123
+	expect blah == 1
+	tag = Blue
+	return # Comment after return keyword
+		tag # Comment after return statement
+
+	# Just a random comment!
+
+	...
+	match_time(
+		..., # Single args with comment
+	)
+	some_func(
+		dbg # After debug
+			42, # After debug expr
+	)
+	crash # Comment after crash keyword
+		"Unreachable!" # Comment after crash statement
+	tag_with_payload = Ok(number)
+	interpolated = "Hello, ${world}"
+	list = [
+		add_one(
+			dbg # After dbg in list
+				number, # after dbg expr as arg
+		), # Comment one
+		456, # Comment two
+		789, # Comment three
+	]
+	for n in list {
+		Stdout.line!("Adding ${n} to ${number}")
+		number = number + n
+	}
+	record = { foo: 123, bar: "Hello", baz: tag, qux: Ok(world), punned }
+	tuple = (123, "World", tag, Ok(world), (nested, tuple), [1, 2, 3])
+	multiline_tuple = (
+		123,
+		"World",
+		tag1,
+		Ok(world), # This one has a comment
+		(nested, tuple),
+		[1, 2, 3],
+	)
+	bin_op_result = Err(foo) ?? 12 > 5 * 5 or 13 + 2 < 5 and 10 - 1 >= 16 or 12 <= 3 / 5
+	static_dispatch_style = some_fn(arg1)?.static_dispatch_method()?.next_static_dispatch_method()?.record_field?
+	Stdout.line!(interpolated)?
+	Stdout.line!(
+		"How about ${ # Comment after string interpolation open
+			Num.toStr(number) # Comment after string interpolation expr
+		} as a string?",
+	)
+} # Comment after top-level decl
+
+empty : {}
+empty = {}
+
+tuple : Value((a, b, c))
+
+expect {
+	foo = 1 # This should work too
+	blah = 1
+	blah == foo
+}
+
+import pf.Stdout exposing [line!, write!]
+
+import # Comment after import keyword
+	pf # Comment after qualifier
+		.StdoutMultiline # Comment after ident
+		exposing [ # Comment after exposing open
+			line!, # Comment after exposed item
+			write!, # Another after exposed item
+		] # Comment after exposing close
+
+import pkg.Something exposing [func as function, Type as ValueCategory, Custom.*]
+
+import BadName as GoodName
+import
+	BadNameMultiline
+		as
+		GoodNameMultiline
+
+Map(a, b) : List(a), (a -> b) -> List(b)
+MapML( # Comment here
+	a, # And here
+	b,
+) # And after the last arg
+	: # And after the colon
+		List( # Inside Tag args
+			a, # After tag arg
+		),
+		(a -> b) -> # After arrow
+			List( # Inside tag args
+				b,
+			) # And after the type decl
+
+Foo : (Bar, Baz)
+
+FooMultiline : ( # Comment after pattern tuple open
+	Bar, # Comment after pattern tuple item
+	Baz, # Another after pattern tuple item
+) # Comment after pattern tuple close
+
+Some(a) : { foo : Ok(a), bar : Something }
+SomeMl(a) : { # After record open
+	foo : Ok(a), # After field
+	bar : Something, # After last field
+}
+
+SomeMultiline(a) : { # Comment after pattern record open
+	foo # After field name
+		: # Before field anno
+			Ok(a), # Comment after pattern record field
+	bar : Something, # Another after pattern record field
+} # Comment after pattern record close
+
+Maybe(a) : [Some(a), None]
+
+MaybeMultiline(a) : [ # Comment after tag union open
+	Some(a), # Comment after tag union member
+	None, # Another after tag union member
+] # Comment after tag union close
+
+SomeFunc(a) : Maybe(a), a -> Maybe(a)
+
+add_one_oneline = |num| if num 2 else 5
+
+add_one : U64 -> U64
+add_one = |num| {
+	other = 1
+	if num {
+		dbg # After debug
+			some_func() # After debug expr
+		0
+	} else {
+		dbg 123
+		other
+	}
+}
+
+match_time = |
+	a, # After arg
+	b,
+| # After args
+	match a {
+		Blue | Green | Red => {
+			x = 12
+			x
+		}
+		Blue # After pattern in alt
+		| # Before pattern in alt
+			Green
+		| Red # After alt pattern
+			=> {
+				x = 12
+				x
+			}
+		lower # After pattern comment
+			=> 1
+		"foo" => # After arrow comment
+			100
+		"foo" | "bar" => 200
+		[1, 2, 3, .. as rest] # After pattern comment
+			=> # After arrow comment
+				123 # After branch comment
+
+		# Just a random comment
+
+		[1, 2 | 5, 3, .. as rest] => 123
+		[
+			1,
+			2 | 5,
+			3,
+			.. # After DoubleDot
+				as # Before alias
+					rest, # After last pattern in list
+		] => 123
+		3.14 => 314
+		3.14 | 6.28 => 314
+		(1, 2, 3) => 123
+		(1, 2 | 5, 3) => 123
+		{ foo: 1, bar: 2, ..rest } => 12->add(34)
+		{ # After pattern record open
+			foo # After pattern record field name
+				: # Before pattern record field value
+					1, # After pattern record field
+			bar: 2,
+			.. # After spread operator
+				rest, # After last field
+		} => 12
+		{ foo: 1, bar: 2 | 7 } => 12
+		{
+			foo: 1,
+			bar: 2 | 7, # After last record field
+		} => 12
+		Ok(123) => 123
+		Ok(Some(dude)) => dude
+		TwoArgs("hello", Some("world")) => 1000
+	}
+
+expect # Comment after expect keyword
+	blah == 1 # Comment after expect statement
+
+main! : List(String) -> Result({}, _)
+main! = |_| { # Yeah I can leave a comment here
+	world = "World"
+	var number = 123
+	expect blah == 1
+	tag = Blue
+	return # Comment after return keyword
+		tag # Comment after return statement
+
+	# Just a random comment!
+
+	...
+	match_time(
+		..., # Single args with comment
+	)
+	some_func(
+		dbg # After debug
+			42, # After debug expr
+	)
+	crash # Comment after crash keyword
+		"Unreachable!" # Comment after crash statement
+	tag_with_payload = Ok(number)
+	interpolated = "Hello, ${world}"
+	list = [
+		add_one(
+			dbg # After dbg in list
+				number, # after dbg expr as arg
+		), # Comment one
+		456, # Comment two
+		789, # Comment three
+	]
+	for n in list {
+		Stdout.line!("Adding ${n} to ${number}")
+		number = number + n
+	}
+	record = { foo: 123, bar: "Hello", baz: tag, qux: Ok(world), punned }
+	tuple = (123, "World", tag, Ok(world), (nested, tuple), [1, 2, 3])
+	multiline_tuple = (
+		123,
+		"World",
+		tag1,
+		Ok(world), # This one has a comment
+		(nested, tuple),
+		[1, 2, 3],
+	)
+	bin_op_result = Err(foo) ?? 12 > 5 * 5 or 13 + 2 < 5 and 10 - 1 >= 16 or 12 <= 3 / 5
+	static_dispatch_style = some_fn(arg1)?.static_dispatch_method()?.next_static_dispatch_method()?.record_field?
+	Stdout.line!(interpolated)?
+	Stdout.line!(
+		"How about ${ # Comment after string interpolation open
+			Num.toStr(number) # Comment after string interpolation expr
+		} as a string?",
+	)
+} # Comment after top-level decl
+
+empty : {}
+empty = {}
+
+tuple : Value((a, b, c))
+
+expect {
+	foo = 1 # This should work too
+	blah = 1
+	blah == foo
+}
+
+import pf.Stdout exposing [line!, write!]
+
+import # Comment after import keyword
+	pf # Comment after qualifier
+		.StdoutMultiline # Comment after ident
+		exposing [ # Comment after exposing open
+			line!, # Comment after exposed item
+			write!, # Another after exposed item
+		] # Comment after exposing close
+
+import pkg.Something exposing [func as function, Type as ValueCategory, Custom.*]
+
+import BadName as GoodName
+import
+	BadNameMultiline
+		as
+		GoodNameMultiline
+
+Map(a, b) : List(a), (a -> b) -> List(b)
+MapML( # Comment here
+	a, # And here
+	b,
+) # And after the last arg
+	: # And after the colon
+		List( # Inside Tag args
+			a, # After tag arg
+		),
+		(a -> b) -> # After arrow
+			List( # Inside tag args
+				b,
+			) # And after the type decl
+
+Foo : (Bar, Baz)
+
+FooMultiline : ( # Comment after pattern tuple open
+	Bar, # Comment after pattern tuple item
+	Baz, # Another after pattern tuple item
+) # Comment after pattern tuple close
+
+Some(a) : { foo : Ok(a), bar : Something }
+SomeMl(a) : { # After record open
+	foo : Ok(a), # After field
+	bar : Something, # After last field
+}
+
+SomeMultiline(a) : { # Comment after pattern record open
+	foo # After field name
+		: # Before field anno
+			Ok(a), # Comment after pattern record field
+	bar : Something, # Another after pattern record field
+} # Comment after pattern record close
+
+Maybe(a) : [Some(a), None]
+
+MaybeMultiline(a) : [ # Comment after tag union open
+	Some(a), # Comment after tag union member
+	None, # Another after tag union member
+] # Comment after tag union close
+
+SomeFunc(a) : Maybe(a), a -> Maybe(a)
+
+add_one_oneline = |num| if num 2 else 5
+
+add_one : U64 -> U64
+add_one = |num| {
+	other = 1
+	if num {
+		dbg # After debug
+			some_func() # After debug expr
+		0
+	} else {
+		dbg 123
+		other
+	}
+}
+
+match_time = |
+	a, # After arg
+	b,
+| # After args
+	match a {
+		Blue | Green | Red => {
+			x = 12
+			x
+		}
+		Blue # After pattern in alt
+		| # Before pattern in alt
+			Green
+		| Red # After alt pattern
+			=> {
+				x = 12
+				x
+			}
+		lower # After pattern comment
+			=> 1
+		"foo" => # After arrow comment
+			100
+		"foo" | "bar" => 200
+		[1, 2, 3, .. as rest] # After pattern comment
+			=> # After arrow comment
+				123 # After branch comment
+
+		# Just a random comment
+
+		[1, 2 | 5, 3, .. as rest] => 123
+		[
+			1,
+			2 | 5,
+			3,
+			.. # After DoubleDot
+				as # Before alias
+					rest, # After last pattern in list
+		] => 123
+		3.14 => 314
+		3.14 | 6.28 => 314
+		(1, 2, 3) => 123
+		(1, 2 | 5, 3) => 123
+		{ foo: 1, bar: 2, ..rest } => 12->add(34)
+		{ # After pattern record open
+			foo # After pattern record field name
+				: # Before pattern record field value
+					1, # After pattern record field
+			bar: 2,
+			.. # After spread operator
+				rest, # After last field
+		} => 12
+		{ foo: 1, bar: 2 | 7 } => 12
+		{
+			foo: 1,
+			bar: 2 | 7, # After last record field
+		} => 12
+		Ok(123) => 123
+		Ok(Some(dude)) => dude
+		TwoArgs("hello", Some("world")) => 1000
+	}
+
+expect # Comment after expect keyword
+	blah == 1 # Comment after expect statement
+
+main! : List(String) -> Result({}, _)
+main! = |_| { # Yeah I can leave a comment here
+	world = "World"
+	var number = 123
+	expect blah == 1
+	tag = Blue
+	return # Comment after return keyword
+		tag # Comment after return statement
+
+	# Just a random comment!
+
+	...
+	match_time(
+		..., # Single args with comment
+	)
+	some_func(
+		dbg # After debug
+			42, # After debug expr
+	)
+	crash # Comment after crash keyword
+		"Unreachable!" # Comment after crash statement
+	tag_with_payload = Ok(number)
+	interpolated = "Hello, ${world}"
+	list = [
+		add_one(
+			dbg # After dbg in list
+				number, # after dbg expr as arg
+		), # Comment one
+		456, # Comment two
+		789, # Comment three
+	]
+	for n in list {
+		Stdout.line!("Adding ${n} to ${number}")
+		number = number + n
+	}
+	record = { foo: 123, bar: "Hello", baz: tag, qux: Ok(world), punned }
+	tuple = (123, "World", tag, Ok(world), (nested, tuple), [1, 2, 3])
+	multiline_tuple = (
+		123,
+		"World",
+		tag1,
+		Ok(world), # This one has a comment
+		(nested, tuple),
+		[1, 2, 3],
+	)
+	bin_op_result = Err(foo) ?? 12 > 5 * 5 or 13 + 2 < 5 and 10 - 1 >= 16 or 12 <= 3 / 5
+	static_dispatch_style = some_fn(arg1)?.static_dispatch_method()?.next_static_dispatch_method()?.record_field?
+	Stdout.line!(interpolated)?
+	Stdout.line!(
+		"How about ${ # Comment after string interpolation open
+			Num.toStr(number) # Comment after string interpolation expr
+		} as a string?",
+	)
+} # Comment after top-level decl
+
+empty : {}
+empty = {}
+
+tuple : Value((a, b, c))
+
+expect {
+	foo = 1 # This should work too
+	blah = 1
+	blah == foo
+}
+
+import pf.Stdout exposing [line!, write!]
+
+import # Comment after import keyword
+	pf # Comment after qualifier
+		.StdoutMultiline # Comment after ident
+		exposing [ # Comment after exposing open
+			line!, # Comment after exposed item
+			write!, # Another after exposed item
+		] # Comment after exposing close
+
+import pkg.Something exposing [func as function, Type as ValueCategory, Custom.*]
+
+import BadName as GoodName
+import
+	BadNameMultiline
+		as
+		GoodNameMultiline
+
+Map(a, b) : List(a), (a -> b) -> List(b)
+MapML( # Comment here
+	a, # And here
+	b,
+) # And after the last arg
+	: # And after the colon
+		List( # Inside Tag args
+			a, # After tag arg
+		),
+		(a -> b) -> # After arrow
+			List( # Inside tag args
+				b,
+			) # And after the type decl
+
+Foo : (Bar, Baz)
+
+FooMultiline : ( # Comment after pattern tuple open
+	Bar, # Comment after pattern tuple item
+	Baz, # Another after pattern tuple item
+) # Comment after pattern tuple close
+
+Some(a) : { foo : Ok(a), bar : Something }
+SomeMl(a) : { # After record open
+	foo : Ok(a), # After field
+	bar : Something, # After last field
+}
+
+SomeMultiline(a) : { # Comment after pattern record open
+	foo # After field name
+		: # Before field anno
+			Ok(a), # Comment after pattern record field
+	bar : Something, # Another after pattern record field
+} # Comment after pattern record close
+
+Maybe(a) : [Some(a), None]
+
+MaybeMultiline(a) : [ # Comment after tag union open
+	Some(a), # Comment after tag union member
+	None, # Another after tag union member
+] # Comment after tag union close
+
+SomeFunc(a) : Maybe(a), a -> Maybe(a)
+
+add_one_oneline = |num| if num 2 else 5
+
+add_one : U64 -> U64
+add_one = |num| {
+	other = 1
+	if num {
+		dbg # After debug
+			some_func() # After debug expr
+		0
+	} else {
+		dbg 123
+		other
+	}
+}
+
+match_time = |
+	a, # After arg
+	b,
+| # After args
+	match a {
+		Blue | Green | Red => {
+			x = 12
+			x
+		}
+		Blue # After pattern in alt
+		| # Before pattern in alt
+			Green
+		| Red # After alt pattern
+			=> {
+				x = 12
+				x
+			}
+		lower # After pattern comment
+			=> 1
+		"foo" => # After arrow comment
+			100
+		"foo" | "bar" => 200
+		[1, 2, 3, .. as rest] # After pattern comment
+			=> # After arrow comment
+				123 # After branch comment
+
+		# Just a random comment
+
+		[1, 2 | 5, 3, .. as rest] => 123
+		[
+			1,
+			2 | 5,
+			3,
+			.. # After DoubleDot
+				as # Before alias
+					rest, # After last pattern in list
+		] => 123
+		3.14 => 314
+		3.14 | 6.28 => 314
+		(1, 2, 3) => 123
+		(1, 2 | 5, 3) => 123
+		{ foo: 1, bar: 2, ..rest } => 12->add(34)
+		{ # After pattern record open
+			foo # After pattern record field name
+				: # Before pattern record field value
+					1, # After pattern record field
+			bar: 2,
+			.. # After spread operator
+				rest, # After last field
+		} => 12
+		{ foo: 1, bar: 2 | 7 } => 12
+		{
+			foo: 1,
+			bar: 2 | 7, # After last record field
+		} => 12
+		Ok(123) => 123
+		Ok(Some(dude)) => dude
+		TwoArgs("hello", Some("world")) => 1000
+	}
+
+expect # Comment after expect keyword
+	blah == 1 # Comment after expect statement
+
+main! : List(String) -> Result({}, _)
+main! = |_| { # Yeah I can leave a comment here
+	world = "World"
+	var number = 123
+	expect blah == 1
+	tag = Blue
+	return # Comment after return keyword
+		tag # Comment after return statement
+
+	# Just a random comment!
+
+	...
+	match_time(
+		..., # Single args with comment
+	)
+	some_func(
+		dbg # After debug
+			42, # After debug expr
+	)
+	crash # Comment after crash keyword
+		"Unreachable!" # Comment after crash statement
+	tag_with_payload = Ok(number)
+	interpolated = "Hello, ${world}"
+	list = [
+		add_one(
+			dbg # After dbg in list
+				number, # after dbg expr as arg
+		), # Comment one
+		456, # Comment two
+		789, # Comment three
+	]
+	for n in list {
+		Stdout.line!("Adding ${n} to ${number}")
+		number = number + n
+	}
+	record = { foo: 123, bar: "Hello", baz: tag, qux: Ok(world), punned }
+	tuple = (123, "World", tag, Ok(world), (nested, tuple), [1, 2, 3])
+	multiline_tuple = (
+		123,
+		"World",
+		tag1,
+		Ok(world), # This one has a comment
+		(nested, tuple),
+		[1, 2, 3],
+	)
+	bin_op_result = Err(foo) ?? 12 > 5 * 5 or 13 + 2 < 5 and 10 - 1 >= 16 or 12 <= 3 / 5
+	static_dispatch_style = some_fn(arg1)?.static_dispatch_method()?.next_static_dispatch_method()?.record_field?
+	Stdout.line!(interpolated)?
+	Stdout.line!(
+		"How about ${ # Comment after string interpolation open
+			Num.toStr(number) # Comment after string interpolation expr
+		} as a string?",
+	)
+} # Comment after top-level decl
+
+empty : {}
+empty = {}
+
+tuple : Value((a, b, c))
+
+expect {
+	foo = 1 # This should work too
+	blah = 1
+	blah == foo
+}
+
+import pf.Stdout exposing [line!, write!]
+
+import # Comment after import keyword
+	pf # Comment after qualifier
+		.StdoutMultiline # Comment after ident
+		exposing [ # Comment after exposing open
+			line!, # Comment after exposed item
+			write!, # Another after exposed item
+		] # Comment after exposing close
+
+import pkg.Something exposing [func as function, Type as ValueCategory, Custom.*]
+
+import BadName as GoodName
+import
+	BadNameMultiline
+		as
+		GoodNameMultiline
+
+Map(a, b) : List(a), (a -> b) -> List(b)
+MapML( # Comment here
+	a, # And here
+	b,
+) # And after the last arg
+	: # And after the colon
+		List( # Inside Tag args
+			a, # After tag arg
+		),
+		(a -> b) -> # After arrow
+			List( # Inside tag args
+				b,
+			) # And after the type decl
+
+Foo : (Bar, Baz)
+
+FooMultiline : ( # Comment after pattern tuple open
+	Bar, # Comment after pattern tuple item
+	Baz, # Another after pattern tuple item
+) # Comment after pattern tuple close
+
+Some(a) : { foo : Ok(a), bar : Something }
+SomeMl(a) : { # After record open
+	foo : Ok(a), # After field
+	bar : Something, # After last field
+}
+
+SomeMultiline(a) : { # Comment after pattern record open
+	foo # After field name
+		: # Before field anno
+			Ok(a), # Comment after pattern record field
+	bar : Something, # Another after pattern record field
+} # Comment after pattern record close
+
+Maybe(a) : [Some(a), None]
+
+MaybeMultiline(a) : [ # Comment after tag union open
+	Some(a), # Comment after tag union member
+	None, # Another after tag union member
+] # Comment after tag union close
+
+SomeFunc(a) : Maybe(a), a -> Maybe(a)
+
+add_one_oneline = |num| if num 2 else 5
+
+add_one : U64 -> U64
+add_one = |num| {
+	other = 1
+	if num {
+		dbg # After debug
+			some_func() # After debug expr
+		0
+	} else {
+		dbg 123
+		other
+	}
+}
+
+match_time = |
+	a, # After arg
+	b,
+| # After args
+	match a {
+		Blue | Green | Red => {
+			x = 12
+			x
+		}
+		Blue # After pattern in alt
+		| # Before pattern in alt
+			Green
+		| Red # After alt pattern
+			=> {
+				x = 12
+				x
+			}
+		lower # After pattern comment
+			=> 1
+		"foo" => # After arrow comment
+			100
+		"foo" | "bar" => 200
+		[1, 2, 3, .. as rest] # After pattern comment
+			=> # After arrow comment
+				123 # After branch comment
+
+		# Just a random comment
+
+		[1, 2 | 5, 3, .. as rest] => 123
+		[
+			1,
+			2 | 5,
+			3,
+			.. # After DoubleDot
+				as # Before alias
+					rest, # After last pattern in list
+		] => 123
+		3.14 => 314
+		3.14 | 6.28 => 314
+		(1, 2, 3) => 123
+		(1, 2 | 5, 3) => 123
+		{ foo: 1, bar: 2, ..rest } => 12->add(34)
+		{ # After pattern record open
+			foo # After pattern record field name
+				: # Before pattern record field value
+					1, # After pattern record field
+			bar: 2,
+			.. # After spread operator
+				rest, # After last field
+		} => 12
+		{ foo: 1, bar: 2 | 7 } => 12
+		{
+			foo: 1,
+			bar: 2 | 7, # After last record field
+		} => 12
+		Ok(123) => 123
+		Ok(Some(dude)) => dude
+		TwoArgs("hello", Some("world")) => 1000
+	}
+
+expect # Comment after expect keyword
+	blah == 1 # Comment after expect statement
+
+main! : List(String) -> Result({}, _)
+main! = |_| { # Yeah I can leave a comment here
+	world = "World"
+	var number = 123
+	expect blah == 1
+	tag = Blue
+	return # Comment after return keyword
+		tag # Comment after return statement
+
+	# Just a random comment!
+
+	...
+	match_time(
+		..., # Single args with comment
+	)
+	some_func(
+		dbg # After debug
+			42, # After debug expr
+	)
+	crash # Comment after crash keyword
+		"Unreachable!" # Comment after crash statement
+	tag_with_payload = Ok(number)
+	interpolated = "Hello, ${world}"
+	list = [
+		add_one(
+			dbg # After dbg in list
+				number, # after dbg expr as arg
+		), # Comment one
+		456, # Comment two
+		789, # Comment three
+	]
+	for n in list {
+		Stdout.line!("Adding ${n} to ${number}")
+		number = number + n
+	}
+	record = { foo: 123, bar: "Hello", baz: tag, qux: Ok(world), punned }
+	tuple = (123, "World", tag, Ok(world), (nested, tuple), [1, 2, 3])
+	multiline_tuple = (
+		123,
+		"World",
+		tag1,
+		Ok(world), # This one has a comment
+		(nested, tuple),
+		[1, 2, 3],
+	)
+	bin_op_result = Err(foo) ?? 12 > 5 * 5 or 13 + 2 < 5 and 10 - 1 >= 16 or 12 <= 3 / 5
+	static_dispatch_style = some_fn(arg1)?.static_dispatch_method()?.next_static_dispatch_method()?.record_field?
+	Stdout.line!(interpolated)?
+	Stdout.line!(
+		"How about ${ # Comment after string interpolation open
+			Num.toStr(number) # Comment after string interpolation expr
+		} as a string?",
+	)
+} # Comment after top-level decl
+
+empty : {}
+empty = {}
+
+tuple : Value((a, b, c))
+
+expect {
+	foo = 1 # This should work too
+	blah = 1
+	blah == foo
+}
+
+import pf.Stdout exposing [line!, write!]
+
+import # Comment after import keyword
+	pf # Comment after qualifier
+		.StdoutMultiline # Comment after ident
+		exposing [ # Comment after exposing open
+			line!, # Comment after exposed item
+			write!, # Another after exposed item
+		] # Comment after exposing close
+
+import pkg.Something exposing [func as function, Type as ValueCategory, Custom.*]
+
+import BadName as GoodName
+import
+	BadNameMultiline
+		as
+		GoodNameMultiline
+
+Map(a, b) : List(a), (a -> b) -> List(b)
+MapML( # Comment here
+	a, # And here
+	b,
+) # And after the last arg
+	: # And after the colon
+		List( # Inside Tag args
+			a, # After tag arg
+		),
+		(a -> b) -> # After arrow
+			List( # Inside tag args
+				b,
+			) # And after the type decl
+
+Foo : (Bar, Baz)
+
+FooMultiline : ( # Comment after pattern tuple open
+	Bar, # Comment after pattern tuple item
+	Baz, # Another after pattern tuple item
+) # Comment after pattern tuple close
+
+Some(a) : { foo : Ok(a), bar : Something }
+SomeMl(a) : { # After record open
+	foo : Ok(a), # After field
+	bar : Something, # After last field
+}
+
+SomeMultiline(a) : { # Comment after pattern record open
+	foo # After field name
+		: # Before field anno
+			Ok(a), # Comment after pattern record field
+	bar : Something, # Another after pattern record field
+} # Comment after pattern record close
+
+Maybe(a) : [Some(a), None]
+
+MaybeMultiline(a) : [ # Comment after tag union open
+	Some(a), # Comment after tag union member
+	None, # Another after tag union member
+] # Comment after tag union close
+
+SomeFunc(a) : Maybe(a), a -> Maybe(a)
+
+add_one_oneline = |num| if num 2 else 5
+
+add_one : U64 -> U64
+add_one = |num| {
+	other = 1
+	if num {
+		dbg # After debug
+			some_func() # After debug expr
+		0
+	} else {
+		dbg 123
+		other
+	}
+}
+
+match_time = |
+	a, # After arg
+	b,
+| # After args
+	match a {
+		Blue | Green | Red => {
+			x = 12
+			x
+		}
+		Blue # After pattern in alt
+		| # Before pattern in alt
+			Green
+		| Red # After alt pattern
+			=> {
+				x = 12
+				x
+			}
+		lower # After pattern comment
+			=> 1
+		"foo" => # After arrow comment
+			100
+		"foo" | "bar" => 200
+		[1, 2, 3, .. as rest] # After pattern comment
+			=> # After arrow comment
+				123 # After branch comment
+
+		# Just a random comment
+
+		[1, 2 | 5, 3, .. as rest] => 123
+		[
+			1,
+			2 | 5,
+			3,
+			.. # After DoubleDot
+				as # Before alias
+					rest, # After last pattern in list
+		] => 123
+		3.14 => 314
+		3.14 | 6.28 => 314
+		(1, 2, 3) => 123
+		(1, 2 | 5, 3) => 123
+		{ foo: 1, bar: 2, ..rest } => 12->add(34)
+		{ # After pattern record open
+			foo # After pattern record field name
+				: # Before pattern record field value
+					1, # After pattern record field
+			bar: 2,
+			.. # After spread operator
+				rest, # After last field
+		} => 12
+		{ foo: 1, bar: 2 | 7 } => 12
+		{
+			foo: 1,
+			bar: 2 | 7, # After last record field
+		} => 12
+		Ok(123) => 123
+		Ok(Some(dude)) => dude
+		TwoArgs("hello", Some("world")) => 1000
+	}
+
+expect # Comment after expect keyword
+	blah == 1 # Comment after expect statement
+
+main! : List(String) -> Result({}, _)
+main! = |_| { # Yeah I can leave a comment here
+	world = "World"
+	var number = 123
+	expect blah == 1
+	tag = Blue
+	return # Comment after return keyword
+		tag # Comment after return statement
+
+	# Just a random comment!
+
+	...
+	match_time(
+		..., # Single args with comment
+	)
+	some_func(
+		dbg # After debug
+			42, # After debug expr
+	)
+	crash # Comment after crash keyword
+		"Unreachable!" # Comment after crash statement
+	tag_with_payload = Ok(number)
+	interpolated = "Hello, ${world}"
+	list = [
+		add_one(
+			dbg # After dbg in list
+				number, # after dbg expr as arg
+		), # Comment one
+		456, # Comment two
+		789, # Comment three
+	]
+	for n in list {
+		Stdout.line!("Adding ${n} to ${number}")
+		number = number + n
+	}
+	record = { foo: 123, bar: "Hello", baz: tag, qux: Ok(world), punned }
+	tuple = (123, "World", tag, Ok(world), (nested, tuple), [1, 2, 3])
+	multiline_tuple = (
+		123,
+		"World",
+		tag1,
+		Ok(world), # This one has a comment
+		(nested, tuple),
+		[1, 2, 3],
+	)
+	bin_op_result = Err(foo) ?? 12 > 5 * 5 or 13 + 2 < 5 and 10 - 1 >= 16 or 12 <= 3 / 5
+	static_dispatch_style = some_fn(arg1)?.static_dispatch_method()?.next_static_dispatch_method()?.record_field?
+	Stdout.line!(interpolated)?
+	Stdout.line!(
+		"How about ${ # Comment after string interpolation open
+			Num.toStr(number) # Comment after string interpolation expr
+		} as a string?",
+	)
+} # Comment after top-level decl
+
+empty : {}
+empty = {}
+
+tuple : Value((a, b, c))
+
+expect {
+	foo = 1 # This should work too
+	blah = 1
+	blah == foo
+}
+
+import pf.Stdout exposing [line!, write!]
+
+import # Comment after import keyword
+	pf # Comment after qualifier
+		.StdoutMultiline # Comment after ident
+		exposing [ # Comment after exposing open
+			line!, # Comment after exposed item
+			write!, # Another after exposed item
+		] # Comment after exposing close
+
+import pkg.Something exposing [func as function, Type as ValueCategory, Custom.*]
+
+import BadName as GoodName
+import
+	BadNameMultiline
+		as
+		GoodNameMultiline
+
+Map(a, b) : List(a), (a -> b) -> List(b)
+MapML( # Comment here
+	a, # And here
+	b,
+) # And after the last arg
+	: # And after the colon
+		List( # Inside Tag args
+			a, # After tag arg
+		),
+		(a -> b) -> # After arrow
+			List( # Inside tag args
+				b,
+			) # And after the type decl
+
+Foo : (Bar, Baz)
+
+FooMultiline : ( # Comment after pattern tuple open
+	Bar, # Comment after pattern tuple item
+	Baz, # Another after pattern tuple item
+) # Comment after pattern tuple close
+
+Some(a) : { foo : Ok(a), bar : Something }
+SomeMl(a) : { # After record open
+	foo : Ok(a), # After field
+	bar : Something, # After last field
+}
+
+SomeMultiline(a) : { # Comment after pattern record open
+	foo # After field name
+		: # Before field anno
+			Ok(a), # Comment after pattern record field
+	bar : Something, # Another after pattern record field
+} # Comment after pattern record close
+
+Maybe(a) : [Some(a), None]
+
+MaybeMultiline(a) : [ # Comment after tag union open
+	Some(a), # Comment after tag union member
+	None, # Another after tag union member
+] # Comment after tag union close
+
+SomeFunc(a) : Maybe(a), a -> Maybe(a)
+
+add_one_oneline = |num| if num 2 else 5
+
+add_one : U64 -> U64
+add_one = |num| {
+	other = 1
+	if num {
+		dbg # After debug
+			some_func() # After debug expr
+		0
+	} else {
+		dbg 123
+		other
+	}
+}
+
+match_time = |
+	a, # After arg
+	b,
+| # After args
+	match a {
+		Blue | Green | Red => {
+			x = 12
+			x
+		}
+		Blue # After pattern in alt
+		| # Before pattern in alt
+			Green
+		| Red # After alt pattern
+			=> {
+				x = 12
+				x
+			}
+		lower # After pattern comment
+			=> 1
+		"foo" => # After arrow comment
+			100
+		"foo" | "bar" => 200
+		[1, 2, 3, .. as rest] # After pattern comment
+			=> # After arrow comment
+				123 # After branch comment
+
+		# Just a random comment
+
+		[1, 2 | 5, 3, .. as rest] => 123
+		[
+			1,
+			2 | 5,
+			3,
+			.. # After DoubleDot
+				as # Before alias
+					rest, # After last pattern in list
+		] => 123
+		3.14 => 314
+		3.14 | 6.28 => 314
+		(1, 2, 3) => 123
+		(1, 2 | 5, 3) => 123
+		{ foo: 1, bar: 2, ..rest } => 12->add(34)
+		{ # After pattern record open
+			foo # After pattern record field name
+				: # Before pattern record field value
+					1, # After pattern record field
+			bar: 2,
+			.. # After spread operator
+				rest, # After last field
+		} => 12
+		{ foo: 1, bar: 2 | 7 } => 12
+		{
+			foo: 1,
+			bar: 2 | 7, # After last record field
+		} => 12
+		Ok(123) => 123
+		Ok(Some(dude)) => dude
+		TwoArgs("hello", Some("world")) => 1000
+	}
+
+expect # Comment after expect keyword
+	blah == 1 # Comment after expect statement
+
+main! : List(String) -> Result({}, _)
+main! = |_| { # Yeah I can leave a comment here
+	world = "World"
+	var number = 123
+	expect blah == 1
+	tag = Blue
+	return # Comment after return keyword
+		tag # Comment after return statement
+
+	# Just a random comment!
+
+	...
+	match_time(
+		..., # Single args with comment
+	)
+	some_func(
+		dbg # After debug
+			42, # After debug expr
+	)
+	crash # Comment after crash keyword
+		"Unreachable!" # Comment after crash statement
+	tag_with_payload = Ok(number)
+	interpolated = "Hello, ${world}"
+	list = [
+		add_one(
+			dbg # After dbg in list
+				number, # after dbg expr as arg
+		), # Comment one
+		456, # Comment two
+		789, # Comment three
+	]
+	for n in list {
+		Stdout.line!("Adding ${n} to ${number}")
+		number = number + n
+	}
+	record = { foo: 123, bar: "Hello", baz: tag, qux: Ok(world), punned }
+	tuple = (123, "World", tag, Ok(world), (nested, tuple), [1, 2, 3])
+	multiline_tuple = (
+		123,
+		"World",
+		tag1,
+		Ok(world), # This one has a comment
+		(nested, tuple),
+		[1, 2, 3],
+	)
+	bin_op_result = Err(foo) ?? 12 > 5 * 5 or 13 + 2 < 5 and 10 - 1 >= 16 or 12 <= 3 / 5
+	static_dispatch_style = some_fn(arg1)?.static_dispatch_method()?.next_static_dispatch_method()?.record_field?
+	Stdout.line!(interpolated)?
+	Stdout.line!(
+		"How about ${ # Comment after string interpolation open
+			Num.toStr(number) # Comment after string interpolation expr
+		} as a string?",
+	)
+} # Comment after top-level decl
+
+empty : {}
+empty = {}
+
+tuple : Value((a, b, c))
+
+expect {
+	foo = 1 # This should work too
+	blah = 1
+	blah == foo
+}
+
+import pf.Stdout exposing [line!, write!]
+
+import # Comment after import keyword
+	pf # Comment after qualifier
+		.StdoutMultiline # Comment after ident
+		exposing [ # Comment after exposing open
+			line!, # Comment after exposed item
+			write!, # Another after exposed item
+		] # Comment after exposing close
+
+import pkg.Something exposing [func as function, Type as ValueCategory, Custom.*]
+
+import BadName as GoodName
+import
+	BadNameMultiline
+		as
+		GoodNameMultiline
+
+Map(a, b) : List(a), (a -> b) -> List(b)
+MapML( # Comment here
+	a, # And here
+	b,
+) # And after the last arg
+	: # And after the colon
+		List( # Inside Tag args
+			a, # After tag arg
+		),
+		(a -> b) -> # After arrow
+			List( # Inside tag args
+				b,
+			) # And after the type decl
+
+Foo : (Bar, Baz)
+
+FooMultiline : ( # Comment after pattern tuple open
+	Bar, # Comment after pattern tuple item
+	Baz, # Another after pattern tuple item
+) # Comment after pattern tuple close
+
+Some(a) : { foo : Ok(a), bar : Something }
+SomeMl(a) : { # After record open
+	foo : Ok(a), # After field
+	bar : Something, # After last field
+}
+
+SomeMultiline(a) : { # Comment after pattern record open
+	foo # After field name
+		: # Before field anno
+			Ok(a), # Comment after pattern record field
+	bar : Something, # Another after pattern record field
+} # Comment after pattern record close
+
+Maybe(a) : [Some(a), None]
+
+MaybeMultiline(a) : [ # Comment after tag union open
+	Some(a), # Comment after tag union member
+	None, # Another after tag union member
+] # Comment after tag union close
+
+SomeFunc(a) : Maybe(a), a -> Maybe(a)
+
+add_one_oneline = |num| if num 2 else 5
+
+add_one : U64 -> U64
+add_one = |num| {
+	other = 1
+	if num {
+		dbg # After debug
+			some_func() # After debug expr
+		0
+	} else {
+		dbg 123
+		other
+	}
+}
+
+match_time = |
+	a, # After arg
+	b,
+| # After args
+	match a {
+		Blue | Green | Red => {
+			x = 12
+			x
+		}
+		Blue # After pattern in alt
+		| # Before pattern in alt
+			Green
+		| Red # After alt pattern
+			=> {
+				x = 12
+				x
+			}
+		lower # After pattern comment
+			=> 1
+		"foo" => # After arrow comment
+			100
+		"foo" | "bar" => 200
+		[1, 2, 3, .. as rest] # After pattern comment
+			=> # After arrow comment
+				123 # After branch comment
+
+		# Just a random comment
+
+		[1, 2 | 5, 3, .. as rest] => 123
+		[
+			1,
+			2 | 5,
+			3,
+			.. # After DoubleDot
+				as # Before alias
+					rest, # After last pattern in list
+		] => 123
+		3.14 => 314
+		3.14 | 6.28 => 314
+		(1, 2, 3) => 123
+		(1, 2 | 5, 3) => 123
+		{ foo: 1, bar: 2, ..rest } => 12->add(34)
+		{ # After pattern record open
+			foo # After pattern record field name
+				: # Before pattern record field value
+					1, # After pattern record field
+			bar: 2,
+			.. # After spread operator
+				rest, # After last field
+		} => 12
+		{ foo: 1, bar: 2 | 7 } => 12
+		{
+			foo: 1,
+			bar: 2 | 7, # After last record field
+		} => 12
+		Ok(123) => 123
+		Ok(Some(dude)) => dude
+		TwoArgs("hello", Some("world")) => 1000
+	}
+
+expect # Comment after expect keyword
+	blah == 1 # Comment after expect statement
+
+main! : List(String) -> Result({}, _)
+main! = |_| { # Yeah I can leave a comment here
+	world = "World"
+	var number = 123
+	expect blah == 1
+	tag = Blue
+	return # Comment after return keyword
+		tag # Comment after return statement
+
+	# Just a random comment!
+
+	...
+	match_time(
+		..., # Single args with comment
+	)
+	some_func(
+		dbg # After debug
+			42, # After debug expr
+	)
+	crash # Comment after crash keyword
+		"Unreachable!" # Comment after crash statement
+	tag_with_payload = Ok(number)
+	interpolated = "Hello, ${world}"
+	list = [
+		add_one(
+			dbg # After dbg in list
+				number, # after dbg expr as arg
+		), # Comment one
+		456, # Comment two
+		789, # Comment three
+	]
+	for n in list {
+		Stdout.line!("Adding ${n} to ${number}")
+		number = number + n
+	}
+	record = { foo: 123, bar: "Hello", baz: tag, qux: Ok(world), punned }
+	tuple = (123, "World", tag, Ok(world), (nested, tuple), [1, 2, 3])
+	multiline_tuple = (
+		123,
+		"World",
+		tag1,
+		Ok(world), # This one has a comment
+		(nested, tuple),
+		[1, 2, 3],
+	)
+	bin_op_result = Err(foo) ?? 12 > 5 * 5 or 13 + 2 < 5 and 10 - 1 >= 16 or 12 <= 3 / 5
+	static_dispatch_style = some_fn(arg1)?.static_dispatch_method()?.next_static_dispatch_method()?.record_field?
+	Stdout.line!(interpolated)?
+	Stdout.line!(
+		"How about ${ # Comment after string interpolation open
+			Num.toStr(number) # Comment after string interpolation expr
+		} as a string?",
+	)
+} # Comment after top-level decl
+
+empty : {}
+empty = {}
+
+tuple : Value((a, b, c))
+
+expect {
+	foo = 1 # This should work too
+	blah = 1
+	blah == foo
+}
+
+import pf.Stdout exposing [line!, write!]
+
+import # Comment after import keyword
+	pf # Comment after qualifier
+		.StdoutMultiline # Comment after ident
+		exposing [ # Comment after exposing open
+			line!, # Comment after exposed item
+			write!, # Another after exposed item
+		] # Comment after exposing close
+
+import pkg.Something exposing [func as function, Type as ValueCategory, Custom.*]
+
+import BadName as GoodName
+import
+	BadNameMultiline
+		as
+		GoodNameMultiline
+
+Map(a, b) : List(a), (a -> b) -> List(b)
+MapML( # Comment here
+	a, # And here
+	b,
+) # And after the last arg
+	: # And after the colon
+		List( # Inside Tag args
+			a, # After tag arg
+		),
+		(a -> b) -> # After arrow
+			List( # Inside tag args
+				b,
+			) # And after the type decl
+
+Foo : (Bar, Baz)
+
+FooMultiline : ( # Comment after pattern tuple open
+	Bar, # Comment after pattern tuple item
+	Baz, # Another after pattern tuple item
+) # Comment after pattern tuple close
+
+Some(a) : { foo : Ok(a), bar : Something }
+SomeMl(a) : { # After record open
+	foo : Ok(a), # After field
+	bar : Something, # After last field
+}
+
+SomeMultiline(a) : { # Comment after pattern record open
+	foo # After field name
+		: # Before field anno
+			Ok(a), # Comment after pattern record field
+	bar : Something, # Another after pattern record field
+} # Comment after pattern record close
+
+Maybe(a) : [Some(a), None]
+
+MaybeMultiline(a) : [ # Comment after tag union open
+	Some(a), # Comment after tag union member
+	None, # Another after tag union member
+] # Comment after tag union close
+
+SomeFunc(a) : Maybe(a), a -> Maybe(a)
+
+add_one_oneline = |num| if num 2 else 5
+
+add_one : U64 -> U64
+add_one = |num| {
+	other = 1
+	if num {
+		dbg # After debug
+			some_func() # After debug expr
+		0
+	} else {
+		dbg 123
+		other
+	}
+}
+
+match_time = |
+	a, # After arg
+	b,
+| # After args
+	match a {
+		Blue | Green | Red => {
+			x = 12
+			x
+		}
+		Blue # After pattern in alt
+		| # Before pattern in alt
+			Green
+		| Red # After alt pattern
+			=> {
+				x = 12
+				x
+			}
+		lower # After pattern comment
+			=> 1
+		"foo" => # After arrow comment
+			100
+		"foo" | "bar" => 200
+		[1, 2, 3, .. as rest] # After pattern comment
+			=> # After arrow comment
+				123 # After branch comment
+
+		# Just a random comment
+
+		[1, 2 | 5, 3, .. as rest] => 123
+		[
+			1,
+			2 | 5,
+			3,
+			.. # After DoubleDot
+				as # Before alias
+					rest, # After last pattern in list
+		] => 123
+		3.14 => 314
+		3.14 | 6.28 => 314
+		(1, 2, 3) => 123
+		(1, 2 | 5, 3) => 123
+		{ foo: 1, bar: 2, ..rest } => 12->add(34)
+		{ # After pattern record open
+			foo # After pattern record field name
+				: # Before pattern record field value
+					1, # After pattern record field
+			bar: 2,
+			.. # After spread operator
+				rest, # After last field
+		} => 12
+		{ foo: 1, bar: 2 | 7 } => 12
+		{
+			foo: 1,
+			bar: 2 | 7, # After last record field
+		} => 12
+		Ok(123) => 123
+		Ok(Some(dude)) => dude
+		TwoArgs("hello", Some("world")) => 1000
+	}
+
+expect # Comment after expect keyword
+	blah == 1 # Comment after expect statement
+
+main! : List(String) -> Result({}, _)
+main! = |_| { # Yeah I can leave a comment here
+	world = "World"
+	var number = 123
+	expect blah == 1
+	tag = Blue
+	return # Comment after return keyword
+		tag # Comment after return statement
+
+	# Just a random comment!
+
+	...
+	match_time(
+		..., # Single args with comment
+	)
+	some_func(
+		dbg # After debug
+			42, # After debug expr
+	)
+	crash # Comment after crash keyword
+		"Unreachable!" # Comment after crash statement
+	tag_with_payload = Ok(number)
+	interpolated = "Hello, ${world}"
+	list = [
+		add_one(
+			dbg # After dbg in list
+				number, # after dbg expr as arg
+		), # Comment one
+		456, # Comment two
+		789, # Comment three
+	]
+	for n in list {
+		Stdout.line!("Adding ${n} to ${number}")
+		number = number + n
+	}
+	record = { foo: 123, bar: "Hello", baz: tag, qux: Ok(world), punned }
+	tuple = (123, "World", tag, Ok(world), (nested, tuple), [1, 2, 3])
+	multiline_tuple = (
+		123,
+		"World",
+		tag1,
+		Ok(world), # This one has a comment
+		(nested, tuple),
+		[1, 2, 3],
+	)
+	bin_op_result = Err(foo) ?? 12 > 5 * 5 or 13 + 2 < 5 and 10 - 1 >= 16 or 12 <= 3 / 5
+	static_dispatch_style = some_fn(arg1)?.static_dispatch_method()?.next_static_dispatch_method()?.record_field?
+	Stdout.line!(interpolated)?
+	Stdout.line!(
+		"How about ${ # Comment after string interpolation open
+			Num.toStr(number) # Comment after string interpolation expr
+		} as a string?",
+	)
+} # Comment after top-level decl
+
+empty : {}
+empty = {}
+
+tuple : Value((a, b, c))
+
+expect {
+	foo = 1 # This should work too
+	blah = 1
+	blah == foo
+}
+
+import pf.Stdout exposing [line!, write!]
+
+import # Comment after import keyword
+	pf # Comment after qualifier
+		.StdoutMultiline # Comment after ident
+		exposing [ # Comment after exposing open
+			line!, # Comment after exposed item
+			write!, # Another after exposed item
+		] # Comment after exposing close
+
+import pkg.Something exposing [func as function, Type as ValueCategory, Custom.*]
+
+import BadName as GoodName
+import
+	BadNameMultiline
+		as
+		GoodNameMultiline
+
+Map(a, b) : List(a), (a -> b) -> List(b)
+MapML( # Comment here
+	a, # And here
+	b,
+) # And after the last arg
+	: # And after the colon
+		List( # Inside Tag args
+			a, # After tag arg
+		),
+		(a -> b) -> # After arrow
+			List( # Inside tag args
+				b,
+			) # And after the type decl
+
+Foo : (Bar, Baz)
+
+FooMultiline : ( # Comment after pattern tuple open
+	Bar, # Comment after pattern tuple item
+	Baz, # Another after pattern tuple item
+) # Comment after pattern tuple close
+
+Some(a) : { foo : Ok(a), bar : Something }
+SomeMl(a) : { # After record open
+	foo : Ok(a), # After field
+	bar : Something, # After last field
+}
+
+SomeMultiline(a) : { # Comment after pattern record open
+	foo # After field name
+		: # Before field anno
+			Ok(a), # Comment after pattern record field
+	bar : Something, # Another after pattern record field
+} # Comment after pattern record close
+
+Maybe(a) : [Some(a), None]
+
+MaybeMultiline(a) : [ # Comment after tag union open
+	Some(a), # Comment after tag union member
+	None, # Another after tag union member
+] # Comment after tag union close
+
+SomeFunc(a) : Maybe(a), a -> Maybe(a)
+
+add_one_oneline = |num| if num 2 else 5
+
+add_one : U64 -> U64
+add_one = |num| {
+	other = 1
+	if num {
+		dbg # After debug
+			some_func() # After debug expr
+		0
+	} else {
+		dbg 123
+		other
+	}
+}
+
+match_time = |
+	a, # After arg
+	b,
+| # After args
+	match a {
+		Blue | Green | Red => {
+			x = 12
+			x
+		}
+		Blue # After pattern in alt
+		| # Before pattern in alt
+			Green
+		| Red # After alt pattern
+			=> {
+				x = 12
+				x
+			}
+		lower # After pattern comment
+			=> 1
+		"foo" => # After arrow comment
+			100
+		"foo" | "bar" => 200
+		[1, 2, 3, .. as rest] # After pattern comment
+			=> # After arrow comment
+				123 # After branch comment
+
+		# Just a random comment
+
+		[1, 2 | 5, 3, .. as rest] => 123
+		[
+			1,
+			2 | 5,
+			3,
+			.. # After DoubleDot
+				as # Before alias
+					rest, # After last pattern in list
+		] => 123
+		3.14 => 314
+		3.14 | 6.28 => 314
+		(1, 2, 3) => 123
+		(1, 2 | 5, 3) => 123
+		{ foo: 1, bar: 2, ..rest } => 12->add(34)
+		{ # After pattern record open
+			foo # After pattern record field name
+				: # Before pattern record field value
+					1, # After pattern record field
+			bar: 2,
+			.. # After spread operator
+				rest, # After last field
+		} => 12
+		{ foo: 1, bar: 2 | 7 } => 12
+		{
+			foo: 1,
+			bar: 2 | 7, # After last record field
+		} => 12
+		Ok(123) => 123
+		Ok(Some(dude)) => dude
+		TwoArgs("hello", Some("world")) => 1000
+	}
+
+expect # Comment after expect keyword
+	blah == 1 # Comment after expect statement
+
+main! : List(String) -> Result({}, _)
+main! = |_| { # Yeah I can leave a comment here
+	world = "World"
+	var number = 123
+	expect blah == 1
+	tag = Blue
+	return # Comment after return keyword
+		tag # Comment after return statement
+
+	# Just a random comment!
+
+	...
+	match_time(
+		..., # Single args with comment
+	)
+	some_func(
+		dbg # After debug
+			42, # After debug expr
+	)
+	crash # Comment after crash keyword
+		"Unreachable!" # Comment after crash statement
+	tag_with_payload = Ok(number)
+	interpolated = "Hello, ${world}"
+	list = [
+		add_one(
+			dbg # After dbg in list
+				number, # after dbg expr as arg
+		), # Comment one
+		456, # Comment two
+		789, # Comment three
+	]
+	for n in list {
+		Stdout.line!("Adding ${n} to ${number}")
+		number = number + n
+	}
+	record = { foo: 123, bar: "Hello", baz: tag, qux: Ok(world), punned }
+	tuple = (123, "World", tag, Ok(world), (nested, tuple), [1, 2, 3])
+	multiline_tuple = (
+		123,
+		"World",
+		tag1,
+		Ok(world), # This one has a comment
+		(nested, tuple),
+		[1, 2, 3],
+	)
+	bin_op_result = Err(foo) ?? 12 > 5 * 5 or 13 + 2 < 5 and 10 - 1 >= 16 or 12 <= 3 / 5
+	static_dispatch_style = some_fn(arg1)?.static_dispatch_method()?.next_static_dispatch_method()?.record_field?
+	Stdout.line!(interpolated)?
+	Stdout.line!(
+		"How about ${ # Comment after string interpolation open
+			Num.toStr(number) # Comment after string interpolation expr
+		} as a string?",
+	)
+} # Comment after top-level decl
+
+empty : {}
+empty = {}
+
+tuple : Value((a, b, c))
+
+expect {
+	foo = 1 # This should work too
+	blah = 1
+	blah == foo
+}
+
+import pf.Stdout exposing [line!, write!]
+
+import # Comment after import keyword
+	pf # Comment after qualifier
+		.StdoutMultiline # Comment after ident
+		exposing [ # Comment after exposing open
+			line!, # Comment after exposed item
+			write!, # Another after exposed item
+		] # Comment after exposing close
+
+import pkg.Something exposing [func as function, Type as ValueCategory, Custom.*]
+
+import BadName as GoodName
+import
+	BadNameMultiline
+		as
+		GoodNameMultiline
+
+Map(a, b) : List(a), (a -> b) -> List(b)
+MapML( # Comment here
+	a, # And here
+	b,
+) # And after the last arg
+	: # And after the colon
+		List( # Inside Tag args
+			a, # After tag arg
+		),
+		(a -> b) -> # After arrow
+			List( # Inside tag args
+				b,
+			) # And after the type decl
+
+Foo : (Bar, Baz)
+
+FooMultiline : ( # Comment after pattern tuple open
+	Bar, # Comment after pattern tuple item
+	Baz, # Another after pattern tuple item
+) # Comment after pattern tuple close
+
+Some(a) : { foo : Ok(a), bar : Something }
+SomeMl(a) : { # After record open
+	foo : Ok(a), # After field
+	bar : Something, # After last field
+}
+
+SomeMultiline(a) : { # Comment after pattern record open
+	foo # After field name
+		: # Before field anno
+			Ok(a), # Comment after pattern record field
+	bar : Something, # Another after pattern record field
+} # Comment after pattern record close
+
+Maybe(a) : [Some(a), None]
+
+MaybeMultiline(a) : [ # Comment after tag union open
+	Some(a), # Comment after tag union member
+	None, # Another after tag union member
+] # Comment after tag union close
+
+SomeFunc(a) : Maybe(a), a -> Maybe(a)
+
+add_one_oneline = |num| if num 2 else 5
+
+add_one : U64 -> U64
+add_one = |num| {
+	other = 1
+	if num {
+		dbg # After debug
+			some_func() # After debug expr
+		0
+	} else {
+		dbg 123
+		other
+	}
+}
+
+match_time = |
+	a, # After arg
+	b,
+| # After args
+	match a {
+		Blue | Green | Red => {
+			x = 12
+			x
+		}
+		Blue # After pattern in alt
+		| # Before pattern in alt
+			Green
+		| Red # After alt pattern
+			=> {
+				x = 12
+				x
+			}
+		lower # After pattern comment
+			=> 1
+		"foo" => # After arrow comment
+			100
+		"foo" | "bar" => 200
+		[1, 2, 3, .. as rest] # After pattern comment
+			=> # After arrow comment
+				123 # After branch comment
+
+		# Just a random comment
+
+		[1, 2 | 5, 3, .. as rest] => 123
+		[
+			1,
+			2 | 5,
+			3,
+			.. # After DoubleDot
+				as # Before alias
+					rest, # After last pattern in list
+		] => 123
+		3.14 => 314
+		3.14 | 6.28 => 314
+		(1, 2, 3) => 123
+		(1, 2 | 5, 3) => 123
+		{ foo: 1, bar: 2, ..rest } => 12->add(34)
+		{ # After pattern record open
+			foo # After pattern record field name
+				: # Before pattern record field value
+					1, # After pattern record field
+			bar: 2,
+			.. # After spread operator
+				rest, # After last field
+		} => 12
+		{ foo: 1, bar: 2 | 7 } => 12
+		{
+			foo: 1,
+			bar: 2 | 7, # After last record field
+		} => 12
+		Ok(123) => 123
+		Ok(Some(dude)) => dude
+		TwoArgs("hello", Some("world")) => 1000
+	}
+
+expect # Comment after expect keyword
+	blah == 1 # Comment after expect statement
+
+main! : List(String) -> Result({}, _)
+main! = |_| { # Yeah I can leave a comment here
+	world = "World"
+	var number = 123
+	expect blah == 1
+	tag = Blue
+	return # Comment after return keyword
+		tag # Comment after return statement
+
+	# Just a random comment!
+
+	...
+	match_time(
+		..., # Single args with comment
+	)
+	some_func(
+		dbg # After debug
+			42, # After debug expr
+	)
+	crash # Comment after crash keyword
+		"Unreachable!" # Comment after crash statement
+	tag_with_payload = Ok(number)
+	interpolated = "Hello, ${world}"
+	list = [
+		add_one(
+			dbg # After dbg in list
+				number, # after dbg expr as arg
+		), # Comment one
+		456, # Comment two
+		789, # Comment three
+	]
+	for n in list {
+		Stdout.line!("Adding ${n} to ${number}")
+		number = number + n
+	}
+	record = { foo: 123, bar: "Hello", baz: tag, qux: Ok(world), punned }
+	tuple = (123, "World", tag, Ok(world), (nested, tuple), [1, 2, 3])
+	multiline_tuple = (
+		123,
+		"World",
+		tag1,
+		Ok(world), # This one has a comment
+		(nested, tuple),
+		[1, 2, 3],
+	)
+	bin_op_result = Err(foo) ?? 12 > 5 * 5 or 13 + 2 < 5 and 10 - 1 >= 16 or 12 <= 3 / 5
+	static_dispatch_style = some_fn(arg1)?.static_dispatch_method()?.next_static_dispatch_method()?.record_field?
+	Stdout.line!(interpolated)?
+	Stdout.line!(
+		"How about ${ # Comment after string interpolation open
+			Num.toStr(number) # Comment after string interpolation expr
+		} as a string?",
+	)
+} # Comment after top-level decl
+
+empty : {}
+empty = {}
+
+tuple : Value((a, b, c))
+
+expect {
+	foo = 1 # This should work too
+	blah = 1
+	blah == foo
+}
+
+import pf.Stdout exposing [line!, write!]
+
+import # Comment after import keyword
+	pf # Comment after qualifier
+		.StdoutMultiline # Comment after ident
+		exposing [ # Comment after exposing open
+			line!, # Comment after exposed item
+			write!, # Another after exposed item
+		] # Comment after exposing close
+
+import pkg.Something exposing [func as function, Type as ValueCategory, Custom.*]
+
+import BadName as GoodName
+import
+	BadNameMultiline
+		as
+		GoodNameMultiline
+
+Map(a, b) : List(a), (a -> b) -> List(b)
+MapML( # Comment here
+	a, # And here
+	b,
+) # And after the last arg
+	: # And after the colon
+		List( # Inside Tag args
+			a, # After tag arg
+		),
+		(a -> b) -> # After arrow
+			List( # Inside tag args
+				b,
+			) # And after the type decl
+
+Foo : (Bar, Baz)
+
+FooMultiline : ( # Comment after pattern tuple open
+	Bar, # Comment after pattern tuple item
+	Baz, # Another after pattern tuple item
+) # Comment after pattern tuple close
+
+Some(a) : { foo : Ok(a), bar : Something }
+SomeMl(a) : { # After record open
+	foo : Ok(a), # After field
+	bar : Something, # After last field
+}
+
+SomeMultiline(a) : { # Comment after pattern record open
+	foo # After field name
+		: # Before field anno
+			Ok(a), # Comment after pattern record field
+	bar : Something, # Another after pattern record field
+} # Comment after pattern record close
+
+Maybe(a) : [Some(a), None]
+
+MaybeMultiline(a) : [ # Comment after tag union open
+	Some(a), # Comment after tag union member
+	None, # Another after tag union member
+] # Comment after tag union close
+
+SomeFunc(a) : Maybe(a), a -> Maybe(a)
+
+add_one_oneline = |num| if num 2 else 5
+
+add_one : U64 -> U64
+add_one = |num| {
+	other = 1
+	if num {
+		dbg # After debug
+			some_func() # After debug expr
+		0
+	} else {
+		dbg 123
+		other
+	}
+}
+
+match_time = |
+	a, # After arg
+	b,
+| # After args
+	match a {
+		Blue | Green | Red => {
+			x = 12
+			x
+		}
+		Blue # After pattern in alt
+		| # Before pattern in alt
+			Green
+		| Red # After alt pattern
+			=> {
+				x = 12
+				x
+			}
+		lower # After pattern comment
+			=> 1
+		"foo" => # After arrow comment
+			100
+		"foo" | "bar" => 200
+		[1, 2, 3, .. as rest] # After pattern comment
+			=> # After arrow comment
+				123 # After branch comment
+
+		# Just a random comment
+
+		[1, 2 | 5, 3, .. as rest] => 123
+		[
+			1,
+			2 | 5,
+			3,
+			.. # After DoubleDot
+				as # Before alias
+					rest, # After last pattern in list
+		] => 123
+		3.14 => 314
+		3.14 | 6.28 => 314
+		(1, 2, 3) => 123
+		(1, 2 | 5, 3) => 123
+		{ foo: 1, bar: 2, ..rest } => 12->add(34)
+		{ # After pattern record open
+			foo # After pattern record field name
+				: # Before pattern record field value
+					1, # After pattern record field
+			bar: 2,
+			.. # After spread operator
+				rest, # After last field
+		} => 12
+		{ foo: 1, bar: 2 | 7 } => 12
+		{
+			foo: 1,
+			bar: 2 | 7, # After last record field
+		} => 12
+		Ok(123) => 123
+		Ok(Some(dude)) => dude
+		TwoArgs("hello", Some("world")) => 1000
+	}
+
+expect # Comment after expect keyword
+	blah == 1 # Comment after expect statement
+
+main! : List(String) -> Result({}, _)
+main! = |_| { # Yeah I can leave a comment here
+	world = "World"
+	var number = 123
+	expect blah == 1
+	tag = Blue
+	return # Comment after return keyword
+		tag # Comment after return statement
+
+	# Just a random comment!
+
+	...
+	match_time(
+		..., # Single args with comment
+	)
+	some_func(
+		dbg # After debug
+			42, # After debug expr
+	)
+	crash # Comment after crash keyword
+		"Unreachable!" # Comment after crash statement
+	tag_with_payload = Ok(number)
+	interpolated = "Hello, ${world}"
+	list = [
+		add_one(
+			dbg # After dbg in list
+				number, # after dbg expr as arg
+		), # Comment one
+		456, # Comment two
+		789, # Comment three
+	]
+	for n in list {
+		Stdout.line!("Adding ${n} to ${number}")
+		number = number + n
+	}
+	record = { foo: 123, bar: "Hello", baz: tag, qux: Ok(world), punned }
+	tuple = (123, "World", tag, Ok(world), (nested, tuple), [1, 2, 3])
+	multiline_tuple = (
+		123,
+		"World",
+		tag1,
+		Ok(world), # This one has a comment
+		(nested, tuple),
+		[1, 2, 3],
+	)
+	bin_op_result = Err(foo) ?? 12 > 5 * 5 or 13 + 2 < 5 and 10 - 1 >= 16 or 12 <= 3 / 5
+	static_dispatch_style = some_fn(arg1)?.static_dispatch_method()?.next_static_dispatch_method()?.record_field?
+	Stdout.line!(interpolated)?
+	Stdout.line!(
+		"How about ${ # Comment after string interpolation open
+			Num.toStr(number) # Comment after string interpolation expr
+		} as a string?",
+	)
+} # Comment after top-level decl
+
+empty : {}
+empty = {}
+
+tuple : Value((a, b, c))
+
+expect {
+	foo = 1 # This should work too
+	blah = 1
+	blah == foo
+}
+
+import pf.Stdout exposing [line!, write!]
+
+import # Comment after import keyword
+	pf # Comment after qualifier
+		.StdoutMultiline # Comment after ident
+		exposing [ # Comment after exposing open
+			line!, # Comment after exposed item
+			write!, # Another after exposed item
+		] # Comment after exposing close
+
+import pkg.Something exposing [func as function, Type as ValueCategory, Custom.*]
+
+import BadName as GoodName
+import
+	BadNameMultiline
+		as
+		GoodNameMultiline
+
+Map(a, b) : List(a), (a -> b) -> List(b)
+MapML( # Comment here
+	a, # And here
+	b,
+) # And after the last arg
+	: # And after the colon
+		List( # Inside Tag args
+			a, # After tag arg
+		),
+		(a -> b) -> # After arrow
+			List( # Inside tag args
+				b,
+			) # And after the type decl
+
+Foo : (Bar, Baz)
+
+FooMultiline : ( # Comment after pattern tuple open
+	Bar, # Comment after pattern tuple item
+	Baz, # Another after pattern tuple item
+) # Comment after pattern tuple close
+
+Some(a) : { foo : Ok(a), bar : Something }
+SomeMl(a) : { # After record open
+	foo : Ok(a), # After field
+	bar : Something, # After last field
+}
+
+SomeMultiline(a) : { # Comment after pattern record open
+	foo # After field name
+		: # Before field anno
+			Ok(a), # Comment after pattern record field
+	bar : Something, # Another after pattern record field
+} # Comment after pattern record close
+
+Maybe(a) : [Some(a), None]
+
+MaybeMultiline(a) : [ # Comment after tag union open
+	Some(a), # Comment after tag union member
+	None, # Another after tag union member
+] # Comment after tag union close
+
+SomeFunc(a) : Maybe(a), a -> Maybe(a)
+
+add_one_oneline = |num| if num 2 else 5
+
+add_one : U64 -> U64
+add_one = |num| {
+	other = 1
+	if num {
+		dbg # After debug
+			some_func() # After debug expr
+		0
+	} else {
+		dbg 123
+		other
+	}
+}
+
+match_time = |
+	a, # After arg
+	b,
+| # After args
+	match a {
+		Blue | Green | Red => {
+			x = 12
+			x
+		}
+		Blue # After pattern in alt
+		| # Before pattern in alt
+			Green
+		| Red # After alt pattern
+			=> {
+				x = 12
+				x
+			}
+		lower # After pattern comment
+			=> 1
+		"foo" => # After arrow comment
+			100
+		"foo" | "bar" => 200
+		[1, 2, 3, .. as rest] # After pattern comment
+			=> # After arrow comment
+				123 # After branch comment
+
+		# Just a random comment
+
+		[1, 2 | 5, 3, .. as rest] => 123
+		[
+			1,
+			2 | 5,
+			3,
+			.. # After DoubleDot
+				as # Before alias
+					rest, # After last pattern in list
+		] => 123
+		3.14 => 314
+		3.14 | 6.28 => 314
+		(1, 2, 3) => 123
+		(1, 2 | 5, 3) => 123
+		{ foo: 1, bar: 2, ..rest } => 12->add(34)
+		{ # After pattern record open
+			foo # After pattern record field name
+				: # Before pattern record field value
+					1, # After pattern record field
+			bar: 2,
+			.. # After spread operator
+				rest, # After last field
+		} => 12
+		{ foo: 1, bar: 2 | 7 } => 12
+		{
+			foo: 1,
+			bar: 2 | 7, # After last record field
+		} => 12
+		Ok(123) => 123
+		Ok(Some(dude)) => dude
+		TwoArgs("hello", Some("world")) => 1000
+	}
+
+expect # Comment after expect keyword
+	blah == 1 # Comment after expect statement
+
+main! : List(String) -> Result({}, _)
+main! = |_| { # Yeah I can leave a comment here
+	world = "World"
+	var number = 123
+	expect blah == 1
+	tag = Blue
+	return # Comment after return keyword
+		tag # Comment after return statement
+
+	# Just a random comment!
+
+	...
+	match_time(
+		..., # Single args with comment
+	)
+	some_func(
+		dbg # After debug
+			42, # After debug expr
+	)
+	crash # Comment after crash keyword
+		"Unreachable!" # Comment after crash statement
+	tag_with_payload = Ok(number)
+	interpolated = "Hello, ${world}"
+	list = [
+		add_one(
+			dbg # After dbg in list
+				number, # after dbg expr as arg
+		), # Comment one
+		456, # Comment two
+		789, # Comment three
+	]
+	for n in list {
+		Stdout.line!("Adding ${n} to ${number}")
+		number = number + n
+	}
+	record = { foo: 123, bar: "Hello", baz: tag, qux: Ok(world), punned }
+	tuple = (123, "World", tag, Ok(world), (nested, tuple), [1, 2, 3])
+	multiline_tuple = (
+		123,
+		"World",
+		tag1,
+		Ok(world), # This one has a comment
+		(nested, tuple),
+		[1, 2, 3],
+	)
+	bin_op_result = Err(foo) ?? 12 > 5 * 5 or 13 + 2 < 5 and 10 - 1 >= 16 or 12 <= 3 / 5
+	static_dispatch_style = some_fn(arg1)?.static_dispatch_method()?.next_static_dispatch_method()?.record_field?
+	Stdout.line!(interpolated)?
+	Stdout.line!(
+		"How about ${ # Comment after string interpolation open
+			Num.toStr(number) # Comment after string interpolation expr
+		} as a string?",
+	)
+} # Comment after top-level decl
+
+empty : {}
+empty = {}
+
+tuple : Value((a, b, c))
+
+expect {
+	foo = 1 # This should work too
+	blah = 1
+	blah == foo
+}
+
+import pf.Stdout exposing [line!, write!]
+
+import # Comment after import keyword
+	pf # Comment after qualifier
+		.StdoutMultiline # Comment after ident
+		exposing [ # Comment after exposing open
+			line!, # Comment after exposed item
+			write!, # Another after exposed item
+		] # Comment after exposing close
+
+import pkg.Something exposing [func as function, Type as ValueCategory, Custom.*]
+
+import BadName as GoodName
+import
+	BadNameMultiline
+		as
+		GoodNameMultiline
+
+Map(a, b) : List(a), (a -> b) -> List(b)
+MapML( # Comment here
+	a, # And here
+	b,
+) # And after the last arg
+	: # And after the colon
+		List( # Inside Tag args
+			a, # After tag arg
+		),
+		(a -> b) -> # After arrow
+			List( # Inside tag args
+				b,
+			) # And after the type decl
+
+Foo : (Bar, Baz)
+
+FooMultiline : ( # Comment after pattern tuple open
+	Bar, # Comment after pattern tuple item
+	Baz, # Another after pattern tuple item
+) # Comment after pattern tuple close
+
+Some(a) : { foo : Ok(a), bar : Something }
+SomeMl(a) : { # After record open
+	foo : Ok(a), # After field
+	bar : Something, # After last field
+}
+
+SomeMultiline(a) : { # Comment after pattern record open
+	foo # After field name
+		: # Before field anno
+			Ok(a), # Comment after pattern record field
+	bar : Something, # Another after pattern record field
+} # Comment after pattern record close
+
+Maybe(a) : [Some(a), None]
+
+MaybeMultiline(a) : [ # Comment after tag union open
+	Some(a), # Comment after tag union member
+	None, # Another after tag union member
+] # Comment after tag union close
+
+SomeFunc(a) : Maybe(a), a -> Maybe(a)
+
+add_one_oneline = |num| if num 2 else 5
+
+add_one : U64 -> U64
+add_one = |num| {
+	other = 1
+	if num {
+		dbg # After debug
+			some_func() # After debug expr
+		0
+	} else {
+		dbg 123
+		other
+	}
+}
+
+match_time = |
+	a, # After arg
+	b,
+| # After args
+	match a {
+		Blue | Green | Red => {
+			x = 12
+			x
+		}
+		Blue # After pattern in alt
+		| # Before pattern in alt
+			Green
+		| Red # After alt pattern
+			=> {
+				x = 12
+				x
+			}
+		lower # After pattern comment
+			=> 1
+		"foo" => # After arrow comment
+			100
+		"foo" | "bar" => 200
+		[1, 2, 3, .. as rest] # After pattern comment
+			=> # After arrow comment
+				123 # After branch comment
+
+		# Just a random comment
+
+		[1, 2 | 5, 3, .. as rest] => 123
+		[
+			1,
+			2 | 5,
+			3,
+			.. # After DoubleDot
+				as # Before alias
+					rest, # After last pattern in list
+		] => 123
+		3.14 => 314
+		3.14 | 6.28 => 314
+		(1, 2, 3) => 123
+		(1, 2 | 5, 3) => 123
+		{ foo: 1, bar: 2, ..rest } => 12->add(34)
+		{ # After pattern record open
+			foo # After pattern record field name
+				: # Before pattern record field value
+					1, # After pattern record field
+			bar: 2,
+			.. # After spread operator
+				rest, # After last field
+		} => 12
+		{ foo: 1, bar: 2 | 7 } => 12
+		{
+			foo: 1,
+			bar: 2 | 7, # After last record field
+		} => 12
+		Ok(123) => 123
+		Ok(Some(dude)) => dude
+		TwoArgs("hello", Some("world")) => 1000
+	}
+
+expect # Comment after expect keyword
+	blah == 1 # Comment after expect statement
+
+main! : List(String) -> Result({}, _)
+main! = |_| { # Yeah I can leave a comment here
+	world = "World"
+	var number = 123
+	expect blah == 1
+	tag = Blue
+	return # Comment after return keyword
+		tag # Comment after return statement
+
+	# Just a random comment!
+
+	...
+	match_time(
+		..., # Single args with comment
+	)
+	some_func(
+		dbg # After debug
+			42, # After debug expr
+	)
+	crash # Comment after crash keyword
+		"Unreachable!" # Comment after crash statement
+	tag_with_payload = Ok(number)
+	interpolated = "Hello, ${world}"
+	list = [
+		add_one(
+			dbg # After dbg in list
+				number, # after dbg expr as arg
+		), # Comment one
+		456, # Comment two
+		789, # Comment three
+	]
+	for n in list {
+		Stdout.line!("Adding ${n} to ${number}")
+		number = number + n
+	}
+	record = { foo: 123, bar: "Hello", baz: tag, qux: Ok(world), punned }
+	tuple = (123, "World", tag, Ok(world), (nested, tuple), [1, 2, 3])
+	multiline_tuple = (
+		123,
+		"World",
+		tag1,
+		Ok(world), # This one has a comment
+		(nested, tuple),
+		[1, 2, 3],
+	)
+	bin_op_result = Err(foo) ?? 12 > 5 * 5 or 13 + 2 < 5 and 10 - 1 >= 16 or 12 <= 3 / 5
+	static_dispatch_style = some_fn(arg1)?.static_dispatch_method()?.next_static_dispatch_method()?.record_field?
+	Stdout.line!(interpolated)?
+	Stdout.line!(
+		"How about ${ # Comment after string interpolation open
+			Num.toStr(number) # Comment after string interpolation expr
+		} as a string?",
+	)
+} # Comment after top-level decl
+
+empty : {}
+empty = {}
+
+tuple : Value((a, b, c))
+
+expect {
+	foo = 1 # This should work too
+	blah = 1
+	blah == foo
+}
+
+import pf.Stdout exposing [line!, write!]
+
+import # Comment after import keyword
+	pf # Comment after qualifier
+		.StdoutMultiline # Comment after ident
+		exposing [ # Comment after exposing open
+			line!, # Comment after exposed item
+			write!, # Another after exposed item
+		] # Comment after exposing close
+
+import pkg.Something exposing [func as function, Type as ValueCategory, Custom.*]
+
+import BadName as GoodName
+import
+	BadNameMultiline
+		as
+		GoodNameMultiline
+
+Map(a, b) : List(a), (a -> b) -> List(b)
+MapML( # Comment here
+	a, # And here
+	b,
+) # And after the last arg
+	: # And after the colon
+		List( # Inside Tag args
+			a, # After tag arg
+		),
+		(a -> b) -> # After arrow
+			List( # Inside tag args
+				b,
+			) # And after the type decl
+
+Foo : (Bar, Baz)
+
+FooMultiline : ( # Comment after pattern tuple open
+	Bar, # Comment after pattern tuple item
+	Baz, # Another after pattern tuple item
+) # Comment after pattern tuple close
+
+Some(a) : { foo : Ok(a), bar : Something }
+SomeMl(a) : { # After record open
+	foo : Ok(a), # After field
+	bar : Something, # After last field
+}
+
+SomeMultiline(a) : { # Comment after pattern record open
+	foo # After field name
+		: # Before field anno
+			Ok(a), # Comment after pattern record field
+	bar : Something, # Another after pattern record field
+} # Comment after pattern record close
+
+Maybe(a) : [Some(a), None]
+
+MaybeMultiline(a) : [ # Comment after tag union open
+	Some(a), # Comment after tag union member
+	None, # Another after tag union member
+] # Comment after tag union close
+
+SomeFunc(a) : Maybe(a), a -> Maybe(a)
+
+add_one_oneline = |num| if num 2 else 5
+
+add_one : U64 -> U64
+add_one = |num| {
+	other = 1
+	if num {
+		dbg # After debug
+			some_func() # After debug expr
+		0
+	} else {
+		dbg 123
+		other
+	}
+}
+
+match_time = |
+	a, # After arg
+	b,
+| # After args
+	match a {
+		Blue | Green | Red => {
+			x = 12
+			x
+		}
+		Blue # After pattern in alt
+		| # Before pattern in alt
+			Green
+		| Red # After alt pattern
+			=> {
+				x = 12
+				x
+			}
+		lower # After pattern comment
+			=> 1
+		"foo" => # After arrow comment
+			100
+		"foo" | "bar" => 200
+		[1, 2, 3, .. as rest] # After pattern comment
+			=> # After arrow comment
+				123 # After branch comment
+
+		# Just a random comment
+
+		[1, 2 | 5, 3, .. as rest] => 123
+		[
+			1,
+			2 | 5,
+			3,
+			.. # After DoubleDot
+				as # Before alias
+					rest, # After last pattern in list
+		] => 123
+		3.14 => 314
+		3.14 | 6.28 => 314
+		(1, 2, 3) => 123
+		(1, 2 | 5, 3) => 123
+		{ foo: 1, bar: 2, ..rest } => 12->add(34)
+		{ # After pattern record open
+			foo # After pattern record field name
+				: # Before pattern record field value
+					1, # After pattern record field
+			bar: 2,
+			.. # After spread operator
+				rest, # After last field
+		} => 12
+		{ foo: 1, bar: 2 | 7 } => 12
+		{
+			foo: 1,
+			bar: 2 | 7, # After last record field
+		} => 12
+		Ok(123) => 123
+		Ok(Some(dude)) => dude
+		TwoArgs("hello", Some("world")) => 1000
+	}
+
+expect # Comment after expect keyword
+	blah == 1 # Comment after expect statement
+
+                                                    main! : List(String) -> Result({}, _)
+                                                    main! = |_| { # Yeah I can leave a comment here
+                                                   	world = "World"
+                                                   	var number = 123
+                                                   	expect blah == 1
+                                                   	tag = Blue
+                                                   	return # Comment after return keyword
+                                                  		tag # Comment after return statement
+
+                                                   	# Just a random comment!
+
+                                                   	...
+                                                   	match_time(
+                                                  		..., # Single args with comment
+                                                   	)
+                                                   	some_func(
+                                                  		dbg # After debug
+                                                 			42, # After debug expr
+                                                   	)
+                                                   	crash # Comment after crash keyword
+                                                  		"Unreachable!" # Comment after crash statement
+                                                   	tag_with_payload = Ok(number)
+                                                   	interpolated = "Hello, ${world}"
+                                                   	list = [
+                                                  		add_one(
+                                                 			dbg # After dbg in list
+                                                    				number, # after dbg expr as arg
+                                                  		), # Comment one
+                                                  		456, # Comment two
+                                                  		789, # Comment three
+                                                   	]
+                                                   	for n in list {
+                                                  		Stdout.line!("Adding ${n} to ${number}")
+                                                  		number = number + n
+                                                   	}
+                                                   	record = { foo: 123, bar: "Hello", baz: tag, qux: Ok(world), punned }
+                                                   	tuple = (123, "World", tag, Ok(world), (nested, tuple), [1, 2, 3])
+                                                   	multiline_tuple = (
+                                                  		123,
+                                                  		"World",
+                                                  		tag1,
+                                                  		Ok(world), # This one has a comment
+                                                  		(nested, tuple),
+                                                  		[1, 2, 3],
+                                                   	)
+                                                   	bin_op_result = Err(foo) ?? 12 > 5 * 5 or 13 + 2 < 5 and 10 - 1 >= 16 or 12 <= 3 / 5
+                                                   	static_dispatch_style = some_fn(arg1)?.static_dispatch_method()?.next_static_dispatch_method()?.record_field?
+                                                   	Stdout.line!(interpolated)?
+                                                   	Stdout.line!(
+                                                  		"How about ${ # Comment after string interpolation open
+                                                 			Num.toStr(number) # Comment after string interpolation expr
+                                                  		} as a string?",
+                                                   	)
+                                                    } # Comment after top-level decl
+
+                                                    empty : {}
+                                                                            empty = {}
+
+                                                    tuple : Value((a, b, c))
+
+                                                    expect {
+                                                   	foo = 1 # This should work too
+                                                   	blah = 1
+                                                   	blah == foo
+                                                    }

--- a/src/README.simd.md
+++ b/src/README.simd.md
@@ -1,0 +1,102 @@
+# SIMD Optimizations
+
+This document describes the SIMD (Single Instruction, Multiple Data) optimizations and how to configure them.
+
+## Overview
+
+Roc uses SIMD instructions to accelerate performance-critical operations by processing multiple data elements simultaneously. We detect the target CPU's SIMD capabilities and select optimal vector widths, while also providing manual override options for advanced users.
+
+## Current SIMD Implementations
+
+### chompTrivia (Tokenizer)
+
+**Location:** `src/check/parse/tokenize.zig`
+
+**Purpose:** The `chompTrivia` function processes whitespace characters (spaces, tabs, newlines, comments) during tokenization. This is a hot path in the compiler as source files often contain significant amounts of leading whitespace and indentation.
+
+**Why SIMD:** Traditional scalar processing examines one character at a time. SIMD allows processing 8-64 characters simultaneously, providing significant speedups for:
+- Files with deep indentation
+- Code with extensive whitespace
+- Large source files with many comments
+
+**Implementation Details:**
+- Processes chunks of uniform whitespace (all spaces or all tabs) using vector operations
+- Falls back to scalar processing for mixed content or special characters
+- Uses `@splat`, `@reduce`, and `@select` Zig SIMD builtins
+- Tracks SIMD usage for debugging and performance analysis
+
+## Build Configuration
+
+### Auto-Detection (Default)
+
+The build system automatically detects optimal SIMD width based on target CPU features:
+
+```bash
+# Uses auto-detected optimal SIMD width
+zig build
+zig build test
+zig build roc
+```
+
+**Detection Logic:**
+- **x86_64/x86:** AVX-512 (64 bytes) → AVX/AVX2 (32 bytes) → SSE2 (16 bytes) → SSE (8 bytes)
+- **ARM64:** NEON (16 bytes) → fallback (8 bytes)
+- **ARM:** NEON (16 bytes) → fallback (8 bytes)
+- **RISC-V:** Vector extension (16 bytes) → fallback (8 bytes)
+- **Other architectures:** Conservative 8-byte default
+
+### Manual Configuration
+
+#### Disable SIMD
+
+Use scalar processing only (useful for debugging or compatibility):
+
+```bash
+zig build -Dsimd=false
+zig build test -Dsimd=false
+zig build roc -Dsimd=false
+```
+
+#### Override SIMD Width
+
+Force a specific vector width (must be supported by target):
+
+```bash
+# Basic SIMD (8 bytes)
+zig build -Dsimd-width=8
+
+# SSE2/NEON (16 bytes)
+zig build -Dsimd-width=16
+
+# AVX/AVX2 (32 bytes)
+zig build -Dsimd-width=32
+
+# AVX-512 (64 bytes)
+zig build -Dsimd-width=64
+```
+
+#### Cross-Compilation Examples
+
+```bash
+# Target modern Intel CPU with AVX2
+zig build -Dtarget=x86_64-linux -Dcpu=haswell
+# Auto-detects: 32 bytes
+
+# Target older x86_64 with SSE2
+zig build -Dtarget=x86_64-linux -Dcpu=x86_64
+# Auto-detects: 16 bytes
+
+# Target ARM64 with NEON
+zig build -Dtarget=aarch64-linux
+# Auto-detects: 16 bytes
+
+# Force specific width on any target (if supported)
+zig build -Dtarget=x86_64-linux -Dsimd-width=32
+```
+
+## Build Options Reference
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `-Dsimd` | bool | `true` | Enable/disable all SIMD optimizations |
+| `-Dsimd-width` | int | auto-detected | SIMD vector width in bytes (8/16/32/64) |

--- a/test_chomp_perf.zig
+++ b/test_chomp_perf.zig
@@ -1,20 +1,14 @@
 const std = @import("std");
+const base = @import("src/base.zig");
 const tokenize = @import("src/check/parse/tokenize.zig");
 const Cursor = tokenize.Cursor;
+const Tokenizer = tokenize.Tokenizer;
 const Diagnostic = tokenize.Diagnostic;
 const build_options = @import("build_options");
 const fs = std.fs;
 
-const RUNS = 10000;
-const SIZES = [_]usize{
-    16,
-    64,
-    256,
-    1024,
-    4096,
-    16384,
-    // 65536, integer overflow in tokenize
-};
+const RUNS = 1000;
+const FILE_PATH = "src/BigFile.roc";
 
 pub fn main() !void {
     const stdout = std.io.getStdOut().writer();
@@ -24,43 +18,54 @@ pub fn main() !void {
     try stdout.print("SIMD Enabled: {}\n", .{comptime Cursor.isSimdEnabled()});
     try stdout.print("SIMD Width: {} bytes\n\n", .{comptime Cursor.getSimdWidth()});
 
-    // Test with a real Roc file
-    try stdout.print("Testing with a real Roc file (src/BigFile.roc):\n", .{});
+    try stdout.print("Testing with {s}\n", .{FILE_PATH});
     try stdout.print("Time (µs) | Throughput (MB/s) | SIMD Chunks | File Size (bytes)\n", .{});
     try stdout.print("------------------------------------------------------------\n", .{});
 
-    // Read the BigFile.roc
-    const file_path = "src/BigFile.roc";
-    const file = try fs.cwd().openFile(file_path, .{});
+    // Read the test file
+    const file = try fs.cwd().openFile(FILE_PATH, .{});
     defer file.close();
-
     const file_size = try file.getEndPos();
     const file_data = try file.readToEndAlloc(allocator, file_size);
     defer allocator.free(file_data);
 
-    // Warmup
-    for (0..10) |_| {
-        var messages = std.ArrayList(Diagnostic).init(allocator);
-        defer messages.deinit();
-
-        var cursor = Cursor.init(file_data, messages.items);
-        _ = cursor.chompTrivia();
-    }
-
     var timer = try std.time.Timer.start();
     var total_simd_chunks: u64 = 0;
+    var gpa_impl = std.heap.GeneralPurposeAllocator(.{}){};
+    defer {
+        _ = gpa_impl.deinit();
+    }
+    const gpa = gpa_impl.allocator();
 
+    // Tokenize multiple times
     const start = timer.read();
     for (0..RUNS) |_| {
+        var module_env = base.ModuleEnv.init(gpa);
+        defer module_env.deinit();
+
+        // Create tokenizer
+        var token_buffer = tokenize.TokenizedBuffer.initCapacity(&module_env, 1024);
+        defer token_buffer.deinit();
+
         var messages = std.ArrayList(Diagnostic).init(allocator);
         defer messages.deinit();
 
-        var cursor = Cursor.init(file_data, messages.items);
-        _ = cursor.chompTrivia();
-        total_simd_chunks += cursor.getChompTriviaSimdChunksProcessed();
+        var tokenizer = Tokenizer.init(
+            &module_env,
+            file_data,
+            messages.items,
+        );
+        defer tokenizer.deinit();
+
+        // Tokenize the entire file
+        tokenizer.tokenize();
+
+        // Count SIMD chunks - we need to access the cursor to get this
+        total_simd_chunks += tokenizer.cursor.getChompTriviaSimdChunksProcessed();
     }
     const end = timer.read();
 
+    // Summarise results
     const total_ns = end - start;
     const ns_per_run = total_ns / RUNS;
     const us_per_run = @as(f64, @floatFromInt(ns_per_run)) / 1000.0;
@@ -73,93 +78,4 @@ pub fn main() !void {
         avg_simd_chunks,
         file_size,
     });
-
-    // try stdout.print("Testing with all spaces:\n", .{});
-    // try stdout.print("Size (bytes) | Time (µs) | Throughput (MB/s) | SIMD Chunks\n", .{});
-    // try stdout.print("------------------------------------------------------------\n", .{});
-
-    // for (SIZES) |size| {
-    //     // Create test data
-    //     const data = try allocator.alloc(u8, size);
-    //     defer allocator.free(data);
-    //     @memset(data, ' ');
-
-    //     // Warmup
-    //     for (0..10) |_| {
-    //         var messages = std.ArrayList(Diagnostic).init(allocator);
-    //         defer messages.deinit();
-
-    //         var cursor = Cursor.init(data, messages.items);
-    //         _ = cursor.chompTrivia();
-    //     }
-
-    //     var timer = try std.time.Timer.start();
-    //     var total_simd_chunks: u64 = 0;
-
-    //     const start = timer.read();
-    //     for (0..RUNS) |_| {
-    //         var messages = std.ArrayList(Diagnostic).init(allocator);
-    //         defer messages.deinit();
-
-    //         var cursor = Cursor.init(data, messages.items);
-    //         _ = cursor.chompTrivia();
-    //         total_simd_chunks += cursor.getChompTriviaSimdChunksProcessed();
-    //     }
-    //     const end = timer.read();
-
-    //     const total_ns = end - start;
-    //     const ns_per_run = total_ns / RUNS;
-    //     const us_per_run = @as(f64, @floatFromInt(ns_per_run)) / 1000.0;
-    //     const throughput_mbps = @as(f64, @floatFromInt(size)) * 1000.0 / @as(f64, @floatFromInt(ns_per_run));
-    //     const avg_simd_chunks = total_simd_chunks / RUNS;
-
-    //     try stdout.print("{:>12} | {:>9.2} | {:>17.2} | {:>11}\n", .{
-    //         size,
-    //         us_per_run,
-    //         throughput_mbps,
-    //         avg_simd_chunks,
-    //     });
-    // }
-
-    // // Test mixed spaces and tabs
-    // try stdout.print("\nTesting with mixed spaces and tabs:\n", .{});
-    // try stdout.print("Size (bytes) | Time (µs) | Throughput (MB/s) | SIMD Chunks\n", .{});
-    // try stdout.print("------------------------------------------------------------\n", .{});
-
-    // for (SIZES) |size| {
-    //     const data = try allocator.alloc(u8, size);
-    //     defer allocator.free(data);
-
-    //     // Create alternating pattern
-    //     for (0..size) |i| {
-    //         data[i] = if (i % 2 == 0) ' ' else '\t';
-    //     }
-
-    //     var timer = try std.time.Timer.start();
-    //     var total_simd_chunks: u64 = 0;
-
-    //     const start = timer.read();
-    //     for (0..RUNS) |_| {
-    //         var messages = std.ArrayList(Diagnostic).init(allocator);
-    //         defer messages.deinit();
-
-    //         var cursor = Cursor.init(data, messages.items);
-    //         _ = cursor.chompTrivia();
-    //         total_simd_chunks += cursor.getChompTriviaSimdChunksProcessed();
-    //     }
-    //     const end = timer.read();
-
-    //     const total_ns = end - start;
-    //     const ns_per_run = total_ns / RUNS;
-    //     const us_per_run = @as(f64, @floatFromInt(ns_per_run)) / 1000.0;
-    //     const throughput_mbps = @as(f64, @floatFromInt(size)) * 1000.0 / @as(f64, @floatFromInt(ns_per_run));
-    //     const avg_simd_chunks = total_simd_chunks / RUNS;
-
-    //     try stdout.print("{:>12} | {:>9.2} | {:>17.2} | {:>11}\n", .{
-    //         size,
-    //         us_per_run,
-    //         throughput_mbps,
-    //         avg_simd_chunks,
-    //     });
-    // }
 }

--- a/test_chomp_perf.zig
+++ b/test_chomp_perf.zig
@@ -1,0 +1,165 @@
+const std = @import("std");
+const tokenize = @import("src/check/parse/tokenize.zig");
+const Cursor = tokenize.Cursor;
+const Diagnostic = tokenize.Diagnostic;
+const build_options = @import("build_options");
+const fs = std.fs;
+
+const RUNS = 10000;
+const SIZES = [_]usize{
+    16,
+    64,
+    256,
+    1024,
+    4096,
+    16384,
+    // 65536, integer overflow in tokenize
+};
+
+pub fn main() !void {
+    const stdout = std.io.getStdOut().writer();
+    const allocator = std.heap.page_allocator;
+
+    try stdout.print("=== chompTrivia Performance Test ===\n", .{});
+    try stdout.print("SIMD Enabled: {}\n", .{comptime Cursor.isSimdEnabled()});
+    try stdout.print("SIMD Width: {} bytes\n\n", .{comptime Cursor.getSimdWidth()});
+
+    // Test with a real Roc file
+    try stdout.print("Testing with a real Roc file (src/BigFile.roc):\n", .{});
+    try stdout.print("Time (µs) | Throughput (MB/s) | SIMD Chunks | File Size (bytes)\n", .{});
+    try stdout.print("------------------------------------------------------------\n", .{});
+
+    // Read the BigFile.roc
+    const file_path = "src/BigFile.roc";
+    const file = try fs.cwd().openFile(file_path, .{});
+    defer file.close();
+
+    const file_size = try file.getEndPos();
+    const file_data = try file.readToEndAlloc(allocator, file_size);
+    defer allocator.free(file_data);
+
+    // Warmup
+    for (0..10) |_| {
+        var messages = std.ArrayList(Diagnostic).init(allocator);
+        defer messages.deinit();
+
+        var cursor = Cursor.init(file_data, messages.items);
+        _ = cursor.chompTrivia();
+    }
+
+    var timer = try std.time.Timer.start();
+    var total_simd_chunks: u64 = 0;
+
+    const start = timer.read();
+    for (0..RUNS) |_| {
+        var messages = std.ArrayList(Diagnostic).init(allocator);
+        defer messages.deinit();
+
+        var cursor = Cursor.init(file_data, messages.items);
+        _ = cursor.chompTrivia();
+        total_simd_chunks += cursor.getChompTriviaSimdChunksProcessed();
+    }
+    const end = timer.read();
+
+    const total_ns = end - start;
+    const ns_per_run = total_ns / RUNS;
+    const us_per_run = @as(f64, @floatFromInt(ns_per_run)) / 1000.0;
+    const throughput_mbps = @as(f64, @floatFromInt(file_size)) * 1000.0 / @as(f64, @floatFromInt(ns_per_run));
+    const avg_simd_chunks = total_simd_chunks / RUNS;
+
+    try stdout.print("{:>9.2} | {:>17.2} | {:>11} | {:>17}\n", .{
+        us_per_run,
+        throughput_mbps,
+        avg_simd_chunks,
+        file_size,
+    });
+
+    // try stdout.print("Testing with all spaces:\n", .{});
+    // try stdout.print("Size (bytes) | Time (µs) | Throughput (MB/s) | SIMD Chunks\n", .{});
+    // try stdout.print("------------------------------------------------------------\n", .{});
+
+    // for (SIZES) |size| {
+    //     // Create test data
+    //     const data = try allocator.alloc(u8, size);
+    //     defer allocator.free(data);
+    //     @memset(data, ' ');
+
+    //     // Warmup
+    //     for (0..10) |_| {
+    //         var messages = std.ArrayList(Diagnostic).init(allocator);
+    //         defer messages.deinit();
+
+    //         var cursor = Cursor.init(data, messages.items);
+    //         _ = cursor.chompTrivia();
+    //     }
+
+    //     var timer = try std.time.Timer.start();
+    //     var total_simd_chunks: u64 = 0;
+
+    //     const start = timer.read();
+    //     for (0..RUNS) |_| {
+    //         var messages = std.ArrayList(Diagnostic).init(allocator);
+    //         defer messages.deinit();
+
+    //         var cursor = Cursor.init(data, messages.items);
+    //         _ = cursor.chompTrivia();
+    //         total_simd_chunks += cursor.getChompTriviaSimdChunksProcessed();
+    //     }
+    //     const end = timer.read();
+
+    //     const total_ns = end - start;
+    //     const ns_per_run = total_ns / RUNS;
+    //     const us_per_run = @as(f64, @floatFromInt(ns_per_run)) / 1000.0;
+    //     const throughput_mbps = @as(f64, @floatFromInt(size)) * 1000.0 / @as(f64, @floatFromInt(ns_per_run));
+    //     const avg_simd_chunks = total_simd_chunks / RUNS;
+
+    //     try stdout.print("{:>12} | {:>9.2} | {:>17.2} | {:>11}\n", .{
+    //         size,
+    //         us_per_run,
+    //         throughput_mbps,
+    //         avg_simd_chunks,
+    //     });
+    // }
+
+    // // Test mixed spaces and tabs
+    // try stdout.print("\nTesting with mixed spaces and tabs:\n", .{});
+    // try stdout.print("Size (bytes) | Time (µs) | Throughput (MB/s) | SIMD Chunks\n", .{});
+    // try stdout.print("------------------------------------------------------------\n", .{});
+
+    // for (SIZES) |size| {
+    //     const data = try allocator.alloc(u8, size);
+    //     defer allocator.free(data);
+
+    //     // Create alternating pattern
+    //     for (0..size) |i| {
+    //         data[i] = if (i % 2 == 0) ' ' else '\t';
+    //     }
+
+    //     var timer = try std.time.Timer.start();
+    //     var total_simd_chunks: u64 = 0;
+
+    //     const start = timer.read();
+    //     for (0..RUNS) |_| {
+    //         var messages = std.ArrayList(Diagnostic).init(allocator);
+    //         defer messages.deinit();
+
+    //         var cursor = Cursor.init(data, messages.items);
+    //         _ = cursor.chompTrivia();
+    //         total_simd_chunks += cursor.getChompTriviaSimdChunksProcessed();
+    //     }
+    //     const end = timer.read();
+
+    //     const total_ns = end - start;
+    //     const ns_per_run = total_ns / RUNS;
+    //     const us_per_run = @as(f64, @floatFromInt(ns_per_run)) / 1000.0;
+    //     const throughput_mbps = @as(f64, @floatFromInt(size)) * 1000.0 / @as(f64, @floatFromInt(ns_per_run));
+    //     const avg_simd_chunks = total_simd_chunks / RUNS;
+
+    //     try stdout.print("{:>12} | {:>9.2} | {:>17.2} | {:>11}\n", .{
+    //         size,
+    //         us_per_run,
+    //         throughput_mbps,
+    //         avg_simd_chunks,
+    //     });
+    // }
+}


### PR DESCRIPTION
Implement a fast path for the tokeniser `chompTrivia` using Zig Vector builtins to operate on bytes in parallel using SIMD operators.