### PR TITLE
Rename custom type to nominal type and reduce its size

### DIFF
--- a/src/check/canonicalize.zig
+++ b/src/check/canonicalize.zig
@@ -3749,11 +3749,11 @@ fn scopeIntroduceTypeDecl(
                 },
             });
         },
-        .custom_type_redeclared => |original_stmt| {
+        .nominal_type_redeclared => |original_stmt| {
             const original_statement = self.can_ir.store.getStatement(original_stmt);
             const original_region = original_statement.toRegion();
             self.can_ir.pushDiagnostic(CIR.Diagnostic{
-                .custom_type_redeclared = .{
+                .nominal_type_redeclared = .{
                     .name = name_ident,
                     .original_region = original_region,
                     .redeclared_region = region,

--- a/src/check/canonicalize/CIR.zig
+++ b/src/check/canonicalize/CIR.zig
@@ -249,11 +249,11 @@ pub fn diagnosticToReport(self: *CIR, diagnostic: Diagnostic, allocator: std.mem
                 filename,
             );
         },
-        .custom_type_redeclared => |data| blk: {
+        .nominal_type_redeclared => |data| blk: {
             const type_name = self.env.idents.getText(data.name);
             const original_region_info = self.calcRegionInfo(data.original_region);
             const redeclared_region_info = self.calcRegionInfo(data.redeclared_region);
-            break :blk Diagnostic.buildCustomTypeRedeclaredReport(
+            break :blk Diagnostic.buildNominalTypeRedeclaredReport(
                 allocator,
                 type_name,
                 original_region_info,
@@ -510,7 +510,7 @@ pub const Statement = union(enum) {
         exposes: ExposedItem.Span,
         region: Region,
     },
-    /// A declaration of a new type - whether an alias or a new nominal custom type
+    /// A declaration of a new type - whether an alias or a new nominal nominal type
     ///
     /// Only valid at the top level of a module
     s_type_decl: struct {

--- a/src/check/canonicalize/Diagnostic.zig
+++ b/src/check/canonicalize/Diagnostic.zig
@@ -87,7 +87,7 @@ pub const Diagnostic = union(enum) {
         original_region: Region,
         redeclared_region: Region,
     },
-    custom_type_redeclared: struct {
+    nominal_type_redeclared: struct {
         name: Ident.Idx,
         original_region: Region,
         redeclared_region: Region,
@@ -145,7 +145,7 @@ pub const Diagnostic = union(enum) {
             .undeclared_type => |d| d.region,
             .undeclared_type_var => |d| d.region,
             .type_alias_redeclared => |d| d.redeclared_region,
-            .custom_type_redeclared => |d| d.redeclared_region,
+            .nominal_type_redeclared => |d| d.redeclared_region,
             .type_shadowed_warning => |d| d.region,
             .type_parameter_conflict => |d| d.region,
             .unused_variable => |d| d.region,
@@ -551,8 +551,8 @@ pub const Diagnostic = union(enum) {
         return report;
     }
 
-    /// Build a report for "custom type redeclared" diagnostic
-    pub fn buildCustomTypeRedeclaredReport(
+    /// Build a report for "nominal type redeclared" diagnostic
+    pub fn buildNominalTypeRedeclaredReport(
         allocator: Allocator,
         type_name: []const u8,
         original_region_info: base.RegionInfo,
@@ -562,7 +562,7 @@ pub const Diagnostic = union(enum) {
     ) !Report {
         var report = Report.init(allocator, "CUSTOM TYPE REDECLARED", .runtime_error);
         const owned_type_name = try report.addOwnedString(type_name);
-        try report.document.addText("The custom type `");
+        try report.document.addText("The nominal type `");
         try report.document.addUnqualifiedSymbol(owned_type_name);
         try report.document.addText("` is being redeclared.");
         try report.document.addLineBreak();

--- a/src/check/canonicalize/Node.zig
+++ b/src/check/canonicalize/Node.zig
@@ -147,7 +147,7 @@ pub const Tag = enum {
     diag_undeclared_type,
     diag_undeclared_type_var,
     diag_type_alias_redeclared,
-    diag_custom_type_redeclared,
+    diag_nominal_type_redeclared,
     diag_type_shadowed_warning,
     diag_type_parameter_conflict,
     diag_unused_variable,

--- a/src/check/canonicalize/NodeStore.zig
+++ b/src/check/canonicalize/NodeStore.zig
@@ -2026,8 +2026,8 @@ pub fn addDiagnostic(store: *NodeStore, reason: CIR.Diagnostic) CIR.Diagnostic.I
             node.data_2 = r.original_region.start.offset;
             node.data_3 = r.original_region.end.offset;
         },
-        .custom_type_redeclared => |r| {
-            node.tag = .diag_custom_type_redeclared;
+        .nominal_type_redeclared => |r| {
+            node.tag = .diag_nominal_type_redeclared;
             node.region = r.redeclared_region;
             node.data_1 = @bitCast(r.name);
             node.data_2 = r.original_region.start.offset;
@@ -2197,7 +2197,7 @@ pub fn getDiagnostic(store: *const NodeStore, diagnostic: CIR.Diagnostic.Idx) CI
                 .end = .{ .offset = @intCast(node.data_3) },
             },
         } },
-        .diag_custom_type_redeclared => return CIR.Diagnostic{ .custom_type_redeclared = .{
+        .diag_nominal_type_redeclared => return CIR.Diagnostic{ .nominal_type_redeclared = .{
             .name = @bitCast(node.data_1),
             .redeclared_region = node.region,
             .original_region = .{

--- a/src/check/canonicalize/Scope.zig
+++ b/src/check/canonicalize/Scope.zig
@@ -104,7 +104,7 @@ pub const TypeIntroduceResult = union(enum) {
     shadowing_warning: CIR.Statement.Idx, // The type declaration that was shadowed
     redeclared_error: CIR.Statement.Idx, // The type declaration that was redeclared
     type_alias_redeclared: CIR.Statement.Idx, // The type alias that was redeclared
-    custom_type_redeclared: CIR.Statement.Idx, // The custom type that was redeclared
+    nominal_type_redeclared: CIR.Statement.Idx, // The nominal type that was redeclared
     cross_scope_shadowing: CIR.Statement.Idx, // Type shadowed across different scopes
     parameter_conflict: struct {
         original_stmt: CIR.Statement.Idx,

--- a/src/check/canonicalize/test/node_store_test.zig
+++ b/src/check/canonicalize/test/node_store_test.zig
@@ -520,7 +520,7 @@ test "NodeStore round trip - Diagnostics" {
     });
 
     try diagnostics.append(CIR.Diagnostic{
-        .custom_type_redeclared = .{
+        .nominal_type_redeclared = .{
             .name = @bitCast(@as(u32, 2425)),
             .original_region = from_raw_offsets(510, 520),
             .redeclared_region = from_raw_offsets(530, 540),

--- a/src/check/check_types/occurs.zig
+++ b/src/check/check_types/occurs.zig
@@ -716,8 +716,6 @@ test "occurs: recursive tag union with multiple nominals (TypeA := TypeB, TypeB 
     } } });
 
     // Set up TypeA's backing var to redirect to TypeB
-    // First create it as a flex var, then union it with type_b_nominal
-    try types_store.setRootVarContent(type_a_backing, Content{ .flex_var = null });
     const type_b_desc = types_store.resolveVar(type_b_nominal).desc;
     types_store.union_(type_a_backing, type_b_nominal, type_b_desc);
 

--- a/src/check/check_types/occurs.zig
+++ b/src/check/check_types/occurs.zig
@@ -688,7 +688,7 @@ test "occurs: recursive tag union with multiple nominals (TypeA := TypeB, TypeB 
     var scratch = Scratch.init(gpa);
     defer scratch.deinit();
 
-    // Create vars in the right order
+    // Create vars in the required order for adjacency to work out
     const type_b_nominal = types_store.fresh(); // Var(0)
     const type_b_backing = types_store.fresh(); // Var(1)
     const type_a_nominal = types_store.fresh(); // Var(2)

--- a/src/check/check_types/occurs.zig
+++ b/src/check/check_types/occurs.zig
@@ -70,9 +70,16 @@ pub fn occurs(types_store: *Store, scratch: *Scratch, var_: Var) Result {
 
     var result: Result = .not_recursive;
 
+    // Check if we're starting from a nominal type
+    const root = types_store.resolveVar(var_);
+    const initial_context = if (root.desc.content == .structure and root.desc.content.structure == .nominal_type)
+        Context.init().markNominal()
+    else
+        Context.init();
+
     // Check for recursion
     var check_occurs = CheckOccurs.init(types_store, scratch);
-    check_occurs.occurs(var_, Context.init()) catch |err| switch (err) {
+    check_occurs.occurs(var_, initial_context) catch |err| switch (err) {
         error.InfiniteType => {
             result = .infinite;
         },
@@ -177,12 +184,12 @@ const CheckOccurs = struct {
                         .num => {},
                         .nominal_type => |nominal_type| {
                             // Check all argument vars using iterator
-                            var arg_iter = nominal_type.argIterator(var_);
+                            var arg_iter = nominal_type.argIterator(root.var_);
                             while (arg_iter.next()) |arg_var| {
                                 try self.occursSubVar(root, arg_var, ctx);
                             }
                             // Check backing var using helper method
-                            const backing_var = nominal_type.getBackingVar(var_);
+                            const backing_var = nominal_type.getBackingVar(root.var_);
                             try self.occursSubVar(root, backing_var, ctx.markNominal());
                         },
                         .func => |func| {
@@ -673,99 +680,103 @@ test "occurs: recursive tag union (v = List: [ Cons(Elem, List), Nil ])" {
     }
 }
 
-// TODO: Fix this test - it needs to be updated for the new nominal type memory layout
-// test "occurs: recursive tag union with multiple nominals (TypeA := TypeB, TypeB := [ Cons(Elem, TypeA), Nil ])" {
-//     const gpa = std.testing.allocator;
-//     var types_store = Store.init(gpa);
-//     defer types_store.deinit();
-//
-//     var scratch = Scratch.init(gpa);
-//     defer scratch.deinit();
-//
-//     // Create type_b_nominal and its backing var first
-//     const type_b_nominal = types_store.fresh();
-//     const type_b_backing = types_store.fresh();
-//
-//     // Then create type_a_nominal and its backing var as a redirect to type_b_nominal
-//     const type_a_nominal = types_store.fresh();
-//     _ = types_store.freshRedirect(type_b_nominal);
-//
-//     const elem = types_store.fresh();
-//     const ext = types_store.fresh();
-//
-//     // Now we can use type_a_nominal in the cons tag
-//     const cons_tag_args = types_store.appendTagArgs(&[_]Var{ elem, type_a_nominal });
-//     const cons_tag = types.Tag{ .name = undefined, .args = cons_tag_args };
-//
-//     const nil_tag = types.Tag{ .name = undefined, .args = Var.SafeList.Range.empty };
-//
-//     const tags = types_store.appendTags(&[_]Tag{ cons_tag, nil_tag });
-//
-//     // TypeB = [ Cons(Elem, TypeA), Nil ]
-//     try types_store.setRootVarContent(type_b_nominal, .{ .structure = .{ .nominal_type = NominalType{
-//         .ident = undefined,
-//         .num_args = 0,
-//     } } });
-//
-//     try types_store.setRootVarContent(type_b_backing, .{ .structure = .{ .tag_union = TagUnion{ .tags = tags, .ext = ext } } });
-//
-//     // TypeA = TypeB
-//     try types_store.setRootVarContent(type_a_nominal, .{ .structure = .{ .nominal_type = NominalType{
-//         .ident = undefined,
-//         .num_args = 0,
-//     } } });
-//
-//     // assert that starting from the `TypeA` nominal, it works
-//
-//     const result1 = occurs(&types_store, &scratch, type_a_nominal);
-//     try std.testing.expectEqual(.recursive_nominal, result1);
-//
-//     const err_chain1 = scratch.errChainSlice();
-//     try std.testing.expectEqual(3, err_chain1.len);
-//     try std.testing.expectEqual(type_b_backing, err_chain1[0]);
-//     try std.testing.expectEqual(type_b_nominal, err_chain1[1]);
-//     try std.testing.expectEqual(type_a_nominal, err_chain1[2]);
-//
-//     const err_chain_nominal1 = scratch.errChainNominalVarsSlice();
-//     try std.testing.expectEqual(2, err_chain_nominal1.len);
-//     try std.testing.expectEqual(type_b_nominal, err_chain_nominal1[0]);
-//     try std.testing.expectEqual(type_a_nominal, err_chain_nominal1[1]);
-//
-//     for (scratch.visited.items.items[0..]) |visited_desc_idx| {
-//         const desc = types_store.descs.get(visited_desc_idx);
-//         const mark = @intFromEnum(desc.mark);
-//         try std.testing.expect(mark == 0);
-//     }
-//
-//     // assert that starting from the `TypeB` nominal, it works
-//
-//     const result2 = occurs(&types_store, &scratch, type_b_nominal);
-//     try std.testing.expectEqual(.recursive_nominal, result2);
-//
-//     const err_chain2 = scratch.errChainSlice();
-//     try std.testing.expectEqual(3, err_chain2.len);
-//     try std.testing.expectEqual(type_a_nominal, err_chain2[0]);
-//     try std.testing.expectEqual(type_b_backing, err_chain2[1]);
-//     try std.testing.expectEqual(type_b_nominal, err_chain2[2]);
-//
-//     const err_chain_nominal2 = scratch.errChainNominalVarsSlice();
-//     try std.testing.expectEqual(2, err_chain_nominal2.len);
-//     try std.testing.expectEqual(type_a_nominal, err_chain_nominal2[0]);
-//     try std.testing.expectEqual(type_b_nominal, err_chain_nominal2[1]);
-//
-//     // assert that starting from the the tag union, it works
-//
-//     const result3 = occurs(&types_store, &scratch, type_b_backing);
-//     try std.testing.expectEqual(.recursive_nominal, result3);
-//
-//     const err_chain3 = scratch.errChainSlice();
-//     try std.testing.expectEqual(3, err_chain3.len);
-//     try std.testing.expectEqual(type_b_nominal, err_chain3[0]);
-//     try std.testing.expectEqual(type_a_nominal, err_chain3[1]);
-//     try std.testing.expectEqual(type_b_backing, err_chain3[2]);
-//
-//     const err_chain_nominal3 = scratch.errChainNominalVarsSlice();
-//     try std.testing.expectEqual(2, err_chain_nominal3.len);
-//     try std.testing.expectEqual(type_b_nominal, err_chain_nominal3[0]);
-//     try std.testing.expectEqual(type_a_nominal, err_chain_nominal3[1]);
-// }
+test "occurs: recursive tag union with multiple nominals (TypeA := TypeB, TypeB := [ Cons(Elem, TypeA), Nil ])" {
+    const gpa = std.testing.allocator;
+    var types_store = Store.init(gpa);
+    defer types_store.deinit();
+
+    var scratch = Scratch.init(gpa);
+    defer scratch.deinit();
+
+    // Create vars in the right order
+    const type_b_nominal = types_store.fresh(); // Var(0)
+    const type_b_backing = types_store.fresh(); // Var(1)
+    const type_a_nominal = types_store.fresh(); // Var(2)
+    const type_a_backing = types_store.fresh(); // Var(3)
+    const elem = types_store.fresh(); // Var(4)
+    const ext = types_store.fresh(); // Var(5)
+
+    // Create the tag union content that references type_a_nominal
+    const cons_tag_args = types_store.appendTagArgs(&[_]Var{ elem, type_a_nominal });
+    const cons_tag = types.Tag{ .name = undefined, .args = cons_tag_args };
+    const nil_tag = types.Tag{ .name = undefined, .args = Var.SafeList.Range.empty };
+    const tags = types_store.appendTags(&[_]Tag{ cons_tag, nil_tag });
+
+    // Set up TypeB = [ Cons(Elem, TypeA), Nil ]
+    try types_store.setRootVarContent(type_b_nominal, .{ .structure = .{ .nominal_type = NominalType{
+        .ident = undefined,
+        .num_args = 0,
+    } } });
+    try types_store.setRootVarContent(type_b_backing, .{ .structure = .{ .tag_union = TagUnion{ .tags = tags, .ext = ext } } });
+
+    // Set up TypeA to be a nominal type
+    try types_store.setRootVarContent(type_a_nominal, .{ .structure = .{ .nominal_type = NominalType{
+        .ident = undefined,
+        .num_args = 0,
+    } } });
+
+    // Set up TypeA's backing var to redirect to TypeB
+    // First create it as a flex var, then union it with type_b_nominal
+    try types_store.setRootVarContent(type_a_backing, Content{ .flex_var = null });
+    const type_b_desc = types_store.resolveVar(type_b_nominal).desc;
+    types_store.union_(type_a_backing, type_b_nominal, type_b_desc);
+
+    // assert that starting from the `TypeA` nominal, it works
+    const result1 = occurs(&types_store, &scratch, type_a_nominal);
+    try std.testing.expectEqual(.recursive_nominal, result1);
+
+    const err_chain1 = scratch.errChainSlice();
+    try std.testing.expectEqual(3, err_chain1.len);
+    try std.testing.expectEqual(type_b_backing, err_chain1[0]);
+    try std.testing.expectEqual(type_b_nominal, err_chain1[1]);
+    try std.testing.expectEqual(type_a_nominal, err_chain1[2]);
+
+    const err_chain_nominal1 = scratch.errChainNominalVarsSlice();
+    try std.testing.expectEqual(2, err_chain_nominal1.len);
+    try std.testing.expectEqual(type_b_nominal, err_chain_nominal1[0]);
+    try std.testing.expectEqual(type_a_nominal, err_chain_nominal1[1]);
+
+    for (scratch.visited.items.items[0..]) |visited_desc_idx| {
+        try std.testing.expectEqual(Mark.none, types_store.getDesc(visited_desc_idx).mark);
+    }
+
+    // assert that starting from the `TypeB` nominal, it works
+
+    const result2 = occurs(&types_store, &scratch, type_b_nominal);
+    try std.testing.expectEqual(.recursive_nominal, result2);
+
+    const err_chain2 = scratch.errChainSlice();
+    try std.testing.expectEqual(3, err_chain2.len);
+    try std.testing.expectEqual(type_a_nominal, err_chain2[0]);
+    try std.testing.expectEqual(type_b_backing, err_chain2[1]);
+    try std.testing.expectEqual(type_b_nominal, err_chain2[2]);
+
+    const err_chain_nominal2 = scratch.errChainNominalVarsSlice();
+    try std.testing.expectEqual(2, err_chain_nominal2.len);
+    try std.testing.expectEqual(type_a_nominal, err_chain_nominal2[0]);
+    try std.testing.expectEqual(type_b_nominal, err_chain_nominal2[1]);
+
+    for (scratch.visited.items.items[0..]) |visited_desc_idx| {
+        try std.testing.expectEqual(Mark.none, types_store.getDesc(visited_desc_idx).mark);
+    }
+
+    // assert that starting from the the tag union, it works
+
+    const result3 = occurs(&types_store, &scratch, type_b_backing);
+    try std.testing.expectEqual(.recursive_nominal, result3);
+
+    const err_chain3 = scratch.errChainSlice();
+    try std.testing.expectEqual(3, err_chain3.len);
+    try std.testing.expectEqual(type_b_nominal, err_chain3[0]);
+    try std.testing.expectEqual(type_a_nominal, err_chain3[1]);
+    try std.testing.expectEqual(type_b_backing, err_chain3[2]);
+
+    const err_chain_nominal3 = scratch.errChainNominalVarsSlice();
+    try std.testing.expectEqual(2, err_chain_nominal3.len);
+    try std.testing.expectEqual(type_b_nominal, err_chain_nominal3[0]);
+    try std.testing.expectEqual(type_a_nominal, err_chain_nominal3[1]);
+
+    for (scratch.visited.items.items[0..]) |visited_desc_idx| {
+        try std.testing.expectEqual(Mark.none, types_store.getDesc(visited_desc_idx).mark);
+    }
+}

--- a/src/check/check_types/snapshot.zig
+++ b/src/check/check_types/snapshot.zig
@@ -216,7 +216,7 @@ pub const Store = struct {
         // Mark starting position in the centralized array
         const start_idx = self.nominal_type_args.len();
 
-        // Copy all argument vars using iterator
+        // // Iterate and append directly
         var arg_iter = nominal_type.argIterator(nominal_var);
         while (arg_iter.next()) |arg_var| {
             const arg_resolved = store.resolveVar(arg_var);

--- a/src/check/check_types/snapshot.zig
+++ b/src/check/check_types/snapshot.zig
@@ -42,7 +42,7 @@ pub const Store = struct {
     // Backing arrays for ranges (like Store)
     alias_args: SnapshotContentIdxSafeList,
     tuple_elems: SnapshotContentIdxSafeList,
-    custom_type_args: SnapshotContentIdxSafeList,
+    nominal_type_args: SnapshotContentIdxSafeList,
     func_args: SnapshotContentIdxSafeList,
     record_fields: SnapshotRecordFieldSafeList,
     tags: SnapshotTagSafeList,
@@ -54,7 +54,7 @@ pub const Store = struct {
             .contents = SnapshotContentList.initCapacity(gpa, capacity),
             .alias_args = SnapshotContentIdxSafeList.initCapacity(gpa, capacity),
             .tuple_elems = SnapshotContentIdxSafeList.initCapacity(gpa, capacity),
-            .custom_type_args = SnapshotContentIdxSafeList.initCapacity(gpa, capacity),
+            .nominal_type_args = SnapshotContentIdxSafeList.initCapacity(gpa, capacity),
             .func_args = SnapshotContentIdxSafeList.initCapacity(gpa, capacity),
             .record_fields = SnapshotRecordFieldSafeList.initCapacity(gpa, capacity),
             .tags = SnapshotTagSafeList.initCapacity(gpa, capacity),
@@ -66,7 +66,7 @@ pub const Store = struct {
         self.contents.deinit(self.gpa);
         self.alias_args.deinit(self.gpa);
         self.tuple_elems.deinit(self.gpa);
-        self.custom_type_args.deinit(self.gpa);
+        self.nominal_type_args.deinit(self.gpa);
         self.func_args.deinit(self.gpa);
         self.record_fields.deinit(self.gpa);
         self.tags.deinit(self.gpa);
@@ -87,24 +87,24 @@ pub const Store = struct {
             .alias => |alias| SnapshotContent{ .alias = self.deepCopyAlias(store, alias, var_) },
             .effectful => SnapshotContent.effectful,
             .pure => SnapshotContent.pure,
-            .structure => |flat_type| SnapshotContent{ .structure = self.deepCopyFlatType(store, flat_type) },
+            .structure => |flat_type| SnapshotContent{ .structure = self.deepCopyFlatType(store, flat_type, var_) },
             .err => SnapshotContent.err,
         };
 
         return self.contents.append(self.gpa, deep_content);
     }
 
-    fn deepCopyFlatType(self: *Self, store: *const TypesStore, flat_type: types.FlatType) SnapshotFlatType {
+    fn deepCopyFlatType(self: *Self, store: *const TypesStore, flat_type: types.FlatType, var_: types.Var) SnapshotFlatType {
         return switch (flat_type) {
             .str => SnapshotFlatType.str,
-            .box => |var_| {
-                const resolved = store.resolveVar(var_);
-                const deep_content = self.deepCopyContent(store, resolved.desc.content, var_);
+            .box => |box_var| {
+                const resolved = store.resolveVar(box_var);
+                const deep_content = self.deepCopyContent(store, resolved.desc.content, box_var);
                 return SnapshotFlatType{ .box = deep_content };
             },
-            .list => |var_| {
-                const resolved = store.resolveVar(var_);
-                const deep_content = self.deepCopyContent(store, resolved.desc.content, var_);
+            .list => |list_var| {
+                const resolved = store.resolveVar(list_var);
+                const deep_content = self.deepCopyContent(store, resolved.desc.content, list_var);
                 return SnapshotFlatType{ .list = deep_content };
             },
             .list_unbound => {
@@ -113,7 +113,7 @@ pub const Store = struct {
             .tuple => |tuple| SnapshotFlatType{ .tuple = self.deepCopyTuple(store, tuple) },
             .tuple_unbound => |tuple| SnapshotFlatType{ .tuple_unbound = self.deepCopyTuple(store, tuple) },
             .num => |num| SnapshotFlatType{ .num = self.deepCopyNum(store, num) },
-            .custom_type => |custom_type| SnapshotFlatType{ .custom_type = self.deepCopyCustomType(store, custom_type) },
+            .nominal_type => |nominal_type| SnapshotFlatType{ .nominal_type = self.deepCopyNominalType(store, nominal_type, var_) },
             .func => |func| SnapshotFlatType{ .func = self.deepCopyFunc(store, func) },
             .record => |record| SnapshotFlatType{ .record = self.deepCopyRecord(store, record) },
             .record_unbound => |record| SnapshotFlatType{ .record_unbound = self.deepCopyRecord(store, record) },
@@ -212,27 +212,26 @@ pub const Store = struct {
         }
     }
 
-    fn deepCopyCustomType(self: *Self, store: *const TypesStore, custom_type: types.CustomType) SnapshotCustomType {
-        const args_slice = store.getCustomTypeArgsSlice(custom_type.args);
+    fn deepCopyNominalType(self: *Self, store: *const TypesStore, nominal_type: types.NominalType, nominal_var: types.Var) SnapshotNominalType {
+        // Mark starting position in the centralized array
+        const start_idx = self.nominal_type_args.len();
 
-        // Mark starting position
-        const start_idx = self.custom_type_args.len();
-
-        // Iterate and append directly
-        for (args_slice) |arg_var| {
+        // Copy all argument vars using iterator
+        var arg_iter = nominal_type.argIterator(nominal_var);
+        while (arg_iter.next()) |arg_var| {
             const arg_resolved = store.resolveVar(arg_var);
             const deep_arg = self.deepCopyContent(store, arg_resolved.desc.content, arg_var);
-            _ = self.custom_type_args.append(self.gpa, deep_arg);
+            _ = self.nominal_type_args.append(self.gpa, deep_arg);
         }
 
         // Create range
         const args_range = SnapshotContentIdxSafeList.Range{
             .start = @enumFromInt(start_idx),
-            .end = @enumFromInt(self.custom_type_args.len()),
+            .end = @enumFromInt(self.nominal_type_args.len()),
         };
 
-        return SnapshotCustomType{
-            .ident = custom_type.ident,
+        return SnapshotNominalType{
+            .ident = nominal_type.ident,
             .args = args_range,
         };
     }
@@ -368,8 +367,8 @@ pub const Store = struct {
         return self.tuple_elems.rangeToSlice(range);
     }
 
-    pub fn getCustomTypeArgsSlice(self: *const Self, range: SnapshotContentIdxSafeList.Range) []const SnapshotContentIdx {
-        return self.custom_type_args.rangeToSlice(range);
+    pub fn getNominalTypeArgsSlice(self: *const Self, range: SnapshotContentIdxSafeList.Range) []const SnapshotContentIdx {
+        return self.nominal_type_args.rangeToSlice(range);
     }
 
     pub fn getFuncArgsSlice(self: *const Self, range: SnapshotContentIdxSafeList.Range) []const SnapshotContentIdx {
@@ -419,7 +418,7 @@ pub const SnapshotFlatType = union(enum) {
     tuple: SnapshotTuple,
     tuple_unbound: SnapshotTuple,
     num: SnapshotNum,
-    custom_type: SnapshotCustomType,
+    nominal_type: SnapshotNominalType,
     func: SnapshotFunc,
     record: SnapshotRecord,
     record_unbound: SnapshotRecord,
@@ -447,9 +446,9 @@ pub const SnapshotNum = union(enum) {
 };
 
 /// TODO
-pub const SnapshotCustomType = struct {
+pub const SnapshotNominalType = struct {
     ident: types.TypeIdent,
-    args: SnapshotContentIdxSafeList.Range, // Range into SnapshotStore.custom_type_args
+    args: SnapshotContentIdxSafeList.Range, // Range into SnapshotStore.nominal_type_args
 };
 
 /// TODO
@@ -575,8 +574,8 @@ pub const SnapshotWriter = struct {
             .num => |num| {
                 try self.writeNum(num);
             },
-            .custom_type => |custom_type| {
-                try self.writeCustomType(custom_type);
+            .nominal_type => |nominal_type| {
+                try self.writeNominalType(nominal_type);
             },
             .func => |func| {
                 try self.writeFunc(func);
@@ -610,10 +609,10 @@ pub const SnapshotWriter = struct {
         _ = try self.writer.write(")");
     }
 
-    /// Write a custom type
-    pub fn writeCustomType(self: *Self, custom_type: SnapshotCustomType) Allocator.Error!void {
-        _ = try self.writer.write(self.idents.getText(custom_type.ident.ident_idx));
-        const args = self.snapshots.getCustomTypeArgsSlice(custom_type.args);
+    /// Write a nominal type
+    pub fn writeNominalType(self: *Self, nominal_type: SnapshotNominalType) Allocator.Error!void {
+        _ = try self.writer.write(self.idents.getText(nominal_type.ident.ident_idx));
+        const args = self.snapshots.getNominalTypeArgsSlice(nominal_type.args);
         if (args.len > 0) {
             _ = try self.writer.write("(");
             for (args, 0..) |arg, i| {

--- a/src/check/check_types/unify.zig
+++ b/src/check/check_types/unify.zig
@@ -523,7 +523,7 @@ const Unifier = struct {
             return error.TypeMismatch;
         }
 
-        // Unify each pair of arguments using iterators
+        // Unify each pair of arguments
         var a_iter = a_alias.argIterator(vars.a.var_);
         var b_iter = b_alias.argIterator(vars.b.var_);
         while (a_iter.next()) |a_arg| {

--- a/src/check/check_types/unify.zig
+++ b/src/check/check_types/unify.zig
@@ -67,7 +67,7 @@ const Rank = types_mod.Rank;
 const Mark = types_mod.Mark;
 const Content = types_mod.Content;
 const Alias = types_mod.Alias;
-const CustomType = types_mod.CustomType;
+const NominalType = types_mod.NominalType;
 const FlatType = types_mod.FlatType;
 const Builtin = types_mod.Builtin;
 const Tuple = types_mod.Tuple;
@@ -678,10 +678,10 @@ const Unifier = struct {
                     else => return error.TypeMismatch,
                 }
             },
-            .custom_type => |a_type| {
+            .nominal_type => |a_type| {
                 switch (b_flat_type) {
-                    .custom_type => |b_type| {
-                        try self.unifyCustomType(vars, a_type, b_type);
+                    .nominal_type => |b_type| {
+                        try self.unifyNominalType(vars, a_type, b_type);
                     },
                     else => return error.TypeMismatch,
                 }
@@ -1412,17 +1412,23 @@ const Unifier = struct {
         }
     }
 
-    // Unify custom type //
+    // Unify nominal type //
 
-    /// Unify when `a` was a custom type
-    fn unifyCustomType(self: *Self, vars: *const ResolvedVarDescs, a_type: CustomType, b_type: CustomType) Error!void {
+    /// Unify when `a` was a nominal type
+    fn unifyNominalType(self: *Self, vars: *const ResolvedVarDescs, a_type: NominalType, b_type: NominalType) Error!void {
         if (!TypeIdent.eql(&self.module_env.idents, a_type.ident, b_type.ident)) {
             return error.TypeMismatch;
         }
 
-        const a_args = self.types_store.getCustomTypeArgsSlice(a_type.args);
-        const b_args = self.types_store.getCustomTypeArgsSlice(b_type.args);
-        for (a_args, b_args) |a_arg, b_arg| {
+        if (a_type.num_args != b_type.num_args) {
+            return error.TypeMismatch;
+        }
+
+        // Unify each pair of arguments using iterators
+        var a_iter = a_type.argIterator(vars.a.var_);
+        var b_iter = b_type.argIterator(vars.b.var_);
+        while (a_iter.next()) |a_arg| {
+            const b_arg = b_iter.next().?; // Safe because we checked num_args match
             try self.unifyGuarded(a_arg, b_arg);
         }
 
@@ -2681,14 +2687,30 @@ const TestEnv = struct {
         return Content{ .structure = .{ .tuple = .{ .elems = elems_range } } };
     }
 
-    // helpers - custom type
+    // helpers - nominal type
 
-    fn mkCustomType(self: *Self, name: []const u8, args: []const Var, backing_var: Var) Content {
-        const args_range = self.module_env.types.appendCustomTypeArgs(args);
-        return Content{ .structure = .{ .custom_type = .{
+    /// Create a NominalType struct with the given name and number of args.
+    ///
+    /// The `args` parameter is only used to determine the count - the actual arg types
+    /// passed here are just for reference/documentation and aren't stored.
+    ///
+    /// IMPORTANT: The caller is responsible for creating the vars in the right order:
+    /// 1. nominal type var
+    /// 2. backing var (nominal type var + 1)
+    /// 3. arg vars (nominal type var + 2, nominal type var + 3, etc.)
+    ///
+    /// For example, to create a nominal type `MyType(Str, Int)`:
+    /// ```
+    /// const nominal = mkNominalType("MyType", &[_]Var{str_var, int_var});
+    /// const nominal_var = types_store.freshFromContent(nominal);
+    /// const backing_var = types_store.fresh(); // Must be created immediately after
+    /// const arg1_redirect = types_store.freshRedirect(str_var); // Must be next
+    /// const arg2_redirect = types_store.freshRedirect(int_var); // Must be next
+    /// ```
+    fn mkNominalType(self: *Self, name: []const u8, args: []const Var) Content {
+        return Content{ .structure = .{ .nominal_type = .{
             .ident = self.mkTypeIdent(name),
-            .args = args_range,
-            .backing_var = backing_var,
+            .num_args = @intCast(args.len),
         } } };
     }
 
@@ -4190,41 +4212,48 @@ test "unify - same funcs first pure, second eff" {
     try std.testing.expectEqual(eff_func, (try env.getDescForRootVar(b)).content);
 }
 
-// unification - structure/structure - custom type
+// unification - structure/structure - nominal type
 
-test "unify - a & b are both the same custom type" {
+test "unify - a & b are both the same nominal type" {
     const gpa = std.testing.allocator;
 
     var env = TestEnv.init(gpa);
     defer env.deinit();
 
-    const backing_var = env.module_env.types.freshFromContent(Content{ .structure = .str });
     const arg_var = env.module_env.types.freshFromContent(Content{ .structure = .{ .num = Num.int_u8 } });
-    const custom_type = env.mkCustomType("MyType", &[_]Var{arg_var}, backing_var);
+    const nominal_type = env.mkNominalType("MyType", &[_]Var{arg_var});
 
-    const a = env.module_env.types.freshFromContent(custom_type);
-    const b = env.module_env.types.freshFromContent(custom_type);
+    const a = env.module_env.types.freshFromContent(nominal_type);
+    _ = env.module_env.types.freshFromContent(Content{ .structure = .str }); // backing var
+    _ = env.module_env.types.freshRedirect(arg_var); // arg
+
+    const b = env.module_env.types.freshFromContent(nominal_type);
+    _ = env.module_env.types.freshFromContent(Content{ .structure = .str }); // backing var
+    _ = env.module_env.types.freshRedirect(arg_var); // arg
     const result = env.unify(a, b);
 
     try std.testing.expectEqual(.ok, result);
     try std.testing.expectEqual(Slot{ .redirect = b }, env.module_env.types.getSlot(a));
-    try std.testing.expectEqual(custom_type, (try env.getDescForRootVar(b)).content);
+    try std.testing.expectEqual(nominal_type, (try env.getDescForRootVar(b)).content);
 }
 
-test "unify - a & b are diff custom types (fail)" {
+test "unify - a & b are diff nominal types (fail)" {
     const gpa = std.testing.allocator;
 
     var env = TestEnv.init(gpa);
     defer env.deinit();
 
-    const backing_var = env.module_env.types.freshFromContent(Content{ .structure = .str });
     const arg_var = env.module_env.types.freshFromContent(Content{ .structure = .{ .num = Num.int_u8 } });
 
-    const custom_type_a = env.mkCustomType("MyType", &[_]Var{arg_var}, backing_var);
-    const a = env.module_env.types.freshFromContent(custom_type_a);
+    const nominal_type_a = env.mkNominalType("MyType", &[_]Var{arg_var});
+    const a = env.module_env.types.freshFromContent(nominal_type_a);
+    _ = env.module_env.types.freshFromContent(Content{ .structure = .str }); // backing var
+    _ = env.module_env.types.freshRedirect(arg_var); // arg
 
-    const custom_type_b = env.mkCustomType("AnotherType", &[_]Var{arg_var}, backing_var);
-    const b = env.module_env.types.freshFromContent(custom_type_b);
+    const nominal_type_b = env.mkNominalType("AnotherType", &[_]Var{arg_var});
+    const b = env.module_env.types.freshFromContent(nominal_type_b);
+    _ = env.module_env.types.freshFromContent(Content{ .structure = .str }); // backing var
+    _ = env.module_env.types.freshRedirect(arg_var); // arg
 
     const result = env.unify(a, b);
 
@@ -4233,20 +4262,24 @@ test "unify - a & b are diff custom types (fail)" {
     try std.testing.expectEqual(.err, (try env.getDescForRootVar(b)).content);
 }
 
-test "unify - a & b are both the same custom type with diff args (fail)" {
+test "unify - a & b are both the same nominal type with diff args (fail)" {
     const gpa = std.testing.allocator;
 
     var env = TestEnv.init(gpa);
     defer env.deinit();
 
-    const backing_var = env.module_env.types.freshFromContent(Content{ .structure = .str });
     const arg_var = env.module_env.types.freshFromContent(Content{ .structure = .{ .num = Num.int_u8 } });
+    const str_var = env.module_env.types.freshFromContent(Content{ .structure = .str });
 
-    const custom_type_a = env.mkCustomType("MyType", &[_]Var{arg_var}, backing_var);
-    const a = env.module_env.types.freshFromContent(custom_type_a);
+    const nominal_type_a = env.mkNominalType("MyType", &[_]Var{arg_var});
+    const a = env.module_env.types.freshFromContent(nominal_type_a);
+    _ = env.module_env.types.freshFromContent(Content{ .structure = .str }); // backing var
+    _ = env.module_env.types.freshRedirect(arg_var); // arg
 
-    const custom_type_b = env.mkCustomType("MyType", &[_]Var{backing_var}, backing_var);
-    const b = env.module_env.types.freshFromContent(custom_type_b);
+    const nominal_type_b = env.mkNominalType("MyType", &[_]Var{str_var});
+    const b = env.module_env.types.freshFromContent(nominal_type_b);
+    _ = env.module_env.types.freshFromContent(Content{ .structure = .str }); // backing var
+    _ = env.module_env.types.freshRedirect(str_var); // arg
 
     const result = env.unify(a, b);
 
@@ -5294,24 +5327,24 @@ test "unify - succeeds on nominal, tag union recursion" {
     var env = TestEnv.init(gpa);
     defer env.deinit();
 
-    const a_custom_type_var = env.module_env.types.fresh();
+    const a_nominal_type_var = env.module_env.types.fresh();
     const a_elem_var = env.module_env.types.fresh();
     const a_nil_tag = env.mkTag("Nil", &[_]Var{});
-    const a_cons_tag = env.mkTag("Cons", &[_]Var{ a_elem_var, a_custom_type_var });
+    const a_cons_tag = env.mkTag("Cons", &[_]Var{ a_elem_var, a_nominal_type_var });
+    const a_nominal_type = env.mkNominalType("List", &[_]Var{});
+    try env.module_env.types.setRootVarContent(a_nominal_type_var, a_nominal_type);
     const a_tag_union_var = env.module_env.types.freshFromContent(env.mkTagUnionOpen(&[_]Tag{ a_nil_tag, a_cons_tag }).content);
-    const a_custom_type = env.mkCustomType("List", &[_]Var{}, a_tag_union_var);
-    try env.module_env.types.setRootVarContent(a_custom_type_var, a_custom_type);
 
-    const b_custom_type_var = env.module_env.types.fresh();
+    const b_nominal_type_var = env.module_env.types.fresh();
     const b_elem_var = env.module_env.types.fresh();
     const b_nil_tag = env.mkTag("Nil", &[_]Var{});
-    const b_cons_tag = env.mkTag("Cons", &[_]Var{ b_elem_var, b_custom_type_var });
+    const b_cons_tag = env.mkTag("Cons", &[_]Var{ b_elem_var, b_nominal_type_var });
+    const b_nominal_type = env.mkNominalType("List", &[_]Var{});
+    try env.module_env.types.setRootVarContent(b_nominal_type_var, b_nominal_type);
     const b_tag_union_var = env.module_env.types.freshFromContent(env.mkTagUnionOpen(&[_]Tag{ b_nil_tag, b_cons_tag }).content);
-    const b_custom_type = env.mkCustomType("List", &[_]Var{}, b_tag_union_var);
-    try env.module_env.types.setRootVarContent(b_custom_type_var, b_custom_type);
 
-    const result_custom_type = env.unify(a_custom_type_var, b_custom_type_var);
-    try std.testing.expectEqual(.ok, result_custom_type);
+    const result_nominal_type = env.unify(a_nominal_type_var, b_nominal_type_var);
+    try std.testing.expectEqual(.ok, result_nominal_type);
 
     const result_tag_union = env.unify(a_tag_union_var, b_tag_union_var);
     try std.testing.expectEqual(.ok, result_tag_union);

--- a/src/layout/store.zig
+++ b/src/layout/store.zig
@@ -566,14 +566,15 @@ pub const Store = struct {
                         try self.layouts_by_var.put(self.env.gpa, current.var_, idx);
                         return idx;
                     },
-                    .custom_type => |custom_type| {
+                    .nominal_type => |nominal_type| {
                         // TODO special-case the builtin Num type here.
                         // If we have one of those, then convert it to a Num layout,
                         // or to a runtime error if it's an invalid elem type.
 
-                        // From a layout perspective, custom types are identical to type aliases:
+                        // From a layout perspective, nominal types are identical to type aliases:
                         // all we care about is what's inside, so just unroll it.
-                        current = self.types_store.resolveVar(custom_type.backing_var);
+                        const backing_var = nominal_type.getBackingVar(current.var_);
+                        current = self.types_store.resolveVar(backing_var);
                         continue;
                     },
                     .num => |num| switch (num) {

--- a/src/types/store.zig
+++ b/src/types/store.zig
@@ -54,7 +54,6 @@ pub const Store = struct {
 
     // Everything else
     tuple_elems: VarSafeList,
-    custom_type_args: VarSafeList,
     func_args: VarSafeList,
     record_fields: RecordFieldSafeMultiList,
     tags: TagSafeMultiList,
@@ -77,7 +76,6 @@ pub const Store = struct {
 
             // everything else
             .tuple_elems = VarSafeList.initCapacity(gpa, child_capacity),
-            .custom_type_args = VarSafeList.initCapacity(gpa, child_capacity),
             .func_args = VarSafeList.initCapacity(gpa, child_capacity),
             .record_fields = RecordFieldSafeMultiList.initCapacity(gpa, child_capacity),
             .tags = TagSafeMultiList.initCapacity(gpa, child_capacity),
@@ -99,7 +97,6 @@ pub const Store = struct {
 
         // everything else
         self.tuple_elems.deinit(self.gpa);
-        self.custom_type_args.deinit(self.gpa);
         self.func_args.deinit(self.gpa);
         self.record_fields.deinit(self.gpa);
         self.tags.deinit(self.gpa);
@@ -261,11 +258,6 @@ pub const Store = struct {
         return self.tuple_elems.appendSlice(self.gpa, slice);
     }
 
-    /// Append a slice of type apply args to the backing list, returning the range
-    pub fn appendCustomTypeArgs(self: *Self, slice: []const Var) VarSafeList.Range {
-        return self.custom_type_args.appendSlice(self.gpa, slice);
-    }
-
     /// Append a slice of func args to the backing list, returning the range
     pub fn appendFuncArgs(self: *Self, slice: []const Var) VarSafeList.Range {
         return self.func_args.appendSlice(self.gpa, slice);
@@ -291,11 +283,6 @@ pub const Store = struct {
     /// Given a range, get a slice of tuple from the backing list
     pub fn getTupleElemsSlice(self: *const Self, range: VarSafeList.Range) VarSafeList.Slice {
         return self.tuple_elems.rangeToSlice(range);
-    }
-
-    /// Given a range, get a slice of type from to the backing
-    pub fn getCustomTypeArgsSlice(self: *const Self, range: VarSafeList.Range) VarSafeList.Slice {
-        return self.custom_type_args.rangeToSlice(range);
     }
 
     /// Given a range, get a slice of func from the backing list

--- a/src/types/types.zig
+++ b/src/types/types.zig
@@ -574,18 +574,6 @@ pub const NominalType = struct {
         return backing_var;
     }
 
-    /// Get the first argument var for this nominal type given the nominal type var
-    pub fn getFirstArgVar(self: NominalType, nominal_var: Var) Var {
-        const first_arg = @as(Var, @enumFromInt(@intFromEnum(nominal_var) + 2));
-
-        // Debug assertion: verify we have at least one arg
-        if (std.debug.runtime_safety) {
-            std.debug.assert(self.num_args > 0);
-        }
-
-        return first_arg;
-    }
-
     /// Get the argument var at the given index for this nominal type given the nominal type var
     pub fn getArgVar(self: NominalType, nominal_var: Var, arg_index: usize) Var {
         std.debug.assert(arg_index < self.num_args);

--- a/src/types/types.zig
+++ b/src/types/types.zig
@@ -574,21 +574,6 @@ pub const NominalType = struct {
         return backing_var;
     }
 
-    /// Get the argument var at the given index for this nominal type given the nominal type var
-    pub fn getArgVar(self: NominalType, nominal_var: Var, arg_index: usize) Var {
-        std.debug.assert(arg_index < self.num_args);
-        const arg_var = @as(Var, @enumFromInt(@intFromEnum(nominal_var) + 2 + arg_index));
-
-        // Debug assertion: verify the arg var index is reasonable
-        if (std.debug.runtime_safety) {
-            // Should be after backing var
-            const backing_var = self.getBackingVar(nominal_var);
-            std.debug.assert(@intFromEnum(arg_var) > @intFromEnum(backing_var));
-        }
-
-        return arg_var;
-    }
-
     /// Iterator for getting all argument vars
     pub const ArgIterator = struct {
         nominal_var: Var,
@@ -610,23 +595,6 @@ pub const NominalType = struct {
             .num_args = self.num_args,
             .current = 0,
         };
-    }
-
-    /// Get a slice of all argument vars (requires allocation)
-    pub fn getArgVarsAlloc(self: NominalType, allocator: std.mem.Allocator, nominal_var: Var) ![]Var {
-        const args = try allocator.alloc(Var, self.num_args);
-        for (0..self.num_args) |i| {
-            args[i] = self.getArgVar(nominal_var, i);
-        }
-        return args;
-    }
-
-    /// Fill a pre-allocated buffer with argument vars
-    pub fn getArgVarsBuf(self: NominalType, nominal_var: Var, buffer: []Var) void {
-        std.debug.assert(buffer.len >= self.num_args);
-        for (0..self.num_args) |i| {
-            buffer[i] = self.getArgVar(nominal_var, i);
-        }
     }
 };
 

--- a/src/types/writers.zig
+++ b/src/types/writers.zig
@@ -194,7 +194,6 @@ pub const TypeWriter = struct {
         _ = try self.writer.write(self.env.idents.getText(nominal_type.ident.ident_idx));
         if (nominal_type.num_args > 0) {
             _ = try self.writer.write("(");
-            // Use iterator to get argument vars
             var arg_iter = nominal_type.argIterator(nominal_var);
             // Write first arg without comma
             if (arg_iter.next()) |arg_var| {

--- a/src/types/writers.zig
+++ b/src/types/writers.zig
@@ -115,7 +115,7 @@ pub const TypeWriter = struct {
             var arg_iter = alias.argIterator(alias_var);
             // Write first arg without comma
             const first_arg = arg_iter.next();
-            std.debug.assert(first_arg != null); // It shouldn't be null becasue we checked num_args > 0
+            std.debug.assert(first_arg != null); // It shouldn't be null because we checked num_args > 0
             try self.writeVar(first_arg.?);
             // Write remaining args with comma prefix
             while (arg_iter.next()) |arg_var| {

--- a/src/types/writers.zig
+++ b/src/types/writers.zig
@@ -93,7 +93,7 @@ pub const TypeWriter = struct {
                 try self.writeAlias(alias, var_);
             },
             .structure => |flat_type| {
-                try self.writeFlatType(flat_type);
+                try self.writeFlatType(flat_type, var_);
             },
             .effectful => {
                 _ = try self.writer.write("Effectful");
@@ -127,7 +127,7 @@ pub const TypeWriter = struct {
     }
 
     /// Convert a flat type to a type string
-    pub fn writeFlatType(self: *Self, flat_type: FlatType) Allocator.Error!void {
+    pub fn writeFlatType(self: *Self, flat_type: FlatType, var_: types.Var) Allocator.Error!void {
         switch (flat_type) {
             .str => {
                 _ = try self.writer.write("Str");
@@ -154,8 +154,8 @@ pub const TypeWriter = struct {
             .num => |num| {
                 try self.writeNum(num);
             },
-            .custom_type => |custom_type| {
-                try self.writeCustomType(custom_type);
+            .nominal_type => |nominal_type| {
+                try self.writeNominalType(nominal_type, var_);
             },
             .func => |func| {
                 try self.writeFunc(func);
@@ -189,15 +189,21 @@ pub const TypeWriter = struct {
         _ = try self.writer.write(")");
     }
 
-    /// Write a custom type
-    pub fn writeCustomType(self: *Self, custom_type: types.CustomType) Allocator.Error!void {
-        _ = try self.writer.write(self.env.idents.getText(custom_type.ident.ident_idx));
-        const args = self.env.types.getCustomTypeArgsSlice(custom_type.args);
-        if (args.len > 0) {
+    /// Write a nominal type
+    pub fn writeNominalType(self: *Self, nominal_type: types.NominalType, nominal_var: types.Var) Allocator.Error!void {
+        _ = try self.writer.write(self.env.idents.getText(nominal_type.ident.ident_idx));
+        if (nominal_type.num_args > 0) {
             _ = try self.writer.write("(");
-            for (args, 0..) |arg, i| {
-                if (i > 0) _ = try self.writer.write(", ");
-                try self.writeVar(arg);
+            // Use iterator to get argument vars
+            var arg_iter = nominal_type.argIterator(nominal_var);
+            // Write first arg without comma
+            if (arg_iter.next()) |arg_var| {
+                try self.writeVar(arg_var);
+            }
+            // Write remaining args with comma prefix
+            while (arg_iter.next()) |arg_var| {
+                _ = try self.writer.write(", ");
+                try self.writeVar(arg_var);
             }
             _ = try self.writer.write(")");
         }


### PR DESCRIPTION
Gave it the same size reduction treatment as `Alias` in https://github.com/roc-lang/roc/pull/7901