### PR TITLE
Re-use `line_starts` to save on memory

### DIFF
--- a/src/coordinate_simple.zig
+++ b/src/coordinate_simple.zig
@@ -172,7 +172,7 @@ fn processSourceInternal(
 
     // Get parser diagnostic Reports
     for (parse_ast.parse_diagnostics.items) |diagnostic| {
-        const report = parse_ast.parseDiagnosticToReport(diagnostic, gpa, "<source>") catch continue;
+        const report = parse_ast.parseDiagnosticToReport(module_env, diagnostic, gpa, "<source>") catch continue;
         reports.append(report) catch continue;
     }
 

--- a/src/snapshot.zig
+++ b/src/snapshot.zig
@@ -1014,7 +1014,7 @@ fn generateProblemsSection(output: *DualOutput, parse_ast: *AST, can_ir: *CIR, s
     // Parser Diagnostics
     for (parse_ast.parse_diagnostics.items) |diagnostic| {
         parser_problems += 1;
-        var report: reporting.Report = parse_ast.parseDiagnosticToReport(diagnostic, output.gpa, snapshot_path) catch |err| {
+        var report: reporting.Report = parse_ast.parseDiagnosticToReport(module_env, diagnostic, output.gpa, snapshot_path) catch |err| {
             try output.md_writer.print("Error creating parse report: {}\n", .{err});
             if (output.html_writer) |writer| {
                 try writer.print("                    <p>Error creating parse report: {}</p>\n", .{err});


### PR DESCRIPTION
This improved the runtime for my `New-List-Cutoff_10MB.roc` from 23s down to 7.8s before it crashes, and reduces the memory used by approximately x30.