### PR TITLE
tokenize.zig refinements

### DIFF
--- a/src/check/parse/tokenize.zig
+++ b/src/check/parse/tokenize.zig
@@ -446,7 +446,7 @@ pub const TokenizedBuffer = struct {
         };
         if (comment) |c| {
             token.offset = c.begin;
-            token.extra = .{ .length = if (c.end > c.begin) c.end - c.begin else 0 };
+            token.extra = .{ .length = c.end - c.begin };
         }
         self.tokens.append(self.env.gpa, token) catch |err| exitOnOom(err);
     }
@@ -463,6 +463,15 @@ pub const TokenizedBuffer = struct {
 pub const Comment = struct {
     begin: u32,
     end: u32,
+
+    pub fn init(begin: u32, end: u32) Comment {
+        std.debug.assert(begin <= end);
+
+        return Comment{
+            .begin = begin,
+            .end = end,
+        };
+    }
 };
 
 /// Represents a diagnostic message including its position in the source.
@@ -656,7 +665,7 @@ pub const Cursor = struct {
                 while (self.pos < self.buf.len and self.buf[self.pos] != '\n' and self.buf[self.pos] != '\r') {
                     self.pos += 1;
                 }
-                self.comment = Comment{ .begin = comment_start, .end = self.pos };
+                self.comment = Comment.init(comment_start, self.pos);
             } else if (b >= 0 and b <= 31) {
                 self.pushMessageHere(.AsciiControl);
                 self.pos += 1;

--- a/src/check/parse/tokenize.zig
+++ b/src/check/parse/tokenize.zig
@@ -681,12 +681,6 @@ pub const Cursor = struct {
         return null;
     }
 
-    fn maybeMessageForUppercaseBase(self: *Cursor, b: u8) void {
-        if (b == 'X' or b == 'O' or b == 'B') {
-            self.pushMessageHere(.UppercaseBase);
-        }
-    }
-
     pub fn chompNumber(self: *Cursor, initialDigit: u8) Token.Tag {
         // Consume the initial digit.
         std.debug.assert(initialDigit == self.buf[self.pos]);
@@ -698,7 +692,9 @@ pub const Cursor = struct {
                 const c = self.peek() orelse 0;
                 switch (c) {
                     'x', 'X' => {
-                        maybeMessageForUppercaseBase(self, c);
+                        if (c == 'X') {
+                            self.pushMessageHere(.UppercaseBase);
+                        }
                         self.pos += 1;
                         self.chompIntegerBase16() catch {
                             tok = .MalformedNumberNoDigits;
@@ -707,7 +703,9 @@ pub const Cursor = struct {
                         break;
                     },
                     'o', 'O' => {
-                        maybeMessageForUppercaseBase(self, c);
+                        if (c == 'O') {
+                            self.pushMessageHere(.UppercaseBase);
+                        }
                         self.pos += 1;
                         self.chompIntegerBase8() catch {
                             tok = .MalformedNumberNoDigits;
@@ -716,7 +714,9 @@ pub const Cursor = struct {
                         break;
                     },
                     'b', 'B' => {
-                        maybeMessageForUppercaseBase(self, c);
+                        if (c == 'B') {
+                            self.pushMessageHere(.UppercaseBase);
+                        }
                         self.pos += 1;
                         self.chompIntegerBase2() catch {
                             tok = .MalformedNumberNoDigits;

--- a/src/check/parse/tokenize.zig
+++ b/src/check/parse/tokenize.zig
@@ -681,9 +681,8 @@ pub const Cursor = struct {
         return null;
     }
 
-    pub fn chompNumber(self: *Cursor, initialDigit: u8) Token.Tag {
-        // Consume the initial digit.
-        std.debug.assert(initialDigit == self.buf[self.pos]);
+    pub fn chompNumber(self: *Cursor) Token.Tag {
+        const initialDigit = self.buf[self.pos];
         self.pos += 1;
 
         var tok = Token.Tag.Int;
@@ -1211,7 +1210,7 @@ pub const Tokenizer = struct {
                             self.output.pushTokenNormal(.OpBinaryMinus, start, 1);
                         } else if (n >= '0' and n <= '9' and sp) {
                             self.cursor.pos += 1;
-                            const tag = self.cursor.chompNumber(n);
+                            const tag = self.cursor.chompNumber();
                             const len = self.cursor.pos - start;
                             self.output.pushTokenNormal(tag, start, len);
                         } else {
@@ -1430,7 +1429,7 @@ pub const Tokenizer = struct {
 
                 // Numbers starting with 0-9
                 '0'...'9' => {
-                    const tag = self.cursor.chompNumber(b);
+                    const tag = self.cursor.chompNumber();
                     const len = self.cursor.pos - start;
                     self.output.pushTokenNormal(tag, start, len);
                 },

--- a/src/check/parse/tokenize.zig
+++ b/src/check/parse/tokenize.zig
@@ -519,7 +519,7 @@ pub const Diagnostic = struct {
         var carets = std.ArrayList(u8).init(gpa);
         defer carets.deinit();
 
-        const caret_length = if (self.end > self.begin) self.end - self.begin else 1;
+        const caret_length = @max(self.end - self.begin, 1);
         for (0..caret_length) |_| {
             try carets.append('^');
         }

--- a/src/check/parse/tokenize.zig
+++ b/src/check/parse/tokenize.zig
@@ -465,20 +465,6 @@ pub const Comment = struct {
     end: u32,
 };
 
-/// Represents a unicode character parse from the source.
-const Unicode = struct {
-    tag: Tag,
-    length: u32,
-
-    const Tag = enum {
-        LetterUpper,
-        LetterNotUpper,
-        Digit,
-        Other,
-        Invalid,
-    };
-};
-
 /// Represents a diagnostic message including its position in the source.
 pub const Diagnostic = struct {
     tag: Tag,

--- a/src/snapshots/numbers.md
+++ b/src/snapshots/numbers.md
@@ -1,0 +1,93 @@
+# META
+~~~ini
+description=Number formats
+type=expr
+~~~
+# SOURCE
+~~~roc
+(
+    0X42,
+    0x42,
+    0B01,
+    0b01,
+    0O42,
+    0o42,
+    0.1e42,
+    0xDEADBEEF,
+    0xdeadbeef,
+    0xDeAdBeEf,
+)
+~~~
+# PROBLEMS
+**UPPERCASE BASE**
+Number base prefixes must be lowercase (0x, 0o, 0b).
+
+**UPPERCASE BASE**
+Number base prefixes must be lowercase (0x, 0o, 0b).
+
+**UPPERCASE BASE**
+Number base prefixes must be lowercase (0x, 0o, 0b).
+
+# TOKENS
+~~~zig
+OpenRound(1:1-1:2),Newline(1:1-1:1),
+Int(2:5-2:9),Comma(2:9-2:10),Newline(1:1-1:1),
+Int(3:5-3:9),Comma(3:9-3:10),Newline(1:1-1:1),
+Int(4:5-4:9),Comma(4:9-4:10),Newline(1:1-1:1),
+Int(5:5-5:9),Comma(5:9-5:10),Newline(1:1-1:1),
+Int(6:5-6:9),Comma(6:9-6:10),Newline(1:1-1:1),
+Int(7:5-7:9),Comma(7:9-7:10),Newline(1:1-1:1),
+Float(8:5-8:11),Comma(8:11-8:12),Newline(1:1-1:1),
+Int(9:5-9:15),Comma(9:15-9:16),Newline(1:1-1:1),
+Int(10:5-10:15),Comma(10:15-10:16),Newline(1:1-1:1),
+Int(11:5-11:15),Comma(11:15-11:16),Newline(1:1-1:1),
+CloseRound(12:1-12:2),EndOfFile(12:2-12:2),
+~~~
+# PARSE
+~~~clojure
+(e-tuple @1.1-12.2
+	(e-int @2.5-2.9 (raw "0X42"))
+	(e-int @3.5-3.9 (raw "0x42"))
+	(e-int @4.5-4.9 (raw "0B01"))
+	(e-int @5.5-5.9 (raw "0b01"))
+	(e-int @6.5-6.9 (raw "0O42"))
+	(e-int @7.5-7.9 (raw "0o42"))
+	(e-frac @8.5-8.11 (raw "0.1e42"))
+	(e-int @9.5-9.15 (raw "0xDEADBEEF"))
+	(e-int @10.5-10.15 (raw "0xdeadbeef"))
+	(e-int @11.5-11.15 (raw "0xDeAdBeEf")))
+~~~
+# FORMATTED
+~~~roc
+(
+	0X42,
+	0x42,
+	0B01,
+	0b01,
+	0O42,
+	0o42,
+	0.1e42,
+	0xDEADBEEF,
+	0xdeadbeef,
+	0xDeAdBeEf,
+)
+~~~
+# CANONICALIZE
+~~~clojure
+(e-tuple @1.1-12.2 (id 83)
+	(elems
+		(e-int @2.5-2.9 (value "66"))
+		(e-int @3.5-3.9 (value "66"))
+		(e-int @4.5-4.9 (value "1"))
+		(e-int @5.5-5.9 (value "1"))
+		(e-int @6.5-6.9 (value "34"))
+		(e-int @7.5-7.9 (value "34"))
+		(e-frac-f64 @8.5-8.11 (value "1e41"))
+		(e-int @9.5-9.15 (value "3735928559"))
+		(e-int @10.5-10.15 (value "3735928559"))
+		(e-int @11.5-11.15 (value "3735928559"))))
+~~~
+# TYPES
+~~~clojure
+(expr (id 83) (type "(Int(*), Int(*), Int(*), Int(*), Int(*), Int(*), Frac(*), Int(*), Int(*), Int(*))"))
+~~~


### PR DESCRIPTION
I'm not confident in the zig compiler yet so I started reading code from the beginning. Performed a minimal cleanup along the way. And some questions:

1. Does it make sense to use region struct instead of `offset + length` and `begin + end` (we have both patterns in different places)?
2. [What is `SingleQuote`](https://github.com/roc-lang/roc/blob/259b290c2a39e45f683d329d16ba2963cec13c68/src/check/parse/tokenize.zig#L980-L1006)? I guess it was prepared for multiline but now we have different syntax (`"""`)?
3. [Why newline has 0-0 region](https://github.com/roc-lang/roc/blob/259b290c2a39e45f683d329d16ba2963cec13c68/src/check/parse/tokenize.zig#L444-L445)? Newline's [offset is used for the indent](https://github.com/roc-lang/roc/blob/259b290c2a39e45f683d329d16ba2963cec13c68/src/check/parse/tokenize.zig#L456). Why not to use a dedicated field for it? Zeroed region seems to be misleading if it ends up in a warning message

