### PR TITLE
Don't store region in type problem

### DIFF
--- a/src/base/ModuleEnv.zig
+++ b/src/base/ModuleEnv.zig
@@ -56,6 +56,6 @@ pub fn calcLineStarts(self: *Self, source: []const u8) !void {
 }
 
 /// Get diagnostic position information for a given range
-pub fn calcRegionInfo(self: *Self, source: []const u8, begin: u32, end: u32) !RegionInfo {
+pub fn calcRegionInfo(self: *const Self, source: []const u8, begin: u32, end: u32) !RegionInfo {
     return RegionInfo.position(source, self.line_starts.items, begin, end);
 }

--- a/src/check/canonicalize/NodeStore.zig
+++ b/src/check/canonicalize/NodeStore.zig
@@ -79,6 +79,12 @@ pub fn deinit(store: *NodeStore) void {
     store.scratch_diagnostics.items.deinit(store.gpa);
 }
 
+/// Retrieves a region from node from the store.
+pub fn getNodeRegion(store: *const NodeStore, node_idx: Node.Idx) Region {
+    const node = store.nodes.get(node_idx);
+    return node.region;
+}
+
 /// Retrieves a statement node from the store.
 pub fn getStatement(store: *NodeStore, statement: CIR.Statement.Idx) CIR.Statement {
     const node_idx: Node.Idx = @enumFromInt(@intFromEnum(statement));

--- a/src/check/check_types.zig
+++ b/src/check/check_types.zig
@@ -58,12 +58,7 @@ pub fn deinit(self: *Self) void {
 
 /// Deinit owned fields
 pub fn unify(self: *Self, a: Var, b: Var) void {
-    self.unifyWithRegion(a, b, null);
-}
-
-/// TODO
-pub fn unifyWithRegion(self: *Self, a: Var, b: Var, region: ?Region) void {
-    _ = unifier.unifyWithRegion(
+    _ = unifier.unify(
         self.can_ir.env,
         self.types,
         &self.problems,
@@ -72,7 +67,6 @@ pub fn unifyWithRegion(self: *Self, a: Var, b: Var, region: ?Region) void {
         &self.occurs_scratch,
         a,
         b,
-        region,
     );
 }
 
@@ -106,12 +100,9 @@ pub fn checkExpr(self: *Self, expr_idx: CIR.Expr.Idx) void {
             const elem_var = list.elem_var;
             for (self.can_ir.store.exprSlice(list.elems)) |single_elem_expr_idx| {
                 self.checkExpr(single_elem_expr_idx);
-                const single_elem_expr = self.can_ir.store.getExpr(single_elem_expr_idx);
-                const elem_region = single_elem_expr.toRegion();
-                self.unifyWithRegion(
+                self.unify(
                     @enumFromInt(@intFromEnum(elem_var)),
                     @enumFromInt(@intFromEnum(single_elem_expr_idx)),
-                    elem_region,
                 );
             }
         },

--- a/src/check/check_types/unify.zig
+++ b/src/check/check_types/unify.zig
@@ -109,21 +109,6 @@ pub fn unify(
     a: Var,
     b: Var,
 ) Result {
-    return unifyWithRegion(module_env, types, problems, snapshots, unify_scratch, occurs_scratch, a, b, null);
-}
-
-/// Unify two type variables with a region
-pub fn unifyWithRegion(
-    module_env: *const base.ModuleEnv,
-    types: *types_root_mod.Store,
-    problems: *problem_mod.Store,
-    snapshots: *snapshot_mod.Store,
-    unify_scratch: *Scratch,
-    occurs_scratch: *occurs.Scratch,
-    a: Var,
-    b: Var,
-    region: ?base.Region,
-) Result {
     // First reset the scratch store
     unify_scratch.reset();
 
@@ -140,7 +125,6 @@ pub fn unifyWithRegion(
                         .expected = expected_snapshot,
                         .actual_var = b,
                         .actual = actual_snapshot,
-                        .region = region orelse base.Region.zero(),
                     } };
                 },
                 error.UnifyErr => {
@@ -200,7 +184,6 @@ pub fn unifyWithRegion(
                             .expected = snapshots.createSnapshot(types, a),
                             .actual_var = b,
                             .actual = snapshots.createSnapshot(types, b),
-                            .region = region orelse base.Region.zero(),
                         } };
                     }
                 },

--- a/src/coordinate_simple.zig
+++ b/src/coordinate_simple.zig
@@ -160,11 +160,11 @@ fn processSourceInternal(
         const report = problem.buildReport(
             gpa,
             &problem_buf,
+            &module_env,
+            cir,
             &solver.snapshots,
-            &module_env.idents,
             owned_source,
             filename,
-            &module_env,
         ) catch continue;
         reports.append(report) catch continue;
     }

--- a/src/snapshot.zig
+++ b/src/snapshot.zig
@@ -715,11 +715,11 @@ fn generateProblemsSection(output: *DualOutput, parse_ast: *AST, can_ir: *CIR, s
         var report: reporting.Report = problem.buildReport(
             output.gpa,
             &problem_buf,
+            module_env,
+            can_ir,
             &solver.snapshots,
-            &module_env.idents,
             content.source,
             snapshot_path,
-            module_env,
         ) catch |err| {
             try output.md_writer.print("Error creating type checking report: {}\n", .{err});
             try output.html_writer.print("                    <p>Error creating type checking report: {}</p>\n", .{err});


### PR DESCRIPTION
This MR updates the type problem struct to not store a `region`. Instead, at the time of error message generation, we convert the `Var` to a `CIR.Node.Idx` and lookup the region from there.