### PR TITLE
Implement tuple expr type solving

### DIFF
--- a/src/check/canonicalize.zig
+++ b/src/check/canonicalize.zig
@@ -3,7 +3,7 @@ const base = @import("../base.zig");
 const parse = @import("parse.zig");
 const tokenize = @import("parse/tokenize.zig");
 const collections = @import("../collections.zig");
-const types = @import("../types/types.zig");
+const types = @import("../types.zig");
 const RocDec = @import("../builtins/dec.zig").RocDec;
 
 const NodeStore = @import("./canonicalize/NodeStore.zig");
@@ -1183,38 +1183,35 @@ pub fn canonicalize_expr(
             // Iterate over the tuple items, canonicalizing each one
             // Then append the result to the scratch list
             const items_slice = self.parse_ir.store.exprSlice(e.items);
+            const elems_var_top = self.can_ir.env.types.tuple_elems.len();
             for (items_slice) |item| {
                 if (self.canonicalize_expr(item)) |canonicalized| {
                     self.can_ir.store.addScratchExpr(canonicalized);
+                    _ = self.can_ir.env.types.appendTupleElem(@enumFromInt(@intFromEnum(canonicalized)));
                 }
             }
+            const elems_var_range = types.Var.SafeList.Range{
+                .start = @enumFromInt(elems_var_top),
+                .end = @enumFromInt(self.can_ir.env.types.tuple_elems.len()),
+            };
 
             // Create span of the new scratch expressions
             const elems_span = self.can_ir.store.exprSpanFrom(scratch_top);
-
-            // create type vars, first "reserve" node slots
-            const tuple_expr_idx = self.can_ir.store.predictNodeIndex(2);
-
-            // then insert the type vars, setting the parent to be the final slot
-            const tuple_type_var = self.can_ir.pushFreshTypeVar(
-                tuple_expr_idx,
-                region,
-            );
 
             // then in the final slot the actual expr is inserted
             const expr_idx = self.can_ir.store.addExpr(CIR.Expr{
                 .tuple = .{
                     .elems = elems_span,
-                    .tuple_var = tuple_type_var,
                     .region = region,
                 },
             });
 
             // Insert concrete type variable for tuple
-            // TODO: Implement proper tuple type structure when tuple types are available
             _ = self.can_ir.setTypeVarAtExpr(
                 expr_idx,
-                Content{ .flex_var = null },
+                Content{ .structure = FlatType{
+                    .tuple = types.Tuple{ .elems = elems_var_range },
+                } },
             );
 
             return expr_idx;
@@ -1820,34 +1817,34 @@ fn canonicalize_pattern(
             // Iterate over the tuple patterns, canonicalizing each one
             // Then append the result to the scratch list
             const patterns_slice = self.parse_ir.store.patternSlice(e.patterns);
+            const elems_var_top = self.can_ir.env.types.tuple_elems.len();
             for (patterns_slice) |pattern| {
                 if (self.canonicalize_pattern(pattern)) |canonicalized| {
                     self.can_ir.store.addScratchPattern(canonicalized);
+                    _ = self.can_ir.env.types.appendTupleElem(@enumFromInt(@intFromEnum(canonicalized)));
                 }
             }
+            const elems_var_range = types.Var.SafeList.Range{
+                .start = @enumFromInt(elems_var_top),
+                .end = @enumFromInt(self.can_ir.env.types.tuple_elems.len()),
+            };
 
             // Create span of the new scratch patterns
             const patterns_span = self.can_ir.store.patternSpanFrom(scratch_top);
 
-            // Reserve node slots for type vars, then insert into them.
-            const tuple_pattern_idx = self.can_ir.store.predictNodeIndex(2);
-            const tuple_type_var = self.can_ir.pushFreshTypeVar(
-                tuple_pattern_idx,
-                region,
-            );
             const pattern_idx = self.can_ir.store.addPattern(CIR.Pattern{
                 .tuple = .{
                     .patterns = patterns_span,
-                    .tuple_var = tuple_type_var,
                     .region = region,
                 },
             });
 
             // Insert concrete type variable for tuple pattern
-            // TODO: Implement proper tuple type structure when tuple types are available
             _ = self.can_ir.setTypeVarAtPat(
                 pattern_idx,
-                Content{ .flex_var = null },
+                Content{ .structure = FlatType{
+                    .tuple = types.Tuple{ .elems = elems_var_range },
+                } },
             );
 
             return pattern_idx;
@@ -2789,7 +2786,6 @@ fn canonicalize_statement(self: *Self, stmt_idx: AST.Statement.Idx) ?CIR.Expr.Id
             // Create an empty tuple as a unit value
             const empty_span = CIR.Expr.Span{ .span = base.DataSpan{ .start = 0, .len = 0 } };
             const unit_expr = self.can_ir.store.addExpr(CIR.Expr{ .tuple = .{
-                .tuple_var = self.can_ir.pushFreshTypeVar(@enumFromInt(0), region),
                 .elems = empty_span,
                 .region = region,
             } });
@@ -2803,7 +2799,6 @@ fn canonicalize_statement(self: *Self, stmt_idx: AST.Statement.Idx) ?CIR.Expr.Id
             const region = self.parse_ir.tokenizedRegionToRegion(import_stmt.region);
             const empty_span = CIR.Expr.Span{ .span = base.DataSpan{ .start = 0, .len = 0 } };
             const unit_expr = self.can_ir.store.addExpr(CIR.Expr{ .tuple = .{
-                .tuple_var = self.can_ir.pushFreshTypeVar(@enumFromInt(0), region),
                 .elems = empty_span,
                 .region = region,
             } });

--- a/src/check/canonicalize/CIR.zig
+++ b/src/check/canonicalize/CIR.zig
@@ -1116,7 +1116,6 @@ pub const Expr = union(enum) {
         region: Region,
     },
     tuple: struct {
-        tuple_var: TypeVar,
         elems: Expr.Span,
         region: Region,
     },
@@ -1466,9 +1465,6 @@ pub const Expr = union(enum) {
             .tuple => |t| {
                 var node = SExpr.init(gpa, "e-tuple");
                 node.appendRegion(gpa, ir.calcRegionInfo(t.region));
-
-                // Add tuple_var
-                node.appendTypeVar(gpa, "tuple-var", t.tuple_var);
 
                 // Add tuple elements
                 var elems_node = SExpr.init(gpa, "elems");
@@ -2219,7 +2215,6 @@ pub const Pattern = union(enum) {
         region: Region,
     },
     tuple: struct {
-        tuple_var: TypeVar,
         patterns: Pattern.Span,
         region: Region,
     },
@@ -2353,9 +2348,6 @@ pub const Pattern = union(enum) {
 
                 // var pattern_idx_node = formatPatternIdxNode(gpa, pattern_idx);
                 // node.appendNode(gpa, &pattern_idx_node);
-
-                // Add tuple_var
-                node.appendTypeVar(gpa, "tuple-var", p.tuple_var);
 
                 var patterns_node = SExpr.init(gpa, "patterns");
 

--- a/src/check/canonicalize/NodeStore.zig
+++ b/src/check/canonicalize/NodeStore.zig
@@ -217,7 +217,6 @@ pub fn getExpr(store: *const NodeStore, expr: CIR.Expr.Idx) CIR.Expr {
             return .{
                 .tuple = .{
                     .elems = .{ .span = .{ .start = node.data_1, .len = node.data_2 } },
-                    .tuple_var = @enumFromInt(node.data_3),
                     .region = node.region,
                 },
             };
@@ -475,7 +474,6 @@ pub fn getPattern(store: *const NodeStore, pattern_idx: CIR.Pattern.Idx) CIR.Pat
             .tuple = .{
                 .region = node.region,
                 .patterns = DataSpan.init(node.data_1, node.data_2).as(CIR.Pattern.Span),
-                .tuple_var = @enumFromInt(node.data_3),
             },
         },
         .pattern_num_literal => {
@@ -824,7 +822,6 @@ pub fn addExpr(store: *NodeStore, expr: CIR.Expr) CIR.Expr.Idx {
             node.tag = .expr_tuple;
             node.data_1 = e.elems.span.start;
             node.data_2 = e.elems.span.len;
-            node.data_3 = @intFromEnum(e.tuple_var);
         },
         .frac_f64 => |e| {
             node.region = e.region;
@@ -1061,7 +1058,6 @@ pub fn addPattern(store: *NodeStore, pattern: CIR.Pattern) CIR.Pattern.Idx {
             node.region = p.region;
             node.data_1 = p.patterns.span.start;
             node.data_2 = p.patterns.span.len;
-            node.data_3 = @intFromEnum(p.tuple_var);
         },
         .int_literal => |p| {
             node.tag = .pattern_int_literal;

--- a/src/check/check_types.zig
+++ b/src/check/check_types.zig
@@ -124,7 +124,11 @@ pub fn checkExpr(self: *Self, expr_idx: CIR.Expr.Idx) void {
         .binop => |_| {},
         .block => |_| {},
         .lambda => |_| {},
-        .tuple => |_| {},
+        .tuple => |tuple| {
+            for (self.can_ir.store.exprSlice(tuple.elems)) |single_elem_expr_idx| {
+                self.checkExpr(single_elem_expr_idx);
+            }
+        },
         .dot_access => |_| {
             // TODO: Implement type checking for dot access
             // This will need to:

--- a/src/snapshots/binops.md
+++ b/src/snapshots/binops.md
@@ -116,7 +116,7 @@ CloseRound(17:1-17:2),EndOfFile(17:2-17:2),
 ~~~
 # CANONICALIZE
 ~~~clojure
-(e-tuple @1-1-17-2 (tuple-var 172) (id 173)
+(e-tuple @1-1-17-2 (id 172)
 	(elems
 		(e-binop @2-5-2-11 (op "add")
 			(e-int @2-5-2-6 (num-var 74) (sign-needed "false") (bits-needed "7") (value "4"))
@@ -166,5 +166,5 @@ CloseRound(17:1-17:2),EndOfFile(17:2-17:2),
 ~~~
 # TYPES
 ~~~clojure
-(expr (id 173) (type "*"))
+(expr (id 172) (type "(*, *, *, *, *, *, *, *, *, *, *, *, *, *, *)"))
 ~~~

--- a/src/snapshots/can_import_comprehensive.md
+++ b/src/snapshots/can_import_comprehensive.md
@@ -172,9 +172,9 @@ main = {
 # CANONICALIZE
 ~~~clojure
 (can-ir
-	(d-let (id 121)
+	(d-let (id 120)
 		(p-assign @7-1-7-5 (ident "main") (id 77))
-		(e-block @7-8-35-2 (id 120)
+		(e-block @7-8-35-2 (id 119)
 			(s-let @8-5-8-22
 				(p-assign @8-5-8-11 (ident "client") (id 78))
 				(e-lookup-external (id 80)
@@ -207,7 +207,7 @@ main = {
 				(p-assign @23-5-23-13 (ident "combined") (id 106))
 				(e-lookup-external (id 108)
 					(ext-decl @23-16-23-26 (qualified "utils.String.concat") (module "utils.String") (local "concat") (kind "value") (type-var 107))))
-			(e-tuple @25-5-34-6 (tuple-var 118)
+			(e-tuple @25-5-34-6
 				(elems
 					(e-lookup-local @26-9-26-15
 						(pattern (id 78)))

--- a/src/snapshots/expr/record_field_update.md
+++ b/src/snapshots/expr/record_field_update.md
@@ -60,13 +60,13 @@ OpenCurly(1:1-1:2),LowerIdent(1:3-1:9),OpAmpersand(1:10-1:11),LowerIdent(1:12-1:
 ~~~
 # CANONICALIZE
 ~~~clojure
-(e-block @1-1-1-21 (id 79)
+(e-block @1-1-1-21 (id 78)
 	(s-expr @1-3-1-11
 		(e-runtime-error (tag "ident_not_in_scope")))
-	(e-tuple @1-12-1-21 (tuple-var 77)
+	(e-tuple @1-12-1-21
 		(elems)))
 ~~~
 # TYPES
 ~~~clojure
-(expr (id 79) (type "*"))
+(expr (id 78) (type "*"))
 ~~~

--- a/src/snapshots/expr/tuple.md
+++ b/src/snapshots/expr/tuple.md
@@ -27,7 +27,7 @@ NO CHANGE
 ~~~
 # CANONICALIZE
 ~~~clojure
-(e-tuple @1-1-1-19 (tuple-var 79) (id 80)
+(e-tuple @1-1-1-19 (id 79)
 	(elems
 		(e-int @1-2-1-3 (num-var 74) (sign-needed "false") (bits-needed "7") (value "1"))
 		(e-string @1-5-1-12
@@ -36,5 +36,5 @@ NO CHANGE
 ~~~
 # TYPES
 ~~~clojure
-(expr (id 80) (type "*"))
+(expr (id 79) (type "(Num(Int(*)), Str, [True, * *])"))
 ~~~

--- a/src/snapshots/expr/tuple_comprehensive.md
+++ b/src/snapshots/expr/tuple_comprehensive.md
@@ -229,7 +229,7 @@ CloseCurly(19:1-19:2),EndOfFile(19:2-19:2),
 ~~~
 # CANONICALIZE
 ~~~clojure
-(e-block @1-1-19-2 (id 189)
+(e-block @1-1-19-2 (id 179)
 	(s-let @3-5-3-21
 		(p-assign @3-5-3-12 (ident "add_one") (id 72))
 		(e-lambda @3-15-3-21 (id 76)
@@ -247,57 +247,57 @@ CloseCurly(19:1-19:2),EndOfFile(19:2-19:2),
 		(e-int @6-9-6-11 (num-var 91) (sign-needed "false") (bits-needed "7") (value "30") (id 91)))
 	(s-let @9-2-9-12
 		(p-assign @9-2-9-7 (ident "empty") (id 93))
-		(e-tuple @9-10-9-12 (tuple-var 94) (id 95)
+		(e-tuple @9-10-9-12 (id 94)
 			(elems)))
 	(s-let @10-2-10-15
-		(p-assign @10-2-10-8 (ident "single") (id 97))
-		(e-tuple @10-11-10-15 (tuple-var 101) (id 102)
+		(p-assign @10-2-10-8 (ident "single") (id 96))
+		(e-tuple @10-11-10-15 (id 100)
 			(elems
-				(e-int @10-12-10-14 (num-var 100) (sign-needed "false") (bits-needed "7") (value "42")))))
+				(e-int @10-12-10-14 (num-var 99) (sign-needed "false") (bits-needed "7") (value "42")))))
 	(s-let @11-2-11-15
-		(p-assign @11-2-11-6 (ident "pair") (id 104))
-		(e-tuple @11-9-11-15 (tuple-var 111) (id 112)
+		(p-assign @11-2-11-6 (ident "pair") (id 102))
+		(e-tuple @11-9-11-15 (id 109)
 			(elems
-				(e-int @11-10-11-11 (num-var 107) (sign-needed "false") (bits-needed "7") (value "1"))
-				(e-int @11-13-11-14 (num-var 110) (sign-needed "false") (bits-needed "7") (value "2")))))
+				(e-int @11-10-11-11 (num-var 105) (sign-needed "false") (bits-needed "7") (value "1"))
+				(e-int @11-13-11-14 (num-var 108) (sign-needed "false") (bits-needed "7") (value "2")))))
 	(s-let @12-2-12-29
-		(p-assign @12-2-12-8 (ident "triple") (id 114))
-		(e-tuple @12-11-12-29 (tuple-var 122) (id 123)
+		(p-assign @12-2-12-8 (ident "triple") (id 111))
+		(e-tuple @12-11-12-29 (id 119)
 			(elems
-				(e-int @12-12-12-13 (num-var 117) (sign-needed "false") (bits-needed "7") (value "1"))
+				(e-int @12-12-12-13 (num-var 114) (sign-needed "false") (bits-needed "7") (value "1"))
 				(e-string @12-15-12-22
 					(e-literal @12-16-12-21 (string "hello")))
 				(e-tag @12-24-12-28 (ext-var 0) (name "True") (args "TODO")))))
 	(s-let @13-2-13-27
-		(p-assign @13-2-13-8 (ident "nested") (id 125))
-		(e-tuple @13-11-13-27 (tuple-var 142) (id 143)
+		(p-assign @13-2-13-8 (ident "nested") (id 121))
+		(e-tuple @13-11-13-27 (id 136)
 			(elems
-				(e-tuple @13-12-13-18 (tuple-var 132)
+				(e-tuple @13-12-13-18
 					(elems
-						(e-int @13-13-13-14 (num-var 128) (sign-needed "false") (bits-needed "7") (value "1"))
-						(e-int @13-16-13-17 (num-var 131) (sign-needed "false") (bits-needed "7") (value "2"))))
-				(e-tuple @13-20-13-26 (tuple-var 140)
+						(e-int @13-13-13-14 (num-var 124) (sign-needed "false") (bits-needed "7") (value "1"))
+						(e-int @13-16-13-17 (num-var 127) (sign-needed "false") (bits-needed "7") (value "2"))))
+				(e-tuple @13-20-13-26
 					(elems
-						(e-int @13-21-13-22 (num-var 136) (sign-needed "false") (bits-needed "7") (value "3"))
-						(e-int @13-24-13-25 (num-var 139) (sign-needed "false") (bits-needed "7") (value "4")))))))
+						(e-int @13-21-13-22 (num-var 131) (sign-needed "false") (bits-needed "7") (value "3"))
+						(e-int @13-24-13-25 (num-var 134) (sign-needed "false") (bits-needed "7") (value "4")))))))
 	(s-let @14-2-14-42
-		(p-assign @14-2-14-7 (ident "mixed") (id 145))
-		(e-tuple @14-10-14-42 (tuple-var 164) (id 165)
+		(p-assign @14-2-14-7 (ident "mixed") (id 138))
+		(e-tuple @14-10-14-42 (id 157)
 			(elems
 				(e-call @14-11-14-21
 					(e-lookup-local @14-11-14-18
 						(pattern (id 72)))
-					(e-int @14-19-14-20 (num-var 149) (sign-needed "false") (bits-needed "7") (value "5")))
+					(e-int @14-19-14-20 (num-var 142) (sign-needed "false") (bits-needed "7") (value "5")))
 				(e-string @14-23-14-30
 					(e-literal @14-24-14-29 (string "world")))
-				(e-list @14-32-14-41 (elem-var 162)
+				(e-list @14-32-14-41 (elem-var 155)
 					(elems
-						(e-int @14-33-14-34 (num-var 155) (sign-needed "false") (bits-needed "7") (value "1"))
-						(e-int @14-36-14-37 (num-var 158) (sign-needed "false") (bits-needed "7") (value "2"))
-						(e-int @14-39-14-40 (num-var 161) (sign-needed "false") (bits-needed "7") (value "3")))))))
+						(e-int @14-33-14-34 (num-var 148) (sign-needed "false") (bits-needed "7") (value "1"))
+						(e-int @14-36-14-37 (num-var 151) (sign-needed "false") (bits-needed "7") (value "2"))
+						(e-int @14-39-14-40 (num-var 154) (sign-needed "false") (bits-needed "7") (value "3")))))))
 	(s-let @15-2-15-23
-		(p-assign @15-2-15-11 (ident "with_vars") (id 167))
-		(e-tuple @15-14-15-23 (tuple-var 171) (id 172)
+		(p-assign @15-2-15-11 (ident "with_vars") (id 159))
+		(e-tuple @15-14-15-23 (id 163)
 			(elems
 				(e-lookup-local @15-15-15-16
 					(pattern (id 78)))
@@ -306,21 +306,21 @@ CloseCurly(19:1-19:2),EndOfFile(19:2-19:2),
 				(e-lookup-local @15-21-15-22
 					(pattern (id 88))))))
 	(s-let @16-2-16-31
-		(p-assign @16-2-16-13 (ident "with_lambda") (id 174))
-		(e-tuple @16-16-16-31 (tuple-var 185) (id 186)
+		(p-assign @16-2-16-13 (ident "with_lambda") (id 165))
+		(e-tuple @16-16-16-31 (id 176)
 			(elems
 				(e-lambda @16-17-16-27
 					(args
-						(p-assign @16-18-16-19 (ident "n") (id 175)))
+						(p-assign @16-18-16-19 (ident "n") (id 166)))
 					(e-binop @16-21-16-27 (op "add")
 						(e-lookup-local @16-21-16-22
-							(pattern (id 175)))
-						(e-int @16-25-16-26 (num-var 179) (sign-needed "false") (bits-needed "7") (value "1"))))
-				(e-int @16-28-16-30 (num-var 184) (sign-needed "false") (bits-needed "7") (value "42")))))
+							(pattern (id 166)))
+						(e-int @16-25-16-26 (num-var 170) (sign-needed "false") (bits-needed "7") (value "1"))))
+				(e-int @16-28-16-30 (num-var 175) (sign-needed "false") (bits-needed "7") (value "42")))))
 	(e-lookup-local @18-2-18-7
 		(pattern (id 93))))
 ~~~
 # TYPES
 ~~~clojure
-(expr (id 189) (type "*"))
+(expr (id 179) (type "*"))
 ~~~

--- a/src/snapshots/expr/tuple_patterns.md
+++ b/src/snapshots/expr/tuple_patterns.md
@@ -255,59 +255,59 @@ CloseCurly(19:1-19:2),EndOfFile(19:2-19:2),
 ~~~
 # CANONICALIZE
 ~~~clojure
-(e-block @1-1-19-2 (id 186)
+(e-block @1-1-19-2 (id 172)
 	(s-expr @4-5-4-13
-		(e-tuple @4-5-4-11 (tuple-var 76)
+		(e-tuple @4-5-4-11
 			(elems
 				(e-runtime-error (tag "ident_not_in_scope"))
 				(e-runtime-error (tag "ident_not_in_scope")))))
 	(s-expr @4-14-7-6
-		(e-tuple @4-14-4-20 (tuple-var 85)
+		(e-tuple @4-14-4-20
 			(elems
-				(e-int @4-15-4-16 (num-var 81) (sign-needed "false") (bits-needed "7") (value "1"))
-				(e-int @4-18-4-19 (num-var 84) (sign-needed "false") (bits-needed "7") (value "2")))))
+				(e-int @4-15-4-16 (num-var 80) (sign-needed "false") (bits-needed "7") (value "1"))
+				(e-int @4-18-4-19 (num-var 83) (sign-needed "false") (bits-needed "7") (value "2")))))
 	(s-expr @7-5-7-23
-		(e-tuple @7-5-7-21 (tuple-var 100)
+		(e-tuple @7-5-7-21
 			(elems
-				(e-tuple @7-6-7-12 (tuple-var 92)
+				(e-tuple @7-6-7-12
 					(elems
 						(e-runtime-error (tag "ident_not_in_scope"))
 						(e-runtime-error (tag "ident_not_in_scope"))))
-				(e-tuple @7-14-7-20 (tuple-var 98)
+				(e-tuple @7-14-7-20
 					(elems
 						(e-runtime-error (tag "ident_not_in_scope"))
 						(e-runtime-error (tag "ident_not_in_scope")))))))
 	(s-expr @7-24-10-6
-		(e-tuple @7-24-7-44 (tuple-var 119)
+		(e-tuple @7-24-7-44
 			(elems
-				(e-tuple @7-25-7-33 (tuple-var 109)
+				(e-tuple @7-25-7-33
 					(elems
-						(e-int @7-26-7-28 (num-var 105) (sign-needed "false") (bits-needed "7") (value "10"))
-						(e-int @7-30-7-32 (num-var 108) (sign-needed "false") (bits-needed "7") (value "20"))))
-				(e-tuple @7-35-7-43 (tuple-var 117)
+						(e-int @7-26-7-28 (num-var 100) (sign-needed "false") (bits-needed "7") (value "10"))
+						(e-int @7-30-7-32 (num-var 103) (sign-needed "false") (bits-needed "7") (value "20"))))
+				(e-tuple @7-35-7-43
 					(elems
-						(e-int @7-36-7-38 (num-var 113) (sign-needed "false") (bits-needed "7") (value "30"))
-						(e-int @7-40-7-42 (num-var 116) (sign-needed "false") (bits-needed "7") (value "40")))))))
+						(e-int @7-36-7-38 (num-var 107) (sign-needed "false") (bits-needed "7") (value "30"))
+						(e-int @7-40-7-42 (num-var 110) (sign-needed "false") (bits-needed "7") (value "40")))))))
 	(s-expr @10-5-10-29
-		(e-tuple @10-5-10-27 (tuple-var 128)
+		(e-tuple @10-5-10-27
 			(elems
 				(e-runtime-error (tag "ident_not_in_scope"))
 				(e-runtime-error (tag "ident_not_in_scope"))
 				(e-runtime-error (tag "ident_not_in_scope")))))
 	(s-expr @10-30-13-6
-		(e-tuple @10-30-10-44 (tuple-var 140)
+		(e-tuple @10-30-10-44
 			(elems
-				(e-int @10-31-10-34 (num-var 133) (sign-needed "false") (bits-needed "7") (value "100"))
-				(e-int @10-36-10-38 (num-var 136) (sign-needed "false") (bits-needed "7") (value "42"))
-				(e-int @10-40-10-43 (num-var 139) (sign-needed "false") (bits-needed "8") (value "200")))))
+				(e-int @10-31-10-34 (num-var 124) (sign-needed "false") (bits-needed "7") (value "100"))
+				(e-int @10-36-10-38 (num-var 127) (sign-needed "false") (bits-needed "7") (value "42"))
+				(e-int @10-40-10-43 (num-var 130) (sign-needed "false") (bits-needed "8") (value "200")))))
 	(s-expr @13-5-13-30
-		(e-tuple @13-5-13-28 (tuple-var 149)
+		(e-tuple @13-5-13-28
 			(elems
 				(e-runtime-error (tag "ident_not_in_scope"))
 				(e-runtime-error (tag "ident_not_in_scope"))
 				(e-runtime-error (tag "ident_not_in_scope")))))
 	(s-expr @13-31-16-6
-		(e-tuple @13-31-13-55 (tuple-var 158)
+		(e-tuple @13-31-13-55
 			(elems
 				(e-string @13-32-13-39
 					(e-literal @13-33-13-38 (string "Alice")))
@@ -315,23 +315,23 @@ CloseCurly(19:1-19:2),EndOfFile(19:2-19:2),
 					(e-literal @13-42-13-47 (string "fixed")))
 				(e-tag @13-50-13-54 (ext-var 0) (name "True") (args "TODO")))))
 	(s-expr @16-5-16-20
-		(e-tuple @16-5-16-18 (tuple-var 165)
+		(e-tuple @16-5-16-18
 			(elems
 				(e-runtime-error (tag "ident_not_in_scope"))
 				(e-runtime-error (tag "ident_not_in_scope")))))
 	(s-expr @16-21-18-6
-		(e-tuple @16-21-16-41 (tuple-var 181)
+		(e-tuple @16-21-16-41
 			(elems
-				(e-list @16-22-16-31 (elem-var 177)
+				(e-list @16-22-16-31 (elem-var 164)
 					(elems
-						(e-int @16-23-16-24 (num-var 170) (sign-needed "false") (bits-needed "7") (value "1"))
-						(e-int @16-26-16-27 (num-var 173) (sign-needed "false") (bits-needed "7") (value "2"))
-						(e-int @16-29-16-30 (num-var 176) (sign-needed "false") (bits-needed "7") (value "3"))))
+						(e-int @16-23-16-24 (num-var 157) (sign-needed "false") (bits-needed "7") (value "1"))
+						(e-int @16-26-16-27 (num-var 160) (sign-needed "false") (bits-needed "7") (value "2"))
+						(e-int @16-29-16-30 (num-var 163) (sign-needed "false") (bits-needed "7") (value "3"))))
 				(e-string @16-33-16-40
 					(e-literal @16-34-16-39 (string "hello"))))))
 	(e-runtime-error (tag "not_implemented")))
 ~~~
 # TYPES
 ~~~clojure
-(expr (id 186) (type "*"))
+(expr (id 172) (type "*"))
 ~~~

--- a/src/snapshots/records/record_access_function_call.md
+++ b/src/snapshots/records/record_access_function_call.md
@@ -32,5 +32,5 @@ NO CHANGE
 ~~~
 # TYPES
 ~~~clojure
-(expr (id 80) (type "*"))
+(expr (id 79) (type "*"))
 ~~~

--- a/src/snapshots/records/record_different_fields_error.md
+++ b/src/snapshots/records/record_different_fields_error.md
@@ -345,5 +345,5 @@ CloseCurly(8:1-8:2),EndOfFile(8:2-8:2),
 ~~~
 # TYPES
 ~~~clojure
-(expr (id 109) (type "*"))
+(expr (id 106) (type "*"))
 ~~~

--- a/src/snapshots/records/record_different_fields_reserved_error.md
+++ b/src/snapshots/records/record_different_fields_reserved_error.md
@@ -286,5 +286,5 @@ CloseCurly(8:1-8:2),EndOfFile(8:2-8:2),
 ~~~
 # TYPES
 ~~~clojure
-(expr (id 93) (type "*"))
+(expr (id 92) (type "*"))
 ~~~

--- a/src/snapshots/records/record_extension_update.md
+++ b/src/snapshots/records/record_extension_update.md
@@ -108,5 +108,5 @@ CloseCurly(4:1-4:2),EndOfFile(4:2-4:2),
 ~~~
 # TYPES
 ~~~clojure
-(expr (id 83) (type "*"))
+(expr (id 81) (type "*"))
 ~~~

--- a/src/snapshots/syntax_grab_bag.md
+++ b/src/snapshots/syntax_grab_bag.md
@@ -1288,9 +1288,9 @@ NO CHANGE
 				(p-assign @81-2-81-3 (ident "a") (id 230))
 				(p-assign @82-2-82-3 (ident "b") (id 231)))
 			(e-runtime-error (tag "not_implemented"))))
-	(d-let (id 463)
+	(d-let (id 459)
 		(p-assign @144-1-144-6 (ident "main!") (id 246))
-		(e-lambda @144-9-196-2 (id 457)
+		(e-lambda @144-9-196-2 (id 453)
 			(args
 				(p-underscore @144-10-144-11 (id 247)))
 			(e-block @144-13-196-2
@@ -1343,7 +1343,7 @@ NO CHANGE
 					(e-runtime-error (tag "not_implemented") (id 311)))
 				(s-let @179-2-179-68
 					(p-assign @179-2-179-7 (ident "tuple") (id 313))
-					(e-tuple @179-10-179-68 (tuple-var 340) (id 341)
+					(e-tuple @179-10-179-68 (id 339)
 						(elems
 							(e-int @179-11-179-14 (num-var 316) (sign-needed "false") (bits-needed "7") (value "123"))
 							(e-string @179-16-179-23
@@ -1354,21 +1354,21 @@ NO CHANGE
 								(e-tag @179-30-179-32 (ext-var 0) (name "Ok") (args "TODO"))
 								(e-lookup-local @179-33-179-38
 									(pattern (id 248))))
-							(e-tuple @179-41-179-56 (tuple-var 327)
+							(e-tuple @179-41-179-56
 								(elems
 									(e-runtime-error (tag "ident_not_in_scope"))
 									(e-lookup-local @179-50-179-55
 										(pattern (id 313)))))
-							(e-list @179-58-179-67 (elem-var 338)
+							(e-list @179-58-179-67 (elem-var 337)
 								(elems
-									(e-int @179-59-179-60 (num-var 331) (sign-needed "false") (bits-needed "7") (value "1"))
-									(e-int @179-62-179-63 (num-var 334) (sign-needed "false") (bits-needed "7") (value "2"))
-									(e-int @179-65-179-66 (num-var 337) (sign-needed "false") (bits-needed "7") (value "3")))))))
+									(e-int @179-59-179-60 (num-var 330) (sign-needed "false") (bits-needed "7") (value "1"))
+									(e-int @179-62-179-63 (num-var 333) (sign-needed "false") (bits-needed "7") (value "2"))
+									(e-int @179-65-179-66 (num-var 336) (sign-needed "false") (bits-needed "7") (value "3")))))))
 				(s-let @180-2-187-3
-					(p-assign @180-2-180-17 (ident "multiline_tuple") (id 343))
-					(e-tuple @180-20-187-3 (tuple-var 371) (id 372)
+					(p-assign @180-2-180-17 (ident "multiline_tuple") (id 341))
+					(e-tuple @180-20-187-3 (id 368)
 						(elems
-							(e-int @181-3-181-6 (num-var 346) (sign-needed "false") (bits-needed "7") (value "123"))
+							(e-int @181-3-181-6 (num-var 344) (sign-needed "false") (bits-needed "7") (value "123"))
 							(e-string @182-3-182-10
 								(e-literal @182-4-182-9 (string "World")))
 							(e-runtime-error (tag "ident_not_in_scope"))
@@ -1376,48 +1376,48 @@ NO CHANGE
 								(e-tag @184-3-184-5 (ext-var 0) (name "Ok") (args "TODO"))
 								(e-lookup-local @184-6-184-11
 									(pattern (id 248))))
-							(e-tuple @185-3-185-18 (tuple-var 358)
+							(e-tuple @185-3-185-18
 								(elems
 									(e-runtime-error (tag "ident_not_in_scope"))
 									(e-lookup-local @185-12-185-17
 										(pattern (id 313)))))
-							(e-list @186-3-186-12 (elem-var 369)
+							(e-list @186-3-186-12 (elem-var 366)
 								(elems
-									(e-int @186-4-186-5 (num-var 362) (sign-needed "false") (bits-needed "7") (value "1"))
-									(e-int @186-7-186-8 (num-var 365) (sign-needed "false") (bits-needed "7") (value "2"))
-									(e-int @186-10-186-11 (num-var 368) (sign-needed "false") (bits-needed "7") (value "3")))))))
+									(e-int @186-4-186-5 (num-var 359) (sign-needed "false") (bits-needed "7") (value "1"))
+									(e-int @186-7-186-8 (num-var 362) (sign-needed "false") (bits-needed "7") (value "2"))
+									(e-int @186-10-186-11 (num-var 365) (sign-needed "false") (bits-needed "7") (value "3")))))))
 				(s-let @188-2-189-23
-					(p-assign @188-2-188-15 (ident "bin_op_result") (id 374))
-					(e-binop @188-18-189-23 (op "or") (id 427)
+					(p-assign @188-2-188-15 (ident "bin_op_result") (id 370))
+					(e-binop @188-18-189-23 (op "or") (id 423)
 						(e-binop @188-18-188-74 (op "or")
 							(e-binop @188-18-188-43 (op "gt")
 								(e-binop @188-18-188-34 (op "null_coalesce")
 									(e-call @188-18-188-26
 										(e-tag @188-18-188-21 (ext-var 0) (name "Err") (args "TODO"))
 										(e-runtime-error (tag "ident_not_in_scope")))
-									(e-int @188-30-188-32 (num-var 382) (sign-needed "false") (bits-needed "7") (value "12")))
+									(e-int @188-30-188-32 (num-var 378) (sign-needed "false") (bits-needed "7") (value "12")))
 								(e-binop @188-35-188-43 (op "mul")
-									(e-int @188-35-188-36 (num-var 386) (sign-needed "false") (bits-needed "7") (value "5"))
-									(e-int @188-39-188-40 (num-var 389) (sign-needed "false") (bits-needed "7") (value "5"))))
+									(e-int @188-35-188-36 (num-var 382) (sign-needed "false") (bits-needed "7") (value "5"))
+									(e-int @188-39-188-40 (num-var 385) (sign-needed "false") (bits-needed "7") (value "5"))))
 							(e-binop @188-44-188-74 (op "and")
 								(e-binop @188-44-188-58 (op "lt")
 									(e-binop @188-44-188-52 (op "add")
-										(e-int @188-44-188-46 (num-var 394) (sign-needed "false") (bits-needed "7") (value "13"))
-										(e-int @188-49-188-50 (num-var 397) (sign-needed "false") (bits-needed "7") (value "2")))
-									(e-int @188-53-188-54 (num-var 401) (sign-needed "false") (bits-needed "7") (value "5")))
+										(e-int @188-44-188-46 (num-var 390) (sign-needed "false") (bits-needed "7") (value "13"))
+										(e-int @188-49-188-50 (num-var 393) (sign-needed "false") (bits-needed "7") (value "2")))
+									(e-int @188-53-188-54 (num-var 397) (sign-needed "false") (bits-needed "7") (value "5")))
 								(e-binop @188-59-188-74 (op "ge")
 									(e-binop @188-59-188-68 (op "sub")
-										(e-int @188-59-188-61 (num-var 405) (sign-needed "false") (bits-needed "7") (value "10"))
-										(e-int @188-64-188-65 (num-var 408) (sign-needed "false") (bits-needed "7") (value "1")))
-									(e-int @188-69-188-71 (num-var 412) (sign-needed "false") (bits-needed "7") (value "16")))))
+										(e-int @188-59-188-61 (num-var 401) (sign-needed "false") (bits-needed "7") (value "10"))
+										(e-int @188-64-188-65 (num-var 404) (sign-needed "false") (bits-needed "7") (value "1")))
+									(e-int @188-69-188-71 (num-var 408) (sign-needed "false") (bits-needed "7") (value "16")))))
 						(e-binop @188-75-189-23 (op "le")
-							(e-int @188-75-188-77 (num-var 418) (sign-needed "false") (bits-needed "7") (value "12"))
+							(e-int @188-75-188-77 (num-var 414) (sign-needed "false") (bits-needed "7") (value "12"))
 							(e-binop @188-81-189-23 (op "div")
-								(e-int @188-81-188-82 (num-var 421) (sign-needed "false") (bits-needed "7") (value "3"))
-								(e-int @188-85-188-86 (num-var 424) (sign-needed "false") (bits-needed "7") (value "5"))))))
+								(e-int @188-81-188-82 (num-var 417) (sign-needed "false") (bits-needed "7") (value "3"))
+								(e-int @188-85-188-86 (num-var 420) (sign-needed "false") (bits-needed "7") (value "5"))))))
 				(s-let @189-2-190-8
-					(p-assign @189-2-189-23 (ident "static_dispatch_style") (id 429))
-					(e-dot-access @189-26-190-8 (field "unknown") (id 434)
+					(p-assign @189-2-189-23 (ident "static_dispatch_style") (id 425))
+					(e-dot-access @189-26-190-8 (field "unknown") (id 430)
 						(receiver
 							(e-dot-access @189-26-189-110 (field "unknown")
 								(receiver
@@ -1428,7 +1428,7 @@ NO CHANGE
 					(e-runtime-error (tag "not_implemented")))
 				(e-call @191-2-195-3
 					(e-lookup-external
-						(ext-decl @191-2-191-14 (qualified "pf.Stdout.line!") (module "pf.Stdout") (local "line!") (kind "value") (type-var 439)))
+						(ext-decl @191-2-191-14 (qualified "pf.Stdout.line!") (module "pf.Stdout") (local "line!") (kind "value") (type-var 435)))
 					(e-string @192-3-194-18
 						(e-literal @192-4-192-14 (string "How about "))
 						(e-call @193-4-193-21
@@ -1436,7 +1436,7 @@ NO CHANGE
 							(e-lookup-local @193-14-193-20
 								(pattern (id 255))))
 						(e-literal @194-4-194-17 (string " as a string?"))))))
-		(annotation @144-1-144-6 (signature 461) (id 462)
+		(annotation @144-1-144-6 (signature 457) (id 458)
 			(declared-type
 				(ty-fn @143-9-143-38 (effectful false)
 					(ty-apply @143-9-143-21 (symbol "List")
@@ -1444,10 +1444,10 @@ NO CHANGE
 					(ty-apply @143-25-143-38 (symbol "Result")
 						(ty-record @143-32-143-34)
 						(ty-underscore @143-36-143-37))))))
-	(d-let (id 471)
-		(p-assign @199-1-199-6 (ident "empty") (id 465))
-		(e-runtime-error (tag "not_implemented") (id 467))
-		(annotation @199-1-199-6 (signature 469) (id 470)
+	(d-let (id 467)
+		(p-assign @199-1-199-6 (ident "empty") (id 461))
+		(e-runtime-error (tag "not_implemented") (id 463))
+		(annotation @199-1-199-6 (signature 465) (id 466)
 			(declared-type
 				(ty-record @198-9-198-11))))
 	(s-type-decl @22-1-23-6 (id 84)

--- a/src/snapshots/type_alias_parameterized.md
+++ b/src/snapshots/type_alias_parameterized.md
@@ -86,21 +86,21 @@ NO CHANGE
 # CANONICALIZE
 ~~~clojure
 (can-ir
-	(d-let (id 105)
+	(d-let (id 103)
 		(p-assign @6-1-6-9 (ident "swapPair") (id 90))
-		(e-lambda @6-12-6-27 (id 99)
+		(e-lambda @6-12-6-27 (id 97)
 			(args
-				(p-tuple @6-13-6-19 (tuple-var 93) (id 94)
+				(p-tuple @6-13-6-19 (id 93)
 					(patterns
 						(p-assign @6-14-6-15 (ident "x") (id 91))
 						(p-assign @6-17-6-18 (ident "y") (id 92)))))
-			(e-tuple @6-21-6-27 (tuple-var 97)
+			(e-tuple @6-21-6-27
 				(elems
 					(e-lookup-local @6-22-6-23
 						(pattern (id 92)))
 					(e-lookup-local @6-25-6-26
 						(pattern (id 91))))))
-		(annotation @6-1-6-9 (signature 103) (id 104)
+		(annotation @6-1-6-9 (signature 101) (id 102)
 			(declared-type
 				(ty-fn @5-12-5-36 (effectful false)
 					(ty-apply @5-12-5-22 (symbol "Pair")
@@ -109,16 +109,16 @@ NO CHANGE
 					(ty-apply @5-26-5-36 (symbol "Pair")
 						(ty-var @5-31-5-32 (name "b"))
 						(ty-var @5-34-5-35 (name "a")))))))
-	(d-let (id 117)
-		(p-assign @8-1-8-6 (ident "main!") (id 106))
-		(e-lambda @8-9-8-27 (id 116)
+	(d-let (id 115)
+		(p-assign @8-1-8-6 (ident "main!") (id 104))
+		(e-lambda @8-9-8-27 (id 114)
 			(args
-				(p-underscore @8-10-8-11 (id 107)))
+				(p-underscore @8-10-8-11 (id 105)))
 			(e-call @8-13-8-27
 				(e-lookup-local @8-13-8-21
 					(pattern (id 90)))
-				(e-int @8-22-8-23 (num-var 111) (sign-needed "false") (bits-needed "7") (value "1"))
-				(e-int @8-25-8-26 (num-var 114) (sign-needed "false") (bits-needed "7") (value "2")))))
+				(e-int @8-22-8-23 (num-var 109) (sign-needed "false") (bits-needed "7") (value "1"))
+				(e-int @8-25-8-26 (num-var 112) (sign-needed "false") (bits-needed "7") (value "2")))))
 	(s-type-decl @3-1-5-9 (id 78)
 		(ty-header @3-1-3-11 (name "Pair")
 			(ty-args

--- a/src/snapshots/type_alias_simple.md
+++ b/src/snapshots/type_alias_simple.md
@@ -79,15 +79,15 @@ NO CHANGE
 # CANONICALIZE
 ~~~clojure
 (can-ir
-	(d-let (id 101)
+	(d-let (id 100)
 		(p-assign @6-1-6-8 (ident "getUser") (id 78))
-		(e-lambda @1-1-1-1 (id 95)
+		(e-lambda @1-1-1-1 (id 94)
 			(args
 				(p-assign @6-12-6-14 (ident "id") (id 79)))
 			(e-if @1-1-1-1 (cond-var 0) (branch-var 0)
 				(if-branches
 					(if-branch
-						(e-tuple @6-19-6-28 (tuple-var 85)
+						(e-tuple @6-19-6-28
 							(elems
 								(e-binop @6-20-6-28 (op "gt")
 									(e-lookup-local @6-20-6-22
@@ -98,20 +98,20 @@ NO CHANGE
 				(if-else
 					(e-string @6-40-6-47
 						(e-literal @6-41-6-46 (string "small"))))))
-		(annotation @6-1-6-8 (signature 99) (id 100)
+		(annotation @6-1-6-8 (signature 98) (id 99)
 			(declared-type
 				(ty-fn @5-11-5-24 (effectful false)
 					(ty @5-11-5-17 (name "UserId"))
 					(ty @5-21-5-24 (name "Str"))))))
-	(d-let (id 110)
-		(p-assign @8-1-8-6 (ident "main!") (id 102))
-		(e-lambda @8-9-8-25 (id 109)
+	(d-let (id 109)
+		(p-assign @8-1-8-6 (ident "main!") (id 101))
+		(e-lambda @8-9-8-25 (id 108)
 			(args
-				(p-underscore @8-10-8-11 (id 103)))
+				(p-underscore @8-10-8-11 (id 102)))
 			(e-call @8-13-8-25
 				(e-lookup-local @8-13-8-20
 					(pattern (id 78)))
-				(e-int @8-21-8-24 (num-var 107) (sign-needed "false") (bits-needed "7") (value "100")))))
+				(e-int @8-21-8-24 (num-var 106) (sign-needed "false") (bits-needed "7") (value "100")))))
 	(s-type-decl @3-1-5-8 (id 74)
 		(ty-header @3-1-3-7 (name "UserId"))
 		(ty @3-10-3-13 (name "U64"))))

--- a/src/snapshots/type_annotation_basic.md
+++ b/src/snapshots/type_annotation_basic.md
@@ -203,19 +203,19 @@ main! = |_| {
 				(ty-fn @4-12-4-18 (effectful false)
 					(ty-var @4-12-4-13 (name "a"))
 					(ty-var @4-17-4-18 (name "a"))))))
-	(d-let (id 113)
+	(d-let (id 112)
 		(p-assign @9-1-9-8 (ident "combine") (id 98))
-		(e-lambda @9-11-9-42 (id 105)
+		(e-lambda @9-11-9-42 (id 104)
 			(args
 				(p-assign @9-12-9-17 (ident "first") (id 99))
 				(p-assign @9-19-9-25 (ident "second") (id 100)))
-			(e-tuple @9-27-9-42 (tuple-var 103)
+			(e-tuple @9-27-9-42
 				(elems
 					(e-lookup-local @9-28-9-33
 						(pattern (id 99)))
 					(e-lookup-local @9-35-9-41
 						(pattern (id 100))))))
-		(annotation @9-1-9-8 (signature 111) (id 112)
+		(annotation @9-1-9-8 (signature 110) (id 111)
 			(declared-type
 				(ty-fn @8-11-8-25 (effectful false)
 					(ty-var @8-11-8-12 (name "a"))
@@ -223,56 +223,56 @@ main! = |_| {
 					(ty-tuple @8-19-8-25
 						(ty-var @8-20-8-21 (name "a"))
 						(ty-var @8-23-8-24 (name "b")))))))
-	(d-let (id 130)
-		(p-assign @13-1-13-7 (ident "addOne") (id 117))
-		(e-lambda @13-10-15-6 (id 124)
+	(d-let (id 129)
+		(p-assign @13-1-13-7 (ident "addOne") (id 116))
+		(e-lambda @13-10-15-6 (id 123)
 			(args
-				(p-assign @13-11-13-12 (ident "n") (id 118)))
+				(p-assign @13-11-13-12 (ident "n") (id 117)))
 			(e-binop @13-14-15-6 (op "add")
 				(e-lookup-local @13-14-13-15
-					(pattern (id 118)))
-				(e-int @13-18-13-19 (num-var 122) (sign-needed "false") (bits-needed "7") (value "1"))))
-		(annotation @13-1-13-7 (signature 128) (id 129)
+					(pattern (id 117)))
+				(e-int @13-18-13-19 (num-var 121) (sign-needed "false") (bits-needed "7") (value "1"))))
+		(annotation @13-1-13-7 (signature 127) (id 128)
 			(declared-type
 				(ty-fn @12-10-12-20 (effectful false)
 					(ty @12-10-12-13 (name "U64"))
 					(ty @12-17-12-20 (name "U64"))))))
-	(d-let (id 163)
-		(p-assign @15-1-15-6 (ident "main!") (id 131))
-		(e-lambda @15-9-27-2 (id 162)
+	(d-let (id 162)
+		(p-assign @15-1-15-6 (ident "main!") (id 130))
+		(e-lambda @15-9-27-2 (id 161)
 			(args
-				(p-underscore @15-10-15-11 (id 132)))
+				(p-underscore @15-10-15-11 (id 131)))
 			(e-block @15-13-27-2
 				(s-let @17-5-17-23
-					(p-assign @17-5-17-8 (ident "num") (id 133))
-					(e-call @17-11-17-23 (id 138)
+					(p-assign @17-5-17-8 (ident "num") (id 132))
+					(e-call @17-11-17-23 (id 137)
 						(e-lookup-local @17-11-17-19
 							(pattern (id 77)))
-						(e-int @17-20-17-22 (num-var 137) (sign-needed "false") (bits-needed "7") (value "42"))))
+						(e-int @17-20-17-22 (num-var 136) (sign-needed "false") (bits-needed "7") (value "42"))))
 				(s-let @18-5-18-29
-					(p-assign @18-5-18-9 (ident "text") (id 140))
-					(e-call @18-12-18-29 (id 144)
+					(p-assign @18-5-18-9 (ident "text") (id 139))
+					(e-call @18-12-18-29 (id 143)
 						(e-lookup-local @18-12-18-20
 							(pattern (id 77)))
 						(e-string @18-21-18-28
 							(e-literal @18-22-18-27 (string "hello")))))
 				(s-let @21-5-21-30
-					(p-assign @21-5-21-9 (ident "pair") (id 146))
-					(e-call @21-12-21-30 (id 150)
+					(p-assign @21-5-21-9 (ident "pair") (id 145))
+					(e-call @21-12-21-30 (id 149)
 						(e-lookup-local @21-12-21-19
 							(pattern (id 98)))
 						(e-lookup-local @21-20-21-23
-							(pattern (id 133)))
+							(pattern (id 132)))
 						(e-lookup-local @21-25-21-29
-							(pattern (id 140)))))
+							(pattern (id 139)))))
 				(s-let @24-5-24-23
-					(p-assign @24-5-24-11 (ident "result") (id 152))
-					(e-call @24-14-24-23 (id 157)
+					(p-assign @24-5-24-11 (ident "result") (id 151))
+					(e-call @24-14-24-23 (id 156)
 						(e-lookup-local @24-14-24-20
-							(pattern (id 117)))
-						(e-int @24-21-24-22 (num-var 156) (sign-needed "false") (bits-needed "7") (value "5"))))
+							(pattern (id 116)))
+						(e-int @24-21-24-22 (num-var 155) (sign-needed "false") (bits-needed "7") (value "5"))))
 				(e-lookup-local @26-5-26-11
-					(pattern (id 152)))))))
+					(pattern (id 151)))))))
 ~~~
 # TYPES
 ~~~clojure

--- a/src/snapshots/type_same_var_multiple_uses.md
+++ b/src/snapshots/type_same_var_multiple_uses.md
@@ -67,29 +67,29 @@ NO CHANGE
 # CANONICALIZE
 ~~~clojure
 (can-ir
-	(d-let (id 93)
+	(d-let (id 92)
 		(p-assign @4-1-4-5 (ident "pair") (id 80))
-		(e-lambda @4-8-4-18 (id 86)
+		(e-lambda @4-8-4-18 (id 85)
 			(args
 				(p-assign @4-9-4-10 (ident "x") (id 81)))
-			(e-tuple @4-12-4-18 (tuple-var 84)
+			(e-tuple @4-12-4-18
 				(elems
 					(e-lookup-local @4-13-4-14
 						(pattern (id 81)))
 					(e-lookup-local @4-16-4-17
 						(pattern (id 81))))))
-		(annotation @4-1-4-5 (signature 91) (id 92)
+		(annotation @4-1-4-5 (signature 90) (id 91)
 			(declared-type
 				(ty-fn @3-8-3-19 (effectful false)
 					(ty-var @3-8-3-9 (name "a"))
 					(ty-tuple @3-13-3-19
 						(ty-var @3-14-3-15 (name "a"))
 						(ty-var @3-17-3-18 (name "a")))))))
-	(d-let (id 99)
-		(p-assign @6-1-6-6 (ident "main!") (id 94))
-		(e-lambda @6-9-6-15 (id 98)
+	(d-let (id 98)
+		(p-assign @6-1-6-6 (ident "main!") (id 93))
+		(e-lambda @6-9-6-15 (id 97)
 			(args
-				(p-underscore @6-10-6-11 (id 95)))
+				(p-underscore @6-10-6-11 (id 94)))
 			(e-runtime-error (tag "not_implemented")))))
 ~~~
 # TYPES

--- a/src/snapshots/type_two_variables.md
+++ b/src/snapshots/type_two_variables.md
@@ -71,21 +71,21 @@ NO CHANGE
 # CANONICALIZE
 ~~~clojure
 (can-ir
-	(d-let (id 98)
+	(d-let (id 96)
 		(p-assign @4-1-4-5 (ident "swap") (id 83))
-		(e-lambda @4-8-4-23 (id 92)
+		(e-lambda @4-8-4-23 (id 90)
 			(args
-				(p-tuple @4-9-4-15 (tuple-var 86) (id 87)
+				(p-tuple @4-9-4-15 (id 86)
 					(patterns
 						(p-assign @4-10-4-11 (ident "x") (id 84))
 						(p-assign @4-13-4-14 (ident "y") (id 85)))))
-			(e-tuple @4-17-4-23 (tuple-var 90)
+			(e-tuple @4-17-4-23
 				(elems
 					(e-lookup-local @4-18-4-19
 						(pattern (id 85)))
 					(e-lookup-local @4-21-4-22
 						(pattern (id 84))))))
-		(annotation @4-1-4-5 (signature 96) (id 97)
+		(annotation @4-1-4-5 (signature 94) (id 95)
 			(declared-type
 				(ty-fn @3-8-3-24 (effectful false)
 					(ty-tuple @3-8-3-14
@@ -94,11 +94,11 @@ NO CHANGE
 					(ty-tuple @3-18-3-24
 						(ty-var @3-19-3-20 (name "b"))
 						(ty-var @3-22-3-23 (name "a")))))))
-	(d-let (id 104)
-		(p-assign @6-1-6-6 (ident "main!") (id 99))
-		(e-lambda @6-9-6-15 (id 103)
+	(d-let (id 102)
+		(p-assign @6-1-6-6 (ident "main!") (id 97))
+		(e-lambda @6-9-6-15 (id 101)
 			(args
-				(p-underscore @6-10-6-11 (id 100)))
+				(p-underscore @6-10-6-11 (id 98)))
 			(e-runtime-error (tag "not_implemented")))))
 ~~~
 # TYPES

--- a/src/snapshots/type_var_multiple.md
+++ b/src/snapshots/type_var_multiple.md
@@ -122,25 +122,25 @@ main! = |_| {}
 # CANONICALIZE
 ~~~clojure
 (can-ir
-	(d-let (id 107)
+	(d-let (id 105)
 		(p-assign @5-1-5-5 (ident "swap") (id 83))
-		(e-lambda @5-8-8-2 (id 101)
+		(e-lambda @5-8-8-2 (id 99)
 			(args
 				(p-assign @5-9-5-13 (ident "pair") (id 84)))
 			(e-block @5-15-8-2
 				(s-expr @6-5-6-22
-					(e-tuple @6-5-6-20 (tuple-var 89)
+					(e-tuple @6-5-6-20
 						(elems
 							(e-runtime-error (tag "ident_not_in_scope"))
 							(e-runtime-error (tag "ident_not_in_scope")))))
 				(s-expr @6-23-7-6
 					(e-lookup-local @6-23-6-27
 						(pattern (id 84))))
-				(e-tuple @7-5-7-20 (tuple-var 98)
+				(e-tuple @7-5-7-20
 					(elems
 						(e-runtime-error (tag "ident_not_in_scope"))
 						(e-runtime-error (tag "ident_not_in_scope"))))))
-		(annotation @5-1-5-5 (signature 105) (id 106)
+		(annotation @5-1-5-5 (signature 103) (id 104)
 			(declared-type
 				(ty-fn @4-8-4-24 (effectful false)
 					(ty-tuple @4-8-4-14
@@ -149,11 +149,11 @@ main! = |_| {}
 					(ty-tuple @4-18-4-24
 						(ty-var @4-19-4-20 (name "b"))
 						(ty-var @4-22-4-23 (name "a")))))))
-	(d-let (id 113)
-		(p-assign @10-1-10-6 (ident "main!") (id 108))
-		(e-lambda @10-9-10-15 (id 112)
+	(d-let (id 111)
+		(p-assign @10-1-10-6 (ident "main!") (id 106))
+		(e-lambda @10-9-10-15 (id 110)
 			(args
-				(p-underscore @10-10-10-11 (id 109)))
+				(p-underscore @10-10-10-11 (id 107)))
 			(e-runtime-error (tag "not_implemented")))))
 ~~~
 # TYPES

--- a/src/snapshots/type_var_namespace.md
+++ b/src/snapshots/type_var_namespace.md
@@ -149,9 +149,9 @@ main! = |_| {}
 # CANONICALIZE
 ~~~clojure
 (can-ir
-	(d-let (id 109)
+	(d-let (id 108)
 		(p-assign @5-1-5-8 (ident "process") (id 78))
-		(e-lambda @5-11-14-2 (id 102)
+		(e-lambda @5-11-14-2 (id 101)
 			(args
 				(p-assign @5-12-5-16 (ident "list") (id 79)))
 			(e-block @5-18-14-2
@@ -159,8 +159,8 @@ main! = |_| {}
 					(p-assign @7-5-7-9 (ident "elem") (id 80))
 					(e-int @7-12-7-14 (num-var 83) (sign-needed "false") (bits-needed "7") (value "42") (id 83)))
 				(s-let @11-5-11-30
-					(p-assign @11-5-11-11 (ident "result") (id 89))
-					(e-call @11-14-11-30 (id 93)
+					(p-assign @11-5-11-11 (ident "result") (id 88))
+					(e-call @11-14-11-30 (id 92)
 						(e-runtime-error (tag "ident_not_in_scope"))
 						(e-lookup-local @11-25-11-29
 							(pattern (id 79)))))
@@ -170,18 +170,18 @@ main! = |_| {}
 						(e-lookup-local @11-53-11-57
 							(pattern (id 80)))))
 				(e-lookup-local @13-5-13-11
-					(pattern (id 89)))))
-		(annotation @5-1-5-8 (signature 107) (id 108)
+					(pattern (id 88)))))
+		(annotation @5-1-5-8 (signature 106) (id 107)
 			(declared-type
 				(ty-fn @4-11-4-29 (effectful false)
 					(ty-apply @4-11-4-21 (symbol "List")
 						(ty-var @4-16-4-20 (name "elem")))
 					(ty-var @4-25-4-29 (name "elem"))))))
-	(d-let (id 115)
-		(p-assign @16-1-16-6 (ident "main!") (id 110))
-		(e-lambda @16-9-16-15 (id 114)
+	(d-let (id 114)
+		(p-assign @16-1-16-6 (ident "main!") (id 109))
+		(e-lambda @16-9-16-15 (id 113)
 			(args
-				(p-underscore @16-10-16-11 (id 111)))
+				(p-underscore @16-10-16-11 (id 110)))
 			(e-runtime-error (tag "not_implemented")))))
 ~~~
 # TYPES

--- a/src/types/store.zig
+++ b/src/types/store.zig
@@ -241,6 +241,11 @@ pub const Store = struct {
         return self.alias_args.appendSlice(self.gpa, slice);
     }
 
+    /// Append a tuple elem to the backing list, returning the idx
+    pub fn appendTupleElem(self: *Self, v: Var) VarSafeList.Idx {
+        return self.tuple_elems.append(self.gpa, v);
+    }
+
     /// Append a slice of tuple elems to the backing list, returning the range
     pub fn appendTupleElems(self: *Self, slice: []const Var) VarSafeList.Range {
         return self.tuple_elems.appendSlice(self.gpa, slice);


### PR DESCRIPTION
This MR adds basic type solving for tuple exprs.

It also removes the sub `tuple_var` field in favor of using the `Expr`'s `Idx` as the type variable for the whole node, as mentioned [here](https://roc.zulipchat.com/#narrow/channel/395097-compiler-development/topic/zig.20compiler.20-.20.60var.60.20fields.20on.20Can.20structs/with/525909297) in Zulip. Depending on what shakes out from that thread, I can update this PR to match!