### PR TITLE
Fix tutorial link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [Roc](https://www.roc-lang.org) is not ready for a 0.1 release yet, but we do have:
 
 - [**installation** guide](https://www.roc-lang.org/install)
-- [**tutorial**](https://roc-lang.org/tutorial)
+- [**tutorial**](https://www.roc-lang.org/tutorial)
 - [**docs** for the standard library](https://www.roc-lang.org/builtins)
 - [**examples**](https://www.roc-lang.org/examples)
 - [**faq**: frequently asked questions](https://www.roc-lang.org/faq)


### PR DESCRIPTION
Hi, I have just started learning roc-lang.
I noticed that the tutorial link in README was not working, so I fixed it.

Old URL:
![CleanShot 2025-07-02 at 22 12 12@2x](https://github.com/user-attachments/assets/74e90a00-c1c3-46d1-92fb-9e94b36d6d1a)

