### PR TITLE
Canonicalize tuple type annotations & reduce allocations

### DIFF
--- a/src/check/canonicalize.zig
+++ b/src/check/canonicalize.zig
@@ -4753,6 +4753,7 @@ fn canonicalizeBasicType(self: *Self, symbol: Ident.Idx, parent_node_idx: Node.I
     const name = self.can_ir.env.idents.getText(symbol);
 
     // Built-in types mapping
+    // TODO: Once these are brought into scope from builtins, we can deleted most of this
     if (std.mem.eql(u8, name, "Bool")) {
         return self.can_ir.pushTypeVar(.{ .flex_var = symbol }, parent_node_idx, region) catch |err| exitOnOom(err);
     } else if (std.mem.eql(u8, name, "Str")) {
@@ -4766,31 +4767,31 @@ fn canonicalizeBasicType(self: *Self, symbol: Ident.Idx, parent_node_idx: Node.I
         };
         return self.can_ir.pushTypeVar(.{ .structure = .{ .num = .{ .num_poly = .{ .var_ = num_var, .requirements = num_requirements } } } }, parent_node_idx, region) catch |err| exitOnOom(err);
     } else if (std.mem.eql(u8, name, "U8")) {
-        return self.can_ir.pushTypeVar(.{ .structure = .{ .num = .{ .num_compact = .{ .int = .u8 } } } }, parent_node_idx, region) catch |err| exitOnOom(err);
+        return self.can_ir.pushTypeVar(.{ .structure = .{ .num = types.Num.int_u8 } }, parent_node_idx, region) catch |err| exitOnOom(err);
     } else if (std.mem.eql(u8, name, "U16")) {
-        return self.can_ir.pushTypeVar(.{ .structure = .{ .num = .{ .num_compact = .{ .int = .u16 } } } }, parent_node_idx, region) catch |err| exitOnOom(err);
+        return self.can_ir.pushTypeVar(.{ .structure = .{ .num = types.Num.int_u16 } }, parent_node_idx, region) catch |err| exitOnOom(err);
     } else if (std.mem.eql(u8, name, "U32")) {
-        return self.can_ir.pushTypeVar(.{ .structure = .{ .num = .{ .num_compact = .{ .int = .u32 } } } }, parent_node_idx, region) catch |err| exitOnOom(err);
+        return self.can_ir.pushTypeVar(.{ .structure = .{ .num = types.Num.int_u32 } }, parent_node_idx, region) catch |err| exitOnOom(err);
     } else if (std.mem.eql(u8, name, "U64")) {
-        return self.can_ir.pushTypeVar(.{ .structure = .{ .num = .{ .num_compact = .{ .int = .u64 } } } }, parent_node_idx, region) catch |err| exitOnOom(err);
+        return self.can_ir.pushTypeVar(.{ .structure = .{ .num = types.Num.int_u64 } }, parent_node_idx, region) catch |err| exitOnOom(err);
     } else if (std.mem.eql(u8, name, "U128")) {
-        return self.can_ir.pushTypeVar(.{ .structure = .{ .num = .{ .num_compact = .{ .int = .u128 } } } }, parent_node_idx, region) catch |err| exitOnOom(err);
+        return self.can_ir.pushTypeVar(.{ .structure = .{ .num = types.Num.int_u128 } }, parent_node_idx, region) catch |err| exitOnOom(err);
     } else if (std.mem.eql(u8, name, "I8")) {
-        return self.can_ir.pushTypeVar(.{ .structure = .{ .num = .{ .num_compact = .{ .int = .i8 } } } }, parent_node_idx, region) catch |err| exitOnOom(err);
+        return self.can_ir.pushTypeVar(.{ .structure = .{ .num = types.Num.int_i8 } }, parent_node_idx, region) catch |err| exitOnOom(err);
     } else if (std.mem.eql(u8, name, "I16")) {
-        return self.can_ir.pushTypeVar(.{ .structure = .{ .num = .{ .num_compact = .{ .int = .i16 } } } }, parent_node_idx, region) catch |err| exitOnOom(err);
+        return self.can_ir.pushTypeVar(.{ .structure = .{ .num = types.Num.int_i16 } }, parent_node_idx, region) catch |err| exitOnOom(err);
     } else if (std.mem.eql(u8, name, "I32")) {
-        return self.can_ir.pushTypeVar(.{ .structure = .{ .num = .{ .num_compact = .{ .int = .i32 } } } }, parent_node_idx, region) catch |err| exitOnOom(err);
+        return self.can_ir.pushTypeVar(.{ .structure = .{ .num = types.Num.int_i32 } }, parent_node_idx, region) catch |err| exitOnOom(err);
     } else if (std.mem.eql(u8, name, "I64")) {
-        return self.can_ir.pushTypeVar(.{ .structure = .{ .num = .{ .num_compact = .{ .int = .i64 } } } }, parent_node_idx, region) catch |err| exitOnOom(err);
+        return self.can_ir.pushTypeVar(.{ .structure = .{ .num = types.Num.int_i64 } }, parent_node_idx, region) catch |err| exitOnOom(err);
     } else if (std.mem.eql(u8, name, "I128")) {
-        return self.can_ir.pushTypeVar(.{ .structure = .{ .num = .{ .num_compact = .{ .int = .i128 } } } }, parent_node_idx, region) catch |err| exitOnOom(err);
+        return self.can_ir.pushTypeVar(.{ .structure = .{ .num = types.Num.int_i128 } }, parent_node_idx, region) catch |err| exitOnOom(err);
     } else if (std.mem.eql(u8, name, "F32")) {
-        return self.can_ir.pushTypeVar(.{ .structure = .{ .num = .{ .num_compact = .{ .frac = .f32 } } } }, parent_node_idx, region) catch |err| exitOnOom(err);
+        return self.can_ir.pushTypeVar(.{ .structure = .{ .num = types.Num.frac_f32 } }, parent_node_idx, region) catch |err| exitOnOom(err);
     } else if (std.mem.eql(u8, name, "F64")) {
-        return self.can_ir.pushTypeVar(.{ .structure = .{ .num = .{ .num_compact = .{ .frac = .f64 } } } }, parent_node_idx, region) catch |err| exitOnOom(err);
+        return self.can_ir.pushTypeVar(.{ .structure = .{ .num = types.Num.frac_f64 } }, parent_node_idx, region) catch |err| exitOnOom(err);
     } else if (std.mem.eql(u8, name, "Dec")) {
-        return self.can_ir.pushTypeVar(.{ .structure = .{ .num = .{ .num_compact = .{ .frac = .dec } } } }, parent_node_idx, region) catch |err| exitOnOom(err);
+        return self.can_ir.pushTypeVar(.{ .structure = .{ .num = types.Num.frac_dec } }, parent_node_idx, region) catch |err| exitOnOom(err);
     } else {
         // Look up user-defined type in scope
         const scope = self.currentScope();
@@ -4809,7 +4810,7 @@ fn canonicalizeBasicType(self: *Self, symbol: Ident.Idx, parent_node_idx: Node.I
 }
 
 /// Handle type applications like List(Str), Dict(k, v)
-fn canonicalizeTypeApplication(self: *Self, apply: anytype, parent_node_idx: Node.Idx, region: Region) std.mem.Allocator.Error!TypeVar {
+fn canonicalizeTypeApplication(self: *Self, apply: CIR.TypeAnno.Apply, parent_node_idx: Node.Idx, region: Region) std.mem.Allocator.Error!TypeVar {
     const trace = tracy.trace(@src());
     defer trace.end();
 
@@ -4876,7 +4877,7 @@ fn canonicalizeTypeApplication(self: *Self, apply: anytype, parent_node_idx: Nod
 }
 
 /// Handle function types like a -> b
-fn canonicalizeFunctionType(self: *Self, func: anytype, parent_node_idx: Node.Idx, region: Region) std.mem.Allocator.Error!TypeVar {
+fn canonicalizeFunctionType(self: *Self, func: CIR.TypeAnno.Func, parent_node_idx: Node.Idx, region: Region) std.mem.Allocator.Error!TypeVar {
     const trace = tracy.trace(@src());
     defer trace.end();
 
@@ -4937,7 +4938,7 @@ fn canonicalizeTupleType(self: *Self, tuple: CIR.TypeAnno.Tuple, parent_node_idx
 }
 
 /// Handle record types like { name: Str, age: Num }
-fn canonicalizeRecordType(self: *Self, record: anytype, parent_node_idx: Node.Idx, region: Region) std.mem.Allocator.Error!TypeVar {
+fn canonicalizeRecordType(self: *Self, record: CIR.TypeAnno.Record, parent_node_idx: Node.Idx, region: Region) std.mem.Allocator.Error!TypeVar {
     const trace = tracy.trace(@src());
     defer trace.end();
 

--- a/src/check/canonicalize/CIR.zig
+++ b/src/check/canonicalize/CIR.zig
@@ -131,7 +131,7 @@ pub fn pushMalformed(self: *CIR, comptime t: type, reason: CIR.Diagnostic) t {
 pub fn getDiagnostics(self: *CIR) []CIR.Diagnostic {
     const all = self.store.diagnosticSpanFrom(0);
 
-    var list = std.ArrayList(CIR.Diagnostic).init(self.env.gpa);
+    var list = std.ArrayList(CIR.Diagnostic).init(self.store.gpa);
 
     for (self.store.sliceDiagnostics(all)) |idx| {
         list.append(self.store.getDiagnostic(idx)) catch |err| exitOnOom(err);

--- a/src/check/canonicalize/NodeStore.zig
+++ b/src/check/canonicalize/NodeStore.zig
@@ -943,11 +943,11 @@ pub fn getTypeAnno(store: *const NodeStore, typeAnno: CIR.TypeAnno.Idx) CIR.Type
         } },
         .ty_tag_union => return CIR.TypeAnno{ .tag_union = .{
             .tags = .{ .span = .{ .start = node.data_1, .len = node.data_2 } },
-            .open_anno = if (node.data_3 != 0) @enumFromInt(node.data_3) else null,
+            .ext = if (node.data_3 != 0) @enumFromInt(node.data_3) else null,
             .region = store.getRegionAt(node_idx),
         } },
         .ty_tuple => return CIR.TypeAnno{ .tuple = .{
-            .annos = .{ .span = .{ .start = node.data_1, .len = node.data_2 } },
+            .elems = .{ .span = .{ .start = node.data_1, .len = node.data_2 } },
             .region = store.getRegionAt(node_idx),
         } },
         .ty_record => return CIR.TypeAnno{ .record = .{
@@ -1783,13 +1783,13 @@ pub fn addTypeAnno(store: *NodeStore, typeAnno: CIR.TypeAnno) CIR.TypeAnno.Idx {
             region = tu.region;
             node.data_1 = tu.tags.span.start;
             node.data_2 = tu.tags.span.len;
-            node.data_3 = if (tu.open_anno) |open| @intFromEnum(open) else 0;
+            node.data_3 = if (tu.ext) |open| @intFromEnum(open) else 0;
             node.tag = .ty_tag_union;
         },
         .tuple => |t| {
             region = t.region;
-            node.data_1 = t.annos.span.start;
-            node.data_2 = t.annos.span.len;
+            node.data_1 = t.elems.span.start;
+            node.data_2 = t.elems.span.len;
             node.tag = .ty_tuple;
         },
         .record => |r| {

--- a/src/check/canonicalize/TypeAnnotation.zig
+++ b/src/check/canonicalize/TypeAnnotation.zig
@@ -57,10 +57,7 @@ pub const TypeAnno = union(enum) {
     /// Tuple type: a fixed-size collection of heterogeneous types.
     ///
     /// Examples: `(Str, U64)`, `(a, b, c)`
-    tuple: struct {
-        annos: TypeAnno.Span, // The types of each tuple element
-        region: Region,
-    },
+    tuple: Tuple,
     /// Record type: a collection of named fields with their types.
     ///
     /// Examples: `{ name: Str, age: U64 }`, `{ x: F64, y: F64 }`
@@ -148,7 +145,7 @@ pub const TypeAnno = union(enum) {
                     node.appendNode(gpa, &tag_node);
                 }
 
-                if (tu.open_anno) |open_idx| {
+                if (tu.ext) |open_idx| {
                     const open_anno = ir.store.getTypeAnno(open_idx);
                     var open_node = open_anno.toSExpr(ir);
                     node.appendNode(gpa, &open_node);
@@ -160,7 +157,7 @@ pub const TypeAnno = union(enum) {
                 var node = SExpr.init(gpa, "ty-tuple");
                 ir.appendRegionInfoToSexprNodeFromRegion(&node, tup.region);
 
-                const annos_slice = ir.store.sliceTypeAnnos(tup.annos);
+                const annos_slice = ir.store.sliceTypeAnnos(tup.elems);
                 for (annos_slice) |anno_idx| {
                     const anno = ir.store.getTypeAnno(anno_idx);
                     var anno_node = anno.toSExpr(ir);
@@ -260,10 +257,16 @@ pub const TypeAnno = union(enum) {
         pub const Span = struct { span: DataSpan };
     };
 
-    /// A tag union in a type annotatino
+    /// A tag union in a type annotation
     pub const TagUnion = struct {
         tags: TypeAnno.Span, // The individual tags in the union
-        open_anno: ?TypeAnno.Idx, // Optional extension variable for open unions
+        ext: ?TypeAnno.Idx, // Optional extension variable for open unions
+        region: Region,
+    };
+
+    /// A tuple in a type annotation
+    pub const Tuple = struct {
+        elems: TypeAnno.Span, // The types of each tuple element
         region: Region,
     };
 };

--- a/src/check/canonicalize/TypeAnnotation.zig
+++ b/src/check/canonicalize/TypeAnnotation.zig
@@ -27,11 +27,7 @@ pub const TypeAnno = union(enum) {
     /// Type application: applying a type constructor to arguments.
     ///
     /// Examples: `List(Str)`, `Dict(String, Int)`, `Result(a, b)`
-    apply: struct {
-        symbol: Ident.Idx, // The type constructor being applied (e.g., "List", "Dict")
-        args: TypeAnno.Span, // The type arguments (e.g., [Str], [String, Int])
-        region: Region,
-    },
+    apply: Apply,
     /// Type variable: a placeholder type that can be unified with other types.
     ///
     /// Examples: `a`, `b`, `elem` in generic type signatures
@@ -61,19 +57,11 @@ pub const TypeAnno = union(enum) {
     /// Record type: a collection of named fields with their types.
     ///
     /// Examples: `{ name: Str, age: U64 }`, `{ x: F64, y: F64 }`
-    record: struct {
-        fields: RecordField.Span, // The field definitions
-        region: Region,
-    },
+    record: Record,
     /// Function type: represents function signatures.
     ///
     /// Examples: `a -> b`, `Str, U64 -> Str`, `{} => Str`
-    @"fn": struct {
-        args: TypeAnno.Span, // Argument types
-        ret: TypeAnno.Idx, // Return type
-        effectful: bool, // Whether the function can perform effects, i.e. uses fat arrow `=>`
-        region: Region,
-    },
+    @"fn": Func,
     /// Parenthesized type: used for grouping and precedence.
     ///
     /// Examples: `(a -> b)` in `a, (a -> b) -> b`
@@ -255,6 +243,27 @@ pub const TypeAnno = union(enum) {
 
         pub const Idx = enum(u32) { _ };
         pub const Span = struct { span: DataSpan };
+    };
+
+    /// A type application in a type annotation
+    pub const Apply = struct {
+        symbol: Ident.Idx, // The type constructor being applied (e.g., "List", "Dict")
+        args: TypeAnno.Span, // The type arguments (e.g., [Str], [String, Int])
+        region: Region,
+    };
+
+    /// A func in a type annotation
+    pub const Func = struct {
+        args: TypeAnno.Span, // Argument types
+        ret: TypeAnno.Idx, // Return type
+        effectful: bool, // Whether the function can perform effects, i.e. uses fat arrow `=>`
+        region: Region,
+    };
+
+    /// A record in a type annotation
+    pub const Record = struct {
+        fields: RecordField.Span, // The field definitions
+        region: Region,
     };
 
     /// A tag union in a type annotation

--- a/src/check/canonicalize/test/node_store_test.zig
+++ b/src/check/canonicalize/test/node_store_test.zig
@@ -629,14 +629,14 @@ test "NodeStore round trip - TypeAnno" {
     try type_annos.append(CIR.TypeAnno{
         .tag_union = .{
             .tags = CIR.TypeAnno.Span{ .span = base.DataSpan.init(678, 890) },
-            .open_anno = @enumFromInt(901),
+            .ext = @enumFromInt(901),
             .region = from_raw_offsets(110, 120),
         },
     });
 
     try type_annos.append(CIR.TypeAnno{
         .tuple = .{
-            .annos = CIR.TypeAnno.Span{ .span = base.DataSpan.init(1012, 1234) },
+            .elems = CIR.TypeAnno.Span{ .span = base.DataSpan.init(1012, 1234) },
             .region = from_raw_offsets(130, 140),
         },
     });

--- a/src/snapshots/rigid_var_no_instantiation_error.md
+++ b/src/snapshots/rigid_var_no_instantiation_error.md
@@ -349,9 +349,9 @@ main! = |_| {
 ~~~clojure
 (inferred-types
 	(defs
-		(patt @5.1-5.5 (type "* -> (Error, Error)"))
+		(patt @5.1-5.5 (type "(a, b) -> (Error, Error)"))
 		(patt @11.1-11.6 (type "* -> {}")))
 	(expressions
-		(expr @5.8-8.2 (type "* -> (Error, Error)"))
+		(expr @5.8-8.2 (type "(a, b) -> (Error, Error)"))
 		(expr @11.9-24.2 (type "* -> {}"))))
 ~~~

--- a/src/snapshots/test_tuple_instantiation_crash.md
+++ b/src/snapshots/test_tuple_instantiation_crash.md
@@ -27,7 +27,7 @@ main = swap(1, 2)
        ^^^^
 
 It is of type:
-    _(*, *) -> (*, *)_
+    _(a, b) -> (b, a)_
 
 But you are trying to use it as:
     _Num(*), Num(*) -> *_

--- a/src/snapshots/type_two_variables.md
+++ b/src/snapshots/type_two_variables.md
@@ -105,9 +105,9 @@ NO CHANGE
 ~~~clojure
 (inferred-types
 	(defs
-		(patt @4.1-4.5 (type "(*, *) -> (*, *)"))
+		(patt @4.1-4.5 (type "(a, b) -> (b, a)"))
 		(patt @6.1-6.6 (type "* -> {}")))
 	(expressions
-		(expr @4.8-4.23 (type "(*, *) -> (*, *)"))
+		(expr @4.8-4.23 (type "(a, b) -> (b, a)"))
 		(expr @6.9-6.15 (type "* -> {}"))))
 ~~~

--- a/src/snapshots/type_var_multiple.md
+++ b/src/snapshots/type_var_multiple.md
@@ -192,9 +192,9 @@ main! = |_| {}
 ~~~clojure
 (inferred-types
 	(defs
-		(patt @5.1-5.5 (type "* -> (Error, Error)"))
+		(patt @5.1-5.5 (type "(a, b) -> (Error, Error)"))
 		(patt @10.1-10.6 (type "* -> {}")))
 	(expressions
-		(expr @5.8-8.2 (type "* -> (Error, Error)"))
+		(expr @5.8-8.2 (type "(a, b) -> (Error, Error)"))
 		(expr @10.9-10.15 (type "* -> {}"))))
 ~~~


### PR DESCRIPTION
* Canonicalized tuple type annotations
* Remove ad-hoc allocations in Can by moving into reusable scratch buffers
