### PR TITLE
Accept both arrows in match branches but push diagnostic if not fat arrow

### DIFF
--- a/src/check/parse/AST.zig
+++ b/src/check/parse/AST.zig
@@ -518,6 +518,9 @@ pub fn parseDiagnosticToReport(self: *AST, env: *base.ModuleEnv, diagnostic: Dia
             try report.document.addIndent(1);
             try report.document.addCodeBlock("module(a).method : a -> b");
         },
+        .match_branch_wrong_arrow => {
+            try report.document.addReflowingText("Match branches use `=>` instead of `->`.");
+        },
         else => {
             const tag_name = @tagName(diagnostic.tag);
             const owned_tag = try report.addOwnedString(tag_name);
@@ -646,6 +649,7 @@ pub const Diagnostic = struct {
         var_must_have_ident,
         var_expected_equals,
         for_expected_in,
+        match_branch_wrong_arrow,
     };
 };
 

--- a/src/check/parse/Parser.zig
+++ b/src/check/parse/Parser.zig
@@ -68,7 +68,7 @@ fn test_parser(source: []const u8, run: fn (parser: Parser) TestError!void) Test
 
 /// helper to advance the parser until a non-newline token is encountered
 pub fn advance(self: *Parser) void {
-    while (true and self.peek() != .EndOfFile) {
+    while (self.peek() != .EndOfFile) {
         self.pos += 1;
         if (self.peek() != .Newline) {
             break;
@@ -2238,6 +2238,14 @@ pub fn parseBranch(self: *Parser) AST.MatchBranch.Idx {
     const start = self.pos;
     const p = self.parsePattern(.alternatives_allowed);
     if (self.peek() == .OpFatArrow) {
+        self.advance();
+    } else if (self.peek() == .OpArrow) {
+        // Add diagnostic for wrong arrow
+        self.pushDiagnostic(.match_branch_wrong_arrow, .{
+            .start = self.pos,
+            .end = self.pos,
+        });
+
         self.advance();
     }
     const b = self.parseExpr();

--- a/src/snapshots/match_expr/wrong_arrow.md
+++ b/src/snapshots/match_expr/wrong_arrow.md
@@ -1,0 +1,113 @@
+# META
+~~~ini
+description=Match expression with empty list pattern followed by list rest pattern (segfault regression test)
+type=expr
+~~~
+# SOURCE
+~~~roc
+match l {
+    [] -> Err(EmptyList)
+    [.., e] -> Ok(e)
+}
+~~~
+# EXPECTED
+UNDEFINED VARIABLE - empty_list_before_rest_pattern.md:1:7:1:8
+# PROBLEMS
+**PARSE ERROR**
+Match branches use `=>` instead of `->`.
+
+Here is the problematic code:
+**wrong_arrow.md:2:8:2:10:**
+```roc
+    [] -> Err(EmptyList)
+```
+       ^^
+
+
+**PARSE ERROR**
+Match branches use `=>` instead of `->`.
+
+Here is the problematic code:
+**wrong_arrow.md:3:13:3:15:**
+```roc
+    [.., e] -> Ok(e)
+```
+            ^^
+
+
+**UNDEFINED VARIABLE**
+Nothing is named `l` in this scope.
+Is there an `import` or `exposing` missing up-top?
+
+**wrong_arrow.md:1:7:1:8:**
+```roc
+match l {
+```
+      ^
+
+
+# TOKENS
+~~~zig
+KwMatch(1:1-1:6),LowerIdent(1:7-1:8),OpenCurly(1:9-1:10),Newline(1:1-1:1),
+OpenSquare(2:5-2:6),CloseSquare(2:6-2:7),OpArrow(2:8-2:10),UpperIdent(2:11-2:14),NoSpaceOpenRound(2:14-2:15),UpperIdent(2:15-2:24),CloseRound(2:24-2:25),Newline(1:1-1:1),
+OpenSquare(3:5-3:6),DoubleDot(3:6-3:8),Comma(3:8-3:9),LowerIdent(3:10-3:11),CloseSquare(3:11-3:12),OpArrow(3:13-3:15),UpperIdent(3:16-3:18),NoSpaceOpenRound(3:18-3:19),LowerIdent(3:19-3:20),CloseRound(3:20-3:21),Newline(1:1-1:1),
+CloseCurly(4:1-4:2),EndOfFile(4:2-4:2),
+~~~
+# PARSE
+~~~clojure
+(e-match
+	(e-ident @1.7-1.8 (raw "l"))
+	(branches
+		(branch @2.5-3.6
+			(p-list @2.5-2.7)
+			(e-apply @2.11-2.25
+				(e-tag @2.11-2.14 (raw "Err"))
+				(e-tag @2.15-2.24 (raw "EmptyList"))))
+		(branch @3.5-4.2
+			(p-list @3.5-3.12
+				(p-list-rest @3.6-3.9)
+				(p-ident @3.10-3.11 (raw "e")))
+			(e-apply @3.16-3.21
+				(e-tag @3.16-3.18 (raw "Ok"))
+				(e-ident @3.19-3.20 (raw "e"))))))
+~~~
+# FORMATTED
+~~~roc
+match l {
+	[] => Err(EmptyList)
+	[.., e] => Ok(e)
+}
+~~~
+# CANONICALIZE
+~~~clojure
+(e-match @1.1-4.2
+	(match @1.1-4.2
+		(cond
+			(e-runtime-error (tag "ident_not_in_scope")))
+		(branches
+			(branch
+				(patterns
+					(pattern (degenerate false)
+						(p-list @2.5-2.7
+							(patterns))))
+				(value
+					(e-tag @2.11-2.25 (name "Err")
+						(args
+							(e-tag @2.15-2.24 (name "EmptyList"))))))
+			(branch
+				(patterns
+					(pattern (degenerate false)
+						(p-list @3.5-3.12
+							(patterns
+								(p-assign @3.10-3.11 (ident "e")))
+							(rest-at (index 0)))))
+				(value
+					(e-tag @3.16-3.21 (name "Ok")
+						(args
+							(e-lookup-local @3.19-3.20
+								(p-assign @3.10-3.11 (ident "e"))))))))))
+~~~
+# TYPES
+~~~clojure
+(expr @1.1-4.2 (type "[Err, Ok]*"))
+~~~

--- a/src/snapshots/match_expr/wrong_arrow.md
+++ b/src/snapshots/match_expr/wrong_arrow.md
@@ -1,6 +1,6 @@
 # META
 ~~~ini
-description=Match expression with empty list pattern followed by list rest pattern (segfault regression test)
+description=Match expression with wrong arrow
 type=expr
 ~~~
 # SOURCE
@@ -11,7 +11,9 @@ match l {
 }
 ~~~
 # EXPECTED
-UNDEFINED VARIABLE - empty_list_before_rest_pattern.md:1:7:1:8
+PARSE ERROR - wrong_arrow.md:2:8:2:10
+PARSE ERROR - wrong_arrow.md:3:13:3:15
+UNDEFINED VARIABLE - wrong_arrow.md:1:7:1:8
 # PROBLEMS
 **PARSE ERROR**
 Match branches use `=>` instead of `->`.


### PR DESCRIPTION
When the wrong arrow is found on a match branch (`->` instead of `=>`), parse it but push a diagnostic error.
***
This comes after https://roc.zulipchat.com/#narrow/channel/395097-compiler-development/topic/List.20destructure.20syntax/with/527986682 and I decided to implement a simple change to check the new codebase.
I find it useful as someone coming from the old syntax, but feel free to reject it if it is not wanted or if it impacts other concurrent changes.