### PR TITLE
DRAFT: Better handle ambiguous parsing

### DIFF
--- a/src/check/parse/AST.zig
+++ b/src/check/parse/AST.zig
@@ -900,26 +900,32 @@ pub const Pattern = union(enum) {
     tag: TagNode(Pattern.Span),
     int: TokenWithRegion,
     frac: TokenWithRegion,
-    string: struct {
-        string_tok: Token.Idx,
-        region: TokenizedRegion,
-        expr: Expr.Idx,
-    },
+    string: Pattern.String,
     record: ItemsWithRegion(PatternRecordField.Span),
     list: ItemsWithRegion(Pattern.Span),
-    list_rest: struct {
-        name: ?Token.Idx,
-        region: TokenizedRegion,
-    },
+    list_rest: Pattern.Rest,
     tuple: ItemsWithRegion(Pattern.Span),
     underscore: Underscore,
     alternatives: ItemsWithRegion(Pattern.Span),
-    as: struct {
+    as: Pattern.As,
+    malformed: MalformedNode,
+
+    pub const As = struct {
         pattern: Pattern.Idx,
         name: Token.Idx,
         region: TokenizedRegion,
-    },
-    malformed: MalformedNode,
+    };
+
+    pub const Rest = struct {
+        name: ?Token.Idx,
+        region: TokenizedRegion,
+    };
+
+    pub const String = struct {
+        string_tok: Token.Idx,
+        region: TokenizedRegion,
+        expr: Expr.Idx,
+    };
 
     pub const Idx = enum(u32) { _ };
     pub const Span = struct { span: base.DataSpan };
@@ -1628,76 +1634,86 @@ pub const WhereClause = union(enum) {
 pub const Expr = union(enum) {
     int: TokenWithRegion,
     frac: TokenWithRegion,
-
-    string_part: struct { // TODO: this should be more properly represented in its own union enum
-        token: Token.Idx,
-        region: TokenizedRegion,
-    },
-    string: struct {
-        token: Token.Idx,
-        region: TokenizedRegion,
-        parts: Expr.Span,
-    },
+    string_part: Expr.StringPart,
+    string: Expr.String,
     list: ItemsWithRegion(Expr.Span),
     tuple: ItemsWithRegion(Expr.Span),
-    record: struct {
-        fields: RecordField.Span,
-        region: TokenizedRegion,
-    },
-    tag: struct { // TODO: This should include args like it does in Patterns and Types
-        token: Token.Idx,
-        args: Expr.Span,
-        region: TokenizedRegion,
-    },
-    lambda: struct {
-        args: Pattern.Span,
-        body: Expr.Idx,
-        region: TokenizedRegion,
-    },
-    apply: struct {
-        args: Expr.Span,
-        @"fn": Expr.Idx,
-        region: TokenizedRegion,
-    },
-    record_updater: struct { // TODO: This hasn't been implemented yet
-        token: Token.Idx,
-        region: TokenizedRegion,
-    },
+    record: ItemsWithRegion(RecordField.Span),
+    tag: TagNode,
+    lambda: Expr.Lambda,
+    apply: Expr.Apply,
+    record_updater: Expr.RecordUpdater,
     field_access: BinOp,
     local_dispatch: BinOp,
     bin_op: BinOp,
     suffix_single_question: Unary,
     unary_op: Unary,
-    if_then_else: struct {
+    if_then_else: Expr.IfThenElse,
+    match: Expr.Match,
+    ident: Expr.Ident,
+    dbg: Expr.Dbg,
+    record_builder: RecordBuilder,
+    ellipsis: Underscore,
+    block: Body,
+    malformed: MalformedNode,
+
+    const Ident = struct {
+        token: Token.Idx,
+        qualifier: ?Token.Idx,
+        region: TokenizedRegion,
+    };
+
+    const StringPart = struct { // TODO: this should be more properly represented in its own union enum
+        token: Token.Idx,
+        region: TokenizedRegion,
+    };
+
+    const String = struct {
+        token: Token.Idx,
+        region: TokenizedRegion,
+        parts: Expr.Span,
+    };
+
+    const Lambda = struct {
+        args: Pattern.Span,
+        body: Expr.Idx,
+        region: TokenizedRegion,
+    };
+
+    const Apply = struct {
+        args: Expr.Span,
+        @"fn": Expr.Idx,
+        region: TokenizedRegion,
+    };
+
+    const RecordUpdater = struct { // TODO: This hasn't been implemented yet
+        token: Token.Idx,
+        region: TokenizedRegion,
+    };
+
+    const IfThenElse = struct {
         condition: Expr.Idx,
         then: Expr.Idx,
         @"else": Expr.Idx,
         region: TokenizedRegion,
-    },
-    match: struct {
+    };
+
+    const Match = struct {
         expr: Expr.Idx,
         branches: WhenBranch.Span,
         region: TokenizedRegion,
-    },
-    ident: struct {
-        token: Token.Idx,
-        qualifier: ?Token.Idx,
-        region: TokenizedRegion,
-    },
-    dbg: struct {
+    };
+
+    const Dbg = struct {
         expr: Expr.Idx,
         region: TokenizedRegion,
-    },
-    record_builder: struct {
+    };
+
+    const RecordBuilder = struct {
         mapper: Expr.Idx,
         fields: RecordField.Idx,
         region: TokenizedRegion,
-    },
-    ellipsis: struct {
-        region: TokenizedRegion,
-    },
-    block: Body,
-    malformed: MalformedNode,
+    };
 
     pub const Idx = enum(u32) { _ };
     pub const Span = struct { span: base.DataSpan };

--- a/src/check/parse/Parser.zig
+++ b/src/check/parse/Parser.zig
@@ -2396,6 +2396,35 @@ pub fn parseWhereClause(self: *Parser) AST.WhereClause.Idx {
     }
 }
 
+pub const UntypedNodeType = enum {
+    /// The nodes that were parsed could any type.
+    /// The next token should reveal intent based on context.
+    any,
+    /// The nodes that were parsed were clearly a type.
+    /// This might never naturally occur.
+    ty_header,
+    /// The nodes that were parsed were clearly a pattern.
+    /// This means we encountered a `|` or a `where` clause.
+    patt,
+    /// The nodes that were parsed were clearly an expr.
+    /// We encountered a keyword besides `where` or `as`,
+    /// string interpolation, a lambda, a apply with lower ident,
+    /// a unary operator,  binop, ellipsis, or some sort of field
+    /// access
+    expr,
+};
+
+/// Parses a syntactic node that is ambiguous in terms of node type -
+/// storing it in as an `Untyped` node until we discover what type it
+/// should be.  We then return an [UntypedNodeType] of the appropriate type to the
+/// caller you will use that information to continue parsing.
+///
+/// The caller should get the top of the untypedScratch and untypedRecordFieldScratch
+/// before calling this function.
+pub fn parseUntypedStmtStart(self: *Parser) UntypedNodeType {
+    _ = self;
+}
+
 /// todo
 pub fn addProblem(self: *Parser, diagnostic: AST.Diagnostic) void {
     self.diagnostics.append(diagnostic) catch |err| exitOnOom(err);


### PR DESCRIPTION
This is A DRAFT.  Feedback is welcome, but understand this will take a number of days to complete.  I will post my work at the end of every day that I work on it.  Hit me on Zulip if you want to talk about the approach in more detail.

Here is the high level plan:

- Untyped parse nodes
- Unified structure for all nodes that appear in two or more node types (Pattern, Expr, and TypeAnno)
- Add parseUntypedNode function and related bits to parser
  - Only called in ambiguous parsing contexts like: Beginning of statement that does not state with keyword; Parsing top of block/record in expr parsing.
- Untyped scratch
- Functions to convert from untyped to typed nodes (hopefully just change tag)
- After conversion, continue parsing where it would have been if we knew the type from the start.