### PR TITLE
Add recursion check to unify

### DIFF
--- a/src/check/check_types/occurs.zig
+++ b/src/check/check_types/occurs.zig
@@ -266,7 +266,7 @@ const Context = struct {
 };
 
 /// Struct to hold intermediate values used during occurs check
-const Scratch = struct {
+pub const Scratch = struct {
     const Self = @This();
 
     gpa: std.mem.Allocator,
@@ -276,7 +276,7 @@ const Scratch = struct {
     err_chain_nominal_vars: Var.SafeList,
     visited: MkSafeList(DescStoreIdx),
 
-    fn init(gpa: std.mem.Allocator) Self {
+    pub fn init(gpa: std.mem.Allocator) Self {
         // TODO: eventually use herusitics here to determine sensible defaults
         // Rust compiler inits with 1024 capacity. But that feels like a lot.
         // Typical recursion cases should only be a few layers deep?
@@ -289,14 +289,14 @@ const Scratch = struct {
         };
     }
 
-    fn deinit(self: *Self) void {
+    pub fn deinit(self: *Self) void {
         self.seen.deinit(self.gpa);
         self.err_chain.deinit(self.gpa);
         self.err_chain_nominal_vars.deinit(self.gpa);
         self.visited.deinit(self.gpa);
     }
 
-    fn reset(self: *Self) void {
+    pub fn reset(self: *Self) void {
         self.seen.items.clearRetainingCapacity();
         self.err_chain.items.clearRetainingCapacity();
         self.err_chain_nominal_vars.items.clearRetainingCapacity();

--- a/src/test.zig
+++ b/src/test.zig
@@ -10,6 +10,5 @@ test {
     testing.refAllDeclsRecursive(@import("reporting/test.zig"));
     testing.refAllDeclsRecursive(@import("eval/stack.zig"));
     testing.refAllDeclsRecursive(@import("check/check_types/unify.zig"));
-    testing.refAllDeclsRecursive(@import("check/check_types/occurs.zig"));
     testing.refAllDeclsRecursive(@import("snapshot.zig"));
 }


### PR DESCRIPTION
### Overview

This MR updates `unify` to add a recursion check.

The strategy here is to track the depth of recursion in `unify`, and if we exceed a certain depth (currently 8), we do a full occur check. The thinking here is that the vast majority of types are not recursive and so should not pay the cost of running the occurs check unless absolutely necessary. 

The potential drawback to this strategy is that simple recursive types, such as `A := (Str, A)` will loop several times before we detect that it is infinite. However, given that error like this are fairly uncommon, this price seems reasonable to pay. 

### Reworking `unify` error strategy

Additionally, this MR reworks `unify`s error strategy. Since errors in zig cannot include payloads, `unify` now captures error-related data is by setting a field in `Scratch` _before_ throwing. Then in the root `unify` function we catch the error, pull out the data from the scratch field, and turn it into a nice tag union for the consumers of `unify`. 
