### PR TITLE
Make ModuleEnv own types.Store

### DIFF
--- a/src/base/ModuleEnv.zig
+++ b/src/base/ModuleEnv.zig
@@ -21,6 +21,7 @@ gpa: std.mem.Allocator,
 idents: Ident.Store = .{},
 ident_ids_for_slicing: collections.SafeList(Ident.Idx),
 strings: StringLiteral.Store,
+types_store: type_mod.Store,
 problems: Problem.List,
 
 /// Initialize the module environment.
@@ -31,6 +32,7 @@ pub fn init(gpa: std.mem.Allocator) Self {
         .idents = Ident.Store.initCapacity(gpa, 1024),
         .ident_ids_for_slicing = collections.SafeList(Ident.Idx).initCapacity(gpa, 256),
         .strings = StringLiteral.Store.initCapacityBytes(gpa, 4096),
+        .types_store = type_mod.Store.initCapacity(gpa, 2048, 512),
         .problems = Problem.List.initCapacity(gpa, 64),
     };
 }
@@ -40,5 +42,6 @@ pub fn deinit(self: *Self) void {
     self.idents.deinit(self.gpa);
     self.ident_ids_for_slicing.deinit(self.gpa);
     self.strings.deinit(self.gpa);
+    self.types_store.deinit();
     self.problems.deinit(self.gpa);
 }

--- a/src/check/canonicalize.zig
+++ b/src/check/canonicalize.zig
@@ -289,7 +289,7 @@ fn canonicalize_decl(
     const expr_idx = self.canonicalize_expr(decl.body) orelse return null;
 
     // Create a new type variable for this definition
-    const expr_var = self.can_ir.type_store.fresh();
+    const expr_var = self.can_ir.env.types_store.fresh();
 
     // Create the def entry
     return self.can_ir.store.addDef(.{
@@ -393,8 +393,8 @@ pub fn canonicalize_expr(
                 });
             };
 
-            const fresh_num_var = self.can_ir.type_store.fresh();
-            const fresh_prec_var = self.can_ir.type_store.fresh();
+            const fresh_num_var = self.can_ir.env.types_store.fresh();
+            const fresh_prec_var = self.can_ir.env.types_store.fresh();
 
             const int_expr = CIR.Expr{
                 .int = .{
@@ -436,8 +436,8 @@ pub fn canonicalize_expr(
                 });
             };
 
-            const fresh_num_var = self.can_ir.type_store.fresh();
-            const fresh_prec_var = self.can_ir.type_store.fresh();
+            const fresh_num_var = self.can_ir.env.types_store.fresh();
+            const fresh_prec_var = self.can_ir.env.types_store.fresh();
 
             const float_expr = CIR.Expr{
                 .float = .{
@@ -493,7 +493,7 @@ pub fn canonicalize_expr(
                 }
             }
 
-            const fresh_type_var = self.can_ir.type_store.fresh();
+            const fresh_type_var = self.can_ir.env.types_store.fresh();
 
             // Mark the start of scratch expressions for the list
             const scratch_top = self.can_ir.store.scratchExprTop();
@@ -521,8 +521,8 @@ pub fn canonicalize_expr(
         },
         .tag => |e| {
             if (self.parse_ir.tokens.resolveIdentifier(e.token)) |tag_name| {
-                const fresh_type_var_tag_union = self.can_ir.type_store.fresh();
-                const fresh_type_var_ext = self.can_ir.type_store.fresh();
+                const fresh_type_var_tag_union = self.can_ir.env.types_store.fresh();
+                const fresh_type_var_ext = self.can_ir.env.types_store.fresh();
 
                 const tag_expr = CIR.Expr{
                     .tag = .{
@@ -914,8 +914,8 @@ fn canonicalize_pattern(
                 return null;
             };
 
-            const fresh_num_var = self.can_ir.type_store.fresh();
-            const fresh_precision_var = self.can_ir.type_store.fresh();
+            const fresh_num_var = self.can_ir.env.types_store.fresh();
+            const fresh_precision_var = self.can_ir.env.types_store.fresh();
 
             const int_pattern = CIR.Pattern{
                 .int_literal = .{
@@ -956,8 +956,8 @@ fn canonicalize_pattern(
                     .len = 867,
                 } };
 
-                const fresh_num_var = self.can_ir.type_store.fresh();
-                const fresh_ext_var = self.can_ir.type_store.fresh();
+                const fresh_num_var = self.can_ir.env.types_store.fresh();
+                const fresh_ext_var = self.can_ir.env.types_store.fresh();
 
                 const tag_pattern = CIR.Pattern{
                     .applied_tag = .{

--- a/src/check/canonicalize/CIR.zig
+++ b/src/check/canonicalize/CIR.zig
@@ -28,7 +28,6 @@ env: base.ModuleEnv,
 store: NodeStore,
 ingested_files: IngestedFile.List,
 imports: ModuleImport.Store,
-type_store: types.Store,
 top_level_defs: Def.Span,
 
 /// Initialize the IR for a module's canonicalization info.
@@ -42,15 +41,15 @@ top_level_defs: Def.Span,
 /// Since the can IR holds indices into the `ModuleEnv`, we need
 /// the `ModuleEnv` to also be owned by the can IR to cache it.
 ///
-/// Takes ownership of the module_env and type_store
-pub fn init(env: ModuleEnv, type_store: types.Store) CIR {
+/// Takes ownership of the module_env
+pub fn init(env: ModuleEnv) CIR {
     // TODO: Figure out what capacity should be
-    return CIR.initCapacity(env, type_store, 1000);
+    return CIR.initCapacity(env, 1000);
 }
 
 /// Initialize the IR for a module's canonicalization info with a specified capacity.
 /// For more information refer to documentation on [init] as well
-pub fn initCapacity(env: ModuleEnv, type_store: types.Store, capacity: usize) CIR {
+pub fn initCapacity(env: ModuleEnv, capacity: usize) CIR {
     var ident_store = env.idents;
 
     return CIR{
@@ -58,7 +57,6 @@ pub fn initCapacity(env: ModuleEnv, type_store: types.Store, capacity: usize) CI
         .store = NodeStore.initCapacity(env.gpa, capacity),
         .ingested_files = .{},
         .imports = ModuleImport.Store.init(&.{}, &ident_store, env.gpa),
-        .type_store = type_store,
         .top_level_defs = .{ .span = .{ .start = 0, .len = 0 } },
     };
 }
@@ -68,7 +66,6 @@ pub fn deinit(self: *CIR) void {
     self.store.deinit();
     self.ingested_files.deinit(self.env.gpa);
     self.imports.deinit(self.env.gpa);
-    self.type_store.deinit();
 }
 
 // Helper to add type index info

--- a/src/check/check_types.zig
+++ b/src/check/check_types.zig
@@ -16,15 +16,15 @@ const ModuleWork = base.ModuleWork;
 /// Solves for the types of expressions in the ResolveIR and populates this
 /// information in the module's type store.
 pub fn checkTypes(
-    type_store: *types.Store,
+    types_store: *types.Store,
     resolve_ir: *const resolve.IR,
     other_modules: *const ModuleWork(resolve.IR).Store,
-    other_typestores: *const ModuleWork(types.Store).Store,
+    other_types_stores: *const ModuleWork(types.Store).Store,
 ) void {
-    _ = type_store;
+    _ = types_store;
     _ = resolve_ir;
     _ = other_modules;
-    _ = other_typestores;
+    _ = other_types_stores;
 
     // TODO: implement
 }
@@ -35,20 +35,18 @@ test "checkTypes - basic type unification" {
     var module_env = ModuleEnv.init(gpa);
     defer module_env.deinit();
 
-    var type_store = types.Store.init(&module_env);
-
     var can_irs = ModuleWork(can.CIR).Store.fromCanIrs(
         gpa,
         &.{ModuleWork(can.CIR){
             .package_idx = @enumFromInt(1),
             .module_idx = @enumFromInt(0),
-            .work = can.CIR.init(module_env, type_store),
+            .work = can.CIR.init(module_env),
         }},
     );
     defer can_irs.deinit(gpa);
 
-    var type_stores = ModuleWork(types.Store).Store.initFromCanIrs(gpa, &can_irs);
-    defer type_stores.deinit(gpa);
+    var other_types_stores = ModuleWork(types.Store).Store.initFromCanIrs(gpa, &can_irs);
+    defer other_types_stores.deinit(gpa);
 
     var resolve_irs = ModuleWork(resolve.IR).Store.initFromCanIrs(gpa, &can_irs);
     defer resolve_irs.deinit(gpa);
@@ -58,10 +56,11 @@ test "checkTypes - basic type unification" {
 
     var env = can_irs.getWork(@enumFromInt(0)).env;
     const resolve_ir = resolve_irs.getWork(@enumFromInt(0));
-    // TODO how should the type_store be passed around?
-    // const type_store = type_stores.getWork(@enumFromInt(0));
 
-    checkTypes(&type_store, resolve_ir, &resolve_irs, &type_stores);
+    checkTypes(&module_env.types_store, resolve_ir, &resolve_irs, &other_types_stores);
+
+    // TODO: Remove below once we have real tests for `checkTypes`. This is
+    // here now so unify tests are run
 
     // Test that we can perform basic type unification
     const flex = types.Content{ .flex_var = null };
@@ -69,13 +68,13 @@ test "checkTypes - basic type unification" {
     const rigid_name = env.idents.insert(env.gpa, Ident.for_text("b"), Region.zero());
     const rigid = types.Content{ .rigid_var = rigid_name };
 
-    const a_type_var = type_store.freshFromContent(flex);
-    const b_type_var = type_store.freshFromContent(rigid);
+    const a_type_var = module_env.types_store.freshFromContent(flex);
+    const b_type_var = module_env.types_store.freshFromContent(rigid);
 
     // After unification, both variables should have the rigid type
-    const result = unify.unify(&type_store, &scratch, a_type_var, b_type_var);
+    const result = unify.unify(&module_env, &module_env.types_store, &scratch, a_type_var, b_type_var);
 
     try testing.expectEqual(.ok, result);
-    try testing.expectEqual(rigid, type_store.resolveVar(a_type_var).desc.content);
-    try testing.expectEqual(rigid, type_store.resolveVar(b_type_var).desc.content);
+    try testing.expectEqual(rigid, module_env.types_store.resolveVar(a_type_var).desc.content);
+    try testing.expectEqual(rigid, module_env.types_store.resolveVar(b_type_var).desc.content);
 }

--- a/src/check/check_types/occurs.zig
+++ b/src/check/check_types/occurs.zig
@@ -342,10 +342,7 @@ const Scratch = struct {
 test "occurs: no recurcion (v = Str)" {
     const gpa = std.testing.allocator;
 
-    var module_env = base.ModuleEnv.init(gpa);
-    defer module_env.deinit();
-
-    var types_store = Store.init(&module_env);
+    var types_store = Store.init(gpa);
     defer types_store.deinit();
 
     var scratch = Scratch.init(gpa);
@@ -359,10 +356,7 @@ test "occurs: no recurcion (v = Str)" {
 
 test "occurs: direct recursion (v = List v)" {
     const gpa = std.testing.allocator;
-    var module_env = base.ModuleEnv.init(gpa);
-    defer module_env.deinit();
-
-    var types_store = Store.init(&module_env);
+    var types_store = Store.init(gpa);
     defer types_store.deinit();
 
     var scratch = Scratch.init(gpa);
@@ -384,10 +378,7 @@ test "occurs: direct recursion (v = List v)" {
 
 test "occurs: indirect recursion (v1 = Box v2, v2 = List v1)" {
     const gpa = std.testing.allocator;
-    var module_env = base.ModuleEnv.init(gpa);
-    defer module_env.deinit();
-
-    var types_store = Store.init(&module_env);
+    var types_store = Store.init(gpa);
     defer types_store.deinit();
 
     var scratch = Scratch.init(gpa);
@@ -410,10 +401,7 @@ test "occurs: indirect recursion (v1 = Box v2, v2 = List v1)" {
 
 test "occurs: no recursion through two levels (v1 = Box v2, v2 = Str)" {
     const gpa = std.testing.allocator;
-    var module_env = base.ModuleEnv.init(gpa);
-    defer module_env.deinit();
-
-    var types_store = Store.init(&module_env);
+    var types_store = Store.init(gpa);
     defer types_store.deinit();
 
     var scratch = Scratch.init(gpa);
@@ -431,10 +419,7 @@ test "occurs: no recursion through two levels (v1 = Box v2, v2 = Str)" {
 
 test "occurs: tuple recursion (v = Tuple(v, Str))" {
     const gpa = std.testing.allocator;
-    var module_env = base.ModuleEnv.init(gpa);
-    defer module_env.deinit();
-
-    var types_store = Store.init(&module_env);
+    var types_store = Store.init(gpa);
     defer types_store.deinit();
 
     var scratch = Scratch.init(gpa);
@@ -458,10 +443,7 @@ test "occurs: tuple recursion (v = Tuple(v, Str))" {
 
 test "occurs: tuple not recursive (v = Tuple(Str, Str))" {
     const gpa = std.testing.allocator;
-    var module_env = base.ModuleEnv.init(gpa);
-    defer module_env.deinit();
-
-    var types_store = Store.init(&module_env);
+    var types_store = Store.init(gpa);
     defer types_store.deinit();
 
     var scratch = Scratch.init(gpa);
@@ -482,10 +464,7 @@ test "occurs: tuple not recursive (v = Tuple(Str, Str))" {
 
 test "occurs: recursive alias (v = Alias(List v))" {
     const gpa = std.testing.allocator;
-    var module_env = base.ModuleEnv.init(gpa);
-    defer module_env.deinit();
-
-    var types_store = Store.init(&module_env);
+    var types_store = Store.init(gpa);
     defer types_store.deinit();
 
     var scratch = Scratch.init(gpa);
@@ -514,10 +493,7 @@ test "occurs: recursive alias (v = Alias(List v))" {
 
 test "occurs: alias with no recursion (v = Alias Str)" {
     const gpa = std.testing.allocator;
-    var module_env = base.ModuleEnv.init(gpa);
-    defer module_env.deinit();
-
-    var types_store = Store.init(&module_env);
+    var types_store = Store.init(gpa);
     defer types_store.deinit();
 
     var scratch = Scratch.init(gpa);
@@ -540,10 +516,7 @@ test "occurs: alias with no recursion (v = Alias Str)" {
 
 test "occurs: recursive tag union (v = [ Cons(elem, v), Nil ]" {
     const gpa = std.testing.allocator;
-    var module_env = base.ModuleEnv.init(gpa);
-    defer module_env.deinit();
-
-    var types_store = Store.init(&module_env);
+    var types_store = Store.init(gpa);
     defer types_store.deinit();
 
     var scratch = Scratch.init(gpa);
@@ -577,10 +550,7 @@ test "occurs: recursive tag union (v = [ Cons(elem, v), Nil ]" {
 }
 test "occurs: nested recursive tag union (v = [ Cons(elem, Box(v)) ] )" {
     const gpa = std.testing.allocator;
-    var module_env = base.ModuleEnv.init(gpa);
-    defer module_env.deinit();
-
-    var types_store = Store.init(&module_env);
+    var types_store = Store.init(gpa);
     defer types_store.deinit();
 
     var scratch = Scratch.init(gpa);
@@ -620,10 +590,7 @@ test "occurs: nested recursive tag union (v = [ Cons(elem, Box(v)) ] )" {
 
 test "occurs: recursive tag union (v = List: [ Cons(Elem, List), Nil ])" {
     const gpa = std.testing.allocator;
-    var module_env = base.ModuleEnv.init(gpa);
-    defer module_env.deinit();
-
-    var types_store = Store.init(&module_env);
+    var types_store = Store.init(gpa);
     defer types_store.deinit();
 
     var scratch = Scratch.init(gpa);
@@ -688,10 +655,7 @@ test "occurs: recursive tag union (v = List: [ Cons(Elem, List), Nil ])" {
 
 test "occurs: recursive tag union with multiple nominals (TypeA := TypeB, TypeB := [ Cons(Elem, TypeA), Nil ])" {
     const gpa = std.testing.allocator;
-    var module_env = base.ModuleEnv.init(gpa);
-    defer module_env.deinit();
-
-    var types_store = Store.init(&module_env);
+    var types_store = Store.init(gpa);
     defer types_store.deinit();
 
     var scratch = Scratch.init(gpa);

--- a/src/coordinate.zig
+++ b/src/coordinate.zig
@@ -42,7 +42,6 @@ pub const TypecheckResult = union(enum) {
         main_module_idx: ModuleWorkIdx,
         can_irs: ModuleWork(can.CIR).Store,
         resolve_irs: ModuleWork(resolve.IR).Store,
-        type_stores: ModuleWork(types.Store).Store,
     };
 
     /// Failure to typecheck a module.
@@ -135,11 +134,12 @@ pub fn typecheckModule(
         resolve.resolveImports(resolve_irs.getWork(idx), can_irs.getWork(idx), &resolve_irs);
     }
 
-    const type_stores = ModuleWork(types.Store).Store.initFromCanIrs(gpa, &can_irs);
-    index_iter = type_stores.iterIndices();
-    while (index_iter.next()) |idx| {
-        check_types.checkTypes(type_stores.getWork(idx), resolve_irs.getWork(idx), &resolve_irs, &type_stores);
-    }
+    // TODO
+    // const type_stores = ModuleWork(types.Store).Store.initFromCanIrs(gpa, &can_irs);
+    // index_iter = type_stores.iterIndices();
+    // while (index_iter.next()) |idx| {
+    //     check_types.checkTypes(type_stores.getWork(idx), resolve_irs.getWork(idx), &resolve_irs, &type_stores);
+    // }
 
     return .{
         .success = .{
@@ -147,7 +147,6 @@ pub fn typecheckModule(
             .main_module_idx = main_module_idx.?,
             .can_irs = can_irs,
             .resolve_irs = resolve_irs,
-            .type_stores = type_stores,
         },
     };
 }

--- a/src/coordinate/ModuleGraph.zig
+++ b/src/coordinate/ModuleGraph.zig
@@ -108,12 +108,11 @@ fn loadOrCompileCanIr(
 
     return if (cache_lookup) |ir| ir else blk: {
         var module_env = base.ModuleEnv.init(gpa);
-        const type_store = types.Store.init(&module_env);
 
         var parse_ir = parse.parse(&module_env, contents);
         parse_ir.store.emptyScratch();
 
-        var can_ir = Can.CIR.init(module_env, type_store);
+        var can_ir = Can.CIR.init(module_env);
         var scope = Scope.init(&can_ir.env, &.{}, &.{});
         defer scope.deinit();
         var can = Can.init(&can_ir, &parse_ir, &scope);

--- a/src/snapshot.zig
+++ b/src/snapshot.zig
@@ -450,11 +450,9 @@ fn processSnapshotFile(gpa: Allocator, snapshot_path: []const u8, maybe_fuzz_cor
     // shouldn't be required in future
     parse_ast.store.emptyScratch();
 
-    const type_store = types.Store.init(&module_env);
-
     // Canonicalize the source code
     // Can.IR.init takes ownership of the module_env and type_store
-    var can_ir = Can.CIR.init(module_env, type_store);
+    var can_ir = Can.CIR.init(module_env);
     defer can_ir.deinit();
 
     var scope = Scope.init(&can_ir.env, &.{}, &.{});


### PR DESCRIPTION
This PR makes `ModuleEnv` own the type store (instead of the other way around, which is what we currently have), as discussed in Zulip. 

This was fairly straightforward with the only exception of `coordinate.zig`. Previously, type stores were created for each module through the `ModuleWork` abstraction. I'm not really sure the intended semantics of `ModuleWork`, so I'm not sure how to port this, and I've left it as a `TODO` for now. I'm happy to make whatever change is necessary, if anyone could give me some direction 😄 