### PR TITLE
SafeList Tweaks + Range Refactor

### DIFF
--- a/src/check/check_types.zig
+++ b/src/check/check_types.zig
@@ -846,7 +846,7 @@ pub fn checkExpr(self: *Self, expr_idx: CIR.Expr.Idx) std.mem.Allocator.Error!bo
                     });
                     const fields_range = types_mod.RecordField.SafeMultiList.Range{
                         .start = field_idx,
-                        .end = @enumFromInt(@intFromEnum(field_idx) + 1),
+                        .count = 1,
                     };
 
                     // Create an extension variable for other possible fields

--- a/src/check/check_types/let_polymorphism_test.zig
+++ b/src/check/check_types/let_polymorphism_test.zig
@@ -312,7 +312,7 @@ test "let-polymorphism interaction with pattern matching" {
     defer tags.deinit();
 
     try tags.append(.{ .name = just_tag_name, .args = try env.store.appendTagArgs(&.{type_param}) });
-    try tags.append(.{ .name = nothing_tag_name, .args = types.Var.SafeList.Range.empty });
+    try tags.append(.{ .name = nothing_tag_name, .args = types.Var.SafeList.Range.empty() });
 
     const tags_range = try env.store.appendTags(tags.items);
     const maybe_content = types.Content{ .structure = .{ .tag_union = .{ .tags = tags_range, .ext = try env.store.fresh() } } };
@@ -320,8 +320,8 @@ test "let-polymorphism interaction with pattern matching" {
 
     // Create a function that pattern matches on Maybe: forall a. Maybe a -> Bool
     const bool_content = types.Content{ .structure = .{ .tag_union = .{ .tags = try env.store.appendTags(&.{
-        .{ .name = try env.module_env.idents.insert(test_allocator, base.Ident.for_text("True"), base.Region.zero()), .args = types.Var.SafeList.Range.empty },
-        .{ .name = try env.module_env.idents.insert(test_allocator, base.Ident.for_text("False"), base.Region.zero()), .args = types.Var.SafeList.Range.empty },
+        .{ .name = try env.module_env.idents.insert(test_allocator, base.Ident.for_text("True"), base.Region.zero()), .args = types.Var.SafeList.Range.empty() },
+        .{ .name = try env.module_env.idents.insert(test_allocator, base.Ident.for_text("False"), base.Region.zero()), .args = types.Var.SafeList.Range.empty() },
     }), .ext = try env.store.fresh() } } };
     const bool_var = try env.store.freshFromContent(bool_content);
 

--- a/src/check/check_types/occurs.zig
+++ b/src/check/check_types/occurs.zig
@@ -563,7 +563,7 @@ test "occurs: recursive tag union (v = [ Cons(elem, v), Nil ]" {
     const cons_tag_args = try types_store.appendTagArgs(&[_]Var{ elem, linked_list });
     const cons_tag = types.Tag{ .name = undefined, .args = cons_tag_args };
 
-    const nil_tag = types.Tag{ .name = undefined, .args = Var.SafeList.Range.empty };
+    const nil_tag = types.Tag{ .name = undefined, .args = Var.SafeList.Range.empty() };
 
     const tags = try types_store.appendTags(&[_]Tag{ cons_tag, nil_tag });
 
@@ -601,7 +601,7 @@ test "occurs: nested recursive tag union (v = [ Cons(elem, Box(v)) ] )" {
     const cons_tag_args = try types_store.appendTagArgs(&[_]Var{ elem, boxed_linked_list });
 
     const cons_tag = types.Tag{ .name = undefined, .args = cons_tag_args };
-    const nil_tag = types.Tag{ .name = undefined, .args = Var.SafeList.Range.empty };
+    const nil_tag = types.Tag{ .name = undefined, .args = Var.SafeList.Range.empty() };
 
     const tags = try types_store.appendTags(&[_]Tag{ cons_tag, nil_tag });
 
@@ -637,7 +637,7 @@ test "occurs: recursive tag union (v = List: [ Cons(Elem, List), Nil ])" {
 
     const cons_tag_args = try types_store.appendTagArgs(&[_]Var{ elem, nominal_type });
     const cons_tag = types.Tag{ .name = undefined, .args = cons_tag_args };
-    const nil_tag = types.Tag{ .name = undefined, .args = Var.SafeList.Range.empty };
+    const nil_tag = types.Tag{ .name = undefined, .args = Var.SafeList.Range.empty() };
     const backing_var = try types_store.freshFromContent(try types_store.mkTagUnion(&.{ cons_tag, nil_tag }, ext));
     try types_store.setVarContent(nominal_type, try types_store.mkNominal(
         undefined,
@@ -700,7 +700,7 @@ test "occurs: recursive tag union with multiple nominals (TypeA := TypeB, TypeB 
     // Create the tag union content that references type_a_nominal
     const cons_tag_args = try types_store.appendTagArgs(&[_]Var{ elem, type_a_nominal });
     const cons_tag = types.Tag{ .name = undefined, .args = cons_tag_args };
-    const nil_tag = types.Tag{ .name = undefined, .args = Var.SafeList.Range.empty };
+    const nil_tag = types.Tag{ .name = undefined, .args = Var.SafeList.Range.empty() };
     const type_b_backing = try types_store.freshFromContent(try types_store.mkTagUnion(&.{ cons_tag, nil_tag }, ext));
 
     // Set up TypeB = [ Cons(Elem, TypeA), Nil ]

--- a/src/check/check_types/snapshot.zig
+++ b/src/check/check_types/snapshot.zig
@@ -155,7 +155,7 @@ pub const Store = struct {
         }
 
         // Append scratch to backing array, and shrink scratch
-        const args_range = try self.alias_args.appendSlice(self.gpa, self.scratch_content.sliceFromStart(scratch_top));
+        const args_range = try self.alias_args.appendSliceRange(self.gpa, self.scratch_content.sliceFromStart(scratch_top));
         self.scratch_content.clearFrom(scratch_top);
 
         return SnapshotAlias{
@@ -178,7 +178,7 @@ pub const Store = struct {
         }
 
         // Append scratch to backing array, and shrink scratch
-        const elems_range = try self.tuple_elems.appendSlice(self.gpa, self.scratch_content.sliceFromStart(scratch_top));
+        const elems_range = try self.tuple_elems.appendSliceRange(self.gpa, self.scratch_content.sliceFromStart(scratch_top));
         self.scratch_content.clearFrom(scratch_top);
 
         return SnapshotTuple{
@@ -246,7 +246,7 @@ pub const Store = struct {
         }
 
         // Append scratch to backing array, and shrink scratch
-        const args_range = try self.nominal_type_args.appendSlice(self.gpa, self.scratch_content.sliceFromStart(scratch_top));
+        const args_range = try self.nominal_type_args.appendSliceRange(self.gpa, self.scratch_content.sliceFromStart(scratch_top));
         self.scratch_content.clearFrom(scratch_top);
 
         return SnapshotNominalType{
@@ -270,7 +270,7 @@ pub const Store = struct {
         }
 
         // Append scratch to backing array, and shrink scratch
-        const args_range = try self.func_args.appendSlice(self.gpa, self.scratch_content.sliceFromStart(scratch_top));
+        const args_range = try self.func_args.appendSliceRange(self.gpa, self.scratch_content.sliceFromStart(scratch_top));
         self.scratch_content.clearFrom(scratch_top);
 
         // Deep copy return type
@@ -302,7 +302,7 @@ pub const Store = struct {
         }
 
         // Append scratch to backing array, and shrink scratch
-        const fields_range = try self.record_fields.appendSlice(self.gpa, self.scratch_record_fields.sliceFromStart(scratch_top));
+        const fields_range = try self.record_fields.appendSliceRange(self.gpa, self.scratch_record_fields.sliceFromStart(scratch_top));
         self.scratch_record_fields.clearFrom(scratch_top);
 
         return fields_range;
@@ -329,7 +329,7 @@ pub const Store = struct {
         }
 
         // Append scratch to backing array, and shrink scratch
-        const fields_range = try self.record_fields.appendSlice(self.gpa, self.scratch_record_fields.sliceFromStart(scratch_top));
+        const fields_range = try self.record_fields.appendSliceRange(self.gpa, self.scratch_record_fields.sliceFromStart(scratch_top));
         self.scratch_record_fields.clearFrom(scratch_top);
 
         // Deep copy extension type
@@ -364,7 +364,7 @@ pub const Store = struct {
             }
 
             // Append scratch to backing array, and shrink scratch
-            const tag_args_range = try self.tag_args.appendSlice(self.gpa, self.scratch_content.sliceFromStart(content_scratch_top));
+            const tag_args_range = try self.tag_args.appendSliceRange(self.gpa, self.scratch_content.sliceFromStart(content_scratch_top));
             self.scratch_content.clearFrom(content_scratch_top);
 
             // Create and append the snapshot tag to scratch
@@ -377,7 +377,7 @@ pub const Store = struct {
         }
 
         // Append scratch tags to backing array, and shrink scratch
-        const tags_range = try self.tags.appendSlice(self.gpa, self.scratch_tags.sliceFromStart(tags_scratch_top));
+        const tags_range = try self.tags.appendSliceRange(self.gpa, self.scratch_tags.sliceFromStart(tags_scratch_top));
         self.scratch_tags.clearFrom(tags_scratch_top);
 
         // Deep copy extension type
@@ -392,31 +392,31 @@ pub const Store = struct {
 
     // Getter methods (similar to Store)
     pub fn getAliasArgsSlice(self: *const Self, range: SnapshotContentIdxSafeList.Range) []const SnapshotContentIdx {
-        return self.alias_args.rangeToSlice(range);
+        return self.alias_args.sliceRange(range);
     }
 
     pub fn getTupleElemsSlice(self: *const Self, range: SnapshotContentIdxSafeList.Range) []const SnapshotContentIdx {
-        return self.tuple_elems.rangeToSlice(range);
+        return self.tuple_elems.sliceRange(range);
     }
 
     pub fn getNominalTypeArgsSlice(self: *const Self, range: SnapshotContentIdxSafeList.Range) []const SnapshotContentIdx {
-        return self.nominal_type_args.rangeToSlice(range);
+        return self.nominal_type_args.sliceRange(range);
     }
 
     pub fn getFuncArgsSlice(self: *const Self, range: SnapshotContentIdxSafeList.Range) []const SnapshotContentIdx {
-        return self.func_args.rangeToSlice(range);
+        return self.func_args.sliceRange(range);
     }
 
     pub fn getRecordFieldsSlice(self: *const Self, range: SnapshotRecordFieldSafeList.Range) SnapshotRecordFieldSafeList.Slice {
-        return self.record_fields.rangeToSlice(range);
+        return self.record_fields.sliceRange(range);
     }
 
     pub fn getTagsSlice(self: *const Self, range: SnapshotTagSafeList.Range) []const SnapshotTag {
-        return self.tags.rangeToSlice(range);
+        return self.tags.sliceRange(range);
     }
 
     pub fn getTagArgsSlice(self: *const Self, range: SnapshotContentIdxSafeList.Range) []const SnapshotContentIdx {
-        return self.tag_args.rangeToSlice(range);
+        return self.tag_args.sliceRange(range);
     }
 
     pub fn getContent(self: *const Self, idx: SnapshotContentIdx) SnapshotContent {
@@ -755,14 +755,14 @@ pub const SnapshotWriter = struct {
                 self.countContent(search_idx, func.ret, count);
             },
             .record => |record| {
-                const fields = self.snapshots.record_fields.rangeToSlice(record.fields);
+                const fields = self.snapshots.record_fields.sliceRange(record.fields);
                 for (fields.items(.content)) |field_content| {
                     self.countContent(search_idx, field_content, count);
                 }
                 self.countContent(search_idx, record.ext, count);
             },
             .record_unbound => |fields| {
-                const fields_slice = self.snapshots.record_fields.rangeToSlice(fields);
+                const fields_slice = self.snapshots.record_fields.sliceRange(fields);
                 for (fields_slice.items(.content)) |field_content| {
                     self.countContent(search_idx, field_content, count);
                 }
@@ -973,7 +973,7 @@ pub const SnapshotWriter = struct {
     pub fn writeRecord(self: *Self, record: SnapshotRecord, root_idx: SnapshotContentIdx) Allocator.Error!void {
         _ = try self.writer.write("{ ");
 
-        const fields_slice = self.snapshots.record_fields.rangeToSlice(record.fields);
+        const fields_slice = self.snapshots.record_fields.sliceRange(record.fields);
 
         if (fields_slice.len > 0) {
             // Write first field
@@ -1015,7 +1015,7 @@ pub const SnapshotWriter = struct {
             return;
         }
 
-        const fields_slice = self.snapshots.record_fields.rangeToSlice(fields);
+        const fields_slice = self.snapshots.record_fields.sliceRange(fields);
 
         _ = try self.writer.write("{ ");
 

--- a/src/check/check_types/snapshot.zig
+++ b/src/check/check_types/snapshot.zig
@@ -155,7 +155,7 @@ pub const Store = struct {
         }
 
         // Append scratch to backing array, and shrink scratch
-        const args_range = try self.alias_args.appendSliceRange(self.gpa, self.scratch_content.sliceFromStart(scratch_top));
+        const args_range = try self.alias_args.appendSlice(self.gpa, self.scratch_content.sliceFromStart(scratch_top));
         self.scratch_content.clearFrom(scratch_top);
 
         return SnapshotAlias{
@@ -178,7 +178,7 @@ pub const Store = struct {
         }
 
         // Append scratch to backing array, and shrink scratch
-        const elems_range = try self.tuple_elems.appendSliceRange(self.gpa, self.scratch_content.sliceFromStart(scratch_top));
+        const elems_range = try self.tuple_elems.appendSlice(self.gpa, self.scratch_content.sliceFromStart(scratch_top));
         self.scratch_content.clearFrom(scratch_top);
 
         return SnapshotTuple{
@@ -246,7 +246,7 @@ pub const Store = struct {
         }
 
         // Append scratch to backing array, and shrink scratch
-        const args_range = try self.nominal_type_args.appendSliceRange(self.gpa, self.scratch_content.sliceFromStart(scratch_top));
+        const args_range = try self.nominal_type_args.appendSlice(self.gpa, self.scratch_content.sliceFromStart(scratch_top));
         self.scratch_content.clearFrom(scratch_top);
 
         return SnapshotNominalType{
@@ -270,7 +270,7 @@ pub const Store = struct {
         }
 
         // Append scratch to backing array, and shrink scratch
-        const args_range = try self.func_args.appendSliceRange(self.gpa, self.scratch_content.sliceFromStart(scratch_top));
+        const args_range = try self.func_args.appendSlice(self.gpa, self.scratch_content.sliceFromStart(scratch_top));
         self.scratch_content.clearFrom(scratch_top);
 
         // Deep copy return type
@@ -302,7 +302,7 @@ pub const Store = struct {
         }
 
         // Append scratch to backing array, and shrink scratch
-        const fields_range = try self.record_fields.appendSliceRange(self.gpa, self.scratch_record_fields.sliceFromStart(scratch_top));
+        const fields_range = try self.record_fields.appendSlice(self.gpa, self.scratch_record_fields.sliceFromStart(scratch_top));
         self.scratch_record_fields.clearFrom(scratch_top);
 
         return fields_range;
@@ -329,7 +329,7 @@ pub const Store = struct {
         }
 
         // Append scratch to backing array, and shrink scratch
-        const fields_range = try self.record_fields.appendSliceRange(self.gpa, self.scratch_record_fields.sliceFromStart(scratch_top));
+        const fields_range = try self.record_fields.appendSlice(self.gpa, self.scratch_record_fields.sliceFromStart(scratch_top));
         self.scratch_record_fields.clearFrom(scratch_top);
 
         // Deep copy extension type
@@ -364,7 +364,7 @@ pub const Store = struct {
             }
 
             // Append scratch to backing array, and shrink scratch
-            const tag_args_range = try self.tag_args.appendSliceRange(self.gpa, self.scratch_content.sliceFromStart(content_scratch_top));
+            const tag_args_range = try self.tag_args.appendSlice(self.gpa, self.scratch_content.sliceFromStart(content_scratch_top));
             self.scratch_content.clearFrom(content_scratch_top);
 
             // Create and append the snapshot tag to scratch
@@ -377,7 +377,7 @@ pub const Store = struct {
         }
 
         // Append scratch tags to backing array, and shrink scratch
-        const tags_range = try self.tags.appendSliceRange(self.gpa, self.scratch_tags.sliceFromStart(tags_scratch_top));
+        const tags_range = try self.tags.appendSlice(self.gpa, self.scratch_tags.sliceFromStart(tags_scratch_top));
         self.scratch_tags.clearFrom(tags_scratch_top);
 
         // Deep copy extension type

--- a/src/check/check_types/test/nominal_type_origin_test.zig
+++ b/src/check/check_types/test/nominal_type_origin_test.zig
@@ -26,7 +26,7 @@ test "nominal type origin - displays origin in snapshot writer" {
     // Create a nominal type snapshot with origin from a different module
     const nominal_type_backing = snapshot.SnapshotContent{ .structure = .str };
     const nominal_type_backing_idx = try snapshots.contents.append(test_allocator, nominal_type_backing);
-    const vars_range = try snapshots.nominal_type_args.appendSlice(test_allocator, &.{nominal_type_backing_idx});
+    const vars_range = try snapshots.nominal_type_args.appendSliceRange(test_allocator, &.{nominal_type_backing_idx});
 
     const nominal_type = snapshot.SnapshotNominalType{
         .ident = types_mod.TypeIdent{ .ident_idx = type_name_ident },
@@ -89,7 +89,7 @@ test "nominal type origin - displays origin in snapshot writer" {
         // Create type arguments
         const str_content = snapshot.SnapshotContent{ .structure = .{ .str = {} } };
         const str_idx = try snapshots.contents.append(test_allocator, str_content);
-        const args_range = try snapshots.nominal_type_args.appendSlice(test_allocator, &.{ nominal_type_backing_idx, str_idx });
+        const args_range = try snapshots.nominal_type_args.appendSliceRange(test_allocator, &.{ nominal_type_backing_idx, str_idx });
 
         // Create a nominal type with args from a different module
         const generic_nominal = snapshot.SnapshotNominalType{
@@ -127,7 +127,7 @@ test "nominal type origin - works with no context" {
 
     const nominal_type_backing = snapshot.SnapshotContent{ .structure = .str };
     const nominal_type_backing_idx = try snapshots.contents.append(test_allocator, nominal_type_backing);
-    const vars_range = try snapshots.nominal_type_args.appendSlice(test_allocator, &.{nominal_type_backing_idx});
+    const vars_range = try snapshots.nominal_type_args.appendSliceRange(test_allocator, &.{nominal_type_backing_idx});
 
     const nominal_type = snapshot.SnapshotNominalType{
         .ident = types_mod.TypeIdent{ .ident_idx = type_name_ident },

--- a/src/check/check_types/test/nominal_type_origin_test.zig
+++ b/src/check/check_types/test/nominal_type_origin_test.zig
@@ -26,7 +26,7 @@ test "nominal type origin - displays origin in snapshot writer" {
     // Create a nominal type snapshot with origin from a different module
     const nominal_type_backing = snapshot.SnapshotContent{ .structure = .str };
     const nominal_type_backing_idx = try snapshots.contents.append(test_allocator, nominal_type_backing);
-    const vars_range = try snapshots.nominal_type_args.appendSliceRange(test_allocator, &.{nominal_type_backing_idx});
+    const vars_range = try snapshots.nominal_type_args.appendSlice(test_allocator, &.{nominal_type_backing_idx});
 
     const nominal_type = snapshot.SnapshotNominalType{
         .ident = types_mod.TypeIdent{ .ident_idx = type_name_ident },
@@ -89,7 +89,7 @@ test "nominal type origin - displays origin in snapshot writer" {
         // Create type arguments
         const str_content = snapshot.SnapshotContent{ .structure = .{ .str = {} } };
         const str_idx = try snapshots.contents.append(test_allocator, str_content);
-        const args_range = try snapshots.nominal_type_args.appendSliceRange(test_allocator, &.{ nominal_type_backing_idx, str_idx });
+        const args_range = try snapshots.nominal_type_args.appendSlice(test_allocator, &.{ nominal_type_backing_idx, str_idx });
 
         // Create a nominal type with args from a different module
         const generic_nominal = snapshot.SnapshotNominalType{
@@ -127,7 +127,7 @@ test "nominal type origin - works with no context" {
 
     const nominal_type_backing = snapshot.SnapshotContent{ .structure = .str };
     const nominal_type_backing_idx = try snapshots.contents.append(test_allocator, nominal_type_backing);
-    const vars_range = try snapshots.nominal_type_args.appendSliceRange(test_allocator, &.{nominal_type_backing_idx});
+    const vars_range = try snapshots.nominal_type_args.appendSlice(test_allocator, &.{nominal_type_backing_idx});
 
     const nominal_type = snapshot.SnapshotNominalType{
         .ident = types_mod.TypeIdent{ .ident_idx = type_name_ident },

--- a/src/check/check_types/unify.zig
+++ b/src/check/check_types/unify.zig
@@ -2767,11 +2767,11 @@ pub const Scratch = struct {
     }
 
     fn appendSliceGatheredFields(self: *Self, fields: []const RecordField) std.mem.Allocator.Error!RecordFieldSafeList.Range {
-        return try self.gathered_fields.appendSliceRange(self.gpa, fields);
+        return try self.gathered_fields.appendSlice(self.gpa, fields);
     }
 
     fn appendSliceGatheredTags(self: *Self, fields: []const Tag) std.mem.Allocator.Error!TagSafeList.Range {
-        return try self.gathered_tags.appendSliceRange(self.gpa, fields);
+        return try self.gathered_tags.appendSlice(self.gpa, fields);
     }
 
     fn setUnifyErr(self: *Self, err: UnifyErrCtx) void {

--- a/src/check/check_types/unify.zig
+++ b/src/check/check_types/unify.zig
@@ -2087,9 +2087,9 @@ fn Unifier(comptime StoreTypeB: type) type {
             std.mem.sort(RecordField, b_fields, ident_store, comptime RecordField.sortByNameAsc);
 
             // Get the start of index of the new range
-            const a_fields_start: u32 = @intCast(scratch.only_in_a_fields.len());
-            const b_fields_start: u32 = @intCast(scratch.only_in_b_fields.len());
-            const both_fields_start: u32 = @intCast(scratch.in_both_fields.len());
+            const a_fields_start: u32 = scratch.only_in_a_fields.len();
+            const b_fields_start: u32 = scratch.only_in_b_fields.len();
+            const both_fields_start: u32 = scratch.in_both_fields.len();
 
             // Iterate over the fields in order, grouping them
             var a_i: usize = 0;
@@ -2153,7 +2153,7 @@ fn Unifier(comptime StoreTypeB: type) type {
             const trace = tracy.trace(@src());
             defer trace.end();
 
-            const range_start: u32 = @intCast(self.types_store_b.record_fields.len());
+            const range_start: u32 = self.types_store_b.record_fields.len();
 
             // Here, iterate over shared fields, sub unifying the field variables.
             // At this point, the fields are know to be identical, so we arbitrary choose b
@@ -2487,9 +2487,9 @@ fn Unifier(comptime StoreTypeB: type) type {
             std.mem.sort(Tag, b_tags, ident_store, comptime Tag.sortByNameAsc);
 
             // Get the start of index of the new range
-            const a_tags_start: u32 = @intCast(scratch.only_in_a_tags.len());
-            const b_tags_start: u32 = @intCast(scratch.only_in_b_tags.len());
-            const both_tags_start: u32 = @intCast(scratch.in_both_tags.len());
+            const a_tags_start: u32 = scratch.only_in_a_tags.len();
+            const b_tags_start: u32 = scratch.only_in_b_tags.len();
+            const both_tags_start: u32 = scratch.in_both_tags.len();
 
             // Iterate over the tags in order, grouping them
             var a_i: usize = 0;
@@ -2550,7 +2550,7 @@ fn Unifier(comptime StoreTypeB: type) type {
             const trace = tracy.trace(@src());
             defer trace.end();
 
-            const range_start: u32 = @intCast(self.types_store_b.tags.len());
+            const range_start: u32 = self.types_store_b.tags.len();
 
             for (shared_tags) |tags| {
                 const tag_a_args = self.types_store_b.getTagArgsSlice(tags.a.args);
@@ -2736,7 +2736,6 @@ pub const Scratch = struct {
         range: RecordFieldSafeMultiList.Range,
     ) std.mem.Allocator.Error!RecordFieldSafeList.Range {
         const start_int = self.gathered_fields.len();
-        const start: RecordFieldSafeList.Idx = @enumFromInt(start_int);
         const record_fields_slice = multi_list.sliceRange(range);
         for (record_fields_slice.items(.name), record_fields_slice.items(.var_)) |name, var_| {
             _ = try self.gathered_fields.append(
@@ -2744,7 +2743,7 @@ pub const Scratch = struct {
                 RecordField{ .name = name, .var_ = var_ },
             );
         }
-        return .{ .start = start, .count = @intCast(self.gathered_fields.len() - start_int) };
+        return self.gathered_fields.rangeToEnd(start_int);
     }
 
     /// Given a multi list of tag and a range, copy from the multi list
@@ -2755,7 +2754,6 @@ pub const Scratch = struct {
         range: TagSafeMultiList.Range,
     ) std.mem.Allocator.Error!TagSafeList.Range {
         const start_int = self.gathered_tags.len();
-        const start: TagSafeList.Idx = @enumFromInt(start_int);
         const tag_slice = multi_list.sliceRange(range);
         for (tag_slice.items(.name), tag_slice.items(.args)) |ident, args| {
             _ = try self.gathered_tags.append(
@@ -2763,7 +2761,7 @@ pub const Scratch = struct {
                 Tag{ .name = ident, .args = args },
             );
         }
-        return .{ .start = start, .count = @intCast(self.gathered_tags.len() - start_int) };
+        return self.gathered_tags.rangeToEnd(start_int);
     }
 
     fn appendSliceGatheredFields(self: *Self, fields: []const RecordField) std.mem.Allocator.Error!RecordFieldSafeList.Range {

--- a/src/check/check_types/unify.zig
+++ b/src/check/check_types/unify.zig
@@ -793,7 +793,7 @@ fn Unifier(comptime StoreTypeB: type) type {
                             // Unify shared fields
                             try self.unifySharedFields(
                                 vars,
-                                self.scratch.in_both_fields.rangeToSlice(partitioned.in_both),
+                                self.scratch.in_both_fields.sliceRange(partitioned.in_both),
                                 null,
                                 null,
                                 a_gathered_fields.ext,
@@ -848,7 +848,7 @@ fn Unifier(comptime StoreTypeB: type) type {
                             // Unify shared fields
                             try self.unifySharedFields(
                                 vars,
-                                self.scratch.in_both_fields.rangeToSlice(partitioned.in_both),
+                                self.scratch.in_both_fields.sliceRange(partitioned.in_both),
                                 null,
                                 null,
                                 b_gathered_fields.ext,
@@ -886,7 +886,7 @@ fn Unifier(comptime StoreTypeB: type) type {
                             const dummy_ext = self.fresh(vars, .{ .structure = .empty_record }) catch return Error.AllocatorError;
                             try self.unifySharedFields(
                                 vars,
-                                self.scratch.in_both_fields.rangeToSlice(partitioned.in_both),
+                                self.scratch.in_both_fields.sliceRange(partitioned.in_both),
                                 null,
                                 null,
                                 dummy_ext,
@@ -922,7 +922,7 @@ fn Unifier(comptime StoreTypeB: type) type {
                             // Unify shared fields
                             try self.unifySharedFields(
                                 vars,
-                                self.scratch.in_both_fields.rangeToSlice(partitioned.in_both),
+                                self.scratch.in_both_fields.sliceRange(partitioned.in_both),
                                 null,
                                 null,
                                 b_gathered_fields.ext,
@@ -974,7 +974,7 @@ fn Unifier(comptime StoreTypeB: type) type {
                             // Unify shared fields
                             try self.unifySharedFields(
                                 vars,
-                                self.scratch.in_both_fields.rangeToSlice(partitioned.in_both),
+                                self.scratch.in_both_fields.sliceRange(partitioned.in_both),
                                 null,
                                 null,
                                 a_gathered_fields.ext,
@@ -1885,7 +1885,7 @@ fn Unifier(comptime StoreTypeB: type) type {
                     // This copies fields from scratch into type_store
                     try self.unifySharedFields(
                         vars,
-                        self.scratch.in_both_fields.rangeToSlice(partitioned.in_both),
+                        self.scratch.in_both_fields.sliceRange(partitioned.in_both),
                         null,
                         null,
                         a_gathered_fields.ext,
@@ -1895,7 +1895,7 @@ fn Unifier(comptime StoreTypeB: type) type {
                     // Create a new variable of a record with only a's uniq fields
                     // This copies fields from scratch into type_store
                     const only_in_a_fields_range = self.types_store_b.appendRecordFields(
-                        self.scratch.only_in_a_fields.rangeToSlice(partitioned.only_in_a),
+                        self.scratch.only_in_a_fields.sliceRange(partitioned.only_in_a),
                     ) catch return Error.AllocatorError;
                     const only_in_a_var = self.fresh(vars, Content{ .structure = FlatType{ .record = .{
                         .fields = only_in_a_fields_range,
@@ -1909,7 +1909,7 @@ fn Unifier(comptime StoreTypeB: type) type {
                     // This copies fields from scratch into type_store
                     try self.unifySharedFields(
                         vars,
-                        self.scratch.in_both_fields.rangeToSlice(partitioned.in_both),
+                        self.scratch.in_both_fields.sliceRange(partitioned.in_both),
                         null,
                         null,
                         only_in_a_var,
@@ -1919,7 +1919,7 @@ fn Unifier(comptime StoreTypeB: type) type {
                     // Create a new variable of a record with only b's uniq fields
                     // This copies fields from scratch into type_store
                     const only_in_b_fields_range = self.types_store_b.appendRecordFields(
-                        self.scratch.only_in_b_fields.rangeToSlice(partitioned.only_in_b),
+                        self.scratch.only_in_b_fields.sliceRange(partitioned.only_in_b),
                     ) catch return Error.AllocatorError;
                     const only_in_b_var = self.fresh(vars, Content{ .structure = FlatType{ .record = .{
                         .fields = only_in_b_fields_range,
@@ -1933,7 +1933,7 @@ fn Unifier(comptime StoreTypeB: type) type {
                     // This copies fields from scratch into type_store
                     try self.unifySharedFields(
                         vars,
-                        self.scratch.in_both_fields.rangeToSlice(partitioned.in_both),
+                        self.scratch.in_both_fields.sliceRange(partitioned.in_both),
                         null,
                         null,
                         only_in_b_var,
@@ -1943,7 +1943,7 @@ fn Unifier(comptime StoreTypeB: type) type {
                     // Create a new variable of a record with only a's uniq fields
                     // This copies fields from scratch into type_store
                     const only_in_a_fields_range = self.types_store_b.appendRecordFields(
-                        self.scratch.only_in_a_fields.rangeToSlice(partitioned.only_in_a),
+                        self.scratch.only_in_a_fields.sliceRange(partitioned.only_in_a),
                     ) catch return Error.AllocatorError;
                     const only_in_a_var = self.fresh(vars, Content{ .structure = FlatType{ .record = .{
                         .fields = only_in_a_fields_range,
@@ -1953,7 +1953,7 @@ fn Unifier(comptime StoreTypeB: type) type {
                     // Create a new variable of a record with only b's uniq fields
                     // This copies fields from scratch into type_store
                     const only_in_b_fields_range = self.types_store_b.appendRecordFields(
-                        self.scratch.only_in_b_fields.rangeToSlice(partitioned.only_in_b),
+                        self.scratch.only_in_b_fields.sliceRange(partitioned.only_in_b),
                     ) catch return Error.AllocatorError;
                     const only_in_b_var = self.fresh(vars, Content{ .structure = FlatType{ .record = .{
                         .fields = only_in_b_fields_range,
@@ -1971,9 +1971,9 @@ fn Unifier(comptime StoreTypeB: type) type {
                     // This copies fields from scratch into type_store
                     try self.unifySharedFields(
                         vars,
-                        self.scratch.in_both_fields.rangeToSlice(partitioned.in_both),
-                        self.scratch.only_in_a_fields.rangeToSlice(partitioned.only_in_a),
-                        self.scratch.only_in_b_fields.rangeToSlice(partitioned.only_in_b),
+                        self.scratch.in_both_fields.sliceRange(partitioned.in_both),
+                        self.scratch.only_in_a_fields.sliceRange(partitioned.only_in_a),
+                        self.scratch.only_in_b_fields.sliceRange(partitioned.only_in_b),
                         new_ext_var,
                     );
                 },
@@ -2081,9 +2081,9 @@ fn Unifier(comptime StoreTypeB: type) type {
             b_fields_range: RecordFieldSafeList.Range,
         ) std.mem.Allocator.Error!PartitionedRecordFields {
             // First sort the fields
-            const a_fields = scratch.gathered_fields.rangeToSlice(a_fields_range);
+            const a_fields = scratch.gathered_fields.sliceRange(a_fields_range);
             std.mem.sort(RecordField, a_fields, ident_store, comptime RecordField.sortByNameAsc);
-            const b_fields = scratch.gathered_fields.rangeToSlice(b_fields_range);
+            const b_fields = scratch.gathered_fields.sliceRange(b_fields_range);
             std.mem.sort(RecordField, b_fields, ident_store, comptime RecordField.sortByNameAsc);
 
             // Get the start of index of the new range
@@ -2309,7 +2309,7 @@ fn Unifier(comptime StoreTypeB: type) type {
                     // This copies tags from scratch into type_store
                     try self.unifySharedTags(
                         vars,
-                        self.scratch.in_both_tags.rangeToSlice(partitioned.in_both),
+                        self.scratch.in_both_tags.sliceRange(partitioned.in_both),
                         null,
                         null,
                         a_gathered_tags.ext,
@@ -2319,7 +2319,7 @@ fn Unifier(comptime StoreTypeB: type) type {
                     // Create a new variable of a tag_union with only a's uniq tags
                     // This copies tags from scratch into type_store
                     const only_in_a_tags_range = self.types_store_b.appendTags(
-                        self.scratch.only_in_a_tags.rangeToSlice(partitioned.only_in_a),
+                        self.scratch.only_in_a_tags.sliceRange(partitioned.only_in_a),
                     ) catch return Error.AllocatorError;
                     const only_in_a_var = self.fresh(vars, Content{ .structure = FlatType{ .tag_union = .{
                         .tags = only_in_a_tags_range,
@@ -2333,7 +2333,7 @@ fn Unifier(comptime StoreTypeB: type) type {
                     // This copies tags from scratch into type_store
                     try self.unifySharedTags(
                         vars,
-                        self.scratch.in_both_tags.rangeToSlice(partitioned.in_both),
+                        self.scratch.in_both_tags.sliceRange(partitioned.in_both),
                         null,
                         null,
                         only_in_a_var,
@@ -2343,7 +2343,7 @@ fn Unifier(comptime StoreTypeB: type) type {
                     // Create a new variable of a tag_union with only b's uniq tags
                     // This copies tags from scratch into type_store
                     const only_in_b_tags_range = self.types_store_b.appendTags(
-                        self.scratch.only_in_b_tags.rangeToSlice(partitioned.only_in_b),
+                        self.scratch.only_in_b_tags.sliceRange(partitioned.only_in_b),
                     ) catch return Error.AllocatorError;
                     const only_in_b_var = self.fresh(vars, Content{ .structure = FlatType{ .tag_union = .{
                         .tags = only_in_b_tags_range,
@@ -2357,7 +2357,7 @@ fn Unifier(comptime StoreTypeB: type) type {
                     // This copies tags from scratch into type_store
                     try self.unifySharedTags(
                         vars,
-                        self.scratch.in_both_tags.rangeToSlice(partitioned.in_both),
+                        self.scratch.in_both_tags.sliceRange(partitioned.in_both),
                         null,
                         null,
                         only_in_b_var,
@@ -2367,7 +2367,7 @@ fn Unifier(comptime StoreTypeB: type) type {
                     // Create a new variable of a tag_union with only a's uniq tags
                     // This copies tags from scratch into type_store
                     const only_in_a_tags_range = self.types_store_b.appendTags(
-                        self.scratch.only_in_a_tags.rangeToSlice(partitioned.only_in_a),
+                        self.scratch.only_in_a_tags.sliceRange(partitioned.only_in_a),
                     ) catch return Error.AllocatorError;
                     const only_in_a_var = self.fresh(vars, Content{ .structure = FlatType{ .tag_union = .{
                         .tags = only_in_a_tags_range,
@@ -2377,7 +2377,7 @@ fn Unifier(comptime StoreTypeB: type) type {
                     // Create a new variable of a tag_union with only b's uniq tags
                     // This copies tags from scratch into type_store
                     const only_in_b_tags_range = self.types_store_b.appendTags(
-                        self.scratch.only_in_b_tags.rangeToSlice(partitioned.only_in_b),
+                        self.scratch.only_in_b_tags.sliceRange(partitioned.only_in_b),
                     ) catch return Error.AllocatorError;
                     const only_in_b_var = self.fresh(vars, Content{ .structure = FlatType{ .tag_union = .{
                         .tags = only_in_b_tags_range,
@@ -2395,9 +2395,9 @@ fn Unifier(comptime StoreTypeB: type) type {
                     // This copies tags from scratch into type_store
                     try self.unifySharedTags(
                         vars,
-                        self.scratch.in_both_tags.rangeToSlice(partitioned.in_both),
-                        self.scratch.only_in_a_tags.rangeToSlice(partitioned.only_in_a),
-                        self.scratch.only_in_b_tags.rangeToSlice(partitioned.only_in_b),
+                        self.scratch.in_both_tags.sliceRange(partitioned.in_both),
+                        self.scratch.only_in_a_tags.sliceRange(partitioned.only_in_a),
+                        self.scratch.only_in_b_tags.sliceRange(partitioned.only_in_b),
                         new_ext_var,
                     );
                 },
@@ -2488,9 +2488,9 @@ fn Unifier(comptime StoreTypeB: type) type {
             b_tags_range: TagSafeList.Range,
         ) std.mem.Allocator.Error!PartitionedTags {
             // First sort the tags
-            const a_tags = scratch.gathered_tags.rangeToSlice(a_tags_range);
+            const a_tags = scratch.gathered_tags.sliceRange(a_tags_range);
             std.mem.sort(Tag, a_tags, ident_store, comptime Tag.sortByNameAsc);
-            const b_tags = scratch.gathered_tags.rangeToSlice(b_tags_range);
+            const b_tags = scratch.gathered_tags.sliceRange(b_tags_range);
             std.mem.sort(Tag, b_tags, ident_store, comptime Tag.sortByNameAsc);
 
             // Get the start of index of the new range
@@ -2750,7 +2750,7 @@ pub const Scratch = struct {
         range: RecordFieldSafeMultiList.Range,
     ) std.mem.Allocator.Error!RecordFieldSafeList.Range {
         const start: RecordFieldSafeList.Idx = @enumFromInt(self.gathered_fields.len());
-        const record_fields_slice = multi_list.rangeToSlice(range);
+        const record_fields_slice = multi_list.sliceRange(range);
         for (record_fields_slice.items(.name), record_fields_slice.items(.var_)) |name, var_| {
             _ = try self.gathered_fields.append(
                 self.gpa,
@@ -2768,7 +2768,7 @@ pub const Scratch = struct {
         range: TagSafeMultiList.Range,
     ) std.mem.Allocator.Error!TagSafeList.Range {
         const start: TagSafeList.Idx = @enumFromInt(self.gathered_tags.len());
-        const tag_slice = multi_list.rangeToSlice(range);
+        const tag_slice = multi_list.sliceRange(range);
         for (tag_slice.items(.name), tag_slice.items(.args)) |ident, args| {
             _ = try self.gathered_tags.append(
                 self.gpa,
@@ -2780,11 +2780,11 @@ pub const Scratch = struct {
     }
 
     fn appendSliceGatheredFields(self: *Self, fields: []const RecordField) std.mem.Allocator.Error!RecordFieldSafeList.Range {
-        return try self.gathered_fields.appendSlice(self.gpa, fields);
+        return try self.gathered_fields.appendSliceRange(self.gpa, fields);
     }
 
     fn appendSliceGatheredTags(self: *Self, fields: []const Tag) std.mem.Allocator.Error!TagSafeList.Range {
-        return try self.gathered_tags.appendSlice(self.gpa, fields);
+        return try self.gathered_tags.appendSliceRange(self.gpa, fields);
     }
 
     fn setUnifyErr(self: *Self, err: UnifyErrCtx) void {
@@ -4367,7 +4367,7 @@ test "partitionFields - same record" {
     try std.testing.expectEqual(0, result.only_in_b.len());
     try std.testing.expectEqual(2, result.in_both.len());
 
-    const both_slice = env.scratch.in_both_fields.rangeToSlice(result.in_both);
+    const both_slice = env.scratch.in_both_fields.sliceRange(result.in_both);
     try std.testing.expectEqual(field_x, both_slice[0].a);
     try std.testing.expectEqual(field_x, both_slice[0].b);
     try std.testing.expectEqual(field_y, both_slice[1].a);
@@ -4392,11 +4392,11 @@ test "partitionFields - disjoint fields" {
     try std.testing.expectEqual(1, result.only_in_b.len());
     try std.testing.expectEqual(0, result.in_both.len());
 
-    const only_in_a_slice = env.scratch.only_in_a_fields.rangeToSlice(result.only_in_a);
+    const only_in_a_slice = env.scratch.only_in_a_fields.sliceRange(result.only_in_a);
     try std.testing.expectEqual(a1, only_in_a_slice[0]);
     try std.testing.expectEqual(a2, only_in_a_slice[1]);
 
-    const only_in_b_slice = env.scratch.only_in_b_fields.rangeToSlice(result.only_in_b);
+    const only_in_b_slice = env.scratch.only_in_b_fields.sliceRange(result.only_in_b);
     try std.testing.expectEqual(b1, only_in_b_slice[0]);
 }
 
@@ -4418,14 +4418,14 @@ test "partitionFields - overlapping fields" {
     try std.testing.expectEqual(1, result.only_in_b.len());
     try std.testing.expectEqual(1, result.in_both.len());
 
-    const both_slice = env.scratch.in_both_fields.rangeToSlice(result.in_both);
+    const both_slice = env.scratch.in_both_fields.sliceRange(result.in_both);
     try std.testing.expectEqual(both, both_slice[0].a);
     try std.testing.expectEqual(both, both_slice[0].b);
 
-    const only_in_a_slice = env.scratch.only_in_a_fields.rangeToSlice(result.only_in_a);
+    const only_in_a_slice = env.scratch.only_in_a_fields.sliceRange(result.only_in_a);
     try std.testing.expectEqual(a1, only_in_a_slice[0]);
 
-    const only_in_b_slice = env.scratch.only_in_b_fields.rangeToSlice(result.only_in_b);
+    const only_in_b_slice = env.scratch.only_in_b_fields.sliceRange(result.only_in_b);
     try std.testing.expectEqual(b1, only_in_b_slice[0]);
 }
 
@@ -4447,7 +4447,7 @@ test "partitionFields - reordering is normalized" {
     try std.testing.expectEqual(0, result.only_in_b.len());
     try std.testing.expectEqual(3, result.in_both.len());
 
-    const both = env.scratch.in_both_fields.rangeToSlice(result.in_both);
+    const both = env.scratch.in_both_fields.sliceRange(result.in_both);
     try std.testing.expectEqual(f1, both[0].a);
     try std.testing.expectEqual(f1, both[0].b);
     try std.testing.expectEqual(f2, both[1].a);
@@ -4467,7 +4467,7 @@ test "unify - identical closed records" {
 
     const fields = [_]RecordField{try env.mkRecordField("a", str)};
     const record_data = try env.mkRecordClosed(&fields);
-    const record_data_fields = env.module_env.types.record_fields.rangeToSlice(record_data.record.fields);
+    const record_data_fields = env.module_env.types.record_fields.sliceRange(record_data.record.fields);
 
     const a = try env.module_env.types.freshFromContent(record_data.content);
     const b = try env.module_env.types.freshFromContent(record_data.content);
@@ -4478,7 +4478,7 @@ test "unify - identical closed records" {
     try std.testing.expectEqual(Slot{ .redirect = b }, env.module_env.types.getSlot(a));
 
     const b_record = try TestEnv.getRecordOrErr(try env.getDescForRootVar(b));
-    const b_record_fields = env.module_env.types.record_fields.rangeToSlice(b_record.fields);
+    const b_record_fields = env.module_env.types.record_fields.sliceRange(b_record.fields);
     try std.testing.expectEqualSlices(Ident.Idx, record_data_fields.items(.name), b_record_fields.items(.name));
     try std.testing.expectEqualSlices(Var, record_data_fields.items(.var_), b_record_fields.items(.var_));
 }
@@ -4823,7 +4823,7 @@ test "partitionTags - same tags" {
     try std.testing.expectEqual(0, result.only_in_b.len());
     try std.testing.expectEqual(2, result.in_both.len());
 
-    const both_slice = env.scratch.in_both_tags.rangeToSlice(result.in_both);
+    const both_slice = env.scratch.in_both_tags.sliceRange(result.in_both);
     try std.testing.expectEqual(tag_x, both_slice[0].a);
     try std.testing.expectEqual(tag_x, both_slice[0].b);
     try std.testing.expectEqual(tag_y, both_slice[1].a);
@@ -4848,11 +4848,11 @@ test "partitionTags - disjoint fields" {
     try std.testing.expectEqual(1, result.only_in_b.len());
     try std.testing.expectEqual(0, result.in_both.len());
 
-    const only_in_a_slice = env.scratch.only_in_a_tags.rangeToSlice(result.only_in_a);
+    const only_in_a_slice = env.scratch.only_in_a_tags.sliceRange(result.only_in_a);
     try std.testing.expectEqual(a1, only_in_a_slice[0]);
     try std.testing.expectEqual(a2, only_in_a_slice[1]);
 
-    const only_in_b_slice = env.scratch.only_in_b_tags.rangeToSlice(result.only_in_b);
+    const only_in_b_slice = env.scratch.only_in_b_tags.sliceRange(result.only_in_b);
     try std.testing.expectEqual(b1, only_in_b_slice[0]);
 }
 
@@ -4874,14 +4874,14 @@ test "partitionTags - overlapping tags" {
     try std.testing.expectEqual(1, result.only_in_b.len());
     try std.testing.expectEqual(1, result.in_both.len());
 
-    const both_slice = env.scratch.in_both_tags.rangeToSlice(result.in_both);
+    const both_slice = env.scratch.in_both_tags.sliceRange(result.in_both);
     try std.testing.expectEqual(both, both_slice[0].a);
     try std.testing.expectEqual(both, both_slice[0].b);
 
-    const only_in_a_slice = env.scratch.only_in_a_tags.rangeToSlice(result.only_in_a);
+    const only_in_a_slice = env.scratch.only_in_a_tags.sliceRange(result.only_in_a);
     try std.testing.expectEqual(a1, only_in_a_slice[0]);
 
-    const only_in_b_slice = env.scratch.only_in_b_tags.rangeToSlice(result.only_in_b);
+    const only_in_b_slice = env.scratch.only_in_b_tags.sliceRange(result.only_in_b);
     try std.testing.expectEqual(b1, only_in_b_slice[0]);
 }
 
@@ -4903,7 +4903,7 @@ test "partitionTags - reordering is normalized" {
     try std.testing.expectEqual(0, result.only_in_b.len());
     try std.testing.expectEqual(3, result.in_both.len());
 
-    const both_slice = env.scratch.in_both_tags.rangeToSlice(result.in_both);
+    const both_slice = env.scratch.in_both_tags.sliceRange(result.in_both);
     try std.testing.expectEqual(f1, both_slice[0].a);
     try std.testing.expectEqual(f1, both_slice[0].b);
     try std.testing.expectEqual(f2, both_slice[1].a);
@@ -4934,7 +4934,7 @@ test "unify - identical closed tag_unions" {
     try std.testing.expectEqual(Slot{ .redirect = b }, env.module_env.types.getSlot(a));
 
     const b_tag_union = try TestEnv.getTagUnionOrErr(try env.getDescForRootVar(b));
-    const b_tags = env.module_env.types.tags.rangeToSlice(b_tag_union.tags);
+    const b_tags = env.module_env.types.tags.sliceRange(b_tag_union.tags);
     const b_tags_names = b_tags.items(.name);
     const b_tags_args = b_tags.items(.args);
     try std.testing.expectEqual(1, b_tags.len);
@@ -4943,7 +4943,7 @@ test "unify - identical closed tag_unions" {
 
     try std.testing.expectEqual(1, b_tags.len);
 
-    const b_tag_args = env.module_env.types.tag_args.rangeToSlice(b_tags_args[0]);
+    const b_tag_args = env.module_env.types.tag_args.sliceRange(b_tags_args[0]);
     try std.testing.expectEqual(1, b_tag_args.len);
     try std.testing.expectEqual(str, b_tag_args[0]);
 }
@@ -5002,7 +5002,7 @@ test "unify - identical open tag unions" {
     const b_tag_union = try TestEnv.getTagUnionOrErr(try env.getDescForRootVar(b));
     try std.testing.expectEqual(1, b_tag_union.tags.len());
 
-    const b_tags = env.module_env.types.tags.rangeToSlice(b_tag_union.tags);
+    const b_tags = env.module_env.types.tags.sliceRange(b_tag_union.tags);
     const b_tags_names = b_tags.items(.name);
     const b_tags_args = b_tags.items(.args);
     try std.testing.expectEqual(1, b_tags.len);
@@ -5044,7 +5044,7 @@ test "unify - open tag union a extends b" {
     const b_tag_union = try TestEnv.getTagUnionOrErr(try env.getDescForRootVar(b));
     try std.testing.expectEqual(1, b_tag_union.tags.len());
 
-    const b_tags = env.module_env.types.tags.rangeToSlice(b_tag_union.tags);
+    const b_tags = env.module_env.types.tags.sliceRange(b_tag_union.tags);
     const b_tags_names = b_tags.items(.name);
     const b_tags_args = b_tags.items(.args);
     try std.testing.expectEqual(1, b_tags.len);
@@ -5054,7 +5054,7 @@ test "unify - open tag union a extends b" {
     const b_ext_tag_union = try TestEnv.getTagUnionOrErr(env.module_env.types.resolveVar(b_tag_union.ext).desc);
     try std.testing.expectEqual(1, b_ext_tag_union.tags.len());
 
-    const b_ext_tags = env.module_env.types.tags.rangeToSlice(b_ext_tag_union.tags);
+    const b_ext_tags = env.module_env.types.tags.sliceRange(b_ext_tag_union.tags);
     const b_ext_tags_names = b_ext_tags.items(.name);
     const b_ext_tags_args = b_ext_tags.items(.args);
     try std.testing.expectEqual(1, b_ext_tags.len);
@@ -5097,7 +5097,7 @@ test "unify - open tag union b extends a" {
     const b_tag_union = try TestEnv.getTagUnionOrErr(try env.getDescForRootVar(b));
     try std.testing.expectEqual(1, b_tag_union.tags.len());
 
-    const b_tags = env.module_env.types.tags.rangeToSlice(b_tag_union.tags);
+    const b_tags = env.module_env.types.tags.sliceRange(b_tag_union.tags);
     const b_tags_names = b_tags.items(.name);
     const b_tags_args = b_tags.items(.args);
     try std.testing.expectEqual(1, b_tags.len);
@@ -5107,7 +5107,7 @@ test "unify - open tag union b extends a" {
     const b_ext_tag_union = try TestEnv.getTagUnionOrErr(env.module_env.types.resolveVar(b_tag_union.ext).desc);
     try std.testing.expectEqual(1, b_ext_tag_union.tags.len());
 
-    const b_ext_tags = env.module_env.types.tags.rangeToSlice(b_ext_tag_union.tags);
+    const b_ext_tags = env.module_env.types.tags.sliceRange(b_ext_tag_union.tags);
     const b_ext_tags_names = b_ext_tags.items(.name);
     const b_ext_tags_args = b_ext_tags.items(.args);
     try std.testing.expectEqual(1, b_ext_tags.len);
@@ -5152,7 +5152,7 @@ test "unify - both extend open tag union" {
     const b_tag_union = try TestEnv.getTagUnionOrErr(try env.getDescForRootVar(b));
     try std.testing.expectEqual(3, b_tag_union.tags.len());
 
-    const b_tags = env.module_env.types.tags.rangeToSlice(b_tag_union.tags);
+    const b_tags = env.module_env.types.tags.sliceRange(b_tag_union.tags);
     try std.testing.expectEqual(3, b_tags.len);
     try std.testing.expectEqual(tag_shared, b_tags.get(0));
     try std.testing.expectEqual(tag_a_only, b_tags.get(1));
@@ -5253,7 +5253,7 @@ test "unify - closed tag union extends open" {
     const b_tag_union = try TestEnv.getTagUnionOrErr(try env.getDescForRootVar(b));
     try std.testing.expectEqual(1, b_tag_union.tags.len());
 
-    const b_tags = env.module_env.types.tags.rangeToSlice(b_tag_union.tags);
+    const b_tags = env.module_env.types.tags.sliceRange(b_tag_union.tags);
     const b_tags_names = b_tags.items(.name);
     const b_tags_args = b_tags.items(.args);
     try std.testing.expectEqual(1, b_tags.len);
@@ -5263,7 +5263,7 @@ test "unify - closed tag union extends open" {
     const b_ext_tag_union = try TestEnv.getTagUnionOrErr(env.module_env.types.resolveVar(b_tag_union.ext).desc);
     try std.testing.expectEqual(1, b_ext_tag_union.tags.len());
 
-    const b_ext_tags = env.module_env.types.tags.rangeToSlice(b_ext_tag_union.tags);
+    const b_ext_tags = env.module_env.types.tags.sliceRange(b_ext_tag_union.tags);
     const b_ext_tags_names = b_ext_tags.items(.name);
     const b_ext_tags_args = b_ext_tags.items(.args);
     try std.testing.expectEqual(1, b_ext_tags.len);

--- a/src/collections.zig
+++ b/src/collections.zig
@@ -26,9 +26,10 @@ pub const NonEmptyRange = struct {
 
     /// Convert to a SafeMultiList range
     pub fn toRange(self: NonEmptyRange, comptime Idx: type) @import("collections/safe_list.zig").SafeRange(Idx) {
+        std.debug.assert(self.count > 0);
         return .{
             .start = @enumFromInt(self.start),
-            .end = @enumFromInt(self.start + self.count),
+            .count = self.count,
         };
     }
 };

--- a/src/collections/safe_list.zig
+++ b/src/collections/safe_list.zig
@@ -124,8 +124,8 @@ pub fn SafeList(comptime T: type) type {
         }
 
         /// Get the length of this list.
-        pub fn len(self: *const SafeList(T)) usize {
-            return self.items.items.len;
+        pub fn len(self: *const SafeList(T)) u32 {
+            return @intCast(self.items.items.len);
         }
 
         /// Add an item to the end of this list.
@@ -422,8 +422,8 @@ pub fn SafeMultiList(comptime T: type) type {
         }
 
         /// Get the length of this list.
-        pub fn len(self: *const SafeMultiList(T)) usize {
-            return self.items.len;
+        pub fn len(self: *const SafeMultiList(T)) u32 {
+            return @intCast(self.items.len);
         }
 
         /// Create a range from the provided idx to the end of the list

--- a/src/collections/safe_list.zig
+++ b/src/collections/safe_list.zig
@@ -191,7 +191,7 @@ pub fn SafeList(comptime T: type) type {
         }
 
         /// Add all the items in a slice to the end of this list.
-        pub fn appendSlice(self: *SafeList(T), gpa: Allocator, items: []const T) std.mem.Allocator.Error!Range {
+        pub fn appendSliceRange(self: *SafeList(T), gpa: Allocator, items: []const T) std.mem.Allocator.Error!Range {
             const start_length = self.len();
             try self.items.appendSlice(gpa, items);
             const end_length = self.len();
@@ -217,7 +217,7 @@ pub fn SafeList(comptime T: type) type {
         }
 
         /// Convert a range to a slice
-        pub fn rangeToSlice(self: *const SafeList(T), range: Range) Slice {
+        pub fn sliceRange(self: *const SafeList(T), range: Range) Slice {
             const start: usize = @intFromEnum(range.start);
             const end: usize = @intFromEnum(range.end);
 
@@ -500,7 +500,7 @@ pub fn SafeMultiList(comptime T: type) type {
             return @enumFromInt(@as(u32, @intCast(length)));
         }
 
-        pub fn appendSlice(self: *SafeMultiList(T), gpa: Allocator, elems: []const T) std.mem.Allocator.Error!Range {
+        pub fn appendSliceRange(self: *SafeMultiList(T), gpa: Allocator, elems: []const T) std.mem.Allocator.Error!Range {
             if (elems.len == 0) {
                 return .{ .start = .zero, .end = .zero };
             }
@@ -514,7 +514,7 @@ pub fn SafeMultiList(comptime T: type) type {
         }
 
         /// Convert a range to a slice
-        pub fn rangeToSlice(self: *const SafeMultiList(T), range: Range) Slice {
+        pub fn sliceRange(self: *const SafeMultiList(T), range: Range) Slice {
             const start: usize = @intFromEnum(range.start);
             const end: usize = @intFromEnum(range.end);
 
@@ -675,28 +675,28 @@ test "SafeList(u8) appendSlice" {
     var list = SafeList(u8){};
     defer list.deinit(gpa);
 
-    const rangeA = try list.appendSlice(gpa, &[_]u8{ 'a', 'b', 'c', 'd' });
+    const rangeA = try list.appendSliceRange(gpa, &[_]u8{ 'a', 'b', 'c', 'd' });
     try testing.expectEqual(0, @intFromEnum(rangeA.start));
     try testing.expectEqual(4, @intFromEnum(rangeA.end));
 
-    const rangeB = try list.appendSlice(gpa, &[_]u8{ 'd', 'e', 'f', 'g' });
+    const rangeB = try list.appendSliceRange(gpa, &[_]u8{ 'd', 'e', 'f', 'g' });
     try testing.expectEqual(4, @intFromEnum(rangeB.start));
     try testing.expectEqual(8, @intFromEnum(rangeB.end));
 }
 
-test "SafeList(u8) rangeToSlice" {
+test "SafeList(u8) sliceRange" {
     const gpa = testing.allocator;
 
     var list = SafeList(u8){};
     defer list.deinit(gpa);
 
-    const rangeA = try list.appendSlice(gpa, &[_]u8{ 'a', 'b', 'c', 'd' });
-    const sliceA = list.rangeToSlice(rangeA);
+    const rangeA = try list.appendSliceRange(gpa, &[_]u8{ 'a', 'b', 'c', 'd' });
+    const sliceA = list.sliceRange(rangeA);
     try testing.expectEqual('a', sliceA[0]);
     try testing.expectEqual('d', sliceA[3]);
 
     const rangeB = SafeList(u8).Range{ .start = @enumFromInt(2), .end = @enumFromInt(4) };
-    const sliceB = list.rangeToSlice(rangeB);
+    const sliceB = list.sliceRange(rangeB);
     try testing.expectEqual('c', sliceB[0]);
     try testing.expectEqual('d', sliceB[1]);
 }
@@ -710,16 +710,16 @@ test "SafeMultiList(u8) appendSlice" {
     var multilist = try StructMultiList.initCapacity(gpa, 3);
     defer multilist.deinit(gpa);
 
-    const rangeA = try multilist.appendSlice(gpa, &[_]Struct{ .{ .num = 100, .char = 'a' }, .{ .num = 200, .char = 'b' }, .{ .num = 300, .char = 'd' } });
+    const rangeA = try multilist.appendSliceRange(gpa, &[_]Struct{ .{ .num = 100, .char = 'a' }, .{ .num = 200, .char = 'b' }, .{ .num = 300, .char = 'd' } });
     try testing.expectEqual(0, @intFromEnum(rangeA.start));
     try testing.expectEqual(3, @intFromEnum(rangeA.end));
 
-    const rangeB = try multilist.appendSlice(gpa, &[_]Struct{ .{ .num = 400, .char = 'd' }, .{ .num = 500, .char = 'e' }, .{ .num = 600, .char = 'f' } });
+    const rangeB = try multilist.appendSliceRange(gpa, &[_]Struct{ .{ .num = 400, .char = 'd' }, .{ .num = 500, .char = 'e' }, .{ .num = 600, .char = 'f' } });
     try testing.expectEqual(3, @intFromEnum(rangeB.start));
     try testing.expectEqual(6, @intFromEnum(rangeB.end));
 }
 
-test "SafeMultiList(u8) rangeToSlice" {
+test "SafeMultiList(u8) sliceRange" {
     const gpa = testing.allocator;
 
     const Struct = struct { num: u32, char: u8 };
@@ -728,8 +728,8 @@ test "SafeMultiList(u8) rangeToSlice" {
     var multilist = try StructMultiList.initCapacity(gpa, 3);
     defer multilist.deinit(gpa);
 
-    const range_a = try multilist.appendSlice(gpa, &[_]Struct{ .{ .num = 100, .char = 'a' }, .{ .num = 200, .char = 'b' }, .{ .num = 300, .char = 'c' } });
-    const slice_a = multilist.rangeToSlice(range_a);
+    const range_a = try multilist.appendSliceRange(gpa, &[_]Struct{ .{ .num = 100, .char = 'a' }, .{ .num = 200, .char = 'b' }, .{ .num = 300, .char = 'c' } });
+    const slice_a = multilist.sliceRange(range_a);
 
     const num_slice_a = slice_a.items(.num);
     try testing.expectEqual(3, num_slice_a.len);
@@ -744,7 +744,7 @@ test "SafeMultiList(u8) rangeToSlice" {
     try testing.expectEqual('c', char_slice_a[2]);
 
     const range_b = StructMultiList.Range{ .start = @enumFromInt(1), .end = @enumFromInt(2) };
-    const slice_b = multilist.rangeToSlice(range_b);
+    const slice_b = multilist.sliceRange(range_b);
 
     const num_slice_b = slice_b.items(.num);
     try testing.expectEqual(1, num_slice_b.len);
@@ -765,7 +765,7 @@ test "SafeMultiList empty range at end" {
     defer multilist.deinit(gpa);
 
     // Add 5 items to fill the list
-    _ = try multilist.appendSlice(gpa, &[_]Struct{
+    _ = try multilist.appendSliceRange(gpa, &[_]Struct{
         .{ .num = 100, .char = 'a' },
         .{ .num = 200, .char = 'b' },
         .{ .num = 300, .char = 'c' },
@@ -775,7 +775,7 @@ test "SafeMultiList empty range at end" {
 
     // Create an empty range at the end (start=5, end=5 for a list of length 5)
     const empty_range = StructMultiList.Range{ .start = @enumFromInt(5), .end = @enumFromInt(5) };
-    const empty_slice = multilist.rangeToSlice(empty_range);
+    const empty_slice = multilist.sliceRange(empty_range);
 
     // The slice should be empty
     const num_slice = empty_slice.items(.num);
@@ -839,7 +839,7 @@ test "SafeList(u8) serialization with data" {
     var list = SafeList(u8){};
     defer list.deinit(gpa);
 
-    _ = try list.appendSlice(gpa, "hello");
+    _ = try list.appendSliceRange(gpa, "hello");
 
     const expected_size = std.mem.alignForward(usize, @sizeOf(u32) + 5, SERIALIZATION_ALIGNMENT);
     try testing.expectEqual(expected_size, list.serializedSize());
@@ -906,7 +906,7 @@ test "SafeList(u8) deserialization with data" {
     defer list.deinit(gpa);
 
     try testing.expectEqual(expected_data.len, list.len());
-    const slice = list.rangeToSlice(SafeList(u8).Range{ .start = @enumFromInt(0), .end = @enumFromInt(expected_data.len) });
+    const slice = list.sliceRange(SafeList(u8).Range{ .start = @enumFromInt(0), .end = @enumFromInt(expected_data.len) });
     try testing.expectEqualSlices(u8, expected_data, slice);
 }
 
@@ -918,7 +918,7 @@ test "SafeList(u32) round-trip serialization" {
     defer original.deinit(gpa);
 
     const test_data = [_]u32{ 1, 2, 3, 42, 100, 255 };
-    _ = try original.appendSlice(gpa, &test_data);
+    _ = try original.appendSliceRange(gpa, &test_data);
 
     // Serialize
     var buffer: [1024]u8 align(SERIALIZATION_ALIGNMENT) = undefined;
@@ -1149,7 +1149,7 @@ test "SafeMultiList(struct) round-trip serialization" {
         Point{ .x = 42, .y = 100 },
         Point{ .x = 255, .y = 128 },
     };
-    _ = try original.appendSlice(gpa, &test_data);
+    _ = try original.appendSliceRange(gpa, &test_data);
 
     // Serialize
     var buffer: [2048]u8 align(SERIALIZATION_ALIGNMENT) = undefined;
@@ -1280,7 +1280,7 @@ test "SafeMultiList complex Node-like structure serialization" {
         },
     };
 
-    _ = try list.appendSlice(gpa, &test_nodes);
+    _ = try list.appendSliceRange(gpa, &test_nodes);
 
     // Test serialization
     const expected_size = std.mem.alignForward(usize, @sizeOf(u32) + (test_nodes.len * @sizeOf(ComplexNode)), SERIALIZATION_ALIGNMENT);

--- a/src/collections/safe_list.zig
+++ b/src/collections/safe_list.zig
@@ -7,66 +7,6 @@ const testing = std.testing;
 const Allocator = std.mem.Allocator;
 const SERIALIZATION_ALIGNMENT = serialization.SERIALIZATION_ALIGNMENT;
 
-/// Represents a type safe span in a list; [start, end)
-///
-/// This is the conceptual equivalent of slice, but since this is based
-/// on indexes in the list rather than pointers, it is reliable across
-/// (de)serilaization and reallocation of the list.
-///
-/// This range is inclusive on the lower bound, exclusive on the upper bound.
-pub fn SafeSpan(comptime Idx: type) type {
-    return struct {
-        const Self = @This();
-
-        start: Idx,
-        count: u32,
-
-        /// An empty range
-        pub fn empty() Self {
-            return .{ .start = @enumFromInt(0), .count = 0 };
-        }
-
-        /// Return whether the range is empty
-        pub fn isEmpty(self: @This()) bool {
-            return self.count == 0;
-        }
-
-        // Drop first elem from the span, if possible
-        pub fn dropFirstElem(self: *Self) void {
-            if (self.count == 0) return;
-            self.start = @enumFromInt(@intFromEnum(self.start) + 1);
-            self.count -= 1;
-        }
-
-        /// Get the length of a range slice
-        pub fn iterIndices(self: @This()) IndexIterator {
-            return IndexIterator{
-                .len = self.count,
-                .current = @intFromEnum(self.start),
-            };
-        }
-
-        /// An iterator over the indices of all elements in a list.
-        pub const IndexIterator = struct {
-            len: u32,
-            current: u32,
-
-            /// Get the next index from this iterator, or `null` if the iterator is finished.
-            pub fn next(iter: *IndexIterator) ?Idx {
-                if (iter.len == iter.current) {
-                    return null;
-                }
-
-                const curr = iter.current;
-                iter.current += 1;
-
-                const idx: u32 = @truncate(curr);
-                return @enumFromInt(idx);
-            }
-        };
-    };
-}
-
 /// Represents a type safe range in a list; [start, end)
 ///
 /// This is the conceptual equivalent of slice, but since this is based
@@ -79,37 +19,51 @@ pub fn SafeRange(comptime Idx: type) type {
         const Self = @This();
 
         start: Idx,
-        end: Idx,
+        count: u32,
 
         /// An empty range
-        pub const empty: Self = .{ .start = @enumFromInt(0), .end = @enumFromInt(0) };
+        pub fn empty() Self {
+            return .{ .start = @enumFromInt(0), .count = 0 };
+        }
+
+        // Drop first elem from the span, if possible
+        pub fn dropFirstElem(self: *Self) void {
+            if (self.count == 0) return;
+            self.start = @enumFromInt(@intFromEnum(self.start) + 1);
+            self.count -= 1;
+        }
 
         /// Get the length of a range slice
         pub fn len(self: @This()) u32 {
-            return @intFromEnum(self.end) - @intFromEnum(self.start);
+            return self.count;
+        }
+
+        /// Get the last index in the range
+        pub fn end(self: @This()) Idx {
+            return @enumFromInt(@intFromEnum(self.start) + self.count);
         }
 
         /// Return whether the range is empty
         pub fn isEmpty(self: @This()) bool {
-            return self.start == self.end;
+            return self.count == 0;
         }
 
         /// Get the length of a range slice
         pub fn iterIndices(self: @This()) IndexIterator {
             return IndexIterator{
-                .len = @intFromEnum(self.end),
+                .end = @intFromEnum(self.start) + self.count,
                 .current = @intFromEnum(self.start),
             };
         }
 
         /// An iterator over the indices of all elements in a list.
         pub const IndexIterator = struct {
-            len: u32,
+            end: u32,
             current: u32,
 
             /// Get the next index from this iterator, or `null` if the iterator is finished.
             pub fn next(iter: *IndexIterator) ?Idx {
-                if (iter.len == iter.current) {
+                if (iter.end == iter.current) {
                     return null;
                 }
 
@@ -154,15 +108,7 @@ pub fn SafeList(comptime T: type) type {
 
         /// A type-safe range which must have at least one element.
         pub const NonEmptyRange = struct {
-            range: Range,
-        };
-
-        /// A type-safe range of the list.
-        pub const Span = SafeSpan(Idx);
-
-        /// A type-safe span which must have at least one element.
-        pub const NonEmptySpan = struct {
-            nonempty: Span,
+            nonempty: Range,
         };
 
         /// Initialize the `SafeList` with the specified capacity.
@@ -190,20 +136,19 @@ pub fn SafeList(comptime T: type) type {
             return @enumFromInt(@as(u32, @intCast(length)));
         }
 
+        /// Create a range from the provided idx to the end of the list
+        pub fn rangeToEnd(self: *SafeList(T), start_int: u32) Range {
+            const len_int = self.len();
+            std.debug.assert(start_int <= len_int);
+            return Range{ .start = @enumFromInt(start_int), .count = @intCast(len_int - start_int) };
+        }
+
         /// Add all the items in a slice to the end of this list.
         pub fn appendSliceRange(self: *SafeList(T), gpa: Allocator, items: []const T) std.mem.Allocator.Error!Range {
             const start_length = self.len();
             try self.items.appendSlice(gpa, items);
             const end_length = self.len();
-            return Range{ .start = @enumFromInt(start_length), .end = @enumFromInt(end_length) };
-        }
-
-        /// Add all the items in a slice to the end of this list.
-        pub fn appendSliceSpan(self: *SafeList(T), gpa: Allocator, items: []const T) std.mem.Allocator.Error!Span {
-            const start_length = self.len();
-            try self.items.appendSlice(gpa, items);
-            const end_length = self.len();
-            return Span{ .start = @enumFromInt(start_length), .count = @intCast(end_length - start_length) };
+            return Range{ .start = @enumFromInt(start_length), .count = @intCast(end_length - start_length) };
         }
 
         /// Extend this list with all items generated by an iterator.
@@ -213,24 +158,13 @@ pub fn SafeList(comptime T: type) type {
                 try self.items.append(gpa, item);
             }
             const end_length = self.len();
-            return Range{ .start = @enumFromInt(start_length), .end = @enumFromInt(end_length) };
+            return Range{ .start = @enumFromInt(start_length), .count = @intCast(end_length - start_length) };
         }
 
         /// Convert a range to a slice
         pub fn sliceRange(self: *const SafeList(T), range: Range) Slice {
             const start: usize = @intFromEnum(range.start);
-            const end: usize = @intFromEnum(range.end);
-
-            std.debug.assert(start <= end);
-            std.debug.assert(end <= self.items.items.len);
-
-            return self.items.items[start..end];
-        }
-
-        /// Convert a span to a slice
-        pub fn sliceSpan(self: *const SafeList(T), span: Span) Slice {
-            const start: usize = @intFromEnum(span.start);
-            const end: usize = start + span.count;
+            const end: usize = start + range.count;
 
             std.debug.assert(start <= end);
             std.debug.assert(end <= self.items.items.len);
@@ -411,11 +345,11 @@ pub fn SafeList(comptime T: type) type {
         };
 
         /// Iterate over the elements in a span
-        pub fn iterSpan(self: *const SafeList(T), span: Span) Iterator {
+        pub fn iterRange(self: *const SafeList(T), range: Range) Iterator {
             return Iterator{
                 .array = self,
-                .len = @intFromEnum(span.start) + span.count,
-                .current = span.start,
+                .len = @intFromEnum(range.start) + range.count,
+                .current = range.start,
             };
         }
 
@@ -492,6 +426,13 @@ pub fn SafeMultiList(comptime T: type) type {
             return self.items.len;
         }
 
+        /// Create a range from the provided idx to the end of the list
+        pub fn rangeToEnd(self: *SafeMultiList(T), start_int: u32) Range {
+            const len_int = self.len();
+            std.debug.assert(start_int <= len_int);
+            return Range{ .start = @enumFromInt(start_int), .count = @intCast(len_int - start_int) };
+        }
+
         /// Add a new item to the end of this list.
         pub fn append(self: *SafeMultiList(T), gpa: Allocator, item: T) std.mem.Allocator.Error!Idx {
             const length = self.len();
@@ -502,7 +443,7 @@ pub fn SafeMultiList(comptime T: type) type {
 
         pub fn appendSliceRange(self: *SafeMultiList(T), gpa: Allocator, elems: []const T) std.mem.Allocator.Error!Range {
             if (elems.len == 0) {
-                return .{ .start = .zero, .end = .zero };
+                return .{ .start = .zero, .count = 0 };
             }
             const start_length = self.len();
             try self.items.ensureUnusedCapacity(gpa, elems.len);
@@ -510,13 +451,13 @@ pub fn SafeMultiList(comptime T: type) type {
                 self.items.appendAssumeCapacity(elem);
             }
             const end_length = self.len();
-            return Range{ .start = @enumFromInt(start_length), .end = @enumFromInt(end_length) };
+            return Range{ .start = @enumFromInt(start_length), .count = @intCast(end_length - start_length) };
         }
 
         /// Convert a range to a slice
         pub fn sliceRange(self: *const SafeMultiList(T), range: Range) Slice {
             const start: usize = @intFromEnum(range.start);
-            const end: usize = @intFromEnum(range.end);
+            const end: usize = start + range.count;
 
             std.debug.assert(start <= end);
             std.debug.assert(end <= self.items.len);
@@ -677,11 +618,11 @@ test "SafeList(u8) appendSlice" {
 
     const rangeA = try list.appendSliceRange(gpa, &[_]u8{ 'a', 'b', 'c', 'd' });
     try testing.expectEqual(0, @intFromEnum(rangeA.start));
-    try testing.expectEqual(4, @intFromEnum(rangeA.end));
+    try testing.expectEqual(4, @intFromEnum(rangeA.end()));
 
     const rangeB = try list.appendSliceRange(gpa, &[_]u8{ 'd', 'e', 'f', 'g' });
     try testing.expectEqual(4, @intFromEnum(rangeB.start));
-    try testing.expectEqual(8, @intFromEnum(rangeB.end));
+    try testing.expectEqual(8, @intFromEnum(rangeB.end()));
 }
 
 test "SafeList(u8) sliceRange" {
@@ -695,7 +636,7 @@ test "SafeList(u8) sliceRange" {
     try testing.expectEqual('a', sliceA[0]);
     try testing.expectEqual('d', sliceA[3]);
 
-    const rangeB = SafeList(u8).Range{ .start = @enumFromInt(2), .end = @enumFromInt(4) };
+    const rangeB = SafeList(u8).Range{ .start = @enumFromInt(2), .count = 2 };
     const sliceB = list.sliceRange(rangeB);
     try testing.expectEqual('c', sliceB[0]);
     try testing.expectEqual('d', sliceB[1]);
@@ -712,11 +653,11 @@ test "SafeMultiList(u8) appendSlice" {
 
     const rangeA = try multilist.appendSliceRange(gpa, &[_]Struct{ .{ .num = 100, .char = 'a' }, .{ .num = 200, .char = 'b' }, .{ .num = 300, .char = 'd' } });
     try testing.expectEqual(0, @intFromEnum(rangeA.start));
-    try testing.expectEqual(3, @intFromEnum(rangeA.end));
+    try testing.expectEqual(3, @intFromEnum(rangeA.end()));
 
     const rangeB = try multilist.appendSliceRange(gpa, &[_]Struct{ .{ .num = 400, .char = 'd' }, .{ .num = 500, .char = 'e' }, .{ .num = 600, .char = 'f' } });
     try testing.expectEqual(3, @intFromEnum(rangeB.start));
-    try testing.expectEqual(6, @intFromEnum(rangeB.end));
+    try testing.expectEqual(6, @intFromEnum(rangeB.end()));
 }
 
 test "SafeMultiList(u8) sliceRange" {
@@ -743,7 +684,7 @@ test "SafeMultiList(u8) sliceRange" {
     try testing.expectEqual('b', char_slice_a[1]);
     try testing.expectEqual('c', char_slice_a[2]);
 
-    const range_b = StructMultiList.Range{ .start = @enumFromInt(1), .end = @enumFromInt(2) };
+    const range_b = StructMultiList.Range{ .start = @enumFromInt(1), .count = 1 };
     const slice_b = multilist.sliceRange(range_b);
 
     const num_slice_b = slice_b.items(.num);
@@ -774,7 +715,7 @@ test "SafeMultiList empty range at end" {
     });
 
     // Create an empty range at the end (start=5, end=5 for a list of length 5)
-    const empty_range = StructMultiList.Range{ .start = @enumFromInt(5), .end = @enumFromInt(5) };
+    const empty_range = StructMultiList.Range{ .start = @enumFromInt(5), .count = 0 };
     const empty_slice = multilist.sliceRange(empty_range);
 
     // The slice should be empty
@@ -906,7 +847,7 @@ test "SafeList(u8) deserialization with data" {
     defer list.deinit(gpa);
 
     try testing.expectEqual(expected_data.len, list.len());
-    const slice = list.sliceRange(SafeList(u8).Range{ .start = @enumFromInt(0), .end = @enumFromInt(expected_data.len) });
+    const slice = list.sliceRange(SafeList(u8).Range{ .start = @enumFromInt(0), .count = expected_data.len });
     try testing.expectEqualSlices(u8, expected_data, slice);
 }
 

--- a/src/collections/safe_list.zig
+++ b/src/collections/safe_list.zig
@@ -144,7 +144,7 @@ pub fn SafeList(comptime T: type) type {
         }
 
         /// Add all the items in a slice to the end of this list.
-        pub fn appendSliceRange(self: *SafeList(T), gpa: Allocator, items: []const T) std.mem.Allocator.Error!Range {
+        pub fn appendSlice(self: *SafeList(T), gpa: Allocator, items: []const T) std.mem.Allocator.Error!Range {
             const start_length = self.len();
             try self.items.appendSlice(gpa, items);
             const end_length = self.len();
@@ -441,7 +441,7 @@ pub fn SafeMultiList(comptime T: type) type {
             return @enumFromInt(@as(u32, @intCast(length)));
         }
 
-        pub fn appendSliceRange(self: *SafeMultiList(T), gpa: Allocator, elems: []const T) std.mem.Allocator.Error!Range {
+        pub fn appendSlice(self: *SafeMultiList(T), gpa: Allocator, elems: []const T) std.mem.Allocator.Error!Range {
             if (elems.len == 0) {
                 return .{ .start = .zero, .count = 0 };
             }
@@ -616,11 +616,11 @@ test "SafeList(u8) appendSlice" {
     var list = SafeList(u8){};
     defer list.deinit(gpa);
 
-    const rangeA = try list.appendSliceRange(gpa, &[_]u8{ 'a', 'b', 'c', 'd' });
+    const rangeA = try list.appendSlice(gpa, &[_]u8{ 'a', 'b', 'c', 'd' });
     try testing.expectEqual(0, @intFromEnum(rangeA.start));
     try testing.expectEqual(4, @intFromEnum(rangeA.end()));
 
-    const rangeB = try list.appendSliceRange(gpa, &[_]u8{ 'd', 'e', 'f', 'g' });
+    const rangeB = try list.appendSlice(gpa, &[_]u8{ 'd', 'e', 'f', 'g' });
     try testing.expectEqual(4, @intFromEnum(rangeB.start));
     try testing.expectEqual(8, @intFromEnum(rangeB.end()));
 }
@@ -631,7 +631,7 @@ test "SafeList(u8) sliceRange" {
     var list = SafeList(u8){};
     defer list.deinit(gpa);
 
-    const rangeA = try list.appendSliceRange(gpa, &[_]u8{ 'a', 'b', 'c', 'd' });
+    const rangeA = try list.appendSlice(gpa, &[_]u8{ 'a', 'b', 'c', 'd' });
     const sliceA = list.sliceRange(rangeA);
     try testing.expectEqual('a', sliceA[0]);
     try testing.expectEqual('d', sliceA[3]);
@@ -651,11 +651,11 @@ test "SafeMultiList(u8) appendSlice" {
     var multilist = try StructMultiList.initCapacity(gpa, 3);
     defer multilist.deinit(gpa);
 
-    const rangeA = try multilist.appendSliceRange(gpa, &[_]Struct{ .{ .num = 100, .char = 'a' }, .{ .num = 200, .char = 'b' }, .{ .num = 300, .char = 'd' } });
+    const rangeA = try multilist.appendSlice(gpa, &[_]Struct{ .{ .num = 100, .char = 'a' }, .{ .num = 200, .char = 'b' }, .{ .num = 300, .char = 'd' } });
     try testing.expectEqual(0, @intFromEnum(rangeA.start));
     try testing.expectEqual(3, @intFromEnum(rangeA.end()));
 
-    const rangeB = try multilist.appendSliceRange(gpa, &[_]Struct{ .{ .num = 400, .char = 'd' }, .{ .num = 500, .char = 'e' }, .{ .num = 600, .char = 'f' } });
+    const rangeB = try multilist.appendSlice(gpa, &[_]Struct{ .{ .num = 400, .char = 'd' }, .{ .num = 500, .char = 'e' }, .{ .num = 600, .char = 'f' } });
     try testing.expectEqual(3, @intFromEnum(rangeB.start));
     try testing.expectEqual(6, @intFromEnum(rangeB.end()));
 }
@@ -669,7 +669,7 @@ test "SafeMultiList(u8) sliceRange" {
     var multilist = try StructMultiList.initCapacity(gpa, 3);
     defer multilist.deinit(gpa);
 
-    const range_a = try multilist.appendSliceRange(gpa, &[_]Struct{ .{ .num = 100, .char = 'a' }, .{ .num = 200, .char = 'b' }, .{ .num = 300, .char = 'c' } });
+    const range_a = try multilist.appendSlice(gpa, &[_]Struct{ .{ .num = 100, .char = 'a' }, .{ .num = 200, .char = 'b' }, .{ .num = 300, .char = 'c' } });
     const slice_a = multilist.sliceRange(range_a);
 
     const num_slice_a = slice_a.items(.num);
@@ -706,7 +706,7 @@ test "SafeMultiList empty range at end" {
     defer multilist.deinit(gpa);
 
     // Add 5 items to fill the list
-    _ = try multilist.appendSliceRange(gpa, &[_]Struct{
+    _ = try multilist.appendSlice(gpa, &[_]Struct{
         .{ .num = 100, .char = 'a' },
         .{ .num = 200, .char = 'b' },
         .{ .num = 300, .char = 'c' },
@@ -780,7 +780,7 @@ test "SafeList(u8) serialization with data" {
     var list = SafeList(u8){};
     defer list.deinit(gpa);
 
-    _ = try list.appendSliceRange(gpa, "hello");
+    _ = try list.appendSlice(gpa, "hello");
 
     const expected_size = std.mem.alignForward(usize, @sizeOf(u32) + 5, SERIALIZATION_ALIGNMENT);
     try testing.expectEqual(expected_size, list.serializedSize());
@@ -859,7 +859,7 @@ test "SafeList(u32) round-trip serialization" {
     defer original.deinit(gpa);
 
     const test_data = [_]u32{ 1, 2, 3, 42, 100, 255 };
-    _ = try original.appendSliceRange(gpa, &test_data);
+    _ = try original.appendSlice(gpa, &test_data);
 
     // Serialize
     var buffer: [1024]u8 align(SERIALIZATION_ALIGNMENT) = undefined;
@@ -1090,7 +1090,7 @@ test "SafeMultiList(struct) round-trip serialization" {
         Point{ .x = 42, .y = 100 },
         Point{ .x = 255, .y = 128 },
     };
-    _ = try original.appendSliceRange(gpa, &test_data);
+    _ = try original.appendSlice(gpa, &test_data);
 
     // Serialize
     var buffer: [2048]u8 align(SERIALIZATION_ALIGNMENT) = undefined;
@@ -1221,7 +1221,7 @@ test "SafeMultiList complex Node-like structure serialization" {
         },
     };
 
-    _ = try list.appendSliceRange(gpa, &test_nodes);
+    _ = try list.appendSlice(gpa, &test_nodes);
 
     // Test serialization
     const expected_size = std.mem.alignForward(usize, @sizeOf(u32) + (test_nodes.len * @sizeOf(ComplexNode)), SERIALIZATION_ALIGNMENT);

--- a/src/layout/layout.zig
+++ b/src/layout/layout.zig
@@ -404,7 +404,7 @@ test "RecordData.getFields()" {
 
     const fields_range = record_data.getFields();
     try testing.expectEqual(@as(u32, 10), @intFromEnum(fields_range.start));
-    try testing.expectEqual(@as(u32, 15), @intFromEnum(fields_range.end));
+    try testing.expectEqual(@as(u32, 15), @intFromEnum(fields_range.start) + fields_range.count);
 }
 
 test "Layout scalar data access" {

--- a/src/layout/store_test.zig
+++ b/src/layout/store_test.zig
@@ -769,7 +769,7 @@ test "addTypeVar - simple record" {
     // Both str and u32 have same alignment on 64-bit systems (8 bytes for str pointer, 4 bytes for u32 but u32 comes first due to smaller alignment)
     // Actually str has alignment of usize (8 on 64-bit), u32 has alignment 4
     // So str should come first (higher alignment), then u32
-    const field_slice = layout_store.record_fields.sliceRange(.{ .start = @enumFromInt(layout_store.getRecordData(record_layout.data.record.idx).fields.start), .end = @enumFromInt(layout_store.getRecordData(record_layout.data.record.idx).fields.start + layout_store.getRecordData(record_layout.data.record.idx).fields.count) });
+    const field_slice = layout_store.record_fields.sliceRange(layout_store.getRecordData(record_layout.data.record.idx).getFields());
 
     // First field: name (str) - higher alignment (8 bytes on 64-bit)
     const name_field = field_slice.get(0);
@@ -891,7 +891,7 @@ test "addTypeVar - nested record" {
 
     // Verify the outer fields
     const player_record_data = layout_store.getRecordData(player_layout.data.record.idx);
-    const outer_field_slice = layout_store.record_fields.sliceRange(.{ .start = @enumFromInt(player_record_data.fields.start), .end = @enumFromInt(player_record_data.fields.start + player_record_data.fields.count) });
+    const outer_field_slice = layout_store.record_fields.sliceRange(player_record_data.getFields());
 
     // First field: name (str)
     const name_field = outer_field_slice.get(0);
@@ -910,7 +910,7 @@ test "addTypeVar - nested record" {
 
     // Verify the inner record fields
     const position_record_data = layout_store.getRecordData(position_layout.data.record.idx);
-    const inner_field_slice = layout_store.record_fields.sliceRange(.{ .start = @enumFromInt(position_record_data.fields.start), .end = @enumFromInt(position_record_data.fields.start + position_record_data.fields.count) });
+    const inner_field_slice = layout_store.record_fields.sliceRange(position_record_data.getFields());
 
     // Inner field x (i32)
     const x_field = inner_field_slice.get(0);
@@ -975,7 +975,7 @@ test "addTypeVar - list of records" {
     try testing.expect(record_layout.tag == .record);
 
     // Verify the record fields
-    const field_slice = layout_store.record_fields.sliceRange(.{ .start = @enumFromInt(layout_store.getRecordData(record_layout.data.record.idx).fields.start), .end = @enumFromInt(layout_store.getRecordData(record_layout.data.record.idx).fields.start + layout_store.getRecordData(record_layout.data.record.idx).fields.count) });
+    const field_slice = layout_store.record_fields.sliceRange(layout_store.getRecordData(record_layout.data.record.idx).getFields());
 
     // First field: id (u64)
     const id_field = field_slice.get(0);
@@ -1043,7 +1043,7 @@ test "addTypeVar - record with extension" {
 
     // Verify we have all 3 fields (x from main, y and z from extension)
     const record_data = layout_store.getRecordData(record_layout.data.record.idx);
-    const field_slice = layout_store.record_fields.sliceRange(.{ .start = @enumFromInt(record_data.fields.start), .end = @enumFromInt(record_data.fields.start + record_data.fields.count) });
+    const field_slice = layout_store.record_fields.sliceRange(record_data.getFields());
     try testing.expectEqual(@as(usize, 3), field_slice.len);
 
     // Fields are sorted by alignment (descending) then by name (ascending)
@@ -1468,7 +1468,7 @@ test "addTypeVar - record with duplicate field in extension (matching types)" {
 
     // Verify we have 3 fields (x appears twice - from main and extension, plus y from extension)
     // TODO: Field deduplication should happen at the type-checking level, not in layout generation
-    const field_slice = layout_store.record_fields.sliceRange(.{ .start = @enumFromInt(layout_store.getRecordData(record_layout.data.record.idx).fields.start), .end = @enumFromInt(layout_store.getRecordData(record_layout.data.record.idx).fields.start + layout_store.getRecordData(record_layout.data.record.idx).fields.count) });
+    const field_slice = layout_store.record_fields.sliceRange(layout_store.getRecordData(record_layout.data.record.idx).getFields());
 
     // Fields are sorted by alignment (descending) then by name (ascending)
     // All fields here have same type alignment, so sorted by name: x, x, y
@@ -1540,7 +1540,7 @@ test "addTypeVar - record with duplicate field in extension (mismatched types)" 
     try testing.expect(record_layout.tag == .record);
 
     // We get both fields even though they have the same name but different types
-    const field_slice = layout_store.record_fields.sliceRange(.{ .start = @enumFromInt(layout_store.getRecordData(record_layout.data.record.idx).fields.start), .end = @enumFromInt(layout_store.getRecordData(record_layout.data.record.idx).fields.start + layout_store.getRecordData(record_layout.data.record.idx).fields.count) });
+    const field_slice = layout_store.record_fields.sliceRange(layout_store.getRecordData(record_layout.data.record.idx).getFields());
 
     // Fields are sorted by alignment (descending) then by name (ascending)
     // str is 8-byte aligned, i32 is 4-byte aligned
@@ -1651,7 +1651,7 @@ test "addTypeVar - record with chained extensions" {
     try testing.expect(record_layout.tag == .record);
 
     // Verify we have all 4 fields from all levels
-    const field_slice = layout_store.record_fields.sliceRange(.{ .start = @enumFromInt(layout_store.getRecordData(record_layout.data.record.idx).fields.start), .end = @enumFromInt(layout_store.getRecordData(record_layout.data.record.idx).fields.start + layout_store.getRecordData(record_layout.data.record.idx).fields.count) });
+    const field_slice = layout_store.record_fields.sliceRange(layout_store.getRecordData(record_layout.data.record.idx).getFields());
 
     // Fields are sorted by alignment (descending) then by name (ascending)
     // str and f64 are 8-byte aligned, i32 is 4-byte aligned, u8 is 1-byte aligned
@@ -1730,7 +1730,7 @@ test "addTypeVar - record with zero-sized fields dropped" {
     try testing.expect(record_layout.tag == .record);
 
     // Verify we only have 2 fields (empty field should be dropped)
-    const field_slice = layout_store.record_fields.sliceRange(.{ .start = @enumFromInt(layout_store.getRecordData(record_layout.data.record.idx).fields.start), .end = @enumFromInt(layout_store.getRecordData(record_layout.data.record.idx).fields.start + layout_store.getRecordData(record_layout.data.record.idx).fields.count) });
+    const field_slice = layout_store.record_fields.sliceRange(layout_store.getRecordData(record_layout.data.record.idx).getFields());
 
     // Debug: Check the actual field count
     const field_count = field_slice.len;
@@ -1988,7 +1988,7 @@ test "addTypeVar - comprehensive nested record combinations" {
 
                 // Count actual non-zero fields in the result
                 const result_record_data = test_layout_store.getRecordData(result_layout.data.record.idx);
-                const field_slice = test_layout_store.record_fields.sliceRange(.{ .start = @enumFromInt(result_record_data.fields.start), .end = @enumFromInt(result_record_data.fields.start + result_record_data.fields.count) });
+                const field_slice = test_layout_store.record_fields.sliceRange(result_record_data.getFields());
                 const actual_field_count = field_slice.len;
 
                 // Verify each field has a valid layout
@@ -2000,7 +2000,7 @@ test "addTypeVar - comprehensive nested record combinations" {
                         .record => {
                             // Verify nested record has fields
                             const nested_record_data = test_layout_store.getRecordData(field_layout.data.record.idx);
-                            const nested_slice = test_layout_store.record_fields.sliceRange(.{ .start = @enumFromInt(nested_record_data.fields.start), .end = @enumFromInt(nested_record_data.fields.start + nested_record_data.fields.count) });
+                            const nested_slice = test_layout_store.record_fields.sliceRange(nested_record_data.getFields());
                             try testing.expect(nested_slice.len > 0);
                         },
 
@@ -2261,7 +2261,7 @@ test "record fields sorted by alignment then name" {
 
     // Verify fields are sorted by alignment (descending) then by name (ascending)
     // Expected order: b (u64, align 8), d (u64, align 8), a (u32, align 4), c (u8, align 1)
-    const field_slice = layout_store.record_fields.sliceRange(.{ .start = @enumFromInt(layout_store.getRecordData(record_layout.data.record.idx).fields.start), .end = @enumFromInt(layout_store.getRecordData(record_layout.data.record.idx).fields.start + layout_store.getRecordData(record_layout.data.record.idx).fields.count) });
+    const field_slice = layout_store.record_fields.sliceRange(layout_store.getRecordData(record_layout.data.record.idx).getFields());
 
     // First field: b (u64, alignment 8)
     const field1 = field_slice.get(0);
@@ -2339,7 +2339,7 @@ test "record fields with same alignment sorted by name" {
 
     // Verify fields are sorted alphabetically since they all have the same alignment
     // Expected order: apple, banana, zebra
-    const field_slice = layout_store.record_fields.sliceRange(.{ .start = @enumFromInt(layout_store.getRecordData(record_layout.data.record.idx).fields.start), .end = @enumFromInt(layout_store.getRecordData(record_layout.data.record.idx).fields.start + layout_store.getRecordData(record_layout.data.record.idx).fields.count) });
+    const field_slice = layout_store.record_fields.sliceRange(layout_store.getRecordData(record_layout.data.record.idx).getFields());
 
     // First field: apple
     const field1 = field_slice.get(0);

--- a/src/layout/store_test.zig
+++ b/src/layout/store_test.zig
@@ -574,7 +574,7 @@ test "alignment - record alignment is max of field alignments" {
     const u64_var = try type_store.freshFromContent(.{ .structure = .{ .num = .{ .num_compact = .{ .int = .u64 } } } });
 
     // Create record type { field1: U8, field2: U32, field3: U64 }
-    const fields = try type_store.record_fields.appendSliceRange(module_env.gpa, &[_]types.RecordField{
+    const fields = try type_store.record_fields.appendSlice(module_env.gpa, &[_]types.RecordField{
         .{ .name = field1_ident, .var_ = u8_var },
         .{ .name = field2_ident, .var_ = u32_var },
         .{ .name = field3_ident, .var_ = u64_var },
@@ -597,7 +597,7 @@ test "alignment - record alignment is max of field alignments" {
     }
 
     // Test with different field order - alignment should still be the same
-    const fields2 = try type_store.record_fields.appendSliceRange(module_env.gpa, &[_]types.RecordField{
+    const fields2 = try type_store.record_fields.appendSlice(module_env.gpa, &[_]types.RecordField{
         .{ .name = field3_ident, .var_ = u64_var },
         .{ .name = field1_ident, .var_ = u8_var },
         .{ .name = field2_ident, .var_ = u32_var },
@@ -640,28 +640,28 @@ test "alignment - deeply nested record alignment (non-recursive)" {
     const u64_var = try type_store.freshFromContent(.{ .structure = .{ .num = .{ .num_compact = .{ .int = .u64 } } } });
 
     // Create innermost record: { data: U64 }
-    const inner_fields = try type_store.record_fields.appendSliceRange(module_env.gpa, &[_]types.RecordField{
+    const inner_fields = try type_store.record_fields.appendSlice(module_env.gpa, &[_]types.RecordField{
         .{ .name = data_ident, .var_ = u64_var },
     });
     const inner_ext = try type_store.freshFromContent(.{ .structure = .empty_record });
     const inner_record_var = try type_store.freshFromContent(.{ .structure = .{ .record = .{ .fields = inner_fields, .ext = inner_ext } } });
 
     // Create middle record: { inner: { data: U64 } }
-    const middle_fields = try type_store.record_fields.appendSliceRange(module_env.gpa, &[_]types.RecordField{
+    const middle_fields = try type_store.record_fields.appendSlice(module_env.gpa, &[_]types.RecordField{
         .{ .name = inner_ident, .var_ = inner_record_var },
     });
     const middle_ext = try type_store.freshFromContent(.{ .structure = .empty_record });
     const middle_record_var = try type_store.freshFromContent(.{ .structure = .{ .record = .{ .fields = middle_fields, .ext = middle_ext } } });
 
     // Create outer record: { middle: { inner: { data: U64 } } }
-    const outer_fields = try type_store.record_fields.appendSliceRange(module_env.gpa, &[_]types.RecordField{
+    const outer_fields = try type_store.record_fields.appendSlice(module_env.gpa, &[_]types.RecordField{
         .{ .name = middle_ident, .var_ = middle_record_var },
     });
     const outer_ext = try type_store.freshFromContent(.{ .structure = .empty_record });
     const outer_record_var = try type_store.freshFromContent(.{ .structure = .{ .record = .{ .fields = outer_fields, .ext = outer_ext } } });
 
     // Create outermost record: { outer: { middle: { inner: { data: U64 } } } }
-    const outermost_fields = try type_store.record_fields.appendSliceRange(module_env.gpa, &[_]types.RecordField{
+    const outermost_fields = try type_store.record_fields.appendSlice(module_env.gpa, &[_]types.RecordField{
         .{ .name = outer_ident, .var_ = outer_record_var },
     });
     const outermost_ext = try type_store.freshFromContent(.{ .structure = .empty_record });
@@ -749,7 +749,7 @@ test "addTypeVar - simple record" {
     const age_ident = try module_env.idents.insert(module_env.gpa, base.Ident.for_text("age"), base.Region.zero());
 
     // Create record type { name: str, age: u32 }
-    const fields = try type_store.record_fields.appendSliceRange(module_env.gpa, &[_]types.RecordField{
+    const fields = try type_store.record_fields.appendSlice(module_env.gpa, &[_]types.RecordField{
         .{ .name = name_ident, .var_ = str_var },
         .{ .name = age_ident, .var_ = u32_var },
     });
@@ -814,7 +814,7 @@ test "record size calculation" {
     const c_ident = try module_env.idents.insert(module_env.gpa, base.Ident.for_text("c"), base.Region.zero());
     const d_ident = try module_env.idents.insert(module_env.gpa, base.Ident.for_text("d"), base.Region.zero());
 
-    const fields = try type_store.record_fields.appendSliceRange(module_env.gpa, &[_]types.RecordField{
+    const fields = try type_store.record_fields.appendSlice(module_env.gpa, &[_]types.RecordField{
         .{ .name = a_ident, .var_ = u8_var },
         .{ .name = b_ident, .var_ = u32_var },
         .{ .name = c_ident, .var_ = u8_var },
@@ -862,7 +862,7 @@ test "addTypeVar - nested record" {
     const x_ident = try module_env.idents.insert(module_env.gpa, base.Ident.for_text("x"), base.Region.zero());
     const y_ident = try module_env.idents.insert(module_env.gpa, base.Ident.for_text("y"), base.Region.zero());
 
-    const point_fields = try type_store.record_fields.appendSliceRange(module_env.gpa, &[_]types.RecordField{
+    const point_fields = try type_store.record_fields.appendSlice(module_env.gpa, &[_]types.RecordField{
         .{ .name = x_ident, .var_ = i32_var },
         .{ .name = y_ident, .var_ = i32_var },
     });
@@ -875,7 +875,7 @@ test "addTypeVar - nested record" {
     const name_ident = try module_env.idents.insert(module_env.gpa, base.Ident.for_text("name"), base.Region.zero());
     const position_ident = try module_env.idents.insert(module_env.gpa, base.Ident.for_text("position"), base.Region.zero());
 
-    const player_fields = try type_store.record_fields.appendSliceRange(module_env.gpa, &[_]types.RecordField{
+    const player_fields = try type_store.record_fields.appendSlice(module_env.gpa, &[_]types.RecordField{
         .{ .name = name_ident, .var_ = str_var },
         .{ .name = position_ident, .var_ = point_var },
     });
@@ -952,7 +952,7 @@ test "addTypeVar - list of records" {
     const id_ident = try module_env.idents.insert(module_env.gpa, base.Ident.for_text("id"), base.Region.zero());
     const active_ident = try module_env.idents.insert(module_env.gpa, base.Ident.for_text("active"), base.Region.zero());
 
-    const record_fields = try type_store.record_fields.appendSliceRange(module_env.gpa, &[_]types.RecordField{
+    const record_fields = try type_store.record_fields.appendSlice(module_env.gpa, &[_]types.RecordField{
         .{ .name = id_ident, .var_ = u64_var },
         .{ .name = active_ident, .var_ = bool_var },
     });
@@ -1016,7 +1016,7 @@ test "addTypeVar - record with extension" {
     const y_ident = try module_env.idents.insert(module_env.gpa, base.Ident.for_text("y"), base.Region.zero());
     const z_ident = try module_env.idents.insert(module_env.gpa, base.Ident.for_text("z"), base.Region.zero());
 
-    const ext_fields = try type_store.record_fields.appendSliceRange(module_env.gpa, &[_]types.RecordField{
+    const ext_fields = try type_store.record_fields.appendSlice(module_env.gpa, &[_]types.RecordField{
         .{ .name = y_ident, .var_ = i32_var },
         .{ .name = z_ident, .var_ = u16_var },
     });
@@ -1028,7 +1028,7 @@ test "addTypeVar - record with extension" {
     const str_var = try type_store.freshFromContent(.{ .structure = .str });
     const x_ident = try module_env.idents.insert(module_env.gpa, base.Ident.for_text("x"), base.Region.zero());
 
-    const main_fields = try type_store.record_fields.appendSliceRange(module_env.gpa, &[_]types.RecordField{
+    const main_fields = try type_store.record_fields.appendSlice(module_env.gpa, &[_]types.RecordField{
         .{ .name = x_ident, .var_ = str_var },
     });
 
@@ -1097,7 +1097,7 @@ test "addTypeVar - record extension with str type fails" {
         .var_ = try type_store.freshFromContent(.{ .structure = .str }),
     });
 
-    const fields_slice = try type_store.record_fields.appendSliceRange(gpa, fields.items);
+    const fields_slice = try type_store.record_fields.appendSlice(gpa, fields.items);
     const str_ext = try type_store.freshFromContent(.{ .structure = .str });
     const record_var = try type_store.freshFromContent(.{ .structure = .{ .record = .{ .fields = fields_slice, .ext = str_ext } } });
 
@@ -1128,7 +1128,7 @@ test "addTypeVar - record extension with num type fails" {
         .var_ = try type_store.freshFromContent(.{ .structure = .str }),
     });
 
-    const fields_slice = try type_store.record_fields.appendSliceRange(gpa, fields.items);
+    const fields_slice = try type_store.record_fields.appendSlice(gpa, fields.items);
     const num_ext = try type_store.freshFromContent(.{ .structure = .{ .num = .{ .num_compact = .{ .int = .u64 } } } });
     const record_var = try type_store.freshFromContent(.{ .structure = .{ .record = .{ .fields = fields_slice, .ext = num_ext } } });
 
@@ -1199,7 +1199,7 @@ test "addTypeVar - record with single zero-sized field in container" {
         .var_ = try type_store.freshFromContent(.{ .structure = .empty_record }),
     });
 
-    const fields_slice = try type_store.record_fields.appendSliceRange(gpa, fields.items);
+    const fields_slice = try type_store.record_fields.appendSlice(gpa, fields.items);
     const empty_ext = try type_store.freshFromContent(.{ .structure = .empty_record });
     const record_var = try type_store.freshFromContent(.{ .structure = .{ .record = .{ .fields = fields_slice, .ext = empty_ext } } });
     const list_var = try type_store.freshFromContent(.{ .structure = .{ .list = record_var } });
@@ -1255,13 +1255,13 @@ test "addTypeVar - record field ordering stability" {
 
     const empty_ext = try type_store.freshFromContent(.{ .structure = .empty_record });
 
-    const fields1_slice = try type_store.record_fields.appendSliceRange(gpa, fields1.items);
+    const fields1_slice = try type_store.record_fields.appendSlice(gpa, fields1.items);
     const record1_var = try type_store.freshFromContent(.{ .structure = .{ .record = .{ .fields = fields1_slice, .ext = empty_ext } } });
 
-    const fields2_slice = try type_store.record_fields.appendSliceRange(gpa, fields2.items);
+    const fields2_slice = try type_store.record_fields.appendSlice(gpa, fields2.items);
     const record2_var = try type_store.freshFromContent(.{ .structure = .{ .record = .{ .fields = fields2_slice, .ext = empty_ext } } });
 
-    const fields3_slice = try type_store.record_fields.appendSliceRange(gpa, fields3.items);
+    const fields3_slice = try type_store.record_fields.appendSlice(gpa, fields3.items);
     const record3_var = try type_store.freshFromContent(.{ .structure = .{ .record = .{ .fields = fields3_slice, .ext = empty_ext } } });
 
     const result1 = try layout_store.addTypeVar(record1_var);
@@ -1354,7 +1354,7 @@ test "addTypeVar - empty record in different contexts" {
         .name = field_name,
         .var_ = empty_record,
     });
-    const fields_slice = try type_store.record_fields.appendSliceRange(gpa, fields.items);
+    const fields_slice = try type_store.record_fields.appendSlice(gpa, fields.items);
     const empty_ext = try type_store.freshFromContent(.{ .structure = .empty_record });
     const record_with_empty = try type_store.freshFromContent(.{ .structure = .{ .record = .{ .fields = fields_slice, .ext = empty_ext } } });
 
@@ -1396,7 +1396,7 @@ test "addTypeVar - record alignment edge cases" {
         });
     }
 
-    const fields_slice = try type_store.record_fields.appendSliceRange(gpa, fields.items);
+    const fields_slice = try type_store.record_fields.appendSlice(gpa, fields.items);
     const empty_ext = try type_store.freshFromContent(.{ .structure = .empty_record });
     const record_var = try type_store.freshFromContent(.{ .structure = .{ .record = .{ .fields = fields_slice, .ext = empty_ext } } });
 
@@ -1444,7 +1444,7 @@ test "addTypeVar - record with duplicate field in extension (matching types)" {
     const y_ident = try module_env.idents.insert(module_env.gpa, base.Ident.for_text("y"), base.Region.zero());
 
     // Create extension record { x: str, y: i32 }
-    const ext_fields = try type_store.record_fields.appendSliceRange(module_env.gpa, &[_]types.RecordField{
+    const ext_fields = try type_store.record_fields.appendSlice(module_env.gpa, &[_]types.RecordField{
         .{ .name = x_ident, .var_ = str_var },
         .{ .name = y_ident, .var_ = i32_var },
     });
@@ -1453,7 +1453,7 @@ test "addTypeVar - record with duplicate field in extension (matching types)" {
     const ext_record_var = try type_store.freshFromContent(.{ .structure = .{ .record = .{ .fields = ext_fields, .ext = empty_ext } } });
 
     // Create main record { x: str } extending the above (x appears in both with same type)
-    const main_fields = try type_store.record_fields.appendSliceRange(module_env.gpa, &[_]types.RecordField{
+    const main_fields = try type_store.record_fields.appendSlice(module_env.gpa, &[_]types.RecordField{
         .{ .name = x_ident, .var_ = str_var },
     });
 
@@ -1517,7 +1517,7 @@ test "addTypeVar - record with duplicate field in extension (mismatched types)" 
     const x_ident = try module_env.idents.insert(module_env.gpa, base.Ident.for_text("x"), base.Region.zero());
 
     // Create extension record { x: i32 }
-    const ext_fields = try type_store.record_fields.appendSliceRange(module_env.gpa, &[_]types.RecordField{
+    const ext_fields = try type_store.record_fields.appendSlice(module_env.gpa, &[_]types.RecordField{
         .{ .name = x_ident, .var_ = i32_var },
     });
 
@@ -1525,7 +1525,7 @@ test "addTypeVar - record with duplicate field in extension (mismatched types)" 
     const ext_record_var = try type_store.freshFromContent(.{ .structure = .{ .record = .{ .fields = ext_fields, .ext = empty_ext } } });
 
     // Create main record { x: str } extending the above (x appears in both with different types)
-    const main_fields = try type_store.record_fields.appendSliceRange(module_env.gpa, &[_]types.RecordField{
+    const main_fields = try type_store.record_fields.appendSlice(module_env.gpa, &[_]types.RecordField{
         .{ .name = x_ident, .var_ = str_var },
     });
 
@@ -1583,7 +1583,7 @@ test "addTypeVar - record with invalid extension type" {
     const x_ident = try module_env.idents.insert(gpa, base.Ident.for_text("x"), base.Region.zero());
 
     // Create main record { x: str } with str as extension (invalid)
-    const main_fields = try type_store.record_fields.appendSliceRange(module_env.gpa, &[_]types.RecordField{
+    const main_fields = try type_store.record_fields.appendSlice(module_env.gpa, &[_]types.RecordField{
         .{ .name = x_ident, .var_ = str_var },
     });
 
@@ -1621,7 +1621,7 @@ test "addTypeVar - record with chained extensions" {
     const z_ident = try module_env.idents.insert(module_env.gpa, base.Ident.for_text("z"), base.Region.zero());
 
     // Create innermost extension record { z: u8 }
-    const inner_fields = try type_store.record_fields.appendSliceRange(module_env.gpa, &[_]types.RecordField{
+    const inner_fields = try type_store.record_fields.appendSlice(module_env.gpa, &[_]types.RecordField{
         .{ .name = z_ident, .var_ = u8_var },
     });
 
@@ -1629,14 +1629,14 @@ test "addTypeVar - record with chained extensions" {
     const inner_record_var = try type_store.freshFromContent(.{ .structure = .{ .record = .{ .fields = inner_fields, .ext = empty_ext } } });
 
     // Create middle extension record { y: f64 } extending inner
-    const middle_fields = try type_store.record_fields.appendSliceRange(module_env.gpa, &[_]types.RecordField{
+    const middle_fields = try type_store.record_fields.appendSlice(module_env.gpa, &[_]types.RecordField{
         .{ .name = y_ident, .var_ = f64_var },
     });
 
     const middle_record_var = try type_store.freshFromContent(.{ .structure = .{ .record = .{ .fields = middle_fields, .ext = inner_record_var } } });
 
     // Create outermost record { w: str, x: i32 } extending middle
-    const outer_fields = try type_store.record_fields.appendSliceRange(module_env.gpa, &[_]types.RecordField{
+    const outer_fields = try type_store.record_fields.appendSlice(module_env.gpa, &[_]types.RecordField{
         .{ .name = w_ident, .var_ = str_var },
         .{ .name = x_ident, .var_ = i32_var },
     });
@@ -1713,7 +1713,7 @@ test "addTypeVar - record with zero-sized fields dropped" {
     const age_ident = try module_env.idents.insert(module_env.gpa, base.Ident.for_text("age"), base.Region.zero());
 
     // Create record { name: str, empty: {}, age: i32 }
-    const fields = try type_store.record_fields.appendSliceRange(module_env.gpa, &[_]types.RecordField{
+    const fields = try type_store.record_fields.appendSlice(module_env.gpa, &[_]types.RecordField{
         .{ .name = name_ident, .var_ = str_var },
         .{ .name = empty_ident, .var_ = empty_record_var },
         .{ .name = age_ident, .var_ = i32_var },
@@ -1776,7 +1776,7 @@ test "addTypeVar - record with all zero-sized fields becomes empty" {
     const field2_ident = try module_env.idents.insert(module_env.gpa, base.Ident.for_text("field2"), base.Region.zero());
 
     // Create record { field1: {}, field2: [] }
-    const fields = try type_store.record_fields.appendSliceRange(module_env.gpa, &[_]types.RecordField{
+    const fields = try type_store.record_fields.appendSlice(module_env.gpa, &[_]types.RecordField{
         .{ .name = field1_ident, .var_ = empty_record_var },
         .{ .name = field2_ident, .var_ = empty_tag_union_var },
     });
@@ -1811,7 +1811,7 @@ test "addTypeVar - box of record with all zero-sized fields" {
     const field2_ident = try module_env.idents.insert(module_env.gpa, base.Ident.for_text("field2"), base.Region.zero());
 
     // Create record { field1: {}, field2: {} }
-    const fields = try type_store.record_fields.appendSliceRange(module_env.gpa, &[_]types.RecordField{
+    const fields = try type_store.record_fields.appendSlice(module_env.gpa, &[_]types.RecordField{
         .{ .name = field1_ident, .var_ = empty_record_var },
         .{ .name = field2_ident, .var_ = empty_record_var },
     });
@@ -1919,7 +1919,7 @@ test "addTypeVar - comprehensive nested record combinations" {
                         expected_non_zero_fields += 1; // The nested record itself counts as 1
                         expected_total_fields += inner_field_count;
 
-                        const inner_fields_slice = try test_type_store.record_fields.appendSliceRange(module_env.gpa, inner_fields.items);
+                        const inner_fields_slice = try test_type_store.record_fields.appendSlice(module_env.gpa, inner_fields.items);
                         const empty_ext = try test_type_store.freshFromContent(.{ .structure = .empty_record });
                         break :blk try test_type_store.freshFromContent(.{ .structure = .{ .record = .{ .fields = inner_fields_slice, .ext = empty_ext } } });
                     },
@@ -1948,7 +1948,7 @@ test "addTypeVar - comprehensive nested record combinations" {
                         // This nested record will have 1 non-zero field (the str field) after dropping zero-sized ones
                         expected_non_zero_fields += 1;
 
-                        const inner_fields_slice = try test_type_store.record_fields.appendSliceRange(module_env.gpa, inner_fields.items);
+                        const inner_fields_slice = try test_type_store.record_fields.appendSlice(module_env.gpa, inner_fields.items);
                         const empty_ext = try test_type_store.freshFromContent(.{ .structure = .empty_record });
                         break :blk try test_type_store.freshFromContent(.{ .structure = .{ .record = .{ .fields = inner_fields_slice, .ext = empty_ext } } });
                     },
@@ -1962,7 +1962,7 @@ test "addTypeVar - comprehensive nested record combinations" {
             }
 
             // Create outer record
-            const outer_fields_slice = try test_type_store.record_fields.appendSliceRange(module_env.gpa, outer_fields.items);
+            const outer_fields_slice = try test_type_store.record_fields.appendSlice(module_env.gpa, outer_fields.items);
             const empty_ext = try test_type_store.freshFromContent(.{ .structure = .empty_record });
             const outer_record_var = try test_type_store.freshFromContent(.{ .structure = .{ .record = .{ .fields = outer_fields_slice, .ext = empty_ext } } });
 
@@ -2038,7 +2038,7 @@ test "addTypeVar - nested record with inner record having all zero-sized fields"
     const b_ident = try module_env.idents.insert(module_env.gpa, base.Ident.for_text("b"), base.Region.zero());
 
     // Create inner record
-    const inner_fields = try type_store.record_fields.appendSliceRange(module_env.gpa, &[_]types.RecordField{
+    const inner_fields = try type_store.record_fields.appendSlice(module_env.gpa, &[_]types.RecordField{
         .{ .name = a_ident, .var_ = empty_record_var },
         .{ .name = b_ident, .var_ = empty_record_var },
     });
@@ -2051,7 +2051,7 @@ test "addTypeVar - nested record with inner record having all zero-sized fields"
     const name_ident = try module_env.idents.insert(module_env.gpa, base.Ident.for_text("name"), base.Region.zero());
     const data_ident = try module_env.idents.insert(module_env.gpa, base.Ident.for_text("data"), base.Region.zero());
 
-    const outer_fields = try type_store.record_fields.appendSliceRange(module_env.gpa, &[_]types.RecordField{
+    const outer_fields = try type_store.record_fields.appendSlice(module_env.gpa, &[_]types.RecordField{
         .{ .name = name_ident, .var_ = str_var },
         .{ .name = data_ident, .var_ = inner_record_var },
     });
@@ -2087,7 +2087,7 @@ test "addTypeVar - list of record with all zero-sized fields" {
     const field_ident = try module_env.idents.insert(module_env.gpa, base.Ident.for_text("field"), base.Region.zero());
 
     // Create record { field: {} }
-    const fields = try type_store.record_fields.appendSliceRange(module_env.gpa, &[_]types.RecordField{
+    const fields = try type_store.record_fields.appendSlice(module_env.gpa, &[_]types.RecordField{
         .{ .name = field_ident, .var_ = empty_record_var },
     });
 
@@ -2123,7 +2123,7 @@ test "alignment - record with log2 alignment representation" {
     {
         const u8_var = try type_store.freshFromContent(.{ .structure = .{ .num = .{ .num_compact = .{ .int = .u8 } } } });
         const field_ident = try module_env.idents.insert(module_env.gpa, base.Ident.for_text("field"), base.Region.zero());
-        const fields = try type_store.record_fields.appendSliceRange(module_env.gpa, &[_]types.RecordField{
+        const fields = try type_store.record_fields.appendSlice(module_env.gpa, &[_]types.RecordField{
             .{ .name = field_ident, .var_ = u8_var },
         });
         const ext = try type_store.freshFromContent(.{ .structure = .empty_record });
@@ -2146,7 +2146,7 @@ test "alignment - record with log2 alignment representation" {
     {
         const u32_var = try type_store.freshFromContent(.{ .structure = .{ .num = .{ .num_compact = .{ .int = .u32 } } } });
         const field_ident = try module_env.idents.insert(module_env.gpa, base.Ident.for_text("field"), base.Region.zero());
-        const fields = try type_store.record_fields.appendSliceRange(module_env.gpa, &[_]types.RecordField{
+        const fields = try type_store.record_fields.appendSlice(module_env.gpa, &[_]types.RecordField{
             .{ .name = field_ident, .var_ = u32_var },
         });
         const ext = try type_store.freshFromContent(.{ .structure = .empty_record });
@@ -2169,7 +2169,7 @@ test "alignment - record with log2 alignment representation" {
     {
         const u64_var = try type_store.freshFromContent(.{ .structure = .{ .num = .{ .num_compact = .{ .int = .u64 } } } });
         const field_ident = try module_env.idents.insert(module_env.gpa, base.Ident.for_text("field"), base.Region.zero());
-        const fields = try type_store.record_fields.appendSliceRange(module_env.gpa, &[_]types.RecordField{
+        const fields = try type_store.record_fields.appendSlice(module_env.gpa, &[_]types.RecordField{
             .{ .name = field_ident, .var_ = u64_var },
         });
         const ext = try type_store.freshFromContent(.{ .structure = .empty_record });
@@ -2194,7 +2194,7 @@ test "alignment - record with log2 alignment representation" {
         const u64_var = try type_store.freshFromContent(.{ .structure = .{ .num = .{ .num_compact = .{ .int = .u64 } } } });
         const field1_ident = try module_env.idents.insert(module_env.gpa, base.Ident.for_text("small"), base.Region.zero());
         const field2_ident = try module_env.idents.insert(module_env.gpa, base.Ident.for_text("large"), base.Region.zero());
-        const fields = try type_store.record_fields.appendSliceRange(module_env.gpa, &[_]types.RecordField{
+        const fields = try type_store.record_fields.appendSlice(module_env.gpa, &[_]types.RecordField{
             .{ .name = field1_ident, .var_ = u8_var },
             .{ .name = field2_ident, .var_ = u64_var },
         });
@@ -2243,7 +2243,7 @@ test "record fields sorted by alignment then name" {
 
     // Create record with fields in a specific order to test sorting
     // { a: u32, b: u64, c: u8, d: u64 }
-    const fields = try type_store.record_fields.appendSliceRange(module_env.gpa, &[_]types.RecordField{
+    const fields = try type_store.record_fields.appendSlice(module_env.gpa, &[_]types.RecordField{
         .{ .name = a_ident, .var_ = u32_var }, // alignment 4
         .{ .name = b_ident, .var_ = u64_var }, // alignment 8
         .{ .name = c_ident, .var_ = u8_var }, // alignment 1
@@ -2322,7 +2322,7 @@ test "record fields with same alignment sorted by name" {
 
     // Create record with fields that all have alignment 4
     // { zebra: i32, apple: u32, banana: f32 }
-    const fields = try type_store.record_fields.appendSliceRange(module_env.gpa, &[_]types.RecordField{
+    const fields = try type_store.record_fields.appendSlice(module_env.gpa, &[_]types.RecordField{
         .{ .name = zebra_ident, .var_ = i32_var },
         .{ .name = apple_ident, .var_ = u32_var },
         .{ .name = banana_ident, .var_ = f32_var },
@@ -2394,7 +2394,7 @@ test "addTypeVar - maximum nesting depth" {
             .var_ = current_var,
         });
 
-        const fields_slice = try type_store.record_fields.appendSliceRange(gpa, fields.items);
+        const fields_slice = try type_store.record_fields.appendSlice(gpa, fields.items);
         const empty_ext = try type_store.freshFromContent(.{ .structure = .empty_record });
         current_var = try type_store.freshFromContent(.{ .structure = .{ .record = .{ .fields = fields_slice, .ext = empty_ext } } });
     }
@@ -2443,7 +2443,7 @@ test "addTypeVar - record with maximum fields" {
         });
     }
 
-    const fields_slice = try type_store.record_fields.appendSliceRange(gpa, fields.items);
+    const fields_slice = try type_store.record_fields.appendSlice(gpa, fields.items);
     const empty_ext = try type_store.freshFromContent(.{ .structure = .empty_record });
     const record_var = try type_store.freshFromContent(.{ .structure = .{ .record = .{ .fields = fields_slice, .ext = empty_ext } } });
 
@@ -2485,7 +2485,7 @@ test "addTypeVar - record field alignments differ between targets" {
     const u32_var = try type_store.freshFromContent(.{ .structure = .{ .num = .{ .num_compact = .{ .int = .u32 } } } });
     const u8_var = try type_store.freshFromContent(.{ .structure = .{ .num = .{ .num_compact = .{ .int = .u8 } } } });
 
-    const fields_slice = try type_store.record_fields.appendSliceRange(gpa, &[_]types.RecordField{
+    const fields_slice = try type_store.record_fields.appendSlice(gpa, &[_]types.RecordField{
         .{ .name = str_field_name, .var_ = str_var },
         .{ .name = u64_field_name, .var_ = u64_var },
         .{ .name = u32_field_name, .var_ = u32_var },
@@ -2582,7 +2582,7 @@ test "addTypeVar - record field sorting follows alignment then name order" {
     const banana_var = try type_store.freshFromContent(.{ .structure = .{ .num = .{ .num_compact = .{ .int = .u32 } } } });
     const carrot_var = try type_store.freshFromContent(.{ .structure = .{ .num = .{ .num_compact = .{ .int = .u8 } } } });
 
-    const fields_slice = try type_store.record_fields.appendSliceRange(gpa, &[_]types.RecordField{
+    const fields_slice = try type_store.record_fields.appendSlice(gpa, &[_]types.RecordField{
         .{ .name = zebra_field_name, .var_ = zebra_var },
         .{ .name = apple_field_name, .var_ = apple_var },
         .{ .name = banana_field_name, .var_ = banana_var },
@@ -2712,7 +2712,7 @@ test "addTypeVar - record with very long field names" {
         .var_ = try type_store.freshFromContent(.{ .structure = .{ .num = .{ .num_compact = .{ .int = .u64 } } } }),
     });
 
-    const fields_slice = try type_store.record_fields.appendSliceRange(gpa, fields.items);
+    const fields_slice = try type_store.record_fields.appendSlice(gpa, fields.items);
     const empty_ext = try type_store.freshFromContent(.{ .structure = .empty_record });
     const record_var = try type_store.freshFromContent(.{ .structure = .{ .record = .{ .fields = fields_slice, .ext = empty_ext } } });
 
@@ -2762,7 +2762,7 @@ test "addTypeVar - alternating zero-sized and non-zero-sized fields" {
         });
     }
 
-    const fields_slice = try type_store.record_fields.appendSliceRange(gpa, fields.items);
+    const fields_slice = try type_store.record_fields.appendSlice(gpa, fields.items);
     const empty_ext = try type_store.freshFromContent(.{ .structure = .empty_record });
     const record_var = try type_store.freshFromContent(.{ .structure = .{ .record = .{ .fields = fields_slice, .ext = empty_ext } } });
 
@@ -2806,7 +2806,7 @@ test "addTypeVar - record field type changes through alias" {
         .var_ = alias_var,
     });
 
-    const fields_slice = try type_store.record_fields.appendSliceRange(gpa, fields.items);
+    const fields_slice = try type_store.record_fields.appendSlice(gpa, fields.items);
     const empty_ext = try type_store.freshFromContent(.{ .structure = .empty_record });
     const record_var = try type_store.freshFromContent(.{ .structure = .{ .record = .{ .fields = fields_slice, .ext = empty_ext } } });
 
@@ -2864,7 +2864,7 @@ test "addTypeVar - mixed container types" {
         .var_ = inner_list_var,
     });
 
-    const fields_slice = try type_store.record_fields.appendSliceRange(gpa, record_fields.items);
+    const fields_slice = try type_store.record_fields.appendSlice(gpa, record_fields.items);
     const empty_ext = try type_store.freshFromContent(.{ .structure = .empty_record });
     const record_var = try type_store.freshFromContent(.{ .structure = .{ .record = .{ .fields = fields_slice, .ext = empty_ext } } });
 
@@ -2949,7 +2949,7 @@ test "addTypeVar - record size calculation with padding" {
         .var_ = try type_store.freshFromContent(.{ .structure = .{ .num = .{ .num_compact = .{ .int = .u16 } } } }),
     });
 
-    const fields_slice = try type_store.record_fields.appendSliceRange(gpa, fields.items);
+    const fields_slice = try type_store.record_fields.appendSlice(gpa, fields.items);
     const empty_ext = try type_store.freshFromContent(.{ .structure = .empty_record });
     const record_var = try type_store.freshFromContent(.{ .structure = .{ .record = .{ .fields = fields_slice, .ext = empty_ext } } });
 
@@ -3133,7 +3133,7 @@ test "addTypeVar - box and list of non-scalar types use indexed approach" {
     // Create a record type (non-scalar)
     const field_name = try module_env.idents.insert(gpa, base.Ident.for_text("field"), base.Region.zero());
     const str_var = try type_store.freshFromContent(.{ .structure = .str });
-    const fields = try type_store.record_fields.appendSliceRange(gpa, &[_]types.RecordField{
+    const fields = try type_store.record_fields.appendSlice(gpa, &[_]types.RecordField{
         .{ .name = field_name, .var_ = str_var },
     });
     const ext = try type_store.freshFromContent(.{ .structure = .empty_record });

--- a/src/types/store.zig
+++ b/src/types/store.zig
@@ -431,12 +431,12 @@ pub const Store = struct {
 
     /// Append a slice of tuple elems to the backing list, returning the range
     pub fn appendTupleElems(self: *Self, slice: []const Var) std.mem.Allocator.Error!VarSafeList.Range {
-        return try self.tuple_elems.appendSlice(self.gpa, slice);
+        return try self.tuple_elems.appendSliceRange(self.gpa, slice);
     }
 
     /// Append a slice of func args to the backing list, returning the range
     pub fn appendFuncArgs(self: *Self, slice: []const Var) std.mem.Allocator.Error!VarSafeList.Range {
-        return try self.func_args.appendSlice(self.gpa, slice);
+        return try self.func_args.appendSliceRange(self.gpa, slice);
     }
 
     /// Append a record field to the backing list, returning the idx
@@ -446,7 +446,7 @@ pub const Store = struct {
 
     /// Append a slice of record fields to the backing list, returning the range
     pub fn appendRecordFields(self: *Self, slice: []const RecordField) std.mem.Allocator.Error!RecordFieldSafeMultiList.Range {
-        return try self.record_fields.appendSlice(self.gpa, slice);
+        return try self.record_fields.appendSliceRange(self.gpa, slice);
     }
 
     /// Append a tag to the backing list, returning the idx
@@ -456,39 +456,39 @@ pub const Store = struct {
 
     /// Append a slice of tags to the backing list, returning the range
     pub fn appendTags(self: *Self, slice: []const Tag) std.mem.Allocator.Error!TagSafeMultiList.Range {
-        return try self.tags.appendSlice(self.gpa, slice);
+        return try self.tags.appendSliceRange(self.gpa, slice);
     }
 
     /// Append a slice of tag args to the backing list, returning the range
     pub fn appendTagArgs(self: *Self, slice: []const Var) std.mem.Allocator.Error!VarSafeList.Range {
-        return try self.tag_args.appendSlice(self.gpa, slice);
+        return try self.tag_args.appendSliceRange(self.gpa, slice);
     }
 
     // sub list getters //
 
     /// Given a range, get a slice of tuple from the backing list
     pub fn getTupleElemsSlice(self: *const Self, range: VarSafeList.Range) VarSafeList.Slice {
-        return self.tuple_elems.rangeToSlice(range);
+        return self.tuple_elems.sliceRange(range);
     }
 
     /// Given a range, get a slice of func from the backing list
     pub fn getFuncArgsSlice(self: *const Self, range: VarSafeList.Range) VarSafeList.Slice {
-        return self.func_args.rangeToSlice(range);
+        return self.func_args.sliceRange(range);
     }
 
     /// Given a range, get a slice of record fields from the backing array
     pub fn getRecordFieldsSlice(self: *const Self, range: RecordFieldSafeMultiList.Range) RecordFieldSafeMultiList.Slice {
-        return self.record_fields.rangeToSlice(range);
+        return self.record_fields.sliceRange(range);
     }
 
     /// Given a range, get a slice of tags from the backing array
     pub fn getTagsSlice(self: *const Self, range: TagSafeMultiList.Range) TagSafeMultiList.Slice {
-        return self.tags.rangeToSlice(range);
+        return self.tags.sliceRange(range);
     }
 
     /// Given a range, get a slice of tag args from the backing list
     pub fn getTagArgsSlice(self: *const Self, range: VarSafeList.Range) VarSafeList.Slice {
-        return self.tag_args.rangeToSlice(range);
+        return self.tag_args.sliceRange(range);
     }
 
     // helpers - alias types //

--- a/src/types/store.zig
+++ b/src/types/store.zig
@@ -421,7 +421,7 @@ pub const Store = struct {
 
     /// Append a var to the backing list, returning the idx
     pub fn appendVars(self: *Self, s: []const Var) std.mem.Allocator.Error!VarSafeList.Range {
-        return try self.vars.appendSliceRange(self.gpa, s);
+        return try self.vars.appendSlice(self.gpa, s);
     }
 
     /// Append a tuple elem to the backing list, returning the idx
@@ -431,12 +431,12 @@ pub const Store = struct {
 
     /// Append a slice of tuple elems to the backing list, returning the range
     pub fn appendTupleElems(self: *Self, slice: []const Var) std.mem.Allocator.Error!VarSafeList.Range {
-        return try self.tuple_elems.appendSliceRange(self.gpa, slice);
+        return try self.tuple_elems.appendSlice(self.gpa, slice);
     }
 
     /// Append a slice of func args to the backing list, returning the range
     pub fn appendFuncArgs(self: *Self, slice: []const Var) std.mem.Allocator.Error!VarSafeList.Range {
-        return try self.func_args.appendSliceRange(self.gpa, slice);
+        return try self.func_args.appendSlice(self.gpa, slice);
     }
 
     /// Append a record field to the backing list, returning the idx
@@ -446,7 +446,7 @@ pub const Store = struct {
 
     /// Append a slice of record fields to the backing list, returning the range
     pub fn appendRecordFields(self: *Self, slice: []const RecordField) std.mem.Allocator.Error!RecordFieldSafeMultiList.Range {
-        return try self.record_fields.appendSliceRange(self.gpa, slice);
+        return try self.record_fields.appendSlice(self.gpa, slice);
     }
 
     /// Append a tag to the backing list, returning the idx
@@ -456,12 +456,12 @@ pub const Store = struct {
 
     /// Append a slice of tags to the backing list, returning the range
     pub fn appendTags(self: *Self, slice: []const Tag) std.mem.Allocator.Error!TagSafeMultiList.Range {
-        return try self.tags.appendSliceRange(self.gpa, slice);
+        return try self.tags.appendSlice(self.gpa, slice);
     }
 
     /// Append a slice of tag args to the backing list, returning the range
     pub fn appendTagArgs(self: *Self, slice: []const Var) std.mem.Allocator.Error!VarSafeList.Range {
-        return try self.tag_args.appendSliceRange(self.gpa, slice);
+        return try self.tag_args.appendSlice(self.gpa, slice);
     }
 
     // sub list getters //

--- a/src/types/store.zig
+++ b/src/types/store.zig
@@ -420,8 +420,8 @@ pub const Store = struct {
     }
 
     /// Append a var to the backing list, returning the idx
-    pub fn appendVars(self: *Self, s: []const Var) std.mem.Allocator.Error!VarSafeList.Span {
-        return try self.vars.appendSliceSpan(self.gpa, s);
+    pub fn appendVars(self: *Self, s: []const Var) std.mem.Allocator.Error!VarSafeList.Range {
+        return try self.vars.appendSliceRange(self.gpa, s);
     }
 
     /// Append a tuple elem to the backing list, returning the idx
@@ -505,7 +505,7 @@ pub const Store = struct {
     /// Get the arg vars for this alias type
     pub fn sliceAliasArgs(self: *const Self, alias: types.Alias) []Var {
         std.debug.assert(alias.vars.nonempty.count > 0);
-        const slice = self.vars.sliceSpan(alias.vars.nonempty);
+        const slice = self.vars.sliceRange(alias.vars.nonempty);
         return slice[1..];
     }
 
@@ -514,7 +514,7 @@ pub const Store = struct {
         std.debug.assert(alias.vars.nonempty.count > 0);
         var span = alias.vars.nonempty;
         span.dropFirstElem();
-        return self.vars.iterSpan(span);
+        return self.vars.iterRange(span);
     }
 
     // helpers - nominal types //
@@ -531,7 +531,7 @@ pub const Store = struct {
     /// Get the arg vars for this nominal type
     pub fn sliceNominalArgs(self: *const Self, nominal: types.NominalType) []Var {
         std.debug.assert(nominal.vars.nonempty.count > 0);
-        const slice = self.vars.sliceSpan(nominal.vars.nonempty);
+        const slice = self.vars.sliceRange(nominal.vars.nonempty);
         return slice[1..];
     }
 
@@ -540,7 +540,7 @@ pub const Store = struct {
         std.debug.assert(nominal.vars.nonempty.count > 0);
         var span = nominal.vars.nonempty;
         span.dropFirstElem();
-        return self.vars.iterSpan(span);
+        return self.vars.iterRange(span);
     }
 
     // mark & rank //

--- a/src/types/types.zig
+++ b/src/types/types.zig
@@ -165,7 +165,7 @@ pub const Content = union(enum) {
 /// A named alias to a different type
 pub const Alias = struct {
     ident: TypeIdent,
-    vars: Var.SafeList.NonEmptySpan,
+    vars: Var.SafeList.NonEmptyRange,
 };
 
 /// Represents an ident of a type
@@ -544,7 +544,7 @@ pub const Num = union(enum) {
 /// A nominal user-defined type
 pub const NominalType = struct {
     ident: TypeIdent,
-    vars: Var.SafeList.NonEmptySpan,
+    vars: Var.SafeList.NonEmptyRange,
     /// The full module path where this nominal type was originally defined
     /// (e.g., "Json.Decode" or "mypackage.Data.Person")
     origin_module: Ident.Idx,


### PR DESCRIPTION
This PR:

* Modifies the `SafeRange` data type to store `start` and `count` instead of `start` and `end`
* Add additional functionality to `SafeRange`, like `end()` and `dropFirstElem()`
* Add Range helper function to `SafeList`, like `rangeToEnd(start: u32)`
* Make `SafeList` & `SafeMultiList`'s `len()` return `u32`
* Updates everything in the types store to use `SafeRange` (previous some used `Span`)
* Fixes some bugs in instantiate and copy_import

No snapshot output was modified with the above changes
