### PR TITLE
Unit Tests for `CIR.NodeStore`

### DIFF
--- a/src/check/canonicalize/CIR.zig
+++ b/src/check/canonicalize/CIR.zig
@@ -24,6 +24,9 @@ const NodeStore = @import("NodeStore.zig");
 
 pub const Diagnostic = @import("Diagnostic.zig").Diagnostic;
 
+// TODO what should this number be? build flag?
+const NODE_STORE_CAPACITY = 10_000;
+
 const CIR = @This();
 
 /// Reference to data that persists between compiler stages
@@ -62,8 +65,6 @@ external_decls: std.ArrayList(ExternalDecl),
 ///
 /// Takes ownership of the module_env
 pub fn init(env: *ModuleEnv) CIR {
-    const NODE_STORE_CAPACITY = 10_000;
-
     return CIR{
         .env = env,
         .store = NodeStore.initCapacity(env.gpa, NODE_STORE_CAPACITY),

--- a/src/check/canonicalize/Node.zig
+++ b/src/check/canonicalize/Node.zig
@@ -59,6 +59,7 @@ pub const Tag = enum {
     expr_frac_dec,
     expr_dec_small,
     expr_tag,
+    expr_zero_argument_tag,
     expr_lambda,
     expr_record_update,
     expr_bin_op,
@@ -70,9 +71,9 @@ pub const Tag = enum {
     expr_block,
     expr_ellipsis,
     expr_record_builder,
-    // Type Header
+    when_branch,
+    where_clause,
     type_header,
-    // Annotation
     annotation,
     // Type Annotation
     ty_apply,

--- a/src/check/canonicalize/NodeStore.zig
+++ b/src/check/canonicalize/NodeStore.zig
@@ -98,6 +98,8 @@ pub const CIR_EXPR_NODE_COUNT = 24;
 pub const CIR_STATEMENT_NODE_COUNT = 11;
 /// Count of the type annotation nodes in the CIR
 pub const CIR_TYPE_ANNO_NODE_COUNT = 11;
+/// Count of the pattern nodes in the CIR
+pub const CIR_PATTERN_NODE_COUNT = 14;
 
 comptime {
     // Check the number of CIR.Diagnostic nodes
@@ -121,6 +123,12 @@ comptime {
     // Check the number of CIR.TypeAnno nodes
     const type_anno_fields = @typeInfo(CIR.TypeAnno).@"union".fields;
     std.debug.assert(type_anno_fields.len == CIR_TYPE_ANNO_NODE_COUNT);
+}
+
+comptime {
+    // Check the number of CIR.Pattern nodes
+    const pattern_fields = @typeInfo(CIR.Pattern).@"union".fields;
+    std.debug.assert(pattern_fields.len == CIR_PATTERN_NODE_COUNT);
 }
 
 /// Retrieves a region from node from the store.

--- a/src/check/canonicalize/NodeStore.zig
+++ b/src/check/canonicalize/NodeStore.zig
@@ -338,11 +338,19 @@ pub fn getExpr(store: *const NodeStore, expr: CIR.Expr.Idx) CIR.Expr {
             node.region,
         ),
         .expr_tag => {
+            const extra_start = node.data_1;
+            const extra_data = store.extra_data.items[extra_start..];
+
+            const ext_var = @as(types.Var, @enumFromInt(extra_data[0]));
+            const name = @as(Ident.Idx, @bitCast(extra_data[1]));
+            const args_start = extra_data[2];
+            const args_len = extra_data[3];
+
             return CIR.Expr{
                 .e_tag = .{
-                    .ext_var = @enumFromInt(0), // Placeholder
-                    .name = @bitCast(@as(base.Ident.Idx, @bitCast(node.data_1))),
-                    .args = .{ .span = .{ .start = 0, .len = 0 } }, // Empty args for now
+                    .ext_var = ext_var,
+                    .name = name,
+                    .args = .{ .span = .{ .start = args_start, .len = args_len } },
                     .region = node.region,
                 },
             };
@@ -408,13 +416,75 @@ pub fn getExpr(store: *const NodeStore, expr: CIR.Expr.Idx) CIR.Expr {
                 },
             };
         },
-        .expr_field_access,
+        .expr_match => {
+            const extra_start = node.data_1;
+            const extra_data = store.extra_data.items[extra_start..];
+
+            const loc_cond = @as(CIR.Expr.Idx, @enumFromInt(extra_data[0]));
+            const cond_var = @as(types.Var, @enumFromInt(extra_data[1]));
+            const expr_var = @as(types.Var, @enumFromInt(extra_data[2]));
+            const branches_start = extra_data[3];
+            const branches_len = extra_data[4];
+            const branches_cond_var = @as(types.Var, @enumFromInt(extra_data[5]));
+            const exhaustive = @as(types.Var, @enumFromInt(extra_data[6]));
+
+            return CIR.Expr{
+                .e_when = CIR.When{
+                    .loc_cond = loc_cond,
+                    .cond_var = cond_var,
+                    .expr_var = expr_var,
+                    .region = node.region,
+                    .branches = .{ .span = .{ .start = branches_start, .len = branches_len } },
+                    .branches_cond_var = branches_cond_var,
+                    .exhaustive = exhaustive,
+                },
+            };
+        },
+        .expr_field_access => {
+            const extra_start = node.data_1;
+            const extra_data = store.extra_data.items[extra_start..];
+
+            const record_var = @as(types.Var, @enumFromInt(extra_data[0]));
+            const ext_var = @as(types.Var, @enumFromInt(extra_data[1]));
+            const field_var = @as(types.Var, @enumFromInt(extra_data[2]));
+            const loc_expr = @as(CIR.Expr.Idx, @enumFromInt(extra_data[3]));
+            const field = @as(Ident.Idx, @bitCast(extra_data[4]));
+
+            return CIR.Expr{
+                .e_record_access = .{
+                    .record_var = record_var,
+                    .ext_var = ext_var,
+                    .field_var = field_var,
+                    .loc_expr = loc_expr,
+                    .field = field,
+                    .region = node.region,
+                },
+            };
+        },
+        .expr_zero_argument_tag => {
+            const extra_start = node.data_1;
+            const extra_data = store.extra_data.items[extra_start..];
+
+            const closure_name = @as(Ident.Idx, @bitCast(extra_data[0]));
+            const variant_var = @as(types.Var, @enumFromInt(extra_data[1]));
+            const ext_var = @as(types.Var, @enumFromInt(extra_data[2]));
+            const name = @as(Ident.Idx, @bitCast(extra_data[3]));
+
+            return CIR.Expr{
+                .e_zero_argument_tag = .{
+                    .closure_name = closure_name,
+                    .variant_var = variant_var,
+                    .ext_var = ext_var,
+                    .name = name,
+                    .region = node.region,
+                },
+            };
+        },
         .expr_static_dispatch,
         .expr_apply,
         .expr_record_update,
         .expr_unary,
         .expr_suffix_single_question,
-        .expr_match,
         .expr_dbg,
         .expr_ellipsis,
         .expr_record_builder,
@@ -478,16 +548,99 @@ pub fn getExpr(store: *const NodeStore, expr: CIR.Expr.Idx) CIR.Expr {
 
 /// Retrieves a 'when' branch from the store.
 pub fn getWhenBranch(store: *const NodeStore, whenBranch: CIR.WhenBranch.Idx) CIR.WhenBranch {
-    _ = store;
-    _ = whenBranch;
-    @panic("TODO: implement getWhenBranch");
+    const node_idx: Node.Idx = @enumFromInt(@intFromEnum(whenBranch));
+    const node = store.nodes.get(node_idx);
+
+    std.debug.assert(node.tag == .when_branch);
+
+    // Retrieve when branch data from extra_data
+    const extra_start = node.data_1;
+    const extra_data = store.extra_data.items[extra_start..];
+
+    const patterns_start = extra_data[0];
+    const patterns_len = extra_data[1];
+    const value_idx = @as(CIR.Expr.Idx, @enumFromInt(extra_data[2]));
+    const guard_idx_raw = extra_data[3];
+    const guard_idx = if (guard_idx_raw == 0) null else @as(CIR.Expr.Idx, @enumFromInt(guard_idx_raw));
+    const redundant = @as(CIR.RedundantMark, @enumFromInt(extra_data[4]));
+
+    return CIR.WhenBranch{
+        .patterns = .{ .span = .{ .start = patterns_start, .len = patterns_len } },
+        .value = value_idx,
+        .guard = guard_idx,
+        .redundant = redundant,
+    };
 }
 
 /// Retrieves a 'where' clause from the store.
 pub fn getWhereClause(store: *NodeStore, whereClause: CIR.WhereClause.Idx) CIR.WhereClause {
-    _ = store;
-    _ = whereClause;
-    @panic("TODO: implement getWhereClause");
+    const node_idx: Node.Idx = @enumFromInt(@intFromEnum(whereClause));
+    const node = store.nodes.get(node_idx);
+
+    std.debug.assert(node.tag == .where_clause);
+
+    // Retrieve where clause data from extra_data
+    const extra_start = node.data_1;
+    const extra_data = store.extra_data.items[extra_start..];
+
+    const discriminant = extra_data[0];
+
+    switch (discriminant) {
+        0 => { // alias
+            const var_tok = @as(Ident.Idx, @bitCast(extra_data[1]));
+            const alias_tok = @as(Ident.Idx, @bitCast(extra_data[2]));
+            const region_start = extra_data[3];
+            const region_end = extra_data[4];
+
+            return CIR.WhereClause{
+                .alias = .{
+                    .var_tok = var_tok,
+                    .alias_tok = alias_tok,
+                    .region = Region{ .start = region_start, .end = region_end },
+                },
+            };
+        },
+        1 => { // method
+            const var_tok = @as(Ident.Idx, @bitCast(extra_data[1]));
+            const name_tok = @as(Ident.Idx, @bitCast(extra_data[2]));
+            const args_start = extra_data[3];
+            const args_len = extra_data[4];
+            const ret_anno = @as(CIR.TypeAnno.Idx, @enumFromInt(extra_data[5]));
+            const region_start = extra_data[6];
+            const region_end = extra_data[7];
+
+            return CIR.WhereClause{
+                .method = .{
+                    .var_tok = var_tok,
+                    .name_tok = name_tok,
+                    .args = .{ .span = .{ .start = args_start, .len = args_len } },
+                    .ret_anno = ret_anno,
+                    .region = Region{ .start = region_start, .end = region_end },
+                },
+            };
+        },
+        2 => { // mod_method
+            const var_tok = @as(Ident.Idx, @bitCast(extra_data[1]));
+            const name_tok = @as(Ident.Idx, @bitCast(extra_data[2]));
+            const args_start = extra_data[3];
+            const args_len = extra_data[4];
+            const ret_anno_start = extra_data[5];
+            const ret_anno_len = extra_data[6];
+            const region_start = extra_data[7];
+            const region_end = extra_data[8];
+
+            return CIR.WhereClause{
+                .mod_method = .{
+                    .var_tok = var_tok,
+                    .name_tok = name_tok,
+                    .args = .{ .span = .{ .start = args_start, .len = args_len } },
+                    .ret_anno = .{ .span = .{ .start = ret_anno_start, .len = ret_anno_len } },
+                    .region = Region{ .start = region_start, .end = region_end },
+                },
+            };
+        },
+        else => @panic("Invalid where clause discriminant"),
+    }
 }
 
 /// Retrieves a pattern from the store.
@@ -509,30 +662,59 @@ pub fn getPattern(store: *const NodeStore, pattern_idx: CIR.Pattern.Idx) CIR.Pat
                 .region = node.region,
             },
         },
-        .pattern_applied_tag => return CIR.Pattern{
-            .applied_tag = .{
-                .region = node.region,
-                .arguments = DataSpan.init(node.data_1, node.data_2).as(CIR.Pattern.Span),
-                .tag_name = @bitCast(node.data_3),
+        .pattern_applied_tag => {
+            const extra_start = node.data_1;
+            const extra_data = store.extra_data.items[extra_start..];
 
-                .ext_var = @enumFromInt(0), // TODO need to store and retrieve from extra_data
-            },
+            const arguments_start = extra_data[0];
+            const arguments_len = extra_data[1];
+            const tag_name = @as(Ident.Idx, @bitCast(extra_data[2]));
+            const ext_var = @as(types.Var, @enumFromInt(extra_data[3]));
+
+            return CIR.Pattern{
+                .applied_tag = .{
+                    .region = node.region,
+                    .arguments = DataSpan.init(arguments_start, arguments_len).as(CIR.Pattern.Span),
+                    .tag_name = tag_name,
+                    .ext_var = ext_var,
+                },
+            };
         },
-        .pattern_record_destructure => return CIR.Pattern{
-            .record_destructure = .{
-                .region = node.region,
-                .destructs = DataSpan.init(node.data_1, node.data_2).as(CIR.RecordDestruct.Span),
-                .ext_var = @enumFromInt(0), // TODO need to store and retrieve from extra_data
-                .whole_var = @enumFromInt(0), // TODO need to store and retrieve from extra_data
-            },
+        .pattern_record_destructure => {
+            const extra_start = node.data_1;
+            const extra_data = store.extra_data.items[extra_start..];
+
+            const destructs_start = extra_data[0];
+            const destructs_len = extra_data[1];
+            const ext_var = @as(types.Var, @enumFromInt(extra_data[2]));
+            const whole_var = @as(types.Var, @enumFromInt(extra_data[3]));
+
+            return CIR.Pattern{
+                .record_destructure = .{
+                    .region = node.region,
+                    .destructs = DataSpan.init(destructs_start, destructs_len).as(CIR.RecordDestruct.Span),
+                    .ext_var = ext_var,
+                    .whole_var = whole_var,
+                },
+            };
         },
-        .pattern_list => return CIR.Pattern{
-            .list = .{
-                .region = node.region,
-                .patterns = DataSpan.init(node.data_1, node.data_2).as(CIR.Pattern.Span),
-                .elem_var = @enumFromInt(0), // TODO need to store elem_var separately
-                .list_var = @enumFromInt(node.data_3),
-            },
+        .pattern_list => {
+            const extra_start = node.data_1;
+            const extra_data = store.extra_data.items[extra_start..];
+
+            const patterns_start = extra_data[0];
+            const patterns_len = extra_data[1];
+            const elem_var = @as(types.Var, @enumFromInt(extra_data[2]));
+            const list_var = @as(types.Var, @enumFromInt(extra_data[3]));
+
+            return CIR.Pattern{
+                .list = .{
+                    .region = node.region,
+                    .patterns = DataSpan.init(patterns_start, patterns_len).as(CIR.Pattern.Span),
+                    .elem_var = elem_var,
+                    .list_var = list_var,
+                },
+            };
         },
         .pattern_tuple => return CIR.Pattern{
             .tuple = .{
@@ -608,13 +790,23 @@ pub fn getPattern(store: *const NodeStore, pattern_idx: CIR.Pattern.Idx) CIR.Pat
             .region = node.region,
             .literal = @enumFromInt(node.data_1),
         } },
-        .pattern_char_literal => return CIR.Pattern{
-            .char_literal = .{
-                .region = node.region,
-                .num_var = @enumFromInt(0), // TODO need to store and retrieve from extra_data
-                .requirements = .{ .sign_needed = false, .bits_needed = .@"32" }, // TODO need to store and retrieve from extra_data
-                .value = node.data_1,
-            },
+        .pattern_char_literal => {
+            const extra_start = node.data_1;
+            const extra_data = store.extra_data.items[extra_start..];
+
+            const value = extra_data[0];
+            const num_var = @as(types.Var, @enumFromInt(extra_data[1]));
+            const sign_needed = extra_data[2] != 0;
+            const bits_needed = @as(types.Num.Int.BitsNeeded, @enumFromInt(extra_data[3]));
+
+            return CIR.Pattern{
+                .char_literal = .{
+                    .region = node.region,
+                    .num_var = num_var,
+                    .requirements = .{ .sign_needed = sign_needed, .bits_needed = bits_needed },
+                    .value = value,
+                },
+            };
         },
         .pattern_underscore => return CIR.Pattern{ .underscore = .{
             .region = node.region,
@@ -635,7 +827,8 @@ pub fn getPattern(store: *const NodeStore, pattern_idx: CIR.Pattern.Idx) CIR.Pat
 pub fn getPatternRecordField(store: *NodeStore, patternRecordField: CIR.PatternRecordField.Idx) CIR.PatternRecordField {
     _ = store;
     _ = patternRecordField;
-    @panic("TODO: implement getPatternRecordField");
+    // Return empty placeholder since PatternRecordField has no fields yet
+    return CIR.PatternRecordField{};
 }
 
 /// Retrieves a type annotation from the store.
@@ -1019,8 +1212,14 @@ pub fn addExpr(store: *NodeStore, expr: CIR.Expr) CIR.Expr.Idx {
         .e_tag => |e| {
             node.region = e.region;
             node.tag = .expr_tag;
-            // Store the full Ident.Idx as a u32
-            node.data_1 = @bitCast(@as(u32, @bitCast(e.name)));
+
+            // Store tag data in extra_data
+            const extra_data_start = @as(u32, @intCast(store.extra_data.items.len));
+            store.extra_data.append(store.gpa, @intFromEnum(e.ext_var)) catch |err| exitOnOom(err);
+            store.extra_data.append(store.gpa, @bitCast(e.name)) catch |err| exitOnOom(err);
+            store.extra_data.append(store.gpa, e.args.span.start) catch |err| exitOnOom(err);
+            store.extra_data.append(store.gpa, e.args.span.len) catch |err| exitOnOom(err);
+            node.data_1 = extra_data_start;
         },
         .e_dot_access => |e| {
             node.region = e.region;
@@ -1061,7 +1260,18 @@ pub fn addExpr(store: *NodeStore, expr: CIR.Expr) CIR.Expr.Idx {
         },
         .e_when => |e| {
             node.region = e.region;
-            @panic("TODO addExpr when");
+            node.tag = .expr_match;
+
+            // Store when data in extra_data
+            const extra_data_start = @as(u32, @intCast(store.extra_data.items.len));
+            store.extra_data.append(store.gpa, @intFromEnum(e.loc_cond)) catch |err| exitOnOom(err);
+            store.extra_data.append(store.gpa, @intFromEnum(e.cond_var)) catch |err| exitOnOom(err);
+            store.extra_data.append(store.gpa, @intFromEnum(e.expr_var)) catch |err| exitOnOom(err);
+            store.extra_data.append(store.gpa, e.branches.span.start) catch |err| exitOnOom(err);
+            store.extra_data.append(store.gpa, e.branches.span.len) catch |err| exitOnOom(err);
+            store.extra_data.append(store.gpa, @intFromEnum(e.branches_cond_var)) catch |err| exitOnOom(err);
+            store.extra_data.append(store.gpa, @intFromEnum(e.exhaustive)) catch |err| exitOnOom(err);
+            node.data_1 = extra_data_start;
         },
         .e_if => |e| {
             // Store def data in extra_data. We store the following fields:
@@ -1114,11 +1324,28 @@ pub fn addExpr(store: *NodeStore, expr: CIR.Expr) CIR.Expr.Idx {
         },
         .e_record_access => |e| {
             node.region = e.region;
-            @panic("TODO addExpr record_access");
+            node.tag = .expr_field_access;
+
+            // Store record access data in extra_data
+            const extra_data_start = @as(u32, @intCast(store.extra_data.items.len));
+            store.extra_data.append(store.gpa, @intFromEnum(e.record_var)) catch |err| exitOnOom(err);
+            store.extra_data.append(store.gpa, @intFromEnum(e.ext_var)) catch |err| exitOnOom(err);
+            store.extra_data.append(store.gpa, @intFromEnum(e.field_var)) catch |err| exitOnOom(err);
+            store.extra_data.append(store.gpa, @intFromEnum(e.loc_expr)) catch |err| exitOnOom(err);
+            store.extra_data.append(store.gpa, @bitCast(e.field)) catch |err| exitOnOom(err);
+            node.data_1 = extra_data_start;
         },
         .e_zero_argument_tag => |e| {
             node.region = e.region;
-            @panic("TODO addExpr zero_argument_tag");
+            node.tag = .expr_zero_argument_tag;
+
+            // Store zero argument tag data in extra_data
+            const extra_data_start = @as(u32, @intCast(store.extra_data.items.len));
+            store.extra_data.append(store.gpa, @bitCast(e.closure_name)) catch |err| exitOnOom(err);
+            store.extra_data.append(store.gpa, @intFromEnum(e.variant_var)) catch |err| exitOnOom(err);
+            store.extra_data.append(store.gpa, @intFromEnum(e.ext_var)) catch |err| exitOnOom(err);
+            store.extra_data.append(store.gpa, @bitCast(e.name)) catch |err| exitOnOom(err);
+            node.data_1 = extra_data_start;
         },
         .e_lambda => |e| {
             node.region = e.region;
@@ -1173,33 +1400,108 @@ pub fn addRecordField(store: *NodeStore, recordField: CIR.RecordField) CIR.Recor
 }
 
 /// Adds a record destructuring to the store.
-pub fn addRecordDestruct(store: *NodeStore, recordDestruct: CIR.RecordDestruct) CIR.RecordDestruct.Idx {
-    const node = Node{
-        .data_1 = @bitCast(recordDestruct.label),
-        .data_2 = @bitCast(recordDestruct.ident),
+pub fn addRecordDestruct(store: *NodeStore, record_destruct: CIR.RecordDestruct) CIR.RecordDestruct.Idx {
+    var node = Node{
+        .data_1 = @bitCast(record_destruct.label),
+        .data_2 = @bitCast(record_destruct.ident),
         .data_3 = 0,
-        .region = recordDestruct.region,
+        .region = record_destruct.region,
         .tag = .record_destruct,
     };
 
-    const nid = store.nodes.append(store.gpa, node);
-    return @enumFromInt(@intFromEnum(nid));
+    // Store kind in extra_data if it's not Required
+    switch (record_destruct.kind) {
+        .Required => {
+            // No extra data needed
+        },
+        .Guard => |guard_pattern| {
+            const extra_data_start = @as(u32, @intCast(store.extra_data.items.len));
+
+            // Store kind tag (1 for Guard)
+            store.extra_data.append(store.gpa, 1) catch |err| exitOnOom(err);
+            // Store guard pattern index
+            store.extra_data.append(store.gpa, @intFromEnum(guard_pattern)) catch |err| exitOnOom(err);
+
+            node.data_3 = extra_data_start;
+        },
+    }
+
+    return @enumFromInt(@intFromEnum(store.nodes.append(store.gpa, node)));
 }
 
 /// Adds a 'when' branch to the store.
 pub fn addWhenBranch(store: *NodeStore, whenBranch: CIR.WhenBranch) CIR.WhenBranch.Idx {
-    _ = store;
-    _ = whenBranch;
+    var node = Node{
+        .data_1 = 0,
+        .data_2 = 0,
+        .data_3 = 0,
+        .region = base.Region.empty(), // TODO should WhenBranch have a region field?
+        .tag = .when_branch,
+    };
 
-    return .{ .id = @enumFromInt(0) };
+    // Store when branch data in extra_data
+    const extra_data_start = @as(u32, @intCast(store.extra_data.items.len));
+    store.extra_data.append(store.gpa, whenBranch.patterns.span.start) catch |err| exitOnOom(err);
+    store.extra_data.append(store.gpa, whenBranch.patterns.span.len) catch |err| exitOnOom(err);
+    store.extra_data.append(store.gpa, @intFromEnum(whenBranch.value)) catch |err| exitOnOom(err);
+    const guard_idx = if (whenBranch.guard) |g| @intFromEnum(g) else 0;
+    store.extra_data.append(store.gpa, guard_idx) catch |err| exitOnOom(err);
+    store.extra_data.append(store.gpa, @intFromEnum(whenBranch.redundant)) catch |err| exitOnOom(err);
+    node.data_1 = extra_data_start;
+
+    return @enumFromInt(@intFromEnum(store.nodes.append(store.gpa, node)));
 }
 
 /// Adds a 'where' clause to the store.
 pub fn addWhereClause(store: *NodeStore, whereClause: CIR.WhereClause) CIR.WhereClause.Idx {
-    _ = store;
-    _ = whereClause;
+    var node = Node{
+        .data_1 = 0,
+        .data_2 = 0,
+        .data_3 = 0,
+        .region = base.Region.empty(),
+        .tag = .where_clause,
+    };
 
-    return .{ .id = @enumFromInt(0) };
+    // Store where clause data in extra_data
+    const extra_data_start = @as(u32, @intCast(store.extra_data.items.len));
+
+    switch (whereClause) {
+        .alias => |alias| {
+            // Store discriminant (0 for alias)
+            store.extra_data.append(store.gpa, 0) catch |err| exitOnOom(err);
+            store.extra_data.append(store.gpa, @bitCast(alias.var_tok)) catch |err| exitOnOom(err);
+            store.extra_data.append(store.gpa, @bitCast(alias.alias_tok)) catch |err| exitOnOom(err);
+            store.extra_data.append(store.gpa, alias.region.start) catch |err| exitOnOom(err);
+            store.extra_data.append(store.gpa, alias.region.end) catch |err| exitOnOom(err);
+        },
+        .method => |method| {
+            // Store discriminant (1 for method)
+            store.extra_data.append(store.gpa, 1) catch |err| exitOnOom(err);
+            store.extra_data.append(store.gpa, @bitCast(method.var_tok)) catch |err| exitOnOom(err);
+            store.extra_data.append(store.gpa, @bitCast(method.name_tok)) catch |err| exitOnOom(err);
+            store.extra_data.append(store.gpa, method.args.span.start) catch |err| exitOnOom(err);
+            store.extra_data.append(store.gpa, method.args.span.len) catch |err| exitOnOom(err);
+            store.extra_data.append(store.gpa, @intFromEnum(method.ret_anno)) catch |err| exitOnOom(err);
+            store.extra_data.append(store.gpa, method.region.start) catch |err| exitOnOom(err);
+            store.extra_data.append(store.gpa, method.region.end) catch |err| exitOnOom(err);
+        },
+        .mod_method => |mod_method| {
+            // Store discriminant (2 for mod_method)
+            store.extra_data.append(store.gpa, 2) catch |err| exitOnOom(err);
+            store.extra_data.append(store.gpa, @bitCast(mod_method.var_tok)) catch |err| exitOnOom(err);
+            store.extra_data.append(store.gpa, @bitCast(mod_method.name_tok)) catch |err| exitOnOom(err);
+            store.extra_data.append(store.gpa, mod_method.args.span.start) catch |err| exitOnOom(err);
+            store.extra_data.append(store.gpa, mod_method.args.span.len) catch |err| exitOnOom(err);
+            store.extra_data.append(store.gpa, mod_method.ret_anno.span.start) catch |err| exitOnOom(err);
+            store.extra_data.append(store.gpa, mod_method.ret_anno.span.len) catch |err| exitOnOom(err);
+            store.extra_data.append(store.gpa, mod_method.region.start) catch |err| exitOnOom(err);
+            store.extra_data.append(store.gpa, mod_method.region.end) catch |err| exitOnOom(err);
+        },
+    }
+
+    node.data_1 = extra_data_start;
+
+    return @enumFromInt(@intFromEnum(store.nodes.append(store.gpa, node)));
 }
 
 /// Adds a pattern to the store.
@@ -1227,24 +1529,38 @@ pub fn addPattern(store: *NodeStore, pattern: CIR.Pattern) CIR.Pattern.Idx {
         .applied_tag => |p| {
             node.tag = .pattern_applied_tag;
             node.region = p.region;
-            node.data_1 = p.arguments.span.start;
-            node.data_2 = p.arguments.span.len;
-            node.data_3 = @bitCast(p.tag_name);
-            // TODO store type vars in extra data
+
+            // Store applied tag data in extra_data
+            const extra_data_start = @as(u32, @intCast(store.extra_data.items.len));
+            store.extra_data.append(store.gpa, p.arguments.span.start) catch |err| exitOnOom(err);
+            store.extra_data.append(store.gpa, p.arguments.span.len) catch |err| exitOnOom(err);
+            store.extra_data.append(store.gpa, @bitCast(p.tag_name)) catch |err| exitOnOom(err);
+            store.extra_data.append(store.gpa, @intFromEnum(p.ext_var)) catch |err| exitOnOom(err);
+            node.data_1 = extra_data_start;
         },
         .record_destructure => |p| {
             node.tag = .pattern_record_destructure;
             node.region = p.region;
-            node.data_1 = p.destructs.span.start;
-            node.data_2 = p.destructs.span.len;
-            // TODO store type vars in extra data
+
+            // Store record destructure data in extra_data
+            const extra_data_start = @as(u32, @intCast(store.extra_data.items.len));
+            store.extra_data.append(store.gpa, p.destructs.span.start) catch |err| exitOnOom(err);
+            store.extra_data.append(store.gpa, p.destructs.span.len) catch |err| exitOnOom(err);
+            store.extra_data.append(store.gpa, @intFromEnum(p.ext_var)) catch |err| exitOnOom(err);
+            store.extra_data.append(store.gpa, @intFromEnum(p.whole_var)) catch |err| exitOnOom(err);
+            node.data_1 = extra_data_start;
         },
         .list => |p| {
             node.tag = .pattern_list;
             node.region = p.region;
-            node.data_1 = p.patterns.span.start;
-            node.data_2 = p.patterns.span.len;
-            node.data_3 = @intFromEnum(p.list_var);
+
+            // Store list pattern data in extra_data
+            const extra_data_start = @as(u32, @intCast(store.extra_data.items.len));
+            store.extra_data.append(store.gpa, p.patterns.span.start) catch |err| exitOnOom(err);
+            store.extra_data.append(store.gpa, p.patterns.span.len) catch |err| exitOnOom(err);
+            store.extra_data.append(store.gpa, @intFromEnum(p.elem_var)) catch |err| exitOnOom(err);
+            store.extra_data.append(store.gpa, @intFromEnum(p.list_var)) catch |err| exitOnOom(err);
+            node.data_1 = extra_data_start;
         },
         .tuple => |p| {
             node.tag = .pattern_tuple;
@@ -1300,13 +1616,18 @@ pub fn addPattern(store: *NodeStore, pattern: CIR.Pattern) CIR.Pattern.Idx {
             node.tag = .pattern_str_literal;
             node.region = p.region;
             node.data_1 = @intFromEnum(p.literal);
-            // TODO store other data
         },
         .char_literal => |p| {
             node.tag = .pattern_char_literal;
             node.region = p.region;
-            node.data_1 = p.value;
-            // TODO store other data
+
+            // Store char literal data in extra_data
+            const extra_data_start = @as(u32, @intCast(store.extra_data.items.len));
+            store.extra_data.append(store.gpa, p.value) catch |err| exitOnOom(err);
+            store.extra_data.append(store.gpa, @intFromEnum(p.num_var)) catch |err| exitOnOom(err);
+            store.extra_data.append(store.gpa, if (p.requirements.sign_needed) 1 else 0) catch |err| exitOnOom(err);
+            store.extra_data.append(store.gpa, @intFromEnum(p.requirements.bits_needed)) catch |err| exitOnOom(err);
+            node.data_1 = extra_data_start;
         },
         .underscore => |p| {
             node.tag = .pattern_underscore;
@@ -1546,11 +1867,25 @@ pub fn getRecordField(store: *const NodeStore, idx: CIR.RecordField.Idx) CIR.Rec
 /// Retrieves a record destructure from the store.
 pub fn getRecordDestruct(store: *const NodeStore, idx: CIR.RecordDestruct.Idx) CIR.RecordDestruct {
     const node = store.nodes.get(@enumFromInt(@intFromEnum(idx)));
+
+    // Retrieve kind from extra_data if it exists
+    const kind = if (node.data_3 != 0) blk: {
+        const extra_start = node.data_3;
+        const extra_data = store.extra_data.items[extra_start..];
+        const kind_tag = extra_data[0];
+
+        break :blk switch (kind_tag) {
+            0 => CIR.RecordDestruct.Kind.Required,
+            1 => CIR.RecordDestruct.Kind{ .Guard = @enumFromInt(extra_data[1]) },
+            else => CIR.RecordDestruct.Kind.Required,
+        };
+    } else CIR.RecordDestruct.Kind.Required;
+
     return CIR.RecordDestruct{
         .label = @bitCast(node.data_1),
         .ident = @bitCast(node.data_2),
         .region = node.region,
-        .kind = .Required, // TODO: Need to store and retrieve kind from extra_data
+        .kind = kind,
     };
 }
 
@@ -1577,7 +1912,7 @@ pub fn addScratchExpr(store: *NodeStore, idx: CIR.Expr.Idx) void {
     store.scratch_exprs.append(store.gpa, idx);
 }
 
-/// TODO
+/// Adds a statement index to the scratch statements list for building spans.
 pub fn addScratchStatement(store: *NodeStore, idx: CIR.Statement.Idx) void {
     store.scratch_statements.append(store.gpa, idx);
 }
@@ -1596,7 +1931,7 @@ pub fn exprSpanFrom(store: *NodeStore, start: u32) CIR.Expr.Span {
     return .{ .span = .{ .start = ed_start, .len = @as(u32, @intCast(end)) - start } };
 }
 
-/// TODO
+/// Creates a statement span from the given start position to the current top of scratch statements.
 pub fn statementSpanFrom(store: *NodeStore, start: u32) CIR.Statement.Span {
     const end = store.scratch_statements.top();
     defer store.scratch_statements.clearFrom(start);
@@ -1837,13 +2172,13 @@ pub fn scratchIfBranchTop(store: *NodeStore) u32 {
     return store.scratch_if_branches.top();
 }
 
-/// TODO
+/// Adds an if branch to the scratch if branches list for building spans.
 pub fn addScratchIfBranch(store: *NodeStore, if_branch: CIR.IfBranch) void {
     const if_branch_idx = store.addIfBranch(if_branch);
     store.scratch_if_branches.append(store.gpa, if_branch_idx);
 }
 
-/// TODO
+/// Creates an if branch span from the given start position to the current top of scratch if branches.
 pub fn ifBranchSpanFrom(store: *NodeStore, start: u32) CIR.IfBranch.Span {
     const end = store.scratch_if_branches.top();
     defer store.scratch_if_branches.clearFrom(start);
@@ -1862,7 +2197,7 @@ pub fn sliceIfBranches(store: *const NodeStore, span: CIR.IfBranch.Span) []CIR.I
     return store.sliceFromSpan(CIR.IfBranch.Idx, span.span);
 }
 
-/// TODO
+/// Adds an if branch to the store and returns its index.
 pub fn addIfBranch(store: *NodeStore, if_branch: CIR.IfBranch) CIR.IfBranch.Idx {
     const node = Node{
         .data_1 = @intFromEnum(if_branch.cond),
@@ -2092,7 +2427,7 @@ pub fn addMalformed(store: *NodeStore, comptime t: type, reason: CIR.Diagnostic)
         .data_1 = @intFromEnum(diagnostic_idx),
         .data_2 = 0,
         .data_3 = 0,
-        // TODO add a toRegion() helper on the Diagnostic type
+
         .region = reason.toRegion(),
         .tag = .malformed,
     };

--- a/src/check/canonicalize/NodeStore.zig
+++ b/src/check/canonicalize/NodeStore.zig
@@ -87,11 +87,17 @@ pub fn deinit(store: *NodeStore) void {
     store.scratch_diagnostics.items.deinit(store.gpa);
 }
 
-// Compile-time constants for union variant counts to ensure we don't miss cases
-// when adding/removing variants from CIR unions. Update these when modifying the unions.
+/// Compile-time constants for union variant counts to ensure we don't miss cases
+/// when adding/removing variants from CIR unions. Update these when modifying the unions.
+///
+/// Count of the diagnostic nodes in the CIR
 pub const CIR_DIAGNOSTIC_NODE_COUNT = 27;
+/// Count of the expression nodes in the CIR
 pub const CIR_EXPR_NODE_COUNT = 24;
+/// Count of the statement nodes in the CIR
 pub const CIR_STATEMENT_NODE_COUNT = 11;
+/// Count of the type annotation nodes in the CIR
+pub const CIR_TYPE_ANNO_NODE_COUNT = 11;
 
 comptime {
     // Check the number of CIR.Diagnostic nodes
@@ -109,6 +115,12 @@ comptime {
     // Check the number of CIR.Statement nodes
     const statement_fields = @typeInfo(CIR.Statement).@"union".fields;
     std.debug.assert(statement_fields.len == CIR_STATEMENT_NODE_COUNT);
+}
+
+comptime {
+    // Check the number of CIR.TypeAnno nodes
+    const type_anno_fields = @typeInfo(CIR.TypeAnno).@"union".fields;
+    std.debug.assert(type_anno_fields.len == CIR_TYPE_ANNO_NODE_COUNT);
 }
 
 /// Retrieves a region from node from the store.
@@ -908,6 +920,10 @@ pub fn getTypeAnno(store: *const NodeStore, typeAnno: CIR.TypeAnno.Idx) CIR.Type
         },
         .ty_parens => return CIR.TypeAnno{ .parens = .{
             .anno = @enumFromInt(node.data_1),
+            .region = node.region,
+        } },
+        .ty_malformed => return CIR.TypeAnno{ .malformed = .{
+            .diagnostic = @enumFromInt(node.data_1),
             .region = node.region,
         } },
         .malformed => return CIR.TypeAnno{ .malformed = .{

--- a/src/check/canonicalize/test/node_store_test.zig
+++ b/src/check/canonicalize/test/node_store_test.zig
@@ -114,15 +114,23 @@ test "NodeStore round trip - Statements" {
         .region = from_raw_offsets(3453, 1232),
     } });
 
-    for (statements.items) |statement| {
-        const idx = store.addStatement(statement);
+    for (statements.items) |stmt| {
+        const idx = store.addStatement(stmt);
         const retrieved = store.getStatement(idx);
 
-        testing.expectEqualDeep(statement, retrieved) catch |err| {
-            std.debug.print("\n\nOriginal:  {any}\n\n", .{statement});
+        testing.expectEqualDeep(stmt, retrieved) catch |err| {
+            std.debug.print("\n\nOriginal:  {any}\n\n", .{stmt});
             std.debug.print("Retrieved: {any}\n\n", .{retrieved});
             return err;
         };
+    }
+
+    // Runtime validation: ensure we have minimum test coverage for all statement variants
+    const actual_test_count = statements.items.len;
+    if (actual_test_count < NodeStore.CIR_STATEMENT_NODE_COUNT) {
+        std.debug.print("Statement test coverage insufficient! Need at least {d} test cases but found {d}.\n", .{ NodeStore.CIR_STATEMENT_NODE_COUNT, actual_test_count });
+        std.debug.print("Please add test cases for missing statement variants.\n", .{});
+        return error.IncompleteStatementTestCoverage;
     }
 }
 
@@ -327,6 +335,14 @@ test "NodeStore round trip - Expressions" {
             std.debug.print("Retrieved: {any}\n\n", .{retrieved});
             return err;
         };
+    }
+
+    // Runtime validation: ensure we have minimum test coverage for all expression variants
+    const actual_test_count = expressions.items.len;
+    if (actual_test_count < NodeStore.CIR_EXPR_NODE_COUNT) {
+        std.debug.print("Expression test coverage insufficient! Need at least {d} test cases but found {d}.\n", .{ NodeStore.CIR_EXPR_NODE_COUNT, actual_test_count });
+        std.debug.print("Please add test cases for missing expression variants.\n", .{});
+        return error.IncompleteExpressionTestCoverage;
     }
 }
 
@@ -534,5 +550,13 @@ test "NodeStore round trip - Diagnostics" {
             std.debug.print("Retrieved: {any}\n\n", .{retrieved});
             return err;
         };
+    }
+
+    // Runtime validation: ensure we have minimum test coverage for all diagnostic variants
+    const actual_test_count = diagnostics.items.len;
+    if (actual_test_count < NodeStore.CIR_DIAGNOSTIC_NODE_COUNT) {
+        std.debug.print("Diagnostic test coverage insufficient! Need at least {d} test cases but found {d}.\n", .{ NodeStore.CIR_DIAGNOSTIC_NODE_COUNT, actual_test_count });
+        std.debug.print("Please add test cases for missing diagnostic variants.\n", .{});
+        return error.IncompleteDiagnosticTestCoverage;
     }
 }

--- a/src/check/canonicalize/test/node_store_test.zig
+++ b/src/check/canonicalize/test/node_store_test.zig
@@ -190,72 +190,52 @@ test "NodeStore round trip - Expressions" {
             .external = @enumFromInt(345),
         },
     });
-
-    // TODO: Test e_list when NodeStore properly handles TypeVar fields
-    // The NodeStore getExpr method currently hardcodes TypeVars to @enumFromInt(0)
-    // instead of restoring the original values from storage
-    // try expressions.append(CIR.Expr{
-    //     .e_list = .{
-    //         .elem_var = @enumFromInt(456),
-    //         .elems = CIR.Expr.Span{ .span = base.DataSpan.init(234, 567) },
-    //         .region = from_raw_offsets(1012, 1345),
-    //     },
-    // });
-
+    try expressions.append(CIR.Expr{
+        .e_list = .{
+            .elem_var = @enumFromInt(456),
+            .elems = CIR.Expr.Span{ .span = base.DataSpan.init(234, 567) },
+            .region = from_raw_offsets(1012, 1345),
+        },
+    });
     try expressions.append(CIR.Expr{
         .e_tuple = .{
             .elems = CIR.Expr.Span{ .span = base.DataSpan.init(345, 678) },
             .region = from_raw_offsets(1123, 1456),
         },
     });
-
-    // TODO: Test e_when when NodeStore implements addExpr for this variant
-    // Currently panics with "TODO addExpr when"
-    // try expressions.append(CIR.Expr{
-    //     .e_when = CIR.When{
-    //         .loc_cond = @enumFromInt(567),
-    //         .cond_var = @enumFromInt(678),
-    //         .expr_var = @enumFromInt(789),
-    //         .region = from_raw_offsets(1234, 1567),
-    //         .branches = CIR.WhenBranch.Span{ .span = base.DataSpan.init(456, 789) },
-    //         .branches_cond_var = @enumFromInt(890),
-    //         .exhaustive = @enumFromInt(901),
-    //     },
-    // });
-
-    // TODO: Test e_if when NodeStore properly handles TypeVar fields
-    // Currently hardcodes cond_var and branch_var to @enumFromInt(0)
-    // try expressions.append(CIR.Expr{
-    //     .e_if = .{
-    //         .cond_var = @enumFromInt(1012),
-    //         .branch_var = @enumFromInt(1123),
-    //         .branches = CIR.IfBranch.Span{ .span = base.DataSpan.init(567, 890) },
-    //         .final_else = @enumFromInt(1234),
-    //         .region = from_raw_offsets(1345, 1678),
-    //     },
-    // });
-
-    // TODO: Test e_call when NodeStore properly handles TypeVar fields
-    // Currently doesn't restore effect_var properly
-    // try expressions.append(CIR.Expr{
-    //     .e_call = .{
-    //         .args = CIR.Expr.Span{ .span = base.DataSpan.init(678, 901) },
-    //         .called_via = base.CalledVia.apply,
-    //         .effect_var = @enumFromInt(1345),
-    //         .region = from_raw_offsets(1456, 1789),
-    //     },
-    // });
-
-    // TODO: Test e_record when NodeStore properly handles TypeVar fields
-    // Currently doesn't restore ext_var properly
-    // try expressions.append(CIR.Expr{
-    //     .e_record = .{
-    //         .ext_var = @enumFromInt(1456),
-    //         .fields = CIR.RecordField.Span{ .span = base.DataSpan.init(789, 1012) },
-    //         .region = from_raw_offsets(1567, 1890),
-    //     },
-    // });
-
+    try expressions.append(CIR.Expr{
+        .e_when = CIR.When{
+            .loc_cond = @enumFromInt(567),
+            .cond_var = @enumFromInt(678),
+            .expr_var = @enumFromInt(789),
+            .region = from_raw_offsets(1234, 1567),
+            .branches = CIR.WhenBranch.Span{ .span = base.DataSpan.init(456, 789) },
+            .branches_cond_var = @enumFromInt(890),
+            .exhaustive = @enumFromInt(901),
+        },
+    });
+    try expressions.append(CIR.Expr{
+        .e_if = .{
+            .branches = CIR.IfBranch.Span{ .span = base.DataSpan.init(567, 890) },
+            .final_else = @enumFromInt(1234),
+            .region = from_raw_offsets(1345, 1678),
+        },
+    });
+    try expressions.append(CIR.Expr{
+        .e_call = .{
+            .args = CIR.Expr.Span{ .span = base.DataSpan.init(678, 901) },
+            .called_via = base.CalledVia.apply,
+            .effect_var = @enumFromInt(1345),
+            .region = from_raw_offsets(1456, 1789),
+        },
+    });
+    try expressions.append(CIR.Expr{
+        .e_record = .{
+            .ext_var = @enumFromInt(1456),
+            .fields = CIR.RecordField.Span{ .span = base.DataSpan.init(789, 1012) },
+            .region = from_raw_offsets(1567, 1890),
+        },
+    });
     try expressions.append(CIR.Expr{
         .e_empty_record = .{
             .region = from_raw_offsets(1678, 1901),
@@ -268,53 +248,44 @@ test "NodeStore round trip - Expressions" {
             .region = from_raw_offsets(1789, 2012),
         },
     });
+    try expressions.append(CIR.Expr{
+        .e_record_access = .{
+            .record_var = @enumFromInt(1678),
+            .ext_var = @enumFromInt(1789),
+            .field_var = @enumFromInt(1890),
+            .loc_expr = @enumFromInt(1901),
+            .field = @bitCast(@as(u32, 2012)),
+            .region = from_raw_offsets(1890, 2123),
+        },
+    });
 
-    // TODO: Test e_record_access when NodeStore implements addExpr for this variant
-    // Currently panics with "TODO addExpr record_access"
-    // try expressions.append(CIR.Expr{
-    //     .e_record_access = .{
-    //         .record_var = @enumFromInt(1678),
-    //         .ext_var = @enumFromInt(1789),
-    //         .field_var = @enumFromInt(1890),
-    //         .loc_expr = @enumFromInt(1901),
-    //         .field = @bitCast(@as(u32, 2012)),
-    //         .region = from_raw_offsets(1890, 2123),
-    //     },
-    // });
+    try expressions.append(CIR.Expr{
+        .e_tag = .{
+            .ext_var = @enumFromInt(2012),
+            .name = @bitCast(@as(u32, 2123)),
+            .args = CIR.Expr.Span{ .span = base.DataSpan.init(901, 1234) },
+            .region = from_raw_offsets(1901, 2234),
+        },
+    });
 
-    // TODO: Test e_tag when NodeStore properly handles TypeVar fields
-    // Currently doesn't restore ext_var properly
-    // try expressions.append(CIR.Expr{
-    //     .e_tag = .{
-    //         .ext_var = @enumFromInt(2012),
-    //         .name = @bitCast(@as(u32, 2123)),
-    //         .args = CIR.Expr.Span{ .span = base.DataSpan.init(901, 1234) },
-    //         .region = from_raw_offsets(1901, 2234),
-    //     },
-    // });
+    try expressions.append(CIR.Expr{
+        .e_zero_argument_tag = .{
+            .closure_name = @bitCast(@as(u32, 2234)),
+            .variant_var = @enumFromInt(2345),
+            .ext_var = @enumFromInt(2456),
+            .name = @bitCast(@as(u32, 2567)),
+            .region = from_raw_offsets(2012, 2345),
+        },
+    });
 
-    // TODO: Test e_zero_argument_tag when NodeStore implements addExpr for this variant
-    // Currently panics with "TODO addExpr zero_argument_tag"
-    // try expressions.append(CIR.Expr{
-    //     .e_zero_argument_tag = .{
-    //         .closure_name = @bitCast(@as(u32, 2234)),
-    //         .variant_var = @enumFromInt(2345),
-    //         .ext_var = @enumFromInt(2456),
-    //         .name = @bitCast(@as(u32, 2567)),
-    //         .region = from_raw_offsets(2012, 2345),
-    //     },
-    // });
-
-    // TODO: Test e_lambda when NodeStore properly handles TypeVar fields
-    // Currently doesn't restore effect_var properly
-    // try expressions.append(CIR.Expr{
-    //     .e_lambda = .{
-    //         .args = CIR.Pattern.Span{ .span = base.DataSpan.init(1012, 1345) },
-    //         .body = @enumFromInt(2678),
-    //         .effect_var = @enumFromInt(2789),
-    //         .region = from_raw_offsets(2123, 2456),
-    //     },
-    // });
+    try expressions.append(CIR.Expr{
+        .e_lambda = .{
+            .args = CIR.Pattern.Span{ .span = base.DataSpan.init(1012, 1345) },
+            .body = @enumFromInt(2678),
+            .effect_var = @enumFromInt(2789),
+            .region = from_raw_offsets(2123, 2456),
+        },
+    });
 
     try expressions.append(CIR.Expr{
         .e_binop = CIR.Expr.Binop.init(

--- a/src/snapshots/binop_omnibus__single__no_spaces.md
+++ b/src/snapshots/binop_omnibus__single__no_spaces.md
@@ -57,7 +57,7 @@ Err(foo) ?? 12 > 5 * 5 or 13 + 2 < 5 and 10 - 1 >= 16 or 12 <= 3 / 5
 		(e-binop @1.1-1.20 (op "gt")
 			(e-binop @1.1-1.14 (op "null_coalesce")
 				(e-call @1.1-1.9
-					(e-tag @1.1-1.4 (ext-var 0) (name "Err") (args "TODO"))
+					(e-tag @1.1-1.4 (ext-var 73) (name "Err") (args "TODO"))
 					(e-runtime-error (tag "ident_not_in_scope")))
 				(e-int @1.11-1.13 (value "12")))
 			(e-binop @1.14-1.20 (op "mul")

--- a/src/snapshots/binop_omnibus__singleline.md
+++ b/src/snapshots/binop_omnibus__singleline.md
@@ -57,7 +57,7 @@ NO CHANGE
 		(e-binop @1.1-1.26 (op "gt")
 			(e-binop @1.1-1.17 (op "null_coalesce")
 				(e-call @1.1-1.9
-					(e-tag @1.1-1.4 (ext-var 0) (name "Err") (args "TODO"))
+					(e-tag @1.1-1.4 (ext-var 73) (name "Err") (args "TODO"))
 					(e-runtime-error (tag "ident_not_in_scope")))
 				(e-int @1.13-1.15 (value "12")))
 			(e-binop @1.18-1.26 (op "mul")

--- a/src/snapshots/binops.md
+++ b/src/snapshots/binops.md
@@ -155,13 +155,13 @@ CloseRound(17:1-17:2),EndOfFile(17:2-17:2),
 			(e-int @13.5-13.6 (value "4"))
 			(e-int @13.10-13.11 (value "2")))
 		(e-binop @14.5-14.19 (op "and")
-			(e-tag @14.5-14.9 (ext-var 0) (name "True") (args "TODO"))
-			(e-tag @14.14-14.18 (ext-var 0) (name "True") (args "TODO")))
+			(e-tag @14.5-14.9 (ext-var 109) (name "True") (args "TODO"))
+			(e-tag @14.14-14.18 (ext-var 111) (name "True") (args "TODO")))
 		(e-binop @15.5-15.18 (op "or")
-			(e-tag @15.5-15.9 (ext-var 0) (name "True") (args "TODO"))
-			(e-tag @15.13-15.17 (ext-var 0) (name "True") (args "TODO")))
+			(e-tag @15.5-15.9 (ext-var 114) (name "True") (args "TODO"))
+			(e-tag @15.13-15.17 (ext-var 116) (name "True") (args "TODO")))
 		(e-binop @16.5-16.15 (op "null_coalesce")
-			(e-tag @16.5-16.9 (ext-var 0) (name "None") (args "TODO"))
+			(e-tag @16.5-16.9 (ext-var 119) (name "None") (args "TODO"))
 			(e-int @16.13-16.14 (value "0")))))
 ~~~
 # TYPES

--- a/src/snapshots/expr/tag_simple.md
+++ b/src/snapshots/expr/tag_simple.md
@@ -23,7 +23,7 @@ NO CHANGE
 ~~~
 # CANONICALIZE
 ~~~clojure
-(e-tag @1.1-1.3 (ext-var 0) (name "Ok") (args "TODO") (id 74))
+(e-tag @1.1-1.3 (ext-var 73) (name "Ok") (args "TODO") (id 74))
 ~~~
 # TYPES
 ~~~clojure

--- a/src/snapshots/expr/tag_with_payload.md
+++ b/src/snapshots/expr/tag_with_payload.md
@@ -26,7 +26,7 @@ NO CHANGE
 # CANONICALIZE
 ~~~clojure
 (e-call @1.1-1.9 (id 77)
-	(e-tag @1.1-1.5 (ext-var 0) (name "Some") (args "TODO"))
+	(e-tag @1.1-1.5 (ext-var 73) (name "Some") (args "TODO"))
 	(e-int @1.6-1.8 (value "42")))
 ~~~
 # TYPES

--- a/src/snapshots/expr/tuple.md
+++ b/src/snapshots/expr/tuple.md
@@ -32,7 +32,7 @@ NO CHANGE
 		(e-int @1.2-1.3 (value "1"))
 		(e-string @1.5-1.12
 			(e-literal @1.6-1.11 (string "hello")))
-		(e-tag @1.14-1.18 (ext-var 0) (name "True") (args "TODO"))))
+		(e-tag @1.14-1.18 (ext-var 76) (name "True") (args "TODO"))))
 ~~~
 # TYPES
 ~~~clojure

--- a/src/snapshots/expr/tuple_comprehensive.md
+++ b/src/snapshots/expr/tuple_comprehensive.md
@@ -271,7 +271,7 @@ CloseCurly(19:1-19:2),EndOfFile(19:2-19:2),
 				(e-int @12.12-12.13 (value "1"))
 				(e-string @12.15-12.22
 					(e-literal @12.16-12.21 (string "hello")))
-				(e-tag @12.24-12.28 (ext-var 0) (name "True") (args "TODO")))))
+				(e-tag @12.24-12.28 (ext-var 104) (name "True") (args "TODO")))))
 	(s-let @13.2-13.27
 		(p-assign @13.2-13.8 (ident "nested") (id 108))
 		(e-tuple @13.11-13.27 (id 115)

--- a/src/snapshots/expr/tuple_patterns.md
+++ b/src/snapshots/expr/tuple_patterns.md
@@ -315,7 +315,7 @@ CloseCurly(19:1-19:2),EndOfFile(19:2-19:2),
 					(e-literal @13.33-13.38 (string "Alice")))
 				(e-string @13.41-13.48
 					(e-literal @13.42-13.47 (string "fixed")))
-				(e-tag @13.50-13.54 (ext-var 0) (name "True") (args "TODO")))))
+				(e-tag @13.50-13.54 (ext-var 128) (name "True") (args "TODO")))))
 	(s-expr @16.5-16.20
 		(e-tuple @16.5-16.18
 			(elems

--- a/src/snapshots/expr/tuple_simple_unbound.md
+++ b/src/snapshots/expr/tuple_simple_unbound.md
@@ -32,7 +32,7 @@ NO CHANGE
 		(e-int @1.2-1.3 (value "1"))
 		(e-string @1.5-1.12
 			(e-literal @1.6-1.11 (string "hello")))
-		(e-tag @1.14-1.18 (ext-var 0) (name "True") (args "TODO"))))
+		(e-tag @1.14-1.18 (ext-var 76) (name "True") (args "TODO"))))
 ~~~
 # TYPES
 ~~~clojure

--- a/src/snapshots/fuzz_crash/fuzz_crash_019.md
+++ b/src/snapshots/fuzz_crash/fuzz_crash_019.md
@@ -1098,7 +1098,7 @@ expect {
 								(e-runtime-error (tag "ident_not_in_scope")))
 							(field (name "qux")
 								(e-call @96.44-96.53
-									(e-tag @96.44-96.46 (ext-var 0) (name "Ok") (args "TODO"))
+									(e-tag @96.44-96.46 (ext-var 235) (name "Ok") (args "TODO"))
 									(e-runtime-error (tag "ident_not_in_scope"))))
 							(field (name "ned")
 								(e-runtime-error (tag "ident_not_in_scope"))))))
@@ -1110,7 +1110,7 @@ expect {
 							(e-string @97.12-97.19
 								(e-literal @97.13-97.18 (string "World")))
 							(e-runtime-error (tag "ident_not_in_scope"))
-							(e-tag @97.26-97.27 (ext-var 0) (name "O") (args "TODO"))
+							(e-tag @97.26-97.27 (ext-var 260) (name "O") (args "TODO"))
 							(e-tuple @97.29-97.36
 								(elems
 									(e-runtime-error (tag "ident_not_in_scope"))
@@ -1130,7 +1130,7 @@ expect {
 							(e-string @100.3-100.10
 								(e-literal @100.4-100.9 (string "World")))
 							(e-runtime-error (tag "ident_not_in_scope"))
-							(e-tag @101.3-101.4 (ext-var 0) (name "O") (args "TODO"))
+							(e-tag @101.3-101.4 (ext-var 280) (name "O") (args "TODO"))
 							(e-tuple @102.3-102.14
 								(elems
 									(e-runtime-error (tag "ident_not_in_scope"))
@@ -1171,7 +1171,7 @@ expect {
 										(receiver
 											(e-runtime-error (tag "not_implemented")))))))))
 				(e-call @106.2-110.3
-					(e-tag @106.2-106.7 (ext-var 0) (name "Stdo!") (args "TODO"))
+					(e-tag @106.2-106.7 (ext-var 322) (name "Stdo!") (args "TODO"))
 					(e-string @107.3-109.6
 						(e-literal @107.4-107.6 (string "Ho"))
 						(e-call @108.4-108.9

--- a/src/snapshots/fuzz_crash/fuzz_crash_020.md
+++ b/src/snapshots/fuzz_crash/fuzz_crash_020.md
@@ -1098,7 +1098,7 @@ expect {
 								(e-runtime-error (tag "ident_not_in_scope")))
 							(field (name "qux")
 								(e-call @96.44-96.53
-									(e-tag @96.44-96.46 (ext-var 0) (name "Ok") (args "TODO"))
+									(e-tag @96.44-96.46 (ext-var 235) (name "Ok") (args "TODO"))
 									(e-runtime-error (tag "ident_not_in_scope"))))
 							(field (name "ned")
 								(e-runtime-error (tag "ident_not_in_scope"))))))
@@ -1110,7 +1110,7 @@ expect {
 							(e-string @97.12-97.19
 								(e-literal @97.13-97.18 (string "World")))
 							(e-runtime-error (tag "ident_not_in_scope"))
-							(e-tag @97.26-97.27 (ext-var 0) (name "O") (args "TODO"))
+							(e-tag @97.26-97.27 (ext-var 260) (name "O") (args "TODO"))
 							(e-tuple @97.29-97.36
 								(elems
 									(e-runtime-error (tag "ident_not_in_scope"))
@@ -1130,7 +1130,7 @@ expect {
 							(e-string @100.3-100.10
 								(e-literal @100.4-100.9 (string "World")))
 							(e-runtime-error (tag "ident_not_in_scope"))
-							(e-tag @101.3-101.4 (ext-var 0) (name "O") (args "TODO"))
+							(e-tag @101.3-101.4 (ext-var 280) (name "O") (args "TODO"))
 							(e-tuple @102.3-102.14
 								(elems
 									(e-runtime-error (tag "ident_not_in_scope"))
@@ -1171,7 +1171,7 @@ expect {
 										(receiver
 											(e-runtime-error (tag "not_implemented")))))))))
 				(e-call @106.2-110.3
-					(e-tag @106.2-106.7 (ext-var 0) (name "Stdo!") (args "TODO"))
+					(e-tag @106.2-106.7 (ext-var 322) (name "Stdo!") (args "TODO"))
 					(e-string @107.3-109.6
 						(e-literal @107.4-107.6 (string "Ho"))
 						(e-call @108.4-108.9

--- a/src/snapshots/fuzz_crash/fuzz_crash_023.md
+++ b/src/snapshots/fuzz_crash/fuzz_crash_023.md
@@ -1933,7 +1933,7 @@ expect {
 					(e-int @146.15-146.18 (value "123") (id 245)))
 				(s-let @148.2-148.12
 					(p-assign @148.2-148.5 (ident "tag") (id 250))
-					(e-tag @148.8-148.12 (ext-var 0) (name "Blue") (args "TODO") (id 252)))
+					(e-tag @148.8-148.12 (ext-var 251) (name "Blue") (args "TODO") (id 252)))
 				(s-expr @154.2-155.12
 					(e-runtime-error (tag "not_implemented")))
 				(s-expr @155.2-158.11
@@ -1948,7 +1948,7 @@ expect {
 				(s-let @164.2-164.31
 					(p-assign @164.2-164.18 (ident "tag_with_payload") (id 274))
 					(e-call @164.21-164.31 (id 279)
-						(e-tag @164.21-164.23 (ext-var 0) (name "Ok") (args "TODO"))
+						(e-tag @164.21-164.23 (ext-var 275) (name "Ok") (args "TODO"))
 						(e-lookup-local @164.24-164.30
 							(pattern (id 246)))))
 				(s-let @165.2-165.34
@@ -1983,7 +1983,7 @@ expect {
 							(e-lookup-local @179.25-179.28
 								(pattern (id 250)))
 							(e-call @179.30-179.39
-								(e-tag @179.30-179.32 (ext-var 0) (name "Ok") (args "TODO"))
+								(e-tag @179.30-179.32 (ext-var 311) (name "Ok") (args "TODO"))
 								(e-lookup-local @179.33-179.38
 									(pattern (id 241))))
 							(e-tuple @179.41-179.56
@@ -2005,7 +2005,7 @@ expect {
 								(e-literal @182.4-182.9 (string "World")))
 							(e-runtime-error (tag "ident_not_in_scope"))
 							(e-call @184.3-184.12
-								(e-tag @184.3-184.5 (ext-var 0) (name "Ok") (args "TODO"))
+								(e-tag @184.3-184.5 (ext-var 332) (name "Ok") (args "TODO"))
 								(e-lookup-local @184.6-184.11
 									(pattern (id 241))))
 							(e-tuple @185.3-185.18
@@ -2025,7 +2025,7 @@ expect {
 							(e-binop @188.18-188.43 (op "gt")
 								(e-binop @188.18-188.34 (op "null_coalesce")
 									(e-call @188.18-188.26
-										(e-tag @188.18-188.21 (ext-var 0) (name "Err") (args "TODO"))
+										(e-tag @188.18-188.21 (ext-var 348) (name "Err") (args "TODO"))
 										(e-runtime-error (tag "ident_not_in_scope")))
 									(e-int @188.30-188.32 (value "12")))
 								(e-binop @188.35-188.43 (op "mul")

--- a/src/snapshots/if_then_else.md
+++ b/src/snapshots/if_then_else.md
@@ -89,7 +89,7 @@ foo = if 1 A
 			(if-branches
 				(if-branch
 					(e-int @3.10-3.11 (value "1"))
-					(e-tag @3.12-3.13 (ext-var 0) (name "A") (args "TODO"))))
+					(e-tag @3.12-3.13 (ext-var 75) (name "A") (args "TODO"))))
 			(if-else
 				(e-block @5.10-7.6
 					(e-string @6.2-6.9

--- a/src/snapshots/if_then_else_3.md
+++ b/src/snapshots/if_then_else_3.md
@@ -54,7 +54,7 @@ NO CHANGE
 		(if-branch
 			(e-runtime-error (tag "ident_not_in_scope"))
 			(e-block @1.9-3.2
-				(e-tag @2.2-2.3 (ext-var 0) (name "A") (args "TODO")))))
+				(e-tag @2.2-2.3 (ext-var 75) (name "A") (args "TODO")))))
 	(if-else
 		(e-int @3.8-3.9 (value "2"))))
 ~~~

--- a/src/snapshots/if_then_else_5.md
+++ b/src/snapshots/if_then_else_5.md
@@ -40,9 +40,9 @@ NO CHANGE
 		(if-branch
 			(e-runtime-error (tag "ident_not_in_scope"))
 			(e-block @1.9-3.2
-				(e-tag @2.2-2.3 (ext-var 0) (name "A") (args "TODO")))))
+				(e-tag @2.2-2.3 (ext-var 75) (name "A") (args "TODO")))))
 	(if-else
-		(e-tag @3.8-3.9 (ext-var 0) (name "B") (args "TODO"))))
+		(e-tag @3.8-3.9 (ext-var 79) (name "B") (args "TODO"))))
 ~~~
 # TYPES
 ~~~clojure

--- a/src/snapshots/primitive/expr_tag.md
+++ b/src/snapshots/primitive/expr_tag.md
@@ -35,7 +35,7 @@ NO CHANGE
 (can-ir
 	(d-let (id 76)
 		(p-assign @2.1-2.4 (ident "foo") (id 73))
-		(e-tag @2.7-2.15 (ext-var 0) (name "FortyTwo") (args "TODO") (id 75))))
+		(e-tag @2.7-2.15 (ext-var 74) (name "FortyTwo") (args "TODO") (id 75))))
 ~~~
 # TYPES
 ~~~clojure

--- a/src/snapshots/records/record_different_fields_error.md
+++ b/src/snapshots/records/record_different_fields_error.md
@@ -371,7 +371,7 @@ CloseCurly(8:1-8:2),EndOfFile(8:2-8:2),
 	(s-type-anno @3.5-3.33 (name "field_")
 		(ty-malformed @3.13-3.33))
 	(s-expr @4.5-4.16
-		(e-tag @4.5-4.15 (ext-var 0) (name "PascalCase") (args "TODO")))
+		(e-tag @4.5-4.15 (ext-var 81) (name "PascalCase") (args "TODO")))
 	(s-expr @4.17-4.26
 		(e-string @4.17-4.25
 			(e-literal @4.18-4.24 (string "pascal"))))

--- a/src/snapshots/records/record_with_complex_types.md
+++ b/src/snapshots/records/record_with_complex_types.md
@@ -155,7 +155,7 @@ CloseCurly(15:1-15:2),EndOfFile(15:2-15:2),
 					(e-int @3.26-3.28 (value "78")))))
 		(field (name "status")
 			(e-call @4.13-4.44
-				(e-tag @4.13-4.19 (ext-var 0) (name "Active") (args "TODO"))
+				(e-tag @4.13-4.19 (ext-var 82) (name "Active") (args "TODO"))
 				(e-record @4.20-4.43 (ext-var 87)
 					(fields
 						(field (name "since")
@@ -165,15 +165,15 @@ CloseCurly(15:1-15:2),EndOfFile(15:2-15:2),
 			(e-record @5.18-5.76 (ext-var 103)
 				(fields
 					(field (name "theme")
-						(e-tag @5.27-5.31 (ext-var 0) (name "Dark") (args "TODO")))
+						(e-tag @5.27-5.31 (ext-var 93) (name "Dark") (args "TODO")))
 					(field (name "notifications")
 						(e-call @5.48-5.74
-							(e-tag @5.48-5.53 (ext-var 0) (name "Email") (args "TODO"))
+							(e-tag @5.48-5.53 (ext-var 96) (name "Email") (args "TODO"))
 							(e-string @5.54-5.73
 								(e-literal @5.55-5.72 (string "alice@example.com"))))))))
 		(field (name "metadata")
 			(e-call @6.15-9.7
-				(e-tag @6.15-6.17 (ext-var 0) (name "Ok") (args "TODO"))
+				(e-tag @6.15-6.17 (ext-var 108) (name "Ok") (args "TODO"))
 				(e-record @6.18-9.6 (ext-var 126)
 					(fields
 						(field (name "tags")
@@ -188,9 +188,9 @@ CloseCurly(15:1-15:2),EndOfFile(15:2-15:2),
 						(field (name "permissions")
 							(e-list @8.22-8.42 (elem-var 119)
 								(elems
-									(e-tag @8.23-8.27 (ext-var 0) (name "Read") (args "TODO"))
-									(e-tag @8.29-8.34 (ext-var 0) (name "Write") (args "TODO"))
-									(e-tag @8.36-8.41 (ext-var 0) (name "Admin") (args "TODO")))))))))
+									(e-tag @8.23-8.27 (ext-var 118) (name "Read") (args "TODO"))
+									(e-tag @8.29-8.34 (ext-var 120) (name "Write") (args "TODO"))
+									(e-tag @8.36-8.41 (ext-var 122) (name "Admin") (args "TODO")))))))))
 		(field (name "callback")
 			(e-lambda @10.15-10.25
 				(args
@@ -206,17 +206,17 @@ CloseCurly(15:1-15:2),EndOfFile(15:2-15:2),
 						(e-list @12.16-12.52 (elem-var 145)
 							(elems
 								(e-call @12.17-12.30
-									(e-tag @12.17-12.21 (ext-var 0) (name "Some") (args "TODO"))
+									(e-tag @12.17-12.21 (ext-var 140) (name "Some") (args "TODO"))
 									(e-string @12.22-12.29
 										(e-literal @12.23-12.28 (string "first"))))
-								(e-tag @12.32-12.36 (ext-var 0) (name "None") (args "TODO"))
+								(e-tag @12.32-12.36 (ext-var 146) (name "None") (args "TODO"))
 								(e-call @12.38-12.51
-									(e-tag @12.38-12.42 (ext-var 0) (name "Some") (args "TODO"))
+									(e-tag @12.38-12.42 (ext-var 148) (name "Some") (args "TODO"))
 									(e-string @12.43-12.50
 										(e-literal @12.44-12.49 (string "third")))))))
 					(field (name "result")
 						(e-call @13.17-13.70
-							(e-tag @13.17-13.24 (ext-var 0) (name "Success") (args "TODO"))
+							(e-tag @13.17-13.24 (ext-var 156) (name "Success") (args "TODO"))
 							(e-record @13.25-13.69 (ext-var 166)
 								(fields
 									(field (name "data")

--- a/src/snapshots/syntax_grab_bag.md
+++ b/src/snapshots/syntax_grab_bag.md
@@ -1302,7 +1302,7 @@ NO CHANGE
 					(e-int @146.15-146.18 (value "123") (id 245)))
 				(s-let @148.2-148.12
 					(p-assign @148.2-148.5 (ident "tag") (id 250))
-					(e-tag @148.8-148.12 (ext-var 0) (name "Blue") (args "TODO") (id 252)))
+					(e-tag @148.8-148.12 (ext-var 251) (name "Blue") (args "TODO") (id 252)))
 				(s-expr @154.2-155.12
 					(e-runtime-error (tag "not_implemented")))
 				(s-expr @155.2-158.11
@@ -1317,7 +1317,7 @@ NO CHANGE
 				(s-let @164.2-164.31
 					(p-assign @164.2-164.18 (ident "tag_with_payload") (id 274))
 					(e-call @164.21-164.31 (id 279)
-						(e-tag @164.21-164.23 (ext-var 0) (name "Ok") (args "TODO"))
+						(e-tag @164.21-164.23 (ext-var 275) (name "Ok") (args "TODO"))
 						(e-lookup-local @164.24-164.30
 							(pattern (id 246)))))
 				(s-let @165.2-165.34
@@ -1351,7 +1351,7 @@ NO CHANGE
 									(pattern (id 250))))
 							(field (name "qux")
 								(e-call @178.52-178.61
-									(e-tag @178.52-178.54 (ext-var 0) (name "Ok") (args "TODO"))
+									(e-tag @178.52-178.54 (ext-var 307) (name "Ok") (args "TODO"))
 									(e-lookup-local @178.55-178.60
 										(pattern (id 241)))))
 							(field (name "punned")
@@ -1366,7 +1366,7 @@ NO CHANGE
 							(e-lookup-local @179.25-179.28
 								(pattern (id 250)))
 							(e-call @179.30-179.39
-								(e-tag @179.30-179.32 (ext-var 0) (name "Ok") (args "TODO"))
+								(e-tag @179.30-179.32 (ext-var 329) (name "Ok") (args "TODO"))
 								(e-lookup-local @179.33-179.38
 									(pattern (id 241))))
 							(e-tuple @179.41-179.56
@@ -1388,7 +1388,7 @@ NO CHANGE
 								(e-literal @182.4-182.9 (string "World")))
 							(e-runtime-error (tag "ident_not_in_scope"))
 							(e-call @184.3-184.12
-								(e-tag @184.3-184.5 (ext-var 0) (name "Ok") (args "TODO"))
+								(e-tag @184.3-184.5 (ext-var 350) (name "Ok") (args "TODO"))
 								(e-lookup-local @184.6-184.11
 									(pattern (id 241))))
 							(e-tuple @185.3-185.18
@@ -1408,7 +1408,7 @@ NO CHANGE
 							(e-binop @188.18-188.43 (op "gt")
 								(e-binop @188.18-188.34 (op "null_coalesce")
 									(e-call @188.18-188.26
-										(e-tag @188.18-188.21 (ext-var 0) (name "Err") (args "TODO"))
+										(e-tag @188.18-188.21 (ext-var 366) (name "Err") (args "TODO"))
 										(e-runtime-error (tag "ident_not_in_scope")))
 									(e-int @188.30-188.32 (value "12")))
 								(e-binop @188.35-188.43 (op "mul")

--- a/src/snapshots/type_alias_decl.md
+++ b/src/snapshots/type_alias_decl.md
@@ -315,7 +315,7 @@ main! = |_| {
 					(ty @35.13-35.18 (name "Color")))
 				(s-let @36.5-36.16
 					(p-assign @36.5-36.10 (ident "color") (id 154))
-					(e-tag @36.13-36.16 (ext-var 0) (name "Red") (args "TODO") (id 156)))
+					(e-tag @36.13-36.16 (ext-var 155) (name "Red") (args "TODO") (id 156)))
 				(e-lookup-local @38.5-38.11
 					(pattern (id 134))))))
 	(s-type-decl @4.1-7.7 (id 75)

--- a/src/snapshots/type_app_complex_nested.md
+++ b/src/snapshots/type_app_complex_nested.md
@@ -322,13 +322,13 @@ main! = |_| processComplex(Ok([Some(42), None]))
 				(e-lookup-local @17.13-17.27
 					(pattern (id 99)))
 				(e-call @17.28-17.48
-					(e-tag @17.28-17.30 (ext-var 0) (name "Ok") (args "TODO"))
+					(e-tag @17.28-17.30 (ext-var 147) (name "Ok") (args "TODO"))
 					(e-list @17.31-17.47 (elem-var 153)
 						(elems
 							(e-call @17.32-17.40
-								(e-tag @17.32-17.36 (ext-var 0) (name "Some") (args "TODO"))
+								(e-tag @17.32-17.36 (ext-var 149) (name "Some") (args "TODO"))
 								(e-int @17.37-17.39 (value "42")))
-							(e-tag @17.42-17.46 (ext-var 0) (name "None") (args "TODO"))))))))
+							(e-tag @17.42-17.46 (ext-var 154) (name "None") (args "TODO"))))))))
 	(s-type-decl @15.1-17.6 (id 84)
 		(ty-header @15.1-15.18 (name "ComplexType")
 			(ty-args


### PR DESCRIPTION
Adding unit tests to ensure the variants roundtrip with the correct data to/from the NodeStore, includes `comptime` checks to mitigate future regressions if we add/remove variants in future.   

Implement missing functionality for the NodeStore to ensure 100% coverage.