### PR TITLE
add tracing to core roc functions

### DIFF
--- a/src/check/canonicalize.zig
+++ b/src/check/canonicalize.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const testing = std.testing;
 const base = @import("../base.zig");
+const tracy = @import("../tracy.zig");
 const parse = @import("parse.zig");
 const tokenize = @import("parse/tokenize.zig");
 const collections = @import("../collections.zig");
@@ -236,6 +237,9 @@ pub const CIR = @import("canonicalize/CIR.zig");
 pub fn canonicalize_file(
     self: *Self,
 ) std.mem.Allocator.Error!void {
+    const trace = tracy.trace(@src());
+    defer trace.end();
+
     const file = self.parse_ir.store.getFile();
 
     // canonicalize_header_packages();
@@ -540,6 +544,9 @@ fn canonicalizeImportStatement(
     self: *Self,
     import_stmt: @TypeOf(@as(AST.Statement, undefined).import),
 ) ?CIR.Statement.Idx {
+    const trace = tracy.trace(@src());
+    defer trace.end();
+
     // 1. Reconstruct the full module name (e.g., "json.Json")
     const module_name = blk: {
         if (self.parse_ir.tokens.resolveIdentifier(import_stmt.module_name_tok) == null) {
@@ -760,6 +767,9 @@ fn canonicalize_decl(
     self: *Self,
     decl: AST.Statement.Decl,
 ) std.mem.Allocator.Error!CIR.Def.Idx {
+    const trace = tracy.trace(@src());
+    defer trace.end();
+
     const pattern_region = self.parse_ir.tokenizedRegionToRegion(self.parse_ir.store.getPattern(decl.pattern).to_tokenized_region());
     const expr_region = self.parse_ir.tokenizedRegionToRegion(self.parse_ir.store.getExpr(decl.body).to_tokenized_region());
 
@@ -849,6 +859,9 @@ fn canonicalize_record_field(
     self: *Self,
     ast_field_idx: AST.RecordField.Idx,
 ) std.mem.Allocator.Error!?CIR.RecordField.Idx {
+    const trace = tracy.trace(@src());
+    defer trace.end();
+
     const field = self.parse_ir.store.getRecordField(ast_field_idx);
 
     // Canonicalize the field name
@@ -887,6 +900,9 @@ pub fn canonicalize_expr(
     self: *Self,
     ast_expr_idx: AST.Expr.Idx,
 ) std.mem.Allocator.Error!?CIR.Expr.Idx {
+    const trace = tracy.trace(@src());
+    defer trace.end();
+
     const expr = self.parse_ir.store.getExpr(ast_expr_idx);
 
     switch (expr) {
@@ -2076,6 +2092,9 @@ fn canonicalize_pattern(
     self: *Self,
     ast_pattern_idx: AST.Pattern.Idx,
 ) std.mem.Allocator.Error!?CIR.Pattern.Idx {
+    const trace = tracy.trace(@src());
+    defer trace.end();
+
     const gpa = self.can_ir.env.gpa;
     switch (self.parse_ir.store.getPattern(ast_pattern_idx)) {
         .ident => |e| {
@@ -3029,6 +3048,9 @@ fn scopeIntroduceVar(
 /// Unlike general type canonicalization, this doesn't validate tag names against scope
 /// since tags in tag unions are anonymous and defined by the union itself
 fn canonicalize_tag_variant(self: *Self, anno_idx: AST.TypeAnno.Idx) CIR.TypeAnno.Idx {
+    const trace = tracy.trace(@src());
+    defer trace.end();
+
     const ast_anno = self.parse_ir.store.getTypeAnno(anno_idx);
     switch (ast_anno) {
         .ty => |ty| {
@@ -3081,6 +3103,9 @@ fn canonicalize_tag_variant(self: *Self, anno_idx: AST.TypeAnno.Idx) CIR.TypeAnn
 
 /// Canonicalize a statement within a block
 fn canonicalize_type_anno(self: *Self, anno_idx: AST.TypeAnno.Idx) CIR.TypeAnno.Idx {
+    const trace = tracy.trace(@src());
+    defer trace.end();
+
     const ast_anno = self.parse_ir.store.getTypeAnno(anno_idx);
     switch (ast_anno) {
         .apply => |apply| {
@@ -3309,6 +3334,9 @@ fn canonicalize_type_anno(self: *Self, anno_idx: AST.TypeAnno.Idx) CIR.TypeAnno.
 }
 
 fn canonicalize_type_header(self: *Self, header_idx: AST.TypeHeader.Idx) CIR.TypeHeader.Idx {
+    const trace = tracy.trace(@src());
+    defer trace.end();
+
     // Check if the node is malformed before calling getTypeHeader
     const node = self.parse_ir.store.nodes.get(@enumFromInt(@intFromEnum(header_idx)));
     if (node.tag == .malformed) {
@@ -3378,6 +3406,9 @@ fn canonicalize_type_header(self: *Self, header_idx: AST.TypeHeader.Idx) CIR.Typ
 
 /// Canonicalize a statement in the canonical IR.
 pub fn canonicalize_statement(self: *Self, stmt_idx: AST.Statement.Idx) std.mem.Allocator.Error!?CIR.Expr.Idx {
+    const trace = tracy.trace(@src());
+    defer trace.end();
+
     const stmt = self.parse_ir.store.getStatement(stmt_idx);
 
     switch (stmt) {
@@ -4441,6 +4472,9 @@ fn canonicalizeTypeAnnoToTypeVar(self: *Self, type_anno_idx: CIR.TypeAnno.Idx, p
 
 /// Handle basic type lookup (Bool, Str, Num, etc.)
 fn canonicalizeBasicType(self: *Self, symbol: Ident.Idx, parent_node_idx: Node.Idx, region: Region) TypeVar {
+    const trace = tracy.trace(@src());
+    defer trace.end();
+
     const name = self.can_ir.env.idents.getText(symbol);
 
     // Built-in types mapping
@@ -4501,6 +4535,9 @@ fn canonicalizeBasicType(self: *Self, symbol: Ident.Idx, parent_node_idx: Node.I
 
 /// Handle type applications like List(Str), Dict(k, v)
 fn canonicalizeTypeApplication(self: *Self, apply: anytype, parent_node_idx: Node.Idx, region: Region) std.mem.Allocator.Error!TypeVar {
+    const trace = tracy.trace(@src());
+    defer trace.end();
+
     // Look up the type name in scope
     if (self.scopeLookupTypeDecl(apply.symbol)) |type_decl_idx| {
         const type_decl = self.can_ir.store.getStatement(type_decl_idx);
@@ -4561,6 +4598,9 @@ fn canonicalizeTypeApplication(self: *Self, apply: anytype, parent_node_idx: Nod
 
 /// Handle function types like a -> b
 fn canonicalizeFunctionType(self: *Self, func: anytype, parent_node_idx: Node.Idx, region: Region) std.mem.Allocator.Error!TypeVar {
+    const trace = tracy.trace(@src());
+    defer trace.end();
+
     const gpa = self.can_ir.env.gpa;
 
     // Canonicalize argument types and return type
@@ -4595,6 +4635,9 @@ fn canonicalizeFunctionType(self: *Self, func: anytype, parent_node_idx: Node.Id
 
 /// Handle tuple types like (a, b, c)
 fn canonicalizeTupleType(self: *Self, tuple: anytype, parent_node_idx: Node.Idx, region: Region) TypeVar {
+    const trace = tracy.trace(@src());
+    defer trace.end();
+
     _ = tuple;
     // Simplified implementation - create flex var for tuples
     return self.can_ir.pushFreshTypeVar(parent_node_idx, region) catch |err| exitOnOom(err);
@@ -4602,6 +4645,9 @@ fn canonicalizeTupleType(self: *Self, tuple: anytype, parent_node_idx: Node.Idx,
 
 /// Handle record types like { name: Str, age: Num }
 fn canonicalizeRecordType(self: *Self, record: anytype, parent_node_idx: Node.Idx, region: Region) std.mem.Allocator.Error!TypeVar {
+    const trace = tracy.trace(@src());
+    defer trace.end();
+
     // Create fresh type variables for each field
     var type_record_fields = std.ArrayList(types.RecordField).init(self.can_ir.env.gpa);
     defer type_record_fields.deinit();
@@ -4632,6 +4678,9 @@ fn canonicalizeRecordType(self: *Self, record: anytype, parent_node_idx: Node.Id
 
 /// Handle tag union types like [Some(a), None]
 fn canonicalizeTagUnionType(self: *Self, tag_union: anytype, parent_node_idx: Node.Idx, region: Region) TypeVar {
+    const trace = tracy.trace(@src());
+    defer trace.end();
+
     _ = tag_union;
     // Simplified implementation - create flex var for tag unions
     return self.can_ir.pushFreshTypeVar(parent_node_idx, region) catch |err| exitOnOom(err);
@@ -4639,12 +4688,18 @@ fn canonicalizeTagUnionType(self: *Self, tag_union: anytype, parent_node_idx: No
 
 /// Handle module-qualified types like Json.Decoder
 fn canonicalizeModuleType(self: *Self, mod_ty: anytype, parent_node_idx: Node.Idx, region: Region) TypeVar {
+    const trace = tracy.trace(@src());
+    defer trace.end();
+
     // Simplified implementation - create flex var for module types
     return self.can_ir.pushTypeVar(.{ .flex_var = mod_ty.ty_symbol }, parent_node_idx, region) catch |err| exitOnOom(err);
 }
 
 /// Create an annotation from a type annotation
 fn createAnnotationFromTypeAnno(self: *Self, type_anno_idx: CIR.TypeAnno.Idx, _: TypeVar, region: Region, parent_node_idx: Node.Idx) std.mem.Allocator.Error!?CIR.Annotation.Idx {
+    const trace = tracy.trace(@src());
+    defer trace.end();
+
     // Convert the type annotation to a type variable
     const signature = try self.canonicalizeTypeAnnoToTypeVar(type_anno_idx, parent_node_idx, region);
 
@@ -4735,6 +4790,9 @@ fn tryModuleQualifiedLookup(self: *Self, field_access: AST.BinOp) ?CIR.Expr.Idx 
 /// - `list.map(transform)` - calling a method with arguments
 /// - `result.isOk` - accessing a field that might be a function
 fn canonicalizeRegularFieldAccess(self: *Self, field_access: AST.BinOp) std.mem.Allocator.Error!?CIR.Expr.Idx {
+    const trace = tracy.trace(@src());
+    defer trace.end();
+
     // Canonicalize the receiver (left side of the dot)
     const receiver_idx = try self.canonicalizeFieldAccessReceiver(field_access) orelse return null;
 
@@ -4762,6 +4820,9 @@ fn canonicalizeRegularFieldAccess(self: *Self, field_access: AST.BinOp) std.mem.
 /// - In `getUser().email`, canonicalizes `getUser()`
 /// - In `[1,2,3].map(fn)`, canonicalizes `[1,2,3]`
 fn canonicalizeFieldAccessReceiver(self: *Self, field_access: AST.BinOp) std.mem.Allocator.Error!?CIR.Expr.Idx {
+    const trace = tracy.trace(@src());
+    defer trace.end();
+
     if (try self.canonicalize_expr(field_access.left)) |idx| {
         return idx;
     } else {

--- a/src/check/check_types.zig
+++ b/src/check/check_types.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const base = @import("../base.zig");
+const tracy = @import("../tracy.zig");
 const collections = @import("../collections.zig");
 const types_mod = @import("../types.zig");
 const can = @import("canonicalize.zig");
@@ -59,6 +60,9 @@ pub fn deinit(self: *Self) void {
 
 /// Unify two types
 pub fn unify(self: *Self, a: Var, b: Var) unifier.Result {
+    const trace = tracy.trace(@src());
+    defer trace.end();
+
     return unifier.unify(
         self.can_ir.env,
         self.types,
@@ -78,6 +82,9 @@ pub fn unify(self: *Self, a: Var, b: Var) unifier.Result {
 /// that  fails we do want to overwrite the builtin `Bool` type variable with
 /// an `.err`
 pub fn unifyPreserveA(self: *Self, a: Var, b: Var) unifier.Result {
+    const trace = tracy.trace(@src());
+    defer trace.end();
+
     return unifier.unifyMode(
         .preserve_a,
         self.can_ir.env,
@@ -93,6 +100,9 @@ pub fn unifyPreserveA(self: *Self, a: Var, b: Var) unifier.Result {
 
 /// Check the types for all defs
 pub fn checkDefs(self: *Self) std.mem.Allocator.Error!void {
+    const trace = tracy.trace(@src());
+    defer trace.end();
+
     const defs_slice = self.can_ir.store.sliceDefs(self.can_ir.all_defs);
     for (defs_slice) |def_idx| {
         try self.checkDef(def_idx);
@@ -101,6 +111,9 @@ pub fn checkDefs(self: *Self) std.mem.Allocator.Error!void {
 
 /// Check the types for a single definition
 fn checkDef(self: *Self, def_idx: CIR.Def.Idx) std.mem.Allocator.Error!void {
+    const trace = tracy.trace(@src());
+    defer trace.end();
+
     const def = self.can_ir.store.getDef(def_idx);
 
     try self.checkPattern(def.pattern);
@@ -137,6 +150,9 @@ fn checkDef(self: *Self, def_idx: CIR.Def.Idx) std.mem.Allocator.Error!void {
 
 /// Check the types for an exprexpression. Returns whether evaluating the expr might perform side effects.
 pub fn checkExpr(self: *Self, expr_idx: CIR.Expr.Idx) std.mem.Allocator.Error!bool {
+    const trace = tracy.trace(@src());
+    defer trace.end();
+
     const expr = self.can_ir.store.getExpr(expr_idx);
     var does_fx = false; // Does this expression potentially perform any side effects?
     switch (expr) {
@@ -448,6 +464,9 @@ pub fn checkExpr(self: *Self, expr_idx: CIR.Expr.Idx) std.mem.Allocator.Error!bo
 
 /// Check a lambda expression with an optional expected type
 fn checkLambdaWithExpected(self: *Self, expr_idx: CIR.Expr.Idx, lambda: anytype, expected_type: ?Var) std.mem.Allocator.Error!bool {
+    const trace = tracy.trace(@src());
+    defer trace.end();
+
     // Get the actual lambda arguments
     const arg_patterns = self.can_ir.store.slicePatterns(lambda.args);
 
@@ -498,6 +517,9 @@ fn checkLambdaWithExpected(self: *Self, expr_idx: CIR.Expr.Idx, lambda: anytype,
 
 /// Check the types for an if-else expr
 fn checkBinopExpr(self: *Self, expr_idx: CIR.Expr.Idx, binop: CIR.Expr.Binop) Allocator.Error!bool {
+    const trace = tracy.trace(@src());
+    defer trace.end();
+
     var does_fx = try self.checkExpr(binop.lhs);
     does_fx = try self.checkExpr(binop.rhs) or does_fx;
 
@@ -550,6 +572,9 @@ fn checkBinopExpr(self: *Self, expr_idx: CIR.Expr.Idx, binop: CIR.Expr.Binop) Al
 
 /// Check the types for an if-else expr
 fn checkIfElseExpr(self: *Self, if_expr_idx: CIR.Expr.Idx, if_: std.meta.FieldType(CIR.Expr, .e_if)) std.mem.Allocator.Error!bool {
+    const trace = tracy.trace(@src());
+    defer trace.end();
+
     const branches = self.can_ir.store.sliceIfBranches(if_.branches);
 
     // Should never be 0
@@ -634,6 +659,9 @@ fn checkIfElseExpr(self: *Self, if_expr_idx: CIR.Expr.Idx, if_: std.meta.FieldTy
 
 /// Check the types for an if-else expr
 fn checkMatchExpr(self: *Self, expr_idx: CIR.Expr.Idx, match: CIR.Expr.Match) Allocator.Error!bool {
+    const trace = tracy.trace(@src());
+    defer trace.end();
+
     // Check the match's condition
     var does_fx = try self.checkExpr(match.cond);
     const cond_var: Var = @enumFromInt(@intFromEnum(match.cond));
@@ -937,6 +965,9 @@ test "verify -128 produces 7 bits needed" {
 
 /// Check the types for the provided pattern
 pub fn checkPattern(self: *Self, pattern_idx: CIR.Pattern.Idx) std.mem.Allocator.Error!void {
+    const trace = tracy.trace(@src());
+    defer trace.end();
+
     _ = self;
     _ = pattern_idx;
 }

--- a/src/check/parse/Parser.zig
+++ b/src/check/parse/Parser.zig
@@ -219,6 +219,9 @@ pub fn parseFile(self: *Parser) void {
 ///
 /// Returns the ending position of the collection
 fn parseCollectionSpan(self: *Parser, comptime T: type, end_token: Token.Tag, scratch_fn: fn (*NodeStore, T) void, parser: fn (*Parser) T) ExpectError!u32 {
+    const trace = tracy.trace(@src());
+    defer trace.end();
+
     while (self.peek() != end_token and self.peek() != .EndOfFile) {
         scratch_fn(&self.store, parser(self));
         self.expect(.Comma) catch {
@@ -256,6 +259,9 @@ fn debugToken(self: *Parser, window: usize) void {
 /// package_entry :: LowerIdent Comma "platform"? String Comma
 /// app_header :: KwApp Newline* OpenSquare provides_entry* CloseSquare OpenCurly package_entry CloseCurly
 pub fn parseHeader(self: *Parser) AST.Header.Idx {
+    const trace = tracy.trace(@src());
+    defer trace.end();
+
     switch (self.peek()) {
         .KwApp => {
             return self.parseAppHeader();
@@ -290,6 +296,9 @@ pub fn parseHeader(self: *Parser) AST.Header.Idx {
 ///     imports []
 ///     provides [main_for_host]
 pub fn parsePlatformHeader(self: *Parser) AST.Header.Idx {
+    const trace = tracy.trace(@src());
+    defer trace.end();
+
     const start = self.pos;
     std.debug.assert(self.peek() == .KwPlatform);
     self.advance(); // Advance past KwPlatform
@@ -523,6 +532,9 @@ pub fn parsePlatformHeader(self: *Parser) AST.Header.Idx {
 ///
 /// e.g. `package [ foo ] { something: "package/path/main.roc" }`
 pub fn parsePackageHeader(self: *Parser) AST.Header.Idx {
+    const trace = tracy.trace(@src());
+    defer trace.end();
+
     const start = self.pos;
 
     std.debug.assert(self.peek() == .KwPackage);
@@ -587,6 +599,9 @@ pub fn parsePackageHeader(self: *Parser) AST.Header.Idx {
 ///
 /// e.g. `hosted [foo]`
 fn parseHostedHeader(self: *Parser) AST.Header.Idx {
+    const trace = tracy.trace(@src());
+    defer trace.end();
+
     std.debug.assert(self.peek() == .KwHosted);
 
     const start = self.pos;
@@ -628,6 +643,9 @@ fn parseHostedHeader(self: *Parser) AST.Header.Idx {
 ///
 /// e.g. `module [foo]`
 fn parseModuleHeader(self: *Parser) AST.Header.Idx {
+    const trace = tracy.trace(@src());
+    defer trace.end();
+
     std.debug.assert(self.peek() == .KwModule);
 
     const start = self.pos;
@@ -669,6 +687,9 @@ fn parseModuleHeader(self: *Parser) AST.Header.Idx {
 ///
 /// e.g. `app [main!] { pf: "../some-platform.roc" }`
 pub fn parseAppHeader(self: *Parser) AST.Header.Idx {
+    const trace = tracy.trace(@src());
+    defer trace.end();
+
     var platform: ?AST.RecordField.Idx = null;
     const start = self.pos;
 
@@ -792,6 +813,9 @@ pub fn parseAppHeader(self: *Parser) AST.Header.Idx {
 
 /// Parses an ExposedItem, adding it to the NodeStore and returning the Idx
 pub fn parseExposedItem(self: *Parser) AST.ExposedItem.Idx {
+    const trace = tracy.trace(@src());
+    defer trace.end();
+
     const start = self.pos;
     var end = start;
     switch (self.peek()) {
@@ -856,6 +880,9 @@ const StatementType = enum { top_level, in_body };
 ///
 /// e.g. `import Foo`
 pub fn parseTopLevelStatement(self: *Parser) ?AST.Statement.Idx {
+    const trace = tracy.trace(@src());
+    defer trace.end();
+
     return self.parseStmtByType(.top_level);
 }
 
@@ -863,6 +890,9 @@ pub fn parseTopLevelStatement(self: *Parser) ?AST.Statement.Idx {
 ///
 /// e.g. `foo = 2 + x`
 pub fn parseStmt(self: *Parser) ?AST.Statement.Idx {
+    const trace = tracy.trace(@src());
+    defer trace.end();
+
     return self.parseStmtByType(.in_body);
 }
 
@@ -870,6 +900,9 @@ pub fn parseStmt(self: *Parser) ?AST.Statement.Idx {
 ///
 /// e.g. `import Foo`, or `foo = 2 + x`
 fn parseStmtByType(self: *Parser, statementType: StatementType) ?AST.Statement.Idx {
+    const trace = tracy.trace(@src());
+    defer trace.end();
+
     switch (self.peek()) {
         .KwImport => {
             if (statementType != .top_level) {
@@ -1130,6 +1163,9 @@ fn parseStmtByType(self: *Parser, statementType: StatementType) ?AST.Statement.I
 }
 
 fn parseWhereConstraint(self: *Parser) ?AST.Collection.Idx {
+    const trace = tracy.trace(@src());
+    defer trace.end();
+
     self.expect(.KwWhere) catch {
         return null;
     };
@@ -1165,6 +1201,9 @@ const Alternatives = enum {
 
 /// todo -- what does this do?
 pub fn parsePattern(self: *Parser, alternatives: Alternatives) AST.Pattern.Idx {
+    const trace = tracy.trace(@src());
+    defer trace.end();
+
     const outer_start = self.pos;
     const patterns_scratch_top = self.store.scratchPatternTop();
     errdefer self.store.clearScratchPatternsFrom(patterns_scratch_top);
@@ -1406,6 +1445,9 @@ pub fn parsePattern(self: *Parser, alternatives: Alternatives) AST.Pattern.Idx {
 }
 
 fn parseAsPattern(self: *Parser, pattern: AST.Pattern.Idx) AST.Pattern.Idx {
+    const trace = tracy.trace(@src());
+    defer trace.end();
+
     if (self.peek() != .KwAs) {
         return pattern;
     }
@@ -1425,14 +1467,23 @@ fn parseAsPattern(self: *Parser, pattern: AST.Pattern.Idx) AST.Pattern.Idx {
 }
 
 fn parsePatternNoAlts(self: *Parser) AST.Pattern.Idx {
+    const trace = tracy.trace(@src());
+    defer trace.end();
+
     return self.parsePattern(.alternatives_forbidden);
 }
 fn parsePatternWithAlts(self: *Parser) AST.Pattern.Idx {
+    const trace = tracy.trace(@src());
+    defer trace.end();
+
     return self.parsePattern(.alternatives_allowed);
 }
 
 /// todo
 pub fn parsePatternRecordField(self: *Parser, alternatives: Alternatives) AST.PatternRecordField.Idx {
+    const trace = tracy.trace(@src());
+    defer trace.end();
+
     const field_start = self.pos;
     if (self.peek() == .DoubleDot) {
         self.advance();
@@ -1485,11 +1536,17 @@ pub fn parsePatternRecordField(self: *Parser, alternatives: Alternatives) AST.Pa
 
 /// todo
 pub fn parseExpr(self: *Parser) AST.Expr.Idx {
+    const trace = tracy.trace(@src());
+    defer trace.end();
+
     return self.parseExprWithBp(0);
 }
 
 /// todo
 pub fn parseExprWithBp(self: *Parser, min_bp: u8) AST.Expr.Idx {
+    const trace = tracy.trace(@src());
+    defer trace.end();
+
     const start = self.pos;
     var expr: ?AST.Expr.Idx = null;
     const token = self.peek();
@@ -1909,6 +1966,9 @@ pub fn parseExprWithBp(self: *Parser, min_bp: u8) AST.Expr.Idx {
 
 /// todo
 fn parseExprSuffix(self: *Parser, start: u32, e: AST.Expr.Idx) AST.Expr.Idx {
+    const trace = tracy.trace(@src());
+    defer trace.end();
+
     var expression = e;
     // Check for an apply...
     if (self.peek() == .NoSpaceOpenRound) {
@@ -1939,6 +1999,9 @@ fn parseExprSuffix(self: *Parser, start: u32, e: AST.Expr.Idx) AST.Expr.Idx {
 
 /// todo
 pub fn parseRecordField(self: *Parser) AST.RecordField.Idx {
+    const trace = tracy.trace(@src());
+    defer trace.end();
+
     const start = self.pos;
     self.expect(.LowerIdent) catch {
         return self.pushMalformed(AST.RecordField.Idx, .expected_expr_record_field_name, start);
@@ -1960,6 +2023,9 @@ pub fn parseRecordField(self: *Parser) AST.RecordField.Idx {
 
 /// todo
 pub fn parseBranch(self: *Parser) AST.MatchBranch.Idx {
+    const trace = tracy.trace(@src());
+    defer trace.end();
+
     const start = self.pos;
     const p = self.parsePattern(.alternatives_allowed);
     if (self.peek() == .OpFatArrow) {
@@ -1975,6 +2041,9 @@ pub fn parseBranch(self: *Parser) AST.MatchBranch.Idx {
 
 /// todo
 pub fn parseStringExpr(self: *Parser) AST.Expr.Idx {
+    const trace = tracy.trace(@src());
+    defer trace.end();
+
     std.debug.assert(self.peek() == .StringStart);
     const start = self.pos;
     // Start parsing string with possible interpolations
@@ -2032,6 +2101,9 @@ pub fn parseStringExpr(self: *Parser) AST.Expr.Idx {
 
 /// todo
 pub fn parseStringPattern(self: *Parser) AST.Pattern.Idx {
+    const trace = tracy.trace(@src());
+    defer trace.end();
+
     const start = self.pos;
     const inner = parseStringExpr(self);
     const patt_idx = self.store.addPattern(.{ .string = .{
@@ -2044,6 +2116,9 @@ pub fn parseStringPattern(self: *Parser) AST.Pattern.Idx {
 
 /// todo
 pub fn parseTypeHeader(self: *Parser) AST.TypeHeader.Idx {
+    const trace = tracy.trace(@src());
+    defer trace.end();
+
     const start = self.pos;
     std.debug.assert(self.peek() == .UpperIdent);
     self.advance(); // Advance past UpperIdent
@@ -2072,6 +2147,9 @@ pub fn parseTypeHeader(self: *Parser) AST.TypeHeader.Idx {
 }
 
 fn parseTypeIdent(self: *Parser) AST.TypeAnno.Idx {
+    const trace = tracy.trace(@src());
+    defer trace.end();
+
     if (self.peek() == .LowerIdent) {
         const tok = self.pos;
         self.advance();
@@ -2090,6 +2168,9 @@ const TyFnArgs = enum {
 
 /// Parse a type annotation, e.g. `Foo(a) : (a,Str,I64)`
 pub fn parseTypeAnno(self: *Parser, looking_for_args: TyFnArgs) AST.TypeAnno.Idx {
+    const trace = tracy.trace(@src());
+    defer trace.end();
+
     const start = self.pos;
     var anno: ?AST.TypeAnno.Idx = null;
 
@@ -2264,11 +2345,17 @@ pub fn parseTypeAnno(self: *Parser, looking_for_args: TyFnArgs) AST.TypeAnno.Idx
 
 /// todo
 pub fn parseTypeAnnoInCollection(self: *Parser) AST.TypeAnno.Idx {
+    const trace = tracy.trace(@src());
+    defer trace.end();
+
     return self.parseTypeAnno(.looking_for_args);
 }
 
 /// todo
 pub fn parseAnnoRecordField(self: *Parser) AST.AnnoRecordField.Idx {
+    const trace = tracy.trace(@src());
+    defer trace.end();
+
     const field_start = self.pos;
     if (self.peek() != .LowerIdent) {
         while (self.peek() != .CloseCurly and self.peek() != .Comma and self.peek() != .EndOfFile) {
@@ -2300,6 +2387,9 @@ pub fn parseAnnoRecordField(self: *Parser) AST.AnnoRecordField.Idx {
 /// e.g. `hasher.Hasher`
 /// e.g. `module(a).decode(List(U8)) -> a`
 pub fn parseWhereClause(self: *Parser) AST.WhereClause.Idx {
+    const trace = tracy.trace(@src());
+    defer trace.end();
+
     const start = self.pos;
     if (self.peek() == .KwModule) {
         // Parsing a mod_method clause

--- a/src/coordinate_simple.zig
+++ b/src/coordinate_simple.zig
@@ -2,6 +2,7 @@
 
 const std = @import("std");
 const base = @import("base.zig");
+const tracy = @import("tracy.zig");
 const parse = @import("check/parse.zig");
 const canonicalize = @import("check/canonicalize.zig");
 const Solver = @import("check/check_types.zig");
@@ -48,6 +49,9 @@ pub fn processFile(
     fs: Filesystem,
     filepath: []const u8,
 ) !ProcessResult {
+    const trace = tracy.trace(@src());
+    defer trace.end();
+
     // Read the file content
     const source = fs.readFile(filepath, gpa) catch |err| switch (err) {
         error.FileNotFound => return error.FileNotFound,
@@ -88,6 +92,9 @@ fn processSourceInternal(
     filename: []const u8,
     take_ownership: bool,
 ) !ProcessResult {
+    const trace = tracy.trace(@src());
+    defer trace.end();
+
     // Initialize the ModuleEnv
     var module_env = ModuleEnv.init(gpa);
     defer module_env.deinit();

--- a/src/main.zig
+++ b/src/main.zig
@@ -101,6 +101,9 @@ fn rocRepl(gpa: Allocator) !void {
 /// Reads, parses, formats, and overwrites all Roc files at the given paths.
 /// Recurses into directories to search for Roc files.
 fn rocFormat(gpa: Allocator, arena: Allocator, args: cli_args.FormatArgs) !void {
+    const trace = tracy.trace(@src());
+    defer trace.end();
+
     var timer = try std.time.Timer.start();
     var count = fmt.SuccessFailCount{ .success = 0, .failure = 0 };
     for (args.paths) |path| {
@@ -130,6 +133,9 @@ fn formatElapsedTime(writer: anytype, elapsed_ns: u64) !void {
 }
 
 fn rocCheck(gpa: Allocator, args: cli_args.CheckArgs) !void {
+    const trace = tracy.trace(@src());
+    defer trace.end();
+
     const stdout = std.io.getStdOut().writer();
     const stderr = std.io.getStdErr().writer();
     const stderr_writer = stderr.any();


### PR DESCRIPTION
Just trying to trace all the core things. This gives us a much clearer view of performance and where time is spent. As long as allocation tracking is off, this tracing should be light weight enough to be reasonable.