### PR TITLE
align nix arguments

### DIFF
--- a/BUILDING_FROM_SOURCE.md
+++ b/BUILDING_FROM_SOURCE.md
@@ -18,7 +18,6 @@ zig build roc
 
 If you're familiar with nix and like using it, you can build the compiler like this:
 ```
-nix develop ./src/flake.nix
+nix develop ./src
 buildcmd
 ```
-


### PR DESCRIPTION
> warning: Path '/home/user/roc/src/flake.nix' should point at the directory containing the 'flake.nix' file, not the file itself. Pretending that you meant '/home/user/roc/src'