### PR TITLE
Fix bug in def regions

### DIFF
--- a/src/check/canonicalize/CIR.zig
+++ b/src/check/canonicalize/CIR.zig
@@ -157,10 +157,10 @@ pub fn pushFreshTypeVar(self: *CIR, parent_node_idx: Node.Idx, region: base.Regi
 /// specified content in the types store at that index
 pub fn pushTypeVar(self: *CIR, content: types.Content, parent_node_idx: Node.Idx, region: base.Region) types.Var {
     // insert a placeholder can node
-    const placeholder_node_idx = self.store.addTypePlaceholder(parent_node_idx, region);
+    const var_slot = self.store.addTypeVarSlot(parent_node_idx, region);
 
     // create a new type var based on the placeholder node
-    return self.env.types_store.freshFromContentAt(@intFromEnum(placeholder_node_idx), content) catch |err| exitOnOom(err);
+    return self.env.types_store.freshFromContentAt(@intFromEnum(var_slot), content) catch |err| exitOnOom(err);
 }
 
 /// Set a type variable To the specified content at the specified CIR node index.

--- a/src/check/canonicalize/NodeStore.zig
+++ b/src/check/canonicalize/NodeStore.zig
@@ -796,7 +796,7 @@ pub fn addDef(store: *NodeStore, def: CIR.Def) CIR.Def.Idx {
 
     // Store the extra data range in the node
     node.data_1 = extra_start;
-    node.data_2 = 8; // Number of extra data items
+    node.data_2 = 7; // Number of extra data items
 
     return @enumFromInt(@intFromEnum(store.nodes.append(store.gpa, node)));
 }
@@ -813,11 +813,11 @@ pub fn getDef(store: *NodeStore, def_idx: CIR.Def.Idx) CIR.Def {
 
     const pattern: CIR.Pattern.Idx = @enumFromInt(extra_data[0]);
     const expr: CIR.Expr.Idx = @enumFromInt(extra_data[1]);
-    const kind_encoded = .{ extra_data[3], extra_data[4] };
+    const kind_encoded = .{ extra_data[2], extra_data[3] };
     const kind = CIR.Def.Kind.decode(kind_encoded);
-    const anno_idx = extra_data[5];
-    const expr_region_start = extra_data[6];
-    const expr_region_end = extra_data[7];
+    const anno_idx = extra_data[4];
+    const expr_region_start = extra_data[5];
+    const expr_region_end = extra_data[6];
 
     const annotation: ?CIR.Annotation.Idx = if (anno_idx == 0) null else @enumFromInt(anno_idx);
 
@@ -1157,8 +1157,8 @@ pub fn predictNodeIndex(store: *NodeStore, count: u32) Node.Idx {
     return @enumFromInt(start_idx + count - 1);
 }
 
-/// Adds an type placeholder to the store.
-pub fn addTypePlaceholder(store: *NodeStore, parent_node_idx: Node.Idx, region: base.Region) Node.Idx {
+/// Adds an type variable slot to the store.
+pub fn addTypeVarSlot(store: *NodeStore, parent_node_idx: Node.Idx, region: base.Region) Node.Idx {
     const nid = store.nodes.append(store.gpa, .{
         .tag = .type_var_slot,
         .data_1 = @intFromEnum(parent_node_idx),

--- a/src/snapshots/001.txt
+++ b/src/snapshots/001.txt
@@ -45,6 +45,6 @@ foo =
 			"let"
 			(pattern (6:1-6:4)
 				(assign (6:1-6:4) (ident "foo")))
-			(expr (1:1-1:1)
+			(expr (8:5-8:10)
 				(string (8:5-8:10) (literal (8:6-8:9) "one"))))))
 ~~~END

--- a/src/snapshots/add_var_with_spaces.txt
+++ b/src/snapshots/add_var_with_spaces.txt
@@ -35,7 +35,7 @@ add2 = x + 2
 			"let"
 			(pattern (3:1-3:5)
 				(assign (3:1-3:5) (ident "add2")))
-			(expr (1:1-1:1)
+			(expr (3:8-3:18)
 				(binop (3:8-3:18)
 					"add"
 					(runtime_error (3:8-3:9) "ident_not_in_scope")

--- a/src/snapshots/binop_omnibus__single__no_spaces.txt
+++ b/src/snapshots/binop_omnibus__single__no_spaces.txt
@@ -70,5 +70,5 @@ UpperIdent(1:1-1:4),NoSpaceOpenRound(1:4-1:5),LowerIdent(1:5-1:8),CloseRound(1:8
 ~~~FORMATTED
 Err(foo) ?? 12 > 5 * 5 or 13 + 2 < 5 and 10 - 1 >= 16 or 12 <= 3 / 5
 ~~~CANONICALIZE
-(runtime_error (1:1-1:1) "not_implemented")
+(runtime_error (1:1-1:51) "not_implemented")
 ~~~END

--- a/src/snapshots/binop_omnibus__singleline.txt
+++ b/src/snapshots/binop_omnibus__singleline.txt
@@ -70,5 +70,5 @@ UpperIdent(1:1-1:4),NoSpaceOpenRound(1:4-1:5),LowerIdent(1:5-1:8),CloseRound(1:8
 ~~~FORMATTED
 NO CHANGE
 ~~~CANONICALIZE
-(runtime_error (1:1-1:1) "not_implemented")
+(runtime_error (1:1-1:69) "not_implemented")
 ~~~END

--- a/src/snapshots/can_two_decls.txt
+++ b/src/snapshots/can_two_decls.txt
@@ -43,7 +43,7 @@ NO CHANGE
 			"let"
 			(pattern (3:1-3:2)
 				(assign (3:1-3:2) (ident "a")))
-			(expr (1:1-1:1)
+			(expr (3:5-3:6)
 				(int (3:5-3:6)
 					(int_var "#1")
 					(precision_var "#0")
@@ -54,7 +54,7 @@ NO CHANGE
 			"let"
 			(pattern (4:1-4:2)
 				(assign (4:1-4:2) (ident "b")))
-			(expr (1:1-1:1)
+			(expr (4:5-4:10)
 				(binop (4:5-4:10)
 					"add"
 					(lookup (4:5-4:6) (pattern_idx "2"))

--- a/src/snapshots/expr_if_missing_else.txt
+++ b/src/snapshots/expr_if_missing_else.txt
@@ -32,5 +32,5 @@ foo =
 			"let"
 			(pattern (3:1-3:4)
 				(assign (3:1-3:4) (ident "foo")))
-			(expr (1:1-1:1) (runtime_error (3:1-3:20) "expr_not_canonicalized")))))
+			(expr (3:19-3:20) (runtime_error (3:19-3:20) "expr_not_canonicalized")))))
 ~~~END

--- a/src/snapshots/expr_no_space_dot_int.txt
+++ b/src/snapshots/expr_no_space_dot_int.txt
@@ -32,5 +32,5 @@ foo =
 			"let"
 			(pattern (3:1-3:4)
 				(assign (3:1-3:4) (ident "foo")))
-			(expr (1:1-1:1) (runtime_error (3:1-3:12) "expr_not_canonicalized")))))
+			(expr (3:10-3:12) (runtime_error (3:10-3:12) "expr_not_canonicalized")))))
 ~~~END

--- a/src/snapshots/fuzz_crash/fuzz_crash_009.txt
+++ b/src/snapshots/fuzz_crash/fuzz_crash_009.txt
@@ -47,6 +47,6 @@ foo =
 			"let"
 			(pattern (4:1-4:4)
 				(assign (4:1-4:4) (ident "foo")))
-			(expr (1:1-1:1)
+			(expr (6:5-6:12)
 				(string (6:5-6:12) (literal (6:6-6:12) "onmo %"))))))
 ~~~END

--- a/src/snapshots/fuzz_crash/fuzz_crash_010.txt
+++ b/src/snapshots/fuzz_crash/fuzz_crash_010.txt
@@ -46,6 +46,6 @@ foo =
 			"let"
 			(pattern (3:1-3:4)
 				(assign (3:1-3:4) (ident "foo")))
-			(expr (1:1-1:1)
+			(expr (5:5-5:35)
 				(string (5:5-5:35) (literal (5:6-5:35) "on        (string 'onmo %')))"))))))
 ~~~END

--- a/src/snapshots/fuzz_crash/fuzz_crash_017.txt
+++ b/src/snapshots/fuzz_crash/fuzz_crash_017.txt
@@ -39,5 +39,5 @@ foo =
 			"let"
 			(pattern (2:1-2:4)
 				(assign (2:1-2:4) (ident "foo")))
-			(expr (1:1-1:1) (runtime_error (2:1-2:20) "expr_not_canonicalized")))))
+			(expr (2:7-2:20) (runtime_error (2:7-2:20) "expr_not_canonicalized")))))
 ~~~END

--- a/src/snapshots/hello_world.txt
+++ b/src/snapshots/hello_world.txt
@@ -50,5 +50,5 @@ NO CHANGE
 			"let"
 			(pattern (5:1-5:6)
 				(assign (5:1-5:6) (ident "main!")))
-			(expr (1:1-1:1) (runtime_error (5:9-5:42) "can_lambda_not_implemented")))))
+			(expr (5:9-5:42) (runtime_error (5:9-5:42) "can_lambda_not_implemented")))))
 ~~~END

--- a/src/snapshots/hello_world_with_block.txt
+++ b/src/snapshots/hello_world_with_block.txt
@@ -68,5 +68,5 @@ NO CHANGE
 			"let"
 			(pattern (8:1-8:6)
 				(assign (8:1-8:6) (ident "main!")))
-			(expr (1:1-1:1) (runtime_error (8:9-12:2) "can_lambda_not_implemented")))))
+			(expr (8:9-12:2) (runtime_error (8:9-12:2) "can_lambda_not_implemented")))))
 ~~~END

--- a/src/snapshots/if_then_else.txt
+++ b/src/snapshots/if_then_else.txt
@@ -47,5 +47,5 @@ foo = if true A
 			"let"
 			(pattern (3:1-3:4)
 				(assign (3:1-3:4) (ident "foo")))
-			(expr (1:1-1:1) (runtime_error (1:1-1:1) "not_implemented")))))
+			(expr (3:7-7:6) (runtime_error (1:1-1:1) "not_implemented")))))
 ~~~END

--- a/src/snapshots/primitive/expr_float.txt
+++ b/src/snapshots/primitive/expr_float.txt
@@ -26,7 +26,7 @@ NO CHANGE
 			"let"
 			(pattern (2:1-2:4)
 				(assign (2:1-2:4) (ident "foo")))
-			(expr (1:1-1:1)
+			(expr (2:7-2:12)
 				(float (2:7-2:12)
 					(frac_var "#1")
 					(precision_var "#0")

--- a/src/snapshots/primitive/expr_int.txt
+++ b/src/snapshots/primitive/expr_int.txt
@@ -26,7 +26,7 @@ NO CHANGE
 			"let"
 			(pattern (2:1-2:4)
 				(assign (2:1-2:4) (ident "foo")))
-			(expr (1:1-1:1)
+			(expr (2:7-2:9)
 				(int (2:7-2:9)
 					(int_var "#1")
 					(precision_var "#0")

--- a/src/snapshots/primitive/expr_string.txt
+++ b/src/snapshots/primitive/expr_string.txt
@@ -34,13 +34,13 @@ NO CHANGE
 			"let"
 			(pattern (2:1-2:5)
 				(assign (2:1-2:5) (ident "name")))
-			(expr (1:1-1:1)
+			(expr (2:8-2:13)
 				(string (2:8-2:13) (literal (2:9-2:12) "luc"))))
 		(def
 			"let"
 			(pattern (3:1-3:4)
 				(assign (3:1-3:4) (ident "foo")))
-			(expr (1:1-1:1)
+			(expr (3:7-3:22)
 				(string (3:7-3:22)
 					(literal (3:8-3:14) "hello ")
 					(lookup (3:16-3:20) (pattern_idx "2"))

--- a/src/snapshots/primitive/expr_tag.txt
+++ b/src/snapshots/primitive/expr_tag.txt
@@ -26,7 +26,7 @@ NO CHANGE
 			"let"
 			(pattern (2:1-2:4)
 				(assign (2:1-2:4) (ident "foo")))
-			(expr (1:1-1:1)
+			(expr (2:7-2:15)
 				(tag (2:7-2:15)
 					(ext_var "#0")
 					(name "FortyTwo")

--- a/src/snapshots/simple_module_no_blanks.txt
+++ b/src/snapshots/simple_module_no_blanks.txt
@@ -42,7 +42,7 @@ NO CHANGE
 			"let"
 			(pattern (3:1-3:7)
 				(assign (3:1-3:7) (ident "hello!")))
-			(expr (1:1-1:1)
+			(expr (3:10-3:31)
 				(call (3:10-3:31)
 					(runtime_error (3:10-3:22) "ident_not_in_scope")
 					(string (3:23-3:30) (literal (3:24-3:29) "Hello")))))
@@ -50,6 +50,6 @@ NO CHANGE
 			"let"
 			(pattern (4:1-4:6)
 				(assign (4:1-4:6) (ident "world")))
-			(expr (1:1-1:1)
+			(expr (4:9-4:16)
 				(string (4:9-4:16) (literal (4:10-4:15) "World"))))))
 ~~~END

--- a/src/snapshots/some_folder/002.txt
+++ b/src/snapshots/some_folder/002.txt
@@ -37,12 +37,12 @@ NO CHANGE
 			"let"
 			(pattern (3:1-3:4)
 				(assign (3:1-3:4) (ident "foo")))
-			(expr (1:1-1:1)
+			(expr (3:7-3:12)
 				(string (3:7-3:12) (literal (3:8-3:11) "one"))))
 		(def
 			"let"
 			(pattern (5:1-5:4)
 				(assign (5:1-5:4) (ident "bar")))
-			(expr (1:1-1:1)
+			(expr (5:7-5:12)
 				(string (5:7-5:12) (literal (5:8-5:11) "two"))))))
 ~~~END

--- a/src/snapshots/syntax_grab_bag.txt
+++ b/src/snapshots/syntax_grab_bag.txt
@@ -1049,25 +1049,25 @@ NO CHANGE
 			"let"
 			(pattern (65:1-65:16)
 				(assign (65:1-65:16) (ident "add_one_oneline")))
-			(expr (1:1-1:1) (runtime_error (65:19-67:8) "can_lambda_not_implemented")))
+			(expr (65:19-67:8) (runtime_error (65:19-67:8) "can_lambda_not_implemented")))
 		(def
 			"let"
 			(pattern (68:1-68:8)
 				(assign (68:1-68:8) (ident "add_one")))
-			(expr (1:1-1:1) (runtime_error (68:11-78:2) "can_lambda_not_implemented")))
+			(expr (68:11-78:2) (runtime_error (68:11-78:2) "can_lambda_not_implemented")))
 		(def
 			"let"
 			(pattern (80:1-80:11)
 				(assign (80:1-80:11) (ident "match_time")))
-			(expr (1:1-1:1) (runtime_error (80:14-140:7) "can_lambda_not_implemented")))
+			(expr (80:14-140:7) (runtime_error (80:14-140:7) "can_lambda_not_implemented")))
 		(def
 			"let"
 			(pattern (144:1-144:6)
 				(assign (144:1-144:6) (ident "main!")))
-			(expr (1:1-1:1) (runtime_error (144:9-196:2) "can_lambda_not_implemented")))
+			(expr (144:9-196:2) (runtime_error (144:9-196:2) "can_lambda_not_implemented")))
 		(def
 			"let"
 			(pattern (199:1-199:6)
 				(assign (199:1-199:6) (ident "empty")))
-			(expr (1:1-1:1) (runtime_error (1:1-1:1) "not_implemented")))))
+			(expr (199:9-199:11) (runtime_error (1:1-1:1) "not_implemented")))))
 ~~~END


### PR DESCRIPTION
* Fix region but I introduced in https://github.com/roc-lang/roc/pull/7837.
  * The issue was due to removing a field from def, but not updating the indexes correctly when converting a raw `Node` into a `Def`
* Make region references more dry
* Rename `addTypePlaceholder` to `addTypeVarSlot`
* Update snapshots