### PR TITLE
Remove branch_var from if_then_else

### DIFF
--- a/src/check/canonicalize.zig
+++ b/src/check/canonicalize.zig
@@ -234,7 +234,7 @@ pub const CIR = @import("canonicalize/CIR.zig");
 /// The canonicalization occurs on a single module (file) in isolation. This allows for this work to be easily parallelized and also cached. So where the source code for a module has not changed, the CanIR can simply be loaded from disk and used immediately.
 pub fn canonicalize_file(
     self: *Self,
-) void {
+) std.mem.Allocator.Error!void {
     const file = self.parse_ir.store.getFile();
 
     // canonicalize_header_packages();
@@ -296,7 +296,7 @@ pub fn canonicalize_file(
                 _ = self.canonicalizeImportStatement(import_stmt);
             },
             .decl => |decl| {
-                const def_idx = self.canonicalize_decl(decl);
+                const def_idx = try self.canonicalize_decl(decl);
                 self.can_ir.store.addScratchDef(def_idx);
             },
             .@"var" => {
@@ -724,7 +724,7 @@ fn introduceExposedItemsIntoScope(
 fn canonicalize_decl(
     self: *Self,
     decl: AST.Statement.Decl,
-) CIR.Def.Idx {
+) std.mem.Allocator.Error!CIR.Def.Idx {
     const pattern_region = self.parse_ir.tokenizedRegionToRegion(self.parse_ir.store.getPattern(decl.pattern).to_tokenized_region());
     const expr_region = self.parse_ir.tokenizedRegionToRegion(self.parse_ir.store.getExpr(decl.body).to_tokenized_region());
 
@@ -740,7 +740,7 @@ fn canonicalize_decl(
     };
 
     const expr_idx = blk: {
-        if (self.canonicalize_expr(decl.body)) |idx| {
+        if (try self.canonicalize_expr(decl.body)) |idx| {
             break :blk idx;
         } else {
             const malformed_idx = self.can_ir.pushMalformed(CIR.Expr.Idx, CIR.Diagnostic{ .expr_not_canonicalized = .{
@@ -815,7 +815,7 @@ fn canonicalize_decl(
 fn canonicalize_record_field(
     self: *Self,
     ast_field_idx: AST.RecordField.Idx,
-) ?CIR.RecordField.Idx {
+) std.mem.Allocator.Error!?CIR.RecordField.Idx {
     const field = self.parse_ir.store.getRecordField(ast_field_idx);
 
     // Canonicalize the field name
@@ -825,7 +825,7 @@ fn canonicalize_record_field(
 
     // Canonicalize the field value
     const value = if (field.value) |v|
-        self.canonicalize_expr(v) orelse return null
+        try self.canonicalize_expr(v) orelse return null
     else blk: {
         // Shorthand syntax: create implicit identifier expression
         // For { name, age }, this creates an implicit identifier lookup for "name" etc.
@@ -837,7 +837,7 @@ fn canonicalize_record_field(
             },
         };
         const ident_expr_idx = self.parse_ir.store.addExpr(ident_expr);
-        break :blk self.canonicalize_expr(ident_expr_idx) orelse return null;
+        break :blk try self.canonicalize_expr(ident_expr_idx) orelse return null;
     };
 
     // Create the CIR record field
@@ -853,7 +853,7 @@ fn canonicalize_record_field(
 pub fn canonicalize_expr(
     self: *Self,
     ast_expr_idx: AST.Expr.Idx,
-) ?CIR.Expr.Idx {
+) std.mem.Allocator.Error!?CIR.Expr.Idx {
     const expr = self.parse_ir.store.getExpr(ast_expr_idx);
 
     switch (expr) {
@@ -862,7 +862,7 @@ pub fn canonicalize_expr(
             const scratch_top = self.can_ir.store.scratchExprTop();
 
             // Canonicalize the function being called and add as first element
-            const fn_expr = self.canonicalize_expr(e.@"fn") orelse {
+            const fn_expr = try self.canonicalize_expr(e.@"fn") orelse {
                 self.can_ir.store.clearScratchExprsFrom(scratch_top);
                 return null;
             };
@@ -871,7 +871,7 @@ pub fn canonicalize_expr(
             // Canonicalize and add all arguments
             const args_slice = self.parse_ir.store.exprSlice(e.args);
             for (args_slice) |arg| {
-                if (self.canonicalize_expr(arg)) |canonicalized_arg_expr_idx| {
+                if (try self.canonicalize_expr(arg)) |canonicalized_arg_expr_idx| {
                     self.can_ir.store.addScratchExpr(canonicalized_arg_expr_idx);
                 }
             }
@@ -1176,7 +1176,7 @@ pub fn canonicalize_expr(
             //
             // Returns a Expr.Span containing the canonicalized string segments
             // a string may consist of multiple string literal or expression segments
-            const str_segments_span = self.extractStringSegments(parts);
+            const str_segments_span = try self.extractStringSegments(parts);
 
             const expr_idx = self.can_ir.store.addExpr(CIR.Expr{ .e_str = .{
                 .span = str_segments_span,
@@ -1216,7 +1216,7 @@ pub fn canonicalize_expr(
             // Iterate over the list item, canonicalizing each one
             // Then append the result to the scratch list
             for (items_slice) |item| {
-                if (self.canonicalize_expr(item)) |canonicalized| {
+                if (try self.canonicalize_expr(item)) |canonicalized| {
                     self.can_ir.store.addScratchExpr(canonicalized);
                 }
             }
@@ -1301,7 +1301,7 @@ pub fn canonicalize_expr(
             const items_slice = self.parse_ir.store.exprSlice(e.items);
             const elems_var_top = self.can_ir.env.types.tuple_elems.len();
             for (items_slice) |item| {
-                if (self.canonicalize_expr(item)) |canonicalized| {
+                if (try self.canonicalize_expr(item)) |canonicalized| {
                     self.can_ir.store.addScratchExpr(canonicalized);
                     _ = self.can_ir.env.types.appendTupleElem(@enumFromInt(@intFromEnum(canonicalized)));
                 }
@@ -1391,13 +1391,13 @@ pub fn canonicalize_expr(
                         }) catch |err| exitOnOom(err);
 
                         // Only canonicalize and include non-duplicate fields
-                        if (self.canonicalize_record_field(field)) |canonicalized| {
+                        if (try self.canonicalize_record_field(field)) |canonicalized| {
                             self.can_ir.store.scratch_record_fields.append(self.can_ir.env.gpa, canonicalized);
                         }
                     }
                 } else {
                     // Field name couldn't be resolved, still try to canonicalize
-                    if (self.canonicalize_record_field(field)) |canonicalized| {
+                    if (try self.canonicalize_record_field(field)) |canonicalized| {
                         self.can_ir.store.scratch_record_fields.append(self.can_ir.env.gpa, canonicalized);
                     }
                 }
@@ -1486,7 +1486,7 @@ pub fn canonicalize_expr(
 
             // body
             const body_idx = blk: {
-                if (self.canonicalize_expr(e.body)) |idx| {
+                if (try self.canonicalize_expr(e.body)) |idx| {
                     break :blk idx;
                 } else {
                     const ast_body = self.parse_ir.store.getExpr(e.body);
@@ -1529,7 +1529,7 @@ pub fn canonicalize_expr(
             }
 
             // Regular field access canonicalization
-            return self.canonicalizeRegularFieldAccess(field_access);
+            return try self.canonicalizeRegularFieldAccess(field_access);
         },
         .local_dispatch => |_| {
             const feature = self.can_ir.env.strings.insert(self.can_ir.env.gpa, "canonicalize local_dispatch expression");
@@ -1544,7 +1544,7 @@ pub fn canonicalize_expr(
 
             // Canonicalize left and right operands
             const lhs = blk: {
-                if (self.canonicalize_expr(e.left)) |left_expr_idx| {
+                if (try self.canonicalize_expr(e.left)) |left_expr_idx| {
                     break :blk left_expr_idx;
                 } else {
                     // TODO should probably use LHS region here
@@ -1556,7 +1556,7 @@ pub fn canonicalize_expr(
             };
 
             const rhs = blk: {
-                if (self.canonicalize_expr(e.right)) |right_expr_idx| {
+                if (try self.canonicalize_expr(e.right)) |right_expr_idx| {
                     break :blk right_expr_idx;
                 } else {
                     // TODO should probably use RHS region here
@@ -1630,8 +1630,14 @@ pub fn canonicalize_expr(
             const scratch_top = self.can_ir.store.scratchIfBranchTop();
 
             // Flatten the if-then-else chain
-            const final_else = self.flattenIfThenElseChainRecursive(e);
+            const final_else = try self.flattenIfThenElseChainRecursive(e);
             const branches_span = self.can_ir.store.ifBranchSpanFrom(scratch_top);
+
+            // Get the first branch's body to redirect to it
+            const branches = self.can_ir.store.sliceIfBranches(branches_span);
+            std.debug.assert(branches.len > 0);
+            const first_branch = self.can_ir.store.getIfBranch(branches[0]);
+            const first_branch_type_var = @as(TypeVar, @enumFromInt(@intFromEnum(first_branch.body)));
 
             // Create the if expression
             const expr_idx = self.can_ir.store.addExpr(CIR.Expr{
@@ -1642,10 +1648,15 @@ pub fn canonicalize_expr(
                 },
             });
 
-            // Set type variable for the entire if expression
-            // The if expression's type variable (its CIR index) will be unified with all branches
-            // during type checking, similar to how list elements are unified
-            _ = self.can_ir.setTypeVarAtExpr(expr_idx, Content{ .flex_var = null });
+            // Immediately redirect the if expression's type variable to the first branch's body
+            // This is similar to how lists unify with their first element
+            const expr_var = @as(TypeVar, @enumFromInt(@intFromEnum(expr_idx)));
+
+            // Ensure the type store has slots up to the expression variable
+            try self.can_ir.env.types.fillInSlotsThru(expr_var);
+
+            const slot_idx = types.Store.varToSlotIdx(expr_var);
+            self.can_ir.env.types.slots.set(slot_idx, .{ .redirect = first_branch_type_var });
 
             return expr_idx;
         },
@@ -1708,10 +1719,10 @@ pub fn canonicalize_expr(
                 if (is_last and stmt == .expr) {
                     // For the last expression statement, canonicalize it directly as the final expression
                     // without adding it as a statement
-                    last_expr = self.canonicalize_expr(stmt.expr.expr);
+                    last_expr = try self.canonicalize_expr(stmt.expr.expr);
                 } else {
                     // Regular statement processing
-                    const result = self.canonicalize_statement(stmt_idx);
+                    const result = try self.canonicalize_statement(stmt_idx);
                     if (result) |expr_idx| {
                         last_expr = expr_idx;
                     }
@@ -1757,7 +1768,7 @@ pub fn canonicalize_expr(
 }
 
 /// Extract string segments from parsed string parts
-fn extractStringSegments(self: *Self, parts: []const AST.Expr.Idx) CIR.Expr.Span {
+fn extractStringSegments(self: *Self, parts: []const AST.Expr.Idx) std.mem.Allocator.Error!CIR.Expr.Span {
     const gpa = self.can_ir.env.gpa;
     const start = self.can_ir.store.scratchExprTop();
 
@@ -1783,7 +1794,7 @@ fn extractStringSegments(self: *Self, parts: []const AST.Expr.Idx) CIR.Expr.Span
             else => {
 
                 // Any non-string-part is an interpolation
-                if (self.canonicalize_expr(part)) |expr_idx| {
+                if (try self.canonicalize_expr(part)) |expr_idx| {
                     // append our interpolated expression
                     self.can_ir.store.addScratchExpr(expr_idx);
                 } else {
@@ -2496,10 +2507,10 @@ test {
 
 /// Flatten a chain of if-then-else expressions into multiple if-branches
 /// Returns the final else expression that is not an if-then-else
-fn flattenIfThenElseChainRecursive(self: *Self, if_expr: anytype) CIR.Expr.Idx {
+fn flattenIfThenElseChainRecursive(self: *Self, if_expr: anytype) std.mem.Allocator.Error!CIR.Expr.Idx {
     // Canonicalize and add the current condition/then pair
     const cond_idx = blk: {
-        if (self.canonicalize_expr(if_expr.condition)) |idx| {
+        if (try self.canonicalize_expr(if_expr.condition)) |idx| {
             break :blk idx;
         } else {
             const ast_cond = self.parse_ir.store.getExpr(if_expr.condition);
@@ -2511,7 +2522,7 @@ fn flattenIfThenElseChainRecursive(self: *Self, if_expr: anytype) CIR.Expr.Idx {
     };
 
     const then_idx = blk: {
-        if (self.canonicalize_expr(if_expr.then)) |idx| {
+        if (try self.canonicalize_expr(if_expr.then)) |idx| {
             break :blk idx;
         } else {
             const ast_then = self.parse_ir.store.getExpr(if_expr.then);
@@ -2533,12 +2544,12 @@ fn flattenIfThenElseChainRecursive(self: *Self, if_expr: anytype) CIR.Expr.Idx {
     const else_expr = self.parse_ir.store.getExpr(if_expr.@"else");
     switch (else_expr) {
         .if_then_else => |nested_if| {
-            // Recursively flatten the nested if-then-else
-            return self.flattenIfThenElseChainRecursive(nested_if);
+            // Recursively process the nested if-then-else
+            return try self.flattenIfThenElseChainRecursive(nested_if);
         },
         else => {
             // This is the final else - canonicalize and return it
-            if (self.canonicalize_expr(if_expr.@"else")) |else_idx| {
+            if (try self.canonicalize_expr(if_expr.@"else")) |else_idx| {
                 return else_idx;
             } else {
                 const else_region = self.parse_ir.tokenizedRegionToRegion(else_expr.to_tokenized_region());
@@ -2982,7 +2993,7 @@ fn canonicalize_type_header(self: *Self, header_idx: AST.TypeHeader.Idx) CIR.Typ
 }
 
 /// Canonicalize a statement in the canonical IR.
-pub fn canonicalize_statement(self: *Self, stmt_idx: AST.Statement.Idx) ?CIR.Expr.Idx {
+pub fn canonicalize_statement(self: *Self, stmt_idx: AST.Statement.Idx) std.mem.Allocator.Error!?CIR.Expr.Idx {
     const stmt = self.parse_ir.store.getStatement(stmt_idx);
 
     switch (stmt) {
@@ -3019,7 +3030,7 @@ pub fn canonicalize_statement(self: *Self, stmt_idx: AST.Statement.Idx) ?CIR.Exp
                             // Check if this was declared as a var
                             if (self.isVarPattern(existing_pattern_idx)) {
                                 // This is a var reassignment - canonicalize the expression and create reassign statement
-                                const expr_idx = self.canonicalize_expr(d.body) orelse return null;
+                                const expr_idx = try self.canonicalize_expr(d.body) orelse return null;
 
                                 // Create reassign statement
                                 const reassign_stmt = CIR.Statement{ .s_reassign = .{
@@ -3042,7 +3053,7 @@ pub fn canonicalize_statement(self: *Self, stmt_idx: AST.Statement.Idx) ?CIR.Exp
 
             // Regular declaration - canonicalize as usual
             const pattern_idx = self.canonicalize_pattern(d.pattern) orelse return null;
-            const expr_idx = self.canonicalize_expr(d.body) orelse return null;
+            const expr_idx = try self.canonicalize_expr(d.body) orelse return null;
 
             // Create a declaration statement
             const decl_stmt = CIR.Statement{ .s_decl = .{
@@ -3061,7 +3072,7 @@ pub fn canonicalize_statement(self: *Self, stmt_idx: AST.Statement.Idx) ?CIR.Exp
             const region = self.parse_ir.tokenizedRegionToRegion(v.region);
 
             // Canonicalize the initial value
-            const init_expr_idx = self.canonicalize_expr(v.body) orelse return null;
+            const init_expr_idx = try self.canonicalize_expr(v.body) orelse return null;
 
             // Create pattern for the var
             const pattern_idx = self.can_ir.store.addPattern(CIR.Pattern{ .assign = .{ .ident = var_name, .region = region } });
@@ -3082,7 +3093,7 @@ pub fn canonicalize_statement(self: *Self, stmt_idx: AST.Statement.Idx) ?CIR.Exp
         },
         .expr => |e| {
             // Expression statement
-            const expr_idx = self.canonicalize_expr(e.expr) orelse return null;
+            const expr_idx = try self.canonicalize_expr(e.expr) orelse return null;
 
             // Create expression statement
             const expr_stmt = CIR.Statement{ .s_expr = .{
@@ -4266,12 +4277,12 @@ fn tryModuleQualifiedLookup(self: *Self, field_access: AST.BinOp) ?CIR.Expr.Idx 
 /// - `user.name` - accessing a field on a record
 /// - `list.map(transform)` - calling a method with arguments
 /// - `result.isOk` - accessing a field that might be a function
-fn canonicalizeRegularFieldAccess(self: *Self, field_access: AST.BinOp) ?CIR.Expr.Idx {
+fn canonicalizeRegularFieldAccess(self: *Self, field_access: AST.BinOp) std.mem.Allocator.Error!?CIR.Expr.Idx {
     // Canonicalize the receiver (left side of the dot)
-    const receiver_idx = self.canonicalizeFieldAccessReceiver(field_access) orelse return null;
+    const receiver_idx = try self.canonicalizeFieldAccessReceiver(field_access) orelse return null;
 
     // Parse the right side - this could be just a field name or a method call
-    const field_name, const args = self.parseFieldAccessRight(field_access);
+    const field_name, const args = try self.parseFieldAccessRight(field_access);
 
     const dot_access_expr = CIR.Expr{
         .e_dot_access = .{
@@ -4293,8 +4304,8 @@ fn canonicalizeRegularFieldAccess(self: *Self, field_access: AST.BinOp) ?CIR.Exp
 /// - In `user.name`, canonicalizes `user`
 /// - In `getUser().email`, canonicalizes `getUser()`
 /// - In `[1,2,3].map(fn)`, canonicalizes `[1,2,3]`
-fn canonicalizeFieldAccessReceiver(self: *Self, field_access: AST.BinOp) ?CIR.Expr.Idx {
-    if (self.canonicalize_expr(field_access.left)) |idx| {
+fn canonicalizeFieldAccessReceiver(self: *Self, field_access: AST.BinOp) std.mem.Allocator.Error!?CIR.Expr.Idx {
+    if (try self.canonicalize_expr(field_access.left)) |idx| {
         return idx;
     } else {
         // Failed to canonicalize receiver, return malformed
@@ -4311,7 +4322,7 @@ fn canonicalizeFieldAccessReceiver(self: *Self, field_access: AST.BinOp) ?CIR.Ex
 /// - `user.name` - returns `("name", null)` for plain field access
 /// - `list.map(fn)` - returns `("map", args)` where args contains the canonicalized function
 /// - `obj.method(a, b)` - returns `("method", args)` where args contains canonicalized a and b
-fn parseFieldAccessRight(self: *Self, field_access: AST.BinOp) struct { Ident.Idx, ?CIR.Expr.Span } {
+fn parseFieldAccessRight(self: *Self, field_access: AST.BinOp) std.mem.Allocator.Error!struct { Ident.Idx, ?CIR.Expr.Span } {
     const right_expr = self.parse_ir.store.getExpr(field_access.right);
 
     return switch (right_expr) {
@@ -4327,7 +4338,7 @@ fn parseFieldAccessRight(self: *Self, field_access: AST.BinOp) struct { Ident.Id
 /// - `.map(transform)` - extracts "map" as method name and canonicalizes `transform` argument
 /// - `.filter(predicate)` - extracts "filter" and canonicalizes `predicate`
 /// - `.fold(0, combine)` - extracts "fold" and canonicalizes both `0` and `combine` arguments
-fn parseMethodCall(self: *Self, apply: @TypeOf(@as(AST.Expr, undefined).apply)) struct { Ident.Idx, ?CIR.Expr.Span } {
+fn parseMethodCall(self: *Self, apply: @TypeOf(@as(AST.Expr, undefined).apply)) std.mem.Allocator.Error!struct { Ident.Idx, ?CIR.Expr.Span } {
     const method_expr = self.parse_ir.store.getExpr(apply.@"fn");
     const field_name = switch (method_expr) {
         .ident => |ident| self.resolveIdentOrFallback(ident.token),
@@ -4337,7 +4348,7 @@ fn parseMethodCall(self: *Self, apply: @TypeOf(@as(AST.Expr, undefined).apply)) 
     // Canonicalize the arguments using scratch system
     const scratch_top = self.can_ir.store.scratchExprTop();
     for (self.parse_ir.store.exprSlice(apply.args)) |arg_idx| {
-        if (self.canonicalize_expr(arg_idx)) |canonicalized| {
+        if (try self.canonicalize_expr(arg_idx)) |canonicalized| {
             self.can_ir.store.addScratchExpr(canonicalized);
         } else {
             self.can_ir.store.clearScratchExprsFrom(scratch_top);
@@ -4709,7 +4720,7 @@ test "hexadecimal integer literals" {
         defer can.deinit();
 
         const expr_idx: parse.AST.Expr.Idx = @enumFromInt(ast.root_node_idx);
-        const canonical_expr_idx = can.canonicalize_expr(expr_idx) orelse {
+        const canonical_expr_idx = try can.canonicalize_expr(expr_idx) orelse {
             std.debug.print("Failed to canonicalize: {s}\n", .{tc.literal});
             try std.testing.expect(false);
             continue;
@@ -4799,7 +4810,7 @@ test "binary integer literals" {
         defer can.deinit();
 
         const expr_idx: parse.AST.Expr.Idx = @enumFromInt(ast.root_node_idx);
-        const canonical_expr_idx = can.canonicalize_expr(expr_idx) orelse {
+        const canonical_expr_idx = try can.canonicalize_expr(expr_idx) orelse {
             std.debug.print("Failed to canonicalize: {s}\n", .{tc.literal});
             try std.testing.expect(false);
             continue;
@@ -4889,7 +4900,7 @@ test "octal integer literals" {
         defer can.deinit();
 
         const expr_idx: parse.AST.Expr.Idx = @enumFromInt(ast.root_node_idx);
-        const canonical_expr_idx = can.canonicalize_expr(expr_idx) orelse {
+        const canonical_expr_idx = try can.canonicalize_expr(expr_idx) orelse {
             std.debug.print("Failed to canonicalize: {s}\n", .{tc.literal});
             try std.testing.expect(false);
             continue;
@@ -4979,7 +4990,7 @@ test "integer literals with uppercase base prefixes" {
         defer can.deinit();
 
         const expr_idx: parse.AST.Expr.Idx = @enumFromInt(ast.root_node_idx);
-        const canonical_expr_idx = can.canonicalize_expr(expr_idx) orelse {
+        const canonical_expr_idx = try can.canonicalize_expr(expr_idx) orelse {
             std.debug.print("Failed to canonicalize: {s}\n", .{tc.literal});
             try std.testing.expect(false);
             continue;

--- a/src/check/canonicalize.zig
+++ b/src/check/canonicalize.zig
@@ -1633,24 +1633,18 @@ pub fn canonicalize_expr(
             const final_else = self.flattenIfThenElseChainRecursive(e);
             const branches_span = self.can_ir.store.ifBranchSpanFrom(scratch_top);
 
-            // Reserve extra node slot for branch var
-            const final_expr_idx = self.can_ir.store.predictNodeIndex(2);
-            const branch_var = self.can_ir.pushFreshTypeVar(final_expr_idx, region);
-
             // Create the if expression
             const expr_idx = self.can_ir.store.addExpr(CIR.Expr{
                 .e_if = .{
                     .branches = branches_span,
                     .final_else = final_else,
                     .region = region,
-                    .branch_var = branch_var,
                 },
             });
 
-            std.debug.assert(@intFromEnum(final_expr_idx) == @intFromEnum(expr_idx));
-
             // Set type variable for the entire if expression
-            // This will be unified with the return type of the if expr in type solving
+            // The if expression's type variable (its CIR index) will be unified with all branches
+            // during type checking, similar to how list elements are unified
             _ = self.can_ir.setTypeVarAtExpr(expr_idx, Content{ .flex_var = null });
 
             return expr_idx;

--- a/src/check/canonicalize/CIR.zig
+++ b/src/check/canonicalize/CIR.zig
@@ -1138,7 +1138,6 @@ pub const Expr = union(enum) {
     },
     e_when: When,
     e_if: struct {
-        branch_var: TypeVar,
         branches: IfBranch.Span,
         final_else: Expr.Idx,
         region: Region,
@@ -1487,9 +1486,6 @@ pub const Expr = union(enum) {
             .e_if => |if_expr| {
                 var node = SExpr.init(gpa, "e-if");
                 node.appendRegion(gpa, ir.calcRegionInfo(if_expr.region));
-
-                // Add branch_var
-                node.appendTypeVar(gpa, "branch-var", if_expr.branch_var);
 
                 // Add branches
                 var branches_node = SExpr.init(gpa, "if-branches");

--- a/src/check/canonicalize/NodeStore.zig
+++ b/src/check/canonicalize/NodeStore.zig
@@ -432,7 +432,6 @@ pub fn getExpr(store: *const NodeStore, expr: CIR.Expr.Idx) CIR.Expr {
             const branches_span_start: u32 = extra_data[0];
             const branches_span_end: u32 = extra_data[1];
             const final_else: CIR.Expr.Idx = @enumFromInt(extra_data[2]);
-            const branch_var: types.Var = @enumFromInt(extra_data[3]);
 
             // Reconstruct the if expression from node data
             const branches_span = CIR.IfBranch.Span{ .span = .{
@@ -443,7 +442,6 @@ pub fn getExpr(store: *const NodeStore, expr: CIR.Expr.Idx) CIR.Expr {
             return CIR.Expr{ .e_if = .{
                 .branches = branches_span,
                 .final_else = final_else,
-                .branch_var = branch_var,
                 .region = node.region,
             } };
         },
@@ -1070,13 +1068,11 @@ pub fn addExpr(store: *NodeStore, expr: CIR.Expr) CIR.Expr.Idx {
             // 1. Branches span start
             // 2. Branches span end
             // 3. Final else expr idx
-            // 4. Branches type var
             const extra_start = @as(u32, @intCast(store.extra_data.items.len));
-            const num_extra_items = 4;
+            const num_extra_items = 3;
             store.extra_data.append(store.gpa, e.branches.span.start) catch |err| exitOnOom(err);
             store.extra_data.append(store.gpa, e.branches.span.len) catch |err| exitOnOom(err);
             store.extra_data.append(store.gpa, @intFromEnum(e.final_else)) catch |err| exitOnOom(err);
-            store.extra_data.append(store.gpa, @intFromEnum(e.branch_var)) catch |err| exitOnOom(err);
 
             node.region = e.region;
             node.tag = .expr_if_then_else;

--- a/src/check/canonicalize/test/frac_test.zig
+++ b/src/check/canonicalize/test/frac_test.zig
@@ -33,7 +33,7 @@ fn parseAndCanonicalizeFrac(allocator: std.mem.Allocator, source: []const u8) !s
     can.* = canonicalize.init(cir, parse_ast);
 
     const expr_idx: parse.AST.Expr.Idx = @enumFromInt(parse_ast.root_node_idx);
-    const canonical_expr_idx = can.canonicalize_expr(expr_idx) orelse {
+    const canonical_expr_idx = try can.canonicalize_expr(expr_idx) orelse {
         const diagnostic_idx = cir.store.addDiagnostic(.{ .not_implemented = .{
             .feature = cir.env.strings.insert(allocator, "canonicalization failed"),
             .region = base.Region.zero(),

--- a/src/check/canonicalize/test/int_test.zig
+++ b/src/check/canonicalize/test/int_test.zig
@@ -32,7 +32,7 @@ fn parseAndCanonicalizeInt(allocator: std.mem.Allocator, source: []const u8) !st
     can.* = canonicalize.init(cir, parse_ast);
 
     const expr_idx: parse.AST.Expr.Idx = @enumFromInt(parse_ast.root_node_idx);
-    const canonical_expr_idx = can.canonicalize_expr(expr_idx) orelse {
+    const canonical_expr_idx = try can.canonicalize_expr(expr_idx) orelse {
         const diagnostic_idx = cir.store.addDiagnostic(.{ .not_implemented = .{
             .feature = cir.env.strings.insert(allocator, "canonicalization failed"),
             .region = base.Region.zero(),

--- a/src/check/check_types.zig
+++ b/src/check/check_types.zig
@@ -367,7 +367,7 @@ pub fn checkExpr(self: *Self, expr_idx: CIR.Expr.Idx) void {
                 // Check the branch's body
                 self.checkExpr(if_branch.body);
                 _ = self.unify(
-                    @enumFromInt(@intFromEnum(if_expr.branch_var)),
+                    @enumFromInt(@intFromEnum(expr_idx)),
                     @enumFromInt(@intFromEnum(if_branch.body)),
                 );
             }
@@ -375,7 +375,7 @@ pub fn checkExpr(self: *Self, expr_idx: CIR.Expr.Idx) void {
             // Check the final else
             self.checkExpr(if_expr.final_else);
             _ = self.unify(
-                @enumFromInt(@intFromEnum(if_expr.branch_var)),
+                @enumFromInt(@intFromEnum(expr_idx)),
                 @enumFromInt(@intFromEnum(if_expr.final_else)),
             );
 

--- a/src/coordinate/ModuleGraph.zig
+++ b/src/coordinate/ModuleGraph.zig
@@ -124,7 +124,7 @@ fn loadOrCompileCanIr(
         var scope = Scope.init(can_ir.env.gpa);
         defer scope.deinit(gpa);
         var can = Can.init(&can_ir, &parse_ir, &scope);
-        can.canonicalize_file();
+        try can.canonicalize_file();
 
         break :blk can_ir;
     };

--- a/src/coordinate_simple.zig
+++ b/src/coordinate_simple.zig
@@ -122,7 +122,7 @@ fn processSourceInternal(
     // Canonicalize the AST
     var canonicalizer = canonicalize.init(cir, &parse_ast);
     defer canonicalizer.deinit();
-    canonicalizer.canonicalize_file();
+    try canonicalizer.canonicalize_file();
 
     // Get diagnostic Reports from CIR
     const diagnostics = cir.getDiagnostics();

--- a/src/snapshot.zig
+++ b/src/snapshot.zig
@@ -1194,19 +1194,19 @@ fn processSnapshotFileUnified(gpa: Allocator, snapshot_path: []const u8, maybe_f
     var maybe_expr_idx: ?CIR.Expr.Idx = null;
 
     switch (content.meta.node_type) {
-        .file => can.canonicalize_file(),
+        .file => try can.canonicalize_file(),
         .header => {
             // TODO: implement canonicalize_header when available
         },
         .expr => {
             const expr_idx: AST.Expr.Idx = @enumFromInt(parse_ast.root_node_idx);
-            maybe_expr_idx = can.canonicalize_expr(expr_idx);
+            maybe_expr_idx = try can.canonicalize_expr(expr_idx);
         },
         .statement => {
             // Manually track scratch statements because we aren't using the file entrypoint
             const stmt_idx: AST.Statement.Idx = @enumFromInt(parse_ast.root_node_idx);
             const scratch_statements_start = can_ir.store.scratch_statements.top();
-            _ = can.canonicalize_statement(stmt_idx);
+            _ = try can.canonicalize_statement(stmt_idx);
             can_ir.all_statements = can_ir.store.statementSpanFrom(scratch_statements_start);
         },
     }

--- a/src/snapshots/fuzz_crash/fuzz_crash_019.md
+++ b/src/snapshots/fuzz_crash/fuzz_crash_019.md
@@ -1002,12 +1002,12 @@ expect {
 # CANONICALIZE
 ~~~clojure
 (can-ir
-	(d-let (id 138)
+	(d-let (id 137)
 		(p-assign @35.1-35.4 (ident "ane") (id 128))
-		(e-lambda @35.7-37.4 (id 137)
+		(e-lambda @35.7-37.4 (id 136)
 			(args
 				(p-assign @35.8-35.11 (ident "num") (id 129)))
-			(e-if @35.13-37.4 (branch-var 134)
+			(e-if @35.13-37.4
 				(if-branches
 					(if-branch
 						(e-lookup-local @35.16-35.19
@@ -1015,19 +1015,19 @@ expect {
 						(e-int @35.20-35.21 (value "2"))))
 				(if-else
 					(e-int @35.27-35.28 (value "5"))))))
-	(d-let (id 164)
-		(p-assign @38.1-38.4 (ident "add") (id 141))
-		(e-lambda @38.7-47.2 (id 163)
+	(d-let (id 162)
+		(p-assign @38.1-38.4 (ident "add") (id 140))
+		(e-lambda @38.7-47.2 (id 161)
 			(args
-				(p-assign @38.8-38.11 (ident "num") (id 142)))
+				(p-assign @38.8-38.11 (ident "num") (id 141)))
 			(e-block @38.13-47.2
 				(s-expr @39.2-40.4
 					(e-int @39.2-39.3 (value "1")))
-				(e-if @40.2-47.2 (branch-var 159)
+				(e-if @40.2-47.2
 					(if-branches
 						(if-branch
 							(e-lookup-local @40.5-40.8
-								(pattern (id 142)))
+								(pattern (id 141)))
 							(e-block @40.9-43.3
 								(s-expr @41.3-42.10
 									(e-runtime-error (tag "not_implemented")))
@@ -1037,57 +1037,57 @@ expect {
 							(s-expr @44.3-45.4
 								(e-runtime-error (tag "not_implemented")))
 							(e-runtime-error (tag "ident_not_in_scope"))))))))
-	(d-let (id 174)
-		(p-assign @49.1-49.3 (ident "me") (id 165))
-		(e-lambda @49.6-71.7 (id 172)
+	(d-let (id 172)
+		(p-assign @49.1-49.3 (ident "me") (id 163))
+		(e-lambda @49.6-71.7 (id 170)
 			(args
-				(p-assign @50.2-50.3 (ident "a") (id 166))
-				(p-applied-tag @50.5-50.7 (id 168)))
+				(p-assign @50.2-50.3 (ident "a") (id 164))
+				(p-applied-tag @50.5-50.7 (id 166)))
 			(e-runtime-error (tag "not_implemented"))))
-	(d-let (id 344)
-		(p-assign @75.1-75.3 (ident "ma") (id 179))
-		(e-lambda @75.5-111.2 (id 343)
+	(d-let (id 342)
+		(p-assign @75.1-75.3 (ident "ma") (id 177))
+		(e-lambda @75.5-111.2 (id 341)
 			(args
-				(p-underscore @75.6-75.7 (id 180)))
+				(p-underscore @75.6-75.7 (id 178)))
 			(e-block @75.9-111.2
 				(s-expr @75.11-76.3
 					(e-runtime-error (tag "ident_not_in_scope")))
 				(s-let @76.2-76.9
-					(p-assign @76.2-76.3 (ident "w") (id 184))
-					(e-string @76.6-76.9 (id 186)
+					(p-assign @76.2-76.3 (ident "w") (id 182))
+					(e-string @76.6-76.9 (id 184)
 						(e-literal @76.7-76.8 (string "d"))))
 				(s-var @77.2-78.8
-					(p-assign @77.2-78.8 (ident "er") (id 189))
-					(e-int @77.11-77.14 (value "123") (id 188)))
+					(p-assign @77.2-78.8 (ident "er") (id 187))
+					(e-int @77.11-77.14 (value "123") (id 186)))
 				(s-expr @83.2-84.4
 					(e-runtime-error (tag "not_implemented")))
 				(s-expr @84.2-86.8
 					(e-call @84.2-86.3
 						(e-lookup-local @84.2-84.4
-							(pattern (id 165)))
+							(pattern (id 163)))
 						(e-runtime-error (tag "not_implemented"))))
 				(s-expr @86.11-86.20
 					(e-string @86.11-86.17
 						(e-literal @86.12-86.16 (string "Unr!"))))
 				(s-let @87.2-87.14
-					(p-assign @87.2-87.3 (ident "i") (id 209))
-					(e-string @87.5-87.14 (id 214)
+					(p-assign @87.2-87.3 (ident "i") (id 207))
+					(e-string @87.5-87.14 (id 212)
 						(e-literal @87.6-87.9 (string "H, "))
 						(e-runtime-error (tag "ident_not_in_scope"))
 						(e-literal @87.13-87.13 (string ""))))
 				(s-let @88.1-91.3
-					(p-assign @88.1-88.2 (ident "t") (id 216))
-					(e-list @88.5-91.3 (elem-var 221) (id 224)
+					(p-assign @88.1-88.2 (ident "t") (id 214))
+					(e-list @88.5-91.3 (elem-var 219) (id 222)
 						(elems
 							(e-call @89.3-89.14
 								(e-runtime-error (tag "ident_not_in_scope"))
 								(e-lookup-local @89.7-89.9
-									(pattern (id 189))))
+									(pattern (id 187))))
 							(e-int @89.16-89.19 (value "456"))
 							(e-int @90.1-90.2 (value "9")))))
 				(s-let @96.2-96.59
-					(p-assign @96.2-96.4 (ident "rd") (id 228))
-					(e-record @96.7-96.59 (ext-var 247) (id 248)
+					(p-assign @96.2-96.4 (ident "rd") (id 226))
+					(e-record @96.7-96.59 (ext-var 245) (id 246)
 						(fields
 							(field (name "foo")
 								(e-int @96.14-96.17 (value "123")))
@@ -1103,8 +1103,8 @@ expect {
 							(field (name "ned")
 								(e-runtime-error (tag "ident_not_in_scope"))))))
 				(s-let @97.2-97.48
-					(p-assign @97.2-97.3 (ident "t") (id 255))
-					(e-tuple @97.6-97.48 (id 272)
+					(p-assign @97.2-97.3 (ident "t") (id 253))
+					(e-tuple @97.6-97.48 (id 270)
 						(elems
 							(e-int @97.7-97.10 (value "123"))
 							(e-string @97.12-97.19
@@ -1115,8 +1115,8 @@ expect {
 								(elems
 									(e-runtime-error (tag "ident_not_in_scope"))
 									(e-lookup-local @97.34-97.35
-										(pattern (id 255)))))
-							(e-list @97.38-97.47 (elem-var 268)
+										(pattern (id 253)))))
+							(e-list @97.38-97.47 (elem-var 266)
 								(elems
 									(e-int @97.39-97.40 (value "1"))
 									(e-int @97.42-97.43 (value "2"))
@@ -1135,7 +1135,7 @@ expect {
 								(elems
 									(e-runtime-error (tag "ident_not_in_scope"))
 									(e-runtime-error (tag "ident_not_in_scope"))))
-							(e-list @103.3-103.12 (elem-var 289)
+							(e-list @103.3-103.12 (elem-var 287)
 								(elems
 									(e-int @103.4-103.5 (value "1"))
 									(e-int @103.7-103.8 (value "2"))
@@ -1178,9 +1178,9 @@ expect {
 							(e-runtime-error (tag "ident_not_in_scope"))
 							(e-runtime-error (tag "ident_not_in_scope")))
 						(e-literal @109.4-109.5 (string " ")))))))
-	(d-let (id 348)
-		(p-assign @114.1-114.2 (ident "e") (id 346))
-		(e-empty_record @114.5-114.7 (id 347)))
+	(d-let (id 346)
+		(p-assign @114.1-114.2 (ident "e") (id 344))
+		(e-empty_record @114.5-114.7 (id 345)))
 	(s-type-decl @13.1-14.6 (id 84)
 		(ty-header @13.1-13.10 (name "Map")
 			(ty-args
@@ -1243,11 +1243,11 @@ expect {
 ~~~clojure
 (inferred-types
 	(defs
-		(d_assign (name "ane") (def_var 138) (type "* ? Num(*)"))
-		(d_assign (name "add") (def_var 164) (type "* ? Error"))
-		(d_assign (name "me") (def_var 174) (type "*, [Tb]* ? Error"))
-		(d_assign (name "ma") (def_var 344) (type "* ? *"))
-		(d_assign (name "e") (def_var 348) (type "{}")))
+		(d_assign (name "ane") (def_var 137) (type "* ? Num(*)"))
+		(d_assign (name "add") (def_var 162) (type "* ? Error"))
+		(d_assign (name "me") (def_var 172) (type "*, [Tb]* ? Error"))
+		(d_assign (name "ma") (def_var 342) (type "* ? *"))
+		(d_assign (name "e") (def_var 346) (type "{}")))
 	(expressions
 		(expr @35.7-37.4 (type "* ? Num(*)"))
 		(expr @38.7-47.2 (type "* ? Error"))

--- a/src/snapshots/fuzz_crash/fuzz_crash_020.md
+++ b/src/snapshots/fuzz_crash/fuzz_crash_020.md
@@ -1004,12 +1004,12 @@ expect {
 # CANONICALIZE
 ~~~clojure
 (can-ir
-	(d-let (id 138)
+	(d-let (id 137)
 		(p-assign @35.1-35.4 (ident "ane") (id 128))
-		(e-lambda @35.7-37.4 (id 137)
+		(e-lambda @35.7-37.4 (id 136)
 			(args
 				(p-assign @35.8-35.11 (ident "num") (id 129)))
-			(e-if @35.13-37.4 (branch-var 134)
+			(e-if @35.13-37.4
 				(if-branches
 					(if-branch
 						(e-lookup-local @35.16-35.19
@@ -1017,15 +1017,15 @@ expect {
 						(e-int @35.20-35.21 (value "2"))))
 				(if-else
 					(e-int @35.27-35.28 (value "5"))))))
-	(d-let (id 166)
-		(p-assign @38.1-38.4 (ident "add") (id 141))
-		(e-lambda @38.7-47.2 (id 165)
+	(d-let (id 164)
+		(p-assign @38.1-38.4 (ident "add") (id 140))
+		(e-lambda @38.7-47.2 (id 163)
 			(args
-				(p-applied-tag @38.8-38.11 (id 143)))
+				(p-applied-tag @38.8-38.11 (id 142)))
 			(e-block @38.13-47.2
 				(s-expr @39.2-40.4
 					(e-int @39.2-39.3 (value "1")))
-				(e-if @40.2-47.2 (branch-var 161)
+				(e-if @40.2-47.2
 					(if-branches
 						(if-branch
 							(e-runtime-error (tag "ident_not_in_scope"))
@@ -1038,56 +1038,56 @@ expect {
 							(s-expr @44.3-45.4
 								(e-runtime-error (tag "not_implemented")))
 							(e-runtime-error (tag "ident_not_in_scope"))))))))
-	(d-let (id 174)
-		(p-assign @49.1-49.3 (ident "me") (id 167))
-		(e-lambda @49.6-71.7 (id 172)
+	(d-let (id 172)
+		(p-assign @49.1-49.3 (ident "me") (id 165))
+		(e-lambda @49.6-71.7 (id 170)
 			(args
-				(p-assign @50.2-50.3 (ident "a") (id 168)))
+				(p-assign @50.2-50.3 (ident "a") (id 166)))
 			(e-runtime-error (tag "not_implemented"))))
-	(d-let (id 344)
-		(p-assign @75.1-75.3 (ident "ma") (id 179))
-		(e-lambda @75.5-111.2 (id 343)
+	(d-let (id 342)
+		(p-assign @75.1-75.3 (ident "ma") (id 177))
+		(e-lambda @75.5-111.2 (id 341)
 			(args
-				(p-underscore @75.6-75.7 (id 180)))
+				(p-underscore @75.6-75.7 (id 178)))
 			(e-block @75.9-111.2
 				(s-expr @75.11-76.3
 					(e-runtime-error (tag "ident_not_in_scope")))
 				(s-let @76.2-76.9
-					(p-assign @76.2-76.3 (ident "w") (id 184))
-					(e-string @76.6-76.9 (id 186)
+					(p-assign @76.2-76.3 (ident "w") (id 182))
+					(e-string @76.6-76.9 (id 184)
 						(e-literal @76.7-76.8 (string "d"))))
 				(s-var @77.2-78.8
-					(p-assign @77.2-78.8 (ident "er") (id 189))
-					(e-int @77.11-77.14 (value "123") (id 188)))
+					(p-assign @77.2-78.8 (ident "er") (id 187))
+					(e-int @77.11-77.14 (value "123") (id 186)))
 				(s-expr @83.2-84.4
 					(e-runtime-error (tag "not_implemented")))
 				(s-expr @84.2-86.8
 					(e-call @84.2-86.3
 						(e-lookup-local @84.2-84.4
-							(pattern (id 167)))
+							(pattern (id 165)))
 						(e-runtime-error (tag "not_implemented"))))
 				(s-expr @86.11-86.20
 					(e-string @86.11-86.17
 						(e-literal @86.12-86.16 (string "Unr!"))))
 				(s-let @87.2-87.14
-					(p-assign @87.2-87.3 (ident "i") (id 209))
-					(e-string @87.5-87.14 (id 214)
+					(p-assign @87.2-87.3 (ident "i") (id 207))
+					(e-string @87.5-87.14 (id 212)
 						(e-literal @87.6-87.9 (string "H, "))
 						(e-runtime-error (tag "ident_not_in_scope"))
 						(e-literal @87.13-87.13 (string ""))))
 				(s-let @88.1-91.3
-					(p-assign @88.1-88.2 (ident "t") (id 216))
-					(e-list @88.5-91.3 (elem-var 221) (id 224)
+					(p-assign @88.1-88.2 (ident "t") (id 214))
+					(e-list @88.5-91.3 (elem-var 219) (id 222)
 						(elems
 							(e-call @89.3-89.14
 								(e-runtime-error (tag "ident_not_in_scope"))
 								(e-lookup-local @89.7-89.9
-									(pattern (id 189))))
+									(pattern (id 187))))
 							(e-int @89.16-89.19 (value "456"))
 							(e-int @90.1-90.2 (value "9")))))
 				(s-let @96.2-96.59
-					(p-assign @96.2-96.4 (ident "rd") (id 228))
-					(e-record @96.7-96.59 (ext-var 247) (id 248)
+					(p-assign @96.2-96.4 (ident "rd") (id 226))
+					(e-record @96.7-96.59 (ext-var 245) (id 246)
 						(fields
 							(field (name "foo")
 								(e-int @96.14-96.17 (value "123")))
@@ -1103,8 +1103,8 @@ expect {
 							(field (name "ned")
 								(e-runtime-error (tag "ident_not_in_scope"))))))
 				(s-let @97.2-97.48
-					(p-assign @97.2-97.3 (ident "t") (id 255))
-					(e-tuple @97.6-97.48 (id 272)
+					(p-assign @97.2-97.3 (ident "t") (id 253))
+					(e-tuple @97.6-97.48 (id 270)
 						(elems
 							(e-int @97.7-97.10 (value "123"))
 							(e-string @97.12-97.19
@@ -1115,8 +1115,8 @@ expect {
 								(elems
 									(e-runtime-error (tag "ident_not_in_scope"))
 									(e-lookup-local @97.34-97.35
-										(pattern (id 255)))))
-							(e-list @97.38-97.47 (elem-var 268)
+										(pattern (id 253)))))
+							(e-list @97.38-97.47 (elem-var 266)
 								(elems
 									(e-int @97.39-97.40 (value "1"))
 									(e-int @97.42-97.43 (value "2"))
@@ -1135,7 +1135,7 @@ expect {
 								(elems
 									(e-runtime-error (tag "ident_not_in_scope"))
 									(e-runtime-error (tag "ident_not_in_scope"))))
-							(e-list @103.3-103.12 (elem-var 289)
+							(e-list @103.3-103.12 (elem-var 287)
 								(elems
 									(e-int @103.4-103.5 (value "1"))
 									(e-int @103.7-103.8 (value "2"))
@@ -1178,9 +1178,9 @@ expect {
 							(e-runtime-error (tag "ident_not_in_scope"))
 							(e-runtime-error (tag "ident_not_in_scope")))
 						(e-literal @109.4-109.5 (string " ")))))))
-	(d-let (id 348)
-		(p-assign @114.1-114.2 (ident "e") (id 346))
-		(e-empty_record @114.5-114.7 (id 347)))
+	(d-let (id 346)
+		(p-assign @114.1-114.2 (ident "e") (id 344))
+		(e-empty_record @114.5-114.7 (id 345)))
 	(s-type-decl @13.1-14.6 (id 84)
 		(ty-header @13.1-13.10 (name "Map")
 			(ty-args
@@ -1243,11 +1243,11 @@ expect {
 ~~~clojure
 (inferred-types
 	(defs
-		(d_assign (name "ane") (def_var 138) (type "* ? Num(*)"))
-		(d_assign (name "add") (def_var 166) (type "[Rum]* ? Error"))
-		(d_assign (name "me") (def_var 174) (type "* ? Error"))
-		(d_assign (name "ma") (def_var 344) (type "* ? *"))
-		(d_assign (name "e") (def_var 348) (type "{}")))
+		(d_assign (name "ane") (def_var 137) (type "* ? Num(*)"))
+		(d_assign (name "add") (def_var 164) (type "[Rum]* ? Error"))
+		(d_assign (name "me") (def_var 172) (type "* ? Error"))
+		(d_assign (name "ma") (def_var 342) (type "* ? *"))
+		(d_assign (name "e") (def_var 346) (type "{}")))
 	(expressions
 		(expr @35.7-37.4 (type "* ? Num(*)"))
 		(expr @38.7-47.2 (type "[Rum]* ? Error"))

--- a/src/snapshots/fuzz_crash/fuzz_crash_022.md
+++ b/src/snapshots/fuzz_crash/fuzz_crash_022.md
@@ -171,12 +171,12 @@ ain! = |_| getUser(900)
 # CANONICALIZE
 ~~~clojure
 (can-ir
-	(d-let (id 97)
+	(d-let (id 96)
 		(p-assign @6.1-6.8 (ident "getUser") (id 83))
-		(e-lambda @1.1-1.1 (id 95)
+		(e-lambda @1.1-1.1 (id 94)
 			(args
 				(p-assign @6.12-6.14 (ident "id") (id 84)))
-			(e-if @1.1-1.1 (branch-var 92)
+			(e-if @1.1-1.1
 				(if-branches
 					(if-branch
 						(e-runtime-error (tag "if_condition_not_canonicalized"))
@@ -185,11 +185,11 @@ ain! = |_| getUser(900)
 				(if-else
 					(e-string @6.40-6.43
 						(e-literal @6.41-6.42 (string "l")))))))
-	(d-let (id 107)
-		(p-assign @8.2-8.6 (ident "ain!") (id 99))
-		(e-lambda @8.9-8.25 (id 106)
+	(d-let (id 106)
+		(p-assign @8.2-8.6 (ident "ain!") (id 98))
+		(e-lambda @8.9-8.25 (id 105)
 			(args
-				(p-underscore @8.10-8.11 (id 100)))
+				(p-underscore @8.10-8.11 (id 99)))
 			(e-call @8.13-8.25
 				(e-lookup-local @8.13-8.20
 					(pattern (id 83)))
@@ -202,8 +202,8 @@ ain! = |_| getUser(900)
 ~~~clojure
 (inferred-types
 	(defs
-		(d_assign (name "getUser") (def_var 97) (type "* ? Str"))
-		(d_assign (name "ain!") (def_var 107) (type "* ? *")))
+		(d_assign (name "getUser") (def_var 96) (type "* ? Str"))
+		(d_assign (name "ain!") (def_var 106) (type "* ? *")))
 	(expressions
 		(expr @1.1-1.1 (type "* ? Str"))
 		(expr @8.9-8.25 (type "* ? *"))))

--- a/src/snapshots/fuzz_crash/fuzz_crash_023.md
+++ b/src/snapshots/fuzz_crash/fuzz_crash_023.md
@@ -1869,12 +1869,12 @@ expect {
 # CANONICALIZE
 ~~~clojure
 (can-ir
-	(d-let (id 190)
+	(d-let (id 189)
 		(p-assign @65.1-65.16 (ident "add_one_oneline") (id 180))
-		(e-lambda @65.19-67.8 (id 189)
+		(e-lambda @65.19-67.8 (id 188)
 			(args
 				(p-assign @65.20-65.23 (ident "num") (id 181)))
-			(e-if @65.25-67.8 (branch-var 186)
+			(e-if @65.25-67.8
 				(if-branches
 					(if-branch
 						(e-lookup-local @65.28-65.31
@@ -1882,20 +1882,20 @@ expect {
 						(e-int @65.32-65.33 (value "2"))))
 				(if-else
 					(e-int @65.39-65.40 (value "5"))))))
-	(d-let (id 222)
-		(p-assign @68.1-68.8 (ident "add_one") (id 194))
-		(e-lambda @68.11-78.2 (id 215)
+	(d-let (id 220)
+		(p-assign @68.1-68.8 (ident "add_one") (id 193))
+		(e-lambda @68.11-78.2 (id 213)
 			(args
-				(p-assign @68.12-68.15 (ident "num") (id 195)))
+				(p-assign @68.12-68.15 (ident "num") (id 194)))
 			(e-block @68.17-78.2
 				(s-let @69.2-69.11
-					(p-assign @69.2-69.7 (ident "other") (id 196))
-					(e-int @69.10-69.11 (value "1") (id 197)))
-				(e-if @70.2-78.2 (branch-var 211)
+					(p-assign @69.2-69.7 (ident "other") (id 195))
+					(e-int @69.10-69.11 (value "1") (id 196)))
+				(e-if @70.2-78.2
 					(if-branches
 						(if-branch
 							(e-lookup-local @70.5-70.8
-								(pattern (id 195)))
+								(pattern (id 194)))
 							(e-block @70.9-74.3
 								(s-expr @71.3-73.4
 									(e-runtime-error (tag "not_implemented")))
@@ -1905,100 +1905,100 @@ expect {
 							(s-expr @75.3-76.8
 								(e-runtime-error (tag "not_implemented")))
 							(e-lookup-local @76.3-76.8
-								(pattern (id 196))))))))
-		(annotation @68.1-68.8 (signature 220) (id 221)
+								(pattern (id 195))))))))
+		(annotation @68.1-68.8 (signature 218) (id 219)
 			(declared-type
 				(ty-fn @67.11-67.21 (effectful false)
 					(ty @67.11-67.14 (name "U64"))
 					(ty @67.18-67.21 (name "U64"))))))
-	(d-let (id 232)
-		(p-assign @80.1-80.11 (ident "match_time") (id 223))
-		(e-lambda @80.14-140.7 (id 229)
+	(d-let (id 230)
+		(p-assign @80.1-80.11 (ident "match_time") (id 221))
+		(e-lambda @80.14-140.7 (id 227)
 			(args
-				(p-assign @81.2-81.3 (ident "a") (id 224))
-				(p-assign @82.2-82.3 (ident "b") (id 225)))
+				(p-assign @81.2-81.3 (ident "a") (id 222))
+				(p-assign @82.2-82.3 (ident "b") (id 223)))
 			(e-runtime-error (tag "not_implemented"))))
-	(d-let (id 419)
-		(p-assign @144.1-144.6 (ident "main!") (id 241))
-		(e-lambda @144.9-196.2 (id 412)
+	(d-let (id 417)
+		(p-assign @144.1-144.6 (ident "main!") (id 239))
+		(e-lambda @144.9-196.2 (id 410)
 			(args
-				(p-underscore @144.10-144.11 (id 242)))
+				(p-underscore @144.10-144.11 (id 240)))
 			(e-block @144.13-196.2
 				(s-let @145.2-145.17
-					(p-assign @145.2-145.7 (ident "world") (id 243))
-					(e-string @145.10-145.17 (id 245)
+					(p-assign @145.2-145.7 (ident "world") (id 241))
+					(e-string @145.10-145.17 (id 243)
 						(e-literal @145.11-145.16 (string "World"))))
 				(s-var @146.2-147.8
-					(p-assign @146.2-147.8 (ident "number") (id 248))
-					(e-int @146.15-146.18 (value "123") (id 247)))
+					(p-assign @146.2-147.8 (ident "number") (id 246))
+					(e-int @146.15-146.18 (value "123") (id 245)))
 				(s-let @148.2-148.12
-					(p-assign @148.2-148.5 (ident "tag") (id 252))
-					(e-tag @148.8-148.12 (ext-var 0) (name "Blue") (args "TODO") (id 254)))
+					(p-assign @148.2-148.5 (ident "tag") (id 250))
+					(e-tag @148.8-148.12 (ext-var 0) (name "Blue") (args "TODO") (id 252)))
 				(s-expr @154.2-155.12
 					(e-runtime-error (tag "not_implemented")))
 				(s-expr @155.2-158.11
 					(e-call @155.2-157.3
 						(e-lookup-local @155.2-155.12
-							(pattern (id 223)))
+							(pattern (id 221)))
 						(e-runtime-error (tag "not_implemented"))))
 				(s-expr @158.2-162.7
 					(e-call @158.2-161.3
 						(e-runtime-error (tag "ident_not_in_scope"))
 						(e-runtime-error (tag "not_implemented"))))
 				(s-let @164.2-164.31
-					(p-assign @164.2-164.18 (ident "tag_with_payload") (id 276))
-					(e-call @164.21-164.31 (id 281)
+					(p-assign @164.2-164.18 (ident "tag_with_payload") (id 274))
+					(e-call @164.21-164.31 (id 279)
 						(e-tag @164.21-164.23 (ext-var 0) (name "Ok") (args "TODO"))
 						(e-lookup-local @164.24-164.30
-							(pattern (id 248)))))
+							(pattern (id 246)))))
 				(s-let @165.2-165.34
-					(p-assign @165.2-165.14 (ident "interpolated") (id 283))
-					(e-string @165.17-165.34 (id 287)
+					(p-assign @165.2-165.14 (ident "interpolated") (id 281))
+					(e-string @165.17-165.34 (id 285)
 						(e-literal @165.18-165.25 (string "Hello, "))
 						(e-lookup-local @165.27-165.32
-							(pattern (id 243)))
+							(pattern (id 241)))
 						(e-literal @165.33-165.33 (string ""))))
 				(s-let @166.2-173.3
-					(p-assign @166.2-166.6 (ident "list") (id 289))
-					(e-list @166.9-173.3 (elem-var 294) (id 297)
+					(p-assign @166.2-166.6 (ident "list") (id 287))
+					(e-list @166.9-173.3 (elem-var 292) (id 295)
 						(elems
 							(e-call @167.3-170.4
 								(e-lookup-local @167.3-167.10
-									(pattern (id 194)))
+									(pattern (id 193)))
 								(e-runtime-error (tag "not_implemented")))
 							(e-int @171.3-171.6 (value "456"))
 							(e-int @172.3-172.6 (value "789")))))
 				(s-expr @178.42-178.46
 					(e-lookup-local @178.42-178.45
-						(pattern (id 252))))
+						(pattern (id 250))))
 				(s-type-anno @1.1-1.1 (name "qux")
 					(ty-malformed @1.1-1.1))
 				(s-let @179.2-179.68
-					(p-assign @179.2-179.7 (ident "tuple") (id 308))
-					(e-tuple @179.10-179.68 (id 326)
+					(p-assign @179.2-179.7 (ident "tuple") (id 306))
+					(e-tuple @179.10-179.68 (id 324)
 						(elems
 							(e-int @179.11-179.14 (value "123"))
 							(e-string @179.16-179.23
 								(e-literal @179.17-179.22 (string "World")))
 							(e-lookup-local @179.25-179.28
-								(pattern (id 252)))
+								(pattern (id 250)))
 							(e-call @179.30-179.39
 								(e-tag @179.30-179.32 (ext-var 0) (name "Ok") (args "TODO"))
 								(e-lookup-local @179.33-179.38
-									(pattern (id 243))))
+									(pattern (id 241))))
 							(e-tuple @179.41-179.56
 								(elems
 									(e-runtime-error (tag "ident_not_in_scope"))
 									(e-lookup-local @179.50-179.55
-										(pattern (id 308)))))
-							(e-list @179.58-179.67 (elem-var 322)
+										(pattern (id 306)))))
+							(e-list @179.58-179.67 (elem-var 320)
 								(elems
 									(e-int @179.59-179.60 (value "1"))
 									(e-int @179.62-179.63 (value "2"))
 									(e-int @179.65-179.66 (value "3")))))))
 				(s-let @180.2-187.3
-					(p-assign @180.2-180.17 (ident "multiline_tuple") (id 328))
-					(e-tuple @180.20-187.3 (id 347)
+					(p-assign @180.2-180.17 (ident "multiline_tuple") (id 326))
+					(e-tuple @180.20-187.3 (id 345)
 						(elems
 							(e-int @181.3-181.6 (value "123"))
 							(e-string @182.3-182.10
@@ -2007,20 +2007,20 @@ expect {
 							(e-call @184.3-184.12
 								(e-tag @184.3-184.5 (ext-var 0) (name "Ok") (args "TODO"))
 								(e-lookup-local @184.6-184.11
-									(pattern (id 243))))
+									(pattern (id 241))))
 							(e-tuple @185.3-185.18
 								(elems
 									(e-runtime-error (tag "ident_not_in_scope"))
 									(e-lookup-local @185.12-185.17
-										(pattern (id 308)))))
-							(e-list @186.3-186.12 (elem-var 343)
+										(pattern (id 306)))))
+							(e-list @186.3-186.12 (elem-var 341)
 								(elems
 									(e-int @186.4-186.5 (value "1"))
 									(e-int @186.7-186.8 (value "2"))
 									(e-int @186.10-186.11 (value "3")))))))
 				(s-let @188.2-189.23
-					(p-assign @188.2-188.15 (ident "bin_op_result") (id 349))
-					(e-binop @188.18-189.23 (op "or") (id 379)
+					(p-assign @188.2-188.15 (ident "bin_op_result") (id 347))
+					(e-binop @188.18-189.23 (op "or") (id 377)
 						(e-binop @188.18-188.74 (op "or")
 							(e-binop @188.18-188.43 (op "gt")
 								(e-binop @188.18-188.34 (op "null_coalesce")
@@ -2048,8 +2048,8 @@ expect {
 								(e-int @188.81-188.82 (value "3"))
 								(e-int @188.85-188.86 (value "5"))))))
 				(s-let @189.2-190.8
-					(p-assign @189.2-189.23 (ident "static_dispatch_style") (id 381))
-					(e-dot-access @189.26-190.8 (field "unknown") (id 386)
+					(p-assign @189.2-189.23 (ident "static_dispatch_style") (id 379))
+					(e-dot-access @189.26-190.8 (field "unknown") (id 384)
 						(receiver
 							(e-dot-access @189.26-189.110 (field "unknown")
 								(receiver
@@ -2060,15 +2060,15 @@ expect {
 					(e-runtime-error (tag "not_implemented")))
 				(e-call @191.2-195.3
 					(e-lookup-external
-						(ext-decl @191.2-191.14 (qualified "pf.Stdout.line!") (module "pf.Stdout") (local "line!") (kind "value") (type-var 391)))
+						(ext-decl @191.2-191.14 (qualified "pf.Stdout.line!") (module "pf.Stdout") (local "line!") (kind "value") (type-var 389)))
 					(e-string @192.3-194.18
 						(e-literal @192.4-192.14 (string "How about "))
 						(e-call @193.4-193.21
 							(e-runtime-error (tag "ident_not_in_scope"))
 							(e-lookup-local @193.14-193.20
-								(pattern (id 248))))
+								(pattern (id 246))))
 						(e-literal @194.4-194.17 (string " as a string?"))))))
-		(annotation @144.1-144.6 (signature 417) (id 418)
+		(annotation @144.1-144.6 (signature 415) (id 416)
 			(declared-type
 				(ty-fn @143.9-143.38 (effectful false)
 					(ty-apply @143.9-143.21 (symbol "List")
@@ -2076,10 +2076,10 @@ expect {
 					(ty-apply @143.25-143.38 (symbol "Result")
 						(ty-record @143.32-143.34)
 						(ty-underscore @143.36-143.37))))))
-	(d-let (id 427)
-		(p-assign @199.1-199.6 (ident "empty") (id 421))
-		(e-empty_record @199.9-199.11 (id 422))
-		(annotation @199.1-199.6 (signature 425) (id 426)
+	(d-let (id 425)
+		(p-assign @199.1-199.6 (ident "empty") (id 419))
+		(e-empty_record @199.9-199.11 (id 420))
+		(annotation @199.1-199.6 (signature 423) (id 424)
 			(declared-type
 				(ty-record @198.9-198.11))))
 	(s-type-decl @22.1-23.6 (id 85)
@@ -2199,11 +2199,11 @@ expect {
 ~~~clojure
 (inferred-types
 	(defs
-		(d_assign (name "add_one_oneline") (def_var 190) (type "* ? Num(*)"))
-		(d_assign (name "add_one") (def_var 222) (type "U64 -> U64"))
-		(d_assign (name "match_time") (def_var 232) (type "*, * ? Error"))
-		(d_assign (name "main!") (def_var 419) (type "List -> Result"))
-		(d_assign (name "empty") (def_var 427) (type "{  }")))
+		(d_assign (name "add_one_oneline") (def_var 189) (type "* ? Num(*)"))
+		(d_assign (name "add_one") (def_var 220) (type "U64 -> U64"))
+		(d_assign (name "match_time") (def_var 230) (type "*, * ? Error"))
+		(d_assign (name "main!") (def_var 417) (type "List -> Result"))
+		(d_assign (name "empty") (def_var 425) (type "{  }")))
 	(expressions
 		(expr @65.19-67.8 (type "* ? Num(*)"))
 		(expr @68.11-78.2 (type "U64 -> U64"))

--- a/src/snapshots/if_then_else.md
+++ b/src/snapshots/if_then_else.md
@@ -83,9 +83,9 @@ foo = if 1 A
 # CANONICALIZE
 ~~~clojure
 (can-ir
-	(d-let (id 83)
+	(d-let (id 82)
 		(p-assign @3.1-3.4 (ident "foo") (id 73))
-		(e-if @3.7-7.6 (branch-var 81) (id 82)
+		(e-if @3.7-7.6 (id 81)
 			(if-branches
 				(if-branch
 					(e-int @3.10-3.11 (value "1"))
@@ -99,7 +99,7 @@ foo = if 1 A
 ~~~clojure
 (inferred-types
 	(defs
-		(d_assign (name "foo") (def_var 83) (type "Error")))
+		(d_assign (name "foo") (def_var 82) (type "Error")))
 	(expressions
 		(expr @3.7-7.6 (type "Error"))))
 ~~~

--- a/src/snapshots/if_then_else_1.md
+++ b/src/snapshots/if_then_else_1.md
@@ -29,7 +29,7 @@ NO CHANGE
 ~~~
 # CANONICALIZE
 ~~~clojure
-(e-if @1.1-1.17 (branch-var 78) (id 79)
+(e-if @1.1-1.17 (id 78)
 	(if-branches
 		(if-branch
 			(e-runtime-error (tag "ident_not_in_scope"))
@@ -39,5 +39,5 @@ NO CHANGE
 ~~~
 # TYPES
 ~~~clojure
-(expr (id 79) (type "Num(*)"))
+(expr (id 78) (type "Num(*)"))
 ~~~

--- a/src/snapshots/if_then_else_11.md
+++ b/src/snapshots/if_then_else_11.md
@@ -45,7 +45,7 @@ NO CHANGE
 ~~~
 # CANONICALIZE
 ~~~clojure
-(e-if @1.1-7.4 (branch-var 80) (id 81)
+(e-if @1.1-7.4 (id 80)
 	(if-branches
 		(if-branch
 			(e-runtime-error (tag "ident_not_in_scope"))
@@ -57,5 +57,5 @@ NO CHANGE
 ~~~
 # TYPES
 ~~~clojure
-(expr (id 81) (type "Num(*)"))
+(expr (id 80) (type "Num(*)"))
 ~~~

--- a/src/snapshots/if_then_else_13.md
+++ b/src/snapshots/if_then_else_13.md
@@ -45,7 +45,7 @@ NO CHANGE
 ~~~
 # CANONICALIZE
 ~~~clojure
-(e-if @1.1-7.4 (branch-var 80) (id 81)
+(e-if @1.1-7.4 (id 80)
 	(if-branches
 		(if-branch
 			(e-runtime-error (tag "ident_not_in_scope"))
@@ -57,5 +57,5 @@ NO CHANGE
 ~~~
 # TYPES
 ~~~clojure
-(expr (id 81) (type "Num(*)"))
+(expr (id 80) (type "Num(*)"))
 ~~~

--- a/src/snapshots/if_then_else_15.md
+++ b/src/snapshots/if_then_else_15.md
@@ -49,7 +49,7 @@ NO CHANGE
 ~~~
 # CANONICALIZE
 ~~~clojure
-(e-if @1.1-9.6 (branch-var 80) (id 81)
+(e-if @1.1-9.6 (id 80)
 	(if-branches
 		(if-branch
 			(e-runtime-error (tag "ident_not_in_scope"))
@@ -61,5 +61,5 @@ NO CHANGE
 ~~~
 # TYPES
 ~~~clojure
-(expr (id 81) (type "Num(*)"))
+(expr (id 80) (type "Num(*)"))
 ~~~

--- a/src/snapshots/if_then_else_3.md
+++ b/src/snapshots/if_then_else_3.md
@@ -49,7 +49,7 @@ NO CHANGE
 ~~~
 # CANONICALIZE
 ~~~clojure
-(e-if @1.1-3.9 (branch-var 80) (id 81)
+(e-if @1.1-3.9 (id 80)
 	(if-branches
 		(if-branch
 			(e-runtime-error (tag "ident_not_in_scope"))
@@ -60,5 +60,5 @@ NO CHANGE
 ~~~
 # TYPES
 ~~~clojure
-(expr (id 81) (type "Error"))
+(expr (id 80) (type "Error"))
 ~~~

--- a/src/snapshots/if_then_else_5.md
+++ b/src/snapshots/if_then_else_5.md
@@ -35,7 +35,7 @@ NO CHANGE
 ~~~
 # CANONICALIZE
 ~~~clojure
-(e-if @1.1-3.9 (branch-var 81) (id 82)
+(e-if @1.1-3.9 (id 81)
 	(if-branches
 		(if-branch
 			(e-runtime-error (tag "ident_not_in_scope"))
@@ -46,5 +46,5 @@ NO CHANGE
 ~~~
 # TYPES
 ~~~clojure
-(expr (id 82) (type "[A, B]*"))
+(expr (id 81) (type "[A, B]*"))
 ~~~

--- a/src/snapshots/if_then_else_7.md
+++ b/src/snapshots/if_then_else_7.md
@@ -41,7 +41,7 @@ NO CHANGE
 ~~~
 # CANONICALIZE
 ~~~clojure
-(e-if @1.1-5.2 (branch-var 80) (id 81)
+(e-if @1.1-5.2 (id 80)
 	(if-branches
 		(if-branch
 			(e-runtime-error (tag "ident_not_in_scope"))
@@ -53,5 +53,5 @@ NO CHANGE
 ~~~
 # TYPES
 ~~~clojure
-(expr (id 81) (type "Num(*)"))
+(expr (id 80) (type "Num(*)"))
 ~~~

--- a/src/snapshots/if_then_else_9.md
+++ b/src/snapshots/if_then_else_9.md
@@ -41,7 +41,7 @@ NO CHANGE
 ~~~
 # CANONICALIZE
 ~~~clojure
-(e-if @1.1-5.2 (branch-var 80) (id 81)
+(e-if @1.1-5.2 (id 80)
 	(if-branches
 		(if-branch
 			(e-runtime-error (tag "ident_not_in_scope"))
@@ -53,5 +53,5 @@ NO CHANGE
 ~~~
 # TYPES
 ~~~clojure
-(expr (id 81) (type "Num(*)"))
+(expr (id 80) (type "Num(*)"))
 ~~~

--- a/src/snapshots/if_then_else_if_chain.md
+++ b/src/snapshots/if_then_else_if_chain.md
@@ -87,13 +87,13 @@ NO CHANGE
 # CANONICALIZE
 ~~~clojure
 (can-ir
-	(d-let (id 104)
+	(d-let (id 103)
 		(p-assign @3.1-3.12 (ident "checkNumber") (id 73))
-		(e-lambda @3.15-13.2 (id 103)
+		(e-lambda @3.15-13.2 (id 102)
 			(args
 				(p-assign @3.16-3.19 (ident "num") (id 74)))
 			(e-block @3.21-13.2
-				(e-if @4.2-13.2 (branch-var 99)
+				(e-if @4.2-13.2
 					(if-branches
 						(if-branch
 							(e-binop @4.5-4.14 (op "lt")
@@ -128,7 +128,7 @@ NO CHANGE
 ~~~clojure
 (inferred-types
 	(defs
-		(d_assign (name "checkNumber") (def_var 104) (type "* ? Str")))
+		(d_assign (name "checkNumber") (def_var 103) (type "* ? Str")))
 	(expressions
 		(expr @3.15-13.2 (type "* ? Str"))))
 ~~~

--- a/src/snapshots/syntax_grab_bag.md
+++ b/src/snapshots/syntax_grab_bag.md
@@ -1238,12 +1238,12 @@ NO CHANGE
 # CANONICALIZE
 ~~~clojure
 (can-ir
-	(d-let (id 190)
+	(d-let (id 189)
 		(p-assign @65.1-65.16 (ident "add_one_oneline") (id 180))
-		(e-lambda @65.19-67.8 (id 189)
+		(e-lambda @65.19-67.8 (id 188)
 			(args
 				(p-assign @65.20-65.23 (ident "num") (id 181)))
-			(e-if @65.25-67.8 (branch-var 186)
+			(e-if @65.25-67.8
 				(if-branches
 					(if-branch
 						(e-lookup-local @65.28-65.31
@@ -1251,20 +1251,20 @@ NO CHANGE
 						(e-int @65.32-65.33 (value "2"))))
 				(if-else
 					(e-int @65.39-65.40 (value "5"))))))
-	(d-let (id 222)
-		(p-assign @68.1-68.8 (ident "add_one") (id 194))
-		(e-lambda @68.11-78.2 (id 215)
+	(d-let (id 220)
+		(p-assign @68.1-68.8 (ident "add_one") (id 193))
+		(e-lambda @68.11-78.2 (id 213)
 			(args
-				(p-assign @68.12-68.15 (ident "num") (id 195)))
+				(p-assign @68.12-68.15 (ident "num") (id 194)))
 			(e-block @68.17-78.2
 				(s-let @69.2-69.11
-					(p-assign @69.2-69.7 (ident "other") (id 196))
-					(e-int @69.10-69.11 (value "1") (id 197)))
-				(e-if @70.2-78.2 (branch-var 211)
+					(p-assign @69.2-69.7 (ident "other") (id 195))
+					(e-int @69.10-69.11 (value "1") (id 196)))
+				(e-if @70.2-78.2
 					(if-branches
 						(if-branch
 							(e-lookup-local @70.5-70.8
-								(pattern (id 195)))
+								(pattern (id 194)))
 							(e-block @70.9-74.3
 								(s-expr @71.3-73.4
 									(e-runtime-error (tag "not_implemented")))
@@ -1274,72 +1274,72 @@ NO CHANGE
 							(s-expr @75.3-76.8
 								(e-runtime-error (tag "not_implemented")))
 							(e-lookup-local @76.3-76.8
-								(pattern (id 196))))))))
-		(annotation @68.1-68.8 (signature 220) (id 221)
+								(pattern (id 195))))))))
+		(annotation @68.1-68.8 (signature 218) (id 219)
 			(declared-type
 				(ty-fn @67.11-67.21 (effectful false)
 					(ty @67.11-67.14 (name "U64"))
 					(ty @67.18-67.21 (name "U64"))))))
-	(d-let (id 232)
-		(p-assign @80.1-80.11 (ident "match_time") (id 223))
-		(e-lambda @80.14-140.7 (id 229)
+	(d-let (id 230)
+		(p-assign @80.1-80.11 (ident "match_time") (id 221))
+		(e-lambda @80.14-140.7 (id 227)
 			(args
-				(p-assign @81.2-81.3 (ident "a") (id 224))
-				(p-assign @82.2-82.3 (ident "b") (id 225)))
+				(p-assign @81.2-81.3 (ident "a") (id 222))
+				(p-assign @82.2-82.3 (ident "b") (id 223)))
 			(e-runtime-error (tag "not_implemented"))))
-	(d-let (id 437)
-		(p-assign @144.1-144.6 (ident "main!") (id 241))
-		(e-lambda @144.9-196.2 (id 430)
+	(d-let (id 435)
+		(p-assign @144.1-144.6 (ident "main!") (id 239))
+		(e-lambda @144.9-196.2 (id 428)
 			(args
-				(p-underscore @144.10-144.11 (id 242)))
+				(p-underscore @144.10-144.11 (id 240)))
 			(e-block @144.13-196.2
 				(s-let @145.2-145.17
-					(p-assign @145.2-145.7 (ident "world") (id 243))
-					(e-string @145.10-145.17 (id 245)
+					(p-assign @145.2-145.7 (ident "world") (id 241))
+					(e-string @145.10-145.17 (id 243)
 						(e-literal @145.11-145.16 (string "World"))))
 				(s-var @146.2-147.8
-					(p-assign @146.2-147.8 (ident "number") (id 248))
-					(e-int @146.15-146.18 (value "123") (id 247)))
+					(p-assign @146.2-147.8 (ident "number") (id 246))
+					(e-int @146.15-146.18 (value "123") (id 245)))
 				(s-let @148.2-148.12
-					(p-assign @148.2-148.5 (ident "tag") (id 252))
-					(e-tag @148.8-148.12 (ext-var 0) (name "Blue") (args "TODO") (id 254)))
+					(p-assign @148.2-148.5 (ident "tag") (id 250))
+					(e-tag @148.8-148.12 (ext-var 0) (name "Blue") (args "TODO") (id 252)))
 				(s-expr @154.2-155.12
 					(e-runtime-error (tag "not_implemented")))
 				(s-expr @155.2-158.11
 					(e-call @155.2-157.3
 						(e-lookup-local @155.2-155.12
-							(pattern (id 223)))
+							(pattern (id 221)))
 						(e-runtime-error (tag "not_implemented"))))
 				(s-expr @158.2-162.7
 					(e-call @158.2-161.3
 						(e-runtime-error (tag "ident_not_in_scope"))
 						(e-runtime-error (tag "not_implemented"))))
 				(s-let @164.2-164.31
-					(p-assign @164.2-164.18 (ident "tag_with_payload") (id 276))
-					(e-call @164.21-164.31 (id 281)
+					(p-assign @164.2-164.18 (ident "tag_with_payload") (id 274))
+					(e-call @164.21-164.31 (id 279)
 						(e-tag @164.21-164.23 (ext-var 0) (name "Ok") (args "TODO"))
 						(e-lookup-local @164.24-164.30
-							(pattern (id 248)))))
+							(pattern (id 246)))))
 				(s-let @165.2-165.34
-					(p-assign @165.2-165.14 (ident "interpolated") (id 283))
-					(e-string @165.17-165.34 (id 287)
+					(p-assign @165.2-165.14 (ident "interpolated") (id 281))
+					(e-string @165.17-165.34 (id 285)
 						(e-literal @165.18-165.25 (string "Hello, "))
 						(e-lookup-local @165.27-165.32
-							(pattern (id 243)))
+							(pattern (id 241)))
 						(e-literal @165.33-165.33 (string ""))))
 				(s-let @166.2-173.3
-					(p-assign @166.2-166.6 (ident "list") (id 289))
-					(e-list @166.9-173.3 (elem-var 294) (id 297)
+					(p-assign @166.2-166.6 (ident "list") (id 287))
+					(e-list @166.9-173.3 (elem-var 292) (id 295)
 						(elems
 							(e-call @167.3-170.4
 								(e-lookup-local @167.3-167.10
-									(pattern (id 194)))
+									(pattern (id 193)))
 								(e-runtime-error (tag "not_implemented")))
 							(e-int @171.3-171.6 (value "456"))
 							(e-int @172.3-172.6 (value "789")))))
 				(s-let @178.2-178.71
-					(p-assign @178.2-178.8 (ident "record") (id 301))
-					(e-record @178.11-178.71 (ext-var 318) (id 319)
+					(p-assign @178.2-178.8 (ident "record") (id 299))
+					(e-record @178.11-178.71 (ext-var 316) (id 317)
 						(fields
 							(field (name "foo")
 								(e-int @178.18-178.21 (value "123")))
@@ -1348,40 +1348,40 @@ NO CHANGE
 									(e-literal @178.29-178.34 (string "Hello"))))
 							(field (name "baz")
 								(e-lookup-local @178.42-178.45
-									(pattern (id 252))))
+									(pattern (id 250))))
 							(field (name "qux")
 								(e-call @178.52-178.61
 									(e-tag @178.52-178.54 (ext-var 0) (name "Ok") (args "TODO"))
 									(e-lookup-local @178.55-178.60
-										(pattern (id 243)))))
+										(pattern (id 241)))))
 							(field (name "punned")
 								(e-runtime-error (tag "ident_not_in_scope"))))))
 				(s-let @179.2-179.68
-					(p-assign @179.2-179.7 (ident "tuple") (id 326))
-					(e-tuple @179.10-179.68 (id 344)
+					(p-assign @179.2-179.7 (ident "tuple") (id 324))
+					(e-tuple @179.10-179.68 (id 342)
 						(elems
 							(e-int @179.11-179.14 (value "123"))
 							(e-string @179.16-179.23
 								(e-literal @179.17-179.22 (string "World")))
 							(e-lookup-local @179.25-179.28
-								(pattern (id 252)))
+								(pattern (id 250)))
 							(e-call @179.30-179.39
 								(e-tag @179.30-179.32 (ext-var 0) (name "Ok") (args "TODO"))
 								(e-lookup-local @179.33-179.38
-									(pattern (id 243))))
+									(pattern (id 241))))
 							(e-tuple @179.41-179.56
 								(elems
 									(e-runtime-error (tag "ident_not_in_scope"))
 									(e-lookup-local @179.50-179.55
-										(pattern (id 326)))))
-							(e-list @179.58-179.67 (elem-var 340)
+										(pattern (id 324)))))
+							(e-list @179.58-179.67 (elem-var 338)
 								(elems
 									(e-int @179.59-179.60 (value "1"))
 									(e-int @179.62-179.63 (value "2"))
 									(e-int @179.65-179.66 (value "3")))))))
 				(s-let @180.2-187.3
-					(p-assign @180.2-180.17 (ident "multiline_tuple") (id 346))
-					(e-tuple @180.20-187.3 (id 365)
+					(p-assign @180.2-180.17 (ident "multiline_tuple") (id 344))
+					(e-tuple @180.20-187.3 (id 363)
 						(elems
 							(e-int @181.3-181.6 (value "123"))
 							(e-string @182.3-182.10
@@ -1390,20 +1390,20 @@ NO CHANGE
 							(e-call @184.3-184.12
 								(e-tag @184.3-184.5 (ext-var 0) (name "Ok") (args "TODO"))
 								(e-lookup-local @184.6-184.11
-									(pattern (id 243))))
+									(pattern (id 241))))
 							(e-tuple @185.3-185.18
 								(elems
 									(e-runtime-error (tag "ident_not_in_scope"))
 									(e-lookup-local @185.12-185.17
-										(pattern (id 326)))))
-							(e-list @186.3-186.12 (elem-var 361)
+										(pattern (id 324)))))
+							(e-list @186.3-186.12 (elem-var 359)
 								(elems
 									(e-int @186.4-186.5 (value "1"))
 									(e-int @186.7-186.8 (value "2"))
 									(e-int @186.10-186.11 (value "3")))))))
 				(s-let @188.2-189.23
-					(p-assign @188.2-188.15 (ident "bin_op_result") (id 367))
-					(e-binop @188.18-189.23 (op "or") (id 397)
+					(p-assign @188.2-188.15 (ident "bin_op_result") (id 365))
+					(e-binop @188.18-189.23 (op "or") (id 395)
 						(e-binop @188.18-188.74 (op "or")
 							(e-binop @188.18-188.43 (op "gt")
 								(e-binop @188.18-188.34 (op "null_coalesce")
@@ -1431,8 +1431,8 @@ NO CHANGE
 								(e-int @188.81-188.82 (value "3"))
 								(e-int @188.85-188.86 (value "5"))))))
 				(s-let @189.2-190.8
-					(p-assign @189.2-189.23 (ident "static_dispatch_style") (id 399))
-					(e-dot-access @189.26-190.8 (field "unknown") (id 404)
+					(p-assign @189.2-189.23 (ident "static_dispatch_style") (id 397))
+					(e-dot-access @189.26-190.8 (field "unknown") (id 402)
 						(receiver
 							(e-dot-access @189.26-189.110 (field "unknown")
 								(receiver
@@ -1443,15 +1443,15 @@ NO CHANGE
 					(e-runtime-error (tag "not_implemented")))
 				(e-call @191.2-195.3
 					(e-lookup-external
-						(ext-decl @191.2-191.14 (qualified "pf.Stdout.line!") (module "pf.Stdout") (local "line!") (kind "value") (type-var 409)))
+						(ext-decl @191.2-191.14 (qualified "pf.Stdout.line!") (module "pf.Stdout") (local "line!") (kind "value") (type-var 407)))
 					(e-string @192.3-194.18
 						(e-literal @192.4-192.14 (string "How about "))
 						(e-call @193.4-193.21
 							(e-runtime-error (tag "ident_not_in_scope"))
 							(e-lookup-local @193.14-193.20
-								(pattern (id 248))))
+								(pattern (id 246))))
 						(e-literal @194.4-194.17 (string " as a string?"))))))
-		(annotation @144.1-144.6 (signature 435) (id 436)
+		(annotation @144.1-144.6 (signature 433) (id 434)
 			(declared-type
 				(ty-fn @143.9-143.38 (effectful false)
 					(ty-apply @143.9-143.21 (symbol "List")
@@ -1459,10 +1459,10 @@ NO CHANGE
 					(ty-apply @143.25-143.38 (symbol "Result")
 						(ty-record @143.32-143.34)
 						(ty-underscore @143.36-143.37))))))
-	(d-let (id 445)
-		(p-assign @199.1-199.6 (ident "empty") (id 439))
-		(e-empty_record @199.9-199.11 (id 440))
-		(annotation @199.1-199.6 (signature 443) (id 444)
+	(d-let (id 443)
+		(p-assign @199.1-199.6 (ident "empty") (id 437))
+		(e-empty_record @199.9-199.11 (id 438))
+		(annotation @199.1-199.6 (signature 441) (id 442)
 			(declared-type
 				(ty-record @198.9-198.11))))
 	(s-type-decl @22.1-23.6 (id 85)
@@ -1582,11 +1582,11 @@ NO CHANGE
 ~~~clojure
 (inferred-types
 	(defs
-		(d_assign (name "add_one_oneline") (def_var 190) (type "* ? Num(*)"))
-		(d_assign (name "add_one") (def_var 222) (type "U64 -> U64"))
-		(d_assign (name "match_time") (def_var 232) (type "*, * ? Error"))
-		(d_assign (name "main!") (def_var 437) (type "List -> Result"))
-		(d_assign (name "empty") (def_var 445) (type "{  }")))
+		(d_assign (name "add_one_oneline") (def_var 189) (type "* ? Num(*)"))
+		(d_assign (name "add_one") (def_var 220) (type "U64 -> U64"))
+		(d_assign (name "match_time") (def_var 230) (type "*, * ? Error"))
+		(d_assign (name "main!") (def_var 435) (type "List -> Result"))
+		(d_assign (name "empty") (def_var 443) (type "{  }")))
 	(expressions
 		(expr @65.19-67.8 (type "* ? Num(*)"))
 		(expr @68.11-78.2 (type "U64 -> U64"))

--- a/src/snapshots/type_alias_simple.md
+++ b/src/snapshots/type_alias_simple.md
@@ -92,12 +92,12 @@ NO CHANGE
 # CANONICALIZE
 ~~~clojure
 (can-ir
-	(d-let (id 100)
+	(d-let (id 99)
 		(p-assign @6.1-6.8 (ident "getUser") (id 79))
-		(e-lambda @1.1-1.1 (id 93)
+		(e-lambda @1.1-1.1 (id 92)
 			(args
 				(p-assign @6.12-6.14 (ident "id") (id 80)))
-			(e-if @1.1-1.1 (branch-var 90)
+			(e-if @1.1-1.1
 				(if-branches
 					(if-branch
 						(e-tuple @6.19-6.28
@@ -111,16 +111,16 @@ NO CHANGE
 				(if-else
 					(e-string @6.40-6.47
 						(e-literal @6.41-6.46 (string "small"))))))
-		(annotation @6.1-6.8 (signature 98) (id 99)
+		(annotation @6.1-6.8 (signature 97) (id 98)
 			(declared-type
 				(ty-fn @5.11-5.24 (effectful false)
 					(ty @5.11-5.17 (name "UserId"))
 					(ty @5.21-5.24 (name "Str"))))))
-	(d-let (id 109)
-		(p-assign @8.1-8.6 (ident "main!") (id 101))
-		(e-lambda @8.9-8.25 (id 108)
+	(d-let (id 108)
+		(p-assign @8.1-8.6 (ident "main!") (id 100))
+		(e-lambda @8.9-8.25 (id 107)
 			(args
-				(p-underscore @8.10-8.11 (id 102)))
+				(p-underscore @8.10-8.11 (id 101)))
 			(e-call @8.13-8.25
 				(e-lookup-local @8.13-8.20
 					(pattern (id 79)))
@@ -133,8 +133,8 @@ NO CHANGE
 ~~~clojure
 (inferred-types
 	(defs
-		(d_assign (name "getUser") (def_var 100) (type "UserId -> Str"))
-		(d_assign (name "main!") (def_var 109) (type "* ? *")))
+		(d_assign (name "getUser") (def_var 99) (type "UserId -> Str"))
+		(d_assign (name "main!") (def_var 108) (type "* ? *")))
 	(expressions
 		(expr @1.1-1.1 (type "UserId -> Str"))
 		(expr @8.9-8.25 (type "* ? *"))))

--- a/src/types/store.zig
+++ b/src/types/store.zig
@@ -520,7 +520,7 @@ const SlotStore = struct {
     }
 
     /// Set a value in the store
-    fn set(self: *Self, idx: Idx, val: Slot) void {
+    pub fn set(self: *Self, idx: Idx, val: Slot) void {
         self.backing.items[@intFromEnum(idx)] = val;
     }
 


### PR DESCRIPTION
This saves some memory and also removes the need for using `predictNodeIndex` with these.