### PR TITLE
Improve Type Error API

### DIFF
--- a/src/check/canonicalize.zig
+++ b/src/check/canonicalize.zig
@@ -2832,6 +2832,7 @@ fn flattenIfThenElseChainRecursive(self: *Self, if_expr: anytype) std.mem.Alloca
     const if_branch = CIR.IfBranch{
         .cond = cond_idx,
         .body = then_idx,
+        .region = self.parse_ir.tokenizedRegionToRegion(if_expr.region),
     };
     self.can_ir.store.addScratchIfBranch(if_branch);
 

--- a/src/check/canonicalize/CIR.zig
+++ b/src/check/canonicalize/CIR.zig
@@ -2010,6 +2010,7 @@ pub const IntValue = struct {
 pub const IfBranch = struct {
     cond: Expr.Idx,
     body: Expr.Idx,
+    region: Region,
 
     pub const Idx = enum(u32) { _ };
     pub const Span = struct { span: base.DataSpan };

--- a/src/check/canonicalize/NodeStore.zig
+++ b/src/check/canonicalize/NodeStore.zig
@@ -2016,6 +2016,7 @@ pub fn getIfBranch(store: *const NodeStore, if_branch_idx: CIR.IfBranch.Idx) CIR
     return CIR.IfBranch{
         .cond = @enumFromInt(node.data_1),
         .body = @enumFromInt(node.data_2),
+        .region = node.region,
     };
 }
 
@@ -2350,7 +2351,7 @@ pub fn addIfBranch(store: *NodeStore, if_branch: CIR.IfBranch) CIR.IfBranch.Idx 
         .data_1 = @intFromEnum(if_branch.cond),
         .data_2 = @intFromEnum(if_branch.body),
         .data_3 = 0,
-        .region = Region.zero(),
+        .region = if_branch.region,
         .tag = .if_branch,
     };
     const node_idx = store.nodes.append(store.gpa, node);

--- a/src/check/check_types.zig
+++ b/src/check/check_types.zig
@@ -311,8 +311,8 @@ pub fn checkExpr(self: *Self, expr_idx: CIR.Expr.Idx) Allocator.Error!void {
                 const result = self.unify(elem_var, @enumFromInt(@intFromEnum(elem_expr_id)));
                 self.setDetailIfTypeMismatch(result, problem.TypeMismatchDetail{ .incompatible_list_elements = .{
                     .last_elem_expr = last_elem_idx,
-                    .incompatible_elem_index = i,
-                    .list_length = elems.len,
+                    .incompatible_elem_index = @intCast(i),
+                    .list_length = @intCast(elems.len),
                 } });
 
                 if (!result.isOk()) {
@@ -531,7 +531,7 @@ pub fn checkIfElseExpr(self: *Self, if_expr_idx: CIR.Expr.Idx, if_: CIR.If) Allo
     const branch_var = @as(Var, @enumFromInt(@intFromEnum(first_branch.body)));
 
     // Total number of branches (including final else)
-    const num_branches = branches.len + 1;
+    const num_branches: u32 = @intCast(branches.len + 1);
 
     var last_if_branch = first_branch_idx;
     for (branches[1..], 1..) |branch_idx, cur_index| {
@@ -551,7 +551,7 @@ pub fn checkIfElseExpr(self: *Self, if_expr_idx: CIR.Expr.Idx, if_: CIR.If) Allo
             .parent_if_expr = if_expr_idx,
             .last_if_branch = last_if_branch,
             .num_branches = num_branches,
-            .problem_branch_index = cur_index,
+            .problem_branch_index = @intCast(cur_index),
         } });
 
         if (!body_result.isOk()) {
@@ -617,10 +617,10 @@ pub fn checkMatchExpr(self: *Self, expr_idx: CIR.Expr.Idx, match: CIR.Match) All
         const ptrn_result = self.unify(cond_var, branch_ptrn_var);
         self.setDetailIfTypeMismatch(ptrn_result, problem.TypeMismatchDetail{ .incompatible_match_patterns = .{
             .match_expr = expr_idx,
-            .num_branches = match.branches.span.len,
+            .num_branches = @intCast(match.branches.span.len),
             .problem_branch_index = 0,
-            .num_patterns = first_branch_ptrn_idxs.len,
-            .problem_pattern_index = cur_ptrn_index,
+            .num_patterns = @intCast(first_branch_ptrn_idxs.len),
+            .problem_pattern_index = @intCast(cur_ptrn_index),
         } });
     }
 
@@ -644,10 +644,10 @@ pub fn checkMatchExpr(self: *Self, expr_idx: CIR.Expr.Idx, match: CIR.Match) All
             const ptrn_result = self.unify(cond_var, branch_ptrn_var);
             self.setDetailIfTypeMismatch(ptrn_result, problem.TypeMismatchDetail{ .incompatible_match_patterns = .{
                 .match_expr = expr_idx,
-                .num_branches = match.branches.span.len,
-                .problem_branch_index = branch_cur_index,
-                .num_patterns = branch_ptrn_idxs.len,
-                .problem_pattern_index = cur_ptrn_index,
+                .num_branches = @intCast(match.branches.span.len),
+                .problem_branch_index = @intCast(branch_cur_index),
+                .num_patterns = @intCast(branch_ptrn_idxs.len),
+                .problem_pattern_index = @intCast(cur_ptrn_index),
             } });
         }
 
@@ -656,8 +656,8 @@ pub fn checkMatchExpr(self: *Self, expr_idx: CIR.Expr.Idx, match: CIR.Match) All
         const branch_result = self.unify(branch_var, @enumFromInt(@intFromEnum(branch.value)));
         self.setDetailIfTypeMismatch(branch_result, problem.TypeMismatchDetail{ .incompatible_match_branches = .{
             .match_expr = expr_idx,
-            .num_branches = match.branches.span.len,
-            .problem_branch_index = branch_cur_index,
+            .num_branches = @intCast(match.branches.span.len),
+            .problem_branch_index = @intCast(branch_cur_index),
         } });
 
         if (!branch_result.isOk()) {
@@ -678,10 +678,10 @@ pub fn checkMatchExpr(self: *Self, expr_idx: CIR.Expr.Idx, match: CIR.Match) All
                     const ptrn_result = self.unify(cond_var, other_branch_ptrn_var);
                     self.setDetailIfTypeMismatch(ptrn_result, problem.TypeMismatchDetail{ .incompatible_match_patterns = .{
                         .match_expr = expr_idx,
-                        .num_branches = match.branches.span.len,
-                        .problem_branch_index = other_branch_cur_index,
-                        .num_patterns = other_branch_ptrn_idxs.len,
-                        .problem_pattern_index = other_cur_ptrn_index,
+                        .num_branches = @intCast(match.branches.span.len),
+                        .problem_branch_index = @intCast(other_branch_cur_index),
+                        .num_patterns = @intCast(other_branch_ptrn_idxs.len),
+                        .problem_pattern_index = @intCast(other_cur_ptrn_index),
                     } });
                 }
 
@@ -711,11 +711,7 @@ fn setDetailIfTypeMismatch(self: *Self, result: unifier.Result, mismatch_detail:
                 .type_mismatch => |mismatch| {
                     self.problems.problems.set(problem_idx, .{
                         .type_mismatch = .{
-                            .expected_var = mismatch.expected_var,
-                            .expected = mismatch.expected,
-                            .actual_var = mismatch.actual_var,
-                            .actual = mismatch.actual,
-                            // Add detail to type mismatch
+                            .types = mismatch.types,
                             .detail = mismatch_detail,
                         },
                     });

--- a/src/check/check_types/unify.zig
+++ b/src/check/check_types/unify.zig
@@ -178,10 +178,12 @@ pub fn unifyMode(
                     const expected_snapshot = snapshots.deepCopyVar(types, a);
                     const actual_snapshot = snapshots.deepCopyVar(types, b);
                     break :blk .{ .type_mismatch = .{
-                        .expected_var = a,
-                        .expected = expected_snapshot,
-                        .actual_var = b,
-                        .actual = actual_snapshot,
+                        .types = .{
+                            .expected_var = a,
+                            .expected_snapshot = expected_snapshot,
+                            .actual_var = b,
+                            .actual_snapshot = actual_snapshot,
+                        },
                         .detail = null,
                     } };
                 },

--- a/src/coordinate_simple.zig
+++ b/src/coordinate_simple.zig
@@ -5,6 +5,7 @@ const base = @import("base.zig");
 const parse = @import("check/parse.zig");
 const canonicalize = @import("check/canonicalize.zig");
 const Solver = @import("check/check_types.zig");
+const types_problem_mod = @import("check/check_types/problem.zig");
 const reporting = @import("reporting.zig");
 const Filesystem = @import("coordinate/Filesystem.zig");
 
@@ -150,22 +151,20 @@ fn processSourceInternal(
         try gpa.dupe(u8, source); // Clone to get our own copy
 
     // Get type checking diagnostic Reports
-    var problem_buf = std.ArrayList(u8).init(gpa);
-    defer problem_buf.deinit();
+    var report_builder = types_problem_mod.ReportBuilder.init(
+        gpa,
+        &module_env,
+        cir,
+        &solver.snapshots,
+        owned_source,
+        filename,
+    );
+    defer report_builder.deinit();
 
     var problems_itr = solver.problems.problems.iterIndices();
     while (problems_itr.next()) |problem_idx| {
-        problem_buf.clearRetainingCapacity();
         const problem = solver.problems.problems.get(problem_idx);
-        const report = problem.buildReport(
-            gpa,
-            &problem_buf,
-            &module_env,
-            cir,
-            &solver.snapshots,
-            owned_source,
-            filename,
-        ) catch continue;
+        const report = report_builder.build(problem) catch continue;
         reports.append(report) catch continue;
     }
 

--- a/src/snapshots/fuzz_crash/fuzz_crash_019.md
+++ b/src/snapshots/fuzz_crash/fuzz_crash_019.md
@@ -473,7 +473,7 @@ expect # Cord
 The fourth pattern has this type:
     _Str_
 
-But all the the other patterns have this type: 
+But all the previous patterns have this type: 
     _[Blue]*_
 
 All patterns in an `match` must have compatible types.

--- a/src/snapshots/fuzz_crash/fuzz_crash_020.md
+++ b/src/snapshots/fuzz_crash/fuzz_crash_020.md
@@ -477,7 +477,7 @@ expect # Cord
 The fourth pattern has this type:
     _Str_
 
-But all the the other patterns have this type: 
+But all the previous patterns have this type: 
     _[Blue]*_
 
 All patterns in an `match` must have compatible types.

--- a/src/snapshots/if_then_else/if_then_else_9.md
+++ b/src/snapshots/if_then_else/if_then_else_9.md
@@ -40,12 +40,15 @@ if bool {
 } else if 10 { # Comment after else open
 	A
 } else { # Comment after else open
+	3
+}
 ```
+ ^
 
 The second branch has this type:
     _[A]*_
 
-But all the previous branches have this type:
+But the previous branch has this type:
     _Num(*)_
 
 All branches in an `if` must have compatible types.

--- a/src/snapshots/if_then_else/if_then_else_9.md
+++ b/src/snapshots/if_then_else/if_then_else_9.md
@@ -40,15 +40,12 @@ if bool {
 } else if 10 { # Comment after else open
 	A
 } else { # Comment after else open
-	3
-}
 ```
- ^
 
 The second branch has this type:
     _[A]*_
 
-But all the other branches have this type:
+But all the previous branches have this type:
     _Num(*)_
 
 All branches in an `if` must have compatible types.

--- a/src/snapshots/if_then_else/if_then_else_simple_file.md
+++ b/src/snapshots/if_then_else/if_then_else_simple_file.md
@@ -29,16 +29,15 @@ Every `if` condition must evaluate to a _Bool_–either `True` or `False`.
 
 **INCOMPATIBLE IF BRANCHES**
 This `if` has an `else` branch with a different type from it's `then` branch:
-**if_then_else_simple_file.md:1:1:**
+**if_then_else_simple_file.md:3:7:**
 ```roc
-module [foo]
-
 foo = if 1 A
 
     else {
 	"hello"
     }
 ```
+ ^^^^^^^
 
 The `else` branch has the type:
     _Str_

--- a/src/snapshots/if_then_else/if_then_else_simple_file.md
+++ b/src/snapshots/if_then_else/if_then_else_simple_file.md
@@ -29,15 +29,16 @@ Every `if` condition must evaluate to a _Bool_–either `True` or `False`.
 
 **INCOMPATIBLE IF BRANCHES**
 This `if` has an `else` branch with a different type from it's `then` branch:
-**if_then_else_simple_file.md:3:7:**
+**if_then_else_simple_file.md:1:1:**
 ```roc
+module [foo]
+
 foo = if 1 A
 
     else {
 	"hello"
     }
 ```
- ^^^^^^^
 
 The `else` branch has the type:
     _Str_

--- a/src/snapshots/match_expr/literal_patterns.md
+++ b/src/snapshots/match_expr/literal_patterns.md
@@ -50,7 +50,7 @@ match Answer {
 The fourth pattern has this type:
     _Num(*)_
 
-But all the the other patterns have this type: 
+But all the previous patterns have this type: 
     _[Answer, Zero, Greeting]*_
 
 All patterns in an `match` must have compatible types.

--- a/src/snapshots/nominal/nominal_tag_payload_two.md
+++ b/src/snapshots/nominal/nominal_tag_payload_two.md
@@ -142,7 +142,7 @@ is_ok = |result| match result {
 The second pattern has this type:
     _(*)_
 
-But all the the other patterns have this type: 
+But all the previous patterns have this type: 
     _[Result]*_
 
 All patterns in an `match` must have compatible types.

--- a/src/snapshots/plume_package/Color.md
+++ b/src/snapshots/plume_package/Color.md
@@ -572,7 +572,7 @@ expect rgb(124, 56, 245).to_str() == "rgb(124, 56, 245)"
 The second pattern has this type:
     _(*, *, *)_
 
-But all the the other patterns have this type: 
+But all the previous patterns have this type: 
     _[Color]*_
 
 All patterns in an `match` must have compatible types.


### PR DESCRIPTION
This PR improve how we set type errors during type checking to be more ergonomic.

* Reduce number of `Problem` variants
* Add a nullable `details` field to `TypeMismatch`, which optionally contains contextual information for better errors
* Remove region from `incompatible_list_elements`
* Make `problems.ReportBuilder` struct with common args, to improve ergonomics