### PR TITLE
Make types store descriptors use multi list

### DIFF
--- a/src/types/store.zig
+++ b/src/types/store.zig
@@ -369,12 +369,13 @@ const SlotStore = struct {
 const DescStore = struct {
     const Self = @This();
 
-    backing: std.ArrayListUnmanaged(Desc),
+    backing: std.MultiArrayList(Desc),
 
     /// Init & allocated memory
     fn init(gpa: std.mem.Allocator, capacity: usize) Self {
-        const arr_list = std.ArrayListUnmanaged(Desc).initCapacity(gpa, capacity) catch |err| exitOnOutOfMemory(err);
-        return .{ .backing = arr_list };
+        var arr = std.MultiArrayList(Desc){};
+        arr.ensureUnusedCapacity(gpa, capacity) catch |err| exitOnOutOfMemory(err);
+        return .{ .backing = arr };
     }
 
     /// Deinit & free allocated memory
@@ -384,19 +385,19 @@ const DescStore = struct {
 
     /// Insert a value into the store
     fn insert(self: *Self, gpa: std.mem.Allocator, typ: Desc) Idx {
-        const idx: Idx = @enumFromInt(self.backing.items.len);
+        const idx: Idx = @enumFromInt(self.backing.len);
         self.backing.append(gpa, typ) catch |err| exitOnOutOfMemory(err);
         return idx;
     }
 
     /// Set a value in the store
     fn set(self: *Self, idx: Idx, val: Desc) void {
-        self.backing.items[@intFromEnum(idx)] = val;
+        self.backing.set(@intFromEnum(idx), val);
     }
 
     /// Get a value from the store
     fn get(self: *const Self, idx: Idx) Desc {
-        return self.backing.items[@intFromEnum(idx)];
+        return self.backing.get(@intFromEnum(idx));
     }
 
     /// A type-safe index into the store


### PR DESCRIPTION
Update type descriptors backing type from `ArrayList` to `MultiArrayList`. This is more efficient representation and unlocks things like [what's described in this comment](https://github.com/roc-lang/roc/pull/7811#discussion_r2134926544).